### PR TITLE
fix: restore hard-coded thread pool size limit of 16

### DIFF
--- a/internal/core/src/storage/ThreadPool.h
+++ b/internal/core/src/storage/ThreadPool.h
@@ -72,6 +72,13 @@ class ThreadPool {
         max_threads_size_.store(std::max(
             1,
             static_cast<int>(std::round(CPU_NUM * thread_core_coefficient))));
+
+        // only IO pool will set large limit, but the CPU helps nothing to IO operations,
+        // we need to limit the max thread num, each thread will download 16~64 MiB data,
+        // according to our benchmark, 16 threads is enough to saturate the network bandwidth.
+        if (max_threads_size_.load() > 16) {
+            max_threads_size_.store(16);
+        }
         LOG_INFO("Init thread pool:{}", name_)
             << " with min worker num:" << min_threads_size_
             << " and max worker num:" << max_threads_size_.load();
@@ -144,6 +151,9 @@ class ThreadPool {
         //no need to hold mutex here as we don't require
         //max_threads_size to take effect instantly, just guaranteed atomic
         new_size = std::max(1, new_size);
+        if (new_size > 16) {
+            new_size = 16;
+        }
         max_threads_size_.store(new_size);
     }
 

--- a/internal/core/src/storage/ThreadPoolTest.cpp
+++ b/internal/core/src/storage/ThreadPoolTest.cpp
@@ -62,15 +62,15 @@ TEST_F(ThreadPoolTest, ResizeBelowMinimum) {
 TEST_F(ThreadPoolTest, ResizeAboveMaximum) {
     ThreadPool pool(1.0, "test_pool");
 
-    // Resize to large values (no upper limit, should be accepted as-is)
+    // Resize to values above maximum (should be clamped to 16)
     pool.Resize(17);
-    EXPECT_EQ(pool.GetMaxThreadNum(), 17);
+    EXPECT_EQ(pool.GetMaxThreadNum(), 16);
 
     pool.Resize(100);
-    EXPECT_EQ(pool.GetMaxThreadNum(), 100);
+    EXPECT_EQ(pool.GetMaxThreadNum(), 16);
 
     pool.Resize(1000);
-    EXPECT_EQ(pool.GetMaxThreadNum(), 1000);
+    EXPECT_EQ(pool.GetMaxThreadNum(), 16);
 }
 
 }  // namespace milvus


### PR DESCRIPTION
## Summary
- Restore the hard-coded maximum of 16 threads for the C++ IO thread pool
- In large file scenarios, CGo threads can consume all available thread resources, starving Go goroutines
- This reverts commit ffd3435c4f and the related test changes from a41d170c14

issue: https://github.com/milvus-io/milvus/issues/48060

## Test plan
- [ ] Verify thread pool size is clamped to 16 via C++ unit test (`ThreadPoolTest.ResizeAboveMaximum`)
- [ ] Test large file load scenarios to confirm Go goroutines are no longer starved

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)