### PR TITLE
fix: add snapshot privileges to v2 cluster privilege groups

### DIFF
--- a/internal/datacoord/garbage_collector_test.go
+++ b/internal/datacoord/garbage_collector_test.go
@@ -2394,7 +2394,8 @@ func TestGarbageCollector_recycleUnusedTextIndexFiles_SnapshotReference(t *testi
 	// Mock WalkWithPrefix to simulate text index files
 	mockWalk := mockey.Mock((*storage.LocalChunkManager).WalkWithPrefix).To(
 		func(cm *storage.LocalChunkManager, ctx context.Context, prefix string,
-			recursive bool, fn storage.ChunkObjectWalkFunc) error {
+			recursive bool, fn storage.ChunkObjectWalkFunc,
+		) error {
 			if strings.Contains(prefix, "text_index") {
 				chunkInfo := &storage.ChunkObjectInfo{
 					FilePath:   "gc/text_index/401/1/100/10/1001/101/file1",
@@ -2481,7 +2482,8 @@ func TestGarbageCollector_recycleUnusedJSONIndexFiles_SnapshotReference(t *testi
 	// Mock WalkWithPrefix to simulate JSON index files
 	mockWalk := mockey.Mock((*storage.LocalChunkManager).WalkWithPrefix).To(
 		func(cm *storage.LocalChunkManager, ctx context.Context, prefix string,
-			recursive bool, fn storage.ChunkObjectWalkFunc) error {
+			recursive bool, fn storage.ChunkObjectWalkFunc,
+		) error {
 			if strings.Contains(prefix, "json_index") {
 				chunkInfo := &storage.ChunkObjectInfo{
 					FilePath:   "gc/json_index/402/1/100/10/1002/102/json_file1",
@@ -2632,7 +2634,8 @@ func TestGarbageCollector_recycleUnusedTextIndexFiles_SkipWhenRefIndexNotLoaded(
 
 	mockWalk := mockey.Mock((*storage.LocalChunkManager).WalkWithPrefix).To(
 		func(cm *storage.LocalChunkManager, ctx context.Context, prefix string,
-			recursive bool, fn storage.ChunkObjectWalkFunc) error {
+			recursive bool, fn storage.ChunkObjectWalkFunc,
+		) error {
 			if strings.Contains(prefix, "text_index") {
 				chunkInfo := &storage.ChunkObjectInfo{
 					FilePath:   "gc/text_index/401/1/100/10/1001/101/file1",
@@ -2710,7 +2713,8 @@ func TestGarbageCollector_recycleUnusedJSONIndexFiles_SkipWhenRefIndexNotLoaded(
 
 	mockWalk := mockey.Mock((*storage.LocalChunkManager).WalkWithPrefix).To(
 		func(cm *storage.LocalChunkManager, ctx context.Context, prefix string,
-			recursive bool, fn storage.ChunkObjectWalkFunc) error {
+			recursive bool, fn storage.ChunkObjectWalkFunc,
+		) error {
 			if strings.Contains(prefix, "json_index") {
 				chunkInfo := &storage.ChunkObjectInfo{
 					FilePath:   "gc/json_index/402/1/100/10/1002/102/json_file1",

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -376,6 +376,8 @@ var (
 		commonpb.ObjectPrivilege_PrivilegeListResourceGroups.String(),
 		commonpb.ObjectPrivilege_PrivilegeListPrivilegeGroups.String(),
 		commonpb.ObjectPrivilege_PrivilegeGetReplicateConfiguration.String(),
+		commonpb.ObjectPrivilege_PrivilegeDescribeSnapshot.String(),
+		commonpb.ObjectPrivilege_PrivilegeListSnapshots.String(),
 	})
 
 	ClusterReadWritePrivileges = append(ClusterReadOnlyPrivileges,
@@ -384,6 +386,8 @@ var (
 			commonpb.ObjectPrivilege_PrivilegeTransferNode.String(),
 			commonpb.ObjectPrivilege_PrivilegeTransferReplica.String(),
 			commonpb.ObjectPrivilege_PrivilegeUpdateResourceGroups.String(),
+			commonpb.ObjectPrivilege_PrivilegeCreateSnapshot.String(),
+			commonpb.ObjectPrivilege_PrivilegeDropSnapshot.String(),
 		})...,
 	)
 
@@ -404,6 +408,7 @@ var (
 			commonpb.ObjectPrivilege_PrivilegeDropPrivilegeGroup.String(),
 			commonpb.ObjectPrivilege_PrivilegeOperatePrivilegeGroup.String(),
 			commonpb.ObjectPrivilege_PrivilegeUpdateReplicateConfiguration.String(),
+			commonpb.ObjectPrivilege_PrivilegeRestoreSnapshot.String(),
 		})...,
 	)
 )

--- a/pkg/util/constant_test.go
+++ b/pkg/util/constant_test.go
@@ -19,6 +19,7 @@ package util
 import (
 	"testing"
 
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
@@ -36,4 +37,84 @@ func TestGetReplicateConfigurationPrivilege(t *testing.T) {
 		}
 	}
 	assert.True(t, found, "PrivilegeGetReplicateConfiguration should be in ClusterReadOnlyPrivileges")
+}
+
+func TestSnapshotPrivilegesInClusterGroups(t *testing.T) {
+	describeSnapshot := MetaStore2API(commonpb.ObjectPrivilege_PrivilegeDescribeSnapshot.String())
+	listSnapshots := MetaStore2API(commonpb.ObjectPrivilege_PrivilegeListSnapshots.String())
+	createSnapshot := MetaStore2API(commonpb.ObjectPrivilege_PrivilegeCreateSnapshot.String())
+	dropSnapshot := MetaStore2API(commonpb.ObjectPrivilege_PrivilegeDropSnapshot.String())
+	restoreSnapshot := MetaStore2API(commonpb.ObjectPrivilege_PrivilegeRestoreSnapshot.String())
+
+	tests := []struct {
+		name      string
+		privilege string
+		inGroups  map[string][]string
+		notIn     map[string][]string
+	}{
+		{
+			name:      "DescribeSnapshot in ReadOnly/ReadWrite/Admin",
+			privilege: describeSnapshot,
+			inGroups: map[string][]string{
+				"ClusterReadOnly":  ClusterReadOnlyPrivileges,
+				"ClusterReadWrite": ClusterReadWritePrivileges,
+				"ClusterAdmin":     ClusterAdminPrivileges,
+			},
+		},
+		{
+			name:      "ListSnapshots in ReadOnly/ReadWrite/Admin",
+			privilege: listSnapshots,
+			inGroups: map[string][]string{
+				"ClusterReadOnly":  ClusterReadOnlyPrivileges,
+				"ClusterReadWrite": ClusterReadWritePrivileges,
+				"ClusterAdmin":     ClusterAdminPrivileges,
+			},
+		},
+		{
+			name:      "CreateSnapshot in ReadWrite/Admin only",
+			privilege: createSnapshot,
+			inGroups: map[string][]string{
+				"ClusterReadWrite": ClusterReadWritePrivileges,
+				"ClusterAdmin":     ClusterAdminPrivileges,
+			},
+			notIn: map[string][]string{
+				"ClusterReadOnly": ClusterReadOnlyPrivileges,
+			},
+		},
+		{
+			name:      "DropSnapshot in ReadWrite/Admin only",
+			privilege: dropSnapshot,
+			inGroups: map[string][]string{
+				"ClusterReadWrite": ClusterReadWritePrivileges,
+				"ClusterAdmin":     ClusterAdminPrivileges,
+			},
+			notIn: map[string][]string{
+				"ClusterReadOnly": ClusterReadOnlyPrivileges,
+			},
+		},
+		{
+			name:      "RestoreSnapshot in Admin only",
+			privilege: restoreSnapshot,
+			inGroups: map[string][]string{
+				"ClusterAdmin": ClusterAdminPrivileges,
+			},
+			notIn: map[string][]string{
+				"ClusterReadOnly":  ClusterReadOnlyPrivileges,
+				"ClusterReadWrite": ClusterReadWritePrivileges,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			for groupName, group := range tc.inGroups {
+				assert.True(t, lo.Contains(group, tc.privilege),
+					"%s should be in %s", tc.privilege, groupName)
+			}
+			for groupName, group := range tc.notIn {
+				assert.False(t, lo.Contains(group, tc.privilege),
+					"%s should NOT be in %s", tc.privilege, groupName)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary
- Add snapshot operation privileges to v2 cluster-level builtin privilege groups for RBAC consistency
- DescribeSnapshot, ListSnapshots → ClusterReadOnly
- CreateSnapshot, DropSnapshot → ClusterReadWrite
- RestoreSnapshot → ClusterAdmin
- Add unit tests validating privilege group membership

issue: #47855

## Test plan
- [x] Unit tests for snapshot privilege group membership (`TestSnapshotPrivilegesInClusterGroups`)
- [x] Lint check passed on `pkg/util/`