### PR TITLE
feat: add function field backfill - Part 2(#44444)

### DIFF
--- a/internal/datacoord/compaction_inspector.go
+++ b/internal/datacoord/compaction_inspector.go
@@ -45,6 +45,7 @@ var maxCompactionTaskExecutionDuration = map[datapb.CompactionType]time.Duration
 	datapb.CompactionType_Level0DeleteCompaction: 30 * time.Minute,
 	datapb.CompactionType_ClusteringCompaction:   60 * time.Minute,
 	datapb.CompactionType_SortCompaction:         20 * time.Minute,
+	datapb.CompactionType_BackfillCompaction:     30 * time.Minute,
 }
 
 type CompactionInspector interface {
@@ -221,7 +222,7 @@ func (c *compactionInspector) schedule() []CompactionTask {
 		switch t.GetTaskProto().GetType() {
 		case datapb.CompactionType_Level0DeleteCompaction:
 			l0ChannelExcludes.Insert(t.GetTaskProto().GetChannel())
-		case datapb.CompactionType_MixCompaction, datapb.CompactionType_SortCompaction:
+		case datapb.CompactionType_MixCompaction, datapb.CompactionType_SortCompaction, datapb.CompactionType_BackfillCompaction:
 			mixChannelExcludes.Insert(t.GetTaskProto().GetChannel())
 			mixLabelExcludes.Insert(t.GetLabel())
 		case datapb.CompactionType_ClusteringCompaction:
@@ -262,7 +263,10 @@ func (c *compactionInspector) schedule() []CompactionTask {
 			}
 			l0ChannelExcludes.Insert(t.GetTaskProto().GetChannel())
 			selected = append(selected, t)
-		case datapb.CompactionType_MixCompaction, datapb.CompactionType_SortCompaction:
+		case datapb.CompactionType_MixCompaction, datapb.CompactionType_SortCompaction, datapb.CompactionType_BackfillCompaction:
+			// BackfillCompaction shares the same exclusion rules as Mix/Sort:
+			// - Channel-level mutual exclusion with L0 (L0 may write delta logs to any segment on the channel)
+			// - Label-level exclusion registered for Clustering awareness
 			if l0ChannelExcludes.Contain(t.GetTaskProto().GetChannel()) {
 				excluded = append(excluded, t)
 				continue
@@ -587,6 +591,8 @@ func (c *compactionInspector) createCompactTask(t *datapb.CompactionTask) (Compa
 		task = newL0CompactionTask(t, c.allocator, c.meta)
 	case datapb.CompactionType_ClusteringCompaction:
 		task = newClusteringCompactionTask(t, c.allocator, c.meta, c.handler, c.analyzeScheduler)
+	case datapb.CompactionType_BackfillCompaction:
+		task = newBackfillCompactionTask(t, c.allocator, c.meta, c.ievm, t.GetDiffFunctions())
 	default:
 		return nil, merr.WrapErrIllegalCompactionPlan("illegal compaction type")
 	}

--- a/internal/datacoord/compaction_inspector_test.go
+++ b/internal/datacoord/compaction_inspector_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/milvus-io/milvus/internal/metastore/kv/datacoord"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	taskcommon "github.com/milvus-io/milvus/pkg/v2/taskcommon"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/metautil"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
@@ -1078,4 +1079,44 @@ func TestGetCompactionTasksNum(t *testing.T) {
 		i := handler.getCompactionTasksNum(CollectionIDCompactionTaskFilter(1), L0CompactionCompactionTaskFilter())
 		assert.Equal(t, 1, i)
 	})
+}
+
+func (s *CompactionPlanHandlerSuite) TestCreateCompactTask_BackfillCompaction() {
+	s.SetupTest()
+	s.mockMeta.EXPECT().CheckAndSetSegmentsCompacting(mock.Anything, mock.Anything).Return(true, true).Maybe()
+
+	mockScheduler := task.NewMockGlobalScheduler(s.T())
+	mockScheduler.EXPECT().Enqueue(mock.Anything).Maybe()
+	handler := newCompactionInspector(s.mockMeta, s.mockAlloc, nil, mockScheduler, mockScheduler, newMockVersionManager())
+
+	t := &datapb.CompactionTask{
+		TriggerID: 1,
+		PlanID:    10,
+		Channel:   "ch-1",
+		Type:      datapb.CompactionType_BackfillCompaction,
+	}
+
+	compactTask, err := handler.createCompactTask(t)
+	s.NoError(err)
+	s.NotNil(compactTask)
+	s.Equal(datapb.CompactionType_BackfillCompaction, compactTask.GetTaskProto().GetType())
+}
+
+func (s *CompactionPlanHandlerSuite) TestCreateCompactTask_UnknownType() {
+	s.SetupTest()
+
+	mockScheduler := task.NewMockGlobalScheduler(s.T())
+	handler := newCompactionInspector(s.mockMeta, s.mockAlloc, nil, mockScheduler, mockScheduler, newMockVersionManager())
+
+	t := &datapb.CompactionTask{
+		TriggerID: 2,
+		PlanID:    20,
+		Channel:   "ch-1",
+		Type:      datapb.CompactionType(9999),
+	}
+
+	compactTask, err := handler.createCompactTask(t)
+	s.Nil(compactTask)
+	s.Error(err)
+	s.True(errors.Is(err, merr.ErrIllegalCompactionPlan))
 }

--- a/internal/datacoord/compaction_policy_backfill.go
+++ b/internal/datacoord/compaction_policy_backfill.go
@@ -1,0 +1,270 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datacoord
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/datacoord/allocator"
+	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+)
+
+// FuncDiff represents the differences in functions between two schemas.
+type FuncDiff struct {
+	Added []*schemapb.FunctionSchema
+}
+
+type backfillCompactionPolicy struct {
+	meta      *meta
+	handler   Handler
+	allocator allocator.Allocator
+}
+
+// Ensure backfillCompactionPolicy implements CompactionPolicy interface
+var _ CompactionPolicy = (*backfillCompactionPolicy)(nil)
+
+func newBackfillCompactionPolicy(meta *meta, allocator allocator.Allocator, handler Handler) *backfillCompactionPolicy {
+	return &backfillCompactionPolicy{meta: meta, allocator: allocator, handler: handler}
+}
+
+func (policy *backfillCompactionPolicy) Enable() bool {
+	return Params.DataCoordCfg.EnableAutoCompaction.GetAsBool()
+}
+
+func (policy *backfillCompactionPolicy) Name() string {
+	return "BackfillCompaction"
+}
+
+// getMissingFunctions checks which functions in the collection schema have output fields
+// missing from the segment's binlogs. Returns the list of functions that need backfill.
+func (policy *backfillCompactionPolicy) getMissingFunctions(segment *SegmentInfo, schema *schemapb.CollectionSchema) []*schemapb.FunctionSchema {
+	// Collect all field IDs present in segment binlogs (FieldID + ChildFields)
+	existingFields := make(map[int64]struct{})
+	for _, binlog := range segment.GetBinlogs() {
+		existingFields[binlog.GetFieldID()] = struct{}{}
+		for _, childFieldID := range binlog.GetChildFields() {
+			existingFields[childFieldID] = struct{}{}
+		}
+	}
+
+	// Check each function's output fields
+	var missing []*schemapb.FunctionSchema
+	for _, fn := range schema.GetFunctions() {
+		for _, outputFieldID := range fn.GetOutputFieldIds() {
+			if _, ok := existingFields[outputFieldID]; !ok {
+				missing = append(missing, fn)
+				break // one missing output field is enough to mark this function
+			}
+		}
+	}
+	return missing
+}
+
+func (policy *backfillCompactionPolicy) Trigger(ctx context.Context) (map[CompactionTriggerType][]CompactionView, error) {
+	collections := policy.meta.GetCollections()
+	events := make(map[CompactionTriggerType][]CompactionView)
+
+	for _, collection := range collections {
+		collectionID := collection.ID
+		collectionSchemaVersion := collection.Schema.GetVersion()
+		// L0 segments are excluded from both the consistency gate (GetCollectionStatistics)
+		// and from backfill processing: they only contain delete logs, so there is no user
+		// data to backfill and no need to update their schema version here.
+		partSegments := GetSegmentsChanPart(policy.meta, collectionID, SegmentFilterFunc(func(segment *SegmentInfo) bool {
+			return isSegmentHealthy(segment) &&
+				isFlushed(segment) &&
+				!segment.isCompacting && // not compacting now
+				!segment.GetIsImporting() && // not importing now
+				!segment.GetIsInvisible() &&
+				segment.GetLevel() != datapb.SegmentLevel_L0 // L0 segments only contain deletes, no data to backfill
+		}))
+
+		// Check each segment's schema version
+		views := make([]CompactionView, 0)
+		doPhysicalBackfill := collection.Schema.GetDoPhysicalBackfill()
+		// triggerID is allocated per collection so that tasks belonging to the same collection
+		// can be grouped and queried independently (e.g. to check backfill progress per collection).
+		// Allocating once per tick across all collections would mix tasks from different collections
+		// under one ID, making per-collection progress tracking impossible.
+		var collectionTriggerID int64
+		for _, group := range partSegments {
+			for _, segment := range group.segments {
+				segmentID := segment.GetID()
+				segmentSchemaVersion := segment.GetSchemaVersion()
+				// Skip segments with up-to-date schema version
+				if segmentSchemaVersion >= collectionSchemaVersion {
+					continue
+				}
+				if !doPhysicalBackfill {
+					// No physical backfill needed — update schema version metadata only.
+					// If UpdateSegment fails, we log and move on.  This is intentional: the
+					// segment's schema version will remain below the collection's, so the next
+					// trigger cycle will revisit this segment automatically.  The failure does
+					// NOT block the consistency gate or cause permanent state corruption — it
+					// is purely a transient metadata write that will self-heal on retry.
+					err := policy.meta.UpdateSegment(segmentID, SetSchemaVersion(collectionSchemaVersion))
+					if err != nil {
+						log.Ctx(ctx).Error("Failed to update segment schema version",
+							zap.Int64("segmentID", segmentID),
+							zap.Int64("collectionID", collectionID),
+							zap.Int32("segmentSchemaVersion", segmentSchemaVersion),
+							zap.Int32("collectionSchemaVersion", collectionSchemaVersion),
+							zap.Error(err))
+					} else {
+						log.Ctx(ctx).Info("Updated segment schema version",
+							zap.Int64("segmentID", segmentID),
+							zap.Int64("collectionID", collectionID),
+							zap.Int32("segmentSchemaVersion", segmentSchemaVersion),
+							zap.Int32("collectionSchemaVersion", collectionSchemaVersion),
+						)
+					}
+					continue
+				}
+				// Physical backfill path: check which function output fields are missing from segment binlogs
+				missingFunctions := policy.getMissingFunctions(segment, collection.Schema)
+				if len(missingFunctions) == 0 {
+					// All function output fields exist, just update schema version
+					err := policy.meta.UpdateSegment(segmentID, SetSchemaVersion(collectionSchemaVersion))
+					if err != nil {
+						log.Ctx(ctx).Error("Failed to update segment schema version, no missing functions",
+							zap.Int64("segmentID", segmentID),
+							zap.Int64("collectionID", collectionID),
+							zap.Error(err))
+					} else {
+						log.Ctx(ctx).Info("All function output fields present, updated schema version directly",
+							zap.Int64("segmentID", segmentID),
+							zap.Int64("collectionID", collectionID),
+							zap.Int32("newSchemaVersion", collectionSchemaVersion))
+					}
+					continue
+				}
+				// Lazily allocate a triggerID for this collection on the first segment that needs
+				// physical backfill. This avoids an unnecessary AllocID RPC for collections whose
+				// segments only require metadata-only updates or are already up-to-date.
+				if collectionTriggerID == 0 {
+					id, err := policy.allocator.AllocID(ctx)
+					if err != nil {
+						log.Ctx(ctx).Warn("Failed to allocate triggerID for backfill, skip remaining segments in current group",
+							zap.Int64("collectionID", collectionID),
+							zap.Error(err))
+						break
+					}
+					collectionTriggerID = id
+				}
+				// Current compactor only supports one function per backfill task,
+				// so pick the first missing function. In practice, the multi-function
+				// scenario cannot occur: RootCoord enforces exactly one function per
+				// AlterCollectionSchema request (ddl_callbacks_alter_collection_schema.go),
+				// and Proxy blocks new schema alterations until previous backfill reaches
+				// 100% consistency (checkSchemaVersionConsistency in impl.go).
+				backfillFunc := missingFunctions[0]
+				log.Ctx(ctx).Info("Found segment missing function output fields, do physical backfill",
+					zap.Int64("segmentID", segmentID),
+					zap.Int64("collectionID", collectionID),
+					zap.Int32("segmentSchemaVersion", segmentSchemaVersion),
+					zap.Int32("collectionSchemaVersion", collectionSchemaVersion),
+					zap.String("backfillFunction", backfillFunc.GetName()),
+					zap.Int("totalMissingFunctions", len(missingFunctions)))
+
+				// Create BackfillSegmentsView for this segment with single function.
+				// GetViewsByInfo returns exactly one SegmentView per segment (one segment
+				// maps to one channel/partition group label); len > 1 is not expected.
+				segmentViews := GetViewsByInfo(segment)
+				if len(segmentViews) == 0 {
+					log.Ctx(ctx).Warn("GetViewsByInfo returned empty views, skip segment",
+						zap.Int64("segmentID", segmentID))
+					continue
+				}
+				if len(segmentViews) != 1 {
+					log.Ctx(ctx).Warn("GetViewsByInfo returned unexpected view count, using first view only",
+						zap.Int64("segmentID", segmentID),
+						zap.Int("viewCount", len(segmentViews)))
+				}
+				view := &BackfillSegmentsView{
+					label:     segmentViews[0].label,
+					segments:  segmentViews,
+					triggerID: collectionTriggerID,
+					funcDiff:  &FuncDiff{Added: []*schemapb.FunctionSchema{backfillFunc}},
+				}
+				views = append(views, view)
+			}
+		}
+
+		// Add views to events if any segments need backfill
+		if len(views) > 0 {
+			if events[TriggerTypeBackfill] == nil {
+				events[TriggerTypeBackfill] = make([]CompactionView, 0)
+			}
+			events[TriggerTypeBackfill] = append(events[TriggerTypeBackfill], views...)
+		}
+	}
+
+	return events, nil
+}
+
+type BackfillSegmentsView struct {
+	label     *CompactionGroupLabel
+	segments  []*SegmentView
+	triggerID int64
+	funcDiff  *FuncDiff
+}
+
+var _ CompactionView = (*BackfillSegmentsView)(nil)
+
+func (v *BackfillSegmentsView) GetGroupLabel() *CompactionGroupLabel {
+	return v.label
+}
+
+func (v *BackfillSegmentsView) GetSegmentsView() []*SegmentView {
+	return v.segments
+}
+
+func (v *BackfillSegmentsView) Append(segments ...*SegmentView) {
+	v.segments = append(v.segments, segments...)
+}
+
+func (v *BackfillSegmentsView) String() string {
+	return fmt.Sprintf("BackfillSegmentsView: label=%s, segments=%d, triggerID=%d",
+		v.label.Key(), len(v.segments), v.triggerID)
+}
+
+func (v *BackfillSegmentsView) Trigger() (CompactionView, string) {
+	return v, "backfill schema version mismatch"
+}
+
+func (v *BackfillSegmentsView) ForceTrigger() (CompactionView, string) {
+	return v.Trigger()
+}
+
+// ForceTriggerAll returns a single-element slice intentionally: the backfill policy
+// creates one BackfillSegmentsView per segment, so each view already represents the
+// smallest unit of work. Unlike LevelZeroCompactionView or ForceMergeSegmentView
+// which aggregate many segments and need multi-round splitting, there is nothing to
+// split further here.
+func (v *BackfillSegmentsView) ForceTriggerAll() ([]CompactionView, string) {
+	view, reason := v.Trigger()
+	return []CompactionView{view}, reason
+}
+
+func (v *BackfillSegmentsView) GetTriggerID() int64 {
+	return v.triggerID
+}

--- a/internal/datacoord/compaction_policy_backfill_test.go
+++ b/internal/datacoord/compaction_policy_backfill_test.go
@@ -1,0 +1,639 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datacoord
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/datacoord/allocator"
+	"github.com/milvus-io/milvus/internal/metastore/mocks"
+	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
+)
+
+func TestBackfillCompactionPolicySuite(t *testing.T) {
+	suite.Run(t, new(BackfillCompactionPolicySuite))
+}
+
+type BackfillCompactionPolicySuite struct {
+	suite.Suite
+
+	mockAlloc      *allocator.MockAllocator
+	handler        *NMockHandler
+	testLabel      *CompactionGroupLabel
+	backfillPolicy *backfillCompactionPolicy
+}
+
+func (s *BackfillCompactionPolicySuite) SetupTest() {
+	s.testLabel = &CompactionGroupLabel{
+		CollectionID: 1,
+		PartitionID:  10,
+		Channel:      "ch-1",
+	}
+
+	segments := genSegmentsForMeta(s.testLabel)
+	mockCatalog := mocks.NewDataCoordCatalog(s.T())
+	meta := &meta{
+		segments:    NewSegmentsInfo(),
+		collections: typeutil.NewConcurrentMap[UniqueID, *collectionInfo](),
+		catalog:     mockCatalog,
+	}
+	for id, segment := range segments {
+		meta.segments.SetSegment(id, segment)
+	}
+
+	s.mockAlloc = newMockAllocator(s.T())
+	mockHandler := NewNMockHandler(s.T())
+	s.handler = mockHandler
+	s.backfillPolicy = newBackfillCompactionPolicy(meta, s.mockAlloc, mockHandler)
+}
+
+func (s *BackfillCompactionPolicySuite) TestTrigger() {
+	// Test basic trigger with no collections
+	events, err := s.backfillPolicy.Trigger(context.Background())
+	s.NoError(err)
+	gotViews, ok := events[TriggerTypeBackfill]
+	s.False(ok)
+	s.Nil(gotViews)
+	s.Equal(0, len(gotViews))
+}
+
+func (s *BackfillCompactionPolicySuite) TestBackfillSegmentsViewBasic() {
+	view := &BackfillSegmentsView{
+		label: &CompactionGroupLabel{
+			CollectionID: 1,
+			PartitionID:  10,
+			Channel:      "ch-1",
+		},
+		segments:  []*SegmentView{},
+		triggerID: 100,
+	}
+
+	// Test GetGroupLabel
+	label := view.GetGroupLabel()
+	s.NotNil(label)
+	s.Equal(int64(1), label.CollectionID)
+
+	// Test GetSegmentsView
+	segments := view.GetSegmentsView()
+	s.NotNil(segments)
+	s.Equal(0, len(segments))
+
+	// Test Append
+	segmentView := &SegmentView{
+		ID:    101,
+		label: label,
+		State: commonpb.SegmentState_Flushed,
+		Level: datapb.SegmentLevel_L1,
+	}
+	view.Append(segmentView)
+	s.Equal(1, len(view.GetSegmentsView()))
+
+	// Test String
+	str := view.String()
+	s.Contains(str, "BackfillSegmentsView")
+	s.Contains(str, "segments=1")
+	s.Contains(str, "triggerID=100")
+
+	// Test Trigger
+	triggeredView, reason := view.Trigger()
+	s.NotNil(triggeredView)
+	s.Equal("backfill schema version mismatch", reason)
+
+	// Test ForceTrigger
+	forceView, reason := view.ForceTrigger()
+	s.NotNil(forceView)
+	s.Equal("backfill schema version mismatch", reason)
+
+	// Test ForceTriggerAll
+	forceViews, reason := view.ForceTriggerAll()
+	s.Equal(1, len(forceViews))
+	s.Equal("backfill schema version mismatch", reason)
+
+	// Test GetTriggerID
+	triggerID := view.GetTriggerID()
+	s.Equal(int64(100), triggerID)
+}
+
+func (s *BackfillCompactionPolicySuite) TestEnable() {
+	// Test Enable method
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key, "true")
+	defer paramtable.Get().Reset(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key)
+	s.True(s.backfillPolicy.Enable())
+
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key, "false")
+	s.False(s.backfillPolicy.Enable())
+	paramtable.Get().Reset(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key)
+}
+
+func (s *BackfillCompactionPolicySuite) TestName() {
+	// Test Name method
+	s.Equal("BackfillCompaction", s.backfillPolicy.Name())
+}
+
+func (s *BackfillCompactionPolicySuite) TestTriggerWithCollectionNoBackfill() {
+	ctx := context.Background()
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key, "true")
+	defer paramtable.Get().Reset(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key)
+
+	collID := int64(100)
+	// Create collection with schema version 1
+	coll := &collectionInfo{
+		ID: collID,
+		Schema: &schemapb.CollectionSchema{
+			Name:               "test_collection",
+			Description:        "test collection",
+			Version:            1,
+			DoPhysicalBackfill: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+				{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar},
+			},
+		},
+	}
+	s.backfillPolicy.meta.collections.Insert(collID, coll)
+
+	// Create segment with same schema version (no backfill needed)
+	segmentID := int64(101)
+	segment := &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:            segmentID,
+			CollectionID:  collID,
+			PartitionID:   10,
+			InsertChannel: "ch-1",
+			Level:         datapb.SegmentLevel_L1,
+			State:         commonpb.SegmentState_Flushed,
+			NumOfRows:     1000,
+			SchemaVersion: 1, // Same as collection schema version
+			StartPosition: &msgpb.MsgPosition{
+				Timestamp: 10000,
+			},
+			Binlogs: []*datapb.FieldBinlog{
+				{
+					FieldID: 101,
+					Binlogs: []*datapb.Binlog{
+						{LogPath: "test_path", EntriesNum: 1000},
+					},
+				},
+			},
+		},
+	}
+	s.backfillPolicy.meta.segments.SetSegment(segmentID, segment)
+
+	events, err := s.backfillPolicy.Trigger(ctx)
+	s.NoError(err)
+	gotViews, ok := events[TriggerTypeBackfill]
+	s.False(ok)
+	s.Nil(gotViews)
+}
+
+func (s *BackfillCompactionPolicySuite) TestTriggerWithCompactingSegment() {
+	ctx := context.Background()
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key, "true")
+	defer paramtable.Get().Reset(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key)
+
+	collID := int64(100)
+	coll := &collectionInfo{
+		ID: collID,
+		Schema: &schemapb.CollectionSchema{
+			Name:               "test_collection",
+			Description:        "test collection",
+			Version:            2,
+			DoPhysicalBackfill: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+				{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar},
+			},
+		},
+	}
+	s.backfillPolicy.meta.collections.Insert(collID, coll)
+
+	// Create segment that is compacting (should be filtered out)
+	segmentID := int64(101)
+	segment := &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:            segmentID,
+			CollectionID:  collID,
+			PartitionID:   10,
+			InsertChannel: "ch-1",
+			Level:         datapb.SegmentLevel_L1,
+			State:         commonpb.SegmentState_Flushed,
+			NumOfRows:     1000,
+			SchemaVersion: 1, // Outdated schema version
+			StartPosition: &msgpb.MsgPosition{
+				Timestamp: 10000,
+			},
+			Binlogs: []*datapb.FieldBinlog{
+				{
+					FieldID: 101,
+					Binlogs: []*datapb.Binlog{
+						{LogPath: "test_path", EntriesNum: 1000},
+					},
+				},
+			},
+		},
+	}
+	segment.isCompacting = true // Mark as compacting
+	s.backfillPolicy.meta.segments.SetSegment(segmentID, segment)
+
+	events, err := s.backfillPolicy.Trigger(ctx)
+	s.NoError(err)
+	gotViews, ok := events[TriggerTypeBackfill]
+	s.False(ok)
+	s.Nil(gotViews)
+}
+
+func (s *BackfillCompactionPolicySuite) TestTriggerWithImportingSegment() {
+	ctx := context.Background()
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key, "true")
+	defer paramtable.Get().Reset(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key)
+
+	collID := int64(100)
+	coll := &collectionInfo{
+		ID: collID,
+		Schema: &schemapb.CollectionSchema{
+			Name:               "test_collection",
+			Description:        "test collection",
+			Version:            2,
+			DoPhysicalBackfill: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+				{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar},
+			},
+		},
+	}
+	s.backfillPolicy.meta.collections.Insert(collID, coll)
+
+	// Create segment that is importing (should be filtered out)
+	segmentID := int64(101)
+	segment := &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:            segmentID,
+			CollectionID:  collID,
+			PartitionID:   10,
+			InsertChannel: "ch-1",
+			Level:         datapb.SegmentLevel_L1,
+			State:         commonpb.SegmentState_Flushed,
+			NumOfRows:     1000,
+			SchemaVersion: 1,    // Outdated schema version
+			IsImporting:   true, // Mark as importing
+			StartPosition: &msgpb.MsgPosition{
+				Timestamp: 10000,
+			},
+			Binlogs: []*datapb.FieldBinlog{
+				{
+					FieldID: 101,
+					Binlogs: []*datapb.Binlog{
+						{LogPath: "test_path", EntriesNum: 1000},
+					},
+				},
+			},
+		},
+	}
+	s.backfillPolicy.meta.segments.SetSegment(segmentID, segment)
+
+	events, err := s.backfillPolicy.Trigger(ctx)
+	s.NoError(err)
+	gotViews, ok := events[TriggerTypeBackfill]
+	s.False(ok)
+	s.Nil(gotViews)
+}
+
+func (s *BackfillCompactionPolicySuite) TestTriggerWithInvisibleSegment() {
+	ctx := context.Background()
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key, "true")
+	defer paramtable.Get().Reset(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key)
+
+	collID := int64(100)
+	coll := &collectionInfo{
+		ID: collID,
+		Schema: &schemapb.CollectionSchema{
+			Name:               "test_collection",
+			Description:        "test collection",
+			Version:            2,
+			DoPhysicalBackfill: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+				{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar},
+			},
+		},
+	}
+	s.backfillPolicy.meta.collections.Insert(collID, coll)
+
+	// Create segment that is invisible (should be filtered out)
+	segmentID := int64(101)
+	segment := &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:            segmentID,
+			CollectionID:  collID,
+			PartitionID:   10,
+			InsertChannel: "ch-1",
+			Level:         datapb.SegmentLevel_L1,
+			State:         commonpb.SegmentState_Flushed,
+			NumOfRows:     1000,
+			SchemaVersion: 1,    // Outdated schema version
+			IsInvisible:   true, // Mark as invisible
+			StartPosition: &msgpb.MsgPosition{
+				Timestamp: 10000,
+			},
+			Binlogs: []*datapb.FieldBinlog{
+				{
+					FieldID: 101,
+					Binlogs: []*datapb.Binlog{
+						{LogPath: "test_path", EntriesNum: 1000},
+					},
+				},
+			},
+		},
+	}
+	s.backfillPolicy.meta.segments.SetSegment(segmentID, segment)
+
+	events, err := s.backfillPolicy.Trigger(ctx)
+	s.NoError(err)
+	gotViews, ok := events[TriggerTypeBackfill]
+	s.False(ok)
+	s.Nil(gotViews)
+}
+
+func (s *BackfillCompactionPolicySuite) TestTriggerWithUnhealthySegment() {
+	ctx := context.Background()
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key, "true")
+	defer paramtable.Get().Reset(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key)
+
+	collID := int64(100)
+	coll := &collectionInfo{
+		ID: collID,
+		Schema: &schemapb.CollectionSchema{
+			Name:               "test_collection",
+			Description:        "test collection",
+			Version:            2,
+			DoPhysicalBackfill: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+				{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar},
+			},
+		},
+	}
+	s.backfillPolicy.meta.collections.Insert(collID, coll)
+
+	// Create segment that is not healthy (should be filtered out)
+	segmentID := int64(101)
+	segment := &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:            segmentID,
+			CollectionID:  collID,
+			PartitionID:   10,
+			InsertChannel: "ch-1",
+			Level:         datapb.SegmentLevel_L1,
+			State:         commonpb.SegmentState_Dropped, // Not healthy
+			NumOfRows:     1000,
+			SchemaVersion: 1, // Outdated schema version
+			StartPosition: &msgpb.MsgPosition{
+				Timestamp: 10000,
+			},
+			Binlogs: []*datapb.FieldBinlog{
+				{
+					FieldID: 101,
+					Binlogs: []*datapb.Binlog{
+						{LogPath: "test_path", EntriesNum: 1000},
+					},
+				},
+			},
+		},
+	}
+	s.backfillPolicy.meta.segments.SetSegment(segmentID, segment)
+
+	// AllocID should NOT be called: unhealthy segment is filtered before physical backfill.
+	events, err := s.backfillPolicy.Trigger(ctx)
+	s.NoError(err)
+	gotViews, ok := events[TriggerTypeBackfill]
+	s.False(ok)
+	s.Nil(gotViews)
+}
+
+func (s *BackfillCompactionPolicySuite) TestTriggerWithNonFlushedSegment() {
+	ctx := context.Background()
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key, "true")
+	defer paramtable.Get().Reset(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key)
+
+	collID := int64(100)
+	coll := &collectionInfo{
+		ID: collID,
+		Schema: &schemapb.CollectionSchema{
+			Name:               "test_collection",
+			Description:        "test collection",
+			Version:            2,
+			DoPhysicalBackfill: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+				{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar},
+			},
+		},
+	}
+	s.backfillPolicy.meta.collections.Insert(collID, coll)
+
+	// Create segment that is not flushed (should be filtered out)
+	segmentID := int64(101)
+	segment := &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:            segmentID,
+			CollectionID:  collID,
+			PartitionID:   10,
+			InsertChannel: "ch-1",
+			Level:         datapb.SegmentLevel_L1,
+			State:         commonpb.SegmentState_Growing, // Not flushed
+			NumOfRows:     1000,
+			SchemaVersion: 1, // Outdated schema version
+			StartPosition: &msgpb.MsgPosition{
+				Timestamp: 10000,
+			},
+			Binlogs: []*datapb.FieldBinlog{
+				{
+					FieldID: 101,
+					Binlogs: []*datapb.Binlog{
+						{LogPath: "test_path", EntriesNum: 1000},
+					},
+				},
+			},
+		},
+	}
+	s.backfillPolicy.meta.segments.SetSegment(segmentID, segment)
+
+	// AllocID should NOT be called: non-flushed segment is filtered before physical backfill.
+	events, err := s.backfillPolicy.Trigger(ctx)
+	s.NoError(err)
+	gotViews, ok := events[TriggerTypeBackfill]
+	s.False(ok)
+	s.Nil(gotViews)
+}
+
+func (s *BackfillCompactionPolicySuite) TestTriggerWithOutdatedSchemaVersion() {
+	ctx := context.Background()
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key, "true")
+	defer paramtable.Get().Reset(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key)
+
+	collID := int64(100)
+
+	// Create collection with schema version 2, with a BM25 function whose output field 102 is missing from segment
+	coll := &collectionInfo{
+		ID: collID,
+		Schema: &schemapb.CollectionSchema{
+			Name:               "test_collection",
+			Description:        "test collection",
+			Version:            2,
+			DoPhysicalBackfill: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+				{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar},
+				{FieldID: 102, Name: "sparse_vector", DataType: schemapb.DataType_SparseFloatVector},
+			},
+			Functions: []*schemapb.FunctionSchema{
+				{
+					Name:           "bm25_func",
+					OutputFieldIds: []int64{102},
+				},
+			},
+		},
+	}
+	s.backfillPolicy.meta.collections.Insert(collID, coll)
+
+	// Create segment with outdated schema version 1, binlogs only have field 101 (missing 102)
+	segmentID := int64(101)
+	segment := &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:            segmentID,
+			CollectionID:  collID,
+			PartitionID:   10,
+			InsertChannel: "ch-1",
+			Level:         datapb.SegmentLevel_L1,
+			State:         commonpb.SegmentState_Flushed,
+			NumOfRows:     1000,
+			SchemaVersion: 1,
+			StartPosition: &msgpb.MsgPosition{
+				Timestamp: 10000,
+			},
+			Binlogs: []*datapb.FieldBinlog{
+				{
+					FieldID: 101,
+					Binlogs: []*datapb.Binlog{
+						{LogPath: "test_path", EntriesNum: 1000},
+					},
+				},
+			},
+		},
+	}
+	s.backfillPolicy.meta.segments.SetSegment(segmentID, segment)
+
+	// Setup allocator mock
+	s.mockAlloc.EXPECT().AllocID(mock.Anything).Return(int64(1), nil)
+
+	events, err := s.backfillPolicy.Trigger(ctx)
+	s.NoError(err)
+	gotViews, ok := events[TriggerTypeBackfill]
+	s.True(ok)
+	s.NotNil(gotViews)
+	s.Equal(1, len(gotViews))
+
+	// Verify the view
+	view, ok := gotViews[0].(*BackfillSegmentsView)
+	s.True(ok)
+	s.NotNil(view)
+	s.Equal(int64(1), view.GetTriggerID())
+	s.Equal(1, len(view.GetSegmentsView()))
+	s.Equal(segmentID, view.GetSegmentsView()[0].ID)
+	// Verify funcDiff contains the missing function
+	s.Equal(1, len(view.funcDiff.Added))
+	s.Equal("bm25_func", view.funcDiff.Added[0].GetName())
+}
+
+func (s *BackfillCompactionPolicySuite) TestTriggerWithOutdatedSchemaVersionNoPhysicalBackfill() {
+	ctx := context.Background()
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key, "true")
+	defer paramtable.Get().Reset(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key)
+
+	collID := int64(100)
+
+	// Create collection with schema version 2, but DoPhysicalBackfill = false
+	coll := &collectionInfo{
+		ID: collID,
+		Schema: &schemapb.CollectionSchema{
+			Name:               "test_collection",
+			Description:        "test collection",
+			Version:            2,
+			DoPhysicalBackfill: false, // No physical backfill
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+				{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar},
+			},
+		},
+	}
+	s.backfillPolicy.meta.collections.Insert(collID, coll)
+
+	// Create segment with outdated schema version 1
+	segmentID := int64(101)
+	segment := &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:            segmentID,
+			CollectionID:  collID,
+			PartitionID:   10,
+			InsertChannel: "ch-1",
+			Level:         datapb.SegmentLevel_L1,
+			State:         commonpb.SegmentState_Flushed,
+			NumOfRows:     1000,
+			SchemaVersion: 1, // Outdated schema version
+			StartPosition: &msgpb.MsgPosition{
+				Timestamp: 10000,
+			},
+			Binlogs: []*datapb.FieldBinlog{
+				{
+					FieldID: 101,
+					Binlogs: []*datapb.Binlog{
+						{LogPath: "test_path", EntriesNum: 1000},
+					},
+				},
+			},
+		},
+	}
+	s.backfillPolicy.meta.segments.SetSegment(segmentID, segment)
+
+	// Setup mock catalog to allow AlterSegments call
+	s.backfillPolicy.meta.catalog.(*mocks.DataCoordCatalog).EXPECT().
+		AlterSegments(mock.Anything, mock.Anything, mock.Anything).
+		Return(nil)
+
+	// AllocID should NOT be called: DoPhysicalBackfill=false only updates metadata, no compaction task.
+	// When DoPhysicalBackfill is false, the segment's schema version should be updated
+	// but no backfill view should be created.
+	events, err := s.backfillPolicy.Trigger(ctx)
+	s.NoError(err)
+	gotViews, ok := events[TriggerTypeBackfill]
+	s.False(ok)
+	s.Nil(gotViews)
+
+	// Verify that segment's schema version has been updated to 2
+	updatedSegment := s.backfillPolicy.meta.segments.GetSegment(segmentID)
+	s.NotNil(updatedSegment)
+	s.Equal(int32(2), updatedSegment.GetSchemaVersion(), "segment schema version should be updated to 2")
+}

--- a/internal/datacoord/compaction_policy_clustering.go
+++ b/internal/datacoord/compaction_policy_clustering.go
@@ -40,6 +40,9 @@ type clusteringCompactionPolicy struct {
 	handler   Handler
 }
 
+// Ensure clusteringCompactionPolicy implements CompactionPolicy interface
+var _ CompactionPolicy = (*clusteringCompactionPolicy)(nil)
+
 func newClusteringCompactionPolicy(meta *meta, allocator allocator.Allocator, handler Handler) *clusteringCompactionPolicy {
 	return &clusteringCompactionPolicy{meta: meta, allocator: allocator, handler: handler}
 }
@@ -48,6 +51,10 @@ func (policy *clusteringCompactionPolicy) Enable() bool {
 	return Params.DataCoordCfg.EnableAutoCompaction.GetAsBool() &&
 		Params.DataCoordCfg.ClusteringCompactionEnable.GetAsBool() &&
 		Params.DataCoordCfg.ClusteringCompactionAutoEnable.GetAsBool()
+}
+
+func (policy *clusteringCompactionPolicy) Name() string {
+	return "ClusteringCompactionPolicy"
 }
 
 func (policy *clusteringCompactionPolicy) Trigger(ctx context.Context) (map[CompactionTriggerType][]CompactionView, error) {
@@ -174,6 +181,18 @@ func (policy *clusteringCompactionPolicy) triggerOneCollection(ctx context.Conte
 			}
 		}
 
+		// Intentionally check internal consistency (all segments share the same schema version)
+		// rather than requiring segments to match the collection schema version.
+		// Clustering before backfill is more efficient: merging N segments first reduces
+		// N separate backfill tasks to 1 backfill task on the merged result.
+		if !policy.checkGroupSchemaVersionInternallyConsistent(group) {
+			log.Debug("segments in group have inconsistent schema versions, skip clustering compaction for this group",
+				zap.Int64("collectionID", group.collectionID),
+				zap.Int64("partitionID", group.partitionID),
+				zap.String("channel", group.channelName))
+			continue
+		}
+
 		segmentViews := GetViewsByInfo(group.segments...)
 		view := &ClusteringSegmentsView{
 			label:              segmentViews[0].label,
@@ -187,6 +206,19 @@ func (policy *clusteringCompactionPolicy) triggerOneCollection(ctx context.Conte
 
 	log.Info("finish trigger collection clustering compaction", zap.Int("viewNum", len(views)))
 	return views, newTriggerID, nil
+}
+
+func (policy *clusteringCompactionPolicy) checkGroupSchemaVersionInternallyConsistent(group *chanPartSegments) bool {
+	if len(group.segments) == 0 {
+		return true
+	}
+	firstSchemaVersion := group.segments[0].GetSchemaVersion()
+	for _, segment := range group.segments {
+		if segment.GetSchemaVersion() != firstSchemaVersion {
+			return false
+		}
+	}
+	return true
 }
 
 func (policy *clusteringCompactionPolicy) collectionIsClusteringCompacting(collectionID UniqueID) (bool, int64) {

--- a/internal/datacoord/compaction_policy_clustering_test.go
+++ b/internal/datacoord/compaction_policy_clustering_test.go
@@ -361,6 +361,78 @@ func (s *ClusteringCompactionPolicySuite) TestTriggerOneCollectionNormal() {
 	s.Equal(testLabel, view[0].GetGroupLabel())
 }
 
+func (s *ClusteringCompactionPolicySuite) TestCheckGroupSchemaVersionInternallyConsistent() {
+	// empty group is trivially consistent
+	s.True(s.clusteringCompactionPolicy.checkGroupSchemaVersionInternallyConsistent(
+		&chanPartSegments{segments: nil},
+	))
+
+	// single segment is trivially consistent
+	s.True(s.clusteringCompactionPolicy.checkGroupSchemaVersionInternallyConsistent(
+		&chanPartSegments{segments: []*SegmentInfo{
+			{SegmentInfo: &datapb.SegmentInfo{SchemaVersion: 3}},
+		}},
+	))
+
+	// all segments with the same schema version → consistent
+	s.True(s.clusteringCompactionPolicy.checkGroupSchemaVersionInternallyConsistent(
+		&chanPartSegments{segments: []*SegmentInfo{
+			{SegmentInfo: &datapb.SegmentInfo{SchemaVersion: 5}},
+			{SegmentInfo: &datapb.SegmentInfo{SchemaVersion: 5}},
+			{SegmentInfo: &datapb.SegmentInfo{SchemaVersion: 5}},
+		}},
+	))
+
+	// segments with different schema versions → inconsistent
+	s.False(s.clusteringCompactionPolicy.checkGroupSchemaVersionInternallyConsistent(
+		&chanPartSegments{segments: []*SegmentInfo{
+			{SegmentInfo: &datapb.SegmentInfo{SchemaVersion: 5}},
+			{SegmentInfo: &datapb.SegmentInfo{SchemaVersion: 6}},
+		}},
+	))
+}
+
+func (s *ClusteringCompactionPolicySuite) TestTriggerOneCollectionSkipsInconsistentSchemaGroup() {
+	paramtable.Get().Save(Params.DataCoordCfg.ClusteringCompactionNewDataSizeThreshold.Key, "0")
+	defer paramtable.Get().Reset(Params.DataCoordCfg.ClusteringCompactionNewDataSizeThreshold.Key)
+
+	testLabel := &CompactionGroupLabel{
+		CollectionID: 1,
+		PartitionID:  10,
+		Channel:      "ch-1",
+	}
+
+	s.meta.collections.Insert(testLabel.CollectionID, &collectionInfo{
+		ID:     testLabel.CollectionID,
+		Schema: newTestScalarClusteringKeySchema(),
+	})
+
+	segments := genSegmentsForMeta(testLabel)
+	// Force all segments to have mixed schema versions so the group is internally inconsistent
+	versionCounter := int32(0)
+	for id, segment := range segments {
+		versionCounter++
+		segment.SegmentInfo.SchemaVersion = versionCounter
+		segments[id] = segment
+	}
+	for id, segment := range segments {
+		s.meta.segments.SetSegment(id, segment)
+	}
+
+	s.handler.EXPECT().GetCollection(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, collectionID int64) (*collectionInfo, error) {
+		coll, exist := s.meta.collections.Get(collectionID)
+		if exist {
+			return coll, nil
+		}
+		return nil, nil
+	})
+
+	// Because the group has mixed schema versions, triggerOneCollection should skip it
+	view, _, err := s.clusteringCompactionPolicy.triggerOneCollection(context.TODO(), 1, false)
+	s.NoError(err)
+	s.Equal(0, len(view))
+}
+
 func (s *ClusteringCompactionPolicySuite) TestGetExpectedSegmentSize() {
 }
 

--- a/internal/datacoord/compaction_policy_l0.go
+++ b/internal/datacoord/compaction_policy_l0.go
@@ -25,6 +25,9 @@ type l0CompactionPolicy struct {
 	allocator         allocator.Allocator
 }
 
+// Ensure l0CompactionPolicy implements CompactionPolicy interface
+var _ CompactionPolicy = (*l0CompactionPolicy)(nil)
+
 func newL0CompactionPolicy(meta *meta, allocator allocator.Allocator) *l0CompactionPolicy {
 	return &l0CompactionPolicy{
 		meta:              meta,
@@ -35,6 +38,10 @@ func newL0CompactionPolicy(meta *meta, allocator allocator.Allocator) *l0Compact
 
 func (policy *l0CompactionPolicy) Enable() bool {
 	return Params.DataCoordCfg.EnableAutoCompaction.GetAsBool()
+}
+
+func (policy *l0CompactionPolicy) Name() string {
+	return "L0Compaction"
 }
 
 // Notify policy to record the active updated(when adding a new L0 segment) collections.

--- a/internal/datacoord/compaction_policy_single.go
+++ b/internal/datacoord/compaction_policy_single.go
@@ -40,12 +40,19 @@ type singleCompactionPolicy struct {
 	handler   Handler
 }
 
+// Ensure singleCompactionPolicy implements CompactionPolicy interface
+var _ CompactionPolicy = (*singleCompactionPolicy)(nil)
+
 func newSingleCompactionPolicy(meta *meta, allocator allocator.Allocator, handler Handler) *singleCompactionPolicy {
 	return &singleCompactionPolicy{meta: meta, allocator: allocator, handler: handler}
 }
 
 func (policy *singleCompactionPolicy) Enable() bool {
 	return Params.DataCoordCfg.EnableAutoCompaction.GetAsBool()
+}
+
+func (policy *singleCompactionPolicy) Name() string {
+	return "SingleCompactionPolicy"
 }
 
 func (policy *singleCompactionPolicy) Trigger(ctx context.Context) (map[CompactionTriggerType][]CompactionView, error) {

--- a/internal/datacoord/compaction_policy_storage_version.go
+++ b/internal/datacoord/compaction_policy_storage_version.go
@@ -51,6 +51,10 @@ func newStorageVersionUpgradePolicy(meta *meta, allocator allocator.Allocator, h
 	}
 }
 
+func (policy *storageVersionUpgradePolicy) Name() string {
+	return "storageVersionUpgrade"
+}
+
 func (policy *storageVersionUpgradePolicy) Enable() bool {
 	return paramtable.Get().DataCoordCfg.StorageVersionCompactionEnabled.GetAsBool()
 }

--- a/internal/datacoord/compaction_queue.go
+++ b/internal/datacoord/compaction_queue.go
@@ -166,6 +166,8 @@ var (
 			return 1
 		case datapb.CompactionType_MixCompaction:
 			return 10
+		case datapb.CompactionType_BackfillCompaction:
+			return 10
 		case datapb.CompactionType_ClusteringCompaction:
 			return 100
 		default:
@@ -178,6 +180,8 @@ var (
 		case datapb.CompactionType_Level0DeleteCompaction:
 			return 10
 		case datapb.CompactionType_MixCompaction:
+			return 1
+		case datapb.CompactionType_BackfillCompaction:
 			return 1
 		case datapb.CompactionType_ClusteringCompaction:
 			return 100

--- a/internal/datacoord/compaction_task_backfill.go
+++ b/internal/datacoord/compaction_task_backfill.go
@@ -1,0 +1,422 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datacoord
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/samber/lo"
+	"go.uber.org/atomic"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/compaction"
+	"github.com/milvus-io/milvus/internal/datacoord/allocator"
+	"github.com/milvus-io/milvus/internal/datacoord/session"
+	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v2/taskcommon"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+)
+
+var _ CompactionTask = (*backfillCompactionTask)(nil)
+
+type backfillCompactionTask struct {
+	taskProto atomic.Value // *datapb.CompactionTask
+	allocator allocator.Allocator
+	meta      CompactionMeta
+	ievm      IndexEngineVersionManager
+	functions []*schemapb.FunctionSchema
+	times     *taskcommon.Times
+}
+
+func newBackfillCompactionTask(t *datapb.CompactionTask, allocator allocator.Allocator, meta CompactionMeta, ievm IndexEngineVersionManager, functions []*schemapb.FunctionSchema) *backfillCompactionTask {
+	task := &backfillCompactionTask{
+		allocator: allocator,
+		meta:      meta,
+		ievm:      ievm,
+		functions: functions,
+		times:     taskcommon.NewTimes(),
+	}
+	task.taskProto.Store(t)
+	return task
+}
+
+func (t *backfillCompactionTask) GetTaskID() int64 {
+	return t.GetTaskProto().GetPlanID()
+}
+
+func (t *backfillCompactionTask) GetTaskType() taskcommon.Type {
+	return taskcommon.Compaction
+}
+
+func (t *backfillCompactionTask) GetTaskState() taskcommon.State {
+	return taskcommon.FromCompactionState(t.GetTaskProto().GetState())
+}
+
+func (t *backfillCompactionTask) GetTaskProto() *datapb.CompactionTask {
+	return t.taskProto.Load().(*datapb.CompactionTask)
+}
+
+func (t *backfillCompactionTask) GetTaskSlot() int64 {
+	return paramtable.Get().DataCoordCfg.BackfillCompactionSlotUsage.GetAsInt64()
+}
+
+func (t *backfillCompactionTask) SetTaskTime(timeType taskcommon.TimeType, time time.Time) {
+	t.times.SetTaskTime(timeType, time)
+}
+
+func (t *backfillCompactionTask) GetTaskTime(timeType taskcommon.TimeType) time.Time {
+	return timeType.GetTaskTime(t.times)
+}
+
+func (t *backfillCompactionTask) GetTaskVersion() int64 {
+	return int64(t.GetTaskProto().GetRetryTimes())
+}
+
+func (t *backfillCompactionTask) BuildCompactionRequest() (*datapb.CompactionPlan, error) {
+	compactionParams, err := compaction.GenerateJSONParams()
+	if err != nil {
+		return nil, err
+	}
+	taskProto := t.GetTaskProto()
+	log := log.With(zap.Int64("triggerID", taskProto.GetTriggerID()), zap.Int64("PlanID", taskProto.GetPlanID()), zap.Int64("collectionID", taskProto.GetCollectionID()))
+	plan := &datapb.CompactionPlan{
+		PlanID:                    taskProto.GetPlanID(),
+		StartTime:                 taskProto.GetStartTime(),
+		Type:                      taskProto.GetType(),
+		Channel:                   taskProto.GetChannel(),
+		CollectionTtl:             taskProto.GetCollectionTtl(),
+		TotalRows:                 taskProto.GetTotalRows(),
+		Schema:                    taskProto.GetSchema(),
+		PreAllocatedSegmentIDs:    taskProto.GetPreAllocatedSegmentIDs(),
+		SlotUsage:                 t.GetSlotUsage(),
+		MaxSize:                   taskProto.GetMaxSize(),
+		JsonParams:                compactionParams,
+		CurrentScalarIndexVersion: t.ievm.GetCurrentScalarIndexEngineVersion(),
+		Functions:                 t.functions,
+	}
+	segments := make([]*SegmentInfo, 0, len(taskProto.GetInputSegments()))
+	for _, segID := range taskProto.GetInputSegments() {
+		segInfo := t.meta.GetHealthySegment(context.TODO(), segID)
+		if segInfo == nil {
+			return nil, merr.WrapErrSegmentNotFound(segID)
+		}
+		plan.SegmentBinlogs = append(plan.SegmentBinlogs, &datapb.CompactionSegmentBinlogs{
+			SegmentID:           segID,
+			CollectionID:        segInfo.GetCollectionID(),
+			PartitionID:         segInfo.GetPartitionID(),
+			Level:               segInfo.GetLevel(),
+			InsertChannel:       segInfo.GetInsertChannel(),
+			FieldBinlogs:        segInfo.GetBinlogs(),
+			Field2StatslogPaths: segInfo.GetStatslogs(),
+			Deltalogs:           segInfo.GetDeltalogs(),
+			IsSorted:            segInfo.GetIsSorted(),
+			IsSortedByNamespace: segInfo.GetIsSortedByNamespace(),
+			StorageVersion:      segInfo.GetStorageVersion(),
+			Manifest:            segInfo.GetManifestPath(),
+		})
+		segments = append(segments, segInfo)
+	}
+
+	logIDRange, err := PreAllocateBinlogIDs(t.allocator, segments)
+	if err != nil {
+		return nil, err
+	}
+	plan.PreAllocatedLogIDs = logIDRange
+	plan.BeginLogID = logIDRange.Begin
+	WrapPluginContext(taskProto.GetCollectionID(), taskProto.GetSchema().GetProperties(), plan)
+	log.Info("Compaction handler refreshed backfill compaction plan", zap.Int64("maxSize", plan.GetMaxSize()),
+		zap.Any("PreAllocatedLogIDs", logIDRange), zap.Int64s("inputSegments", taskProto.GetInputSegments()))
+	return plan, nil
+}
+
+func (t *backfillCompactionTask) GetSlotUsage() int64 {
+	return t.GetTaskSlot()
+}
+
+func (t *backfillCompactionTask) GetLabel() string {
+	return fmt.Sprintf("%d-%s", t.GetTaskProto().GetPartitionID(), t.GetTaskProto().GetChannel())
+}
+
+func (t *backfillCompactionTask) SetTask(task *datapb.CompactionTask) {
+	t.taskProto.Store(task)
+}
+
+func (t *backfillCompactionTask) ShadowClone(opts ...compactionTaskOpt) *datapb.CompactionTask {
+	cloned := proto.Clone(t.GetTaskProto()).(*datapb.CompactionTask)
+	for _, opt := range opts {
+		opt(cloned)
+	}
+	return cloned
+}
+
+func (t *backfillCompactionTask) SetNodeID(nodeID int64) error {
+	return t.updateAndSaveTaskMeta(setNodeID(nodeID))
+}
+
+func (t *backfillCompactionTask) NeedReAssignNodeID() bool {
+	return t.GetTaskProto().GetState() == datapb.CompactionTaskState_pipelining && (t.GetTaskProto().GetNodeID() == 0 || t.GetTaskProto().GetNodeID() == NullNodeID)
+}
+
+func (t *backfillCompactionTask) saveTaskMeta(task *datapb.CompactionTask) error {
+	return t.meta.SaveCompactionTask(context.TODO(), task)
+}
+
+func (t *backfillCompactionTask) SaveTaskMeta() error {
+	return t.saveTaskMeta(t.GetTaskProto())
+}
+
+func (t *backfillCompactionTask) Clean() bool {
+	return t.doClean() == nil
+}
+
+func (t *backfillCompactionTask) doClean() error {
+	log := log.With(zap.Int64("triggerID", t.GetTaskProto().GetTriggerID()),
+		zap.Int64("PlanID", t.GetTaskProto().GetPlanID()),
+		zap.Int64("collectionID", t.GetTaskProto().GetCollectionID()))
+	err := t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_cleaned))
+	if err != nil {
+		log.Warn("backfillCompactionTask fail to updateAndSaveTaskMeta", zap.Error(err))
+		return err
+	}
+	// resetSegmentCompacting must be the last step of Clean, to make sure resetSegmentCompacting only called once
+	// otherwise, it may unlock segments locked by other compaction tasks
+	t.resetSegmentCompacting()
+	log.Info("backfillCompactionTask clean done")
+	return nil
+}
+
+func (t *backfillCompactionTask) resetSegmentCompacting() {
+	t.meta.SetSegmentsCompacting(context.TODO(), t.GetTaskProto().GetInputSegments(), false)
+}
+
+func (t *backfillCompactionTask) processFailed() bool {
+	return true
+}
+
+func (t *backfillCompactionTask) CreateTaskOnWorker(nodeID int64, cluster session.Cluster) {
+	log := log.With(zap.Int64("triggerID", t.GetTaskProto().GetTriggerID()),
+		zap.Int64("PlanID", t.GetTaskProto().GetPlanID()),
+		zap.Int64("collectionID", t.GetTaskProto().GetCollectionID()),
+		zap.Int64("nodeID", nodeID))
+
+	plan, err := t.BuildCompactionRequest()
+	if err != nil {
+		log.Warn("backfillCompactionTask failed to build compaction request", zap.Error(err))
+		err = t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_failed), setFailReason(err.Error()))
+		if err != nil {
+			log.Warn("backfillCompactionTask failed to updateAndSaveTaskMeta", zap.Error(err))
+		}
+		return
+	}
+
+	err = cluster.CreateCompaction(nodeID, plan)
+	if err != nil {
+		log.Warn("backfillCompactionTask failed to notify compaction tasks to DataNode",
+			zap.Int64("planID", t.GetTaskProto().GetPlanID()),
+			zap.Int64("nodeID", nodeID),
+			zap.Error(err))
+		err = t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_pipelining), setNodeID(NullNodeID))
+		if err != nil {
+			log.Warn("backfillCompactionTask failed to updateAndSaveTaskMeta", zap.Error(err))
+		}
+		return
+	}
+
+	log.Info("backfillCompactionTask created task on worker", zap.Int64("planID", t.GetTaskProto().GetPlanID()),
+		zap.Int64("nodeID", nodeID))
+
+	err = t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_executing), setNodeID(nodeID))
+	if err != nil {
+		log.Warn("backfillCompactionTask failed to updateAndSaveTaskMeta", zap.Error(err))
+	}
+}
+
+func (t *backfillCompactionTask) QueryTaskOnWorker(cluster session.Cluster) {
+	log := log.With(zap.Int64("triggerID", t.GetTaskProto().GetTriggerID()),
+		zap.Int64("PlanID", t.GetTaskProto().GetPlanID()),
+		zap.Int64("collectionID", t.GetTaskProto().GetCollectionID()))
+	result, err := cluster.QueryCompaction(t.GetTaskProto().GetNodeID(), &datapb.CompactionStateRequest{
+		PlanID: t.GetTaskProto().GetPlanID(),
+	})
+	if err != nil || result == nil {
+		if errors.Is(err, merr.ErrNodeNotFound) {
+			if err := t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_pipelining), setNodeID(NullNodeID)); err != nil {
+				log.Warn("backfillCompactionTask failed to updateAndSaveTaskMeta", zap.Error(err))
+			}
+		}
+		log.Warn("backfillCompactionTask failed to get compaction result", zap.Error(err))
+		return
+	}
+	switch result.GetState() {
+	case datapb.CompactionTaskState_completed:
+		if len(result.GetSegments()) == 0 {
+			log.Warn("backfillCompactionTask illegal compaction results: no segments returned")
+			if err := t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_failed),
+				setFailReason("illegal compaction results: no segments returned")); err != nil {
+				log.Warn("backfillCompactionTask failed to setState failed", zap.Error(err))
+			}
+			return
+		}
+		err = t.meta.ValidateSegmentStateBeforeCompleteCompactionMutation(t.GetTaskProto())
+		if err != nil {
+			if saveErr := t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_failed), setFailReason(err.Error())); saveErr != nil {
+				log.Warn("backfillCompactionTask failed to setState failed", zap.Error(saveErr))
+			}
+			return
+		}
+		if err := t.saveSegmentMeta(result); err != nil {
+			log.Warn("backfillCompactionTask failed to save segment meta", zap.Error(err))
+			if errors.Is(err, merr.ErrIllegalCompactionPlan) {
+				if saveErr := t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_failed),
+					setFailReason(err.Error())); saveErr != nil {
+					log.Warn("backfillCompactionTask failed to setState failed", zap.Error(saveErr))
+				}
+			}
+			return
+		}
+		UpdateCompactionSegmentSizeMetrics(result.GetSegments())
+		t.processMetaSaved()
+	case datapb.CompactionTaskState_pipelining, datapb.CompactionTaskState_executing:
+		return
+	case datapb.CompactionTaskState_timeout:
+		err = t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_timeout))
+		if err != nil {
+			log.Warn("backfillCompactionTask failed to updateAndSaveTaskMeta", zap.Error(err))
+			return
+		}
+	case datapb.CompactionTaskState_failed:
+		log.Warn("backfillCompactionTask fail in datanode")
+		if err := t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_failed),
+			setFailReason("compaction failed in datanode")); err != nil {
+			log.Warn("backfillCompactionTask failed to updateAndSaveTaskMeta", zap.Error(err))
+		}
+	default:
+		log.Error("not support compaction task state", zap.String("state", result.GetState().String()))
+		reason := fmt.Sprintf("unsupported compaction state: %s", result.GetState().String())
+		if err = t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_failed),
+			setFailReason(reason)); err != nil {
+			log.Warn("backfillCompactionTask failed to updateAndSaveTaskMeta", zap.Error(err))
+			return
+		}
+	}
+}
+
+func (t *backfillCompactionTask) DropTaskOnWorker(cluster session.Cluster) {
+	log := log.With(zap.Int64("triggerID", t.GetTaskProto().GetTriggerID()),
+		zap.Int64("PlanID", t.GetTaskProto().GetPlanID()),
+		zap.Int64("collectionID", t.GetTaskProto().GetCollectionID()))
+	if err := cluster.DropCompaction(t.GetTaskProto().GetNodeID(), t.GetTaskProto().GetPlanID()); err != nil {
+		log.Warn("backfillCompactionTask unable to drop compaction plan", zap.Error(err))
+	}
+}
+
+// Process performs the task's state machine
+// Note: return True means exit this state machine.
+// ONLY return True for Completed, Failed, Timeout
+func (t *backfillCompactionTask) Process() bool {
+	log := log.With(zap.Int64("triggerID", t.GetTaskProto().GetTriggerID()),
+		zap.Int64("PlanID", t.GetTaskProto().GetPlanID()),
+		zap.Int64("collectionID", t.GetTaskProto().GetCollectionID()))
+	lastState := t.GetTaskProto().GetState().String()
+	processResult := false
+	switch t.GetTaskProto().GetState() {
+	case datapb.CompactionTaskState_meta_saved:
+		processResult = t.processMetaSaved()
+	case datapb.CompactionTaskState_completed:
+		processResult = t.processCompleted()
+	case datapb.CompactionTaskState_failed:
+		processResult = t.processFailed()
+	case datapb.CompactionTaskState_timeout:
+		processResult = true
+	}
+	currentState := t.GetTaskProto().GetState().String()
+	if currentState != lastState {
+		log.Info("backfill compaction task state changed", zap.String("lastState", lastState), zap.String("currentState", currentState))
+	}
+	return processResult
+}
+
+func (t *backfillCompactionTask) saveSegmentMeta(result *datapb.CompactionPlanResult) error {
+	log := log.With(zap.Int64("triggerID", t.GetTaskProto().GetTriggerID()),
+		zap.Int64("PlanID", t.GetTaskProto().GetPlanID()),
+		zap.Int64("collectionID", t.GetTaskProto().GetCollectionID()))
+	newSegments, metricMutation, err := t.meta.CompleteCompactionMutation(context.TODO(), t.GetTaskProto(), result)
+	if err != nil {
+		return err
+	}
+	newSegmentIDs := lo.Map(newSegments, func(s *SegmentInfo, _ int) UniqueID { return s.GetID() })
+	metricMutation.commit()
+	for _, newSegID := range newSegmentIDs {
+		select {
+		case getBuildIndexChSingleton() <- newSegID:
+		default:
+		}
+	}
+
+	err = t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_meta_saved), setResultSegments(newSegmentIDs))
+	if err != nil {
+		log.Warn("backfillCompactionTask failed to setState meta saved", zap.Error(err))
+		return err
+	}
+	log.Info("backfillCompactionTask success to save segment meta")
+	return nil
+}
+
+func (t *backfillCompactionTask) processMetaSaved() bool {
+	err := t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_completed))
+	if err != nil {
+		log.Warn("backfillCompactionTask unable to processMetaSaved",
+			zap.Int64("planID", t.GetTaskProto().GetPlanID()),
+			zap.Error(err))
+		return false
+	}
+	return t.processCompleted()
+}
+
+func (t *backfillCompactionTask) processCompleted() bool {
+	log := log.With(zap.Int64("triggerID", t.GetTaskProto().GetTriggerID()),
+		zap.Int64("PlanID", t.GetTaskProto().GetPlanID()),
+		zap.Int64("collectionID", t.GetTaskProto().GetCollectionID()))
+	log.Info("backfillCompactionTask processCompleted done")
+	return true
+}
+
+func (t *backfillCompactionTask) updateAndSaveTaskMeta(opts ...compactionTaskOpt) error {
+	// if task state is completed, cleaned, failed, timeout, then do append end time and save
+	if t.GetTaskProto().State == datapb.CompactionTaskState_completed ||
+		t.GetTaskProto().State == datapb.CompactionTaskState_cleaned ||
+		t.GetTaskProto().State == datapb.CompactionTaskState_failed ||
+		t.GetTaskProto().State == datapb.CompactionTaskState_timeout {
+		ts := time.Now().Unix()
+		opts = append(opts, setEndTime(ts))
+	}
+
+	task := t.ShadowClone(opts...)
+	err := t.saveTaskMeta(task)
+	if err != nil {
+		return err
+	}
+	t.SetTask(task)
+	return nil
+}

--- a/internal/datacoord/compaction_task_backfill_test.go
+++ b/internal/datacoord/compaction_task_backfill_test.go
@@ -1,0 +1,698 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datacoord
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/atomic"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/datacoord/allocator"
+	"github.com/milvus-io/milvus/internal/datacoord/broker"
+	"github.com/milvus-io/milvus/internal/datacoord/session"
+	"github.com/milvus-io/milvus/internal/metastore/kv/datacoord"
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/pkg/v2/objectstorage"
+	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+	taskcommon "github.com/milvus-io/milvus/pkg/v2/taskcommon"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+)
+
+func TestBackfillCompactionTaskSuite(t *testing.T) {
+	suite.Run(t, new(BackfillCompactionTaskSuite))
+}
+
+type BackfillCompactionTaskSuite struct {
+	suite.Suite
+
+	mockID    atomic.Int64
+	mockAlloc *allocator.MockAllocator
+	meta      *meta
+	handler   *NMockHandler
+	ievm      IndexEngineVersionManager
+}
+
+func (s *BackfillCompactionTaskSuite) SetupTest() {
+	ctx := context.Background()
+	cm := storage.NewLocalChunkManager(objectstorage.RootPath(""))
+	catalog := datacoord.NewCatalog(NewMetaMemoryKV(), "", "")
+	broker := broker.NewMockBroker(s.T())
+	broker.EXPECT().ShowCollectionIDs(mock.Anything).Return(nil, nil)
+	meta, err := newMeta(ctx, catalog, cm, broker)
+	s.NoError(err)
+	s.meta = meta
+
+	s.mockID.Store(time.Now().UnixMilli())
+	s.mockAlloc = allocator.NewMockAllocator(s.T())
+	s.mockAlloc.EXPECT().AllocN(mock.Anything).RunAndReturn(func(x int64) (int64, int64, error) {
+		start := s.mockID.Load()
+		end := s.mockID.Add(int64(x))
+		return start, end, nil
+	}).Maybe()
+	s.mockAlloc.EXPECT().AllocID(mock.Anything).RunAndReturn(func(ctx context.Context) (int64, error) {
+		end := s.mockID.Add(1)
+		return end, nil
+	}).Maybe()
+
+	s.handler = NewNMockHandler(s.T())
+	s.handler.EXPECT().GetCollection(mock.Anything, mock.Anything).Return(&collectionInfo{}, nil).Maybe()
+	s.ievm = newIndexEngineVersionManager()
+}
+
+func (s *BackfillCompactionTaskSuite) SetupSubTest() {
+	s.SetupTest()
+}
+
+func (s *BackfillCompactionTaskSuite) generateBasicTask() *backfillCompactionTask {
+	schema := &schemapb.CollectionSchema{
+		Name:        "test_backfill_collection",
+		Description: "test collection for backfill compaction",
+		Version:     2,
+		Fields: []*schemapb.FieldSchema{
+			{
+				FieldID:      100,
+				Name:         "pk",
+				IsPrimaryKey: true,
+				DataType:     schemapb.DataType_Int64,
+				AutoID:       true,
+			},
+			{
+				FieldID:  101,
+				Name:     "text",
+				DataType: schemapb.DataType_VarChar,
+			},
+			{
+				FieldID:  102,
+				Name:     "sparse_vector",
+				DataType: schemapb.DataType_SparseFloatVector,
+			},
+		},
+	}
+
+	// Create BM25 function schema
+	// Note: FunctionSchema structure needs to be verified from actual proto definition
+	// For now, we create an empty functions slice
+	functions := []*schemapb.FunctionSchema{}
+
+	compactionTask := &datapb.CompactionTask{
+		PlanID:         1,
+		TriggerID:      19530,
+		CollectionID:   1,
+		PartitionID:    10,
+		Type:           datapb.CompactionType_BackfillCompaction,
+		NodeID:         1,
+		State:          datapb.CompactionTaskState_pipelining,
+		Schema:         schema,
+		InputSegments:  []int64{101},
+		ResultSegments: []int64{1000},
+		PreAllocatedSegmentIDs: &datapb.IDRange{
+			Begin: 1000,
+			End:   2000,
+		},
+		Channel: "ch-1",
+	}
+
+	task := newBackfillCompactionTask(compactionTask, s.mockAlloc, s.meta, s.ievm, functions)
+	return task
+}
+
+func (s *BackfillCompactionTaskSuite) TestBackfillCompactionTaskBasic() {
+	task := s.generateBasicTask()
+
+	// Test basic getters
+	s.Equal(int64(1), task.GetTaskID())
+	s.Equal(taskcommon.Compaction, task.GetTaskType())
+	s.Equal(int64(1), task.GetSlotUsage())
+	s.Equal("10-ch-1", task.GetLabel())
+	s.Equal(int64(0), task.GetTaskVersion())
+
+	// Test task proto
+	taskProto := task.GetTaskProto()
+	s.NotNil(taskProto)
+	s.Equal(int64(1), taskProto.GetPlanID())
+	s.Equal(int64(19530), taskProto.GetTriggerID())
+	s.Equal(int64(1), taskProto.GetCollectionID())
+	s.Equal(int64(10), taskProto.GetPartitionID())
+	s.Equal(datapb.CompactionType_BackfillCompaction, taskProto.GetType())
+	s.Equal(datapb.CompactionTaskState_pipelining, taskProto.GetState())
+	s.Equal([]int64{101}, taskProto.GetInputSegments())
+	s.Equal([]int64{1000}, taskProto.GetResultSegments())
+}
+
+func (s *BackfillCompactionTaskSuite) TestBuildCompactionRequest() {
+	// Add a segment to meta
+	segmentID := int64(101)
+	err := s.meta.AddSegment(context.TODO(), &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:            segmentID,
+			CollectionID:  1,
+			PartitionID:   10,
+			InsertChannel: "ch-1",
+			Level:         datapb.SegmentLevel_L1,
+			State:         commonpb.SegmentState_Flushed,
+			NumOfRows:     1000,
+			Binlogs: []*datapb.FieldBinlog{
+				{
+					FieldID: 101,
+					Binlogs: []*datapb.Binlog{
+						{LogID: 1000, EntriesNum: 1000},
+					},
+				},
+			},
+		},
+	})
+	s.NoError(err)
+
+	task := s.generateBasicTask()
+
+	// Build compaction request
+	plan, err := task.BuildCompactionRequest()
+	s.NoError(err)
+	s.NotNil(plan)
+
+	// Verify plan
+	s.Equal(int64(1), plan.GetPlanID())
+	s.Equal(datapb.CompactionType_BackfillCompaction, plan.GetType())
+	s.Equal("ch-1", plan.GetChannel())
+	s.Equal(1, len(plan.GetSegmentBinlogs()))
+	s.Equal(segmentID, plan.GetSegmentBinlogs()[0].GetSegmentID())
+	s.Equal(int64(1), plan.GetSegmentBinlogs()[0].GetCollectionID())
+	s.Equal(int64(10), plan.GetSegmentBinlogs()[0].GetPartitionID())
+	s.NotNil(plan.GetFunctions())
+}
+
+func (s *BackfillCompactionTaskSuite) TestBuildCompactionRequestSegmentNotFound() {
+	task := s.generateBasicTask()
+
+	// Try to build compaction request without adding segment to meta
+	plan, err := task.BuildCompactionRequest()
+	s.Error(err)
+	s.Nil(plan)
+	s.Contains(err.Error(), "segment not found")
+}
+
+func (s *BackfillCompactionTaskSuite) TestCreateTaskOnWorker() {
+	s.Run("CreateTaskOnWorker fail, segment not found", func() {
+		task := s.generateBasicTask()
+		cluster := session.NewMockCluster(s.T())
+		task.CreateTaskOnWorker(1, cluster)
+		s.Equal(datapb.CompactionTaskState_failed, task.GetTaskProto().GetState())
+	})
+
+	s.Run("CreateTaskOnWorker fail, CreateCompaction error", func() {
+		// Add segment to meta
+		segmentID := int64(101)
+		err := s.meta.AddSegment(context.TODO(), &SegmentInfo{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:            segmentID,
+				CollectionID:  1,
+				PartitionID:   10,
+				InsertChannel: "ch-1",
+				Level:         datapb.SegmentLevel_L1,
+				State:         commonpb.SegmentState_Flushed,
+				NumOfRows:     1000,
+				Binlogs: []*datapb.FieldBinlog{
+					{
+						FieldID: 101,
+						Binlogs: []*datapb.Binlog{
+							{LogID: 1000, EntriesNum: 1000},
+						},
+					},
+				},
+			},
+		})
+		s.NoError(err)
+
+		task := s.generateBasicTask()
+		cluster := session.NewMockCluster(s.T())
+		cluster.EXPECT().CreateCompaction(mock.Anything, mock.Anything).Return(merr.WrapErrNodeNotFound(1))
+		task.CreateTaskOnWorker(1, cluster)
+		// Should remain in pipelining state when CreateCompaction fails
+		s.Equal(datapb.CompactionTaskState_pipelining, task.GetTaskProto().GetState())
+		// NodeID should be set to NullNodeID (-1) when CreateCompaction fails
+		s.Equal(int64(-1), task.GetTaskProto().GetNodeID())
+	})
+
+	s.Run("CreateTaskOnWorker succeed", func() {
+		// Add segment to meta
+		segmentID := int64(101)
+		err := s.meta.AddSegment(context.TODO(), &SegmentInfo{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:            segmentID,
+				CollectionID:  1,
+				PartitionID:   10,
+				InsertChannel: "ch-1",
+				Level:         datapb.SegmentLevel_L1,
+				State:         commonpb.SegmentState_Flushed,
+				NumOfRows:     1000,
+				Binlogs: []*datapb.FieldBinlog{
+					{
+						FieldID: 101,
+						Binlogs: []*datapb.Binlog{
+							{LogID: 1000, EntriesNum: 1000},
+						},
+					},
+				},
+			},
+		})
+		s.NoError(err)
+
+		task := s.generateBasicTask()
+		cluster := session.NewMockCluster(s.T())
+		cluster.EXPECT().CreateCompaction(mock.Anything, mock.Anything).Return(nil)
+		task.CreateTaskOnWorker(1, cluster)
+		s.Equal(datapb.CompactionTaskState_executing, task.GetTaskProto().GetState())
+		s.Equal(int64(1), task.GetTaskProto().GetNodeID())
+	})
+}
+
+func (s *BackfillCompactionTaskSuite) TestQueryTaskOnWorker() {
+	s.Run("QueryTaskOnWorker, node not found", func() {
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_executing), setNodeID(1)))
+		cluster := session.NewMockCluster(s.T())
+		cluster.EXPECT().QueryCompaction(mock.Anything, mock.Anything).Return(nil, merr.WrapErrNodeNotFound(1)).Once()
+		task.QueryTaskOnWorker(cluster)
+		s.Equal(datapb.CompactionTaskState_pipelining, task.GetTaskProto().GetState())
+		s.Equal(int64(-1), task.GetTaskProto().GetNodeID())
+	})
+
+	s.Run("QueryTaskOnWorker, result is nil", func() {
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_executing), setNodeID(1)))
+		cluster := session.NewMockCluster(s.T())
+		cluster.EXPECT().QueryCompaction(mock.Anything, mock.Anything).Return(nil, nil).Once()
+		task.QueryTaskOnWorker(cluster)
+		// State should remain unchanged when result is nil
+		s.Equal(datapb.CompactionTaskState_executing, task.GetTaskProto().GetState())
+	})
+
+	s.Run("QueryTaskOnWorker, completed with empty segments", func() {
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_executing), setNodeID(1)))
+		cluster := session.NewMockCluster(s.T())
+		cluster.EXPECT().QueryCompaction(mock.Anything, mock.Anything).Return(&datapb.CompactionPlanResult{
+			State:    datapb.CompactionTaskState_completed,
+			Segments: []*datapb.CompactionSegment{},
+		}, nil).Once()
+		task.QueryTaskOnWorker(cluster)
+		s.Equal(datapb.CompactionTaskState_failed, task.GetTaskProto().GetState())
+	})
+
+	s.Run("QueryTaskOnWorker, pipelining state", func() {
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_executing), setNodeID(1)))
+		cluster := session.NewMockCluster(s.T())
+		cluster.EXPECT().QueryCompaction(mock.Anything, mock.Anything).Return(&datapb.CompactionPlanResult{
+			State: datapb.CompactionTaskState_pipelining,
+		}, nil).Once()
+		task.QueryTaskOnWorker(cluster)
+		// State should remain unchanged
+		s.Equal(datapb.CompactionTaskState_executing, task.GetTaskProto().GetState())
+	})
+
+	s.Run("QueryTaskOnWorker, executing state", func() {
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_executing), setNodeID(1)))
+		cluster := session.NewMockCluster(s.T())
+		cluster.EXPECT().QueryCompaction(mock.Anything, mock.Anything).Return(&datapb.CompactionPlanResult{
+			State: datapb.CompactionTaskState_executing,
+		}, nil).Once()
+		task.QueryTaskOnWorker(cluster)
+		// State should remain unchanged
+		s.Equal(datapb.CompactionTaskState_executing, task.GetTaskProto().GetState())
+	})
+
+	s.Run("QueryTaskOnWorker, timeout state", func() {
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_executing), setNodeID(1)))
+		cluster := session.NewMockCluster(s.T())
+		cluster.EXPECT().QueryCompaction(mock.Anything, mock.Anything).Return(&datapb.CompactionPlanResult{
+			State: datapb.CompactionTaskState_timeout,
+		}, nil).Once()
+		task.QueryTaskOnWorker(cluster)
+		s.Equal(datapb.CompactionTaskState_timeout, task.GetTaskProto().GetState())
+	})
+
+	s.Run("QueryTaskOnWorker, failed state", func() {
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_executing), setNodeID(1)))
+		cluster := session.NewMockCluster(s.T())
+		cluster.EXPECT().QueryCompaction(mock.Anything, mock.Anything).Return(&datapb.CompactionPlanResult{
+			State: datapb.CompactionTaskState_failed,
+		}, nil).Once()
+		task.QueryTaskOnWorker(cluster)
+		s.Equal(datapb.CompactionTaskState_failed, task.GetTaskProto().GetState())
+	})
+
+	s.Run("QueryTaskOnWorker, completed with ValidateSegmentState error (segment not in meta)", func() {
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_executing), setNodeID(1)))
+		cluster := session.NewMockCluster(s.T())
+		// segment 101 is NOT in meta → ValidateSegmentStateBeforeCompleteCompactionMutation returns error
+		cluster.EXPECT().QueryCompaction(mock.Anything, mock.Anything).Return(&datapb.CompactionPlanResult{
+			State:    datapb.CompactionTaskState_completed,
+			Segments: []*datapb.CompactionSegment{{SegmentID: 101}},
+		}, nil).Once()
+		task.QueryTaskOnWorker(cluster)
+		s.Equal(datapb.CompactionTaskState_failed, task.GetTaskProto().GetState())
+	})
+
+	s.Run("QueryTaskOnWorker, completed with ErrIllegalCompactionPlan from saveSegmentMeta", func() {
+		// Add segment 101 so ValidateSegmentState passes, but result segmentID mismatches → ErrIllegalCompactionPlan
+		segmentID := int64(101)
+		err := s.meta.AddSegment(context.TODO(), &SegmentInfo{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:            segmentID,
+				CollectionID:  1,
+				PartitionID:   10,
+				InsertChannel: "ch-1",
+				Level:         datapb.SegmentLevel_L1,
+				State:         commonpb.SegmentState_Flushed,
+				NumOfRows:     1000,
+			},
+			isCompacting: true,
+		})
+		s.NoError(err)
+
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_executing), setNodeID(1)))
+		cluster := session.NewMockCluster(s.T())
+		cluster.EXPECT().QueryCompaction(mock.Anything, mock.Anything).Return(&datapb.CompactionPlanResult{
+			State:    datapb.CompactionTaskState_completed,
+			Segments: []*datapb.CompactionSegment{{SegmentID: 999}}, // mismatched → ErrIllegalCompactionPlan
+		}, nil).Once()
+		task.QueryTaskOnWorker(cluster)
+		s.Equal(datapb.CompactionTaskState_failed, task.GetTaskProto().GetState())
+	})
+
+	s.Run("QueryTaskOnWorker, completed success path", func() {
+		segmentID := int64(101)
+		err := s.meta.AddSegment(context.TODO(), &SegmentInfo{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:            segmentID,
+				CollectionID:  1,
+				PartitionID:   10,
+				InsertChannel: "ch-1",
+				Level:         datapb.SegmentLevel_L1,
+				State:         commonpb.SegmentState_Flushed,
+				NumOfRows:     1000,
+			},
+			isCompacting: true,
+		})
+		s.NoError(err)
+
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_executing), setNodeID(1)))
+		cluster := session.NewMockCluster(s.T())
+		cluster.EXPECT().QueryCompaction(mock.Anything, mock.Anything).Return(&datapb.CompactionPlanResult{
+			State: datapb.CompactionTaskState_completed,
+			Segments: []*datapb.CompactionSegment{{
+				SegmentID:  segmentID,
+				InsertLogs: []*datapb.FieldBinlog{},
+			}},
+		}, nil).Once()
+		task.QueryTaskOnWorker(cluster)
+		// saveSegmentMeta succeeds → processMetaSaved → completed
+		s.Equal(datapb.CompactionTaskState_completed, task.GetTaskProto().GetState())
+	})
+
+	s.Run("QueryTaskOnWorker, default unknown state", func() {
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_executing), setNodeID(1)))
+		cluster := session.NewMockCluster(s.T())
+		cluster.EXPECT().QueryCompaction(mock.Anything, mock.Anything).Return(&datapb.CompactionPlanResult{
+			State: datapb.CompactionTaskState_unknown,
+		}, nil).Once()
+		task.QueryTaskOnWorker(cluster)
+		s.Equal(datapb.CompactionTaskState_failed, task.GetTaskProto().GetState())
+	})
+}
+
+func (s *BackfillCompactionTaskSuite) TestProcess() {
+	s.Run("Process meta_saved state", func() {
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_meta_saved)))
+		result := task.Process()
+		// processMetaSaved should transition to completed and return true
+		s.True(result)
+		s.Equal(datapb.CompactionTaskState_completed, task.GetTaskProto().GetState())
+	})
+
+	s.Run("Process completed state", func() {
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_completed)))
+		result := task.Process()
+		s.True(result)
+		s.Equal(datapb.CompactionTaskState_completed, task.GetTaskProto().GetState())
+	})
+
+	s.Run("Process failed state", func() {
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_failed)))
+		result := task.Process()
+		s.True(result)
+		s.Equal(datapb.CompactionTaskState_failed, task.GetTaskProto().GetState())
+	})
+
+	s.Run("Process timeout state", func() {
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_timeout)))
+		result := task.Process()
+		s.True(result)
+		s.Equal(datapb.CompactionTaskState_timeout, task.GetTaskProto().GetState())
+	})
+
+	s.Run("Process other states return false", func() {
+		testStates := []datapb.CompactionTaskState{
+			datapb.CompactionTaskState_pipelining,
+			datapb.CompactionTaskState_executing,
+			datapb.CompactionTaskState_unknown,
+		}
+		for _, state := range testStates {
+			task := s.generateBasicTask()
+			task.SetTask(task.ShadowClone(setState(state)))
+			result := task.Process()
+			s.False(result, "state %s should return false", state.String())
+		}
+	})
+}
+
+func (s *BackfillCompactionTaskSuite) TestClean() {
+	task := s.generateBasicTask()
+	// Mark segment as compacting
+	s.meta.SetSegmentsCompacting(context.TODO(), []int64{101}, true)
+
+	// Add segment to meta
+	segmentID := int64(101)
+	err := s.meta.AddSegment(context.TODO(), &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:            segmentID,
+			CollectionID:  1,
+			PartitionID:   10,
+			InsertChannel: "ch-1",
+			Level:         datapb.SegmentLevel_L1,
+			State:         commonpb.SegmentState_Flushed,
+			NumOfRows:     1000,
+		},
+	})
+	s.NoError(err)
+
+	result := task.Clean()
+	s.True(result)
+	s.Equal(datapb.CompactionTaskState_cleaned, task.GetTaskProto().GetState())
+
+	// Verify segment compacting flag is reset
+	seg := s.meta.GetSegment(context.TODO(), segmentID)
+	s.NotNil(seg)
+	s.False(seg.isCompacting)
+}
+
+func (s *BackfillCompactionTaskSuite) TestNeedReAssignNodeID() {
+	s.Run("NeedReAssignNodeID, pipelining with nodeID 0", func() {
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_pipelining), setNodeID(0)))
+		s.True(task.NeedReAssignNodeID())
+	})
+
+	s.Run("NeedReAssignNodeID, pipelining with NullNodeID", func() {
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_pipelining), setNodeID(-1)))
+		s.True(task.NeedReAssignNodeID())
+	})
+
+	s.Run("NeedReAssignNodeID, pipelining with valid nodeID", func() {
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_pipelining), setNodeID(1)))
+		s.False(task.NeedReAssignNodeID())
+	})
+
+	s.Run("NeedReAssignNodeID, non-pipelining state", func() {
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_executing), setNodeID(0)))
+		s.False(task.NeedReAssignNodeID())
+	})
+}
+
+func (s *BackfillCompactionTaskSuite) TestDropTaskOnWorker() {
+	task := s.generateBasicTask()
+	task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_executing), setNodeID(1)))
+	cluster := session.NewMockCluster(s.T())
+	cluster.EXPECT().DropCompaction(mock.Anything, mock.Anything).Return(nil).Once()
+	task.DropTaskOnWorker(cluster)
+}
+
+func (s *BackfillCompactionTaskSuite) TestSetNodeID() {
+	task := s.generateBasicTask()
+	err := task.SetNodeID(100)
+	s.NoError(err)
+	s.Equal(int64(100), task.GetTaskProto().GetNodeID())
+}
+
+func (s *BackfillCompactionTaskSuite) TestSaveSegmentMeta() {
+	s.Run("success", func() {
+		segmentID := int64(101)
+		err := s.meta.AddSegment(context.TODO(), &SegmentInfo{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:            segmentID,
+				CollectionID:  1,
+				PartitionID:   10,
+				InsertChannel: "ch-1",
+				Level:         datapb.SegmentLevel_L1,
+				State:         commonpb.SegmentState_Flushed,
+				NumOfRows:     1000,
+				Binlogs: []*datapb.FieldBinlog{
+					{FieldID: 101, Binlogs: []*datapb.Binlog{{LogID: 1000, EntriesNum: 1000}}},
+				},
+			},
+			isCompacting: true,
+		})
+		s.NoError(err)
+
+		task := s.generateBasicTask()
+		result := &datapb.CompactionPlanResult{
+			PlanID: 1,
+			State:  datapb.CompactionTaskState_completed,
+			Type:   datapb.CompactionType_BackfillCompaction,
+			Segments: []*datapb.CompactionSegment{
+				{
+					SegmentID: segmentID,
+					InsertLogs: []*datapb.FieldBinlog{
+						{FieldID: 101, Binlogs: []*datapb.Binlog{{LogID: 1000, EntriesNum: 1000}}},
+						{FieldID: 102, Binlogs: []*datapb.Binlog{{LogID: 2000, EntriesNum: 1000}}},
+					},
+				},
+			},
+		}
+		err = task.saveSegmentMeta(result)
+		s.NoError(err)
+		s.Equal(datapb.CompactionTaskState_meta_saved, task.GetTaskProto().GetState())
+	})
+
+	s.Run("CompleteCompactionMutation error", func() {
+		// Without adding a segment to meta, CompleteCompactionMutation should fail
+		task := s.generateBasicTask()
+		result := &datapb.CompactionPlanResult{
+			PlanID: 1,
+			State:  datapb.CompactionTaskState_completed,
+			Type:   datapb.CompactionType_BackfillCompaction,
+			Segments: []*datapb.CompactionSegment{
+				{SegmentID: 101},
+			},
+		}
+		err := task.saveSegmentMeta(result)
+		s.Error(err)
+	})
+}
+
+func (s *BackfillCompactionTaskSuite) TestProcessCompleted() {
+	segmentID := int64(101)
+	err := s.meta.AddSegment(context.TODO(), &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:            segmentID,
+			CollectionID:  1,
+			PartitionID:   10,
+			InsertChannel: "ch-1",
+			Level:         datapb.SegmentLevel_L1,
+			State:         commonpb.SegmentState_Flushed,
+		},
+		isCompacting: true,
+	})
+	s.NoError(err)
+
+	task := s.generateBasicTask()
+	task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_completed)))
+
+	result := task.processCompleted()
+	s.True(result)
+	// processCompleted() does NOT reset the compacting flag — that is done by Clean().
+}
+
+func (s *BackfillCompactionTaskSuite) TestUpdateAndSaveTaskMeta() {
+	s.Run("normal state update", func() {
+		task := s.generateBasicTask()
+		err := task.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_executing))
+		s.NoError(err)
+		s.Equal(datapb.CompactionTaskState_executing, task.GetTaskProto().GetState())
+		// EndTime should not be set for non-terminal states
+		s.Equal(int64(0), task.GetTaskProto().GetEndTime())
+	})
+
+	s.Run("terminal state sets end time", func() {
+		task := s.generateBasicTask()
+		// First set to completed state
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_completed)))
+		// Then call updateAndSaveTaskMeta which checks current state
+		err := task.updateAndSaveTaskMeta()
+		s.NoError(err)
+		s.Equal(datapb.CompactionTaskState_completed, task.GetTaskProto().GetState())
+		s.NotZero(task.GetTaskProto().GetEndTime())
+	})
+
+	s.Run("failed state sets end time", func() {
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_failed)))
+		err := task.updateAndSaveTaskMeta()
+		s.NoError(err)
+		s.Equal(datapb.CompactionTaskState_failed, task.GetTaskProto().GetState())
+		s.NotZero(task.GetTaskProto().GetEndTime())
+	})
+}
+
+func (s *BackfillCompactionTaskSuite) TestProcessFailed() {
+	task := s.generateBasicTask()
+	task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_failed)))
+	s.True(task.processFailed())
+}
+
+func (s *BackfillCompactionTaskSuite) TestGetSlotUsage() {
+	task := s.generateBasicTask()
+	s.Equal(int64(1), task.GetSlotUsage())
+}
+
+func (s *BackfillCompactionTaskSuite) TestSetTaskTime() {
+	task := s.generateBasicTask()
+	now := time.Now()
+	task.SetTaskTime(taskcommon.TimeQueue, now)
+	s.False(task.GetTaskTime(taskcommon.TimeQueue).IsZero())
+}

--- a/internal/datacoord/compaction_trigger.go
+++ b/internal/datacoord/compaction_trigger.go
@@ -230,6 +230,19 @@ func (t *compactionTrigger) getCollection(collectionID UniqueID) (*collectionInf
 	return coll, nil
 }
 
+func (t *compactionTrigger) checkGroupSchemaVersionMatchesCollection(group chanPartSegments, coll *collectionInfo) bool {
+	if len(group.segments) == 0 {
+		return true
+	}
+	collectionSchemaVersion := coll.Schema.GetVersion()
+	for _, segment := range group.segments {
+		if segment.GetSchemaVersion() != collectionSchemaVersion {
+			return false
+		}
+	}
+	return true
+}
+
 func isCollectionAutoCompactionEnabled(coll *collectionInfo) bool {
 	if coll == nil {
 		return false
@@ -371,6 +384,14 @@ func (t *compactionTrigger) handleSignal(signal *compactionSignal) error {
 			if signal.collectionID != 0 {
 				return err
 			}
+			continue
+		}
+
+		if !t.checkGroupSchemaVersionMatchesCollection(group, coll) {
+			log.Debug("segments in group have schema versions not matching collection schema version, skip this group for mix compaction",
+				zap.Int64("collectionID", group.collectionID),
+				zap.Int64("partitionID", group.partitionID),
+				zap.String("channel", group.channelName))
 			continue
 		}
 

--- a/internal/datacoord/compaction_trigger_test.go
+++ b/internal/datacoord/compaction_trigger_test.go
@@ -2003,6 +2003,45 @@ func Test_compactionTrigger_new(t *testing.T) {
 	}
 }
 
+func TestCheckGroupSchemaVersionMatchesCollection(t *testing.T) {
+	m := &meta{
+		channelCPs:  newChannelCps(),
+		segments:    NewSegmentsInfo(),
+		collections: typeutil.NewConcurrentMap[UniqueID, *collectionInfo](),
+	}
+	tr := newCompactionTrigger(m, &compactionInspector{}, newMockAllocator(t),
+		newMockHandlerWithMeta(m), newMockVersionManager())
+
+	coll := &collectionInfo{
+		ID:     1,
+		Schema: &schemapb.CollectionSchema{Version: 5},
+	}
+
+	// empty group: trivially matches
+	assert.True(t, tr.checkGroupSchemaVersionMatchesCollection(
+		chanPartSegments{segments: nil}, coll))
+
+	// all segments with the same schema version as collection → matches
+	assert.True(t, tr.checkGroupSchemaVersionMatchesCollection(
+		chanPartSegments{segments: []*SegmentInfo{
+			{SegmentInfo: &datapb.SegmentInfo{SchemaVersion: 5}},
+			{SegmentInfo: &datapb.SegmentInfo{SchemaVersion: 5}},
+		}}, coll))
+
+	// any segment with a different schema version → no match
+	assert.False(t, tr.checkGroupSchemaVersionMatchesCollection(
+		chanPartSegments{segments: []*SegmentInfo{
+			{SegmentInfo: &datapb.SegmentInfo{SchemaVersion: 5}},
+			{SegmentInfo: &datapb.SegmentInfo{SchemaVersion: 4}},
+		}}, coll))
+
+	// all segments with schema version 0 (pre-alter) → no match when collection version > 0
+	assert.False(t, tr.checkGroupSchemaVersionMatchesCollection(
+		chanPartSegments{segments: []*SegmentInfo{
+			{SegmentInfo: &datapb.SegmentInfo{SchemaVersion: 0}},
+		}}, coll))
+}
+
 func Test_compactionTrigger_getCompactTime(t *testing.T) {
 	coll := &collectionInfo{
 		ID:         1,

--- a/internal/datacoord/compaction_trigger_v2.go
+++ b/internal/datacoord/compaction_trigger_v2.go
@@ -18,6 +18,7 @@ package datacoord
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -48,6 +49,17 @@ const (
 	TriggerTypeSort
 	TriggerTypeForceMerge
 	TriggerTypeStorageVersionUpgrade
+	TriggerTypeBackfill
+)
+
+type TickerType int8
+
+const (
+	L0Ticker TickerType = iota + 1
+	ClusteringTicker
+	SingleTicker
+	BackfillTicker
+	StorageVersionTicker
 )
 
 func (t CompactionTriggerType) GetCompactionType() datapb.CompactionType {
@@ -62,6 +74,8 @@ func (t CompactionTriggerType) GetCompactionType() datapb.CompactionType {
 		return datapb.CompactionType_SortCompaction
 	case TriggerTypeStorageVersionUpgrade:
 		return datapb.CompactionType_MixCompaction
+	case TriggerTypeBackfill:
+		return datapb.CompactionType_BackfillCompaction
 	default:
 		return datapb.CompactionType_MixCompaction
 	}
@@ -87,9 +101,21 @@ func (t CompactionTriggerType) String() string {
 		return "ForceMerge"
 	case TriggerTypeStorageVersionUpgrade:
 		return "StorageVersionUpgrade"
+	case TriggerTypeBackfill:
+		return "Backfill"
 	default:
 		return ""
 	}
+}
+
+// CompactionPolicy defines the interface for different compaction policies
+type CompactionPolicy interface {
+	// Enable returns whether this compaction policy is enabled
+	Enable() bool
+	// Trigger triggers compaction for all collections and returns compaction views grouped by trigger type
+	Trigger(ctx context.Context) (map[CompactionTriggerType][]CompactionView, error)
+	// Name returns the name of this compaction policy
+	Name() string
 }
 
 type TriggerManager interface {
@@ -110,7 +136,9 @@ type CompactionTriggerManager struct {
 	handler   Handler
 	allocator allocator.Allocator
 
-	meta                        *meta
+	meta     *meta
+	policies map[TickerType]CompactionPolicy
+
 	l0Policy                    *l0CompactionPolicy
 	clusteringPolicy            *clusteringCompactionPolicy
 	singlePolicy                *singleCompactionPolicy
@@ -121,18 +149,32 @@ type CompactionTriggerManager struct {
 	closeWg sync.WaitGroup
 }
 
-func NewCompactionTriggerManager(alloc allocator.Allocator, handler Handler, inspector CompactionInspector, meta *meta, versionManager IndexEngineVersionManager) *CompactionTriggerManager {
+func NewCompactionTriggerManager(alloc allocator.Allocator, handler Handler, inspector CompactionInspector, meta *meta,
+	versionManager IndexEngineVersionManager,
+) *CompactionTriggerManager {
 	m := &CompactionTriggerManager{
 		allocator: alloc,
 		handler:   handler,
 		inspector: inspector,
 		meta:      meta,
+		policies:  make(map[TickerType]CompactionPolicy),
 	}
+	// Initialize policies and keep separate pointers for frequently accessed ones
+
 	m.l0Policy = newL0CompactionPolicy(meta, alloc)
 	m.clusteringPolicy = newClusteringCompactionPolicy(meta, m.allocator, m.handler)
 	m.singlePolicy = newSingleCompactionPolicy(meta, m.allocator, m.handler)
+
 	m.forceMergePolicy = newForceMergeCompactionPolicy(meta, m.allocator, m.handler)
 	m.upgradeStorageVersionPolicy = newStorageVersionUpgradePolicy(meta, m.allocator, m.handler, versionManager)
+	backfillPolicy := newBackfillCompactionPolicy(meta, m.allocator, m.handler)
+
+	// Initialize policies map for ticker handling
+	m.policies[L0Ticker] = m.l0Policy
+	m.policies[ClusteringTicker] = m.clusteringPolicy
+	m.policies[SingleTicker] = m.singlePolicy
+	m.policies[BackfillTicker] = backfillPolicy
+	m.policies[StorageVersionTicker] = m.upgradeStorageVersionPolicy
 	return m
 }
 
@@ -179,6 +221,8 @@ func (m *CompactionTriggerManager) loop(ctx context.Context) {
 	defer singleTicker.Stop()
 	storageVersionTicker := time.NewTicker(Params.DataCoordCfg.MixCompactionTriggerInterval.GetAsDuration(time.Second))
 	defer storageVersionTicker.Stop()
+	backfillTicker := time.NewTicker(Params.DataCoordCfg.BackfillCompactionTriggerInterval.GetAsDuration(time.Second))
+	defer backfillTicker.Stop()
 	log.Info("Compaction trigger manager start")
 	for {
 		select {
@@ -186,77 +230,15 @@ func (m *CompactionTriggerManager) loop(ctx context.Context) {
 			log.Info("Compaction trigger manager checkLoop quit")
 			return
 		case <-l0Ticker.C:
-			if !m.l0Policy.Enable() {
-				continue
-			}
-			if m.inspector.isFull() {
-				log.RatedInfo(10, "Skip trigger l0 compaction since inspector is full")
-				continue
-			}
-			events, err := m.l0Policy.Trigger(ctx)
-			if err != nil {
-				log.Warn("Fail to trigger L0 policy", zap.Error(err))
-				continue
-			}
-			if len(events) > 0 {
-				for triggerType, views := range events {
-					m.notify(ctx, triggerType, views)
-				}
-			}
+			m.handleTicker(ctx, L0Ticker)
 		case <-clusteringTicker.C:
-			if !m.clusteringPolicy.Enable() {
-				continue
-			}
-			if m.inspector.isFull() {
-				log.RatedInfo(10, "Skip trigger clustering compaction since inspector is full")
-				continue
-			}
-			events, err := m.clusteringPolicy.Trigger(ctx)
-			if err != nil {
-				log.Warn("Fail to trigger clustering policy", zap.Error(err))
-				continue
-			}
-			if len(events) > 0 {
-				for triggerType, views := range events {
-					m.notify(ctx, triggerType, views)
-				}
-			}
+			m.handleTicker(ctx, ClusteringTicker)
 		case <-singleTicker.C:
-			if !m.singlePolicy.Enable() {
-				continue
-			}
-			if m.inspector.isFull() {
-				log.RatedInfo(10, "Skip trigger single compaction since inspector is full")
-				continue
-			}
-			events, err := m.singlePolicy.Trigger(ctx)
-			if err != nil {
-				log.Warn("Fail to trigger single policy", zap.Error(err))
-				continue
-			}
-			if len(events) > 0 {
-				for triggerType, views := range events {
-					m.notify(ctx, triggerType, views)
-				}
-			}
+			m.handleTicker(ctx, SingleTicker)
 		case <-storageVersionTicker.C:
-			if !m.upgradeStorageVersionPolicy.Enable() {
-				continue
-			}
-			if m.inspector.isFull() {
-				log.RatedInfo(10, "Skip trigger storage version compaction since inspector is full")
-				continue
-			}
-			events, err := m.upgradeStorageVersionPolicy.Trigger(ctx)
-			if err != nil {
-				log.Warn("Fail to trigger storage version policy", zap.Error(err))
-				continue
-			}
-			if len(events) > 0 {
-				for triggerType, views := range events {
-					m.notify(ctx, triggerType, views)
-				}
-			}
+			m.handleTicker(ctx, StorageVersionTicker)
+		case <-backfillTicker.C:
+			m.handleTicker(ctx, BackfillTicker)
 		case segID := <-getStatsTaskChSingleton():
 			log.Info("receive new segment to trigger sort compaction", zap.Int64("segmentID", segID))
 			view := m.singlePolicy.triggerSegmentSortCompaction(ctx, segID)
@@ -269,6 +251,35 @@ func (m *CompactionTriggerManager) loop(ctx context.Context) {
 				continue
 			}
 			m.notify(ctx, TriggerTypeSort, []CompactionView{view})
+		}
+	}
+}
+
+func (m *CompactionTriggerManager) handleTicker(ctx context.Context, tickerType TickerType) {
+	policy, exists := m.policies[tickerType]
+	if !exists {
+		log.Warn("Policy not found for ticker type", zap.Any("tickerType", tickerType))
+		return
+	}
+
+	if !policy.Enable() {
+		return
+	}
+
+	if m.inspector.isFull() {
+		log.RatedInfo(10, "Skip trigger compaction since inspector is full", zap.String("policy", policy.Name()))
+		return
+	}
+
+	events, err := policy.Trigger(ctx)
+	if err != nil {
+		log.Warn("Fail to trigger policy", zap.String("policy", policy.Name()), zap.Error(err))
+		return
+	}
+
+	if len(events) > 0 {
+		for triggerType, views := range events {
+			m.notify(ctx, triggerType, views)
 		}
 	}
 }
@@ -356,6 +367,8 @@ func (m *CompactionTriggerManager) notify(ctx context.Context, eventType Compact
 					m.SubmitSingleViewToScheduler(ctx, outView, eventType)
 				case TriggerTypeForceMerge:
 					m.SubmitForceMergeViewToScheduler(ctx, outView)
+				case TriggerTypeBackfill:
+					m.SubmitBackfillViewToScheduler(ctx, outView)
 				}
 			}
 		}
@@ -626,6 +639,75 @@ func (m *CompactionTriggerManager) SubmitForceMergeViewToScheduler(ctx context.C
 		zap.Int64("triggerID", task.GetTriggerID()),
 		zap.Int64("collectionID", task.GetCollectionID()),
 		zap.Int64("targetSize", task.GetMaxSize()),
+	)
+}
+
+func (m *CompactionTriggerManager) SubmitBackfillViewToScheduler(ctx context.Context, view CompactionView) {
+	log := log.Ctx(ctx).With(zap.String("view", view.String()))
+	planID, _, err := m.allocator.AllocN(1)
+	if err != nil {
+		log.Warn("Failed to submit compaction view to scheduler because allocate id fail", zap.Error(err))
+		return
+	}
+	collection, err := m.handler.GetCollection(ctx, view.GetGroupLabel().CollectionID)
+	if err != nil {
+		log.Warn("Failed to submit compaction view to scheduler because get collection fail", zap.Error(err))
+		return
+	}
+	if collection == nil {
+		log.Warn("Failed to submit compaction view to scheduler because collection is nil")
+		return
+	}
+	if collection.IsExternal() {
+		log.Info("skip submitting backfill compaction for external collection", zap.Int64("collectionID", collection.ID))
+		return
+	}
+	var totalRows int64 = 0
+	for _, s := range view.GetSegmentsView() {
+		totalRows += s.NumOfRows
+	}
+	expectedSize := getExpectedSegmentSize(m.meta, collection.ID, collection.Schema)
+	bfView, ok := view.(*BackfillSegmentsView)
+	if !ok {
+		log.Warn("unexpected view type for backfill trigger, expected *BackfillSegmentsView",
+			zap.String("actualType", fmt.Sprintf("%T", view)))
+		return
+	}
+	if bfView.funcDiff == nil || len(bfView.funcDiff.Added) != 1 {
+		log.Warn("backfill view must have exactly one function to backfill",
+			zap.Int("funcCount", lo.If(bfView.funcDiff == nil, 0).Else(len(bfView.funcDiff.Added))))
+		return
+	}
+	task := &datapb.CompactionTask{
+		PlanID:             planID,
+		TriggerID:          bfView.triggerID,
+		State:              datapb.CompactionTaskState_pipelining,
+		StartTime:          time.Now().Unix(),
+		Type:               datapb.CompactionType_BackfillCompaction,
+		CollectionID:       view.GetGroupLabel().CollectionID,
+		PartitionID:        view.GetGroupLabel().PartitionID,
+		Channel:            view.GetGroupLabel().Channel,
+		Schema:             collection.Schema,
+		InputSegments:      lo.Map(view.GetSegmentsView(), func(segmentView *SegmentView, _ int) int64 { return segmentView.ID }),
+		ResultSegments:     []int64{},
+		TotalRows:          totalRows,
+		LastStateStartTime: time.Now().Unix(),
+		MaxSize:            expectedSize,
+		DiffFunctions:      bfView.funcDiff.Added,
+	}
+	err = m.inspector.enqueueCompaction(task)
+	if err != nil {
+		log.Warn("Failed to execute compaction task",
+			zap.Int64("triggerID", task.GetTriggerID()),
+			zap.Int64("planID", task.GetPlanID()),
+			zap.Int64s("segmentIDs", task.GetInputSegments()),
+			zap.Error(err))
+		return
+	}
+	log.Info("Finish to submit a backfill compaction task",
+		zap.Int64("triggerID", task.GetTriggerID()),
+		zap.Int64("planID", task.GetPlanID()),
+		zap.String("type", task.GetType().String()),
 	)
 }
 

--- a/internal/datacoord/compaction_trigger_v2_test.go
+++ b/internal/datacoord/compaction_trigger_v2_test.go
@@ -2,6 +2,7 @@ package datacoord
 
 import (
 	"context"
+	"errors"
 	"strconv"
 	"testing"
 
@@ -25,6 +26,20 @@ import (
 func TestCompactionTriggerManagerSuite(t *testing.T) {
 	suite.Run(t, new(CompactionTriggerManagerSuite))
 }
+
+// testCompactionPolicy is a minimal CompactionPolicy stub for handleTicker tests.
+type testCompactionPolicy struct {
+	enabled       bool
+	triggerResult map[CompactionTriggerType][]CompactionView
+	triggerErr    error
+	policyName    string
+}
+
+func (p *testCompactionPolicy) Enable() bool { return p.enabled }
+func (p *testCompactionPolicy) Trigger(_ context.Context) (map[CompactionTriggerType][]CompactionView, error) {
+	return p.triggerResult, p.triggerErr
+}
+func (p *testCompactionPolicy) Name() string { return p.policyName }
 
 type CompactionTriggerManagerSuite struct {
 	suite.Suite
@@ -390,4 +405,216 @@ func (s *CompactionTriggerManagerSuite) TestManualTriggerInvalidParams() {
 	triggerID, err := s.triggerManager.ManualTrigger(context.Background(), s.testLabel.CollectionID, false, false, 0)
 	s.NoError(err)
 	s.Equal(int64(0), triggerID)
+}
+
+func (s *CompactionTriggerManagerSuite) TestSubmitBackfillViewToScheduler() {
+	collectionSchema := &schemapb.CollectionSchema{
+		Name: "test_coll",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 1, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+		},
+		Functions: []*schemapb.FunctionSchema{
+			{Name: "bm25_fn", Type: schemapb.FunctionType_BM25, OutputFieldIds: []int64{100}},
+		},
+	}
+	backfillFunc := collectionSchema.Functions[0]
+
+	makeBackfillView := func(triggerID int64) *BackfillSegmentsView {
+		segView := &SegmentView{
+			ID:        200,
+			label:     s.testLabel,
+			NumOfRows: 1000,
+		}
+		return &BackfillSegmentsView{
+			label:     s.testLabel,
+			segments:  []*SegmentView{segView},
+			triggerID: triggerID,
+			funcDiff:  &FuncDiff{Added: []*schemapb.FunctionSchema{backfillFunc}},
+		}
+	}
+
+	s.Run("AllocN fails", func() {
+		s.SetupTest()
+		s.mockAlloc.EXPECT().AllocN(int64(1)).Return(int64(0), int64(0), errors.New("alloc error")).Once()
+		view := makeBackfillView(111)
+		// Should return early with no panic — no other mock calls expected.
+		s.triggerManager.SubmitBackfillViewToScheduler(context.Background(), view)
+	})
+
+	s.Run("GetCollection fails", func() {
+		s.SetupTest()
+		const planID = int64(500)
+		s.mockAlloc.EXPECT().AllocN(int64(1)).Return(planID, planID, nil).Once()
+		handler := NewNMockHandler(s.T())
+		handler.EXPECT().GetCollection(mock.Anything, s.testLabel.CollectionID).
+			Return(nil, errors.New("get collection error")).Once()
+		s.triggerManager.handler = handler
+
+		view := makeBackfillView(111)
+		s.triggerManager.SubmitBackfillViewToScheduler(context.Background(), view)
+	})
+
+	s.Run("collection is nil", func() {
+		s.SetupTest()
+		const planID = int64(501)
+		s.mockAlloc.EXPECT().AllocN(int64(1)).Return(planID, planID, nil).Once()
+		handler := NewNMockHandler(s.T())
+		handler.EXPECT().GetCollection(mock.Anything, s.testLabel.CollectionID).
+			Return(nil, nil).Once()
+		s.triggerManager.handler = handler
+
+		view := makeBackfillView(111)
+		s.triggerManager.SubmitBackfillViewToScheduler(context.Background(), view)
+	})
+
+	s.Run("collection is external", func() {
+		s.SetupTest()
+		const planID = int64(502)
+		s.mockAlloc.EXPECT().AllocN(int64(1)).Return(planID, planID, nil).Once()
+		handler := NewNMockHandler(s.T())
+		handler.EXPECT().GetCollection(mock.Anything, s.testLabel.CollectionID).
+			Return(&collectionInfo{
+				ID: s.testLabel.CollectionID,
+				// IsExternal() checks for fields with ExternalField set, not Schema.ExternalSource.
+				Schema: &schemapb.CollectionSchema{
+					Fields: []*schemapb.FieldSchema{
+						{FieldID: 1, Name: "ext_field", ExternalField: "s3://bucket/external"},
+					},
+				},
+			}, nil).Once()
+		s.triggerManager.handler = handler
+
+		view := makeBackfillView(111)
+		s.triggerManager.SubmitBackfillViewToScheduler(context.Background(), view)
+	})
+
+	s.Run("view is not BackfillSegmentsView", func() {
+		s.SetupTest()
+		s.meta.indexMeta = &indexMeta{indexes: make(map[UniqueID]map[UniqueID]*model.Index)}
+		const planID = int64(503)
+		s.mockAlloc.EXPECT().AllocN(int64(1)).Return(planID, planID, nil).Once()
+		handler := NewNMockHandler(s.T())
+		handler.EXPECT().GetCollection(mock.Anything, s.testLabel.CollectionID).
+			Return(&collectionInfo{
+				ID:     s.testLabel.CollectionID,
+				Schema: collectionSchema,
+			}, nil).Once()
+		s.triggerManager.handler = handler
+
+		// Use LevelZeroCompactionView which is NOT a *BackfillSegmentsView.
+		nonBackfillView := &LevelZeroCompactionView{
+			label:      s.testLabel,
+			l0Segments: []*SegmentView{},
+		}
+		s.triggerManager.SubmitBackfillViewToScheduler(context.Background(), nonBackfillView)
+	})
+
+	s.Run("enqueueCompaction fails", func() {
+		s.SetupTest()
+		s.meta.indexMeta = &indexMeta{indexes: make(map[UniqueID]map[UniqueID]*model.Index)}
+		const (
+			planID    = int64(504)
+			triggerID = int64(999)
+		)
+		s.mockAlloc.EXPECT().AllocN(int64(1)).Return(planID, planID, nil).Once()
+		handler := NewNMockHandler(s.T())
+		handler.EXPECT().GetCollection(mock.Anything, s.testLabel.CollectionID).
+			Return(&collectionInfo{
+				ID:     s.testLabel.CollectionID,
+				Schema: collectionSchema,
+			}, nil).Once()
+		s.triggerManager.handler = handler
+		s.inspector.EXPECT().enqueueCompaction(mock.Anything).Return(errors.New("enqueue error")).Once()
+
+		view := makeBackfillView(triggerID)
+		s.triggerManager.SubmitBackfillViewToScheduler(context.Background(), view)
+	})
+
+	s.Run("success", func() {
+		s.SetupTest()
+		s.meta.indexMeta = &indexMeta{indexes: make(map[UniqueID]map[UniqueID]*model.Index)}
+		const (
+			planID    = int64(600)
+			triggerID = int64(1001)
+		)
+		s.mockAlloc.EXPECT().AllocN(int64(1)).Return(planID, planID, nil).Once()
+		handler := NewNMockHandler(s.T())
+		handler.EXPECT().GetCollection(mock.Anything, s.testLabel.CollectionID).
+			Return(&collectionInfo{
+				ID:     s.testLabel.CollectionID,
+				Schema: collectionSchema,
+			}, nil).Once()
+		s.triggerManager.handler = handler
+		s.inspector.EXPECT().enqueueCompaction(mock.Anything).
+			RunAndReturn(func(task *datapb.CompactionTask) error {
+				s.EqualValues(planID, task.GetPlanID())
+				s.EqualValues(triggerID, task.GetTriggerID())
+				s.Equal(datapb.CompactionType_BackfillCompaction, task.GetType())
+				s.Equal(s.testLabel.CollectionID, task.GetCollectionID())
+				s.Equal(s.testLabel.PartitionID, task.GetPartitionID())
+				s.Equal(s.testLabel.Channel, task.GetChannel())
+				s.Equal(collectionSchema, task.GetSchema())
+				s.Require().Len(task.GetDiffFunctions(), 1)
+				s.Equal(backfillFunc.GetName(), task.GetDiffFunctions()[0].GetName())
+				s.ElementsMatch([]int64{200}, task.GetInputSegments())
+				return nil
+			}).Once()
+
+		view := makeBackfillView(triggerID)
+		s.triggerManager.SubmitBackfillViewToScheduler(context.Background(), view)
+	})
+}
+
+func (s *CompactionTriggerManagerSuite) TestHandleTicker() {
+	s.Run("policy not found for ticker type", func() {
+		s.SetupTest()
+		// TickerType 99 is not registered in policies map
+		s.triggerManager.handleTicker(context.Background(), TickerType(99))
+		// Should return without panic
+	})
+
+	s.Run("policy disabled", func() {
+		s.SetupTest()
+		mockPolicy := &testCompactionPolicy{enabled: false, policyName: "test-disabled"}
+		s.triggerManager.policies[BackfillTicker] = mockPolicy
+		s.triggerManager.handleTicker(context.Background(), BackfillTicker)
+		// Returns early — no inspector or trigger calls
+	})
+
+	s.Run("inspector full", func() {
+		s.SetupTest()
+		mockPolicy := &testCompactionPolicy{enabled: true, policyName: "test-full"}
+		s.triggerManager.policies[BackfillTicker] = mockPolicy
+		s.inspector.EXPECT().isFull().Return(true).Once()
+		s.triggerManager.handleTicker(context.Background(), BackfillTicker)
+		// Returns early — no trigger call
+	})
+
+	s.Run("policy trigger error", func() {
+		s.SetupTest()
+		mockPolicy := &testCompactionPolicy{
+			enabled:    true,
+			policyName: "test-err",
+			triggerErr: errors.New("trigger error"),
+		}
+		s.triggerManager.policies[BackfillTicker] = mockPolicy
+		s.inspector.EXPECT().isFull().Return(false).Once()
+		s.triggerManager.handleTicker(context.Background(), BackfillTicker)
+		// Returns early after logging error
+	})
+
+	s.Run("policy trigger returns events", func() {
+		s.SetupTest()
+		mockPolicy := &testCompactionPolicy{
+			enabled:    true,
+			policyName: "test-events",
+			// One trigger type with empty views — notify is called but inner loop is empty.
+			triggerResult: map[CompactionTriggerType][]CompactionView{
+				TriggerTypeBackfill: {},
+			},
+		}
+		s.triggerManager.policies[BackfillTicker] = mockPolicy
+		s.inspector.EXPECT().isFull().Return(false).Once()
+		s.triggerManager.handleTicker(context.Background(), BackfillTicker)
+	})
 }

--- a/internal/datacoord/index_inspector.go
+++ b/internal/datacoord/index_inspector.go
@@ -160,6 +160,13 @@ func (i *indexInspector) createIndexesForSegment(ctx context.Context, segment *S
 	indexIDToSegIndexes := i.meta.indexMeta.GetSegmentIndexes(segment.CollectionID, segment.ID)
 	for _, index := range indexes {
 		if _, ok := indexIDToSegIndexes[index.IndexID]; !ok {
+			// TODO: check index.MinSchemaVersion > segment.GetSchemaVersion() to skip indexing
+			// for function-output columns (e.g. BM25 sparse vector) before backfill writes the data.
+			// The condition must also verify that the schema change requires physical backfill
+			// (doPhysicalBackfill=true); for non-physical changes (e.g. add field with default_value),
+			// index creation should proceed immediately since data is filled at query time.
+			// This requires either a per-index NeedPhysicalBackfill flag or a schema-version-to-backfill
+			// mapping. Tracked as a follow-up.
 			if err := i.createIndexForSegment(ctx, segment, index.IndexID); err != nil {
 				log.Ctx(ctx).Warn("create index for segment fail", zap.Int64("segmentID", segment.ID),
 					zap.Int64("indexID", index.IndexID))

--- a/internal/datacoord/index_service.go
+++ b/internal/datacoord/index_service.go
@@ -270,12 +270,19 @@ func (s *Server) CreateIndex(ctx context.Context, req *indexpb.CreateIndexReques
 		CreateTime:      req.GetTimestamp(),
 		IsAutoIndex:     req.GetIsAutoIndex(),
 		UserIndexParams: req.GetUserIndexParams(),
+		// MinSchemaVersion prevents building an index on a function-output column (e.g. BM25 sparse
+		// vector) before backfill has written that column into old segments.  The inspector skips any
+		// segment whose SchemaVersion is still below this value.
+		MinSchemaVersion: schema.GetVersion(),
 	}
 	// Validate the index params.
 	if err := ValidateIndexParams(index); err != nil {
 		return nil, err
 	}
 
+	channels := make([]string, 0, len(coll.GetVirtualChannelNames())+1)
+	channels = append(channels, streaming.WAL().ControlChannel())
+	channels = append(channels, coll.GetVirtualChannelNames()...)
 	if _, err = broadcaster.Broadcast(ctx, message.NewCreateIndexMessageBuilderV2().
 		WithHeader(&message.CreateIndexMessageHeader{
 			DbId:         coll.GetDbId(),
@@ -287,7 +294,7 @@ func (s *Server) CreateIndex(ctx context.Context, req *indexpb.CreateIndexReques
 		WithBody(&message.CreateIndexMessageBody{
 			FieldIndex: model.MarshalIndexModel(index),
 		}).
-		WithBroadcast([]string{streaming.WAL().ControlChannel()}).
+		WithBroadcast(channels).
 		MustBuildBroadcast(),
 	); err != nil {
 		log.Error("CreateIndex fail", zap.Error(err))
@@ -296,7 +303,8 @@ func (s *Server) CreateIndex(ctx context.Context, req *indexpb.CreateIndexReques
 	}
 	log.Info("CreateIndex successfully",
 		zap.String("IndexName", index.IndexName), zap.Int64("fieldID", index.FieldID),
-		zap.Int64("IndexID", index.IndexID))
+		zap.Int64("IndexID", index.IndexID), zap.Int32("MinSchemaVersion", index.MinSchemaVersion),
+		zap.Strings("channels", channels))
 	metrics.IndexRequestCounter.WithLabelValues(metrics.SuccessLabel).Inc()
 	return merr.Success(), nil
 }

--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -1859,6 +1859,7 @@ func (m *meta) completeClusterCompactionMutation(t *datapb.CompactionTask, resul
 			StorageVersion: seg.GetStorageVersion(),
 			ManifestPath:   seg.GetManifest(),
 			ExpirQuantiles: seg.GetExpirQuantiles(),
+			SchemaVersion:  compactFromSegInfos[0].GetSchemaVersion(),
 		}
 		segment := NewSegmentInfo(segmentInfo)
 		compactToSegInfos = append(compactToSegInfos, segment)
@@ -1971,6 +1972,7 @@ func (m *meta) completeMixCompactionMutation(
 				ManifestPath:        compactToSegment.GetManifest(),
 				IsSortedByNamespace: compactToSegment.GetIsSortedByNamespace(),
 				ExpirQuantiles:      compactToSegment.GetExpirQuantiles(),
+				SchemaVersion:       compactFromSegInfos[0].GetSchemaVersion(),
 			})
 
 		if compactToSegmentInfo.GetNumOfRows() == 0 {
@@ -2059,6 +2061,8 @@ func (m *meta) CompleteCompactionMutation(ctx context.Context, t *datapb.Compact
 		return m.completeClusterCompactionMutation(t, result)
 	case datapb.CompactionType_SortCompaction:
 		return m.completeSortCompactionMutation(t, result)
+	case datapb.CompactionType_BackfillCompaction:
+		return m.completeBackfillCompactionMutation(t, result)
 	}
 	return nil, nil, merr.WrapErrIllegalCompactionPlan("illegal compaction type")
 }
@@ -2478,6 +2482,7 @@ func (m *meta) completeSortCompactionMutation(
 		ManifestPath:              resultSegment.GetManifest(),
 		ExpirQuantiles:            resultSegment.GetExpirQuantiles(),
 		IsSortedByNamespace:       resultSegment.GetIsSortedByNamespace(),
+		SchemaVersion:             oldSegment.GetSchemaVersion(),
 	}
 
 	segment := NewSegmentInfo(segmentInfo)
@@ -2510,6 +2515,119 @@ func (m *meta) completeSortCompactionMutation(
 	m.segments.SetSegment(segment.GetID(), segment)
 	log.Info("meta update: alter in memory meta after compaction - complete")
 	return []*SegmentInfo{segment}, metricMutation, nil
+}
+
+func (m *meta) completeBackfillCompactionMutation(
+	t *datapb.CompactionTask,
+	result *datapb.CompactionPlanResult,
+) ([]*SegmentInfo, *segMetricMutation, error) {
+	log := log.Ctx(context.TODO()).With(zap.Int64("planID", t.GetPlanID()),
+		zap.String("type", t.GetType().String()),
+		zap.Int64("collectionID", t.CollectionID),
+		zap.Int64("partitionID", t.PartitionID),
+		zap.String("channel", t.GetChannel()))
+
+	metricMutation := &segMetricMutation{stateChange: make(map[string]map[string]map[string]map[string]int)}
+
+	// Backfill compaction updates the existing segment, not creating a new one
+	if len(t.GetInputSegments()) != 1 {
+		return nil, nil, merr.WrapErrIllegalCompactionPlan("backfill compaction should have exactly one input segment")
+	}
+	if len(result.GetSegments()) != 1 {
+		return nil, nil, merr.WrapErrIllegalCompactionPlan("backfill compaction result should have exactly one segment")
+	}
+
+	segmentID := t.GetInputSegments()[0]
+	oldSegment := m.segments.GetSegment(segmentID)
+	if oldSegment == nil {
+		return nil, nil, merr.WrapErrSegmentNotFound(segmentID)
+	}
+
+	// Re-validate segment health to prevent race condition with drop collection
+	// between ValidateSegmentStateBeforeCompleteCompactionMutation and here
+	if !isSegmentHealthy(oldSegment) {
+		log.Warn("input segment was dropped during compaction mutation",
+			zap.Int64("planID", t.GetPlanID()),
+			zap.Int64("segmentID", segmentID),
+			zap.String("state", oldSegment.GetState().String()))
+		return nil, nil, merr.WrapErrSegmentNotFound(segmentID, "input segment was dropped")
+	}
+
+	resultSegment := result.GetSegments()[0]
+	if resultSegment.GetSegmentID() != segmentID {
+		return nil, nil, merr.WrapErrIllegalCompactionPlan(fmt.Sprintf("backfill compaction result segment ID %d does not match input segment ID %d", resultSegment.GetSegmentID(), segmentID))
+	}
+
+	// Clone the segment for update
+	cloned := oldSegment.Clone()
+
+	// Replace binlogs with result (result already contains original + new function output field binlogs)
+	cloned.Binlogs = resultSegment.GetInsertLogs()
+
+	// Update BM25 stats logs: for V2 segments, stats are separate files tracked in Bm25Statslogs.
+	// Use mergeFieldBinlogs so that stats for previously backfilled BM25 fields are preserved
+	// when a second AlterCollectionSchema adds another BM25 function.
+	// For V3 segments (manifest-based), BM25 stats are embedded in the manifest and
+	// Bm25Logs in the result is nil — skip updating Bm25Statslogs to avoid clearing existing stats.
+	if resultSegment.GetManifest() == "" {
+		cloned.Bm25Statslogs = mergeFieldBinlogs(cloned.GetBm25Statslogs(), resultSegment.GetBm25Logs())
+	}
+
+	// Update SchemaVersion from task schema.
+	// t.Schema is set from collection.Schema at task creation time and should never be nil.
+	// A nil schema here indicates data corruption (e.g. etcd serialization loss); we warn
+	// and skip the update so the segment's schemaVersion remains stale, causing the next
+	// backfill trigger to re-evaluate and re-submit the task.
+	if t.GetSchema() == nil {
+		log.Warn("backfill compaction task has nil schema, skipping schemaVersion update — segment will be re-evaluated on next trigger",
+			zap.Int64("segmentID", segmentID),
+			zap.Int64("planID", t.GetPlanID()))
+	} else {
+		newSchemaVersion := t.GetSchema().GetVersion()
+		if newSchemaVersion > cloned.GetSchemaVersion() {
+			cloned.SchemaVersion = newSchemaVersion
+			log.Info("meta update: update schema version for backfill compaction",
+				zap.Int64("segmentID", segmentID),
+				zap.Int32("oldSchemaVersion", oldSegment.GetSchemaVersion()),
+				zap.Int32("newSchemaVersion", newSchemaVersion))
+		}
+	}
+
+	// Update StorageVersion only when result has manifest (true V3 segment).
+	// V2 segments on V3 clusters stay V2 — backfill forces V2 path to avoid
+	// creating partial manifests that would corrupt segment loading.
+	// Update ManifestPath for V3 segments — the merged manifest contains both
+	// original columns and new function output columns + BM25 stats.
+	if resultSegment.GetManifest() != "" {
+		cloned.StorageVersion = resultSegment.GetStorageVersion()
+		cloned.ManifestPath = resultSegment.GetManifest()
+	}
+
+	// Prepare binlogs increment for catalog update
+	binlogsIncrement := metastore.BinlogsIncrement{
+		Segment: cloned.SegmentInfo,
+	}
+
+	log = log.With(zap.Int64("segmentID", segmentID),
+		zap.Int32("oldSchemaVersion", oldSegment.GetSchemaVersion()),
+		zap.Int32("newSchemaVersion", cloned.GetSchemaVersion()),
+		zap.Int("newInsertLogsCount", len(resultSegment.GetInsertLogs())),
+		zap.Int("newBm25LogsCount", len(resultSegment.GetBm25Logs())))
+
+	log.Info("meta update: prepare for complete backfill compaction mutation - complete",
+		zap.Int64("num rows", cloned.GetNumOfRows()))
+
+	// Save to catalog
+	if err := m.catalog.AlterSegments(m.ctx, []*datapb.SegmentInfo{cloned.SegmentInfo}, binlogsIncrement); err != nil {
+		log.Warn("fail to alter segment for backfill compaction", zap.Error(err))
+		return nil, nil, err
+	}
+
+	// Update in-memory meta
+	m.segments.SetSegment(segmentID, cloned)
+	log.Info("meta update: alter in memory meta after backfill compaction - complete")
+
+	return []*SegmentInfo{cloned}, metricMutation, nil
 }
 
 func (m *meta) getSegmentsMetrics(collectionID int64) []*metricsinfo.Segment {

--- a/internal/datacoord/meta_test.go
+++ b/internal/datacoord/meta_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/datacoord/broker"
 	mockkv "github.com/milvus-io/milvus/internal/kv/mocks"
 	"github.com/milvus-io/milvus/internal/metastore/kv/datacoord"
@@ -767,6 +768,273 @@ func (suite *MetaBasicSuite) TestSetSegment() {
 		err := meta.UpdateSegment(segmentID, noOp)
 		suite.Error(err)
 		suite.ErrorIs(err, merr.ErrSegmentNotFound)
+	})
+}
+
+func (suite *MetaBasicSuite) TestCompleteBackfillCompactionMutation() {
+	// Helper to build a SegmentsInfo containing a single healthy Flushed segment with the given ID.
+	makeSegments := func(segID int64, state commonpb.SegmentState) *SegmentsInfo {
+		segs := NewSegmentsInfo()
+		segs.SetSegment(segID, &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{
+			ID:            segID,
+			CollectionID:  100,
+			PartitionID:   10,
+			State:         state,
+			Level:         datapb.SegmentLevel_L1,
+			Binlogs:       []*datapb.FieldBinlog{getFieldBinlogIDs(0, 10000)},
+			Statslogs:     []*datapb.FieldBinlog{getFieldBinlogIDs(0, 20000)},
+			NumOfRows:     5,
+			SchemaVersion: 1,
+		}})
+		return segs
+	}
+
+	suite.Run("too many input segments", func() {
+		m := &meta{
+			catalog:  &datacoord.Catalog{MetaKv: NewMetaMemoryKV()},
+			segments: makeSegments(1, commonpb.SegmentState_Flushed),
+		}
+		task := &datapb.CompactionTask{
+			InputSegments: []int64{1, 2}, // two inputs — should error
+			Type:          datapb.CompactionType_BackfillCompaction,
+		}
+		result := &datapb.CompactionPlanResult{
+			Segments: []*datapb.CompactionSegment{
+				{SegmentID: 1},
+			},
+		}
+		infos, mutation, err := m.completeBackfillCompactionMutation(task, result)
+		suite.Error(err)
+		suite.Nil(infos)
+		suite.Nil(mutation)
+	})
+
+	suite.Run("too many result segments", func() {
+		m := &meta{
+			catalog:  &datacoord.Catalog{MetaKv: NewMetaMemoryKV()},
+			segments: makeSegments(1, commonpb.SegmentState_Flushed),
+		}
+		task := &datapb.CompactionTask{
+			InputSegments: []int64{1},
+			Type:          datapb.CompactionType_BackfillCompaction,
+		}
+		result := &datapb.CompactionPlanResult{
+			Segments: []*datapb.CompactionSegment{
+				{SegmentID: 1},
+				{SegmentID: 2}, // two results — should error
+			},
+		}
+		infos, mutation, err := m.completeBackfillCompactionMutation(task, result)
+		suite.Error(err)
+		suite.Nil(infos)
+		suite.Nil(mutation)
+	})
+
+	suite.Run("segment not found", func() {
+		// Segment 99 is not in meta.
+		m := &meta{
+			catalog:  &datacoord.Catalog{MetaKv: NewMetaMemoryKV()},
+			segments: NewSegmentsInfo(),
+		}
+		task := &datapb.CompactionTask{
+			InputSegments: []int64{99},
+			Type:          datapb.CompactionType_BackfillCompaction,
+		}
+		result := &datapb.CompactionPlanResult{
+			Segments: []*datapb.CompactionSegment{
+				{SegmentID: 99},
+			},
+		}
+		infos, mutation, err := m.completeBackfillCompactionMutation(task, result)
+		suite.Error(err)
+		suite.ErrorIs(err, merr.ErrSegmentNotFound)
+		suite.Nil(infos)
+		suite.Nil(mutation)
+	})
+
+	suite.Run("segment dropped", func() {
+		m := &meta{
+			catalog:  &datacoord.Catalog{MetaKv: NewMetaMemoryKV()},
+			segments: makeSegments(1, commonpb.SegmentState_Dropped),
+		}
+		task := &datapb.CompactionTask{
+			InputSegments: []int64{1},
+			Type:          datapb.CompactionType_BackfillCompaction,
+		}
+		result := &datapb.CompactionPlanResult{
+			Segments: []*datapb.CompactionSegment{
+				{SegmentID: 1},
+			},
+		}
+		infos, mutation, err := m.completeBackfillCompactionMutation(task, result)
+		suite.Error(err)
+		suite.ErrorIs(err, merr.ErrSegmentNotFound)
+		suite.Nil(infos)
+		suite.Nil(mutation)
+	})
+
+	suite.Run("segment ID mismatch", func() {
+		m := &meta{
+			catalog:  &datacoord.Catalog{MetaKv: NewMetaMemoryKV()},
+			segments: makeSegments(1, commonpb.SegmentState_Flushed),
+		}
+		task := &datapb.CompactionTask{
+			InputSegments: []int64{1},
+			Type:          datapb.CompactionType_BackfillCompaction,
+		}
+		result := &datapb.CompactionPlanResult{
+			Segments: []*datapb.CompactionSegment{
+				{SegmentID: 999}, // ID mismatch
+			},
+		}
+		infos, mutation, err := m.completeBackfillCompactionMutation(task, result)
+		suite.Error(err)
+		suite.Nil(infos)
+		suite.Nil(mutation)
+	})
+
+	suite.Run("v2 success - schema version updated", func() {
+		// Task schema version (3) > old segment schema version (1) → cloned.SchemaVersion should become 3.
+		segs := NewSegmentsInfo()
+		segs.SetSegment(1, &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{
+			ID:            1,
+			CollectionID:  100,
+			PartitionID:   10,
+			State:         commonpb.SegmentState_Flushed,
+			Level:         datapb.SegmentLevel_L1,
+			Binlogs:       []*datapb.FieldBinlog{getFieldBinlogIDs(0, 10000)},
+			NumOfRows:     5,
+			SchemaVersion: 1,
+		}})
+		m := &meta{
+			catalog:  &datacoord.Catalog{MetaKv: NewMetaMemoryKV()},
+			segments: segs,
+		}
+		task := &datapb.CompactionTask{
+			InputSegments: []int64{1},
+			Type:          datapb.CompactionType_BackfillCompaction,
+			Schema: &schemapb.CollectionSchema{
+				Version: 3,
+			},
+		}
+		result := &datapb.CompactionPlanResult{
+			Segments: []*datapb.CompactionSegment{
+				{
+					SegmentID:  1,
+					InsertLogs: []*datapb.FieldBinlog{getFieldBinlogIDs(0, 10001)},
+					// No manifest → V2 path
+				},
+			},
+		}
+		infos, mutation, err := m.completeBackfillCompactionMutation(task, result)
+		suite.NoError(err)
+		suite.NotNil(mutation)
+		suite.Require().Len(infos, 1)
+		suite.EqualValues(3, infos[0].GetSchemaVersion())
+		// In-memory segment should also be updated.
+		updated := m.segments.GetSegment(1)
+		suite.EqualValues(3, updated.GetSchemaVersion())
+	})
+
+	suite.Run("v2 success - bm25 stats merged", func() {
+		// Old segment already has BM25 stats for field 101.
+		// Result adds BM25 stats for field 102.
+		// Both should be present after mutation.
+		segs := NewSegmentsInfo()
+		segs.SetSegment(1, &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{
+			ID:            1,
+			CollectionID:  100,
+			PartitionID:   10,
+			State:         commonpb.SegmentState_Flushed,
+			Level:         datapb.SegmentLevel_L1,
+			Binlogs:       []*datapb.FieldBinlog{getFieldBinlogIDs(0, 10000)},
+			Bm25Statslogs: []*datapb.FieldBinlog{getFieldBinlogIDs(101, 50001)},
+			NumOfRows:     5,
+			SchemaVersion: 1,
+		}})
+		m := &meta{
+			catalog:  &datacoord.Catalog{MetaKv: NewMetaMemoryKV()},
+			segments: segs,
+		}
+		task := &datapb.CompactionTask{
+			InputSegments: []int64{1},
+			Type:          datapb.CompactionType_BackfillCompaction,
+		}
+		result := &datapb.CompactionPlanResult{
+			Segments: []*datapb.CompactionSegment{
+				{
+					SegmentID:  1,
+					InsertLogs: []*datapb.FieldBinlog{getFieldBinlogIDs(0, 10001)},
+					Bm25Logs:   []*datapb.FieldBinlog{getFieldBinlogIDs(102, 50002)},
+					// No manifest → V2 path, BM25 stats should be merged
+				},
+			},
+		}
+		infos, mutation, err := m.completeBackfillCompactionMutation(task, result)
+		suite.NoError(err)
+		suite.NotNil(mutation)
+		suite.Require().Len(infos, 1)
+
+		// Collect all field IDs present in Bm25Statslogs of the result.
+		fieldIDs := make(map[int64]bool)
+		for _, fl := range infos[0].GetBm25Statslogs() {
+			fieldIDs[fl.GetFieldID()] = true
+		}
+		suite.True(fieldIDs[101], "field 101 bm25 stats should be preserved")
+		suite.True(fieldIDs[102], "field 102 bm25 stats should be added from result")
+	})
+
+	suite.Run("v3 success - manifest and storage version updated", func() {
+		// Result segment has a non-empty manifest → V3 path.
+		// ManifestPath and StorageVersion should be set; Bm25Statslogs should NOT change.
+		segs := NewSegmentsInfo()
+		segs.SetSegment(1, &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{
+			ID:            1,
+			CollectionID:  100,
+			PartitionID:   10,
+			State:         commonpb.SegmentState_Flushed,
+			Level:         datapb.SegmentLevel_L1,
+			Binlogs:       []*datapb.FieldBinlog{getFieldBinlogIDs(0, 10000)},
+			Bm25Statslogs: []*datapb.FieldBinlog{getFieldBinlogIDs(101, 50001)},
+			NumOfRows:     5,
+			SchemaVersion: 1,
+		}})
+		m := &meta{
+			catalog:  &datacoord.Catalog{MetaKv: NewMetaMemoryKV()},
+			segments: segs,
+		}
+		task := &datapb.CompactionTask{
+			InputSegments: []int64{1},
+			Type:          datapb.CompactionType_BackfillCompaction,
+		}
+		const manifestPath = "collection/100/partition/10/segment/1/v3_manifest.json"
+		result := &datapb.CompactionPlanResult{
+			Segments: []*datapb.CompactionSegment{
+				{
+					SegmentID:      1,
+					InsertLogs:     []*datapb.FieldBinlog{getFieldBinlogIDs(0, 10001)},
+					Bm25Logs:       []*datapb.FieldBinlog{getFieldBinlogIDs(102, 50002)},
+					Manifest:       manifestPath,
+					StorageVersion: 3,
+				},
+			},
+		}
+		infos, mutation, err := m.completeBackfillCompactionMutation(task, result)
+		suite.NoError(err)
+		suite.NotNil(mutation)
+		suite.Require().Len(infos, 1)
+
+		// ManifestPath and StorageVersion should reflect the V3 result.
+		suite.Equal(manifestPath, infos[0].GetManifestPath())
+		suite.EqualValues(3, infos[0].GetStorageVersion())
+
+		// BM25 stats should NOT be updated for V3 path — still only field 101.
+		fieldIDs := make(map[int64]bool)
+		for _, fl := range infos[0].GetBm25Statslogs() {
+			fieldIDs[fl.GetFieldID()] = true
+		}
+		suite.True(fieldIDs[101], "field 101 bm25 stats should be preserved")
+		suite.False(fieldIDs[102], "field 102 bm25 stats should NOT be added for V3 path")
 	})
 }
 
@@ -1624,18 +1892,17 @@ func Test_meta_SetSegmentsCompacting(t *testing.T) {
 			"test set segment compacting",
 			fields{
 				NewMetaMemoryKV(),
-				&SegmentsInfo{
-					segments: map[int64]*SegmentInfo{
-						1: {
-							SegmentInfo: &datapb.SegmentInfo{
-								ID:    1,
-								State: commonpb.SegmentState_Flushed,
-							},
-							isCompacting: false,
+				func() *SegmentsInfo {
+					s := NewSegmentsInfo()
+					s.SetSegment(1, &SegmentInfo{
+						SegmentInfo: &datapb.SegmentInfo{
+							ID:    1,
+							State: commonpb.SegmentState_Flushed,
 						},
-					},
-					compactionTo: make(map[int64][]UniqueID),
-				},
+						isCompacting: false,
+					})
+					return s
+				}(),
 			},
 			args{
 				segmentID:  1,

--- a/internal/datacoord/segment_info.go
+++ b/internal/datacoord/segment_info.go
@@ -19,7 +19,6 @@ package datacoord
 import (
 	"fmt"
 	"math"
-	"runtime/debug"
 	"time"
 
 	"github.com/samber/lo"
@@ -304,12 +303,21 @@ func (s *SegmentsInfo) SetFlushTime(segmentID UniqueID, t time.Time) {
 	}
 }
 
-// SetIsCompacting sets compaction status for segment
+// SetIsCompacting sets compaction status for segment.
+// NOTE: This method manually updates secondary indexes after ShadowClone.
+// Other Set methods (SetRowCount, SetLevel, SetFlushTime, etc.) have the same
+// stale-index problem but are not yet fixed. See #48593 for the tracking issue
+// to extract a common updateSegment helper for all Set methods.
 func (s *SegmentsInfo) SetIsCompacting(segmentID UniqueID, isCompacting bool) {
-	st := fmt.Sprintf("%s", debug.Stack())
-	log.Info("set compacting", zap.Int64("segmentID", segmentID), zap.Bool("isCompacting", isCompacting), zap.Any("stacktrace", st))
 	if segment, ok := s.segments[segmentID]; ok {
-		s.segments[segmentID] = segment.ShadowClone(SetIsCompacting(isCompacting))
+		newSegment := segment.ShadowClone(SetIsCompacting(isCompacting))
+		s.segments[segmentID] = newSegment
+		if collSegs, ok := s.secondaryIndexes.coll2Segments[segment.GetCollectionID()]; ok {
+			collSegs[segmentID] = newSegment
+		}
+		if chSegs, ok := s.secondaryIndexes.channel2Segments[segment.GetInsertChannel()]; ok {
+			chSegs[segmentID] = newSegment
+		}
 	}
 }
 

--- a/internal/datacoord/segment_manager.go
+++ b/internal/datacoord/segment_manager.go
@@ -80,6 +80,7 @@ type AllocNewGrowingSegmentRequest struct {
 	ChannelName          string
 	StorageVersion       int64
 	IsCreatedByStreaming bool
+	SchemaVersion        int32
 }
 
 // Manager manages segment related operations.
@@ -441,6 +442,7 @@ func (s *SegmentManager) openNewSegmentWithGivenSegmentID(ctx context.Context, r
 		StorageVersion:       req.StorageVersion,
 		IsCreatedByStreaming: req.IsCreatedByStreaming,
 		ManifestPath:         manifestPath,
+		SchemaVersion:        req.SchemaVersion,
 	}
 	segment := NewSegmentInfo(segmentInfo)
 	if err := s.meta.AddSegment(ctx, segment); err != nil {
@@ -454,6 +456,7 @@ func (s *SegmentManager) openNewSegmentWithGivenSegmentID(ctx context.Context, r
 		zap.Int64("SegmentID", segmentInfo.ID),
 		zap.String("Channel", segmentInfo.InsertChannel),
 		zap.Bool("IsCreatedByStreaming", segmentInfo.IsCreatedByStreaming),
+		zap.Int32("SchemaVersion", segmentInfo.SchemaVersion),
 	)
 
 	return segment, s.helper.afterCreateSegment(segmentInfo)

--- a/internal/datacoord/segment_operator.go
+++ b/internal/datacoord/segment_operator.go
@@ -69,6 +69,16 @@ func SetJsonKeyIndexLogs(jsonKeyIndexLogs map[int64]*datapb.JsonKeyStats) Segmen
 	}
 }
 
+func SetSchemaVersion(schemaVersion int32) SegmentOperator {
+	return func(segment *SegmentInfo) bool {
+		if segment.GetSchemaVersion() == schemaVersion {
+			return false
+		}
+		segment.SchemaVersion = schemaVersion
+		return true
+	}
+}
+
 type segmentCriterion struct {
 	collectionID int64
 	channel      string

--- a/internal/datacoord/server_test.go
+++ b/internal/datacoord/server_test.go
@@ -256,6 +256,150 @@ func TestGetCollectionStatistics(t *testing.T) {
 	})
 }
 
+func TestGetCollectionStatisticsSchemaVersionConsistency(t *testing.T) {
+	// All subtests share one server to avoid spawning 6 etcd connections.
+	// Each subtest uses a unique collectionID and segmentID range to stay isolated.
+	svr := newTestServer(t)
+	defer closeTestServer(t, svr)
+
+	statsMap := func(resp *datapb.GetCollectionStatisticsResponse) map[string]string {
+		m := map[string]string{}
+		for _, kv := range resp.GetStats() {
+			m[kv.Key] = kv.Value
+		}
+		return m
+	}
+
+	// schema version == 0: no consistency stats emitted
+	t.Run("schema version 0 emits no consistency stats", func(t *testing.T) {
+		collectionID := int64(9001)
+		svr.meta.AddCollection(&collectionInfo{
+			ID:     collectionID,
+			Schema: &schemapb.CollectionSchema{Version: 0},
+		})
+		assert.NoError(t, svr.meta.AddSegment(context.TODO(), NewSegmentInfo(&datapb.SegmentInfo{
+			ID: 9100, CollectionID: collectionID, State: commonpb.SegmentState_Flushed,
+		})))
+
+		resp, err := svr.GetCollectionStatistics(svr.ctx, &datapb.GetCollectionStatisticsRequest{CollectionID: collectionID})
+		assert.NoError(t, err)
+		m := statsMap(resp)
+		assert.NotContains(t, m, common.SchemaVersionConsistentSegmentsKey)
+		assert.NotContains(t, m, common.SchemaVersionTotalSegmentsKey)
+	})
+
+	// schema version > 0 but no healthy segments: no consistency stats emitted
+	t.Run("no healthy segments emits no consistency stats", func(t *testing.T) {
+		collectionID := int64(9002)
+		svr.meta.AddCollection(&collectionInfo{
+			ID:     collectionID,
+			Schema: &schemapb.CollectionSchema{Version: 1},
+		})
+		// Dropped segment is not healthy — should be excluded
+		assert.NoError(t, svr.meta.AddSegment(context.TODO(), NewSegmentInfo(&datapb.SegmentInfo{
+			ID: 9101, CollectionID: collectionID, State: commonpb.SegmentState_Dropped,
+		})))
+
+		resp, err := svr.GetCollectionStatistics(svr.ctx, &datapb.GetCollectionStatisticsRequest{CollectionID: collectionID})
+		assert.NoError(t, err)
+		m := statsMap(resp)
+		assert.NotContains(t, m, common.SchemaVersionConsistentSegmentsKey)
+		assert.NotContains(t, m, common.SchemaVersionTotalSegmentsKey)
+	})
+
+	// L0 segment must not be counted in the consistency gate
+	t.Run("L0 segment excluded from consistency gate", func(t *testing.T) {
+		collectionID := int64(9003)
+		svr.meta.AddCollection(&collectionInfo{
+			ID:     collectionID,
+			Schema: &schemapb.CollectionSchema{Version: 2},
+		})
+		// L0 segment with outdated schema version — must not contribute to total
+		assert.NoError(t, svr.meta.AddSegment(context.TODO(), NewSegmentInfo(&datapb.SegmentInfo{
+			ID: 9102, CollectionID: collectionID, State: commonpb.SegmentState_Flushed,
+			Level: datapb.SegmentLevel_L0, SchemaVersion: 1,
+		})))
+		// Normal L1 flushed segment that IS consistent
+		assert.NoError(t, svr.meta.AddSegment(context.TODO(), NewSegmentInfo(&datapb.SegmentInfo{
+			ID: 9103, CollectionID: collectionID, State: commonpb.SegmentState_Flushed,
+			Level: datapb.SegmentLevel_L1, SchemaVersion: 2,
+		})))
+
+		resp, err := svr.GetCollectionStatistics(svr.ctx, &datapb.GetCollectionStatisticsRequest{CollectionID: collectionID})
+		assert.NoError(t, err)
+		m := statsMap(resp)
+		assert.Equal(t, "1", m[common.SchemaVersionConsistentSegmentsKey])
+		assert.Equal(t, "1", m[common.SchemaVersionTotalSegmentsKey])
+	})
+
+	// importing segment must not affect the consistency gate
+	t.Run("importing segment excluded from consistency gate", func(t *testing.T) {
+		collectionID := int64(9004)
+		svr.meta.AddCollection(&collectionInfo{
+			ID:     collectionID,
+			Schema: &schemapb.CollectionSchema{Version: 3},
+		})
+		assert.NoError(t, svr.meta.AddSegment(context.TODO(), NewSegmentInfo(&datapb.SegmentInfo{
+			ID: 9104, CollectionID: collectionID, State: commonpb.SegmentState_Flushed,
+			IsImporting: true, SchemaVersion: 1,
+		})))
+		assert.NoError(t, svr.meta.AddSegment(context.TODO(), NewSegmentInfo(&datapb.SegmentInfo{
+			ID: 9105, CollectionID: collectionID, State: commonpb.SegmentState_Flushed,
+			SchemaVersion: 3,
+		})))
+
+		resp, err := svr.GetCollectionStatistics(svr.ctx, &datapb.GetCollectionStatisticsRequest{CollectionID: collectionID})
+		assert.NoError(t, err)
+		m := statsMap(resp)
+		assert.Equal(t, "1", m[common.SchemaVersionConsistentSegmentsKey])
+		assert.Equal(t, "1", m[common.SchemaVersionTotalSegmentsKey])
+	})
+
+	// all segments consistent: consistent == total
+	t.Run("all segments consistent", func(t *testing.T) {
+		collectionID := int64(9005)
+		svr.meta.AddCollection(&collectionInfo{
+			ID:     collectionID,
+			Schema: &schemapb.CollectionSchema{Version: 5},
+		})
+		for _, id := range []int64{9200, 9201, 9202} {
+			assert.NoError(t, svr.meta.AddSegment(context.TODO(), NewSegmentInfo(&datapb.SegmentInfo{
+				ID: id, CollectionID: collectionID, State: commonpb.SegmentState_Flushed, SchemaVersion: 5,
+			})))
+		}
+
+		resp, err := svr.GetCollectionStatistics(svr.ctx, &datapb.GetCollectionStatisticsRequest{CollectionID: collectionID})
+		assert.NoError(t, err)
+		m := statsMap(resp)
+		assert.Equal(t, "3", m[common.SchemaVersionConsistentSegmentsKey])
+		assert.Equal(t, "3", m[common.SchemaVersionTotalSegmentsKey])
+	})
+
+	// partial segments consistent: consistent < total
+	t.Run("partial segments consistent", func(t *testing.T) {
+		collectionID := int64(9006)
+		svr.meta.AddCollection(&collectionInfo{
+			ID:     collectionID,
+			Schema: &schemapb.CollectionSchema{Version: 7},
+		})
+		for _, id := range []int64{9300, 9301} {
+			assert.NoError(t, svr.meta.AddSegment(context.TODO(), NewSegmentInfo(&datapb.SegmentInfo{
+				ID: id, CollectionID: collectionID, State: commonpb.SegmentState_Flushed, SchemaVersion: 7,
+			})))
+		}
+		// 1 stale segment (not yet backfilled)
+		assert.NoError(t, svr.meta.AddSegment(context.TODO(), NewSegmentInfo(&datapb.SegmentInfo{
+			ID: 9302, CollectionID: collectionID, State: commonpb.SegmentState_Flushed, SchemaVersion: 6,
+		})))
+
+		resp, err := svr.GetCollectionStatistics(svr.ctx, &datapb.GetCollectionStatisticsRequest{CollectionID: collectionID})
+		assert.NoError(t, err)
+		m := statsMap(resp)
+		assert.Equal(t, "2", m[common.SchemaVersionConsistentSegmentsKey])
+		assert.Equal(t, "3", m[common.SchemaVersionTotalSegmentsKey])
+	})
+}
+
 func TestGetPartitionStatistics(t *testing.T) {
 	t.Run("normal cases", func(t *testing.T) {
 		svr := newTestServer(t)

--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -302,7 +302,6 @@ func (s *Server) AllocSegment(ctx context.Context, req *datapb.AllocSegmentReque
 	if req.GetCollectionId() == 0 || req.GetPartitionId() == 0 || req.GetVchannel() == "" || req.GetSegmentId() == 0 {
 		return &datapb.AllocSegmentResponse{Status: merr.Status(merr.ErrParameterInvalid)}, nil
 	}
-
 	// Alloc new growing segment and return the segment info.
 	segmentInfo, err := s.segmentManager.AllocNewGrowingSegment(
 		ctx,
@@ -313,6 +312,7 @@ func (s *Server) AllocSegment(ctx context.Context, req *datapb.AllocSegmentReque
 			ChannelName:          req.GetVchannel(),
 			StorageVersion:       req.GetStorageVersion(),
 			IsCreatedByStreaming: req.GetIsCreatedByStreaming(),
+			SchemaVersion:        req.GetSchemaVersion(),
 		},
 	)
 	if err != nil {
@@ -414,6 +414,52 @@ func (s *Server) GetCollectionStatistics(ctx context.Context, req *datapb.GetCol
 	}
 	nums := s.meta.GetNumRowsOfCollection(ctx, req.CollectionID)
 	resp.Stats = append(resp.Stats, &commonpb.KeyValuePair{Key: "row_count", Value: strconv.FormatInt(nums, 10)})
+
+	// Calculate schema version consistency proportion
+	// Only report when schema version > 0 (i.e., AlterCollectionSchema has been called)
+	collection := s.meta.GetCollection(req.CollectionID)
+	if collection != nil && collection.Schema != nil && collection.Schema.GetVersion() > 0 {
+		collectionSchemaVersion := collection.Schema.GetVersion()
+		// Growing segments are included: pre-alter ones get sealed and eventually backfilled;
+		// post-alter ones carry the new schema version from creation (companion PR).
+		// L0 segments only contain delete logs and are excluded from backfill processing,
+		// so they must not be counted in the consistency gate either.
+		segments := s.meta.SelectSegments(ctx, WithCollection(req.CollectionID), SegmentFilterFunc(func(si *SegmentInfo) bool {
+			return isSegmentHealthy(si) &&
+				!si.GetIsImporting() &&
+				!si.GetIsInvisible() &&
+				si.GetLevel() != datapb.SegmentLevel_L0
+		}))
+
+		// When there are no segments the collection is trivially consistent; emit nothing so the
+		// proxy treats the absent keys as "no backfill in progress" and allows the DDL through.
+		if len(segments) > 0 {
+			consistentCount := 0
+			for _, segment := range segments {
+				if segment.GetSchemaVersion() == collectionSchemaVersion {
+					consistentCount++
+				}
+			}
+			log.Info("calculated schema version consistency",
+				zap.Int32("collectionSchemaVersion", collectionSchemaVersion),
+				zap.Int("totalSegments", len(segments)),
+				zap.Int("consistentSegments", consistentCount))
+			// Emit raw integer counts instead of a floating-point proportion to avoid the rounding
+			// hazard where e.g. 99999/100000 = 99.999% formats as "100.00" with "%.2f" and would
+			// falsely satisfy a 100% gate check.  Proxy compares these as exact integers.
+			resp.Stats = append(resp.Stats,
+				&commonpb.KeyValuePair{
+					Key:   common.SchemaVersionConsistentSegmentsKey,
+					Value: strconv.Itoa(consistentCount),
+				},
+				&commonpb.KeyValuePair{
+					Key:   common.SchemaVersionTotalSegmentsKey,
+					Value: strconv.Itoa(len(segments)),
+				},
+			)
+		}
+	}
+
 	log.Info("success to get collection statistics", zap.Any("response", resp))
 	return resp, nil
 }

--- a/internal/datanode/compactor/backfill_compactor.go
+++ b/internal/datanode/compactor/backfill_compactor.go
@@ -1,0 +1,804 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compactor
+
+import (
+	"context"
+	"fmt"
+	sio "io"
+	"path"
+	"strconv"
+	"time"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/memory"
+	"github.com/cockroachdb/errors"
+	"github.com/samber/lo"
+	"go.opentelemetry.io/otel"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/allocator"
+	"github.com/milvus-io/milvus/internal/compaction"
+	"github.com/milvus-io/milvus/internal/metastore/kv/binlog"
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/storagecommon"
+	"github.com/milvus-io/milvus/internal/storagev2/packed"
+	"github.com/milvus-io/milvus/internal/util/function"
+	"github.com/milvus-io/milvus/internal/util/hookutil"
+	"github.com/milvus-io/milvus/pkg/v2/common"
+	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexcgopb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+	"github.com/milvus-io/milvus/pkg/v2/util/metautil"
+	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
+)
+
+// backfillWriter abstracts the packed writer interface for V2/V3 compatibility.
+// Both packed.PackedWriter (V2) and packed.FFIPackedWriter (V3) implement WriteRecordBatch,
+// but their Close signatures differ, so we use wrappers for both.
+// Manifest() returns the V3 manifest path after Close(); V2 always returns "".
+type backfillWriter interface {
+	WriteRecordBatch(arrow.Record) error
+	Close() error
+	Manifest() string
+}
+
+// ffiWriterWrapper wraps packed.FFIPackedWriter to implement backfillWriter,
+// capturing the manifest string returned by Close.
+type ffiWriterWrapper struct {
+	writer   *packed.FFIPackedWriter
+	manifest string
+}
+
+func (w *ffiWriterWrapper) WriteRecordBatch(r arrow.Record) error {
+	return w.writer.WriteRecordBatch(r)
+}
+
+func (w *ffiWriterWrapper) Close() error {
+	manifest, err := w.writer.Close()
+	if err != nil {
+		return err
+	}
+	w.manifest = manifest
+	return nil
+}
+
+func (w *ffiWriterWrapper) Manifest() string {
+	return w.manifest
+}
+
+// v2WriterWrapper wraps packed.PackedWriter to implement backfillWriter.
+// Manifest() always returns "" for V2 segments (no manifest concept).
+// fileSizes is populated by Close() via CloseAndTell, indexed by column group order.
+type v2WriterWrapper struct {
+	writer    *packed.PackedWriter
+	numGroups int
+	fileSizes []int64
+}
+
+func (w *v2WriterWrapper) WriteRecordBatch(r arrow.Record) error {
+	return w.writer.WriteRecordBatch(r)
+}
+
+func (w *v2WriterWrapper) Close() error {
+	sizes, err := w.writer.CloseAndTell(w.numGroups)
+	if err != nil {
+		return err
+	}
+	w.fileSizes = sizes
+	return nil
+}
+
+func (w *v2WriterWrapper) Manifest() string {
+	return ""
+}
+
+type backfillCompactionTask struct {
+	ctx              context.Context
+	cancel           context.CancelFunc
+	plan             *datapb.CompactionPlan
+	compactionParams compaction.Params
+	done             chan struct{}
+	logIDAlloc       allocator.Interface
+	functionRunner   function.FunctionRunner
+	chunkManager     storage.ChunkManager
+}
+
+func (t *backfillCompactionTask) Compact() (*datapb.CompactionPlanResult, error) {
+	if !funcutil.CheckCtxValid(t.ctx) {
+		return nil, t.ctx.Err()
+	}
+	ctx, span := otel.Tracer(typeutil.DataNodeRole).Start(t.ctx, fmt.Sprintf("BackfillCompact-%d", t.GetPlanID()))
+	defer span.End()
+
+	if err := t.preCompact(); err != nil {
+		log.Ctx(ctx).Warn("failed to preCompact", zap.Error(err))
+		return nil, err
+	}
+	defer t.functionRunner.Close()
+
+	compactStart := time.Now()
+	log := log.Ctx(ctx).With(
+		zap.Int64("planID", t.GetPlanID()),
+		zap.Int64("collectionID", t.GetCollection()),
+	)
+
+	log.Info("backfill compact start")
+
+	result, err := t.runBackfillFunction(ctx, t.functionRunner)
+	if err != nil {
+		log.Warn("backfill compact failed", zap.Error(err), zap.Duration("compact cost", time.Since(compactStart)))
+		return nil, err
+	}
+
+	log.Info("backfill compact done", zap.Duration("compact cost", time.Since(compactStart)))
+	return result, nil
+}
+
+// preCompact validates the compaction plan, checks context, and sets up the function runner.
+func (t *backfillCompactionTask) preCompact() error {
+	if ok := funcutil.CheckCtxValid(t.ctx); !ok {
+		return t.ctx.Err()
+	}
+
+	// Check segment binlogs: must have exactly one segment
+	if len(t.plan.GetSegmentBinlogs()) != 1 {
+		return errors.Newf("backfill compaction plan is illegal, must have exactly one segment, but got %d segments, planID = %d", len(t.plan.GetSegmentBinlogs()), t.GetPlanID())
+	}
+
+	segment := t.plan.GetSegmentBinlogs()[0]
+	if segment.GetManifest() == "" && len(segment.GetFieldBinlogs()) == 0 {
+		return errors.Newf("compaction plan is illegal, segment's field binlogs are empty, planID = %d, segmentID = %d", t.GetPlanID(), segment.GetSegmentID())
+	}
+
+	backfillFunctions := t.plan.GetFunctions()
+	if len(backfillFunctions) != 1 {
+		return errors.New("backfill functions should be exactly one")
+	}
+	backfillFunction := backfillFunctions[0]
+
+	functionRunner, err := function.NewFunctionRunner(t.plan.GetSchema(), backfillFunction)
+	if err != nil {
+		return err
+	}
+	if functionRunner == nil {
+		return errors.New("failed to set up backfill function runner")
+	}
+
+	// Validate function runner
+	if err := t.checkFunctionRunner(functionRunner); err != nil {
+		functionRunner.Close()
+		return err
+	}
+
+	t.functionRunner = functionRunner
+	return nil
+}
+
+func (t *backfillCompactionTask) checkFunctionRunner(functionRunner function.FunctionRunner) error {
+	switch functionRunner.GetSchema().GetType() {
+	case schemapb.FunctionType_BM25:
+		functionSchema := functionRunner.GetSchema()
+
+		// 1. Check inputFieldIDs: must have exactly one, and type must be varchar
+		inputFieldIDs := functionSchema.GetInputFieldIds()
+		if len(inputFieldIDs) != 1 {
+			return errors.New("bm25 function should have exactly one input field")
+		}
+		inputFieldID := inputFieldIDs[0]
+		inputField := typeutil.GetField(t.plan.GetSchema(), inputFieldID)
+		if inputField == nil {
+			return errors.New("input field not found in schema")
+		}
+		if inputField.GetDataType() != schemapb.DataType_VarChar && inputField.GetDataType() != schemapb.DataType_Text {
+			return errors.New("input field data type must be varchar or text for bm25 function backfill")
+		}
+
+		// 2. Check outputFieldIDs: must have exactly one, and type must be SparseFloatVector
+		outputFieldIDs := functionSchema.GetOutputFieldIds()
+		if len(outputFieldIDs) != 1 {
+			return errors.New("bm25 function should have exactly one output field")
+		}
+		outputFieldID := outputFieldIDs[0]
+		outputField := typeutil.GetField(t.plan.GetSchema(), outputFieldID)
+		if outputField == nil {
+			return errors.New("output field not found in schema")
+		}
+		if outputField.GetDataType() != schemapb.DataType_SparseFloatVector {
+			return errors.New("output field data type must be sparse float vector for bm25 function backfill")
+		}
+
+		return nil
+	default:
+		return errors.New("unsupported function type")
+	}
+}
+
+func (t *backfillCompactionTask) runBackfillFunction(ctx context.Context, functionRunner function.FunctionRunner) (*datapb.CompactionPlanResult, error) {
+	switch functionRunner.GetSchema().GetType() {
+	case schemapb.FunctionType_BM25:
+		return t.runBm25Function(ctx, functionRunner)
+	default:
+		return nil, errors.New("unsupported function type")
+	}
+}
+
+func (t *backfillCompactionTask) openBinlogReader(functionRunner function.FunctionRunner) (storage.RecordReader, error) {
+	functionSchema := functionRunner.GetSchema()
+	inputFieldID := functionSchema.GetInputFieldIds()[0]
+	inputField := typeutil.GetField(t.plan.GetSchema(), inputFieldID)
+
+	segment := t.plan.GetSegmentBinlogs()[0]
+	collectionID := segment.GetCollectionID()
+	partitionID := segment.GetPartitionID()
+	segmentID := segment.GetSegmentID()
+
+	inputSchema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		inputField,
+	}}
+
+	if segment.GetManifest() != "" {
+		return storage.NewManifestRecordReader(t.ctx, segment.GetManifest(), inputSchema,
+			storage.WithVersion(segment.GetStorageVersion()),
+			storage.WithDownloader(t.chunkManager.MultiRead),
+			storage.WithStorageConfig(t.compactionParams.StorageConfig),
+		)
+	}
+
+	if err := binlog.DecompressBinLogWithRootPath(t.compactionParams.StorageConfig.GetRootPath(),
+		storage.InsertBinlog, collectionID, partitionID,
+		segmentID, segment.GetFieldBinlogs()); err != nil {
+		log.Ctx(t.ctx).Warn("Decompress insert binlog error", zap.Error(err))
+		return nil, err
+	}
+	return storage.NewBinlogRecordReader(t.ctx, segment.GetFieldBinlogs(), inputSchema,
+		storage.WithVersion(segment.GetStorageVersion()),
+		storage.WithDownloader(t.chunkManager.MultiRead),
+		storage.WithStorageConfig(t.compactionParams.StorageConfig),
+	)
+}
+
+func (t *backfillCompactionTask) processBatch(functionRunner function.FunctionRunner, inputStrs []string, outputFieldID int64) (*storage.InsertData, int, error) {
+	// run function on this batch
+	output, err := functionRunner.BatchRun(inputStrs)
+	if err != nil {
+		return nil, 0, err
+	}
+	if len(output) != 1 {
+		return nil, 0, errors.New("bm25 function backfill should return exactly one output")
+	}
+	outputSparseArray, ok := output[0].(*schemapb.SparseFloatArray)
+	if !ok {
+		return nil, 0, errors.New("unexpected output type from BM25 function runner, expected SparseFloatArray")
+	}
+
+	// build output field data
+	outputFieldData := &storage.SparseFloatVectorFieldData{
+		SparseFloatArray: schemapb.SparseFloatArray{
+			Contents: outputSparseArray.GetContents(),
+			Dim:      outputSparseArray.GetDim(),
+		},
+	}
+
+	// build insert data
+	insertData := &storage.InsertData{
+		Data: make(map[int64]storage.FieldData),
+	}
+	insertData.Data[outputFieldID] = outputFieldData
+	sparseFieldMemorySize := proto.Size(&outputFieldData.SparseFloatArray)
+
+	return insertData, sparseFieldMemorySize, nil
+}
+
+// backfillWriterResult holds the writer and associated metadata needed after writing.
+type backfillWriterResult struct {
+	writer         backfillWriter
+	arrowSchema    *arrow.Schema
+	outputSchema   *schemapb.CollectionSchema
+	columnGroups   []storagecommon.ColumnGroup
+	paths          []string // V2 only: log paths for buildMergedLogs
+	truePaths      []string // V2 only: true paths for log path resolution
+	fileSizes      []int64  // V2 only: on-disk compressed sizes from CloseAndTell, indexed by column group order
+	storageVersion int64
+	basePath       string             // V3 only: parsed from existing manifest in setupWriter
+	v3Stats        []packed.StatEntry // V3 only: stats to commit atomically with column groups
+}
+
+func (t *backfillCompactionTask) setupWriter(outputField *schemapb.FieldSchema, outputFieldID int64, segment *datapb.CompactionSegmentBinlogs, collectionID, partitionID, segmentID int64) (*backfillWriterResult, error) {
+	outputSchema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		outputField,
+	}}
+	arrowSchema, err := storage.ConvertToArrowSchema(outputSchema, false)
+	if err != nil {
+		return nil, err
+	}
+	if segment.GetManifest() == "" && len(segment.GetFieldBinlogs()) == 0 {
+		return nil, errors.New("segment field binlogs is empty, wrong state for compaction segments")
+	}
+	newColumnGroups := []storagecommon.ColumnGroup{
+		{
+			GroupID: outputFieldID,
+			Columns: []int{0},
+			Fields:  []int64{outputFieldID},
+		},
+	}
+
+	var pluginContext *indexcgopb.StoragePluginContext
+	if hookutil.IsClusterEncryptionEnabled() {
+		ez := hookutil.GetEzByCollProperties(t.plan.GetSchema().GetProperties(), collectionID)
+		if ez != nil {
+			unsafe := hookutil.GetCipher().GetUnsafeKey(ez.EzID, ez.CollectionID)
+			if len(unsafe) > 0 {
+				pluginContext = &indexcgopb.StoragePluginContext{
+					EncryptionZoneId: ez.EzID,
+					CollectionId:     ez.CollectionID,
+					EncryptionKey:    string(unsafe),
+				}
+			}
+		}
+	}
+
+	// Determine effective storage version: V3 only if segment already has a manifest.
+	// V2 segments on V3 clusters must stay V2 — a partial manifest (only new columns)
+	// would cause segcore to ignore original binlog data, corrupting the segment.
+	storageVersion := t.compactionParams.StorageVersion
+	existingManifest := segment.GetManifest()
+	if storageVersion == storage.StorageV3 && existingManifest == "" {
+		storageVersion = storage.StorageV2 // force V2 path for V2 segment on V3 cluster
+	}
+
+	result := &backfillWriterResult{
+		arrowSchema:    arrowSchema,
+		outputSchema:   outputSchema,
+		columnGroups:   newColumnGroups,
+		storageVersion: storageVersion,
+	}
+
+	if storageVersion == storage.StorageV3 {
+		// V3: extend existing manifest by appending new column groups.
+		// Parse basePath and version from the segment's current manifest,
+		// so the transaction reads the existing manifest and merges new columns in.
+		basePath, existingVersion, err := packed.UnmarshalManifestPath(existingManifest)
+		if err != nil {
+			return nil, merr.WrapErrServiceInternal("failed to parse existing manifest for V3 backfill", err.Error())
+		}
+		ffiWriter, err := packed.NewFFIPackedWriter(basePath, existingVersion, arrowSchema, newColumnGroups, t.compactionParams.StorageConfig, pluginContext)
+		if err != nil {
+			return nil, err
+		}
+		// The output field is a new addition to the existing manifest (backfill).
+		// Use AddColumnGroup semantics so Loon does not require the count to match
+		// the existing groups in the manifest.
+		ffiWriter.AsNewColumnGroups()
+		result.writer = &ffiWriterWrapper{writer: ffiWriter}
+		result.basePath = basePath
+	} else {
+		// V2: use PackedWriter with explicit file paths
+		logIdStart, _, err := t.logIDAlloc.Alloc(uint32(len(newColumnGroups)))
+		if err != nil {
+			return nil, err
+		}
+		paths := []string{}
+		for _, columnGroup := range newColumnGroups {
+			p := metautil.BuildInsertLogPath(t.compactionParams.StorageConfig.GetRootPath(), collectionID, partitionID, segmentID, columnGroup.GroupID, logIdStart)
+			paths = append(paths, p)
+			logIdStart++
+		}
+		truePaths := lo.Map(paths, func(p string, _ int) string {
+			if t.compactionParams.StorageConfig.GetStorageType() == "local" {
+				return p
+			}
+			return path.Join(t.compactionParams.StorageConfig.GetBucketName(), p)
+		})
+		writer, err := packed.NewPackedWriter(truePaths, arrowSchema, packed.DefaultWriteBufferSize, packed.DefaultMultiPartUploadSize, newColumnGroups, t.compactionParams.StorageConfig, pluginContext)
+		if err != nil {
+			return nil, err
+		}
+		result.writer = &v2WriterWrapper{writer: writer, numGroups: len(newColumnGroups)}
+		result.paths = paths
+		result.truePaths = truePaths
+	}
+
+	return result, nil
+}
+
+func (t *backfillCompactionTask) writeBatch(writer backfillWriter, arrowSchema *arrow.Schema, insertData *storage.InsertData, outputSchema *schemapb.CollectionSchema) error {
+	builder := array.NewRecordBuilder(memory.DefaultAllocator, arrowSchema)
+	defer builder.Release()
+	err := storage.BuildRecord(builder, insertData, outputSchema)
+	if err != nil {
+		return err
+	}
+	arrowRecord := builder.NewRecord()
+	defer arrowRecord.Release()
+	return writer.WriteRecordBatch(arrowRecord)
+}
+
+func (t *backfillCompactionTask) updateStats(stats *storage.BM25Stats, collectionID, partitionID, segmentID, outputFieldID int64, writerResult *backfillWriterResult) ([]byte, string, error) {
+	cli := t.chunkManager
+	statsID, _, err := t.logIDAlloc.Alloc(uint32(1))
+	if err != nil {
+		return nil, "", err
+	}
+
+	bytes, err := stats.Serialize()
+	if err != nil {
+		return nil, "", err
+	}
+
+	if writerResult.storageVersion == storage.StorageV3 {
+		// V3: write stats file under manifest basePath/_stats/ directory.
+		// Stats will be registered in manifest via AddStatsToManifest after Close().
+		// basePath was already parsed from the manifest in setupWriter — reuse it here.
+		basePath := writerResult.basePath
+		statsRelPath := fmt.Sprintf("_stats/bm25.%d/%d", outputFieldID, statsID)
+		absStatsPath := path.Join(basePath, statsRelPath)
+		if err := cli.Write(t.ctx, absStatsPath, bytes); err != nil {
+			return nil, "", merr.WrapErrServiceInternal("failed to write V3 BM25 stats", err.Error())
+		}
+		writerResult.v3Stats = append(writerResult.v3Stats, packed.StatEntry{
+			Key:   fmt.Sprintf("bm25.%d", outputFieldID),
+			Files: []string{absStatsPath}, // C++ converts absolute to relative at commit
+			Metadata: map[string]string{
+				"memory_size": strconv.FormatInt(int64(len(bytes)), 10),
+			},
+		})
+		return bytes, "", nil // no separate bm25LogPathForResult for V3
+	}
+
+	// V2: write stats file to bm25_stats path, return path for result metadata
+	statsPath := metautil.JoinIDPath(collectionID, partitionID, segmentID, outputFieldID, statsID)
+	bm25LogPath := path.Join(cli.RootPath(), common.SegmentBm25LogPath, statsPath)
+	if err := cli.Write(t.ctx, bm25LogPath, bytes); err != nil {
+		return nil, "", err
+	}
+
+	bm25LogPathForResult := metautil.BuildBm25LogPath(
+		t.compactionParams.StorageConfig.GetRootPath(),
+		collectionID, partitionID, segmentID, outputFieldID, statsID)
+	if t.compactionParams.StorageConfig.GetStorageType() != "local" {
+		bm25LogPathForResult = path.Join(t.compactionParams.StorageConfig.GetBucketName(), bm25LogPathForResult)
+	}
+
+	return bytes, bm25LogPathForResult, nil
+}
+
+func (t *backfillCompactionTask) buildMergedLogsV2(segment *datapb.CompactionSegmentBinlogs, writerResult *backfillWriterResult, sparseFieldMemorySize int, totalRows int64, bytes []byte, bm25LogPathForResult string, outputFieldID int64) ([]*datapb.FieldBinlog, []*datapb.FieldBinlog, error) {
+	newInsertLogs := make(map[int64]*datapb.FieldBinlog)
+	for i, columnGroup := range writerResult.columnGroups {
+		fileSize := writerResult.fileSizes[i]
+		logPath := writerResult.paths[i]
+		truePath := writerResult.truePaths[i]
+		if t.compactionParams.StorageConfig.GetStorageType() != "local" {
+			logPath = truePath
+		}
+		fieldBinlog := &datapb.FieldBinlog{
+			FieldID:     columnGroup.GroupID,
+			ChildFields: columnGroup.Fields,
+			Binlogs: []*datapb.Binlog{
+				{
+					LogSize:    fileSize,
+					MemorySize: int64(sparseFieldMemorySize),
+					LogPath:    logPath,
+					EntriesNum: totalRows,
+				},
+			},
+		}
+		newInsertLogs[columnGroup.GroupID] = fieldBinlog
+	}
+
+	return t.finalizeMergedLogs(segment, newInsertLogs, totalRows, bytes, bm25LogPathForResult, outputFieldID)
+}
+
+func (t *backfillCompactionTask) buildMergedLogsV3(segment *datapb.CompactionSegmentBinlogs, writerResult *backfillWriterResult, sparseFieldMemorySize int, totalRows int64, bytes []byte, bm25LogPathForResult string, outputFieldID int64) ([]*datapb.FieldBinlog, []*datapb.FieldBinlog, error) {
+	// V3: paths are managed by C++, use mock paths similar to PackedManifestRecordWriter.finalizeBinlogs
+	newInsertLogs := make(map[int64]*datapb.FieldBinlog)
+	for _, columnGroup := range writerResult.columnGroups {
+		fieldBinlog := &datapb.FieldBinlog{
+			FieldID:     columnGroup.GroupID,
+			ChildFields: columnGroup.Fields,
+			Binlogs: []*datapb.Binlog{
+				{
+					MemorySize: int64(sparseFieldMemorySize),
+					EntriesNum: totalRows,
+				},
+			},
+		}
+		newInsertLogs[columnGroup.GroupID] = fieldBinlog
+	}
+
+	return t.finalizeMergedLogs(segment, newInsertLogs, totalRows, bytes, bm25LogPathForResult, outputFieldID)
+}
+
+func (t *backfillCompactionTask) finalizeMergedLogs(segment *datapb.CompactionSegmentBinlogs, newInsertLogs map[int64]*datapb.FieldBinlog, totalRows int64, bytes []byte, bm25LogPathForResult string, outputFieldID int64) ([]*datapb.FieldBinlog, []*datapb.FieldBinlog, error) {
+	// build new Bm25Logs
+	bm25FileSize := int64(len(bytes))
+	newBm25Logs := []*datapb.FieldBinlog{
+		{
+			FieldID: outputFieldID,
+			Binlogs: []*datapb.Binlog{
+				{
+					LogSize:    bm25FileSize,
+					MemorySize: bm25FileSize,
+					LogPath:    bm25LogPathForResult,
+					EntriesNum: totalRows,
+				},
+			},
+		},
+	}
+
+	// merge with original segment's binlogs
+	originalInsertLogs := segment.GetFieldBinlogs()
+	mergedInsertLogs := make([]*datapb.FieldBinlog, 0, len(originalInsertLogs)+len(newInsertLogs))
+	mergedInsertLogs = append(mergedInsertLogs, originalInsertLogs...)
+	newInsertLogsList := storage.SortFieldBinlogs(newInsertLogs)
+	mergedInsertLogs = append(mergedInsertLogs, newInsertLogsList...)
+
+	return mergedInsertLogs, newBm25Logs, nil
+}
+
+func (t *backfillCompactionTask) runBm25Function(ctx context.Context, functionRunner function.FunctionRunner) (*datapb.CompactionPlanResult, error) {
+	// 1. set up function schema (validation already done in checkFunctionRunner)
+	functionSchema := functionRunner.GetSchema()
+	outputFieldID := functionSchema.GetOutputFieldIds()[0]
+	inputFieldID := functionSchema.GetInputFieldIds()[0]
+	outputField := typeutil.GetField(t.plan.GetSchema(), outputFieldID)
+
+	// 2. get segment info
+	segment := t.plan.GetSegmentBinlogs()[0]
+	collectionID := segment.GetCollectionID()
+	partitionID := segment.GetPartitionID()
+	segmentID := segment.GetSegmentID()
+
+	// Track durations for each heavy operation
+	var readDuration, computeDuration, writeDuration, updateStatsDuration time.Duration
+
+	// 3. open binlog reader
+	reader, err := t.openBinlogReader(functionRunner)
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+
+	// 4. set up writer
+	writerResult, err := t.setupWriter(outputField, outputFieldID, segment, collectionID, partitionID, segmentID)
+	if err != nil {
+		return nil, err
+	}
+	writerClosed := false
+	defer func() {
+		if !writerClosed {
+			writerResult.writer.Close()
+		}
+	}()
+
+	// 5. batch loop: read → compute → write → accumulate stats
+	_, span := otel.Tracer(typeutil.DataNodeRole).Start(ctx, "BackfillCompact.batchProcess")
+	stats := storage.NewBM25Stats()
+	var totalRows int64
+	var totalSparseMemorySize int
+
+	for {
+		// read one batch
+		readStart := time.Now()
+		record, err := reader.Next()
+		if err != nil {
+			if err == sio.EOF {
+				readDuration += time.Since(readStart)
+				break
+			}
+			span.End()
+			return nil, err
+		}
+		readDuration += time.Since(readStart)
+
+		// extract input strings from this batch
+		col := record.Column(inputFieldID)
+		if col == nil {
+			record.Release()
+			span.End()
+			return nil, merr.WrapErrServiceInternal(fmt.Sprintf("input field %d not found in record", inputFieldID))
+		}
+		recordStr, ok := col.(*array.String)
+		if !ok {
+			record.Release()
+			span.End()
+			return nil, merr.WrapErrServiceInternal(fmt.Sprintf("input field %d data type must be varchar or text for bm25 function backfill, got %T", inputFieldID, col))
+		}
+		batchStrs := make([]string, record.Len())
+		for i := 0; i < record.Len(); i++ {
+			batchStrs[i] = recordStr.Value(i)
+		}
+		record.Release()
+
+		// compute BM25 for this batch
+		computeStart := time.Now()
+		insertData, batchMemSize, err := t.processBatch(functionRunner, batchStrs, outputFieldID)
+		computeDuration += time.Since(computeStart)
+		if err != nil {
+			span.End()
+			return nil, err
+		}
+
+		// accumulate stats from this batch
+		outputFieldData := insertData.Data[outputFieldID].(*storage.SparseFloatVectorFieldData)
+		stats.AppendBytes(outputFieldData.SparseFloatArray.GetContents()...)
+
+		// write this batch
+		writeStart := time.Now()
+		if err := t.writeBatch(writerResult.writer, writerResult.arrowSchema, insertData, writerResult.outputSchema); err != nil {
+			span.End()
+			return nil, err
+		}
+		writeDuration += time.Since(writeStart)
+
+		totalRows += int64(len(batchStrs))
+		totalSparseMemorySize += batchMemSize
+	}
+	span.End()
+
+	// 6. write stats file (must happen before Close for V3 — stats are committed atomically)
+	_, span2 := otel.Tracer(typeutil.DataNodeRole).Start(ctx, "BackfillCompact.updateStats")
+	startTime := time.Now()
+	bytes, bm25LogPathForResult, err := t.updateStats(stats, collectionID, partitionID, segmentID, outputFieldID, writerResult)
+	updateStatsDuration = time.Since(startTime)
+	span2.End()
+	if err != nil {
+		return nil, err
+	}
+
+	// Close writer — for V3, this commits new column groups to the existing manifest
+	// (version N → N+1). BM25 stats are added separately via AddStatsToManifest.
+	if err := writerResult.writer.Close(); err != nil {
+		return nil, err
+	}
+	writerClosed = true
+	// For V2: capture on-disk compressed file sizes written by CloseAndTell.
+	if v2w, ok := writerResult.writer.(*v2WriterWrapper); ok {
+		writerResult.fileSizes = v2w.fileSizes
+	}
+	// Read the manifest produced by Close(); "" for V2, real path for V3.
+	manifestPath := writerResult.writer.Manifest()
+
+	// For V3: register BM25 stats in manifest (version N+1 → N+2).
+	// Channel-level scheduler exclusion guarantees no concurrent manifest modification.
+	if writerResult.storageVersion == storage.StorageV3 && len(writerResult.v3Stats) > 0 {
+		newManifest, err := packed.AddStatsToManifest(
+			manifestPath, t.compactionParams.StorageConfig, writerResult.v3Stats)
+		if err != nil {
+			return nil, merr.WrapErrServiceInternal("failed to add BM25 stats to V3 manifest", err.Error())
+		}
+		manifestPath = newManifest
+	}
+
+	// 7. build merged logs
+	var mergedInsertLogs, mergedBm25Logs []*datapb.FieldBinlog
+	if writerResult.storageVersion == storage.StorageV3 {
+		mergedInsertLogs, mergedBm25Logs, err = t.buildMergedLogsV3(segment, writerResult, totalSparseMemorySize, totalRows, bytes, bm25LogPathForResult, outputFieldID)
+	} else {
+		mergedInsertLogs, mergedBm25Logs, err = t.buildMergedLogsV2(segment, writerResult, totalSparseMemorySize, totalRows, bytes, bm25LogPathForResult, outputFieldID)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// 8. manifest path is already set from Close() and optionally updated by AddStatsToManifest above.
+
+	// 9. return compaction result
+	// For V3: BM25 stats are embedded in the manifest (committed atomically with
+	// column groups), so Bm25Logs should be nil — PackSegmentLoadInfo skips
+	// Bm25Logs when ManifestPath is set, relying on StatsResolver to read from manifest.
+	resultBm25Logs := mergedBm25Logs
+	if writerResult.storageVersion == storage.StorageV3 {
+		resultBm25Logs = nil
+	}
+	ret := &datapb.CompactionPlanResult{
+		PlanID: t.plan.GetPlanID(),
+		State:  datapb.CompactionTaskState_completed,
+		Segments: []*datapb.CompactionSegment{
+			{
+				SegmentID:           segmentID,
+				NumOfRows:           totalRows,
+				InsertLogs:          mergedInsertLogs,
+				Bm25Logs:            resultBm25Logs,
+				Field2StatslogPaths: segment.GetField2StatslogPaths(),
+				Deltalogs:           segment.GetDeltalogs(),
+				Channel:             segment.GetInsertChannel(),
+				StorageVersion:      writerResult.storageVersion,
+				Manifest:            manifestPath,
+			},
+		},
+		Type: t.plan.GetType(),
+	}
+	log.Ctx(ctx).Info("backfill compaction result",
+		zap.Int64("segmentID", segmentID),
+		zap.Int64("numOfRows", totalRows),
+		zap.Int("insertLogsCount", len(mergedInsertLogs)),
+		zap.Int("bm25LogsCount", len(mergedBm25Logs)),
+		zap.Duration("readDuration", readDuration),
+		zap.Duration("computeDuration", computeDuration),
+		zap.Duration("writeDuration", writeDuration),
+		zap.Duration("updateStatsDuration", updateStatsDuration))
+	return ret, nil
+}
+
+func (t *backfillCompactionTask) Complete() {
+	if t.done != nil {
+		select {
+		case t.done <- struct{}{}:
+		default:
+		}
+	}
+}
+
+func (t *backfillCompactionTask) Stop() {
+	if t.cancel != nil {
+		t.cancel()
+	}
+	if t.done != nil {
+		<-t.done
+	}
+}
+
+func (t *backfillCompactionTask) GetPlanID() typeutil.UniqueID {
+	return t.plan.GetPlanID()
+}
+
+func (t *backfillCompactionTask) GetCollection() typeutil.UniqueID {
+	// Get collection ID from the first segment binlog
+	if len(t.plan.GetSegmentBinlogs()) > 0 {
+		return t.plan.GetSegmentBinlogs()[0].GetCollectionID()
+	}
+	return 0
+}
+
+func (t *backfillCompactionTask) GetChannelName() string {
+	return t.plan.GetChannel()
+}
+
+func (t *backfillCompactionTask) GetCompactionType() datapb.CompactionType {
+	return t.plan.GetType()
+}
+
+func (t *backfillCompactionTask) GetSlotUsage() int64 {
+	return t.plan.GetSlotUsage()
+}
+
+func (t *backfillCompactionTask) GetStorageConfig() *indexpb.StorageConfig {
+	return t.compactionParams.StorageConfig
+}
+
+var _ Compactor = (*backfillCompactionTask)(nil)
+
+func NewBackfillCompactionTask(ctx context.Context, cm storage.ChunkManager, plan *datapb.CompactionPlan, compactionParams compaction.Params) *backfillCompactionTask {
+	ctx, cancel := context.WithCancel(ctx)
+	return &backfillCompactionTask{
+		ctx:              ctx,
+		cancel:           cancel,
+		plan:             plan,
+		compactionParams: compactionParams,
+		done:             make(chan struct{}, 1),
+		logIDAlloc:       allocator.NewLocalAllocator(plan.GetPreAllocatedLogIDs().GetBegin(), plan.GetPreAllocatedLogIDs().GetEnd()),
+		chunkManager:     cm,
+	}
+}

--- a/internal/datanode/compactor/backfill_compactor_test.go
+++ b/internal/datanode/compactor/backfill_compactor_test.go
@@ -1,0 +1,647 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compactor
+
+import (
+	"context"
+	"errors"
+	"math"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/allocator"
+	"github.com/milvus-io/milvus/internal/compaction"
+	"github.com/milvus-io/milvus/internal/mocks/flushcommon/mock_util"
+	mock_storage "github.com/milvus-io/milvus/internal/mocks/mock_storage"
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/storagecommon"
+	"github.com/milvus-io/milvus/internal/util/function"
+	"github.com/milvus-io/milvus/pkg/v2/common"
+	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/etcdpb"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v2/util/tsoutil"
+)
+
+func TestBackfillCompactionTaskSuite(t *testing.T) {
+	suite.Run(t, new(BackfillCompactionTaskSuite))
+}
+
+type BackfillCompactionTaskSuite struct {
+	suite.Suite
+
+	mockBinlogIO *mock_util.MockBinlogIO
+
+	meta           *etcdpb.CollectionMeta
+	multiSegWriter *MultiSegmentWriter
+
+	task *backfillCompactionTask
+}
+
+func (s *BackfillCompactionTaskSuite) SetupSuite() {
+	paramtable.Get().Init(paramtable.NewBaseTable())
+}
+
+func (s *BackfillCompactionTaskSuite) setupTest() {
+	s.mockBinlogIO = mock_util.NewMockBinlogIO(s.T())
+
+	s.meta = genTestCollectionMetaWithBM25()
+
+	params, err := compaction.GenerateJSONParams()
+	if err != nil {
+		panic(err)
+	}
+
+	plan := &datapb.CompactionPlan{
+		PlanID: 999,
+		SegmentBinlogs: []*datapb.CompactionSegmentBinlogs{{
+			CollectionID:        1,
+			PartitionID:         1,
+			SegmentID:           100,
+			FieldBinlogs:        nil,
+			Field2StatslogPaths: nil,
+			Deltalogs:           nil,
+			InsertChannel:       "test_channel",
+			StorageVersion:      storage.StorageV2,
+		}},
+		Type:                   datapb.CompactionType_BackfillCompaction,
+		Schema:                 s.meta.GetSchema(),
+		PreAllocatedSegmentIDs: &datapb.IDRange{Begin: 19531, End: math.MaxInt64},
+		PreAllocatedLogIDs:     &datapb.IDRange{Begin: 9530, End: 19530},
+		MaxSize:                64 * 1024 * 1024,
+		JsonParams:             params,
+		Functions: []*schemapb.FunctionSchema{{
+			Name:             "BM25",
+			Id:               100,
+			Type:             schemapb.FunctionType_BM25,
+			InputFieldNames:  []string{"text"},
+			InputFieldIds:    []int64{101},
+			OutputFieldNames: []string{"sparse"},
+			OutputFieldIds:   []int64{102},
+		}},
+		TotalRows: 3,
+	}
+
+	cm, err := storage.NewChunkManagerFactoryWithParam(paramtable.Get()).NewPersistentStorageChunkManager(context.Background())
+	if err != nil {
+		panic(err)
+	}
+	s.task = NewBackfillCompactionTask(context.Background(), cm, plan, compaction.GenParams())
+}
+
+func (s *BackfillCompactionTaskSuite) SetupTest() {
+	paramtable.Get().Save("common.storage.enablev2", "true")
+	paramtable.Get().Save("common.storageType", "local")
+	// Clean up local storage to avoid data accumulation from previous test runs
+	localPath := paramtable.Get().LocalStorageCfg.Path.GetValue()
+	os.RemoveAll(localPath)
+	s.setupTest()
+}
+
+func (s *BackfillCompactionTaskSuite) TearDownTest() {
+	paramtable.Get().Reset("common.storageType")
+	paramtable.Get().Reset("common.storage.enablev2")
+	// Clean up local storage after test
+	localPath := paramtable.Get().LocalStorageCfg.Path.GetValue()
+	os.RemoveAll(localPath)
+}
+
+func (s *BackfillCompactionTaskSuite) prepareBackfillCompaction() {
+	segID := int64(100)
+	s.mockBinlogIO.EXPECT().Upload(mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	// Create multi segment writer with varchar field (input) but without sparse vector field (output)
+	// This simulates a segment that needs backfill
+	s.initSegBufferForBackfill(segID)
+
+	// Close the writer to finalize segments
+	err := s.multiSegWriter.Close()
+	s.Require().NoError(err)
+
+	// Get compaction segments
+	segments := s.multiSegWriter.GetCompactionSegments()
+	s.Require().Equal(1, len(segments), "should create exactly one segment")
+
+	segment := segments[0]
+	// Use the actual segmentID allocated by MultiSegmentWriter
+	actualSegID := segment.GetSegmentID()
+	s.task.plan.SegmentBinlogs = []*datapb.CompactionSegmentBinlogs{
+		{
+			CollectionID:   1,
+			PartitionID:    1,
+			SegmentID:      actualSegID,
+			FieldBinlogs:   segment.GetInsertLogs(),
+			InsertChannel:  "test_channel",
+			StorageVersion: segment.GetStorageVersion(),
+			Manifest:       segment.GetManifest(),
+		},
+	}
+
+	// Write blobs to disk from the uploaded blobs
+	// Note: MultiSegmentWriter handles upload internally, but we can still write to disk for testing
+	log.Info("created segment with MultiSegmentWriter",
+		zap.Int64("segmentID", segID),
+		zap.Int("numRows", int(segment.GetNumOfRows())),
+		zap.Int("insertLogsCount", len(segment.GetInsertLogs())))
+}
+
+func (s *BackfillCompactionTaskSuite) initSegBufferForBackfill(segID int64) {
+	// Create schema without sparse vector field (output field)
+	// Only include input field (varchar)
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{
+				FieldID:  common.RowIDField,
+				Name:     "row_id",
+				DataType: schemapb.DataType_Int64,
+			},
+			{
+				FieldID:  common.TimeStampField,
+				Name:     "Timestamp",
+				DataType: schemapb.DataType_Int64,
+			},
+			{
+				FieldID:      100,
+				Name:         "pk",
+				DataType:     schemapb.DataType_Int64,
+				IsPrimaryKey: true,
+			},
+			{
+				FieldID:  101,
+				Name:     "text",
+				DataType: schemapb.DataType_VarChar,
+				TypeParams: []*commonpb.KeyValuePair{
+					{
+						Key:   common.MaxLengthKey,
+						Value: "128",
+					},
+				},
+			},
+		},
+	}
+
+	// Create allocator for MultiSegmentWriter
+	// Use segID as the starting point for segmentID allocation to ensure consistent paths
+	segIDAlloc := allocator.NewLocalAllocator(segID, math.MaxInt64)
+	logIDAlloc := allocator.NewLocalAllocator(9530, 19530)
+	compAlloc := NewCompactionAllocator(segIDAlloc, logIDAlloc)
+
+	// Create MultiSegmentWriter with StorageV2
+	multiSegWriter, err := NewMultiSegmentWriter(
+		context.Background(),
+		s.mockBinlogIO,
+		compAlloc,
+		64*1024*1024, // 64MB segment size
+		schema,
+		s.task.compactionParams,
+		1000, // maxRows
+		PartitionID,
+		CollectionID,
+		"test_channel",
+		compactionBatchSize,
+		storage.WithStorageConfig(s.task.compactionParams.StorageConfig),
+		storage.WithVersion(storage.StorageV2),
+	)
+	s.Require().NoError(err)
+
+	// Write test data with varchar field
+	for i := 0; i < 3; i++ {
+		v := storage.Value{
+			PK:        storage.NewInt64PrimaryKey(segID + int64(i)),
+			Timestamp: int64(tsoutil.ComposeTSByTime(getMilvusBirthday(), 0)),
+			Value: map[int64]interface{}{
+				common.RowIDField:     segID + int64(i),
+				common.TimeStampField: int64(tsoutil.ComposeTSByTime(getMilvusBirthday(), 0)),
+				100:                   segID + int64(i),
+				101:                   "test string " + string(rune('0'+i)),
+			},
+		}
+		err = multiSegWriter.WriteValue(&v)
+		s.Require().NoError(err)
+	}
+
+	s.multiSegWriter = multiSegWriter
+}
+
+func (s *BackfillCompactionTaskSuite) TestBackfillCompactionSuccess() {
+	s.prepareBackfillCompaction()
+
+	result, err := s.task.Compact()
+	s.NoError(err)
+	s.NotNil(result)
+
+	s.Equal(s.task.plan.GetPlanID(), result.GetPlanID())
+	s.Equal(datapb.CompactionTaskState_completed, result.GetState())
+	s.Equal(1, len(result.GetSegments()))
+
+	segment := result.GetSegments()[0]
+	// SegmentID should match the one allocated by MultiSegmentWriter
+	s.NotZero(segment.GetSegmentID())
+	s.EqualValues(3, segment.GetNumOfRows())
+	s.NotEmpty(segment.GetInsertLogs())
+	// For V3 segments (with manifest), BM25 stats are embedded in the manifest
+	// atomically with the column groups. PackSegmentLoadInfo relies on StatsResolver
+	// to read them from the manifest instead of Bm25Logs.
+	// For V2 segments (no manifest), BM25 stats are returned in Bm25Logs as usual.
+	if segment.GetManifest() != "" {
+		s.Empty(segment.GetBm25Logs())
+		s.NotEmpty(segment.GetManifest())
+	} else {
+		s.NotEmpty(segment.GetBm25Logs())
+		s.Equal(1, len(segment.GetBm25Logs()))
+	}
+}
+
+func (s *BackfillCompactionTaskSuite) TestBackfillCompactionInvalidFunctionCount() {
+	s.prepareBackfillCompaction()
+
+	// Test with zero functions
+	s.task.plan.Functions = []*schemapb.FunctionSchema{}
+	_, err := s.task.Compact()
+	s.Error(err)
+	s.Contains(err.Error(), "backfill functions should be exactly one")
+
+	// Test with multiple functions
+	s.task.plan.Functions = []*schemapb.FunctionSchema{
+		{Type: schemapb.FunctionType_BM25},
+		{Type: schemapb.FunctionType_BM25},
+	}
+	_, err = s.task.Compact()
+	s.Error(err)
+	s.Contains(err.Error(), "backfill functions should be exactly one")
+}
+
+func (s *BackfillCompactionTaskSuite) TestBackfillCompactionInvalidInputField() {
+	s.prepareBackfillCompaction()
+
+	// Test with wrong input field type (Int64 instead of VarChar)
+	s.task.plan.Functions = []*schemapb.FunctionSchema{{
+		Name:           "BM25",
+		Type:           schemapb.FunctionType_BM25,
+		InputFieldIds:  []int64{100}, // Int64 field instead of VarChar
+		OutputFieldIds: []int64{102},
+	}}
+
+	_, err := s.task.Compact()
+	s.Error(err)
+	s.Contains(err.Error(), "input field data type must be varchar")
+}
+
+func (s *BackfillCompactionTaskSuite) TestBackfillCompactionInvalidOutputField() {
+	s.prepareBackfillCompaction()
+
+	// Test with wrong output field type (VarChar instead of SparseFloatVector)
+	s.task.plan.Functions = []*schemapb.FunctionSchema{{
+		Name:           "BM25",
+		Type:           schemapb.FunctionType_BM25,
+		InputFieldIds:  []int64{101},
+		OutputFieldIds: []int64{101}, // VarChar field instead of SparseFloatVector
+	}}
+
+	_, err := s.task.Compact()
+	s.Error(err)
+	s.Contains(err.Error(), "output field data type must be sparse float vector")
+}
+
+func (s *BackfillCompactionTaskSuite) TestBackfillCompactionMultipleInputFields() {
+	s.prepareBackfillCompaction()
+
+	// Test with multiple input fields
+	s.task.plan.Functions = []*schemapb.FunctionSchema{{
+		Name:           "BM25",
+		Type:           schemapb.FunctionType_BM25,
+		InputFieldIds:  []int64{101, 115}, // Multiple input fields
+		OutputFieldIds: []int64{102},
+	}}
+
+	_, err := s.task.Compact()
+	s.Error(err)
+	s.Contains(err.Error(), "bm25 function should have exactly one input field")
+}
+
+func (s *BackfillCompactionTaskSuite) TestBackfillCompactionMultipleOutputFields() {
+	s.prepareBackfillCompaction()
+
+	// Test with multiple output fields
+	s.task.plan.Functions = []*schemapb.FunctionSchema{{
+		Name:           "BM25",
+		Type:           schemapb.FunctionType_BM25,
+		InputFieldIds:  []int64{101},
+		OutputFieldIds: []int64{102, 114}, // Multiple output fields
+	}}
+
+	_, err := s.task.Compact()
+	s.Error(err)
+	s.Contains(err.Error(), "bm25 function should only have one output field")
+}
+
+func (s *BackfillCompactionTaskSuite) TestBackfillCompactionInputFieldNotFound() {
+	s.prepareBackfillCompaction()
+
+	// Test with non-existent input field ID
+	s.task.plan.Functions = []*schemapb.FunctionSchema{{
+		Name:           "BM25",
+		Type:           schemapb.FunctionType_BM25,
+		InputFieldIds:  []int64{999}, // Non-existent field ID
+		OutputFieldIds: []int64{102},
+	}}
+
+	_, err := s.task.Compact()
+	s.Error(err)
+	s.Contains(err.Error(), "input field not found in schema")
+}
+
+func (s *BackfillCompactionTaskSuite) TestBackfillCompactionOutputFieldNotFound() {
+	s.prepareBackfillCompaction()
+
+	// Test with non-existent output field ID
+	s.task.plan.Functions = []*schemapb.FunctionSchema{{
+		Name:           "BM25",
+		Type:           schemapb.FunctionType_BM25,
+		InputFieldIds:  []int64{101},
+		OutputFieldIds: []int64{999}, // Non-existent field ID
+	}}
+
+	_, err := s.task.Compact()
+	s.Error(err)
+	s.Contains(err.Error(), "no output field")
+}
+
+func (s *BackfillCompactionTaskSuite) TestBackfillCompactionUnsupportedFunctionType() {
+	s.prepareBackfillCompaction()
+
+	// Test with unsupported function type
+	s.task.plan.Functions = []*schemapb.FunctionSchema{{
+		Name:           "Unknown",
+		Type:           schemapb.FunctionType_Unknown,
+		InputFieldIds:  []int64{101},
+		OutputFieldIds: []int64{102},
+	}}
+
+	_, err := s.task.Compact()
+	s.Error(err)
+	s.Contains(err.Error(), "unknown functionRunner type")
+}
+
+func (s *BackfillCompactionTaskSuite) TestBackfillCompactionEmptySegmentBinlogs() {
+	// Test with empty segment binlogs
+	s.task.plan.SegmentBinlogs = nil
+
+	_, err := s.task.Compact()
+	s.Error(err)
+}
+
+func (s *BackfillCompactionTaskSuite) TestBackfillCompactionEmptyColumnGroups() {
+	s.prepareBackfillCompaction()
+
+	// Create segment binlogs with empty field binlogs to trigger empty field binlogs error
+	s.task.plan.SegmentBinlogs = []*datapb.CompactionSegmentBinlogs{
+		{
+			CollectionID:   1,
+			PartitionID:    1,
+			SegmentID:      100,
+			FieldBinlogs:   []*datapb.FieldBinlog{}, // Empty field binlogs
+			InsertChannel:  "test_channel",
+			StorageVersion: storage.StorageV2,
+		},
+	}
+
+	_, err := s.task.Compact()
+	s.Error(err)
+	s.Contains(err.Error(), "segment's field binlogs are empty")
+}
+
+func (s *BackfillCompactionTaskSuite) TestBackfillCompactionMultipleSegments() {
+	s.prepareBackfillCompaction()
+
+	// Test with multiple segments (should fail, must have exactly one)
+	s.task.plan.SegmentBinlogs = []*datapb.CompactionSegmentBinlogs{
+		{
+			CollectionID:   1,
+			PartitionID:    1,
+			SegmentID:      100,
+			FieldBinlogs:   []*datapb.FieldBinlog{{FieldID: 101}},
+			InsertChannel:  "test_channel",
+			StorageVersion: storage.StorageV2,
+		},
+		{
+			CollectionID:   1,
+			PartitionID:    1,
+			SegmentID:      200,
+			FieldBinlogs:   []*datapb.FieldBinlog{{FieldID: 101}},
+			InsertChannel:  "test_channel",
+			StorageVersion: storage.StorageV2,
+		},
+	}
+
+	_, err := s.task.Compact()
+	s.Error(err)
+	s.Contains(err.Error(), "must have exactly one segment")
+	s.Contains(err.Error(), "but got 2 segments")
+}
+
+func (s *BackfillCompactionTaskSuite) TestBackfillCompactionContextCanceled() {
+	// Cancel context before compact (before prepareBackfillCompaction)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	s.task.ctx = ctx
+	s.task.cancel = cancel
+
+	// Compact should detect context cancel at the beginning
+	_, err := s.task.Compact()
+	s.Error(err)
+	s.ErrorIs(err, context.Canceled)
+}
+
+func TestBackfillCompactionTaskBasic(t *testing.T) {
+	ctx := context.Background()
+
+	meta := genTestCollectionMetaWithBM25()
+	params, err := compaction.GenerateJSONParams()
+	assert.NoError(t, err)
+
+	plan := &datapb.CompactionPlan{
+		PlanID: 1000,
+		SegmentBinlogs: []*datapb.CompactionSegmentBinlogs{{
+			CollectionID:   1,
+			PartitionID:    1,
+			SegmentID:      200,
+			InsertChannel:  "test_channel",
+			StorageVersion: storage.StorageV2,
+		}},
+		Type:                   datapb.CompactionType_BackfillCompaction,
+		Schema:                 meta.GetSchema(),
+		PreAllocatedSegmentIDs: &datapb.IDRange{Begin: 19531, End: math.MaxInt64},
+		PreAllocatedLogIDs:     &datapb.IDRange{Begin: 9530, End: 19530},
+		MaxSize:                64 * 1024 * 1024,
+		JsonParams:             params,
+		Functions: []*schemapb.FunctionSchema{{
+			Name:           "BM25",
+			Type:           schemapb.FunctionType_BM25,
+			InputFieldIds:  []int64{101},
+			OutputFieldIds: []int64{102},
+		}},
+		TotalRows: 0,
+		Channel:   "test_channel",
+		SlotUsage: 1,
+	}
+
+	mockCM := mock_storage.NewMockChunkManager(t)
+	task := NewBackfillCompactionTask(ctx, mockCM, plan, compaction.GenParams())
+	assert.NotNil(t, task)
+	assert.Equal(t, int64(1000), task.GetPlanID())
+	assert.Equal(t, int64(1), task.GetCollection())
+	assert.Equal(t, "test_channel", task.GetChannelName())
+	assert.Equal(t, datapb.CompactionType_BackfillCompaction, task.GetCompactionType())
+	assert.Equal(t, int64(1), task.GetSlotUsage())
+}
+
+func (s *BackfillCompactionTaskSuite) TestProcessBatch() {
+	s.Run("success", func() {
+		s.setupTest()
+		mockRunner := function.NewMockFunctionRunner(s.T())
+		sparseArray := &schemapb.SparseFloatArray{
+			Contents: [][]byte{{1, 2, 3, 4}},
+			Dim:      100,
+		}
+		mockRunner.EXPECT().BatchRun([]string{"hello world"}).Return([]interface{}{sparseArray}, nil)
+
+		insertData, memSize, err := s.task.processBatch(mockRunner, []string{"hello world"}, 102)
+		s.NoError(err)
+		s.Greater(memSize, 0)
+		s.NotNil(insertData)
+		s.NotNil(insertData.Data[102])
+	})
+
+	s.Run("BatchRun error", func() {
+		s.setupTest()
+		mockRunner := function.NewMockFunctionRunner(s.T())
+		mockRunner.EXPECT().BatchRun([]string{"test"}).Return(nil, errors.New("batch run failed"))
+
+		_, _, err := s.task.processBatch(mockRunner, []string{"test"}, 102)
+		s.Error(err)
+		s.Contains(err.Error(), "batch run failed")
+	})
+
+	s.Run("wrong output count", func() {
+		s.setupTest()
+		mockRunner := function.NewMockFunctionRunner(s.T())
+		mockRunner.EXPECT().BatchRun([]string{"test"}).Return([]interface{}{nil, nil}, nil)
+
+		_, _, err := s.task.processBatch(mockRunner, []string{"test"}, 102)
+		s.Error(err)
+		s.Contains(err.Error(), "exactly one output")
+	})
+
+	s.Run("wrong output type", func() {
+		s.setupTest()
+		mockRunner := function.NewMockFunctionRunner(s.T())
+		mockRunner.EXPECT().BatchRun([]string{"test"}).Return([]interface{}{"not_sparse"}, nil)
+
+		_, _, err := s.task.processBatch(mockRunner, []string{"test"}, 102)
+		s.Error(err)
+		s.Contains(err.Error(), "unexpected output type")
+	})
+}
+
+func (s *BackfillCompactionTaskSuite) TestFinalizeMergedLogs() {
+	s.setupTest()
+
+	segment := &datapb.CompactionSegmentBinlogs{
+		SegmentID: 1,
+		FieldBinlogs: []*datapb.FieldBinlog{
+			{
+				FieldID: 100,
+				Binlogs: []*datapb.Binlog{
+					{LogPath: "original/100", EntriesNum: 1000},
+				},
+			},
+		},
+	}
+	newInsertLogs := map[int64]*datapb.FieldBinlog{
+		102: {
+			FieldID: 102,
+			Binlogs: []*datapb.Binlog{
+				{LogPath: "new/102", EntriesNum: 1000, MemorySize: 500},
+			},
+		},
+	}
+	bm25Bytes := []byte{1, 2, 3, 4, 5}
+
+	mergedInsert, mergedBm25, err := s.task.finalizeMergedLogs(segment, newInsertLogs, 1000, bm25Bytes, "bm25/stats/path", 102)
+	s.NoError(err)
+
+	// Check merged insert logs contain both original and new
+	s.Equal(2, len(mergedInsert))
+	s.Equal(int64(100), mergedInsert[0].GetFieldID())
+	s.Equal(int64(102), mergedInsert[1].GetFieldID())
+
+	// Check BM25 logs
+	s.Equal(1, len(mergedBm25))
+	s.Equal(int64(102), mergedBm25[0].GetFieldID())
+	s.Equal(int64(5), mergedBm25[0].GetBinlogs()[0].GetLogSize())
+	s.Equal("bm25/stats/path", mergedBm25[0].GetBinlogs()[0].GetLogPath())
+	s.Equal(int64(1000), mergedBm25[0].GetBinlogs()[0].GetEntriesNum())
+}
+
+func (s *BackfillCompactionTaskSuite) TestBuildMergedLogsV3() {
+	s.setupTest()
+
+	segment := &datapb.CompactionSegmentBinlogs{
+		SegmentID: 1,
+		FieldBinlogs: []*datapb.FieldBinlog{
+			{FieldID: 100, Binlogs: []*datapb.Binlog{{LogPath: "original/100", EntriesNum: 1000}}},
+		},
+	}
+	writerResult := &backfillWriterResult{
+		columnGroups: []storagecommon.ColumnGroup{
+			{GroupID: 102, Fields: []int64{102}},
+		},
+	}
+
+	mergedInsert, mergedBm25, err := s.task.buildMergedLogsV3(segment, writerResult, 512, 1000, []byte{1, 2, 3}, "bm25/path", 102)
+	s.NoError(err)
+
+	// Original + new
+	s.Equal(2, len(mergedInsert))
+	s.Equal(int64(100), mergedInsert[0].GetFieldID())
+	s.Equal(int64(102), mergedInsert[1].GetFieldID())
+	s.Equal(int64(512), mergedInsert[1].GetBinlogs()[0].GetMemorySize())
+	s.Equal(int64(1000), mergedInsert[1].GetBinlogs()[0].GetEntriesNum())
+
+	s.Equal(1, len(mergedBm25))
+	s.Equal(int64(102), mergedBm25[0].GetFieldID())
+}
+
+func (s *BackfillCompactionTaskSuite) TestCompleteAndStop() {
+	s.setupTest()
+	s.task.Complete()
+	s.task.Stop()
+}
+
+func (s *BackfillCompactionTaskSuite) TestGetStorageConfig() {
+	s.setupTest()
+	s.NotNil(s.task.GetStorageConfig())
+}

--- a/internal/datanode/compactor/executor.go
+++ b/internal/datanode/compactor/executor.go
@@ -91,6 +91,8 @@ func getTaskSlotUsage(task Compactor) int64 {
 			taskSlotUsage = paramtable.Get().DataCoordCfg.MixCompactionSlotUsage.GetAsInt64()
 		case datapb.CompactionType_Level0DeleteCompaction:
 			taskSlotUsage = paramtable.Get().DataCoordCfg.L0DeleteCompactionSlotUsage.GetAsInt64()
+		case datapb.CompactionType_BackfillCompaction:
+			taskSlotUsage = paramtable.Get().DataCoordCfg.BackfillCompactionSlotUsage.GetAsInt64()
 		}
 		log.Warn("illegal task slot usage, change it to a default value",
 			zap.Int64("illegalSlotUsage", task.GetSlotUsage()),

--- a/internal/datanode/services.go
+++ b/internal/datanode/services.go
@@ -302,6 +302,8 @@ func (node *DataNode) CompactionV2(ctx context.Context, req *datapb.CompactionPl
 			compactionParams,
 			sortFields,
 		)
+	case datapb.CompactionType_BackfillCompaction:
+		task = compactor.NewBackfillCompactionTask(taskCtx, cm, req, compactionParams)
 	default:
 		log.Warn("Unknown compaction type", zap.String("type", req.GetType().String()))
 		return merr.Status(merr.WrapErrParameterInvalidMsg("Unknown compaction type: %v", req.GetType().String())), nil

--- a/internal/metastore/model/collection.go
+++ b/internal/metastore/model/collection.go
@@ -58,6 +58,7 @@ type Collection struct {
 	FileResourceIds      []int64
 	ExternalSource       string
 	ExternalSpec         string
+	DoPhysicalBackfill   bool
 }
 
 type ShardInfo struct {
@@ -100,6 +101,7 @@ func (c *Collection) ShallowClone() *Collection {
 		FileResourceIds:      c.FileResourceIds,
 		ExternalSource:       c.ExternalSource,
 		ExternalSpec:         c.ExternalSpec,
+		DoPhysicalBackfill:   c.DoPhysicalBackfill,
 	}
 }
 
@@ -141,6 +143,7 @@ func (c *Collection) Clone() *Collection {
 		FileResourceIds:      slices.Clone(c.FileResourceIds),
 		ExternalSource:       c.ExternalSource,
 		ExternalSpec:         c.ExternalSpec,
+		DoPhysicalBackfill:   c.DoPhysicalBackfill,
 	}
 }
 
@@ -193,6 +196,7 @@ func (c *Collection) ApplyUpdates(header *message.AlterCollectionMessageHeader, 
 			c.SchemaVersion = updates.Schema.Version
 			c.ExternalSource = updates.Schema.ExternalSource
 			c.ExternalSpec = updates.Schema.ExternalSpec
+			c.DoPhysicalBackfill = updates.Schema.DoPhysicalBackfill
 		}
 	}
 }
@@ -254,6 +258,7 @@ func UnmarshalCollectionModel(coll *pb.CollectionInfo) *Collection {
 		FileResourceIds:      coll.Schema.GetFileResourceIds(),
 		ExternalSource:       coll.Schema.ExternalSource,
 		ExternalSpec:         coll.Schema.ExternalSpec,
+		DoPhysicalBackfill:   coll.Schema.DoPhysicalBackfill,
 	}
 }
 
@@ -309,6 +314,7 @@ func marshalCollectionModelWithConfig(coll *Collection, c *config) *pb.Collectio
 		FileResourceIds:    coll.FileResourceIds,
 		ExternalSource:     coll.ExternalSource,
 		ExternalSpec:       coll.ExternalSpec,
+		DoPhysicalBackfill: coll.DoPhysicalBackfill,
 	}
 
 	if c.withFields {

--- a/internal/metastore/model/index.go
+++ b/internal/metastore/model/index.go
@@ -8,17 +8,18 @@ import (
 )
 
 type Index struct {
-	TenantID        string
-	CollectionID    int64
-	FieldID         int64
-	IndexID         int64
-	IndexName       string
-	IsDeleted       bool
-	CreateTime      uint64
-	TypeParams      []*commonpb.KeyValuePair
-	IndexParams     []*commonpb.KeyValuePair
-	IsAutoIndex     bool
-	UserIndexParams []*commonpb.KeyValuePair
+	TenantID         string
+	CollectionID     int64
+	FieldID          int64
+	IndexID          int64
+	IndexName        string
+	IsDeleted        bool
+	CreateTime       uint64
+	TypeParams       []*commonpb.KeyValuePair
+	IndexParams      []*commonpb.KeyValuePair
+	IsAutoIndex      bool
+	UserIndexParams  []*commonpb.KeyValuePair
+	MinSchemaVersion int32
 }
 
 func UnmarshalIndexModel(indexInfo *indexpb.FieldIndex) *Index {
@@ -27,16 +28,17 @@ func UnmarshalIndexModel(indexInfo *indexpb.FieldIndex) *Index {
 	}
 
 	return &Index{
-		CollectionID:    indexInfo.IndexInfo.GetCollectionID(),
-		FieldID:         indexInfo.IndexInfo.GetFieldID(),
-		IndexID:         indexInfo.IndexInfo.GetIndexID(),
-		IndexName:       indexInfo.IndexInfo.GetIndexName(),
-		IsDeleted:       indexInfo.GetDeleted(),
-		CreateTime:      indexInfo.CreateTime,
-		TypeParams:      indexInfo.IndexInfo.GetTypeParams(),
-		IndexParams:     indexInfo.IndexInfo.GetIndexParams(),
-		IsAutoIndex:     indexInfo.IndexInfo.GetIsAutoIndex(),
-		UserIndexParams: indexInfo.IndexInfo.GetUserIndexParams(),
+		CollectionID:     indexInfo.IndexInfo.GetCollectionID(),
+		FieldID:          indexInfo.IndexInfo.GetFieldID(),
+		IndexID:          indexInfo.IndexInfo.GetIndexID(),
+		IndexName:        indexInfo.IndexInfo.GetIndexName(),
+		IsDeleted:        indexInfo.GetDeleted(),
+		CreateTime:       indexInfo.CreateTime,
+		TypeParams:       indexInfo.IndexInfo.GetTypeParams(),
+		IndexParams:      indexInfo.IndexInfo.GetIndexParams(),
+		IsAutoIndex:      indexInfo.IndexInfo.GetIsAutoIndex(),
+		UserIndexParams:  indexInfo.IndexInfo.GetUserIndexParams(),
+		MinSchemaVersion: indexInfo.GetMinSchemaVersion(),
 	}
 }
 
@@ -56,8 +58,9 @@ func MarshalIndexModel(index *Index) *indexpb.FieldIndex {
 			IsAutoIndex:     index.IsAutoIndex,
 			UserIndexParams: index.UserIndexParams,
 		},
-		Deleted:    index.IsDeleted,
-		CreateTime: index.CreateTime,
+		Deleted:          index.IsDeleted,
+		CreateTime:       index.CreateTime,
+		MinSchemaVersion: index.MinSchemaVersion,
 	}
 }
 
@@ -113,17 +116,18 @@ func MarshalIndexModel(index *Index) *indexpb.FieldIndex {
 
 func CloneIndex(index *Index) *Index {
 	clonedIndex := &Index{
-		TenantID:        index.TenantID,
-		CollectionID:    index.CollectionID,
-		FieldID:         index.FieldID,
-		IndexID:         index.IndexID,
-		IndexName:       index.IndexName,
-		IsDeleted:       index.IsDeleted,
-		CreateTime:      index.CreateTime,
-		TypeParams:      make([]*commonpb.KeyValuePair, len(index.TypeParams)),
-		IndexParams:     make([]*commonpb.KeyValuePair, len(index.IndexParams)),
-		IsAutoIndex:     index.IsAutoIndex,
-		UserIndexParams: make([]*commonpb.KeyValuePair, len(index.UserIndexParams)),
+		TenantID:         index.TenantID,
+		CollectionID:     index.CollectionID,
+		FieldID:          index.FieldID,
+		IndexID:          index.IndexID,
+		IndexName:        index.IndexName,
+		IsDeleted:        index.IsDeleted,
+		CreateTime:       index.CreateTime,
+		TypeParams:       make([]*commonpb.KeyValuePair, len(index.TypeParams)),
+		IndexParams:      make([]*commonpb.KeyValuePair, len(index.IndexParams)),
+		IsAutoIndex:      index.IsAutoIndex,
+		UserIndexParams:  make([]*commonpb.KeyValuePair, len(index.UserIndexParams)),
+		MinSchemaVersion: index.MinSchemaVersion,
 	}
 	for i, param := range index.TypeParams {
 		clonedIndex.TypeParams[i] = proto.Clone(param).(*commonpb.KeyValuePair)

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -968,6 +968,11 @@ func (node *Proxy) AddCollectionField(ctx context.Context, request *milvuspb.Add
 			"add field operation is not supported for external collection %s", request.GetCollectionName())), nil
 	}
 
+	// TODO: gate AddCollectionField against in-progress backfill once segment schema-version
+	// propagation for DoPhysicalBackfill=false DDLs is synchronous.  Currently the backfill
+	// policy updates segment schema versions on a tick, so a rapid second AddCollectionField
+	// can arrive before the tick fires and be incorrectly rejected by the gate.
+
 	task := &addCollectionFieldTask{
 		ctx:                       ctx,
 		Condition:                 NewTaskCondition(ctx),
@@ -1016,6 +1021,173 @@ func (node *Proxy) AddCollectionField(ctx context.Context, request *milvuspb.Add
 
 	metrics.ProxyReqLatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), method).Observe(float64(tr.ElapseSpan().Milliseconds()))
 	return task.result, nil
+}
+
+func (node *Proxy) AlterCollectionSchema(ctx context.Context, request *milvuspb.AlterCollectionSchemaRequest) (*milvuspb.AlterCollectionSchemaResponse, error) {
+	if err := merr.CheckHealthy(node.GetStateCode()); err != nil {
+		return &milvuspb.AlterCollectionSchemaResponse{
+			AlterStatus: merr.Status(err),
+		}, nil
+	}
+	ctx, sp := otel.Tracer(typeutil.ProxyRole).Start(ctx, "Proxy-AlterCollectionSchema")
+	defer sp.End()
+
+	dresp, err := node.DescribeCollection(ctx, &milvuspb.DescribeCollectionRequest{DbName: request.DbName, CollectionName: request.CollectionName})
+	if err := merr.CheckRPCCall(dresp, err); err != nil {
+		return &milvuspb.AlterCollectionSchemaResponse{
+			AlterStatus: merr.Status(err),
+		}, nil
+	}
+
+	// Check for external collection - alter collection schema is not supported
+	if typeutil.IsExternalCollection(dresp.GetSchema()) {
+		return &milvuspb.AlterCollectionSchemaResponse{
+			AlterStatus: merr.Status(merr.WrapErrParameterInvalidMsg(
+				"alter collection schema operation is not supported for external collection %s", request.GetCollectionName())),
+		}, nil
+	}
+
+	// Check schema version consistency before proceeding with alter collection schema
+	if err := node.checkSchemaVersionConsistency(ctx, request.DbName, request.CollectionName); err != nil {
+		return &milvuspb.AlterCollectionSchemaResponse{
+			AlterStatus: merr.Status(err),
+		}, nil
+	}
+
+	task := &alterCollectionSchemaTask{
+		ctx:                          ctx,
+		Condition:                    NewTaskCondition(ctx),
+		AlterCollectionSchemaRequest: request,
+		mixCoord:                     node.mixCoord,
+		oldSchema:                    dresp.GetSchema(),
+	}
+	method := "AlterCollectionSchema"
+	tr := timerecord.NewTimeRecorder(method)
+
+	log := log.Ctx(ctx).With(
+		zap.String("role", typeutil.ProxyRole),
+		zap.String("db", request.DbName),
+		zap.String("collection", request.CollectionName))
+
+	log.Info(rpcReceived(method))
+
+	if err := node.sched.ddQueue.Enqueue(task); err != nil {
+		log.Warn(
+			rpcFailedToEnqueue(method),
+			zap.Error(err))
+		return &milvuspb.AlterCollectionSchemaResponse{
+			AlterStatus: merr.Status(err),
+		}, nil
+	}
+
+	log.Info(
+		rpcEnqueued(method),
+		zap.Uint64("BeginTs", task.BeginTs()),
+		zap.Uint64("EndTs", task.EndTs()))
+
+	if err := task.WaitToFinish(); err != nil {
+		log.Warn(
+			rpcFailedToWaitToFinish(method),
+			zap.Error(err),
+			zap.Uint64("BeginTs", task.BeginTs()),
+			zap.Uint64("EndTs", task.EndTs()))
+		return &milvuspb.AlterCollectionSchemaResponse{
+			AlterStatus: merr.Status(err),
+		}, nil
+	}
+	log.Info(
+		rpcDone(method),
+		zap.Uint64("BeginTs", task.BeginTs()),
+		zap.Uint64("EndTs", task.EndTs()))
+
+	metrics.ProxyReqLatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), method).Observe(float64(tr.ElapseSpan().Milliseconds()))
+
+	return task.AlterCollectionSchemaResponse, nil
+}
+
+// checkSchemaVersionConsistency checks if all segments have consistent schema version
+// Returns error if schema version consistency proportion is less than 100%
+func (node *Proxy) checkSchemaVersionConsistency(ctx context.Context, dbName, collectionName string) error {
+	log := log.Ctx(ctx).With(
+		zap.String("role", typeutil.ProxyRole),
+		zap.String("db", dbName),
+		zap.String("collection", collectionName))
+
+	// Get collection statistics to check schema version consistency
+	statsResp, err := node.GetCollectionStatistics(ctx, &milvuspb.GetCollectionStatisticsRequest{
+		Base:           commonpbutil.NewMsgBase(),
+		DbName:         dbName,
+		CollectionName: collectionName,
+	})
+	if err != nil {
+		log.Warn("failed to get collection statistics for schema version consistency check", zap.Error(err))
+		return err
+	}
+	if err := merr.CheckRPCCall(statsResp, err); err != nil {
+		log.Warn("get collection statistics returned error", zap.Error(err))
+		return err
+	}
+
+	// Find schema_version_consistent_segments and schema_version_total_segments from Stats.
+	// DataCoord emits these two integer keys only when the collection's schema version > 0
+	// (i.e. AlterCollectionSchema has been called at least once).  Absent keys mean the
+	// schema version is still 0 — no function field has ever been added — so there is no
+	// in-flight backfill and no DDL can be racing with one.  This does NOT open a window
+	// for concurrent DDL to slip through: RootCoord serializes all schema-change DDLs through
+	// a single DDL queue, so a second AlterCollectionSchema call can only enter this check
+	// after the first has already bumped the schema version and DataCoord has started reporting
+	// the count keys.
+	//
+	// Integer counts are used instead of a floating-point proportion to avoid the rounding
+	// hazard where e.g. 99999/100000 = 99.999% would format as "100.00" with "%.2f" and
+	// falsely satisfy the 100% gate check.
+	consistentSegments := -1
+	totalSegments := -1
+	for _, stat := range statsResp.GetStats() {
+		switch stat.GetKey() {
+		case common.SchemaVersionConsistentSegmentsKey:
+			v, err := strconv.Atoi(stat.GetValue())
+			if err != nil {
+				log.Warn("failed to parse schema_version_consistent_segments",
+					zap.String("value", stat.GetValue()), zap.Error(err))
+				return merr.WrapErrParameterInvalidMsg(
+					"invalid schema_version_consistent_segments value: %s", stat.GetValue())
+			}
+			consistentSegments = v
+		case common.SchemaVersionTotalSegmentsKey:
+			v, err := strconv.Atoi(stat.GetValue())
+			if err != nil {
+				log.Warn("failed to parse schema_version_total_segments",
+					zap.String("value", stat.GetValue()), zap.Error(err))
+				return merr.WrapErrParameterInvalidMsg(
+					"invalid schema_version_total_segments value: %s", stat.GetValue())
+			}
+			totalSegments = v
+		}
+	}
+
+	log.Info("checked schema version consistency",
+		zap.Int("consistentSegments", consistentSegments),
+		zap.Int("totalSegments", totalSegments))
+
+	if consistentSegments < 0 && totalSegments < 0 {
+		// Both keys absent: schema version is 0, no backfill has ever been triggered.
+		return nil
+	}
+	if consistentSegments < 0 || totalSegments < 0 {
+		// Exactly one key present — should never happen since DataCoord emits both atomically.
+		// Treat as a data corruption signal and block the DDL rather than silently passing.
+		log.Warn("incomplete schema version consistency stats, blocking DDL",
+			zap.Int("consistentSegments", consistentSegments),
+			zap.Int("totalSegments", totalSegments))
+		return merr.WrapErrParameterInvalidMsg("incomplete schema version consistency stats from DataCoord")
+	}
+	if consistentSegments < totalSegments {
+		return merr.WrapErrParameterInvalidMsg(
+			"schema version consistency check failed: %d/%d segments are consistent, required 100%%",
+			consistentSegments, totalSegments)
+	}
+	return nil
 }
 
 // GetStatistics get the statistics, such as `num_rows`.
@@ -1447,6 +1619,10 @@ func (node *Proxy) AlterCollectionField(ctx context.Context, request *milvuspb.A
 	if err := checkExternalCollectionBlockedForWrite(ctx, request.GetDbName(), request.GetCollectionName(), "alter field"); err != nil {
 		return merr.Status(err), nil
 	}
+
+	// TODO: gate AlterCollectionField against in-progress backfill once segment schema-version
+	// propagation for DoPhysicalBackfill=false DDLs is synchronous.  Same timing issue as
+	// AddCollectionField — backfill tick may not have fired before the next DDL arrives.
 
 	act := &alterCollectionFieldTask{
 		ctx:                         ctx,

--- a/internal/proxy/impl_test.go
+++ b/internal/proxy/impl_test.go
@@ -2606,3 +2606,256 @@ func TestProxy_BatchUpdateManifest(t *testing.T) {
 		})
 	})
 }
+
+func TestProxy_AlterCollectionSchema(t *testing.T) {
+	t.Run("unhealthy node", func(t *testing.T) {
+		proxy := &Proxy{}
+		proxy.UpdateStateCode(commonpb.StateCode_Abnormal)
+		resp, err := proxy.AlterCollectionSchema(context.Background(), &milvuspb.AlterCollectionSchemaRequest{})
+		assert.NoError(t, err)
+		assert.Error(t, merr.Error(resp.GetAlterStatus()))
+	})
+
+	t.Run("DescribeCollection fails", func(t *testing.T) {
+		mockey.PatchConvey("DescribeCollection fails", t, func() {
+			node := createTestProxy()
+			defer node.sched.Close()
+
+			mockey.Mock((*Proxy).DescribeCollection).Return(&milvuspb.DescribeCollectionResponse{
+				Status: merr.Status(merr.ErrCollectionNotFound),
+			}, nil).Build()
+
+			resp, err := node.AlterCollectionSchema(context.Background(), &milvuspb.AlterCollectionSchemaRequest{
+				CollectionName: "test_coll",
+			})
+			assert.NoError(t, err)
+			assert.Error(t, merr.Error(resp.GetAlterStatus()))
+		})
+	})
+
+	t.Run("external collection rejected", func(t *testing.T) {
+		mockey.PatchConvey("external collection", t, func() {
+			node := createTestProxy()
+			defer node.sched.Close()
+
+			mockey.Mock((*Proxy).DescribeCollection).Return(&milvuspb.DescribeCollectionResponse{
+				Status: merr.Success(),
+				Schema: &schemapb.CollectionSchema{
+					Name: "ext_col",
+					Fields: []*schemapb.FieldSchema{
+						{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true, ExternalField: "ext_id"},
+					},
+				},
+			}, nil).Build()
+
+			resp, err := node.AlterCollectionSchema(context.Background(), &milvuspb.AlterCollectionSchemaRequest{
+				CollectionName: "ext_col",
+			})
+			assert.NoError(t, err)
+			assert.Error(t, merr.Error(resp.GetAlterStatus()))
+			assert.Contains(t, resp.GetAlterStatus().GetReason(), "external collection")
+		})
+	})
+
+	t.Run("schema version consistency check fails", func(t *testing.T) {
+		mockey.PatchConvey("consistency check fails", t, func() {
+			node := createTestProxy()
+			defer node.sched.Close()
+
+			mockey.Mock((*Proxy).DescribeCollection).Return(&milvuspb.DescribeCollectionResponse{
+				Status: merr.Success(),
+				Schema: &schemapb.CollectionSchema{Name: "test_coll"},
+			}, nil).Build()
+
+			mockey.Mock((*Proxy).checkSchemaVersionConsistency).Return(
+				merr.WrapErrParameterInvalidMsg("consistency check failed"),
+			).Build()
+
+			resp, err := node.AlterCollectionSchema(context.Background(), &milvuspb.AlterCollectionSchemaRequest{
+				CollectionName: "test_coll",
+			})
+			assert.NoError(t, err)
+			assert.Error(t, merr.Error(resp.GetAlterStatus()))
+		})
+	})
+}
+
+func TestCheckSchemaVersionConsistency(t *testing.T) {
+	t.Run("GetCollectionStatistics returns error", func(t *testing.T) {
+		mockey.PatchConvey("error from GetCollectionStatistics", t, func() {
+			node := createTestProxy()
+			defer node.sched.Close()
+
+			mockey.Mock((*Proxy).GetCollectionStatistics).To(
+				func(_ *Proxy, ctx context.Context, req *milvuspb.GetCollectionStatisticsRequest) (*milvuspb.GetCollectionStatisticsResponse, error) {
+					return nil, errors.New("rpc error")
+				}).Build()
+
+			err := node.checkSchemaVersionConsistency(context.Background(), "db", "coll")
+			assert.Error(t, err)
+		})
+	})
+
+	t.Run("GetCollectionStatistics returns RPC error status", func(t *testing.T) {
+		mockey.PatchConvey("rpc status error", t, func() {
+			node := createTestProxy()
+			defer node.sched.Close()
+
+			mockey.Mock((*Proxy).GetCollectionStatistics).To(
+				func(_ *Proxy, ctx context.Context, req *milvuspb.GetCollectionStatisticsRequest) (*milvuspb.GetCollectionStatisticsResponse, error) {
+					return &milvuspb.GetCollectionStatisticsResponse{
+						Status: merr.Status(merr.ErrCollectionNotFound),
+					}, nil
+				}).Build()
+
+			err := node.checkSchemaVersionConsistency(context.Background(), "db", "coll")
+			assert.Error(t, err)
+		})
+	})
+
+	t.Run("both keys absent returns nil", func(t *testing.T) {
+		mockey.PatchConvey("no keys present", t, func() {
+			node := createTestProxy()
+			defer node.sched.Close()
+
+			mockey.Mock((*Proxy).GetCollectionStatistics).To(
+				func(_ *Proxy, ctx context.Context, req *milvuspb.GetCollectionStatisticsRequest) (*milvuspb.GetCollectionStatisticsResponse, error) {
+					return &milvuspb.GetCollectionStatisticsResponse{
+						Status: merr.Success(),
+						Stats:  []*commonpb.KeyValuePair{},
+					}, nil
+				}).Build()
+
+			err := node.checkSchemaVersionConsistency(context.Background(), "db", "coll")
+			assert.NoError(t, err)
+		})
+	})
+
+	t.Run("only consistent key present total absent returns error", func(t *testing.T) {
+		mockey.PatchConvey("consistent only", t, func() {
+			node := createTestProxy()
+			defer node.sched.Close()
+
+			mockey.Mock((*Proxy).GetCollectionStatistics).To(
+				func(_ *Proxy, ctx context.Context, req *milvuspb.GetCollectionStatisticsRequest) (*milvuspb.GetCollectionStatisticsResponse, error) {
+					return &milvuspb.GetCollectionStatisticsResponse{
+						Status: merr.Success(),
+						Stats: []*commonpb.KeyValuePair{
+							{Key: common.SchemaVersionConsistentSegmentsKey, Value: "5"},
+						},
+					}, nil
+				}).Build()
+
+			err := node.checkSchemaVersionConsistency(context.Background(), "db", "coll")
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "incomplete schema version consistency stats")
+		})
+	})
+
+	t.Run("only total key present consistent absent returns error", func(t *testing.T) {
+		mockey.PatchConvey("total only", t, func() {
+			node := createTestProxy()
+			defer node.sched.Close()
+
+			mockey.Mock((*Proxy).GetCollectionStatistics).To(
+				func(_ *Proxy, ctx context.Context, req *milvuspb.GetCollectionStatisticsRequest) (*milvuspb.GetCollectionStatisticsResponse, error) {
+					return &milvuspb.GetCollectionStatisticsResponse{
+						Status: merr.Success(),
+						Stats: []*commonpb.KeyValuePair{
+							{Key: common.SchemaVersionTotalSegmentsKey, Value: "10"},
+						},
+					}, nil
+				}).Build()
+
+			err := node.checkSchemaVersionConsistency(context.Background(), "db", "coll")
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "incomplete schema version consistency stats")
+		})
+	})
+
+	t.Run("consistent less than total returns error with counts", func(t *testing.T) {
+		mockey.PatchConvey("consistent < total", t, func() {
+			node := createTestProxy()
+			defer node.sched.Close()
+
+			mockey.Mock((*Proxy).GetCollectionStatistics).To(
+				func(_ *Proxy, ctx context.Context, req *milvuspb.GetCollectionStatisticsRequest) (*milvuspb.GetCollectionStatisticsResponse, error) {
+					return &milvuspb.GetCollectionStatisticsResponse{
+						Status: merr.Success(),
+						Stats: []*commonpb.KeyValuePair{
+							{Key: common.SchemaVersionConsistentSegmentsKey, Value: "5"},
+							{Key: common.SchemaVersionTotalSegmentsKey, Value: "10"},
+						},
+					}, nil
+				}).Build()
+
+			err := node.checkSchemaVersionConsistency(context.Background(), "db", "coll")
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "5")
+			assert.Contains(t, err.Error(), "10")
+		})
+	})
+
+	t.Run("consistent equals total returns nil", func(t *testing.T) {
+		mockey.PatchConvey("consistent == total", t, func() {
+			node := createTestProxy()
+			defer node.sched.Close()
+
+			mockey.Mock((*Proxy).GetCollectionStatistics).To(
+				func(_ *Proxy, ctx context.Context, req *milvuspb.GetCollectionStatisticsRequest) (*milvuspb.GetCollectionStatisticsResponse, error) {
+					return &milvuspb.GetCollectionStatisticsResponse{
+						Status: merr.Success(),
+						Stats: []*commonpb.KeyValuePair{
+							{Key: common.SchemaVersionConsistentSegmentsKey, Value: "10"},
+							{Key: common.SchemaVersionTotalSegmentsKey, Value: "10"},
+						},
+					}, nil
+				}).Build()
+
+			err := node.checkSchemaVersionConsistency(context.Background(), "db", "coll")
+			assert.NoError(t, err)
+		})
+	})
+
+	t.Run("malformed consistent value returns parse error", func(t *testing.T) {
+		mockey.PatchConvey("bad consistent value", t, func() {
+			node := createTestProxy()
+			defer node.sched.Close()
+
+			mockey.Mock((*Proxy).GetCollectionStatistics).To(
+				func(_ *Proxy, ctx context.Context, req *milvuspb.GetCollectionStatisticsRequest) (*milvuspb.GetCollectionStatisticsResponse, error) {
+					return &milvuspb.GetCollectionStatisticsResponse{
+						Status: merr.Success(),
+						Stats: []*commonpb.KeyValuePair{
+							{Key: common.SchemaVersionConsistentSegmentsKey, Value: "not-a-number"},
+							{Key: common.SchemaVersionTotalSegmentsKey, Value: "10"},
+						},
+					}, nil
+				}).Build()
+
+			err := node.checkSchemaVersionConsistency(context.Background(), "db", "coll")
+			assert.Error(t, err)
+		})
+	})
+
+	t.Run("malformed total value returns parse error", func(t *testing.T) {
+		mockey.PatchConvey("bad total value", t, func() {
+			node := createTestProxy()
+			defer node.sched.Close()
+
+			mockey.Mock((*Proxy).GetCollectionStatistics).To(
+				func(_ *Proxy, ctx context.Context, req *milvuspb.GetCollectionStatisticsRequest) (*milvuspb.GetCollectionStatisticsResponse, error) {
+					return &milvuspb.GetCollectionStatisticsResponse{
+						Status: merr.Success(),
+						Stats: []*commonpb.KeyValuePair{
+							{Key: common.SchemaVersionConsistentSegmentsKey, Value: "5"},
+							{Key: common.SchemaVersionTotalSegmentsKey, Value: "bad-value"},
+						},
+					}, nil
+				}).Build()
+
+			err := node.checkSchemaVersionConsistency(context.Background(), "db", "coll")
+			assert.Error(t, err)
+		})
+	})
+}

--- a/internal/proxy/service_provider.go
+++ b/internal/proxy/service_provider.go
@@ -213,6 +213,8 @@ func (node *CachedProxyServiceProvider) DescribeCollection(ctx context.Context,
 		DbName:             c.schema.CollectionSchema.DbName,
 		ExternalSource:     c.schema.CollectionSchema.ExternalSource,
 		ExternalSpec:       c.schema.CollectionSchema.ExternalSpec,
+		Version:            c.schema.CollectionSchema.Version,
+		DoPhysicalBackfill: c.schema.CollectionSchema.DoPhysicalBackfill,
 	}
 
 	// Restore struct field names from internal format (structName[fieldName]) to original format
@@ -239,12 +241,10 @@ func (node *CachedProxyServiceProvider) DescribeCollection(ctx context.Context,
 	resp.ShardsNum = c.shardsNum
 	resp.Aliases = c.aliases
 	resp.Properties = c.properties
-
 	log.Debug("DescribeCollection done",
 		zap.Int64("collectionID", resp.GetCollectionID()),
 		zap.Any("schema", resp.GetSchema()),
 	)
-
 	return resp, nil
 }
 

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -129,7 +129,8 @@ const (
 	AlterDatabaseTaskName    = "AlterDatabaseTaskName"
 	DescribeDatabaseTaskName = "DescribeDatabaseTaskName"
 
-	AddFieldTaskName = "AddFieldTaskName"
+	AddFieldTaskName              = "AddFieldTaskName"
+	AlterCollectionSchemaTaskName = "AlterCollectionSchemaTaskName"
 
 	// minFloat32 minimum float.
 	minFloat32 = -1 * float32(math.MaxFloat32)
@@ -592,6 +593,76 @@ func (t *createCollectionTask) PostExecute(ctx context.Context) error {
 	return nil
 }
 
+// validateAddFieldRequest validates both the old schema constraints and the new field properties
+// for an AddCollectionField request. It is the single source of truth for add-field validation.
+func validateAddFieldRequest(schema *schemapb.CollectionSchema, newFieldSchema *schemapb.FieldSchema) error {
+	// --- old schema constraints ---
+	fieldList := typeutil.NewSet[string]()
+	for _, f := range schema.Fields {
+		fieldList.Insert(f.Name)
+	}
+	if len(fieldList) >= Params.ProxyCfg.MaxFieldNum.GetAsInt() {
+		msg := fmt.Sprintf("The number of fields has reached the maximum value %d", Params.ProxyCfg.MaxFieldNum.GetAsInt())
+		return merr.WrapErrParameterInvalidMsg(msg)
+	}
+	if fieldList.Contain(newFieldSchema.GetName()) {
+		return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("duplicated field name %s", newFieldSchema.GetName()))
+	}
+
+	// --- new field property constraints ---
+	if _, ok := schemapb.DataType_name[int32(newFieldSchema.GetDataType())]; !ok || newFieldSchema.GetDataType() == schemapb.DataType_None {
+		return merr.WrapErrParameterInvalid("valid field", fmt.Sprintf("field data type: %s is not supported", newFieldSchema.GetDataType()))
+	}
+	if funcutil.SliceContain([]string{common.RowIDFieldName, common.TimeStampFieldName, common.MetaFieldName, common.NamespaceFieldName}, newFieldSchema.GetName()) {
+		return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("not support to add system field, field name = %s", newFieldSchema.GetName()))
+	}
+	if newFieldSchema.GetIsPrimaryKey() {
+		return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("not support to add pk field, field name = %s", newFieldSchema.GetName()))
+	}
+	if newFieldSchema.GetAutoID() {
+		return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("only primary field can speficy AutoID with true, field name = %s", newFieldSchema.GetName()))
+	}
+	if newFieldSchema.GetIsPartitionKey() {
+		return merr.WrapErrParameterInvalidMsg("not support to add partition key field, field name  = %s", newFieldSchema.GetName())
+	}
+	if newFieldSchema.GetIsClusteringKey() {
+		if !typeutil.IsClusteringKeyType(newFieldSchema.GetDataType()) {
+			return merr.WrapErrParameterInvalidMsg(
+				fmt.Sprintf("clustering key field %s has unsupported data type %s",
+					newFieldSchema.GetName(), newFieldSchema.GetDataType().String()))
+		}
+		for _, f := range schema.GetFields() {
+			if f.GetIsClusteringKey() {
+				return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("already has another clustering key field, field name: %s", newFieldSchema.GetName()))
+			}
+		}
+	}
+	if typeutil.IsVectorType(newFieldSchema.DataType) {
+		vectorFields := len(typeutil.GetVectorFieldSchemas(schema))
+		if vectorFields >= Params.ProxyCfg.MaxVectorFieldNum.GetAsInt() {
+			return merr.WrapErrParameterInvalidMsg("maximum vector field's number should be limited to %d", Params.ProxyCfg.MaxVectorFieldNum.GetAsInt())
+		}
+	}
+
+	// NOTE: The nullable requirement for added fields is enforced by callers that deal with
+	// user-defined fields (e.g. addCollectionFieldTask). Function output fields managed by
+	// alterCollectionSchemaTask are explicitly prohibited from being nullable by validateFunction,
+	// so the check is intentionally left to callers rather than enforced here universally.
+	// Dense vector fields require a dimension type param.
+	if typeutil.IsVectorType(newFieldSchema.DataType) {
+		if newFieldSchema.DataType == schemapb.DataType_FloatVector ||
+			newFieldSchema.DataType == schemapb.DataType_Float16Vector ||
+			newFieldSchema.DataType == schemapb.DataType_BFloat16Vector ||
+			newFieldSchema.DataType == schemapb.DataType_BinaryVector ||
+			newFieldSchema.DataType == schemapb.DataType_Int8Vector {
+			if len(newFieldSchema.TypeParams) == 0 {
+				return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("vector field must have dimension specified, field name = %s", newFieldSchema.GetName()))
+			}
+		}
+	}
+	return nil
+}
+
 type addCollectionFieldTask struct {
 	baseTask
 	Condition
@@ -650,76 +721,20 @@ func (t *addCollectionFieldTask) PreExecute(ctx context.Context) error {
 	}
 
 	t.fieldSchema = &schemapb.FieldSchema{}
-	err := proto.Unmarshal(t.GetSchema(), t.fieldSchema)
-	if err != nil {
+	if err := proto.Unmarshal(t.GetSchema(), t.fieldSchema); err != nil {
 		return err
 	}
-	fieldList := typeutil.NewSet[string]()
-	for _, schema := range t.oldSchema.Fields {
-		fieldList.Insert(schema.Name)
+	if err := validateAddFieldRequest(t.oldSchema, t.fieldSchema); err != nil {
+		return err
 	}
-
-	if len(fieldList) >= Params.ProxyCfg.MaxFieldNum.GetAsInt() {
-		msg := fmt.Sprintf("The number of fields has reached the maximum value %d", Params.ProxyCfg.MaxFieldNum.GetAsInt())
-		return merr.WrapErrParameterInvalidMsg(msg)
-	}
-
-	if typeutil.IsVectorType(t.fieldSchema.DataType) {
-		vectorFields := len(typeutil.GetVectorFieldSchemas(t.oldSchema))
-		if vectorFields >= Params.ProxyCfg.MaxVectorFieldNum.GetAsInt() {
-			return fmt.Errorf("maximum vector field's number should be limited to %d", Params.ProxyCfg.MaxVectorFieldNum.GetAsInt())
-		}
-	}
-
-	if _, ok := schemapb.DataType_name[int32(t.fieldSchema.DataType)]; !ok || t.fieldSchema.GetDataType() == schemapb.DataType_None {
-		return merr.WrapErrParameterInvalid("valid field", fmt.Sprintf("field data type: %s is not supported", t.fieldSchema.GetDataType()))
-	}
-
-	if funcutil.SliceContain([]string{common.RowIDFieldName, common.TimeStampFieldName, common.MetaFieldName, common.NamespaceFieldName}, t.fieldSchema.GetName()) {
-		return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("not support to add system field, field name = %s", t.fieldSchema.Name))
-	}
-	if t.fieldSchema.IsPrimaryKey {
-		return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("not support to add pk field, field name = %s", t.fieldSchema.Name))
-	}
-	if !t.fieldSchema.Nullable {
-		return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("added field must be nullable, please check it, field name = %s", t.fieldSchema.Name))
-	}
-	if typeutil.IsVectorType(t.fieldSchema.DataType) && t.fieldSchema.Nullable {
-		if t.fieldSchema.DataType == schemapb.DataType_FloatVector ||
-			t.fieldSchema.DataType == schemapb.DataType_Float16Vector ||
-			t.fieldSchema.DataType == schemapb.DataType_BFloat16Vector ||
-			t.fieldSchema.DataType == schemapb.DataType_BinaryVector ||
-			t.fieldSchema.DataType == schemapb.DataType_Int8Vector {
-			if len(t.fieldSchema.TypeParams) == 0 {
-				return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("vector field must have dimension specified, field name = %s", t.fieldSchema.Name))
-			}
-		}
-	}
-	if t.fieldSchema.AutoID {
-		return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("only primary field can speficy AutoID with true, field name = %s", t.fieldSchema.Name))
-	}
-	if t.fieldSchema.IsPartitionKey {
-		return merr.WrapErrParameterInvalidMsg("not support to add partition key field, field name  = %s", t.fieldSchema.Name)
-	}
-	if t.fieldSchema.GetIsClusteringKey() {
-		if !typeutil.IsClusteringKeyType(t.fieldSchema.GetDataType()) {
-			return merr.WrapErrParameterInvalidMsg(
-				fmt.Sprintf("clustering key field %s has unsupported data type %s",
-					t.fieldSchema.GetName(), t.fieldSchema.GetDataType().String()))
-		}
-		for _, f := range t.oldSchema.Fields {
-			if f.GetIsClusteringKey() {
-				return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("already has another clutering key field, field name: %s", t.fieldSchema.GetName()))
-			}
-		}
+	// User-added fields must be nullable so that old segments without this field can return
+	// NULL rather than causing a schema inconsistency at query time.
+	if !t.fieldSchema.GetNullable() {
+		return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("added field must be nullable, please check it, field name = %s", t.fieldSchema.GetName()))
 	}
 	if err := ValidateField(t.fieldSchema, t.oldSchema); err != nil {
 		return err
 	}
-	if fieldList.Contain(t.fieldSchema.Name) {
-		return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("duplicate field name: %s", t.fieldSchema.GetName()))
-	}
-
 	log.Info("PreExecute addField task done", zap.Any("field schema", t.fieldSchema))
 	return nil
 }
@@ -731,6 +746,135 @@ func (t *addCollectionFieldTask) Execute(ctx context.Context) error {
 }
 
 func (t *addCollectionFieldTask) PostExecute(ctx context.Context) error {
+	return nil
+}
+
+type alterCollectionSchemaTask struct {
+	baseTask
+	Condition
+	*milvuspb.AlterCollectionSchemaRequest
+	*milvuspb.AlterCollectionSchemaResponse
+	ctx       context.Context
+	mixCoord  types.MixCoordClient
+	oldSchema *schemapb.CollectionSchema
+}
+
+func (t *alterCollectionSchemaTask) TraceCtx() context.Context {
+	return t.ctx
+}
+
+func (t *alterCollectionSchemaTask) ID() UniqueID {
+	return t.Base.MsgID
+}
+
+func (t *alterCollectionSchemaTask) SetID(uid UniqueID) {
+	t.Base.MsgID = uid
+}
+
+func (t *alterCollectionSchemaTask) Name() string {
+	return AlterCollectionSchemaTaskName
+}
+
+func (t *alterCollectionSchemaTask) Type() commonpb.MsgType {
+	return t.Base.MsgType
+}
+
+func (t *alterCollectionSchemaTask) BeginTs() Timestamp {
+	return t.Base.Timestamp
+}
+
+func (t *alterCollectionSchemaTask) EndTs() Timestamp {
+	return t.Base.Timestamp
+}
+
+func (t *alterCollectionSchemaTask) SetTs(ts Timestamp) {
+	t.Base.Timestamp = ts
+}
+
+func (t *alterCollectionSchemaTask) OnEnqueue() error {
+	if t.Base == nil {
+		t.Base = commonpbutil.NewMsgBase()
+	}
+	t.Base.MsgType = commonpb.MsgType_AlterCollectionSchema
+	t.Base.SourceID = paramtable.GetNodeID()
+	return nil
+}
+
+func (t *alterCollectionSchemaTask) PreExecute(ctx context.Context) error {
+	if t.oldSchema == nil {
+		return merr.WrapErrParameterInvalidMsg("empty old schema in alter collection schema task")
+	}
+
+	action := t.AlterCollectionSchemaRequest.GetAction()
+	if action == nil {
+		return merr.WrapErrParameterInvalidMsg("action is nil in alter schema task")
+	}
+	addRequest := action.GetAddRequest()
+	if addRequest == nil {
+		return merr.WrapErrParameterInvalidMsg("add_request is nil, only add operation is supported for now")
+	}
+
+	fieldInfos := addRequest.GetFieldInfos()
+	funcSchemas := addRequest.GetFuncSchema()
+
+	// AlterCollectionSchema currently only supports adding exactly one function with its output fields.
+	// RootCoord enforces the same constraint (ddl_callbacks_alter_collection_schema.go);
+	// validate early at Proxy to give clearer error messages.
+	if len(funcSchemas) != 1 || funcSchemas[0] == nil {
+		return merr.WrapErrParameterInvalidMsg("For now, exactly one function schema is required in alter schema task")
+	}
+	if len(fieldInfos) == 0 {
+		return merr.WrapErrParameterInvalidMsg("fieldInfos is empty, function output fields are required")
+	}
+
+	if len(fieldInfos) != 1 {
+		return merr.WrapErrParameterInvalidMsg("For now, only one field info is supported in alter schema task")
+	}
+	newFieldSchema := fieldInfos[0].GetFieldSchema()
+	if newFieldSchema == nil {
+		return merr.WrapErrParameterInvalidMsg("empty new field schema in alter schema task")
+	}
+	if err := validateAddFieldRequest(t.oldSchema, newFieldSchema); err != nil {
+		return err
+	}
+	if err := ValidateField(newFieldSchema, t.oldSchema); err != nil {
+		return err
+	}
+
+	// Validate function-field type compatibility (e.g., BM25 requires varchar input,
+	// SparseFloatVector output). Construct a merged schema with old fields + new fields
+	// + new function, then validate only the new function to avoid re-checking existing
+	// functions' runtime providers.
+	mergedSchema := proto.Clone(t.oldSchema).(*schemapb.CollectionSchema)
+	for _, fieldInfo := range fieldInfos {
+		mergedSchema.Fields = append(mergedSchema.Fields, fieldInfo.GetFieldSchema())
+	}
+	mergedSchema.Functions = append(mergedSchema.Functions, funcSchemas[0])
+	if err := validateFunction(mergedSchema, funcSchemas[0].GetName(), false); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (t *alterCollectionSchemaTask) Execute(ctx context.Context) error {
+	action := t.AlterCollectionSchemaRequest.GetAction()
+	if action != nil {
+		addRequest := action.GetAddRequest()
+		if addRequest != nil {
+			for _, fieldInfo := range addRequest.GetFieldInfos() {
+				if fieldInfo != nil && fieldInfo.GetFieldSchema() != nil {
+					fieldInfo.GetFieldSchema().IsFunctionOutput = true
+				}
+			}
+		}
+	}
+	var err error
+	t.AlterCollectionSchemaResponse, err = t.mixCoord.AlterCollectionSchema(ctx, t.AlterCollectionSchemaRequest)
+	return merr.CheckRPCCall(t.AlterCollectionSchemaResponse.GetAlterStatus(), err)
+}
+
+func (t *alterCollectionSchemaTask) PostExecute(ctx context.Context) error {
 	return nil
 }
 

--- a/internal/proxy/task_insert_streaming.go
+++ b/internal/proxy/task_insert_streaming.go
@@ -20,6 +20,11 @@ import (
 )
 
 // we only overwrite the Execute function
+// TODO: InsertMessageHeader does not carry SchemaVersion, which means the consistency gate
+// in StreamingNode cannot tell whether an insert was produced before or after a schema change.
+// This can cause a deadlock when the gate waits for inserts at the new schema version that
+// will never arrive. The companion PR https://github.com/milvus-io/milvus/pull/48139
+// resolves this by propagating SchemaVersion through the insert path.
 func (it *insertTask) Execute(ctx context.Context) error {
 	ctx, sp := otel.Tracer(typeutil.ProxyRole).Start(ctx, "Proxy-Insert-Execute")
 	defer sp.End()

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -6674,3 +6674,443 @@ func TestHasPropInDeletekeys(t *testing.T) {
 		assert.Equal(t, "", hasPropInDeletekeys([]string{}))
 	})
 }
+
+func TestValidateAddFieldRequest(t *testing.T) {
+	// Build a base schema with one int64 PK and one float vector field.
+	baseSchema := func() *schemapb.CollectionSchema {
+		return &schemapb.CollectionSchema{
+			Name: "test_coll",
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+				{
+					FieldID: 101, Name: "vec", DataType: schemapb.DataType_FloatVector,
+					TypeParams: []*commonpb.KeyValuePair{{Key: "dim", Value: "128"}},
+				},
+			},
+		}
+	}
+
+	t.Run("happy path", func(t *testing.T) {
+		schema := baseSchema()
+		newField := &schemapb.FieldSchema{
+			Name:     "new_field",
+			DataType: schemapb.DataType_Int64,
+			Nullable: true,
+		}
+		err := validateAddFieldRequest(schema, newField)
+		assert.NoError(t, err)
+	})
+
+	t.Run("field count exceeds MaxFieldNum", func(t *testing.T) {
+		schema := baseSchema()
+		// Build exactly MaxFieldNum fields so that the check triggers.
+		maxFieldNum := Params.ProxyCfg.MaxFieldNum.GetAsInt()
+		for i := len(schema.Fields); i < maxFieldNum; i++ {
+			schema.Fields = append(schema.Fields, &schemapb.FieldSchema{
+				FieldID:  int64(200 + i),
+				Name:     fmt.Sprintf("field_%d", i),
+				DataType: schemapb.DataType_Int64,
+			})
+		}
+		newField := &schemapb.FieldSchema{
+			Name:     "overflow_field",
+			DataType: schemapb.DataType_Int64,
+		}
+		err := validateAddFieldRequest(schema, newField)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("duplicate field name", func(t *testing.T) {
+		schema := baseSchema()
+		newField := &schemapb.FieldSchema{
+			Name:     "vec", // already exists
+			DataType: schemapb.DataType_Int64,
+		}
+		err := validateAddFieldRequest(schema, newField)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("invalid DataType_None", func(t *testing.T) {
+		schema := baseSchema()
+		newField := &schemapb.FieldSchema{
+			Name:     "invalid_type_field",
+			DataType: schemapb.DataType_None,
+		}
+		err := validateAddFieldRequest(schema, newField)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("system field name RowID", func(t *testing.T) {
+		schema := baseSchema()
+		newField := &schemapb.FieldSchema{
+			Name:     "RowID",
+			DataType: schemapb.DataType_Int64,
+		}
+		err := validateAddFieldRequest(schema, newField)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("is_primary_key = true", func(t *testing.T) {
+		schema := baseSchema()
+		newField := &schemapb.FieldSchema{
+			Name:         "new_pk",
+			DataType:     schemapb.DataType_Int64,
+			IsPrimaryKey: true,
+		}
+		err := validateAddFieldRequest(schema, newField)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("auto_id = true", func(t *testing.T) {
+		schema := baseSchema()
+		newField := &schemapb.FieldSchema{
+			Name:     "auto_field",
+			DataType: schemapb.DataType_Int64,
+			AutoID:   true,
+		}
+		err := validateAddFieldRequest(schema, newField)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("is_partition_key = true", func(t *testing.T) {
+		schema := baseSchema()
+		newField := &schemapb.FieldSchema{
+			Name:           "part_key",
+			DataType:       schemapb.DataType_Int64,
+			IsPartitionKey: true,
+		}
+		err := validateAddFieldRequest(schema, newField)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("clustering key when schema already has one", func(t *testing.T) {
+		schema := baseSchema()
+		// Mark an existing field as clustering key.
+		schema.Fields[0].IsClusteringKey = true
+		newField := &schemapb.FieldSchema{
+			Name:            "new_cluster",
+			DataType:        schemapb.DataType_Int64,
+			IsClusteringKey: true,
+		}
+		err := validateAddFieldRequest(schema, newField)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("vector type with max vector fields exceeded", func(t *testing.T) {
+		schema := baseSchema()
+		// Fill up vector fields to MaxVectorFieldNum.
+		maxVecFieldNum := Params.ProxyCfg.MaxVectorFieldNum.GetAsInt()
+		// schema already has one FloatVector; add more to reach the limit.
+		for i := 1; i < maxVecFieldNum; i++ {
+			schema.Fields = append(schema.Fields, &schemapb.FieldSchema{
+				FieldID:  int64(300 + i),
+				Name:     fmt.Sprintf("vec_%d", i),
+				DataType: schemapb.DataType_FloatVector,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: "dim", Value: "128"},
+				},
+			})
+		}
+		newVecField := &schemapb.FieldSchema{
+			Name:     "extra_vec",
+			DataType: schemapb.DataType_FloatVector,
+			TypeParams: []*commonpb.KeyValuePair{
+				{Key: "dim", Value: "128"},
+			},
+		}
+		err := validateAddFieldRequest(schema, newVecField)
+		assert.Error(t, err)
+	})
+}
+
+func TestAlterCollectionSchemaTask(t *testing.T) {
+	rc := NewMixCoordMock()
+	ctx := context.Background()
+	prefix := "TestAlterCollectionSchemaTask"
+	dbName := ""
+	collectionName := prefix + funcutil.GenRandomStr()
+	collectionID := int64(1)
+
+	rc.collName2ID[collectionName] = collectionID
+	rc.collID2Meta[collectionID] = collectionMeta{
+		name: collectionName,
+		id:   collectionID,
+		schema: &schemapb.CollectionSchema{
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, DataType: schemapb.DataType_Int64, AutoID: true, Name: "ID", IsPrimaryKey: true},
+				{
+					FieldID: 101, DataType: schemapb.DataType_VarChar, Name: "text",
+					TypeParams: []*commonpb.KeyValuePair{
+						{Key: "max_length", Value: "65535"},
+					},
+				},
+			},
+		},
+	}
+
+	// oldSchema matches the collection: has a varchar field "text" used as BM25 input.
+	oldSchema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, DataType: schemapb.DataType_Int64, AutoID: true, Name: "ID", IsPrimaryKey: true},
+			{
+				FieldID: 101, DataType: schemapb.DataType_VarChar, Name: "text",
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: "max_length", Value: "65535"},
+					{Key: "enable_analyzer", Value: "true"},
+				},
+			},
+		},
+	}
+
+	// sparseOutputField is the output field for the BM25 function.
+	sparseOutputField := &schemapb.FieldSchema{
+		Name:     "sparse_bm25",
+		DataType: schemapb.DataType_SparseFloatVector,
+	}
+
+	// BM25 function schema: input "text", output "sparse_bm25".
+	functionSchema := &schemapb.FunctionSchema{
+		Name:             "bm25_func",
+		Type:             schemapb.FunctionType_BM25,
+		InputFieldNames:  []string{"text"},
+		OutputFieldNames: []string{"sparse_bm25"},
+	}
+
+	buildValidRequest := func() *milvuspb.AlterCollectionSchemaRequest {
+		return &milvuspb.AlterCollectionSchemaRequest{
+			DbName:         dbName,
+			CollectionName: collectionName,
+			Action: &milvuspb.AlterCollectionSchemaRequest_Action{
+				Op: &milvuspb.AlterCollectionSchemaRequest_Action_AddRequest{
+					AddRequest: &milvuspb.AlterCollectionSchemaRequest_AddRequest{
+						FieldInfos: []*milvuspb.AlterCollectionSchemaRequest_FieldInfo{
+							{FieldSchema: sparseOutputField},
+						},
+						FuncSchema: []*schemapb.FunctionSchema{functionSchema},
+					},
+				},
+			},
+		}
+	}
+
+	buildTask := func(req *milvuspb.AlterCollectionSchemaRequest, schema *schemapb.CollectionSchema) *alterCollectionSchemaTask {
+		return &alterCollectionSchemaTask{
+			Condition:                     NewTaskCondition(ctx),
+			AlterCollectionSchemaRequest:  req,
+			AlterCollectionSchemaResponse: nil,
+			ctx:                           ctx,
+			mixCoord:                      rc,
+			oldSchema:                     schema,
+		}
+	}
+
+	t.Run("OnEnqueue", func(t *testing.T) {
+		task := buildTask(buildValidRequest(), oldSchema)
+		err := task.OnEnqueue()
+		assert.NoError(t, err)
+		assert.Equal(t, commonpb.MsgType_AlterCollectionSchema, task.Type())
+	})
+
+	t.Run("ctx", func(t *testing.T) {
+		task := buildTask(buildValidRequest(), oldSchema)
+		assert.NotNil(t, task.TraceCtx())
+	})
+
+	t.Run("id", func(t *testing.T) {
+		task := buildTask(buildValidRequest(), oldSchema)
+		_ = task.OnEnqueue()
+		id := UniqueID(uniquegenerator.GetUniqueIntGeneratorIns().GetInt())
+		task.SetID(id)
+		assert.Equal(t, id, task.ID())
+	})
+
+	t.Run("name", func(t *testing.T) {
+		task := buildTask(buildValidRequest(), oldSchema)
+		assert.Equal(t, AlterCollectionSchemaTaskName, task.Name())
+	})
+
+	t.Run("ts", func(t *testing.T) {
+		task := buildTask(buildValidRequest(), oldSchema)
+		_ = task.OnEnqueue()
+		ts := Timestamp(time.Now().UnixNano())
+		task.SetTs(ts)
+		assert.Equal(t, ts, task.BeginTs())
+		assert.Equal(t, ts, task.EndTs())
+	})
+
+	t.Run("PostExecute", func(t *testing.T) {
+		task := buildTask(buildValidRequest(), oldSchema)
+		assert.NoError(t, task.PostExecute(ctx))
+	})
+
+	t.Run("PreExecute nil oldSchema", func(t *testing.T) {
+		task := buildTask(buildValidRequest(), nil)
+		err := task.PreExecute(ctx)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("PreExecute nil action", func(t *testing.T) {
+		req := &milvuspb.AlterCollectionSchemaRequest{
+			DbName:         dbName,
+			CollectionName: collectionName,
+			Action:         nil,
+		}
+		task := buildTask(req, oldSchema)
+		err := task.PreExecute(ctx)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("PreExecute nil addRequest", func(t *testing.T) {
+		// Action is set but Op is not AddRequest (use nil oneof).
+		req := &milvuspb.AlterCollectionSchemaRequest{
+			DbName:         dbName,
+			CollectionName: collectionName,
+			Action:         &milvuspb.AlterCollectionSchemaRequest_Action{
+				// Op is nil — GetAddRequest() returns nil.
+			},
+		}
+		task := buildTask(req, oldSchema)
+		err := task.PreExecute(ctx)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("PreExecute zero funcSchemas", func(t *testing.T) {
+		req := &milvuspb.AlterCollectionSchemaRequest{
+			DbName:         dbName,
+			CollectionName: collectionName,
+			Action: &milvuspb.AlterCollectionSchemaRequest_Action{
+				Op: &milvuspb.AlterCollectionSchemaRequest_Action_AddRequest{
+					AddRequest: &milvuspb.AlterCollectionSchemaRequest_AddRequest{
+						FieldInfos: []*milvuspb.AlterCollectionSchemaRequest_FieldInfo{
+							{FieldSchema: sparseOutputField},
+						},
+						FuncSchema: nil, // no functions
+					},
+				},
+			},
+		}
+		task := buildTask(req, oldSchema)
+		err := task.PreExecute(ctx)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("PreExecute multiple funcSchemas", func(t *testing.T) {
+		req := &milvuspb.AlterCollectionSchemaRequest{
+			DbName:         dbName,
+			CollectionName: collectionName,
+			Action: &milvuspb.AlterCollectionSchemaRequest_Action{
+				Op: &milvuspb.AlterCollectionSchemaRequest_Action_AddRequest{
+					AddRequest: &milvuspb.AlterCollectionSchemaRequest_AddRequest{
+						FieldInfos: []*milvuspb.AlterCollectionSchemaRequest_FieldInfo{
+							{FieldSchema: sparseOutputField},
+						},
+						FuncSchema: []*schemapb.FunctionSchema{functionSchema, functionSchema}, // two functions
+					},
+				},
+			},
+		}
+		task := buildTask(req, oldSchema)
+		err := task.PreExecute(ctx)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("PreExecute empty fieldInfos", func(t *testing.T) {
+		req := &milvuspb.AlterCollectionSchemaRequest{
+			DbName:         dbName,
+			CollectionName: collectionName,
+			Action: &milvuspb.AlterCollectionSchemaRequest_Action{
+				Op: &milvuspb.AlterCollectionSchemaRequest_Action_AddRequest{
+					AddRequest: &milvuspb.AlterCollectionSchemaRequest_AddRequest{
+						FieldInfos: nil, // empty
+						FuncSchema: []*schemapb.FunctionSchema{functionSchema},
+					},
+				},
+			},
+		}
+		task := buildTask(req, oldSchema)
+		err := task.PreExecute(ctx)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("PreExecute multiple fieldInfos", func(t *testing.T) {
+		req := &milvuspb.AlterCollectionSchemaRequest{
+			DbName:         dbName,
+			CollectionName: collectionName,
+			Action: &milvuspb.AlterCollectionSchemaRequest_Action{
+				Op: &milvuspb.AlterCollectionSchemaRequest_Action_AddRequest{
+					AddRequest: &milvuspb.AlterCollectionSchemaRequest_AddRequest{
+						FieldInfos: []*milvuspb.AlterCollectionSchemaRequest_FieldInfo{
+							{FieldSchema: sparseOutputField},
+							{FieldSchema: &schemapb.FieldSchema{Name: "extra", DataType: schemapb.DataType_Int64}},
+						},
+						FuncSchema: []*schemapb.FunctionSchema{functionSchema},
+					},
+				},
+			},
+		}
+		task := buildTask(req, oldSchema)
+		err := task.PreExecute(ctx)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("PreExecute nil fieldSchema in fieldInfo", func(t *testing.T) {
+		req := &milvuspb.AlterCollectionSchemaRequest{
+			DbName:         dbName,
+			CollectionName: collectionName,
+			Action: &milvuspb.AlterCollectionSchemaRequest_Action{
+				Op: &milvuspb.AlterCollectionSchemaRequest_Action_AddRequest{
+					AddRequest: &milvuspb.AlterCollectionSchemaRequest_AddRequest{
+						FieldInfos: []*milvuspb.AlterCollectionSchemaRequest_FieldInfo{
+							{FieldSchema: nil}, // nil inner schema
+						},
+						FuncSchema: []*schemapb.FunctionSchema{functionSchema},
+					},
+				},
+			},
+		}
+		task := buildTask(req, oldSchema)
+		err := task.PreExecute(ctx)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("PreExecute happy path", func(t *testing.T) {
+		task := buildTask(buildValidRequest(), oldSchema)
+		err := task.PreExecute(ctx)
+		assert.NoError(t, err)
+	})
+
+	t.Run("Execute sets IsFunctionOutput and calls AlterCollectionSchema", func(t *testing.T) {
+		req := buildValidRequest()
+		task := buildTask(req, oldSchema)
+
+		// Ensure PreExecute passes first.
+		err := task.PreExecute(ctx)
+		assert.NoError(t, err)
+
+		err = task.Execute(ctx)
+		assert.NoError(t, err)
+
+		// After Execute, the output field should have IsFunctionOutput = true.
+		addReq := req.GetAction().GetAddRequest()
+		assert.NotNil(t, addReq)
+		for _, fi := range addReq.GetFieldInfos() {
+			assert.True(t, fi.GetFieldSchema().GetIsFunctionOutput())
+		}
+	})
+}

--- a/internal/rootcoord/ddl_callbacks_alter_collection_schema.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_schema.go
@@ -1,0 +1,204 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rootcoord
+
+import (
+	"context"
+
+	"github.com/cockroachdb/errors"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/distributed/streaming"
+	"github.com/milvus-io/milvus/internal/metastore/model"
+	"github.com/milvus-io/milvus/pkg/v2/proto/messagespb"
+	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
+)
+
+// broadcastAlterCollectionSchema broadcasts the alter collection schema message to all channels.
+func (c *Core) broadcastAlterCollectionSchema(ctx context.Context, req *milvuspb.AlterCollectionSchemaRequest) error {
+	broadcaster, err := c.startBroadcastWithAliasOrCollectionLock(ctx, req.GetDbName(), req.GetCollectionName())
+	if err != nil {
+		return err
+	}
+	defer broadcaster.Close()
+	coll, err := c.meta.GetCollectionByName(ctx, req.GetDbName(), req.GetCollectionName(), typeutil.MaxTimestamp)
+	if err != nil {
+		return err
+	}
+
+	// 1. check if the request is valid.
+	action := req.GetAction()
+	if action == nil {
+		return merr.WrapErrParameterInvalidMsg("action is nil")
+	}
+	addRequest := action.GetAddRequest()
+	if addRequest == nil {
+		return merr.WrapErrParameterInvalidMsg("add_request is nil, only add operation is supported for now")
+	}
+
+	fieldInfos := addRequest.GetFieldInfos()
+	funcSchemas := addRequest.GetFuncSchema()
+	if len(funcSchemas) != 1 || funcSchemas[0] == nil {
+		return merr.WrapErrParameterInvalidMsg("For now, exactly one function schema is supported in alter schema task")
+	}
+	functionSchema := funcSchemas[0]
+
+	if len(fieldInfos) != 1 {
+		return merr.WrapErrParameterInvalidMsg("exactly one field info is required in alter schema task, got %d", len(fieldInfos))
+	}
+
+	// 2. check if the field schemas are illegal.
+	fieldSchemas := make([]*schemapb.FieldSchema, 0, len(fieldInfos))
+	for _, fieldInfo := range fieldInfos {
+		fieldSchema := fieldInfo.GetFieldSchema()
+		if fieldSchema == nil {
+			return merr.WrapErrParameterInvalidMsg("fieldSchema is nil in fieldInfos")
+		}
+		fieldSchemas = append(fieldSchemas, fieldSchema)
+	}
+	if err := checkFieldSchema(fieldSchemas); err != nil {
+		return errors.Wrap(err, "failed to check field schema")
+	}
+
+	// 3. check if the fields already exist
+	fieldNameSet := make(map[string]struct{})
+	for _, field := range coll.Fields {
+		fieldNameSet[field.Name] = struct{}{}
+	}
+	for _, structField := range coll.StructArrayFields {
+		fieldNameSet[structField.Name] = struct{}{}
+		for _, subField := range structField.Fields {
+			fieldNameSet[subField.Name] = struct{}{}
+		}
+	}
+	for _, fieldSchema := range fieldSchemas {
+		if _, ok := fieldNameSet[fieldSchema.Name]; ok {
+			return merr.WrapErrParameterInvalidMsg("field already exists, name: %s", fieldSchema.Name)
+		}
+		fieldNameSet[fieldSchema.Name] = struct{}{}
+	}
+
+	// 4. check if the function already exists
+	for _, function := range coll.Functions {
+		if function.Name == functionSchema.GetName() {
+			return merr.WrapErrParameterInvalidMsg("function already exists, name: %s", functionSchema.GetName())
+		}
+	}
+
+	// 5. assign new field and function ids.
+	fieldIDStart := nextFieldID(coll)
+	for i, fieldSchema := range fieldSchemas {
+		fieldSchema.FieldID = fieldIDStart + int64(i)
+	}
+	functionSchema.Id = nextFunctionID(coll)
+	name2id := make(map[string]int64)
+	for _, field := range coll.Fields {
+		name2id[field.Name] = field.FieldID
+	}
+	for _, structField := range coll.StructArrayFields {
+		name2id[structField.Name] = structField.FieldID
+		for _, subField := range structField.Fields {
+			name2id[subField.Name] = subField.FieldID
+		}
+	}
+	for _, fieldSchema := range fieldSchemas {
+		name2id[fieldSchema.Name] = fieldSchema.FieldID
+	}
+
+	functionSchema.InputFieldIds = make([]int64, len(functionSchema.InputFieldNames))
+	for idx, name := range functionSchema.InputFieldNames {
+		fieldID, ok := name2id[name]
+		if !ok {
+			return merr.WrapErrParameterInvalidMsg("input field %s of function %s not found", name, functionSchema.GetName())
+		}
+		functionSchema.InputFieldIds[idx] = fieldID
+	}
+
+	outputFieldNameSet := make(map[string]struct{}, len(functionSchema.OutputFieldNames))
+	functionSchema.OutputFieldIds = make([]int64, len(functionSchema.OutputFieldNames))
+	for idx, name := range functionSchema.OutputFieldNames {
+		fieldID, ok := name2id[name]
+		if !ok {
+			return merr.WrapErrParameterInvalidMsg("output field %s of function %s not found", name, functionSchema.GetName())
+		}
+		functionSchema.OutputFieldIds[idx] = fieldID
+		outputFieldNameSet[name] = struct{}{}
+	}
+	// Enforce IsFunctionOutput on new output fields regardless of what the caller set.
+	for _, fieldSchema := range fieldSchemas {
+		if _, ok := outputFieldNameSet[fieldSchema.Name]; ok {
+			fieldSchema.IsFunctionOutput = true
+		}
+	}
+
+	// 6. build new collection schema.
+	schema := &schemapb.CollectionSchema{
+		Name:               coll.Name,
+		Description:        coll.Description,
+		AutoID:             coll.AutoID,
+		Fields:             model.MarshalFieldModels(coll.Fields),
+		StructArrayFields:  model.MarshalStructArrayFieldModels(coll.StructArrayFields),
+		Functions:          model.MarshalFunctionModels(coll.Functions),
+		EnableDynamicField: coll.EnableDynamicField,
+		Properties:         coll.Properties,
+		DbName:             coll.DBName,
+		FileResourceIds:    coll.FileResourceIds,
+		// Version is incremented by 1. No CAS is needed here because Proxy's
+		// checkSchemaVersionConsistency gate blocks new AlterCollectionSchema calls
+		// until the previous backfill reaches 100% consistency, and DDL requests
+		// are serialized through a single DDL queue — so concurrent schema changes
+		// that could produce duplicate version numbers are impossible.
+		Version:            coll.SchemaVersion + 1,
+		DoPhysicalBackfill: addRequest.GetDoPhysicalBackfill(),
+	}
+	schema.Fields = append(schema.Fields, fieldSchemas...)
+	schema.Functions = append(schema.Functions, functionSchema)
+
+	// 7. get cache expirations.
+	cacheExpirations, err := c.getCacheExpireForCollection(ctx, req.GetDbName(), req.GetCollectionName())
+	if err != nil {
+		return err
+	}
+
+	channels := make([]string, 0, len(coll.VirtualChannelNames)+1)
+	channels = append(channels, streaming.WAL().ControlChannel())
+	channels = append(channels, coll.VirtualChannelNames...)
+	msg := message.NewAlterCollectionMessageBuilderV2().
+		WithHeader(&messagespb.AlterCollectionMessageHeader{
+			DbId:         coll.DBID,
+			CollectionId: coll.CollectionID,
+			UpdateMask: &fieldmaskpb.FieldMask{
+				Paths: []string{message.FieldMaskCollectionSchema},
+			},
+			CacheExpirations: cacheExpirations,
+		}).
+		WithBody(&messagespb.AlterCollectionMessageBody{
+			Updates: &messagespb.AlterCollectionMessageUpdates{
+				Schema: schema,
+			},
+		}).
+		WithBroadcast(channels).
+		MustBuildBroadcast()
+	if _, err := broadcaster.Broadcast(ctx, msg); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/rootcoord/ddl_callbacks_alter_collection_schema_test.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_schema_test.go
@@ -1,0 +1,241 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rootcoord
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/pkg/v2/common"
+	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+)
+
+// buildAlterSchemaReq constructs a valid AlterCollectionSchemaRequest with an add operation.
+func buildAlterSchemaReq(dbName, collName, inputField, outputField, funcName string, doBackfill bool) *milvuspb.AlterCollectionSchemaRequest {
+	outputFieldSchema := &schemapb.FieldSchema{
+		Name:             outputField,
+		DataType:         schemapb.DataType_SparseFloatVector,
+		IsFunctionOutput: true,
+	}
+	functionSchema := &schemapb.FunctionSchema{
+		Name:             funcName,
+		Type:             schemapb.FunctionType_BM25,
+		InputFieldNames:  []string{inputField},
+		OutputFieldNames: []string{outputField},
+	}
+	return &milvuspb.AlterCollectionSchemaRequest{
+		DbName:         dbName,
+		CollectionName: collName,
+		Action: &milvuspb.AlterCollectionSchemaRequest_Action{
+			Op: &milvuspb.AlterCollectionSchemaRequest_Action_AddRequest{
+				AddRequest: &milvuspb.AlterCollectionSchemaRequest_AddRequest{
+					FieldInfos: []*milvuspb.AlterCollectionSchemaRequest_FieldInfo{
+						{FieldSchema: outputFieldSchema},
+					},
+					FuncSchema:         []*schemapb.FunctionSchema{functionSchema},
+					DoPhysicalBackfill: doBackfill,
+				},
+			},
+		},
+	}
+}
+
+func TestDDLCallbacksBroadcastAlterCollectionSchema(t *testing.T) {
+	core := initStreamingSystemAndCore(t)
+
+	ctx := context.Background()
+	dbName := "testDB" + funcutil.RandomString(10)
+	collectionName := "testCollection" + funcutil.RandomString(10)
+
+	createCollectionForTest(t, ctx, core, dbName, collectionName)
+	assertSchemaVersion(t, ctx, core, dbName, collectionName, 0)
+
+	// case 1: action == nil
+	resp, err := core.AlterCollectionSchema(ctx, &milvuspb.AlterCollectionSchemaRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		Action:         nil,
+	})
+	require.ErrorIs(t, merr.CheckRPCCall(resp.GetAlterStatus(), err), merr.ErrParameterInvalid)
+
+	// case 2: add_request == nil (action present but no Op set)
+	resp, err = core.AlterCollectionSchema(ctx, &milvuspb.AlterCollectionSchemaRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		Action:         &milvuspb.AlterCollectionSchemaRequest_Action{},
+	})
+	require.ErrorIs(t, merr.CheckRPCCall(resp.GetAlterStatus(), err), merr.ErrParameterInvalid)
+
+	// case 3: funcSchemas empty (len != 1)
+	resp, err = core.AlterCollectionSchema(ctx, &milvuspb.AlterCollectionSchemaRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		Action: &milvuspb.AlterCollectionSchemaRequest_Action{
+			Op: &milvuspb.AlterCollectionSchemaRequest_Action_AddRequest{
+				AddRequest: &milvuspb.AlterCollectionSchemaRequest_AddRequest{
+					FuncSchema: []*schemapb.FunctionSchema{},
+					FieldInfos: []*milvuspb.AlterCollectionSchemaRequest_FieldInfo{
+						{FieldSchema: &schemapb.FieldSchema{Name: "sparse1", DataType: schemapb.DataType_SparseFloatVector}},
+					},
+				},
+			},
+		},
+	})
+	require.ErrorIs(t, merr.CheckRPCCall(resp.GetAlterStatus(), err), merr.ErrParameterInvalid)
+
+	// case 4: fieldInfos empty
+	resp, err = core.AlterCollectionSchema(ctx, &milvuspb.AlterCollectionSchemaRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		Action: &milvuspb.AlterCollectionSchemaRequest_Action{
+			Op: &milvuspb.AlterCollectionSchemaRequest_Action_AddRequest{
+				AddRequest: &milvuspb.AlterCollectionSchemaRequest_AddRequest{
+					FuncSchema: []*schemapb.FunctionSchema{
+						{Name: "fn1", Type: schemapb.FunctionType_BM25},
+					},
+					FieldInfos: []*milvuspb.AlterCollectionSchemaRequest_FieldInfo{},
+				},
+			},
+		},
+	})
+	require.ErrorIs(t, merr.CheckRPCCall(resp.GetAlterStatus(), err), merr.ErrParameterInvalid)
+
+	// case 5: fieldSchema nil in fieldInfos
+	resp, err = core.AlterCollectionSchema(ctx, &milvuspb.AlterCollectionSchemaRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		Action: &milvuspb.AlterCollectionSchemaRequest_Action{
+			Op: &milvuspb.AlterCollectionSchemaRequest_Action_AddRequest{
+				AddRequest: &milvuspb.AlterCollectionSchemaRequest_AddRequest{
+					FuncSchema: []*schemapb.FunctionSchema{
+						{Name: "fn1", Type: schemapb.FunctionType_BM25},
+					},
+					FieldInfos: []*milvuspb.AlterCollectionSchemaRequest_FieldInfo{
+						{FieldSchema: nil},
+					},
+				},
+			},
+		},
+	})
+	require.ErrorIs(t, merr.CheckRPCCall(resp.GetAlterStatus(), err), merr.ErrParameterInvalid)
+
+	// case 6: output field already exists (field1 created by createCollectionForTest)
+	resp, err = core.AlterCollectionSchema(ctx, &milvuspb.AlterCollectionSchemaRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		Action: &milvuspb.AlterCollectionSchemaRequest_Action{
+			Op: &milvuspb.AlterCollectionSchemaRequest_Action_AddRequest{
+				AddRequest: &milvuspb.AlterCollectionSchemaRequest_AddRequest{
+					FuncSchema: []*schemapb.FunctionSchema{
+						{Name: "fn_dup_field", Type: schemapb.FunctionType_BM25, InputFieldNames: []string{"field1"}, OutputFieldNames: []string{"field1"}},
+					},
+					FieldInfos: []*milvuspb.AlterCollectionSchemaRequest_FieldInfo{
+						{FieldSchema: &schemapb.FieldSchema{Name: "field1", DataType: schemapb.DataType_SparseFloatVector}},
+					},
+				},
+			},
+		},
+	})
+	require.ErrorIs(t, merr.CheckRPCCall(resp.GetAlterStatus(), err), merr.ErrParameterInvalid)
+
+	// Add a VARCHAR input field so that the happy-path call below can succeed.
+	varcharFieldSchema := &schemapb.FieldSchema{
+		Name:     "text_input",
+		DataType: schemapb.DataType_VarChar,
+		TypeParams: []*commonpb.KeyValuePair{
+			{Key: common.MaxLengthKey, Value: "256"},
+		},
+	}
+	varcharBytes, err := proto.Marshal(varcharFieldSchema)
+	require.NoError(t, err)
+	addFieldResp, err := core.AddCollectionField(ctx, &milvuspb.AddCollectionFieldRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		Schema:         varcharBytes,
+	})
+	require.NoError(t, merr.CheckRPCCall(addFieldResp, err))
+
+	// happy path: add sparse vector output field + BM25 function → schema version bumps (AddCollectionField already bumped to 1, so now 2)
+	firstAlterReq := buildAlterSchemaReq(dbName, collectionName, "text_input", "sparse_output", "bm25_fn", false)
+	resp, err = core.AlterCollectionSchema(ctx, firstAlterReq)
+	require.NoError(t, merr.CheckRPCCall(resp.GetAlterStatus(), err))
+	assertSchemaVersion(t, ctx, core, dbName, collectionName, 2)
+
+	// case 7: function already exists (same name "bm25_fn")
+	resp, err = core.AlterCollectionSchema(ctx, &milvuspb.AlterCollectionSchemaRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		Action: &milvuspb.AlterCollectionSchemaRequest_Action{
+			Op: &milvuspb.AlterCollectionSchemaRequest_Action_AddRequest{
+				AddRequest: &milvuspb.AlterCollectionSchemaRequest_AddRequest{
+					FuncSchema: []*schemapb.FunctionSchema{
+						{Name: "bm25_fn", Type: schemapb.FunctionType_BM25, InputFieldNames: []string{"text_input"}, OutputFieldNames: []string{"sparse_output2"}},
+					},
+					FieldInfos: []*milvuspb.AlterCollectionSchemaRequest_FieldInfo{
+						{FieldSchema: &schemapb.FieldSchema{Name: "sparse_output2", DataType: schemapb.DataType_SparseFloatVector, IsFunctionOutput: true}},
+					},
+				},
+			},
+		},
+	})
+	require.ErrorIs(t, merr.CheckRPCCall(resp.GetAlterStatus(), err), merr.ErrParameterInvalid)
+
+	// case 8: input field not found
+	resp, err = core.AlterCollectionSchema(ctx, &milvuspb.AlterCollectionSchemaRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		Action: &milvuspb.AlterCollectionSchemaRequest_Action{
+			Op: &milvuspb.AlterCollectionSchemaRequest_Action_AddRequest{
+				AddRequest: &milvuspb.AlterCollectionSchemaRequest_AddRequest{
+					FuncSchema: []*schemapb.FunctionSchema{
+						{Name: "fn_missing_input", Type: schemapb.FunctionType_BM25, InputFieldNames: []string{"nonexistent_input"}, OutputFieldNames: []string{"sparse_output3"}},
+					},
+					FieldInfos: []*milvuspb.AlterCollectionSchemaRequest_FieldInfo{
+						{FieldSchema: &schemapb.FieldSchema{Name: "sparse_output3", DataType: schemapb.DataType_SparseFloatVector, IsFunctionOutput: true}},
+					},
+				},
+			},
+		},
+	})
+	require.Error(t, merr.CheckRPCCall(resp.GetAlterStatus(), err))
+
+	// case 9: output field not found (function references "ghost_output" but FieldInfos has "sparse_output4")
+	resp, err = core.AlterCollectionSchema(ctx, &milvuspb.AlterCollectionSchemaRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		Action: &milvuspb.AlterCollectionSchemaRequest_Action{
+			Op: &milvuspb.AlterCollectionSchemaRequest_Action_AddRequest{
+				AddRequest: &milvuspb.AlterCollectionSchemaRequest_AddRequest{
+					FuncSchema: []*schemapb.FunctionSchema{
+						{Name: "fn_missing_output", Type: schemapb.FunctionType_BM25, InputFieldNames: []string{"text_input"}, OutputFieldNames: []string{"ghost_output"}},
+					},
+					FieldInfos: []*milvuspb.AlterCollectionSchemaRequest_FieldInfo{
+						{FieldSchema: &schemapb.FieldSchema{Name: "sparse_output4", DataType: schemapb.DataType_SparseFloatVector, IsFunctionOutput: true}},
+					},
+				},
+			},
+		},
+	})
+	require.Error(t, merr.CheckRPCCall(resp.GetAlterStatus(), err))
+}

--- a/internal/rootcoord/meta_table.go
+++ b/internal/rootcoord/meta_table.go
@@ -729,7 +729,7 @@ func (mt *MetaTable) RemoveCollection(ctx context.Context, collectionID UniqueID
 
 // Note: The returned model.Collection is read-only. Do NOT modify it directly,
 // as it may cause unexpected behavior or inconsistencies.
-func filterUnavailable(coll *model.Collection) *model.Collection {
+func filterUnavailablePartition(coll *model.Collection) *model.Collection {
 	clone := coll.ShallowClone()
 	// pick available partitions.
 	clone.Partitions = make([]*model.Partition, 0, len(coll.Partitions))
@@ -756,7 +756,7 @@ func (mt *MetaTable) getLatestCollectionByIDInternal(ctx context.Context, collec
 	if !coll.Available() {
 		return nil, merr.WrapErrCollectionNotFound(collectionID)
 	}
-	return filterUnavailable(coll), nil
+	return filterUnavailablePartition(coll), nil
 }
 
 // getCollectionByIDInternal get collection by collection id without lock.
@@ -769,7 +769,16 @@ func (mt *MetaTable) getCollectionByIDInternal(ctx context.Context, dbName strin
 
 	var coll *model.Collection
 	coll, ok := mt.collID2Meta[collectionID]
-	if !ok || coll == nil || !coll.Available() || coll.CreateTime > ts {
+	// Use UpdateTimestamp (not CreateTime) for cache invalidation.
+	// This is a bug fix for time-travel correctness, not merely an enhancement for backfill:
+	// collID2Meta always holds the *latest* collection state.  After a schema alteration (e.g.
+	// AlterCollectionSchema), the in-memory entry has a schema that didn't exist at timestamps
+	// before the alteration.  The old code compared against CreateTime, so a time-travel query
+	// at T where CreateTime < T < AlterTime would incorrectly serve the altered schema from the
+	// in-memory cache instead of falling back to the catalog for the historical version.
+	// Comparing against UpdateTimestamp ensures the cache is bypassed for any ts that predates
+	// the last schema modification, fixing time-travel semantics for all schema-altering DDLs.
+	if !ok || coll == nil || !coll.Available() || coll.UpdateTimestamp > ts {
 		// travel meta information from catalog.
 		ctx1 := contextutil.WithTenantID(ctx, Params.CommonCfg.ClusterName.GetValue())
 		db, err := mt.getDatabaseByNameInternal(ctx, dbName, typeutil.MaxTimestamp)
@@ -796,7 +805,7 @@ func (mt *MetaTable) getCollectionByIDInternal(ctx context.Context, dbName strin
 		return nil, merr.WrapErrCollectionNotFound(dbName, coll.Name)
 	}
 
-	return filterUnavailable(coll), nil
+	return filterUnavailablePartition(coll), nil
 }
 
 func (mt *MetaTable) GetCollectionByName(ctx context.Context, dbName string, collectionName string, ts Timestamp) (*model.Collection, error) {
@@ -873,7 +882,7 @@ func (mt *MetaTable) getCollectionByNameInternal(ctx context.Context, dbName str
 	if coll == nil || !coll.Available() {
 		return nil, merr.WrapErrCollectionNotFoundWithDB(dbName, collectionName)
 	}
-	return filterUnavailable(coll), nil
+	return filterUnavailablePartition(coll), nil
 }
 
 func (mt *MetaTable) GetCollectionByID(ctx context.Context, dbName string, collectionID UniqueID, ts Timestamp, allowUnavailable bool) (*model.Collection, error) {
@@ -1019,7 +1028,6 @@ func (mt *MetaTable) AlterCollection(ctx context.Context, result message.Broadca
 		// collection not exists, return directly.
 		return errAlterCollectionNotFound
 	}
-
 	oldColl := coll.Clone()
 	newColl := coll.Clone()
 	newColl.ApplyUpdates(header, body)
@@ -1067,6 +1075,8 @@ func (mt *MetaTable) AlterCollection(ctx context.Context, result message.Broadca
 		zap.Int64("oldCollectionID", oldColl.CollectionID),
 		zap.Bool("dbChanged", dbChanged),
 		zap.Uint64("ts", newColl.UpdateTimestamp),
+		zap.Bool("doPhysicalBackfill", newColl.DoPhysicalBackfill),
+		zap.Int32("schemaVersion", newColl.SchemaVersion),
 	)
 	return nil
 }

--- a/internal/rootcoord/meta_table_test.go
+++ b/internal/rootcoord/meta_table_test.go
@@ -1101,7 +1101,7 @@ func Test_filterUnavailable(t *testing.T) {
 		}
 		coll.Partitions = append(coll.Partitions, partition)
 	}
-	clone := filterUnavailable(coll)
+	clone := filterUnavailablePartition(coll)
 	assert.Equal(t, nAvailablePartition, len(clone.Partitions))
 	for _, p := range clone.Partitions {
 		assert.True(t, p.Available())

--- a/internal/rootcoord/root_coord.go
+++ b/internal/rootcoord/root_coord.go
@@ -988,6 +988,37 @@ func (c *Core) AddCollectionField(ctx context.Context, in *milvuspb.AddCollectio
 	return merr.Success(), nil
 }
 
+func (c *Core) AlterCollectionSchema(ctx context.Context, in *milvuspb.AlterCollectionSchemaRequest) (*milvuspb.AlterCollectionSchemaResponse, error) {
+	if err := merr.CheckHealthy(c.GetStateCode()); err != nil {
+		return &milvuspb.AlterCollectionSchemaResponse{
+			AlterStatus: merr.Status(err),
+		}, nil
+	}
+
+	metrics.RootCoordDDLReqCounter.WithLabelValues("AlterCollectionSchema", metrics.TotalLabel).Inc()
+	tr := timerecord.NewTimeRecorder("AlterCollectionSchema")
+
+	log := log.Ctx(ctx).With(zap.String("role", typeutil.RootCoordRole),
+		zap.String("dbName", in.GetDbName()),
+		zap.String("collectionName", in.GetCollectionName()))
+	log.Info("received request to add function field")
+
+	if err := c.broadcastAlterCollectionSchema(ctx, in); err != nil {
+		log.Info("failed to add function field", zap.Error(err))
+		metrics.RootCoordDDLReqCounter.WithLabelValues("AlterCollectionSchema", metrics.FailLabel).Inc()
+		return &milvuspb.AlterCollectionSchemaResponse{
+			AlterStatus: merr.Status(err),
+		}, nil
+	}
+
+	metrics.RootCoordDDLReqCounter.WithLabelValues("AlterCollectionSchema", metrics.SuccessLabel).Inc()
+	metrics.RootCoordDDLReqLatency.WithLabelValues("AlterCollectionSchema").Observe(float64(tr.ElapseSpan().Milliseconds()))
+	log.Info("done to alter collection schema")
+	return &milvuspb.AlterCollectionSchemaResponse{
+		AlterStatus: merr.Success(),
+	}, nil
+}
+
 // DropCollection drop collection
 func (c *Core) DropCollection(ctx context.Context, in *milvuspb.DropCollectionRequest) (*commonpb.Status, error) {
 	if err := merr.CheckHealthy(c.GetStateCode()); err != nil {
@@ -1136,6 +1167,8 @@ func convertModelToDesc(collInfo *model.Collection, aliases []string, dbName str
 		ExternalSource:     collInfo.ExternalSource,
 		ExternalSpec:       collInfo.ExternalSpec,
 		DbName:             dbName, // Use dbName parameter for consistency with resp.DbName
+		Version:            collInfo.SchemaVersion,
+		DoPhysicalBackfill: collInfo.DoPhysicalBackfill,
 	}
 	resp.CollectionID = collInfo.CollectionID
 	resp.VirtualChannelNames = collInfo.VirtualChannelNames
@@ -1496,29 +1529,6 @@ func (c *Core) AlterCollectionField(ctx context.Context, in *milvuspb.AlterColle
 	metrics.RootCoordDDLReqLatency.WithLabelValues("AlterCollectionField").Observe(float64(tr.ElapseSpan().Milliseconds()))
 	log.Info("done to alter collection field")
 	return merr.Success(), nil
-}
-
-func (c *Core) AlterCollectionSchema(ctx context.Context, in *milvuspb.AlterCollectionSchemaRequest) (*milvuspb.AlterCollectionSchemaResponse, error) {
-	if err := merr.CheckHealthy(c.GetStateCode()); err != nil {
-		return &milvuspb.AlterCollectionSchemaResponse{}, nil
-	}
-
-	metrics.RootCoordDDLReqCounter.WithLabelValues("AlterCollectionSchema", metrics.TotalLabel).Inc()
-	tr := timerecord.NewTimeRecorder("AlterCollectionSchema")
-
-	log := log.Ctx(ctx).With(zap.String("role", typeutil.RootCoordRole),
-		zap.String("dbName", in.GetDbName()),
-		zap.String("collectionName", in.GetCollectionName()),
-	)
-	log.Info("received request to alter collection schema")
-
-	// AlterCollectionSchema is currently a placeholder implementation
-	// The actual logic should handle schema alterations similar to AlterCollection
-	// For now, return success to satisfy the interface
-	metrics.RootCoordDDLReqCounter.WithLabelValues("AlterCollectionSchema", metrics.SuccessLabel).Inc()
-	metrics.RootCoordDDLReqLatency.WithLabelValues("AlterCollectionSchema").Observe(float64(tr.ElapseSpan().Milliseconds()))
-	log.Info("done to alter collection schema")
-	return &milvuspb.AlterCollectionSchemaResponse{}, nil
 }
 
 func (c *Core) AlterDatabase(ctx context.Context, in *rootcoordpb.AlterDatabaseRequest) (*commonpb.Status, error) {

--- a/internal/rootcoord/util.go
+++ b/internal/rootcoord/util.go
@@ -551,3 +551,13 @@ func nextFieldID(coll *model.Collection) int64 {
 
 	return maxFieldID + 1
 }
+
+func nextFunctionID(coll *model.Collection) int64 {
+	maxFunctionID := int64(common.StartOfUserFunctionID)
+	for _, function := range coll.Functions {
+		if function.ID > maxFunctionID {
+			maxFunctionID = function.ID
+		}
+	}
+	return maxFunctionID + 1
+}

--- a/internal/storagev2/packed/packed_writer_ffi.go
+++ b/internal/storagev2/packed/packed_writer_ffi.go
@@ -151,6 +151,15 @@ func NewFFIPackedWriter(basePath string, baseVersion int64, schema *arrow.Schema
 	}, nil
 }
 
+// AsNewColumnGroups marks this writer so that Close() calls loon_transaction_add_column_group
+// for each written column group instead of loon_transaction_append_files.
+// Call this when the written columns are brand-new additions to an existing manifest
+// (e.g. function-field backfill), not when appending more files to the same column structure.
+func (pw *FFIPackedWriter) AsNewColumnGroups() *FFIPackedWriter {
+	pw.addNewColumnGroups = true
+	return pw
+}
+
 func (pw *FFIPackedWriter) WriteRecordBatch(recordBatch arrow.Record) error {
 	var caa cdata.CArrowArray
 	var cas cdata.CArrowSchema
@@ -185,9 +194,24 @@ func (pw *FFIPackedWriter) Close() (string, error) {
 	}
 	defer C.loon_transaction_destroy(transationHandle)
 
-	result = C.loon_transaction_append_files(transationHandle, cColumnGroups)
-	if err := HandleLoonFFIResult(result); err != nil {
-		return "", err
+	if pw.addNewColumnGroups {
+		// Each written group is a brand-new column group: add them one-by-one.
+		// loon_transaction_append_files requires the count to match existing groups,
+		// which would fail when extending the schema (e.g. backfill adds sparse vector
+		// to a manifest that already has 2 groups of different columns).
+		numGroups := int(cColumnGroups.num_of_column_groups)
+		colGroupSlice := (*[1 << 20]C.LoonColumnGroup)(unsafe.Pointer(cColumnGroups.column_group_array))[:numGroups:numGroups]
+		for i := range colGroupSlice {
+			result = C.loon_transaction_add_column_group(transationHandle, &colGroupSlice[i])
+			if err := HandleLoonFFIResult(result); err != nil {
+				return "", err
+			}
+		}
+	} else {
+		result = C.loon_transaction_append_files(transationHandle, cColumnGroups)
+		if err := HandleLoonFFIResult(result); err != nil {
+			return "", err
+		}
 	}
 
 	var cCommitVersion C.int64_t

--- a/internal/storagev2/packed/type.go
+++ b/internal/storagev2/packed/type.go
@@ -39,6 +39,12 @@ type FFIPackedWriter struct {
 	baseVersion   int64
 	cWriterHandle C.LoonWriterHandle
 	cProperties   *C.LoonProperties
+	// addNewColumnGroups controls whether Close() uses loon_transaction_add_column_group
+	// (true) or loon_transaction_append_files (false).
+	//
+	// Use true when adding columns that do not yet exist in the manifest (e.g. backfill).
+	// Use false (default) when writing more files into the same column structure (e.g. multi-batch write).
+	addNewColumnGroups bool
 }
 
 type PackedReader struct {

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -190,7 +190,14 @@ const (
 	JSONPathKey         = "json_path"
 	JSONCastFunctionKey = "json_cast_function"
 
-	SchemaVersionConsistencyProportionKey = "schema_version_consistency_proportion"
+	// SchemaVersionConsistentSegmentsKey and SchemaVersionTotalSegmentsKey are emitted by DataCoord
+	// in GetCollectionStatistics when the collection's schema version > 0 (i.e. AlterCollectionSchema
+	// has been called).  Proxy uses these two integer counts to gate schema-change DDLs: the gate
+	// passes only when consistentSegments == totalSegments (exact integer equality, no floating-point
+	// rounding).  Using raw counts avoids the false-100% problem that arises when a float proportion
+	// like 99.999% is formatted with "%.2f" and rounds up to "100.00".
+	SchemaVersionConsistentSegmentsKey = "schema_version_consistent_segments"
+	SchemaVersionTotalSegmentsKey      = "schema_version_total_segments"
 )
 
 // expr query params

--- a/tests/go_client/testcases/add_field_test.go
+++ b/tests/go_client/testcases/add_field_test.go
@@ -169,7 +169,7 @@ func TestAddCollectionFieldInvalid(t *testing.T) {
 			fieldBuilder: func() *entity.Field {
 				return entity.NewField().WithName(common.DefaultNewField).WithDataType(entity.FieldTypeInt64).WithNullable(true).WithIsClusteringKey(true)
 			},
-			expectedError: "already has another clutering key field, field name: " + common.DefaultNewField + ": invalid parameter",
+			expectedError: "already has another clustering key field, field name: " + common.DefaultNewField + ": invalid parameter",
 		},
 		{
 			name: "addFieldSameOtherName",
@@ -185,7 +185,7 @@ func TestAddCollectionFieldInvalid(t *testing.T) {
 			fieldBuilder: func() *entity.Field {
 				return entity.NewField().WithName(common.DefaultVarcharFieldName).WithDataType(entity.FieldTypeVarChar).WithNullable(true).WithMaxLength(64)
 			},
-			expectedError: "duplicate field name: varchar: invalid parameter",
+			expectedError: "duplicated field name varchar: invalid parameter",
 		},
 	}
 


### PR DESCRIPTION
related: https://github.com/milvus-io/milvus/pull/44444
design doc: https://github.com/milvus-io/milvus-design-docs/blob/main/design_docs/20260129-add-function-field-design.md

- RootCoord: AlterCollectionSchema DDL callback, schema versioning in broadcast
- DataCoord: backfill compaction policy, task, trigger; DescribeCollectionInternal with timestamp
- StreamingNode: schema version validation on insert, shard manager schema tracking
- DataNode: backfill compactor executor for running function runners on old segments
- Proxy: AlterCollectionSchema handler, schema version propagation in insert/upsert
- FlushCommon: schema version in write buffer and pipeline