### PR TITLE
enhance: optimize RANDOM_SAMPLE sampling algorithms

### DIFF
--- a/internal/core/src/exec/operator/RandomSampleBench.cpp
+++ b/internal/core/src/exec/operator/RandomSampleBench.cpp
@@ -1,0 +1,371 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Standalone benchmark for RandomSampleNode sampling algorithms.
+// No Milvus dependencies — compile with:
+//   g++ -O2 -std=c++17 -o /tmp/bench RandomSampleBench.cpp && /tmp/bench
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <limits>
+#include <numeric>
+#include <random>
+#include <unordered_set>
+#include <vector>
+
+// ============================================================================
+// Shared: thread-local PRNG (used by NEW implementations)
+// ============================================================================
+
+std::mt19937&
+GetThreadLocalGen() {
+    thread_local std::mt19937 gen(std::random_device{}());
+    return gen;
+}
+
+// ============================================================================
+// Shared: dispatch threshold (same logic as production code)
+// ============================================================================
+
+bool
+UseFloydPath(uint32_t N, float factor) {
+    float epsilon = std::numeric_limits<float>::epsilon();
+    return factor <= 0.02 + epsilon ||
+           (N <= 10000000 && factor <= 0.045 + epsilon) ||
+           (N <= 60000000 && factor <= 0.025 + epsilon);
+}
+
+// ============================================================================
+// OLD implementations (baseline — per-call seeding, vector materialization)
+// ============================================================================
+
+std::vector<uint32_t>
+OldHashsetSample(uint32_t N, uint32_t M, std::mt19937& gen) {
+    std::uniform_int_distribution<> dis(0, N - 1);
+    std::unordered_set<uint32_t> sampled;
+    sampled.reserve(N);  // bug: reserves N instead of M
+    while (sampled.size() < M) {
+        sampled.insert(dis(gen));
+    }
+    return std::vector<uint32_t>(sampled.begin(), sampled.end());
+}
+
+std::vector<uint32_t>
+OldStandardSample(uint32_t N, uint32_t M, std::mt19937& gen) {
+    std::vector<uint32_t> inputs(N);
+    std::vector<uint32_t> outputs(M);
+    std::iota(inputs.begin(), inputs.end(), 0);
+    std::sample(inputs.begin(), inputs.end(), outputs.begin(), M, gen);
+    return outputs;
+}
+
+std::vector<uint32_t>
+OldSample(uint32_t N, float factor) {
+    uint32_t M = std::max(static_cast<uint32_t>(N * factor), 1u);
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    if (UseFloydPath(N, factor)) {
+        return OldHashsetSample(N, M, gen);
+    }
+    return OldStandardSample(N, M, gen);
+}
+
+// Old source path: Sample() → vector → scatter → flip
+void
+OldSourcePath(std::vector<bool>& bitmap, float factor) {
+    uint32_t N = bitmap.size();
+    bool need_flip = true;
+    float f = factor;
+    if (f > 0.5) {
+        need_flip = false;
+        f = 1.0 - f;
+    }
+    auto sampled = OldSample(N, f);
+    for (auto n : sampled) {
+        bitmap[n] = true;
+    }
+    if (need_flip) {
+        bitmap.flip();
+    }
+}
+
+// Old filtered path: materialize positions → sample → scatter
+void
+OldFilteredSample(std::vector<bool>& bitmap, float factor) {
+    size_t false_count = 0;
+    for (size_t i = 0; i < bitmap.size(); ++i) {
+        if (!bitmap[i])
+            false_count++;
+    }
+    if (false_count == 0)
+        return;
+
+    std::vector<uint32_t> pos;
+    pos.reserve(false_count);
+    for (size_t i = 0; i < bitmap.size(); ++i) {
+        if (!bitmap[i])
+            pos.push_back(i);
+    }
+
+    std::fill(bitmap.begin(), bitmap.end(), true);
+    auto sampled = OldSample(false_count, factor);
+    for (auto idx : sampled) {
+        bitmap[pos[idx]] = false;
+    }
+}
+
+// ============================================================================
+// NEW implementations (thread-local PRNG, direct bitmap writes)
+// ============================================================================
+
+std::vector<uint32_t>
+NewFloydSample(uint32_t N, uint32_t M, std::mt19937& gen) {
+    std::unordered_set<uint32_t> selected;
+    selected.reserve(M);
+    for (uint32_t j = N - M; j < N; ++j) {
+        std::uniform_int_distribution<uint32_t> dis(0, j);
+        uint32_t t = dis(gen);
+        if (!selected.insert(t).second) {
+            selected.insert(j);
+        }
+    }
+    return std::vector<uint32_t>(selected.begin(), selected.end());
+}
+
+// New source path: direct bitmap write, thread-local PRNG, no intermediate vector
+void
+NewSourcePath(std::vector<bool>& bitmap, float factor) {
+    uint32_t N = bitmap.size();
+    bool need_flip = true;
+    float f = factor;
+    if (f > 0.5) {
+        need_flip = false;
+        f = 1.0 - f;
+    }
+    uint32_t M = std::max(static_cast<uint32_t>(N * f), 1u);
+    auto& gen = GetThreadLocalGen();
+
+    if (UseFloydPath(N, f)) {
+        auto sampled = NewFloydSample(N, M, gen);
+        for (auto n : sampled) {
+            bitmap[n] = true;
+        }
+    } else {
+        // Selection sampling: write directly into bitmap
+        uint32_t remaining = N, needed = M;
+        for (uint32_t i = 0; i < N && needed > 0; ++i) {
+            if (std::uniform_int_distribution<uint32_t>(0, remaining - 1)(
+                    gen) < needed) {
+                bitmap[i] = true;
+                --needed;
+            }
+            --remaining;
+        }
+    }
+
+    if (need_flip) {
+        bitmap.flip();
+    }
+}
+
+// New filtered path: inline selection, thread-local PRNG
+void
+NewFilteredSample(std::vector<bool>& bitmap, float factor) {
+    size_t false_count = 0;
+    for (size_t i = 0; i < bitmap.size(); ++i) {
+        if (!bitmap[i])
+            false_count++;
+    }
+    if (false_count == 0)
+        return;
+
+    size_t remaining = false_count;
+    size_t needed =
+        std::max(static_cast<size_t>(false_count * factor), static_cast<size_t>(1));
+    auto& gen = GetThreadLocalGen();
+
+    for (size_t i = 0; i < bitmap.size(); ++i) {
+        if (bitmap[i])
+            continue;
+        if (needed > 0 &&
+            std::uniform_int_distribution<size_t>(0, remaining - 1)(gen) <
+                needed) {
+            --needed;
+        } else {
+            bitmap[i] = true;
+        }
+        --remaining;
+    }
+}
+
+// ============================================================================
+// Benchmark harness
+// ============================================================================
+
+struct BenchResult {
+    double mean_us;
+    double min_us;
+    double max_us;
+};
+
+template <typename Func>
+BenchResult
+Benchmark(Func&& fn, int iterations = 10) {
+    double total = 0, min_v = 1e18, max_v = 0;
+    for (int i = 0; i < iterations; ++i) {
+        auto start = std::chrono::high_resolution_clock::now();
+        fn();
+        auto end = std::chrono::high_resolution_clock::now();
+        double us =
+            std::chrono::duration<double, std::micro>(end - start).count();
+        total += us;
+        min_v = std::min(min_v, us);
+        max_v = std::max(max_v, us);
+    }
+    return {total / iterations, min_v, max_v};
+}
+
+void
+PrintResult(const char* label, BenchResult r) {
+    printf("  %-40s  mean=%10.0f us  min=%10.0f us  max=%10.0f us\n", label,
+           r.mean_us, r.min_us, r.max_us);
+}
+
+size_t
+CountFalse(const std::vector<bool>& bm) {
+    size_t count = 0;
+    for (size_t i = 0; i < bm.size(); ++i) {
+        if (!bm[i])
+            count++;
+    }
+    return count;
+}
+
+int
+main() {
+    // =================================================================
+    // Source path benchmark (bitmap starts all-false, sample into it)
+    // =================================================================
+    printf("=== Source Path Benchmark ===\n\n");
+
+    uint32_t Ns[] = {1000000, 10000000};
+    float factors[] = {0.01f, 0.05f, 0.1f, 0.5f, 0.9f};
+
+    for (auto N : Ns) {
+        for (auto f : factors) {
+            uint32_t expected_M = std::max(static_cast<uint32_t>(N * f), 1u);
+            printf("N=%u, factor=%.2f (expected M=%u):\n", N, f, expected_M);
+
+            // Correctness check
+            std::vector<bool> bm_old(N, false);
+            OldSourcePath(bm_old, f);
+            size_t old_false = CountFalse(bm_old);
+
+            std::vector<bool> bm_new(N, false);
+            NewSourcePath(bm_new, f);
+            size_t new_false = CountFalse(bm_new);
+
+            bool old_ok = (old_false >= expected_M - 1 &&
+                           old_false <= expected_M + 1);
+            bool new_ok = (new_false >= expected_M - 1 &&
+                           new_false <= expected_M + 1);
+
+            auto r1 = Benchmark([&]() {
+                std::vector<bool> bm(N, false);
+                OldSourcePath(bm, f);
+            });
+            PrintResult("OLD Source", r1);
+
+            auto r2 = Benchmark([&]() {
+                std::vector<bool> bm(N, false);
+                NewSourcePath(bm, f);
+            });
+            PrintResult("NEW Source", r2);
+
+            double speedup = r1.mean_us / r2.mean_us;
+            printf(
+                "  Speedup: %.2fx  |  false: old=%zu new=%zu  count_ok: "
+                "old=%s new=%s\n\n",
+                speedup, old_false, new_false, old_ok ? "PASS" : "FAIL",
+                new_ok ? "PASS" : "FAIL");
+        }
+    }
+
+    // =================================================================
+    // Filtered path benchmark
+    // =================================================================
+    printf("=== Filtered Path Benchmark ===\n\n");
+    uint32_t total = 1000000;
+    uint32_t false_counts[] = {100000, 500000, 900000};
+    float filter_factors[] = {0.01f, 0.1f, 0.5f};
+
+    for (auto K : false_counts) {
+        for (auto f : filter_factors) {
+            uint32_t expected_sampled =
+                std::max(static_cast<uint32_t>(K * f), 1u);
+            printf(
+                "Total=%u, K(false)=%u, factor=%.2f (expect ~%u sampled):\n",
+                total, K, f, expected_sampled);
+
+            // Pre-build the template bitmap once (outside timing)
+            std::vector<bool> template_bm(total, true);
+            {
+                std::mt19937 rng(42);
+                std::vector<uint32_t> indices(total);
+                std::iota(indices.begin(), indices.end(), 0);
+                std::shuffle(indices.begin(), indices.end(), rng);
+                for (uint32_t i = 0; i < K; ++i) {
+                    template_bm[indices[i]] = false;
+                }
+            }
+
+            // Correctness check
+            auto bm_old = template_bm;
+            OldFilteredSample(bm_old, f);
+            size_t old_sampled = CountFalse(bm_old);
+            auto bm_new = template_bm;
+            NewFilteredSample(bm_new, f);
+            size_t new_sampled = CountFalse(bm_new);
+            bool old_ok = (old_sampled >= expected_sampled - 1 &&
+                           old_sampled <= expected_sampled + 1);
+            bool new_ok = (new_sampled >= expected_sampled - 1 &&
+                           new_sampled <= expected_sampled + 1);
+
+            auto r1 = Benchmark([&]() {
+                auto bm = template_bm;
+                OldFilteredSample(bm, f);
+            });
+            PrintResult("OLD Filtered", r1);
+
+            auto r2 = Benchmark([&]() {
+                auto bm = template_bm;
+                NewFilteredSample(bm, f);
+            });
+            PrintResult("NEW Filtered", r2);
+
+            double speedup = r1.mean_us / r2.mean_us;
+            printf(
+                "  Speedup: %.2fx  |  sampled: old=%zu new=%zu  count_ok: "
+                "old=%s new=%s\n\n",
+                speedup, old_sampled, new_sampled, old_ok ? "PASS" : "FAIL",
+                new_ok ? "PASS" : "FAIL");
+        }
+    }
+
+    return 0;
+}

--- a/internal/core/src/exec/operator/RandomSampleNode.cpp
+++ b/internal/core/src/exec/operator/RandomSampleNode.cpp
@@ -74,20 +74,20 @@ PhyRandomSampleNode::AddInput(RowVectorPtr& input) {
     input_ = std::move(input);
 }
 
-FixedVector<uint32_t>
-PhyRandomSampleNode::FloydSample(const uint32_t N,
-                                 const uint32_t M,
+FixedVector<size_t>
+PhyRandomSampleNode::FloydSample(const size_t N,
+                                 const size_t M,
                                  std::mt19937& gen) {
-    std::unordered_set<uint32_t> selected;
+    std::unordered_set<size_t> selected;
     selected.reserve(M);
-    for (uint32_t j = N - M; j < N; ++j) {
-        std::uniform_int_distribution<uint32_t> dis(0, j);
-        uint32_t t = dis(gen);
+    for (size_t j = N - M; j < N; ++j) {
+        std::uniform_int_distribution<size_t> dis(0, j);
+        size_t t = dis(gen);
         if (!selected.insert(t).second) {
             selected.insert(j);
         }
     }
-    return FixedVector<uint32_t>(selected.begin(), selected.end());
+    return FixedVector<size_t>(selected.begin(), selected.end());
 }
 
 RowVectorPtr
@@ -165,8 +165,9 @@ PhyRandomSampleNode::GetOutput() {
             factor = 1.0 - factor;
         }
 
-        uint32_t N = active_count_;
-        uint32_t M = std::max(static_cast<uint32_t>(N * factor), 1u);
+        size_t N = active_count_;
+        size_t M = std::max(static_cast<size_t>(N * factor),
+                            static_cast<size_t>(1));
         auto& gen = GetThreadLocalGen();
 
         float epsilon = std::numeric_limits<float>::epsilon();
@@ -180,9 +181,9 @@ PhyRandomSampleNode::GetOutput() {
             }
         } else {
             // Selection sampling: write directly into bitmap
-            uint32_t remaining = N, needed = M;
-            for (uint32_t i = 0; i < N && needed > 0; ++i) {
-                if (std::uniform_int_distribution<uint32_t>(
+            size_t remaining = N, needed = M;
+            for (size_t i = 0; i < N && needed > 0; ++i) {
+                if (std::uniform_int_distribution<size_t>(
                         0, remaining - 1)(gen) < needed) {
                     data[i] = true;
                     --needed;

--- a/internal/core/src/exec/operator/RandomSampleNode.cpp
+++ b/internal/core/src/exec/operator/RandomSampleNode.cpp
@@ -22,7 +22,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <limits>
-#include <numeric>
 #include <optional>
 #include <ratio>
 #include <unordered_set>
@@ -39,6 +38,14 @@
 #include "monitor/Monitor.h"
 #include "plan/PlanNode.h"
 #include "prometheus/histogram.h"
+
+namespace {
+std::mt19937&
+GetThreadLocalGen() {
+    thread_local std::mt19937 gen(std::random_device{}());
+    return gen;
+}
+}  // namespace
 
 namespace milvus {
 namespace exec {
@@ -68,44 +75,19 @@ PhyRandomSampleNode::AddInput(RowVectorPtr& input) {
 }
 
 FixedVector<uint32_t>
-PhyRandomSampleNode::HashsetSample(const uint32_t N,
-                                   const uint32_t M,
-                                   std::mt19937& gen) {
-    std::uniform_int_distribution<> dis(0, N - 1);
-    std::unordered_set<uint32_t> sampled;
-    sampled.reserve(N);
-    while (sampled.size() < M) {
-        sampled.insert(dis(gen));
+PhyRandomSampleNode::FloydSample(const uint32_t N,
+                                 const uint32_t M,
+                                 std::mt19937& gen) {
+    std::unordered_set<uint32_t> selected;
+    selected.reserve(M);
+    for (uint32_t j = N - M; j < N; ++j) {
+        std::uniform_int_distribution<uint32_t> dis(0, j);
+        uint32_t t = dis(gen);
+        if (!selected.insert(t).second) {
+            selected.insert(j);
+        }
     }
-
-    return FixedVector<uint32_t>(sampled.begin(), sampled.end());
-}
-
-FixedVector<uint32_t>
-PhyRandomSampleNode::StandardSample(const uint32_t N,
-                                    const uint32_t M,
-                                    std::mt19937& gen) {
-    FixedVector<uint32_t> inputs(N);
-    FixedVector<uint32_t> outputs(M);
-    std::iota(inputs.begin(), inputs.end(), 0);
-
-    std::sample(inputs.begin(), inputs.end(), outputs.begin(), M, gen);
-    return outputs;
-}
-
-FixedVector<uint32_t>
-PhyRandomSampleNode::Sample(const uint32_t N, const float factor) {
-    const uint32_t M = std::max(static_cast<uint32_t>(N * factor), 1u);
-    std::random_device rd;
-    std::mt19937 gen(rd());
-    float epsilon = std::numeric_limits<float>::epsilon();
-    // It's derived from some experiments
-    if (factor <= 0.02 + epsilon ||
-        (N <= 10000000 && factor <= 0.045 + epsilon) ||
-        (N <= 60000000 && factor <= 0.025 + epsilon)) {
-        return HashsetSample(N, M, gen);
-    }
-    return StandardSample(N, M, gen);
+    return FixedVector<uint32_t>(selected.begin(), selected.end());
 }
 
 RowVectorPtr
@@ -144,21 +126,25 @@ PhyRandomSampleNode::GetOutput() {
         size_t input_false_count = input_data.size() - input_data.count();
 
         if (input_false_count > 0) {
-            FixedVector<uint32_t> pos{};
-            pos.reserve(input_false_count);
+            size_t remaining = input_false_count;
+            size_t needed = std::max(
+                static_cast<size_t>(input_false_count * factor_),
+                static_cast<size_t>(1));
+            auto& gen = GetThreadLocalGen();
+
             auto value = input_data.find_first(false);
             while (value.has_value()) {
                 auto offset = value.value();
-                pos.push_back(offset);
-                value = input_data.find_next(offset, false);
-            }
-            assert(pos.size() == input_false_count);
-
-            input_data.set();
-            auto sampled = Sample(input_false_count, factor_);
-            assert(sampled.back() < input_false_count);
-            for (auto i = 0; i < sampled.size(); ++i) {
-                input_data[pos[sampled[i]]] = false;
+                auto next = input_data.find_next(offset, false);
+                if (needed > 0 &&
+                    std::uniform_int_distribution<size_t>(
+                        0, remaining - 1)(gen) < needed) {
+                    --needed;  // keep as false (selected)
+                } else {
+                    input_data[offset] = true;  // not selected
+                }
+                --remaining;
+                value = next;
             }
         }
 
@@ -168,19 +154,41 @@ PhyRandomSampleNode::GetOutput() {
             TargetBitmap(active_count_), TargetBitmap(active_count_));
         TargetBitmapView data(sample_output->GetRawData(),
                               sample_output->size());
-        // true in TargetBitmap means we don't want this row, while for readability, we set the relevant row be true
-        // if it's sampled. So we need to flip the bits at last.
-        // However, if sample rate is larger than 0.5, we use 1-factor for sampling so that in some cases, the sampling
-        // performance would be better. In that case, we don't need to flip at last.
+        // true in TargetBitmap means we don't want this row.
+        // We sample the minority set (min(factor, 1-factor)) and mark those
+        // bits true, then flip if needed so that exactly factor*N bits are
+        // false (wanted).
         bool need_flip = true;
         float factor = factor_;
         if (factor > 0.5) {
             need_flip = false;
             factor = 1.0 - factor;
         }
-        auto sampled = Sample(active_count_, factor);
-        for (auto n : sampled) {
-            data[n] = true;
+
+        uint32_t N = active_count_;
+        uint32_t M = std::max(static_cast<uint32_t>(N * factor), 1u);
+        auto& gen = GetThreadLocalGen();
+
+        float epsilon = std::numeric_limits<float>::epsilon();
+        if (factor <= 0.02 + epsilon ||
+            (N <= 10000000 && factor <= 0.045 + epsilon) ||
+            (N <= 60000000 && factor <= 0.025 + epsilon)) {
+            // Floyd: small M, use vector + scatter
+            auto sampled = FloydSample(N, M, gen);
+            for (auto n : sampled) {
+                data[n] = true;
+            }
+        } else {
+            // Selection sampling: write directly into bitmap
+            uint32_t remaining = N, needed = M;
+            for (uint32_t i = 0; i < N && needed > 0; ++i) {
+                if (std::uniform_int_distribution<uint32_t>(
+                        0, remaining - 1)(gen) < needed) {
+                    data[i] = true;
+                    --needed;
+                }
+                --remaining;
+            }
         }
 
         if (need_flip) {

--- a/internal/core/src/exec/operator/RandomSampleNode.h
+++ b/internal/core/src/exec/operator/RandomSampleNode.h
@@ -64,20 +64,10 @@ class PhyRandomSampleNode : public Operator {
     }
 
  private:
-    // Samples M elements from 0 to N - 1 where every element has equal probability to be selected.
+    // Floyd's algorithm: exactly M iterations with zero collision retries.
+    // Used for low sampling factors where M << N; result scattered into bitmap.
     static FixedVector<uint32_t>
-    HashsetSample(const uint32_t N, const uint32_t M, std::mt19937& gen);
-
-    // Samples M elements from 0 to N - 1 where every element has equal probability to be selected.
-    static FixedVector<uint32_t>
-    StandardSample(const uint32_t N, const uint32_t M, std::mt19937& gen);
-
-    // Samples M elements from 0 to N - 1 where every element has equal probability to be selected.
-    // It selects which kinds of sample method we use for sampling which is based on some experiments.
-    // Basically, the performance of HashsetSample is highly related to N * factor while StandardSample is highly
-    // related to N.
-    static FixedVector<uint32_t>
-    Sample(const uint32_t N, const float factor);
+    FloydSample(const uint32_t N, const uint32_t M, std::mt19937& gen);
 
     float factor_{0};
     int64_t active_count_{0};

--- a/internal/core/src/exec/operator/RandomSampleNode.h
+++ b/internal/core/src/exec/operator/RandomSampleNode.h
@@ -66,8 +66,8 @@ class PhyRandomSampleNode : public Operator {
  private:
     // Floyd's algorithm: exactly M iterations with zero collision retries.
     // Used for low sampling factors where M << N; result scattered into bitmap.
-    static FixedVector<uint32_t>
-    FloydSample(const uint32_t N, const uint32_t M, std::mt19937& gen);
+    static FixedVector<size_t>
+    FloydSample(const size_t N, const size_t M, std::mt19937& gen);
 
     float factor_{0};
     int64_t active_count_{0};


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/47920

Replace HashsetSample (collision retries, reserve(N) bug) with Floyd's algorithm (exactly M iterations, reserve(M)). Replace StandardSample (O(N) throwaway index array) with inline selection sampling that writes directly into the bitmap, eliminating intermediate vector allocation.

Refactor the filtered path to use inline selection sampling during bitset scan, reducing extra memory from O(K) to O(1) with a single pass.

Use a thread-local PRNG seeded once per thread instead of creating std::random_device + std::mt19937 on every call, avoiding repeated getrandom syscalls and mt19937 state initialization.

Add standalone benchmark (RandomSampleBench.cpp) for validating performance and correctness of old vs new implementations.


results
| Scenario                  | Speedup     |
|---------------------------|------------|
| N=10M, f=0.01 (Floyd)     | 8.35x      |
| N=10M, f=0.05             | 1.37x      |
| N=10M, f=0.10             | 1.35x      |
| N=10M, f=0.50             | 1.32x      |
| N=10M, f=0.90             | 1.36x      |
| N=1M, f=0.01 (Floyd)      | 3.55x      |
| N=1M, f=0.05–0.90         | 1.05–1.12x |