### PR TITLE
fix: set ValidData on user-provided $meta before partial update merge

### DIFF
--- a/internal/proxy/task_upsert.go
+++ b/internal/proxy/task_upsert.go
@@ -308,6 +308,18 @@ func (it *upsertTask) queryPreExecute(ctx context.Context) error {
 		fieldData.FieldId = fieldSchema.GetFieldID()
 		fieldData.FieldName = fieldName
 
+		// Ensure dynamic field has ValidData before merge logic.
+		// SDK doesn't set ValidData on $meta; without it, AppendFieldDataByColumn
+		// won't propagate ValidData for insert rows, causing length mismatch.
+		if fieldData.GetIsDynamic() && len(fieldData.GetValidData()) == 0 {
+			nRows := int(it.upsertMsg.InsertMsg.NRows())
+			validData := make([]bool, nRows)
+			for i := range validData {
+				validData[i] = true
+			}
+			fieldData.ValidData = validData
+		}
+
 		// compatible with different nullable/default_value data format from sdk
 		if len(fieldData.GetValidData()) != 0 {
 			var err error
@@ -1345,20 +1357,6 @@ func (it *upsertTask) PreExecute(ctx context.Context) error {
 	}
 
 	if it.req.GetPartialUpdate() {
-		// Ensure ValidData is set on user-provided $meta before queryPreExecute merge logic.
-		// Without this, AppendFieldDataByColumn won't propagate ValidData for insert rows,
-		// causing length mismatch in FillWithDefaultValue later.
-		for _, fd := range it.upsertMsg.InsertMsg.GetFieldsData() {
-			if fd.GetIsDynamic() && len(fd.GetValidData()) == 0 {
-				nRows := int(it.upsertMsg.InsertMsg.NRows())
-				validData := make([]bool, nRows)
-				for i := range validData {
-					validData[i] = true
-				}
-				fd.ValidData = validData
-				break
-			}
-		}
 		err = it.queryPreExecute(ctx)
 		if err != nil {
 			log.Warn("Fail to queryPreExecute", zap.Error(err))

--- a/internal/proxy/task_upsert.go
+++ b/internal/proxy/task_upsert.go
@@ -1345,6 +1345,20 @@ func (it *upsertTask) PreExecute(ctx context.Context) error {
 	}
 
 	if it.req.GetPartialUpdate() {
+		// Ensure ValidData is set on user-provided $meta before queryPreExecute merge logic.
+		// Without this, AppendFieldDataByColumn won't propagate ValidData for insert rows,
+		// causing length mismatch in FillWithDefaultValue later.
+		for _, fd := range it.upsertMsg.InsertMsg.GetFieldsData() {
+			if fd.GetIsDynamic() && len(fd.GetValidData()) == 0 {
+				nRows := int(it.upsertMsg.InsertMsg.NRows())
+				validData := make([]bool, nRows)
+				for i := range validData {
+					validData[i] = true
+				}
+				fd.ValidData = validData
+				break
+			}
+		}
 		err = it.queryPreExecute(ctx)
 		if err != nil {
 			log.Warn("Fail to queryPreExecute", zap.Error(err))

--- a/internal/proxy/task_upsert_test.go
+++ b/internal/proxy/task_upsert_test.go
@@ -2871,3 +2871,342 @@ func TestUpsertTask_queryPreExecute_DefaultValueError(t *testing.T) {
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, merr.ErrParameterInvalid)
 }
+
+func TestUpsertTask_queryPreExecute_DynamicFieldValidData(t *testing.T) {
+	// Schema with dynamic field enabled, simulating a collection with id + value + $meta
+	schema := newSchemaInfo(&schemapb.CollectionSchema{
+		Name:               "test_dynamic_validdata",
+		EnableDynamicField: true,
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "id", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+			{FieldID: 101, Name: "value", DataType: schemapb.DataType_Int32},
+			{
+				FieldID: 102, Name: common.MetaFieldName, DataType: schemapb.DataType_JSON,
+				IsDynamic: true, Nullable: true,
+				DefaultValue: &schemapb.ValueField{
+					Data: &schemapb.ValueField_StringData{StringData: "{}"},
+				},
+			},
+		},
+	})
+
+	t.Run("dynamic field with ValidData merges correctly", func(t *testing.T) {
+		// Upsert 3 rows: IDs 1,2 (update), 3 (insert)
+		// User provides dynamic field $meta with ValidData already set (as PreExecute would do)
+		meta1, _ := json.Marshal(map[string]interface{}{"color": "gold"})
+		meta2, _ := json.Marshal(map[string]interface{}{"color": "silver"})
+		meta3, _ := json.Marshal(map[string]interface{}{"color": "bronze"})
+
+		upsertData := []*schemapb.FieldData{
+			{
+				FieldName: "id", FieldId: 100, Type: schemapb.DataType_Int64,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{1, 2, 3}}}}},
+			},
+			{
+				FieldName: "value", FieldId: 101, Type: schemapb.DataType_Int32,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: []int32{100, 200, 300}}}}},
+			},
+			{
+				FieldName: common.MetaFieldName, FieldId: 102, Type: schemapb.DataType_JSON, IsDynamic: true,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_JsonData{
+					JsonData: &schemapb.JSONArray{Data: [][]byte{meta1, meta2, meta3}},
+				}}},
+				ValidData: []bool{true, true, true}, // Set by PreExecute before queryPreExecute
+			},
+		}
+
+		// Query result: existing PKs 1, 2
+		existMeta1, _ := json.Marshal(map[string]interface{}{"color": "red"})
+		existMeta2, _ := json.Marshal(map[string]interface{}{"color": "blue"})
+		mockQueryResult := &milvuspb.QueryResults{
+			Status: merr.Success(),
+			FieldsData: []*schemapb.FieldData{
+				{
+					FieldName: "id", FieldId: 100, Type: schemapb.DataType_Int64,
+					Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{1, 2}}}}},
+				},
+				{
+					FieldName: "value", FieldId: 101, Type: schemapb.DataType_Int32,
+					Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: []int32{10, 20}}}}},
+				},
+				{
+					FieldName: common.MetaFieldName, FieldId: 102, Type: schemapb.DataType_JSON, IsDynamic: true,
+					Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_JsonData{
+						JsonData: &schemapb.JSONArray{Data: [][]byte{existMeta1, existMeta2}},
+					}}},
+				},
+			},
+		}
+
+		task := &upsertTask{
+			ctx:    context.Background(),
+			schema: schema,
+			req: &milvuspb.UpsertRequest{
+				FieldsData: upsertData,
+				NumRows:    3,
+			},
+			upsertMsg: &msgstream.UpsertMsg{
+				InsertMsg: &msgstream.InsertMsg{
+					InsertRequest: &msgpb.InsertRequest{
+						FieldsData: upsertData,
+						NumRows:    3,
+						Version:    msgpb.InsertDataVersion_ColumnBased,
+					},
+				},
+			},
+			node: &Proxy{},
+		}
+
+		mockRetrieve := mockey.Mock(retrieveByPKs).Return(mockQueryResult, segcore.StorageCost{}, nil).Build()
+		defer mockRetrieve.UnPatch()
+
+		err := task.queryPreExecute(context.Background())
+		assert.NoError(t, err)
+
+		// Verify merged $meta has 3 entries with correct ValidData length
+		var metaField *schemapb.FieldData
+		for _, f := range task.insertFieldData {
+			if f.GetFieldName() == common.MetaFieldName {
+				metaField = f
+				break
+			}
+		}
+		assert.NotNil(t, metaField)
+		metaData := metaField.GetScalars().GetJsonData().GetData()
+		assert.Equal(t, 3, len(metaData), "merged $meta should have 3 rows")
+		// ValidData should also have 3 entries (2 from update + 1 from insert)
+		assert.Equal(t, 3, len(metaField.GetValidData()), "ValidData length should match row count")
+	})
+
+	t.Run("dynamic field without ValidData causes merge mismatch", func(t *testing.T) {
+		// This test demonstrates the bug: when $meta has NO ValidData,
+		// the merge logic produces mismatched ValidData length
+		meta1, _ := json.Marshal(map[string]interface{}{"color": "gold"})
+		meta2, _ := json.Marshal(map[string]interface{}{"color": "silver"})
+		meta3, _ := json.Marshal(map[string]interface{}{"color": "bronze"})
+
+		upsertData := []*schemapb.FieldData{
+			{
+				FieldName: "id", FieldId: 100, Type: schemapb.DataType_Int64,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{1, 2, 3}}}}},
+			},
+			{
+				FieldName: "value", FieldId: 101, Type: schemapb.DataType_Int32,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: []int32{100, 200, 300}}}}},
+			},
+			{
+				FieldName: common.MetaFieldName, FieldId: 102, Type: schemapb.DataType_JSON, IsDynamic: true,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_JsonData{
+					JsonData: &schemapb.JSONArray{Data: [][]byte{meta1, meta2, meta3}},
+				}}},
+				// NO ValidData — simulates SDK behavior before PreExecute fix
+			},
+		}
+
+		existMeta1, _ := json.Marshal(map[string]interface{}{"color": "red"})
+		existMeta2, _ := json.Marshal(map[string]interface{}{"color": "blue"})
+		mockQueryResult := &milvuspb.QueryResults{
+			Status: merr.Success(),
+			FieldsData: []*schemapb.FieldData{
+				{
+					FieldName: "id", FieldId: 100, Type: schemapb.DataType_Int64,
+					Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{1, 2}}}}},
+				},
+				{
+					FieldName: "value", FieldId: 101, Type: schemapb.DataType_Int32,
+					Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: []int32{10, 20}}}}},
+				},
+				{
+					FieldName: common.MetaFieldName, FieldId: 102, Type: schemapb.DataType_JSON, IsDynamic: true,
+					Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_JsonData{
+						JsonData: &schemapb.JSONArray{Data: [][]byte{existMeta1, existMeta2}},
+					}}},
+				},
+			},
+		}
+
+		task := &upsertTask{
+			ctx:    context.Background(),
+			schema: schema,
+			req: &milvuspb.UpsertRequest{
+				FieldsData: upsertData,
+				NumRows:    3,
+			},
+			upsertMsg: &msgstream.UpsertMsg{
+				InsertMsg: &msgstream.InsertMsg{
+					InsertRequest: &msgpb.InsertRequest{
+						FieldsData: upsertData,
+						NumRows:    3,
+						Version:    msgpb.InsertDataVersion_ColumnBased,
+					},
+				},
+			},
+			node: &Proxy{},
+		}
+
+		mockRetrieve := mockey.Mock(retrieveByPKs).Return(mockQueryResult, segcore.StorageCost{}, nil).Build()
+		defer mockRetrieve.UnPatch()
+
+		err := task.queryPreExecute(context.Background())
+		assert.NoError(t, err)
+
+		// Without the fix in PreExecute, $meta ValidData would be length 2 (only from update path)
+		// instead of 3 (matching data length). This mismatch would cause FillWithDefaultValue to fail.
+		var metaField *schemapb.FieldData
+		for _, f := range task.insertFieldData {
+			if f.GetFieldName() == common.MetaFieldName {
+				metaField = f
+				break
+			}
+		}
+		assert.NotNil(t, metaField)
+		metaData := metaField.GetScalars().GetJsonData().GetData()
+		assert.Equal(t, 3, len(metaData), "merged $meta should have 3 rows")
+		// Without ValidData on src, ValidData length will be 2 (only from update path)
+		// This demonstrates the bug that PreExecute fix prevents
+		validData := metaField.GetValidData()
+		if len(validData) > 0 {
+			assert.Equal(t, 2, len(validData),
+				"without PreExecute fix, ValidData length is 2 (only from update path), not 3")
+		}
+	})
+}
+
+func TestPreExecute_SetsDynamicFieldValidData(t *testing.T) {
+	t.Run("sets ValidData on dynamic field without ValidData", func(t *testing.T) {
+		meta, _ := json.Marshal(map[string]interface{}{"color": "gold"})
+		fieldsData := []*schemapb.FieldData{
+			{
+				FieldName: "id", Type: schemapb.DataType_Int64,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{1, 2, 3}}}}},
+			},
+			{
+				FieldName: common.MetaFieldName, Type: schemapb.DataType_JSON, IsDynamic: true,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_JsonData{
+					JsonData: &schemapb.JSONArray{Data: [][]byte{meta, meta, meta}},
+				}}},
+				// No ValidData
+			},
+		}
+
+		task := &upsertTask{
+			req: &milvuspb.UpsertRequest{
+				PartialUpdate: true,
+			},
+			upsertMsg: &msgstream.UpsertMsg{
+				InsertMsg: &msgstream.InsertMsg{
+					InsertRequest: &msgpb.InsertRequest{
+						FieldsData: fieldsData,
+						NumRows:    3,
+						Version:    msgpb.InsertDataVersion_ColumnBased,
+					},
+				},
+			},
+		}
+
+		// Simulate the ValidData-setting logic from PreExecute
+		for _, fd := range task.upsertMsg.InsertMsg.GetFieldsData() {
+			if fd.GetIsDynamic() && len(fd.GetValidData()) == 0 {
+				nRows := int(task.upsertMsg.InsertMsg.NRows())
+				validData := make([]bool, nRows)
+				for i := range validData {
+					validData[i] = true
+				}
+				fd.ValidData = validData
+				break
+			}
+		}
+
+		// Verify ValidData was set
+		dynamicField := fieldsData[1]
+		assert.Equal(t, 3, len(dynamicField.GetValidData()))
+		for _, v := range dynamicField.GetValidData() {
+			assert.True(t, v)
+		}
+	})
+
+	t.Run("preserves existing ValidData on dynamic field", func(t *testing.T) {
+		meta, _ := json.Marshal(map[string]interface{}{"color": "gold"})
+		existingValidData := []bool{true, false, true}
+		fieldsData := []*schemapb.FieldData{
+			{
+				FieldName: common.MetaFieldName, Type: schemapb.DataType_JSON, IsDynamic: true,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_JsonData{
+					JsonData: &schemapb.JSONArray{Data: [][]byte{meta, meta, meta}},
+				}}},
+				ValidData: existingValidData,
+			},
+		}
+
+		task := &upsertTask{
+			req: &milvuspb.UpsertRequest{
+				PartialUpdate: true,
+			},
+			upsertMsg: &msgstream.UpsertMsg{
+				InsertMsg: &msgstream.InsertMsg{
+					InsertRequest: &msgpb.InsertRequest{
+						FieldsData: fieldsData,
+						NumRows:    3,
+						Version:    msgpb.InsertDataVersion_ColumnBased,
+					},
+				},
+			},
+		}
+
+		// Simulate the ValidData-setting logic
+		for _, fd := range task.upsertMsg.InsertMsg.GetFieldsData() {
+			if fd.GetIsDynamic() && len(fd.GetValidData()) == 0 {
+				nRows := int(task.upsertMsg.InsertMsg.NRows())
+				validData := make([]bool, nRows)
+				for i := range validData {
+					validData[i] = true
+				}
+				fd.ValidData = validData
+				break
+			}
+		}
+
+		// ValidData should NOT be overwritten
+		assert.Equal(t, existingValidData, fieldsData[0].GetValidData())
+	})
+
+	t.Run("no-op when no dynamic field exists", func(t *testing.T) {
+		fieldsData := []*schemapb.FieldData{
+			{
+				FieldName: "id", Type: schemapb.DataType_Int64,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{1, 2, 3}}}}},
+			},
+		}
+
+		task := &upsertTask{
+			req: &milvuspb.UpsertRequest{
+				PartialUpdate: true,
+			},
+			upsertMsg: &msgstream.UpsertMsg{
+				InsertMsg: &msgstream.InsertMsg{
+					InsertRequest: &msgpb.InsertRequest{
+						FieldsData: fieldsData,
+						NumRows:    3,
+						Version:    msgpb.InsertDataVersion_ColumnBased,
+					},
+				},
+			},
+		}
+
+		// Simulate the ValidData-setting logic
+		for _, fd := range task.upsertMsg.InsertMsg.GetFieldsData() {
+			if fd.GetIsDynamic() && len(fd.GetValidData()) == 0 {
+				nRows := int(task.upsertMsg.InsertMsg.NRows())
+				validData := make([]bool, nRows)
+				for i := range validData {
+					validData[i] = true
+				}
+				fd.ValidData = validData
+				break
+			}
+		}
+
+		// No field should have ValidData set
+		assert.Equal(t, 0, len(fieldsData[0].GetValidData()))
+	})
+}

--- a/internal/proxy/task_upsert_test.go
+++ b/internal/proxy/task_upsert_test.go
@@ -2892,7 +2892,8 @@ func TestUpsertTask_queryPreExecute_DynamicFieldValidData(t *testing.T) {
 
 	t.Run("dynamic field with ValidData merges correctly", func(t *testing.T) {
 		// Upsert 3 rows: IDs 1,2 (update), 3 (insert)
-		// User provides dynamic field $meta with ValidData already set (as PreExecute would do)
+		// User provides dynamic field $meta WITHOUT ValidData
+		// queryPreExecute will auto-fill ValidData with all-true before merge
 		meta1, _ := json.Marshal(map[string]interface{}{"color": "gold"})
 		meta2, _ := json.Marshal(map[string]interface{}{"color": "silver"})
 		meta3, _ := json.Marshal(map[string]interface{}{"color": "bronze"})
@@ -2911,7 +2912,7 @@ func TestUpsertTask_queryPreExecute_DynamicFieldValidData(t *testing.T) {
 				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_JsonData{
 					JsonData: &schemapb.JSONArray{Data: [][]byte{meta1, meta2, meta3}},
 				}}},
-				ValidData: []bool{true, true, true}, // Set by PreExecute before queryPreExecute
+				// No ValidData — queryPreExecute auto-fills with all-true
 			},
 		}
 
@@ -2978,9 +2979,9 @@ func TestUpsertTask_queryPreExecute_DynamicFieldValidData(t *testing.T) {
 		assert.Equal(t, 3, len(metaField.GetValidData()), "ValidData length should match row count")
 	})
 
-	t.Run("dynamic field without ValidData causes merge mismatch", func(t *testing.T) {
-		// This test demonstrates the bug: when $meta has NO ValidData,
-		// the merge logic produces mismatched ValidData length
+	t.Run("dynamic field without ValidData is auto-filled by queryPreExecute", func(t *testing.T) {
+		// This test verifies the fix: when $meta has NO ValidData (SDK behavior),
+		// queryPreExecute auto-fills it with all-true, so merge produces correct length
 		meta1, _ := json.Marshal(map[string]interface{}{"color": "gold"})
 		meta2, _ := json.Marshal(map[string]interface{}{"color": "silver"})
 		meta3, _ := json.Marshal(map[string]interface{}{"color": "bronze"})
@@ -2999,7 +3000,7 @@ func TestUpsertTask_queryPreExecute_DynamicFieldValidData(t *testing.T) {
 				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_JsonData{
 					JsonData: &schemapb.JSONArray{Data: [][]byte{meta1, meta2, meta3}},
 				}}},
-				// NO ValidData — simulates SDK behavior before PreExecute fix
+				// NO ValidData — queryPreExecute will auto-fill
 			},
 		}
 
@@ -3050,8 +3051,7 @@ func TestUpsertTask_queryPreExecute_DynamicFieldValidData(t *testing.T) {
 		err := task.queryPreExecute(context.Background())
 		assert.NoError(t, err)
 
-		// Without the fix in PreExecute, $meta ValidData would be length 2 (only from update path)
-		// instead of 3 (matching data length). This mismatch would cause FillWithDefaultValue to fail.
+		// queryPreExecute auto-fills ValidData on $meta, so merge produces correct length 3
 		var metaField *schemapb.FieldData
 		for _, f := range task.insertFieldData {
 			if f.GetFieldName() == common.MetaFieldName {
@@ -3062,151 +3062,8 @@ func TestUpsertTask_queryPreExecute_DynamicFieldValidData(t *testing.T) {
 		assert.NotNil(t, metaField)
 		metaData := metaField.GetScalars().GetJsonData().GetData()
 		assert.Equal(t, 3, len(metaData), "merged $meta should have 3 rows")
-		// Without ValidData on src, ValidData length will be 2 (only from update path)
-		// This demonstrates the bug that PreExecute fix prevents
 		validData := metaField.GetValidData()
-		if len(validData) > 0 {
-			assert.Equal(t, 2, len(validData),
-				"without PreExecute fix, ValidData length is 2 (only from update path), not 3")
-		}
-	})
-}
-
-func TestPreExecute_SetsDynamicFieldValidData(t *testing.T) {
-	t.Run("sets ValidData on dynamic field without ValidData", func(t *testing.T) {
-		meta, _ := json.Marshal(map[string]interface{}{"color": "gold"})
-		fieldsData := []*schemapb.FieldData{
-			{
-				FieldName: "id", Type: schemapb.DataType_Int64,
-				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{1, 2, 3}}}}},
-			},
-			{
-				FieldName: common.MetaFieldName, Type: schemapb.DataType_JSON, IsDynamic: true,
-				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_JsonData{
-					JsonData: &schemapb.JSONArray{Data: [][]byte{meta, meta, meta}},
-				}}},
-				// No ValidData
-			},
-		}
-
-		task := &upsertTask{
-			req: &milvuspb.UpsertRequest{
-				PartialUpdate: true,
-			},
-			upsertMsg: &msgstream.UpsertMsg{
-				InsertMsg: &msgstream.InsertMsg{
-					InsertRequest: &msgpb.InsertRequest{
-						FieldsData: fieldsData,
-						NumRows:    3,
-						Version:    msgpb.InsertDataVersion_ColumnBased,
-					},
-				},
-			},
-		}
-
-		// Simulate the ValidData-setting logic from PreExecute
-		for _, fd := range task.upsertMsg.InsertMsg.GetFieldsData() {
-			if fd.GetIsDynamic() && len(fd.GetValidData()) == 0 {
-				nRows := int(task.upsertMsg.InsertMsg.NRows())
-				validData := make([]bool, nRows)
-				for i := range validData {
-					validData[i] = true
-				}
-				fd.ValidData = validData
-				break
-			}
-		}
-
-		// Verify ValidData was set
-		dynamicField := fieldsData[1]
-		assert.Equal(t, 3, len(dynamicField.GetValidData()))
-		for _, v := range dynamicField.GetValidData() {
-			assert.True(t, v)
-		}
-	})
-
-	t.Run("preserves existing ValidData on dynamic field", func(t *testing.T) {
-		meta, _ := json.Marshal(map[string]interface{}{"color": "gold"})
-		existingValidData := []bool{true, false, true}
-		fieldsData := []*schemapb.FieldData{
-			{
-				FieldName: common.MetaFieldName, Type: schemapb.DataType_JSON, IsDynamic: true,
-				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_JsonData{
-					JsonData: &schemapb.JSONArray{Data: [][]byte{meta, meta, meta}},
-				}}},
-				ValidData: existingValidData,
-			},
-		}
-
-		task := &upsertTask{
-			req: &milvuspb.UpsertRequest{
-				PartialUpdate: true,
-			},
-			upsertMsg: &msgstream.UpsertMsg{
-				InsertMsg: &msgstream.InsertMsg{
-					InsertRequest: &msgpb.InsertRequest{
-						FieldsData: fieldsData,
-						NumRows:    3,
-						Version:    msgpb.InsertDataVersion_ColumnBased,
-					},
-				},
-			},
-		}
-
-		// Simulate the ValidData-setting logic
-		for _, fd := range task.upsertMsg.InsertMsg.GetFieldsData() {
-			if fd.GetIsDynamic() && len(fd.GetValidData()) == 0 {
-				nRows := int(task.upsertMsg.InsertMsg.NRows())
-				validData := make([]bool, nRows)
-				for i := range validData {
-					validData[i] = true
-				}
-				fd.ValidData = validData
-				break
-			}
-		}
-
-		// ValidData should NOT be overwritten
-		assert.Equal(t, existingValidData, fieldsData[0].GetValidData())
-	})
-
-	t.Run("no-op when no dynamic field exists", func(t *testing.T) {
-		fieldsData := []*schemapb.FieldData{
-			{
-				FieldName: "id", Type: schemapb.DataType_Int64,
-				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{1, 2, 3}}}}},
-			},
-		}
-
-		task := &upsertTask{
-			req: &milvuspb.UpsertRequest{
-				PartialUpdate: true,
-			},
-			upsertMsg: &msgstream.UpsertMsg{
-				InsertMsg: &msgstream.InsertMsg{
-					InsertRequest: &msgpb.InsertRequest{
-						FieldsData: fieldsData,
-						NumRows:    3,
-						Version:    msgpb.InsertDataVersion_ColumnBased,
-					},
-				},
-			},
-		}
-
-		// Simulate the ValidData-setting logic
-		for _, fd := range task.upsertMsg.InsertMsg.GetFieldsData() {
-			if fd.GetIsDynamic() && len(fd.GetValidData()) == 0 {
-				nRows := int(task.upsertMsg.InsertMsg.NRows())
-				validData := make([]bool, nRows)
-				for i := range validData {
-					validData[i] = true
-				}
-				fd.ValidData = validData
-				break
-			}
-		}
-
-		// No field should have ValidData set
-		assert.Equal(t, 0, len(fieldsData[0].GetValidData()))
+		assert.Equal(t, 3, len(validData),
+			"queryPreExecute auto-fills ValidData, merge produces correct length 3")
 	})
 }

--- a/tests/go_client/testcases/update_test.go
+++ b/tests/go_client/testcases/update_test.go
@@ -229,6 +229,131 @@ func TestPartialUpdateDynamicSchemaStaticOnly(t *testing.T) {
 	require.Equal(t, "static_new_801", resultMap[801], "id=801 should be inserted")
 }
 
+func TestPartialUpdateDynamicSchemaWithDynamicFields(t *testing.T) {
+	/*
+		Test partial upsert with dynamic schema enabled AND user-provided dynamic fields:
+		1. Create collection with enable_dynamic_field=true, schema has id + vector + name(nullable)
+		2. Insert initial data with static fields + dynamic field "color"
+		3. Partial upsert a mixed batch (existing + new rows) with static + dynamic fields
+		4. Verify existing rows updated, new rows inserted, dynamic fields correct
+
+		This reproduces a bug where $meta valid_data length mismatches when:
+		- enable_dynamic_field=true
+		- partial_update=true
+		- data contains user-provided dynamic fields
+		- batch mixes existing and new primary keys
+	*/
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	collName := common.GenRandomString("update_dyn_fields", 6)
+
+	// Create schema: id(pk) + vector + name(nullable), enable_dynamic_field=true
+	pkField := entity.NewField().WithName(common.DefaultInt64FieldName).WithDataType(entity.FieldTypeInt64).WithIsPrimaryKey(true)
+	vecField := entity.NewField().WithName(common.DefaultFloatVecFieldName).WithDataType(entity.FieldTypeFloatVector).WithDim(common.DefaultDim)
+	nameField := entity.NewField().WithName("name").WithDataType(entity.FieldTypeVarChar).WithMaxLength(256).WithNullable(true)
+
+	fields := []*entity.Field{pkField, vecField, nameField}
+	schema := hp.GenSchema(hp.TNewSchemaOption().
+		TWithName(collName).
+		TWithDescription("test partial update with dynamic schema and dynamic data").
+		TWithFields(fields).
+		TWithEnableDynamicField(true))
+
+	err := mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, true)
+
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Second*10)
+		defer cancel()
+		err := mc.DropCollection(ctx, client.NewDropCollectionOption(collName))
+		common.CheckErr(t, err, true)
+	})
+
+	// Insert initial data with static fields + dynamic field "color"
+	initNb := 10
+	initPks := make([]int64, initNb)
+	initNames := make([]string, initNb)
+	for i := 0; i < initNb; i++ {
+		initPks[i] = int64(i)
+		initNames[i] = fmt.Sprintf("item_%d", i)
+	}
+	initPkCol := column.NewColumnInt64(common.DefaultInt64FieldName, initPks)
+	initVecCol := hp.GenColumnData(initNb, entity.FieldTypeFloatVector, *hp.TNewDataOption())
+	initNameCol := column.NewColumnVarChar("name", initNames)
+	initColorCol := column.NewColumnVarChar("color", []string{
+		"red", "blue", "green", "yellow", "purple",
+		"orange", "pink", "white", "black", "gray",
+	})
+
+	_, err = mc.Insert(ctx, client.NewColumnBasedInsertOption(collName).
+		WithColumns(initPkCol, initVecCol, initNameCol, initColorCol))
+	common.CheckErr(t, err, true)
+
+	// Flush -> Index -> Load
+	prepare := &hp.CollectionPrepare{}
+	prepare.FlushData(ctx, t, mc, collName)
+	prepare.CreateIndex(ctx, t, mc, hp.TNewIndexParams(schema))
+	prepare.Load(ctx, t, mc, hp.NewLoadParams(collName))
+	time.Sleep(time.Second * 3)
+
+	// Partial upsert mixed batch with static + dynamic fields
+	// existing rows (id=0,1) + new rows (id=800,801), with dynamic field "color"
+	upsertPks := []int64{0, 1, 800, 801}
+	upsertNames := []string{"upd_0", "upd_1", "new_800", "new_801"}
+	upsertColors := []string{"gold", "silver", "bronze", "copper"}
+	upsertNb := len(upsertPks)
+
+	upsertPkCol := column.NewColumnInt64(common.DefaultInt64FieldName, upsertPks)
+	upsertVecCol := hp.GenColumnData(upsertNb, entity.FieldTypeFloatVector, *hp.TNewDataOption().TWithStart(500))
+	upsertNameCol := column.NewColumnVarChar("name", upsertNames)
+	upsertColorCol := column.NewColumnVarChar("color", upsertColors)
+
+	upsertRes, err := mc.Upsert(ctx, client.NewColumnBasedInsertOption(collName).
+		WithColumns(upsertPkCol, upsertVecCol, upsertNameCol, upsertColorCol).
+		WithPartialUpdate(true))
+	common.CheckErr(t, err, true)
+	require.EqualValues(t, upsertNb, upsertRes.UpsertCount)
+
+	// Query and verify
+	resSet, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithFilter(fmt.Sprintf("%s in [0, 1, 800, 801]", common.DefaultInt64FieldName)).
+		WithOutputFields(common.DefaultInt64FieldName, "name", "color").
+		WithConsistencyLevel(entity.ClStrong))
+	common.CheckErr(t, err, true)
+
+	require.Equal(t, 4, resSet.GetColumn(common.DefaultInt64FieldName).Len())
+	pkResults := resSet.GetColumn(common.DefaultInt64FieldName).(*column.ColumnInt64).Data()
+	nameResults := resSet.GetColumn("name").(*column.ColumnVarChar).Data()
+
+	// Build result maps
+	nameMap := make(map[int64]string)
+	for i, pk := range pkResults {
+		nameMap[pk] = nameResults[i]
+	}
+
+	// Verify static field "name"
+	require.Equal(t, "upd_0", nameMap[0], "id=0 name should be updated")
+	require.Equal(t, "upd_1", nameMap[1], "id=1 name should be updated")
+	require.Equal(t, "new_800", nameMap[800], "id=800 name should be inserted")
+	require.Equal(t, "new_801", nameMap[801], "id=801 name should be inserted")
+
+	// Verify dynamic field "color" updated for all rows
+	colorCol := resSet.GetColumn("color")
+	require.NotNil(t, colorCol, "color column should exist")
+	require.Equal(t, 4, colorCol.Len())
+	colorMap := make(map[int64]string)
+	for i, pk := range pkResults {
+		val, err := colorCol.GetAsString(i)
+		require.NoError(t, err)
+		colorMap[pk] = val
+	}
+	require.Equal(t, "gold", colorMap[0], "id=0 color should be updated")
+	require.Equal(t, "silver", colorMap[1], "id=1 color should be updated")
+	require.Equal(t, "bronze", colorMap[800], "id=800 color should be inserted")
+	require.Equal(t, "copper", colorMap[801], "id=801 color should be inserted")
+}
+
 func TestUpdateNullableFieldBehavior(t *testing.T) {
 	/*
 		Test nullable field behavior for Update operation:
@@ -383,6 +508,104 @@ func TestUpdateDefaultValueFieldBehavior(t *testing.T) {
 	require.Equal(t, 1, resSet3.GetColumn("default_varchar").Len())
 	unchangedResults := resSet3.GetColumn("default_varchar").(*column.ColumnVarChar).Data()
 	require.Equal(t, "original_3", unchangedResults[0])
+}
+
+func TestPartialUpdateEmptyStringDefaultValue(t *testing.T) {
+	/*
+		Test partial update on a non-nullable field with empty string as default value:
+		1. Create collection with non-nullable varchar field, defaultValue=""
+		2. Insert rows with explicit non-empty values
+		3. Partial update to a different non-empty value → should succeed
+		4. Partial update to empty string "" → should succeed (empty string is a valid value, not null)
+	*/
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	collName := common.GenRandomString("update_empty_default", 6)
+
+	pkField := entity.NewField().WithName(common.DefaultInt64FieldName).WithDataType(entity.FieldTypeInt64).WithIsPrimaryKey(true)
+	vecField := entity.NewField().WithName(common.DefaultFloatVecFieldName).WithDataType(entity.FieldTypeFloatVector).WithDim(common.DefaultDim)
+	tagField := entity.NewField().WithName("tag").WithDataType(entity.FieldTypeVarChar).WithMaxLength(256).WithDefaultValueString("")
+
+	fields := []*entity.Field{pkField, vecField, tagField}
+	schema := hp.GenSchema(hp.TNewSchemaOption().
+		TWithName(collName).
+		TWithDescription("test partial update with empty string default value").
+		TWithFields(fields))
+
+	err := mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, true)
+
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Second*10)
+		defer cancel()
+		err := mc.DropCollection(ctx, client.NewDropCollectionOption(collName))
+		common.CheckErr(t, err, true)
+	})
+
+	// Step 2: Insert 3 rows with explicit tag values
+	pkColumn := column.NewColumnInt64(common.DefaultInt64FieldName, []int64{1, 2, 3})
+	vecColumn := hp.GenColumnData(3, entity.FieldTypeFloatVector, *hp.TNewDataOption())
+	tagColumn := column.NewColumnVarChar("tag", []string{"alpha", "beta", "gamma"})
+
+	_, err = mc.Insert(ctx, client.NewColumnBasedInsertOption(collName).WithColumns(pkColumn, vecColumn, tagColumn))
+	common.CheckErr(t, err, true)
+
+	// Flush -> Index -> Load
+	prepare := &hp.CollectionPrepare{}
+	prepare.FlushData(ctx, t, mc, collName)
+	prepare.CreateIndex(ctx, t, mc, hp.TNewIndexParams(schema))
+	prepare.Load(ctx, t, mc, hp.NewLoadParams(collName))
+	time.Sleep(time.Second * 3)
+
+	// Step 3: Partial update id=1 tag to a different non-empty value
+	updatePk1 := column.NewColumnInt64(common.DefaultInt64FieldName, []int64{1})
+	updateVec1 := hp.GenColumnData(1, entity.FieldTypeFloatVector, *hp.TNewDataOption().TWithStart(100))
+	updateTag1 := column.NewColumnVarChar("tag", []string{"updated_alpha"})
+
+	res1, err := mc.Upsert(ctx, client.NewColumnBasedInsertOption(collName).
+		WithColumns(updatePk1, updateVec1, updateTag1).
+		WithPartialUpdate(true))
+	common.CheckErr(t, err, true)
+	require.EqualValues(t, 1, res1.UpsertCount)
+
+	// Verify id=1 tag updated
+	resSet1, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithFilter(fmt.Sprintf("%s == 1", common.DefaultInt64FieldName)).
+		WithOutputFields("tag").
+		WithConsistencyLevel(entity.ClStrong))
+	common.CheckErr(t, err, true)
+	tagResults1 := resSet1.GetColumn("tag").(*column.ColumnVarChar).Data()
+	require.Equal(t, "updated_alpha", tagResults1[0], "id=1 tag should be updated to new value")
+
+	// Step 4: Partial update id=2 tag to empty string ""
+	updatePk2 := column.NewColumnInt64(common.DefaultInt64FieldName, []int64{2})
+	updateVec2 := hp.GenColumnData(1, entity.FieldTypeFloatVector, *hp.TNewDataOption().TWithStart(200))
+	updateTag2 := column.NewColumnVarChar("tag", []string{""})
+
+	res2, err := mc.Upsert(ctx, client.NewColumnBasedInsertOption(collName).
+		WithColumns(updatePk2, updateVec2, updateTag2).
+		WithPartialUpdate(true))
+	common.CheckErr(t, err, true)
+	require.EqualValues(t, 1, res2.UpsertCount)
+
+	// Verify id=2 tag updated to empty string
+	resSet2, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithFilter(fmt.Sprintf("%s == 2", common.DefaultInt64FieldName)).
+		WithOutputFields("tag").
+		WithConsistencyLevel(entity.ClStrong))
+	common.CheckErr(t, err, true)
+	tagResults2 := resSet2.GetColumn("tag").(*column.ColumnVarChar).Data()
+	require.Equal(t, "", tagResults2[0], "id=2 tag should be updated to empty string")
+
+	// Verify id=3 tag unchanged
+	resSet3, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithFilter(fmt.Sprintf("%s == 3", common.DefaultInt64FieldName)).
+		WithOutputFields("tag").
+		WithConsistencyLevel(entity.ClStrong))
+	common.CheckErr(t, err, true)
+	tagResults3 := resSet3.GetColumn("tag").(*column.ColumnVarChar).Data()
+	require.Equal(t, "gamma", tagResults3[0], "id=3 tag should remain unchanged")
 }
 
 func TestUpsertDefaultValueWithCompressedValidData(t *testing.T) {


### PR DESCRIPTION
## Summary

When partial upsert includes user-provided dynamic fields and the batch mixes existing rows (update) with new rows (insert), the `$meta` field lacks `ValidData`. During `queryPreExecute` merge, the update path sets `ValidData` on dstField (length=existRows), but the insert path's `AppendFieldDataByColumn` skips `ValidData` propagation when src has none, leaving `ValidData` length < total rows. `FillWithDefaultValue` then fails with `the length of valid_data of field($meta) is wrong`.

Fix: initialize all-true `ValidData` on user-provided `$meta` in `PreExecute` before `queryPreExecute` runs, consistent with `autoGenDynamicFieldData`.

issue: https://github.com/milvus-io/milvus/issues/47957

## Changes

- `internal/proxy/task_upsert.go`: Set `ValidData` on user-provided dynamic `$meta` field before `queryPreExecute` merge logic
- `internal/proxy/task_upsert_test.go`: Add unit tests for dynamic field ValidData merge and PreExecute ValidData setting
- `tests/go_client/testcases/update_test.go`: Add E2E tests for partial update with dynamic fields and empty string default value