### PR TITLE
fix: propagate context in QueryCluster client creation

### DIFF
--- a/internal/querycoordv2/session/cluster.go
+++ b/internal/querycoordv2/session/cluster.go
@@ -384,7 +384,7 @@ func (c *clients) getOrCreate(ctx context.Context, node *NodeInfo) (types.QueryN
 	if cli := c.get(node.ID()); cli != nil {
 		return cli, nil
 	}
-	return c.create(node)
+	return c.create(ctx, node)
 }
 
 func createNewClient(ctx context.Context, addr string, nodeID int64, queryNodeCreator QueryNodeCreator) (types.QueryNodeClient, error) {
@@ -395,13 +395,13 @@ func createNewClient(ctx context.Context, addr string, nodeID int64, queryNodeCr
 	return newCli, nil
 }
 
-func (c *clients) create(node *NodeInfo) (types.QueryNodeClient, error) {
+func (c *clients) create(ctx context.Context, node *NodeInfo) (types.QueryNodeClient, error) {
 	c.Lock()
 	defer c.Unlock()
 	if cli, ok := c.clients[node.ID()]; ok {
 		return cli, nil
 	}
-	cli, err := createNewClient(context.Background(), node.Addr(), node.ID(), c.queryNodeCreator)
+	cli, err := createNewClient(ctx, node.Addr(), node.ID(), c.queryNodeCreator)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/querycoordv2/session/cluster_test.go
+++ b/internal/querycoordv2/session/cluster_test.go
@@ -374,6 +374,37 @@ func (suite *ClusterTestSuite) TestGetComponentStates() {
 	suite.Equal(status.State.GetStateCode(), commonpb.StateCode_Abnormal)
 }
 
+func (suite *ClusterTestSuite) TestContextCancellation() {
+	// Create a context that's already canceled
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	// Remove node 0 from manager to force client creation
+	suite.nodeManager.Remove(0)
+
+	// Add a new node that will require client creation
+	// Use a non-existent address to simulate connection attempt
+	node := NewNodeInfo(ImmutableNodeInfo{
+		NodeID:   100,
+		Address:  "127.0.0.1:99999", // Invalid port, will fail to connect
+		Hostname: "localhost",
+	})
+	suite.nodeManager.Add(node)
+
+	// The request should fail fast due to canceled context, not hang
+	start := time.Now()
+	_, err := suite.cluster.LoadSegments(ctx, 100, &querypb.LoadSegmentsRequest{
+		Base:  &commonpb.MsgBase{},
+		Infos: []*querypb.SegmentLoadInfo{{}},
+	})
+	elapsed := time.Since(start)
+
+	// Should fail quickly (< 1 second) due to context cancellation
+	// rather than hanging for gRPC default timeout
+	suite.Error(err)
+	suite.Less(elapsed, 1*time.Second, "Request should fail fast on canceled context")
+}
+
 func TestClusterSuite(t *testing.T) {
 	suite.Run(t, new(ClusterTestSuite))
 }


### PR DESCRIPTION
## Summary

Fix a bug where `clients.create()` in QueryCluster ignores the caller's context, using `context.Background()` instead.

**Related issue**: #48080

## Problem

The `getOrCreate(ctx, node)` method receives a context but doesn't pass it to `create()`. The `create()` method then uses `context.Background()` when calling `createNewClient()`, causing:

1. Context cancellation to be ignored
2. Mutex lock held until gRPC default timeout when connecting to unresponsive nodes
3. All other client operations blocked waiting for the lock

## Solution

Propagate the caller's context through the call chain:
- Add `ctx context.Context` parameter to `create()` method
- Pass context from `getOrCreate()` to `create(ctx, node)`
- Use `ctx` instead of `context.Background()` in `createNewClient()` call

## Changes

| File | Change |
|------|--------|
| `cluster.go:387` | Pass `ctx` to `create()` |
| `cluster.go:398` | Add `ctx context.Context` parameter |
| `cluster.go:404` | Replace `context.Background()` with `ctx` |
| `cluster_test.go` | Add `TestContextCancellation` test |

## Test Plan

- [x] Added `TestContextCancellation` test to verify context cancellation works
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)