### PR TITLE
test: Add null vector checkers to chaos test pipeline

### DIFF
--- a/tests/python_client/chaos/testcases/test_concurrent_operation.py
+++ b/tests/python_client/chaos/testcases/test_concurrent_operation.py
@@ -18,6 +18,9 @@ from chaos.checker import (InsertChecker,
                            AddFieldChecker,
                            SnapshotChecker,
                            SnapshotRestoreChecker,
+                           NullVectorSearchChecker,
+                           NullVectorQueryChecker,
+                           AddVectorFieldChecker,
                            Op,
                            ResultAnalyzer
                            )
@@ -112,6 +115,9 @@ class TestOperations(TestBase):
             Op.add_field: AddFieldChecker(collection_name=c_name),
             Op.snapshot: SnapshotChecker(collection_name=c_name),
             Op.restore_snapshot: SnapshotRestoreChecker(),
+            Op.null_vector_search: NullVectorSearchChecker(collection_name=c_name),
+            Op.null_vector_query: NullVectorQueryChecker(collection_name=c_name),
+            Op.add_vector_field: AddVectorFieldChecker(collection_name=c_name),
         }
         log.info(f"init_health_checkers: {checkers}")
         self.health_checkers = checkers


### PR DESCRIPTION
## Summary

Wire three null-vector checkers into the chaos test concurrent operation pipeline (`test_concurrent_operation.py`):

- **NullVectorSearchChecker** — detects NaN distances from null vector leaks in search index
- **NullVectorQueryChecker** — validates null/non-null ratio consistency in queries
- **AddVectorFieldChecker** — dynamically adds nullable FLOAT_VECTOR fields, creates index, inserts data, and verifies

These checkers are already implemented in `checker.py` but were not registered in `init_health_checkers()`. The default collection schema already has nullable vector fields (`float_vector` and `image_emb` both `nullable=True`), so the checkers use the shared collection name.

issue: #47867

### Changes

**Modified:**
- `tests/python_client/chaos/testcases/test_concurrent_operation.py`: Added imports and registered 3 checkers

🤖 Generated with [Claude Code](https://claude.com/claude-code)