### PR TITLE
enhance: migrate golang.org/x/exp slices/maps to Go stdlib

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -23,7 +23,7 @@ import (
 	"os/signal"
 	"strings"
 
-	"golang.org/x/exp/slices"
+	"slices"
 
 	"github.com/milvus-io/milvus/cmd/asan"
 	"github.com/milvus-io/milvus/cmd/milvus"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -21,9 +21,8 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
-	"strings"
-
 	"slices"
+	"strings"
 
 	"github.com/milvus-io/milvus/cmd/asan"
 	"github.com/milvus-io/milvus/cmd/milvus"

--- a/cmd/tools/config/generate.go
+++ b/cmd/tools/config/generate.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/samber/lo"
 	"go.uber.org/zap"
-	"golang.org/x/exp/slices"
+	"slices"
 
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"

--- a/cmd/tools/config/generate.go
+++ b/cmd/tools/config/generate.go
@@ -6,12 +6,12 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 
 	"github.com/samber/lo"
 	"go.uber.org/zap"
-	"slices"
 
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"

--- a/internal/datacoord/copy_segment_meta.go
+++ b/internal/datacoord/copy_segment_meta.go
@@ -18,11 +18,10 @@ package datacoord
 
 import (
 	"context"
-	"math"
-	"sync"
-
 	"maps"
+	"math"
 	"slices"
+	"sync"
 
 	"go.uber.org/zap"
 

--- a/internal/datacoord/copy_segment_meta.go
+++ b/internal/datacoord/copy_segment_meta.go
@@ -21,8 +21,10 @@ import (
 	"math"
 	"sync"
 
+	"maps"
+	"slices"
+
 	"go.uber.org/zap"
-	"golang.org/x/exp/maps"
 
 	"github.com/milvus-io/milvus/internal/metastore"
 	"github.com/milvus-io/milvus/pkg/v2/log"
@@ -261,7 +263,7 @@ func (t *copySegmentTasks) remove(taskID int64) {
 
 // listTasks returns all tasks as a slice (unordered).
 func (t *copySegmentTasks) listTasks() []CopySegmentTask {
-	return maps.Values(t.tasks)
+	return slices.Collect(maps.Values(t.tasks))
 }
 
 // getByJobID retrieves all tasks belonging to a specific job using secondary index.

--- a/internal/datacoord/import_meta.go
+++ b/internal/datacoord/import_meta.go
@@ -18,10 +18,9 @@ package datacoord
 
 import (
 	"context"
-	"time"
-
 	"maps"
 	"slices"
+	"time"
 
 	"github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/samber/lo"

--- a/internal/datacoord/import_meta.go
+++ b/internal/datacoord/import_meta.go
@@ -20,9 +20,11 @@ import (
 	"context"
 	"time"
 
+	"maps"
+	"slices"
+
 	"github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/samber/lo"
-	"golang.org/x/exp/maps"
 
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/json"
@@ -83,7 +85,7 @@ func (t *importTasks) remove(taskID int64) {
 }
 
 func (t *importTasks) listTasks() []ImportTask {
-	return maps.Values(t.tasks)
+	return slices.Collect(maps.Values(t.tasks))
 }
 
 func (t *importTasks) listTaskStats() []ImportTask {

--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"maps"
 	"math"
 	"path"
 	"strconv"
@@ -29,8 +30,6 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"go.uber.org/zap"
-	"maps"
-
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"

--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -29,7 +29,8 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"go.uber.org/zap"
-	"golang.org/x/exp/maps"
+	"maps"
+
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"

--- a/internal/datacoord/meta_test.go
+++ b/internal/datacoord/meta_test.go
@@ -29,7 +29,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/exp/slices"
+	"slices"
+
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"

--- a/internal/datacoord/meta_test.go
+++ b/internal/datacoord/meta_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"slices"
 	"sync/atomic"
 	"testing"
 
@@ -29,8 +30,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"slices"
-
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"

--- a/internal/kv/etcd/embed_etcd_kv_test.go
+++ b/internal/kv/etcd/embed_etcd_kv_test.go
@@ -19,15 +19,15 @@ package etcdkv_test
 import (
 	"context"
 	"fmt"
+	"maps"
 	"path"
-	"sort"
+	"slices"
 	"testing"
 
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/exp/maps"
 
 	embed_etcd_kv "github.com/milvus-io/milvus/internal/kv/etcd"
 	"github.com/milvus-io/milvus/pkg/v2/kv"
@@ -750,8 +750,7 @@ func TestEmbedEtcd(te *testing.T) {
 					"AB/2/100": "v4",
 				}
 
-				expectedSortedKey := maps.Keys(expected)
-				sort.Strings(expectedSortedKey)
+				expectedSortedKey := slices.Sorted(maps.Keys(expected))
 
 				ret := make(map[string]string)
 				actualSortedKey := make([]string, 0)

--- a/internal/kv/etcd/etcd_kv_test.go
+++ b/internal/kv/etcd/etcd_kv_test.go
@@ -19,9 +19,10 @@ package etcdkv
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"path"
-	"sort"
+	"slices"
 	"testing"
 	"time"
 
@@ -30,7 +31,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	clientv3 "go.etcd.io/etcd/client/v3"
-	"golang.org/x/exp/maps"
 
 	"github.com/milvus-io/milvus/pkg/v2/kv/predicates"
 	"github.com/milvus-io/milvus/pkg/v2/util/etcd"
@@ -763,8 +763,7 @@ func Test_WalkWithPagination(t *testing.T) {
 				"AB/2/100": "v4",
 			}
 
-			expectedSortedKey := maps.Keys(expected)
-			sort.Strings(expectedSortedKey)
+			expectedSortedKey := slices.Sorted(maps.Keys(expected))
 
 			ret := make(map[string]string)
 			actualSortedKey := make([]string, 0)

--- a/internal/kv/tikv/txn_tikv_test.go
+++ b/internal/kv/tikv/txn_tikv_test.go
@@ -19,7 +19,8 @@ package tikv
 import (
 	"context"
 	"fmt"
-	"sort"
+	"maps"
+	"slices"
 	"testing"
 	"time"
 
@@ -28,7 +29,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/client-go/v2/txnkv"
 	"github.com/tikv/client-go/v2/txnkv/transaction"
-	"golang.org/x/exp/maps"
 
 	"github.com/milvus-io/milvus/pkg/v2/kv/predicates"
 )
@@ -393,8 +393,7 @@ func TestWalkWithPagination(t *testing.T) {
 				"AB/2/100": "v4",
 			}
 
-			expectedKeys := maps.Keys(expected)
-			sort.Strings(expectedKeys)
+			expectedKeys := slices.Sorted(maps.Keys(expected))
 
 			ret := make(map[string]string)
 			actualKeys := make([]string, 0)

--- a/internal/metastore/kv/datacoord/kv_catalog.go
+++ b/internal/metastore/kv/datacoord/kv_catalog.go
@@ -25,7 +25,8 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
-	"golang.org/x/exp/maps"
+	"maps"
+
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/proto"
 

--- a/internal/metastore/kv/datacoord/kv_catalog.go
+++ b/internal/metastore/kv/datacoord/kv_catalog.go
@@ -19,14 +19,13 @@ package datacoord
 import (
 	"context"
 	"fmt"
+	"maps"
 	"path"
 	"strconv"
 	"strings"
 
 	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
-	"maps"
-
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/proto"
 

--- a/internal/metastore/kv/datacoord/kv_catalog_test.go
+++ b/internal/metastore/kv/datacoord/kv_catalog_test.go
@@ -30,7 +30,8 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"golang.org/x/exp/maps"
+	"maps"
+
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"

--- a/internal/metastore/kv/datacoord/kv_catalog_test.go
+++ b/internal/metastore/kv/datacoord/kv_catalog_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"maps"
 	"math/rand"
 	"os"
 	"path"
@@ -30,8 +31,6 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"maps"
-
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"

--- a/internal/rootcoord/meta_table.go
+++ b/internal/rootcoord/meta_table.go
@@ -19,14 +19,14 @@ package rootcoord
 import (
 	"context"
 	"fmt"
+	"maps"
+	"slices"
 	"sync"
 	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"go.uber.org/zap"
-	"maps"
-	"slices"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus/internal/metastore"

--- a/internal/rootcoord/meta_table.go
+++ b/internal/rootcoord/meta_table.go
@@ -25,7 +25,8 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"go.uber.org/zap"
-	"golang.org/x/exp/maps"
+	"maps"
+	"slices"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus/internal/metastore"
@@ -217,7 +218,7 @@ func (mt *MetaTable) reload() error {
 	for _, db := range dbs {
 		mt.dbName2Meta[db.Name] = db
 	}
-	dbNames := maps.Keys(mt.dbName2Meta)
+	dbNames := slices.Collect(maps.Keys(mt.dbName2Meta))
 	// create default database.
 	if !funcutil.SliceContain(dbNames, util.DefaultDBName) {
 		if err := mt.createDefaultDb(); err != nil {
@@ -493,7 +494,7 @@ func (mt *MetaTable) ListDatabases(ctx context.Context, ts typeutil.Timestamp) (
 	mt.ddLock.RLock()
 	defer mt.ddLock.RUnlock()
 
-	return maps.Values(mt.dbName2Meta), nil
+	return slices.Collect(maps.Values(mt.dbName2Meta)), nil
 }
 
 func (mt *MetaTable) GetDatabaseByID(ctx context.Context, dbID int64, ts Timestamp) (*model.Database, error) {

--- a/internal/rootcoord/name_db.go
+++ b/internal/rootcoord/name_db.go
@@ -18,8 +18,8 @@ package rootcoord
 
 import (
 	"fmt"
-
-	"golang.org/x/exp/maps"
+	"maps"
+	"slices"
 
 	"github.com/milvus-io/milvus/pkg/v2/util"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
@@ -88,7 +88,7 @@ func (n *nameDb) listCollectionID(dbName string) ([]typeutil.UniqueID, error) {
 	if !ok {
 		return nil, fmt.Errorf("database not exist: %s", dbName)
 	}
-	return maps.Values(name2ID), nil
+	return slices.Collect(maps.Values(name2ID)), nil
 }
 
 func (n *nameDb) removeIf(selector func(db string, collection string, id UniqueID) bool) {

--- a/internal/rootcoord/quota_center.go
+++ b/internal/rootcoord/quota_center.go
@@ -19,7 +19,9 @@ package rootcoord
 import (
 	"context"
 	"fmt"
+	"maps"
 	"math"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -27,9 +29,6 @@ import (
 
 	"github.com/samber/lo"
 	"go.uber.org/zap"
-	"maps"
-	"slices"
-
 	"golang.org/x/sync/errgroup"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"

--- a/internal/rootcoord/quota_center.go
+++ b/internal/rootcoord/quota_center.go
@@ -27,7 +27,9 @@ import (
 
 	"github.com/samber/lo"
 	"go.uber.org/zap"
-	"golang.org/x/exp/maps"
+	"maps"
+	"slices"
+
 	"golang.org/x/sync/errgroup"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
@@ -846,7 +848,7 @@ func (q *QuotaCenter) calculateReadRates() error {
 
 	deniedDatabaseIDs := q.getDenyReadingDBs()
 	if len(deniedDatabaseIDs) != 0 {
-		q.forceDenyReading(commonpb.ErrorCode_ForceDeny, false, maps.Keys(deniedDatabaseIDs), "force deny reading in database properties", log)
+		q.forceDenyReading(commonpb.ErrorCode_ForceDeny, false, slices.Collect(maps.Keys(deniedDatabaseIDs)), "force deny reading in database properties", log)
 	}
 	return nil
 }
@@ -882,7 +884,7 @@ func (q *QuotaCenter) calculateWriteRates() error {
 	// check force deny writing of db level
 	dbIDs := q.getDenyWritingDBs()
 	if len(dbIDs) != 0 {
-		if err := q.forceDenyWriting(commonpb.ErrorCode_ForceDeny, false, maps.Keys(dbIDs), nil, nil, "force deny writing in database properties"); err != nil {
+		if err := q.forceDenyWriting(commonpb.ErrorCode_ForceDeny, false, slices.Collect(maps.Keys(dbIDs)), nil, nil, "force deny writing in database properties"); err != nil {
 			return err
 		}
 	}

--- a/internal/util/importutilv2/binlog/reader_test.go
+++ b/internal/util/importutilv2/binlog/reader_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/exp/slices"
+	"slices"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"

--- a/internal/util/importutilv2/binlog/reader_test.go
+++ b/internal/util/importutilv2/binlog/reader_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"slices"
 	"testing"
 	"time"
 
@@ -27,7 +28,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
-	"slices"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"

--- a/internal/util/importutilv2/numpy/reader_test.go
+++ b/internal/util/importutilv2/numpy/reader_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/exp/slices"
+	"slices"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"

--- a/internal/util/importutilv2/numpy/reader_test.go
+++ b/internal/util/importutilv2/numpy/reader_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"slices"
 	"strings"
 	"testing"
 
@@ -30,7 +31,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
-	"slices"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"

--- a/internal/util/importutilv2/parquet/reader_test.go
+++ b/internal/util/importutilv2/parquet/reader_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/exp/slices"
+	"slices"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"

--- a/internal/util/importutilv2/parquet/reader_test.go
+++ b/internal/util/importutilv2/parquet/reader_test.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"math/rand"
 	"os"
+	"slices"
 	"testing"
 
 	"github.com/apache/arrow/go/v17/arrow"
@@ -32,7 +33,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
-	"slices"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"

--- a/internal/util/metrics/c_registry.go
+++ b/internal/util/metrics/c_registry.go
@@ -40,7 +40,8 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 	"go.uber.org/zap"
-	"golang.org/x/exp/maps"
+	"maps"
+
 	"google.golang.org/protobuf/proto"
 
 	_ "github.com/milvus-io/milvus/internal/util/cgo"

--- a/internal/util/metrics/c_registry.go
+++ b/internal/util/metrics/c_registry.go
@@ -30,6 +30,7 @@ package metrics
 import "C"
 
 import (
+	"maps"
 	"sort"
 	"strings"
 	"sync"
@@ -40,8 +41,6 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 	"go.uber.org/zap"
-	"maps"
-
 	"google.golang.org/protobuf/proto"
 
 	_ "github.com/milvus-io/milvus/internal/util/cgo"

--- a/pkg/mq/msgstream/mq_msgstream.go
+++ b/pkg/mq/msgstream/mq_msgstream.go
@@ -27,7 +27,8 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"go.uber.org/zap"
-	"golang.org/x/exp/maps"
+	"maps"
+
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/proto"
 

--- a/pkg/mq/msgstream/mq_msgstream.go
+++ b/pkg/mq/msgstream/mq_msgstream.go
@@ -19,6 +19,7 @@ package msgstream
 import (
 	"context"
 	"fmt"
+	"maps"
 	"path/filepath"
 	"sync"
 	"sync/atomic"
@@ -27,8 +28,6 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"go.uber.org/zap"
-	"maps"
-
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/proto"
 


### PR DESCRIPTION
Related to #46199

## Summary
- Replace `golang.org/x/exp/slices` -> `slices` (Go stdlib) in 6 files
- Replace `golang.org/x/exp/maps` -> `maps` (Go stdlib) in 13 files
- Keep `golang.org/x/exp/constraints` (5 files) -- no stdlib equivalent
- Handle API differences: `maps.Keys`/`maps.Values` return iterators in stdlib, wrapped with `slices.Collect()` or `slices.Sorted()` where slice is needed
- Removed unused `sort` import in 3 test files by combining `maps.Keys` + `sort.Strings` into `slices.Sorted(maps.Keys(...))`

## Test plan
- [ ] CI build passes
- [ ] CI ut-go passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)