### PR TITLE
fix: [2.6] eliminate ArrowTable memory accumulation in GroupChunkTranslator::get_cells() (#47859)

### DIFF
--- a/internal/core/src/segcore/memory_planner.cpp
+++ b/internal/core/src/segcore/memory_planner.cpp
@@ -252,133 +252,134 @@ LoadWithStrategy(const std::vector<std::string>& remote_files,
 }
 
 std::vector<std::future<void>>
-LoadWithStrategyAsync(milvus::OpContext* op_ctx,
-                      const std::vector<std::string>& remote_files,
-                      std::shared_ptr<ArrowReaderChannel>& channel,
-                      int64_t memory_limit,
-                      std::unique_ptr<RowGroupSplitStrategy> strategy,
-                      const std::vector<std::vector<int64_t>>& row_group_lists,
-                      const milvus_storage::ArrowFileSystemPtr& fs,
-                      const std::shared_ptr<arrow::Schema>& schema,
-                      milvus::proto::common::LoadPriority priority) {
-    AssertInfo(remote_files.size() == row_group_lists.size(),
-               "[StorageV2] Number of remote files must match number of "
-               "row group lists");
-    auto& pool = ThreadPools::GetThreadPool(milvus::PriorityForLoad(priority));
-
-    // First pass: split row groups and count total number of tasks
-    // Cache the blocks to avoid calling split() twice
-    std::vector<std::vector<RowGroupBlock>> all_blocks;
-    all_blocks.reserve(remote_files.size());
-    size_t total_tasks = 0;
-
-    for (size_t file_idx = 0; file_idx < remote_files.size(); ++file_idx) {
-        const auto& row_groups = row_group_lists[file_idx];
-        if (!row_groups.empty()) {
-            auto blocks = strategy->split(row_groups);
-            total_tasks += blocks.size();
-            all_blocks.push_back(std::move(blocks));
-        } else {
-            all_blocks.emplace_back();  // empty vector for this file
-        }
-    }
-
-    // If no tasks, close channel immediately and return
-    if (total_tasks == 0) {
+LoadCellBatchAsync(milvus::OpContext* op_ctx,
+                   const std::vector<std::string>& remote_files,
+                   std::vector<CellSpec> cell_specs,
+                   std::shared_ptr<CellReaderChannel>& channel,
+                   int64_t memory_limit,
+                   const milvus_storage::ArrowFileSystemPtr& fs,
+                   milvus::proto::common::LoadPriority priority) {
+    if (cell_specs.empty()) {
         channel->close();
         return {};
     }
 
-    // Use atomic counter to track remaining tasks.
-    // The last task to complete will close the channel.
-    // This avoids the deadlock caused by std::packaged_task holding
-    // the callable (and captured shared_ptr) in its shared_state,
-    // which is only released when the future is destroyed.
-    auto remaining_tasks = std::make_shared<std::atomic<size_t>>(total_tasks);
+    // Sort by (file_idx, local_rg_offset) for IO merging
+    std::sort(cell_specs.begin(),
+              cell_specs.end(),
+              [](const CellSpec& a, const CellSpec& b) {
+                  if (a.file_idx != b.file_idx) {
+                      return a.file_idx < b.file_idx;
+                  }
+                  return a.local_rg_offset < b.local_rg_offset;
+              });
 
-    // Create and submit tasks for each block
+    // Determine batch size based on parallel degree
+    auto parallel_degree =
+        static_cast<size_t>(memory_limit / FILE_SLICE_SIZE.load());
+    size_t cells_per_batch = std::max<size_t>(
+        1, (cell_specs.size() + parallel_degree - 1) / parallel_degree);
+
+    // Group consecutive, same-file cells into batches for IO merging
+    struct CellBatch {
+        size_t file_idx;
+        int64_t rg_offset;
+        int64_t rg_count;
+        std::vector<CellSpec> cells;
+    };
+
+    std::vector<CellBatch> batches;
+    CellBatch current{};
+
+    for (const auto& spec : cell_specs) {
+        bool should_split = false;
+        if (!current.cells.empty()) {
+            if (spec.file_idx != current.file_idx ||
+                spec.local_rg_offset != current.rg_offset + current.rg_count ||
+                current.cells.size() >= cells_per_batch) {
+                should_split = true;
+            }
+        }
+        if (should_split) {
+            batches.push_back(std::move(current));
+            current = {};
+        }
+        if (current.cells.empty()) {
+            current.file_idx = spec.file_idx;
+            current.rg_offset = spec.local_rg_offset;
+            current.rg_count = 0;
+        }
+        current.rg_count += spec.rg_count;
+        current.cells.push_back(spec);
+    }
+    if (!current.cells.empty()) {
+        batches.push_back(std::move(current));
+    }
+
+    if (batches.empty()) {
+        channel->close();
+        return {};
+    }
+
+    auto& pool = ThreadPools::GetThreadPool(milvus::PriorityForLoad(priority));
+    auto remaining = std::make_shared<std::atomic<size_t>>(batches.size());
+    auto reader_memory_limit =
+        std::max<int64_t>(memory_limit / static_cast<int64_t>(batches.size()),
+                          FILE_SLICE_SIZE.load());
+
     std::vector<std::future<void>> futures;
-    futures.reserve(total_tasks);
+    futures.reserve(batches.size());
 
-    for (size_t file_idx = 0; file_idx < remote_files.size(); ++file_idx) {
-        const auto& file = remote_files[file_idx];
-        const auto& blocks = all_blocks[file_idx];
-
-        if (blocks.empty()) {
-            continue;
-        }
-
-        LOG_INFO("[StorageV2] split row groups into blocks: {} for file {}",
-                 blocks.size(),
-                 file);
-
-        auto reader_memory_limit = std::max<int64_t>(
-            memory_limit / blocks.size(), FILE_SLICE_SIZE.load());
-
-        for (const auto& block : blocks) {
-            futures.emplace_back(pool.Submit([block,
-                                              fs,
-                                              file,
-                                              file_idx,
-                                              schema,
-                                              reader_memory_limit,
-                                              channel,
-                                              remaining_tasks,
-                                              op_ctx]() {
-                // Use a guard to ensure we always decrement the counter
-                // and close the channel when the last task completes,
-                // even if an exception is thrown.
-                auto task_guard =
-                    folly::makeGuard([&channel, &remaining_tasks]() {
-                        if (remaining_tasks->fetch_sub(1) == 1) {
-                            // This is the last task, close the channel
-                            channel->close();
-                        }
-                    });
-
-                AssertInfo(fs != nullptr, "[StorageV2] file system is nullptr");
-                CheckCancellation(op_ctx, -1, "LoadWithStrategyAsync");
-                auto result = milvus_storage::FileRowGroupReader::Make(
-                    fs,
-                    file,
-                    schema,
-                    reader_memory_limit,
-                    milvus::storage::GetReaderProperties());
-                AssertInfo(result.ok(),
-                           "[StorageV2] Failed to create row group reader: " +
-                               result.status().ToString());
-                auto row_group_reader = result.ValueOrDie();
-                auto status = row_group_reader->SetRowGroupOffsetAndCount(
-                    block.offset, block.count);
-                AssertInfo(status.ok(),
-                           "[StorageV2] Failed to set row group offset "
-                           "and count " +
-                               std::to_string(block.offset) + " and " +
-                               std::to_string(block.count) + " with error " +
-                               status.ToString());
-                auto ret = std::make_shared<ArrowDataWrapper>();
-                for (int64_t i = 0; i < block.count; ++i) {
-                    std::shared_ptr<arrow::Table> table;
-                    auto status = row_group_reader->ReadNextRowGroup(&table);
-                    AssertInfo(status.ok(),
-                               "[StorageV2] Failed to read row group " +
-                                   std::to_string(block.offset + i) +
-                                   " from file " + file + " with error " +
-                                   status.ToString());
-                    ret->arrow_tables.push_back(
-                        {file_idx,
-                         static_cast<size_t>(block.offset + i),
-                         table});
+    for (auto& batch : batches) {
+        futures.emplace_back(pool.Submit([batch = std::move(batch),
+                                          fs,
+                                          &remote_files,
+                                          reader_memory_limit,
+                                          channel,
+                                          remaining,
+                                          op_ctx]() {
+            auto task_guard = folly::makeGuard([&channel, &remaining]() {
+                if (remaining->fetch_sub(1) == 1) {
+                    channel->close();
                 }
-                auto close_status = row_group_reader->Close();
-                AssertInfo(close_status.ok(),
-                           "[StorageV2] Failed to close row group reader "
-                           "for file " +
-                               file + " with error " + close_status.ToString());
+            });
+            CheckCancellation(op_ctx, -1, "LoadCellBatchAsync");
 
-                channel->push(ret);
-            }));
-        }
+            auto result = milvus_storage::FileRowGroupReader::Make(
+                fs,
+                remote_files[batch.file_idx],
+                nullptr,
+                reader_memory_limit,
+                milvus::storage::GetReaderProperties());
+            AssertInfo(result.ok(),
+                       "[StorageV2] Failed to create reader: " +
+                           result.status().ToString());
+            auto reader = result.ValueOrDie();
+            auto status = reader->SetRowGroupOffsetAndCount(batch.rg_offset,
+                                                            batch.rg_count);
+            AssertInfo(status.ok(),
+                       "[StorageV2] Failed to set row group range: " +
+                           status.ToString());
+
+            for (const auto& cell : batch.cells) {
+                auto cell_result = std::make_shared<CellLoadResult>();
+                cell_result->cid = cell.cid;
+                cell_result->tables.reserve(cell.rg_count);
+                for (int64_t i = 0; i < cell.rg_count; ++i) {
+                    std::shared_ptr<arrow::Table> table;
+                    auto s = reader->ReadNextRowGroup(&table);
+                    AssertInfo(s.ok(),
+                               "[StorageV2] Failed to read row group: " +
+                                   s.ToString());
+                    cell_result->tables.push_back(std::move(table));
+                }
+                channel->push(std::move(cell_result));
+            }
+            auto close_status = reader->Close();
+            AssertInfo(close_status.ok(),
+                       "[StorageV2] Failed to close reader: " +
+                           close_status.ToString());
+        }));
     }
 
     return futures;

--- a/internal/core/src/segcore/memory_planner.h
+++ b/internal/core/src/segcore/memory_planner.h
@@ -15,15 +15,19 @@
 // limitations under the License.
 #pragma once
 
-#include <vector>
-#include <cstdint>
+#include <arrow/record_batch.h>
+#include <arrow/table.h>
 #include <cstddef>
+#include <cstdint>
 #include <future>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "common/Channel.h"
+#include "common/FieldData.h"
 #include "common/OpContext.h"
 #include "milvus-storage/common/metadata.h"
-#include <arrow/record_batch.h>
-#include <vector>
-#include "common/FieldData.h"
 #include "milvus-storage/filesystem/fs.h"
 
 namespace milvus::segcore {
@@ -94,30 +98,47 @@ LoadWithStrategy(const std::vector<std::string>& remote_files,
                  milvus::proto::common::LoadPriority priority =
                      milvus::proto::common::LoadPriority::HIGH);
 
+// ---- Cell-batch loading ----
+
+// A cell specification: identifies a cell's location within a specific file.
+struct CellSpec {
+    int64_t cid;              // cell id
+    size_t file_idx;          // index into the remote_files list
+    int64_t local_rg_offset;  // file-local row group start offset
+    int64_t rg_count;         // number of row groups in this cell
+};
+
+// Result of loading a single cell: cid + the arrow tables read.
+struct CellLoadResult {
+    int64_t cid;
+    std::vector<std::shared_ptr<arrow::Table>> tables;
+};
+
+using CellReaderChannel = milvus::Channel<std::shared_ptr<CellLoadResult>>;
+
 /**
- * Load storage v2 files with specified strategy. The number of row group readers is determined by the strategy.
+ * Load cells from storage v2 files in batches. Cells are sorted by
+ * (file_idx, local_rg_offset) and grouped into IO-merged batches.
+ * Each completed cell is pushed to the channel immediately, enabling
+ * streaming consumption without accumulating all ArrowTables.
  *
- * @param op_ctx: operation context for cancellation
- * @param remote_files: list of remote files
- * @param channel: channel to store the loaded data
- * @param memory_limit: memory limit for each chunk
- * @param strategy: strategy to split row groups
- * @param row_group_lists: list of row group lists
- * @param fs: the arrow filesystem pointer used to load
- * @param schema: schema of the data, if not provided, storage v2 will read all columns of the files.
- * @param priority: load priority
- * @return vector of futures, encapsulating the loading tasks and potential exceptions
+ * @param op_ctx operation context for cancellation
+ * @param remote_files list of remote files
+ * @param cell_specs cell specifications (sorted internally)
+ * @param channel channel to receive loaded cell data; closed when all done
+ * @param memory_limit total memory limit for readers
+ * @param fs arrow filesystem
+ * @param priority load priority
+ * @return vector of futures for the batch loading tasks
  */
 std::vector<std::future<void>>
-LoadWithStrategyAsync(milvus::OpContext* op_ctx,
-                      const std::vector<std::string>& remote_files,
-                      std::shared_ptr<ArrowReaderChannel>& channel,
-                      int64_t memory_limit,
-                      std::unique_ptr<RowGroupSplitStrategy> strategy,
-                      const std::vector<std::vector<int64_t>>& row_group_lists,
-                      const milvus_storage::ArrowFileSystemPtr& fs,
-                      const std::shared_ptr<arrow::Schema>& schema = nullptr,
-                      milvus::proto::common::LoadPriority priority =
-                          milvus::proto::common::LoadPriority::HIGH);
+LoadCellBatchAsync(milvus::OpContext* op_ctx,
+                   const std::vector<std::string>& remote_files,
+                   std::vector<CellSpec> cell_specs,
+                   std::shared_ptr<CellReaderChannel>& channel,
+                   int64_t memory_limit,
+                   const milvus_storage::ArrowFileSystemPtr& fs,
+                   milvus::proto::common::LoadPriority priority =
+                       milvus::proto::common::LoadPriority::HIGH);
 
 }  // namespace milvus::segcore

--- a/internal/core/src/segcore/storagev2translator/GroupCTMeta.h
+++ b/internal/core/src/segcore/storagev2translator/GroupCTMeta.h
@@ -35,6 +35,9 @@ struct GroupCTMeta : public milvus::cachinglayer::Meta {
     size_t num_fields_;
     // total number of row groups
     size_t total_row_groups_;
+    // Per-cell [start, end) row group range (global indices).
+    // Cells never span files — each cell's row groups come from the same file.
+    std::vector<std::pair<size_t, size_t>> cell_row_group_ranges_;
 
     GroupCTMeta(size_t num_fields,
                 milvus::cachinglayer::StorageType storage_type,
@@ -54,9 +57,7 @@ struct GroupCTMeta : public milvus::cachinglayer::Meta {
     // Get the range of row groups for a cell [start, end)
     std::pair<size_t, size_t>
     get_row_group_range(size_t cid) const {
-        size_t start = cid * kRowGroupsPerCell;
-        size_t end = std::min(start + kRowGroupsPerCell, total_row_groups_);
-        return {start, end};
+        return cell_row_group_ranges_[cid];
     }
 };
 

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslatorTest.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslatorTest.cpp
@@ -285,12 +285,12 @@ TEST_P(GroupChunkTranslatorTest, TestMultipleFiles) {
         /* warmup_policy */ "");
 
     // Test total number of cells across all files
+    // Cells never span files, so count per-file ceil
     int64_t expected_total_cells = 0;
     for (auto row_groups : expected_row_groups_per_file) {
-        expected_total_cells += row_groups;
+        expected_total_cells +=
+            (row_groups + kRowGroupsPerCell - 1) / kRowGroupsPerCell;
     }
-    expected_total_cells =
-        (expected_total_cells + kRowGroupsPerCell - 1) / kRowGroupsPerCell;
     EXPECT_EQ(translator->num_cells(), expected_total_cells);
 
     // Test get_file_and_row_group_offset for global row group indices across
@@ -364,9 +364,8 @@ TEST_P(GroupChunkTranslatorTest, TestMultipleFiles) {
         auto usage = translator->estimated_byte_size_of_cell(cid).first;
 
         // Calculate expected size by summing all row groups in this cell
-        size_t rg_start = cid * kRowGroupsPerCell;
-        size_t rg_end =
-            std::min(rg_start + kRowGroupsPerCell, total_row_groups);
+        auto [rg_start, rg_end] = static_cast<GroupCTMeta*>(translator->meta())
+                                      ->get_row_group_range(cid);
         int64_t expected_size = 0;
         for (size_t rg_idx = rg_start; rg_idx < rg_end; ++rg_idx) {
             auto [file_idx, local_rg_idx] =

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
@@ -120,6 +120,14 @@ ManifestGroupTranslator::ManifestGroupTranslator(
     size_t num_cells =
         (total_row_groups + kRowGroupsPerCell - 1) / kRowGroupsPerCell;
 
+    // Populate cell_row_group_ranges_ (single data source, no multi-file)
+    meta_.cell_row_group_ranges_.reserve(num_cells);
+    for (size_t cid = 0; cid < num_cells; ++cid) {
+        size_t start = cid * kRowGroupsPerCell;
+        size_t end = std::min(start + kRowGroupsPerCell, total_row_groups);
+        meta_.cell_row_group_ranges_.push_back({start, end});
+    }
+
     // Build num_rows_until_chunk_ and chunk_memory_size_
     meta_.num_rows_until_chunk_.reserve(num_cells + 1);
     meta_.num_rows_until_chunk_.push_back(0);


### PR DESCRIPTION
Cherry-pick from master
pr: #47859
Related to #47858

The previous implementation collected all row group ArrowTables into an unordered_map before processing any cell, causing peak memory usage proportional to the total decoded size of all requested row groups. Tables were held until get_cells() returned, so already-processed cells could not release their memory early.

Two changes address this:

1. Cell boundaries now align to file boundaries — each cell's row groups come entirely from one file, simplifying IO batch construction and removing cross-file reader coordination.

2. Replace LoadWithStrategyAsync with LoadCellBatchAsync, which groups cells into IO-merged batches by (file, offset) continuity, reads row groups sequentially within each batch, and pushes each completed cell to a channel immediately. The consumer loop calls load_group_chunk() on each cell as it arrives, so only a bounded number of ArrowTables exist in memory at any time.

Files changed:
- GroupCTMeta.h: add cell_row_group_ranges_ vector, get_row_group_range() now does table lookup instead of arithmetic
- GroupChunkTranslator.cpp: constructor builds cells per-file; get_cells() uses LoadCellBatchAsync + streaming pop-and-convert loop
- ManifestGroupTranslator.cpp: populate cell_row_group_ranges_ for single data source
- memory_planner.h/cpp: add CellSpec, CellLoadResult, CellReaderChannel types and LoadCellBatchAsync(); remove LoadWithStrategyAsync() (no remaining callers)
- GroupChunkTranslatorTest.cpp: update expected cell count to per-file ceil; use get_row_group_range() for byte size validation