### PR TITLE
fix: [2.6] remove interactive logic between import and L0 compaction

### DIFF
--- a/internal/datacoord/compaction_policy_l0.go
+++ b/internal/datacoord/compaction_policy_l0.go
@@ -12,7 +12,6 @@ import (
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
-	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
@@ -23,51 +22,18 @@ type l0CompactionPolicy struct {
 
 	activeCollections *activeCollections
 	allocator         allocator.Allocator
-
-	// key: collectionID, value: reference count
-	skipCompactionCollections map[int64]int
-	skipLocker                sync.RWMutex
 }
 
 func newL0CompactionPolicy(meta *meta, allocator allocator.Allocator) *l0CompactionPolicy {
 	return &l0CompactionPolicy{
-		meta:                      meta,
-		activeCollections:         newActiveCollections(),
-		allocator:                 allocator,
-		skipCompactionCollections: make(map[int64]int),
+		meta:              meta,
+		activeCollections: newActiveCollections(),
+		allocator:         allocator,
 	}
 }
 
 func (policy *l0CompactionPolicy) Enable() bool {
 	return Params.DataCoordCfg.EnableAutoCompaction.GetAsBool()
-}
-
-func (policy *l0CompactionPolicy) AddSkipCollection(collectionID UniqueID) {
-	policy.skipLocker.Lock()
-	defer policy.skipLocker.Unlock()
-
-	if _, ok := policy.skipCompactionCollections[collectionID]; !ok {
-		policy.skipCompactionCollections[collectionID] = 1
-	} else {
-		policy.skipCompactionCollections[collectionID]++
-	}
-}
-
-func (policy *l0CompactionPolicy) RemoveSkipCollection(collectionID UniqueID) {
-	policy.skipLocker.Lock()
-	defer policy.skipLocker.Unlock()
-	refCount := policy.skipCompactionCollections[collectionID]
-	if refCount > 1 {
-		policy.skipCompactionCollections[collectionID]--
-	} else {
-		delete(policy.skipCompactionCollections, collectionID)
-	}
-}
-
-func (policy *l0CompactionPolicy) isSkipCollection(collectionID UniqueID) bool {
-	policy.skipLocker.RLock()
-	defer policy.skipLocker.RUnlock()
-	return policy.skipCompactionCollections[collectionID] > 0
 }
 
 // Notify policy to record the active updated(when adding a new L0 segment) collections.
@@ -94,10 +60,6 @@ func (policy *l0CompactionPolicy) Trigger(ctx context.Context) (events map[Compa
 	}
 	events = make(map[CompactionTriggerType][]CompactionView)
 	for collID, segments := range latestCollSegs {
-		if policy.isSkipCollection(collID) {
-			continue
-		}
-
 		policy.activeCollections.Read(collID)
 		levelZeroSegments := lo.Filter(segments, func(info *SegmentInfo, _ int) bool {
 			return info.GetLevel() == datapb.SegmentLevel_L0
@@ -126,9 +88,6 @@ func (policy *l0CompactionPolicy) Trigger(ctx context.Context) (events map[Compa
 func (policy *l0CompactionPolicy) triggerOneCollection(ctx context.Context, collectionID int64) ([]CompactionView, int64, error) {
 	log := log.Ctx(ctx).With(zap.Int64("collectionID", collectionID))
 	log.Info("start trigger collection l0 compaction")
-	if policy.isSkipCollection(collectionID) {
-		return nil, 0, merr.WrapErrCollectionNotLoaded(collectionID, "the collection being paused by importing cannot do force l0 compaction")
-	}
 	allL0Segments := policy.meta.SelectSegments(ctx, WithCollection(collectionID), SegmentFilterFunc(func(segment *SegmentInfo) bool {
 		return isSegmentHealthy(segment) &&
 			isFlushed(segment) &&

--- a/internal/datacoord/compaction_policy_l0_test.go
+++ b/internal/datacoord/compaction_policy_l0_test.go
@@ -117,29 +117,6 @@ func (s *L0CompactionPolicySuite) TestTriggerIdle() {
 		s.Equal(datapb.SegmentLevel_L0, view.Level)
 	}
 
-	// test for skip collection
-	s.l0_policy.AddSkipCollection(1)
-	s.l0_policy.AddSkipCollection(1)
-	// Test for skip collection
-	events, err = s.l0_policy.Trigger(context.Background())
-	s.NoError(err)
-	s.Empty(events)
-
-	// Test for skip collection with ref count
-	s.l0_policy.RemoveSkipCollection(1)
-	events, err = s.l0_policy.Trigger(context.Background())
-	s.NoError(err)
-	s.Empty(events)
-
-	s.l0_policy.RemoveSkipCollection(1)
-	events, err = s.l0_policy.Trigger(context.Background())
-	s.NoError(err)
-	s.Equal(1, len(events))
-	gotViews, ok = events[TriggerTypeLevelZeroViewIDLE]
-	s.True(ok)
-	s.NotNil(gotViews)
-	s.Equal(1, len(gotViews))
-
 	log.Info("cView", zap.String("string", cView.String()))
 }
 

--- a/internal/datacoord/compaction_trigger_v2.go
+++ b/internal/datacoord/compaction_trigger_v2.go
@@ -31,7 +31,6 @@ import (
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
-	"github.com/milvus-io/milvus/pkg/v2/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/logutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
@@ -97,8 +96,6 @@ type TriggerManager interface {
 	Stop()
 	OnCollectionUpdate(collectionID int64)
 	ManualTrigger(ctx context.Context, collectionID int64, clusteringCompaction bool, l0Compaction bool, targetSize int64) (UniqueID, error)
-	GetPauseCompactionChan(jobID, collectionID int64) <-chan struct{}
-	GetResumeCompactionChan(jobID, collectionID int64) <-chan struct{}
 	InitForceMergeMemoryQuerier(nodeManager session.NodeManager, mixCoord types.MixCoord, session sessionutil.SessionInterface)
 }
 
@@ -113,7 +110,6 @@ type CompactionTriggerManager struct {
 	allocator allocator.Allocator
 
 	meta                        *meta
-	importMeta                  ImportMeta
 	l0Policy                    *l0CompactionPolicy
 	clusteringPolicy            *clusteringCompactionPolicy
 	singlePolicy                *singleCompactionPolicy
@@ -122,28 +118,15 @@ type CompactionTriggerManager struct {
 
 	cancel  context.CancelFunc
 	closeWg sync.WaitGroup
-
-	l0Triggering bool
-	l0SigLock    *sync.Mutex
-	l0TickSig    *sync.Cond
-
-	pauseCompactionChanMap  map[int64]chan struct{}
-	resumeCompactionChanMap map[int64]chan struct{}
-	compactionChanLock      sync.Mutex
 }
 
-func NewCompactionTriggerManager(alloc allocator.Allocator, handler Handler, inspector CompactionInspector, meta *meta, importMeta ImportMeta) *CompactionTriggerManager {
+func NewCompactionTriggerManager(alloc allocator.Allocator, handler Handler, inspector CompactionInspector, meta *meta) *CompactionTriggerManager {
 	m := &CompactionTriggerManager{
-		allocator:               alloc,
-		handler:                 handler,
-		inspector:               inspector,
-		meta:                    meta,
-		importMeta:              importMeta,
-		pauseCompactionChanMap:  make(map[int64]chan struct{}),
-		resumeCompactionChanMap: make(map[int64]chan struct{}),
+		allocator: alloc,
+		handler:   handler,
+		inspector: inspector,
+		meta:      meta,
 	}
-	m.l0SigLock = &sync.Mutex{}
-	m.l0TickSig = sync.NewCond(m.l0SigLock)
 	m.l0Policy = newL0CompactionPolicy(meta, alloc)
 	m.clusteringPolicy = newClusteringCompactionPolicy(meta, m.allocator, m.handler)
 	m.singlePolicy = newSingleCompactionPolicy(meta, m.allocator, m.handler)
@@ -183,64 +166,6 @@ func (m *CompactionTriggerManager) Stop() {
 	m.closeWg.Wait()
 }
 
-func (m *CompactionTriggerManager) pauseL0SegmentCompacting(jobID, collectionID int64) {
-	m.l0Policy.AddSkipCollection(collectionID)
-	m.l0SigLock.Lock()
-	for m.l0Triggering {
-		m.l0TickSig.Wait()
-	}
-	m.l0SigLock.Unlock()
-	m.compactionChanLock.Lock()
-	if ch, ok := m.pauseCompactionChanMap[jobID]; ok {
-		close(ch)
-	}
-	m.compactionChanLock.Unlock()
-}
-
-func (m *CompactionTriggerManager) resumeL0SegmentCompacting(jobID, collectionID int64) {
-	m.compactionChanLock.Lock()
-	m.l0Policy.RemoveSkipCollection(collectionID)
-	if ch, ok := m.resumeCompactionChanMap[jobID]; ok {
-		close(ch)
-		delete(m.pauseCompactionChanMap, jobID)
-		delete(m.resumeCompactionChanMap, jobID)
-	}
-	m.compactionChanLock.Unlock()
-}
-
-func (m *CompactionTriggerManager) GetPauseCompactionChan(jobID, collectionID int64) <-chan struct{} {
-	m.compactionChanLock.Lock()
-	defer m.compactionChanLock.Unlock()
-	if ch, ok := m.pauseCompactionChanMap[jobID]; ok {
-		return ch
-	}
-	ch := make(chan struct{})
-	m.pauseCompactionChanMap[jobID] = ch
-	go m.pauseL0SegmentCompacting(jobID, collectionID)
-	return ch
-}
-
-func (m *CompactionTriggerManager) GetResumeCompactionChan(jobID, collectionID int64) <-chan struct{} {
-	m.compactionChanLock.Lock()
-	defer m.compactionChanLock.Unlock()
-	if ch, ok := m.resumeCompactionChanMap[jobID]; ok {
-		return ch
-	}
-	ch := make(chan struct{})
-	m.resumeCompactionChanMap[jobID] = ch
-	go m.resumeL0SegmentCompacting(jobID, collectionID)
-	return ch
-}
-
-func (m *CompactionTriggerManager) setL0Triggering(b bool) {
-	m.l0SigLock.Lock()
-	defer m.l0SigLock.Unlock()
-	m.l0Triggering = b
-	if !b {
-		m.l0TickSig.Broadcast()
-	}
-}
-
 func (m *CompactionTriggerManager) loop(ctx context.Context) {
 	defer logutil.LogPanic()
 
@@ -267,11 +192,9 @@ func (m *CompactionTriggerManager) loop(ctx context.Context) {
 				log.RatedInfo(10, "Skip trigger l0 compaction since inspector is full")
 				continue
 			}
-			m.setL0Triggering(true)
 			events, err := m.l0Policy.Trigger(ctx)
 			if err != nil {
 				log.Warn("Fail to trigger L0 policy", zap.Error(err))
-				m.setL0Triggering(false)
 				continue
 			}
 			if len(events) > 0 {
@@ -279,7 +202,6 @@ func (m *CompactionTriggerManager) loop(ctx context.Context) {
 					m.notify(ctx, triggerType, views)
 				}
 			}
-			m.setL0Triggering(false)
 		case <-clusteringTicker.C:
 			if !m.clusteringPolicy.Enable() {
 				continue
@@ -362,8 +284,6 @@ func (m *CompactionTriggerManager) ManualTrigger(ctx context.Context, collection
 		views, triggerID, err = m.forceMergePolicy.triggerOneCollection(ctx, collectionID, targetSize)
 		events[TriggerTypeForceMerge] = views
 	} else if isL0 {
-		m.setL0Triggering(true)
-		defer m.setL0Triggering(false)
 		views, triggerID, err = m.l0Policy.triggerOneCollection(ctx, collectionID)
 		events[TriggerTypeLevelZeroViewManual] = views
 	} else if isClustering {
@@ -444,12 +364,6 @@ func (m *CompactionTriggerManager) SubmitL0ViewToScheduler(ctx context.Context, 
 		return
 	}
 
-	err = m.addL0ImportTaskForImport(ctx, collection, view)
-	if err != nil {
-		log.Warn("Failed to submit compaction view to scheduler because add l0 import task fail", zap.Error(err))
-		return
-	}
-
 	totalRows := lo.SumBy(view.GetSegmentsView(), func(segView *SegmentView) int64 {
 		return segView.NumOfRows
 	})
@@ -484,82 +398,6 @@ func (m *CompactionTriggerManager) SubmitL0ViewToScheduler(ctx context.Context, 
 		zap.String("type", task.GetType().String()),
 		zap.Int64s("L0 segments", levelZeroSegs),
 	)
-}
-
-func (m *CompactionTriggerManager) addL0ImportTaskForImport(ctx context.Context, collection *collectionInfo, view CompactionView) error {
-	// add l0 import task for the collection if the collection is importing
-	importJobs := m.importMeta.GetJobBy(ctx,
-		WithCollectionID(collection.ID),
-		WithoutJobStates(internalpb.ImportJobState_Completed, internalpb.ImportJobState_Failed),
-		WithoutL0Job(),
-	)
-	if len(importJobs) > 0 {
-		partitionID := view.GetGroupLabel().PartitionID
-		var (
-			fileSize        int64 = 0
-			totalRows       int64 = 0
-			totalMemorySize int64 = 0
-			importPaths     []string
-		)
-		idStart := time.Now().UnixMilli()
-		for _, segmentView := range view.GetSegmentsView() {
-			segInfo := m.meta.GetSegment(ctx, segmentView.ID)
-			if segInfo == nil {
-				continue
-			}
-			totalRows += int64(segmentView.DeltaRowCount)
-			totalMemorySize += int64(segmentView.DeltaSize)
-			for _, deltaLogs := range segInfo.GetDeltalogs() {
-				for _, binlog := range deltaLogs.GetBinlogs() {
-					fileSize += binlog.GetLogSize()
-					importPaths = append(importPaths, binlog.GetLogPath())
-				}
-			}
-		}
-		if len(importPaths) == 0 {
-			return nil
-		}
-
-		for i, job := range importJobs {
-			newTasks, err := NewImportTasks([][]*datapb.ImportFileStats{
-				{
-					{
-						ImportFile: &internalpb.ImportFile{
-							Id:    idStart + int64(i),
-							Paths: importPaths,
-						},
-						FileSize:        fileSize,
-						TotalRows:       totalRows,
-						TotalMemorySize: totalMemorySize,
-						HashedStats: map[string]*datapb.PartitionImportStats{
-							// which is vchannel
-							view.GetGroupLabel().Channel: {
-								PartitionRows: map[int64]int64{
-									partitionID: totalRows,
-								},
-								PartitionDataSize: map[int64]int64{
-									partitionID: totalMemorySize,
-								},
-							},
-						},
-					},
-				},
-			}, job, m.allocator, m.meta, m.importMeta, paramtable.Get().DataNodeCfg.FlushDeleteBufferBytes.GetAsInt())
-			if err != nil {
-				log.Warn("new import tasks failed", zap.Error(err))
-				return err
-			}
-			for _, t := range newTasks {
-				err = m.importMeta.AddTask(ctx, t)
-				if err != nil {
-					log.Warn("add new l0 import task from l0 compaction failed", WrapTaskLog(t, zap.Error(err))...)
-					return err
-				}
-				log.Info("add new l0 import task from l0 compaction", WrapTaskLog(t)...)
-			}
-		}
-	}
-	return nil
 }
 
 func (m *CompactionTriggerManager) SubmitClusteringViewToScheduler(ctx context.Context, view CompactionView) {

--- a/internal/datacoord/compaction_trigger_v2_test.go
+++ b/internal/datacoord/compaction_trigger_v2_test.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/samber/lo"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
@@ -15,12 +13,10 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
-	"github.com/milvus-io/milvus/internal/metastore/mocks"
 	"github.com/milvus-io/milvus/internal/metastore/model"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
-	"github.com/milvus-io/milvus/pkg/v2/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
@@ -31,12 +27,11 @@ func TestCompactionTriggerManagerSuite(t *testing.T) {
 type CompactionTriggerManagerSuite struct {
 	suite.Suite
 
-	mockAlloc  *allocator.MockAllocator
-	handler    Handler
-	inspector  *MockCompactionInspector
-	testLabel  *CompactionGroupLabel
-	meta       *meta
-	importMeta ImportMeta
+	mockAlloc *allocator.MockAllocator
+	handler   Handler
+	inspector *MockCompactionInspector
+	testLabel *CompactionGroupLabel
+	meta      *meta
 
 	triggerManager *CompactionTriggerManager
 }
@@ -56,14 +51,7 @@ func (s *CompactionTriggerManagerSuite) SetupTest() {
 	for id, segment := range segments {
 		s.meta.segments.SetSegment(id, segment)
 	}
-	catalog := mocks.NewDataCoordCatalog(s.T())
-	catalog.EXPECT().ListPreImportTasks(mock.Anything).Return([]*datapb.PreImportTask{}, nil)
-	catalog.EXPECT().ListImportTasks(mock.Anything).Return([]*datapb.ImportTaskV2{}, nil)
-	catalog.EXPECT().ListImportJobs(mock.Anything).Return([]*datapb.ImportJob{}, nil)
-	importMeta, err := NewImportMeta(context.TODO(), catalog, s.mockAlloc, s.meta)
-	s.Require().NoError(err)
-	s.importMeta = importMeta
-	s.triggerManager = NewCompactionTriggerManager(s.mockAlloc, s.handler, s.inspector, s.meta, s.importMeta)
+	s.triggerManager = NewCompactionTriggerManager(s.mockAlloc, s.handler, s.inspector, s.meta)
 }
 
 func (s *CompactionTriggerManagerSuite) TestNotifyByViewIDLE() {
@@ -318,85 +306,6 @@ func (s *CompactionTriggerManagerSuite) TestGetExpectedSegmentSize() {
 
 		s.Equal(int64(100*1024*1024), getExpectedSegmentSize(s.triggerManager.meta, collection.ID, collection.Schema))
 	})
-}
-
-func TestCompactionAndImport(t *testing.T) {
-	paramtable.Init()
-	mockAlloc := allocator.NewMockAllocator(t)
-	handler := NewNMockHandler(t)
-	handler.EXPECT().GetCollection(mock.Anything, mock.Anything).Return(&collectionInfo{
-		ID: 1,
-	}, nil)
-	inspector := NewMockCompactionInspector(t)
-	inspector.EXPECT().isFull().Return(false)
-
-	testLabel := &CompactionGroupLabel{
-		CollectionID: 1,
-		PartitionID:  10,
-		Channel:      "ch-1",
-	}
-	segments := genSegmentsForMeta(testLabel)
-	catelog := mocks.NewDataCoordCatalog(t)
-	catelog.EXPECT().AddSegment(mock.Anything, mock.Anything).Return(nil)
-	meta := &meta{
-		segments: NewSegmentsInfo(),
-		catalog:  catelog,
-	}
-	for id, segment := range segments {
-		meta.segments.SetSegment(id, segment)
-	}
-	catalog := mocks.NewDataCoordCatalog(t)
-	catalog.EXPECT().ListPreImportTasks(mock.Anything).Return([]*datapb.PreImportTask{}, nil)
-	catalog.EXPECT().ListImportTasks(mock.Anything).Return([]*datapb.ImportTaskV2{}, nil)
-	catalog.EXPECT().ListImportJobs(mock.Anything).Return([]*datapb.ImportJob{
-		{
-			JobID:        100,
-			CollectionID: 1,
-			State:        internalpb.ImportJobState_Importing,
-			Schema: &schemapb.CollectionSchema{
-				Fields: []*schemapb.FieldSchema{
-					{
-						FieldID:      100,
-						Name:         "pk",
-						DataType:     schemapb.DataType_Int64,
-						IsPrimaryKey: true,
-					},
-				},
-			},
-		},
-	}, nil).Once()
-	catalog.EXPECT().SaveImportTask(mock.Anything, mock.Anything).Return(nil)
-	importMeta, err := NewImportMeta(context.TODO(), catalog, mockAlloc, meta)
-	assert.NoError(t, err)
-	triggerManager := NewCompactionTriggerManager(mockAlloc, handler, inspector, meta, importMeta)
-
-	Params.Save(Params.DataCoordCfg.L0CompactionTriggerInterval.Key, "1")
-	defer Params.Reset(Params.DataCoordCfg.L0CompactionTriggerInterval.Key)
-	Params.Save(Params.DataCoordCfg.ClusteringCompactionTriggerInterval.Key, "6000000")
-	defer Params.Reset(Params.DataCoordCfg.ClusteringCompactionTriggerInterval.Key)
-	Params.Save(Params.DataCoordCfg.MixCompactionTriggerInterval.Key, "6000000")
-	defer Params.Reset(Params.DataCoordCfg.MixCompactionTriggerInterval.Key)
-
-	mockAlloc.EXPECT().AllocID(mock.Anything).Return(1, nil)
-	mockAlloc.EXPECT().AllocN(mock.Anything).Return(195300, 195300, nil)
-	mockAlloc.EXPECT().AllocTimestamp(mock.Anything).Return(30000, nil)
-	inspector.EXPECT().enqueueCompaction(mock.Anything).
-		RunAndReturn(func(task *datapb.CompactionTask) error {
-			assert.Equal(t, datapb.CompactionType_Level0DeleteCompaction, task.GetType())
-			expectedSegs := []int64{100, 101, 102}
-			assert.ElementsMatch(t, expectedSegs, task.GetInputSegments())
-			return nil
-		}).Return(nil)
-	mockAlloc.EXPECT().AllocID(mock.Anything).Return(19530, nil).Maybe()
-
-	<-triggerManager.GetPauseCompactionChan(100, 10)
-	defer func() {
-		<-triggerManager.GetResumeCompactionChan(100, 10)
-	}()
-
-	triggerManager.Start()
-	defer triggerManager.Stop()
-	time.Sleep(3 * time.Second)
 }
 
 func (s *CompactionTriggerManagerSuite) TestManualTriggerL0Compaction() {

--- a/internal/datacoord/import_job.go
+++ b/internal/datacoord/import_job.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
-	"github.com/milvus-io/milvus/internal/util/importutilv2"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/internalpb"
@@ -59,12 +58,6 @@ func WithoutJobStates(states ...internalpb.ImportJobState) ImportJobFilter {
 			}
 		}
 		return true
-	}
-}
-
-func WithoutL0Job() ImportJobFilter {
-	return func(job ImportJob) bool {
-		return !importutilv2.IsL0Import(job.GetOptions())
 	}
 }
 

--- a/internal/datacoord/import_task.go
+++ b/internal/datacoord/import_task.go
@@ -69,12 +69,6 @@ func WithRequestSource() ImportTaskFilter {
 	}
 }
 
-func WithL0CompactionSource() ImportTaskFilter {
-	return func(task ImportTask) bool {
-		return task.GetSource() == datapb.ImportTaskSourceV2_L0Compaction
-	}
-}
-
 type UpdateAction func(task ImportTask)
 
 func UpdateState(state datapb.ImportTaskStateV2) UpdateAction {

--- a/internal/datacoord/mock_trigger_manager.go
+++ b/internal/datacoord/mock_trigger_manager.go
@@ -26,104 +26,6 @@ func (_m *MockTriggerManager) EXPECT() *MockTriggerManager_Expecter {
 	return &MockTriggerManager_Expecter{mock: &_m.Mock}
 }
 
-// GetPauseCompactionChan provides a mock function with given fields: jobID, collectionID
-func (_m *MockTriggerManager) GetPauseCompactionChan(jobID int64, collectionID int64) <-chan struct{} {
-	ret := _m.Called(jobID, collectionID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetPauseCompactionChan")
-	}
-
-	var r0 <-chan struct{}
-	if rf, ok := ret.Get(0).(func(int64, int64) <-chan struct{}); ok {
-		r0 = rf(jobID, collectionID)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(<-chan struct{})
-		}
-	}
-
-	return r0
-}
-
-// MockTriggerManager_GetPauseCompactionChan_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetPauseCompactionChan'
-type MockTriggerManager_GetPauseCompactionChan_Call struct {
-	*mock.Call
-}
-
-// GetPauseCompactionChan is a helper method to define mock.On call
-//   - jobID int64
-//   - collectionID int64
-func (_e *MockTriggerManager_Expecter) GetPauseCompactionChan(jobID interface{}, collectionID interface{}) *MockTriggerManager_GetPauseCompactionChan_Call {
-	return &MockTriggerManager_GetPauseCompactionChan_Call{Call: _e.mock.On("GetPauseCompactionChan", jobID, collectionID)}
-}
-
-func (_c *MockTriggerManager_GetPauseCompactionChan_Call) Run(run func(jobID int64, collectionID int64)) *MockTriggerManager_GetPauseCompactionChan_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(int64), args[1].(int64))
-	})
-	return _c
-}
-
-func (_c *MockTriggerManager_GetPauseCompactionChan_Call) Return(_a0 <-chan struct{}) *MockTriggerManager_GetPauseCompactionChan_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockTriggerManager_GetPauseCompactionChan_Call) RunAndReturn(run func(int64, int64) <-chan struct{}) *MockTriggerManager_GetPauseCompactionChan_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetResumeCompactionChan provides a mock function with given fields: jobID, collectionID
-func (_m *MockTriggerManager) GetResumeCompactionChan(jobID int64, collectionID int64) <-chan struct{} {
-	ret := _m.Called(jobID, collectionID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetResumeCompactionChan")
-	}
-
-	var r0 <-chan struct{}
-	if rf, ok := ret.Get(0).(func(int64, int64) <-chan struct{}); ok {
-		r0 = rf(jobID, collectionID)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(<-chan struct{})
-		}
-	}
-
-	return r0
-}
-
-// MockTriggerManager_GetResumeCompactionChan_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetResumeCompactionChan'
-type MockTriggerManager_GetResumeCompactionChan_Call struct {
-	*mock.Call
-}
-
-// GetResumeCompactionChan is a helper method to define mock.On call
-//   - jobID int64
-//   - collectionID int64
-func (_e *MockTriggerManager_Expecter) GetResumeCompactionChan(jobID interface{}, collectionID interface{}) *MockTriggerManager_GetResumeCompactionChan_Call {
-	return &MockTriggerManager_GetResumeCompactionChan_Call{Call: _e.mock.On("GetResumeCompactionChan", jobID, collectionID)}
-}
-
-func (_c *MockTriggerManager_GetResumeCompactionChan_Call) Run(run func(jobID int64, collectionID int64)) *MockTriggerManager_GetResumeCompactionChan_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(int64), args[1].(int64))
-	})
-	return _c
-}
-
-func (_c *MockTriggerManager_GetResumeCompactionChan_Call) Return(_a0 <-chan struct{}) *MockTriggerManager_GetResumeCompactionChan_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockTriggerManager_GetResumeCompactionChan_Call) RunAndReturn(run func(int64, int64) <-chan struct{}) *MockTriggerManager_GetResumeCompactionChan_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // InitForceMergeMemoryQuerier provides a mock function with given fields: nodeManager, mixCoord, _a2
 func (_m *MockTriggerManager) InitForceMergeMemoryQuerier(nodeManager session.NodeManager, mixCoord types.MixCoord, _a2 sessionutil.SessionInterface) {
 	_m.Called(nodeManager, mixCoord, _a2)
@@ -321,7 +223,8 @@ func (_c *MockTriggerManager_Stop_Call) RunAndReturn(run func()) *MockTriggerMan
 func NewMockTriggerManager(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *MockTriggerManager {
+},
+) *MockTriggerManager {
 	mock := &MockTriggerManager{}
 	mock.Mock.Test(t)
 

--- a/internal/datacoord/server.go
+++ b/internal/datacoord/server.go
@@ -330,7 +330,7 @@ func (s *Server) initDataCoord() error {
 
 	s.importInspector = NewImportInspector(s.ctx, s.meta, s.importMeta, s.globalScheduler)
 
-	s.importChecker = NewImportChecker(s.ctx, s.meta, s.broker, s.allocator, s.importMeta, s.compactionInspector, s.handler, s.compactionTriggerManager)
+	s.importChecker = NewImportChecker(s.ctx, s.meta, s.broker, s.allocator, s.importMeta, s.compactionInspector, s.handler)
 
 	s.serverLoopCtx, s.serverLoopCancel = context.WithCancel(s.ctx)
 
@@ -680,7 +680,7 @@ func (s *Server) initCompaction() {
 	cph := newCompactionInspector(s.meta, s.allocator, s.handler, s.globalScheduler, s.indexEngineVersionManager)
 	cph.loadMeta()
 	s.compactionInspector = cph
-	s.compactionTriggerManager = NewCompactionTriggerManager(s.allocator, s.handler, s.compactionInspector, s.meta, s.importMeta)
+	s.compactionTriggerManager = NewCompactionTriggerManager(s.allocator, s.handler, s.compactionInspector, s.meta)
 	s.compactionTriggerManager.InitForceMergeMemoryQuerier(s.nodeManager, s.mixCoord, s.session)
 	s.compactionTrigger = newCompactionTrigger(s.meta, s.compactionInspector, s.allocator, s.handler, s.indexEngineVersionManager)
 }


### PR DESCRIPTION
The interactive coordination between import and L0 compaction (pause/resume channels, skip collections, L0 import task waiting) causes BulkInsert to fail with "too many input paths for binlog import" when L0 compaction triggers during import. Remove this coordination entirely so import and L0 compaction operate independently.

issue: https://github.com/milvus-io/milvus/issues/47762

pr: https://github.com/milvus-io/milvus/pull/47768