### PR TITLE
feat: implement MOL fingerprint function for molecular similarity searc

### DIFF
--- a/internal/core/conanfile.py
+++ b/internal/core/conanfile.py
@@ -14,6 +14,7 @@ class MilvusConan(ConanFile):
         "snappy/1.1.9#0519333fef284acd04806243de7d3070",
         "arrow/17.0.0@milvus/dev-2.6#7af258a853e20887f9969f713110aac8",
         "openssl/3.1.2#02594c4c0a6e2b4feb3cd15119993597",
+        "aws-sdk-cpp/1.11.352@milvus/dev",
         "googleapis/cci.20221108#65604e1b3b9a6b363044da625b201a2a",
         "gtest/1.13.0#f9548be18a41ccc6367efcb8146e92be",
         "benchmark/1.7.0#459f3bb1a64400a886ba43047576df3c",
@@ -45,11 +46,11 @@ class MilvusConan(ConanFile):
         "geos/3.12.0#0b177c90c25a8ca210578fb9e2899c37",
         "icu/74.2#cd1937b9561b8950a2ae6311284c5813",
         "libavrocpp/1.12.1@milvus/dev",
+        "rdkit/2025.09.1@milvus/dev",
     )
 
     generators = ("cmake", "cmake_find_package")
     default_options = {
-        "openssl:shared": True,
         "libevent:shared": True,
         "double-conversion:shared": True,
         "folly:shared": True,
@@ -98,23 +99,10 @@ class MilvusConan(ConanFile):
             # By default abseil use static link but can not be compatible with macos X86
             self.options["abseil"].shared = True
             self.options["arrow"].with_jemalloc = False
-            # Disable Arrow's S3 support on macOS - the Conan aws-c-* packages
-            # (aws-c-cal, aws-c-io) use deprecated macOS Security framework APIs
-            # that were removed in macOS 15+. Instead, milvus-storage provides
-            # S3 support using Homebrew's aws-sdk-cpp (1.11.735+) which has
-            # the compatibility fixes.
-            self.options["arrow"].with_s3 = False
-            # Use OpenSSL for libcurl on macOS
-            self.options["libcurl"].with_ssl = "openssl"
 
     def requirements(self):
         if self.settings.os != "Macos":
             self.requires("libunwind/1.7.2")
-            # On Linux, use Conan's aws-sdk-cpp (Arrow and milvus-storage both use it)
-            self.requires("aws-sdk-cpp/1.11.352@milvus/dev")
-        # On macOS, S3 support is provided by milvus-storage using Homebrew's
-        # aws-sdk-cpp (brew install aws-sdk-cpp). Arrow's S3 is disabled to avoid
-        # pulling in incompatible aws-c-* packages from Conan.
 
     def imports(self):
         self.copy("*.dylib", "../lib", "lib")

--- a/internal/core/src/CMakeLists.txt
+++ b/internal/core/src/CMakeLists.txt
@@ -38,17 +38,6 @@ include_directories(
     ${MILVUS_STORAGE_INCLUDE_DIR}
 )
 
-if(APPLE)
-    # On macOS, aws-sdk-cpp comes from Homebrew instead of Conan.
-    # Add Homebrew include path AFTER Conan includes so Conan headers take precedence,
-    # avoiding conflicts (e.g., Boost version mismatch).
-    if(EXISTS "/opt/homebrew/include/aws")
-        include_directories("/opt/homebrew/include")
-    elseif(EXISTS "/usr/local/include/aws")
-        include_directories("/usr/local/include")
-    endif()
-endif()
-
 add_subdirectory( pb )
 add_subdirectory( config )
 add_subdirectory( common )
@@ -68,7 +57,8 @@ add_subdirectory( minhash )
 
 milvus_add_pkg_config("milvus_core")
 
-add_library(milvus_core SHARED
+# Collect object files for milvus_core
+set(MILVUS_CORE_OBJECTS
     $<TARGET_OBJECTS:milvus_pb>
     $<TARGET_OBJECTS:milvus_config>
     $<TARGET_OBJECTS:milvus_common>
@@ -87,6 +77,8 @@ add_library(milvus_core SHARED
     $<TARGET_OBJECTS:milvus_minhash>
 )
 
+add_library(milvus_core SHARED ${MILVUS_CORE_OBJECTS})
+
 set(LINK_TARGETS
     boost_bitset_ext
     simdjson
@@ -98,6 +90,11 @@ set(LINK_TARGETS
     ${OpenMP_CXX_FLAGS}
     ${CONAN_LIBS}
     )
+
+# Add RDKit libraries
+if(TARGET RDKit::RDKit)
+    list(APPEND LINK_TARGETS RDKit::RDKit)
+endif()
 
 if(USE_OPENDAL)
     set(LINK_TARGETS ${LINK_TARGETS} opendal)
@@ -114,5 +111,16 @@ if (ENABLE_GCP_NATIVE)
 endif()
 
 target_link_libraries(milvus_core ${LINK_TARGETS})
+
+# Add mol_c.o at link time (compiled separately with GCC 11 for C++20 support)
+# Cannot add .o file to add_library sources as CMake checks file existence at configure time
+if(DEFINED RDKIT_INCLUDE_DIR)
+    set(MOL_C_OBJECT ${CMAKE_CURRENT_BINARY_DIR}/common/mol_c.o)
+    target_link_libraries(milvus_core ${MOL_C_OBJECT})
+    # Ensure mol_c.o is built before linking milvus_core
+    add_dependencies(milvus_core mol_c_build)
+    # Ensure RDKit shared libraries can be found at runtime
+    target_link_directories(milvus_core PUBLIC ${CONAN_LIB_DIRS_RDKIT})
+endif()
 
 install(TARGETS milvus_core DESTINATION "${CMAKE_INSTALL_LIBDIR}")

--- a/internal/core/src/common/Array.h
+++ b/internal/core/src/common/Array.h
@@ -235,8 +235,9 @@ class Array {
             }
             case DataType::STRING:
             case DataType::VARCHAR:
-            //treat Geometry as wkb string
-            case DataType::GEOMETRY: {
+            //treat Geometry and MOL as string
+            case DataType::GEOMETRY:
+            case DataType::MOL: {
                 for (int i = 0; i < length_; ++i) {
                     if (get_data<std::string_view>(i) !=
                         arr.get_data<std::string_view>(i)) {
@@ -366,6 +367,15 @@ class Array {
                 }
                 break;
             }
+            case DataType::MOL: {
+                data_array.mutable_mol_data()->mutable_data()->Reserve(length_);
+                for (int j = 0; j < length_; ++j) {
+                    auto element = get_data<std::string_view>(j);
+                    data_array.mutable_mol_data()->add_data(element.data(),
+                                                            element.size());
+                }
+                break;
+            }
             default: {
                 // empty array
             }
@@ -460,7 +470,8 @@ class Array {
             }
             case DataType::VARCHAR:
             case DataType::STRING:
-            case DataType::GEOMETRY: {
+            case DataType::GEOMETRY:
+            case DataType::MOL: {
                 for (int i = 0; i < length_; i++) {
                     auto val = get_data<std::string>(i);
                     if (val != arr2.array(i).string_val()) {
@@ -631,6 +642,15 @@ class ArrayView {
                 }
                 break;
             }
+            case DataType::MOL: {
+                data_array.mutable_mol_data()->mutable_data()->Reserve(length_);
+                for (int j = 0; j < length_; ++j) {
+                    auto element = get_data<std::string_view>(j);
+                    data_array.mutable_mol_data()->add_data(element.data(),
+                                                            element.size());
+                }
+                break;
+            }
             default: {
                 // empty array
             }
@@ -733,7 +753,8 @@ class ArrayView {
             }
             case DataType::VARCHAR:
             case DataType::STRING:
-            case DataType::GEOMETRY: {
+            case DataType::GEOMETRY:
+            case DataType::MOL: {
                 for (int i = 0; i < length_; i++) {
                     auto val = get_data<std::string>(i);
                     if (val != arr2.array(i).string_val()) {

--- a/internal/core/src/common/CMakeLists.txt
+++ b/internal/core/src/common/CMakeLists.txt
@@ -10,4 +10,66 @@
 # or implied. See the License for the specific language governing permissions and limitations under the License
 
 add_source_at_current_directory_recursively()
+
+# Remove mol_c.cpp from SOURCE_FILES - it will be compiled separately with GCC 11
+if(DEFINED RDKIT_INCLUDE_DIR)
+    # SOURCE_FILES contains relative paths from add_source_at_current_directory_recursively()
+    list(REMOVE_ITEM SOURCE_FILES mol_c.cpp)
+    message(STATUS "mol_c.cpp removed from milvus_common, will be compiled separately with GCC 11")
+endif()
+
 add_library(milvus_common OBJECT ${SOURCE_FILES})
+
+# Build mol_c.cpp separately with GCC 11 (required for RDKit C++20 constexpr destructors)
+# GCC 9 does not support constexpr destructors even with -std=c++2a
+if(DEFINED RDKIT_INCLUDE_DIR)
+    set(MOL_C_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/mol_c.cpp)
+    set(MOL_C_OBJECT ${CMAKE_CURRENT_BINARY_DIR}/mol_c.o)
+
+    # Use GCC 11 for mol_c.cpp (RDKit requires C++20 constexpr destructor support)
+    if(EXISTS "/usr/bin/g++-11")
+        set(MOL_C_COMPILER "/usr/bin/g++-11")
+        message(STATUS "mol_c.cpp will be compiled with GCC 11: ${MOL_C_COMPILER}")
+    else()
+        set(MOL_C_COMPILER ${CMAKE_CXX_COMPILER})
+        message(WARNING "GCC 11 not found. mol_c.cpp may fail to compile due to C++20 requirements.")
+    endif()
+
+    message(STATUS "mol_c.cpp RDKIT_INCLUDE_DIR: ${RDKIT_INCLUDE_DIR}")
+
+    # Build include directories list for the custom command
+    # RDKIT_INCLUDE_DIR is set by the Conan-based thirdparty/rdkit/CMakeLists.txt
+    set(MOL_C_INC_DIRS
+        ${RDKIT_INCLUDE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${MILVUS_ENGINE_SRC}
+        ${MILVUS_THIRDPARTY_SRC}
+    )
+    # Add conan include directories
+    foreach(inc_dir ${CONAN_INCLUDE_DIRS})
+        list(APPEND MOL_C_INC_DIRS ${inc_dir})
+    endforeach()
+
+    # Convert to -I flags
+    set(MOL_C_INC_FLAGS "")
+    foreach(inc_dir ${MOL_C_INC_DIRS})
+        list(APPEND MOL_C_INC_FLAGS "-I${inc_dir}")
+    endforeach()
+
+    # Custom command to compile mol_c.cpp with GCC 11
+    add_custom_command(
+        OUTPUT ${MOL_C_OBJECT}
+        COMMAND ${MOL_C_COMPILER}
+            -c ${MOL_C_SOURCE}
+            -o ${MOL_C_OBJECT}
+            -std=c++20
+            -fPIC
+            -g
+            ${MOL_C_INC_FLAGS}
+        DEPENDS ${MOL_C_SOURCE}
+        COMMENT "Compiling mol_c.cpp with GCC 11 (C++20)"
+    )
+
+    # Create a custom target to ensure mol_c.o is built
+    add_custom_target(mol_c_build DEPENDS ${MOL_C_OBJECT})
+endif()

--- a/internal/core/src/common/Chunk.h
+++ b/internal/core/src/common/Chunk.h
@@ -37,6 +37,7 @@
 namespace milvus {
 constexpr uint64_t MMAP_STRING_PADDING = 1;
 constexpr uint64_t MMAP_GEOMETRY_PADDING = 1;
+constexpr uint64_t MMAP_MOL_PADDING = 1;
 constexpr uint64_t MMAP_ARRAY_PADDING = 1;
 
 // Shared mmap region manager for group chunks
@@ -319,6 +320,7 @@ class StringChunk : public Chunk {
 
 using JSONChunk = StringChunk;
 using GeometryChunk = StringChunk;
+using MolChunk = StringChunk;
 
 // An ArrayChunk is a class that represents a collection of arrays stored in a contiguous memory block.
 // It is initialized with the number of rows, a pointer to the data, the size of the data, the element type,

--- a/internal/core/src/common/ChunkWriter.cpp
+++ b/internal/core/src/common/ChunkWriter.cpp
@@ -247,6 +247,71 @@ GeometryChunkWriter::write_to_target(
 }
 
 std::pair<size_t, size_t>
+MolChunkWriter::calculate_size(const arrow::ArrayVector& array_vec) {
+    row_nums_ = 0;
+    size_t size = 0;
+    for (const auto& data : array_vec) {
+        auto array = std::dynamic_pointer_cast<arrow::BinaryArray>(data);
+        for (int64_t i = 0; i < array->length(); ++i) {
+            auto str = array->GetView(i);
+            size += str.size();
+        }
+        row_nums_ += array->length();
+    }
+    if (nullable_) {
+        size += (row_nums_ + 7) / 8;
+    }
+    size += sizeof(uint32_t) * (row_nums_ + 1) + MMAP_MOL_PADDING;
+    return {size, row_nums_};
+}
+
+void
+MolChunkWriter::write_to_target(const arrow::ArrayVector& array_vec,
+                                const std::shared_ptr<ChunkTarget>& target) {
+    std::vector<std::string_view> mol_strs;
+    std::vector<std::tuple<const uint8_t*, int64_t, int64_t>> null_bitmaps;
+    mol_strs.reserve(row_nums_);
+
+    for (const auto& data : array_vec) {
+        auto array = std::dynamic_pointer_cast<arrow::BinaryArray>(data);
+        for (int64_t i = 0; i < array->length(); ++i) {
+            auto str = array->GetView(i);
+            mol_strs.emplace_back(str);
+        }
+        if (nullable_) {
+            null_bitmaps.emplace_back(
+                data->null_bitmap_data(), data->length(), data->offset());
+        }
+    }
+
+    // chunk layout: null bitmap, offsets, mol strings, padding
+    write_null_bit_maps(null_bitmaps, target);
+
+    const int offset_num = row_nums_ + 1;
+    const uint32_t null_bitmap_bytes =
+        nullable_ ? static_cast<uint32_t>((row_nums_ + 7) / 8) : 0;
+    uint32_t offset_start_pos =
+        null_bitmap_bytes +
+        static_cast<uint32_t>(sizeof(uint32_t) * offset_num);
+    std::vector<uint32_t> offsets;
+    offsets.reserve(offset_num);
+    for (const auto& str : mol_strs) {
+        offsets.push_back(offset_start_pos);
+        offset_start_pos += str.size();
+    }
+    offsets.push_back(offset_start_pos);
+
+    target->write(offsets.data(), offsets.size() * sizeof(uint32_t));
+
+    for (const auto& str : mol_strs) {
+        target->write(str.data(), str.size());
+    }
+
+    char padding[MMAP_MOL_PADDING];
+    target->write(padding, MMAP_MOL_PADDING);
+}
+
+std::pair<size_t, size_t>
 ArrayChunkWriter::calculate_size(const arrow::ArrayVector& array_vec) {
     row_nums_ = 0;
     size_t size = 0;
@@ -606,6 +671,9 @@ create_chunk_writer(const FieldMeta& field_meta) {
         case milvus::DataType::GEOMETRY: {
             return std::make_shared<GeometryChunkWriter>(nullable);
         }
+        case milvus::DataType::MOL: {
+            return std::make_shared<MolChunkWriter>(nullable);
+        }
         case milvus::DataType::ARRAY:
             return std::make_shared<ArrayChunkWriter>(
                 field_meta.get_element_type(), nullable);
@@ -745,6 +813,10 @@ make_chunk(const FieldMeta& field_meta,
                 row_nums, data, size, nullable, chunk_mmap_guard);
         case milvus::DataType::GEOMETRY: {
             return std::make_unique<GeometryChunk>(
+                row_nums, data, size, nullable, chunk_mmap_guard);
+        }
+        case milvus::DataType::MOL: {
+            return std::make_unique<MolChunk>(
                 row_nums, data, size, nullable, chunk_mmap_guard);
         }
         case milvus::DataType::ARRAY:

--- a/internal/core/src/common/ChunkWriter.h
+++ b/internal/core/src/common/ChunkWriter.h
@@ -260,6 +260,18 @@ class GeometryChunkWriter : public ChunkWriterBase {
                     const std::shared_ptr<ChunkTarget>& target) override;
 };
 
+class MolChunkWriter : public ChunkWriterBase {
+ public:
+    using ChunkWriterBase::ChunkWriterBase;
+
+    std::pair<size_t, size_t>
+    calculate_size(const arrow::ArrayVector& array_vec) override;
+
+    void
+    write_to_target(const arrow::ArrayVector& array_vec,
+                    const std::shared_ptr<ChunkTarget>& target) override;
+};
+
 class ArrayChunkWriter : public ChunkWriterBase {
  public:
     ArrayChunkWriter(const milvus::DataType element_type, bool nullable)

--- a/internal/core/src/common/FieldData.cpp
+++ b/internal/core/src/common/FieldData.cpp
@@ -279,6 +279,23 @@ FieldDataImpl<Type, is_type_entire_row>::FillFieldData(
             }
             return FillFieldData(values.data(), element_count);
         }
+        case DataType::MOL: {
+            AssertInfo(array->type()->id() == arrow::Type::type::BINARY,
+                       "inconsistent data type");
+            auto mol_array =
+                std::dynamic_pointer_cast<arrow::BinaryArray>(array);
+            std::vector<std::string> values(element_count);
+            for (size_t index = 0; index < element_count; ++index) {
+                values[index] = mol_array->GetString(index);
+            }
+            if (nullable_) {
+                return FillFieldData(values.data(),
+                                     array->null_bitmap_data(),
+                                     element_count,
+                                     array->offset());
+            }
+            return FillFieldData(values.data(), element_count);
+        }
         case DataType::ARRAY: {
             auto array_array =
                 std::dynamic_pointer_cast<arrow::BinaryArray>(array);
@@ -560,6 +577,16 @@ FieldDataImpl<Type, is_type_entire_row>::FillFieldData(
             return FillFieldData(
                 values.data(), valid_data_ptr.get(), element_count, 0);
         }
+        case DataType::MOL: {
+            FixedVector<std::string> values(element_count);
+            if (default_value.has_value()) {
+                std::fill(
+                    values.begin(), values.end(), default_value->string_data());
+                return FillFieldData(values.data(), nullptr, element_count, 0);
+            }
+            return FillFieldData(
+                values.data(), valid_data_ptr.get(), element_count, 0);
+        }
         case DataType::ARRAY: {
             // todo: add array default_value
             FixedVector<Array> values(element_count);
@@ -721,6 +748,9 @@ InitScalarFieldData(const DataType& type, bool nullable, int64_t cap_rows) {
         case DataType::JSON:
             return std::make_shared<FieldData<Json>>(type, nullable, cap_rows);
         case DataType::GEOMETRY:
+            return std::make_shared<FieldData<std::string>>(
+                type, nullable, cap_rows);
+        case DataType::MOL:
             return std::make_shared<FieldData<std::string>>(
                 type, nullable, cap_rows);
         default:

--- a/internal/core/src/common/FieldData.h
+++ b/internal/core/src/common/FieldData.h
@@ -83,6 +83,17 @@ class FieldData<Geometry> : public FieldDataGeometryImpl {
 };
 
 template <>
+class FieldData<Mol> : public FieldDataMolImpl {
+ public:
+    static_assert(IsScalar<Mol>);
+    explicit FieldData(DataType data_type,
+                       bool nullable,
+                       int64_t buffered_num_rows = 0)
+        : FieldDataMolImpl(data_type, nullable, buffered_num_rows) {
+    }
+};
+
+template <>
 class FieldData<Array> : public FieldDataArrayImpl {
  public:
     static_assert(IsScalar<Array> || std::is_same_v<std::string, PkType>);

--- a/internal/core/src/common/FieldDataInterface.h
+++ b/internal/core/src/common/FieldDataInterface.h
@@ -694,6 +694,74 @@ class FieldDataGeometryImpl : public FieldDataImpl<std::string, true> {
     }
 };
 
+class FieldDataMolImpl : public FieldDataImpl<std::string, true> {
+ public:
+    explicit FieldDataMolImpl(DataType data_type,
+                              bool nullable,
+                              int64_t total_num_rows = 0)
+        : FieldDataImpl<std::string, true>(
+              1, data_type, nullable, total_num_rows) {
+    }
+
+    int64_t
+    DataSize() const override {
+        int64_t data_size = 0;
+        for (size_t offset = 0; offset < length(); ++offset) {
+            data_size += data_[offset].size();
+        }
+        return data_size;
+    }
+
+    int64_t
+    DataSize(ssize_t offset) const override {
+        AssertInfo(offset < get_num_rows(),
+                   "field data subscript out of range");
+        AssertInfo(offset < length(),
+                   "subscript position don't has valid value");
+        return data_[offset].size();
+    }
+
+    void
+    FillFieldData(const std::shared_ptr<arrow::Array> array) override {
+        AssertInfo(array->type()->id() == arrow::Type::type::BINARY,
+                   "inconsistent data type, expected: {}, got: {}",
+                   "BINARY",
+                   array->type()->ToString());
+        auto mol_array = std::dynamic_pointer_cast<arrow::BinaryArray>(array);
+        FillFieldData(mol_array);
+    }
+
+    void
+    FillFieldData(const std::shared_ptr<arrow::BinaryArray>& array) override {
+        auto n = array->length();
+        if (n == 0) {
+            return;
+        }
+        null_count_ = array->null_count();
+
+        std::lock_guard lck(tell_mutex_);
+        if (length_ + n > get_num_rows()) {
+            resize_field_data(length_ + n);
+        }
+        for (int64_t i = 0; i < n; ++i) {
+            if (array->IsNull(i)) continue;
+            data_[length_ + i] = array->GetString(i);
+        }
+        if (IsNullable()) {
+            auto valid_data = array->null_bitmap_data();
+            if (valid_data != nullptr) {
+                bitset::detail::ElementWiseBitsetPolicy<uint8_t>::op_copy(
+                    valid_data,
+                    array->offset(),
+                    valid_data_.data(),
+                    length_,
+                    n);
+            }
+        }
+        length_ += n;
+    }
+};
+
 class FieldDataJsonImpl : public FieldDataImpl<Json, true> {
  public:
     explicit FieldDataJsonImpl(DataType data_type,

--- a/internal/core/src/common/Mol.h
+++ b/internal/core/src/common/Mol.h
@@ -1,0 +1,17 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+#pragma once
+
+namespace milvus {
+
+class Mol {};
+
+}  // namespace milvus

--- a/internal/core/src/common/MolChunkWriterTest.cpp
+++ b/internal/core/src/common/MolChunkWriterTest.cpp
@@ -1,0 +1,235 @@
+// Copyright (C) 2019-2025 Zilliz. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License.
+
+#include <gtest/gtest.h>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "arrow/api.h"
+#include "arrow/array/array_binary.h"
+#include "arrow/array/builder_binary.h"
+
+#include "common/Chunk.h"
+#include "common/ChunkWriter.h"
+#include "common/FieldMeta.h"
+#include "common/Types.h"
+
+using milvus::create_chunk;
+using milvus::DataType;
+using milvus::FieldId;
+using milvus::FieldMeta;
+using milvus::FieldName;
+using milvus::MolChunk;
+
+namespace {
+
+std::shared_ptr<arrow::BinaryArray>
+BuildMolBinaryArray(const std::vector<std::optional<std::string>>& values) {
+    arrow::BinaryBuilder builder;
+    for (const auto& v : values) {
+        if (v.has_value()) {
+            auto st =
+                builder.Append(v->data(), static_cast<int32_t>(v->size()));
+            EXPECT_TRUE(st.ok());
+        } else {
+            auto st = builder.AppendNull();
+            EXPECT_TRUE(st.ok());
+        }
+    }
+    std::shared_ptr<arrow::Array> arr;
+    auto st = builder.Finish(&arr);
+    EXPECT_TRUE(st.ok());
+    return std::static_pointer_cast<arrow::BinaryArray>(arr);
+}
+
+FieldMeta
+MakeMolFieldMeta(bool nullable) {
+    return FieldMeta(
+        FieldName("mol"), FieldId(1), DataType::MOL, nullable, std::nullopt);
+}
+
+}  // namespace
+
+TEST(MolChunkWriterTest, NoNullsMultiBatches) {
+    // Prepare two batches of MOL data (SMILES strings stored as binary)
+    std::vector<std::optional<std::string>> b1 = {
+        std::string("C"),
+        std::string("CC"),
+        std::string("CCO"),
+        std::string("c1ccccc1"),
+        std::string("CC(=O)O"),
+    };
+    std::vector<std::optional<std::string>> b2 = {
+        std::string("CCN"),
+        std::string("CCOCC"),
+        std::string("CC(C)C"),
+    };
+
+    auto a1 = BuildMolBinaryArray(b1);
+    auto a2 = BuildMolBinaryArray(b2);
+
+    arrow::ArrayVector vec{a1, a2};
+
+    auto field_meta = MakeMolFieldMeta(/*nullable=*/false);
+    auto chunk_up = create_chunk(field_meta, vec);
+
+    auto* chunk = dynamic_cast<MolChunk*>(chunk_up.get());
+    ASSERT_NE(chunk, nullptr);
+
+    // Verify rows and content
+    int64_t total_rows = static_cast<int64_t>(b1.size() + b2.size());
+    EXPECT_EQ(chunk->RowNums(), total_rows);
+
+    for (int64_t i = 0; i < static_cast<int64_t>(b1.size()); ++i) {
+        auto sv = (*chunk)[static_cast<int>(i)];
+        ASSERT_TRUE(chunk->isValid(static_cast<int>(i)));
+        EXPECT_EQ(sv, b1[static_cast<size_t>(i)].value());
+    }
+    for (int64_t i = 0; i < static_cast<int64_t>(b2.size()); ++i) {
+        auto idx = static_cast<int>(b1.size() + i);
+        auto sv = (*chunk)[idx];
+        ASSERT_TRUE(chunk->isValid(idx));
+        EXPECT_EQ(sv, b2[static_cast<size_t>(i)].value());
+    }
+}
+
+TEST(MolChunkWriterTest, WithNullsMergedBitmap) {
+    // Prepare batches with nulls
+    std::vector<std::optional<std::string>> b1 = {
+        std::nullopt,
+        std::string("C"),
+        std::nullopt,
+        std::string("CCO"),
+        std::string("c1ccccc1"),
+    };
+    std::vector<std::optional<std::string>> b2 = {
+        std::string("CC(=O)O"),
+        std::nullopt,
+        std::string("CCN"),
+        std::string(""),
+    };
+
+    auto a1 = BuildMolBinaryArray(b1);
+    auto a2 = BuildMolBinaryArray(b2);
+
+    arrow::ArrayVector vec{a1, a2};
+
+    auto field_meta = MakeMolFieldMeta(/*nullable=*/true);
+    auto chunk_up = create_chunk(field_meta, vec);
+
+    auto* chunk = dynamic_cast<MolChunk*>(chunk_up.get());
+    ASSERT_NE(chunk, nullptr);
+
+    // Verify validity and content for non-null entries only
+    std::vector<std::optional<std::string>> all;
+    all.reserve(b1.size() + b2.size());
+    all.insert(all.end(), b1.begin(), b1.end());
+    all.insert(all.end(), b2.begin(), b2.end());
+
+    for (int i = 0; i < static_cast<int>(all.size()); ++i) {
+        bool expect_valid = all[static_cast<size_t>(i)].has_value();
+        EXPECT_EQ(chunk->isValid(i), expect_valid);
+        if (expect_valid) {
+            EXPECT_EQ((*chunk)[i], all[static_cast<size_t>(i)].value());
+        }
+    }
+}
+
+TEST(MolChunkWriterTest, EmptyBatch) {
+    // Test with an empty array
+    std::vector<std::optional<std::string>> empty_batch;
+    auto a1 = BuildMolBinaryArray(empty_batch);
+
+    arrow::ArrayVector vec{a1};
+
+    auto field_meta = MakeMolFieldMeta(/*nullable=*/false);
+    auto chunk_up = create_chunk(field_meta, vec);
+
+    auto* chunk = dynamic_cast<MolChunk*>(chunk_up.get());
+    ASSERT_NE(chunk, nullptr);
+    EXPECT_EQ(chunk->RowNums(), 0);
+}
+
+TEST(MolChunkWriterTest, LargeBatch) {
+    // Test with a large batch of MOL data
+    static const std::vector<std::string> smiles_list = {
+        "C",
+        "CC",
+        "CCC",
+        "CCO",
+        "CCCO",
+        "c1ccccc1",
+        "CC(=O)O",
+        "CCN",
+        "CCOCC",
+        "CC(C)C",
+    };
+
+    std::vector<std::optional<std::string>> batch;
+    for (int i = 0; i < 1000; ++i) {
+        batch.emplace_back(smiles_list[i % smiles_list.size()]);
+    }
+
+    auto arr = BuildMolBinaryArray(batch);
+    arrow::ArrayVector vec{arr};
+
+    auto field_meta = MakeMolFieldMeta(/*nullable=*/false);
+    auto chunk_up = create_chunk(field_meta, vec);
+
+    auto* chunk = dynamic_cast<MolChunk*>(chunk_up.get());
+    ASSERT_NE(chunk, nullptr);
+    EXPECT_EQ(chunk->RowNums(), 1000);
+
+    for (int i = 0; i < 1000; ++i) {
+        auto sv = (*chunk)[i];
+        EXPECT_EQ(sv, smiles_list[i % smiles_list.size()]);
+    }
+}
+
+TEST(MolChunkWriterTest, SingleRow) {
+    // Test with a single row
+    std::vector<std::optional<std::string>> batch = {
+        std::string("c1ccc(O)cc1"),  // Phenol
+    };
+
+    auto arr = BuildMolBinaryArray(batch);
+    arrow::ArrayVector vec{arr};
+
+    auto field_meta = MakeMolFieldMeta(/*nullable=*/false);
+    auto chunk_up = create_chunk(field_meta, vec);
+
+    auto* chunk = dynamic_cast<MolChunk*>(chunk_up.get());
+    ASSERT_NE(chunk, nullptr);
+    EXPECT_EQ(chunk->RowNums(), 1);
+    EXPECT_EQ((*chunk)[0], "c1ccc(O)cc1");
+}
+
+TEST(MolChunkWriterTest, NullableSingleNull) {
+    // Test with all nulls
+    std::vector<std::optional<std::string>> batch = {
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
+    };
+
+    auto arr = BuildMolBinaryArray(batch);
+    arrow::ArrayVector vec{arr};
+
+    auto field_meta = MakeMolFieldMeta(/*nullable=*/true);
+    auto chunk_up = create_chunk(field_meta, vec);
+
+    auto* chunk = dynamic_cast<MolChunk*>(chunk_up.get());
+    ASSERT_NE(chunk, nullptr);
+    EXPECT_EQ(chunk->RowNums(), 3);
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_FALSE(chunk->isValid(i));
+    }
+}

--- a/internal/core/src/common/TypeTraits.h
+++ b/internal/core/src/common/TypeTraits.h
@@ -35,8 +35,9 @@ template <typename T>
 constexpr bool IsScalar =
     std::is_fundamental_v<T> || std::is_same_v<T, std::string> ||
     std::is_same_v<T, Json> || std::is_same_v<T, Geometry> ||
-    std::is_same_v<T, std::string_view> || std::is_same_v<T, Array> ||
-    std::is_same_v<T, ArrayView> || std::is_same_v<T, proto::plan::Array>;
+    std::is_same_v<T, Mol> || std::is_same_v<T, std::string_view> ||
+    std::is_same_v<T, Array> || std::is_same_v<T, ArrayView> ||
+    std::is_same_v<T, proto::plan::Array>;
 
 template <typename T>
 constexpr bool IsSparse =

--- a/internal/core/src/common/Types.h
+++ b/internal/core/src/common/Types.h
@@ -48,6 +48,7 @@
 #include "pb/schema.pb.h"
 #include "pb/segcore.pb.h"
 #include "type_c.h"
+#include "Mol.h"
 
 namespace milvus {
 
@@ -83,6 +84,7 @@ enum class DataType {
     GEOMETRY = 24,
     TEXT = 25,
     TIMESTAMPTZ = 26,  // Timestamp with timezone, stored as int64
+    MOL = 27,
 
     // Some special Data type, start from after 50
     // just for internal use now, may sync proto in future
@@ -206,6 +208,8 @@ ToProtoDataType(DataType data_type) {
             return proto::schema::DataType::ArrayOfVector;
         case DataType::GEOMETRY:
             return proto::schema::DataType::Geometry;
+        case DataType::MOL:
+            return proto::schema::DataType::Mol;
 
         // Internal-only or unsupported mappings
         case DataType::ROW:
@@ -245,6 +249,8 @@ GetArrowDataType(DataType data_type, int dim = 1) {
         case DataType::JSON:
             return arrow::binary();
         case DataType::GEOMETRY:
+            return arrow::binary();
+        case DataType::MOL:
             return arrow::binary();
         case DataType::VECTOR_FLOAT:
             return arrow::fixed_size_binary(dim * 4);
@@ -337,6 +343,8 @@ GetDataTypeName(DataType data_type) {
             return "text";
         case DataType::GEOMETRY:
             return "geometry";
+        case DataType::MOL:
+            return "mol";
         case DataType::VECTOR_FLOAT:
             return "vector_float";
         case DataType::VECTOR_BINARY:
@@ -437,6 +445,11 @@ IsGeometryDataType(DataType data_type) {
 }
 
 inline bool
+IsMolDataType(DataType data_type) {
+    return data_type == DataType::MOL;
+}
+
+inline bool
 IsArrayDataType(DataType data_type) {
     return data_type == DataType::ARRAY || data_type == DataType::VECTOR_ARRAY;
 }
@@ -444,7 +457,7 @@ IsArrayDataType(DataType data_type) {
 inline bool
 IsBinaryDataType(DataType data_type) {
     return IsJsonDataType(data_type) || IsArrayDataType(data_type) ||
-           IsGeometryDataType(data_type);
+           IsGeometryDataType(data_type) || IsMolDataType(data_type);
 }
 
 inline bool
@@ -944,6 +957,9 @@ struct fmt::formatter<milvus::DataType> : formatter<string_view> {
                 break;
             case milvus::DataType::GEOMETRY:
                 name = "GEOMETRY";
+                break;
+            case milvus::DataType::MOL:
+                name = "MOL";
                 break;
             case milvus::DataType::ROW:
                 name = "ROW";

--- a/internal/core/src/common/mol_c.cpp
+++ b/internal/core/src/common/mol_c.cpp
@@ -1,0 +1,166 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License.
+
+#include "mol_c.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+// RDKit includes
+#include <GraphMol/GraphMol.h>
+#include <GraphMol/SmilesParse/SmilesParse.h>
+#include <GraphMol/SmilesParse/SmilesWrite.h>
+#include <GraphMol/MolPickler.h>
+#include <GraphMol/Fingerprints/Fingerprints.h>
+#include <GraphMol/Fingerprints/MorganFingerprints.h>
+#include <GraphMol/Fingerprints/MACCS.h>
+#include <DataStructs/ExplicitBitVect.h>
+
+namespace {
+
+MolDataResult CreateErrorResult(int32_t error_code, const char* error_msg) {
+    MolDataResult result{};
+    result.error_code = error_code;
+    result.error_msg = error_msg ? strdup(error_msg) : nullptr;
+    return result;
+}
+
+MolDataResult CreateSuccessResult(const uint8_t* data, size_t size) {
+    MolDataResult result{};
+    result.data = static_cast<uint8_t*>(malloc(size));
+    if (!result.data) {
+        return CreateErrorResult(MOL_ERROR_MEMORY, "Failed to allocate memory");
+    }
+    memcpy(result.data, data, size);
+    result.size = size;
+    return result;
+}
+
+std::vector<uint8_t> BitVectToBinaryVector(const ExplicitBitVect& bv) {
+    size_t num_bits = bv.getNumBits();
+    size_t num_bytes = (num_bits + 7) / 8;
+    std::vector<uint8_t> result(num_bytes, 0);
+    for (size_t i = 0; i < num_bits; ++i) {
+        if (bv.getBit(i)) {
+            result[i / 8] |= (1 << (i % 8));
+        }
+    }
+    return result;
+}
+
+MolDataResult GenerateFingerprintImpl(
+    const char* smiles,
+    const std::function<ExplicitBitVect*(RDKit::ROMol&)>& gen_fp) {
+    if (!smiles || !*smiles) {
+        return CreateErrorResult(MOL_ERROR_INVALID_SMILES, "Empty SMILES string");
+    }
+    try {
+        std::unique_ptr<RDKit::ROMol> mol(RDKit::SmilesToMol(smiles));
+        if (!mol) {
+            return CreateErrorResult(MOL_ERROR_INVALID_SMILES, "Failed to parse SMILES string");
+        }
+        std::unique_ptr<ExplicitBitVect> fp(gen_fp(*mol));
+        if (!fp) {
+            return CreateErrorResult(MOL_ERROR_FINGERPRINT_FAILED, "Failed to generate fingerprint");
+        }
+        auto binary = BitVectToBinaryVector(*fp);
+        return CreateSuccessResult(binary.data(), binary.size());
+    } catch (const std::exception& e) {
+        return CreateErrorResult(MOL_ERROR_FINGERPRINT_FAILED, e.what());
+    }
+}
+
+}  // namespace
+
+extern "C" {
+
+void FreeMolDataResult(MolDataResult* result) {
+    if (result) {
+        if (result->data) {
+            free(result->data);
+            result->data = nullptr;
+        }
+        if (result->error_msg) {
+            free(result->error_msg);
+            result->error_msg = nullptr;
+        }
+        result->size = 0;
+        result->error_code = 0;
+    }
+}
+
+MolDataResult ConvertSMILESToPickle(const char* smiles) {
+    if (!smiles || !*smiles) {
+        return CreateErrorResult(MOL_ERROR_INVALID_SMILES, "Empty SMILES string");
+    }
+    try {
+        std::unique_ptr<RDKit::ROMol> mol(RDKit::SmilesToMol(smiles));
+        if (!mol) {
+            return CreateErrorResult(MOL_ERROR_INVALID_SMILES, "Failed to parse SMILES string");
+        }
+        std::string pickle;
+        RDKit::MolPickler::pickleMol(*mol, pickle);
+        if (pickle.empty()) {
+            return CreateErrorResult(MOL_ERROR_PICKLE_FAILED, "Failed to pickle molecule");
+        }
+        return CreateSuccessResult(reinterpret_cast<const uint8_t*>(pickle.data()), pickle.size());
+    } catch (const std::exception& e) {
+        return CreateErrorResult(MOL_ERROR_INVALID_SMILES, e.what());
+    }
+}
+
+MolDataResult ConvertPickleToSMILES(const uint8_t* pickle_data, size_t pickle_size) {
+    if (!pickle_data || pickle_size == 0) {
+        return CreateErrorResult(MOL_ERROR_PICKLE_FAILED, "Empty pickle data");
+    }
+    try {
+        std::string pickle_str(reinterpret_cast<const char*>(pickle_data), pickle_size);
+        RDKit::ROMol mol;
+        RDKit::MolPickler::molFromPickle(pickle_str, &mol);
+        std::string smiles = RDKit::MolToSmiles(mol);
+        if (smiles.empty()) {
+            return CreateErrorResult(MOL_ERROR_PICKLE_FAILED, "Failed to convert molecule to SMILES");
+        }
+        return CreateSuccessResult(reinterpret_cast<const uint8_t*>(smiles.c_str()), smiles.size() + 1);
+    } catch (const std::exception& e) {
+        return CreateErrorResult(MOL_ERROR_PICKLE_FAILED, e.what());
+    }
+}
+
+MolDataResult GenerateMorganFingerprint(const char* smiles, int radius, int fingerprint_size) {
+    if (radius < 0 || fingerprint_size <= 0) {
+        return CreateErrorResult(MOL_ERROR_FINGERPRINT_FAILED, "Invalid fingerprint parameters");
+    }
+    return GenerateFingerprintImpl(smiles, [=](RDKit::ROMol& mol) {
+        return RDKit::MorganFingerprints::getFingerprintAsBitVect(mol, radius, fingerprint_size);
+    });
+}
+
+MolDataResult GenerateMACCSFingerprint(const char* smiles) {
+    return GenerateFingerprintImpl(smiles, [](RDKit::ROMol& mol) {
+        return RDKit::MACCSFingerprints::getFingerprintAsBitVect(mol);
+    });
+}
+
+MolDataResult GenerateRDKitFingerprint(const char* smiles, int min_path, int max_path, int fingerprint_size) {
+    if (min_path < 1 || max_path < min_path || fingerprint_size <= 0) {
+        return CreateErrorResult(MOL_ERROR_FINGERPRINT_FAILED, "Invalid fingerprint parameters");
+    }
+    return GenerateFingerprintImpl(smiles, [=](RDKit::ROMol& mol) {
+        return RDKit::RDKFingerprintMol(mol, min_path, max_path, fingerprint_size);
+    });
+}
+
+}  // extern "C"

--- a/internal/core/src/common/mol_c.h
+++ b/internal/core/src/common/mol_c.h
@@ -1,0 +1,69 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License.
+
+#ifndef MILVUS_MOL_C_H
+#define MILVUS_MOL_C_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Error codes
+#define MOL_SUCCESS 0
+#define MOL_ERROR_INVALID_SMILES 1
+#define MOL_ERROR_PICKLE_FAILED 2
+#define MOL_ERROR_FINGERPRINT_FAILED 3
+#define MOL_ERROR_MEMORY 4
+
+// Result structure for operations that return binary data
+typedef struct {
+    uint8_t* data;      // Binary data (caller must free with FreeMolDataResult)
+    size_t size;        // Size of data in bytes
+    int32_t error_code; // Error code (0 = success)
+    char* error_msg;    // Error message (caller must free with FreeMolDataResult if not NULL)
+} MolDataResult;
+
+// Free the MolDataResult structure
+void FreeMolDataResult(MolDataResult* result);
+
+// Convert SMILES string to Pickle binary format
+// Returns MolDataResult with pickle data on success, or error on failure
+MolDataResult ConvertSMILESToPickle(const char* smiles);
+
+// Convert Pickle binary data to SMILES string
+// Returns MolDataResult with SMILES string (as bytes) on success, or error on failure
+MolDataResult ConvertPickleToSMILES(const uint8_t* pickle_data, size_t pickle_size);
+
+// Generate Morgan fingerprint from SMILES
+// radius: fingerprint radius (e.g., 2)
+// fingerprint_size: number of bits (e.g., 2048)
+// Returns MolDataResult with binary fingerprint on success, or error on failure
+MolDataResult GenerateMorganFingerprint(const char* smiles, int radius, int fingerprint_size);
+
+// Generate MACCS fingerprint from SMILES
+// Returns MolDataResult with binary fingerprint (167 bits) on success, or error on failure
+MolDataResult GenerateMACCSFingerprint(const char* smiles);
+
+// Generate RDKit fingerprint from SMILES
+// min_path: minimum path length (e.g., 1)
+// max_path: maximum path length (e.g., 7)
+// fingerprint_size: number of bits (e.g., 2048)
+// Returns MolDataResult with binary fingerprint on success, or error on failure
+MolDataResult GenerateRDKitFingerprint(const char* smiles, int min_path, int max_path, int fingerprint_size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // MILVUS_MOL_C_H

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -1645,7 +1645,8 @@ class SegmentExpr : public Expr {
                     case DataType::VARCHAR: {
                         return ProcessIndexChunksForValid<std::string>();
                     }
-                    case DataType::GEOMETRY: {
+                    case DataType::GEOMETRY:
+                    case DataType::MOL: {
                         return ProcessIndexChunksForValid<std::string>();
                     }
                     default:

--- a/internal/core/src/exec/expression/NullExpr.cpp
+++ b/internal/core/src/exec/expression/NullExpr.cpp
@@ -110,6 +110,17 @@ PhyNullExpr::Eval(EvalCtx& context, VectorPtr& result) {
             }
             break;
         }
+        case DataType::MOL: {
+            if (segment_->type() == SegmentType::Growing &&
+                !storage::MmapManager::GetInstance()
+                     .GetMmapConfig()
+                     .growing_enable_mmap) {
+                result = ExecVisitorImpl<std::string>(input);
+            } else {
+                result = ExecVisitorImpl<std::string_view>(input);
+            }
+            break;
+        }
         default:
             ThrowInfo(DataTypeInvalid,
                       "unsupported data type: {}",

--- a/internal/core/src/mmap/ChunkedColumnInterface.h
+++ b/internal/core/src/mmap/ChunkedColumnInterface.h
@@ -254,7 +254,8 @@ class ChunkedColumnInterface {
     IsChunkedVariableColumnDataType(DataType data_type) {
         return data_type == DataType::STRING ||
                data_type == DataType::VARCHAR || data_type == DataType::TEXT ||
-               data_type == DataType::JSON || data_type == DataType::GEOMETRY;
+               data_type == DataType::JSON || data_type == DataType::GEOMETRY ||
+               data_type == DataType::MOL;
     }
 
     static bool

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -1638,7 +1638,8 @@ ChunkedSegmentSealedImpl::bulk_subscript(milvus::OpContext* op_ctx,
                                           static_cast<Json*>(data));
             break;
         }
-        case DataType::GEOMETRY: {
+        case DataType::GEOMETRY:
+        case DataType::MOL: {
             // dst must have at least count elements; the callback's offset
             // parameter is guaranteed to be in [0, count)
             bulk_subscript_ptr_impl<std::string>(
@@ -2065,6 +2066,16 @@ ChunkedSegmentSealedImpl::get_raw_data(milvus::OpContext* op_ctx,
                                                  ret->mutable_scalars()
                                                      ->mutable_geometry_data()
                                                      ->mutable_data());
+            break;
+        }
+
+        case DataType::MOL: {
+            bulk_subscript_ptr_impl<std::string>(
+                op_ctx,
+                column.get(),
+                seg_offsets,
+                count,
+                ret->mutable_scalars()->mutable_mol_data()->mutable_data());
             break;
         }
 

--- a/internal/core/src/segcore/ConcurrentVector.cpp
+++ b/internal/core/src/segcore/ConcurrentVector.cpp
@@ -131,6 +131,17 @@ VectorBase::set_data_raw(ssize_t element_offset,
             }
             return set_data_raw(element_offset, data_raw.data(), element_count);
         }
+        case DataType::MOL: {
+            // get the mol array of a column from proto message
+            auto& mol_data = FIELD_DATA(data, mol);
+            std::vector<std::string> data_raw{};
+            data_raw.reserve(mol_data.size());
+            for (auto& mol_bytes : mol_data) {
+                data_raw.emplace_back(
+                    std::string(mol_bytes.data(), mol_bytes.size()));
+            }
+            return set_data_raw(element_offset, data_raw.data(), element_count);
+        }
         case DataType::ARRAY: {
             auto& array_data = FIELD_DATA(data, array);
             std::vector<Array> data_raw{};

--- a/internal/core/src/segcore/InsertRecord.h
+++ b/internal/core/src/segcore/InsertRecord.h
@@ -938,6 +938,11 @@ class InsertRecordGrowing {
                     field_id, size_per_chunk, scalar_mmap_descriptor);
                 return;
             }
+            case DataType::MOL: {
+                this->append_data<std::string>(
+                    field_id, size_per_chunk, scalar_mmap_descriptor);
+                return;
+            }
             default: {
                 ThrowInfo(DataTypeInvalid,
                           fmt::format("unsupported scalar type",

--- a/internal/core/src/segcore/ReduceUtils.cpp
+++ b/internal/core/src/segcore/ReduceUtils.cpp
@@ -175,6 +175,19 @@ AssembleGroupByValues(
                 }
                 break;
             }
+            case DataType::MOL: {
+                mutable_group_by_field_value->set_type(
+                    milvus::proto::schema::DataType::Mol);
+                auto field_data = group_by_res_values->mutable_mol_data();
+                for (std::size_t idx = 0; idx < group_by_val_size; idx++) {
+                    if (group_by_vals[idx].has_value()) {
+                        std::string val =
+                            std::get<std::string>(group_by_vals[idx].value());
+                        *(field_data->mutable_data()->Add()) = val;
+                    }
+                }
+                break;
+            }
             case DataType::JSON: {
                 auto json_path = plan->plan_node_->search_info_.json_path_;
                 auto json_type = plan->plan_node_->search_info_.json_type_;

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -406,7 +406,8 @@ SegmentGrowingImpl::EstimateSegmentResourceUsage() const {
                     break;
                 case DataType::VARCHAR:
                 case DataType::TEXT:
-                case DataType::GEOMETRY: {
+                case DataType::GEOMETRY:
+                case DataType::MOL: {
                     auto avg_size =
                         SegmentInternalInterface::get_field_avg_size(field_id);
                     field_bytes = num_rows * avg_size;
@@ -1402,6 +1403,15 @@ SegmentGrowingImpl::bulk_subscript(milvus::OpContext* op_ctx,
                                                      ->mutable_data());
             break;
         }
+        case DataType::MOL: {
+            bulk_subscript_ptr_impl<std::string>(
+                op_ctx,
+                vec_ptr,
+                seg_offsets,
+                count,
+                result->mutable_scalars()->mutable_mol_data()->mutable_data());
+            break;
+        }
         case DataType::ARRAY: {
             // element
             bulk_subscript_array_impl(op_ctx,
@@ -1723,7 +1733,8 @@ SegmentGrowingImpl::bulk_subscript(milvus::OpContext* op_ctx,
                 vec_ptr, seg_offsets, count, static_cast<Json*>(data));
             break;
         }
-        case DataType::GEOMETRY: {
+        case DataType::GEOMETRY:
+        case DataType::MOL: {
             bulk_subscript_ptr_impl<std::string>(
                 vec_ptr, seg_offsets, count, static_cast<std::string*>(data));
             break;

--- a/internal/core/src/segcore/SegmentGrowingTest.cpp
+++ b/internal/core/src/segcore/SegmentGrowingTest.cpp
@@ -193,6 +193,7 @@ TEST_P(GrowingTest, FillData) {
     auto varchar_field = schema->AddDebugField("varchar", DataType::VARCHAR);
     auto json_field = schema->AddDebugField("json", DataType::JSON);
     auto geometry_field = schema->AddDebugField("geometry", DataType::GEOMETRY);
+    auto mol_field = schema->AddDebugField("mol", DataType::MOL);
     auto int_array_field =
         schema->AddDebugField("int_array", DataType::ARRAY, DataType::INT8);
     auto long_array_field =
@@ -260,6 +261,8 @@ TEST_P(GrowingTest, FillData) {
             nullptr, json_field, ids_ds->GetIds(), num_inserted);
         auto geometry_result = segment->bulk_subscript(
             nullptr, geometry_field, ids_ds->GetIds(), num_inserted);
+        auto mol_result = segment->bulk_subscript(
+            nullptr, mol_field, ids_ds->GetIds(), num_inserted);
         auto int_array_result = segment->bulk_subscript(
             nullptr, int_array_field, ids_ds->GetIds(), num_inserted);
         auto long_array_result = segment->bulk_subscript(
@@ -292,6 +295,7 @@ TEST_P(GrowingTest, FillData) {
         EXPECT_EQ(json_result->scalars().json_data().data_size(), num_inserted);
         EXPECT_EQ(geometry_result->scalars().geometry_data().data_size(),
                   num_inserted);
+        EXPECT_EQ(mol_result->scalars().mol_data().data_size(), num_inserted);
         if (data_type == DataType::VECTOR_FLOAT) {
             EXPECT_EQ(vec_result->vectors().float_vector().data_size(),
                       num_inserted * dim);
@@ -349,6 +353,7 @@ TEST(Growing, FillNullableData) {
     auto varchar_field =
         schema->AddDebugField("varchar", DataType::VARCHAR, true);
     auto json_field = schema->AddDebugField("json", DataType::JSON, true);
+    auto mol_field = schema->AddDebugField("mol", DataType::MOL, true);
     auto int_array_field = schema->AddDebugField(
         "int_array", DataType::ARRAY, DataType::INT8, true);
     auto long_array_field = schema->AddDebugField(
@@ -415,6 +420,8 @@ TEST(Growing, FillNullableData) {
             nullptr, varchar_field, ids_ds->GetIds(), num_inserted);
         auto json_result = segment->bulk_subscript(
             nullptr, json_field, ids_ds->GetIds(), num_inserted);
+        auto mol_result = segment->bulk_subscript(
+            nullptr, mol_field, ids_ds->GetIds(), num_inserted);
         auto int_array_result = segment->bulk_subscript(
             nullptr, int_array_field, ids_ds->GetIds(), num_inserted);
         auto long_array_result = segment->bulk_subscript(
@@ -445,6 +452,7 @@ TEST(Growing, FillNullableData) {
         EXPECT_EQ(varchar_result->scalars().string_data().data_size(),
                   num_inserted);
         EXPECT_EQ(json_result->scalars().json_data().data_size(), num_inserted);
+        EXPECT_EQ(mol_result->scalars().mol_data().data_size(), num_inserted);
         EXPECT_EQ(vec_result->vectors().float_vector().data_size(),
                   num_inserted * dim);
         EXPECT_EQ(int_array_result->scalars().array_data().data_size(),
@@ -468,6 +476,7 @@ TEST(Growing, FillNullableData) {
         EXPECT_EQ(timestamptz_result->valid_data_size(), num_inserted);
         EXPECT_EQ(varchar_result->valid_data_size(), num_inserted);
         EXPECT_EQ(json_result->valid_data_size(), num_inserted);
+        EXPECT_EQ(mol_result->valid_data_size(), num_inserted);
         EXPECT_EQ(int_array_result->valid_data_size(), num_inserted);
         EXPECT_EQ(long_array_result->valid_data_size(), num_inserted);
         EXPECT_EQ(bool_array_result->valid_data_size(), num_inserted);

--- a/internal/core/src/segcore/SegmentInterface.cpp
+++ b/internal/core/src/segcore/SegmentInterface.cpp
@@ -669,6 +669,16 @@ SegmentInternalInterface::bulk_subscript_not_exist_field(
                 }
                 break;
             }
+            case DataType::MOL: {
+                auto data_ptr = result->mutable_scalars()
+                                    ->mutable_mol_data()
+                                    ->mutable_data();
+
+                for (int64_t i = 0; i < count; ++i) {
+                    data_ptr->at(i) = field_meta.default_value()->bytes_data();
+                }
+                break;
+            }
             default: {
                 ThrowInfo(DataTypeInvalid,
                           fmt::format("unsupported default value type {}",

--- a/internal/core/src/storage/Event.cpp
+++ b/internal/core/src/storage/Event.cpp
@@ -342,6 +342,17 @@ BaseEventData::Serialize() {
                 }
                 break;
             }
+            case DataType::MOL: {
+                for (size_t offset = 0; offset < field_data->get_num_rows();
+                     ++offset) {
+                    auto mol_ptr = static_cast<const std::string*>(
+                        field_data->RawValue(offset));
+                    payload_writer->add_one_binary_payload(
+                        reinterpret_cast<const uint8_t*>(mol_ptr->data()),
+                        mol_ptr->size());
+                }
+                break;
+            }
             case DataType::VECTOR_SPARSE_U32_F32: {
                 for (size_t offset = 0; offset < field_data->get_num_rows();
                      ++offset) {

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -444,7 +444,8 @@ CreateArrowBuilder(DataType data_type) {
         }
         case DataType::ARRAY:
         case DataType::JSON:
-        case DataType::GEOMETRY: {
+        case DataType::GEOMETRY:
+        case DataType::MOL: {
             return std::make_shared<arrow::BinaryBuilder>();
         }
         // sparse float vector doesn't require a dim
@@ -655,7 +656,8 @@ CreateArrowSchema(DataType data_type, bool nullable) {
         }
         case DataType::ARRAY:
         case DataType::JSON:
-        case DataType::GEOMETRY: {
+        case DataType::GEOMETRY:
+        case DataType::MOL: {
             return arrow::schema(
                 {arrow::field("val", arrow::binary(), nullable)});
         }
@@ -1224,6 +1226,9 @@ CreateFieldData(const DataType& type,
                 type, nullable, total_num_rows);
         case DataType::GEOMETRY:
             return std::make_shared<FieldData<Geometry>>(
+                type, nullable, total_num_rows);
+        case DataType::MOL:
+            return std::make_shared<FieldData<Mol>>(
                 type, nullable, total_num_rows);
         case DataType::ARRAY:
             return std::make_shared<FieldData<Array>>(

--- a/internal/core/thirdparty/rdkit/CMakeLists.txt
+++ b/internal/core/thirdparty/rdkit/CMakeLists.txt
@@ -1,0 +1,51 @@
+#-------------------------------------------------------------------------------
+# Copyright (C) 2019-2020 Zilliz. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under the License.
+#-------------------------------------------------------------------------------
+
+# RDKit integration for Milvus — now provided by Conan package
+#
+# The Conan package "rdkit/2025.09.1@milvus/dev" supplies:
+#   - SMILES / MOL parsing  (SmilesParse, GraphMol)
+#   - Pickle serialization  (GraphMol/MolPickler)
+#   - Molecular fingerprints (Fingerprints – Morgan, MACCS, RDKit)
+#   - Substructure matching  (SubstructMatch)
+#
+# After `conan_basic_setup()` the variables below are available:
+#   CONAN_INCLUDE_DIRS_RDKIT   — header search paths
+#   CONAN_LIB_DIRS_RDKIT       — library search paths
+#   CONAN_LIBS_RDKIT            — library names (e.g. RDKitGraphMol …)
+
+# ---------- sanity check ----------
+if(NOT DEFINED CONAN_LIBS_RDKIT)
+    message(FATAL_ERROR
+        "RDKit Conan package not found. "
+        "Make sure 'rdkit/2025.09.1@milvus/dev' is listed in conanfile.py "
+        "and `conan install` has been run.")
+endif()
+
+# ---------- convenience imported target ----------
+# Create RDKit::RDKit interface target so the rest of the build system
+# can keep using `target_link_libraries(... RDKit::RDKit)` unchanged.
+add_library(RDKit::RDKit INTERFACE IMPORTED GLOBAL)
+set_target_properties(RDKit::RDKit PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${CONAN_INCLUDE_DIRS_RDKIT}"
+    INTERFACE_LINK_DIRECTORIES    "${CONAN_LIB_DIRS_RDKIT}"
+    INTERFACE_LINK_LIBRARIES      "${CONAN_LIBS_RDKIT}"
+)
+
+# Backward-compat: expose RDKIT_INCLUDE_DIR for mol_c.cpp compilation
+set(RDKIT_INCLUDE_DIR "${CONAN_INCLUDE_DIRS_RDKIT}" CACHE INTERNAL
+    "RDKit include directories (from Conan)")
+
+message(STATUS "RDKit configured from Conan package")
+message(STATUS "  Include dirs : ${CONAN_INCLUDE_DIRS_RDKIT}")
+message(STATUS "  Libraries    : ${CONAN_LIBS_RDKIT}")

--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -506,6 +506,7 @@ TEST(Sealed, LoadFieldData) {
     schema->AddDebugField("float", DataType::FLOAT);
     schema->AddDebugField("json", DataType::JSON);
     schema->AddDebugField("geometry", DataType::GEOMETRY);
+    schema->AddDebugField("mol", DataType::MOL);
     schema->AddDebugField("array", DataType::ARRAY, DataType::INT64);
     schema->set_primary_field_id(counter_id);
     auto int8_nullable_id =
@@ -671,6 +672,7 @@ TEST(Sealed, ClearData) {
     schema->AddDebugField("float", DataType::FLOAT);
     schema->AddDebugField("json", DataType::JSON);
     schema->AddDebugField("geometry", DataType::GEOMETRY);
+    schema->AddDebugField("mol", DataType::MOL);
     schema->AddDebugField("array", DataType::ARRAY, DataType::INT64);
     schema->set_primary_field_id(counter_id);
 
@@ -758,6 +760,7 @@ TEST(Sealed, LoadFieldDataMmap) {
     schema->AddDebugField("float", DataType::FLOAT);
     schema->AddDebugField("json", DataType::JSON);
     schema->AddDebugField("geometry", DataType::GEOMETRY);
+    schema->AddDebugField("mol", DataType::MOL);
     schema->AddDebugField("array", DataType::ARRAY, DataType::INT64);
     schema->set_primary_field_id(counter_id);
 
@@ -1931,6 +1934,7 @@ TEST(Sealed, QueryAllFields) {
     auto varchar_field = schema->AddDebugField("varchar", DataType::VARCHAR);
     auto json_field = schema->AddDebugField("json", DataType::JSON);
     auto geometry_field = schema->AddDebugField("geometry", DataType::GEOMETRY);
+    auto mol_field = schema->AddDebugField("mol", DataType::MOL);
     auto int_array_field =
         schema->AddDebugField("int_array", DataType::ARRAY, DataType::INT8);
     auto long_array_field =
@@ -2020,6 +2024,8 @@ TEST(Sealed, QueryAllFields) {
         nullptr, json_field, ids_ds->GetIds(), dataset_size);
     auto geometry_result = segment->bulk_subscript(
         nullptr, geometry_field, ids_ds->GetIds(), dataset_size);
+    auto mol_result = segment->bulk_subscript(
+        nullptr, mol_field, ids_ds->GetIds(), dataset_size);
     auto int_array_result = segment->bulk_subscript(
         nullptr, int_array_field, ids_ds->GetIds(), dataset_size);
     auto long_array_result = segment->bulk_subscript(
@@ -2053,6 +2059,7 @@ TEST(Sealed, QueryAllFields) {
     EXPECT_EQ(json_result->scalars().json_data().data_size(), dataset_size);
     EXPECT_EQ(geometry_result->scalars().geometry_data().data_size(),
               dataset_size);
+    EXPECT_EQ(mol_result->scalars().mol_data().data_size(), dataset_size);
     EXPECT_EQ(vec_result->vectors().float_vector().data_size(),
               dataset_size * dim);
     EXPECT_EQ(float16_vec_result->vectors().float16_vector().size(),
@@ -2107,6 +2114,7 @@ TEST(Sealed, QueryAllNullableFields) {
     auto json_field = schema->AddDebugField("json", DataType::JSON, true);
     auto geometry_field =
         schema->AddDebugField("geometry", DataType::GEOMETRY, true);
+    auto mol_field = schema->AddDebugField("mol", DataType::MOL, true);
     auto int_array_field = schema->AddDebugField(
         "int_array", DataType::ARRAY, DataType::INT8, true);
     auto long_array_field = schema->AddDebugField(
@@ -2175,6 +2183,7 @@ TEST(Sealed, QueryAllNullableFields) {
     auto varchar_valid_values = dataset.get_col_valid(varchar_field);
     auto json_valid_values = dataset.get_col_valid(json_field);
     auto geometry_valid_values = dataset.get_col_valid(geometry_field);
+    auto mol_valid_values = dataset.get_col_valid(mol_field);
     auto int_array_valid_values = dataset.get_col_valid(int_array_field);
     auto long_array_valid_values = dataset.get_col_valid(long_array_field);
     auto bool_array_valid_values = dataset.get_col_valid(bool_array_field);
@@ -2203,6 +2212,8 @@ TEST(Sealed, QueryAllNullableFields) {
         nullptr, json_field, ids_ds->GetIds(), dataset_size);
     auto geometry_result = segment->bulk_subscript(
         nullptr, geometry_field, ids_ds->GetIds(), dataset_size);
+    auto mol_result = segment->bulk_subscript(
+        nullptr, mol_field, ids_ds->GetIds(), dataset_size);
     auto int_array_result = segment->bulk_subscript(
         nullptr, int_array_field, ids_ds->GetIds(), dataset_size);
     auto long_array_result = segment->bulk_subscript(
@@ -2230,6 +2241,7 @@ TEST(Sealed, QueryAllNullableFields) {
     EXPECT_EQ(json_result->scalars().json_data().data_size(), dataset_size);
     EXPECT_EQ(geometry_result->scalars().geometry_data().data_size(),
               dataset_size);
+    EXPECT_EQ(mol_result->scalars().mol_data().data_size(), dataset_size);
     EXPECT_EQ(vec_result->vectors().float_vector().data_size(),
               dataset_size * dim);
     EXPECT_EQ(int_array_result->scalars().array_data().data_size(),
@@ -2254,6 +2266,7 @@ TEST(Sealed, QueryAllNullableFields) {
     EXPECT_EQ(varchar_result->valid_data_size(), dataset_size);
     EXPECT_EQ(json_result->valid_data_size(), dataset_size);
     EXPECT_EQ(geometry_result->valid_data_size(), dataset_size);
+    EXPECT_EQ(mol_result->valid_data_size(), dataset_size);
     EXPECT_EQ(int_array_result->valid_data_size(), dataset_size);
     EXPECT_EQ(long_array_result->valid_data_size(), dataset_size);
     EXPECT_EQ(bool_array_result->valid_data_size(), dataset_size);

--- a/internal/proxy/task_query.go
+++ b/internal/proxy/task_query.go
@@ -749,6 +749,12 @@ func (t *queryTask) PostExecute(ctx context.Context) error {
 				return err
 			}
 		}
+		if fieldData.Type == schemapb.DataType_Mol {
+			if err := validateMOLFieldSearchResult(&t.result.FieldsData[i]); err != nil {
+				log.Warn("fail to validate MOL field search result", zap.Error(err))
+				return err
+			}
+		}
 	}
 	t.result.OutputFields = t.userOutputFields
 	if !t.reQuery {

--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -99,9 +99,6 @@ type searchTask struct {
 	functionScore *rerank.FunctionScore
 	rankParams    *rankParams
 
-	// Order by fields for sorting results
-	orderByFields []OrderByField
-
 	resolvedTimezoneStr string
 
 	isIterator bool
@@ -430,17 +427,6 @@ func (t *searchTask) initAdvancedSearchRequest(ctx context.Context) error {
 		return err
 	}
 
-	// Parse order_by_fields from main search params
-	if t.orderByFields, err = parseOrderByFields(t.request.GetSearchParams(), t.schema.CollectionSchema); err != nil {
-		log.Error("parseOrderByFields failed", zap.Error(err))
-		return err
-	}
-
-	// order_by is not supported for hybrid search
-	if len(t.orderByFields) > 0 {
-		return merr.WrapErrParameterInvalidMsg("order_by is not supported for hybrid search")
-	}
-
 	switch strings.ToLower(paramtable.Get().CommonCfg.HybridSearchRequeryPolicy.GetValue()) {
 	case "always":
 		t.needRequery = true
@@ -462,8 +448,7 @@ func (t *searchTask) initAdvancedSearchRequest(ctx context.Context) error {
 	t.queryInfos = make([]*planpb.QueryInfo, len(t.request.GetSubReqs()))
 	queryFieldIDs := []int64{}
 	for index, subReq := range t.request.GetSubReqs() {
-		// For hybrid search, order_by_fields comes from main search params, not sub-search params
-		plan, queryInfo, offset, _, _, err := t.tryGeneratePlan(subReq.GetSearchParams(), subReq.GetDsl(), subReq.GetExprTemplateValues())
+		plan, queryInfo, offset, _, err := t.tryGeneratePlan(subReq.GetSearchParams(), subReq.GetDsl(), subReq.GetExprTemplateValues())
 		if err != nil {
 			return err
 		}
@@ -553,7 +538,7 @@ func (t *searchTask) initAdvancedSearchRequest(ctx context.Context) error {
 			zap.Stringer("plan", plan)) // may be very large if large term passed.
 	}
 
-	if embedding.HasNonBM25AndMinHashFunctions(t.schema.CollectionSchema.Functions, queryFieldIDs) {
+	if embedding.HasFunctionsForSearch(t.schema.CollectionSchema.Functions, queryFieldIDs) {
 		ctx, sp := otel.Tracer(typeutil.ProxyRole).Start(ctx, "Proxy-AdvancedSearch-call-function-udf")
 		defer sp.End()
 		exec, err := embedding.NewFunctionExecutor(t.schema.CollectionSchema, nil, &models.ModelExtraInfo{ClusterID: paramtable.Get().CommonCfg.ClusterPrefix.GetValue(), DBName: t.request.GetDbName()})
@@ -662,11 +647,10 @@ func (t *searchTask) initSearchRequest(ctx context.Context) error {
 
 	log := log.Ctx(ctx).With(zap.Int64("collID", t.GetCollectionID()), zap.String("collName", t.collectionName))
 
-	plan, queryInfo, offset, isIterator, orderByFields, err := t.tryGeneratePlan(t.request.GetSearchParams(), t.request.GetDsl(), t.request.GetExprTemplateValues())
+	plan, queryInfo, offset, isIterator, err := t.tryGeneratePlan(t.request.GetSearchParams(), t.request.GetDsl(), t.request.GetExprTemplateValues())
 	if err != nil {
 		return err
 	}
-	t.orderByFields = orderByFields
 
 	if t.request.FunctionScore != nil {
 		if t.functionScore, err = rerank.NewFunctionScore(t.schema.CollectionSchema, t.request.FunctionScore, &models.ModelExtraInfo{ClusterID: paramtable.Get().CommonCfg.ClusterPrefix.GetValue(), DBName: t.request.GetDbName()}); err != nil {
@@ -677,11 +661,6 @@ func (t *searchTask) initSearchRequest(ctx context.Context) error {
 		if !t.functionScore.IsSupportGroup() && queryInfo.GetGroupByFieldId() > 0 {
 			return merr.WrapErrParameterInvalidMsg("Rerank %s does not support grouping search", t.functionScore.RerankName())
 		}
-	}
-
-	// order_by and function_score cannot be used together
-	if len(t.orderByFields) > 0 && t.functionScore != nil {
-		return merr.WrapErrParameterInvalidMsg("order_by and function_score cannot be used together: they specify conflicting sort criteria")
 	}
 
 	analyzer, err := funcutil.GetAttrByKeyFromRepeatedKV(AnalyzerKey, t.request.GetSearchParams())
@@ -699,7 +678,7 @@ func (t *searchTask) initSearchRequest(ctx context.Context) error {
 
 	// add highlight field ids to output fields id
 	if t.highlighter != nil {
-		t.SearchRequest.OutputFieldsId = append(t.SearchRequest.OutputFieldsId, t.highlighter.RequiredFieldIDs()...)
+		t.SearchRequest.OutputFieldsId = append(t.SearchRequest.OutputFieldsId, t.highlighter.FieldIDs()...)
 	}
 
 	if t.partitionKeyMode {
@@ -734,15 +713,6 @@ func (t *searchTask) initSearchRequest(ctx context.Context) error {
 		allFieldIDs.Insert(primaryFieldSchema.FieldID)
 		plan.OutputFieldIds = allFieldIDs.Collect()
 		plan.DynamicFields = t.userDynamicFields
-		// Merge highlight dynamic fields into plan.DynamicFields
-		if t.highlighter != nil {
-			highlightDynFields := t.highlighter.DynamicFieldNames()
-			if len(highlightDynFields) > 0 {
-				dynFieldSet := typeutil.NewSet[string](plan.DynamicFields...)
-				dynFieldSet.Insert(highlightDynFields...)
-				plan.DynamicFields = dynFieldSet.Collect()
-			}
-		}
 	}
 	plan.Namespace = t.request.Namespace
 
@@ -765,7 +735,7 @@ func (t *searchTask) initSearchRequest(ctx context.Context) error {
 	t.SearchRequest.GroupByFieldId = queryInfo.GroupByFieldId
 	t.SearchRequest.GroupSize = queryInfo.GroupSize
 
-	if embedding.HasNonBM25AndMinHashFunctions(t.schema.CollectionSchema.Functions, []int64{queryInfo.GetQueryFieldId()}) {
+	if embedding.HasFunctionsForSearch(t.schema.CollectionSchema.Functions, []int64{queryInfo.GetQueryFieldId()}) {
 		ctx, sp := otel.Tracer(typeutil.ProxyRole).Start(ctx, "Proxy-Search-call-function-udf")
 		defer sp.End()
 		exec, err := embedding.NewFunctionExecutor(t.schema.CollectionSchema, nil, &models.ModelExtraInfo{ClusterID: paramtable.Get().CommonCfg.ClusterPrefix.GetValue(), DBName: t.request.GetDbName()})
@@ -795,31 +765,31 @@ func (t *searchTask) convertPlaceholderIfNeeded(phgBytes []byte, fieldID int64) 
 	return ConvertPlaceholderGroup(phgBytes, field)
 }
 
-func (t *searchTask) tryGeneratePlan(params []*commonpb.KeyValuePair, dsl string, exprTemplateValues map[string]*schemapb.TemplateValue) (*planpb.PlanNode, *planpb.QueryInfo, int64, bool, []OrderByField, error) {
+func (t *searchTask) tryGeneratePlan(params []*commonpb.KeyValuePair, dsl string, exprTemplateValues map[string]*schemapb.TemplateValue) (*planpb.PlanNode, *planpb.QueryInfo, int64, bool, error) {
 	annsFieldName, err := funcutil.GetAttrByKeyFromRepeatedKV(AnnsFieldKey, params)
 	if err != nil || len(annsFieldName) == 0 {
 		vecFields := typeutil.GetVectorFieldSchemas(t.schema.CollectionSchema)
 		if len(vecFields) == 0 {
-			return nil, nil, 0, false, nil, errors.New(AnnsFieldKey + " not found in schema")
+			return nil, nil, 0, false, errors.New(AnnsFieldKey + " not found in schema")
 		}
 
 		if enableMultipleVectorFields && len(vecFields) > 1 {
-			return nil, nil, 0, false, nil, errors.New("multiple anns_fields exist, please specify a anns_field in search_params")
+			return nil, nil, 0, false, errors.New("multiple anns_fields exist, please specify a anns_field in search_params")
 		}
 		annsFieldName = vecFields[0].Name
 	}
 	searchInfo, err := parseSearchInfo(params, t.schema.CollectionSchema, t.rankParams)
 	if err != nil {
-		return nil, nil, 0, false, nil, err
+		return nil, nil, 0, false, err
 	}
 	if searchInfo.collectionID > 0 && searchInfo.collectionID != t.GetCollectionID() {
-		return nil, nil, 0, false, nil, merr.WrapErrParameterInvalidMsg("collection id:%d in the request is not consistent to that in the search context,"+
+		return nil, nil, 0, false, merr.WrapErrParameterInvalidMsg("collection id:%d in the request is not consistent to that in the search context,"+
 			"alias or database may have been changed: %d", searchInfo.collectionID, t.GetCollectionID())
 	}
 
 	annField := typeutil.GetFieldByName(t.schema.CollectionSchema, annsFieldName)
 	if searchInfo.planInfo.GetGroupByFieldId() != -1 && annField.GetDataType() == schemapb.DataType_BinaryVector {
-		return nil, nil, 0, false, nil, errors.New("not support search_group_by operation based on binary vector column")
+		return nil, nil, 0, false, errors.New("not support search_group_by operation based on binary vector column")
 	}
 
 	searchInfo.planInfo.QueryFieldId = annField.GetFieldID()
@@ -830,13 +800,13 @@ func (t *searchTask) tryGeneratePlan(params []*commonpb.KeyValuePair, dsl string
 			zap.String("dsl", dsl), // may be very large if large term passed.
 			zap.String("anns field", annsFieldName), zap.Any("query info", searchInfo.planInfo))
 		metrics.ProxyParseExpressionLatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), "search", metrics.FailLabel).Observe(float64(time.Since(start).Milliseconds()))
-		return nil, nil, 0, false, nil, merr.WrapErrParameterInvalidMsg("failed to create query plan: %v", planErr)
+		return nil, nil, 0, false, merr.WrapErrParameterInvalidMsg("failed to create query plan: %v", planErr)
 	}
 	metrics.ProxyParseExpressionLatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), "search", metrics.SuccessLabel).Observe(float64(time.Since(start).Milliseconds()))
 	log.Ctx(t.ctx).Debug("create query plan",
 		zap.String("dsl", t.request.Dsl), // may be very large if large term passed.
 		zap.String("anns field", annsFieldName), zap.Any("query info", searchInfo.planInfo))
-	return plan, searchInfo.planInfo, searchInfo.offset, searchInfo.isIterator, searchInfo.orderByFields, nil
+	return plan, searchInfo.planInfo, searchInfo.offset, searchInfo.isIterator, nil
 }
 
 func (t *searchTask) tryParsePartitionIDsFromPlan(plan *planpb.PlanNode) ([]int64, error) {
@@ -1007,12 +977,25 @@ func (t *searchTask) PostExecute(ctx context.Context) error {
 				return err
 			}
 		}
+		if fieldData.Type == schemapb.DataType_Mol {
+			if err := validateMOLFieldSearchResult(&fieldsData[i]); err != nil {
+				log.Warn("fail to validate MOL field search result", zap.Error(err))
+				return err
+			}
+		}
 	}
-	if t.result.GetResults().GetGroupByFieldValue() != nil &&
-		t.result.GetResults().GetGroupByFieldValue().GetType() == schemapb.DataType_Geometry {
-		if err := validateGeometryFieldSearchResult(&t.result.Results.GroupByFieldValue); err != nil {
-			log.Warn("fail to validate geometry field search result", zap.Error(err))
-			return err
+	if t.result.GetResults().GetGroupByFieldValue() != nil {
+		if t.result.GetResults().GetGroupByFieldValue().GetType() == schemapb.DataType_Geometry {
+			if err := validateGeometryFieldSearchResult(&t.result.Results.GroupByFieldValue); err != nil {
+				log.Warn("fail to validate geometry field search result", zap.Error(err))
+				return err
+			}
+		}
+		if t.result.GetResults().GetGroupByFieldValue().GetType() == schemapb.DataType_Mol {
+			if err := validateMOLFieldSearchResult(&t.result.Results.GroupByFieldValue); err != nil {
+				log.Warn("fail to validate MOL field search result", zap.Error(err))
+				return err
+			}
 		}
 	}
 

--- a/internal/util/function/embedding/mol_fingerprint_embedding_function.go
+++ b/internal/util/function/embedding/mol_fingerprint_embedding_function.go
@@ -1,0 +1,223 @@
+/*
+ * # Licensed to the LF AI & Data foundation under one
+ * # or more contributor license agreements. See the NOTICE file
+ * # distributed with this work for additional information
+ * # regarding copyright ownership. The ASF licenses this file
+ * # to you under the Apache License, Version 2.0 (the
+ * # "License"); you may not use this file except in compliance
+ * # with the License. You may obtain a copy of the License at
+ * #
+ * #     http://www.apache.org/licenses/LICENSE-2.0
+ * #
+ * # Unless required by applicable law or agreed to in writing, software
+ * # distributed under the License is distributed on an "AS IS" BASIS,
+ * # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * # See the License for the specific language governing permissions and
+ * # limitations under the License.
+ */
+
+package embedding
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/util/function"
+	"github.com/milvus-io/milvus/internal/util/function/mol"
+	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
+)
+
+// MolFingerprintEmbeddingFunction wraps the MolFingerprintFunctionRunner for search operations
+type MolFingerprintEmbeddingFunction struct {
+	schema       *schemapb.FunctionSchema
+	outputFields []*schemapb.FieldSchema
+	runner       function.FunctionRunner
+
+	collectionName   string
+	functionTypeName string
+	functionName     string
+}
+
+func NewMolFingerprintEmbeddingFunction(coll *schemapb.CollectionSchema, functionSchema *schemapb.FunctionSchema) (*MolFingerprintEmbeddingFunction, error) {
+	runner, err := function.NewMolFingerprintFunctionRunner(coll, functionSchema)
+	if err != nil {
+		return nil, err
+	}
+
+	f := &MolFingerprintEmbeddingFunction{
+		schema:           functionSchema,
+		outputFields:     runner.GetOutputFields(),
+		runner:           runner,
+		collectionName:   coll.Name,
+		functionTypeName: functionSchema.GetType().String(),
+		functionName:     functionSchema.Name,
+	}
+
+	return f, nil
+}
+
+func (f *MolFingerprintEmbeddingFunction) GetSchema() *schemapb.FunctionSchema {
+	return f.schema
+}
+
+func (f *MolFingerprintEmbeddingFunction) GetOutputFields() []*schemapb.FieldSchema {
+	return f.outputFields
+}
+
+func (f *MolFingerprintEmbeddingFunction) GetCollectionName() string {
+	return f.collectionName
+}
+
+func (f *MolFingerprintEmbeddingFunction) GetFunctionTypeName() string {
+	return f.functionTypeName
+}
+
+func (f *MolFingerprintEmbeddingFunction) GetFunctionProvider() string {
+	return "local_rdkit"
+}
+
+func (f *MolFingerprintEmbeddingFunction) GetFunctionName() string {
+	return f.functionName
+}
+
+func (f *MolFingerprintEmbeddingFunction) Check(ctx context.Context) error {
+	// Local RDKit, no external service to check
+	return nil
+}
+
+func (f *MolFingerprintEmbeddingFunction) MaxBatch() int {
+	return 1024 // Reasonable batch size for local processing
+}
+
+func (f *MolFingerprintEmbeddingFunction) ProcessInsert(ctx context.Context, inputs []*schemapb.FieldData) ([]*schemapb.FieldData, error) {
+	if len(inputs) != 1 {
+		return nil, fmt.Errorf("MolFingerprint function only receives one input, but got [%d]", len(inputs))
+	}
+
+	// Get SMILES strings from input
+	// Client sends MolSmilesData (SMILES strings), which may be converted to MolData (pickle) by validation
+	var smilesList []string
+	if molSmilesData := inputs[0].GetScalars().GetMolSmilesData(); molSmilesData != nil {
+		// Direct SMILES data from client
+		smilesList = molSmilesData.GetData()
+	} else if stringData := inputs[0].GetScalars().GetStringData(); stringData != nil {
+		// String data (also SMILES)
+		smilesList = stringData.GetData()
+	} else if molData := inputs[0].GetScalars().GetMolData(); molData != nil {
+		// MOL data in pickle format, need to convert back to SMILES for fingerprint generation
+		molBytes := molData.GetData()
+		smilesList = make([]string, len(molBytes))
+		for i, bytes := range molBytes {
+			smilesList[i] = string(bytes)
+		}
+	} else {
+		return nil, fmt.Errorf("MolFingerprint function input must be MOL or string type, got: %T", inputs[0].GetScalars().GetData())
+	}
+
+	// Generate fingerprints
+	output, err := f.runner.BatchRun(smilesList)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate fingerprints: %w", err)
+	}
+
+	binaryVectorData, ok := output[0].(*storage.BinaryVectorFieldData)
+	if !ok {
+		return nil, fmt.Errorf("MolFingerprint runner returned unexpected type: %T", output[0])
+	}
+
+	// Convert to FieldData
+	outputField := f.outputFields[0]
+	fieldData := &schemapb.FieldData{
+		Type:      schemapb.DataType_BinaryVector,
+		FieldName: outputField.GetName(),
+		FieldId:   outputField.GetFieldID(),
+		Field: &schemapb.FieldData_Vectors{
+			Vectors: &schemapb.VectorField{
+				Dim: int64(binaryVectorData.Dim),
+				Data: &schemapb.VectorField_BinaryVector{
+					BinaryVector: binaryVectorData.Data,
+				},
+			},
+		},
+	}
+
+	return []*schemapb.FieldData{fieldData}, nil
+}
+
+func (f *MolFingerprintEmbeddingFunction) ProcessSearch(ctx context.Context, placeholderGroup *commonpb.PlaceholderGroup) (*commonpb.PlaceholderGroup, error) {
+	// Get SMILES strings from placeholder
+	smilesList := funcutil.GetVarCharFromPlaceholder(placeholderGroup.Placeholders[0])
+
+	numRows := len(smilesList)
+	if numRows > f.MaxBatch() {
+		return nil, fmt.Errorf("MolFingerprint supports up to [%d] pieces of data at a time, got [%d]", f.MaxBatch(), numRows)
+	}
+
+	// Convert SMILES to pickle and back to canonical SMILES to match storage path
+	// Storage: SMILES -> Pickle -> canonical SMILES -> fingerprint
+	// Search must follow the same path for consistency
+	canonicalSmilesList := make([]string, len(smilesList))
+	for i, smiles := range smilesList {
+		if len(smiles) == 0 {
+			canonicalSmilesList[i] = ""
+			continue
+		}
+		// Convert to pickle and back to get canonical SMILES
+		pickle, err := mol.ConvertSMILESToPickle(smiles)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert SMILES to pickle at index %d: %w", i, err)
+		}
+		canonical, err := mol.ConvertPickleToSMILES(pickle)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert pickle to canonical SMILES at index %d: %w", i, err)
+		}
+		canonicalSmilesList[i] = canonical
+	}
+
+	// Generate fingerprints using the runner with canonical SMILES
+	output, err := f.runner.BatchRun(canonicalSmilesList)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate fingerprints for search: %w", err)
+	}
+
+	binaryVectorData, ok := output[0].(*storage.BinaryVectorFieldData)
+	if !ok {
+		return nil, fmt.Errorf("MolFingerprint runner returned unexpected type: %T", output[0])
+	}
+
+	// Convert binary vectors to PlaceholderGroup
+	return BinaryVectorsToPlaceholderGroup(binaryVectorData.Data, binaryVectorData.Dim), nil
+}
+
+func (f *MolFingerprintEmbeddingFunction) ProcessBulkInsert(ctx context.Context, inputs []storage.FieldData) (map[storage.FieldID]storage.FieldData, error) {
+	// BulkInsert is handled by the pipeline embedding node, not here
+	return nil, fmt.Errorf("MolFingerprintEmbeddingFunction.ProcessBulkInsert should not be called directly")
+}
+
+// BinaryVectorsToPlaceholderGroup converts binary vector data to a PlaceholderGroup
+func BinaryVectorsToPlaceholderGroup(data []byte, dim int) *commonpb.PlaceholderGroup {
+	bytesPerVector := dim / 8
+	if dim%8 != 0 {
+		bytesPerVector++
+	}
+
+	numVectors := len(data) / bytesPerVector
+	values := make([][]byte, numVectors)
+
+	for i := 0; i < numVectors; i++ {
+		start := i * bytesPerVector
+		end := start + bytesPerVector
+		values[i] = data[start:end]
+	}
+
+	return &commonpb.PlaceholderGroup{
+		Placeholders: []*commonpb.PlaceholderValue{{
+			Tag:    "$0",
+			Type:   commonpb.PlaceholderType_BinaryVector,
+			Values: values,
+		}},
+	}
+}

--- a/internal/util/function/embedding/mol_fingerprint_embedding_function_test.go
+++ b/internal/util/function/embedding/mol_fingerprint_embedding_function_test.go
@@ -1,0 +1,270 @@
+/*
+ * # Licensed to the LF AI & Data foundation under one
+ * # or more contributor license agreements. See the NOTICE file
+ * # distributed with this work for additional information
+ * # regarding copyright ownership. The ASF licenses this file
+ * # to you under the Apache License, Version 2.0 (the
+ * # "License"); you may not use this file except in compliance
+ * # with the License. You may obtain a copy of the License at
+ * #
+ * #     http://www.apache.org/licenses/LICENSE-2.0
+ * #
+ * # Unless required by applicable law or agreed to in writing, software
+ * # distributed under the License is distributed on an "AS IS" BASIS,
+ * # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * # See the License for the specific language governing permissions and
+ * # limitations under the License.
+ */
+
+package embedding
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/util/function/mol"
+)
+
+func TestMolFingerprintEmbeddingFunction(t *testing.T) {
+	suite.Run(t, new(MolFingerprintEmbeddingFunctionSuite))
+}
+
+type MolFingerprintEmbeddingFunctionSuite struct {
+	suite.Suite
+	schema     *schemapb.CollectionSchema
+	funcSchema *schemapb.FunctionSchema
+}
+
+func (s *MolFingerprintEmbeddingFunctionSuite) SetupTest() {
+	s.schema = &schemapb.CollectionSchema{
+		Name: "test_mol",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64},
+			{FieldID: 101, Name: "mol_field", DataType: schemapb.DataType_Mol},
+			{
+				FieldID: 102, Name: "fp_field", DataType: schemapb.DataType_BinaryVector,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: "dim", Value: "2048"},
+				},
+			},
+		},
+	}
+	s.funcSchema = &schemapb.FunctionSchema{
+		Name:           "mol_fp",
+		Type:           schemapb.FunctionType_MolFingerprint,
+		InputFieldIds:  []int64{101},
+		OutputFieldIds: []int64{102},
+		InputFieldNames:  []string{"mol_field"},
+		OutputFieldNames: []string{"fp_field"},
+	}
+}
+
+func (s *MolFingerprintEmbeddingFunctionSuite) TestNewFunction() {
+	f, err := NewMolFingerprintEmbeddingFunction(s.schema, s.funcSchema)
+	s.NoError(err)
+	s.NotNil(f)
+	s.Equal("test_mol", f.GetCollectionName())
+	s.Equal("mol_fp", f.GetFunctionName())
+	s.Equal("local_rdkit", f.GetFunctionProvider())
+	s.Equal(1024, f.MaxBatch())
+	s.NoError(f.Check(context.Background()))
+	s.Equal(1, len(f.GetOutputFields()))
+}
+
+func (s *MolFingerprintEmbeddingFunctionSuite) TestProcessInsertMolSmilesData() {
+	f, err := NewMolFingerprintEmbeddingFunction(s.schema, s.funcSchema)
+	s.NoError(err)
+
+	inputs := []*schemapb.FieldData{
+		{
+			Type:    schemapb.DataType_Mol,
+			FieldId: 101,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_MolSmilesData{
+						MolSmilesData: &schemapb.MolSmilesArray{
+							Data: []string{"CCO", "c1ccccc1"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := f.ProcessInsert(context.Background(), inputs)
+	s.NoError(err)
+	s.Equal(1, len(result))
+	s.Equal(schemapb.DataType_BinaryVector, result[0].GetType())
+	s.Equal(int64(2048), result[0].GetVectors().GetDim())
+}
+
+func (s *MolFingerprintEmbeddingFunctionSuite) TestProcessInsertStringData() {
+	f, err := NewMolFingerprintEmbeddingFunction(s.schema, s.funcSchema)
+	s.NoError(err)
+
+	inputs := []*schemapb.FieldData{
+		{
+			Type:    schemapb.DataType_VarChar,
+			FieldId: 101,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_StringData{
+						StringData: &schemapb.StringArray{
+							Data: []string{"CCO"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := f.ProcessInsert(context.Background(), inputs)
+	s.NoError(err)
+	s.Equal(1, len(result))
+}
+
+func (s *MolFingerprintEmbeddingFunctionSuite) TestProcessInsertErrors() {
+	f, err := NewMolFingerprintEmbeddingFunction(s.schema, s.funcSchema)
+	s.NoError(err)
+
+	// wrong input count
+	_, err = f.ProcessInsert(context.Background(), []*schemapb.FieldData{})
+	s.Error(err)
+
+	_, err = f.ProcessInsert(context.Background(), []*schemapb.FieldData{{}, {}})
+	s.Error(err)
+
+	// unsupported input type
+	_, err = f.ProcessInsert(context.Background(), []*schemapb.FieldData{
+		{
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_IntData{
+						IntData: &schemapb.IntArray{Data: []int32{1}},
+					},
+				},
+			},
+		},
+	})
+	s.Error(err)
+}
+
+func (s *MolFingerprintEmbeddingFunctionSuite) TestProcessSearch() {
+	f, err := NewMolFingerprintEmbeddingFunction(s.schema, s.funcSchema)
+	s.NoError(err)
+
+	placeholderGroup := &commonpb.PlaceholderGroup{
+		Placeholders: []*commonpb.PlaceholderValue{
+			{
+				Tag:    "$0",
+				Type:   commonpb.PlaceholderType_VarChar,
+				Values: [][]byte{[]byte("CCO")},
+			},
+		},
+	}
+
+	result, err := f.ProcessSearch(context.Background(), placeholderGroup)
+	s.NoError(err)
+	s.Equal(1, len(result.GetPlaceholders()))
+	s.Equal(commonpb.PlaceholderType_BinaryVector, result.GetPlaceholders()[0].GetType())
+	s.Equal(1, len(result.GetPlaceholders()[0].GetValues()))
+	s.Equal(2048/8, len(result.GetPlaceholders()[0].GetValues()[0]))
+}
+
+func (s *MolFingerprintEmbeddingFunctionSuite) TestProcessSearchEmptySmiles() {
+	f, err := NewMolFingerprintEmbeddingFunction(s.schema, s.funcSchema)
+	s.NoError(err)
+
+	placeholderGroup := &commonpb.PlaceholderGroup{
+		Placeholders: []*commonpb.PlaceholderValue{
+			{
+				Tag:    "$0",
+				Type:   commonpb.PlaceholderType_VarChar,
+				Values: [][]byte{[]byte("")},
+			},
+		},
+	}
+
+	result, err := f.ProcessSearch(context.Background(), placeholderGroup)
+	s.NoError(err)
+	s.Equal(1, len(result.GetPlaceholders()[0].GetValues()))
+}
+
+func (s *MolFingerprintEmbeddingFunctionSuite) TestProcessSearchInvalidSmiles() {
+	f, err := NewMolFingerprintEmbeddingFunction(s.schema, s.funcSchema)
+	s.NoError(err)
+
+	placeholderGroup := &commonpb.PlaceholderGroup{
+		Placeholders: []*commonpb.PlaceholderValue{
+			{
+				Tag:    "$0",
+				Type:   commonpb.PlaceholderType_VarChar,
+				Values: [][]byte{[]byte("not_valid!!!")},
+			},
+		},
+	}
+
+	_, err = f.ProcessSearch(context.Background(), placeholderGroup)
+	s.Error(err)
+}
+
+func (s *MolFingerprintEmbeddingFunctionSuite) TestProcessBulkInsert() {
+	f, err := NewMolFingerprintEmbeddingFunction(s.schema, s.funcSchema)
+	s.NoError(err)
+
+	_, err = f.ProcessBulkInsert(context.Background(), nil)
+	s.Error(err)
+}
+
+func (s *MolFingerprintEmbeddingFunctionSuite) TestBinaryVectorsToPlaceholderGroup() {
+	// 2 vectors, dim=16 (2 bytes each)
+	data := []byte{0xFF, 0x00, 0x00, 0xFF}
+	result := BinaryVectorsToPlaceholderGroup(data, 16)
+
+	s.Equal(1, len(result.GetPlaceholders()))
+	s.Equal(commonpb.PlaceholderType_BinaryVector, result.GetPlaceholders()[0].GetType())
+	s.Equal(2, len(result.GetPlaceholders()[0].GetValues()))
+	s.Equal([]byte{0xFF, 0x00}, result.GetPlaceholders()[0].GetValues()[0])
+	s.Equal([]byte{0x00, 0xFF}, result.GetPlaceholders()[0].GetValues()[1])
+}
+
+func (s *MolFingerprintEmbeddingFunctionSuite) TestBinaryVectorsToPlaceholderGroupOddDim() {
+	// dim=9 -> 2 bytes per vector, 1 vector
+	data := []byte{0xFF, 0x01}
+	result := BinaryVectorsToPlaceholderGroup(data, 9)
+
+	s.Equal(1, len(result.GetPlaceholders()[0].GetValues()))
+	s.Equal(2, len(result.GetPlaceholders()[0].GetValues()[0]))
+}
+
+func (s *MolFingerprintEmbeddingFunctionSuite) TestProcessInsertMolData() {
+	f, err := NewMolFingerprintEmbeddingFunction(s.schema, s.funcSchema)
+	s.NoError(err)
+
+	pickle, err := mol.ConvertSMILESToPickle("CCO")
+	s.NoError(err)
+
+	inputs := []*schemapb.FieldData{
+		{
+			Type:    schemapb.DataType_Mol,
+			FieldId: 101,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_MolData{
+						MolData: &schemapb.MolArray{
+							Data: [][]byte{pickle},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := f.ProcessInsert(context.Background(), inputs)
+	s.NoError(err)
+	s.Equal(1, len(result))
+}

--- a/internal/util/function/function.go
+++ b/internal/util/function/function.go
@@ -42,6 +42,8 @@ func NewFunctionRunner(coll *schemapb.CollectionSchema, schema *schemapb.Functio
 		return NewMinHashFunctionRunner(coll, schema)
 	case schemapb.FunctionType_TextEmbedding:
 		return nil, nil
+	case schemapb.FunctionType_MolFingerprint:
+		return NewMolFingerprintFunctionRunner(coll, schema)
 	default:
 		return nil, fmt.Errorf("unknown functionRunner type %s", schema.GetType().String())
 	}

--- a/internal/util/function/mol/maccs.go
+++ b/internal/util/function/mol/maccs.go
@@ -1,0 +1,56 @@
+/*
+ * # Licensed to the LF AI & Data foundation under one
+ * # or more contributor license agreements. See the NOTICE file
+ * # distributed with this work for additional information
+ * # regarding copyright ownership. The ASF licenses this file
+ * # to you under the Apache License, Version 2.0 (the
+ * # "License"); you may not use this file except in compliance
+ * # with the License. You may obtain a copy of the License at
+ * #
+ * #     http://www.apache.org/licenses/LICENSE-2.0
+ * #
+ * # Unless required by applicable law or agreed to in writing, software
+ * # distributed under the License is distributed on an "AS IS" BASIS,
+ * # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * # See the License for the specific language governing permissions and
+ * # limitations under the License.
+ */
+
+package mol
+
+const (
+	// MACCSNumBits is the fixed size of MACCS fingerprint
+	MACCSNumBits = 167
+)
+
+// GenerateMACCSFingerprint generates a MACCS fingerprint for a SMILES string
+// MACCS fingerprint is fixed at 167 bits
+// Returns binary fingerprint as []byte
+func GenerateMACCSFingerprint(smiles string) ([]byte, error) {
+	if len(smiles) == 0 {
+		return make([]byte, MACCSNumBits/8+1), nil
+	}
+
+	return cgoGenerateMACCSFingerprint(smiles)
+}
+
+// MACCSFingerprintToFloatVector converts binary MACCS fingerprint to float32 vector
+// Each bit becomes 0.0 or 1.0
+func MACCSFingerprintToFloatVector(fingerprint []byte) []float32 {
+	result := make([]float32, MACCSNumBits)
+	for i := 0; i < MACCSNumBits && i/8 < len(fingerprint); i++ {
+		if fingerprint[i/8]&(1<<(i%8)) != 0 {
+			result[i] = 1.0
+		}
+	}
+	return result
+}
+
+// GenerateMACCSFingerprintAsFloatVector generates MACCS fingerprint and converts to float32 vector
+func GenerateMACCSFingerprintAsFloatVector(smiles string) ([]float32, error) {
+	fp, err := GenerateMACCSFingerprint(smiles)
+	if err != nil {
+		return nil, err
+	}
+	return MACCSFingerprintToFloatVector(fp), nil
+}

--- a/internal/util/function/mol/maccs_test.go
+++ b/internal/util/function/mol/maccs_test.go
@@ -1,0 +1,102 @@
+/*
+ * # Licensed to the LF AI & Data foundation under one
+ * # or more contributor license agreements. See the NOTICE file
+ * # distributed with this work for additional information
+ * # regarding copyright ownership. The ASF licenses this file
+ * # to you under the Apache License, Version 2.0 (the
+ * # "License"); you may not use this file except in compliance
+ * # with the License. You may obtain a copy of the License at
+ * #
+ * #     http://www.apache.org/licenses/LICENSE-2.0
+ * #
+ * # Unless required by applicable law or agreed to in writing, software
+ * # distributed under the License is distributed on an "AS IS" BASIS,
+ * # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * # See the License for the specific language governing permissions and
+ * # limitations under the License.
+ */
+
+package mol
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateMACCSFingerprint(t *testing.T) {
+	t.Run("valid SMILES", func(t *testing.T) {
+		fp, err := GenerateMACCSFingerprint("CCO")
+		assert.NoError(t, err)
+		assert.Equal(t, MACCSNumBits/8+1, len(fp))
+	})
+
+	t.Run("benzene", func(t *testing.T) {
+		fp, err := GenerateMACCSFingerprint("c1ccccc1")
+		assert.NoError(t, err)
+		assert.Equal(t, MACCSNumBits/8+1, len(fp))
+		hasNonZero := false
+		for _, b := range fp {
+			if b != 0 {
+				hasNonZero = true
+				break
+			}
+		}
+		assert.True(t, hasNonZero)
+	})
+
+	t.Run("empty SMILES returns zero vector", func(t *testing.T) {
+		fp, err := GenerateMACCSFingerprint("")
+		assert.NoError(t, err)
+		assert.Equal(t, MACCSNumBits/8+1, len(fp))
+		for _, b := range fp {
+			assert.Equal(t, byte(0), b)
+		}
+	})
+
+	t.Run("invalid SMILES", func(t *testing.T) {
+		_, err := GenerateMACCSFingerprint("not_valid!!!")
+		assert.Error(t, err)
+	})
+}
+
+func TestMACCSFingerprintToFloatVector(t *testing.T) {
+	t.Run("all zeros", func(t *testing.T) {
+		fp := make([]byte, MACCSNumBits/8+1)
+		result := MACCSFingerprintToFloatVector(fp)
+		assert.Equal(t, MACCSNumBits, len(result))
+		for _, v := range result {
+			assert.Equal(t, float32(0.0), v)
+		}
+	})
+
+	t.Run("all ones", func(t *testing.T) {
+		fp := []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+			0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}
+		result := MACCSFingerprintToFloatVector(fp)
+		assert.Equal(t, MACCSNumBits, len(result))
+		for _, v := range result {
+			assert.Equal(t, float32(1.0), v)
+		}
+	})
+}
+
+func TestGenerateMACCSFingerprintAsFloatVector(t *testing.T) {
+	t.Run("valid SMILES", func(t *testing.T) {
+		result, err := GenerateMACCSFingerprintAsFloatVector("CCO")
+		assert.NoError(t, err)
+		assert.Equal(t, MACCSNumBits, len(result))
+		for _, v := range result {
+			assert.True(t, v == 0.0 || v == 1.0)
+		}
+	})
+
+	t.Run("invalid SMILES", func(t *testing.T) {
+		_, err := GenerateMACCSFingerprintAsFloatVector("not_valid!!!")
+		assert.Error(t, err)
+	})
+}
+
+func TestMACCSNumBitsConstant(t *testing.T) {
+	assert.Equal(t, 167, MACCSNumBits)
+}

--- a/internal/util/function/mol/mol_cgo.go
+++ b/internal/util/function/mol/mol_cgo.go
@@ -1,0 +1,144 @@
+/*
+ * # Licensed to the LF AI & Data foundation under one
+ * # or more contributor license agreements. See the NOTICE file
+ * # distributed with this work for additional information
+ * # regarding copyright ownership. The ASF licenses this file
+ * # to you under the Apache License, Version 2.0 (the
+ * # "License"); you may not use this file except in compliance
+ * # with the License. You may obtain a copy of the License at
+ * #
+ * #     http://www.apache.org/licenses/LICENSE-2.0
+ * #
+ * # Unless required by applicable law or agreed to in writing, software
+ * # distributed under the License is distributed on an "AS IS" BASIS,
+ * # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * # See the License for the specific language governing permissions and
+ * # limitations under the License.
+ */
+
+package mol
+
+/*
+#cgo CFLAGS: -I${SRCDIR}/../../../core/src/common
+#cgo LDFLAGS: -L${SRCDIR}/../../../core/output/lib -lmilvus_core -Wl,-rpath,${SRCDIR}/../../../core/output/lib
+
+#include "mol_c.h"
+#include <stdlib.h>
+*/
+import "C"
+import (
+	"fmt"
+	"unsafe"
+)
+
+// cgoGenerateMorganFingerprint calls the C++ RDKit implementation
+func cgoGenerateMorganFingerprint(smiles string, radius int, fingerprintSize int) ([]byte, error) {
+	cSmiles := C.CString(smiles)
+	defer C.free(unsafe.Pointer(cSmiles))
+
+	result := C.GenerateMorganFingerprint(cSmiles, C.int(radius), C.int(fingerprintSize))
+	defer C.FreeMolDataResult(&result)
+
+	if result.error_code != C.MOL_SUCCESS {
+		if result.error_msg != nil {
+			return nil, fmt.Errorf("Morgan fingerprint generation failed: %s", C.GoString(result.error_msg))
+		}
+		return nil, fmt.Errorf("Morgan fingerprint generation failed with error code: %d", result.error_code)
+	}
+
+	if result.data == nil || result.size == 0 {
+		return nil, fmt.Errorf("Morgan fingerprint generation returned empty result")
+	}
+
+	return C.GoBytes(unsafe.Pointer(result.data), C.int(result.size)), nil
+}
+
+// cgoGenerateMACCSFingerprint calls the C++ RDKit implementation
+func cgoGenerateMACCSFingerprint(smiles string) ([]byte, error) {
+	cSmiles := C.CString(smiles)
+	defer C.free(unsafe.Pointer(cSmiles))
+
+	result := C.GenerateMACCSFingerprint(cSmiles)
+	defer C.FreeMolDataResult(&result)
+
+	if result.error_code != C.MOL_SUCCESS {
+		if result.error_msg != nil {
+			return nil, fmt.Errorf("MACCS fingerprint generation failed: %s", C.GoString(result.error_msg))
+		}
+		return nil, fmt.Errorf("MACCS fingerprint generation failed with error code: %d", result.error_code)
+	}
+
+	if result.data == nil || result.size == 0 {
+		return nil, fmt.Errorf("MACCS fingerprint generation returned empty result")
+	}
+
+	return C.GoBytes(unsafe.Pointer(result.data), C.int(result.size)), nil
+}
+
+// cgoGenerateRDKitFingerprint calls the C++ RDKit implementation
+func cgoGenerateRDKitFingerprint(smiles string, minPath int, maxPath int, fingerprintSize int) ([]byte, error) {
+	cSmiles := C.CString(smiles)
+	defer C.free(unsafe.Pointer(cSmiles))
+
+	result := C.GenerateRDKitFingerprint(cSmiles, C.int(minPath), C.int(maxPath), C.int(fingerprintSize))
+	defer C.FreeMolDataResult(&result)
+
+	if result.error_code != C.MOL_SUCCESS {
+		if result.error_msg != nil {
+			return nil, fmt.Errorf("RDKit fingerprint generation failed: %s", C.GoString(result.error_msg))
+		}
+		return nil, fmt.Errorf("RDKit fingerprint generation failed with error code: %d", result.error_code)
+	}
+
+	if result.data == nil || result.size == 0 {
+		return nil, fmt.Errorf("RDKit fingerprint generation returned empty result")
+	}
+
+	return C.GoBytes(unsafe.Pointer(result.data), C.int(result.size)), nil
+}
+
+// cgoConvertSMILESToPickle converts SMILES to RDKit pickle format
+func cgoConvertSMILESToPickle(smiles string) ([]byte, error) {
+	cSmiles := C.CString(smiles)
+	defer C.free(unsafe.Pointer(cSmiles))
+
+	result := C.ConvertSMILESToPickle(cSmiles)
+	defer C.FreeMolDataResult(&result)
+
+	if result.error_code != C.MOL_SUCCESS {
+		if result.error_msg != nil {
+			return nil, fmt.Errorf("SMILES to pickle conversion failed: %s", C.GoString(result.error_msg))
+		}
+		return nil, fmt.Errorf("SMILES to pickle conversion failed with error code: %d", result.error_code)
+	}
+
+	if result.data == nil || result.size == 0 {
+		return nil, fmt.Errorf("SMILES to pickle conversion returned empty result")
+	}
+
+	return C.GoBytes(unsafe.Pointer(result.data), C.int(result.size)), nil
+}
+
+// cgoConvertPickleToSMILES converts RDKit pickle format to SMILES
+func cgoConvertPickleToSMILES(pickle []byte) (string, error) {
+	if len(pickle) == 0 {
+		return "", fmt.Errorf("empty pickle data")
+	}
+
+	result := C.ConvertPickleToSMILES((*C.uint8_t)(unsafe.Pointer(&pickle[0])), C.size_t(len(pickle)))
+	defer C.FreeMolDataResult(&result)
+
+	if result.error_code != C.MOL_SUCCESS {
+		if result.error_msg != nil {
+			return "", fmt.Errorf("pickle to SMILES conversion failed: %s", C.GoString(result.error_msg))
+		}
+		return "", fmt.Errorf("pickle to SMILES conversion failed with error code: %d", result.error_code)
+	}
+
+	if result.data == nil || result.size == 0 {
+		return "", fmt.Errorf("pickle to SMILES conversion returned empty result")
+	}
+
+	// result.data contains null-terminated string
+	return C.GoString((*C.char)(unsafe.Pointer(result.data))), nil
+}

--- a/internal/util/function/mol/mol_cgo_test.go
+++ b/internal/util/function/mol/mol_cgo_test.go
@@ -1,0 +1,157 @@
+/*
+ * # Licensed to the LF AI & Data foundation under one
+ * # or more contributor license agreements. See the NOTICE file
+ * # distributed with this work for additional information
+ * # regarding copyright ownership. The ASF licenses this file
+ * # to you under the Apache License, Version 2.0 (the
+ * # "License"); you may not use this file except in compliance
+ * # with the License. You may obtain a copy of the License at
+ * #
+ * #     http://www.apache.org/licenses/LICENSE-2.0
+ * #
+ * # Unless required by applicable law or agreed to in writing, software
+ * # distributed under the License is distributed on an "AS IS" BASIS,
+ * # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * # See the License for the specific language governing permissions and
+ * # limitations under the License.
+ */
+
+package mol
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConvertSMILESToPickle(t *testing.T) {
+	t.Run("valid SMILES", func(t *testing.T) {
+		testCases := []string{
+			"CCO",                // ethanol
+			"c1ccccc1",          // benzene
+			"CC(=O)O",           // acetic acid
+			"CC(=O)Oc1ccccc1C(=O)O", // aspirin
+		}
+		for _, smiles := range testCases {
+			pickle, err := ConvertSMILESToPickle(smiles)
+			assert.NoError(t, err)
+			assert.NotEmpty(t, pickle)
+		}
+	})
+
+	t.Run("empty SMILES", func(t *testing.T) {
+		_, err := cgoConvertSMILESToPickle("")
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid SMILES", func(t *testing.T) {
+		_, err := cgoConvertSMILESToPickle("not_a_valid_smiles_XYZ123!!!")
+		assert.Error(t, err)
+	})
+}
+
+func TestConvertPickleToSMILES(t *testing.T) {
+	t.Run("roundtrip", func(t *testing.T) {
+		testCases := []string{
+			"CCO",
+			"c1ccccc1",
+			"CC(=O)O",
+		}
+		for _, smiles := range testCases {
+			pickle, err := cgoConvertSMILESToPickle(smiles)
+			assert.NoError(t, err)
+
+			result, err := ConvertPickleToSMILES(pickle)
+			assert.NoError(t, err)
+			assert.NotEmpty(t, result)
+		}
+	})
+
+	t.Run("empty pickle", func(t *testing.T) {
+		_, err := cgoConvertPickleToSMILES(nil)
+		assert.Error(t, err)
+
+		_, err = cgoConvertPickleToSMILES([]byte{})
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid pickle", func(t *testing.T) {
+		_, err := cgoConvertPickleToSMILES([]byte{0x00, 0x01, 0x02})
+		assert.Error(t, err)
+	})
+}
+
+func TestGenerateMorganFingerprint(t *testing.T) {
+	t.Run("valid SMILES", func(t *testing.T) {
+		fp, err := cgoGenerateMorganFingerprint("CCO", 2, 2048)
+		assert.NoError(t, err)
+		assert.Equal(t, 2048/8, len(fp))
+	})
+
+	t.Run("empty SMILES", func(t *testing.T) {
+		_, err := cgoGenerateMorganFingerprint("", 2, 2048)
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid SMILES", func(t *testing.T) {
+		_, err := cgoGenerateMorganFingerprint("not_valid!!!", 2, 2048)
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid parameters", func(t *testing.T) {
+		_, err := cgoGenerateMorganFingerprint("CCO", -1, 2048)
+		assert.Error(t, err)
+
+		_, err = cgoGenerateMorganFingerprint("CCO", 2, 0)
+		assert.Error(t, err)
+	})
+}
+
+func TestGenerateMACCSFingerprint(t *testing.T) {
+	t.Run("valid SMILES", func(t *testing.T) {
+		fp, err := cgoGenerateMACCSFingerprint("CCO")
+		assert.NoError(t, err)
+		assert.NotEmpty(t, fp)
+		// MACCS fingerprint is 167 bits = 21 bytes
+		assert.Equal(t, (167+7)/8, len(fp))
+	})
+
+	t.Run("empty SMILES", func(t *testing.T) {
+		_, err := cgoGenerateMACCSFingerprint("")
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid SMILES", func(t *testing.T) {
+		_, err := cgoGenerateMACCSFingerprint("not_valid!!!")
+		assert.Error(t, err)
+	})
+}
+
+func TestGenerateRDKitFingerprint(t *testing.T) {
+	t.Run("valid SMILES", func(t *testing.T) {
+		fp, err := cgoGenerateRDKitFingerprint("CCO", 1, 7, 2048)
+		assert.NoError(t, err)
+		assert.Equal(t, 2048/8, len(fp))
+	})
+
+	t.Run("empty SMILES", func(t *testing.T) {
+		_, err := cgoGenerateRDKitFingerprint("", 1, 7, 2048)
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid SMILES", func(t *testing.T) {
+		_, err := cgoGenerateRDKitFingerprint("not_valid!!!", 1, 7, 2048)
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid parameters", func(t *testing.T) {
+		_, err := cgoGenerateRDKitFingerprint("CCO", 0, 7, 2048)
+		assert.Error(t, err)
+
+		_, err = cgoGenerateRDKitFingerprint("CCO", 1, 0, 2048)
+		assert.Error(t, err)
+
+		_, err = cgoGenerateRDKitFingerprint("CCO", 1, 7, 0)
+		assert.Error(t, err)
+	})
+}

--- a/internal/util/function/mol/morgan.go
+++ b/internal/util/function/mol/morgan.go
@@ -1,0 +1,52 @@
+/*
+ * # Licensed to the LF AI & Data foundation under one
+ * # or more contributor license agreements. See the NOTICE file
+ * # distributed with this work for additional information
+ * # regarding copyright ownership. The ASF licenses this file
+ * # to you under the Apache License, Version 2.0 (the
+ * # "License"); you may not use this file except in compliance
+ * # with the License. You may obtain a copy of the License at
+ * #
+ * #     http://www.apache.org/licenses/LICENSE-2.0
+ * #
+ * # Unless required by applicable law or agreed to in writing, software
+ * # distributed under the License is distributed on an "AS IS" BASIS,
+ * # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * # See the License for the specific language governing permissions and
+ * # limitations under the License.
+ */
+
+package mol
+
+// GenerateMorganFingerprint generates a Morgan fingerprint for a SMILES string
+// radius: fingerprint radius (commonly 2 for ECFP4)
+// fingerprintSize: number of bits (commonly 2048)
+// Returns binary fingerprint as []byte
+func GenerateMorganFingerprint(smiles string, radius int, fingerprintSize int) ([]byte, error) {
+	if len(smiles) == 0 {
+		return make([]byte, fingerprintSize/8), nil
+	}
+
+	return cgoGenerateMorganFingerprint(smiles, radius, fingerprintSize)
+}
+
+// MorganFingerprintToFloatVector converts binary fingerprint to float32 vector
+// Each bit becomes 0.0 or 1.0
+func MorganFingerprintToFloatVector(fingerprint []byte, numBits int) []float32 {
+	result := make([]float32, numBits)
+	for i := 0; i < numBits && i/8 < len(fingerprint); i++ {
+		if fingerprint[i/8]&(1<<(i%8)) != 0 {
+			result[i] = 1.0
+		}
+	}
+	return result
+}
+
+// GenerateMorganFingerprintAsFloatVector generates Morgan fingerprint and converts to float32 vector
+func GenerateMorganFingerprintAsFloatVector(smiles string, radius int, fingerprintSize int) ([]float32, error) {
+	fp, err := GenerateMorganFingerprint(smiles, radius, fingerprintSize)
+	if err != nil {
+		return nil, err
+	}
+	return MorganFingerprintToFloatVector(fp, fingerprintSize), nil
+}

--- a/internal/util/function/mol/morgan_test.go
+++ b/internal/util/function/mol/morgan_test.go
@@ -1,0 +1,119 @@
+/*
+ * # Licensed to the LF AI & Data foundation under one
+ * # or more contributor license agreements. See the NOTICE file
+ * # distributed with this work for additional information
+ * # regarding copyright ownership. The ASF licenses this file
+ * # to you under the Apache License, Version 2.0 (the
+ * # "License"); you may not use this file except in compliance
+ * # with the License. You may obtain a copy of the License at
+ * #
+ * #     http://www.apache.org/licenses/LICENSE-2.0
+ * #
+ * # Unless required by applicable law or agreed to in writing, software
+ * # distributed under the License is distributed on an "AS IS" BASIS,
+ * # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * # See the License for the specific language governing permissions and
+ * # limitations under the License.
+ */
+
+package mol
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateMorganFingerprint(t *testing.T) {
+	t.Run("valid SMILES", func(t *testing.T) {
+		fp, err := GenerateMorganFingerprint("CCO", 2, 2048)
+		assert.NoError(t, err)
+		assert.Equal(t, 2048/8, len(fp))
+	})
+
+	t.Run("benzene", func(t *testing.T) {
+		fp, err := GenerateMorganFingerprint("c1ccccc1", 2, 2048)
+		assert.NoError(t, err)
+		assert.Equal(t, 2048/8, len(fp))
+		// benzene should have some bits set
+		hasNonZero := false
+		for _, b := range fp {
+			if b != 0 {
+				hasNonZero = true
+				break
+			}
+		}
+		assert.True(t, hasNonZero)
+	})
+
+	t.Run("empty SMILES returns zero vector", func(t *testing.T) {
+		fp, err := GenerateMorganFingerprint("", 2, 2048)
+		assert.NoError(t, err)
+		assert.Equal(t, 2048/8, len(fp))
+		for _, b := range fp {
+			assert.Equal(t, byte(0), b)
+		}
+	})
+
+	t.Run("invalid SMILES", func(t *testing.T) {
+		_, err := GenerateMorganFingerprint("not_valid!!!", 2, 2048)
+		assert.Error(t, err)
+	})
+
+	t.Run("different radius produces different fingerprints", func(t *testing.T) {
+		fp1, err := GenerateMorganFingerprint("c1ccccc1", 1, 2048)
+		assert.NoError(t, err)
+		fp2, err := GenerateMorganFingerprint("c1ccccc1", 3, 2048)
+		assert.NoError(t, err)
+		assert.Equal(t, len(fp1), len(fp2))
+	})
+
+	t.Run("custom fingerprint size", func(t *testing.T) {
+		fp, err := GenerateMorganFingerprint("CCO", 2, 1024)
+		assert.NoError(t, err)
+		assert.Equal(t, 1024/8, len(fp))
+	})
+}
+
+func TestMorganFingerprintToFloatVector(t *testing.T) {
+	t.Run("all zeros", func(t *testing.T) {
+		fp := make([]byte, 4) // 32 bits
+		result := MorganFingerprintToFloatVector(fp, 32)
+		assert.Equal(t, 32, len(result))
+		for _, v := range result {
+			assert.Equal(t, float32(0.0), v)
+		}
+	})
+
+	t.Run("all ones", func(t *testing.T) {
+		fp := []byte{0xFF, 0xFF}
+		result := MorganFingerprintToFloatVector(fp, 16)
+		assert.Equal(t, 16, len(result))
+		for _, v := range result {
+			assert.Equal(t, float32(1.0), v)
+		}
+	})
+
+	t.Run("specific pattern", func(t *testing.T) {
+		fp := []byte{0x01} // bit 0 set
+		result := MorganFingerprintToFloatVector(fp, 8)
+		assert.Equal(t, float32(1.0), result[0])
+		assert.Equal(t, float32(0.0), result[1])
+	})
+}
+
+func TestGenerateMorganFingerprintAsFloatVector(t *testing.T) {
+	t.Run("valid SMILES", func(t *testing.T) {
+		result, err := GenerateMorganFingerprintAsFloatVector("CCO", 2, 2048)
+		assert.NoError(t, err)
+		assert.Equal(t, 2048, len(result))
+		for _, v := range result {
+			assert.True(t, v == 0.0 || v == 1.0)
+		}
+	})
+
+	t.Run("invalid SMILES", func(t *testing.T) {
+		_, err := GenerateMorganFingerprintAsFloatVector("not_valid!!!", 2, 2048)
+		assert.Error(t, err)
+	})
+}

--- a/internal/util/function/mol/rdkit.go
+++ b/internal/util/function/mol/rdkit.go
@@ -1,0 +1,29 @@
+/*
+ * # Licensed to the LF AI & Data foundation under one
+ * # or more contributor license agreements. See the NOTICE file
+ * # distributed with this work for additional information
+ * # regarding copyright ownership. The ASF licenses this file
+ * # to you under the Apache License, Version 2.0 (the
+ * # "License"); you may not use this file except in compliance
+ * # with the License. You may obtain a copy of the License at
+ * #
+ * #     http://www.apache.org/licenses/LICENSE-2.0
+ * #
+ * # Unless required by applicable law or agreed to in writing, software
+ * # distributed under the License is distributed on an "AS IS" BASIS,
+ * # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * # See the License for the specific language governing permissions and
+ * # limitations under the License.
+ */
+
+package mol
+
+// ConvertSMILESToPickle converts SMILES string to RDKit pickle format for storage
+func ConvertSMILESToPickle(smiles string) ([]byte, error) {
+	return cgoConvertSMILESToPickle(smiles)
+}
+
+// ConvertPickleToSMILES converts RDKit pickle format back to SMILES string
+func ConvertPickleToSMILES(pickle []byte) (string, error) {
+	return cgoConvertPickleToSMILES(pickle)
+}

--- a/internal/util/function/mol/rdkit.go
+++ b/internal/util/function/mol/rdkit.go
@@ -18,6 +18,44 @@
 
 package mol
 
+// GenerateRDKitFingerprint generates an RDKit fingerprint for a SMILES string
+// minPath: minimum path length (commonly 1)
+// maxPath: maximum path length (commonly 7)
+// fingerprintSize: number of bits (commonly 2048)
+// Returns binary fingerprint as []byte
+func GenerateRDKitFingerprint(smiles string, minPath int, maxPath int, fingerprintSize int) ([]byte, error) {
+	if len(smiles) == 0 {
+		byteSize := fingerprintSize / 8
+		if fingerprintSize%8 != 0 {
+			byteSize++
+		}
+		return make([]byte, byteSize), nil
+	}
+
+	return cgoGenerateRDKitFingerprint(smiles, minPath, maxPath, fingerprintSize)
+}
+
+// RDKitFingerprintToFloatVector converts binary RDKit fingerprint to float32 vector
+// Each bit becomes 0.0 or 1.0
+func RDKitFingerprintToFloatVector(fingerprint []byte, numBits int) []float32 {
+	result := make([]float32, numBits)
+	for i := 0; i < numBits && i/8 < len(fingerprint); i++ {
+		if fingerprint[i/8]&(1<<(i%8)) != 0 {
+			result[i] = 1.0
+		}
+	}
+	return result
+}
+
+// GenerateRDKitFingerprintAsFloatVector generates RDKit fingerprint and converts to float32 vector
+func GenerateRDKitFingerprintAsFloatVector(smiles string, minPath int, maxPath int, fingerprintSize int) ([]float32, error) {
+	fp, err := GenerateRDKitFingerprint(smiles, minPath, maxPath, fingerprintSize)
+	if err != nil {
+		return nil, err
+	}
+	return RDKitFingerprintToFloatVector(fp, fingerprintSize), nil
+}
+
 // ConvertSMILESToPickle converts SMILES string to RDKit pickle format for storage
 func ConvertSMILESToPickle(smiles string) ([]byte, error) {
 	return cgoConvertSMILESToPickle(smiles)

--- a/internal/util/function/mol/rdkit_test.go
+++ b/internal/util/function/mol/rdkit_test.go
@@ -1,0 +1,160 @@
+/*
+ * # Licensed to the LF AI & Data foundation under one
+ * # or more contributor license agreements. See the NOTICE file
+ * # distributed with this work for additional information
+ * # regarding copyright ownership. The ASF licenses this file
+ * # to you under the Apache License, Version 2.0 (the
+ * # "License"); you may not use this file except in compliance
+ * # with the License. You may obtain a copy of the License at
+ * #
+ * #     http://www.apache.org/licenses/LICENSE-2.0
+ * #
+ * # Unless required by applicable law or agreed to in writing, software
+ * # distributed under the License is distributed on an "AS IS" BASIS,
+ * # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * # See the License for the specific language governing permissions and
+ * # limitations under the License.
+ */
+
+package mol
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateRDKitFingerprint(t *testing.T) {
+	t.Run("valid SMILES", func(t *testing.T) {
+		fp, err := GenerateRDKitFingerprint("CCO", 1, 7, 2048)
+		assert.NoError(t, err)
+		assert.Equal(t, 2048/8, len(fp))
+	})
+
+	t.Run("benzene", func(t *testing.T) {
+		fp, err := GenerateRDKitFingerprint("c1ccccc1", 1, 7, 2048)
+		assert.NoError(t, err)
+		assert.Equal(t, 2048/8, len(fp))
+		hasNonZero := false
+		for _, b := range fp {
+			if b != 0 {
+				hasNonZero = true
+				break
+			}
+		}
+		assert.True(t, hasNonZero)
+	})
+
+	t.Run("empty SMILES returns zero vector", func(t *testing.T) {
+		fp, err := GenerateRDKitFingerprint("", 1, 7, 2048)
+		assert.NoError(t, err)
+		assert.Equal(t, 2048/8, len(fp))
+		for _, b := range fp {
+			assert.Equal(t, byte(0), b)
+		}
+	})
+
+	t.Run("empty SMILES with non-byte-aligned size", func(t *testing.T) {
+		fp, err := GenerateRDKitFingerprint("", 1, 7, 167)
+		assert.NoError(t, err)
+		assert.Equal(t, 167/8+1, len(fp))
+	})
+
+	t.Run("invalid SMILES", func(t *testing.T) {
+		_, err := GenerateRDKitFingerprint("not_valid!!!", 1, 7, 2048)
+		assert.Error(t, err)
+	})
+
+	t.Run("custom fingerprint size", func(t *testing.T) {
+		fp, err := GenerateRDKitFingerprint("CCO", 1, 7, 1024)
+		assert.NoError(t, err)
+		assert.Equal(t, 1024/8, len(fp))
+	})
+}
+
+func TestRDKitFingerprintToFloatVector(t *testing.T) {
+	t.Run("all zeros", func(t *testing.T) {
+		fp := make([]byte, 4) // 32 bits
+		result := RDKitFingerprintToFloatVector(fp, 32)
+		assert.Equal(t, 32, len(result))
+		for _, v := range result {
+			assert.Equal(t, float32(0.0), v)
+		}
+	})
+
+	t.Run("all ones", func(t *testing.T) {
+		fp := []byte{0xFF, 0xFF}
+		result := RDKitFingerprintToFloatVector(fp, 16)
+		assert.Equal(t, 16, len(result))
+		for _, v := range result {
+			assert.Equal(t, float32(1.0), v)
+		}
+	})
+
+	t.Run("specific pattern", func(t *testing.T) {
+		fp := []byte{0x01} // bit 0 set
+		result := RDKitFingerprintToFloatVector(fp, 8)
+		assert.Equal(t, float32(1.0), result[0])
+		assert.Equal(t, float32(0.0), result[1])
+	})
+}
+
+func TestGenerateRDKitFingerprintAsFloatVector(t *testing.T) {
+	t.Run("valid SMILES", func(t *testing.T) {
+		result, err := GenerateRDKitFingerprintAsFloatVector("CCO", 1, 7, 2048)
+		assert.NoError(t, err)
+		assert.Equal(t, 2048, len(result))
+		for _, v := range result {
+			assert.True(t, v == 0.0 || v == 1.0)
+		}
+	})
+
+	t.Run("invalid SMILES", func(t *testing.T) {
+		_, err := GenerateRDKitFingerprintAsFloatVector("not_valid!!!", 1, 7, 2048)
+		assert.Error(t, err)
+	})
+}
+
+func TestConvertSMILESToPickle(t *testing.T) {
+	t.Run("valid SMILES", func(t *testing.T) {
+		pickle, err := ConvertSMILESToPickle("CCO")
+		assert.NoError(t, err)
+		assert.True(t, len(pickle) > 0)
+	})
+
+	t.Run("benzene", func(t *testing.T) {
+		pickle, err := ConvertSMILESToPickle("c1ccccc1")
+		assert.NoError(t, err)
+		assert.True(t, len(pickle) > 0)
+	})
+
+	t.Run("invalid SMILES", func(t *testing.T) {
+		_, err := ConvertSMILESToPickle("not_valid!!!")
+		assert.Error(t, err)
+	})
+}
+
+func TestConvertPickleToSMILES(t *testing.T) {
+	t.Run("roundtrip", func(t *testing.T) {
+		pickle, err := ConvertSMILESToPickle("CCO")
+		assert.NoError(t, err)
+
+		smiles, err := ConvertPickleToSMILES(pickle)
+		assert.NoError(t, err)
+		assert.Equal(t, "CCO", smiles)
+	})
+
+	t.Run("benzene roundtrip", func(t *testing.T) {
+		pickle, err := ConvertSMILESToPickle("c1ccccc1")
+		assert.NoError(t, err)
+
+		smiles, err := ConvertPickleToSMILES(pickle)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, smiles)
+	})
+
+	t.Run("invalid pickle", func(t *testing.T) {
+		_, err := ConvertPickleToSMILES([]byte{0x00, 0x01, 0x02})
+		assert.Error(t, err)
+	})
+}

--- a/internal/util/function/mol_fingerprint_function.go
+++ b/internal/util/function/mol_fingerprint_function.go
@@ -1,0 +1,377 @@
+/*
+ * # Licensed to the LF AI & Data foundation under one
+ * # or more contributor license agreements. See the NOTICE file
+ * # distributed with this work for additional information
+ * # regarding copyright ownership. The ASF licenses this file
+ * # to you under the Apache License, Version 2.0 (the
+ * # "License"); you may not use this file except in compliance
+ * # with the License. You may obtain a copy of the License at
+ * #
+ * #     http://www.apache.org/licenses/LICENSE-2.0
+ * #
+ * # Unless required by applicable law or agreed to in writing, software
+ * # distributed under the License is distributed on an "AS IS" BASIS,
+ * # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * # See the License for the specific language governing permissions and
+ * # limitations under the License.
+ */
+
+package function
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+
+	"github.com/cockroachdb/errors"
+	"go.uber.org/zap"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/util/function/mol"
+	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+)
+
+// Helper function to get dimension from type parameters
+func getDimFromTypeParams(params []*commonpb.KeyValuePair) (int, error) {
+	for _, param := range params {
+		if param.GetKey() == "dim" {
+			dim, err := strconv.Atoi(param.GetValue())
+			if err != nil {
+				return 0, fmt.Errorf("invalid dim parameter: %s", param.GetValue())
+			}
+			return dim, nil
+		}
+	}
+	return 0, fmt.Errorf("dim parameter not found")
+}
+
+const (
+	paramFingerprintType   = "fingerprint_type"
+	paramFingerprintSize   = "fingerprint_size"
+	paramRadius            = "radius"
+	paramMinPath           = "min_path"
+	paramMaxPath           = "max_path"
+	defaultFingerprintSize = 2048
+	defaultRadius          = 2
+	defaultMinPath         = 1
+	defaultMaxPath         = 7
+	maccsFingerprintSize   = 167 // MACCS fingerprint is fixed at 167 bits
+)
+
+const (
+	fingerprintTypeMorgan = "morgan"
+	fingerprintTypeMACCS  = "maccs"
+	fingerprintTypeRDKit  = "rdkit"
+)
+
+// MolFingerprintFunctionRunner implements FunctionRunner for MOL fingerprint generation
+// Input: MOL type (SMILES strings)
+// Output: BINARY_VECTOR type (fingerprint vectors)
+type MolFingerprintFunctionRunner struct {
+	mu     sync.RWMutex
+	closed bool
+
+	schema      *schemapb.FunctionSchema
+	outputField *schemapb.FieldSchema
+	inputField  *schemapb.FieldSchema
+
+	fingerprintType string
+	fingerprintSize int
+	radius          int
+	minPath         int
+	maxPath         int
+}
+
+// ValidateMolFingerprintFunction validates MolFingerprint function using FieldNames
+// This is used during collection creation when FieldIds are not yet assigned
+func ValidateMolFingerprintFunction(collSchema *schemapb.CollectionSchema, funSchema *schemapb.FunctionSchema) error {
+	// check input field count
+	if len(funSchema.GetInputFieldNames()) != 1 {
+		return fmt.Errorf("mol fingerprint function should only have one input field, but now %d", len(funSchema.GetInputFieldNames()))
+	}
+	if len(funSchema.GetOutputFieldNames()) != 1 {
+		return fmt.Errorf("mol fingerprint function should only have one output field, but now %d", len(funSchema.GetOutputFieldNames()))
+	}
+
+	// Find fields by name (since FieldIDs may not be assigned yet during validation)
+	inputFieldName := funSchema.GetInputFieldNames()[0]
+	outputFieldName := funSchema.GetOutputFieldNames()[0]
+
+	var inputField, outputField *schemapb.FieldSchema
+	for _, field := range collSchema.GetFields() {
+		if field.GetName() == inputFieldName {
+			inputField = field
+		}
+		if field.GetName() == outputFieldName {
+			outputField = field
+		}
+	}
+
+	if inputField == nil {
+		return fmt.Errorf("mol fingerprint function input field '%s' not found", inputFieldName)
+	}
+	if outputField == nil {
+		return fmt.Errorf("mol fingerprint function output field '%s' not found", outputFieldName)
+	}
+
+	// Validate input field type
+	if inputField.GetDataType() != schemapb.DataType_Mol {
+		return fmt.Errorf("mol fingerprint function input field must be MOL type, got %s", inputField.GetDataType().String())
+	}
+
+	// Validate output field type
+	if outputField.GetDataType() != schemapb.DataType_BinaryVector {
+		return fmt.Errorf("mol fingerprint function output field must be BINARY_VECTOR type, got %s", outputField.GetDataType().String())
+	}
+
+	return nil
+}
+
+// NewMolFingerprintFunctionRunner creates a new MolFingerprintFunctionRunner
+// This is used after collection creation when FieldIds are assigned
+func NewMolFingerprintFunctionRunner(coll *schemapb.CollectionSchema, schema *schemapb.FunctionSchema) (FunctionRunner, error) {
+	if len(schema.GetOutputFieldIds()) != 1 {
+		return nil, fmt.Errorf("mol fingerprint function should only have one output field, but now %d", len(schema.GetOutputFieldIds()))
+	}
+
+	if len(schema.GetInputFieldIds()) != 1 {
+		return nil, fmt.Errorf("mol fingerprint function should only have one input field, but now %d", len(schema.GetInputFieldIds()))
+	}
+
+	var inputField, outputField *schemapb.FieldSchema
+	for _, field := range coll.GetFields() {
+		if field.GetFieldID() == schema.GetOutputFieldIds()[0] {
+			outputField = field
+		}
+		if field.GetFieldID() == schema.GetInputFieldIds()[0] {
+			inputField = field
+		}
+	}
+
+	if inputField == nil {
+		return nil, errors.New("input field not found")
+	}
+	if outputField == nil {
+		return nil, errors.New("output field not found")
+	}
+
+	// Validate input field type
+	if inputField.GetDataType() != schemapb.DataType_Mol {
+		return nil, fmt.Errorf("mol fingerprint function input field must be MOL type, got %s", inputField.GetDataType().String())
+	}
+
+	// Validate output field type
+	if outputField.GetDataType() != schemapb.DataType_BinaryVector {
+		return nil, fmt.Errorf("mol fingerprint function output field must be BINARY_VECTOR type, got %s", outputField.GetDataType().String())
+	}
+
+	// Parse parameters
+	fingerprintType := fingerprintTypeMorgan // default
+	fingerprintSize := defaultFingerprintSize
+	radius := defaultRadius
+	minPath := defaultMinPath
+	maxPath := defaultMaxPath
+
+	for _, param := range schema.GetParams() {
+		switch param.GetKey() {
+		case paramFingerprintType:
+			fingerprintType = param.GetValue()
+			switch fingerprintType {
+			case fingerprintTypeMorgan, fingerprintTypeMACCS, fingerprintTypeRDKit:
+				// Valid types
+			default:
+				return nil, fmt.Errorf("unsupported fingerprint type: %s, supported types: morgan, maccs, rdkit", fingerprintType)
+			}
+		case paramFingerprintSize:
+			size, err := strconv.Atoi(param.GetValue())
+			if err != nil {
+				return nil, fmt.Errorf("invalid fingerprint_size parameter: %s", param.GetValue())
+			}
+			if size <= 0 {
+				return nil, fmt.Errorf("fingerprint_size must be positive, got %d", size)
+			}
+			fingerprintSize = size
+		case paramRadius:
+			r, err := strconv.Atoi(param.GetValue())
+			if err != nil {
+				return nil, fmt.Errorf("invalid radius parameter: %s", param.GetValue())
+			}
+			if r < 0 {
+				return nil, fmt.Errorf("radius must be non-negative, got %d", r)
+			}
+			radius = r
+		case paramMinPath:
+			mp, err := strconv.Atoi(param.GetValue())
+			if err != nil {
+				return nil, fmt.Errorf("invalid min_path parameter: %s", param.GetValue())
+			}
+			if mp < 1 {
+				return nil, fmt.Errorf("min_path must be at least 1, got %d", mp)
+			}
+			minPath = mp
+		case paramMaxPath:
+			mp, err := strconv.Atoi(param.GetValue())
+			if err != nil {
+				return nil, fmt.Errorf("invalid max_path parameter: %s", param.GetValue())
+			}
+			if mp < minPath {
+				return nil, fmt.Errorf("max_path (%d) must be >= min_path (%d)", mp, minPath)
+			}
+			maxPath = mp
+		}
+	}
+
+	// MACCS fingerprint has fixed size
+	if fingerprintType == fingerprintTypeMACCS {
+		fingerprintSize = maccsFingerprintSize
+	}
+
+	// Validate output field dimension matches fingerprint size
+	dim, err := getDimFromTypeParams(outputField.GetTypeParams())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dimension from output field: %w", err)
+	}
+	if dim != fingerprintSize {
+		return nil, fmt.Errorf("output field dimension (%d) does not match fingerprint_size (%d)", dim, fingerprintSize)
+	}
+
+	return &MolFingerprintFunctionRunner{
+		schema:          schema,
+		inputField:      inputField,
+		outputField:     outputField,
+		fingerprintType: fingerprintType,
+		fingerprintSize: fingerprintSize,
+		radius:          radius,
+		minPath:         minPath,
+		maxPath:         maxPath,
+	}, nil
+}
+
+// BatchRun processes a batch of SMILES strings and generates fingerprint vectors
+func (v *MolFingerprintFunctionRunner) BatchRun(inputs ...any) ([]any, error) {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+
+	if v.closed {
+		return nil, errors.New("mol fingerprint function received request after closed")
+	}
+
+	if len(inputs) != 1 {
+		return nil, errors.New("mol fingerprint function received more than one input column")
+	}
+
+	// Extract SMILES strings from input
+	// Input can be []string (SMILES strings) or [][]byte (pickle data from MOL field)
+	var smilesData []string
+	switch input := inputs[0].(type) {
+	case []string:
+		smilesData = input
+	case [][]byte:
+		// MOL field stores data in pickle format, need to convert to SMILES first
+		smilesData = make([]string, len(input))
+		for i, pickleBytes := range input {
+			if len(pickleBytes) == 0 {
+				smilesData[i] = ""
+				continue
+			}
+			// Convert pickle to SMILES
+			smiles, err := mol.ConvertPickleToSMILES(pickleBytes)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert pickle to SMILES at index %d: %w", i, err)
+			}
+			smilesData[i] = smiles
+		}
+	default:
+		return nil, fmt.Errorf("mol fingerprint function batch input must be []string or [][]byte, got %T", inputs[0])
+	}
+
+	rowNum := len(smilesData)
+	if rowNum == 0 {
+		return []any{&storage.BinaryVectorFieldData{
+			Data: []byte{},
+			Dim:  v.fingerprintSize,
+		}}, nil
+	}
+
+	// Generate fingerprints based on fingerprint type
+	fingerprints := make([][]byte, rowNum)
+	for i, smiles := range smilesData {
+		if len(smiles) == 0 {
+			// Empty SMILES -> zero fingerprint
+			byteSize := v.fingerprintSize / 8
+			if v.fingerprintSize%8 != 0 {
+				byteSize++
+			}
+			fingerprints[i] = make([]byte, byteSize)
+			continue
+		}
+
+		var fp []byte
+		var err error
+
+		switch v.fingerprintType {
+		case fingerprintTypeMorgan:
+			fp, err = mol.GenerateMorganFingerprint(smiles, v.radius, v.fingerprintSize)
+		case fingerprintTypeMACCS:
+			fp, err = mol.GenerateMACCSFingerprint(smiles)
+		case fingerprintTypeRDKit:
+			fp, err = mol.GenerateRDKitFingerprint(smiles, v.minPath, v.maxPath, v.fingerprintSize)
+		default:
+			return nil, fmt.Errorf("unsupported fingerprint type: %s", v.fingerprintType)
+		}
+
+		if err != nil {
+			log.Warn("failed to generate fingerprint for SMILES",
+				zap.String("smiles", smiles),
+				zap.String("fingerprint_type", v.fingerprintType),
+				zap.Int("index", i),
+				zap.Error(err))
+			return nil, merr.WrapErrParameterInvalidMsg("failed to generate %s fingerprint for SMILES %s: %v", v.fingerprintType, smiles, err)
+		}
+		fingerprints[i] = fp
+	}
+
+	// Convert fingerprints to BINARY_VECTOR format
+	// BINARY_VECTOR stores bits packed into bytes
+	byteSize := v.fingerprintSize / 8
+	if v.fingerprintSize%8 != 0 {
+		byteSize++
+	}
+	binaryVector := make([]byte, 0, rowNum*byteSize)
+	for _, fp := range fingerprints {
+		binaryVector = append(binaryVector, fp...)
+	}
+
+	// Return BinaryVectorFieldData
+	outputData := &storage.BinaryVectorFieldData{
+		Data: binaryVector,
+		Dim:  v.fingerprintSize,
+	}
+
+	return []any{outputData}, nil
+}
+
+// GetSchema returns the function schema
+func (v *MolFingerprintFunctionRunner) GetSchema() *schemapb.FunctionSchema {
+	return v.schema
+}
+
+// GetOutputFields returns the output field schemas
+func (v *MolFingerprintFunctionRunner) GetOutputFields() []*schemapb.FieldSchema {
+	return []*schemapb.FieldSchema{v.outputField}
+}
+
+// GetInputFields returns the input field schemas
+func (v *MolFingerprintFunctionRunner) GetInputFields() []*schemapb.FieldSchema {
+	return []*schemapb.FieldSchema{v.inputField}
+}
+
+// Close closes the function runner
+func (v *MolFingerprintFunctionRunner) Close() {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.closed = true
+}

--- a/internal/util/function/mol_fingerprint_function_test.go
+++ b/internal/util/function/mol_fingerprint_function_test.go
@@ -1,0 +1,385 @@
+/*
+ * # Licensed to the LF AI & Data foundation under one
+ * # or more contributor license agreements. See the NOTICE file
+ * # distributed with this work for additional information
+ * # regarding copyright ownership. The ASF licenses this file
+ * # to you under the Apache License, Version 2.0 (the
+ * # "License"); you may not use this file except in compliance
+ * # with the License. You may obtain a copy of the License at
+ * #
+ * #     http://www.apache.org/licenses/LICENSE-2.0
+ * #
+ * # Unless required by applicable law or agreed to in writing, software
+ * # distributed under the License is distributed on an "AS IS" BASIS,
+ * # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * # See the License for the specific language governing permissions and
+ * # limitations under the License.
+ */
+
+package function
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/util/function/mol"
+)
+
+func TestMolFingerprintFunctionRunnerSuite(t *testing.T) {
+	suite.Run(t, new(MolFingerprintFunctionRunnerSuite))
+}
+
+type MolFingerprintFunctionRunnerSuite struct {
+	suite.Suite
+	schema *schemapb.CollectionSchema
+}
+
+func (s *MolFingerprintFunctionRunnerSuite) SetupTest() {
+	s.schema = &schemapb.CollectionSchema{
+		Name: "test",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "int64", DataType: schemapb.DataType_Int64},
+			{FieldID: 101, Name: "mol_field", DataType: schemapb.DataType_Mol},
+			{
+				FieldID: 102, Name: "fp_field", DataType: schemapb.DataType_BinaryVector,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: "dim", Value: "2048"},
+				},
+			},
+		},
+	}
+}
+
+func (s *MolFingerprintFunctionRunnerSuite) newFuncSchema(params []*commonpb.KeyValuePair) *schemapb.FunctionSchema {
+	return &schemapb.FunctionSchema{
+		Name:           "mol_fp",
+		Type:           schemapb.FunctionType_MolFingerprint,
+		InputFieldIds:  []int64{101},
+		OutputFieldIds: []int64{102},
+		Params:         params,
+	}
+}
+
+func (s *MolFingerprintFunctionRunnerSuite) TestValidateMolFingerprintFunction() {
+	// valid
+	err := ValidateMolFingerprintFunction(s.schema, &schemapb.FunctionSchema{
+		InputFieldNames:  []string{"mol_field"},
+		OutputFieldNames: []string{"fp_field"},
+	})
+	s.NoError(err)
+
+	// wrong input field count
+	err = ValidateMolFingerprintFunction(s.schema, &schemapb.FunctionSchema{
+		InputFieldNames:  []string{},
+		OutputFieldNames: []string{"fp_field"},
+	})
+	s.Error(err)
+
+	// wrong output field count
+	err = ValidateMolFingerprintFunction(s.schema, &schemapb.FunctionSchema{
+		InputFieldNames:  []string{"mol_field"},
+		OutputFieldNames: []string{},
+	})
+	s.Error(err)
+
+	// input field not found
+	err = ValidateMolFingerprintFunction(s.schema, &schemapb.FunctionSchema{
+		InputFieldNames:  []string{"nonexistent"},
+		OutputFieldNames: []string{"fp_field"},
+	})
+	s.Error(err)
+
+	// output field not found
+	err = ValidateMolFingerprintFunction(s.schema, &schemapb.FunctionSchema{
+		InputFieldNames:  []string{"mol_field"},
+		OutputFieldNames: []string{"nonexistent"},
+	})
+	s.Error(err)
+
+	// input field wrong type
+	wrongSchema := &schemapb.CollectionSchema{
+		Name: "test",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 101, Name: "text_field", DataType: schemapb.DataType_VarChar},
+			{FieldID: 102, Name: "fp_field", DataType: schemapb.DataType_BinaryVector},
+		},
+	}
+	err = ValidateMolFingerprintFunction(wrongSchema, &schemapb.FunctionSchema{
+		InputFieldNames:  []string{"text_field"},
+		OutputFieldNames: []string{"fp_field"},
+	})
+	s.Error(err)
+
+	// output field wrong type
+	wrongSchema2 := &schemapb.CollectionSchema{
+		Name: "test",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 101, Name: "mol_field", DataType: schemapb.DataType_Mol},
+			{FieldID: 102, Name: "vec_field", DataType: schemapb.DataType_FloatVector},
+		},
+	}
+	err = ValidateMolFingerprintFunction(wrongSchema2, &schemapb.FunctionSchema{
+		InputFieldNames:  []string{"mol_field"},
+		OutputFieldNames: []string{"vec_field"},
+	})
+	s.Error(err)
+}
+
+func (s *MolFingerprintFunctionRunnerSuite) TestNewRunner() {
+	// default params (morgan, 2048)
+	runner, err := NewMolFingerprintFunctionRunner(s.schema, s.newFuncSchema(nil))
+	s.NoError(err)
+	s.NotNil(runner)
+
+	// explicit morgan
+	runner, err = NewMolFingerprintFunctionRunner(s.schema, s.newFuncSchema([]*commonpb.KeyValuePair{
+		{Key: "fingerprint_type", Value: "morgan"},
+	}))
+	s.NoError(err)
+	s.NotNil(runner)
+
+	// rdkit type
+	runner, err = NewMolFingerprintFunctionRunner(s.schema, s.newFuncSchema([]*commonpb.KeyValuePair{
+		{Key: "fingerprint_type", Value: "rdkit"},
+	}))
+	s.NoError(err)
+	s.NotNil(runner)
+
+	// unsupported fingerprint type
+	_, err = NewMolFingerprintFunctionRunner(s.schema, s.newFuncSchema([]*commonpb.KeyValuePair{
+		{Key: "fingerprint_type", Value: "unknown"},
+	}))
+	s.Error(err)
+
+	// invalid fingerprint_size
+	_, err = NewMolFingerprintFunctionRunner(s.schema, s.newFuncSchema([]*commonpb.KeyValuePair{
+		{Key: "fingerprint_size", Value: "abc"},
+	}))
+	s.Error(err)
+
+	_, err = NewMolFingerprintFunctionRunner(s.schema, s.newFuncSchema([]*commonpb.KeyValuePair{
+		{Key: "fingerprint_size", Value: "0"},
+	}))
+	s.Error(err)
+
+	// invalid radius
+	_, err = NewMolFingerprintFunctionRunner(s.schema, s.newFuncSchema([]*commonpb.KeyValuePair{
+		{Key: "radius", Value: "abc"},
+	}))
+	s.Error(err)
+
+	_, err = NewMolFingerprintFunctionRunner(s.schema, s.newFuncSchema([]*commonpb.KeyValuePair{
+		{Key: "radius", Value: "-1"},
+	}))
+	s.Error(err)
+
+	// invalid min_path
+	_, err = NewMolFingerprintFunctionRunner(s.schema, s.newFuncSchema([]*commonpb.KeyValuePair{
+		{Key: "min_path", Value: "0"},
+	}))
+	s.Error(err)
+
+	// invalid max_path (< min_path)
+	_, err = NewMolFingerprintFunctionRunner(s.schema, s.newFuncSchema([]*commonpb.KeyValuePair{
+		{Key: "min_path", Value: "3"},
+		{Key: "max_path", Value: "1"},
+	}))
+	s.Error(err)
+
+	// dimension mismatch
+	_, err = NewMolFingerprintFunctionRunner(s.schema, s.newFuncSchema([]*commonpb.KeyValuePair{
+		{Key: "fingerprint_size", Value: "1024"},
+	}))
+	s.Error(err)
+
+	// missing output field
+	_, err = NewMolFingerprintFunctionRunner(s.schema, &schemapb.FunctionSchema{
+		Name:           "mol_fp",
+		Type:           schemapb.FunctionType_MolFingerprint,
+		InputFieldIds:  []int64{101},
+		OutputFieldIds: []int64{999},
+	})
+	s.Error(err)
+
+	// missing input field
+	_, err = NewMolFingerprintFunctionRunner(s.schema, &schemapb.FunctionSchema{
+		Name:           "mol_fp",
+		Type:           schemapb.FunctionType_MolFingerprint,
+		InputFieldIds:  []int64{999},
+		OutputFieldIds: []int64{102},
+	})
+	s.Error(err)
+
+	// wrong field counts
+	_, err = NewMolFingerprintFunctionRunner(s.schema, &schemapb.FunctionSchema{
+		Name:           "mol_fp",
+		Type:           schemapb.FunctionType_MolFingerprint,
+		InputFieldIds:  []int64{101},
+		OutputFieldIds: []int64{},
+	})
+	s.Error(err)
+}
+
+func (s *MolFingerprintFunctionRunnerSuite) TestNewRunnerMACCS() {
+	maccsSchema := &schemapb.CollectionSchema{
+		Name: "test",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "int64", DataType: schemapb.DataType_Int64},
+			{FieldID: 101, Name: "mol_field", DataType: schemapb.DataType_Mol},
+			{
+				FieldID: 102, Name: "fp_field", DataType: schemapb.DataType_BinaryVector,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: "dim", Value: "167"},
+				},
+			},
+		},
+	}
+	runner, err := NewMolFingerprintFunctionRunner(maccsSchema, &schemapb.FunctionSchema{
+		Name:           "mol_fp",
+		Type:           schemapb.FunctionType_MolFingerprint,
+		InputFieldIds:  []int64{101},
+		OutputFieldIds: []int64{102},
+		Params: []*commonpb.KeyValuePair{
+			{Key: "fingerprint_type", Value: "maccs"},
+		},
+	})
+	s.NoError(err)
+	s.NotNil(runner)
+}
+
+func (s *MolFingerprintFunctionRunnerSuite) TestBatchRunMorgan() {
+	runner, err := NewMolFingerprintFunctionRunner(s.schema, s.newFuncSchema(nil))
+	s.NoError(err)
+
+	output, err := runner.BatchRun([]string{"CCO", "c1ccccc1"})
+	s.NoError(err)
+	s.Equal(1, len(output))
+
+	result, ok := output[0].(*storage.BinaryVectorFieldData)
+	s.True(ok)
+	s.Equal(2048, result.Dim)
+	s.Equal(2*2048/8, len(result.Data))
+}
+
+func (s *MolFingerprintFunctionRunnerSuite) TestBatchRunRDKit() {
+	runner, err := NewMolFingerprintFunctionRunner(s.schema, s.newFuncSchema([]*commonpb.KeyValuePair{
+		{Key: "fingerprint_type", Value: "rdkit"},
+	}))
+	s.NoError(err)
+
+	output, err := runner.BatchRun([]string{"CCO"})
+	s.NoError(err)
+
+	result, ok := output[0].(*storage.BinaryVectorFieldData)
+	s.True(ok)
+	s.Equal(2048, result.Dim)
+}
+
+func (s *MolFingerprintFunctionRunnerSuite) TestBatchRunMACCS() {
+	maccsSchema := &schemapb.CollectionSchema{
+		Name: "test",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 101, Name: "mol_field", DataType: schemapb.DataType_Mol},
+			{
+				FieldID: 102, Name: "fp_field", DataType: schemapb.DataType_BinaryVector,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: "dim", Value: "167"},
+				},
+			},
+		},
+	}
+	runner, err := NewMolFingerprintFunctionRunner(maccsSchema, &schemapb.FunctionSchema{
+		Name:           "mol_fp",
+		Type:           schemapb.FunctionType_MolFingerprint,
+		InputFieldIds:  []int64{101},
+		OutputFieldIds: []int64{102},
+		Params: []*commonpb.KeyValuePair{
+			{Key: "fingerprint_type", Value: "maccs"},
+		},
+	})
+	s.NoError(err)
+
+	output, err := runner.BatchRun([]string{"CCO"})
+	s.NoError(err)
+
+	result, ok := output[0].(*storage.BinaryVectorFieldData)
+	s.True(ok)
+	s.Equal(167, result.Dim)
+}
+
+func (s *MolFingerprintFunctionRunnerSuite) TestBatchRunPickleInput() {
+	runner, err := NewMolFingerprintFunctionRunner(s.schema, s.newFuncSchema(nil))
+	s.NoError(err)
+
+	pickle, err := mol.ConvertSMILESToPickle("CCO")
+	s.NoError(err)
+
+	output, err := runner.BatchRun([][]byte{pickle})
+	s.NoError(err)
+
+	result, ok := output[0].(*storage.BinaryVectorFieldData)
+	s.True(ok)
+	s.Equal(2048, result.Dim)
+}
+
+func (s *MolFingerprintFunctionRunnerSuite) TestBatchRunEmptySmiles() {
+	runner, err := NewMolFingerprintFunctionRunner(s.schema, s.newFuncSchema(nil))
+	s.NoError(err)
+
+	output, err := runner.BatchRun([]string{""})
+	s.NoError(err)
+
+	result, ok := output[0].(*storage.BinaryVectorFieldData)
+	s.True(ok)
+	s.Equal(2048/8, len(result.Data))
+}
+
+func (s *MolFingerprintFunctionRunnerSuite) TestBatchRunEmptyBatch() {
+	runner, err := NewMolFingerprintFunctionRunner(s.schema, s.newFuncSchema(nil))
+	s.NoError(err)
+
+	output, err := runner.BatchRun([]string{})
+	s.NoError(err)
+
+	result, ok := output[0].(*storage.BinaryVectorFieldData)
+	s.True(ok)
+	s.Equal(0, len(result.Data))
+}
+
+func (s *MolFingerprintFunctionRunnerSuite) TestBatchRunErrors() {
+	runner, err := NewMolFingerprintFunctionRunner(s.schema, s.newFuncSchema(nil))
+	s.NoError(err)
+
+	// more than one input
+	_, err = runner.BatchRun([]string{}, []string{})
+	s.Error(err)
+
+	// wrong input type
+	_, err = runner.BatchRun([]int64{})
+	s.Error(err)
+
+	// invalid SMILES
+	_, err = runner.BatchRun([]string{"not_valid_smiles!!!"})
+	s.Error(err)
+
+	// close and run
+	runner.Close()
+	_, err = runner.BatchRun([]string{"CCO"})
+	s.Error(err)
+}
+
+func (s *MolFingerprintFunctionRunnerSuite) TestGetters() {
+	funcSchema := s.newFuncSchema(nil)
+	runner, err := NewMolFingerprintFunctionRunner(s.schema, funcSchema)
+	s.NoError(err)
+
+	s.Equal(funcSchema, runner.GetSchema())
+	s.Equal(1, len(runner.GetOutputFields()))
+	s.Equal("fp_field", runner.GetOutputFields()[0].GetName())
+	s.Equal(1, len(runner.GetInputFields()))
+	s.Equal("mol_field", runner.GetInputFields()[0].GetName())
+}

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -418,3 +418,40 @@ func TestWKTWKBConversion(t *testing.T) {
 		})
 	}
 }
+
+func TestSMILESPickleConversion(t *testing.T) {
+	testCases := []struct {
+		name   string
+		smiles string
+	}{
+		{"ethanol", "CCO"},
+		{"benzene", "c1ccccc1"},
+		{"acetic acid", "CC(=O)O"},
+		{"aspirin", "CC(=O)Oc1ccccc1C(=O)O"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pickle, err := ConvertSMILESToPickle(tc.smiles)
+			assert.NoError(t, err)
+			assert.NotEmpty(t, pickle)
+
+			smilesResult, err := ConvertPickleToSMILES(pickle)
+			assert.NoError(t, err)
+			assert.NotEmpty(t, smilesResult)
+		})
+	}
+
+	t.Run("empty SMILES", func(t *testing.T) {
+		_, err := ConvertSMILESToPickle("")
+		assert.Error(t, err)
+	})
+
+	t.Run("empty pickle", func(t *testing.T) {
+		_, err := ConvertPickleToSMILES(nil)
+		assert.Error(t, err)
+
+		_, err = ConvertPickleToSMILES([]byte{})
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
## Related to
- milvus-io/milvus#47229

## Design Doc
- milvus-io/milvus-design-docs#30

This PR is part of the MOL feature stack and should be reviewed together with the design doc above.

## Summary

Implement molecular fingerprint function that converts MOL (SMILES) data into binary fingerprint vectors for similarity search, supporting Morgan, MACCS, and RDKit fingerprint types.

## Changes

### Fingerprint Generation
- `morgan.go` / `maccs.go` / `rdkit.go`: Three fingerprint type implementations via CGO
- `mol_fingerprint_function.go`: Function runner with parameter validation and dispatch

### Embedding Pipeline Integration
- `mol_fingerprint_embedding_function.go`: Embedding function executor for MOL fingerprints
- `function_executor.go` / `function_util.go`: Register MOL fingerprint in function framework
- `flow_graph_embedding_node.go` / `embedding_node.go`: Support MOL in flush and query embedding nodes

### Other
- `proxy/util.go`: MOL fingerprint support in search path
- `schema.go`: MOL function schema validation

## Dependencies
- Depends on #47744 (RDKit CGO integration)