### PR TITLE
fix: compaction forward delete replay blocks tsafe advancement

### DIFF
--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -541,13 +541,7 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 		return err
 	}
 
-	log.Debug("load delete...")
-	err = sd.loadStreamDelete(ctx, candidates, infos, req, targetNodeID, worker)
-	if err != nil {
-		log.Warn("load stream delete failed", zap.Error(err))
-		return err
-	}
-
+	// Load BM25 stats BEFORE loadStreamDelete so stats are ready before segment becomes visible
 	err = sd.loadBM25Stats(ctx, infos, req)
 	if err != nil {
 		log.Warn("failed to load BM25 stats", zap.Error(err))
@@ -563,8 +557,7 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 		bfMap[candidate.ID()] = candidate
 	}
 
-	// Build entries with Candidate - use filtered infos instead of req.GetInfos()
-	// This ensures we only add entries for segments that were actually loaded (not skipped as duplicates)
+	// Build entries with Candidate before loadStreamDelete, which will atomically add them to distribution
 	entries := make([]SegmentEntry, 0, len(infos))
 	for _, info := range infos {
 		entry := SegmentEntry{
@@ -578,7 +571,24 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 		entries = append(entries, entry)
 	}
 
-	return sd.addDistributionIfVersionOK(req.GetLoadMeta().GetSchemaVersion(), entries...)
+	log.Debug("load delete...")
+	// loadStreamDelete now handles distribution add atomically in Phase 3
+	err = sd.loadStreamDelete(ctx, candidates, infos, req, targetNodeID, worker,
+		entries, req.GetLoadMeta().GetSchemaVersion())
+	if err != nil {
+		log.Warn("load stream delete failed", zap.Error(err))
+		// Rollback BM25 stats registered by loadBM25Stats above,
+		// since segment will not be added to distribution.
+		if sd.idfOracle != nil {
+			segmentIDs := lo.Map(infos, func(info *querypb.SegmentLoadInfo, _ int) int64 {
+				return info.GetSegmentID()
+			})
+			sd.idfOracle.UnregisterSealed(segmentIDs...)
+		}
+		return err
+	}
+
+	return nil
 }
 
 func (sd *shardDelegator) addDistributionIfVersionOK(version uint64, entries ...SegmentEntry) error {
@@ -724,35 +734,101 @@ func (sd *shardDelegator) RefreshLevel0DeletionStats() {
 	).Set(float64(totalSize))
 }
 
+// processDeleteRecords performs BF checks on delete buffer records and forwards matching deletes
+// via the buffered forwarder. Does NOT require any lock to be held.
+// Returns the number of timestamp-hit and bloom-filter-hit rows.
+func (sd *shardDelegator) processDeleteRecords(
+	candidate *pkoracle.BloomFilterSet,
+	records []*deletebuffer.Item,
+	forwarder *BufferForwarder,
+) (tsHit, bfHit int64, err error) {
+	for _, entry := range records {
+		for _, record := range entry.Data {
+			tsHit += int64(len(record.DeleteData.Pks))
+			if record.PartitionID != common.AllPartitionsID && candidate.Partition() != record.PartitionID {
+				continue
+			}
+			pks := record.DeleteData.Pks
+			batchSize := paramtable.Get().CommonCfg.BloomFilterApplyBatchSize.GetAsInt()
+			for idx := 0; idx < len(pks); idx += batchSize {
+				endIdx := idx + batchSize
+				if endIdx > len(pks) {
+					endIdx = len(pks)
+				}
+
+				lc := storage.NewBatchLocationsCache(pks[idx:endIdx])
+				hits := candidate.BatchPkExist(lc)
+				for i, hit := range hits {
+					if hit {
+						bfHit++
+						if err = forwarder.Buffer(pks[idx+i], record.DeleteData.Tss[idx+i]); err != nil {
+							return tsHit, bfHit, err
+						}
+					}
+				}
+			}
+		}
+	}
+	return tsHit, bfHit, nil
+}
+
+// segDeleteSnapshot holds the snapshotted delete buffer entries for a segment,
+// captured under RLock in Phase 1 of loadStreamDelete.
+type segDeleteSnapshot struct {
+	records       []*deletebuffer.Item // copied slice of delete buffer entries
+	snapshotMaxTs uint64               // max Item.Ts in snapshot, used for timestamp-based catch-up
+}
+
 func (sd *shardDelegator) loadStreamDelete(ctx context.Context,
 	candidates []*pkoracle.BloomFilterSet,
 	infos []*querypb.SegmentLoadInfo,
 	req *querypb.LoadSegmentsRequest,
 	targetNodeID int64,
 	worker cluster.Worker,
+	entries []SegmentEntry,
+	schemaVersion uint64,
 ) error {
 	log := sd.getLogger(ctx)
 
 	idCandidates := lo.SliceToMap(candidates, func(candidate *pkoracle.BloomFilterSet) (int64, *pkoracle.BloomFilterSet) {
 		return candidate.ID(), candidate
 	})
+
+	// Phase 0: Forward L0 deletions (no lock needed, unchanged)
 	for _, info := range infos {
 		candidate := idCandidates[info.GetSegmentID()]
-		// forward l0 deletion
 		err := sd.forwardL0Deletion(ctx, info, req, candidate, targetNodeID, worker)
 		if err != nil {
 			return err
 		}
 	}
 
+	// === Phase 1: Snapshot delete buffer entries under RLock (fast — microseconds) ===
 	sd.deleteMut.RLock()
-	defer sd.deleteMut.RUnlock()
-	// apply buffered delete for new segments
-	// no goroutines here since qnv2 has no load merging logic
-	for _, info := range infos {
+	snapshots := make([]segDeleteSnapshot, len(infos))
+	for i, info := range infos {
+		records := sd.deleteBuffer.ListAfter(info.GetStartPosition().GetTimestamp())
+		// Copy the slice to safely use outside lock scope.
+		// ListAfter returns a new slice from doubleCacheBuffer, but we copy to
+		// ensure no dependency on internal buffer state that may change after unlock.
+		copied := make([]*deletebuffer.Item, len(records))
+		copy(copied, records)
+		var maxTs uint64
+		if len(records) > 0 {
+			maxTs = records[len(records)-1].Ts
+		}
+		snapshots[i] = segDeleteSnapshot{
+			records:       copied,
+			snapshotMaxTs: maxTs,
+		}
+	}
+	sd.deleteMut.RUnlock()
+	// RLock released — WAL pipeline (ProcessDelete) is now unblocked
+
+	// Create one forwarder per segment, shared across Phase 2 and Phase 3, flushed once at the end.
+	forwarders := make([]*BufferForwarder, len(infos))
+	for i, info := range infos {
 		candidate := idCandidates[info.GetSegmentID()]
-		// after L0 segment feature
-		// growing segemnts should have load stream delete as well
 		deleteScope := querypb.DataScope_All
 		switch candidate.Type() {
 		case commonpb.SegmentState_Sealed:
@@ -760,57 +836,73 @@ func (sd *shardDelegator) loadStreamDelete(ctx context.Context,
 		case commonpb.SegmentState_Growing:
 			deleteScope = querypb.DataScope_Streaming
 		}
-
-		bufferedForwarder := NewBufferedForwarder(paramtable.Get().QueryNodeCfg.ForwardBatchSize.GetAsInt64(),
+		forwarders[i] = NewBufferedForwarder(paramtable.Get().QueryNodeCfg.ForwardBatchSize.GetAsInt64(),
 			deleteViaWorker(ctx, worker, targetNodeID, info, deleteScope))
+	}
 
-		// list buffered delete
-		deleteRecords := sd.deleteBuffer.ListAfter(info.GetStartPosition().GetTimestamp())
-		tsHitDeleteRows := int64(0)
-		bfHitDeleteRows := int64(0)
+	// === Phase 2: Process snapshot WITHOUT lock (expensive — seconds) ===
+	for i, info := range infos {
+		candidate := idCandidates[info.GetSegmentID()]
 		start := time.Now()
-		for _, entry := range deleteRecords {
-			for _, record := range entry.Data {
-				tsHitDeleteRows += int64(len(record.DeleteData.Pks))
-				if record.PartitionID != common.AllPartitionsID && candidate.Partition() != record.PartitionID {
-					continue
-				}
-				pks := record.DeleteData.Pks
-				batchSize := paramtable.Get().CommonCfg.BloomFilterApplyBatchSize.GetAsInt()
-				for idx := 0; idx < len(pks); idx += batchSize {
-					endIdx := idx + batchSize
-					if endIdx > len(pks) {
-						endIdx = len(pks)
-					}
-
-					lc := storage.NewBatchLocationsCache(pks[idx:endIdx])
-					hits := candidate.BatchPkExist(lc)
-					for i, hit := range hits {
-						if hit {
-							bfHitDeleteRows += 1
-							err := bufferedForwarder.Buffer(pks[idx+i], record.DeleteData.Tss[idx+i])
-							if err != nil {
-								return err
-							}
-						}
-					}
-				}
-			}
-		}
-		log.Info("forward delete to worker...",
-			zap.String("channel", info.InsertChannel),
-			zap.Int64("segmentID", info.GetSegmentID()),
-			zap.Time("startPosition", tsoutil.PhysicalTime(info.GetStartPosition().GetTimestamp())),
-			zap.Int64("tsHitDeleteRowNum", tsHitDeleteRows),
-			zap.Int64("bfHitDeleteRowNum", bfHitDeleteRows),
-			zap.Int64("bfCost", time.Since(start).Milliseconds()),
-		)
-		err := bufferedForwarder.Flush()
+		tsHit, bfHit, err := sd.processDeleteRecords(candidate, snapshots[i].records, forwarders[i])
 		if err != nil {
 			return err
 		}
+		log.Info("forward delete to worker (phase 2: snapshot)...",
+			zap.String("channel", info.InsertChannel),
+			zap.Int64("segmentID", info.GetSegmentID()),
+			zap.Time("startPosition", tsoutil.PhysicalTime(info.GetStartPosition().GetTimestamp())),
+			zap.Int64("tsHitDeleteRowNum", tsHit),
+			zap.Int64("bfHitDeleteRowNum", bfHit),
+			zap.Int64("bfCost", time.Since(start).Milliseconds()),
+		)
 	}
-	log.Info("load delete done")
+
+	// === Phase 3: Catch-up new entries + flush + add distribution under RLock (fast — milliseconds) ===
+	sd.deleteMut.RLock()
+	defer sd.deleteMut.RUnlock()
+
+	for i, info := range infos {
+		candidate := idCandidates[info.GetSegmentID()]
+
+		// Use timestamp-based catch-up: fetch records added after the snapshot's max timestamp.
+		// This is robust against delete buffer eviction (Put → evict discards old tail during Phase 2).
+		// Index-based approach (allRecords[snapshotLen:]) would panic or miss data if eviction occurs.
+		// Item.Ts comes from WAL TSO, monotonically increasing and unique per ProcessDelete call,
+		// so ListAfter(snapshotMaxTs + 1) precisely captures only new records.
+		catchUpTs := info.GetStartPosition().GetTimestamp()
+		if snapshots[i].snapshotMaxTs > 0 {
+			catchUpTs = snapshots[i].snapshotMaxTs + 1
+		}
+		newRecords := sd.deleteBuffer.ListAfter(catchUpTs)
+		if len(newRecords) > 0 {
+			start := time.Now()
+			tsHit, bfHit, err := sd.processDeleteRecords(candidate, newRecords, forwarders[i])
+			if err != nil {
+				return err
+			}
+			log.Info("forward delete to worker (phase 3: catch-up)...",
+				zap.String("channel", info.InsertChannel),
+				zap.Int64("segmentID", info.GetSegmentID()),
+				zap.Int64("tsHitDeleteRowNum", tsHit),
+				zap.Int64("bfHitDeleteRowNum", bfHit),
+				zap.Int64("bfCost", time.Since(start).Milliseconds()),
+			)
+		}
+
+		// Flush once per segment after both phases are done
+		if err := forwarders[i].Flush(); err != nil {
+			return err
+		}
+	}
+
+	// Atomically add to distribution while still holding RLock.
+	// This guarantees no ProcessDelete can run between catch-up and distribution update,
+	// so there is no gap between "deletes applied" and "segment visible".
+	if err := sd.addDistributionIfVersionOK(schemaVersion, entries...); err != nil {
+		return err
+	}
+	log.Info("load stream delete done")
 	return nil
 }
 

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -22,6 +22,8 @@ import (
 	"path"
 	"path/filepath"
 	"strconv"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1537,6 +1539,116 @@ func (s *DelegatorDataSuite) TestLevel0Deletions() {
 	delegator.deleteBuffer.UnRegister(uint64(21))
 	pks, _ = delegator.GetLevel0Deletions(partitionID+1, pkoracle.NewCandidateKey(l0.ID(), l0.Partition(), segments.SegmentTypeGrowing))
 	s.Empty(pks)
+}
+
+// TestLoadSegmentsDoesNotBlockProcessDelete verifies that the 3-phase loadStreamDelete
+// does not block ProcessDelete for extended periods. Before the fix (#47882),
+// loadStreamDelete held deleteMut.RLock for the entire duration of BF checking (30-60s),
+// which blocked ProcessDelete (needs WLock), freezing tsafe and causing query timeouts.
+func (s *DelegatorDataSuite) TestLoadSegmentsDoesNotBlockProcessDelete() {
+	defer func() {
+		s.workerManager.ExpectedCalls = nil
+		s.loader.ExpectedCalls = nil
+	}()
+
+	// Set up bloom filter that will match some deletes
+	s.loader.EXPECT().LoadBloomFilterSet(mock.Anything, s.collectionID, mock.Anything).
+		Call.Return(func(ctx context.Context, collectionID int64, infos ...*querypb.SegmentLoadInfo) []*pkoracle.BloomFilterSet {
+		return lo.Map(infos, func(info *querypb.SegmentLoadInfo, _ int) *pkoracle.BloomFilterSet {
+			bfs := pkoracle.NewBloomFilterSet(info.GetSegmentID(), info.GetPartitionID(), commonpb.SegmentState_Sealed)
+			bf := bloomfilter.NewBloomFilterWithType(
+				paramtable.Get().CommonCfg.BloomFilterSize.GetAsUint(),
+				paramtable.Get().CommonCfg.MaxBloomFalsePositive.GetAsFloat(),
+				paramtable.Get().CommonCfg.BloomFilterType.GetValue())
+			pks := &storage.PkStatistics{PkFilter: bf}
+			pks.UpdatePKRange(&storage.Int64FieldData{Data: []int64{10, 20, 30}})
+			bfs.AddHistoricalStats(pks)
+			return bfs
+		})
+	}, func(ctx context.Context, collectionID int64, infos ...*querypb.SegmentLoadInfo) error {
+		return nil
+	})
+
+	workers := make(map[int64]*cluster.MockWorker)
+	worker1 := &cluster.MockWorker{}
+	workers[1] = worker1
+
+	worker1.EXPECT().LoadSegments(mock.Anything, mock.AnythingOfType("*querypb.LoadSegmentsRequest")).
+		Return(nil)
+	worker1.EXPECT().Delete(mock.Anything, mock.AnythingOfType("*querypb.DeleteRequest")).Return(nil)
+	s.workerManager.EXPECT().GetWorker(mock.Anything, mock.AnythingOfType("int64")).Call.Return(func(_ context.Context, nodeID int64) cluster.Worker {
+		return workers[nodeID]
+	}, nil)
+
+	// Pre-populate delete buffer with entries so loadStreamDelete has work to do
+	for i := 0; i < 100; i++ {
+		s.delegator.ProcessDelete([]*DeleteData{
+			{
+				PartitionID: 500,
+				PrimaryKeys: []storage.PrimaryKey{
+					storage.NewInt64PrimaryKey(int64(i)),
+				},
+				Timestamps: []uint64{uint64(10 + i)},
+				RowCount:   1,
+			},
+		}, uint64(10+i))
+	}
+
+	// Track ProcessDelete latency during concurrent LoadSegments
+	var processDeleteBlocked atomic.Bool
+	var wg sync.WaitGroup
+
+	// Start LoadSegments in background
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		_ = s.delegator.LoadSegments(ctx, &querypb.LoadSegmentsRequest{
+			Base:         commonpbutil.NewMsgBase(),
+			DstNodeID:    1,
+			CollectionID: s.collectionID,
+			Infos: []*querypb.SegmentLoadInfo{
+				{
+					SegmentID:     300,
+					PartitionID:   500,
+					StartPosition: &msgpb.MsgPosition{Timestamp: 5},
+					DeltaPosition: &msgpb.MsgPosition{Timestamp: 5},
+					Level:         datapb.SegmentLevel_L1,
+					InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", s.collectionID),
+				},
+			},
+		})
+	}()
+
+	// Give LoadSegments time to start Phase 2 (unlock period)
+	time.Sleep(10 * time.Millisecond)
+
+	// Attempt ProcessDelete — with the fix, this should complete quickly
+	// because Phase 2 does NOT hold deleteMut
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		start := time.Now()
+		s.delegator.ProcessDelete([]*DeleteData{
+			{
+				PartitionID: 500,
+				PrimaryKeys: []storage.PrimaryKey{
+					storage.NewInt64PrimaryKey(999),
+				},
+				Timestamps: []uint64{200},
+				RowCount:   1,
+			},
+		}, 200)
+		// If ProcessDelete took more than 5 seconds, something is wrong
+		// (before the fix, it would block for 30-60s)
+		if time.Since(start) > 5*time.Second {
+			processDeleteBlocked.Store(true)
+		}
+	}()
+
+	wg.Wait()
+	s.False(processDeleteBlocked.Load(), "ProcessDelete was blocked for too long during LoadSegments — tsafe would freeze")
 }
 
 func (s *DelegatorDataSuite) TestDelegatorData_ExcludeSegments() {

--- a/internal/querynodev2/delegator/idf_oracle.go
+++ b/internal/querynodev2/delegator/idf_oracle.go
@@ -51,6 +51,7 @@ type IDFOracle interface {
 
 	RegisterGrowing(segmentID int64, stats bm25Stats)
 	RegisterSealed(segmentID int64, stats bm25Stats) error
+	UnregisterSealed(segmentIDs ...int64)
 
 	BuildIDF(fieldID int64, tfs *schemapb.SparseFloatArray) ([][]byte, float64, error)
 
@@ -354,6 +355,14 @@ func (o *idfOracle) RegisterSealed(segmentID int64, stats bm25Stats) error {
 		return err
 	}
 	return nil
+}
+
+func (o *idfOracle) UnregisterSealed(segmentIDs ...int64) {
+	for _, segmentID := range segmentIDs {
+		if stats, ok := o.sealed.GetAndRemove(segmentID); ok {
+			stats.Remove()
+		}
+	}
 }
 
 func (o *idfOracle) UpdateGrowing(segmentID int64, stats bm25Stats) {


### PR DESCRIPTION
Problem:
During compaction, loadStreamDelete() holds deleteMut.RLock for 30-60+ seconds while replaying historical WAL deletes via bloom filter checking. This blocks ProcessDelete() (needs WLock), which in turn blocks UpdateTSafe() (called after ProcessDelete in DeleteNode.Operate()). Strong consistency queries timeout waiting for tsafe.

Blocking chain:
  loadStreamDelete holds deleteMut.RLock (30-60s)
    → ProcessDelete blocked on deleteMut.Lock
      → DeleteNode.Operate blocked
        → UpdateTSafe never called → tsafe frozen → query timeout

Solution:
Split loadStreamDelete into a 3-phase snapshot-and-release pattern to minimize lock hold time:

- Phase 1 (RLock, microseconds): snapshot delete buffer entries, copy the slice, release lock immediately.
- Phase 2 (no lock, seconds): perform expensive BF check and forward deletes from snapshot. WAL pipeline is fully unblocked.
- Phase 3 (RLock, milliseconds): catch up new entries added during Phase 2 using index-based slicing, flush the forwarder, then atomically add segment to distribution.

Additional changes:
- Extract processDeleteRecords helper for BF check + forward logic.
- Move loadBM25Stats before loadStreamDelete so stats are ready before segment becomes visible. Add rollback via UnregisterSealed on failure.
- Use one BufferForwarder per segment shared across Phase 2 and Phase 3, flushed once after all records are processed.

issue: #47882
pr: #47947