### PR TITLE
fix: search without filter returns expired data when entity TTL is enabled

### DIFF
--- a/internal/core/src/exec/expression/EntityTTLEdgeCaseTest.cpp
+++ b/internal/core/src/exec/expression/EntityTTLEdgeCaseTest.cpp
@@ -88,3 +88,97 @@ TEST(PhysicalTimeEdgeCase, ZeroPhysicalTimeUs) {
     // Should use converted query_timestamp
     EXPECT_EQ(ctx.get_entity_ttl_physical_time_us(), expected_physical_us);
 }
+
+// Test: search without filter + TTL field applies TTL filtering (issue #47977)
+TEST(PhysicalTimeEdgeCase, SearchWithoutFilterTTLFiltering) {
+    auto schema = std::make_shared<Schema>();
+    auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
+    auto ttl_fid = schema->AddDebugField("ttl_field", DataType::TIMESTAMPTZ);
+    schema->set_primary_field_id(pk_fid);
+    schema->set_ttl_field_id(ttl_fid);
+
+    auto segment = CreateGrowingSegment(schema, empty_index_meta);
+    auto segment_internal =
+        dynamic_cast<SegmentInternalInterface*>(segment.get());
+
+    int64_t test_data_count = 100;
+    uint64_t base_ts = 1000000000ULL << 18;
+
+    std::vector<Timestamp> ts_data(test_data_count);
+    std::vector<idx_t> row_ids(test_data_count);
+    std::vector<int64_t> pk_data(test_data_count);
+    std::vector<int64_t> ttl_data(test_data_count);
+
+    int64_t current_physical_us = 1770026400000000LL;
+
+    for (int i = 0; i < test_data_count; i++) {
+        ts_data[i] = base_ts + i;
+        row_ids[i] = i;
+        pk_data[i] = i;
+
+        if (i < test_data_count / 2) {
+            ttl_data[i] = current_physical_us - 1000000;
+        } else {
+            ttl_data[i] = current_physical_us + 1000000;
+        }
+    }
+
+    auto insert_record_proto = std::make_unique<InsertRecordProto>();
+    insert_record_proto->set_num_rows(test_data_count);
+
+    {
+        auto field_data = insert_record_proto->add_fields_data();
+        field_data->set_field_id(pk_fid.get());
+        field_data->set_type(proto::schema::DataType::Int64);
+        auto* scalars = field_data->mutable_scalars();
+        auto* data = scalars->mutable_long_data();
+        for (auto v : pk_data) {
+            data->add_data(v);
+        }
+    }
+
+    {
+        auto field_data = insert_record_proto->add_fields_data();
+        field_data->set_field_id(ttl_fid.get());
+        field_data->set_type(proto::schema::DataType::Timestamptz);
+        auto* scalars = field_data->mutable_scalars();
+        auto* data = scalars->mutable_timestamptz_data();
+        for (auto v : ttl_data) {
+            data->add_data(v);
+        }
+    }
+
+    auto offset = segment->PreInsert(test_data_count);
+    segment->Insert(offset,
+                    test_data_count,
+                    row_ids.data(),
+                    ts_data.data(),
+                    insert_record_proto.get());
+
+    uint64_t query_ts = base_ts + test_data_count;
+    int64_t active_count = segment->get_active_count(query_ts);
+
+    // AlwaysTrueExpr + FilterBitsNode: simulates the fixed plan path
+    // for search without filter when TTL field is configured.
+    auto always_true_expr = std::make_shared<expr::AlwaysTrueExpr>();
+    auto plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                       always_true_expr);
+    BitsetType bitset = query::ExecuteQueryExpr(
+        plan, segment_internal, active_count, query_ts, current_physical_us);
+    BitsetTypeView bitset_view(bitset);
+
+    int expired_count = 0;
+    for (int i = 0; i < test_data_count; i++) {
+        if (!bitset_view[i]) {
+            expired_count++;
+        }
+    }
+
+    EXPECT_EQ(expired_count, test_data_count / 2);
+    for (int i = 0; i < test_data_count / 2; i++) {
+        EXPECT_FALSE(bitset_view[i]) << "Row " << i << " should be expired";
+    }
+    for (int i = test_data_count / 2; i < test_data_count; i++) {
+        EXPECT_TRUE(bitset_view[i]) << "Row " << i << " should not be expired";
+    }
+}

--- a/internal/core/src/query/PlanProto.cpp
+++ b/internal/core/src/query/PlanProto.cpp
@@ -479,8 +479,21 @@ ProtoParser::PlanNodeFromProto(const planpb::PlanNode& plan_node_proto) {
             sources = std::vector<milvus::plan::PlanNodePtr>{plannode};
         }
     } else {
-        // no filter, force set iterative filter hint to false, go with normal vector search path
+        // No user filter. Force non-iterative: the iterative path requires
+        // a FilterNode for row-by-row post-filtering, which doesn't apply
+        // here (TTL uses bitmap pre-filtering via FilterBitsNode).
         plan_node->search_info_.iterative_filter_execution = false;
+
+        // When entity-level TTL is enabled, add an AlwaysTrueExpr so that
+        // CompileExpressions injects the TTL bitmap filter at runtime.
+        // (issue #47977)
+        if (schema->get_ttl_field_id().has_value()) {
+            auto always_true_expr = std::make_shared<expr::AlwaysTrueExpr>();
+            plannode = std::make_shared<plan::FilterBitsNode>(
+                milvus::plan::GetNextPlanNodeId(), always_true_expr);
+            sources = std::vector<milvus::plan::PlanNodePtr>{plannode};
+        }
+
         plannode = std::make_shared<milvus::plan::MvccNode>(
             milvus::plan::GetNextPlanNodeId(), sources);
         sources = std::vector<milvus::plan::PlanNodePtr>{plannode};


### PR DESCRIPTION
When a collection has ttl_field configured, search() without a filter expression still returns expired entities. This is because entity-level TTL filtering is injected in CompileExpressions, which is only called when a FilterBitsNode exists in the plan. Search without filter builds the plan as MvccNode -> VectorSearchNode with no FilterBitsNode, so TTL filtering is completely skipped.

Add an AlwaysTrueExpr FilterBitsNode when no user filter is present but entity-level TTL is enabled, so CompileExpressions is invoked and merges the TTL filter expression at execution time.

issue: #47977