### PR TITLE
fix: eliminate memory accumulation in ManifestGroupTranslator::get_cells()

### DIFF
--- a/internal/core/src/segcore/memory_planner.cpp
+++ b/internal/core/src/segcore/memory_planner.cpp
@@ -254,11 +254,10 @@ LoadWithStrategy(const std::vector<std::string>& remote_files,
 
 std::vector<std::future<void>>
 LoadCellBatchAsync(milvus::OpContext* op_ctx,
-                   const std::vector<std::string>& remote_files,
                    std::vector<CellSpec> cell_specs,
+                   BatchReaderFactory reader_factory,
                    std::shared_ptr<CellReaderChannel>& channel,
                    int64_t memory_limit,
-                   const milvus_storage::ArrowFileSystemPtr& fs,
                    milvus::proto::common::LoadPriority priority) {
     if (cell_specs.empty()) {
         channel->close();
@@ -281,7 +280,7 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
     size_t cells_per_batch = std::max<size_t>(
         1, (cell_specs.size() + parallel_degree - 1) / parallel_degree);
 
-    // Group consecutive, same-file cells into batches for IO merging
+    // Group consecutive, same-key cells into batches for IO merging
     struct CellBatch {
         size_t file_idx;
         int64_t rg_offset;
@@ -327,14 +326,15 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
     auto reader_memory_limit =
         std::max<int64_t>(memory_limit / static_cast<int64_t>(batches.size()),
                           FILE_SLICE_SIZE.load());
+    auto shared_factory =
+        std::make_shared<BatchReaderFactory>(std::move(reader_factory));
 
     std::vector<std::future<void>> futures;
     futures.reserve(batches.size());
 
     for (auto& batch : batches) {
         futures.emplace_back(pool.Submit([batch = std::move(batch),
-                                          fs,
-                                          &remote_files,
+                                          shared_factory,
                                           reader_memory_limit,
                                           channel,
                                           remaining,
@@ -346,44 +346,73 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
             });
             CheckCancellation(op_ctx, -1, "LoadCellBatchAsync");
 
-            auto result = milvus_storage::FileRowGroupReader::Make(
-                fs,
-                remote_files[batch.file_idx],
-                nullptr,
-                reader_memory_limit,
-                milvus::storage::GetReaderProperties());
-            AssertInfo(result.ok(),
-                       "[StorageV2] Failed to create reader: " +
-                           result.status().ToString());
-            auto reader = result.ValueOrDie();
-            auto status = reader->SetRowGroupOffsetAndCount(batch.rg_offset,
-                                                            batch.rg_count);
-            AssertInfo(status.ok(),
-                       "[StorageV2] Failed to set row group range: " +
-                           status.ToString());
+            auto reader_result = (*shared_factory)(batch.file_idx,
+                                                   batch.rg_offset,
+                                                   batch.rg_count,
+                                                   reader_memory_limit);
+            AssertInfo(reader_result.ok(),
+                       "[StorageV2] Failed to create batch reader: " +
+                           reader_result.status().ToString());
+            auto sequential_reader = std::move(reader_result).ValueOrDie();
 
             for (const auto& cell : batch.cells) {
                 auto cell_result = std::make_shared<CellLoadResult>();
                 cell_result->cid = cell.cid;
                 cell_result->tables.reserve(cell.rg_count);
                 for (int64_t i = 0; i < cell.rg_count; ++i) {
-                    std::shared_ptr<arrow::Table> table;
-                    auto s = reader->ReadNextRowGroup(&table);
-                    AssertInfo(s.ok(),
+                    auto table_result = sequential_reader();
+                    AssertInfo(table_result.ok(),
                                "[StorageV2] Failed to read row group: " +
-                                   s.ToString());
-                    cell_result->tables.push_back(std::move(table));
+                                   table_result.status().ToString());
+                    cell_result->tables.push_back(
+                        std::move(table_result).ValueOrDie());
                 }
                 channel->push(std::move(cell_result));
             }
-            auto close_status = reader->Close();
-            AssertInfo(close_status.ok(),
-                       "[StorageV2] Failed to close reader: " +
-                           close_status.ToString());
         }));
     }
 
     return futures;
+}
+
+BatchReaderFactory
+MakeFileReaderFactory(std::vector<std::string> remote_files,
+                      milvus_storage::ArrowFileSystemPtr fs) {
+    auto files =
+        std::make_shared<std::vector<std::string>>(std::move(remote_files));
+    return [files, fs](size_t batch_key,
+                       int64_t rg_offset,
+                       int64_t total_rg_count,
+                       int64_t reader_memory_limit)
+               -> arrow::Result<SequentialRowGroupReader> {
+        auto result = milvus_storage::FileRowGroupReader::Make(
+            fs,
+            (*files)[batch_key],
+            nullptr,
+            reader_memory_limit,
+            milvus::storage::GetReaderProperties());
+        if (!result.ok()) {
+            return result.status();
+        }
+        auto reader = result.ValueOrDie();
+        auto status =
+            reader->SetRowGroupOffsetAndCount(rg_offset, total_rg_count);
+        if (!status.ok()) {
+            return status;
+        }
+
+        auto reads_remaining = std::make_shared<int64_t>(total_rg_count);
+        return SequentialRowGroupReader(
+            [reader = std::move(reader), reads_remaining]()
+                -> arrow::Result<std::shared_ptr<arrow::Table>> {
+                std::shared_ptr<arrow::Table> table;
+                ARROW_RETURN_NOT_OK(reader->ReadNextRowGroup(&table));
+                if (--(*reads_remaining) == 0) {
+                    ARROW_RETURN_NOT_OK(reader->Close());
+                }
+                return table;
+            });
+    };
 }
 
 }  // namespace milvus::segcore

--- a/internal/core/src/segcore/memory_planner.cpp
+++ b/internal/core/src/segcore/memory_planner.cpp
@@ -204,6 +204,10 @@ LoadWithStrategy(const std::vector<std::string>& remote_files,
                             "[StorageV2] Failed to create row group reader: " +
                                 result.status().ToString());
                         auto row_group_reader = result.ValueOrDie();
+                        auto close_guard =
+                            folly::makeGuard([&row_group_reader]() {
+                                (void)row_group_reader->Close();
+                            });
                         auto status =
                             row_group_reader->SetRowGroupOffsetAndCount(
                                 block.offset, block.count);
@@ -347,27 +351,25 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
             });
             CheckCancellation(op_ctx, -1, "LoadCellBatchAsync");
 
-            auto reader_result = (*shared_factory)(batch.file_idx,
+            auto tables_result = (*shared_factory)(batch.file_idx,
                                                    batch.rg_offset,
                                                    batch.rg_count,
                                                    reader_memory_limit);
-            AssertInfo(reader_result.ok(),
-                       "[StorageV2] Failed to create batch reader: " +
-                           reader_result.status().ToString());
-            auto sequential_reader = std::move(reader_result).ValueOrDie();
+            AssertInfo(tables_result.ok(),
+                       "[StorageV2] Failed to read batch: " +
+                           tables_result.status().ToString());
+            auto all_tables = std::move(tables_result).ValueOrDie();
 
+            int64_t table_offset = 0;
             for (const auto& cell : batch.cells) {
                 auto cell_result = std::make_shared<CellLoadResult>();
                 cell_result->cid = cell.cid;
                 cell_result->tables.reserve(cell.rg_count);
                 for (int64_t i = 0; i < cell.rg_count; ++i) {
-                    auto table_result = sequential_reader();
-                    AssertInfo(table_result.ok(),
-                               "[StorageV2] Failed to read row group: " +
-                                   table_result.status().ToString());
                     cell_result->tables.push_back(
-                        std::move(table_result).ValueOrDie());
+                        std::move(all_tables[table_offset + i]));
                 }
+                table_offset += cell.rg_count;
                 channel->push(std::move(cell_result));
             }
         }));
@@ -385,34 +387,26 @@ MakeFileReaderFactory(std::vector<std::string> remote_files,
                        int64_t rg_offset,
                        int64_t total_rg_count,
                        int64_t reader_memory_limit)
-               -> arrow::Result<SequentialRowGroupReader> {
-        auto result = milvus_storage::FileRowGroupReader::Make(
-            fs,
-            (*files)[batch_key],
-            nullptr,
-            reader_memory_limit,
-            milvus::storage::GetReaderProperties());
-        if (!result.ok()) {
-            return result.status();
+               -> arrow::Result<std::vector<std::shared_ptr<arrow::Table>>> {
+        ARROW_ASSIGN_OR_RAISE(auto reader,
+                              milvus_storage::FileRowGroupReader::Make(
+                                  fs,
+                                  (*files)[batch_key],
+                                  nullptr,
+                                  reader_memory_limit,
+                                  milvus::storage::GetReaderProperties()));
+        auto close_guard =
+            folly::makeGuard([&reader]() { (void)reader->Close(); });
+        ARROW_RETURN_NOT_OK(
+            reader->SetRowGroupOffsetAndCount(rg_offset, total_rg_count));
+        std::vector<std::shared_ptr<arrow::Table>> tables;
+        tables.reserve(total_rg_count);
+        for (int64_t i = 0; i < total_rg_count; ++i) {
+            std::shared_ptr<arrow::Table> table;
+            ARROW_RETURN_NOT_OK(reader->ReadNextRowGroup(&table));
+            tables.push_back(std::move(table));
         }
-        auto reader = result.ValueOrDie();
-        auto status =
-            reader->SetRowGroupOffsetAndCount(rg_offset, total_rg_count);
-        if (!status.ok()) {
-            return status;
-        }
-
-        auto reads_remaining = std::make_shared<int64_t>(total_rg_count);
-        return SequentialRowGroupReader(
-            [reader = std::move(reader), reads_remaining]()
-                -> arrow::Result<std::shared_ptr<arrow::Table>> {
-                std::shared_ptr<arrow::Table> table;
-                ARROW_RETURN_NOT_OK(reader->ReadNextRowGroup(&table));
-                if (--(*reads_remaining) == 0) {
-                    ARROW_RETURN_NOT_OK(reader->Close());
-                }
-                return table;
-            });
+        return tables;
     };
 }
 
@@ -423,23 +417,21 @@ MakeChunkReaderFactory(
                           int64_t rg_offset,
                           int64_t total_rg_count,
                           int64_t /*reader_memory_limit*/)
-               -> arrow::Result<SequentialRowGroupReader> {
-        // Pre-load all row groups for this batch in one IO call
+               -> arrow::Result<std::vector<std::shared_ptr<arrow::Table>>> {
         std::vector<int64_t> rg_indices(total_rg_count);
         std::iota(rg_indices.begin(), rg_indices.end(), rg_offset);
         ARROW_ASSIGN_OR_RAISE(
             auto batches,
             chunk_reader->get_chunks(rg_indices, /*parallelism=*/1));
-        auto shared_batches =
-            std::make_shared<std::vector<std::shared_ptr<arrow::RecordBatch>>>(
-                std::move(batches));
-        auto idx = std::make_shared<size_t>(0);
-        return SequentialRowGroupReader(
-            [shared_batches,
-             idx]() -> arrow::Result<std::shared_ptr<arrow::Table>> {
-                return arrow::Table::FromRecordBatches(
-                    {(*shared_batches)[(*idx)++]});
-            });
+        std::vector<std::shared_ptr<arrow::Table>> tables;
+        tables.reserve(batches.size());
+        for (auto& batch : batches) {
+            ARROW_ASSIGN_OR_RAISE(
+                auto table,
+                arrow::Table::FromRecordBatches({std::move(batch)}));
+            tables.push_back(std::move(table));
+        }
+        return tables;
     };
 }
 

--- a/internal/core/src/segcore/memory_planner.cpp
+++ b/internal/core/src/segcore/memory_planner.cpp
@@ -20,6 +20,7 @@
 #include <exception>
 #include <future>
 #include <memory>
+#include <numeric>
 #include <string>
 #include <utility>
 #include <vector>
@@ -411,6 +412,33 @@ MakeFileReaderFactory(std::vector<std::string> remote_files,
                     ARROW_RETURN_NOT_OK(reader->Close());
                 }
                 return table;
+            });
+    };
+}
+
+BatchReaderFactory
+MakeChunkReaderFactory(
+    std::shared_ptr<milvus_storage::api::ChunkReader> chunk_reader) {
+    return [chunk_reader](size_t /*batch_key*/,
+                          int64_t rg_offset,
+                          int64_t total_rg_count,
+                          int64_t /*reader_memory_limit*/)
+               -> arrow::Result<SequentialRowGroupReader> {
+        // Pre-load all row groups for this batch in one IO call
+        std::vector<int64_t> rg_indices(total_rg_count);
+        std::iota(rg_indices.begin(), rg_indices.end(), rg_offset);
+        ARROW_ASSIGN_OR_RAISE(
+            auto batches,
+            chunk_reader->get_chunks(rg_indices, /*parallelism=*/1));
+        auto shared_batches =
+            std::make_shared<std::vector<std::shared_ptr<arrow::RecordBatch>>>(
+                std::move(batches));
+        auto idx = std::make_shared<size_t>(0);
+        return SequentialRowGroupReader(
+            [shared_batches,
+             idx]() -> arrow::Result<std::shared_ptr<arrow::Table>> {
+                return arrow::Table::FromRecordBatches(
+                    {(*shared_batches)[(*idx)++]});
             });
     };
 }

--- a/internal/core/src/segcore/memory_planner.h
+++ b/internal/core/src/segcore/memory_planner.h
@@ -116,17 +116,14 @@ struct CellLoadResult {
 
 using CellReaderChannel = milvus::Channel<std::shared_ptr<CellLoadResult>>;
 
-// Reads one row group at a time. Called N times for N row groups.
-using SequentialRowGroupReader =
-    std::function<arrow::Result<std::shared_ptr<arrow::Table>>()>;
-
-// Creates a sequential reader for a batch of contiguous row groups.
+// Creates a batch reader for a range of contiguous row groups.
+// Returns all row groups as a vector of tables in one call.
 // batch_key: grouping key (file_idx for files, 0 for single reader)
 // rg_offset: start row group index for this batch
 // total_rg_count: total row groups across all cells in this batch
 // reader_memory_limit: memory budget for this batch's reader
 using BatchReaderFactory =
-    std::function<arrow::Result<SequentialRowGroupReader>(
+    std::function<arrow::Result<std::vector<std::shared_ptr<arrow::Table>>>(
         size_t batch_key,
         int64_t rg_offset,
         int64_t total_rg_count,
@@ -140,7 +137,7 @@ using BatchReaderFactory =
  *
  * @param op_ctx operation context for cancellation
  * @param cell_specs cell specifications (sorted internally)
- * @param reader_factory factory that creates a sequential reader per batch
+ * @param reader_factory factory that reads all row groups for a batch
  * @param channel channel to receive loaded cell data; closed when all done
  * @param memory_limit total memory limit for readers
  * @param priority load priority
@@ -166,9 +163,9 @@ MakeFileReaderFactory(std::vector<std::string> remote_files,
 
 /**
  * Creates a BatchReaderFactory that reads from a ChunkReader via batch
- * get_chunks(). Row groups are pre-loaded in a single IO call for IO merging,
- * then yielded sequentially. The factory captures the shared_ptr by value,
- * extending the ChunkReader's lifetime automatically.
+ * get_chunks(). Row groups are loaded in a single IO call for IO merging
+ * and returned as a vector of tables. The factory captures the shared_ptr
+ * by value, extending the ChunkReader's lifetime automatically.
  */
 BatchReaderFactory
 MakeChunkReaderFactory(

--- a/internal/core/src/segcore/memory_planner.h
+++ b/internal/core/src/segcore/memory_planner.h
@@ -30,6 +30,7 @@
 #include "common/OpContext.h"
 #include "milvus-storage/common/metadata.h"
 #include "milvus-storage/filesystem/fs.h"
+#include "milvus-storage/reader.h"
 
 namespace milvus::segcore {
 
@@ -162,5 +163,15 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
 BatchReaderFactory
 MakeFileReaderFactory(std::vector<std::string> remote_files,
                       milvus_storage::ArrowFileSystemPtr fs);
+
+/**
+ * Creates a BatchReaderFactory that reads from a ChunkReader via batch
+ * get_chunks(). Row groups are pre-loaded in a single IO call for IO merging,
+ * then yielded sequentially. The factory captures the shared_ptr by value,
+ * extending the ChunkReader's lifetime automatically.
+ */
+BatchReaderFactory
+MakeChunkReaderFactory(
+    std::shared_ptr<milvus_storage::api::ChunkReader> chunk_reader);
 
 }  // namespace milvus::segcore

--- a/internal/core/src/segcore/memory_planner.h
+++ b/internal/core/src/segcore/memory_planner.h
@@ -19,6 +19,7 @@
 #include <arrow/table.h>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <future>
 #include <memory>
 #include <string>
@@ -114,29 +115,52 @@ struct CellLoadResult {
 
 using CellReaderChannel = milvus::Channel<std::shared_ptr<CellLoadResult>>;
 
+// Reads one row group at a time. Called N times for N row groups.
+using SequentialRowGroupReader =
+    std::function<arrow::Result<std::shared_ptr<arrow::Table>>()>;
+
+// Creates a sequential reader for a batch of contiguous row groups.
+// batch_key: grouping key (file_idx for files, 0 for single reader)
+// rg_offset: start row group index for this batch
+// total_rg_count: total row groups across all cells in this batch
+// reader_memory_limit: memory budget for this batch's reader
+using BatchReaderFactory =
+    std::function<arrow::Result<SequentialRowGroupReader>(
+        size_t batch_key,
+        int64_t rg_offset,
+        int64_t total_rg_count,
+        int64_t reader_memory_limit)>;
+
 /**
- * Load cells from storage v2 files in batches. Cells are sorted by
+ * Load cells in batches using a pluggable reader factory. Cells are sorted by
  * (file_idx, local_rg_offset) and grouped into IO-merged batches.
  * Each completed cell is pushed to the channel immediately, enabling
  * streaming consumption without accumulating all ArrowTables.
  *
  * @param op_ctx operation context for cancellation
- * @param remote_files list of remote files
  * @param cell_specs cell specifications (sorted internally)
+ * @param reader_factory factory that creates a sequential reader per batch
  * @param channel channel to receive loaded cell data; closed when all done
  * @param memory_limit total memory limit for readers
- * @param fs arrow filesystem
  * @param priority load priority
  * @return vector of futures for the batch loading tasks
  */
 std::vector<std::future<void>>
 LoadCellBatchAsync(milvus::OpContext* op_ctx,
-                   const std::vector<std::string>& remote_files,
                    std::vector<CellSpec> cell_specs,
+                   BatchReaderFactory reader_factory,
                    std::shared_ptr<CellReaderChannel>& channel,
                    int64_t memory_limit,
-                   const milvus_storage::ArrowFileSystemPtr& fs,
                    milvus::proto::common::LoadPriority priority =
                        milvus::proto::common::LoadPriority::HIGH);
+
+/**
+ * Creates a BatchReaderFactory that reads from Parquet files via FileRowGroupReader.
+ * The returned factory owns a copy of remote_files, so the caller's vector
+ * need not outlive the factory.
+ */
+BatchReaderFactory
+MakeFileReaderFactory(std::vector<std::string> remote_files,
+                      milvus_storage::ArrowFileSystemPtr fs);
 
 }  // namespace milvus::segcore

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
@@ -362,12 +362,22 @@ GroupChunkTranslator::get_cells(milvus::OpContext* ctx,
         completed_cells;
     completed_cells.reserve(cids.size());
 
-    std::shared_ptr<milvus::segcore::CellLoadResult> cell_data;
-    while (channel->pop(cell_data)) {
-        CheckCancellation(
-            ctx, segment_id_, "GroupChunkTranslator::get_cells()");
-        completed_cells[cell_data->cid] =
-            load_group_chunk(cell_data->tables, cell_data->cid);
+    try {
+        std::shared_ptr<milvus::segcore::CellLoadResult> cell_data;
+        while (channel->pop(cell_data)) {
+            CheckCancellation(
+                ctx, segment_id_, "GroupChunkTranslator::get_cells()");
+            completed_cells[cell_data->cid] =
+                load_group_chunk(cell_data->tables, cell_data->cid);
+        }
+    } catch (std::exception& ex) {
+        // make sure all futures are handled, but still throw pop & load ex
+        try {
+            storage::WaitAllFutures(load_futures);
+        } catch (...) {
+            LOG_WARN("WaitAllFutures exception swallowed");
+        }
+        throw;
     }
 
     storage::WaitAllFutures(load_futures);

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
@@ -49,6 +49,7 @@
 #include "segcore/memory_planner.h"
 #include "segcore/storagev2translator/GroupCTMeta.h"
 #include "storage/KeyRetriever.h"
+#include "storage/ThreadPools.h"
 #include "storage/Util.h"
 
 namespace milvus::segcore::storagev2translator {
@@ -338,7 +339,10 @@ GroupChunkTranslator::get_cells(milvus::OpContext* ctx,
     }
 
     // Submit cell-batch loading tasks
-    auto channel = std::make_shared<milvus::segcore::CellReaderChannel>();
+    auto& pool = milvus::ThreadPools::GetThreadPool(
+        milvus::PriorityForLoad(load_priority_));
+    auto channel = std::make_shared<milvus::segcore::CellReaderChannel>(
+        static_cast<size_t>(pool.GetMaxThreadNum() * 1.5));
     auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
                   .GetArrowFileSystem();
 

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
@@ -342,13 +342,13 @@ GroupChunkTranslator::get_cells(milvus::OpContext* ctx,
     auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
                   .GetArrowFileSystem();
 
+    auto factory = milvus::segcore::MakeFileReaderFactory(insert_files_, fs);
     auto load_futures =
         milvus::segcore::LoadCellBatchAsync(ctx,
-                                            insert_files_,
                                             std::move(cell_specs),
+                                            std::move(factory),
                                             channel,
                                             DEFAULT_FIELD_MAX_MEMORY_LIMIT,
-                                            fs,
                                             load_priority_);
 
     LOG_INFO(

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <exception>
 #include <filesystem>
 #include <memory>
 #include <stdexcept>
@@ -247,12 +248,22 @@ ManifestGroupTranslator::get_cells(
         completed_cells;
     completed_cells.reserve(cids.size());
 
-    std::shared_ptr<milvus::segcore::CellLoadResult> cell_data;
-    while (channel->pop(cell_data)) {
-        CheckCancellation(
-            ctx, segment_id_, "ManifestGroupTranslator::get_cells()");
-        completed_cells[cell_data->cid] =
-            load_group_chunk(cell_data->tables, cell_data->cid);
+    try {
+        std::shared_ptr<milvus::segcore::CellLoadResult> cell_data;
+        while (channel->pop(cell_data)) {
+            CheckCancellation(
+                ctx, segment_id_, "ManifestGroupTranslator::get_cells()");
+            completed_cells[cell_data->cid] =
+                load_group_chunk(cell_data->tables, cell_data->cid);
+        }
+    } catch (std::exception& ex) {
+        // make sure all futures are handled, but still throw pop & load ex
+        try {
+            storage::WaitAllFutures(load_futures);
+        } catch (...) {
+            LOG_WARN("WaitAllFutures exception swallowed");
+        }
+        throw;
     }
 
     storage::WaitAllFutures(load_futures);

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
@@ -45,6 +45,7 @@
 #include "milvus-storage/reader.h"
 #include "segcore/Utils.h"
 #include "segcore/memory_planner.h"
+#include "storage/ThreadPools.h"
 #include "segcore/storagev2translator/GroupCTMeta.h"
 #include "storage/Util.h"
 
@@ -225,7 +226,10 @@ ManifestGroupTranslator::get_cells(
     auto factory = milvus::segcore::MakeChunkReaderFactory(chunk_reader_);
 
     // Submit cell-batch loading tasks
-    auto channel = std::make_shared<milvus::segcore::CellReaderChannel>();
+    auto& pool = milvus::ThreadPools::GetThreadPool(
+        milvus::PriorityForLoad(load_priority_));
+    auto channel = std::make_shared<milvus::segcore::CellReaderChannel>(
+        static_cast<size_t>(pool.GetMaxThreadNum() * 1.5));
 
     auto load_futures =
         milvus::segcore::LoadCellBatchAsync(ctx,

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
@@ -17,12 +17,10 @@
 #include "segcore/storagev2translator/ManifestGroupTranslator.h"
 
 #include <algorithm>
-#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <filesystem>
 #include <memory>
-#include <numeric>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -55,7 +53,7 @@ ManifestGroupTranslator::ManifestGroupTranslator(
     int64_t segment_id,
     GroupChunkType group_chunk_type,
     int64_t column_group_index,
-    std::unique_ptr<milvus_storage::api::ChunkReader> chunk_reader,
+    std::shared_ptr<milvus_storage::api::ChunkReader> chunk_reader,
     const std::unordered_map<FieldId, FieldMeta>& field_metas,
     bool use_mmap,
     bool mmap_populate,
@@ -223,29 +221,7 @@ ManifestGroupTranslator::get_cells(
     }
 
     // Create factory using ChunkReader — reads a batch of row groups at once
-    milvus::segcore::BatchReaderFactory factory =
-        [chunk_reader = chunk_reader_.get()](size_t /*batch_key*/,
-                                             int64_t rg_offset,
-                                             int64_t total_rg_count,
-                                             int64_t /*reader_memory_limit*/)
-        -> arrow::Result<milvus::segcore::SequentialRowGroupReader> {
-        // Pre-load all row groups for this batch via get_chunks
-        std::vector<int64_t> rg_indices(total_rg_count);
-        std::iota(rg_indices.begin(), rg_indices.end(), rg_offset);
-        ARROW_ASSIGN_OR_RAISE(
-            auto batches,
-            chunk_reader->get_chunks(rg_indices, /*parallelism=*/1));
-        auto shared_batches =
-            std::make_shared<std::vector<std::shared_ptr<arrow::RecordBatch>>>(
-                std::move(batches));
-        auto idx = std::make_shared<size_t>(0);
-        return milvus::segcore::SequentialRowGroupReader(
-            [shared_batches,
-             idx]() -> arrow::Result<std::shared_ptr<arrow::Table>> {
-                return arrow::Table::FromRecordBatches(
-                    {(*shared_batches)[(*idx)++]});
-            });
-    };
+    auto factory = milvus::segcore::MakeChunkReaderFactory(chunk_reader_);
 
     // Submit cell-batch loading tasks
     auto channel = std::make_shared<milvus::segcore::CellReaderChannel>();

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
@@ -22,6 +22,7 @@
 #include <cstdint>
 #include <filesystem>
 #include <memory>
+#include <numeric>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -44,7 +45,9 @@
 #include "log/Log.h"
 #include "milvus-storage/reader.h"
 #include "segcore/Utils.h"
+#include "segcore/memory_planner.h"
 #include "segcore/storagev2translator/GroupCTMeta.h"
+#include "storage/Util.h"
 
 namespace milvus::segcore::storagev2translator {
 
@@ -208,53 +211,83 @@ ManifestGroupTranslator::get_cells(
             meta_.chunk_memory_size_.size());
     }
 
-    // Collect all row group indices needed for the requested cells
-    std::vector<int64_t> needed_row_group_indices;
-    needed_row_group_indices.reserve(kRowGroupsPerCell * cids.size());
+    // Build CellSpec for each requested cid
+    std::vector<milvus::segcore::CellSpec> cell_specs;
+    cell_specs.reserve(cids.size());
     for (auto cid : cids) {
         auto [start, end] = meta_.get_row_group_range(cid);
-        for (size_t i = start; i < end; ++i) {
-            needed_row_group_indices.push_back(static_cast<int64_t>(i));
-        }
+        cell_specs.push_back({cid,
+                              /*file_idx=*/0,
+                              static_cast<int64_t>(start),
+                              static_cast<int64_t>(end - start)});
     }
 
-    auto parallel_degree =
-        static_cast<uint64_t>(DEFAULT_FIELD_MAX_MEMORY_LIMIT / FILE_SLICE_SIZE);
+    // Create factory using ChunkReader — reads a batch of row groups at once
+    milvus::segcore::BatchReaderFactory factory =
+        [chunk_reader = chunk_reader_.get()](size_t /*batch_key*/,
+                                             int64_t rg_offset,
+                                             int64_t total_rg_count,
+                                             int64_t /*reader_memory_limit*/)
+        -> arrow::Result<milvus::segcore::SequentialRowGroupReader> {
+        // Pre-load all row groups for this batch via get_chunks
+        std::vector<int64_t> rg_indices(total_rg_count);
+        std::iota(rg_indices.begin(), rg_indices.end(), rg_offset);
+        ARROW_ASSIGN_OR_RAISE(
+            auto batches,
+            chunk_reader->get_chunks(rg_indices, /*parallelism=*/1));
+        auto shared_batches =
+            std::make_shared<std::vector<std::shared_ptr<arrow::RecordBatch>>>(
+                std::move(batches));
+        auto idx = std::make_shared<size_t>(0);
+        return milvus::segcore::SequentialRowGroupReader(
+            [shared_batches,
+             idx]() -> arrow::Result<std::shared_ptr<arrow::Table>> {
+                return arrow::Table::FromRecordBatches(
+                    {(*shared_batches)[(*idx)++]});
+            });
+    };
 
-    auto read_result = chunk_reader_->get_chunks(
-        needed_row_group_indices, static_cast<int64_t>(parallel_degree));
+    // Submit cell-batch loading tasks
+    auto channel = std::make_shared<milvus::segcore::CellReaderChannel>();
 
-    if (!read_result.ok()) {
-        throw std::runtime_error("get chunk failed");
+    auto load_futures =
+        milvus::segcore::LoadCellBatchAsync(ctx,
+                                            std::move(cell_specs),
+                                            std::move(factory),
+                                            channel,
+                                            DEFAULT_FIELD_MAX_MEMORY_LIMIT,
+                                            load_priority_);
+
+    LOG_INFO(
+        "[StorageV2] translator {} submits {} batch tasks for manifest column "
+        "group {}",
+        key_,
+        load_futures.size(),
+        column_group_index_);
+
+    // Pop loop — convert each cell immediately, no ArrowTable accumulation
+    std::unordered_map<milvus::cachinglayer::cid_t,
+                       std::unique_ptr<milvus::GroupChunk>>
+        completed_cells;
+    completed_cells.reserve(cids.size());
+
+    std::shared_ptr<milvus::segcore::CellLoadResult> cell_data;
+    while (channel->pop(cell_data)) {
+        CheckCancellation(
+            ctx, segment_id_, "ManifestGroupTranslator::get_cells()");
+        completed_cells[cell_data->cid] =
+            load_group_chunk(cell_data->tables, cell_data->cid);
     }
 
-    auto loaded_row_groups = read_result.ValueOrDie();
+    storage::WaitAllFutures(load_futures);
 
-    // Build a map from row group index to loaded record batch
-    std::unordered_map<int64_t, std::shared_ptr<arrow::RecordBatch>>
-        row_group_map;
-    row_group_map.reserve(needed_row_group_indices.size());
-    for (size_t i = 0; i < needed_row_group_indices.size(); ++i) {
-        row_group_map[needed_row_group_indices[i]] = loaded_row_groups[i];
-    }
-
-    for (const auto& cid : cids) {
-        auto [start, end] = meta_.get_row_group_range(cid);
-        std::vector<std::shared_ptr<arrow::RecordBatch>> record_batches;
-        record_batches.reserve(end - start);
-
-        for (size_t i = start; i < end; ++i) {
-            auto it = row_group_map.find(static_cast<int64_t>(i));
-            AssertInfo(it != row_group_map.end(),
-                       fmt::format("[StorageV2] translator {} row group {} for "
-                                   "cell {} was not loaded",
-                                   key_,
-                                   i,
-                                   cid));
-            record_batches.push_back(it->second);
-        }
-
-        cells.emplace_back(cid, load_group_chunk(record_batches, cid));
+    for (auto cid : cids) {
+        auto it = completed_cells.find(cid);
+        AssertInfo(
+            it != completed_cells.end(),
+            fmt::format(
+                "[StorageV2] translator {} cell {} not loaded", key_, cid));
+        cells.emplace_back(cid, std::move(it->second));
     }
 
     return cells;
@@ -262,23 +295,23 @@ ManifestGroupTranslator::get_cells(
 
 std::unique_ptr<milvus::GroupChunk>
 ManifestGroupTranslator::load_group_chunk(
-    const std::vector<std::shared_ptr<arrow::RecordBatch>>& record_batches,
+    const std::vector<std::shared_ptr<arrow::Table>>& tables,
     const milvus::cachinglayer::cid_t cid) {
-    assert(!record_batches.empty());
-    // Use the first record batch as the reference for field iteration
-    const auto& first_batch = record_batches[0];
+    assert(!tables.empty());
+    // Use the first table's schema as reference for field iteration
+    const auto& schema = tables[0]->schema();
 
     std::vector<FieldId> field_ids;
-    field_ids.reserve(first_batch->num_columns());
+    field_ids.reserve(schema->num_fields());
     std::vector<FieldMeta> field_metas;
-    field_metas.reserve(first_batch->num_columns());
+    field_metas.reserve(schema->num_fields());
     std::vector<arrow::ArrayVector> array_vecs;
-    array_vecs.reserve(first_batch->num_columns());
+    array_vecs.reserve(schema->num_fields());
 
-    // Iterate through field_id_list to get field_id and create chunk
-    for (int i = 0; i < first_batch->num_columns(); ++i) {
-        // column name here is field id
-        auto column_name = first_batch->column_name(i);
+    // Iterate through fields to get field_id and create chunk
+    for (int i = 0; i < schema->num_fields(); ++i) {
+        // column name here is field id (ChunkReader stores field IDs as column names)
+        auto column_name = schema->field(i)->name();
         auto field_id = std::stoll(column_name);
 
         auto fid = milvus::FieldId(field_id);
@@ -288,22 +321,19 @@ ManifestGroupTranslator::load_group_chunk(
         }
         auto it = field_metas_.find(fid);
         // Workaround for projection push-down missing for chunk reader
-        // change back to asssertion after supported
+        // change back to assertion after supported
         if (it == field_metas_.end()) {
             continue;
         }
-        // AssertInfo(
-        //     it != field_metas_.end(),
-        //     "[StorageV2] translator {} field id {} not found in field_metas",
-        //     key_,
-        //     fid.get());
         const auto& field_meta = it->second;
 
-        // Merge arrays from all record batches for this field
-        // All record batches in a cell come from the same column group with consistent schema
+        // Merge arrays from all tables for this field
+        // All tables in a cell come from the same column group with consistent schema
         arrow::ArrayVector merged_array_vec;
-        for (const auto& batch : record_batches) {
-            merged_array_vec.push_back(batch->column(i));
+        for (const auto& table : tables) {
+            auto chunks = table->column(i)->chunks();
+            merged_array_vec.insert(
+                merged_array_vec.end(), chunks.begin(), chunks.end());
         }
 
         field_ids.push_back(fid);

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.h
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.h
@@ -69,7 +69,7 @@ class ManifestGroupTranslator
         int64_t segment_id,
         GroupChunkType group_chunk_type,
         int64_t column_group_index,
-        std::unique_ptr<milvus_storage::api::ChunkReader> chunk_reader,
+        std::shared_ptr<milvus_storage::api::ChunkReader> chunk_reader,
         const std::unordered_map<FieldId, FieldMeta>& field_metas,
         bool use_mmap,
         bool mmap_populate,
@@ -187,7 +187,7 @@ class ManifestGroupTranslator
     int64_t column_group_index_;
     std::string key_;
     std::unordered_map<FieldId, FieldMeta> field_metas_;
-    std::unique_ptr<milvus_storage::api::ChunkReader> chunk_reader_;
+    std::shared_ptr<milvus_storage::api::ChunkReader> chunk_reader_;
 
     GroupCTMeta meta_;
     bool use_mmap_;

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.h
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.h
@@ -27,6 +27,7 @@
 
 #include "NamedType/underlying_functionalities.hpp"
 #include "arrow/record_batch.h"
+#include "arrow/table.h"
 #include "cachinglayer/Translator.h"
 #include "cachinglayer/Utils.h"
 #include "common/FieldMeta.h"
@@ -168,19 +169,18 @@ class ManifestGroupTranslator
 
  private:
     /**
-     * @brief Load a cell from multiple Arrow RecordBatches
+     * @brief Load a cell from multiple Arrow Tables
      *
-     * Converts multiple Arrow RecordBatches (from row groups) into a single
+     * Converts multiple Arrow Tables (from row groups) into a single
      * GroupChunk containing merged field data for all columns.
      *
-     * @param record_batches Arrow RecordBatches from row groups
+     * @param tables Arrow Tables from row groups
      * @param cid Cell ID of the chunk being loaded
      * @return GroupChunk containing the loaded field data
      */
     std::unique_ptr<milvus::GroupChunk>
-    load_group_chunk(
-        const std::vector<std::shared_ptr<arrow::RecordBatch>>& record_batches,
-        milvus::cachinglayer::cid_t cid);
+    load_group_chunk(const std::vector<std::shared_ptr<arrow::Table>>& tables,
+                     milvus::cachinglayer::cid_t cid);
 
     int64_t segment_id_;
     GroupChunkType group_chunk_type_;


### PR DESCRIPTION
Related to #47858

ManifestGroupTranslator::get_cells() previously called chunk_reader_->get_chunks() with ALL needed row group indices at once, loading every row group into memory simultaneously. This caused memory spikes proportional to the total size of all requested cells.

Refactor LoadCellBatchAsync into a generic streaming loader that accepts a pluggable BatchReaderFactory, enabling both ManifestGroupTranslator (ChunkReader-based) and GroupChunkTranslator (file-based) to share the same channel-based streaming infrastructure.

Key changes:
- Add BatchReaderFactory / SequentialRowGroupReader abstractions to memory_planner.h, allowing LoadCellBatchAsync to work with any row-group data source
- Add MakeFileReaderFactory() that encapsulates FileRowGroupReader creation, replacing the old file-path-based LoadCellBatchAsync overload
- ManifestGroupTranslator now loads per-batch via chunk_reader_->get_chunks(rg_indices, 1) instead of one bulk get_chunks() for all cells, streaming results through channel
- ManifestGroupTranslator::load_group_chunk() changed from RecordBatch to Table input to match the unified CellLoadResult format
- GroupChunkTranslator updated to use MakeFileReaderFactory + generic LoadCellBatchAsync (no behavioral change)

Peak memory during get_cells() drops from O(all_requested_cells) to O(single_cell).