### PR TITLE
enhance: add global TLS config for CDC outbound mTLS connections

### DIFF
--- a/client/milvusclient/client.go
+++ b/client/milvusclient/client.go
@@ -98,7 +98,9 @@ func New(ctx context.Context, config *ClientConfig) (*Client, error) {
 func (c *Client) dialOptions() []grpc.DialOption {
 	var options []grpc.DialOption
 	// Construct dial option.
-	if c.config.EnableTLSAuth {
+	if c.config.TLSConfig != nil {
+		options = append(options, grpc.WithTransportCredentials(credentials.NewTLS(c.config.TLSConfig)))
+	} else if c.config.EnableTLSAuth {
 		options = append(options, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{})))
 	} else {
 		options = append(options, grpc.WithTransportCredentials(insecure.NewCredentials()))

--- a/client/milvusclient/client_config.go
+++ b/client/milvusclient/client_config.go
@@ -2,6 +2,7 @@ package milvusclient
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"math"
 	"net/url"
@@ -53,8 +54,9 @@ type ClientConfig struct {
 	Password string // Password for auth.
 	DBName   string // DBName for this client.
 
-	EnableTLSAuth bool   // Enable TLS Auth for transport security.
-	APIKey        string // API key
+	EnableTLSAuth bool       // Enable TLS Auth for transport security.
+	APIKey        string     // API key
+	TLSConfig     *tls.Config // Custom TLS config (overrides EnableTLSAuth when set).
 
 	DialOptions []grpc.DialOption // Dial options for GRPC.
 

--- a/client/milvusclient/tls.go
+++ b/client/milvusclient/tls.go
@@ -1,3 +1,19 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package milvusclient
 
 import (
@@ -22,7 +38,12 @@ func BuildTLSConfig(caPemPath, clientPemPath, clientKeyPath string) (*tls.Config
 	}
 
 	tlsConfig := &tls.Config{
-		RootCAs: certPool,
+		RootCAs:    certPool,
+		MinVersion: tls.VersionTLS13,
+	}
+
+	if (clientPemPath != "") != (clientKeyPath != "") {
+		return nil, fmt.Errorf("both clientPemPath and clientKeyPath must be set for mTLS, got clientPemPath=%q clientKeyPath=%q", clientPemPath, clientKeyPath)
 	}
 
 	if clientPemPath != "" && clientKeyPath != "" {

--- a/client/milvusclient/tls.go
+++ b/client/milvusclient/tls.go
@@ -1,0 +1,37 @@
+package milvusclient
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+)
+
+// BuildTLSConfig creates a tls.Config for outbound mTLS connections.
+// caPemPath is required (for server cert verification).
+// clientPemPath + clientKeyPath are optional (for mutual TLS client auth).
+func BuildTLSConfig(caPemPath, clientPemPath, clientKeyPath string) (*tls.Config, error) {
+	caPem, err := os.ReadFile(caPemPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read CA cert %s: %w", caPemPath, err)
+	}
+
+	certPool := x509.NewCertPool()
+	if !certPool.AppendCertsFromPEM(caPem) {
+		return nil, fmt.Errorf("failed to parse CA cert from %s", caPemPath)
+	}
+
+	tlsConfig := &tls.Config{
+		RootCAs: certPool,
+	}
+
+	if clientPemPath != "" && clientKeyPath != "" {
+		clientCert, err := tls.LoadX509KeyPair(clientPemPath, clientKeyPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load client cert (%s, %s): %w", clientPemPath, clientKeyPath, err)
+		}
+		tlsConfig.Certificates = []tls.Certificate{clientCert}
+	}
+
+	return tlsConfig, nil
+}

--- a/client/milvusclient/tls_test.go
+++ b/client/milvusclient/tls_test.go
@@ -1,0 +1,63 @@
+package milvusclient
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildTLSConfig(t *testing.T) {
+	t.Run("valid CA only", func(t *testing.T) {
+		caPem := filepath.Join("..", "..", "configs", "cert", "ca.pem")
+		if _, err := os.Stat(caPem); os.IsNotExist(err) {
+			t.Skip("test cert fixtures not found")
+		}
+		tlsConfig, err := BuildTLSConfig(caPem, "", "")
+		require.NoError(t, err)
+		assert.NotNil(t, tlsConfig.RootCAs)
+		assert.Empty(t, tlsConfig.Certificates)
+	})
+
+	t.Run("valid mTLS", func(t *testing.T) {
+		caPem := filepath.Join("..", "..", "configs", "cert", "ca.pem")
+		clientPem := filepath.Join("..", "..", "configs", "cert", "client.pem")
+		clientKey := filepath.Join("..", "..", "configs", "cert", "client.key")
+		for _, f := range []string{caPem, clientPem, clientKey} {
+			if _, err := os.Stat(f); os.IsNotExist(err) {
+				t.Skip("test cert fixtures not found")
+			}
+		}
+		tlsConfig, err := BuildTLSConfig(caPem, clientPem, clientKey)
+		require.NoError(t, err)
+		assert.NotNil(t, tlsConfig.RootCAs)
+		assert.Len(t, tlsConfig.Certificates, 1)
+	})
+
+	t.Run("nonexistent CA", func(t *testing.T) {
+		_, err := BuildTLSConfig("/nonexistent/ca.pem", "", "")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read CA cert")
+	})
+
+	t.Run("invalid CA content", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		badCA := filepath.Join(tmpDir, "bad-ca.pem")
+		os.WriteFile(badCA, []byte("not a certificate"), 0o644)
+		_, err := BuildTLSConfig(badCA, "", "")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse CA cert")
+	})
+
+	t.Run("nonexistent client cert", func(t *testing.T) {
+		caPem := filepath.Join("..", "..", "configs", "cert", "ca.pem")
+		if _, err := os.Stat(caPem); os.IsNotExist(err) {
+			t.Skip("test cert fixtures not found")
+		}
+		_, err := BuildTLSConfig(caPem, "/nonexistent/client.pem", "/nonexistent/client.key")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to load client cert")
+	})
+}

--- a/client/milvusclient/tls_test.go
+++ b/client/milvusclient/tls_test.go
@@ -1,20 +1,92 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package milvusclient
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+// generateTestCerts creates a self-signed CA and a client cert signed by it.
+// Returns paths to ca.pem, client.pem, client.key in a temp directory.
+func generateTestCerts(t *testing.T) (caPem, clientPem, clientKey string) {
+	t.Helper()
+	dir := t.TempDir()
+
+	// Generate CA key and self-signed cert.
+	caPriv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test CA"},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+	}
+	caCertDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caPriv.PublicKey, caPriv)
+	require.NoError(t, err)
+
+	caPem = filepath.Join(dir, "ca.pem")
+	require.NoError(t, os.WriteFile(caPem, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caCertDER}), 0o644))
+
+	// Generate client key and cert signed by CA.
+	clientPriv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	clientTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "Test Client"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	clientCertDER, err := x509.CreateCertificate(rand.Reader, clientTemplate, caTemplate, &clientPriv.PublicKey, caPriv)
+	require.NoError(t, err)
+
+	clientPem = filepath.Join(dir, "client.pem")
+	require.NoError(t, os.WriteFile(clientPem, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientCertDER}), 0o644))
+
+	clientKeyBytes, err := x509.MarshalECPrivateKey(clientPriv)
+	require.NoError(t, err)
+	clientKey = filepath.Join(dir, "client.key")
+	require.NoError(t, os.WriteFile(clientKey, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: clientKeyBytes}), 0o600))
+
+	return caPem, clientPem, clientKey
+}
+
 func TestBuildTLSConfig(t *testing.T) {
 	t.Run("valid CA only", func(t *testing.T) {
-		caPem := filepath.Join("..", "..", "configs", "cert", "ca.pem")
-		if _, err := os.Stat(caPem); os.IsNotExist(err) {
-			t.Skip("test cert fixtures not found")
-		}
+		caPem, _, _ := generateTestCerts(t)
 		tlsConfig, err := BuildTLSConfig(caPem, "", "")
 		require.NoError(t, err)
 		assert.NotNil(t, tlsConfig.RootCAs)
@@ -22,14 +94,7 @@ func TestBuildTLSConfig(t *testing.T) {
 	})
 
 	t.Run("valid mTLS", func(t *testing.T) {
-		caPem := filepath.Join("..", "..", "configs", "cert", "ca.pem")
-		clientPem := filepath.Join("..", "..", "configs", "cert", "client.pem")
-		clientKey := filepath.Join("..", "..", "configs", "cert", "client.key")
-		for _, f := range []string{caPem, clientPem, clientKey} {
-			if _, err := os.Stat(f); os.IsNotExist(err) {
-				t.Skip("test cert fixtures not found")
-			}
-		}
+		caPem, clientPem, clientKey := generateTestCerts(t)
 		tlsConfig, err := BuildTLSConfig(caPem, clientPem, clientKey)
 		require.NoError(t, err)
 		assert.NotNil(t, tlsConfig.RootCAs)
@@ -52,12 +117,23 @@ func TestBuildTLSConfig(t *testing.T) {
 	})
 
 	t.Run("nonexistent client cert", func(t *testing.T) {
-		caPem := filepath.Join("..", "..", "configs", "cert", "ca.pem")
-		if _, err := os.Stat(caPem); os.IsNotExist(err) {
-			t.Skip("test cert fixtures not found")
-		}
+		caPem, _, _ := generateTestCerts(t)
 		_, err := BuildTLSConfig(caPem, "/nonexistent/client.pem", "/nonexistent/client.key")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to load client cert")
+	})
+
+	t.Run("partial client config errors", func(t *testing.T) {
+		caPem, clientPem, _ := generateTestCerts(t)
+
+		// Only clientPemPath set.
+		_, err := BuildTLSConfig(caPem, clientPem, "")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "both clientPemPath and clientKeyPath must be set")
+
+		// Only clientKeyPath set.
+		_, err = BuildTLSConfig(caPem, "", "/some/client.key")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "both clientPemPath and clientKeyPath must be set")
 	})
 }

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -904,6 +904,8 @@ tls:
   serverPemPath: configs/cert/server.pem
   serverKeyPath: configs/cert/server.key
   caPemPath: configs/cert/ca.pem
+  clientPemPath:  # Client certificate for outbound mTLS connections (e.g. CDC)
+  clientKeyPath:  # Client private key for outbound mTLS connections (e.g. CDC)
 
 # Configure internal tls.
 internaltls:

--- a/internal/cdc/cluster/milvus_client.go
+++ b/internal/cdc/cluster/milvus_client.go
@@ -21,11 +21,13 @@ import (
 	"crypto/tls"
 
 	"github.com/cockroachdb/errors"
+	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus/client/v2/milvusclient"
+	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
@@ -64,16 +66,21 @@ func NewMilvusClient(ctx context.Context, cluster *commonpb.MilvusCluster) (Milv
 }
 
 // buildCDCTLSConfig reads TLS config from paramtable for CDC outbound connections.
-// Returns nil if no CA cert is configured (TLS disabled).
+// Returns nil if client cert paths are not configured (TLS disabled for CDC).
 func buildCDCTLSConfig() (*tls.Config, error) {
 	params := paramtable.Get()
-	caPemPath := params.ProxyGrpcServerCfg.CaPemPath.GetValue()
-	if caPemPath == "" {
+	clientPemPath := params.ProxyGrpcServerCfg.ClientPemPath.GetValue()
+	clientKeyPath := params.ProxyGrpcServerCfg.ClientKeyPath.GetValue()
+	// Only activate TLS when client cert paths are explicitly configured.
+	if clientPemPath == "" || clientKeyPath == "" {
 		return nil, nil
 	}
 
-	clientPemPath := params.ProxyGrpcServerCfg.ClientPemPath.GetValue()
-	clientKeyPath := params.ProxyGrpcServerCfg.ClientKeyPath.GetValue()
+	caPemPath := params.ProxyGrpcServerCfg.CaPemPath.GetValue()
+	log.Info("CDC outbound TLS enabled",
+		zap.String("caPemPath", caPemPath),
+		zap.String("clientPemPath", clientPemPath),
+		zap.String("clientKeyPath", clientKeyPath))
 
 	return milvusclient.BuildTLSConfig(caPemPath, clientPemPath, clientKeyPath)
 }

--- a/internal/cdc/cluster/milvus_client.go
+++ b/internal/cdc/cluster/milvus_client.go
@@ -18,6 +18,7 @@ package cluster
 
 import (
 	"context"
+	"crypto/tls"
 
 	"github.com/cockroachdb/errors"
 	"google.golang.org/grpc"
@@ -25,6 +26,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus/client/v2/milvusclient"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
 type MilvusClient interface {
@@ -39,12 +41,39 @@ type MilvusClient interface {
 type CreateMilvusClientFunc func(ctx context.Context, cluster *commonpb.MilvusCluster) (MilvusClient, error)
 
 func NewMilvusClient(ctx context.Context, cluster *commonpb.MilvusCluster) (MilvusClient, error) {
-	cli, err := milvusclient.New(ctx, &milvusclient.ClientConfig{
-		Address: cluster.GetConnectionParam().GetUri(),
-		APIKey:  cluster.GetConnectionParam().GetToken(),
-	})
+	connParam := cluster.GetConnectionParam()
+	config := &milvusclient.ClientConfig{
+		Address: connParam.GetUri(),
+		APIKey:  connParam.GetToken(),
+	}
+
+	// Build TLS config from paramtable if CA cert is configured.
+	tlsConfig, err := buildCDCTLSConfig()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build CDC TLS config")
+	}
+	if tlsConfig != nil {
+		config.TLSConfig = tlsConfig
+	}
+
+	cli, err := milvusclient.New(ctx, config)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create milvus client")
 	}
 	return cli, nil
+}
+
+// buildCDCTLSConfig reads TLS config from paramtable for CDC outbound connections.
+// Returns nil if no CA cert is configured (TLS disabled).
+func buildCDCTLSConfig() (*tls.Config, error) {
+	params := paramtable.Get()
+	caPemPath := params.ProxyGrpcServerCfg.CaPemPath.GetValue()
+	if caPemPath == "" {
+		return nil, nil
+	}
+
+	clientPemPath := params.ProxyGrpcServerCfg.ClientPemPath.GetValue()
+	clientKeyPath := params.ProxyGrpcServerCfg.ClientKeyPath.GetValue()
+
+	return milvusclient.BuildTLSConfig(caPemPath, clientPemPath, clientKeyPath)
 }

--- a/internal/cdc/cluster/milvus_client_test.go
+++ b/internal/cdc/cluster/milvus_client_test.go
@@ -1,0 +1,48 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+)
+
+func TestBuildCDCTLSConfig(t *testing.T) {
+	paramtable.Init()
+
+	t.Run("no CA configured returns nil", func(t *testing.T) {
+		paramtable.Get().Save("tls.caPemPath", "")
+		paramtable.Get().Save("tls.clientPemPath", "")
+		paramtable.Get().Save("tls.clientKeyPath", "")
+
+		tlsConfig, err := buildCDCTLSConfig()
+		assert.NoError(t, err)
+		assert.Nil(t, tlsConfig)
+	})
+
+	t.Run("invalid CA path returns error", func(t *testing.T) {
+		paramtable.Get().Save("tls.caPemPath", "/nonexistent/ca.pem")
+		defer paramtable.Get().Save("tls.caPemPath", "")
+
+		_, err := buildCDCTLSConfig()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read CA cert")
+	})
+}

--- a/internal/cdc/cluster/milvus_client_test.go
+++ b/internal/cdc/cluster/milvus_client_test.go
@@ -27,8 +27,7 @@ import (
 func TestBuildCDCTLSConfig(t *testing.T) {
 	paramtable.Init()
 
-	t.Run("no CA configured returns nil", func(t *testing.T) {
-		paramtable.Get().Save("tls.caPemPath", "")
+	t.Run("no client cert configured returns nil", func(t *testing.T) {
 		paramtable.Get().Save("tls.clientPemPath", "")
 		paramtable.Get().Save("tls.clientKeyPath", "")
 
@@ -37,9 +36,38 @@ func TestBuildCDCTLSConfig(t *testing.T) {
 		assert.Nil(t, tlsConfig)
 	})
 
+	t.Run("only caPemPath set returns nil", func(t *testing.T) {
+		// Even with caPemPath set, if client certs are not configured, TLS is not activated.
+		paramtable.Get().Save("tls.caPemPath", "/some/ca.pem")
+		paramtable.Get().Save("tls.clientPemPath", "")
+		paramtable.Get().Save("tls.clientKeyPath", "")
+		defer paramtable.Get().Save("tls.caPemPath", "")
+
+		tlsConfig, err := buildCDCTLSConfig()
+		assert.NoError(t, err)
+		assert.Nil(t, tlsConfig)
+	})
+
+	t.Run("partial client cert configured returns nil", func(t *testing.T) {
+		// Only clientPemPath set, clientKeyPath empty — should not activate.
+		paramtable.Get().Save("tls.clientPemPath", "/some/client.pem")
+		paramtable.Get().Save("tls.clientKeyPath", "")
+		defer paramtable.Get().Save("tls.clientPemPath", "")
+
+		tlsConfig, err := buildCDCTLSConfig()
+		assert.NoError(t, err)
+		assert.Nil(t, tlsConfig)
+	})
+
 	t.Run("invalid CA path returns error", func(t *testing.T) {
 		paramtable.Get().Save("tls.caPemPath", "/nonexistent/ca.pem")
-		defer paramtable.Get().Save("tls.caPemPath", "")
+		paramtable.Get().Save("tls.clientPemPath", "/some/client.pem")
+		paramtable.Get().Save("tls.clientKeyPath", "/some/client.key")
+		defer func() {
+			paramtable.Get().Save("tls.caPemPath", "")
+			paramtable.Get().Save("tls.clientPemPath", "")
+			paramtable.Get().Save("tls.clientKeyPath", "")
+		}()
 
 		_, err := buildCDCTLSConfig()
 		assert.Error(t, err)

--- a/pkg/util/paramtable/grpc_param.go
+++ b/pkg/util/paramtable/grpc_param.go
@@ -76,6 +76,8 @@ type grpcConfig struct {
 	ServerPemPath ParamItem `refreshable:"false"`
 	ServerKeyPath ParamItem `refreshable:"false"`
 	CaPemPath     ParamItem `refreshable:"false"`
+	ClientPemPath ParamItem `refreshable:"false"`
+	ClientKeyPath ParamItem `refreshable:"false"`
 }
 
 func (p *grpcConfig) init(domain string, base *BaseTable) {
@@ -133,6 +135,20 @@ func (p *grpcConfig) init(domain string, base *BaseTable) {
 		Export:  true,
 	}
 	p.CaPemPath.Init(base.mgr)
+
+	p.ClientPemPath = ParamItem{
+		Key:     "tls.clientPemPath",
+		Version: "2.6.0",
+		Export:  true,
+	}
+	p.ClientPemPath.Init(base.mgr)
+
+	p.ClientKeyPath = ParamItem{
+		Key:     "tls.clientKeyPath",
+		Version: "2.6.0",
+		Export:  true,
+	}
+	p.ClientKeyPath.Init(base.mgr)
 }
 
 // GetAddress return grpc address

--- a/pkg/util/paramtable/grpc_param_test.go
+++ b/pkg/util/paramtable/grpc_param_test.go
@@ -176,6 +176,11 @@ func TestGrpcClientParams(t *testing.T) {
 	assert.Equal(t, clientConfig.ServerPemPath.GetValue(), "/pem")
 	assert.Equal(t, clientConfig.ServerKeyPath.GetValue(), "/key")
 	assert.Equal(t, clientConfig.CaPemPath.GetValue(), "/ca")
+
+	base.Save("tls.clientPemPath", "/client.pem")
+	base.Save("tls.clientKeyPath", "/client.key")
+	assert.Equal(t, clientConfig.ClientPemPath.GetValue(), "/client.pem")
+	assert.Equal(t, clientConfig.ClientKeyPath.GetValue(), "/client.key")
 }
 
 func TestInternalTLSParams(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add `tls.clientPemPath` and `tls.clientKeyPath` to paramtable so CDC reads client cert config from `milvus.yaml`
- Add `BuildTLSConfig` helper to SDK client and `TLSConfig` field to `ClientConfig`
- CDC `NewMilvusClient` auto-builds TLS config from paramtable for outbound mTLS connections

issue: #47843

## Test plan
- [x] Unit tests for `BuildTLSConfig` (5 cases)
- [x] Unit tests for `buildCDCTLSConfig` (2 cases)
- [ ] E2E: configure `tls.clientPemPath`/`tls.clientKeyPath` in milvus.yaml, verify CDC replication over mTLS

🤖 Generated with [Claude Code](https://claude.com/claude-code)