### PR TITLE
enhance: unify log.level to control all logging subsystems

### DIFF
--- a/internal/core/src/common/Common.cpp
+++ b/internal/core/src/common/Common.cpp
@@ -22,6 +22,7 @@
 #include "gflags/gflags.h"
 #include "glog/logging.h"
 #include "log/Log.h"
+#include "tantivy-binding.h"
 
 namespace milvus {
 
@@ -114,6 +115,7 @@ SetLogLevel(const char* level) {
             gflags::SetCommandLineOption("minloglevel", "2");
         }
     }
+    tantivy_set_log_level(level);
 }
 
 }  // namespace milvus

--- a/internal/core/thirdparty/tantivy/tantivy-binding/include/tantivy-binding.h
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/include/tantivy-binding.h
@@ -534,6 +534,8 @@ RustResult tantivy_set_analyzer_options(const char *params);
 
 bool tantivy_index_exist(const char *path);
 
+void tantivy_set_log_level(const char *level);
+
 RustResult tantivy_compute_phrase_match_slop(const char *tokenizer_params,
                                              const char *query,
                                              const char *data,

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/lib.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/lib.rs
@@ -23,6 +23,7 @@ mod index_writer_text_c;
 mod index_writer_v5;
 mod index_writer_v7;
 mod log;
+mod log_c;
 mod milvus_id_collector;
 mod string_c;
 mod token_stream_c;

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/log.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/log.rs
@@ -1,10 +1,10 @@
-use env_logger::Env;
 use std::sync::Once;
 
 pub(crate) fn init_log() {
     static _INITIALIZED: Once = Once::new();
     _INITIALIZED.call_once(|| {
-        let _env = Env::default().filter_or("MY_LOG_LEVEL", "info");
-        env_logger::init_from_env(_env);
+        env_logger::Builder::new()
+            .filter_level(log::LevelFilter::Info)
+            .init();
     });
 }

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/log_c.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/log_c.rs
@@ -1,0 +1,20 @@
+use std::ffi::{c_char, CStr};
+
+#[no_mangle]
+pub extern "C" fn tantivy_set_log_level(level: *const c_char) {
+    let level_str = unsafe { CStr::from_ptr(level) }
+        .to_str()
+        .unwrap_or("info");
+
+    let filter = match level_str {
+        "trace" => log::LevelFilter::Trace,
+        "debug" => log::LevelFilter::Debug,
+        "info" => log::LevelFilter::Info,
+        "warn" => log::LevelFilter::Warn,
+        "error" => log::LevelFilter::Error,
+        "fatal" | "panic" => log::LevelFilter::Error,
+        _ => log::LevelFilter::Info,
+    };
+
+    log::set_max_level(filter);
+}


### PR DESCRIPTION
Unified log.level configuration to manage all logging subsystems in Milvus (Go zap, C++ glog, Rust tantivy). Added Rust FFI function to control Tantivy log level via log::set_max_level() and call it from C++ SetLogLevel() to sync levels across all subsystems. Removed MY_LOG_LEVEL environment variable dependency from Tantivy initialization.

🤖 Generated with Claude Code