### PR TITLE
enhance: add retryable error detection for transient network errors in object storage

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -1022,6 +1022,7 @@ common:
         enabled: true # enable split by average size policy in storage v2
         threshold: 1024 # split by average size policy threshold(in bytes) in storage v2
     useLoonFFI: false
+    retryableErrorPatterns:  # Comma-separated list of error message substrings that should trigger retry for object storage operations. This is useful for custom S3-compatible backends that return non-standard error messages on transient failures.
   traceLogMode: 0 # trace request info
   bloomFilterSize: 100000 # bloom filter initial size
   bloomFilterType: BlockedBloomFilter # bloom filter type, support BasicBloomFilter and BlockedBloomFilter

--- a/internal/storage/remote_chunk_manager.go
+++ b/internal/storage/remote_chunk_manager.go
@@ -20,7 +20,9 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"net"
 	"net/http"
+	"os"
 	"strings"
 	"syscall"
 
@@ -37,6 +39,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/metrics"
 	"github.com/milvus-io/milvus/pkg/v2/objectstorage"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/retry"
 	"github.com/milvus-io/milvus/pkg/v2/util/timerecord"
 )
@@ -492,6 +495,33 @@ func checkObjectStorageError(fileName string, err error) error {
 	if err == io.ErrUnexpectedEOF {
 		return merr.WrapErrIoUnexpectEOF(fileName, err)
 	}
+
+	// Detect Go-level transient network errors (timeouts, connection refused).
+	// These are common with custom S3-compatible backends that return non-standard errors.
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return merr.WrapErrIoTransient(fileName, err)
+	}
+	if errors.Is(err, syscall.ECONNREFUSED) {
+		return merr.WrapErrIoTransient(fileName, err)
+	}
+	if errors.Is(err, os.ErrDeadlineExceeded) {
+		return merr.WrapErrIoTransient(fileName, err)
+	}
+
+	// Check user-configured retryable error patterns.
+	// This allows custom storage backends to define retryable errors via config
+	// without code changes (e.g., common.storage.retryableErrorPatterns: "server throttled,custom error").
+	patterns := paramtable.Get().CommonCfg.StorageRetryableErrorPatterns.GetAsStrings()
+	if len(patterns) > 0 {
+		errMsg := err.Error()
+		for _, pattern := range patterns {
+			if pattern != "" && strings.Contains(errMsg, pattern) {
+				return merr.WrapErrIoTransient(fileName, err)
+			}
+		}
+	}
+
 	return merr.WrapErrIoFailed(fileName, err)
 }
 

--- a/internal/storage/remote_chunk_manager_test.go
+++ b/internal/storage/remote_chunk_manager_test.go
@@ -18,8 +18,11 @@ package storage
 
 import (
 	"context"
+	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"os"
 	"path"
 	"syscall"
 	"testing"
@@ -34,6 +37,7 @@ import (
 
 	"github.com/milvus-io/milvus/pkg/v2/objectstorage"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
 // TODO: NewRemoteChunkManager is deprecated. Rewrite this unittest.
@@ -1327,6 +1331,67 @@ func TestToMilvusIoError(t *testing.T) {
 	t.Run("googleapi other error", func(t *testing.T) {
 		googleErr := &googleapi.Error{Code: http.StatusForbidden}
 		err := ToMilvusIoError(fileName, googleErr)
+		assert.ErrorIs(t, err, merr.ErrIoFailed)
+	})
+
+	t.Run("net timeout error", func(t *testing.T) {
+		// net.OpError with Timeout() == true, simulating "net/http: timeout awaiting response headers"
+		netErr := &net.OpError{
+			Op:  "read",
+			Err: &net.DNSError{IsTimeout: true},
+		}
+		err := ToMilvusIoError(fileName, netErr)
+		assert.ErrorIs(t, err, merr.ErrIoTransient)
+		assert.True(t, merr.IsRetryableErr(err))
+	})
+
+	t.Run("syscall.ECONNREFUSED", func(t *testing.T) {
+		err := ToMilvusIoError(fileName, &net.OpError{
+			Op:  "dial",
+			Err: &os.SyscallError{Syscall: "connect", Err: syscall.ECONNREFUSED},
+		})
+		assert.ErrorIs(t, err, merr.ErrIoTransient)
+		assert.True(t, merr.IsRetryableErr(err))
+	})
+
+	t.Run("os.ErrDeadlineExceeded", func(t *testing.T) {
+		err := ToMilvusIoError(fileName, os.ErrDeadlineExceeded)
+		assert.ErrorIs(t, err, merr.ErrIoTransient)
+		assert.True(t, merr.IsRetryableErr(err))
+	})
+
+	t.Run("config pattern match", func(t *testing.T) {
+		paramtable.Get().Save("common.storage.retryableErrorPatterns", "server throttled,custom busy")
+		defer paramtable.Get().Reset("common.storage.retryableErrorPatterns")
+
+		err := ToMilvusIoError(fileName, fmt.Errorf("request failed: server throttled"))
+		assert.ErrorIs(t, err, merr.ErrIoTransient)
+		assert.True(t, merr.IsRetryableErr(err))
+	})
+
+	t.Run("config pattern match second pattern", func(t *testing.T) {
+		paramtable.Get().Save("common.storage.retryableErrorPatterns", "server throttled,custom busy")
+		defer paramtable.Get().Reset("common.storage.retryableErrorPatterns")
+
+		err := ToMilvusIoError(fileName, fmt.Errorf("request failed: custom busy"))
+		assert.ErrorIs(t, err, merr.ErrIoTransient)
+		assert.True(t, merr.IsRetryableErr(err))
+	})
+
+	t.Run("config pattern no match", func(t *testing.T) {
+		paramtable.Get().Save("common.storage.retryableErrorPatterns", "server throttled")
+		defer paramtable.Get().Reset("common.storage.retryableErrorPatterns")
+
+		err := ToMilvusIoError(fileName, fmt.Errorf("some other error"))
+		assert.ErrorIs(t, err, merr.ErrIoFailed)
+		assert.False(t, merr.IsRetryableErr(err))
+	})
+
+	t.Run("config pattern empty", func(t *testing.T) {
+		paramtable.Get().Save("common.storage.retryableErrorPatterns", "")
+		defer paramtable.Get().Reset("common.storage.retryableErrorPatterns")
+
+		err := ToMilvusIoError(fileName, fmt.Errorf("some random error"))
 		assert.ErrorIs(t, err, merr.ErrIoFailed)
 	})
 }

--- a/internal/util/importutilv2/common/retryable_reader_test.go
+++ b/internal/util/importutilv2/common/retryable_reader_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"io"
 	"math"
+	"net"
 	"testing"
 
 	"github.com/minio/minio-go/v7"
@@ -91,4 +92,25 @@ func TestRetryableReader_ReadWithNonRetryableError(t *testing.T) {
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, merr.ErrIoFailed)
 	assert.Equal(t, 0, n)
+}
+
+func TestRetryableReader_ReadWithTimeoutError(t *testing.T) {
+	ctx := context.Background()
+	path := "/test/path"
+	expectedData := "data after timeout retry"
+
+	// Simulate a net timeout error that should be retryable
+	timeoutErr := &net.OpError{
+		Op:  "read",
+		Err: &net.DNSError{IsTimeout: true},
+	}
+	mockReader := newErrorMockReader(expectedData, timeoutErr, 3)
+
+	reader := NewRetryableReader(ctx, path, mockReader)
+	buf := make([]byte, len(expectedData))
+	n, err := reader.Read(buf)
+
+	assert.NoError(t, err)
+	assert.Equal(t, len(expectedData), n)
+	assert.Equal(t, expectedData, string(buf))
 }

--- a/pkg/util/merr/errors.go
+++ b/pkg/util/merr/errors.go
@@ -137,6 +137,7 @@ var (
 	ErrIoFailed          = newMilvusError("IO failed", 1001, false)
 	ErrIoUnexpectEOF     = newMilvusError("unexpected EOF", 1002, true)
 	ErrIoTooManyRequests = newMilvusError("too many requests", 1003, true)
+	ErrIoTransient       = newMilvusError("transient IO error", 1004, true)
 
 	// Parameter related
 	ErrParameterInvalid  = newMilvusError("invalid parameter", 1100, false)

--- a/pkg/util/merr/errors_test.go
+++ b/pkg/util/merr/errors_test.go
@@ -134,6 +134,7 @@ func (s *ErrSuite) TestWrap() {
 	s.ErrorIs(WrapErrIoKeyNotFound("test_key", "failed to read"), ErrIoKeyNotFound)
 	s.ErrorIs(WrapErrIoFailed("test_key", os.ErrClosed), ErrIoFailed)
 	s.ErrorIs(WrapErrIoUnexpectEOF("test_key", os.ErrClosed), ErrIoUnexpectEOF)
+	s.ErrorIs(WrapErrIoTransient("test_key", os.ErrClosed), ErrIoTransient)
 
 	// Parameter related
 	s.ErrorIs(WrapErrParameterInvalid(8, 1, "failed to create"), ErrParameterInvalid)

--- a/pkg/util/merr/utils.go
+++ b/pkg/util/merr/utils.go
@@ -947,6 +947,13 @@ func WrapErrIoTooManyRequests(key string, err error) error {
 	return wrapFieldsWithDesc(ErrIoTooManyRequests, err.Error(), value("key", key))
 }
 
+func WrapErrIoTransient(key string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return wrapFieldsWithDesc(ErrIoTransient, err.Error(), value("key", key))
+}
+
 // Parameter related
 func WrapErrParameterInvalid[T any](expected, actual T, msg ...string) error {
 	err := wrapFields(ErrParameterInvalid,

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -295,9 +295,10 @@ type commonConfig struct {
 	Stv2SplitAvgSizeThreshold            ParamItem `refreshable:"true"`
 	UseLoonFFI                           ParamItem `refreshable:"true"`
 
-	StoragePathPrefix        ParamItem `refreshable:"false"`
-	StorageZstdConcurrency   ParamItem `refreshable:"false"`
-	StorageReadRetryAttempts ParamItem `refreshable:"true"`
+	StoragePathPrefix             ParamItem `refreshable:"false"`
+	StorageZstdConcurrency        ParamItem `refreshable:"false"`
+	StorageReadRetryAttempts      ParamItem `refreshable:"true"`
+	StorageRetryableErrorPatterns ParamItem `refreshable:"true"`
 
 	TraceLogMode              ParamItem `refreshable:"true"`
 	BloomFilterSize           ParamItem `refreshable:"true"`
@@ -1061,6 +1062,15 @@ The default value is 1, which is enough for most cases.`,
 		Export:       false,
 	}
 	p.StorageReadRetryAttempts.Init(base.mgr)
+
+	p.StorageRetryableErrorPatterns = ParamItem{
+		Key:          "common.storage.retryableErrorPatterns",
+		Version:      "2.6.12",
+		DefaultValue: "",
+		Doc:          "Comma-separated list of error message substrings that should trigger retry for object storage operations. This is useful for custom S3-compatible backends that return non-standard error messages on transient failures.",
+		Export:       true,
+	}
+	p.StorageRetryableErrorPatterns.Init(base.mgr)
 
 	p.TraceLogMode = ParamItem{
 		Key:          "common.traceLogMode",


### PR DESCRIPTION
## Summary

- Add `ErrIoTimeout` error code (retryable, code 1004) and detect Go-level transient network errors (`net.Error.Timeout()`, `ECONNREFUSED`, `os.ErrDeadlineExceeded`) in `checkObjectStorageError()`
- Add configurable retryable error patterns via `common.storage.retryableErrorPatterns` for custom S3-compatible backends that return non-standard error messages
- Existing retry loops (`RemoteChunkManager` and `RetryableReader`) automatically benefit via `merr.IsRetryableErr()`

issue: #47934

## Test plan

- [x] `ErrIoTimeout` error code is retryable (`merr.IsRetryableErr` returns true)
- [x] `net.Error` with `Timeout()` → classified as `ErrIoTimeout`
- [x] `syscall.ECONNREFUSED` → classified as `ErrIoTimeout`
- [x] `os.ErrDeadlineExceeded` → classified as `ErrIoTimeout`
- [x] Config pattern match triggers retry
- [x] Config pattern no-match falls through to `ErrIoFailed`
- [x] Empty config has no effect
- [x] `RetryableReader` retries on timeout errors and succeeds after transient failures
- [x] All existing error classification tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)