### PR TITLE
enhance: support replace field data and indexes in LoadDiff framework

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -992,10 +992,13 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     search_ids(BitsetType& bitset, const IdArray& id_array) const override;
 
     void
-    LoadVecIndex(LoadIndexInfo& info);
+    LoadVecIndex(LoadIndexInfo& info, bool is_replace = false);
 
     void
-    LoadScalarIndex(LoadIndexInfo& info);
+    LoadScalarIndex(LoadIndexInfo& info, bool is_replace = false);
+
+    void
+    LoadIndex(LoadIndexInfo& info, bool is_replace);
 
     bool
     generate_interim_index(const FieldId field_id, int64_t num_rows);
@@ -1020,25 +1023,34 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                          size_t num_rows);
 
     void
+    LoadFieldData(const LoadFieldDataInfo& load_info,
+                  milvus::OpContext* op_ctx,
+                  bool is_replace);
+
+    void
     load_field_data_internal(const LoadFieldDataInfo& load_info,
-                             milvus::OpContext* op_ctx = nullptr);
+                             milvus::OpContext* op_ctx = nullptr,
+                             bool is_replace = false);
 
     void
     load_column_group_data_internal(const LoadFieldDataInfo& load_info,
-                                    milvus::OpContext* op_ctx = nullptr);
+                                    milvus::OpContext* op_ctx = nullptr,
+                                    bool is_replace = false);
 
     void
     LoadBatchIndexes(milvus::tracer::TraceContext& trace_ctx,
                      std::unordered_map<FieldId, std::vector<LoadIndexInfo>>&
                          field_id_to_index_info,
-                     milvus::OpContext* op_ctx = nullptr);
+                     milvus::OpContext* op_ctx = nullptr,
+                     bool is_replace = false);
 
     void
     LoadBatchFieldData(milvus::tracer::TraceContext& trace_ctx,
                        std::vector<std::pair<std::vector<FieldId>,
                                              proto::segcore::FieldBinlog>>&
                            field_binlog_to_load,
-                       milvus::OpContext* op_ctx = nullptr);
+                       milvus::OpContext* op_ctx = nullptr,
+                       bool is_replace = false);
 
     void
     LoadColumnGroups(
@@ -1046,7 +1058,8 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         const std::shared_ptr<milvus_storage::api::Properties>& properties,
         std::vector<std::pair<int, std::vector<FieldId>>>& cg_field_ids,
         bool eager_load,
-        milvus::OpContext* op_ctx = nullptr);
+        milvus::OpContext* op_ctx = nullptr,
+        bool is_replace = false);
 
     /**
      * @brief Load a single column group at the specified index
@@ -1068,7 +1081,8 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         int64_t index,
         const std::vector<FieldId>& milvus_field_ids,
         bool eager_load,
-        milvus::OpContext* op_ctx = nullptr);
+        milvus::OpContext* op_ctx = nullptr,
+        bool is_replace = false);
 
     /**
      * @brief Reloads columns from the specified field IDs
@@ -1118,7 +1132,8 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         bool enable_mmap,
         bool is_proxy_column,
         std::optional<ParquetStatistics> statistics = {},
-        milvus::OpContext* op_ctx = nullptr);
+        milvus::OpContext* op_ctx = nullptr,
+        bool is_replace = false);
 
     std::shared_ptr<ChunkedColumnInterface>
     get_column(FieldId field_id) const {

--- a/internal/proxy/impl_test.go
+++ b/internal/proxy/impl_test.go
@@ -2524,8 +2524,7 @@ func TestProxy_BatchUpdateManifest(t *testing.T) {
 			mockey.Mock(globalMetaCache.GetCollectionID).To(func(ctx context.Context, dbName, collectionName string) (UniqueID, error) {
 				return UniqueID(0), nil
 			}).Build()
-			mockey.Mock(globalMetaCache.RemoveDatabase).To(func(ctx context.Context, dbName string) error {
-				return nil
+			mockey.Mock(globalMetaCache.RemoveDatabase).To(func(ctx context.Context, dbName string) {
 			}).Build()
 
 			mockey.Mock(paramtable.Init).Return().Build()
@@ -2553,8 +2552,7 @@ func TestProxy_BatchUpdateManifest(t *testing.T) {
 			mockey.Mock((*MetaCache).GetCollectionID).To(func(m *MetaCache, ctx context.Context, dbName, collectionName string) (UniqueID, error) {
 				return UniqueID(100), nil
 			}).Build()
-			mockey.Mock((*MetaCache).RemoveDatabase).To(func(m *MetaCache, ctx context.Context, dbName string) error {
-				return nil
+			mockey.Mock((*MetaCache).RemoveDatabase).To(func(m *MetaCache, ctx context.Context, dbName string) {
 			}).Build()
 
 			mockey.Mock(paramtable.Init).Return().Build()


### PR DESCRIPTION
Related to #46358

When Reopen() triggers LoadDiff, fields or indexes may need replacement rather than first-time loading (e.g., field moves between column groups, index_id changes for an already-indexed field, or default-filled field gets actual data). Previously, safety assertions may cause reopen failure.

This change:
- Adds `is_replace` flag to load methods (load_field_data_common, LoadVecIndex, LoadScalarIndex, LoadIndex) to distinguish first-load from replacement, restoring safety assertions for the first-load path
- Splits LoadDiff into separate to_load/to_replace lists (indexes, binlogs, column_groups) so callers explicitly indicate intent
- Updates ComputeDiffIndexes/Binlogs/ColumnGroups to classify items into to_load vs to_replace based on current segment state
- Handles default-filled fields: fields previously filled with default values are correctly classified as to_replace when actual data arrives
- Adds unit tests for all replace scenarios