### PR TITLE
enhance: [2.5] limit ChannelOp KV size via maxBytesPerTxn to reduce KV size.(#47958)

### DIFF
--- a/internal/datacoord/channel_store.go
+++ b/internal/datacoord/channel_store.go
@@ -83,10 +83,10 @@ type RWChannelStore interface {
 var ChannelOpTypeNames = []string{"Add", "Delete", "Watch", "Release"}
 
 const (
-	bufferID            = math.MinInt64
-	delimiter           = "/"
-	maxOperationsPerTxn = 64
-	maxBytesPerTxn      = 1024 * 1024
+	bufferID              = math.MinInt64
+	delimiter             = "/"
+	maxOperationsPerTxn   = 64
+	defaultMaxBytesPerTxn = 1024 * 1024
 )
 
 var errUnknownOpType = errors.New("unknown operation type")
@@ -431,8 +431,11 @@ func (c *StateChannelStore) Update(opSet *ChannelOpSet) error {
 	// Split opset into multiple txn. Operations on the same channel must be executed in one txn.
 	perChOps := opSet.SplitByChannel()
 
-	// Execute a txn for every 64 operations.
+	maxBytesPerTxn := Params.DataCoordCfg.ChannelStoreMaxBytesPerTxn.GetAsInt()
+
+	// Execute a txn with both operations-count and total-bytes limit.
 	count := 0
+	bytes := 0
 	operations := make([]*ChannelOp, 0, maxOperationsPerTxn)
 	for _, opset := range perChOps {
 		if !c.sanityCheckPerChannelOpSet(opset) {
@@ -444,14 +447,27 @@ func (c *StateChannelStore) Update(opSet *ChannelOpSet) error {
 				zap.Any("opset size", opset.Len()),
 				zap.Int("limit", maxOperationsPerTxn))
 		}
-		if count+opset.Len() > maxOperationsPerTxn {
+		opBytes, err := estimateOpSetBytes(opset)
+		if err != nil {
+			return err
+		}
+		if opBytes > maxBytesPerTxn {
+			log.Error("Operations for one channel exceeds maxBytesPerTxn",
+				zap.Int("bytes", opBytes),
+				zap.Int("limit", maxBytesPerTxn),
+				zap.Any("opset", opset))
+			return errors.Newf("channel opset bytes exceeds limit, bytes=%d limit=%d", opBytes, maxBytesPerTxn)
+		}
+		if count > 0 && (count+opset.Len() > maxOperationsPerTxn || bytes+opBytes > maxBytesPerTxn) {
 			if err := c.updateMeta(NewChannelOpSet(operations...)); err != nil {
 				return err
 			}
 			count = 0
+			bytes = 0
 			operations = make([]*ChannelOp, 0, maxOperationsPerTxn)
 		}
 		count += opset.Len()
+		bytes += opBytes
 		operations = append(operations, opset.Collect()...)
 	}
 	if count == 0 {
@@ -459,6 +475,39 @@ func (c *StateChannelStore) Update(opSet *ChannelOpSet) error {
 	}
 
 	return c.updateMeta(NewChannelOpSet(operations...))
+}
+
+func estimateOpSetBytes(opSet *ChannelOpSet) (int, error) {
+	total := 0
+	for _, op := range opSet.Collect() {
+		bs, err := estimateOpBytes(op)
+		if err != nil {
+			return 0, err
+		}
+		total += bs
+	}
+	return total, nil
+}
+
+func estimateOpBytes(op *ChannelOp) (int, error) {
+	total := 0
+	for _, ch := range op.Channels {
+		k := buildNodeChannelKey(op.NodeID, ch.GetName())
+		total += len(k)
+		switch op.Type {
+		case Add, Watch, Release:
+			tmpWatchInfo := proto.Clone(ch.GetWatchInfo()).(*datapb.ChannelWatchInfo)
+			tmpWatchInfo.Vchan = reduceVChanSize(tmpWatchInfo.GetVchan())
+			// Keep consistent with persisted data: schema is cleared before saving.
+			tmpWatchInfo.Schema = nil
+			total += proto.Size(tmpWatchInfo)
+		case Delete:
+			// key already counted.
+		default:
+			return 0, errUnknownOpType
+		}
+	}
+	return total, nil
 }
 
 // remove from the assignments

--- a/internal/datacoord/channel_store_test.go
+++ b/internal/datacoord/channel_store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/errors"
@@ -261,6 +262,41 @@ func (s *StateChannelStoreSuite) TestUpdateWithTxnLimit() {
 			s.NoError(err)
 		})
 	}
+}
+
+func (s *StateChannelStoreSuite) TestUpdateWithTxnByteLimit() {
+	// Ensure Update splits txns by bytes (not only by operation count).
+	nameLen := 8 * 1024
+	makeCh := func(i int) RWChannel {
+		name := fmt.Sprintf("ch%d_%s", i, strings.Repeat("a", nameLen))
+		ch := NewStateChannel(getChannel(name, 1))
+		ch.Info = generateWatchInfo(name, datapb.ChannelWatchState_ToWatch)
+		return ch
+	}
+
+	// Find a per-op size so that a single op fits, but two ops exceed maxBytesPerTxn.
+	for {
+		op := NewChannelOp(1, Watch, makeCh(1))
+		opBytes, err := estimateOpBytes(op)
+		s.Require().NoError(err)
+		if opBytes < defaultMaxBytesPerTxn && 2*opBytes > defaultMaxBytesPerTxn {
+			break
+		}
+		nameLen += 8 * 1024
+		s.Require().LessOrEqual(nameLen, 4*1024*1024, "failed to find suitable nameLen for byte-limit test")
+	}
+
+	ops := NewChannelOpSet(
+		NewChannelOp(1, Watch, makeCh(1)),
+		NewChannelOp(1, Watch, makeCh(2)),
+	)
+	s.SetupTest()
+	s.mockTxn.EXPECT().MultiSaveAndRemove(mock.Anything, mock.Anything, mock.Anything).Return(nil).Times(2)
+
+	store := NewStateChannelStore(s.mockTxn)
+	store.AddNode(1)
+	err := store.Update(ops)
+	s.NoError(err)
 }
 
 func (s *StateChannelStoreSuite) TestUpdateMeta2000kSegs() {

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3839,6 +3839,7 @@ type dataCoordConfig struct {
 	ChannelBalanceInterval       ParamItem `refreshable:"true"`
 	ChannelCheckInterval         ParamItem `refreshable:"true"`
 	ChannelOperationRPCTimeout   ParamItem `refreshable:"true"`
+	ChannelStoreMaxBytesPerTxn   ParamItem `refreshable:"true"`
 
 	// --- SEGMENTS ---
 	SegmentMaxSize                 ParamItem `refreshable:"false"`
@@ -4031,6 +4032,15 @@ func (p *dataCoordConfig) init(base *BaseTable) {
 		Export:       true,
 	}
 	p.ChannelOperationRPCTimeout.Init(base.mgr)
+
+	p.ChannelStoreMaxBytesPerTxn = ParamItem{
+		Key:          "dataCoord.channel.storeMaxBytesPerTxn",
+		Version:      "2.5.26",
+		DefaultValue: "1048576",
+		Doc:          "Maximum bytes per transaction in channel store operations (in bytes).",
+		Export:       true,
+	}
+	p.ChannelStoreMaxBytesPerTxn.Init(base.mgr)
 
 	p.SegmentMaxSize = ParamItem{
 		Key:          "dataCoord.segment.maxSize",


### PR DESCRIPTION
see also #47958