### PR TITLE
fix: handle NaN vs None comparison in output field value check for nullable fields

### DIFF
--- a/tests/python_client/check/param_check.py
+++ b/tests/python_client/check/param_check.py
@@ -462,6 +462,10 @@ def output_field_value_check(search_res, original, pk_name):
                     assert entity[field].keys() == original[-1][_id].keys()
                 else:
                     num = original[original[pk_name] == _id].index.to_list()[0]
-                    assert original[field][num] == entity[field], f"the output field values are wrong at nq={n}"
+                    expected_val = original[field][num]
+                    # pandas converts None to NaN, while Milvus returns None for nullable fields
+                    if entity[field] is None and (expected_val is None or (isinstance(expected_val, float) and np.isnan(expected_val))):
+                        continue
+                    assert expected_val == entity[field], f"the output field values are wrong at nq={n}"
 
     return True

--- a/tests/python_client/milvus_client/test_add_field_feature.py
+++ b/tests/python_client/milvus_client/test_add_field_feature.py
@@ -174,7 +174,7 @@ class TestMilvusClientAddFieldFeature(TestMilvusClientV2Base):
                                  "nq": ct.default_nq,
                                  "limit": ct.default_limit,
                                  "pk_name": pk_name})
-        # search by ids on nullable fields (issue #47065 fixed)
+        # search by ids on nullable fields
         # PKs 0-999: basic rows, embeddings_new is null (backfilled)
         # PKs 1000-1999: embeddings_new is null if pk%2==0, valid vector if pk%2==1
         res = self.search(client, collection_name, ids=query_pks,

--- a/tests/python_client/milvus_client/test_milvus_client_collection.py
+++ b/tests/python_client/milvus_client/test_milvus_client_collection.py
@@ -947,7 +947,7 @@ class TestMilvusClientCollectionValid(TestMilvusClientV2Base):
                                  "nq": len(ids_to_search),
                                  "limit": num_entities_with_not_null_vector,
                                  "pk_name": "id_string"})
-        # search by ids that belong to null vectors (returns empty results after #47065 fix)
+        # search by ids that belong to null vectors
         ids_to_search = ["0", "2"]
         res = self.search(client, collection_name, ids=ids_to_search,
                           search_params={},


### PR DESCRIPTION
## Summary

- Fix `output_field_value_check` in `param_check.py` to handle NaN vs None comparison for nullable fields
- When nullable fields contain `None` values, `pandas.DataFrame` converts them to `NaN`. The check function then fails comparing `NaN` (from DataFrame) with `None` (from Milvus search results). This fix treats both as equivalent null values.
- Remove resolved issue reference comments (`#47065`)

**Related issue**: #47065

### Changes

**Modified Files:**
- `tests/python_client/check/param_check.py`: Add NaN/None equivalence check before asserting output field values
- `tests/python_client/milvus_client/test_add_field_feature.py`: Remove resolved `#47065` comment
- `tests/python_client/milvus_client/test_milvus_client_collection.py`: Remove resolved `#47065` comment

### Test Plan

- [x] `test_search_by_pk_with_output_fields_and_consistency_level[Strong/Session/Bounded/Eventually]` - 4 previously failing tests now PASS
- [x] All 98 search_by_pk tests: 93 passed + 4 fixed + 1 skipped
- [x] 13 null/nullable vector related tests all PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)