### PR TITLE
fix: [2.6] fix non-atomic CreateCollection causes schema loss

### DIFF
--- a/internal/datacoord/task_stats.go
+++ b/internal/datacoord/task_stats.go
@@ -302,6 +302,9 @@ func (st *statsTask) prepareJobRequest(ctx context.Context, segment *SegmentInfo
 	if err != nil || collInfo == nil {
 		return nil, fmt.Errorf("failed to get collection info: %w", err)
 	}
+	if collInfo.Schema == nil || len(collInfo.Schema.GetFields()) == 0 {
+		return nil, fmt.Errorf("collection schema is nil or has no fields, collectionID: %d", segment.GetCollectionID())
+	}
 
 	// Calculate binlog allocation
 	binlogNum := (segment.getSegmentSize()/Params.DataNodeCfg.BinLogMaxSize.GetAsInt64() + 1) *

--- a/internal/datacoord/task_stats_test.go
+++ b/internal/datacoord/task_stats_test.go
@@ -27,6 +27,7 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/datacoord/session"
 	catalogmocks "github.com/milvus-io/milvus/internal/metastore/mocks"
@@ -590,6 +591,30 @@ func (s *statsTaskSuite) TestPrepareJobRequest() {
 		_, err := st.prepareJobRequest(context.Background(), segment)
 		s.Error(err)
 		s.Contains(err.Error(), "failed to get collection info")
+	})
+
+	s.Run("nil schema", func() {
+		handler := NewNMockHandler(s.T())
+		handler.EXPECT().GetCollection(mock.Anything, s.collID).Return(&collectionInfo{
+			Schema: nil,
+		}, nil)
+		st.handler = handler
+
+		_, err := st.prepareJobRequest(context.Background(), segment)
+		s.Error(err)
+		s.Contains(err.Error(), "collection schema is nil or has no fields")
+	})
+
+	s.Run("empty schema fields", func() {
+		handler := NewNMockHandler(s.T())
+		handler.EXPECT().GetCollection(mock.Anything, s.collID).Return(&collectionInfo{
+			Schema: &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{}},
+		}, nil)
+		st.handler = handler
+
+		_, err := st.prepareJobRequest(context.Background(), segment)
+		s.Error(err)
+		s.Contains(err.Error(), "collection schema is nil or has no fields")
 	})
 
 	s.Run("allocation failure", func() {

--- a/internal/proxy/impl_test.go
+++ b/internal/proxy/impl_test.go
@@ -1423,6 +1423,20 @@ func TestProxy_ImportV2(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotEqual(t, int32(0), rsp.GetStatus().GetCode())
 
+		// schema has no fields
+		mc = NewMockCache(t)
+		mc.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(&schemaInfo{
+			CollectionSchema: &schemapb.CollectionSchema{},
+		}, nil).Once()
+		mc.EXPECT().GetCollectionID(mock.Anything, mock.Anything, mock.Anything).Return(0, nil)
+		mc.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(&schemaInfo{
+			CollectionSchema: &schemapb.CollectionSchema{},
+		}, nil).Once()
+		globalMetaCache = mc
+		rsp, err = node.ImportV2(ctx, &internalpb.ImportRequest{CollectionName: "aaa"})
+		assert.NoError(t, err)
+		assert.NotEqual(t, int32(0), rsp.GetStatus().GetCode())
+
 		// get channel failed
 		mc = NewMockCache(t)
 		mc.EXPECT().GetCollectionID(mock.Anything, mock.Anything, mock.Anything).Return(0, nil)
@@ -1463,7 +1477,7 @@ func TestProxy_ImportV2(t *testing.T) {
 		mc = NewMockCache(t)
 		mc.EXPECT().GetCollectionID(mock.Anything, mock.Anything, mock.Anything).Return(0, nil)
 		mc.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(&schemaInfo{
-			CollectionSchema: &schemapb.CollectionSchema{},
+			CollectionSchema: &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{{FieldID: 1}}},
 		}, nil)
 		mc.EXPECT().GetPartitionID(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(0, mockErr)
 		globalMetaCache = mc
@@ -1475,7 +1489,7 @@ func TestProxy_ImportV2(t *testing.T) {
 		mc = NewMockCache(t)
 		mc.EXPECT().GetCollectionID(mock.Anything, mock.Anything, mock.Anything).Return(0, nil)
 		mc.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(&schemaInfo{
-			CollectionSchema: &schemapb.CollectionSchema{},
+			CollectionSchema: &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{{FieldID: 1}}},
 		}, nil)
 		mc.EXPECT().GetPartitionID(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(0, nil)
 		globalMetaCache = mc

--- a/internal/proxy/impl_test.go
+++ b/internal/proxy/impl_test.go
@@ -1425,9 +1425,6 @@ func TestProxy_ImportV2(t *testing.T) {
 
 		// schema has no fields
 		mc = NewMockCache(t)
-		mc.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(&schemaInfo{
-			CollectionSchema: &schemapb.CollectionSchema{},
-		}, nil).Once()
 		mc.EXPECT().GetCollectionID(mock.Anything, mock.Anything, mock.Anything).Return(0, nil)
 		mc.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(&schemaInfo{
 			CollectionSchema: &schemapb.CollectionSchema{},

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -4286,7 +4286,7 @@ func TestProxy_Import(t *testing.T) {
 		mc := NewMockCache(t)
 		mc.EXPECT().GetCollectionID(mock.Anything, mock.Anything, mock.Anything).Return(0, nil)
 		mc.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(&schemaInfo{
-			CollectionSchema: &schemapb.CollectionSchema{},
+			CollectionSchema: &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{{FieldID: 1}}},
 		}, nil)
 		mc.EXPECT().GetPartitionID(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(0, nil)
 		globalMetaCache = mc

--- a/internal/proxy/task_import.go
+++ b/internal/proxy/task_import.go
@@ -106,6 +106,9 @@ func (it *importTask) PreExecute(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	if schema.CollectionSchema == nil || len(schema.CollectionSchema.GetFields()) == 0 {
+		return merr.WrapErrImportFailed("collection schema has no fields")
+	}
 	it.schema = schema
 	channels, err := node.chMgr.getVChannels(collectionID)
 	if err != nil {


### PR DESCRIPTION
pr: #47900
issue: https://github.com/milvus-io/milvus/issues/47898

## Summary

Cherry-pick of #47900 to 2.6 branch.

- **Root cause fix**: Reverse write order in `Catalog.CreateCollection` to save fields/partitions/functions first, then collection key last. The collection key is the "commit point" — if a crash happens before it's written, the DDL ack callback retries the full write.
- **Defense-in-depth**: Stats task and import task validate schema before proceeding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)