### PR TITLE
fix: use generic GetFunctionOutputFields for partial update filtering

### DIFF
--- a/internal/proxy/task_upsert.go
+++ b/internal/proxy/task_upsert.go
@@ -1023,12 +1023,12 @@ func (it *upsertTask) insertPreExecute(ctx context.Context) error {
 		return err
 	}
 
-	bm25Fields := typeutil.NewSet[string](GetBM25FunctionOutputFields(it.schema.CollectionSchema)...)
+	functionOutputFields := typeutil.NewSet[string](GetFunctionOutputFields(it.schema.CollectionSchema)...)
 	if it.req.PartialUpdate {
-		// remove the old bm25 fields
+		// remove the old function output fields (BM25, MinHash, etc.)
 		ret := make([]*schemapb.FieldData, 0)
 		for _, fieldData := range it.upsertMsg.InsertMsg.GetFieldsData() {
-			if bm25Fields.Contain(fieldData.GetFieldName()) {
+			if functionOutputFields.Contain(fieldData.GetFieldName()) {
 				continue
 			}
 			ret = append(ret, fieldData)

--- a/internal/proxy/task_upsert.go
+++ b/internal/proxy/task_upsert.go
@@ -1023,12 +1023,16 @@ func (it *upsertTask) insertPreExecute(ctx context.Context) error {
 		return err
 	}
 
-	functionOutputFields := typeutil.NewSet[string](GetFunctionOutputFields(it.schema.CollectionSchema)...)
+	bm25Fields := GetBM25FunctionOutputFields(it.schema.CollectionSchema)
+	minHashFields := GetMinHashFunctionOutputFields(it.schema.CollectionSchema)
+	fieldsToFilter := typeutil.NewSet[string](append(bm25Fields, minHashFields...)...)
 	if it.req.PartialUpdate {
-		// remove the old function output fields (BM25, MinHash, etc.)
+		// remove old BM25 and MinHash function output fields, which will be regenerated downstream
+		// Note: do NOT filter other function outputs (e.g. text embedding) as they are generated
+		// by genFunctionFields and expected by validateFieldDataColumns
 		ret := make([]*schemapb.FieldData, 0)
 		for _, fieldData := range it.upsertMsg.InsertMsg.GetFieldsData() {
-			if functionOutputFields.Contain(fieldData.GetFieldName()) {
+			if fieldsToFilter.Contain(fieldData.GetFieldName()) {
 				continue
 			}
 			ret = append(ret, fieldData)

--- a/internal/proxy/task_upsert_test.go
+++ b/internal/proxy/task_upsert_test.go
@@ -2198,59 +2198,10 @@ func TestUpsertTask_queryPreExecute_EmptyDataArray(t *testing.T) {
 	})
 }
 
-func TestInsertPreExecute_FilterFunctionOutputFields(t *testing.T) {
+func TestInsertPreExecute_FilterBM25AndMinHashOutputFields(t *testing.T) {
 	paramtable.Init()
 
-	// Schema with BM25 and MinHash functions
-	schema := newSchemaInfo(&schemapb.CollectionSchema{
-		Name:   "test_filter_func_output",
-		AutoID: true,
-		Fields: []*schemapb.FieldSchema{
-			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true, AutoID: true},
-			{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar, TypeParams: []*commonpb.KeyValuePair{{Key: "max_length", Value: "2000"}}},
-			{FieldID: 102, Name: "vec", DataType: schemapb.DataType_FloatVector, TypeParams: []*commonpb.KeyValuePair{{Key: "dim", Value: "4"}}},
-			{FieldID: 103, Name: "sparse", DataType: schemapb.DataType_SparseFloatVector, IsFunctionOutput: true},
-			{FieldID: 104, Name: "mh", DataType: schemapb.DataType_BinaryVector, IsFunctionOutput: true, TypeParams: []*commonpb.KeyValuePair{{Key: "dim", Value: "512"}}},
-		},
-		Functions: []*schemapb.FunctionSchema{
-			{
-				Name:             "bm25",
-				Type:             schemapb.FunctionType_BM25,
-				InputFieldIds:    []int64{101},
-				InputFieldNames:  []string{"text"},
-				OutputFieldIds:   []int64{103},
-				OutputFieldNames: []string{"sparse"},
-			},
-			{
-				Name:             "minhash",
-				Type:             schemapb.FunctionType_MinHash,
-				InputFieldIds:    []int64{101},
-				InputFieldNames:  []string{"text"},
-				OutputFieldIds:   []int64{104},
-				OutputFieldNames: []string{"mh"},
-			},
-		},
-	})
-
 	numRows := 2
-	fieldsData := []*schemapb.FieldData{
-		{
-			FieldName: "text", FieldId: 101, Type: schemapb.DataType_VarChar,
-			Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"hello", "world"}}}}},
-		},
-		{
-			FieldName: "vec", FieldId: 102, Type: schemapb.DataType_FloatVector,
-			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{Dim: 4, Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: make([]float32, numRows*4)}}}},
-		},
-		{
-			FieldName: "sparse", FieldId: 103, Type: schemapb.DataType_SparseFloatVector,
-			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{Data: &schemapb.VectorField_SparseFloatVector{}}},
-		},
-		{
-			FieldName: "mh", FieldId: 104, Type: schemapb.DataType_BinaryVector,
-			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{Dim: 512, Data: &schemapb.VectorField_BinaryVector{BinaryVector: make([]byte, numRows*512/8)}}},
-		},
-	}
 
 	getFieldNames := func(data []*schemapb.FieldData) []string {
 		names := make([]string, 0, len(data))
@@ -2260,27 +2211,73 @@ func TestInsertPreExecute_FilterFunctionOutputFields(t *testing.T) {
 		return names
 	}
 
-	t.Run("partial update filters all function output fields", func(t *testing.T) {
+	t.Run("partial update filters BM25 and MinHash output fields", func(t *testing.T) {
 		m := mockey.Mock(common.AllocAutoID).Return(int64(1000), int64(1000+numRows), nil).Build()
 		defer m.UnPatch()
 
-		copiedData := make([]*schemapb.FieldData, len(fieldsData))
-		copy(copiedData, fieldsData)
+		schema := newSchemaInfo(&schemapb.CollectionSchema{
+			Name:   "test_filter_bm25_minhash",
+			AutoID: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true, AutoID: true},
+				{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar, TypeParams: []*commonpb.KeyValuePair{{Key: "max_length", Value: "2000"}}},
+				{FieldID: 102, Name: "vec", DataType: schemapb.DataType_FloatVector, TypeParams: []*commonpb.KeyValuePair{{Key: "dim", Value: "4"}}},
+				{FieldID: 103, Name: "sparse", DataType: schemapb.DataType_SparseFloatVector, IsFunctionOutput: true},
+				{FieldID: 104, Name: "mh", DataType: schemapb.DataType_BinaryVector, IsFunctionOutput: true, TypeParams: []*commonpb.KeyValuePair{{Key: "dim", Value: "512"}}},
+			},
+			Functions: []*schemapb.FunctionSchema{
+				{
+					Name:             "bm25",
+					Type:             schemapb.FunctionType_BM25,
+					InputFieldIds:    []int64{101},
+					InputFieldNames:  []string{"text"},
+					OutputFieldIds:   []int64{103},
+					OutputFieldNames: []string{"sparse"},
+				},
+				{
+					Name:             "minhash",
+					Type:             schemapb.FunctionType_MinHash,
+					InputFieldIds:    []int64{101},
+					InputFieldNames:  []string{"text"},
+					OutputFieldIds:   []int64{104},
+					OutputFieldNames: []string{"mh"},
+				},
+			},
+		})
+
+		fieldsData := []*schemapb.FieldData{
+			{
+				FieldName: "text", FieldId: 101, Type: schemapb.DataType_VarChar,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"hello", "world"}}}}},
+			},
+			{
+				FieldName: "vec", FieldId: 102, Type: schemapb.DataType_FloatVector,
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{Dim: 4, Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: make([]float32, numRows*4)}}}},
+			},
+			{
+				FieldName: "sparse", FieldId: 103, Type: schemapb.DataType_SparseFloatVector,
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{Data: &schemapb.VectorField_SparseFloatVector{}}},
+			},
+			{
+				FieldName: "mh", FieldId: 104, Type: schemapb.DataType_BinaryVector,
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{Dim: 512, Data: &schemapb.VectorField_BinaryVector{BinaryVector: make([]byte, numRows*512/8)}}},
+			},
+		}
 
 		task := &upsertTask{
 			ctx:         context.Background(),
 			schema:      schema,
 			idAllocator: &allocator.IDAllocator{},
 			req: &milvuspb.UpsertRequest{
-				CollectionName: "test_filter_func_output",
+				CollectionName: "test_filter_bm25_minhash",
 				PartialUpdate:  true,
 			},
 			upsertMsg: &msgstream.UpsertMsg{
 				InsertMsg: &msgstream.InsertMsg{
 					InsertRequest: &msgpb.InsertRequest{
-						CollectionName: "test_filter_func_output",
+						CollectionName: "test_filter_bm25_minhash",
 						Version:        msgpb.InsertDataVersion_ColumnBased,
-						FieldsData:     copiedData,
+						FieldsData:     fieldsData,
 						NumRows:        uint64(numRows),
 						PartitionName:  Params.CommonCfg.DefaultPartitionName.GetValue(),
 					},
@@ -2291,12 +2288,78 @@ func TestInsertPreExecute_FilterFunctionOutputFields(t *testing.T) {
 
 		_ = task.insertPreExecute(context.Background())
 
-		// Verify: sparse and mh (function outputs) should be filtered out
 		remainingFields := getFieldNames(task.upsertMsg.InsertMsg.GetFieldsData())
 		assert.NotContains(t, remainingFields, "sparse")
 		assert.NotContains(t, remainingFields, "mh")
 		assert.Contains(t, remainingFields, "text")
 		assert.Contains(t, remainingFields, "vec")
+	})
+
+	t.Run("partial update preserves non-BM25/MinHash function output fields", func(t *testing.T) {
+		m := mockey.Mock(common.AllocAutoID).Return(int64(1000), int64(1000+numRows), nil).Build()
+		defer m.UnPatch()
+
+		// Schema with a text embedding function (non-BM25/MinHash)
+		schema := newSchemaInfo(&schemapb.CollectionSchema{
+			Name:   "test_preserve_embedding",
+			AutoID: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true, AutoID: true},
+				{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar, TypeParams: []*commonpb.KeyValuePair{{Key: "max_length", Value: "2000"}}},
+				{FieldID: 102, Name: "embedding", DataType: schemapb.DataType_FloatVector, IsFunctionOutput: true, TypeParams: []*commonpb.KeyValuePair{{Key: "dim", Value: "4"}}},
+			},
+			Functions: []*schemapb.FunctionSchema{
+				{
+					Name:             "text_embedding",
+					Type:             schemapb.FunctionType_TextEmbedding,
+					InputFieldIds:    []int64{101},
+					InputFieldNames:  []string{"text"},
+					OutputFieldIds:   []int64{102},
+					OutputFieldNames: []string{"embedding"},
+				},
+			},
+		})
+
+		fieldsData := []*schemapb.FieldData{
+			{
+				FieldName: "text", FieldId: 101, Type: schemapb.DataType_VarChar,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"hello", "world"}}}}},
+			},
+			{
+				FieldName: "embedding", FieldId: 102, Type: schemapb.DataType_FloatVector,
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{Dim: 4, Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: make([]float32, numRows*4)}}}},
+			},
+		}
+
+		task := &upsertTask{
+			ctx:         context.Background(),
+			schema:      schema,
+			idAllocator: &allocator.IDAllocator{},
+			req: &milvuspb.UpsertRequest{
+				CollectionName: "test_preserve_embedding",
+				PartialUpdate:  true,
+			},
+			upsertMsg: &msgstream.UpsertMsg{
+				InsertMsg: &msgstream.InsertMsg{
+					InsertRequest: &msgpb.InsertRequest{
+						CollectionName: "test_preserve_embedding",
+						Version:        msgpb.InsertDataVersion_ColumnBased,
+						FieldsData:     fieldsData,
+						NumRows:        uint64(numRows),
+						PartitionName:  Params.CommonCfg.DefaultPartitionName.GetValue(),
+					},
+				},
+			},
+			result: &milvuspb.MutationResult{},
+		}
+
+		_ = task.insertPreExecute(context.Background())
+
+		// embedding (text embedding output) should NOT be filtered
+		remainingFields := getFieldNames(task.upsertMsg.InsertMsg.GetFieldsData())
+		assert.Contains(t, remainingFields, "text")
+		assert.Contains(t, remainingFields, "embedding")
+		assert.Len(t, remainingFields, 2)
 	})
 
 	t.Run("partial update with no functions keeps all fields", func(t *testing.T) {

--- a/internal/proxy/task_upsert_test.go
+++ b/internal/proxy/task_upsert_test.go
@@ -2198,6 +2198,163 @@ func TestUpsertTask_queryPreExecute_EmptyDataArray(t *testing.T) {
 	})
 }
 
+func TestInsertPreExecute_FilterFunctionOutputFields(t *testing.T) {
+	paramtable.Init()
+
+	// Schema with BM25 and MinHash functions
+	schema := newSchemaInfo(&schemapb.CollectionSchema{
+		Name:   "test_filter_func_output",
+		AutoID: true,
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true, AutoID: true},
+			{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar, TypeParams: []*commonpb.KeyValuePair{{Key: "max_length", Value: "2000"}}},
+			{FieldID: 102, Name: "vec", DataType: schemapb.DataType_FloatVector, TypeParams: []*commonpb.KeyValuePair{{Key: "dim", Value: "4"}}},
+			{FieldID: 103, Name: "sparse", DataType: schemapb.DataType_SparseFloatVector, IsFunctionOutput: true},
+			{FieldID: 104, Name: "mh", DataType: schemapb.DataType_BinaryVector, IsFunctionOutput: true, TypeParams: []*commonpb.KeyValuePair{{Key: "dim", Value: "512"}}},
+		},
+		Functions: []*schemapb.FunctionSchema{
+			{
+				Name:             "bm25",
+				Type:             schemapb.FunctionType_BM25,
+				InputFieldIds:    []int64{101},
+				InputFieldNames:  []string{"text"},
+				OutputFieldIds:   []int64{103},
+				OutputFieldNames: []string{"sparse"},
+			},
+			{
+				Name:             "minhash",
+				Type:             schemapb.FunctionType_MinHash,
+				InputFieldIds:    []int64{101},
+				InputFieldNames:  []string{"text"},
+				OutputFieldIds:   []int64{104},
+				OutputFieldNames: []string{"mh"},
+			},
+		},
+	})
+
+	numRows := 2
+	fieldsData := []*schemapb.FieldData{
+		{
+			FieldName: "text", FieldId: 101, Type: schemapb.DataType_VarChar,
+			Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"hello", "world"}}}}},
+		},
+		{
+			FieldName: "vec", FieldId: 102, Type: schemapb.DataType_FloatVector,
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{Dim: 4, Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: make([]float32, numRows*4)}}}},
+		},
+		{
+			FieldName: "sparse", FieldId: 103, Type: schemapb.DataType_SparseFloatVector,
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{Data: &schemapb.VectorField_SparseFloatVector{}}},
+		},
+		{
+			FieldName: "mh", FieldId: 104, Type: schemapb.DataType_BinaryVector,
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{Dim: 512, Data: &schemapb.VectorField_BinaryVector{BinaryVector: make([]byte, numRows*512/8)}}},
+		},
+	}
+
+	getFieldNames := func(data []*schemapb.FieldData) []string {
+		names := make([]string, 0, len(data))
+		for _, fd := range data {
+			names = append(names, fd.GetFieldName())
+		}
+		return names
+	}
+
+	t.Run("partial update filters all function output fields", func(t *testing.T) {
+		m := mockey.Mock(common.AllocAutoID).Return(int64(1000), int64(1000+numRows), nil).Build()
+		defer m.UnPatch()
+
+		copiedData := make([]*schemapb.FieldData, len(fieldsData))
+		copy(copiedData, fieldsData)
+
+		task := &upsertTask{
+			ctx:         context.Background(),
+			schema:      schema,
+			idAllocator: &allocator.IDAllocator{},
+			req: &milvuspb.UpsertRequest{
+				CollectionName: "test_filter_func_output",
+				PartialUpdate:  true,
+			},
+			upsertMsg: &msgstream.UpsertMsg{
+				InsertMsg: &msgstream.InsertMsg{
+					InsertRequest: &msgpb.InsertRequest{
+						CollectionName: "test_filter_func_output",
+						Version:        msgpb.InsertDataVersion_ColumnBased,
+						FieldsData:     copiedData,
+						NumRows:        uint64(numRows),
+						PartitionName:  Params.CommonCfg.DefaultPartitionName.GetValue(),
+					},
+				},
+			},
+			result: &milvuspb.MutationResult{},
+		}
+
+		_ = task.insertPreExecute(context.Background())
+
+		// Verify: sparse and mh (function outputs) should be filtered out
+		remainingFields := getFieldNames(task.upsertMsg.InsertMsg.GetFieldsData())
+		assert.NotContains(t, remainingFields, "sparse")
+		assert.NotContains(t, remainingFields, "mh")
+		assert.Contains(t, remainingFields, "text")
+		assert.Contains(t, remainingFields, "vec")
+	})
+
+	t.Run("partial update with no functions keeps all fields", func(t *testing.T) {
+		m := mockey.Mock(common.AllocAutoID).Return(int64(1000), int64(1000+numRows), nil).Build()
+		defer m.UnPatch()
+
+		noFuncSchema := newSchemaInfo(&schemapb.CollectionSchema{
+			Name:   "test_no_func",
+			AutoID: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true, AutoID: true},
+				{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar, TypeParams: []*commonpb.KeyValuePair{{Key: "max_length", Value: "2000"}}},
+				{FieldID: 102, Name: "vec", DataType: schemapb.DataType_FloatVector, TypeParams: []*commonpb.KeyValuePair{{Key: "dim", Value: "4"}}},
+			},
+		})
+
+		noFuncFieldsData := []*schemapb.FieldData{
+			{
+				FieldName: "text", FieldId: 101, Type: schemapb.DataType_VarChar,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"hello", "world"}}}}},
+			},
+			{
+				FieldName: "vec", FieldId: 102, Type: schemapb.DataType_FloatVector,
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{Dim: 4, Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: make([]float32, numRows*4)}}}},
+			},
+		}
+
+		task := &upsertTask{
+			ctx:         context.Background(),
+			schema:      noFuncSchema,
+			idAllocator: &allocator.IDAllocator{},
+			req: &milvuspb.UpsertRequest{
+				CollectionName: "test_no_func",
+				PartialUpdate:  true,
+			},
+			upsertMsg: &msgstream.UpsertMsg{
+				InsertMsg: &msgstream.InsertMsg{
+					InsertRequest: &msgpb.InsertRequest{
+						CollectionName: "test_no_func",
+						Version:        msgpb.InsertDataVersion_ColumnBased,
+						FieldsData:     noFuncFieldsData,
+						NumRows:        uint64(numRows),
+						PartitionName:  Params.CommonCfg.DefaultPartitionName.GetValue(),
+					},
+				},
+			},
+			result: &milvuspb.MutationResult{},
+		}
+
+		_ = task.insertPreExecute(context.Background())
+
+		remainingFields := getFieldNames(task.upsertMsg.InsertMsg.GetFieldsData())
+		assert.Contains(t, remainingFields, "text")
+		assert.Contains(t, remainingFields, "vec")
+		assert.Len(t, remainingFields, 2)
+	})
+}
+
 func TestUpsertTask_queryPreExecute_NullableFields(t *testing.T) {
 	dim := int64(4)
 

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -2768,26 +2768,6 @@ func GetFunctionOutputFields(collSchema *schemapb.CollectionSchema) []string {
 	return fields
 }
 
-func GetBM25FunctionOutputFields(collSchema *schemapb.CollectionSchema) []string {
-	fields := make([]string, 0)
-	for _, fSchema := range collSchema.Functions {
-		if fSchema.Type == schemapb.FunctionType_BM25 {
-			fields = append(fields, fSchema.OutputFieldNames...)
-		}
-	}
-	return fields
-}
-
-func GetMinHashFunctionOutputFields(collSchema *schemapb.CollectionSchema) []string {
-	fields := make([]string, 0)
-	for _, fSchema := range collSchema.Functions {
-		if fSchema.Type == schemapb.FunctionType_MinHash {
-			fields = append(fields, fSchema.OutputFieldNames...)
-		}
-	}
-	return fields
-}
-
 // getCollectionTTL returns ttl if collection's ttl is specified
 // or return global ttl if collection's ttl is not specified
 // this is a helper util wrapping common.GetCollectionTTL without returning error

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -2768,6 +2768,26 @@ func GetFunctionOutputFields(collSchema *schemapb.CollectionSchema) []string {
 	return fields
 }
 
+func GetBM25FunctionOutputFields(collSchema *schemapb.CollectionSchema) []string {
+	fields := make([]string, 0)
+	for _, fSchema := range collSchema.Functions {
+		if fSchema.Type == schemapb.FunctionType_BM25 {
+			fields = append(fields, fSchema.OutputFieldNames...)
+		}
+	}
+	return fields
+}
+
+func GetMinHashFunctionOutputFields(collSchema *schemapb.CollectionSchema) []string {
+	fields := make([]string, 0)
+	for _, fSchema := range collSchema.Functions {
+		if fSchema.Type == schemapb.FunctionType_MinHash {
+			fields = append(fields, fSchema.OutputFieldNames...)
+		}
+	}
+	return fields
+}
+
 // getCollectionTTL returns ttl if collection's ttl is specified
 // or return global ttl if collection's ttl is not specified
 // this is a helper util wrapping common.GetCollectionTTL without returning error


### PR DESCRIPTION
## Summary
- Replace BM25-specific `GetBM25FunctionOutputFields` with the generic `GetFunctionOutputFields` in upsert task, so all function output fields (BM25, MinHash, etc.) are properly filtered during partial update
- Remove unused `GetBM25FunctionOutputFields` and `GetMinHashFunctionOutputFields` helper functions
- Add unit tests for function output field filtering in partial update scenarios

issue: #47928

## Test plan
- [x] `TestInsertPreExecute_FilterFunctionOutputFields/partial_update_filters_all_function_output_fields` — verifies BM25 + MinHash output fields are removed
- [x] `TestInsertPreExecute_FilterFunctionOutputFields/partial_update_with_no_functions_keeps_all_fields` — verifies no-function schema keeps all fields
- [x] All existing `TestUpsertTask*` tests pass

Signed-off-by: Wei Liu <wei.liu@zilliz.com>