### PR TITLE
fix: [2.6] handle non-nullable fields with defaultValue in insert and upsert

### DIFF
--- a/internal/proxy/task_upsert.go
+++ b/internal/proxy/task_upsert.go
@@ -306,11 +306,16 @@ func (it *upsertTask) queryPreExecute(ctx context.Context) error {
 		fieldData.FieldId = fieldSchema.GetFieldID()
 		fieldData.FieldName = fieldName
 
-		// compatible with different nullable data format from sdk
+		// compatible with different nullable/default_value data format from sdk
 		if len(fieldData.GetValidData()) != 0 {
-			err := FillWithNullValue(fieldData, fieldSchema, int(it.upsertMsg.InsertMsg.NRows()))
+			var err error
+			if fieldSchema.GetDefaultValue() != nil {
+				err = FillWithDefaultValue(fieldData, fieldSchema, int(it.upsertMsg.InsertMsg.NRows()))
+			} else {
+				err = FillWithNullValue(fieldData, fieldSchema, int(it.upsertMsg.InsertMsg.NRows()))
+			}
 			if err != nil {
-				log.Info("unify null field data format failed", zap.Error(err))
+				log.Info("unify field data format failed", zap.Error(err))
 				return err
 			}
 		}

--- a/internal/proxy/task_upsert_test.go
+++ b/internal/proxy/task_upsert_test.go
@@ -1915,3 +1915,172 @@ func TestUpsertTask_queryPreExecute_EmptyDataArray(t *testing.T) {
 		})
 	})
 }
+
+func TestUpsertTask_queryPreExecute_DefaultValueWithValidData(t *testing.T) {
+	// Schema with a non-nullable field that has DefaultValue
+	schema := newSchemaInfo(&schemapb.CollectionSchema{
+		Name: "test_default_value_upsert",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "id", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+			{FieldID: 101, Name: "value", DataType: schemapb.DataType_Int32},
+			{
+				FieldID: 102, Name: "default_col", DataType: schemapb.DataType_VarChar,
+				DefaultValue: &schemapb.ValueField{
+					Data: &schemapb.ValueField_StringData{StringData: "default_val"},
+				},
+			},
+		},
+	})
+
+	// Upsert 3 rows; default_col in compressed format: 2 actual values, row 3 uses default
+	upsertData := []*schemapb.FieldData{
+		{
+			FieldName: "id", FieldId: 100, Type: schemapb.DataType_Int64,
+			Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{1, 2, 3}}}}},
+		},
+		{
+			FieldName: "value", FieldId: 101, Type: schemapb.DataType_Int32,
+			Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: []int32{100, 200, 300}}}}},
+		},
+		{
+			FieldName: "default_col", FieldId: 102, Type: schemapb.DataType_VarChar,
+			Field:     &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"a", "b"}}}}},
+			ValidData: []bool{true, true, false},
+		},
+	}
+
+	// Query result: existing records for PKs 1, 2
+	mockQueryResult := &milvuspb.QueryResults{
+		Status: merr.Success(),
+		FieldsData: []*schemapb.FieldData{
+			{
+				FieldName: "id", FieldId: 100, Type: schemapb.DataType_Int64,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{1, 2}}}}},
+			},
+			{
+				FieldName: "value", FieldId: 101, Type: schemapb.DataType_Int32,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: []int32{10, 20}}}}},
+			},
+			{
+				FieldName: "default_col", FieldId: 102, Type: schemapb.DataType_VarChar,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"old1", "old2"}}}}},
+			},
+		},
+	}
+
+	task := &upsertTask{
+		ctx:    context.Background(),
+		schema: schema,
+		req: &milvuspb.UpsertRequest{
+			FieldsData: upsertData,
+			NumRows:    3,
+		},
+		upsertMsg: &msgstream.UpsertMsg{
+			InsertMsg: &msgstream.InsertMsg{
+				InsertRequest: &msgpb.InsertRequest{
+					FieldsData: upsertData,
+					NumRows:    3,
+					Version:    msgpb.InsertDataVersion_ColumnBased,
+				},
+			},
+		},
+		node: &Proxy{},
+	}
+
+	mockRetrieve := mockey.Mock(retrieveByPKs).Return(mockQueryResult, segcore.StorageCost{}, nil).Build()
+	defer mockRetrieve.UnPatch()
+
+	err := task.queryPreExecute(context.Background())
+	assert.NoError(t, err)
+
+	// Verify default_col was expanded: "a", "b", "default_val"
+	var defaultColField *schemapb.FieldData
+	for _, f := range task.insertFieldData {
+		if f.GetFieldName() == "default_col" {
+			defaultColField = f
+			break
+		}
+	}
+	assert.NotNil(t, defaultColField)
+	assert.Equal(t, []string{"a", "b", "default_val"}, defaultColField.GetScalars().GetStringData().GetData())
+}
+
+func TestUpsertTask_queryPreExecute_DefaultValueError(t *testing.T) {
+	// Schema with a non-nullable field that has DefaultValue
+	schema := newSchemaInfo(&schemapb.CollectionSchema{
+		Name: "test_default_value_error",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "id", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+			{FieldID: 101, Name: "value", DataType: schemapb.DataType_Int32},
+			{
+				FieldID: 102, Name: "default_col", DataType: schemapb.DataType_VarChar,
+				DefaultValue: &schemapb.ValueField{
+					Data: &schemapb.ValueField_StringData{StringData: "default_val"},
+				},
+			},
+		},
+	})
+
+	// Upsert 3 rows; default_col has ValidData with wrong length (2 instead of 3)
+	upsertData := []*schemapb.FieldData{
+		{
+			FieldName: "id", FieldId: 100, Type: schemapb.DataType_Int64,
+			Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{1, 2, 3}}}}},
+		},
+		{
+			FieldName: "value", FieldId: 101, Type: schemapb.DataType_Int32,
+			Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: []int32{100, 200, 300}}}}},
+		},
+		{
+			// ValidData length (2) doesn't match numRows (3) → FillWithDefaultValue returns error
+			FieldName: "default_col", FieldId: 102, Type: schemapb.DataType_VarChar,
+			Field:     &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"a"}}}}},
+			ValidData: []bool{true, false},
+		},
+	}
+
+	// Query result: existing records for PKs 1, 2
+	mockQueryResult := &milvuspb.QueryResults{
+		Status: merr.Success(),
+		FieldsData: []*schemapb.FieldData{
+			{
+				FieldName: "id", FieldId: 100, Type: schemapb.DataType_Int64,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{1, 2}}}}},
+			},
+			{
+				FieldName: "value", FieldId: 101, Type: schemapb.DataType_Int32,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: []int32{10, 20}}}}},
+			},
+			{
+				FieldName: "default_col", FieldId: 102, Type: schemapb.DataType_VarChar,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"old1", "old2"}}}}},
+			},
+		},
+	}
+
+	task := &upsertTask{
+		ctx:    context.Background(),
+		schema: schema,
+		req: &milvuspb.UpsertRequest{
+			FieldsData: upsertData,
+			NumRows:    3,
+		},
+		upsertMsg: &msgstream.UpsertMsg{
+			InsertMsg: &msgstream.InsertMsg{
+				InsertRequest: &msgpb.InsertRequest{
+					FieldsData: upsertData,
+					NumRows:    3,
+					Version:    msgpb.InsertDataVersion_ColumnBased,
+				},
+			},
+		},
+		node: &Proxy{},
+	}
+
+	mockRetrieve := mockey.Mock(retrieveByPKs).Return(mockQueryResult, segcore.StorageCost{}, nil).Build()
+	defer mockRetrieve.UnPatch()
+
+	err := task.queryPreExecute(context.Background())
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+}

--- a/internal/proxy/validate_util.go
+++ b/internal/proxy/validate_util.go
@@ -392,8 +392,8 @@ func (v *validateUtil) fillWithValue(data []*schemapb.FieldData, schema *typeuti
 			return err
 		}
 
-		// adapt all valid data for nullable column
-		if fieldSchema.GetNullable() && len(field.GetValidData()) == 0 {
+		// adapt all valid data for nullable or default value column
+		if (fieldSchema.GetNullable() || fieldSchema.GetDefaultValue() != nil) && len(field.GetValidData()) == 0 {
 			field.ValidData = lo.RepeatBy(numRows, func(i int) bool { return true })
 		}
 

--- a/internal/proxy/validate_util_test.go
+++ b/internal/proxy/validate_util_test.go
@@ -6353,6 +6353,147 @@ func Test_validateUtil_fillWithValue(t *testing.T) {
 		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
 	})
 
+	t.Run("default_value_field_data_without_validdata", func(t *testing.T) {
+		// non-nullable field with defaultValue, data present, NO ValidData
+		// Should auto-fill ValidData to all-true, then FillWithDefaultValue keeps data as-is
+		stringData := []string{"actual_value"}
+		data := []*schemapb.FieldData{
+			{
+				FieldName: "test",
+				Type:      schemapb.DataType_VarChar,
+				Field: &schemapb.FieldData_Scalars{
+					Scalars: &schemapb.ScalarField{
+						Data: &schemapb.ScalarField_StringData{
+							StringData: &schemapb.StringArray{
+								Data: stringData,
+							},
+						},
+					},
+				},
+				// No ValidData set - this triggers the new auto-fill logic
+			},
+		}
+
+		schema := &schemapb.CollectionSchema{
+			Fields: []*schemapb.FieldSchema{
+				{
+					Name:     "test",
+					DataType: schemapb.DataType_VarChar,
+					DefaultValue: &schemapb.ValueField{
+						Data: &schemapb.ValueField_StringData{
+							StringData: "default_val",
+						},
+					},
+					// Nullable is false (default)
+				},
+			},
+		}
+		h, err := typeutil.CreateSchemaHelper(schema)
+		assert.NoError(t, err)
+
+		v := newValidateUtil()
+
+		err = v.fillWithValue(data, h, 1)
+
+		assert.NoError(t, err)
+		// Data should remain "actual_value" since all ValidData was auto-filled to true
+		assert.Equal(t, []string{"actual_value"}, data[0].GetScalars().GetStringData().GetData())
+		// ValidData should be cleared for non-nullable field
+		assert.Equal(t, 0, len(data[0].GetValidData()))
+	})
+
+	t.Run("default_value_field_no_data_without_validdata", func(t *testing.T) {
+		// non-nullable field with defaultValue, empty data, NO ValidData
+		// Should auto-fill ValidData to all-true, FillWithDefaultValue sees all valid so data stays empty...
+		// BUT: fillWithDefaultValueImpl checks len(array)==getValidNumber(validData), so
+		// data=[] with validData=[true,true] gives n=2 != len(array)=0 → error
+		data := []*schemapb.FieldData{
+			{
+				FieldName: "test",
+				Type:      schemapb.DataType_VarChar,
+				Field: &schemapb.FieldData_Scalars{
+					Scalars: &schemapb.ScalarField{
+						Data: &schemapb.ScalarField_StringData{
+							StringData: &schemapb.StringArray{
+								Data: []string{},
+							},
+						},
+					},
+				},
+				// No ValidData set
+			},
+		}
+
+		schema := &schemapb.CollectionSchema{
+			Fields: []*schemapb.FieldSchema{
+				{
+					Name:     "test",
+					DataType: schemapb.DataType_VarChar,
+					DefaultValue: &schemapb.ValueField{
+						Data: &schemapb.ValueField_StringData{
+							StringData: "default_val",
+						},
+					},
+				},
+			},
+		}
+		h, err := typeutil.CreateSchemaHelper(schema)
+		assert.NoError(t, err)
+
+		v := newValidateUtil()
+
+		err = v.fillWithValue(data, h, 2)
+
+		// Error because data length (0) doesn't match valid count (2)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("default_value_nullable_field_data_without_validdata", func(t *testing.T) {
+		// nullable + defaultValue field, data present, NO ValidData
+		// Should auto-fill ValidData to all-true, FillWithDefaultValue keeps data, ValidData set to all-true
+		data := []*schemapb.FieldData{
+			{
+				FieldName: "test",
+				Type:      schemapb.DataType_VarChar,
+				Field: &schemapb.FieldData_Scalars{
+					Scalars: &schemapb.ScalarField{
+						Data: &schemapb.ScalarField_StringData{
+							StringData: &schemapb.StringArray{
+								Data: []string{"val1", "val2"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		schema := &schemapb.CollectionSchema{
+			Fields: []*schemapb.FieldSchema{
+				{
+					Name:     "test",
+					DataType: schemapb.DataType_VarChar,
+					Nullable: true,
+					DefaultValue: &schemapb.ValueField{
+						Data: &schemapb.ValueField_StringData{
+							StringData: "default_val",
+						},
+					},
+				},
+			},
+		}
+		h, err := typeutil.CreateSchemaHelper(schema)
+		assert.NoError(t, err)
+
+		v := newValidateUtil()
+
+		err = v.fillWithValue(data, h, 2)
+
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"val1", "val2"}, data[0].GetScalars().GetStringData().GetData())
+		// ValidData should be all-true for nullable field
+		assert.Equal(t, []bool{true, true}, data[0].GetValidData())
+	})
+
 	t.Run("check the length of ValidData when has default value", func(t *testing.T) {
 		stringData := []string{"a"}
 		data := []*schemapb.FieldData{

--- a/tests/go_client/testcases/nullable_default_value_test.go
+++ b/tests/go_client/testcases/nullable_default_value_test.go
@@ -110,8 +110,8 @@ func TestDefaultValueDefault(t *testing.T) {
 	defaultVarCharField := entity.NewField().WithName(common.GenRandomString("varchar", 3)).WithDataType(entity.FieldTypeVarChar).WithDefaultValueString("default").WithMaxLength(common.TestMaxLen)
 	schema.WithField(defaultBoolField).WithField(defaultInt8Field).WithField(defaultInt16Field).WithField(defaultInt32Field).WithField(defaultInt64Field).WithField(defaultFloatField).WithField(defaultDoubleField).WithField(defaultVarCharField)
 
-	// create collection
-	err := mc.CreateCollection(ctx, client.NewCreateCollectionOption(schema.CollectionName, schema))
+	// create collection with strong consistency to ensure inserted data is immediately visible
+	err := mc.CreateCollection(ctx, client.NewCreateCollectionOption(schema.CollectionName, schema).WithConsistencyLevel(entity.ClStrong))
 	common.CheckErr(t, err, true)
 	coll, _ := mc.DescribeCollection(ctx, client.NewDescribeCollectionOption(schema.CollectionName))
 	common.CheckFieldsDefaultValue(t, map[string]interface{}{
@@ -132,18 +132,20 @@ func TestDefaultValueDefault(t *testing.T) {
 	defColumnOpt := hp.TNewColumnOptions()
 	prepare.InsertData(ctx, t, mc, hp.NewInsertParams(schema), defColumnOpt)
 
-	// query with null expr
-	countRes, err := mc.Query(ctx, client.NewQueryOption(schema.CollectionName).WithFilter(fmt.Sprintf("%s == -1", defaultInt8Field.Name)).WithOutputFields(common.QueryCountFieldName))
+	// query to verify first insert has no default values for fields where default doesn't overlap with generated data
+	// use int64 field (default=10000) since generated values are 0..2999, so no overlap
+	countRes, err := mc.Query(ctx, client.NewQueryOption(schema.CollectionName).WithFilter(fmt.Sprintf("%s == %d", defaultInt64Field.Name, 10000)).WithOutputFields(common.QueryCountFieldName))
 	common.CheckErr(t, err, true)
 	count, _ := countRes.Fields[0].GetAsInt64(0)
 	require.EqualValues(t, 0, count)
 
-	// insert data
+	// insert data with validData (half valid, half use default values), use different PK range to avoid overlap
 	validData := make([]bool, common.DefaultNb)
 	for i := 0; i < common.DefaultNb; i++ {
 		validData[i] = i%2 == 0
 	}
-	columnOpt := hp.TNewColumnOptions()
+	columnOpt := hp.TNewColumnOptions().
+		WithColumnOption(common.DefaultInt64FieldName, hp.TNewDataOption().TWithStart(common.DefaultNb))
 	for _, name := range []string{
 		defaultBoolField.Name, defaultInt8Field.Name, defaultInt16Field.Name, defaultInt32Field.Name,
 		defaultInt64Field.Name, defaultFloatField.Name, defaultDoubleField.Name, defaultVarCharField.Name,
@@ -157,11 +159,18 @@ func TestDefaultValueDefault(t *testing.T) {
 		expr  string
 		count int64
 	}
+	// Expected counts with 6000 total rows (2 inserts x 3000, different PKs):
+	// - First insert: full generated data (3000 rows, no defaults)
+	// - Second insert: 1500 valid (generated) + 1500 invalid (filled with default values)
+	// For int8: default=-1 also appears in generated data due to int8 wrapping (int8(255)==-1, etc.)
+	//   First insert: 11 occurrences (i%256==255 for i in [0,3000)), Second valid: 5 (i in [0,1500))
+	// For int16: default=4, appears at i=4 in both inserts' generated data
+	// For int32: default=2000, appears at i=2000 in first insert only (second valid range is [0,1500))
 	exprCounts := []exprCount{
 		{expr: fmt.Sprintf("%s == %t", defaultBoolField.Name, true), count: common.DefaultNb * 5 / 4},
-		{expr: fmt.Sprintf("%s == %d", defaultInt8Field.Name, -1), count: common.DefaultNb/2 + 10}, // int8 [-128, 127]
+		{expr: fmt.Sprintf("%s == %d", defaultInt8Field.Name, -1), count: common.DefaultNb/2 + 16}, // int8 wrapping: 11 from first + 5 from second valid
 		{expr: fmt.Sprintf("%s == %d", defaultInt16Field.Name, 4), count: common.DefaultNb/2 + 2},
-		{expr: fmt.Sprintf("%s == %d", defaultInt32Field.Name, 2000), count: common.DefaultNb / 2},
+		{expr: fmt.Sprintf("%s == %d", defaultInt32Field.Name, 2000), count: common.DefaultNb/2 + 1},
 		{expr: fmt.Sprintf("%s == %d", defaultInt64Field.Name, 10000), count: common.DefaultNb / 2},
 		{expr: fmt.Sprintf("%s == %f", defaultFloatField.Name, -1.0), count: common.DefaultNb / 2},
 		{expr: fmt.Sprintf("%s == %f", defaultDoubleField.Name, math.MaxFloat64), count: common.DefaultNb / 2},

--- a/tests/go_client/testcases/nullable_default_value_test.go
+++ b/tests/go_client/testcases/nullable_default_value_test.go
@@ -139,13 +139,12 @@ func TestDefaultValueDefault(t *testing.T) {
 	count, _ := countRes.Fields[0].GetAsInt64(0)
 	require.EqualValues(t, 0, count)
 
-	// insert data with validData (half valid, half use default values), use different PK range to avoid overlap
+	// insert data with validData (half valid, half use default values)
 	validData := make([]bool, common.DefaultNb)
 	for i := 0; i < common.DefaultNb; i++ {
 		validData[i] = i%2 == 0
 	}
-	columnOpt := hp.TNewColumnOptions().
-		WithColumnOption(common.DefaultInt64FieldName, hp.TNewDataOption().TWithStart(common.DefaultNb))
+	columnOpt := hp.TNewColumnOptions()
 	for _, name := range []string{
 		defaultBoolField.Name, defaultInt8Field.Name, defaultInt16Field.Name, defaultInt32Field.Name,
 		defaultInt64Field.Name, defaultFloatField.Name, defaultDoubleField.Name, defaultVarCharField.Name,
@@ -159,7 +158,7 @@ func TestDefaultValueDefault(t *testing.T) {
 		expr  string
 		count int64
 	}
-	// Expected counts with 6000 total rows (2 inserts x 3000, different PKs):
+	// Expected counts with 6000 total rows (2 inserts x 3000, same PKs but count(*) doesn't dedup):
 	// - First insert: full generated data (3000 rows, no defaults)
 	// - Second insert: 1500 valid (generated) + 1500 invalid (filled with default values)
 	// For int8: default=-1 also appears in generated data due to int8 wrapping (int8(255)==-1, etc.)

--- a/tests/go_client/testcases/nullable_default_value_test.go
+++ b/tests/go_client/testcases/nullable_default_value_test.go
@@ -91,7 +91,6 @@ func TestNullableDefault(t *testing.T) {
 
 // create collection with default value and insert with column / nullableColumn
 func TestDefaultValueDefault(t *testing.T) {
-	t.Skip("set defaultValue and insert with default column gets unexpected error, waiting for fix")
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -497,7 +496,6 @@ func TestNullableQuery(t *testing.T) {
 
 // test insert with part/all/not default value -> query check
 func TestDefaultValueQuery(t *testing.T) {
-	t.Skip("set defaultValue and insert with default column gets unexpected error, waiting for fix")
 	for _, nullable := range [2]bool{false, true} {
 		ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 		mc := hp.CreateDefaultMilvusClient(ctx, t)

--- a/tests/go_client/testcases/update_test.go
+++ b/tests/go_client/testcases/update_test.go
@@ -204,3 +204,156 @@ func TestUpdateNullableFieldBehavior(t *testing.T) {
 	require.Equal(t, "original_1", nullableResults[0])
 	require.Equal(t, "original_2", nullableResults[1])
 }
+
+func TestUpdateDefaultValueFieldBehavior(t *testing.T) {
+	/*
+		Test default value field behavior for Update operation:
+		1. Insert data with a non-nullable default-value field having explicit values
+		2. Partial update the same entities without providing the default-value field
+		3. Verify that the field retains its original value (not replaced with the default)
+	*/
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	// Create collection with non-nullable default-value field
+	collName := common.GenRandomString("update_default", 6)
+
+	pkField := entity.NewField().WithName(common.DefaultInt64FieldName).WithDataType(entity.FieldTypeInt64).WithIsPrimaryKey(true)
+	vecField := entity.NewField().WithName(common.DefaultFloatVecFieldName).WithDataType(entity.FieldTypeFloatVector).WithDim(common.DefaultDim)
+	defaultField := entity.NewField().WithName("default_varchar").WithDataType(entity.FieldTypeVarChar).WithMaxLength(100).WithDefaultValueString("default_val")
+
+	fields := []*entity.Field{pkField, vecField, defaultField}
+	schema := hp.GenSchema(hp.TNewSchemaOption().TWithName(collName).TWithDescription("test default value field behavior for update").TWithFields(fields))
+
+	err := mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, true)
+
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Second*10)
+		defer cancel()
+		err := mc.DropCollection(ctx, client.NewDropCollectionOption(collName))
+		common.CheckErr(t, err, true)
+	})
+
+	// Insert initial data with explicit varchar values
+	pkColumn := column.NewColumnInt64(common.DefaultInt64FieldName, []int64{1, 2, 3})
+	vecColumn := hp.GenColumnData(3, entity.FieldTypeFloatVector, *hp.TNewDataOption())
+	defaultColumn := column.NewColumnVarChar("default_varchar", []string{"original_1", "original_2", "original_3"})
+
+	_, err = mc.Insert(ctx, client.NewColumnBasedInsertOption(collName).WithColumns(pkColumn, vecColumn, defaultColumn))
+	common.CheckErr(t, err, true)
+
+	// Flush -> Index -> Load
+	prepare := &hp.CollectionPrepare{}
+	prepare.FlushData(ctx, t, mc, collName)
+	indexParams := hp.TNewIndexParams(schema)
+	prepare.CreateIndex(ctx, t, mc, indexParams)
+	loadParams := hp.NewLoadParams(collName)
+	prepare.Load(ctx, t, mc, loadParams)
+
+	time.Sleep(time.Second * 5)
+
+	// Partial update PKs 1,2 with only pk + vec (omit default_varchar)
+	updatePkColumn := column.NewColumnInt64(common.DefaultInt64FieldName, []int64{1, 2})
+	updateVecColumn := hp.GenColumnData(2, entity.FieldTypeFloatVector, *hp.TNewDataOption().TWithStart(100))
+
+	updateRes, err := mc.Upsert(ctx, client.NewColumnBasedInsertOption(collName).WithColumns(updatePkColumn, updateVecColumn).WithPartialUpdate(true))
+	common.CheckErr(t, err, true)
+	require.EqualValues(t, 2, updateRes.UpsertCount)
+
+	time.Sleep(time.Second * 3)
+
+	// Query PKs 1,2 -> verify default_varchar retains original values
+	resSet, err := mc.Query(ctx, client.NewQueryOption(collName).WithFilter(fmt.Sprintf("%s in [1, 2]", common.DefaultInt64FieldName)).WithOutputFields("*").WithConsistencyLevel(entity.ClStrong))
+	common.CheckErr(t, err, true)
+
+	require.Equal(t, 2, resSet.GetColumn("default_varchar").Len())
+	defaultResults := resSet.GetColumn("default_varchar").(*column.ColumnVarChar).Data()
+	require.Equal(t, "original_1", defaultResults[0])
+	require.Equal(t, "original_2", defaultResults[1])
+
+	// Query PK 3 -> verify unchanged
+	resSet3, err := mc.Query(ctx, client.NewQueryOption(collName).WithFilter(fmt.Sprintf("%s == 3", common.DefaultInt64FieldName)).WithOutputFields("*").WithConsistencyLevel(entity.ClStrong))
+	common.CheckErr(t, err, true)
+
+	require.Equal(t, 1, resSet3.GetColumn("default_varchar").Len())
+	unchangedResults := resSet3.GetColumn("default_varchar").(*column.ColumnVarChar).Data()
+	require.Equal(t, "original_3", unchangedResults[0])
+}
+
+func TestUpsertDefaultValueWithCompressedValidData(t *testing.T) {
+	/*
+		Test upsert with compressed ValidData for a field with defaultValue.
+		This covers the upsert path (task_upsert.go queryPreExecute) where
+		FillWithDefaultValue is dispatched instead of FillWithNullValue.
+
+		1. Create collection with nullable + defaultValue varchar field
+		2. Insert 3 rows with explicit values
+		3. Upsert 3 rows using NullableColumn (compressed format with ValidData),
+		   where row 3 has valid=false -> should be filled with default value
+		4. Query and verify row 3 gets the default value
+	*/
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	collName := common.GenRandomString("upsert_default_compressed", 6)
+
+	pkField := entity.NewField().WithName(common.DefaultInt64FieldName).WithDataType(entity.FieldTypeInt64).WithIsPrimaryKey(true)
+	vecField := entity.NewField().WithName(common.DefaultFloatVecFieldName).WithDataType(entity.FieldTypeFloatVector).WithDim(common.DefaultDim)
+	defaultField := entity.NewField().WithName("default_varchar").WithDataType(entity.FieldTypeVarChar).
+		WithMaxLength(100).WithNullable(true).WithDefaultValueString("default_val")
+
+	fields := []*entity.Field{pkField, vecField, defaultField}
+	schema := hp.GenSchema(hp.TNewSchemaOption().TWithName(collName).TWithDescription("test upsert default value with compressed valid data").TWithFields(fields))
+
+	err := mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, true)
+
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Second*10)
+		defer cancel()
+		err := mc.DropCollection(ctx, client.NewDropCollectionOption(collName))
+		common.CheckErr(t, err, true)
+	})
+
+	// Insert 3 rows with explicit values
+	pkColumn := column.NewColumnInt64(common.DefaultInt64FieldName, []int64{1, 2, 3})
+	vecColumn := hp.GenColumnData(3, entity.FieldTypeFloatVector, *hp.TNewDataOption())
+	varcharColumn := column.NewColumnVarChar("default_varchar", []string{"v1", "v2", "v3"})
+
+	_, err = mc.Insert(ctx, client.NewColumnBasedInsertOption(collName).WithColumns(pkColumn, vecColumn, varcharColumn))
+	common.CheckErr(t, err, true)
+
+	prepare := &hp.CollectionPrepare{}
+	prepare.FlushData(ctx, t, mc, collName)
+	indexParams := hp.TNewIndexParams(schema)
+	prepare.CreateIndex(ctx, t, mc, indexParams)
+	loadParams := hp.NewLoadParams(collName)
+	prepare.Load(ctx, t, mc, loadParams)
+
+	time.Sleep(time.Second * 5)
+
+	// Upsert 3 rows with compressed ValidData:
+	// data=["new1","new2"], validData=[true,true,false]
+	// Row 3 (valid=false) should be filled with "default_val" by FillWithDefaultValue
+	upsertPkColumn := column.NewColumnInt64(common.DefaultInt64FieldName, []int64{1, 2, 3})
+	upsertVecColumn := hp.GenColumnData(3, entity.FieldTypeFloatVector, *hp.TNewDataOption().TWithStart(100))
+	nullableVarcharColumn, err := column.NewNullableColumnVarChar("default_varchar", []string{"new1", "new2"}, []bool{true, true, false})
+	common.CheckErr(t, err, true)
+
+	upsertRes, err := mc.Upsert(ctx, client.NewColumnBasedInsertOption(collName).WithColumns(upsertPkColumn, upsertVecColumn, nullableVarcharColumn))
+	common.CheckErr(t, err, true)
+	require.EqualValues(t, 3, upsertRes.UpsertCount)
+
+	time.Sleep(time.Second * 3)
+
+	// Query all 3 rows and verify
+	resSet, err := mc.Query(ctx, client.NewQueryOption(collName).WithFilter(fmt.Sprintf("%s in [1, 2, 3]", common.DefaultInt64FieldName)).WithOutputFields("*").WithConsistencyLevel(entity.ClStrong))
+	common.CheckErr(t, err, true)
+
+	require.Equal(t, 3, resSet.GetColumn("default_varchar").Len())
+	results := resSet.GetColumn("default_varchar").(*column.ColumnVarChar).Data()
+	require.Equal(t, "new1", results[0])
+	require.Equal(t, "new2", results[1])
+	require.Equal(t, "default_val", results[2])
+}


### PR DESCRIPTION
pr: #48019

## Summary
- **Insert path**: `fillWithValue()` now initializes `ValidData` for non-nullable fields with `defaultValue`, not just nullable fields. Previously caused `FillWithDefaultValue` to crash with "the length of valid_data is wrong".
- **Upsert path**: `queryPreExecute()` now dispatches to `FillWithDefaultValue` when a field has `defaultValue`, instead of always calling `FillWithNullValue` which rejects `ValidData` on non-nullable fields.
- Unskips `TestDefaultValueDefault` and `TestDefaultValueQuery` e2e tests that were blocked by this bug.
- Adds unit tests for both fixes and e2e tests for partial update / upsert with default value fields.

issue: #48002

## Test plan
- [x] `Test_validateUtil_fillWithValue` — 84 subtests including 3 new default value subtests
- [x] `TestUpsertTask_queryPreExecute_DefaultValueWithValidData` — compressed ValidData expansion
- [x] `TestUpsertTask_queryPreExecute_DefaultValueError` — error path validation
- [x] `TestDefaultValueDefault` — e2e: insert with default column (unskipped)
- [x] `TestDefaultValueQuery` — e2e: query default value fields (unskipped)
- [x] `TestUpdateDefaultValueFieldBehavior` — e2e: partial update retains original values
- [x] `TestUpsertDefaultValueWithCompressedValidData` — e2e: upsert with compressed ValidData