### PR TITLE
enhance: propagate TLS minimum version config to C++ storage layer

### DIFF
--- a/internal/core/src/clustering/analyze_c.cpp
+++ b/internal/core/src/clustering/analyze_c.cpp
@@ -56,6 +56,7 @@ get_storage_config(const milvus::proto::clustering::StorageConfig& config) {
     storage_config.gcp_credential_json =
         std::string(config.gcpcredentialjson());
     storage_config.max_connections = config.max_connections();
+    storage_config.tls_min_version = std::string(config.ssl_tls_min_version());
 
     return storage_config;
 }
@@ -107,6 +108,7 @@ Analyze(CAnalyze* res_analyze,
             storage_config.gcp_credential_json,
             false,
             storage_config.max_connections,
+            storage_config.tls_min_version,
         });
 
         milvus::storage::FileManagerContext fileManagerContext(

--- a/internal/core/src/common/type_c.h
+++ b/internal/core/src/common/type_c.h
@@ -92,6 +92,7 @@ typedef struct CStorageConfig {
     const char* gcp_credential_json;
     bool use_custom_part_upload;
     uint32_t max_connections;
+    const char* tls_min_version;
 } CStorageConfig;
 
 typedef struct CDiskWriteRateLimiterConfig {

--- a/internal/core/src/indexbuilder/index_c.cpp
+++ b/internal/core/src/indexbuilder/index_c.cpp
@@ -125,6 +125,8 @@ get_storage_config(const milvus::proto::indexcgo::StorageConfig& config) {
     storage_config.requestTimeoutMs = config.request_timeout_ms();
     storage_config.gcp_credential_json =
         std::string(config.gcpcredentialjson());
+    storage_config.max_connections = config.max_connections();
+    storage_config.tls_min_version = std::string(config.ssl_tls_min_version());
     return storage_config;
 }
 

--- a/internal/core/src/segcore/arrow_fs_c.cpp
+++ b/internal/core/src/segcore/arrow_fs_c.cpp
@@ -69,6 +69,10 @@ InitRemoteArrowFileSystemSingleton(CStorageConfig c_storage_config) {
             std::string(c_storage_config.gcp_credential_json);
         conf.use_custom_part_upload = c_storage_config.use_custom_part_upload;
         conf.max_connections = c_storage_config.max_connections;
+        if (c_storage_config.tls_min_version != nullptr) {
+            conf.tls_min_version =
+                std::string(c_storage_config.tls_min_version);
+        }
         milvus_storage::ArrowFileSystemSingleton::GetInstance().Init(conf);
 
         milvus::storage::LoonFFIPropertiesSingleton::GetInstance().Init(

--- a/internal/core/src/segcore/packed_reader_c.cpp
+++ b/internal/core/src/segcore/packed_reader_c.cpp
@@ -67,6 +67,9 @@ NewPackedReaderWithStorageConfig(char** paths,
             std::string(c_storage_config.gcp_credential_json),
             c_storage_config.use_custom_part_upload,
             c_storage_config.max_connections,
+            c_storage_config.tls_min_version != nullptr
+                ? std::string(c_storage_config.tls_min_version)
+                : "",
         });
         if (!trueFs) {
             return milvus::FailureCStatus(

--- a/internal/core/src/segcore/packed_writer_c.cpp
+++ b/internal/core/src/segcore/packed_writer_c.cpp
@@ -81,6 +81,9 @@ NewPackedWriterWithStorageConfig(struct ArrowSchema* schema,
             std::string(c_storage_config.gcp_credential_json),
             c_storage_config.use_custom_part_upload,
             c_storage_config.max_connections,
+            c_storage_config.tls_min_version != nullptr
+                ? std::string(c_storage_config.tls_min_version)
+                : "",
         });
         if (!trueFs) {
             return milvus::FailureCStatus(
@@ -335,6 +338,9 @@ GetFileSizeWithStorageConfig(const char* path,
             std::string(c_storage_config.gcp_credential_json),
             c_storage_config.use_custom_part_upload,
             c_storage_config.max_connections,
+            c_storage_config.tls_min_version != nullptr
+                ? std::string(c_storage_config.tls_min_version)
+                : "",
         });
 
         if (!trueFs) {

--- a/internal/core/src/storage/StorageV2FSCache.cpp
+++ b/internal/core/src/storage/StorageV2FSCache.cpp
@@ -49,6 +49,9 @@ StorageV2FSCache::Get(const Key& key) {
     props[PROPERTY_FS_GCP_CREDENTIAL_JSON] = key.gcp_credential_json;
     props[PROPERTY_FS_USE_CUSTOM_PART_UPLOAD] = key.use_custom_part_upload;
     props[PROPERTY_FS_MAX_CONNECTIONS] = key.max_connections;
+    if (!key.tls_min_version.empty() && key.tls_min_version != "default") {
+        props[PROPERTY_FS_TLS_MIN_VERSION] = key.tls_min_version;
+    }
 
     LOG_INFO(
         "StorageV2FSCache::Get: address={}, bucket={}, root_path={}, "

--- a/internal/core/src/storage/StorageV2FSCache.h
+++ b/internal/core/src/storage/StorageV2FSCache.h
@@ -45,6 +45,7 @@ class StorageV2FSCache {
         std::string gcp_credential_json = "";
         bool use_custom_part_upload = true;
         uint32_t max_connections = 100;
+        std::string tls_min_version = "";
     };
 
  public:

--- a/internal/core/src/storage/Types.h
+++ b/internal/core/src/storage/Types.h
@@ -110,6 +110,7 @@ struct StorageConfig {
     bool gcp_native_without_auth = false;
     std::string gcp_credential_json = "";
     uint32_t max_connections = 100;
+    std::string tls_min_version = "";
 
     std::string
     ToString() const {
@@ -125,7 +126,8 @@ struct StorageConfig {
            << ", requestTimeoutMs=" << requestTimeoutMs
            << ", maxConnections=" << max_connections
            << ", gcp_native_without_auth=" << std::boolalpha
-           << gcp_native_without_auth << "]";
+           << gcp_native_without_auth << ", tls_min_version=" << tls_min_version
+           << "]";
 
         return ss.str();
     }

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -1179,6 +1179,7 @@ InitArrowFileSystem(milvus::storage::StorageConfig storage_config) {
             std::string(storage_config.gcp_credential_json);
         conf.use_custom_part_upload = true;
         conf.max_connections = storage_config.max_connections;
+        conf.tls_min_version = storage_config.tls_min_version;
     }
     return StorageV2FSCache::Instance().Get(conf);
 }

--- a/internal/core/src/storage/loon_ffi/util.cpp
+++ b/internal/core/src/storage/loon_ffi/util.cpp
@@ -116,6 +116,13 @@ MakePropertiesFromStorageConfig(CStorageConfig c_storage_config) {
     keys.emplace_back(PROPERTY_FS_MAX_CONNECTIONS);
     values.emplace_back(max_connections_str.c_str());
 
+    if (c_storage_config.tls_min_version != nullptr &&
+        std::string(c_storage_config.tls_min_version).length() > 0 &&
+        std::string(c_storage_config.tls_min_version) != "default") {
+        keys.emplace_back(PROPERTY_FS_TLS_MIN_VERSION);
+        values.emplace_back(c_storage_config.tls_min_version);
+    }
+
     // Create Properties using FFI
     auto properties = std::make_shared<LoonProperties>();
     LoonFFIResult result = loon_properties_create(
@@ -221,6 +228,14 @@ MakeInternalPropertiesFromStorageConfig(CStorageConfig c_storage_config) {
         PROPERTY_FS_MAX_CONNECTIONS,
         std::to_string(c_storage_config.max_connections).c_str());
 
+    if (c_storage_config.tls_min_version != nullptr &&
+        std::string(c_storage_config.tls_min_version).length() > 0 &&
+        std::string(c_storage_config.tls_min_version) != "default") {
+        milvus_storage::api::SetValue(*properties_map,
+                                      PROPERTY_FS_TLS_MIN_VERSION,
+                                      c_storage_config.tls_min_version);
+    }
+
     return properties_map;
 }
 
@@ -256,7 +271,8 @@ ToCStorageConfig(const milvus::storage::StorageConfig& config) {
                           config.requestTimeoutMs,
                           config.gcp_credential_json.c_str(),
                           false,  // this field does not exist in StorageConfig
-                          config.max_connections};
+                          config.max_connections,
+                          config.tls_min_version.c_str()};
 }
 
 std::shared_ptr<milvus_storage::api::Manifest>

--- a/internal/core/src/storage/storage_c.cpp
+++ b/internal/core/src/storage/storage_c.cpp
@@ -93,6 +93,10 @@ InitRemoteChunkManagerSingleton(CStorageConfig c_storage_config) {
         storage_config.max_connections = c_storage_config.max_connections;
         storage_config.gcp_credential_json =
             std::string(c_storage_config.gcp_credential_json);
+        if (c_storage_config.tls_min_version != nullptr) {
+            storage_config.tls_min_version =
+                std::string(c_storage_config.tls_min_version);
+        }
         milvus::storage::RemoteChunkManagerSingleton::GetInstance().Init(
             storage_config);
 

--- a/internal/core/thirdparty/milvus-storage/CMakeLists.txt
+++ b/internal/core/thirdparty/milvus-storage/CMakeLists.txt
@@ -14,7 +14,7 @@
 # Update milvus-storage_VERSION for the first occurrence
 milvus_add_pkg_config("milvus-storage")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( milvus-storage_VERSION 2955b08)
+set( milvus-storage_VERSION 849d940)
 set( GIT_REPOSITORY  "https://github.com/milvus-io/milvus-storage.git")
 message(STATUS "milvus-storage repo: ${GIT_REPOSITORY}")
 message(STATUS "milvus-storage version: ${milvus-storage_VERSION}")

--- a/internal/storagev2/packed/packed_reader.go
+++ b/internal/storagev2/packed/packed_reader.go
@@ -86,6 +86,7 @@ func NewPackedReader(filePaths []string, schema *arrow.Schema, bufferSize int64,
 			gcp_credential_json:    C.CString(storageConfig.GetGcpCredentialJSON()),
 			use_custom_part_upload: true,
 			max_connections:        C.uint32_t(storageConfig.GetMaxConnections()),
+			tls_min_version:        C.CString(tlsMinVersionForStorage(storageConfig.GetSslTlsMinVersion())),
 		}
 		defer C.free(unsafe.Pointer(cStorageConfig.address))
 		defer C.free(unsafe.Pointer(cStorageConfig.bucket_name))
@@ -99,6 +100,7 @@ func NewPackedReader(filePaths []string, schema *arrow.Schema, bufferSize int64,
 		defer C.free(unsafe.Pointer(cStorageConfig.sslCACert))
 		defer C.free(unsafe.Pointer(cStorageConfig.region))
 		defer C.free(unsafe.Pointer(cStorageConfig.gcp_credential_json))
+		defer C.free(unsafe.Pointer(cStorageConfig.tls_min_version))
 
 		status = C.NewPackedReaderWithStorageConfig(cFilePathsArray, cNumPaths, cSchema, cBufferSize, cStorageConfig, &cPackedReader, pluginContextPtr)
 	} else {

--- a/internal/storagev2/packed/packed_reader_ffi.go
+++ b/internal/storagev2/packed/packed_reader_ffi.go
@@ -85,6 +85,7 @@ func NewFFIPackedReader(manifestPath string, schema *arrow.Schema, neededColumns
 			gcp_credential_json:    C.CString(storageConfig.GetGcpCredentialJSON()),
 			use_custom_part_upload: true,
 			max_connections:        C.uint32_t(storageConfig.GetMaxConnections()),
+			tls_min_version:        C.CString(tlsMinVersionForStorage(storageConfig.GetSslTlsMinVersion())),
 		}
 		defer C.free(unsafe.Pointer(cStorageConfig.address))
 		defer C.free(unsafe.Pointer(cStorageConfig.bucket_name))
@@ -98,6 +99,7 @@ func NewFFIPackedReader(manifestPath string, schema *arrow.Schema, neededColumns
 		defer C.free(unsafe.Pointer(cStorageConfig.sslCACert))
 		defer C.free(unsafe.Pointer(cStorageConfig.region))
 		defer C.free(unsafe.Pointer(cStorageConfig.gcp_credential_json))
+		defer C.free(unsafe.Pointer(cStorageConfig.tls_min_version))
 
 		cNeededColumn := make([]*C.char, len(neededColumns))
 		for i, columnName := range neededColumns {

--- a/internal/storagev2/packed/packed_writer.go
+++ b/internal/storagev2/packed/packed_writer.go
@@ -104,6 +104,7 @@ func NewPackedWriter(filePaths []string, schema *arrow.Schema, bufferSize int64,
 			gcp_credential_json:    C.CString(storageConfig.GetGcpCredentialJSON()),
 			use_custom_part_upload: true,
 			max_connections:        C.uint32_t(storageConfig.GetMaxConnections()),
+			tls_min_version:        C.CString(tlsMinVersionForStorage(storageConfig.GetSslTlsMinVersion())),
 		}
 		defer C.free(unsafe.Pointer(cStorageConfig.address))
 		defer C.free(unsafe.Pointer(cStorageConfig.bucket_name))
@@ -117,6 +118,7 @@ func NewPackedWriter(filePaths []string, schema *arrow.Schema, bufferSize int64,
 		defer C.free(unsafe.Pointer(cStorageConfig.sslCACert))
 		defer C.free(unsafe.Pointer(cStorageConfig.region))
 		defer C.free(unsafe.Pointer(cStorageConfig.gcp_credential_json))
+		defer C.free(unsafe.Pointer(cStorageConfig.tls_min_version))
 		status = C.NewPackedWriterWithStorageConfig(cSchema, cBufferSize, cFilePathsArray, cNumPaths, cMultiPartUploadSize, cColumnSplits, cStorageConfig, &cPackedWriter, pluginContextPtr)
 	} else {
 		status = C.NewPackedWriter(cSchema, cBufferSize, cFilePathsArray, cNumPaths, cMultiPartUploadSize, cColumnSplits, &cPackedWriter, pluginContextPtr)

--- a/internal/storagev2/packed/util.go
+++ b/internal/storagev2/packed/util.go
@@ -60,6 +60,16 @@ func GetFileSize(path string, storageConfig *indexpb.StorageConfig) (int64, erro
 	}
 }
 
+// tlsMinVersionForStorage converts TLS min version config value
+// to the format expected by milvus-storage. "default" and "" map to ""
+// (empty string = system/library default).
+func tlsMinVersionForStorage(v string) string {
+	if v == "" || v == "default" {
+		return ""
+	}
+	return v
+}
+
 func GetCStorageConfig(storageConfig *indexpb.StorageConfig) C.CStorageConfig {
 	cStorageConfig := C.CStorageConfig{
 		address:                C.CString(storageConfig.GetAddress()),
@@ -80,6 +90,7 @@ func GetCStorageConfig(storageConfig *indexpb.StorageConfig) C.CStorageConfig {
 		gcp_credential_json:    C.CString(storageConfig.GetGcpCredentialJSON()),
 		use_custom_part_upload: true,
 		max_connections:        C.uint32_t(storageConfig.GetMaxConnections()),
+		tls_min_version:        C.CString(tlsMinVersionForStorage(storageConfig.GetSslTlsMinVersion())),
 	}
 	return cStorageConfig
 }
@@ -97,4 +108,5 @@ func DeleteCStorageConfig(cStorageConfig C.CStorageConfig) {
 	C.free(unsafe.Pointer(cStorageConfig.sslCACert))
 	C.free(unsafe.Pointer(cStorageConfig.region))
 	C.free(unsafe.Pointer(cStorageConfig.gcp_credential_json))
+	C.free(unsafe.Pointer(cStorageConfig.tls_min_version))
 }

--- a/internal/util/initcore/init_core.go
+++ b/internal/util/initcore/init_core.go
@@ -173,6 +173,7 @@ func InitRemoteArrowFileSystem(params *paramtable.ComponentParam) error {
 	cRegion := C.CString(params.MinioCfg.Region.GetValue())
 	cSslCACert := C.CString(params.MinioCfg.SslCACert.GetValue())
 	cGcpCredentialJSON := C.CString(params.MinioCfg.GcpCredentialJSON.GetValue())
+	cTLSMinVersion := C.CString(tlsMinVersionForStorage(params.MinioCfg.SslTLSMinVersion.GetValue()))
 	defer C.free(unsafe.Pointer(cAddress))
 	defer C.free(unsafe.Pointer(cBucketName))
 	defer C.free(unsafe.Pointer(cAccessKey))
@@ -185,6 +186,7 @@ func InitRemoteArrowFileSystem(params *paramtable.ComponentParam) error {
 	defer C.free(unsafe.Pointer(cCloudProvider))
 	defer C.free(unsafe.Pointer(cSslCACert))
 	defer C.free(unsafe.Pointer(cGcpCredentialJSON))
+	defer C.free(unsafe.Pointer(cTLSMinVersion))
 	storageConfig := C.CStorageConfig{
 		address:                cAddress,
 		bucket_name:            cBucketName,
@@ -204,6 +206,7 @@ func InitRemoteArrowFileSystem(params *paramtable.ComponentParam) error {
 		gcp_credential_json:    cGcpCredentialJSON,
 		use_custom_part_upload: true,
 		max_connections:        C.uint32_t(params.MinioCfg.MaxConnections.GetAsInt()),
+		tls_min_version:        cTLSMinVersion,
 	}
 
 	status := C.InitRemoteArrowFileSystemSingleton(storageConfig)
@@ -228,6 +231,7 @@ func InitRemoteChunkManager(params *paramtable.ComponentParam) error {
 	cRegion := C.CString(params.MinioCfg.Region.GetValue())
 	cSslCACert := C.CString(params.MinioCfg.SslCACert.GetValue())
 	cGcpCredentialJSON := C.CString(params.MinioCfg.GcpCredentialJSON.GetValue())
+	cTLSMinVersion := C.CString(tlsMinVersionForStorage(params.MinioCfg.SslTLSMinVersion.GetValue()))
 	defer C.free(unsafe.Pointer(cAddress))
 	defer C.free(unsafe.Pointer(cBucketName))
 	defer C.free(unsafe.Pointer(cAccessKey))
@@ -240,6 +244,7 @@ func InitRemoteChunkManager(params *paramtable.ComponentParam) error {
 	defer C.free(unsafe.Pointer(cCloudProvider))
 	defer C.free(unsafe.Pointer(cSslCACert))
 	defer C.free(unsafe.Pointer(cGcpCredentialJSON))
+	defer C.free(unsafe.Pointer(cTLSMinVersion))
 	storageConfig := C.CStorageConfig{
 		address:             cAddress,
 		bucket_name:         cBucketName,
@@ -258,6 +263,7 @@ func InitRemoteChunkManager(params *paramtable.ComponentParam) error {
 		requestTimeoutMs:    C.int64_t(params.MinioCfg.RequestTimeoutMs.GetAsInt64()),
 		gcp_credential_json: cGcpCredentialJSON,
 		max_connections:     C.uint32_t(params.MinioCfg.MaxConnections.GetAsInt()),
+		tls_min_version:     cTLSMinVersion,
 	}
 
 	status := C.InitRemoteChunkManagerSingleton(storageConfig)
@@ -652,6 +658,17 @@ func HandleCStatus(status *C.CStatus, extraInfo string) error {
 	logMsg := fmt.Sprintf("%s, C Runtime Exception: %s\n", extraInfo, finalMsg)
 	log.Warn(logMsg)
 	return errors.New(finalMsg)
+}
+
+// tlsMinVersionForStorage converts minio config's TLS min version value
+// to the format expected by milvus-storage. "default" and "" map to ""
+// (empty string = system/library default). Other values like "1.0", "1.1",
+// "1.2", "1.3" pass through as-is.
+func tlsMinVersionForStorage(v string) string {
+	if v == "" || v == "default" {
+		return ""
+	}
+	return v
 }
 
 func serializeHeaders(headerstr string) string {


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/44999

The previous PR (#48000) added the configurable TLS minimum version on the Go side but didn't wire it through to the C++ core. This commit fills that gap by adding the tls_min_version field to CStorageConfig and passing it down to all the places that build storage configs — index builder, clustering analyzer, packed reader/writer, chunk manager, arrow filesystem, and the loon FFI layer. Also bumps milvus-storage to a version that supports the new property.