### PR TITLE
fix: resolve macOS AWS SDK transitive include path for brew upgrades

### DIFF
--- a/internal/core/thirdparty/milvus-storage/CMakeLists.txt
+++ b/internal/core/thirdparty/milvus-storage/CMakeLists.txt
@@ -66,23 +66,25 @@ if ( NOT milvus-storage_POPULATED )
                 "(searched ${_HOMEBREW_PREFIX}/lib/cmake/AWSSDK). "
                 "Install with: brew install aws-sdk-cpp")
         endif()
-        find_package(AWSSDK REQUIRED COMPONENTS identity-management s3)
+        find_package(AWSSDK REQUIRED COMPONENTS core s3 identity-management)
 
         if(NOT TARGET AWS::aws-sdk-cpp-identity-management)
             add_library(AWS::aws-sdk-cpp-identity-management INTERFACE IMPORTED)
             set_target_properties(AWS::aws-sdk-cpp-identity-management PROPERTIES
                 INTERFACE_LINK_LIBRARIES "${AWSSDK_LINK_LIBRARIES}")
-            # Ensure transitive headers (e.g. sts → pagination) resolve
-            # correctly even when Conan's -isystem paths take precedence.
-            # Prefer AWSSDK_INCLUDE_DIR (set by the SDK's cmake config) for
-            # a narrow scope; fall back to the full Homebrew prefix.
-            if(AWSSDK_INCLUDE_DIR)
-                target_include_directories(AWS::aws-sdk-cpp-identity-management SYSTEM INTERFACE
-                    "${AWSSDK_INCLUDE_DIR}")
-            else()
-                target_include_directories(AWS::aws-sdk-cpp-identity-management SYSTEM INTERFACE
-                    "${_HOMEBREW_PREFIX}/include")
+            # AWSSDK_INCLUDE_DIR is set by find_package(AWSSDK REQUIRED ...).
+            # We add it as SYSTEM INTERFACE so transitive AWS headers
+            # (e.g. sts → pagination) resolve correctly even when Conan's
+            # -isystem paths take precedence. This exposes Homebrew's full
+            # include tree, but Conan's -I flags take priority over -isystem
+            # so there is no practical ABI conflict risk with Boost etc.
+            if(NOT AWSSDK_INCLUDE_DIR)
+                message(FATAL_ERROR
+                    "AWSSDK_INCLUDE_DIR not set after find_package(AWSSDK). "
+                    "Check Homebrew aws-sdk-cpp installation.")
             endif()
+            target_include_directories(AWS::aws-sdk-cpp-identity-management SYSTEM INTERFACE
+                "${AWSSDK_INCLUDE_DIR}")
         endif()
 
         # Ignore Homebrew paths so milvus-storage's find_package(Boost) uses

--- a/internal/core/thirdparty/milvus-storage/CMakeLists.txt
+++ b/internal/core/thirdparty/milvus-storage/CMakeLists.txt
@@ -66,13 +66,18 @@ if ( NOT milvus-storage_POPULATED )
                 "(searched ${_HOMEBREW_PREFIX}/lib/cmake/AWSSDK). "
                 "Install with: brew install aws-sdk-cpp")
         endif()
-        find_package(AWSSDK REQUIRED COMPONENTS core s3 identity-management)
+        find_package(AWSSDK REQUIRED COMPONENTS identity-management s3)
 
         if(NOT TARGET AWS::aws-sdk-cpp-identity-management)
             add_library(AWS::aws-sdk-cpp-identity-management INTERFACE IMPORTED)
             set_target_properties(AWS::aws-sdk-cpp-identity-management PROPERTIES
                 INTERFACE_LINK_LIBRARIES "${AWSSDK_LINK_LIBRARIES}")
         endif()
+        # Ensure Homebrew's full include tree is visible so transitive
+        # headers (e.g. sts → pagination) resolve correctly even when
+        # Conan's -isystem paths take precedence.
+        target_include_directories(AWS::aws-sdk-cpp-identity-management SYSTEM INTERFACE
+            "${_HOMEBREW_PREFIX}/include")
 
         # Ignore Homebrew paths so milvus-storage's find_package(Boost) uses
         # Conan's Boost 1.83, not Homebrew's Boost 1.90+ (ABI incompatible).

--- a/internal/core/thirdparty/milvus-storage/CMakeLists.txt
+++ b/internal/core/thirdparty/milvus-storage/CMakeLists.txt
@@ -72,12 +72,18 @@ if ( NOT milvus-storage_POPULATED )
             add_library(AWS::aws-sdk-cpp-identity-management INTERFACE IMPORTED)
             set_target_properties(AWS::aws-sdk-cpp-identity-management PROPERTIES
                 INTERFACE_LINK_LIBRARIES "${AWSSDK_LINK_LIBRARIES}")
+            # Ensure transitive headers (e.g. sts → pagination) resolve
+            # correctly even when Conan's -isystem paths take precedence.
+            # Prefer AWSSDK_INCLUDE_DIR (set by the SDK's cmake config) for
+            # a narrow scope; fall back to the full Homebrew prefix.
+            if(AWSSDK_INCLUDE_DIR)
+                target_include_directories(AWS::aws-sdk-cpp-identity-management SYSTEM INTERFACE
+                    "${AWSSDK_INCLUDE_DIR}")
+            else()
+                target_include_directories(AWS::aws-sdk-cpp-identity-management SYSTEM INTERFACE
+                    "${_HOMEBREW_PREFIX}/include")
+            endif()
         endif()
-        # Ensure Homebrew's full include tree is visible so transitive
-        # headers (e.g. sts → pagination) resolve correctly even when
-        # Conan's -isystem paths take precedence.
-        target_include_directories(AWS::aws-sdk-cpp-identity-management SYSTEM INTERFACE
-            "${_HOMEBREW_PREFIX}/include")
 
         # Ignore Homebrew paths so milvus-storage's find_package(Boost) uses
         # Conan's Boost 1.83, not Homebrew's Boost 1.90+ (ABI incompatible).


### PR DESCRIPTION
## Summary
- After a recent Homebrew `aws-sdk-cpp` update, the STS module now references `aws/core/utils/pagination/Paginator.h` which wasn't being resolved
- Let AWSSDK cmake config auto-resolve transitive dependencies instead of manually listing `core`
- Add Homebrew's include directory to the IMPORTED target so transitive headers always resolve correctly

issue: https://github.com/milvus-io/milvus/issues/47460

## Test plan
- [ ] CI `Code Checker MacOS` passes (currently broken on all open PRs since ~PR #47900)

🤖 Generated with [Claude Code](https://claude.com/claude-code)