### PR TITLE
fix: [2.6] send ConfirmedTimeTick for skipped replicate messages to advance checkpoint

### DIFF
--- a/internal/distributed/streaming/replicate_service.go
+++ b/internal/distributed/streaming/replicate_service.go
@@ -18,10 +18,22 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
+// buildSkipMessageTypes builds a set of message type names to skip during replication.
+func buildSkipMessageTypes(types []string) map[string]struct{} {
+	m := make(map[string]struct{}, len(types))
+	for _, t := range types {
+		if t != "" {
+			m[t] = struct{}{}
+		}
+	}
+	return m
+}
+
 var _ ReplicateService = replicateService{}
 
 type replicateService struct {
 	*walAccesserImpl
+	skipMessageTypes map[string]struct{}
 }
 
 // Append appends the message into current cluster.
@@ -82,21 +94,15 @@ func (s replicateService) GetReplicateCheckpoint(ctx context.Context, channelNam
 }
 
 // shouldSkipReplicateMessageType checks if the given message type should be skipped during replication.
-func shouldSkipReplicateMessageType(msgType message.MessageType) bool {
-	skipTypes := paramtable.Get().StreamingCfg.ReplicationSkipMessageTypes.GetAsStrings()
-	typeName := msgType.String()
-	for _, s := range skipTypes {
-		if s == typeName {
-			return true
-		}
-	}
-	return false
+func (s replicateService) shouldSkipReplicateMessageType(msgType message.MessageType) bool {
+	_, ok := s.skipMessageTypes[msgType.String()]
+	return ok
 }
 
 // overwriteReplicateMessage overwrites the replicate message.
 // because some message such as create collection message write vchannel in its body, so we need to overwrite the message.
 func (s replicateService) overwriteReplicateMessage(ctx context.Context, msg message.ReplicateMutableMessage, rh *message.ReplicateHeader) (message.MutableMessage, error) {
-	if shouldSkipReplicateMessageType(msg.MessageType()) {
+	if s.shouldSkipReplicateMessageType(msg.MessageType()) {
 		return nil, status.NewIgnoreOperation("message type %s is configured to be skipped during replication", msg.MessageType())
 	}
 

--- a/internal/distributed/streaming/replicate_service_test.go
+++ b/internal/distributed/streaming/replicate_service_test.go
@@ -223,7 +223,7 @@ func TestReplicateService_GetReplicateConfiguration(t *testing.T) {
 }
 
 func TestReplicateService_SkipMessageTypes(t *testing.T) {
-	newReplicateService := func(t *testing.T) *replicateService {
+	newReplicateService := func(t *testing.T, skipTypes map[string]struct{}) *replicateService {
 		c := mock_client.NewMockClient(t)
 		as := mock_client.NewMockAssignmentService(t)
 		c.EXPECT().Assignment().Return(as).Maybe()
@@ -258,14 +258,14 @@ func TestReplicateService_SkipMessageTypes(t *testing.T) {
 				handlerClient:        h,
 				producers:            make(map[string]*producer.ResumableProducer),
 			},
+			skipMessageTypes: skipTypes,
 		}
 	}
 
-	t.Run("skip_AlterResourceGroup", func(t *testing.T) {
-		old := paramtable.Get().StreamingCfg.ReplicationSkipMessageTypes.SwapTempValue("AlterResourceGroup,DropResourceGroup")
-		defer paramtable.Get().StreamingCfg.ReplicationSkipMessageTypes.SwapTempValue(old)
+	skipSet := buildSkipMessageTypes([]string{"AlterResourceGroup", "DropResourceGroup"})
 
-		rs := newReplicateService(t)
+	t.Run("skip_AlterResourceGroup", func(t *testing.T) {
+		rs := newReplicateService(t, skipSet)
 		broadcastMsg := message.NewAlterResourceGroupMessageBuilderV2().
 			WithHeader(&message.AlterResourceGroupMessageHeader{}).
 			WithBody(&message.AlterResourceGroupMessageBody{}).
@@ -282,10 +282,7 @@ func TestReplicateService_SkipMessageTypes(t *testing.T) {
 	})
 
 	t.Run("skip_DropResourceGroup", func(t *testing.T) {
-		old := paramtable.Get().StreamingCfg.ReplicationSkipMessageTypes.SwapTempValue("AlterResourceGroup,DropResourceGroup")
-		defer paramtable.Get().StreamingCfg.ReplicationSkipMessageTypes.SwapTempValue(old)
-
-		rs := newReplicateService(t)
+		rs := newReplicateService(t, skipSet)
 		broadcastMsg := message.NewDropResourceGroupMessageBuilderV2().
 			WithHeader(&message.DropResourceGroupMessageHeader{ResourceGroupName: "test_rg"}).
 			WithBody(&message.DropResourceGroupMessageBody{}).
@@ -302,10 +299,7 @@ func TestReplicateService_SkipMessageTypes(t *testing.T) {
 	})
 
 	t.Run("non_skipped_message_passthrough", func(t *testing.T) {
-		old := paramtable.Get().StreamingCfg.ReplicationSkipMessageTypes.SwapTempValue("AlterResourceGroup,DropResourceGroup")
-		defer paramtable.Get().StreamingCfg.ReplicationSkipMessageTypes.SwapTempValue(old)
-
-		rs := newReplicateService(t)
+		rs := newReplicateService(t, skipSet)
 		replicateMsgs := createReplicateCreateCollectionMessages()
 		for _, msg := range replicateMsgs {
 			_, err := rs.Append(context.Background(), msg)
@@ -314,10 +308,7 @@ func TestReplicateService_SkipMessageTypes(t *testing.T) {
 	})
 
 	t.Run("empty_skip_list", func(t *testing.T) {
-		old := paramtable.Get().StreamingCfg.ReplicationSkipMessageTypes.SwapTempValue("")
-		defer paramtable.Get().StreamingCfg.ReplicationSkipMessageTypes.SwapTempValue(old)
-
-		rs := newReplicateService(t)
+		rs := newReplicateService(t, buildSkipMessageTypes(nil))
 		replicateMsgs := createReplicateCreateCollectionMessages()
 		for _, msg := range replicateMsgs {
 			_, err := rs.Append(context.Background(), msg)
@@ -657,6 +648,29 @@ func TestReplicateService_AlterLoadConfigUseLocalReplicaConfig(t *testing.T) {
 			_, err := rs.Append(context.Background(), msg)
 			assert.NoError(t, err)
 		}
+	})
+}
+
+func TestBuildSkipMessageTypes(t *testing.T) {
+	t.Run("normal", func(t *testing.T) {
+		m := buildSkipMessageTypes([]string{"AlterResourceGroup", "DropResourceGroup"})
+		assert.Len(t, m, 2)
+		_, ok := m["AlterResourceGroup"]
+		assert.True(t, ok)
+		_, ok = m["DropResourceGroup"]
+		assert.True(t, ok)
+	})
+
+	t.Run("empty_strings_filtered", func(t *testing.T) {
+		m := buildSkipMessageTypes([]string{"", "AlterResourceGroup", ""})
+		assert.Len(t, m, 1)
+		_, ok := m["AlterResourceGroup"]
+		assert.True(t, ok)
+	})
+
+	t.Run("nil_input", func(t *testing.T) {
+		m := buildSkipMessageTypes(nil)
+		assert.Empty(t, m)
 	})
 }
 

--- a/internal/distributed/streaming/wal.go
+++ b/internal/distributed/streaming/wal.go
@@ -70,7 +70,10 @@ func (w *walAccesserImpl) ForwardService() ForwardService {
 }
 
 func (w *walAccesserImpl) Replicate() ReplicateService {
-	return replicateService{w}
+	return replicateService{
+		walAccesserImpl:  w,
+		skipMessageTypes: buildSkipMessageTypes(paramtable.Get().StreamingCfg.ReplicationSkipMessageTypes.GetAsStrings()),
+	}
 }
 
 func (w *walAccesserImpl) Balancer() Balancer {

--- a/internal/proxy/replicate/replicate_stream_server.go
+++ b/internal/proxy/replicate/replicate_stream_server.go
@@ -133,6 +133,7 @@ func (p *ReplicateStreamServer) handleReplicateMessage(req *milvuspb.ReplicateRe
 	}
 	if status.AsStreamingError(err).IsIgnoredOperation() {
 		log.Info("append replicate message to wal ignored", log.FieldMessage(msg), zap.Error(err))
+		p.sendReplicateResult(sourceTs, msg)
 		return nil
 	}
 	// unexpected error, will close the stream and wait for client to reconnect.

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -6614,7 +6614,7 @@ type streamingConfig struct {
 	FlushEmptyTimeTickMaxFilterInterval     ParamItem `refreshable:"true"`
 
 	// Replication filtering configuration
-	ReplicationSkipMessageTypes ParamItem `refreshable:"true"`
+	ReplicationSkipMessageTypes ParamItem `refreshable:"false"`
 
 	// Replication configuration
 	ReplicationUseLocalReplicaConfig ParamItem `refreshable:"true"`


### PR DESCRIPTION
pr: #47777

This cherry-picks the fix commit from master PR #47777 that was missing in #47910.

Changes:
- Send ConfirmedTimeTick for ignored messages so checkpoint advances past skipped messages
- Replace linear scan with map lookup for skip message types
- Mark ReplicationSkipMessageTypes as refreshable:false