### PR TITLE
fix: resolve missing Paginator.h in macOS CI from stale aws-sdk-cpp install

### DIFF
--- a/.github/workflows/mac.yaml
+++ b/.github/workflows/mac.yaml
@@ -93,16 +93,15 @@ jobs:
           if [[ ! -d "/var/tmp/ccache" ]];then
             mkdir -p /var/tmp/ccache
           fi
-          brew install libomp ninja openblas ccache pkg-config aws-sdk-cpp
+          brew install libomp ninja openblas ccache pkg-config
           BREW_PREFIX=$(brew --prefix)
-          # aws-sdk-cpp 1.11.750 had a packaging bug where Paginator.h was not
-          # installed. Homebrew backported the fix (rebuild 1). If the runner has
-          # a stale installation without the fix, reinstall to pick up the
+          # aws-sdk-cpp 1.11.750 had a packaging bug where Paginator.h was
+          # not installed (missing CMake install rule for pagination headers).
+          # Homebrew backported the fix with "rebuild 1", but the CI runner's
+          # formula may be stale.  Run brew update first so we get the
           # patched bottle.
-          if [ ! -f "${BREW_PREFIX}/include/aws/core/utils/pagination/Paginator.h" ]; then
-            echo "Paginator.h missing – reinstalling aws-sdk-cpp to pick up pagination header fix"
-            brew reinstall aws-sdk-cpp
-          fi
+          brew update
+          brew install aws-sdk-cpp || brew upgrade aws-sdk-cpp
           # Install llvm@17 explicitly as a stable version
           brew install llvm@17
           if [[ ! -d "${BREW_PREFIX}/opt/llvm" ]]; then

--- a/.github/workflows/mac.yaml
+++ b/.github/workflows/mac.yaml
@@ -95,6 +95,14 @@ jobs:
           fi
           brew install libomp ninja openblas ccache pkg-config aws-sdk-cpp
           BREW_PREFIX=$(brew --prefix)
+          # aws-sdk-cpp 1.11.750 had a packaging bug where Paginator.h was not
+          # installed. Homebrew backported the fix (rebuild 1). If the runner has
+          # a stale installation without the fix, reinstall to pick up the
+          # patched bottle.
+          if [ ! -f "${BREW_PREFIX}/include/aws/core/utils/pagination/Paginator.h" ]; then
+            echo "Paginator.h missing – reinstalling aws-sdk-cpp to pick up pagination header fix"
+            brew reinstall aws-sdk-cpp
+          fi
           # Install llvm@17 explicitly as a stable version
           brew install llvm@17
           if [[ ! -d "${BREW_PREFIX}/opt/llvm" ]]; then

--- a/internal/core/thirdparty/milvus-storage/CMakeLists.txt
+++ b/internal/core/thirdparty/milvus-storage/CMakeLists.txt
@@ -68,6 +68,20 @@ if ( NOT milvus-storage_POPULATED )
         endif()
         find_package(AWSSDK REQUIRED COMPONENTS core s3 identity-management)
 
+        # aws-sdk-cpp 1.11.750 had a packaging bug: the core CMakeLists.txt
+        # was missing the install() rule for pagination headers, so
+        # Paginator.h is absent from the installation even though the STS
+        # module's STSPaginationBase.h references it.  Homebrew backported
+        # the fix (commit 175e803) with rebuild 1.  Fail early with a clear
+        # message so developers know to reinstall.
+        if(NOT EXISTS "${_HOMEBREW_PREFIX}/include/aws/core/utils/pagination/Paginator.h")
+            message(FATAL_ERROR
+                "aws/core/utils/pagination/Paginator.h is missing from "
+                "Homebrew's aws-sdk-cpp installation.  This is a known "
+                "packaging bug in aws-sdk-cpp 1.11.750.  "
+                "Fix with:  brew reinstall aws-sdk-cpp")
+        endif()
+
         if(NOT TARGET AWS::aws-sdk-cpp-identity-management)
             add_library(AWS::aws-sdk-cpp-identity-management INTERFACE IMPORTED)
             set_target_properties(AWS::aws-sdk-cpp-identity-management PROPERTIES


### PR DESCRIPTION
aws-sdk-cpp 1.11.750 shipped with a packaging bug: the core CMakeLists.txt lacked an install() rule for the pagination headers directory, so aws/core/utils/pagination/Paginator.h was never copied to the installation prefix. The STS module's STSPaginationBase.h (transitively included via STSClient.h) references this header, causing a fatal compilation error in milvus-storage on macOS.

Homebrew backported the upstream fix (aws/aws-sdk-cpp@175e803) with rebuild 1, but CI runners that already had the pre-fix bottle installed were unaffected by `brew install` (which is a no-op for already-installed packages).

- mac.yaml: after brew install, check for Paginator.h and reinstall aws-sdk-cpp if missing to pick up the patched bottle
- milvus-storage/CMakeLists.txt: fail early with a clear message if the header is absent, so local developers know to reinstall

issue: https://github.com/milvus-io/milvus/issues/47460