### PR TITLE
fix: Validate dynamic field names and optimize static field check

### DIFF
--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -2421,6 +2421,11 @@ func verifyDynamicFieldData(schema *schemapb.CollectionSchema, insertMsg *msgstr
 			if !schema.EnableDynamicField {
 				return fmt.Errorf("without dynamic schema enabled, the field name cannot be set to %s", common.MetaFieldName)
 			}
+			staticFieldNames := make(map[string]struct{}, len(schema.GetFields()))
+			for _, f := range schema.GetFields() {
+				staticFieldNames[f.GetName()] = struct{}{}
+			}
+			validatedKeys := make(map[string]struct{})
 			for _, rowData := range field.GetScalars().GetJsonData().GetData() {
 				jsonData := make(map[string]interface{})
 				if err := json.Unmarshal(rowData, &jsonData); err != nil {
@@ -2433,10 +2438,16 @@ func verifyDynamicFieldData(schema *schemapb.CollectionSchema, insertMsg *msgstr
 				if _, ok := jsonData[common.MetaFieldName]; ok {
 					return fmt.Errorf("cannot set json key to: %s", common.MetaFieldName)
 				}
-				for _, f := range schema.GetFields() {
-					if _, ok := jsonData[f.GetName()]; ok {
-						log.Info("dynamic field name include the static field name", zap.String("fieldName", f.GetName()))
-						return fmt.Errorf("dynamic field name cannot include the static field name: %s", f.GetName())
+				for key := range jsonData {
+					if _, ok := staticFieldNames[key]; ok {
+						log.Info("dynamic field name include the static field name", zap.String("fieldName", key))
+						return fmt.Errorf("dynamic field name cannot include the static field name: %s", key)
+					}
+					if _, ok := validatedKeys[key]; !ok {
+						if err := validateFieldName(key); err != nil {
+							return err
+						}
+						validatedKeys[key] = struct{}{}
 					}
 				}
 			}

--- a/internal/proxy/util_test.go
+++ b/internal/proxy/util_test.go
@@ -2295,6 +2295,69 @@ func Test_CheckDynamicFieldData(t *testing.T) {
 		err := checkDynamicFieldData(schema, insertMsg)
 		assert.NoError(t, err)
 	})
+	t.Run("invalid dynamic field name starting with number", func(t *testing.T) {
+		jsonData := make([][]byte, 0)
+		data := map[string]interface{}{
+			"123field": "value",
+		}
+		jsonBytes, err := json.Marshal(data)
+		assert.NoError(t, err)
+		jsonData = append(jsonData, jsonBytes)
+		jsonFieldData := autoGenDynamicFieldData(jsonData)
+		schema := newTestSchema()
+		insertMsg := &msgstream.InsertMsg{
+			InsertRequest: &msgpb.InsertRequest{
+				CollectionName: "collectionName",
+				FieldsData:     []*schemapb.FieldData{jsonFieldData},
+				NumRows:        1,
+				Version:        msgpb.InsertDataVersion_ColumnBased,
+			},
+		}
+		err = checkDynamicFieldData(schema, insertMsg)
+		assert.Error(t, err)
+	})
+	t.Run("invalid dynamic field name with special char", func(t *testing.T) {
+		jsonData := make([][]byte, 0)
+		data := map[string]interface{}{
+			"my-field": "value",
+		}
+		jsonBytes, err := json.Marshal(data)
+		assert.NoError(t, err)
+		jsonData = append(jsonData, jsonBytes)
+		jsonFieldData := autoGenDynamicFieldData(jsonData)
+		schema := newTestSchema()
+		insertMsg := &msgstream.InsertMsg{
+			InsertRequest: &msgpb.InsertRequest{
+				CollectionName: "collectionName",
+				FieldsData:     []*schemapb.FieldData{jsonFieldData},
+				NumRows:        1,
+				Version:        msgpb.InsertDataVersion_ColumnBased,
+			},
+		}
+		err = checkDynamicFieldData(schema, insertMsg)
+		assert.Error(t, err)
+	})
+	t.Run("invalid dynamic field name with at sign", func(t *testing.T) {
+		jsonData := make([][]byte, 0)
+		data := map[string]interface{}{
+			"@field": "value",
+		}
+		jsonBytes, err := json.Marshal(data)
+		assert.NoError(t, err)
+		jsonData = append(jsonData, jsonBytes)
+		jsonFieldData := autoGenDynamicFieldData(jsonData)
+		schema := newTestSchema()
+		insertMsg := &msgstream.InsertMsg{
+			InsertRequest: &msgpb.InsertRequest{
+				CollectionName: "collectionName",
+				FieldsData:     []*schemapb.FieldData{jsonFieldData},
+				NumRows:        1,
+				Version:        msgpb.InsertDataVersion_ColumnBased,
+			},
+		}
+		err = checkDynamicFieldData(schema, insertMsg)
+		assert.Error(t, err)
+	})
 }
 
 func Test_validateMaxCapacityPerRow(t *testing.T) {


### PR DESCRIPTION
fix #47763
Add field name validation for dynamic field keys to reject invalid names (e.g., starting with numbers, containing special characters). Also optimize the static field name collision check by using a map lookup instead of iterating over schema fields for each row.