### PR TITLE
enhance: add configurable skip list for replicate message types

### DIFF
--- a/internal/distributed/streaming/replicate_service.go
+++ b/internal/distributed/streaming/replicate_service.go
@@ -18,10 +18,22 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
+// buildSkipMessageTypes builds a set of message type names to skip during replication.
+func buildSkipMessageTypes(types []string) map[string]struct{} {
+	m := make(map[string]struct{}, len(types))
+	for _, t := range types {
+		if t != "" {
+			m[t] = struct{}{}
+		}
+	}
+	return m
+}
+
 var _ ReplicateService = replicateService{}
 
 type replicateService struct {
 	*walAccesserImpl
+	skipMessageTypes map[string]struct{}
 }
 
 // Append appends the message into current cluster.
@@ -82,21 +94,15 @@ func (s replicateService) GetReplicateCheckpoint(ctx context.Context, channelNam
 }
 
 // shouldSkipReplicateMessageType checks if the given message type should be skipped during replication.
-func shouldSkipReplicateMessageType(msgType message.MessageType) bool {
-	skipTypes := paramtable.Get().StreamingCfg.ReplicationSkipMessageTypes.GetAsStrings()
-	typeName := msgType.String()
-	for _, s := range skipTypes {
-		if s == typeName {
-			return true
-		}
-	}
-	return false
+func (s replicateService) shouldSkipReplicateMessageType(msgType message.MessageType) bool {
+	_, ok := s.skipMessageTypes[msgType.String()]
+	return ok
 }
 
 // overwriteReplicateMessage overwrites the replicate message.
 // because some message such as create collection message write vchannel in its body, so we need to overwrite the message.
 func (s replicateService) overwriteReplicateMessage(ctx context.Context, msg message.ReplicateMutableMessage, rh *message.ReplicateHeader) (message.MutableMessage, error) {
-	if shouldSkipReplicateMessageType(msg.MessageType()) {
+	if s.shouldSkipReplicateMessageType(msg.MessageType()) {
 		return nil, status.NewIgnoreOperation("message type %s is configured to be skipped during replication", msg.MessageType())
 	}
 

--- a/internal/distributed/streaming/replicate_service.go
+++ b/internal/distributed/streaming/replicate_service.go
@@ -81,9 +81,25 @@ func (s replicateService) GetReplicateCheckpoint(ctx context.Context, channelNam
 	return checkpoint, nil
 }
 
+// shouldSkipReplicateMessageType checks if the given message type should be skipped during replication.
+func shouldSkipReplicateMessageType(msgType message.MessageType) bool {
+	skipTypes := paramtable.Get().StreamingCfg.ReplicationSkipMessageTypes.GetAsStrings()
+	typeName := msgType.String()
+	for _, s := range skipTypes {
+		if s == typeName {
+			return true
+		}
+	}
+	return false
+}
+
 // overwriteReplicateMessage overwrites the replicate message.
 // because some message such as create collection message write vchannel in its body, so we need to overwrite the message.
 func (s replicateService) overwriteReplicateMessage(ctx context.Context, msg message.ReplicateMutableMessage, rh *message.ReplicateHeader) (message.MutableMessage, error) {
+	if shouldSkipReplicateMessageType(msg.MessageType()) {
+		return nil, status.NewIgnoreOperation("message type %s is configured to be skipped during replication", msg.MessageType())
+	}
+
 	cfg, err := s.streamingCoordClient.Assignment().GetReplicateConfiguration(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/distributed/streaming/replicate_service_test.go
+++ b/internal/distributed/streaming/replicate_service_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/milvus-io/milvus/internal/mocks/streamingcoord/mock_client"
 	"github.com/milvus-io/milvus/internal/mocks/streamingnode/client/handler/mock_producer"
 	"github.com/milvus-io/milvus/internal/mocks/streamingnode/client/mock_handler"
+	"github.com/milvus-io/milvus/internal/util/streamingutil/status"
 	"github.com/milvus-io/milvus/pkg/v2/proto/messagespb"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/types"
@@ -301,6 +302,110 @@ func TestReplicateService_AlterLoadConfigUseLocalReplicaConfig(t *testing.T) {
 	})
 }
 
+func TestReplicateService_SkipMessageTypes(t *testing.T) {
+	newReplicateService := func(t *testing.T) *replicateService {
+		c := mock_client.NewMockClient(t)
+		as := mock_client.NewMockAssignmentService(t)
+		c.EXPECT().Assignment().Return(as).Maybe()
+		as.EXPECT().GetReplicateConfiguration(mock.Anything).Return(replicateutil.MustNewConfigHelper(
+			"by-dev",
+			&commonpb.ReplicateConfiguration{
+				Clusters: []*commonpb.MilvusCluster{
+					{ClusterId: "primary", Pchannels: []string{"primary-rootcoord-dml_0", "primary-rootcoord-dml_1"}},
+					{ClusterId: "by-dev", Pchannels: []string{"by-dev-rootcoord-dml_0", "by-dev-rootcoord-dml_1"}},
+				},
+				CrossClusterTopology: []*commonpb.CrossClusterTopology{
+					{SourceClusterId: "primary", TargetClusterId: "by-dev"},
+				},
+			},
+		), nil).Maybe()
+
+		h := mock_handler.NewMockHandlerClient(t)
+		p := mock_producer.NewMockProducer(t)
+		p.EXPECT().Append(mock.Anything, mock.Anything).Return(&types.AppendResult{
+			MessageID: walimplstest.NewTestMessageID(1),
+			TimeTick:  1,
+		}, nil).Maybe()
+		p.EXPECT().IsAvailable().Return(true).Maybe()
+		p.EXPECT().Available().Return(make(chan struct{})).Maybe()
+		h.EXPECT().CreateProducer(mock.Anything, mock.Anything).Return(p, nil).Maybe()
+
+		return &replicateService{
+			walAccesserImpl: &walAccesserImpl{
+				lifetime:             typeutil.NewLifetime(),
+				clusterID:            "by-dev",
+				streamingCoordClient: c,
+				handlerClient:        h,
+				producers:            make(map[string]*producer.ResumableProducer),
+			},
+		}
+	}
+
+	t.Run("skip_AlterResourceGroup", func(t *testing.T) {
+		old := paramtable.Get().StreamingCfg.ReplicationSkipMessageTypes.SwapTempValue("AlterResourceGroup,DropResourceGroup")
+		defer paramtable.Get().StreamingCfg.ReplicationSkipMessageTypes.SwapTempValue(old)
+
+		rs := newReplicateService(t)
+		broadcastMsg := message.NewAlterResourceGroupMessageBuilderV2().
+			WithHeader(&message.AlterResourceGroupMessageHeader{}).
+			WithBody(&message.AlterResourceGroupMessageBody{}).
+			WithBroadcast([]string{"primary-rootcoord-dml_0_cchannel"}).
+			MustBuildBroadcast()
+		msgs := broadcastMsgToReplicateMsgs(broadcastMsg)
+		for _, msg := range msgs {
+			_, err := rs.Append(context.Background(), msg)
+			assert.Error(t, err)
+			se := status.AsStreamingError(err)
+			assert.NotNil(t, se)
+			assert.True(t, se.IsIgnoredOperation())
+		}
+	})
+
+	t.Run("skip_DropResourceGroup", func(t *testing.T) {
+		old := paramtable.Get().StreamingCfg.ReplicationSkipMessageTypes.SwapTempValue("AlterResourceGroup,DropResourceGroup")
+		defer paramtable.Get().StreamingCfg.ReplicationSkipMessageTypes.SwapTempValue(old)
+
+		rs := newReplicateService(t)
+		broadcastMsg := message.NewDropResourceGroupMessageBuilderV2().
+			WithHeader(&message.DropResourceGroupMessageHeader{ResourceGroupName: "test_rg"}).
+			WithBody(&message.DropResourceGroupMessageBody{}).
+			WithBroadcast([]string{"primary-rootcoord-dml_0_cchannel"}).
+			MustBuildBroadcast()
+		msgs := broadcastMsgToReplicateMsgs(broadcastMsg)
+		for _, msg := range msgs {
+			_, err := rs.Append(context.Background(), msg)
+			assert.Error(t, err)
+			se := status.AsStreamingError(err)
+			assert.NotNil(t, se)
+			assert.True(t, se.IsIgnoredOperation())
+		}
+	})
+
+	t.Run("non_skipped_message_passthrough", func(t *testing.T) {
+		old := paramtable.Get().StreamingCfg.ReplicationSkipMessageTypes.SwapTempValue("AlterResourceGroup,DropResourceGroup")
+		defer paramtable.Get().StreamingCfg.ReplicationSkipMessageTypes.SwapTempValue(old)
+
+		rs := newReplicateService(t)
+		replicateMsgs := createReplicateCreateCollectionMessages()
+		for _, msg := range replicateMsgs {
+			_, err := rs.Append(context.Background(), msg)
+			assert.NoError(t, err)
+		}
+	})
+
+	t.Run("empty_skip_list", func(t *testing.T) {
+		old := paramtable.Get().StreamingCfg.ReplicationSkipMessageTypes.SwapTempValue("")
+		defer paramtable.Get().StreamingCfg.ReplicationSkipMessageTypes.SwapTempValue(old)
+
+		rs := newReplicateService(t)
+		replicateMsgs := createReplicateCreateCollectionMessages()
+		for _, msg := range replicateMsgs {
+			_, err := rs.Append(context.Background(), msg)
+			assert.NoError(t, err)
+		}
+	})
+}
+
 func createReplicateAlterLoadConfigMessages() []message.ReplicateMutableMessage {
 	msg := message.NewAlterLoadConfigMessageBuilderV2().
 		WithHeader(&message.AlterLoadConfigMessageHeader{
@@ -321,6 +426,18 @@ func createReplicateAlterLoadConfigMessages() []message.ReplicateMutableMessage 
 		immutableMsg := msg.WithLastConfirmedUseMessageID().WithTimeTick(1).IntoImmutableMessage(
 			pulsar2.NewPulsarID(pulsar.NewMessageID(1, 2, 3, 4)),
 		)
+		replicateMsgs = append(replicateMsgs, message.MustNewReplicateMessage("primary", immutableMsg.IntoImmutableMessageProto()))
+	}
+	return replicateMsgs
+}
+
+func broadcastMsgToReplicateMsgs(broadcastMsg message.BroadcastMutableMessage) []message.ReplicateMutableMessage {
+	msgs := broadcastMsg.WithBroadcastID(200).SplitIntoMutableMessage()
+	replicateMsgs := make([]message.ReplicateMutableMessage, 0, len(msgs))
+	for _, msg := range msgs {
+		immutableMsg := msg.WithLastConfirmedUseMessageID().WithTimeTick(1).IntoImmutableMessage(pulsar2.NewPulsarID(
+			pulsar.NewMessageID(1, 2, 3, 4),
+		))
 		replicateMsgs = append(replicateMsgs, message.MustNewReplicateMessage("primary", immutableMsg.IntoImmutableMessageProto()))
 	}
 	return replicateMsgs

--- a/internal/distributed/streaming/replicate_service_test.go
+++ b/internal/distributed/streaming/replicate_service_test.go
@@ -303,7 +303,7 @@ func TestReplicateService_AlterLoadConfigUseLocalReplicaConfig(t *testing.T) {
 }
 
 func TestReplicateService_SkipMessageTypes(t *testing.T) {
-	newReplicateService := func(t *testing.T) *replicateService {
+	newReplicateService := func(t *testing.T, skipTypes map[string]struct{}) *replicateService {
 		c := mock_client.NewMockClient(t)
 		as := mock_client.NewMockAssignmentService(t)
 		c.EXPECT().Assignment().Return(as).Maybe()
@@ -338,14 +338,14 @@ func TestReplicateService_SkipMessageTypes(t *testing.T) {
 				handlerClient:        h,
 				producers:            make(map[string]*producer.ResumableProducer),
 			},
+			skipMessageTypes: skipTypes,
 		}
 	}
 
-	t.Run("skip_AlterResourceGroup", func(t *testing.T) {
-		old := paramtable.Get().StreamingCfg.ReplicationSkipMessageTypes.SwapTempValue("AlterResourceGroup,DropResourceGroup")
-		defer paramtable.Get().StreamingCfg.ReplicationSkipMessageTypes.SwapTempValue(old)
+	skipSet := buildSkipMessageTypes([]string{"AlterResourceGroup", "DropResourceGroup"})
 
-		rs := newReplicateService(t)
+	t.Run("skip_AlterResourceGroup", func(t *testing.T) {
+		rs := newReplicateService(t, skipSet)
 		broadcastMsg := message.NewAlterResourceGroupMessageBuilderV2().
 			WithHeader(&message.AlterResourceGroupMessageHeader{}).
 			WithBody(&message.AlterResourceGroupMessageBody{}).
@@ -362,10 +362,7 @@ func TestReplicateService_SkipMessageTypes(t *testing.T) {
 	})
 
 	t.Run("skip_DropResourceGroup", func(t *testing.T) {
-		old := paramtable.Get().StreamingCfg.ReplicationSkipMessageTypes.SwapTempValue("AlterResourceGroup,DropResourceGroup")
-		defer paramtable.Get().StreamingCfg.ReplicationSkipMessageTypes.SwapTempValue(old)
-
-		rs := newReplicateService(t)
+		rs := newReplicateService(t, skipSet)
 		broadcastMsg := message.NewDropResourceGroupMessageBuilderV2().
 			WithHeader(&message.DropResourceGroupMessageHeader{ResourceGroupName: "test_rg"}).
 			WithBody(&message.DropResourceGroupMessageBody{}).
@@ -382,10 +379,7 @@ func TestReplicateService_SkipMessageTypes(t *testing.T) {
 	})
 
 	t.Run("non_skipped_message_passthrough", func(t *testing.T) {
-		old := paramtable.Get().StreamingCfg.ReplicationSkipMessageTypes.SwapTempValue("AlterResourceGroup,DropResourceGroup")
-		defer paramtable.Get().StreamingCfg.ReplicationSkipMessageTypes.SwapTempValue(old)
-
-		rs := newReplicateService(t)
+		rs := newReplicateService(t, skipSet)
 		replicateMsgs := createReplicateCreateCollectionMessages()
 		for _, msg := range replicateMsgs {
 			_, err := rs.Append(context.Background(), msg)
@@ -394,15 +388,35 @@ func TestReplicateService_SkipMessageTypes(t *testing.T) {
 	})
 
 	t.Run("empty_skip_list", func(t *testing.T) {
-		old := paramtable.Get().StreamingCfg.ReplicationSkipMessageTypes.SwapTempValue("")
-		defer paramtable.Get().StreamingCfg.ReplicationSkipMessageTypes.SwapTempValue(old)
-
-		rs := newReplicateService(t)
+		rs := newReplicateService(t, buildSkipMessageTypes(nil))
 		replicateMsgs := createReplicateCreateCollectionMessages()
 		for _, msg := range replicateMsgs {
 			_, err := rs.Append(context.Background(), msg)
 			assert.NoError(t, err)
 		}
+	})
+}
+
+func TestBuildSkipMessageTypes(t *testing.T) {
+	t.Run("normal", func(t *testing.T) {
+		m := buildSkipMessageTypes([]string{"AlterResourceGroup", "DropResourceGroup"})
+		assert.Len(t, m, 2)
+		_, ok := m["AlterResourceGroup"]
+		assert.True(t, ok)
+		_, ok = m["DropResourceGroup"]
+		assert.True(t, ok)
+	})
+
+	t.Run("empty_strings_filtered", func(t *testing.T) {
+		m := buildSkipMessageTypes([]string{"", "AlterResourceGroup", ""})
+		assert.Len(t, m, 1)
+		_, ok := m["AlterResourceGroup"]
+		assert.True(t, ok)
+	})
+
+	t.Run("nil_input", func(t *testing.T) {
+		m := buildSkipMessageTypes(nil)
+		assert.Empty(t, m)
 	})
 }
 

--- a/internal/distributed/streaming/wal.go
+++ b/internal/distributed/streaming/wal.go
@@ -70,7 +70,10 @@ func (w *walAccesserImpl) ForwardService() ForwardService {
 }
 
 func (w *walAccesserImpl) Replicate() ReplicateService {
-	return replicateService{w}
+	return replicateService{
+		walAccesserImpl:  w,
+		skipMessageTypes: buildSkipMessageTypes(paramtable.Get().StreamingCfg.ReplicationSkipMessageTypes.GetAsStrings()),
+	}
 }
 
 func (w *walAccesserImpl) Balancer() Balancer {

--- a/internal/proxy/replicate/replicate_stream_server.go
+++ b/internal/proxy/replicate/replicate_stream_server.go
@@ -133,6 +133,7 @@ func (p *ReplicateStreamServer) handleReplicateMessage(req *milvuspb.ReplicateRe
 	}
 	if status.AsStreamingError(err).IsIgnoredOperation() {
 		log.Info("append replicate message to wal ignored", log.FieldMessage(msg), zap.Error(err))
+		p.sendReplicateResult(sourceTs, msg)
 		return nil
 	}
 	// unexpected error, will close the stream and wait for client to reconnect.

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -6716,6 +6716,9 @@ type streamingConfig struct {
 
 	// Replication configuration
 	ReplicationUseLocalReplicaConfig ParamItem `refreshable:"true"`
+
+	// Replication filtering configuration
+	ReplicationSkipMessageTypes ParamItem `refreshable:"true"`
 }
 
 func (p *streamingConfig) init(base *BaseTable) {
@@ -7114,6 +7117,15 @@ so we set 1 second here as a threshold.`,
 		Export:       false,
 	}
 	p.ReplicationUseLocalReplicaConfig.Init(base.mgr)
+
+	p.ReplicationSkipMessageTypes = ParamItem{
+		Key:          "streaming.replication.skipMessageTypes",
+		Version:      "2.6.11",
+		Doc:          `Comma-separated list of message type names to skip when replicating to a secondary cluster. Messages of these types will be ignored by the secondary's replicate stream server.`,
+		DefaultValue: "AlterResourceGroup,DropResourceGroup",
+		Export:       false,
+	}
+	p.ReplicationSkipMessageTypes.Init(base.mgr)
 }
 
 // runtimeConfig is just a private environment value table.

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -6718,7 +6718,7 @@ type streamingConfig struct {
 	ReplicationUseLocalReplicaConfig ParamItem `refreshable:"true"`
 
 	// Replication filtering configuration
-	ReplicationSkipMessageTypes ParamItem `refreshable:"true"`
+	ReplicationSkipMessageTypes ParamItem `refreshable:"false"`
 }
 
 func (p *streamingConfig) init(base *BaseTable) {


### PR DESCRIPTION
- Add `streaming.replication.skipMessageTypes` config parameter (comma-separated message type names, default `AlterResourceGroup,DropResourceGroup`)
- On the secondary side, `overwriteReplicateMessage()` checks incoming message type against skip set and returns `IgnoreOperation`, which `ReplicateStreamServer` already handles gracefully
- Configurable at runtime (refreshable)

issue: https://github.com/milvus-io/milvus/issues/47776