### PR TITLE
fix: pin libavrocpp revision and add cmake find module shim

### DIFF
--- a/internal/core/cmake/Findlibavrocpp.cmake
+++ b/internal/core/cmake/Findlibavrocpp.cmake
@@ -1,0 +1,38 @@
+# Findlibavrocpp.cmake
+# Bridge module for milvus-storage's find_package(libavrocpp) call.
+#
+# The libavrocpp conan recipe exports cmake_file_name="avro-cpp" and
+# cmake_target_name="avro-cpp::avrocpp_s", but milvus-storage expects
+# find_package(libavrocpp) and target libavrocpp::libavrocpp.
+# This module creates the expected target using conan variables.
+
+if(TARGET libavrocpp::libavrocpp)
+    set(libavrocpp_FOUND TRUE)
+    return()
+endif()
+
+if(CONAN_LIBAVROCPP_ROOT)
+    set(libavrocpp_FOUND TRUE)
+
+    # Collect transitive dependency include dirs needed by avro headers
+    # (avro/Exception.hh includes fmt/core.h, avro headers use boost, etc.)
+    set(_LIBAVROCPP_INCLUDE_DIRS
+        ${CONAN_INCLUDE_DIRS_LIBAVROCPP}
+        ${CONAN_INCLUDE_DIRS_FMT}
+        ${CONAN_INCLUDE_DIRS_BOOST}
+        ${CONAN_INCLUDE_DIRS_SNAPPY}
+        ${CONAN_INCLUDE_DIRS_ZLIB}
+    )
+
+    add_library(libavrocpp::libavrocpp INTERFACE IMPORTED)
+    set_target_properties(libavrocpp::libavrocpp PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${_LIBAVROCPP_INCLUDE_DIRS}"
+        INTERFACE_LINK_DIRECTORIES "${CONAN_LIB_DIRS_LIBAVROCPP}"
+        INTERFACE_LINK_LIBRARIES "${CONAN_LIBS_LIBAVROCPP}"
+    )
+else()
+    set(libavrocpp_FOUND FALSE)
+    if(libavrocpp_FIND_REQUIRED)
+        message(FATAL_ERROR "libavrocpp not found. Ensure it is installed via conan.")
+    endif()
+endif()

--- a/internal/core/conanfile.py
+++ b/internal/core/conanfile.py
@@ -44,7 +44,7 @@ class MilvusConan(ConanFile):
         "unordered_dense/4.4.0#6a855c992618cc4c63019109a2e47298",
         "geos/3.12.0#0b177c90c25a8ca210578fb9e2899c37",
         "icu/74.2#cd1937b9561b8950a2ae6311284c5813",
-        "libavrocpp/1.12.1@milvus/dev",
+        "libavrocpp/1.12.1@milvus/dev#edb1853b9ee08fde205c20219e159e32",
     )
 
     generators = ("cmake", "cmake_find_package")


### PR DESCRIPTION
issue: #47816

## Summary
- Pin `libavrocpp` conan recipe to a specific revision (`edb1853b9ee08fde205c20219e159e32`) to ensure reproducible builds
- Add `Findlibavrocpp.cmake` shim module to bridge the gap between conan's exported cmake target name (`avro-cpp::avrocpp_s`) and what milvus-storage expects (`libavrocpp::libavrocpp`)

## Test plan
- [ ] Verify C++ build succeeds with the pinned libavrocpp revision
- [ ] Verify milvus-storage can find and link libavrocpp correctly

Signed-off-by: huanghaoyuanhhy <haoyuan.huang@zilliz.com>