### PR TITLE
fix: fix non-atomic CreateCollection causes schema loss

### DIFF
--- a/internal/datacoord/task_stats.go
+++ b/internal/datacoord/task_stats.go
@@ -302,6 +302,9 @@ func (st *statsTask) prepareJobRequest(ctx context.Context, segment *SegmentInfo
 	if err != nil || collInfo == nil {
 		return nil, fmt.Errorf("failed to get collection info: %w", err)
 	}
+	if collInfo.Schema == nil || len(collInfo.Schema.GetFields()) == 0 {
+		return nil, fmt.Errorf("collection schema is nil or has no fields, collectionID: %d", segment.GetCollectionID())
+	}
 
 	// Calculate binlog allocation
 	binlogNum := (segment.getSegmentSize()/Params.DataNodeCfg.BinLogMaxSize.GetAsInt64() + 1) *

--- a/internal/datacoord/task_stats_test.go
+++ b/internal/datacoord/task_stats_test.go
@@ -27,6 +27,7 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/datacoord/session"
 	catalogmocks "github.com/milvus-io/milvus/internal/metastore/mocks"
@@ -590,6 +591,30 @@ func (s *statsTaskSuite) TestPrepareJobRequest() {
 		_, err := st.prepareJobRequest(context.Background(), segment)
 		s.Error(err)
 		s.Contains(err.Error(), "failed to get collection info")
+	})
+
+	s.Run("nil schema", func() {
+		handler := NewNMockHandler(s.T())
+		handler.EXPECT().GetCollection(mock.Anything, s.collID).Return(&collectionInfo{
+			Schema: nil,
+		}, nil)
+		st.handler = handler
+
+		_, err := st.prepareJobRequest(context.Background(), segment)
+		s.Error(err)
+		s.Contains(err.Error(), "collection schema is nil or has no fields")
+	})
+
+	s.Run("empty schema fields", func() {
+		handler := NewNMockHandler(s.T())
+		handler.EXPECT().GetCollection(mock.Anything, s.collID).Return(&collectionInfo{
+			Schema: &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{}},
+		}, nil)
+		st.handler = handler
+
+		_, err := st.prepareJobRequest(context.Background(), segment)
+		s.Error(err)
+		s.Contains(err.Error(), "collection schema is nil or has no fields")
 	})
 
 	s.Run("allocation failure", func() {

--- a/internal/proxy/impl_test.go
+++ b/internal/proxy/impl_test.go
@@ -1434,6 +1434,20 @@ func TestProxy_ImportV2(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotEqual(t, int32(0), rsp.GetStatus().GetCode())
 
+		// schema has no fields
+		mc = NewMockCache(t)
+		mc.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(&schemaInfo{
+			CollectionSchema: &schemapb.CollectionSchema{},
+		}, nil).Once()
+		mc.EXPECT().GetCollectionID(mock.Anything, mock.Anything, mock.Anything).Return(0, nil)
+		mc.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(&schemaInfo{
+			CollectionSchema: &schemapb.CollectionSchema{},
+		}, nil).Once()
+		globalMetaCache = mc
+		rsp, err = node.ImportV2(ctx, &internalpb.ImportRequest{CollectionName: "aaa"})
+		assert.NoError(t, err)
+		assert.NotEqual(t, int32(0), rsp.GetStatus().GetCode())
+
 		// get channel failed
 		mc = NewMockCache(t)
 		mc.EXPECT().GetCollectionID(mock.Anything, mock.Anything, mock.Anything).Return(0, nil)
@@ -1474,7 +1488,7 @@ func TestProxy_ImportV2(t *testing.T) {
 		mc = NewMockCache(t)
 		mc.EXPECT().GetCollectionID(mock.Anything, mock.Anything, mock.Anything).Return(0, nil)
 		mc.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(&schemaInfo{
-			CollectionSchema: &schemapb.CollectionSchema{},
+			CollectionSchema: &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{{FieldID: 1}}},
 		}, nil)
 		mc.EXPECT().GetPartitionID(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(0, mockErr)
 		globalMetaCache = mc
@@ -1486,7 +1500,7 @@ func TestProxy_ImportV2(t *testing.T) {
 		mc = NewMockCache(t)
 		mc.EXPECT().GetCollectionID(mock.Anything, mock.Anything, mock.Anything).Return(0, nil)
 		mc.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(&schemaInfo{
-			CollectionSchema: &schemapb.CollectionSchema{},
+			CollectionSchema: &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{{FieldID: 1}}},
 		}, nil)
 		mc.EXPECT().GetPartitionID(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(0, nil)
 		globalMetaCache = mc

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -4284,7 +4284,7 @@ func TestProxy_Import(t *testing.T) {
 		mc := NewMockCache(t)
 		mc.EXPECT().GetCollectionID(mock.Anything, mock.Anything, mock.Anything).Return(0, nil)
 		mc.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(&schemaInfo{
-			CollectionSchema: &schemapb.CollectionSchema{},
+			CollectionSchema: &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{{FieldID: 1}}},
 		}, nil)
 		mc.EXPECT().GetPartitionID(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(0, nil)
 		globalMetaCache = mc

--- a/internal/proxy/task_import.go
+++ b/internal/proxy/task_import.go
@@ -106,6 +106,9 @@ func (it *importTask) PreExecute(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	if schema.CollectionSchema == nil || len(schema.CollectionSchema.GetFields()) == 0 {
+		return merr.WrapErrImportFailed("collection schema has no fields")
+	}
 	it.schema = schema
 
 	channels, err := node.chMgr.getVChannels(collectionID)


### PR DESCRIPTION
## Summary

- **Root cause fix**: Reverse write order in `Catalog.CreateCollection` to save fields/partitions/functions first, then collection key last. The collection key is the "commit point" — if a crash happens before it's written, the DDL ack callback retries the full write since the collection won't be in `collID2Meta` on reload.
- **Defense-in-depth**: `AddCollection` detects and repairs collections with empty fields; stats task and import task validate schema before proceeding.

## Details

During RootCoord failover, `Catalog.CreateCollection` was non-atomic with collection key saved first. If the process crashed between the collection key write and the fields write, the collection was persisted without fields. On restart, `AddCollection`'s idempotency check short-circuited because the collection already existed in `collID2Meta`, so fields were never saved. This caused "primary field is not found" errors in stats/index/compaction/import tasks.

### Changes

1. `kv_catalog.go` — Save fields/partitions/functions before collection key
2. `meta_table.go` — Detect and repair collections with empty fields in `AddCollection`
3. `task_stats.go` — Validate schema before building stats request
4. `task_import.go` — Validate schema before broadcasting import

issue: https://github.com/milvus-io/milvus/issues/47898

🤖 Generated with [Claude Code](https://claude.com/claude-code)