### PR TITLE
enhance: replace deprecated jaeger-client-go rate limiter with internal impl

### DIFF
--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -40,7 +40,6 @@ require (
 	github.com/tidwall/gjson v1.17.0
 	github.com/tikv/client-go/v2 v2.0.4
 	github.com/twpayne/go-geom v1.6.1
-	github.com/uber/jaeger-client-go v2.30.0+incompatible
 	github.com/x448/float16 v0.8.4
 	github.com/zilliztech/woodpecker v0.1.13
 	go.etcd.io/etcd/api/v3 v3.5.23
@@ -195,6 +194,7 @@ require (
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 // indirect
 	github.com/twmb/murmur3 v1.1.3 // indirect
+	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.1 // indirect
 	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -38,7 +38,6 @@ import (
 	"sync/atomic"
 
 	"github.com/cockroachdb/errors"
-	"github.com/uber/jaeger-client-go/utils"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest"
@@ -62,8 +61,8 @@ func init() {
 	s := _globalL.Load().(*zap.Logger).Sugar()
 	_globalS.Store(s)
 
-	r := utils.NewRateLimiter(1.0, 60.0)
-	_globalR.Store(r)
+	rl := NewRateLimiter(1.0, 60.0)
+	_globalR.Store(rl)
 }
 
 // InitLogger initializes a zap logger.
@@ -179,9 +178,9 @@ func S() *zap.SugaredLogger {
 	return _globalS.Load().(*zap.SugaredLogger)
 }
 
-// R returns utils.ReconfigurableRateLimiter.
-func R() *utils.ReconfigurableRateLimiter {
-	return _globalR.Load().(*utils.ReconfigurableRateLimiter)
+// R returns the global RateLimiter.
+func R() *RateLimiter {
+	return _globalR.Load().(*RateLimiter)
 }
 
 func ctxL() *zap.Logger {

--- a/pkg/log/mlogger.go
+++ b/pkg/log/mlogger.go
@@ -44,8 +44,8 @@ func (l *MLogger) WithRateGroup(groupName string, creditPerSecond, maxBalance fl
 	rl := NewRateLimiter(creditPerSecond, maxBalance)
 	actual, loaded := _namedRateLimiters.LoadOrStore(groupName, rl)
 	if loaded {
-		rl.Update(creditPerSecond, maxBalance)
 		rl = actual.(*RateLimiter)
+		rl.Update(creditPerSecond, maxBalance)
 	}
 	l.rl.Store(rl)
 	return l

--- a/pkg/log/mlogger.go
+++ b/pkg/log/mlogger.go
@@ -19,7 +19,6 @@ package log
 import (
 	"sync/atomic"
 
-	"github.com/uber/jaeger-client-go/utils"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -27,7 +26,7 @@ import (
 // MLogger is a wrapper type of zap.Logger.
 type MLogger struct {
 	*zap.Logger
-	rl atomic.Value // *utils.ReconfigurableRateLimiter
+	rl atomic.Value // *RateLimiter
 }
 
 // With encapsulates zap.Logger With method to return MLogger instance.
@@ -42,22 +41,22 @@ func (l *MLogger) With(fields ...zap.Field) *MLogger {
 
 // WithRateGroup uses named RateLimiter for this logger.
 func (l *MLogger) WithRateGroup(groupName string, creditPerSecond, maxBalance float64) *MLogger {
-	rl := utils.NewRateLimiter(creditPerSecond, maxBalance)
+	rl := NewRateLimiter(creditPerSecond, maxBalance)
 	actual, loaded := _namedRateLimiters.LoadOrStore(groupName, rl)
 	if loaded {
 		rl.Update(creditPerSecond, maxBalance)
-		rl = actual.(*utils.ReconfigurableRateLimiter)
+		rl = actual.(*RateLimiter)
 	}
 	l.rl.Store(rl)
 	return l
 }
 
-func (l *MLogger) r() utils.RateLimiter {
+func (l *MLogger) r() *RateLimiter {
 	val := l.rl.Load()
-	if l.rl.Load() == nil {
+	if val == nil {
 		return R()
 	}
-	return val.(*utils.ReconfigurableRateLimiter)
+	return val.(*RateLimiter)
 }
 
 // RatedDebug calls log.Debug with RateLimiter.

--- a/pkg/log/ratelimiter.go
+++ b/pkg/log/ratelimiter.go
@@ -1,0 +1,69 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"sync"
+	"time"
+)
+
+// RateLimiter is a simple token bucket rate limiter that replaces
+// the deprecated jaeger-client-go utils.ReconfigurableRateLimiter.
+type RateLimiter struct {
+	sync.Mutex
+	creditsPerSecond float64
+	maxBalance       float64
+	balance          float64
+	lastTime         time.Time
+}
+
+// NewRateLimiter creates a rate limiter with the given rate and max balance.
+func NewRateLimiter(creditsPerSecond, maxBalance float64) *RateLimiter {
+	return &RateLimiter{
+		creditsPerSecond: creditsPerSecond,
+		maxBalance:       maxBalance,
+		balance:          maxBalance,
+		lastTime:         time.Now(),
+	}
+}
+
+// CheckCredit checks if the given amount of credits is available.
+func (r *RateLimiter) CheckCredit(itemCost float64) bool {
+	r.Lock()
+	defer r.Unlock()
+
+	now := time.Now()
+	elapsed := now.Sub(r.lastTime).Seconds()
+	r.lastTime = now
+	r.balance += elapsed * r.creditsPerSecond
+	if r.balance > r.maxBalance {
+		r.balance = r.maxBalance
+	}
+	if r.balance >= itemCost {
+		r.balance -= itemCost
+		return true
+	}
+	return false
+}
+
+// Update reconfigures the rate limiter.
+func (r *RateLimiter) Update(creditsPerSecond, maxBalance float64) {
+	r.Lock()
+	defer r.Unlock()
+	r.creditsPerSecond = creditsPerSecond
+	r.maxBalance = maxBalance
+}

--- a/pkg/log/ratelimiter.go
+++ b/pkg/log/ratelimiter.go
@@ -24,7 +24,7 @@ import (
 // RateLimiter is a simple token bucket rate limiter that replaces
 // the deprecated jaeger-client-go utils.ReconfigurableRateLimiter.
 type RateLimiter struct {
-	sync.Mutex
+	mu sync.Mutex
 	creditsPerSecond float64
 	maxBalance       float64
 	balance          float64
@@ -43,8 +43,8 @@ func NewRateLimiter(creditsPerSecond, maxBalance float64) *RateLimiter {
 
 // CheckCredit checks if the given amount of credits is available.
 func (r *RateLimiter) CheckCredit(itemCost float64) bool {
-	r.Lock()
-	defer r.Unlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	now := time.Now()
 	elapsed := now.Sub(r.lastTime).Seconds()
@@ -63,8 +63,8 @@ func (r *RateLimiter) CheckCredit(itemCost float64) bool {
 // Update reconfigures the rate limiter, pro-rating the current balance
 // proportionally to the change in maxBalance (matching Jaeger behavior).
 func (r *RateLimiter) Update(creditsPerSecond, maxBalance float64) {
-	r.Lock()
-	defer r.Unlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	// Update balance based on elapsed time (same as CheckCredit).
 	now := time.Now()

--- a/pkg/log/ratelimiter.go
+++ b/pkg/log/ratelimiter.go
@@ -60,10 +60,26 @@ func (r *RateLimiter) CheckCredit(itemCost float64) bool {
 	return false
 }
 
-// Update reconfigures the rate limiter.
+// Update reconfigures the rate limiter, pro-rating the current balance
+// proportionally to the change in maxBalance (matching Jaeger behavior).
 func (r *RateLimiter) Update(creditsPerSecond, maxBalance float64) {
 	r.Lock()
 	defer r.Unlock()
+
+	// Update balance based on elapsed time (same as CheckCredit).
+	now := time.Now()
+	elapsed := now.Sub(r.lastTime).Seconds()
+	r.lastTime = now
+	r.balance += elapsed * r.creditsPerSecond
+	if r.balance > r.maxBalance {
+		r.balance = r.maxBalance
+	}
+
+	// Pro-rate balance proportionally to the new maxBalance.
+	if r.maxBalance > 0 {
+		r.balance = r.balance * maxBalance / r.maxBalance
+	}
+
 	r.creditsPerSecond = creditsPerSecond
 	r.maxBalance = maxBalance
 }

--- a/pkg/log/ratelimiter_test.go
+++ b/pkg/log/ratelimiter_test.go
@@ -1,0 +1,105 @@
+//go:build test
+
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRateLimiterInitialState(t *testing.T) {
+	rl := NewRateLimiter(1.0, 10.0)
+
+	// Initial balance should be maxBalance, so we can consume up to 10 credits.
+	assert.True(t, rl.CheckCredit(10.0), "should have maxBalance credits available initially")
+}
+
+func TestRateLimiterExhaustsCredits(t *testing.T) {
+	rl := NewRateLimiter(1.0, 5.0)
+
+	// Consume all 5 credits.
+	assert.True(t, rl.CheckCredit(5.0), "should succeed consuming all credits")
+	// Now balance is 0 (plus tiny elapsed time replenishment); a cost of 1 should fail.
+	assert.False(t, rl.CheckCredit(1.0), "should fail after credits exhausted")
+}
+
+func TestRateLimiterRecovery(t *testing.T) {
+	// 100 credits/sec, max 10 credits. Start full, drain, then wait for recovery.
+	rl := NewRateLimiter(100.0, 10.0)
+
+	// Drain all credits.
+	assert.True(t, rl.CheckCredit(10.0))
+	assert.False(t, rl.CheckCredit(1.0))
+
+	// Wait 100ms -> should recover ~10 credits (100 credits/sec * 0.1s = 10).
+	time.Sleep(110 * time.Millisecond)
+
+	assert.True(t, rl.CheckCredit(5.0), "should have recovered credits after sleeping")
+}
+
+func TestRateLimiterUpdateProRatesBalance(t *testing.T) {
+	rl := NewRateLimiter(1.0, 10.0)
+
+	// Consume 5, leaving balance ~5 out of 10 max.
+	rl.CheckCredit(5.0)
+
+	// Update maxBalance from 10 -> 20. Balance should be pro-rated: 5 * 20/10 = 10.
+	rl.Update(1.0, 20.0)
+
+	// The pro-rated balance should be ~10. Consuming 9 should succeed.
+	assert.True(t, rl.CheckCredit(9.0), "pro-rated balance should allow consuming 9 credits")
+}
+
+func TestRateLimiterUpdateZeroMaxBalance(t *testing.T) {
+	rl := NewRateLimiter(1.0, 10.0)
+
+	// Update with maxBalance=0 should not panic (divide by zero guard).
+	assert.NotPanics(t, func() {
+		rl.Update(1.0, 0.0)
+	})
+
+	// After setting maxBalance to 0, the balance is 0 (pro-rated: old_balance * 0 / old_max = 0).
+	// But since old maxBalance was 10 (>0), the pro-rate runs: balance = balance * 0 / 10 = 0.
+	// Actually, after Update sets maxBalance to 0, the guard `if r.maxBalance > 0` now
+	// refers to the OLD maxBalance (10), so the pro-rate runs: balance * 0/10 = 0.
+	assert.False(t, rl.CheckCredit(1.0), "balance should be zero after updating maxBalance to 0")
+}
+
+func TestRateLimiterCheckCreditZeroCost(t *testing.T) {
+	rl := NewRateLimiter(1.0, 1.0)
+
+	// Drain all credits.
+	rl.CheckCredit(1.0)
+
+	// Zero-cost check should always succeed since balance >= 0 >= 0.
+	assert.True(t, rl.CheckCredit(0.0), "zero cost should always succeed")
+}
+
+func TestRateLimiterBalanceCappedAtMax(t *testing.T) {
+	// Even with high credits/sec, balance should never exceed maxBalance.
+	rl := NewRateLimiter(1000.0, 5.0)
+
+	time.Sleep(50 * time.Millisecond)
+
+	// After sleeping, accrued credits would be ~50 but capped at maxBalance=5.
+	assert.True(t, rl.CheckCredit(5.0), "should be able to consume up to maxBalance")
+	assert.False(t, rl.CheckCredit(1.0), "should not have more than maxBalance credits")
+}


### PR DESCRIPTION
Related to #46199

## Summary
- Replace `jaeger-client-go/utils.RateLimiter` with internal token bucket implementation in `pkg/log/ratelimiter.go`
- The jaeger-client-go package is deprecated; Milvus only used it for log rate limiting, not tracing
- New `pkg/log/ratelimiter.go` implements the same token bucket algorithm (~85 lines)
- Removes jaeger-client-go from pkg/go.mod direct dependencies (remains as indirect via woodpecker)

## Bug fixes included
- **WithRateGroup bug fix** (`pkg/log/mlogger.go`): Fixed pre-existing bug where `Update()` was called on a newly created instance instead of the stored rate limiter, meaning rate group reconfiguration was silently broken. Also eliminated a redundant second `atomic.Load()` in the `r()` method.

## Test plan
- [x] New unit tests: `pkg/log/ratelimiter_test.go` with 7 test cases (initial state, exhaustion, recovery, pro-rate update, zero maxBalance, zero cost, balance cap)
- [ ] CI build passes
- [ ] CI ut-go passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)