### PR TITLE
feat: Add Yandex Cloud (YC) text embedding support

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -1456,6 +1456,10 @@ function:
         credential:  # The name in the crendential configuration item
         enable: true # Whether to enable voyageai model service
         url:  # Your voyageai embedding url, Default is the official embedding url
+      yc:
+        credential:  # The name in the credential configuration item
+        enable: true # Whether to enable Yandex Cloud model service
+        url:  # Your Yandex Cloud text embedding url, Default is the official text embedding url
   rerank:
     model:
       providers:

--- a/internal/util/function/embedding/mock_embedding_service.go
+++ b/internal/util/function/embedding/mock_embedding_service.go
@@ -238,6 +238,40 @@ func CreateTEIEmbeddingServer(dim int) *httptest.Server {
 	return ts
 }
 
+func CreateYCEmbeddingServer() *httptest.Server {
+	reqCount := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req YCEmbeddingRequest
+		body, _ := io.ReadAll(r.Body)
+		defer r.Body.Close()
+		_ = json.Unmarshal(body, &req)
+
+		if req.Text != "" {
+			req.Texts = []string{req.Text}
+		}
+		embs := mockEmbedding[float32](req.Texts, 4)
+		for i := range embs {
+			for j := range embs[i] {
+				embs[i][j] += float32(reqCount)
+			}
+			reqCount++
+		}
+
+		res := YCEmbeddingResponse{
+			Embeddings: embs,
+		}
+		if len(embs) == 1 {
+			res.Embedding = embs[0]
+			res.Embeddings = nil
+		}
+
+		w.WriteHeader(http.StatusOK)
+		data, _ := json.Marshal(res)
+		w.Write(data)
+	}))
+	return ts
+}
+
 type MockBedrockClient struct {
 	dim int
 }

--- a/internal/util/function/embedding/mock_embedding_service.go
+++ b/internal/util/function/embedding/mock_embedding_service.go
@@ -239,7 +239,6 @@ func CreateTEIEmbeddingServer(dim int) *httptest.Server {
 }
 
 func CreateYCEmbeddingServer() *httptest.Server {
-	reqCount := 0
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req YCEmbeddingRequest
 		body, _ := io.ReadAll(r.Body)
@@ -250,12 +249,6 @@ func CreateYCEmbeddingServer() *httptest.Server {
 			req.Texts = []string{req.Text}
 		}
 		embs := mockEmbedding[float32](req.Texts, 4)
-		for i := range embs {
-			for j := range embs[i] {
-				embs[i][j] += float32(reqCount)
-			}
-			reqCount++
-		}
 
 		res := YCEmbeddingResponse{
 			Embeddings: embs,

--- a/internal/util/function/embedding/text_embedding_function.go
+++ b/internal/util/function/embedding/text_embedding_function.go
@@ -48,6 +48,7 @@ const (
 	cohereProvider       string = "cohere"
 	siliconflowProvider  string = "siliconflow"
 	teiProvider          string = "tei"
+	ycProvider           string = "yc"
 	zillizProvider       string = "zilliz"
 )
 
@@ -136,11 +137,13 @@ func NewTextEmbeddingFunction(coll *schemapb.CollectionSchema, functionSchema *s
 		embP, newProviderErr = NewSiliconflowEmbeddingProvider(base.outputFields[0], functionSchema, conf, credentials, extraInfo)
 	case teiProvider:
 		embP, newProviderErr = NewTEIEmbeddingProvider(base.outputFields[0], functionSchema, conf, credentials, extraInfo)
+	case ycProvider:
+		embP, newProviderErr = NewYCEmbeddingProvider(base.outputFields[0], functionSchema, conf, credentials, extraInfo)
 	case zillizProvider:
 		conf := paramtable.Get().FunctionCfg.ZillizProviders.GetValue()
 		embP, newProviderErr = NewZillizEmbeddingProvider(base.outputFields[0], functionSchema, conf, extraInfo)
 	default:
-		return nil, fmt.Errorf("Unsupported text embedding service provider: [%s] , list of supported [%s, %s, %s, %s, %s, %s, %s, %s, %s, %s]", base.provider, openAIProvider, azureOpenAIProvider, aliDashScopeProvider, bedrockProvider, vertexAIProvider, voyageAIProvider, cohereProvider, siliconflowProvider, teiProvider, zillizProvider)
+		return nil, fmt.Errorf("Unsupported text embedding service provider: [%s] , list of supported [%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s]", base.provider, openAIProvider, azureOpenAIProvider, aliDashScopeProvider, bedrockProvider, vertexAIProvider, voyageAIProvider, cohereProvider, siliconflowProvider, teiProvider, ycProvider, zillizProvider)
 	}
 
 	if newProviderErr != nil {

--- a/internal/util/function/embedding/text_embedding_function_test.go
+++ b/internal/util/function/embedding/text_embedding_function_test.go
@@ -114,6 +114,24 @@ func (s *TextEmbeddingFunctionSuite) TestInvalidProvider() {
 	s.Error(err)
 }
 
+func (s *TextEmbeddingFunctionSuite) TestUnsupportedProvider() {
+	_, err := NewTextEmbeddingFunction(s.schema, &schemapb.FunctionSchema{
+		Name:             "test",
+		Type:             schemapb.FunctionType_TextEmbedding,
+		InputFieldNames:  []string{"text"},
+		OutputFieldNames: []string{"vector"},
+		InputFieldIds:    []int64{101},
+		OutputFieldIds:   []int64{102},
+		Params: []*commonpb.KeyValuePair{
+			{Key: Provider, Value: "unknown"},
+			{Key: models.ModelNameParamKey, Value: "test-model"},
+			{Key: models.DimParamKey, Value: "4"},
+			{Key: models.CredentialParamKey, Value: "mock"},
+		},
+	}, &models.ModelExtraInfo{ClusterID: "test-cluster", DBName: "test-db"})
+	s.ErrorContains(err, "Unsupported text embedding service provider")
+}
+
 func (s *TextEmbeddingFunctionSuite) TestProcessInsert() {
 	ts := CreateOpenAIEmbeddingServer()
 	defer ts.Close()

--- a/internal/util/function/embedding/text_embedding_function_test.go
+++ b/internal/util/function/embedding/text_embedding_function_test.go
@@ -1024,6 +1024,62 @@ func (s *TextEmbeddingFunctionSuite) TestDisable() {
 	s.ErrorContains(err, "Text embedding model provider [openai] is disabled")
 }
 
+func (s *TextEmbeddingFunctionSuite) TestYCEmbedding() {
+	ts := CreateYCEmbeddingServer()
+	defer ts.Close()
+
+	paramtable.Get().FunctionCfg.TextEmbeddingProviders.GetFunc = func() map[string]string {
+		key := ycProvider + "." + models.URLParamKey
+		return map[string]string{
+			key: ts.URL,
+		}
+	}
+
+	runner, err := NewTextEmbeddingFunction(s.schema, &schemapb.FunctionSchema{
+		Name:             "test",
+		Type:             schemapb.FunctionType_TextEmbedding,
+		InputFieldNames:  []string{"text"},
+		OutputFieldNames: []string{"vector"},
+		InputFieldIds:    []int64{101},
+		OutputFieldIds:   []int64{102},
+		Params: []*commonpb.KeyValuePair{
+			{Key: Provider, Value: ycProvider},
+			{Key: models.ModelNameParamKey, Value: "emb://test/model"},
+			{Key: models.DimParamKey, Value: "4"},
+			{Key: models.CredentialParamKey, Value: "mock"},
+		},
+	}, &models.ModelExtraInfo{ClusterID: "test-cluster", DBName: "test-db"})
+	s.NoError(err)
+
+	ret, err := runner.ProcessInsert(context.Background(), createData([]string{"sentence", "sentence 2"}))
+	s.NoError(err)
+	s.Equal([]float32{0.0, 1.0, 2.0, 3.0, 1.0, 2.0, 3.0, 4.0}, ret[0].GetVectors().GetFloatVector().GetData())
+}
+
+func (s *TextEmbeddingFunctionSuite) TestDisableYC() {
+	paramtable.Get().FunctionCfg.TextEmbeddingProviders.GetFunc = func() map[string]string {
+		key := ycProvider + "." + models.EnableConf
+		return map[string]string{
+			key: "false",
+		}
+	}
+	_, err := NewTextEmbeddingFunction(s.schema, &schemapb.FunctionSchema{
+		Name:             "test",
+		Type:             schemapb.FunctionType_TextEmbedding,
+		InputFieldNames:  []string{"text"},
+		OutputFieldNames: []string{"vector"},
+		InputFieldIds:    []int64{101},
+		OutputFieldIds:   []int64{102},
+		Params: []*commonpb.KeyValuePair{
+			{Key: Provider, Value: ycProvider},
+			{Key: models.ModelNameParamKey, Value: "emb://test/model"},
+			{Key: models.DimParamKey, Value: "4"},
+			{Key: models.CredentialParamKey, Value: "mock"},
+		},
+	}, &models.ModelExtraInfo{ClusterID: "test-cluster", DBName: "test-db"})
+	s.ErrorContains(err, "Text embedding model provider [yc] is disabled")
+}
+
 func (s *TextEmbeddingFunctionSuite) TestCheck() {
 	schema := &schemapb.CollectionSchema{
 		Name: "test",

--- a/internal/util/function/embedding/yc_embedding_provider.go
+++ b/internal/util/function/embedding/yc_embedding_provider.go
@@ -1,0 +1,166 @@
+/*
+ * # Licensed to the LF AI & Data foundation under one
+ * # or more contributor license agreements. See the NOTICE file
+ * # distributed with this work for additional information
+ * # regarding copyright ownership. The ASF licenses this file
+ * # to you under the Apache License, Version 2.0 (the
+ * # "License"); you may not use this file except in compliance
+ * # with the License. You may obtain a copy of the License at
+ * #
+ * #     http://www.apache.org/licenses/LICENSE-2.0
+ * #
+ * # Unless required by applicable law or agreed to in writing, software
+ * # distributed under the License is distributed on an "AS IS" BASIS,
+ * # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * # See the License for the specific language governing permissions and
+ * # limitations under the License.
+ */
+
+package embedding
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/util/credentials"
+	"github.com/milvus-io/milvus/internal/util/function/models"
+	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
+)
+
+const (
+	defaultYCTextEmbeddingURL = "https://llm.api.cloud.yandex.net/foundationModels/v1/textEmbedding"
+)
+
+type YCEmbeddingRequest struct {
+	ModelURI string   `json:"modelUri"`
+	Text     string   `json:"text,omitempty"`
+	Texts    []string `json:"texts,omitempty"`
+}
+
+type YCEmbeddingResponse struct {
+	Embedding  []float32   `json:"embedding"`
+	Embeddings [][]float32 `json:"embeddings"`
+}
+
+type YCEmbeddingProvider struct {
+	fieldDim int64
+
+	url       string
+	apiKey    string
+	modelName string
+
+	maxBatch   int
+	timeoutSec int64
+	extraInfo  *models.ModelExtraInfo
+}
+
+func NewYCEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSchema *schemapb.FunctionSchema, params map[string]string, credentials *credentials.Credentials, extraInfo *models.ModelExtraInfo) (*YCEmbeddingProvider, error) {
+	fieldDim, err := typeutil.GetDim(fieldSchema)
+	if err != nil {
+		return nil, err
+	}
+
+	var modelName string
+	for _, param := range functionSchema.Params {
+		switch strings.ToLower(param.Key) {
+		case models.ModelNameParamKey:
+			modelName = param.Value
+		case models.DimParamKey:
+			if _, err = models.ParseAndCheckFieldDim(param.Value, fieldDim, fieldSchema.Name); err != nil {
+				return nil, err
+			}
+		default:
+		}
+	}
+	if modelName == "" {
+		return nil, fmt.Errorf("yc embedding model name is required")
+	}
+
+	apiKey, url, err := models.ParseAKAndURL(credentials, functionSchema.Params, params, models.YandexCloudAKEnvStr, extraInfo)
+	if err != nil {
+		return nil, err
+	}
+	if apiKey == "" {
+		return nil, fmt.Errorf("Missing credentials config or configure the %s environment variable in the Milvus service.", models.YandexCloudAKEnvStr)
+	}
+	if url == "" {
+		url = defaultYCTextEmbeddingURL
+	}
+
+	provider := YCEmbeddingProvider{
+		fieldDim:   fieldDim,
+		url:        url,
+		apiKey:     apiKey,
+		modelName:  modelName,
+		maxBatch:   128,
+		timeoutSec: 30,
+		extraInfo:  extraInfo,
+	}
+	return &provider, nil
+}
+
+func (provider *YCEmbeddingProvider) MaxBatch() int {
+	return provider.extraInfo.BatchFactor * provider.maxBatch
+}
+
+func (provider *YCEmbeddingProvider) FieldDim() int64 {
+	return provider.fieldDim
+}
+
+func (provider *YCEmbeddingProvider) headers() map[string]string {
+	return map[string]string{
+		"Content-Type":  "application/json",
+		"Authorization": fmt.Sprintf("Api-Key %s", provider.apiKey),
+	}
+}
+
+func (provider *YCEmbeddingProvider) CallEmbedding(ctx context.Context, texts []string, _ models.TextEmbeddingMode) (any, error) {
+	_ = ctx
+	numRows := len(texts)
+	data := make([][]float32, 0, numRows)
+	for i := 0; i < numRows; i += provider.maxBatch {
+		end := i + provider.maxBatch
+		if end > numRows {
+			end = numRows
+		}
+
+		req := YCEmbeddingRequest{
+			ModelURI: provider.modelName,
+			Texts:    texts[i:end],
+		}
+		if end-i == 1 {
+			req.Text = texts[i]
+			req.Texts = nil
+		}
+
+		resp, err := models.PostRequest[YCEmbeddingResponse](req, provider.url, provider.headers(), provider.timeoutSec)
+		if err != nil {
+			return nil, err
+		}
+
+		embeddings := extractYCEmbeddings(resp)
+		if end-i != len(embeddings) {
+			return nil, fmt.Errorf("Get embedding failed. The number of texts and embeddings does not match text:[%d], embedding:[%d]", end-i, len(embeddings))
+		}
+		for _, emb := range embeddings {
+			if len(emb) != int(provider.fieldDim) {
+				return nil, fmt.Errorf("The required embedding dim is [%d], but the embedding obtained from the model is [%d]",
+					provider.fieldDim, len(emb))
+			}
+			data = append(data, emb)
+		}
+	}
+	return data, nil
+}
+
+func extractYCEmbeddings(resp *YCEmbeddingResponse) [][]float32 {
+	if len(resp.Embeddings) > 0 {
+		return resp.Embeddings
+	}
+	if len(resp.Embedding) > 0 {
+		return [][]float32{resp.Embedding}
+	}
+	return nil
+}

--- a/internal/util/function/embedding/yc_embedding_provider_test.go
+++ b/internal/util/function/embedding/yc_embedding_provider_test.go
@@ -1,0 +1,174 @@
+/*
+ * # Licensed to the LF AI & Data foundation under one
+ * # or more contributor license agreements. See the NOTICE file
+ * # distributed with this work for additional information
+ * # regarding copyright ownership. The ASF licenses this file
+ * # to you under the Apache License, Version 2.0 (the
+ * # "License"); you may not use this file except in compliance
+ * # with the License. You may obtain a copy of the License at
+ * #
+ * #     http://www.apache.org/licenses/LICENSE-2.0
+ * #
+ * # Unless required by applicable law or agreed to in writing, software
+ * # distributed under the License is distributed on an "AS IS" BASIS,
+ * # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * # See the License for the specific language governing permissions and
+ * # limitations under the License.
+ */
+
+package embedding
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/util/credentials"
+	"github.com/milvus-io/milvus/internal/util/function/models"
+)
+
+func TestYCEmbeddingProvider(t *testing.T) {
+	suite.Run(t, new(YCEmbeddingProviderSuite))
+}
+
+type YCEmbeddingProviderSuite struct {
+	suite.Suite
+	schema *schemapb.CollectionSchema
+}
+
+func (s *YCEmbeddingProviderSuite) SetupTest() {
+	s.schema = &schemapb.CollectionSchema{
+		Name: "test",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "int64", DataType: schemapb.DataType_Int64},
+			{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar},
+			{
+				FieldID: 102, Name: "vector", DataType: schemapb.DataType_FloatVector,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: "dim", Value: "4"},
+				},
+			},
+		},
+	}
+}
+
+func createYCProvider(url string, schema *schemapb.FieldSchema) (textEmbeddingProvider, error) {
+	functionSchema := &schemapb.FunctionSchema{
+		Name:             "test",
+		Type:             schemapb.FunctionType_Unknown,
+		InputFieldNames:  []string{"text"},
+		OutputFieldNames: []string{"vector"},
+		InputFieldIds:    []int64{101},
+		OutputFieldIds:   []int64{102},
+		Params: []*commonpb.KeyValuePair{
+			{Key: models.ModelNameParamKey, Value: "emb://test/model"},
+			{Key: models.CredentialParamKey, Value: "mock"},
+			{Key: models.DimParamKey, Value: "4"},
+		},
+	}
+	return NewYCEmbeddingProvider(schema, functionSchema, map[string]string{models.URLParamKey: url}, credentials.NewCredentials(map[string]string{"mock.apikey": "mock"}), &models.ModelExtraInfo{})
+}
+
+func (s *YCEmbeddingProviderSuite) TestEmbedding() {
+	ts := CreateYCEmbeddingServer()
+	defer ts.Close()
+
+	provider, err := createYCProvider(ts.URL, s.schema.Fields[2])
+	s.NoError(err)
+
+	data, err := provider.CallEmbedding(context.Background(), []string{"sentence"}, models.InsertMode)
+	s.NoError(err)
+	s.Equal([][]float32{{0.0, 1.0, 2.0, 3.0}}, data)
+}
+
+func (s *YCEmbeddingProviderSuite) TestBatchEmbedding() {
+	ts := CreateYCEmbeddingServer()
+	defer ts.Close()
+
+	provider, err := createYCProvider(ts.URL, s.schema.Fields[2])
+	s.NoError(err)
+
+	data, err := provider.CallEmbedding(context.Background(), []string{"sentence 1", "sentence 2", "sentence 3"}, models.SearchMode)
+	s.NoError(err)
+	s.Equal([][]float32{{0.0, 1.0, 2.0, 3.0}, {1.0, 2.0, 3.0, 4.0}, {2.0, 3.0, 4.0, 5.0}}, data)
+}
+
+func (s *YCEmbeddingProviderSuite) TestEmbeddingNumberNotMatch() {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		res := YCEmbeddingResponse{
+			Embeddings: [][]float32{{1.0, 1.0, 1.0, 1.0}},
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(res)
+	}))
+	defer ts.Close()
+
+	provider, err := createYCProvider(ts.URL, s.schema.Fields[2])
+	s.NoError(err)
+	_, err = provider.CallEmbedding(context.Background(), []string{"sentence", "sentence 2"}, models.InsertMode)
+	s.Error(err)
+}
+
+func (s *YCEmbeddingProviderSuite) TestEmbeddingDimNotMatch() {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		res := YCEmbeddingResponse{
+			Embeddings: [][]float32{{1.0, 1.0}},
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(res)
+	}))
+	defer ts.Close()
+
+	provider, err := createYCProvider(ts.URL, s.schema.Fields[2])
+	s.NoError(err)
+	_, err = provider.CallEmbedding(context.Background(), []string{"sentence"}, models.InsertMode)
+	s.Error(err)
+}
+
+func (s *YCEmbeddingProviderSuite) TestMissingCredential() {
+	functionSchema := &schemapb.FunctionSchema{
+		Name:             "test",
+		Type:             schemapb.FunctionType_Unknown,
+		InputFieldNames:  []string{"text"},
+		OutputFieldNames: []string{"vector"},
+		InputFieldIds:    []int64{101},
+		OutputFieldIds:   []int64{102},
+		Params: []*commonpb.KeyValuePair{
+			{Key: models.ModelNameParamKey, Value: "emb://test/model"},
+		},
+	}
+	_, err := NewYCEmbeddingProvider(s.schema.Fields[2], functionSchema, map[string]string{}, credentials.NewCredentials(map[string]string{}), &models.ModelExtraInfo{})
+	s.ErrorContains(err, models.YandexCloudAKEnvStr)
+}
+
+func (s *YCEmbeddingProviderSuite) TestCustomAndDefaultURL() {
+	ts := CreateYCEmbeddingServer()
+	defer ts.Close()
+
+	provider, err := createYCProvider(ts.URL, s.schema.Fields[2])
+	s.NoError(err)
+	s.Equal(ts.URL, provider.(*YCEmbeddingProvider).url)
+
+	functionSchema := &schemapb.FunctionSchema{
+		Name:             "test",
+		Type:             schemapb.FunctionType_Unknown,
+		InputFieldNames:  []string{"text"},
+		OutputFieldNames: []string{"vector"},
+		InputFieldIds:    []int64{101},
+		OutputFieldIds:   []int64{102},
+		Params: []*commonpb.KeyValuePair{
+			{Key: models.ModelNameParamKey, Value: "emb://test/model"},
+			{Key: models.CredentialParamKey, Value: "mock"},
+			{Key: models.DimParamKey, Value: "4"},
+		},
+	}
+	p, err := NewYCEmbeddingProvider(s.schema.Fields[2], functionSchema, map[string]string{}, credentials.NewCredentials(map[string]string{"mock.apikey": "mock"}), &models.ModelExtraInfo{})
+	s.NoError(err)
+	s.Equal(defaultYCTextEmbeddingURL, p.url)
+}

--- a/internal/util/function/embedding/yc_embedding_provider_test.go
+++ b/internal/util/function/embedding/yc_embedding_provider_test.go
@@ -25,6 +25,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
@@ -171,4 +172,73 @@ func (s *YCEmbeddingProviderSuite) TestCustomAndDefaultURL() {
 	p, err := NewYCEmbeddingProvider(s.schema.Fields[2], functionSchema, map[string]string{}, credentials.NewCredentials(map[string]string{"mock.apikey": "mock"}), &models.ModelExtraInfo{})
 	s.NoError(err)
 	s.Equal(defaultYCTextEmbeddingURL, p.url)
+}
+
+func (s *YCEmbeddingProviderSuite) TestMissingModelName() {
+	functionSchema := &schemapb.FunctionSchema{
+		Name:             "test",
+		Type:             schemapb.FunctionType_Unknown,
+		InputFieldNames:  []string{"text"},
+		OutputFieldNames: []string{"vector"},
+		InputFieldIds:    []int64{101},
+		OutputFieldIds:   []int64{102},
+		Params: []*commonpb.KeyValuePair{
+			{Key: models.CredentialParamKey, Value: "mock"},
+		},
+	}
+	_, err := NewYCEmbeddingProvider(s.schema.Fields[2], functionSchema, map[string]string{}, credentials.NewCredentials(map[string]string{"mock.apikey": "mock"}), &models.ModelExtraInfo{})
+	s.ErrorContains(err, "yc embedding model name is required")
+}
+
+func (s *YCEmbeddingProviderSuite) TestInvalidDimParam() {
+	functionSchema := &schemapb.FunctionSchema{
+		Name:             "test",
+		Type:             schemapb.FunctionType_Unknown,
+		InputFieldNames:  []string{"text"},
+		OutputFieldNames: []string{"vector"},
+		InputFieldIds:    []int64{101},
+		OutputFieldIds:   []int64{102},
+		Params: []*commonpb.KeyValuePair{
+			{Key: models.ModelNameParamKey, Value: "emb://test/model"},
+			{Key: models.DimParamKey, Value: "invalid"},
+			{Key: models.CredentialParamKey, Value: "mock"},
+		},
+	}
+	_, err := NewYCEmbeddingProvider(s.schema.Fields[2], functionSchema, map[string]string{}, credentials.NewCredentials(map[string]string{"mock.apikey": "mock"}), &models.ModelExtraInfo{})
+	s.ErrorContains(err, "is not a valid int")
+}
+
+func (s *YCEmbeddingProviderSuite) TestParseCredentialError() {
+	functionSchema := &schemapb.FunctionSchema{
+		Name:             "test",
+		Type:             schemapb.FunctionType_Unknown,
+		InputFieldNames:  []string{"text"},
+		OutputFieldNames: []string{"vector"},
+		InputFieldIds:    []int64{101},
+		OutputFieldIds:   []int64{102},
+		Params: []*commonpb.KeyValuePair{
+			{Key: models.ModelNameParamKey, Value: "emb://test/model"},
+			{Key: models.CredentialParamKey, Value: "mock"},
+		},
+	}
+	_, err := NewYCEmbeddingProvider(s.schema.Fields[2], functionSchema, map[string]string{}, credentials.NewCredentials(map[string]string{"mock.token": "not-apikey"}), &models.ModelExtraInfo{})
+	s.Error(err)
+}
+
+func (s *YCEmbeddingProviderSuite) TestEmptyEmbeddingResponse() {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(YCEmbeddingResponse{})
+	}))
+	defer ts.Close()
+
+	provider, err := createYCProvider(ts.URL, s.schema.Fields[2])
+	s.NoError(err)
+	_, err = provider.CallEmbedding(context.Background(), []string{"sentence"}, models.InsertMode)
+	s.ErrorContains(err, "number of texts and embeddings does not match")
+}
+
+func TestExtractYCEmbeddings(t *testing.T) {
+	resp := &YCEmbeddingResponse{}
+	assert.Equal(t, [][]float32(nil), extractYCEmbeddings(resp))
 }

--- a/internal/util/function/embedding/yc_embedding_provider_test.go
+++ b/internal/util/function/embedding/yc_embedding_provider_test.go
@@ -238,7 +238,74 @@ func (s *YCEmbeddingProviderSuite) TestEmptyEmbeddingResponse() {
 	s.ErrorContains(err, "number of texts and embeddings does not match")
 }
 
+func (s *YCEmbeddingProviderSuite) TestYCProviderBasicGetters() {
+	ts := CreateYCEmbeddingServer()
+	defer ts.Close()
+
+	functionSchema := &schemapb.FunctionSchema{
+		Name:             "test",
+		Type:             schemapb.FunctionType_Unknown,
+		InputFieldNames:  []string{"text"},
+		OutputFieldNames: []string{"vector"},
+		InputFieldIds:    []int64{101},
+		OutputFieldIds:   []int64{102},
+		Params: []*commonpb.KeyValuePair{
+			{Key: models.ModelNameParamKey, Value: "emb://test/model"},
+			{Key: models.CredentialParamKey, Value: "mock"},
+			{Key: models.DimParamKey, Value: "4"},
+		},
+	}
+	provider, err := NewYCEmbeddingProvider(
+		s.schema.Fields[2],
+		functionSchema,
+		map[string]string{models.URLParamKey: ts.URL},
+		credentials.NewCredentials(map[string]string{"mock.apikey": "mock"}),
+		&models.ModelExtraInfo{BatchFactor: 3},
+	)
+	s.NoError(err)
+	s.Equal(int64(4), provider.FieldDim())
+	s.Equal(384, provider.MaxBatch())
+	s.Equal("Api-Key mock", provider.headers()["Authorization"])
+}
+
+func (s *YCEmbeddingProviderSuite) TestBatchEmbeddingAcrossMultipleRequests() {
+	ts := CreateYCEmbeddingServer()
+	defer ts.Close()
+
+	provider, err := createYCProvider(ts.URL, s.schema.Fields[2])
+	s.NoError(err)
+
+	ycProvider := provider.(*YCEmbeddingProvider)
+	ycProvider.maxBatch = 2
+	ret, err := ycProvider.CallEmbedding(context.Background(), []string{"1", "2", "3", "4", "5"}, models.InsertMode)
+	s.NoError(err)
+	embeddings, ok := ret.([][]float32)
+	s.True(ok)
+	s.Len(embeddings, 5)
+	for _, emb := range embeddings {
+		s.Len(emb, 4)
+	}
+}
+
+func (s *YCEmbeddingProviderSuite) TestCallEmbeddingHTTPError() {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("internal error"))
+	}))
+	defer ts.Close()
+
+	provider, err := createYCProvider(ts.URL, s.schema.Fields[2])
+	s.NoError(err)
+	_, err = provider.CallEmbedding(context.Background(), []string{"sentence"}, models.InsertMode)
+	s.Error(err)
+}
+
 func TestExtractYCEmbeddings(t *testing.T) {
 	resp := &YCEmbeddingResponse{}
 	assert.Equal(t, [][]float32(nil), extractYCEmbeddings(resp))
+}
+
+func TestExtractYCEmbeddingsSingleEmbedding(t *testing.T) {
+	resp := &YCEmbeddingResponse{Embedding: []float32{1, 2, 3, 4}}
+	assert.Equal(t, [][]float32{{1, 2, 3, 4}}, extractYCEmbeddings(resp))
 }

--- a/internal/util/function/models/common.go
+++ b/internal/util/function/models/common.go
@@ -124,6 +124,12 @@ const (
 	SiliconflowAKEnvStr string = "MILVUS_SILICONFLOW_API_KEY"
 )
 
+// Yandex Cloud
+
+const (
+	YandexCloudAKEnvStr string = "MILVUS_YC_API_KEY"
+)
+
 // TEI and vllm
 
 const (

--- a/pkg/util/paramtable/function_param.go
+++ b/pkg/util/paramtable/function_param.go
@@ -96,6 +96,12 @@ func (p *functionConfig) init(base *BaseTable) {
 				return "The name in the crendential configuration item"
 			case "vertexai.enable":
 				return "Whether to enable vertexai model service"
+			case "yc.credential":
+				return "The name in the credential configuration item"
+			case "yc.url":
+				return "Your Yandex Cloud text embedding url, Default is the official text embedding url"
+			case "yc.enable":
+				return "Whether to enable Yandex Cloud model service"
 			default:
 				return ""
 			}

--- a/pkg/util/paramtable/function_param_test.go
+++ b/pkg/util/paramtable/function_param_test.go
@@ -59,6 +59,9 @@ func TestFunctionConfig(t *testing.T) {
 		"vertexai.url",
 		"vertexai.credential",
 		"vertexai.enable",
+		"yc.credential",
+		"yc.url",
+		"yc.enable",
 	}
 	for _, key := range keys {
 		assert.True(t, cfg.TextEmbeddingProviders.GetDoc(key) != "")


### PR DESCRIPTION
issue: #47938

- Updated milvus.yaml to include configuration for Yandex Cloud model service.
- Implemented CreateYCEmbeddingServer function to mock Yandex Cloud embedding service.
- Added support for YC provider in text embedding function logic.
- Enhanced error handling for unsupported providers.
- Added unit tests for Yandex Cloud embedding functionality and its disabled state.

Design documents location: https://github.com/milvus-io/milvus-design-docs/blob/main/design_docs/20260227-yc-text-embedding-provider.md
