### PR TITLE
enhance: [2.6] add per-cluster TLS config for CDC outbound mTLS connections

### DIFF
--- a/client/milvusclient/client.go
+++ b/client/milvusclient/client.go
@@ -90,7 +90,9 @@ func New(ctx context.Context, config *ClientConfig) (*Client, error) {
 func (c *Client) dialOptions() []grpc.DialOption {
 	var options []grpc.DialOption
 	// Construct dial option.
-	if c.config.EnableTLSAuth {
+	if c.config.TLSConfig != nil {
+		options = append(options, grpc.WithTransportCredentials(credentials.NewTLS(c.config.TLSConfig)))
+	} else if c.config.EnableTLSAuth {
 		options = append(options, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{})))
 	} else {
 		options = append(options, grpc.WithTransportCredentials(insecure.NewCredentials()))

--- a/client/milvusclient/client.go
+++ b/client/milvusclient/client.go
@@ -90,10 +90,12 @@ func New(ctx context.Context, config *ClientConfig) (*Client, error) {
 func (c *Client) dialOptions() []grpc.DialOption {
 	var options []grpc.DialOption
 	// Construct dial option.
-	if c.config.TLSConfig != nil {
-		options = append(options, grpc.WithTransportCredentials(credentials.NewTLS(c.config.TLSConfig)))
-	} else if c.config.EnableTLSAuth {
-		options = append(options, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{})))
+	if c.config.EnableTLSAuth {
+		if c.config.tlsConfig != nil {
+			options = append(options, grpc.WithTransportCredentials(credentials.NewTLS(c.config.tlsConfig)))
+		} else {
+			options = append(options, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{})))
+		}
 	} else {
 		options = append(options, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	}

--- a/client/milvusclient/client_config.go
+++ b/client/milvusclient/client_config.go
@@ -2,6 +2,7 @@ package milvusclient
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"math"
 	"net/url"
@@ -53,8 +54,9 @@ type ClientConfig struct {
 	Password string // Password for auth.
 	DBName   string // DBName for this client.
 
-	EnableTLSAuth bool   // Enable TLS Auth for transport security.
-	APIKey        string // API key
+	EnableTLSAuth bool        // Enable TLS Auth for transport security.
+	APIKey        string      // API key
+	TLSConfig     *tls.Config // Custom TLS config (overrides EnableTLSAuth when set).
 
 	DialOptions []grpc.DialOption // Dial options for GRPC.
 

--- a/client/milvusclient/client_config.go
+++ b/client/milvusclient/client_config.go
@@ -54,9 +54,10 @@ type ClientConfig struct {
 	Password string // Password for auth.
 	DBName   string // DBName for this client.
 
-	EnableTLSAuth bool        // Enable TLS Auth for transport security.
-	APIKey        string      // API key
-	TLSConfig     *tls.Config // Custom TLS config (overrides EnableTLSAuth when set).
+	EnableTLSAuth bool   // Enable TLS Auth for transport security.
+	APIKey        string // API key
+
+	tlsConfig *tls.Config // Custom TLS config, set via WithTLSConfig method.
 
 	DialOptions []grpc.DialOption // Dial options for GRPC.
 
@@ -147,4 +148,12 @@ func (c *ClientConfig) hasFlags(flags uint64) bool {
 
 func (c *ClientConfig) resetFlags(flags uint64) {
 	c.flags &= ^flags
+}
+
+// WithTLSConfig sets the custom TLS configuration and enables TLS auth.
+// This method should be used to configure custom TLS settings (e.g., mTLS, custom CA).
+func (c *ClientConfig) WithTLSConfig(tlsConfig *tls.Config) *ClientConfig {
+	c.tlsConfig = tlsConfig
+	c.EnableTLSAuth = true
+	return c
 }

--- a/client/milvusclient/tls.go
+++ b/client/milvusclient/tls.go
@@ -1,0 +1,58 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package milvusclient
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+)
+
+// BuildTLSConfig creates a tls.Config for outbound mTLS connections.
+// caPemPath is required (for server cert verification).
+// clientPemPath + clientKeyPath are optional (for mutual TLS client auth).
+func BuildTLSConfig(caPemPath, clientPemPath, clientKeyPath string) (*tls.Config, error) {
+	caPem, err := os.ReadFile(caPemPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read CA cert %s: %w", caPemPath, err)
+	}
+
+	certPool := x509.NewCertPool()
+	if !certPool.AppendCertsFromPEM(caPem) {
+		return nil, fmt.Errorf("failed to parse CA cert from %s", caPemPath)
+	}
+
+	tlsConfig := &tls.Config{
+		RootCAs:    certPool,
+		MinVersion: tls.VersionTLS13,
+	}
+
+	if (clientPemPath != "") != (clientKeyPath != "") {
+		return nil, fmt.Errorf("both clientPemPath and clientKeyPath must be set for mTLS, got clientPemPath=%q clientKeyPath=%q", clientPemPath, clientKeyPath)
+	}
+
+	if clientPemPath != "" && clientKeyPath != "" {
+		clientCert, err := tls.LoadX509KeyPair(clientPemPath, clientKeyPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load client cert (%s, %s): %w", clientPemPath, clientKeyPath, err)
+		}
+		tlsConfig.Certificates = []tls.Certificate{clientCert}
+	}
+
+	return tlsConfig, nil
+}

--- a/client/milvusclient/tls_test.go
+++ b/client/milvusclient/tls_test.go
@@ -1,0 +1,139 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package milvusclient
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// generateTestCerts creates a self-signed CA and a client cert signed by it.
+// Returns paths to ca.pem, client.pem, client.key in a temp directory.
+func generateTestCerts(t *testing.T) (caPem, clientPem, clientKey string) {
+	t.Helper()
+	dir := t.TempDir()
+
+	// Generate CA key and self-signed cert.
+	caPriv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test CA"},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+	}
+	caCertDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caPriv.PublicKey, caPriv)
+	require.NoError(t, err)
+
+	caPem = filepath.Join(dir, "ca.pem")
+	require.NoError(t, os.WriteFile(caPem, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caCertDER}), 0o600))
+
+	// Generate client key and cert signed by CA.
+	clientPriv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	clientTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "Test Client"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	clientCertDER, err := x509.CreateCertificate(rand.Reader, clientTemplate, caTemplate, &clientPriv.PublicKey, caPriv)
+	require.NoError(t, err)
+
+	clientPem = filepath.Join(dir, "client.pem")
+	require.NoError(t, os.WriteFile(clientPem, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientCertDER}), 0o600))
+
+	clientKeyBytes, err := x509.MarshalECPrivateKey(clientPriv)
+	require.NoError(t, err)
+	clientKey = filepath.Join(dir, "client.key")
+	require.NoError(t, os.WriteFile(clientKey, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: clientKeyBytes}), 0o600))
+
+	return caPem, clientPem, clientKey
+}
+
+func TestBuildTLSConfig(t *testing.T) {
+	t.Run("valid CA only", func(t *testing.T) {
+		caPem, _, _ := generateTestCerts(t)
+		tlsConfig, err := BuildTLSConfig(caPem, "", "")
+		require.NoError(t, err)
+		assert.NotNil(t, tlsConfig.RootCAs)
+		assert.Empty(t, tlsConfig.Certificates)
+	})
+
+	t.Run("valid mTLS", func(t *testing.T) {
+		caPem, clientPem, clientKey := generateTestCerts(t)
+		tlsConfig, err := BuildTLSConfig(caPem, clientPem, clientKey)
+		require.NoError(t, err)
+		assert.NotNil(t, tlsConfig.RootCAs)
+		assert.Len(t, tlsConfig.Certificates, 1)
+	})
+
+	t.Run("nonexistent CA", func(t *testing.T) {
+		_, err := BuildTLSConfig("/nonexistent/ca.pem", "", "")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read CA cert")
+	})
+
+	t.Run("invalid CA content", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		badCA := filepath.Join(tmpDir, "bad-ca.pem")
+		os.WriteFile(badCA, []byte("not a certificate"), 0o600)
+		_, err := BuildTLSConfig(badCA, "", "")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse CA cert")
+	})
+
+	t.Run("nonexistent client cert", func(t *testing.T) {
+		caPem, _, _ := generateTestCerts(t)
+		_, err := BuildTLSConfig(caPem, "/nonexistent/client.pem", "/nonexistent/client.key")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to load client cert")
+	})
+
+	t.Run("partial client config errors", func(t *testing.T) {
+		caPem, clientPem, _ := generateTestCerts(t)
+
+		// Only clientPemPath set.
+		_, err := BuildTLSConfig(caPem, clientPem, "")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "both clientPemPath and clientKeyPath must be set")
+
+		// Only clientKeyPath set.
+		_, err = BuildTLSConfig(caPem, "", "/some/client.key")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "both clientPemPath and clientKeyPath must be set")
+	})
+}

--- a/client/milvusclient/tls_test.go
+++ b/client/milvusclient/tls_test.go
@@ -137,3 +137,41 @@ func TestBuildTLSConfig(t *testing.T) {
 		assert.Contains(t, err.Error(), "both clientPemPath and clientKeyPath must be set")
 	})
 }
+
+func TestWithTLSConfig(t *testing.T) {
+	t.Run("sets tlsConfig and enables TLS auth", func(t *testing.T) {
+		caPem, clientPem, clientKey := generateTestCerts(t)
+		tlsConfig, err := BuildTLSConfig(caPem, clientPem, clientKey)
+		require.NoError(t, err)
+
+		config := &ClientConfig{
+			Address: "localhost:19530",
+		}
+		assert.False(t, config.EnableTLSAuth)
+		assert.Nil(t, config.tlsConfig)
+
+		result := config.WithTLSConfig(tlsConfig)
+
+		assert.True(t, config.EnableTLSAuth)
+		assert.NotNil(t, config.tlsConfig)
+		assert.Same(t, config, result) // Returns self for chaining
+	})
+
+	t.Run("chained with other config", func(t *testing.T) {
+		caPem, _, _ := generateTestCerts(t)
+		tlsConfig, err := BuildTLSConfig(caPem, "", "")
+		require.NoError(t, err)
+
+		config := (&ClientConfig{
+			Address:  "localhost:19530",
+			Username: "root",
+			Password: "milvus",
+		}).WithTLSConfig(tlsConfig)
+
+		assert.Equal(t, "localhost:19530", config.Address)
+		assert.Equal(t, "root", config.Username)
+		assert.Equal(t, "milvus", config.Password)
+		assert.True(t, config.EnableTLSAuth)
+		assert.NotNil(t, config.tlsConfig)
+	})
+}

--- a/internal/cdc/cluster/milvus_client.go
+++ b/internal/cdc/cluster/milvus_client.go
@@ -18,13 +18,17 @@ package cluster
 
 import (
 	"context"
+	"crypto/tls"
 
 	"github.com/cockroachdb/errors"
+	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus/client/v2/milvusclient"
+	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
 type MilvusClient interface {
@@ -39,12 +43,43 @@ type MilvusClient interface {
 type CreateMilvusClientFunc func(ctx context.Context, cluster *commonpb.MilvusCluster) (MilvusClient, error)
 
 func NewMilvusClient(ctx context.Context, cluster *commonpb.MilvusCluster) (MilvusClient, error) {
-	cli, err := milvusclient.New(ctx, &milvusclient.ClientConfig{
-		Address: cluster.GetConnectionParam().GetUri(),
-		APIKey:  cluster.GetConnectionParam().GetToken(),
-	})
+	connParam := cluster.GetConnectionParam()
+	config := &milvusclient.ClientConfig{
+		Address: connParam.GetUri(),
+		APIKey:  connParam.GetToken(),
+	}
+
+	// Build TLS config from per-cluster paramtable config.
+	tlsConfig, err := buildCDCTLSConfig(cluster.GetClusterId())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build CDC TLS config")
+	}
+	if tlsConfig != nil {
+		config.TLSConfig = tlsConfig
+	}
+
+	cli, err := milvusclient.New(ctx, config)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create milvus client")
 	}
 	return cli, nil
+}
+
+// buildCDCTLSConfig reads per-cluster TLS config from paramtable for CDC outbound connections.
+// Looks up tls.clusters.<clusterID>.{caPemPath,clientPemPath,clientKeyPath}.
+// Returns nil if client cert paths are not configured for this cluster.
+func buildCDCTLSConfig(clusterID string) (*tls.Config, error) {
+	caPemPath, clientPemPath, clientKeyPath := paramtable.Get().ProxyGrpcServerCfg.GetClusterTLSConfig(clusterID)
+	// Only activate TLS when client cert paths are explicitly configured.
+	if clientPemPath == "" || clientKeyPath == "" {
+		return nil, nil
+	}
+
+	log.Info("CDC outbound TLS enabled",
+		zap.String("targetCluster", clusterID),
+		zap.String("caPemPath", caPemPath),
+		zap.String("clientPemPath", clientPemPath),
+		zap.String("clientKeyPath", clientKeyPath))
+
+	return milvusclient.BuildTLSConfig(caPemPath, clientPemPath, clientKeyPath)
 }

--- a/internal/cdc/cluster/milvus_client.go
+++ b/internal/cdc/cluster/milvus_client.go
@@ -55,7 +55,7 @@ func NewMilvusClient(ctx context.Context, cluster *commonpb.MilvusCluster) (Milv
 		return nil, errors.Wrap(err, "failed to build CDC TLS config")
 	}
 	if tlsConfig != nil {
-		config.TLSConfig = tlsConfig
+		config.WithTLSConfig(tlsConfig)
 	}
 
 	cli, err := milvusclient.New(ctx, config)

--- a/internal/cdc/cluster/milvus_client_test.go
+++ b/internal/cdc/cluster/milvus_client_test.go
@@ -1,0 +1,92 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+)
+
+func TestBuildCDCTLSConfig(t *testing.T) {
+	paramtable.Init()
+
+	t.Run("no config for cluster returns nil", func(t *testing.T) {
+		tlsConfig, err := buildCDCTLSConfig("unknown-cluster")
+		assert.NoError(t, err)
+		assert.Nil(t, tlsConfig)
+	})
+
+	t.Run("only caPemPath set returns nil", func(t *testing.T) {
+		paramtable.Get().Save("tls.clusters.test-cluster.caPemPath", "/some/ca.pem")
+		defer paramtable.Get().Save("tls.clusters.test-cluster.caPemPath", "")
+
+		tlsConfig, err := buildCDCTLSConfig("test-cluster")
+		assert.NoError(t, err)
+		assert.Nil(t, tlsConfig)
+	})
+
+	t.Run("partial client cert configured returns nil", func(t *testing.T) {
+		paramtable.Get().Save("tls.clusters.test-cluster.clientPemPath", "/some/client.pem")
+		defer paramtable.Get().Save("tls.clusters.test-cluster.clientPemPath", "")
+
+		tlsConfig, err := buildCDCTLSConfig("test-cluster")
+		assert.NoError(t, err)
+		assert.Nil(t, tlsConfig)
+	})
+
+	t.Run("invalid CA path returns error", func(t *testing.T) {
+		paramtable.Get().Save("tls.clusters.test-cluster.caPemPath", "/nonexistent/ca.pem")
+		paramtable.Get().Save("tls.clusters.test-cluster.clientPemPath", "/some/client.pem")
+		paramtable.Get().Save("tls.clusters.test-cluster.clientKeyPath", "/some/client.key")
+		defer func() {
+			paramtable.Get().Save("tls.clusters.test-cluster.caPemPath", "")
+			paramtable.Get().Save("tls.clusters.test-cluster.clientPemPath", "")
+			paramtable.Get().Save("tls.clusters.test-cluster.clientKeyPath", "")
+		}()
+
+		_, err := buildCDCTLSConfig("test-cluster")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read CA cert")
+	})
+
+	t.Run("different clusters use different configs", func(t *testing.T) {
+		paramtable.Get().Save("tls.clusters.cluster-a.clientPemPath", "/certs/a/client.pem")
+		paramtable.Get().Save("tls.clusters.cluster-b.clientPemPath", "/certs/b/client.pem")
+		defer func() {
+			paramtable.Get().Save("tls.clusters.cluster-a.clientPemPath", "")
+			paramtable.Get().Save("tls.clusters.cluster-b.clientPemPath", "")
+		}()
+
+		// cluster-a has only clientPemPath (no key) → nil
+		tlsConfig, err := buildCDCTLSConfig("cluster-a")
+		assert.NoError(t, err)
+		assert.Nil(t, tlsConfig)
+
+		// cluster-b also has only clientPemPath (no key) → nil
+		tlsConfig, err = buildCDCTLSConfig("cluster-b")
+		assert.NoError(t, err)
+		assert.Nil(t, tlsConfig)
+
+		// cluster-c has no config at all → nil
+		tlsConfig, err = buildCDCTLSConfig("cluster-c")
+		assert.NoError(t, err)
+		assert.Nil(t, tlsConfig)
+	})
+}

--- a/pkg/util/paramtable/grpc_param.go
+++ b/pkg/util/paramtable/grpc_param.go
@@ -76,10 +76,13 @@ type grpcConfig struct {
 	ServerPemPath ParamItem `refreshable:"false"`
 	ServerKeyPath ParamItem `refreshable:"false"`
 	CaPemPath     ParamItem `refreshable:"false"`
+
+	base *BaseTable // stored for dynamic per-cluster TLS lookups
 }
 
 func (p *grpcConfig) init(domain string, base *BaseTable) {
 	p.Domain = domain
+	p.base = base
 	p.IPItem = ParamItem{
 		Key:     p.Domain + ".ip",
 		Version: "2.3.3",
@@ -133,6 +136,17 @@ func (p *grpcConfig) init(domain string, base *BaseTable) {
 		Export:  true,
 	}
 	p.CaPemPath.Init(base.mgr)
+}
+
+// GetClusterTLSConfig returns per-cluster outbound TLS cert paths for CDC connections.
+// Reads from tls.clusters.<clusterID>.{caPemPath,clientPemPath,clientKeyPath}.
+// Returns empty strings if the cluster has no TLS config.
+func (p *grpcConfig) GetClusterTLSConfig(clusterID string) (caPemPath, clientPemPath, clientKeyPath string) {
+	prefix := "tls.clusters." + clusterID + "."
+	caPemPath = p.base.Get(prefix + "caPemPath")
+	clientPemPath = p.base.Get(prefix + "clientPemPath")
+	clientKeyPath = p.base.Get(prefix + "clientKeyPath")
+	return
 }
 
 // GetAddress return grpc address

--- a/pkg/util/paramtable/grpc_param_test.go
+++ b/pkg/util/paramtable/grpc_param_test.go
@@ -176,6 +176,22 @@ func TestGrpcClientParams(t *testing.T) {
 	assert.Equal(t, clientConfig.ServerPemPath.GetValue(), "/pem")
 	assert.Equal(t, clientConfig.ServerKeyPath.GetValue(), "/key")
 	assert.Equal(t, clientConfig.CaPemPath.GetValue(), "/ca")
+
+	// Per-cluster TLS config lookup
+	base.Save("tls.clusters.cluster-b.caPemPath", "/certs/cluster-b/ca.pem")
+	base.Save("tls.clusters.cluster-b.clientPemPath", "/certs/cluster-b/client.pem")
+	base.Save("tls.clusters.cluster-b.clientKeyPath", "/certs/cluster-b/client.key")
+
+	caPem, clientPem, clientKey := clientConfig.GetClusterTLSConfig("cluster-b")
+	assert.Equal(t, "/certs/cluster-b/ca.pem", caPem)
+	assert.Equal(t, "/certs/cluster-b/client.pem", clientPem)
+	assert.Equal(t, "/certs/cluster-b/client.key", clientKey)
+
+	// Unknown cluster returns empty strings
+	caPem, clientPem, clientKey = clientConfig.GetClusterTLSConfig("unknown-cluster")
+	assert.Equal(t, "", caPem)
+	assert.Equal(t, "", clientPem)
+	assert.Equal(t, "", clientKey)
 }
 
 func TestInternalTLSParams(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add `BuildTLSConfig` helper and `TLSConfig` field to SDK `ClientConfig` for mTLS support
- Add `GetClusterTLSConfig(clusterID)` for dynamic per-cluster paramtable lookup
- CDC `NewMilvusClient` reads per-cluster TLS config by target cluster ID

pr: #47968
issue: #47843

🤖 Generated with [Claude Code](https://claude.com/claude-code)