### PR TITLE
feat: [ExternalTable Part5] Enable loading and querying external collections

### DIFF
--- a/docs/external_table_load_query_design.md
+++ b/docs/external_table_load_query_design.md
@@ -1,0 +1,753 @@
+# External Table: Index, Load & Query Design Document
+
+## Overview
+
+This document describes how external collections (tables backed by external Parquet files in object storage) implement **indexing**, **loading**, and **querying** in Milvus. The implementation spans Proxy, DataCoord, DataNode, QueryNode (Go), and Segcore (C++).
+
+## Architecture
+
+```
+                         +---------+
+                         |  Client |
+                         +----+----+
+                              |
+                    RefreshExternalCollection
+                    CreateIndex / LoadCollection
+                    Search / Query
+                              |
+                         +----v----+
+                         |  Proxy  |  -- validates external collection, injects virtual PK
+                         +----+----+
+                              |
+              +---------------+----------------+
+              |                                |
+        +-----v------+                  +------v------+
+        |  DataCoord  |                 |  QueryCoord  |
+        +-----+------+                  +------+------+
+              |                                |
+      Refresh (segment                  Load (assign segments
+      creation & manifest)              to query nodes)
+              |                                |
+        +-----v------+                  +------v------+
+        |  DataNode   |                 |  QueryNode   |
+        +------------+                  +------+------+
+                                               |
+                                        +------v------+
+                                        |   Segcore   |  -- C++ engine
+                                        |  (sealed    |     loads parquet via
+                                        |   segment)  |     milvus-storage Reader
+                                        +-------------+
+```
+
+---
+
+## 1. Refresh: From External Files to Segments
+
+### 1.1 RPC Flow
+
+```
+Client.RefreshExternalCollection(collectionName)
+  -> Proxy.RefreshExternalCollection()
+       validates collection, resolves collectionID
+  -> DataCoord.RefreshExternalCollection()
+       pre-allocates JobID, broadcasts to WAL
+  -> WAL callback -> Manager.SubmitRefreshJobWithID()
+       creates Job + Task, enqueues to Scheduler
+  -> Scheduler dispatches Task to DataNode
+  -> DataNode.UpdateExternalCollection()
+       scans external source, creates manifests
+  -> DataCoord.SetJobInfo()
+       atomic segment metadata update (drop old + add new)
+```
+
+### 1.2 DataNode: Fragment Discovery & Segment Organization
+
+**File**: `internal/datanode/external/task_update.go`
+
+The DataNode receives an `UpdateExternalCollectionRequest` containing:
+- `CurrentSegments`: existing segment list
+- `PreAllocatedSegmentIds`: ID range [begin, end) pre-allocated by DataCoord
+- `Schema`, `ExternalSource`, `ExternalSpec`, `StorageConfig`
+
+**Step 1: Fetch Fragments from External Source**
+
+```
+ExternalSource (e.g., "external-data/my_collection/")
+  -> packed.ExploreFiles()        -- FFI: scan directory for parquet files
+  -> packed.GetFileInfo()          -- FFI: get row count per file
+  -> packed.SplitFileToFragments() -- split large files (>1M rows) into fragments
+  -> []Fragment{FilePath, StartRow, EndRow, RowCount}
+```
+
+A **Fragment** is the smallest unit of data assignment:
+```go
+type Fragment struct {
+    FragmentID int64
+    FilePath   string   // e.g., "external-data/my_collection/data0.parquet"
+    StartRow   int64    // inclusive
+    EndRow     int64    // exclusive
+    RowCount   int64    // EndRow - StartRow
+}
+```
+
+**Step 2: Compare with Current Segments**
+
+For each current segment, read its manifest to get its fragments. If ALL fragments of a segment still exist in the new external source, the segment is **kept**. Otherwise, its fragments become **orphans**.
+
+```
+currentSegmentFragments = BuildCurrentSegmentFragments(currentSegments)
+
+for each currentSegment:
+    if all its fragments exist in newFragments:
+        mark as KEPT, record used fragments
+    else:
+        mark as INVALIDATED, fragments become orphans
+
+orphanFragments = newFragments - usedFragments
+```
+
+**Step 3: Balance Orphan Fragments into New Segments**
+
+Uses **greedy bin-packing** (largest-first, fill-lightest-bin):
+
+```
+targetRowsPerSegment = config (default from paramtable)
+numSegments = ceil(totalOrphanRows / targetRowsPerSegment)
+
+sort fragments by rowCount DESC
+for each fragment:
+    assign to bin with minimum current rowCount
+```
+
+**Step 4: Create Manifest for Each New Segment**
+
+```go
+manifestPath = packed.CreateSegmentManifest(
+    basePath: "external/{collectionID}/segments/{segmentID}",
+    format: "parquet",
+    columns: schema field names,
+    fragments: assigned fragments,
+    storageConfig: S3/MinIO config,
+)
+```
+
+The manifest is a milvus-storage transaction that records which column groups (files + row ranges) belong to this segment.
+
+**Step 5: Return Results**
+
+```go
+Response{
+    KeptSegments:    []int64{seg1, seg2},           // unchanged segments
+    UpdatedSegments: []*SegmentInfo{newSeg1, ...},  // newly created segments
+}
+```
+
+### 1.3 DataCoord: Atomic Segment Update
+
+**File**: `internal/datacoord/task_refresh_external_collection.go` (`SetJobInfo`)
+
+The DataCoord atomically:
+1. **Drops** segments not in `KeptSegments` (sets `State = Dropped`)
+2. **Adds** new segments from `UpdatedSegments` (fills in `InsertChannel`, `PartitionID`, sets `State = Flushed`)
+3. Updates via `meta.UpdateSegmentsInfo(operators...)` in a single transaction
+
+Safety checks:
+- Refuses to delete ALL segments if active segments exist (prevents data loss)
+- Warns if deletion ratio exceeds 90% (configurable)
+
+### 1.4 Manifest Path Format
+
+```
+external/{collectionID}/segments/{segmentID}/manifest_v{version}
+```
+
+The manifest stores:
+- Column groups (each group = one parquet file path + row range)
+- Column names and their mapping to parquet columns
+- Format metadata (parquet/csv/json)
+
+---
+
+## 2. Loading: From Segment to Queryable Data
+
+### 2.1 QueryNode Go Layer
+
+**File**: `internal/querynodev2/segments/segment_loader.go`
+
+When loading an external collection segment, the loader takes a **different path** from normal segments:
+
+```go
+func (loader *segmentLoader) Load(ctx context.Context, segment *LocalSegment, loadInfo *querypb.SegmentLoadInfo) error {
+    // Normal segment: load binlogs, delta logs, bloom filters
+    // External segment: different handling
+
+    // 1. Load segment data via CGO (triggers C++ LoadExternalCollectionFields)
+    segment.Load(loadInfo)
+
+    // 2. Skip delta logs (external collections are read-only)
+    if !IsExternalCollection(collection.Schema()) {
+        loader.loadDeltalogs(ctx, segment, loadInfo.GetDeltalogs())
+    }
+
+    // 3. Use ExternalSegmentCandidate instead of BloomFilter
+    if IsExternalCollection(collection.Schema()) {
+        candidate := pkoracle.NewExternalSegmentCandidate(
+            loadInfo.GetSegmentID(),
+            loadInfo.GetPartitionID(),
+            segment.Type(),
+        )
+        segment.SetPKCandidate(candidate)
+    } else {
+        bfs := loader.loadSingleBloomFilterSet(...)
+        segment.SetBloomFilter(bfs)
+    }
+}
+```
+
+Key differences from normal segment loading:
+| Aspect | Normal Segment | External Segment |
+|--------|----------------|------------------|
+| Data source | Binlog files | Parquet via milvus-storage Reader |
+| Delta logs | Loaded | Skipped (read-only) |
+| PK check | BloomFilterSet (probabilistic) | ExternalSegmentCandidate (deterministic) |
+| PK type | Real user-defined PK | Virtual PK: `(segmentID << 32) \| offset` |
+
+### 2.2 Segcore C++ Layer: LoadExternalCollectionFields
+
+**File**: `internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp`
+
+This is the core loading function that creates in-memory column representations for external data:
+
+```cpp
+void ChunkedSegmentSealedImpl::LoadExternalCollectionFields() {
+    int64_t num_rows = segment_load_info_.GetNumOfRows();
+
+    // Guard: skip 0-row segments
+    if (num_rows == 0) {
+        update_row_count(0);
+        system_ready_count_++;
+        return;
+    }
+
+    // Shared mutex for serializing Reader access (Reader is NOT thread-safe)
+    auto reader_mutex = std::make_shared<std::mutex>();
+    std::vector<std::shared_ptr<ExternalFieldChunkedColumn>> ext_columns;
+
+    for (const auto& [field_id, field_meta] : schema_->get_fields()) {
+        // Skip system fields
+        if (field_id.get() < START_USER_FIELDID) continue;
+
+        // 1. Virtual PK field -> VirtualPKChunkedColumn
+        if (field_meta.get_name() == "__virtual_pk__") {
+            auto column = std::make_shared<VirtualPKChunkedColumn>(id_, num_rows);
+            fields_.emplace(field_id, column);
+            continue;
+        }
+
+        // 2. External data field -> ExternalFieldChunkedColumn
+        if (field_meta.is_external_field()) {
+            auto column = std::make_shared<ExternalFieldChunkedColumn>(
+                num_rows, data_type, nullable, field_id, dim,
+                field_meta.get_external_field(),  // parquet column name
+                reader_.get(),                    // milvus-storage Reader
+                reader_mutex                      // shared mutex
+            );
+            ext_columns.push_back(column);
+            fields_.emplace(field_id, column);
+            continue;
+        }
+    }
+
+    // 3. Eagerly materialize ALL external columns during load
+    //    (avoids concurrent Reader access during query)
+    for (auto& col : ext_columns) {
+        col->EagerMaterialize();
+    }
+
+    // 4. Build PK->offset index for virtual PKs
+    insert_record_.insert_pks(DataType::INT64, pk_column);
+    insert_record_.seal_pks();
+
+    // 5. Initialize synthetic timestamps (all zeros = always visible)
+    std::vector<Timestamp> timestamps(num_rows, 0);
+    insert_record_.init_timestamps(timestamps, index);
+
+    // 6. Mark segment ready
+    update_row_count(num_rows);
+    system_ready_count_++;
+}
+```
+
+### 2.3 Column Implementations
+
+#### VirtualPKChunkedColumn
+
+**File**: `internal/core/src/mmap/VirtualPKChunkedColumn.h`
+
+Generates virtual primary keys on-the-fly without storing actual data:
+
+```
+Virtual PK format:  [63:32] truncated_segment_id | [31:0] row_offset
+Max rows per segment: 2^32 (~4 billion)
+```
+
+```cpp
+class VirtualPKChunkedColumn : public ChunkedColumnInterface {
+    // Bulk access: computes PKs on-the-fly (zero memory for filtered queries)
+    void BulkPrimitiveValueAt(dst, offsets, count) {
+        for (int64_t i = 0; i < count; i++) {
+            typed_dst[i] = GetVirtualPK(truncated_segment_id_, offsets[i]);
+        }
+    }
+
+    // Span access: lazy-materializes all PKs (for full scans)
+    PinWrapper<SpanBase> Span() {
+        EnsureMaterialized();  // std::call_once
+        return SpanBase(materialized_pks_.data(), num_rows_, sizeof(int64_t));
+    }
+};
+```
+
+#### ExternalFieldChunkedColumn
+
+**File**: `internal/core/src/mmap/ExternalFieldChunkedColumn.h`
+
+Wraps external parquet data with lazy/eager materialization:
+
+```cpp
+class ExternalFieldChunkedColumn : public ChunkedColumnInterface {
+    // Eager materialization during load (called from LoadExternalCollectionFields)
+    void EagerMaterialize() {
+        EnsureMaterialized();
+    }
+
+    void EnsureMaterialized() {
+        std::call_once(materialize_once_, [this]() {
+            // Read ALL rows from parquet via milvus-storage Reader
+            std::vector<int64_t> all_indices(num_rows_);
+            std::iota(all_indices.begin(), all_indices.end(), 0);
+
+            std::lock_guard<std::mutex> lock(*reader_mutex_);
+            auto table = reader_->take(all_indices);
+
+            // Copy Arrow data to contiguous memory buffer
+            auto column = table->GetColumnByName(external_field_name_);
+            // Handle: FIXED_SIZE_BINARY, LIST, FIXED_SIZE_LIST for vectors
+            // Handle: INT8..INT64, FLOAT, DOUBLE, BOOL for scalars
+            CopyToBuffer(column, materialized_data_);
+        });
+    }
+
+    // Query-time access: reads from materialized buffer (no Reader needed)
+    void BulkPrimitiveValueAt(dst, offsets, count) {
+        EnsureMaterialized();
+        auto src = materialized_data_.data();
+        for (int64_t i = 0; i < count; i++) {
+            memcpy(dst + i * element_size, src + offsets[i] * element_size, element_size);
+        }
+    }
+};
+```
+
+### 2.4 ExternalSegmentCandidate (PK Oracle)
+
+**File**: `internal/querynodev2/pkoracle/external_segment_candidate.go`
+
+Replaces BloomFilter for external segments. Uses virtual PK format for deterministic segment matching:
+
+```go
+type ExternalSegmentCandidate struct {
+    segmentID          int64
+    truncatedSegmentID int64  // segmentID & 0xFFFFFFFF
+    partitionID        int64
+    segType            commonpb.SegmentState
+}
+
+func (c *ExternalSegmentCandidate) MayPkExist(lc *storage.LocationsCache) bool {
+    pk := lc.GetPk()
+    if int64Pk, ok := pk.(*storage.Int64PrimaryKey); ok {
+        extractedSegmentID := int64(uint64(int64Pk.Value) >> 32)
+        return extractedSegmentID == c.truncatedSegmentID
+    }
+    return false  // only int64 virtual PKs
+}
+```
+
+| Property | BloomFilter | ExternalSegmentCandidate |
+|----------|-------------|--------------------------|
+| False positives | Yes (probabilistic) | No (deterministic) |
+| Memory | O(n) based on cardinality | O(1) - zero |
+| PK types | Any | Int64 only (virtual PK) |
+
+---
+
+## 3. Indexing
+
+### 3.1 Current Status: Brute-Force Search
+
+External collections currently use **brute-force (flat) search** with no vector index. When a search request arrives:
+
+1. All vector data is already materialized in memory (from `EagerMaterialize` during load)
+2. The segcore search engine performs flat L2/IP/Cosine distance computation directly on the materialized buffer
+3. No index build step is required
+
+This means:
+- `CreateIndex` on external collection embedding fields is a **no-op** or uses AutoIndex which falls back to flat
+- Search latency scales linearly with segment size
+- Memory usage equals raw vector data size (no index overhead, but also no compression)
+
+### 3.2 Why No Index (Yet)
+
+External collection segments are different from normal segments:
+- Normal segments store data in Milvus-managed binlog format with well-defined paths
+- External segments reference parquet files in user-controlled storage
+- The existing index build pipeline (IndexNode) expects to read binlogs, not parquet via manifest
+
+### 3.3 Future Index Support (Planned)
+
+Potential approaches:
+1. **Pre-built index**: Users provide pre-built index files alongside parquet data
+2. **On-load index build**: Build index from materialized data after loading
+3. **IndexNode adaptation**: Extend IndexNode to read external parquet via manifest
+
+---
+
+## 4. Query Execution
+
+### 4.1 Query Flow
+
+```
+Client.Search(collection, vectors, topK, filter)
+  -> Proxy: route to QueryNode shards
+  -> QueryNode: iterate over loaded segments
+
+For each external segment:
+  1. PK Pruning: ExternalSegmentCandidate.MayPkExist()
+     -> deterministic: (virtualPK >> 32) == truncatedSegmentID
+
+  2. Expression Evaluation (filter):
+     -> Access VirtualPKChunkedColumn for PK comparisons
+     -> Access ExternalFieldChunkedColumn for scalar filters
+     -> All data from materialized memory buffers
+
+  3. Vector Search (ANN):
+     -> Brute-force on materialized vector data
+     -> L2/IP/Cosine distance computation
+
+  4. Result Assembly:
+     -> Return virtual PKs, distances, output fields
+     -> Virtual PKs are transparent to users (AutoID=true)
+```
+
+### 4.2 Supported Query Types (Verified by E2E Tests)
+
+| Query Type | Example | Verified |
+|------------|---------|----------|
+| Count aggregation | `count(*)` | Yes |
+| Scalar filter | `id < 100` with output fields | Yes |
+| ANN Search | top-K L2 single vector | Yes |
+| Hybrid Search | Search + scalar filter `id >= 500 && id < 1000` | Yes |
+| Pagination | `offset=10, limit=20` | Yes |
+| Multi-vector Search | Multiple query vectors, top-K each | Yes |
+| Vector output | Query with embedding in output fields | Yes |
+
+### 4.3 Timestamp Handling
+
+External collection segments use **synthetic timestamps** (all zeros):
+
+```cpp
+std::vector<Timestamp> timestamps(num_rows, 0);  // timestamp = 0 for all rows
+```
+
+This means:
+- All rows are visible at any query timestamp (no TTL expiration)
+- Consistency level settings still apply but timestamps are always satisfied
+- External data is treated as "always present"
+
+---
+
+## 5. Virtual Primary Key Design
+
+### 5.1 Injection at Create Time
+
+**File**: `internal/proxy/util.go` (`injectVirtualPKForExternalCollection`)
+
+When creating an external collection, Proxy automatically injects a virtual PK field:
+
+```go
+virtualPKField := &schemapb.FieldSchema{
+    Name:         "__virtual_pk__",
+    DataType:     schemapb.DataType_Int64,
+    IsPrimaryKey: true,
+    AutoID:       true,
+    Description:  "Virtual primary key: (segmentID << 32) | offset",
+}
+schema.Fields = append(schema.Fields, virtualPKField)
+```
+
+### 5.2 Format
+
+```
+Bit layout:  [63:32] truncated_segment_id  |  [31:0] row_offset
+
+GetVirtualPK(segmentID, offset) = (segmentID << 32) | (offset & 0xFFFFFFFF)
+ExtractSegmentID(vpk)           = int64(uint64(vpk) >> 32)
+ExtractOffset(vpk)              = vpk & 0xFFFFFFFF
+```
+
+Constraints:
+- Max rows per segment: 2^32 (~4.29 billion)
+- Segment ID truncated to lower 32 bits (theoretical collision if >2^32 segments)
+- Only Int64 type (not VarChar)
+
+### 5.3 Consistency Across Layers
+
+The same virtual PK logic is implemented in three places:
+
+| Layer | File | Language |
+|-------|------|----------|
+| C++ | `internal/core/src/common/VirtualPK.h` | C++ inline |
+| C++ | `internal/core/src/mmap/VirtualPKChunkedColumn.h` | C++ class |
+| Go | `internal/querynodev2/segments/utils.go` | Go functions |
+| Go | `internal/querynodev2/pkoracle/external_segment_candidate.go` | Go struct |
+
+---
+
+## 6. Thread Safety: Reader Mutex
+
+### Problem
+
+`milvus_storage::api::Reader` is **NOT thread-safe**. Multiple fields (id, value, embedding) of the same segment share one Reader instance. During loading, concurrent calls to `reader_->take()` from different threads cause SIGSEGV.
+
+### Solution
+
+```cpp
+// Shared mutex across all ExternalFieldChunkedColumn instances of the same segment
+auto reader_mutex = std::make_shared<std::mutex>();
+
+// Each column holds a reference to the shared mutex
+ExternalFieldChunkedColumn(..., reader_mutex);
+
+// Reader access is serialized
+void EnsureMaterialized() {
+    std::call_once(materialize_once_, [this]() {
+        std::lock_guard<std::mutex> lock(*reader_mutex_);
+        auto table = reader_->take(all_indices);
+        // ... copy to buffer
+    });
+}
+```
+
+Additionally, **eager materialization** during load ensures that by the time queries arrive, all data is already in memory buffers and no Reader access is needed:
+
+```cpp
+// In LoadExternalCollectionFields:
+for (auto& col : ext_columns) {
+    col->EagerMaterialize();  // materialize during load, not query
+}
+```
+
+---
+
+## 7. Data Flow Summary
+
+```
+                    REFRESH PHASE
+                    =============
+
+    External Source (S3/MinIO)
+    ├── data0.parquet (1000 rows)
+    ├── data1.parquet (1000 rows)
+    └── data2.parquet (500 rows)
+              │
+              ▼
+    ExploreFiles() + GetFileInfo()
+              │
+              ▼
+    Fragments:
+    ├── frag_0: data0.parquet [0, 1000)
+    ├── frag_1: data1.parquet [0, 1000)
+    └── frag_2: data2.parquet [0, 500)
+              │
+              ▼
+    balanceFragmentsToSegments()
+    (greedy bin-packing)
+              │
+              ▼
+    Segment_A: [frag_0, frag_2]  1500 rows
+    Segment_B: [frag_1]          1000 rows
+              │
+              ▼
+    CreateManifestForSegment()
+    ├── external/{coll}/segments/{segA}/manifest_v1
+    └── external/{coll}/segments/{segB}/manifest_v1
+
+
+                    LOAD PHASE
+                    ==========
+
+    QueryNode receives segment load request
+              │
+              ▼
+    LoadExternalCollectionFields()
+              │
+              ▼
+    ┌──────────────────────────────────────────────┐
+    │ For each field in schema:                     │
+    │                                               │
+    │ __virtual_pk__ → VirtualPKChunkedColumn       │
+    │   generates: (segID<<32)|offset               │
+    │                                               │
+    │ id (int64) → ExternalFieldChunkedColumn       │
+    │   reads: parquet column "id" via Reader       │
+    │                                               │
+    │ value (float) → ExternalFieldChunkedColumn    │
+    │   reads: parquet column "value" via Reader    │
+    │                                               │
+    │ embedding (vec) → ExternalFieldChunkedColumn  │
+    │   reads: parquet column "embedding"           │
+    └──────────────────────────────────────────────┘
+              │
+              ▼
+    EagerMaterialize() for all columns
+    (reader_->take([0,1,...,N-1]) with mutex)
+              │
+              ▼
+    All data in memory buffers, Reader no longer needed
+              │
+              ▼
+    Build PK→offset index, init timestamps(=0)
+              │
+              ▼
+    Segment READY for queries
+
+
+                    QUERY PHASE
+                    ===========
+
+    Search(vectors, topK=5, filter="id < 100")
+              │
+              ▼
+    ExternalSegmentCandidate.MayPkExist()
+    (deterministic segment pruning)
+              │
+              ▼
+    Expression filter: access materialized id column
+    → offsets = [0, 1, ..., 99]
+              │
+              ▼
+    Vector search: brute-force on materialized embedding
+    → top-5 nearest neighbors within filtered offsets
+              │
+              ▼
+    Output: virtual PKs + distances + requested fields
+```
+
+---
+
+## 8. File Inventory
+
+### New Files
+
+| File | Language | Purpose |
+|------|----------|---------|
+| `internal/core/src/common/VirtualPK.h` | C++ | Virtual PK utility functions |
+| `internal/core/src/mmap/VirtualPKChunkedColumn.h` | C++ | Virtual PK column implementation |
+| `internal/core/src/mmap/ExternalFieldChunkedColumn.h` | C++ | External field column with lazy materialization |
+| `internal/querynodev2/pkoracle/external_segment_candidate.go` | Go | PK oracle for external segments |
+| `internal/storagev2/packed/explore_ffi.go` | Go | FFI: explore external parquet files |
+| `internal/storagev2/packed/manifest_ffi.go` | Go | FFI: create/read segment manifests |
+| `internal/storagev2/packed/utils.go` | Go | Fragment splitting, segment manifest creation |
+| `internal/datanode/external/external_spec.go` | Go | Parse external collection spec (format) |
+| `internal/datanode/external/task_update.go` | Go | DataNode refresh task execution |
+| `internal/datacoord/external_collection_refresh_meta.go` | Go | Job/Task metadata management |
+| `internal/datacoord/external_collection_refresh_manager.go` | Go | Refresh lifecycle management |
+| `internal/datacoord/external_collection_refresh_checker.go` | Go | Job timeout & GC |
+| `internal/datacoord/external_collection_refresh_inspector.go` | Go | Task scheduling & recovery |
+| `internal/datacoord/task_refresh_external_collection.go` | Go | Refresh task scheduler wrapper |
+| `internal/datacoord/ddl_callbacks_external_collection.go` | Go | WAL callback for refresh |
+
+### Modified Files
+
+| File | Language | Change |
+|------|----------|--------|
+| `internal/core/src/common/Schema.h/.cpp` | C++ | `external_source_`, `external_spec_` fields |
+| `internal/core/src/common/FieldMeta.h/.cpp` | C++ | `external_field_` mapping to parquet column name |
+| `internal/core/src/segcore/ChunkedSegmentSealedImpl.h/.cpp` | C++ | `LoadExternalCollectionFields()`, Reader member |
+| `internal/core/src/segcore/SegmentLoadInfo.h/.cpp` | C++ | External segment load info support |
+| `internal/core/src/segcore/segment_c.h/.cpp` | C++ | New C API for external segment loading |
+| `internal/querynodev2/segments/segment_loader.go` | Go | External segment loading path |
+| `internal/querynodev2/segments/segment.go` | Go | `pkCandidate` field, `SetPKCandidate()` |
+| `internal/querynodev2/segments/segment_interface.go` | Go | `SetPKCandidate()` interface method |
+| `internal/querynodev2/segments/utils.go` | Go | `IsExternalCollection()`, virtual PK utils |
+| `internal/proxy/task.go` | Go | Virtual PK injection at collection creation |
+| `internal/proxy/util.go` | Go | `injectVirtualPKForExternalCollection()` |
+| `internal/proxy/impl.go` | Go | Refresh/Progress/List RPC handlers |
+| `internal/datacoord/services.go` | Go | Refresh/Progress/List RPC handlers |
+| `internal/datacoord/handler.go` | Go | External segment filter in handler |
+
+---
+
+## 9. Key Design Decisions
+
+### 9.1 Eager vs Lazy Materialization
+
+**Chosen: Eager materialization during load**
+
+Rationale:
+- milvus-storage Reader is not thread-safe
+- Multiple query threads would need concurrent Reader access
+- Eager materialization moves all I/O to the load phase
+- Query-time access is pure memory copy (predictable latency)
+
+Trade-off: Higher memory usage (all external data in memory), but consistent query performance.
+
+### 9.2 Virtual PK vs Real PK
+
+**Chosen: Auto-generated virtual PK**
+
+Rationale:
+- External parquet files may not have a unique PK column
+- Avoids reading and deduplicating real PKs from external storage
+- Enables deterministic segment-to-PK mapping (no bloom filter needed)
+- Transparent to users (AutoID=true, users never see/use virtual PKs directly)
+
+Trade-off: Cannot do PK-based point lookups by user-defined ID. Users use scalar filters instead.
+
+### 9.3 No Delta Logs
+
+External collections are **read-only** (no insert/delete/upsert). Therefore:
+- No delta log loading
+- No compaction
+- No growing segments
+- Data changes only through `RefreshExternalCollection`
+
+### 9.4 Segment ID Pre-allocation
+
+**Chosen: DataCoord pre-allocates ID batch, DataNode uses sequentially**
+
+Rationale:
+- Eliminates round-trips between DataNode and DataCoord during segment creation
+- All manifest files written to final paths (no temporary paths or cleanup)
+- Failed manifests remain but are never registered in metadata
+
+### 9.5 Fragment-based Data Assignment
+
+**Chosen: Fragment as atomic unit (file + row range)**
+
+Rationale:
+- Supports large parquet files by splitting into sub-ranges
+- Enables incremental refresh: only new/changed fragments need new segments
+- Greedy bin-packing produces balanced segment sizes
+
+---
+
+## 10. Configuration
+
+| Config Key | Description | Default |
+|------------|-------------|---------|
+| `ExternalCollectionCheckInterval` | Inspector/Checker check interval | 60s |
+| `ExternalCollectionJobTimeout` | Maximum job duration | 3600s |
+| `ExternalCollectionJobRetention` | GC retention for completed jobs | 86400s |
+| `ExternalCollectionTargetRowsPerSegment` | Target rows per segment for balancing | Configured |
+| `ExternalCollectionDropRatioWarn` | Warn if segment deletion ratio exceeds this | 0.9 |

--- a/internal/core/src/common/FieldMeta.h
+++ b/internal/core/src/common/FieldMeta.h
@@ -280,6 +280,21 @@ class FieldMeta {
         return default_value_;
     }
 
+    bool
+    is_external_field() const {
+        return !external_field_mapping_.empty();
+    }
+
+    const std::string&
+    get_external_field() const {
+        return external_field_mapping_;
+    }
+
+    void
+    set_external_field(const std::string& external_field) {
+        external_field_mapping_ = external_field;
+    }
+
     milvus::proto::schema::FieldSchema
     ToProto() const;
 

--- a/internal/core/src/common/Schema.cpp
+++ b/internal/core/src/common/Schema.cpp
@@ -123,6 +123,12 @@ Schema::ParseFrom(const milvus::proto::schema::CollectionSchema& schema_proto) {
     AssertInfo(schema->get_primary_field_id().has_value(),
                "primary key should be specified");
 
+    // Parse external collection properties
+    if (!schema_proto.external_source().empty()) {
+        schema->set_external_source(schema_proto.external_source());
+        schema->set_external_spec(schema_proto.external_spec());
+    }
+
     return schema;
 }
 
@@ -224,6 +230,51 @@ Schema::AbsentFields(Schema& old_schema) const {
     }
 
     return std::make_unique<std::vector<FieldMeta>>(std::move(result));
+}
+
+const ArrowSchemaPtr
+Schema::BuildReaderArrowSchema() const {
+    if (!is_external_collection()) {
+        return ConvertToArrowSchema();
+    }
+    // External collections: build a filtered schema containing only
+    // external fields. System fields (RowID, Timestamp) and virtual PK
+    // don't exist in the parquet files.
+    arrow::FieldVector external_fields;
+    for (const auto& [field_id, meta] : fields_) {
+        if (!meta.is_external_field()) {
+            continue;
+        }
+        int dim = IsVectorDataType(meta.get_data_type()) &&
+                          !IsSparseFloatVectorDataType(meta.get_data_type())
+                      ? meta.get_dim()
+                      : 1;
+        auto arrow_data_type = GetArrowDataType(meta.get_data_type(), dim);
+        auto arrow_field = std::make_shared<arrow::Field>(
+            meta.get_external_field(),
+            arrow_data_type,
+            meta.is_nullable(),
+            arrow::key_value_metadata({milvus_storage::ARROW_FIELD_ID_KEY},
+                                      {std::to_string(meta.get_id().get())}));
+        external_fields.push_back(arrow_field);
+    }
+    return arrow::schema(external_fields);
+}
+
+FieldId
+Schema::ResolveColumnFieldId(const std::string& column_name) const {
+    if (is_external_collection()) {
+        for (const auto& [fid, meta] : fields_) {
+            if (meta.is_external_field() &&
+                meta.get_external_field() == column_name) {
+                return fid;
+            }
+        }
+        ThrowInfo(ErrorCode::DataFormatBroken,
+                  "external column '{}' not found in schema",
+                  column_name);
+    }
+    return FieldId(std::stoll(column_name));
 }
 
 std::pair<bool, bool>

--- a/internal/core/src/common/Schema.h
+++ b/internal/core/src/common/Schema.h
@@ -366,6 +366,31 @@ class Schema {
         return ttl_field_id_opt_;
     }
 
+    bool
+    is_external_collection() const {
+        return !external_source_.empty();
+    }
+
+    const std::string&
+    get_external_source() const {
+        return external_source_;
+    }
+
+    const std::string&
+    get_external_spec() const {
+        return external_spec_;
+    }
+
+    void
+    set_external_source(const std::string& source) {
+        external_source_ = source;
+    }
+
+    void
+    set_external_spec(const std::string& spec) {
+        external_spec_ = spec;
+    }
+
     const ArrowSchemaPtr
     ConvertToArrowSchema() const;
 
@@ -373,6 +398,21 @@ class Schema {
     /// used by Loon FFI / milvus-storage Reader.
     const ArrowSchemaPtr
     ConvertToLoonArrowSchema() const;
+
+    // Build an Arrow schema suitable for reading data from storage.
+    // Normal collections: same as ConvertToArrowSchema().
+    // External collections: filtered to external fields only, using
+    // parquet column names with ARROW_FIELD_ID_KEY metadata for
+    // downstream field ID resolution.
+    const ArrowSchemaPtr
+    BuildReaderArrowSchema() const;
+
+    // Resolve a column group column name to a FieldId.
+    // Normal collections: column name is the numeric field ID string.
+    // External collections: column name is the parquet field name mapped
+    // via external_field metadata.
+    FieldId
+    ResolveColumnFieldId(const std::string& column_name) const;
 
     proto::schema::CollectionSchema
     ToProto() const;
@@ -542,6 +582,12 @@ class Schema {
     std::optional<std::string> warmup_vector_field_ = std::nullopt;
     // Per-field warmup policy (key: "warmup" in field type_params)
     std::unordered_map<FieldId, std::string> warmup_fields_;
+
+    // External collection properties
+    std::string
+        external_source_;  // External data source identifier (e.g., S3 path, table name)
+    std::string
+        external_spec_;  // External data source specification (JSON format)
 };
 
 using SchemaPtr = std::shared_ptr<Schema>;

--- a/internal/core/src/common/VirtualPK.h
+++ b/internal/core/src/common/VirtualPK.h
@@ -1,0 +1,68 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+
+namespace milvus {
+
+// Virtual PK utilities for external collections.
+// Virtual PK format: (segmentID << 32) | offset
+// This allows up to 4 billion (2^32) rows per segment.
+
+// Name of the virtual PK field for external collections
+constexpr const char* VIRTUAL_PK_FIELD_NAME = "__virtual_pk__";
+
+// Generate a virtual primary key from segment ID and row offset.
+// Only the lower 32 bits of segment_id are preserved in the virtual PK.
+// Milvus segment IDs are TSO-allocated 64-bit values that typically exceed
+// 32 bits, so truncation is expected. Uniqueness depends on the lower 32 bits
+// being distinct across concurrently loaded segments of the same collection.
+inline int64_t
+GetVirtualPK(int64_t segment_id, int64_t offset) {
+    return ((segment_id & 0xFFFFFFFF) << 32) | (offset & 0xFFFFFFFF);
+}
+
+// Extract the segment ID from a virtual PK.
+// Returns the lower 32 bits that were originally from the segment ID.
+// Uses unsigned right shift to avoid sign-extension for large segment IDs.
+inline int64_t
+ExtractSegmentIDFromVirtualPK(int64_t virtual_pk) {
+    return static_cast<int64_t>(static_cast<uint64_t>(virtual_pk) >> 32);
+}
+
+// Extract the row offset from a virtual PK.
+inline int64_t
+ExtractOffsetFromVirtualPK(int64_t virtual_pk) {
+    return virtual_pk & 0xFFFFFFFF;
+}
+
+// Check if a virtual PK belongs to the given segment.
+// Note: Only compares the lower 32 bits of segment_id.
+inline bool
+IsVirtualPKFromSegment(int64_t virtual_pk, int64_t segment_id) {
+    return ExtractSegmentIDFromVirtualPK(virtual_pk) ==
+           (segment_id & 0xFFFFFFFF);
+}
+
+// Get the truncated segment ID (lower 32 bits) for comparison with virtual PKs.
+inline int64_t
+GetTruncatedSegmentID(int64_t segment_id) {
+    return segment_id & 0xFFFFFFFF;
+}
+
+}  // namespace milvus

--- a/internal/core/src/common/logging_c.cpp
+++ b/internal/core/src/common/logging_c.cpp
@@ -38,16 +38,14 @@ goZapLogExt(int severity,
 
 // Go export function.
 // will be implemented in github.com/milvus-io/milvus/internal/util/cgo/logging
-// macOS linker requires weak_import to allow unresolved symbols.
-extern "C" void
-goZapLogExt(int severity,
-            const char* file,
-            int file_len,
-            int line,
-            const char* msg,
-            int msg_len) {
+// Use weak attribute so Go's //export goZapLogExt can override this stub.
+extern "C" void __attribute__((weak)) goZapLogExt(int severity,
+                                                  const char* file,
+                                                  int file_len,
+                                                  int line,
+                                                  const char* msg,
+                                                  int msg_len) {
 }
-__attribute__((weak_import));
 
 #else
 

--- a/internal/core/src/mmap/VirtualPKChunkedColumn.h
+++ b/internal/core/src/mmap/VirtualPKChunkedColumn.h
@@ -1,0 +1,289 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+#include "common/EasyAssert.h"
+#include "common/VirtualPK.h"
+#include "mmap/ChunkedColumnInterface.h"
+
+namespace milvus {
+
+// VirtualPKChunkedColumn generates virtual primary keys on-the-fly.
+// Virtual PK format: (truncated_segment_id << 32) | offset
+// This is used for external collections that don't have real PK fields.
+class VirtualPKChunkedColumn : public ChunkedColumnInterface {
+ public:
+    explicit VirtualPKChunkedColumn(int64_t segment_id, int64_t num_rows)
+        : segment_id_(segment_id),
+          truncated_segment_id_(milvus::GetTruncatedSegmentID(segment_id)),
+          num_rows_(num_rows) {
+        num_rows_until_chunk_ = {0, num_rows_};
+    }
+
+    ~VirtualPKChunkedColumn() override = default;
+
+    cachinglayer::PinWrapper<const char*>
+    DataOfChunk(milvus::OpContext* op_ctx, int chunk_id) const override {
+        EnsureMaterialized();
+        return PinWrapper<const char*>(
+            reinterpret_cast<const char*>(materialized_pks_.data()));
+    }
+
+    bool
+    IsValid(milvus::OpContext* op_ctx, size_t offset) const override {
+        return offset < num_rows_;
+    }
+
+    void
+    BulkIsValid(milvus::OpContext* ctx,
+                std::function<void(bool, size_t)> fn,
+                const int64_t* offsets,
+                int64_t count) const override {
+        if (offsets == nullptr) {
+            for (int64_t i = 0; i < num_rows_; i++) {
+                fn(true, i);
+            }
+        } else {
+            for (int64_t i = 0; i < count; i++) {
+                fn(true, i);
+            }
+        }
+    }
+
+    bool
+    IsNullable() const override {
+        return false;
+    }
+
+    size_t
+    NumRows() const override {
+        return num_rows_;
+    }
+
+    int64_t
+    num_chunks() const override {
+        return 1;
+    }
+
+    size_t
+    DataByteSize() const override {
+        return num_rows_ * sizeof(int64_t);
+    }
+
+    int64_t
+    chunk_row_nums(int64_t chunk_id) const override {
+        AssertInfo(chunk_id == 0, "VirtualPKChunkedColumn has only 1 chunk");
+        return num_rows_;
+    }
+
+    PinWrapper<SpanBase>
+    Span(milvus::OpContext* op_ctx, int64_t chunk_id) const override {
+        EnsureMaterialized();
+        return PinWrapper<SpanBase>(
+            SpanBase(materialized_pks_.data(), num_rows_, sizeof(int64_t)));
+    }
+
+    void
+    PrefetchChunks(milvus::OpContext* op_ctx,
+                   const std::vector<int64_t>& chunk_ids) const override {
+        // No-op - no data to prefetch
+    }
+
+    PinWrapper<std::pair<std::vector<std::string_view>, FixedVector<bool>>>
+    StringViews(milvus::OpContext* op_ctx,
+                int64_t chunk_id,
+                std::optional<std::pair<int64_t, int64_t>> offset_len =
+                    std::nullopt) const override {
+        ThrowInfo(ErrorCode::Unsupported,
+                  "StringViews not supported for VirtualPKChunkedColumn");
+    }
+
+    PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>
+    ArrayViews(
+        milvus::OpContext* op_ctx,
+        int64_t chunk_id,
+        std::optional<std::pair<int64_t, int64_t>> offset_len) const override {
+        ThrowInfo(ErrorCode::Unsupported,
+                  "ArrayViews not supported for VirtualPKChunkedColumn");
+    }
+
+    PinWrapper<std::pair<std::vector<VectorArrayView>, FixedVector<bool>>>
+    VectorArrayViews(
+        milvus::OpContext* op_ctx,
+        int64_t chunk_id,
+        std::optional<std::pair<int64_t, int64_t>> offset_len) const override {
+        ThrowInfo(ErrorCode::Unsupported,
+                  "VectorArrayViews not supported for VirtualPKChunkedColumn");
+    }
+
+    PinWrapper<const size_t*>
+    VectorArrayOffsets(milvus::OpContext* op_ctx,
+                       int64_t chunk_id) const override {
+        ThrowInfo(
+            ErrorCode::Unsupported,
+            "VectorArrayOffsets not supported for VirtualPKChunkedColumn");
+    }
+
+    PinWrapper<std::pair<std::vector<std::string_view>, FixedVector<bool>>>
+    StringViewsByOffsets(milvus::OpContext* op_ctx,
+                         int64_t chunk_id,
+                         const FixedVector<int32_t>& offsets) const override {
+        ThrowInfo(
+            ErrorCode::Unsupported,
+            "StringViewsByOffsets not supported for VirtualPKChunkedColumn");
+    }
+
+    PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>
+    ArrayViewsByOffsets(milvus::OpContext* op_ctx,
+                        int64_t chunk_id,
+                        const FixedVector<int32_t>& offsets) const override {
+        ThrowInfo(
+            ErrorCode::Unsupported,
+            "ArrayViewsByOffsets not supported for VirtualPKChunkedColumn");
+    }
+
+    std::pair<size_t, size_t>
+    GetChunkIDByOffset(int64_t offset) const override {
+        AssertInfo(offset >= 0 && offset < num_rows_,
+                   "offset {} is out of range, num_rows: {}",
+                   offset,
+                   num_rows_);
+        return {0, static_cast<size_t>(offset)};
+    }
+
+    std::pair<std::vector<milvus::cachinglayer::cid_t>, std::vector<int64_t>>
+    GetChunkIDsByOffsets(const int64_t* offsets, int64_t count) const override {
+        std::vector<milvus::cachinglayer::cid_t> cids(count, 0);
+        std::vector<int64_t> offsets_in_chunk(offsets, offsets + count);
+        return std::make_pair(std::move(cids), std::move(offsets_in_chunk));
+    }
+
+    PinWrapper<Chunk*>
+    GetChunk(milvus::OpContext* op_ctx, int64_t chunk_id) const override {
+        ThrowInfo(ErrorCode::Unsupported,
+                  "GetChunk not supported for VirtualPKChunkedColumn");
+    }
+
+    std::vector<PinWrapper<Chunk*>>
+    GetAllChunks(milvus::OpContext* op_ctx) const override {
+        ThrowInfo(ErrorCode::Unsupported,
+                  "GetAllChunks not supported for VirtualPKChunkedColumn");
+    }
+
+    int64_t
+    GetNumRowsUntilChunk(int64_t chunk_id) const override {
+        return num_rows_until_chunk_[chunk_id];
+    }
+
+    const std::vector<int64_t>&
+    GetNumRowsUntilChunk() const override {
+        return num_rows_until_chunk_;
+    }
+
+    const std::vector<int64_t>&
+    GetNumValidRowsUntilChunk() const override {
+        // Virtual PK is never nullable, so valid rows == total rows
+        return num_rows_until_chunk_;
+    }
+
+    void
+    BulkValueAt(milvus::OpContext* op_ctx,
+                std::function<void(const char*, size_t)> fn,
+                const int64_t* offsets,
+                int64_t count) override {
+        // Pre-compute all virtual PKs to ensure pointers remain valid
+        std::vector<int64_t> virtual_pks(count);
+        for (int64_t i = 0; i < count; i++) {
+            virtual_pks[i] =
+                milvus::GetVirtualPK(truncated_segment_id_, offsets[i]);
+        }
+        for (int64_t i = 0; i < count; i++) {
+            fn(reinterpret_cast<const char*>(&virtual_pks[i]), i);
+        }
+    }
+
+    void
+    BulkPrimitiveValueAt(milvus::OpContext* op_ctx,
+                         void* dst,
+                         const int64_t* offsets,
+                         int64_t count,
+                         bool small_int_raw_type = false) override {
+        auto typed_dst = static_cast<int64_t*>(dst);
+        for (int64_t i = 0; i < count; i++) {
+            typed_dst[i] =
+                milvus::GetVirtualPK(truncated_segment_id_, offsets[i]);
+        }
+    }
+
+    void
+    BulkVectorValueAt(milvus::OpContext* op_ctx,
+                      void* dst,
+                      const int64_t* offsets,
+                      int64_t element_sizeof,
+                      int64_t count) override {
+        ThrowInfo(ErrorCode::Unsupported,
+                  "BulkVectorValueAt not supported for VirtualPKChunkedColumn");
+    }
+
+    // Get a virtual PK at a specific offset
+    int64_t
+    GetVirtualPKAt(int64_t offset) const {
+        AssertInfo(offset >= 0 && offset < num_rows_,
+                   "offset {} is out of range, num_rows: {}",
+                   offset,
+                   num_rows_);
+        return milvus::GetVirtualPK(truncated_segment_id_, offset);
+    }
+
+    // Get the segment ID used for virtual PK generation
+    int64_t
+    GetSegmentID() const {
+        return segment_id_;
+    }
+
+    // Get the truncated segment ID (lower 32 bits)
+    int64_t
+    GetTruncatedSegmentID() const {
+        return truncated_segment_id_;
+    }
+
+ private:
+    void
+    EnsureMaterialized() const {
+        std::call_once(materialize_once_, [this]() {
+            materialized_pks_.resize(num_rows_);
+            for (int64_t i = 0; i < num_rows_; i++) {
+                materialized_pks_[i] =
+                    milvus::GetVirtualPK(truncated_segment_id_, i);
+            }
+        });
+    }
+
+    int64_t segment_id_;
+    int64_t truncated_segment_id_;
+    int64_t num_rows_;
+    std::vector<int64_t> num_rows_until_chunk_;
+    mutable std::once_flag materialize_once_;
+    mutable std::vector<int64_t> materialized_pks_;
+};
+
+}  // namespace milvus

--- a/internal/core/src/mmap/VirtualPKChunkedColumn.h
+++ b/internal/core/src/mmap/VirtualPKChunkedColumn.h
@@ -35,6 +35,7 @@ class VirtualPKChunkedColumn : public ChunkedColumnInterface {
     explicit VirtualPKChunkedColumn(int64_t segment_id, int64_t num_rows)
         : segment_id_(segment_id),
           truncated_segment_id_(milvus::GetTruncatedSegmentID(segment_id)),
+          shifted_segment_id_(truncated_segment_id_ << 32),
           num_rows_(num_rows) {
         num_rows_until_chunk_ = {0, num_rows_};
     }
@@ -213,8 +214,7 @@ class VirtualPKChunkedColumn : public ChunkedColumnInterface {
         // Pre-compute all virtual PKs to ensure pointers remain valid
         std::vector<int64_t> virtual_pks(count);
         for (int64_t i = 0; i < count; i++) {
-            virtual_pks[i] =
-                milvus::GetVirtualPK(truncated_segment_id_, offsets[i]);
+            virtual_pks[i] = ComputeVirtualPK(offsets[i]);
         }
         for (int64_t i = 0; i < count; i++) {
             fn(reinterpret_cast<const char*>(&virtual_pks[i]), i);
@@ -229,8 +229,7 @@ class VirtualPKChunkedColumn : public ChunkedColumnInterface {
                          bool small_int_raw_type = false) override {
         auto typed_dst = static_cast<int64_t*>(dst);
         for (int64_t i = 0; i < count; i++) {
-            typed_dst[i] =
-                milvus::GetVirtualPK(truncated_segment_id_, offsets[i]);
+            typed_dst[i] = ComputeVirtualPK(offsets[i]);
         }
     }
 
@@ -251,7 +250,7 @@ class VirtualPKChunkedColumn : public ChunkedColumnInterface {
                    "offset {} is out of range, num_rows: {}",
                    offset,
                    num_rows_);
-        return milvus::GetVirtualPK(truncated_segment_id_, offset);
+        return ComputeVirtualPK(offset);
     }
 
     // Get the segment ID used for virtual PK generation
@@ -267,19 +266,26 @@ class VirtualPKChunkedColumn : public ChunkedColumnInterface {
     }
 
  private:
+    // Compute virtual PK from an offset using the pre-shifted segment ID.
+    // Centralizes the inlined formula so all call sites stay consistent.
+    inline int64_t
+    ComputeVirtualPK(int64_t offset) const {
+        return shifted_segment_id_ | (offset & 0xFFFFFFFF);
+    }
+
     void
     EnsureMaterialized() const {
         std::call_once(materialize_once_, [this]() {
             materialized_pks_.resize(num_rows_);
             for (int64_t i = 0; i < num_rows_; i++) {
-                materialized_pks_[i] =
-                    milvus::GetVirtualPK(truncated_segment_id_, i);
+                materialized_pks_[i] = ComputeVirtualPK(i);
             }
         });
     }
 
     int64_t segment_id_;
     int64_t truncated_segment_id_;
+    int64_t shifted_segment_id_;  // truncated_segment_id_ << 32, pre-computed
     int64_t num_rows_;
     std::vector<int64_t> num_rows_until_chunk_;
     mutable std::once_flag materialize_once_;

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -89,6 +89,7 @@
 #include "knowhere/sparse_utils.h"
 #include "knowhere/version.h"
 #include "log/Log.h"
+#include "milvus-storage/common/constants.h"
 #include "milvus-storage/common/metadata.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/packed/chunk_manager.h"
@@ -97,10 +98,11 @@
 #include "mmap/ChunkedColumn.h"
 #include "mmap/ChunkedColumnGroup.h"
 #include "mmap/ChunkedColumnInterface.h"
+#include "mmap/VirtualPKChunkedColumn.h"
 #include "mmap/Types.h"
+#include "common/VirtualPK.h"
 #include "monitor/Monitor.h"
 #include "monitor/scope_metric.h"
-#include "nlohmann/json.hpp"
 #include "parquet/metadata.h"
 #include "pb/index_cgo_msg.pb.h"
 #include "pb/schema.pb.h"
@@ -336,6 +338,113 @@ ChunkedSegmentSealedImpl::LoadFieldData(const LoadFieldDataInfo& load_info,
             load_field_data_internal(load_info, op_ctx, is_replace);
             break;
     }
+}
+
+void
+ChunkedSegmentSealedImpl::LoadColumnGroups(const std::string& manifest_path) {
+    LOG_INFO(
+        "Loading segment {} field data with manifest {}", id_, manifest_path);
+    auto properties = milvus::storage::LoonFFIPropertiesSingleton::GetInstance()
+                          .GetProperties();
+    auto column_groups = segment_load_info_.GetColumnGroups();
+
+    auto arrow_schema = schema_->BuildReaderArrowSchema();
+    reader_ = milvus_storage::api::Reader::create(
+        column_groups, arrow_schema, nullptr, *properties);
+
+    // Pre-resolve field IDs for each column group, then reuse the
+    // standard LoadColumnGroup overload.
+    std::vector<std::pair<int, std::vector<FieldId>>> cg_field_ids;
+    cg_field_ids.reserve(column_groups->size());
+    for (size_t i = 0; i < column_groups->size(); ++i) {
+        auto cg = column_groups->at(i);
+        std::vector<FieldId> field_ids;
+        field_ids.reserve(cg->columns.size());
+        for (auto& column : cg->columns) {
+            field_ids.emplace_back(schema_->ResolveColumnFieldId(column));
+        }
+        cg_field_ids.emplace_back(static_cast<int>(i), std::move(field_ids));
+    }
+
+    auto& pool = ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::LOW);
+    std::vector<std::future<void>> load_group_futures;
+    for (const auto& pair : cg_field_ids) {
+        auto cg_index = pair.first;
+        const auto& field_ids = pair.second;
+        auto future =
+            pool.Submit([this, column_groups, properties, cg_index, field_ids] {
+                LoadColumnGroup(column_groups,
+                                properties,
+                                cg_index,
+                                field_ids,
+                                /*eager_load=*/false,
+                                /*op_ctx=*/nullptr);
+            });
+        load_group_futures.emplace_back(std::move(future));
+    }
+
+    std::vector<std::exception_ptr> load_exceptions;
+    for (auto& future : load_group_futures) {
+        try {
+            future.get();
+        } catch (...) {
+            load_exceptions.push_back(std::current_exception());
+        }
+    }
+
+    // If any exceptions occurred during index loading, handle them
+    if (!load_exceptions.empty()) {
+        LOG_ERROR("Failed to load {} out of {} indexes for segment {}",
+                  load_exceptions.size(),
+                  load_group_futures.size(),
+                  id_);
+
+        // Rethrow the first exception
+        std::rethrow_exception(load_exceptions[0]);
+    }
+
+    if (schema_->is_external_collection()) {
+        SynthesizeExternalSystemFields();
+    }
+}
+
+void
+ChunkedSegmentSealedImpl::SynthesizeExternalSystemFields() {
+    int64_t num_rows = segment_load_info_.GetNumOfRows();
+    if (num_rows == 0) {
+        std::unique_lock lck(mutex_);
+        update_row_count(0);
+        system_ready_count_++;
+        return;
+    }
+
+    // 1. VirtualPKChunkedColumn for the synthetic primary key
+    auto pk_field_id = schema_->get_primary_field_id().value();
+    auto virtual_pk = std::make_shared<VirtualPKChunkedColumn>(id_, num_rows);
+    fields_.wlock()->emplace(pk_field_id, virtual_pk);
+    set_bit(field_data_ready_bitset_, pk_field_id, true);
+
+    // 2. PK→offset index for filter expressions
+    insert_record_.insert_pks(DataType::INT64, virtual_pk.get());
+    insert_record_.seal_pks();
+
+    // 3. Synthetic timestamps (all 0 — rows always visible)
+    std::vector<Timestamp> timestamps(num_rows, 0);
+    TimestampIndex index;
+    auto min_slice_length = num_rows < 4096 ? 1 : 4096;
+    auto meta =
+        GenerateFakeSlices(timestamps.data(), num_rows, min_slice_length);
+    index.set_length_meta(std::move(meta));
+    index.build_with(timestamps.data(), num_rows);
+    insert_record_.init_timestamps_from_owned(std::move(timestamps),
+                                              std::move(index));
+
+    // 4. Row count + readiness
+    {
+        std::unique_lock lck(mutex_);
+        update_row_count(num_rows);
+    }
+    system_ready_count_++;
 }
 
 std::optional<ChunkedSegmentSealedImpl::ParquetStatistics>
@@ -2633,9 +2742,12 @@ void
 ChunkedSegmentSealedImpl::mask_with_timestamps(BitsetTypeView& bitset_chunk,
                                                Timestamp timestamp,
                                                Timestamp collection_ttl) const {
+    // External collections have no timestamps; all data is always visible
+    if (schema_->is_external_collection()) {
+        return;
+    }
     auto& ts = insert_record_.timestamps_;
     auto total_size = static_cast<int64_t>(ts.size());
-
     if (collection_ttl > 0) {
         auto range =
             insert_record_.timestamp_index_.get_active_range(collection_ttl);
@@ -3103,53 +3215,58 @@ ChunkedSegmentSealedImpl::ApplyLoadDiff(SegmentLoadInfo& segment_load_info,
     // always have a data source available during the transition.
 
     // load column groups
-    bool has_cg_changes = !diff.column_groups_to_load.empty() ||
-                          !diff.column_groups_to_replace.empty() ||
-                          !diff.column_groups_to_lazyload.empty() ||
-                          !diff.column_groups_to_lazyreplace.empty();
-    if (has_cg_changes) {
-        auto properties =
-            milvus::storage::LoonFFIPropertiesSingleton::GetInstance()
-                .GetProperties();
-        auto column_groups = segment_load_info.GetColumnGroups();
-        auto arrow_schema = schema_->ConvertToLoonArrowSchema();
-        auto needed_columns = std::make_shared<std::vector<std::string>>();
-        for (const auto& field_id : schema_->get_field_ids()) {
-            needed_columns->push_back(std::to_string(field_id.get()));
-        }
-        reader_ = milvus_storage::api::Reader::create(
-            column_groups, arrow_schema, needed_columns, *properties);
-        // New column group fields
-        if (!diff.column_groups_to_load.empty()) {
-            LoadColumnGroups(column_groups,
-                             properties,
-                             diff.column_groups_to_load,
-                             true,
-                             op_ctx);
-        }
-        if (!diff.column_groups_to_lazyload.empty()) {
-            LoadColumnGroups(column_groups,
-                             properties,
-                             diff.column_groups_to_lazyload,
-                             false,
-                             op_ctx);
-        }
-        // Replace column group fields
-        if (!diff.column_groups_to_replace.empty()) {
-            LoadColumnGroups(column_groups,
-                             properties,
-                             diff.column_groups_to_replace,
-                             true,
-                             op_ctx,
-                             true);
-        }
-        if (!diff.column_groups_to_lazyreplace.empty()) {
-            LoadColumnGroups(column_groups,
-                             properties,
-                             diff.column_groups_to_lazyreplace,
-                             false,
-                             op_ctx,
-                             true);
+    if (diff.load_external_manifest) {
+        // External collections: load via manifest path
+        LoadColumnGroups(segment_load_info.GetManifestPath());
+    } else {
+        bool has_cg_changes = !diff.column_groups_to_load.empty() ||
+                              !diff.column_groups_to_replace.empty() ||
+                              !diff.column_groups_to_lazyload.empty() ||
+                              !diff.column_groups_to_lazyreplace.empty();
+        if (has_cg_changes) {
+            auto properties =
+                milvus::storage::LoonFFIPropertiesSingleton::GetInstance()
+                    .GetProperties();
+            auto column_groups = segment_load_info.GetColumnGroups();
+            auto arrow_schema = schema_->ConvertToLoonArrowSchema();
+            auto needed_columns = std::make_shared<std::vector<std::string>>();
+            for (const auto& field_id : schema_->get_field_ids()) {
+                needed_columns->push_back(std::to_string(field_id.get()));
+            }
+            reader_ = milvus_storage::api::Reader::create(
+                column_groups, arrow_schema, needed_columns, *properties);
+            // New column group fields
+            if (!diff.column_groups_to_load.empty()) {
+                LoadColumnGroups(column_groups,
+                                 properties,
+                                 diff.column_groups_to_load,
+                                 true,
+                                 op_ctx);
+            }
+            if (!diff.column_groups_to_lazyload.empty()) {
+                LoadColumnGroups(column_groups,
+                                 properties,
+                                 diff.column_groups_to_lazyload,
+                                 false,
+                                 op_ctx);
+            }
+            // Replace column group fields
+            if (!diff.column_groups_to_replace.empty()) {
+                LoadColumnGroups(column_groups,
+                                 properties,
+                                 diff.column_groups_to_replace,
+                                 true,
+                                 op_ctx,
+                                 true);
+            }
+            if (!diff.column_groups_to_lazyreplace.empty()) {
+                LoadColumnGroups(column_groups,
+                                 properties,
+                                 diff.column_groups_to_lazyreplace,
+                                 false,
+                                 op_ctx,
+                                 true);
+            }
         }
     }
 
@@ -3436,7 +3553,12 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
     auto needed_columns = std::make_shared<std::vector<std::string>>();
     needed_columns->reserve(milvus_field_ids.size());
     for (const auto& fid : milvus_field_ids) {
-        needed_columns->push_back(std::to_string(fid.get()));
+        const auto& field_meta = (*schema_)[fid];
+        if (field_meta.is_external_field()) {
+            needed_columns->push_back(field_meta.get_external_field());
+        } else {
+            needed_columns->push_back(std::to_string(fid.get()));
+        }
     }
     auto chunk_reader_result = reader_->get_chunk_reader(index, needed_columns);
     AssertInfo(chunk_reader_result.ok(),

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -1076,6 +1076,10 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         milvus::OpContext* op_ctx = nullptr,
         bool is_replace = false);
 
+    // Load column groups from a manifest file path (for external collections)
+    void
+    LoadColumnGroups(const std::string& manifest_path);
+
     /**
      * @brief Load a single column group at the specified index
      *
@@ -1098,6 +1102,12 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         bool eager_load,
         milvus::OpContext* op_ctx = nullptr,
         bool is_replace = false);
+
+    // Synthesize system fields (virtual PK, timestamps, PK index, row count)
+    // for external collections. External collections don't have real PK or
+    // timestamp fields in their parquet data, so these must be generated.
+    void
+    SynthesizeExternalSystemFields();
 
     /**
      * @brief Reloads columns from the specified field IDs

--- a/internal/core/src/segcore/SegmentLoadInfo.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfo.cpp
@@ -651,17 +651,30 @@ SegmentLoadInfo::GetLoadDiff() {
     // - manifest -> manifest
     // Cross-category changes are not supported.
     if (HasManifestPath()) {
-        // set mock path for null check
-        empty_info.info_.set_manifest_path("mocked manifest path");
-        empty_info.column_groups_ =
-            std::make_shared<milvus_storage::api::ColumnGroups>();
-        empty_info.ComputeDiffColumnGroups(diff, *this);
+        if (schema_->is_external_collection()) {
+            // External collections use parquet field names (e.g., "id",
+            // "value") as column group column names, not numeric field IDs.
+            // ComputeDiffColumnGroups calls std::stoll which would crash.
+            // Flag for direct manifest loading in ApplyLoadDiff.
+            diff.load_external_manifest = true;
+        } else {
+            // set mock path for null check
+            empty_info.info_.set_manifest_path("mocked manifest path");
+            empty_info.column_groups_ =
+                std::make_shared<milvus_storage::api::ColumnGroups>();
+            empty_info.ComputeDiffColumnGroups(diff, *this);
+        }
     } else {
         empty_info.ComputeDiffBinlogs(diff, *this);
     }
 
     // Compute fields that need default value filling (schema evolution)
-    empty_info.ComputeDiffDefaultFields(diff, *this);
+    // Skip for external collections: collect_data_fields() calls std::stoll
+    // on column group names, and external collections don't need default fills
+    // (all fields are either external or virtual PK).
+    if (!schema_->is_external_collection()) {
+        empty_info.ComputeDiffDefaultFields(diff, *this);
+    }
 
     return diff;
 }

--- a/internal/core/src/segcore/SegmentLoadInfo.h
+++ b/internal/core/src/segcore/SegmentLoadInfo.h
@@ -101,6 +101,11 @@ struct LoadDiff {
     // Text fields that need text indexes created from raw data
     std::unordered_set<FieldId> text_indexes_to_create;
 
+    // External collections with manifest should bypass ComputeDiffColumnGroups
+    // (their column names are parquet field names, not numeric field IDs)
+    // and use LoadColumnGroups(manifest_path) directly in ApplyLoadDiff
+    bool load_external_manifest = false;
+
     // Whether manifest path has changed (only when both use manifest mode)
     bool manifest_updated = false;
 
@@ -118,7 +123,8 @@ struct LoadDiff {
                !fields_to_reload.empty() || !indexes_to_drop.empty() ||
                !field_data_to_drop.empty() || !fields_to_fill_default.empty() ||
                !text_indexes_to_load.empty() ||
-               !text_indexes_to_create.empty() || manifest_updated;
+               !text_indexes_to_create.empty() || manifest_updated ||
+               load_external_manifest;
     }
 
     [[nodiscard]] bool
@@ -315,6 +321,11 @@ struct LoadDiff {
         oss << "manifest_updated=" << (manifest_updated ? "true" : "false");
         if (manifest_updated) {
             oss << ", new_manifest_path=" << new_manifest_path;
+        }
+
+        // load_external_manifest
+        if (load_external_manifest) {
+            oss << ", load_external_manifest=true";
         }
 
         oss << "}";

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
@@ -42,6 +42,7 @@
 #include "fmt/core.h"
 #include "glog/logging.h"
 #include "log/Log.h"
+#include "milvus-storage/common/constants.h"
 #include "milvus-storage/reader.h"
 #include "segcore/Utils.h"
 #include "segcore/memory_planner.h"
@@ -50,6 +51,87 @@
 #include "storage/Util.h"
 
 namespace milvus::segcore::storagev2translator {
+
+// Convert LIST or FIXED_SIZE_LIST arrays to FixedSizeBinary.
+// External parquet files store vectors in list format; Milvus expects
+// FixedSizeBinary (raw bytes). Supports all fixed-width vector types
+// (FLOAT, FLOAT16, BFLOAT16, BINARY, INT8). Returns the input unchanged
+// if already FixedSizeBinary.
+static arrow::ArrayVector
+NormalizeVectorArraysToFixedSizeBinary(const arrow::ArrayVector& arrays,
+                                       const milvus::FieldMeta& field_meta) {
+    int dim = field_meta.get_dim();
+    int byte_width = GetDataTypeSize(field_meta.get_data_type(), dim);
+    auto fsb_type = arrow::fixed_size_binary(byte_width);
+
+    arrow::ArrayVector result;
+    result.reserve(arrays.size());
+
+    for (const auto& array : arrays) {
+        auto type_id = array->type_id();
+        if (type_id == arrow::Type::FIXED_SIZE_BINARY) {
+            result.push_back(array);
+            continue;
+        }
+
+        int64_t num_rows = array->length();
+        AssertInfo(array->null_count() == 0,
+                   "Null values in vector columns are not supported for "
+                   "external collections, field: {}",
+                   field_meta.get_name().get());
+        auto buffer_result = arrow::AllocateBuffer(num_rows * byte_width);
+        AssertInfo(buffer_result.ok(),
+                   "Failed to allocate buffer for vector normalization");
+        auto buffer = std::move(*buffer_result);
+        auto dst = buffer->mutable_data();
+
+        if (type_id == arrow::Type::LIST) {
+            auto list_array = std::static_pointer_cast<arrow::ListArray>(array);
+            auto values = list_array->values();
+            int elem_bit_width = values->type()->bit_width();
+            AssertInfo(elem_bit_width > 0 && elem_bit_width % 8 == 0,
+                       "Vector list element must be fixed-width byte-aligned "
+                       "type, got bit_width={}",
+                       elem_bit_width);
+            int elem_byte_size = elem_bit_width / 8;
+            auto raw = reinterpret_cast<const uint8_t*>(
+                values->data()->buffers[1]->data());
+            for (int64_t i = 0; i < num_rows; i++) {
+                auto offset = list_array->value_offset(i);
+                memcpy(dst + i * byte_width,
+                       raw + offset * elem_byte_size,
+                       byte_width);
+            }
+        } else if (type_id == arrow::Type::FIXED_SIZE_LIST) {
+            auto fsl_array =
+                std::static_pointer_cast<arrow::FixedSizeListArray>(array);
+            auto values = fsl_array->values();
+            int elem_bit_width = values->type()->bit_width();
+            AssertInfo(elem_bit_width > 0 && elem_bit_width % 8 == 0,
+                       "Vector list element must be fixed-width byte-aligned "
+                       "type, got bit_width={}",
+                       elem_bit_width);
+            int elem_byte_size = elem_bit_width / 8;
+            auto raw = reinterpret_cast<const uint8_t*>(
+                values->data()->buffers[1]->data());
+            for (int64_t i = 0; i < num_rows; i++) {
+                auto offset = fsl_array->value_offset(i);
+                memcpy(dst + i * byte_width,
+                       raw + offset * elem_byte_size,
+                       byte_width);
+            }
+        } else {
+            ThrowInfo(ErrorCode::Unsupported,
+                      "Unsupported arrow type for vector normalization: {}",
+                      array->type()->ToString());
+        }
+
+        auto fsb_array = std::make_shared<arrow::FixedSizeBinaryArray>(
+            fsb_type, num_rows, std::move(buffer));
+        result.push_back(std::move(fsb_array));
+    }
+    return result;
+}
 
 ManifestGroupTranslator::ManifestGroupTranslator(
     int64_t segment_id,
@@ -106,13 +188,16 @@ ManifestGroupTranslator::ManifestGroupTranslator(
       load_priority_(load_priority) {
     auto chunk_size_result = chunk_reader_->get_chunk_size();
     if (!chunk_size_result.ok()) {
-        throw std::runtime_error("get row group size failed");
+        throw std::runtime_error(
+            fmt::format("get row group size failed: {}",
+                        chunk_size_result.status().ToString()));
     }
     const auto& row_group_sizes = chunk_size_result.ValueOrDie();
 
     auto rows_result = chunk_reader_->get_chunk_rows();
     if (!rows_result.ok()) {
-        throw std::runtime_error("get row group rows failed");
+        throw std::runtime_error(fmt::format("get row group rows failed: {}",
+                                             rows_result.status().ToString()));
     }
     const auto& row_group_rows = rows_result.ValueOrDie();
 
@@ -304,11 +389,32 @@ ManifestGroupTranslator::load_group_chunk(
     std::vector<arrow::ArrayVector> array_vecs;
     array_vecs.reserve(schema->num_fields());
 
-    // Iterate through fields to get field_id and create chunk
+    // Iterate through fields to get field_id and create chunk.
+    // Normal collections store field IDs as column names (numeric strings).
+    // External collections use original column names, so we fall back to
+    // matching against external field names when stoll fails.
     for (int i = 0; i < schema->num_fields(); ++i) {
-        // column name here is field id (ChunkReader stores field IDs as column names)
         auto column_name = schema->field(i)->name();
-        auto field_id = std::stoll(column_name);
+        int64_t field_id = -1;
+        try {
+            field_id = std::stoll(column_name);
+        } catch (const std::exception&) {
+            // External collection fallback: resolve by column name
+            for (const auto& [fid, meta] : field_metas_) {
+                if (meta.is_external_field() &&
+                    meta.get_external_field() == column_name) {
+                    field_id = fid.get();
+                    break;
+                }
+            }
+            AssertInfo(
+                field_id >= 0,
+                fmt::format(
+                    "[StorageV2] translator {} field {} not a numeric field ID "
+                    "and not found as external field",
+                    key_,
+                    column_name));
+        }
 
         auto fid = milvus::FieldId(field_id);
         if (fid == RowFieldID) {
@@ -335,6 +441,20 @@ ManifestGroupTranslator::load_group_chunk(
         field_ids.push_back(fid);
         field_metas.push_back(field_meta);
         array_vecs.push_back(std::move(merged_array_vec));
+    }
+
+    // Normalize vector arrays from LIST/FIXED_SIZE_LIST to FixedSizeBinary.
+    // External parquet files use list-of-float format; Milvus expects
+    // FixedSizeBinary. No-op for normal collections (already FixedSizeBinary).
+    for (size_t idx = 0; idx < field_ids.size(); ++idx) {
+        if (IsVectorDataType(field_metas[idx].get_data_type()) &&
+            !IsSparseFloatVectorDataType(field_metas[idx].get_data_type()) &&
+            !IsVectorArrayDataType(field_metas[idx].get_data_type()) &&
+            !array_vecs[idx].empty() &&
+            array_vecs[idx][0]->type_id() != arrow::Type::FIXED_SIZE_BINARY) {
+            array_vecs[idx] = NormalizeVectorArraysToFixedSizeBinary(
+                array_vecs[idx], field_metas[idx]);
+        }
     }
 
     std::unordered_map<FieldId, std::shared_ptr<Chunk>> chunks;

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
@@ -444,10 +444,12 @@ ManifestGroupTranslator::load_group_chunk(
     }
 
     // Normalize vector arrays from LIST/FIXED_SIZE_LIST to FixedSizeBinary.
-    // External parquet files use list-of-float format; Milvus expects
-    // FixedSizeBinary. No-op for normal collections (already FixedSizeBinary).
+    // External parquet files store vectors as list-of-float; Milvus expects
+    // FixedSizeBinary. Only run for external fields — normal collections
+    // already store vectors as FIXED_SIZE_BINARY (or BINARY for nullable).
     for (size_t idx = 0; idx < field_ids.size(); ++idx) {
-        if (IsVectorDataType(field_metas[idx].get_data_type()) &&
+        if (field_metas[idx].is_external_field() &&
+            IsVectorDataType(field_metas[idx].get_data_type()) &&
             !IsSparseFloatVectorDataType(field_metas[idx].get_data_type()) &&
             !IsVectorArrayDataType(field_metas[idx].get_data_type()) &&
             !array_vecs[idx].empty() &&

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -1509,13 +1509,22 @@ GetFieldDatasFromManifest(
     auto column_groups = std::make_shared<milvus_storage::api::ColumnGroups>(
         loon_manifest->columnGroups());
 
+    // Determine the column name to use: external fields use their external name,
+    // internal fields use the numeric field ID string.
+    std::string column_name;
+    const auto& ext_field = field_meta.field_schema.external_field();
+    if (!ext_field.empty()) {
+        column_name = ext_field;
+    } else {
+        column_name = std::to_string(field_meta.field_id);
+    }
+
     // TODO remove manual check after loon support read null for non-exists field
     bool field_exists = false;
-    const auto field_id_to_find = std::to_string(field_meta.field_id);
     for (size_t i = 0; i < column_groups->size() && !field_exists; i++) {
         auto column_group = column_groups->at(i);
         for (const auto& column : column_group->columns) {
-            if (column == field_id_to_find) {
+            if (column == column_name) {
                 field_exists = true;
                 break;
             }
@@ -1525,8 +1534,7 @@ GetFieldDatasFromManifest(
         return {};
     }
 
-    std::string field_id_str = std::to_string(field_meta.field_id);
-    std::vector<std::string> needed_columns = {field_id_str};
+    std::vector<std::string> needed_columns = {column_name};
 
     // Create arrow schema from field meta
     std::shared_ptr<arrow::Schema> arrow_schema;
@@ -1552,8 +1560,7 @@ GetFieldDatasFromManifest(
     }
 
     auto updated_schema = std::make_shared<arrow::Schema>(
-        arrow::Schema({arrow_schema->field(0)->WithName(
-            std::to_string((field_meta.field_id)))}));
+        arrow::Schema({arrow_schema->field(0)->WithName(column_name)}));
 
     auto reader = milvus_storage::api::Reader::create(
         column_groups,
@@ -1589,7 +1596,7 @@ GetFieldDatasFromManifest(
         }
 
         auto chunked_array = std::make_shared<arrow::ChunkedArray>(
-            batch->GetColumnByName(field_id_str));
+            batch->GetColumnByName(column_name));
         auto field_data = CreateFieldData(data_type.value(),
                                           element_type.value(),
                                           batch->schema()->field(0)->nullable(),

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -1595,8 +1595,61 @@ GetFieldDatasFromManifest(
             continue;
         }
 
-        auto chunked_array = std::make_shared<arrow::ChunkedArray>(
-            batch->GetColumnByName(column_name));
+        auto column = batch->GetColumnByName(column_name);
+
+        // External parquet files store vectors as List<float> or
+        // FixedSizeList<float>, but Milvus expects FixedSizeBinary.
+        // Normalize here so that FillFieldData sees the right Arrow type.
+        if (!field_meta.field_schema.external_field().empty() &&
+            IsVectorDataType(data_type.value()) &&
+            !IsSparseFloatVectorDataType(data_type.value()) &&
+            column->type_id() != arrow::Type::FIXED_SIZE_BINARY) {
+            int byte_width = GetDataTypeSize(data_type.value(), dim);
+            auto fsb_type = arrow::fixed_size_binary(byte_width);
+            int64_t n = column->length();
+
+            auto buf_res = arrow::AllocateBuffer(n * byte_width);
+            AssertInfo(buf_res.ok(),
+                       "Failed to allocate buffer for vector normalization");
+            auto buffer = std::move(*buf_res);
+            auto dst = buffer->mutable_data();
+
+            if (column->type_id() == arrow::Type::LIST) {
+                auto list_arr =
+                    std::static_pointer_cast<arrow::ListArray>(column);
+                auto values = list_arr->values();
+                int elem_bytes = values->type()->bit_width() / 8;
+                auto raw = reinterpret_cast<const uint8_t*>(
+                    values->data()->buffers[1]->data());
+                for (int64_t i = 0; i < n; i++) {
+                    memcpy(dst + i * byte_width,
+                           raw + list_arr->value_offset(i) * elem_bytes,
+                           byte_width);
+                }
+            } else if (column->type_id() == arrow::Type::FIXED_SIZE_LIST) {
+                auto fsl_arr =
+                    std::static_pointer_cast<arrow::FixedSizeListArray>(column);
+                auto values = fsl_arr->values();
+                int elem_bytes = values->type()->bit_width() / 8;
+                auto raw = reinterpret_cast<const uint8_t*>(
+                    values->data()->buffers[1]->data());
+                for (int64_t i = 0; i < n; i++) {
+                    memcpy(dst + i * byte_width,
+                           raw + fsl_arr->value_offset(i) * elem_bytes,
+                           byte_width);
+                }
+            } else {
+                ThrowInfo(Unsupported,
+                          "Unsupported arrow type for external vector "
+                          "normalization: {}",
+                          column->type()->ToString());
+            }
+
+            column = std::make_shared<arrow::FixedSizeBinaryArray>(
+                fsb_type, n, std::move(buffer));
+        }
+
+        auto chunked_array = std::make_shared<arrow::ChunkedArray>(column);
         auto field_data = CreateFieldData(data_type.value(),
                                           element_type.value(),
                                           batch->schema()->field(0)->nullable(),

--- a/internal/core/src/storage/loon_ffi/util.cpp
+++ b/internal/core/src/storage/loon_ffi/util.cpp
@@ -42,10 +42,21 @@ MakePropertiesFromStorageConfig(CStorageConfig c_storage_config) {
     std::vector<const char*> keys;
     std::vector<const char*> values;
 
+    // Lance's BuildEndpointUrl defaults to HTTPS when no scheme is present.
+    // Prepend http:// when SSL is not enabled so that Lance sets allow_http=true.
+    std::string fs_address;
+    if (c_storage_config.address != nullptr) {
+        fs_address = c_storage_config.address;
+        if (!c_storage_config.useSSL &&
+            fs_address.find("://") == std::string::npos) {
+            fs_address = "http://" + fs_address;
+        }
+    }
+
     // Add non-null string fields
     if (c_storage_config.address != nullptr) {
         keys.emplace_back(PROPERTY_FS_ADDRESS);
-        values.emplace_back(c_storage_config.address);
+        values.emplace_back(fs_address.c_str());
     }
     if (c_storage_config.bucket_name != nullptr) {
         keys.emplace_back(PROPERTY_FS_BUCKET_NAME);
@@ -122,6 +133,67 @@ MakePropertiesFromStorageConfig(CStorageConfig c_storage_config) {
         keys.emplace_back(PROPERTY_FS_TLS_MIN_VERSION);
         values.emplace_back(c_storage_config.tls_min_version);
     }
+    // Add extfs.default.* properties for external collection filesystem resolution
+    if (c_storage_config.storage_type != nullptr) {
+        keys.emplace_back("extfs.default.storage_type");
+        values.emplace_back(c_storage_config.storage_type);
+        if (std::string(c_storage_config.storage_type) == "local") {
+            keys.emplace_back("extfs.default.bucket_name");
+            values.emplace_back("local");
+        } else if (c_storage_config.bucket_name != nullptr) {
+            keys.emplace_back("extfs.default.bucket_name");
+            values.emplace_back(c_storage_config.bucket_name);
+        }
+    }
+    if (c_storage_config.address != nullptr) {
+        keys.emplace_back("extfs.default.address");
+        values.emplace_back(fs_address.c_str());
+    }
+    if (c_storage_config.root_path != nullptr) {
+        keys.emplace_back("extfs.default.root_path");
+        values.emplace_back(c_storage_config.root_path);
+    }
+    if (c_storage_config.access_key_id != nullptr) {
+        keys.emplace_back("extfs.default.access_key_id");
+        values.emplace_back(c_storage_config.access_key_id);
+    }
+    if (c_storage_config.access_key_value != nullptr) {
+        keys.emplace_back("extfs.default.access_key_value");
+        values.emplace_back(c_storage_config.access_key_value);
+    }
+    if (c_storage_config.cloud_provider != nullptr) {
+        keys.emplace_back("extfs.default.cloud_provider");
+        values.emplace_back(c_storage_config.cloud_provider);
+    }
+    if (c_storage_config.iam_endpoint != nullptr) {
+        keys.emplace_back("extfs.default.iam_endpoint");
+        values.emplace_back(c_storage_config.iam_endpoint);
+    }
+    if (c_storage_config.region != nullptr) {
+        keys.emplace_back("extfs.default.region");
+        values.emplace_back(c_storage_config.region);
+    }
+    if (c_storage_config.sslCACert != nullptr) {
+        keys.emplace_back("extfs.default.ssl_ca_cert");
+        values.emplace_back(c_storage_config.sslCACert);
+    }
+    if (c_storage_config.gcp_credential_json != nullptr) {
+        keys.emplace_back("extfs.default.gcp_credential_json");
+        values.emplace_back(c_storage_config.gcp_credential_json);
+    }
+    // Temporarily disabled: extfs.default.* boolean properties.
+    // extfs.* keys are not registered in property_infos, so
+    // ConvertFFIProperties stores them as std::string instead of bool.
+    // ExtractExternalFsProperties copies them as-is to fs.*, causing
+    // GetValue<bool> type mismatch. Omitting lets defaults be used.
+    // TODO: re-enable once milvus-storage fixes ExtractExternalFsProperties.
+    //
+    // keys.emplace_back("extfs.default.use_ssl");
+    // values.emplace_back(c_storage_config.useSSL ? "true" : "false");
+    // keys.emplace_back("extfs.default.use_iam");
+    // values.emplace_back(c_storage_config.useIAM ? "true" : "false");
+    // keys.emplace_back("extfs.default.use_virtual_host");
+    // values.emplace_back(c_storage_config.useVirtualHost ? "true" : "false");
 
     // Create Properties using FFI
     auto properties = std::make_shared<LoonProperties>();
@@ -144,10 +216,21 @@ std::shared_ptr<milvus_storage::api::Properties>
 MakeInternalPropertiesFromStorageConfig(CStorageConfig c_storage_config) {
     auto properties_map = std::make_shared<milvus_storage::api::Properties>();
 
+    // Lance's BuildEndpointUrl defaults to HTTPS when no scheme is present.
+    // Prepend http:// when SSL is not enabled so that Lance sets allow_http=true.
+    std::string fs_address_internal;
+    if (c_storage_config.address != nullptr) {
+        fs_address_internal = c_storage_config.address;
+        if (!c_storage_config.useSSL &&
+            fs_address_internal.find("://") == std::string::npos) {
+            fs_address_internal = "http://" + fs_address_internal;
+        }
+    }
+
     // Add non-null string fields
     if (c_storage_config.address != nullptr) {
         milvus_storage::api::SetValue(
-            *properties_map, PROPERTY_FS_ADDRESS, c_storage_config.address);
+            *properties_map, PROPERTY_FS_ADDRESS, fs_address_internal.c_str());
     }
     if (c_storage_config.bucket_name != nullptr) {
         milvus_storage::api::SetValue(*properties_map,
@@ -235,6 +318,82 @@ MakeInternalPropertiesFromStorageConfig(CStorageConfig c_storage_config) {
                                       PROPERTY_FS_TLS_MIN_VERSION,
                                       c_storage_config.tls_min_version);
     }
+    // Add extfs.default.* properties for external collection filesystem resolution.
+    // When segments reference absolute URIs (e.g., aws://host/bucket/path),
+    // the storage layer matches against extfs.* configs to find credentials.
+    if (c_storage_config.storage_type != nullptr) {
+        milvus_storage::api::SetValue(*properties_map,
+                                      "extfs.default.storage_type",
+                                      c_storage_config.storage_type);
+        if (std::string(c_storage_config.storage_type) == "local") {
+            milvus_storage::api::SetValue(
+                *properties_map, "extfs.default.bucket_name", "local");
+        } else if (c_storage_config.bucket_name != nullptr) {
+            milvus_storage::api::SetValue(*properties_map,
+                                          "extfs.default.bucket_name",
+                                          c_storage_config.bucket_name);
+        }
+    }
+    if (c_storage_config.address != nullptr) {
+        milvus_storage::api::SetValue(*properties_map,
+                                      "extfs.default.address",
+                                      fs_address_internal.c_str());
+    }
+    if (c_storage_config.root_path != nullptr) {
+        milvus_storage::api::SetValue(*properties_map,
+                                      "extfs.default.root_path",
+                                      c_storage_config.root_path);
+    }
+    if (c_storage_config.access_key_id != nullptr) {
+        milvus_storage::api::SetValue(*properties_map,
+                                      "extfs.default.access_key_id",
+                                      c_storage_config.access_key_id);
+    }
+    if (c_storage_config.access_key_value != nullptr) {
+        milvus_storage::api::SetValue(*properties_map,
+                                      "extfs.default.access_key_value",
+                                      c_storage_config.access_key_value);
+    }
+    if (c_storage_config.cloud_provider != nullptr) {
+        milvus_storage::api::SetValue(*properties_map,
+                                      "extfs.default.cloud_provider",
+                                      c_storage_config.cloud_provider);
+    }
+    if (c_storage_config.iam_endpoint != nullptr) {
+        milvus_storage::api::SetValue(*properties_map,
+                                      "extfs.default.iam_endpoint",
+                                      c_storage_config.iam_endpoint);
+    }
+    if (c_storage_config.region != nullptr) {
+        milvus_storage::api::SetValue(
+            *properties_map, "extfs.default.region", c_storage_config.region);
+    }
+    if (c_storage_config.sslCACert != nullptr) {
+        milvus_storage::api::SetValue(*properties_map,
+                                      "extfs.default.ssl_ca_cert",
+                                      c_storage_config.sslCACert);
+    }
+    if (c_storage_config.gcp_credential_json != nullptr) {
+        milvus_storage::api::SetValue(*properties_map,
+                                      "extfs.default.gcp_credential_json",
+                                      c_storage_config.gcp_credential_json);
+    }
+    // Temporarily disabled: extfs.default.* boolean properties.
+    // extfs.* keys are not registered in property_infos, so SetValue stores
+    // them as std::string("false") instead of bool(false). When
+    // ExtractExternalFsProperties copies them to fs.*, GetValue<bool> fails
+    // with type mismatch. Omitting lets defaults be used.
+    // TODO: re-enable once milvus-storage fixes ExtractExternalFsProperties.
+    //
+    // milvus_storage::api::SetValue(
+    //     *properties_map, "extfs.default.use_ssl",
+    //     c_storage_config.useSSL ? "true" : "false");
+    // milvus_storage::api::SetValue(
+    //     *properties_map, "extfs.default.use_iam",
+    //     c_storage_config.useIAM ? "true" : "false");
+    // milvus_storage::api::SetValue(
+    //     *properties_map, "extfs.default.use_virtual_host",
+    //     c_storage_config.useVirtualHost ? "true" : "false");
 
     return properties_map;
 }

--- a/internal/core/unittest/CMakeLists.txt
+++ b/internal/core/unittest/CMakeLists.txt
@@ -63,6 +63,7 @@ set(MILVUS_TEST_FILES
         test_sort_buffer.cpp
         test_query_order_by.cpp
         test_determine_use_index.cpp
+        test_virtual_pk.cpp
         )
 
 if ( NOT (INDEX_ENGINE STREQUAL "cardinal") )

--- a/internal/core/unittest/test_virtual_pk.cpp
+++ b/internal/core/unittest/test_virtual_pk.cpp
@@ -1,0 +1,348 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+#include <gtest/gtest.h>
+
+#include "common/VirtualPK.h"
+#include "mmap/VirtualPKChunkedColumn.h"
+
+using namespace milvus;
+
+class VirtualPKTest : public ::testing::Test {
+ protected:
+    void
+    SetUp() override {
+    }
+};
+
+// Test GetVirtualPK function
+TEST_F(VirtualPKTest, GetVirtualPK) {
+    // Test basic virtual PK generation
+    int64_t segment_id = 12345;
+    int64_t offset = 100;
+    int64_t virtual_pk = GetVirtualPK(segment_id, offset);
+
+    // Virtual PK format: (segment_id << 32) | offset
+    int64_t expected = (segment_id << 32) | offset;
+    ASSERT_EQ(virtual_pk, expected);
+}
+
+TEST_F(VirtualPKTest, GetVirtualPKWithLargeOffset) {
+    // Test with large offset (near 32-bit limit)
+    int64_t segment_id = 1;
+    int64_t offset = 0xFFFFFFFF;  // Max 32-bit value
+    int64_t virtual_pk = GetVirtualPK(segment_id, offset);
+
+    ASSERT_EQ(ExtractSegmentIDFromVirtualPK(virtual_pk), 1);
+    ASSERT_EQ(ExtractOffsetFromVirtualPK(virtual_pk), 0xFFFFFFFF);
+}
+
+TEST_F(VirtualPKTest, GetVirtualPKWithLargeSegmentID) {
+    // Milvus segment IDs are TSO-allocated 64-bit values.
+    // GetVirtualPK truncates to lower 32 bits - this is expected.
+    int64_t segment_id = 0x100000001;  // 33-bit value, lower 32 bits = 1
+    int64_t offset = 42;
+    int64_t virtual_pk = GetVirtualPK(segment_id, offset);
+
+    ASSERT_TRUE(IsVirtualPKFromSegment(virtual_pk, segment_id));
+    ASSERT_EQ(ExtractOffsetFromVirtualPK(virtual_pk), 42);
+    ASSERT_EQ(ExtractSegmentIDFromVirtualPK(virtual_pk),
+              GetTruncatedSegmentID(segment_id));
+}
+
+// Test ExtractSegmentIDFromVirtualPK function
+TEST_F(VirtualPKTest, ExtractSegmentID) {
+    int64_t segment_id = 999;
+    int64_t offset = 500;
+    int64_t virtual_pk = GetVirtualPK(segment_id, offset);
+
+    ASSERT_EQ(ExtractSegmentIDFromVirtualPK(virtual_pk), segment_id);
+}
+
+// Test ExtractOffsetFromVirtualPK function
+TEST_F(VirtualPKTest, ExtractOffset) {
+    int64_t segment_id = 999;
+    int64_t offset = 500;
+    int64_t virtual_pk = GetVirtualPK(segment_id, offset);
+
+    ASSERT_EQ(ExtractOffsetFromVirtualPK(virtual_pk), offset);
+}
+
+// Test IsVirtualPKFromSegment function
+TEST_F(VirtualPKTest, IsVirtualPKFromSegment) {
+    int64_t segment_id = 12345;
+    int64_t offset = 100;
+    int64_t virtual_pk = GetVirtualPK(segment_id, offset);
+
+    ASSERT_TRUE(IsVirtualPKFromSegment(virtual_pk, segment_id));
+    ASSERT_FALSE(IsVirtualPKFromSegment(virtual_pk, segment_id + 1));
+    ASSERT_FALSE(IsVirtualPKFromSegment(virtual_pk, 0));
+}
+
+TEST_F(VirtualPKTest, IsVirtualPKFromSegmentWithTruncation) {
+    // Test that comparison works when segment IDs differ in upper bits
+    int64_t segment_id = 0x1000000001;  // Upper bits set
+    int64_t truncated_segment_id = 1;   // Same lower 32 bits
+    int64_t offset = 100;
+    int64_t virtual_pk = GetVirtualPK(segment_id, offset);
+
+    // Both should match because only lower 32 bits are compared
+    ASSERT_TRUE(IsVirtualPKFromSegment(virtual_pk, segment_id));
+    ASSERT_TRUE(IsVirtualPKFromSegment(virtual_pk, truncated_segment_id));
+}
+
+// Test GetTruncatedSegmentID function
+TEST_F(VirtualPKTest, GetTruncatedSegmentID) {
+    int64_t segment_id = 0x1FFFFFFFF;  // 33-bit value
+    int64_t truncated = GetTruncatedSegmentID(segment_id);
+
+    ASSERT_EQ(truncated, segment_id & 0xFFFFFFFF);
+    ASSERT_EQ(truncated, 0xFFFFFFFF);
+}
+
+// Test round-trip: create virtual PK, extract components, verify
+TEST_F(VirtualPKTest, RoundTrip) {
+    for (int64_t seg = 0; seg < 100; seg++) {
+        for (int64_t off = 0; off < 100; off++) {
+            int64_t virtual_pk = GetVirtualPK(seg, off);
+            ASSERT_EQ(ExtractSegmentIDFromVirtualPK(virtual_pk), seg);
+            ASSERT_EQ(ExtractOffsetFromVirtualPK(virtual_pk), off);
+            ASSERT_TRUE(IsVirtualPKFromSegment(virtual_pk, seg));
+        }
+    }
+}
+
+// Test VirtualPKChunkedColumn
+class VirtualPKChunkedColumnTest : public ::testing::Test {
+ protected:
+    void
+    SetUp() override {
+    }
+};
+
+TEST_F(VirtualPKChunkedColumnTest, BasicProperties) {
+    int64_t segment_id = 12345;
+    int64_t num_rows = 1000;
+
+    VirtualPKChunkedColumn column(segment_id, num_rows);
+
+    ASSERT_EQ(column.NumRows(), num_rows);
+    ASSERT_EQ(column.num_chunks(), 1);
+    ASSERT_EQ(column.chunk_row_nums(0), num_rows);
+    ASSERT_EQ(column.DataByteSize(), num_rows * sizeof(int64_t));
+    ASSERT_FALSE(column.IsNullable());
+    ASSERT_EQ(column.GetSegmentID(), segment_id);
+    ASSERT_EQ(column.GetTruncatedSegmentID(),
+              GetTruncatedSegmentID(segment_id));
+}
+
+TEST_F(VirtualPKChunkedColumnTest, GetVirtualPKAt) {
+    int64_t segment_id = 100;
+    int64_t num_rows = 50;
+
+    VirtualPKChunkedColumn column(segment_id, num_rows);
+
+    for (int64_t i = 0; i < num_rows; i++) {
+        int64_t expected = GetVirtualPK(segment_id, i);
+        ASSERT_EQ(column.GetVirtualPKAt(i), expected);
+    }
+}
+
+TEST_F(VirtualPKChunkedColumnTest, BulkPrimitiveValueAt) {
+    int64_t segment_id = 200;
+    int64_t num_rows = 100;
+
+    VirtualPKChunkedColumn column(segment_id, num_rows);
+
+    // Test with sequential offsets
+    std::vector<int64_t> offsets = {0, 5, 10, 50, 99};
+    std::vector<int64_t> results(offsets.size());
+
+    column.BulkPrimitiveValueAt(
+        nullptr, results.data(), offsets.data(), offsets.size());
+
+    for (size_t i = 0; i < offsets.size(); i++) {
+        int64_t expected = GetVirtualPK(segment_id, offsets[i]);
+        ASSERT_EQ(results[i], expected);
+    }
+}
+
+TEST_F(VirtualPKChunkedColumnTest, BulkValueAt) {
+    int64_t segment_id = 300;
+    int64_t num_rows = 50;
+
+    VirtualPKChunkedColumn column(segment_id, num_rows);
+
+    std::vector<int64_t> offsets = {0, 10, 20, 30, 40};
+    std::vector<int64_t> collected_values;
+    std::vector<size_t> collected_indices;
+
+    column.BulkValueAt(
+        nullptr,
+        [&](const char* data, size_t idx) {
+            int64_t value = *reinterpret_cast<const int64_t*>(data);
+            collected_values.push_back(value);
+            collected_indices.push_back(idx);
+        },
+        offsets.data(),
+        offsets.size());
+
+    ASSERT_EQ(collected_values.size(), offsets.size());
+    for (size_t i = 0; i < offsets.size(); i++) {
+        int64_t expected = GetVirtualPK(segment_id, offsets[i]);
+        ASSERT_EQ(collected_values[i], expected);
+        ASSERT_EQ(collected_indices[i], i);
+    }
+}
+
+TEST_F(VirtualPKChunkedColumnTest, IsValid) {
+    int64_t segment_id = 100;
+    int64_t num_rows = 50;
+
+    VirtualPKChunkedColumn column(segment_id, num_rows);
+
+    // Valid offsets
+    ASSERT_TRUE(column.IsValid(nullptr, 0));
+    ASSERT_TRUE(column.IsValid(nullptr, 25));
+    ASSERT_TRUE(column.IsValid(nullptr, 49));
+
+    // Invalid offsets
+    ASSERT_FALSE(column.IsValid(nullptr, 50));
+    ASSERT_FALSE(column.IsValid(nullptr, 100));
+}
+
+TEST_F(VirtualPKChunkedColumnTest, BulkIsValid) {
+    int64_t segment_id = 100;
+    int64_t num_rows = 50;
+
+    VirtualPKChunkedColumn column(segment_id, num_rows);
+
+    // Test with offsets
+    std::vector<int64_t> offsets = {0, 10, 20};
+    int count = 0;
+    column.BulkIsValid(
+        nullptr,
+        [&](bool valid, size_t idx) {
+            ASSERT_TRUE(valid);
+            count++;
+        },
+        offsets.data(),
+        offsets.size());
+    ASSERT_EQ(count, offsets.size());
+
+    // Test without offsets (nullptr)
+    count = 0;
+    column.BulkIsValid(
+        nullptr,
+        [&](bool valid, size_t idx) {
+            ASSERT_TRUE(valid);
+            count++;
+        },
+        nullptr,
+        0);
+    ASSERT_EQ(count, num_rows);
+}
+
+TEST_F(VirtualPKChunkedColumnTest, GetChunkIDByOffset) {
+    int64_t segment_id = 100;
+    int64_t num_rows = 100;
+
+    VirtualPKChunkedColumn column(segment_id, num_rows);
+
+    // All offsets should map to chunk 0
+    auto [chunk_id, offset_in_chunk] = column.GetChunkIDByOffset(0);
+    ASSERT_EQ(chunk_id, 0);
+    ASSERT_EQ(offset_in_chunk, 0);
+
+    auto [chunk_id2, offset_in_chunk2] = column.GetChunkIDByOffset(50);
+    ASSERT_EQ(chunk_id2, 0);
+    ASSERT_EQ(offset_in_chunk2, 50);
+}
+
+TEST_F(VirtualPKChunkedColumnTest, GetChunkIDsByOffsets) {
+    int64_t segment_id = 100;
+    int64_t num_rows = 100;
+
+    VirtualPKChunkedColumn column(segment_id, num_rows);
+
+    std::vector<int64_t> offsets = {0, 25, 50, 75, 99};
+    auto [cids, offsets_in_chunk] =
+        column.GetChunkIDsByOffsets(offsets.data(), offsets.size());
+
+    ASSERT_EQ(cids.size(), offsets.size());
+    ASSERT_EQ(offsets_in_chunk.size(), offsets.size());
+
+    for (size_t i = 0; i < offsets.size(); i++) {
+        ASSERT_EQ(cids[i], 0);  // All in chunk 0
+        ASSERT_EQ(offsets_in_chunk[i], offsets[i]);
+    }
+}
+
+TEST_F(VirtualPKChunkedColumnTest, GetNumRowsUntilChunk) {
+    int64_t segment_id = 100;
+    int64_t num_rows = 100;
+
+    VirtualPKChunkedColumn column(segment_id, num_rows);
+
+    ASSERT_EQ(column.GetNumRowsUntilChunk(0), 0);
+    ASSERT_EQ(column.GetNumRowsUntilChunk(1), num_rows);
+
+    const auto& all_nums = column.GetNumRowsUntilChunk();
+    ASSERT_EQ(all_nums.size(), 2);
+    ASSERT_EQ(all_nums[0], 0);
+    ASSERT_EQ(all_nums[1], num_rows);
+}
+
+TEST_F(VirtualPKChunkedColumnTest, SupportedOperations) {
+    int64_t segment_id = 100;
+    int64_t num_rows = 50;
+
+    VirtualPKChunkedColumn column(segment_id, num_rows);
+
+    // DataOfChunk and Span are supported via EnsureMaterialized
+    EXPECT_NO_THROW(column.DataOfChunk(nullptr, 0));
+    EXPECT_NO_THROW(column.Span(nullptr, 0));
+
+    // Verify DataOfChunk returns valid data
+    auto data = column.DataOfChunk(nullptr, 0);
+    auto pks = reinterpret_cast<const int64_t*>(data.get());
+    ASSERT_NE(pks, nullptr);
+    ASSERT_EQ(pks[0], GetVirtualPK(GetTruncatedSegmentID(segment_id), 0));
+}
+
+TEST_F(VirtualPKChunkedColumnTest, UnsupportedOperations) {
+    int64_t segment_id = 100;
+    int64_t num_rows = 50;
+
+    VirtualPKChunkedColumn column(segment_id, num_rows);
+
+    // These operations should throw
+    EXPECT_THROW(column.GetChunk(nullptr, 0), std::exception);
+    EXPECT_THROW(column.GetAllChunks(nullptr), std::exception);
+    EXPECT_THROW(column.StringViews(nullptr, 0, std::nullopt), std::exception);
+    EXPECT_THROW(column.ArrayViews(nullptr, 0, std::nullopt), std::exception);
+}
+
+TEST_F(VirtualPKChunkedColumnTest, LargeSegmentID) {
+    // Test with segment ID that has upper bits set (real Milvus TSO IDs)
+    int64_t segment_id = 0x100000001;  // 33-bit value
+    int64_t num_rows = 10;
+
+    VirtualPKChunkedColumn column(segment_id, num_rows);
+
+    // Truncated segment ID should only have lower 32 bits
+    ASSERT_EQ(column.GetTruncatedSegmentID(), 1);
+
+    // Virtual PKs should use truncated segment ID
+    int64_t pk = column.GetVirtualPKAt(5);
+    ASSERT_EQ(ExtractSegmentIDFromVirtualPK(pk), 1);
+    ASSERT_EQ(ExtractOffsetFromVirtualPK(pk), 5);
+}

--- a/internal/datacoord/external_collection_refresh_meta.go
+++ b/internal/datacoord/external_collection_refresh_meta.go
@@ -500,6 +500,9 @@ func (m *externalCollectionRefreshMeta) UpdateTaskState(taskID int64, state inde
 	cloneTask := proto.Clone(task).(*datapb.ExternalCollectionRefreshTask)
 	cloneTask.State = state
 	cloneTask.FailReason = failReason
+	if state == indexpb.JobState_JobStateFinished {
+		cloneTask.Progress = 100
+	}
 
 	if err := m.catalog.SaveExternalCollectionRefreshTask(m.ctx, cloneTask); err != nil {
 		log.Warn("update task state failed",
@@ -629,7 +632,12 @@ func (m *externalCollectionRefreshMeta) AggregateJobStateFromTasks(jobID int64) 
 	var totalProgress int64
 
 	for _, task := range tasks {
-		totalProgress += task.GetProgress()
+		taskProgress := task.GetProgress()
+		// Finished tasks should always count as 100% regardless of stored value
+		if task.GetState() == indexpb.JobState_JobStateFinished {
+			taskProgress = 100
+		}
+		totalProgress += taskProgress
 		switch task.GetState() {
 		case indexpb.JobState_JobStateInit:
 			hasInit = true

--- a/internal/datacoord/handler.go
+++ b/internal/datacoord/handler.go
@@ -171,7 +171,8 @@ func (h *ServerHandler) GetQueryVChanPositions(channel RWChannel, partitionIDs .
 		if filterWithPartition && !validPartitionsMap[s.GetPartitionID()] {
 			continue
 		}
-		if s.GetStartPosition() == nil && s.GetDmlPosition() == nil {
+		if s.GetStartPosition() == nil && s.GetDmlPosition() == nil && s.GetManifestPath() == "" {
+			// External collection segments may not have start/DML positions but have ManifestPath
 			continue
 		}
 		if s.GetIsImporting() {

--- a/internal/datacoord/index_inspector.go
+++ b/internal/datacoord/index_inspector.go
@@ -107,8 +107,9 @@ func (i *indexInspector) createIndexForSegmentLoop(ctx context.Context) {
 			}
 		case collectionID := <-i.notifyIndexChan:
 			log.Info("receive create index notify", zap.Int64("collectionID", collectionID))
+			isExternal := i.isExternalCollection(collectionID)
 			segments := i.meta.SelectSegments(ctx, WithCollection(collectionID), SegmentFilterFunc(func(info *SegmentInfo) bool {
-				return isFlush(info) && (!enableSortCompaction() || info.GetIsSorted() || info.GetIsSortedByNamespace())
+				return isFlush(info) && (!enableSortCompaction() || info.GetIsSorted() || info.GetIsSortedByNamespace() || isExternal)
 			}))
 			for _, segment := range segments {
 				if err := i.createIndexesForSegment(ctx, segment); err != nil {
@@ -146,7 +147,7 @@ func (i *indexInspector) getUnIndexTaskSegments(ctx context.Context) []*SegmentI
 }
 
 func (i *indexInspector) createIndexesForSegment(ctx context.Context, segment *SegmentInfo) error {
-	if enableSortCompaction() && !segment.GetIsSorted() && !segment.GetIsSortedByNamespace() {
+	if enableSortCompaction() && !segment.GetIsSorted() && !segment.GetIsSortedByNamespace() && !i.isExternalCollection(segment.CollectionID) {
 		log.Ctx(ctx).Debug("segment is not sorted by pk, skip create indexes", zap.Int64("segmentID", segment.GetID()))
 		return nil
 	}
@@ -225,6 +226,11 @@ func (i *indexInspector) createIndexForSegment(ctx context.Context, segment *Seg
 		zap.Int64("field size", fieldSize),
 		zap.Int64("task slot", taskSlot))
 	return nil
+}
+
+func (i *indexInspector) isExternalCollection(collectionID int64) bool {
+	coll := i.meta.GetCollection(collectionID)
+	return coll != nil && coll.IsExternal()
 }
 
 func (i *indexInspector) reloadFromMeta() {

--- a/internal/datacoord/index_inspector_test.go
+++ b/internal/datacoord/index_inspector_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/datacoord/task"
 	mocks2 "github.com/milvus-io/milvus/internal/metastore/mocks"
@@ -166,6 +167,153 @@ func TestIndexInspector_ReloadFromMeta(t *testing.T) {
 
 	scheduler.EXPECT().Enqueue(mock.Anything).Return()
 	inspector.reloadFromMeta()
+}
+
+func TestIndexInspector_isExternalCollection(t *testing.T) {
+	ctx := context.Background()
+	notifyChan := make(chan int64, 1)
+	scheduler := task.NewMockGlobalScheduler(t)
+	alloc := allocator.NewMockAllocator(t)
+	handler := NewNMockHandler(t)
+	storageCli := mocks.NewChunkManager(t)
+	versionManager := newIndexEngineVersionManager()
+
+	m := &meta{
+		segments:    NewSegmentsInfo(),
+		collections: typeutil.NewConcurrentMap[UniqueID, *collectionInfo](),
+		indexMeta: &indexMeta{
+			keyLock:          lock.NewKeyLock[UniqueID](),
+			segmentBuildInfo: newSegmentIndexBuildInfo(),
+			indexes:          make(map[UniqueID]map[UniqueID]*model.Index),
+			segmentIndexes:   typeutil.NewConcurrentMap[UniqueID, *typeutil.ConcurrentMap[UniqueID, *model.SegmentIndex]](),
+		},
+	}
+
+	inspector := newIndexInspector(ctx, notifyChan, m, scheduler, alloc, handler, storageCli, versionManager)
+
+	t.Run("collection not found", func(t *testing.T) {
+		assert.False(t, inspector.isExternalCollection(999))
+	})
+
+	t.Run("normal collection is not external", func(t *testing.T) {
+		m.collections.Insert(10, &collectionInfo{
+			ID: 10,
+			Schema: &schemapb.CollectionSchema{
+				Fields: []*schemapb.FieldSchema{
+					{Name: "pk", FieldID: 100, DataType: schemapb.DataType_Int64},
+				},
+			},
+		})
+		assert.False(t, inspector.isExternalCollection(10))
+	})
+
+	t.Run("external collection is external", func(t *testing.T) {
+		m.collections.Insert(20, &collectionInfo{
+			ID: 20,
+			Schema: &schemapb.CollectionSchema{
+				Fields: []*schemapb.FieldSchema{
+					{Name: "id", FieldID: 101, DataType: schemapb.DataType_Int64, ExternalField: "id"},
+				},
+			},
+		})
+		assert.True(t, inspector.isExternalCollection(20))
+	})
+}
+
+func TestIndexInspector_CreateIndexesForSegment_ExternalUnsorted(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.EnableSortCompaction.Key, "true")
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.EnableCompaction.Key, "true")
+	defer func() {
+		paramtable.Get().Reset(paramtable.Get().DataCoordCfg.EnableSortCompaction.Key)
+		paramtable.Get().Reset(paramtable.Get().DataCoordCfg.EnableCompaction.Key)
+	}()
+
+	ctx := context.Background()
+	notifyChan := make(chan int64, 1)
+	scheduler := task.NewMockGlobalScheduler(t)
+	alloc := allocator.NewMockAllocator(t)
+	handler := NewNMockHandler(t)
+	storageCli := mocks.NewChunkManager(t)
+	versionManager := newIndexEngineVersionManager()
+	catalog := mocks2.NewDataCoordCatalog(t)
+
+	m := &meta{
+		segments:    NewSegmentsInfo(),
+		collections: typeutil.NewConcurrentMap[UniqueID, *collectionInfo](),
+		indexMeta: &indexMeta{
+			keyLock:          lock.NewKeyLock[UniqueID](),
+			catalog:          catalog,
+			segmentBuildInfo: newSegmentIndexBuildInfo(),
+			indexes:          make(map[UniqueID]map[UniqueID]*model.Index),
+			segmentIndexes:   typeutil.NewConcurrentMap[UniqueID, *typeutil.ConcurrentMap[UniqueID, *model.SegmentIndex]](),
+		},
+	}
+
+	m.indexMeta.indexes[2] = map[UniqueID]*model.Index{
+		5: {
+			CollectionID: 2,
+			FieldID:      101,
+			IndexID:      5,
+			IndexName:    indexName,
+		},
+	}
+
+	inspector := newIndexInspector(ctx, notifyChan, m, scheduler, alloc, handler, storageCli, versionManager)
+
+	t.Run("normal unsorted segment is skipped", func(t *testing.T) {
+		m.collections.Insert(2, &collectionInfo{
+			ID: 2,
+			Schema: &schemapb.CollectionSchema{
+				Fields: []*schemapb.FieldSchema{
+					{Name: "pk", FieldID: 100, DataType: schemapb.DataType_Int64},
+				},
+			},
+		})
+
+		segment := &SegmentInfo{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:           1,
+				CollectionID: 2,
+				State:        commonpb.SegmentState_Flushed,
+				IsSorted:     false,
+			},
+		}
+		m.segments.SetSegment(segment.GetID(), segment)
+
+		err := inspector.createIndexesForSegment(ctx, segment)
+		assert.NoError(t, err)
+		// No index should be created because segment is unsorted and collection is not external
+		assert.True(t, m.indexMeta.IsUnIndexedSegment(2, 1))
+	})
+
+	t.Run("external unsorted segment is not skipped", func(t *testing.T) {
+		m.collections.Insert(2, &collectionInfo{
+			ID: 2,
+			Schema: &schemapb.CollectionSchema{
+				Fields: []*schemapb.FieldSchema{
+					{Name: "id", FieldID: 101, DataType: schemapb.DataType_Int64, ExternalField: "id"},
+				},
+			},
+		})
+
+		segment := &SegmentInfo{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:           1,
+				CollectionID: 2,
+				State:        commonpb.SegmentState_Flushed,
+				IsSorted:     false,
+			},
+		}
+		m.segments.SetSegment(segment.GetID(), segment)
+
+		alloc.EXPECT().AllocID(mock.Anything).Return(int64(12345), nil)
+		catalog.EXPECT().CreateSegmentIndex(mock.Anything, mock.Anything).Return(nil)
+		scheduler.EXPECT().Enqueue(mock.Anything).Return()
+
+		err := inspector.createIndexesForSegment(ctx, segment)
+		assert.NoError(t, err)
+	})
 }
 
 func TestIndexInspector_CreateIndexForSegment_OverrideIndexType(t *testing.T) {

--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -982,7 +982,7 @@ func (s *Server) GetRecoveryInfoV2(ctx context.Context, req *datapb.GetRecoveryI
 		}
 
 		binlogs := segment.GetBinlogs()
-		if len(binlogs) == 0 && segment.GetLevel() != datapb.SegmentLevel_L0 {
+		if len(binlogs) == 0 && segment.GetLevel() != datapb.SegmentLevel_L0 && segment.GetManifestPath() == "" {
 			continue
 		}
 		rowCount := segmentutil.CalcRowCountFromBinLog(segment.SegmentInfo)

--- a/internal/datacoord/task_refresh_external_collection.go
+++ b/internal/datacoord/task_refresh_external_collection.go
@@ -140,6 +140,28 @@ func (t *refreshExternalCollectionTask) UpdateStateWithMeta(state indexpb.JobSta
 		return err
 	}
 	t.SetState(state, failReason)
+
+	// When task reaches a terminal state, aggregate and persist job state immediately.
+	// This eliminates the race window where HasActiveJob still sees InProgress
+	// while all tasks have already completed (checker loop updates every 10s).
+	if state == indexpb.JobState_JobStateFinished || state == indexpb.JobState_JobStateFailed {
+		jobState, _ := t.refreshMeta.AggregateJobStateFromTasks(t.GetJobId())
+		if jobState == indexpb.JobState_JobStateFinished || jobState == indexpb.JobState_JobStateFailed {
+			jobFailReason := ""
+			if jobState == indexpb.JobState_JobStateFailed {
+				jobFailReason = failReason
+			}
+			if err := t.refreshMeta.UpdateJobState(t.GetJobId(), jobState, jobFailReason); err != nil {
+				log.Warn("failed to eagerly update job state after task completion",
+					zap.Int64("taskID", t.GetTaskId()),
+					zap.Int64("jobID", t.GetJobId()),
+					zap.String("jobState", jobState.String()),
+					zap.Error(err))
+				// Non-fatal: checker loop will eventually update the job state
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -231,8 +253,30 @@ func (t *refreshExternalCollectionTask) SetJobInfo(ctx context.Context, resp *da
 
 	// DataNode already used pre-allocated segment IDs and wrote manifests to final paths.
 	// Just set the segment state to Flushed — no second ID allocation needed.
+	// Also populate InsertChannel and PartitionID which DataNode doesn't set for external segments.
+	// These are required for QueryCoord to include segments in its loading target.
+	collInfo := t.mt.GetCollection(t.GetCollectionId())
+	if collInfo == nil {
+		return fmt.Errorf("collection %d not found in meta", t.GetCollectionId())
+	}
+	// External collections are single-shard, single-partition (enforced at creation).
+	// Assert exactly-one here to catch any invariant violation from data corruption or legacy data.
+	if len(collInfo.VChannelNames) != 1 {
+		return fmt.Errorf("external collection %d expected exactly 1 VChannel, got %d", t.GetCollectionId(), len(collInfo.VChannelNames))
+	}
+	if len(collInfo.Partitions) != 1 {
+		return fmt.Errorf("external collection %d expected exactly 1 partition, got %d", t.GetCollectionId(), len(collInfo.Partitions))
+	}
+	insertChannel := collInfo.VChannelNames[0]
+	partitionID := collInfo.Partitions[0]
 	for _, seg := range updatedSegments {
 		seg.State = commonpb.SegmentState_Flushed
+		if seg.InsertChannel == "" {
+			seg.InsertChannel = insertChannel
+		}
+		if seg.PartitionID == 0 {
+			seg.PartitionID = partitionID
+		}
 	}
 
 	// Build update operators

--- a/internal/datacoord/task_refresh_external_collection_test.go
+++ b/internal/datacoord/task_refresh_external_collection_test.go
@@ -117,6 +117,18 @@ func (s *stubCluster) DropExternalCollectionTask(nodeID int64, taskID int64) err
 
 // ==================== Helper Functions ====================
 
+// newTestCollections creates a collections map with a single external collection
+// that has one VChannel and one partition, as expected by SetJobInfo.
+func newTestCollections(collectionID int64) *typeutil.ConcurrentMap[UniqueID, *collectionInfo] {
+	collections := typeutil.NewConcurrentMap[UniqueID, *collectionInfo]()
+	collections.Insert(collectionID, &collectionInfo{
+		ID:            collectionID,
+		VChannelNames: []string{"by-dev-rootcoord-dml_0_v1"},
+		Partitions:    []int64{1},
+	})
+	return collections
+}
+
 func createTestRefreshTaskWithStubs(t *testing.T, taskID, jobID, collectionID int64) (*refreshExternalCollectionTask, *externalCollectionRefreshMeta) {
 	catalog := &stubCatalog{}
 	refreshMeta, err := newExternalCollectionRefreshMeta(context.Background(), catalog)
@@ -435,7 +447,7 @@ func TestRefreshExternalCollectionTask_SetJobInfo(t *testing.T) {
 		mt := &meta{
 			catalog:     catalog,
 			segments:    segments,
-			collections: typeutil.NewConcurrentMap[UniqueID, *collectionInfo](),
+			collections: newTestCollections(100),
 		}
 
 		task := createTestRefreshTaskWithMetaAndStubs(t, 1001, 1, 100, mt, refreshMeta)
@@ -473,7 +485,7 @@ func TestRefreshExternalCollectionTask_SetJobInfo(t *testing.T) {
 		mt := &meta{
 			catalog:     catalog,
 			segments:    segments,
-			collections: typeutil.NewConcurrentMap[UniqueID, *collectionInfo](),
+			collections: newTestCollections(100),
 		}
 
 		task := createTestRefreshTaskWithMetaAndStubs(t, 1001, 1, 100, mt, refreshMeta)
@@ -502,7 +514,7 @@ func TestRefreshExternalCollectionTask_SetJobInfo(t *testing.T) {
 		mt := &meta{
 			catalog:     catalog,
 			segments:    segments,
-			collections: typeutil.NewConcurrentMap[UniqueID, *collectionInfo](),
+			collections: newTestCollections(100),
 		}
 
 		protoTask := &datapb.ExternalCollectionRefreshTask{
@@ -1001,12 +1013,10 @@ func TestRefreshExternalCollectionTask_QueryTaskOnWorker(t *testing.T) {
 			},
 		})
 
-		collections := typeutil.NewConcurrentMap[UniqueID, *collectionInfo]()
-		collections.Insert(100, &collectionInfo{ID: 100, Schema: &schemapb.CollectionSchema{Name: "test_coll"}})
 		mt := &meta{
 			catalog:     catalog,
 			segments:    segments,
-			collections: collections,
+			collections: newTestCollections(100),
 		}
 
 		alloc := &stubAllocator{nextID: 99999}
@@ -1023,6 +1033,10 @@ func TestRefreshExternalCollectionTask_QueryTaskOnWorker(t *testing.T) {
 			},
 		}, nil).Build()
 		defer mockQuery.UnPatch()
+
+		// Mock UpdateSegmentsInfo to succeed
+		mockUpdate := mockey.Mock((*meta).UpdateSegmentsInfo).Return(nil).Build()
+		defer mockUpdate.UnPatch()
 
 		task.QueryTaskOnWorker(cluster)
 
@@ -1165,7 +1179,7 @@ func TestRefreshExternalCollectionTask_QueryTaskOnWorker_FinishedSuccess(t *test
 	segments := NewSegmentsInfo()
 	mt := &meta{
 		segments:    segments,
-		collections: typeutil.NewConcurrentMap[UniqueID, *collectionInfo](),
+		collections: newTestCollections(100),
 	}
 
 	alloc := &stubAllocator{nextID: 99999}
@@ -1355,7 +1369,7 @@ func TestRefreshExternalCollectionTask_SetJobInfo_SuccessWithSegments(t *testing
 
 	mt := &meta{
 		segments:    segments,
-		collections: typeutil.NewConcurrentMap[UniqueID, *collectionInfo](),
+		collections: newTestCollections(100),
 	}
 
 	alloc := &stubAllocator{nextID: 99999}
@@ -1408,7 +1422,7 @@ func TestRefreshExternalCollectionTask_SetJobInfo_HighDropRatioWarning(t *testin
 
 	mt := &meta{
 		segments:    segments,
-		collections: typeutil.NewConcurrentMap[UniqueID, *collectionInfo](),
+		collections: newTestCollections(100),
 	}
 
 	alloc := &stubAllocator{nextID: 99999}
@@ -1448,7 +1462,7 @@ func TestRefreshExternalCollectionTask_SetJobInfo_UpdateSegmentsInfoFailed(t *te
 	segments := NewSegmentsInfo()
 	mt := &meta{
 		segments:    segments,
-		collections: typeutil.NewConcurrentMap[UniqueID, *collectionInfo](),
+		collections: newTestCollections(100),
 	}
 
 	alloc := &stubAllocator{nextID: 99999}

--- a/internal/datanode/external/external_spec.go
+++ b/internal/datanode/external/external_spec.go
@@ -23,15 +23,15 @@ import (
 
 // ExternalSpec represents the parsed external collection specification
 type ExternalSpec struct {
-	Format  string   `json:"format"`  // e.g., "parquet", "csv"
+	Format  string   `json:"format"`  // e.g., "parquet", "vortex", "lance-table"
 	Columns []string `json:"columns"` // optional: specific columns to load
 }
 
 // supportedFormats lists the file formats supported for external collections
 var supportedFormats = map[string]bool{
-	"parquet": true,
-	"csv":     true,
-	"json":    true,
+	"parquet":     true,
+	"lance-table": true,
+	"vortex":      true,
 }
 
 // ParseExternalSpec parses the JSON external spec string
@@ -50,7 +50,7 @@ func ParseExternalSpec(specStr string) (*ExternalSpec, error) {
 	}
 
 	if !supportedFormats[spec.Format] {
-		return nil, fmt.Errorf("unsupported format %q, supported formats: parquet, csv, json", spec.Format)
+		return nil, fmt.Errorf("unsupported format %q, supported formats: parquet, lance-table, vortex", spec.Format)
 	}
 
 	return &spec, nil

--- a/internal/datanode/external/manager.go
+++ b/internal/datanode/external/manager.go
@@ -259,9 +259,6 @@ func (m *ExternalCollectionManager) SubmitTask(
 		}
 		failReason := resp.GetFailReason()
 		kept := resp.GetKeptSegments()
-		if len(kept) == 0 {
-			kept = info.KeptSegments
-		}
 		m.UpdateResult(clusterID, taskID, state, failReason, kept, resp.GetUpdatedSegments())
 		log.Info("external collection task completed",
 			zap.Int64("taskID", taskID))

--- a/internal/datanode/external/task_update.go
+++ b/internal/datanode/external/task_update.go
@@ -46,6 +46,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
@@ -572,10 +573,11 @@ func (t *UpdateExternalTask) balanceFragmentsToSegments(ctx context.Context, fra
 		}
 
 		seg := &datapb.SegmentInfo{
-			ID:           segmentID,
-			CollectionID: t.req.GetCollectionID(),
-			NumOfRows:    bin.rowCount,
-			ManifestPath: manifestPath,
+			ID:             segmentID,
+			CollectionID:   t.req.GetCollectionID(),
+			NumOfRows:      bin.rowCount,
+			ManifestPath:   manifestPath,
+			StorageVersion: storage.StorageV3,
 		}
 		result = append(result, seg)
 

--- a/internal/datanode/external/task_update_test.go
+++ b/internal/datanode/external/task_update_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
@@ -195,6 +196,8 @@ func (s *UpdateExternalTaskSuite) TestBalanceFragmentsToSegments_SingleFragment(
 	s.NoError(err)
 	s.Len(result, 1)
 	s.Equal(int64(500), result[0].GetNumOfRows())
+	s.Equal(int64(storage.StorageV3), result[0].GetStorageVersion(),
+		"external segments should have StorageVersion=V3")
 }
 
 func (s *UpdateExternalTaskSuite) TestBalanceFragmentsToSegments_MultipleFragments() {
@@ -229,6 +232,12 @@ func (s *UpdateExternalTaskSuite) TestBalanceFragmentsToSegments_MultipleFragmen
 
 	result, err := task.balanceFragmentsToSegments(context.Background(), fragments)
 	s.NoError(err)
+
+	// Verify all segments have StorageVersion=V3
+	for i, seg := range result {
+		s.Equal(int64(storage.StorageV3), seg.GetStorageVersion(),
+			"segment %d should have StorageVersion=V3", i)
+	}
 
 	// Verify total rows are preserved
 	var totalRows int64
@@ -840,15 +849,15 @@ func (s *UpdateExternalTaskSuite) TestParseExternalSpec() {
 	s.NoError(err)
 	s.Equal("parquet", spec.Format)
 
-	// Explicit format
-	spec, err = ParseExternalSpec(`{"format":"csv"}`)
+	// Lance-table format
+	spec, err = ParseExternalSpec(`{"format":"lance-table"}`)
 	s.NoError(err)
-	s.Equal("csv", spec.Format)
+	s.Equal("lance-table", spec.Format)
 
-	// JSON format
-	spec, err = ParseExternalSpec(`{"format":"json"}`)
+	// Vortex format
+	spec, err = ParseExternalSpec(`{"format":"vortex"}`)
 	s.NoError(err)
-	s.Equal("json", spec.Format)
+	s.Equal("vortex", spec.Format)
 
 	// Missing format defaults to parquet
 	spec, err = ParseExternalSpec(`{}`)

--- a/internal/flushcommon/pipeline/flow_graph_write_node.go
+++ b/internal/flushcommon/pipeline/flow_graph_write_node.go
@@ -151,7 +151,7 @@ func newWriteNode(
 	// pkfield is a immutable property of the collection, so we can get it from any schema
 	collSchema := config.metacache.GetSchema(0)
 	pkField, err := typeutil.GetPrimaryFieldSchema(collSchema)
-	if err != nil && !typeutil.IsExternalCollection(collSchema) {
+	if err != nil {
 		return nil, err
 	}
 

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -436,6 +436,12 @@ func (t *createCollectionTask) PreExecute(ctx context.Context) error {
 		return err
 	}
 
+	// External collections must be single-shard: the refresh mechanism assigns all
+	// segments to VChannelNames[0], so multiple shards would leave segments orphaned.
+	if isExternalCollection && t.ShardsNum > 1 {
+		return fmt.Errorf("external collection does not support multiple shards, got ShardsNum=%d", t.ShardsNum)
+	}
+
 	if t.ShardsNum > Params.ProxyCfg.MaxShardNum.GetAsInt32() {
 		return fmt.Errorf("maximum shards's number should be limited to %d", Params.ProxyCfg.MaxShardNum.GetAsInt())
 	}
@@ -459,11 +465,16 @@ func (t *createCollectionTask) PreExecute(ctx context.Context) error {
 		return err
 	}
 
-	// validate primary key definition when needed
-	if !isExternalCollection {
-		if err := validatePrimaryKey(t.schema); err != nil {
+	// For external collections, inject virtual PK field if no PK exists
+	if isExternalCollection {
+		if err := injectVirtualPKForExternalCollection(t.schema); err != nil {
 			return err
 		}
+	}
+
+	// validate primary key definition
+	if err := validatePrimaryKey(t.schema); err != nil {
+		return err
 	}
 
 	// validate dynamic field

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -1784,6 +1784,33 @@ func TestCreateCollectionTaskExternalCollection(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("virtual PK injected after PreExecute", func(t *testing.T) {
+		schema := buildExternalSchema()
+		freshTask := &createCollectionTask{
+			Condition: NewTaskCondition(ctx),
+			CreateCollectionRequest: &milvuspb.CreateCollectionRequest{
+				CollectionName: collectionName,
+				Schema:         marshal(schema),
+				ShardsNum:      common.DefaultShardsNum,
+			},
+			ctx:      ctx,
+			mixCoord: mix,
+		}
+		err := freshTask.OnEnqueue()
+		require.NoError(t, err)
+		err = freshTask.PreExecute(ctx)
+		require.NoError(t, err)
+
+		// After PreExecute, schema should have virtual PK prepended
+		assert.Equal(t, common.VirtualPKFieldName, freshTask.schema.Fields[0].Name)
+		assert.True(t, freshTask.schema.Fields[0].IsPrimaryKey)
+		assert.True(t, freshTask.schema.Fields[0].AutoID)
+		assert.Equal(t, schemapb.DataType_Int64, freshTask.schema.Fields[0].DataType)
+		// Original fields should follow
+		assert.Equal(t, "text_field", freshTask.schema.Fields[1].Name)
+		assert.Equal(t, "vec_field", freshTask.schema.Fields[2].Name)
+	})
+
 	t.Run("functions forbidden", func(t *testing.T) {
 		schema := buildExternalSchema()
 		schema.Functions = []*schemapb.FunctionSchema{{Name: "test_func"}}

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -765,6 +765,34 @@ func validatePrimaryKey(coll *schemapb.CollectionSchema) error {
 	return nil
 }
 
+// injectVirtualPKForExternalCollection adds a virtual PK field for external collections
+// if no primary key field exists. External collections use virtual PKs in the format:
+// (segmentID << 32) | offset
+func injectVirtualPKForExternalCollection(schema *schemapb.CollectionSchema) error {
+	// Check if a primary key already exists
+	for _, field := range schema.Fields {
+		if field.IsPrimaryKey {
+			// PK already exists, nothing to inject
+			return nil
+		}
+	}
+
+	// Create virtual PK field with FieldID=0; RootCoord's assignFieldAndFunctionID
+	// will assign the actual field ID during collection creation.
+	virtualPKField := &schemapb.FieldSchema{
+		Name:         common.VirtualPKFieldName,
+		Description:  "Virtual primary key for external collection: (segmentID << 32) | offset",
+		DataType:     schemapb.DataType_Int64,
+		IsPrimaryKey: true,
+		AutoID:       true, // Virtual PKs are auto-generated
+	}
+
+	// Prepend virtual PK field to the schema fields
+	schema.Fields = append([]*schemapb.FieldSchema{virtualPKField}, schema.Fields...)
+
+	return nil
+}
+
 func validateDynamicField(coll *schemapb.CollectionSchema) error {
 	for _, field := range coll.Fields {
 		if field.IsDynamic {

--- a/internal/proxy/util_test.go
+++ b/internal/proxy/util_test.go
@@ -5345,3 +5345,74 @@ func TestMinHashFunction(t *testing.T) {
 		assert.NoError(t, err)
 	})
 }
+
+func TestInjectVirtualPKForExternalCollection(t *testing.T) {
+	t.Run("NoPKExists_InjectsVirtualPK", func(t *testing.T) {
+		schema := &schemapb.CollectionSchema{
+			Name:           "test_ext_coll",
+			ExternalSource: "s3://bucket/data",
+			Fields: []*schemapb.FieldSchema{
+				{Name: "text", DataType: schemapb.DataType_VarChar, ExternalField: "text_col"},
+				{Name: "vec", DataType: schemapb.DataType_FloatVector, ExternalField: "vec_col"},
+			},
+		}
+
+		err := injectVirtualPKForExternalCollection(schema)
+		assert.NoError(t, err)
+
+		// Virtual PK should be prepended as first field
+		assert.Len(t, schema.Fields, 3)
+		vpk := schema.Fields[0]
+		assert.Equal(t, common.VirtualPKFieldName, vpk.Name)
+		assert.Equal(t, schemapb.DataType_Int64, vpk.DataType)
+		assert.True(t, vpk.IsPrimaryKey)
+		assert.True(t, vpk.AutoID)
+
+		// Original fields remain unchanged
+		assert.Equal(t, "text", schema.Fields[1].Name)
+		assert.Equal(t, "vec", schema.Fields[2].Name)
+	})
+
+	t.Run("PKAlreadyExists_NoInjection", func(t *testing.T) {
+		schema := &schemapb.CollectionSchema{
+			Fields: []*schemapb.FieldSchema{
+				{Name: "my_pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+				{Name: "vec", DataType: schemapb.DataType_FloatVector},
+			},
+		}
+
+		err := injectVirtualPKForExternalCollection(schema)
+		assert.NoError(t, err)
+
+		// No virtual PK injected — only 2 fields remain
+		assert.Len(t, schema.Fields, 2)
+		assert.Equal(t, "my_pk", schema.Fields[0].Name)
+	})
+
+	t.Run("EmptyFields_InjectsVirtualPK", func(t *testing.T) {
+		schema := &schemapb.CollectionSchema{
+			Fields: []*schemapb.FieldSchema{},
+		}
+
+		err := injectVirtualPKForExternalCollection(schema)
+		assert.NoError(t, err)
+
+		assert.Len(t, schema.Fields, 1)
+		assert.Equal(t, common.VirtualPKFieldName, schema.Fields[0].Name)
+		assert.True(t, schema.Fields[0].IsPrimaryKey)
+	})
+
+	t.Run("VirtualPKFieldID_IsZero", func(t *testing.T) {
+		schema := &schemapb.CollectionSchema{
+			Fields: []*schemapb.FieldSchema{
+				{Name: "vec", DataType: schemapb.DataType_FloatVector, ExternalField: "vec_col"},
+			},
+		}
+
+		err := injectVirtualPKForExternalCollection(schema)
+		assert.NoError(t, err)
+
+		// FieldID should be 0 (assigned by RootCoord later)
+		assert.Equal(t, int64(0), schema.Fields[0].FieldID)
+	})
+}

--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -133,7 +133,7 @@ func (sd *shardDelegator) ProcessInsert(insertRecords map[int64]*InsertData) {
 			// panic here, insert failure
 			panic(err)
 		}
-		growing.UpdateBloomFilter(insertData.PrimaryKeys)
+		growing.UpdatePkCandidate(insertData.PrimaryKeys)
 
 		if newGrowingSegment {
 			sd.growingSegmentLock.Lock()

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -1522,7 +1522,7 @@ func (s *DelegatorDataSuite) TestLevel0Deletions() {
 	s.ElementsMatch(rawPks, []storage.PrimaryKey{partitionDeleteData.DeletePks().Get(0), allPartitionDeleteData.DeletePks().Get(0)})
 
 	bfs := pkoracle.NewBloomFilterSet(3, l0.Partition(), commonpb.SegmentState_Sealed)
-	bfs.UpdateBloomFilter([]storage.PrimaryKey{allPartitionDeleteData.DeletePks().Get(0)})
+	bfs.UpdatePkCandidate([]storage.PrimaryKey{allPartitionDeleteData.DeletePks().Get(0)})
 
 	pks, _ = delegator.GetLevel0Deletions(partitionID, bfs)
 	// bf filtered segment

--- a/internal/querynodev2/delegator/distribution.go
+++ b/internal/querynodev2/delegator/distribution.go
@@ -376,12 +376,10 @@ func (d *distribution) AddDistributions(entries ...SegmentEntry) {
 	refundCandidates(toRefund)
 }
 
-// refundCandidates refunds resources for candidates that implement Refundable.
+// refundCandidates refunds resources for removed candidates.
 func refundCandidates(candidates []pkoracle.Candidate) {
 	for _, c := range candidates {
-		if r, ok := c.(pkoracle.Refundable); ok {
-			r.Refund()
-		}
+		c.Refund()
 	}
 }
 

--- a/internal/querynodev2/delegator/distribution_test.go
+++ b/internal/querynodev2/delegator/distribution_test.go
@@ -1693,6 +1693,12 @@ func (m *mockCandidate) Type() commonpb.SegmentState {
 	return commonpb.SegmentState_Sealed
 }
 
+func (m *mockCandidate) PkCandidateExist() bool                   { return true }
+func (m *mockCandidate) UpdatePkCandidate(_ []storage.PrimaryKey) {}
+func (m *mockCandidate) Stats() *storage.PkStatistics             { return nil }
+func (m *mockCandidate) Charge()                                  {}
+func (m *mockCandidate) Refund()                                  {}
+
 func TestBatchGetFromSegments(t *testing.T) {
 	t.Run("basic_sealed_segments", func(t *testing.T) {
 		candidate1 := &mockCandidate{id: 1, partition: 1, hits: []bool{true, false, true}}

--- a/internal/querynodev2/pkoracle/bloom_filter_set.go
+++ b/internal/querynodev2/pkoracle/bloom_filter_set.go
@@ -105,13 +105,13 @@ func (s *BloomFilterSet) Stats() *storage.PkStatistics {
 	return s.currentStat
 }
 
-// Have BloomFilter exist
-func (s *BloomFilterSet) BloomFilterExist() bool {
+// PkCandidateExist reports whether bloom filter data has been loaded (current or historical).
+func (s *BloomFilterSet) PkCandidateExist() bool {
 	return s.currentStat != nil || s.historyStats != nil
 }
 
-// UpdateBloomFilter updates currentStats with provided pks.
-func (s *BloomFilterSet) UpdateBloomFilter(pks []storage.PrimaryKey) {
+// UpdatePkCandidate updates currentStats with provided pks.
+func (s *BloomFilterSet) UpdatePkCandidate(pks []storage.PrimaryKey) {
 	s.statsMutex.Lock()
 	defer s.statsMutex.Unlock()
 

--- a/internal/querynodev2/pkoracle/bloom_filter_set_test.go
+++ b/internal/querynodev2/pkoracle/bloom_filter_set_test.go
@@ -38,7 +38,7 @@ func TestInt64Pk(t *testing.T) {
 	}
 
 	bfs := NewBloomFilterSet(1, 1, commonpb.SegmentState_Sealed)
-	bfs.UpdateBloomFilter(pks)
+	bfs.UpdatePkCandidate(pks)
 
 	for i := 0; i < batchSize; i++ {
 		lc := storage.NewLocationsCache(pks[i])
@@ -62,7 +62,7 @@ func TestVarCharPk(t *testing.T) {
 	}
 
 	bfs := NewBloomFilterSet(1, 1, commonpb.SegmentState_Sealed)
-	bfs.UpdateBloomFilter(pks)
+	bfs.UpdatePkCandidate(pks)
 
 	for i := 0; i < batchSize; i++ {
 		lc := storage.NewLocationsCache(pks[i])
@@ -81,7 +81,7 @@ func TestHistoricalStat(t *testing.T) {
 	}
 
 	bfs := NewBloomFilterSet(1, 1, commonpb.SegmentState_Sealed)
-	bfs.UpdateBloomFilter(pks)
+	bfs.UpdatePkCandidate(pks)
 
 	// mock historical bf
 	bfs.AddHistoricalStats(bfs.currentStat)
@@ -119,7 +119,7 @@ func TestMemSize(t *testing.T) {
 		}
 
 		bfs := NewBloomFilterSet(1, 1, commonpb.SegmentState_Sealed)
-		bfs.UpdateBloomFilter(pks)
+		bfs.UpdatePkCandidate(pks)
 
 		size := bfs.MemSize()
 		assert.Greater(t, size, int64(0))
@@ -138,7 +138,7 @@ func TestMemSize(t *testing.T) {
 		}
 
 		bfs := NewBloomFilterSet(1, 1, commonpb.SegmentState_Sealed)
-		bfs.UpdateBloomFilter(pks)
+		bfs.UpdatePkCandidate(pks)
 
 		currentSize := bfs.MemSize()
 
@@ -161,7 +161,7 @@ func TestMemSize(t *testing.T) {
 		}
 
 		bfs := NewBloomFilterSet(1, 1, commonpb.SegmentState_Sealed)
-		bfs.UpdateBloomFilter(pks)
+		bfs.UpdatePkCandidate(pks)
 
 		singleSize := bfs.MemSize()
 
@@ -182,7 +182,7 @@ func TestMemSize(t *testing.T) {
 		}
 
 		bfs := NewBloomFilterSet(1, 1, commonpb.SegmentState_Sealed)
-		bfs.UpdateBloomFilter(pks)
+		bfs.UpdatePkCandidate(pks)
 
 		size := bfs.MemSize()
 		assert.Greater(t, size, int64(0))

--- a/internal/querynodev2/pkoracle/candidate.go
+++ b/internal/querynodev2/pkoracle/candidate.go
@@ -24,6 +24,15 @@ import (
 )
 
 // Candidate is the interface for pk oracle candidate.
+//
+// Core methods (all implementers must provide meaningful logic):
+//
+//	MayPkExist, BatchPkExist, ID, Partition, Type, PkCandidateExist
+//
+// Resource lifecycle methods (no-op is a valid implementation for candidates
+// that don't track resources, e.g. ExternalSegmentCandidate, candidateKey):
+//
+//	UpdatePkCandidate, Stats, Charge, Refund
 type Candidate interface {
 	// MayPkExist checks whether primary key could exists in this candidate.
 	MayPkExist(lc *storage.LocationsCache) bool
@@ -32,11 +41,27 @@ type Candidate interface {
 	ID() int64
 	Partition() int64
 	Type() commonpb.SegmentState
-}
 
-// Refundable is an optional interface for candidates that need resource cleanup.
-// BloomFilterSet implements this interface to refund charged memory resources.
-type Refundable interface {
+	// PkCandidateExist reports whether the candidate has been initialized with PK data.
+	// This is a precondition for MayPkExist / BatchPkExist calls.
+	// BloomFilterSet: true when bloom filter data has been loaded.
+	// ExternalSegmentCandidate: always true (deterministic PK-to-segment mapping).
+	PkCandidateExist() bool
+
+	// UpdatePkCandidate feeds new primary keys into the candidate.
+	// BloomFilterSet: updates the bloom filter with the provided keys.
+	// ExternalSegmentCandidate: no-op (virtual PKs are deterministic).
+	UpdatePkCandidate(pks []storage.PrimaryKey)
+
+	// Stats returns PK statistics (min/max PK) if available, nil otherwise.
+	Stats() *storage.PkStatistics
+
+	// Charge charges memory resources consumed by this candidate.
+	// No-op is valid for candidates without trackable resources.
+	Charge()
+
+	// Refund releases memory resources previously charged by this candidate.
+	// No-op is valid for candidates without trackable resources.
 	Refund()
 }
 

--- a/internal/querynodev2/pkoracle/external_segment_candidate.go
+++ b/internal/querynodev2/pkoracle/external_segment_candidate.go
@@ -45,14 +45,20 @@ func NewExternalSegmentCandidate(segmentID int64, partitionID int64, segType com
 	}
 }
 
+// extractSegmentIDFromVirtualPK extracts the truncated segment ID from a virtual PK.
+// Virtual PK format: (truncated_segmentID << 32) | offset.
+// Uses unsigned right shift to avoid sign-extension for large segment IDs.
+func extractSegmentIDFromVirtualPK(virtualPK int64) int64 {
+	return int64(uint64(virtualPK) >> 32)
+}
+
 // MayPkExist checks if the primary key could exist in this segment.
 // For external collections, virtual PK format is (segmentID << 32) | offset,
 // so we determine segment membership by extracting segmentID from the PK.
 func (c *ExternalSegmentCandidate) MayPkExist(lc *storage.LocationsCache) bool {
 	pk := lc.GetPk()
 	if int64Pk, ok := pk.(*storage.Int64PrimaryKey); ok {
-		extractedSegmentID := int64(uint64(int64Pk.Value) >> 32)
-		return extractedSegmentID == c.truncatedSegmentID
+		return extractSegmentIDFromVirtualPK(int64Pk.Value) == c.truncatedSegmentID
 	}
 	// External collections only support int64 virtual PK
 	return false
@@ -65,8 +71,7 @@ func (c *ExternalSegmentCandidate) BatchPkExist(lc *storage.BatchLocationsCache)
 
 	for i, pk := range pks {
 		if int64Pk, ok := pk.(*storage.Int64PrimaryKey); ok {
-			extractedSegmentID := int64(uint64(int64Pk.Value) >> 32)
-			hits[i] = extractedSegmentID == c.truncatedSegmentID
+			hits[i] = extractSegmentIDFromVirtualPK(int64Pk.Value) == c.truncatedSegmentID
 		}
 	}
 

--- a/internal/querynodev2/pkoracle/external_segment_candidate.go
+++ b/internal/querynodev2/pkoracle/external_segment_candidate.go
@@ -1,0 +1,108 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkoracle
+
+import (
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus/internal/storage"
+)
+
+var _ Candidate = (*ExternalSegmentCandidate)(nil)
+
+// ExternalSegmentCandidate is a Candidate implementation for external collections.
+// External collections use virtual PKs in the format: (segmentID << 32) | offset.
+// Instead of using bloom filters, this candidate uses segment-based PK matching:
+// a PK belongs to this segment if (pk >> 32) == (segmentID & 0xFFFFFFFF).
+// Note: Only the lower 32 bits of segmentID are preserved in the virtual PK.
+type ExternalSegmentCandidate struct {
+	segmentID          int64
+	truncatedSegmentID int64 // Lower 32 bits of segmentID for comparison with virtual PK
+	partitionID        int64
+	segType            commonpb.SegmentState
+}
+
+// NewExternalSegmentCandidate creates a new ExternalSegmentCandidate.
+func NewExternalSegmentCandidate(segmentID int64, partitionID int64, segType commonpb.SegmentState) *ExternalSegmentCandidate {
+	return &ExternalSegmentCandidate{
+		segmentID:          segmentID,
+		truncatedSegmentID: segmentID & 0xFFFFFFFF, // Keep only lower 32 bits
+		partitionID:        partitionID,
+		segType:            segType,
+	}
+}
+
+// MayPkExist checks if the primary key could exist in this segment.
+// For external collections, virtual PK format is (segmentID << 32) | offset,
+// so we determine segment membership by extracting segmentID from the PK.
+func (c *ExternalSegmentCandidate) MayPkExist(lc *storage.LocationsCache) bool {
+	pk := lc.GetPk()
+	if int64Pk, ok := pk.(*storage.Int64PrimaryKey); ok {
+		extractedSegmentID := int64(uint64(int64Pk.Value) >> 32)
+		return extractedSegmentID == c.truncatedSegmentID
+	}
+	// External collections only support int64 virtual PK
+	return false
+}
+
+// BatchPkExist checks if multiple primary keys could exist in this segment.
+func (c *ExternalSegmentCandidate) BatchPkExist(lc *storage.BatchLocationsCache) []bool {
+	pks := lc.PKs()
+	hits := make([]bool, len(pks))
+
+	for i, pk := range pks {
+		if int64Pk, ok := pk.(*storage.Int64PrimaryKey); ok {
+			extractedSegmentID := int64(uint64(int64Pk.Value) >> 32)
+			hits[i] = extractedSegmentID == c.truncatedSegmentID
+		}
+	}
+
+	return hits
+}
+
+// ID returns the segment ID.
+func (c *ExternalSegmentCandidate) ID() int64 {
+	return c.segmentID
+}
+
+// Partition returns the partition ID.
+func (c *ExternalSegmentCandidate) Partition() int64 {
+	return c.partitionID
+}
+
+// Type returns the segment type.
+func (c *ExternalSegmentCandidate) Type() commonpb.SegmentState {
+	return c.segType
+}
+
+// PkCandidateExist returns true — external candidates are always ready (deterministic PK mapping).
+func (c *ExternalSegmentCandidate) PkCandidateExist() bool {
+	return true
+}
+
+// UpdatePkCandidate is a no-op for external candidates (virtual PKs are deterministic).
+func (c *ExternalSegmentCandidate) UpdatePkCandidate(_ []storage.PrimaryKey) {}
+
+// Stats returns nil — external candidates have no PK statistics.
+func (c *ExternalSegmentCandidate) Stats() *storage.PkStatistics {
+	return nil
+}
+
+// Charge is a no-op for external candidates (no bloom filter memory to track).
+func (c *ExternalSegmentCandidate) Charge() {}
+
+// Refund is a no-op for external candidates (no resources to refund).
+func (c *ExternalSegmentCandidate) Refund() {}

--- a/internal/querynodev2/pkoracle/external_segment_candidate_test.go
+++ b/internal/querynodev2/pkoracle/external_segment_candidate_test.go
@@ -1,0 +1,239 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkoracle
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus/internal/storage"
+)
+
+// Helper function to create virtual PK: ((segmentID & 0xFFFFFFFF) << 32) | (offset & 0xFFFFFFFF)
+// Must match the production GetVirtualPK encoding which truncates segmentID to 32 bits.
+func createVirtualPK(segmentID int64, offset int64) int64 {
+	return ((segmentID & 0xFFFFFFFF) << 32) | (offset & 0xFFFFFFFF)
+}
+
+func TestNewExternalSegmentCandidate(t *testing.T) {
+	segmentID := int64(12345)
+	partitionID := int64(100)
+	segType := commonpb.SegmentState_Sealed
+
+	candidate := NewExternalSegmentCandidate(segmentID, partitionID, segType)
+
+	assert.Equal(t, segmentID, candidate.ID())
+	assert.Equal(t, partitionID, candidate.Partition())
+	assert.Equal(t, segType, candidate.Type())
+	assert.Equal(t, segmentID&0xFFFFFFFF, candidate.truncatedSegmentID)
+}
+
+func TestExternalSegmentCandidate_MayPkExist(t *testing.T) {
+	segmentID := int64(100)
+	partitionID := int64(1)
+	candidate := NewExternalSegmentCandidate(segmentID, partitionID, commonpb.SegmentState_Sealed)
+
+	// Test with PK from this segment
+	virtualPK := createVirtualPK(segmentID, 42)
+	pk := storage.NewInt64PrimaryKey(virtualPK)
+	lc := storage.NewLocationsCache(pk)
+	assert.True(t, candidate.MayPkExist(lc))
+
+	// Test with PK from different segment
+	differentPK := createVirtualPK(segmentID+1, 42)
+	pk2 := storage.NewInt64PrimaryKey(differentPK)
+	lc2 := storage.NewLocationsCache(pk2)
+	assert.False(t, candidate.MayPkExist(lc2))
+
+	// Test with PK from segment 0
+	zeroPK := createVirtualPK(0, 42)
+	pk3 := storage.NewInt64PrimaryKey(zeroPK)
+	lc3 := storage.NewLocationsCache(pk3)
+	assert.False(t, candidate.MayPkExist(lc3))
+}
+
+func TestExternalSegmentCandidate_MayPkExist_LargeSegmentID(t *testing.T) {
+	// Test with segment ID that exceeds 32 bits
+	segmentID := int64(0x100000001) // 33-bit value, lower 32 bits = 1
+	partitionID := int64(1)
+	candidate := NewExternalSegmentCandidate(segmentID, partitionID, commonpb.SegmentState_Sealed)
+
+	// Truncated segment ID should be 1
+	assert.Equal(t, int64(1), candidate.truncatedSegmentID)
+
+	// Virtual PK created with truncated segment ID should match
+	virtualPK := createVirtualPK(1, 100)
+	pk := storage.NewInt64PrimaryKey(virtualPK)
+	lc := storage.NewLocationsCache(pk)
+	assert.True(t, candidate.MayPkExist(lc))
+
+	// Virtual PK created with different segment should not match
+	differentPK := createVirtualPK(2, 100)
+	pk2 := storage.NewInt64PrimaryKey(differentPK)
+	lc2 := storage.NewLocationsCache(pk2)
+	assert.False(t, candidate.MayPkExist(lc2))
+}
+
+func TestExternalSegmentCandidate_MayPkExist_VarCharPK(t *testing.T) {
+	segmentID := int64(100)
+	partitionID := int64(1)
+	candidate := NewExternalSegmentCandidate(segmentID, partitionID, commonpb.SegmentState_Sealed)
+
+	// VarChar PKs should always return false for external collections
+	pk := storage.NewVarCharPrimaryKey("test-pk")
+	lc := storage.NewLocationsCache(pk)
+	assert.False(t, candidate.MayPkExist(lc))
+}
+
+func TestExternalSegmentCandidate_BatchPkExist(t *testing.T) {
+	segmentID := int64(100)
+	partitionID := int64(1)
+	candidate := NewExternalSegmentCandidate(segmentID, partitionID, commonpb.SegmentState_Sealed)
+
+	// Create a batch of PKs
+	pks := []storage.PrimaryKey{
+		storage.NewInt64PrimaryKey(createVirtualPK(segmentID, 0)),   // Match
+		storage.NewInt64PrimaryKey(createVirtualPK(segmentID, 10)),  // Match
+		storage.NewInt64PrimaryKey(createVirtualPK(segmentID+1, 0)), // No match
+		storage.NewInt64PrimaryKey(createVirtualPK(segmentID, 100)), // Match
+		storage.NewInt64PrimaryKey(createVirtualPK(0, 0)),           // No match
+	}
+
+	lc := storage.NewBatchLocationsCache(pks)
+	results := candidate.BatchPkExist(lc)
+
+	assert.Equal(t, len(pks), len(results))
+	assert.True(t, results[0])  // Match
+	assert.True(t, results[1])  // Match
+	assert.False(t, results[2]) // No match (different segment)
+	assert.True(t, results[3])  // Match
+	assert.False(t, results[4]) // No match (segment 0)
+}
+
+func TestExternalSegmentCandidate_BatchPkExist_AllMatch(t *testing.T) {
+	segmentID := int64(50)
+	partitionID := int64(1)
+	candidate := NewExternalSegmentCandidate(segmentID, partitionID, commonpb.SegmentState_Sealed)
+
+	// All PKs from this segment
+	pks := make([]storage.PrimaryKey, 100)
+	for i := 0; i < 100; i++ {
+		pks[i] = storage.NewInt64PrimaryKey(createVirtualPK(segmentID, int64(i)))
+	}
+
+	lc := storage.NewBatchLocationsCache(pks)
+	results := candidate.BatchPkExist(lc)
+
+	for i, result := range results {
+		assert.True(t, result, "Expected PK at index %d to match", i)
+	}
+}
+
+func TestExternalSegmentCandidate_BatchPkExist_NoneMatch(t *testing.T) {
+	segmentID := int64(50)
+	partitionID := int64(1)
+	candidate := NewExternalSegmentCandidate(segmentID, partitionID, commonpb.SegmentState_Sealed)
+
+	// All PKs from different segment
+	pks := make([]storage.PrimaryKey, 100)
+	for i := 0; i < 100; i++ {
+		pks[i] = storage.NewInt64PrimaryKey(createVirtualPK(segmentID+1, int64(i)))
+	}
+
+	lc := storage.NewBatchLocationsCache(pks)
+	results := candidate.BatchPkExist(lc)
+
+	for i, result := range results {
+		assert.False(t, result, "Expected PK at index %d to not match", i)
+	}
+}
+
+func TestExternalSegmentCandidate_BatchPkExist_MixedTypes(t *testing.T) {
+	segmentID := int64(100)
+	partitionID := int64(1)
+	candidate := NewExternalSegmentCandidate(segmentID, partitionID, commonpb.SegmentState_Sealed)
+
+	// Mix of Int64 and VarChar PKs
+	pks := []storage.PrimaryKey{
+		storage.NewInt64PrimaryKey(createVirtualPK(segmentID, 0)), // Match
+		storage.NewVarCharPrimaryKey("test1"),                     // No match (wrong type)
+		storage.NewInt64PrimaryKey(createVirtualPK(segmentID, 1)), // Match
+		storage.NewVarCharPrimaryKey("test2"),                     // No match (wrong type)
+	}
+
+	lc := storage.NewBatchLocationsCache(pks)
+	results := candidate.BatchPkExist(lc)
+
+	assert.True(t, results[0])  // Int64 match
+	assert.False(t, results[1]) // VarChar no match
+	assert.True(t, results[2])  // Int64 match
+	assert.False(t, results[3]) // VarChar no match
+}
+
+func TestExternalSegmentCandidate_CandidateInterface(t *testing.T) {
+	// Verify that ExternalSegmentCandidate implements Candidate interface
+	var _ Candidate = (*ExternalSegmentCandidate)(nil)
+
+	segmentID := int64(123)
+	partitionID := int64(456)
+	segType := commonpb.SegmentState_Growing
+
+	candidate := NewExternalSegmentCandidate(segmentID, partitionID, segType)
+
+	// Test interface methods
+	assert.Equal(t, segmentID, candidate.ID())
+	assert.Equal(t, partitionID, candidate.Partition())
+	assert.Equal(t, segType, candidate.Type())
+}
+
+func TestExternalSegmentCandidate_EdgeCases(t *testing.T) {
+	t.Run("ZeroSegmentID", func(t *testing.T) {
+		candidate := NewExternalSegmentCandidate(0, 0, commonpb.SegmentState_Sealed)
+
+		// PK from segment 0 should match
+		pk := storage.NewInt64PrimaryKey(createVirtualPK(0, 42))
+		lc := storage.NewLocationsCache(pk)
+		assert.True(t, candidate.MayPkExist(lc))
+
+		// PK from segment 1 should not match
+		pk2 := storage.NewInt64PrimaryKey(createVirtualPK(1, 42))
+		lc2 := storage.NewLocationsCache(pk2)
+		assert.False(t, candidate.MayPkExist(lc2))
+	})
+
+	t.Run("MaxOffset", func(t *testing.T) {
+		segmentID := int64(100)
+		candidate := NewExternalSegmentCandidate(segmentID, 0, commonpb.SegmentState_Sealed)
+
+		// Max 32-bit offset
+		maxOffset := int64(0xFFFFFFFF)
+		pk := storage.NewInt64PrimaryKey(createVirtualPK(segmentID, maxOffset))
+		lc := storage.NewLocationsCache(pk)
+		assert.True(t, candidate.MayPkExist(lc))
+	})
+
+	t.Run("EmptyBatch", func(t *testing.T) {
+		candidate := NewExternalSegmentCandidate(100, 0, commonpb.SegmentState_Sealed)
+
+		pks := []storage.PrimaryKey{}
+		lc := storage.NewBatchLocationsCache(pks)
+		results := candidate.BatchPkExist(lc)
+		assert.Empty(t, results)
+	})
+}

--- a/internal/querynodev2/pkoracle/external_segment_candidate_test.go
+++ b/internal/querynodev2/pkoracle/external_segment_candidate_test.go
@@ -200,6 +200,17 @@ func TestExternalSegmentCandidate_CandidateInterface(t *testing.T) {
 	assert.Equal(t, segmentID, candidate.ID())
 	assert.Equal(t, partitionID, candidate.Partition())
 	assert.Equal(t, segType, candidate.Type())
+
+	// PkCandidateExist: always true for external candidates
+	assert.True(t, candidate.PkCandidateExist())
+
+	// Stats: always nil for external candidates
+	assert.Nil(t, candidate.Stats())
+
+	// No-op methods: should not panic
+	candidate.UpdatePkCandidate([]storage.PrimaryKey{storage.NewInt64PrimaryKey(1)})
+	candidate.Charge()
+	candidate.Refund()
 }
 
 func TestExternalSegmentCandidate_EdgeCases(t *testing.T) {

--- a/internal/querynodev2/pkoracle/key.go
+++ b/internal/querynodev2/pkoracle/key.go
@@ -56,6 +56,12 @@ func (k candidateKey) Type() commonpb.SegmentState {
 	return k.typ
 }
 
+func (k candidateKey) PkCandidateExist() bool                   { return true }
+func (k candidateKey) UpdatePkCandidate(_ []storage.PrimaryKey) {}
+func (k candidateKey) Stats() *storage.PkStatistics             { return nil }
+func (k candidateKey) Charge()                                  {}
+func (k candidateKey) Refund()                                  {}
+
 // NewCandidateKey creates a candidateKey and returns as Candidate.
 func NewCandidateKey(id int64, partitionID int64, typ commonpb.SegmentState) Candidate {
 	return candidateKey{

--- a/internal/querynodev2/pkoracle/pk_oracle.go
+++ b/internal/querynodev2/pkoracle/pk_oracle.go
@@ -134,24 +134,19 @@ func (pko *pkOracle) Range(fn func(candidate Candidate) bool) {
 	})
 }
 
-// RefundRemoved refunds resources for BloomFilterSet candidates.
-// For candidates that are not BloomFilterSet (e.g., LocalSegment), this is a no-op.
+// RefundRemoved refunds resources for removed candidates.
 func (pko *pkOracle) RefundRemoved(candidates []Candidate) {
 	for _, candidate := range candidates {
-		if bfs, ok := candidate.(*BloomFilterSet); ok {
-			bfs.Refund()
-		}
+		candidate.Refund()
 	}
 }
 
-// RemoveAndRefundAll removes all candidates and refunds resources for BloomFilterSet candidates.
+// RemoveAndRefundAll removes all candidates and refunds their resources.
 // Used during shutdown to clean up and refund resources.
 func (pko *pkOracle) RemoveAndRefundAll() {
 	removed := pko.Remove()
 	for _, candidate := range removed {
-		if bfs, ok := candidate.(*BloomFilterSet); ok {
-			bfs.Refund()
-		}
+		candidate.Refund()
 	}
 }
 

--- a/internal/querynodev2/pkoracle/pk_oracle_test.go
+++ b/internal/querynodev2/pkoracle/pk_oracle_test.go
@@ -38,7 +38,7 @@ func TestGet(t *testing.T) {
 	}
 
 	bfs := NewBloomFilterSet(1, 1, commonpb.SegmentState_Sealed)
-	bfs.UpdateBloomFilter(pks)
+	bfs.UpdatePkCandidate(pks)
 	pko.Register(bfs, 1)
 
 	ret := pko.Exists(bfs, 1)
@@ -78,7 +78,7 @@ func TestRemoveReturnsRemovedCandidates(t *testing.T) {
 		}
 
 		bfs := NewBloomFilterSet(1, 1, commonpb.SegmentState_Sealed)
-		bfs.UpdateBloomFilter(pks)
+		bfs.UpdatePkCandidate(pks)
 		pko.Register(bfs, 1)
 
 		removed := pko.Remove(WithSegmentIDs(1))
@@ -98,15 +98,15 @@ func TestRemoveReturnsRemovedCandidates(t *testing.T) {
 
 		// Register multiple candidates
 		bfs1 := NewBloomFilterSet(1, 1, commonpb.SegmentState_Sealed)
-		bfs1.UpdateBloomFilter(pks)
+		bfs1.UpdatePkCandidate(pks)
 		pko.Register(bfs1, 1)
 
 		bfs2 := NewBloomFilterSet(2, 1, commonpb.SegmentState_Sealed)
-		bfs2.UpdateBloomFilter(pks)
+		bfs2.UpdatePkCandidate(pks)
 		pko.Register(bfs2, 1)
 
 		bfs3 := NewBloomFilterSet(3, 1, commonpb.SegmentState_Sealed)
-		bfs3.UpdateBloomFilter(pks)
+		bfs3.UpdatePkCandidate(pks)
 		pko.Register(bfs3, 1)
 
 		// Remove multiple segments
@@ -143,12 +143,12 @@ func TestRemoveReturnsRemovedCandidates(t *testing.T) {
 
 		// Register sealed segment
 		bfsSealed := NewBloomFilterSet(1, 1, commonpb.SegmentState_Sealed)
-		bfsSealed.UpdateBloomFilter(pks)
+		bfsSealed.UpdatePkCandidate(pks)
 		pko.Register(bfsSealed, 1)
 
 		// Register growing segment
 		bfsGrowing := NewBloomFilterSet(2, 1, commonpb.SegmentState_Growing)
-		bfsGrowing.UpdateBloomFilter(pks)
+		bfsGrowing.UpdatePkCandidate(pks)
 		pko.Register(bfsGrowing, 1)
 
 		// Remove only sealed segments
@@ -172,11 +172,11 @@ func TestRemoveReturnsRemovedCandidates(t *testing.T) {
 
 		// Register on different workers
 		bfs1 := NewBloomFilterSet(1, 1, commonpb.SegmentState_Sealed)
-		bfs1.UpdateBloomFilter(pks)
+		bfs1.UpdatePkCandidate(pks)
 		pko.Register(bfs1, 1)
 
 		bfs2 := NewBloomFilterSet(2, 1, commonpb.SegmentState_Sealed)
-		bfs2.UpdateBloomFilter(pks)
+		bfs2.UpdatePkCandidate(pks)
 		pko.Register(bfs2, 2)
 
 		// Remove only from worker 1
@@ -201,7 +201,7 @@ func TestRemoveReturnsRemovedCandidates(t *testing.T) {
 		// Register multiple candidates
 		for i := 0; i < 5; i++ {
 			bfs := NewBloomFilterSet(int64(i), 1, commonpb.SegmentState_Sealed)
-			bfs.UpdateBloomFilter(pks)
+			bfs.UpdatePkCandidate(pks)
 			pko.Register(bfs, 1)
 		}
 
@@ -234,10 +234,10 @@ func TestRefundRemoved(t *testing.T) {
 
 		// Create bloom filter sets (not charged, so Refund() is a no-op)
 		bfs1 := NewBloomFilterSet(1, 1, commonpb.SegmentState_Sealed)
-		bfs1.UpdateBloomFilter(pks)
+		bfs1.UpdatePkCandidate(pks)
 
 		bfs2 := NewBloomFilterSet(2, 1, commonpb.SegmentState_Sealed)
-		bfs2.UpdateBloomFilter(pks)
+		bfs2.UpdatePkCandidate(pks)
 
 		candidates := []Candidate{bfs1, bfs2}
 
@@ -268,11 +268,11 @@ func TestRemoveAndRefundAll(t *testing.T) {
 
 		// Create and register bloom filter sets (not charged)
 		bfs1 := NewBloomFilterSet(1, 1, commonpb.SegmentState_Sealed)
-		bfs1.UpdateBloomFilter(pks)
+		bfs1.UpdatePkCandidate(pks)
 		pko.Register(bfs1, 1)
 
 		bfs2 := NewBloomFilterSet(2, 1, commonpb.SegmentState_Sealed)
-		bfs2.UpdateBloomFilter(pks)
+		bfs2.UpdatePkCandidate(pks)
 		pko.Register(bfs2, 1)
 
 		// Should not panic - Refund() returns early when not charged

--- a/internal/querynodev2/segments/mock_segment.go
+++ b/internal/querynodev2/segments/mock_segment.go
@@ -87,51 +87,6 @@ func (_c *MockSegment_BatchPkExist_Call) RunAndReturn(run func(*storage.BatchLoc
 	return _c
 }
 
-// BloomFilterExist provides a mock function with no fields
-func (_m *MockSegment) BloomFilterExist() bool {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for BloomFilterExist")
-	}
-
-	var r0 bool
-	if rf, ok := ret.Get(0).(func() bool); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-
-	return r0
-}
-
-// MockSegment_BloomFilterExist_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BloomFilterExist'
-type MockSegment_BloomFilterExist_Call struct {
-	*mock.Call
-}
-
-// BloomFilterExist is a helper method to define mock.On call
-func (_e *MockSegment_Expecter) BloomFilterExist() *MockSegment_BloomFilterExist_Call {
-	return &MockSegment_BloomFilterExist_Call{Call: _e.mock.On("BloomFilterExist")}
-}
-
-func (_c *MockSegment_BloomFilterExist_Call) Run(run func()) *MockSegment_BloomFilterExist_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *MockSegment_BloomFilterExist_Call) Return(_a0 bool) *MockSegment_BloomFilterExist_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockSegment_BloomFilterExist_Call) RunAndReturn(run func() bool) *MockSegment_BloomFilterExist_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // CASVersion provides a mock function with given fields: _a0, _a1
 func (_m *MockSegment) CASVersion(_a0 int64, _a1 int64) bool {
 	ret := _m.Called(_a0, _a1)
@@ -176,6 +131,38 @@ func (_c *MockSegment_CASVersion_Call) Return(_a0 bool) *MockSegment_CASVersion_
 
 func (_c *MockSegment_CASVersion_Call) RunAndReturn(run func(int64, int64) bool) *MockSegment_CASVersion_Call {
 	_c.Call.Return(run)
+	return _c
+}
+
+// Charge provides a mock function with no fields
+func (_m *MockSegment) Charge() {
+	_m.Called()
+}
+
+// MockSegment_Charge_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Charge'
+type MockSegment_Charge_Call struct {
+	*mock.Call
+}
+
+// Charge is a helper method to define mock.On call
+func (_e *MockSegment_Expecter) Charge() *MockSegment_Charge_Call {
+	return &MockSegment_Charge_Call{Call: _e.mock.On("Charge")}
+}
+
+func (_c *MockSegment_Charge_Call) Run(run func()) *MockSegment_Charge_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockSegment_Charge_Call) Return() *MockSegment_Charge_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockSegment_Charge_Call) RunAndReturn(run func()) *MockSegment_Charge_Call {
+	_c.Run(run)
 	return _c
 }
 
@@ -1427,6 +1414,83 @@ func (_c *MockSegment_PinIfNotReleased_Call) RunAndReturn(run func() error) *Moc
 	return _c
 }
 
+// PkCandidateExist provides a mock function with no fields
+func (_m *MockSegment) PkCandidateExist() bool {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for PkCandidateExist")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// MockSegment_PkCandidateExist_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PkCandidateExist'
+type MockSegment_PkCandidateExist_Call struct {
+	*mock.Call
+}
+
+// PkCandidateExist is a helper method to define mock.On call
+func (_e *MockSegment_Expecter) PkCandidateExist() *MockSegment_PkCandidateExist_Call {
+	return &MockSegment_PkCandidateExist_Call{Call: _e.mock.On("PkCandidateExist")}
+}
+
+func (_c *MockSegment_PkCandidateExist_Call) Run(run func()) *MockSegment_PkCandidateExist_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockSegment_PkCandidateExist_Call) Return(_a0 bool) *MockSegment_PkCandidateExist_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockSegment_PkCandidateExist_Call) RunAndReturn(run func() bool) *MockSegment_PkCandidateExist_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// Refund provides a mock function with no fields
+func (_m *MockSegment) Refund() {
+	_m.Called()
+}
+
+// MockSegment_Refund_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Refund'
+type MockSegment_Refund_Call struct {
+	*mock.Call
+}
+
+// Refund is a helper method to define mock.On call
+func (_e *MockSegment_Expecter) Refund() *MockSegment_Refund_Call {
+	return &MockSegment_Refund_Call{Call: _e.mock.On("Refund")}
+}
+
+func (_c *MockSegment_Refund_Call) Run(run func()) *MockSegment_Refund_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockSegment_Refund_Call) Return() *MockSegment_Refund_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockSegment_Refund_Call) RunAndReturn(run func()) *MockSegment_Refund_Call {
+	_c.Run(run)
+	return _c
+}
+
 // Release provides a mock function with given fields: ctx, opts
 func (_m *MockSegment) Release(ctx context.Context, opts ...releaseOption) {
 	_va := make([]interface{}, len(opts))
@@ -1912,35 +1976,35 @@ func (_c *MockSegment_Search_Call) RunAndReturn(run func(context.Context, *segco
 	return _c
 }
 
-// SetBloomFilter provides a mock function with given fields: bf
-func (_m *MockSegment) SetBloomFilter(bf *pkoracle.BloomFilterSet) {
-	_m.Called(bf)
+// SetPKCandidate provides a mock function with given fields: candidate
+func (_m *MockSegment) SetPKCandidate(candidate pkoracle.Candidate) {
+	_m.Called(candidate)
 }
 
-// MockSegment_SetBloomFilter_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetBloomFilter'
-type MockSegment_SetBloomFilter_Call struct {
+// MockSegment_SetPKCandidate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetPKCandidate'
+type MockSegment_SetPKCandidate_Call struct {
 	*mock.Call
 }
 
-// SetBloomFilter is a helper method to define mock.On call
-//   - bf *pkoracle.BloomFilterSet
-func (_e *MockSegment_Expecter) SetBloomFilter(bf interface{}) *MockSegment_SetBloomFilter_Call {
-	return &MockSegment_SetBloomFilter_Call{Call: _e.mock.On("SetBloomFilter", bf)}
+// SetPKCandidate is a helper method to define mock.On call
+//   - candidate pkoracle.Candidate
+func (_e *MockSegment_Expecter) SetPKCandidate(candidate interface{}) *MockSegment_SetPKCandidate_Call {
+	return &MockSegment_SetPKCandidate_Call{Call: _e.mock.On("SetPKCandidate", candidate)}
 }
 
-func (_c *MockSegment_SetBloomFilter_Call) Run(run func(bf *pkoracle.BloomFilterSet)) *MockSegment_SetBloomFilter_Call {
+func (_c *MockSegment_SetPKCandidate_Call) Run(run func(candidate pkoracle.Candidate)) *MockSegment_SetPKCandidate_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*pkoracle.BloomFilterSet))
+		run(args[0].(pkoracle.Candidate))
 	})
 	return _c
 }
 
-func (_c *MockSegment_SetBloomFilter_Call) Return() *MockSegment_SetBloomFilter_Call {
+func (_c *MockSegment_SetPKCandidate_Call) Return() *MockSegment_SetPKCandidate_Call {
 	_c.Call.Return()
 	return _c
 }
 
-func (_c *MockSegment_SetBloomFilter_Call) RunAndReturn(run func(*pkoracle.BloomFilterSet)) *MockSegment_SetBloomFilter_Call {
+func (_c *MockSegment_SetPKCandidate_Call) RunAndReturn(run func(pkoracle.Candidate)) *MockSegment_SetPKCandidate_Call {
 	_c.Run(run)
 	return _c
 }
@@ -2033,6 +2097,53 @@ func (_c *MockSegment_StartPosition_Call) Return(_a0 *msgpb.MsgPosition) *MockSe
 }
 
 func (_c *MockSegment_StartPosition_Call) RunAndReturn(run func() *msgpb.MsgPosition) *MockSegment_StartPosition_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// Stats provides a mock function with no fields
+func (_m *MockSegment) Stats() *storage.PkStatistics {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Stats")
+	}
+
+	var r0 *storage.PkStatistics
+	if rf, ok := ret.Get(0).(func() *storage.PkStatistics); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*storage.PkStatistics)
+		}
+	}
+
+	return r0
+}
+
+// MockSegment_Stats_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Stats'
+type MockSegment_Stats_Call struct {
+	*mock.Call
+}
+
+// Stats is a helper method to define mock.On call
+func (_e *MockSegment_Expecter) Stats() *MockSegment_Stats_Call {
+	return &MockSegment_Stats_Call{Call: _e.mock.On("Stats")}
+}
+
+func (_c *MockSegment_Stats_Call) Run(run func()) *MockSegment_Stats_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockSegment_Stats_Call) Return(_a0 *storage.PkStatistics) *MockSegment_Stats_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockSegment_Stats_Call) RunAndReturn(run func() *storage.PkStatistics) *MockSegment_Stats_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -2147,35 +2258,35 @@ func (_c *MockSegment_UpdateBM25Stats_Call) RunAndReturn(run func(map[int64]*sto
 	return _c
 }
 
-// UpdateBloomFilter provides a mock function with given fields: pks
-func (_m *MockSegment) UpdateBloomFilter(pks []storage.PrimaryKey) {
+// UpdatePkCandidate provides a mock function with given fields: pks
+func (_m *MockSegment) UpdatePkCandidate(pks []storage.PrimaryKey) {
 	_m.Called(pks)
 }
 
-// MockSegment_UpdateBloomFilter_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateBloomFilter'
-type MockSegment_UpdateBloomFilter_Call struct {
+// MockSegment_UpdatePkCandidate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdatePkCandidate'
+type MockSegment_UpdatePkCandidate_Call struct {
 	*mock.Call
 }
 
-// UpdateBloomFilter is a helper method to define mock.On call
+// UpdatePkCandidate is a helper method to define mock.On call
 //   - pks []storage.PrimaryKey
-func (_e *MockSegment_Expecter) UpdateBloomFilter(pks interface{}) *MockSegment_UpdateBloomFilter_Call {
-	return &MockSegment_UpdateBloomFilter_Call{Call: _e.mock.On("UpdateBloomFilter", pks)}
+func (_e *MockSegment_Expecter) UpdatePkCandidate(pks interface{}) *MockSegment_UpdatePkCandidate_Call {
+	return &MockSegment_UpdatePkCandidate_Call{Call: _e.mock.On("UpdatePkCandidate", pks)}
 }
 
-func (_c *MockSegment_UpdateBloomFilter_Call) Run(run func(pks []storage.PrimaryKey)) *MockSegment_UpdateBloomFilter_Call {
+func (_c *MockSegment_UpdatePkCandidate_Call) Run(run func(pks []storage.PrimaryKey)) *MockSegment_UpdatePkCandidate_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].([]storage.PrimaryKey))
 	})
 	return _c
 }
 
-func (_c *MockSegment_UpdateBloomFilter_Call) Return() *MockSegment_UpdateBloomFilter_Call {
+func (_c *MockSegment_UpdatePkCandidate_Call) Return() *MockSegment_UpdatePkCandidate_Call {
 	_c.Call.Return()
 	return _c
 }
 
-func (_c *MockSegment_UpdateBloomFilter_Call) RunAndReturn(run func([]storage.PrimaryKey)) *MockSegment_UpdateBloomFilter_Call {
+func (_c *MockSegment_UpdatePkCandidate_Call) RunAndReturn(run func([]storage.PrimaryKey)) *MockSegment_UpdatePkCandidate_Call {
 	_c.Run(run)
 	return _c
 }

--- a/internal/querynodev2/segments/retrieve_test.go
+++ b/internal/querynodev2/segments/retrieve_test.go
@@ -129,7 +129,7 @@ func (suite *RetrieveSuite) SetupTest() {
 
 	bfs, err := loader.loadSingleBloomFilterSet(suite.ctx, suite.collectionID, &sealLoadInfo, SegmentTypeSealed)
 	suite.Require().NoError(err)
-	suite.sealed.SetBloomFilter(bfs)
+	suite.sealed.SetPKCandidate(bfs)
 
 	for _, binlog := range binlogs {
 		err = suite.sealed.(*LocalSegment).LoadFieldData(suite.ctx, binlog.FieldID, int64(msgLength), binlog)
@@ -170,7 +170,7 @@ func (suite *RetrieveSuite) SetupTest() {
 
 	bfs, err = loader.loadSingleBloomFilterSet(suite.ctx, suite.collectionID, &growingLoadInfo, SegmentTypeGrowing)
 	suite.Require().NoError(err)
-	suite.growing.SetBloomFilter(bfs)
+	suite.growing.SetPKCandidate(bfs)
 
 	insertMsg, err := mock_segcore.GenInsertMsg(suite.collection.GetCCollection(), suite.partitionID, suite.growing.ID(), msgLength)
 	suite.Require().NoError(err)
@@ -309,7 +309,7 @@ func (suite *RetrieveSuite) TestRetrieveWithFilter() {
 			bfs, err := loader.loadSingleBloomFilterSet(suite.ctx, suite.collectionID,
 				&sealLoadInfo, SegmentTypeSealed)
 			suite.Require().NoError(err)
-			sealseg.SetBloomFilter(bfs)
+			sealseg.SetPKCandidate(bfs)
 
 			suite.manager.Segment.Put(suite.ctx, SegmentTypeSealed, sealseg)
 		}
@@ -485,7 +485,7 @@ func (suite *RetrieveSuite) TestRetrieveStreamWithFilter() {
 
 		bfs, err := loader.loadSingleBloomFilterSet(ctx, suite.collectionID, loadInfo, SegmentTypeSealed)
 		suite.Require().NoError(err)
-		seg.SetBloomFilter(bfs)
+		seg.SetPKCandidate(bfs)
 
 		for _, binlog := range binlogs {
 			err = seg.(*LocalSegment).LoadFieldData(ctx, binlog.FieldID, int64(msgLen), binlog)

--- a/internal/querynodev2/segments/search_test.go
+++ b/internal/querynodev2/segments/search_test.go
@@ -215,7 +215,7 @@ func (suite *SearchSuite) TestSearchWithFilter() {
 
 		bfs, err := loader.loadSingleBloomFilterSet(ctx, suite.collectionID, loadInfo, SegmentTypeSealed)
 		suite.Require().NoError(err)
-		seg.SetBloomFilter(bfs)
+		seg.SetPKCandidate(bfs)
 
 		for _, binlog := range binlogs {
 			err = seg.(*LocalSegment).LoadFieldData(ctx, binlog.FieldID, int64(msgLen), binlog)

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -271,6 +271,13 @@ func (s *baseSegment) BatchPkExist(lc *storage.BatchLocationsCache) []bool {
 		}
 		return allPositive
 	}
+	if s.pkCandidate == nil {
+		allPositive := make([]bool, lc.Size())
+		for i := 0; i < lc.Size(); i++ {
+			allPositive[i] = true
+		}
+		return allPositive
+	}
 	return s.pkCandidate.BatchPkExist(lc)
 }
 

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -86,11 +86,11 @@ type baseSegment struct {
 	collection *Collection
 	version    *atomic.Int64
 
-	segmentType    SegmentType
-	bloomFilterSet *pkoracle.BloomFilterSet
-	loadInfo       *atomic.Pointer[querypb.SegmentLoadInfo]
-	skipGrowingBF  bool // Skip generating or maintaining BF for growing segments; deletion checks will be handled in segcore.
-	channel        metautil.Channel
+	segmentType   SegmentType
+	pkCandidate   pkoracle.Candidate // PK candidate: BloomFilterSet for regular collections, ExternalSegmentCandidate for external collections
+	loadInfo      *atomic.Pointer[querypb.SegmentLoadInfo]
+	skipGrowingBF bool // Skip generating or maintaining BF for growing segments; deletion checks will be handled in segcore.
+	channel       metautil.Channel
 
 	bm25Stats map[int64]*storage.BM25Stats
 
@@ -105,14 +105,14 @@ func newBaseSegment(collection *Collection, segmentType SegmentType, version int
 		return baseSegment{}, err
 	}
 	bs := baseSegment{
-		collection:     collection,
-		loadInfo:       atomic.NewPointer[querypb.SegmentLoadInfo](loadInfo),
-		version:        atomic.NewInt64(version),
-		segmentType:    segmentType,
-		bloomFilterSet: pkoracle.NewBloomFilterSet(loadInfo.GetSegmentID(), loadInfo.GetPartitionID(), segmentType),
-		bm25Stats:      make(map[int64]*storage.BM25Stats),
-		channel:        channel,
-		skipGrowingBF:  segmentType == SegmentTypeGrowing && paramtable.Get().QueryNodeCfg.SkipGrowingSegmentBF.GetAsBool(),
+		collection:    collection,
+		loadInfo:      atomic.NewPointer[querypb.SegmentLoadInfo](loadInfo),
+		version:       atomic.NewInt64(version),
+		segmentType:   segmentType,
+		pkCandidate:   pkoracle.NewBloomFilterSet(loadInfo.GetSegmentID(), loadInfo.GetPartitionID(), segmentType),
+		bm25Stats:     make(map[int64]*storage.BM25Stats),
+		channel:       channel,
+		skipGrowingBF: segmentType == SegmentTypeGrowing && paramtable.Get().QueryNodeCfg.SkipGrowingSegmentBF.GetAsBool(),
 
 		resourceUsageCache: atomic.NewPointer[ResourceUsage](nil),
 		needUpdatedVersion: atomic.NewInt64(0),
@@ -177,19 +177,45 @@ func (s *baseSegment) LoadInfo() *querypb.SegmentLoadInfo {
 	return s.loadInfo.Load()
 }
 
-func (s *baseSegment) SetBloomFilter(bf *pkoracle.BloomFilterSet) {
-	s.bloomFilterSet = bf
+func (s *baseSegment) SetPKCandidate(candidate pkoracle.Candidate) {
+	s.pkCandidate = candidate
 }
 
-func (s *baseSegment) BloomFilterExist() bool {
-	return s.bloomFilterSet.BloomFilterExist()
+// PkCandidateExist implements pkoracle.Candidate — reports whether PK data has been loaded.
+func (s *baseSegment) PkCandidateExist() bool {
+	return s.pkCandidate != nil && s.pkCandidate.PkCandidateExist()
 }
 
-func (s *baseSegment) UpdateBloomFilter(pks []storage.PrimaryKey) {
+// UpdatePkCandidate feeds new primary keys into the PK candidate.
+func (s *baseSegment) UpdatePkCandidate(pks []storage.PrimaryKey) {
 	if s.skipGrowingBF {
 		return
 	}
-	s.bloomFilterSet.UpdateBloomFilter(pks)
+	if s.pkCandidate != nil {
+		s.pkCandidate.UpdatePkCandidate(pks)
+	}
+}
+
+// Stats implements pkoracle.Candidate — returns PK statistics (min/max PK).
+func (s *baseSegment) Stats() *storage.PkStatistics {
+	if s.pkCandidate != nil {
+		return s.pkCandidate.Stats()
+	}
+	return nil
+}
+
+// Charge implements pkoracle.Candidate — charges memory resources.
+func (s *baseSegment) Charge() {
+	if s.pkCandidate != nil {
+		s.pkCandidate.Charge()
+	}
+}
+
+// Refund implements pkoracle.Candidate — releases memory resources.
+func (s *baseSegment) Refund() {
+	if s.pkCandidate != nil {
+		s.pkCandidate.Refund()
+	}
 }
 
 func (s *baseSegment) UpdateBM25Stats(stats map[int64]*storage.BM25Stats) {
@@ -213,21 +239,28 @@ func (s *baseSegment) MayPkExist(pk *storage.LocationsCache) bool {
 	if s.skipGrowingBF {
 		return true
 	}
-	return s.bloomFilterSet.MayPkExist(pk)
+	if s.pkCandidate == nil {
+		return true // No candidate, assume PK might exist
+	}
+	return s.pkCandidate.MayPkExist(pk)
 }
 
 func (s *baseSegment) GetMinPk() *storage.PrimaryKey {
-	if s.bloomFilterSet.Stats() == nil {
-		return nil
+	if s.pkCandidate != nil {
+		if stats := s.pkCandidate.Stats(); stats != nil {
+			return &stats.MinPK
+		}
 	}
-	return &s.bloomFilterSet.Stats().MinPK
+	return nil
 }
 
 func (s *baseSegment) GetMaxPk() *storage.PrimaryKey {
-	if s.bloomFilterSet.Stats() == nil {
-		return nil
+	if s.pkCandidate != nil {
+		if stats := s.pkCandidate.Stats(); stats != nil {
+			return &stats.MaxPK
+		}
 	}
-	return &s.bloomFilterSet.Stats().MaxPK
+	return nil
 }
 
 func (s *baseSegment) BatchPkExist(lc *storage.BatchLocationsCache) []bool {
@@ -238,7 +271,7 @@ func (s *baseSegment) BatchPkExist(lc *storage.BatchLocationsCache) []bool {
 		}
 		return allPositive
 	}
-	return s.bloomFilterSet.BatchPkExist(lc)
+	return s.pkCandidate.BatchPkExist(lc)
 }
 
 // ResourceUsageEstimate returns the final estimated resource usage of the segment.
@@ -484,18 +517,17 @@ func (s *LocalSegment) LastDeltaTimestamp() uint64 {
 	return s.lastDeltaTimestamp.Load()
 }
 
-// UpdateBloomFilter updates bloom filter with provided pks and charges resource if BF is newly created.
-// This overrides baseSegment.UpdateBloomFilter to handle resource charging for growing segments.
-func (s *LocalSegment) UpdateBloomFilter(pks []storage.PrimaryKey) {
+// UpdatePkCandidate updates the PK candidate with provided pks and charges resource.
+// Overrides baseSegment.UpdatePkCandidate to handle resource charging for growing segments.
+func (s *LocalSegment) UpdatePkCandidate(pks []storage.PrimaryKey) {
 	if s.skipGrowingBF {
 		return
 	}
 
-	// Update bloom filter (may create new BF if not exist)
-	s.bloomFilterSet.UpdateBloomFilter(pks)
+	s.pkCandidate.UpdatePkCandidate(pks)
 
-	// Charge bloom filter resource (safe to call multiple times - only charges once)
-	s.bloomFilterSet.Charge()
+	// Charge resource (safe to call multiple times - only charges once)
+	s.pkCandidate.Charge()
 }
 
 func (s *LocalSegment) GetIndexByID(indexID int64) *IndexedFieldInfo {
@@ -1321,8 +1353,8 @@ func (s *LocalSegment) Release(ctx context.Context, opts ...releaseOption) {
 	// usage := s.ResourceUsageEstimate()
 	// s.manager.SubLogicalResource(usage)
 
-	// Refund bloom filter resource
-	s.bloomFilterSet.Refund()
+	// Refund PK candidate resource
+	s.pkCandidate.Refund()
 
 	binlogSize := s.binlogSize.Load()
 	if binlogSize > 0 {

--- a/internal/querynodev2/segments/segment_filter.go
+++ b/internal/querynodev2/segments/segment_filter.go
@@ -282,9 +282,9 @@ func doSparseFilter(seg Segment, plan *planpb.PlanNode) bool {
 		switch op {
 		case planpb.OpType_Equal:
 
-			// bloom filter
-			existBF := seg.BloomFilterExist()
-			if existBF {
+			// bloom filter / PK candidate check
+			pkCheckReady := seg.PkCandidateExist()
+			if pkCheckReady {
 				lc := storage.NewLocationsCache(pk)
 				// BloomFilter contains this key, no filter here
 				noFilter = seg.MayPkExist(lc)
@@ -329,7 +329,7 @@ func WithSparseFilter(plan *planpb.PlanNode, filteredCount *int) SegmentFilter {
 		log.Debug("SparseFilter",
 			zap.Int64("Segment ID", segment.ID()),
 			zap.Bool("No Filter", rc),
-			zap.Bool("Exist BF", segment.BloomFilterExist()))
+			zap.Bool("pkCheckReady", segment.PkCandidateExist()))
 		return rc
 	})
 }

--- a/internal/querynodev2/segments/segment_interface.go
+++ b/internal/querynodev2/segments/segment_interface.go
@@ -89,10 +89,15 @@ type Segment interface {
 	Release(ctx context.Context, opts ...releaseOption)
 	Reopen(ctx context.Context, newLoadInfo *querypb.SegmentLoadInfo) error
 
-	// Bloom filter related
-	SetBloomFilter(bf *pkoracle.BloomFilterSet)
-	BloomFilterExist() bool
-	UpdateBloomFilter(pks []storage.PrimaryKey)
+	// PK candidate related (BloomFilterSet for regular segments, ExternalSegmentCandidate for external)
+	// Segment implements pkoracle.Candidate: MayPkExist, BatchPkExist, ID, Partition, Type,
+	// PkCandidateExist, UpdatePkCandidate, Stats, Charge, Refund — with protective guards (e.g. skipGrowingBF).
+	SetPKCandidate(candidate pkoracle.Candidate)
+	PkCandidateExist() bool
+	UpdatePkCandidate(pks []storage.PrimaryKey)
+	Stats() *storage.PkStatistics
+	Charge()
+	Refund()
 	MayPkExist(lc *storage.LocationsCache) bool
 	BatchPkExist(lc *storage.BatchLocationsCache) []bool
 

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -46,6 +46,7 @@ import (
 	"github.com/milvus-io/milvus/internal/querynodev2/pkoracle"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/storagecommon"
+	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/internal/util/indexparamcheck"
 	"github.com/milvus-io/milvus/internal/util/vecindexmgr"
 	"github.com/milvus-io/milvus/pkg/v2/common"
@@ -646,8 +647,15 @@ func (loader *segmentLoader) LoadBM25Stats(ctx context.Context, collectionID int
 		stats := make(map[int64]*storage.BM25Stats)
 
 		log.Info("loading bm25 stats for remote...", zap.Int64("collectionID", collectionID), zap.Int64("segment", segmentID))
-		logpaths := loader.filterBM25Stats(loadInfo.Bm25Logs)
-		err := loader.loadBm25Stats(ctx, segmentID, stats, logpaths)
+		logpaths, err := packed.NewStatsResolverFromLoadInfo(loadInfo).BM25StatsPaths()
+		if err != nil {
+			log.Warn("load remote segment bm25 stats paths failed",
+				zap.Int64("segmentID", segmentID),
+				zap.Error(err),
+			)
+			return err
+		}
+		err = loader.loadBm25Stats(ctx, segmentID, stats, logpaths)
 		if err != nil {
 			log.Warn("load remote segment bm25 stats failed",
 				zap.Int64("segmentID", segmentID),
@@ -700,8 +708,11 @@ func (loader *segmentLoader) loadSingleBloomFilterSet(ctx context.Context, colle
 	}
 
 	log.Info("loading bloom filter for remote...")
-	pkStatsBinlogs, logType := loader.filterPKStatsBinlogs(loadInfo.Statslogs, pkField.GetFieldID())
-	err := loader.loadBloomFilter(ctx, segmentID, bfs, pkStatsBinlogs, logType)
+	pkStatsBinlogs, err := packed.NewStatsResolverFromLoadInfo(loadInfo).BloomFilterPaths(pkField.GetFieldID())
+	if err != nil {
+		return nil, err
+	}
+	err = loader.loadBloomFilter(ctx, segmentID, bfs, pkStatsBinlogs)
 	if err != nil {
 		log.Warn("load remote segment bloom filter failed",
 			zap.Int64("partitionID", partitionID),
@@ -740,11 +751,8 @@ func (loader *segmentLoader) LoadBloomFilterSet(ctx context.Context, collectionI
 	// Calculate total memory size needed for bloom filters (PK stats)
 	var totalMemorySize int64
 	for _, info := range infos {
-		for _, fieldBinlog := range info.Statslogs {
-			if fieldBinlog.FieldID == pkFieldID {
-				totalMemorySize += getBinlogDataMemorySize(fieldBinlog)
-			}
-		}
+		memSize, _ := packed.NewStatsResolverFromLoadInfo(info).BloomFilterMemorySize(pkFieldID)
+		totalMemorySize += memSize
 	}
 
 	// Reserve memory resource if tiered eviction is enabled
@@ -788,8 +796,11 @@ func (loader *segmentLoader) LoadBloomFilterSet(ctx context.Context, collectionI
 		}
 
 		log.Info("loading bloom filter for remote...")
-		pkStatsBinlogs, logType := loader.filterPKStatsBinlogs(loadInfo.Statslogs, pkField.GetFieldID())
-		err := loader.loadBloomFilter(ctx, segmentID, bfs, pkStatsBinlogs, logType)
+		pkStatsBinlogs, err := packed.NewStatsResolverFromLoadInfo(loadInfo).BloomFilterPaths(pkFieldID)
+		if err != nil {
+			return err
+		}
+		err = loader.loadBloomFilter(ctx, segmentID, bfs, pkStatsBinlogs)
 		if err != nil {
 			log.Warn("load remote segment bloom filter failed",
 				zap.Int64("partitionID", partitionID),
@@ -1116,64 +1127,25 @@ func (loader *segmentLoader) LoadSegment(ctx context.Context,
 	if segment.segmentType == SegmentTypeGrowing {
 		if bf, ok := segment.pkCandidate.(*pkoracle.BloomFilterSet); ok {
 			log.Info("loading statslog...")
-			pkStatsBinlogs, logType := loader.filterPKStatsBinlogs(loadInfo.Statslogs, pkField.GetFieldID())
-			err := loader.loadBloomFilter(ctx, segment.ID(), bf, pkStatsBinlogs, logType)
+			resolver := packed.NewStatsResolverFromLoadInfo(loadInfo)
+			bfPaths, err := resolver.BloomFilterPaths(pkField.GetFieldID())
 			if err != nil {
 				return err
 			}
-		}
+			if err := loader.loadBloomFilter(ctx, segment.ID(), bf, bfPaths); err != nil {
+				return err
+			}
 
-		if len(loadInfo.Bm25Logs) > 0 {
-			log.Info("loading bm25 stats...")
-			bm25StatsLogs := loader.filterBM25Stats(loadInfo.Bm25Logs)
-
-			err := loader.loadBm25Stats(ctx, segment.ID(), segment.bm25Stats, bm25StatsLogs)
+			bm25Paths, err := resolver.BM25StatsPaths()
 			if err != nil {
+				return err
+			}
+			if err := loader.loadBm25Stats(ctx, segment.ID(), segment.bm25Stats, bm25Paths); err != nil {
 				return err
 			}
 		}
 	}
 	return nil
-}
-
-func (loader *segmentLoader) filterPKStatsBinlogs(fieldBinlogs []*datapb.FieldBinlog, pkFieldID int64) ([]string, storage.StatsLogType) {
-	result := make([]string, 0)
-	for _, fieldBinlog := range fieldBinlogs {
-		if fieldBinlog.FieldID == pkFieldID {
-			for _, binlog := range fieldBinlog.GetBinlogs() {
-				_, logidx := path.Split(binlog.GetLogPath())
-				// if special status log exist
-				// only load one file
-				switch logidx {
-				case storage.CompoundStatsType.LogIdx():
-					return []string{binlog.GetLogPath()}, storage.CompoundStatsType
-				default:
-					result = append(result, binlog.GetLogPath())
-				}
-			}
-		}
-	}
-	return result, storage.DefaultStatsType
-}
-
-func (loader *segmentLoader) filterBM25Stats(fieldBinlogs []*datapb.FieldBinlog) map[int64][]string {
-	result := make(map[int64][]string, 0)
-	for _, fieldBinlog := range fieldBinlogs {
-		logpaths := []string{}
-		for _, binlog := range fieldBinlog.GetBinlogs() {
-			_, logidx := path.Split(binlog.GetLogPath())
-			// if special status log exist
-			// only load one file
-			if logidx == storage.CompoundStatsType.LogIdx() {
-				logpaths = []string{binlog.GetLogPath()}
-				break
-			} else {
-				logpaths = append(logpaths, binlog.GetLogPath())
-			}
-		}
-		result[fieldBinlog.FieldID] = logpaths
-	}
-	return result
 }
 
 func loadSealedSegmentFields(ctx context.Context, collection *Collection, segment *LocalSegment, fields []*datapb.FieldBinlog, rowCount int64) error {
@@ -1314,7 +1286,7 @@ func (loader *segmentLoader) loadBm25Stats(ctx context.Context, segmentID int64,
 }
 
 func (loader *segmentLoader) loadBloomFilter(ctx context.Context, segmentID int64, bfs *pkoracle.BloomFilterSet,
-	binlogPaths []string, logType storage.StatsLogType,
+	binlogPaths []string,
 ) error {
 	log := log.Ctx(ctx).With(
 		zap.Int64("segmentID", segmentID),
@@ -1329,24 +1301,15 @@ func (loader *segmentLoader) loadBloomFilter(ctx context.Context, segmentID int6
 	if err != nil {
 		return err
 	}
-	blobs := []*storage.Blob{}
-	for i := 0; i < len(values); i++ {
-		blobs = append(blobs, &storage.Blob{Value: values[i]})
+	blobs := make([]*storage.Blob, len(values))
+	for i := range values {
+		blobs[i] = &storage.Blob{Value: values[i]}
 	}
 
-	var stats []*storage.PrimaryKeyStats
-	if logType == storage.CompoundStatsType {
-		stats, err = storage.DeserializeStatsList(blobs[0])
-		if err != nil {
-			log.Warn("failed to deserialize stats list", zap.Error(err))
-			return err
-		}
-	} else {
-		stats, err = storage.DeserializeStats(blobs)
-		if err != nil {
-			log.Warn("failed to deserialize stats", zap.Error(err))
-			return err
-		}
+	stats, err := storage.DeserializeBloomFilterStats(binlogPaths, blobs)
+	if err != nil {
+		log.Warn("failed to deserialize bloom filter stats", zap.Error(err))
+		return err
 	}
 
 	var size uint

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -387,17 +387,12 @@ func (loader *segmentLoader) Load(ctx context.Context,
 					zap.Int64("segmentID", loadInfo.GetSegmentID()))
 
 				// Check for truncated segment ID collision with other segments being loaded.
-				// Virtual PK only preserves lower 32 bits of segmentID; a collision means
-				// two segments produce overlapping PK spaces.
-				truncatedID := loadInfo.GetSegmentID() & 0xFFFFFFFF
-				for _, otherInfo := range infos {
-					if otherInfo.GetSegmentID() != loadInfo.GetSegmentID() &&
-						(otherInfo.GetSegmentID()&0xFFFFFFFF) == truncatedID {
-						log.Warn("virtual PK collision detected: two segments share truncated segment ID",
-							zap.Int64("segmentID1", loadInfo.GetSegmentID()),
-							zap.Int64("segmentID2", otherInfo.GetSegmentID()),
-							zap.Int64("truncatedID", truncatedID))
-					}
+				collisions := detectVirtualPKCollisions(loadInfo.GetSegmentID(), infos)
+				for _, collidingID := range collisions {
+					log.Warn("virtual PK collision detected: two segments share truncated segment ID",
+						zap.Int64("segmentID1", loadInfo.GetSegmentID()),
+						zap.Int64("segmentID2", collidingID),
+						zap.Int64("truncatedID", loadInfo.GetSegmentID()&0xFFFFFFFF))
 				}
 			} else {
 				bfs, err := loader.loadSingleBloomFilterSet(ctx, loadInfo.GetCollectionID(), loadInfo, segment.Type())
@@ -854,6 +849,21 @@ func separateIndexAndBinlog(loadInfo *querypb.SegmentLoadInfo) (map[int64]*Index
 	}
 
 	return indexedFieldInfos, fieldBinlogs
+}
+
+// detectVirtualPKCollisions checks if any segments in infos share the same
+// truncated (lower 32 bits) segment ID as segmentID. A collision means two
+// segments produce overlapping virtual PK spaces.
+func detectVirtualPKCollisions(segmentID int64, infos []*querypb.SegmentLoadInfo) []int64 {
+	truncatedID := segmentID & 0xFFFFFFFF
+	var collisions []int64
+	for _, info := range infos {
+		if info.GetSegmentID() != segmentID &&
+			(info.GetSegmentID()&0xFFFFFFFF) == truncatedID {
+			collisions = append(collisions, info.GetSegmentID())
+		}
+	}
+	return collisions
 }
 
 func separateLoadInfoV2(loadInfo *querypb.SegmentLoadInfo, schema *schemapb.CollectionSchema) (

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -39,13 +39,13 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/querynodev2/pkoracle"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/storagecommon"
-	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/internal/util/indexparamcheck"
 	"github.com/milvus-io/milvus/internal/util/vecindexmgr"
 	"github.com/milvus-io/milvus/pkg/v2/common"
@@ -366,19 +366,48 @@ func (loader *segmentLoader) Load(ctx context.Context,
 				return errors.Wrap(err, "At LoadSegment")
 			}
 		}
-		if err = loader.loadDeltalogs(ctx, segment, loadInfo); err != nil {
-			return errors.Wrap(err, "At LoadDeltaLogs")
+		// Skip delta logs for external collections (they are read-only, no deletions)
+		if !typeutil.IsExternalCollection(collection.Schema()) {
+			if err = loader.loadDeltalogs(ctx, segment, loadInfo); err != nil {
+				return errors.Wrap(err, "At LoadDeltaLogs")
+			}
 		}
 
-		if !segment.BloomFilterExist() {
-			log.Debug("loading bloom filter for segment", zap.Int64("segmentID", segment.ID()))
-			bfs, err := loader.loadSingleBloomFilterSet(ctx, loadInfo.GetCollectionID(), loadInfo, segment.Type())
-			if err != nil {
-				return errors.Wrap(err, "At LoadBloomFilter")
+		if !segment.PkCandidateExist() {
+			log.Debug("loading PK candidate for segment", zap.Int64("segmentID", segment.ID()))
+			// For external collections, use ExternalSegmentCandidate instead of BloomFilterSet
+			if typeutil.IsExternalCollection(collection.Schema()) {
+				candidate := pkoracle.NewExternalSegmentCandidate(
+					loadInfo.GetSegmentID(),
+					loadInfo.GetPartitionID(),
+					segment.Type(),
+				)
+				segment.SetPKCandidate(candidate)
+				log.Info("using ExternalSegmentCandidate for external collection",
+					zap.Int64("segmentID", loadInfo.GetSegmentID()))
+
+				// Check for truncated segment ID collision with other segments being loaded.
+				// Virtual PK only preserves lower 32 bits of segmentID; a collision means
+				// two segments produce overlapping PK spaces.
+				truncatedID := loadInfo.GetSegmentID() & 0xFFFFFFFF
+				for _, otherInfo := range infos {
+					if otherInfo.GetSegmentID() != loadInfo.GetSegmentID() &&
+						(otherInfo.GetSegmentID()&0xFFFFFFFF) == truncatedID {
+						log.Warn("virtual PK collision detected: two segments share truncated segment ID",
+							zap.Int64("segmentID1", loadInfo.GetSegmentID()),
+							zap.Int64("segmentID2", otherInfo.GetSegmentID()),
+							zap.Int64("truncatedID", truncatedID))
+					}
+				}
+			} else {
+				bfs, err := loader.loadSingleBloomFilterSet(ctx, loadInfo.GetCollectionID(), loadInfo, segment.Type())
+				if err != nil {
+					return errors.Wrap(err, "At LoadBloomFilter")
+				}
+				segment.SetPKCandidate(bfs)
+				// Charge bloom filter resource
+				bfs.Charge()
 			}
-			segment.SetBloomFilter(bfs)
-			// Charge bloom filter resource
-			bfs.Charge()
 		}
 
 		if segment.Level() != datapb.SegmentLevel_L0 {
@@ -622,10 +651,8 @@ func (loader *segmentLoader) LoadBM25Stats(ctx context.Context, collectionID int
 		stats := make(map[int64]*storage.BM25Stats)
 
 		log.Info("loading bm25 stats for remote...", zap.Int64("collectionID", collectionID), zap.Int64("segment", segmentID))
-		logpaths, err := packed.NewStatsResolverFromLoadInfo(loadInfo).BM25StatsPaths()
-		if err == nil {
-			err = loader.loadBm25Stats(ctx, segmentID, stats, logpaths)
-		}
+		logpaths := loader.filterBM25Stats(loadInfo.Bm25Logs)
+		err := loader.loadBm25Stats(ctx, segmentID, stats, logpaths)
 		if err != nil {
 			log.Warn("load remote segment bm25 stats failed",
 				zap.Int64("segmentID", segmentID),
@@ -667,12 +694,20 @@ func (loader *segmentLoader) loadSingleBloomFilterSet(ctx context.Context, colle
 	segmentID := loadInfo.SegmentID
 	bfs := pkoracle.NewBloomFilterSet(segmentID, partitionID, segtype)
 
-	log.Info("loading bloom filter for remote...")
-	pkStatsBinlogs, err := packed.NewStatsResolverFromLoadInfo(loadInfo).BloomFilterPaths(pkField.GetFieldID())
-	if err != nil {
-		return nil, err
+	// For external collections, return empty bloom filter set.
+	// External collections use ExternalSegmentCandidate for PK checking (set on segment)
+	// and don't have stats logs, so we skip loading bloom filters.
+	// NOTE: This is a defensive guard. Normal external collection load path uses
+	// ExternalSegmentCandidate directly and should not reach here.
+	if typeutil.IsExternalCollection(collection.Schema()) {
+		log.Debug("external collection: returning empty bloom filter set (defensive path)")
+		return bfs, nil
 	}
-	if err := loader.loadBloomFilter(ctx, segmentID, bfs, pkStatsBinlogs); err != nil {
+
+	log.Info("loading bloom filter for remote...")
+	pkStatsBinlogs, logType := loader.filterPKStatsBinlogs(loadInfo.Statslogs, pkField.GetFieldID())
+	err := loader.loadBloomFilter(ctx, segmentID, bfs, pkStatsBinlogs, logType)
+	if err != nil {
 		log.Warn("load remote segment bloom filter failed",
 			zap.Int64("partitionID", partitionID),
 			zap.Int64("segmentID", segmentID),
@@ -710,8 +745,11 @@ func (loader *segmentLoader) LoadBloomFilterSet(ctx context.Context, collectionI
 	// Calculate total memory size needed for bloom filters (PK stats)
 	var totalMemorySize int64
 	for _, info := range infos {
-		memSize, _ := packed.NewStatsResolverFromLoadInfo(info).BloomFilterMemorySize(pkFieldID)
-		totalMemorySize += memSize
+		for _, fieldBinlog := range info.Statslogs {
+			if fieldBinlog.FieldID == pkFieldID {
+				totalMemorySize += getBinlogDataMemorySize(fieldBinlog)
+			}
+		}
 	}
 
 	// Reserve memory resource if tiered eviction is enabled
@@ -740,18 +778,24 @@ func (loader *segmentLoader) LoadBloomFilterSet(ctx context.Context, collectionI
 	log.Info("start loading remote...", zap.Int("segmentNum", segmentNum))
 
 	loadedBfs := typeutil.NewConcurrentSet[*pkoracle.BloomFilterSet]()
+	isExternal := typeutil.IsExternalCollection(collection.Schema())
 	loadRemoteFunc := func(idx int) error {
 		loadInfo := infos[idx]
 		partitionID := loadInfo.PartitionID
 		segmentID := loadInfo.SegmentID
 		bfs := pkoracle.NewBloomFilterSet(segmentID, partitionID, commonpb.SegmentState_Sealed)
 
-		log.Info("loading bloom filter for remote...")
-		pkStatsBinlogs, err := packed.NewStatsResolverFromLoadInfo(loadInfo).BloomFilterPaths(pkFieldID)
-		if err != nil {
-			return err
+		// For external collections, return empty bloom filter set
+		// External collections don't have stats logs and use ExternalSegmentCandidate for PK checking
+		if isExternal {
+			loadedBfs.Insert(bfs)
+			return nil
 		}
-		if err := loader.loadBloomFilter(ctx, segmentID, bfs, pkStatsBinlogs); err != nil {
+
+		log.Info("loading bloom filter for remote...")
+		pkStatsBinlogs, logType := loader.filterPKStatsBinlogs(loadInfo.Statslogs, pkField.GetFieldID())
+		err := loader.loadBloomFilter(ctx, segmentID, bfs, pkStatsBinlogs, logType)
+		if err != nil {
 			log.Warn("load remote segment bloom filter failed",
 				zap.Int64("partitionID", partitionID),
 				zap.Int64("segmentID", segmentID),
@@ -821,6 +865,18 @@ func separateLoadInfoV2(loadInfo *querypb.SegmentLoadInfo, schema *schemapb.Coll
 ) {
 	storageVersion := loadInfo.GetStorageVersion()
 
+	// Build a map of external field IDs for quick lookup
+	// External fields are skipped during loading (lazy loaded on demand)
+	externalFieldIDs := make(map[int64]bool)
+	isExternalColl := typeutil.IsExternalCollection(schema)
+	if isExternalColl {
+		for _, field := range schema.GetFields() {
+			if IsExternalField(field) {
+				externalFieldIDs[field.GetFieldID()] = true
+			}
+		}
+	}
+
 	fieldID2IndexInfo := make(map[int64][]*querypb.FieldIndexInfo)
 	for _, indexInfo := range loadInfo.IndexInfos {
 		if len(indexInfo.GetIndexFilePaths()) > 0 {
@@ -836,10 +892,19 @@ func separateLoadInfoV2(loadInfo *querypb.SegmentLoadInfo, schema *schemapb.Coll
 		for _, fieldBinlog := range loadInfo.BinlogPaths {
 			fieldID := fieldBinlog.FieldID
 
+			// Skip external fields - they are lazy loaded on demand
+			if externalFieldIDs[fieldID] {
+				continue
+			}
+
 			if fieldID == storagecommon.DefaultShortColumnGroupID {
 				allFields := typeutil.GetAllFieldSchemas(schema)
 				// for short column group, we need to load all fields in the group
 				for _, field := range allFields {
+					// Skip external fields in short column group
+					if externalFieldIDs[field.GetFieldID()] {
+						continue
+					}
 					if infos, ok := fieldID2IndexInfo[field.GetFieldID()]; ok {
 						for _, indexInfo := range infos {
 							fieldInfo := &IndexedFieldInfo{
@@ -869,6 +934,12 @@ func separateLoadInfoV2(loadInfo *querypb.SegmentLoadInfo, schema *schemapb.Coll
 	} else {
 		for _, fieldBinlog := range loadInfo.BinlogPaths {
 			fieldID := fieldBinlog.FieldID
+
+			// Skip external fields - they are lazy loaded on demand
+			if externalFieldIDs[fieldID] {
+				continue
+			}
+
 			if infos, ok := fieldID2IndexInfo[fieldID]; ok {
 				for _, indexInfo := range infos {
 					fieldInfo := &IndexedFieldInfo{
@@ -883,18 +954,24 @@ func separateLoadInfoV2(loadInfo *querypb.SegmentLoadInfo, schema *schemapb.Coll
 		}
 	}
 
-	textIndexedInfo, jsonKeyIndexInfo, err := packed.NewStatsResolverFromLoadInfo(loadInfo).TextAndJSONIndexStats()
-	if err != nil {
-		log.Warn("failed to load text/json stats from manifest",
-			zap.String("manifestPath", loadInfo.GetManifestPath()), zap.Error(err))
-		textIndexedInfo = make(map[int64]*datapb.TextIndexStats)
-		jsonKeyIndexInfo = make(map[int64]*datapb.JsonKeyStats)
+	textIndexedInfo := make(map[int64]*datapb.TextIndexStats, len(loadInfo.GetTextStatsLogs()))
+	for _, fieldStatsLog := range loadInfo.GetTextStatsLogs() {
+		textLog, ok := textIndexedInfo[fieldStatsLog.FieldID]
+		if !ok {
+			textIndexedInfo[fieldStatsLog.FieldID] = fieldStatsLog
+		} else if fieldStatsLog.GetVersion() > textLog.GetVersion() {
+			textIndexedInfo[fieldStatsLog.FieldID] = fieldStatsLog
+		}
 	}
-	if textIndexedInfo == nil {
-		textIndexedInfo = make(map[int64]*datapb.TextIndexStats)
-	}
-	if jsonKeyIndexInfo == nil {
-		jsonKeyIndexInfo = make(map[int64]*datapb.JsonKeyStats)
+
+	jsonKeyIndexInfo := make(map[int64]*datapb.JsonKeyStats, len(loadInfo.GetJsonKeyStatsLogs()))
+	for _, fieldStatsLog := range loadInfo.GetJsonKeyStatsLogs() {
+		jsonKeyLog, ok := jsonKeyIndexInfo[fieldStatsLog.FieldID]
+		if !ok {
+			jsonKeyIndexInfo[fieldStatsLog.FieldID] = fieldStatsLog
+		} else if fieldStatsLog.GetVersion() > jsonKeyLog.GetVersion() {
+			jsonKeyIndexInfo[fieldStatsLog.FieldID] = fieldStatsLog
+		}
 	}
 
 	unindexedTextFields := make(map[int64]struct{})
@@ -1027,24 +1104,134 @@ func (loader *segmentLoader) LoadSegment(ctx context.Context,
 
 	// load statslog if it's growing segment
 	if segment.segmentType == SegmentTypeGrowing {
-		log.Info("loading statslog...")
-		resolver := packed.NewStatsResolverFromLoadInfo(loadInfo)
-		bfPaths, err := resolver.BloomFilterPaths(pkField.GetFieldID())
-		if err != nil {
-			return err
+		if bf, ok := segment.pkCandidate.(*pkoracle.BloomFilterSet); ok {
+			log.Info("loading statslog...")
+			pkStatsBinlogs, logType := loader.filterPKStatsBinlogs(loadInfo.Statslogs, pkField.GetFieldID())
+			err := loader.loadBloomFilter(ctx, segment.ID(), bf, pkStatsBinlogs, logType)
+			if err != nil {
+				return err
+			}
 		}
-		if err := loader.loadBloomFilter(ctx, segment.ID(), segment.bloomFilterSet, bfPaths); err != nil {
+
+		if len(loadInfo.Bm25Logs) > 0 {
+			log.Info("loading bm25 stats...")
+			bm25StatsLogs := loader.filterBM25Stats(loadInfo.Bm25Logs)
+
+			err := loader.loadBm25Stats(ctx, segment.ID(), segment.bm25Stats, bm25StatsLogs)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (loader *segmentLoader) filterPKStatsBinlogs(fieldBinlogs []*datapb.FieldBinlog, pkFieldID int64) ([]string, storage.StatsLogType) {
+	result := make([]string, 0)
+	for _, fieldBinlog := range fieldBinlogs {
+		if fieldBinlog.FieldID == pkFieldID {
+			for _, binlog := range fieldBinlog.GetBinlogs() {
+				_, logidx := path.Split(binlog.GetLogPath())
+				// if special status log exist
+				// only load one file
+				switch logidx {
+				case storage.CompoundStatsType.LogIdx():
+					return []string{binlog.GetLogPath()}, storage.CompoundStatsType
+				default:
+					result = append(result, binlog.GetLogPath())
+				}
+			}
+		}
+	}
+	return result, storage.DefaultStatsType
+}
+
+func (loader *segmentLoader) filterBM25Stats(fieldBinlogs []*datapb.FieldBinlog) map[int64][]string {
+	result := make(map[int64][]string, 0)
+	for _, fieldBinlog := range fieldBinlogs {
+		logpaths := []string{}
+		for _, binlog := range fieldBinlog.GetBinlogs() {
+			_, logidx := path.Split(binlog.GetLogPath())
+			// if special status log exist
+			// only load one file
+			if logidx == storage.CompoundStatsType.LogIdx() {
+				logpaths = []string{binlog.GetLogPath()}
+				break
+			} else {
+				logpaths = append(logpaths, binlog.GetLogPath())
+			}
+		}
+		result[fieldBinlog.FieldID] = logpaths
+	}
+	return result
+}
+
+func loadSealedSegmentFields(ctx context.Context, collection *Collection, segment *LocalSegment, fields []*datapb.FieldBinlog, rowCount int64) error {
+	runningGroup, _ := errgroup.WithContext(ctx)
+	for _, field := range fields {
+		fieldBinLog := field
+		fieldID := field.FieldID
+		runningGroup.Go(func() error {
+			return segment.LoadFieldData(ctx, fieldID, rowCount, fieldBinLog)
+		})
+	}
+	err := runningGroup.Wait()
+	if err != nil {
+		return err
+	}
+
+	log.Ctx(ctx).Info("load field binlogs done for sealed segment",
+		zap.Int64("collection", segment.Collection()),
+		zap.Int64("segment", segment.ID()),
+		zap.Int("len(field)", len(fields)),
+		zap.String("segmentType", segment.Type().String()))
+
+	return nil
+}
+
+func (loader *segmentLoader) loadFieldsIndex(ctx context.Context,
+	schemaHelper *typeutil.SchemaHelper,
+	segment *LocalSegment,
+	numRows int64,
+	indexedFieldInfos map[int64]*IndexedFieldInfo,
+) error {
+	log := log.Ctx(ctx).With(
+		zap.Int64("collectionID", segment.Collection()),
+		zap.Int64("partitionID", segment.Partition()),
+		zap.Int64("segmentID", segment.ID()),
+		zap.Int64("rowCount", numRows),
+	)
+
+	for _, fieldInfo := range indexedFieldInfos {
+		fieldID := fieldInfo.IndexInfo.FieldID
+		indexInfo := fieldInfo.IndexInfo
+		tr := timerecord.NewTimeRecorder("loadFieldIndex")
+		err := loader.loadFieldIndex(ctx, segment, indexInfo)
+		loadFieldIndexSpan := tr.RecordSpan()
+		if err != nil {
 			return err
 		}
 
-		bm25Paths, err := resolver.BM25StatsPaths()
+		log.Info("load field binlogs done for sealed segment with index",
+			zap.Int64("fieldID", fieldID),
+			zap.Any("binlog", fieldInfo.FieldBinlog.Binlogs),
+			zap.Int32("current_index_version", fieldInfo.IndexInfo.GetCurrentIndexVersion()),
+			zap.Duration("load_duration", loadFieldIndexSpan),
+		)
+
+		// set average row data size of variable field
+		field, err := schemaHelper.GetFieldFromID(fieldID)
 		if err != nil {
 			return err
 		}
-		if err := loader.loadBm25Stats(ctx, segment.ID(), segment.bm25Stats, bm25Paths); err != nil {
-			return err
+		if typeutil.IsVariableDataType(field.GetDataType()) {
+			err = segment.UpdateFieldRawDataSize(ctx, numRows, fieldInfo.FieldBinlog)
+			if err != nil {
+				return err
+			}
 		}
 	}
+
 	return nil
 }
 
@@ -1117,7 +1304,7 @@ func (loader *segmentLoader) loadBm25Stats(ctx context.Context, segmentID int64,
 }
 
 func (loader *segmentLoader) loadBloomFilter(ctx context.Context, segmentID int64, bfs *pkoracle.BloomFilterSet,
-	binlogPaths []string,
+	binlogPaths []string, logType storage.StatsLogType,
 ) error {
 	log := log.Ctx(ctx).With(
 		zap.Int64("segmentID", segmentID),
@@ -1132,15 +1319,24 @@ func (loader *segmentLoader) loadBloomFilter(ctx context.Context, segmentID int6
 	if err != nil {
 		return err
 	}
-	blobs := make([]*storage.Blob, len(values))
-	for i := range values {
-		blobs[i] = &storage.Blob{Value: values[i]}
+	blobs := []*storage.Blob{}
+	for i := 0; i < len(values); i++ {
+		blobs = append(blobs, &storage.Blob{Value: values[i]})
 	}
 
-	stats, err := storage.DeserializeBloomFilterStats(binlogPaths, blobs)
-	if err != nil {
-		log.Warn("failed to deserialize bloom filter stats", zap.Error(err))
-		return err
+	var stats []*storage.PrimaryKeyStats
+	if logType == storage.CompoundStatsType {
+		stats, err = storage.DeserializeStatsList(blobs[0])
+		if err != nil {
+			log.Warn("failed to deserialize stats list", zap.Error(err))
+			return err
+		}
+	} else {
+		stats, err = storage.DeserializeStats(blobs)
+		if err != nil {
+			log.Warn("failed to deserialize stats", zap.Error(err))
+			return err
+		}
 	}
 
 	var size uint
@@ -1770,8 +1966,7 @@ func estimateLogicalResourceUsageOfSegment(schema *schemapb.CollectionSchema, lo
 	// Text match indexes are evictable (support_eviction=true in caching layer).
 	// Text match index mmap is driven by scalar_field_enable_mmap (same as raw scalar data).
 	textIndexMmapEnable := paramtable.Get().QueryNodeCfg.MmapScalarField.GetAsBool()
-	textStatsLogs, _, _ := packed.NewStatsResolverFromLoadInfo(loadInfo).TextAndJSONIndexStats()
-	for _, textStats := range textStatsLogs {
+	for _, textStats := range loadInfo.GetTextStatsLogs() {
 		if textIndexMmapEnable {
 			segmentEvictableDiskSize += uint64(float64(textStats.GetMemorySize()) * multiplyFactor.textIndexExpansionFactor)
 		} else {
@@ -1999,9 +2194,8 @@ func estimateLoadingResourceUsageOfSegment(schema *schemapb.CollectionSchema, lo
 	}
 
 	// PART 5: calculate size of json key stats data
-	textStatsLogs, jsonKeyStatsLogs, _ := packed.NewStatsResolverFromLoadInfo(loadInfo).TextAndJSONIndexStats()
 	jsonStatsMmapEnable := paramtable.Get().QueryNodeCfg.MmapJSONStats.GetAsBool()
-	for _, jsonKeyStats := range jsonKeyStatsLogs {
+	for _, jsonKeyStats := range loadInfo.GetJsonKeyStatsLogs() {
 		if jsonStatsMmapEnable {
 			if !multiplyFactor.TieredEvictionEnabled {
 				segDiskLoadingSize += uint64(float64(jsonKeyStats.GetMemorySize()) * multiplyFactor.jsonKeyStatsExpansionFactor)
@@ -2030,7 +2224,7 @@ func estimateLoadingResourceUsageOfSegment(schema *schemapb.CollectionSchema, lo
 	// memory_size = sum of Tantivy index file sizes (same value as C++ ByteSize() after load),
 	// so 1.0x is the baseline; textIndexExpansionFactor allows tuning if needed.
 	textIndexMmapEnable := paramtable.Get().QueryNodeCfg.MmapScalarField.GetAsBool()
-	for _, textStats := range textStatsLogs {
+	for _, textStats := range loadInfo.GetTextStatsLogs() {
 		if textIndexMmapEnable {
 			if !multiplyFactor.TieredEvictionEnabled {
 				segDiskLoadingSize += uint64(float64(textStats.GetMemorySize()) * multiplyFactor.textIndexExpansionFactor)
@@ -2201,17 +2395,22 @@ func (loader *segmentLoader) LoadJSONIndex(ctx context.Context,
 		return merr.WrapErrParameterInvalid("LocalSegment", fmt.Sprintf("%T", seg))
 	}
 
-	_, jsonKeyIndexInfo, err := packed.NewStatsResolverFromLoadInfo(loadInfo).TextAndJSONIndexStats()
-	if err != nil {
-		return err
-	}
-	if len(jsonKeyIndexInfo) == 0 {
+	if len(loadInfo.GetJsonKeyStatsLogs()) == 0 {
 		return nil
 	}
 
 	collection := segment.GetCollection()
 	schemaHelper, _ := typeutil.CreateSchemaHelper(collection.Schema())
 
+	jsonKeyIndexInfo := make(map[int64]*datapb.JsonKeyStats, len(loadInfo.GetJsonKeyStatsLogs()))
+	for _, fieldStatsLog := range loadInfo.GetJsonKeyStatsLogs() {
+		jsonKeyLog, ok := jsonKeyIndexInfo[fieldStatsLog.FieldID]
+		if !ok {
+			jsonKeyIndexInfo[fieldStatsLog.FieldID] = fieldStatsLog
+		} else if fieldStatsLog.GetVersion() > jsonKeyLog.GetVersion() {
+			jsonKeyIndexInfo[fieldStatsLog.FieldID] = fieldStatsLog
+		}
+	}
 	for _, info := range jsonKeyIndexInfo {
 		if err := segment.LoadJSONKeyIndex(ctx, info, schemaHelper); err != nil {
 			return err

--- a/internal/querynodev2/segments/segment_loader_test.go
+++ b/internal/querynodev2/segments/segment_loader_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/metric"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
 type SegmentLoaderSuite struct {
@@ -1408,6 +1409,215 @@ func TestSeparateLoadInfoV2_MixedExternalAndNormalFields(t *testing.T) {
 	assert.Len(t, fieldBinlogs, 0)
 	// IndexInfos still contains both external and normal field indexes
 	assert.Len(t, loadInfo.IndexInfos, 2)
+}
+
+func TestSeparateLoadInfoV2_ExternalFieldInShortColumnGroupV3(t *testing.T) {
+	// Verify that external fields within a short column group (FieldID=0) are skipped
+	// when matching indexes, but the short column group binlog entry itself is kept.
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{Name: "__virtual_pk__", FieldID: 100, DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+			{Name: "ext_id", FieldID: 101, DataType: schemapb.DataType_Int64, ExternalField: "id"},
+			{Name: "normal_ts", FieldID: 103, DataType: schemapb.DataType_Int64},
+		},
+	}
+
+	loadInfo := &querypb.SegmentLoadInfo{
+		StorageVersion: storage.StorageV3,
+		IndexInfos: []*querypb.FieldIndexInfo{
+			// Index on external field 101 — should NOT be matched via short column group
+			{FieldID: 101, IndexID: 1001, IndexFilePaths: []string{"index/101/file1"}},
+			// Index on normal field 103 — should be matched
+			{FieldID: 103, IndexID: 1003, IndexFilePaths: []string{"index/103/file1"}},
+		},
+		BinlogPaths: []*datapb.FieldBinlog{
+			// Short column group (FieldID=0) contains all fields
+			{FieldID: 0, Binlogs: []*datapb.Binlog{{LogPath: "binlog/short_group"}}},
+		},
+	}
+
+	indexedFieldInfos, fieldBinlogs, _, _, _ := separateLoadInfoV2(loadInfo, schema)
+
+	// Normal field 103 should be matched via short column group iteration
+	assert.Contains(t, indexedFieldInfos, int64(1003))
+	// External field 101 should NOT be matched (skipped by externalFieldIDs check)
+	assert.NotContains(t, indexedFieldInfos, int64(1001))
+	// Short column group binlog should still be in fieldBinlogs
+	assert.Len(t, fieldBinlogs, 1)
+	assert.Equal(t, int64(0), fieldBinlogs[0].FieldID)
+}
+
+func TestSeparateLoadInfoV2_ExternalFieldBinlogsSkippedV3(t *testing.T) {
+	// Verify that BinlogPaths entries for external fields are skipped in the V3 path.
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{Name: "__virtual_pk__", FieldID: 100, DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+			{Name: "ext_id", FieldID: 101, DataType: schemapb.DataType_Int64, ExternalField: "id"},
+			{Name: "ext_vec", FieldID: 102, DataType: schemapb.DataType_FloatVector, ExternalField: "vec"},
+			{Name: "normal_ts", FieldID: 103, DataType: schemapb.DataType_Int64},
+		},
+	}
+
+	loadInfo := &querypb.SegmentLoadInfo{
+		StorageVersion: storage.StorageV3,
+		BinlogPaths: []*datapb.FieldBinlog{
+			{FieldID: 100, Binlogs: []*datapb.Binlog{{LogPath: "binlog/100"}}},
+			{FieldID: 101, Binlogs: []*datapb.Binlog{{LogPath: "binlog/101"}}}, // external, should skip
+			{FieldID: 102, Binlogs: []*datapb.Binlog{{LogPath: "binlog/102"}}}, // external, should skip
+			{FieldID: 103, Binlogs: []*datapb.Binlog{{LogPath: "binlog/103"}}},
+		},
+	}
+
+	_, fieldBinlogs, _, _, _ := separateLoadInfoV2(loadInfo, schema)
+
+	// Only non-external fields (100 and 103) should remain in fieldBinlogs
+	assert.Len(t, fieldBinlogs, 2)
+	fieldIDs := make([]int64, len(fieldBinlogs))
+	for i, fb := range fieldBinlogs {
+		fieldIDs[i] = fb.FieldID
+	}
+	assert.Contains(t, fieldIDs, int64(100))
+	assert.Contains(t, fieldIDs, int64(103))
+	assert.NotContains(t, fieldIDs, int64(101))
+	assert.NotContains(t, fieldIDs, int64(102))
+}
+
+func TestSeparateLoadInfoV2_ExternalFieldBinlogsSkippedLegacy(t *testing.T) {
+	// Verify that BinlogPaths entries for external fields are skipped in the legacy (non-V2/V3) path.
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{Name: "__virtual_pk__", FieldID: 100, DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+			{Name: "ext_field", FieldID: 101, DataType: schemapb.DataType_Int64, ExternalField: "col1"},
+			{Name: "normal_field", FieldID: 102, DataType: schemapb.DataType_Int64},
+		},
+	}
+
+	loadInfo := &querypb.SegmentLoadInfo{
+		StorageVersion: 0, // legacy, not V2 or V3
+		BinlogPaths: []*datapb.FieldBinlog{
+			{FieldID: 100, Binlogs: []*datapb.Binlog{{LogPath: "binlog/100"}}},
+			{FieldID: 101, Binlogs: []*datapb.Binlog{{LogPath: "binlog/101"}}}, // external, should skip
+			{FieldID: 102, Binlogs: []*datapb.Binlog{{LogPath: "binlog/102"}}},
+		},
+	}
+
+	_, fieldBinlogs, _, _, _ := separateLoadInfoV2(loadInfo, schema)
+
+	// Only non-external fields (100 and 102) should remain
+	assert.Len(t, fieldBinlogs, 2)
+	fieldIDs := make([]int64, len(fieldBinlogs))
+	for i, fb := range fieldBinlogs {
+		fieldIDs[i] = fb.FieldID
+	}
+	assert.Contains(t, fieldIDs, int64(100))
+	assert.Contains(t, fieldIDs, int64(102))
+	assert.NotContains(t, fieldIDs, int64(101))
+}
+
+func TestSeparateLoadInfoV2_NonExternalCollectionUnaffected(t *testing.T) {
+	// Verify that non-external collections are unaffected by external field filtering.
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{Name: "pk", FieldID: 100, DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+			{Name: "field1", FieldID: 101, DataType: schemapb.DataType_Int64},
+			{Name: "field2", FieldID: 102, DataType: schemapb.DataType_FloatVector},
+		},
+	}
+
+	loadInfo := &querypb.SegmentLoadInfo{
+		StorageVersion: storage.StorageV3,
+		BinlogPaths: []*datapb.FieldBinlog{
+			{FieldID: 100, Binlogs: []*datapb.Binlog{{LogPath: "binlog/100"}}},
+			{FieldID: 101, Binlogs: []*datapb.Binlog{{LogPath: "binlog/101"}}},
+			{FieldID: 102, Binlogs: []*datapb.Binlog{{LogPath: "binlog/102"}}},
+		},
+	}
+
+	_, fieldBinlogs, _, _, _ := separateLoadInfoV2(loadInfo, schema)
+
+	// All fields should be included (no external fields to skip)
+	assert.Len(t, fieldBinlogs, 3)
+}
+
+func TestDetectVirtualPKCollisions(t *testing.T) {
+	t.Run("NoCollision", func(t *testing.T) {
+		infos := []*querypb.SegmentLoadInfo{
+			{SegmentID: 1},
+			{SegmentID: 2},
+			{SegmentID: 3},
+		}
+		collisions := detectVirtualPKCollisions(1, infos)
+		assert.Empty(t, collisions)
+	})
+
+	t.Run("CollisionWithTruncatedID", func(t *testing.T) {
+		// Two segment IDs with same lower 32 bits but different upper bits
+		segID1 := int64(0x100000001) // lower 32 = 1
+		segID2 := int64(0x200000001) // lower 32 = 1
+		infos := []*querypb.SegmentLoadInfo{
+			{SegmentID: segID1},
+			{SegmentID: segID2},
+			{SegmentID: 3},
+		}
+		collisions := detectVirtualPKCollisions(segID1, infos)
+		assert.Equal(t, []int64{segID2}, collisions)
+	})
+
+	t.Run("SelfNotIncluded", func(t *testing.T) {
+		infos := []*querypb.SegmentLoadInfo{
+			{SegmentID: 100},
+		}
+		collisions := detectVirtualPKCollisions(100, infos)
+		assert.Empty(t, collisions)
+	})
+
+	t.Run("MultipleCollisions", func(t *testing.T) {
+		segID1 := int64(0x100000005)
+		segID2 := int64(0x200000005)
+		segID3 := int64(0x300000005)
+		infos := []*querypb.SegmentLoadInfo{
+			{SegmentID: segID1},
+			{SegmentID: segID2},
+			{SegmentID: segID3},
+		}
+		collisions := detectVirtualPKCollisions(segID1, infos)
+		assert.Len(t, collisions, 2)
+		assert.Contains(t, collisions, segID2)
+		assert.Contains(t, collisions, segID3)
+	})
+
+	t.Run("EmptyInfos", func(t *testing.T) {
+		collisions := detectVirtualPKCollisions(100, nil)
+		assert.Empty(t, collisions)
+	})
+}
+
+func TestExternalCollectionSkipsDeltaLogs(t *testing.T) {
+	// Verify that IsExternalCollection correctly identifies external schemas,
+	// which is the condition used to skip delta log loading in the segment loader.
+	externalSchema := &schemapb.CollectionSchema{
+		ExternalSource: "s3://bucket/data",
+		Fields: []*schemapb.FieldSchema{
+			{Name: "vec", DataType: schemapb.DataType_FloatVector, ExternalField: "embedding"},
+		},
+	}
+	assert.True(t, typeutil.IsExternalCollection(externalSchema))
+
+	normalSchema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{Name: "vec", DataType: schemapb.DataType_FloatVector},
+		},
+	}
+	assert.False(t, typeutil.IsExternalCollection(normalSchema))
+
+	// Empty ExternalSource is not external
+	emptySourceSchema := &schemapb.CollectionSchema{
+		ExternalSource: "",
+		Fields: []*schemapb.FieldSchema{
+			{Name: "vec", DataType: schemapb.DataType_FloatVector},
+		},
+	}
+	assert.False(t, typeutil.IsExternalCollection(emptySourceSchema))
 }
 
 func TestSegmentLoader(t *testing.T) {

--- a/internal/querynodev2/segments/segment_loader_test.go
+++ b/internal/querynodev2/segments/segment_loader_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/atomic"
@@ -244,9 +245,9 @@ func (suite *SegmentLoaderSuite) TestLoadMultipleSegments() {
 	for _, segment := range segments {
 		for pk := 0; pk < 100; pk++ {
 			lc := storage.NewLocationsCache(storage.NewInt64PrimaryKey(int64(pk)))
-			exist := segment.BloomFilterExist()
-			suite.Require().True(exist)
-			exist = segment.MayPkExist(lc)
+			pkReady := segment.PkCandidateExist()
+			suite.Require().True(pkReady)
+			exist := segment.MayPkExist(lc)
 			suite.Require().True(exist)
 		}
 	}
@@ -281,9 +282,9 @@ func (suite *SegmentLoaderSuite) TestLoadMultipleSegments() {
 	for _, segment := range segments {
 		for pk := 0; pk < 100; pk++ {
 			lc := storage.NewLocationsCache(storage.NewInt64PrimaryKey(int64(pk)))
-			exist := segment.BloomFilterExist()
-			suite.True(exist)
-			exist = segment.MayPkExist(lc)
+			pkReady := segment.PkCandidateExist()
+			suite.True(pkReady)
+			exist := segment.MayPkExist(lc)
 			suite.True(exist)
 		}
 	}
@@ -1324,6 +1325,89 @@ func (suite *SegmentLoaderTextIndexEstimateSuite) TestLogicalEstimate_ExpansionF
 	suite.NoError(err)
 	expected := uint64(float64(textIndexSize) * expansionFactor)
 	suite.EqualValues(expected, usage.MemorySize)
+}
+
+func TestSeparateLoadInfoV2_ExternalFieldIndexNotSkipped(t *testing.T) {
+	// Verifies that indexes on external fields are NOT skipped in separateLoadInfoV2.
+	// Previously, external field indexes were filtered out, preventing index loading for external tables.
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{Name: "__virtual_pk__", FieldID: 100, DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+			{Name: "id", FieldID: 101, DataType: schemapb.DataType_Int64, ExternalField: "id"},
+			{Name: "embedding", FieldID: 102, DataType: schemapb.DataType_FloatVector, ExternalField: "embedding"},
+		},
+	}
+
+	loadInfo := &querypb.SegmentLoadInfo{
+		StorageVersion: storage.StorageV3,
+		IndexInfos: []*querypb.FieldIndexInfo{
+			{
+				FieldID:        101,
+				IndexID:        1001,
+				IndexFilePaths: []string{"index/101/file1", "index/101/file2"},
+			},
+			{
+				FieldID:        102,
+				IndexID:        1002,
+				IndexFilePaths: []string{"index/102/file1"},
+			},
+		},
+		// External segments have no BinlogPaths — data is loaded from manifest
+		BinlogPaths: []*datapb.FieldBinlog{},
+	}
+
+	indexedFieldInfos, fieldBinlogs, _, _, _ := separateLoadInfoV2(loadInfo, schema)
+
+	// External field indexes should be included (not skipped)
+	assert.Len(t, indexedFieldInfos, 0, "no binlog paths means no indexed field infos via binlog matching")
+	assert.Len(t, fieldBinlogs, 0, "no binlog paths for external segments")
+
+	// The key point: fieldID2IndexInfo should contain external field indexes.
+	// Even though indexedFieldInfos is empty (no binlog to match), the indexes are
+	// still available in loadInfo.IndexInfos for the C++ managed loading path.
+	// This test ensures the code doesn't filter them out from IndexInfos.
+	assert.Len(t, loadInfo.IndexInfos, 2, "IndexInfos should still contain all external field indexes")
+}
+
+func TestSeparateLoadInfoV2_MixedExternalAndNormalFields(t *testing.T) {
+	// Verify that normal field indexes are matched while external field binlogs are skipped.
+	// Index info for both external and normal fields should remain in IndexInfos.
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{Name: "__virtual_pk__", FieldID: 100, DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+			{Name: "id", FieldID: 101, DataType: schemapb.DataType_Int64, ExternalField: "id"},
+			{Name: "normal_field", FieldID: 103, DataType: schemapb.DataType_Int64},
+		},
+	}
+
+	loadInfo := &querypb.SegmentLoadInfo{
+		StorageVersion: storage.StorageV3,
+		IndexInfos: []*querypb.FieldIndexInfo{
+			{
+				FieldID:        101,
+				IndexID:        1001,
+				IndexFilePaths: []string{"index/101/file1"},
+			},
+			{
+				FieldID:        103,
+				IndexID:        1003,
+				IndexFilePaths: []string{"index/103/file1"},
+			},
+		},
+		BinlogPaths: []*datapb.FieldBinlog{
+			// Normal field has binlog; external field 101 does not
+			{FieldID: 103, Binlogs: []*datapb.Binlog{{LogPath: "binlog/103"}}},
+		},
+	}
+
+	indexedFieldInfos, fieldBinlogs, _, _, _ := separateLoadInfoV2(loadInfo, schema)
+
+	// Normal field 103 has binlog + index → indexed
+	assert.Len(t, indexedFieldInfos, 1)
+	assert.Contains(t, indexedFieldInfos, int64(1003))
+	assert.Len(t, fieldBinlogs, 0)
+	// IndexInfos still contains both external and normal field indexes
+	assert.Len(t, loadInfo.IndexInfos, 2)
 }
 
 func TestSegmentLoader(t *testing.T) {

--- a/internal/querynodev2/segments/segment_test.go
+++ b/internal/querynodev2/segments/segment_test.go
@@ -6,10 +6,13 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/atomic"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/mocks/util/mock_segcore"
+	"github.com/milvus-io/milvus/internal/querynodev2/pkoracle"
 	storage "github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/util/initcore"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
@@ -273,4 +276,159 @@ func (suite *SegmentSuite) TestSegmentReleased() {
 
 func TestSegment(t *testing.T) {
 	suite.Run(t, new(SegmentSuite))
+}
+
+// newTestBaseSegment creates a baseSegment for testing without requiring segcore Collection.
+func newTestBaseSegment(segmentID, partitionID int64) baseSegment {
+	return baseSegment{
+		loadInfo: atomic.NewPointer(&querypb.SegmentLoadInfo{
+			SegmentID:   segmentID,
+			PartitionID: partitionID,
+		}),
+		version:            atomic.NewInt64(0),
+		bm25Stats:          make(map[int64]*storage.BM25Stats),
+		resourceUsageCache: atomic.NewPointer[ResourceUsage](nil),
+		needUpdatedVersion: atomic.NewInt64(0),
+	}
+}
+
+// TestBaseSegment_PkCandidateExternalCandidate tests pkCandidate wrapper methods
+// with an ExternalSegmentCandidate (used for external/virtual-PK collections).
+func TestBaseSegment_PkCandidateExternalCandidate(t *testing.T) {
+	paramtable.Init()
+
+	segmentID := int64(12345)
+	partitionID := int64(10)
+	candidate := pkoracle.NewExternalSegmentCandidate(segmentID, partitionID, SegmentTypeSealed)
+
+	bs := newTestBaseSegment(segmentID, partitionID)
+	bs.SetPKCandidate(candidate)
+
+	// PkCandidateExist: ExternalSegmentCandidate always returns true
+	assert.True(t, bs.PkCandidateExist())
+
+	// Stats: ExternalSegmentCandidate returns nil
+	assert.Nil(t, bs.Stats())
+
+	// GetMinPk / GetMaxPk: nil stats → nil
+	assert.Nil(t, bs.GetMinPk())
+	assert.Nil(t, bs.GetMaxPk())
+
+	// Charge / Refund: no-op, should not panic
+	bs.Charge()
+	bs.Refund()
+
+	// UpdatePkCandidate: no-op for external candidate
+	bs.UpdatePkCandidate([]storage.PrimaryKey{storage.NewInt64PrimaryKey(1)})
+
+	// MayPkExist with a virtual PK belonging to this segment
+	virtualPK := GetVirtualPK(segmentID, 42)
+	lc := storage.NewLocationsCache(storage.NewInt64PrimaryKey(virtualPK))
+	assert.True(t, bs.MayPkExist(lc))
+
+	// MayPkExist with a virtual PK from a different segment
+	otherPK := GetVirtualPK(segmentID+1, 42)
+	lc2 := storage.NewLocationsCache(storage.NewInt64PrimaryKey(otherPK))
+	assert.False(t, bs.MayPkExist(lc2))
+
+	// BatchPkExist
+	pks := []storage.PrimaryKey{
+		storage.NewInt64PrimaryKey(GetVirtualPK(segmentID, 0)),
+		storage.NewInt64PrimaryKey(GetVirtualPK(segmentID+1, 0)),
+		storage.NewInt64PrimaryKey(GetVirtualPK(segmentID, 99)),
+	}
+	blc := storage.NewBatchLocationsCache(pks)
+	results := bs.BatchPkExist(blc)
+	assert.Equal(t, []bool{true, false, true}, results)
+}
+
+// TestBaseSegment_GetMinMaxPkWithStats tests GetMinPk/GetMaxPk when Stats() returns non-nil.
+func TestBaseSegment_GetMinMaxPkWithStats(t *testing.T) {
+	paramtable.Init()
+
+	segmentID := int64(100)
+	partitionID := int64(10)
+	bfs := pkoracle.NewBloomFilterSet(segmentID, partitionID, SegmentTypeSealed)
+	// Feed PKs so Stats() returns non-nil with min/max
+	bfs.UpdatePkCandidate([]storage.PrimaryKey{
+		storage.NewInt64PrimaryKey(10),
+		storage.NewInt64PrimaryKey(50),
+		storage.NewInt64PrimaryKey(100),
+	})
+
+	bs := newTestBaseSegment(segmentID, partitionID)
+	bs.SetPKCandidate(bfs)
+
+	minPk := bs.GetMinPk()
+	assert.NotNil(t, minPk)
+	maxPk := bs.GetMaxPk()
+	assert.NotNil(t, maxPk)
+}
+
+// TestBaseSegment_PkCandidateNil tests pkCandidate wrapper methods when candidate is nil.
+func TestBaseSegment_PkCandidateNil(t *testing.T) {
+	paramtable.Init()
+
+	bs := newTestBaseSegment(1, 0)
+	// pkCandidate is nil by default from newTestBaseSegment
+
+	// PkCandidateExist: nil → false
+	assert.False(t, bs.PkCandidateExist())
+
+	// Stats: nil candidate → nil
+	assert.Nil(t, bs.Stats())
+
+	// GetMinPk / GetMaxPk: nil candidate → nil
+	assert.Nil(t, bs.GetMinPk())
+	assert.Nil(t, bs.GetMaxPk())
+
+	// Charge / Refund: nil candidate → no-op, should not panic
+	bs.Charge()
+	bs.Refund()
+
+	// UpdatePkCandidate: nil candidate → no-op
+	bs.UpdatePkCandidate([]storage.PrimaryKey{storage.NewInt64PrimaryKey(1)})
+
+	// MayPkExist: nil candidate → returns true (assume PK might exist)
+	lc := storage.NewLocationsCache(storage.NewInt64PrimaryKey(42))
+	assert.True(t, bs.MayPkExist(lc))
+
+	// BatchPkExist: nil candidate → all true (consistent with MayPkExist)
+	pks := []storage.PrimaryKey{
+		storage.NewInt64PrimaryKey(1),
+		storage.NewInt64PrimaryKey(2),
+	}
+	blc := storage.NewBatchLocationsCache(pks)
+	results := bs.BatchPkExist(blc)
+	assert.Equal(t, []bool{true, true}, results)
+}
+
+// TestBaseSegment_SkipGrowingBF tests that skipGrowingBF bypasses PK candidate checks.
+func TestBaseSegment_SkipGrowingBF(t *testing.T) {
+	paramtable.Init()
+
+	segmentID := int64(100)
+	candidate := pkoracle.NewExternalSegmentCandidate(segmentID, 10, SegmentTypeGrowing)
+
+	bs := newTestBaseSegment(segmentID, 10)
+	bs.skipGrowingBF = true
+	bs.SetPKCandidate(candidate)
+
+	// MayPkExist: skipGrowingBF → always true regardless of candidate
+	otherPK := GetVirtualPK(segmentID+999, 42)
+	lc := storage.NewLocationsCache(storage.NewInt64PrimaryKey(otherPK))
+	assert.True(t, bs.MayPkExist(lc))
+
+	// UpdatePkCandidate: skipGrowingBF → skips update
+	bs.UpdatePkCandidate([]storage.PrimaryKey{storage.NewInt64PrimaryKey(1)})
+
+	// BatchPkExist: skipGrowingBF → all true
+	pks := []storage.PrimaryKey{
+		storage.NewInt64PrimaryKey(1),
+		storage.NewInt64PrimaryKey(2),
+		storage.NewInt64PrimaryKey(3),
+	}
+	blc := storage.NewBatchLocationsCache(pks)
+	results := bs.BatchPkExist(blc)
+	assert.Equal(t, []bool{true, true, true}, results)
 }

--- a/internal/querynodev2/segments/utils.go
+++ b/internal/querynodev2/segments/utils.go
@@ -334,3 +334,35 @@ func getScalarDataWarmupPolicy(fieldSchema *schemapb.FieldSchema) string {
 	}
 	return params.Params.QueryNodeCfg.TieredWarmupScalarField.GetValue()
 }
+
+// GetVirtualPK generates a virtual primary key from segmentID and offset.
+// Virtual PK format: (truncated_segmentID << 32) | offset
+// Only the lower 32 bits of segmentID are preserved. Milvus segment IDs are
+// TSO-allocated 64-bit values that typically exceed 32 bits, so truncation
+// is expected. Use IsVirtualPKFromSegment for safe comparison.
+func GetVirtualPK(segmentID int64, offset int64) int64 {
+	return ((segmentID & 0xFFFFFFFF) << 32) | (offset & 0xFFFFFFFF)
+}
+
+// ExtractSegmentIDFromVirtualPK extracts the segmentID from a virtual PK.
+// Uses unsigned right shift to avoid sign-extension for large segment IDs.
+func ExtractSegmentIDFromVirtualPK(virtualPK int64) int64 {
+	return int64(uint64(virtualPK) >> 32)
+}
+
+// ExtractOffsetFromVirtualPK extracts the offset from a virtual PK.
+func ExtractOffsetFromVirtualPK(virtualPK int64) int64 {
+	return virtualPK & 0xFFFFFFFF
+}
+
+// IsVirtualPKFromSegment checks if a virtual PK belongs to the given segment.
+// Note: Only the lower 32 bits of segmentID are preserved in the virtual PK,
+// so we compare with the truncated segment ID.
+func IsVirtualPKFromSegment(virtualPK int64, segmentID int64) bool {
+	return ExtractSegmentIDFromVirtualPK(virtualPK) == (segmentID & 0xFFFFFFFF)
+}
+
+// IsExternalField checks if a field is an external field (data stored externally).
+func IsExternalField(field *schemapb.FieldSchema) bool {
+	return field.GetExternalField() != ""
+}

--- a/internal/querynodev2/segments/utils_test.go
+++ b/internal/querynodev2/segments/utils_test.go
@@ -417,3 +417,182 @@ func TestGetScalarDataWarmupPolicy(t *testing.T) {
 		assert.Equal(t, common.WarmupSync, policy)
 	})
 }
+
+// Tests for external collection utilities
+
+func TestIsExternalField(t *testing.T) {
+	t.Run("ExternalField", func(t *testing.T) {
+		field := &schemapb.FieldSchema{
+			FieldID:       100,
+			Name:          "vector",
+			ExternalField: "external_vector_col",
+		}
+		assert.True(t, IsExternalField(field))
+	})
+
+	t.Run("RegularField", func(t *testing.T) {
+		field := &schemapb.FieldSchema{
+			FieldID:       100,
+			Name:          "vector",
+			ExternalField: "",
+		}
+		assert.False(t, IsExternalField(field))
+	})
+
+	t.Run("NilExternalField", func(t *testing.T) {
+		field := &schemapb.FieldSchema{
+			FieldID: 100,
+			Name:    "vector",
+		}
+		assert.False(t, IsExternalField(field))
+	})
+}
+
+func TestGetVirtualPK(t *testing.T) {
+	t.Run("BasicGeneration", func(t *testing.T) {
+		segmentID := int64(12345)
+		offset := int64(100)
+		virtualPK := GetVirtualPK(segmentID, offset)
+
+		expected := (segmentID << 32) | offset
+		assert.Equal(t, expected, virtualPK)
+	})
+
+	t.Run("ZeroOffset", func(t *testing.T) {
+		segmentID := int64(1)
+		offset := int64(0)
+		virtualPK := GetVirtualPK(segmentID, offset)
+
+		assert.Equal(t, int64(1)<<32, virtualPK)
+	})
+
+	t.Run("LargeOffset", func(t *testing.T) {
+		segmentID := int64(1)
+		offset := int64(0xFFFFFFFF) // Max 32-bit value
+		virtualPK := GetVirtualPK(segmentID, offset)
+
+		extractedSegment := ExtractSegmentIDFromVirtualPK(virtualPK)
+		extractedOffset := ExtractOffsetFromVirtualPK(virtualPK)
+
+		assert.Equal(t, int64(1), extractedSegment)
+		assert.Equal(t, int64(0xFFFFFFFF), extractedOffset)
+	})
+}
+
+func TestExtractSegmentIDFromVirtualPK(t *testing.T) {
+	t.Run("BasicExtraction", func(t *testing.T) {
+		segmentID := int64(999)
+		offset := int64(500)
+		virtualPK := GetVirtualPK(segmentID, offset)
+
+		extracted := ExtractSegmentIDFromVirtualPK(virtualPK)
+		assert.Equal(t, segmentID, extracted)
+	})
+
+	t.Run("ZeroSegmentID", func(t *testing.T) {
+		virtualPK := GetVirtualPK(0, 100)
+		extracted := ExtractSegmentIDFromVirtualPK(virtualPK)
+		assert.Equal(t, int64(0), extracted)
+	})
+
+	t.Run("MaxValidSegmentID", func(t *testing.T) {
+		segmentID := int64(0xFFFFFFFF)
+		virtualPK := GetVirtualPK(segmentID, 0)
+		extracted := ExtractSegmentIDFromVirtualPK(virtualPK)
+		assert.Equal(t, segmentID, extracted)
+	})
+
+	t.Run("LargeSegmentIDTruncated", func(t *testing.T) {
+		// Milvus segment IDs are TSO-allocated 64-bit values.
+		// GetVirtualPK truncates to lower 32 bits.
+		segmentID := int64(464224901019732378) // Real Milvus segment ID
+		virtualPK := GetVirtualPK(segmentID, 0)
+		extracted := ExtractSegmentIDFromVirtualPK(virtualPK)
+		assert.Equal(t, segmentID&0xFFFFFFFF, extracted)
+		assert.True(t, IsVirtualPKFromSegment(virtualPK, segmentID))
+	})
+}
+
+func TestExtractOffsetFromVirtualPK(t *testing.T) {
+	t.Run("BasicExtraction", func(t *testing.T) {
+		segmentID := int64(999)
+		offset := int64(500)
+		virtualPK := GetVirtualPK(segmentID, offset)
+
+		extracted := ExtractOffsetFromVirtualPK(virtualPK)
+		assert.Equal(t, offset, extracted)
+	})
+
+	t.Run("ZeroOffset", func(t *testing.T) {
+		virtualPK := GetVirtualPK(100, 0)
+		extracted := ExtractOffsetFromVirtualPK(virtualPK)
+		assert.Equal(t, int64(0), extracted)
+	})
+
+	t.Run("MaxOffset", func(t *testing.T) {
+		maxOffset := int64(0xFFFFFFFF)
+		virtualPK := GetVirtualPK(100, maxOffset)
+		extracted := ExtractOffsetFromVirtualPK(virtualPK)
+		assert.Equal(t, maxOffset, extracted)
+	})
+}
+
+func TestIsVirtualPKFromSegment(t *testing.T) {
+	t.Run("Matching", func(t *testing.T) {
+		segmentID := int64(12345)
+		virtualPK := GetVirtualPK(segmentID, 100)
+
+		assert.True(t, IsVirtualPKFromSegment(virtualPK, segmentID))
+	})
+
+	t.Run("NotMatching", func(t *testing.T) {
+		segmentID := int64(12345)
+		virtualPK := GetVirtualPK(segmentID, 100)
+
+		assert.False(t, IsVirtualPKFromSegment(virtualPK, segmentID+1))
+		assert.False(t, IsVirtualPKFromSegment(virtualPK, 0))
+	})
+
+	t.Run("TruncatedSegmentID", func(t *testing.T) {
+		// Segment ID with upper bits set - truncation is expected
+		segmentID := int64(0x100000001) // 33-bit value, lower 32 bits = 1
+		virtualPK := GetVirtualPK(segmentID, 100)
+
+		// Should match both the original and truncated segment ID
+		assert.True(t, IsVirtualPKFromSegment(virtualPK, segmentID))
+		assert.True(t, IsVirtualPKFromSegment(virtualPK, 1)) // Truncated
+	})
+}
+
+func TestVirtualPKRoundTrip(t *testing.T) {
+	testCases := []struct {
+		segmentID int64
+		offset    int64
+	}{
+		{0, 0},
+		{1, 0},
+		{0, 1},
+		{100, 100},
+		{12345, 67890},
+		{0xFFFFFFFF, 0xFFFFFFFF},
+		{1, 0xFFFFFFFF},
+		{0xFFFFFFFF, 1},
+	}
+
+	for _, tc := range testCases {
+		virtualPK := GetVirtualPK(tc.segmentID, tc.offset)
+		extractedSegment := ExtractSegmentIDFromVirtualPK(virtualPK)
+		extractedOffset := ExtractOffsetFromVirtualPK(virtualPK)
+
+		// Note: segment ID is truncated to lower 32 bits
+		expectedSegment := tc.segmentID & 0xFFFFFFFF
+		expectedOffset := tc.offset & 0xFFFFFFFF
+
+		assert.Equal(t, expectedSegment, extractedSegment,
+			"Segment ID mismatch for input segmentID=%d, offset=%d", tc.segmentID, tc.offset)
+		assert.Equal(t, expectedOffset, extractedOffset,
+			"Offset mismatch for input segmentID=%d, offset=%d", tc.segmentID, tc.offset)
+		assert.True(t, IsVirtualPKFromSegment(virtualPK, tc.segmentID),
+			"IsVirtualPKFromSegment should return true for input segmentID=%d", tc.segmentID)
+	}
+}

--- a/internal/storagev2/packed/explore_ffi.go
+++ b/internal/storagev2/packed/explore_ffi.go
@@ -19,6 +19,7 @@ package packed
 #include <stdlib.h>
 #include "milvus-storage/ffi_c.h"
 #include "milvus-storage/ffi_exttable_c.h"
+#include "milvus-storage/ffi_filesystem_c.h"
 #include "arrow/c/abi.h"
 #include "arrow/c/helpers.h"
 */
@@ -28,6 +29,9 @@ import (
 	"fmt"
 	"unsafe"
 
+	"go.uber.org/zap"
+
+	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
 )
 
@@ -37,16 +41,18 @@ type FileInfo struct {
 	NumRows  int64
 }
 
-// ExploreFiles scans an external directory and returns a list of file paths.
+// ExploreFiles scans an external directory and returns file information.
 // It internally calls exttable_explore to find files, then reads the manifest
-// to extract column group and file information.
+// to extract column group, file path, and row count information.
+// For lance-table format, row counts come from the manifest (via BlockingDataset).
+// For other formats, row counts are set to 0 and must be fetched separately via GetFileInfo.
 func ExploreFiles(
 	columns []string,
 	format string,
 	baseDir string,
 	exploreDir string,
 	storageConfig *indexpb.StorageConfig,
-) ([]string, error) {
+) ([]FileInfo, error) {
 	// Create C string arrays for columns
 	cColumns := make([]*C.char, len(columns))
 	for i, col := range columns {
@@ -117,8 +123,8 @@ func ExploreFiles(
 	// Ensure we destroy the manifest when done (this also frees column_groups)
 	defer C.loon_manifest_destroy(manifest)
 
-	// Step 3: Extract file paths from manifest's column groups
-	var filePaths []string
+	// Step 3: Extract file paths and row counts from manifest's column groups
+	var fileInfos []FileInfo
 	cgroups := &manifest.column_groups
 
 	// Validate column groups structure before accessing
@@ -146,11 +152,14 @@ func ExploreFiles(
 			if fileArray[j].path == nil {
 				return nil, fmt.Errorf("file path is nil in column group %d, file %d (possible FFI data corruption)", i, j)
 			}
-			filePaths = append(filePaths, C.GoString(fileArray[j].path))
+			fileInfos = append(fileInfos, FileInfo{
+				FilePath: C.GoString(fileArray[j].path),
+				NumRows:  int64(fileArray[j].end_index),
+			})
 		}
 	}
 
-	return filePaths, nil
+	return fileInfos, nil
 }
 
 // GetFileInfo retrieves row count information for a single external file.
@@ -183,4 +192,65 @@ func GetFileInfo(
 		FilePath: filePath,
 		NumRows:  int64(numRows),
 	}, nil
+}
+
+// CleanupExploreTempDir removes all files created by ExploreFiles in the temp directory.
+// The loon_exttable_explore FFI writes manifest files to baseDir as a side effect.
+// This function cleans up those temp files after the explore results have been consumed.
+func CleanupExploreTempDir(tempDir string, storageConfig *indexpb.StorageConfig) {
+	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
+	if err != nil {
+		log.Warn("failed to create properties for explore temp cleanup", zap.Error(err))
+		return
+	}
+	defer C.loon_properties_free(cProperties)
+
+	// Get filesystem handle
+	cPath := C.CString(tempDir)
+	defer C.free(unsafe.Pointer(cPath))
+	pathLen := C.uint32_t(len(tempDir))
+
+	var fsHandle C.FileSystemHandle
+	result := C.loon_filesystem_get(cProperties, cPath, pathLen, &fsHandle)
+	if err := HandleLoonFFIResult(result); err != nil {
+		log.Warn("failed to get filesystem for explore temp cleanup",
+			zap.String("tempDir", tempDir), zap.Error(err))
+		return
+	}
+	defer C.loon_filesystem_destroy(fsHandle)
+
+	// List all files in the temp directory
+	var fileInfoList C.LoonFileInfoList
+
+	result = C.loon_filesystem_list_dir(
+		fsHandle, cPath, pathLen, true, // recursive
+		&fileInfoList,
+	)
+	if err := HandleLoonFFIResult(result); err != nil {
+		log.Warn("failed to list explore temp dir for cleanup",
+			zap.String("tempDir", tempDir), zap.Error(err))
+		return
+	}
+	defer C.loon_filesystem_free_file_info_list(&fileInfoList)
+
+	count := int(fileInfoList.count)
+	if count == 0 {
+		return
+	}
+
+	// Convert C array to Go slice for safe access
+	entries := unsafe.Slice(fileInfoList.entries, count)
+
+	// Delete files first (not directories), in reverse order
+	for i := count - 1; i >= 0; i-- {
+		if entries[i].is_dir {
+			continue
+		}
+		delResult := C.loon_filesystem_delete_file(fsHandle, entries[i].path, entries[i].path_len)
+		if err := HandleLoonFFIResult(delResult); err != nil {
+			log.Warn("failed to delete explore temp file",
+				zap.String("file", C.GoStringN(entries[i].path, C.int(entries[i].path_len))),
+				zap.Error(err))
+		}
+	}
 }

--- a/internal/storagev2/packed/exttable_test.go
+++ b/internal/storagev2/packed/exttable_test.go
@@ -291,6 +291,52 @@ func TestGetColumnNamesFromSchema_WithExternalField(t *testing.T) {
 	assert.Equal(t, []string{"external_id", "vector", "raw_text"}, columns)
 }
 
+func TestGetColumnNamesFromSchema_ExternalCollectionSkipsSystemFields(t *testing.T) {
+	// External collection: ExternalSource is set.
+	// Fields without ExternalField (like __virtual_pk__) should be skipped.
+	schema := &schemapb.CollectionSchema{
+		ExternalSource: "s3://bucket/data",
+		Fields: []*schemapb.FieldSchema{
+			{Name: "__virtual_pk__", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+			{Name: "id_field", ExternalField: "id"},
+			{Name: "vec_field", ExternalField: "embedding"},
+		},
+	}
+	columns := GetColumnNamesFromSchema(schema)
+	// Only external field mappings should be returned, __virtual_pk__ is skipped
+	assert.Equal(t, []string{"id", "embedding"}, columns)
+}
+
+func TestGetColumnNamesFromSchema_ExternalCollectionAllFieldsMapped(t *testing.T) {
+	// All user fields have ExternalField mappings
+	schema := &schemapb.CollectionSchema{
+		ExternalSource: "s3://bucket/data",
+		Fields: []*schemapb.FieldSchema{
+			{Name: "__virtual_pk__", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+			{Name: "a", ExternalField: "col_a"},
+			{Name: "b", ExternalField: "col_b"},
+			{Name: "c", ExternalField: "col_c"},
+		},
+	}
+	columns := GetColumnNamesFromSchema(schema)
+	assert.Equal(t, []string{"col_a", "col_b", "col_c"}, columns)
+}
+
+func TestGetColumnNamesFromSchema_MixedExternalAndNonExternal(t *testing.T) {
+	// Non-external collection with some fields having ExternalField set
+	// (edge case: ExternalSource not set, but some fields have ExternalField)
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{Name: "pk", DataType: schemapb.DataType_Int64},
+			{Name: "ext_field", ExternalField: "ext_col"},
+			{Name: "normal_field"},
+		},
+	}
+	columns := GetColumnNamesFromSchema(schema)
+	// Non-external collection: all fields included, external field uses mapping name
+	assert.Equal(t, []string{"pk", "ext_col", "normal_field"}, columns)
+}
+
 func TestGetColumnNamesFromSchema_EmptyFields(t *testing.T) {
 	schema := &schemapb.CollectionSchema{
 		Fields: []*schemapb.FieldSchema{},

--- a/internal/storagev2/packed/ffi_common.go
+++ b/internal/storagev2/packed/ffi_common.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 	"unsafe"
 
 	_ "github.com/milvus-io/milvus/internal/util/cgo"
@@ -65,7 +66,13 @@ func MakePropertiesFromStorageConfig(storageConfig *indexpb.StorageConfig, extra
 	// Add non-empty string fields
 	if storageConfig.GetAddress() != "" {
 		keys = append(keys, PropertyFSAddress)
-		values = append(values, storageConfig.GetAddress())
+		// Lance's BuildEndpointUrl defaults to HTTPS when no scheme is present.
+		// Prepend http:// when SSL is not enabled so that Lance sets allow_http=true.
+		fsAddr := storageConfig.GetAddress()
+		if !storageConfig.GetUseSSL() && !strings.Contains(fsAddr, "://") {
+			fsAddr = "http://" + fsAddr
+		}
+		values = append(values, fsAddr)
 	}
 	if storageConfig.GetBucketName() != "" {
 		keys = append(keys, PropertyFSBucketName)
@@ -155,7 +162,13 @@ func MakePropertiesFromStorageConfig(storageConfig *indexpb.StorageConfig, extra
 	}
 	if storageConfig.GetAddress() != "" {
 		keys = append(keys, extfsPrefix+"address")
-		values = append(values, storageConfig.GetAddress())
+		// Lance's BuildEndpointUrl defaults to HTTPS when no scheme is present.
+		// Prepend http:// when SSL is not enabled so that Lance sets allow_http=true.
+		addr := storageConfig.GetAddress()
+		if !storageConfig.GetUseSSL() && !strings.Contains(addr, "://") {
+			addr = "http://" + addr
+		}
+		values = append(values, addr)
 	}
 	if storageConfig.GetRootPath() != "" {
 		keys = append(keys, extfsPrefix+"root_path")
@@ -189,6 +202,40 @@ func MakePropertiesFromStorageConfig(storageConfig *indexpb.StorageConfig, extra
 		keys = append(keys, extfsPrefix+"gcp_credential_json")
 		values = append(values, storageConfig.GetGcpCredentialJSON())
 	}
+	// Temporarily disabled: extfs.default.* boolean properties.
+	//
+	// Root cause: extfs.* keys are not registered in milvus-storage's property_infos.
+	// The FFI (loon_properties_create) only accepts string key-value pairs, so
+	// ConvertFFIProperties stores unregistered keys as std::string (e.g.,
+	// extfs.default.use_ssl = string("false")). Later, ExtractExternalFsProperties
+	// copies this variant as-is to fs.use_ssl, but create_file_system_config expects
+	// GetValue<bool>, which fails because the variant holds a string, not a bool.
+	//
+	// Workaround: omit these properties so they are absent from the extfs-mapped
+	// Properties map. GetValue<bool> then falls back to the default value from
+	// property_infos (false), which is correct for non-SSL environments.
+	//
+	// TODO: re-enable once milvus-storage fixes ExtractExternalFsProperties to
+	// perform type conversion when mapping extfs.* → fs.* properties.
+	//
+	// keys = append(keys, extfsPrefix+"use_ssl")
+	// if storageConfig.GetUseSSL() {
+	// 	values = append(values, "true")
+	// } else {
+	// 	values = append(values, "false")
+	// }
+	// keys = append(keys, extfsPrefix+"use_iam")
+	// if storageConfig.GetUseIAM() {
+	// 	values = append(values, "true")
+	// } else {
+	// 	values = append(values, "false")
+	// }
+	// keys = append(keys, extfsPrefix+"use_virtual_host")
+	// if storageConfig.GetUseVirtualHost() {
+	// 	values = append(values, "true")
+	// } else {
+	// 	values = append(values, "false")
+	// }
 
 	// Add extra kvs
 	for k, v := range extraKVs {

--- a/internal/storagev2/packed/manifest_ffi.go
+++ b/internal/storagev2/packed/manifest_ffi.go
@@ -176,30 +176,37 @@ func createColumnGroups(
 
 // ReadFragmentsFromManifest reads fragment info from a manifest path.
 // This function wraps the C exttable_read_column_groups call.
+//
+// The manifestPath is a JSON string like {"ver":1,"base_path":"external/.../segments/..."}.
+// The actual manifest file is at: base_path/_metadata/manifest-{ver}.avro
 func ReadFragmentsFromManifest(
 	manifestPath string,
 	storageConfig *indexpb.StorageConfig,
 ) ([]Fragment, error) {
-	// 1. Parse manifest path to get base path
-	basePath, _, err := UnmarshalManifestPath(manifestPath)
+	// 1. Parse manifest path to get base path and version
+	basePath, version, err := UnmarshalManifestPath(manifestPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse manifest path: %w", err)
 	}
 
-	// 2. Create properties from storage config
+	// 2. Construct full manifest file path: base_path/_metadata/manifest-{version}.avro
+	// This matches the C++ layout: get_manifest_filepath(base_path, version)
+	manifestFilePath := fmt.Sprintf("%s/_metadata/manifest-%d.avro", basePath, version)
+
+	// 3. Create properties from storage config
 	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create properties: %w", err)
 	}
 	defer C.loon_properties_free(cProperties)
 
-	// 3. Convert base path to C string
-	cBasePath := C.CString(basePath)
-	defer C.free(unsafe.Pointer(cBasePath))
+	// 4. Convert manifest file path to C string
+	cManifestFilePath := C.CString(manifestFilePath)
+	defer C.free(unsafe.Pointer(cManifestFilePath))
 
-	// 4. Call loon_exttable_read_manifest
+	// 5. Call loon_exttable_read_manifest with the full file path
 	var manifest *C.LoonManifest
-	result := C.loon_exttable_read_manifest(cBasePath, cProperties, &manifest)
+	result := C.loon_exttable_read_manifest(cManifestFilePath, cProperties, &manifest)
 	if err := HandleLoonFFIResult(result); err != nil {
 		return nil, fmt.Errorf("loon_exttable_read_manifest failed: %w", err)
 	}

--- a/internal/storagev2/packed/utils.go
+++ b/internal/storagev2/packed/utils.go
@@ -17,7 +17,9 @@ package packed
 import (
 	"context"
 	"fmt"
+	"strings"
 
+	"github.com/google/uuid"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
@@ -85,6 +87,11 @@ func SplitFileToFragments(
 
 // FetchFragmentsFromExternalSource scans the external source and returns fragments.
 // It explores files from the external source and splits large files into multiple fragments.
+//
+// IMPORTANT: The loon_exttable_explore FFI uses a Transaction that writes a manifest file
+// to baseDir. If baseDir == exploreDir, the manifest pollutes the data directory and
+// accumulates stale column groups across calls (Transaction append semantics).
+// To avoid this, we use a unique temporary baseDir for each explore call.
 func FetchFragmentsFromExternalSource(
 	ctx context.Context,
 	format string,
@@ -94,55 +101,83 @@ func FetchFragmentsFromExternalSource(
 ) ([]Fragment, error) {
 	log := log.Ctx(ctx)
 
-	// Call ExploreFiles to get file list
-	filePaths, err := ExploreFiles(
+	// Use a unique temp base dir for explore output to prevent:
+	// 1. Manifest files polluting the user's data directory
+	// 2. Transaction accumulating stale column groups across calls
+	exploreBaseDir := fmt.Sprintf("__explore_temp__/%s", uuid.New().String())
+
+	// For lance-table format, BuildLanceBaseUri constructs "scheme://bucket/path" without
+	// root_path (unlike Parquet which uses Arrow S3 FileSystemProxy that prepends root_path).
+	// Prepend root_path so Lance can locate the dataset in the correct bucket prefix.
+	exploreDir := externalSource
+	if format == "lance-table" && storageConfig.GetRootPath() != "" {
+		exploreDir = strings.TrimRight(storageConfig.GetRootPath(), "/") + "/" + externalSource
+	}
+
+	// Call ExploreFiles to get file list with row counts.
+	// ExploreFiles writes temp manifest files to exploreBaseDir as a side effect of the FFI.
+	// We clean them up immediately after consuming the results.
+	fileInfos, err := ExploreFiles(
 		columns,
 		format,
-		externalSource,
-		externalSource,
+		exploreBaseDir,
+		exploreDir,
 		storageConfig,
 	)
+	// Always clean up temp dir, regardless of whether ExploreFiles succeeded or failed.
+	defer CleanupExploreTempDir(exploreBaseDir, storageConfig)
+
 	if err != nil {
 		return nil, fmt.Errorf("failed to explore files: %w", err)
 	}
 
-	if len(filePaths) == 0 {
+	if len(fileInfos) == 0 {
 		return nil, fmt.Errorf("no files found in external source %q with format %q", externalSource, format)
 	}
 
 	log.Info("Explored external files",
-		zap.Int("fileCount", len(filePaths)),
-		zap.String("format", format))
+		zap.Int("fileCount", len(fileInfos)),
+		zap.String("format", format),
+		zap.String("externalSource", externalSource))
 
-	// Get row count for each file and split large files into fragments
+	// Get row count for each file and split large files into fragments.
 	var fragments []Fragment
 	fragmentIDGenerator := NewFragmentIDGenerator(0)
 
-	for _, filePath := range filePaths {
+	for _, fi := range fileInfos {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		default:
 		}
 
-		fileInfo, err := GetFileInfo(format, filePath, storageConfig)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get file info for %s: %w", filePath, err)
+		numRows := fi.NumRows
+		if numRows <= 0 {
+			// Row count not available from explore (e.g., parquet format).
+			// Fetch it separately via GetFileInfo FFI call.
+			fetchedInfo, err := GetFileInfo(format, fi.FilePath, storageConfig)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get file info for %s: %w", fi.FilePath, err)
+			}
+			numRows = fetchedInfo.NumRows
 		}
 
-		// Split large files into multiple fragments
 		fileFragments := SplitFileToFragments(
-			filePath,
-			fileInfo.NumRows,
+			fi.FilePath,
+			numRows,
 			DefaultFragmentRowLimit,
 			fragmentIDGenerator,
 		)
 		fragments = append(fragments, fileFragments...)
 	}
 
+	if len(fragments) == 0 {
+		return nil, fmt.Errorf("no data files found in external source %q", externalSource)
+	}
+
 	log.Info("Created fragments from external files",
 		zap.Int("totalFragments", len(fragments)),
-		zap.Int("fileCount", len(filePaths)))
+		zap.Int("fileCount", len(fileInfos)))
 
 	return fragments, nil
 }
@@ -251,20 +286,26 @@ func CreateSegmentManifestWithBasePath(
 }
 
 // GetColumnNamesFromSchema extracts column names from schema.
-// If a field has ExternalField set, it uses that; otherwise uses the field name.
+// For external collections: only includes fields with ExternalField set
+// (system fields like __virtual_pk__ are skipped as they don't exist in parquet data).
+// For normal collections: uses field name for all fields.
 func GetColumnNamesFromSchema(schema *schemapb.CollectionSchema) []string {
 	if schema == nil {
 		return nil
 	}
 
+	isExternal := schema.GetExternalSource() != ""
 	var columns []string
 	for _, field := range schema.GetFields() {
 		extField := field.GetExternalField()
 		if extField != "" {
 			columns = append(columns, extField)
-		} else {
+		} else if !isExternal {
+			// Non-external collections: use field name
 			columns = append(columns, field.GetName())
 		}
+		// External collections: skip fields without ExternalField
+		// (e.g., __virtual_pk__, RowID, Timestamp)
 	}
 	return columns
 }

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -65,6 +65,10 @@ const (
 	// MetaFieldName is the field name of dynamic schema
 	MetaFieldName = "$meta"
 
+	// VirtualPKFieldName is the field name of virtual primary key for external collections
+	// Virtual PK format: (segmentID << 32) | offset
+	VirtualPKFieldName = "__virtual_pk__"
+
 	// DefaultShardsNum defines the default number of shards when creating a collection
 	DefaultShardsNum = int32(1)
 

--- a/pkg/util/typeutil/schema.go
+++ b/pkg/util/typeutil/schema.go
@@ -2199,8 +2199,9 @@ func ValidateExternalCollectionSchema(schema *schemapb.CollectionSchema) error {
 	}
 
 	for _, field := range schema.GetFields() {
-		// Skip system fields (RowID and Timestamp)
-		if field.GetName() == common.RowIDFieldName || field.GetName() == common.TimeStampFieldName {
+		// Skip system fields (RowID, Timestamp) and virtual PK (injected by proxy)
+		if field.GetName() == common.RowIDFieldName || field.GetName() == common.TimeStampFieldName ||
+			field.GetName() == common.VirtualPKFieldName {
 			continue
 		}
 

--- a/tests/go_client/Dockerfile
+++ b/tests/go_client/Dockerfile
@@ -8,6 +8,14 @@ ENV GOPROXY=${CUSTOM_GOPROXY:-https://proxy.golang.org}
 
 RUN go install gotest.tools/gotestsum@v1.12.0
 
+# Install Python3 (3.13 in Debian Trixie) for external table test data generation.
+# vortex-data==0.56.0 must match the Rust vortex crate version in milvus-storage.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 python3-pip && \
+    rm -rf /var/lib/apt/lists/*
+RUN pip3 install --no-cache-dir --break-system-packages \
+    pyarrow==23.0.1 lance==1.2.1 vortex-data==0.56.0 obstore==0.9.1 || true
+
 # Set the Current Working Directory inside the container
 WORKDIR /milvus
 

--- a/tests/go_client/Dockerfile
+++ b/tests/go_client/Dockerfile
@@ -9,12 +9,16 @@ ENV GOPROXY=${CUSTOM_GOPROXY:-https://proxy.golang.org}
 RUN go install gotest.tools/gotestsum@v1.12.0
 
 # Install Python3 (3.13 in Debian Trixie) for external table test data generation.
-# vortex-data==0.56.0 must match the Rust vortex crate version in milvus-storage.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 python3-pip && \
     rm -rf /var/lib/apt/lists/*
+# Required packages for external table tests (must succeed)
 RUN pip3 install --no-cache-dir --break-system-packages \
-    pyarrow==23.0.1 lance==1.2.1 vortex-data==0.56.0 obstore==0.9.1 || true
+    pyarrow==23.0.1 lance==1.2.1 obstore==0.9.1
+# Optional: vortex-data has Rust native deps that may not build on all platforms.
+# Version must match the Rust vortex crate version in milvus-storage.
+RUN pip3 install --no-cache-dir --break-system-packages \
+    vortex-data==0.56.0 || true
 
 # Set the Current Working Directory inside the container
 WORKDIR /milvus

--- a/tests/go_client/requirements.txt
+++ b/tests/go_client/requirements.txt
@@ -1,0 +1,7 @@
+# Python dependencies for external table E2E test data generation.
+# Requires Python >= 3.11 (for vortex-data >= 0.56.0).
+# Install: pip install -r requirements.txt
+pyarrow==23.0.1
+lance==1.2.1
+vortex-data==0.56.0
+obstore==0.9.1

--- a/tests/go_client/testcases/external_table_refresh_test.go
+++ b/tests/go_client/testcases/external_table_refresh_test.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -18,7 +20,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/milvus-io/milvus/client/v2/entity"
+	"github.com/milvus-io/milvus/client/v2/index"
 	client "github.com/milvus-io/milvus/client/v2/milvusclient"
+	"github.com/milvus-io/milvus/tests/go_client/base"
 	"github.com/milvus-io/milvus/tests/go_client/common"
 	hp "github.com/milvus-io/milvus/tests/go_client/testcases/helper"
 )
@@ -123,6 +127,202 @@ func generateParquetBytes(numRows int64, startID int64) ([]byte, error) {
 	}
 
 	return buf.Bytes(), nil
+}
+
+// --- Multi-type parquet generation ---
+
+// generateMultiTypeParquetBytes creates a Parquet file with multiple data types:
+//   - id (Int64), bool_val (Boolean), int8_val (Int8), int16_val (Int16),
+//   - int32_val (Int32), float_val (Float32), double_val (Float64),
+//   - embedding (FixedSizeList[Float32, testVecDim])
+//
+// Data formulas for row i (startID+i):
+//
+//	bool_val = (i is even), int8_val = i%100, int16_val = i*10,
+//	int32_val = i*100, float_val = i*1.5, double_val = i*0.01
+func generateMultiTypeParquetBytes(numRows int64, startID int64) ([]byte, error) {
+	arrowSchema := arrow.NewSchema(
+		[]arrow.Field{
+			{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+			{Name: "bool_val", Type: arrow.FixedWidthTypes.Boolean},
+			{Name: "int8_val", Type: arrow.PrimitiveTypes.Int8},
+			{Name: "int16_val", Type: arrow.PrimitiveTypes.Int16},
+			{Name: "int32_val", Type: arrow.PrimitiveTypes.Int32},
+			{Name: "float_val", Type: arrow.PrimitiveTypes.Float32},
+			{Name: "double_val", Type: arrow.PrimitiveTypes.Float64},
+			{Name: "varchar_val", Type: arrow.BinaryTypes.String},
+			{Name: "embedding", Type: arrow.FixedSizeListOf(testVecDim, arrow.PrimitiveTypes.Float32)},
+		},
+		nil,
+	)
+
+	var buf bytes.Buffer
+	writer, err := pqarrow.NewFileWriter(arrowSchema, &buf, nil, pqarrow.DefaultWriterProps())
+	if err != nil {
+		return nil, fmt.Errorf("create parquet writer: %w", err)
+	}
+
+	pool := memory.NewGoAllocator()
+	builder := array.NewRecordBuilder(pool, arrowSchema)
+	defer builder.Release()
+
+	idBuilder := builder.Field(0).(*array.Int64Builder)
+	boolBuilder := builder.Field(1).(*array.BooleanBuilder)
+	int8Builder := builder.Field(2).(*array.Int8Builder)
+	int16Builder := builder.Field(3).(*array.Int16Builder)
+	int32Builder := builder.Field(4).(*array.Int32Builder)
+	floatBuilder := builder.Field(5).(*array.Float32Builder)
+	doubleBuilder := builder.Field(6).(*array.Float64Builder)
+	varcharBuilder := builder.Field(7).(*array.StringBuilder)
+	embeddingBuilder := builder.Field(8).(*array.FixedSizeListBuilder)
+	vecValueBuilder := embeddingBuilder.ValueBuilder().(*array.Float32Builder)
+
+	for i := int64(0); i < numRows; i++ {
+		idx := startID + i
+		idBuilder.Append(idx)
+		boolBuilder.Append(idx%2 == 0)
+		int8Builder.Append(int8(idx % 100))
+		int16Builder.Append(int16(idx * 10))
+		int32Builder.Append(int32(idx * 100))
+		floatBuilder.Append(float32(idx) * 1.5)
+		doubleBuilder.Append(float64(idx) * 0.01)
+		varcharBuilder.Append(fmt.Sprintf("str_%04d", idx))
+		embeddingBuilder.Append(true)
+		for d := 0; d < testVecDim; d++ {
+			vecValueBuilder.Append(float32(idx)*0.1 + float32(d))
+		}
+	}
+
+	record := builder.NewRecord()
+	defer record.Release()
+
+	if err := writer.Write(record); err != nil {
+		return nil, fmt.Errorf("write record: %w", err)
+	}
+	if err := writer.Close(); err != nil {
+		return nil, fmt.Errorf("close writer: %w", err)
+	}
+
+	return buf.Bytes(), nil
+}
+
+// --- Helpers ---
+
+func uploadParquetToMinIO(ctx context.Context, t *testing.T, mc *miniogo.Client, bucket, objectKey string, data []byte) {
+	t.Helper()
+	_, err := mc.PutObject(ctx, bucket, objectKey,
+		bytes.NewReader(data), int64(len(data)),
+		miniogo.PutObjectOptions{ContentType: "application/octet-stream"})
+	require.NoError(t, err, "upload parquet file to MinIO: %s", objectKey)
+	t.Logf("Uploaded %s/%s (%d bytes)", bucket, objectKey, len(data))
+}
+
+func waitForRefreshComplete(ctx context.Context, t *testing.T, mc *base.MilvusClient, jobID int64, timeout time.Duration) {
+	t.Helper()
+	deadline := time.After(timeout)
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-deadline:
+			t.Fatalf("Refresh job %d timed out after %s", jobID, timeout)
+		case <-ticker.C:
+			progress, err := mc.GetRefreshExternalCollectionProgress(ctx,
+				client.NewGetRefreshExternalCollectionProgressOption(jobID))
+			require.NoError(t, err)
+			t.Logf("Job %d: state=%s progress=%d%%", jobID, progress.State, progress.Progress)
+
+			if progress.State == entity.RefreshStateCompleted {
+				return
+			}
+			if progress.State == entity.RefreshStateFailed {
+				t.Fatalf("Refresh job %d failed: %s", jobID, progress.Reason)
+			}
+		}
+	}
+}
+
+func refreshAndWait(ctx context.Context, t *testing.T, mc *base.MilvusClient, collName string) int64 {
+	t.Helper()
+	refreshResult, err := mc.RefreshExternalCollection(ctx,
+		client.NewRefreshExternalCollectionOption(collName))
+	common.CheckErr(t, err, true)
+	require.Greater(t, refreshResult.JobID, int64(0))
+	t.Logf("Started refresh job: %d", refreshResult.JobID)
+
+	waitForRefreshComplete(ctx, t, mc, refreshResult.JobID, 120*time.Second)
+	return refreshResult.JobID
+}
+
+func indexAndLoadCollection(ctx context.Context, t *testing.T, mc *base.MilvusClient, collName, vecFieldName string) {
+	t.Helper()
+	idx := index.NewAutoIndex(entity.L2)
+	idxTask, err := mc.CreateIndex(ctx, client.NewCreateIndexOption(collName, vecFieldName, idx))
+	common.CheckErr(t, err, true)
+	err = idxTask.Await(ctx)
+	common.CheckErr(t, err, true)
+	t.Log("Vector index created on " + vecFieldName)
+
+	loadTask, err := mc.LoadCollection(ctx, client.NewLoadCollectionOption(collName))
+	common.CheckErr(t, err, true)
+	err = loadTask.Await(ctx)
+	common.CheckErr(t, err, true)
+	t.Log("Collection loaded")
+}
+
+// indexAndLoadCollectionWithScalarAndVector creates scalar indexes on id and value fields,
+// a vector index on the embedding field, verifies all indexes are built successfully,
+// and then loads the collection.
+func indexAndLoadCollectionWithScalarAndVector(ctx context.Context, t *testing.T, mc *base.MilvusClient, collName string, totalRows int64) {
+	t.Helper()
+
+	// Create scalar index on "id" field
+	idIdx := index.NewAutoIndex(entity.IP)
+	idIdxTask, err := mc.CreateIndex(ctx, client.NewCreateIndexOption(collName, "id", idIdx))
+	common.CheckErr(t, err, true)
+	err = idIdxTask.Await(ctx)
+	common.CheckErr(t, err, true)
+	t.Log("Scalar index created on id field")
+
+	// Create scalar index on "value" field
+	valIdx := index.NewAutoIndex(entity.IP)
+	valIdxTask, err := mc.CreateIndex(ctx, client.NewCreateIndexOption(collName, "value", valIdx))
+	common.CheckErr(t, err, true)
+	err = valIdxTask.Await(ctx)
+	common.CheckErr(t, err, true)
+	t.Log("Scalar index created on value field")
+
+	// Create vector index on "embedding" field
+	vecIdx := index.NewAutoIndex(entity.L2)
+	vecIdxTask, err := mc.CreateIndex(ctx, client.NewCreateIndexOption(collName, "embedding", vecIdx))
+	common.CheckErr(t, err, true)
+	err = vecIdxTask.Await(ctx)
+	common.CheckErr(t, err, true)
+	t.Log("Vector index created on embedding field")
+
+	// Verify all indexes via DescribeIndex
+	for _, fieldName := range []string{"id", "value", "embedding"} {
+		descIdx, err := mc.DescribeIndex(ctx, client.NewDescribeIndexOption(collName, fieldName))
+		common.CheckErr(t, err, true)
+		require.Equal(t, index.IndexState(3), descIdx.State,
+			"index on %s should be Finished (state=3)", fieldName) // 3 = IndexState_Finished
+		require.Equal(t, totalRows, descIdx.TotalRows,
+			"index on %s: TotalRows should be %d", fieldName, totalRows)
+		require.Equal(t, totalRows, descIdx.IndexedRows,
+			"index on %s: IndexedRows should be %d", fieldName, totalRows)
+		require.Equal(t, int64(0), descIdx.PendingIndexRows,
+			"index on %s: PendingIndexRows should be 0", fieldName)
+		t.Logf("Index on %s: state=%d totalRows=%d indexedRows=%d pendingRows=%d",
+			fieldName, descIdx.State, descIdx.TotalRows, descIdx.IndexedRows, descIdx.PendingIndexRows)
+	}
+
+	// Load collection
+	loadTask, err := mc.LoadCollection(ctx, client.NewLoadCollectionOption(collName))
+	common.CheckErr(t, err, true)
+	err = loadTask.Await(ctx)
+	common.CheckErr(t, err, true)
+	t.Log("Collection loaded")
 }
 
 // --- E2E Tests ---
@@ -291,4 +491,1180 @@ verify:
 		}
 	}
 	require.True(t, found, "should find the completed refresh job in job list")
+}
+
+// TestExternalCollectionLoadAndQuery tests the full external collection lifecycle:
+//  1. Upload parquet test data to MinIO
+//  2. Create an external collection
+//  3. Refresh and wait for completion
+//  4. Create index on vector field
+//  5. Load collection
+//  6. Query count(*)
+//  7. Query with filter and output fields
+//  8. Search with vector
+func TestExternalCollectionLoadAndQuery(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	// Connect to MinIO (skip if unavailable)
+	minioCfg := getMinIOConfig()
+	minioClient, err := newMinIOClient(minioCfg)
+	if err != nil {
+		t.Skipf("Failed to create MinIO client, skipping: %v", err)
+	}
+
+	exists, err := minioClient.BucketExists(ctx, minioCfg.bucket)
+	if err != nil || !exists {
+		t.Skipf("MinIO bucket %q not accessible (exists=%v, err=%v), skipping",
+			minioCfg.bucket, exists, err)
+	}
+
+	collName := common.GenRandomString("ext_load_query", 6)
+	extPath := fmt.Sprintf("external-e2e-test/%s", collName)
+
+	// ---------------------------------------------------------------
+	// Step 1: Generate and upload parquet data to MinIO
+	// ---------------------------------------------------------------
+	const numFiles = 2
+	const rowsPerFile = int64(1000)
+	totalExpectedRows := int64(numFiles) * rowsPerFile
+
+	for i := 0; i < numFiles; i++ {
+		data, err := generateParquetBytes(rowsPerFile, int64(i)*rowsPerFile)
+		require.NoError(t, err, "generate parquet file %d", i)
+
+		objectKey := fmt.Sprintf("%s/data%d.parquet", extPath, i)
+		_, err = minioClient.PutObject(ctx, minioCfg.bucket, objectKey,
+			bytes.NewReader(data), int64(len(data)),
+			miniogo.PutObjectOptions{ContentType: "application/octet-stream"})
+		require.NoError(t, err, "upload parquet file %d to MinIO", i)
+		t.Logf("Uploaded %s/%s (%d bytes, %d rows)", minioCfg.bucket, objectKey, len(data), rowsPerFile)
+	}
+
+	t.Cleanup(func() {
+		cleanupMinIOPrefix(context.Background(), minioClient, minioCfg.bucket,
+			fmt.Sprintf("%s/", extPath))
+	})
+
+	// ---------------------------------------------------------------
+	// Step 2: Create external collection
+	// ---------------------------------------------------------------
+	schema := entity.NewSchema().
+		WithName(collName).
+		WithExternalSource(extPath).
+		WithExternalSpec(`{"format":"parquet"}`).
+		WithField(
+			entity.NewField().
+				WithName("id").
+				WithDataType(entity.FieldTypeInt64).
+				WithExternalField("id"),
+		).
+		WithField(
+			entity.NewField().
+				WithName("value").
+				WithDataType(entity.FieldTypeFloat).
+				WithExternalField("value"),
+		).
+		WithField(
+			entity.NewField().
+				WithName("embedding").
+				WithDataType(entity.FieldTypeFloatVector).
+				WithDim(testVecDim).
+				WithExternalField("embedding"),
+		)
+
+	err = mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, true)
+	t.Logf("Created external collection: %s", collName)
+
+	t.Cleanup(func() {
+		_ = mc.DropCollection(context.Background(), client.NewDropCollectionOption(collName))
+	})
+
+	// Verify collection exists with correct external source
+	coll, err := mc.DescribeCollection(ctx, client.NewDescribeCollectionOption(collName))
+	common.CheckErr(t, err, true)
+	require.Equal(t, extPath, coll.Schema.ExternalSource)
+
+	// ---------------------------------------------------------------
+	// Step 3: Trigger refresh and poll until complete
+	// ---------------------------------------------------------------
+	refreshResult, err := mc.RefreshExternalCollection(ctx,
+		client.NewRefreshExternalCollectionOption(collName))
+	common.CheckErr(t, err, true)
+	require.Greater(t, refreshResult.JobID, int64(0))
+	t.Logf("Started refresh job: %d", refreshResult.JobID)
+
+	jobID := refreshResult.JobID
+	deadline := time.After(120 * time.Second)
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-deadline:
+			t.Fatalf("Refresh job %d timed out after 120s", jobID)
+		case <-ticker.C:
+			progress, err := mc.GetRefreshExternalCollectionProgress(ctx,
+				client.NewGetRefreshExternalCollectionProgressOption(jobID))
+			require.NoError(t, err)
+			t.Logf("Job %d: state=%s progress=%d%%", jobID, progress.State, progress.Progress)
+
+			if progress.State == entity.RefreshStateCompleted {
+				goto indexAndLoad
+			}
+			if progress.State == entity.RefreshStateFailed {
+				t.Fatalf("Refresh job %d failed: %s", jobID, progress.Reason)
+			}
+		}
+	}
+indexAndLoad:
+
+	// ---------------------------------------------------------------
+	// Step 4: Create scalar + vector indexes and load collection
+	// ---------------------------------------------------------------
+	indexAndLoadCollectionWithScalarAndVector(ctx, t, mc, collName, totalExpectedRows)
+
+	// ---------------------------------------------------------------
+	// Step 6: Query count(*)
+	// ---------------------------------------------------------------
+	countRes, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithConsistencyLevel(entity.ClStrong).
+		WithOutputFields(common.QueryCountFieldName))
+	common.CheckErr(t, err, true)
+
+	count, err := countRes.GetColumn(common.QueryCountFieldName).GetAsInt64(0)
+	require.NoError(t, err)
+	require.Equal(t, totalExpectedRows, count,
+		"count(*) should match total uploaded rows")
+	t.Logf("Query count(*) = %d (expected %d)", count, totalExpectedRows)
+
+	// ---------------------------------------------------------------
+	// Step 7: Query with filter and output fields
+	// ---------------------------------------------------------------
+	filterRes, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithConsistencyLevel(entity.ClStrong).
+		WithFilter("id < 100").
+		WithOutputFields("id", "value"))
+	common.CheckErr(t, err, true)
+
+	idCol := filterRes.GetColumn("id")
+	require.Equal(t, 100, idCol.Len(),
+		"filter id < 100 should return exactly 100 rows")
+	t.Logf("Query with filter returned %d rows", idCol.Len())
+
+	// ---------------------------------------------------------------
+	// Step 8: Search with vector
+	// ---------------------------------------------------------------
+	vec := make([]float32, testVecDim)
+	for i := range vec {
+		vec[i] = float32(i) * 0.1
+	}
+	searchRes, err := mc.Search(ctx, client.NewSearchOption(collName, 5,
+		[]entity.Vector{entity.FloatVector(vec)}).
+		WithConsistencyLevel(entity.ClStrong).
+		WithANNSField("embedding").
+		WithOutputFields("id", "value"))
+	common.CheckErr(t, err, true)
+
+	require.Equal(t, 1, len(searchRes), "should have 1 result set for 1 query vector")
+	require.Greater(t, searchRes[0].ResultCount, 0, "search should return results")
+	t.Logf("Search returned %d results", searchRes[0].ResultCount)
+
+	// ---------------------------------------------------------------
+	// Step 9: Search with filter (hybrid search)
+	// ---------------------------------------------------------------
+	hybridRes, err := mc.Search(ctx, client.NewSearchOption(collName, 5,
+		[]entity.Vector{entity.FloatVector(vec)}).
+		WithConsistencyLevel(entity.ClStrong).
+		WithANNSField("embedding").
+		WithFilter("id >= 500 && id < 1000").
+		WithOutputFields("id", "value"))
+	common.CheckErr(t, err, true)
+
+	require.Equal(t, 1, len(hybridRes))
+	require.Greater(t, hybridRes[0].ResultCount, 0, "hybrid search should return results")
+	// Verify all returned IDs satisfy the filter
+	hybridIDCol := hybridRes[0].GetColumn("id")
+	for i := 0; i < hybridIDCol.Len(); i++ {
+		val, _ := hybridIDCol.GetAsInt64(i)
+		require.GreaterOrEqual(t, val, int64(500), "filtered search result id should be >= 500")
+		require.Less(t, val, int64(1000), "filtered search result id should be < 1000")
+	}
+	t.Logf("Hybrid search (filter id in [500,1000)) returned %d results", hybridRes[0].ResultCount)
+
+	// ---------------------------------------------------------------
+	// Step 10: Query with pagination (offset + limit)
+	// ---------------------------------------------------------------
+	pageRes, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithConsistencyLevel(entity.ClStrong).
+		WithFilter("id >= 0").
+		WithOutputFields("id").
+		WithOffset(10).
+		WithLimit(20))
+	common.CheckErr(t, err, true)
+
+	pageIDCol := pageRes.GetColumn("id")
+	require.Equal(t, 20, pageIDCol.Len(), "pagination should return exactly 20 rows")
+	firstID, _ := pageIDCol.GetAsInt64(0)
+	require.Equal(t, int64(10), firstID, "first row after offset=10 should have id=10")
+	t.Logf("Pagination query (offset=10, limit=20) returned %d rows, first id=%d", pageIDCol.Len(), firstID)
+
+	// ---------------------------------------------------------------
+	// Step 11: Search with multiple query vectors
+	// ---------------------------------------------------------------
+	vec2 := make([]float32, testVecDim)
+	for i := range vec2 {
+		vec2[i] = float32(999-i) * 0.1
+	}
+	multiRes, err := mc.Search(ctx, client.NewSearchOption(collName, 3,
+		[]entity.Vector{entity.FloatVector(vec), entity.FloatVector(vec2)}).
+		WithConsistencyLevel(entity.ClStrong).
+		WithANNSField("embedding").
+		WithOutputFields("id"))
+	common.CheckErr(t, err, true)
+
+	require.Equal(t, 2, len(multiRes), "should have 2 result sets for 2 query vectors")
+	require.Greater(t, multiRes[0].ResultCount, 0, "first query should return results")
+	require.Greater(t, multiRes[1].ResultCount, 0, "second query should return results")
+	t.Logf("Multi-vector search returned %d and %d results", multiRes[0].ResultCount, multiRes[1].ResultCount)
+
+	// ---------------------------------------------------------------
+	// Step 12: Query with output embedding field (vector retrieval)
+	// ---------------------------------------------------------------
+	vecRes, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithConsistencyLevel(entity.ClStrong).
+		WithFilter("id == 0").
+		WithOutputFields("id", "embedding"))
+	common.CheckErr(t, err, true)
+
+	vecIDCol := vecRes.GetColumn("id")
+	require.Equal(t, 1, vecIDCol.Len(), "should return exactly 1 row for id==0")
+	embCol := vecRes.GetColumn("embedding")
+	require.NotNil(t, embCol, "embedding column should be present in output")
+	require.Equal(t, 1, embCol.Len(), "embedding column should have 1 row")
+	t.Log("Query with embedding output field succeeded")
+}
+
+// TestExternalCollectionIncrementalRefresh tests that refreshing an external collection
+// after modifying the underlying parquet files correctly updates segments:
+//  1. Initial files: data0 (ids 0-499) + data1 (ids 500-999) → 1000 rows
+//  2. Remove data1, add data2 (ids 2000-2299) → 800 rows
+//  3. Verify: data0 intact, data1 gone, data2 present
+func TestExternalCollectionIncrementalRefresh(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*600) // 10 min for two refresh+load cycles
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	minioCfg := getMinIOConfig()
+	minioClient, err := newMinIOClient(minioCfg)
+	if err != nil {
+		t.Skipf("Failed to create MinIO client, skipping: %v", err)
+	}
+
+	exists, err := minioClient.BucketExists(ctx, minioCfg.bucket)
+	if err != nil || !exists {
+		t.Skipf("MinIO bucket %q not accessible, skipping", minioCfg.bucket)
+	}
+
+	collName := common.GenRandomString("ext_incr_refresh", 6)
+	extPath := fmt.Sprintf("external-e2e-test/%s", collName)
+
+	t.Cleanup(func() {
+		cleanupMinIOPrefix(context.Background(), minioClient, minioCfg.bucket, extPath+"/")
+		_ = mc.DropCollection(context.Background(), client.NewDropCollectionOption(collName))
+	})
+
+	// ---------------------------------------------------------------
+	// Phase 1: Upload initial data files
+	// ---------------------------------------------------------------
+	data0, err := generateParquetBytes(500, 0) // ids 0-499
+	require.NoError(t, err)
+	data1, err := generateParquetBytes(500, 500) // ids 500-999
+	require.NoError(t, err)
+
+	uploadParquetToMinIO(ctx, t, minioClient, minioCfg.bucket, extPath+"/data0.parquet", data0)
+	uploadParquetToMinIO(ctx, t, minioClient, minioCfg.bucket, extPath+"/data1.parquet", data1)
+
+	// ---------------------------------------------------------------
+	// Create external collection
+	// ---------------------------------------------------------------
+	schema := entity.NewSchema().
+		WithName(collName).
+		WithExternalSource(extPath).
+		WithExternalSpec(`{"format":"parquet"}`).
+		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithExternalField("id")).
+		WithField(entity.NewField().WithName("value").WithDataType(entity.FieldTypeFloat).WithExternalField("value")).
+		WithField(entity.NewField().WithName("embedding").WithDataType(entity.FieldTypeFloatVector).WithDim(testVecDim).WithExternalField("embedding"))
+
+	err = mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, true)
+	t.Logf("Created external collection: %s", collName)
+
+	// ---------------------------------------------------------------
+	// First refresh + load
+	// ---------------------------------------------------------------
+	refreshAndWait(ctx, t, mc, collName)
+	indexAndLoadCollection(ctx, t, mc, collName, "embedding")
+
+	// Verify: count = 1000
+	countRes, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithConsistencyLevel(entity.ClStrong).
+		WithOutputFields(common.QueryCountFieldName))
+	common.CheckErr(t, err, true)
+	count, _ := countRes.GetColumn(common.QueryCountFieldName).GetAsInt64(0)
+	require.Equal(t, int64(1000), count, "initial count should be 1000")
+	t.Logf("Phase 1: count(*) = %d", count)
+
+	// Verify: data1 range (ids 500-999) is present
+	res1, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithConsistencyLevel(entity.ClStrong).
+		WithFilter("id >= 500 && id < 1000").
+		WithOutputFields("id"))
+	common.CheckErr(t, err, true)
+	require.Equal(t, 500, res1.GetColumn("id").Len(), "should find 500 rows in data1 range")
+
+	// ---------------------------------------------------------------
+	// Phase 2: Release, modify files, refresh again
+	// ---------------------------------------------------------------
+	err = mc.ReleaseCollection(ctx, client.NewReleaseCollectionOption(collName))
+	require.NoError(t, err, "release collection")
+	t.Log("Collection released")
+
+	// Remove data1.parquet (ids 500-999)
+	err = minioClient.RemoveObject(ctx, minioCfg.bucket, extPath+"/data1.parquet", miniogo.RemoveObjectOptions{})
+	require.NoError(t, err, "remove data1.parquet")
+	t.Log("Removed data1.parquet from MinIO")
+
+	// Upload data2.parquet (ids 2000-2299, 300 rows)
+	data2, err := generateParquetBytes(300, 2000)
+	require.NoError(t, err)
+	uploadParquetToMinIO(ctx, t, minioClient, minioCfg.bucket, extPath+"/data2.parquet", data2)
+
+	// Second refresh
+	refreshAndWait(ctx, t, mc, collName)
+
+	// Verify collection stats: count = 500 + 300 = 800
+	stats, err := mc.GetCollectionStats(ctx, client.NewGetCollectionStatsOption(collName))
+	common.CheckErr(t, err, true)
+	rowCountStr, ok := stats["row_count"]
+	require.True(t, ok, "stats should contain row_count")
+	rowCount, _ := strconv.ParseInt(rowCountStr, 10, 64)
+	require.Equal(t, int64(800), rowCount, "after file change: 500 (data0) + 300 (data2) = 800")
+	t.Logf("Phase 2: collection stats row_count = %d", rowCount)
+
+	// ---------------------------------------------------------------
+	// Phase 3: Reload and verify data correctness
+	// ---------------------------------------------------------------
+	indexAndLoadCollection(ctx, t, mc, collName, "embedding")
+
+	// Verify total count = 800
+	countRes2, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithConsistencyLevel(entity.ClStrong).
+		WithOutputFields(common.QueryCountFieldName))
+	common.CheckErr(t, err, true)
+	count2, _ := countRes2.GetColumn(common.QueryCountFieldName).GetAsInt64(0)
+	require.Equal(t, int64(800), count2, "count should be 800 after file change")
+
+	// Verify: data0 range (ids 0-499) still intact
+	res0, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithConsistencyLevel(entity.ClStrong).
+		WithFilter("id >= 0 && id < 500").
+		WithOutputFields("id"))
+	common.CheckErr(t, err, true)
+	require.Equal(t, 500, res0.GetColumn("id").Len(), "data0 (ids 0-499) should be intact")
+
+	// Verify: data1 range (ids 500-999) is gone
+	res1Gone, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithConsistencyLevel(entity.ClStrong).
+		WithFilter("id >= 500 && id < 1000").
+		WithOutputFields("id"))
+	common.CheckErr(t, err, true)
+	data1Len := 0
+	if col := res1Gone.GetColumn("id"); col != nil {
+		data1Len = col.Len()
+	}
+	require.Equal(t, 0, data1Len, "data1 (ids 500-999) should be removed after refresh")
+
+	// Verify: data2 range (ids 2000-2299) is present
+	res2, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithConsistencyLevel(entity.ClStrong).
+		WithFilter("id >= 2000 && id < 2300").
+		WithOutputFields("id"))
+	common.CheckErr(t, err, true)
+	require.Equal(t, 300, res2.GetColumn("id").Len(), "data2 (ids 2000-2299) should be present")
+
+	// Verify: search still works after incremental refresh
+	vec := make([]float32, testVecDim)
+	for i := range vec {
+		vec[i] = float32(i) * 0.1
+	}
+	searchRes, err := mc.Search(ctx, client.NewSearchOption(collName, 5,
+		[]entity.Vector{entity.FloatVector(vec)}).
+		WithConsistencyLevel(entity.ClStrong).
+		WithANNSField("embedding").
+		WithOutputFields("id"))
+	common.CheckErr(t, err, true)
+	require.Greater(t, searchRes[0].ResultCount, 0, "search should return results after incremental refresh")
+
+	t.Log("Phase 3: all verifications passed — incremental refresh works correctly")
+}
+
+// TestExternalCollectionMultipleDataTypes tests external collections with various data types:
+// Bool, Int8, Int16, Int32, Int64, Float, Double, VarChar, FloatVector
+func TestExternalCollectionMultipleDataTypes(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	minioCfg := getMinIOConfig()
+	minioClient, err := newMinIOClient(minioCfg)
+	if err != nil {
+		t.Skipf("Failed to create MinIO client, skipping: %v", err)
+	}
+
+	exists, err := minioClient.BucketExists(ctx, minioCfg.bucket)
+	if err != nil || !exists {
+		t.Skipf("MinIO bucket %q not accessible, skipping", minioCfg.bucket)
+	}
+
+	collName := common.GenRandomString("ext_multi_type", 6)
+	extPath := fmt.Sprintf("external-e2e-test/%s", collName)
+
+	t.Cleanup(func() {
+		cleanupMinIOPrefix(context.Background(), minioClient, minioCfg.bucket, extPath+"/")
+		_ = mc.DropCollection(context.Background(), client.NewDropCollectionOption(collName))
+	})
+
+	// ---------------------------------------------------------------
+	// Step 1: Generate and upload multi-type parquet data
+	// ---------------------------------------------------------------
+	const numRows = int64(100)
+	data, err := generateMultiTypeParquetBytes(numRows, 0)
+	require.NoError(t, err)
+	uploadParquetToMinIO(ctx, t, minioClient, minioCfg.bucket, extPath+"/data.parquet", data)
+
+	// ---------------------------------------------------------------
+	// Step 2: Create external collection with multi-type schema
+	// ---------------------------------------------------------------
+	schema := entity.NewSchema().
+		WithName(collName).
+		WithExternalSource(extPath).
+		WithExternalSpec(`{"format":"parquet"}`).
+		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithExternalField("id")).
+		WithField(entity.NewField().WithName("bool_val").WithDataType(entity.FieldTypeBool).WithExternalField("bool_val")).
+		WithField(entity.NewField().WithName("int8_val").WithDataType(entity.FieldTypeInt8).WithExternalField("int8_val")).
+		WithField(entity.NewField().WithName("int16_val").WithDataType(entity.FieldTypeInt16).WithExternalField("int16_val")).
+		WithField(entity.NewField().WithName("int32_val").WithDataType(entity.FieldTypeInt32).WithExternalField("int32_val")).
+		WithField(entity.NewField().WithName("float_val").WithDataType(entity.FieldTypeFloat).WithExternalField("float_val")).
+		WithField(entity.NewField().WithName("double_val").WithDataType(entity.FieldTypeDouble).WithExternalField("double_val")).
+		WithField(entity.NewField().WithName("varchar_val").WithDataType(entity.FieldTypeVarChar).WithMaxLength(64).WithExternalField("varchar_val")).
+		WithField(entity.NewField().WithName("embedding").WithDataType(entity.FieldTypeFloatVector).WithDim(testVecDim).WithExternalField("embedding"))
+
+	err = mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, true)
+	t.Logf("Created multi-type external collection: %s", collName)
+
+	// ---------------------------------------------------------------
+	// Step 3: Refresh + load
+	// ---------------------------------------------------------------
+	refreshAndWait(ctx, t, mc, collName)
+	indexAndLoadCollection(ctx, t, mc, collName, "embedding")
+
+	// ---------------------------------------------------------------
+	// Step 4: Verify count(*)
+	// ---------------------------------------------------------------
+	countRes, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithConsistencyLevel(entity.ClStrong).
+		WithOutputFields(common.QueryCountFieldName))
+	common.CheckErr(t, err, true)
+	count, _ := countRes.GetColumn(common.QueryCountFieldName).GetAsInt64(0)
+	require.Equal(t, numRows, count, "count should match uploaded rows")
+	t.Logf("count(*) = %d", count)
+
+	// ---------------------------------------------------------------
+	// Step 5: Bool filter — bool_val == true → even ids → 50 rows
+	// ---------------------------------------------------------------
+	boolRes, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithConsistencyLevel(entity.ClStrong).
+		WithFilter("bool_val == true").
+		WithOutputFields("id", "bool_val"))
+	common.CheckErr(t, err, true)
+	require.Equal(t, int(numRows/2), boolRes.GetColumn("id").Len(),
+		"bool_val==true should match even-id rows")
+	t.Logf("Bool filter: %d rows", boolRes.GetColumn("id").Len())
+
+	// ---------------------------------------------------------------
+	// Step 6: Int8 filter — int8_val < 10 → ids 0-9 → 10 rows
+	// ---------------------------------------------------------------
+	int8Res, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithConsistencyLevel(entity.ClStrong).
+		WithFilter("int8_val < 10").
+		WithOutputFields("id", "int8_val"))
+	common.CheckErr(t, err, true)
+	require.Equal(t, 10, int8Res.GetColumn("id").Len(), "int8_val < 10 should be 10 rows")
+	t.Logf("Int8 filter: %d rows", int8Res.GetColumn("id").Len())
+
+	// ---------------------------------------------------------------
+	// Step 7: Int16 filter — int16_val >= 500 → ids >= 50 → 50 rows
+	// ---------------------------------------------------------------
+	int16Res, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithConsistencyLevel(entity.ClStrong).
+		WithFilter("int16_val >= 500").
+		WithOutputFields("id", "int16_val"))
+	common.CheckErr(t, err, true)
+	require.Equal(t, 50, int16Res.GetColumn("id").Len(), "int16_val >= 500 should be 50 rows")
+	t.Logf("Int16 filter: %d rows", int16Res.GetColumn("id").Len())
+
+	// ---------------------------------------------------------------
+	// Step 8: Int32 filter — int32_val < 5000 → ids < 50 → 50 rows
+	// ---------------------------------------------------------------
+	int32Res, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithConsistencyLevel(entity.ClStrong).
+		WithFilter("int32_val < 5000").
+		WithOutputFields("id", "int32_val"))
+	common.CheckErr(t, err, true)
+	require.Equal(t, 50, int32Res.GetColumn("id").Len(), "int32_val < 5000 should be 50 rows")
+	t.Logf("Int32 filter: %d rows", int32Res.GetColumn("id").Len())
+
+	// ---------------------------------------------------------------
+	// Step 9: Float filter — float_val < 15.0 → id*1.5 < 15.0 → ids 0-9 → 10 rows
+	// ---------------------------------------------------------------
+	floatRes, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithConsistencyLevel(entity.ClStrong).
+		WithFilter("float_val < 15.0").
+		WithOutputFields("id", "float_val"))
+	common.CheckErr(t, err, true)
+	require.Equal(t, 10, floatRes.GetColumn("id").Len(), "float_val < 15.0 should be 10 rows")
+	t.Logf("Float filter: %d rows", floatRes.GetColumn("id").Len())
+
+	// ---------------------------------------------------------------
+	// Step 10: Double filter — double_val < 0.5 → id*0.01 < 0.5 → ids 0-49 → 50 rows
+	// ---------------------------------------------------------------
+	doubleRes, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithConsistencyLevel(entity.ClStrong).
+		WithFilter("double_val < 0.5").
+		WithOutputFields("id", "double_val"))
+	common.CheckErr(t, err, true)
+	require.Equal(t, 50, doubleRes.GetColumn("id").Len(), "double_val < 0.5 should be 50 rows")
+	t.Logf("Double filter: %d rows", doubleRes.GetColumn("id").Len())
+
+	// ---------------------------------------------------------------
+	// Step 10b: VarChar prefix filter — varchar_val like "str_004%" → ids 40-49 → 10 rows
+	// ---------------------------------------------------------------
+	varcharRes, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithConsistencyLevel(entity.ClStrong).
+		WithFilter(`varchar_val like "str_004%"`).
+		WithOutputFields("id", "varchar_val"))
+	common.CheckErr(t, err, true)
+	require.Equal(t, 10, varcharRes.GetColumn("id").Len(), `varchar_val like "str_004%" should be 10 rows`)
+	t.Logf("VarChar prefix filter: %d rows", varcharRes.GetColumn("id").Len())
+
+	// ---------------------------------------------------------------
+	// Step 10c: VarChar equality filter — varchar_val == "str_0042" → id=42 → 1 row
+	// ---------------------------------------------------------------
+	varcharEqRes, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithConsistencyLevel(entity.ClStrong).
+		WithFilter(`varchar_val == "str_0042"`).
+		WithOutputFields("id", "varchar_val"))
+	common.CheckErr(t, err, true)
+	require.Equal(t, 1, varcharEqRes.GetColumn("id").Len(), `varchar_val == "str_0042" should be 1 row`)
+	eqID, _ := varcharEqRes.GetColumn("id").GetAsInt64(0)
+	require.Equal(t, int64(42), eqID, "matched row should be id=42")
+	t.Logf("VarChar equality filter: matched id=%d", eqID)
+
+	// ---------------------------------------------------------------
+	// Step 11: Verify specific row values for id=42
+	// ---------------------------------------------------------------
+	row42, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithConsistencyLevel(entity.ClStrong).
+		WithFilter("id == 42").
+		WithOutputFields("id", "bool_val", "int8_val", "int16_val", "int32_val", "float_val", "double_val", "varchar_val"))
+	common.CheckErr(t, err, true)
+	require.Equal(t, 1, row42.GetColumn("id").Len(), "should find exactly 1 row with id==42")
+
+	boolVal, err := row42.GetColumn("bool_val").GetAsBool(0)
+	require.NoError(t, err)
+	require.Equal(t, true, boolVal, "id=42 (even) → bool_val should be true")
+
+	int8Val, err := row42.GetColumn("int8_val").GetAsInt64(0)
+	require.NoError(t, err)
+	require.Equal(t, int64(42), int8Val, "int8_val for id=42 should be 42")
+
+	int16Val, err := row42.GetColumn("int16_val").GetAsInt64(0)
+	require.NoError(t, err)
+	require.Equal(t, int64(420), int16Val, "int16_val for id=42 should be 420 (42*10)")
+
+	int32Val, err := row42.GetColumn("int32_val").GetAsInt64(0)
+	require.NoError(t, err)
+	require.Equal(t, int64(4200), int32Val, "int32_val for id=42 should be 4200 (42*100)")
+
+	floatVal, err := row42.GetColumn("float_val").GetAsDouble(0)
+	require.NoError(t, err)
+	require.InDelta(t, 63.0, floatVal, 0.1, "float_val for id=42 should be ~63.0 (42*1.5)")
+
+	doubleVal, err := row42.GetColumn("double_val").GetAsDouble(0)
+	require.NoError(t, err)
+	require.InDelta(t, 0.42, doubleVal, 0.001, "double_val for id=42 should be ~0.42 (42*0.01)")
+
+	varcharVal, err := row42.GetColumn("varchar_val").GetAsString(0)
+	require.NoError(t, err)
+	require.Equal(t, "str_0042", varcharVal, "varchar_val for id=42 should be 'str_0042'")
+
+	t.Log("All field values verified for id=42")
+
+	// ---------------------------------------------------------------
+	// Step 12: Search — verify nearest neighbor matches exact vector
+	// ---------------------------------------------------------------
+	vec := make([]float32, testVecDim)
+	for i := range vec {
+		vec[i] = float32(42)*0.1 + float32(i) // same formula as id=42's embedding
+	}
+	searchRes, err := mc.Search(ctx, client.NewSearchOption(collName, 5,
+		[]entity.Vector{entity.FloatVector(vec)}).
+		WithConsistencyLevel(entity.ClStrong).
+		WithANNSField("embedding").
+		WithOutputFields("id"))
+	common.CheckErr(t, err, true)
+	require.Equal(t, 1, len(searchRes))
+	require.Greater(t, searchRes[0].ResultCount, 0, "search should return at least 1 result")
+	nearestID, _ := searchRes[0].GetColumn("id").GetAsInt64(0)
+	t.Logf("Search: nearest neighbor for id=42's vector is id=%d (top-5 returned %d results)", nearestID, searchRes[0].ResultCount)
+
+	// ---------------------------------------------------------------
+	// Step 13: Compound filter across types — bool AND int range AND varchar
+	// ---------------------------------------------------------------
+	compoundRes, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithConsistencyLevel(entity.ClStrong).
+		WithFilter(`bool_val == true && int32_val < 5000 && varchar_val like "str_00%"`).
+		WithOutputFields("id"))
+	common.CheckErr(t, err, true)
+	// ids 0-49 have int32_val < 5000, of which 25 are even (bool_val==true)
+	// varchar_val like "str_00%" matches ids 0-99 (all have str_00xx format), so no extra filter
+	require.Equal(t, 25, compoundRes.GetColumn("id").Len(),
+		`compound filter: bool_val==true AND int32_val<5000 AND varchar like "str_00%" → 25 rows`)
+	t.Log("Compound filter across types (incl. varchar) passed")
+}
+
+// --- Lance format helpers ---
+
+// generateLanceDataOnMinIO uses the Python lance library to write a Lance dataset
+// directly to MinIO/S3. This is necessary because lance format writing requires the
+// Rust-based lance library, which is not accessible from Go directly.
+func generateLanceDataOnMinIO(t *testing.T, s3URI string, numRows, startID int) {
+	t.Helper()
+	minioCfg := getMinIOConfig()
+
+	scriptPath := "generate_lance_data.py"
+	cmd := fmt.Sprintf(
+		"MINIO_ADDRESS=%s MINIO_ACCESS_KEY=%s MINIO_SECRET_KEY=%s python3 %s %s %d %d",
+		minioCfg.address, minioCfg.accessKey, minioCfg.secretKey,
+		scriptPath, s3URI, numRows, startID,
+	)
+	out, err := runShellCommand(t, cmd)
+	require.NoError(t, err, "generate lance data: %s", out)
+	require.Contains(t, out, "OK", "lance data generation should succeed")
+	t.Logf("Generated lance data: %s", out)
+}
+
+// runShellCommand runs a shell command and returns its combined output.
+func runShellCommand(t *testing.T, cmd string) (string, error) {
+	t.Helper()
+	c := exec.Command("bash", "-c", cmd)
+	output, err := c.CombinedOutput()
+	return string(output), err
+}
+
+// checkPythonDeps verifies that the given python interpreter and packages are available.
+// Returns nil if all dependencies are importable, or an error describing what's missing.
+func checkPythonDeps(pythonBin string, packages ...string) error {
+	if _, err := exec.LookPath(pythonBin); err != nil {
+		return fmt.Errorf("%s not found in PATH: %w", pythonBin, err)
+	}
+	for _, pkg := range packages {
+		cmd := exec.Command(pythonBin, "-c", fmt.Sprintf("import %s", pkg)) // #nosec G204
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("python package %q not importable via %s: %s (%w)", pkg, pythonBin, string(out), err)
+		}
+	}
+	return nil
+}
+
+// findPython3ForVortex returns a python3 interpreter that is >= 3.11, which is
+// required by vortex-data >= 0.56.0. It tries "python3" first (works in Docker
+// where python3 is 3.13+), then falls back to "python3.11" (works on dev machines
+// where the default python3 may be 3.10).
+func findPython3ForVortex() (string, error) {
+	for _, bin := range []string{"python3", "python3.11"} {
+		path, err := exec.LookPath(bin)
+		if err != nil {
+			continue
+		}
+		out, err := exec.Command(path, "-c", // #nosec G204
+			"import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')").Output()
+		if err != nil {
+			continue
+		}
+		ver := strings.TrimSpace(string(out))
+		parts := strings.SplitN(ver, ".", 2)
+		if len(parts) == 2 {
+			major, _ := strconv.Atoi(parts[0])
+			minor, _ := strconv.Atoi(parts[1])
+			if major > 3 || (major == 3 && minor >= 11) {
+				return bin, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("no python3 >= 3.11 found (tried python3, python3.11)")
+}
+
+// TestExternalCollectionLanceFormat tests external collections with lance-table format:
+//  1. Generate Lance dataset on MinIO using Python
+//  2. Create external collection with lance-table format
+//  3. Refresh and wait for completion
+//  4. Create index and load collection
+//  5. Query count(*) and verify row count
+//  6. Query with filter
+//  7. Search with vector
+func TestExternalCollectionLanceFormat(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*600) // 10 min for lance operations
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	// Connect to MinIO
+	minioCfg := getMinIOConfig()
+	minioClient, err := newMinIOClient(minioCfg)
+	if err != nil {
+		t.Skipf("Failed to create MinIO client, skipping: %v", err)
+	}
+
+	exists, err := minioClient.BucketExists(ctx, minioCfg.bucket)
+	if err != nil || !exists {
+		t.Skipf("MinIO bucket %q not accessible, skipping", minioCfg.bucket)
+	}
+
+	if err := checkPythonDeps("python3", "pyarrow", "lance"); err != nil {
+		t.Skipf("Python deps for Lance unavailable, skipping: %v", err)
+	}
+
+	collName := common.GenRandomString("ext_lance", 6)
+	extPath := fmt.Sprintf("external-e2e-test/%s", collName)
+
+	// ---------------------------------------------------------------
+	// Step 1: Generate Lance dataset on MinIO
+	// ---------------------------------------------------------------
+	const totalRows = 100000
+	s3URI := fmt.Sprintf("s3://%s/%s/%s", minioCfg.bucket, minioCfg.rootPath, extPath)
+	generateLanceDataOnMinIO(t, s3URI, totalRows, 0)
+
+	t.Cleanup(func() {
+		cleanupMinIOPrefix(context.Background(), minioClient, minioCfg.bucket,
+			fmt.Sprintf("%s/%s/", minioCfg.rootPath, extPath))
+	})
+
+	// ---------------------------------------------------------------
+	// Step 2: Create external collection with lance-table format
+	// ---------------------------------------------------------------
+	schema := entity.NewSchema().
+		WithName(collName).
+		WithExternalSource(extPath).
+		WithExternalSpec(`{"format":"lance-table"}`).
+		WithField(
+			entity.NewField().
+				WithName("id").
+				WithDataType(entity.FieldTypeInt64).
+				WithExternalField("id"),
+		).
+		WithField(
+			entity.NewField().
+				WithName("value").
+				WithDataType(entity.FieldTypeFloat).
+				WithExternalField("value"),
+		).
+		WithField(
+			entity.NewField().
+				WithName("embedding").
+				WithDataType(entity.FieldTypeFloatVector).
+				WithDim(testVecDim).
+				WithExternalField("embedding"),
+		)
+
+	err = mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, true)
+	t.Logf("Created external collection with lance-table format: %s", collName)
+
+	t.Cleanup(func() {
+		_ = mc.DropCollection(context.Background(), client.NewDropCollectionOption(collName))
+	})
+
+	// Verify collection
+	coll, err := mc.DescribeCollection(ctx, client.NewDescribeCollectionOption(collName))
+	common.CheckErr(t, err, true)
+	require.Equal(t, extPath, coll.Schema.ExternalSource)
+	require.Equal(t, `{"format":"lance-table"}`, coll.Schema.ExternalSpec)
+
+	// ---------------------------------------------------------------
+	// Step 3: Refresh and wait for completion
+	// ---------------------------------------------------------------
+	refreshAndWait(ctx, t, mc, collName)
+
+	// Verify row count via stats
+	stats, err := mc.GetCollectionStats(ctx, client.NewGetCollectionStatsOption(collName))
+	common.CheckErr(t, err, true)
+	rowCountStr, ok := stats["row_count"]
+	require.True(t, ok, "stats should contain row_count")
+	rowCount, err := strconv.ParseInt(rowCountStr, 10, 64)
+	require.NoError(t, err)
+	require.Equal(t, int64(totalRows), rowCount,
+		"collection stats row_count should match lance dataset")
+	t.Logf("Refresh complete: row_count=%d", rowCount)
+
+	// ---------------------------------------------------------------
+	// Step 4: Create scalar + vector indexes and load collection
+	// ---------------------------------------------------------------
+	indexAndLoadCollectionWithScalarAndVector(ctx, t, mc, collName, totalRows)
+
+	// ---------------------------------------------------------------
+	// Step 5: Query count(*)
+	// ---------------------------------------------------------------
+	countRes, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithConsistencyLevel(entity.ClStrong).
+		WithOutputFields(common.QueryCountFieldName))
+	common.CheckErr(t, err, true)
+
+	count, err := countRes.GetColumn(common.QueryCountFieldName).GetAsInt64(0)
+	require.NoError(t, err)
+	require.Equal(t, int64(totalRows), count,
+		"count(*) should match lance dataset rows")
+	t.Logf("Query count(*) = %d", count)
+
+	// ---------------------------------------------------------------
+	// Step 6: Query with filter
+	// ---------------------------------------------------------------
+	filterRes, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithConsistencyLevel(entity.ClStrong).
+		WithFilter("id < 100").
+		WithOutputFields("id", "value"))
+	common.CheckErr(t, err, true)
+
+	idCol := filterRes.GetColumn("id")
+	require.Equal(t, 100, idCol.Len(),
+		"filter id < 100 should return exactly 100 rows")
+	t.Logf("Query with filter returned %d rows", idCol.Len())
+
+	// Verify specific value
+	val42, err := filterRes.GetColumn("value").GetAsDouble(42)
+	require.NoError(t, err)
+	expected42 := float64(42) * 1.5
+	require.InDelta(t, expected42, val42, 0.01,
+		"value for id=42 should be 42*1.5=63.0")
+
+	// ---------------------------------------------------------------
+	// Step 6b: Verify data correctness — sample rows across the range
+	// ---------------------------------------------------------------
+	sampleIDs := []int64{0, 1, 999, 50000, 99999}
+	for _, sid := range sampleIDs {
+		sampleRes, err := mc.Query(ctx, client.NewQueryOption(collName).
+			WithConsistencyLevel(entity.ClStrong).
+			WithFilter(fmt.Sprintf("id == %d", sid)).
+			WithOutputFields("id", "value"))
+		common.CheckErr(t, err, true)
+		require.Equal(t, 1, sampleRes.GetColumn("id").Len(),
+			"should find exactly 1 row for id=%d", sid)
+		sampleVal, err := sampleRes.GetColumn("value").GetAsDouble(0)
+		require.NoError(t, err)
+		require.InDelta(t, float64(sid)*1.5, sampleVal, 0.01,
+			"value for id=%d should be %f", sid, float64(sid)*1.5)
+	}
+	t.Logf("Verified %d sample rows across id range", len(sampleIDs))
+
+	// ---------------------------------------------------------------
+	// Step 6c: Verify large range query
+	// ---------------------------------------------------------------
+	largeRangeRes, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithConsistencyLevel(entity.ClStrong).
+		WithFilter("id >= 50000 && id < 60000").
+		WithOutputFields(common.QueryCountFieldName))
+	common.CheckErr(t, err, true)
+	rangeCount, err := largeRangeRes.GetColumn(common.QueryCountFieldName).GetAsInt64(0)
+	require.NoError(t, err)
+	require.Equal(t, int64(10000), rangeCount,
+		"id in [50000, 60000) should return 10000 rows")
+	t.Logf("Large range query [50000, 60000) returned %d rows", rangeCount)
+
+	// ---------------------------------------------------------------
+	// Step 7: Search with vector — verify nearest neighbor is id=0
+	// ---------------------------------------------------------------
+	vec := make([]float32, testVecDim)
+	for i := range vec {
+		vec[i] = float32(i) * 0.1 // same as id=0's embedding
+	}
+	searchRes, err := mc.Search(ctx, client.NewSearchOption(collName, 5,
+		[]entity.Vector{entity.FloatVector(vec)}).
+		WithConsistencyLevel(entity.ClStrong).
+		WithANNSField("embedding").
+		WithOutputFields("id", "value"))
+	common.CheckErr(t, err, true)
+
+	require.Equal(t, 1, len(searchRes), "should have 1 result set")
+	require.Greater(t, searchRes[0].ResultCount, 0, "search should return results")
+	nearestID, _ := searchRes[0].GetColumn("id").GetAsInt64(0)
+	nearestVal, _ := searchRes[0].GetColumn("value").GetAsDouble(0)
+	t.Logf("Search: nearest neighbor id=%d value=%.2f", nearestID, nearestVal)
+
+	// ---------------------------------------------------------------
+	// Step 8: Search with filter (hybrid search)
+	// ---------------------------------------------------------------
+	hybridRes, err := mc.Search(ctx, client.NewSearchOption(collName, 5,
+		[]entity.Vector{entity.FloatVector(vec)}).
+		WithConsistencyLevel(entity.ClStrong).
+		WithANNSField("embedding").
+		WithFilter("id >= 50000 && id < 60000").
+		WithOutputFields("id", "value"))
+	common.CheckErr(t, err, true)
+
+	require.Equal(t, 1, len(hybridRes))
+	require.Greater(t, hybridRes[0].ResultCount, 0, "hybrid search should return results")
+	hybridIDCol := hybridRes[0].GetColumn("id")
+	for i := 0; i < hybridIDCol.Len(); i++ {
+		val, _ := hybridIDCol.GetAsInt64(i)
+		require.GreaterOrEqual(t, val, int64(50000))
+		require.Less(t, val, int64(60000))
+	}
+	t.Logf("Hybrid search (id in [50000,60000)) returned %d results with correct values", hybridRes[0].ResultCount)
+
+	t.Log("Lance format external collection test passed!")
+}
+
+// generateVortexDataOnMinIO uses the Python vortex library to write a Vortex
+// dataset directly to MinIO/S3. This mirrors the Lance test pattern where a
+// Python script handles format-specific data generation.
+func generateVortexDataOnMinIO(t *testing.T, pythonBin, outputPath string, numRows, dim int) {
+	t.Helper()
+	minioCfg := getMinIOConfig()
+
+	scriptPath := "generate_vortex_data.py"
+	cmd := fmt.Sprintf(
+		"MINIO_ADDRESS=%s MINIO_ACCESS_KEY=%s MINIO_SECRET_KEY=%s MINIO_BUCKET=%s %s %s %s %d %d",
+		minioCfg.address, minioCfg.accessKey, minioCfg.secretKey, minioCfg.bucket,
+		pythonBin, scriptPath, outputPath, numRows, dim,
+	)
+	out, err := runShellCommand(t, cmd)
+	require.NoError(t, err, "generate vortex data: %s", out)
+	require.Contains(t, out, "OK", "vortex data generation should succeed")
+	t.Logf("Generated vortex data: %s", out)
+}
+
+// TestExternalCollectionVortexFormat tests external collections with vortex format:
+//  1. Generate vortex dataset on MinIO using the generate_vortex_data tool
+//  2. Create external collection with vortex format
+//  3. Refresh and wait for completion
+//  4. Create index and load collection
+//  5. Query count(*) and verify row count
+//  6. Query with filter
+//  7. Search with vector
+func TestExternalCollectionVortexFormat(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*600)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	minioCfg := getMinIOConfig()
+	minioClient, err := newMinIOClient(minioCfg)
+	if err != nil {
+		t.Skipf("Failed to create MinIO client, skipping: %v", err)
+	}
+
+	exists, err := minioClient.BucketExists(ctx, minioCfg.bucket)
+	if err != nil || !exists {
+		t.Skipf("MinIO bucket %q not accessible, skipping", minioCfg.bucket)
+	}
+
+	// vortex-data >= 0.56.0 requires Python >= 3.11
+	pythonBin, err := findPython3ForVortex()
+	if err != nil {
+		t.Skipf("Python >= 3.11 not found for Vortex, skipping: %v", err)
+	}
+	if err := checkPythonDeps(pythonBin, "pyarrow", "vortex", "obstore"); err != nil {
+		t.Skipf("Python deps for Vortex unavailable, skipping: %v", err)
+	}
+
+	collName := common.GenRandomString("ext_vortex", 6)
+	extPath := fmt.Sprintf("external-e2e-test/%s", collName)
+
+	// ---------------------------------------------------------------
+	// Step 1: Generate vortex dataset on MinIO
+	// ---------------------------------------------------------------
+	const totalRows = 100000
+	generateVortexDataOnMinIO(t, pythonBin, extPath, totalRows, testVecDim)
+
+	t.Cleanup(func() {
+		cleanupMinIOPrefix(context.Background(), minioClient, minioCfg.bucket,
+			fmt.Sprintf("%s/", extPath))
+	})
+
+	// ---------------------------------------------------------------
+	// Step 2: Create external collection with vortex format
+	// ---------------------------------------------------------------
+	schema := entity.NewSchema().
+		WithName(collName).
+		WithExternalSource(extPath).
+		WithExternalSpec(`{"format":"vortex"}`).
+		WithField(
+			entity.NewField().
+				WithName("id").
+				WithDataType(entity.FieldTypeInt64).
+				WithExternalField("id"),
+		).
+		WithField(
+			entity.NewField().
+				WithName("value").
+				WithDataType(entity.FieldTypeFloat).
+				WithExternalField("value"),
+		).
+		WithField(
+			entity.NewField().
+				WithName("embedding").
+				WithDataType(entity.FieldTypeFloatVector).
+				WithDim(testVecDim).
+				WithExternalField("embedding"),
+		)
+
+	err = mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, true)
+	t.Logf("Created external collection with vortex format: %s", collName)
+
+	t.Cleanup(func() {
+		_ = mc.DropCollection(context.Background(), client.NewDropCollectionOption(collName))
+	})
+
+	coll, err := mc.DescribeCollection(ctx, client.NewDescribeCollectionOption(collName))
+	common.CheckErr(t, err, true)
+	require.Equal(t, extPath, coll.Schema.ExternalSource)
+	require.Equal(t, `{"format":"vortex"}`, coll.Schema.ExternalSpec)
+
+	// ---------------------------------------------------------------
+	// Step 3: Refresh and wait for completion
+	// ---------------------------------------------------------------
+	refreshAndWait(ctx, t, mc, collName)
+
+	stats, err := mc.GetCollectionStats(ctx, client.NewGetCollectionStatsOption(collName))
+	common.CheckErr(t, err, true)
+	rowCountStr, ok := stats["row_count"]
+	require.True(t, ok, "stats should contain row_count")
+	rowCount, err := strconv.ParseInt(rowCountStr, 10, 64)
+	require.NoError(t, err)
+	require.Equal(t, int64(totalRows), rowCount,
+		"collection stats row_count should match vortex dataset")
+	t.Logf("Refresh complete: row_count=%d", rowCount)
+
+	// ---------------------------------------------------------------
+	// Step 4: Create scalar + vector indexes and load collection
+	// ---------------------------------------------------------------
+	indexAndLoadCollectionWithScalarAndVector(ctx, t, mc, collName, totalRows)
+
+	// ---------------------------------------------------------------
+	// Step 5: Query count(*)
+	// ---------------------------------------------------------------
+	countRes, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithConsistencyLevel(entity.ClStrong).
+		WithOutputFields(common.QueryCountFieldName))
+	common.CheckErr(t, err, true)
+
+	count, err := countRes.GetColumn(common.QueryCountFieldName).GetAsInt64(0)
+	require.NoError(t, err)
+	require.Equal(t, int64(totalRows), count,
+		"count(*) should match vortex dataset rows")
+	t.Logf("Query count(*) = %d", count)
+
+	// ---------------------------------------------------------------
+	// Step 6: Query with filter
+	// ---------------------------------------------------------------
+	filterRes, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithConsistencyLevel(entity.ClStrong).
+		WithFilter("id < 100").
+		WithOutputFields("id", "value"))
+	common.CheckErr(t, err, true)
+
+	idCol := filterRes.GetColumn("id")
+	require.Equal(t, 100, idCol.Len(),
+		"filter id < 100 should return exactly 100 rows")
+	t.Logf("Query with filter returned %d rows", idCol.Len())
+
+	val42, err := filterRes.GetColumn("value").GetAsDouble(42)
+	require.NoError(t, err)
+	expected42 := float64(42) * 1.5
+	require.InDelta(t, expected42, val42, 0.01,
+		"value for id=42 should be 42*1.5=63.0")
+
+	// ---------------------------------------------------------------
+	// Step 6b: Verify data correctness — sample rows across the range
+	// ---------------------------------------------------------------
+	sampleIDs := []int64{0, 1, 999, 50000, 99999}
+	for _, sid := range sampleIDs {
+		sampleRes, err := mc.Query(ctx, client.NewQueryOption(collName).
+			WithConsistencyLevel(entity.ClStrong).
+			WithFilter(fmt.Sprintf("id == %d", sid)).
+			WithOutputFields("id", "value"))
+		common.CheckErr(t, err, true)
+		require.Equal(t, 1, sampleRes.GetColumn("id").Len(),
+			"should find exactly 1 row for id=%d", sid)
+		sampleVal, err := sampleRes.GetColumn("value").GetAsDouble(0)
+		require.NoError(t, err)
+		require.InDelta(t, float64(sid)*1.5, sampleVal, 0.01,
+			"value for id=%d should be %f", sid, float64(sid)*1.5)
+	}
+	t.Logf("Verified %d sample rows across id range", len(sampleIDs))
+
+	// ---------------------------------------------------------------
+	// Step 6c: Verify large range query
+	// ---------------------------------------------------------------
+	largeRangeRes, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithConsistencyLevel(entity.ClStrong).
+		WithFilter("id >= 50000 && id < 60000").
+		WithOutputFields(common.QueryCountFieldName))
+	common.CheckErr(t, err, true)
+	rangeCount, err := largeRangeRes.GetColumn(common.QueryCountFieldName).GetAsInt64(0)
+	require.NoError(t, err)
+	require.Equal(t, int64(10000), rangeCount,
+		"id in [50000, 60000) should return 10000 rows")
+	t.Logf("Large range query [50000, 60000) returned %d rows", rangeCount)
+
+	// ---------------------------------------------------------------
+	// Step 7: Search with vector — verify nearest neighbor is id=0
+	// ---------------------------------------------------------------
+	vec := make([]float32, testVecDim)
+	for i := range vec {
+		vec[i] = float32(i) * 0.1 // same as id=0's embedding
+	}
+	searchRes, err := mc.Search(ctx, client.NewSearchOption(collName, 5,
+		[]entity.Vector{entity.FloatVector(vec)}).
+		WithConsistencyLevel(entity.ClStrong).
+		WithANNSField("embedding").
+		WithOutputFields("id", "value"))
+	common.CheckErr(t, err, true)
+
+	require.Equal(t, 1, len(searchRes), "should have 1 result set")
+	require.Greater(t, searchRes[0].ResultCount, 0, "search should return results")
+	nearestID, _ := searchRes[0].GetColumn("id").GetAsInt64(0)
+	nearestVal, _ := searchRes[0].GetColumn("value").GetAsDouble(0)
+	t.Logf("Search: nearest neighbor id=%d value=%.2f", nearestID, nearestVal)
+
+	// ---------------------------------------------------------------
+	// Step 8: Search with filter (hybrid search)
+	// ---------------------------------------------------------------
+	hybridRes, err := mc.Search(ctx, client.NewSearchOption(collName, 5,
+		[]entity.Vector{entity.FloatVector(vec)}).
+		WithConsistencyLevel(entity.ClStrong).
+		WithANNSField("embedding").
+		WithFilter("id >= 50000 && id < 60000").
+		WithOutputFields("id", "value"))
+	common.CheckErr(t, err, true)
+
+	require.Equal(t, 1, len(hybridRes))
+	require.Greater(t, hybridRes[0].ResultCount, 0, "hybrid search should return results")
+	hybridIDCol := hybridRes[0].GetColumn("id")
+	for i := 0; i < hybridIDCol.Len(); i++ {
+		val, _ := hybridIDCol.GetAsInt64(i)
+		require.GreaterOrEqual(t, val, int64(50000))
+		require.Less(t, val, int64(60000))
+	}
+	t.Logf("Hybrid search (id in [50000,60000)) returned %d results with correct values", hybridRes[0].ResultCount)
+
+	t.Log("Vortex format external collection test passed!")
 }

--- a/tests/go_client/testcases/external_table_test.go
+++ b/tests/go_client/testcases/external_table_test.go
@@ -56,8 +56,14 @@ func TestCreateExternalCollection(t *testing.T) {
 	require.Equal(t, "s3://test-bucket/data/", coll.Schema.ExternalSource)
 	require.Equal(t, `{"format": "parquet"}`, coll.Schema.ExternalSpec)
 
-	// Verify fields
-	require.Len(t, coll.Schema.Fields, 2)
+	// Verify fields (user-defined fields + auto-generated __virtual_pk__)
+	require.Len(t, coll.Schema.Fields, 3)
+
+	// Verify virtual PK field
+	vpkField := findFieldByName(coll.Schema.Fields, "__virtual_pk__")
+	require.NotNil(t, vpkField)
+	require.True(t, vpkField.PrimaryKey)
+	require.True(t, vpkField.AutoID)
 
 	// Verify text field
 	textField := findFieldByName(coll.Schema.Fields, "text")
@@ -290,8 +296,8 @@ func TestCreateExternalCollectionMultipleVectorFields(t *testing.T) {
 	// Verify external source
 	require.Equal(t, "s3://test-bucket/data/", coll.Schema.ExternalSource)
 
-	// Verify fields
-	require.Len(t, coll.Schema.Fields, 3)
+	// Verify fields (user-defined fields + auto-generated __virtual_pk__)
+	require.Len(t, coll.Schema.Fields, 4)
 
 	// Verify vector fields
 	denseField := findFieldByName(coll.Schema.Fields, "dense_embedding")

--- a/tests/go_client/testcases/generate_lance_data.py
+++ b/tests/go_client/testcases/generate_lance_data.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Generate Lance dataset on MinIO for e2e tests.
+
+Usage:
+    python3 generate_lance_data.py <s3_uri> <num_rows> [start_id]
+
+Example:
+    python3 generate_lance_data.py s3://a-bucket/files/external-e2e-test/lance_test 2000 0
+
+Schema:
+    - id (Int64)
+    - value (Float32)
+    - embedding (FixedSizeBinary[dim * sizeof(float32)])
+
+Environment variables:
+    MINIO_ADDRESS   (default: localhost:9000)
+    MINIO_ACCESS_KEY (default: minioadmin)
+    MINIO_SECRET_KEY (default: minioadmin)
+"""
+import os
+import struct
+import sys
+
+import lance
+import pyarrow as pa
+
+
+def main():
+    if len(sys.argv) < 3:
+        print(f"Usage: {sys.argv[0]} <s3_uri> <num_rows> [start_id]", file=sys.stderr)
+        sys.exit(1)
+
+    s3_uri = sys.argv[1]
+    num_rows = int(sys.argv[2])
+    start_id = int(sys.argv[3]) if len(sys.argv) > 3 else 0
+
+    endpoint = os.environ.get("MINIO_ADDRESS", "localhost:9000")
+    access_key = os.environ.get("MINIO_ACCESS_KEY", "minioadmin")
+    secret_key = os.environ.get("MINIO_SECRET_KEY", "minioadmin")
+
+    dim = 4
+    byte_width = dim * 4  # sizeof(float32)
+
+    # TODO: Switch to FixedSizeList<Float32, dim> (Lance's native vector format)
+    # once milvus-storage's lance bridge supports automatic schema resolution.
+    #
+    # Currently BlockingFragmentReader (lance_bridgeimpl.rs) uses the caller's
+    # schema as the FFI output schema (self.projection), but Lance reads data in
+    # its native types. When Milvus passes FixedSizeBinary but Lance stores
+    # FixedSizeList, ImportChunkedArray fails due to n_children mismatch.
+    # Storing vectors as FixedSizeBinary avoids the type conflict.
+    schema = pa.schema([
+        pa.field("id", pa.int64()),
+        pa.field("value", pa.float32()),
+        pa.field("embedding", pa.binary(byte_width)),
+    ])
+
+    ids = list(range(start_id, start_id + num_rows))
+    values = [float(i) * 1.5 for i in ids]
+    embeddings = [
+        struct.pack(f"{dim}f", *[float(i) * 0.1 + j for j in range(dim)])
+        for i in ids
+    ]
+
+    table = pa.table(
+        {
+            "id": pa.array(ids, type=pa.int64()),
+            "value": pa.array(values, type=pa.float32()),
+            "embedding": pa.array(embeddings, type=pa.binary(byte_width)),
+        },
+        schema=schema,
+    )
+
+    storage_options = {
+        "aws_access_key_id": access_key,
+        "aws_secret_access_key": secret_key,
+        "aws_endpoint": f"http://{endpoint}",
+        "aws_region": "us-east-1",
+        "allow_http": "true",
+    }
+
+    ds = lance.write_dataset(
+        table,
+        s3_uri,
+        mode="overwrite",
+        storage_options=storage_options,
+    )
+
+    print(
+        f"OK rows={ds.count_rows()} fragments={len(ds.get_fragments())} "
+        f"fragment_ids={[f.fragment_id for f in ds.get_fragments()]}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/go_client/testcases/generate_vortex_data.py
+++ b/tests/go_client/testcases/generate_vortex_data.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Generate Vortex dataset on MinIO for e2e tests.
+
+Usage:
+    python3 generate_vortex_data.py <output_path> <num_rows> [dim]
+
+Example:
+    python3 generate_vortex_data.py external-e2e-test/vortex_test 2000 4
+
+Schema:
+    - id (Int64)
+    - value (Float32)
+    - embedding (FixedSizeList<UInt8>[dim * sizeof(float32)])
+
+Environment variables:
+    MINIO_ADDRESS   (default: localhost:9000)
+    MINIO_ACCESS_KEY (default: minioadmin)
+    MINIO_SECRET_KEY (default: minioadmin)
+    MINIO_BUCKET     (default: a-bucket)
+
+Requires: vortex-data>=0.56.0, pyarrow, obstore (pip install in Python >=3.11)
+"""
+import os
+import struct
+import sys
+import tempfile
+
+import obstore
+import pyarrow as pa
+import vortex.io  # noqa: F401 — ensure vx.io is importable
+import vortex as vx
+from obstore.store import S3Store
+
+
+def main():
+    if len(sys.argv) < 3:
+        print(f"Usage: {sys.argv[0]} <output_path> <num_rows> [dim]", file=sys.stderr)
+        sys.exit(1)
+
+    output_path = sys.argv[1]
+    num_rows = int(sys.argv[2])
+    dim = int(sys.argv[3]) if len(sys.argv) > 3 else 4
+
+    endpoint = os.environ.get("MINIO_ADDRESS", "localhost:9000")
+    access_key = os.environ.get("MINIO_ACCESS_KEY", "minioadmin")
+    secret_key = os.environ.get("MINIO_SECRET_KEY", "minioadmin")
+    bucket = os.environ.get("MINIO_BUCKET", "a-bucket")
+
+    byte_width = dim * 4  # sizeof(float32)
+
+    # Milvus represents FloatVector(dim) as FixedSizeList(UInt8, dim*4) internally.
+    # Vortex Python bindings don't support FixedSizeBinary, but FixedSizeList works.
+    ids = list(range(num_rows))
+    values = [float(i) * 1.5 for i in ids]
+    # Pack floats to bytes, then flatten to a single uint8 array for FixedSizeListArray
+    flat_bytes = []
+    for i in ids:
+        flat_bytes.extend(struct.pack(f"{dim}f", *[float(i) * 0.1 + j for j in range(dim)]))
+
+    embedding_arr = pa.FixedSizeListArray.from_arrays(
+        pa.array(flat_bytes, type=pa.uint8()), byte_width,
+    )
+    table = pa.table({
+        "id": pa.array(ids, type=pa.int64()),
+        "value": pa.array(values, type=pa.float32()),
+        "embedding": embedding_arr,
+    })
+
+    # vx.io.write() only writes to local filesystem.
+    # Write locally then upload to MinIO via obstore.
+    with tempfile.NamedTemporaryFile(suffix=".vortex", delete=False) as tmp:
+        tmp_path = tmp.name
+    vx.io.write(table, tmp_path)
+    data = open(tmp_path, "rb").read()
+    os.unlink(tmp_path)
+
+    store = S3Store(
+        bucket=bucket,
+        config={
+            "access_key_id": access_key,
+            "secret_access_key": secret_key,
+            "endpoint_url": f"http://{endpoint}",
+            "region": "us-east-1",
+            "allow_http": "true",
+        },
+    )
+
+    file_key = f"{output_path}/data.vortex"
+    obstore.put(store, file_key, data)
+
+    print(f"OK rows={num_rows} file={file_key}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Implement virtual primary key (VirtualPK) for external collections without user-defined PK
- Add ExternalSegmentCandidate for PK oracle to support segment pruning on external segments
- Support loading external segments via manifest-based sealed segment loader
- Add ManifestGroupTranslator with external field name fallback for column mapping
- Add lance-table and vortex format support with HTTP scheme fix for MinIO endpoints
- Fix extfs boolean property type mismatch by disabling extfs.* bool properties
- Add lance and vortex format E2E tests with full query/search coverage
- Add Python data generation scripts and CI Docker Python environment

issue: #45881

design doc: https://github.com/milvus-io/milvus-design-docs/blob/main/design_docs/20260105-external_table.md

## Test plan

- [x] Unit tests pass (pkoracle, segments, delegator, datanode/external)
- [x] E2E tests pass (13/13): TestCreateExternal*, TestRefreshExternal*, TestExternalCollectionLanceFormat, TestExternalCollectionVortexFormat
- [x] `make milvus` compiles successfully
- [x] `make lint-fix` passes with no auto-fixes
- [ ] CI checks pass