### PR TITLE
test: add entity TTL E2E test cases

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_highlighter.py
+++ b/tests/python_client/milvus_client/test_milvus_client_highlighter.py
@@ -251,9 +251,6 @@ class TestMilvusClientHighlighter(TestMilvusClientV2Base):
         for result in results[0]:
             assert result['highlight'][default_text_field_name]['fragments'] in expected
 
-        # test with multi analyzer
-        # BUG: #46498
-        '''
         results = client.search(
             collection_name, 
             ["water"],
@@ -265,7 +262,6 @@ class TestMilvusClientHighlighter(TestMilvusClientV2Base):
         assert results[0] != []
         for result in results[0]:
             assert result['highlight'][default_text_field_name_multi_analyzer]['fragments'] in expected
-            '''
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_milvus_client_highlighter_multiple_tags(self):

--- a/tests/python_client/milvus_client_v2/test_milvus_client_ttl.py
+++ b/tests/python_client/milvus_client_v2/test_milvus_client_ttl.py
@@ -16,6 +16,7 @@ default_primary_key_field_name = ct.default_primary_key_field_name
 default_vector_field_name = ct.default_vector_field_name
 default_int32_field_name = ct.default_int32_field_name
 default_search_exp = "id >= 0"
+ENTITY_TTL_QUERY_COLLECTION = "test_entity_ttl_query" + cf.gen_unique_str("_")
 
 class TestMilvusClientTTL(TestMilvusClientV2Base):
     """ Test case of Time To Live """
@@ -50,7 +51,7 @@ class TestMilvusClientTTL(TestMilvusClientV2Base):
         nb = 1000
         collection_name = cf.gen_collection_name_by_testcase_name()
         schema = self.create_schema(client, enable_dynamic_field=False)[0]
-        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field("id", DataType.INT64, is_primary=True, auto_id=False)
         schema.add_field("embeddings", DataType.FLOAT_VECTOR, dim=dim)
         schema.add_field("embeddings_2", DataType.FLOAT_VECTOR, dim=dim)
         schema.add_field("visible", DataType.BOOL, nullable=True)
@@ -70,13 +71,13 @@ class TestMilvusClientTTL(TestMilvusClientV2Base):
         # insert data
         insert_times = 2
         for i in range(insert_times):
-            vectors = cf.gen_vectors(nb, dim=default_dim)
+            vectors = cf.gen_vectors(nb, dim=dim)
             vectors_2 = cf.gen_vectors(nb, dim=dim)
             rows = []
             start_id = i * nb
             for j in range(nb):
                 row = {
-                    default_primary_key_field_name: start_id + j,
+                    "id": start_id + j,
                     "embeddings": list(vectors[j]),
                     "embeddings_2": list(vectors_2[j]),
                     "visible": False
@@ -139,13 +140,13 @@ class TestMilvusClientTTL(TestMilvusClientV2Base):
 
         # insert more data
         for i in range(insert_times):
-            vectors = cf.gen_vectors(nb, dim=default_dim)
+            vectors = cf.gen_vectors(nb, dim=dim)
             vectors_2 = cf.gen_vectors(nb, dim=dim)
             rows = []
             start_id = (insert_times + i) * nb
             for j in range(nb):
                 row = {
-                    default_primary_key_field_name: start_id + j,
+                    "id": start_id + j,
                     "embeddings": list(vectors[j]),
                     "embeddings_2": list(vectors_2[j]),
                     "visible": True
@@ -226,7 +227,6 @@ class TestMilvusClientTTL(TestMilvusClientV2Base):
                 assert res[0].get('count(*)', 0) == insert_times * nb * 2
 
     @pytest.mark.tags(CaseLabel.L2)
-    @pytest.mark.skip("not stable")
     def test_milvus_client_ttl_edge(self):
         """
         Test case for verifying edge case of TTL (Time To Live) functionality in Milvus client.
@@ -250,29 +250,13 @@ class TestMilvusClientTTL(TestMilvusClientV2Base):
         collection_name = cf.gen_collection_name_by_testcase_name()
         schema = self.create_schema(client, enable_dynamic_field=False)[0]
         schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
-        schema.add_field("embeddings", DataType.FLOAT_VECTOR, dim=dim)
-        
+        schema.add_field("embeddings", DataType.FLOAT_VECTOR, dim=dim)       
         # Attempt to create collection with extremely large TTL, expecting it to fail
         # Use force_teardown=False since collection creation should fail
+        error = {ct.err_code: 1100, ct.err_msg: f"collection TTL is out of range, expect [-1, 3155760000], got {ttl}: invalid parameter"}
         self.create_collection(client, collection_name, schema=schema, 
-                               properties={"collection.ttl.seconds": ttl})
-        index_params = self.prepare_index_params(client)[0]
-        index_params.add_index(field_name="embeddings", index_type="IVF_FLAT", metric_type="COSINE", nlist=128)
-        self.create_index(client, collection_name, index_params=index_params)
-
-        # insert data
-        vectors = cf.gen_vectors(1000, dim=dim)
-        rows = []
-        for i in range(1000):
-            row = {default_primary_key_field_name: i, "embeddings": list(vectors[i])}
-            rows.append(row)
-        self.insert(client, collection_name, rows)
-        self.flush(client, collection_name)
-        self.load_collection(client, collection_name)
-
-        self.describe_collection(client, collection_name)
-
-        self.query(client, collection_name, output_fields=["count(*)"])
+                               properties={"collection.ttl.seconds": ttl},
+                               check_task=CheckTasks.err_res, check_items=error)
     
     @pytest.mark.tags(CaseLabel.L0)
     @pytest.mark.parametrize("partial_update", [False, True])
@@ -565,8 +549,6 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
 
 
     @pytest.mark.tags(CaseLabel.L0)
-    @pytest.mark.skip("BUG #47413")
-    # BUG #47413
     def test_insert_with_future_entity_ttl(self):
         """
         target: test inserting data with future ttl timestamp
@@ -705,8 +687,6 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
         self.drop_collection(client, collection_name)
 
     @pytest.mark.tags(CaseLabel.L0)
-    @pytest.mark.skip("BUG #47413")
-    # BUG #47413
     def test_insert_mixed_entity_ttl_values(self):
         """
         target: test inserting data with mixed ttl values (future, past, NULL)
@@ -774,8 +754,6 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
 
 
     @pytest.mark.tags(CaseLabel.L0)
-    @pytest.mark.skip("BUG #47413")
-    # BUG #47413
     def test_upsert_partial_update_without_entity_ttl(self):
         """
         target: test partial update without ttl field preserves original ttl
@@ -840,6 +818,11 @@ class TestMilvusClientEntityTTLQuery(TestMilvusClientV2Base):
     """
     Entity TTL Query Tests - Using shared collection to reduce time cost
     """
+    collection_name = ENTITY_TTL_QUERY_COLLECTION
+    nb = 500
+    dim = default_dim
+    ttl_seconds = 10
+    vectors = None
     _ttl_expired = False
 
     @pytest.fixture(scope="class", autouse=True)
@@ -848,9 +831,12 @@ class TestMilvusClientEntityTTLQuery(TestMilvusClientV2Base):
         Prepare shared collection with entity ttl data for query tests
         """
         client = self._client()
-        collection_name = cf.gen_collection_name_by_testcase_name()
-        nb = 500
-        ttl_seconds = 10
+        collection_name = self.collection_name
+        nb = self.nb
+        ttl_seconds = self.ttl_seconds
+
+        if client.has_collection(collection_name):
+            client.drop_collection(collection_name)
 
         # Create schema
         schema = self.create_schema(client, enable_dynamic_field=False)[0]
@@ -859,9 +845,9 @@ class TestMilvusClientEntityTTLQuery(TestMilvusClientV2Base):
         schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
         schema.add_field("varchar_field", DataType.VARCHAR, max_length=100, nullable=True)
 
-        # Create collection with ttl_field
+        # Create collection with ttl_field (force_teardown=False to keep shared collection across tests)
         properties = {"ttl_field": "ttl", "timezone": "UTC"}
-        self.create_collection(client, collection_name, schema=schema, properties=properties)
+        self.create_collection(client, collection_name, schema=schema, properties=properties, force_teardown=False)
 
         # Create index and load
         index_params = self.prepare_index_params(client)[0]
@@ -892,18 +878,17 @@ class TestMilvusClientEntityTTLQuery(TestMilvusClientV2Base):
         self.insert(client, collection_name, rows)
         self.flush(client, collection_name)
 
-        # Store for test methods
-        self.collection_name = collection_name
-        self.nb = nb
-        self.dim = default_dim
-        self.ttl_seconds = ttl_seconds
-        self.vectors = vectors
+        # Store generated vectors on class (other attributes are already class-level)
+        TestMilvusClientEntityTTLQuery.vectors = vectors
         TestMilvusClientEntityTTLQuery._ttl_expired = False
 
-        yield
-
-        # Cleanup
-        self.drop_collection(client, collection_name)
+        def teardown():
+            try:
+                if self.has_collection(self._client(), collection_name):
+                    self.drop_collection(self._client(), collection_name)
+            except Exception:
+                pass
+        request.addfinalizer(teardown)
 
     def _wait_for_ttl_expire(self):
         if TestMilvusClientEntityTTLQuery._ttl_expired:
@@ -957,9 +942,9 @@ class TestMilvusClientEntityTTLQuery(TestMilvusClientV2Base):
     @pytest.mark.tags(CaseLabel.L0)
     def test_search_filter_expired_entity_data(self):
         """
-        target: test search automatically filters expired data
+        target: test search filters expired data when filter expression is present
         method:
-            1. Perform vector search
+            1. Perform vector search with a filter expression
             2. Verify search results only contain non-expired data
         expected: Search results do not include expired data
         """
@@ -967,10 +952,11 @@ class TestMilvusClientEntityTTLQuery(TestMilvusClientV2Base):
 
         self._wait_for_ttl_expire()
 
-        # Search
+        # Search with filter - TTL filtering is applied when a filter expression is present
         search_vectors = cf.gen_vectors(1, dim=self.dim)
         res = self.search(client, self.collection_name, search_vectors, anns_field='vector',
-                         search_params={}, limit=10, consistency_level=CONSISTENCY_STRONG)[0]
+                         search_params={}, limit=10, filter="id >= 0",
+                         consistency_level=CONSISTENCY_STRONG)[0]
 
         # Should get results from NULL data only
         assert len(res[0]) > 0

--- a/tests/python_client/milvus_client_v2/test_milvus_client_ttl.py
+++ b/tests/python_client/milvus_client_v2/test_milvus_client_ttl.py
@@ -536,7 +536,7 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
 
         # Wait for TTL to expire
         log.info("Waiting 10 seconds for data to expire...")
-        time.sleep(10)
+        time.sleep(13)
 
         # Verify data expires based on original UTC timestamp
         res = self.query(client, collection_name, filter="", output_fields=["count(*)"])[0]
@@ -812,6 +812,352 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
         assert res[0].get('count(*)') == 0
 
         self.drop_collection(client, collection_name)
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_upsert_extend_entity_ttl(self):
+        """
+        target: test upsert with new future TTL extends entity lifetime
+        method:
+            1. Create collection with ttl_field
+            2. Insert data with ttl = now() + 8 seconds
+            3. After 4 seconds, upsert same IDs with ttl = now() + 12 seconds
+            4. Wait past original TTL
+            5. Verify data is still visible (TTL was extended)
+            6. Wait past new TTL and verify data expires
+        expected: Upsert with new TTL extends the expiration deadline
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        nb = 50
+        original_ttl_seconds = 8
+
+        # Create schema
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field("ttl", DataType.TIMESTAMPTZ, nullable=True)
+        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
+        index_params = self.prepare_index_params(client)[0]
+        index_params.add_index(field_name=default_vector_field_name, index_type="IVF_FLAT", metric_type="L2", nlist=128)
+
+        # Create collection with ttl_field
+        properties = {"ttl_field": "ttl", "timezone": "UTC"}
+        self.create_collection(client, collection_name, schema=schema,
+                               properties=properties, consistency_level="Strong", index_params=index_params)
+
+        # Insert data with original TTL (8s)
+        original_ttl = (datetime.now(timezone.utc) + timedelta(seconds=original_ttl_seconds)).isoformat()
+        vectors = cf.gen_vectors(nb, dim=default_dim)
+        rows = [{default_primary_key_field_name: i, "ttl": original_ttl,
+                 default_vector_field_name: list(vectors[i])} for i in range(nb)]
+        self.insert(client, collection_name, rows)
+        self.flush(client, collection_name)
+
+        # Wait 4 seconds, then upsert with extended TTL (12s from now)
+        time.sleep(4)
+        extended_ttl = (datetime.now(timezone.utc) + timedelta(seconds=12)).isoformat()
+        upsert_rows = [{default_primary_key_field_name: i, "ttl": extended_ttl,
+                        default_vector_field_name: list(vectors[i])} for i in range(nb)]
+        self.upsert(client, collection_name, upsert_rows)
+
+        # Wait past original TTL (4 more seconds) — data should still be alive
+        time.sleep(6)
+        res = self.query(client, collection_name, filter="", output_fields=["count(*)"],
+                         consistency_level=CONSISTENCY_STRONG)[0]
+        log.info(f"Count after original TTL expired: {res[0].get('count(*)')}")
+        assert res[0].get('count(*)') == nb
+
+        # Wait past extended TTL
+        time.sleep(8)
+        res = self.query(client, collection_name, filter="", output_fields=["count(*)"],
+                         consistency_level=CONSISTENCY_STRONG)[0]
+        assert res[0].get('count(*)') == 0
+
+        self.drop_collection(client, collection_name)
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_upsert_shorten_entity_ttl(self):
+        """
+        target: test upsert with shorter TTL makes entity expire sooner
+        method:
+            1. Create collection with ttl_field
+            2. Insert data with ttl = now() + 60 seconds (long TTL)
+            3. Upsert same IDs with ttl = now() + 8 seconds (short TTL)
+            4. Wait for short TTL to expire
+            5. Verify data expires at the shorter deadline
+        expected: Upsert with shorter TTL overrides the original deadline
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        nb = 50
+        short_ttl_seconds = 8
+
+        # Create schema
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field("ttl", DataType.TIMESTAMPTZ, nullable=True)
+        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
+        index_params = self.prepare_index_params(client)[0]
+        index_params.add_index(field_name=default_vector_field_name, index_type="IVF_FLAT", metric_type="L2", nlist=128)
+
+        # Create collection with ttl_field
+        properties = {"ttl_field": "ttl", "timezone": "UTC"}
+        self.create_collection(client, collection_name, schema=schema,
+                               properties=properties, consistency_level="Strong", index_params=index_params)
+
+        # Insert data with long TTL (60s)
+        long_ttl = (datetime.now(timezone.utc) + timedelta(seconds=60)).isoformat()
+        vectors = cf.gen_vectors(nb, dim=default_dim)
+        rows = [{default_primary_key_field_name: i, "ttl": long_ttl,
+                 default_vector_field_name: list(vectors[i])} for i in range(nb)]
+        self.insert(client, collection_name, rows)
+        self.flush(client, collection_name)
+
+        # Verify data is visible
+        res = self.query(client, collection_name, filter="", output_fields=["count(*)"],
+                         consistency_level=CONSISTENCY_STRONG)[0]
+        assert res[0].get('count(*)') == nb
+
+        # Upsert with short TTL (8s from now)
+        short_ttl = (datetime.now(timezone.utc) + timedelta(seconds=short_ttl_seconds)).isoformat()
+        upsert_rows = [{default_primary_key_field_name: i, "ttl": short_ttl,
+                        default_vector_field_name: list(vectors[i])} for i in range(nb)]
+        self.upsert(client, collection_name, upsert_rows)
+
+        # Wait for short TTL to expire
+        log.info(f"Waiting {short_ttl_seconds + 3} seconds for shortened TTL to expire...")
+        time.sleep(short_ttl_seconds + 3)
+
+        # Verify data expired at the shorter deadline
+        res = self.query(client, collection_name, filter="", output_fields=["count(*)"],
+                         consistency_level=CONSISTENCY_STRONG)[0]
+        assert res[0].get('count(*)') == 0
+
+        self.drop_collection(client, collection_name)
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_entity_ttl_after_release_reload(self):
+        """
+        target: test entity TTL still works after release and reload
+        method:
+            1. Create collection with ttl_field
+            2. Insert data with ttl = now() + 10 seconds
+            3. Release and reload collection
+            4. Verify data is still visible
+            5. Wait for TTL to expire
+            6. Verify data is invisible after TTL expires
+        expected: TTL filtering persists across release/reload cycles
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        nb = 100
+        ttl_seconds = 10
+
+        # Create schema
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field("ttl", DataType.TIMESTAMPTZ, nullable=True)
+        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
+        index_params = self.prepare_index_params(client)[0]
+        index_params.add_index(field_name=default_vector_field_name, index_type="IVF_FLAT", metric_type="L2", nlist=128)
+
+        # Create collection with ttl_field
+        properties = {"ttl_field": "ttl", "timezone": "UTC"}
+        self.create_collection(client, collection_name, schema=schema,
+                               properties=properties, consistency_level="Strong", index_params=index_params)
+
+        # Insert data with future ttl
+        ttl_timestamp = (datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds)).isoformat()
+        vectors = cf.gen_vectors(nb, dim=default_dim)
+        rows = [{default_primary_key_field_name: i, "ttl": ttl_timestamp,
+                 default_vector_field_name: list(vectors[i])} for i in range(nb)]
+        self.insert(client, collection_name, rows)
+        self.flush(client, collection_name)
+
+        # Verify data is visible before release
+        res = self.query(client, collection_name, filter="", output_fields=["count(*)"],
+                         consistency_level=CONSISTENCY_STRONG)[0]
+        assert res[0].get('count(*)') == nb
+
+        # Release and reload
+        self.release_collection(client, collection_name)
+        self.load_collection(client, collection_name)
+
+        # Verify data is still visible after reload
+        res = self.query(client, collection_name, filter="", output_fields=["count(*)"],
+                         consistency_level=CONSISTENCY_STRONG)[0]
+        assert res[0].get('count(*)') == nb
+
+        # Wait for TTL to expire
+        log.info(f"Waiting {ttl_seconds + 3} seconds for data to expire after reload...")
+        time.sleep(ttl_seconds + 3)
+
+        # Verify data is invisible after TTL expires
+        res = self.query(client, collection_name, filter="", output_fields=["count(*)"],
+                         consistency_level=CONSISTENCY_STRONG)[0]
+        assert res[0].get('count(*)') == 0
+
+        self.drop_collection(client, collection_name)
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_delete_before_entity_ttl_expires(self):
+        """
+        target: test explicit delete removes entities immediately, not waiting for TTL
+        method:
+            1. Create collection with ttl_field
+            2. Insert data with ttl = now() + 60 seconds (long TTL)
+            3. Delete half of the entities explicitly
+            4. Verify deleted entities are gone immediately
+            5. Verify remaining entities are still visible
+        expected: Explicit delete takes effect immediately regardless of TTL
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        nb = 100
+        ttl_seconds = 60
+
+        # Create schema
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field("ttl", DataType.TIMESTAMPTZ, nullable=True)
+        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
+        index_params = self.prepare_index_params(client)[0]
+        index_params.add_index(field_name=default_vector_field_name, index_type="IVF_FLAT", metric_type="L2", nlist=128)
+
+        # Create collection with ttl_field
+        properties = {"ttl_field": "ttl", "timezone": "UTC"}
+        self.create_collection(client, collection_name, schema=schema,
+                               properties=properties, consistency_level="Strong", index_params=index_params)
+
+        # Insert data with long TTL
+        ttl_timestamp = (datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds)).isoformat()
+        vectors = cf.gen_vectors(nb, dim=default_dim)
+        rows = [{default_primary_key_field_name: i, "ttl": ttl_timestamp,
+                 default_vector_field_name: list(vectors[i])} for i in range(nb)]
+        self.insert(client, collection_name, rows)
+        self.flush(client, collection_name)
+
+        # Verify all data is visible
+        res = self.query(client, collection_name, filter="", output_fields=["count(*)"],
+                         consistency_level=CONSISTENCY_STRONG)[0]
+        assert res[0].get('count(*)') == nb
+
+        # Delete first half of entities
+        delete_ids = list(range(nb // 2))
+        self.delete(client, collection_name, ids=delete_ids)
+
+        # Verify deleted entities are gone immediately
+        res = self.query(client, collection_name, filter="", output_fields=["count(*)"],
+                         consistency_level=CONSISTENCY_STRONG)[0]
+        assert res[0].get('count(*)') == nb // 2
+
+        # Verify remaining entities are the second half
+        res = self.query(client, collection_name, filter=f"id >= {nb // 2}",
+                         output_fields=[default_primary_key_field_name],
+                         consistency_level=CONSISTENCY_STRONG)[0]
+        assert len(res) == nb // 2
+        for row in res:
+            assert row[default_primary_key_field_name] >= nb // 2
+
+        # Verify deleted entities are not returned even by ID filter
+        res = self.query(client, collection_name, filter=f"id < {nb // 2}",
+                         output_fields=["count(*)"],
+                         consistency_level=CONSISTENCY_STRONG)[0]
+        assert res[0].get('count(*)') == 0
+
+        self.drop_collection(client, collection_name)
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_insert_new_data_after_entity_ttl_expiry(self):
+        """
+        target: test inserting new data after previous data expired by entity TTL
+        method:
+            1. Create collection with ttl_field
+            2. Insert first batch with ttl = now() + 8 seconds
+            3. Wait for TTL to expire, verify data is gone
+            4. Insert second batch with new future TTL
+            5. Verify new data is visible and queryable
+        expected: New inserts work normally after previous data expired
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        nb = 100
+        ttl_seconds = 8
+
+        # Create schema
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field("ttl", DataType.TIMESTAMPTZ, nullable=True)
+        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
+        index_params = self.prepare_index_params(client)[0]
+        index_params.add_index(field_name=default_vector_field_name, index_type="IVF_FLAT", metric_type="L2", nlist=128)
+
+        # Create collection with ttl_field
+        properties = {"ttl_field": "ttl", "timezone": "UTC"}
+        self.create_collection(client, collection_name, schema=schema,
+                               properties=properties, consistency_level="Strong", index_params=index_params)
+
+        # Insert first batch with short TTL
+        ttl_str = (datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds)).isoformat()
+        vectors = cf.gen_vectors(nb, dim=default_dim)
+        rows = [{default_primary_key_field_name: i, "ttl": ttl_str,
+                 default_vector_field_name: list(vectors[i])} for i in range(nb)]
+        self.insert(client, collection_name, rows)
+        self.flush(client, collection_name)
+
+        # Verify first batch is visible
+        res = self.query(client, collection_name, filter="", output_fields=["count(*)"],
+                         consistency_level=CONSISTENCY_STRONG)[0]
+        assert res[0].get('count(*)') == nb
+
+        # Wait for TTL to expire
+        log.info(f"Waiting {ttl_seconds + 3} seconds for first batch to expire...")
+        time.sleep(ttl_seconds + 3)
+
+        # Verify first batch is gone
+        res = self.query(client, collection_name, filter="", output_fields=["count(*)"],
+                         consistency_level=CONSISTENCY_STRONG)[0]
+        assert res[0].get('count(*)') == 0
+
+        # Re-insert using the same PKs (0..nb-1) — should succeed since originals are expired
+        reuse_ttl_str = (datetime.now(timezone.utc) + timedelta(seconds=60)).isoformat()
+        reuse_vectors = cf.gen_vectors(nb, dim=default_dim)
+        reuse_rows = [{default_primary_key_field_name: i, "ttl": reuse_ttl_str,
+                       default_vector_field_name: list(reuse_vectors[i])} for i in range(nb)]
+        self.insert(client, collection_name, reuse_rows)
+        self.flush(client, collection_name)
+
+        # Verify reused PKs are visible
+        res = self.query(client, collection_name, filter="", output_fields=["count(*)"],
+                         consistency_level=CONSISTENCY_STRONG)[0]
+        assert res[0].get('count(*)') == nb
+
+        # Verify the reused PK data is queryable by ID
+        res = self.query(client, collection_name, filter="id >= 0 and id < 10",
+                         output_fields=[default_primary_key_field_name, "ttl"],
+                         consistency_level=CONSISTENCY_STRONG)[0]
+        assert len(res) == 10
+
+        # Insert additional batch with new PKs
+        new_ttl_str = (datetime.now(timezone.utc) + timedelta(seconds=60)).isoformat()
+        new_vectors = cf.gen_vectors(nb, dim=default_dim)
+        new_rows = [{default_primary_key_field_name: nb + i, "ttl": new_ttl_str,
+                     default_vector_field_name: list(new_vectors[i])} for i in range(nb)]
+        self.insert(client, collection_name, new_rows)
+        self.flush(client, collection_name)
+
+        # Verify both batches are visible (reused PKs + new PKs)
+        res = self.query(client, collection_name, filter="", output_fields=["count(*)"],
+                         consistency_level=CONSISTENCY_STRONG)[0]
+        assert res[0].get('count(*)') == nb * 2
+
+        # Verify search returns results from both batches
+        search_vectors = cf.gen_vectors(1, dim=default_dim)
+        res = self.search(client, collection_name, search_vectors, anns_field=default_vector_field_name,
+                          search_params={}, limit=10, consistency_level=CONSISTENCY_STRONG)[0]
+        assert len(res[0]) == 10
+
+        self.drop_collection(client, collection_name)
+
 
 @pytest.mark.xdist_group("TestMilvusClientEntityTTLQuery")
 class TestMilvusClientEntityTTLQuery(TestMilvusClientV2Base):

--- a/tests/python_client/milvus_client_v2/test_milvus_client_ttl.py
+++ b/tests/python_client/milvus_client_v2/test_milvus_client_ttl.py
@@ -1459,70 +1459,64 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
         self.drop_collection(client, collection_name)
 
     @pytest.mark.tags(CaseLabel.L1)
-    def test_entity_ttl_with_dynamic_field(self):
+    def test_entity_ttl_switch_ttl_field(self):
         """
-        target: test entity TTL works with enable_dynamic_field=True and dynamic fields
-                are properly cleaned up on expiry
+        target: test switching ttl_field from one TIMESTAMPTZ field to another
         method:
-            1. Create collection with ttl_field and enable_dynamic_field=True
-            2. Insert short TTL data with dynamic fields + NULL TTL data with dynamic fields
-            3. Verify dynamic fields are queryable before expiry
-            4. Wait for short TTL to expire
-            5. Verify expired rows (including their dynamic fields) are gone
-            6. Verify surviving NULL TTL rows still have correct dynamic fields
-        expected: TTL works correctly with dynamic fields; expired entities and their
-                  dynamic field data are fully removed
+            1. Create collection with two TIMESTAMPTZ fields (ttl, ttl_dynamic),
+               set ttl as ttl_field
+            2. Insert data where ttl = far future (won't expire), ttl_dynamic = short TTL
+            3. Verify data does NOT expire based on ttl_dynamic (not the active ttl_field)
+            4. Switch ttl_field to ttl_dynamic via alter_collection_properties
+            5. Verify data now expires based on ttl_dynamic
+        expected: Expiration behavior follows the currently active ttl_field;
+                  switching ttl_field changes which field controls expiry
         """
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
         nb = 50
-        ttl_seconds = 8
+        short_ttl_seconds = 8
 
-        # Create schema with dynamic field enabled
-        schema = self.create_schema(client, enable_dynamic_field=True)[0]
-        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
-        schema.add_field("ttl", DataType.TIMESTAMPTZ, nullable=True)
-        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
-        index_params = self.prepare_index_params(client)[0]
-        index_params.add_index(field_name=default_vector_field_name, index_type="IVF_FLAT", metric_type="L2", nlist=128)
-        properties = {"ttl_field": "ttl", "timezone": "UTC"}
-        self.create_collection(client, collection_name, schema=schema, properties=properties,
-                               consistency_level="Strong", index_params=index_params)
+        # Create schema with two TIMESTAMPTZ fields
+        self._create_ttl_collection(client, collection_name, extra_fields=[
+            {"field_name": "ttl_dynamic", "datatype": DataType.TIMESTAMPTZ, "nullable": True}
+        ])
 
-        # Insert short TTL data (id 0~49) with dynamic fields
-        future_ttl = (datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds)).isoformat()
-        vectors = cf.gen_vectors(nb * 2, dim=default_dim)
-        rows = []
-        for i in range(nb):
-            rows.append({default_primary_key_field_name: i, "ttl": future_ttl,
-                         default_vector_field_name: list(vectors[i]),
-                         "dynamic_str": f"expire_{i}", "dynamic_int": i})
-        # Insert NULL TTL data (id 50~99) with dynamic fields
-        for i in range(nb, nb * 2):
-            rows.append({default_primary_key_field_name: i, "ttl": None,
-                         default_vector_field_name: list(vectors[i]),
-                         "dynamic_str": f"keep_{i}", "dynamic_int": i * 10})
+        # ttl = far future (won't expire under original ttl_field)
+        # ttl_dynamic = short TTL (will expire if switched to)
+        far_future = (datetime.now(timezone.utc) + timedelta(seconds=300)).isoformat()
+        short_ttl = (datetime.now(timezone.utc) + timedelta(seconds=short_ttl_seconds)).isoformat()
+        vectors = cf.gen_vectors(nb, dim=default_dim)
+        rows = [{default_primary_key_field_name: i, "ttl": far_future,
+                 "ttl_dynamic": short_ttl,
+                 default_vector_field_name: list(vectors[i])} for i in range(nb)]
         self.insert(client, collection_name, rows)
         self.flush(client, collection_name)
 
-        # Verify dynamic fields are queryable before expiry
-        res = self.query(client, collection_name, filter="id < 5",
-                         output_fields=[default_primary_key_field_name, "dynamic_str", "dynamic_int"])[0]
-        assert len(res) == 5
-        for row in res:
-            assert row["dynamic_str"].startswith("expire_")
+        # Verify all data is visible (ttl_field=ttl, ttl is far future)
+        res = self.query(client, collection_name, filter="", output_fields=["count(*)"])[0]
+        assert res[0].get('count(*)') == nb
 
-        # Wait for short TTL to expire
-        time.sleep(ttl_seconds)
-        self._wait_until_count(client, collection_name, expected_count=nb)
+        # Wait past short_ttl_seconds — data should still be alive because
+        # the active ttl_field is "ttl" (far future), not "ttl_dynamic"
+        time.sleep(short_ttl_seconds + 3)
+        res = self.query(client, collection_name, filter="", output_fields=["count(*)"])[0]
+        assert res[0].get('count(*)') == nb, \
+            "Data should NOT expire based on inactive ttl_dynamic field"
 
-        # Verify surviving NULL TTL rows still have correct dynamic fields
-        res = self.query(client, collection_name, filter=f"id >= {nb} and id < {nb + 5}",
-                         output_fields=[default_primary_key_field_name, "dynamic_str", "dynamic_int"])[0]
-        assert len(res) == 5
-        for row in res:
-            assert row["dynamic_str"].startswith("keep_")
-            assert row["dynamic_int"] == row[default_primary_key_field_name] * 10
+        # Switch ttl_field to ttl_dynamic
+        self.alter_collection_properties(client, collection_name,
+                                         properties={"ttl_field": "ttl_dynamic"})
+
+        # Verify ttl_field is updated
+        collection_info = self.describe_collection(client, collection_name)[0]
+        assert collection_info['properties'].get("ttl_field") == "ttl_dynamic"
+
+        # Query immediately — ttl_dynamic timestamps are already past,
+        # data should become invisible right after switching
+        res = self.query(client, collection_name, filter="", output_fields=["count(*)"])[0]
+        assert res[0].get('count(*)') == 0, \
+            f"Expected 0 after switching ttl_field to ttl_dynamic (already expired), got {res[0].get('count(*)')}"
 
         self.drop_collection(client, collection_name)
 

--- a/tests/python_client/milvus_client_v2/test_milvus_client_ttl.py
+++ b/tests/python_client/milvus_client_v2/test_milvus_client_ttl.py
@@ -477,16 +477,82 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
         self.drop_collection(client, collection_name)
 
     @pytest.mark.tags(CaseLabel.L1)
+    def test_add_field_then_set_ttl_field(self):
+        """
+        target: test evolving schema by adding TIMESTAMPTZ field then setting ttl_field
+        method:
+            1. Create collection without TIMESTAMPTZ field
+            2. Use add_field to add a TIMESTAMPTZ field
+            3. Use alter_collection_properties to set ttl_field
+            4. Insert data with TTL values and verify TTL behavior works
+        expected: Schema evolution workflow (add_field -> set ttl_field) works correctly
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        nb = 50
+        ttl_seconds = 8
+
+        # Create schema without TIMESTAMPTZ field
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
+        index_params = self.prepare_index_params(client)[0]
+        index_params.add_index(field_name=default_vector_field_name, index_type="IVF_FLAT", metric_type="L2", nlist=128)
+
+        # Create collection without ttl_field
+        self.create_collection(client, collection_name, schema=schema,
+                               consistency_level="Strong", index_params=index_params)
+
+        # Add TIMESTAMPTZ field via schema evolution
+        self.add_collection_field(client, collection_name, field_name="ttl",
+                                  data_type=DataType.TIMESTAMPTZ, nullable=True)
+
+        # Reload collection after schema evolution
+        self.release_collection(client, collection_name)
+        self.load_collection(client, collection_name)
+
+        # Set ttl_field property
+        self.alter_collection_properties(client, collection_name,
+                                         properties={"ttl_field": "ttl", "timezone": "UTC"})
+
+        # Verify ttl_field is set
+        collection_info = self.describe_collection(client, collection_name)[0]
+        assert collection_info['properties'].get("ttl_field") == "ttl"
+
+        # Insert data with future TTL
+        ttl_str = (datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds)).isoformat()
+        vectors = cf.gen_vectors(nb, dim=default_dim)
+        rows = [{default_primary_key_field_name: i, "ttl": ttl_str,
+                 default_vector_field_name: list(vectors[i])} for i in range(nb)]
+        self.insert(client, collection_name, rows)
+        self.flush(client, collection_name)
+
+        # Verify data is visible
+        res = self.query(client, collection_name, filter="", output_fields=["count(*)"])[0]
+        assert res[0].get('count(*)') == nb
+
+        # Wait for TTL to expire
+        log.info(f"Waiting {ttl_seconds + 5} seconds for data to expire...")
+        time.sleep(ttl_seconds + 5)
+
+        # Verify data is expired
+        res = self.query(client, collection_name, filter="", output_fields=["count(*)"])[0]
+        assert res[0].get('count(*)') == 0
+
+        self.drop_collection(client, collection_name)
+
+    @pytest.mark.tags(CaseLabel.L1)
     def test_alter_database_timezone_for_entity_ttl(self):
         """
-        target: test altering database timezone affects entity TTL behavior
+        target: test altering database timezone does not affect entity TTL expiration
         method:
             1. Create database with UTC timezone
             2. Create collection with ttl_field
             3. Insert data with timestamptz value
             4. Alter database timezone to a different timezone (e.g., Asia/Shanghai)
-            5. Verify TTL behavior is affected by timezone change
-        expected: Changing database timezone affects how TTL timestamps are interpreted
+            5. Verify TTL expiration is not affected by timezone change
+        expected: Changing database timezone does not affect expiration of existing data
+                  with absolute timestamps
         """
         client = self._client()
         db_name = cf.gen_unique_str("test_db_ttl")
@@ -535,8 +601,8 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
         assert res[0].get('count(*)') == nb
 
         # Wait for TTL to expire
-        log.info("Waiting 10 seconds for data to expire...")
-        time.sleep(13)
+        log.info("Waiting for data to expire...")
+        time.sleep(15)
 
         # Verify data expires based on original UTC timestamp
         res = self.query(client, collection_name, filter="", output_fields=["count(*)"])[0]
@@ -591,8 +657,8 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
         assert res[0].get('count(*)') == nb
 
         # Wait for TTL to expire
-        log.info(f"Waiting {ttl_seconds + 3} seconds for data to expire...")
-        time.sleep(ttl_seconds + 3)
+        log.info(f"Waiting {ttl_seconds + 5} seconds for data to expire...")
+        time.sleep(ttl_seconds + 5)
 
         # Verify data is invisible
         res = self.query(client, collection_name, filter="", output_fields=["count(*)"])[0]
@@ -743,8 +809,8 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
         assert res[0].get('count(*)') == 60
 
         # Wait for future data to expire
-        log.info(f"Waiting {ttl_seconds + 3} seconds for future data to expire...")
-        time.sleep(ttl_seconds + 3)
+        log.info(f"Waiting {ttl_seconds + 5} seconds for future data to expire...")
+        time.sleep(ttl_seconds + 5)
 
         # Verify only NULL data remains (30)
         res = self.query(client, collection_name, filter="", output_fields=["count(*)"])[0]
@@ -777,13 +843,10 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
 
         # Create collection with ttl_field
         properties = {"ttl_field": "ttl", "timezone": "UTC"}
-        self.create_collection(client, collection_name, schema=schema, properties=properties)
-
-        # Create index and load
         index_params = self.prepare_index_params(client)[0]
         index_params.add_index(field_name=default_vector_field_name, index_type="IVF_FLAT", metric_type="L2", nlist=128)
-        self.create_index(client, collection_name, index_params=index_params)
-        self.load_collection(client, collection_name)
+        self.create_collection(client, collection_name, schema=schema,
+                               properties=properties, index_params=index_params)
 
         # Insert data with future ttl
         ttl_timestamp = datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds)
@@ -804,8 +867,8 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
         assert res[0].get('count(*)') == nb
 
         # Wait for original ttl to expire
-        log.info(f"Waiting {ttl_seconds + 3} seconds for data to expire...")
-        time.sleep(ttl_seconds + 3)
+        log.info(f"Waiting {ttl_seconds + 5} seconds for data to expire...")
+        time.sleep(ttl_seconds + 5)
 
         # Verify data expires at original ttl time
         res = self.query(client, collection_name, filter="", output_fields=["count(*)"], consistency_level=CONSISTENCY_STRONG)[0]
@@ -866,8 +929,8 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
         log.info(f"Count after original TTL expired: {res[0].get('count(*)')}")
         assert res[0].get('count(*)') == nb
 
-        # Wait past extended TTL
-        time.sleep(8)
+        # Wait past extended TTL (with buffer for CI)
+        time.sleep(10)
         res = self.query(client, collection_name, filter="", output_fields=["count(*)"],
                          consistency_level=CONSISTENCY_STRONG)[0]
         assert res[0].get('count(*)') == 0
@@ -924,8 +987,8 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
         self.upsert(client, collection_name, upsert_rows)
 
         # Wait for short TTL to expire
-        log.info(f"Waiting {short_ttl_seconds + 3} seconds for shortened TTL to expire...")
-        time.sleep(short_ttl_seconds + 3)
+        log.info(f"Waiting {short_ttl_seconds + 5} seconds for shortened TTL to expire...")
+        time.sleep(short_ttl_seconds + 5)
 
         # Verify data expired at the shorter deadline
         res = self.query(client, collection_name, filter="", output_fields=["count(*)"],
@@ -988,8 +1051,8 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
         assert res[0].get('count(*)') == nb
 
         # Wait for TTL to expire
-        log.info(f"Waiting {ttl_seconds + 3} seconds for data to expire after reload...")
-        time.sleep(ttl_seconds + 3)
+        log.info(f"Waiting {ttl_seconds + 5} seconds for data to expire after reload...")
+        time.sleep(ttl_seconds + 5)
 
         # Verify data is invisible after TTL expires
         res = self.query(client, collection_name, filter="", output_fields=["count(*)"],
@@ -1067,6 +1130,74 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
         self.drop_collection(client, collection_name)
 
     @pytest.mark.tags(CaseLabel.L1)
+    def test_insert_with_timezone_offset_entity_ttl(self):
+        """
+        target: test entity TTL with explicit timezone offset timestamps
+        method:
+            1. Create collection with ttl_field
+            2. Insert data using timestamps with explicit timezone offset (e.g., +08:00)
+            3. Insert data using second-level precision (no fractional seconds)
+            4. Verify data is visible before TTL, invisible after TTL
+        expected: Different timestamp formats (timezone offsets, different precisions)
+                  are handled correctly
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        nb = 30
+        ttl_seconds = 8
+
+        # Create schema
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field("ttl", DataType.TIMESTAMPTZ, nullable=True)
+        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
+        index_params = self.prepare_index_params(client)[0]
+        index_params.add_index(field_name=default_vector_field_name, index_type="IVF_FLAT", metric_type="L2", nlist=128)
+
+        # Create collection with ttl_field
+        properties = {"ttl_field": "ttl", "timezone": "UTC"}
+        self.create_collection(client, collection_name, schema=schema,
+                               properties=properties, consistency_level="Strong", index_params=index_params)
+
+        # Insert data with explicit timezone offset (+08:00)
+        now_utc = datetime.now(timezone.utc)
+        future_utc = now_utc + timedelta(seconds=ttl_seconds)
+        # Convert to +08:00 offset format
+        tz_shanghai = timezone(timedelta(hours=8))
+        future_shanghai = future_utc.astimezone(tz_shanghai)
+        ttl_with_offset = future_shanghai.strftime("%Y-%m-%dT%H:%M:%S+08:00")
+
+        # Insert with second-level precision (no fractional seconds)
+        ttl_second_precision = future_utc.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        vectors = cf.gen_vectors(nb, dim=default_dim)
+        rows = []
+        for i in range(nb):
+            if i < 15:
+                ttl_value = ttl_with_offset  # Explicit timezone offset
+            else:
+                ttl_value = ttl_second_precision  # Second-level precision with Z suffix
+            rows.append({default_primary_key_field_name: i, "ttl": ttl_value,
+                         default_vector_field_name: list(vectors[i])})
+
+        self.insert(client, collection_name, rows)
+        self.flush(client, collection_name)
+
+        # Verify all data is visible
+        res = self.query(client, collection_name, filter="", output_fields=["count(*)"])[0]
+        assert res[0].get('count(*)') == nb
+
+        # Wait for TTL to expire
+        log.info(f"Waiting {ttl_seconds + 5} seconds for data to expire...")
+        time.sleep(ttl_seconds + 5)
+
+        # Verify all data expired regardless of timestamp format
+        res = self.query(client, collection_name, filter="", output_fields=["count(*)"])[0]
+        assert res[0].get('count(*)') == 0
+
+        self.drop_collection(client, collection_name)
+
+    @pytest.mark.tags(CaseLabel.L1)
     def test_insert_new_data_after_entity_ttl_expiry(self):
         """
         target: test inserting new data after previous data expired by entity TTL
@@ -1074,9 +1205,14 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
             1. Create collection with ttl_field
             2. Insert first batch with ttl = now() + 8 seconds
             3. Wait for TTL to expire, verify data is gone
-            4. Insert second batch with new future TTL
-            5. Verify new data is visible and queryable
-        expected: New inserts work normally after previous data expired
+            4. Re-insert using the same PKs with new future TTL
+            5. Insert additional batch with new PKs
+            6. Verify all new data is visible and queryable
+        expected: New inserts work normally after previous data expired.
+                  Expired PKs can be reused as open slots for new data — even though
+                  physical deletion (compaction) may not have completed, the expired
+                  data is logically invisible, and re-inserting with the same PKs
+                  succeeds via upsert semantics.
         """
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
@@ -1110,8 +1246,8 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
         assert res[0].get('count(*)') == nb
 
         # Wait for TTL to expire
-        log.info(f"Waiting {ttl_seconds + 3} seconds for first batch to expire...")
-        time.sleep(ttl_seconds + 3)
+        log.info(f"Waiting {ttl_seconds + 5} seconds for first batch to expire...")
+        time.sleep(ttl_seconds + 5)
 
         # Verify first batch is gone
         res = self.query(client, collection_name, filter="", output_fields=["count(*)"],
@@ -1224,6 +1360,13 @@ class TestMilvusClientEntityTTLQuery(TestMilvusClientV2Base):
         self.insert(client, collection_name, rows)
         self.flush(client, collection_name)
 
+        # Verify data before expiry inside fixture where execution order is guaranteed
+        # Future (200) + NULL (100) = 300 visible; past (200) already expired
+        res = self.query(client, collection_name, filter="", output_fields=["count(*)"],
+                         consistency_level=CONSISTENCY_STRONG)[0]
+        assert res[0].get('count(*)') == 300, \
+            f"Expected 300 visible rows before TTL expiry, got {res[0].get('count(*)')}"
+
         # Store generated vectors on class (other attributes are already class-level)
         TestMilvusClientEntityTTLQuery.vectors = vectors
         TestMilvusClientEntityTTLQuery._ttl_expired = False
@@ -1239,26 +1382,20 @@ class TestMilvusClientEntityTTLQuery(TestMilvusClientV2Base):
     def _wait_for_ttl_expire(self):
         if TestMilvusClientEntityTTLQuery._ttl_expired:
             return
-        log.info(f"Waiting {self.ttl_seconds + 3} seconds for data to expire...")
-        time.sleep(self.ttl_seconds + 3)
+        log.info(f"Waiting {self.ttl_seconds + 5} seconds for data to expire...")
+        time.sleep(self.ttl_seconds + 5)
         TestMilvusClientEntityTTLQuery._ttl_expired = True
 
     @pytest.mark.tags(CaseLabel.L0)
     def test_query_filter_expired_entity_data(self):
         """
-        target: test query automatically filters expired data
+        target: test query automatically filters expired data after TTL expiry
         method:
-            1. Query collection with entity ttl enabled
-            2. Verify only non-expired data is returned (200 future + 100 NULL = 300)
-            3. Wait for ttl to expire
-            4. Verify only NULL data remains (100)
+            1. Wait for ttl to expire (pre-expiry count verified in prepare_data fixture)
+            2. Query and verify only NULL data remains (100)
         expected: Query automatically filters expired data
         """
         client = self._client()
-
-        # Query before expiration - should get future + NULL data (300 total)
-        res = self.query(client, self.collection_name, filter="", output_fields=["count(*)"], consistency_level=CONSISTENCY_STRONG)[0]
-        assert res[0].get('count(*)') == 300
 
         # Wait for ttl to expire
         self._wait_for_ttl_expire()
@@ -1267,23 +1404,6 @@ class TestMilvusClientEntityTTLQuery(TestMilvusClientV2Base):
         res = self.query(client, self.collection_name, filter="", output_fields=["count(*)"], consistency_level=CONSISTENCY_STRONG)[0]
         assert res[0].get('count(*)') == 100
 
-    @pytest.mark.tags(CaseLabel.L0)
-    def test_query_count_expired_entity_data(self):
-        """
-        target: test count(*) aggregation excludes expired data
-        method:
-            1. Use count(*) to count records
-            2. Verify count matches non-expired data
-        expected: count(*) does not include expired data
-        """
-        client = self._client()
-
-        self._wait_for_ttl_expire()
-
-        # count(*) should match non-expired data
-        res = self.query(client, self.collection_name, filter="", output_fields=["count(*)"], consistency_level=CONSISTENCY_STRONG)[0]
-        count_result = res[0].get('count(*)')
-        assert count_result == 100  # Only NULL data remains
 
     @pytest.mark.tags(CaseLabel.L0)
     def test_search_filter_expired_entity_data(self):
@@ -1309,6 +1429,32 @@ class TestMilvusClientEntityTTLQuery(TestMilvusClientV2Base):
         for hit in res[0]:
             # All results should be from id >= 400 (NULL ttl data)
             assert hit['id'] >= 400
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_search_without_filter_expired_entity_data(self):
+        """
+        target: test search without filter also filters expired data
+        method:
+            1. Wait for TTL to expire
+            2. Perform vector search without any filter expression
+            3. Verify search results only contain non-expired (NULL ttl) data
+        expected: TTL filtering is applied regardless of whether a filter expression
+                  is present. Search without filter should not return expired entities.
+        """
+        client = self._client()
+
+        self._wait_for_ttl_expire()
+
+        search_vectors = cf.gen_vectors(1, dim=self.dim)
+        res = self.search(client, self.collection_name, search_vectors, anns_field='vector',
+                         search_params={}, limit=10,
+                         consistency_level=CONSISTENCY_STRONG)[0]
+
+        assert len(res[0]) > 0
+        for hit in res[0]:
+            # All results should be from id >= 400 (NULL ttl data that never expires)
+            assert hit['id'] >= 400, \
+                f"Search without filter returned expired entity id={hit['id']} (expected only id >= 400)"
 
     @pytest.mark.tags(CaseLabel.L0)
     def test_query_output_entity_ttl_field(self):

--- a/tests/python_client/milvus_client_v2/test_milvus_client_ttl.py
+++ b/tests/python_client/milvus_client_v2/test_milvus_client_ttl.py
@@ -16,7 +16,6 @@ default_primary_key_field_name = ct.default_primary_key_field_name
 default_vector_field_name = ct.default_vector_field_name
 default_int32_field_name = ct.default_int32_field_name
 default_search_exp = "id >= 0"
-ENTITY_TTL_QUERY_COLLECTION = "test_entity_ttl_query" + cf.gen_unique_str("_")
 
 class TestMilvusClientTTL(TestMilvusClientV2Base):
     """ Test case of Time To Live """
@@ -348,6 +347,36 @@ class TestMilvusClientTTL(TestMilvusClientV2Base):
 
 # ==================== Entity TTL Tests ==================== #
 class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
+
+    def _create_ttl_collection(self, client, collection_name, extra_fields=None,
+                               properties=None, ttl_nullable=True, **kwargs):
+        """Create a collection with standard TTL schema (pk + ttl + vector + index)."""
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field("ttl", DataType.TIMESTAMPTZ, nullable=ttl_nullable)
+        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
+        for field in (extra_fields or []):
+            schema.add_field(**field)
+        index_params = self.prepare_index_params(client)[0]
+        index_params.add_index(field_name=default_vector_field_name, index_type="IVF_FLAT", metric_type="L2", nlist=128)
+        if properties is None:
+            properties = {"ttl_field": "ttl", "timezone": "UTC"}
+        self.create_collection(client, collection_name, schema=schema, properties=properties,
+                               consistency_level="Strong", index_params=index_params, **kwargs)
+
+    def _wait_until_count(self, client, collection_name, expected_count, timeout=30, interval=2):
+        """Poll until query count(*) equals expected_count or timeout is reached."""
+        for _ in range(timeout // interval):
+            res = self.query(client, collection_name, filter="", output_fields=["count(*)"],
+                             consistency_level=CONSISTENCY_STRONG)[0]
+            if res[0].get('count(*)') == expected_count:
+                return
+            time.sleep(interval)
+        res = self.query(client, collection_name, filter="", output_fields=["count(*)"],
+                         consistency_level=CONSISTENCY_STRONG)[0]
+        assert res[0].get('count(*)') == expected_count, \
+            f"Expected count {expected_count}, got {res[0].get('count(*)')} after {timeout}s"
+
     @pytest.mark.tags(CaseLabel.L0)
     def test_create_collection_with_entity_ttl_field(self):
         """
@@ -411,7 +440,6 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
 
     @pytest.mark.tags(CaseLabel.L0)
     @pytest.mark.skip("BUG #47416")
-    # BUG #47416
     def test_alter_remove_entity_ttl_field(self):
         """
         target: test removing ttl_field from collection
@@ -531,13 +559,9 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
         res = self.query(client, collection_name, filter="", output_fields=["count(*)"])[0]
         assert res[0].get('count(*)') == nb
 
-        # Wait for TTL to expire
-        log.info(f"Waiting {ttl_seconds + 5} seconds for data to expire...")
-        time.sleep(ttl_seconds + 5)
-
-        # Verify data is expired
-        res = self.query(client, collection_name, filter="", output_fields=["count(*)"])[0]
-        assert res[0].get('count(*)') == 0
+        # Wait for TTL to expire (poll until count reaches 0)
+        time.sleep(ttl_seconds)
+        self._wait_until_count(client, collection_name, expected_count=0)
 
         self.drop_collection(client, collection_name)
 
@@ -563,18 +587,7 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
         self.create_database(client, db_name, properties={"timezone": "UTC"})
         self.using_database(client, db_name)
 
-        # Create schema
-        schema = self.create_schema(client, enable_dynamic_field=False)[0]
-        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
-        schema.add_field("ttl", DataType.TIMESTAMPTZ, nullable=True)
-        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
-        index_params = self.prepare_index_params(client)[0]
-        index_params.add_index(field_name=default_vector_field_name, index_type="IVF_FLAT", metric_type="L2", nlist=128)
-
-        # Create collection with ttl_field
-        properties = {"ttl_field": "ttl"}
-        self.create_collection(client, collection_name, schema=schema,
-                               properties=properties, consistency_level="Strong", index_params=index_params)
+        self._create_ttl_collection(client, collection_name, properties={"ttl_field": "ttl"})
 
         # Insert data with future timestamp (10 seconds from now in UTC)
         ttl_timestamp = datetime.now(timezone.utc) + timedelta(seconds=10)
@@ -600,13 +613,9 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
         res = self.query(client, collection_name, filter="", output_fields=["count(*)"])[0]
         assert res[0].get('count(*)') == nb
 
-        # Wait for TTL to expire
-        log.info("Waiting for data to expire...")
-        time.sleep(15)
-
-        # Verify data expires based on original UTC timestamp
-        res = self.query(client, collection_name, filter="", output_fields=["count(*)"])[0]
-        assert res[0].get('count(*)') == 0
+        # Wait for TTL to expire (poll until count reaches 0)
+        time.sleep(10)
+        self._wait_until_count(client, collection_name, expected_count=0)
 
         # Cleanup
         self.drop_collection(client, collection_name)
@@ -630,18 +639,7 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
         nb = 100
         ttl_seconds = 8
 
-        # Create schema
-        schema = self.create_schema(client, enable_dynamic_field=False)[0]
-        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
-        schema.add_field("ttl", DataType.TIMESTAMPTZ, nullable=True)
-        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
-        index_params = self.prepare_index_params(client)[0]
-        index_params.add_index(field_name=default_vector_field_name, index_type="IVF_FLAT", metric_type="L2", nlist=128)
-
-        # Create collection with ttl_field
-        properties = {"ttl_field": "ttl", "timezone": "UTC"}
-        self.create_collection(client, collection_name, schema=schema, 
-                               properties=properties, consistency_level="Strong", index_params=index_params)
+        self._create_ttl_collection(client, collection_name)
 
         # Insert data with future ttl
         ttl_timestamp = datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds)
@@ -656,13 +654,9 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
         res = self.query(client, collection_name, filter="", output_fields=["count(*)"])[0]
         assert res[0].get('count(*)') == nb
 
-        # Wait for TTL to expire
-        log.info(f"Waiting {ttl_seconds + 5} seconds for data to expire...")
-        time.sleep(ttl_seconds + 5)
-
-        # Verify data is invisible
-        res = self.query(client, collection_name, filter="", output_fields=["count(*)"])[0]
-        assert res[0].get('count(*)') == 0
+        # Wait for TTL to expire (poll until count reaches 0)
+        time.sleep(ttl_seconds)
+        self._wait_until_count(client, collection_name, expected_count=0)
 
         self.drop_collection(client, collection_name)
 
@@ -680,18 +674,7 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
         collection_name = cf.gen_collection_name_by_testcase_name()
         nb = 100
 
-        # Create schema
-        schema = self.create_schema(client, enable_dynamic_field=False)[0]
-        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
-        schema.add_field("ttl", DataType.TIMESTAMPTZ, nullable=True)
-        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
-        index_params = self.prepare_index_params(client)[0]
-        index_params.add_index(field_name=default_vector_field_name, index_type="IVF_FLAT", metric_type="L2", nlist=128)
-
-        # Create collection with ttl_field
-        properties = {"ttl_field": "ttl", "timezone": "UTC"}
-        self.create_collection(client, collection_name, schema=schema, 
-                        properties=properties, consistency_level="Strong", index_params=index_params)
+        self._create_ttl_collection(client, collection_name)
 
         # Insert data with past ttl (already expired)
         ttl_timestamp = datetime.now(timezone.utc) - timedelta(seconds=60)
@@ -711,42 +694,55 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
     @pytest.mark.tags(CaseLabel.L0)
     def test_insert_with_null_entity_ttl(self):
         """
-        target: test inserting data with NULL ttl (never expires)
+        target: test inserting data with NULL ttl (never expires) persists through
+                flush, compaction, and release/reload
         method:
             1. Create collection with ttl_field (nullable=True)
-            2. Insert data with ttl = NULL
-            3. Verify data remains visible after significant time
-        expected: Data with NULL ttl never expires
+            2. Insert NULL ttl data + short TTL data
+            3. Wait for short TTL data to expire
+            4. Verify NULL data survives after flush, compact, release/reload
+        expected: Data with NULL ttl never expires and persists through all operations
         """
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
-        nb = 100
+        nb = 50
+        ttl_seconds = 8
 
-        # Create schema
-        schema = self.create_schema(client, enable_dynamic_field=False)[0]
-        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
-        schema.add_field("ttl", DataType.TIMESTAMPTZ, nullable=True)
-        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
-        index_params = self.prepare_index_params(client)[0]
-        index_params.add_index(field_name=default_vector_field_name, index_type="IVF_FLAT", metric_type="L2", nlist=128)
+        self._create_ttl_collection(client, collection_name)
 
-        # Create collection with ttl_field
-        properties = {"ttl_field": "ttl", "timezone": "UTC"}
-        self.create_collection(client, collection_name, schema=schema, 
-                               properties=properties, consistency_level="Strong", index_params=index_params)
-
-        # Insert data with NULL ttl
-        vectors = cf.gen_vectors(nb, dim=default_dim)
-        rows = [{default_primary_key_field_name: i, "ttl": None, default_vector_field_name: list(vectors[i])} for i in range(nb)]
+        # Insert NULL ttl data (never expires) + short TTL data
+        future_ttl = (datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds)).isoformat()
+        vectors = cf.gen_vectors(nb * 2, dim=default_dim)
+        rows = []
+        for i in range(nb * 2):
+            ttl_value = None if i < nb else future_ttl
+            rows.append({default_primary_key_field_name: i, "ttl": ttl_value,
+                         default_vector_field_name: list(vectors[i])})
         self.insert(client, collection_name, rows)
         self.flush(client, collection_name)
 
-        # Verify data is visible
+        # Verify all data visible before expiry
+        res = self.query(client, collection_name, filter="", output_fields=["count(*)"])[0]
+        assert res[0].get('count(*)') == nb * 2
+
+        # Wait for short TTL data to expire
+        time.sleep(ttl_seconds)
+        self._wait_until_count(client, collection_name, expected_count=nb)
+
+        # Flush and verify NULL data persists
+        self.flush(client, collection_name)
         res = self.query(client, collection_name, filter="", output_fields=["count(*)"])[0]
         assert res[0].get('count(*)') == nb
 
-        # Wait a bit and verify data is still visible
+        # Compact and verify NULL data persists
+        self.compact(client, collection_name)
         time.sleep(3)
+        res = self.query(client, collection_name, filter="", output_fields=["count(*)"])[0]
+        assert res[0].get('count(*)') == nb
+
+        # Release and reload, verify NULL data persists
+        self.release_collection(client, collection_name)
+        self.load_collection(client, collection_name)
         res = self.query(client, collection_name, filter="", output_fields=["count(*)"])[0]
         assert res[0].get('count(*)') == nb
 
@@ -772,18 +768,7 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
         nb = 90  # 30 for each category
         ttl_seconds = 8
 
-        # Create schema
-        schema = self.create_schema(client, enable_dynamic_field=False)[0]
-        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
-        schema.add_field("ttl", DataType.TIMESTAMPTZ, nullable=True)
-        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
-        index_params = self.prepare_index_params(client)[0]
-        index_params.add_index(field_name=default_vector_field_name, index_type="IVF_FLAT", metric_type="L2", nlist=128)
-
-        # Create collection with ttl_field
-        properties = {"ttl_field": "ttl", "timezone": "UTC"}
-        self.create_collection(client, collection_name, schema=schema, 
-                               properties=properties, consistency_level="Strong", index_params=index_params)
+        self._create_ttl_collection(client, collection_name)
 
         # Prepare ttl values
         future_ttl = (datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds)).isoformat()
@@ -808,13 +793,9 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
         res = self.query(client, collection_name, filter="", output_fields=["count(*)"])[0]
         assert res[0].get('count(*)') == 60
 
-        # Wait for future data to expire
-        log.info(f"Waiting {ttl_seconds + 5} seconds for future data to expire...")
-        time.sleep(ttl_seconds + 5)
-
-        # Verify only NULL data remains (30)
-        res = self.query(client, collection_name, filter="", output_fields=["count(*)"])[0]
-        assert res[0].get('count(*)') == 30
+        # Wait for future data to expire (poll until only NULL data remains)
+        time.sleep(ttl_seconds)
+        self._wait_until_count(client, collection_name, expected_count=30)
 
         self.drop_collection(client, collection_name)
 
@@ -835,18 +816,7 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
         nb = 50
         ttl_seconds = 10
 
-        # Create schema
-        schema = self.create_schema(client, enable_dynamic_field=False)[0]
-        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
-        schema.add_field("ttl", DataType.TIMESTAMPTZ, nullable=True)
-        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
-
-        # Create collection with ttl_field
-        properties = {"ttl_field": "ttl", "timezone": "UTC"}
-        index_params = self.prepare_index_params(client)[0]
-        index_params.add_index(field_name=default_vector_field_name, index_type="IVF_FLAT", metric_type="L2", nlist=128)
-        self.create_collection(client, collection_name, schema=schema,
-                               properties=properties, index_params=index_params)
+        self._create_ttl_collection(client, collection_name)
 
         # Insert data with future ttl
         ttl_timestamp = datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds)
@@ -866,13 +836,9 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
         res = self.query(client, collection_name, filter="", output_fields=["count(*)"], consistency_level=CONSISTENCY_STRONG)[0]
         assert res[0].get('count(*)') == nb
 
-        # Wait for original ttl to expire
-        log.info(f"Waiting {ttl_seconds + 5} seconds for data to expire...")
-        time.sleep(ttl_seconds + 5)
-
-        # Verify data expires at original ttl time
-        res = self.query(client, collection_name, filter="", output_fields=["count(*)"], consistency_level=CONSISTENCY_STRONG)[0]
-        assert res[0].get('count(*)') == 0
+        # Wait for original ttl to expire (poll until count reaches 0)
+        time.sleep(ttl_seconds)
+        self._wait_until_count(client, collection_name, expected_count=0)
 
         self.drop_collection(client, collection_name)
 
@@ -894,18 +860,7 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
         nb = 50
         original_ttl_seconds = 8
 
-        # Create schema
-        schema = self.create_schema(client, enable_dynamic_field=False)[0]
-        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
-        schema.add_field("ttl", DataType.TIMESTAMPTZ, nullable=True)
-        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
-        index_params = self.prepare_index_params(client)[0]
-        index_params.add_index(field_name=default_vector_field_name, index_type="IVF_FLAT", metric_type="L2", nlist=128)
-
-        # Create collection with ttl_field
-        properties = {"ttl_field": "ttl", "timezone": "UTC"}
-        self.create_collection(client, collection_name, schema=schema,
-                               properties=properties, consistency_level="Strong", index_params=index_params)
+        self._create_ttl_collection(client, collection_name)
 
         # Insert data with original TTL (8s)
         original_ttl = (datetime.now(timezone.utc) + timedelta(seconds=original_ttl_seconds)).isoformat()
@@ -929,11 +884,8 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
         log.info(f"Count after original TTL expired: {res[0].get('count(*)')}")
         assert res[0].get('count(*)') == nb
 
-        # Wait past extended TTL (with buffer for CI)
-        time.sleep(10)
-        res = self.query(client, collection_name, filter="", output_fields=["count(*)"],
-                         consistency_level=CONSISTENCY_STRONG)[0]
-        assert res[0].get('count(*)') == 0
+        # Wait past extended TTL (poll until count reaches 0)
+        self._wait_until_count(client, collection_name, expected_count=0)
 
         self.drop_collection(client, collection_name)
 
@@ -954,18 +906,7 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
         nb = 50
         short_ttl_seconds = 8
 
-        # Create schema
-        schema = self.create_schema(client, enable_dynamic_field=False)[0]
-        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
-        schema.add_field("ttl", DataType.TIMESTAMPTZ, nullable=True)
-        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
-        index_params = self.prepare_index_params(client)[0]
-        index_params.add_index(field_name=default_vector_field_name, index_type="IVF_FLAT", metric_type="L2", nlist=128)
-
-        # Create collection with ttl_field
-        properties = {"ttl_field": "ttl", "timezone": "UTC"}
-        self.create_collection(client, collection_name, schema=schema,
-                               properties=properties, consistency_level="Strong", index_params=index_params)
+        self._create_ttl_collection(client, collection_name)
 
         # Insert data with long TTL (60s)
         long_ttl = (datetime.now(timezone.utc) + timedelta(seconds=60)).isoformat()
@@ -986,14 +927,9 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
                         default_vector_field_name: list(vectors[i])} for i in range(nb)]
         self.upsert(client, collection_name, upsert_rows)
 
-        # Wait for short TTL to expire
-        log.info(f"Waiting {short_ttl_seconds + 5} seconds for shortened TTL to expire...")
-        time.sleep(short_ttl_seconds + 5)
-
-        # Verify data expired at the shorter deadline
-        res = self.query(client, collection_name, filter="", output_fields=["count(*)"],
-                         consistency_level=CONSISTENCY_STRONG)[0]
-        assert res[0].get('count(*)') == 0
+        # Wait for short TTL to expire (poll until count reaches 0)
+        time.sleep(short_ttl_seconds)
+        self._wait_until_count(client, collection_name, expected_count=0)
 
         self.drop_collection(client, collection_name)
 
@@ -1015,18 +951,7 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
         nb = 100
         ttl_seconds = 10
 
-        # Create schema
-        schema = self.create_schema(client, enable_dynamic_field=False)[0]
-        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
-        schema.add_field("ttl", DataType.TIMESTAMPTZ, nullable=True)
-        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
-        index_params = self.prepare_index_params(client)[0]
-        index_params.add_index(field_name=default_vector_field_name, index_type="IVF_FLAT", metric_type="L2", nlist=128)
-
-        # Create collection with ttl_field
-        properties = {"ttl_field": "ttl", "timezone": "UTC"}
-        self.create_collection(client, collection_name, schema=schema,
-                               properties=properties, consistency_level="Strong", index_params=index_params)
+        self._create_ttl_collection(client, collection_name)
 
         # Insert data with future ttl
         ttl_timestamp = (datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds)).isoformat()
@@ -1050,14 +975,9 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
                          consistency_level=CONSISTENCY_STRONG)[0]
         assert res[0].get('count(*)') == nb
 
-        # Wait for TTL to expire
-        log.info(f"Waiting {ttl_seconds + 5} seconds for data to expire after reload...")
-        time.sleep(ttl_seconds + 5)
-
-        # Verify data is invisible after TTL expires
-        res = self.query(client, collection_name, filter="", output_fields=["count(*)"],
-                         consistency_level=CONSISTENCY_STRONG)[0]
-        assert res[0].get('count(*)') == 0
+        # Wait for TTL to expire (poll until count reaches 0)
+        time.sleep(ttl_seconds)
+        self._wait_until_count(client, collection_name, expected_count=0)
 
         self.drop_collection(client, collection_name)
 
@@ -1078,18 +998,7 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
         nb = 100
         ttl_seconds = 60
 
-        # Create schema
-        schema = self.create_schema(client, enable_dynamic_field=False)[0]
-        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
-        schema.add_field("ttl", DataType.TIMESTAMPTZ, nullable=True)
-        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
-        index_params = self.prepare_index_params(client)[0]
-        index_params.add_index(field_name=default_vector_field_name, index_type="IVF_FLAT", metric_type="L2", nlist=128)
-
-        # Create collection with ttl_field
-        properties = {"ttl_field": "ttl", "timezone": "UTC"}
-        self.create_collection(client, collection_name, schema=schema,
-                               properties=properties, consistency_level="Strong", index_params=index_params)
+        self._create_ttl_collection(client, collection_name)
 
         # Insert data with long TTL
         ttl_timestamp = (datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds)).isoformat()
@@ -1146,18 +1055,7 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
         nb = 30
         ttl_seconds = 8
 
-        # Create schema
-        schema = self.create_schema(client, enable_dynamic_field=False)[0]
-        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
-        schema.add_field("ttl", DataType.TIMESTAMPTZ, nullable=True)
-        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
-        index_params = self.prepare_index_params(client)[0]
-        index_params.add_index(field_name=default_vector_field_name, index_type="IVF_FLAT", metric_type="L2", nlist=128)
-
-        # Create collection with ttl_field
-        properties = {"ttl_field": "ttl", "timezone": "UTC"}
-        self.create_collection(client, collection_name, schema=schema,
-                               properties=properties, consistency_level="Strong", index_params=index_params)
+        self._create_ttl_collection(client, collection_name)
 
         # Insert data with explicit timezone offset (+08:00)
         now_utc = datetime.now(timezone.utc)
@@ -1187,13 +1085,9 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
         res = self.query(client, collection_name, filter="", output_fields=["count(*)"])[0]
         assert res[0].get('count(*)') == nb
 
-        # Wait for TTL to expire
-        log.info(f"Waiting {ttl_seconds + 5} seconds for data to expire...")
-        time.sleep(ttl_seconds + 5)
-
-        # Verify all data expired regardless of timestamp format
-        res = self.query(client, collection_name, filter="", output_fields=["count(*)"])[0]
-        assert res[0].get('count(*)') == 0
+        # Wait for TTL to expire (poll until count reaches 0)
+        time.sleep(ttl_seconds)
+        self._wait_until_count(client, collection_name, expected_count=0)
 
         self.drop_collection(client, collection_name)
 
@@ -1219,18 +1113,7 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
         nb = 100
         ttl_seconds = 8
 
-        # Create schema
-        schema = self.create_schema(client, enable_dynamic_field=False)[0]
-        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
-        schema.add_field("ttl", DataType.TIMESTAMPTZ, nullable=True)
-        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
-        index_params = self.prepare_index_params(client)[0]
-        index_params.add_index(field_name=default_vector_field_name, index_type="IVF_FLAT", metric_type="L2", nlist=128)
-
-        # Create collection with ttl_field
-        properties = {"ttl_field": "ttl", "timezone": "UTC"}
-        self.create_collection(client, collection_name, schema=schema,
-                               properties=properties, consistency_level="Strong", index_params=index_params)
+        self._create_ttl_collection(client, collection_name)
 
         # Insert first batch with short TTL
         ttl_str = (datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds)).isoformat()
@@ -1245,9 +1128,9 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
                          consistency_level=CONSISTENCY_STRONG)[0]
         assert res[0].get('count(*)') == nb
 
-        # Wait for TTL to expire
-        log.info(f"Waiting {ttl_seconds + 5} seconds for first batch to expire...")
-        time.sleep(ttl_seconds + 5)
+        # Wait for TTL to expire (poll until count reaches 0)
+        time.sleep(ttl_seconds)
+        self._wait_until_count(client, collection_name, expected_count=0)
 
         # Verify first batch is gone
         res = self.query(client, collection_name, filter="", output_fields=["count(*)"],
@@ -1294,188 +1177,409 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
 
         self.drop_collection(client, collection_name)
 
-
-@pytest.mark.xdist_group("TestMilvusClientEntityTTLQuery")
-class TestMilvusClientEntityTTLQuery(TestMilvusClientV2Base):
-    """
-    Entity TTL Query Tests - Using shared collection to reduce time cost
-    """
-    collection_name = ENTITY_TTL_QUERY_COLLECTION
-    nb = 500
-    dim = default_dim
-    ttl_seconds = 10
-    vectors = None
-    _ttl_expired = False
-
-    @pytest.fixture(scope="class", autouse=True)
-    def prepare_data(self, request):
-        """
-        Prepare shared collection with entity ttl data for query tests
-        """
-        client = self._client()
-        collection_name = self.collection_name
-        nb = self.nb
-        ttl_seconds = self.ttl_seconds
-
-        if client.has_collection(collection_name):
-            client.drop_collection(collection_name)
-
-        # Create schema
-        schema = self.create_schema(client, enable_dynamic_field=False)[0]
-        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
-        schema.add_field("ttl", DataType.TIMESTAMPTZ, nullable=True)
-        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
-        schema.add_field("varchar_field", DataType.VARCHAR, max_length=100, nullable=True)
-
-        # Create collection with ttl_field (force_teardown=False to keep shared collection across tests)
-        properties = {"ttl_field": "ttl", "timezone": "UTC"}
-        self.create_collection(client, collection_name, schema=schema, properties=properties, force_teardown=False)
-
-        # Create index and load
-        index_params = self.prepare_index_params(client)[0]
-        index_params.add_index(field_name=default_vector_field_name, index_type="IVF_FLAT", metric_type="L2", nlist=128)
-        self.create_index(client, collection_name, index_params=index_params)
-        self.load_collection(client, collection_name)
-
-        # Insert data with mixed ttl
-        future_ttl = (datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds)).isoformat()
-        past_ttl = (datetime.now(timezone.utc) - timedelta(seconds=60)).isoformat()
-
-        vectors = cf.gen_vectors(nb, dim=default_dim)
-        rows = []
-        for i in range(nb):
-            if i < 200:
-                ttl_value = future_ttl  # Will expire in 10 seconds
-            elif i < 400:
-                ttl_value = past_ttl  # Already expired
-            else:
-                ttl_value = None  # Never expires
-            rows.append({
-                default_primary_key_field_name: i,
-                "ttl": ttl_value,
-                default_vector_field_name: list(vectors[i]),
-                "varchar_field": f"text_{i}"
-            })
-
-        self.insert(client, collection_name, rows)
-        self.flush(client, collection_name)
-
-        # Verify data before expiry inside fixture where execution order is guaranteed
-        # Future (200) + NULL (100) = 300 visible; past (200) already expired
-        res = self.query(client, collection_name, filter="", output_fields=["count(*)"],
-                         consistency_level=CONSISTENCY_STRONG)[0]
-        assert res[0].get('count(*)') == 300, \
-            f"Expected 300 visible rows before TTL expiry, got {res[0].get('count(*)')}"
-
-        # Store generated vectors on class (other attributes are already class-level)
-        TestMilvusClientEntityTTLQuery.vectors = vectors
-        TestMilvusClientEntityTTLQuery._ttl_expired = False
-
-        def teardown():
-            try:
-                if self.has_collection(self._client(), collection_name):
-                    self.drop_collection(self._client(), collection_name)
-            except Exception:
-                pass
-        request.addfinalizer(teardown)
-
-    def _wait_for_ttl_expire(self):
-        if TestMilvusClientEntityTTLQuery._ttl_expired:
-            return
-        log.info(f"Waiting {self.ttl_seconds + 5} seconds for data to expire...")
-        time.sleep(self.ttl_seconds + 5)
-        TestMilvusClientEntityTTLQuery._ttl_expired = True
-
     @pytest.mark.tags(CaseLabel.L0)
     def test_query_filter_expired_entity_data(self):
         """
         target: test query automatically filters expired data after TTL expiry
         method:
-            1. Wait for ttl to expire (pre-expiry count verified in prepare_data fixture)
-            2. Query and verify only NULL data remains (100)
+            1. Create collection with ttl_field, insert mixed TTL data
+            2. Verify count before expiry (future + NULL = visible)
+            3. Wait for TTL to expire
+            4. Query and verify only NULL data remains
         expected: Query automatically filters expired data
         """
         client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        nb = 300
+        ttl_seconds = 8
 
-        # Wait for ttl to expire
-        self._wait_for_ttl_expire()
+        self._create_ttl_collection(client, collection_name)
 
-        # Query after expiration - should only get NULL data (100)
-        res = self.query(client, self.collection_name, filter="", output_fields=["count(*)"], consistency_level=CONSISTENCY_STRONG)[0]
-        assert res[0].get('count(*)') == 100
+        future_ttl = (datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds)).isoformat()
+        past_ttl = (datetime.now(timezone.utc) - timedelta(seconds=60)).isoformat()
+        vectors = cf.gen_vectors(nb, dim=default_dim)
+        rows = []
+        for i in range(nb):
+            if i < 100:
+                ttl_value = future_ttl
+            elif i < 200:
+                ttl_value = past_ttl
+            else:
+                ttl_value = None
+            rows.append({default_primary_key_field_name: i, "ttl": ttl_value,
+                         default_vector_field_name: list(vectors[i])})
+        self.insert(client, collection_name, rows)
+        self.flush(client, collection_name)
 
+        # Before expiry: future (100) + NULL (100) = 200 visible; past (100) already expired
+        res = self.query(client, collection_name, filter="", output_fields=["count(*)"])[0]
+        assert res[0].get('count(*)') == 200
+
+        # Wait for TTL to expire (poll until only NULL data remains)
+        time.sleep(ttl_seconds)
+        self._wait_until_count(client, collection_name, expected_count=100)
+
+        self.drop_collection(client, collection_name)
 
     @pytest.mark.tags(CaseLabel.L0)
     def test_search_filter_expired_entity_data(self):
         """
         target: test search filters expired data when filter expression is present
         method:
-            1. Perform vector search with a filter expression
-            2. Verify search results only contain non-expired data
+            1. Create collection with ttl_field, insert future TTL + NULL TTL data
+            2. Wait for TTL to expire
+            3. Search with filter and verify only NULL TTL data is returned
         expected: Search results do not include expired data
         """
         client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        nb = 200
+        ttl_seconds = 8
 
-        self._wait_for_ttl_expire()
+        self._create_ttl_collection(client, collection_name)
 
-        # Search with filter - TTL filtering is applied when a filter expression is present
-        search_vectors = cf.gen_vectors(1, dim=self.dim)
-        res = self.search(client, self.collection_name, search_vectors, anns_field='vector',
+        future_ttl = (datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds)).isoformat()
+        vectors = cf.gen_vectors(nb, dim=default_dim)
+        rows = []
+        for i in range(nb):
+            if i < 100:
+                ttl_value = future_ttl
+            else:
+                ttl_value = None
+            rows.append({default_primary_key_field_name: i, "ttl": ttl_value,
+                         default_vector_field_name: list(vectors[i])})
+        self.insert(client, collection_name, rows)
+        self.flush(client, collection_name)
+
+        # Wait for TTL to expire (poll until only NULL data remains)
+        time.sleep(ttl_seconds)
+        self._wait_until_count(client, collection_name, expected_count=100)
+
+        search_vectors = cf.gen_vectors(1, dim=default_dim)
+        res = self.search(client, collection_name, search_vectors, anns_field=default_vector_field_name,
                          search_params={}, limit=10, filter="id >= 0",
                          consistency_level=CONSISTENCY_STRONG)[0]
 
-        # Should get results from NULL data only
         assert len(res[0]) > 0
         for hit in res[0]:
-            # All results should be from id >= 400 (NULL ttl data)
-            assert hit['id'] >= 400
+            assert hit['id'] >= 100
+
+        self.drop_collection(client, collection_name)
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_search_without_filter_expired_entity_data(self):
         """
         target: test search without filter also filters expired data
         method:
-            1. Wait for TTL to expire
-            2. Perform vector search without any filter expression
-            3. Verify search results only contain non-expired (NULL ttl) data
+            1. Create collection with ttl_field, insert future TTL + NULL TTL data
+            2. Wait for TTL to expire
+            3. Search without filter and verify only NULL TTL data is returned
         expected: TTL filtering is applied regardless of whether a filter expression
                   is present. Search without filter should not return expired entities.
         """
         client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        nb = 200
+        ttl_seconds = 8
 
-        self._wait_for_ttl_expire()
+        self._create_ttl_collection(client, collection_name)
 
-        search_vectors = cf.gen_vectors(1, dim=self.dim)
-        res = self.search(client, self.collection_name, search_vectors, anns_field='vector',
+        future_ttl = (datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds)).isoformat()
+        vectors = cf.gen_vectors(nb, dim=default_dim)
+        rows = []
+        for i in range(nb):
+            if i < 100:
+                ttl_value = future_ttl
+            else:
+                ttl_value = None
+            rows.append({default_primary_key_field_name: i, "ttl": ttl_value,
+                         default_vector_field_name: list(vectors[i])})
+        self.insert(client, collection_name, rows)
+        self.flush(client, collection_name)
+
+        # Wait for TTL to expire (poll until only NULL data remains)
+        time.sleep(ttl_seconds)
+        self._wait_until_count(client, collection_name, expected_count=100)
+
+        search_vectors = cf.gen_vectors(1, dim=default_dim)
+        res = self.search(client, collection_name, search_vectors, anns_field=default_vector_field_name,
                          search_params={}, limit=10,
                          consistency_level=CONSISTENCY_STRONG)[0]
 
         assert len(res[0]) > 0
         for hit in res[0]:
-            # All results should be from id >= 400 (NULL ttl data that never expires)
-            assert hit['id'] >= 400, \
-                f"Search without filter returned expired entity id={hit['id']} (expected only id >= 400)"
+            assert hit['id'] >= 100, \
+                f"Search without filter returned expired entity id={hit['id']} (expected only id >= 100)"
+
+        self.drop_collection(client, collection_name)
 
     @pytest.mark.tags(CaseLabel.L0)
     def test_query_output_entity_ttl_field(self):
         """
         target: test query can output ttl field values
         method:
-            1. Query with output_fields including ttl
-            2. Verify ttl values are returned correctly
+            1. Create collection with ttl_field, insert data with NULL ttl
+            2. Query with output_fields including ttl
+            3. Verify ttl values are returned correctly
         expected: ttl field values are returned in query results
         """
         client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        nb = 10
 
-        # Query with ttl field in output
-        res = self.query(client, self.collection_name, filter="id >= 400 and id < 405",
-                        output_fields=[default_primary_key_field_name, "ttl", "varchar_field"], consistency_level=CONSISTENCY_STRONG)[0]
+        self._create_ttl_collection(client, collection_name, extra_fields=[
+            {"field_name": "varchar_field", "datatype": DataType.VARCHAR, "max_length": 100, "nullable": True}
+        ])
+
+        vectors = cf.gen_vectors(nb, dim=default_dim)
+        rows = [{default_primary_key_field_name: i, "ttl": None,
+                 default_vector_field_name: list(vectors[i]),
+                 "varchar_field": f"text_{i}"} for i in range(nb)]
+        self.insert(client, collection_name, rows)
+        self.flush(client, collection_name)
+
+        res = self.query(client, collection_name, filter=f"id >= 0 and id < 5",
+                        output_fields=[default_primary_key_field_name, "ttl", "varchar_field"],
+                        consistency_level=CONSISTENCY_STRONG)[0]
 
         assert len(res) == 5
         for row in res:
             assert default_primary_key_field_name in row
             assert "ttl" in row
-            assert row["ttl"] is None  # NULL ttl data
+            assert row["ttl"] is None
+
+        self.drop_collection(client, collection_name)
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_entity_ttl_compaction_reclaims_space(self):
+        """
+        target: test that compaction physically removes expired TTL data and reclaims space
+        method:
+            1. Create collection with ttl_field, insert data with short TTL
+            2. Record row_count from collection stats before expiry
+            3. Wait for TTL to expire, then trigger compaction
+            4. Verify row_count decreases after compaction completes
+        expected: Compaction physically deletes expired data and reduces row_count
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        nb = 200
+        ttl_seconds = 8
+
+        self._create_ttl_collection(client, collection_name)
+
+        # Insert data with short TTL
+        future_ttl = (datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds)).isoformat()
+        vectors = cf.gen_vectors(nb, dim=default_dim)
+        rows = [{default_primary_key_field_name: i, "ttl": future_ttl,
+                 default_vector_field_name: list(vectors[i])} for i in range(nb)]
+        self.insert(client, collection_name, rows)
+        self.flush(client, collection_name)
+
+        # Record row_count before expiry
+        stats_before = self.get_collection_stats(client, collection_name)[0]
+        row_count_before = stats_before.get("row_count", 0)
+        log.info(f"Row count before expiry: {row_count_before}")
+
+        # Wait for TTL to expire
+        time.sleep(ttl_seconds)
+        self._wait_until_count(client, collection_name, expected_count=0)
+
+        # Trigger compaction and wait for it to complete
+        self.compact(client, collection_name)
+        time.sleep(10)
+
+        # Verify row_count decreases after compaction
+        stats_after = self.get_collection_stats(client, collection_name)[0]
+        row_count_after = stats_after.get("row_count", 0)
+        log.info(f"Row count after compaction: {row_count_after}")
+        assert row_count_after < row_count_before, \
+            f"Expected row_count to decrease after compaction, before={row_count_before}, after={row_count_after}"
+
+        self.drop_collection(client, collection_name)
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_entity_ttl_with_partitions(self):
+        """
+        target: test entity TTL works independently across different partitions
+        method:
+            1. Create collection with ttl_field and two partitions
+            2. Insert short TTL data into partition_a, long TTL data into partition_b
+            3. Wait for short TTL to expire
+            4. Verify partition_a data expired, partition_b data still visible
+        expected: TTL expiration is per-entity and works correctly across partitions
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        nb = 50
+        short_ttl_seconds = 8
+
+        self._create_ttl_collection(client, collection_name)
+        self.create_partition(client, collection_name, "partition_a")
+        self.create_partition(client, collection_name, "partition_b")
+
+        # Insert short TTL data into partition_a
+        short_ttl = (datetime.now(timezone.utc) + timedelta(seconds=short_ttl_seconds)).isoformat()
+        vectors_a = cf.gen_vectors(nb, dim=default_dim)
+        rows_a = [{default_primary_key_field_name: i, "ttl": short_ttl,
+                   default_vector_field_name: list(vectors_a[i])} for i in range(nb)]
+        self.insert(client, collection_name, rows_a, partition_name="partition_a")
+
+        # Insert long TTL data into partition_b
+        long_ttl = (datetime.now(timezone.utc) + timedelta(seconds=300)).isoformat()
+        vectors_b = cf.gen_vectors(nb, dim=default_dim)
+        rows_b = [{default_primary_key_field_name: nb + i, "ttl": long_ttl,
+                   default_vector_field_name: list(vectors_b[i])} for i in range(nb)]
+        self.insert(client, collection_name, rows_b, partition_name="partition_b")
+        self.flush(client, collection_name)
+
+        # Verify both partitions have data
+        res = self.query(client, collection_name, filter="", output_fields=["count(*)"],
+                         partition_names=["partition_a"])[0]
+        assert res[0].get('count(*)') == nb
+        res = self.query(client, collection_name, filter="", output_fields=["count(*)"],
+                         partition_names=["partition_b"])[0]
+        assert res[0].get('count(*)') == nb
+
+        # Wait for short TTL to expire
+        time.sleep(short_ttl_seconds)
+        # Poll on total count: partition_a expired (0) + partition_b alive (nb) = nb
+        self._wait_until_count(client, collection_name, expected_count=nb)
+
+        # Verify partition_a data expired
+        res = self.query(client, collection_name, filter="", output_fields=["count(*)"],
+                         partition_names=["partition_a"])[0]
+        assert res[0].get('count(*)') == 0
+
+        # Verify partition_b data still visible
+        res = self.query(client, collection_name, filter="", output_fields=["count(*)"],
+                         partition_names=["partition_b"])[0]
+        assert res[0].get('count(*)') == nb
+
+        self.drop_collection(client, collection_name)
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_entity_ttl_with_dynamic_field(self):
+        """
+        target: test entity TTL works with enable_dynamic_field=True and dynamic fields
+                are properly cleaned up on expiry
+        method:
+            1. Create collection with ttl_field and enable_dynamic_field=True
+            2. Insert short TTL data with dynamic fields + NULL TTL data with dynamic fields
+            3. Verify dynamic fields are queryable before expiry
+            4. Wait for short TTL to expire
+            5. Verify expired rows (including their dynamic fields) are gone
+            6. Verify surviving NULL TTL rows still have correct dynamic fields
+        expected: TTL works correctly with dynamic fields; expired entities and their
+                  dynamic field data are fully removed
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        nb = 50
+        ttl_seconds = 8
+
+        # Create schema with dynamic field enabled
+        schema = self.create_schema(client, enable_dynamic_field=True)[0]
+        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field("ttl", DataType.TIMESTAMPTZ, nullable=True)
+        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
+        index_params = self.prepare_index_params(client)[0]
+        index_params.add_index(field_name=default_vector_field_name, index_type="IVF_FLAT", metric_type="L2", nlist=128)
+        properties = {"ttl_field": "ttl", "timezone": "UTC"}
+        self.create_collection(client, collection_name, schema=schema, properties=properties,
+                               consistency_level="Strong", index_params=index_params)
+
+        # Insert short TTL data (id 0~49) with dynamic fields
+        future_ttl = (datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds)).isoformat()
+        vectors = cf.gen_vectors(nb * 2, dim=default_dim)
+        rows = []
+        for i in range(nb):
+            rows.append({default_primary_key_field_name: i, "ttl": future_ttl,
+                         default_vector_field_name: list(vectors[i]),
+                         "dynamic_str": f"expire_{i}", "dynamic_int": i})
+        # Insert NULL TTL data (id 50~99) with dynamic fields
+        for i in range(nb, nb * 2):
+            rows.append({default_primary_key_field_name: i, "ttl": None,
+                         default_vector_field_name: list(vectors[i]),
+                         "dynamic_str": f"keep_{i}", "dynamic_int": i * 10})
+        self.insert(client, collection_name, rows)
+        self.flush(client, collection_name)
+
+        # Verify dynamic fields are queryable before expiry
+        res = self.query(client, collection_name, filter="id < 5",
+                         output_fields=[default_primary_key_field_name, "dynamic_str", "dynamic_int"])[0]
+        assert len(res) == 5
+        for row in res:
+            assert row["dynamic_str"].startswith("expire_")
+
+        # Wait for short TTL to expire
+        time.sleep(ttl_seconds)
+        self._wait_until_count(client, collection_name, expected_count=nb)
+
+        # Verify surviving NULL TTL rows still have correct dynamic fields
+        res = self.query(client, collection_name, filter=f"id >= {nb} and id < {nb + 5}",
+                         output_fields=[default_primary_key_field_name, "dynamic_str", "dynamic_int"])[0]
+        assert len(res) == 5
+        for row in res:
+            assert row["dynamic_str"].startswith("keep_")
+            assert row["dynamic_int"] == row[default_primary_key_field_name] * 10
+
+        self.drop_collection(client, collection_name)
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_entity_ttl_with_query_iterator(self):
+        """
+        target: test query iterator filters expired TTL data
+        method:
+            1. Create collection with ttl_field
+            2. Insert short TTL data + NULL TTL data
+            3. Wait for short TTL to expire
+            4. Use query_iterator to traverse all data
+            5. Verify iterator only returns non-expired (NULL TTL) data
+        expected: Query iterator respects TTL filtering, expired entities are not yielded
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        nb = 50
+        ttl_seconds = 8
+
+        self._create_ttl_collection(client, collection_name)
+
+        # Insert short TTL data (id 0~49) + NULL TTL data (id 50~99)
+        future_ttl = (datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds)).isoformat()
+        vectors = cf.gen_vectors(nb * 2, dim=default_dim)
+        rows = []
+        for i in range(nb * 2):
+            ttl_value = future_ttl if i < nb else None
+            rows.append({default_primary_key_field_name: i, "ttl": ttl_value,
+                         default_vector_field_name: list(vectors[i])})
+        self.insert(client, collection_name, rows)
+        self.flush(client, collection_name)
+
+        # Wait for short TTL to expire
+        time.sleep(ttl_seconds)
+        self._wait_until_count(client, collection_name, expected_count=nb)
+
+        # Use query_iterator to traverse all remaining data
+        iterator = self.query_iterator(client, collection_name, batch_size=10,
+                                       output_fields=[default_primary_key_field_name, "ttl"])[0]
+        iterated_ids = []
+        while True:
+            batch = iterator.next()
+            if not batch:
+                break
+            for row in batch:
+                iterated_ids.append(row[default_primary_key_field_name])
+        iterator.close()
+
+        # Verify iterator only returned NULL TTL data (id >= 50)
+        assert len(iterated_ids) == nb, \
+            f"Expected {nb} rows from iterator, got {len(iterated_ids)}"
+        for pk in iterated_ids:
+            assert pk >= nb, \
+                f"Iterator returned expired entity id={pk} (expected only id >= {nb})"
+
+        self.drop_collection(client, collection_name)
 
 
 class TestMilvusClientEntityTTLInvalid(TestMilvusClientV2Base):

--- a/tests/python_client/milvus_client_v2/test_milvus_client_ttl.py
+++ b/tests/python_client/milvus_client_v2/test_milvus_client_ttl.py
@@ -1,5 +1,6 @@
 import pytest
 import time
+from datetime import datetime, timedelta, timezone
 from common.common_type import CaseLabel, CheckTasks
 from common import common_func as cf
 from common import common_type as ct
@@ -49,7 +50,7 @@ class TestMilvusClientTTL(TestMilvusClientV2Base):
         nb = 1000
         collection_name = cf.gen_collection_name_by_testcase_name()
         schema = self.create_schema(client, enable_dynamic_field=False)[0]
-        schema.add_field("id", DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
         schema.add_field("embeddings", DataType.FLOAT_VECTOR, dim=dim)
         schema.add_field("embeddings_2", DataType.FLOAT_VECTOR, dim=dim)
         schema.add_field("visible", DataType.BOOL, nullable=True)
@@ -69,13 +70,13 @@ class TestMilvusClientTTL(TestMilvusClientV2Base):
         # insert data
         insert_times = 2
         for i in range(insert_times):
-            vectors = cf.gen_vectors(nb, dim=dim)
+            vectors = cf.gen_vectors(nb, dim=default_dim)
             vectors_2 = cf.gen_vectors(nb, dim=dim)
             rows = []
             start_id = i * nb
             for j in range(nb):
                 row = {
-                    "id": start_id + j,
+                    default_primary_key_field_name: start_id + j,
                     "embeddings": list(vectors[j]),
                     "embeddings_2": list(vectors_2[j]),
                     "visible": False
@@ -138,13 +139,13 @@ class TestMilvusClientTTL(TestMilvusClientV2Base):
 
         # insert more data
         for i in range(insert_times):
-            vectors = cf.gen_vectors(nb, dim=dim)
+            vectors = cf.gen_vectors(nb, dim=default_dim)
             vectors_2 = cf.gen_vectors(nb, dim=dim)
             rows = []
             start_id = (insert_times + i) * nb
             for j in range(nb):
                 row = {
-                    "id": start_id + j,
+                    default_primary_key_field_name: start_id + j,
                     "embeddings": list(vectors[j]),
                     "embeddings_2": list(vectors_2[j]),
                     "visible": True
@@ -248,7 +249,7 @@ class TestMilvusClientTTL(TestMilvusClientV2Base):
         ttl = 9223372036854775800
         collection_name = cf.gen_collection_name_by_testcase_name()
         schema = self.create_schema(client, enable_dynamic_field=False)[0]
-        schema.add_field("id", DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
         schema.add_field("embeddings", DataType.FLOAT_VECTOR, dim=dim)
         
         # Attempt to create collection with extremely large TTL, expecting it to fail
@@ -263,7 +264,7 @@ class TestMilvusClientTTL(TestMilvusClientV2Base):
         vectors = cf.gen_vectors(1000, dim=dim)
         rows = []
         for i in range(1000):
-            row = {"id": i, "embeddings": list(vectors[i])}
+            row = {default_primary_key_field_name: i, "embeddings": list(vectors[i])}
             rows.append(row)
         self.insert(client, collection_name, rows)
         self.flush(client, collection_name)
@@ -357,6 +358,796 @@ class TestMilvusClientTTL(TestMilvusClientV2Base):
                 new_ttl_time = pu_time + ttl_time
                 pu = False
                 time.sleep(1)
+
+        self.drop_collection(client, collection_name)
+
+
+# ==================== Entity TTL Tests ==================== #
+class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_create_collection_with_entity_ttl_field(self):
+        """
+        target: test creating collection with entity ttl_field
+        method:
+            1. Create a collection with ttl_field specified in properties
+            2. Verify ttl_field is set correctly in collection properties
+        expected: Collection created successfully with ttl_field configured
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+
+        # Create schema with Timestamptz field
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field("ttl", DataType.TIMESTAMPTZ, nullable=True)
+        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
+
+        # Create collection with ttl_field
+        properties = {"ttl_field": "ttl", "timezone": "UTC"}
+        self.create_collection(client, collection_name, schema=schema, properties=properties)
+
+        # Verify ttl_field is set
+        collection_info = self.describe_collection(client, collection_name)[0]
+        assert collection_info['properties'].get("ttl_field") == "ttl"
+        assert collection_info['properties'].get("timezone") == "UTC"
+
+        self.drop_collection(client, collection_name)
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_alter_add_entity_ttl_field(self):
+        """
+        target: test adding ttl_field to existing collection via alter
+        method:
+            1. Create a collection without ttl_field
+            2. Use alter_collection_properties to add ttl_field
+            3. Verify ttl_field is set correctly
+        expected: ttl_field added successfully
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+
+        # Create schema with Timestamptz field
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field("ttl", DataType.TIMESTAMPTZ, nullable=True)
+        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
+
+        # Create collection without ttl_field
+        properties = {"timezone": "UTC"}
+        self.create_collection(client, collection_name, schema=schema, properties=properties)
+
+        # Alter to add ttl_field
+        self.alter_collection_properties(client, collection_name, properties={"ttl_field": "ttl"})
+
+        # Verify ttl_field is set
+        collection_info = self.describe_collection(client, collection_name)[0]
+        assert collection_info['properties'].get("ttl_field") == "ttl"
+
+        self.drop_collection(client, collection_name)
+
+    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.skip("BUG #47416")
+    # BUG #47416
+    def test_alter_remove_entity_ttl_field(self):
+        """
+        target: test removing ttl_field from collection
+        method:
+            1. Create a collection with ttl_field
+            2. Use alter_collection_properties to remove ttl_field (set to empty string)
+            3. Verify ttl_field is removed
+        expected: ttl_field removed successfully, data no longer expires
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+
+        # Create schema
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field("ttl", DataType.TIMESTAMPTZ, nullable=True)
+        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
+
+        # Create collection with ttl_field
+        properties = {"ttl_field": "ttl", "timezone": "UTC"}
+        self.create_collection(client, collection_name, schema=schema, properties=properties)
+
+        # Alter to remove ttl_field
+        self.alter_collection_properties(client, collection_name, properties={"ttl_field": ""})
+
+        # Verify ttl_field is removed
+        collection_info = self.describe_collection(client, collection_name)[0]
+        assert collection_info['properties'].get("ttl_field", "") == ""
+
+        self.drop_collection(client, collection_name)
+    
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_change_entity_ttl_field(self):
+        """
+        target: test changing ttl_field to a new field
+        method:
+            1. Create collection with ttl_field
+            2. Use alter_collection_properties to change ttl_field to a new field
+            3. Verify the new field is set as ttl_field
+        expected: the new field is set as ttl_field
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+
+        # Create schema
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field("ttl", DataType.TIMESTAMPTZ, nullable=True)
+        schema.add_field("new_ttl", DataType.TIMESTAMPTZ, nullable=True)
+        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
+
+        # Create collection with ttl_field
+        properties = {"ttl_field": "ttl", "timezone": "UTC"}
+        self.create_collection(client, collection_name, schema=schema, properties=properties)
+
+        # Alter to change ttl_field to new_ttl
+        self.alter_collection_properties(client, collection_name, properties={"ttl_field": "new_ttl"})
+
+        # Verify the new field is set as ttl_field
+        collection_info = self.describe_collection(client, collection_name)[0]
+        assert collection_info['properties'].get("ttl_field") == "new_ttl"
+
+        self.drop_collection(client, collection_name)
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_alter_database_timezone_for_entity_ttl(self):
+        """
+        target: test altering database timezone affects entity TTL behavior
+        method:
+            1. Create database with UTC timezone
+            2. Create collection with ttl_field
+            3. Insert data with timestamptz value
+            4. Alter database timezone to a different timezone (e.g., Asia/Shanghai)
+            5. Verify TTL behavior is affected by timezone change
+        expected: Changing database timezone affects how TTL timestamps are interpreted
+        """
+        client = self._client()
+        db_name = cf.gen_unique_str("test_db_ttl")
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        nb = 100
+
+        # Create database with UTC timezone
+        self.create_database(client, db_name, properties={"timezone": "UTC"})
+        self.using_database(client, db_name)
+
+        # Create schema
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field("ttl", DataType.TIMESTAMPTZ, nullable=True)
+        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
+        index_params = self.prepare_index_params(client)[0]
+        index_params.add_index(field_name=default_vector_field_name, index_type="IVF_FLAT", metric_type="L2", nlist=128)
+
+        # Create collection with ttl_field
+        properties = {"ttl_field": "ttl"}
+        self.create_collection(client, collection_name, schema=schema,
+                               properties=properties, consistency_level="Strong", index_params=index_params)
+
+        # Insert data with future timestamp (10 seconds from now in UTC)
+        ttl_timestamp = datetime.now(timezone.utc) + timedelta(seconds=10)
+        ttl_str = ttl_timestamp.isoformat()
+
+        vectors = cf.gen_vectors(nb, dim=default_dim)
+        rows = [{default_primary_key_field_name: i, "ttl": ttl_str, default_vector_field_name: list(vectors[i])} for i in range(nb)]
+        self.insert(client, collection_name, rows)
+        self.flush(client, collection_name)
+
+        # Verify data is visible
+        res = self.query(client, collection_name, filter="", output_fields=["count(*)"])[0]
+        assert res[0].get('count(*)') == nb
+
+        # Alter database timezone to Asia/Shanghai (UTC+8)
+        self.alter_database_properties(client, db_name, properties={"timezone": "Asia/Shanghai"})
+
+        # Verify database timezone is changed
+        db_info = self.describe_database(client, db_name)[0]
+        assert db_info.get("timezone") == "Asia/Shanghai"
+
+        # Query again to verify data is still visible (timezone change doesn't affect existing timestamps)
+        res = self.query(client, collection_name, filter="", output_fields=["count(*)"])[0]
+        assert res[0].get('count(*)') == nb
+
+        # Wait for TTL to expire
+        log.info("Waiting 10 seconds for data to expire...")
+        time.sleep(10)
+
+        # Verify data expires based on original UTC timestamp
+        res = self.query(client, collection_name, filter="", output_fields=["count(*)"])[0]
+        assert res[0].get('count(*)') == 0
+
+        # Cleanup
+        self.drop_collection(client, collection_name)
+        self.using_database(client, "default")
+        self.drop_database(client, db_name)
+
+
+    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.skip("BUG #47413")
+    # BUG #47413
+    def test_insert_with_future_entity_ttl(self):
+        """
+        target: test inserting data with future ttl timestamp
+        method:
+            1. Create collection with ttl_field
+            2. Insert data with ttl = now() + 8 seconds
+            3. Verify data is visible immediately
+            4. Wait for expiration and verify data becomes invisible
+        expected: Data visible before TTL, invisible after TTL expires
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        nb = 100
+        ttl_seconds = 8
+
+        # Create schema
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field("ttl", DataType.TIMESTAMPTZ, nullable=True)
+        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
+        index_params = self.prepare_index_params(client)[0]
+        index_params.add_index(field_name=default_vector_field_name, index_type="IVF_FLAT", metric_type="L2", nlist=128)
+
+        # Create collection with ttl_field
+        properties = {"ttl_field": "ttl", "timezone": "UTC"}
+        self.create_collection(client, collection_name, schema=schema, 
+                               properties=properties, consistency_level="Strong", index_params=index_params)
+
+        # Insert data with future ttl
+        ttl_timestamp = datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds)
+        ttl_str = ttl_timestamp.isoformat()
+
+        vectors = cf.gen_vectors(nb, dim=default_dim)
+        rows = [{default_primary_key_field_name: i, "ttl": ttl_str, default_vector_field_name: list(vectors[i])} for i in range(nb)]
+        self.insert(client, collection_name, rows)
+        self.flush(client, collection_name)
+
+        # Verify data is visible
+        res = self.query(client, collection_name, filter="", output_fields=["count(*)"])[0]
+        assert res[0].get('count(*)') == nb
+
+        # Wait for TTL to expire
+        log.info(f"Waiting {ttl_seconds + 3} seconds for data to expire...")
+        time.sleep(ttl_seconds + 3)
+
+        # Verify data is invisible
+        res = self.query(client, collection_name, filter="", output_fields=["count(*)"])[0]
+        assert res[0].get('count(*)') == 0
+
+        self.drop_collection(client, collection_name)
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_insert_with_expired_entity_ttl(self):
+        """
+        target: test inserting data with past ttl timestamp
+        method:
+            1. Create collection with ttl_field
+            2. Insert data with ttl = now() - 60 seconds (already expired)
+            3. Query immediately to verify data is invisible
+        expected: Data is immediately invisible after insert
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        nb = 100
+
+        # Create schema
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field("ttl", DataType.TIMESTAMPTZ, nullable=True)
+        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
+        index_params = self.prepare_index_params(client)[0]
+        index_params.add_index(field_name=default_vector_field_name, index_type="IVF_FLAT", metric_type="L2", nlist=128)
+
+        # Create collection with ttl_field
+        properties = {"ttl_field": "ttl", "timezone": "UTC"}
+        self.create_collection(client, collection_name, schema=schema, 
+                        properties=properties, consistency_level="Strong", index_params=index_params)
+
+        # Insert data with past ttl (already expired)
+        ttl_timestamp = datetime.now(timezone.utc) - timedelta(seconds=60)
+        ttl_str = ttl_timestamp.isoformat()
+
+        vectors = cf.gen_vectors(nb, dim=default_dim)
+        rows = [{default_primary_key_field_name: i, "ttl": ttl_str, default_vector_field_name: list(vectors[i])} for i in range(nb)]
+        self.insert(client, collection_name, rows)
+        self.flush(client, collection_name)
+
+        # Verify data is invisible
+        res = self.query(client, collection_name, filter="", output_fields=["count(*)"])[0]
+        assert res[0].get('count(*)') == 0
+
+        self.drop_collection(client, collection_name)
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_insert_with_null_entity_ttl(self):
+        """
+        target: test inserting data with NULL ttl (never expires)
+        method:
+            1. Create collection with ttl_field (nullable=True)
+            2. Insert data with ttl = NULL
+            3. Verify data remains visible after significant time
+        expected: Data with NULL ttl never expires
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        nb = 100
+
+        # Create schema
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field("ttl", DataType.TIMESTAMPTZ, nullable=True)
+        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
+        index_params = self.prepare_index_params(client)[0]
+        index_params.add_index(field_name=default_vector_field_name, index_type="IVF_FLAT", metric_type="L2", nlist=128)
+
+        # Create collection with ttl_field
+        properties = {"ttl_field": "ttl", "timezone": "UTC"}
+        self.create_collection(client, collection_name, schema=schema, 
+                               properties=properties, consistency_level="Strong", index_params=index_params)
+
+        # Insert data with NULL ttl
+        vectors = cf.gen_vectors(nb, dim=default_dim)
+        rows = [{default_primary_key_field_name: i, "ttl": None, default_vector_field_name: list(vectors[i])} for i in range(nb)]
+        self.insert(client, collection_name, rows)
+        self.flush(client, collection_name)
+
+        # Verify data is visible
+        res = self.query(client, collection_name, filter="", output_fields=["count(*)"])[0]
+        assert res[0].get('count(*)') == nb
+
+        # Wait a bit and verify data is still visible
+        time.sleep(3)
+        res = self.query(client, collection_name, filter="", output_fields=["count(*)"])[0]
+        assert res[0].get('count(*)') == nb
+
+        self.drop_collection(client, collection_name)
+
+    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.skip("BUG #47413")
+    # BUG #47413
+    def test_insert_mixed_entity_ttl_values(self):
+        """
+        target: test inserting data with mixed ttl values (future, past, NULL)
+        method:
+            1. Create collection with ttl_field
+            2. Insert data with:
+            - 1/3 with ttl = now() + 8 seconds (future)
+            - 1/3 with ttl = now() - 60 seconds (past, already expired)
+            - 1/3 with ttl = NULL (never expires)
+            3. Verify only future and NULL data are visible initially
+            4. Wait for future data to expire
+            5. Verify only NULL data remains visible
+        expected: Each data expires according to its ttl value
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        nb = 90  # 30 for each category
+        ttl_seconds = 8
+
+        # Create schema
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field("ttl", DataType.TIMESTAMPTZ, nullable=True)
+        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
+        index_params = self.prepare_index_params(client)[0]
+        index_params.add_index(field_name=default_vector_field_name, index_type="IVF_FLAT", metric_type="L2", nlist=128)
+
+        # Create collection with ttl_field
+        properties = {"ttl_field": "ttl", "timezone": "UTC"}
+        self.create_collection(client, collection_name, schema=schema, 
+                               properties=properties, consistency_level="Strong", index_params=index_params)
+
+        # Prepare ttl values
+        future_ttl = (datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds)).isoformat()
+        past_ttl = (datetime.now(timezone.utc) - timedelta(seconds=60)).isoformat()
+
+        # Insert mixed data
+        vectors = cf.gen_vectors(nb, dim=default_dim)
+        rows = []
+        for i in range(nb):
+            if i < 30:
+                ttl_value = future_ttl  # Future
+            elif i < 60:
+                ttl_value = past_ttl  # Past (expired)
+            else:
+                ttl_value = None  # NULL (never expires)
+            rows.append({default_primary_key_field_name: i, "ttl": ttl_value, default_vector_field_name: list(vectors[i])})
+
+        self.insert(client, collection_name, rows)
+        self.flush(client, collection_name)
+
+        # Verify only future + NULL data are visible (30 + 30 = 60)
+        res = self.query(client, collection_name, filter="", output_fields=["count(*)"])[0]
+        assert res[0].get('count(*)') == 60
+
+        # Wait for future data to expire
+        log.info(f"Waiting {ttl_seconds + 3} seconds for future data to expire...")
+        time.sleep(ttl_seconds + 3)
+
+        # Verify only NULL data remains (30)
+        res = self.query(client, collection_name, filter="", output_fields=["count(*)"])[0]
+        assert res[0].get('count(*)') == 30
+
+        self.drop_collection(client, collection_name)
+
+
+    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.skip("BUG #47413")
+    # BUG #47413
+    def test_upsert_partial_update_without_entity_ttl(self):
+        """
+        target: test partial update without ttl field preserves original ttl
+        method:
+            1. Create collection with ttl_field
+            2. Insert data with ttl = now() + 10 seconds
+            3. Perform partial update (only id and vector) without ttl field
+            4. Verify data still expires at original ttl time
+        expected: Partial update without ttl field preserves original ttl
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        nb = 50
+        ttl_seconds = 10
+
+        # Create schema
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field("ttl", DataType.TIMESTAMPTZ, nullable=True)
+        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
+
+        # Create collection with ttl_field
+        properties = {"ttl_field": "ttl", "timezone": "UTC"}
+        self.create_collection(client, collection_name, schema=schema, properties=properties)
+
+        # Create index and load
+        index_params = self.prepare_index_params(client)[0]
+        index_params.add_index(field_name=default_vector_field_name, index_type="IVF_FLAT", metric_type="L2", nlist=128)
+        self.create_index(client, collection_name, index_params=index_params)
+        self.load_collection(client, collection_name)
+
+        # Insert data with future ttl
+        ttl_timestamp = datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds)
+        ttl_str = ttl_timestamp.isoformat()
+
+        vectors = cf.gen_vectors(nb, dim=default_dim)
+        rows = [{default_primary_key_field_name: i, "ttl": ttl_str, default_vector_field_name: list(vectors[i])} for i in range(nb)]
+        self.insert(client, collection_name, rows)
+        self.flush(client, collection_name)
+
+        # Perform partial update without ttl field
+        new_vectors = cf.gen_vectors(nb, dim=default_dim)
+        update_rows = [{default_primary_key_field_name: i, default_vector_field_name: list(new_vectors[i])} for i in range(nb)]
+        self.upsert(client, collection_name, update_rows, partial_update=True)
+
+        # Verify data is still visible
+        res = self.query(client, collection_name, filter="", output_fields=["count(*)"], consistency_level=CONSISTENCY_STRONG)[0]
+        assert res[0].get('count(*)') == nb
+
+        # Wait for original ttl to expire
+        log.info(f"Waiting {ttl_seconds + 3} seconds for data to expire...")
+        time.sleep(ttl_seconds + 3)
+
+        # Verify data expires at original ttl time
+        res = self.query(client, collection_name, filter="", output_fields=["count(*)"], consistency_level=CONSISTENCY_STRONG)[0]
+        assert res[0].get('count(*)') == 0
+
+        self.drop_collection(client, collection_name)
+
+@pytest.mark.xdist_group("TestMilvusClientEntityTTLQuery")
+class TestMilvusClientEntityTTLQuery(TestMilvusClientV2Base):
+    """
+    Entity TTL Query Tests - Using shared collection to reduce time cost
+    """
+    _ttl_expired = False
+
+    @pytest.fixture(scope="class", autouse=True)
+    def prepare_data(self, request):
+        """
+        Prepare shared collection with entity ttl data for query tests
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        nb = 500
+        ttl_seconds = 10
+
+        # Create schema
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field("ttl", DataType.TIMESTAMPTZ, nullable=True)
+        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
+        schema.add_field("varchar_field", DataType.VARCHAR, max_length=100, nullable=True)
+
+        # Create collection with ttl_field
+        properties = {"ttl_field": "ttl", "timezone": "UTC"}
+        self.create_collection(client, collection_name, schema=schema, properties=properties)
+
+        # Create index and load
+        index_params = self.prepare_index_params(client)[0]
+        index_params.add_index(field_name=default_vector_field_name, index_type="IVF_FLAT", metric_type="L2", nlist=128)
+        self.create_index(client, collection_name, index_params=index_params)
+        self.load_collection(client, collection_name)
+
+        # Insert data with mixed ttl
+        future_ttl = (datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds)).isoformat()
+        past_ttl = (datetime.now(timezone.utc) - timedelta(seconds=60)).isoformat()
+
+        vectors = cf.gen_vectors(nb, dim=default_dim)
+        rows = []
+        for i in range(nb):
+            if i < 200:
+                ttl_value = future_ttl  # Will expire in 10 seconds
+            elif i < 400:
+                ttl_value = past_ttl  # Already expired
+            else:
+                ttl_value = None  # Never expires
+            rows.append({
+                default_primary_key_field_name: i,
+                "ttl": ttl_value,
+                default_vector_field_name: list(vectors[i]),
+                "varchar_field": f"text_{i}"
+            })
+
+        self.insert(client, collection_name, rows)
+        self.flush(client, collection_name)
+
+        # Store for test methods
+        self.collection_name = collection_name
+        self.nb = nb
+        self.dim = default_dim
+        self.ttl_seconds = ttl_seconds
+        self.vectors = vectors
+        TestMilvusClientEntityTTLQuery._ttl_expired = False
+
+        yield
+
+        # Cleanup
+        self.drop_collection(client, collection_name)
+
+    def _wait_for_ttl_expire(self):
+        if TestMilvusClientEntityTTLQuery._ttl_expired:
+            return
+        log.info(f"Waiting {self.ttl_seconds + 3} seconds for data to expire...")
+        time.sleep(self.ttl_seconds + 3)
+        TestMilvusClientEntityTTLQuery._ttl_expired = True
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_query_filter_expired_entity_data(self):
+        """
+        target: test query automatically filters expired data
+        method:
+            1. Query collection with entity ttl enabled
+            2. Verify only non-expired data is returned (200 future + 100 NULL = 300)
+            3. Wait for ttl to expire
+            4. Verify only NULL data remains (100)
+        expected: Query automatically filters expired data
+        """
+        client = self._client()
+
+        # Query before expiration - should get future + NULL data (300 total)
+        res = self.query(client, self.collection_name, filter="", output_fields=["count(*)"], consistency_level=CONSISTENCY_STRONG)[0]
+        assert res[0].get('count(*)') == 300
+
+        # Wait for ttl to expire
+        self._wait_for_ttl_expire()
+
+        # Query after expiration - should only get NULL data (100)
+        res = self.query(client, self.collection_name, filter="", output_fields=["count(*)"], consistency_level=CONSISTENCY_STRONG)[0]
+        assert res[0].get('count(*)') == 100
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_query_count_expired_entity_data(self):
+        """
+        target: test count(*) aggregation excludes expired data
+        method:
+            1. Use count(*) to count records
+            2. Verify count matches non-expired data
+        expected: count(*) does not include expired data
+        """
+        client = self._client()
+
+        self._wait_for_ttl_expire()
+
+        # count(*) should match non-expired data
+        res = self.query(client, self.collection_name, filter="", output_fields=["count(*)"], consistency_level=CONSISTENCY_STRONG)[0]
+        count_result = res[0].get('count(*)')
+        assert count_result == 100  # Only NULL data remains
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_search_filter_expired_entity_data(self):
+        """
+        target: test search automatically filters expired data
+        method:
+            1. Perform vector search
+            2. Verify search results only contain non-expired data
+        expected: Search results do not include expired data
+        """
+        client = self._client()
+
+        self._wait_for_ttl_expire()
+
+        # Search
+        search_vectors = cf.gen_vectors(1, dim=self.dim)
+        res = self.search(client, self.collection_name, search_vectors, anns_field='vector',
+                         search_params={}, limit=10, consistency_level=CONSISTENCY_STRONG)[0]
+
+        # Should get results from NULL data only
+        assert len(res[0]) > 0
+        for hit in res[0]:
+            # All results should be from id >= 400 (NULL ttl data)
+            assert hit['id'] >= 400
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_query_output_entity_ttl_field(self):
+        """
+        target: test query can output ttl field values
+        method:
+            1. Query with output_fields including ttl
+            2. Verify ttl values are returned correctly
+        expected: ttl field values are returned in query results
+        """
+        client = self._client()
+
+        # Query with ttl field in output
+        res = self.query(client, self.collection_name, filter="id >= 400 and id < 405",
+                        output_fields=[default_primary_key_field_name, "ttl", "varchar_field"], consistency_level=CONSISTENCY_STRONG)[0]
+
+        assert len(res) == 5
+        for row in res:
+            assert default_primary_key_field_name in row
+            assert "ttl" in row
+            assert row["ttl"] is None  # NULL ttl data
+
+
+class TestMilvusClientEntityTTLInvalid(TestMilvusClientV2Base):
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_entity_ttl_field_nullable_false(self):
+        """
+        target: test inserting NULL to non-nullable ttl field should fail
+        method:
+            1. Create collection with ttl_field (nullable=False)
+            2. Attempt to insert data with ttl = NULL
+            3. Verify insert fails
+        expected: Insert fails when ttl is NULL and field is not nullable
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+
+        # Create schema with non-nullable ttl field
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field("ttl", DataType.TIMESTAMPTZ, nullable=False)  # Not nullable
+        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
+
+        # Create collection with ttl_field
+        properties = {"ttl_field": "ttl", "timezone": "UTC"}
+        self.create_collection(client, collection_name, schema=schema, properties=properties)
+
+        # Create index and load
+        index_params = self.prepare_index_params(client)[0]
+        index_params.add_index(field_name=default_vector_field_name, index_type="IVF_FLAT", metric_type="L2", nlist=128)
+        self.create_index(client, collection_name, index_params=index_params)
+        self.load_collection(client, collection_name)
+
+        # Attempt to insert NULL ttl - should fail
+        vectors = cf.gen_vectors(10, dim=default_dim)
+        rows = [{default_primary_key_field_name: i, "ttl": None, default_vector_field_name: list(vectors[i])} for i in range(10)]
+
+        error = {ct.err_code: 1100, ct.err_msg: "the num_rows (0) of field (ttl) is not equal to passed num_rows (10): invalid parameter[expected=10][actual=0]"}
+        self.insert(client, collection_name, rows, check_task=CheckTasks.err_res, check_items=error)
+
+        self.drop_collection(client, collection_name)
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_create_collection_entity_ttl_field_not_timestamptz(self):
+        """
+        target: test creating collection with non-Timestamptz ttl_field should fail
+        method:
+            1. Create schema with Int64 field
+            2. Attempt to create collection with ttl_field pointing to Int64 field
+            3. Verify creation fails
+        expected: Collection creation fails when ttl_field is not Timestamptz type
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+
+        # Create schema with Int64 field (not Timestamptz)
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field("int_field", DataType.INT64, nullable=True)  # Not Timestamptz
+        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
+
+        # Attempt to create collection with int_field as ttl_field - should fail
+        properties = {"ttl_field": "int_field", "timezone": "UTC"}
+
+        error = {ct.err_code: 1100, ct.err_msg: "ttl field must be timestamptz, field name = int_field: invalid parameter"}
+        self.create_collection(client, collection_name, schema=schema, properties=properties,
+                              check_task=CheckTasks.err_res, check_items=error)
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_create_collection_entity_ttl_field_nonexistent(self):
+        """
+        target: test creating collection with non-existent ttl_field should fail
+        method:
+            1. Create schema without the specified ttl field
+            2. Attempt to create collection with ttl_field pointing to non-existent field
+            3. Verify creation fails
+        expected: Collection creation fails when ttl_field does not exist
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+
+        # Create schema without ttl field
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
+
+        # Attempt to create collection with non-existent ttl_field - should fail
+        properties = {"ttl_field": "nonexistent_field", "timezone": "UTC"}
+
+        error = {ct.err_code: 1100, ct.err_msg: "ttl field name nonexistent_field not found in schema: invalid parameter"}
+        self.create_collection(client, collection_name, schema=schema, properties=properties,
+                              check_task=CheckTasks.err_res, check_items=error)
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_create_collection_both_entity_and_collection_ttl(self):
+        """
+        target: test creating collection with both ttl_field and collection.ttl.seconds should fail
+        method:
+            1. Create schema with Timestamptz field
+            2. Attempt to create collection with both ttl_field and collection.ttl.seconds
+            3. Verify creation fails with mutual exclusion error
+        expected: Collection creation fails when both TTL types are specified
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+
+        # Create schema
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field("ttl", DataType.TIMESTAMPTZ, nullable=True)
+        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
+
+        # Attempt to create collection with both TTL configs - should fail
+        properties = {
+            "ttl_field": "ttl",
+            "collection.ttl.seconds": 3600,
+            "timezone": "UTC"
+        }
+
+        error = {ct.err_code: 1100, ct.err_msg: "collection TTL and ttl field cannot be set at the same time: invalid parameter"}
+        self.create_collection(client, collection_name, schema=schema, properties=properties,
+                              check_task=CheckTasks.err_res, check_items=error)
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_alter_add_entity_ttl_with_existing_collection_ttl(self):
+        """
+        target: test adding ttl_field when collection.ttl.seconds already exists should fail
+        method:
+            1. Create collection with collection.ttl.seconds
+            2. Attempt to add ttl_field via alter
+            3. Verify alter fails
+        expected: Cannot add ttl_field when collection.ttl.seconds is set
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+
+        # Create schema
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field("ttl", DataType.TIMESTAMPTZ, nullable=True)
+        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
+
+        # Create collection with collection.ttl.seconds
+        properties = {"collection.ttl.seconds": 3600}
+        self.create_collection(client, collection_name, schema=schema, properties=properties)
+
+        # Attempt to add ttl_field - should fail
+        error = {ct.err_code: 1100, ct.err_msg: "collection TTL is already set, cannot be set ttl field: invalid parameter"}
+        self.alter_collection_properties(client, collection_name, properties={"ttl_field": "ttl"},
+                                        check_task=CheckTasks.err_res, check_items=error)
 
         self.drop_collection(client, collection_name)
 


### PR DESCRIPTION
## Summary
- Add comprehensive E2E test cases for the Entity TTL feature (#47482)
- Cover collection creation/alter with `ttl_field`, insert with future/expired/null TTL values, upsert to extend/shorten TTL, delete before expiry, release/reload behavior, and query/search filtering of expired data
- Add invalid parameter test cases: non-timestamptz field, nonexistent field, nullable=false, and conflict with collection-level TTL
- Fix existing `test_milvus_client_ttl_edge` to properly assert error on out-of-range TTL

## Test plan
- [x] All new test cases pass against a Milvus instance with entity TTL support enabled
- [x] Existing TTL test cases remain passing

issue: #47482