### PR TITLE
enhance: Log level for varchar length validation error should be warning instead of info

### DIFF
--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -2885,7 +2885,7 @@ func (node *Proxy) Upsert(ctx context.Context, request *milvuspb.UpsertRequest) 
 		zap.Uint64("EndTS", it.EndTs()))
 
 	if err := it.WaitToFinish(); err != nil {
-		log.Info("Failed to execute insert task in task scheduler",
+		log.Warn("Failed to execute insert task in task scheduler",
 			zap.Error(err))
 		// Not every error case changes the status internally
 		// change status there to handle it


### PR DESCRIPTION
This pull request makes a small change to the logging behavior in the `Upsert` method of the `Proxy` struct. Specifically, it changes the log level from `Info` to `Warn` when an insert task fails to execute in the task scheduler, making it easier to identify and prioritize potential issues in the logs.

- Changed log level from `Info` to `Warn` for failed insert task execution in `Proxy.Upsert` (`internal/proxy/impl.go`).

fix: https://github.com/milvus-io/milvus/issues/48130