### PR TITLE
fix: workaround chunk reader lacking projection support by passing needed_columns to Reader

### DIFF
--- a/internal/core/src/common/Schema.cpp
+++ b/internal/core/src/common/Schema.cpp
@@ -160,6 +160,35 @@ Schema::ConvertToArrowSchema() const {
     return arrow::schema(arrow_fields);
 }
 
+const ArrowSchemaPtr
+Schema::ConvertToLoonArrowSchema() const {
+    arrow::FieldVector arrow_fields;
+    arrow_fields.reserve(field_ids_.size());
+    for (const auto& field_id : field_ids_) {
+        const auto& meta = fields_.at(field_id);
+        int dim = IsVectorDataType(meta.get_data_type()) &&
+                          !IsSparseFloatVectorDataType(meta.get_data_type())
+                      ? meta.get_dim()
+                      : 1;
+
+        std::shared_ptr<arrow::DataType> arrow_data_type = nullptr;
+        auto data_type = meta.get_data_type();
+        if (data_type == DataType::VECTOR_ARRAY) {
+            arrow_data_type = GetArrowDataTypeForVectorArray(
+                meta.get_element_type(), meta.get_dim());
+        } else {
+            arrow_data_type = GetArrowDataType(data_type, dim);
+        }
+
+        auto arrow_field = std::make_shared<arrow::Field>(
+            std::to_string(field_id.get()),
+            arrow_data_type,
+            meta.is_nullable());
+        arrow_fields.push_back(arrow_field);
+    }
+    return arrow::schema(arrow_fields);
+}
+
 proto::schema::CollectionSchema
 Schema::ToProto() const {
     proto::schema::CollectionSchema schema_proto;

--- a/internal/core/src/common/Schema.cpp
+++ b/internal/core/src/common/Schema.cpp
@@ -180,10 +180,10 @@ Schema::ConvertToLoonArrowSchema() const {
             arrow_data_type = GetArrowDataType(data_type, dim);
         }
 
-        auto arrow_field = std::make_shared<arrow::Field>(
-            std::to_string(field_id.get()),
-            arrow_data_type,
-            meta.is_nullable());
+        auto arrow_field =
+            std::make_shared<arrow::Field>(std::to_string(field_id.get()),
+                                           arrow_data_type,
+                                           meta.is_nullable());
         arrow_fields.push_back(arrow_field);
     }
     return arrow::schema(arrow_fields);

--- a/internal/core/src/common/Schema.h
+++ b/internal/core/src/common/Schema.h
@@ -369,6 +369,11 @@ class Schema {
     const ArrowSchemaPtr
     ConvertToArrowSchema() const;
 
+    /// Convert to Arrow schema with field ID strings as field names,
+    /// used by Loon FFI / milvus-storage Reader.
+    const ArrowSchemaPtr
+    ConvertToLoonArrowSchema() const;
+
     proto::schema::CollectionSchema
     ToProto() const;
 

--- a/internal/core/src/common/SchemaTest.cpp
+++ b/internal/core/src/common/SchemaTest.cpp
@@ -424,8 +424,7 @@ TEST_F(SchemaTest, WarmupPolicyFallbackToCollectionLevel) {
 // ConvertToLoonArrowSchema tests
 
 TEST_F(SchemaTest, ConvertToLoonArrowSchemaFieldNamesAreFieldIds) {
-    auto pk_id =
-        schema_->AddDebugField("pk_field", DataType::INT64, false);
+    auto pk_id = schema_->AddDebugField("pk_field", DataType::INT64, false);
     schema_->set_primary_field_id(pk_id);
     auto float_id =
         schema_->AddDebugField("float_field", DataType::FLOAT, false);
@@ -439,8 +438,7 @@ TEST_F(SchemaTest, ConvertToLoonArrowSchemaFieldNamesAreFieldIds) {
 }
 
 TEST_F(SchemaTest, ConvertToLoonArrowSchemaVsConvertToArrowSchema) {
-    auto pk_id =
-        schema_->AddDebugField("pk_field", DataType::INT64, false);
+    auto pk_id = schema_->AddDebugField("pk_field", DataType::INT64, false);
     schema_->set_primary_field_id(pk_id);
     auto varchar_id =
         schema_->AddDebugField("varchar_field", DataType::VARCHAR, true);

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -2922,11 +2922,9 @@ ChunkedSegmentSealedImpl::ApplyLoadDiff(SegmentLoadInfo& segment_load_info,
                 .GetProperties();
         auto column_groups = segment_load_info.GetColumnGroups();
         auto arrow_schema = schema_->ConvertToLoonArrowSchema();
-        auto needed_columns =
-            std::make_shared<std::vector<std::string>>();
+        auto needed_columns = std::make_shared<std::vector<std::string>>();
         for (const auto& field_id : schema_->get_field_ids()) {
-            needed_columns->push_back(
-                std::to_string(field_id.get()));
+            needed_columns->push_back(std::to_string(field_id.get()));
         }
         reader_ = milvus_storage::api::Reader::create(
             column_groups, arrow_schema, needed_columns, *properties);

--- a/internal/core/src/segcore/SegmentLoadInfo.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfo.cpp
@@ -306,9 +306,11 @@ SegmentLoadInfo::ComputeDiffColumnGroups(LoadDiff& diff,
             auto iter = cur_field_ids.find(field_id);
             // If this field doesn't exist in current, mark the column group for loading
             if (iter == cur_field_ids.end() || iter->second != i) {
-                if (schema_->ShouldLoadField(FieldId(field_id)) &&
-                    field_index_has_raw_data_.find(FieldId(field_id)) ==
-                        field_index_has_raw_data_.end()) {
+                if (field_id < START_USER_FIELDID ||
+                    (schema_->ShouldLoadField(FieldId(field_id)) &&
+                     field_index_has_raw_data_.find(FieldId(field_id)) ==
+                         field_index_has_raw_data_.end())) {
+                    // system fields are always proactively loaded
                     fields.emplace_back(field_id);
                 } else {
                     // put lazy load & index_has_raw_data field in lazy_fields

--- a/internal/core/src/segcore/SegmentLoadInfo.h
+++ b/internal/core/src/segcore/SegmentLoadInfo.h
@@ -157,6 +157,23 @@ struct LoadDiff {
         }
         oss << "], ";
 
+        // column_groups_to_lazyload
+        oss << "column_groups_to_lazyload=[";
+        first = true;
+        for (const auto& [group_idx, field_ids] : column_groups_to_lazyload) {
+            if (!first)
+                oss << ", ";
+            first = false;
+            oss << "group" << group_idx << ":[";
+            for (size_t i = 0; i < field_ids.size(); ++i) {
+                if (i > 0)
+                    oss << ",";
+                oss << field_ids[i].get();
+            }
+            oss << "]";
+        }
+        oss << "], ";
+
         // indexes_to_drop
         oss << "indexes_to_drop=[";
         first = true;

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
@@ -279,11 +279,16 @@ ManifestGroupTranslator::load_group_chunk(
             continue;
         }
         auto it = field_metas_.find(fid);
-        AssertInfo(
-            it != field_metas_.end(),
-            "[StorageV2] translator {} field id {} not found in field_metas",
-            key_,
-            fid.get());
+        // Workaround for projection push-down missing for chunk reader
+        // change back to asssertion after supported
+        if (it == field_metas_.end()) {
+            continue;
+        }
+        // AssertInfo(
+        //     it != field_metas_.end(),
+        //     "[StorageV2] translator {} field id {} not found in field_metas",
+        //     key_,
+        //     fid.get());
         const auto& field_meta = it->second;
 
         // Merge arrays from all record batches for this field


### PR DESCRIPTION
Related to #44956

milvus-storage chunk reader does not yet support projection push-down, causing it to return all columns in a column group regardless of what fields the segment actually needs. This leads to assertion failures in ManifestGroupTranslator when unexpected field IDs appear in the result.

Workaround:
- Add Schema::ConvertToLoonArrowSchema() that uses field ID strings as arrow field names (matching milvus-storage column naming convention)
- Pass all schema field IDs as needed_columns when creating the Reader, so the top-level Reader filters columns before they reach chunk reader
- Skip unknown field IDs in ManifestGroupTranslator::load_group_chunk instead of asserting, as a safety net until chunk reader supports projection natively

Other changes:
- System fields (RowID/Timestamp, field_id < 100) are now always proactively loaded in ComputeDiffColumnGroups, preventing them from being incorrectly placed into lazy load when partial load is active
- Add column_groups_to_lazyload to LoadDiff::ToString() for debugging
- Improve error message in LoadColumnGroup to include status details
- Add unit tests for ConvertToLoonArrowSchema