### PR TITLE
fix: restore hard-coded thread pool size limit of 16

### DIFF
--- a/internal/core/src/storage/ThreadPool.h
+++ b/internal/core/src/storage/ThreadPool.h
@@ -72,6 +72,13 @@ class ThreadPool {
         max_threads_size_.store(std::max(
             1,
             static_cast<int>(std::round(CPU_NUM * thread_core_coefficient))));
+
+        // only IO pool will set large limit, but the CPU helps nothing to IO operations,
+        // we need to limit the max thread num, each thread will download 16~64 MiB data,
+        // according to our benchmark, 16 threads is enough to saturate the network bandwidth.
+        if (max_threads_size_.load() > 16) {
+            max_threads_size_.store(16);
+        }
         LOG_INFO("Init thread pool:{}", name_)
             << " with min worker num:" << min_threads_size_
             << " and max worker num:" << max_threads_size_.load();
@@ -144,6 +151,9 @@ class ThreadPool {
         //no need to hold mutex here as we don't require
         //max_threads_size to take effect instantly, just guaranteed atomic
         new_size = std::max(1, new_size);
+        if (new_size > 16) {
+            new_size = 16;
+        }
         max_threads_size_.store(new_size);
     }
 

--- a/internal/core/src/storage/ThreadPoolTest.cpp
+++ b/internal/core/src/storage/ThreadPoolTest.cpp
@@ -62,15 +62,15 @@ TEST_F(ThreadPoolTest, ResizeBelowMinimum) {
 TEST_F(ThreadPoolTest, ResizeAboveMaximum) {
     ThreadPool pool(1.0, "test_pool");
 
-    // Resize to large values (no upper limit, should be accepted as-is)
+    // Resize to values above maximum (should be clamped to 16)
     pool.Resize(17);
-    EXPECT_EQ(pool.GetMaxThreadNum(), 17);
+    EXPECT_EQ(pool.GetMaxThreadNum(), 16);
 
     pool.Resize(100);
-    EXPECT_EQ(pool.GetMaxThreadNum(), 100);
+    EXPECT_EQ(pool.GetMaxThreadNum(), 16);
 
     pool.Resize(1000);
-    EXPECT_EQ(pool.GetMaxThreadNum(), 1000);
+    EXPECT_EQ(pool.GetMaxThreadNum(), 16);
 }
 
 }  // namespace milvus

--- a/internal/querycoordv2/meta/replica_manager.go
+++ b/internal/querycoordv2/meta/replica_manager.go
@@ -522,43 +522,13 @@ func (m *ReplicaManager) RecoverNodesInCollection(ctx context.Context, collectio
 		return err
 	}
 
-	// Phase 1: Calculate modifications under read lock (fast, memory-only)
-	modifiedReplicas, err := m.calculateRecoverModifications(collectionID, rgs)
-	if err != nil {
-		return err
-	}
-
-	if len(modifiedReplicas) == 0 {
-		return nil
-	}
-
-	// Phase 2: Persist to etcd without holding lock (slow, IO operation)
-	replicaPBs := make([]*querypb.Replica, 0, len(modifiedReplicas))
-	for _, replica := range modifiedReplicas {
-		replicaPBs = append(replicaPBs, replica.replicaPB)
-	}
-	if err := m.catalog.SaveReplica(ctx, replicaPBs...); err != nil {
-		return err
-	}
-
-	// Phase 3: Update in-memory state under write lock (fast, memory-only)
 	m.rwmutex.Lock()
-	m.putReplicaInMemory(modifiedReplicas...)
-	m.rwmutex.Unlock()
-
-	return nil
-}
-
-// calculateRecoverModifications calculates the replica modifications needed for recovery.
-// This method holds read lock only and performs no IO operations.
-func (m *ReplicaManager) calculateRecoverModifications(collectionID typeutil.UniqueID, rgs map[string]typeutil.UniqueSet) ([]*Replica, error) {
-	m.rwmutex.RLock()
-	defer m.rwmutex.RUnlock()
+	defer m.rwmutex.Unlock()
 
 	// create a helper to do the recover.
 	helper, err := m.getCollectionAssignmentHelper(collectionID, rgs)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	modifiedReplicas := make([]*Replica, 0)
@@ -596,7 +566,7 @@ func (m *ReplicaManager) calculateRecoverModifications(collectionID typeutil.Uni
 			modifiedReplicas = append(modifiedReplicas, mutableReplica.IntoReplica())
 		})
 	})
-	return modifiedReplicas, nil
+	return m.put(ctx, modifiedReplicas...)
 }
 
 // validateResourceGroups checks if the resource groups are valid.
@@ -638,56 +608,32 @@ func (m *ReplicaManager) getCollectionAssignmentHelper(collectionID typeutil.Uni
 
 // RemoveNode removes the node from all replicas of given collection.
 func (m *ReplicaManager) RemoveNode(ctx context.Context, replicaID typeutil.UniqueID, nodes ...typeutil.UniqueID) error {
-	// Phase 1: Calculate modifications under read lock (fast, memory-only)
-	m.rwmutex.RLock()
+	m.rwmutex.Lock()
+	defer m.rwmutex.Unlock()
+
 	replica, ok := m.replicas[replicaID]
 	if !ok {
-		m.rwmutex.RUnlock()
 		return merr.WrapErrReplicaNotFound(replicaID)
 	}
+
 	mutableReplica := replica.CopyForWrite()
 	mutableReplica.RemoveNode(nodes...) // ro -> unused
-	modifiedReplica := mutableReplica.IntoReplica()
-	m.rwmutex.RUnlock()
-
-	// Phase 2: Persist to etcd without holding lock (slow, IO operation)
-	if err := m.catalog.SaveReplica(ctx, modifiedReplica.replicaPB); err != nil {
-		return err
-	}
-
-	// Phase 3: Update in-memory state under write lock (fast, memory-only)
-	m.rwmutex.Lock()
-	m.putReplicaInMemory(modifiedReplica)
-	m.rwmutex.Unlock()
-
-	return nil
+	return m.put(ctx, mutableReplica.IntoReplica())
 }
 
 // RemoveSQNode removes the sq node from all replicas of given collection.
 func (m *ReplicaManager) RemoveSQNode(ctx context.Context, replicaID typeutil.UniqueID, nodes ...typeutil.UniqueID) error {
-	// Phase 1: Calculate modifications under read lock (fast, memory-only)
-	m.rwmutex.RLock()
+	m.rwmutex.Lock()
+	defer m.rwmutex.Unlock()
+
 	replica, ok := m.replicas[replicaID]
 	if !ok {
-		m.rwmutex.RUnlock()
 		return merr.WrapErrReplicaNotFound(replicaID)
 	}
+
 	mutableReplica := replica.CopyForWrite()
 	mutableReplica.RemoveSQNode(nodes...) // ro -> unused
-	modifiedReplica := mutableReplica.IntoReplica()
-	m.rwmutex.RUnlock()
-
-	// Phase 2: Persist to etcd without holding lock (slow, IO operation)
-	if err := m.catalog.SaveReplica(ctx, modifiedReplica.replicaPB); err != nil {
-		return err
-	}
-
-	// Phase 3: Update in-memory state under write lock (fast, memory-only)
-	m.rwmutex.Lock()
-	m.putReplicaInMemory(modifiedReplica)
-	m.rwmutex.Unlock()
-
-	return nil
+	return m.put(ctx, mutableReplica.IntoReplica())
 }
 
 func (m *ReplicaManager) GetResourceGroupByCollection(ctx context.Context, collection typeutil.UniqueID) typeutil.Set[string] {
@@ -742,42 +688,12 @@ func (m *ReplicaManager) GetReplicasJSON(ctx context.Context, meta *Meta) string
 // 2. Add new incoming nodes into the replica if they are not ro node of other replicas in same collection.
 // 3. replicas will shared the nodes in resource group fairly.
 func (m *ReplicaManager) RecoverSQNodesInCollection(ctx context.Context, collectionID int64, sqnNodeIDs typeutil.UniqueSet) error {
-	// Phase 1: Calculate modifications under read lock (fast, memory-only)
-	modifiedReplicas, err := m.calculateRecoverSQNModifications(collectionID, sqnNodeIDs)
-	if err != nil {
-		return err
-	}
-
-	if len(modifiedReplicas) == 0 {
-		return nil
-	}
-
-	// Phase 2: Persist to etcd without holding lock (slow, IO operation)
-	replicaPBs := make([]*querypb.Replica, 0, len(modifiedReplicas))
-	for _, replica := range modifiedReplicas {
-		replicaPBs = append(replicaPBs, replica.replicaPB)
-	}
-	if err := m.catalog.SaveReplica(ctx, replicaPBs...); err != nil {
-		return err
-	}
-
-	// Phase 3: Update in-memory state under write lock (fast, memory-only)
 	m.rwmutex.Lock()
-	m.putReplicaInMemory(modifiedReplicas...)
-	m.rwmutex.Unlock()
-
-	return nil
-}
-
-// calculateRecoverSQNModifications calculates the replica modifications needed for SQN recovery.
-// This method holds read lock only and performs no IO operations.
-func (m *ReplicaManager) calculateRecoverSQNModifications(collectionID int64, sqnNodeIDs typeutil.UniqueSet) ([]*Replica, error) {
-	m.rwmutex.RLock()
-	defer m.rwmutex.RUnlock()
+	defer m.rwmutex.Unlock()
 
 	collReplicas, ok := m.coll2Replicas[collectionID]
 	if !ok {
-		return nil, errors.Errorf("collection %d not loaded", collectionID)
+		return errors.Errorf("collection %d not loaded", collectionID)
 	}
 
 	helper := newReplicaSQNAssignmentHelper(collReplicas.replicas, sqnNodeIDs)
@@ -814,5 +730,5 @@ func (m *ReplicaManager) calculateRecoverSQNModifications(collectionID int64, sq
 		)
 		modifiedReplicas = append(modifiedReplicas, mutableReplica.IntoReplica())
 	})
-	return modifiedReplicas, nil
+	return m.put(ctx, modifiedReplicas...)
 }


### PR DESCRIPTION
## Summary
- Restore the hard-coded maximum of 16 threads for the C++ IO thread pool
- In large file scenarios, CGo threads can consume all available thread resources, starving Go goroutines
- This reverts commit ffd3435c4f and the related test changes from a41d170c14

issue: https://github.com/milvus-io/milvus/issues/48060

## Test plan
- [ ] Verify thread pool size is clamped to 16 via C++ unit test (`ThreadPoolTest.ResizeAboveMaximum`)
- [ ] Test large file load scenarios to confirm Go goroutines are no longer starved

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)