### PR TITLE
fix: add FileResource privileges to RBAC v2 built-in privilege groups

### DIFF
--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -380,6 +380,7 @@ var (
 		commonpb.ObjectPrivilege_PrivilegeListResourceGroups.String(),
 		commonpb.ObjectPrivilege_PrivilegeListPrivilegeGroups.String(),
 		commonpb.ObjectPrivilege_PrivilegeGetReplicateConfiguration.String(),
+		commonpb.ObjectPrivilege_PrivilegeListFileResources.String(),
 	})
 
 	ClusterReadWritePrivileges = append(ClusterReadOnlyPrivileges,
@@ -388,6 +389,8 @@ var (
 			commonpb.ObjectPrivilege_PrivilegeTransferNode.String(),
 			commonpb.ObjectPrivilege_PrivilegeTransferReplica.String(),
 			commonpb.ObjectPrivilege_PrivilegeUpdateResourceGroups.String(),
+			commonpb.ObjectPrivilege_PrivilegeAddFileResource.String(),
+			commonpb.ObjectPrivilege_PrivilegeRemoveFileResource.String(),
 		})...,
 	)
 


### PR DESCRIPTION
## Summary
- Add FileResource privileges to v2 built-in privilege groups in `pkg/util/constant.go`

issue: #47893