### PR TITLE
doc: add .claude/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,7 @@ pkg/streaming/proto/**/*.pb.go
 
 #AI rules
 WARP.md
+.claude/
 
 # Antlr
 .antlr


### PR DESCRIPTION
## Summary
- Add `.claude/` to `.gitignore` to prevent Claude Code runtime files (settings.local.json, memory/, projects/) from being accidentally committed

## Test plan
- [x] Confirm `.claude/` directory is ignored while `CLAUDE.md` remains tracked
- [x] Confirm DCO check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)