### PR TITLE
fix: keep HTTP ttlSeconds integers out of exponential notation

### DIFF
--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -2030,18 +2030,11 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 		var valueStr string
 		switch v := ttlSeconds.(type) {
 		case float64:
-			if v != math.Trunc(v) {
-				err := merr.WrapErrParameterInvalid("integer", ttlSeconds,
-					"ttlSeconds should be an integer representing seconds")
-				log.Ctx(ctx).Warn("high level restful api, create collection fail", zap.Error(err), zap.Any("request", anyReq))
-				HTTPAbortReturn(c, http.StatusOK, gin.H{
-					HTTPReturnCode:    merr.Code(err),
-					HTTPReturnMessage: err.Error(),
-				})
-				return nil, err
+			if v == math.Trunc(v) {
+				valueStr = strconv.FormatInt(int64(v), 10)
+			} else {
+				valueStr = strconv.FormatFloat(v, 'f', -1, 64)
 			}
-
-			valueStr = strconv.FormatInt(int64(v), 10)
 		default:
 			valueStr = fmt.Sprintf("%v", ttlSeconds)
 		}


### PR DESCRIPTION
fixes #47761

HTTP v2 collection APIs accept ttlSeconds in the JSON body. When a client sends a large integer ttlSeconds value, it is parsed as a float and can be formatted in exponential notation (e.g. 3.1536e+11) when building collection properties. Downstream components expect ttlSeconds to be a plain decimal integer string, so this causes failures.

This PR:
- Fixes the HTTP v2 handlers so that large integer ttlSeconds values from JSON are preserved as decimal integer strings (not exponential notation) in collection properties passed to the proxy.
- Adds tests for createCollection and alterCollectionProperties to cover this behavior.
