### PR TITLE
fix: preserve trailing slash semantics for meta KV prefix paths

### DIFF
--- a/internal/kv/etcd/embed_etcd_kv.go
+++ b/internal/kv/etcd/embed_etcd_kv.go
@@ -19,7 +19,6 @@ package etcdkv
 import (
 	"context"
 	"fmt"
-	"path"
 	"sync"
 	"time"
 
@@ -33,6 +32,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/kv"
 	"github.com/milvus-io/milvus/pkg/v2/kv/predicates"
 	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/util"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
@@ -120,11 +120,11 @@ func (kv *EmbedEtcdKV) Close() {
 
 // GetPath returns the full path by given key
 func (kv *EmbedEtcdKV) GetPath(key string) string {
-	return path.Join(kv.rootPath, key)
+	return util.GetPath(kv.rootPath, key)
 }
 
 func (kv *EmbedEtcdKV) WalkWithPrefix(ctx context.Context, prefix string, paginationSize int, fn func([]byte, []byte) error) error {
-	prefix = path.Join(kv.rootPath, prefix)
+	prefix = kv.GetPath(prefix)
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
 	defer cancel()
 
@@ -159,7 +159,7 @@ func (kv *EmbedEtcdKV) WalkWithPrefix(ctx context.Context, prefix string, pagina
 
 // LoadWithPrefix returns all the keys and values with the given key prefix
 func (kv *EmbedEtcdKV) LoadWithPrefix(ctx context.Context, key string) ([]string, []string, error) {
-	key = path.Join(kv.rootPath, key)
+	key = kv.GetPath(key)
 	log.Ctx(ctx).Debug("LoadWithPrefix ", zap.String("prefix", key))
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
 	defer cancel()
@@ -179,7 +179,7 @@ func (kv *EmbedEtcdKV) LoadWithPrefix(ctx context.Context, key string) ([]string
 }
 
 func (kv *EmbedEtcdKV) Has(ctx context.Context, key string) (bool, error) {
-	key = path.Join(kv.rootPath, key)
+	key = kv.GetPath(key)
 	log.Ctx(ctx).Debug("Has", zap.String("key", key))
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
 	defer cancel()
@@ -191,7 +191,7 @@ func (kv *EmbedEtcdKV) Has(ctx context.Context, key string) (bool, error) {
 }
 
 func (kv *EmbedEtcdKV) HasPrefix(ctx context.Context, prefix string) (bool, error) {
-	prefix = path.Join(kv.rootPath, prefix)
+	prefix = kv.GetPath(prefix)
 	log.Ctx(ctx).Debug("HasPrefix", zap.String("prefix", prefix))
 
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
@@ -207,7 +207,7 @@ func (kv *EmbedEtcdKV) HasPrefix(ctx context.Context, prefix string) (bool, erro
 
 // LoadBytesWithPrefix returns all the keys and values with the given key prefix
 func (kv *EmbedEtcdKV) LoadBytesWithPrefix(ctx context.Context, key string) ([]string, [][]byte, error) {
-	key = path.Join(kv.rootPath, key)
+	key = kv.GetPath(key)
 	log.Ctx(ctx).Debug("LoadBytesWithPrefix ", zap.String("prefix", key))
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
 	defer cancel()
@@ -227,7 +227,7 @@ func (kv *EmbedEtcdKV) LoadBytesWithPrefix(ctx context.Context, key string) ([]s
 
 // LoadBytesWithPrefix2 returns all the keys and values with versions by the given key prefix
 func (kv *EmbedEtcdKV) LoadBytesWithPrefix2(ctx context.Context, key string) ([]string, [][]byte, []int64, error) {
-	key = path.Join(kv.rootPath, key)
+	key = kv.GetPath(key)
 	log.Ctx(ctx).Debug("LoadBytesWithPrefix2 ", zap.String("prefix", key))
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
 	defer cancel()
@@ -249,7 +249,7 @@ func (kv *EmbedEtcdKV) LoadBytesWithPrefix2(ctx context.Context, key string) ([]
 
 // Load returns value of the given key
 func (kv *EmbedEtcdKV) Load(ctx context.Context, key string) (string, error) {
-	key = path.Join(kv.rootPath, key)
+	key = kv.GetPath(key)
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
 	defer cancel()
 	resp, err := kv.client.Get(ctx1, key)
@@ -265,7 +265,7 @@ func (kv *EmbedEtcdKV) Load(ctx context.Context, key string) (string, error) {
 
 // LoadBytes returns value of the given key
 func (kv *EmbedEtcdKV) LoadBytes(ctx context.Context, key string) ([]byte, error) {
-	key = path.Join(kv.rootPath, key)
+	key = kv.GetPath(key)
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
 	defer cancel()
 	resp, err := kv.client.Get(ctx1, key)
@@ -283,7 +283,7 @@ func (kv *EmbedEtcdKV) LoadBytes(ctx context.Context, key string) ([]byte, error
 func (kv *EmbedEtcdKV) MultiLoad(ctx context.Context, keys []string) ([]string, error) {
 	ops := make([]clientv3.Op, 0, len(keys))
 	for _, keyLoad := range keys {
-		ops = append(ops, clientv3.OpGet(path.Join(kv.rootPath, keyLoad)))
+		ops = append(ops, clientv3.OpGet(kv.GetPath(keyLoad)))
 	}
 
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
@@ -319,7 +319,7 @@ func (kv *EmbedEtcdKV) MultiLoad(ctx context.Context, keys []string) ([]string, 
 func (kv *EmbedEtcdKV) MultiLoadBytes(ctx context.Context, keys []string) ([][]byte, error) {
 	ops := make([]clientv3.Op, 0, len(keys))
 	for _, keyLoad := range keys {
-		ops = append(ops, clientv3.OpGet(path.Join(kv.rootPath, keyLoad)))
+		ops = append(ops, clientv3.OpGet(kv.GetPath(keyLoad)))
 	}
 
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
@@ -353,7 +353,7 @@ func (kv *EmbedEtcdKV) MultiLoadBytes(ctx context.Context, keys []string) ([][]b
 
 // LoadBytesWithRevision returns keys, values and revision with given key prefix.
 func (kv *EmbedEtcdKV) LoadBytesWithRevision(ctx context.Context, key string) ([]string, [][]byte, int64, error) {
-	key = path.Join(kv.rootPath, key)
+	key = kv.GetPath(key)
 	log.Ctx(ctx).Debug("LoadBytesWithRevision ", zap.String("prefix", key))
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
 	defer cancel()
@@ -373,7 +373,7 @@ func (kv *EmbedEtcdKV) LoadBytesWithRevision(ctx context.Context, key string) ([
 
 // Save saves the key-value pair.
 func (kv *EmbedEtcdKV) Save(ctx context.Context, key, value string) error {
-	key = path.Join(kv.rootPath, key)
+	key = kv.GetPath(key)
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
 	defer cancel()
 	_, err := kv.client.Put(ctx1, key, value)
@@ -382,7 +382,7 @@ func (kv *EmbedEtcdKV) Save(ctx context.Context, key, value string) error {
 
 // SaveBytes saves the key-value pair.
 func (kv *EmbedEtcdKV) SaveBytes(ctx context.Context, key string, value []byte) error {
-	key = path.Join(kv.rootPath, key)
+	key = kv.GetPath(key)
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
 	defer cancel()
 	_, err := kv.client.Put(ctx1, key, string(value))
@@ -391,7 +391,7 @@ func (kv *EmbedEtcdKV) SaveBytes(ctx context.Context, key string, value []byte) 
 
 // SaveBytesWithLease is a function to put value in etcd with etcd lease options.
 func (kv *EmbedEtcdKV) SaveBytesWithLease(ctx context.Context, key string, value []byte, id clientv3.LeaseID) error {
-	key = path.Join(kv.rootPath, key)
+	key = kv.GetPath(key)
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
 	defer cancel()
 	_, err := kv.client.Put(ctx1, key, string(value), clientv3.WithLease(id))
@@ -402,7 +402,7 @@ func (kv *EmbedEtcdKV) SaveBytesWithLease(ctx context.Context, key string, value
 func (kv *EmbedEtcdKV) MultiSave(ctx context.Context, kvs map[string]string) error {
 	ops := make([]clientv3.Op, 0, len(kvs))
 	for key, value := range kvs {
-		ops = append(ops, clientv3.OpPut(path.Join(kv.rootPath, key), value))
+		ops = append(ops, clientv3.OpPut(kv.GetPath(key), value))
 	}
 
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
@@ -416,7 +416,7 @@ func (kv *EmbedEtcdKV) MultiSave(ctx context.Context, kvs map[string]string) err
 func (kv *EmbedEtcdKV) MultiSaveBytes(ctx context.Context, kvs map[string][]byte) error {
 	ops := make([]clientv3.Op, 0, len(kvs))
 	for key, value := range kvs {
-		ops = append(ops, clientv3.OpPut(path.Join(kv.rootPath, key), string(value)))
+		ops = append(ops, clientv3.OpPut(kv.GetPath(key), string(value)))
 	}
 
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
@@ -428,7 +428,7 @@ func (kv *EmbedEtcdKV) MultiSaveBytes(ctx context.Context, kvs map[string][]byte
 
 // RemoveWithPrefix removes the keys with given prefix.
 func (kv *EmbedEtcdKV) RemoveWithPrefix(ctx context.Context, prefix string) error {
-	key := path.Join(kv.rootPath, prefix)
+	key := kv.GetPath(prefix)
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
 	defer cancel()
 
@@ -438,7 +438,7 @@ func (kv *EmbedEtcdKV) RemoveWithPrefix(ctx context.Context, prefix string) erro
 
 // Remove removes the key.
 func (kv *EmbedEtcdKV) Remove(ctx context.Context, key string) error {
-	key = path.Join(kv.rootPath, key)
+	key = kv.GetPath(key)
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
 	defer cancel()
 
@@ -450,7 +450,7 @@ func (kv *EmbedEtcdKV) Remove(ctx context.Context, key string) error {
 func (kv *EmbedEtcdKV) MultiRemove(ctx context.Context, keys []string) error {
 	ops := make([]clientv3.Op, 0, len(keys))
 	for _, key := range keys {
-		ops = append(ops, clientv3.OpDelete(path.Join(kv.rootPath, key)))
+		ops = append(ops, clientv3.OpDelete(kv.GetPath(key)))
 	}
 
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
@@ -474,11 +474,11 @@ func (kv *EmbedEtcdKV) MultiSaveAndRemove(ctx context.Context, saves map[string]
 	removals = removeKeys.Complement(saveKeys).Collect()
 
 	for _, keyDelete := range removals {
-		ops = append(ops, clientv3.OpDelete(path.Join(kv.rootPath, keyDelete)))
+		ops = append(ops, clientv3.OpDelete(kv.GetPath(keyDelete)))
 	}
 
 	for key, value := range saves {
-		ops = append(ops, clientv3.OpPut(path.Join(kv.rootPath, key), value))
+		ops = append(ops, clientv3.OpPut(kv.GetPath(key), value))
 	}
 
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
@@ -500,11 +500,11 @@ func (kv *EmbedEtcdKV) MultiSaveBytesAndRemove(ctx context.Context, saves map[st
 	ops := make([]clientv3.Op, 0, len(saves)+len(removals))
 
 	for _, keyDelete := range removals {
-		ops = append(ops, clientv3.OpDelete(path.Join(kv.rootPath, keyDelete)))
+		ops = append(ops, clientv3.OpDelete(kv.GetPath(keyDelete)))
 	}
 
 	for key, value := range saves {
-		ops = append(ops, clientv3.OpPut(path.Join(kv.rootPath, key), string(value)))
+		ops = append(ops, clientv3.OpPut(kv.GetPath(key), string(value)))
 	}
 
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
@@ -515,19 +515,19 @@ func (kv *EmbedEtcdKV) MultiSaveBytesAndRemove(ctx context.Context, saves map[st
 }
 
 func (kv *EmbedEtcdKV) Watch(ctx context.Context, key string) clientv3.WatchChan {
-	key = path.Join(kv.rootPath, key)
+	key = kv.GetPath(key)
 	rch := kv.client.Watch(context.Background(), key, clientv3.WithCreatedNotify())
 	return rch
 }
 
 func (kv *EmbedEtcdKV) WatchWithPrefix(ctx context.Context, key string) clientv3.WatchChan {
-	key = path.Join(kv.rootPath, key)
+	key = kv.GetPath(key)
 	rch := kv.client.Watch(context.Background(), key, clientv3.WithPrefix(), clientv3.WithCreatedNotify())
 	return rch
 }
 
 func (kv *EmbedEtcdKV) WatchWithRevision(ctx context.Context, key string, revision int64) clientv3.WatchChan {
-	key = path.Join(kv.rootPath, key)
+	key = kv.GetPath(key)
 	rch := kv.client.Watch(context.Background(), key, clientv3.WithPrefix(), clientv3.WithPrevKV(), clientv3.WithRev(revision))
 	return rch
 }
@@ -541,11 +541,11 @@ func (kv *EmbedEtcdKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves m
 
 	ops := make([]clientv3.Op, 0, len(saves)+len(removals))
 	for _, keyDelete := range removals {
-		ops = append(ops, clientv3.OpDelete(path.Join(kv.rootPath, keyDelete), clientv3.WithPrefix()))
+		ops = append(ops, clientv3.OpDelete(kv.GetPath(keyDelete), clientv3.WithPrefix()))
 	}
 
 	for key, value := range saves {
-		ops = append(ops, clientv3.OpPut(path.Join(kv.rootPath, key), value))
+		ops = append(ops, clientv3.OpPut(kv.GetPath(key), value))
 	}
 
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
@@ -566,11 +566,11 @@ func (kv *EmbedEtcdKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves m
 func (kv *EmbedEtcdKV) MultiSaveBytesAndRemoveWithPrefix(ctx context.Context, saves map[string][]byte, removals []string) error {
 	ops := make([]clientv3.Op, 0, len(saves)+len(removals))
 	for key, value := range saves {
-		ops = append(ops, clientv3.OpPut(path.Join(kv.rootPath, key), string(value)))
+		ops = append(ops, clientv3.OpPut(kv.GetPath(key), string(value)))
 	}
 
 	for _, keyDelete := range removals {
-		ops = append(ops, clientv3.OpDelete(path.Join(kv.rootPath, keyDelete), clientv3.WithPrefix()))
+		ops = append(ops, clientv3.OpDelete(kv.GetPath(keyDelete), clientv3.WithPrefix()))
 	}
 
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
@@ -587,10 +587,10 @@ func (kv *EmbedEtcdKV) CompareVersionAndSwap(ctx context.Context, key string, ve
 	defer cancel()
 	resp, err := kv.client.Txn(ctx1).If(
 		clientv3.Compare(
-			clientv3.Version(path.Join(kv.rootPath, key)),
+			clientv3.Version(kv.GetPath(key)),
 			"=",
 			version)).
-		Then(clientv3.OpPut(path.Join(kv.rootPath, key), target)).Commit()
+		Then(clientv3.OpPut(kv.GetPath(key), target)).Commit()
 	if err != nil {
 		return false, err
 	}
@@ -604,10 +604,10 @@ func (kv *EmbedEtcdKV) CompareVersionAndSwapBytes(ctx context.Context, key strin
 	defer cancel()
 	resp, err := kv.client.Txn(ctx1).If(
 		clientv3.Compare(
-			clientv3.Version(path.Join(kv.rootPath, key)),
+			clientv3.Version(kv.GetPath(key)),
 			"=",
 			version)).
-		Then(clientv3.OpPut(path.Join(kv.rootPath, key), string(target), opts...)).Commit()
+		Then(clientv3.OpPut(kv.GetPath(key), string(target), opts...)).Commit()
 	if err != nil {
 		return false, err
 	}

--- a/internal/kv/etcd/etcd_kv.go
+++ b/internal/kv/etcd/etcd_kv.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	"path"
 	"time"
 
 	"github.com/samber/lo"
@@ -31,6 +30,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/kv/predicates"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/metrics"
+	"github.com/milvus-io/milvus/pkg/v2/util"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/timerecord"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
@@ -74,12 +74,12 @@ func (kv *etcdKV) Close() {
 
 // GetPath returns the path of the key.
 func (kv *etcdKV) GetPath(key string) string {
-	return path.Join(kv.rootPath, key)
+	return util.GetPath(kv.rootPath, key)
 }
 
 func (kv *etcdKV) WalkWithPrefix(ctx context.Context, prefix string, paginationSize int, fn func([]byte, []byte) error) error {
 	start := time.Now()
-	prefix = path.Join(kv.rootPath, prefix)
+	prefix = kv.GetPath(prefix)
 
 	batch := int64(paginationSize)
 	opts := []clientv3.OpOption{
@@ -120,7 +120,7 @@ func (kv *etcdKV) WalkWithPrefix(ctx context.Context, prefix string, paginationS
 // LoadWithPrefix returns all the keys and values with the given key prefix.
 func (kv *etcdKV) LoadWithPrefix(ctx context.Context, key string) ([]string, []string, error) {
 	start := time.Now()
-	key = path.Join(kv.rootPath, key)
+	key = kv.GetPath(key)
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
 	defer cancel()
 	resp, err := kv.getEtcdMeta(ctx1, key, clientv3.WithPrefix(),
@@ -140,7 +140,7 @@ func (kv *etcdKV) LoadWithPrefix(ctx context.Context, key string) ([]string, []s
 
 func (kv *etcdKV) Has(ctx context.Context, key string) (bool, error) {
 	start := time.Now()
-	key = path.Join(kv.rootPath, key)
+	key = kv.GetPath(key)
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
 	defer cancel()
 
@@ -155,7 +155,7 @@ func (kv *etcdKV) Has(ctx context.Context, key string) (bool, error) {
 
 func (kv *etcdKV) HasPrefix(ctx context.Context, prefix string) (bool, error) {
 	start := time.Now()
-	prefix = path.Join(kv.rootPath, prefix)
+	prefix = kv.GetPath(prefix)
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
 	defer cancel()
 
@@ -171,7 +171,7 @@ func (kv *etcdKV) HasPrefix(ctx context.Context, prefix string) (bool, error) {
 // LoadBytesWithPrefix returns all the keys and values with the given key prefix.
 func (kv *etcdKV) LoadBytesWithPrefix(ctx context.Context, key string) ([]string, [][]byte, error) {
 	start := time.Now()
-	key = path.Join(kv.rootPath, key)
+	key = kv.GetPath(key)
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
 	defer cancel()
 	resp, err := kv.getEtcdMeta(ctx1, key, clientv3.WithPrefix(),
@@ -192,7 +192,7 @@ func (kv *etcdKV) LoadBytesWithPrefix(ctx context.Context, key string) ([]string
 // LoadBytesWithPrefix2 returns all the keys,values and key versions with the given key prefix.
 func (kv *etcdKV) LoadBytesWithPrefix2(ctx context.Context, key string) ([]string, [][]byte, []int64, error) {
 	start := time.Now()
-	key = path.Join(kv.rootPath, key)
+	key = kv.GetPath(key)
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
 	defer cancel()
 	resp, err := kv.getEtcdMeta(ctx1, key, clientv3.WithPrefix(),
@@ -215,7 +215,7 @@ func (kv *etcdKV) LoadBytesWithPrefix2(ctx context.Context, key string) ([]strin
 // Load returns value of the key.
 func (kv *etcdKV) Load(ctx context.Context, key string) (string, error) {
 	start := time.Now()
-	key = path.Join(kv.rootPath, key)
+	key = kv.GetPath(key)
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
 	defer cancel()
 	resp, err := kv.getEtcdMeta(ctx1, key)
@@ -232,7 +232,7 @@ func (kv *etcdKV) Load(ctx context.Context, key string) (string, error) {
 // LoadBytes returns value of the key.
 func (kv *etcdKV) LoadBytes(ctx context.Context, key string) ([]byte, error) {
 	start := time.Now()
-	key = path.Join(kv.rootPath, key)
+	key = kv.GetPath(key)
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
 	defer cancel()
 	resp, err := kv.getEtcdMeta(ctx1, key)
@@ -251,7 +251,7 @@ func (kv *etcdKV) MultiLoad(ctx context.Context, keys []string) ([]string, error
 	start := time.Now()
 	ops := make([]clientv3.Op, 0, len(keys))
 	for _, keyLoad := range keys {
-		ops = append(ops, clientv3.OpGet(path.Join(kv.rootPath, keyLoad)))
+		ops = append(ops, clientv3.OpGet(kv.GetPath(keyLoad)))
 	}
 
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
@@ -286,7 +286,7 @@ func (kv *etcdKV) MultiLoadBytes(ctx context.Context, keys []string) ([][]byte, 
 	start := time.Now()
 	ops := make([]clientv3.Op, 0, len(keys))
 	for _, keyLoad := range keys {
-		ops = append(ops, clientv3.OpGet(path.Join(kv.rootPath, keyLoad)))
+		ops = append(ops, clientv3.OpGet(kv.GetPath(keyLoad)))
 	}
 
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
@@ -319,7 +319,7 @@ func (kv *etcdKV) MultiLoadBytes(ctx context.Context, keys []string) ([][]byte, 
 // LoadBytesWithRevision returns keys, values and revision with given key prefix.
 func (kv *etcdKV) LoadBytesWithRevision(ctx context.Context, key string) ([]string, [][]byte, int64, error) {
 	start := time.Now()
-	key = path.Join(kv.rootPath, key)
+	key = kv.GetPath(key)
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
 	defer cancel()
 	resp, err := kv.getEtcdMeta(ctx1, key, clientv3.WithPrefix(),
@@ -340,7 +340,7 @@ func (kv *etcdKV) LoadBytesWithRevision(ctx context.Context, key string) ([]stri
 // Save saves the key-value pair.
 func (kv *etcdKV) Save(ctx context.Context, key, value string) error {
 	start := time.Now()
-	key = path.Join(kv.rootPath, key)
+	key = kv.GetPath(key)
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
 	defer cancel()
 	CheckValueSizeAndWarn(ctx, key, value)
@@ -352,7 +352,7 @@ func (kv *etcdKV) Save(ctx context.Context, key, value string) error {
 // SaveBytes saves the key-value pair.
 func (kv *etcdKV) SaveBytes(ctx context.Context, key string, value []byte) error {
 	start := time.Now()
-	key = path.Join(kv.rootPath, key)
+	key = kv.GetPath(key)
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
 	defer cancel()
 	CheckValueSizeAndWarn(ctx, key, value)
@@ -364,7 +364,7 @@ func (kv *etcdKV) SaveBytes(ctx context.Context, key string, value []byte) error
 // SaveBytesWithLease is a function to put value in etcd with etcd lease options.
 func (kv *etcdKV) SaveBytesWithLease(ctx context.Context, key string, value []byte, id clientv3.LeaseID) error {
 	start := time.Now()
-	key = path.Join(kv.rootPath, key)
+	key = kv.GetPath(key)
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
 	defer cancel()
 	CheckValueSizeAndWarn(ctx, key, value)
@@ -380,7 +380,7 @@ func (kv *etcdKV) MultiSave(ctx context.Context, kvs map[string]string) error {
 	var keys []string
 	for key, value := range kvs {
 		keys = append(keys, key)
-		ops = append(ops, clientv3.OpPut(path.Join(kv.rootPath, key), value))
+		ops = append(ops, clientv3.OpPut(kv.GetPath(key), value))
 	}
 
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
@@ -402,7 +402,7 @@ func (kv *etcdKV) MultiSaveBytes(ctx context.Context, kvs map[string][]byte) err
 	var keys []string
 	for key, value := range kvs {
 		keys = append(keys, key)
-		ops = append(ops, clientv3.OpPut(path.Join(kv.rootPath, key), string(value)))
+		ops = append(ops, clientv3.OpPut(kv.GetPath(key), string(value)))
 	}
 
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
@@ -420,7 +420,7 @@ func (kv *etcdKV) MultiSaveBytes(ctx context.Context, kvs map[string][]byte) err
 // RemoveWithPrefix removes the keys with given prefix.
 func (kv *etcdKV) RemoveWithPrefix(ctx context.Context, prefix string) error {
 	start := time.Now()
-	key := path.Join(kv.rootPath, prefix)
+	key := kv.GetPath(prefix)
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
 	defer cancel()
 
@@ -432,7 +432,7 @@ func (kv *etcdKV) RemoveWithPrefix(ctx context.Context, prefix string) error {
 // Remove removes the key.
 func (kv *etcdKV) Remove(ctx context.Context, key string) error {
 	start := time.Now()
-	key = path.Join(kv.rootPath, key)
+	key = kv.GetPath(key)
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
 	defer cancel()
 
@@ -446,7 +446,7 @@ func (kv *etcdKV) MultiRemove(ctx context.Context, keys []string) error {
 	start := time.Now()
 	ops := make([]clientv3.Op, 0, len(keys))
 	for _, key := range keys {
-		ops = append(ops, clientv3.OpDelete(path.Join(kv.rootPath, key)))
+		ops = append(ops, clientv3.OpDelete(kv.GetPath(key)))
 	}
 
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
@@ -474,13 +474,13 @@ func (kv *etcdKV) MultiSaveAndRemove(ctx context.Context, saves map[string]strin
 	removeKeys := typeutil.NewSet(removals...)
 	removals = removeKeys.Complement(saveKeys).Collect()
 	for _, keyDelete := range removals {
-		ops = append(ops, clientv3.OpDelete(path.Join(kv.rootPath, keyDelete)))
+		ops = append(ops, clientv3.OpDelete(kv.GetPath(keyDelete)))
 	}
 
 	var keys []string
 	for key, value := range saves {
 		keys = append(keys, key)
-		ops = append(ops, clientv3.OpPut(path.Join(kv.rootPath, key), value))
+		ops = append(ops, clientv3.OpPut(kv.GetPath(key), value))
 	}
 
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
@@ -510,12 +510,12 @@ func (kv *etcdKV) MultiSaveBytesAndRemove(ctx context.Context, saves map[string]
 	ops := make([]clientv3.Op, 0, len(saves)+len(removals))
 	var keys []string
 	for _, keyDelete := range removals {
-		ops = append(ops, clientv3.OpDelete(path.Join(kv.rootPath, keyDelete)))
+		ops = append(ops, clientv3.OpDelete(kv.GetPath(keyDelete)))
 	}
 
 	for key, value := range saves {
 		keys = append(keys, key)
-		ops = append(ops, clientv3.OpPut(path.Join(kv.rootPath, key), string(value)))
+		ops = append(ops, clientv3.OpPut(kv.GetPath(key), string(value)))
 	}
 
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
@@ -537,7 +537,7 @@ func (kv *etcdKV) MultiSaveBytesAndRemove(ctx context.Context, saves map[string]
 // Watch starts watching a key, returns a watch channel.
 func (kv *etcdKV) Watch(ctx context.Context, key string) clientv3.WatchChan {
 	start := time.Now()
-	key = path.Join(kv.rootPath, key)
+	key = kv.GetPath(key)
 	rch := kv.client.Watch(context.Background(), key, clientv3.WithCreatedNotify())
 	CheckElapseAndWarn(ctx, start, "Slow etcd operation watch", zap.String("key", key))
 	return rch
@@ -546,7 +546,7 @@ func (kv *etcdKV) Watch(ctx context.Context, key string) clientv3.WatchChan {
 // WatchWithPrefix starts watching a key with prefix, returns a watch channel.
 func (kv *etcdKV) WatchWithPrefix(ctx context.Context, key string) clientv3.WatchChan {
 	start := time.Now()
-	key = path.Join(kv.rootPath, key)
+	key = kv.GetPath(key)
 	rch := kv.client.Watch(context.Background(), key, clientv3.WithPrefix(), clientv3.WithCreatedNotify())
 	CheckElapseAndWarn(ctx, start, "Slow etcd operation watch with prefix", zap.String("key", key))
 	return rch
@@ -555,7 +555,7 @@ func (kv *etcdKV) WatchWithPrefix(ctx context.Context, key string) clientv3.Watc
 // WatchWithRevision starts watching a key with revision, returns a watch channel.
 func (kv *etcdKV) WatchWithRevision(ctx context.Context, key string, revision int64) clientv3.WatchChan {
 	start := time.Now()
-	key = path.Join(kv.rootPath, key)
+	key = kv.GetPath(key)
 	rch := kv.client.Watch(context.Background(), key, clientv3.WithPrefix(), clientv3.WithPrevKV(), clientv3.WithRev(revision))
 	CheckElapseAndWarn(ctx, start, "Slow etcd operation watch with revision", zap.String("key", key))
 	return rch
@@ -571,13 +571,13 @@ func (kv *etcdKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[st
 	start := time.Now()
 	ops := make([]clientv3.Op, 0, len(saves))
 	for _, keyDelete := range removals {
-		ops = append(ops, clientv3.OpDelete(path.Join(kv.rootPath, keyDelete), clientv3.WithPrefix()))
+		ops = append(ops, clientv3.OpDelete(kv.GetPath(keyDelete), clientv3.WithPrefix()))
 	}
 
 	var keys []string
 	for key, value := range saves {
 		keys = append(keys, key)
-		ops = append(ops, clientv3.OpPut(path.Join(kv.rootPath, key), value))
+		ops = append(ops, clientv3.OpPut(kv.GetPath(key), value))
 	}
 
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
@@ -607,11 +607,11 @@ func (kv *etcdKV) MultiSaveBytesAndRemoveWithPrefix(ctx context.Context, saves m
 	var keys []string
 	for key, value := range saves {
 		keys = append(keys, key)
-		ops = append(ops, clientv3.OpPut(path.Join(kv.rootPath, key), string(value)))
+		ops = append(ops, clientv3.OpPut(kv.GetPath(key), string(value)))
 	}
 
 	for _, keyDelete := range removals {
-		ops = append(ops, clientv3.OpDelete(path.Join(kv.rootPath, keyDelete), clientv3.WithPrefix()))
+		ops = append(ops, clientv3.OpDelete(kv.GetPath(keyDelete), clientv3.WithPrefix()))
 	}
 
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
@@ -637,8 +637,8 @@ func (kv *etcdKV) CompareVersionAndSwap(ctx context.Context, key string, source 
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
 	defer cancel()
 	resp, err := kv.executeTxn(kv.getTxnWithCmp(ctx1,
-		clientv3.Compare(clientv3.Version(path.Join(kv.rootPath, key)), "=", source)),
-		clientv3.OpPut(path.Join(kv.rootPath, key), target))
+		clientv3.Compare(clientv3.Version(kv.GetPath(key)), "=", source)),
+		clientv3.OpPut(kv.GetPath(key), target))
 	if err != nil {
 		return false, err
 	}
@@ -653,8 +653,8 @@ func (kv *etcdKV) CompareVersionAndSwapBytes(ctx context.Context, key string, so
 	ctx1, cancel := getContextWithTimeout(ctx, kv.requestTimeout)
 	defer cancel()
 	resp, err := kv.executeTxn(kv.getTxnWithCmp(ctx1,
-		clientv3.Compare(clientv3.Version(path.Join(kv.rootPath, key)), "=", source)),
-		clientv3.OpPut(path.Join(kv.rootPath, key), string(target), opts...))
+		clientv3.Compare(clientv3.Version(kv.GetPath(key)), "=", source)),
+		clientv3.OpPut(kv.GetPath(key), string(target), opts...))
 	if err != nil {
 		return false, err
 	}

--- a/internal/kv/etcd/etcd_kv_test.go
+++ b/internal/kv/etcd/etcd_kv_test.go
@@ -33,6 +33,7 @@ import (
 	"golang.org/x/exp/maps"
 
 	"github.com/milvus-io/milvus/pkg/v2/kv/predicates"
+	"github.com/milvus-io/milvus/pkg/v2/util"
 	"github.com/milvus-io/milvus/pkg/v2/util/etcd"
 	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
@@ -700,6 +701,61 @@ func (s *EtcdKVSuite) TestRevisionBytes() {
 	success, err = etcdKV.CompareVersionAndSwapBytes(context.TODO(), "a/b/c", 0, []byte("1"))
 	s.NoError(err)
 	s.False(success)
+}
+
+func (s *EtcdKVSuite) TestGetPathPreservesTrailingSlash() {
+	rootPath := s.rootPath
+
+	// GetPath should match path.Join for normal keys (no trailing /)
+	s.Equal(path.Join(rootPath, "key"), util.GetPath(rootPath, "key"))
+	s.Equal(path.Join(rootPath, "a/b/c"), util.GetPath(rootPath, "a/b/c"))
+
+	// GetPath should preserve trailing / (unlike path.Join)
+	s.Equal(rootPath+"/key/", util.GetPath(rootPath, "key/"))
+	s.NotEqual(rootPath+"/key/", path.Join(rootPath, "key/")) // path.Join strips it
+
+	// empty key should return rootPath
+	s.Equal(rootPath, util.GetPath(rootPath, ""))
+
+	// rootPath ending with "/" should not produce duplicate slashes.
+	s.Equal(rootPath+"/key", util.GetPath(rootPath+"/", "key"))
+	s.Equal(rootPath+"/key", util.GetPath(rootPath+"/", "/key"))
+
+	// empty root should not prepend "/".
+	s.Equal("key", util.GetPath("", "key"))
+}
+
+func (s *EtcdKVSuite) TestLoadWithPrefixIsolation() {
+	etcdKV := s.etcdKV
+
+	// Save keys that share a common prefix stem
+	err := etcdKV.MultiSave(context.TODO(), map[string]string{
+		"user_content/role1":           "v1",
+		"user_content/role2":           "v2",
+		"user_content_marketing/role3": "v3",
+		"user_content_marketing/role4": "v4",
+	})
+	s.Require().NoError(err)
+
+	// LoadWithPrefix with trailing "/" should only match the exact namespace
+	keys, values, err := etcdKV.LoadWithPrefix(context.TODO(), "user_content/")
+	s.NoError(err)
+	s.Len(keys, 2)
+	s.ElementsMatch(values, []string{"v1", "v2"})
+
+	// LoadWithPrefix without trailing "/" matches both namespaces (broader match)
+	keys, _, err = etcdKV.LoadWithPrefix(context.TODO(), "user_content")
+	s.NoError(err)
+	s.Len(keys, 4)
+
+	// WalkWithPrefix with trailing "/" should also be isolated
+	var walkedKeys []string
+	err = etcdKV.WalkWithPrefix(context.TODO(), "user_content/", 10, func(key []byte, value []byte) error {
+		walkedKeys = append(walkedKeys, string(key))
+		return nil
+	})
+	s.NoError(err)
+	s.Len(walkedKeys, 2)
 }
 
 func TestEtcdKV(t *testing.T) {

--- a/internal/kv/etcd/util.go
+++ b/internal/kv/etcd/util.go
@@ -3,7 +3,6 @@ package etcdkv
 import (
 	"context"
 	"fmt"
-	"path"
 	"time"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -26,7 +25,7 @@ func parsePredicates(rootPath string, preds ...predicates.Predicate) ([]clientv3
 			if err != nil {
 				return nil, err
 			}
-			cmp := clientv3.Compare(clientv3.Value(path.Join(rootPath, pred.Key())), pt, pred.TargetValue())
+			cmp := clientv3.Compare(clientv3.Value(util.GetPath(rootPath, pred.Key())), pt, pred.TargetValue())
 			result = append(result, cmp)
 		default:
 			return nil, merr.WrapErrParameterInvalid("valid predicate target", fmt.Sprintf("%d", pred.Target()))

--- a/internal/kv/tikv/txn_tikv.go
+++ b/internal/kv/tikv/txn_tikv.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"path"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -37,6 +36,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/kv/predicates"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/metrics"
+	"github.com/milvus-io/milvus/pkg/v2/util"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/timerecord"
@@ -127,7 +127,7 @@ func (kv *txnTiKV) Close() {
 
 // GetPath returns the path of the key/prefix.
 func (kv *txnTiKV) GetPath(key string) string {
-	return path.Join(kv.rootPath, key)
+	return util.GetPath(kv.rootPath, key)
 }
 
 // Log if error is not nil. We use error pointer as in most cases this function
@@ -142,7 +142,7 @@ func logWarnOnFailure(err *error, msg string, fields ...zap.Field) {
 // Has returns if a key exists.
 func (kv *txnTiKV) Has(ctx context.Context, key string) (bool, error) {
 	start := time.Now()
-	key = path.Join(kv.rootPath, key)
+	key = kv.GetPath(key)
 	ctx, cancel := context.WithTimeout(ctx, kv.requestTimeout)
 	defer cancel()
 
@@ -171,7 +171,7 @@ func rollbackOnFailure(err *error, txn *transaction.KVTxn) {
 // HasPrefix returns if a key prefix exists.
 func (kv *txnTiKV) HasPrefix(ctx context.Context, prefix string) (bool, error) {
 	start := time.Now()
-	prefix = path.Join(kv.rootPath, prefix)
+	prefix = kv.GetPath(prefix)
 
 	var loggingErr error
 	defer logWarnOnFailure(&loggingErr, "txnTiKV HasPrefix() error", zap.String("prefix", prefix))
@@ -201,7 +201,7 @@ func (kv *txnTiKV) HasPrefix(ctx context.Context, prefix string) (bool, error) {
 // Load returns value of the key.
 func (kv *txnTiKV) Load(ctx context.Context, key string) (string, error) {
 	start := time.Now()
-	key = path.Join(kv.rootPath, key)
+	key = kv.GetPath(key)
 	ctx, cancel := context.WithTimeout(ctx, kv.requestTimeout)
 	defer cancel()
 
@@ -224,7 +224,7 @@ func (kv *txnTiKV) Load(ctx context.Context, key string) (string, error) {
 func batchConvertFromString(prefix string, keys []string) [][]byte {
 	output := make([][]byte, len(keys))
 	for i := 0; i < len(keys); i++ {
-		keys[i] = path.Join(prefix, keys[i])
+		keys[i] = util.GetPath(prefix, keys[i])
 		output[i] = []byte(keys[i])
 	}
 	return output
@@ -275,7 +275,7 @@ func (kv *txnTiKV) MultiLoad(ctx context.Context, keys []string) ([]string, erro
 // LoadWithPrefix returns all the keys and values for the given key prefix.
 func (kv *txnTiKV) LoadWithPrefix(ctx context.Context, prefix string) ([]string, []string, error) {
 	start := time.Now()
-	prefix = path.Join(kv.rootPath, prefix)
+	prefix = kv.GetPath(prefix)
 
 	var loggingErr error
 	defer logWarnOnFailure(&loggingErr, "txnTiKV LoadWithPrefix() error", zap.String("prefix", prefix))
@@ -314,7 +314,7 @@ func (kv *txnTiKV) LoadWithPrefix(ctx context.Context, prefix string) ([]string,
 
 // Save saves the input key-value pair.
 func (kv *txnTiKV) Save(ctx context.Context, key, value string) error {
-	key = path.Join(kv.rootPath, key)
+	key = kv.GetPath(key)
 	ctx, cancel := context.WithTimeout(ctx, kv.requestTimeout)
 	defer cancel()
 
@@ -344,7 +344,7 @@ func (kv *txnTiKV) MultiSave(ctx context.Context, kvs map[string]string) error {
 	defer rollbackOnFailure(&loggingErr, txn)
 
 	for key, value := range kvs {
-		key = path.Join(kv.rootPath, key)
+		key = kv.GetPath(key)
 		// Check if value is empty or taking reserved EmptyValue
 		byteValue, err := convertEmptyStringToByte(value)
 		if err != nil {
@@ -369,7 +369,7 @@ func (kv *txnTiKV) MultiSave(ctx context.Context, kvs map[string]string) error {
 
 // Remove removes the input key.
 func (kv *txnTiKV) Remove(ctx context.Context, key string) error {
-	key = path.Join(kv.rootPath, key)
+	key = kv.GetPath(key)
 	ctx, cancel := context.WithTimeout(ctx, kv.requestTimeout)
 	defer cancel()
 
@@ -399,7 +399,7 @@ func (kv *txnTiKV) MultiRemove(ctx context.Context, keys []string) error {
 	defer rollbackOnFailure(&loggingErr, txn)
 
 	for _, key := range keys {
-		key = path.Join(kv.rootPath, key)
+		key = kv.GetPath(key)
 		err = txn.Delete([]byte(key))
 		if err != nil {
 			loggingErr = errors.Wrap(err, fmt.Sprintf("Failed to delete %s for MultiRemove", key))
@@ -419,7 +419,7 @@ func (kv *txnTiKV) MultiRemove(ctx context.Context, keys []string) error {
 // RemoveWithPrefix removes the keys for the given prefix.
 func (kv *txnTiKV) RemoveWithPrefix(ctx context.Context, prefix string) error {
 	start := time.Now()
-	prefix = path.Join(kv.rootPath, prefix)
+	prefix = kv.GetPath(prefix)
 	ctx, cancel := context.WithTimeout(ctx, kv.requestTimeout)
 	defer cancel()
 
@@ -456,7 +456,7 @@ func (kv *txnTiKV) MultiSaveAndRemove(ctx context.Context, saves map[string]stri
 	defer rollbackOnFailure(&loggingErr, txn)
 
 	for _, pred := range preds {
-		key := path.Join(kv.rootPath, pred.Key())
+		key := kv.GetPath(pred.Key())
 		val, err := txn.Get(ctx, []byte(key))
 		if err != nil {
 			loggingErr = errors.Wrap(err, fmt.Sprintf("failed to read predicate target (%s:%v) for MultiSaveAndRemove", pred.Key(), pred.TargetValue()))
@@ -474,7 +474,7 @@ func (kv *txnTiKV) MultiSaveAndRemove(ctx context.Context, saves map[string]stri
 	removals = removeKeys.Complement(saveKeys).Collect()
 
 	for _, key := range removals {
-		key = path.Join(kv.rootPath, key)
+		key = kv.GetPath(key)
 		if err = txn.Delete([]byte(key)); err != nil {
 			loggingErr = errors.Wrap(err, fmt.Sprintf("Failed to delete %s for MultiSaveAndRemove", key))
 			return loggingErr
@@ -482,7 +482,7 @@ func (kv *txnTiKV) MultiSaveAndRemove(ctx context.Context, saves map[string]stri
 	}
 
 	for key, value := range saves {
-		key = path.Join(kv.rootPath, key)
+		key = kv.GetPath(key)
 		// Check if value is empty or taking reserved EmptyValue
 		byteValue, err := convertEmptyStringToByte(value)
 		if err != nil {
@@ -524,7 +524,7 @@ func (kv *txnTiKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[s
 	defer rollbackOnFailure(&loggingErr, txn)
 
 	for _, pred := range preds {
-		key := path.Join(kv.rootPath, pred.Key())
+		key := kv.GetPath(pred.Key())
 		val, err := txn.Get(ctx, []byte(key))
 		if err != nil {
 			loggingErr = errors.Wrap(err, fmt.Sprintf("failed to read predicate target (%s:%v) for MultiSaveAndRemove", pred.Key(), pred.TargetValue()))
@@ -538,7 +538,7 @@ func (kv *txnTiKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[s
 
 	// Remove keys with prefix
 	for _, prefix := range removals {
-		prefix = path.Join(kv.rootPath, prefix)
+		prefix = kv.GetPath(prefix)
 		// Get the start and end keys for the prefix range
 		startKey := []byte(prefix)
 		endKey := tikv.PrefixNextKey([]byte(prefix))
@@ -570,7 +570,7 @@ func (kv *txnTiKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[s
 
 	// Save key-value pairs
 	for key, value := range saves {
-		key = path.Join(kv.rootPath, key)
+		key = kv.GetPath(key)
 		// Check if value is empty or taking reserved EmptyValue
 		byteValue, err := convertEmptyStringToByte(value)
 		if err != nil {
@@ -596,7 +596,7 @@ func (kv *txnTiKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[s
 // WalkWithPrefix visits each kv with input prefix and apply given fn to it.
 func (kv *txnTiKV) WalkWithPrefix(ctx context.Context, prefix string, paginationSize int, fn func([]byte, []byte) error) error {
 	start := time.Now()
-	prefix = path.Join(kv.rootPath, prefix)
+	prefix = kv.GetPath(prefix)
 
 	var loggingErr error
 	defer logWarnOnFailure(&loggingErr, "txnTiKV WalkWithPagination error", zap.String("prefix", prefix))

--- a/internal/metastore/kv/datacoord/kv_catalog.go
+++ b/internal/metastore/kv/datacoord/kv_catalog.go
@@ -19,7 +19,6 @@ package datacoord
 import (
 	"context"
 	"fmt"
-	"path"
 	"strconv"
 	"strings"
 
@@ -200,7 +199,7 @@ func (kc *Catalog) listBinlogs(ctx context.Context, binlogType storage.BinlogTyp
 
 		segmentID, err := kc.parseBinlogKey(string(key))
 		if err != nil {
-			return fmt.Errorf("prefix:%s, %w", path.Join(kc.metaRootpath, logPathPrefix), err)
+			return fmt.Errorf("prefix:%s, %w", kc.metaRootpath+"/"+logPathPrefix, err)
 		}
 
 		// set log size to memory size if memory size is zero for old segment before v2.4.3
@@ -419,12 +418,12 @@ func (kc *Catalog) SaveDroppedSegmentsInBatch(ctx context.Context, segments []*d
 
 func (kc *Catalog) DropSegment(ctx context.Context, segment *datapb.SegmentInfo) error {
 	segKey := buildSegmentPath(segment.GetCollectionID(), segment.GetPartitionID(), segment.GetID())
-	binlogPreix := fmt.Sprintf("%s/%d/%d/%d", SegmentBinlogPathPrefix, segment.GetCollectionID(), segment.GetPartitionID(), segment.GetID())
-	deltalogPreix := fmt.Sprintf("%s/%d/%d/%d", SegmentDeltalogPathPrefix, segment.GetCollectionID(), segment.GetPartitionID(), segment.GetID())
-	statelogPreix := fmt.Sprintf("%s/%d/%d/%d", SegmentStatslogPathPrefix, segment.GetCollectionID(), segment.GetPartitionID(), segment.GetID())
-	bm25logPrefix := fmt.Sprintf("%s/%d/%d/%d", SegmentBM25logPathPrefix, segment.GetCollectionID(), segment.GetPartitionID(), segment.GetID())
+	binlogPrefix := fmt.Sprintf("%s/%d/%d/%d/", SegmentBinlogPathPrefix, segment.GetCollectionID(), segment.GetPartitionID(), segment.GetID())
+	deltalogPrefix := fmt.Sprintf("%s/%d/%d/%d/", SegmentDeltalogPathPrefix, segment.GetCollectionID(), segment.GetPartitionID(), segment.GetID())
+	statelogPrefix := fmt.Sprintf("%s/%d/%d/%d/", SegmentStatslogPathPrefix, segment.GetCollectionID(), segment.GetPartitionID(), segment.GetID())
+	bm25logPrefix := fmt.Sprintf("%s/%d/%d/%d/", SegmentBM25logPathPrefix, segment.GetCollectionID(), segment.GetPartitionID(), segment.GetID())
 
-	keys := []string{segKey, binlogPreix, deltalogPreix, statelogPreix, bm25logPrefix}
+	keys := []string{segKey, binlogPrefix, deltalogPrefix, statelogPrefix, bm25logPrefix}
 	if err := kc.MetaKv.MultiSaveAndRemoveWithPrefix(ctx, nil, keys); err != nil {
 		return err
 	}
@@ -491,7 +490,7 @@ func (kc *Catalog) ListChannelCheckpoint(ctx context.Context) (map[string]*msgpb
 		return nil
 	}
 
-	err := kc.MetaKv.WalkWithPrefix(ctx, ChannelCheckpointPrefix, kc.paginationSize, applyFn)
+	err := kc.MetaKv.WalkWithPrefix(ctx, ChannelCheckpointPrefix+"/", kc.paginationSize, applyFn)
 	if err != nil {
 		return nil, err
 	}
@@ -576,7 +575,7 @@ func (kc *Catalog) ListIndexes(ctx context.Context) ([]*model.Index, error) {
 		return nil
 	}
 
-	err := kc.MetaKv.WalkWithPrefix(ctx, util.FieldIndexPrefix, kc.paginationSize, applyFn)
+	err := kc.MetaKv.WalkWithPrefix(ctx, util.FieldIndexPrefix+"/", kc.paginationSize, applyFn)
 	if err != nil {
 		return nil, err
 	}
@@ -651,7 +650,7 @@ func (kc *Catalog) ListSegmentIndexes(ctx context.Context) ([]*model.SegmentInde
 		return nil
 	}
 
-	err := kc.MetaKv.WalkWithPrefix(ctx, util.SegmentIndexPrefix, kc.paginationSize, applyFn)
+	err := kc.MetaKv.WalkWithPrefix(ctx, util.SegmentIndexPrefix+"/", kc.paginationSize, applyFn)
 	if err != nil {
 		return nil, err
 	}
@@ -705,7 +704,7 @@ func (kc *Catalog) ListImportJobs(ctx context.Context) ([]*datapb.ImportJob, err
 		return nil
 	}
 
-	err := kc.MetaKv.WalkWithPrefix(ctx, ImportJobPrefix, kc.paginationSize, applyFn)
+	err := kc.MetaKv.WalkWithPrefix(ctx, ImportJobPrefix+"/", kc.paginationSize, applyFn)
 	if err != nil {
 		return nil, err
 	}
@@ -739,7 +738,7 @@ func (kc *Catalog) ListPreImportTasks(ctx context.Context) ([]*datapb.PreImportT
 		return nil
 	}
 
-	err := kc.MetaKv.WalkWithPrefix(ctx, PreImportTaskPrefix, kc.paginationSize, applyFn)
+	err := kc.MetaKv.WalkWithPrefix(ctx, PreImportTaskPrefix+"/", kc.paginationSize, applyFn)
 	if err != nil {
 		return nil, err
 	}
@@ -773,7 +772,7 @@ func (kc *Catalog) ListImportTasks(ctx context.Context) ([]*datapb.ImportTaskV2,
 		return nil
 	}
 
-	err := kc.MetaKv.WalkWithPrefix(ctx, ImportTaskPrefix, kc.paginationSize, applyFn)
+	err := kc.MetaKv.WalkWithPrefix(ctx, ImportTaskPrefix+"/", kc.paginationSize, applyFn)
 	if err != nil {
 		return nil, err
 	}
@@ -806,7 +805,7 @@ func (kc *Catalog) ListCopySegmentJobs(ctx context.Context) ([]*datapb.CopySegme
 		return nil
 	}
 
-	err := kc.MetaKv.WalkWithPrefix(ctx, CopySegmentJobPrefix, kc.paginationSize, applyFn)
+	err := kc.MetaKv.WalkWithPrefix(ctx, CopySegmentJobPrefix+"/", kc.paginationSize, applyFn)
 	if err != nil {
 		return nil, err
 	}
@@ -858,7 +857,7 @@ func (kc *Catalog) ListCopySegmentTasks(ctx context.Context) ([]*datapb.CopySegm
 		return nil
 	}
 
-	err := kc.MetaKv.WalkWithPrefix(ctx, CopySegmentTaskPrefix, kc.paginationSize, applyFn)
+	err := kc.MetaKv.WalkWithPrefix(ctx, CopySegmentTaskPrefix+"/", kc.paginationSize, applyFn)
 	if err != nil {
 		return nil, err
 	}
@@ -898,7 +897,7 @@ func (kc *Catalog) ListCompactionTask(ctx context.Context) ([]*datapb.Compaction
 		return nil
 	}
 
-	err := kc.MetaKv.WalkWithPrefix(ctx, CompactionTaskPrefix, kc.paginationSize, applyFn)
+	err := kc.MetaKv.WalkWithPrefix(ctx, CompactionTaskPrefix+"/", kc.paginationSize, applyFn)
 	if err != nil {
 		return nil, err
 	}
@@ -937,7 +936,7 @@ func (kc *Catalog) ListAnalyzeTasks(ctx context.Context) ([]*indexpb.AnalyzeTask
 		return nil
 	}
 
-	err := kc.MetaKv.WalkWithPrefix(ctx, AnalyzeTaskPrefix, kc.paginationSize, applyFn)
+	err := kc.MetaKv.WalkWithPrefix(ctx, AnalyzeTaskPrefix+"/", kc.paginationSize, applyFn)
 	if err != nil {
 		return nil, err
 	}
@@ -977,7 +976,7 @@ func (kc *Catalog) ListPartitionStatsInfos(ctx context.Context) ([]*datapb.Parti
 		return nil
 	}
 
-	err := kc.MetaKv.WalkWithPrefix(ctx, PartitionStatsInfoPrefix, kc.paginationSize, applyFn)
+	err := kc.MetaKv.WalkWithPrefix(ctx, PartitionStatsInfoPrefix+"/", kc.paginationSize, applyFn)
 	if err != nil {
 		return nil, err
 	}
@@ -1040,7 +1039,7 @@ func (kc *Catalog) ListStatsTasks(ctx context.Context) ([]*indexpb.StatsTask, er
 		return nil
 	}
 
-	err := kc.MetaKv.WalkWithPrefix(ctx, StatsTaskPrefix, kc.paginationSize, applyFn)
+	err := kc.MetaKv.WalkWithPrefix(ctx, StatsTaskPrefix+"/", kc.paginationSize, applyFn)
 	if err != nil {
 		return nil, err
 	}
@@ -1079,7 +1078,7 @@ func (kc *Catalog) ListUpdateExternalCollectionTasks(ctx context.Context) ([]*in
 		return nil
 	}
 
-	err := kc.MetaKv.WalkWithPrefix(ctx, UpdateExternalCollectionTaskPrefix, kc.paginationSize, applyFn)
+	err := kc.MetaKv.WalkWithPrefix(ctx, UpdateExternalCollectionTaskPrefix+"/", kc.paginationSize, applyFn)
 	if err != nil {
 		return nil, err
 	}
@@ -1117,7 +1116,7 @@ func (kc *Catalog) ListExternalCollectionRefreshJobs(ctx context.Context) ([]*da
 		jobs = append(jobs, job)
 		return nil
 	}
-	err := kc.MetaKv.WalkWithPrefix(ctx, ExternalCollectionRefreshJobPrefix, kc.paginationSize, applyFn)
+	err := kc.MetaKv.WalkWithPrefix(ctx, ExternalCollectionRefreshJobPrefix+"/", kc.paginationSize, applyFn)
 	if err != nil {
 		return nil, err
 	}
@@ -1152,7 +1151,7 @@ func (kc *Catalog) ListExternalCollectionRefreshTasks(ctx context.Context) ([]*d
 		tasks = append(tasks, task)
 		return nil
 	}
-	err := kc.MetaKv.WalkWithPrefix(ctx, ExternalCollectionRefreshTaskPrefix, kc.paginationSize, applyFn)
+	err := kc.MetaKv.WalkWithPrefix(ctx, ExternalCollectionRefreshTaskPrefix+"/", kc.paginationSize, applyFn)
 	if err != nil {
 		return nil, err
 	}
@@ -1204,7 +1203,7 @@ func (kc *Catalog) RemoveFileResource(ctx context.Context, resourceID int64, ver
 }
 
 func (kc *Catalog) ListFileResource(ctx context.Context) ([]*internalpb.FileResourceInfo, uint64, error) {
-	_, values, err := kc.MetaKv.LoadWithPrefix(ctx, FileResourceMetaPrefix)
+	_, values, err := kc.MetaKv.LoadWithPrefix(ctx, FileResourceMetaPrefix+"/")
 	if err != nil {
 		return nil, 0, err
 	}
@@ -1271,7 +1270,7 @@ func (kc *Catalog) ListSnapshots(ctx context.Context) ([]*datapb.SnapshotInfo, e
 		return nil
 	}
 
-	err := kc.MetaKv.WalkWithPrefix(ctx, SnapshotPrefix, kc.paginationSize, applyFn)
+	err := kc.MetaKv.WalkWithPrefix(ctx, SnapshotPrefix+"/", kc.paginationSize, applyFn)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/metastore/kv/datacoord/kv_catalog_test.go
+++ b/internal/metastore/kv/datacoord/kv_catalog_test.go
@@ -551,12 +551,13 @@ func Test_DropSegment(t *testing.T) {
 		assert.NoError(t, err)
 
 		segKey := buildSegmentPath(segment1.GetCollectionID(), segment1.GetPartitionID(), segment1.GetID())
-		binlogPreix := fmt.Sprintf("%s/%d/%d/%d", SegmentBinlogPathPrefix, segment1.GetCollectionID(), segment1.GetPartitionID(), segment1.GetID())
-		deltalogPreix := fmt.Sprintf("%s/%d/%d/%d", SegmentDeltalogPathPrefix, segment1.GetCollectionID(), segment1.GetPartitionID(), segment1.GetID())
-		statelogPreix := fmt.Sprintf("%s/%d/%d/%d", SegmentStatslogPathPrefix, segment1.GetCollectionID(), segment1.GetPartitionID(), segment1.GetID())
+		binlogPrefix := fmt.Sprintf("%s/%d/%d/%d/", SegmentBinlogPathPrefix, segment1.GetCollectionID(), segment1.GetPartitionID(), segment1.GetID())
+		deltalogPrefix := fmt.Sprintf("%s/%d/%d/%d/", SegmentDeltalogPathPrefix, segment1.GetCollectionID(), segment1.GetPartitionID(), segment1.GetID())
+		statelogPrefix := fmt.Sprintf("%s/%d/%d/%d/", SegmentStatslogPathPrefix, segment1.GetCollectionID(), segment1.GetPartitionID(), segment1.GetID())
+		bm25logPrefix := fmt.Sprintf("%s/%d/%d/%d/", SegmentBM25logPathPrefix, segment1.GetCollectionID(), segment1.GetPartitionID(), segment1.GetID())
 
 		assert.Equal(t, 5, len(removedKvs))
-		for _, k := range []string{segKey, binlogPreix, deltalogPreix, statelogPreix} {
+		for _, k := range []string{segKey, binlogPrefix, deltalogPrefix, statelogPrefix, bm25logPrefix} {
 			_, ok := removedKvs[k]
 			assert.True(t, ok)
 		}

--- a/internal/metastore/kv/datacoord/util.go
+++ b/internal/metastore/kv/datacoord/util.go
@@ -301,15 +301,15 @@ func buildFieldBM25StatslogPath(collectionID typeutil.UniqueID, partitionID type
 }
 
 func buildFieldBinlogPathPrefix(collectionID typeutil.UniqueID, partitionID typeutil.UniqueID, segmentID typeutil.UniqueID) string {
-	return fmt.Sprintf("%s/%d/%d/%d", SegmentBinlogPathPrefix, collectionID, partitionID, segmentID)
+	return fmt.Sprintf("%s/%d/%d/%d/", SegmentBinlogPathPrefix, collectionID, partitionID, segmentID)
 }
 
 func buildFieldDeltalogPathPrefix(collectionID typeutil.UniqueID, partitionID typeutil.UniqueID, segmentID typeutil.UniqueID) string {
-	return fmt.Sprintf("%s/%d/%d/%d", SegmentDeltalogPathPrefix, collectionID, partitionID, segmentID)
+	return fmt.Sprintf("%s/%d/%d/%d/", SegmentDeltalogPathPrefix, collectionID, partitionID, segmentID)
 }
 
 func buildFieldStatslogPathPrefix(collectionID typeutil.UniqueID, partitionID typeutil.UniqueID, segmentID typeutil.UniqueID) string {
-	return fmt.Sprintf("%s/%d/%d/%d", SegmentStatslogPathPrefix, collectionID, partitionID, segmentID)
+	return fmt.Sprintf("%s/%d/%d/%d/", SegmentStatslogPathPrefix, collectionID, partitionID, segmentID)
 }
 
 // buildChannelRemovePath builds vchannel remove flag path
@@ -330,11 +330,11 @@ func BuildSegmentIndexKey(collectionID, partitionID, segmentID, buildID int64) s
 }
 
 func buildCollectionPrefix(collectionID typeutil.UniqueID) string {
-	return fmt.Sprintf("%s/%d", SegmentPrefix, collectionID)
+	return fmt.Sprintf("%s/%d/", SegmentPrefix, collectionID)
 }
 
 func buildPartitionPrefix(collectionID, partitionID typeutil.UniqueID) string {
-	return fmt.Sprintf("%s/%d/%d", SegmentPrefix, collectionID, partitionID)
+	return fmt.Sprintf("%s/%d/%d/", SegmentPrefix, collectionID, partitionID)
 }
 
 func buildImportJobKey(jobID int64) string {

--- a/internal/metastore/kv/querycoord/kv_catalog.go
+++ b/internal/metastore/kv/querycoord/kv_catalog.go
@@ -123,7 +123,7 @@ func (s Catalog) GetCollections(ctx context.Context) ([]*querypb.CollectionLoadI
 		return nil
 	}
 
-	err := s.cli.WalkWithPrefix(ctx, CollectionLoadInfoPrefix, s.paginationSize, applyFn)
+	err := s.cli.WalkWithPrefix(ctx, CollectionLoadInfoPrefix+"/", s.paginationSize, applyFn)
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +178,7 @@ func (s Catalog) GetReplicas(ctx context.Context) ([]*querypb.Replica, error) {
 		return nil
 	}
 
-	err := s.cli.WalkWithPrefix(ctx, ReplicaPrefix, s.paginationSize, applyFn)
+	err := s.cli.WalkWithPrefix(ctx, ReplicaPrefix+"/", s.paginationSize, applyFn)
 	if err != nil {
 		return nil, err
 	}
@@ -193,7 +193,7 @@ func (s Catalog) GetReplicas(ctx context.Context) ([]*querypb.Replica, error) {
 }
 
 func (s Catalog) getReplicasFromV1(ctx context.Context) ([]*querypb.Replica, error) {
-	_, replicaValues, err := s.cli.LoadWithPrefix(ctx, ReplicaMetaPrefixV1)
+	_, replicaValues, err := s.cli.LoadWithPrefix(ctx, ReplicaMetaPrefixV1+"/")
 	if err != nil {
 		return nil, err
 	}
@@ -216,7 +216,7 @@ func (s Catalog) getReplicasFromV1(ctx context.Context) ([]*querypb.Replica, err
 }
 
 func (s Catalog) GetResourceGroups(ctx context.Context) ([]*querypb.ResourceGroup, error) {
-	_, rgs, err := s.cli.LoadWithPrefix(ctx, ResourceGroupPrefix)
+	_, rgs, err := s.cli.LoadWithPrefix(ctx, ResourceGroupPrefix+"/")
 	if err != nil {
 		return nil, err
 	}
@@ -241,7 +241,7 @@ func (s Catalog) ReleaseCollection(ctx context.Context, collection int64) error 
 	if err != nil {
 		return err
 	}
-	partitionsPrefix := fmt.Sprintf("%s/%d", PartitionLoadInfoPrefix, collection)
+	partitionsPrefix := fmt.Sprintf("%s/%d/", PartitionLoadInfoPrefix, collection)
 	return s.cli.RemoveWithPrefix(ctx, partitionsPrefix)
 }
 
@@ -268,7 +268,7 @@ func (s Catalog) ReleasePartition(ctx context.Context, collection int64, partiti
 }
 
 func (s Catalog) ReleaseReplicas(ctx context.Context, collectionID int64) error {
-	key := encodeCollectionReplicaKey(collectionID)
+	key := encodeCollectionReplicaPrefix(collectionID)
 	return s.cli.RemoveWithPrefix(ctx, key)
 }
 
@@ -341,7 +341,7 @@ func (s Catalog) GetCollectionTargets(ctx context.Context) (map[int64]*querypb.C
 		return nil
 	}
 
-	err := s.cli.WalkWithPrefix(ctx, CollectionTargetPrefix, s.paginationSize, applyFn)
+	err := s.cli.WalkWithPrefix(ctx, CollectionTargetPrefix+"/", s.paginationSize, applyFn)
 	if err != nil {
 		return nil, err
 	}
@@ -365,8 +365,8 @@ func encodeReplicaKey(collection, replica int64) string {
 	return fmt.Sprintf("%s/%d/%d", ReplicaPrefix, collection, replica)
 }
 
-func encodeCollectionReplicaKey(collection int64) string {
-	return fmt.Sprintf("%s/%d", ReplicaPrefix, collection)
+func encodeCollectionReplicaPrefix(collection int64) string {
+	return fmt.Sprintf("%s/%d/", ReplicaPrefix, collection)
 }
 
 func encodeResourceGroupKey(rgName string) string {

--- a/internal/metastore/kv/rootcoord/kv_catalog.go
+++ b/internal/metastore/kv/rootcoord/kv_catalog.go
@@ -58,35 +58,35 @@ func BuildCollectionKey(dbID typeutil.UniqueID, collectionID typeutil.UniqueID) 
 }
 
 func BuildPartitionPrefix(collectionID typeutil.UniqueID) string {
-	return fmt.Sprintf("%s/%d", PartitionMetaPrefix, collectionID)
+	return fmt.Sprintf("%s/%d/", PartitionMetaPrefix, collectionID)
 }
 
 func BuildPartitionKey(collectionID, partitionID typeutil.UniqueID) string {
-	return fmt.Sprintf("%s/%d", BuildPartitionPrefix(collectionID), partitionID)
+	return fmt.Sprintf("%s/%d/%d", PartitionMetaPrefix, collectionID, partitionID)
 }
 
 func BuildFieldPrefix(collectionID typeutil.UniqueID) string {
-	return fmt.Sprintf("%s/%d", FieldMetaPrefix, collectionID)
+	return fmt.Sprintf("%s/%d/", FieldMetaPrefix, collectionID)
 }
 
 func BuildFieldKey(collectionID typeutil.UniqueID, fieldID int64) string {
-	return fmt.Sprintf("%s/%d", BuildFieldPrefix(collectionID), fieldID)
+	return fmt.Sprintf("%s/%d/%d", FieldMetaPrefix, collectionID, fieldID)
 }
 
 func BuildFunctionPrefix(collectionID typeutil.UniqueID) string {
-	return fmt.Sprintf("%s/%d", FunctionMetaPrefix, collectionID)
+	return fmt.Sprintf("%s/%d/", FunctionMetaPrefix, collectionID)
 }
 
 func BuildFunctionKey(collectionID typeutil.UniqueID, functionID int64) string {
-	return fmt.Sprintf("%s/%d", BuildFunctionPrefix(collectionID), functionID)
+	return fmt.Sprintf("%s/%d/%d", FunctionMetaPrefix, collectionID, functionID)
 }
 
 func BuildStructArrayFieldPrefix(collectionID typeutil.UniqueID) string {
-	return fmt.Sprintf("%s/%d", StructArrayFieldMetaPrefix, collectionID)
+	return fmt.Sprintf("%s/%d/", StructArrayFieldMetaPrefix, collectionID)
 }
 
 func BuildStructArrayFieldKey(collectionId typeutil.UniqueID, fieldId int64) string {
-	return fmt.Sprintf("%s/%d", BuildStructArrayFieldPrefix(collectionId), fieldId)
+	return fmt.Sprintf("%s/%d/%d", StructArrayFieldMetaPrefix, collectionId, fieldId)
 }
 
 func BuildAliasKey210(alias string) string {
@@ -107,9 +107,9 @@ func BuildAliasKeyWithDB(dbID int64, aliasName string) string {
 
 func BuildAliasPrefixWithDB(dbID int64) string {
 	if dbID == util.NonDBID {
-		return AliasMetaPrefix
+		return AliasMetaPrefix + "/"
 	}
-	return fmt.Sprintf("%s/%s/%d", DatabaseMetaPrefix, Aliases, dbID)
+	return fmt.Sprintf("%s/%s/%d/", DatabaseMetaPrefix, Aliases, dbID)
 }
 
 // since SnapshotKV may save both snapshot key and the original key if the original key is newest
@@ -153,7 +153,7 @@ func (kc *Catalog) DropDatabase(ctx context.Context, dbID int64, ts typeutil.Tim
 }
 
 func (kc *Catalog) ListDatabases(ctx context.Context, ts typeutil.Timestamp) ([]*model.Database, error) {
-	_, vals, err := kc.Snapshot.LoadWithPrefix(ctx, DBInfoMetaPrefix, ts)
+	_, vals, err := kc.Snapshot.LoadWithPrefix(ctx, DBInfoMetaPrefix+"/", ts)
 	if err != nil {
 		return nil, err
 	}
@@ -383,7 +383,7 @@ func (kc *Catalog) listPartitionsAfter210(ctx context.Context, collectionID type
 }
 
 func (kc *Catalog) batchListPartitionsAfter210(ctx context.Context, ts typeutil.Timestamp) (map[int64][]*model.Partition, error) {
-	_, values, err := kc.Snapshot.LoadWithPrefix(ctx, PartitionMetaPrefix, ts)
+	_, values, err := kc.Snapshot.LoadWithPrefix(ctx, PartitionMetaPrefix+"/", ts)
 	if err != nil {
 		return nil, err
 	}
@@ -427,7 +427,7 @@ func (kc *Catalog) listFieldsAfter210(ctx context.Context, collectionID typeutil
 }
 
 func (kc *Catalog) batchListFieldsAfter210(ctx context.Context, ts typeutil.Timestamp) (map[int64][]*model.Field, error) {
-	keys, values, err := kc.Snapshot.LoadWithPrefix(ctx, FieldMetaPrefix, ts)
+	keys, values, err := kc.Snapshot.LoadWithPrefix(ctx, FieldMetaPrefix+"/", ts)
 	if err != nil {
 		return nil, err
 	}
@@ -489,7 +489,7 @@ func (kc *Catalog) listFunctions(ctx context.Context, collectionID typeutil.Uniq
 }
 
 func (kc *Catalog) batchListFunctions(ctx context.Context, ts typeutil.Timestamp) (map[int64][]*model.Function, error) {
-	keys, values, err := kc.Snapshot.LoadWithPrefix(ctx, FunctionMetaPrefix, ts)
+	keys, values, err := kc.Snapshot.LoadWithPrefix(ctx, FunctionMetaPrefix+"/", ts)
 	if err != nil {
 		return nil, err
 	}
@@ -852,7 +852,7 @@ func (kc *Catalog) DropCredential(ctx context.Context, username string) error {
 	for _, userResult := range userResults {
 		if userResult.User.Name == username {
 			for _, role := range userResult.Roles {
-				userRoleKey := funcutil.HandleTenantForEtcdKey(RoleMappingPrefix, util.DefaultTenant, fmt.Sprintf("%s/%s", username, role.Name))
+				userRoleKey := fmt.Sprintf("%s/%s/%s", RoleMappingPrefix, username, role.Name)
 				deleteKeys = append(deleteKeys, userRoleKey)
 			}
 		}
@@ -955,7 +955,7 @@ func (kc *Catalog) fixDefaultDBIDConsistency(ctx context.Context, collMeta *pb.C
 }
 
 func (kc *Catalog) listAliasesBefore210(ctx context.Context, ts typeutil.Timestamp) ([]*model.Alias, error) {
-	_, values, err := kc.Snapshot.LoadWithPrefix(ctx, CollectionAliasMetaPrefix210, ts)
+	_, values, err := kc.Snapshot.LoadWithPrefix(ctx, CollectionAliasMetaPrefix210+"/", ts)
 	if err != nil {
 		return nil, err
 	}
@@ -1035,7 +1035,7 @@ func (kc *Catalog) ListCredentials(ctx context.Context) ([]string, error) {
 }
 
 func (kc *Catalog) ListCredentialsWithPasswd(ctx context.Context) (map[string]string, error) {
-	keys, values, err := kc.Txn.LoadWithPrefix(ctx, CredentialPrefix)
+	keys, values, err := kc.Txn.LoadWithPrefix(ctx, CredentialPrefix+"/")
 	if err != nil {
 		log.Ctx(ctx).Error("list all credential usernames fail", zap.String("prefix", CredentialPrefix), zap.Error(err))
 		return nil, err
@@ -1073,12 +1073,12 @@ func (kc *Catalog) remove(ctx context.Context, k string) error {
 }
 
 func (kc *Catalog) CreateRole(ctx context.Context, tenant string, entity *milvuspb.RoleEntity) error {
-	k := funcutil.HandleTenantForEtcdKey(RolePrefix, tenant, entity.Name)
+	k := RolePrefix + "/" + entity.Name
 	return kc.Txn.Save(ctx, k, "")
 }
 
 func (kc *Catalog) DropRole(ctx context.Context, tenant string, roleName string) error {
-	k := funcutil.HandleTenantForEtcdKey(RolePrefix, tenant, roleName)
+	k := RolePrefix + "/" + roleName
 	roleResults, err := kc.ListRole(ctx, tenant, &milvuspb.RoleEntity{Name: roleName}, true)
 	if err != nil && !errors.Is(err, merr.ErrIoKeyNotFound) {
 		log.Ctx(ctx).Warn("fail to list role", zap.String("key", k), zap.Error(err))
@@ -1090,7 +1090,7 @@ func (kc *Catalog) DropRole(ctx context.Context, tenant string, roleName string)
 	for _, roleResult := range roleResults {
 		if roleResult.Role.Name == roleName {
 			for _, userInfo := range roleResult.Users {
-				userRoleKey := funcutil.HandleTenantForEtcdKey(RoleMappingPrefix, tenant, fmt.Sprintf("%s/%s", userInfo.Name, roleName))
+				userRoleKey := fmt.Sprintf("%s/%s/%s", RoleMappingPrefix, userInfo.Name, roleName)
 				deleteKeys = append(deleteKeys, userRoleKey)
 			}
 		}
@@ -1105,7 +1105,7 @@ func (kc *Catalog) DropRole(ctx context.Context, tenant string, roleName string)
 }
 
 func (kc *Catalog) AlterUserRole(ctx context.Context, tenant string, userEntity *milvuspb.UserEntity, roleEntity *milvuspb.RoleEntity, operateType milvuspb.OperateUserRoleType) error {
-	k := funcutil.HandleTenantForEtcdKey(RoleMappingPrefix, tenant, fmt.Sprintf("%s/%s", userEntity.Name, roleEntity.Name))
+	k := fmt.Sprintf("%s/%s/%s", RoleMappingPrefix, userEntity.Name, roleEntity.Name)
 	switch operateType {
 	case milvuspb.OperateUserRoleType_AddUserToRole:
 		return kc.Txn.Save(ctx, k, "")
@@ -1120,7 +1120,7 @@ func (kc *Catalog) ListRole(ctx context.Context, tenant string, entity *milvuspb
 
 	roleToUsers := make(map[string][]string)
 	if includeUserInfo {
-		roleMappingKey := funcutil.HandleTenantForEtcdKey(RoleMappingPrefix, tenant, "")
+		roleMappingKey := funcutil.HandleTenantForEtcdPrefix(RoleMappingPrefix, tenant)
 		keys, _, err := kc.Txn.LoadWithPrefix(ctx, roleMappingKey)
 		if err != nil {
 			log.Ctx(ctx).Error("fail to load role mappings", zap.String("key", roleMappingKey), zap.Error(err))
@@ -1128,7 +1128,7 @@ func (kc *Catalog) ListRole(ctx context.Context, tenant string, entity *milvuspb
 		}
 
 		for _, key := range keys {
-			roleMappingInfos := typeutil.AfterN(key, roleMappingKey+"/", "/")
+			roleMappingInfos := typeutil.AfterN(key, roleMappingKey, "/")
 			if len(roleMappingInfos) != 2 {
 				log.Ctx(ctx).Warn("invalid role mapping key", zap.String("string", key), zap.String("sub_string", roleMappingKey))
 				continue
@@ -1151,14 +1151,14 @@ func (kc *Catalog) ListRole(ctx context.Context, tenant string, entity *milvuspb
 	}
 
 	if entity == nil {
-		roleKey := funcutil.HandleTenantForEtcdKey(RolePrefix, tenant, "")
+		roleKey := funcutil.HandleTenantForEtcdPrefix(RolePrefix, tenant)
 		keys, _, err := kc.Txn.LoadWithPrefix(ctx, roleKey)
 		if err != nil {
 			log.Ctx(ctx).Error("fail to load roles", zap.String("key", roleKey), zap.Error(err))
 			return results, err
 		}
 		for _, key := range keys {
-			infoArr := typeutil.AfterN(key, roleKey+"/", "/")
+			infoArr := typeutil.AfterN(key, roleKey, "/")
 			if len(infoArr) != 1 || len(infoArr[0]) == 0 {
 				log.Ctx(ctx).Warn("invalid role key", zap.String("string", key), zap.String("sub_string", roleKey))
 				continue
@@ -1169,7 +1169,7 @@ func (kc *Catalog) ListRole(ctx context.Context, tenant string, entity *milvuspb
 		if funcutil.IsEmptyString(entity.Name) {
 			return results, errors.New("role name in the role entity is empty")
 		}
-		roleKey := funcutil.HandleTenantForEtcdKey(RolePrefix, tenant, entity.Name)
+		roleKey := RolePrefix + "/" + entity.Name
 		_, err := kc.Txn.Load(ctx, roleKey)
 		if err != nil {
 			log.Ctx(ctx).Warn("fail to load a role", zap.String("key", roleKey), zap.Error(err))
@@ -1183,7 +1183,7 @@ func (kc *Catalog) ListRole(ctx context.Context, tenant string, entity *milvuspb
 
 func (kc *Catalog) getRolesByUsername(ctx context.Context, tenant string, username string) ([]string, error) {
 	var roles []string
-	k := funcutil.HandleTenantForEtcdKey(RoleMappingPrefix, tenant, username) + "/"
+	k := funcutil.HandleTenantForEtcdPrefix(RoleMappingPrefix, tenant, username)
 	keys, _, err := kc.Txn.LoadWithPrefix(ctx, k)
 	if err != nil {
 		log.Ctx(ctx).Error("fail to load role mappings by the username", zap.String("key", k), zap.Error(err))
@@ -1262,7 +1262,7 @@ func (kc *Catalog) ListUser(ctx context.Context, tenant string, entity *milvuspb
 func (kc *Catalog) AlterGrant(ctx context.Context, tenant string, entity *milvuspb.GrantEntity, operateType milvuspb.OperatePrivilegeType) error {
 	var (
 		privilegeName = entity.Grantor.Privilege.Name
-		k             = funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, fmt.Sprintf("%s/%s/%s", entity.Role.Name, entity.Object.Name, funcutil.CombineObjectName(entity.DbName, entity.ObjectName)))
+		k             = fmt.Sprintf("%s/%s/%s/%s", GranteePrefix, entity.Role.Name, entity.Object.Name, funcutil.CombineObjectName(entity.DbName, entity.ObjectName))
 		idStr         string
 		v             string
 		err           error
@@ -1270,7 +1270,7 @@ func (kc *Catalog) AlterGrant(ctx context.Context, tenant string, entity *milvus
 
 	// Compatible with logic without db
 	if entity.DbName == util.DefaultDBName {
-		v, err = kc.Txn.Load(ctx, funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, fmt.Sprintf("%s/%s/%s", entity.Role.Name, entity.Object.Name, entity.ObjectName)))
+		v, err = kc.Txn.Load(ctx, fmt.Sprintf("%s/%s/%s/%s", GranteePrefix, entity.Role.Name, entity.Object.Name, entity.ObjectName))
 		if err == nil {
 			idStr = v
 		}
@@ -1298,7 +1298,7 @@ func (kc *Catalog) AlterGrant(ctx context.Context, tenant string, entity *milvus
 			}
 		}
 	}
-	k = funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, fmt.Sprintf("%s/%s", idStr, privilegeName))
+	k = fmt.Sprintf("%s/%s/%s", GranteeIDPrefix, idStr, privilegeName)
 	_, err = kc.Txn.Load(ctx, k)
 	if err != nil {
 		log.Ctx(ctx).Warn("fail to load the grantee id", zap.String("key", k), zap.Error(err))
@@ -1338,7 +1338,7 @@ func (kc *Catalog) ListGrant(ctx context.Context, tenant string, entity *milvusp
 		if dbName != entity.DbName && dbName != util.AnyWord && entity.DbName != util.AnyWord {
 			return nil
 		}
-		granteeIDKey := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, v) + "/"
+		granteeIDKey := funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant, v)
 		keys, values, err := kc.Txn.LoadWithPrefix(ctx, granteeIDKey)
 		if err != nil {
 			log.Ctx(ctx).Error("fail to load the grantee ids", zap.String("key", granteeIDKey), zap.Error(err))
@@ -1370,7 +1370,7 @@ func (kc *Catalog) ListGrant(ctx context.Context, tenant string, entity *milvusp
 
 	if !funcutil.IsEmptyString(entity.ObjectName) && entity.Object != nil && !funcutil.IsEmptyString(entity.Object.Name) {
 		if entity.DbName == util.DefaultDBName {
-			granteeKey = funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, fmt.Sprintf("%s/%s/%s", entity.Role.Name, entity.Object.Name, entity.ObjectName))
+			granteeKey = fmt.Sprintf("%s/%s/%s/%s", GranteePrefix, entity.Role.Name, entity.Object.Name, entity.ObjectName)
 			v, err := kc.Txn.Load(ctx, granteeKey)
 			if err == nil {
 				err = appendGrantEntity(v, entity.Object.Name, entity.ObjectName)
@@ -1381,14 +1381,14 @@ func (kc *Catalog) ListGrant(ctx context.Context, tenant string, entity *milvusp
 		}
 
 		if entity.DbName != util.AnyWord {
-			granteeKey = funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, fmt.Sprintf("%s/%s/%s", entity.Role.Name, entity.Object.Name, funcutil.CombineObjectName(util.AnyWord, entity.ObjectName)))
+			granteeKey = fmt.Sprintf("%s/%s/%s/%s", GranteePrefix, entity.Role.Name, entity.Object.Name, funcutil.CombineObjectName(util.AnyWord, entity.ObjectName))
 			v, err := kc.Txn.Load(ctx, granteeKey)
 			if err == nil {
 				_ = appendGrantEntity(v, entity.Object.Name, funcutil.CombineObjectName(util.AnyWord, entity.ObjectName))
 			}
 		}
 
-		granteeKey = funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, fmt.Sprintf("%s/%s/%s", entity.Role.Name, entity.Object.Name, funcutil.CombineObjectName(entity.DbName, entity.ObjectName)))
+		granteeKey = fmt.Sprintf("%s/%s/%s/%s", GranteePrefix, entity.Role.Name, entity.Object.Name, funcutil.CombineObjectName(entity.DbName, entity.ObjectName))
 		v, err := kc.Txn.Load(ctx, granteeKey)
 		if err != nil {
 			log.Ctx(ctx).Error("fail to load the grant privilege entity", zap.String("key", granteeKey), zap.Error(err))
@@ -1399,7 +1399,7 @@ func (kc *Catalog) ListGrant(ctx context.Context, tenant string, entity *milvusp
 			return entities, err
 		}
 	} else {
-		granteeKey = funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, entity.Role.Name) + "/"
+		granteeKey = funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant, entity.Role.Name)
 		keys, values, err := kc.Txn.LoadWithPrefix(ctx, granteeKey)
 		if err != nil {
 			log.Ctx(ctx).Error("fail to load grant privilege entities", zap.String("key", granteeKey), zap.Error(err))
@@ -1422,7 +1422,7 @@ func (kc *Catalog) ListGrant(ctx context.Context, tenant string, entity *milvusp
 }
 
 func (kc *Catalog) DeleteGrantByCollectionName(ctx context.Context, tenant string, dbName string, collectionName string) error {
-	granteeKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, "")
+	granteeKey := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant)
 	keys, values, err := kc.Txn.LoadWithPrefix(ctx, granteeKey)
 	if err != nil {
 		log.Ctx(ctx).Warn("fail to load grant privilege entities for collection cleanup",
@@ -1433,7 +1433,7 @@ func (kc *Catalog) DeleteGrantByCollectionName(ctx context.Context, tenant strin
 	var exactRemoveKeys []string
 	var prefixRemoveKeys []string
 	for i, key := range keys {
-		grantInfos := typeutil.AfterN(key, granteeKey+"/", "/")
+		grantInfos := typeutil.AfterN(key, granteeKey, "/")
 		if len(grantInfos) != 3 {
 			continue
 		}
@@ -1447,11 +1447,10 @@ func (kc *Catalog) DeleteGrantByCollectionName(ctx context.Context, tenant strin
 			// LoadWithPrefix returns full etcd keys (with rootPath prefix),
 			// but MultiSaveAndRemove prepends rootPath again, so we must
 			// use the logical key to avoid double-prefix.
-			logicalKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant,
-				fmt.Sprintf("%s/%s/%s", grantInfos[0], grantInfos[1], grantInfos[2]))
+			logicalKey := fmt.Sprintf("%s/%s/%s/%s", GranteePrefix, grantInfos[0], grantInfos[1], grantInfos[2])
 			exactRemoveKeys = append(exactRemoveKeys, logicalKey)
 			// Use prefix deletion for the granteeID key (has sub-keys)
-			granteeIDKey := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, values[i]+"/")
+			granteeIDKey := funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant, values[i])
 			prefixRemoveKeys = append(prefixRemoveKeys, granteeIDKey)
 		}
 	}
@@ -1484,7 +1483,7 @@ func (kc *Catalog) DeleteGrantByCollectionName(ctx context.Context, tenant strin
 }
 
 func (kc *Catalog) MigrateGrantCollectionName(ctx context.Context, tenant string, oldDBName string, oldName string, newDBName string, newName string) error {
-	granteeKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, "")
+	granteeKey := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant)
 	keys, values, err := kc.Txn.LoadWithPrefix(ctx, granteeKey)
 	if err != nil {
 		log.Ctx(ctx).Warn("fail to load grant privilege entities for collection migration",
@@ -1495,7 +1494,7 @@ func (kc *Catalog) MigrateGrantCollectionName(ctx context.Context, tenant string
 	saves := make(map[string]string)
 	var removeKeys []string
 	for i, key := range keys {
-		grantInfos := typeutil.AfterN(key, granteeKey+"/", "/")
+		grantInfos := typeutil.AfterN(key, granteeKey, "/")
 		if len(grantInfos) != 3 {
 			continue
 		}
@@ -1509,7 +1508,7 @@ func (kc *Catalog) MigrateGrantCollectionName(ctx context.Context, tenant string
 			// Load GranteeIDPrefix entries FIRST, before queuing the parent key
 			// for migration. If this load fails, we skip both parent and child
 			// to avoid half-migration (parent migrated, children lost).
-			oldGranteeIDKey := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, oldIdStr+"/")
+			oldGranteeIDKey := funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant, oldIdStr)
 			idKeys, idValues, loadErr := kc.Txn.LoadWithPrefix(ctx, oldGranteeIDKey)
 			if loadErr != nil {
 				log.Ctx(ctx).Warn("fail to load grantee id entries for migration, skipping this grant entirely",
@@ -1521,16 +1520,14 @@ func (kc *Catalog) MigrateGrantCollectionName(ctx context.Context, tenant string
 			// to avoid sharing permission space with a future collection
 			// that reuses the old name.
 			newObjName := funcutil.CombineObjectName(newDBName, newName)
-			newKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant,
-				fmt.Sprintf("%s/%s/%s", grantInfos[0], grantInfos[1], newObjName))
+			newKey := fmt.Sprintf("%s/%s/%s/%s", GranteePrefix, grantInfos[0], grantInfos[1], newObjName)
 			newIdStr := crypto.MD5(newKey)
 			saves[newKey] = newIdStr
 			// Reconstruct logical key (without etcd rootPath) for deletion.
 			// LoadWithPrefix returns full etcd keys (with rootPath prefix),
 			// but MultiSaveAndRemove prepends rootPath again, so we must
 			// use the logical key to avoid double-prefix.
-			oldKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant,
-				fmt.Sprintf("%s/%s/%s", grantInfos[0], grantInfos[1], grantInfos[2]))
+			oldKey := fmt.Sprintf("%s/%s/%s/%s", GranteePrefix, grantInfos[0], grantInfos[1], grantInfos[2])
 			removeKeys = append(removeKeys, oldKey)
 
 			// Migrate GranteeIDPrefix entries from oldIdStr to newIdStr
@@ -1543,12 +1540,10 @@ func (kc *Catalog) MigrateGrantCollectionName(ctx context.Context, tenant string
 						zap.String("idKey", idKey), zap.String("prefix", oldGranteeIDKey))
 					continue
 				}
-				newIDKey := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant,
-					fmt.Sprintf("%s/%s", newIdStr, privilegeName))
+				newIDKey := fmt.Sprintf("%s/%s/%s", GranteeIDPrefix, newIdStr, privilegeName)
 				saves[newIDKey] = idValues[j]
 				// Reconstruct logical key for deletion
-				oldIDKey := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant,
-					fmt.Sprintf("%s/%s", oldIdStr, privilegeName))
+				oldIDKey := fmt.Sprintf("%s/%s/%s", GranteeIDPrefix, oldIdStr, privilegeName)
 				removeKeys = append(removeKeys, oldIDKey)
 			}
 		}
@@ -1570,7 +1565,7 @@ func (kc *Catalog) MigrateGrantCollectionName(ctx context.Context, tenant string
 
 func (kc *Catalog) DeleteGrant(ctx context.Context, tenant string, role *milvuspb.RoleEntity) error {
 	var (
-		k          = funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, role.Name+"/")
+		k          = funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant, role.Name)
 		err        error
 		removeKeys []string
 	)
@@ -1584,7 +1579,7 @@ func (kc *Catalog) DeleteGrant(ctx context.Context, tenant string, role *milvusp
 		return err
 	}
 	for _, v := range values {
-		granteeIDKey := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, v+"/")
+		granteeIDKey := funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant, v)
 		removeKeys = append(removeKeys, granteeIDKey)
 	}
 
@@ -1596,7 +1591,7 @@ func (kc *Catalog) DeleteGrant(ctx context.Context, tenant string, role *milvusp
 
 func (kc *Catalog) ListPolicy(ctx context.Context, tenant string) ([]*milvuspb.GrantEntity, error) {
 	var grants []*milvuspb.GrantEntity
-	granteeKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, "")
+	granteeKey := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant)
 	keys, values, err := kc.Txn.LoadWithPrefix(ctx, granteeKey)
 	if err != nil {
 		log.Ctx(ctx).Error("fail to load all grant privilege entities", zap.String("key", granteeKey), zap.Error(err))
@@ -1604,19 +1599,19 @@ func (kc *Catalog) ListPolicy(ctx context.Context, tenant string) ([]*milvuspb.G
 	}
 
 	for i, key := range keys {
-		grantInfos := typeutil.AfterN(key, granteeKey+"/", "/")
+		grantInfos := typeutil.AfterN(key, granteeKey, "/")
 		if len(grantInfos) != 3 {
 			log.Ctx(ctx).Warn("invalid grantee key", zap.String("string", key), zap.String("sub_string", granteeKey))
 			continue
 		}
-		granteeIDKey := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, values[i])
+		granteeIDKey := funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant, values[i])
 		idKeys, _, err := kc.Txn.LoadWithPrefix(ctx, granteeIDKey)
 		if err != nil {
 			log.Ctx(ctx).Error("fail to load the grantee ids", zap.String("key", granteeIDKey), zap.Error(err))
 			return []*milvuspb.GrantEntity{}, err
 		}
 		for _, idKey := range idKeys {
-			granteeIDInfos := typeutil.AfterN(idKey, granteeIDKey+"/", "/")
+			granteeIDInfos := typeutil.AfterN(idKey, granteeIDKey, "/")
 			if len(granteeIDInfos) != 1 {
 				log.Ctx(ctx).Warn("invalid grantee id", zap.String("string", idKey), zap.String("sub_string", granteeIDKey))
 				continue
@@ -1645,7 +1640,7 @@ func (kc *Catalog) ListPolicy(ctx context.Context, tenant string) ([]*milvuspb.G
 
 func (kc *Catalog) ListUserRole(ctx context.Context, tenant string) ([]string, error) {
 	var userRoles []string
-	k := funcutil.HandleTenantForEtcdKey(RoleMappingPrefix, tenant, "")
+	k := funcutil.HandleTenantForEtcdPrefix(RoleMappingPrefix, tenant)
 	keys, _, err := kc.Txn.LoadWithPrefix(ctx, k)
 	if err != nil {
 		log.Ctx(ctx).Error("fail to load all user-role mappings", zap.String("key", k), zap.Error(err))
@@ -1653,7 +1648,7 @@ func (kc *Catalog) ListUserRole(ctx context.Context, tenant string) ([]string, e
 	}
 
 	for _, key := range keys {
-		userRolesInfos := typeutil.AfterN(key, k+"/", "/")
+		userRolesInfos := typeutil.AfterN(key, k, "/")
 		if len(userRolesInfos) != 2 {
 			log.Ctx(ctx).Warn("invalid user-role key", zap.String("string", key), zap.String("sub_string", k))
 			continue
@@ -1819,7 +1814,7 @@ func (kc *Catalog) SavePrivilegeGroup(ctx context.Context, data *milvuspb.Privil
 }
 
 func (kc *Catalog) ListPrivilegeGroups(ctx context.Context) ([]*milvuspb.PrivilegeGroupInfo, error) {
-	_, vals, err := kc.Txn.LoadWithPrefix(ctx, PrivilegeGroupPrefix)
+	_, vals, err := kc.Txn.LoadWithPrefix(ctx, PrivilegeGroupPrefix+"/")
 	if err != nil {
 		log.Ctx(ctx).Error("failed to list privilege groups", zap.String("prefix", PrivilegeGroupPrefix), zap.Error(err))
 		return nil, err
@@ -1866,7 +1861,7 @@ func (kc *Catalog) RemoveFileResource(ctx context.Context, resourceID int64, ver
 }
 
 func (kc *Catalog) ListFileResource(ctx context.Context) ([]*internalpb.FileResourceInfo, uint64, error) {
-	_, values, err := kc.Txn.LoadWithPrefix(ctx, FileResourceMetaPrefix)
+	_, values, err := kc.Txn.LoadWithPrefix(ctx, FileResourceMetaPrefix+"/")
 	if err != nil {
 		return nil, 0, err
 	}

--- a/internal/metastore/kv/rootcoord/kv_catalog_test.go
+++ b/internal/metastore/kv/rootcoord/kv_catalog_test.go
@@ -103,7 +103,7 @@ func TestCatalog_ListCollections(t *testing.T) {
 	t.Run("load collection with prefix fail", func(t *testing.T) {
 		kv := mocks.NewSnapShotKV(t)
 		ts := uint64(1)
-		kv.On("LoadWithPrefix", mock.Anything, CollectionMetaPrefix, ts).
+		kv.On("LoadWithPrefix", mock.Anything, CollectionMetaPrefix+"/", ts).
 			Return(nil, nil, targetErr)
 
 		kc := NewCatalog(nil, kv)
@@ -118,7 +118,7 @@ func TestCatalog_ListCollections(t *testing.T) {
 
 		bColl, err := proto.Marshal(coll2)
 		assert.NoError(t, err)
-		kv.On("LoadWithPrefix", mock.Anything, CollectionMetaPrefix, ts).
+		kv.On("LoadWithPrefix", mock.Anything, CollectionMetaPrefix+"/", ts).
 			Return([]string{"key"}, []string{string(bColl)}, nil)
 		kv.EXPECT().LoadWithPrefix(mock.Anything, mock.Anything, mock.Anything).Return(nil, nil, targetErr)
 		kc := NewCatalog(nil, kv)
@@ -134,7 +134,7 @@ func TestCatalog_ListCollections(t *testing.T) {
 
 		bColl, err := proto.Marshal(coll2)
 		assert.NoError(t, err)
-		kv.On("LoadWithPrefix", mock.Anything, CollectionMetaPrefix, ts).
+		kv.On("LoadWithPrefix", mock.Anything, CollectionMetaPrefix+"/", ts).
 			Return([]string{"key"}, []string{string(bColl)}, nil)
 
 		partitionMeta := &pb.PartitionInfo{}
@@ -165,7 +165,7 @@ func TestCatalog_ListCollections(t *testing.T) {
 
 		bColl, err := proto.Marshal(coll1)
 		assert.NoError(t, err)
-		kv.On("LoadWithPrefix", mock.Anything, CollectionMetaPrefix, ts).
+		kv.On("LoadWithPrefix", mock.Anything, CollectionMetaPrefix+"/", ts).
 			Return([]string{"key"}, []string{string(bColl)}, nil)
 		kv.On("MultiSaveAndRemove", mock.Anything, mock.Anything, mock.Anything, ts).Return(nil)
 		kc := NewCatalog(nil, kv)
@@ -239,7 +239,7 @@ func TestCatalog_ListCollections(t *testing.T) {
 		aColl, err := proto.Marshal(coll3)
 		assert.NoError(t, err)
 
-		kv.On("LoadWithPrefix", mock.Anything, CollectionMetaPrefix, ts).
+		kv.On("LoadWithPrefix", mock.Anything, CollectionMetaPrefix+"/", ts).
 			Return([]string{"key", "key2"}, []string{string(bColl), string(aColl)}, nil)
 
 		partitionMeta := &pb.PartitionInfo{}
@@ -1676,10 +1676,10 @@ func TestRBAC_Credential(t *testing.T) {
 			c      = NewCatalog(kvmock, nil)
 
 			validName              = "user1"
-			validUserRoleKeyPrefix = funcutil.HandleTenantForEtcdKey(RoleMappingPrefix, util.DefaultTenant, validName) + "/"
+			validUserRoleKeyPrefix = funcutil.HandleTenantForEtcdPrefix(RoleMappingPrefix, util.DefaultTenant, validName)
 
 			dropFailName          = "drop-fail"
-			dropUserRoleKeyPrefix = funcutil.HandleTenantForEtcdKey(RoleMappingPrefix, util.DefaultTenant, dropFailName) + "/"
+			dropUserRoleKeyPrefix = funcutil.HandleTenantForEtcdPrefix(RoleMappingPrefix, util.DefaultTenant, dropFailName)
 			getFailName           = "get-fail"
 		)
 
@@ -1808,7 +1808,7 @@ func TestRBAC_Credential(t *testing.T) {
 
 func TestRBAC_Role(t *testing.T) {
 	ctx := context.TODO()
-	tenant := "default"
+	tenant := util.DefaultTenant
 
 	t.Run("test remove", func(t *testing.T) {
 		var (
@@ -1875,27 +1875,27 @@ func TestRBAC_Role(t *testing.T) {
 			getFailName = "get-fail"
 		)
 
-		kvmock.EXPECT().MultiRemove(mock.Anything, []string{funcutil.HandleTenantForEtcdKey(RolePrefix, tenant, errorName)}).Return(errors.New("remove error"))
+		kvmock.EXPECT().MultiRemove(mock.Anything, []string{RolePrefix + "/" + errorName}).Return(errors.New("remove error"))
 		kvmock.EXPECT().MultiRemove(mock.Anything, []string{
-			funcutil.HandleTenantForEtcdKey(RolePrefix, tenant, validName),
-			funcutil.HandleTenantForEtcdKey(RoleMappingPrefix, tenant, fmt.Sprintf("%s/%s", "user1", validName)),
-			funcutil.HandleTenantForEtcdKey(RoleMappingPrefix, tenant, fmt.Sprintf("%s/%s", "user2", validName)),
+			RolePrefix + "/" + validName,
+			fmt.Sprintf("%s/%s/%s", RoleMappingPrefix, "user1", validName),
+			fmt.Sprintf("%s/%s/%s", RoleMappingPrefix, "user2", validName),
 		}).Return(nil)
 		kvmock.EXPECT().MultiRemove(mock.Anything, mock.Anything).Return(errors.New("mock multi remove error"))
 
 		getRoleMappingKey := func(username, rolename string) string {
-			return funcutil.HandleTenantForEtcdKey(RoleMappingPrefix, tenant, fmt.Sprintf("%s/%s", username, rolename))
+			return fmt.Sprintf("%s/%s/%s", RoleMappingPrefix, username, rolename)
 		}
 
-		kvmock.EXPECT().LoadWithPrefix(mock.Anything, funcutil.HandleTenantForEtcdKey(RoleMappingPrefix, tenant, "")).Return(
+		kvmock.EXPECT().LoadWithPrefix(mock.Anything, funcutil.HandleTenantForEtcdPrefix(RoleMappingPrefix, tenant)).Return(
 			[]string{getRoleMappingKey("user1", validName), getRoleMappingKey("user2", validName), getRoleMappingKey("user3", "role3")},
 			[]string{},
 			nil,
 		)
 
-		kvmock.EXPECT().Load(mock.Anything, funcutil.HandleTenantForEtcdKey(RolePrefix, tenant, getFailName)).Return("", errors.New("mock load error"))
-		kvmock.EXPECT().Load(mock.Anything, funcutil.HandleTenantForEtcdKey(RolePrefix, tenant, validName)).Return("", nil)
-		kvmock.EXPECT().Load(mock.Anything, funcutil.HandleTenantForEtcdKey(RolePrefix, tenant, errorName)).Return("", nil)
+		kvmock.EXPECT().Load(mock.Anything, RolePrefix+"/"+getFailName).Return("", errors.New("mock load error"))
+		kvmock.EXPECT().Load(mock.Anything, RolePrefix+"/"+validName).Return("", nil)
+		kvmock.EXPECT().Load(mock.Anything, RolePrefix+"/"+errorName).Return("", nil)
 
 		tests := []struct {
 			description string
@@ -1946,7 +1946,7 @@ func TestRBAC_Role(t *testing.T) {
 				c      = NewCatalog(kvmock, nil)
 
 				errorLoad     = "error"
-				errorLoadPath = funcutil.HandleTenantForEtcdKey(RolePrefix, tenant, errorLoad)
+				errorLoadPath = RolePrefix + "/" + errorLoad
 			)
 
 			kvmock.EXPECT().Load(mock.Anything, errorLoadPath).Call.Return("", errors.New("mock load error"))
@@ -1958,9 +1958,9 @@ func TestRBAC_Role(t *testing.T) {
 				func(ctx context.Context, key string) []string {
 					if loadWithPrefixReturn.Load() {
 						return []string{
-							fmt.Sprintf("%s/%s/%s", RoleMappingPrefix, tenant, "user1/role1"),
-							fmt.Sprintf("%s/%s/%s", RoleMappingPrefix, tenant, "user2/role2"),
-							fmt.Sprintf("%s/%s/%s", RoleMappingPrefix, tenant, "user3/role3"),
+							fmt.Sprintf("%s/%s/%s", RoleMappingPrefix, "user1", "role1"),
+							fmt.Sprintf("%s/%s/%s", RoleMappingPrefix, "user2", "role2"),
+							fmt.Sprintf("%s/%s/%s", RoleMappingPrefix, "user3", "role3"),
 							"random",
 						}
 					}
@@ -2029,9 +2029,9 @@ func TestRBAC_Role(t *testing.T) {
 				func(ctx context.Context, key string) []string {
 					if loadWithPrefixReturn.Load() {
 						return []string{
-							fmt.Sprintf("%s/%s/%s", RolePrefix, tenant, "role1"),
-							fmt.Sprintf("%s/%s/%s", RolePrefix, tenant, "role2"),
-							fmt.Sprintf("%s/%s/%s", RolePrefix, tenant, "role3"),
+							RolePrefix + "/role1",
+							RolePrefix + "/role2",
+							RolePrefix + "/role3",
 							"random",
 						}
 					}
@@ -2079,14 +2079,14 @@ func TestRBAC_Role(t *testing.T) {
 			c      = NewCatalog(kvmock, nil).(*Catalog)
 
 			invalidUser    = "invalid-user"
-			invalidUserKey = funcutil.HandleTenantForEtcdKey(RoleMappingPrefix, tenant, invalidUser) + "/"
+			invalidUserKey = funcutil.HandleTenantForEtcdPrefix(RoleMappingPrefix, tenant, invalidUser)
 		)
 		// returns error for invalidUserKey
 		kvmock.EXPECT().LoadWithPrefix(mock.Anything, invalidUserKey).Call.Return(
 			nil, nil, errors.New("Mock load with prefix wrong"))
 
 		// Returns keys for RoleMappingPrefix/tenant/user1/ (with trailing slash after the fix)
-		user1Key := funcutil.HandleTenantForEtcdKey(RoleMappingPrefix, tenant, "user1") + "/"
+		user1Key := funcutil.HandleTenantForEtcdPrefix(RoleMappingPrefix, tenant, "user1")
 		kvmock.EXPECT().LoadWithPrefix(mock.Anything, user1Key).Call.Return(
 			func(ctx context.Context, key string) []string {
 				return []string{
@@ -2098,7 +2098,7 @@ func TestRBAC_Role(t *testing.T) {
 
 		// Returns keys for CredentialPrefix
 		var loadCredentialPrefixReturn atomic.Bool
-		kvmock.EXPECT().LoadWithPrefix(mock.Anything, CredentialPrefix).Call.Return(
+		kvmock.EXPECT().LoadWithPrefix(mock.Anything, CredentialPrefix+"/").Call.Return(
 			func(ctx context.Context, key string) []string {
 				if loadCredentialPrefixReturn.Load() {
 					return []string{
@@ -2228,9 +2228,9 @@ func TestRBAC_Role(t *testing.T) {
 			func(ctx context.Context, key string) []string {
 				if loadWithPrefixReturn.Load() {
 					return []string{
-						fmt.Sprintf("%s/%s/%s", RoleMappingPrefix, tenant, "user1/role1"),
-						fmt.Sprintf("%s/%s/%s", RoleMappingPrefix, tenant, "user1/role2"),
-						fmt.Sprintf("%s/%s/%s", RoleMappingPrefix, tenant, "user3/role3"),
+						fmt.Sprintf("%s/%s/%s", RoleMappingPrefix, "user1", "role1"),
+						fmt.Sprintf("%s/%s/%s", RoleMappingPrefix, "user1", "role2"),
+						fmt.Sprintf("%s/%s/%s", RoleMappingPrefix, "user3", "role3"),
 						"random",
 					}
 				}
@@ -2297,18 +2297,18 @@ func TestRBAC_Grant(t *testing.T) {
 			c      = NewCatalog(kvmock, nil)
 		)
 
-		validRoleKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, fmt.Sprintf("%s/%s/%s", validRole, object, objName))
+		validRoleKey := fmt.Sprintf("%s/%s/%s/%s", GranteePrefix, validRole, object, objName)
 		validRoleValue := crypto.MD5(validRoleKey)
 
-		invalidRoleKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, fmt.Sprintf("%s/%s/%s", invalidRole, object, objName))
-		invalidRoleKeyWithDb := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, fmt.Sprintf("%s/%s/%s", invalidRole, object, funcutil.CombineObjectName(util.DefaultDBName, objName)))
+		invalidRoleKey := fmt.Sprintf("%s/%s/%s/%s", GranteePrefix, invalidRole, object, objName)
+		invalidRoleKeyWithDb := fmt.Sprintf("%s/%s/%s/%s", GranteePrefix, invalidRole, object, funcutil.CombineObjectName(util.DefaultDBName, objName))
 
-		keyNotExistRoleKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, fmt.Sprintf("%s/%s/%s", keyNotExistRole, object, objName))
-		keyNotExistRoleKeyWithDb := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, fmt.Sprintf("%s/%s/%s", keyNotExistRole, object, funcutil.CombineObjectName(util.DefaultDBName, objName)))
+		keyNotExistRoleKey := fmt.Sprintf("%s/%s/%s/%s", GranteePrefix, keyNotExistRole, object, objName)
+		keyNotExistRoleKeyWithDb := fmt.Sprintf("%s/%s/%s/%s", GranteePrefix, keyNotExistRole, object, funcutil.CombineObjectName(util.DefaultDBName, objName))
 		keyNotExistRoleValueWithDb := crypto.MD5(keyNotExistRoleKeyWithDb)
 
-		errorSaveRoleKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, fmt.Sprintf("%s/%s/%s", errorSaveRole, object, objName))
-		errorSaveRoleKeyWithDb := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, fmt.Sprintf("%s/%s/%s", errorSaveRole, object, funcutil.CombineObjectName(util.DefaultDBName, objName)))
+		errorSaveRoleKey := fmt.Sprintf("%s/%s/%s/%s", GranteePrefix, errorSaveRole, object, objName)
+		errorSaveRoleKeyWithDb := fmt.Sprintf("%s/%s/%s/%s", GranteePrefix, errorSaveRole, object, funcutil.CombineObjectName(util.DefaultDBName, objName))
 
 		// Mock return in kv_catalog.go:AlterGrant:L815
 		kvmock.EXPECT().Load(mock.Anything, validRoleKey).Call.
@@ -2341,10 +2341,10 @@ func TestRBAC_Grant(t *testing.T) {
 		kvmock.EXPECT().Save(mock.Anything, keyNotExistRoleKeyWithDb, mock.Anything).Return(nil)
 		kvmock.EXPECT().Save(mock.Anything, errorSaveRoleKeyWithDb, mock.Anything).Return(errors.New("mock save error role"))
 
-		validPrivilegeKey := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, fmt.Sprintf("%s/%s", validRoleValue, validPrivilege))
-		invalidPrivilegeKey := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, fmt.Sprintf("%s/%s", validRoleValue, invalidPrivilege))
-		keyNotExistPrivilegeKey := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, fmt.Sprintf("%s/%s", validRoleValue, keyNotExistPrivilege))
-		keyNotExistPrivilegeKey2WithDb := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, fmt.Sprintf("%s/%s", keyNotExistRoleValueWithDb, keyNotExistPrivilege2))
+		validPrivilegeKey := fmt.Sprintf("%s/%s/%s", GranteeIDPrefix, validRoleValue, validPrivilege)
+		invalidPrivilegeKey := fmt.Sprintf("%s/%s/%s", GranteeIDPrefix, validRoleValue, invalidPrivilege)
+		keyNotExistPrivilegeKey := fmt.Sprintf("%s/%s/%s", GranteeIDPrefix, validRoleValue, keyNotExistPrivilege)
+		keyNotExistPrivilegeKey2WithDb := fmt.Sprintf("%s/%s/%s", GranteeIDPrefix, keyNotExistRoleValueWithDb, keyNotExistPrivilege2)
 
 		// Mock return in kv_catalog.go:AlterGrant:L838
 		kvmock.EXPECT().Load(mock.Anything, validPrivilegeKey).Call.Return("", nil)
@@ -2421,7 +2421,7 @@ func TestRBAC_Grant(t *testing.T) {
 
 		t.Run("test Revoke", func(t *testing.T) {
 			invalidPrivilegeRemove := "p-remove"
-			invalidPrivilegeRemoveKey := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, fmt.Sprintf("%s/%s", validRoleValue, invalidPrivilegeRemove))
+			invalidPrivilegeRemoveKey := fmt.Sprintf("%s/%s/%s", GranteeIDPrefix, validRoleValue, invalidPrivilegeRemove)
 
 			kvmock.EXPECT().Load(mock.Anything, invalidPrivilegeRemoveKey).Call.Return("", nil)
 			kvmock.EXPECT().Remove(mock.Anything, invalidPrivilegeRemoveKey).Return(errors.New("mock remove error"))
@@ -2483,11 +2483,11 @@ func TestRBAC_Grant(t *testing.T) {
 			c      = NewCatalog(kvmock, nil)
 
 			errorRole           = "error-role"
-			errorRolePrefix     = funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, errorRole+"/")
+			errorRolePrefix     = funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant, errorRole)
 			loadErrorRole       = "load-error-role"
-			loadErrorRolePrefix = funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, loadErrorRole+"/")
+			loadErrorRolePrefix = funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant, loadErrorRole)
 			granteeID           = "123456"
-			granteePrefix       = funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, granteeID+"/")
+			granteePrefix       = funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant, granteeID)
 		)
 
 		kvmock.EXPECT().LoadWithPrefix(mock.Anything, loadErrorRolePrefix).Call.Return(nil, nil, errors.New("mock loadWithPrefix error"))
@@ -2524,23 +2524,20 @@ func TestRBAC_Grant(t *testing.T) {
 		)
 
 		// Mock Load in kv_catalog.go:L901
-		validGranteeKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant,
-			fmt.Sprintf("%s/%s/%s", "role1", "obj1", "obj_name1"))
+		validGranteeKey := fmt.Sprintf("%s/%s/%s/%s", GranteePrefix, "role1", "obj1", "obj_name1")
 		kvmock.EXPECT().Load(mock.Anything, validGranteeKey).Call.
 			Return(func(ctx context.Context, key string) string { return crypto.MD5(key) }, nil)
-		validGranteeKey2 := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant,
-			fmt.Sprintf("%s/%s/%s", "role1", "obj2", "foo.obj_name2"))
+		validGranteeKey2 := fmt.Sprintf("%s/%s/%s/%s", GranteePrefix, "role1", "obj2", "foo.obj_name2")
 		kvmock.EXPECT().Load(mock.Anything, validGranteeKey2).Call.
 			Return(func(ctx context.Context, key string) string { return crypto.MD5(key) }, nil)
-		validGranteeKey3 := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant,
-			fmt.Sprintf("%s/%s/%s", "role1", "obj3", "*.obj_name3"))
+		validGranteeKey3 := fmt.Sprintf("%s/%s/%s/%s", GranteePrefix, "role1", "obj3", "*.obj_name3")
 		kvmock.EXPECT().Load(mock.Anything, validGranteeKey3).Call.
 			Return(func(ctx context.Context, key string) string { return crypto.MD5(key) }, nil)
 
 		kvmock.EXPECT().Load(mock.Anything, mock.Anything).Call.
 			Return("", errors.New("mock Load error"))
 
-		invalidRoleKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, invalidRole) + "/"
+		invalidRoleKey := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant, invalidRole)
 		kvmock.EXPECT().LoadWithPrefix(mock.Anything, invalidRoleKey).Call.Return(nil, nil, errors.New("mock loadWithPrefix error"))
 		kvmock.EXPECT().LoadWithPrefix(mock.Anything, mock.Anything).Call.Return(
 			func(ctx context.Context, key string) []string {
@@ -2668,10 +2665,10 @@ func TestRBAC_Grant(t *testing.T) {
 				if contains {
 					if secondLoadWithPrefixReturn.Load() {
 						return []string{
-							fmt.Sprintf("%s/%s", key, "PrivilegeLoad"),
-							fmt.Sprintf("%s/%s", key, "PrivilegeRelease"),
-							fmt.Sprintf("%s/%s", key, "random/a/b/c"),
-							fmt.Sprintf("%s/%s", key, util.AnyWord),
+							key + "PrivilegeLoad",
+							key + "PrivilegeRelease",
+							key + "random/a/b/c",
+							key + util.AnyWord,
 						}
 					}
 					return nil
@@ -2679,8 +2676,8 @@ func TestRBAC_Grant(t *testing.T) {
 
 				if firstLoadWithPrefixReturn.Load() {
 					return []string{
-						fmt.Sprintf("%s/%s", key, "role1/obj1/obj_name1"),
-						fmt.Sprintf("%s/%s", key, "role2/obj2/obj_name2"),
+						key + "role1/obj1/obj_name1",
+						key + "role2/obj2/obj_name2",
 						"random",
 					}
 				}
@@ -2690,8 +2687,8 @@ func TestRBAC_Grant(t *testing.T) {
 			func(ctx context.Context, key string) []string {
 				if firstLoadWithPrefixReturn.Load() {
 					return []string{
-						crypto.MD5(fmt.Sprintf("%s/%s", key, "obj1/obj_name1")),
-						crypto.MD5(fmt.Sprintf("%s/%s", key, "obj2/obj_name2")),
+						crypto.MD5(key + "obj1/obj_name1"),
+						crypto.MD5(key + "obj2/obj_name2"),
 					}
 				}
 				return nil
@@ -3067,7 +3064,7 @@ func TestRBAC_PrivilegeGroup(t *testing.T) {
 			c      = NewCatalog(kvmock, nil)
 		)
 
-		kvmock.EXPECT().LoadWithPrefix(mock.Anything, PrivilegeGroupPrefix).Return(
+		kvmock.EXPECT().LoadWithPrefix(mock.Anything, PrivilegeGroupPrefix+"/").Return(
 			[]string{key1, key2},
 			[]string{string(v1), string(v2)},
 			nil,
@@ -3145,7 +3142,7 @@ func TestRBACPrefixMatch(t *testing.T) {
 
 		// The fix adds "/" to the prefix, so query for "user1" uses prefix "RoleMappingPrefix/tenant/user1/"
 		// This ensures user10's data won't be matched
-		user1Prefix := funcutil.HandleTenantForEtcdKey(RoleMappingPrefix, tenant, "user1") + "/"
+		user1Prefix := funcutil.HandleTenantForEtcdPrefix(RoleMappingPrefix, tenant, "user1")
 
 		// Mock: return keys that match the prefix correctly
 		// Key format: prefix + roleName (where prefix already ends with "/")
@@ -3171,7 +3168,7 @@ func TestRBACPrefixMatch(t *testing.T) {
 		c := NewCatalog(kvmock, nil).(*Catalog)
 
 		// The fix adds "/" to the prefix for role query
-		role1Prefix := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, "role1") + "/"
+		role1Prefix := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant, "role1")
 
 		// Mock: return only role1's grants (the fix ensures role10 won't be matched)
 		// Key format: prefix + object + "/" + objectName (prefix already ends with "/")
@@ -3188,8 +3185,8 @@ func TestRBACPrefixMatch(t *testing.T) {
 		)
 
 		// Mock granteeID lookups with "/" suffix
-		granteeID1Prefix := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, "grantee_id_1") + "/"
-		granteeID2Prefix := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, "grantee_id_2") + "/"
+		granteeID1Prefix := funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant, "grantee_id_1")
+		granteeID2Prefix := funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant, "grantee_id_2")
 
 		kvmock.EXPECT().LoadWithPrefix(mock.Anything, granteeID1Prefix).Return(
 			[]string{granteeID1Prefix + "Load"},
@@ -3220,14 +3217,13 @@ func TestRBACPrefixMatch(t *testing.T) {
 		c := NewCatalog(kvmock, nil).(*Catalog)
 
 		// Setup for a specific object query that triggers appendGrantEntity
-		granteeKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant,
-			fmt.Sprintf("%s/%s/%s", "testRole", "Collection", "testCol"))
+		granteeKey := fmt.Sprintf("%s/%s/%s/%s", GranteePrefix, "testRole", "Collection", "testCol")
 
 		// Mock Load to return a granteeID
 		kvmock.EXPECT().Load(mock.Anything, granteeKey).Return("grantee_abc", nil)
 
 		// The fix adds "/" to granteeID prefix query
-		granteeIDPrefix := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, "grantee_abc") + "/"
+		granteeIDPrefix := funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant, "grantee_abc")
 
 		// Mock: return only grantee_abc's privileges (not grantee_abc123's)
 		kvmock.EXPECT().LoadWithPrefix(mock.Anything, granteeIDPrefix).Return(
@@ -3332,7 +3328,7 @@ func TestCatalog_FileResource(t *testing.T) {
 		value, err := proto.Marshal(resource)
 		assert.NoError(t, err)
 
-		kvmock.EXPECT().LoadWithPrefix(mock.Anything, FileResourceMetaPrefix).Return(
+		kvmock.EXPECT().LoadWithPrefix(mock.Anything, FileResourceMetaPrefix+"/").Return(
 			[]string{BuildFileResourceKey(1)},
 			[]string{string(value)},
 			nil,
@@ -3361,7 +3357,7 @@ func TestCatalog_FileResource(t *testing.T) {
 		value, err := proto.Marshal(resource)
 		assert.NoError(t, err)
 
-		kvmock.EXPECT().LoadWithPrefix(mock.Anything, FileResourceMetaPrefix).Return(
+		kvmock.EXPECT().LoadWithPrefix(mock.Anything, FileResourceMetaPrefix+"/").Return(
 			[]string{BuildFileResourceKey(2)},
 			[]string{string(value)},
 			nil,
@@ -3378,7 +3374,7 @@ func TestCatalog_FileResource(t *testing.T) {
 		kvmock := mocks.NewTxnKV(t)
 		c := NewCatalog(kvmock, nil)
 
-		kvmock.EXPECT().LoadWithPrefix(mock.Anything, FileResourceMetaPrefix).Return(nil, nil, mockErr)
+		kvmock.EXPECT().LoadWithPrefix(mock.Anything, FileResourceMetaPrefix+"/").Return(nil, nil, mockErr)
 
 		resources, version, err := c.ListFileResource(ctx)
 		assert.Error(t, err)
@@ -3390,7 +3386,7 @@ func TestCatalog_FileResource(t *testing.T) {
 		kvmock := mocks.NewTxnKV(t)
 		c := NewCatalog(kvmock, nil)
 
-		kvmock.EXPECT().LoadWithPrefix(mock.Anything, FileResourceMetaPrefix).Return([]string{}, []string{}, nil)
+		kvmock.EXPECT().LoadWithPrefix(mock.Anything, FileResourceMetaPrefix+"/").Return([]string{}, []string{}, nil)
 		kvmock.EXPECT().Has(mock.Anything, FileResourceVersionKey).Return(false, mockErr)
 
 		resources, version, err := c.ListFileResource(ctx)
@@ -3403,7 +3399,7 @@ func TestCatalog_FileResource(t *testing.T) {
 		kvmock := mocks.NewTxnKV(t)
 		c := NewCatalog(kvmock, nil)
 
-		kvmock.EXPECT().LoadWithPrefix(mock.Anything, FileResourceMetaPrefix).Return([]string{}, []string{}, nil)
+		kvmock.EXPECT().LoadWithPrefix(mock.Anything, FileResourceMetaPrefix+"/").Return([]string{}, []string{}, nil)
 		kvmock.EXPECT().Has(mock.Anything, FileResourceVersionKey).Return(true, nil)
 		kvmock.EXPECT().Load(mock.Anything, FileResourceVersionKey).Return("", mockErr)
 
@@ -3417,7 +3413,7 @@ func TestCatalog_FileResource(t *testing.T) {
 		kvmock := mocks.NewTxnKV(t)
 		c := NewCatalog(kvmock, nil)
 
-		kvmock.EXPECT().LoadWithPrefix(mock.Anything, FileResourceMetaPrefix).Return([]string{}, []string{}, nil)
+		kvmock.EXPECT().LoadWithPrefix(mock.Anything, FileResourceMetaPrefix+"/").Return([]string{}, []string{}, nil)
 		kvmock.EXPECT().Has(mock.Anything, FileResourceVersionKey).Return(true, nil)
 		kvmock.EXPECT().Load(mock.Anything, FileResourceVersionKey).Return("invalid_version", nil)
 
@@ -3431,7 +3427,7 @@ func TestCatalog_FileResource(t *testing.T) {
 		kvmock := mocks.NewTxnKV(t)
 		c := NewCatalog(kvmock, nil)
 
-		kvmock.EXPECT().LoadWithPrefix(mock.Anything, FileResourceMetaPrefix).Return(
+		kvmock.EXPECT().LoadWithPrefix(mock.Anything, FileResourceMetaPrefix+"/").Return(
 			[]string{BuildFileResourceKey(1)},
 			[]string{"invalid_proto_data"},
 			nil,
@@ -3448,7 +3444,7 @@ func TestCatalog_FileResource(t *testing.T) {
 		kvmock := mocks.NewTxnKV(t)
 		c := NewCatalog(kvmock, nil)
 
-		kvmock.EXPECT().LoadWithPrefix(mock.Anything, FileResourceMetaPrefix).Return([]string{}, []string{}, nil)
+		kvmock.EXPECT().LoadWithPrefix(mock.Anything, FileResourceMetaPrefix+"/").Return([]string{}, []string{}, nil)
 		kvmock.EXPECT().Has(mock.Anything, FileResourceVersionKey).Return(false, nil)
 
 		resources, version, err := c.ListFileResource(ctx)
@@ -3474,7 +3470,7 @@ func TestCatalog_FileResource(t *testing.T) {
 		value1, _ := proto.Marshal(resource1)
 		value2, _ := proto.Marshal(resource2)
 
-		kvmock.EXPECT().LoadWithPrefix(mock.Anything, FileResourceMetaPrefix).Return(
+		kvmock.EXPECT().LoadWithPrefix(mock.Anything, FileResourceMetaPrefix+"/").Return(
 			[]string{BuildFileResourceKey(1), BuildFileResourceKey(2)},
 			[]string{string(value1), string(value2)},
 			nil,
@@ -3491,12 +3487,12 @@ func TestCatalog_FileResource(t *testing.T) {
 
 func TestDeleteGrantByCollectionName(t *testing.T) {
 	ctx := context.Background()
-	tenant := "test-tenant"
+	tenant := util.DefaultTenant
 
 	t.Run("load error", func(t *testing.T) {
 		kvmock := mocks.NewTxnKV(t)
 		c := NewCatalog(kvmock, nil)
-		granteeKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, "")
+		granteeKey := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant)
 		kvmock.EXPECT().LoadWithPrefix(mock.Anything, granteeKey).Return(nil, nil, errors.New("load error"))
 
 		err := c.DeleteGrantByCollectionName(ctx, tenant, "default", "col1")
@@ -3506,10 +3502,10 @@ func TestDeleteGrantByCollectionName(t *testing.T) {
 	t.Run("no matching grants", func(t *testing.T) {
 		kvmock := mocks.NewTxnKV(t)
 		c := NewCatalog(kvmock, nil)
-		granteeKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, "")
+		granteeKey := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant)
 
 		// Only a grant for a different collection
-		key1 := granteeKey + "/role1/Collection/default.other_col"
+		key1 := granteeKey + "role1/Collection/default.other_col"
 		kvmock.EXPECT().LoadWithPrefix(mock.Anything, granteeKey).Return(
 			[]string{key1}, []string{"granteeID1"}, nil)
 
@@ -3520,12 +3516,12 @@ func TestDeleteGrantByCollectionName(t *testing.T) {
 	t.Run("deletes matching grants only", func(t *testing.T) {
 		kvmock := mocks.NewTxnKV(t)
 		c := NewCatalog(kvmock, nil)
-		granteeKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, "")
+		granteeKey := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant)
 
-		key1 := granteeKey + "/role1/Collection/default.col1"
-		key2 := granteeKey + "/role2/Collection/default.col1"
-		key3 := granteeKey + "/role1/Collection/default.other_col"
-		key4 := granteeKey + "/role1/Global/default.col1" // different objectType
+		key1 := granteeKey + "role1/Collection/default.col1"
+		key2 := granteeKey + "role2/Collection/default.col1"
+		key3 := granteeKey + "role1/Collection/default.other_col"
+		key4 := granteeKey + "role1/Global/default.col1" // different objectType
 
 		kvmock.EXPECT().LoadWithPrefix(mock.Anything, granteeKey).Return(
 			[]string{key1, key2, key3, key4},
@@ -3533,8 +3529,8 @@ func TestDeleteGrantByCollectionName(t *testing.T) {
 			nil)
 
 		// Prefix deletion for granteeID keys (have sub-keys)
-		gid1Key := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, "gid1/")
-		gid2Key := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, "gid2/")
+		gid1Key := funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant, "gid1")
+		gid2Key := funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant, "gid2")
 		kvmock.EXPECT().MultiSaveAndRemoveWithPrefix(mock.Anything, (map[string]string)(nil),
 			[]string{gid1Key, gid2Key}).Return(nil)
 		// Exact deletion for grantee keys (leaf keys, no sub-keys)
@@ -3548,15 +3544,15 @@ func TestDeleteGrantByCollectionName(t *testing.T) {
 	t.Run("handles old format without db prefix", func(t *testing.T) {
 		kvmock := mocks.NewTxnKV(t)
 		c := NewCatalog(kvmock, nil)
-		granteeKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, "")
+		granteeKey := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant)
 
 		// Old format: objectName without "." is treated as default db
-		key1 := granteeKey + "/role1/Collection/col1"
+		key1 := granteeKey + "role1/Collection/col1"
 
 		kvmock.EXPECT().LoadWithPrefix(mock.Anything, granteeKey).Return(
 			[]string{key1}, []string{"gid1"}, nil)
 
-		gid1Key := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, "gid1/")
+		gid1Key := funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant, "gid1")
 		kvmock.EXPECT().MultiSaveAndRemoveWithPrefix(mock.Anything, (map[string]string)(nil),
 			[]string{gid1Key}).Return(nil)
 		kvmock.EXPECT().MultiSaveAndRemove(mock.Anything, (map[string]string)(nil),
@@ -3569,18 +3565,18 @@ func TestDeleteGrantByCollectionName(t *testing.T) {
 	t.Run("skips wildcard dbName grants on drop", func(t *testing.T) {
 		kvmock := mocks.NewTxnKV(t)
 		c := NewCatalog(kvmock, nil)
-		granteeKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, "")
+		granteeKey := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant)
 
 		// Wildcard grant *.col1 should NOT be deleted when dropping db1.col1,
 		// because it may also protect col1 in other databases.
-		key1 := granteeKey + "/role1/Collection/*.col1"
-		key2 := granteeKey + "/role1/Collection/default.col1"
+		key1 := granteeKey + "role1/Collection/*.col1"
+		key2 := granteeKey + "role1/Collection/default.col1"
 
 		kvmock.EXPECT().LoadWithPrefix(mock.Anything, granteeKey).Return(
 			[]string{key1, key2}, []string{"gid1", "gid2"}, nil)
 
 		// Only key2 (default.col1) should be deleted, not key1 (*.col1)
-		gid2Key := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, "gid2/")
+		gid2Key := funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant, "gid2")
 		kvmock.EXPECT().MultiSaveAndRemoveWithPrefix(mock.Anything, (map[string]string)(nil),
 			[]string{gid2Key}).Return(nil)
 		kvmock.EXPECT().MultiSaveAndRemove(mock.Anything, (map[string]string)(nil),
@@ -3593,19 +3589,18 @@ func TestDeleteGrantByCollectionName(t *testing.T) {
 	t.Run("handles rootPath prefix in etcd keys", func(t *testing.T) {
 		kvmock := mocks.NewTxnKV(t)
 		c := NewCatalog(kvmock, nil)
-		granteeKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, "")
+		granteeKey := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant)
 
 		// Simulate etcd returning keys WITH rootPath prefix (as real etcd does)
 		rootPath := "by-dev/meta/"
-		key1 := rootPath + granteeKey + "/role1/Collection/default.col1"
+		key1 := rootPath + granteeKey + "role1/Collection/default.col1"
 
 		kvmock.EXPECT().LoadWithPrefix(mock.Anything, granteeKey).Return(
 			[]string{key1}, []string{"gid1"}, nil)
 
 		// The logical key (without rootPath) should be used for deletion
-		logicalKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant,
-			"role1/Collection/default.col1")
-		gid1Key := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, "gid1/")
+		logicalKey := fmt.Sprintf("%s/%s/%s/%s", GranteePrefix, "role1", "Collection", "default.col1")
+		gid1Key := funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant, "gid1")
 		kvmock.EXPECT().MultiSaveAndRemoveWithPrefix(mock.Anything, (map[string]string)(nil),
 			[]string{gid1Key}).Return(nil)
 		kvmock.EXPECT().MultiSaveAndRemove(mock.Anything, (map[string]string)(nil),
@@ -3618,13 +3613,13 @@ func TestDeleteGrantByCollectionName(t *testing.T) {
 	t.Run("MultiSaveAndRemoveWithPrefix error", func(t *testing.T) {
 		kvmock := mocks.NewTxnKV(t)
 		c := NewCatalog(kvmock, nil)
-		granteeKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, "")
+		granteeKey := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant)
 
-		key1 := granteeKey + "/role1/Collection/default.col1"
+		key1 := granteeKey + "role1/Collection/default.col1"
 		kvmock.EXPECT().LoadWithPrefix(mock.Anything, granteeKey).Return(
 			[]string{key1}, []string{"gid1"}, nil)
 
-		gid1Key := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, "gid1/")
+		gid1Key := funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant, "gid1")
 		kvmock.EXPECT().MultiSaveAndRemoveWithPrefix(mock.Anything, (map[string]string)(nil),
 			[]string{gid1Key}).Return(errors.New("remove error"))
 
@@ -3635,13 +3630,13 @@ func TestDeleteGrantByCollectionName(t *testing.T) {
 	t.Run("MultiSaveAndRemove error", func(t *testing.T) {
 		kvmock := mocks.NewTxnKV(t)
 		c := NewCatalog(kvmock, nil)
-		granteeKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, "")
+		granteeKey := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant)
 
-		key1 := granteeKey + "/role1/Collection/default.col1"
+		key1 := granteeKey + "role1/Collection/default.col1"
 		kvmock.EXPECT().LoadWithPrefix(mock.Anything, granteeKey).Return(
 			[]string{key1}, []string{"gid1"}, nil)
 
-		gid1Key := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, "gid1/")
+		gid1Key := funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant, "gid1")
 		kvmock.EXPECT().MultiSaveAndRemoveWithPrefix(mock.Anything, (map[string]string)(nil),
 			[]string{gid1Key}).Return(nil)
 		kvmock.EXPECT().MultiSaveAndRemove(mock.Anything, (map[string]string)(nil),
@@ -3654,12 +3649,12 @@ func TestDeleteGrantByCollectionName(t *testing.T) {
 
 func TestMigrateGrantCollectionName(t *testing.T) {
 	ctx := context.Background()
-	tenant := "test-tenant"
+	tenant := util.DefaultTenant
 
 	t.Run("load error", func(t *testing.T) {
 		kvmock := mocks.NewTxnKV(t)
 		c := NewCatalog(kvmock, nil)
-		granteeKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, "")
+		granteeKey := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant)
 		kvmock.EXPECT().LoadWithPrefix(mock.Anything, granteeKey).Return(nil, nil, errors.New("load error"))
 
 		err := c.MigrateGrantCollectionName(ctx, tenant, "default", "old_col", "default", "new_col")
@@ -3669,9 +3664,9 @@ func TestMigrateGrantCollectionName(t *testing.T) {
 	t.Run("no matching grants", func(t *testing.T) {
 		kvmock := mocks.NewTxnKV(t)
 		c := NewCatalog(kvmock, nil)
-		granteeKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, "")
+		granteeKey := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant)
 
-		key1 := granteeKey + "/role1/Collection/default.other_col"
+		key1 := granteeKey + "role1/Collection/default.other_col"
 		kvmock.EXPECT().LoadWithPrefix(mock.Anything, granteeKey).Return(
 			[]string{key1}, []string{"gid1"}, nil)
 
@@ -3682,42 +3677,39 @@ func TestMigrateGrantCollectionName(t *testing.T) {
 	t.Run("migrates matching grants with grantee id recomputation", func(t *testing.T) {
 		kvmock := mocks.NewTxnKV(t)
 		c := NewCatalog(kvmock, nil)
-		granteeKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, "")
+		granteeKey := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant)
 
-		key1 := granteeKey + "/role1/Collection/default.old_col"
-		key2 := granteeKey + "/role2/Collection/default.old_col"
-		key3 := granteeKey + "/role1/Collection/default.other_col"
+		key1 := granteeKey + "role1/Collection/default.old_col"
+		key2 := granteeKey + "role2/Collection/default.old_col"
+		key3 := granteeKey + "role1/Collection/default.other_col"
 
 		kvmock.EXPECT().LoadWithPrefix(mock.Anything, granteeKey).Return(
 			[]string{key1, key2, key3},
 			[]string{"gid1", "gid2", "gid3"},
 			nil)
 
-		newKey1 := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant,
-			fmt.Sprintf("role1/Collection/%s", funcutil.CombineObjectName("default", "new_col")))
-		newKey2 := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant,
-			fmt.Sprintf("role2/Collection/%s", funcutil.CombineObjectName("default", "new_col")))
+		newKey1 := fmt.Sprintf("%s/%s/%s/%s", GranteePrefix,
+			"role1", "Collection", funcutil.CombineObjectName("default", "new_col"))
+		newKey2 := fmt.Sprintf("%s/%s/%s/%s", GranteePrefix,
+			"role2", "Collection", funcutil.CombineObjectName("default", "new_col"))
 		newIdStr1 := crypto.MD5(newKey1)
 		newIdStr2 := crypto.MD5(newKey2)
 
 		// Mock loading GranteeIDPrefix entries for each old idStr
-		oldGranteeIDKey1 := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, "gid1/")
+		oldGranteeIDKey1 := funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant, "gid1")
 		oldIDEntry1 := oldGranteeIDKey1 + "Insert"
 		kvmock.EXPECT().LoadWithPrefix(mock.Anything, oldGranteeIDKey1).Return(
 			[]string{oldIDEntry1}, []string{"root"}, nil)
 
-		oldGranteeIDKey2 := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, "gid2/")
+		oldGranteeIDKey2 := funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant, "gid2")
 		oldIDEntry2a := oldGranteeIDKey2 + "Insert"
 		oldIDEntry2b := oldGranteeIDKey2 + "Query"
 		kvmock.EXPECT().LoadWithPrefix(mock.Anything, oldGranteeIDKey2).Return(
 			[]string{oldIDEntry2a, oldIDEntry2b}, []string{"root", "admin"}, nil)
 
-		newIDKey1 := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant,
-			fmt.Sprintf("%s/Insert", newIdStr1))
-		newIDKey2a := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant,
-			fmt.Sprintf("%s/Insert", newIdStr2))
-		newIDKey2b := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant,
-			fmt.Sprintf("%s/Query", newIdStr2))
+		newIDKey1 := fmt.Sprintf("%s/%s/%s", GranteeIDPrefix, newIdStr1, "Insert")
+		newIDKey2a := fmt.Sprintf("%s/%s/%s", GranteeIDPrefix, newIdStr2, "Insert")
+		newIDKey2b := fmt.Sprintf("%s/%s/%s", GranteeIDPrefix, newIdStr2, "Query")
 
 		kvmock.EXPECT().MultiSaveAndRemove(mock.Anything,
 			map[string]string{
@@ -3734,18 +3726,18 @@ func TestMigrateGrantCollectionName(t *testing.T) {
 	t.Run("cross-db rename", func(t *testing.T) {
 		kvmock := mocks.NewTxnKV(t)
 		c := NewCatalog(kvmock, nil)
-		granteeKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, "")
+		granteeKey := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant)
 
-		key1 := granteeKey + "/role1/Collection/db1.col1"
+		key1 := granteeKey + "role1/Collection/db1.col1"
 		kvmock.EXPECT().LoadWithPrefix(mock.Anything, granteeKey).Return(
 			[]string{key1}, []string{"gid1"}, nil)
 
-		newKey1 := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant,
-			fmt.Sprintf("role1/Collection/%s", funcutil.CombineObjectName("db2", "col2")))
+		newKey1 := fmt.Sprintf("%s/%s/%s/%s", GranteePrefix,
+			"role1", "Collection", funcutil.CombineObjectName("db2", "col2"))
 		newIdStr1 := crypto.MD5(newKey1)
 
 		// Mock loading GranteeIDPrefix entries for old idStr
-		oldGranteeIDKey1 := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, "gid1/")
+		oldGranteeIDKey1 := funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant, "gid1")
 		kvmock.EXPECT().LoadWithPrefix(mock.Anything, oldGranteeIDKey1).Return(
 			nil, nil, nil)
 
@@ -3760,22 +3752,22 @@ func TestMigrateGrantCollectionName(t *testing.T) {
 	t.Run("skips wildcard dbName grants on rename", func(t *testing.T) {
 		kvmock := mocks.NewTxnKV(t)
 		c := NewCatalog(kvmock, nil)
-		granteeKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, "")
+		granteeKey := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant)
 
 		// Wildcard grant *.old_col should NOT be migrated when renaming db1.old_col,
 		// because it may also apply to old_col in other databases.
-		key1 := granteeKey + "/role1/Collection/*.old_col"
-		key2 := granteeKey + "/role1/Collection/default.old_col"
+		key1 := granteeKey + "role1/Collection/*.old_col"
+		key2 := granteeKey + "role1/Collection/default.old_col"
 		kvmock.EXPECT().LoadWithPrefix(mock.Anything, granteeKey).Return(
 			[]string{key1, key2}, []string{"gid1", "gid2"}, nil)
 
 		// Only key2 (default.old_col) should be migrated
-		oldGranteeIDKey2 := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, "gid2/")
+		oldGranteeIDKey2 := funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant, "gid2")
 		kvmock.EXPECT().LoadWithPrefix(mock.Anything, oldGranteeIDKey2).Return(
 			nil, nil, nil)
 
-		newKey2 := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant,
-			fmt.Sprintf("role1/Collection/%s", funcutil.CombineObjectName("default", "new_col")))
+		newKey2 := fmt.Sprintf("%s/%s/%s/%s", GranteePrefix,
+			"role1", "Collection", funcutil.CombineObjectName("default", "new_col"))
 		newIdStr2 := crypto.MD5(newKey2)
 
 		kvmock.EXPECT().MultiSaveAndRemove(mock.Anything,
@@ -3789,13 +3781,13 @@ func TestMigrateGrantCollectionName(t *testing.T) {
 	t.Run("save error", func(t *testing.T) {
 		kvmock := mocks.NewTxnKV(t)
 		c := NewCatalog(kvmock, nil)
-		granteeKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, "")
+		granteeKey := funcutil.HandleTenantForEtcdPrefix(GranteePrefix, tenant)
 
-		key1 := granteeKey + "/role1/Collection/default.old_col"
+		key1 := granteeKey + "role1/Collection/default.old_col"
 		kvmock.EXPECT().LoadWithPrefix(mock.Anything, granteeKey).Return(
 			[]string{key1}, []string{"gid1"}, nil)
 
-		oldGranteeIDKey1 := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, "gid1/")
+		oldGranteeIDKey1 := funcutil.HandleTenantForEtcdPrefix(GranteeIDPrefix, tenant, "gid1")
 		kvmock.EXPECT().LoadWithPrefix(mock.Anything, oldGranteeIDKey1).Return(
 			nil, nil, nil)
 

--- a/internal/metastore/kv/rootcoord/rootcoord_constant.go
+++ b/internal/metastore/kv/rootcoord/rootcoord_constant.go
@@ -55,13 +55,13 @@ const (
 	// PrivilegeGroupPrefix prefix for privilege group
 	PrivilegeGroupPrefix = ComponentPrefix + "/privilege-group"
 
-	// prefix for file resource meta
+	// FileResourceMetaPrefix prefix for file resource meta
 	FileResourceMetaPrefix = ComponentPrefix + "/file_resource_info"
 	FileResourceVersionKey = ComponentPrefix + "/file_resource_version"
 )
 
 func BuildDatabasePrefixWithDBID(dbID int64) string {
-	return fmt.Sprintf("%s/%d", CollectionInfoMetaPrefix, dbID)
+	return fmt.Sprintf("%s/%d/", CollectionInfoMetaPrefix, dbID)
 }
 
 func BuildCollectionKeyWithDBID(dbID int64, collectionID int64) string {
@@ -76,7 +76,7 @@ func getDatabasePrefix(dbID int64) string {
 	if dbID != util.NonDBID {
 		return BuildDatabasePrefixWithDBID(dbID)
 	}
-	return CollectionMetaPrefix
+	return CollectionMetaPrefix + "/"
 }
 
 func BuildPrivilegeGroupkey(groupName string) string {

--- a/internal/metastore/kv/rootcoord/suffix_snapshot.go
+++ b/internal/metastore/kv/rootcoord/suffix_snapshot.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"path"
 	"sort"
 	"strconv"
 	"strings"
@@ -33,6 +32,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/kv"
 	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/util"
 	"github.com/milvus-io/milvus/pkg/v2/util/etcd"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
@@ -100,13 +100,16 @@ func NewSuffixSnapshot(metaKV kv.MetaKv, sep, root, snapshot string) (*SuffixSna
 		return nil, retry.Unrecoverable(errors.New("MetaKv is nil"))
 	}
 
-	// handles trailing / logic
-	tk := path.Join(snapshot, "k")
-	snapshotLen := len(tk) - 1
-	// makes sure snapshot has trailing '/'
-	snapshot = tk[:len(tk)-1]
-	tk = path.Join(root, "k")
-	rootLen := len(tk) - 1
+	// ensure snapshot has trailing '/'
+	if !strings.HasSuffix(snapshot, "/") {
+		snapshot += "/"
+	}
+	snapshotLen := len(snapshot)
+	// keep empty root unchanged to preserve rootLen=0 behavior.
+	if root != "" && !strings.HasSuffix(root, "/") {
+		root += "/"
+	}
+	rootLen := len(root)
 
 	ss := &SuffixSnapshot{
 		MetaKv:         metaKV,
@@ -134,15 +137,15 @@ func (ss *SuffixSnapshot) hideRootPrefix(value string) string {
 }
 
 // composeSnapshotPrefix build a prefix for load snapshots
-// formated like [snapshotPrefix]/key[sep]
+// formated like [snapshotPrefix]key[sep]
 func (ss *SuffixSnapshot) composeSnapshotPrefix(key string) string {
-	return path.Join(ss.snapshotPrefix, key+ss.separator)
+	return ss.snapshotPrefix + key + ss.separator
 }
 
 // ComposeSnapshotKey used in migration tool also, in case of any rules change.
 func ComposeSnapshotKey(snapshotPrefix string, key string, separator string, ts typeutil.Timestamp) string {
 	// [key][sep][ts]
-	return path.Join(snapshotPrefix, fmt.Sprintf("%s%s%d", key, separator, ts))
+	return util.GetPath(snapshotPrefix, fmt.Sprintf("%s%s%d", key, separator, ts))
 }
 
 // composeTSKey unified tsKey composing method
@@ -460,7 +463,7 @@ func (ss *SuffixSnapshot) LoadWithPrefix(ctx context.Context, key string, ts typ
 	latestOriginalKey := ""
 	tValueGroups := make([]tsv, 0)
 
-	prefix := path.Join(ss.snapshotPrefix, key)
+	prefix := ss.snapshotPrefix + key
 	appendResultFn := func(ts typeutil.Timestamp) {
 		value, ok := binarySearchRecords(tValueGroups, ts)
 		if !ok || ss.isTombstone(value) {

--- a/internal/metastore/kv/rootcoord/suffix_snapshot_test.go
+++ b/internal/metastore/kv/rootcoord/suffix_snapshot_test.go
@@ -225,6 +225,27 @@ func Test_ComposeIsTsKey(t *testing.T) {
 	}
 }
 
+func TestComposeSnapshotKey(t *testing.T) {
+	key := "root-coord/collection/1"
+	sep := "_ts"
+	ts := typeutil.Timestamp(100)
+
+	// ComposeSnapshotKey should normalize snapshotPrefix with a trailing slash.
+	assert.Equal(t, "snapshots/"+key+sep+"100", ComposeSnapshotKey("snapshots", key, sep, ts))
+	assert.Equal(t, "snapshots/"+key+sep+"100", ComposeSnapshotKey("snapshots/", key, sep, ts))
+}
+
+func Test_SuffixSnapshotEmptyRootPrefix(t *testing.T) {
+	sep := "_ts"
+	ss, err := NewSuffixSnapshot(etcdkv.NewEtcdKV(nil, ""), sep, "", snapshotPrefix)
+	require.NoError(t, err)
+	defer ss.Close()
+
+	// Empty root should not trim the first byte when hiding root prefix.
+	key := ss.composeTSKey("k", 100)
+	assert.Equal(t, key, ss.hideRootPrefix(key))
+}
+
 func Test_SuffixSnaphotIsTSOfKey(t *testing.T) {
 	sep := "_ts"
 	ss, err := NewSuffixSnapshot(etcdkv.NewEtcdKV(nil, ""), sep, "", snapshotPrefix)

--- a/internal/metastore/kv/streamingnode/kv_catalog.go
+++ b/internal/metastore/kv/streamingnode/kv_catalog.go
@@ -3,7 +3,6 @@ package streamingnode
 import (
 	"context"
 	"fmt"
-	"path"
 	"sort"
 	"strconv"
 	"strings"
@@ -60,7 +59,7 @@ type catalog struct {
 
 // ListVChannel lists the vchannel info of the pchannel.
 func (c *catalog) ListVChannel(ctx context.Context, pchannelName string) ([]*streamingpb.VChannelMeta, error) {
-	prefix := buildVChannelMetaPath(pchannelName)
+	prefix := buildVChannelPrefix(pchannelName)
 	keys, values, err := c.metaKV.LoadWithPrefix(ctx, prefix)
 	if err != nil {
 		return nil, err
@@ -152,12 +151,12 @@ func (c *catalog) getRemovalAndSaveForVChannel(pchannelName string, info *stream
 	removes := make([]string, 0, len(info.CollectionInfo.Schemas)+1)
 	kvs := make(map[string]string, len(info.CollectionInfo.Schemas)+1)
 
-	key := buildVChannelMetaPathOfVChannel(pchannelName, info.GetVchannel())
+	key := buildVChannelKey(pchannelName, info.GetVchannel())
 	if info.GetState() == streamingpb.VChannelState_VCHANNEL_STATE_DROPPED {
 		// Dropped vchannel should be removed from meta
 		for _, schema := range info.GetCollectionInfo().GetSchemas() {
 			// Also remove the schema of the vchannel.
-			removes = append(removes, buildVChannelSchemaPath(pchannelName, info.GetVchannel(), schema.GetCheckpointTimeTick()))
+			removes = append(removes, buildVChannelSchemaKey(pchannelName, info.GetVchannel(), schema.GetCheckpointTimeTick()))
 		}
 		removes = append(removes, key)
 		return removes, kvs, nil
@@ -168,13 +167,13 @@ func (c *catalog) getRemovalAndSaveForVChannel(pchannelName string, info *stream
 		switch schema.State {
 		case streamingpb.VChannelSchemaState_VCHANNEL_SCHEMA_STATE_DROPPED:
 			// Dropped schema should be removed from meta
-			removes = append(removes, buildVChannelSchemaPath(pchannelName, info.GetVchannel(), schema.GetCheckpointTimeTick()))
+			removes = append(removes, buildVChannelSchemaKey(pchannelName, info.GetVchannel(), schema.GetCheckpointTimeTick()))
 		default:
 			data, err := proto.Marshal(schema)
 			if err != nil {
 				return nil, nil, errors.Wrapf(err, "marshal schema %d at pchannel %s failed", schema.GetCheckpointTimeTick(), pchannelName)
 			}
-			kvs[buildVChannelSchemaPath(pchannelName, info.GetVchannel(), schema.GetCheckpointTimeTick())] = string(data)
+			kvs[buildVChannelSchemaKey(pchannelName, info.GetVchannel(), schema.GetCheckpointTimeTick())] = string(data)
 		}
 	}
 	// Schema is saved in the other key, so we don't need to save it in the vchannel meta.
@@ -192,7 +191,7 @@ func (c *catalog) getRemovalAndSaveForVChannel(pchannelName string, info *stream
 
 // ListSegmentAssignment lists the segment assignment info of the pchannel.
 func (c *catalog) ListSegmentAssignment(ctx context.Context, pChannelName string) ([]*streamingpb.SegmentAssignmentMeta, error) {
-	prefix := buildSegmentAssignmentMetaPath(pChannelName)
+	prefix := buildSegmentAssignmentPrefix(pChannelName)
 	keys, values, err := c.metaKV.LoadWithPrefix(ctx, prefix)
 	if err != nil {
 		return nil, err
@@ -214,7 +213,7 @@ func (c *catalog) SaveSegmentAssignments(ctx context.Context, pChannelName strin
 	kvs := make(map[string]string, len(infos))
 	removes := make([]string, 0)
 	for _, info := range infos {
-		key := buildSegmentAssignmentMetaPathOfSegment(pChannelName, info.GetSegmentId())
+		key := buildSegmentAssignmentKey(pChannelName, info.GetSegmentId())
 		if info.GetState() == streamingpb.SegmentAssignmentState_SEGMENT_ASSIGNMENT_STATE_FLUSHED {
 			// Flushed segment should be removed from meta
 			removes = append(removes, key)
@@ -247,7 +246,7 @@ func (c *catalog) SaveSegmentAssignments(ctx context.Context, pChannelName strin
 
 // GetConsumeCheckpoint gets the consuming checkpoint of the wal.
 func (c *catalog) GetConsumeCheckpoint(ctx context.Context, pchannelName string) (*streamingpb.WALCheckpoint, error) {
-	key := buildConsumeCheckpointPath(pchannelName)
+	key := buildConsumeCheckpointKey(pchannelName)
 	value, err := c.metaKV.Load(ctx, key)
 	if errors.Is(err, merr.ErrIoKeyNotFound) {
 		return nil, nil
@@ -264,7 +263,7 @@ func (c *catalog) GetConsumeCheckpoint(ctx context.Context, pchannelName string)
 
 // SaveConsumeCheckpoint saves the consuming checkpoint of the wal.
 func (c *catalog) SaveConsumeCheckpoint(ctx context.Context, pchannelName string, checkpoint *streamingpb.WALCheckpoint) error {
-	key := buildConsumeCheckpointPath(pchannelName)
+	key := buildConsumeCheckpointKey(pchannelName)
 	value, err := proto.Marshal(checkpoint)
 	if err != nil {
 		return err
@@ -272,9 +271,43 @@ func (c *catalog) SaveConsumeCheckpoint(ctx context.Context, pchannelName string
 	return c.metaKV.Save(ctx, key, string(value))
 }
 
-// buildVChannelMetaPath builds the path for vchannel meta
-func buildVChannelMetaPath(pChannelName string) string {
-	return path.Join(buildWALDirectory(pChannelName), DirectoryVChannel) + "/"
+// Prefix functions: return paths ending with "/" for LoadWithPrefix queries.
+
+// buildWALPrefix returns the prefix for all WAL metadata under a pchannel.
+func buildWALPrefix(pchannelName string) string {
+	return MetaPrefix + "/" + DirectoryWAL + "/" + pchannelName + "/"
+}
+
+// buildVChannelPrefix returns the prefix for all vchannel metadata under a pchannel.
+func buildVChannelPrefix(pChannelName string) string {
+	return buildWALPrefix(pChannelName) + DirectoryVChannel + "/"
+}
+
+// buildSegmentAssignmentPrefix returns the prefix for all segment assignment metadata under a pchannel.
+func buildSegmentAssignmentPrefix(pChannelName string) string {
+	return buildWALPrefix(pChannelName) + DirectorySegmentAssign + "/"
+}
+
+// Key functions: return exact keys for individual records.
+
+// buildVChannelKey returns the key for a specific vchannel's metadata.
+func buildVChannelKey(pChannelName string, vchannelName string) string {
+	return buildVChannelPrefix(pChannelName) + vchannelName
+}
+
+// buildVChannelSchemaKey returns the key for a specific vchannel schema version.
+func buildVChannelSchemaKey(pChannelName string, vchannelName string, version uint64) string {
+	return buildVChannelKey(pChannelName, vchannelName) + "/" + DirectorySchema + "/" + strconv.FormatUint(version, 10)
+}
+
+// buildSegmentAssignmentKey returns the key for a specific segment assignment.
+func buildSegmentAssignmentKey(pChannelName string, segmentID int64) string {
+	return buildSegmentAssignmentPrefix(pChannelName) + strconv.FormatInt(segmentID, 10)
+}
+
+// buildConsumeCheckpointKey returns the key for the consume checkpoint of a pchannel.
+func buildConsumeCheckpointKey(pchannelName string) string {
+	return buildWALPrefix(pchannelName) + KeyConsumeCheckpoint
 }
 
 // removePrefix removes the prefix from the keys.
@@ -283,34 +316,4 @@ func removePrefix(prefix string, keys []string) []string {
 		keys[idx] = typeutil.After(key, prefix)
 	}
 	return keys
-}
-
-// buildVChannelMetaPathOfVChannel builds the path for vchannel meta
-func buildVChannelMetaPathOfVChannel(pChannelName string, vchannelName string) string {
-	return path.Join(buildVChannelMetaPath(pChannelName), vchannelName)
-}
-
-// buildVChannelSchemaPath builds the path for vchannel schema
-func buildVChannelSchemaPath(pChannelName string, vchannelName string, version uint64) string {
-	return path.Join(buildVChannelMetaPathOfVChannel(pChannelName, vchannelName), DirectorySchema, strconv.FormatUint(version, 10))
-}
-
-// buildSegmentAssignmentMetaPath builds the path for segment assignment
-func buildSegmentAssignmentMetaPath(pChannelName string) string {
-	return path.Join(buildWALDirectory(pChannelName), DirectorySegmentAssign) + "/"
-}
-
-// buildSegmentAssignmentMetaPathOfSegment builds the path for segment assignment
-func buildSegmentAssignmentMetaPathOfSegment(pChannelName string, segmentID int64) string {
-	return path.Join(buildWALDirectory(pChannelName), DirectorySegmentAssign, strconv.FormatInt(segmentID, 10))
-}
-
-// buildConsumeCheckpointPath builds the path for consume checkpoint
-func buildConsumeCheckpointPath(pchannelName string) string {
-	return path.Join(buildWALDirectory(pchannelName), KeyConsumeCheckpoint)
-}
-
-// buildWALDirectory builds the path for wal directory
-func buildWALDirectory(pchannelName string) string {
-	return path.Join(MetaPrefix, DirectoryWAL, pchannelName) + "/"
 }

--- a/internal/metastore/kv/streamingnode/kv_catalog_test.go
+++ b/internal/metastore/kv/streamingnode/kv_catalog_test.go
@@ -197,13 +197,26 @@ func TestCatalogVChannel(t *testing.T) {
 	}
 }
 
-func TestBuildDirectory(t *testing.T) {
-	assert.Equal(t, "streamingnode-meta/wal/p1/", buildWALDirectory("p1"))
-	assert.Equal(t, "streamingnode-meta/wal/p2/", buildWALDirectory("p2"))
+func TestBuildPrefixAndKey(t *testing.T) {
+	// Prefix functions
+	assert.Equal(t, "streamingnode-meta/wal/p1/", buildWALPrefix("p1"))
+	assert.Equal(t, "streamingnode-meta/wal/p2/", buildWALPrefix("p2"))
 
-	assert.Equal(t, "streamingnode-meta/wal/p1/segment-assign/", buildSegmentAssignmentMetaPath("p1"))
-	assert.Equal(t, "streamingnode-meta/wal/p2/segment-assign/", buildSegmentAssignmentMetaPath("p2"))
+	assert.Equal(t, "streamingnode-meta/wal/p1/segment-assign/", buildSegmentAssignmentPrefix("p1"))
+	assert.Equal(t, "streamingnode-meta/wal/p2/segment-assign/", buildSegmentAssignmentPrefix("p2"))
 
-	assert.Equal(t, "streamingnode-meta/wal/p1/segment-assign/1", buildSegmentAssignmentMetaPathOfSegment("p1", 1))
-	assert.Equal(t, "streamingnode-meta/wal/p2/segment-assign/2", buildSegmentAssignmentMetaPathOfSegment("p2", 2))
+	assert.Equal(t, "streamingnode-meta/wal/p1/vchannel/", buildVChannelPrefix("p1"))
+	assert.Equal(t, "streamingnode-meta/wal/p2/vchannel/", buildVChannelPrefix("p2"))
+
+	// Key functions
+	assert.Equal(t, "streamingnode-meta/wal/p1/segment-assign/1", buildSegmentAssignmentKey("p1", 1))
+	assert.Equal(t, "streamingnode-meta/wal/p2/segment-assign/2", buildSegmentAssignmentKey("p2", 2))
+
+	assert.Equal(t, "streamingnode-meta/wal/p1/vchannel/v1", buildVChannelKey("p1", "v1"))
+	assert.Equal(t, "streamingnode-meta/wal/p2/vchannel/v2", buildVChannelKey("p2", "v2"))
+	assert.Equal(t, "streamingnode-meta/wal/p1/vchannel/v1/schema/100", buildVChannelSchemaKey("p1", "v1", 100))
+	assert.Equal(t, "streamingnode-meta/wal/p2/vchannel/v2/schema/200", buildVChannelSchemaKey("p2", "v2", 200))
+
+	assert.Equal(t, "streamingnode-meta/wal/p1/consume-checkpoint", buildConsumeCheckpointKey("p1"))
+	assert.Equal(t, "streamingnode-meta/wal/p2/consume-checkpoint", buildConsumeCheckpointKey("p2"))
 }

--- a/pkg/util/funcutil/func.go
+++ b/pkg/util/funcutil/func.go
@@ -711,14 +711,18 @@ func IsEmptyString(str string) bool {
 	return strings.TrimSpace(str) == ""
 }
 
-func HandleTenantForEtcdKey(prefix string, tenant string, key string) string {
+// HandleTenantForEtcdPrefix builds an etcd prefix for range scans (always ends with /).
+// Two layers: HandleTenantForEtcdPrefix("a", "b") => "a/b/"
+// Three layers: HandleTenantForEtcdPrefix("a", "b", "c") => "a/b/c/"
+func HandleTenantForEtcdPrefix(prefix string, tenant string, subPrefixes ...string) string {
 	res := prefix
 	if tenant != "" {
 		res += "/" + tenant
 	}
-	if key != "" {
-		res += "/" + key
+	for _, sub := range subPrefixes {
+		res += "/" + sub
 	}
+	res += "/"
 	return res
 }
 

--- a/pkg/util/funcutil/func_test.go
+++ b/pkg/util/funcutil/func_test.go
@@ -598,14 +598,12 @@ func TestIsEmptyString(t *testing.T) {
 	assert.Equal(t, IsEmptyString("hello"), false)
 }
 
-func TestHandleTenantForEtcdKey(t *testing.T) {
-	assert.Equal(t, "a/b/c", HandleTenantForEtcdKey("a", "b", "c"))
-
-	assert.Equal(t, "a/b", HandleTenantForEtcdKey("a", "", "b"))
-
-	assert.Equal(t, "a/b", HandleTenantForEtcdKey("a", "b", ""))
-
-	assert.Equal(t, "a", HandleTenantForEtcdKey("a", "", ""))
+func TestHandleTenantForEtcdPrefix(t *testing.T) {
+	assert.Equal(t, "a/b/c/", HandleTenantForEtcdPrefix("a", "b", "c"))
+	assert.Equal(t, "a/b/", HandleTenantForEtcdPrefix("a", "", "b"))
+	assert.Equal(t, "a/sub/", HandleTenantForEtcdPrefix("a", "", "sub"))
+	assert.Equal(t, "a/b/", HandleTenantForEtcdPrefix("a", "b"))
+	assert.Equal(t, "a/", HandleTenantForEtcdPrefix("a", ""))
 }
 
 func TestIsRevoke(t *testing.T) {

--- a/pkg/util/kvutil.go
+++ b/pkg/util/kvutil.go
@@ -1,0 +1,40 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"strings"
+)
+
+// GetPath joins rootPath and key with a "/" separator for KV storage operations.
+// Unlike path.Join, it preserves trailing "/" in key, which is semantically significant
+// for prefix-based queries in etcd/TiKV (e.g. "user/" must not match "user_data/...").
+func GetPath(rootPath, key string) string {
+	if len(key) == 0 {
+		return rootPath
+	}
+	if len(rootPath) == 0 {
+		return key
+	}
+	if strings.HasSuffix(rootPath, "/") && strings.HasPrefix(key, "/") {
+		return rootPath + key[1:]
+	}
+	if !strings.HasSuffix(rootPath, "/") && !strings.HasPrefix(key, "/") {
+		return rootPath + "/" + key
+	}
+	return rootPath + key
+}


### PR DESCRIPTION
issue: #47998 
 - add util.GetPath/GetPrefixPath and replace path.Join in etcd/tikv key composition
  - normalize metastore prefix builders and Walk/Load/Remove prefix usage with trailing /
  - fix suffix snapshot prefix/root handling when root is empty
  - add regression tests for trailing-slash behavior and prefix isolation