### PR TITLE
fix: cherry-pick #47616, #47670, #47725 to 2.6

### DIFF
--- a/internal/proxy/search_pipeline_test.go
+++ b/internal/proxy/search_pipeline_test.go
@@ -1498,6 +1498,2531 @@ func (s *SearchPipelineSuite) TestMergeIDsFunc() {
 	}
 }
 
+// Test parseOrderByFields function
+func (s *SearchPipelineSuite) TestParseOrderByFields() {
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{Name: "id", DataType: schemapb.DataType_Int64},
+			{Name: "score", DataType: schemapb.DataType_Float},
+			{Name: "name", DataType: schemapb.DataType_VarChar},
+			{Name: "active", DataType: schemapb.DataType_Bool},
+			{Name: "vector", DataType: schemapb.DataType_FloatVector},
+		},
+	}
+
+	// Test empty order_by_fields
+	params := []*commonpb.KeyValuePair{}
+	result, err := parseOrderByFields(params, schema)
+	s.NoError(err)
+	s.Nil(result)
+
+	// Test single field ascending (default)
+	params = []*commonpb.KeyValuePair{{Key: OrderByFieldsKey, Value: "score"}}
+	result, err = parseOrderByFields(params, schema)
+	s.NoError(err)
+	s.Len(result, 1)
+	s.Equal("score", result[0].FieldName)
+	s.True(result[0].Ascending)
+
+	// Test single field with explicit asc
+	params = []*commonpb.KeyValuePair{{Key: OrderByFieldsKey, Value: "score:asc"}}
+	result, err = parseOrderByFields(params, schema)
+	s.NoError(err)
+	s.Len(result, 1)
+	s.Equal("score", result[0].FieldName)
+	s.True(result[0].Ascending)
+
+	// Test single field descending
+	params = []*commonpb.KeyValuePair{{Key: OrderByFieldsKey, Value: "score:desc"}}
+	result, err = parseOrderByFields(params, schema)
+	s.NoError(err)
+	s.Len(result, 1)
+	s.Equal("score", result[0].FieldName)
+	s.False(result[0].Ascending)
+
+	// Test multiple fields
+	params = []*commonpb.KeyValuePair{{Key: OrderByFieldsKey, Value: "score:desc,name:asc,id"}}
+	result, err = parseOrderByFields(params, schema)
+	s.NoError(err)
+	s.Len(result, 3)
+	s.Equal("score", result[0].FieldName)
+	s.False(result[0].Ascending)
+	s.Equal("name", result[1].FieldName)
+	s.True(result[1].Ascending)
+	s.Equal("id", result[2].FieldName)
+	s.True(result[2].Ascending)
+
+	// Test invalid direction
+	params = []*commonpb.KeyValuePair{{Key: OrderByFieldsKey, Value: "score:invalid"}}
+	_, err = parseOrderByFields(params, schema)
+	s.Error(err)
+	s.Contains(err.Error(), "invalid order direction")
+
+	// Test non-existent field
+	params = []*commonpb.KeyValuePair{{Key: OrderByFieldsKey, Value: "nonexistent"}}
+	_, err = parseOrderByFields(params, schema)
+	s.Error(err)
+	s.Contains(err.Error(), "does not exist")
+
+	// Test unsortable type (vector)
+	params = []*commonpb.KeyValuePair{{Key: OrderByFieldsKey, Value: "vector"}}
+	_, err = parseOrderByFields(params, schema)
+	s.Error(err)
+	s.Contains(err.Error(), "unsortable type")
+
+	// Test empty field name
+	params = []*commonpb.KeyValuePair{{Key: OrderByFieldsKey, Value: ":asc"}}
+	_, err = parseOrderByFields(params, schema)
+	s.Error(err)
+	s.Contains(err.Error(), "empty field name")
+}
+
+// Test parseOrderByFields with various input formats and edge cases
+func (s *SearchPipelineSuite) TestParseOrderByFieldsEdgeCases() {
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{Name: "id", DataType: schemapb.DataType_Int64},
+			{Name: "score", DataType: schemapb.DataType_Float},
+			{Name: "name", DataType: schemapb.DataType_VarChar},
+		},
+	}
+
+	// Test whitespace handling - spaces around field name
+	params := []*commonpb.KeyValuePair{{Key: OrderByFieldsKey, Value: "  score  "}}
+	result, err := parseOrderByFields(params, schema)
+	s.NoError(err)
+	s.Len(result, 1)
+	s.Equal("score", result[0].FieldName)
+
+	// Test whitespace handling - spaces around colon
+	params = []*commonpb.KeyValuePair{{Key: OrderByFieldsKey, Value: "score : desc"}}
+	result, err = parseOrderByFields(params, schema)
+	s.NoError(err)
+	s.Len(result, 1)
+	s.Equal("score", result[0].FieldName)
+	s.False(result[0].Ascending)
+
+	// Test whitespace handling - spaces around comma
+	params = []*commonpb.KeyValuePair{{Key: OrderByFieldsKey, Value: "score:desc , name:asc"}}
+	result, err = parseOrderByFields(params, schema)
+	s.NoError(err)
+	s.Len(result, 2)
+	s.Equal("score", result[0].FieldName)
+	s.Equal("name", result[1].FieldName)
+
+	// Test case insensitivity - uppercase ASC
+	params = []*commonpb.KeyValuePair{{Key: OrderByFieldsKey, Value: "score:ASC"}}
+	result, err = parseOrderByFields(params, schema)
+	s.NoError(err)
+	s.True(result[0].Ascending)
+
+	// Test case insensitivity - uppercase DESC
+	params = []*commonpb.KeyValuePair{{Key: OrderByFieldsKey, Value: "score:DESC"}}
+	result, err = parseOrderByFields(params, schema)
+	s.NoError(err)
+	s.False(result[0].Ascending)
+
+	// Test case insensitivity - mixed case
+	params = []*commonpb.KeyValuePair{{Key: OrderByFieldsKey, Value: "score:Desc"}}
+	result, err = parseOrderByFields(params, schema)
+	s.NoError(err)
+	s.False(result[0].Ascending)
+
+	// Test "ascending" keyword
+	params = []*commonpb.KeyValuePair{{Key: OrderByFieldsKey, Value: "score:ascending"}}
+	result, err = parseOrderByFields(params, schema)
+	s.NoError(err)
+	s.True(result[0].Ascending)
+
+	// Test "descending" keyword
+	params = []*commonpb.KeyValuePair{{Key: OrderByFieldsKey, Value: "score:descending"}}
+	result, err = parseOrderByFields(params, schema)
+	s.NoError(err)
+	s.False(result[0].Ascending)
+
+	// Test empty string value
+	params = []*commonpb.KeyValuePair{{Key: OrderByFieldsKey, Value: ""}}
+	result, err = parseOrderByFields(params, schema)
+	s.NoError(err)
+	s.Nil(result)
+
+	// Test trailing comma - should skip empty part
+	params = []*commonpb.KeyValuePair{{Key: OrderByFieldsKey, Value: "score:asc,"}}
+	result, err = parseOrderByFields(params, schema)
+	s.NoError(err)
+	s.Len(result, 1)
+	s.Equal("score", result[0].FieldName)
+
+	// Test leading comma - should skip empty part
+	params = []*commonpb.KeyValuePair{{Key: OrderByFieldsKey, Value: ",score:asc"}}
+	result, err = parseOrderByFields(params, schema)
+	s.NoError(err)
+	s.Len(result, 1)
+	s.Equal("score", result[0].FieldName)
+
+	// Test multiple commas - should skip empty parts
+	params = []*commonpb.KeyValuePair{{Key: OrderByFieldsKey, Value: "score:asc,,name:desc"}}
+	result, err = parseOrderByFields(params, schema)
+	s.NoError(err)
+	s.Len(result, 2)
+
+	// Test only commas - should return nil
+	params = []*commonpb.KeyValuePair{{Key: OrderByFieldsKey, Value: ",,,"}}
+	result, err = parseOrderByFields(params, schema)
+	s.NoError(err)
+	s.Nil(result)
+
+	// Test key not present - should return nil
+	params = []*commonpb.KeyValuePair{{Key: "other_key", Value: "score:asc"}}
+	result, err = parseOrderByFields(params, schema)
+	s.NoError(err)
+	s.Nil(result)
+
+	// Test all supported sortable types
+	schemaAllTypes := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{Name: "f_bool", DataType: schemapb.DataType_Bool},
+			{Name: "f_int8", DataType: schemapb.DataType_Int8},
+			{Name: "f_int16", DataType: schemapb.DataType_Int16},
+			{Name: "f_int32", DataType: schemapb.DataType_Int32},
+			{Name: "f_int64", DataType: schemapb.DataType_Int64},
+			{Name: "f_float", DataType: schemapb.DataType_Float},
+			{Name: "f_double", DataType: schemapb.DataType_Double},
+			{Name: "f_string", DataType: schemapb.DataType_String},
+			{Name: "f_varchar", DataType: schemapb.DataType_VarChar},
+		},
+	}
+
+	// All these should be valid
+	for _, fieldName := range []string{"f_bool", "f_int8", "f_int16", "f_int32", "f_int64", "f_float", "f_double", "f_string", "f_varchar"} {
+		params = []*commonpb.KeyValuePair{{Key: OrderByFieldsKey, Value: fieldName}}
+		result, err = parseOrderByFields(params, schemaAllTypes)
+		s.NoError(err, "field %s should be sortable", fieldName)
+		s.Len(result, 1)
+		s.Equal(fieldName, result[0].FieldName)
+	}
+
+	// Test unsortable types
+	// Note: JSON without path syntax is not directly sortable; use path syntax like field["key"] instead
+	schemaUnsortable := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{Name: "f_float_vector", DataType: schemapb.DataType_FloatVector},
+			{Name: "f_binary_vector", DataType: schemapb.DataType_BinaryVector},
+			{Name: "f_array", DataType: schemapb.DataType_Array},
+			{Name: "f_json", DataType: schemapb.DataType_JSON},
+		},
+	}
+
+	for _, fieldName := range []string{"f_float_vector", "f_binary_vector", "f_array", "f_json"} {
+		params = []*commonpb.KeyValuePair{{Key: OrderByFieldsKey, Value: fieldName}}
+		_, err = parseOrderByFields(params, schemaUnsortable)
+		s.Error(err, "field %s should not be sortable", fieldName)
+		s.Contains(err.Error(), "unsortable type")
+	}
+}
+
+// Test isSortableFieldType function
+func (s *SearchPipelineSuite) TestIsSortableFieldType() {
+	// Sortable types
+	s.True(isSortableFieldType(schemapb.DataType_Bool))
+	s.True(isSortableFieldType(schemapb.DataType_Int8))
+	s.True(isSortableFieldType(schemapb.DataType_Int16))
+	s.True(isSortableFieldType(schemapb.DataType_Int32))
+	s.True(isSortableFieldType(schemapb.DataType_Int64))
+	s.True(isSortableFieldType(schemapb.DataType_Float))
+	s.True(isSortableFieldType(schemapb.DataType_Double))
+	s.True(isSortableFieldType(schemapb.DataType_String))
+	s.True(isSortableFieldType(schemapb.DataType_VarChar))
+
+	// Non-sortable types
+	// Note: JSON type requires path syntax (e.g., field["key"]) for sorting
+	s.False(isSortableFieldType(schemapb.DataType_JSON))
+	s.False(isSortableFieldType(schemapb.DataType_FloatVector))
+	s.False(isSortableFieldType(schemapb.DataType_BinaryVector))
+	s.False(isSortableFieldType(schemapb.DataType_Array))
+}
+
+// Test compareFieldDataAt function
+func (s *SearchPipelineSuite) TestCompareFieldDataAt() {
+	// Helper to call compareFieldDataAt and assert no error
+	mustCompare := func(field *schemapb.FieldData, i, j int) int {
+		cmp, err := compareFieldDataAt(field, i, j)
+		s.NoError(err)
+		return cmp
+	}
+
+	// Test Int64 comparison
+	int64Field := &schemapb.FieldData{
+		Type:      schemapb.DataType_Int64,
+		FieldName: "int64_field",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{
+					LongData: &schemapb.LongArray{Data: []int64{10, 20, 15}},
+				},
+			},
+		},
+	}
+	s.Equal(-1, mustCompare(int64Field, 0, 1)) // 10 < 20
+	s.Equal(1, mustCompare(int64Field, 1, 0))  // 20 > 10
+	s.Equal(0, mustCompare(int64Field, 0, 0))  // 10 == 10
+
+	// Test Float comparison
+	floatField := &schemapb.FieldData{
+		Type:      schemapb.DataType_Float,
+		FieldName: "float_field",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_FloatData{
+					FloatData: &schemapb.FloatArray{Data: []float32{1.5, 2.5, 1.5}},
+				},
+			},
+		},
+	}
+	s.Equal(-1, mustCompare(floatField, 0, 1)) // 1.5 < 2.5
+	s.Equal(1, mustCompare(floatField, 1, 0))  // 2.5 > 1.5
+	s.Equal(0, mustCompare(floatField, 0, 2))  // 1.5 == 1.5
+
+	// Test String comparison
+	stringField := &schemapb.FieldData{
+		Type:      schemapb.DataType_VarChar,
+		FieldName: "string_field",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_StringData{
+					StringData: &schemapb.StringArray{Data: []string{"apple", "banana", "apple"}},
+				},
+			},
+		},
+	}
+	s.Equal(-1, mustCompare(stringField, 0, 1)) // "apple" < "banana"
+	s.Equal(1, mustCompare(stringField, 1, 0))  // "banana" > "apple"
+	s.Equal(0, mustCompare(stringField, 0, 2))  // "apple" == "apple"
+
+	// Test Bool comparison (false < true)
+	boolField := &schemapb.FieldData{
+		Type:      schemapb.DataType_Bool,
+		FieldName: "bool_field",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_BoolData{
+					BoolData: &schemapb.BoolArray{Data: []bool{false, true, false}},
+				},
+			},
+		},
+	}
+	s.Equal(-1, mustCompare(boolField, 0, 1)) // false < true
+	s.Equal(1, mustCompare(boolField, 1, 0))  // true > false
+	s.Equal(0, mustCompare(boolField, 0, 2))  // false == false
+}
+
+// Test compareFieldDataAt with null handling
+func (s *SearchPipelineSuite) TestCompareFieldDataAtWithNulls() {
+	// Helper to call compareFieldDataAt and assert no error
+	mustCompare := func(field *schemapb.FieldData, i, j int) int {
+		cmp, err := compareFieldDataAt(field, i, j)
+		s.NoError(err)
+		return cmp
+	}
+
+	// Test with ValidData (nullable field)
+	nullableField := &schemapb.FieldData{
+		Type:      schemapb.DataType_Int64,
+		FieldName: "nullable_field",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{
+					LongData: &schemapb.LongArray{Data: []int64{10, 20, 30}},
+				},
+			},
+		},
+		ValidData: []bool{true, false, true}, // index 1 is null
+	}
+
+	// null vs non-null: null should be first (return -1)
+	s.Equal(-1, mustCompare(nullableField, 1, 0)) // null < 10
+	s.Equal(1, mustCompare(nullableField, 0, 1))  // 10 > null
+
+	// null vs null: equal
+	nullableField2 := &schemapb.FieldData{
+		Type:      schemapb.DataType_Int64,
+		FieldName: "nullable_field2",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{
+					LongData: &schemapb.LongArray{Data: []int64{10, 20, 30}},
+				},
+			},
+		},
+		ValidData: []bool{false, false, true}, // index 0 and 1 are null
+	}
+	s.Equal(0, mustCompare(nullableField2, 0, 1)) // null == null
+
+	// non-null vs non-null: normal comparison
+	s.Equal(-1, mustCompare(nullableField, 0, 2)) // 10 < 30
+}
+
+// Test isSameGroupByValue function
+func (s *SearchPipelineSuite) TestIsSameGroupByValue() {
+	// Test Int64
+	int64Field := &schemapb.FieldData{
+		Type: schemapb.DataType_Int64,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{
+					LongData: &schemapb.LongArray{Data: []int64{1, 1, 2, 2, 3}},
+				},
+			},
+		},
+	}
+	s.True(isSameGroupByValue(int64Field, 0, 1))  // 1 == 1
+	s.False(isSameGroupByValue(int64Field, 1, 2)) // 1 != 2
+	s.True(isSameGroupByValue(int64Field, 2, 3))  // 2 == 2
+
+	// Test String
+	stringField := &schemapb.FieldData{
+		Type: schemapb.DataType_VarChar,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_StringData{
+					StringData: &schemapb.StringArray{Data: []string{"a", "a", "b"}},
+				},
+			},
+		},
+	}
+	s.True(isSameGroupByValue(stringField, 0, 1))  // "a" == "a"
+	s.False(isSameGroupByValue(stringField, 1, 2)) // "a" != "b"
+
+	// Test Bool
+	boolField := &schemapb.FieldData{
+		Type: schemapb.DataType_Bool,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_BoolData{
+					BoolData: &schemapb.BoolArray{Data: []bool{true, true, false}},
+				},
+			},
+		},
+	}
+	s.True(isSameGroupByValue(boolField, 0, 1))  // true == true
+	s.False(isSameGroupByValue(boolField, 1, 2)) // true != false
+}
+
+// Test orderByOperator sorting
+func (s *SearchPipelineSuite) TestOrderByOperator() {
+	// Create test search result
+	result := &milvuspb.SearchResults{
+		Results: &schemapb.SearchResultData{
+			Ids: &schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{
+					IntId: &schemapb.LongArray{Data: []int64{1, 2, 3, 4}},
+				},
+			},
+			Scores: []float32{0.9, 0.8, 0.7, 0.6},
+			Topks:  []int64{4}, // nq=1, 4 results
+			FieldsData: []*schemapb.FieldData{
+				{
+					Type:      schemapb.DataType_Int64,
+					FieldName: "price",
+					Field: &schemapb.FieldData_Scalars{
+						Scalars: &schemapb.ScalarField{
+							Data: &schemapb.ScalarField_LongData{
+								LongData: &schemapb.LongArray{Data: []int64{30, 10, 40, 20}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Test ascending sort by price
+	op := &orderByOperator{
+		orderByFields: []OrderByField{
+			{FieldName: "price", Ascending: true},
+		},
+		groupByFieldId: -1,
+	}
+
+	outputs, err := op.run(context.Background(), s.span, result)
+	s.NoError(err)
+	sortedResult := outputs[0].(*milvuspb.SearchResults)
+
+	// After ascending sort by price: 10, 20, 30, 40
+	// Original order: 30(id=1), 10(id=2), 40(id=3), 20(id=4)
+	// Sorted order: 10(id=2), 20(id=4), 30(id=1), 40(id=3)
+	expectedIds := []int64{2, 4, 1, 3}
+	s.Equal(expectedIds, sortedResult.Results.Ids.GetIntId().Data)
+
+	expectedPrices := []int64{10, 20, 30, 40}
+	actualPrices := sortedResult.Results.FieldsData[0].GetScalars().GetLongData().Data
+	s.Equal(expectedPrices, actualPrices)
+}
+
+// Test orderByOperator with nq>1 (multiple queries)
+// Each query's results should be sorted independently
+func (s *SearchPipelineSuite) TestOrderByOperatorMultipleQueries() {
+	// Create test search result with nq=2, topk=3 each
+	// Query 1: ids [1,2,3] with prices [30,10,20] -> sorted: [2,3,1] with prices [10,20,30]
+	// Query 2: ids [4,5,6] with prices [60,40,50] -> sorted: [5,6,4] with prices [40,50,60]
+	result := &milvuspb.SearchResults{
+		Results: &schemapb.SearchResultData{
+			Ids: &schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{
+					IntId: &schemapb.LongArray{Data: []int64{1, 2, 3, 4, 5, 6}},
+				},
+			},
+			Scores: []float32{0.9, 0.8, 0.7, 0.6, 0.5, 0.4},
+			Topks:  []int64{3, 3}, // nq=2, each query has 3 results
+			FieldsData: []*schemapb.FieldData{
+				{
+					Type:      schemapb.DataType_Int64,
+					FieldName: "price",
+					Field: &schemapb.FieldData_Scalars{
+						Scalars: &schemapb.ScalarField{
+							Data: &schemapb.ScalarField_LongData{
+								LongData: &schemapb.LongArray{Data: []int64{30, 10, 20, 60, 40, 50}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	op := &orderByOperator{
+		orderByFields: []OrderByField{
+			{FieldName: "price", Ascending: true},
+		},
+		groupByFieldId: -1,
+	}
+
+	outputs, err := op.run(context.Background(), s.span, result)
+	s.NoError(err)
+	sortedResult := outputs[0].(*milvuspb.SearchResults)
+
+	// Each query should be sorted independently
+	// Query 1: [10,20,30] -> ids [2,3,1]
+	// Query 2: [40,50,60] -> ids [5,6,4]
+	expectedIds := []int64{2, 3, 1, 5, 6, 4}
+	s.Equal(expectedIds, sortedResult.Results.Ids.GetIntId().Data)
+
+	expectedPrices := []int64{10, 20, 30, 40, 50, 60}
+	actualPrices := sortedResult.Results.FieldsData[0].GetScalars().GetLongData().Data
+	s.Equal(expectedPrices, actualPrices)
+
+	// Verify Topks unchanged
+	s.Equal([]int64{3, 3}, sortedResult.Results.Topks)
+}
+
+// Test orderByOperator with nq>1 and group_by
+// Each query's groups should be sorted independently
+func (s *SearchPipelineSuite) TestOrderByOperatorMultipleQueriesWithGroupBy() {
+	// nq=2, each query has 2 groups with 2 results each
+	// Query 1: group A [ids 1,2], group B [ids 3,4] with prices [20,25,10,15]
+	//   -> After sort by first row price: group B (10) comes before group A (20)
+	//   -> Result: [3,4,1,2] with prices [10,15,20,25]
+	// Query 2: group C [ids 5,6], group D [ids 7,8] with prices [50,55,30,35]
+	//   -> After sort by first row price: group D (30) comes before group C (50)
+	//   -> Result: [7,8,5,6] with prices [30,35,50,55]
+	result := &milvuspb.SearchResults{
+		Results: &schemapb.SearchResultData{
+			Ids: &schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{
+					IntId: &schemapb.LongArray{Data: []int64{1, 2, 3, 4, 5, 6, 7, 8}},
+				},
+			},
+			Scores: []float32{0.9, 0.85, 0.8, 0.75, 0.7, 0.65, 0.6, 0.55},
+			Topks:  []int64{4, 4}, // nq=2, each query has 4 results (2 groups x 2)
+			GroupByFieldValue: &schemapb.FieldData{
+				Type:      schemapb.DataType_Int64,
+				FieldName: "category",
+				Field: &schemapb.FieldData_Scalars{
+					Scalars: &schemapb.ScalarField{
+						Data: &schemapb.ScalarField_LongData{
+							// Query 1: groups A(100), A(100), B(200), B(200)
+							// Query 2: groups C(300), C(300), D(400), D(400)
+							LongData: &schemapb.LongArray{Data: []int64{100, 100, 200, 200, 300, 300, 400, 400}},
+						},
+					},
+				},
+			},
+			FieldsData: []*schemapb.FieldData{
+				{
+					Type:      schemapb.DataType_Int64,
+					FieldName: "price",
+					Field: &schemapb.FieldData_Scalars{
+						Scalars: &schemapb.ScalarField{
+							Data: &schemapb.ScalarField_LongData{
+								LongData: &schemapb.LongArray{Data: []int64{20, 25, 10, 15, 50, 55, 30, 35}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	op := &orderByOperator{
+		orderByFields: []OrderByField{
+			{FieldName: "price", Ascending: true},
+		},
+		groupByFieldId: 1, // Enable group_by
+		groupSize:      2,
+	}
+
+	outputs, err := op.run(context.Background(), s.span, result)
+	s.NoError(err)
+	sortedResult := outputs[0].(*milvuspb.SearchResults)
+
+	// Query 1: group B (price 10) before group A (price 20) -> [3,4,1,2]
+	// Query 2: group D (price 30) before group C (price 50) -> [7,8,5,6]
+	expectedIds := []int64{3, 4, 1, 2, 7, 8, 5, 6}
+	s.Equal(expectedIds, sortedResult.Results.Ids.GetIntId().Data)
+
+	expectedPrices := []int64{10, 15, 20, 25, 30, 35, 50, 55}
+	actualPrices := sortedResult.Results.FieldsData[0].GetScalars().GetLongData().Data
+	s.Equal(expectedPrices, actualPrices)
+}
+
+// Test orderByOperator with descending sort
+func (s *SearchPipelineSuite) TestOrderByOperatorDescending() {
+	result := &milvuspb.SearchResults{
+		Results: &schemapb.SearchResultData{
+			Ids: &schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{
+					IntId: &schemapb.LongArray{Data: []int64{1, 2, 3, 4}},
+				},
+			},
+			Scores: []float32{0.9, 0.8, 0.7, 0.6},
+			Topks:  []int64{4},
+			FieldsData: []*schemapb.FieldData{
+				{
+					Type:      schemapb.DataType_Int64,
+					FieldName: "price",
+					Field: &schemapb.FieldData_Scalars{
+						Scalars: &schemapb.ScalarField{
+							Data: &schemapb.ScalarField_LongData{
+								LongData: &schemapb.LongArray{Data: []int64{30, 10, 40, 20}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	op := &orderByOperator{
+		orderByFields: []OrderByField{
+			{FieldName: "price", Ascending: false},
+		},
+		groupByFieldId: -1,
+	}
+
+	outputs, err := op.run(context.Background(), s.span, result)
+	s.NoError(err)
+	sortedResult := outputs[0].(*milvuspb.SearchResults)
+
+	// After descending sort by price: 40, 30, 20, 10
+	expectedIds := []int64{3, 1, 4, 2}
+	s.Equal(expectedIds, sortedResult.Results.Ids.GetIntId().Data)
+}
+
+// Test orderByOperator validates missing fields
+func (s *SearchPipelineSuite) TestOrderByOperatorMissingField() {
+	result := &milvuspb.SearchResults{
+		Results: &schemapb.SearchResultData{
+			Ids: &schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{
+					IntId: &schemapb.LongArray{Data: []int64{1, 2}},
+				},
+			},
+			Scores:     []float32{0.9, 0.8},
+			FieldsData: []*schemapb.FieldData{},
+		},
+	}
+
+	op := &orderByOperator{
+		orderByFields: []OrderByField{
+			{FieldName: "nonexistent", Ascending: true},
+		},
+		groupByFieldId: -1,
+	}
+
+	_, err := op.run(context.Background(), s.span, result)
+	s.Error(err)
+	s.Contains(err.Error(), "not found")
+}
+
+// Test orderByOperator with empty results
+func (s *SearchPipelineSuite) TestOrderByOperatorEmptyResults() {
+	result := &milvuspb.SearchResults{
+		Results: &schemapb.SearchResultData{
+			Ids:        nil,
+			Scores:     []float32{},
+			FieldsData: []*schemapb.FieldData{},
+		},
+	}
+
+	op := &orderByOperator{
+		orderByFields: []OrderByField{
+			{FieldName: "price", Ascending: true},
+		},
+		groupByFieldId: -1,
+	}
+
+	outputs, err := op.run(context.Background(), s.span, result)
+	s.NoError(err)
+	s.NotNil(outputs)
+}
+
+// Test orderByOperator with no order_by fields (passthrough)
+func (s *SearchPipelineSuite) TestOrderByOperatorNoOrderBy() {
+	result := &milvuspb.SearchResults{
+		Results: &schemapb.SearchResultData{
+			Ids: &schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{
+					IntId: &schemapb.LongArray{Data: []int64{1, 2, 3}},
+				},
+			},
+			Scores: []float32{0.9, 0.8, 0.7},
+		},
+	}
+
+	op := &orderByOperator{
+		orderByFields:  []OrderByField{},
+		groupByFieldId: -1,
+	}
+
+	outputs, err := op.run(context.Background(), s.span, result)
+	s.NoError(err)
+	sortedResult := outputs[0].(*milvuspb.SearchResults)
+
+	// Should be unchanged
+	s.Equal([]int64{1, 2, 3}, sortedResult.Results.Ids.GetIntId().Data)
+}
+
+// Test orderByOperator with group_by - critical test for sortGroupsByOrderByFields
+func (s *SearchPipelineSuite) TestOrderByOperatorWithGroupBy() {
+	// Create result with GroupByFieldValue where groups have varying sizes
+	// Group 1: ids [1,2] with group value "A", prices [30, 25]
+	// Group 2: ids [3] with group value "B", price [10]
+	// Group 3: ids [4,5,6] with group value "C", prices [20, 15, 18]
+	// After order_by price:asc (by first row in each group), groups should be ordered: B(10), C(20), A(30)
+	// Final order: [3, 4, 5, 6, 1, 2]
+	result := &milvuspb.SearchResults{
+		Results: &schemapb.SearchResultData{
+			Ids: &schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{
+					IntId: &schemapb.LongArray{Data: []int64{1, 2, 3, 4, 5, 6}},
+				},
+			},
+			Scores: []float32{0.9, 0.85, 0.8, 0.75, 0.7, 0.65},
+			Topks:  []int64{6},
+			FieldsData: []*schemapb.FieldData{
+				{
+					Type:      schemapb.DataType_Int64,
+					FieldName: "price",
+					Field: &schemapb.FieldData_Scalars{
+						Scalars: &schemapb.ScalarField{
+							Data: &schemapb.ScalarField_LongData{
+								LongData: &schemapb.LongArray{Data: []int64{30, 25, 10, 20, 15, 18}},
+							},
+						},
+					},
+				},
+			},
+			// GroupByFieldValue indicates group membership
+			// "A", "A", "B", "C", "C", "C"
+			GroupByFieldValue: &schemapb.FieldData{
+				Type: schemapb.DataType_VarChar,
+				Field: &schemapb.FieldData_Scalars{
+					Scalars: &schemapb.ScalarField{
+						Data: &schemapb.ScalarField_StringData{
+							StringData: &schemapb.StringArray{Data: []string{"A", "A", "B", "C", "C", "C"}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	op := &orderByOperator{
+		orderByFields: []OrderByField{
+			{FieldName: "price", Ascending: true},
+		},
+		groupByFieldId: 100, // Any value >= 0 indicates group_by mode
+		groupSize:      3,
+	}
+
+	outputs, err := op.run(context.Background(), s.span, result)
+	s.NoError(err)
+	sortedResult := outputs[0].(*milvuspb.SearchResults)
+
+	// After sorting by first row's price in each group:
+	// Group B (price=10) -> Group C (price=20) -> Group A (price=30)
+	// Final order: [3, 4, 5, 6, 1, 2]
+	expectedIds := []int64{3, 4, 5, 6, 1, 2}
+	s.Equal(expectedIds, sortedResult.Results.Ids.GetIntId().Data)
+
+	// Verify group by values are also reordered correctly
+	expectedGroupValues := []string{"B", "C", "C", "C", "A", "A"}
+	actualGroupValues := sortedResult.Results.GroupByFieldValue.GetScalars().GetStringData().Data
+	s.Equal(expectedGroupValues, actualGroupValues)
+}
+
+// Test orderByOperator with multiple sort fields (tie-breaking)
+func (s *SearchPipelineSuite) TestOrderByOperatorMultiField() {
+	// Test tie-breaking: sort by category:asc, then by price:desc
+	// Same category should be ordered by price descending
+	result := &milvuspb.SearchResults{
+		Results: &schemapb.SearchResultData{
+			Ids: &schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{
+					IntId: &schemapb.LongArray{Data: []int64{1, 2, 3, 4, 5}},
+				},
+			},
+			Scores: []float32{0.9, 0.8, 0.7, 0.6, 0.5},
+			Topks:  []int64{5},
+			FieldsData: []*schemapb.FieldData{
+				{
+					Type:      schemapb.DataType_VarChar,
+					FieldName: "category",
+					Field: &schemapb.FieldData_Scalars{
+						Scalars: &schemapb.ScalarField{
+							Data: &schemapb.ScalarField_StringData{
+								StringData: &schemapb.StringArray{Data: []string{"B", "A", "B", "A", "A"}},
+							},
+						},
+					},
+				},
+				{
+					Type:      schemapb.DataType_Int64,
+					FieldName: "price",
+					Field: &schemapb.FieldData_Scalars{
+						Scalars: &schemapb.ScalarField{
+							Data: &schemapb.ScalarField_LongData{
+								LongData: &schemapb.LongArray{Data: []int64{100, 200, 150, 50, 300}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	op := &orderByOperator{
+		orderByFields: []OrderByField{
+			{FieldName: "category", Ascending: true}, // First sort by category asc
+			{FieldName: "price", Ascending: false},   // Then by price desc
+		},
+		groupByFieldId: -1,
+	}
+
+	outputs, err := op.run(context.Background(), s.span, result)
+	s.NoError(err)
+	sortedResult := outputs[0].(*milvuspb.SearchResults)
+
+	// Category A: ids 2(200), 4(50), 5(300) -> sorted by price desc: 5(300), 2(200), 4(50)
+	// Category B: ids 1(100), 3(150) -> sorted by price desc: 3(150), 1(100)
+	// Final order: A first (5, 2, 4), then B (3, 1)
+	expectedIds := []int64{5, 2, 4, 3, 1}
+	s.Equal(expectedIds, sortedResult.Results.Ids.GetIntId().Data)
+
+	// Verify categories are in order
+	expectedCategories := []string{"A", "A", "A", "B", "B"}
+	actualCategories := sortedResult.Results.FieldsData[0].GetScalars().GetStringData().Data
+	s.Equal(expectedCategories, actualCategories)
+
+	// Verify prices within each category are descending
+	expectedPrices := []int64{300, 200, 50, 150, 100}
+	actualPrices := sortedResult.Results.FieldsData[1].GetScalars().GetLongData().Data
+	s.Equal(expectedPrices, actualPrices)
+}
+
+// Test orderByOperator with string IDs
+func (s *SearchPipelineSuite) TestOrderByOperatorStringIds() {
+	result := &milvuspb.SearchResults{
+		Results: &schemapb.SearchResultData{
+			Ids: &schemapb.IDs{
+				IdField: &schemapb.IDs_StrId{
+					StrId: &schemapb.StringArray{Data: []string{"id_a", "id_b", "id_c", "id_d"}},
+				},
+			},
+			Scores: []float32{0.9, 0.8, 0.7, 0.6},
+			Topks:  []int64{4},
+			FieldsData: []*schemapb.FieldData{
+				{
+					Type:      schemapb.DataType_Int64,
+					FieldName: "priority",
+					Field: &schemapb.FieldData_Scalars{
+						Scalars: &schemapb.ScalarField{
+							Data: &schemapb.ScalarField_LongData{
+								LongData: &schemapb.LongArray{Data: []int64{3, 1, 4, 2}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	op := &orderByOperator{
+		orderByFields: []OrderByField{
+			{FieldName: "priority", Ascending: true},
+		},
+		groupByFieldId: -1,
+	}
+
+	outputs, err := op.run(context.Background(), s.span, result)
+	s.NoError(err)
+	sortedResult := outputs[0].(*milvuspb.SearchResults)
+
+	// After sorting by priority asc: 1, 2, 3, 4
+	// Original: id_a(3), id_b(1), id_c(4), id_d(2)
+	// Sorted: id_b(1), id_d(2), id_a(3), id_c(4)
+	expectedIds := []string{"id_b", "id_d", "id_a", "id_c"}
+	s.Equal(expectedIds, sortedResult.Results.Ids.GetStrId().Data)
+
+	// Verify scores are also reordered
+	expectedScores := []float32{0.8, 0.6, 0.9, 0.7}
+	s.Equal(expectedScores, sortedResult.Results.Scores)
+}
+
+// Test JSON field comparison (byte-level ordering)
+func (s *SearchPipelineSuite) TestCompareFieldDataAtJSON() {
+	jsonField := &schemapb.FieldData{
+		Type:      schemapb.DataType_JSON,
+		FieldName: "metadata",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_JsonData{
+					JsonData: &schemapb.JSONArray{Data: [][]byte{
+						[]byte(`{"a": 2}`),
+						[]byte(`{"a": 10}`),
+						[]byte(`{"b": 1}`),
+					}},
+				},
+			},
+		},
+	}
+
+	// JSON comparison is byte-level, so "2" > "1" (comparing '2' vs '1' in "10")
+	// This tests the documented behavior that JSON sorting is lexicographic
+	cmp, err := compareFieldDataAt(jsonField, 0, 1)
+	s.NoError(err)
+	s.Greater(cmp, 0) // {"a": 2} > {"a": 10} in byte comparison because '2' > '1'
+
+	// Different keys
+	cmp, err = compareFieldDataAt(jsonField, 0, 2)
+	s.NoError(err)
+	s.Less(cmp, 0) // {"a": ...} < {"b": ...} because 'a' < 'b'
+}
+
+// Test vector field reordering (FloatVector)
+func (s *SearchPipelineSuite) TestReorderFieldDataFloatVector() {
+	dim := 4
+	// 3 vectors, each with dim=4
+	vectorField := &schemapb.FieldData{
+		Type:      schemapb.DataType_FloatVector,
+		FieldName: "embedding",
+		Field: &schemapb.FieldData_Vectors{
+			Vectors: &schemapb.VectorField{
+				Dim: int64(dim),
+				Data: &schemapb.VectorField_FloatVector{
+					FloatVector: &schemapb.FloatArray{
+						Data: []float32{
+							1.0, 1.1, 1.2, 1.3, // vector 0
+							2.0, 2.1, 2.2, 2.3, // vector 1
+							3.0, 3.1, 3.2, 3.3, // vector 2
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Reorder: [2, 0, 1]
+	indices := []int{2, 0, 1}
+	err := reorderFieldData(vectorField, indices)
+	s.NoError(err)
+
+	expectedData := []float32{
+		3.0, 3.1, 3.2, 3.3, // was vector 2
+		1.0, 1.1, 1.2, 1.3, // was vector 0
+		2.0, 2.1, 2.2, 2.3, // was vector 1
+	}
+	actualData := vectorField.GetVectors().GetFloatVector().GetData()
+	s.Equal(expectedData, actualData)
+}
+
+// Test Double comparison in compareFieldDataAt
+func (s *SearchPipelineSuite) TestCompareFieldDataAtDouble() {
+	mustCompare := func(field *schemapb.FieldData, i, j int) int {
+		cmp, err := compareFieldDataAt(field, i, j)
+		s.NoError(err)
+		return cmp
+	}
+
+	doubleField := &schemapb.FieldData{
+		Type:      schemapb.DataType_Double,
+		FieldName: "score",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_DoubleData{
+					DoubleData: &schemapb.DoubleArray{Data: []float64{1.5, 2.5, 1.5}},
+				},
+			},
+		},
+	}
+	s.Equal(-1, mustCompare(doubleField, 0, 1)) // 1.5 < 2.5
+	s.Equal(1, mustCompare(doubleField, 1, 0))  // 2.5 > 1.5
+	s.Equal(0, mustCompare(doubleField, 0, 2))  // 1.5 == 1.5
+}
+
+// Test Int32 comparison in compareFieldDataAt
+func (s *SearchPipelineSuite) TestCompareFieldDataAtInt32() {
+	mustCompare := func(field *schemapb.FieldData, i, j int) int {
+		cmp, err := compareFieldDataAt(field, i, j)
+		s.NoError(err)
+		return cmp
+	}
+
+	int32Field := &schemapb.FieldData{
+		Type:      schemapb.DataType_Int32,
+		FieldName: "count",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_IntData{
+					IntData: &schemapb.IntArray{Data: []int32{10, 20, 10}},
+				},
+			},
+		},
+	}
+	s.Equal(-1, mustCompare(int32Field, 0, 1)) // 10 < 20
+	s.Equal(1, mustCompare(int32Field, 1, 0))  // 20 > 10
+	s.Equal(0, mustCompare(int32Field, 0, 2))  // 10 == 10
+}
+
+// Test extractJSONValue function
+func (s *SearchPipelineSuite) TestExtractJSONValue() {
+	jsonData := []byte(`{"price": 99.99, "name": "product", "active": true, "count": 42}`)
+
+	// Extract number
+	result := extractJSONValue(jsonData, "/price")
+	s.True(result.Exists())
+	s.Equal(99.99, result.Float())
+
+	// Extract string
+	result = extractJSONValue(jsonData, "/name")
+	s.True(result.Exists())
+	s.Equal("product", result.String())
+
+	// Extract boolean
+	result = extractJSONValue(jsonData, "/active")
+	s.True(result.Exists())
+	s.True(result.Bool())
+
+	// Extract integer
+	result = extractJSONValue(jsonData, "/count")
+	s.True(result.Exists())
+	s.Equal(int64(42), result.Int())
+
+	// Non-existent path
+	result = extractJSONValue(jsonData, "/nonexistent")
+	s.False(result.Exists())
+
+	// Empty path returns empty result
+	result = extractJSONValue(jsonData, "")
+	s.False(result.Exists())
+
+	// Nested path
+	nestedJSON := []byte(`{"user": {"profile": {"age": 30}}}`)
+	result = extractJSONValue(nestedJSON, "/user/profile/age")
+	s.True(result.Exists())
+	s.Equal(int64(30), result.Int())
+
+	// Key with literal slash (escaped as ~1 in JSON Pointer)
+	jsonWithSlash := []byte(`{"key/with/slash": 100}`)
+	result = extractJSONValue(jsonWithSlash, "/key~1with~1slash")
+	s.True(result.Exists())
+	s.Equal(int64(100), result.Int())
+
+	// Key with literal tilde (escaped as ~0 in JSON Pointer)
+	jsonWithTilde := []byte(`{"key~tilde": 200}`)
+	result = extractJSONValue(jsonWithTilde, "/key~0tilde")
+	s.True(result.Exists())
+	s.Equal(int64(200), result.Int())
+
+	// Key with dot (should be escaped for gjson)
+	jsonWithDot := []byte(`{"key.with.dot": 300}`)
+	result = extractJSONValue(jsonWithDot, "/key.with.dot")
+	s.True(result.Exists())
+	s.Equal(int64(300), result.Int())
+}
+
+// Test compareJSONValues function
+func (s *SearchPipelineSuite) TestCompareJSONValues() {
+	// Number comparison
+	a := extractJSONValue([]byte(`{"v": 10}`), "/v")
+	b := extractJSONValue([]byte(`{"v": 20}`), "/v")
+	s.Equal(-1, compareJSONValues(a, b)) // 10 < 20
+	s.Equal(1, compareJSONValues(b, a))  // 20 > 10
+	s.Equal(0, compareJSONValues(a, a))  // 10 == 10
+
+	// String comparison
+	a = extractJSONValue([]byte(`{"v": "apple"}`), "/v")
+	b = extractJSONValue([]byte(`{"v": "banana"}`), "/v")
+	s.Equal(-1, compareJSONValues(a, b)) // "apple" < "banana"
+	s.Equal(1, compareJSONValues(b, a))  // "banana" > "apple"
+
+	// Boolean comparison (false < true)
+	a = extractJSONValue([]byte(`{"v": false}`), "/v")
+	b = extractJSONValue([]byte(`{"v": true}`), "/v")
+	s.Equal(-1, compareJSONValues(a, b)) // false < true
+	s.Equal(1, compareJSONValues(b, a))  // true > false
+
+	// Non-existent values (nulls first)
+	a = extractJSONValue([]byte(`{}`), "/v")
+	b = extractJSONValue([]byte(`{"v": 10}`), "/v")
+	s.Equal(-1, compareJSONValues(a, b)) // null < 10
+	s.Equal(1, compareJSONValues(b, a))  // 10 > null
+
+	// Both non-existent
+	a = extractJSONValue([]byte(`{}`), "/v")
+	b = extractJSONValue([]byte(`{}`), "/v")
+	s.Equal(0, compareJSONValues(a, b)) // null == null
+
+	// Explicit JSON null value (type gjson.Null)
+	a = extractJSONValue([]byte(`{"v": null}`), "/v")
+	b = extractJSONValue([]byte(`{"v": 10}`), "/v")
+	s.Equal(-1, compareJSONValues(a, b)) // null < 10
+	s.Equal(1, compareJSONValues(b, a))  // 10 > null
+
+	// Both explicit null
+	a = extractJSONValue([]byte(`{"v": null}`), "/v")
+	b = extractJSONValue([]byte(`{"v": null}`), "/v")
+	s.Equal(0, compareJSONValues(a, b)) // null == null
+
+	// Explicit null vs non-existent (both treated as null)
+	a = extractJSONValue([]byte(`{"v": null}`), "/v")
+	b = extractJSONValue([]byte(`{}`), "/v")
+	s.Equal(0, compareJSONValues(a, b)) // null == null
+}
+
+// Test orderByOperator with JSON subfield path
+func (s *SearchPipelineSuite) TestOrderByOperatorWithJSONPath() {
+	// Create result with JSON field containing nested data
+	result := &milvuspb.SearchResults{
+		Results: &schemapb.SearchResultData{
+			Ids: &schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{
+					IntId: &schemapb.LongArray{Data: []int64{1, 2, 3, 4}},
+				},
+			},
+			Scores: []float32{0.9, 0.8, 0.7, 0.6},
+			Topks:  []int64{4},
+			FieldsData: []*schemapb.FieldData{
+				{
+					Type:      schemapb.DataType_JSON,
+					FieldName: "metadata",
+					Field: &schemapb.FieldData_Scalars{
+						Scalars: &schemapb.ScalarField{
+							Data: &schemapb.ScalarField_JsonData{
+								JsonData: &schemapb.JSONArray{Data: [][]byte{
+									[]byte(`{"price": 30, "category": "A"}`),
+									[]byte(`{"price": 10, "category": "B"}`),
+									[]byte(`{"price": 40, "category": "A"}`),
+									[]byte(`{"price": 20, "category": "B"}`),
+								}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Sort by metadata["price"] ascending
+	op := &orderByOperator{
+		orderByFields: []OrderByField{
+			{FieldName: "metadata", FieldID: 100, JSONPath: "/price", Ascending: true},
+		},
+		groupByFieldId: -1,
+	}
+
+	outputs, err := op.run(context.Background(), s.span, result)
+	s.NoError(err)
+	sortedResult := outputs[0].(*milvuspb.SearchResults)
+
+	// After ascending sort by price: 10, 20, 30, 40
+	// Original order: 30(id=1), 10(id=2), 40(id=3), 20(id=4)
+	// Sorted order: 10(id=2), 20(id=4), 30(id=1), 40(id=3)
+	expectedIds := []int64{2, 4, 1, 3}
+	s.Equal(expectedIds, sortedResult.Results.Ids.GetIntId().Data)
+}
+
+// Test orderByOperator with JSON path - descending order
+func (s *SearchPipelineSuite) TestOrderByOperatorWithJSONPathDescending() {
+	result := &milvuspb.SearchResults{
+		Results: &schemapb.SearchResultData{
+			Ids: &schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{
+					IntId: &schemapb.LongArray{Data: []int64{1, 2, 3}},
+				},
+			},
+			Scores: []float32{0.9, 0.8, 0.7},
+			Topks:  []int64{3},
+			FieldsData: []*schemapb.FieldData{
+				{
+					Type:      schemapb.DataType_JSON,
+					FieldName: "data",
+					Field: &schemapb.FieldData_Scalars{
+						Scalars: &schemapb.ScalarField{
+							Data: &schemapb.ScalarField_JsonData{
+								JsonData: &schemapb.JSONArray{Data: [][]byte{
+									[]byte(`{"score": 100}`),
+									[]byte(`{"score": 300}`),
+									[]byte(`{"score": 200}`),
+								}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	op := &orderByOperator{
+		orderByFields: []OrderByField{
+			{FieldName: "data", FieldID: 100, JSONPath: "/score", Ascending: false},
+		},
+		groupByFieldId: -1,
+	}
+
+	outputs, err := op.run(context.Background(), s.span, result)
+	s.NoError(err)
+	sortedResult := outputs[0].(*milvuspb.SearchResults)
+
+	// After descending sort: 300, 200, 100
+	// Original: 100(id=1), 300(id=2), 200(id=3)
+	// Sorted: 300(id=2), 200(id=3), 100(id=1)
+	expectedIds := []int64{2, 3, 1}
+	s.Equal(expectedIds, sortedResult.Results.Ids.GetIntId().Data)
+}
+
+// Test orderByOperator with missing JSON path values (nulls first)
+func (s *SearchPipelineSuite) TestOrderByOperatorWithMissingJSONPath() {
+	result := &milvuspb.SearchResults{
+		Results: &schemapb.SearchResultData{
+			Ids: &schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{
+					IntId: &schemapb.LongArray{Data: []int64{1, 2, 3, 4}},
+				},
+			},
+			Scores: []float32{0.9, 0.8, 0.7, 0.6},
+			Topks:  []int64{4},
+			FieldsData: []*schemapb.FieldData{
+				{
+					Type:      schemapb.DataType_JSON,
+					FieldName: "metadata",
+					Field: &schemapb.FieldData_Scalars{
+						Scalars: &schemapb.ScalarField{
+							Data: &schemapb.ScalarField_JsonData{
+								JsonData: &schemapb.JSONArray{Data: [][]byte{
+									[]byte(`{"price": 30}`),
+									[]byte(`{}`), // missing price - should sort first
+									[]byte(`{"price": 10}`),
+									[]byte(`{"other": 99}`), // missing price - should sort first
+								}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	op := &orderByOperator{
+		orderByFields: []OrderByField{
+			{FieldName: "metadata", FieldID: 100, JSONPath: "/price", Ascending: true},
+		},
+		groupByFieldId: -1,
+	}
+
+	outputs, err := op.run(context.Background(), s.span, result)
+	s.NoError(err)
+	sortedResult := outputs[0].(*milvuspb.SearchResults)
+
+	// Nulls first, then ascending: null, null, 10, 30
+	// IDs with missing price (2, 4) should come first, then 3(10), 1(30)
+	// Note: stable sort preserves relative order of equal elements
+	resultIds := sortedResult.Results.Ids.GetIntId().Data
+	// First two should be the ones with missing price (2 and 4)
+	s.Contains([]int64{2, 4}, resultIds[0])
+	s.Contains([]int64{2, 4}, resultIds[1])
+	// Last two should be 3(10) and 1(30) in that order
+	s.Equal(int64(3), resultIds[2])
+	s.Equal(int64(1), resultIds[3])
+}
+
+// Test parseOrderByFields with JSON path syntax
+func (s *SearchPipelineSuite) TestParseOrderByFieldsWithJSONPath() {
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64},
+			{FieldID: 101, Name: "metadata", DataType: schemapb.DataType_JSON},
+			{FieldID: 102, Name: "score", DataType: schemapb.DataType_Float},
+		},
+	}
+
+	// Test JSON path with ascending
+	params := []*commonpb.KeyValuePair{{Key: OrderByFieldsKey, Value: `metadata["price"]:asc`}}
+	result, err := parseOrderByFields(params, schema)
+	s.NoError(err)
+	s.Len(result, 1)
+	s.Equal("metadata", result[0].FieldName)
+	s.Equal(int64(101), result[0].FieldID)
+	s.Equal("/price", result[0].JSONPath)
+	s.True(result[0].Ascending)
+	s.Equal("metadata", result[0].OutputFieldName) // Regular JSON: request whole field
+	s.False(result[0].IsDynamicField)              // Not a dynamic field
+
+	// Test JSON path with descending
+	params = []*commonpb.KeyValuePair{{Key: OrderByFieldsKey, Value: `metadata["rating"]:desc`}}
+	result, err = parseOrderByFields(params, schema)
+	s.NoError(err)
+	s.Len(result, 1)
+	s.Equal("metadata", result[0].FieldName)
+	s.Equal("/rating", result[0].JSONPath)
+	s.False(result[0].Ascending)
+	s.Equal("metadata", result[0].OutputFieldName) // Regular JSON: request whole field
+	s.False(result[0].IsDynamicField)
+
+	// Test mixed: regular field + JSON path
+	params = []*commonpb.KeyValuePair{{Key: OrderByFieldsKey, Value: `score:desc,metadata["price"]:asc`}}
+	result, err = parseOrderByFields(params, schema)
+	s.NoError(err)
+	s.Len(result, 2)
+	// First field: regular
+	s.Equal("score", result[0].FieldName)
+	s.Equal("", result[0].JSONPath)
+	s.False(result[0].Ascending)
+	// Second field: JSON path
+	s.Equal("metadata", result[1].FieldName)
+	s.Equal("/price", result[1].JSONPath)
+	s.True(result[1].Ascending)
+
+	// Test nested JSON path
+	params = []*commonpb.KeyValuePair{{Key: OrderByFieldsKey, Value: `metadata["user"]["age"]:asc`}}
+	result, err = parseOrderByFields(params, schema)
+	s.NoError(err)
+	s.Len(result, 1)
+	s.Equal("metadata", result[0].FieldName)
+	s.Equal("/user/age", result[0].JSONPath)
+}
+
+// Test parseOrderByFields with dynamic fields
+func (s *SearchPipelineSuite) TestParseOrderByFieldsWithDynamicField() {
+	schema := &schemapb.CollectionSchema{
+		EnableDynamicField: true,
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64},
+			{FieldID: 101, Name: "vector", DataType: schemapb.DataType_FloatVector},
+			{FieldID: 102, Name: "$meta", DataType: schemapb.DataType_JSON, IsDynamic: true},
+		},
+	}
+
+	// Test dynamic field key without brackets (age -> $meta["age"])
+	params := []*commonpb.KeyValuePair{{Key: OrderByFieldsKey, Value: "age:asc"}}
+	result, err := parseOrderByFields(params, schema)
+	s.NoError(err)
+	s.Len(result, 1)
+	s.Equal("$meta", result[0].FieldName)
+	s.Equal(int64(102), result[0].FieldID)
+	s.Equal("/age", result[0].JSONPath)
+	s.True(result[0].Ascending)
+	s.Equal("age", result[0].OutputFieldName) // Dynamic field: use original key for requery
+	s.True(result[0].IsDynamicField)          // Is a dynamic field - QueryNode extracts subfield
+
+	// Test dynamic field with explicit path
+	params = []*commonpb.KeyValuePair{{Key: OrderByFieldsKey, Value: `$meta["category"]:desc`}}
+	result, err = parseOrderByFields(params, schema)
+	s.NoError(err)
+	s.Len(result, 1)
+	s.Equal("$meta", result[0].FieldName)
+	s.Equal("/category", result[0].JSONPath)
+	s.False(result[0].Ascending)
+	s.Equal(`$meta["category"]`, result[0].OutputFieldName) // Explicit path for requery
+	s.True(result[0].IsDynamicField)
+
+	// Test unknown field with brackets treated as dynamic (e.g., dyn_meta["price"])
+	// outputFieldName should be baseName ("dyn_meta"), NOT fieldSpec ("dyn_meta[\"price\"]"),
+	// because the output field parser would reject multi-level dynamic paths like $meta["dyn_meta"]["price"].
+	params = []*commonpb.KeyValuePair{{Key: OrderByFieldsKey, Value: `dyn_meta["price"]:asc`}}
+	result, err = parseOrderByFields(params, schema)
+	s.NoError(err)
+	s.Len(result, 1)
+	s.Equal("$meta", result[0].FieldName)
+	s.Equal("/dyn_meta/price", result[0].JSONPath)
+	s.True(result[0].Ascending)
+	s.Equal("dyn_meta", result[0].OutputFieldName) // Base name only; full path would cause multi-level rejection
+	s.True(result[0].IsDynamicField)
+}
+
+// Test splitOrderByFieldAndDirection helper
+func (s *SearchPipelineSuite) TestSplitOrderByFieldAndDirection() {
+	// Simple field
+	field, dir := splitOrderByFieldAndDirection("name:asc")
+	s.Equal("name", field)
+	s.Equal("asc", dir)
+
+	// Field without direction
+	field, dir = splitOrderByFieldAndDirection("name")
+	s.Equal("name", field)
+	s.Equal("", dir)
+
+	// JSON path with direction
+	field, dir = splitOrderByFieldAndDirection(`metadata["price"]:desc`)
+	s.Equal(`metadata["price"]`, field)
+	s.Equal("desc", dir)
+
+	// JSON path without direction
+	field, dir = splitOrderByFieldAndDirection(`metadata["price"]`)
+	s.Equal(`metadata["price"]`, field)
+	s.Equal("", dir)
+
+	// Nested JSON path with direction
+	field, dir = splitOrderByFieldAndDirection(`data["user"]["age"]:asc`)
+	s.Equal(`data["user"]["age"]`, field)
+	s.Equal("asc", dir)
+
+	// JSON path with colon in value (edge case - not typical but should handle)
+	field, dir = splitOrderByFieldAndDirection(`metadata["key:with:colons"]:desc`)
+	s.Equal(`metadata["key:with:colons"]`, field)
+	s.Equal("desc", dir)
+}
+
+// Test jsonPointerToGjsonPath conversion
+func (s *SearchPipelineSuite) TestJSONPointerToGjsonPath() {
+	// Simple path
+	s.Equal("price", jsonPointerToGjsonPath("/price"))
+
+	// Nested path
+	s.Equal("user.profile.age", jsonPointerToGjsonPath("/user/profile/age"))
+
+	// Key with literal slash (escaped as ~1)
+	s.Equal("key/with/slash", jsonPointerToGjsonPath("/key~1with~1slash"))
+
+	// Key with literal tilde (escaped as ~0)
+	s.Equal("key~tilde", jsonPointerToGjsonPath("/key~0tilde"))
+
+	// Key with dot (escaped for gjson)
+	s.Equal(`key\.with\.dot`, jsonPointerToGjsonPath("/key.with.dot"))
+
+	// Combined: nested path with special characters
+	s.Equal(`user.profile\.v2.score`, jsonPointerToGjsonPath("/user/profile.v2/score"))
+
+	// Empty path
+	s.Equal("", jsonPointerToGjsonPath(""))
+	s.Equal("", jsonPointerToGjsonPath("/"))
+
+	// Path without leading slash
+	s.Equal("price", jsonPointerToGjsonPath("price"))
+}
+
+// Test parseOrderByFields error cases for better coverage
+func (s *SearchPipelineSuite) TestParseOrderByFieldsErrors() {
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64},
+			{FieldID: 101, Name: "vector", DataType: schemapb.DataType_FloatVector},
+			{FieldID: 102, Name: "score", DataType: schemapb.DataType_Float},
+			{FieldID: 103, Name: "metadata", DataType: schemapb.DataType_JSON},
+		},
+	}
+
+	// Test invalid direction
+	params := []*commonpb.KeyValuePair{{Key: OrderByFieldsKey, Value: "score:invalid"}}
+	_, err := parseOrderByFields(params, schema)
+	s.Error(err)
+	s.Contains(err.Error(), "invalid order direction")
+
+	// Test non-JSON field with brackets
+	params = []*commonpb.KeyValuePair{{Key: OrderByFieldsKey, Value: `score["key"]:asc`}}
+	_, err = parseOrderByFields(params, schema)
+	s.Error(err)
+	s.Contains(err.Error(), "not a JSON type")
+
+	// Test unknown field with brackets and no dynamic field
+	params = []*commonpb.KeyValuePair{{Key: OrderByFieldsKey, Value: `unknown["key"]:asc`}}
+	_, err = parseOrderByFields(params, schema)
+	s.Error(err)
+	s.Contains(err.Error(), "not found")
+
+	// Test unknown field without brackets and no dynamic field
+	params = []*commonpb.KeyValuePair{{Key: OrderByFieldsKey, Value: "unknown_field:asc"}}
+	_, err = parseOrderByFields(params, schema)
+	s.Error(err)
+	s.Contains(err.Error(), "does not exist")
+
+	// Test unsortable field type (vector)
+	params = []*commonpb.KeyValuePair{{Key: OrderByFieldsKey, Value: "vector:asc"}}
+	_, err = parseOrderByFields(params, schema)
+	s.Error(err)
+	s.Contains(err.Error(), "unsortable type")
+
+	// Test JSON field without path - not allowed, must use path syntax like metadata["key"]
+	params = []*commonpb.KeyValuePair{{Key: OrderByFieldsKey, Value: "metadata:asc"}}
+	_, err = parseOrderByFields(params, schema)
+	s.Error(err)
+	s.Contains(err.Error(), "unsortable type")
+	s.Contains(err.Error(), "JSON")
+}
+
+// Test compareFieldDataAt for different data types
+func (s *SearchPipelineSuite) TestCompareFieldDataAtAllTypes() {
+	mustCompare := func(field *schemapb.FieldData, i, j int) int {
+		cmp, err := compareFieldDataAt(field, i, j)
+		s.NoError(err)
+		return cmp
+	}
+
+	// Test Int8/Int16/Int32 comparison
+	intField := &schemapb.FieldData{
+		Type:      schemapb.DataType_Int32,
+		FieldName: "int_field",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_IntData{
+					IntData: &schemapb.IntArray{Data: []int32{30, 10, 20}},
+				},
+			},
+		},
+	}
+	s.Equal(-1, mustCompare(intField, 1, 2)) // 10 < 20
+	s.Equal(1, mustCompare(intField, 0, 1))  // 30 > 10
+	s.Equal(0, mustCompare(intField, 0, 0))  // 30 == 30
+
+	// Test Float comparison
+	floatField := &schemapb.FieldData{
+		Type:      schemapb.DataType_Float,
+		FieldName: "float_field",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_FloatData{
+					FloatData: &schemapb.FloatArray{Data: []float32{3.5, 1.5, 2.5}},
+				},
+			},
+		},
+	}
+	s.Equal(-1, mustCompare(floatField, 1, 2)) // 1.5 < 2.5
+	s.Equal(1, mustCompare(floatField, 0, 1))  // 3.5 > 1.5
+	s.Equal(0, mustCompare(floatField, 0, 0))  // 3.5 == 3.5
+
+	// Test Double comparison
+	doubleField := &schemapb.FieldData{
+		Type:      schemapb.DataType_Double,
+		FieldName: "double_field",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_DoubleData{
+					DoubleData: &schemapb.DoubleArray{Data: []float64{3.5, 1.5, 2.5}},
+				},
+			},
+		},
+	}
+	s.Equal(-1, mustCompare(doubleField, 1, 2)) // 1.5 < 2.5
+	s.Equal(1, mustCompare(doubleField, 0, 1))  // 3.5 > 1.5
+	s.Equal(0, mustCompare(doubleField, 0, 0))  // 3.5 == 3.5
+
+	// Test Bool comparison
+	boolField := &schemapb.FieldData{
+		Type:      schemapb.DataType_Bool,
+		FieldName: "bool_field",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_BoolData{
+					BoolData: &schemapb.BoolArray{Data: []bool{true, false, true}},
+				},
+			},
+		},
+	}
+	s.Equal(1, mustCompare(boolField, 0, 1))  // true > false
+	s.Equal(-1, mustCompare(boolField, 1, 0)) // false < true
+	s.Equal(0, mustCompare(boolField, 0, 2))  // true == true
+
+	// Test out of bounds returns error
+	_, err := compareFieldDataAt(intField, 10, 20)
+	s.Error(err)
+	_, err = compareFieldDataAt(floatField, 10, 20)
+	s.Error(err)
+	_, err = compareFieldDataAt(doubleField, 10, 20)
+	s.Error(err)
+	_, err = compareFieldDataAt(boolField, 10, 20)
+	s.Error(err)
+}
+
+// Test compareFieldDataAt with nullable fields (ValidData)
+func (s *SearchPipelineSuite) TestCompareFieldDataAtNullable() {
+	mustCompare := func(field *schemapb.FieldData, i, j int) int {
+		cmp, err := compareFieldDataAt(field, i, j)
+		s.NoError(err)
+		return cmp
+	}
+
+	// Create field with ValidData (nullable)
+	nullableField := &schemapb.FieldData{
+		Type:      schemapb.DataType_Int64,
+		FieldName: "nullable_field",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{
+					LongData: &schemapb.LongArray{Data: []int64{100, 200, 300}},
+				},
+			},
+		},
+		ValidData: []bool{true, false, true}, // Index 1 is null
+	}
+
+	// null vs non-null: null should come first (NULLS FIRST)
+	s.Equal(1, mustCompare(nullableField, 0, 1))  // 100 > null
+	s.Equal(-1, mustCompare(nullableField, 1, 0)) // null < 100
+	s.Equal(-1, mustCompare(nullableField, 1, 2)) // null < 300
+
+	// Create field where both are null
+	nullableField2 := &schemapb.FieldData{
+		Type:      schemapb.DataType_Int64,
+		FieldName: "nullable_field2",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{
+					LongData: &schemapb.LongArray{Data: []int64{100, 200, 300}},
+				},
+			},
+		},
+		ValidData: []bool{false, false, true}, // Index 0 and 1 are null
+	}
+	s.Equal(0, mustCompare(nullableField2, 0, 1)) // null == null
+}
+
+// Test isSameGroupByValue for different types
+func (s *SearchPipelineSuite) TestIsSameGroupByValueAllTypes() {
+	// Test Int8/Int16/Int32
+	intField := &schemapb.FieldData{
+		Type: schemapb.DataType_Int32,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_IntData{
+					IntData: &schemapb.IntArray{Data: []int32{10, 10, 20}},
+				},
+			},
+		},
+	}
+	s.True(isSameGroupByValue(intField, 0, 1))  // 10 == 10
+	s.False(isSameGroupByValue(intField, 0, 2)) // 10 != 20
+
+	// Test Int64
+	int64Field := &schemapb.FieldData{
+		Type: schemapb.DataType_Int64,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{
+					LongData: &schemapb.LongArray{Data: []int64{100, 100, 200}},
+				},
+			},
+		},
+	}
+	s.True(isSameGroupByValue(int64Field, 0, 1))  // 100 == 100
+	s.False(isSameGroupByValue(int64Field, 0, 2)) // 100 != 200
+
+	// Test Bool
+	boolField := &schemapb.FieldData{
+		Type: schemapb.DataType_Bool,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_BoolData{
+					BoolData: &schemapb.BoolArray{Data: []bool{true, true, false}},
+				},
+			},
+		},
+	}
+	s.True(isSameGroupByValue(boolField, 0, 1))  // true == true
+	s.False(isSameGroupByValue(boolField, 0, 2)) // true != false
+
+	// Test VarChar (already covered but verify)
+	stringField := &schemapb.FieldData{
+		Type: schemapb.DataType_VarChar,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_StringData{
+					StringData: &schemapb.StringArray{Data: []string{"A", "A", "B"}},
+				},
+			},
+		},
+	}
+	s.True(isSameGroupByValue(stringField, 0, 1))  // "A" == "A"
+	s.False(isSameGroupByValue(stringField, 0, 2)) // "A" != "B"
+
+	// Test out of bounds returns false
+	s.False(isSameGroupByValue(intField, 10, 20))
+	s.False(isSameGroupByValue(int64Field, 10, 20))
+	s.False(isSameGroupByValue(boolField, 10, 20))
+	s.False(isSameGroupByValue(stringField, 10, 20))
+
+	// Test unsupported type (Float) returns false
+	floatField := &schemapb.FieldData{
+		Type: schemapb.DataType_Float,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_FloatData{
+					FloatData: &schemapb.FloatArray{Data: []float32{1.0, 1.0}},
+				},
+			},
+		},
+	}
+	s.False(isSameGroupByValue(floatField, 0, 1)) // Float not supported
+}
+
+// Test compareJSONValues with boolean values
+func (s *SearchPipelineSuite) TestCompareJSONValuesBool() {
+	// Test bool: false < true
+	a := extractJSONValue([]byte(`{"v": false}`), "/v")
+	b := extractJSONValue([]byte(`{"v": true}`), "/v")
+	s.Equal(-1, compareJSONValues(a, b)) // false < true
+	s.Equal(1, compareJSONValues(b, a))  // true > false
+
+	// Test both true
+	a = extractJSONValue([]byte(`{"v": true}`), "/v")
+	b = extractJSONValue([]byte(`{"v": true}`), "/v")
+	s.Equal(0, compareJSONValues(a, b)) // true == true
+
+	// Test both false
+	a = extractJSONValue([]byte(`{"v": false}`), "/v")
+	b = extractJSONValue([]byte(`{"v": false}`), "/v")
+	s.Equal(0, compareJSONValues(a, b)) // false == false
+}
+
+// Test compareJSONValues with mixed types (fallback to raw comparison)
+func (s *SearchPipelineSuite) TestCompareJSONValuesMixedTypes() {
+	// Number vs String - falls back to raw comparison
+	// Raw: "10" vs "\"hello\"" - quote char '"' (34) < '1' (49)
+	a := extractJSONValue([]byte(`{"v": 10}`), "/v")
+	b := extractJSONValue([]byte(`{"v": "hello"}`), "/v")
+	cmp := compareJSONValues(a, b)
+	// String (with quotes) should sort before number due to quote ASCII
+	s.Equal(1, cmp) // "10" > "\"hello\"" because '1' > '"'
+}
+
+// Test orderByOperator with Float field type
+func (s *SearchPipelineSuite) TestOrderByOperatorFloatField() {
+	result := &milvuspb.SearchResults{
+		Results: &schemapb.SearchResultData{
+			Ids: &schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{
+					IntId: &schemapb.LongArray{Data: []int64{1, 2, 3, 4}},
+				},
+			},
+			Scores: []float32{0.9, 0.8, 0.7, 0.6},
+			Topks:  []int64{4},
+			FieldsData: []*schemapb.FieldData{
+				{
+					Type:      schemapb.DataType_Float,
+					FieldName: "rating",
+					Field: &schemapb.FieldData_Scalars{
+						Scalars: &schemapb.ScalarField{
+							Data: &schemapb.ScalarField_FloatData{
+								FloatData: &schemapb.FloatArray{Data: []float32{3.5, 1.5, 4.5, 2.5}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	op := &orderByOperator{
+		orderByFields: []OrderByField{
+			{FieldName: "rating", Ascending: true},
+		},
+		groupByFieldId: -1,
+	}
+
+	outputs, err := op.run(context.Background(), s.span, result)
+	s.NoError(err)
+	sortedResult := outputs[0].(*milvuspb.SearchResults)
+
+	// After ascending sort: 1.5, 2.5, 3.5, 4.5
+	// Original: 3.5(id=1), 1.5(id=2), 4.5(id=3), 2.5(id=4)
+	// Sorted: 1.5(id=2), 2.5(id=4), 3.5(id=1), 4.5(id=3)
+	expectedIds := []int64{2, 4, 1, 3}
+	s.Equal(expectedIds, sortedResult.Results.Ids.GetIntId().Data)
+}
+
+// Test orderByOperator with Bool field type
+func (s *SearchPipelineSuite) TestOrderByOperatorBoolField() {
+	result := &milvuspb.SearchResults{
+		Results: &schemapb.SearchResultData{
+			Ids: &schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{
+					IntId: &schemapb.LongArray{Data: []int64{1, 2, 3, 4}},
+				},
+			},
+			Scores: []float32{0.9, 0.8, 0.7, 0.6},
+			Topks:  []int64{4},
+			FieldsData: []*schemapb.FieldData{
+				{
+					Type:      schemapb.DataType_Bool,
+					FieldName: "active",
+					Field: &schemapb.FieldData_Scalars{
+						Scalars: &schemapb.ScalarField{
+							Data: &schemapb.ScalarField_BoolData{
+								BoolData: &schemapb.BoolArray{Data: []bool{true, false, true, false}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	op := &orderByOperator{
+		orderByFields: []OrderByField{
+			{FieldName: "active", Ascending: true},
+		},
+		groupByFieldId: -1,
+	}
+
+	outputs, err := op.run(context.Background(), s.span, result)
+	s.NoError(err)
+	sortedResult := outputs[0].(*milvuspb.SearchResults)
+
+	// After ascending sort: false, false, true, true
+	// Original: true(id=1), false(id=2), true(id=3), false(id=4)
+	// Sorted (stable): false(id=2), false(id=4), true(id=1), true(id=3)
+	expectedIds := []int64{2, 4, 1, 3}
+	s.Equal(expectedIds, sortedResult.Results.Ids.GetIntId().Data)
+}
+
+// Test orderByOperator group_by with Int64 group values
+func (s *SearchPipelineSuite) TestOrderByOperatorWithGroupByInt64() {
+	result := &milvuspb.SearchResults{
+		Results: &schemapb.SearchResultData{
+			Ids: &schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{
+					IntId: &schemapb.LongArray{Data: []int64{1, 2, 3, 4, 5}},
+				},
+			},
+			Scores: []float32{0.9, 0.85, 0.8, 0.75, 0.7},
+			Topks:  []int64{5},
+			FieldsData: []*schemapb.FieldData{
+				{
+					Type:      schemapb.DataType_Int64,
+					FieldName: "price",
+					Field: &schemapb.FieldData_Scalars{
+						Scalars: &schemapb.ScalarField{
+							Data: &schemapb.ScalarField_LongData{
+								LongData: &schemapb.LongArray{Data: []int64{30, 25, 10, 20, 15}},
+							},
+						},
+					},
+				},
+			},
+			// GroupByFieldValue with Int64 type
+			// Group 100: ids [1,2], prices [30,25]
+			// Group 200: ids [3], price [10]
+			// Group 300: ids [4,5], prices [20,15]
+			GroupByFieldValue: &schemapb.FieldData{
+				Type: schemapb.DataType_Int64,
+				Field: &schemapb.FieldData_Scalars{
+					Scalars: &schemapb.ScalarField{
+						Data: &schemapb.ScalarField_LongData{
+							LongData: &schemapb.LongArray{Data: []int64{100, 100, 200, 300, 300}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	op := &orderByOperator{
+		orderByFields: []OrderByField{
+			{FieldName: "price", Ascending: true},
+		},
+		groupByFieldId: 100,
+		groupSize:      2,
+	}
+
+	outputs, err := op.run(context.Background(), s.span, result)
+	s.NoError(err)
+	sortedResult := outputs[0].(*milvuspb.SearchResults)
+
+	// After sorting groups by first row's price:
+	// Group 200 (price=10) -> Group 300 (price=20) -> Group 100 (price=30)
+	// Final order: [3, 4, 5, 1, 2]
+	expectedIds := []int64{3, 4, 5, 1, 2}
+	s.Equal(expectedIds, sortedResult.Results.Ids.GetIntId().Data)
+}
+
+// Test sortGroupsByOrderByFields with no GroupByFieldValue (fallback to regular sort)
+func (s *SearchPipelineSuite) TestOrderByOperatorWithGroupByNoGroupValue() {
+	result := &milvuspb.SearchResults{
+		Results: &schemapb.SearchResultData{
+			Ids: &schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{
+					IntId: &schemapb.LongArray{Data: []int64{1, 2, 3}},
+				},
+			},
+			Scores: []float32{0.9, 0.8, 0.7},
+			Topks:  []int64{3},
+			FieldsData: []*schemapb.FieldData{
+				{
+					Type:      schemapb.DataType_Int64,
+					FieldName: "price",
+					Field: &schemapb.FieldData_Scalars{
+						Scalars: &schemapb.ScalarField{
+							Data: &schemapb.ScalarField_LongData{
+								LongData: &schemapb.LongArray{Data: []int64{30, 10, 20}},
+							},
+						},
+					},
+				},
+			},
+			// No GroupByFieldValue - should fallback to regular sort
+			GroupByFieldValue: nil,
+		},
+	}
+
+	op := &orderByOperator{
+		orderByFields: []OrderByField{
+			{FieldName: "price", Ascending: true},
+		},
+		groupByFieldId: 100, // Says group_by but no GroupByFieldValue
+		groupSize:      2,
+	}
+
+	outputs, err := op.run(context.Background(), s.span, result)
+	s.NoError(err)
+	sortedResult := outputs[0].(*milvuspb.SearchResults)
+
+	// Should fallback to regular sort: 10, 20, 30
+	expectedIds := []int64{2, 3, 1}
+	s.Equal(expectedIds, sortedResult.Results.Ids.GetIntId().Data)
+}
+
+// Test reorderFieldData for Int8/Int16/Int32 scalar types
+func (s *SearchPipelineSuite) TestReorderFieldDataInt32() {
+	field := &schemapb.FieldData{
+		Type:      schemapb.DataType_Int32,
+		FieldName: "int_field",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_IntData{
+					IntData: &schemapb.IntArray{Data: []int32{10, 20, 30, 40}},
+				},
+			},
+		},
+	}
+
+	// Reorder: [2, 0, 3, 1] means new[0]=old[2], new[1]=old[0], etc.
+	indices := []int{2, 0, 3, 1}
+	err := reorderFieldData(field, indices)
+	s.NoError(err)
+
+	expected := []int32{30, 10, 40, 20}
+	s.Equal(expected, field.GetScalars().GetIntData().Data)
+}
+
+// Test reorderFieldData for Array type
+func (s *SearchPipelineSuite) TestReorderFieldDataArray() {
+	field := &schemapb.FieldData{
+		Type:      schemapb.DataType_Array,
+		FieldName: "array_field",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_ArrayData{
+					ArrayData: &schemapb.ArrayArray{
+						Data: []*schemapb.ScalarField{
+							{Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: []int32{1, 2}}}},
+							{Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: []int32{3, 4}}}},
+							{Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: []int32{5, 6}}}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Reorder: [2, 0, 1]
+	indices := []int{2, 0, 1}
+	err := reorderFieldData(field, indices)
+	s.NoError(err)
+
+	result := field.GetScalars().GetArrayData().Data
+	s.Len(result, 3)
+	s.Equal([]int32{5, 6}, result[0].GetIntData().Data)
+	s.Equal([]int32{1, 2}, result[1].GetIntData().Data)
+	s.Equal([]int32{3, 4}, result[2].GetIntData().Data)
+}
+
+// Test reorderFieldData for BinaryVector type
+func (s *SearchPipelineSuite) TestReorderFieldDataBinaryVector() {
+	// 3 vectors, dim=16 (2 bytes per vector)
+	field := &schemapb.FieldData{
+		Type:      schemapb.DataType_BinaryVector,
+		FieldName: "binary_vec",
+		Field: &schemapb.FieldData_Vectors{
+			Vectors: &schemapb.VectorField{
+				Dim: 16,
+				Data: &schemapb.VectorField_BinaryVector{
+					BinaryVector: []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}, // 3 vectors * 2 bytes
+				},
+			},
+		},
+	}
+
+	// Reorder: [2, 0, 1]
+	indices := []int{2, 0, 1}
+	err := reorderFieldData(field, indices)
+	s.NoError(err)
+
+	expected := []byte{0x05, 0x06, 0x01, 0x02, 0x03, 0x04}
+	s.Equal(expected, field.GetVectors().GetBinaryVector())
+}
+
+// Test reorderFieldData for Float16Vector type
+func (s *SearchPipelineSuite) TestReorderFieldDataFloat16Vector() {
+	// 3 vectors, dim=2 (4 bytes per vector: 2 bytes per float16 * 2 dims)
+	field := &schemapb.FieldData{
+		Type:      schemapb.DataType_Float16Vector,
+		FieldName: "fp16_vec",
+		Field: &schemapb.FieldData_Vectors{
+			Vectors: &schemapb.VectorField{
+				Dim: 2,
+				Data: &schemapb.VectorField_Float16Vector{
+					Float16Vector: []byte{
+						0x01, 0x02, 0x03, 0x04, // vector 0
+						0x05, 0x06, 0x07, 0x08, // vector 1
+						0x09, 0x0A, 0x0B, 0x0C, // vector 2
+					},
+				},
+			},
+		},
+	}
+
+	// Reorder: [2, 0, 1]
+	indices := []int{2, 0, 1}
+	err := reorderFieldData(field, indices)
+	s.NoError(err)
+
+	expected := []byte{
+		0x09, 0x0A, 0x0B, 0x0C, // was vector 2
+		0x01, 0x02, 0x03, 0x04, // was vector 0
+		0x05, 0x06, 0x07, 0x08, // was vector 1
+	}
+	s.Equal(expected, field.GetVectors().GetFloat16Vector())
+}
+
+// Test reorderFieldData for BFloat16Vector type
+func (s *SearchPipelineSuite) TestReorderFieldDataBFloat16Vector() {
+	// 3 vectors, dim=2 (4 bytes per vector: 2 bytes per bfloat16 * 2 dims)
+	field := &schemapb.FieldData{
+		Type:      schemapb.DataType_BFloat16Vector,
+		FieldName: "bf16_vec",
+		Field: &schemapb.FieldData_Vectors{
+			Vectors: &schemapb.VectorField{
+				Dim: 2,
+				Data: &schemapb.VectorField_Bfloat16Vector{
+					Bfloat16Vector: []byte{
+						0x11, 0x12, 0x13, 0x14, // vector 0
+						0x21, 0x22, 0x23, 0x24, // vector 1
+						0x31, 0x32, 0x33, 0x34, // vector 2
+					},
+				},
+			},
+		},
+	}
+
+	// Reorder: [1, 2, 0]
+	indices := []int{1, 2, 0}
+	err := reorderFieldData(field, indices)
+	s.NoError(err)
+
+	expected := []byte{
+		0x21, 0x22, 0x23, 0x24, // was vector 1
+		0x31, 0x32, 0x33, 0x34, // was vector 2
+		0x11, 0x12, 0x13, 0x14, // was vector 0
+	}
+	s.Equal(expected, field.GetVectors().GetBfloat16Vector())
+}
+
+// Test reorderFieldData for SparseFloatVector type
+func (s *SearchPipelineSuite) TestReorderFieldDataSparseFloatVector() {
+	field := &schemapb.FieldData{
+		Type:      schemapb.DataType_SparseFloatVector,
+		FieldName: "sparse_vec",
+		Field: &schemapb.FieldData_Vectors{
+			Vectors: &schemapb.VectorField{
+				Dim: 100,
+				Data: &schemapb.VectorField_SparseFloatVector{
+					SparseFloatVector: &schemapb.SparseFloatArray{
+						Contents: [][]byte{
+							{0x01, 0x02}, // sparse vector 0
+							{0x03, 0x04}, // sparse vector 1
+							{0x05, 0x06}, // sparse vector 2
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Reorder: [2, 0, 1]
+	indices := []int{2, 0, 1}
+	err := reorderFieldData(field, indices)
+	s.NoError(err)
+
+	result := field.GetVectors().GetSparseFloatVector().GetContents()
+	s.Len(result, 3)
+	s.Equal([]byte{0x05, 0x06}, result[0])
+	s.Equal([]byte{0x01, 0x02}, result[1])
+	s.Equal([]byte{0x03, 0x04}, result[2])
+}
+
+// Test reorderFieldData for Int8Vector type
+func (s *SearchPipelineSuite) TestReorderFieldDataInt8Vector() {
+	// 3 vectors, dim=4 (4 bytes per vector)
+	field := &schemapb.FieldData{
+		Type:      schemapb.DataType_Int8Vector,
+		FieldName: "int8_vec",
+		Field: &schemapb.FieldData_Vectors{
+			Vectors: &schemapb.VectorField{
+				Dim: 4,
+				Data: &schemapb.VectorField_Int8Vector{
+					Int8Vector: []byte{
+						0x01, 0x02, 0x03, 0x04, // vector 0
+						0x05, 0x06, 0x07, 0x08, // vector 1
+						0x09, 0x0A, 0x0B, 0x0C, // vector 2
+					},
+				},
+			},
+		},
+	}
+
+	// Reorder: [2, 0, 1]
+	indices := []int{2, 0, 1}
+	err := reorderFieldData(field, indices)
+	s.NoError(err)
+
+	expected := []byte{
+		0x09, 0x0A, 0x0B, 0x0C, // was vector 2
+		0x01, 0x02, 0x03, 0x04, // was vector 0
+		0x05, 0x06, 0x07, 0x08, // was vector 1
+	}
+	s.Equal(expected, field.GetVectors().GetInt8Vector())
+}
+
+// Test reorderFieldData with ValidData (nullable fields)
+func (s *SearchPipelineSuite) TestReorderFieldDataWithValidData() {
+	field := &schemapb.FieldData{
+		Type:      schemapb.DataType_Int64,
+		FieldName: "nullable_field",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{
+					LongData: &schemapb.LongArray{Data: []int64{10, 20, 30}},
+				},
+			},
+		},
+		ValidData: []bool{true, false, true}, // index 1 is null
+	}
+
+	// Reorder: [2, 0, 1]
+	indices := []int{2, 0, 1}
+	err := reorderFieldData(field, indices)
+	s.NoError(err)
+
+	expectedData := []int64{30, 10, 20}
+	expectedValid := []bool{true, true, false} // null moves to index 2
+	s.Equal(expectedData, field.GetScalars().GetLongData().Data)
+	s.Equal(expectedValid, field.ValidData)
+}
+
+// Test orderByOperator with Int32 field to cover reorderFieldData Int32 branch
+func (s *SearchPipelineSuite) TestOrderByOperatorInt32Field() {
+	result := &milvuspb.SearchResults{
+		Results: &schemapb.SearchResultData{
+			Ids: &schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{
+					IntId: &schemapb.LongArray{Data: []int64{1, 2, 3, 4}},
+				},
+			},
+			Scores: []float32{0.9, 0.8, 0.7, 0.6},
+			Topks:  []int64{4},
+			FieldsData: []*schemapb.FieldData{
+				{
+					Type:      schemapb.DataType_Int32,
+					FieldName: "count",
+					Field: &schemapb.FieldData_Scalars{
+						Scalars: &schemapb.ScalarField{
+							Data: &schemapb.ScalarField_IntData{
+								IntData: &schemapb.IntArray{Data: []int32{30, 10, 40, 20}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	op := &orderByOperator{
+		orderByFields: []OrderByField{
+			{FieldName: "count", Ascending: true},
+		},
+		groupByFieldId: -1,
+	}
+
+	outputs, err := op.run(context.Background(), s.span, result)
+	s.NoError(err)
+	sortedResult := outputs[0].(*milvuspb.SearchResults)
+
+	// After ascending sort: 10, 20, 30, 40
+	expectedIds := []int64{2, 4, 1, 3}
+	s.Equal(expectedIds, sortedResult.Results.Ids.GetIntId().Data)
+
+	expectedCounts := []int32{10, 20, 30, 40}
+	s.Equal(expectedCounts, sortedResult.Results.FieldsData[0].GetScalars().GetIntData().Data)
+}
+
+// Test orderByOperator with Double field
+func (s *SearchPipelineSuite) TestOrderByOperatorDoubleField() {
+	result := &milvuspb.SearchResults{
+		Results: &schemapb.SearchResultData{
+			Ids: &schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{
+					IntId: &schemapb.LongArray{Data: []int64{1, 2, 3}},
+				},
+			},
+			Scores: []float32{0.9, 0.8, 0.7},
+			Topks:  []int64{3},
+			FieldsData: []*schemapb.FieldData{
+				{
+					Type:      schemapb.DataType_Double,
+					FieldName: "value",
+					Field: &schemapb.FieldData_Scalars{
+						Scalars: &schemapb.ScalarField{
+							Data: &schemapb.ScalarField_DoubleData{
+								DoubleData: &schemapb.DoubleArray{Data: []float64{3.14, 1.41, 2.72}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	op := &orderByOperator{
+		orderByFields: []OrderByField{
+			{FieldName: "value", Ascending: true},
+		},
+		groupByFieldId: -1,
+	}
+
+	outputs, err := op.run(context.Background(), s.span, result)
+	s.NoError(err)
+	sortedResult := outputs[0].(*milvuspb.SearchResults)
+
+	// After ascending sort: 1.41, 2.72, 3.14
+	expectedIds := []int64{2, 3, 1}
+	s.Equal(expectedIds, sortedResult.Results.Ids.GetIntId().Data)
+
+	expectedValues := []float64{1.41, 2.72, 3.14}
+	s.Equal(expectedValues, sortedResult.Results.FieldsData[0].GetScalars().GetDoubleData().Data)
+}
+
+// Test orderByOperator with VarChar field
+func (s *SearchPipelineSuite) TestOrderByOperatorVarCharField() {
+	result := &milvuspb.SearchResults{
+		Results: &schemapb.SearchResultData{
+			Ids: &schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{
+					IntId: &schemapb.LongArray{Data: []int64{1, 2, 3}},
+				},
+			},
+			Scores: []float32{0.9, 0.8, 0.7},
+			Topks:  []int64{3},
+			FieldsData: []*schemapb.FieldData{
+				{
+					Type:      schemapb.DataType_VarChar,
+					FieldName: "name",
+					Field: &schemapb.FieldData_Scalars{
+						Scalars: &schemapb.ScalarField{
+							Data: &schemapb.ScalarField_StringData{
+								StringData: &schemapb.StringArray{Data: []string{"charlie", "alice", "bob"}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	op := &orderByOperator{
+		orderByFields: []OrderByField{
+			{FieldName: "name", Ascending: true},
+		},
+		groupByFieldId: -1,
+	}
+
+	outputs, err := op.run(context.Background(), s.span, result)
+	s.NoError(err)
+	sortedResult := outputs[0].(*milvuspb.SearchResults)
+
+	// After ascending sort: alice, bob, charlie
+	expectedIds := []int64{2, 3, 1}
+	s.Equal(expectedIds, sortedResult.Results.Ids.GetIntId().Data)
+
+	expectedNames := []string{"alice", "bob", "charlie"}
+	s.Equal(expectedNames, sortedResult.Results.FieldsData[0].GetScalars().GetStringData().Data)
+}
+
+// Test compareNullsFirst helper function
+func (s *SearchPipelineSuite) TestCompareNullsFirst() {
+	// Empty ValidData - should return (0, false)
+	cmp, handled := compareNullsFirst(nil, 0, 1)
+	s.Equal(0, cmp)
+	s.False(handled)
+
+	cmp, handled = compareNullsFirst([]bool{}, 0, 1)
+	s.Equal(0, cmp)
+	s.False(handled)
+
+	// Both non-null - should return (0, false)
+	validData := []bool{true, true, true}
+	cmp, handled = compareNullsFirst(validData, 0, 1)
+	s.Equal(0, cmp)
+	s.False(handled)
+
+	// First is null, second is not - should return (-1, true) (nulls first)
+	validData = []bool{false, true, true}
+	cmp, handled = compareNullsFirst(validData, 0, 1)
+	s.Equal(-1, cmp)
+	s.True(handled)
+
+	// First is not null, second is null - should return (1, true)
+	cmp, handled = compareNullsFirst(validData, 1, 0)
+	s.Equal(1, cmp)
+	s.True(handled)
+
+	// Both are null - should return (0, true)
+	validData = []bool{false, false, true}
+	cmp, handled = compareNullsFirst(validData, 0, 1)
+	s.Equal(0, cmp)
+	s.True(handled)
+}
+
+// Test buildJSONValueCache and getCachedJSONValue
+func (s *SearchPipelineSuite) TestBuildJSONValueCache() {
+	jsonField := &schemapb.FieldData{
+		Type:      schemapb.DataType_JSON,
+		FieldName: "metadata",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_JsonData{
+					JsonData: &schemapb.JSONArray{
+						Data: [][]byte{
+							[]byte(`{"score": 100}`),
+							[]byte(`{"score": 200}`),
+							[]byte(`{"score": 150}`),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fieldMap := map[string]*schemapb.FieldData{
+		"metadata": jsonField,
+	}
+	orderByFields := []OrderByField{
+		{FieldName: "metadata", JSONPath: "/score"},
+	}
+
+	cache := buildJSONValueCache(fieldMap, orderByFields, []int{0, 1, 2})
+
+	// Verify cache contains extracted values
+	val0 := cache.getCachedJSONValue("metadata", "/score", 0)
+	s.True(val0.Exists())
+	s.Equal(float64(100), val0.Float())
+
+	val1 := cache.getCachedJSONValue("metadata", "/score", 1)
+	s.True(val1.Exists())
+	s.Equal(float64(200), val1.Float())
+
+	val2 := cache.getCachedJSONValue("metadata", "/score", 2)
+	s.True(val2.Exists())
+	s.Equal(float64(150), val2.Float())
+
+	// Non-existent field/path returns empty result
+	valMissing := cache.getCachedJSONValue("nonexistent", "/score", 0)
+	s.False(valMissing.Exists())
+
+	valMissingPath := cache.getCachedJSONValue("metadata", "/nonexistent", 0)
+	s.False(valMissingPath.Exists())
+
+	// Out of bounds index returns empty result
+	valOOB := cache.getCachedJSONValue("metadata", "/score", 100)
+	s.False(valOOB.Exists())
+}
+
+// Test buildJSONValueCache skips non-JSON fields
+func (s *SearchPipelineSuite) TestBuildJSONValueCacheSkipsNonJSON() {
+	intField := &schemapb.FieldData{
+		Type:      schemapb.DataType_Int64,
+		FieldName: "age",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{
+					LongData: &schemapb.LongArray{Data: []int64{10, 20, 30}},
+				},
+			},
+		},
+	}
+
+	fieldMap := map[string]*schemapb.FieldData{
+		"age": intField,
+	}
+	orderByFields := []OrderByField{
+		{FieldName: "age", JSONPath: ""}, // No JSON path, should be skipped
+	}
+
+	cache := buildJSONValueCache(fieldMap, orderByFields, []int{0, 1, 2})
+	s.Empty(cache) // No entries should be cached for non-JSON fields
+}
+
+// Test compareOrderByField with nullable JSON field
+func (s *SearchPipelineSuite) TestCompareOrderByFieldNullableJSON() {
+	jsonField := &schemapb.FieldData{
+		Type:      schemapb.DataType_JSON,
+		FieldName: "metadata",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_JsonData{
+					JsonData: &schemapb.JSONArray{
+						Data: [][]byte{
+							[]byte(`{"score": 100}`),
+							[]byte(`{"score": 200}`),
+							[]byte(`{"score": 150}`),
+						},
+					},
+				},
+			},
+		},
+		ValidData: []bool{true, false, true}, // Index 1 is null
+	}
+
+	fieldMap := map[string]*schemapb.FieldData{
+		"metadata": jsonField,
+	}
+	orderBy := OrderByField{FieldName: "metadata", JSONPath: "/score"}
+	cache := buildJSONValueCache(fieldMap, []OrderByField{orderBy}, []int{0, 1, 2})
+
+	// null vs non-null: null should come first
+	cmp, err := compareOrderByField(jsonField, orderBy, 1, 0, cache)
+	s.NoError(err)
+	s.Equal(-1, cmp) // null < 100
+
+	cmp, err = compareOrderByField(jsonField, orderBy, 0, 1, cache)
+	s.NoError(err)
+	s.Equal(1, cmp) // 100 > null
+
+	// non-null vs non-null: normal comparison
+	cmp, err = compareOrderByField(jsonField, orderBy, 0, 2, cache)
+	s.NoError(err)
+	s.Equal(-1, cmp) // 100 < 150
+
+	cmp, err = compareOrderByField(jsonField, orderBy, 2, 0, cache)
+	s.NoError(err)
+	s.Equal(1, cmp) // 150 > 100
+}
+
+// Test reorderFieldData returns error for unhandled data type
+func (s *SearchPipelineSuite) TestReorderFieldDataUnhandledType() {
+	// Create a field with an unhandled type (None type is not handled)
+	field := &schemapb.FieldData{
+		Type:      schemapb.DataType_None,
+		FieldName: "unknown",
+	}
+
+	indices := []int{0, 1, 2}
+	err := reorderFieldData(field, indices)
+	s.Error(err)
+	s.Contains(err.Error(), "unhandled data type")
+}
+
+// TestNewSearchPipelineWithOrderBy tests that newSearchPipeline correctly routes
+// to searchWithOrderByPipe when orderByFields is set
+func (s *SearchPipelineSuite) TestNewSearchPipelineWithOrderBy() {
+	collectionName := "test_collection"
+
+	// Mock requery operation
+	f1 := testutils.GenerateScalarFieldData(schemapb.DataType_Int64, "intField", 20)
+	f1.FieldId = 101
+	f2 := testutils.GenerateScalarFieldData(schemapb.DataType_Int64, "int64", 20)
+	f2.FieldId = 100
+	mocker := mockey.Mock((*requeryOperator).requery).Return(&milvuspb.QueryResults{
+		FieldsData: []*schemapb.FieldData{f1, f2},
+	}, segcore.StorageCost{ScannedRemoteBytes: 100, ScannedTotalBytes: 200}, nil).Build()
+	defer mocker.UnPatch()
+
+	task := &searchTask{
+		ctx:            context.Background(),
+		collectionName: collectionName,
+		SearchRequest: &internalpb.SearchRequest{
+			Base: &commonpb.MsgBase{
+				MsgType:   commonpb.MsgType_Search,
+				Timestamp: uint64(time.Now().UnixNano()),
+			},
+			MetricType:   "L2",
+			Topk:         10,
+			Nq:           2,
+			PartitionIDs: []int64{1},
+			CollectionID: 1,
+			DbID:         1,
+			IsAdvanced:   false, // Regular search, not hybrid
+		},
+		schema: &schemaInfo{
+			CollectionSchema: &schemapb.CollectionSchema{
+				Fields: []*schemapb.FieldSchema{
+					{FieldID: 100, Name: "int64", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+					{FieldID: 101, Name: "intField", DataType: schemapb.DataType_Int64},
+				},
+			},
+			pkField: &schemapb.FieldSchema{FieldID: 100, Name: "int64", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+		},
+		queryInfos:             []*planpb.QueryInfo{{}},
+		translatedOutputFields: []string{"intField"},
+		request:                &milvuspb.SearchRequest{Namespace: nil},
+		// Set orderByFields to trigger searchWithOrderByPipe
+		orderByFields: []OrderByField{
+			{FieldName: "intField", OutputFieldName: "intField", Ascending: true},
+		},
+	}
+
+	// Use newSearchPipeline (the actual entry point)
+	pipeline, err := newSearchPipeline(task)
+	s.NoError(err)
+	s.NotNil(pipeline)
+
+	// Run the pipeline with test data
+	sr := genTestSearchResultData(2, 10, schemapb.DataType_Int64, "intField", 101, false)
+	results, _, err := pipeline.Run(context.Background(), s.span, []*internalpb.SearchResults{sr}, segcore.StorageCost{ScannedRemoteBytes: 100, ScannedTotalBytes: 200})
+	s.NoError(err)
+	s.NotNil(results)
+	s.NotNil(results.Results)
+	s.Equal(int64(2), results.Results.NumQueries)
+}
+
 func (s *SearchPipelineSuite) TestNewRequeryOperator_WithHighlightDynamicFields() {
 	// Test that highlight dynamic fields are added to requery output
 	schema := &schemaInfo{

--- a/internal/proxy/search_util.go
+++ b/internal/proxy/search_util.go
@@ -79,10 +79,227 @@ func (r *rankParams) String() string {
 }
 
 type SearchInfo struct {
-	planInfo     *planpb.QueryInfo
-	offset       int64
-	isIterator   bool
-	collectionID int64
+	planInfo      *planpb.QueryInfo
+	offset        int64
+	isIterator    bool
+	collectionID  int64
+	orderByFields []OrderByField
+}
+
+// parseOrderByFields parses the order_by_fields parameter from search params.
+// Format: "field1:asc,field2:desc" or "field1,field2" (default is asc)
+// Supports JSON subfield paths: metadata["price"]:asc, metadata["user"]["score"]:desc
+// Supports dynamic fields: age:desc (maps to $meta["age"])
+// Validates that fields exist in schema and are sortable types.
+func parseOrderByFields(searchParamsPair []*commonpb.KeyValuePair, schema *schemapb.CollectionSchema) ([]OrderByField, error) {
+	orderByStr, err := funcutil.GetAttrByKeyFromRepeatedKV(OrderByFieldsKey, searchParamsPair)
+	if err != nil || orderByStr == "" {
+		return nil, nil
+	}
+
+	// Build field name to schema map and find dynamic field
+	fieldSchemaMap := make(map[string]*schemapb.FieldSchema)
+	var dynamicField *schemapb.FieldSchema
+	for _, field := range schema.GetFields() {
+		fieldSchemaMap[field.GetName()] = field
+		if field.GetIsDynamic() {
+			dynamicField = field
+		}
+	}
+
+	var orderByFields []OrderByField
+	pairs := strings.Split(orderByStr, ",")
+	for _, pair := range pairs {
+		pair = strings.TrimSpace(pair)
+		if pair == "" {
+			continue
+		}
+
+		// Split field spec and direction, handling brackets in field spec
+		// e.g., "metadata[\"price\"]:asc" -> fieldSpec="metadata[\"price\"]", direction="asc"
+		fieldSpec, direction := splitOrderByFieldAndDirection(pair)
+		if fieldSpec == "" {
+			return nil, fmt.Errorf("empty field name in order_by_fields")
+		}
+
+		// Parse direction
+		ascending := true // default is ascending
+		if direction != "" {
+			switch strings.ToLower(direction) {
+			case "asc", "ascending":
+				ascending = true
+			case "desc", "descending":
+				ascending = false
+			default:
+				return nil, fmt.Errorf("invalid order direction '%s' for field '%s', expected 'asc' or 'desc'", direction, fieldSpec)
+			}
+		}
+
+		// Parse field spec to extract field name, field ID, JSON path, and requery info
+		fieldName, fieldID, jsonPath, outputFieldName, isDynamic, err := parseOrderByFieldSpec(fieldSpec, fieldSchemaMap, dynamicField, schema)
+		if err != nil {
+			return nil, err
+		}
+
+		orderByFields = append(orderByFields, OrderByField{
+			FieldName:       fieldName,
+			FieldID:         fieldID,
+			JSONPath:        jsonPath,
+			Ascending:       ascending,
+			OutputFieldName: outputFieldName,
+			IsDynamicField:  isDynamic,
+		})
+	}
+
+	return orderByFields, nil
+}
+
+// splitOrderByFieldAndDirection splits "fieldSpec:direction" handling brackets in fieldSpec
+// e.g., "metadata[\"price\"]:asc" -> ("metadata[\"price\"]", "asc")
+// e.g., "name:desc" -> ("name", "desc")
+// e.g., "name" -> ("name", "")
+//
+// Limitation: This simple bracket-depth tracking does not handle:
+//   - Brackets inside quoted strings: metadata["key]value"] would incorrectly parse
+//   - Escaped quotes inside strings: metadata["key\"with\"quotes"] may misbehave
+//
+// These edge cases are rare in practice. Field names containing unbalanced brackets
+// or complex escape sequences are not supported.
+func splitOrderByFieldAndDirection(pair string) (fieldSpec, direction string) {
+	// Find the last colon that's not inside brackets
+	bracketDepth := 0
+	lastColonIdx := -1
+	for i, ch := range pair {
+		switch ch {
+		case '[':
+			bracketDepth++
+		case ']':
+			bracketDepth--
+		case ':':
+			if bracketDepth == 0 {
+				lastColonIdx = i
+			}
+		}
+	}
+
+	if lastColonIdx == -1 {
+		return strings.TrimSpace(pair), ""
+	}
+	return strings.TrimSpace(pair[:lastColonIdx]), strings.TrimSpace(pair[lastColonIdx+1:])
+}
+
+// parseOrderByFieldSpec parses a field specification and returns field name, ID, JSON path, and requery info
+// Handles: regular fields, JSON fields with paths, and dynamic fields
+// Returns:
+//   - fieldName: top-level field name ($meta for dynamic, actual name for others)
+//   - fieldID: field ID
+//   - jsonPath: JSON Pointer format path (empty for non-JSON fields)
+//   - outputFieldName: field name to use in requery (original key for dynamic fields)
+//   - isDynamicField: true if this uses dynamic field extraction at QueryNode
+func parseOrderByFieldSpec(fieldSpec string, fieldSchemaMap map[string]*schemapb.FieldSchema, dynamicField *schemapb.FieldSchema, schema *schemapb.CollectionSchema) (fieldName string, fieldID int64, jsonPath string, outputFieldName string, isDynamicField bool, err error) {
+	// Check for JSON path syntax (brackets)
+	hasBrackets := strings.Contains(fieldSpec, "[") && strings.Contains(fieldSpec, "]")
+
+	if hasBrackets {
+		// Extract base field name (part before the first '[')
+		baseName := strings.Split(fieldSpec, "[")[0]
+		field, exists := fieldSchemaMap[baseName]
+
+		if exists {
+			// Field exists in schema
+			if field.GetIsDynamic() {
+				// This is $meta["key"] - explicit dynamic field access
+				// Use QueryNode-level extraction for dynamic fields
+				fieldName = common.MetaFieldName
+				fieldID = field.GetFieldID()
+				jsonPath, err = typeutil2.ParseAndVerifyNestedPath(fieldSpec, schema, fieldID)
+				if err != nil {
+					return "", 0, "", "", false, fmt.Errorf("invalid JSON path in order_by field '%s': %w", fieldSpec, err)
+				}
+				outputFieldName = fieldSpec // Explicit $meta["key"] path; single-level, parser accepts it
+				isDynamicField = true
+			} else if typeutil.IsJSONType(field.GetDataType()) {
+				// Regular JSON field with path: metadata["price"]
+				// Regular JSON fields don't support QueryNode-level extraction
+				fieldName = baseName
+				fieldID = field.GetFieldID()
+				jsonPath, err = typeutil2.ParseAndVerifyNestedPath(fieldSpec, schema, fieldID)
+				if err != nil {
+					return "", 0, "", "", false, fmt.Errorf("invalid JSON path in order_by field '%s': %w", fieldSpec, err)
+				}
+				outputFieldName = baseName // Request the whole JSON field
+				isDynamicField = false
+			} else {
+				// Non-JSON field with brackets - not supported
+				return "", 0, "", "", false, fmt.Errorf("order_by field '%s' has brackets but is not a JSON type", fieldSpec)
+			}
+		} else if dynamicField != nil {
+			// Unknown field name with brackets, treat as dynamic field path
+			// e.g., unknown["key"] -> $meta with path /unknown/key
+			fieldName = common.MetaFieldName
+			fieldID = dynamicField.GetFieldID()
+			jsonPath, err = typeutil2.ParseAndVerifyNestedPath(fieldSpec, schema, fieldID)
+			if err != nil {
+				return "", 0, "", "", false, fmt.Errorf("invalid JSON path in order_by field '%s': %w", fieldSpec, err)
+			}
+			// Request the base dynamic field; full path is in jsonPath
+			outputFieldName = baseName
+			isDynamicField = true
+		} else {
+			return "", 0, "", "", false, fmt.Errorf("order_by field '%s' not found in schema and no dynamic field available", baseName)
+		}
+	} else {
+		// No brackets - regular field name or dynamic field key
+		field, exists := fieldSchemaMap[fieldSpec]
+		if exists {
+			// Regular field
+			fieldName = fieldSpec
+			fieldID = field.GetFieldID()
+			outputFieldName = fieldSpec
+			isDynamicField = false
+			// Validate sortable type
+			if !isSortableFieldType(field.GetDataType()) {
+				return "", 0, "", "", false, fmt.Errorf("order_by field '%s' has unsortable type %s; supported types: bool, int8/16/32/64, float, double, string, varchar; for JSON fields use path syntax like field[\"key\"]",
+					fieldSpec, field.GetDataType().String())
+			}
+		} else if dynamicField != nil {
+			// Treat as dynamic field key: age -> $meta["age"]
+			fieldName = common.MetaFieldName
+			fieldID = dynamicField.GetFieldID()
+			jsonPath, err = typeutil2.ParseAndVerifyNestedPath(fieldSpec, schema, fieldID)
+			if err != nil {
+				return "", 0, "", "", false, fmt.Errorf("invalid dynamic field key '%s': %w", fieldSpec, err)
+			}
+			// For dynamic fields, pass the original key so translateOutputFields can extract it
+			outputFieldName = fieldSpec
+			isDynamicField = true
+		} else {
+			return "", 0, "", "", false, fmt.Errorf("order_by field '%s' does not exist in collection schema", fieldSpec)
+		}
+	}
+
+	return fieldName, fieldID, jsonPath, outputFieldName, isDynamicField, nil
+}
+
+// isSortableFieldType returns true if the data type can be used for order_by
+// Note: JSON type is not directly sortable. Use JSON path syntax (e.g., metadata["price"])
+// to sort by specific JSON subfields, or use dynamic fields for schema-less data.
+func isSortableFieldType(dataType schemapb.DataType) bool {
+	switch dataType {
+	case schemapb.DataType_Bool,
+		schemapb.DataType_Int8,
+		schemapb.DataType_Int16,
+		schemapb.DataType_Int32,
+		schemapb.DataType_Int64,
+		schemapb.DataType_Float,
+		schemapb.DataType_Double,
+		schemapb.DataType_String,
+		schemapb.DataType_VarChar:
+		return true
+	default:
+		// Vectors, Arrays, JSON (without path), etc. are not sortable
+		return false
+	}
 }
 
 func parseSearchIteratorV2Info(searchParamsPair []*commonpb.KeyValuePair, groupByFieldId int64, isIterator bool, offset int64, queryTopK *int64) (*planpb.SearchIteratorV2Info, error) {

--- a/internal/proxy/task_upsert.go
+++ b/internal/proxy/task_upsert.go
@@ -866,7 +866,12 @@ func (it *upsertTask) insertPreExecute(ctx context.Context) error {
 	it.result.SuccIndex = sliceIndex
 
 	if it.schema.EnableDynamicField {
-		err := checkDynamicFieldData(it.schema.CollectionSchema, it.upsertMsg.InsertMsg)
+		var err error
+		if it.req.GetPartialUpdate() {
+			err = checkDynamicFieldDataForPartialUpdate(it.schema.CollectionSchema, it.upsertMsg.InsertMsg)
+		} else {
+			err = checkDynamicFieldData(it.schema.CollectionSchema, it.upsertMsg.InsertMsg)
+		}
 		if err != nil {
 			return err
 		}

--- a/internal/proxy/task_upsert_test.go
+++ b/internal/proxy/task_upsert_test.go
@@ -17,6 +17,7 @@ package proxy
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/bytedance/mockey"
@@ -1379,6 +1380,376 @@ func TestUpsertTask_queryPreExecute_PureUpdate(t *testing.T) {
 	}
 	assert.NotNil(t, valueField)
 	assert.Equal(t, []int32{600, 700}, valueField.GetScalars().GetIntData().GetData())
+}
+
+func TestCheckDynamicFieldDataForPartialUpdate(t *testing.T) {
+	t.Run("preserves $meta keys matching static field names after schema evolution", func(t *testing.T) {
+		schema := &schemapb.CollectionSchema{
+			Name:               "test_collection",
+			EnableDynamicField: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "id", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+				{FieldID: 101, Name: "dfA", DataType: schemapb.DataType_Int64},
+				{FieldID: 102, Name: "$meta", DataType: schemapb.DataType_JSON, IsDynamic: true},
+			},
+		}
+
+		// $meta contains {"dfA": 111, "dfB": "keep_me", "dfC": 999}
+		// All keys must be preserved — including "dfA" which matches a static field name.
+		metaJSON, _ := json.Marshal(map[string]interface{}{"dfA": 111, "dfB": "keep_me", "dfC": 999})
+		insertMsg := &msgstream.InsertMsg{
+			InsertRequest: &msgpb.InsertRequest{
+				FieldsData: []*schemapb.FieldData{
+					{
+						FieldName: "$meta", FieldId: 102, Type: schemapb.DataType_JSON, IsDynamic: true,
+						Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_JsonData{
+							JsonData: &schemapb.JSONArray{Data: [][]byte{metaJSON}},
+						}}},
+					},
+				},
+			},
+		}
+
+		err := checkDynamicFieldDataForPartialUpdate(schema, insertMsg)
+		assert.NoError(t, err)
+
+		jsonData := insertMsg.FieldsData[0].GetScalars().GetJsonData().GetData()
+		assert.Len(t, jsonData, 1)
+
+		var m map[string]interface{}
+		err = json.Unmarshal(jsonData[0], &m)
+		assert.NoError(t, err)
+		assert.Contains(t, m, "dfA", "key matching static field name must be preserved")
+		assert.Contains(t, m, "dfB", "non-conflicting key must be preserved")
+		assert.Equal(t, "keep_me", m["dfB"])
+		assert.Contains(t, m, "dfC", "non-conflicting key must be preserved")
+	})
+
+	t.Run("rejects $meta key in dynamic field", func(t *testing.T) {
+		schema := &schemapb.CollectionSchema{
+			Name:               "test_collection",
+			EnableDynamicField: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "id", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+				{FieldID: 102, Name: "$meta", DataType: schemapb.DataType_JSON, IsDynamic: true},
+			},
+		}
+
+		metaJSON := []byte(`{"$meta": "bad_value"}`)
+		insertMsg := &msgstream.InsertMsg{
+			InsertRequest: &msgpb.InsertRequest{
+				FieldsData: []*schemapb.FieldData{
+					{
+						FieldName: "$meta", FieldId: 102, Type: schemapb.DataType_JSON, IsDynamic: true,
+						Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_JsonData{
+							JsonData: &schemapb.JSONArray{Data: [][]byte{metaJSON}},
+						}}},
+					},
+				},
+			},
+		}
+
+		err := checkDynamicFieldDataForPartialUpdate(schema, insertMsg)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "$meta")
+	})
+
+	t.Run("rejects malformed JSON", func(t *testing.T) {
+		schema := &schemapb.CollectionSchema{
+			Name:               "test_collection",
+			EnableDynamicField: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "id", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+				{FieldID: 102, Name: "$meta", DataType: schemapb.DataType_JSON, IsDynamic: true},
+			},
+		}
+
+		insertMsg := &msgstream.InsertMsg{
+			InsertRequest: &msgpb.InsertRequest{
+				FieldsData: []*schemapb.FieldData{
+					{
+						FieldName: "$meta", FieldId: 102, Type: schemapb.DataType_JSON, IsDynamic: true,
+						Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_JsonData{
+							JsonData: &schemapb.JSONArray{Data: [][]byte{[]byte(`{invalid json`)}},
+						}}},
+					},
+				},
+			},
+		}
+
+		err := checkDynamicFieldDataForPartialUpdate(schema, insertMsg)
+		assert.Error(t, err)
+	})
+
+	t.Run("rejects dynamic field when dynamic schema is disabled", func(t *testing.T) {
+		schema := &schemapb.CollectionSchema{
+			Name:               "test_collection",
+			EnableDynamicField: false,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "id", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+			},
+		}
+
+		metaJSON := []byte(`{"key": "value"}`)
+		insertMsg := &msgstream.InsertMsg{
+			InsertRequest: &msgpb.InsertRequest{
+				FieldsData: []*schemapb.FieldData{
+					{
+						FieldName: "$meta", FieldId: 102, Type: schemapb.DataType_JSON, IsDynamic: true,
+						Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_JsonData{
+							JsonData: &schemapb.JSONArray{Data: [][]byte{metaJSON}},
+						}}},
+					},
+				},
+			},
+		}
+
+		err := checkDynamicFieldDataForPartialUpdate(schema, insertMsg)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "without dynamic schema enabled")
+	})
+
+	t.Run("auto-generates empty dynamic field when none present", func(t *testing.T) {
+		schema := &schemapb.CollectionSchema{
+			Name:               "test_collection",
+			EnableDynamicField: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "id", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+			},
+		}
+
+		insertMsg := &msgstream.InsertMsg{
+			InsertRequest: &msgpb.InsertRequest{
+				NumRows: 2,
+				Version: msgpb.InsertDataVersion_ColumnBased,
+				FieldsData: []*schemapb.FieldData{
+					{
+						FieldName: "id", FieldId: 100, Type: schemapb.DataType_Int64,
+						Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{
+							LongData: &schemapb.LongArray{Data: []int64{1, 2}},
+						}}},
+					},
+				},
+			},
+		}
+
+		err := checkDynamicFieldDataForPartialUpdate(schema, insertMsg)
+		assert.NoError(t, err)
+		// Should have appended a dynamic field
+		assert.Len(t, insertMsg.FieldsData, 2)
+		assert.True(t, insertMsg.FieldsData[1].IsDynamic)
+		assert.Len(t, insertMsg.FieldsData[1].GetScalars().GetJsonData().GetData(), 2)
+	})
+
+	t.Run("strict checkDynamicFieldData rejects what partial update allows", func(t *testing.T) {
+		schema := &schemapb.CollectionSchema{
+			Name:               "test_collection",
+			EnableDynamicField: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "id", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+				{FieldID: 101, Name: "end_timestamp", DataType: schemapb.DataType_Int64},
+				{FieldID: 102, Name: "$meta", DataType: schemapb.DataType_JSON, IsDynamic: true},
+			},
+		}
+
+		makeMsg := func() *msgstream.InsertMsg {
+			metaJSON := []byte(`{"end_timestamp": 1234, "color": "red"}`)
+			return &msgstream.InsertMsg{
+				InsertRequest: &msgpb.InsertRequest{
+					FieldsData: []*schemapb.FieldData{
+						{
+							FieldName: "$meta", FieldId: 102, Type: schemapb.DataType_JSON, IsDynamic: true,
+							Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_JsonData{
+								JsonData: &schemapb.JSONArray{Data: [][]byte{metaJSON}},
+							}}},
+						},
+					},
+				},
+			}
+		}
+
+		// Strict path must reject: $meta contains "end_timestamp" which is a static field
+		err := checkDynamicFieldData(schema, makeMsg())
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "end_timestamp")
+
+		// Partial update path must allow the same data
+		err = checkDynamicFieldDataForPartialUpdate(schema, makeMsg())
+		assert.NoError(t, err)
+	})
+
+	t.Run("multiple rows with mixed dynamic keys", func(t *testing.T) {
+		schema := &schemapb.CollectionSchema{
+			Name:               "test_collection",
+			EnableDynamicField: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "id", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+				{FieldID: 101, Name: "status", DataType: schemapb.DataType_VarChar},
+				{FieldID: 102, Name: "$meta", DataType: schemapb.DataType_JSON, IsDynamic: true},
+			},
+		}
+
+		row1 := []byte(`{"status": "active", "color": "red"}`)   // "status" matches static field
+		row2 := []byte(`{"color": "blue", "size": 42}`)          // no conflict
+		row3 := []byte(`{"status": "done", "tag": "important"}`) // "status" matches static field
+
+		insertMsg := &msgstream.InsertMsg{
+			InsertRequest: &msgpb.InsertRequest{
+				FieldsData: []*schemapb.FieldData{
+					{
+						FieldName: "$meta", FieldId: 102, Type: schemapb.DataType_JSON, IsDynamic: true,
+						Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_JsonData{
+							JsonData: &schemapb.JSONArray{Data: [][]byte{row1, row2, row3}},
+						}}},
+					},
+				},
+			},
+		}
+
+		err := checkDynamicFieldDataForPartialUpdate(schema, insertMsg)
+		assert.NoError(t, err)
+
+		// Verify all 3 rows preserved intact
+		jsonRows := insertMsg.FieldsData[0].GetScalars().GetJsonData().GetData()
+		assert.Len(t, jsonRows, 3)
+		for i, row := range jsonRows {
+			var m map[string]interface{}
+			assert.NoError(t, json.Unmarshal(row, &m), "row %d must be valid JSON", i)
+		}
+	})
+
+	t.Run("multiple static fields with overlapping keys in $meta", func(t *testing.T) {
+		schema := &schemapb.CollectionSchema{
+			Name:               "test_collection",
+			EnableDynamicField: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "id", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+				{FieldID: 101, Name: "fieldA", DataType: schemapb.DataType_Int64},
+				{FieldID: 102, Name: "fieldB", DataType: schemapb.DataType_VarChar},
+				{FieldID: 103, Name: "fieldC", DataType: schemapb.DataType_Float},
+				{FieldID: 104, Name: "$meta", DataType: schemapb.DataType_JSON, IsDynamic: true},
+			},
+		}
+
+		// $meta contains keys matching ALL 3 static fields plus an extra dynamic key
+		metaJSON := []byte(`{"fieldA": 1, "fieldB": "val", "fieldC": 3.14, "extra": true}`)
+		insertMsg := &msgstream.InsertMsg{
+			InsertRequest: &msgpb.InsertRequest{
+				FieldsData: []*schemapb.FieldData{
+					{
+						FieldName: "$meta", FieldId: 104, Type: schemapb.DataType_JSON, IsDynamic: true,
+						Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_JsonData{
+							JsonData: &schemapb.JSONArray{Data: [][]byte{metaJSON}},
+						}}},
+					},
+				},
+			},
+		}
+
+		err := checkDynamicFieldDataForPartialUpdate(schema, insertMsg)
+		assert.NoError(t, err)
+
+		var m map[string]interface{}
+		err = json.Unmarshal(insertMsg.FieldsData[0].GetScalars().GetJsonData().GetData()[0], &m)
+		assert.NoError(t, err)
+		assert.Contains(t, m, "fieldA")
+		assert.Contains(t, m, "fieldB")
+		assert.Contains(t, m, "fieldC")
+		assert.Contains(t, m, "extra")
+	})
+
+	t.Run("sets FieldName to $meta for IsDynamic field", func(t *testing.T) {
+		schema := &schemapb.CollectionSchema{
+			Name:               "test_collection",
+			EnableDynamicField: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "id", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+				{FieldID: 102, Name: "$meta", DataType: schemapb.DataType_JSON, IsDynamic: true},
+			},
+		}
+
+		metaJSON := []byte(`{"color": "green"}`)
+		insertMsg := &msgstream.InsertMsg{
+			InsertRequest: &msgpb.InsertRequest{
+				FieldsData: []*schemapb.FieldData{
+					{
+						FieldName: "original_name", FieldId: 102, Type: schemapb.DataType_JSON, IsDynamic: true,
+						Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_JsonData{
+							JsonData: &schemapb.JSONArray{Data: [][]byte{metaJSON}},
+						}}},
+					},
+				},
+			},
+		}
+
+		err := checkDynamicFieldDataForPartialUpdate(schema, insertMsg)
+		assert.NoError(t, err)
+		// The function must normalize FieldName to "$meta"
+		assert.Equal(t, "$meta", insertMsg.FieldsData[0].GetFieldName())
+	})
+
+	t.Run("non-conflicting keys pass both strict and partial update", func(t *testing.T) {
+		schema := &schemapb.CollectionSchema{
+			Name:               "test_collection",
+			EnableDynamicField: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "id", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+				{FieldID: 101, Name: "status", DataType: schemapb.DataType_VarChar},
+				{FieldID: 102, Name: "$meta", DataType: schemapb.DataType_JSON, IsDynamic: true},
+			},
+		}
+
+		makeMsg := func() *msgstream.InsertMsg {
+			metaJSON := []byte(`{"color": "blue", "size": 42}`)
+			return &msgstream.InsertMsg{
+				InsertRequest: &msgpb.InsertRequest{
+					FieldsData: []*schemapb.FieldData{
+						{
+							FieldName: "$meta", FieldId: 102, Type: schemapb.DataType_JSON, IsDynamic: true,
+							Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_JsonData{
+								JsonData: &schemapb.JSONArray{Data: [][]byte{metaJSON}},
+							}}},
+						},
+					},
+				},
+			}
+		}
+
+		// Both paths must accept $meta with no static field conflicts
+		err := checkDynamicFieldData(schema, makeMsg())
+		assert.NoError(t, err)
+
+		err = checkDynamicFieldDataForPartialUpdate(schema, makeMsg())
+		assert.NoError(t, err)
+	})
+
+	t.Run("empty JSON object in $meta", func(t *testing.T) {
+		schema := &schemapb.CollectionSchema{
+			Name:               "test_collection",
+			EnableDynamicField: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "id", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+				{FieldID: 101, Name: "value", DataType: schemapb.DataType_Int64},
+				{FieldID: 102, Name: "$meta", DataType: schemapb.DataType_JSON, IsDynamic: true},
+			},
+		}
+
+		insertMsg := &msgstream.InsertMsg{
+			InsertRequest: &msgpb.InsertRequest{
+				FieldsData: []*schemapb.FieldData{
+					{
+						FieldName: "$meta", FieldId: 102, Type: schemapb.DataType_JSON, IsDynamic: true,
+						Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_JsonData{
+							JsonData: &schemapb.JSONArray{Data: [][]byte{[]byte(`{}`)}},
+						}}},
+					},
+				},
+			},
+		}
+
+		err := checkDynamicFieldDataForPartialUpdate(schema, insertMsg)
+		assert.NoError(t, err)
+	})
 }
 
 // Test ToCompressedFormatNullable for Geometry and Timestamptz types

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -2353,7 +2353,7 @@ func ErrWithLog(logger *log.MLogger, msg string, err error) error {
 	return wrapErr
 }
 
-func verifyDynamicFieldData(schema *schemapb.CollectionSchema, insertMsg *msgstream.InsertMsg) error {
+func verifyDynamicFieldData(schema *schemapb.CollectionSchema, insertMsg *msgstream.InsertMsg, skipStaticFieldNameCheck bool) error {
 	for _, field := range insertMsg.FieldsData {
 		if field.GetFieldName() == common.MetaFieldName {
 			if !schema.EnableDynamicField {
@@ -2371,10 +2371,12 @@ func verifyDynamicFieldData(schema *schemapb.CollectionSchema, insertMsg *msgstr
 				if _, ok := jsonData[common.MetaFieldName]; ok {
 					return fmt.Errorf("cannot set json key to: %s", common.MetaFieldName)
 				}
-				for _, f := range schema.GetFields() {
-					if _, ok := jsonData[f.GetName()]; ok {
-						log.Info("dynamic field name include the static field name", zap.String("fieldName", f.GetName()))
-						return fmt.Errorf("dynamic field name cannot include the static field name: %s", f.GetName())
+				if !skipStaticFieldNameCheck {
+					for _, f := range schema.GetFields() {
+						if _, ok := jsonData[f.GetName()]; ok {
+							log.Info("dynamic field name include the static field name", zap.String("fieldName", f.GetName()))
+							return fmt.Errorf("dynamic field name cannot include the static field name: %s", f.GetName())
+						}
 					}
 				}
 			}
@@ -2384,11 +2386,15 @@ func verifyDynamicFieldData(schema *schemapb.CollectionSchema, insertMsg *msgstr
 	return nil
 }
 
-func checkDynamicFieldData(schema *schemapb.CollectionSchema, insertMsg *msgstream.InsertMsg) error {
+// doCheckDynamicFieldData is the shared implementation for dynamic field validation.
+// When skipStaticFieldNameCheck is true, $meta keys matching static field names are
+// allowed — this is needed for partial updates after schema evolution, where $meta
+// may legitimately contain keys that now correspond to static columns.
+func doCheckDynamicFieldData(schema *schemapb.CollectionSchema, insertMsg *msgstream.InsertMsg, skipStaticFieldNameCheck bool) error {
 	for _, data := range insertMsg.FieldsData {
 		if data.IsDynamic {
 			data.FieldName = common.MetaFieldName
-			return verifyDynamicFieldData(schema, insertMsg)
+			return verifyDynamicFieldData(schema, insertMsg, skipStaticFieldNameCheck)
 		}
 	}
 	defaultData := make([][]byte, insertMsg.NRows())
@@ -2398,6 +2404,20 @@ func checkDynamicFieldData(schema *schemapb.CollectionSchema, insertMsg *msgstre
 	dynamicData := autoGenDynamicFieldData(defaultData)
 	insertMsg.FieldsData = append(insertMsg.FieldsData, dynamicData)
 	return nil
+}
+
+func checkDynamicFieldData(schema *schemapb.CollectionSchema, insertMsg *msgstream.InsertMsg) error {
+	return doCheckDynamicFieldData(schema, insertMsg, false)
+}
+
+// checkDynamicFieldDataForPartialUpdate is a relaxed version of checkDynamicFieldData
+// for partial updates. After schema evolution, $meta may legitimately contain keys
+// matching static field names (e.g., a dynamic field "end_timestamp" that was later
+// added as a static column). This function validates JSON format and rejects the
+// reserved $meta key, but skips the static field name conflict check so that
+// existing dynamic field data is preserved.
+func checkDynamicFieldDataForPartialUpdate(schema *schemapb.CollectionSchema, insertMsg *msgstream.InsertMsg) error {
+	return doCheckDynamicFieldData(schema, insertMsg, true)
 }
 
 func addNamespaceData(schema *schemapb.CollectionSchema, insertMsg *msgstream.InsertMsg) error {

--- a/tests/python_client/milvus_client/test_milvus_client_partial_update.py
+++ b/tests/python_client/milvus_client/test_milvus_client_partial_update.py
@@ -1300,7 +1300,74 @@ class TestMilvusClientPartialUpdateValid(TestMilvusClientV2Base):
         assert result[0][0]["count(*)"] == default_nb
         
         self.drop_collection(client, collection_name)
-        
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_milvus_client_partial_update_after_schema_evolution_dynamic_to_static(self):
+        """
+        target: test partial update succeeds after a dynamic field name becomes a static column via schema evolution
+        method:
+            1. Create a collection with dynamic fields enabled
+            2. Insert full rows, then partial upsert a dynamic field `end_timestamp`
+            3. Add `end_timestamp` as a static column (schema evolution)
+            4. Partial upsert again with `end_timestamp` — should succeed after fix
+            5. Verify the static field has the new value
+        expected: Step 4 should succeed without "dynamic field name cannot include the static field name" error
+        """
+        # step 1: create collection with dynamic fields
+        client = self._client()
+        schema = self.create_schema(client, enable_dynamic_field=True)[0]
+        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
+        schema.add_field(default_string_field_name, DataType.VARCHAR, max_length=64, nullable=True)
+        index_params = self.prepare_index_params(client)[0]
+        index_params.add_index(default_primary_key_field_name, index_type="AUTOINDEX")
+        index_params.add_index(default_vector_field_name, index_type="AUTOINDEX")
+        collection_name = cf.gen_collection_name_by_testcase_name(module_index=1)
+        self.create_collection(client, collection_name, default_dim, schema=schema,
+                               consistency_level="Strong", index_params=index_params)
+
+        # step 2: insert full rows, then partial upsert dynamic field `end_timestamp`
+        nb = 100
+        vectors = cf.gen_vectors(nb, default_dim)
+        rows = [{default_primary_key_field_name: i,
+                 default_vector_field_name: vectors[i],
+                 default_string_field_name: f"row_{i}"} for i in range(nb)]
+        self.insert(client, collection_name, rows)
+        self.flush(client, collection_name)
+
+        partial_rows = [{default_primary_key_field_name: i, "end_timestamp": 1000 + i} for i in range(nb)]
+        self.upsert(client, collection_name, partial_rows, partial_update=True)
+        self.flush(client, collection_name)
+
+        # verify dynamic field was written
+        res = self.query(client, collection_name, filter="id < 5",
+                         output_fields=[default_primary_key_field_name, "end_timestamp"])[0]
+        for r in res:
+            assert "end_timestamp" in r, f"end_timestamp should exist as dynamic field, got {r}"
+
+        # step 3: add `end_timestamp` as a static column (schema evolution)
+        self.add_collection_field(client, collection_name, field_name="end_timestamp",
+                                  data_type=DataType.INT64, nullable=True)
+        self.release_collection(client, collection_name)
+        self.load_collection(client, collection_name)
+
+        # step 4: partial upsert again — this is the operation that used to fail
+        new_ts = 9999
+        partial_rows_2 = [{default_primary_key_field_name: i, "end_timestamp": new_ts + i} for i in range(nb)]
+        self.upsert(client, collection_name, partial_rows_2, partial_update=True)
+        self.flush(client, collection_name)
+
+        # step 5: verify the static field has the new value
+        res = self.query(client, collection_name, filter="id < 5",
+                         output_fields=[default_primary_key_field_name, "end_timestamp"])[0]
+        for r in res:
+            pk = r[default_primary_key_field_name]
+            assert r["end_timestamp"] == new_ts + pk, \
+                f"end_timestamp mismatch for pk={pk}: expected {new_ts + pk}, got {r['end_timestamp']}"
+
+        self.drop_collection(client, collection_name)
+
+
 class TestMilvusClientPartialUpdateInvalid(TestMilvusClientV2Base):
     """ Test case of partial update interface """
     @pytest.fixture(scope="function", params=[False, True])

--- a/tests/python_client/milvus_client/test_milvus_client_search_order.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search_order.py
@@ -1,0 +1,971 @@
+import random
+import pytest
+
+from base.client_v2_base import TestMilvusClientV2Base
+from utils.util_log import test_log as log
+from common import common_func as cf
+from common import common_type as ct
+from common.common_type import CaseLabel, CheckTasks
+from utils.util_pymilvus import *
+from pymilvus import DataType, AnnSearchRequest, WeightedRanker
+
+prefix = "client_search_order"
+default_nb = 3000
+default_dim = 8
+default_limit = 20
+default_primary_key_field_name = "id"
+default_vector_field_name = "embeddings"
+
+# Global collection names with unique suffix to avoid conflicts across parallel runs
+VALID_COLLECTION_NAME = "test_search_order_valid_" + cf.gen_unique_str("_")
+INVALID_COLLECTION_NAME = "test_search_order_invalid_" + cf.gen_unique_str("_")
+
+# Data generation constants
+PRICE_MIN = 10.0
+PRICE_MAX = 59.0
+RATING_MIN = 0.0
+RATING_MAX = 4.9
+CATEGORIES = [
+    "electronics", "tools", "books", "sports", "movies",
+    "games", "furniture", "health", "toys", "jewelry",
+    "cosmetics", "clothing", "garden", "food", "travel",
+    "pet_supplies", "beauty", "appliances", "automotive", "music"
+]
+
+
+def build_search_order_schema(client):
+    """Build schema for search order by tests.
+    Includes diverse scalar types and dynamic field for comprehensive coverage."""
+    schema = client.create_schema(auto_id=False, enable_dynamic_field=True)
+    schema.add_field("id", DataType.INT64, is_primary=True)
+    schema.add_field("price", DataType.DOUBLE)
+    schema.add_field("rating", DataType.DOUBLE)
+    schema.add_field("category", DataType.VARCHAR, max_length=64)
+    schema.add_field("int32_field", DataType.INT32)
+    schema.add_field("bool_field", DataType.BOOL)
+    schema.add_field("int8_field", DataType.INT8)
+    schema.add_field("int16_field", DataType.INT16)
+    schema.add_field("float_field", DataType.FLOAT)
+    schema.add_field("json_field", DataType.JSON)
+    schema.add_field("embeddings", DataType.FLOAT_VECTOR, dim=default_dim)
+    return schema
+
+
+def gen_search_order_data(nb, schema):
+    """Generate test data using cf.gen_row_data_by_schema, then override
+    fields with controlled values for order-by testing."""
+    rows = cf.gen_row_data_by_schema(nb=nb, schema=schema)
+    for i, row in enumerate(rows):
+        row["price"] = float(random.randint(int(PRICE_MIN), int(PRICE_MAX)))
+        row["rating"] = round(random.uniform(RATING_MIN, RATING_MAX), 1)
+        row["category"] = CATEGORIES[i % len(CATEGORIES)]
+        row["bool_field"] = i % 2 == 0
+        row["int8_field"] = i % 127
+        row["int16_field"] = i % 1000
+        row["float_field"] = round(random.uniform(0.0, 100.0), 2)
+        row["json_field"] = {"nested_price": float(random.randint(1, 100)),
+                             "nested": {"score": round(random.uniform(0, 10), 1)}}
+        # Dynamic fields (not in schema, stored via enable_dynamic_field=True)
+        row["dyn_age"] = random.randint(18, 80)
+        row["dyn_meta"] = {"price": float(random.randint(1, 100)),
+                           "profile": {"score": round(random.uniform(0, 10), 1)}}
+    return rows
+
+
+@pytest.mark.xdist_group("TestMilvusClientSearchOrderValid")
+class TestMilvusClientSearchOrderValid(TestMilvusClientV2Base):
+    """
+    Test cases for search with order_by_fields - valid scenarios.
+    Collection is initialized once via fixture and shared across all tests.
+    """
+
+    @pytest.fixture(scope="module", autouse=True)
+    def prepare_valid_collection(self, request):
+        """Create the shared collection once before all tests in this module,
+        and drop it after all tests complete."""
+        client = self._client()
+        collection_name = VALID_COLLECTION_NAME
+        if client.has_collection(collection_name):
+            client.drop_collection(collection_name)
+
+        schema = build_search_order_schema(client)
+
+        index_params = client.prepare_index_params()
+        index_params.add_index(field_name="embeddings", index_type="HNSW",
+                               metric_type="COSINE", M=16, efConstruction=200)
+
+        client.create_collection(collection_name=collection_name, schema=schema,
+                                 index_params=index_params, consistency_level="Strong")
+
+        # Insert data in 3 batches to create multiple segments
+        nb = default_nb
+        all_rows = gen_search_order_data(nb, schema)
+        batch_size = nb // 3
+        for i in range(3):
+            start = i * batch_size
+            end = start + batch_size if i < 2 else nb
+            client.insert(collection_name=collection_name, data=all_rows[start:end])
+
+        client.flush(collection_name=collection_name)
+
+        def teardown():
+            try:
+                if self.has_collection(self._client(), VALID_COLLECTION_NAME):
+                    self.drop_collection(self._client(), VALID_COLLECTION_NAME)
+            except Exception:
+                pass
+        request.addfinalizer(teardown)
+
+    # ==================== L0: Smoke Tests ====================
+
+    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.parametrize("field_name,order", [
+        ("price", "asc"),
+        ("price", "ascending"),
+        ("rating", "desc"),
+        ("rating", "descending"),
+    ])
+    def test_milvus_client_search_order_by_single_field(self, field_name, order):
+        """
+        target: test search with order_by_fields on a single field with all direction forms
+        method: search with order_by_fields using asc/ascending/desc/descending
+        expected: results sorted correctly in the specified direction
+        """
+        client = self._client()
+        collection_name = VALID_COLLECTION_NAME
+
+        vectors_to_search = cf.gen_vectors(1, default_dim)
+        res = self.search(client, collection_name, vectors_to_search,
+                          limit=default_limit,
+                          anns_field="embeddings",
+                          output_fields=["id", "price", "rating", "category"],
+                          order_by_fields=[{"field": field_name, "order": order}],
+                          consistency_level="Strong")[0]
+
+        assert len(res) == 1, f"Expected 1 query result, got {len(res)}"
+        results = res[0]
+        assert len(results) == default_limit, f"Expected {default_limit} results, got {len(results)}"
+
+        # Verify all output fields are present
+        for r in results:
+            for f in ["price", "rating", "category", "id"]:
+                assert f in r["entity"], f"Field '{f}' missing in result entity"
+
+        # Verify sort order
+        is_asc = order in ("asc", "ascending")
+        values = [r["entity"][field_name] for r in results]
+        for i in range(len(values) - 1):
+            if is_asc:
+                assert values[i] <= values[i + 1], \
+                    f"{field_name} not ascending at index {i}: {values[i]} > {values[i + 1]}"
+            else:
+                assert values[i] >= values[i + 1], \
+                    f"{field_name} not descending at index {i}: {values[i]} < {values[i + 1]}"
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_milvus_client_search_order_by_multi_fields(self):
+        """
+        target: test search with multi-field order_by (price asc, rating desc)
+        method: search with order_by_fields with two fields
+        expected: results sorted by price asc first, then by rating desc within same price
+        """
+        client = self._client()
+        collection_name = VALID_COLLECTION_NAME
+
+        vectors_to_search = cf.gen_vectors(1, default_dim)
+        res = self.search(client, collection_name, vectors_to_search,
+                          limit=default_limit,
+                          anns_field="embeddings",
+                          output_fields=["id", "price", "rating", "category"],
+                          order_by_fields=[
+                              {"field": "price", "order": "asc"},
+                              {"field": "rating", "order": "desc"}
+                          ],
+                          consistency_level="Strong")[0]
+
+        results = res[0]
+        assert len(results) == default_limit
+
+        # Verify primary sort: price ascending
+        prices = [r["entity"]["price"] for r in results]
+        for i in range(len(prices) - 1):
+            assert prices[i] <= prices[i + 1], \
+                f"Price not ascending at index {i}: {prices[i]} > {prices[i + 1]}"
+
+        # Verify secondary sort: within same price, rating descending
+        for i in range(len(results) - 1):
+            if results[i]["entity"]["price"] == results[i + 1]["entity"]["price"]:
+                assert results[i]["entity"]["rating"] >= results[i + 1]["entity"]["rating"], \
+                    f"Rating not descending within same price at index {i}: " \
+                    f"price={results[i]['entity']['price']}, " \
+                    f"rating {results[i]['entity']['rating']} < {results[i + 1]['entity']['rating']}"
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_milvus_client_search_group_by_with_order_by(self):
+        """
+        target: test search with group_by_field combined with order_by_fields
+        method: search with group_by_field="category" and order_by_fields price asc
+        expected: results grouped by category, groups ordered by price ascending
+        """
+        client = self._client()
+        collection_name = VALID_COLLECTION_NAME
+
+        vectors_to_search = cf.gen_vectors(1, default_dim)
+        res = self.search(client, collection_name, vectors_to_search,
+                          limit=default_limit,
+                          anns_field="embeddings",
+                          output_fields=["id", "price", "rating", "category"],
+                          group_by_field="category",
+                          group_size=3,
+                          strict_group_size=True,
+                          order_by_fields=[{"field": "price", "order": "asc"}],
+                          consistency_level="Strong")[0]
+
+        results = res[0]
+        assert len(results) > 0
+
+        # Verify grouping: collect groups by category
+        groups = {}
+        for r in results:
+            cat = r["entity"]["category"]
+            if cat not in groups:
+                groups[cat] = []
+            groups[cat].append(r)
+
+        # Verify each group has at most group_size entities
+        for cat, group_results in groups.items():
+            assert len(group_results) <= 3, \
+                f"Category '{cat}' has {len(group_results)} results, expected <= 3"
+
+        # Verify top1 of each group is sorted by price ascending
+        group_top1_prices = []
+        seen_categories = []
+        for r in results:
+            cat = r["entity"]["category"]
+            if cat not in seen_categories:
+                seen_categories.append(cat)
+                group_top1_prices.append(r["entity"]["price"])
+
+        for i in range(len(group_top1_prices) - 1):
+            assert group_top1_prices[i] <= group_top1_prices[i + 1], \
+                f"Group top1 price not ascending at index {i}: " \
+                f"{group_top1_prices[i]} > {group_top1_prices[i + 1]}"
+
+    # ==================== L1: Core Functionality ====================
+
+    @pytest.mark.tags(CaseLabel.L1)
+    @pytest.mark.parametrize("field_name,order", [
+        ("bool_field", "asc"),
+        ("int8_field", "asc"),
+        ("int8_field", "desc"),
+        ("int16_field", "asc"),
+        ("int16_field", "desc"),
+        ("int32_field", "asc"),
+        ("int32_field", "desc"),
+        ("float_field", "asc"),
+        ("float_field", "desc"),
+        ("category", "asc"),
+    ])
+    def test_milvus_client_search_order_by_scalar_types(self, field_name, order):
+        """
+        target: test search order by various scalar data types
+        method: search with order_by_fields on bool/int8/int16/int32/float fields
+        expected: results sorted correctly for each type
+        """
+        client = self._client()
+        collection_name = VALID_COLLECTION_NAME
+
+        vectors_to_search = cf.gen_vectors(1, default_dim)
+        res = self.search(client, collection_name, vectors_to_search,
+                          limit=default_limit,
+                          anns_field="embeddings",
+                          output_fields=["id", field_name],
+                          order_by_fields=[{"field": field_name, "order": order}],
+                          consistency_level="Strong")[0]
+
+        results = res[0]
+        assert len(results) == default_limit
+        values = [r["entity"][field_name] for r in results]
+        for i in range(len(values) - 1):
+            if order == "asc":
+                assert values[i] <= values[i + 1], \
+                    f"{field_name} not ascending at index {i}: {values[i]} > {values[i + 1]}"
+            else:
+                assert values[i] >= values[i + 1], \
+                    f"{field_name} not descending at index {i}: {values[i]} < {values[i + 1]}"
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_milvus_client_search_order_by_field_not_in_output_fields(self):
+        """
+        target: test that order_by field not in output_fields still sorts correctly
+        method: search with order_by on price but output_fields only has id and category
+        expected: results are still sorted by price (auto-added to requery)
+        """
+        client = self._client()
+        collection_name = VALID_COLLECTION_NAME
+
+        vectors_to_search = cf.gen_vectors(1, default_dim)
+        res = self.search(client, collection_name, vectors_to_search,
+                          limit=default_limit,
+                          anns_field="embeddings",
+                          output_fields=["id", "category"],
+                          order_by_fields=[{"field": "price", "order": "asc"}],
+                          consistency_level="Strong")[0]
+
+        results = res[0]
+        assert len(results) == default_limit
+        # price should be auto-included in output for order_by requery
+        if "price" in results[0]["entity"]:
+            prices = [r["entity"]["price"] for r in results]
+            for i in range(len(prices) - 1):
+                assert prices[i] <= prices[i + 1], \
+                    f"Price not ascending at index {i}: {prices[i]} > {prices[i + 1]}"
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_milvus_client_search_order_by_dynamic_field(self):
+        """
+        target: test search order by a dynamic field (not in schema)
+        method: search with order_by_fields on dynamic field "dyn_age"
+        expected: results sorted by dynamic field value
+        """
+        client = self._client()
+        collection_name = VALID_COLLECTION_NAME
+
+        vectors_to_search = cf.gen_vectors(1, default_dim)
+        res = self.search(client, collection_name, vectors_to_search,
+                          limit=default_limit,
+                          anns_field="embeddings",
+                          output_fields=["id", "dyn_age"],
+                          order_by_fields=[{"field": "dyn_age", "order": "asc"}],
+                          consistency_level="Strong")[0]
+
+        results = res[0]
+        assert len(results) == default_limit
+        ages = [r["entity"]["dyn_age"] for r in results]
+        for i in range(len(ages) - 1):
+            assert ages[i] <= ages[i + 1], \
+                f"dyn_age not ascending at index {i}: {ages[i]} > {ages[i + 1]}"
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_milvus_client_search_order_by_json_path(self):
+        """
+        target: test search order by JSON path on schema JSON field
+        method: search with order_by_fields using JSON path syntax json_field["nested_price"]
+        expected: results sorted by the JSON path value
+        """
+        client = self._client()
+        collection_name = VALID_COLLECTION_NAME
+
+        vectors_to_search = cf.gen_vectors(1, default_dim)
+        res = self.search(client, collection_name, vectors_to_search,
+                          limit=default_limit,
+                          anns_field="embeddings",
+                          output_fields=["id", "json_field"],
+                          order_by_fields=[{"field": 'json_field["nested_price"]', "order": "asc"}],
+                          consistency_level="Strong")[0]
+
+        results = res[0]
+        assert len(results) == default_limit
+        prices = [r["entity"]["json_field"]["nested_price"] for r in results]
+        for i in range(len(prices) - 1):
+            assert prices[i] <= prices[i + 1], \
+                f"json nested_price not ascending at index {i}: {prices[i]} > {prices[i + 1]}"
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_milvus_client_search_order_by_nested_json_path(self):
+        """
+        target: test search order by nested JSON path on schema JSON field
+        method: search with order_by_fields using json_field["nested"]["score"]
+        expected: results sorted by the deeply nested JSON value
+        """
+        client = self._client()
+        collection_name = VALID_COLLECTION_NAME
+
+        vectors_to_search = cf.gen_vectors(1, default_dim)
+        res = self.search(client, collection_name, vectors_to_search,
+                          limit=default_limit,
+                          anns_field="embeddings",
+                          output_fields=["id", "json_field"],
+                          order_by_fields=[{"field": 'json_field["nested"]["score"]', "order": "desc"}],
+                          consistency_level="Strong")[0]
+
+        results = res[0]
+        assert len(results) == default_limit
+        scores = [r["entity"]["json_field"]["nested"]["score"] for r in results]
+        for i in range(len(scores) - 1):
+            assert scores[i] >= scores[i + 1], \
+                f"nested score not descending at index {i}: {scores[i]} < {scores[i + 1]}"
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_milvus_client_search_order_by_dynamic_json_path(self):
+        """
+        target: test search order by JSON path on a dynamic field
+        method: search with order_by_fields using dyn_meta["price"] (dynamic field with JSON path)
+        expected: results sorted by the nested dynamic field value
+        """
+        client = self._client()
+        collection_name = VALID_COLLECTION_NAME
+
+        vectors_to_search = cf.gen_vectors(1, default_dim)
+        res = self.search(client, collection_name, vectors_to_search,
+                          limit=default_limit,
+                          anns_field="embeddings",
+                          output_fields=["id", "dyn_meta"],
+                          order_by_fields=[{"field": 'dyn_meta["price"]', "order": "asc"}],
+                          consistency_level="Strong")[0]
+
+        results = res[0]
+        assert len(results) == default_limit
+        dyn_prices = [r["entity"]["dyn_meta"]["price"] for r in results]
+        for i in range(len(dyn_prices) - 1):
+            assert dyn_prices[i] <= dyn_prices[i + 1], \
+                f"dyn_meta.price not ascending at index {i}: {dyn_prices[i]} > {dyn_prices[i + 1]}"
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_milvus_client_search_order_by_with_filter(self):
+        """
+        target: test search order by with filter expression
+        method: search with filter "price >= 20.0 && price <= 40.0" and order_by price asc
+        expected: only filtered results returned, sorted by price ascending
+        """
+        client = self._client()
+        collection_name = VALID_COLLECTION_NAME
+
+        vectors_to_search = cf.gen_vectors(1, default_dim)
+        filter_expr = "price >= 20.0 && price <= 40.0"
+        res = self.search(client, collection_name, vectors_to_search,
+                          limit=default_limit,
+                          anns_field="embeddings",
+                          filter=filter_expr,
+                          output_fields=["id", "price", "rating"],
+                          order_by_fields=[{"field": "price", "order": "asc"}],
+                          consistency_level="Strong")[0]
+
+        results = res[0]
+        assert len(results) <= default_limit
+
+        prices = [r["entity"]["price"] for r in results]
+        # Verify filter
+        for p in prices:
+            assert 20.0 <= p <= 40.0, f"Price {p} not in filter range [20.0, 40.0]"
+        # Verify sort
+        for i in range(len(prices) - 1):
+            assert prices[i] <= prices[i + 1], \
+                f"Price not ascending at index {i}: {prices[i]} > {prices[i + 1]}"
+
+    @pytest.mark.tags(CaseLabel.L1)
+    @pytest.mark.parametrize("limit", [1, 50, 100])
+    def test_milvus_client_search_order_by_different_limit(self, limit):
+        """
+        target: test search order by with different limit values
+        method: search with various limit values and order_by price asc
+        expected: correct number of results returned, all sorted
+        """
+        client = self._client()
+        collection_name = VALID_COLLECTION_NAME
+
+        vectors_to_search = cf.gen_vectors(1, default_dim)
+        res = self.search(client, collection_name, vectors_to_search,
+                          limit=limit,
+                          anns_field="embeddings",
+                          output_fields=["id", "price"],
+                          order_by_fields=[{"field": "price", "order": "asc"}],
+                          consistency_level="Strong")[0]
+
+        results = res[0]
+        assert len(results) == limit, f"Expected {limit} results, got {len(results)}"
+
+        prices = [r["entity"]["price"] for r in results]
+        for i in range(len(prices) - 1):
+            assert prices[i] <= prices[i + 1], \
+                f"Price not ascending at index {i}: {prices[i]} > {prices[i + 1]}"
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_milvus_client_search_order_by_output_fields_complete(self):
+        """
+        target: test that all specified output_fields are present in results
+        method: search with order_by and multiple output_fields
+        expected: every result entity contains all specified output fields
+        """
+        client = self._client()
+        collection_name = VALID_COLLECTION_NAME
+
+        vectors_to_search = cf.gen_vectors(1, default_dim)
+        output_fields = ["id", "price", "rating", "category", "int32_field"]
+        res = self.search(client, collection_name, vectors_to_search,
+                          limit=default_limit,
+                          anns_field="embeddings",
+                          output_fields=output_fields,
+                          order_by_fields=[{"field": "price", "order": "asc"}],
+                          consistency_level="Strong")[0]
+
+        results = res[0]
+        for r in results:
+            for field in output_fields:
+                assert field in r["entity"], \
+                    f"Field '{field}' missing in result entity: {r['entity'].keys()}"
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_milvus_client_search_group_by_order_by_with_group_size(self):
+        """
+        target: test group_by + order_by with group_size parameter
+        method: search with group_by_field, group_size=2, order_by price asc
+        expected: each group has at most 2 entities
+        """
+        client = self._client()
+        collection_name = VALID_COLLECTION_NAME
+
+        vectors_to_search = cf.gen_vectors(1, default_dim)
+        res = self.search(client, collection_name, vectors_to_search,
+                          limit=default_limit,
+                          anns_field="embeddings",
+                          output_fields=["id", "price", "category"],
+                          group_by_field="category",
+                          group_size=2,
+                          order_by_fields=[{"field": "price", "order": "asc"}],
+                          consistency_level="Strong")[0]
+
+        results = res[0]
+        groups = {}
+        for r in results:
+            cat = r["entity"]["category"]
+            if cat not in groups:
+                groups[cat] = []
+            groups[cat].append(r)
+
+        for cat, group_results in groups.items():
+            assert len(group_results) <= 2, \
+                f"Category '{cat}' has {len(group_results)} results, expected <= 2"
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_milvus_client_search_group_by_order_by_strict_group_size(self):
+        """
+        target: test group_by + order_by with strict_group_size=True
+        method: search with strict_group_size=True
+        expected: each group has exactly group_size entities (if enough data)
+        """
+        client = self._client()
+        collection_name = VALID_COLLECTION_NAME
+
+        vectors_to_search = cf.gen_vectors(1, default_dim)
+        group_size = 3
+        res = self.search(client, collection_name, vectors_to_search,
+                          limit=default_limit,
+                          anns_field="embeddings",
+                          output_fields=["id", "price", "category"],
+                          group_by_field="category",
+                          group_size=group_size,
+                          strict_group_size=True,
+                          order_by_fields=[{"field": "price", "order": "asc"}],
+                          consistency_level="Strong")[0]
+
+        results = res[0]
+        groups = {}
+        for r in results:
+            cat = r["entity"]["category"]
+            if cat not in groups:
+                groups[cat] = []
+            groups[cat].append(r)
+
+        # With strict_group_size=True, each group should have exactly group_size
+        for cat, group_results in groups.items():
+            assert len(group_results) == group_size, \
+                f"Category '{cat}' has {len(group_results)} results, expected exactly {group_size}"
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_milvus_client_search_order_by_multi_nq(self):
+        """
+        target: test search order by with multiple query vectors (nq > 1)
+        method: search with 3 query vectors and order_by price asc
+        expected: each nq result is independently sorted by price ascending
+        """
+        client = self._client()
+        collection_name = VALID_COLLECTION_NAME
+
+        nq = 3
+        vectors_to_search = cf.gen_vectors(nq, default_dim)
+        res = self.search(client, collection_name, vectors_to_search,
+                          limit=default_limit,
+                          anns_field="embeddings",
+                          output_fields=["id", "price"],
+                          order_by_fields=[{"field": "price", "order": "asc"}],
+                          consistency_level="Strong")[0]
+
+        assert len(res) == nq, f"Expected {nq} result sets, got {len(res)}"
+
+        for q in range(nq):
+            results = res[q]
+            assert len(results) == default_limit
+            prices = [r["entity"]["price"] for r in results]
+            for i in range(len(prices) - 1):
+                assert prices[i] <= prices[i + 1], \
+                    f"nq={q}: Price not ascending at index {i}: {prices[i]} > {prices[i + 1]}"
+
+    # ==================== L2: Edge Cases & Boundary Tests ====================
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_milvus_client_search_order_by_with_narrow_filter(self):
+        """
+        target: test order by with a narrow filter that returns few results
+        method: search with filter on a specific category and order by price
+        expected: filtered results sorted correctly, count <= limit
+        """
+        client = self._client()
+        collection_name = VALID_COLLECTION_NAME
+
+        vectors_to_search = cf.gen_vectors(1, default_dim)
+        filter_expr = "category == \"electronics\""
+        res = self.search(client, collection_name, vectors_to_search,
+                          limit=default_limit,
+                          anns_field="embeddings",
+                          filter=filter_expr,
+                          output_fields=["id", "price", "category"],
+                          order_by_fields=[{"field": "price", "order": "asc"}],
+                          consistency_level="Strong")[0]
+
+        results = res[0]
+        for r in results:
+            assert r["entity"]["category"] == "electronics"
+
+        prices = [r["entity"]["price"] for r in results]
+        for i in range(len(prices) - 1):
+            assert prices[i] <= prices[i + 1], \
+                f"Price not ascending at index {i}: {prices[i]} > {prices[i + 1]}"
+
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_milvus_client_search_order_by_nullable_field(self):
+        """
+        target: test order_by on nullable field with NULLS FIRST semantics
+        method: create collection with nullable price field, insert some null values,
+                search with order_by price asc
+        expected: null values appear before all non-null values (NULLS FIRST)
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(prefix)
+
+        schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
+        schema.add_field("id", DataType.INT64, is_primary=True)
+        schema.add_field("score", DataType.DOUBLE, nullable=True)
+        schema.add_field("embeddings", DataType.FLOAT_VECTOR, dim=default_dim)
+
+        index_params = client.prepare_index_params()
+        index_params.add_index(field_name="embeddings", index_type="HNSW",
+                               metric_type="COSINE", M=16, efConstruction=200)
+
+        client.create_collection(collection_name=collection_name, schema=schema,
+                                 index_params=index_params, consistency_level="Strong")
+        try:
+            nb = 500
+            rows = []
+            for i in range(nb):
+                row = {
+                    "id": i,
+                    "embeddings": list(cf.gen_vectors(1, default_dim)[0]),
+                }
+                # Make ~20% of values null
+                if i % 5 == 0:
+                    row["score"] = None
+                else:
+                    row["score"] = float(random.randint(1, 100))
+                rows.append(row)
+            client.insert(collection_name=collection_name, data=rows)
+            client.flush(collection_name=collection_name)
+
+            vectors_to_search = cf.gen_vectors(1, default_dim)
+            res = self.search(client, collection_name, vectors_to_search,
+                              limit=default_limit,
+                              anns_field="embeddings",
+                              output_fields=["id", "score"],
+                              order_by_fields=[{"field": "score", "order": "asc"}],
+                              consistency_level="Strong")[0]
+
+            results = res[0]
+            assert len(results) == default_limit
+
+            # Verify NULLS FIRST: all nulls come before non-nulls
+            seen_non_null = False
+            non_null_scores = []
+            for r in results:
+                val = r["entity"].get("score")
+                if val is None:
+                    assert not seen_non_null, \
+                        "Null value found after non-null value (expected NULLS FIRST)"
+                else:
+                    seen_non_null = True
+                    non_null_scores.append(val)
+
+            # Verify non-null values are sorted ascending
+            for i in range(len(non_null_scores) - 1):
+                assert non_null_scores[i] <= non_null_scores[i + 1], \
+                    f"Score not ascending at index {i}: {non_null_scores[i]} > {non_null_scores[i + 1]}"
+        finally:
+            client.drop_collection(collection_name)
+
+
+@pytest.mark.xdist_group("TestMilvusClientSearchOrderInvalid")
+class TestMilvusClientSearchOrderInvalid(TestMilvusClientV2Base):
+    """
+    Test cases for search with order_by_fields - invalid/negative scenarios.
+    Collection is initialized once via fixture and shared across all tests.
+    """
+
+    @pytest.fixture(scope="module", autouse=True)
+    def prepare_invalid_collection(self, request):
+        """Create the shared collection once before all tests in this module,
+        and drop it after all tests complete."""
+        client = self._client()
+        collection_name = INVALID_COLLECTION_NAME
+        if client.has_collection(collection_name):
+            client.drop_collection(collection_name)
+
+        schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
+        schema.add_field("id", DataType.INT64, is_primary=True)
+        schema.add_field("price", DataType.DOUBLE)
+        schema.add_field("json_field", DataType.JSON)
+        schema.add_field("embeddings", DataType.FLOAT_VECTOR, dim=default_dim)
+
+        index_params = client.prepare_index_params()
+        index_params.add_index(field_name="embeddings", index_type="HNSW",
+                               metric_type="COSINE", M=16, efConstruction=200)
+
+        client.create_collection(collection_name=collection_name, schema=schema,
+                                 index_params=index_params, consistency_level="Strong")
+
+        rows = cf.gen_row_data_by_schema(nb=500, schema=schema)
+        for i, row in enumerate(rows):
+            row["price"] = float(random.randint(10, 59))
+            row["json_field"] = {"val": i}
+        client.insert(collection_name=collection_name, data=rows)
+        client.flush(collection_name=collection_name)
+
+        def teardown():
+            try:
+                if self.has_collection(self._client(), INVALID_COLLECTION_NAME):
+                    self.drop_collection(self._client(), INVALID_COLLECTION_NAME)
+            except Exception:
+                pass
+        request.addfinalizer(teardown)
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_milvus_client_search_order_by_nonexistent_field(self):
+        """
+        target: test search order by a field that does not exist in schema
+        method: search with order_by_fields on non-existent field
+        expected: returns error
+        """
+        client = self._client()
+        collection_name = INVALID_COLLECTION_NAME
+
+        vectors_to_search = cf.gen_vectors(1, default_dim)
+        error = {ct.err_code: 65536, ct.err_msg: "order_by field 'nonexistent_field' does not exist in collection schema"}
+        self.search(client, collection_name, vectors_to_search,
+                    limit=default_limit,
+                    anns_field="embeddings",
+                    output_fields=["id", "price"],
+                    order_by_fields=[{"field": "nonexistent_field", "order": "asc"}],
+                    check_task=CheckTasks.err_res,
+                    check_items=error)
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_milvus_client_search_order_by_vector_field(self):
+        """
+        target: test search order by a vector field
+        method: search with order_by_fields on embeddings (vector field)
+        expected: returns error
+        """
+        client = self._client()
+        collection_name = INVALID_COLLECTION_NAME
+
+        vectors_to_search = cf.gen_vectors(1, default_dim)
+        error = {
+            ct.err_code: 65536,
+            ct.err_msg: (
+                "order_by field 'embeddings' has unsortable type FloatVector; supported types: "
+                "bool, int8/16/32/64, float, double, string, varchar; for JSON fields use path "
+                "syntax like field[\"key\"]"
+            )
+        }
+        self.search(client, collection_name, vectors_to_search,
+                    limit=default_limit,
+                    anns_field="embeddings",
+                    output_fields=["id", "price"],
+                    order_by_fields=[{"field": "embeddings", "order": "asc"}],
+                    check_task=CheckTasks.err_res,
+                    check_items=error)
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_milvus_client_search_order_by_invalid_order_value(self):
+        """
+        target: test search order by with invalid order value
+        method: search with order_by_fields with order="invalid"
+        expected: returns error
+        """
+        client = self._client()
+        collection_name = INVALID_COLLECTION_NAME
+
+        vectors_to_search = cf.gen_vectors(1, default_dim)
+        error = {ct.err_code: 65536, ct.err_msg: "invalid order direction 'invalid' for field 'price', expected 'asc' or 'desc'"}
+        self.search(client, collection_name, vectors_to_search,
+                    limit=default_limit,
+                    anns_field="embeddings",
+                    output_fields=["id", "price"],
+                    order_by_fields=[{"field": "price", "order": "invalid"}],
+                    check_task=CheckTasks.err_res,
+                    check_items=error)
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_milvus_client_search_order_by_empty_list(self):
+        """
+        target: test search order by with empty order_by_fields list
+        method: search with order_by_fields=[]
+        expected: normal search behavior (no ordering applied) or returns error
+        """
+        client = self._client()
+        collection_name = INVALID_COLLECTION_NAME
+
+        vectors_to_search = cf.gen_vectors(1, default_dim)
+        # Empty list should either work as normal search or return error
+        res = self.search(client, collection_name, vectors_to_search,
+                          limit=default_limit,
+                          anns_field="embeddings",
+                          output_fields=["id", "price"],
+                          order_by_fields=[],
+                          consistency_level="Strong")[0]
+
+        # Should return results (normal search without ordering)
+        results = res[0]
+        assert len(results) == default_limit
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_milvus_client_search_order_by_missing_field_key(self):
+        """
+        target: test search order by with malformed dict (missing 'field' key)
+        method: search with order_by_fields=[{"order": "asc"}]
+        expected: returns error
+        """
+        client = self._client()
+        collection_name = INVALID_COLLECTION_NAME
+
+        vectors_to_search = cf.gen_vectors(1, default_dim)
+        error = {ct.err_code: 1, ct.err_msg: "Invalid order_by_fields item: 'field' key is required and cannot be empty"}
+        self.search(client, collection_name, vectors_to_search,
+                    limit=default_limit,
+                    anns_field="embeddings",
+                    output_fields=["id", "price"],
+                    order_by_fields=[{"order": "asc"}],
+                    check_task=CheckTasks.err_res,
+                    check_items=error)
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_milvus_client_search_order_by_missing_order_key(self):
+        """
+        target: test search order by with malformed dict (missing 'order' key)
+        method: search with order_by_fields=[{"field": "price"}]
+        expected: returns error or defaults to ascending
+        """
+        client = self._client()
+        collection_name = INVALID_COLLECTION_NAME
+
+        vectors_to_search = cf.gen_vectors(1, default_dim)
+        # Missing 'order' key - may default to asc or return error
+        try:
+            res = self.search(client, collection_name, vectors_to_search,
+                              limit=default_limit,
+                              anns_field="embeddings",
+                              output_fields=["id", "price"],
+                              order_by_fields=[{"field": "price"}],
+                              consistency_level="Strong")[0]
+            # If it succeeds, verify it defaults to some ordering
+            results = res[0]
+            assert len(results) == default_limit
+        except Exception as e:
+            log.info(f"Expected error for missing 'order' key: {e}")
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_milvus_client_search_order_by_iterator_conflict(self):
+        """
+        target: test that order_by is not supported with search iterator
+        method: call search_iterator with order_by_fields parameter
+        expected: returns error indicating incompatibility
+        """
+        client = self._client()
+        collection_name = INVALID_COLLECTION_NAME
+
+        vectors_to_search = cf.gen_vectors(1, default_dim)
+        error = {ct.err_code: 1,
+                 ct.err_msg: "order_by is not supported when using search iterator"}
+        self.search_iterator(client, collection_name, vectors_to_search,
+                             batch_size=10,
+                             anns_field="embeddings",
+                             output_fields=["id", "price"],
+                             order_by_fields=[{"field": "price", "order": "asc"}],
+                             check_task=CheckTasks.err_res,
+                             check_items=error)
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_milvus_client_search_order_by_json_field_without_path(self):
+        """
+        target: test that order_by on a regular JSON field (without path) is rejected
+        method: search with order_by_fields on json_field directly
+        expected: returns error indicating JSON field needs path syntax
+        """
+        client = self._client()
+        collection_name = INVALID_COLLECTION_NAME
+
+        vectors_to_search = cf.gen_vectors(1, default_dim)
+        error = {ct.err_code: 65535,
+                 ct.err_msg: (
+                     "order_by field 'json_field' has unsortable type JSON; supported types: "
+                     "bool, int8/16/32/64, float, double, string, varchar; for JSON fields use "
+                     "path syntax like field[\"key\"]"
+                 )}
+        self.search(client, collection_name, vectors_to_search,
+                    limit=default_limit,
+                    anns_field="embeddings",
+                    output_fields=["id", "price"],
+                    order_by_fields=[{"field": "json_field", "order": "asc"}],
+                    check_task=CheckTasks.err_res,
+                    check_items=error)
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_milvus_client_search_order_by_empty_field_name(self):
+        """
+        target: test search order by with empty string as field name
+        method: search with order_by_fields=[{"field": "", "order": "asc"}]
+        expected: returns error about empty field name
+        """
+        client = self._client()
+        collection_name = INVALID_COLLECTION_NAME
+
+        vectors_to_search = cf.gen_vectors(1, default_dim)
+        error = {ct.err_code: 1,
+                 ct.err_msg: "Invalid order_by_fields item: 'field' key is required and cannot be empty"}
+        self.search(client, collection_name, vectors_to_search,
+                    limit=default_limit,
+                    anns_field="embeddings",
+                    output_fields=["id", "price"],
+                    order_by_fields=[{"field": "", "order": "asc"}],
+                    check_task=CheckTasks.err_res,
+                    check_items=error)
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_milvus_client_search_order_by_invalid_json_path(self):
+        """
+        target: test search order by with invalid JSON path syntax
+        method: search with order_by_fields with malformed JSON path
+        expected: returns error about invalid JSON path
+        """
+        client = self._client()
+        collection_name = INVALID_COLLECTION_NAME
+
+        vectors_to_search = cf.gen_vectors(1, default_dim)
+        error = {ct.err_code: 65535,
+                 ct.err_msg: "order_by field 'json_field[invalid:asc' does not exist in collection schema"}
+        self.search(client, collection_name, vectors_to_search,
+                    limit=default_limit,
+                    anns_field="embeddings",
+                    output_fields=["id", "price"],
+                    order_by_fields=[{"field": 'json_field[invalid', "order": "asc"}],
+                    check_task=CheckTasks.err_res,
+                    check_items=error)

--- a/tests/python_client/milvus_client/test_milvus_client_timestamptz.py
+++ b/tests/python_client/milvus_client/test_milvus_client_timestamptz.py
@@ -1133,25 +1133,83 @@ class TestMilvusClientTimestamptzInvalid(TestMilvusClientV2Base):
 
 
 COLLECTION_NAME = "test_timestamptz" + cf.gen_unique_str("_")
-ROWS = [{default_primary_key_field_name: 0, default_vector_field_name: [1,2,3], default_timestamp_field_name: "0000-01-01 00:00:00"},
-        {default_primary_key_field_name: 1, default_vector_field_name: [4,5,6], default_timestamp_field_name: "9999-12-31T23:59:59"},
-        {default_primary_key_field_name: 2, default_vector_field_name: [7,8,9], default_timestamp_field_name: "1970-01-01T00:00:00+01:00"},
-        {default_primary_key_field_name: 3, default_vector_field_name: [10,11,12], default_timestamp_field_name: "2000-01-01T00:00:00+01:00"},
-        {default_primary_key_field_name: 4, default_vector_field_name: [13,14,15], default_timestamp_field_name: "2024-02-29T00:00:00+03:00"}]
+
+# ---------------------------------------------------------------------------
+# Per-test data – each test owns a non-overlapping 10-PK slot so that
+# parallel execution never causes cross-test interference.
+# ---------------------------------------------------------------------------
+
+# test_edge_case: pk 0-9 (uses 0-3)
+EDGE_CASE_ROWS = [
+    {default_primary_key_field_name: 0, default_vector_field_name: [1, 2, 3], default_timestamp_field_name: "0000-01-01 00:00:00"},
+    {default_primary_key_field_name: 1, default_vector_field_name: [4, 5, 6], default_timestamp_field_name: "9999-12-31T23:59:59"},
+    {default_primary_key_field_name: 2, default_vector_field_name: [7, 8, 9], default_timestamp_field_name: "1970-01-01T00:00:00+01:00"},
+    {default_primary_key_field_name: 3, default_vector_field_name: [10, 11, 12], default_timestamp_field_name: "2000-01-01T00:00:00+01:00"}]
+
+# test_Feb_29: pk 10-19 (uses 10)
+FEB29_ROWS = [
+    {default_primary_key_field_name: 10, default_vector_field_name: [13, 14, 15], default_timestamp_field_name: "2024-02-29T00:00:00+03:00"}]
+
+# test_partial_update: pk 20-29 (base rows 20-24 inserted by fixture; test mutates this range only)
+PARTIAL_UPDATE_BASE_ROWS = [
+    {default_primary_key_field_name: 20, default_vector_field_name: [1, 2, 3], default_timestamp_field_name: "0000-01-01 00:00:00"},
+    {default_primary_key_field_name: 21, default_vector_field_name: [4, 5, 6], default_timestamp_field_name: "9999-12-31T23:59:59"},
+    {default_primary_key_field_name: 22, default_vector_field_name: [7, 8, 9], default_timestamp_field_name: "1970-01-01T00:00:00+01:00"},
+    {default_primary_key_field_name: 23, default_vector_field_name: [10, 11, 12], default_timestamp_field_name: "2000-01-01T00:00:00+01:00"},
+    {default_primary_key_field_name: 24, default_vector_field_name: [13, 14, 15], default_timestamp_field_name: "2024-02-29T00:00:00+03:00"}]
+
+# test_query: pk 30-39 (uses 30-35)
+QUERY_ROWS = [
+    {default_primary_key_field_name: 30, default_vector_field_name: [1, 2, 3], default_timestamp_field_name: "1970-01-01 00:00:00"},
+    {default_primary_key_field_name: 31, default_vector_field_name: [4, 5, 6], default_timestamp_field_name: "2021-02-28T00:00:00Z"},
+    {default_primary_key_field_name: 32, default_vector_field_name: [7, 8, 9], default_timestamp_field_name: "2025-05-25T23:46:05"},
+    {default_primary_key_field_name: 33, default_vector_field_name: [10, 11, 12], default_timestamp_field_name: "2025-05-30T23:46:05+05:30"},
+    {default_primary_key_field_name: 34, default_vector_field_name: [13, 14, 15], default_timestamp_field_name: "2025-10-05 12:56:34"},
+    {default_primary_key_field_name: 35, default_vector_field_name: [16, 17, 18], default_timestamp_field_name: "9999-12-31T23:46:05"}]
+
+# test_different_time_expressions: pk 40-49 (uses 40-47, inserted with Asia/Shanghai tz)
+TIME_EXPR_ROWS = [
+    {default_primary_key_field_name: 40, default_vector_field_name: [1, 2, 3], default_timestamp_field_name: "2024-12-31 22:00:00Z"},
+    {default_primary_key_field_name: 41, default_vector_field_name: [4, 5, 6], default_timestamp_field_name: "2024-12-31 22:00:00"},
+    {default_primary_key_field_name: 42, default_vector_field_name: [7, 8, 9], default_timestamp_field_name: "2024-12-31T22:00:00"},
+    {default_primary_key_field_name: 43, default_vector_field_name: [10, 11, 12], default_timestamp_field_name: "2024-12-31T22:00:00+08:00"},
+    {default_primary_key_field_name: 44, default_vector_field_name: [13, 14, 15], default_timestamp_field_name: "2024-12-31T22:00:00-08:00"},
+    {default_primary_key_field_name: 45, default_vector_field_name: [16, 17, 18], default_timestamp_field_name: "2024-12-31T22:00:00Z"},
+    {default_primary_key_field_name: 46, default_vector_field_name: [19, 20, 21], default_timestamp_field_name: "2024-12-31 22:00:00+08:00"},
+    {default_primary_key_field_name: 47, default_vector_field_name: [22, 23, 24], default_timestamp_field_name: "2024-12-31 22:00:00-08:00"}]
+
+# test_different_timezone_query: pk 50-59 (uses 50-57, inserted with Asia/Shanghai tz)
+TZ_QUERY_ROWS = [
+    {default_primary_key_field_name: 50, default_vector_field_name: [1, 2, 3], default_timestamp_field_name: "2024-12-31 22:00:00Z"},
+    {default_primary_key_field_name: 51, default_vector_field_name: [4, 5, 6], default_timestamp_field_name: "2024-12-31 22:00:00"},
+    {default_primary_key_field_name: 52, default_vector_field_name: [7, 8, 9], default_timestamp_field_name: "2024-12-31T22:00:00"},
+    {default_primary_key_field_name: 53, default_vector_field_name: [10, 11, 12], default_timestamp_field_name: "2024-12-31T22:00:00+08:00"},
+    {default_primary_key_field_name: 54, default_vector_field_name: [13, 14, 15], default_timestamp_field_name: "2024-12-31T22:00:00-08:00"},
+    {default_primary_key_field_name: 55, default_vector_field_name: [16, 17, 18], default_timestamp_field_name: "2024-12-31T22:00:00Z"},
+    {default_primary_key_field_name: 56, default_vector_field_name: [19, 20, 21], default_timestamp_field_name: "2024-12-31 22:00:00+08:00"},
+    {default_primary_key_field_name: 57, default_vector_field_name: [22, 23, 24], default_timestamp_field_name: "2024-12-31 22:00:00-08:00"}]
+
+
 @pytest.mark.xdist_group("TestMilvusClientTimestamptz")
 class TestMilvusClientTimestamptz(TestMilvusClientV2Base):
     """
     #########################################################
-    Init collection with timestamptz so all the tests can use the same collection
-    This aims to save time for the tests
-    Also, timestamptz is difficult to compare the results,
-    so we need to init the collection with pre-defined data
+    Timestamptz tests sharing a single collection.
+    Each test owns a non-overlapping PK range so tests can
+    run in parallel without data interference.
+    All data is inserted once in the module-scoped fixture.
     #########################################################
     """
-    @pytest.fixture(scope="module", autouse=True)
+    @pytest.fixture(scope="class", autouse=True)
     def prepare_timestamptz_collection(self, request):
         """
-        Prepare timestamptz collection for the tests
+        Create the shared collection and insert ALL test data once.
+
+        Scoped to **class** so the setup only runs when at least one test
+        in this class is collected (e.g. skipped entirely under ``-m L0``).
+
+        - UTC batch  (pk 0-39): naive timestamps interpreted as UTC.
+        - Shanghai batch (pk 40-59): naive timestamps interpreted as Asia/Shanghai.
         """
         default_dim = 3
         client = self._client()
@@ -1164,10 +1222,20 @@ class TestMilvusClientTimestamptz(TestMilvusClientV2Base):
         index_params.add_index(default_primary_key_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_vector_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_timestamp_field_name, index_type="AUTOINDEX")
-        client.create_collection(collection_name, schema=schema, 
-                               consistency_level="Strong", index_params=index_params)
-        
-        self.insert(client, collection_name, ROWS)
+        client.create_collection(collection_name, schema=schema,
+                                 consistency_level="Strong", index_params=index_params)
+
+        # --- UTC batch (naive timestamps → UTC) ---
+        self.alter_collection_properties(client, collection_name,
+                                         properties={"timezone": "UTC"})
+        utc_rows = EDGE_CASE_ROWS + FEB29_ROWS + PARTIAL_UPDATE_BASE_ROWS + QUERY_ROWS
+        self.insert(client, collection_name, utc_rows)
+
+        # --- Asia/Shanghai batch (naive timestamps → +08:00) ---
+        self.alter_collection_properties(client, collection_name,
+                                         properties={"timezone": "Asia/Shanghai"})
+        shanghai_rows = TIME_EXPR_ROWS + TZ_QUERY_ROWS
+        self.insert(client, collection_name, shanghai_rows)
 
         def teardown():
             try:
@@ -1177,8 +1245,11 @@ class TestMilvusClientTimestamptz(TestMilvusClientV2Base):
                 pass
         request.addfinalizer(teardown)
 
+    # ------------------------------------------------------------------
+    #  Tests – each one touches only its own PK range
+    # ------------------------------------------------------------------
+
     @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.order(0)
     def test_milvus_client_timestamptz_edge_case(self):
         """
         target:  Test timestamptz edge case can be successfully queried
@@ -1187,15 +1258,15 @@ class TestMilvusClientTimestamptz(TestMilvusClientV2Base):
         collection_name = COLLECTION_NAME
         client.load_collection(collection_name)
 
-        rows = cf.convert_timestamptz(ROWS[:4], default_timestamp_field_name, "UTC")
-        self.query(client, collection_name, filter=f"0 <= {default_primary_key_field_name} <= 3",
-                            check_task=CheckTasks.check_query_results,
-                            check_items={exp_res: rows,
-                                         "pk_name": default_primary_key_field_name})
-        
+        expected = cf.convert_timestamptz(EDGE_CASE_ROWS, default_timestamp_field_name, "UTC")
+        self.query(client, collection_name,
+                   filter=f"0 <= {default_primary_key_field_name} <= 3",
+                   timezone="UTC",
+                   check_task=CheckTasks.check_query_results,
+                   check_items={exp_res: expected,
+                                "pk_name": default_primary_key_field_name})
 
     @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.order(1)
     def test_milvus_client_timestamptz_Feb_29(self):
         """
         target:  Milvus can query input data with Feb 29 on a leap year
@@ -1204,16 +1275,15 @@ class TestMilvusClientTimestamptz(TestMilvusClientV2Base):
         collection_name = COLLECTION_NAME
         client.load_collection(collection_name)
 
-        row = [ROWS[4].copy()]
-        row = cf.convert_timestamptz(row, default_timestamp_field_name, "UTC")
-        self.query(client, collection_name, filter=f"{default_primary_key_field_name} == 4",
-                            check_task=CheckTasks.check_query_results,
-                            check_items={exp_res: row,
-                                         "pk_name": default_primary_key_field_name})
+        expected = cf.convert_timestamptz(FEB29_ROWS, default_timestamp_field_name, "UTC")
+        self.query(client, collection_name,
+                   filter=f"{default_primary_key_field_name} == 10",
+                   timezone="UTC",
+                   check_task=CheckTasks.check_query_results,
+                   check_items={exp_res: expected,
+                                "pk_name": default_primary_key_field_name})
 
-    
     @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.order(2)
     def test_milvus_client_timestamptz_partial_update(self):
         """
         target:  Milvus can partial update timestamptz field
@@ -1222,94 +1292,92 @@ class TestMilvusClientTimestamptz(TestMilvusClientV2Base):
         collection_name = COLLECTION_NAME
         client.load_collection(collection_name)
 
-        # partial update these rows to set up for query with filters
-        # pk:5 does not exist in the collection so include all fields
-        rows = [{default_primary_key_field_name: 0, default_timestamp_field_name: "1970-01-01 00:00:00"},
-                {default_primary_key_field_name: 1, default_timestamp_field_name: "2021-02-28T00:00:00Z"},
-                {default_primary_key_field_name: 2, default_timestamp_field_name: "2025-05-25T23:46:05"},
-                {default_primary_key_field_name: 3, default_timestamp_field_name:"2025-05-30T23:46:05+05:30"},
-                {default_primary_key_field_name: 4, default_timestamp_field_name: "2025-10-05 12:56:34"},
-                {default_primary_key_field_name: 5, default_vector_field_name: [16,17,18], default_timestamp_field_name: "9999-12-31T23:46:05"}]
-        
-        # Because partial update does NOT support different fields 
-        # The last row will be inserted
-        self.upsert(client, collection_name, rows[:-1], partial_update=True)
-        self.insert(client, collection_name, rows[-1])
-        
+        # Partial update pk 20-24 (only pk + timestamp; vectors are kept from fixture).
+        update_rows = [
+            {default_primary_key_field_name: 20, default_timestamp_field_name: "1970-01-01 00:00:00"},
+            {default_primary_key_field_name: 21, default_timestamp_field_name: "2021-02-28T00:00:00Z"},
+            {default_primary_key_field_name: 22, default_timestamp_field_name: "2025-05-25T23:46:05"},
+            {default_primary_key_field_name: 23, default_timestamp_field_name: "2025-05-30T23:46:05+05:30"},
+            {default_primary_key_field_name: 24, default_timestamp_field_name: "2025-10-05 12:56:34"}]
+        self.upsert(client, collection_name, update_rows, partial_update=True)
+
+        expected_update = cf.convert_timestamptz(update_rows, default_timestamp_field_name, "Asia/Shanghai")
+        self.query(client, collection_name,
+                   filter=f"20 <= {default_primary_key_field_name} <= 24",
+                   timezone="Asia/Shanghai",
+                   output_fields=[default_timestamp_field_name],
+                   check_task=CheckTasks.check_query_results,
+                   check_items={exp_res: expected_update,
+                                "pk_name": default_primary_key_field_name})
 
     @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.order(3)
     def test_milvus_client_timestamptz_query(self):
         """
-        target:  Milvus can query rows with timestamptz field
+        target:  Milvus can query rows with timestamptz field using various operators
         """
         client = self._client()
         collection_name = COLLECTION_NAME
         client.load_collection(collection_name)
 
-        rows = [{default_primary_key_field_name: 0, default_vector_field_name: [1,2,3], default_timestamp_field_name: "1970-01-01 00:00:00"},
-                {default_primary_key_field_name: 1, default_vector_field_name: [4,5,6], default_timestamp_field_name: "2021-02-28T00:00:00Z"},
-                {default_primary_key_field_name: 2, default_vector_field_name: [7,8,9], default_timestamp_field_name: "2025-05-25T23:46:05"},
-                {default_primary_key_field_name: 3, default_vector_field_name: [10,11,12], default_timestamp_field_name:"2025-05-30T23:46:05+05:30"},
-                {default_primary_key_field_name: 4, default_vector_field_name: [13,14,15], default_timestamp_field_name: "2025-10-05 12:56:34"},
-                {default_primary_key_field_name: 5, default_vector_field_name: [16,17,18], default_timestamp_field_name: "9999-12-31T23:46:05"}]
-        
+        pk = default_primary_key_field_name
+        ts = default_timestamp_field_name
+        pk_range = f"30 <= {pk} <= 35"
 
-        UTC_time_row = cf.convert_timestamptz(rows, default_timestamp_field_name, "UTC")
-        shanghai_time_row = cf.convert_timestamptz(UTC_time_row, default_timestamp_field_name, "Asia/Shanghai")
-        self.query(client, collection_name, filter=default_search_exp,
-                            timezone="Asia/Shanghai",
-                            check_task=CheckTasks.check_query_results,
-                            check_items={exp_res: shanghai_time_row,
-                                         "pk_name": default_primary_key_field_name})
+        UTC_time_row = cf.convert_timestamptz(QUERY_ROWS, ts, "UTC")
+        shanghai_time_row = cf.convert_timestamptz(UTC_time_row, ts, "Asia/Shanghai")
+
+        # all rows
+        self.query(client, collection_name,
+                   filter=pk_range,
+                   timezone="Asia/Shanghai",
+                   check_task=CheckTasks.check_query_results,
+                   check_items={exp_res: shanghai_time_row,
+                                "pk_name": pk})
         # >=
-        expr = f"{default_timestamp_field_name} >= ISO '2025-05-30T23:46:05+05:30'"
+        expr = f"{pk_range} and {ts} >= ISO '2025-05-30T23:46:05+05:30'"
         self.query(client, collection_name, filter=expr,
-                            timezone="Asia/Shanghai",
-                            check_task=CheckTasks.check_query_results,
-                            check_items={exp_res: shanghai_time_row[3:],
-                                         "pk_name": default_primary_key_field_name})
+                   timezone="Asia/Shanghai",
+                   check_task=CheckTasks.check_query_results,
+                   check_items={exp_res: shanghai_time_row[3:],
+                                "pk_name": pk})
         # ==
-        expr = f"{default_timestamp_field_name} == ISO '9999-12-31T23:46:05Z'"
+        expr = f"{pk_range} and {ts} == ISO '9999-12-31T23:46:05Z'"
         self.query(client, collection_name, filter=expr,
-                    timezone="Asia/Shanghai",
-                    check_task=CheckTasks.check_query_results,
-                    check_items={exp_res: [shanghai_time_row[-1]],
-                                    "pk_name": default_primary_key_field_name})
-        
+                   timezone="Asia/Shanghai",
+                   check_task=CheckTasks.check_query_results,
+                   check_items={exp_res: [shanghai_time_row[-1]],
+                                "pk_name": pk})
         # <=
-        expr = f"{default_timestamp_field_name} <= ISO '2025-01-01T00:00:00+08:00'"
+        expr = f"{pk_range} and {ts} <= ISO '2025-01-01T00:00:00+08:00'"
         self.query(client, collection_name, filter=expr,
-                    timezone="Asia/Shanghai",
-                    check_task=CheckTasks.check_query_results,
-                    check_items={exp_res: shanghai_time_row[:2],
-                                    "pk_name": default_primary_key_field_name})
+                   timezone="Asia/Shanghai",
+                   check_task=CheckTasks.check_query_results,
+                   check_items={exp_res: shanghai_time_row[:2],
+                                "pk_name": pk})
         # !=
-        expr = f"{default_timestamp_field_name} != ISO '9999-12-31T23:46:05Z'"
+        expr = f"{pk_range} and {ts} != ISO '9999-12-31T23:46:05Z'"
         self.query(client, collection_name, filter=expr,
-                    timezone="Asia/Shanghai",
-                    check_task=CheckTasks.check_query_results,
-                    check_items={exp_res: shanghai_time_row[:-1],
-                                    "pk_name": default_primary_key_field_name})
+                   timezone="Asia/Shanghai",
+                   check_task=CheckTasks.check_query_results,
+                   check_items={exp_res: shanghai_time_row[:-1],
+                                "pk_name": pk})
         # INTERVAL
-        expr = f"{default_timestamp_field_name} - INTERVAL 'P3D' >= ISO '1970-01-01T00:00:00Z'"
+        expr = f"{pk_range} and {ts} - INTERVAL 'P3D' >= ISO '1970-01-01T00:00:00Z'"
         self.query(client, collection_name, filter=expr,
-                    timezone="Asia/Shanghai",
-                    check_task=CheckTasks.check_query_results,
-                    check_items={exp_res: shanghai_time_row[1:],
-                                    "pk_name": default_primary_key_field_name})
-        
+                   timezone="Asia/Shanghai",
+                   check_task=CheckTasks.check_query_results,
+                   check_items={exp_res: shanghai_time_row[1:],
+                                "pk_name": pk})
+
         # lower < tz < upper
         # BUG: https://github.com/milvus-io/milvus/issues/44600
-        # expr = f"ISO '2025-01-01T00:00:00+08:00' < {default_timestamp_field_name} < ISO '2026-10-05T12:56:34+08:00'"
+        # expr = f"{pk_range} and ISO '2025-01-01T00:00:00+08:00' < {ts} < ISO '2026-10-05T12:56:34+08:00'"
         # self.query(client, collection_name, filter=expr,
         #             check_task=CheckTasks.check_query_results,
         #             check_items={exp_res: shanghai_time_row,
-        #                             "pk_name": default_primary_key_field_name})
-
+        #                             "pk_name": pk})
 
     @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.order(4)
     def test_milvus_client_timestamptz_different_time_expressions(self):
         """
         target:  Milvus can query rows with different time expressions
@@ -1318,26 +1386,14 @@ class TestMilvusClientTimestamptz(TestMilvusClientV2Base):
         collection_name = COLLECTION_NAME
         client.load_collection(collection_name)
 
-        self.alter_collection_properties(client, collection_name, properties={"timezone": "Asia/Shanghai"})
-        rows = [{default_primary_key_field_name: 0, default_vector_field_name: [1,2,3], default_timestamp_field_name: "2024-12-31 22:00:00Z"},
-                {default_primary_key_field_name: 1, default_vector_field_name: [4,5,6], default_timestamp_field_name: "2024-12-31 22:00:00"},
-                {default_primary_key_field_name: 2, default_vector_field_name: [7,8,9], default_timestamp_field_name: "2024-12-31T22:00:00"},
-                {default_primary_key_field_name: 3, default_vector_field_name: [10,11,12], default_timestamp_field_name: "2024-12-31T22:00:00+08:00"},
-                {default_primary_key_field_name: 4, default_vector_field_name: [13,14,15], default_timestamp_field_name: "2024-12-31T22:00:00-08:00"},
-                {default_primary_key_field_name: 5, default_vector_field_name: [16,17,18], default_timestamp_field_name: "2024-12-31T22:00:00Z"},
-                {default_primary_key_field_name: 6, default_vector_field_name: [19,20,21], default_timestamp_field_name: "2024-12-31 22:00:00+08:00"},
-                {default_primary_key_field_name: 7, default_vector_field_name: [22,23,24], default_timestamp_field_name: "2024-12-31 22:00:00-08:00"}]
-        self.upsert(client, collection_name, rows)
+        expected_rows = cf.convert_timestamptz(TIME_EXPR_ROWS, default_timestamp_field_name, "Asia/Shanghai")
+        self.query(client, collection_name,
+                   filter=f"40 <= {default_primary_key_field_name} <= 47",
+                   check_task=CheckTasks.check_query_results,
+                   check_items={exp_res: expected_rows,
+                                "pk_name": default_primary_key_field_name})
 
-        expected_rows = cf.convert_timestamptz(rows, default_timestamp_field_name, "Asia/Shanghai")
-        self.query(client, collection_name, filter=f"{default_primary_key_field_name} <= 7",
-                    check_task=CheckTasks.check_query_results,
-                    check_items={exp_res: expected_rows,
-                                    "pk_name": default_primary_key_field_name})
-
-    
     @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.order(5)
     def test_milvus_client_timestamptz_different_timezone_query(self):
         """
         target:  Milvus can query rows with different time expressions with filter
@@ -1346,50 +1402,62 @@ class TestMilvusClientTimestamptz(TestMilvusClientV2Base):
         collection_name = COLLECTION_NAME
         client.load_collection(collection_name)
 
+        pk = default_primary_key_field_name
+        ts = default_timestamp_field_name
+        pk_range = f"50 <= {pk} <= 57"
+
         """
         # To test different timezone query, we need to query the same timestamp in different timezone
-        # For reference: 
-        #    2024-12-31T22:00:00Z 
-        # == 2024-12-31T17:00:00-05:00 
-        # == 2025-01-01T06:00:00+08:00 
-        # == 2024-12-31 17:00:00 (with NY timezone) 
+        # For reference:
+        #    2024-12-31T22:00:00Z
+        # == 2024-12-31T17:00:00-05:00
+        # == 2025-01-01T06:00:00+08:00
+        # == 2024-12-31 17:00:00 (with NY timezone)
         # == 2025-01-01 06:00:00 (with SH timezone)
         # these are all the same time in different timezone
         """
-        
-        # filter: UTC, timezone: None, expected: 2025-01-01T06:00:00+08:00
-        expected_rows = [{default_primary_key_field_name: 0, default_vector_field_name: [1,2,3], default_timestamp_field_name: "2025-01-01T06:00:00+08:00"},
-                         {default_primary_key_field_name: 5, default_vector_field_name: [16,17,18], default_timestamp_field_name: "2025-01-01T06:00:00+08:00"}]  
-        self.query(client, collection_name, filter=f"{default_timestamp_field_name} == ISO '2024-12-31T22:00:00Z'", 
-                    check_task=CheckTasks.check_query_results,
-                    check_items={exp_res: expected_rows,
-                                    "pk_name": default_primary_key_field_name})
 
-        # filter: America/New_York, timezone: Asia/Shanghai, expected: No result 
-        # because Asia/Shanghai will apply to filter time, so it will be 2024-12-31T17:00:00+08:00 Does not exist in the collection
+        # filter: UTC, timezone: None (collection default=Asia/Shanghai), expected: +08:00
+        # pk 50 and 55 both have "...22:00:00Z" → 2024-12-31 22:00:00 UTC
+        expected_rows = [
+            {pk: 50, default_vector_field_name: [1, 2, 3], ts: "2025-01-01T06:00:00+08:00"},
+            {pk: 55, default_vector_field_name: [16, 17, 18], ts: "2025-01-01T06:00:00+08:00"}]
+        self.query(client, collection_name,
+                   filter=f"{pk_range} and {ts} == ISO '2024-12-31T22:00:00Z'",
+                   check_task=CheckTasks.check_query_results,
+                   check_items={exp_res: expected_rows,
+                                "pk_name": pk})
+
+        # filter: naive "17:00:00", timezone: Asia/Shanghai → interpreted as 17:00:00+08:00 = 09:00 UTC
+        # No row has 09:00 UTC → empty result
         expected_rows = []
-        self.query(client, collection_name, filter=f"{default_timestamp_field_name} == ISO '2024-12-31 17:00:00'", 
-                    timezone="Asia/Shanghai",
-                    check_task=CheckTasks.check_query_results,
-                    check_items={exp_res: expected_rows,
-                                    "pk_name": default_primary_key_field_name})
+        self.query(client, collection_name,
+                   filter=f"{pk_range} and {ts} == ISO '2024-12-31 17:00:00'",
+                   timezone="Asia/Shanghai",
+                   check_task=CheckTasks.check_query_results,
+                   check_items={exp_res: expected_rows,
+                                "pk_name": pk})
 
-        # filter: America/New_York, timezone: America/New_York, expected: 2024-12-31T17:00:00-05:00
-        # because America/New_York will apply to filter time, so it will be 2024-12-31T17:00:00-05:00
-        expected_rows = [{default_primary_key_field_name: 0, default_vector_field_name: [1,2,3], default_timestamp_field_name: "2024-12-31T17:00:00-05:00"},
-                         {default_primary_key_field_name: 5, default_vector_field_name: [16,17,18], default_timestamp_field_name: "2024-12-31T17:00:00-05:00"}]  
-        self.query(client, collection_name, filter=f"{default_timestamp_field_name} == ISO '2024-12-31 17:00:00'",
-                    timezone="America/New_York",
-                    check_task=CheckTasks.check_query_results,
-                    check_items={exp_res: expected_rows,
-                                    "pk_name": default_primary_key_field_name})
+        # filter: naive "17:00:00", timezone: America/New_York → interpreted as 17:00:00-05:00 = 22:00 UTC
+        # Matches pk 50 and 55
+        expected_rows = [
+            {pk: 50, default_vector_field_name: [1, 2, 3], ts: "2024-12-31T17:00:00-05:00"},
+            {pk: 55, default_vector_field_name: [16, 17, 18], ts: "2024-12-31T17:00:00-05:00"}]
+        self.query(client, collection_name,
+                   filter=f"{pk_range} and {ts} == ISO '2024-12-31 17:00:00'",
+                   timezone="America/New_York",
+                   check_task=CheckTasks.check_query_results,
+                   check_items={exp_res: expected_rows,
+                                "pk_name": pk})
 
-        # filter: Asia/Shanghai, timezone: Asia/Shanghai, expected: 2024-12-31T17:00:00+08:00
-        # because Asia/Shanghai is the same as the filter time, so it will be 2024-12-31T17:00:00+08:00
-        expected_rows = [{default_primary_key_field_name: 0, default_vector_field_name: [1,2,3], default_timestamp_field_name: "2025-01-01T06:00:00+08:00"},
-                         {default_primary_key_field_name: 5, default_vector_field_name: [16,17,18], default_timestamp_field_name: "2025-01-01T06:00:00+08:00"}]  
-        self.query(client, collection_name, filter=f"{default_timestamp_field_name} == ISO '2025-01-01 06:00:00'",
-                    timezone="Asia/Shanghai",
-                    check_task=CheckTasks.check_query_results,
-                    check_items={exp_res: expected_rows,
-                                    "pk_name": default_primary_key_field_name})
+        # filter: naive "06:00:00", timezone: Asia/Shanghai → interpreted as 06:00:00+08:00 = 22:00 UTC
+        # Matches pk 50 and 55
+        expected_rows = [
+            {pk: 50, default_vector_field_name: [1, 2, 3], ts: "2025-01-01T06:00:00+08:00"},
+            {pk: 55, default_vector_field_name: [16, 17, 18], ts: "2025-01-01T06:00:00+08:00"}]
+        self.query(client, collection_name,
+                   filter=f"{pk_range} and {ts} == ISO '2025-01-01 06:00:00'",
+                   timezone="Asia/Shanghai",
+                   check_task=CheckTasks.check_query_results,
+                   check_items={exp_res: expected_rows,
+                                "pk_name": pk})


### PR DESCRIPTION
## Summary
Cherry-pick the following PRs from master to 2.6 branch:
issue: #47548, #47668, #47717
pr: #47616, #47670, #47725

- **pr: #47616** — test: add e2e test case for search order by (issue: #47548)
- **pr: #47670** — test: restructure timestamptz e2e cases with shared collection (issue: #47668)
- **pr: #47725** — fix: partial update default update static field when fields name are the same (issue: #47717)

## Test plan
- [x] All cherry-picked changes compile and pass tests
- [x] Conflicts resolved (search_util.go, search_pipeline_test.go, partial_update test, requirements.txt)