### PR TITLE
fix: avoid current working directory in library search path

### DIFF
--- a/scripts/setenv.sh
+++ b/scripts/setenv.sh
@@ -50,8 +50,8 @@ case "${unameOut}" in
       else
         echo "WARN: Cannot find $LIBJEMALLOC"
       fi
-      export PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:$ROOT_DIR/internal/core/output/lib/pkgconfig:$ROOT_DIR/internal/core/output/lib64/pkgconfig"
-      export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:$ROOT_DIR/internal/core/output/lib:$ROOT_DIR/internal/core/output/lib64"
+      export PKG_CONFIG_PATH="${PKG_CONFIG_PATH:+$PKG_CONFIG_PATH:}$ROOT_DIR/internal/core/output/lib/pkgconfig:$ROOT_DIR/internal/core/output/lib64/pkgconfig"
+      export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$ROOT_DIR/internal/core/output/lib:$ROOT_DIR/internal/core/output/lib64"
       export RPATH=$LD_LIBRARY_PATH;;
     Darwin*)
       # detect llvm version by valid list (supports LLVM 14-17)
@@ -80,12 +80,12 @@ case "${unameOut}" in
       export CGO_CFLAGS="${CFLAGS}"
       export CGO_LDFLAGS="${LDFLAGS} -framework Security -framework CoreFoundation"
 
-      export PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:$ROOT_DIR/internal/core/output/lib/pkgconfig"
+      export PKG_CONFIG_PATH="${PKG_CONFIG_PATH:+$PKG_CONFIG_PATH:}$ROOT_DIR/internal/core/output/lib/pkgconfig"
       export DYLD_LIBRARY_PATH=$ROOT_DIR/internal/core/output/lib
       export RPATH=$DYLD_LIBRARY_PATH;;
     MINGW*)
       extra_path=$(cygpath -w "$ROOT_DIR/internal/core/output/lib")
-      export PKG_CONFIG_PATH="${PKG_CONFIG_PATH};${extra_path}\pkgconfig"
+      export PKG_CONFIG_PATH="${PKG_CONFIG_PATH:+$PKG_CONFIG_PATH;}${extra_path}\pkgconfig"
       export LD_LIBRARY_PATH=$extra_path
       export RPATH=$LD_LIBRARY_PATH;;
     *)


### PR DESCRIPTION
On Linux, setenv.sh accidentally sets LD_LIBRARY_PATH and RPATH to look up shared objects in the current working directory first if nothing explicitly set an LD_LIBRARY_PATH already, because an empty path on either variable is interpreted as the current working directory. This results in races during parallel builds (e.g. tools invoked by Conan finding corrupt shared libraries, because said libraries are currently compiled and written out by another process in the build). Since the LD_LIBRARY_PATH is also used as the RPATH, the compiled Milvus binary also looks up shared objects in the current working directory, potentially picking up unintended versions of a shared object.

Fix this and similar "empty path" problems for other environment variables on Linux, macOS, and Windows by placing the path separator only if there are pre-existing paths.

issue: #47828 