### PR TITLE
feat: integrate manifest-based statistics for V3 storage segments

### DIFF
--- a/internal/compaction/common.go
+++ b/internal/compaction/common.go
@@ -19,6 +19,7 @@ package compaction
 import (
 	"context"
 	"io"
+	"strings"
 
 	"github.com/apache/arrow/go/v17/arrow/array"
 	"github.com/cockroachdb/errors"
@@ -50,7 +51,7 @@ func readFromReader(reader storage.RecordReader, pkType schemapb.DataType) ([]st
 			if pkType == schemapb.DataType_Int64 {
 				pk = storage.NewInt64PrimaryKey(rec.Column(0).(*array.Int64).Value(i))
 			} else {
-				pk = storage.NewVarCharPrimaryKey(rec.Column(0).(*array.String).Value(i))
+				pk = storage.NewVarCharPrimaryKey(strings.Clone(rec.Column(0).(*array.String).Value(i)))
 			}
 			ts := typeutil.Timestamp(rec.Column(1).(*array.Int64).Value(i))
 			pks = append(pks, pk)

--- a/internal/compaction/load_stats.go
+++ b/internal/compaction/load_stats.go
@@ -21,35 +21,37 @@ import (
 	"path"
 	"time"
 
-	"github.com/samber/lo"
 	"go.uber.org/zap"
 
-	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/pkg/v2/log"
-	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
-	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
-func LoadBM25Stats(ctx context.Context, chunkManager storage.ChunkManager, segmentID int64, statsBinlogs []*datapb.FieldBinlog) (map[int64]*storage.BM25Stats, error) {
-	startTs := time.Now()
-	log := log.With(zap.Int64("segmentID", segmentID))
-	log.Info("begin to reload history BM25 stats", zap.Int("statsBinLogsLen", len(statsBinlogs)))
-
-	fieldList, fieldOffset := make([]int64, len(statsBinlogs)), make([]int, len(statsBinlogs))
-	logpaths := make([]string, 0)
-	for i, binlog := range statsBinlogs {
-		fieldList[i] = binlog.FieldID
-		fieldOffset[i] = len(binlog.Binlogs)
-		logpaths = append(logpaths, lo.Map(binlog.Binlogs, func(log *datapb.Binlog, _ int) string { return log.GetLogPath() })...)
+// LoadBM25StatsFromPaths loads BM25 stats from resolved file paths grouped by field ID.
+func LoadBM25StatsFromPaths(ctx context.Context, chunkManager storage.ChunkManager, segmentID int64, pathsByField map[int64][]string) (map[int64]*storage.BM25Stats, error) {
+	if len(pathsByField) == 0 {
+		return nil, nil
 	}
 
-	if len(logpaths) == 0 {
+	startTs := time.Now()
+	log := log.With(zap.Int64("segmentID", segmentID))
+	log.Info("begin to reload history BM25 stats")
+
+	fieldList := make([]int64, 0, len(pathsByField))
+	fieldOffset := make([]int, 0, len(pathsByField))
+	allPaths := make([]string, 0)
+	for fieldID, paths := range pathsByField {
+		fieldList = append(fieldList, fieldID)
+		fieldOffset = append(fieldOffset, len(paths))
+		allPaths = append(allPaths, paths...)
+	}
+
+	if len(allPaths) == 0 {
 		log.Warn("no BM25 stats to load")
 		return nil, nil
 	}
 
-	values, err := chunkManager.MultiRead(ctx, logpaths)
+	values, err := chunkManager.MultiRead(ctx, allPaths)
 	if err != nil {
 		log.Warn("failed to load BM25 stats files", zap.Error(err))
 		return nil, err
@@ -72,75 +74,53 @@ func LoadBM25Stats(ctx context.Context, chunkManager storage.ChunkManager, segme
 		cnt += fieldOffset[i]
 	}
 
-	// TODO ADD METRIC FOR LOAD BM25 TIME
 	log.Info("Successfully load BM25 stats", zap.Any("time", time.Since(startTs)))
 	return result, nil
 }
 
-func LoadStats(ctx context.Context, chunkManager storage.ChunkManager, schema *schemapb.CollectionSchema, segmentID int64, statsBinlogs []*datapb.FieldBinlog) ([]*storage.PkStatistics, error) {
-	startTs := time.Now()
-	log := log.With(zap.Int64("segmentID", segmentID))
-	log.Info("begin to init pk bloom filter", zap.Int("statsBinLogsLen", len(statsBinlogs)))
-
-	pkField, err := typeutil.GetPrimaryFieldSchema(schema)
-	if err != nil {
-		return nil, err
-	}
-
-	// filter stats binlog files which is pk field stats log
-	bloomFilterFiles := []string{}
-	logType := storage.DefaultStatsType
-
-	for _, binlog := range statsBinlogs {
-		if binlog.FieldID != pkField.GetFieldID() {
-			continue
-		}
-	Loop:
-		for _, log := range binlog.GetBinlogs() {
-			_, logidx := path.Split(log.GetLogPath())
-			// if special status log exist
-			// only load one file
-			switch logidx {
-			case storage.CompoundStatsType.LogIdx():
-				bloomFilterFiles = []string{log.GetLogPath()}
-				logType = storage.CompoundStatsType
-				break Loop
-			default:
-				bloomFilterFiles = append(bloomFilterFiles, log.GetLogPath())
-			}
-		}
-	}
-
-	// no stats log to parse, initialize a new BF
-	if len(bloomFilterFiles) == 0 {
-		log.Warn("no stats files to load")
+// LoadStatsFromPaths loads bloom filter stats from resolved file paths.
+// It handles CompoundStatsType detection based on the last path component,
+// similar to LoadStats but accepts pre-resolved paths instead of FieldBinlog.
+func LoadStatsFromPaths(ctx context.Context, chunkManager storage.ChunkManager, segmentID int64, paths []string) ([]*storage.PkStatistics, error) {
+	if len(paths) == 0 {
 		return nil, nil
 	}
 
-	// read historical PK filter
-	values, err := chunkManager.MultiRead(ctx, bloomFilterFiles)
+	startTs := time.Now()
+	log := log.With(zap.Int64("segmentID", segmentID))
+	log.Info("begin to load bloom filter from paths", zap.Int("pathCount", len(paths)))
+
+	// Detect CompoundStatsType
+	logType := storage.DefaultStatsType
+	for _, p := range paths {
+		_, logidx := path.Split(p)
+		if logidx == storage.CompoundStatsType.LogIdx() {
+			paths = []string{p}
+			logType = storage.CompoundStatsType
+			break
+		}
+	}
+
+	values, err := chunkManager.MultiRead(ctx, paths)
 	if err != nil {
 		log.Warn("failed to load bloom filter files", zap.Error(err))
 		return nil, err
 	}
-	blobs := make([]*storage.Blob, 0)
-	for i := 0; i < len(values); i++ {
-		blobs = append(blobs, &storage.Blob{Value: values[i]})
+
+	blobs := make([]*storage.Blob, 0, len(values))
+	for _, v := range values {
+		blobs = append(blobs, &storage.Blob{Value: v})
 	}
 
 	var stats []*storage.PrimaryKeyStats
 	if logType == storage.CompoundStatsType {
 		stats, err = storage.DeserializeStatsList(blobs[0])
-		if err != nil {
-			log.Warn("failed to deserialize stats list", zap.Error(err))
-			return nil, err
-		}
 	} else {
 		stats, err = storage.DeserializeStats(blobs)
-		if err != nil {
-			log.Warn("failed to deserialize stats", zap.Error(err))
-			return nil, err
-		}
+	}
+	if err != nil {
+		log.Warn("failed to deserialize bloom filter stats", zap.Error(err))
+		return nil, err
 	}
 
 	var size uint
@@ -155,6 +135,6 @@ func LoadStats(ctx context.Context, chunkManager storage.ChunkManager, schema *s
 		result = append(result, pkStat)
 	}
 
-	log.Info("Successfully load pk stats", zap.Any("time", time.Since(startTs)), zap.Uint("size", size))
+	log.Info("Successfully load bloom filter from paths", zap.Any("time", time.Since(startTs)), zap.Uint("size", size))
 	return result, nil
 }

--- a/internal/core/thirdparty/milvus-storage/CMakeLists.txt
+++ b/internal/core/thirdparty/milvus-storage/CMakeLists.txt
@@ -14,7 +14,7 @@
 # Update milvus-storage_VERSION for the first occurrence
 milvus_add_pkg_config("milvus-storage")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( milvus-storage_VERSION 9b817b1)
+set( milvus-storage_VERSION 50dd3c9)
 set( GIT_REPOSITORY  "https://github.com/milvus-io/milvus-storage.git")
 message(STATUS "milvus-storage repo: ${GIT_REPOSITORY}")
 message(STATUS "milvus-storage version: ${milvus-storage_VERSION}")

--- a/internal/datacoord/segment_info.go
+++ b/internal/datacoord/segment_info.go
@@ -572,3 +572,32 @@ func (s *SegmentInfo) getDeltaCount() int64 {
 
 // SegmentInfoSelector is the function type to select SegmentInfo from meta
 type SegmentInfoSelector func(*SegmentInfo) bool
+
+// ValidateManifestSegment checks that segments with manifest_path have empty
+// legacy stats fields. Returns a descriptive message if validation fails,
+// or empty string if the segment is valid.
+func ValidateManifestSegment(info *SegmentInfo) string {
+	if info.GetManifestPath() == "" {
+		return ""
+	}
+
+	var nonEmpty []string
+	if len(info.GetStatslogs()) > 0 {
+		nonEmpty = append(nonEmpty, fmt.Sprintf("statslogs(%d)", len(info.GetStatslogs())))
+	}
+	if len(info.GetBm25Statslogs()) > 0 {
+		nonEmpty = append(nonEmpty, fmt.Sprintf("bm25statslogs(%d)", len(info.GetBm25Statslogs())))
+	}
+	if len(info.GetTextStatsLogs()) > 0 {
+		nonEmpty = append(nonEmpty, fmt.Sprintf("textStatsLogs(%d)", len(info.GetTextStatsLogs())))
+	}
+	if len(info.GetJsonKeyStats()) > 0 {
+		nonEmpty = append(nonEmpty, fmt.Sprintf("jsonKeyStats(%d)", len(info.GetJsonKeyStats())))
+	}
+
+	if len(nonEmpty) > 0 {
+		return fmt.Sprintf("segment %d has manifest_path but non-empty legacy stats fields: %v",
+			info.GetID(), nonEmpty)
+	}
+	return ""
+}

--- a/internal/datacoord/segment_info_test.go
+++ b/internal/datacoord/segment_info_test.go
@@ -194,3 +194,86 @@ func TestIsStatsLogExists(t *testing.T) {
 	assert.False(t, segment.IsStatsLogExists(3))
 	assert.False(t, segment.IsStatsLogExists(0))
 }
+
+func TestValidateManifestSegment(t *testing.T) {
+	t.Run("no manifest is always valid", func(t *testing.T) {
+		info := NewSegmentInfo(&datapb.SegmentInfo{
+			ID: 1,
+			Statslogs: []*datapb.FieldBinlog{
+				{FieldID: 100},
+			},
+		})
+		assert.Empty(t, ValidateManifestSegment(info))
+	})
+
+	t.Run("manifest with empty legacy fields is valid", func(t *testing.T) {
+		info := NewSegmentInfo(&datapb.SegmentInfo{
+			ID:           2,
+			ManifestPath: "base/path@1",
+		})
+		assert.Empty(t, ValidateManifestSegment(info))
+	})
+
+	t.Run("manifest with statslogs is invalid", func(t *testing.T) {
+		info := NewSegmentInfo(&datapb.SegmentInfo{
+			ID:           3,
+			ManifestPath: "base/path@1",
+			Statslogs: []*datapb.FieldBinlog{
+				{FieldID: 100},
+			},
+		})
+		msg := ValidateManifestSegment(info)
+		assert.Contains(t, msg, "statslogs")
+		assert.Contains(t, msg, "segment 3")
+	})
+
+	t.Run("manifest with bm25statslogs is invalid", func(t *testing.T) {
+		info := NewSegmentInfo(&datapb.SegmentInfo{
+			ID:           4,
+			ManifestPath: "base/path@1",
+			Bm25Statslogs: []*datapb.FieldBinlog{
+				{FieldID: 200},
+			},
+		})
+		msg := ValidateManifestSegment(info)
+		assert.Contains(t, msg, "bm25statslogs")
+	})
+
+	t.Run("manifest with text stats is invalid", func(t *testing.T) {
+		info := NewSegmentInfo(&datapb.SegmentInfo{
+			ID:           5,
+			ManifestPath: "base/path@1",
+			TextStatsLogs: map[int64]*datapb.TextIndexStats{
+				10: {FieldID: 10},
+			},
+		})
+		msg := ValidateManifestSegment(info)
+		assert.Contains(t, msg, "textStatsLogs")
+	})
+
+	t.Run("manifest with json key stats is invalid", func(t *testing.T) {
+		info := NewSegmentInfo(&datapb.SegmentInfo{
+			ID:           6,
+			ManifestPath: "base/path@1",
+			JsonKeyStats: map[int64]*datapb.JsonKeyStats{
+				20: {FieldID: 20},
+			},
+		})
+		msg := ValidateManifestSegment(info)
+		assert.Contains(t, msg, "jsonKeyStats")
+	})
+
+	t.Run("manifest with multiple non-empty fields", func(t *testing.T) {
+		info := NewSegmentInfo(&datapb.SegmentInfo{
+			ID:           7,
+			ManifestPath: "base/path@1",
+			Statslogs:    []*datapb.FieldBinlog{{FieldID: 100}},
+			TextStatsLogs: map[int64]*datapb.TextIndexStats{
+				10: {FieldID: 10},
+			},
+		})
+		msg := ValidateManifestSegment(info)
+		assert.Contains(t, msg, "statslogs")
+		assert.Contains(t, msg, "textStatsLogs")
+	})
+}

--- a/internal/datacoord/segment_operator.go
+++ b/internal/datacoord/segment_operator.go
@@ -43,6 +43,20 @@ func SetTextIndexLogs(textIndexLogs map[int64]*datapb.TextIndexStats) SegmentOpe
 	}
 }
 
+func SetStatslogs(statslogs []*datapb.FieldBinlog) SegmentOperator {
+	return func(segment *SegmentInfo) bool {
+		segment.Statslogs = statslogs
+		return true
+	}
+}
+
+func SetBm25Statslogs(bm25Statslogs []*datapb.FieldBinlog) SegmentOperator {
+	return func(segment *SegmentInfo) bool {
+		segment.Bm25Statslogs = bm25Statslogs
+		return true
+	}
+}
+
 func SetJsonKeyIndexLogs(jsonKeyIndexLogs map[int64]*datapb.JsonKeyStats) SegmentOperator {
 	return func(segment *SegmentInfo) bool {
 		if segment.JsonKeyStats == nil {

--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -645,6 +645,13 @@ func (s *Server) SaveBinlogPaths(ctx context.Context, req *datapb.SaveBinlogPath
 		zap.Strings("bm25logs", stringifyBinlogs(req.GetField2Bm25LogPaths())),
 	)
 
+	// Validate manifest segment after update
+	if segment := s.meta.GetSegment(ctx, req.GetSegmentID()); segment != nil {
+		if msg := ValidateManifestSegment(segment); msg != "" {
+			log.Warn("manifest segment validation warning", zap.String("detail", msg))
+		}
+	}
+
 	if req.GetSegLevel() == datapb.SegmentLevel_L0 {
 		metrics.DataCoordSizeStoredL0Segment.WithLabelValues(fmt.Sprint(req.GetCollectionID())).Observe(calculateL0SegmentSize(req.GetField2StatslogPaths()))
 

--- a/internal/datacoord/task_stats.go
+++ b/internal/datacoord/task_stats.go
@@ -367,6 +367,27 @@ func (st *statsTask) SetJobInfo(ctx context.Context, result *workerpb.StatsResul
 				zap.Int64("segmentID", st.GetSegmentID()), zap.Error(err))
 			break
 		}
+	case indexpb.StatsSubJob_Sort:
+		// For V2 segments (no manifest), persist statsLogs and bm25Logs.
+		// For V3 segments (manifest set), stats are already in manifest.
+		segment := st.meta.GetHealthySegment(ctx, st.GetTargetSegmentID())
+		if segment != nil && segment.GetManifestPath() == "" {
+			var operators []SegmentOperator
+			if len(result.GetStatsLogs()) > 0 {
+				operators = append(operators, SetStatslogs(result.GetStatsLogs()))
+			}
+			if len(result.GetBm25Logs()) > 0 {
+				operators = append(operators, SetBm25Statslogs(result.GetBm25Logs()))
+			}
+			if len(operators) > 0 {
+				err = st.meta.UpdateSegment(st.GetTargetSegmentID(), operators...)
+				if err != nil {
+					log.Ctx(ctx).Warn("save sort stats result failed", zap.Int64("taskID", st.GetTaskID()),
+						zap.Int64("segmentID", st.GetTargetSegmentID()), zap.Error(err))
+					break
+				}
+			}
+		}
 	case indexpb.StatsSubJob_BM25Job:
 	// bm25 logs are generated during with segment flush.
 	default:

--- a/internal/datanode/compactor/l0_compactor.go
+++ b/internal/datanode/compactor/l0_compactor.go
@@ -491,6 +491,7 @@ func (t *LevelZeroCompactionTask) loadBF(ctx context.Context, targetSegments []*
 		segment := segment
 		innerCtx := ctx
 		future := pool.Submit(func() (any, error) {
+			// Decompress fills in LogPath from LogID for legacy segments; no-op for V3.
 			err := binlog.DecompressBinLogWithRootPath(
 				t.compactionParams.StorageConfig.GetRootPath(),
 				storage.StatsBinlog,
@@ -505,12 +506,25 @@ func (t *LevelZeroCompactionTask) loadBF(ctx context.Context, targetSegments []*
 					zap.Error(err))
 				return err, err
 			}
-			pks, err := compaction.LoadStats(innerCtx, t.cm,
-				t.plan.GetSchema(), segment.GetSegmentID(), segment.GetField2StatslogPaths())
+
+			pkField, err := typeutil.GetPrimaryFieldSchema(t.plan.GetSchema())
+			if err != nil {
+				return err, err
+			}
+
+			resolver := packed.NewStatsResolver(segment.GetManifest(), t.compactionParams.StorageConfig).
+				WithStatslogs(segment.GetField2StatslogPaths())
+			paths, err := resolver.BloomFilterPaths(pkField.GetFieldID())
+			if err != nil {
+				return err, err
+			}
+
+			pks, err := compaction.LoadStatsFromPaths(innerCtx, t.cm, segment.GetSegmentID(), paths)
 			if err != nil {
 				log.Warn("failed to load segment stats log",
 					zap.Int64("planID", t.plan.GetPlanID()),
 					zap.String("type", t.plan.GetType().String()),
+					zap.Int64("segmentID", segment.GetSegmentID()),
 					zap.Error(err))
 				return err, err
 			}

--- a/internal/datanode/compactor/namespace_compactor_test.go
+++ b/internal/datanode/compactor/namespace_compactor_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"testing"
+	"time"
 
 	"github.com/apache/arrow/go/v17/arrow/array"
 	"github.com/stretchr/testify/mock"
@@ -39,11 +40,11 @@ type NamespaceCompactorTestSuite struct {
 
 func (s *NamespaceCompactorTestSuite) SetupSuite() {
 	paramtable.Get().Init(paramtable.NewBaseTable())
-	paramtable.Get().Save("common.storageType", "local")
+	paramtable.Get().Save(paramtable.Get().CommonCfg.StorageType.Key, "local")
 	initcore.InitStorageV2FileSystem(paramtable.Get())
 
 	s.binlogIO = mock_util.NewMockBinlogIO(s.T())
-	s.binlogIO.EXPECT().Upload(mock.Anything, mock.Anything).Return(nil)
+	s.binlogIO.EXPECT().Upload(mock.Anything, mock.Anything).Return(nil).Maybe()
 	s.schema = &schemapb.CollectionSchema{
 		Fields: []*schemapb.FieldSchema{
 			{
@@ -70,6 +71,11 @@ func (s *NamespaceCompactorTestSuite) SetupSuite() {
 		},
 	}
 	s.setupSortedSegments()
+}
+
+func (s *NamespaceCompactorTestSuite) TearDownSuite() {
+	paramtable.Get().Reset(paramtable.Get().CommonCfg.StorageType.Key)
+	initcore.CleanArrowFileSystemSingleton()
 }
 
 func (s *NamespaceCompactorTestSuite) setupSortedSegments() {
@@ -125,15 +131,18 @@ func (s *NamespaceCompactorTestSuite) setupSortedSegments() {
 }
 
 func (s *NamespaceCompactorTestSuite) TestCompactSorted() {
+	// Use time-based IDs so each run writes to a unique V3 manifest path,
+	// preventing the loon library from accumulating rows across runs.
+	idBase := time.Now().UnixNano()
 	plan := &datapb.CompactionPlan{
 		SegmentBinlogs: s.sortedSegments,
 		Schema:         s.schema,
 		PreAllocatedSegmentIDs: &datapb.IDRange{
-			Begin: 0,
+			Begin: idBase,
 			End:   math.MaxInt64,
 		},
 		PreAllocatedLogIDs: &datapb.IDRange{
-			Begin: 0,
+			Begin: idBase + 1000000,
 			End:   math.MaxInt64,
 		},
 		MaxSize: 1024 * 1024 * 1024,
@@ -152,10 +161,25 @@ func (s *NamespaceCompactorTestSuite) TestCompactSorted() {
 }
 
 func (s *NamespaceCompactorTestSuite) assertSorted(segment *datapb.CompactionSegment, sortedByFieldIDs []int64) {
-	reader, err := storage.NewBinlogRecordReader(context.Background(), segment.GetInsertLogs(), s.schema, storage.WithVersion(segment.GetStorageVersion()), storage.WithStorageConfig(&indexpb.StorageConfig{
+	storageConfig := &indexpb.StorageConfig{
 		StorageType: "local",
 		RootPath:    paramtable.Get().LocalStorageCfg.Path.GetValue(),
-	}))
+	}
+	var reader storage.RecordReader
+	var err error
+	if segment.GetManifest() != "" {
+		reader, err = storage.NewManifestRecordReader(context.Background(),
+			segment.GetManifest(), s.schema,
+			storage.WithVersion(segment.GetStorageVersion()),
+			storage.WithStorageConfig(storageConfig),
+		)
+	} else {
+		reader, err = storage.NewBinlogRecordReader(context.Background(),
+			segment.GetInsertLogs(), s.schema,
+			storage.WithVersion(segment.GetStorageVersion()),
+			storage.WithStorageConfig(storageConfig),
+		)
+	}
 	s.Require().NoError(err)
 	records := make([]storage.Record, 0)
 	for {

--- a/internal/datanode/compactor/sort_compaction.go
+++ b/internal/datanode/compactor/sort_compaction.go
@@ -37,6 +37,7 @@ import (
 	"github.com/milvus-io/milvus/internal/flushcommon/io"
 	"github.com/milvus-io/milvus/internal/metastore/kv/binlog"
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/internal/util/analyzer"
 	"github.com/milvus-io/milvus/internal/util/fileresource"
 	"github.com/milvus-io/milvus/internal/util/indexcgowrapper"
@@ -283,19 +284,35 @@ func (t *sortCompactionTask) sortSegment(ctx context.Context) (*datapb.Compactio
 
 	phaseStart = time.Now()
 	binlogs, stats, bm25stats, manifest, expirQuantiles := srw.GetLogs()
+
+	// For V3 segments, bloom filter and BM25 stats are already written to
+	// basePath/_stats/ and registered in the manifest by writeStatsV3()
+	// during PackedManifestRecordWriter.Close(). stats and bm25stats will
+	// be nil; only the manifest carries stats information.
+	if manifest != "" {
+		stats = nil
+		bm25stats = nil
+	}
+
 	insertLogs := storage.SortFieldBinlogs(binlogs)
 	if err := binlog.CompressFieldBinlogs(insertLogs); err != nil {
 		return nil, err
 	}
 
-	statsLogs := []*datapb.FieldBinlog{stats}
-	if err := binlog.CompressFieldBinlogs(statsLogs); err != nil {
-		return nil, err
+	var statsLogs []*datapb.FieldBinlog
+	if stats != nil {
+		statsLogs = []*datapb.FieldBinlog{stats}
+		if err := binlog.CompressFieldBinlogs(statsLogs); err != nil {
+			return nil, err
+		}
 	}
 
-	bm25StatsLogs := lo.Values(bm25stats)
-	if err := binlog.CompressFieldBinlogs(bm25StatsLogs); err != nil {
-		return nil, err
+	var bm25StatsLogs []*datapb.FieldBinlog
+	if len(bm25stats) > 0 {
+		bm25StatsLogs = lo.Values(bm25stats)
+		if err := binlog.CompressFieldBinlogs(bm25StatsLogs); err != nil {
+			return nil, err
+		}
 	}
 	compressCost := time.Since(phaseStart)
 
@@ -427,6 +444,22 @@ func (t *sortCompactionTask) Compact() (*datapb.CompactionPlanResult, error) {
 				PlanID: t.GetPlanID(),
 				State:  datapb.CompactionTaskState_failed,
 			}, nil
+		}
+		// For V3 segments, register text index stats in manifest
+		if resultSegment.GetManifest() != "" && len(textStatsLogs) > 0 {
+			statEntries := packed.TextIndexStatEntries(textStatsLogs, t.plan.GetCurrentScalarIndexVersion())
+			newManifest, mErr := packed.AddStatsToManifest(
+				resultSegment.GetManifest(), t.compactionParams.StorageConfig, statEntries)
+			if mErr != nil {
+				log.Warn("failed to add text index stats to manifest",
+					zap.Int64("targetSegmentID", targetSegemntID), zap.Error(mErr))
+				return &datapb.CompactionPlanResult{
+					PlanID: t.GetPlanID(),
+					State:  datapb.CompactionTaskState_failed,
+				}, nil
+			}
+			resultSegment.Manifest = newManifest
+			textStatsLogs = nil
 		}
 		resultSegment.TextStatsLogs = textStatsLogs
 	}

--- a/internal/datanode/index/task_stats.go
+++ b/internal/datanode/index/task_stats.go
@@ -39,6 +39,7 @@ import (
 	"github.com/milvus-io/milvus/internal/flushcommon/io"
 	"github.com/milvus-io/milvus/internal/metastore/kv/binlog"
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/internal/util/analyzer"
 	"github.com/milvus-io/milvus/internal/util/fileresource"
 	"github.com/milvus-io/milvus/internal/util/indexcgowrapper"
@@ -73,8 +74,9 @@ type statsTask struct {
 	binlogIO io.BinlogIO
 	cm       storage.ChunkManager
 
-	logIDOffset int64
-	currentTime time.Time
+	logIDOffset  int64
+	currentTime  time.Time
+	manifestPath string // current manifest version, updated after each AddStatsToManifest
 }
 
 type BuildIndexOptions struct {
@@ -272,14 +274,44 @@ func (st *statsTask) sort(ctx context.Context) ([]*datapb.FieldBinlog, error) {
 		return nil, err
 	}
 
-	statsLogs := []*datapb.FieldBinlog{stats}
-	if err := binlog.CompressFieldBinlogs(statsLogs); err != nil {
-		return nil, err
+	// For V3 segments, register bloom filter and BM25 stats in manifest.
+	// After registration, stats/bm25stats are set to nil so the legacy
+	// binlog-compress path below is skipped for these fields.
+	if st.manifestPath != "" {
+		var statEntries []packed.StatEntry
+		if stats != nil {
+			statEntries = append(statEntries, packed.FieldBinlogStatEntry("bloom_filter", stats.GetFieldID(), stats))
+		}
+		for fieldID, bm25stat := range bm25stats {
+			statEntries = append(statEntries, packed.FieldBinlogStatEntry("bm25", fieldID, bm25stat))
+		}
+
+		if len(statEntries) > 0 {
+			newManifest, err := packed.AddStatsToManifest(
+				st.manifestPath, st.req.GetStorageConfig(), statEntries)
+			if err != nil {
+				return nil, fmt.Errorf("failed to add stats to manifest: %w", err)
+			}
+			st.manifestPath = newManifest
+		}
+		stats = nil
+		bm25stats = nil
 	}
 
-	bm25StatsLogs := lo.Values(bm25stats)
-	if err := binlog.CompressFieldBinlogs(bm25StatsLogs); err != nil {
-		return nil, err
+	var statsLogs []*datapb.FieldBinlog
+	if stats != nil {
+		statsLogs = []*datapb.FieldBinlog{stats}
+		if err := binlog.CompressFieldBinlogs(statsLogs); err != nil {
+			return nil, err
+		}
+	}
+
+	var bm25StatsLogs []*datapb.FieldBinlog
+	if len(bm25stats) > 0 {
+		bm25StatsLogs = lo.Values(bm25stats)
+		if err := binlog.CompressFieldBinlogs(bm25StatsLogs); err != nil {
+			return nil, err
+		}
 	}
 
 	st.manager.StorePKSortStatsResult(st.req.GetClusterID(),
@@ -312,6 +344,7 @@ func (st *statsTask) Execute(ctx context.Context) error {
 	ctx, span := otel.Tracer(typeutil.IndexNodeRole).Start(ctx, fmt.Sprintf("Stats-Execute-%s-%d", st.req.GetClusterID(), st.req.GetTaskID()))
 	defer span.End()
 
+	st.manifestPath = st.req.GetManifestPath()
 	insertLogs := st.req.GetInsertLogs()
 	var err error
 	if st.req.GetSubJobType() == indexpb.StatsSubJob_Sort {
@@ -551,6 +584,18 @@ func (st *statsTask) createTextIndex(ctx context.Context,
 		return err
 	}
 
+	// When manifest_path is set, register text index stats in manifest
+	if st.manifestPath != "" && len(textIndexLogs) > 0 {
+		statEntries := packed.TextIndexStatEntries(textIndexLogs, st.req.GetCurrentScalarIndexVersion())
+		newManifest, err := packed.AddStatsToManifest(
+			st.manifestPath, st.req.GetStorageConfig(), statEntries)
+		if err != nil {
+			return fmt.Errorf("failed to add text index stats to manifest: %w", err)
+		}
+		st.manifestPath = newManifest
+		clear(textIndexLogs)
+	}
+
 	st.manager.StoreStatsTextIndexResult(st.req.GetClusterID(),
 		st.req.GetTaskID(),
 		st.req.GetCollectionID(),
@@ -691,6 +736,18 @@ func (st *statsTask) createJSONKeyStats(ctx context.Context,
 
 	if err := eg.Wait(); err != nil {
 		return err
+	}
+
+	// When manifest_path is set, register JSON key stats in manifest
+	if st.manifestPath != "" && len(jsonKeyIndexStats) > 0 {
+		statEntries := packed.JSONKeyStatEntries(jsonKeyIndexStats)
+		newManifest, err := packed.AddStatsToManifest(
+			st.manifestPath, st.req.GetStorageConfig(), statEntries)
+		if err != nil {
+			return fmt.Errorf("failed to add JSON key stats to manifest: %w", err)
+		}
+		st.manifestPath = newManifest
+		clear(jsonKeyIndexStats)
 	}
 
 	totalElapse := st.tr.RecordSpan()

--- a/internal/flushcommon/pipeline/data_sync_service.go
+++ b/internal/flushcommon/pipeline/data_sync_service.go
@@ -32,6 +32,7 @@ import (
 	"github.com/milvus-io/milvus/internal/flushcommon/util"
 	"github.com/milvus-io/milvus/internal/flushcommon/writebuffer"
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/internal/util/flowgraph"
 	"github.com/milvus-io/milvus/internal/util/streamingutil"
 	"github.com/milvus-io/milvus/pkg/v2/log"
@@ -159,9 +160,16 @@ func initMetaCache(initCtx context.Context, chunkManager storage.ChunkManager, i
 			)
 			segment := item
 			future := io.GetOrCreateStatsPool().Submit(func() (any, error) {
-				var stats []*storage.PkStatistics
-				var err error
-				stats, err = compaction.LoadStats(initCtx, chunkManager, info.GetSchema(), segment.GetID(), segment.GetStatslogs())
+				pkField, err := typeutil.GetPrimaryFieldSchema(info.GetSchema())
+				if err != nil {
+					return nil, err
+				}
+				resolver := packed.NewStatsResolverFromSegmentInfo(segment)
+				bfPaths, err := resolver.BloomFilterPaths(pkField.GetFieldID())
+				if err != nil {
+					return nil, err
+				}
+				stats, err := compaction.LoadStatsFromPaths(initCtx, chunkManager, segment.GetID(), bfPaths)
 				if err != nil {
 					return nil, err
 				}
@@ -170,12 +178,18 @@ func initMetaCache(initCtx context.Context, chunkManager storage.ChunkManager, i
 					tickler.Inc()
 				}
 
-				if segType == "growing" && len(segment.GetBm25Statslogs()) > 0 {
-					bm25stats, err := compaction.LoadBM25Stats(initCtx, chunkManager, segment.GetID(), segment.GetBm25Statslogs())
+				if segType == "growing" {
+					bm25Paths, err := resolver.BM25StatsPaths()
 					if err != nil {
 						return nil, err
 					}
-					segmentBm25.Insert(segment.GetID(), bm25stats)
+					if len(bm25Paths) > 0 {
+						bm25stats, err := compaction.LoadBM25StatsFromPaths(initCtx, chunkManager, segment.GetID(), bm25Paths)
+						if err != nil {
+							return nil, err
+						}
+						segmentBm25.Insert(segment.GetID(), bm25stats)
+					}
 				}
 
 				return struct{}{}, nil

--- a/internal/flushcommon/syncmgr/pack_writer_v3.go
+++ b/internal/flushcommon/syncmgr/pack_writer_v3.go
@@ -19,6 +19,7 @@ package syncmgr
 import (
 	"context"
 	"fmt"
+	"path"
 
 	"go.uber.org/zap"
 
@@ -73,6 +74,7 @@ func (bw *BulkPackWriterV3) Write(ctx context.Context, pack *SyncPack) (
 	// Update manifestPath after writeInserts
 	bw.manifestPath = manifest
 
+	// writeStats for V3 adds bloom filter stats to manifest
 	if stats, err = bw.writeStats(ctx, pack); err != nil {
 		log.Error("failed to process stats blob", zap.Error(err))
 		return
@@ -82,13 +84,15 @@ func (bw *BulkPackWriterV3) Write(ctx context.Context, pack *SyncPack) (
 		log.Error("failed to process delta blob", zap.Error(err))
 		return
 	}
+	// writeBM25Stasts for V3 adds BM25 stats to manifest
 	if bm25Stats, err = bw.writeBM25Stasts(ctx, pack); err != nil {
 		log.Error("failed to process bm25 stats blob", zap.Error(err))
 		return
 	}
 
-	// For V3, deltas is always nil since deltalogs are in manifest
+	// For V3, deltas and stats are in manifest
 	deltas = nil
+	manifest = bw.manifestPath
 	size = bw.sizeWritten
 	return
 }
@@ -257,4 +261,182 @@ func (bw *BulkPackWriterV3) writeDelta(ctx context.Context, pack *SyncPack) (str
 	bw.sizeWritten += pack.deltaData.Size()
 
 	return newManifest, nil
+}
+
+// writeStats overrides the base class to write bloom filter stats into the
+// manifest instead of separate binlog files. The stat files are written
+// under _stats/ relative to the manifest base path, then registered in
+// the manifest via a transaction.
+func (bw *BulkPackWriterV3) writeStats(ctx context.Context, pack *SyncPack) (map[int64]*datapb.FieldBinlog, error) {
+	if len(pack.insertData) == 0 {
+		return make(map[int64]*datapb.FieldBinlog), nil
+	}
+
+	serializer, err := NewStorageSerializer(bw.metaCache, bw.schema)
+	if err != nil {
+		return nil, err
+	}
+	singlePKStats, batchStatsBlob, err := serializer.serializeStatslog(pack)
+	if err != nil {
+		return nil, err
+	}
+
+	// Update metacache (same as base class)
+	actions := []metacache.SegmentAction{metacache.RollStats(singlePKStats)}
+	bw.metaCache.UpdateSegments(metacache.MergeSegmentAction(actions...), metacache.WithSegmentIDs(pack.segmentID))
+
+	pkFieldID := serializer.pkField.GetFieldID()
+	basePath, _, err := packed.UnmarshalManifestPath(bw.manifestPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var files []string
+	var memorySize int64
+
+	// Write batch stats blob via filesystem FFI.
+	id, err := bw.allocator.AllocOne()
+	if err != nil {
+		return nil, err
+	}
+	relPath := fmt.Sprintf("_stats/bloom_filter.%d/%d", pkFieldID, id)
+	fullPath := path.Join(basePath, relPath)
+	if err := packed.WriteFile(bw.storageConfig, fullPath, batchStatsBlob.Value); err != nil {
+		return nil, err
+	}
+	bw.sizeWritten += int64(len(batchStatsBlob.Value))
+	memorySize += int64(len(batchStatsBlob.Value))
+	files = append(files, fullPath)
+
+	// Write merged stats on flush
+	if pack.isFlush && pack.level != datapb.SegmentLevel_L0 {
+		mergedStatsBlob, err := serializer.serializeMergedPkStats(pack)
+		if err != nil {
+			return nil, err
+		}
+		mergedRelPath := fmt.Sprintf("_stats/bloom_filter.%d/%d", pkFieldID, int64(storage.CompoundStatsType))
+		mergedFullPath := path.Join(basePath, mergedRelPath)
+		if err := packed.WriteFile(bw.storageConfig, mergedFullPath, mergedStatsBlob.Value); err != nil {
+			return nil, err
+		}
+		bw.sizeWritten += int64(len(mergedStatsBlob.Value))
+		memorySize += int64(len(mergedStatsBlob.Value))
+		files = append(files, mergedFullPath)
+	}
+
+	// Register stats in manifest
+	newManifest, err := packed.AddStatsToManifest(bw.manifestPath, bw.storageConfig, []packed.StatEntry{
+		{
+			Key:      fmt.Sprintf("bloom_filter.%d", pkFieldID),
+			Files:    files,
+			Metadata: map[string]string{"memory_size": fmt.Sprintf("%d", memorySize)},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to add stats to manifest: %w", err)
+	}
+	bw.manifestPath = newManifest
+
+	// Return empty map - stats are in manifest
+	return make(map[int64]*datapb.FieldBinlog), nil
+}
+
+// writeBM25Stasts overrides the base class to write BM25 stats into the
+// manifest instead of separate binlog files.
+func (bw *BulkPackWriterV3) writeBM25Stasts(ctx context.Context, pack *SyncPack) (map[int64]*datapb.FieldBinlog, error) {
+	if len(pack.bm25Stats) == 0 {
+		return make(map[int64]*datapb.FieldBinlog), nil
+	}
+
+	serializer, err := NewStorageSerializer(bw.metaCache, bw.schema)
+	if err != nil {
+		return nil, err
+	}
+	bm25Blobs, err := serializer.serializeBM25Stats(pack)
+	if err != nil {
+		return nil, err
+	}
+
+	basePath, _, err := packed.UnmarshalManifestPath(bw.manifestPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Track per-field files and memory sizes, then build stat entries at the end
+	type fieldStats struct {
+		files      []string
+		memorySize int64
+	}
+	fieldMap := make(map[int64]*fieldStats)
+
+	for fieldID, blob := range bm25Blobs {
+		id, err := bw.allocator.AllocOne()
+		if err != nil {
+			return nil, err
+		}
+
+		relPath := fmt.Sprintf("_stats/bm25.%d/%d", fieldID, id)
+		fullPath := path.Join(basePath, relPath)
+		if err := packed.WriteFile(bw.storageConfig, fullPath, blob.Value); err != nil {
+			return nil, err
+		}
+		bw.sizeWritten += int64(len(blob.Value))
+
+		fs := fieldMap[fieldID]
+		if fs == nil {
+			fs = &fieldStats{}
+			fieldMap[fieldID] = fs
+		}
+		fs.files = append(fs.files, fullPath)
+		fs.memorySize += int64(len(blob.Value))
+	}
+
+	// Update metacache (same as base class)
+	actions := []metacache.SegmentAction{metacache.MergeBm25Stats(pack.bm25Stats)}
+	bw.metaCache.UpdateSegments(metacache.MergeSegmentAction(actions...), metacache.WithSegmentIDs(pack.segmentID))
+
+	// Write merged BM25 stats on flush
+	if pack.isFlush && pack.level != datapb.SegmentLevel_L0 && hasBM25Function(bw.schema) {
+		mergedBM25Blob, err := serializer.serializeMergedBM25Stats(pack)
+		if err != nil {
+			return nil, err
+		}
+		for fieldID, blob := range mergedBM25Blob {
+			mergedRelPath := fmt.Sprintf("_stats/bm25.%d/%d", fieldID, int64(storage.CompoundStatsType))
+			mergedFullPath := path.Join(basePath, mergedRelPath)
+			if err := packed.WriteFile(bw.storageConfig, mergedFullPath, blob.Value); err != nil {
+				return nil, err
+			}
+			bw.sizeWritten += int64(len(blob.Value))
+
+			fs := fieldMap[fieldID]
+			if fs == nil {
+				fs = &fieldStats{}
+				fieldMap[fieldID] = fs
+			}
+			fs.files = append(fs.files, mergedFullPath)
+			fs.memorySize += int64(len(blob.Value))
+		}
+	}
+
+	// Build stat entries with memory_size metadata
+	var statEntries []packed.StatEntry
+	for fieldID, fs := range fieldMap {
+		statEntries = append(statEntries, packed.StatEntry{
+			Key:      fmt.Sprintf("bm25.%d", fieldID),
+			Files:    fs.files,
+			Metadata: map[string]string{"memory_size": fmt.Sprintf("%d", fs.memorySize)},
+		})
+	}
+
+	if len(statEntries) > 0 {
+		newManifest, err := packed.AddStatsToManifest(bw.manifestPath, bw.storageConfig, statEntries)
+		if err != nil {
+			return nil, fmt.Errorf("failed to add BM25 stats to manifest: %w", err)
+		}
+		bw.manifestPath = newManifest
+	}
+
+	// Return empty map - stats are in manifest
+	return make(map[int64]*datapb.FieldBinlog), nil
 }

--- a/internal/flushcommon/syncmgr/pack_writer_v3.go
+++ b/internal/flushcommon/syncmgr/pack_writer_v3.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"strconv"
 
 	"go.uber.org/zap"
 
@@ -294,6 +295,21 @@ func (bw *BulkPackWriterV3) writeStats(ctx context.Context, pack *SyncPack) (map
 	var files []string
 	var memorySize int64
 
+	// Preserve existing bloom filter files from previous batches.
+	// loon_transaction_update_stat uses replace semantics, so we must
+	// merge previously written files into the new entry.
+	statKey := fmt.Sprintf("bloom_filter.%d", pkFieldID)
+	existingStats, err := packed.GetManifestStats(bw.manifestPath, bw.storageConfig)
+	if err == nil {
+		if existing, ok := existingStats[statKey]; ok && len(existing.Paths) > 0 {
+			files = append(files, existing.Paths...)
+			if memStr, ok := existing.Metadata["memory_size"]; ok {
+				existingMem, _ := strconv.ParseInt(memStr, 10, 64)
+				memorySize += existingMem
+			}
+		}
+	}
+
 	// Write batch stats blob via filesystem FFI.
 	id, err := bw.allocator.AllocOne()
 	if err != nil {
@@ -327,7 +343,7 @@ func (bw *BulkPackWriterV3) writeStats(ctx context.Context, pack *SyncPack) (map
 	// Register stats in manifest
 	newManifest, err := packed.AddStatsToManifest(bw.manifestPath, bw.storageConfig, []packed.StatEntry{
 		{
-			Key:      fmt.Sprintf("bloom_filter.%d", pkFieldID),
+			Key:      statKey,
 			Files:    files,
 			Metadata: map[string]string{"memory_size": fmt.Sprintf("%d", memorySize)},
 		},
@@ -368,6 +384,22 @@ func (bw *BulkPackWriterV3) writeBM25Stasts(ctx context.Context, pack *SyncPack)
 		memorySize int64
 	}
 	fieldMap := make(map[int64]*fieldStats)
+
+	// Preserve existing BM25 stat files from previous batches.
+	existingStats, err := packed.GetManifestStats(bw.manifestPath, bw.storageConfig)
+	if err == nil {
+		for key, existing := range existingStats {
+			prefix, fieldID, ok := packed.ParseStatKey(key)
+			if !ok || prefix != "bm25" || len(existing.Paths) == 0 {
+				continue
+			}
+			fs := &fieldStats{files: existing.Paths}
+			if memStr, ok := existing.Metadata["memory_size"]; ok {
+				fs.memorySize, _ = strconv.ParseInt(memStr, 10, 64)
+			}
+			fieldMap[fieldID] = fs
+		}
+	}
 
 	for fieldID, blob := range bm25Blobs {
 		id, err := bw.allocator.AllocOne()

--- a/internal/flushcommon/syncmgr/pack_writer_v3_test.go
+++ b/internal/flushcommon/syncmgr/pack_writer_v3_test.go
@@ -350,3 +350,197 @@ func (s *PackWriterV3Suite) TestV3InheritsV2Fields() {
 	s.Equal(s.currentSplit, bw.columnGroups)
 	s.Equal(manifestPath, bw.manifestPath)
 }
+
+// genInsertDataWithPKOffset generates insert data with PKs starting at pkOffset+1.
+func genInsertDataWithPKOffset(size int, pkOffset int, schema *schemapb.CollectionSchema) []*storage.InsertData {
+	buf, _ := storage.NewInsertData(schema)
+	for i := 0; i < size; i++ {
+		data := make(map[storage.FieldID]any)
+		data[common.RowIDField] = int64(pkOffset + i + 1)
+		data[common.TimeStampField] = int64(pkOffset + i + 1)
+		data[100] = int64(pkOffset + i + 1) // pk field
+
+		vector := make([]float32, 128)
+		for j := range vector {
+			vector[j] = float32(i+j) * 0.01
+		}
+		data[101] = vector
+
+		vectorData := []float32{float32(i) * 0.1, float32(i) * 0.2}
+		vectorArray := &schemapb.VectorField{
+			Dim: 128,
+			Data: &schemapb.VectorField_FloatVector{
+				FloatVector: &schemapb.FloatArray{Data: vectorData},
+			},
+		}
+		data[103] = vectorArray
+		buf.Append(data)
+	}
+	return []*storage.InsertData{buf}
+}
+
+// TestMultiBatchStatsAccumulation verifies that bloom filter and BM25 stat files
+// from multiple batches accumulate in the manifest rather than being replaced.
+// This is the regression test for the bug where loon_transaction_update_stat
+// replaced the previous batch's stat entry, leaving only the last batch's
+// bloom filter in the manifest.
+func (s *PackWriterV3Suite) TestMultiBatchStatsAccumulation() {
+	collectionID := int64(123)
+	partitionID := int64(456)
+	segmentID := int64(10001) // unique ID to avoid manifest collision with other tests
+	channelName := fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", collectionID)
+	batchRows := 5
+
+	bfs := pkoracle.NewBloomFilterSet()
+
+	k := metautil.JoinIDPath(collectionID, partitionID, segmentID)
+	basePath := path.Join(common.SegmentInsertLogPath, k)
+	manifestPath := packed.MarshalManifestPath(basePath, -1)
+
+	seg := metacache.NewSegmentInfo(&datapb.SegmentInfo{
+		ManifestPath: manifestPath,
+	}, bfs, nil)
+	metacache.UpdateNumOfRows(1000)(seg)
+	mc := metacache.NewMockMetaCache(s.T())
+	mc.EXPECT().Collection().Return(collectionID).Maybe()
+	mc.EXPECT().GetSchema(mock.Anything).Return(s.schema).Maybe()
+	mc.EXPECT().GetSegmentByID(segmentID).Return(seg, true).Maybe()
+	mc.EXPECT().GetSegmentsBy(mock.Anything, mock.Anything).Return([]*metacache.SegmentInfo{seg}).Maybe()
+	mc.EXPECT().UpdateSegments(mock.Anything, mock.Anything).Run(func(action metacache.SegmentAction, filters ...metacache.SegmentFilter) {
+		action(seg)
+	}).Return().Maybe()
+
+	bfKey := fmt.Sprintf("bloom_filter.%d", 100) // pk field ID
+
+	// Batch 1: PKs 1..5
+	pack1 := new(SyncPack).
+		WithCollectionID(collectionID).
+		WithPartitionID(partitionID).
+		WithSegmentID(segmentID).
+		WithChannelName(channelName).
+		WithInsertData(genInsertDataWithPKOffset(batchRows, 0, s.schema)).
+		WithBatchRows(int64(batchRows))
+
+	bw1 := NewBulkPackWriterV3(mc, s.schema, s.cm, s.logIDAlloc, packed.DefaultWriteBufferSize, 0, s.storageConfig, s.currentSplit, manifestPath)
+	_, _, _, _, manifest1, _, err := bw1.Write(context.Background(), pack1)
+	s.Require().NoError(err)
+
+	stats1, err := packed.GetManifestStats(manifest1, s.storageConfig)
+	s.Require().NoError(err)
+	count1 := len(stats1[bfKey].Paths)
+	s.Greater(count1, 0, "batch 1 should produce bloom filter files")
+
+	// Batch 2: PKs 6..10, starting from the manifest written by batch 1
+	pack2 := new(SyncPack).
+		WithCollectionID(collectionID).
+		WithPartitionID(partitionID).
+		WithSegmentID(segmentID).
+		WithChannelName(channelName).
+		WithInsertData(genInsertDataWithPKOffset(batchRows, batchRows, s.schema)).
+		WithBatchRows(int64(batchRows))
+
+	bw2 := NewBulkPackWriterV3(mc, s.schema, s.cm, s.logIDAlloc, packed.DefaultWriteBufferSize, 0, s.storageConfig, s.currentSplit, manifest1)
+	_, _, _, _, manifest2, _, err := bw2.Write(context.Background(), pack2)
+	s.Require().NoError(err)
+
+	stats2, err := packed.GetManifestStats(manifest2, s.storageConfig)
+	s.Require().NoError(err)
+	count2 := len(stats2[bfKey].Paths)
+	s.Greater(count2, count1, "batch 2 should accumulate more bloom filter files than batch 1")
+
+	// Batch 3: PKs 11..15
+	pack3 := new(SyncPack).
+		WithCollectionID(collectionID).
+		WithPartitionID(partitionID).
+		WithSegmentID(segmentID).
+		WithChannelName(channelName).
+		WithInsertData(genInsertDataWithPKOffset(batchRows, batchRows*2, s.schema)).
+		WithBatchRows(int64(batchRows))
+
+	bw3 := NewBulkPackWriterV3(mc, s.schema, s.cm, s.logIDAlloc, packed.DefaultWriteBufferSize, 0, s.storageConfig, s.currentSplit, manifest2)
+	_, _, _, _, manifest3, _, err := bw3.Write(context.Background(), pack3)
+	s.Require().NoError(err)
+
+	stats3, err := packed.GetManifestStats(manifest3, s.storageConfig)
+	s.Require().NoError(err)
+	count3 := len(stats3[bfKey].Paths)
+	s.Greater(count3, count2, "batch 3 should accumulate more bloom filter files than batch 2")
+	s.NotEmpty(stats3[bfKey].Metadata["memory_size"], "memory_size metadata should be set")
+}
+
+// TestMultiBatchBM25StatsAccumulation verifies that BM25 stat files from
+// multiple batches accumulate in the manifest.
+func (s *PackWriterV3Suite) TestMultiBatchBM25StatsAccumulation() {
+	collectionID := int64(123)
+	partitionID := int64(456)
+	segmentID := int64(10002) // unique ID to avoid manifest collision with other tests
+	channelName := fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", collectionID)
+	batchRows := 5
+
+	bfs := pkoracle.NewBloomFilterSet()
+
+	k := metautil.JoinIDPath(collectionID, partitionID, segmentID)
+	basePath := path.Join(common.SegmentInsertLogPath, k)
+	manifestPath := packed.MarshalManifestPath(basePath, -1)
+
+	seg := metacache.NewSegmentInfo(&datapb.SegmentInfo{
+		ManifestPath: manifestPath,
+	}, bfs, nil)
+	metacache.UpdateNumOfRows(1000)(seg)
+	mc := metacache.NewMockMetaCache(s.T())
+	mc.EXPECT().Collection().Return(collectionID).Maybe()
+	mc.EXPECT().GetSchema(mock.Anything).Return(s.schema).Maybe()
+	mc.EXPECT().GetSegmentByID(segmentID).Return(seg, true).Maybe()
+	mc.EXPECT().GetSegmentsBy(mock.Anything, mock.Anything).Return([]*metacache.SegmentInfo{seg}).Maybe()
+	mc.EXPECT().UpdateSegments(mock.Anything, mock.Anything).Run(func(action metacache.SegmentAction, filters ...metacache.SegmentFilter) {
+		action(seg)
+	}).Return().Maybe()
+
+	bm25FieldID := int64(200)
+	makeBM25Stats := func() map[int64]*storage.BM25Stats {
+		stats := storage.NewBM25Stats()
+		stats.Append(map[uint32]float32{1: 1.0, 2: 2.0})
+		return map[int64]*storage.BM25Stats{bm25FieldID: stats}
+	}
+
+	bm25Key := fmt.Sprintf("bm25.%d", bm25FieldID)
+
+	// Batch 1
+	pack1 := new(SyncPack).
+		WithCollectionID(collectionID).
+		WithPartitionID(partitionID).
+		WithSegmentID(segmentID).
+		WithChannelName(channelName).
+		WithInsertData(genInsertDataWithPKOffset(batchRows, 0, s.schema)).
+		WithBatchRows(int64(batchRows)).
+		WithBM25Stats(makeBM25Stats())
+
+	bw1 := NewBulkPackWriterV3(mc, s.schema, s.cm, s.logIDAlloc, packed.DefaultWriteBufferSize, 0, s.storageConfig, s.currentSplit, manifestPath)
+	_, _, _, _, manifest1, _, err := bw1.Write(context.Background(), pack1)
+	s.Require().NoError(err)
+
+	stats1, err := packed.GetManifestStats(manifest1, s.storageConfig)
+	s.Require().NoError(err)
+	count1 := len(stats1[bm25Key].Paths)
+	s.Greater(count1, 0, "batch 1 should produce bm25 stat files")
+
+	// Batch 2
+	pack2 := new(SyncPack).
+		WithCollectionID(collectionID).
+		WithPartitionID(partitionID).
+		WithSegmentID(segmentID).
+		WithChannelName(channelName).
+		WithInsertData(genInsertDataWithPKOffset(batchRows, batchRows, s.schema)).
+		WithBatchRows(int64(batchRows)).
+		WithBM25Stats(makeBM25Stats())
+
+	bw2 := NewBulkPackWriterV3(mc, s.schema, s.cm, s.logIDAlloc, packed.DefaultWriteBufferSize, 0, s.storageConfig, s.currentSplit, manifest1)
+	_, _, _, _, manifest2, _, err := bw2.Write(context.Background(), pack2)
+	s.Require().NoError(err)
+
+	stats2, err := packed.GetManifestStats(manifest2, s.storageConfig)
+	s.Require().NoError(err)
+	count2 := len(stats2[bm25Key].Paths)
+	s.Greater(count2, count1, "batch 2 should accumulate more bm25 files than batch 1")
+	s.NotEmpty(stats2[bm25Key].Metadata["memory_size"], "memory_size metadata should be set")
+}

--- a/internal/flushcommon/writebuffer/write_buffer.go
+++ b/internal/flushcommon/writebuffer/write_buffer.go
@@ -632,6 +632,7 @@ func (wb *writeBufferBase) getSyncTask(ctx context.Context, segmentID int64) (sy
 		WithMetaCache(wb.metaCache).
 		WithSchema(schema).
 		WithSyncPack(pack).
+		WithStorageConfig(packed.CreateStorageConfig()).
 		WithWriteRetryOptions(retry.AttemptAlways(), retry.MaxSleepTime(10*time.Second))
 	return task, nil
 }

--- a/internal/querycoordv2/utils/types.go
+++ b/internal/querycoordv2/utils/types.go
@@ -73,25 +73,33 @@ func PackSegmentLoadInfo(segment *datapb.SegmentInfo, channelCheckpoint *msgpb.M
 			zap.Duration("tsLag", tsLag))
 	}
 	loadInfo := &querypb.SegmentLoadInfo{
-		SegmentID:        segment.ID,
-		PartitionID:      segment.PartitionID,
-		CollectionID:     segment.CollectionID,
-		BinlogPaths:      segment.Binlogs,
-		NumOfRows:        segment.NumOfRows,
-		Statslogs:        segment.Statslogs,
-		Deltalogs:        segment.Deltalogs,
-		Bm25Logs:         segment.Bm25Statslogs,
-		InsertChannel:    segment.InsertChannel,
-		IndexInfos:       indexes,
-		StartPosition:    segment.GetStartPosition(),
-		DeltaPosition:    channelCheckpoint,
-		Level:            segment.GetLevel(),
-		StorageVersion:   segment.GetStorageVersion(),
-		IsSorted:         segment.GetIsSorted(),
-		TextStatsLogs:    segment.GetTextStatsLogs(),
-		JsonKeyStatsLogs: segment.GetJsonKeyStats(),
-		ManifestPath:     segment.GetManifestPath(),
+		SegmentID:      segment.ID,
+		PartitionID:    segment.PartitionID,
+		CollectionID:   segment.CollectionID,
+		BinlogPaths:    segment.Binlogs,
+		NumOfRows:      segment.NumOfRows,
+		InsertChannel:  segment.InsertChannel,
+		IndexInfos:     indexes,
+		StartPosition:  segment.GetStartPosition(),
+		DeltaPosition:  channelCheckpoint,
+		Level:          segment.GetLevel(),
+		StorageVersion: segment.GetStorageVersion(),
+		IsSorted:       segment.GetIsSorted(),
+		ManifestPath:   segment.GetManifestPath(),
 	}
+
+	// Deltalogs are always populated (delta log loading has its own manifest path)
+	loadInfo.Deltalogs = segment.Deltalogs
+
+	// When manifest_path is set, stats are stored in the manifest.
+	// Skip populating legacy stats fields - the reader will load from manifest.
+	if segment.GetManifestPath() == "" {
+		loadInfo.Statslogs = segment.Statslogs
+		loadInfo.Bm25Logs = segment.Bm25Statslogs
+		loadInfo.TextStatsLogs = segment.GetTextStatsLogs()
+		loadInfo.JsonKeyStatsLogs = segment.GetJsonKeyStats()
+	}
+
 	return loadInfo
 }
 

--- a/internal/querycoordv2/utils/types_test.go
+++ b/internal/querycoordv2/utils/types_test.go
@@ -83,3 +83,71 @@ func Test_packLoadSegmentRequest(t *testing.T) {
 		assert.Equal(t, channel.SeekPosition.Timestamp, req.GetDeltaPosition().GetTimestamp())
 	})
 }
+
+func TestPackSegmentLoadInfo_ManifestPath(t *testing.T) {
+	mockPChannel := "fake-by-dev-rootcoord-dml-1"
+	checkpoint := &msgpb.MsgPosition{
+		ChannelName: mockPChannel,
+		Timestamp:   tsoutil.ComposeTSByTime(time.Now().Add(-1*time.Minute), 0),
+	}
+
+	t.Run("manifest set clears legacy stats fields", func(t *testing.T) {
+		seg := &datapb.SegmentInfo{
+			ID:           100,
+			ManifestPath: "base/path@5",
+			Statslogs: []*datapb.FieldBinlog{
+				{FieldID: 1},
+			},
+			Bm25Statslogs: []*datapb.FieldBinlog{
+				{FieldID: 2},
+			},
+			TextStatsLogs: map[int64]*datapb.TextIndexStats{
+				10: {FieldID: 10},
+			},
+			JsonKeyStats: map[int64]*datapb.JsonKeyStats{
+				20: {FieldID: 20},
+			},
+			Deltalogs: []*datapb.FieldBinlog{
+				{FieldID: 0, Binlogs: []*datapb.Binlog{{LogPath: "delta/1"}}},
+			},
+		}
+		loadInfo := PackSegmentLoadInfo(seg, checkpoint, nil)
+
+		assert.Equal(t, "base/path@5", loadInfo.GetManifestPath())
+		assert.Empty(t, loadInfo.GetStatslogs())
+		assert.Empty(t, loadInfo.GetBm25Logs())
+		assert.Empty(t, loadInfo.GetTextStatsLogs())
+		assert.Empty(t, loadInfo.GetJsonKeyStatsLogs())
+		// Deltalogs should always be populated
+		assert.NotEmpty(t, loadInfo.GetDeltalogs())
+	})
+
+	t.Run("no manifest populates all legacy fields", func(t *testing.T) {
+		seg := &datapb.SegmentInfo{
+			ID: 200,
+			Statslogs: []*datapb.FieldBinlog{
+				{FieldID: 1},
+			},
+			Bm25Statslogs: []*datapb.FieldBinlog{
+				{FieldID: 2},
+			},
+			TextStatsLogs: map[int64]*datapb.TextIndexStats{
+				10: {FieldID: 10},
+			},
+			JsonKeyStats: map[int64]*datapb.JsonKeyStats{
+				20: {FieldID: 20},
+			},
+			Deltalogs: []*datapb.FieldBinlog{
+				{FieldID: 0, Binlogs: []*datapb.Binlog{{LogPath: "delta/1"}}},
+			},
+		}
+		loadInfo := PackSegmentLoadInfo(seg, checkpoint, nil)
+
+		assert.Empty(t, loadInfo.GetManifestPath())
+		assert.NotEmpty(t, loadInfo.GetStatslogs())
+		assert.NotEmpty(t, loadInfo.GetBm25Logs())
+		assert.NotEmpty(t, loadInfo.GetTextStatsLogs())
+		assert.NotEmpty(t, loadInfo.GetJsonKeyStatsLogs())
+		assert.NotEmpty(t, loadInfo.GetDeltalogs())
+	})
+}

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -39,13 +39,13 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/querynodev2/pkoracle"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/storagecommon"
+	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/internal/util/indexparamcheck"
 	"github.com/milvus-io/milvus/internal/util/vecindexmgr"
 	"github.com/milvus-io/milvus/pkg/v2/common"
@@ -622,8 +622,10 @@ func (loader *segmentLoader) LoadBM25Stats(ctx context.Context, collectionID int
 		stats := make(map[int64]*storage.BM25Stats)
 
 		log.Info("loading bm25 stats for remote...", zap.Int64("collectionID", collectionID), zap.Int64("segment", segmentID))
-		logpaths := loader.filterBM25Stats(loadInfo.Bm25Logs)
-		err := loader.loadBm25Stats(ctx, segmentID, stats, logpaths)
+		logpaths, err := packed.NewStatsResolverFromLoadInfo(loadInfo).BM25StatsPaths()
+		if err == nil {
+			err = loader.loadBm25Stats(ctx, segmentID, stats, logpaths)
+		}
 		if err != nil {
 			log.Warn("load remote segment bm25 stats failed",
 				zap.Int64("segmentID", segmentID),
@@ -666,9 +668,11 @@ func (loader *segmentLoader) loadSingleBloomFilterSet(ctx context.Context, colle
 	bfs := pkoracle.NewBloomFilterSet(segmentID, partitionID, segtype)
 
 	log.Info("loading bloom filter for remote...")
-	pkStatsBinlogs, logType := loader.filterPKStatsBinlogs(loadInfo.Statslogs, pkField.GetFieldID())
-	err := loader.loadBloomFilter(ctx, segmentID, bfs, pkStatsBinlogs, logType)
+	pkStatsBinlogs, err := packed.NewStatsResolverFromLoadInfo(loadInfo).BloomFilterPaths(pkField.GetFieldID())
 	if err != nil {
+		return nil, err
+	}
+	if err := loader.loadBloomFilter(ctx, segmentID, bfs, pkStatsBinlogs); err != nil {
 		log.Warn("load remote segment bloom filter failed",
 			zap.Int64("partitionID", partitionID),
 			zap.Int64("segmentID", segmentID),
@@ -706,11 +710,8 @@ func (loader *segmentLoader) LoadBloomFilterSet(ctx context.Context, collectionI
 	// Calculate total memory size needed for bloom filters (PK stats)
 	var totalMemorySize int64
 	for _, info := range infos {
-		for _, fieldBinlog := range info.Statslogs {
-			if fieldBinlog.FieldID == pkFieldID {
-				totalMemorySize += getBinlogDataMemorySize(fieldBinlog)
-			}
-		}
+		memSize, _ := packed.NewStatsResolverFromLoadInfo(info).BloomFilterMemorySize(pkFieldID)
+		totalMemorySize += memSize
 	}
 
 	// Reserve memory resource if tiered eviction is enabled
@@ -746,9 +747,11 @@ func (loader *segmentLoader) LoadBloomFilterSet(ctx context.Context, collectionI
 		bfs := pkoracle.NewBloomFilterSet(segmentID, partitionID, commonpb.SegmentState_Sealed)
 
 		log.Info("loading bloom filter for remote...")
-		pkStatsBinlogs, logType := loader.filterPKStatsBinlogs(loadInfo.Statslogs, pkField.GetFieldID())
-		err := loader.loadBloomFilter(ctx, segmentID, bfs, pkStatsBinlogs, logType)
+		pkStatsBinlogs, err := packed.NewStatsResolverFromLoadInfo(loadInfo).BloomFilterPaths(pkFieldID)
 		if err != nil {
+			return err
+		}
+		if err := loader.loadBloomFilter(ctx, segmentID, bfs, pkStatsBinlogs); err != nil {
 			log.Warn("load remote segment bloom filter failed",
 				zap.Int64("partitionID", partitionID),
 				zap.Int64("segmentID", segmentID),
@@ -880,24 +883,18 @@ func separateLoadInfoV2(loadInfo *querypb.SegmentLoadInfo, schema *schemapb.Coll
 		}
 	}
 
-	textIndexedInfo := make(map[int64]*datapb.TextIndexStats, len(loadInfo.GetTextStatsLogs()))
-	for _, fieldStatsLog := range loadInfo.GetTextStatsLogs() {
-		textLog, ok := textIndexedInfo[fieldStatsLog.FieldID]
-		if !ok {
-			textIndexedInfo[fieldStatsLog.FieldID] = fieldStatsLog
-		} else if fieldStatsLog.GetVersion() > textLog.GetVersion() {
-			textIndexedInfo[fieldStatsLog.FieldID] = fieldStatsLog
-		}
+	textIndexedInfo, jsonKeyIndexInfo, err := packed.NewStatsResolverFromLoadInfo(loadInfo).TextAndJSONIndexStats()
+	if err != nil {
+		log.Warn("failed to load text/json stats from manifest",
+			zap.String("manifestPath", loadInfo.GetManifestPath()), zap.Error(err))
+		textIndexedInfo = make(map[int64]*datapb.TextIndexStats)
+		jsonKeyIndexInfo = make(map[int64]*datapb.JsonKeyStats)
 	}
-
-	jsonKeyIndexInfo := make(map[int64]*datapb.JsonKeyStats, len(loadInfo.GetJsonKeyStatsLogs()))
-	for _, fieldStatsLog := range loadInfo.GetJsonKeyStatsLogs() {
-		jsonKeyLog, ok := jsonKeyIndexInfo[fieldStatsLog.FieldID]
-		if !ok {
-			jsonKeyIndexInfo[fieldStatsLog.FieldID] = fieldStatsLog
-		} else if fieldStatsLog.GetVersion() > jsonKeyLog.GetVersion() {
-			jsonKeyIndexInfo[fieldStatsLog.FieldID] = fieldStatsLog
-		}
+	if textIndexedInfo == nil {
+		textIndexedInfo = make(map[int64]*datapb.TextIndexStats)
+	}
+	if jsonKeyIndexInfo == nil {
+		jsonKeyIndexInfo = make(map[int64]*datapb.JsonKeyStats)
 	}
 
 	unindexedTextFields := make(map[int64]struct{})
@@ -1031,131 +1028,23 @@ func (loader *segmentLoader) LoadSegment(ctx context.Context,
 	// load statslog if it's growing segment
 	if segment.segmentType == SegmentTypeGrowing {
 		log.Info("loading statslog...")
-		pkStatsBinlogs, logType := loader.filterPKStatsBinlogs(loadInfo.Statslogs, pkField.GetFieldID())
-		err := loader.loadBloomFilter(ctx, segment.ID(), segment.bloomFilterSet, pkStatsBinlogs, logType)
+		resolver := packed.NewStatsResolverFromLoadInfo(loadInfo)
+		bfPaths, err := resolver.BloomFilterPaths(pkField.GetFieldID())
 		if err != nil {
 			return err
 		}
-
-		if len(loadInfo.Bm25Logs) > 0 {
-			log.Info("loading bm25 stats...")
-			bm25StatsLogs := loader.filterBM25Stats(loadInfo.Bm25Logs)
-
-			err = loader.loadBm25Stats(ctx, segment.ID(), segment.bm25Stats, bm25StatsLogs)
-			if err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
-func (loader *segmentLoader) filterPKStatsBinlogs(fieldBinlogs []*datapb.FieldBinlog, pkFieldID int64) ([]string, storage.StatsLogType) {
-	result := make([]string, 0)
-	for _, fieldBinlog := range fieldBinlogs {
-		if fieldBinlog.FieldID == pkFieldID {
-			for _, binlog := range fieldBinlog.GetBinlogs() {
-				_, logidx := path.Split(binlog.GetLogPath())
-				// if special status log exist
-				// only load one file
-				switch logidx {
-				case storage.CompoundStatsType.LogIdx():
-					return []string{binlog.GetLogPath()}, storage.CompoundStatsType
-				default:
-					result = append(result, binlog.GetLogPath())
-				}
-			}
-		}
-	}
-	return result, storage.DefaultStatsType
-}
-
-func (loader *segmentLoader) filterBM25Stats(fieldBinlogs []*datapb.FieldBinlog) map[int64][]string {
-	result := make(map[int64][]string, 0)
-	for _, fieldBinlog := range fieldBinlogs {
-		logpaths := []string{}
-		for _, binlog := range fieldBinlog.GetBinlogs() {
-			_, logidx := path.Split(binlog.GetLogPath())
-			// if special status log exist
-			// only load one file
-			if logidx == storage.CompoundStatsType.LogIdx() {
-				logpaths = []string{binlog.GetLogPath()}
-				break
-			} else {
-				logpaths = append(logpaths, binlog.GetLogPath())
-			}
-		}
-		result[fieldBinlog.FieldID] = logpaths
-	}
-	return result
-}
-
-func loadSealedSegmentFields(ctx context.Context, collection *Collection, segment *LocalSegment, fields []*datapb.FieldBinlog, rowCount int64) error {
-	runningGroup, _ := errgroup.WithContext(ctx)
-	for _, field := range fields {
-		fieldBinLog := field
-		fieldID := field.FieldID
-		runningGroup.Go(func() error {
-			return segment.LoadFieldData(ctx, fieldID, rowCount, fieldBinLog)
-		})
-	}
-	err := runningGroup.Wait()
-	if err != nil {
-		return err
-	}
-
-	log.Ctx(ctx).Info("load field binlogs done for sealed segment",
-		zap.Int64("collection", segment.Collection()),
-		zap.Int64("segment", segment.ID()),
-		zap.Int("len(field)", len(fields)),
-		zap.String("segmentType", segment.Type().String()))
-
-	return nil
-}
-
-func (loader *segmentLoader) loadFieldsIndex(ctx context.Context,
-	schemaHelper *typeutil.SchemaHelper,
-	segment *LocalSegment,
-	numRows int64,
-	indexedFieldInfos map[int64]*IndexedFieldInfo,
-) error {
-	log := log.Ctx(ctx).With(
-		zap.Int64("collectionID", segment.Collection()),
-		zap.Int64("partitionID", segment.Partition()),
-		zap.Int64("segmentID", segment.ID()),
-		zap.Int64("rowCount", numRows),
-	)
-
-	for _, fieldInfo := range indexedFieldInfos {
-		fieldID := fieldInfo.IndexInfo.FieldID
-		indexInfo := fieldInfo.IndexInfo
-		tr := timerecord.NewTimeRecorder("loadFieldIndex")
-		err := loader.loadFieldIndex(ctx, segment, indexInfo)
-		loadFieldIndexSpan := tr.RecordSpan()
-		if err != nil {
+		if err := loader.loadBloomFilter(ctx, segment.ID(), segment.bloomFilterSet, bfPaths); err != nil {
 			return err
 		}
 
-		log.Info("load field binlogs done for sealed segment with index",
-			zap.Int64("fieldID", fieldID),
-			zap.Any("binlog", fieldInfo.FieldBinlog.Binlogs),
-			zap.Int32("current_index_version", fieldInfo.IndexInfo.GetCurrentIndexVersion()),
-			zap.Duration("load_duration", loadFieldIndexSpan),
-		)
-
-		// set average row data size of variable field
-		field, err := schemaHelper.GetFieldFromID(fieldID)
+		bm25Paths, err := resolver.BM25StatsPaths()
 		if err != nil {
 			return err
 		}
-		if typeutil.IsVariableDataType(field.GetDataType()) {
-			err = segment.UpdateFieldRawDataSize(ctx, numRows, fieldInfo.FieldBinlog)
-			if err != nil {
-				return err
-			}
+		if err := loader.loadBm25Stats(ctx, segment.ID(), segment.bm25Stats, bm25Paths); err != nil {
+			return err
 		}
 	}
-
 	return nil
 }
 
@@ -1228,7 +1117,7 @@ func (loader *segmentLoader) loadBm25Stats(ctx context.Context, segmentID int64,
 }
 
 func (loader *segmentLoader) loadBloomFilter(ctx context.Context, segmentID int64, bfs *pkoracle.BloomFilterSet,
-	binlogPaths []string, logType storage.StatsLogType,
+	binlogPaths []string,
 ) error {
 	log := log.Ctx(ctx).With(
 		zap.Int64("segmentID", segmentID),
@@ -1243,24 +1132,15 @@ func (loader *segmentLoader) loadBloomFilter(ctx context.Context, segmentID int6
 	if err != nil {
 		return err
 	}
-	blobs := []*storage.Blob{}
-	for i := 0; i < len(values); i++ {
-		blobs = append(blobs, &storage.Blob{Value: values[i]})
+	blobs := make([]*storage.Blob, len(values))
+	for i := range values {
+		blobs[i] = &storage.Blob{Value: values[i]}
 	}
 
-	var stats []*storage.PrimaryKeyStats
-	if logType == storage.CompoundStatsType {
-		stats, err = storage.DeserializeStatsList(blobs[0])
-		if err != nil {
-			log.Warn("failed to deserialize stats list", zap.Error(err))
-			return err
-		}
-	} else {
-		stats, err = storage.DeserializeStats(blobs)
-		if err != nil {
-			log.Warn("failed to deserialize stats", zap.Error(err))
-			return err
-		}
+	stats, err := storage.DeserializeBloomFilterStats(binlogPaths, blobs)
+	if err != nil {
+		log.Warn("failed to deserialize bloom filter stats", zap.Error(err))
+		return err
 	}
 
 	var size uint
@@ -1890,7 +1770,8 @@ func estimateLogicalResourceUsageOfSegment(schema *schemapb.CollectionSchema, lo
 	// Text match indexes are evictable (support_eviction=true in caching layer).
 	// Text match index mmap is driven by scalar_field_enable_mmap (same as raw scalar data).
 	textIndexMmapEnable := paramtable.Get().QueryNodeCfg.MmapScalarField.GetAsBool()
-	for _, textStats := range loadInfo.GetTextStatsLogs() {
+	textStatsLogs, _, _ := packed.NewStatsResolverFromLoadInfo(loadInfo).TextAndJSONIndexStats()
+	for _, textStats := range textStatsLogs {
 		if textIndexMmapEnable {
 			segmentEvictableDiskSize += uint64(float64(textStats.GetMemorySize()) * multiplyFactor.textIndexExpansionFactor)
 		} else {
@@ -2118,8 +1999,9 @@ func estimateLoadingResourceUsageOfSegment(schema *schemapb.CollectionSchema, lo
 	}
 
 	// PART 5: calculate size of json key stats data
+	textStatsLogs, jsonKeyStatsLogs, _ := packed.NewStatsResolverFromLoadInfo(loadInfo).TextAndJSONIndexStats()
 	jsonStatsMmapEnable := paramtable.Get().QueryNodeCfg.MmapJSONStats.GetAsBool()
-	for _, jsonKeyStats := range loadInfo.GetJsonKeyStatsLogs() {
+	for _, jsonKeyStats := range jsonKeyStatsLogs {
 		if jsonStatsMmapEnable {
 			if !multiplyFactor.TieredEvictionEnabled {
 				segDiskLoadingSize += uint64(float64(jsonKeyStats.GetMemorySize()) * multiplyFactor.jsonKeyStatsExpansionFactor)
@@ -2148,7 +2030,7 @@ func estimateLoadingResourceUsageOfSegment(schema *schemapb.CollectionSchema, lo
 	// memory_size = sum of Tantivy index file sizes (same value as C++ ByteSize() after load),
 	// so 1.0x is the baseline; textIndexExpansionFactor allows tuning if needed.
 	textIndexMmapEnable := paramtable.Get().QueryNodeCfg.MmapScalarField.GetAsBool()
-	for _, textStats := range loadInfo.GetTextStatsLogs() {
+	for _, textStats := range textStatsLogs {
 		if textIndexMmapEnable {
 			if !multiplyFactor.TieredEvictionEnabled {
 				segDiskLoadingSize += uint64(float64(textStats.GetMemorySize()) * multiplyFactor.textIndexExpansionFactor)
@@ -2319,22 +2201,17 @@ func (loader *segmentLoader) LoadJSONIndex(ctx context.Context,
 		return merr.WrapErrParameterInvalid("LocalSegment", fmt.Sprintf("%T", seg))
 	}
 
-	if len(loadInfo.GetJsonKeyStatsLogs()) == 0 {
+	_, jsonKeyIndexInfo, err := packed.NewStatsResolverFromLoadInfo(loadInfo).TextAndJSONIndexStats()
+	if err != nil {
+		return err
+	}
+	if len(jsonKeyIndexInfo) == 0 {
 		return nil
 	}
 
 	collection := segment.GetCollection()
 	schemaHelper, _ := typeutil.CreateSchemaHelper(collection.Schema())
 
-	jsonKeyIndexInfo := make(map[int64]*datapb.JsonKeyStats, len(loadInfo.GetJsonKeyStatsLogs()))
-	for _, fieldStatsLog := range loadInfo.GetJsonKeyStatsLogs() {
-		jsonKeyLog, ok := jsonKeyIndexInfo[fieldStatsLog.FieldID]
-		if !ok {
-			jsonKeyIndexInfo[fieldStatsLog.FieldID] = fieldStatsLog
-		} else if fieldStatsLog.GetVersion() > jsonKeyLog.GetVersion() {
-			jsonKeyIndexInfo[fieldStatsLog.FieldID] = fieldStatsLog
-		}
-	}
 	for _, info := range jsonKeyIndexInfo {
 		if err := segment.LoadJSONKeyIndex(ctx, info, schemaHelper); err != nil {
 			return err

--- a/internal/storage/binlog_record_writer.go
+++ b/internal/storage/binlog_record_writer.go
@@ -26,6 +26,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/allocator"
 	"github.com/milvus-io/milvus/internal/storagecommon"
+	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/indexcgopb"
@@ -423,7 +424,7 @@ func (pw *PackedManifestRecordWriter) initWriters(r Record) error {
 
 		var err error
 		k := metautil.JoinIDPath(pw.collectionID, pw.partitionID, pw.segmentID)
-		basePath := path.Join(pw.storageConfig.GetRootPath(), common.SegmentInsertLogPath, k)
+		basePath := path.Join(common.SegmentInsertLogPath, k)
 		pw.writer, err = NewPackedRecordManifestWriter(basePath, -1, pw.schema, pw.bufferSize, pw.multiPartUploadSize, pw.columnGroups, pw.storageConfig, pw.storagePluginContext)
 		if err != nil {
 			return merr.WrapErrServiceInternal(fmt.Sprintf("can not new packed record writer %s", err.Error()))
@@ -468,9 +469,86 @@ func (pw *PackedManifestRecordWriter) Close() error {
 		}
 	}
 	pw.finalizeBinlogs()
-	if err := pw.writeStats(); err != nil {
+	// For V3 (manifest-based) segments, stats are stored under basePath/_stats/
+	// and registered in the manifest. If pw.manifest is empty, no data was
+	// written, so there are no stats to write.
+	if pw.manifest != "" {
+		if err := pw.writeStatsV3(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// writeStatsV3 writes bloom filter and BM25 stats for V3 (manifest-based)
+// segments. Stats blobs are written to basePath/_stats/ and registered in the
+// manifest via a transaction, leaving pw.statsLog and pw.bm25StatsLog nil so
+// callers know stats are embedded in the manifest.
+func (pw *PackedManifestRecordWriter) writeStatsV3() error {
+	basePath, _, err := packed.UnmarshalManifestPath(pw.manifest)
+	if err != nil {
+		return fmt.Errorf("writeStatsV3: failed to parse manifest path: %w", err)
+	}
+
+	// --- Bloom filter (PK) stats ---
+	statsBlob, pkFieldID, err := pw.pkCollector.SerializeBlob(pw.rowNum)
+	if err != nil {
 		return err
 	}
+	if statsBlob != nil {
+		id, err := pw.allocator.AllocOne()
+		if err != nil {
+			return err
+		}
+		fullPath := path.Join(basePath, fmt.Sprintf("_stats/bloom_filter.%d/%d", pkFieldID, id))
+		if err := packed.WriteFile(pw.storageConfig, fullPath, statsBlob.Value); err != nil {
+			return fmt.Errorf("writeStatsV3: failed to write bloom filter stats: %w", err)
+		}
+
+		newManifest, err := packed.AddStatsToManifest(pw.manifest, pw.storageConfig, []packed.StatEntry{
+			{
+				Key:      fmt.Sprintf("bloom_filter.%d", pkFieldID),
+				Files:    []string{fullPath},
+				Metadata: map[string]string{"memory_size": fmt.Sprintf("%d", int64(len(statsBlob.Value)))},
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("writeStatsV3: failed to add bloom filter stats to manifest: %w", err)
+		}
+		pw.manifest = newManifest
+		// Stats are stored in the manifest; leave pw.statsLog nil.
+	}
+
+	// --- BM25 stats ---
+	bm25Blobs, err := pw.bm25Collector.SerializeBlobs()
+	if err != nil {
+		return err
+	}
+	if len(bm25Blobs) > 0 {
+		var statEntries []packed.StatEntry
+		for fieldID, blob := range bm25Blobs {
+			id, err := pw.allocator.AllocOne()
+			if err != nil {
+				return err
+			}
+			fullPath := path.Join(basePath, fmt.Sprintf("_stats/bm25.%d/%d", fieldID, id))
+			if err := packed.WriteFile(pw.storageConfig, fullPath, blob.Value); err != nil {
+				return fmt.Errorf("writeStatsV3: failed to write bm25 stats: %w", err)
+			}
+			statEntries = append(statEntries, packed.StatEntry{
+				Key:      fmt.Sprintf("bm25.%d", fieldID),
+				Files:    []string{fullPath},
+				Metadata: map[string]string{"memory_size": fmt.Sprintf("%d", blob.MemorySize)},
+			})
+		}
+		newManifest, err := packed.AddStatsToManifest(pw.manifest, pw.storageConfig, statEntries)
+		if err != nil {
+			return fmt.Errorf("writeStatsV3: failed to add bm25 stats to manifest: %w", err)
+		}
+		pw.manifest = newManifest
+		// Stats are stored in the manifest; leave pw.bm25StatsLog nil.
+	}
+
 	return nil
 }
 

--- a/internal/storage/rw_test.go
+++ b/internal/storage/rw_test.go
@@ -20,7 +20,9 @@ import (
 	"context"
 	"io"
 	"math"
+	"path"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -28,6 +30,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
@@ -35,9 +38,11 @@ import (
 	"github.com/milvus-io/milvus/internal/allocator"
 	"github.com/milvus-io/milvus/internal/mocks/flushcommon/mock_util"
 	"github.com/milvus-io/milvus/internal/storagecommon"
+	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v2/util/metautil"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/tsoutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
@@ -348,6 +353,78 @@ func (s *PackedBinlogRecordSuite) TestAllocIDExhausedError() {
 		s.NoError(err)
 		err = w.Write(rec)
 		s.Error(err)
+	}
+}
+
+// TestV3StatsWrittenUnderBasePath verifies the regression fix: for V3
+// (manifest-based) storage, bloom filter stats must be written to
+// basePath/_stats/bloom_filter.{fieldID}/{id}, NOT to stats_log/.
+// Before the fix, writeStats() was called, placing files at
+// {rootPath}/stats_log/... which caused a mangled path on read-back.
+func (s *PackedBinlogRecordSuite) TestV3StatsWrittenUnderBasePath() {
+	dir := s.T().TempDir()
+	paramtable.Get().Save(paramtable.Get().CommonCfg.StorageType.Key, "local")
+	paramtable.Get().Save(paramtable.Get().LocalStorageCfg.Path.Key, dir)
+	defer func() {
+		paramtable.Get().Reset(paramtable.Get().CommonCfg.StorageType.Key)
+		paramtable.Get().Reset(paramtable.Get().LocalStorageCfg.Path.Key)
+	}()
+
+	storageConfig := &indexpb.StorageConfig{
+		RootPath:    dir,
+		StorageType: "local",
+	}
+	columnGroups := []storagecommon.ColumnGroup{
+		{GroupID: 0, Columns: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}, Fields: []int64{0, 1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 101}},
+	}
+	wOption := []RwOption{
+		WithVersion(StorageV3),
+		WithColumnGroups(columnGroups),
+		WithStorageConfig(storageConfig),
+		WithUploader(func(ctx context.Context, kvs map[string][]byte) error { return nil }),
+	}
+
+	w, err := NewBinlogRecordWriter(s.ctx, s.collectionID, s.partitionID, s.segmentID, s.schema, s.logIDAlloc, s.chunkSize, s.maxRowNum, wOption...)
+	require.NoError(s.T(), err)
+
+	blobs, err := generateTestData(10)
+	require.NoError(s.T(), err)
+	reader, err := NewBinlogDeserializeReader(generateTestSchema(), MakeBlobsReader(blobs), false)
+	require.NoError(s.T(), err)
+	defer reader.Close()
+	for i := 0; i < 10; i++ {
+		v, err := reader.NextValue()
+		require.NoError(s.T(), err)
+		rec, err := ValueSerializer([]*Value{*v}, s.schema)
+		require.NoError(s.T(), err)
+		require.NoError(s.T(), w.Write(rec))
+	}
+	require.NoError(s.T(), w.Close())
+
+	_, statsLog, _, manifestPath, _ := w.GetLogs()
+
+	// For V3: stats are in the manifest, not in a separate FieldBinlog.
+	assert.Nil(s.T(), statsLog, "V3 statsLog must be nil; stats are stored in the manifest")
+	require.NotEmpty(s.T(), manifestPath, "V3 manifest path must be non-empty")
+
+	// The manifest must contain bloom filter stats with paths under basePath/_stats/.
+	stats, err := packed.GetManifestStats(manifestPath, storageConfig)
+	require.NoError(s.T(), err)
+
+	pkField, err := typeutil.GetPrimaryFieldSchema(s.schema)
+	require.NoError(s.T(), err)
+	bfKey := "bloom_filter." + strconv.FormatInt(pkField.GetFieldID(), 10)
+	bfStat, ok := stats[bfKey]
+	require.True(s.T(), ok, "manifest must contain bloom filter stats under key %q", bfKey)
+	require.NotEmpty(s.T(), bfStat.Paths)
+
+	basePath := path.Join(common.SegmentInsertLogPath,
+		metautil.JoinIDPath(s.collectionID, s.partitionID, s.segmentID))
+	for _, p := range bfStat.Paths {
+		assert.True(s.T(), strings.HasPrefix(p, basePath+"/_stats/"),
+			"bloom filter stat path %q must be under basePath/_stats/, got path outside basePath", p)
+		assert.NotContains(s.T(), p, "stats_log",
+			"bloom filter stat path must not use legacy stats_log/ layout")
 	}
 }
 

--- a/internal/storage/stats.go
+++ b/internal/storage/stats.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"maps"
 	"math"
+	"path"
 
 	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
@@ -500,7 +501,20 @@ func (m *BM25Stats) GetAvgdl() float64 {
 	return float64(m.numToken) / float64(m.numRow)
 }
 
-// DeserializeStats deserialize @blobs as []*PrimaryKeyStats
+// DeserializeBloomFilterStats auto-detects compound vs default stats format
+// from the paths and deserializes accordingly. Compound format is detected
+// when any path has a basename matching CompoundStatsType.LogIdx().
+func DeserializeBloomFilterStats(paths []string, blobs []*Blob) ([]*PrimaryKeyStats, error) {
+	for _, p := range paths {
+		_, logidx := path.Split(p)
+		if logidx == CompoundStatsType.LogIdx() {
+			return DeserializeStatsList(blobs[0])
+		}
+	}
+	return DeserializeStats(blobs)
+}
+
+// DeserializeStats deserializes @blobs as []*PrimaryKeyStats
 func DeserializeStats(blobs []*Blob) ([]*PrimaryKeyStats, error) {
 	results := make([]*PrimaryKeyStats, 0, len(blobs))
 	for _, blob := range blobs {

--- a/internal/storage/stats.go
+++ b/internal/storage/stats.go
@@ -505,10 +505,10 @@ func (m *BM25Stats) GetAvgdl() float64 {
 // from the paths and deserializes accordingly. Compound format is detected
 // when any path has a basename matching CompoundStatsType.LogIdx().
 func DeserializeBloomFilterStats(paths []string, blobs []*Blob) ([]*PrimaryKeyStats, error) {
-	for _, p := range paths {
+	for i, p := range paths {
 		_, logidx := path.Split(p)
 		if logidx == CompoundStatsType.LogIdx() {
-			return DeserializeStatsList(blobs[0])
+			return DeserializeStatsList(blobs[i])
 		}
 	}
 	return DeserializeStats(blobs)

--- a/internal/storage/stats_collector.go
+++ b/internal/storage/stats_collector.go
@@ -142,6 +142,31 @@ func (c *PkStatsCollector) Digest(
 	}, nil
 }
 
+// SerializeBlob serializes the collected PK statistics into a Blob without
+// writing to storage. Returns nil if no stats were collected.
+// Also returns the PK field ID for use in path construction.
+func (c *PkStatsCollector) SerializeBlob(rowNum int64) (*Blob, int64, error) {
+	if c.pkstats == nil {
+		return nil, 0, nil
+	}
+
+	codec := NewInsertCodecWithSchema(&etcdpb.CollectionMeta{
+		ID:     c.collectionID,
+		Schema: c.schema,
+	})
+	blob, err := codec.SerializePkStats(c.pkstats, rowNum)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	pkField, err := typeutil.GetPrimaryFieldSchema(c.schema)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return blob, pkField.GetFieldID(), nil
+}
+
 // NewPkStatsCollector creates a new primary key stats collector
 func NewPkStatsCollector(
 	collectionID UniqueID,
@@ -256,6 +281,28 @@ func (c *Bm25StatsCollector) Digest(
 		return nil, err
 	}
 
+	return result, nil
+}
+
+// SerializeBlobs serializes the collected BM25 statistics into Blobs without
+// writing to storage. Returns nil if no BM25 stats were collected.
+// The map key is the field ID.
+func (c *Bm25StatsCollector) SerializeBlobs() (map[int64]*Blob, error) {
+	if len(c.bm25Stats) == 0 {
+		return nil, nil
+	}
+
+	result := make(map[int64]*Blob, len(c.bm25Stats))
+	for fieldID, stats := range c.bm25Stats {
+		data, err := stats.Serialize()
+		if err != nil {
+			return nil, err
+		}
+		result[fieldID] = &Blob{
+			Value:      data,
+			MemorySize: int64(len(data)),
+		}
+	}
 	return result, nil
 }
 

--- a/internal/storage/stats_test.go
+++ b/internal/storage/stats_test.go
@@ -160,6 +160,65 @@ func TestStatsWriter_UpgradePrimaryKey(t *testing.T) {
 	}
 }
 
+func TestDeserializeBloomFilterStats(t *testing.T) {
+	// Build a compound stats blob using GenerateList.
+	stat, err := NewPrimaryKeyStats(1, int64(schemapb.DataType_Int64), 100)
+	assert.NoError(t, err)
+	stat.Update(NewInt64PrimaryKey(1))
+	stat.Update(NewInt64PrimaryKey(2))
+
+	sw := &StatsWriter{}
+	sw.GenerateList([]*PrimaryKeyStats{stat})
+	compoundBlob := &Blob{Value: sw.GetBuffer()}
+
+	// Build a default (per-row) stats blob.
+	sw2 := &StatsWriter{}
+	err = sw2.GenerateByData(common.RowIDField, schemapb.DataType_Int64, &Int64FieldData{
+		Data: []int64{10, 20},
+	})
+	assert.NoError(t, err)
+	defaultBlob := &Blob{Value: sw2.GetBuffer()}
+
+	t.Run("compound path at non-zero index", func(t *testing.T) {
+		// The compound blob is at index 1 (not 0). Before the fix this
+		// would incorrectly use blobs[0] (the default blob) and fail.
+		paths := []string{
+			"root/stats/0",
+			"root/stats/" + CompoundStatsType.LogIdx(),
+		}
+		blobs := []*Blob{defaultBlob, compoundBlob}
+
+		stats, err := DeserializeBloomFilterStats(paths, blobs)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(stats))
+		assert.True(t, stats[0].MinPk.EQ(NewInt64PrimaryKey(1)))
+		assert.True(t, stats[0].MaxPk.EQ(NewInt64PrimaryKey(2)))
+	})
+
+	t.Run("compound path at index zero", func(t *testing.T) {
+		paths := []string{
+			"root/stats/" + CompoundStatsType.LogIdx(),
+		}
+		blobs := []*Blob{compoundBlob}
+
+		stats, err := DeserializeBloomFilterStats(paths, blobs)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(stats))
+		assert.True(t, stats[0].MinPk.EQ(NewInt64PrimaryKey(1)))
+	})
+
+	t.Run("default stats fallback", func(t *testing.T) {
+		paths := []string{"root/stats/0"}
+		blobs := []*Blob{defaultBlob}
+
+		stats, err := DeserializeBloomFilterStats(paths, blobs)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(stats))
+		assert.True(t, stats[0].MinPk.EQ(NewInt64PrimaryKey(10)))
+		assert.True(t, stats[0].MaxPk.EQ(NewInt64PrimaryKey(20)))
+	})
+}
+
 func TestDeserializeStatsFailed(t *testing.T) {
 	blob := &Blob{
 		Value: []byte("abc"),

--- a/internal/storagev2/packed/ffi_filesystem.go
+++ b/internal/storagev2/packed/ffi_filesystem.go
@@ -1,0 +1,85 @@
+// Copyright 2023 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packed
+
+/*
+#cgo pkg-config: milvus_core milvus-storage
+
+#include <stdlib.h>
+#include "milvus-storage/ffi_filesystem_c.h"
+*/
+import "C"
+
+import (
+	"fmt"
+	"strings"
+	"unsafe"
+
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
+)
+
+// WriteFile writes raw bytes to a file using milvus-storage filesystem FFI.
+// filePath is the full storage path (rootPath/basePath/...).
+func WriteFile(
+	storageConfig *indexpb.StorageConfig,
+	filePath string,
+	data []byte,
+) error {
+	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create properties: %w", err)
+	}
+	defer C.loon_properties_free(cProperties)
+
+	cPath := C.CString(filePath)
+	defer C.free(unsafe.Pointer(cPath))
+	pathLen := C.uint32_t(len(filePath))
+
+	// Get filesystem handle (LRU-cached by C++ side)
+	var fsHandle C.FileSystemHandle
+	result := C.loon_filesystem_get(cProperties, cPath, pathLen, &fsHandle)
+	if err := HandleLoonFFIResult(result); err != nil {
+		return fmt.Errorf("failed to get filesystem: %w", err)
+	}
+	defer C.loon_filesystem_destroy(fsHandle)
+
+	// Local filesystem requires parent directories to exist before writing.
+	// Object stores (S3/MinIO/GCS) don't have real directories.
+	if storageConfig.GetStorageType() == "local" {
+		if idx := strings.LastIndex(filePath, "/"); idx > 0 {
+			dir := filePath[:idx]
+			cDir := C.CString(dir)
+			defer C.free(unsafe.Pointer(cDir))
+			result = C.loon_filesystem_create_dir(fsHandle, cDir, C.uint32_t(len(dir)), true)
+			if err := HandleLoonFFIResult(result); err != nil {
+				return fmt.Errorf("failed to create parent directory %q: %w", dir, err)
+			}
+		}
+	}
+
+	// Write file atomically
+	var dataPtr *C.uint8_t
+	if len(data) > 0 {
+		dataPtr = (*C.uint8_t)(unsafe.Pointer(&data[0]))
+	}
+
+	result = C.loon_filesystem_write_file(
+		fsHandle,
+		cPath, pathLen,
+		dataPtr, C.uint64_t(len(data)),
+		nil, 0, // no file metadata
+	)
+	return HandleLoonFFIResult(result)
+}

--- a/internal/storagev2/packed/ffi_stats.go
+++ b/internal/storagev2/packed/ffi_stats.go
@@ -1,0 +1,156 @@
+// Copyright 2023 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packed
+
+/*
+#cgo pkg-config: milvus_core milvus-storage
+
+#include <stdlib.h>
+#include "milvus-storage/ffi_c.h"
+*/
+import "C"
+
+import (
+	"fmt"
+	"unsafe"
+
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
+)
+
+// ManifestStat represents a stat entry from the manifest.
+type ManifestStat struct {
+	Paths    []string
+	Metadata map[string]string
+}
+
+// UpdateTransactionStat writes a stat entry to a manifest transaction.
+// key is "type.fieldID" (e.g. "bloom_filter.100"), files are relative
+// paths, metadata is arbitrary key-value pairs (may be nil).
+func UpdateTransactionStat(
+	handle C.LoonTransactionHandle,
+	key string,
+	files []string,
+	metadata map[string]string,
+) error {
+	cKey := C.CString(key)
+	defer C.free(unsafe.Pointer(cKey))
+
+	// Build files array
+	cFiles := make([]*C.char, len(files))
+	for i, f := range files {
+		cFiles[i] = C.CString(f)
+	}
+	defer func() {
+		for _, p := range cFiles {
+			C.free(unsafe.Pointer(p))
+		}
+	}()
+
+	var cFilesPtr **C.char
+	if len(cFiles) > 0 {
+		cFilesPtr = &cFiles[0]
+	}
+
+	// Build metadata parallel arrays
+	var cMetaKeys, cMetaValues []*C.char
+	for k, v := range metadata {
+		cMetaKeys = append(cMetaKeys, C.CString(k))
+		cMetaValues = append(cMetaValues, C.CString(v))
+	}
+	defer func() {
+		for _, p := range cMetaKeys {
+			C.free(unsafe.Pointer(p))
+		}
+		for _, p := range cMetaValues {
+			C.free(unsafe.Pointer(p))
+		}
+	}()
+
+	var cMetaKeysPtr, cMetaValuesPtr **C.char
+	if len(cMetaKeys) > 0 {
+		cMetaKeysPtr = &cMetaKeys[0]
+		cMetaValuesPtr = &cMetaValues[0]
+	}
+
+	result := C.loon_transaction_update_stat(
+		handle,
+		cKey,
+		(**C.char)(unsafe.Pointer(cFilesPtr)),
+		C.size_t(len(files)),
+		(**C.char)(unsafe.Pointer(cMetaKeysPtr)),
+		(**C.char)(unsafe.Pointer(cMetaValuesPtr)),
+		C.size_t(len(metadata)),
+	)
+	return HandleLoonFFIResult(result)
+}
+
+// GetManifestStats reads all stats from a manifest.
+// Returns map[statKey]ManifestStat with paths and metadata for each key.
+func GetManifestStats(
+	manifestPath string,
+	storageConfig *indexpb.StorageConfig,
+) (map[string]ManifestStat, error) {
+	cManifest, err := GetManifestHandle(manifestPath, storageConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get manifest: %w", err)
+	}
+	defer C.loon_manifest_destroy(cManifest)
+
+	numStats := int(cManifest.stats.num_stats)
+	result := make(map[string]ManifestStat, numStats)
+
+	if numStats == 0 {
+		return result, nil
+	}
+
+	statKeys := unsafe.Slice(cManifest.stats.stat_keys, numStats)
+	statFiles := unsafe.Slice(cManifest.stats.stat_files, numStats)
+	statFileCounts := unsafe.Slice(cManifest.stats.stat_file_counts, numStats)
+	statMetaKeys := unsafe.Slice(cManifest.stats.stat_metadata_keys, numStats)
+	statMetaValues := unsafe.Slice(cManifest.stats.stat_metadata_values, numStats)
+	statMetaCounts := unsafe.Slice(cManifest.stats.stat_metadata_counts, numStats)
+
+	for i := 0; i < numStats; i++ {
+		key := C.GoString(statKeys[i])
+
+		// Read paths
+		fileCount := int(statFileCounts[i])
+		paths := make([]string, fileCount)
+		if fileCount > 0 {
+			files := unsafe.Slice(statFiles[i], fileCount)
+			for j := 0; j < fileCount; j++ {
+				paths[j] = C.GoString(files[j])
+			}
+		}
+
+		// Read metadata
+		metaCount := int(statMetaCounts[i])
+		metadata := make(map[string]string, metaCount)
+		if metaCount > 0 {
+			mKeys := unsafe.Slice(statMetaKeys[i], metaCount)
+			mValues := unsafe.Slice(statMetaValues[i], metaCount)
+			for j := 0; j < metaCount; j++ {
+				metadata[C.GoString(mKeys[j])] = C.GoString(mValues[j])
+			}
+		}
+
+		result[key] = ManifestStat{
+			Paths:    paths,
+			Metadata: metadata,
+		}
+	}
+
+	return result, nil
+}

--- a/internal/storagev2/packed/packed_reader.go
+++ b/internal/storagev2/packed/packed_reader.go
@@ -27,6 +27,7 @@ import "C"
 import (
 	"fmt"
 	"io"
+	"strings"
 	"unsafe"
 
 	"github.com/apache/arrow/go/v17/arrow"
@@ -37,6 +38,15 @@ import (
 )
 
 func NewPackedReader(filePaths []string, schema *arrow.Schema, bufferSize int64, storageConfig *indexpb.StorageConfig, storagePluginContext *indexcgopb.StoragePluginContext) (*PackedReader, error) {
+	// The C++ packed reader prepends root_path from storageConfig to file paths.
+	// Stored binlog paths already include root_path, so strip it to avoid double-append.
+	if storageConfig != nil && storageConfig.GetRootPath() != "" {
+		prefix := storageConfig.GetRootPath() + "/"
+		for i, p := range filePaths {
+			filePaths[i] = strings.TrimPrefix(p, prefix)
+		}
+	}
+
 	cFilePaths := make([]*C.char, len(filePaths))
 	for i, path := range filePaths {
 		cFilePaths[i] = C.CString(path)

--- a/internal/storagev2/packed/packed_writer.go
+++ b/internal/storagev2/packed/packed_writer.go
@@ -26,6 +26,7 @@ package packed
 import "C"
 
 import (
+	"strings"
 	"unsafe"
 
 	"github.com/apache/arrow/go/v17/arrow"
@@ -38,6 +39,15 @@ import (
 )
 
 func NewPackedWriter(filePaths []string, schema *arrow.Schema, bufferSize int64, multiPartUploadSize int64, columnGroups []storagecommon.ColumnGroup, storageConfig *indexpb.StorageConfig, storagePluginContext *indexcgopb.StoragePluginContext) (*PackedWriter, error) {
+	// The C++ packed writer prepends root_path from storageConfig to file paths.
+	// Stored binlog paths already include root_path, so strip it to avoid double-append.
+	if storageConfig != nil && storageConfig.GetRootPath() != "" {
+		prefix := storageConfig.GetRootPath() + "/"
+		for i, p := range filePaths {
+			filePaths[i] = strings.TrimPrefix(p, prefix)
+		}
+	}
+
 	cFilePaths := make([]*C.char, len(filePaths))
 	for i, path := range filePaths {
 		cFilePaths[i] = C.CString(path)

--- a/internal/storagev2/packed/packed_writer_ffi.go
+++ b/internal/storagev2/packed/packed_writer_ffi.go
@@ -43,7 +43,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
-func createStorageConfig() *indexpb.StorageConfig {
+func CreateStorageConfig() *indexpb.StorageConfig {
 	var storageConfig *indexpb.StorageConfig
 
 	if paramtable.Get().CommonCfg.StorageType.GetValue() == "local" {
@@ -85,7 +85,7 @@ func NewFFIPackedWriter(basePath string, baseVersion int64, schema *arrow.Schema
 	defer cdata.ReleaseCArrowSchema(&cas)
 
 	if storageConfig == nil {
-		storageConfig = createStorageConfig()
+		storageConfig = CreateStorageConfig()
 	}
 
 	pattern := strings.Join(lo.Map(columnGroups, func(columnGroup storagecommon.ColumnGroup, _ int) string {

--- a/internal/storagev2/packed/stat_entry_builders.go
+++ b/internal/storagev2/packed/stat_entry_builders.go
@@ -1,0 +1,78 @@
+// Copyright 2023 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packed
+
+import (
+	"fmt"
+
+	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+)
+
+// FieldBinlogStatEntry builds a StatEntry from a FieldBinlog with the given key prefix.
+// For example: FieldBinlogStatEntry("bloom_filter", stats.GetFieldID(), stats)
+func FieldBinlogStatEntry(prefix string, fieldID int64, fb *datapb.FieldBinlog) StatEntry {
+	var memorySize int64
+	paths := make([]string, 0, len(fb.GetBinlogs()))
+	for _, b := range fb.GetBinlogs() {
+		paths = append(paths, b.GetLogPath())
+		memorySize += b.GetMemorySize()
+	}
+	entry := StatEntry{
+		Key:   fmt.Sprintf("%s.%d", prefix, fieldID),
+		Files: paths,
+	}
+	if memorySize > 0 {
+		entry.Metadata = map[string]string{"memory_size": fmt.Sprintf("%d", memorySize)}
+	}
+	return entry
+}
+
+// TextIndexStatEntries builds StatEntry slice from text index stats.
+func TextIndexStatEntries(textStats map[int64]*datapb.TextIndexStats, scalarIndexVersion int32) []StatEntry {
+	entries := make([]StatEntry, 0, len(textStats))
+	for fieldID, ts := range textStats {
+		entries = append(entries, StatEntry{
+			Key:   fmt.Sprintf("text_index.%d", fieldID),
+			Files: ts.GetFiles(),
+			Metadata: map[string]string{
+				"version":                      fmt.Sprintf("%d", ts.GetVersion()),
+				"build_id":                     fmt.Sprintf("%d", ts.GetBuildID()),
+				"log_size":                     fmt.Sprintf("%d", ts.GetLogSize()),
+				"memory_size":                  fmt.Sprintf("%d", ts.GetMemorySize()),
+				"current_scalar_index_version": fmt.Sprintf("%d", scalarIndexVersion),
+			},
+		})
+	}
+	return entries
+}
+
+// JSONKeyStatEntries builds StatEntry slice from JSON key stats.
+func JSONKeyStatEntries(jsonStats map[int64]*datapb.JsonKeyStats) []StatEntry {
+	entries := make([]StatEntry, 0, len(jsonStats))
+	for fieldID, js := range jsonStats {
+		entries = append(entries, StatEntry{
+			Key:   fmt.Sprintf("json_key_index.%d", fieldID),
+			Files: js.GetFiles(),
+			Metadata: map[string]string{
+				"version":                    fmt.Sprintf("%d", js.GetVersion()),
+				"build_id":                   fmt.Sprintf("%d", js.GetBuildID()),
+				"log_size":                   fmt.Sprintf("%d", js.GetLogSize()),
+				"memory_size":                fmt.Sprintf("%d", js.GetMemorySize()),
+				"json_key_stats_data_format": fmt.Sprintf("%d", js.GetJsonKeyStatsDataFormat()),
+			},
+		})
+	}
+	return entries
+}

--- a/internal/storagev2/packed/stat_entry_builders_test.go
+++ b/internal/storagev2/packed/stat_entry_builders_test.go
@@ -1,0 +1,120 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packed
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+)
+
+func TestFieldBinlogStatEntry(t *testing.T) {
+	t.Run("key format and paths", func(t *testing.T) {
+		fb := &datapb.FieldBinlog{
+			FieldID: 100,
+			Binlogs: []*datapb.Binlog{
+				{LogPath: "path/a", MemorySize: 1024},
+				{LogPath: "path/b", MemorySize: 2048},
+			},
+		}
+		entry := FieldBinlogStatEntry("bloom_filter", 100, fb)
+		assert.Equal(t, "bloom_filter.100", entry.Key)
+		assert.Equal(t, []string{"path/a", "path/b"}, entry.Files)
+		assert.Equal(t, "3072", entry.Metadata["memory_size"])
+	})
+
+	t.Run("bm25 prefix", func(t *testing.T) {
+		fb := &datapb.FieldBinlog{
+			FieldID: 200,
+			Binlogs: []*datapb.Binlog{
+				{LogPath: "path/c", MemorySize: 500},
+			},
+		}
+		entry := FieldBinlogStatEntry("bm25", 200, fb)
+		assert.Equal(t, "bm25.200", entry.Key)
+		assert.Equal(t, []string{"path/c"}, entry.Files)
+		assert.Equal(t, "500", entry.Metadata["memory_size"])
+	})
+
+	t.Run("zero memory size omits metadata", func(t *testing.T) {
+		fb := &datapb.FieldBinlog{
+			FieldID: 100,
+			Binlogs: []*datapb.Binlog{
+				{LogPath: "path/a", MemorySize: 0},
+			},
+		}
+		entry := FieldBinlogStatEntry("bloom_filter", 100, fb)
+		assert.Nil(t, entry.Metadata)
+	})
+
+	t.Run("empty binlogs", func(t *testing.T) {
+		fb := &datapb.FieldBinlog{FieldID: 100}
+		entry := FieldBinlogStatEntry("bloom_filter", 100, fb)
+		assert.Equal(t, "bloom_filter.100", entry.Key)
+		assert.Empty(t, entry.Files)
+		assert.Nil(t, entry.Metadata)
+	})
+}
+
+func TestTextIndexStatEntries(t *testing.T) {
+	textStats := map[int64]*datapb.TextIndexStats{
+		10: {
+			FieldID:    10,
+			Version:    5,
+			BuildID:    42,
+			Files:      []string{"file1", "file2"},
+			LogSize:    1000,
+			MemorySize: 2000,
+		},
+	}
+	entries := TextIndexStatEntries(textStats, 3)
+	assert.Len(t, entries, 1)
+	e := entries[0]
+	assert.Equal(t, "text_index.10", e.Key)
+	assert.Equal(t, []string{"file1", "file2"}, e.Files)
+	assert.Equal(t, "5", e.Metadata["version"])
+	assert.Equal(t, "42", e.Metadata["build_id"])
+	assert.Equal(t, "1000", e.Metadata["log_size"])
+	assert.Equal(t, "2000", e.Metadata["memory_size"])
+	assert.Equal(t, "3", e.Metadata["current_scalar_index_version"])
+}
+
+func TestJSONKeyStatEntries(t *testing.T) {
+	jsonStats := map[int64]*datapb.JsonKeyStats{
+		20: {
+			FieldID:                20,
+			Version:                1,
+			BuildID:                99,
+			Files:                  []string{"json1"},
+			LogSize:                500,
+			MemorySize:             800,
+			JsonKeyStatsDataFormat: 2,
+		},
+	}
+	entries := JSONKeyStatEntries(jsonStats)
+	assert.Len(t, entries, 1)
+	e := entries[0]
+	assert.Equal(t, "json_key_index.20", e.Key)
+	assert.Equal(t, []string{"json1"}, e.Files)
+	assert.Equal(t, "1", e.Metadata["version"])
+	assert.Equal(t, "99", e.Metadata["build_id"])
+	assert.Equal(t, "500", e.Metadata["log_size"])
+	assert.Equal(t, "800", e.Metadata["memory_size"])
+	assert.Equal(t, "2", e.Metadata["json_key_stats_data_format"])
+}

--- a/internal/storagev2/packed/stats_resolver.go
+++ b/internal/storagev2/packed/stats_resolver.go
@@ -1,0 +1,360 @@
+// Copyright 2023 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packed
+
+import (
+	"fmt"
+	"path"
+	"strconv"
+	"strings"
+
+	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/querypb"
+)
+
+// compoundStatsLogIdx is the log index that identifies compound stats format.
+// This mirrors storage.CompoundStatsType.LogIdx() == "1" but avoids
+// importing internal/storage (which already imports this package).
+const compoundStatsLogIdx = "1"
+
+// StatsResolver resolves stat file paths from either a LOON manifest (V3)
+// or legacy FieldBinlog arrays (V2). It caches the manifest FFI call
+// so multiple stat lookups share a single read.
+type StatsResolver struct {
+	// Manifest-based (V3)
+	manifestPath  string
+	storageConfig *indexpb.StorageConfig
+
+	// Legacy (V2)
+	statslogs     []*datapb.FieldBinlog
+	bm25Logs      []*datapb.FieldBinlog
+	textStatsLogs map[int64]*datapb.TextIndexStats
+	jsonKeyStats  map[int64]*datapb.JsonKeyStats
+
+	// Lazy-loaded manifest cache
+	manifestStats  map[string]ManifestStat
+	manifestLoaded bool
+	manifestErr    error
+}
+
+// NewStatsResolver creates a StatsResolver. Pass a non-empty manifestPath
+// for V3 (manifest-based) segments, or an empty string for V2 (legacy).
+func NewStatsResolver(manifestPath string, storageConfig *indexpb.StorageConfig) *StatsResolver {
+	return &StatsResolver{
+		manifestPath:  manifestPath,
+		storageConfig: storageConfig,
+	}
+}
+
+// NewStatsResolverFromLoadInfo creates a fully-populated StatsResolver from a
+// SegmentLoadInfo. This is the preferred constructor for QueryNode call sites.
+func NewStatsResolverFromLoadInfo(loadInfo *querypb.SegmentLoadInfo) *StatsResolver {
+	return &StatsResolver{
+		manifestPath:  loadInfo.GetManifestPath(),
+		storageConfig: CreateStorageConfig(),
+		statslogs:     loadInfo.GetStatslogs(),
+		bm25Logs:      loadInfo.GetBm25Logs(),
+		textStatsLogs: loadInfo.GetTextStatsLogs(),
+		jsonKeyStats:  loadInfo.GetJsonKeyStatsLogs(),
+	}
+}
+
+// NewStatsResolverFromSegmentInfo creates a fully-populated StatsResolver from a
+// datapb.SegmentInfo. This is the preferred constructor for DataNode call sites.
+func NewStatsResolverFromSegmentInfo(info *datapb.SegmentInfo) *StatsResolver {
+	return &StatsResolver{
+		manifestPath:  info.GetManifestPath(),
+		storageConfig: CreateStorageConfig(),
+		statslogs:     info.GetStatslogs(),
+		bm25Logs:      info.GetBm25Statslogs(),
+		textStatsLogs: info.GetTextStatsLogs(),
+		jsonKeyStats:  info.GetJsonKeyStats(),
+	}
+}
+
+func (r *StatsResolver) WithStatslogs(s []*datapb.FieldBinlog) *StatsResolver {
+	r.statslogs = s
+	return r
+}
+
+func (r *StatsResolver) WithBM25Logs(b []*datapb.FieldBinlog) *StatsResolver {
+	r.bm25Logs = b
+	return r
+}
+
+func (r *StatsResolver) WithTextStatsLogs(t map[int64]*datapb.TextIndexStats) *StatsResolver {
+	r.textStatsLogs = t
+	return r
+}
+
+func (r *StatsResolver) WithJSONKeyStats(j map[int64]*datapb.JsonKeyStats) *StatsResolver {
+	r.jsonKeyStats = j
+	return r
+}
+
+// isManifest returns true when stats come from a LOON manifest.
+func (r *StatsResolver) isManifest() bool {
+	return r.manifestPath != ""
+}
+
+// BloomFilterPaths returns bloom filter file paths for a segment.
+// Compound stats format is handled transparently — if a compound stats file
+// is found, only that single path is returned.
+func (r *StatsResolver) BloomFilterPaths(pkFieldID int64) ([]string, error) {
+	if !r.isManifest() {
+		return filterPKStatsBinlogs(r.statslogs, pkFieldID), nil
+	}
+
+	if err := r.loadManifest(); err != nil {
+		return nil, err
+	}
+
+	key := fmt.Sprintf("bloom_filter.%d", pkFieldID)
+	stat, ok := r.manifestStats[key]
+	if !ok || len(stat.Paths) == 0 {
+		return nil, nil
+	}
+
+	resolved := r.resolveStatPaths(stat.Paths)
+	for i, p := range stat.Paths {
+		_, logidx := path.Split(p)
+		if logidx == compoundStatsLogIdx {
+			return []string{resolved[i]}, nil
+		}
+	}
+	return resolved, nil
+}
+
+// BloomFilterMemorySize returns the estimated memory size for bloom filters.
+// For manifest: reads memory_size metadata. For legacy: sums MemorySize from
+// the FieldBinlog matching pkFieldID. Returns 0 if unavailable.
+func (r *StatsResolver) BloomFilterMemorySize(pkFieldID int64) (int64, error) {
+	if !r.isManifest() {
+		var total int64
+		for _, fb := range r.statslogs {
+			if fb.FieldID == pkFieldID {
+				for _, b := range fb.GetBinlogs() {
+					total += b.GetMemorySize()
+				}
+			}
+		}
+		return total, nil
+	}
+
+	if err := r.loadManifest(); err != nil {
+		return 0, err
+	}
+
+	key := fmt.Sprintf("bloom_filter.%d", pkFieldID)
+	stat, ok := r.manifestStats[key]
+	if !ok {
+		return 0, nil
+	}
+
+	memStr, ok := stat.Metadata["memory_size"]
+	if !ok || memStr == "" {
+		return 0, nil
+	}
+
+	memSize, err := strconv.ParseInt(memStr, 10, 64)
+	if err != nil {
+		return 0, nil
+	}
+	return memSize, nil
+}
+
+// BM25StatsPaths returns BM25 stat file paths grouped by field ID.
+func (r *StatsResolver) BM25StatsPaths() (map[int64][]string, error) {
+	if !r.isManifest() {
+		return filterBM25Stats(r.bm25Logs), nil
+	}
+
+	if err := r.loadManifest(); err != nil {
+		return nil, err
+	}
+
+	result := make(map[int64][]string)
+	for key, stat := range r.manifestStats {
+		prefix, fieldID, ok := parseStatKey(key)
+		if !ok || prefix != "bm25" || len(stat.Paths) == 0 {
+			continue
+		}
+
+		resolved := r.resolveStatPaths(stat.Paths)
+
+		found := false
+		for i, p := range stat.Paths {
+			_, logidx := path.Split(p)
+			if logidx == compoundStatsLogIdx {
+				result[fieldID] = []string{resolved[i]}
+				found = true
+				break
+			}
+		}
+		if !found {
+			result[fieldID] = resolved
+		}
+	}
+	return result, nil
+}
+
+// TextAndJSONIndexStats returns text index and JSON key stats.
+// For manifest: parsed from manifest metadata (highest version wins per field).
+// For legacy: returns the WithTextStatsLogs/WithJSONKeyStats maps directly.
+func (r *StatsResolver) TextAndJSONIndexStats() (
+	map[int64]*datapb.TextIndexStats, map[int64]*datapb.JsonKeyStats, error,
+) {
+	if !r.isManifest() {
+		return r.textStatsLogs, r.jsonKeyStats, nil
+	}
+
+	if err := r.loadManifest(); err != nil {
+		return nil, nil, err
+	}
+
+	textIndexedInfo := make(map[int64]*datapb.TextIndexStats)
+	jsonKeyIndexInfo := make(map[int64]*datapb.JsonKeyStats)
+
+	for key, stat := range r.manifestStats {
+		prefix, fieldID, ok := parseStatKey(key)
+		if !ok {
+			continue
+		}
+
+		switch prefix {
+		case "text_index":
+			resolvedPaths := r.resolveStatPaths(stat.Paths)
+			version, _ := strconv.ParseInt(stat.Metadata["version"], 10, 64)
+			buildID, _ := strconv.ParseInt(stat.Metadata["build_id"], 10, 64)
+			logSize, _ := strconv.ParseInt(stat.Metadata["log_size"], 10, 64)
+			memorySize, _ := strconv.ParseInt(stat.Metadata["memory_size"], 10, 64)
+			scalarVer, _ := strconv.ParseInt(stat.Metadata["current_scalar_index_version"], 10, 32)
+
+			textStats := &datapb.TextIndexStats{
+				FieldID:                   fieldID,
+				Version:                   version,
+				BuildID:                   buildID,
+				Files:                     resolvedPaths,
+				LogSize:                   logSize,
+				MemorySize:                memorySize,
+				CurrentScalarIndexVersion: int32(scalarVer),
+			}
+
+			existing, ok := textIndexedInfo[fieldID]
+			if !ok || version > existing.GetVersion() {
+				textIndexedInfo[fieldID] = textStats
+			}
+
+		case "json_key_index":
+			resolvedPaths := r.resolveStatPaths(stat.Paths)
+			version, _ := strconv.ParseInt(stat.Metadata["version"], 10, 64)
+			buildID, _ := strconv.ParseInt(stat.Metadata["build_id"], 10, 64)
+			logSize, _ := strconv.ParseInt(stat.Metadata["log_size"], 10, 64)
+			memorySize, _ := strconv.ParseInt(stat.Metadata["memory_size"], 10, 64)
+			dataFormat, _ := strconv.ParseInt(stat.Metadata["json_key_stats_data_format"], 10, 64)
+
+			jsonStats := &datapb.JsonKeyStats{
+				FieldID:                fieldID,
+				Version:                version,
+				BuildID:                buildID,
+				Files:                  resolvedPaths,
+				LogSize:                logSize,
+				MemorySize:             memorySize,
+				JsonKeyStatsDataFormat: dataFormat,
+			}
+
+			existing, ok := jsonKeyIndexInfo[fieldID]
+			if !ok || version > existing.GetVersion() {
+				jsonKeyIndexInfo[fieldID] = jsonStats
+			}
+		}
+	}
+
+	return textIndexedInfo, jsonKeyIndexInfo, nil
+}
+
+// loadManifest lazily loads and caches the manifest stats via FFI.
+func (r *StatsResolver) loadManifest() error {
+	if r.manifestLoaded {
+		return r.manifestErr
+	}
+	r.manifestLoaded = true
+
+	stats, err := GetManifestStats(r.manifestPath, r.storageConfig)
+	if err != nil {
+		r.manifestErr = fmt.Errorf("failed to get manifest stats: %w", err)
+		return r.manifestErr
+	}
+	r.manifestStats = stats
+	return nil
+}
+
+// resolveStatPaths returns stat file paths from the manifest.
+// C++ ToAbsolutePaths() already converts stored relative paths to absolute
+// by prepending basePath/_stats/, so the paths are ready to use as-is.
+func (r *StatsResolver) resolveStatPaths(paths []string) []string {
+	return paths
+}
+
+// parseStatKey parses a "type.fieldID" stat key into its type prefix and field ID.
+func parseStatKey(key string) (string, int64, bool) {
+	idx := strings.LastIndex(key, ".")
+	if idx < 0 {
+		return "", 0, false
+	}
+	prefix := key[:idx]
+	fieldID, err := strconv.ParseInt(key[idx+1:], 10, 64)
+	if err != nil {
+		return "", 0, false
+	}
+	return prefix, fieldID, true
+}
+
+// filterPKStatsBinlogs filters legacy FieldBinlog arrays for the given pkFieldID.
+// If a compound stats file is found, only that single path is returned.
+func filterPKStatsBinlogs(fieldBinlogs []*datapb.FieldBinlog, pkFieldID int64) []string {
+	result := make([]string, 0)
+	for _, fieldBinlog := range fieldBinlogs {
+		if fieldBinlog.FieldID == pkFieldID {
+			for _, binlog := range fieldBinlog.GetBinlogs() {
+				_, logidx := path.Split(binlog.GetLogPath())
+				if logidx == compoundStatsLogIdx {
+					return []string{binlog.GetLogPath()}
+				}
+				result = append(result, binlog.GetLogPath())
+			}
+		}
+	}
+	return result
+}
+
+// filterBM25Stats filters legacy FieldBinlog arrays into BM25 paths grouped by field ID.
+func filterBM25Stats(fieldBinlogs []*datapb.FieldBinlog) map[int64][]string {
+	result := make(map[int64][]string, 0)
+	for _, fieldBinlog := range fieldBinlogs {
+		logpaths := []string{}
+		for _, binlog := range fieldBinlog.GetBinlogs() {
+			_, logidx := path.Split(binlog.GetLogPath())
+			if logidx == compoundStatsLogIdx {
+				logpaths = []string{binlog.GetLogPath()}
+				break
+			}
+			logpaths = append(logpaths, binlog.GetLogPath())
+		}
+		result[fieldBinlog.FieldID] = logpaths
+	}
+	return result
+}

--- a/internal/storagev2/packed/stats_resolver.go
+++ b/internal/storagev2/packed/stats_resolver.go
@@ -188,7 +188,7 @@ func (r *StatsResolver) BM25StatsPaths() (map[int64][]string, error) {
 
 	result := make(map[int64][]string)
 	for key, stat := range r.manifestStats {
-		prefix, fieldID, ok := parseStatKey(key)
+		prefix, fieldID, ok := ParseStatKey(key)
 		if !ok || prefix != "bm25" || len(stat.Paths) == 0 {
 			continue
 		}
@@ -229,7 +229,7 @@ func (r *StatsResolver) TextAndJSONIndexStats() (
 	jsonKeyIndexInfo := make(map[int64]*datapb.JsonKeyStats)
 
 	for key, stat := range r.manifestStats {
-		prefix, fieldID, ok := parseStatKey(key)
+		prefix, fieldID, ok := ParseStatKey(key)
 		if !ok {
 			continue
 		}
@@ -309,8 +309,8 @@ func (r *StatsResolver) resolveStatPaths(paths []string) []string {
 	return paths
 }
 
-// parseStatKey parses a "type.fieldID" stat key into its type prefix and field ID.
-func parseStatKey(key string) (string, int64, bool) {
+// ParseStatKey parses a "type.fieldID" stat key into its type prefix and field ID.
+func ParseStatKey(key string) (string, int64, bool) {
 	idx := strings.LastIndex(key, ".")
 	if idx < 0 {
 		return "", 0, false

--- a/internal/storagev2/packed/stats_resolver_test.go
+++ b/internal/storagev2/packed/stats_resolver_test.go
@@ -1,0 +1,311 @@
+// Copyright 2023 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packed
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+)
+
+func TestParseStatKey(t *testing.T) {
+	t.Run("valid bloom_filter key", func(t *testing.T) {
+		prefix, fieldID, ok := parseStatKey("bloom_filter.100")
+		assert.True(t, ok)
+		assert.Equal(t, "bloom_filter", prefix)
+		assert.Equal(t, int64(100), fieldID)
+	})
+
+	t.Run("valid bm25 key", func(t *testing.T) {
+		prefix, fieldID, ok := parseStatKey("bm25.200")
+		assert.True(t, ok)
+		assert.Equal(t, "bm25", prefix)
+		assert.Equal(t, int64(200), fieldID)
+	})
+
+	t.Run("valid text_index key", func(t *testing.T) {
+		prefix, fieldID, ok := parseStatKey("text_index.50")
+		assert.True(t, ok)
+		assert.Equal(t, "text_index", prefix)
+		assert.Equal(t, int64(50), fieldID)
+	})
+
+	t.Run("valid json_key_index key", func(t *testing.T) {
+		prefix, fieldID, ok := parseStatKey("json_key_index.30")
+		assert.True(t, ok)
+		assert.Equal(t, "json_key_index", prefix)
+		assert.Equal(t, int64(30), fieldID)
+	})
+
+	t.Run("invalid key no dot", func(t *testing.T) {
+		_, _, ok := parseStatKey("bloom_filter")
+		assert.False(t, ok)
+	})
+
+	t.Run("invalid key non-numeric fieldID", func(t *testing.T) {
+		_, _, ok := parseStatKey("bloom_filter.abc")
+		assert.False(t, ok)
+	})
+
+	t.Run("empty string", func(t *testing.T) {
+		_, _, ok := parseStatKey("")
+		assert.False(t, ok)
+	})
+}
+
+func TestFilterPKStatsBinlogs(t *testing.T) {
+	t.Run("matching fieldID", func(t *testing.T) {
+		binlogs := []*datapb.FieldBinlog{
+			{
+				FieldID: 100,
+				Binlogs: []*datapb.Binlog{
+					{LogPath: "path/100"},
+					{LogPath: "path/200"},
+				},
+			},
+			{
+				FieldID: 200,
+				Binlogs: []*datapb.Binlog{
+					{LogPath: "path/300"},
+				},
+			},
+		}
+		paths := filterPKStatsBinlogs(binlogs, 100)
+		assert.Equal(t, []string{"path/100", "path/200"}, paths)
+	})
+
+	t.Run("non-matching fieldID", func(t *testing.T) {
+		binlogs := []*datapb.FieldBinlog{
+			{
+				FieldID: 200,
+				Binlogs: []*datapb.Binlog{{LogPath: "path/100"}},
+			},
+		}
+		paths := filterPKStatsBinlogs(binlogs, 100)
+		assert.Empty(t, paths)
+	})
+
+	t.Run("CompoundStatsType returns single path", func(t *testing.T) {
+		binlogs := []*datapb.FieldBinlog{
+			{
+				FieldID: 100,
+				Binlogs: []*datapb.Binlog{
+					{LogPath: "path/0"},
+					{LogPath: "path/" + compoundStatsLogIdx},
+				},
+			},
+		}
+		paths := filterPKStatsBinlogs(binlogs, 100)
+		assert.Len(t, paths, 1)
+		assert.Contains(t, paths[0], compoundStatsLogIdx)
+	})
+
+	t.Run("empty input", func(t *testing.T) {
+		paths := filterPKStatsBinlogs(nil, 100)
+		assert.Empty(t, paths)
+	})
+}
+
+func TestFilterBM25Stats(t *testing.T) {
+	t.Run("multiple fields", func(t *testing.T) {
+		binlogs := []*datapb.FieldBinlog{
+			{
+				FieldID: 10,
+				Binlogs: []*datapb.Binlog{
+					{LogPath: "bm25/10/100"},
+					{LogPath: "bm25/10/200"},
+				},
+			},
+			{
+				FieldID: 20,
+				Binlogs: []*datapb.Binlog{
+					{LogPath: "bm25/20/100"},
+				},
+			},
+		}
+		result := filterBM25Stats(binlogs)
+		assert.Len(t, result, 2)
+		assert.Equal(t, []string{"bm25/10/100", "bm25/10/200"}, result[10])
+		assert.Equal(t, []string{"bm25/20/100"}, result[20])
+	})
+
+	t.Run("CompoundStatsType in BM25", func(t *testing.T) {
+		binlogs := []*datapb.FieldBinlog{
+			{
+				FieldID: 10,
+				Binlogs: []*datapb.Binlog{
+					{LogPath: "bm25/10/100"},
+					{LogPath: "bm25/10/" + compoundStatsLogIdx},
+				},
+			},
+		}
+		result := filterBM25Stats(binlogs)
+		assert.Len(t, result[10], 1)
+		assert.Contains(t, result[10][0], compoundStatsLogIdx)
+	})
+
+	t.Run("empty input", func(t *testing.T) {
+		result := filterBM25Stats(nil)
+		assert.Empty(t, result)
+	})
+}
+
+func TestStatsResolverLegacy(t *testing.T) {
+	statslogs := []*datapb.FieldBinlog{
+		{
+			FieldID: 100,
+			Binlogs: []*datapb.Binlog{
+				{LogPath: "stats/100/10", MemorySize: 1024},
+				{LogPath: "stats/100/20", MemorySize: 2048},
+			},
+		},
+	}
+	bm25Logs := []*datapb.FieldBinlog{
+		{
+			FieldID: 50,
+			Binlogs: []*datapb.Binlog{
+				{LogPath: "bm25/50/10"},
+			},
+		},
+	}
+	textStats := map[int64]*datapb.TextIndexStats{
+		10: {FieldID: 10, Version: 1, Files: []string{"text/10/f1"}},
+	}
+	jsonStats := map[int64]*datapb.JsonKeyStats{
+		20: {FieldID: 20, Version: 1, Files: []string{"json/20/f1"}},
+	}
+
+	resolver := NewStatsResolver("", nil).
+		WithStatslogs(statslogs).
+		WithBM25Logs(bm25Logs).
+		WithTextStatsLogs(textStats).
+		WithJSONKeyStats(jsonStats)
+
+	t.Run("isManifest", func(t *testing.T) {
+		assert.False(t, resolver.isManifest())
+	})
+
+	t.Run("BloomFilterPaths", func(t *testing.T) {
+		paths, err := resolver.BloomFilterPaths(100)
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"stats/100/10", "stats/100/20"}, paths)
+	})
+
+	t.Run("BloomFilterPaths non-matching", func(t *testing.T) {
+		paths, err := resolver.BloomFilterPaths(999)
+		assert.NoError(t, err)
+		assert.Empty(t, paths)
+	})
+
+	t.Run("BloomFilterMemorySize", func(t *testing.T) {
+		memSize, err := resolver.BloomFilterMemorySize(100)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(3072), memSize)
+	})
+
+	t.Run("BloomFilterMemorySize non-matching", func(t *testing.T) {
+		memSize, err := resolver.BloomFilterMemorySize(999)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(0), memSize)
+	})
+
+	t.Run("BM25StatsPaths", func(t *testing.T) {
+		paths, err := resolver.BM25StatsPaths()
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"bm25/50/10"}, paths[50])
+	})
+
+	t.Run("TextAndJSONIndexStats", func(t *testing.T) {
+		text, json, err := resolver.TextAndJSONIndexStats()
+		assert.NoError(t, err)
+		assert.Equal(t, textStats, text)
+		assert.Equal(t, jsonStats, json)
+	})
+}
+
+// TestStatsResolverManifest exercises the V3 manifest-based code path
+// end-to-end: write stats to a manifest via AddStatsToManifest, then
+// read them back through StatsResolver and verify exact paths.
+func TestStatsResolverManifest(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	pt.Save(pt.CommonCfg.StorageType.Key, "local")
+	dir := t.TempDir()
+	pt.Save(pt.LocalStorageCfg.Path.Key, dir)
+	t.Cleanup(func() {
+		pt.Reset(pt.CommonCfg.StorageType.Key)
+		pt.Reset(pt.LocalStorageCfg.Path.Key)
+	})
+
+	storageConfig := &indexpb.StorageConfig{
+		RootPath:    dir,
+		StorageType: "local",
+	}
+
+	bp := filepath.Join(dir, "insert_log/1/2/3_resolver")
+	manifestPath := createBaseManifest(t, bp, storageConfig)
+
+	// Add bloom filter + BM25 stats to manifest
+	bfPath := filepath.Join(bp, "_stats/bloom_filter.100/42")
+	bm25Path := filepath.Join(bp, "_stats/bm25.200/43")
+	newManifest, err := AddStatsToManifest(manifestPath, storageConfig, []StatEntry{
+		{
+			Key:      "bloom_filter.100",
+			Files:    []string{bfPath},
+			Metadata: map[string]string{"memory_size": "8192"},
+		},
+		{
+			Key:   "bm25.200",
+			Files: []string{bm25Path},
+		},
+	})
+	require.NoError(t, err)
+
+	// Use StatsResolver (V3 path) to read back
+	resolver := NewStatsResolver(newManifest, storageConfig)
+	assert.True(t, resolver.isManifest())
+
+	t.Run("BloomFilterPaths returns exact path", func(t *testing.T) {
+		paths, err := resolver.BloomFilterPaths(100)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(paths))
+		assert.Equal(t, bfPath, paths[0])
+	})
+
+	t.Run("BloomFilterMemorySize", func(t *testing.T) {
+		memSize, err := resolver.BloomFilterMemorySize(100)
+		require.NoError(t, err)
+		assert.Equal(t, int64(8192), memSize)
+	})
+
+	t.Run("BloomFilterPaths non-matching fieldID", func(t *testing.T) {
+		paths, err := resolver.BloomFilterPaths(999)
+		require.NoError(t, err)
+		assert.Nil(t, paths)
+	})
+
+	t.Run("BM25StatsPaths returns exact path", func(t *testing.T) {
+		paths, err := resolver.BM25StatsPaths()
+		require.NoError(t, err)
+		require.Equal(t, 1, len(paths[200]))
+		assert.Equal(t, bm25Path, paths[200][0])
+	})
+}

--- a/internal/storagev2/packed/stats_resolver_test.go
+++ b/internal/storagev2/packed/stats_resolver_test.go
@@ -28,45 +28,45 @@ import (
 
 func TestParseStatKey(t *testing.T) {
 	t.Run("valid bloom_filter key", func(t *testing.T) {
-		prefix, fieldID, ok := parseStatKey("bloom_filter.100")
+		prefix, fieldID, ok := ParseStatKey("bloom_filter.100")
 		assert.True(t, ok)
 		assert.Equal(t, "bloom_filter", prefix)
 		assert.Equal(t, int64(100), fieldID)
 	})
 
 	t.Run("valid bm25 key", func(t *testing.T) {
-		prefix, fieldID, ok := parseStatKey("bm25.200")
+		prefix, fieldID, ok := ParseStatKey("bm25.200")
 		assert.True(t, ok)
 		assert.Equal(t, "bm25", prefix)
 		assert.Equal(t, int64(200), fieldID)
 	})
 
 	t.Run("valid text_index key", func(t *testing.T) {
-		prefix, fieldID, ok := parseStatKey("text_index.50")
+		prefix, fieldID, ok := ParseStatKey("text_index.50")
 		assert.True(t, ok)
 		assert.Equal(t, "text_index", prefix)
 		assert.Equal(t, int64(50), fieldID)
 	})
 
 	t.Run("valid json_key_index key", func(t *testing.T) {
-		prefix, fieldID, ok := parseStatKey("json_key_index.30")
+		prefix, fieldID, ok := ParseStatKey("json_key_index.30")
 		assert.True(t, ok)
 		assert.Equal(t, "json_key_index", prefix)
 		assert.Equal(t, int64(30), fieldID)
 	})
 
 	t.Run("invalid key no dot", func(t *testing.T) {
-		_, _, ok := parseStatKey("bloom_filter")
+		_, _, ok := ParseStatKey("bloom_filter")
 		assert.False(t, ok)
 	})
 
 	t.Run("invalid key non-numeric fieldID", func(t *testing.T) {
-		_, _, ok := parseStatKey("bloom_filter.abc")
+		_, _, ok := ParseStatKey("bloom_filter.abc")
 		assert.False(t, ok)
 	})
 
 	t.Run("empty string", func(t *testing.T) {
-		_, _, ok := parseStatKey("")
+		_, _, ok := ParseStatKey("")
 		assert.False(t, ok)
 	})
 }

--- a/internal/storagev2/packed/transaction.go
+++ b/internal/storagev2/packed/transaction.go
@@ -24,8 +24,6 @@ import "C"
 
 import (
 	"fmt"
-	"path/filepath"
-	"strings"
 	"unsafe"
 
 	"go.uber.org/zap"
@@ -82,12 +80,10 @@ func AddDeltaLogsToManifest(
 	}
 	defer C.loon_transaction_destroy(transactionHandle)
 
-	// Add each delta log to the transaction
+	// Add each delta log to the transaction.
+	// The C++ loon library converts absolute paths to relative at commit time
 	for _, deltaLog := range deltaLogs {
-		// Convert full path to relative path
-		relativePath := toRelativePath(deltaLog.Path, basePath, storageConfig.GetRootPath())
-
-		cPath := C.CString(relativePath)
+		cPath := C.CString(deltaLog.Path)
 		result = C.loon_transaction_add_delta_log(transactionHandle, cPath, C.int64_t(deltaLog.NumEntries))
 		C.free(unsafe.Pointer(cPath))
 
@@ -96,7 +92,7 @@ func AddDeltaLogsToManifest(
 		}
 
 		log.Debug("Added delta log to transaction",
-			zap.String("relativePath", relativePath),
+			zap.String("path", deltaLog.Path),
 			zap.Int64("numEntries", deltaLog.NumEntries))
 	}
 
@@ -170,45 +166,67 @@ func GetDeltaLogPathsFromManifest(
 	return paths, nil
 }
 
-// toRelativePath converts a full path to a path relative to basePath/_delta/.
-// The C loon library stores delta log paths relative to basePath/_delta/ (the kDeltaPath convention).
-// When deserializing, it prepends basePath/_delta/ to the relative path and normalizes.
-//
-// For V3 delta paths ({basePath}/_delta/{logID}), the file is already under basePath/_delta/,
-// so the relative path is simply the filename ({logID}).
-//
-// For legacy delta paths ({rootPath}/delta_log/{collID}/{partID}/{segID}/{logID}),
-// we need baseDepth + 1 levels of "../" to escape basePath/_delta/ back to rootPath.
-func toRelativePath(fullPath, basePath, rootPath string) string {
-	// V3 path: if fullPath is under basePath/_delta/, just return the filename
-	deltaDir := filepath.Join(basePath, "_delta") + "/"
-	if strings.HasPrefix(fullPath, deltaDir) {
-		return strings.TrimPrefix(fullPath, deltaDir)
+// StatEntry represents a stat entry to be added to the manifest.
+type StatEntry struct {
+	Key      string            // Manifest stat key, e.g. "bloom_filter.100"
+	Files    []string          // Relative file paths under manifest base path
+	Metadata map[string]string // Optional key-value metadata
+}
+
+// AddStatsToManifest adds stats to an existing manifest and returns the new manifest path.
+func AddStatsToManifest(
+	manifestPath string,
+	storageConfig *indexpb.StorageConfig,
+	stats []StatEntry,
+) (string, error) {
+	if len(stats) == 0 {
+		return manifestPath, nil
 	}
 
-	// Legacy path: compute relative path from basePath/_delta/ via "../" traversal
-	if strings.HasPrefix(fullPath, rootPath) {
-		// Get the path relative to rootPath for both
-		fullRel := strings.TrimPrefix(fullPath, rootPath)
-		fullRel = strings.TrimPrefix(fullRel, "/")
+	basePath, version, err := UnmarshalManifestPath(manifestPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse manifest path: %w", err)
+	}
 
-		baseRel := strings.TrimPrefix(basePath, rootPath)
-		baseRel = strings.TrimPrefix(baseRel, "/")
+	log.Debug("AddStatsToManifest",
+		zap.String("basePath", basePath),
+		zap.Int64("version", version),
+		zap.Int("numStats", len(stats)))
 
-		// Count the depth of basePath to know how many "../" we need.
-		// Add 1 for the _delta/ subdirectory that C prepends during deserialization.
-		baseDepth := len(strings.Split(baseRel, "/")) + 1
+	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create properties: %w", err)
+	}
+	defer C.loon_properties_free(cProperties)
 
-		// Build the relative path: go up baseDepth levels, then down to fullRel
-		var parts []string
-		for i := 0; i < baseDepth; i++ {
-			parts = append(parts, "..")
+	cBasePath := C.CString(basePath)
+	defer C.free(unsafe.Pointer(cBasePath))
+
+	var transactionHandle C.LoonTransactionHandle
+	result := C.loon_transaction_begin(cBasePath, cProperties, C.int64_t(version), 1, &transactionHandle)
+	if err := HandleLoonFFIResult(result); err != nil {
+		return "", fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer C.loon_transaction_destroy(transactionHandle)
+
+	// The C++ loon library converts absolute paths to relative at commit time
+	for _, stat := range stats {
+		if err := UpdateTransactionStat(transactionHandle, stat.Key, stat.Files, stat.Metadata); err != nil {
+			return "", fmt.Errorf("failed to update stat %s: %w", stat.Key, err)
 		}
-		parts = append(parts, fullRel)
-
-		return filepath.Join(parts...)
+		log.Debug("Added stat to transaction",
+			zap.String("key", stat.Key),
+			zap.Strings("files", stat.Files))
 	}
 
-	// Fallback: return as-is
-	return fullPath
+	var commitVersion C.int64_t
+	result = C.loon_transaction_commit(transactionHandle, &commitVersion)
+	if err := HandleLoonFFIResult(result); err != nil {
+		return "", fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	newManifestPath := MarshalManifestPath(basePath, int64(commitVersion))
+	log.Debug("Stats committed to manifest", zap.Int64("newVersion", int64(commitVersion)))
+
+	return newManifestPath, nil
 }

--- a/internal/storagev2/packed/transaction_test.go
+++ b/internal/storagev2/packed/transaction_test.go
@@ -29,67 +29,6 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
-func TestToRelativePath(t *testing.T) {
-	tests := []struct {
-		name     string
-		fullPath string
-		basePath string
-		rootPath string
-		expected string
-	}{
-		{
-			// basePath has depth 4 (insert_log/123/456/789), +1 for _delta/ = 5 levels of ..
-			name:     "deltalog relative to insert_log",
-			fullPath: "/data/delta_log/123/456/789/1",
-			basePath: "/data/insert_log/123/456/789",
-			rootPath: "/data",
-			expected: "../../../../../delta_log/123/456/789/1",
-		},
-		{
-			name:     "same collection different segment",
-			fullPath: "/milvus/delta_log/100/200/300/5",
-			basePath: "/milvus/insert_log/100/200/300",
-			rootPath: "/milvus",
-			expected: "../../../../../delta_log/100/200/300/5",
-		},
-		{
-			name:     "v3 deltalog under basePath/_delta/",
-			fullPath: "/data/insert_log/123/456/789/_delta/1",
-			basePath: "/data/insert_log/123/456/789",
-			rootPath: "/data",
-			expected: "1",
-		},
-		{
-			name:     "path without rootPath prefix",
-			fullPath: "/other/path/file",
-			basePath: "/data/insert_log/123/456/789",
-			rootPath: "/data",
-			expected: "/other/path/file",
-		},
-		{
-			name:     "empty rootPath",
-			fullPath: "delta_log/123/456/789/1",
-			basePath: "insert_log/123/456/789",
-			rootPath: "",
-			expected: "../../../../../delta_log/123/456/789/1",
-		},
-		{
-			name:     "v3 deltalog with empty rootPath",
-			fullPath: "insert_log/123/456/789/_delta/1",
-			basePath: "insert_log/123/456/789",
-			rootPath: "",
-			expected: "1",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := toRelativePath(tt.fullPath, tt.basePath, tt.rootPath)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
 func TestDeltaLogEntry(t *testing.T) {
 	entry := DeltaLogEntry{
 		Path:       "/data/delta_log/123/456/789/1",
@@ -138,6 +77,115 @@ func createBaseManifest(t *testing.T, basePath string, storageConfig *indexpb.St
 	manifestPath, err := pw.Close()
 	require.NoError(t, err)
 	return manifestPath
+}
+
+func TestStatsRoundtrip(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	pt.Save(pt.CommonCfg.StorageType.Key, "local")
+	dir := t.TempDir()
+	pt.Save(pt.LocalStorageCfg.Path.Key, dir)
+	t.Cleanup(func() {
+		pt.Reset(pt.CommonCfg.StorageType.Key)
+		pt.Reset(pt.LocalStorageCfg.Path.Key)
+	})
+
+	storageConfig := &indexpb.StorageConfig{
+		RootPath:    dir,
+		StorageType: "local",
+	}
+
+	t.Run("no stats", func(t *testing.T) {
+		bp := filepath.Join(dir, "insert_log/1/2/3_no_stats")
+		manifestPath := createBaseManifest(t, bp, storageConfig)
+
+		stats, err := GetManifestStats(manifestPath, storageConfig)
+		require.NoError(t, err)
+		assert.Empty(t, stats)
+	})
+
+	t.Run("single bloom filter stat", func(t *testing.T) {
+		bp := filepath.Join(dir, "insert_log/1/2/3_bf")
+		manifestPath := createBaseManifest(t, bp, storageConfig)
+
+		statPath := filepath.Join(bp, "_stats/bloom_filter.100/1")
+		newManifest, err := AddStatsToManifest(manifestPath, storageConfig, []StatEntry{
+			{
+				Key:      "bloom_filter.100",
+				Files:    []string{statPath},
+				Metadata: map[string]string{"memory_size": "4096"},
+			},
+		})
+		require.NoError(t, err)
+
+		stats, err := GetManifestStats(newManifest, storageConfig)
+		require.NoError(t, err)
+		require.Contains(t, stats, "bloom_filter.100")
+
+		stat := stats["bloom_filter.100"]
+		require.Equal(t, 1, len(stat.Paths))
+		assert.Equal(t, statPath, stat.Paths[0])
+		assert.Equal(t, "4096", stat.Metadata["memory_size"])
+	})
+
+	t.Run("multiple stats with metadata", func(t *testing.T) {
+		bp := filepath.Join(dir, "insert_log/1/2/3_multi_stats")
+		manifestPath := createBaseManifest(t, bp, storageConfig)
+
+		entries := []StatEntry{
+			{
+				Key:      "bloom_filter.100",
+				Files:    []string{filepath.Join(bp, "_stats/bloom_filter.100/1")},
+				Metadata: map[string]string{"memory_size": "2048"},
+			},
+			{
+				Key:   "bm25.200",
+				Files: []string{filepath.Join(bp, "_stats/bm25.200/1")},
+			},
+			{
+				Key:   "text_index.300",
+				Files: []string{filepath.Join(bp, "_stats/text_index.300/f1"), filepath.Join(bp, "_stats/text_index.300/f2")},
+				Metadata: map[string]string{
+					"version":  "5",
+					"build_id": "42",
+				},
+			},
+		}
+		newManifest, err := AddStatsToManifest(manifestPath, storageConfig, entries)
+		require.NoError(t, err)
+
+		stats, err := GetManifestStats(newManifest, storageConfig)
+		require.NoError(t, err)
+		assert.Equal(t, 3, len(stats))
+
+		// bloom filter
+		bf := stats["bloom_filter.100"]
+		require.Equal(t, 1, len(bf.Paths))
+		assert.Equal(t, filepath.Join(bp, "_stats/bloom_filter.100/1"), bf.Paths[0])
+		assert.Equal(t, "2048", bf.Metadata["memory_size"])
+
+		// bm25
+		bm := stats["bm25.200"]
+		require.Equal(t, 1, len(bm.Paths))
+		assert.Equal(t, filepath.Join(bp, "_stats/bm25.200/1"), bm.Paths[0])
+
+		// text index with multiple files
+		ti := stats["text_index.300"]
+		require.Equal(t, 2, len(ti.Paths))
+		assert.Equal(t, filepath.Join(bp, "_stats/text_index.300/f1"), ti.Paths[0])
+		assert.Equal(t, filepath.Join(bp, "_stats/text_index.300/f2"), ti.Paths[1])
+		assert.Equal(t, "5", ti.Metadata["version"])
+		assert.Equal(t, "42", ti.Metadata["build_id"])
+	})
+
+	t.Run("empty stats input returns original manifest", func(t *testing.T) {
+		bp := filepath.Join(dir, "insert_log/1/2/3_empty_stats")
+		manifestPath := createBaseManifest(t, bp, storageConfig)
+
+		sameManifest, err := AddStatsToManifest(manifestPath, storageConfig, []StatEntry{})
+		require.NoError(t, err)
+		assert.Equal(t, manifestPath, sameManifest)
+	})
 }
 
 func TestGetDeltaLogPathsFromManifest(t *testing.T) {

--- a/internal/storagev2/packed/transaction_test.go
+++ b/internal/storagev2/packed/transaction_test.go
@@ -15,6 +15,7 @@
 package packed
 
 import (
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -186,6 +187,140 @@ func TestStatsRoundtrip(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, manifestPath, sameManifest)
 	})
+}
+
+// TestStatsUpdateReplacesEntry verifies that calling AddStatsToManifest
+// with the same key in separate transactions replaces (not appends) files.
+// This is the underlying behavior that caused the multi-batch import bug:
+// each batch overwrote the previous batch's bloom filter entry.
+func TestStatsUpdateReplacesEntry(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	pt.Save(pt.CommonCfg.StorageType.Key, "local")
+	dir := t.TempDir()
+	pt.Save(pt.LocalStorageCfg.Path.Key, dir)
+	t.Cleanup(func() {
+		pt.Reset(pt.CommonCfg.StorageType.Key)
+		pt.Reset(pt.LocalStorageCfg.Path.Key)
+	})
+
+	storageConfig := &indexpb.StorageConfig{
+		RootPath:    dir,
+		StorageType: "local",
+	}
+
+	bp := filepath.Join(dir, "insert_log/1/2/3_replace_test")
+	manifestPath := createBaseManifest(t, bp, storageConfig)
+
+	// Transaction 1: write bloom_filter.100 with file1
+	file1 := filepath.Join(bp, "_stats/bloom_filter.100/1001")
+	m1, err := AddStatsToManifest(manifestPath, storageConfig, []StatEntry{
+		{
+			Key:      "bloom_filter.100",
+			Files:    []string{file1},
+			Metadata: map[string]string{"memory_size": "100"},
+		},
+	})
+	require.NoError(t, err)
+
+	// Transaction 2: write bloom_filter.100 with file2 only (simulating naive per-batch write)
+	file2 := filepath.Join(bp, "_stats/bloom_filter.100/1002")
+	m2, err := AddStatsToManifest(m1, storageConfig, []StatEntry{
+		{
+			Key:      "bloom_filter.100",
+			Files:    []string{file2},
+			Metadata: map[string]string{"memory_size": "200"},
+		},
+	})
+	require.NoError(t, err)
+
+	// Verify: only file2 survives (update_stat replaces the entry)
+	stats, err := GetManifestStats(m2, storageConfig)
+	require.NoError(t, err)
+	bf := stats["bloom_filter.100"]
+	assert.Equal(t, 1, len(bf.Paths), "update_stat should replace, leaving only the last write's file")
+	assert.Equal(t, file2, bf.Paths[0])
+	assert.Equal(t, "200", bf.Metadata["memory_size"])
+}
+
+// TestStatsAccumulationAcrossTransactions verifies the fix: when files
+// from the previous manifest are merged before update, all files survive.
+func TestStatsAccumulationAcrossTransactions(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	pt.Save(pt.CommonCfg.StorageType.Key, "local")
+	dir := t.TempDir()
+	pt.Save(pt.LocalStorageCfg.Path.Key, dir)
+	t.Cleanup(func() {
+		pt.Reset(pt.CommonCfg.StorageType.Key)
+		pt.Reset(pt.LocalStorageCfg.Path.Key)
+	})
+
+	storageConfig := &indexpb.StorageConfig{
+		RootPath:    dir,
+		StorageType: "local",
+	}
+
+	bp := filepath.Join(dir, "insert_log/1/2/3_accum_test")
+	manifestPath := createBaseManifest(t, bp, storageConfig)
+
+	// Simulate 3 import batches with the accumulation fix:
+	// Before each update, read existing files and merge.
+	currentManifest := manifestPath
+	allBloomFiles := []string{}
+	allBM25Files := []string{}
+
+	for batch := 0; batch < 3; batch++ {
+		bfFile := filepath.Join(bp, fmt.Sprintf("_stats/bloom_filter.100/%d", 1001+batch))
+		bm25File := filepath.Join(bp, fmt.Sprintf("_stats/bm25.200/%d", 2001+batch))
+
+		// Read existing stats from current manifest
+		existingStats, err := GetManifestStats(currentManifest, storageConfig)
+		require.NoError(t, err)
+
+		// Merge existing bloom filter files
+		bfFiles := []string{}
+		if existing, ok := existingStats["bloom_filter.100"]; ok {
+			bfFiles = append(bfFiles, existing.Paths...)
+		}
+		bfFiles = append(bfFiles, bfFile)
+		allBloomFiles = append(allBloomFiles, bfFile)
+
+		// Merge existing BM25 files
+		bmFiles := []string{}
+		if existing, ok := existingStats["bm25.200"]; ok {
+			bmFiles = append(bmFiles, existing.Paths...)
+		}
+		bmFiles = append(bmFiles, bm25File)
+		allBM25Files = append(allBM25Files, bm25File)
+
+		newManifest, err := AddStatsToManifest(currentManifest, storageConfig, []StatEntry{
+			{
+				Key:      "bloom_filter.100",
+				Files:    bfFiles,
+				Metadata: map[string]string{"memory_size": fmt.Sprintf("%d", (batch+1)*100)},
+			},
+			{
+				Key:   "bm25.200",
+				Files: bmFiles,
+			},
+		})
+		require.NoError(t, err)
+		currentManifest = newManifest
+	}
+
+	// Verify: all 3 bloom filter files and 3 BM25 files survive
+	stats, err := GetManifestStats(currentManifest, storageConfig)
+	require.NoError(t, err)
+
+	bf := stats["bloom_filter.100"]
+	require.Equal(t, 3, len(bf.Paths), "bloom filter should have files from all 3 batches")
+	assert.Equal(t, allBloomFiles, bf.Paths)
+	assert.Equal(t, "300", bf.Metadata["memory_size"])
+
+	bm := stats["bm25.200"]
+	require.Equal(t, 3, len(bm.Paths), "bm25 stats should have files from all 3 batches")
+	assert.Equal(t, allBM25Files, bm.Paths)
 }
 
 func TestGetDeltaLogPathsFromManifest(t *testing.T) {


### PR DESCRIPTION
See: #48006

design doc: https://github.com/milvus-io/milvus-design-docs/blob/main/design_docs/20260226-manifest-format.md

Integrate manifest-based statistics storage (bloom filter, BM25,
text index, JSON key index) for V3 LOON segments across all write
and read paths.

Key changes:
- Add StatsResolver to centralize V2/V3 stats branching with lazy
  manifest caching, shared across segment loading, L0 compaction,
  and flush recovery
- Write-side: pack_writer_v3, sort_compaction, task_stats register
  stats in manifest with memory_size metadata
- Read-side: segment_loader, l0_compactor, data_sync_service use
  StatsResolver for unified path resolution
- New FFI layer for manifest stats reading/writing
- PackSegmentLoadInfo clears legacy fields when manifest_path set
- Fix manifest version chaining across sequential stats registrations