### PR TITLE
enhance: use PreparedGeometry for geo index refinement

### DIFF
--- a/internal/core/src/common/PreparedGeometry.h
+++ b/internal/core/src/common/PreparedGeometry.h
@@ -1,0 +1,352 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+#pragma once
+
+#include <geos_c.h>
+#include <memory>
+#include "common/EasyAssert.h"
+#include "common/Geometry.h"
+
+namespace milvus {
+
+/**
+ * PreparedGeometry wraps GEOS PreparedGeometry for accelerated repeated spatial predicate evaluation.
+ *
+ * GEOS prepared geometries pre-compute spatial indexes and other structures that make
+ * repeated intersection/containment tests faster than raw geometry operations.
+ *
+ * Use case: When testing one geometry (e.g., a query polygon) against many other geometries
+ * (e.g., candidate points from R-tree), prepare the query geometry once and reuse it.
+ *
+ * Example:
+ *   Geometry query_polygon(ctx, wkt);
+ *   PreparedGeometry prepared(ctx, query_polygon);
+ *
+ *   for (auto& candidate : candidates) {
+ *       if (prepared.intersects(candidate)) {  // faster than query_polygon.intersects(candidate)
+ *           results.push_back(candidate);
+ *       }
+ *   }
+ *
+ * Thread safety: PreparedGeometry is NOT thread-safe. Each thread should create its own
+ * PreparedGeometry instance, or access must be synchronized externally.
+ */
+class PreparedGeometry {
+ public:
+    // Default constructor creates invalid prepared geometry
+    PreparedGeometry() : prepared_(nullptr), ctx_(nullptr) {
+    }
+
+    /**
+     * Construct PreparedGeometry from an existing Geometry.
+     * The source Geometry must remain valid for the lifetime of this PreparedGeometry.
+     *
+     * @param ctx GEOS context handle (must match the Geometry's context)
+     * @param geom Source geometry to prepare
+     */
+    explicit PreparedGeometry(GEOSContextHandle_t ctx, const Geometry& geom)
+        : ctx_(ctx), prepared_(nullptr) {
+        if (!geom.IsValid()) {
+            return;
+        }
+
+        prepared_ = GEOSPrepare_r(ctx, geom.GetGeometry());
+        AssertInfo(prepared_ != nullptr,
+                   "Failed to create GEOS prepared geometry");
+    }
+
+    /**
+     * Construct PreparedGeometry from a raw GEOS geometry pointer.
+     * The source geometry must remain valid for the lifetime of this PreparedGeometry.
+     *
+     * @param ctx GEOS context handle
+     * @param geom Raw GEOS geometry pointer
+     */
+    explicit PreparedGeometry(GEOSContextHandle_t ctx, const GEOSGeometry* geom)
+        : ctx_(ctx), prepared_(nullptr) {
+        if (geom == nullptr) {
+            return;
+        }
+
+        prepared_ = GEOSPrepare_r(ctx, geom);
+        AssertInfo(prepared_ != nullptr,
+                   "Failed to create GEOS prepared geometry");
+    }
+
+    ~PreparedGeometry() {
+        if (prepared_ != nullptr) {
+            GEOSPreparedGeom_destroy_r(ctx_, prepared_);
+        }
+    }
+
+    // Non-copyable (prepared geometry references the original)
+    PreparedGeometry(const PreparedGeometry&) = delete;
+    PreparedGeometry&
+    operator=(const PreparedGeometry&) = delete;
+
+    // Moveable
+    PreparedGeometry(PreparedGeometry&& other) noexcept
+        : ctx_(other.ctx_), prepared_(other.prepared_) {
+        other.prepared_ = nullptr;
+        other.ctx_ = nullptr;
+    }
+
+    PreparedGeometry&
+    operator=(PreparedGeometry&& other) noexcept {
+        if (this != &other) {
+            if (prepared_ != nullptr) {
+                GEOSPreparedGeom_destroy_r(ctx_, prepared_);
+            }
+            ctx_ = other.ctx_;
+            prepared_ = other.prepared_;
+            other.prepared_ = nullptr;
+            other.ctx_ = nullptr;
+        }
+        return *this;
+    }
+
+    bool
+    IsValid() const {
+        return prepared_ != nullptr;
+    }
+
+    // ============================================================================
+    // Prepared spatial predicates - faster than unprepared versions
+    // ============================================================================
+
+    /**
+     * Tests if the prepared geometry intersects with the other geometry.
+     * This is the most commonly used predicate for spatial filtering.
+     */
+    bool
+    intersects(const Geometry& other) const {
+        if (!IsValid() || !other.IsValid()) {
+            return false;
+        }
+        return GEOSPreparedIntersects_r(ctx_, prepared_, other.GetGeometry()) ==
+               1;
+    }
+
+    bool
+    intersects(const GEOSGeometry* other) const {
+        if (!IsValid() || other == nullptr) {
+            return false;
+        }
+        return GEOSPreparedIntersects_r(ctx_, prepared_, other) == 1;
+    }
+
+    /**
+     * Tests if the prepared geometry contains the other geometry.
+     * Note: For ST_Contains queries, prepare the container (larger geometry).
+     */
+    bool
+    contains(const Geometry& other) const {
+        if (!IsValid() || !other.IsValid()) {
+            return false;
+        }
+        return GEOSPreparedContains_r(ctx_, prepared_, other.GetGeometry()) ==
+               1;
+    }
+
+    bool
+    contains(const GEOSGeometry* other) const {
+        if (!IsValid() || other == nullptr) {
+            return false;
+        }
+        return GEOSPreparedContains_r(ctx_, prepared_, other) == 1;
+    }
+
+    /**
+     * Tests if the prepared geometry contains the other geometry properly
+     * (no boundary intersection).
+     */
+    bool
+    containsProperly(const Geometry& other) const {
+        if (!IsValid() || !other.IsValid()) {
+            return false;
+        }
+        return GEOSPreparedContainsProperly_r(
+                   ctx_, prepared_, other.GetGeometry()) == 1;
+    }
+
+    bool
+    containsProperly(const GEOSGeometry* other) const {
+        if (!IsValid() || other == nullptr) {
+            return false;
+        }
+        return GEOSPreparedContainsProperly_r(ctx_, prepared_, other) == 1;
+    }
+
+    /**
+     * Tests if the prepared geometry covers the other geometry.
+     */
+    bool
+    covers(const Geometry& other) const {
+        if (!IsValid() || !other.IsValid()) {
+            return false;
+        }
+        return GEOSPreparedCovers_r(ctx_, prepared_, other.GetGeometry()) == 1;
+    }
+
+    bool
+    covers(const GEOSGeometry* other) const {
+        if (!IsValid() || other == nullptr) {
+            return false;
+        }
+        return GEOSPreparedCovers_r(ctx_, prepared_, other) == 1;
+    }
+
+    /**
+     * Tests if the prepared geometry is covered by the other geometry.
+     */
+    bool
+    coveredBy(const Geometry& other) const {
+        if (!IsValid() || !other.IsValid()) {
+            return false;
+        }
+        return GEOSPreparedCoveredBy_r(ctx_, prepared_, other.GetGeometry()) ==
+               1;
+    }
+
+    bool
+    coveredBy(const GEOSGeometry* other) const {
+        if (!IsValid() || other == nullptr) {
+            return false;
+        }
+        return GEOSPreparedCoveredBy_r(ctx_, prepared_, other) == 1;
+    }
+
+    /**
+     * Tests if the prepared geometry crosses the other geometry.
+     */
+    bool
+    crosses(const Geometry& other) const {
+        if (!IsValid() || !other.IsValid()) {
+            return false;
+        }
+        return GEOSPreparedCrosses_r(ctx_, prepared_, other.GetGeometry()) == 1;
+    }
+
+    bool
+    crosses(const GEOSGeometry* other) const {
+        if (!IsValid() || other == nullptr) {
+            return false;
+        }
+        return GEOSPreparedCrosses_r(ctx_, prepared_, other) == 1;
+    }
+
+    /**
+     * Tests if the prepared geometry is disjoint from the other geometry.
+     */
+    bool
+    disjoint(const Geometry& other) const {
+        if (!IsValid() || !other.IsValid()) {
+            return false;
+        }
+        return GEOSPreparedDisjoint_r(ctx_, prepared_, other.GetGeometry()) ==
+               1;
+    }
+
+    bool
+    disjoint(const GEOSGeometry* other) const {
+        if (!IsValid() || other == nullptr) {
+            return false;
+        }
+        return GEOSPreparedDisjoint_r(ctx_, prepared_, other) == 1;
+    }
+
+    /**
+     * Tests if the prepared geometry overlaps with the other geometry.
+     */
+    bool
+    overlaps(const Geometry& other) const {
+        if (!IsValid() || !other.IsValid()) {
+            return false;
+        }
+        return GEOSPreparedOverlaps_r(ctx_, prepared_, other.GetGeometry()) ==
+               1;
+    }
+
+    bool
+    overlaps(const GEOSGeometry* other) const {
+        if (!IsValid() || other == nullptr) {
+            return false;
+        }
+        return GEOSPreparedOverlaps_r(ctx_, prepared_, other) == 1;
+    }
+
+    /**
+     * Tests if the prepared geometry touches the other geometry.
+     */
+    bool
+    touches(const Geometry& other) const {
+        if (!IsValid() || !other.IsValid()) {
+            return false;
+        }
+        return GEOSPreparedTouches_r(ctx_, prepared_, other.GetGeometry()) == 1;
+    }
+
+    bool
+    touches(const GEOSGeometry* other) const {
+        if (!IsValid() || other == nullptr) {
+            return false;
+        }
+        return GEOSPreparedTouches_r(ctx_, prepared_, other) == 1;
+    }
+
+    /**
+     * Tests if the prepared geometry is within the other geometry.
+     * Note: For ST_Within queries where you're testing if candidates are within
+     * a query polygon, prepare the query polygon and use contains() instead.
+     */
+    bool
+    within(const Geometry& other) const {
+        if (!IsValid() || !other.IsValid()) {
+            return false;
+        }
+        return GEOSPreparedWithin_r(ctx_, prepared_, other.GetGeometry()) == 1;
+    }
+
+    bool
+    within(const GEOSGeometry* other) const {
+        if (!IsValid() || other == nullptr) {
+            return false;
+        }
+        return GEOSPreparedWithin_r(ctx_, prepared_, other) == 1;
+    }
+
+    // ============================================================================
+    // Non-prepared predicates (no prepared version available in GEOS)
+    // These fall back to regular geometry operations
+    // ============================================================================
+
+    /**
+     * Tests if the prepared geometry equals the other geometry.
+     * Note: GEOS doesn't provide a prepared version of equals, so this requires
+     * the original geometry to be passed.
+     */
+    static bool
+    equals(GEOSContextHandle_t ctx,
+           const GEOSGeometry* geom,
+           const Geometry& other) {
+        if (geom == nullptr || !other.IsValid()) {
+            return false;
+        }
+        return GEOSEquals_r(ctx, geom, other.GetGeometry()) == 1;
+    }
+
+ private:
+    GEOSContextHandle_t ctx_;
+    const GEOSPreparedGeometry* prepared_;
+};
+
+}  // namespace milvus

--- a/internal/core/src/common/PreparedGeometryTest.cpp
+++ b/internal/core/src/common/PreparedGeometryTest.cpp
@@ -1,0 +1,339 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+#include <gtest/gtest.h>
+#include <cmath>
+#include <thread>
+#include <vector>
+#include <set>
+#include <mutex>
+#include "common/Geometry.h"
+#include "common/PreparedGeometry.h"
+
+namespace milvus {
+namespace {
+
+class PreparedGeometryTest : public ::testing::Test {
+ protected:
+    void
+    SetUp() override {
+        ctx_ = GEOS_init_r();
+    }
+
+    void
+    TearDown() override {
+        GEOS_finish_r(ctx_);
+    }
+
+    GEOSContextHandle_t ctx_;
+};
+
+TEST_F(PreparedGeometryTest, BasicIntersects) {
+    // Create a polygon
+    Geometry polygon(ctx_, "POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))");
+    ASSERT_TRUE(polygon.IsValid());
+
+    // Create prepared geometry from polygon
+    PreparedGeometry prepared(ctx_, polygon);
+    ASSERT_TRUE(prepared.IsValid());
+
+    // Point inside polygon
+    Geometry point_inside(ctx_, "POINT(5 5)");
+    EXPECT_TRUE(prepared.intersects(point_inside));
+
+    // Point outside polygon
+    Geometry point_outside(ctx_, "POINT(15 15)");
+    EXPECT_FALSE(prepared.intersects(point_outside));
+
+    // Point on boundary
+    Geometry point_boundary(ctx_, "POINT(0 5)");
+    EXPECT_TRUE(prepared.intersects(point_boundary));
+}
+
+TEST_F(PreparedGeometryTest, Contains) {
+    // Create a polygon
+    Geometry polygon(ctx_, "POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))");
+    PreparedGeometry prepared(ctx_, polygon);
+
+    // Point inside - should be contained
+    Geometry point_inside(ctx_, "POINT(5 5)");
+    EXPECT_TRUE(prepared.contains(point_inside));
+
+    // Point outside - should not be contained
+    Geometry point_outside(ctx_, "POINT(15 15)");
+    EXPECT_FALSE(prepared.contains(point_outside));
+
+    // Point on boundary - contains returns false for boundary points
+    Geometry point_boundary(ctx_, "POINT(0 5)");
+    EXPECT_FALSE(prepared.contains(point_boundary));
+}
+
+TEST_F(PreparedGeometryTest, Within) {
+    // Create a small polygon inside a larger one
+    Geometry large_polygon(ctx_, "POLYGON((0 0, 100 0, 100 100, 0 100, 0 0))");
+    Geometry small_polygon(ctx_,
+                           "POLYGON((10 10, 20 10, 20 20, 10 20, 10 10))");
+
+    // Prepare the small polygon, test if it's within the large one
+    PreparedGeometry prepared_small(ctx_, small_polygon);
+    EXPECT_TRUE(prepared_small.within(large_polygon));
+
+    // Prepare the large polygon, test if it's within the small one (should be false)
+    PreparedGeometry prepared_large(ctx_, large_polygon);
+    EXPECT_FALSE(prepared_large.within(small_polygon));
+}
+
+TEST_F(PreparedGeometryTest, PredicateSemantics) {
+    // Test that prepared predicates give same results as non-prepared
+    // This is important for correctness verification
+
+    Geometry polygon(ctx_, "POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))");
+    Geometry point(ctx_, "POINT(5 5)");
+
+    PreparedGeometry prepared_polygon(ctx_, polygon);
+    PreparedGeometry prepared_point(ctx_, point);
+
+    // intersects is symmetric
+    EXPECT_EQ(polygon.intersects(point), prepared_polygon.intersects(point));
+    EXPECT_EQ(point.intersects(polygon), prepared_point.intersects(polygon));
+
+    // contains/within are inverses
+    // polygon.contains(point) should equal prepared_polygon.contains(point)
+    EXPECT_EQ(polygon.contains(point), prepared_polygon.contains(point));
+
+    // point.within(polygon) should equal prepared_point.within(polygon)
+    EXPECT_EQ(point.within(polygon), prepared_point.within(polygon));
+
+    // Verify the inverse relationship
+    // polygon.contains(point) == point.within(polygon)
+    EXPECT_EQ(polygon.contains(point), point.within(polygon));
+}
+
+TEST_F(PreparedGeometryTest, PerformanceBenefit) {
+    // This test demonstrates the use case: prepare once, test many times
+    // Create a complex polygon (many vertices)
+    std::string wkt = "POLYGON((";
+    for (int i = 0; i < 100; i++) {
+        double angle = 2.0 * 3.14159 * i / 100.0;
+        double x = 50.0 + 40.0 * cos(angle);
+        double y = 50.0 + 40.0 * sin(angle);
+        if (i > 0)
+            wkt += ", ";
+        wkt += std::to_string(x) + " " + std::to_string(y);
+    }
+    wkt +=
+        ", " + std::to_string(50.0 + 40.0) + " " + std::to_string(50.0) + "))";
+
+    Geometry complex_polygon(ctx_, wkt.c_str());
+    ASSERT_TRUE(complex_polygon.IsValid());
+
+    PreparedGeometry prepared(ctx_, complex_polygon);
+    ASSERT_TRUE(prepared.IsValid());
+
+    // Test many points against the prepared polygon
+    int inside_count = 0;
+    for (int i = 0; i < 1000; i++) {
+        double x = (i % 100);
+        double y = (i / 10);
+        std::string point_wkt =
+            "POINT(" + std::to_string(x) + " " + std::to_string(y) + ")";
+        Geometry point(ctx_, point_wkt.c_str());
+        if (prepared.intersects(point)) {
+            inside_count++;
+        }
+    }
+
+    // Just verify we got some results (exact count depends on geometry)
+    EXPECT_GT(inside_count, 0);
+    EXPECT_LT(inside_count, 1000);
+}
+
+TEST_F(PreparedGeometryTest, InvalidGeometry) {
+    // Test handling of invalid geometry
+    PreparedGeometry prepared_default;
+    EXPECT_FALSE(prepared_default.IsValid());
+
+    Geometry valid_point(ctx_, "POINT(5 5)");
+    EXPECT_FALSE(prepared_default.intersects(valid_point));
+    EXPECT_FALSE(prepared_default.contains(valid_point));
+}
+
+TEST_F(PreparedGeometryTest, MoveSemantics) {
+    Geometry polygon(ctx_, "POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))");
+    PreparedGeometry prepared1(ctx_, polygon);
+    ASSERT_TRUE(prepared1.IsValid());
+
+    // Move construct
+    PreparedGeometry prepared2(std::move(prepared1));
+    EXPECT_TRUE(prepared2.IsValid());
+    EXPECT_FALSE(prepared1.IsValid());  // moved-from should be invalid
+
+    // Move assign
+    PreparedGeometry prepared3;
+    prepared3 = std::move(prepared2);
+    EXPECT_TRUE(prepared3.IsValid());
+    EXPECT_FALSE(prepared2.IsValid());
+
+    // Verify the moved geometry still works
+    Geometry point(ctx_, "POINT(5 5)");
+    EXPECT_TRUE(prepared3.intersects(point));
+}
+
+TEST_F(PreparedGeometryTest, AllPredicates) {
+    // Test all available prepared predicates
+    Geometry polygon(ctx_, "POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))");
+    Geometry point_inside(ctx_, "POINT(5 5)");
+    Geometry point_outside(ctx_, "POINT(15 15)");
+    Geometry touching_line(ctx_, "LINESTRING(10 5, 15 5)");
+
+    PreparedGeometry prepared(ctx_, polygon);
+
+    // intersects
+    EXPECT_TRUE(prepared.intersects(point_inside));
+    EXPECT_FALSE(prepared.intersects(point_outside));
+
+    // contains
+    EXPECT_TRUE(prepared.contains(point_inside));
+    EXPECT_FALSE(prepared.contains(point_outside));
+
+    // containsProperly
+    EXPECT_TRUE(prepared.containsProperly(point_inside));
+
+    // covers
+    EXPECT_TRUE(prepared.covers(point_inside));
+    EXPECT_FALSE(prepared.covers(point_outside));
+
+    // disjoint (opposite of intersects)
+    EXPECT_FALSE(prepared.disjoint(point_inside));
+    EXPECT_TRUE(prepared.disjoint(point_outside));
+
+    // touches
+    EXPECT_TRUE(prepared.touches(touching_line));
+    EXPECT_FALSE(prepared.touches(point_inside));
+}
+
+// Tests for GetThreadLocalGEOSContext
+TEST(ThreadLocalGEOSContextTest, ReturnsValidContext) {
+    GEOSContextHandle_t ctx = GetThreadLocalGEOSContext();
+    ASSERT_NE(ctx, nullptr);
+
+    // Verify the context works by creating a geometry
+    Geometry point(ctx, "POINT(1 2)");
+    EXPECT_TRUE(point.IsValid());
+}
+
+TEST(ThreadLocalGEOSContextTest, ReturnsSameContextOnSameThread) {
+    GEOSContextHandle_t ctx1 = GetThreadLocalGEOSContext();
+    GEOSContextHandle_t ctx2 = GetThreadLocalGEOSContext();
+    GEOSContextHandle_t ctx3 = GetThreadLocalGEOSContext();
+
+    // Should return the same context handle each time on the same thread
+    EXPECT_EQ(ctx1, ctx2);
+    EXPECT_EQ(ctx2, ctx3);
+}
+
+TEST(ThreadLocalGEOSContextTest, DifferentThreadsGetDifferentContexts) {
+    std::mutex mutex;
+    std::set<GEOSContextHandle_t> contexts;
+
+    auto worker = [&mutex, &contexts]() {
+        GEOSContextHandle_t ctx = GetThreadLocalGEOSContext();
+
+        // Verify context is valid by using it
+        Geometry point(ctx, "POINT(5 5)");
+        EXPECT_TRUE(point.IsValid());
+
+        std::lock_guard<std::mutex> lock(mutex);
+        contexts.insert(ctx);
+    };
+
+    constexpr int num_threads = 4;
+    std::vector<std::thread> threads;
+    threads.reserve(num_threads);
+
+    for (int i = 0; i < num_threads; i++) {
+        threads.emplace_back(worker);
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    // Each thread should have gotten a different context
+    EXPECT_EQ(contexts.size(), static_cast<size_t>(num_threads));
+}
+
+TEST(ThreadLocalGEOSContextTest, ConcurrentGeometryOperations) {
+    // Test that concurrent operations using thread-local contexts don't interfere
+    auto worker = [](int thread_id) {
+        GEOSContextHandle_t ctx = GetThreadLocalGEOSContext();
+
+        // Each thread creates and tests geometries
+        // Use coordinates strictly inside the polygon (avoid boundary)
+        for (int i = 0; i < 100; i++) {
+            std::string wkt = "POINT(" +
+                              std::to_string(thread_id * 10 + i + 1) + " " +
+                              std::to_string(i + 1) + ")";
+            Geometry point(ctx, wkt.c_str());
+            EXPECT_TRUE(point.IsValid());
+
+            Geometry polygon(ctx,
+                             "POLYGON((0 0, 1000 0, 1000 1000, 0 1000, 0 0))");
+            EXPECT_TRUE(polygon.IsValid());
+            EXPECT_TRUE(polygon.contains(point));
+        }
+    };
+
+    constexpr int num_threads = 4;
+    std::vector<std::thread> threads;
+    threads.reserve(num_threads);
+
+    for (int i = 0; i < num_threads; i++) {
+        threads.emplace_back(worker, i);
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+}
+
+TEST(ThreadLocalGEOSContextTest, ConcurrentPreparedGeometry) {
+    // Test PreparedGeometry with thread-local contexts
+    auto worker = []() {
+        GEOSContextHandle_t ctx = GetThreadLocalGEOSContext();
+
+        Geometry polygon(ctx, "POLYGON((0 0, 100 0, 100 100, 0 100, 0 0))");
+        PreparedGeometry prepared(ctx, polygon);
+        ASSERT_TRUE(prepared.IsValid());
+
+        for (int i = 0; i < 100; i++) {
+            std::string wkt = "POINT(" + std::to_string(i % 50 + 25) + " " +
+                              std::to_string(i % 50 + 25) + ")";
+            Geometry point(ctx, wkt.c_str());
+            EXPECT_TRUE(prepared.contains(point));
+        }
+    };
+
+    constexpr int num_threads = 4;
+    std::vector<std::thread> threads;
+    threads.reserve(num_threads);
+
+    for (int i = 0; i < num_threads; i++) {
+        threads.emplace_back(worker);
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+}
+
+}  // namespace
+}  // namespace milvus

--- a/internal/core/src/exec/expression/GISFunctionFilterExpr.cpp
+++ b/internal/core/src/exec/expression/GISFunctionFilterExpr.cpp
@@ -13,6 +13,7 @@
 #include <cstdlib>
 #include "common/EasyAssert.h"
 #include "common/Geometry.h"
+#include "common/PreparedGeometry.h"
 #include "common/Types.h"
 #include "pb/plan.pb.h"
 #include <cmath>
@@ -145,7 +146,7 @@ PhyGISFunctionFilterExpr::EvalForDataSegment() {
     valid_res.set();
 
     auto right_source =
-        Geometry(segment_->get_ctx(), expr_->geometry_wkt_.c_str());
+        Geometry(GetThreadLocalGEOSContext(), expr_->geometry_wkt_.c_str());
 
     // Choose underlying data type according to segment type to avoid element
     // size mismatch: Sealed segments and growing segments with mmap use std::string_view;
@@ -310,32 +311,52 @@ PhyGISFunctionFilterExpr::EvalForIndexSegment() {
         return nullptr;
     }
 
-    Geometry query_geometry =
-        Geometry(segment_->get_ctx(), expr_->geometry_wkt_.c_str());
+    // Use thread-local GEOS context for thread safety - segment_->get_ctx() is shared
+    // and not safe for concurrent access from multiple query threads
+    GEOSContextHandle_t ctx = GetThreadLocalGEOSContext();
+
+    Geometry query_geometry = Geometry(ctx, expr_->geometry_wkt_.c_str());
+
+    // Prepare the query geometry once for accelerated repeated predicate evaluation.
+    PreparedGeometry prepared_query(ctx, query_geometry);
 
     /* ------------------------------------------------------------------
      * Prefetch: if coarse results are not cached yet, run a single R-Tree
      * query for all index chunks and cache their coarse bitmaps.
      * ------------------------------------------------------------------*/
 
-    auto evaluate_geometry = [this](const Geometry& left,
-                                    const Geometry& query_geometry) -> bool {
+    // Evaluate geometry operation using PreparedGeometry for supported operations.
+    // Note on predicate semantics when using prepared query:
+    // - Symmetric predicates (intersects, touches, overlaps, crosses): prepared_query.op(left) == left.op(query)
+    // - contains/within swap: left.contains(query) == prepared_query.within(left)
+    //                         left.within(query) == prepared_query.contains(left)
+    // - equals, dwithin: no prepared version, fall back to regular Geometry
+    auto evaluate_geometry_prepared =
+        [this, &prepared_query, &query_geometry](const Geometry& left) -> bool {
         switch (expr_->op_) {
-            case proto::plan::GISFunctionFilterExpr_GISOp_Equals:
-                return left.equals(query_geometry);
-            case proto::plan::GISFunctionFilterExpr_GISOp_Touches:
-                return left.touches(query_geometry);
-            case proto::plan::GISFunctionFilterExpr_GISOp_Overlaps:
-                return left.overlaps(query_geometry);
-            case proto::plan::GISFunctionFilterExpr_GISOp_Crosses:
-                return left.crosses(query_geometry);
-            case proto::plan::GISFunctionFilterExpr_GISOp_Contains:
-                return left.contains(query_geometry);
             case proto::plan::GISFunctionFilterExpr_GISOp_Intersects:
-                return left.intersects(query_geometry);
+                // Symmetric: prepared_query.intersects(left) == left.intersects(query)
+                return prepared_query.intersects(left);
+            case proto::plan::GISFunctionFilterExpr_GISOp_Touches:
+                // Symmetric
+                return prepared_query.touches(left);
+            case proto::plan::GISFunctionFilterExpr_GISOp_Overlaps:
+                // Symmetric
+                return prepared_query.overlaps(left);
+            case proto::plan::GISFunctionFilterExpr_GISOp_Crosses:
+                // Symmetric
+                return prepared_query.crosses(left);
+            case proto::plan::GISFunctionFilterExpr_GISOp_Contains:
+                // left.contains(query) == query.within(left)
+                return prepared_query.within(left);
             case proto::plan::GISFunctionFilterExpr_GISOp_Within:
-                return left.within(query_geometry);
+                // left.within(query) == query.contains(left)
+                return prepared_query.contains(left);
+            case proto::plan::GISFunctionFilterExpr_GISOp_Equals:
+                // No prepared version - fall back to regular geometry
+                return left.equals(query_geometry);
             case proto::plan::GISFunctionFilterExpr_GISOp_DWithin:
+                // Distance-based operation - no prepared version
                 return left.dwithin(query_geometry, expr_->distance_);
             default:
                 ThrowInfo(NotImplemented, "unknown GIS op : {}", expr_->op_);
@@ -357,16 +378,15 @@ PhyGISFunctionFilterExpr::EvalForIndexSegment() {
         if (expr_->op_ == proto::plan::GISFunctionFilterExpr_GISOp_DWithin) {
             // Create bounding box geometry for index coarse filtering
             Geometry bbox_geometry = create_bounding_box_for_dwithin(
-                segment_->get_ctx(), query_geometry, expr_->distance_);
+                ctx, query_geometry, expr_->distance_);
 
             ds->Set(milvus::index::MATCH_VALUE, bbox_geometry);
 
             // Note: Distance is not used for bounding box intersection query
         } else {
             // For other operations, use original geometry
-            ds->Set(
-                milvus::index::MATCH_VALUE,
-                Geometry(segment_->get_ctx(), expr_->geometry_wkt_.c_str()));
+            ds->Set(milvus::index::MATCH_VALUE,
+                    Geometry(ctx, expr_->geometry_wkt_.c_str()));
         }
 
         // Query segment-level R-Tree index **once** since each chunk shares the same index
@@ -427,8 +447,8 @@ PhyGISFunctionFilterExpr::EvalForIndexSegment() {
                     if (cached_geometry == nullptr) {
                         continue;
                     }
-                    bool result =
-                        evaluate_geometry(*cached_geometry, query_geometry);
+                    // Use prepared geometry for faster evaluation
+                    bool result = evaluate_geometry_prepared(*cached_geometry);
 
                     if (result) {
                         refined.set(pos);
@@ -444,7 +464,7 @@ PhyGISFunctionFilterExpr::EvalForIndexSegment() {
                         &data_array->scalars().geometry_data());
                 const auto& valid_data = data_array->valid_data();
 
-                GEOSContextHandle_t ctx = GEOS_init_r();
+                GEOSContextHandle_t local_ctx = GetThreadLocalGEOSContext();
                 for (size_t i = 0; i < hit_offsets.size(); ++i) {
                     const auto pos = hit_offsets[i];
 
@@ -454,14 +474,14 @@ PhyGISFunctionFilterExpr::EvalForIndexSegment() {
                     }
 
                     const auto& wkb_data = geometry_array->data(i);
-                    Geometry left(ctx, wkb_data.data(), wkb_data.size());
-                    bool result = evaluate_geometry(left, query_geometry);
+                    Geometry left(local_ctx, wkb_data.data(), wkb_data.size());
+                    // Use prepared geometry for faster evaluation
+                    bool result = evaluate_geometry_prepared(left);
 
                     if (result) {
                         refined.set(pos);
                     }
                 }
-                GEOS_finish_r(ctx);
             }
         };
 

--- a/internal/core/unittest/bench/CMakeLists.txt
+++ b/internal/core/unittest/bench/CMakeLists.txt
@@ -15,6 +15,7 @@ include_directories(${CMAKE_HOME_DIRECTORY}/unittest)
 set(bench_srcs
     bench_naive.cpp
     bench_search.cpp
+    bench_prepared_geometry.cpp
 )
 
 set(indexbuilder_bench_srcs

--- a/internal/core/unittest/bench/bench_prepared_geometry.cpp
+++ b/internal/core/unittest/bench/bench_prepared_geometry.cpp
@@ -1,0 +1,253 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+/**
+ * Google Benchmark for PreparedGeometry vs regular Geometry.
+ *
+ * This benchmark measures the REALISTIC performance difference between using GEOS
+ * PreparedGeometry vs regular Geometry for spatial predicate evaluation.
+ *
+ * IMPORTANT: This benchmark includes geometry parsing time (WKT -> GEOSGeometry)
+ * to reflect real-world usage where candidate geometries are parsed from stored data.
+ *
+ * Typical results (100-vertex polygon, 10000 candidates):
+ *   - Unprepared: ~460K QPS
+ *   - Prepared:   ~2M QPS
+ *   - Speedup:    ~4.5x
+ *
+ * Note: The predicate-only speedup is ~37x, but parsing dominates (~90% of time).
+ *
+ * Run with:
+ *   ./all_bench --benchmark_filter=PreparedGeometry
+ */
+
+#include <benchmark/benchmark.h>
+#include <cmath>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "common/Geometry.h"
+#include "common/PreparedGeometry.h"
+
+namespace milvus {
+namespace {
+
+// Helper to create a polygon WKT with N vertices (approximate circle)
+std::string
+CreatePolygonWKT(int num_vertices, double cx, double cy, double r) {
+    std::string wkt = "POLYGON((";
+    for (int i = 0; i <= num_vertices; i++) {
+        int idx = i % num_vertices;
+        double angle = 2.0 * M_PI * idx / num_vertices;
+        double x = cx + r * cos(angle);
+        double y = cy + r * sin(angle);
+        if (i > 0)
+            wkt += ", ";
+        wkt += std::to_string(x) + " " + std::to_string(y);
+    }
+    wkt += "))";
+    return wkt;
+}
+
+// Fixture for realistic PreparedGeometry benchmarks
+// These benchmarks include geometry parsing to reflect real-world usage
+class RealisticPreparedGeometryBenchmark : public benchmark::Fixture {
+ public:
+    void
+    SetUp(const benchmark::State& state) override {
+        ctx_ = GEOS_init_r();
+
+        int num_vertices = state.range(0);
+        int num_candidates = state.range(1);
+
+        // Create query polygon
+        polygon_wkt_ = CreatePolygonWKT(num_vertices, 50.0, 50.0, 30.0);
+        query_polygon_ = std::make_unique<Geometry>(ctx_, polygon_wkt_.c_str());
+        prepared_query_ =
+            std::make_unique<PreparedGeometry>(ctx_, *query_polygon_);
+
+        // Generate candidate point WKTs (not parsed yet - parsing happens in benchmark)
+        std::mt19937 rng(42);
+        std::uniform_real_distribution<double> dist(0.0, 100.0);
+        candidate_wkts_.reserve(num_candidates);
+        for (int i = 0; i < num_candidates; i++) {
+            candidate_wkts_.push_back("POINT(" + std::to_string(dist(rng)) +
+                                      " " + std::to_string(dist(rng)) + ")");
+        }
+    }
+
+    void
+    TearDown(const benchmark::State&) override {
+        candidate_wkts_.clear();
+        prepared_query_.reset();
+        query_polygon_.reset();
+        GEOS_finish_r(ctx_);
+    }
+
+ protected:
+    GEOSContextHandle_t ctx_;
+    std::string polygon_wkt_;
+    std::unique_ptr<Geometry> query_polygon_;
+    std::unique_ptr<PreparedGeometry> prepared_query_;
+    std::vector<std::string> candidate_wkts_;  // Store WKTs, parse in benchmark
+};
+
+// Realistic benchmark: unprepared geometry intersects (includes parsing)
+BENCHMARK_DEFINE_F(RealisticPreparedGeometryBenchmark,
+                   Realistic_Unprepared_Intersects)
+(benchmark::State& state) {
+    int matches = 0;
+    for (auto _ : state) {
+        matches = 0;
+        for (const auto& wkt : candidate_wkts_) {
+            // Parse geometry (as Milvus does from WKB)
+            Geometry point(ctx_, wkt.c_str());
+            if (query_polygon_->intersects(point)) {
+                matches++;
+            }
+            // Geometry destructor cleans up
+        }
+        benchmark::DoNotOptimize(matches);
+    }
+    state.SetItemsProcessed(state.iterations() * candidate_wkts_.size());
+    state.counters["matches"] = matches;
+}
+
+// Realistic benchmark: prepared geometry intersects (includes parsing)
+BENCHMARK_DEFINE_F(RealisticPreparedGeometryBenchmark,
+                   Realistic_Prepared_Intersects)
+(benchmark::State& state) {
+    int matches = 0;
+    for (auto _ : state) {
+        matches = 0;
+        for (const auto& wkt : candidate_wkts_) {
+            // Parse geometry (as Milvus does from WKB)
+            Geometry point(ctx_, wkt.c_str());
+            if (prepared_query_->intersects(point)) {
+                matches++;
+            }
+            // Geometry destructor cleans up
+        }
+        benchmark::DoNotOptimize(matches);
+    }
+    state.SetItemsProcessed(state.iterations() * candidate_wkts_.size());
+    state.counters["matches"] = matches;
+}
+
+// Realistic benchmark: unprepared geometry contains (includes parsing)
+BENCHMARK_DEFINE_F(RealisticPreparedGeometryBenchmark,
+                   Realistic_Unprepared_Contains)
+(benchmark::State& state) {
+    int matches = 0;
+    for (auto _ : state) {
+        matches = 0;
+        for (const auto& wkt : candidate_wkts_) {
+            Geometry point(ctx_, wkt.c_str());
+            if (query_polygon_->contains(point)) {
+                matches++;
+            }
+        }
+        benchmark::DoNotOptimize(matches);
+    }
+    state.SetItemsProcessed(state.iterations() * candidate_wkts_.size());
+    state.counters["matches"] = matches;
+}
+
+// Realistic benchmark: prepared geometry contains (includes parsing)
+BENCHMARK_DEFINE_F(RealisticPreparedGeometryBenchmark,
+                   Realistic_Prepared_Contains)
+(benchmark::State& state) {
+    int matches = 0;
+    for (auto _ : state) {
+        matches = 0;
+        for (const auto& wkt : candidate_wkts_) {
+            Geometry point(ctx_, wkt.c_str());
+            if (prepared_query_->contains(point)) {
+                matches++;
+            }
+        }
+        benchmark::DoNotOptimize(matches);
+    }
+    state.SetItemsProcessed(state.iterations() * candidate_wkts_.size());
+    state.counters["matches"] = matches;
+}
+
+// Benchmark just geometry parsing (to understand overhead)
+BENCHMARK_DEFINE_F(RealisticPreparedGeometryBenchmark, ParsingOnly)
+(benchmark::State& state) {
+    for (auto _ : state) {
+        for (const auto& wkt : candidate_wkts_) {
+            Geometry point(ctx_, wkt.c_str());
+            benchmark::DoNotOptimize(point.IsValid());
+        }
+    }
+    state.SetItemsProcessed(state.iterations() * candidate_wkts_.size());
+}
+
+// Register realistic benchmarks
+// Args: (num_vertices, num_candidates)
+
+// Medium polygon - typical use case
+BENCHMARK_REGISTER_F(RealisticPreparedGeometryBenchmark,
+                     Realistic_Unprepared_Intersects)
+    ->Args({100, 10000})
+    ->Args({100, 50000});
+BENCHMARK_REGISTER_F(RealisticPreparedGeometryBenchmark,
+                     Realistic_Prepared_Intersects)
+    ->Args({100, 10000})
+    ->Args({100, 50000});
+
+// Large polygon - more complex queries
+BENCHMARK_REGISTER_F(RealisticPreparedGeometryBenchmark,
+                     Realistic_Unprepared_Intersects)
+    ->Args({500, 10000})
+    ->Args({1000, 10000});
+BENCHMARK_REGISTER_F(RealisticPreparedGeometryBenchmark,
+                     Realistic_Prepared_Intersects)
+    ->Args({500, 10000})
+    ->Args({1000, 10000});
+
+// Contains benchmarks
+BENCHMARK_REGISTER_F(RealisticPreparedGeometryBenchmark,
+                     Realistic_Unprepared_Contains)
+    ->Args({100, 10000})
+    ->Args({500, 10000});
+BENCHMARK_REGISTER_F(RealisticPreparedGeometryBenchmark,
+                     Realistic_Prepared_Contains)
+    ->Args({100, 10000})
+    ->Args({500, 10000});
+
+// Parsing overhead benchmark
+BENCHMARK_REGISTER_F(RealisticPreparedGeometryBenchmark, ParsingOnly)
+    ->Args({100, 10000})
+    ->Args({100, 50000});
+
+// Benchmark the one-time preparation cost
+static void
+BM_PrepareGeometry(benchmark::State& state) {
+    int num_vertices = state.range(0);
+
+    GEOSContextHandle_t ctx = GEOS_init_r();
+    std::string polygon_wkt = CreatePolygonWKT(num_vertices, 50.0, 50.0, 30.0);
+    Geometry polygon(ctx, polygon_wkt.c_str());
+
+    for (auto _ : state) {
+        PreparedGeometry prepared(ctx, polygon);
+        benchmark::DoNotOptimize(prepared.IsValid());
+    }
+
+    GEOS_finish_r(ctx);
+}
+BENCHMARK(BM_PrepareGeometry)->Arg(10)->Arg(100)->Arg(500)->Arg(1000);
+
+}  // namespace
+}  // namespace milvus


### PR DESCRIPTION
## Summary
Cherry-pick of #47389 to hotfix-2.6.10

Add GEOS PreparedGeometry wrapper to accelerate spatial predicate evaluation during geo index refinement phase.

Changes:
- Add PreparedGeometry.h: RAII wrapper for GEOSPreparedGeometry with all spatial predicates (intersects, contains, within, etc.)
- Modify GISFunctionFilterExpr.cpp: prepare query geometry once before refinement loop, use prepared predicates for each candidate
- Handle predicate semantics: left.contains(query) == prepared_query.within(left)
- Reuse segment's GEOS context instead of creating/destroying per batch

issue: https://github.com/milvus-io/milvus/issues/47181

Signed-off-by: bigsheeper <yihao.dai@zilliz.com>