### PR TITLE
fix: [loon] read deltalogs from manifest delta_logs section instead of column_groups

### DIFF
--- a/internal/compaction/common_test.go
+++ b/internal/compaction/common_test.go
@@ -18,6 +18,8 @@ package compaction
 
 import (
 	"context"
+	"io"
+	"path/filepath"
 	"testing"
 
 	"github.com/apache/arrow/go/v17/arrow"
@@ -28,7 +30,10 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/storagecommon"
+	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
@@ -319,4 +324,190 @@ func (s *CommonSuite) createTestRecord(pkType schemapb.DataType, int64Pks []int6
 	}
 
 	return storage.NewSimpleArrowRecord(record, field2Col)
+}
+
+// writeV2DeltaLog writes a V2 deltalog parquet file at the given path.
+// path should follow production pattern: filepath.Join(rootPath, "delta_log/collID/partID/segID/logID")
+func (s *CommonSuite) writeV2DeltaLog(
+	ctx context.Context,
+	pkType schemapb.DataType,
+	pks any,
+	tss []int64,
+	path string,
+	storageConfig *indexpb.StorageConfig,
+) {
+	t := s.T()
+
+	var record storage.Record
+	switch pkType {
+	case schemapb.DataType_Int64:
+		int64Pks := pks.([]int64)
+		record = s.createTestRecord(pkType, int64Pks, nil, tss)
+	case schemapb.DataType_VarChar:
+		stringPks := pks.([]string)
+		record = s.createTestRecord(pkType, nil, stringPks, tss)
+	default:
+		s.FailNow("unsupported pk type")
+	}
+	defer record.Release()
+
+	writer, err := storage.NewDeltalogWriter(ctx, 1, 2, 3, 101, pkType, path,
+		storage.WithVersion(storage.StorageV2),
+		storage.WithStorageConfig(storageConfig))
+	require.NoError(t, err)
+
+	err = writer.Write(record)
+	require.NoError(t, err)
+
+	err = writer.Close()
+	require.NoError(t, err)
+}
+
+// createBaseManifest creates a base manifest via FFIPackedWriter for V2 deltalog tests.
+// basePath should follow production pattern: filepath.Join(rootPath, "insert_log/collID/partID/segID")
+func (s *CommonSuite) createBaseManifest(basePath string, storageConfig *indexpb.StorageConfig) string {
+	t := s.T()
+
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{
+			Name:     "pk",
+			Type:     arrow.PrimitiveTypes.Int64,
+			Nullable: false,
+			Metadata: arrow.NewMetadata([]string{packed.ArrowFieldIdMetadataKey}, []string{"100"}),
+		},
+		{
+			Name:     "vector",
+			Type:     &arrow.FixedSizeBinaryType{ByteWidth: 16},
+			Nullable: false,
+			Metadata: arrow.NewMetadata([]string{packed.ArrowFieldIdMetadataKey}, []string{"101"}),
+		},
+	}, nil)
+
+	columnGroups := []storagecommon.ColumnGroup{
+		{Columns: []int{0, 1}, GroupID: storagecommon.DefaultShortColumnGroupID},
+	}
+
+	pw, err := packed.NewFFIPackedWriter(basePath, 0, arrowSchema, columnGroups, storageConfig, nil)
+	require.NoError(t, err)
+
+	// Write minimal data to create a valid manifest
+	b := array.NewRecordBuilder(memory.DefaultAllocator, arrowSchema)
+	defer b.Release()
+	b.Field(0).(*array.Int64Builder).Append(1)
+	vectorBytes := make([]byte, 16)
+	b.Field(1).(*array.FixedSizeBinaryBuilder).Append(vectorBytes)
+	rec := b.NewRecord()
+	defer rec.Release()
+
+	err = pw.WriteRecordBatch(rec)
+	require.NoError(t, err)
+
+	manifestPath, err := pw.Close()
+	require.NoError(t, err)
+
+	return manifestPath
+}
+
+func (s *CommonSuite) TestComposeDeleteFromDeltalogsV2() {
+	ctx := context.Background()
+
+	pt := paramtable.Get()
+	pt.Save(pt.CommonCfg.StorageType.Key, "local")
+	dir := s.T().TempDir()
+	pt.Save(pt.LocalStorageCfg.Path.Key, dir)
+	s.T().Cleanup(func() {
+		pt.Reset(pt.CommonCfg.StorageType.Key)
+		pt.Reset(pt.LocalStorageCfg.Path.Key)
+	})
+
+	storageConfig := &indexpb.StorageConfig{
+		RootPath:    dir,
+		StorageType: "local",
+	}
+
+	// Options that match production callers: downloader (for V1 validate) + storageConfig (for V2 ops)
+	options := []storage.RwOption{
+		storage.WithDownloader(func(ctx context.Context, paths []string) ([][]byte, error) {
+			return nil, nil
+		}),
+		storage.WithStorageConfig(storageConfig),
+	}
+
+	s.Run("V2 manifest - Int64 PK", func() {
+		// Use basePath matching production pattern: path.Join(rootPath, "insert_log", collID, partID, segID)
+		basePath := filepath.Join(dir, "insert_log/1/2/3_int64")
+		manifestPath := s.createBaseManifest(basePath, storageConfig)
+
+		// deltaPath matching production: path.Join(rootPath, "delta_log", collID, partID, segID, logID)
+		deltaPath := filepath.Join(dir, "delta_log/1/2/3/101")
+		s.writeV2DeltaLog(ctx, schemapb.DataType_Int64, []int64{10, 20, 30}, []int64{1000, 1001, 1002}, deltaPath, storageConfig)
+
+		newManifest, err := packed.AddDeltaLogsToManifest(manifestPath, storageConfig, []packed.DeltaLogEntry{
+			{Path: deltaPath, NumEntries: 3},
+		})
+		s.Require().NoError(err)
+
+		segment := &datapb.CompactionSegmentBinlogs{Manifest: newManifest}
+		pk2Ts, err := ComposeDeleteFromDeltalogs(ctx, schemapb.DataType_Int64, segment, options...)
+		s.NoError(err)
+		s.Equal(3, len(pk2Ts))
+		s.Equal(typeutil.Timestamp(1000), pk2Ts[int64(10)])
+		s.Equal(typeutil.Timestamp(1001), pk2Ts[int64(20)])
+		s.Equal(typeutil.Timestamp(1002), pk2Ts[int64(30)])
+	})
+
+	s.Run("V2 manifest - VarChar PK", func() {
+		basePath := filepath.Join(dir, "insert_log/1/2/3_varchar")
+		manifestPath := s.createBaseManifest(basePath, storageConfig)
+
+		deltaPath := filepath.Join(dir, "delta_log/1/2/3/102")
+		s.writeV2DeltaLog(ctx, schemapb.DataType_VarChar, []string{"pk_a", "pk_b", "pk_c"}, []int64{2000, 2001, 2002}, deltaPath, storageConfig)
+
+		newManifest, err := packed.AddDeltaLogsToManifest(manifestPath, storageConfig, []packed.DeltaLogEntry{
+			{Path: deltaPath, NumEntries: 3},
+		})
+		s.Require().NoError(err)
+
+		segment := &datapb.CompactionSegmentBinlogs{Manifest: newManifest}
+		pk2Ts, err := ComposeDeleteFromDeltalogs(ctx, schemapb.DataType_VarChar, segment, options...)
+		s.NoError(err)
+		s.Equal(3, len(pk2Ts))
+		s.Equal(typeutil.Timestamp(2000), pk2Ts["pk_a"])
+		s.Equal(typeutil.Timestamp(2001), pk2Ts["pk_b"])
+		s.Equal(typeutil.Timestamp(2002), pk2Ts["pk_c"])
+	})
+
+	s.Run("V2 manifest - multiple deltalogs", func() {
+		basePath := filepath.Join(dir, "insert_log/1/2/3_multi")
+		manifestPath := s.createBaseManifest(basePath, storageConfig)
+
+		deltaPath1 := filepath.Join(dir, "delta_log/1/2/3/201")
+		deltaPath2 := filepath.Join(dir, "delta_log/1/2/3/202")
+		s.writeV2DeltaLog(ctx, schemapb.DataType_Int64, []int64{100, 200}, []int64{3000, 3001}, deltaPath1, storageConfig)
+		s.writeV2DeltaLog(ctx, schemapb.DataType_Int64, []int64{300, 400}, []int64{3002, 3003}, deltaPath2, storageConfig)
+
+		newManifest, err := packed.AddDeltaLogsToManifest(manifestPath, storageConfig, []packed.DeltaLogEntry{
+			{Path: deltaPath1, NumEntries: 2},
+			{Path: deltaPath2, NumEntries: 2},
+		})
+		s.Require().NoError(err)
+
+		segment := &datapb.CompactionSegmentBinlogs{Manifest: newManifest}
+		pk2Ts, err := ComposeDeleteFromDeltalogs(ctx, schemapb.DataType_Int64, segment, options...)
+		s.NoError(err)
+		s.Equal(4, len(pk2Ts))
+		s.Equal(typeutil.Timestamp(3000), pk2Ts[int64(100)])
+		s.Equal(typeutil.Timestamp(3001), pk2Ts[int64(200)])
+		s.Equal(typeutil.Timestamp(3002), pk2Ts[int64(300)])
+		s.Equal(typeutil.Timestamp(3003), pk2Ts[int64(400)])
+	})
+
+	s.Run("V2 manifest - no deltalogs", func() {
+		basePath := filepath.Join(dir, "insert_log/1/2/3_empty")
+		manifestPath := s.createBaseManifest(basePath, storageConfig)
+
+		segment := &datapb.CompactionSegmentBinlogs{Manifest: manifestPath}
+		_, err := ComposeDeleteFromDeltalogs(ctx, schemapb.DataType_Int64, segment, options...)
+		s.ErrorIs(err, io.EOF)
+	})
 }

--- a/internal/storage/rw.go
+++ b/internal/storage/rw.go
@@ -514,7 +514,7 @@ func NewDeltalogReader(
 }
 
 // NewDeltalogReaderFromManifest creates a deltalog reader from segment manifest path.
-// The manifest contains deltalog file paths that will be read using FFI.
+// It extracts delta log file paths from the manifest and reads them as V2 parquet files.
 func NewDeltalogReaderFromManifest(
 	pkType schemapb.DataType,
 	manifestPath string,
@@ -528,21 +528,13 @@ func NewDeltalogReaderFromManifest(
 		return nil, err
 	}
 
-	schema := &schemapb.CollectionSchema{
-		Fields: []*schemapb.FieldSchema{
-			{
-				FieldID:      0,
-				Name:         "pk",
-				DataType:     pkType,
-				IsPrimaryKey: true,
-			},
-			{
-				FieldID:  common.TimeStampField,
-				Name:     "ts",
-				DataType: schemapb.DataType_Int64,
-			},
-		},
+	paths, err := packed.GetDeltaLogPathsFromManifest(manifestPath, rwOptions.storageConfig)
+	if err != nil {
+		return nil, err
+	}
+	if len(paths) == 0 {
+		return nil, io.EOF
 	}
 
-	return NewManifestReader(manifestPath, schema, rwOptions.bufferSize, rwOptions.storageConfig, nil)
+	return NewDeltalogReader(pkType, paths, WithVersion(StorageV2), WithStorageConfig(rwOptions.storageConfig))
 }

--- a/internal/storagev2/packed/packed_reader_ffi.go
+++ b/internal/storagev2/packed/packed_reader_ffi.go
@@ -197,6 +197,7 @@ func GetManifestHandle(manifestPath string, storageConfig *indexpb.StorageConfig
 	if err != nil {
 		return cManifestHandle, err
 	}
+	defer C.loon_properties_free(cProperties)
 	cBasePath := C.CString(basePath)
 	defer C.free(unsafe.Pointer(cBasePath))
 

--- a/internal/storagev2/packed/packed_reader_ffi.go
+++ b/internal/storagev2/packed/packed_reader_ffi.go
@@ -44,6 +44,7 @@ func NewFFIPackedReader(manifestPath string, schema *arrow.Schema, neededColumns
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get manifest")
 	}
+	defer C.loon_manifest_destroy(cLoonManifest)
 
 	var cas cdata.CArrowSchema
 	cdata.ExportArrowSchema(schema, &cas)

--- a/internal/storagev2/packed/transaction.go
+++ b/internal/storagev2/packed/transaction.go
@@ -113,6 +113,63 @@ func AddDeltaLogsToManifest(
 	return newManifestPath, nil
 }
 
+// GetDeltaLogPathsFromManifest extracts delta log file paths from a Loon manifest.
+// It opens a transaction, reads the manifest's delta_logs section, converts relative
+// paths to absolute paths, and returns them.
+func GetDeltaLogPathsFromManifest(
+	manifestPath string,
+	storageConfig *indexpb.StorageConfig,
+) ([]string, error) {
+	basePath, version, err := UnmarshalManfestPath(manifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse manifest path: %w", err)
+	}
+
+	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create properties: %w", err)
+	}
+	defer C.loon_properties_free(cProperties)
+
+	cBasePath := C.CString(basePath)
+	defer C.free(unsafe.Pointer(cBasePath))
+
+	var cTransactionHandle C.LoonTransactionHandle
+	result := C.loon_transaction_begin(cBasePath, cProperties, C.int64_t(version), 1, &cTransactionHandle)
+	if err := HandleLoonFFIResult(result); err != nil {
+		return nil, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer C.loon_transaction_destroy(cTransactionHandle)
+
+	var cManifest *C.LoonManifest
+	result = C.loon_transaction_get_manifest(cTransactionHandle, &cManifest)
+	if err := HandleLoonFFIResult(result); err != nil {
+		return nil, fmt.Errorf("failed to get manifest: %w", err)
+	}
+	defer C.loon_manifest_destroy(cManifest)
+
+	numDeltaLogs := int(cManifest.delta_logs.num_delta_logs)
+	if numDeltaLogs == 0 {
+		return nil, nil
+	}
+
+	// Convert C array of relative paths to Go slice of absolute paths
+	cPaths := unsafe.Slice(cManifest.delta_logs.delta_log_paths, numDeltaLogs)
+	paths := make([]string, 0, numDeltaLogs)
+	for _, cPath := range cPaths {
+		relativePath := C.GoString(cPath)
+		absolutePath := filepath.Clean(filepath.Join(basePath, relativePath))
+		paths = append(paths, absolutePath)
+	}
+
+	log.Debug("GetDeltaLogPathsFromManifest",
+		zap.String("manifestPath", manifestPath),
+		zap.Int("numDeltaLogs", numDeltaLogs),
+		zap.Strings("paths", paths))
+
+	return paths, nil
+}
+
 // toRelativePath converts a full path to a path relative to the base path.
 // The deltalog path format is: {rootPath}/delta_log/{collectionID}/{partitionID}/{segmentID}/{logID}
 // The basePath format is: {rootPath}/insert_log/{collectionID}/{partitionID}/{segmentID}

--- a/internal/storagev2/packed/transaction.go
+++ b/internal/storagev2/packed/transaction.go
@@ -153,13 +153,13 @@ func GetDeltaLogPathsFromManifest(
 		return nil, nil
 	}
 
-	// Convert C array of relative paths to Go slice of absolute paths
+	// The C loon library resolves relative paths to absolute via ToAbsolute
+	// (prepending basePath/_delta/ and normalizing). The returned paths are
+	// already absolute and can be used directly.
 	cPaths := unsafe.Slice(cManifest.delta_logs.delta_log_paths, numDeltaLogs)
 	paths := make([]string, 0, numDeltaLogs)
 	for _, cPath := range cPaths {
-		relativePath := C.GoString(cPath)
-		absolutePath := filepath.Clean(filepath.Join(basePath, relativePath))
-		paths = append(paths, absolutePath)
+		paths = append(paths, C.GoString(cPath))
 	}
 
 	log.Debug("GetDeltaLogPathsFromManifest",
@@ -173,9 +173,12 @@ func GetDeltaLogPathsFromManifest(
 // toRelativePath converts a full path to a path relative to the base path.
 // The deltalog path format is: {rootPath}/delta_log/{collectionID}/{partitionID}/{segmentID}/{logID}
 // The basePath format is: {rootPath}/insert_log/{collectionID}/{partitionID}/{segmentID}
-// We need to return the relative path from basePath, e.g., "../../../delta_log/..."
+//
+// The C loon library stores delta log paths relative to basePath/_delta/ (the kDeltaPath convention).
+// When deserializing, it prepends basePath/_delta/ to the relative path and normalizes.
+// So we need baseDepth + 1 levels of "../" (the +1 accounts for the _delta/ subdirectory).
 func toRelativePath(fullPath, basePath, rootPath string) string {
-	// If fullPath starts with rootPath, make it relative to basePath
+	// If fullPath starts with rootPath, make it relative to basePath/_delta/
 	if strings.HasPrefix(fullPath, rootPath) {
 		// Get the path relative to rootPath for both
 		fullRel := strings.TrimPrefix(fullPath, rootPath)
@@ -184,8 +187,9 @@ func toRelativePath(fullPath, basePath, rootPath string) string {
 		baseRel := strings.TrimPrefix(basePath, rootPath)
 		baseRel = strings.TrimPrefix(baseRel, "/")
 
-		// Count the depth of basePath to know how many "../" we need
-		baseDepth := len(strings.Split(baseRel, "/"))
+		// Count the depth of basePath to know how many "../" we need.
+		// Add 1 for the _delta/ subdirectory that C prepends during deserialization.
+		baseDepth := len(strings.Split(baseRel, "/")) + 1
 
 		// Build the relative path: go up baseDepth levels, then down to fullRel
 		var parts []string

--- a/internal/storagev2/packed/transaction_test.go
+++ b/internal/storagev2/packed/transaction_test.go
@@ -15,9 +15,18 @@
 package packed
 
 import (
+	"path/filepath"
 	"testing"
 
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/memory"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus/internal/storagecommon"
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
 func TestToRelativePath(t *testing.T) {
@@ -29,18 +38,19 @@ func TestToRelativePath(t *testing.T) {
 		expected string
 	}{
 		{
+			// basePath has depth 4 (insert_log/123/456/789), +1 for _delta/ = 5 levels of ..
 			name:     "deltalog relative to insert_log",
 			fullPath: "/data/delta_log/123/456/789/1",
 			basePath: "/data/insert_log/123/456/789",
 			rootPath: "/data",
-			expected: "../../../../delta_log/123/456/789/1",
+			expected: "../../../../../delta_log/123/456/789/1",
 		},
 		{
 			name:     "same collection different segment",
 			fullPath: "/milvus/delta_log/100/200/300/5",
 			basePath: "/milvus/insert_log/100/200/300",
 			rootPath: "/milvus",
-			expected: "../../../../delta_log/100/200/300/5",
+			expected: "../../../../../delta_log/100/200/300/5",
 		},
 		{
 			name:     "path without rootPath prefix",
@@ -54,7 +64,7 @@ func TestToRelativePath(t *testing.T) {
 			fullPath: "delta_log/123/456/789/1",
 			basePath: "insert_log/123/456/789",
 			rootPath: "",
-			expected: "../../../../delta_log/123/456/789/1",
+			expected: "../../../../../delta_log/123/456/789/1",
 		},
 	}
 
@@ -74,4 +84,115 @@ func TestDeltaLogEntry(t *testing.T) {
 
 	assert.Equal(t, "/data/delta_log/123/456/789/1", entry.Path)
 	assert.Equal(t, int64(100), entry.NumEntries)
+}
+
+// createBaseManifest creates a base manifest via FFIPackedWriter for delta log tests.
+// basePath should follow production pattern: filepath.Join(rootPath, "insert_log/collID/partID/segID")
+func createBaseManifest(t *testing.T, basePath string, storageConfig *indexpb.StorageConfig) string {
+	schema := arrow.NewSchema([]arrow.Field{
+		{
+			Name:     "pk",
+			Type:     arrow.PrimitiveTypes.Int64,
+			Nullable: false,
+			Metadata: arrow.NewMetadata([]string{ArrowFieldIdMetadataKey}, []string{"100"}),
+		},
+		{
+			Name:     "ts",
+			Type:     arrow.PrimitiveTypes.Int64,
+			Nullable: false,
+			Metadata: arrow.NewMetadata([]string{ArrowFieldIdMetadataKey}, []string{"101"}),
+		},
+	}, nil)
+
+	columnGroups := []storagecommon.ColumnGroup{
+		{Columns: []int{0, 1}, GroupID: storagecommon.DefaultShortColumnGroupID},
+	}
+
+	pw, err := NewFFIPackedWriter(basePath, 0, schema, columnGroups, storageConfig, nil)
+	require.NoError(t, err)
+
+	b := array.NewRecordBuilder(memory.DefaultAllocator, schema)
+	defer b.Release()
+	b.Field(0).(*array.Int64Builder).Append(1)
+	b.Field(1).(*array.Int64Builder).Append(1000)
+	rec := b.NewRecord()
+	defer rec.Release()
+
+	err = pw.WriteRecordBatch(rec)
+	require.NoError(t, err)
+
+	manifestPath, err := pw.Close()
+	require.NoError(t, err)
+	return manifestPath
+}
+
+func TestGetDeltaLogPathsFromManifest(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	pt.Save(pt.CommonCfg.StorageType.Key, "local")
+	dir := t.TempDir()
+	pt.Save(pt.LocalStorageCfg.Path.Key, dir)
+	t.Cleanup(func() {
+		pt.Reset(pt.CommonCfg.StorageType.Key)
+		pt.Reset(pt.LocalStorageCfg.Path.Key)
+	})
+
+	storageConfig := &indexpb.StorageConfig{
+		RootPath:    dir,
+		StorageType: "local",
+	}
+
+	// Use basePath that includes rootPath, matching production pattern:
+	// basePath = path.Join(storageConfig.GetRootPath(), "insert_log", collID, partID, segID)
+	basePath := filepath.Join(dir, "insert_log/1/2/3")
+
+	t.Run("no delta logs", func(t *testing.T) {
+		manifestPath := createBaseManifest(t, basePath, storageConfig)
+		paths, err := GetDeltaLogPathsFromManifest(manifestPath, storageConfig)
+		assert.NoError(t, err)
+		assert.Nil(t, paths)
+	})
+
+	t.Run("single delta log", func(t *testing.T) {
+		bp := filepath.Join(dir, "insert_log/1/2/3_single")
+		manifestPath := createBaseManifest(t, bp, storageConfig)
+
+		// deltaPath follows production pattern: path.Join(rootPath, "delta_log", collID, partID, segID, logID)
+		deltaFullPath := filepath.Join(dir, "delta_log/1/2/3/101")
+		newManifest, err := AddDeltaLogsToManifest(manifestPath, storageConfig, []DeltaLogEntry{
+			{Path: deltaFullPath, NumEntries: 5},
+		})
+		require.NoError(t, err)
+
+		paths, err := GetDeltaLogPathsFromManifest(newManifest, storageConfig)
+		assert.NoError(t, err)
+		require.Equal(t, 1, len(paths))
+		// Verify the returned path resolves to the correct delta log location
+		assert.Contains(t, paths[0], "delta_log/1/2/3/101")
+	})
+
+	t.Run("multiple delta logs", func(t *testing.T) {
+		bp := filepath.Join(dir, "insert_log/1/2/3_multi")
+		manifestPath := createBaseManifest(t, bp, storageConfig)
+
+		deltaLogs := []DeltaLogEntry{
+			{Path: filepath.Join(dir, "delta_log/1/2/3/201"), NumEntries: 5},
+			{Path: filepath.Join(dir, "delta_log/1/2/3/202"), NumEntries: 3},
+		}
+		newManifest, err := AddDeltaLogsToManifest(manifestPath, storageConfig, deltaLogs)
+		require.NoError(t, err)
+
+		paths, err := GetDeltaLogPathsFromManifest(newManifest, storageConfig)
+		assert.NoError(t, err)
+		require.Equal(t, 2, len(paths))
+		assert.Contains(t, paths[0], "delta_log/1/2/3/201")
+		assert.Contains(t, paths[1], "delta_log/1/2/3/202")
+	})
+
+	t.Run("empty deltaLogs input returns original manifest", func(t *testing.T) {
+		manifestPath := createBaseManifest(t, basePath+"_empty", storageConfig)
+		sameManifest, err := AddDeltaLogsToManifest(manifestPath, storageConfig, []DeltaLogEntry{})
+		require.NoError(t, err)
+		assert.Equal(t, manifestPath, sameManifest)
+	})
 }


### PR DESCRIPTION
Related to #39173 #45279

NewDeltalogReaderFromManifest was using NewManifestReader which reads from column_groups (insert data), not from the delta_logs section. When pk type is VarChar, the type mismatch between insert data columns and deltalog schema causes sigpanic in sort compaction.

Fix by extracting delta log file paths from the manifest's delta_logs field via FFI and reading them with the existing V2 parquet deltalog reader. Also fix LoonManifest memory leak in NewFFIPackedReader.