### PR TITLE
enhance: add big topk optimization property

### DIFF
--- a/internal/proxy/meta_cache.go
+++ b/internal/proxy/meta_cache.go
@@ -109,6 +109,7 @@ type collectionInfo struct {
 	createdUtcTimestamp   uint64
 	consistencyLevel      commonpb.ConsistencyLevel
 	partitionKeyIsolation bool
+	bigTopKOptimization   bool
 	updateTimestamp       uint64
 	collectionTTL         uint64
 	numPartitions         int64
@@ -479,6 +480,10 @@ func (m *MetaCache) update(ctx context.Context, database, collectionName string,
 	if err != nil {
 		return nil, err
 	}
+	bigTopKOptimizationEnabled, err := common.IsBigTopKOptimizationEnabled(collection.Properties...)
+	if err != nil {
+		return nil, err
+	}
 
 	schemaInfo := newSchemaInfo(collection.Schema)
 
@@ -498,6 +503,7 @@ func (m *MetaCache) update(ctx context.Context, database, collectionName string,
 			createdUtcTimestamp:   collection.CreatedUtcTimestamp,
 			consistencyLevel:      collection.ConsistencyLevel,
 			partitionKeyIsolation: isolation,
+			bigTopKOptimization:   bigTopKOptimizationEnabled,
 			updateTimestamp:       collection.UpdateTimestamp,
 			collectionTTL:         getCollectionTTL(schemaInfo.CollectionSchema.GetProperties()),
 			vChannels:             collection.VirtualChannelNames,
@@ -529,6 +535,7 @@ func (m *MetaCache) update(ctx context.Context, database, collectionName string,
 		createdUtcTimestamp:   collection.CreatedUtcTimestamp,
 		consistencyLevel:      collection.ConsistencyLevel,
 		partitionKeyIsolation: isolation,
+		bigTopKOptimization:   bigTopKOptimizationEnabled,
 		updateTimestamp:       collection.UpdateTimestamp,
 		collectionTTL:         getCollectionTTL(schemaInfo.CollectionSchema.GetProperties()),
 		vChannels:             collection.VirtualChannelNames,

--- a/internal/proxy/search_util.go
+++ b/internal/proxy/search_util.go
@@ -323,7 +323,7 @@ func isSortableFieldType(dataType schemapb.DataType) bool {
 	}
 }
 
-func parseSearchIteratorV2Info(searchParamsPair []*commonpb.KeyValuePair, groupByFieldId int64, isIterator bool, offset int64, queryTopK *int64) (*planpb.SearchIteratorV2Info, error) {
+func parseSearchIteratorV2Info(searchParamsPair []*commonpb.KeyValuePair, groupByFieldId int64, isIterator bool, offset int64, queryTopK *int64, bigTopKEnabled bool) (*planpb.SearchIteratorV2Info, error) {
 	isIteratorV2Str, _ := funcutil.GetAttrByKeyFromRepeatedKV(SearchIterV2Key, searchParamsPair)
 	isIteratorV2, _ := strconv.ParseBool(isIteratorV2Str)
 	if !isIteratorV2 {
@@ -373,7 +373,7 @@ func parseSearchIteratorV2Info(searchParamsPair []*commonpb.KeyValuePair, groupB
 		return nil, fmt.Errorf("batch size is invalid, %w", err)
 	}
 	// use the same validation logic as topk
-	if err := validateLimit(batchSize); err != nil {
+	if err := validateLimit(batchSize, bigTopKEnabled); err != nil {
 		return nil, fmt.Errorf("batch size is invalid, %w", err)
 	}
 	*queryTopK = batchSize // for compatibility
@@ -399,7 +399,7 @@ func parseSearchIteratorV2Info(searchParamsPair []*commonpb.KeyValuePair, groupB
 }
 
 // parseSearchInfo returns QueryInfo and offset
-func parseSearchInfo(searchParamsPair []*commonpb.KeyValuePair, schema *schemapb.CollectionSchema, rankParams *rankParams) (*SearchInfo, error) {
+func parseSearchInfo(searchParamsPair []*commonpb.KeyValuePair, schema *schemapb.CollectionSchema, rankParams *rankParams, bigTopKEnabled bool) (*SearchInfo, error) {
 	var topK int64
 	isAdvanced := rankParams != nil
 	externalLimit := rankParams.GetLimit() + rankParams.GetOffset()
@@ -427,11 +427,15 @@ func parseSearchInfo(searchParamsPair []*commonpb.KeyValuePair, schema *schemapb
 	collectionIDStr, _ := funcutil.GetAttrByKeyFromRepeatedKV(CollectionID, searchParamsPair)
 	collectionId, _ := strconv.ParseInt(collectionIDStr, 0, 64)
 
-	if err := validateLimit(topK); err != nil {
+	if err := validateLimit(topK, bigTopKEnabled); err != nil {
 		if isIterator {
 			// 1. if the request is from iterator, we set topK to QuotaLimit as the iterator can resolve too large topK problem
 			// 2. GetAsInt64 has cached inside, no need to worry about cpu cost for parsing here
-			topK = Params.QuotaConfig.TopKLimit.GetAsInt64()
+			if bigTopKEnabled {
+				topK = Params.QuotaConfig.BigTopKLimit.GetAsInt64()
+			} else {
+				topK = Params.QuotaConfig.TopKLimit.GetAsInt64()
+			}
 		} else {
 			return nil, fmt.Errorf("%s [%d] is invalid, %w", TopKKey, topK, err)
 		}
@@ -448,7 +452,7 @@ func parseSearchInfo(searchParamsPair []*commonpb.KeyValuePair, schema *schemapb
 			}
 
 			if offset != 0 {
-				if err := validateLimit(offset); err != nil {
+				if err := validateLimit(offset, bigTopKEnabled); err != nil {
 					return nil, fmt.Errorf("%s [%d] is invalid, %w", OffsetKey, offset, err)
 				}
 			}
@@ -456,7 +460,7 @@ func parseSearchInfo(searchParamsPair []*commonpb.KeyValuePair, schema *schemapb
 	}
 
 	queryTopK := topK + offset
-	if err := validateLimit(queryTopK); err != nil {
+	if err := validateLimit(queryTopK, bigTopKEnabled); err != nil {
 		return nil, fmt.Errorf("%s+%s [%d] is invalid, %w", OffsetKey, TopKKey, queryTopK, err)
 	}
 
@@ -525,7 +529,7 @@ func parseSearchInfo(searchParamsPair []*commonpb.KeyValuePair, schema *schemapb
 			"Not allowed to do range-search when doing search-group-by")
 	}
 
-	planSearchIteratorV2Info, err := parseSearchIteratorV2Info(searchParamsPair, groupByFieldId, isIterator, offset, &queryTopK)
+	planSearchIteratorV2Info, err := parseSearchIteratorV2Info(searchParamsPair, groupByFieldId, isIterator, offset, &queryTopK, bigTopKEnabled)
 	if err != nil {
 		return nil, fmt.Errorf("parse iterator v2 info failed: %w", err)
 	}
@@ -879,7 +883,7 @@ func parseGroupByInfo(searchParamsPair []*commonpb.KeyValuePair, schema *schemap
 }
 
 // parseRankParams get limit and offset from rankParams, both are optional.
-func parseRankParams(rankParamsPair []*commonpb.KeyValuePair, schema *schemapb.CollectionSchema) (*rankParams, error) {
+func parseRankParams(rankParamsPair []*commonpb.KeyValuePair, schema *schemapb.CollectionSchema, bigTopKEnabled bool) (*rankParams, error) {
 	var (
 		limit        int64
 		offset       int64
@@ -905,7 +909,7 @@ func parseRankParams(rankParamsPair []*commonpb.KeyValuePair, schema *schemapb.C
 	}
 
 	// validate max result window.
-	if err = validateMaxQueryResultWindow(offset, limit); err != nil {
+	if err = validateMaxQueryResultWindow(offset, limit, bigTopKEnabled); err != nil {
 		return nil, fmt.Errorf("invalid max query result window, %w", err)
 	}
 

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -487,6 +487,11 @@ func (t *createCollectionTask) PreExecute(ctx context.Context) error {
 		return err
 	}
 
+	// validate bigTopK optimization mode
+	if _, err := common.IsBigTopKOptimizationEnabled(t.GetProperties()...); err != nil {
+		return err
+	}
+
 	// Validate timezone
 	tz, exist := funcutil.TryGetAttrByKeyFromRepeatedKV(common.TimezoneKey, t.GetProperties())
 	if exist && !timestamptz.IsTimezoneValid(tz) {
@@ -1353,6 +1358,62 @@ func hasPropInDeletekeys(keys []string) string {
 	return ""
 }
 
+// checkVectorIndexExist checks if the collection has any vector index.
+// Returns the vector field name that has an index, or empty string if none.
+func checkVectorIndexExist(ctx context.Context, dbName, collectionName string, collectionID int64, mixCoord types.MixCoordClient) (string, error) {
+	collSchema, err := globalMetaCache.GetCollectionSchema(ctx, dbName, collectionName)
+	if err != nil {
+		return "", err
+	}
+
+	indexResponse, err := mixCoord.DescribeIndex(ctx, &indexpb.DescribeIndexRequest{
+		CollectionID: collectionID,
+		IndexName:    "",
+	})
+	if err = merr.CheckRPCCall(indexResponse, err); err != nil && !errors.Is(err, merr.ErrIndexNotFound) {
+		return "", merr.WrapErrServiceInternal("describe index failed", err.Error())
+	}
+	for _, index := range indexResponse.IndexInfos {
+		for _, field := range collSchema.Fields {
+			if index.FieldID == field.FieldID && typeutil.IsVectorType(field.DataType) {
+				return field.GetName(), nil
+			}
+		}
+	}
+	return "", nil
+}
+
+// detectBoolPropChange detects whether a boolean collection property is being
+// changed via Properties or DeleteKeys. parseFn validates and parses the new
+// value when the key is found in Properties.
+func detectBoolPropChange(
+	oldValue bool,
+	propKey string,
+	properties []*commonpb.KeyValuePair,
+	deleteKeys []string,
+	parseFn func() (bool, error),
+) (newValue bool, changed bool, err error) {
+	if len(properties) > 0 && len(deleteKeys) > 0 {
+		return false, false, merr.WrapErrParameterInvalidMsg("cannot provide both DeleteKeys and ExtraParams")
+	}
+	newValue = oldValue
+	if _, ok := funcutil.TryGetAttrByKeyFromRepeatedKV(propKey, properties); ok {
+		newValue, err = parseFn()
+		if err != nil {
+			return false, false, err
+		}
+		changed = oldValue != newValue
+	}
+	for _, key := range deleteKeys {
+		if key == propKey {
+			newValue = false
+			changed = oldValue != newValue
+			break
+		}
+	}
+	return newValue, changed, nil
+}
+
 func validatePartitionKeyIsolation(ctx context.Context, colName string, isPartitionKeyEnabled bool, props ...*commonpb.KeyValuePair) (bool, error) {
 	iso, err := common.IsPartitionKeyIsolationKvEnabled(props...)
 	if err != nil {
@@ -1469,7 +1530,10 @@ func (t *alterCollectionTask) PreExecute(ctx context.Context) error {
 				return err
 			}
 			if loaded {
-				return merr.WrapErrCollectionLoaded(t.CollectionName, "can not delete mmap properties if collection loaded")
+				if key == common.MmapEnabledKey {
+					return merr.WrapErrCollectionLoaded(t.CollectionName, "can not delete mmap properties if collection loaded")
+				}
+				return merr.WrapErrCollectionLoaded(t.CollectionName, "can not delete %s properties if collection loaded", key)
 			}
 		}
 	}
@@ -1478,55 +1542,58 @@ func (t *alterCollectionTask) PreExecute(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	// check if the new partition key isolation is valid to use
-	newIsoValue, err := validatePartitionKeyIsolation(ctx, t.CollectionName, isPartitionKeyMode, t.Properties...)
-	if err != nil {
-		return err
-	}
 	collBasicInfo, err := globalMetaCache.GetCollectionInfo(t.ctx, t.GetDbName(), t.CollectionName, t.CollectionID)
 	if err != nil {
 		return err
 	}
-	oldIsoValue := collBasicInfo.partitionKeyIsolation
+	newIsoValue, isoChanged, err := detectBoolPropChange(
+		collBasicInfo.partitionKeyIsolation, common.PartitionKeyIsolationKey,
+		t.Properties, t.GetDeleteKeys(),
+		func() (bool, error) {
+			return validatePartitionKeyIsolation(ctx, t.CollectionName, isPartitionKeyMode, t.Properties...)
+		},
+	)
+	if err != nil {
+		return err
+	}
 
-	log.Ctx(ctx).Info("alter collection pre check with partition key isolation",
+	newBigTopK, bigTopKChanged, err := detectBoolPropChange(
+		collBasicInfo.bigTopKOptimization, common.BigTopKOptimizationEnabledKey,
+		t.Properties, t.GetDeleteKeys(),
+		func() (bool, error) {
+			return common.IsBigTopKOptimizationEnabled(t.Properties...)
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	log.Ctx(ctx).Info("alter collection pre check with partition key isolation/big topk optimization",
 		zap.String("collectionName", t.CollectionName),
 		zap.Bool("isPartitionKeyMode", isPartitionKeyMode),
 		zap.Bool("newIsoValue", newIsoValue),
-		zap.Bool("oldIsoValue", oldIsoValue))
+		zap.Bool("oldIsoValue", collBasicInfo.partitionKeyIsolation),
+		zap.Bool("newBigTopKOptimizationValue", newBigTopK),
+		zap.Bool("oldBigTopKOptimizationValue", collBasicInfo.bigTopKOptimization))
 
-	// if the isolation flag in properties is not set, meta cache will assign partitionKeyIsolation in collection info to false
+	// if the isolation/bigTopKOptimization flag in properties is not set, meta cache will assign partitionKeyIsolation/bigTopKOptimization in collection info to false
 	//   - None|false -> false, skip
 	//   - None|false -> true, check if the collection has vector index
 	//   - true -> false, check if the collection has vector index
 	//   - false -> true, check if the collection has vector index
 	//   - true -> true, skip
-	if oldIsoValue != newIsoValue {
-		collSchema, err := globalMetaCache.GetCollectionSchema(ctx, t.GetDbName(), t.CollectionName)
-		if err != nil {
+	if isoChanged || bigTopKChanged {
+		if vecField, err := checkVectorIndexExist(ctx, t.GetDbName(), t.CollectionName, t.CollectionID, t.mixCoord); err != nil {
 			return err
-		}
-
-		hasVecIndex := false
-		indexName := ""
-		indexResponse, err := t.mixCoord.DescribeIndex(ctx, &indexpb.DescribeIndexRequest{
-			CollectionID: t.CollectionID,
-			IndexName:    "",
-		})
-		if err != nil {
-			return merr.WrapErrServiceInternal("describe index failed", err.Error())
-		}
-		for _, index := range indexResponse.IndexInfos {
-			for _, field := range collSchema.Fields {
-				if index.FieldID == field.FieldID && typeutil.IsVectorType(field.DataType) {
-					hasVecIndex = true
-					indexName = field.GetName()
-				}
+		} else if vecField != "" {
+			if isoChanged {
+				return merr.WrapErrIndexDuplicate(vecField,
+					"can not alter partition key isolation mode if the collection already has a vector index. Please drop the index first")
 			}
-		}
-		if hasVecIndex {
-			return merr.WrapErrIndexDuplicate(indexName,
-				"can not alter partition key isolation mode if the collection already has a vector index. Please drop the index first")
+			if bigTopKChanged {
+				return merr.WrapErrIndexDuplicate(vecField,
+					"can not alter "+common.BigTopKOptimizationEnabledKey+" if the collection already has a vector index. Please drop the index first")
+			}
 		}
 	}
 	return nil

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -1386,6 +1386,7 @@ func checkVectorIndexExist(ctx context.Context, dbName, collectionName string, c
 // detectBoolPropChange detects whether a boolean collection property is being
 // changed via Properties or DeleteKeys. parseFn validates and parses the new
 // value when the key is found in Properties.
+// only one of properties or deleteKeys should be provided
 func detectBoolPropChange(
 	oldValue bool,
 	propKey string,
@@ -1393,6 +1394,7 @@ func detectBoolPropChange(
 	deleteKeys []string,
 	parseFn func() (bool, error),
 ) (newValue bool, changed bool, err error) {
+	// this is duplicated with the check in alterCollectionTask PreExecute
 	if len(properties) > 0 && len(deleteKeys) > 0 {
 		return false, false, merr.WrapErrParameterInvalidMsg("cannot provide both DeleteKeys and ExtraParams")
 	}

--- a/internal/proxy/task_index.go
+++ b/internal/proxy/task_index.go
@@ -118,6 +118,17 @@ func adjustAutoIndexParamsByDataType(config map[string]string, dataType schemapb
 	return adjusted
 }
 
+func getDenseFloatAutoIndexParams(collectionProperties []*commonpb.KeyValuePair) (map[string]string, error) {
+	bigTopKOptimizationEnabled, err := common.IsBigTopKOptimizationEnabled(collectionProperties...)
+	if err != nil {
+		return nil, err
+	}
+	if bigTopKOptimizationEnabled {
+		return Params.AutoIndexConfig.BigTopKIndexParams.GetAsJSONMap(), nil
+	}
+	return Params.AutoIndexConfig.IndexParams.GetAsJSONMap(), nil
+}
+
 type createIndexTask struct {
 	baseTask
 	Condition
@@ -335,17 +346,9 @@ func (cit *createIndexTask) parseIndexParams(ctx context.Context) error {
 
 			if typeutil.IsDenseFloatVectorType(cit.fieldSchema.DataType) ||
 				(typeutil.IsArrayOfVectorType(cit.fieldSchema.DataType) && typeutil.IsDenseFloatVectorType(cit.fieldSchema.ElementType)) {
-				var autoIndexParams map[string]string
-				bigTopKOptimizationEnabled, err := common.IsBigTopKOptimizationEnabled(cit.collectionProperties...)
+				autoIndexParams, err := getDenseFloatAutoIndexParams(cit.collectionProperties)
 				if err != nil {
 					return err
-				}
-				if bigTopKOptimizationEnabled {
-					// Use BigTopK-optimized index params
-					autoIndexParams = Params.AutoIndexConfig.BigTopKIndexParams.GetAsJSONMap()
-				} else {
-					// Use regular autoindex float vector index params
-					autoIndexParams = Params.AutoIndexConfig.IndexParams.GetAsJSONMap()
 				}
 				// override float vector index params by autoindex
 				// filter incompatible refine_type for fp16/bf16 vectors
@@ -443,16 +446,10 @@ func (cit *createIndexTask) parseIndexParams(ctx context.Context) error {
 			var config map[string]string
 			if typeutil.IsDenseFloatVectorType(cit.fieldSchema.DataType) ||
 				(typeutil.IsArrayOfVectorType(cit.fieldSchema.DataType) && typeutil.IsDenseFloatVectorType(cit.fieldSchema.ElementType)) {
-				bigTopKOptimizationEnabled, err := common.IsBigTopKOptimizationEnabled(cit.collectionProperties...)
+				var err error
+				config, err = getDenseFloatAutoIndexParams(cit.collectionProperties)
 				if err != nil {
 					return err
-				}
-				if bigTopKOptimizationEnabled {
-					// Use BigTopK-optimized index params
-					config = Params.AutoIndexConfig.BigTopKIndexParams.GetAsJSONMap()
-				} else {
-					// Use regular autoindex float vector index params
-					config = Params.AutoIndexConfig.IndexParams.GetAsJSONMap()
 				}
 				// filter incompatible refine_type for fp16/bf16 vectors
 				dataType := cit.fieldSchema.DataType

--- a/internal/proxy/task_index.go
+++ b/internal/proxy/task_index.go
@@ -135,6 +135,7 @@ type createIndexTask struct {
 	functionSchema                   *schemapb.FunctionSchema
 	fieldSchema                      *schemapb.FieldSchema
 	userAutoIndexMetricTypeSpecified bool
+	collectionProperties             []*commonpb.KeyValuePair
 }
 
 func (cit *createIndexTask) TraceCtx() context.Context {
@@ -334,13 +335,25 @@ func (cit *createIndexTask) parseIndexParams(ctx context.Context) error {
 
 			if typeutil.IsDenseFloatVectorType(cit.fieldSchema.DataType) ||
 				(typeutil.IsArrayOfVectorType(cit.fieldSchema.DataType) && typeutil.IsDenseFloatVectorType(cit.fieldSchema.ElementType)) {
+				var autoIndexParams map[string]string
+				bigTopKOptimizationEnabled, err := common.IsBigTopKOptimizationEnabled(cit.collectionProperties...)
+				if err != nil {
+					return err
+				}
+				if bigTopKOptimizationEnabled {
+					// Use BigTopK-optimized index params
+					autoIndexParams = Params.AutoIndexConfig.BigTopKIndexParams.GetAsJSONMap()
+				} else {
+					// Use regular autoindex float vector index params
+					autoIndexParams = Params.AutoIndexConfig.IndexParams.GetAsJSONMap()
+				}
 				// override float vector index params by autoindex
 				// filter incompatible refine_type for fp16/bf16 vectors
 				dataType := cit.fieldSchema.DataType
 				if typeutil.IsArrayOfVectorType(cit.fieldSchema.DataType) {
 					dataType = cit.fieldSchema.ElementType
 				}
-				autoIndexParams := adjustAutoIndexParamsByDataType(Params.AutoIndexConfig.IndexParams.GetAsJSONMap(), dataType)
+				autoIndexParams = adjustAutoIndexParamsByDataType(autoIndexParams, dataType)
 				for k, v := range autoIndexParams {
 					indexParamsMap[k] = v
 				}
@@ -430,13 +443,23 @@ func (cit *createIndexTask) parseIndexParams(ctx context.Context) error {
 			var config map[string]string
 			if typeutil.IsDenseFloatVectorType(cit.fieldSchema.DataType) ||
 				(typeutil.IsArrayOfVectorType(cit.fieldSchema.DataType) && typeutil.IsDenseFloatVectorType(cit.fieldSchema.ElementType)) {
-				// override float vector index params by autoindex
+				bigTopKOptimizationEnabled, err := common.IsBigTopKOptimizationEnabled(cit.collectionProperties...)
+				if err != nil {
+					return err
+				}
+				if bigTopKOptimizationEnabled {
+					// Use BigTopK-optimized index params
+					config = Params.AutoIndexConfig.BigTopKIndexParams.GetAsJSONMap()
+				} else {
+					// Use regular autoindex float vector index params
+					config = Params.AutoIndexConfig.IndexParams.GetAsJSONMap()
+				}
 				// filter incompatible refine_type for fp16/bf16 vectors
 				dataType := cit.fieldSchema.DataType
 				if typeutil.IsArrayOfVectorType(cit.fieldSchema.DataType) {
 					dataType = cit.fieldSchema.ElementType
 				}
-				config = adjustAutoIndexParamsByDataType(Params.AutoIndexConfig.IndexParams.GetAsJSONMap(), dataType)
+				config = adjustAutoIndexParamsByDataType(config, dataType)
 			} else if typeutil.IsSparseFloatVectorType(cit.fieldSchema.DataType) ||
 				(typeutil.IsArrayOfVectorType(cit.fieldSchema.DataType) && typeutil.IsSparseFloatVectorType(cit.fieldSchema.ElementType)) {
 				// override sparse float vector index params by autoindex
@@ -677,6 +700,12 @@ func (cit *createIndexTask) PreExecute(ctx context.Context) error {
 		return err
 	}
 	cit.collectionID = collID
+
+	collInfo, err := globalMetaCache.GetCollectionInfo(ctx, cit.req.GetDbName(), cit.req.GetCollectionName(), cit.collectionID)
+	if err != nil {
+		return err
+	}
+	cit.collectionProperties = collInfo.properties
 
 	if err = validateIndexName(cit.req.GetIndexName()); err != nil {
 		return err

--- a/internal/proxy/task_index_test.go
+++ b/internal/proxy/task_index_test.go
@@ -216,6 +216,12 @@ func TestCreateIndexTask_PreExecute(t *testing.T) {
 		mock.AnythingOfType("string"),
 		mock.AnythingOfType("string"),
 	).Return(newSchemaInfo(newTestSchema()), nil)
+	mockCache.On("GetCollectionInfo",
+		mock.Anything, // context.Context
+		mock.AnythingOfType("string"),
+		mock.AnythingOfType("string"),
+		mock.AnythingOfType("int64"),
+	).Return(&collectionInfo{}, nil)
 
 	globalMetaCache = mockCache
 
@@ -1453,6 +1459,149 @@ func Test_parseIndexParams_AutoIndex_WithType(t *testing.T) {
 			{Key: common.IndexTypeKey, Value: "BIN_IVF_FLAT"},
 			{Key: common.MetricTypeKey, Value: "JACCARD"},
 			{Key: "nlist", Value: "1024"},
+		}, task.newIndexParams)
+	})
+}
+
+func Test_parseIndexParams_BigTopKOptimization(t *testing.T) {
+	paramtable.Init()
+
+	t.Run("cloud autoindex with BigTopK enabled selects IVF_FLAT", func(t *testing.T) {
+		Params.Save(Params.AutoIndexConfig.Enable.Key, "true")
+		Params.Save(Params.AutoIndexConfig.IndexParams.Key, `{"M": 30,"efConstruction": 360,"index_type": "HNSW"}`)
+		Params.Save(Params.AutoIndexConfig.BigTopKIndexParams.Key, `{"nlist": 128, "index_type": "IVF_FLAT", "metric_type": "COSINE"}`)
+		defer Params.Reset(Params.AutoIndexConfig.Enable.Key)
+		defer Params.Reset(Params.AutoIndexConfig.IndexParams.Key)
+		defer Params.Reset(Params.AutoIndexConfig.BigTopKIndexParams.Key)
+
+		task := &createIndexTask{
+			fieldSchema: &schemapb.FieldSchema{
+				DataType: schemapb.DataType_FloatVector,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.DimKey, Value: "128"},
+				},
+			},
+			collectionProperties: []*commonpb.KeyValuePair{
+				{Key: common.BigTopKOptimizationEnabledKey, Value: "true"},
+			},
+			req: &milvuspb.CreateIndexRequest{
+				ExtraParams: []*commonpb.KeyValuePair{
+					{Key: common.MetricTypeKey, Value: "L2"},
+				},
+			},
+		}
+		err := task.parseIndexParams(context.TODO())
+		assert.NoError(t, err)
+		assert.True(t, task.userAutoIndexMetricTypeSpecified)
+		// Should use IVF_FLAT from BigTopK config, with user metric type overriding
+		assert.ElementsMatch(t, []*commonpb.KeyValuePair{
+			{Key: common.IndexTypeKey, Value: "IVF_FLAT"},
+			{Key: common.MetricTypeKey, Value: "L2"},
+			{Key: "nlist", Value: "128"},
+		}, task.newIndexParams)
+	})
+
+	t.Run("cloud autoindex without BigTopK uses default HNSW", func(t *testing.T) {
+		Params.Save(Params.AutoIndexConfig.Enable.Key, "true")
+		Params.Save(Params.AutoIndexConfig.IndexParams.Key, `{"M": 30,"efConstruction": 360,"index_type": "HNSW"}`)
+		Params.Save(Params.AutoIndexConfig.BigTopKIndexParams.Key, `{"nlist": 128, "index_type": "IVF_FLAT", "metric_type": "COSINE"}`)
+		defer Params.Reset(Params.AutoIndexConfig.Enable.Key)
+		defer Params.Reset(Params.AutoIndexConfig.IndexParams.Key)
+		defer Params.Reset(Params.AutoIndexConfig.BigTopKIndexParams.Key)
+
+		task := &createIndexTask{
+			fieldSchema: &schemapb.FieldSchema{
+				DataType: schemapb.DataType_FloatVector,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.DimKey, Value: "128"},
+				},
+			},
+			collectionProperties: []*commonpb.KeyValuePair{},
+			req: &milvuspb.CreateIndexRequest{
+				ExtraParams: []*commonpb.KeyValuePair{
+					{Key: common.MetricTypeKey, Value: "L2"},
+				},
+			},
+		}
+		err := task.parseIndexParams(context.TODO())
+		assert.NoError(t, err)
+		assert.True(t, task.userAutoIndexMetricTypeSpecified)
+		// Should use default HNSW params
+		assert.ElementsMatch(t, []*commonpb.KeyValuePair{
+			{Key: common.IndexTypeKey, Value: "HNSW"},
+			{Key: common.MetricTypeKey, Value: "L2"},
+			{Key: "M", Value: "30"},
+			{Key: "efConstruction", Value: "360"},
+		}, task.newIndexParams)
+	})
+
+	t.Run("non-cloud autoindex with BigTopK enabled selects IVF_FLAT", func(t *testing.T) {
+		Params.Save(Params.AutoIndexConfig.Enable.Key, "false")
+		Params.Save(Params.AutoIndexConfig.IndexParams.Key, `{"M": 30,"efConstruction": 360,"index_type": "HNSW", "metric_type": "IP"}`)
+		Params.Save(Params.AutoIndexConfig.BigTopKIndexParams.Key, `{"nlist": 128, "index_type": "IVF_FLAT", "metric_type": "COSINE"}`)
+		defer Params.Reset(Params.AutoIndexConfig.Enable.Key)
+		defer Params.Reset(Params.AutoIndexConfig.IndexParams.Key)
+		defer Params.Reset(Params.AutoIndexConfig.BigTopKIndexParams.Key)
+
+		task := &createIndexTask{
+			fieldSchema: &schemapb.FieldSchema{
+				DataType: schemapb.DataType_FloatVector,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.DimKey, Value: "128"},
+				},
+			},
+			collectionProperties: []*commonpb.KeyValuePair{
+				{Key: common.BigTopKOptimizationEnabledKey, Value: "true"},
+			},
+			req: &milvuspb.CreateIndexRequest{
+				ExtraParams: make([]*commonpb.KeyValuePair, 0),
+			},
+		}
+		err := task.parseIndexParams(context.TODO())
+		assert.NoError(t, err)
+		// Should use IVF_FLAT from BigTopK config
+		found := false
+		for _, kv := range task.newIndexParams {
+			if kv.Key == common.IndexTypeKey {
+				assert.Equal(t, "IVF_FLAT", kv.Value)
+				found = true
+			}
+		}
+		assert.True(t, found, "index_type should be set to IVF_FLAT")
+	})
+
+	t.Run("BigTopK property set to false uses default", func(t *testing.T) {
+		Params.Save(Params.AutoIndexConfig.Enable.Key, "true")
+		Params.Save(Params.AutoIndexConfig.IndexParams.Key, `{"M": 30,"efConstruction": 360,"index_type": "HNSW"}`)
+		Params.Save(Params.AutoIndexConfig.BigTopKIndexParams.Key, `{"nlist": 128, "index_type": "IVF_FLAT", "metric_type": "COSINE"}`)
+		defer Params.Reset(Params.AutoIndexConfig.Enable.Key)
+		defer Params.Reset(Params.AutoIndexConfig.IndexParams.Key)
+		defer Params.Reset(Params.AutoIndexConfig.BigTopKIndexParams.Key)
+
+		task := &createIndexTask{
+			fieldSchema: &schemapb.FieldSchema{
+				DataType: schemapb.DataType_FloatVector,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.DimKey, Value: "128"},
+				},
+			},
+			collectionProperties: []*commonpb.KeyValuePair{
+				{Key: common.BigTopKOptimizationEnabledKey, Value: "false"},
+			},
+			req: &milvuspb.CreateIndexRequest{
+				ExtraParams: []*commonpb.KeyValuePair{
+					{Key: common.MetricTypeKey, Value: "L2"},
+				},
+			},
+		}
+		err := task.parseIndexParams(context.TODO())
+		assert.NoError(t, err)
+		// Should use default HNSW params
+		assert.ElementsMatch(t, []*commonpb.KeyValuePair{
+			{Key: common.IndexTypeKey, Value: "HNSW"},
+			{Key: common.MetricTypeKey, Value: "L2"},
+			{Key: "M", Value: "30"},
+			{Key: "efConstruction", Value: "360"},
 		}, task.newIndexParams)
 	})
 }

--- a/internal/proxy/task_query.go
+++ b/internal/proxy/task_query.go
@@ -221,7 +221,7 @@ func filterSystemFields(outputFieldIDs []UniqueID) []UniqueID {
 }
 
 // parseQueryParams get limit and offset from queryParamsPair, both are optional.
-func parseQueryParams(queryParamsPair []*commonpb.KeyValuePair) (*queryParams, error) {
+func parseQueryParams(queryParamsPair []*commonpb.KeyValuePair, bigTopKEnabled bool) (*queryParams, error) {
 	var (
 		limit             int64
 		offset            int64
@@ -291,7 +291,7 @@ func parseQueryParams(queryParamsPair []*commonpb.KeyValuePair) (*queryParams, e
 			}
 		}
 		// validate max result window.
-		if err = validateMaxQueryResultWindow(offset, limit); err != nil {
+		if err = validateMaxQueryResultWindow(offset, limit, bigTopKEnabled); err != nil {
 			return nil, fmt.Errorf("invalid max query result window, %w", err)
 		}
 	}
@@ -523,7 +523,7 @@ func (t *queryTask) PreExecute(ctx context.Context) error {
 	if t.RetrieveRequest.IgnoreGrowing, err = isIgnoreGrowing(t.request.GetQueryParams()); err != nil {
 		return err
 	}
-	queryParams, err := parseQueryParams(t.request.GetQueryParams())
+	queryParams, err := parseQueryParams(t.request.GetQueryParams(), colInfo.bigTopKOptimization)
 	if err != nil {
 		return err
 	}

--- a/internal/proxy/task_query_test.go
+++ b/internal/proxy/task_query_test.go
@@ -656,7 +656,7 @@ func TestTaskQuery_functions(t *testing.T) {
 						Value: test.inValue[i],
 					})
 				}
-				ret, err := parseQueryParams(inParams)
+				ret, err := parseQueryParams(inParams, false)
 				if test.expectErr {
 					assert.Error(t, err)
 					assert.Empty(t, ret)
@@ -680,7 +680,7 @@ func TestTaskQuery_functions(t *testing.T) {
 				Key:   IteratorField,
 				Value: "True",
 			})
-			ret, err := parseQueryParams(inParams)
+			ret, err := parseQueryParams(inParams, false)
 			assert.NoError(t, err)
 			assert.Equal(t, reduce.IReduceInOrderForBest, ret.reduceType)
 		}
@@ -694,7 +694,7 @@ func TestTaskQuery_functions(t *testing.T) {
 				Key:   IteratorField,
 				Value: "TrueXXXX",
 			})
-			ret, err := parseQueryParams(inParams)
+			ret, err := parseQueryParams(inParams, false)
 			assert.Error(t, err)
 			assert.Nil(t, ret)
 		}
@@ -708,7 +708,7 @@ func TestTaskQuery_functions(t *testing.T) {
 				Key:   IteratorField,
 				Value: "True",
 			})
-			ret, err := parseQueryParams(inParams)
+			ret, err := parseQueryParams(inParams, false)
 			assert.Error(t, err)
 			assert.Nil(t, ret)
 		}
@@ -719,7 +719,7 @@ func TestTaskQuery_functions(t *testing.T) {
 				Value: "True",
 			})
 			// when not setting iterator tag, ignore reduce_stop_for_best
-			ret, err := parseQueryParams(inParams)
+			ret, err := parseQueryParams(inParams, false)
 			assert.NoError(t, err)
 			assert.Equal(t, reduce.IReduceNoOrder, ret.reduceType)
 		}
@@ -730,7 +730,7 @@ func TestTaskQuery_functions(t *testing.T) {
 				Value: "True",
 			})
 			// when not setting reduce_stop_for_best tag, reduce by keep results in order
-			ret, err := parseQueryParams(inParams)
+			ret, err := parseQueryParams(inParams, false)
 			assert.NoError(t, err)
 			assert.Equal(t, reduce.IReduceInOrder, ret.reduceType)
 		}
@@ -744,7 +744,7 @@ func TestTaskQuery_functions(t *testing.T) {
 				Key:   IteratorField,
 				Value: "True",
 			})
-			ret, err := parseQueryParams(inParams)
+			ret, err := parseQueryParams(inParams, false)
 			assert.NoError(t, err)
 			assert.Equal(t, reduce.IReduceInOrder, ret.reduceType)
 		}
@@ -758,7 +758,7 @@ func TestTaskQuery_functions(t *testing.T) {
 				Key:   IteratorField,
 				Value: "False",
 			})
-			ret, err := parseQueryParams(inParams)
+			ret, err := parseQueryParams(inParams, false)
 			assert.NoError(t, err)
 			assert.Equal(t, reduce.IReduceNoOrder, ret.reduceType)
 		}

--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -73,6 +73,7 @@ type searchTask struct {
 	schema                 *schemaInfo
 	needRequery            bool
 	partitionKeyMode       bool
+	bigTopKOptimization    bool
 	enableMaterializedView bool
 	mustUsePartitionKey    bool
 	resultSizeInsufficient bool
@@ -158,11 +159,15 @@ func (t *searchTask) PreExecute(ctx context.Context) error {
 	t.SearchRequest.DbID = 0 // todo
 	t.SearchRequest.CollectionID = collID
 	log := log.Ctx(ctx).With(zap.Int64("collID", collID), zap.String("collName", collectionName))
-	t.schema, err = globalMetaCache.GetCollectionSchema(ctx, t.request.GetDbName(), collectionName)
+
+	collectionInfo, err := globalMetaCache.GetCollectionInfo(ctx, t.request.GetDbName(), collectionName, collID)
 	if err != nil {
-		log.Warn("get collection schema failed", zap.Error(err))
+		log.Warn("Proxy::searchTask::PreExecute failed to GetCollectionInfo from cache",
+			zap.String("collectionName", collectionName), zap.Int64("collectionID", collID), zap.Error(err))
 		return err
 	}
+	t.schema = collectionInfo.schema
+	t.bigTopKOptimization = collectionInfo.bigTopKOptimization
 
 	t.partitionKeyMode, err = isPartitionKeyMode(ctx, t.request.GetDbName(), collectionName)
 	if err != nil {
@@ -239,12 +244,6 @@ func (t *searchTask) PreExecute(ctx context.Context) error {
 		return err
 	}
 
-	collectionInfo, err2 := globalMetaCache.GetCollectionInfo(ctx, t.request.GetDbName(), collectionName, t.CollectionID)
-	if err2 != nil {
-		log.Warn("Proxy::searchTask::PreExecute failed to GetCollectionInfo from cache",
-			zap.String("collectionName", collectionName), zap.Int64("collectionID", t.CollectionID), zap.Error(err2))
-		return err2
-	}
 	guaranteeTs := t.request.GetGuaranteeTimestamp()
 	var consistencyLevel commonpb.ConsistencyLevel
 	useDefaultConsistency := t.request.GetUseDefaultConsistency()
@@ -428,7 +427,7 @@ func (t *searchTask) initAdvancedSearchRequest(ctx context.Context) error {
 		return lo.Contains(t.translatedOutputFields, field.GetName()) && typeutil.IsVectorType(field.GetDataType())
 	})
 
-	if t.rankParams, err = parseRankParams(t.request.GetSearchParams(), t.schema.CollectionSchema); err != nil {
+	if t.rankParams, err = parseRankParams(t.request.GetSearchParams(), t.schema.CollectionSchema, t.bigTopKOptimization); err != nil {
 		log.Error("parseRankParams failed", zap.Error(err))
 		return err
 	}
@@ -811,7 +810,7 @@ func (t *searchTask) tryGeneratePlan(params []*commonpb.KeyValuePair, dsl string
 		}
 		annsFieldName = vecFields[0].Name
 	}
-	searchInfo, err := parseSearchInfo(params, t.schema.CollectionSchema, t.rankParams)
+	searchInfo, err := parseSearchInfo(params, t.schema.CollectionSchema, t.rankParams, t.bigTopKOptimization)
 	if err != nil {
 		return nil, nil, 0, false, nil, err
 	}

--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -159,14 +159,18 @@ func (t *searchTask) PreExecute(ctx context.Context) error {
 	t.SearchRequest.DbID = 0 // todo
 	t.SearchRequest.CollectionID = collID
 	log := log.Ctx(ctx).With(zap.Int64("collID", collID), zap.String("collName", collectionName))
-
-	collectionInfo, err := globalMetaCache.GetCollectionInfo(ctx, t.request.GetDbName(), collectionName, collID)
+	t.schema, err = globalMetaCache.GetCollectionSchema(ctx, t.request.GetDbName(), collectionName)
 	if err != nil {
-		log.Warn("Proxy::searchTask::PreExecute failed to GetCollectionInfo from cache",
-			zap.String("collectionName", collectionName), zap.Int64("collectionID", collID), zap.Error(err))
+		log.Warn("get collection schema failed", zap.Error(err))
 		return err
 	}
-	t.schema = collectionInfo.schema
+
+	collectionInfo, err2 := globalMetaCache.GetCollectionInfo(ctx, t.request.GetDbName(), collectionName, t.CollectionID)
+	if err2 != nil {
+		log.Warn("Proxy::searchTask::PreExecute failed to GetCollectionInfo from cache",
+			zap.String("collectionName", collectionName), zap.Int64("collectionID", t.CollectionID), zap.Error(err2))
+		return err2
+	}
 	t.bigTopKOptimization = collectionInfo.bigTopKOptimization
 
 	t.partitionKeyMode, err = isPartitionKeyMode(ctx, t.request.GetDbName(), collectionName)

--- a/internal/proxy/task_search_test.go
+++ b/internal/proxy/task_search_test.go
@@ -3121,7 +3121,7 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 
 		for _, test := range tests {
 			t.Run(test.description, func(t *testing.T) {
-				searchInfo, err := parseSearchInfo(test.validParams, nil, nil)
+				searchInfo, err := parseSearchInfo(test.validParams, nil, nil, false)
 				assert.NoError(t, err)
 				assert.NotNil(t, searchInfo.planInfo)
 				if test.description == "offsetParam" {
@@ -3142,7 +3142,7 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 			limit: externalLimit,
 		}
 
-		searchInfo, err := parseSearchInfo(offsetParam, nil, rank)
+		searchInfo, err := parseSearchInfo(offsetParam, nil, rank, false)
 		assert.NoError(t, err)
 		assert.NotNil(t, searchInfo.planInfo)
 		assert.Equal(t, int64(10), searchInfo.planInfo.GetTopk())
@@ -3176,7 +3176,7 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 			Key:   LimitKey,
 			Value: "100",
 		})
-		testRankParams, err := parseRankParams(testRankParamsPairs, schema)
+		testRankParams, err := parseRankParams(testRankParamsPairs, schema, false)
 		assert.NoError(t, err)
 
 		// 2. parse search params for sub request in hybridsearch
@@ -3195,7 +3195,7 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 			Value: "true",
 		})
 
-		searchInfo, err := parseSearchInfo(params, schema, testRankParams)
+		searchInfo, err := parseSearchInfo(params, schema, testRankParams, false)
 		assert.NoError(t, err)
 		assert.NotNil(t, searchInfo.planInfo)
 
@@ -3285,7 +3285,7 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 
 		for _, test := range tests {
 			t.Run(test.description, func(t *testing.T) {
-				searchInfo, err := parseSearchInfo(test.invalidParams, nil, nil)
+				searchInfo, err := parseSearchInfo(test.invalidParams, nil, nil, false)
 				assert.Error(t, err)
 				assert.Nil(t, searchInfo)
 
@@ -3311,7 +3311,7 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 		schema := &schemapb.CollectionSchema{
 			Fields: fields,
 		}
-		searchInfo, err := parseSearchInfo(normalParam, schema, nil)
+		searchInfo, err := parseSearchInfo(normalParam, schema, nil, false)
 		assert.Nil(t, searchInfo)
 		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
 	})
@@ -3330,7 +3330,7 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 		schema := &schemapb.CollectionSchema{
 			Fields: fields,
 		}
-		searchInfo, err := parseSearchInfo(normalParam, schema, nil)
+		searchInfo, err := parseSearchInfo(normalParam, schema, nil, false)
 		assert.Nil(t, searchInfo)
 		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
 	})
@@ -3349,7 +3349,7 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 		schema := &schemapb.CollectionSchema{
 			Fields: fields,
 		}
-		searchInfo, err := parseSearchInfo(normalParam, schema, nil)
+		searchInfo, err := parseSearchInfo(normalParam, schema, nil, false)
 		assert.NotNil(t, searchInfo)
 		assert.NoError(t, err)
 	})
@@ -3368,10 +3368,49 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 		schema := &schemapb.CollectionSchema{
 			Fields: fields,
 		}
-		searchInfo, err := parseSearchInfo(normalParam, schema, nil)
+		searchInfo, err := parseSearchInfo(normalParam, schema, nil, false)
 		assert.NotNil(t, searchInfo)
 		assert.NoError(t, err)
 		assert.Equal(t, Params.QuotaConfig.TopKLimit.GetAsInt64(), searchInfo.planInfo.GetTopk())
+	})
+
+	t.Run("check bigTopK uses dedicated topK limit", func(t *testing.T) {
+		Params.Save(Params.QuotaConfig.TopKLimit.Key, "100")
+		Params.Save(Params.QuotaConfig.BigTopKLimit.Key, "200")
+		defer Params.Reset(Params.QuotaConfig.TopKLimit.Key)
+		defer Params.Reset(Params.QuotaConfig.BigTopKLimit.Key)
+
+		param := getValidSearchParams()
+		resetSearchParamsValue(param, TopKKey, `150`)
+
+		_, err := parseSearchInfo(param, nil, nil, false)
+		assert.Error(t, err)
+
+		searchInfo, err := parseSearchInfo(param, nil, nil, true)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(150), searchInfo.planInfo.GetTopk())
+	})
+
+	t.Run("check iterator uses bigTopK limit fallback", func(t *testing.T) {
+		Params.Save(Params.QuotaConfig.TopKLimit.Key, "100")
+		Params.Save(Params.QuotaConfig.BigTopKLimit.Key, "200")
+		defer Params.Reset(Params.QuotaConfig.TopKLimit.Key)
+		defer Params.Reset(Params.QuotaConfig.BigTopKLimit.Key)
+
+		param := getValidSearchParams()
+		param = append(param, &commonpb.KeyValuePair{
+			Key:   IteratorField,
+			Value: "True",
+		})
+		resetSearchParamsValue(param, TopKKey, `250`)
+
+		searchInfo, err := parseSearchInfo(param, nil, nil, false)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(100), searchInfo.planInfo.GetTopk())
+
+		searchInfo, err = parseSearchInfo(param, nil, nil, true)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(200), searchInfo.planInfo.GetTopk())
 	})
 
 	t.Run("check correctness of group size", func(t *testing.T) {
@@ -3388,24 +3427,24 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 		schema := &schemapb.CollectionSchema{
 			Fields: fields,
 		}
-		_, err := parseSearchInfo(normalParam, schema, nil)
+		_, err := parseSearchInfo(normalParam, schema, nil, false)
 		assert.Error(t, err)
 		assert.True(t, strings.Contains(err.Error(), "exceeds configured max group size"))
 		{
 			resetSearchParamsValue(normalParam, GroupSizeKey, `10`)
-			searchInfo, err := parseSearchInfo(normalParam, schema, nil)
+			searchInfo, err := parseSearchInfo(normalParam, schema, nil, false)
 			assert.NoError(t, err)
 			assert.Equal(t, int64(10), searchInfo.planInfo.GroupSize)
 		}
 		{
 			resetSearchParamsValue(normalParam, GroupSizeKey, `-1`)
-			_, err := parseSearchInfo(normalParam, schema, nil)
+			_, err := parseSearchInfo(normalParam, schema, nil, false)
 			assert.Error(t, err)
 			assert.True(t, strings.Contains(err.Error(), "is negative"))
 		}
 		{
 			resetSearchParamsValue(normalParam, GroupSizeKey, `xxx`)
-			_, err := parseSearchInfo(normalParam, schema, nil)
+			_, err := parseSearchInfo(normalParam, schema, nil, false)
 			assert.Error(t, err)
 			assert.True(t, strings.Contains(err.Error(), "failed to parse input group size"))
 		}
@@ -3433,7 +3472,7 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 
 		t.Run("iteratorV2 normal", func(t *testing.T) {
 			param := generateValidParamsForSearchIteratorV2()
-			searchInfo, err := parseSearchInfo(param, nil, nil)
+			searchInfo, err := parseSearchInfo(param, nil, nil, false)
 			assert.NoError(t, err)
 			assert.NotNil(t, searchInfo.planInfo)
 			assert.NotEmpty(t, searchInfo.planInfo.SearchIteratorV2Info.Token)
@@ -3445,7 +3484,7 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 		t.Run("iteratorV2 without isIterator", func(t *testing.T) {
 			param := generateValidParamsForSearchIteratorV2()
 			resetSearchParamsValue(param, IteratorField, "False")
-			_, err := parseSearchInfo(param, nil, nil)
+			_, err := parseSearchInfo(param, nil, nil, false)
 			assert.Error(t, err)
 			assert.ErrorContains(t, err, "both")
 		})
@@ -3464,7 +3503,7 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 			schema := &schemapb.CollectionSchema{
 				Fields: fields,
 			}
-			_, err := parseSearchInfo(param, schema, nil)
+			_, err := parseSearchInfo(param, schema, nil, false)
 			assert.Error(t, err)
 			assert.ErrorContains(t, err, "roupBy")
 		})
@@ -3475,7 +3514,7 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 				Key:   OffsetKey,
 				Value: "10",
 			})
-			_, err := parseSearchInfo(param, nil, nil)
+			_, err := parseSearchInfo(param, nil, nil, false)
 			assert.Error(t, err)
 			assert.ErrorContains(t, err, "offset")
 		})
@@ -3486,7 +3525,7 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 				Key:   SearchIterIdKey,
 				Value: "invalid_token",
 			})
-			_, err := parseSearchInfo(param, nil, nil)
+			_, err := parseSearchInfo(param, nil, nil, false)
 			assert.Error(t, err)
 			assert.ErrorContains(t, err, "invalid token format")
 		})
@@ -3499,7 +3538,7 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 				Key:   SearchIterIdKey,
 				Value: token.String(),
 			})
-			searchInfo, err := parseSearchInfo(param, nil, nil)
+			searchInfo, err := parseSearchInfo(param, nil, nil, false)
 			assert.NoError(t, err)
 			assert.NotEmpty(t, searchInfo.planInfo.SearchIteratorV2Info.Token)
 			assert.Equal(t, token.String(), searchInfo.planInfo.SearchIteratorV2Info.Token)
@@ -3508,7 +3547,7 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 		t.Run("iteratorV2 batch size", func(t *testing.T) {
 			param := generateValidParamsForSearchIteratorV2()
 			resetSearchParamsValue(param, SearchIterBatchSizeKey, "1.123")
-			_, err := parseSearchInfo(param, nil, nil)
+			_, err := parseSearchInfo(param, nil, nil, false)
 			assert.Error(t, err)
 			assert.ErrorContains(t, err, "batch size is invalid")
 		})
@@ -3516,7 +3555,7 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 		t.Run("iteratorV2 batch size", func(t *testing.T) {
 			param := generateValidParamsForSearchIteratorV2()
 			resetSearchParamsValue(param, SearchIterBatchSizeKey, "")
-			_, err := parseSearchInfo(param, nil, nil)
+			_, err := parseSearchInfo(param, nil, nil, false)
 			assert.Error(t, err)
 			assert.ErrorContains(t, err, "batch size is required")
 		})
@@ -3524,7 +3563,7 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 		t.Run("iteratorV2 batch size negative", func(t *testing.T) {
 			param := generateValidParamsForSearchIteratorV2()
 			resetSearchParamsValue(param, SearchIterBatchSizeKey, "-1")
-			_, err := parseSearchInfo(param, nil, nil)
+			_, err := parseSearchInfo(param, nil, nil, false)
 			assert.Error(t, err)
 			assert.ErrorContains(t, err, "batch size is invalid")
 		})
@@ -3532,9 +3571,28 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 		t.Run("iteratorV2 batch size too large", func(t *testing.T) {
 			param := generateValidParamsForSearchIteratorV2()
 			resetSearchParamsValue(param, SearchIterBatchSizeKey, fmt.Sprintf("%d", Params.QuotaConfig.TopKLimit.GetAsInt64()+1))
-			_, err := parseSearchInfo(param, nil, nil)
+			_, err := parseSearchInfo(param, nil, nil, false)
 			assert.Error(t, err)
 			assert.ErrorContains(t, err, "batch size is invalid")
+		})
+
+		t.Run("iteratorV2 batch size uses bigTopK limit", func(t *testing.T) {
+			Params.Save(Params.QuotaConfig.TopKLimit.Key, "100")
+			Params.Save(Params.QuotaConfig.BigTopKLimit.Key, "200")
+			defer Params.Reset(Params.QuotaConfig.TopKLimit.Key)
+			defer Params.Reset(Params.QuotaConfig.BigTopKLimit.Key)
+
+			param := generateValidParamsForSearchIteratorV2()
+			resetSearchParamsValue(param, SearchIterBatchSizeKey, "150")
+
+			_, err := parseSearchInfo(param, nil, nil, false)
+			assert.Error(t, err)
+			assert.ErrorContains(t, err, "batch size is invalid")
+
+			searchInfo, err := parseSearchInfo(param, nil, nil, true)
+			assert.NoError(t, err)
+			assert.Equal(t, uint32(150), searchInfo.planInfo.SearchIteratorV2Info.BatchSize)
+			assert.Equal(t, int64(150), searchInfo.planInfo.GetTopk())
 		})
 
 		t.Run("iteratorV2 last bound", func(t *testing.T) {
@@ -3544,7 +3602,7 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 				Key:   SearchIterLastBoundKey,
 				Value: fmt.Sprintf("%f", kLastBound),
 			})
-			searchInfo, err := parseSearchInfo(param, nil, nil)
+			searchInfo, err := parseSearchInfo(param, nil, nil, false)
 			assert.NoError(t, err)
 			assert.NotNil(t, searchInfo.planInfo)
 			assert.Equal(t, kLastBound, *searchInfo.planInfo.SearchIteratorV2Info.LastBound)
@@ -3556,7 +3614,7 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 				Key:   SearchIterLastBoundKey,
 				Value: "xxx",
 			})
-			_, err := parseSearchInfo(param, nil, nil)
+			_, err := parseSearchInfo(param, nil, nil, false)
 			assert.Error(t, err)
 			assert.ErrorContains(t, err, "failed to parse input last bound")
 		})
@@ -3644,7 +3702,7 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 			// Add radius parameter for range search
 			resetSearchParamsValue(params, ParamsKey, `{"nprobe": 10, "radius": 0.2}`)
 
-			searchInfo, err := parseSearchInfo(params, schema, nil)
+			searchInfo, err := parseSearchInfo(params, schema, nil, false)
 			assert.Error(t, err)
 			assert.Nil(t, searchInfo)
 			assert.ErrorIs(t, err, merr.ErrParameterInvalid)
@@ -3662,7 +3720,7 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 				Value: "group_field",
 			})
 
-			searchInfo, err := parseSearchInfo(params, schema, nil)
+			searchInfo, err := parseSearchInfo(params, schema, nil, false)
 			assert.Error(t, err)
 			assert.Nil(t, searchInfo)
 			assert.ErrorIs(t, err, merr.ErrParameterInvalid)
@@ -3680,7 +3738,7 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 				Value: "True",
 			})
 
-			searchInfo, err := parseSearchInfo(params, schema, nil)
+			searchInfo, err := parseSearchInfo(params, schema, nil, false)
 			assert.Error(t, err)
 			assert.Nil(t, searchInfo)
 			assert.ErrorIs(t, err, merr.ErrParameterInvalid)
@@ -3708,7 +3766,7 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 				},
 			)
 
-			searchInfo, err := parseSearchInfo(params, schema, nil)
+			searchInfo, err := parseSearchInfo(params, schema, nil, false)
 			assert.Error(t, err)
 			assert.Nil(t, searchInfo)
 			assert.ErrorIs(t, err, merr.ErrParameterInvalid)
@@ -3720,7 +3778,7 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 			schema := createSchemaWithVectorArray("embeddings_list")
 			params := createSearchParams("embeddings_list")
 
-			searchInfo, err := parseSearchInfo(params, schema, nil)
+			searchInfo, err := parseSearchInfo(params, schema, nil, false)
 			assert.NoError(t, err)
 			assert.NotNil(t, searchInfo)
 			assert.NotNil(t, searchInfo.planInfo)
@@ -3733,7 +3791,7 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 			// Add radius parameter for range search
 			resetSearchParamsValue(params, ParamsKey, `{"nprobe": 10, "radius": 0.2}`)
 
-			searchInfo, err := parseSearchInfo(params, schema, nil)
+			searchInfo, err := parseSearchInfo(params, schema, nil, false)
 			assert.NoError(t, err)
 			assert.NotNil(t, searchInfo)
 			assert.NotNil(t, searchInfo.planInfo)
@@ -3749,7 +3807,7 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 				Value: "group_field",
 			})
 
-			searchInfo, err := parseSearchInfo(params, schema, nil)
+			searchInfo, err := parseSearchInfo(params, schema, nil, false)
 			assert.NoError(t, err)
 			assert.NotNil(t, searchInfo)
 			assert.NotNil(t, searchInfo.planInfo)
@@ -3766,7 +3824,7 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 				Value: "True",
 			})
 
-			searchInfo, err := parseSearchInfo(params, schema, nil)
+			searchInfo, err := parseSearchInfo(params, schema, nil, false)
 			assert.NoError(t, err)
 			assert.NotNil(t, searchInfo)
 			assert.NotNil(t, searchInfo.planInfo)
@@ -3777,7 +3835,7 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 			params := createSearchParams("embeddings_list")
 			resetSearchParamsValue(params, ParamsKey, `{"nprobe": 10, "radius": 0.2}`)
 
-			searchInfo, err := parseSearchInfo(params, schema, nil)
+			searchInfo, err := parseSearchInfo(params, schema, nil, false)
 			assert.Error(t, err)
 			assert.Nil(t, searchInfo)
 			// Should fail on range search first
@@ -3789,7 +3847,7 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 			params := getValidSearchParams()
 			// Don't specify anns field
 
-			searchInfo, err := parseSearchInfo(params, schema, nil)
+			searchInfo, err := parseSearchInfo(params, schema, nil, false)
 			assert.NoError(t, err)
 			assert.NotNil(t, searchInfo)
 			// Should not trigger vector array validation without anns field
@@ -3799,7 +3857,7 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 			schema := createSchemaWithVectorArray("embeddings_list")
 			params := createSearchParams("non_existent_field")
 
-			searchInfo, err := parseSearchInfo(params, schema, nil)
+			searchInfo, err := parseSearchInfo(params, schema, nil, false)
 			assert.NoError(t, err)
 			assert.NotNil(t, searchInfo)
 			// Should not trigger vector array validation for non-existent field
@@ -3821,12 +3879,12 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 				},
 			)
 
-			parsedRankParams, err := parseRankParams(rankParams, schema)
+			parsedRankParams, err := parseRankParams(rankParams, schema, false)
 			assert.NoError(t, err)
 
 			searchParams := createSearchParams("embeddings_list")
 			// Parse search info with rank params
-			searchInfo, err := parseSearchInfo(searchParams, schema, parsedRankParams)
+			searchInfo, err := parseSearchInfo(searchParams, schema, parsedRankParams, false)
 			assert.Error(t, err)
 			assert.Nil(t, searchInfo)
 			assert.ErrorIs(t, err, merr.ErrParameterInvalid)
@@ -3870,7 +3928,7 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 			Value: "true",
 		})
 
-		searchInfo, err := parseSearchInfo(params, schema, nil)
+		searchInfo, err := parseSearchInfo(params, schema, nil, false)
 		assert.NoError(t, err)
 		assert.NotNil(t, searchInfo.planInfo)
 
@@ -3905,7 +3963,7 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 			Value: "3",
 		})
 
-		searchInfo, err := parseSearchInfo(params, schema, nil)
+		searchInfo, err := parseSearchInfo(params, schema, nil, false)
 		assert.NoError(t, err)
 		assert.NotNil(t, searchInfo.planInfo)
 
@@ -3940,7 +3998,7 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 			Value: "invalid_type",
 		})
 
-		searchInfo, err := parseSearchInfo(params, schema, nil)
+		searchInfo, err := parseSearchInfo(params, schema, nil, false)
 		assert.NoError(t, err) // Should not error, just use default value
 		assert.NotNil(t, searchInfo.planInfo)
 
@@ -3968,7 +4026,7 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 			Value: "invalid_bool",
 		})
 
-		searchInfo, err := parseSearchInfo(params, schema, nil)
+		searchInfo, err := parseSearchInfo(params, schema, nil, false)
 		assert.NoError(t, err) // Should not error, just use default value
 		assert.NotNil(t, searchInfo.planInfo)
 
@@ -4013,7 +4071,7 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 					Value: tc.jsonTypeStr,
 				})
 
-				searchInfo, err := parseSearchInfo(params, schema, nil)
+				searchInfo, err := parseSearchInfo(params, schema, nil, false)
 				assert.NoError(t, err)
 				assert.NotNil(t, searchInfo.planInfo)
 

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -3320,6 +3320,12 @@ func Test_createIndexTask_PreExecute(t *testing.T) {
 				},
 			},
 		}), nil)
+		cache.On("GetCollectionInfo",
+			mock.Anything, // context.Context
+			mock.AnythingOfType("string"),
+			mock.AnythingOfType("string"),
+			mock.AnythingOfType("int64"),
+		).Return(&collectionInfo{}, nil)
 		globalMetaCache = cache
 		cit.req.ExtraParams = []*commonpb.KeyValuePair{
 			{
@@ -3356,6 +3362,12 @@ func Test_createIndexTask_PreExecute(t *testing.T) {
 			mock.AnythingOfType("string"),
 			mock.AnythingOfType("string"),
 		).Return(UniqueID(100), nil)
+		cache.On("GetCollectionInfo",
+			mock.Anything, // context.Context
+			mock.AnythingOfType("string"),
+			mock.AnythingOfType("string"),
+			mock.AnythingOfType("int64"),
+		).Return(&collectionInfo{}, nil)
 		globalMetaCache = cache
 
 		for i := 0; i < 256; i++ {
@@ -5010,6 +5022,34 @@ func TestAlterCollectionTaskValidateTTLAndTTLField(t *testing.T) {
 	})
 }
 
+func mockVectorIndexForCollection(t *testing.T, ctx context.Context, qc *MixCoordMock, colName string) {
+	t.Helper()
+
+	resp, err := qc.DescribeCollection(ctx, &milvuspb.DescribeCollectionRequest{DbName: dbName, CollectionName: colName})
+	assert.NoError(t, err)
+
+	var vecFieldID int64
+	for _, field := range resp.Schema.Fields {
+		if field.DataType == schemapb.DataType_FloatVector {
+			vecFieldID = field.FieldID
+			break
+		}
+	}
+	assert.NotEqual(t, int64(0), vecFieldID)
+
+	qc.DescribeIndexFunc = func(ctx context.Context, request *indexpb.DescribeIndexRequest, opts ...grpc.CallOption) (*indexpb.DescribeIndexResponse, error) {
+		return &indexpb.DescribeIndexResponse{
+			Status: merr.Success(),
+			IndexInfos: []*indexpb.IndexInfo{
+				{FieldID: vecFieldID},
+			},
+		}, nil
+	}
+	t.Cleanup(func() {
+		qc.DescribeIndexFunc = nil
+	})
+}
+
 func TestTaskPartitionKeyIsolation(t *testing.T) {
 	qc := NewMixCoordMock()
 	ctx := context.Background()
@@ -5163,7 +5203,7 @@ func TestTaskPartitionKeyIsolation(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("alter collection without isolation", func(t *testing.T) {
+	t.Run("alter collection without isolation property should succeed", func(t *testing.T) {
 		colName := collectionName + "AlterNoIso"
 		createIsoCollection(colName, true, false, true)
 		alterTask := alterCollectionTask{
@@ -5193,34 +5233,219 @@ func TestTaskPartitionKeyIsolation(t *testing.T) {
 		assert.ErrorContains(t, alterTask.PreExecute(ctx), "partition key isolation mode is enabled but current Milvus does not support it")
 	})
 
-	t.Run("alter collection with vec index and isolation", func(t *testing.T) {
+	t.Run("alter isolation with vector index should fail", func(t *testing.T) {
 		paramtable.Get().CommonCfg.EnableMaterializedView.SwapTempValue("true")
 		defer paramtable.Get().CommonCfg.EnableMaterializedView.SwapTempValue("false")
 		colName := collectionName + "AlterVecIndex"
 		createIsoCollection(colName, true, true, false)
-		resp, err := qc.DescribeCollection(ctx, &milvuspb.DescribeCollectionRequest{DbName: dbName, CollectionName: colName})
-		assert.NoError(t, err)
-		var vecFieldID int64 = 0
-		for _, field := range resp.Schema.Fields {
-			if field.DataType == schemapb.DataType_FloatVector {
-				vecFieldID = field.FieldID
-				break
-			}
-		}
-		assert.NotEqual(t, vecFieldID, int64(0))
-		qc.DescribeIndexFunc = func(ctx context.Context, request *indexpb.DescribeIndexRequest, opts ...grpc.CallOption) (*indexpb.DescribeIndexResponse, error) {
-			return &indexpb.DescribeIndexResponse{
-				Status: merr.Success(),
-				IndexInfos: []*indexpb.IndexInfo{
-					{
-						FieldID: vecFieldID,
-					},
-				},
-			}, nil
-		}
+		mockVectorIndexForCollection(t, ctx, qc, colName)
 		alterTask := getAlterCollectionTask(colName, false)
 		assert.ErrorContains(t, alterTask.PreExecute(ctx),
 			"can not alter partition key isolation mode if the collection already has a vector index. Please drop the index first")
+	})
+
+	t.Run("delete isolation property with vector index should fail", func(t *testing.T) {
+		paramtable.Get().CommonCfg.EnableMaterializedView.SwapTempValue("true")
+		defer paramtable.Get().CommonCfg.EnableMaterializedView.SwapTempValue("false")
+		colName := collectionName + "DeleteIsoWithIdx"
+		createIsoCollection(colName, true, true, false)
+		mockVectorIndexForCollection(t, ctx, qc, colName)
+		alterTask := &alterCollectionTask{
+			AlterCollectionRequest: &milvuspb.AlterCollectionRequest{
+				Base:           &commonpb.MsgBase{},
+				CollectionName: colName,
+				DeleteKeys:     []string{common.PartitionKeyIsolationKey},
+			},
+			mixCoord: qc,
+		}
+		err = alterTask.PreExecute(ctx)
+		assert.ErrorContains(t, err,
+			"can not alter partition key isolation mode if the collection already has a vector index. Please drop the index first")
+	})
+
+	t.Run("delete isolation property without vector index should succeed", func(t *testing.T) {
+		colName := collectionName + "DeleteIsoNoIdx"
+		createIsoCollection(colName, true, true, false)
+		alterTask := &alterCollectionTask{
+			AlterCollectionRequest: &milvuspb.AlterCollectionRequest{
+				Base:           &commonpb.MsgBase{},
+				CollectionName: colName,
+				DeleteKeys:     []string{common.PartitionKeyIsolationKey},
+			},
+			mixCoord: qc,
+		}
+		err := alterTask.PreExecute(ctx)
+		assert.NoError(t, err)
+	})
+
+	t.Run("alter unrelated property with isolation enabled should not check index", func(t *testing.T) {
+		paramtable.Get().CommonCfg.EnableMaterializedView.SwapTempValue("true")
+		defer paramtable.Get().CommonCfg.EnableMaterializedView.SwapTempValue("false")
+		colName := collectionName + "AlterOtherPropWithIso"
+		createIsoCollection(colName, true, true, false)
+		mockVectorIndexForCollection(t, ctx, qc, colName)
+		alterTask := &alterCollectionTask{
+			AlterCollectionRequest: &milvuspb.AlterCollectionRequest{
+				Base:           &commonpb.MsgBase{},
+				CollectionName: colName,
+				Properties:     []*commonpb.KeyValuePair{{Key: common.CollectionTTLConfigKey, Value: "3600"}},
+			},
+			mixCoord: qc,
+		}
+		err = alterTask.PreExecute(ctx)
+		assert.NoError(t, err)
+	})
+}
+
+func TestAlterCollectionBigTopKOptimization(t *testing.T) {
+	qc := NewMixCoordMock()
+	ctx := context.Background()
+	err := InitMetaCache(ctx, qc)
+	assert.NoError(t, err)
+	prefix := "TestBigTopKOptimization"
+
+	getSchema := func(colName string) *schemapb.CollectionSchema {
+		fieldName2Type := make(map[string]schemapb.DataType)
+		fieldName2Type["fvec_field"] = schemapb.DataType_FloatVector
+		fieldName2Type["int64_field"] = schemapb.DataType_Int64
+		return constructCollectionSchemaByDataType(colName, fieldName2Type, "int64_field", false)
+	}
+
+	createCollection := func(colName string, bigTopKEnabled bool) {
+		schema := getSchema(colName)
+		marshaledSchema, err := proto.Marshal(schema)
+		assert.NoError(t, err)
+		props := []*commonpb.KeyValuePair{}
+		if bigTopKEnabled {
+			props = append(props, &commonpb.KeyValuePair{Key: common.BigTopKOptimizationEnabledKey, Value: "true"})
+		}
+		createColReq := &milvuspb.CreateCollectionRequest{
+			Base: &commonpb.MsgBase{
+				MsgType:   commonpb.MsgType_CreateCollection,
+				MsgID:     100,
+				Timestamp: 100,
+			},
+			DbName:         dbName,
+			CollectionName: colName,
+			Schema:         marshaledSchema,
+			ShardsNum:      1,
+			Properties:     props,
+		}
+		stats, err := qc.CreateCollection(ctx, createColReq)
+		assert.NoError(t, err)
+		assert.Equal(t, commonpb.ErrorCode_Success, stats.ErrorCode)
+	}
+
+	t.Run("alter bigTopK from false to true without vector index", func(t *testing.T) {
+		colName := prefix + funcutil.GenRandomStr()
+		createCollection(colName, false)
+		alterTask := &alterCollectionTask{
+			AlterCollectionRequest: &milvuspb.AlterCollectionRequest{
+				Base:           &commonpb.MsgBase{},
+				CollectionName: colName,
+				Properties:     []*commonpb.KeyValuePair{{Key: common.BigTopKOptimizationEnabledKey, Value: "true"}},
+			},
+			mixCoord: qc,
+		}
+		err := alterTask.PreExecute(ctx)
+		assert.NoError(t, err)
+	})
+
+	t.Run("alter bigTopK from true to false without vector index", func(t *testing.T) {
+		colName := prefix + funcutil.GenRandomStr()
+		createCollection(colName, true)
+		alterTask := &alterCollectionTask{
+			AlterCollectionRequest: &milvuspb.AlterCollectionRequest{
+				Base:           &commonpb.MsgBase{},
+				CollectionName: colName,
+				Properties:     []*commonpb.KeyValuePair{{Key: common.BigTopKOptimizationEnabledKey, Value: "false"}},
+			},
+			mixCoord: qc,
+		}
+		err := alterTask.PreExecute(ctx)
+		assert.NoError(t, err)
+	})
+
+	t.Run("alter bigTopK from false to true with vector index should fail", func(t *testing.T) {
+		colName := prefix + funcutil.GenRandomStr()
+		createCollection(colName, false)
+		mockVectorIndexForCollection(t, ctx, qc, colName)
+		alterTask := &alterCollectionTask{
+			AlterCollectionRequest: &milvuspb.AlterCollectionRequest{
+				Base:           &commonpb.MsgBase{},
+				CollectionName: colName,
+				Properties:     []*commonpb.KeyValuePair{{Key: common.BigTopKOptimizationEnabledKey, Value: "true"}},
+			},
+			mixCoord: qc,
+		}
+		err = alterTask.PreExecute(ctx)
+		assert.ErrorContains(t, err,
+			"can not alter bigtopk_optimization.enabled if the collection already has a vector index. Please drop the index first")
+	})
+
+	t.Run("alter bigTopK from true to false with vector index should fail", func(t *testing.T) {
+		colName := prefix + funcutil.GenRandomStr()
+		createCollection(colName, true)
+		mockVectorIndexForCollection(t, ctx, qc, colName)
+		alterTask := &alterCollectionTask{
+			AlterCollectionRequest: &milvuspb.AlterCollectionRequest{
+				Base:           &commonpb.MsgBase{},
+				CollectionName: colName,
+				Properties:     []*commonpb.KeyValuePair{{Key: common.BigTopKOptimizationEnabledKey, Value: "false"}},
+			},
+			mixCoord: qc,
+		}
+		err = alterTask.PreExecute(ctx)
+		assert.ErrorContains(t, err,
+			"can not alter bigtopk_optimization.enabled if the collection already has a vector index. Please drop the index first")
+	})
+
+	t.Run("delete bigTopK property with vector index should fail", func(t *testing.T) {
+		colName := prefix + funcutil.GenRandomStr()
+		createCollection(colName, true)
+		mockVectorIndexForCollection(t, ctx, qc, colName)
+		alterTask := &alterCollectionTask{
+			AlterCollectionRequest: &milvuspb.AlterCollectionRequest{
+				Base:           &commonpb.MsgBase{},
+				CollectionName: colName,
+				DeleteKeys:     []string{common.BigTopKOptimizationEnabledKey},
+			},
+			mixCoord: qc,
+		}
+		err = alterTask.PreExecute(ctx)
+		assert.ErrorContains(t, err,
+			"can not alter bigtopk_optimization.enabled if the collection already has a vector index. Please drop the index first")
+	})
+
+	t.Run("delete bigTopK property without vector index should succeed", func(t *testing.T) {
+		colName := prefix + funcutil.GenRandomStr()
+		createCollection(colName, true)
+		alterTask := &alterCollectionTask{
+			AlterCollectionRequest: &milvuspb.AlterCollectionRequest{
+				Base:           &commonpb.MsgBase{},
+				CollectionName: colName,
+				DeleteKeys:     []string{common.BigTopKOptimizationEnabledKey},
+			},
+			mixCoord: qc,
+		}
+		err := alterTask.PreExecute(ctx)
+		assert.NoError(t, err)
+	})
+
+	t.Run("alter unrelated property with bigTopK enabled should not check index", func(t *testing.T) {
+		colName := prefix + funcutil.GenRandomStr()
+		createCollection(colName, true)
+		mockVectorIndexForCollection(t, ctx, qc, colName)
+		alterTask := &alterCollectionTask{
+			AlterCollectionRequest: &milvuspb.AlterCollectionRequest{
+				Base:           &commonpb.MsgBase{},
+				CollectionName: colName,
+				Properties:     []*commonpb.KeyValuePair{{Key: common.CollectionTTLConfigKey, Value: "3600"}},
+			},
+			mixCoord: qc,
+		}
+		err = alterTask.PreExecute(ctx)
+		assert.NoError(t, err)
 	})
 }
 

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -178,7 +178,7 @@ func validateRunAnalyzer(req *milvuspb.RunAnalyzerRequest) error {
 	return nil
 }
 
-func validateMaxQueryResultWindow(offset int64, limit int64) error {
+func validateMaxQueryResultWindow(offset int64, limit int64, bigTopKEnabled bool) error {
 	if offset < 0 {
 		return fmt.Errorf("%s [%d] is invalid, should be gte than 0", OffsetKey, offset)
 	}
@@ -188,14 +188,20 @@ func validateMaxQueryResultWindow(offset int64, limit int64) error {
 
 	depth := offset + limit
 	maxQueryResultWindow := Params.QuotaConfig.MaxQueryResultWindow.GetAsInt64()
+	if bigTopKEnabled {
+		maxQueryResultWindow = Params.QuotaConfig.BigMaxQueryResultWindow.GetAsInt64()
+	}
 	if depth <= 0 || depth > maxQueryResultWindow {
 		return fmt.Errorf("(offset+limit) should be in range [1, %d], but got %d", maxQueryResultWindow, depth)
 	}
 	return nil
 }
 
-func validateLimit(limit int64) error {
+func validateLimit(limit int64, bigTopKEnabled bool) error {
 	topKLimit := Params.QuotaConfig.TopKLimit.GetAsInt64()
+	if bigTopKEnabled {
+		topKLimit = Params.QuotaConfig.BigTopKLimit.GetAsInt64()
+	}
 	if limit <= 0 || limit > topKLimit {
 		return fmt.Errorf("it should be in range [1, %d], but got %d", topKLimit, limit)
 	}

--- a/internal/proxy/util_test.go
+++ b/internal/proxy/util_test.go
@@ -2118,19 +2118,41 @@ func Test_NQLimit(t *testing.T) {
 
 func Test_TopKLimit(t *testing.T) {
 	paramtable.Init()
-	assert.Nil(t, validateLimit(16384))
-	assert.Nil(t, validateLimit(1))
-	assert.Error(t, validateLimit(16385))
-	assert.Error(t, validateLimit(0))
+	assert.Nil(t, validateLimit(16384, false))
+	assert.Nil(t, validateLimit(1, false))
+	assert.Error(t, validateLimit(16385, false))
+	assert.Error(t, validateLimit(0, false))
+}
+
+func Test_BigTopKLimit(t *testing.T) {
+	paramtable.Init()
+	Params.Save(Params.QuotaConfig.TopKLimit.Key, "100")
+	Params.Save(Params.QuotaConfig.BigTopKLimit.Key, "200")
+	defer Params.Reset(Params.QuotaConfig.TopKLimit.Key)
+	defer Params.Reset(Params.QuotaConfig.BigTopKLimit.Key)
+
+	assert.Nil(t, validateLimit(100, false))
+	assert.Error(t, validateLimit(101, false))
+
+	assert.Nil(t, validateLimit(200, true))
+	assert.Nil(t, validateLimit(150, true))
+	assert.Error(t, validateLimit(201, true))
+	assert.Error(t, validateLimit(0, true))
 }
 
 func Test_MaxQueryResultWindow(t *testing.T) {
 	paramtable.Init()
-	assert.Nil(t, validateMaxQueryResultWindow(0, 16384))
-	assert.Nil(t, validateMaxQueryResultWindow(0, 1))
-	assert.Error(t, validateMaxQueryResultWindow(0, 16385))
-	assert.Error(t, validateMaxQueryResultWindow(0, 0))
-	assert.Error(t, validateMaxQueryResultWindow(1, 0))
+	assert.Nil(t, validateMaxQueryResultWindow(0, 16384, false))
+	assert.Nil(t, validateMaxQueryResultWindow(0, 1, false))
+	assert.Error(t, validateMaxQueryResultWindow(0, 16385, false))
+	assert.Error(t, validateMaxQueryResultWindow(0, 0, false))
+	assert.Error(t, validateMaxQueryResultWindow(1, 0, false))
+
+	Params.Save(Params.QuotaConfig.BigMaxQueryResultWindow.Key, "1000000")
+	defer Params.Reset(Params.QuotaConfig.BigMaxQueryResultWindow.Key)
+	assert.Nil(t, validateMaxQueryResultWindow(0, 16385, true))
+	assert.Nil(t, validateMaxQueryResultWindow(0, 1000000, true))
+	assert.Error(t, validateMaxQueryResultWindow(0, 1000001, true))
 }
 
 func Test_GetPartitionProgressFailed(t *testing.T) {

--- a/internal/util/indexparamcheck/utils.go
+++ b/internal/util/indexparamcheck/utils.go
@@ -95,6 +95,7 @@ func CheckAutoIndexConfig() {
 	CheckAutoIndexHelper(autoIndexCfg.BinaryIndexParams.Key, autoIndexCfg.BinaryIndexParams.GetAsJSONMap(), schemapb.DataType_BinaryVector)
 	CheckAutoIndexHelper(autoIndexCfg.BinaryIndexParams.Key, autoIndexCfg.DeduplicateIndexParams.GetAsJSONMap(), schemapb.DataType_BinaryVector)
 	CheckAutoIndexHelper(autoIndexCfg.SparseIndexParams.Key, autoIndexCfg.SparseIndexParams.GetAsJSONMap(), schemapb.DataType_SparseFloatVector)
+	CheckAutoIndexHelper(autoIndexCfg.BigTopKIndexParams.Key, autoIndexCfg.BigTopKIndexParams.GetAsJSONMap(), schemapb.DataType_FloatVector)
 }
 
 func ValidateParamTable() {

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -265,6 +265,9 @@ const (
 	AllowInsertAutoIDKey    = "allow_insert_auto_id"
 	DisableFuncRuntimeCheck = "disable_func_runtime_check"
 
+	// BigTopK optimization
+	BigTopKOptimizationEnabledKey = "bigtopk_optimization.enabled"
+
 	// warmup related
 	WarmupKey            = "warmup"
 	WarmupScalarFieldKey = "warmup.scalarField"
@@ -450,6 +453,19 @@ func IsPartitionKeyIsolationKvEnabled(kvs ...*commonpb.KeyValuePair) (bool, erro
 			val, err := strconv.ParseBool(strings.ToLower(kv.Value))
 			if err != nil {
 				return false, errors.Wrap(err, "failed to parse partition key isolation")
+			}
+			return val, nil
+		}
+	}
+	return false, nil
+}
+
+func IsBigTopKOptimizationEnabled(kvs ...*commonpb.KeyValuePair) (bool, error) {
+	for _, kv := range kvs {
+		if kv.Key == BigTopKOptimizationEnabledKey {
+			val, err := strconv.ParseBool(strings.ToLower(kv.Value))
+			if err != nil {
+				return false, errors.Wrap(err, "failed to parse bigTopK Optimization")
 			}
 			return val, nil
 		}

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -395,6 +395,50 @@ func TestWarmupPolicy(t *testing.T) {
 	})
 }
 
+func TestIsBigTopKOptimizationEnabled(t *testing.T) {
+	t.Run("returns true when enabled", func(t *testing.T) {
+		kvs := []*commonpb.KeyValuePair{
+			{Key: BigTopKOptimizationEnabledKey, Value: "true"},
+		}
+		enabled, err := IsBigTopKOptimizationEnabled(kvs...)
+		assert.NoError(t, err)
+		assert.True(t, enabled)
+	})
+
+	t.Run("returns false when disabled", func(t *testing.T) {
+		kvs := []*commonpb.KeyValuePair{
+			{Key: BigTopKOptimizationEnabledKey, Value: "false"},
+		}
+		enabled, err := IsBigTopKOptimizationEnabled(kvs...)
+		assert.NoError(t, err)
+		assert.False(t, enabled)
+	})
+
+	t.Run("returns false when not present", func(t *testing.T) {
+		kvs := []*commonpb.KeyValuePair{
+			{Key: "other.key", Value: "true"},
+		}
+		enabled, err := IsBigTopKOptimizationEnabled(kvs...)
+		assert.NoError(t, err)
+		assert.False(t, enabled)
+	})
+
+	t.Run("returns false for empty kvs", func(t *testing.T) {
+		enabled, err := IsBigTopKOptimizationEnabled()
+		assert.NoError(t, err)
+		assert.False(t, enabled)
+	})
+
+	t.Run("returns false for invalid value", func(t *testing.T) {
+		kvs := []*commonpb.KeyValuePair{
+			{Key: BigTopKOptimizationEnabledKey, Value: "invalid"},
+		}
+		enabled, err := IsBigTopKOptimizationEnabled(kvs...)
+		assert.Error(t, err)
+		assert.False(t, enabled)
+	})
+}
+
 func TestWKTWKBConversion(t *testing.T) {
 	testCases := []struct {
 		name string

--- a/pkg/util/paramtable/autoindex_param.go
+++ b/pkg/util/paramtable/autoindex_param.go
@@ -40,6 +40,7 @@ type AutoIndexConfig struct {
 	SparseIndexParams      ParamItem  `refreshable:"true"`
 	BinaryIndexParams      ParamItem  `refreshable:"true"`
 	DeduplicateIndexParams ParamItem  `refreshable:"true"`
+	BigTopKIndexParams     ParamItem  `refreshable:"true"`
 	EnableDeduplicateIndex ParamItem  `refreshable:"true"`
 	PrepareParams          ParamItem  `refreshable:"true"`
 	LoadAdaptParams        ParamItem  `refreshable:"true"`
@@ -61,8 +62,6 @@ type AutoIndexConfig struct {
 	ScalarTimestampTzIndexType ParamItem `refreshable:"true"`
 
 	BitmapCardinalityLimit ParamItem `refreshable:"true"`
-
-	BigTopKIndexParams ParamItem `refreshable:"true"`
 }
 
 const (
@@ -140,6 +139,15 @@ func (p *AutoIndexConfig) init(base *BaseTable) {
 		PanicIfEmpty: false,
 	}
 	p.EnableDeduplicateIndex.Init(base.mgr)
+
+	p.BigTopKIndexParams = ParamItem{
+		Key:          "autoIndex.params.bigTopK.build",
+		Version:      "2.6.13",
+		DefaultValue: `{"nlist": 128, "index_type": "IVF_SQ8", "metric_type": "COSINE"}`,
+		Formatter:    GetBuildParamFormatter(FloatVectorDefaultMetricType, "autoIndex.params.bigTopK.build"),
+		Export:       true,
+	}
+	p.BigTopKIndexParams.Init(base.mgr)
 
 	p.PrepareParams = ParamItem{
 		Key:     "autoIndex.params.prepare",
@@ -296,15 +304,6 @@ func (p *AutoIndexConfig) init(base *BaseTable) {
 		},
 	}
 	p.ScalarVarcharIndexType.Init(base.mgr)
-
-	p.BigTopKIndexParams = ParamItem{
-		Key:          "autoIndex.params.bigTopK.build",
-		Version:      "2.6.12",
-		DefaultValue: `{"nlist": 128, "index_type": "IVF_FLAT", "metric_type": "COSINE"}`,
-		Formatter:    GetBuildParamFormatter(FloatVectorDefaultMetricType, "autoIndex.params.bigTopK.build"),
-		Export:       true,
-	}
-	p.BigTopKIndexParams.Init(base.mgr)
 
 	p.ScalarBoolIndexType = ParamItem{
 		Version: "2.4.0",

--- a/pkg/util/paramtable/autoindex_param.go
+++ b/pkg/util/paramtable/autoindex_param.go
@@ -61,6 +61,8 @@ type AutoIndexConfig struct {
 	ScalarTimestampTzIndexType ParamItem `refreshable:"true"`
 
 	BitmapCardinalityLimit ParamItem `refreshable:"true"`
+
+	BigTopKIndexParams ParamItem `refreshable:"true"`
 }
 
 const (
@@ -294,6 +296,15 @@ func (p *AutoIndexConfig) init(base *BaseTable) {
 		},
 	}
 	p.ScalarVarcharIndexType.Init(base.mgr)
+
+	p.BigTopKIndexParams = ParamItem{
+		Key:          "autoIndex.params.bigTopK.build",
+		Version:      "2.6.12",
+		DefaultValue: `{"nlist": 128, "index_type": "IVF_FLAT", "metric_type": "COSINE"}`,
+		Formatter:    GetBuildParamFormatter(FloatVectorDefaultMetricType, "autoIndex.params.bigTopK.build"),
+		Export:       true,
+	}
+	p.BigTopKIndexParams.Init(base.mgr)
 
 	p.ScalarBoolIndexType = ParamItem{
 		Version: "2.4.0",

--- a/pkg/util/paramtable/quota_param.go
+++ b/pkg/util/paramtable/quota_param.go
@@ -124,8 +124,10 @@ type quotaConfig struct {
 	MaxCollectionNum               ParamItem `refreshable:"true"`
 	MaxCollectionNumPerDB          ParamItem `refreshable:"true"`
 	TopKLimit                      ParamItem `refreshable:"true"`
+	BigTopKLimit                   ParamItem `refreshable:"true"`
 	NQLimit                        ParamItem `refreshable:"true"`
 	MaxQueryResultWindow           ParamItem `refreshable:"true"`
+	BigMaxQueryResultWindow        ParamItem `refreshable:"true"`
 	MaxOutputSize                  ParamItem `refreshable:"true"`
 	MaxInsertSize                  ParamItem `refreshable:"true"`
 	MaxResourceGroupNumOfQueryNode ParamItem `refreshable:"true"`
@@ -1454,6 +1456,15 @@ Check https://milvus.io/docs/limitations.md for more details.`,
 	}
 	p.TopKLimit.Init(base.mgr)
 
+	p.BigTopKLimit = ParamItem{
+		Key:          "quotaAndLimits.limits.bigTopK",
+		Version:      "2.6.13",
+		DefaultValue: "1000000",
+		Doc: `Search limit for collections with bigTopK optimization enabled, which applies on:
+maximum # of results to return (topK).`,
+	}
+	p.BigTopKLimit.Init(base.mgr)
+
 	p.NQLimit = ParamItem{
 		Key:          "quotaAndLimits.limits.nq",
 		Version:      "2.3.0",
@@ -1473,6 +1484,14 @@ Check https://milvus.io/docs/limitations.md for more details.`,
 		Doc:          `Query limit, which applies on: maximum of offset + limit`,
 	}
 	p.MaxQueryResultWindow.Init(base.mgr)
+
+	p.BigMaxQueryResultWindow = ParamItem{
+		Key:          "quotaAndLimits.limits.bigMaxQueryResultWindow",
+		Version:      "2.6.13",
+		DefaultValue: "1000000",
+		Doc:          `Query limit for collections with bigTopK optimization enabled, which applies on: maximum of offset + limit`,
+	}
+	p.BigMaxQueryResultWindow.Init(base.mgr)
 
 	p.MaxOutputSize = ParamItem{
 		Key:          "quotaAndLimits.limits.maxOutputSize",


### PR DESCRIPTION
issue: #48011 

  ## Summary
  - Add a new collection-level property `bigtopk_optimization.enabled` that allows collections to use significantly higher TopK limits (up to 1M by default vs 16384) for search and query operations
  - When enabled, auto-index creation selects an IVF-based index type (configurable via `autoIndex.params.bigTopK.build`, default IVF_SQ8) instead of the default HNSW, which is better suited for large TopK retrieval scenarios
  - Introduce dedicated quota parameters (`quotaAndLimits.limits.bigTopK` and `quotaAndLimits.limits.bigMaxQueryResultWindow`) to control the relaxed limits independently
  - The property can be set at collection creation or via alter collection, but changing it requires dropping any existing vector index first
- This PR also fix the partitionkey isolation alter bug when non related properties could affect isolation's vector index check