### PR TITLE
enhance: [loon] pass projection (needed_columns) to chunk reader for sealed segment

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -3298,7 +3298,12 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
                                      : mmap_config.GetScalarFieldEnableMmap();
     auto use_mmap = has_mmap_setting ? mmap_enabled : global_use_mmap;
 
-    auto chunk_reader_result = reader_->get_chunk_reader(index);
+    auto needed_columns = std::make_shared<std::vector<std::string>>();
+    needed_columns->reserve(milvus_field_ids.size());
+    for (const auto& fid : milvus_field_ids) {
+        needed_columns->push_back(std::to_string(fid.get()));
+    }
+    auto chunk_reader_result = reader_->get_chunk_reader(index, needed_columns);
     AssertInfo(chunk_reader_result.ok(),
                "get chunk reader failed, segment {}, column group index {}, "
                "status msg: {}",

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
@@ -315,11 +315,11 @@ ManifestGroupTranslator::load_group_chunk(
             continue;
         }
         auto it = field_metas_.find(fid);
-        // Workaround for projection push-down missing for chunk reader
-        // change back to assertion after supported
-        if (it == field_metas_.end()) {
-            continue;
-        }
+        AssertInfo(
+            it != field_metas_.end(),
+            "[StorageV2] translator {} field id {} not found in field_metas",
+            key_,
+            fid.get());
         const auto& field_meta = it->second;
 
         // Merge arrays from all tables for this field

--- a/internal/core/thirdparty/milvus-storage/CMakeLists.txt
+++ b/internal/core/thirdparty/milvus-storage/CMakeLists.txt
@@ -14,7 +14,7 @@
 # Update milvus-storage_VERSION for the first occurrence
 milvus_add_pkg_config("milvus-storage")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( milvus-storage_VERSION 0a9cb7ebe8a9bcd1be15a59c7fa870aff7554593)
+set( milvus-storage_VERSION 2955b08)
 set( GIT_REPOSITORY  "https://github.com/milvus-io/milvus-storage.git")
 message(STATUS "milvus-storage repo: ${GIT_REPOSITORY}")
 message(STATUS "milvus-storage version: ${milvus-storage_VERSION}")


### PR DESCRIPTION
Related to #44956
Previous PR: #47750

Pass milvus_field_ids as needed_columns projection to get_chunk_reader in ChunkedSegmentSealedImpl::LoadColumnGroup, so the storage layer can skip reading columns that already have index raw data. This reduces I/O when loading column groups where only a subset of fields need field data.

Also bumps milvus-storage to 2955b08 which supports projection push-down in chunk reader, and restores the assertion in ManifestGroupTranslator that was previously a workaround for the missing projection support.