### PR TITLE
test: Add null vector coverage to chaos tests

### DIFF
--- a/tests/python_client/pytest.ini
+++ b/tests/python_client/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 
 
-addopts = --host localhost -v
+addopts = -p no:locust --host localhost -v
 #  python3 -W ignore -m pytest
 
 log_format = [%(asctime)s - %(levelname)s - %(name)s]: %(message)s (%(filename)s:%(lineno)s)


### PR DESCRIPTION
## Summary

Add nullable vector field validation to the chaos test framework via three independent checkers, following the existing one-operation-per-checker pattern.

**Related issue**: #47867

### Changes (v2, addressing review feedback)

**Removed** (per review):
- Reverted all modifications to existing `SearchChecker`, `QueryChecker`, `AddFieldChecker`
- Removed `TestNullVectorDataPersistence` from `test_data_persistence.py` — persistence verification is covered by checkers

**New independent checkers (`chaos/checker.py`)**:

| Checker | Op Enum | Responsibility | Frequency |
|---|---|---|---|
| `NullVectorSearchChecker` | `null_vector_search` | Search on nullable vector fields, NaN distance detection with accumulation threshold (3 consecutive) | `WAIT_PER_OP / 10` |
| `NullVectorQueryChecker` | `null_vector_query` | Query nullable vector fields, validate null/non-null ratio, fail on all-null (data corruption) | `WAIT_PER_OP / 10` |
| `AddVectorFieldChecker` | `add_vector_field` | Add nullable FLOAT_VECTOR + HNSW index + insert + query verification, with vector field limit guard | `WAIT_PER_OP * 6` |

**Review feedback addressed**:
- Each checker has independent stats and frequency (no sampling bias)
- NaN detection uses accumulation threshold (`NAN_THRESHOLD=3`) to avoid false positives from transient errors or zero-norm vectors
- `AddVectorFieldChecker` checks vector field limit dynamically via `describe_collection` (no hardcoded `MAX_FIELD_NUM`)
- Query results are properly validated (no `result = True` hardcode)

**pytest.ini**: disable locust plugin (`-p no:locust`) to fix `--host` option conflict

### Test Plan

- [x] `checker.py` syntax verified
- [x] New checkers follow existing patterns (TensorSearchChecker, JsonQueryChecker, GeoQueryChecker)
- [x] No modifications to existing checkers

🤖 Generated with [Claude Code](https://claude.com/claude-code)