### PR TITLE
enhance: [ExtTable] add external field mapping support to FieldMeta for lazy load

### DIFF
--- a/internal/core/src/common/FieldMeta.cpp
+++ b/internal/core/src/common/FieldMeta.cpp
@@ -140,7 +140,7 @@ FieldMeta::ParseFrom(const milvus::proto::schema::FieldSchema& schema_proto) {
     auto field_id = FieldId(schema_proto.fieldid());
     auto name = FieldName(schema_proto.name());
     auto nullable = schema_proto.nullable();
-    if (field_id.get() < 100) {
+    if (field_id.get() < START_USER_FIELDID) {
         // system field id
         auto is_system =
             SystemProperty::Instance().SystemFieldVerify(name, field_id);
@@ -151,6 +151,7 @@ FieldMeta::ParseFrom(const milvus::proto::schema::FieldSchema& schema_proto) {
 
     auto data_type = DataType(schema_proto.data_type());
     auto element_type = DataType(schema_proto.element_type());
+    auto external_field_mapping = schema_proto.external_field();
 
     if (data_type == DataType::VECTOR_ARRAY) {
         AssertInfo(element_type != DataType::NONE,
@@ -171,8 +172,13 @@ FieldMeta::ParseFrom(const milvus::proto::schema::FieldSchema& schema_proto) {
         AssertInfo(type_map.count("dim"), "dim not found");
         dim = boost::lexical_cast<int64_t>(type_map.at("dim"));
 
-        return FieldMeta{
-            name, field_id, data_type, element_type, dim, std::nullopt};
+        return FieldMeta{name,
+                         field_id,
+                         data_type,
+                         element_type,
+                         dim,
+                         std::nullopt,
+                         external_field_mapping};
     }
 
     if (IsVectorDataType(data_type)) {
@@ -194,7 +200,8 @@ FieldMeta::ParseFrom(const milvus::proto::schema::FieldSchema& schema_proto) {
                              dim,
                              std::nullopt,
                              nullable,
-                             default_value};
+                             default_value,
+                             external_field_mapping};
         }
         auto metric_type = index_map.at("metric_type");
         return FieldMeta{name,
@@ -203,7 +210,8 @@ FieldMeta::ParseFrom(const milvus::proto::schema::FieldSchema& schema_proto) {
                          dim,
                          metric_type,
                          nullable,
-                         default_value};
+                         default_value,
+                         external_field_mapping};
     }
 
     if (IsStringDataType(data_type)) {
@@ -237,7 +245,8 @@ FieldMeta::ParseFrom(const milvus::proto::schema::FieldSchema& schema_proto) {
                          enable_match,
                          enable_analyzer,
                          type_map,
-                         default_value};
+                         default_value,
+                         external_field_mapping};
     }
 
     if (IsArrayDataType(data_type)) {
@@ -246,10 +255,16 @@ FieldMeta::ParseFrom(const milvus::proto::schema::FieldSchema& schema_proto) {
                          data_type,
                          DataType(schema_proto.element_type()),
                          nullable,
-                         default_value};
+                         default_value,
+                         external_field_mapping};
     }
 
-    return FieldMeta{name, field_id, data_type, nullable, default_value};
+    return FieldMeta{name,
+                     field_id,
+                     data_type,
+                     nullable,
+                     default_value,
+                     external_field_mapping};
 }
 
 }  // namespace milvus

--- a/internal/core/src/common/FieldMeta.h
+++ b/internal/core/src/common/FieldMeta.h
@@ -50,12 +50,14 @@ class FieldMeta {
               FieldId id,
               DataType type,
               bool nullable,
-              std::optional<DefaultValueType> default_value)
+              std::optional<DefaultValueType> default_value,
+              std::string external_field_mapping = "")
         : name_(std::move(name)),
           id_(id),
           type_(type),
           nullable_(nullable),
-          default_value_(std::move(default_value)) {
+          default_value_(std::move(default_value)),
+          external_field_mapping_(std::move(external_field_mapping)) {
         Assert(!IsVectorDataType(type_));
     }
 
@@ -64,13 +66,15 @@ class FieldMeta {
               DataType type,
               int64_t max_length,
               bool nullable,
-              std::optional<DefaultValueType> default_value)
+              std::optional<DefaultValueType> default_value,
+              std::string external_field_mapping = "")
         : name_(std::move(name)),
           id_(id),
           type_(type),
           nullable_(nullable),
           string_info_(StringInfo{max_length}),
-          default_value_(std::move(default_value)) {
+          default_value_(std::move(default_value)),
+          external_field_mapping_(std::move(external_field_mapping)) {
         Assert(IsStringDataType(type_));
     }
 
@@ -82,7 +86,8 @@ class FieldMeta {
               bool enable_match,
               bool enable_analyzer,
               std::map<std::string, std::string>& params,
-              std::optional<DefaultValueType> default_value)
+              std::optional<DefaultValueType> default_value,
+              std::string external_field_mapping = "")
         : name_(std::move(name)),
           id_(id),
           type_(type),
@@ -93,7 +98,8 @@ class FieldMeta {
               enable_analyzer,
               std::move(params),
           }),
-          default_value_(std::move(default_value)) {
+          default_value_(std::move(default_value)),
+          external_field_mapping_(std::move(external_field_mapping)) {
         Assert(IsStringDataType(type_));
     }
 
@@ -102,13 +108,15 @@ class FieldMeta {
               DataType type,
               DataType element_type,
               bool nullable,
-              std::optional<DefaultValueType> default_value)
+              std::optional<DefaultValueType> default_value,
+              std::string external_field_mapping = "")
         : name_(std::move(name)),
           id_(id),
           type_(type),
           element_type_(element_type),
           nullable_(nullable),
-          default_value_(std::move(default_value)) {
+          default_value_(std::move(default_value)),
+          external_field_mapping_(std::move(external_field_mapping)) {
         Assert(IsArrayDataType(type_));
     }
 
@@ -120,13 +128,15 @@ class FieldMeta {
               int64_t dim,
               std::optional<knowhere::MetricType> metric_type,
               bool nullable,
-              std::optional<DefaultValueType> default_value)
+              std::optional<DefaultValueType> default_value,
+              std::string external_field_mapping = "")
         : name_(std::move(name)),
           id_(id),
           type_(type),
           nullable_(nullable),
           vector_info_(VectorInfo{dim, std::move(metric_type)}),
-          default_value_(std::move(default_value)) {
+          default_value_(std::move(default_value)),
+          external_field_mapping_(std::move(external_field_mapping)) {
         Assert(IsVectorDataType(type_));
         Assert(!default_value_.has_value() &&
                "vector fields do not support default values");
@@ -138,13 +148,15 @@ class FieldMeta {
               DataType type,
               DataType element_type,
               int64_t dim,
-              std::optional<knowhere::MetricType> metric_type)
+              std::optional<knowhere::MetricType> metric_type,
+              std::string external_field_mapping = "")
         : name_(std::move(name)),
           id_(id),
           type_(type),
           nullable_(false),
           element_type_(element_type),
-          vector_info_(VectorInfo{dim, std::move(metric_type)}) {
+          vector_info_(VectorInfo{dim, std::move(metric_type)}),
+          external_field_mapping_(std::move(external_field_mapping)) {
         Assert(type_ == DataType::VECTOR_ARRAY);
         Assert(IsVectorDataType(element_type_));
     }
@@ -156,13 +168,15 @@ class FieldMeta {
               int64_t main_field_id,
               DataType type,
               bool nullable,
-              std::optional<DefaultValueType> default_value)
+              std::optional<DefaultValueType> default_value,
+              std::string external_field_mapping = "")
         : name_(std::move(name)),
           id_(id),
           main_field_id_(main_field_id),
           type_(type),
           nullable_(nullable),
-          default_value_(std::move(default_value)) {
+          default_value_(std::move(default_value)),
+          external_field_mapping_(std::move(external_field_mapping)) {
         Assert(!IsVectorDataType(type_));
     }
 
@@ -247,6 +261,16 @@ class FieldMeta {
     }
 
     bool
+    NeedLoad() const {
+        return external_field_mapping_.empty();
+    }
+
+    const std::string&
+    get_external_field_mapping() const {
+        return external_field_mapping_;
+    }
+
+    bool
     has_default_value() const {
         return default_value_.has_value();
     }
@@ -308,6 +332,7 @@ class FieldMeta {
     // for json stats, the main field id is the real field id
     // of collection schema, the field id is the json shredding field id
     int64_t main_field_id_ = INVALID_FIELD_ID;
+    std::string external_field_mapping_;
 };
 
 }  // namespace milvus

--- a/internal/core/src/common/FieldMetaTest.cpp
+++ b/internal/core/src/common/FieldMetaTest.cpp
@@ -1,0 +1,138 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+
+#include "common/FieldMeta.h"
+#include "common/Schema.h"
+#include "common/Types.h"
+#include "gtest/gtest.h"
+#include "pb/schema.pb.h"
+
+namespace milvus {
+
+TEST(FieldMetaTest, NeedLoadReturnsTrueForNormalField) {
+    auto field = FieldMeta(FieldName("normal_field"),
+                           FieldId(100),
+                           DataType::INT64,
+                           false,
+                           std::nullopt);
+    EXPECT_TRUE(field.NeedLoad());
+    EXPECT_TRUE(field.get_external_field_mapping().empty());
+}
+
+TEST(FieldMetaTest, NeedLoadReturnsFalseForExternalField) {
+    auto field = FieldMeta(FieldName("external_field"),
+                           FieldId(101),
+                           DataType::INT64,
+                           false,
+                           std::nullopt,
+                           "s3://bucket/path/field.parquet");
+    EXPECT_FALSE(field.NeedLoad());
+    EXPECT_EQ(field.get_external_field_mapping(),
+              "s3://bucket/path/field.parquet");
+}
+
+TEST(FieldMetaTest, NeedLoadReturnsFalseForExternalVectorField) {
+    auto field = FieldMeta(FieldName("external_vec"),
+                           FieldId(102),
+                           DataType::VECTOR_FLOAT,
+                           128,
+                           std::nullopt,
+                           false,
+                           std::nullopt,
+                           "s3://bucket/path/vec.parquet");
+    EXPECT_FALSE(field.NeedLoad());
+}
+
+TEST(FieldMetaTest, ParseFromWithExternalField) {
+    milvus::proto::schema::FieldSchema proto;
+    proto.set_fieldid(200);
+    proto.set_name("ext_scalar");
+    proto.set_data_type(milvus::proto::schema::DataType::Int64);
+    proto.set_nullable(false);
+    proto.set_external_field("s3://bucket/ext_scalar.parquet");
+
+    auto field = FieldMeta::ParseFrom(proto);
+    EXPECT_FALSE(field.NeedLoad());
+    EXPECT_EQ(field.get_external_field_mapping(),
+              "s3://bucket/ext_scalar.parquet");
+}
+
+TEST(FieldMetaTest, ParseFromWithoutExternalField) {
+    milvus::proto::schema::FieldSchema proto;
+    proto.set_fieldid(201);
+    proto.set_name("normal_scalar");
+    proto.set_data_type(milvus::proto::schema::DataType::Int64);
+    proto.set_nullable(false);
+
+    auto field = FieldMeta::ParseFrom(proto);
+    EXPECT_TRUE(field.NeedLoad());
+    EXPECT_TRUE(field.get_external_field_mapping().empty());
+}
+
+TEST(FieldMetaTest, ShouldLoadFieldReturnsFalseForExternalField) {
+    auto schema = std::make_shared<Schema>();
+
+    // Add a normal field
+    auto normal_field = FieldMeta(FieldName("normal"),
+                                  FieldId(100),
+                                  DataType::INT64,
+                                  false,
+                                  std::nullopt);
+    schema->AddField(std::move(normal_field));
+
+    // Add an external field
+    auto external_field = FieldMeta(FieldName("external"),
+                                    FieldId(101),
+                                    DataType::INT64,
+                                    false,
+                                    std::nullopt,
+                                    "s3://bucket/external.parquet");
+    schema->AddField(std::move(external_field));
+
+    // load_fields_ is empty, so normally all fields should load
+    // But external field should NOT load
+    EXPECT_TRUE(schema->ShouldLoadField(FieldId(100)));
+    EXPECT_FALSE(schema->ShouldLoadField(FieldId(101)));
+}
+
+TEST(FieldMetaTest, ShouldLoadFieldExternalFieldIgnoredByLoadFields) {
+    auto schema = std::make_shared<Schema>();
+
+    auto normal_field = FieldMeta(FieldName("normal"),
+                                  FieldId(100),
+                                  DataType::INT64,
+                                  false,
+                                  std::nullopt);
+    schema->AddField(std::move(normal_field));
+
+    auto external_field = FieldMeta(FieldName("external"),
+                                    FieldId(101),
+                                    DataType::INT64,
+                                    false,
+                                    std::nullopt,
+                                    "s3://bucket/external.parquet");
+    schema->AddField(std::move(external_field));
+
+    // Even if load_fields explicitly includes the external field, it should
+    // still return false
+    schema->UpdateLoadFields({100, 101});
+    EXPECT_TRUE(schema->ShouldLoadField(FieldId(100)));
+    EXPECT_FALSE(schema->ShouldLoadField(FieldId(101)));
+}
+
+}  // namespace milvus

--- a/internal/core/src/common/Schema.h
+++ b/internal/core/src/common/Schema.h
@@ -387,6 +387,10 @@ class Schema {
 
     bool
     ShouldLoadField(FieldId field_id) {
+        auto it = fields_.find(field_id);
+        if (it != fields_.end() && !it->second.NeedLoad()) {
+            return false;
+        }
         return load_fields_.empty() || load_fields_.count(field_id) > 0;
     }
 


### PR DESCRIPTION
Related to #45881

Add external_field_mapping to FieldMeta to support fields stored in external storage (e.g., S3). Fields with non-empty external mapping are excluded from segment loading via ShouldLoadField(), enabling lazy load of external table fields.