### PR TITLE
[2.6] fix: use generic GetFunctionOutputFields for partial update filtering

### DIFF
--- a/internal/proxy/task_upsert.go
+++ b/internal/proxy/task_upsert.go
@@ -823,12 +823,12 @@ func (it *upsertTask) insertPreExecute(ctx context.Context) error {
 		return err
 	}
 
-	bm25Fields := typeutil.NewSet[string](GetBM25FunctionOutputFields(it.schema.CollectionSchema)...)
+	functionOutputFields := typeutil.NewSet[string](GetFunctionOutputFields(it.schema.CollectionSchema)...)
 	if it.req.PartialUpdate {
-		// remove the old bm25 fields
+		// remove the old function output fields (BM25, MinHash, etc.)
 		ret := make([]*schemapb.FieldData, 0)
 		for _, fieldData := range it.upsertMsg.InsertMsg.GetFieldsData() {
-			if bm25Fields.Contain(fieldData.GetFieldName()) {
+			if functionOutputFields.Contain(fieldData.GetFieldName()) {
 				continue
 			}
 			ret = append(ret, fieldData)

--- a/internal/proxy/task_upsert.go
+++ b/internal/proxy/task_upsert.go
@@ -823,12 +823,16 @@ func (it *upsertTask) insertPreExecute(ctx context.Context) error {
 		return err
 	}
 
-	functionOutputFields := typeutil.NewSet[string](GetFunctionOutputFields(it.schema.CollectionSchema)...)
+	bm25Fields := GetBM25FunctionOutputFields(it.schema.CollectionSchema)
+	minHashFields := GetMinHashFunctionOutputFields(it.schema.CollectionSchema)
+	fieldsToFilter := typeutil.NewSet[string](append(bm25Fields, minHashFields...)...)
 	if it.req.PartialUpdate {
-		// remove the old function output fields (BM25, MinHash, etc.)
+		// remove old BM25 and MinHash function output fields, which will be regenerated downstream
+		// Note: do NOT filter other function outputs (e.g. text embedding) as they are generated
+		// by genFunctionFields and expected by validateFieldDataColumns
 		ret := make([]*schemapb.FieldData, 0)
 		for _, fieldData := range it.upsertMsg.InsertMsg.GetFieldsData() {
-			if functionOutputFields.Contain(fieldData.GetFieldName()) {
+			if fieldsToFilter.Contain(fieldData.GetFieldName()) {
 				continue
 			}
 			ret = append(ret, fieldData)

--- a/internal/proxy/task_upsert_test.go
+++ b/internal/proxy/task_upsert_test.go
@@ -1916,59 +1916,10 @@ func TestUpsertTask_queryPreExecute_EmptyDataArray(t *testing.T) {
 	})
 }
 
-func TestInsertPreExecute_FilterFunctionOutputFields(t *testing.T) {
+func TestInsertPreExecute_FilterBM25AndMinHashOutputFields(t *testing.T) {
 	paramtable.Init()
 
-	// Schema with BM25 and MinHash functions
-	schema := newSchemaInfo(&schemapb.CollectionSchema{
-		Name:   "test_filter_func_output",
-		AutoID: true,
-		Fields: []*schemapb.FieldSchema{
-			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true, AutoID: true},
-			{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar, TypeParams: []*commonpb.KeyValuePair{{Key: "max_length", Value: "2000"}}},
-			{FieldID: 102, Name: "vec", DataType: schemapb.DataType_FloatVector, TypeParams: []*commonpb.KeyValuePair{{Key: "dim", Value: "4"}}},
-			{FieldID: 103, Name: "sparse", DataType: schemapb.DataType_SparseFloatVector, IsFunctionOutput: true},
-			{FieldID: 104, Name: "mh", DataType: schemapb.DataType_BinaryVector, IsFunctionOutput: true, TypeParams: []*commonpb.KeyValuePair{{Key: "dim", Value: "512"}}},
-		},
-		Functions: []*schemapb.FunctionSchema{
-			{
-				Name:             "bm25",
-				Type:             schemapb.FunctionType_BM25,
-				InputFieldIds:    []int64{101},
-				InputFieldNames:  []string{"text"},
-				OutputFieldIds:   []int64{103},
-				OutputFieldNames: []string{"sparse"},
-			},
-			{
-				Name:             "minhash",
-				Type:             schemapb.FunctionType_MinHash,
-				InputFieldIds:    []int64{101},
-				InputFieldNames:  []string{"text"},
-				OutputFieldIds:   []int64{104},
-				OutputFieldNames: []string{"mh"},
-			},
-		},
-	})
-
 	numRows := 2
-	fieldsData := []*schemapb.FieldData{
-		{
-			FieldName: "text", FieldId: 101, Type: schemapb.DataType_VarChar,
-			Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"hello", "world"}}}}},
-		},
-		{
-			FieldName: "vec", FieldId: 102, Type: schemapb.DataType_FloatVector,
-			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{Dim: 4, Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: make([]float32, numRows*4)}}}},
-		},
-		{
-			FieldName: "sparse", FieldId: 103, Type: schemapb.DataType_SparseFloatVector,
-			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{Data: &schemapb.VectorField_SparseFloatVector{}}},
-		},
-		{
-			FieldName: "mh", FieldId: 104, Type: schemapb.DataType_BinaryVector,
-			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{Dim: 512, Data: &schemapb.VectorField_BinaryVector{BinaryVector: make([]byte, numRows*512/8)}}},
-		},
-	}
 
 	getFieldNames := func(data []*schemapb.FieldData) []string {
 		names := make([]string, 0, len(data))
@@ -1978,27 +1929,73 @@ func TestInsertPreExecute_FilterFunctionOutputFields(t *testing.T) {
 		return names
 	}
 
-	t.Run("partial update filters all function output fields", func(t *testing.T) {
+	t.Run("partial update filters BM25 and MinHash output fields", func(t *testing.T) {
 		m := mockey.Mock(common.AllocAutoID).Return(int64(1000), int64(1000+numRows), nil).Build()
 		defer m.UnPatch()
 
-		copiedData := make([]*schemapb.FieldData, len(fieldsData))
-		copy(copiedData, fieldsData)
+		schema := newSchemaInfo(&schemapb.CollectionSchema{
+			Name:   "test_filter_bm25_minhash",
+			AutoID: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true, AutoID: true},
+				{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar, TypeParams: []*commonpb.KeyValuePair{{Key: "max_length", Value: "2000"}}},
+				{FieldID: 102, Name: "vec", DataType: schemapb.DataType_FloatVector, TypeParams: []*commonpb.KeyValuePair{{Key: "dim", Value: "4"}}},
+				{FieldID: 103, Name: "sparse", DataType: schemapb.DataType_SparseFloatVector, IsFunctionOutput: true},
+				{FieldID: 104, Name: "mh", DataType: schemapb.DataType_BinaryVector, IsFunctionOutput: true, TypeParams: []*commonpb.KeyValuePair{{Key: "dim", Value: "512"}}},
+			},
+			Functions: []*schemapb.FunctionSchema{
+				{
+					Name:             "bm25",
+					Type:             schemapb.FunctionType_BM25,
+					InputFieldIds:    []int64{101},
+					InputFieldNames:  []string{"text"},
+					OutputFieldIds:   []int64{103},
+					OutputFieldNames: []string{"sparse"},
+				},
+				{
+					Name:             "minhash",
+					Type:             schemapb.FunctionType_MinHash,
+					InputFieldIds:    []int64{101},
+					InputFieldNames:  []string{"text"},
+					OutputFieldIds:   []int64{104},
+					OutputFieldNames: []string{"mh"},
+				},
+			},
+		})
+
+		fieldsData := []*schemapb.FieldData{
+			{
+				FieldName: "text", FieldId: 101, Type: schemapb.DataType_VarChar,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"hello", "world"}}}}},
+			},
+			{
+				FieldName: "vec", FieldId: 102, Type: schemapb.DataType_FloatVector,
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{Dim: 4, Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: make([]float32, numRows*4)}}}},
+			},
+			{
+				FieldName: "sparse", FieldId: 103, Type: schemapb.DataType_SparseFloatVector,
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{Data: &schemapb.VectorField_SparseFloatVector{}}},
+			},
+			{
+				FieldName: "mh", FieldId: 104, Type: schemapb.DataType_BinaryVector,
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{Dim: 512, Data: &schemapb.VectorField_BinaryVector{BinaryVector: make([]byte, numRows*512/8)}}},
+			},
+		}
 
 		task := &upsertTask{
 			ctx:         context.Background(),
 			schema:      schema,
 			idAllocator: &allocator.IDAllocator{},
 			req: &milvuspb.UpsertRequest{
-				CollectionName: "test_filter_func_output",
+				CollectionName: "test_filter_bm25_minhash",
 				PartialUpdate:  true,
 			},
 			upsertMsg: &msgstream.UpsertMsg{
 				InsertMsg: &msgstream.InsertMsg{
 					InsertRequest: &msgpb.InsertRequest{
-						CollectionName: "test_filter_func_output",
+						CollectionName: "test_filter_bm25_minhash",
 						Version:        msgpb.InsertDataVersion_ColumnBased,
-						FieldsData:     copiedData,
+						FieldsData:     fieldsData,
 						NumRows:        uint64(numRows),
 						PartitionName:  Params.CommonCfg.DefaultPartitionName.GetValue(),
 					},
@@ -2009,12 +2006,78 @@ func TestInsertPreExecute_FilterFunctionOutputFields(t *testing.T) {
 
 		_ = task.insertPreExecute(context.Background())
 
-		// Verify: sparse and mh (function outputs) should be filtered out
 		remainingFields := getFieldNames(task.upsertMsg.InsertMsg.GetFieldsData())
 		assert.NotContains(t, remainingFields, "sparse")
 		assert.NotContains(t, remainingFields, "mh")
 		assert.Contains(t, remainingFields, "text")
 		assert.Contains(t, remainingFields, "vec")
+	})
+
+	t.Run("partial update preserves non-BM25/MinHash function output fields", func(t *testing.T) {
+		m := mockey.Mock(common.AllocAutoID).Return(int64(1000), int64(1000+numRows), nil).Build()
+		defer m.UnPatch()
+
+		// Schema with a text embedding function (non-BM25/MinHash)
+		schema := newSchemaInfo(&schemapb.CollectionSchema{
+			Name:   "test_preserve_embedding",
+			AutoID: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true, AutoID: true},
+				{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar, TypeParams: []*commonpb.KeyValuePair{{Key: "max_length", Value: "2000"}}},
+				{FieldID: 102, Name: "embedding", DataType: schemapb.DataType_FloatVector, IsFunctionOutput: true, TypeParams: []*commonpb.KeyValuePair{{Key: "dim", Value: "4"}}},
+			},
+			Functions: []*schemapb.FunctionSchema{
+				{
+					Name:             "text_embedding",
+					Type:             schemapb.FunctionType_TextEmbedding,
+					InputFieldIds:    []int64{101},
+					InputFieldNames:  []string{"text"},
+					OutputFieldIds:   []int64{102},
+					OutputFieldNames: []string{"embedding"},
+				},
+			},
+		})
+
+		fieldsData := []*schemapb.FieldData{
+			{
+				FieldName: "text", FieldId: 101, Type: schemapb.DataType_VarChar,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"hello", "world"}}}}},
+			},
+			{
+				FieldName: "embedding", FieldId: 102, Type: schemapb.DataType_FloatVector,
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{Dim: 4, Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: make([]float32, numRows*4)}}}},
+			},
+		}
+
+		task := &upsertTask{
+			ctx:         context.Background(),
+			schema:      schema,
+			idAllocator: &allocator.IDAllocator{},
+			req: &milvuspb.UpsertRequest{
+				CollectionName: "test_preserve_embedding",
+				PartialUpdate:  true,
+			},
+			upsertMsg: &msgstream.UpsertMsg{
+				InsertMsg: &msgstream.InsertMsg{
+					InsertRequest: &msgpb.InsertRequest{
+						CollectionName: "test_preserve_embedding",
+						Version:        msgpb.InsertDataVersion_ColumnBased,
+						FieldsData:     fieldsData,
+						NumRows:        uint64(numRows),
+						PartitionName:  Params.CommonCfg.DefaultPartitionName.GetValue(),
+					},
+				},
+			},
+			result: &milvuspb.MutationResult{},
+		}
+
+		_ = task.insertPreExecute(context.Background())
+
+		// embedding (text embedding output) should NOT be filtered
+		remainingFields := getFieldNames(task.upsertMsg.InsertMsg.GetFieldsData())
+		assert.Contains(t, remainingFields, "text")
+		assert.Contains(t, remainingFields, "embedding")
+		assert.Len(t, remainingFields, 2)
 	})
 
 	t.Run("partial update with no functions keeps all fields", func(t *testing.T) {

--- a/internal/proxy/task_upsert_test.go
+++ b/internal/proxy/task_upsert_test.go
@@ -1915,3 +1915,445 @@ func TestUpsertTask_queryPreExecute_EmptyDataArray(t *testing.T) {
 		})
 	})
 }
+
+func TestInsertPreExecute_FilterFunctionOutputFields(t *testing.T) {
+	paramtable.Init()
+
+	// Schema with BM25 and MinHash functions
+	schema := newSchemaInfo(&schemapb.CollectionSchema{
+		Name:   "test_filter_func_output",
+		AutoID: true,
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true, AutoID: true},
+			{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar, TypeParams: []*commonpb.KeyValuePair{{Key: "max_length", Value: "2000"}}},
+			{FieldID: 102, Name: "vec", DataType: schemapb.DataType_FloatVector, TypeParams: []*commonpb.KeyValuePair{{Key: "dim", Value: "4"}}},
+			{FieldID: 103, Name: "sparse", DataType: schemapb.DataType_SparseFloatVector, IsFunctionOutput: true},
+			{FieldID: 104, Name: "mh", DataType: schemapb.DataType_BinaryVector, IsFunctionOutput: true, TypeParams: []*commonpb.KeyValuePair{{Key: "dim", Value: "512"}}},
+		},
+		Functions: []*schemapb.FunctionSchema{
+			{
+				Name:             "bm25",
+				Type:             schemapb.FunctionType_BM25,
+				InputFieldIds:    []int64{101},
+				InputFieldNames:  []string{"text"},
+				OutputFieldIds:   []int64{103},
+				OutputFieldNames: []string{"sparse"},
+			},
+			{
+				Name:             "minhash",
+				Type:             schemapb.FunctionType_MinHash,
+				InputFieldIds:    []int64{101},
+				InputFieldNames:  []string{"text"},
+				OutputFieldIds:   []int64{104},
+				OutputFieldNames: []string{"mh"},
+			},
+		},
+	})
+
+	numRows := 2
+	fieldsData := []*schemapb.FieldData{
+		{
+			FieldName: "text", FieldId: 101, Type: schemapb.DataType_VarChar,
+			Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"hello", "world"}}}}},
+		},
+		{
+			FieldName: "vec", FieldId: 102, Type: schemapb.DataType_FloatVector,
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{Dim: 4, Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: make([]float32, numRows*4)}}}},
+		},
+		{
+			FieldName: "sparse", FieldId: 103, Type: schemapb.DataType_SparseFloatVector,
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{Data: &schemapb.VectorField_SparseFloatVector{}}},
+		},
+		{
+			FieldName: "mh", FieldId: 104, Type: schemapb.DataType_BinaryVector,
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{Dim: 512, Data: &schemapb.VectorField_BinaryVector{BinaryVector: make([]byte, numRows*512/8)}}},
+		},
+	}
+
+	getFieldNames := func(data []*schemapb.FieldData) []string {
+		names := make([]string, 0, len(data))
+		for _, fd := range data {
+			names = append(names, fd.GetFieldName())
+		}
+		return names
+	}
+
+	t.Run("partial update filters all function output fields", func(t *testing.T) {
+		m := mockey.Mock(common.AllocAutoID).Return(int64(1000), int64(1000+numRows), nil).Build()
+		defer m.UnPatch()
+
+		copiedData := make([]*schemapb.FieldData, len(fieldsData))
+		copy(copiedData, fieldsData)
+
+		task := &upsertTask{
+			ctx:         context.Background(),
+			schema:      schema,
+			idAllocator: &allocator.IDAllocator{},
+			req: &milvuspb.UpsertRequest{
+				CollectionName: "test_filter_func_output",
+				PartialUpdate:  true,
+			},
+			upsertMsg: &msgstream.UpsertMsg{
+				InsertMsg: &msgstream.InsertMsg{
+					InsertRequest: &msgpb.InsertRequest{
+						CollectionName: "test_filter_func_output",
+						Version:        msgpb.InsertDataVersion_ColumnBased,
+						FieldsData:     copiedData,
+						NumRows:        uint64(numRows),
+						PartitionName:  Params.CommonCfg.DefaultPartitionName.GetValue(),
+					},
+				},
+			},
+			result: &milvuspb.MutationResult{},
+		}
+
+		_ = task.insertPreExecute(context.Background())
+
+		// Verify: sparse and mh (function outputs) should be filtered out
+		remainingFields := getFieldNames(task.upsertMsg.InsertMsg.GetFieldsData())
+		assert.NotContains(t, remainingFields, "sparse")
+		assert.NotContains(t, remainingFields, "mh")
+		assert.Contains(t, remainingFields, "text")
+		assert.Contains(t, remainingFields, "vec")
+	})
+
+	t.Run("partial update with no functions keeps all fields", func(t *testing.T) {
+		m := mockey.Mock(common.AllocAutoID).Return(int64(1000), int64(1000+numRows), nil).Build()
+		defer m.UnPatch()
+
+		noFuncSchema := newSchemaInfo(&schemapb.CollectionSchema{
+			Name:   "test_no_func",
+			AutoID: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true, AutoID: true},
+				{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar, TypeParams: []*commonpb.KeyValuePair{{Key: "max_length", Value: "2000"}}},
+				{FieldID: 102, Name: "vec", DataType: schemapb.DataType_FloatVector, TypeParams: []*commonpb.KeyValuePair{{Key: "dim", Value: "4"}}},
+			},
+		})
+
+		noFuncFieldsData := []*schemapb.FieldData{
+			{
+				FieldName: "text", FieldId: 101, Type: schemapb.DataType_VarChar,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"hello", "world"}}}}},
+			},
+			{
+				FieldName: "vec", FieldId: 102, Type: schemapb.DataType_FloatVector,
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{Dim: 4, Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: make([]float32, numRows*4)}}}},
+			},
+		}
+
+		task := &upsertTask{
+			ctx:         context.Background(),
+			schema:      noFuncSchema,
+			idAllocator: &allocator.IDAllocator{},
+			req: &milvuspb.UpsertRequest{
+				CollectionName: "test_no_func",
+				PartialUpdate:  true,
+			},
+			upsertMsg: &msgstream.UpsertMsg{
+				InsertMsg: &msgstream.InsertMsg{
+					InsertRequest: &msgpb.InsertRequest{
+						CollectionName: "test_no_func",
+						Version:        msgpb.InsertDataVersion_ColumnBased,
+						FieldsData:     noFuncFieldsData,
+						NumRows:        uint64(numRows),
+						PartitionName:  Params.CommonCfg.DefaultPartitionName.GetValue(),
+					},
+				},
+			},
+			result: &milvuspb.MutationResult{},
+		}
+
+		_ = task.insertPreExecute(context.Background())
+
+		remainingFields := getFieldNames(task.upsertMsg.InsertMsg.GetFieldsData())
+		assert.Contains(t, remainingFields, "text")
+		assert.Contains(t, remainingFields, "vec")
+		assert.Len(t, remainingFields, 2)
+	})
+}
+
+func TestUpsertTask_queryPreExecute_NullableFields(t *testing.T) {
+	dim := int64(4)
+
+	schema := newSchemaInfo(&schemapb.CollectionSchema{
+		Name: "test_nullable_vec",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "id", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+			{FieldID: 101, Name: "vector", DataType: schemapb.DataType_FloatVector, TypeParams: []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "4"}}},
+			{FieldID: 102, Name: "nullable_vec", DataType: schemapb.DataType_FloatVector, Nullable: true, TypeParams: []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "4"}}},
+		},
+	})
+
+	// Generate vector data: [pk, pk, pk, pk]
+	genVec := func(pk int64) []float32 {
+		return []float32{float32(pk), float32(pk), float32(pk), float32(pk)}
+	}
+
+	// Create all_columns upsert data (includes nullable_vec)
+	// nullable_vec = [pk+100, pk+100, pk+100, pk+100], ValidData = all true
+	createAllCols := func(pks []int64) []*schemapb.FieldData {
+		var ids []int64
+		var vecData, nullableData []float32
+		var validData []bool
+		for _, pk := range pks {
+			ids = append(ids, pk)
+			vecData = append(vecData, genVec(pk)...)
+			nullableData = append(nullableData, genVec(pk+100)...)
+			validData = append(validData, true)
+		}
+		return []*schemapb.FieldData{
+			{
+				FieldName: "id", FieldId: 100, Type: schemapb.DataType_Int64,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: ids}}}},
+			},
+			{
+				FieldName: "vector", FieldId: 101, Type: schemapb.DataType_FloatVector,
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{Dim: dim, Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: vecData}}}},
+			},
+			{
+				FieldName: "nullable_vec", FieldId: 102, Type: schemapb.DataType_FloatVector, ValidData: validData,
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{Dim: dim, Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: nullableData}}}},
+			},
+		}
+	}
+
+	// Create partial_columns upsert data (excludes nullable_vec)
+	createPartialCols := func(pks []int64) []*schemapb.FieldData {
+		var ids []int64
+		var vecData []float32
+		for _, pk := range pks {
+			ids = append(ids, pk)
+			vecData = append(vecData, genVec(pk)...)
+		}
+		return []*schemapb.FieldData{
+			{
+				FieldName: "id", FieldId: 100, Type: schemapb.DataType_Int64,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: ids}}}},
+			},
+			{
+				FieldName: "vector", FieldId: 101, Type: schemapb.DataType_FloatVector,
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{Dim: dim, Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: vecData}}}},
+			},
+		}
+	}
+
+	// Create mock query result
+	// existing nullable_vec = [pk+300, pk+300, pk+300, pk+300], ValidData = all true
+	queryResult := func(pks []int64) *milvuspb.QueryResults {
+		var ids []int64
+		var vecData, nullableData []float32
+		var validData []bool
+		for _, pk := range pks {
+			ids = append(ids, pk)
+			vecData = append(vecData, genVec(pk+200)...)
+			nullableData = append(nullableData, genVec(pk+300)...)
+			validData = append(validData, true)
+		}
+		return &milvuspb.QueryResults{
+			Status: merr.Success(),
+			FieldsData: []*schemapb.FieldData{
+				{
+					FieldName: "id", FieldId: 100, Type: schemapb.DataType_Int64,
+					Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: ids}}}},
+				},
+				{
+					FieldName: "vector", FieldId: 101, Type: schemapb.DataType_FloatVector,
+					Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{Dim: dim, Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: vecData}}}},
+				},
+				{
+					FieldName: "nullable_vec", FieldId: 102, Type: schemapb.DataType_FloatVector, ValidData: validData,
+					Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{Dim: dim, Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: nullableData}}}},
+				},
+			},
+		}
+	}
+
+	runUpsert := func(upsertData []*schemapb.FieldData, mockResult *milvuspb.QueryResults) *upsertTask {
+		numRows := uint32(len(upsertData[0].GetScalars().GetLongData().GetData()))
+		task := &upsertTask{
+			ctx:    context.Background(),
+			schema: schema,
+			req:    &milvuspb.UpsertRequest{FieldsData: upsertData, NumRows: numRows},
+			upsertMsg: &msgstream.UpsertMsg{InsertMsg: &msgstream.InsertMsg{
+				InsertRequest: &msgpb.InsertRequest{
+					FieldsData: upsertData,
+					NumRows:    uint64(numRows),
+					Version:    msgpb.InsertDataVersion_ColumnBased, // Required, otherwise NRows() returns 0
+				},
+			}},
+			node: &Proxy{},
+		}
+		mock := mockey.Mock(retrieveByPKs).Return(mockResult, segcore.StorageCost{}, nil).Build()
+		defer mock.UnPatch()
+		err := task.queryPreExecute(context.Background())
+		assert.NoError(t, err)
+		return task
+	}
+
+	// Step 1a: Empty data, upsert pk1(partial) -> insert, nullable_vec=null
+	task1a := runUpsert(createPartialCols([]int64{1}), queryResult(nil))
+	assert.Empty(t, task1a.deletePKs.GetIntId().GetData())
+	assert.Equal(t, []int64{1}, task1a.insertFieldData[0].GetScalars().GetLongData().GetData())
+	assert.Equal(t, []float32{1, 1, 1, 1}, task1a.insertFieldData[1].GetVectors().GetFloatVector().GetData())
+	assert.Equal(t, []bool{false}, task1a.insertFieldData[2].ValidData)
+	assert.Empty(t, task1a.insertFieldData[2].GetVectors().GetFloatVector().GetData())
+
+	// Step 1b: Empty data, upsert pk2(all) -> insert, nullable_vec=[102,...]
+	task1b := runUpsert(createAllCols([]int64{2}), queryResult(nil))
+	assert.Empty(t, task1b.deletePKs.GetIntId().GetData())
+	assert.Equal(t, []int64{2}, task1b.insertFieldData[0].GetScalars().GetLongData().GetData())
+	assert.Equal(t, []float32{2, 2, 2, 2}, task1b.insertFieldData[1].GetVectors().GetFloatVector().GetData())
+	assert.Equal(t, []float32{102, 102, 102, 102}, task1b.insertFieldData[2].GetVectors().GetFloatVector().GetData())
+
+	// Step 2a: pk1 exists, upsert pk1(all) -> update, nullable_vec=[101,...] (from upsert)
+	task2a := runUpsert(createAllCols([]int64{1}), queryResult([]int64{1}))
+	assert.Equal(t, []int64{1}, task2a.deletePKs.GetIntId().GetData())
+	assert.Equal(t, []int64{1}, task2a.insertFieldData[0].GetScalars().GetLongData().GetData())
+	assert.Equal(t, []float32{1, 1, 1, 1}, task2a.insertFieldData[1].GetVectors().GetFloatVector().GetData())
+	assert.Equal(t, []float32{101, 101, 101, 101}, task2a.insertFieldData[2].GetVectors().GetFloatVector().GetData())
+
+	// Step 2b: pk2 exists, upsert pk2(partial) -> update, nullable_vec=[302,...] (from existing)
+	task2b := runUpsert(createPartialCols([]int64{2}), queryResult([]int64{2}))
+	assert.Equal(t, []int64{2}, task2b.deletePKs.GetIntId().GetData())
+	assert.Equal(t, []int64{2}, task2b.insertFieldData[0].GetScalars().GetLongData().GetData())
+	assert.Equal(t, []float32{2, 2, 2, 2}, task2b.insertFieldData[1].GetVectors().GetFloatVector().GetData())
+	assert.Equal(t, []float32{302, 302, 302, 302}, task2b.insertFieldData[2].GetVectors().GetFloatVector().GetData())
+
+	// Step 3a: Empty data, upsert pk3(partial) -> insert, nullable_vec=null
+	task3a := runUpsert(createPartialCols([]int64{3}), queryResult(nil))
+	assert.Empty(t, task3a.deletePKs.GetIntId().GetData())
+	assert.Equal(t, []int64{3}, task3a.insertFieldData[0].GetScalars().GetLongData().GetData())
+	assert.Equal(t, []bool{false}, task3a.insertFieldData[2].ValidData)
+	assert.Empty(t, task3a.insertFieldData[2].GetVectors().GetFloatVector().GetData())
+
+	// Step 3b: Empty data, upsert pk4(all) -> insert, nullable_vec=[104,...]
+	task3b := runUpsert(createAllCols([]int64{4}), queryResult(nil))
+	assert.Empty(t, task3b.deletePKs.GetIntId().GetData())
+	assert.Equal(t, []int64{4}, task3b.insertFieldData[0].GetScalars().GetLongData().GetData())
+	assert.Equal(t, []float32{104, 104, 104, 104}, task3b.insertFieldData[2].GetVectors().GetFloatVector().GetData())
+
+	// Step 4a: pk3,pk4 exist, upsert pk3,pk4,pk5,pk6(all) -> pk3,pk4 update, pk5,pk6 insert
+	task4a := runUpsert(createAllCols([]int64{3, 4, 5, 6}), queryResult([]int64{3, 4}))
+	assert.Equal(t, []int64{3, 4}, task4a.deletePKs.GetIntId().GetData())
+	assert.Equal(t, []int64{3, 4, 5, 6}, task4a.insertFieldData[0].GetScalars().GetLongData().GetData())
+	assert.Equal(t, []float32{3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6}, task4a.insertFieldData[1].GetVectors().GetFloatVector().GetData())
+	assert.Equal(t, []float32{103, 103, 103, 103, 104, 104, 104, 104, 105, 105, 105, 105, 106, 106, 106, 106}, task4a.insertFieldData[2].GetVectors().GetFloatVector().GetData())
+
+	// Step 4b: pk3,pk4 exist, upsert pk3,pk4,pk5,pk6(partial) -> pk3,pk4 update (use existing), pk5,pk6 insert (null)
+	task4b := runUpsert(createPartialCols([]int64{3, 4, 5, 6}), queryResult([]int64{3, 4}))
+	assert.Equal(t, []int64{3, 4}, task4b.deletePKs.GetIntId().GetData())
+	assert.Equal(t, []int64{3, 4, 5, 6}, task4b.insertFieldData[0].GetScalars().GetLongData().GetData())
+	// Update rows pk3,pk4: nullable_vec from existing data (ValidData=true)
+	// Insert rows pk5,pk6: nullable_vec generated by GenNullableFieldData (null, ValidData=false)
+	// ValidData has 4 elements, FloatVector only contains data for ValidData=true rows
+	assert.Equal(t, []bool{true, true, false, false}, task4b.insertFieldData[2].ValidData)
+	assert.Equal(t, []float32{303, 303, 303, 303, 304, 304, 304, 304}, task4b.insertFieldData[2].GetVectors().GetFloatVector().GetData())
+}
+
+func TestUpsertTask_GenNullableFieldData(t *testing.T) {
+	upsertIDSize := 5
+
+	t.Run("scalar_types", func(t *testing.T) {
+		testCases := []struct {
+			name     string
+			dataType schemapb.DataType
+		}{
+			{"Bool", schemapb.DataType_Bool},
+			{"Int32", schemapb.DataType_Int32},
+			{"Int64", schemapb.DataType_Int64},
+			{"Float", schemapb.DataType_Float},
+			{"Double", schemapb.DataType_Double},
+			{"VarChar", schemapb.DataType_VarChar},
+			{"JSON", schemapb.DataType_JSON},
+			{"Array", schemapb.DataType_Array},
+			{"Timestamptz", schemapb.DataType_Timestamptz},
+			{"Geometry", schemapb.DataType_Geometry},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				field := &schemapb.FieldSchema{
+					FieldID:  100,
+					Name:     "test_field",
+					DataType: tc.dataType,
+					Nullable: true,
+				}
+				result, err := GenNullableFieldData(field, upsertIDSize)
+				assert.NoError(t, err)
+				assert.NotNil(t, result)
+				assert.Equal(t, field.FieldID, result.FieldId)
+				assert.Equal(t, field.Name, result.FieldName)
+				assert.Equal(t, tc.dataType, result.Type)
+				assert.Equal(t, upsertIDSize, len(result.ValidData))
+				// All ValidData should be false (null)
+				for _, v := range result.ValidData {
+					assert.False(t, v)
+				}
+			})
+		}
+	})
+
+	t.Run("vector_types", func(t *testing.T) {
+		testCases := []struct {
+			name     string
+			dataType schemapb.DataType
+		}{
+			{"FloatVector", schemapb.DataType_FloatVector},
+			{"Float16Vector", schemapb.DataType_Float16Vector},
+			{"BFloat16Vector", schemapb.DataType_BFloat16Vector},
+			{"BinaryVector", schemapb.DataType_BinaryVector},
+			{"Int8Vector", schemapb.DataType_Int8Vector},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				field := &schemapb.FieldSchema{
+					FieldID:    100,
+					Name:       "test_vector",
+					DataType:   tc.dataType,
+					Nullable:   true,
+					TypeParams: []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "128"}},
+				}
+				result, err := GenNullableFieldData(field, upsertIDSize)
+				assert.NoError(t, err)
+				assert.NotNil(t, result)
+				assert.Equal(t, field.FieldID, result.FieldId)
+				assert.Equal(t, field.Name, result.FieldName)
+				assert.Equal(t, tc.dataType, result.Type)
+				assert.Equal(t, upsertIDSize, len(result.ValidData))
+				// All ValidData should be false (null)
+				for _, v := range result.ValidData {
+					assert.False(t, v)
+				}
+				assert.NotNil(t, result.GetVectors())
+			})
+		}
+	})
+
+	t.Run("sparse_float_vector", func(t *testing.T) {
+		field := &schemapb.FieldSchema{
+			FieldID:  100,
+			Name:     "test_sparse",
+			DataType: schemapb.DataType_SparseFloatVector,
+			Nullable: true,
+		}
+		result, err := GenNullableFieldData(field, upsertIDSize)
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, upsertIDSize, len(result.ValidData))
+		assert.NotNil(t, result.GetVectors().GetSparseFloatVector())
+	})
+
+	t.Run("unsupported_type", func(t *testing.T) {
+		field := &schemapb.FieldSchema{
+			FieldID:  100,
+			Name:     "test_unsupported",
+			DataType: schemapb.DataType_None,
+			Nullable: true,
+		}
+		result, err := GenNullableFieldData(field, upsertIDSize)
+		assert.Error(t, err)
+		assert.Nil(t, result)
+	})
+}

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -2719,6 +2719,16 @@ func GetBM25FunctionOutputFields(collSchema *schemapb.CollectionSchema) []string
 	return fields
 }
 
+func GetMinHashFunctionOutputFields(collSchema *schemapb.CollectionSchema) []string {
+	fields := make([]string, 0)
+	for _, fSchema := range collSchema.Functions {
+		if fSchema.Type == schemapb.FunctionType_MinHash {
+			fields = append(fields, fSchema.OutputFieldNames...)
+		}
+	}
+	return fields
+}
+
 // getCollectionTTL returns ttl if collection's ttl is specified
 // or return global ttl if collection's ttl is not specified
 // this is a helper util wrapping common.GetCollectionTTL without returning error


### PR DESCRIPTION
pr: #47930

Cherry-pick of #47930 to release-2.6.

- Use generic `GetFunctionOutputFields` for partial update filtering
- Only filter BM25 and MinHash output fields in partial update

Signed-off-by: Wei Liu <wei.liu@zilliz.com>