### PR TITLE
fix: macos build by using CXX env for building plan-parser-so

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -414,7 +414,7 @@ plan-parser-so:
 		GO111MODULE=on $(GO) build -buildmode=c-shared -o $(PWD)/internal/core/output/lib/libmilvus-planparser.so $(PWD)/internal/parser/planparserv2/cwrapper/wrapper.go && \
 		mv $(PWD)/internal/core/output/lib/libmilvus-planparser.h $(PWD)/internal/core/output/include/libmilvus-planparser.h && \
 		cp $(PWD)/internal/parser/planparserv2/cwrapper/milvus_plan_parser.h $(PWD)/internal/core/output/include/ && \
-		g++ -std=c++17 -shared -fPIC -o $(PWD)/internal/core/output/lib/libmilvus-planparser-cpp.so $(PWD)/internal/parser/planparserv2/cwrapper/milvus_plan_parser.cpp \
+		$${CXX:-g++} -std=c++17 -shared -fPIC -o $(PWD)/internal/core/output/lib/libmilvus-planparser-cpp.so $(PWD)/internal/parser/planparserv2/cwrapper/milvus_plan_parser.cpp \
 			-I$(PWD)/internal/core/output/include \
 			-L$(PWD)/internal/core/output/lib -lmilvus-planparser \
 			$(planparser_rpath_flag)


### PR DESCRIPTION
issue: #44452 
