### PR TITLE
enhance: Throttle index build concurrency and CPU usage in standalone mode

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -965,7 +965,7 @@ common:
     lowPriority: 1 # This parameter specify how many times the number of threads is the number of cores in low priority pool
     bm25Load: 1 # This parameter specify how many times the number of threads is the number of cores in BM25 load pool
     maxThreadsSize: 16 # The maximum number of threads in the thread pool, only effective when greater than 0
-  buildIndexThreadPoolRatio: 0.75
+  buildIndexThreadPoolRatio: 0.5
   DiskIndex:
     MaxDegree: 56
     SearchListSize: 100

--- a/internal/datanode/index/pool.go
+++ b/internal/datanode/index/pool.go
@@ -29,37 +29,37 @@ import (
 )
 
 var (
-	vecIndexBuildPool         *conc.Pool[any]
-	vecIndexBuildPoolInitOnce sync.Once
+	indexBuildPool         *conc.Pool[any]
+	indexBuildPoolInitOnce sync.Once
 )
 
-func initVecIndexBuildPool() {
+func initIndexBuildPool() {
 	pt := paramtable.Get()
-	initPoolSize := pt.DataNodeCfg.MaxVecIndexBuildConcurrency.GetAsInt()
-	vecIndexBuildPool = conc.NewPool[any](
+	initPoolSize := pt.DataNodeCfg.MaxIndexBuildConcurrency.GetAsInt()
+	indexBuildPool = conc.NewPool[any](
 		initPoolSize,
 	)
 
-	watchKey := pt.DataNodeCfg.MaxVecIndexBuildConcurrency.Key
-	pt.Watch(watchKey, config.NewHandler(watchKey, resizeVecIndexBuildPool))
-	log.Info("init vector index building pool done", zap.Int("size", initPoolSize))
+	watchKey := pt.DataNodeCfg.MaxIndexBuildConcurrency.Key
+	pt.Watch(watchKey, config.NewHandler(watchKey, resizeIndexBuildPool))
+	log.Info("init index building pool done", zap.Int("size", initPoolSize))
 }
 
-func resizeVecIndexBuildPool(evt *config.Event) {
+func resizeIndexBuildPool(evt *config.Event) {
 	if evt.HasUpdated {
-		newSize := paramtable.Get().DataNodeCfg.MaxVecIndexBuildConcurrency.GetAsInt()
+		newSize := paramtable.Get().DataNodeCfg.MaxIndexBuildConcurrency.GetAsInt()
 		log := log.Ctx(context.Background()).With(zap.Int("newSize", newSize))
 
-		err := GetVecIndexBuildPool().Resize(newSize)
+		err := GetIndexBuildPool().Resize(newSize)
 		if err != nil {
 			log.Warn("failed to resize pool", zap.Error(err))
 			return
 		}
-		log.Info("vector index building pool resize successfully")
+		log.Info("index building pool resize successfully")
 	}
 }
 
-func GetVecIndexBuildPool() *conc.Pool[any] {
-	vecIndexBuildPoolInitOnce.Do(initVecIndexBuildPool)
-	return vecIndexBuildPool
+func GetIndexBuildPool() *conc.Pool[any] {
+	indexBuildPoolInitOnce.Do(initIndexBuildPool)
+	return indexBuildPool
 }

--- a/internal/datanode/index/pool.go
+++ b/internal/datanode/index/pool.go
@@ -28,38 +28,61 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
-var (
-	indexBuildPool         *conc.Pool[any]
-	indexBuildPoolInitOnce sync.Once
-)
-
-func initIndexBuildPool() {
-	pt := paramtable.Get()
-	initPoolSize := pt.DataNodeCfg.MaxIndexBuildConcurrency.GetAsInt()
-	indexBuildPool = conc.NewPool[any](
-		initPoolSize,
-	)
-
-	watchKey := pt.DataNodeCfg.MaxIndexBuildConcurrency.Key
-	pt.Watch(watchKey, config.NewHandler(watchKey, resizeIndexBuildPool))
-	log.Info("init index building pool done", zap.Int("size", initPoolSize))
+// indexBuildPool wraps a concurrency pool that auto-initializes from a ParamItem
+// and watches for dynamic config changes.
+type indexBuildPool struct {
+	name string
+	once sync.Once
+	pool *conc.Pool[any]
+	// param returns the ParamItem that controls pool size.
+	param func() *paramtable.ParamItem
 }
 
-func resizeIndexBuildPool(evt *config.Event) {
-	if evt.HasUpdated {
-		newSize := paramtable.Get().DataNodeCfg.MaxIndexBuildConcurrency.GetAsInt()
-		log := log.Ctx(context.Background()).With(zap.Int("newSize", newSize))
+func newIndexBuildPool(name string, param func() *paramtable.ParamItem) *indexBuildPool {
+	return &indexBuildPool{name: name, param: param}
+}
 
-		err := GetIndexBuildPool().Resize(newSize)
-		if err != nil {
-			log.Warn("failed to resize pool", zap.Error(err))
+func (p *indexBuildPool) init() {
+	item := p.param()
+	size := item.GetAsInt()
+	p.pool = conc.NewPool[any](size)
+
+	pt := paramtable.Get()
+	pt.Watch(item.Key, config.NewHandler(item.Key, p.resize))
+	log.Info("init index building pool done", zap.String("name", p.name), zap.Int("size", size))
+}
+
+func (p *indexBuildPool) resize(evt *config.Event) {
+	if evt.HasUpdated {
+		newSize := p.param().GetAsInt()
+		l := log.Ctx(context.Background()).With(zap.String("name", p.name), zap.Int("newSize", newSize))
+
+		if err := p.Get().Resize(newSize); err != nil {
+			l.Warn("failed to resize index build pool", zap.Error(err))
 			return
 		}
-		log.Info("index building pool resize successfully")
+		l.Info("index building pool resize successfully")
 	}
 }
 
-func GetIndexBuildPool() *conc.Pool[any] {
-	indexBuildPoolInitOnce.Do(initIndexBuildPool)
-	return indexBuildPool
+func (p *indexBuildPool) Get() *conc.Pool[any] {
+	p.once.Do(p.init)
+	return p.pool
+}
+
+var (
+	vecPool = newIndexBuildPool("vec", func() *paramtable.ParamItem {
+		return &paramtable.Get().DataNodeCfg.MaxVecIndexBuildConcurrency
+	})
+	standalonePool = newIndexBuildPool("standalone", func() *paramtable.ParamItem {
+		return &paramtable.Get().DataNodeCfg.StandaloneIndexBuildParallelism
+	})
+)
+
+func GetVecIndexBuildPool() *conc.Pool[any] {
+	return vecPool.Get()
+}
+
+func GetStandaloneIndexBuildPool() *conc.Pool[any] {
+	return standalonePool.Get()
 }

--- a/internal/datanode/index/pool_test.go
+++ b/internal/datanode/index/pool_test.go
@@ -30,35 +30,38 @@ func TestResizePools(t *testing.T) {
 	paramtable.Get().Init(paramtable.NewBaseTable(paramtable.SkipRemote(true)))
 	pt := paramtable.Get()
 
-	defer func() {
-		_ = pt.Reset(pt.DataNodeCfg.MaxIndexBuildConcurrency.Key)
-	}()
+	testCases := []struct {
+		name  string
+		pool  *indexBuildPool
+		param *paramtable.ParamItem
+	}{
+		{"VecIndexBuildPool", vecPool, &pt.DataNodeCfg.MaxVecIndexBuildConcurrency},
+		{"StandaloneIndexBuildPool", standalonePool, &pt.DataNodeCfg.StandaloneIndexBuildParallelism},
+	}
 
-	t.Run("GetIndexBuildPool", func(t *testing.T) {
-		expectedCap := pt.DataNodeCfg.MaxIndexBuildConcurrency.GetAsInt()
-		assert.Equal(t, expectedCap, GetIndexBuildPool().Cap())
-		resizeIndexBuildPool(&config.Event{
-			HasUpdated: true,
-		})
-		assert.Equal(t, expectedCap, GetIndexBuildPool().Cap())
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				_ = pt.Reset(tc.param.Key)
+			}()
 
-		_ = pt.Save(pt.DataNodeCfg.MaxIndexBuildConcurrency.Key, fmt.Sprintf("%d", expectedCap*2))
-		expectedCap = pt.DataNodeCfg.MaxIndexBuildConcurrency.GetAsInt()
-		resizeIndexBuildPool(&config.Event{
-			HasUpdated: true,
-		})
-		assert.Equal(t, expectedCap, GetIndexBuildPool().Cap())
+			expectedCap := tc.param.GetAsInt()
+			assert.Equal(t, expectedCap, tc.pool.Get().Cap())
+			tc.pool.resize(&config.Event{HasUpdated: true})
+			assert.Equal(t, expectedCap, tc.pool.Get().Cap())
 
-		_ = pt.Save(pt.DataNodeCfg.MaxIndexBuildConcurrency.Key, "0")
-		resizeIndexBuildPool(&config.Event{
-			HasUpdated: true,
-		})
-		assert.Equal(t, expectedCap, GetIndexBuildPool().Cap(), "pool shall not be resized when newSize is 0")
+			_ = pt.Save(tc.param.Key, fmt.Sprintf("%d", expectedCap*2))
+			expectedCap = tc.param.GetAsInt()
+			tc.pool.resize(&config.Event{HasUpdated: true})
+			assert.Equal(t, expectedCap, tc.pool.Get().Cap())
 
-		_ = pt.Save(pt.DataNodeCfg.MaxIndexBuildConcurrency.Key, "invalid")
-		resizeIndexBuildPool(&config.Event{
-			HasUpdated: true,
+			_ = pt.Save(tc.param.Key, "0")
+			tc.pool.resize(&config.Event{HasUpdated: true})
+			assert.Equal(t, expectedCap, tc.pool.Get().Cap(), "pool shall not be resized when newSize is 0")
+
+			_ = pt.Save(tc.param.Key, "invalid")
+			tc.pool.resize(&config.Event{HasUpdated: true})
+			assert.Equal(t, expectedCap, tc.pool.Get().Cap())
 		})
-		assert.Equal(t, expectedCap, GetIndexBuildPool().Cap())
-	})
+	}
 }

--- a/internal/datanode/index/pool_test.go
+++ b/internal/datanode/index/pool_test.go
@@ -31,34 +31,34 @@ func TestResizePools(t *testing.T) {
 	pt := paramtable.Get()
 
 	defer func() {
-		_ = pt.Reset(pt.DataNodeCfg.MaxVecIndexBuildConcurrency.Key)
+		_ = pt.Reset(pt.DataNodeCfg.MaxIndexBuildConcurrency.Key)
 	}()
 
-	t.Run("GetVecIndexBuildPool", func(t *testing.T) {
-		expectedCap := pt.DataNodeCfg.MaxVecIndexBuildConcurrency.GetAsInt()
-		assert.Equal(t, expectedCap, GetVecIndexBuildPool().Cap())
-		resizeVecIndexBuildPool(&config.Event{
+	t.Run("GetIndexBuildPool", func(t *testing.T) {
+		expectedCap := pt.DataNodeCfg.MaxIndexBuildConcurrency.GetAsInt()
+		assert.Equal(t, expectedCap, GetIndexBuildPool().Cap())
+		resizeIndexBuildPool(&config.Event{
 			HasUpdated: true,
 		})
-		assert.Equal(t, expectedCap, GetVecIndexBuildPool().Cap())
+		assert.Equal(t, expectedCap, GetIndexBuildPool().Cap())
 
-		_ = pt.Save(pt.DataNodeCfg.MaxVecIndexBuildConcurrency.Key, fmt.Sprintf("%d", expectedCap*2))
-		expectedCap = pt.DataNodeCfg.MaxVecIndexBuildConcurrency.GetAsInt()
-		resizeVecIndexBuildPool(&config.Event{
+		_ = pt.Save(pt.DataNodeCfg.MaxIndexBuildConcurrency.Key, fmt.Sprintf("%d", expectedCap*2))
+		expectedCap = pt.DataNodeCfg.MaxIndexBuildConcurrency.GetAsInt()
+		resizeIndexBuildPool(&config.Event{
 			HasUpdated: true,
 		})
-		assert.Equal(t, expectedCap, GetVecIndexBuildPool().Cap())
+		assert.Equal(t, expectedCap, GetIndexBuildPool().Cap())
 
-		_ = pt.Save(pt.DataNodeCfg.MaxVecIndexBuildConcurrency.Key, "0")
-		resizeVecIndexBuildPool(&config.Event{
+		_ = pt.Save(pt.DataNodeCfg.MaxIndexBuildConcurrency.Key, "0")
+		resizeIndexBuildPool(&config.Event{
 			HasUpdated: true,
 		})
-		assert.Equal(t, expectedCap, GetVecIndexBuildPool().Cap(), "pool shall not be resized when newSize is 0")
+		assert.Equal(t, expectedCap, GetIndexBuildPool().Cap(), "pool shall not be resized when newSize is 0")
 
-		_ = pt.Save(pt.DataNodeCfg.MaxVecIndexBuildConcurrency.Key, "invalid")
-		resizeVecIndexBuildPool(&config.Event{
+		_ = pt.Save(pt.DataNodeCfg.MaxIndexBuildConcurrency.Key, "invalid")
+		resizeIndexBuildPool(&config.Event{
 			HasUpdated: true,
 		})
-		assert.Equal(t, expectedCap, GetVecIndexBuildPool().Cap())
+		assert.Equal(t, expectedCap, GetIndexBuildPool().Cap())
 	})
 }

--- a/internal/datanode/index/scheduler.go
+++ b/internal/datanode/index/scheduler.go
@@ -198,7 +198,8 @@ func NewIndexBuildTaskQueue(sched *TaskScheduler) *IndexTaskQueue {
 
 // TaskScheduler is a scheduler of indexing tasks.
 type TaskScheduler struct {
-	TaskQueue TaskQueue
+	TaskQueue    TaskQueue
+	isStandalone bool
 
 	wg     sync.WaitGroup
 	ctx    context.Context
@@ -209,8 +210,9 @@ type TaskScheduler struct {
 func NewTaskScheduler(ctx context.Context) *TaskScheduler {
 	ctx1, cancel := context.WithCancel(ctx)
 	s := &TaskScheduler{
-		ctx:    ctx1,
-		cancel: cancel,
+		ctx:          ctx1,
+		cancel:       cancel,
+		isStandalone: paramtable.GetRole() == typeutil.StandaloneRole,
 	}
 	s.TaskQueue = NewIndexBuildTaskQueue(s)
 
@@ -274,8 +276,15 @@ func (sched *TaskScheduler) indexBuildLoop() {
 		case <-sched.TaskQueue.utChan():
 			t := sched.TaskQueue.PopUnissuedTask()
 			go func(t Task) {
-				if t.IsVectorIndex() || paramtable.GetRole() == typeutil.StandaloneRole {
-					GetIndexBuildPool().Submit(func() (any, error) {
+				if sched.isStandalone {
+					// In standalone mode, throttle ALL index builds to avoid resource contention.
+					GetStandaloneIndexBuildPool().Submit(func() (any, error) {
+						sched.processTask(t)
+						return nil, nil
+					})
+				} else if t.IsVectorIndex() {
+					// In cluster mode, only throttle vector index builds.
+					GetVecIndexBuildPool().Submit(func() (any, error) {
 						sched.processTask(t)
 						return nil, nil
 					})

--- a/internal/datanode/index/scheduler.go
+++ b/internal/datanode/index/scheduler.go
@@ -30,6 +30,8 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
 // TaskQueue is a queue used to store tasks.
@@ -272,8 +274,8 @@ func (sched *TaskScheduler) indexBuildLoop() {
 		case <-sched.TaskQueue.utChan():
 			t := sched.TaskQueue.PopUnissuedTask()
 			go func(t Task) {
-				if t.IsVectorIndex() {
-					GetVecIndexBuildPool().Submit(func() (any, error) {
+				if t.IsVectorIndex() || paramtable.GetRole() == typeutil.StandaloneRole {
+					GetIndexBuildPool().Submit(func() (any, error) {
 						sched.processTask(t)
 						return nil, nil
 					})

--- a/pkg/util/paramtable/base_table.go
+++ b/pkg/util/paramtable/base_table.go
@@ -53,7 +53,7 @@ const (
 	DefaultRootPath                                      = ""
 	DefaultMinioLogLevel                                 = "fatal"
 	DefaultKnowhereThreadPoolNumRatioInBuild             = 1
-	DefaultKnowhereThreadPoolNumRatioInBuildOfStandalone = 0.75
+	DefaultKnowhereThreadPoolNumRatioInBuildOfStandalone = 0.5
 	DefaultMinioRegion                                   = ""
 	DefaultMinioUseVirtualHost                           = "false"
 	DefaultMinioRequestTimeout                           = "10000"

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -6675,8 +6675,9 @@ type dataNodeConfig struct {
 	DeltalogFormat ParamItem `refreshable:"false"`
 
 	// index services config
-	BuildParallel            ParamItem `refreshable:"false"`
-	MaxIndexBuildConcurrency ParamItem `refreshable:"true"`
+	BuildParallel                   ParamItem `refreshable:"false"`
+	MaxVecIndexBuildConcurrency     ParamItem `refreshable:"true"`
+	StandaloneIndexBuildParallelism ParamItem `refreshable:"true"`
 
 	WorkerSlotUnit      ParamItem `refreshable:"true"`
 	StandaloneSlotRatio ParamItem `refreshable:"false"`
@@ -7164,13 +7165,23 @@ if this parameter <= 0, will set it as 10`,
 	}
 	p.BuildParallel.Init(base.mgr)
 
-	p.MaxIndexBuildConcurrency = ParamItem{
+	p.MaxVecIndexBuildConcurrency = ParamItem{
 		Key:          "dataNode.index.maxVecIndexBuildConcurrency",
 		Version:      "2.6.9",
 		DefaultValue: "4",
+		Doc:          "Max concurrent index build tasks for vector index building",
 		Export:       false,
 	}
-	p.MaxIndexBuildConcurrency.Init(base.mgr)
+	p.MaxVecIndexBuildConcurrency.Init(base.mgr)
+
+	p.StandaloneIndexBuildParallelism = ParamItem{
+		Key:          "dataNode.index.maxIndexBuildParallelism",
+		Version:      "2.6.13",
+		DefaultValue: "4",
+		Doc:          "Max concurrent index build tasks in standalone mode",
+		Export:       false,
+	}
+	p.StandaloneIndexBuildParallelism.Init(base.mgr)
 
 	p.WorkerSlotUnit = ParamItem{
 		Key:          "dataNode.workerSlotUnit",

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -7165,7 +7165,7 @@ if this parameter <= 0, will set it as 10`,
 	p.BuildParallel.Init(base.mgr)
 
 	p.MaxIndexBuildConcurrency = ParamItem{
-		Key:          "dataNode.index.maxIndexBuildConcurrency",
+		Key:          "dataNode.index.maxVecIndexBuildConcurrency",
 		Version:      "2.6.9",
 		DefaultValue: "4",
 		Export:       false,

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -6675,7 +6675,7 @@ type dataNodeConfig struct {
 	DeltalogFormat ParamItem `refreshable:"false"`
 
 	// index services config
-	BuildParallel               ParamItem `refreshable:"false"`
+	BuildParallel            ParamItem `refreshable:"false"`
 	MaxIndexBuildConcurrency ParamItem `refreshable:"true"`
 
 	WorkerSlotUnit      ParamItem `refreshable:"true"`

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -6676,7 +6676,7 @@ type dataNodeConfig struct {
 
 	// index services config
 	BuildParallel               ParamItem `refreshable:"false"`
-	MaxVecIndexBuildConcurrency ParamItem `refreshable:"true"`
+	MaxIndexBuildConcurrency ParamItem `refreshable:"true"`
 
 	WorkerSlotUnit      ParamItem `refreshable:"true"`
 	StandaloneSlotRatio ParamItem `refreshable:"false"`
@@ -7164,13 +7164,13 @@ if this parameter <= 0, will set it as 10`,
 	}
 	p.BuildParallel.Init(base.mgr)
 
-	p.MaxVecIndexBuildConcurrency = ParamItem{
-		Key:          "dataNode.index.maxVecIndexBuildConcurrency",
+	p.MaxIndexBuildConcurrency = ParamItem{
+		Key:          "dataNode.index.maxIndexBuildConcurrency",
 		Version:      "2.6.9",
 		DefaultValue: "4",
 		Export:       false,
 	}
-	p.MaxVecIndexBuildConcurrency.Init(base.mgr)
+	p.MaxIndexBuildConcurrency.Init(base.mgr)
 
 	p.WorkerSlotUnit = ParamItem{
 		Key:          "dataNode.workerSlotUnit",

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -694,7 +694,7 @@ func TestComponentParam(t *testing.T) {
 		// compaction
 		assert.Equal(t, 10, Params.MaxCompactionConcurrency.GetAsInt())
 
-		assert.Equal(t, 4, Params.MaxVecIndexBuildConcurrency.GetAsInt())
+		assert.Equal(t, 4, Params.MaxIndexBuildConcurrency.GetAsInt())
 
 		// clustering compaction
 		params.Save("datanode.clusteringCompaction.memoryBufferRatio", "0.1")

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -694,7 +694,8 @@ func TestComponentParam(t *testing.T) {
 		// compaction
 		assert.Equal(t, 10, Params.MaxCompactionConcurrency.GetAsInt())
 
-		assert.Equal(t, 4, Params.MaxIndexBuildConcurrency.GetAsInt())
+		assert.Equal(t, 4, Params.MaxVecIndexBuildConcurrency.GetAsInt())
+		assert.Equal(t, 4, Params.StandaloneIndexBuildParallelism.GetAsInt())
 
 		// clustering compaction
 		params.Save("datanode.clusteringCompaction.memoryBufferRatio", "0.1")


### PR DESCRIPTION
## Summary
- Reduce the default knowhere build index thread pool ratio in standalone mode from 0.75 to 0.5, leaving more CPU headroom for concurrent operations like WAL consumption and segment inserts
- Rename `VecIndexBuildPool` to `IndexBuildPool` and route **all** index build tasks (vector, scalar, stats, analyze) through it in standalone mode, preventing unbounded scalar index concurrency from starving other CGO operations
- In cluster mode, non-vector tasks continue to execute directly without pool throttling, preserving existing behavior

issue: #47913