### PR TITLE
fix: pin libavrocpp revision to avoid fmt target mismatch

### DIFF
--- a/internal/core/conanfile.py
+++ b/internal/core/conanfile.py
@@ -44,7 +44,7 @@ class MilvusConan(ConanFile):
         "unordered_dense/4.4.0#6a855c992618cc4c63019109a2e47298",
         "geos/3.12.0#0b177c90c25a8ca210578fb9e2899c37",
         "icu/74.2#cd1937b9561b8950a2ae6311284c5813",
-        "libavrocpp/1.12.1@milvus/dev",
+        "libavrocpp/1.12.1@milvus/dev#edb1853b9ee08fde205c20219e159e32",
     )
 
     generators = ("cmake", "cmake_find_package")


### PR DESCRIPTION
## Summary
- Pin `libavrocpp/1.12.1@milvus/dev` to revision `#edb1853b9ee08fde205c20219e159e32` (2025-12-02)
- The new revision `f249d87...` uploaded on 2026-02-18 introduced a `fmt::fmt` link target dependency, which is incompatible with Milvus's `fmt:header_only=True` configuration (only `fmt::fmt-header-only` target is available)
- This causes CMake configure failure during CI: `Target "avrocpp_s" links to fmt::fmt but the target was not found`

## Test plan
- [ ] Verify CI cpp build passes with the pinned revision

Signed-off-by: huanghaoyuanhhy <haoyuan.huang@zilliz.com>