### PR TITLE
fix: [2.6] remove bounded channel capacity for system field loading to prevent deadlock

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -459,10 +459,9 @@ ChunkedSegmentSealedImpl::load_field_data_internal(
         if (SystemProperty::Instance().IsSystem(field_id)) {
             auto insert_files = info.insert_files;
             storage::SortByPath(insert_files);
-            auto parallel_degree = static_cast<uint64_t>(
-                DEFAULT_FIELD_MAX_MEMORY_LIMIT / FILE_SLICE_SIZE);
-            field_data_info.arrow_reader_channel->set_capacity(parallel_degree *
-                                                               2);
+            // field_data_info.arrow_reader_channel cannot have capacity
+            // othersize deadlock could happen if result count is greater than cap
+            // since this branch handles system only, we shall leave channel without cap for quick fix
             LoadArrowReaderFromRemote(insert_files,
                                       field_data_info.arrow_reader_channel,
                                       load_info.load_priority);


### PR DESCRIPTION
Cherry-pick from master
pr: #48036
When loading V1 segments with system fields (RowID/Timestamp) that have more than 16 binlog files, a deadlock occurs because the producer (LoadArrowReaderFromRemote) and consumer (load_system_field_internal) run sequentially on the same thread with a bounded channel. The producer fills the channel and blocks, while the consumer never starts.

Remove the set_capacity call so the channel is unbounded, matching the approach used in ChunkTranslator.

issue: #48035