### PR TITLE
enhance: [loon] support loading deltalogs from StorageV3 manifest in QueryNode

### DIFF
--- a/internal/querynodev2/delegator/delta_forward.go
+++ b/internal/querynodev2/delegator/delta_forward.go
@@ -119,7 +119,12 @@ func (sd *shardDelegator) addL0GrowingBF(ctx context.Context, segment segments.S
 func (sd *shardDelegator) addL0ForGrowingLoad(ctx context.Context, segment segments.Segment) error {
 	deltalogs := sd.getLevel0Deltalogs(segment.Partition())
 	log.Info("forwarding L0 via loader...", zap.Int64("segmentID", segment.ID()), zap.Int("deltalogsNum", len(deltalogs)))
-	return sd.loader.LoadDeltaLogs(ctx, segment, deltalogs)
+	loadInfo := &querypb.SegmentLoadInfo{
+		SegmentID:    segment.ID(),
+		CollectionID: segment.Collection(),
+		Deltalogs:    deltalogs,
+	}
+	return sd.loader.LoadDeltaLogs(ctx, segment, loadInfo)
 }
 
 func (sd *shardDelegator) forwardL0ByBF(ctx context.Context,

--- a/internal/querynodev2/delegator/delta_forward_test.go
+++ b/internal/querynodev2/delegator/delta_forward_test.go
@@ -466,6 +466,7 @@ func (s *GrowingMergeL0Suite) TestAddL0ForGrowingLoad() {
 	s.delegator.deleteBuffer.RegisterL0(l0Segment)
 
 	seg.EXPECT().ID().Return(10000)
+	seg.EXPECT().Collection().Return(s.collectionID)
 	seg.EXPECT().Partition().Return(100)
 	s.loader.EXPECT().LoadDeltaLogs(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, seg segments.Segment, loadInfo *querypb.SegmentLoadInfo) error {
 		fb := loadInfo.GetDeltalogs()

--- a/internal/querynodev2/delegator/delta_forward_test.go
+++ b/internal/querynodev2/delegator/delta_forward_test.go
@@ -467,7 +467,8 @@ func (s *GrowingMergeL0Suite) TestAddL0ForGrowingLoad() {
 
 	seg.EXPECT().ID().Return(10000)
 	seg.EXPECT().Partition().Return(100)
-	s.loader.EXPECT().LoadDeltaLogs(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, seg segments.Segment, fb []*datapb.FieldBinlog) error {
+	s.loader.EXPECT().LoadDeltaLogs(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, seg segments.Segment, loadInfo *querypb.SegmentLoadInfo) error {
+		fb := loadInfo.GetDeltalogs()
 		s.ElementsMatch([]string{"mocked_log_path"}, lo.Flatten(lo.Map(fb, func(fbl *datapb.FieldBinlog, _ int) []string {
 			return lo.Map(fbl.Binlogs, func(bl *datapb.Binlog, _ int) string { return bl.LogPath })
 		})))
@@ -477,7 +478,7 @@ func (s *GrowingMergeL0Suite) TestAddL0ForGrowingLoad() {
 	err = sd.addL0ForGrowing(context.Background(), seg)
 	s.NoError(err)
 
-	s.loader.EXPECT().LoadDeltaLogs(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, seg segments.Segment, fb []*datapb.FieldBinlog) error {
+	s.loader.EXPECT().LoadDeltaLogs(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, seg segments.Segment, loadInfo *querypb.SegmentLoadInfo) error {
 		return errors.New("mocked")
 	}).Once()
 	err = sd.addL0ForGrowing(context.Background(), seg)

--- a/internal/querynodev2/handlers.go
+++ b/internal/querynodev2/handlers.go
@@ -120,7 +120,7 @@ func (node *QueryNode) loadDeltaLogs(ctx context.Context, req *querypb.LoadSegme
 			continue
 		}
 
-		err := node.loader.LoadDeltaLogs(ctx, segment, info.GetDeltalogs())
+		err := node.loader.LoadDeltaLogs(ctx, segment, info)
 		if err != nil {
 			if finalErr == nil {
 				finalErr = err

--- a/internal/querynodev2/segments/mock_loader.go
+++ b/internal/querynodev2/segments/mock_loader.go
@@ -7,8 +7,6 @@ import (
 
 	commonpb "github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 
-	datapb "github.com/milvus-io/milvus/pkg/v2/proto/datapb"
-
 	mock "github.com/stretchr/testify/mock"
 
 	pkoracle "github.com/milvus-io/milvus/internal/querynodev2/pkoracle"
@@ -257,17 +255,17 @@ func (_c *MockLoader_LoadBloomFilterSet_Call) RunAndReturn(run func(context.Cont
 	return _c
 }
 
-// LoadDeltaLogs provides a mock function with given fields: ctx, segment, deltaLogs
-func (_m *MockLoader) LoadDeltaLogs(ctx context.Context, segment Segment, deltaLogs []*datapb.FieldBinlog) error {
-	ret := _m.Called(ctx, segment, deltaLogs)
+// LoadDeltaLogs provides a mock function with given fields: ctx, segment, loadInfo
+func (_m *MockLoader) LoadDeltaLogs(ctx context.Context, segment Segment, loadInfo *querypb.SegmentLoadInfo) error {
+	ret := _m.Called(ctx, segment, loadInfo)
 
 	if len(ret) == 0 {
 		panic("no return value specified for LoadDeltaLogs")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, Segment, []*datapb.FieldBinlog) error); ok {
-		r0 = rf(ctx, segment, deltaLogs)
+	if rf, ok := ret.Get(0).(func(context.Context, Segment, *querypb.SegmentLoadInfo) error); ok {
+		r0 = rf(ctx, segment, loadInfo)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -283,14 +281,14 @@ type MockLoader_LoadDeltaLogs_Call struct {
 // LoadDeltaLogs is a helper method to define mock.On call
 //   - ctx context.Context
 //   - segment Segment
-//   - deltaLogs []*datapb.FieldBinlog
-func (_e *MockLoader_Expecter) LoadDeltaLogs(ctx interface{}, segment interface{}, deltaLogs interface{}) *MockLoader_LoadDeltaLogs_Call {
-	return &MockLoader_LoadDeltaLogs_Call{Call: _e.mock.On("LoadDeltaLogs", ctx, segment, deltaLogs)}
+//   - loadInfo *querypb.SegmentLoadInfo
+func (_e *MockLoader_Expecter) LoadDeltaLogs(ctx interface{}, segment interface{}, loadInfo interface{}) *MockLoader_LoadDeltaLogs_Call {
+	return &MockLoader_LoadDeltaLogs_Call{Call: _e.mock.On("LoadDeltaLogs", ctx, segment, loadInfo)}
 }
 
-func (_c *MockLoader_LoadDeltaLogs_Call) Run(run func(ctx context.Context, segment Segment, deltaLogs []*datapb.FieldBinlog)) *MockLoader_LoadDeltaLogs_Call {
+func (_c *MockLoader_LoadDeltaLogs_Call) Run(run func(ctx context.Context, segment Segment, loadInfo *querypb.SegmentLoadInfo)) *MockLoader_LoadDeltaLogs_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(Segment), args[2].([]*datapb.FieldBinlog))
+		run(args[0].(context.Context), args[1].(Segment), args[2].(*querypb.SegmentLoadInfo))
 	})
 	return _c
 }
@@ -300,7 +298,7 @@ func (_c *MockLoader_LoadDeltaLogs_Call) Return(_a0 error) *MockLoader_LoadDelta
 	return _c
 }
 
-func (_c *MockLoader_LoadDeltaLogs_Call) RunAndReturn(run func(context.Context, Segment, []*datapb.FieldBinlog) error) *MockLoader_LoadDeltaLogs_Call {
+func (_c *MockLoader_LoadDeltaLogs_Call) RunAndReturn(run func(context.Context, Segment, *querypb.SegmentLoadInfo) error) *MockLoader_LoadDeltaLogs_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -1321,6 +1321,7 @@ func (loader *segmentLoader) loadDeltalogs(ctx context.Context, segment Segment,
 				if err == io.EOF {
 					break
 				}
+				log.Warn("CQX readDeltaRecords next failed", zap.Error(err))
 				return err
 			}
 
@@ -1371,9 +1372,10 @@ func (loader *segmentLoader) loadDeltalogs(ctx context.Context, segment Segment,
 			pkField.DataType,
 			manifestPath,
 			storage.WithStorageConfig(createStorageConfig()),
+			storage.WithVersion(storage.StorageV2),
 		)
 		if err != nil {
-			if err != io.EOF {
+			if !errors.Is(err, io.EOF) {
 				return err
 			}
 			// io.EOF means no deltalogs in manifest, not an error

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -52,6 +52,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/metrics"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/hardware"
@@ -79,7 +80,7 @@ type Loader interface {
 
 	// LoadDeltaLogs load deltalog and write delta data into provided segment.
 	// it also executes resource protection logic in case of OOM.
-	LoadDeltaLogs(ctx context.Context, segment Segment, deltaLogs []*datapb.FieldBinlog) error
+	LoadDeltaLogs(ctx context.Context, segment Segment, loadInfo *querypb.SegmentLoadInfo) error
 
 	// LoadBloomFilterSet loads needed statslog for RemoteSegment.
 	LoadBloomFilterSet(ctx context.Context, collectionID int64, infos ...*querypb.SegmentLoadInfo) ([]*pkoracle.BloomFilterSet, error)
@@ -365,7 +366,7 @@ func (loader *segmentLoader) Load(ctx context.Context,
 				return errors.Wrap(err, "At LoadSegment")
 			}
 		}
-		if err = loader.loadDeltalogs(ctx, segment, loadInfo.GetDeltalogs()); err != nil {
+		if err = loader.loadDeltalogs(ctx, segment, loadInfo); err != nil {
 			return errors.Wrap(err, "At LoadDeltaLogs")
 		}
 
@@ -1278,7 +1279,8 @@ func (loader *segmentLoader) loadBloomFilter(ctx context.Context, segmentID int6
 
 // loadDeltalogs performs the internal actions of `LoadDeltaLogs`
 // this function does not perform resource check and is meant be used among other load APIs.
-func (loader *segmentLoader) loadDeltalogs(ctx context.Context, segment Segment, deltaLogs []*datapb.FieldBinlog) error {
+func (loader *segmentLoader) loadDeltalogs(ctx context.Context, segment Segment, loadInfo *querypb.SegmentLoadInfo) error {
+	deltaLogs := loadInfo.GetDeltalogs()
 	ctx, sp := otel.Tracer(typeutil.QueryNodeRole).Start(ctx, fmt.Sprintf("LoadDeltalogs-%d", segment.ID()))
 	defer sp.End()
 	log := log.Ctx(ctx).With(
@@ -1311,6 +1313,35 @@ func (loader *segmentLoader) loadDeltalogs(ctx context.Context, segment Segment,
 		return err
 	}
 
+	readDeltaRecords := func(reader storage.RecordReader) error {
+		defer reader.Close()
+		for {
+			dl, err := reader.Next()
+			if err != nil {
+				if err == io.EOF {
+					break
+				}
+				return err
+			}
+
+			for i := 0; i < dl.Len(); i++ {
+				var pk storage.PrimaryKey
+				switch pkField.DataType {
+				case schemapb.DataType_Int64:
+					pk = storage.NewInt64PrimaryKey(dl.Column(0).(*array.Int64).Value(i))
+				case schemapb.DataType_VarChar:
+					pk = storage.NewVarCharPrimaryKey(dl.Column(0).(*array.String).Value(i))
+				}
+				ts := typeutil.Timestamp(dl.Column(1).(*array.Int64).Value(i))
+				err = deltaData.Append(pk, ts)
+				if err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
+
 	for _, deltalog := range deltaLogs {
 		err := func() error {
 			opts := []storage.RwOption{
@@ -1327,36 +1358,29 @@ func (loader *segmentLoader) loadDeltalogs(ctx context.Context, segment Segment,
 			if err != nil {
 				return err
 			}
-			defer reader.Close()
-
-			for {
-				dl, err := reader.Next()
-				if err != nil {
-					if err == io.EOF {
-						break
-					}
-					return err
-				}
-
-				for i := 0; i < dl.Len(); i++ {
-					var pk storage.PrimaryKey
-					switch pkField.DataType {
-					case schemapb.DataType_Int64:
-						pk = storage.NewInt64PrimaryKey(dl.Column(0).(*array.Int64).Value(i))
-					case schemapb.DataType_VarChar:
-						pk = storage.NewVarCharPrimaryKey(dl.Column(0).(*array.String).Value(i))
-					}
-					ts := typeutil.Timestamp(dl.Column(1).(*array.Int64).Value(i))
-					err = deltaData.Append(pk, ts)
-					if err != nil {
-						return err
-					}
-				}
-			}
-			return nil
+			return readDeltaRecords(reader)
 		}()
 		if err != nil {
 			return err
+		}
+	}
+
+	// Read deltalogs from manifest for StorageV3 segments
+	if manifestPath := loadInfo.GetManifestPath(); manifestPath != "" {
+		reader, err := storage.NewDeltalogReaderFromManifest(
+			pkField.DataType,
+			manifestPath,
+			storage.WithStorageConfig(createStorageConfig()),
+		)
+		if err != nil {
+			if err != io.EOF {
+				return err
+			}
+			// io.EOF means no deltalogs in manifest, not an error
+		} else {
+			if err := readDeltaRecords(reader); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -1371,12 +1395,7 @@ func (loader *segmentLoader) loadDeltalogs(ctx context.Context, segment Segment,
 
 // LoadDeltaLogs load deltalog and write delta data into provided segment.
 // it also executes resource protection logic in case of OOM.
-func (loader *segmentLoader) LoadDeltaLogs(ctx context.Context, segment Segment, deltaLogs []*datapb.FieldBinlog) error {
-	loadInfo := &querypb.SegmentLoadInfo{
-		SegmentID:    segment.ID(),
-		CollectionID: segment.Collection(),
-		Deltalogs:    deltaLogs,
-	}
+func (loader *segmentLoader) LoadDeltaLogs(ctx context.Context, segment Segment, loadInfo *querypb.SegmentLoadInfo) error {
 	// Check memory & storage limit
 	requestResourceResult, err := loader.requestResource(ctx, loadInfo)
 	if err != nil {
@@ -1384,7 +1403,35 @@ func (loader *segmentLoader) LoadDeltaLogs(ctx context.Context, segment Segment,
 		return err
 	}
 	defer loader.freeRequestResource(requestResourceResult)
-	return loader.loadDeltalogs(ctx, segment, deltaLogs)
+	return loader.loadDeltalogs(ctx, segment, loadInfo)
+}
+
+func createStorageConfig() *indexpb.StorageConfig {
+	params := paramtable.Get()
+	if params.CommonCfg.StorageType.GetValue() == "local" {
+		return &indexpb.StorageConfig{
+			RootPath:    params.LocalStorageCfg.Path.GetValue(),
+			StorageType: params.CommonCfg.StorageType.GetValue(),
+		}
+	}
+	return &indexpb.StorageConfig{
+		Address:           params.MinioCfg.Address.GetValue(),
+		AccessKeyID:       params.MinioCfg.AccessKeyID.GetValue(),
+		SecretAccessKey:   params.MinioCfg.SecretAccessKey.GetValue(),
+		UseSSL:            params.MinioCfg.UseSSL.GetAsBool(),
+		SslCACert:         params.MinioCfg.SslCACert.GetValue(),
+		BucketName:        params.MinioCfg.BucketName.GetValue(),
+		RootPath:          params.MinioCfg.RootPath.GetValue(),
+		UseIAM:            params.MinioCfg.UseIAM.GetAsBool(),
+		IAMEndpoint:       params.MinioCfg.IAMEndpoint.GetValue(),
+		StorageType:       params.CommonCfg.StorageType.GetValue(),
+		Region:            params.MinioCfg.Region.GetValue(),
+		UseVirtualHost:    params.MinioCfg.UseVirtualHost.GetAsBool(),
+		CloudProvider:     params.MinioCfg.CloudProvider.GetValue(),
+		RequestTimeoutMs:  params.MinioCfg.RequestTimeoutMs.GetAsInt64(),
+		GcpCredentialJSON: params.MinioCfg.GcpCredentialJSON.GetValue(),
+		SslTlsMinVersion:  params.MinioCfg.SslTLSMinVersion.GetValue(),
+	}
 }
 
 func (loader *segmentLoader) patchEntryNumber(ctx context.Context, segment *LocalSegment, loadInfo *querypb.SegmentLoadInfo) error {

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -1321,7 +1321,6 @@ func (loader *segmentLoader) loadDeltalogs(ctx context.Context, segment Segment,
 				if err == io.EOF {
 					break
 				}
-				log.Warn("CQX readDeltaRecords next failed", zap.Error(err))
 				return err
 			}
 

--- a/internal/querynodev2/segments/segment_loader_test.go
+++ b/internal/querynodev2/segments/segment_loader_test.go
@@ -527,7 +527,7 @@ func (suite *SegmentLoaderSuite) TestLoadDupDeltaLogs() {
 		// so the released segment won't cause error
 		seg.Release(ctx)
 		loadInfos[i].Deltalogs[0].Binlogs[0].TimestampTo--
-		err := suite.loader.LoadDeltaLogs(ctx, seg, loadInfos[i].GetDeltalogs())
+		err := suite.loader.LoadDeltaLogs(ctx, seg, loadInfos[i])
 		suite.NoError(err)
 	}
 }


### PR DESCRIPTION
Related to #44956

Change LoadDeltaLogs interface to accept *querypb.SegmentLoadInfo instead of []*datapb.FieldBinlog, enabling access to ManifestPath. When a segment has a manifest path, deltalogs are also read from the Loon manifest via storage.NewDeltalogReaderFromManifest in addition to traditional binlog paths. Add createStorageConfig helper for building storage config from paramtable.