### PR TITLE
fix: fast-fail ServerIDMismatch for node connections and increase walBalancer operationTimeout

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -1297,9 +1297,9 @@ streaming:
     # The max interval of balance task trigger backoff, 5s by default.
     # It's ok to set it into duration string, such as 30s or 1m30s, see time.ParseDuration
     backoffMaxInterval: 5s
-    # The timeout of wal balancer operation, 30s by default.
+    # The timeout of wal balancer operation, 30m by default.
     # If the operation exceeds this timeout, it will be canceled.
-    operationTimeout: 30s
+    operationTimeout: 30m
     balancePolicy:
       name: vchannelFair # The multiplier of balance task trigger backoff, 2 by default
       # Whether to allow rebalance, true by default.

--- a/internal/util/grpcclient/client.go
+++ b/internal/util/grpcclient/client.go
@@ -428,10 +428,14 @@ func (c *ClientBase[T]) checkGrpcErr(ctx context.Context, err error) (needRetry,
 		// so if new interface appear in new coord, will got a unimplemented error
 		return false, true, true, merr.WrapErrServiceUnimplemented(err)
 	case IsServerIDMismatchErr(err):
-		if ok := c.checkNodeSessionExist(ctx); !ok {
-			// if session doesn't exist, no need to retry for datanode/indexnode/querynode/proxy
-			return false, false, false, err
+		if c.isNode {
+			// Node connections: fast-fail to let shard client handle failover.
+			// Retrying is futile because NodeID (injected via interceptor at
+			// connection time) won't change during retry.
+			return false, true, true, err
 		}
+		// Coord connections: retry with force reset (only one coord instance,
+		// getAddrFunc may return new address after reset).
 		return true, true, true, err
 	case IsCrossClusterRoutingErr(err):
 		return true, true, true, err

--- a/internal/util/grpcclient/client_test.go
+++ b/internal/util/grpcclient/client_test.go
@@ -385,7 +385,7 @@ func TestClientBase_CheckGrpcError(t *testing.T) {
 	assert.True(t, reset)
 	assert.True(t, forceReset)
 
-	// test serverId mismatch
+	// test serverId mismatch (coord connection, isNode=false: should retry)
 	retry, reset, forceReset, _ = base.checkGrpcErr(ctx, status.Error(codes.Unknown, merr.ErrNodeNotMatch.Error()))
 	assert.True(t, retry)
 	assert.True(t, reset)
@@ -587,4 +587,50 @@ func TestVerifySession(t *testing.T) {
 	base.role = typeutil.QueryNodeRole
 	err = base.verifySession(ctx)
 	assert.ErrorIs(t, err, merr.ErrNodeNotFound)
+}
+
+func TestClientBase_CheckGrpcError_ServerIDMismatch_Node(t *testing.T) {
+	base := ClientBase[*mockClient]{
+		isNode: true,
+	}
+	base.grpcClient = &clientConnWrapper[*mockClient]{client: &mockClient{}}
+
+	ctx := context.Background()
+
+	// Node connection: ServerIDMismatch should fast-fail (no retry) with reset+forceReset
+	retry, reset, forceReset, err := base.checkGrpcErr(ctx, status.Error(codes.Unknown, merr.ErrNodeNotMatch.Error()))
+	assert.False(t, retry)
+	assert.True(t, reset)
+	assert.True(t, forceReset)
+	assert.True(t, IsServerIDMismatchErr(err))
+}
+
+func TestClientBase_ServerIDMismatch_NodeFastFail(t *testing.T) {
+	// Test the full Call() path: ServerIDMismatch on a node connection
+	// should fail immediately without retrying.
+	callCount := 0
+	base := ClientBase[*mockClient]{
+		maxCancelError: 10,
+		MaxAttempts:    3,
+		isNode:         true,
+	}
+	base.SetGetAddrFunc(func() (string, error) {
+		return "", errors.New("mocked address error")
+	})
+	base.role = typeutil.QueryNodeRole
+	mockSession := sessionutil.NewMockSession(t)
+	base.sess = mockSession
+	base.grpcClientMtx.Lock()
+	base.grpcClient = &clientConnWrapper[*mockClient]{client: &mockClient{}}
+	base.grpcClientMtx.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_, err := base.Call(ctx, func(client *mockClient) (any, error) {
+		callCount++
+		return struct{}{}, status.Error(codes.Unknown, merr.ErrNodeNotMatch.Error())
+	})
+	assert.True(t, IsServerIDMismatchErr(err))
+	// The caller should be invoked exactly once (no retries)
+	assert.Equal(t, 1, callCount)
 }

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -6678,9 +6678,9 @@ It's ok to set it into duration string, such as 30s or 1m30s, see time.ParseDura
 	p.WALBalancerOperationTimeout = ParamItem{
 		Key:     "streaming.walBalancer.operationTimeout",
 		Version: "2.6.0",
-		Doc: `The timeout of wal balancer operation, 30s by default.
+		Doc: `The timeout of wal balancer operation, 30m by default.
 If the operation exceeds this timeout, it will be canceled.`,
-		DefaultValue: "30s",
+		DefaultValue: "30m",
 		Export:       true,
 	}
 	p.WALBalancerOperationTimeout.Init(base.mgr)

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -691,7 +691,7 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, 0.01, params.StreamingCfg.WALBalancerPolicyVChannelFairAntiAffinityWeight.GetAsFloat())
 		assert.Equal(t, 0.01, params.StreamingCfg.WALBalancerPolicyVChannelFairRebalanceTolerance.GetAsFloat())
 		assert.Equal(t, 3, params.StreamingCfg.WALBalancerPolicyVChannelFairRebalanceMaxStep.GetAsInt())
-		assert.Equal(t, 30*time.Second, params.StreamingCfg.WALBalancerOperationTimeout.GetAsDurationByParse())
+		assert.Equal(t, 30*time.Minute, params.StreamingCfg.WALBalancerOperationTimeout.GetAsDurationByParse())
 		assert.Equal(t, 4.0, params.StreamingCfg.WALBroadcasterConcurrencyRatio.GetAsFloat())
 		assert.Equal(t, 5*time.Minute, params.StreamingCfg.WALBroadcasterTombstoneCheckInternal.GetAsDurationByParse())
 		assert.Equal(t, 8192, params.StreamingCfg.WALBroadcasterTombstoneMaxCount.GetAsInt())


### PR DESCRIPTION
For node connections (isNode=true), ServerIDMismatch now returns needRetry=false immediately instead of retrying 10 times with exponential backoff (~52.6s). Retrying is futile because the NodeID injected via the interceptor at connection time never changes during retry. Coord connections keep existing retry behavior.

Also increase streaming.walBalancer.operationTimeout default from 30s to 30m.

issue: #46182
pr: #47981