### PR TITLE
enhance: [2.5]fast stop when resource limited

### DIFF
--- a/internal/querycoordv2/job/job_load.go
+++ b/internal/querycoordv2/job/job_load.go
@@ -141,6 +141,7 @@ func (job *LoadCollectionJob) Execute() error {
 	req := job.req
 	log := log.Ctx(job.ctx).With(zap.Int64("collectionID", req.GetCollectionID()))
 	meta.GlobalFailedLoadCache.Remove(req.GetCollectionID())
+	triggerResourceLimitFlagClearHook(req.GetCollectionID())
 
 	// 1. Fetch target partitions
 	partitionIDs, err := job.broker.GetPartitions(job.ctx, req.GetCollectionID())
@@ -354,6 +355,7 @@ func (job *LoadPartitionJob) Execute() error {
 		zap.Int64s("partitionIDs", req.GetPartitionIDs()),
 	)
 	meta.GlobalFailedLoadCache.Remove(req.GetCollectionID())
+	triggerResourceLimitFlagClearHook(req.GetCollectionID())
 
 	// 1. Fetch target partitions
 	loadedPartitionIDs := lo.Map(job.meta.CollectionManager.GetPartitionsByCollection(job.ctx, req.GetCollectionID()),

--- a/internal/querycoordv2/job/resource_limit_hook.go
+++ b/internal/querycoordv2/job/resource_limit_hook.go
@@ -1,0 +1,30 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package job
+
+var resourceLimitFlagClearHook func(collectionID int64)
+
+// SetResourceLimitFlagClearHook registers a hook for clearing resource limit flags on load.
+func SetResourceLimitFlagClearHook(hook func(collectionID int64)) {
+	resourceLimitFlagClearHook = hook
+}
+
+func triggerResourceLimitFlagClearHook(collectionID int64) {
+	if resourceLimitFlagClearHook != nil {
+		resourceLimitFlagClearHook(collectionID)
+	}
+}

--- a/internal/querycoordv2/resource_limit_flag.go
+++ b/internal/querycoordv2/resource_limit_flag.go
@@ -1,0 +1,81 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package querycoordv2
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"strconv"
+	"time"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.uber.org/zap"
+
+	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+)
+
+const (
+	resourceLimitCollectionFlagKeyPrefix = "querycoord/failed_load/resource_limit/collections"
+	resourceLimitFlagTTL                 = 5 * time.Minute
+)
+
+func markResourceLimitFlag(ctx context.Context, cli *clientv3.Client, collectionID int64) {
+	if cli == nil {
+		return
+	}
+	if collectionID <= 0 {
+		log.Ctx(ctx).Warn("skip mark resource limit flag due to invalid collectionID", zap.Int64("collectionID", collectionID))
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), paramtable.Get().ServiceParam.EtcdCfg.RequestTimeout.GetAsDuration(time.Millisecond))
+	defer cancel()
+	leaseResp, err := cli.Grant(ctx, int64(resourceLimitFlagTTL.Seconds()))
+	if err != nil {
+		log.Ctx(ctx).Warn("failed to grant resource limit flag lease", zap.Error(err))
+		return
+	}
+	key := resourceLimitFlagPath(collectionID)
+	if _, err := cli.Put(ctx, key, fmt.Sprint(time.Now().Unix()), clientv3.WithLease(leaseResp.ID)); err != nil {
+		log.Ctx(ctx).Warn("failed to mark resource limit flag", zap.String("key", key), zap.Error(err))
+	}
+}
+
+func clearResourceLimitFlag(ctx context.Context, cli *clientv3.Client, collectionID int64) {
+	if cli == nil {
+		return
+	}
+	if collectionID <= 0 {
+		log.Ctx(ctx).Warn("skip clear resource limit flag due to invalid collectionID", zap.Int64("collectionID", collectionID))
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), paramtable.Get().ServiceParam.EtcdCfg.RequestTimeout.GetAsDuration(time.Millisecond))
+	defer cancel()
+	key := resourceLimitFlagPath(collectionID)
+	if _, err := cli.Delete(ctx, key); err != nil {
+		log.Ctx(ctx).Warn("failed to clear resource limit flag", zap.String("key", key), zap.Error(err))
+	}
+}
+
+func resourceLimitFlagPath(collectionID int64) string {
+	return path.Join(
+		paramtable.Get().EtcdCfg.MetaRootPath.GetValue(),
+		resourceLimitCollectionFlagKeyPrefix,
+		strconv.FormatInt(collectionID, 10),
+	)
+}

--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -420,6 +420,12 @@ func (s *Server) initQueryCoord() error {
 
 	// Init load status cache
 	meta.GlobalFailedLoadCache = meta.NewFailedLoadCache()
+	task.SetResourceLimitFlagHook(func(collectionID int64) {
+		markResourceLimitFlag(s.ctx, s.etcdCli, collectionID)
+	})
+	job.SetResourceLimitFlagClearHook(func(collectionID int64) {
+		clearResourceLimitFlag(s.ctx, s.etcdCli, collectionID)
+	})
 
 	log.Info("init querycoord done", zap.Int64("nodeID", paramtable.GetNodeID()), zap.String("Address", s.address))
 	return err

--- a/internal/querycoordv2/task/resource_limit_hook.go
+++ b/internal/querycoordv2/task/resource_limit_hook.go
@@ -1,0 +1,30 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package task
+
+var resourceLimitFlagHook func(collectionID int64)
+
+// SetResourceLimitFlagHook registers a hook for signaling resource limit failures.
+func SetResourceLimitFlagHook(hook func(collectionID int64)) {
+	resourceLimitFlagHook = hook
+}
+
+func triggerResourceLimitFlagHook(collectionID int64) {
+	if resourceLimitFlagHook != nil {
+		resourceLimitFlagHook(collectionID)
+	}
+}

--- a/internal/querycoordv2/task/scheduler.go
+++ b/internal/querycoordv2/task/scheduler.go
@@ -948,6 +948,9 @@ func (scheduler *taskScheduler) recordSegmentTaskError(task *SegmentTask) {
 		zap.Error(task.err),
 	)
 	meta.GlobalFailedLoadCache.Put(task.collectionID, task.Err())
+	if errors.IsAny(task.Err(), merr.ErrServiceMemoryLimitExceeded, merr.ErrServiceDiskLimitExceeded, merr.ErrServiceResourceInsufficient) {
+		triggerResourceLimitFlagHook(task.CollectionID())
+	}
 }
 
 func (scheduler *taskScheduler) remove(task Task) {

--- a/internal/querynodev2/pipeline/manager.go
+++ b/internal/querynodev2/pipeline/manager.go
@@ -43,6 +43,7 @@ type Manager interface {
 	Start(channels ...string) error
 	Close()
 	GetChannelStats(collectionID int64) []*metricsinfo.Channel
+	CollectionIDs() []int64
 }
 
 type manager struct {
@@ -177,6 +178,23 @@ func (m *manager) GetChannelStats(collectionID int64) []*metricsinfo.Channel {
 				CollectionID:   p.GetCollectionID(),
 			})
 		}
+	}
+	return ret
+}
+
+func (m *manager) CollectionIDs() []int64 {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	set := typeutil.NewUniqueSet()
+	for _, p := range m.channel2Pipeline {
+		set.Insert(p.GetCollectionID())
+	}
+
+	ids := set.Collect()
+	ret := make([]int64, 0, len(ids))
+	for _, id := range ids {
+		ret = append(ret, id)
 	}
 	return ret
 }

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -1500,12 +1500,13 @@ func (loader *segmentLoader) checkSegmentSize(ctx context.Context, segmentLoadIn
 	)
 
 	if predictMemUsage > uint64(float64(totalMem)*paramtable.Get().QueryNodeCfg.OverloadedMemoryThresholdPercentage.GetAsFloat()) {
-		return 0, 0, fmt.Errorf("load segment failed, OOM if load, maxSegmentSize = %v MB,  memUsage = %v MB, predictMemUsage = %v MB, totalMem = %v MB thresholdFactor = %f",
+		return 0, 0, merr.WrapErrServiceMemoryLimitExceeded(float32(predictMemUsage), float32(totalMem), fmt.Sprintf(
+			"load segment failed, OOM if load, maxSegmentSize = %v MB, memUsage = %v MB, predictMemUsage = %v MB, totalMem = %v MB thresholdFactor = %f",
 			toMB(maxSegmentSize),
 			toMB(memUsage),
 			toMB(predictMemUsage),
 			toMB(totalMem),
-			paramtable.Get().QueryNodeCfg.OverloadedMemoryThresholdPercentage.GetAsFloat())
+			paramtable.Get().QueryNodeCfg.OverloadedMemoryThresholdPercentage.GetAsFloat()))
 	}
 
 	if predictDiskUsage > uint64(float64(paramtable.Get().QueryNodeCfg.DiskCapacityLimit.GetAsInt64())*paramtable.Get().QueryNodeCfg.MaxDiskUsagePercentage.GetAsFloat()) {

--- a/internal/querynodev2/server.go
+++ b/internal/querynodev2/server.go
@@ -35,6 +35,7 @@ import (
 	"path"
 	"path/filepath"
 	"plugin"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -79,6 +80,8 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
+
+const queryCoordCollectionResourceLimitFlagKeyPrefix = "querycoord/failed_load/resource_limit/collections"
 
 // make sure QueryNode implements types.QueryNode
 var _ types.QueryNode = (*QueryNode)(nil)
@@ -542,48 +545,65 @@ func (node *QueryNode) Stop() error {
 			// Integration test is still using it, Remove it in future.
 			timeoutCh := time.After(paramtable.Get().QueryNodeCfg.GracefulStopTimeout.GetAsDuration(time.Second))
 
+			lastResourceCheck := time.Now().Add(-time.Minute)
+			resourceLimitedCollections := make(map[int64]struct{})
 		outer:
 			for (node.manager != nil && !node.manager.Segment.Empty()) ||
 				(node.pipelineManager != nil && node.pipelineManager.Num() != 0) {
 				var (
-					sealedSegments  = []segments.Segment{}
-					growingSegments = []segments.Segment{}
-					channelNum      = 0
+					sealedSegments     = []segments.Segment{}
+					growingSegments    = []segments.Segment{}
+					pipelineCollection = []int64{}
 				)
 				if node.manager != nil {
 					sealedSegments = node.manager.Segment.GetBy(segments.WithType(segments.SegmentTypeSealed), segments.WithoutLevel(datapb.SegmentLevel_L0))
 					growingSegments = node.manager.Segment.GetBy(segments.WithType(segments.SegmentTypeGrowing), segments.WithoutLevel(datapb.SegmentLevel_L0))
 				}
 				if node.pipelineManager != nil {
-					channelNum = node.pipelineManager.Num()
+					pipelineCollection = node.pipelineManager.CollectionIDs()
 				}
-				if len(sealedSegments) == 0 && len(growingSegments) == 0 && channelNum == 0 {
-					break
+
+				if time.Since(lastResourceCheck) >= time.Minute {
+					lastResourceCheck = time.Now()
+					pendingCollections := node.pendingMigrationCollectionIDs(sealedSegments, growingSegments, pipelineCollection)
+					resourceLimitedCollections = node.getResourceLimitedCollections(log, pendingCollections)
+				}
+
+				pendingSealed := node.filterSegmentsByLimitedCollections(sealedSegments, resourceLimitedCollections)
+				pendingGrowing := node.filterSegmentsByLimitedCollections(growingSegments, resourceLimitedCollections)
+				pendingChannelCollection := lo.Filter(pipelineCollection, func(collectionID int64, _ int) bool {
+					_, limited := resourceLimitedCollections[collectionID]
+					return !limited
+				})
+
+				if len(pendingSealed) == 0 && len(pendingGrowing) == 0 && len(pendingChannelCollection) == 0 {
+					break outer
 				}
 
 				select {
 				case <-timeoutCh:
 					log.Warn("migrate data timed out", zap.Int64("ServerID", node.GetNodeID()),
-						zap.Int64s("sealedSegments", lo.Map(sealedSegments, func(s segments.Segment, i int) int64 {
+						zap.Int64s("sealedSegments", lo.Map(pendingSealed, func(s segments.Segment, i int) int64 {
 							return s.ID()
 						})),
-						zap.Int64s("growingSegments", lo.Map(growingSegments, func(t segments.Segment, i int) int64 {
+						zap.Int64s("growingSegments", lo.Map(pendingGrowing, func(t segments.Segment, i int) int64 {
 							return t.ID()
 						})),
-						zap.Int("channelNum", channelNum),
+						zap.Int("channelCollectionNum", len(pendingChannelCollection)),
 					)
 					break outer
 				case <-time.After(time.Second):
-					metrics.StoppingBalanceSegmentNum.WithLabelValues(fmt.Sprint(node.GetNodeID())).Set(float64(len(sealedSegments)))
-					metrics.StoppingBalanceChannelNum.WithLabelValues(fmt.Sprint(node.GetNodeID())).Set(float64(channelNum))
+					metrics.StoppingBalanceSegmentNum.WithLabelValues(fmt.Sprint(node.GetNodeID())).Set(float64(len(pendingSealed)))
+					metrics.StoppingBalanceChannelNum.WithLabelValues(fmt.Sprint(node.GetNodeID())).Set(float64(len(pendingChannelCollection)))
 					log.Info("migrate data...", zap.Int64("ServerID", node.GetNodeID()),
-						zap.Int64s("sealedSegments", lo.Map(sealedSegments, func(s segments.Segment, i int) int64 {
+						zap.Int64s("sealedSegments", lo.Map(pendingSealed, func(s segments.Segment, i int) int64 {
 							return s.ID()
 						})),
-						zap.Int64s("growingSegments", lo.Map(growingSegments, func(t segments.Segment, i int) int64 {
+						zap.Int64s("growingSegments", lo.Map(pendingGrowing, func(t segments.Segment, i int) int64 {
 							return t.ID()
 						})),
-						zap.Int("channelNum", channelNum),
+						zap.Int("channelCollectionNum", len(pendingChannelCollection)),
+						zap.Int("resourceLimitedCollectionNum", len(resourceLimitedCollections)),
 					)
 				}
 			}
@@ -623,6 +643,74 @@ func (node *QueryNode) Stop() error {
 // UpdateStateCode updata the state of query node, which can be initializing, healthy, and abnormal
 func (node *QueryNode) UpdateStateCode(code commonpb.StateCode) {
 	node.lifetime.SetState(code)
+}
+
+func (node *QueryNode) getResourceLimitedCollections(log *log.MLogger, collectionIDs []int64) map[int64]struct{} {
+	limitedCollections := make(map[int64]struct{})
+	if node.etcdCli == nil {
+		return limitedCollections
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), paramtable.Get().ServiceParam.EtcdCfg.RequestTimeout.GetAsDuration(time.Millisecond))
+	defer cancel()
+
+	for _, collectionID := range collectionIDs {
+		if collectionID <= 0 {
+			continue
+		}
+		key := node.collectionResourceLimitFlagPath(collectionID)
+		resp, err := node.etcdCli.Get(ctx, key)
+		if err != nil {
+			log.Warn("failed to get collection resource limit flag", zap.String("key", key), zap.Int64("collectionID", collectionID), zap.Error(err))
+			continue
+		}
+		if resp.Count > 0 {
+			limitedCollections[collectionID] = struct{}{}
+		}
+	}
+
+	return limitedCollections
+}
+
+func (node *QueryNode) pendingMigrationCollectionIDs(sealedSegments, growingSegments []segments.Segment, pipelineCollections []int64) []int64 {
+	set := typeutil.NewUniqueSet()
+	for _, segment := range sealedSegments {
+		set.Insert(segment.Collection())
+	}
+	for _, segment := range growingSegments {
+		set.Insert(segment.Collection())
+	}
+	for _, collectionID := range pipelineCollections {
+		set.Insert(collectionID)
+	}
+
+	ids := set.Collect()
+	ret := make([]int64, 0, len(ids))
+	for _, id := range ids {
+		ret = append(ret, id)
+	}
+	return ret
+}
+
+func (node *QueryNode) filterSegmentsByLimitedCollections(segmentsIn []segments.Segment, limitedCollections map[int64]struct{}) []segments.Segment {
+	if len(limitedCollections) == 0 {
+		return segmentsIn
+	}
+
+	ret := make([]segments.Segment, 0, len(segmentsIn))
+	for _, segment := range segmentsIn {
+		if _, limited := limitedCollections[segment.Collection()]; !limited {
+			ret = append(ret, segment)
+		}
+	}
+	return ret
+}
+
+func (node *QueryNode) collectionResourceLimitFlagPath(collectionID int64) string {
+	return path.Join(
+		paramtable.Get().EtcdCfg.MetaRootPath.GetValue(),
+		queryCoordCollectionResourceLimitFlagKeyPrefix,
+		strconv.FormatInt(collectionID, 10),
+	)
 }
 
 // SetEtcdClient assigns parameter client to its member etcdCli


### PR DESCRIPTION
This commit improves the graceful shutdown behavior of QueryNode under resource pressure. When QueryCoord detects resource limit failures (memory/disk/insufficient resources), it now sets a short-lived flag in etcd. QueryNode checks this flag during the migration loop in Stop() and exits early if the flag is present, avoiding prolonged shutdown while the cluster is resource constrained. The flag is also cleared when a load succeeds or when a node comes back online.

issue: https://github.com/milvus-io/milvus/issues/47591