### PR TITLE
fix: update IndexMeta in PutOrRef for existing collections

### DIFF
--- a/internal/core/src/segcore/Collection.cpp
+++ b/internal/core/src/segcore/Collection.cpp
@@ -62,8 +62,9 @@ Collection::parseIndexMeta(const void* index_proto, const int64_t length) {
         return;
     }
 
-    index_meta_ = std::make_shared<CollectionIndexMeta>(indexMeta);
-    LOG_INFO("index meta info: {}", index_meta_->ToString());
+    auto new_index_meta = std::make_shared<CollectionIndexMeta>(indexMeta);
+    LOG_INFO("index meta info: {}", new_index_meta->ToString());
+    set_index_meta(new_index_meta);
 }
 
 void

--- a/internal/core/src/segcore/Collection.h
+++ b/internal/core/src/segcore/Collection.h
@@ -63,13 +63,15 @@ class Collection {
         }
     }
 
-    IndexMetaPtr&
+    IndexMetaPtr
     get_index_meta() {
+        std::shared_lock lock(index_meta_mutex_);
         return index_meta_;
     }
 
     void
     set_index_meta(const IndexMetaPtr index_meta) {
+        std::unique_lock lock(index_meta_mutex_);
         index_meta_ = index_meta;
     }
 
@@ -83,6 +85,7 @@ class Collection {
     SchemaPtr schema_;
     std::shared_mutex schema_mutex_;
     IndexMetaPtr index_meta_;
+    std::shared_mutex index_meta_mutex_;
 };
 
 using CollectionPtr = std::unique_ptr<Collection>;

--- a/internal/querynodev2/segments/collection.go
+++ b/internal/querynodev2/segments/collection.go
@@ -104,6 +104,16 @@ func (m *collectionManager) PutOrRef(collectionID int64, schema *schemapb.Collec
 				zap.Any("schema", schema),
 			)
 		}
+		// Always update index meta to ensure newly indexed fields are visible
+		// for search plan creation (CollectionIndexMeta::HasField check).
+		if meta != nil {
+			if err := collection.ccollection.UpdateIndexMeta(meta); err != nil {
+				log.Warn("failed to update index meta",
+					zap.Int64("collectionID", collectionID),
+					zap.Error(err),
+				)
+			}
+		}
 		collection.Ref(1)
 		return nil
 	}

--- a/internal/querynodev2/segments/collection.go
+++ b/internal/querynodev2/segments/collection.go
@@ -108,10 +108,7 @@ func (m *collectionManager) PutOrRef(collectionID int64, schema *schemapb.Collec
 		// for search plan creation (CollectionIndexMeta::HasField check).
 		if meta != nil {
 			if err := collection.ccollection.UpdateIndexMeta(meta); err != nil {
-				log.Warn("failed to update index meta",
-					zap.Int64("collectionID", collectionID),
-					zap.Error(err),
-				)
+				return err
 			}
 		}
 		collection.Ref(1)

--- a/internal/util/segcore/collection.go
+++ b/internal/util/segcore/collection.go
@@ -99,6 +99,24 @@ func (c *CCollection) IndexMeta() *segcorepb.CollectionIndexMeta {
 	return c.indexMeta
 }
 
+func (c *CCollection) UpdateIndexMeta(meta *segcorepb.CollectionIndexMeta) error {
+	if meta == nil {
+		return nil
+	}
+
+	indexMetaBlob, err := proto.Marshal(meta)
+	if err != nil {
+		return err
+	}
+
+	status := C.SetIndexMeta(c.ptr, unsafe.Pointer(&indexMetaBlob[0]), (C.int64_t)(len(indexMetaBlob)))
+	if err := ConsumeCStatusIntoError(&status); err != nil {
+		return err
+	}
+	c.indexMeta = meta
+	return nil
+}
+
 func (c *CCollection) UpdateSchema(sch *schemapb.CollectionSchema, version uint64) error {
 	if sch == nil {
 		return merr.WrapErrServiceInternal("update collection schema with nil")


### PR DESCRIPTION
issue: #47873 
relate: #45993 

#47829  changed Reopen to succeed instead of failing fast, which makes PutOrRef more likely to find existing collections whose IndexMeta was never updated, causing "field is not loaded" errors on new vector fields.

Add CCollection.UpdateIndexMeta() and call it in PutOrRef to keep IndexMeta in sync with schema updates.