### PR TITLE
fix: memory leak in broadcasterScheduler.AddTask due to uncanceled MergeContext

### DIFF
--- a/internal/streamingcoord/server/broadcaster/broadcast_scheduler.go
+++ b/internal/streamingcoord/server/broadcaster/broadcast_scheduler.go
@@ -54,7 +54,8 @@ func (b *broadcasterScheduler) AddTask(ctx context.Context, task *pendingBroadca
 	}
 
 	// Wait both request context and the background task context.
-	ctx, _ = contextutil.MergeContext(ctx, b.backgroundTaskNotifier.Context())
+	ctx, cancel := contextutil.MergeContext(ctx, b.backgroundTaskNotifier.Context())
+	defer cancel()
 	// wait for all the vchannels acked.
 	result, err := task.BlockUntilDone(ctx)
 	if err != nil {


### PR DESCRIPTION
issue: #47908