### PR TITLE
fix: Add data type validation for dynamic fields to prevent type inconsistency

### DIFF
--- a/internal/proxy/meta_cache.go
+++ b/internal/proxy/meta_cache.go
@@ -122,11 +122,12 @@ type databaseInfo struct {
 // with extra fields mapping and methods
 type schemaInfo struct {
 	*schemapb.CollectionSchema
-	fieldMap              *typeutil.ConcurrentMap[string, int64] // field name to id mapping
+	fieldMap              *typeutil.ConcurrentMap[string, int64]  // field name to id mapping
 	hasPartitionKeyField  bool
 	pkField               *schemapb.FieldSchema
-	multiAnalyzerFieldMap *typeutil.ConcurrentMap[int64, int64] // multi analzyer field id to dependent field id mapping
+	multiAnalyzerFieldMap *typeutil.ConcurrentMap[int64, int64]  // multi analzyer field id to dependent field id mapping
 	schemaHelper          *typeutil.SchemaHelper
+	dynamicFieldTypes     *typeutil.ConcurrentMap[string, string] // tracks JSON value types per dynamic field key
 }
 
 func newSchemaInfo(schema *schemapb.CollectionSchema) *schemaInfo {
@@ -158,6 +159,7 @@ func newSchemaInfo(schema *schemapb.CollectionSchema) *schemaInfo {
 		pkField:               pkField,
 		multiAnalyzerFieldMap: typeutil.NewConcurrentMap[int64, int64](),
 		schemaHelper:          schemaHelper,
+		dynamicFieldTypes:     typeutil.NewConcurrentMap[string, string](),
 	}
 }
 

--- a/internal/proxy/task_insert.go
+++ b/internal/proxy/task_insert.go
@@ -196,8 +196,8 @@ func (it *insertTask) PreExecute(ctx context.Context) error {
 	}
 	it.result.SuccIndex = sliceIndex
 
-	if it.schema.EnableDynamicField {
-		err = checkDynamicFieldData(it.schema, it.insertMsg)
+	if schema.EnableDynamicField {
+		err = checkDynamicFieldData(schema, it.insertMsg)
 		if err != nil {
 			return err
 		}

--- a/internal/proxy/task_upsert.go
+++ b/internal/proxy/task_upsert.go
@@ -1074,7 +1074,7 @@ func (it *upsertTask) insertPreExecute(ctx context.Context) error {
 	it.result.SuccIndex = sliceIndex
 
 	if it.schema.EnableDynamicField {
-		err := checkDynamicFieldData(it.schema.CollectionSchema, it.upsertMsg.InsertMsg)
+		err := checkDynamicFieldData(it.schema, it.upsertMsg.InsertMsg)
 		if err != nil {
 			return err
 		}

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -2415,12 +2415,36 @@ func ErrWithLog(logger *log.MLogger, msg string, err error) error {
 	return wrapErr
 }
 
-func verifyDynamicFieldData(schema *schemapb.CollectionSchema, insertMsg *msgstream.InsertMsg) error {
+// jsonValueType classifies a Go value produced by json.Unmarshal into
+// map[string]interface{} and returns its JSON type name.
+func jsonValueType(v interface{}) string {
+	switch v.(type) {
+	case string:
+		return "string"
+	case float64:
+		return "number"
+	case bool:
+		return "bool"
+	case nil:
+		return "null"
+	case map[string]interface{}:
+		return "object"
+	case []interface{}:
+		return "array"
+	default:
+		return "unknown"
+	}
+}
+
+func verifyDynamicFieldData(schema *schemaInfo, insertMsg *msgstream.InsertMsg) error {
 	for _, field := range insertMsg.FieldsData {
 		if field.GetFieldName() == common.MetaFieldName {
 			if !schema.EnableDynamicField {
 				return fmt.Errorf("without dynamic schema enabled, the field name cannot be set to %s", common.MetaFieldName)
 			}
+
+			// Phase 1: validate all rows and check intra-batch type consistency
+			batchTypes := make(map[string]string)
 			for _, rowData := range field.GetScalars().GetJsonData().GetData() {
 				jsonData := make(map[string]interface{})
 				if err := json.Unmarshal(rowData, &jsonData); err != nil {
@@ -2439,6 +2463,28 @@ func verifyDynamicFieldData(schema *schemapb.CollectionSchema, insertMsg *msgstr
 						return fmt.Errorf("dynamic field name cannot include the static field name: %s", f.GetName())
 					}
 				}
+
+				for key, value := range jsonData {
+					valType := jsonValueType(value)
+					if valType == "null" {
+						continue
+					}
+					if existing, ok := batchTypes[key]; ok {
+						if existing != valType {
+							return fmt.Errorf("dynamic field '%s' expects type %s but got %s", key, existing, valType)
+						}
+					} else {
+						batchTypes[key] = valType
+					}
+				}
+			}
+
+			// Phase 2: check cross-batch type consistency and register new types
+			for key, valType := range batchTypes {
+				existing, loaded := schema.dynamicFieldTypes.GetOrInsert(key, valType)
+				if loaded && existing != valType {
+					return fmt.Errorf("dynamic field '%s' expects type %s but got %s", key, existing, valType)
+				}
 			}
 		}
 	}
@@ -2446,7 +2492,7 @@ func verifyDynamicFieldData(schema *schemapb.CollectionSchema, insertMsg *msgstr
 	return nil
 }
 
-func checkDynamicFieldData(schema *schemapb.CollectionSchema, insertMsg *msgstream.InsertMsg) error {
+func checkDynamicFieldData(schema *schemaInfo, insertMsg *msgstream.InsertMsg) error {
 	for _, data := range insertMsg.FieldsData {
 		if data.IsDynamic {
 			data.FieldName = common.MetaFieldName

--- a/internal/proxy/util_test.go
+++ b/internal/proxy/util_test.go
@@ -2168,7 +2168,7 @@ func Test_CheckDynamicFieldData(t *testing.T) {
 		assert.NoError(t, err)
 		jsonData = append(jsonData, jsonBytes)
 		jsonFieldData := autoGenDynamicFieldData(jsonData)
-		schema := newTestSchema()
+		schema := newSchemaInfo(newTestSchema())
 		insertMsg := &msgstream.InsertMsg{
 			InsertRequest: &msgpb.InsertRequest{
 				CollectionName: "collectionName",
@@ -2197,7 +2197,7 @@ func Test_CheckDynamicFieldData(t *testing.T) {
 		assert.NoError(t, err)
 		jsonData = append(jsonData, jsonBytes)
 		jsonFieldData := autoGenDynamicFieldData(jsonData)
-		schema := newTestSchema()
+		schema := newSchemaInfo(newTestSchema())
 		insertMsg := &msgstream.InsertMsg{
 			InsertRequest: &msgpb.InsertRequest{
 				CollectionName: "collectionName",
@@ -2226,7 +2226,7 @@ func Test_CheckDynamicFieldData(t *testing.T) {
 		assert.NoError(t, err)
 		jsonData = append(jsonData, jsonBytes)
 		jsonFieldData := autoGenDynamicFieldData(jsonData)
-		schema := newTestSchema()
+		schema := newSchemaInfo(newTestSchema())
 		insertMsg := &msgstream.InsertMsg{
 			InsertRequest: &msgpb.InsertRequest{
 				CollectionName: "collectionName",
@@ -2254,7 +2254,9 @@ func Test_CheckDynamicFieldData(t *testing.T) {
 		assert.NoError(t, err)
 		jsonData = append(jsonData, jsonBytes)
 		jsonFieldData := autoGenDynamicFieldData(jsonData)
-		schema := newTestSchema()
+		rawSchema := newTestSchema()
+		rawSchema.EnableDynamicField = false
+		schema := newSchemaInfo(rawSchema)
 		insertMsg := &msgstream.InsertMsg{
 			InsertRequest: &msgpb.InsertRequest{
 				CollectionName: "collectionName",
@@ -2263,14 +2265,13 @@ func Test_CheckDynamicFieldData(t *testing.T) {
 				Version:        msgpb.InsertDataVersion_ColumnBased,
 			},
 		}
-		schema.EnableDynamicField = false
 		err = checkDynamicFieldData(schema, insertMsg)
 		assert.Error(t, err)
 	})
 	t.Run("json data is string", func(t *testing.T) {
 		data := "abcdefg"
 		jsonFieldData := autoGenDynamicFieldData([][]byte{[]byte(data)})
-		schema := newTestSchema()
+		schema := newSchemaInfo(newTestSchema())
 		insertMsg := &msgstream.InsertMsg{
 			InsertRequest: &msgpb.InsertRequest{
 				CollectionName: "collectionName",
@@ -2283,7 +2284,7 @@ func Test_CheckDynamicFieldData(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("no json data", func(t *testing.T) {
-		schema := newTestSchema()
+		schema := newSchemaInfo(newTestSchema())
 		insertMsg := &msgstream.InsertMsg{
 			InsertRequest: &msgpb.InsertRequest{
 				CollectionName: "collectionName",
@@ -2295,6 +2296,166 @@ func Test_CheckDynamicFieldData(t *testing.T) {
 		err := checkDynamicFieldData(schema, insertMsg)
 		assert.NoError(t, err)
 	})
+	t.Run("intra-batch type mismatch", func(t *testing.T) {
+		row1, _ := json.Marshal(map[string]interface{}{"text_field": "hello"})
+		row2, _ := json.Marshal(map[string]interface{}{"text_field": 12345})
+		jsonFieldData := autoGenDynamicFieldData([][]byte{row1, row2})
+		schema := newSchemaInfo(newTestSchema())
+		insertMsg := &msgstream.InsertMsg{
+			InsertRequest: &msgpb.InsertRequest{
+				CollectionName: "collectionName",
+				FieldsData:     []*schemapb.FieldData{jsonFieldData},
+				NumRows:        2,
+				Version:        msgpb.InsertDataVersion_ColumnBased,
+			},
+		}
+		err := checkDynamicFieldData(schema, insertMsg)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "text_field")
+		assert.Contains(t, err.Error(), "string")
+		assert.Contains(t, err.Error(), "number")
+	})
+	t.Run("intra-batch type consistent", func(t *testing.T) {
+		row1, _ := json.Marshal(map[string]interface{}{"text_field": "hello"})
+		row2, _ := json.Marshal(map[string]interface{}{"text_field": "world"})
+		jsonFieldData := autoGenDynamicFieldData([][]byte{row1, row2})
+		schema := newSchemaInfo(newTestSchema())
+		insertMsg := &msgstream.InsertMsg{
+			InsertRequest: &msgpb.InsertRequest{
+				CollectionName: "collectionName",
+				FieldsData:     []*schemapb.FieldData{jsonFieldData},
+				NumRows:        2,
+				Version:        msgpb.InsertDataVersion_ColumnBased,
+			},
+		}
+		err := checkDynamicFieldData(schema, insertMsg)
+		assert.NoError(t, err)
+	})
+	t.Run("cross-batch type mismatch", func(t *testing.T) {
+		schema := newSchemaInfo(newTestSchema())
+
+		// First batch: establish text_field as string
+		row1, _ := json.Marshal(map[string]interface{}{"text_field": "hello"})
+		jsonFieldData1 := autoGenDynamicFieldData([][]byte{row1})
+		insertMsg1 := &msgstream.InsertMsg{
+			InsertRequest: &msgpb.InsertRequest{
+				CollectionName: "collectionName",
+				FieldsData:     []*schemapb.FieldData{jsonFieldData1},
+				NumRows:        1,
+				Version:        msgpb.InsertDataVersion_ColumnBased,
+			},
+		}
+		err := checkDynamicFieldData(schema, insertMsg1)
+		assert.NoError(t, err)
+
+		// Second batch: insert integer for same field
+		row2, _ := json.Marshal(map[string]interface{}{"text_field": 12345})
+		jsonFieldData2 := autoGenDynamicFieldData([][]byte{row2})
+		insertMsg2 := &msgstream.InsertMsg{
+			InsertRequest: &msgpb.InsertRequest{
+				CollectionName: "collectionName",
+				FieldsData:     []*schemapb.FieldData{jsonFieldData2},
+				NumRows:        1,
+				Version:        msgpb.InsertDataVersion_ColumnBased,
+			},
+		}
+		err = checkDynamicFieldData(schema, insertMsg2)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "text_field")
+		assert.Contains(t, err.Error(), "string")
+		assert.Contains(t, err.Error(), "number")
+	})
+	t.Run("cross-batch type consistent", func(t *testing.T) {
+		schema := newSchemaInfo(newTestSchema())
+
+		// First batch
+		row1, _ := json.Marshal(map[string]interface{}{"text_field": "hello"})
+		jsonFieldData1 := autoGenDynamicFieldData([][]byte{row1})
+		insertMsg1 := &msgstream.InsertMsg{
+			InsertRequest: &msgpb.InsertRequest{
+				CollectionName: "collectionName",
+				FieldsData:     []*schemapb.FieldData{jsonFieldData1},
+				NumRows:        1,
+				Version:        msgpb.InsertDataVersion_ColumnBased,
+			},
+		}
+		err := checkDynamicFieldData(schema, insertMsg1)
+		assert.NoError(t, err)
+
+		// Second batch: same type
+		row2, _ := json.Marshal(map[string]interface{}{"text_field": "world"})
+		jsonFieldData2 := autoGenDynamicFieldData([][]byte{row2})
+		insertMsg2 := &msgstream.InsertMsg{
+			InsertRequest: &msgpb.InsertRequest{
+				CollectionName: "collectionName",
+				FieldsData:     []*schemapb.FieldData{jsonFieldData2},
+				NumRows:        1,
+				Version:        msgpb.InsertDataVersion_ColumnBased,
+			},
+		}
+		err = checkDynamicFieldData(schema, insertMsg2)
+		assert.NoError(t, err)
+	})
+	t.Run("null value compatible with any type", func(t *testing.T) {
+		schema := newSchemaInfo(newTestSchema())
+
+		// First batch: establish text_field as string
+		row1, _ := json.Marshal(map[string]interface{}{"text_field": "hello"})
+		jsonFieldData1 := autoGenDynamicFieldData([][]byte{row1})
+		insertMsg1 := &msgstream.InsertMsg{
+			InsertRequest: &msgpb.InsertRequest{
+				CollectionName: "collectionName",
+				FieldsData:     []*schemapb.FieldData{jsonFieldData1},
+				NumRows:        1,
+				Version:        msgpb.InsertDataVersion_ColumnBased,
+			},
+		}
+		err := checkDynamicFieldData(schema, insertMsg1)
+		assert.NoError(t, err)
+
+		// Second batch: null for same field should be accepted
+		row2, _ := json.Marshal(map[string]interface{}{"text_field": nil})
+		jsonFieldData2 := autoGenDynamicFieldData([][]byte{row2})
+		insertMsg2 := &msgstream.InsertMsg{
+			InsertRequest: &msgpb.InsertRequest{
+				CollectionName: "collectionName",
+				FieldsData:     []*schemapb.FieldData{jsonFieldData2},
+				NumRows:        1,
+				Version:        msgpb.InsertDataVersion_ColumnBased,
+			},
+		}
+		err = checkDynamicFieldData(schema, insertMsg2)
+		assert.NoError(t, err)
+	})
+	t.Run("different keys different types allowed", func(t *testing.T) {
+		row1, _ := json.Marshal(map[string]interface{}{
+			"bool_field":   true,
+			"int_field":    100,
+			"string_field": "abc",
+		})
+		jsonFieldData := autoGenDynamicFieldData([][]byte{row1})
+		schema := newSchemaInfo(newTestSchema())
+		insertMsg := &msgstream.InsertMsg{
+			InsertRequest: &msgpb.InsertRequest{
+				CollectionName: "collectionName",
+				FieldsData:     []*schemapb.FieldData{jsonFieldData},
+				NumRows:        1,
+				Version:        msgpb.InsertDataVersion_ColumnBased,
+			},
+		}
+		err := checkDynamicFieldData(schema, insertMsg)
+		assert.NoError(t, err)
+	})
+}
+
+func Test_jsonValueType(t *testing.T) {
+	assert.Equal(t, "string", jsonValueType("hello"))
+	assert.Equal(t, "number", jsonValueType(float64(123)))
+	assert.Equal(t, "bool", jsonValueType(true))
+	assert.Equal(t, "null", jsonValueType(nil))
+	assert.Equal(t, "object", jsonValueType(map[string]interface{}{"a": 1}))
+	assert.Equal(t, "array", jsonValueType([]interface{}{1, 2}))
+	assert.Equal(t, "unknown", jsonValueType(struct{}{}))
 }
 
 func Test_validateMaxCapacityPerRow(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add data type consistency validation for dynamic fields during insert/upsert operations
- When a dynamic field key is first seen with a particular JSON type (string, number, bool, etc.), subsequent inserts with a different type for the same key are now rejected
- Fixes #47766 

## Details

Dynamic fields stored in the `$meta` JSON column previously accepted any value type without validation, allowing the same field key to hold both strings and integers across different inserts. This violates the documented schema consistency requirement.

### Changes:
- Added `dynamicFieldTypes` type registry to `schemaInfo` in `meta_cache.go`
- Added `jsonValueType()` helper and two-phase validation (intra-batch + cross-batch) in `verifyDynamicFieldData()`
- Updated `checkDynamicFieldData()` signature to accept `*schemaInfo` instead of raw `*CollectionSchema`
- Updated callers in `task_insert.go` and `task_upsert.go`

### Error example after this fix:

## Test plan

- [x] Updated all existing `Test_CheckDynamicFieldData` tests
- [x] Added intra-batch type mismatch test
- [x] Added intra-batch type consistent test
- [x] Added cross-batch type mismatch test (reproduces the exact bug from #47766)
- [x] Added cross-batch type consistent test
- [x] Added null value compatibility test
- [x] Added different-keys-different-types test
- [x] Added `Test_jsonValueType` unit test

Signed-off-by: Suraj Desai