### PR TITLE
enhance: bypass broadcaster for resource group DDL on non-primary clusters

### DIFF
--- a/internal/querycoordv2/ddl_callbacks.go
+++ b/internal/querycoordv2/ddl_callbacks.go
@@ -25,6 +25,7 @@ import (
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster/broadcast"
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster/registry"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
 // RegisterDDLCallbacks registers the ddl callbacks.
@@ -49,6 +50,21 @@ func (c *DDLCallbacks) registerLoadConfigCallbacks() {
 func (c *DDLCallbacks) registerResourceGroupCallbacks() {
 	registry.RegisterAlterResourceGroupV2AckCallback(c.alterResourceGroupV2AckCallback)
 	registry.RegisterDropResourceGroupV2AckCallback(c.dropResourceGroupV2AckCallback)
+}
+
+// shouldApplyLocallyOnNonPrimary checks if the error from broadcaster indicates a non-primary cluster
+// and the message type is configured to be skipped via streaming.replication.skipMessageTypes.
+// If true, the caller should bypass the broadcaster and apply the operation locally.
+func shouldApplyLocallyOnNonPrimary(err error, msgType message.MessageType) bool {
+	if !errors.Is(err, broadcast.ErrNotPrimary) {
+		return false
+	}
+	for _, t := range paramtable.Get().StreamingCfg.ReplicationSkipMessageTypes.GetAsStrings() {
+		if t == msgType.String() {
+			return true
+		}
+	}
+	return false
 }
 
 // startBroadcastWithCollectionIDLock starts a broadcast with collection id lock.

--- a/internal/querycoordv2/ddl_callbacks_alter_resource_group.go
+++ b/internal/querycoordv2/ddl_callbacks_alter_resource_group.go
@@ -26,6 +26,7 @@ import (
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/internal/querycoordv2/meta"
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster/broadcast"
+	"github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster/registry"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
@@ -34,9 +35,14 @@ import (
 func (s *Server) broadcastCreateResourceGroup(ctx context.Context, req *milvuspb.CreateResourceGroupRequest) error {
 	broadcaster, err := broadcast.StartBroadcastWithResourceKeys(ctx, message.NewExclusiveClusterResourceKey())
 	if err != nil {
-		return err
+		if !shouldApplyLocallyOnNonPrimary(err, message.MessageTypeAlterResourceGroup) {
+			return err
+		}
+		err = nil
 	}
-	defer broadcaster.Close()
+	if broadcaster != nil {
+		defer broadcaster.Close()
+	}
 
 	cfg := req.GetConfig()
 	if cfg == nil {
@@ -54,6 +60,9 @@ func (s *Server) broadcastCreateResourceGroup(ctx context.Context, req *milvuspb
 		WithBody(&message.AlterResourceGroupMessageBody{}).
 		WithBroadcast([]string{streaming.WAL().ControlChannel()}).
 		MustBuildBroadcast()
+	if broadcaster == nil {
+		return registry.CallMessageAckCallback(ctx, msg, nil)
+	}
 	_, err = broadcaster.Broadcast(ctx, msg)
 	return err
 }
@@ -65,9 +74,14 @@ func (s *Server) broadcastUpdateResourceGroups(ctx context.Context, req *querypb
 
 	broadcaster, err := broadcast.StartBroadcastWithResourceKeys(ctx, message.NewExclusiveClusterResourceKey())
 	if err != nil {
-		return err
+		if !shouldApplyLocallyOnNonPrimary(err, message.MessageTypeAlterResourceGroup) {
+			return err
+		}
+		err = nil
 	}
-	defer broadcaster.Close()
+	if broadcaster != nil {
+		defer broadcaster.Close()
+	}
 
 	if err := s.meta.ResourceManager.CheckIfResourceGroupsUpdatable(ctx, req.GetResourceGroups()); err != nil {
 		return err
@@ -80,6 +94,9 @@ func (s *Server) broadcastUpdateResourceGroups(ctx context.Context, req *querypb
 		WithBody(&message.AlterResourceGroupMessageBody{}).
 		WithBroadcast([]string{streaming.WAL().ControlChannel()}).
 		MustBuildBroadcast()
+	if broadcaster == nil {
+		return registry.CallMessageAckCallback(ctx, msg, nil)
+	}
 	_, err = broadcaster.Broadcast(ctx, msg)
 	return err
 }
@@ -87,9 +104,14 @@ func (s *Server) broadcastUpdateResourceGroups(ctx context.Context, req *querypb
 func (s *Server) broadcastTransferNode(ctx context.Context, req *milvuspb.TransferNodeRequest) error {
 	broadcaster, err := broadcast.StartBroadcastWithResourceKeys(ctx, message.NewExclusiveClusterResourceKey())
 	if err != nil {
-		return err
+		if !shouldApplyLocallyOnNonPrimary(err, message.MessageTypeAlterResourceGroup) {
+			return err
+		}
+		err = nil
 	}
-	defer broadcaster.Close()
+	if broadcaster != nil {
+		defer broadcaster.Close()
+	}
 
 	// Move node from source resource group to target resource group.
 	rgs, err := s.meta.ResourceManager.CheckIfTransferNode(ctx, req.GetSourceResourceGroup(), req.GetTargetResourceGroup(), int(req.GetNumNode()))
@@ -105,6 +127,9 @@ func (s *Server) broadcastTransferNode(ctx context.Context, req *milvuspb.Transf
 		WithBody(&message.AlterResourceGroupMessageBody{}).
 		WithBroadcast([]string{streaming.WAL().ControlChannel()}).
 		MustBuildBroadcast()
+	if broadcaster == nil {
+		return registry.CallMessageAckCallback(ctx, msg, nil)
+	}
 	_, err = broadcaster.Broadcast(ctx, msg)
 	return err
 }

--- a/internal/querycoordv2/ddl_callbacks_alter_resource_group.go
+++ b/internal/querycoordv2/ddl_callbacks_alter_resource_group.go
@@ -38,7 +38,6 @@ func (s *Server) broadcastCreateResourceGroup(ctx context.Context, req *milvuspb
 		if !shouldApplyLocallyOnNonPrimary(err, message.MessageTypeAlterResourceGroup) {
 			return err
 		}
-		err = nil
 	}
 	if broadcaster != nil {
 		defer broadcaster.Close()
@@ -77,7 +76,6 @@ func (s *Server) broadcastUpdateResourceGroups(ctx context.Context, req *querypb
 		if !shouldApplyLocallyOnNonPrimary(err, message.MessageTypeAlterResourceGroup) {
 			return err
 		}
-		err = nil
 	}
 	if broadcaster != nil {
 		defer broadcaster.Close()
@@ -107,7 +105,6 @@ func (s *Server) broadcastTransferNode(ctx context.Context, req *milvuspb.Transf
 		if !shouldApplyLocallyOnNonPrimary(err, message.MessageTypeAlterResourceGroup) {
 			return err
 		}
-		err = nil
 	}
 	if broadcaster != nil {
 		defer broadcaster.Close()

--- a/internal/querycoordv2/ddl_callbacks_drop_resource_group.go
+++ b/internal/querycoordv2/ddl_callbacks_drop_resource_group.go
@@ -25,6 +25,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster/broadcast"
+	"github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster/registry"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 )
@@ -32,9 +33,14 @@ import (
 func (s *Server) broadcastDropResourceGroup(ctx context.Context, req *milvuspb.DropResourceGroupRequest) error {
 	broadcaster, err := broadcast.StartBroadcastWithResourceKeys(ctx, message.NewExclusiveClusterResourceKey())
 	if err != nil {
-		return err
+		if !shouldApplyLocallyOnNonPrimary(err, message.MessageTypeDropResourceGroup) {
+			return err
+		}
+		err = nil
 	}
-	defer broadcaster.Close()
+	if broadcaster != nil {
+		defer broadcaster.Close()
+	}
 
 	replicas := s.meta.ReplicaManager.GetByResourceGroup(ctx, req.GetResourceGroup())
 	if len(replicas) > 0 {
@@ -53,6 +59,9 @@ func (s *Server) broadcastDropResourceGroup(ctx context.Context, req *milvuspb.D
 		WithBody(&message.DropResourceGroupMessageBody{}).
 		WithBroadcast([]string{streaming.WAL().ControlChannel()}).
 		MustBuildBroadcast()
+	if broadcaster == nil {
+		return registry.CallMessageAckCallback(ctx, msg, nil)
+	}
 	_, err = broadcaster.Broadcast(ctx, msg)
 	return err
 }

--- a/internal/querycoordv2/ddl_callbacks_drop_resource_group.go
+++ b/internal/querycoordv2/ddl_callbacks_drop_resource_group.go
@@ -36,7 +36,6 @@ func (s *Server) broadcastDropResourceGroup(ctx context.Context, req *milvuspb.D
 		if !shouldApplyLocallyOnNonPrimary(err, message.MessageTypeDropResourceGroup) {
 			return err
 		}
-		err = nil
 	}
 	if broadcaster != nil {
 		defer broadcaster.Close()

--- a/internal/querycoordv2/ddl_callbacks_test.go
+++ b/internal/querycoordv2/ddl_callbacks_test.go
@@ -1,0 +1,74 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package querycoordv2
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster/broadcast"
+	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+)
+
+func TestShouldApplyLocallyOnNonPrimary(t *testing.T) {
+	paramtable.Init()
+
+	t.Run("non_ErrNotPrimary_returns_false", func(t *testing.T) {
+		assert.False(t, shouldApplyLocallyOnNonPrimary(errors.New("some other error"), message.MessageTypeAlterResourceGroup))
+		assert.False(t, shouldApplyLocallyOnNonPrimary(errors.New("some other error"), message.MessageTypeDropResourceGroup))
+	})
+
+	t.Run("nil_error_returns_false", func(t *testing.T) {
+		assert.False(t, shouldApplyLocallyOnNonPrimary(nil, message.MessageTypeAlterResourceGroup))
+	})
+
+	t.Run("ErrNotPrimary_with_default_skip_config", func(t *testing.T) {
+		// Default config: "AlterResourceGroup,DropResourceGroup"
+		assert.True(t, shouldApplyLocallyOnNonPrimary(broadcast.ErrNotPrimary, message.MessageTypeAlterResourceGroup))
+		assert.True(t, shouldApplyLocallyOnNonPrimary(broadcast.ErrNotPrimary, message.MessageTypeDropResourceGroup))
+	})
+
+	t.Run("ErrNotPrimary_with_msg_type_not_in_skip_config", func(t *testing.T) {
+		// CreateCollection is not in the default skip list
+		assert.False(t, shouldApplyLocallyOnNonPrimary(broadcast.ErrNotPrimary, message.MessageTypeCreateCollection))
+	})
+
+	t.Run("wrapped_ErrNotPrimary_returns_true", func(t *testing.T) {
+		wrappedErr := fmt.Errorf("wrapped: %w", broadcast.ErrNotPrimary)
+		assert.True(t, shouldApplyLocallyOnNonPrimary(wrappedErr, message.MessageTypeAlterResourceGroup))
+	})
+
+	t.Run("ErrNotPrimary_with_empty_skip_config", func(t *testing.T) {
+		paramtable.Get().Save(paramtable.Get().StreamingCfg.ReplicationSkipMessageTypes.Key, "")
+		defer paramtable.Get().Reset(paramtable.Get().StreamingCfg.ReplicationSkipMessageTypes.Key)
+
+		assert.False(t, shouldApplyLocallyOnNonPrimary(broadcast.ErrNotPrimary, message.MessageTypeAlterResourceGroup))
+		assert.False(t, shouldApplyLocallyOnNonPrimary(broadcast.ErrNotPrimary, message.MessageTypeDropResourceGroup))
+	})
+
+	t.Run("ErrNotPrimary_with_custom_skip_config", func(t *testing.T) {
+		paramtable.Get().Save(paramtable.Get().StreamingCfg.ReplicationSkipMessageTypes.Key, "AlterResourceGroup")
+		defer paramtable.Get().Reset(paramtable.Get().StreamingCfg.ReplicationSkipMessageTypes.Key)
+
+		assert.True(t, shouldApplyLocallyOnNonPrimary(broadcast.ErrNotPrimary, message.MessageTypeAlterResourceGroup))
+		assert.False(t, shouldApplyLocallyOnNonPrimary(broadcast.ErrNotPrimary, message.MessageTypeDropResourceGroup))
+	})
+}


### PR DESCRIPTION
issue: #48029
pr: #48033

When the broadcaster reports ErrNotPrimary and the message type is in streaming.replication.skipMessageTypes, set a skipBroadcast flag and continue with the same validation logic. After validation and message construction, call registry.CallMessageAckCallback directly instead of broadcasting.