### PR TITLE
test: fix snapshot checker row count mismatch in chaos test

### DIFF
--- a/tests/python_client/chaos/testcases/test_concurrent_operation.py
+++ b/tests/python_client/chaos/testcases/test_concurrent_operation.py
@@ -16,6 +16,7 @@ from chaos.checker import (InsertChecker,
                            GeoQueryChecker,
                            DeleteChecker,
                            AddFieldChecker,
+                           SnapshotChecker,
                            SnapshotRestoreChecker,
                            Op,
                            ResultAnalyzer
@@ -109,7 +110,8 @@ class TestOperations(TestBase):
             Op.geo_query: GeoQueryChecker(collection_name=c_name),
             Op.delete: DeleteChecker(collection_name=c_name),
             Op.add_field: AddFieldChecker(collection_name=c_name),
-            Op.restore_snapshot: SnapshotRestoreChecker(collection_name=c_name),
+            Op.snapshot: SnapshotChecker(collection_name=c_name),
+            Op.restore_snapshot: SnapshotRestoreChecker(),
         }
         log.info(f"init_health_checkers: {checkers}")
         self.health_checkers = checkers


### PR DESCRIPTION
## Summary
- Split snapshot testing into two checkers to fix row count mismatch failures in chaos tests
  - **SnapshotChecker** (`Op.snapshot`): lightweight, shares collection with other checkers, only verifies snapshot create/restore operations succeed
  - **SnapshotRestoreChecker** (`Op.restore_snapshot`): uses independent collection with internal DML operations, verifies data correctness (row count + PK) after restore
- Removed `_snapshot_lock` from `Checker` class and all DML checkers (Insert/Upsert/Delete) to eliminate coupling

## Root Cause
The `SnapshotRestoreChecker` shared a collection with other concurrent checkers and relied on a global `_snapshot_lock` to prevent data modifications during snapshot creation. However, some code paths (e.g., `Checker.insert_data()` base method, `DeleteChecker.update_delete_expr()` refill logic) bypassed the lock, causing row count mismatches after restore. The delta was exactly 3000 (`DELTA_PER_INS`).

Failure log: `expected=158188, actual=155188` (delta=3000)

ref: https://qa-jenkins.milvus.io/blue/organizations/jenkins/chaos-test-cron/detail/chaos-test-cron/23943/pipeline

## Test plan
- [ ] Run chaos-test-cron pipeline and verify `Op.snapshot` (shared collection) passes
- [ ] Verify `Op.restore_snapshot` (independent collection) passes with no row count mismatch
- [ ] Confirm other checkers (insert/upsert/delete) are not impacted by lock removal