### PR TITLE
fix: Changed the mock functions to match the actual signature

### DIFF
--- a/internal/proxy/impl_test.go
+++ b/internal/proxy/impl_test.go
@@ -2524,8 +2524,7 @@ func TestProxy_BatchUpdateManifest(t *testing.T) {
 			mockey.Mock(globalMetaCache.GetCollectionID).To(func(ctx context.Context, dbName, collectionName string) (UniqueID, error) {
 				return UniqueID(0), nil
 			}).Build()
-			mockey.Mock(globalMetaCache.RemoveDatabase).To(func(ctx context.Context, dbName string) error {
-				return nil
+			mockey.Mock(globalMetaCache.RemoveDatabase).To(func(ctx context.Context, dbName string) {
 			}).Build()
 
 			mockey.Mock(paramtable.Init).Return().Build()
@@ -2553,8 +2552,7 @@ func TestProxy_BatchUpdateManifest(t *testing.T) {
 			mockey.Mock((*MetaCache).GetCollectionID).To(func(m *MetaCache, ctx context.Context, dbName, collectionName string) (UniqueID, error) {
 				return UniqueID(100), nil
 			}).Build()
-			mockey.Mock((*MetaCache).RemoveDatabase).To(func(m *MetaCache, ctx context.Context, dbName string) error {
-				return nil
+			mockey.Mock((*MetaCache).RemoveDatabase).To(func(m *MetaCache, ctx context.Context, dbName string) {
 			}).Build()
 
 			mockey.Mock(paramtable.Init).Return().Build()


### PR DESCRIPTION
Related to #47773

Problem: MetaCache.RemoveDatabase has signature func(ctx context.Context , database string) (no return value), but the mockey mocks were using
  func(...) error (returning an error).

Fix: Changed the mock functions to match the actual signature:
- Line 2527: func(ctx context.Context, dbName string) error { return nil } → func(ctx context.Context, dbName string) {}
- Line 2556: func(m *MetaCache, ctx context.Context, dbName string) error { return nil } → func(m *MetaCache, ctx context.Context, dbName string) {}