### PR TITLE
fix: propagate caller context in QueryCluster client creation

### DIFF
--- a/internal/querycoordv2/session/cluster.go
+++ b/internal/querycoordv2/session/cluster.go
@@ -384,7 +384,7 @@ func (c *clients) getOrCreate(ctx context.Context, node *NodeInfo) (types.QueryN
 	if cli := c.get(node.ID()); cli != nil {
 		return cli, nil
 	}
-	return c.create(node)
+	return c.create(ctx, node)
 }
 
 func createNewClient(ctx context.Context, addr string, nodeID int64, queryNodeCreator QueryNodeCreator) (types.QueryNodeClient, error) {
@@ -395,13 +395,13 @@ func createNewClient(ctx context.Context, addr string, nodeID int64, queryNodeCr
 	return newCli, nil
 }
 
-func (c *clients) create(node *NodeInfo) (types.QueryNodeClient, error) {
+func (c *clients) create(ctx context.Context, node *NodeInfo) (types.QueryNodeClient, error) {
 	c.Lock()
 	defer c.Unlock()
 	if cli, ok := c.clients[node.ID()]; ok {
 		return cli, nil
 	}
-	cli, err := createNewClient(context.Background(), node.Addr(), node.ID(), c.queryNodeCreator)
+	cli, err := createNewClient(ctx, node.Addr(), node.ID(), c.queryNodeCreator)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

`clients.create()` uses `context.Background()` when calling `createNewClient()`, ignoring the caller's context passed to `getOrCreate()`. This means:

1. Client creation cannot be canceled even if the caller's context times out
2. The mutex lock is held until gRPC default timeout
3. All other client operations are blocked waiting for the lock

This PR propagates the caller's `ctx` from `getOrCreate` through `create` into `createNewClient`, so that context cancellation and timeouts work correctly.

## Changes

Three lines changed in `internal/querycoordv2/session/cluster.go`:

1. `getOrCreate` now passes `ctx` to `create`: `c.create(ctx, node)`
2. `create` signature updated to accept `ctx context.Context`
3. `createNewClient(context.Background(), ...)` replaced with `createNewClient(ctx, ...)`

Fixes #48080

Signed-off-by: Max Calkin <maxwellcalkin@gmail.com>