### PR TITLE
fix: filter frozen nodes from GetAllStreamingNodes in balancer

### DIFF
--- a/internal/streamingcoord/server/balancer/balancer_impl.go
+++ b/internal/streamingcoord/server/balancer/balancer_impl.go
@@ -59,7 +59,7 @@ func RecoverBalancer(
 		policy:                 policy,
 		reqCh:                  make(chan *request, 5),
 		backgroundTaskNotifier: syncutil.NewAsyncTaskNotifier[struct{}](),
-		freezeNodes:            typeutil.NewSet[int64](),
+		freezeNodes:            typeutil.NewConcurrentSet[int64](),
 	}
 	b.SetLogger(logger)
 	ready260Future, err := b.checkIfAllNodeGreaterThan260AndWatch(ctx)
@@ -81,7 +81,7 @@ type balancerImpl struct {
 	policy                 Policy                                // policy is the balance policy, TODO: should be dynamic in future.
 	reqCh                  chan *request                         // reqCh is the request channel, send the operation to background task.
 	backgroundTaskNotifier *syncutil.AsyncTaskNotifier[struct{}] // backgroundTaskNotifier is used to conmunicate with the background task.
-	freezeNodes            typeutil.Set[int64]                   // freezeNodes is the nodes that will be frozen, no more wal will be assigned to these nodes and wal will be removed from these nodes.
+	freezeNodes            *typeutil.ConcurrentSet[int64]        // freezeNodes is the nodes that will be frozen, no more wal will be assigned to these nodes and wal will be removed from these nodes.
 
 	fileResourceChecker FileResourceChecker
 	checkerMu           sync.RWMutex
@@ -119,8 +119,21 @@ func (b *balancerImpl) ReplicateRole() replicateutil.Role {
 }
 
 // GetAllStreamingNodes fetches all streaming node info.
+// Filter out frozen nodes to prevent downstream consumers (e.g., ReplicaObserver)
+// from treating frozen nodes as available.
 func (b *balancerImpl) GetAllStreamingNodes(ctx context.Context) (map[int64]*types.StreamingNodeInfo, error) {
-	return resource.Resource().StreamingNodeManagerClient().GetAllStreamingNodes(ctx)
+	nodes, err := resource.Resource().StreamingNodeManagerClient().GetAllStreamingNodes(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	filtered := make(map[int64]*types.StreamingNodeInfo, len(nodes))
+	for nodeID, info := range nodes {
+		if !b.freezeNodes.Contain(nodeID) {
+			filtered[nodeID] = info
+		}
+	}
+	return filtered, nil
 }
 
 // GetLatestWALLocated returns the server id of the node that the wal of the vChannel is located.
@@ -530,12 +543,13 @@ func (b *balancerImpl) fetchStreamingNodeStatus(ctx context.Context) (map[int64]
 	}
 
 	// clean up the freeze node that has been removed from session.
-	for serverID := range b.freezeNodes {
+	b.freezeNodes.Range(func(serverID int64) bool {
 		if _, ok := nodeStatus[serverID]; !ok {
 			b.Logger().Info("freeze node has been removed from session", zap.Int64("serverID", serverID))
 			b.freezeNodes.Remove(serverID)
 		}
-	}
+		return true
+	})
 	return nodeStatus, nil
 }
 

--- a/internal/streamingcoord/server/balancer/request.go
+++ b/internal/streamingcoord/server/balancer/request.go
@@ -48,7 +48,7 @@ func newOpUpdateBalancePolicy(ctx context.Context, req *types.UpdateWALBalancePo
 			// apply the freeze streaming nodes.
 			if len(req.GetNodes().GetFreezeNodeIds()) > 0 || len(req.GetNodes().GetDefreezeNodeIds()) > 0 {
 				impl.Logger().Info("update freeze nodes", zap.Int64s("freezeNodeIDs", req.GetNodes().GetFreezeNodeIds()), zap.Int64s("defreezeNodeIDs", req.GetNodes().GetDefreezeNodeIds()))
-				impl.freezeNodes.Insert(req.GetNodes().GetFreezeNodeIds()...)
+				impl.freezeNodes.Upsert(req.GetNodes().GetFreezeNodeIds()...)
 				impl.freezeNodes.Remove(req.GetNodes().GetDefreezeNodeIds()...)
 			}
 			future.Set(response{resp: &types.UpdateWALBalancePolicyResponse{


### PR DESCRIPTION
issue: #47831

GetAllStreamingNodes directly returned all nodes without filtering frozen ones, causing ReplicaObserver to treat frozen nodes as available in multi-replica environments. Now filters frozen nodes using ConcurrentSet for thread safety without explicit locks.