### PR TITLE
fix: add snapshot privileges to database-level privilege groups

### DIFF
--- a/internal/datacoord/garbage_collector_test.go
+++ b/internal/datacoord/garbage_collector_test.go
@@ -2394,7 +2394,8 @@ func TestGarbageCollector_recycleUnusedTextIndexFiles_SnapshotReference(t *testi
 	// Mock WalkWithPrefix to simulate text index files
 	mockWalk := mockey.Mock((*storage.LocalChunkManager).WalkWithPrefix).To(
 		func(cm *storage.LocalChunkManager, ctx context.Context, prefix string,
-			recursive bool, fn storage.ChunkObjectWalkFunc) error {
+			recursive bool, fn storage.ChunkObjectWalkFunc,
+		) error {
 			if strings.Contains(prefix, "text_index") {
 				chunkInfo := &storage.ChunkObjectInfo{
 					FilePath:   "gc/text_index/401/1/100/10/1001/101/file1",
@@ -2481,7 +2482,8 @@ func TestGarbageCollector_recycleUnusedJSONIndexFiles_SnapshotReference(t *testi
 	// Mock WalkWithPrefix to simulate JSON index files
 	mockWalk := mockey.Mock((*storage.LocalChunkManager).WalkWithPrefix).To(
 		func(cm *storage.LocalChunkManager, ctx context.Context, prefix string,
-			recursive bool, fn storage.ChunkObjectWalkFunc) error {
+			recursive bool, fn storage.ChunkObjectWalkFunc,
+		) error {
 			if strings.Contains(prefix, "json_index") {
 				chunkInfo := &storage.ChunkObjectInfo{
 					FilePath:   "gc/json_index/402/1/100/10/1002/102/json_file1",
@@ -2632,7 +2634,8 @@ func TestGarbageCollector_recycleUnusedTextIndexFiles_SkipWhenRefIndexNotLoaded(
 
 	mockWalk := mockey.Mock((*storage.LocalChunkManager).WalkWithPrefix).To(
 		func(cm *storage.LocalChunkManager, ctx context.Context, prefix string,
-			recursive bool, fn storage.ChunkObjectWalkFunc) error {
+			recursive bool, fn storage.ChunkObjectWalkFunc,
+		) error {
 			if strings.Contains(prefix, "text_index") {
 				chunkInfo := &storage.ChunkObjectInfo{
 					FilePath:   "gc/text_index/401/1/100/10/1001/101/file1",
@@ -2710,7 +2713,8 @@ func TestGarbageCollector_recycleUnusedJSONIndexFiles_SkipWhenRefIndexNotLoaded(
 
 	mockWalk := mockey.Mock((*storage.LocalChunkManager).WalkWithPrefix).To(
 		func(cm *storage.LocalChunkManager, ctx context.Context, prefix string,
-			recursive bool, fn storage.ChunkObjectWalkFunc) error {
+			recursive bool, fn storage.ChunkObjectWalkFunc,
+		) error {
 			if strings.Contains(prefix, "json_index") {
 				chunkInfo := &storage.ChunkObjectInfo{
 					FilePath:   "gc/json_index/402/1/100/10/1002/102/json_file1",

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -353,11 +353,15 @@ var (
 	DatabaseReadOnlyPrivileges = ConvertPrivileges([]string{
 		commonpb.ObjectPrivilege_PrivilegeShowCollections.String(),
 		commonpb.ObjectPrivilege_PrivilegeDescribeDatabase.String(),
+		commonpb.ObjectPrivilege_PrivilegeDescribeSnapshot.String(),
+		commonpb.ObjectPrivilege_PrivilegeListSnapshots.String(),
 	})
 
 	DatabaseReadWritePrivileges = append(DatabaseReadOnlyPrivileges,
 		ConvertPrivileges([]string{
 			commonpb.ObjectPrivilege_PrivilegeAlterDatabase.String(),
+			commonpb.ObjectPrivilege_PrivilegeCreateSnapshot.String(),
+			commonpb.ObjectPrivilege_PrivilegeDropSnapshot.String(),
 		})...,
 	)
 
@@ -365,6 +369,7 @@ var (
 		ConvertPrivileges([]string{
 			commonpb.ObjectPrivilege_PrivilegeCreateCollection.String(),
 			commonpb.ObjectPrivilege_PrivilegeDropCollection.String(),
+			commonpb.ObjectPrivilege_PrivilegeRestoreSnapshot.String(),
 		})...,
 	)
 

--- a/pkg/util/constant_test.go
+++ b/pkg/util/constant_test.go
@@ -19,6 +19,7 @@ package util
 import (
 	"testing"
 
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
@@ -36,4 +37,97 @@ func TestGetReplicateConfigurationPrivilege(t *testing.T) {
 		}
 	}
 	assert.True(t, found, "PrivilegeGetReplicateConfiguration should be in ClusterReadOnlyPrivileges")
+}
+
+func TestSnapshotPrivilegesInDatabaseGroups(t *testing.T) {
+	describeSnapshot := MetaStore2API(commonpb.ObjectPrivilege_PrivilegeDescribeSnapshot.String())
+	listSnapshots := MetaStore2API(commonpb.ObjectPrivilege_PrivilegeListSnapshots.String())
+	createSnapshot := MetaStore2API(commonpb.ObjectPrivilege_PrivilegeCreateSnapshot.String())
+	dropSnapshot := MetaStore2API(commonpb.ObjectPrivilege_PrivilegeDropSnapshot.String())
+	restoreSnapshot := MetaStore2API(commonpb.ObjectPrivilege_PrivilegeRestoreSnapshot.String())
+
+	tests := []struct {
+		name      string
+		privilege string
+		inGroups  map[string][]string
+		notIn     map[string][]string
+	}{
+		{
+			name:      "DescribeSnapshot in DatabaseReadOnly/ReadWrite/Admin",
+			privilege: describeSnapshot,
+			inGroups: map[string][]string{
+				"DatabaseReadOnly":  DatabaseReadOnlyPrivileges,
+				"DatabaseReadWrite": DatabaseReadWritePrivileges,
+				"DatabaseAdmin":     DatabaseAdminPrivileges,
+			},
+			notIn: map[string][]string{
+				"ClusterReadOnly": ClusterReadOnlyPrivileges,
+				"ClusterAdmin":    ClusterAdminPrivileges,
+			},
+		},
+		{
+			name:      "ListSnapshots in DatabaseReadOnly/ReadWrite/Admin",
+			privilege: listSnapshots,
+			inGroups: map[string][]string{
+				"DatabaseReadOnly":  DatabaseReadOnlyPrivileges,
+				"DatabaseReadWrite": DatabaseReadWritePrivileges,
+				"DatabaseAdmin":     DatabaseAdminPrivileges,
+			},
+			notIn: map[string][]string{
+				"ClusterReadOnly": ClusterReadOnlyPrivileges,
+				"ClusterAdmin":    ClusterAdminPrivileges,
+			},
+		},
+		{
+			name:      "CreateSnapshot in DatabaseReadWrite/Admin only",
+			privilege: createSnapshot,
+			inGroups: map[string][]string{
+				"DatabaseReadWrite": DatabaseReadWritePrivileges,
+				"DatabaseAdmin":     DatabaseAdminPrivileges,
+			},
+			notIn: map[string][]string{
+				"DatabaseReadOnly": DatabaseReadOnlyPrivileges,
+				"ClusterReadWrite": ClusterReadWritePrivileges,
+				"ClusterAdmin":     ClusterAdminPrivileges,
+			},
+		},
+		{
+			name:      "DropSnapshot in DatabaseReadWrite/Admin only",
+			privilege: dropSnapshot,
+			inGroups: map[string][]string{
+				"DatabaseReadWrite": DatabaseReadWritePrivileges,
+				"DatabaseAdmin":     DatabaseAdminPrivileges,
+			},
+			notIn: map[string][]string{
+				"DatabaseReadOnly": DatabaseReadOnlyPrivileges,
+				"ClusterReadWrite": ClusterReadWritePrivileges,
+				"ClusterAdmin":     ClusterAdminPrivileges,
+			},
+		},
+		{
+			name:      "RestoreSnapshot in DatabaseAdmin only",
+			privilege: restoreSnapshot,
+			inGroups: map[string][]string{
+				"DatabaseAdmin": DatabaseAdminPrivileges,
+			},
+			notIn: map[string][]string{
+				"DatabaseReadOnly":  DatabaseReadOnlyPrivileges,
+				"DatabaseReadWrite": DatabaseReadWritePrivileges,
+				"ClusterAdmin":      ClusterAdminPrivileges,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			for groupName, group := range tc.inGroups {
+				assert.True(t, lo.Contains(group, tc.privilege),
+					"%s should be in %s", tc.privilege, groupName)
+			}
+			for groupName, group := range tc.notIn {
+				assert.False(t, lo.Contains(group, tc.privilege),
+					"%s should NOT be in %s", tc.privilege, groupName)
+			}
+		})
+	}
 }

--- a/tests/go_client/testcases/advcases/rbac_test.go
+++ b/tests/go_client/testcases/advcases/rbac_test.go
@@ -767,3 +767,172 @@ func TestRevokePrivilegeInvalid(t *testing.T) {
 	err = mc.RevokePrivilegeV2(ctx, client.NewRevokePrivilegeV2Option(roleName, "CollectionAdmin", "*").WithDbName(common.GenRandomString("db", 6)))
 	common.CheckErr(t, err, true)
 }
+
+// TestSnapshotPrivilegesDatabaseLevel verifies that snapshot privileges are database-level,
+// meaning they can be granted per-database and actual API calls respect those permissions.
+// It tests a progression from read-only (List/Describe) to read-write (Create/Drop) privileges.
+func TestSnapshotPrivilegesDatabaseLevel(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateMilvusClient(ctx, t, &client.ClientConfig{Address: hp.GetAddr(), Username: hp.GetUser(), Password: hp.GetPassword()})
+	setupTest(t, ctx, mc)
+
+	// Step 1: Root user prepares test data - create collection, insert data, flush, create snapshot
+	collName := common.GenRandomString("snapshot", 6)
+	err := mc.CreateCollection(ctx, client.SimpleCreateCollectionOptions(collName, common.DefaultDim))
+	common.CheckErr(t, err, true)
+	coll, err := mc.DescribeCollection(ctx, client.NewDescribeCollectionOption(collName))
+	common.CheckErr(t, err, true)
+	prepare, _ := hp.CollPrepare.InsertData(ctx, t, mc, hp.NewInsertParams(coll.Schema), hp.TNewDataOption())
+	prepare.FlushData(ctx, t, mc, collName)
+
+	snapName := common.GenRandomString("snap", 6)
+	err = mc.CreateSnapshot(ctx, client.NewCreateSnapshotOption(snapName, collName))
+	common.CheckErr(t, err, true)
+	snapName2 := common.GenRandomString("snap", 6)
+	t.Cleanup(func() {
+		_ = mc.DropSnapshot(ctx, client.NewDropSnapshotOption(snapName))
+		_ = mc.DropSnapshot(ctx, client.NewDropSnapshotOption(snapName2))
+		_ = mc.DropCollection(ctx, client.NewDropCollectionOption(collName))
+	})
+
+	// Step 2: Create user + role
+	userName := common.GenRandomString("user", 6)
+	pwd := common.GenRandomString("pwd", 6)
+	roleName := common.GenRandomString("role", 6)
+	err = mc.CreateUser(ctx, client.NewCreateUserOption(userName, pwd))
+	common.CheckErr(t, err, true)
+	err = mc.CreateRole(ctx, client.NewCreateRoleOption(roleName))
+	common.CheckErr(t, err, true)
+	err = mc.GrantRole(ctx, client.NewGrantRoleOption(userName, roleName))
+	common.CheckErr(t, err, true)
+
+	// Step 3: Grant read-only snapshot privileges on default database
+	err = mc.GrantPrivilegeV2(ctx, client.NewGrantPrivilegeV2Option(roleName, "ListSnapshots", AllObjectName).WithDbName("default"))
+	common.CheckErr(t, err, true)
+	err = mc.GrantPrivilegeV2(ctx, client.NewGrantPrivilegeV2Option(roleName, "DescribeSnapshot", AllObjectName).WithDbName("default"))
+	common.CheckErr(t, err, true)
+
+	mcUser := hp.CreateMilvusClient(ctx, t, &client.ClientConfig{Address: hp.GetAddr(), Username: userName, Password: pwd})
+
+	// Step 4: ListSnapshots on default db → should succeed after privilege propagation
+	require.Eventuallyf(t, func() bool {
+		_, err = mcUser.ListSnapshots(ctx, client.NewListSnapshotsOption().WithDbName("default"))
+		return err == nil
+	}, time.Second*10, 2*time.Second, "Waiting for ListSnapshots permission to take effect")
+
+	// Step 5: DescribeSnapshot → should succeed (privilege granted, client connected to default db)
+	_, err = mcUser.DescribeSnapshot(ctx, client.NewDescribeSnapshotOption(snapName))
+	common.CheckErr(t, err, true)
+
+	// Step 6: CreateSnapshot → should be denied (no CreateSnapshot privilege yet)
+	err = mcUser.CreateSnapshot(ctx, client.NewCreateSnapshotOption(snapName2, collName).WithDbName("default"))
+	common.CheckErr(t, err, false, "permission deny")
+
+	// Step 7: Grant CreateSnapshot privilege
+	err = mc.GrantPrivilegeV2(ctx, client.NewGrantPrivilegeV2Option(roleName, "CreateSnapshot", AllObjectName).WithDbName("default"))
+	common.CheckErr(t, err, true)
+
+	// Step 8: CreateSnapshot → should succeed after privilege propagation
+	require.Eventuallyf(t, func() bool {
+		err = mcUser.CreateSnapshot(ctx, client.NewCreateSnapshotOption(snapName2, collName).WithDbName("default"))
+		return err == nil
+	}, time.Second*10, 2*time.Second, "Waiting for CreateSnapshot permission to take effect")
+
+	// Step 9: Grant DropSnapshot privilege
+	err = mc.GrantPrivilegeV2(ctx, client.NewGrantPrivilegeV2Option(roleName, "DropSnapshot", AllObjectName).WithDbName("default"))
+	common.CheckErr(t, err, true)
+
+	// Step 10: DropSnapshot → should succeed after privilege propagation
+	require.Eventuallyf(t, func() bool {
+		err = mcUser.DropSnapshot(ctx, client.NewDropSnapshotOption(snapName2))
+		return err == nil
+	}, time.Second*10, 2*time.Second, "Waiting for DropSnapshot permission to take effect")
+}
+
+// TestSnapshotPrivilegeDatabaseIsolation verifies that granting a snapshot privilege
+// on one database does NOT allow access to another database's snapshots.
+func TestSnapshotPrivilegeDatabaseIsolation(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateMilvusClient(ctx, t, &client.ClientConfig{Address: hp.GetAddr(), Username: hp.GetUser(), Password: hp.GetPassword()})
+	setupTest(t, ctx, mc)
+
+	// Step 1: Create two databases
+	dbA := common.GenRandomString("db", 6)
+	dbB := common.GenRandomString("db", 6)
+	err := mc.CreateDatabase(ctx, client.NewCreateDatabaseOption(dbA))
+	common.CheckErr(t, err, true)
+	err = mc.CreateDatabase(ctx, client.NewCreateDatabaseOption(dbB))
+	common.CheckErr(t, err, true)
+
+	// Step 2: Create collections, insert data, and create snapshots in both databases
+	mcA := hp.CreateMilvusClient(ctx, t, &client.ClientConfig{Address: hp.GetAddr(), Username: hp.GetUser(), Password: hp.GetPassword(), DBName: dbA})
+	collA := common.GenRandomString("coll", 6)
+	err = mcA.CreateCollection(ctx, client.SimpleCreateCollectionOptions(collA, common.DefaultDim))
+	common.CheckErr(t, err, true)
+	collADesc, err := mcA.DescribeCollection(ctx, client.NewDescribeCollectionOption(collA))
+	common.CheckErr(t, err, true)
+	prepareA, _ := hp.CollPrepare.InsertData(ctx, t, mcA, hp.NewInsertParams(collADesc.Schema), hp.TNewDataOption())
+	prepareA.FlushData(ctx, t, mcA, collA)
+	snapA := common.GenRandomString("snap", 6)
+	err = mcA.CreateSnapshot(ctx, client.NewCreateSnapshotOption(snapA, collA))
+	common.CheckErr(t, err, true)
+
+	mcB := hp.CreateMilvusClient(ctx, t, &client.ClientConfig{Address: hp.GetAddr(), Username: hp.GetUser(), Password: hp.GetPassword(), DBName: dbB})
+	collB := common.GenRandomString("coll", 6)
+	err = mcB.CreateCollection(ctx, client.SimpleCreateCollectionOptions(collB, common.DefaultDim))
+	common.CheckErr(t, err, true)
+	collBDesc, err := mcB.DescribeCollection(ctx, client.NewDescribeCollectionOption(collB))
+	common.CheckErr(t, err, true)
+	prepareB, _ := hp.CollPrepare.InsertData(ctx, t, mcB, hp.NewInsertParams(collBDesc.Schema), hp.TNewDataOption())
+	prepareB.FlushData(ctx, t, mcB, collB)
+	snapB := common.GenRandomString("snap", 6)
+	err = mcB.CreateSnapshot(ctx, client.NewCreateSnapshotOption(snapB, collB))
+	common.CheckErr(t, err, true)
+
+	snapUserA := common.GenRandomString("snap", 6)
+	t.Cleanup(func() {
+		_ = mcA.DropSnapshot(ctx, client.NewDropSnapshotOption(snapA))
+		_ = mcA.DropSnapshot(ctx, client.NewDropSnapshotOption(snapUserA))
+		_ = mcB.DropSnapshot(ctx, client.NewDropSnapshotOption(snapB))
+		_ = mcA.DropCollection(ctx, client.NewDropCollectionOption(collA))
+		_ = mcB.DropCollection(ctx, client.NewDropCollectionOption(collB))
+		_ = mc.DropDatabase(ctx, client.NewDropDatabaseOption(dbA))
+		_ = mc.DropDatabase(ctx, client.NewDropDatabaseOption(dbB))
+	})
+
+	// Step 3: Create user + role, grant ListSnapshots + CreateSnapshot only on dbA
+	userName := common.GenRandomString("user", 6)
+	pwd := common.GenRandomString("pwd", 6)
+	roleName := common.GenRandomString("role", 6)
+	err = mc.CreateUser(ctx, client.NewCreateUserOption(userName, pwd))
+	common.CheckErr(t, err, true)
+	err = mc.CreateRole(ctx, client.NewCreateRoleOption(roleName))
+	common.CheckErr(t, err, true)
+	err = mc.GrantRole(ctx, client.NewGrantRoleOption(userName, roleName))
+	common.CheckErr(t, err, true)
+	err = mc.GrantPrivilegeV2(ctx, client.NewGrantPrivilegeV2Option(roleName, "ListSnapshots", AllObjectName).WithDbName(dbA))
+	common.CheckErr(t, err, true)
+	err = mc.GrantPrivilegeV2(ctx, client.NewGrantPrivilegeV2Option(roleName, "CreateSnapshot", AllObjectName).WithDbName(dbA))
+	common.CheckErr(t, err, true)
+
+	mcUser := hp.CreateMilvusClient(ctx, t, &client.ClientConfig{Address: hp.GetAddr(), Username: userName, Password: pwd})
+
+	// Step 4: ListSnapshots on dbA → should succeed
+	require.Eventuallyf(t, func() bool {
+		_, err = mcUser.ListSnapshots(ctx, client.NewListSnapshotsOption().WithDbName(dbA))
+		return err == nil
+	}, time.Second*10, 2*time.Second, "Waiting for ListSnapshots permission on dbA to take effect")
+
+	// Step 5: ListSnapshots on dbB → should be denied
+	_, err = mcUser.ListSnapshots(ctx, client.NewListSnapshotsOption().WithDbName(dbB))
+	common.CheckErr(t, err, false, "permission deny")
+
+	// Step 6: CreateSnapshot in dbA → should succeed
+	err = mcUser.CreateSnapshot(ctx, client.NewCreateSnapshotOption(snapUserA, collA).WithDbName(dbA))
+	common.CheckErr(t, err, true)
+
+	// Step 7: CreateSnapshot in dbB → should be denied
+	snapUserB := common.GenRandomString("snap", 6)
+	err = mcUser.CreateSnapshot(ctx, client.NewCreateSnapshotOption(snapUserB, collB).WithDbName(dbB))
+	common.CheckErr(t, err, false, "permission deny")
+}


### PR DESCRIPTION
issue: #44358

## Summary
- Move snapshot privileges from cluster-level to database-level builtin privilege groups, enabling per-database access control for snapshot operations
- DescribeSnapshot, ListSnapshots → DatabaseReadOnly; CreateSnapshot, DropSnapshot → DatabaseReadWrite; RestoreSnapshot → DatabaseAdmin
- Add unit tests for group membership and E2E tests for database-level enforcement and cross-database isolation

issue: #47855
issue: #47890

## Test plan
- [x] Unit tests: `TestSnapshotPrivilegesInDatabaseGroups` validates all 5 privileges in correct database groups and absent from cluster groups
- [ ] E2E tests: `TestSnapshotPrivilegesDatabaseLevel` verifies per-database privilege grant/deny progression
- [ ] E2E tests: `TestSnapshotPrivilegeDatabaseIsolation` verifies cross-database permission isolation