### PR TITLE
fix: [2.6] eliminate memory accumulation in ManifestGroupTranslator::get_cells() (#47904)

### DIFF
--- a/internal/core/src/index/Meta.h
+++ b/internal/core/src/index/Meta.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "knowhere/comp/index_param.h"
 
 namespace milvus::index {

--- a/internal/core/src/segcore/memory_planner.cpp
+++ b/internal/core/src/segcore/memory_planner.cpp
@@ -13,32 +13,32 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include <cstddef>
+#include "segcore/memory_planner.h"
+
 #include <algorithm>
 #include <atomic>
-#include "common/OpContext.h"
-#include "milvus-storage/common/metadata.h"
-#include "segcore/memory_planner.h"
-#include <memory>
-#include <vector>
-#include <arrow/record_batch.h>
-
+#include <cstddef>
 #include <future>
 #include <memory>
+#include <numeric>
 #include <string>
 #include <vector>
 
+#include <arrow/record_batch.h>
 #include "arrow/type.h"
+#include "folly/ScopeGuard.h"
+
+#include "common/Common.h"
 #include "common/EasyAssert.h"
 #include "common/FieldData.h"
-#include "folly/ScopeGuard.h"
-#include "milvus-storage/format/parquet/file_reader.h"
-#include "milvus-storage/filesystem/fs.h"
+#include "common/OpContext.h"
 #include "log/Log.h"
+#include "milvus-storage/common/metadata.h"
+#include "milvus-storage/filesystem/fs.h"
+#include "milvus-storage/format/parquet/file_reader.h"
 #include "segcore/Utils.h"
-#include "storage/ThreadPools.h"
-#include "common/Common.h"
 #include "storage/KeyRetriever.h"
+#include "storage/ThreadPools.h"
 
 namespace milvus::segcore {
 
@@ -202,6 +202,10 @@ LoadWithStrategy(const std::vector<std::string>& remote_files,
                             "[StorageV2] Failed to create row group reader: " +
                                 result.status().ToString());
                         auto row_group_reader = result.ValueOrDie();
+                        auto close_guard =
+                            folly::makeGuard([&row_group_reader]() {
+                                (void)row_group_reader->Close();
+                            });
                         auto status =
                             row_group_reader->SetRowGroupOffsetAndCount(
                                 block.offset, block.count);
@@ -253,11 +257,10 @@ LoadWithStrategy(const std::vector<std::string>& remote_files,
 
 std::vector<std::future<void>>
 LoadCellBatchAsync(milvus::OpContext* op_ctx,
-                   const std::vector<std::string>& remote_files,
                    std::vector<CellSpec> cell_specs,
+                   BatchReaderFactory reader_factory,
                    std::shared_ptr<CellReaderChannel>& channel,
                    int64_t memory_limit,
-                   const milvus_storage::ArrowFileSystemPtr& fs,
                    milvus::proto::common::LoadPriority priority) {
     if (cell_specs.empty()) {
         channel->close();
@@ -280,7 +283,7 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
     size_t cells_per_batch = std::max<size_t>(
         1, (cell_specs.size() + parallel_degree - 1) / parallel_degree);
 
-    // Group consecutive, same-file cells into batches for IO merging
+    // Group consecutive, same-key cells into batches for IO merging
     struct CellBatch {
         size_t file_idx;
         int64_t rg_offset;
@@ -326,14 +329,15 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
     auto reader_memory_limit =
         std::max<int64_t>(memory_limit / static_cast<int64_t>(batches.size()),
                           FILE_SLICE_SIZE.load());
+    auto shared_factory =
+        std::make_shared<BatchReaderFactory>(std::move(reader_factory));
 
     std::vector<std::future<void>> futures;
     futures.reserve(batches.size());
 
     for (auto& batch : batches) {
         futures.emplace_back(pool.Submit([batch = std::move(batch),
-                                          fs,
-                                          &remote_files,
+                                          shared_factory,
                                           reader_memory_limit,
                                           channel,
                                           remaining,
@@ -345,44 +349,88 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
             });
             CheckCancellation(op_ctx, -1, "LoadCellBatchAsync");
 
-            auto result = milvus_storage::FileRowGroupReader::Make(
-                fs,
-                remote_files[batch.file_idx],
-                nullptr,
-                reader_memory_limit,
-                milvus::storage::GetReaderProperties());
-            AssertInfo(result.ok(),
-                       "[StorageV2] Failed to create reader: " +
-                           result.status().ToString());
-            auto reader = result.ValueOrDie();
-            auto status = reader->SetRowGroupOffsetAndCount(batch.rg_offset,
-                                                            batch.rg_count);
-            AssertInfo(status.ok(),
-                       "[StorageV2] Failed to set row group range: " +
-                           status.ToString());
+            auto tables_result = (*shared_factory)(batch.file_idx,
+                                                   batch.rg_offset,
+                                                   batch.rg_count,
+                                                   reader_memory_limit);
+            AssertInfo(tables_result.ok(),
+                       "[StorageV2] Failed to read batch: " +
+                           tables_result.status().ToString());
+            auto all_tables = std::move(tables_result).ValueOrDie();
 
+            int64_t table_offset = 0;
             for (const auto& cell : batch.cells) {
                 auto cell_result = std::make_shared<CellLoadResult>();
                 cell_result->cid = cell.cid;
                 cell_result->tables.reserve(cell.rg_count);
                 for (int64_t i = 0; i < cell.rg_count; ++i) {
-                    std::shared_ptr<arrow::Table> table;
-                    auto s = reader->ReadNextRowGroup(&table);
-                    AssertInfo(s.ok(),
-                               "[StorageV2] Failed to read row group: " +
-                                   s.ToString());
-                    cell_result->tables.push_back(std::move(table));
+                    cell_result->tables.push_back(
+                        std::move(all_tables[table_offset + i]));
                 }
+                table_offset += cell.rg_count;
                 channel->push(std::move(cell_result));
             }
-            auto close_status = reader->Close();
-            AssertInfo(close_status.ok(),
-                       "[StorageV2] Failed to close reader: " +
-                           close_status.ToString());
         }));
     }
 
     return futures;
+}
+
+BatchReaderFactory
+MakeFileReaderFactory(std::vector<std::string> remote_files,
+                      milvus_storage::ArrowFileSystemPtr fs) {
+    auto files =
+        std::make_shared<std::vector<std::string>>(std::move(remote_files));
+    return [files, fs](size_t batch_key,
+                       int64_t rg_offset,
+                       int64_t total_rg_count,
+                       int64_t reader_memory_limit)
+               -> arrow::Result<std::vector<std::shared_ptr<arrow::Table>>> {
+        ARROW_ASSIGN_OR_RAISE(auto reader,
+                              milvus_storage::FileRowGroupReader::Make(
+                                  fs,
+                                  (*files)[batch_key],
+                                  nullptr,
+                                  reader_memory_limit,
+                                  milvus::storage::GetReaderProperties()));
+        auto close_guard =
+            folly::makeGuard([&reader]() { (void)reader->Close(); });
+        ARROW_RETURN_NOT_OK(
+            reader->SetRowGroupOffsetAndCount(rg_offset, total_rg_count));
+        std::vector<std::shared_ptr<arrow::Table>> tables;
+        tables.reserve(total_rg_count);
+        for (int64_t i = 0; i < total_rg_count; ++i) {
+            std::shared_ptr<arrow::Table> table;
+            ARROW_RETURN_NOT_OK(reader->ReadNextRowGroup(&table));
+            tables.push_back(std::move(table));
+        }
+        return tables;
+    };
+}
+
+BatchReaderFactory
+MakeChunkReaderFactory(
+    std::shared_ptr<milvus_storage::api::ChunkReader> chunk_reader) {
+    return [chunk_reader](size_t /*batch_key*/,
+                          int64_t rg_offset,
+                          int64_t total_rg_count,
+                          int64_t /*reader_memory_limit*/)
+               -> arrow::Result<std::vector<std::shared_ptr<arrow::Table>>> {
+        std::vector<int64_t> rg_indices(total_rg_count);
+        std::iota(rg_indices.begin(), rg_indices.end(), rg_offset);
+        ARROW_ASSIGN_OR_RAISE(
+            auto batches,
+            chunk_reader->get_chunks(rg_indices, /*parallelism=*/1));
+        std::vector<std::shared_ptr<arrow::Table>> tables;
+        tables.reserve(batches.size());
+        for (auto& batch : batches) {
+            ARROW_ASSIGN_OR_RAISE(
+                auto table,
+                arrow::Table::FromRecordBatches({std::move(batch)}));
+            tables.push_back(std::move(table));
+        }
+        return tables;
+    };
 }
 
 }  // namespace milvus::segcore

--- a/internal/core/src/segcore/memory_planner.cpp
+++ b/internal/core/src/segcore/memory_planner.cpp
@@ -230,13 +230,6 @@ LoadWithStrategy(const std::vector<std::string>& remote_files,
                                  static_cast<size_t>(block.offset + i),
                                  table});
                         }
-                        auto close_status = row_group_reader->Close();
-                        AssertInfo(
-                            close_status.ok(),
-                            "[StorageV2] Failed to close row group reader "
-                            "for file " +
-                                file + " with error " +
-                                close_status.ToString());
                         return ret;
                     }));
             }
@@ -357,6 +350,11 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
                        "[StorageV2] Failed to read batch: " +
                            tables_result.status().ToString());
             auto all_tables = std::move(tables_result).ValueOrDie();
+            AssertInfo(all_tables.size() == static_cast<size_t>(batch.rg_count),
+                       "reader returns less tables than expected, batch rg "
+                       "count: {}, result size: {}",
+                       batch.rg_count,
+                       all_tables.size());
 
             int64_t table_offset = 0;
             for (const auto& cell : batch.cells) {

--- a/internal/core/src/segcore/memory_planner.h
+++ b/internal/core/src/segcore/memory_planner.h
@@ -15,20 +15,23 @@
 // limitations under the License.
 #pragma once
 
-#include <arrow/record_batch.h>
-#include <arrow/table.h>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <future>
 #include <memory>
 #include <string>
 #include <vector>
+
+#include <arrow/record_batch.h>
+#include <arrow/table.h>
 
 #include "common/Channel.h"
 #include "common/FieldData.h"
 #include "common/OpContext.h"
 #include "milvus-storage/common/metadata.h"
 #include "milvus-storage/filesystem/fs.h"
+#include "milvus-storage/reader.h"
 
 namespace milvus::segcore {
 
@@ -116,29 +119,59 @@ struct CellLoadResult {
 
 using CellReaderChannel = milvus::Channel<std::shared_ptr<CellLoadResult>>;
 
+// Creates a batch reader for a range of contiguous row groups.
+// Returns all row groups as a vector of tables in one call.
+// batch_key: grouping key (file_idx for files, 0 for single reader)
+// rg_offset: start row group index for this batch
+// total_rg_count: total row groups across all cells in this batch
+// reader_memory_limit: memory budget for this batch's reader
+using BatchReaderFactory =
+    std::function<arrow::Result<std::vector<std::shared_ptr<arrow::Table>>>(
+        size_t batch_key,
+        int64_t rg_offset,
+        int64_t total_rg_count,
+        int64_t reader_memory_limit)>;
+
 /**
- * Load cells from storage v2 files in batches. Cells are sorted by
+ * Load cells in batches using a pluggable reader factory. Cells are sorted by
  * (file_idx, local_rg_offset) and grouped into IO-merged batches.
  * Each completed cell is pushed to the channel immediately, enabling
  * streaming consumption without accumulating all ArrowTables.
  *
  * @param op_ctx operation context for cancellation
- * @param remote_files list of remote files
  * @param cell_specs cell specifications (sorted internally)
+ * @param reader_factory factory that reads all row groups for a batch
  * @param channel channel to receive loaded cell data; closed when all done
  * @param memory_limit total memory limit for readers
- * @param fs arrow filesystem
  * @param priority load priority
  * @return vector of futures for the batch loading tasks
  */
 std::vector<std::future<void>>
 LoadCellBatchAsync(milvus::OpContext* op_ctx,
-                   const std::vector<std::string>& remote_files,
                    std::vector<CellSpec> cell_specs,
+                   BatchReaderFactory reader_factory,
                    std::shared_ptr<CellReaderChannel>& channel,
                    int64_t memory_limit,
-                   const milvus_storage::ArrowFileSystemPtr& fs,
                    milvus::proto::common::LoadPriority priority =
                        milvus::proto::common::LoadPriority::HIGH);
+
+/**
+ * Creates a BatchReaderFactory that reads from Parquet files via FileRowGroupReader.
+ * The returned factory owns a copy of remote_files, so the caller's vector
+ * need not outlive the factory.
+ */
+BatchReaderFactory
+MakeFileReaderFactory(std::vector<std::string> remote_files,
+                      milvus_storage::ArrowFileSystemPtr fs);
+
+/**
+ * Creates a BatchReaderFactory that reads from a ChunkReader via batch
+ * get_chunks(). Row groups are loaded in a single IO call for IO merging
+ * and returned as a vector of tables. The factory captures the shared_ptr
+ * by value, extending the ChunkReader's lifetime automatically.
+ */
+BatchReaderFactory
+MakeChunkReaderFactory(
+    std::shared_ptr<milvus_storage::api::ChunkReader> chunk_reader);
 
 }  // namespace milvus::segcore

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
@@ -367,12 +367,16 @@ GroupChunkTranslator::get_cells(milvus::OpContext* ctx,
             completed_cells[cell_data->cid] =
                 load_group_chunk(cell_data->tables, cell_data->cid);
         }
-    } catch (std::exception& ex) {
-        // make sure all futures are handled, but still throw pop & load ex
+    } catch (...) {
+        // Drain the channel to unblock producers that may be stuck on push()
+        // to a full bounded channel. Without draining, producers block forever
+        // and their task_guard (which calls channel->close()) never executes.
+        std::shared_ptr<milvus::segcore::CellLoadResult> discard;
         try {
-            storage::WaitAllFutures(load_futures);
+            while (channel->pop(discard)) {
+            }
         } catch (...) {
-            LOG_WARN("WaitAllFutures exception swallowed");
+            LOG_WARN("drain channel exception swallowed");
         }
         throw;
     }

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
@@ -15,11 +15,8 @@
 // limitations under the License.
 #include "segcore/storagev2translator/GroupChunkTranslator.h"
 
-#include "common/type_c.h"
-#include "segcore/Utils.h"
-#include "segcore/storagev2translator/GroupCTMeta.h"
-#include <cassert>
 #include <algorithm>
+#include <cassert>
 #include <cstdint>
 #include <filesystem>
 #include <memory>
@@ -29,6 +26,7 @@
 
 #include "NamedType/named_type_impl.hpp"
 #include "arrow/api.h"
+
 #include "cachinglayer/Utils.h"
 #include "common/Chunk.h"
 #include "common/ChunkWriter.h"
@@ -37,29 +35,18 @@
 #include "common/EasyAssert.h"
 #include "common/FieldMeta.h"
 #include "common/GroupChunk.h"
-#include "mmap/Types.h"
 #include "common/Types.h"
+#include "common/type_c.h"
+#include "milvus-storage/common/constants.h"
 #include "milvus-storage/common/metadata.h"
 #include "milvus-storage/filesystem/fs.h"
-#include "milvus-storage/common/constants.h"
 #include "milvus-storage/format/parquet/file_reader.h"
-#include "storage/ThreadPools.h"
-#include "storage/KeyRetriever.h"
-#include "segcore/memory_planner.h"
-
-#include <memory>
-#include <string>
-#include <unordered_set>
-#include <vector>
-#include <unordered_map>
-#include <set>
-#include <algorithm>
-
-#include "arrow/type.h"
-#include "arrow/type_fwd.h"
-#include "cachinglayer/Utils.h"
-#include "common/ChunkWriter.h"
+#include "mmap/Types.h"
 #include "segcore/Utils.h"
+#include "segcore/memory_planner.h"
+#include "segcore/storagev2translator/GroupCTMeta.h"
+#include "storage/KeyRetriever.h"
+#include "storage/ThreadPools.h"
 #include "storage/Util.h"
 
 namespace milvus::segcore::storagev2translator {
@@ -345,17 +332,20 @@ GroupChunkTranslator::get_cells(milvus::OpContext* ctx,
     }
 
     // Submit cell-batch loading tasks
-    auto channel = std::make_shared<milvus::segcore::CellReaderChannel>();
+    auto& pool = milvus::ThreadPools::GetThreadPool(
+        milvus::PriorityForLoad(load_priority_));
+    auto channel = std::make_shared<milvus::segcore::CellReaderChannel>(
+        static_cast<size_t>(pool.GetMaxThreadNum() * 1.5));
     auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
                   .GetArrowFileSystem();
 
+    auto factory = milvus::segcore::MakeFileReaderFactory(insert_files_, fs);
     auto load_futures =
         milvus::segcore::LoadCellBatchAsync(ctx,
-                                            insert_files_,
                                             std::move(cell_specs),
+                                            std::move(factory),
                                             channel,
                                             DEFAULT_FIELD_MAX_MEMORY_LIMIT,
-                                            fs,
                                             load_priority_);
 
     LOG_INFO(
@@ -369,12 +359,22 @@ GroupChunkTranslator::get_cells(milvus::OpContext* ctx,
         completed_cells;
     completed_cells.reserve(cids.size());
 
-    std::shared_ptr<milvus::segcore::CellLoadResult> cell_data;
-    while (channel->pop(cell_data)) {
-        CheckCancellation(
-            ctx, segment_id_, "GroupChunkTranslator::get_cells()");
-        completed_cells[cell_data->cid] =
-            load_group_chunk(cell_data->tables, cell_data->cid);
+    try {
+        std::shared_ptr<milvus::segcore::CellLoadResult> cell_data;
+        while (channel->pop(cell_data)) {
+            CheckCancellation(
+                ctx, segment_id_, "GroupChunkTranslator::get_cells()");
+            completed_cells[cell_data->cid] =
+                load_group_chunk(cell_data->tables, cell_data->cid);
+        }
+    } catch (std::exception& ex) {
+        // make sure all futures are handled, but still throw pop & load ex
+        try {
+            storage::WaitAllFutures(load_futures);
+        } catch (...) {
+            LOG_WARN("WaitAllFutures exception swallowed");
+        }
+        throw;
     }
 
     // access underlying future to get exception if any

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
@@ -16,36 +16,38 @@
 
 #include "segcore/storagev2translator/ManifestGroupTranslator.h"
 
-#include "common/type_c.h"
-#include "segcore/Utils.h"
-#include "milvus-storage/reader.h"
-#include "segcore/storagev2translator/GroupCTMeta.h"
-#include "common/GroupChunk.h"
-#include "mmap/Types.h"
-#include "common/Types.h"
-#include "milvus-storage/common/metadata.h"
-#include "milvus-storage/filesystem/fs.h"
-#include "milvus-storage/common/constants.h"
-#include "milvus-storage/format/parquet/file_reader.h"
-#include "storage/ThreadPools.h"
-#include "storage/KeyRetriever.h"
-#include "segcore/memory_planner.h"
-
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <exception>
+#include <filesystem>
 #include <memory>
+#include <set>
 #include <string>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
-#include <unordered_map>
-#include <set>
-#include <algorithm>
 
 #include "arrow/type.h"
 #include "arrow/type_fwd.h"
+
 #include "cachinglayer/Utils.h"
 #include "common/ChunkWriter.h"
+#include "common/GroupChunk.h"
+#include "common/Types.h"
+#include "common/type_c.h"
+#include "milvus-storage/common/constants.h"
+#include "milvus-storage/common/metadata.h"
+#include "milvus-storage/filesystem/fs.h"
+#include "milvus-storage/format/parquet/file_reader.h"
+#include "milvus-storage/reader.h"
+#include "mmap/Types.h"
 #include "segcore/Utils.h"
+#include "segcore/memory_planner.h"
+#include "segcore/storagev2translator/GroupCTMeta.h"
+#include "storage/KeyRetriever.h"
+#include "storage/ThreadPools.h"
+#include "storage/Util.h"
 
 namespace milvus::segcore::storagev2translator {
 
@@ -53,7 +55,7 @@ ManifestGroupTranslator::ManifestGroupTranslator(
     int64_t segment_id,
     GroupChunkType group_chunk_type,
     int64_t column_group_index,
-    std::unique_ptr<milvus_storage::api::ChunkReader> chunk_reader,
+    std::shared_ptr<milvus_storage::api::ChunkReader> chunk_reader,
     const std::unordered_map<FieldId, FieldMeta>& field_metas,
     bool use_mmap,
     bool mmap_populate,
@@ -209,53 +211,74 @@ ManifestGroupTranslator::get_cells(
             meta_.chunk_memory_size_.size());
     }
 
-    // Collect all row group indices needed for the requested cells
-    std::vector<int64_t> needed_row_group_indices;
-    needed_row_group_indices.reserve(kRowGroupsPerCell * cids.size());
+    // Build CellSpec for each requested cid
+    std::vector<milvus::segcore::CellSpec> cell_specs;
+    cell_specs.reserve(cids.size());
     for (auto cid : cids) {
         auto [start, end] = meta_.get_row_group_range(cid);
-        for (size_t i = start; i < end; ++i) {
-            needed_row_group_indices.push_back(static_cast<int64_t>(i));
+        cell_specs.push_back({cid,
+                              /*file_idx=*/0,
+                              static_cast<int64_t>(start),
+                              static_cast<int64_t>(end - start)});
+    }
+
+    // Create factory using ChunkReader — reads a batch of row groups at once
+    auto factory = milvus::segcore::MakeChunkReaderFactory(chunk_reader_);
+
+    // Submit cell-batch loading tasks
+    auto& pool = milvus::ThreadPools::GetThreadPool(
+        milvus::PriorityForLoad(load_priority_));
+    auto channel = std::make_shared<milvus::segcore::CellReaderChannel>(
+        static_cast<size_t>(pool.GetMaxThreadNum() * 1.5));
+
+    auto load_futures =
+        milvus::segcore::LoadCellBatchAsync(ctx,
+                                            std::move(cell_specs),
+                                            std::move(factory),
+                                            channel,
+                                            DEFAULT_FIELD_MAX_MEMORY_LIMIT,
+                                            load_priority_);
+
+    LOG_INFO(
+        "[StorageV2] translator {} submits {} batch tasks for manifest column "
+        "group {}",
+        key_,
+        load_futures.size(),
+        column_group_index_);
+
+    // Pop loop — convert each cell immediately, no ArrowTable accumulation
+    std::unordered_map<milvus::cachinglayer::cid_t,
+                       std::unique_ptr<milvus::GroupChunk>>
+        completed_cells;
+    completed_cells.reserve(cids.size());
+
+    try {
+        std::shared_ptr<milvus::segcore::CellLoadResult> cell_data;
+        while (channel->pop(cell_data)) {
+            CheckCancellation(
+                ctx, segment_id_, "ManifestGroupTranslator::get_cells()");
+            completed_cells[cell_data->cid] =
+                load_group_chunk(cell_data->tables, cell_data->cid);
         }
-    }
-
-    auto parallel_degree =
-        static_cast<uint64_t>(DEFAULT_FIELD_MAX_MEMORY_LIMIT / FILE_SLICE_SIZE);
-
-    auto read_result = chunk_reader_->get_chunks(
-        needed_row_group_indices, static_cast<int64_t>(parallel_degree));
-
-    if (!read_result.ok()) {
-        throw std::runtime_error("get chunk failed");
-    }
-
-    auto loaded_row_groups = read_result.ValueOrDie();
-
-    // Build a map from row group index to loaded record batch
-    std::unordered_map<int64_t, std::shared_ptr<arrow::RecordBatch>>
-        row_group_map;
-    row_group_map.reserve(needed_row_group_indices.size());
-    for (size_t i = 0; i < needed_row_group_indices.size(); ++i) {
-        row_group_map[needed_row_group_indices[i]] = loaded_row_groups[i];
-    }
-
-    for (const auto& cid : cids) {
-        auto [start, end] = meta_.get_row_group_range(cid);
-        std::vector<std::shared_ptr<arrow::RecordBatch>> record_batches;
-        record_batches.reserve(end - start);
-
-        for (size_t i = start; i < end; ++i) {
-            auto it = row_group_map.find(static_cast<int64_t>(i));
-            AssertInfo(it != row_group_map.end(),
-                       fmt::format("[StorageV2] translator {} row group {} for "
-                                   "cell {} was not loaded",
-                                   key_,
-                                   i,
-                                   cid));
-            record_batches.push_back(it->second);
+    } catch (std::exception& ex) {
+        // make sure all futures are handled, but still throw pop & load ex
+        try {
+            storage::WaitAllFutures(load_futures);
+        } catch (...) {
+            LOG_WARN("WaitAllFutures exception swallowed");
         }
+        throw;
+    }
 
-        cells.emplace_back(cid, load_group_chunk(record_batches, cid));
+    storage::WaitAllFutures(load_futures);
+
+    for (auto cid : cids) {
+        auto it = completed_cells.find(cid);
+        AssertInfo(
+            it != completed_cells.end(),
+            fmt::format(
+                "[StorageV2] translator {} cell {} not loaded", key_, cid));
+        cells.emplace_back(cid, std::move(it->second));
     }
 
     return cells;
@@ -263,23 +286,23 @@ ManifestGroupTranslator::get_cells(
 
 std::unique_ptr<milvus::GroupChunk>
 ManifestGroupTranslator::load_group_chunk(
-    const std::vector<std::shared_ptr<arrow::RecordBatch>>& record_batches,
+    const std::vector<std::shared_ptr<arrow::Table>>& tables,
     const milvus::cachinglayer::cid_t cid) {
-    assert(!record_batches.empty());
-    // Use the first record batch as the reference for field iteration
-    const auto& first_batch = record_batches[0];
+    assert(!tables.empty());
+    // Use the first table's schema as reference for field iteration
+    const auto& schema = tables[0]->schema();
 
     std::vector<FieldId> field_ids;
-    field_ids.reserve(first_batch->num_columns());
+    field_ids.reserve(schema->num_fields());
     std::vector<FieldMeta> field_metas;
-    field_metas.reserve(first_batch->num_columns());
+    field_metas.reserve(schema->num_fields());
     std::vector<arrow::ArrayVector> array_vecs;
-    array_vecs.reserve(first_batch->num_columns());
+    array_vecs.reserve(schema->num_fields());
 
-    // Iterate through field_id_list to get field_id and create chunk
-    for (int i = 0; i < first_batch->num_columns(); ++i) {
-        // column name here is field id
-        auto column_name = first_batch->column_name(i);
+    // Iterate through fields to get field_id and create chunk
+    for (int i = 0; i < schema->num_fields(); ++i) {
+        // column name here is field id (ChunkReader stores field IDs as column names)
+        auto column_name = schema->field(i)->name();
         auto field_id = std::stoll(column_name);
 
         auto fid = milvus::FieldId(field_id);
@@ -288,18 +311,20 @@ ManifestGroupTranslator::load_group_chunk(
             continue;
         }
         auto it = field_metas_.find(fid);
-        AssertInfo(
-            it != field_metas_.end(),
-            "[StorageV2] translator {} field id {} not found in field_metas",
-            key_,
-            fid.get());
+        // Workaround for projection push-down missing for chunk reader
+        // change back to assertion after supported
+        if (it == field_metas_.end()) {
+            continue;
+        }
         const auto& field_meta = it->second;
 
-        // Merge arrays from all record batches for this field
-        // All record batches in a cell come from the same column group with consistent schema
+        // Merge arrays from all tables for this field
+        // All tables in a cell come from the same column group with consistent schema
         arrow::ArrayVector merged_array_vec;
-        for (const auto& batch : record_batches) {
-            merged_array_vec.push_back(batch->column(i));
+        for (const auto& table : tables) {
+            auto chunks = table->column(i)->chunks();
+            merged_array_vec.insert(
+                merged_array_vec.end(), chunks.begin(), chunks.end());
         }
 
         field_ids.push_back(fid);

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.h
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.h
@@ -15,18 +15,22 @@
 // limitations under the License.
 #pragma once
 
-#include <string>
-#include <vector>
 #include <memory>
+#include <string>
 #include <unordered_map>
+#include <vector>
+
+#include "NamedType/underlying_functionalities.hpp"
+#include "arrow/record_batch.h"
+#include "arrow/table.h"
+#include "parquet/metadata.h"
 
 #include "cachinglayer/Translator.h"
 #include "cachinglayer/Utils.h"
+#include "common/GroupChunk.h"
+#include "common/Types.h"
 #include "milvus-storage/common/metadata.h"
 #include "mmap/Types.h"
-#include "common/Types.h"
-#include "common/GroupChunk.h"
-#include "parquet/metadata.h"
 #include "segcore/ChunkedSegmentSealedImpl.h"
 #include "segcore/InsertRecord.h"
 #include "segcore/storagev2translator/GroupCTMeta.h"
@@ -61,7 +65,7 @@ class ManifestGroupTranslator
         int64_t segment_id,
         GroupChunkType group_chunk_type,
         int64_t column_group_index,
-        std::unique_ptr<milvus_storage::api::ChunkReader> chunk_reader,
+        std::shared_ptr<milvus_storage::api::ChunkReader> chunk_reader,
         const std::unordered_map<FieldId, FieldMeta>& field_metas,
         bool use_mmap,
         bool mmap_populate,
@@ -161,26 +165,25 @@ class ManifestGroupTranslator
 
  private:
     /**
-     * @brief Load a cell from multiple Arrow RecordBatches
+     * @brief Load a cell from multiple Arrow Tables
      *
-     * Converts multiple Arrow RecordBatches (from row groups) into a single
+     * Converts multiple Arrow Tables (from row groups) into a single
      * GroupChunk containing merged field data for all columns.
      *
-     * @param record_batches Arrow RecordBatches from row groups
+     * @param tables Arrow Tables from row groups
      * @param cid Cell ID of the chunk being loaded
      * @return GroupChunk containing the loaded field data
      */
     std::unique_ptr<milvus::GroupChunk>
-    load_group_chunk(
-        const std::vector<std::shared_ptr<arrow::RecordBatch>>& record_batches,
-        milvus::cachinglayer::cid_t cid);
+    load_group_chunk(const std::vector<std::shared_ptr<arrow::Table>>& tables,
+                     milvus::cachinglayer::cid_t cid);
 
     int64_t segment_id_;
     GroupChunkType group_chunk_type_;
     int64_t column_group_index_;
     std::string key_;
     std::unordered_map<FieldId, FieldMeta> field_metas_;
-    std::unique_ptr<milvus_storage::api::ChunkReader> chunk_reader_;
+    std::shared_ptr<milvus_storage::api::ChunkReader> chunk_reader_;
 
     GroupCTMeta meta_;
     bool use_mmap_;


### PR DESCRIPTION
Cherry-pick from master
pr: #47904

Related to #47858

ManifestGroupTranslator::get_cells() previously called chunk_reader_->get_chunks() with ALL needed row group indices at once, loading every row group into memory simultaneously. This caused memory spikes proportional to the total size of all requested cells.

Refactor LoadCellBatchAsync into a generic streaming loader that accepts a pluggable BatchReaderFactory, enabling both ManifestGroupTranslator (ChunkReader-based) and GroupChunkTranslator (file-based) to share the same channel-based streaming infrastructure.

Key changes:
- Add BatchReaderFactory / SequentialRowGroupReader abstractions to memory_planner.h, allowing LoadCellBatchAsync to work with any row-group data source
- Add MakeFileReaderFactory() that encapsulates FileRowGroupReader creation, replacing the old file-path-based LoadCellBatchAsync overload
- ManifestGroupTranslator now loads per-batch via chunk_reader_->get_chunks(rg_indices, 1) instead of one bulk get_chunks() for all cells, streaming results through channel
- ManifestGroupTranslator::load_group_chunk() changed from RecordBatch to Table input to match the unified CellLoadResult format
- GroupChunkTranslator updated to use MakeFileReaderFactory + generic LoadCellBatchAsync (no behavioral change)

Peak memory during get_cells() drops from O(all_requested_cells) to O(single_cell).

---------