### PR TITLE
fix: add missing snapshot privileges to v2 built-in groups

### DIFF
--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -376,6 +376,8 @@ var (
 		commonpb.ObjectPrivilege_PrivilegeListResourceGroups.String(),
 		commonpb.ObjectPrivilege_PrivilegeListPrivilegeGroups.String(),
 		commonpb.ObjectPrivilege_PrivilegeGetReplicateConfiguration.String(),
+		commonpb.ObjectPrivilege_PrivilegeDescribeSnapshot.String(),
+		commonpb.ObjectPrivilege_PrivilegeListSnapshots.String(),
 	})
 
 	ClusterReadWritePrivileges = append(ClusterReadOnlyPrivileges,
@@ -384,6 +386,8 @@ var (
 			commonpb.ObjectPrivilege_PrivilegeTransferNode.String(),
 			commonpb.ObjectPrivilege_PrivilegeTransferReplica.String(),
 			commonpb.ObjectPrivilege_PrivilegeUpdateResourceGroups.String(),
+			commonpb.ObjectPrivilege_PrivilegeCreateSnapshot.String(),
+			commonpb.ObjectPrivilege_PrivilegeDropSnapshot.String(),
 		})...,
 	)
 
@@ -404,6 +408,7 @@ var (
 			commonpb.ObjectPrivilege_PrivilegeDropPrivilegeGroup.String(),
 			commonpb.ObjectPrivilege_PrivilegeOperatePrivilegeGroup.String(),
 			commonpb.ObjectPrivilege_PrivilegeUpdateReplicateConfiguration.String(),
+			commonpb.ObjectPrivilege_PrivilegeRestoreSnapshot.String(),
 		})...,
 	)
 )

--- a/pkg/util/constant_test.go
+++ b/pkg/util/constant_test.go
@@ -37,3 +37,25 @@ func TestGetReplicateConfigurationPrivilege(t *testing.T) {
 	}
 	assert.True(t, found, "PrivilegeGetReplicateConfiguration should be in ClusterReadOnlyPrivileges")
 }
+
+func TestSnapshotPrivilegesInBuiltinGroups(t *testing.T) {
+	describePrivilege := MetaStore2API(commonpb.ObjectPrivilege_PrivilegeDescribeSnapshot.String())
+	listPrivilege := MetaStore2API(commonpb.ObjectPrivilege_PrivilegeListSnapshots.String())
+	createPrivilege := MetaStore2API(commonpb.ObjectPrivilege_PrivilegeCreateSnapshot.String())
+	dropPrivilege := MetaStore2API(commonpb.ObjectPrivilege_PrivilegeDropSnapshot.String())
+	restorePrivilege := MetaStore2API(commonpb.ObjectPrivilege_PrivilegeRestoreSnapshot.String())
+
+	assert.Contains(t, ClusterReadOnlyPrivileges, describePrivilege)
+	assert.Contains(t, ClusterReadOnlyPrivileges, listPrivilege)
+
+	assert.Contains(t, ClusterReadWritePrivileges, describePrivilege)
+	assert.Contains(t, ClusterReadWritePrivileges, listPrivilege)
+	assert.Contains(t, ClusterReadWritePrivileges, createPrivilege)
+	assert.Contains(t, ClusterReadWritePrivileges, dropPrivilege)
+
+	assert.Contains(t, ClusterAdminPrivileges, describePrivilege)
+	assert.Contains(t, ClusterAdminPrivileges, listPrivilege)
+	assert.Contains(t, ClusterAdminPrivileges, createPrivilege)
+	assert.Contains(t, ClusterAdminPrivileges, dropPrivilege)
+	assert.Contains(t, ClusterAdminPrivileges, restorePrivilege)
+}


### PR DESCRIPTION
This PR fixes issue [#47855](https://github.com/milvus-io/milvus/issues/47855), where the built-in v2 RBAC privilege groups (ClusterReadOnly, ClusterReadWrite, and ClusterAdmin) were missing snapshot operations. This aligns the behavior of the v2 built-in groups with the v1 privilege groups.

## Changes made
Added the following missing cluster-level snapshot privileges to  pkg/util/constant.go:
- ClusterReadOnlyPrivileges: Added DescribeSnapshot and ListSnapshots
- ClusterReadWritePrivileges: Inherits read-only + added CreateSnapshot and DropSnapshot
- ClusterAdminPrivileges: Inherits read-write + added RestoreSnapshot

Related Issue: #47855