### PR TITLE
fix: [cp26]convert ForceMerge targetSize from MB to bytes for proper validation

### DIFF
--- a/internal/datacoord/compaction_policy_forcemerge.go
+++ b/internal/datacoord/compaction_policy_forcemerge.go
@@ -3,6 +3,7 @@ package datacoord
 import (
 	"context"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/samber/lo"
@@ -87,9 +88,18 @@ func (policy *forceMergeCompactionPolicy) triggerOneCollection(
 		collectionTTL = 0
 	}
 
+	// Convert targetSize from MB to bytes (per design doc: targetSize is in MB)
+	// Handle overflow: when targetSize is very large (e.g., max_int64 for auto-calculate mode)
+	var targetSizeBytes int64
+	if targetSize > math.MaxInt64/(1024*1024) {
+		targetSizeBytes = math.MaxInt64
+	} else {
+		targetSizeBytes = targetSize * 1024 * 1024
+	}
+
 	configMaxSize := getExpectedSegmentSize(policy.meta, collectionID, collection.Schema)
-	if targetSize < configMaxSize {
-		return nil, 0, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("targetSize %d should be greater than or equal to configMaxSize %d", targetSize, configMaxSize))
+	if targetSizeBytes < configMaxSize {
+		return nil, 0, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("targetSize %d MB should be greater than or equal to configMaxSize %d MB", targetSize, configMaxSize/(1024*1024)))
 	}
 
 	segments := policy.meta.SelectSegments(ctx, WithCollection(collectionID), SegmentFilterFunc(func(segment *SegmentInfo) bool {
@@ -120,7 +130,7 @@ func (policy *forceMergeCompactionPolicy) triggerOneCollection(
 			collectionTTL: collectionTTL,
 
 			configMaxSize:      float64(configMaxSize),
-			expectedTargetSize: float64(targetSize),
+			expectedTargetSize: float64(targetSizeBytes),
 			topology:           topology,
 		}
 		views = append(views, view)


### PR DESCRIPTION
- Convert `targetSize` from MB to bytes before comparing with `configMaxSize` in `triggerOneCollection`
- Update error message to display values in MB for better user understanding
- Update `expectedTargetSize` in `ForceMergeSegmentView` to use converted bytes value
- Update test cases to use MB values for `targetSize` parameter
- Add new test case `TestTriggerOneCollection_TargetSizeTooSmall` for boundary validation

According to the ForceMerge design doc, `targetSize` is specified in MB (e.g., `target_size=2048` means 2GB). However, `configMaxSize` from `getExpectedSegmentSize()` returns bytes. The direct comparison caused valid requests like `compact(target_size=32)` to fail when `configMaxSize` was 16MB (16777216 bytes).

- [x] Verify existing unit tests pass with updated `targetSize` values
- [x] Verify new boundary test `TestTriggerOneCollection_TargetSizeTooSmall` passes
- [x] Integration test: Deploy Milvus with `dataCoord.segment.maxSize: 16`, call `compact(target_size=32)` should succeed

issue #47195
pr: #47327