### PR TITLE
enhance: use effective version in banner and metrics BuildInfo label

### DIFF
--- a/cmd/milvus/run.go
+++ b/cmd/milvus/run.go
@@ -56,12 +56,12 @@ func (c *run) printBanner(w io.Writer) {
 	fmt.Fprintln(w, " /_/  /_/___/____/___/\\____/___/     ")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Welcome to Milvus!")
-	fmt.Fprintln(w, "Version:   "+common.Version.String())
+	fmt.Fprintln(w, "Version:   "+getEffectiveVersion())
 	fmt.Fprintln(w, "Built:     "+BuildTime)
 	fmt.Fprintln(w, "GitCommit: "+GitCommit)
 	fmt.Fprintln(w, "GoVersion: "+GoVersion)
 	fmt.Fprintln(w)
-	metrics.BuildInfo.WithLabelValues(common.Version.String(), BuildTime, GitCommit).Set(1)
+	metrics.BuildInfo.WithLabelValues(getEffectiveVersion(), BuildTime, GitCommit).Set(1)
 }
 
 func (c *run) printHardwareInfo(w io.Writer) {


### PR DESCRIPTION
## Summary
- Use `getEffectiveVersion()` instead of hardcoded `common.Version` for startup banner and `milvus_build_info` Prometheus metric
- Dev builds now correctly display `master-20260228-add6e4c6d4` instead of always showing `2.6.6`
- Release builds are unaffected (git tag matches semver, so `getEffectiveVersion()` returns the same value)

## Motivation

The startup banner (`Version:` line) and `milvus_build_info{version="..."}` metric currently always show the hardcoded semver from `common.Version` (e.g. `2.6.6`), regardless of whether the binary is a release build or a dev build. This makes it impossible to identify the actual build version from logs or monitoring dashboards.

`getEffectiveVersion()` already exists and is used by the `GetVersion` RPC and `Connect` RPC (via `MILVUS_GIT_BUILD_TAGS` env var, introduced in PR #47822). This PR makes the banner and metrics consistent with those APIs.

### What changes

| Component | Before | After (release) | After (dev) |
|-----------|--------|-----------------|-------------|
| Banner `Version:` | `2.6.6` | `2.6.6` | `master-20260228-add6e4c6d4` |
| Metric `milvus_build_info{version=}` | `2.6.6` | `2.6.6` | `master-20260228-add6e4c6d4` |
| Session etcd version | `2.6.6` | `2.6.6` (unchanged) | `2.6.6` (unchanged) |
| `GetVersion` RPC | `master-20260228-...` | `2.6.6` (unchanged) | `master-20260228-...` (unchanged) |

### What is NOT affected

- `common.Version` itself (still hardcoded semver, used for session compatibility)
- Session registration in etcd (still uses `common.Version` for cluster version negotiation)
- Coordinator version range checks (still uses `common.Version`)

## Test plan
- [x] `go vet ./cmd/milvus/...` passes
- [x] Verified `getEffectiveVersion()` fallback: when `MilvusVersion` is empty or "unknown", returns `common.Version.String()`
- [x] Verified no Grafana dashboard on internal 4am Grafana queries `milvus_build_info` — zero PromQL impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)