### PR TITLE
test: set Strong consistency level for chaos test collections

### DIFF
--- a/tests/python_client/chaos/checker.py
+++ b/tests/python_client/chaos/checker.py
@@ -457,6 +457,7 @@ class Checker:
                 collection_name=c_name,
                 schema=schema,
                 shards_num=shards_num,
+                consistency_level="Strong",
                 timeout=timeout
             )
         self.scalar_field_names = cf.get_scalar_field_name_list(schema=schema)
@@ -1599,7 +1600,8 @@ class CollectionCreateChecker(Checker):
             collection_name = cf.gen_unique_str("CreateChecker_")
             schema = cf.gen_default_collection_schema()
             self.milvus_client.create_collection(collection_name=collection_name,
-                                                schema=schema)
+                                                schema=schema,
+                                                consistency_level="Strong")
             return None, True
         except Exception as e:
             return str(e), False
@@ -1633,7 +1635,7 @@ class CollectionDropChecker(Checker):
         for i in range(pool_size):
             collection_name = cf.gen_unique_str("DropChecker_")
             try:
-                self.milvus_client.create_collection(collection_name=collection_name, schema=schema)
+                self.milvus_client.create_collection(collection_name=collection_name, schema=schema, consistency_level="Strong")
                 self.collection_pool.append(collection_name)
             except Exception as e:
                 log.error(f"Failed to create collection {collection_name}: {e}")
@@ -1680,7 +1682,7 @@ class PartitionCreateChecker(Checker):
             collection_name = cf.gen_unique_str("PartitionCreateChecker_")
         super().__init__(collection_name=collection_name, schema=schema, partition_name=partition_name)
         c_name = cf.gen_unique_str("PartitionDropChecker_")
-        self.milvus_client.create_collection(collection_name=c_name, schema=self.schema)
+        self.milvus_client.create_collection(collection_name=c_name, schema=self.schema, consistency_level="Strong")
         self.c_name = c_name
         log.info(f"collection {c_name} created")
         p_name = cf.gen_unique_str("PartitionDropChecker_")
@@ -1717,7 +1719,7 @@ class PartitionDropChecker(Checker):
             collection_name = cf.gen_unique_str("PartitionDropChecker_")
         super().__init__(collection_name=collection_name, schema=schema, partition_name=partition_name)
         c_name = cf.gen_unique_str("PartitionDropChecker_")
-        self.milvus_client.create_collection(collection_name=c_name, schema=self.schema)
+        self.milvus_client.create_collection(collection_name=c_name, schema=self.schema, consistency_level="Strong")
         self.c_name = c_name
         log.info(f"collection {c_name} created")
         p_name = cf.gen_unique_str("PartitionDropChecker_")
@@ -1843,7 +1845,7 @@ class IndexCreateChecker(Checker):
     @exception_handler()
     def run_task(self):
         c_name = cf.gen_unique_str("IndexCreateChecker_")
-        self.milvus_client.create_collection(collection_name=c_name, schema=self.schema)
+        self.milvus_client.create_collection(collection_name=c_name, schema=self.schema, consistency_level="Strong")
         self.c_name = c_name
         res, result = self.create_index()
         if result:
@@ -1883,14 +1885,14 @@ class IndexDropChecker(Checker):
     def run_task(self):
         res, result = self.drop_index()
         if result:
-            self.milvus_client.create_collection(collection_name=cf.gen_unique_str("IndexDropChecker_"), schema=self.schema)
+            self.milvus_client.create_collection(collection_name=cf.gen_unique_str("IndexDropChecker_"), schema=self.schema, consistency_level="Strong")
             index_params = create_index_params_from_dict(self.float_vector_field_name, constants.DEFAULT_INDEX_PARAM)
             self.milvus_client.create_index(collection_name=self.c_name, index_params=index_params)
         return res, result
 
     def keep_running(self):
         while self._keep_running:
-            self.milvus_client.create_collection(collection_name=cf.gen_unique_str("IndexDropChecker_"), schema=self.schema)
+            self.milvus_client.create_collection(collection_name=cf.gen_unique_str("IndexDropChecker_"), schema=self.schema, consistency_level="Strong")
             index_params = create_index_params_from_dict(self.float_vector_field_name, constants.DEFAULT_INDEX_PARAM)
             self.milvus_client.create_index(collection_name=self.c_name, index_params=index_params)
             self.run_task()
@@ -2380,7 +2382,7 @@ class BulkInsertChecker(Checker):
                 log.debug(f"check failed task: {self.c_name}")
             else:
                 self.c_name = cf.gen_unique_str("BulkInsertChecker_")
-        self.milvus_client.create_collection(collection_name=self.c_name, schema=self.schema)
+        self.milvus_client.create_collection(collection_name=self.c_name, schema=self.schema, consistency_level="Strong")
         log.info(f"collection schema: {self.milvus_client.describe_collection(self.c_name)}")
         # bulk insert data
         num_entities = self.milvus_client.get_collection_stats(collection_name=self.c_name).get("row_count", 0)

--- a/tests/python_client/chaos/testcases/test_all_collections_after_chaos.py
+++ b/tests/python_client/chaos/testcases/test_all_collections_after_chaos.py
@@ -142,7 +142,8 @@ class TestAllCollection:
             data=search_vectors,
             anns_field=float_vector_field_name,
             search_params=dense_search_params,
-            limit=1
+            limit=1,
+            consistency_level="Strong"
         )
         tt = time.time() - t0
         log.info(f"assert search: {tt}")
@@ -158,7 +159,8 @@ class TestAllCollection:
                 data=queries,
                 anns_field=bm25_vec_field_name_list[0],
                 search_params=bm25_search_params,
-                limit=1
+                limit=1,
+                consistency_level="Strong"
             )
             tt = time.time() - t0
             log.info(f"assert full text search: {tt}")
@@ -170,7 +172,8 @@ class TestAllCollection:
         res = milvus_client.query(
             collection_name=name,
             filter=term_expr,
-            limit=5
+            limit=5,
+            consistency_level="Strong"
         )
         tt = time.time() - t0
         log.info(f"assert query result {len(res)}: {tt}")
@@ -184,7 +187,8 @@ class TestAllCollection:
             res = milvus_client.query(
                 collection_name=name,
                 filter=expr,
-                limit=5
+                limit=5,
+                consistency_level="Strong"
             )
             tt = time.time() - t0
             log.info(f"assert text match: {tt}")
@@ -211,7 +215,8 @@ class TestAllCollection:
             data=search_vectors,
             anns_field=float_vector_field_name,
             search_params=dense_search_params,
-            limit=topk
+            limit=topk,
+            consistency_level="Strong"
         )
         tt = time.time() - t0
         log.info(f"assert search: {tt}")
@@ -228,7 +233,8 @@ class TestAllCollection:
                 data=queries,
                 anns_field=bm25_vec_field_name_list[0],
                 search_params=bm25_search_params,
-                limit=1
+                limit=1,
+                consistency_level="Strong"
             )
             tt = time.time() - t0
             log.info(f"assert full text search: {tt}")
@@ -240,7 +246,8 @@ class TestAllCollection:
         res = milvus_client.query(
             collection_name=name,
             filter=term_expr,
-            limit=5
+            limit=5,
+            consistency_level="Strong"
         )
         tt = time.time() - t0
         log.info(f"assert query result {len(res)}: {tt}")
@@ -254,7 +261,8 @@ class TestAllCollection:
             res = milvus_client.query(
                 collection_name=name,
                 filter=expr,
-                limit=5
+                limit=5,
+                consistency_level="Strong"
             )
             tt = time.time() - t0
             log.info(f"assert text match: {tt}")


### PR DESCRIPTION
## Summary
- Set `consistency_level="Strong"` at collection creation time in chaos `checker.py` (9 places) to ensure data correctness during chaos testing
- Add explicit `consistency_level="Strong"` to all search/query calls in `test_all_collections_after_chaos.py` (8 places) since it operates on pre-existing collections

## Test plan
- [x] Pod logs confirm `[consistency_level=Strong]` at CreateCollection
- [x] `describe_collection` returns `consistency_level: 0` (Strong)
- [x] Insert-then-query returns all data immediately without explicit consistency_level param