### PR TITLE
fix: validate Arrow buffer layout before import to prevent SIGSEGV on schema mismatch

### DIFF
--- a/internal/storagev2/packed/packed_reader.go
+++ b/internal/storagev2/packed/packed_reader.go
@@ -133,6 +133,19 @@ func (pr *PackedReader) ReadNext() (arrow.Record, error) {
 		return nil, io.EOF // end of stream, no more records to read
 	}
 
+	// Validate buffer layout BEFORE import to prevent SIGSEGV.
+	// C++ may produce a RecordBatch where schema says type A (expected) but data
+	// buffers are laid out for type B (actual from parquet). The exported CArrowSchema
+	// uses expected types (lies), but CArrowArray children's n_buffers reflects the
+	// true layout. Comparing these catches the mismatch before import.
+	if err := validateCArrayBufferLayout(unsafe.Pointer(cArr), pr.schema); err != nil {
+		goCArr := (*cdata.CArrowArray)(unsafe.Pointer(cArr))
+		goCSchema := (*cdata.CArrowSchema)(unsafe.Pointer(cSchema))
+		cdata.ReleaseCArrowArray(goCArr)
+		cdata.ReleaseCArrowSchema(goCSchema)
+		return nil, err
+	}
+
 	// Convert ArrowArray to Go RecordBatch using cdata
 	goCArr := (*cdata.CArrowArray)(unsafe.Pointer(cArr))
 	goCSchema := (*cdata.CArrowSchema)(unsafe.Pointer(cSchema))

--- a/internal/storagev2/packed/packed_reader_ffi.go
+++ b/internal/storagev2/packed/packed_reader_ffi.go
@@ -157,6 +157,16 @@ func (r *FFIPackedReader) ReadNext() (arrow.Record, error) {
 		return nil, fmt.Errorf("failed to read next record: %w", err)
 	}
 
+	// Validate schema consistency on first record to catch type mismatches early
+	// before they cause SIGSEGV in downstream processing
+	if !r.schemaValidated {
+		if err := ValidateSchemaConsistency(r.schema, rec.Schema()); err != nil {
+			rec.Release()
+			return nil, err
+		}
+		r.schemaValidated = true
+	}
+
 	return rec, nil
 }
 

--- a/internal/storagev2/packed/schema_validate.go
+++ b/internal/storagev2/packed/schema_validate.go
@@ -1,0 +1,221 @@
+// Copyright 2023 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packed
+
+/*
+#include <stdlib.h>
+#include "arrow/c/abi.h"
+*/
+import "C"
+
+import (
+	"fmt"
+	"strings"
+	"unsafe"
+
+	"github.com/apache/arrow/go/v17/arrow"
+
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+)
+
+// ValidateSchemaConsistency checks that the actual Arrow schema returned from C++
+// is type-compatible with the expected schema. This prevents SIGSEGV when the
+// underlying data type (e.g. JSON/UTF8) doesn't match the expected type (e.g. Int64)
+// due to field ID reuse across backup/restore with different schemas.
+//
+// Fields are matched by name (in binlog context, names are field ID strings).
+// Only Arrow type IDs are compared (coarse-grained check).
+func ValidateSchemaConsistency(expected, actual *arrow.Schema) error {
+	if expected == nil || actual == nil {
+		return nil
+	}
+
+	actualFieldMap := make(map[string]arrow.Field, len(actual.Fields()))
+	for _, f := range actual.Fields() {
+		actualFieldMap[f.Name] = f
+	}
+
+	var mismatches []string
+	for _, ef := range expected.Fields() {
+		af, ok := actualFieldMap[ef.Name]
+		if !ok {
+			continue // field not present in actual schema, skip (projection may have removed it)
+		}
+		if ef.Type.ID() != af.Type.ID() {
+			mismatches = append(mismatches, fmt.Sprintf(
+				"field %q: expected type %s (ID=%d) but got %s (ID=%d)",
+				ef.Name, ef.Type, ef.Type.ID(), af.Type, af.Type.ID(),
+			))
+		}
+	}
+
+	if len(mismatches) > 0 {
+		return merr.WrapErrImportFailed(
+			fmt.Sprintf("schema type mismatch between expected and actual data: %s", strings.Join(mismatches, "; ")),
+		)
+	}
+	return nil
+}
+
+// validateCArrayBufferLayout inspects the raw C ArrowArray structure to verify
+// that each child's buffer count matches what the schema type expects.
+//
+// This is the critical defense against SIGSEGV: C++ PackedRecordBatchReader may
+// produce a RecordBatch where the schema says type A (from the expected/target schema)
+// but the actual data buffers are laid out for type B (from the source parquet files).
+// The exported CArrowSchema lies (uses expected types), but the CArrowArray children's
+// n_buffers reflects the true buffer layout. Comparing these catches the mismatch
+// before ImportCRecordBatch tries to interpret incompatible buffers.
+//
+// Example: schema says Int64 (2 buffers: validity+values) but data is actually
+// String/JSON (3 buffers: validity+offsets+data). Reading 800 bytes of "values"
+// from a 400-byte offsets buffer → SIGSEGV.
+func validateCArrayBufferLayout(cArr unsafe.Pointer, schema *arrow.Schema) error {
+	if cArr == nil || schema == nil {
+		return nil
+	}
+
+	arr := (*C.struct_ArrowArray)(cArr)
+	nChildren := int(arr.n_children)
+	nFields := len(schema.Fields())
+
+	if nChildren != nFields {
+		return merr.WrapErrImportFailed(
+			fmt.Sprintf("field count mismatch: schema has %d fields but data has %d children", nFields, nChildren),
+		)
+	}
+
+	if nChildren == 0 {
+		return nil
+	}
+
+	children := unsafe.Slice(arr.children, nChildren)
+
+	var mismatches []string
+	for i, field := range schema.Fields() {
+		child := children[i]
+		if child == nil {
+			continue
+		}
+		expected := expectedBufferCount(field.Type)
+		if expected < 0 {
+			continue // unknown type, skip validation
+		}
+		actual := int(child.n_buffers)
+		if expected != actual {
+			mismatches = append(mismatches, fmt.Sprintf(
+				"field %q (type %s): expected %d buffers but data has %d (possible type mismatch in source data)",
+				field.Name, field.Type, expected, actual,
+			))
+		}
+	}
+
+	if len(mismatches) > 0 {
+		return merr.WrapErrImportFailed(
+			fmt.Sprintf("data buffer layout mismatch, source data types may differ from target schema: %s",
+				strings.Join(mismatches, "; ")),
+		)
+	}
+	return nil
+}
+
+// newFakeCArrowArray creates a minimal C ArrowArray with the specified children n_buffers.
+// Used for testing validateCArrayBufferLayout without real Arrow data.
+func newFakeCArrowArray(childBufferCounts []int) (*C.struct_ArrowArray, func()) {
+	nChildren := len(childBufferCounts)
+
+	parent := (*C.struct_ArrowArray)(C.malloc(C.size_t(unsafe.Sizeof(C.struct_ArrowArray{}))))
+	parent.length = 100
+	parent.null_count = 0
+	parent.offset = 0
+	parent.n_buffers = 1
+	parent.n_children = C.int64_t(nChildren)
+	parent.release = nil
+	parent.dictionary = nil
+	parent.private_data = nil
+	parent.buffers = nil
+
+	if nChildren > 0 {
+		childrenPtr := (**C.struct_ArrowArray)(C.malloc(C.size_t(uintptr(nChildren) * unsafe.Sizeof((*C.struct_ArrowArray)(nil)))))
+		children := unsafe.Slice(childrenPtr, nChildren)
+		for i, nBufs := range childBufferCounts {
+			child := (*C.struct_ArrowArray)(C.malloc(C.size_t(unsafe.Sizeof(C.struct_ArrowArray{}))))
+			child.length = 100
+			child.null_count = 0
+			child.offset = 0
+			child.n_buffers = C.int64_t(nBufs)
+			child.n_children = 0
+			child.children = nil
+			child.release = nil
+			child.dictionary = nil
+			child.private_data = nil
+			child.buffers = nil
+			children[i] = child
+		}
+		parent.children = childrenPtr
+	} else {
+		parent.children = nil
+	}
+
+	cleanup := func() {
+		if nChildren > 0 {
+			children := unsafe.Slice(parent.children, nChildren)
+			for _, child := range children {
+				C.free(unsafe.Pointer(child))
+			}
+			C.free(unsafe.Pointer(parent.children))
+		}
+		C.free(unsafe.Pointer(parent))
+	}
+
+	return parent, cleanup
+}
+
+// expectedBufferCount returns the number of buffers expected for an Arrow type
+// according to the Arrow columnar format specification.
+// Returns -1 for unknown types (validation will be skipped).
+func expectedBufferCount(dt arrow.DataType) int {
+	switch dt.ID() {
+	case arrow.NULL:
+		return 0
+	case arrow.BOOL,
+		arrow.INT8, arrow.INT16, arrow.INT32, arrow.INT64,
+		arrow.UINT8, arrow.UINT16, arrow.UINT32, arrow.UINT64,
+		arrow.FLOAT16, arrow.FLOAT32, arrow.FLOAT64,
+		arrow.DATE32, arrow.DATE64,
+		arrow.TIME32, arrow.TIME64,
+		arrow.TIMESTAMP, arrow.DURATION,
+		arrow.INTERVAL_MONTHS, arrow.INTERVAL_DAY_TIME, arrow.INTERVAL_MONTH_DAY_NANO,
+		arrow.DECIMAL128, arrow.DECIMAL256,
+		arrow.FIXED_SIZE_BINARY:
+		return 2 // validity bitmap + values
+	case arrow.STRING, arrow.BINARY:
+		return 3 // validity bitmap + offsets + data
+	case arrow.LARGE_STRING, arrow.LARGE_BINARY:
+		return 3 // validity bitmap + offsets + data
+	case arrow.LIST, arrow.MAP:
+		return 2 // validity bitmap + offsets
+	case arrow.LARGE_LIST:
+		return 2 // validity bitmap + offsets
+	case arrow.FIXED_SIZE_LIST, arrow.STRUCT:
+		return 1 // validity bitmap only
+	case arrow.DENSE_UNION:
+		return 2 // type_ids + offsets
+	case arrow.SPARSE_UNION:
+		return 1 // type_ids only
+	default:
+		return -1 // unknown, skip validation
+	}
+}

--- a/internal/storagev2/packed/schema_validate_test.go
+++ b/internal/storagev2/packed/schema_validate_test.go
@@ -1,0 +1,220 @@
+// Copyright 2023 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packed
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateSchemaConsistency(t *testing.T) {
+	t.Run("nil schemas", func(t *testing.T) {
+		assert.NoError(t, ValidateSchemaConsistency(nil, nil))
+		schema := arrow.NewSchema([]arrow.Field{
+			{Name: "100", Type: arrow.PrimitiveTypes.Int64},
+		}, nil)
+		assert.NoError(t, ValidateSchemaConsistency(nil, schema))
+		assert.NoError(t, ValidateSchemaConsistency(schema, nil))
+	})
+
+	t.Run("matching schemas", func(t *testing.T) {
+		expected := arrow.NewSchema([]arrow.Field{
+			{Name: "100", Type: arrow.PrimitiveTypes.Int32},
+			{Name: "101", Type: arrow.PrimitiveTypes.Int64},
+			{Name: "102", Type: arrow.BinaryTypes.String},
+		}, nil)
+		actual := arrow.NewSchema([]arrow.Field{
+			{Name: "100", Type: arrow.PrimitiveTypes.Int32},
+			{Name: "101", Type: arrow.PrimitiveTypes.Int64},
+			{Name: "102", Type: arrow.BinaryTypes.String},
+		}, nil)
+		assert.NoError(t, ValidateSchemaConsistency(expected, actual))
+	})
+
+	t.Run("type mismatch", func(t *testing.T) {
+		expected := arrow.NewSchema([]arrow.Field{
+			{Name: "100", Type: arrow.PrimitiveTypes.Int32},
+			{Name: "101", Type: arrow.PrimitiveTypes.Int64},
+			{Name: "102", Type: arrow.PrimitiveTypes.Int64},
+		}, nil)
+		actual := arrow.NewSchema([]arrow.Field{
+			{Name: "100", Type: arrow.PrimitiveTypes.Int32},
+			{Name: "101", Type: arrow.PrimitiveTypes.Int64},
+			{Name: "102", Type: arrow.BinaryTypes.String},
+		}, nil)
+		err := ValidateSchemaConsistency(expected, actual)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "schema type mismatch")
+		assert.Contains(t, err.Error(), "102")
+	})
+
+	t.Run("multiple mismatches", func(t *testing.T) {
+		expected := arrow.NewSchema([]arrow.Field{
+			{Name: "100", Type: arrow.PrimitiveTypes.Int64},
+			{Name: "101", Type: arrow.PrimitiveTypes.Float32},
+		}, nil)
+		actual := arrow.NewSchema([]arrow.Field{
+			{Name: "100", Type: arrow.BinaryTypes.String},
+			{Name: "101", Type: arrow.PrimitiveTypes.Int64},
+		}, nil)
+		err := ValidateSchemaConsistency(expected, actual)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "100")
+		assert.Contains(t, err.Error(), "101")
+	})
+
+	t.Run("extra fields in actual are ignored", func(t *testing.T) {
+		expected := arrow.NewSchema([]arrow.Field{
+			{Name: "100", Type: arrow.PrimitiveTypes.Int32},
+		}, nil)
+		actual := arrow.NewSchema([]arrow.Field{
+			{Name: "100", Type: arrow.PrimitiveTypes.Int32},
+			{Name: "101", Type: arrow.PrimitiveTypes.Int64},
+		}, nil)
+		assert.NoError(t, ValidateSchemaConsistency(expected, actual))
+	})
+
+	t.Run("missing field in actual is skipped", func(t *testing.T) {
+		expected := arrow.NewSchema([]arrow.Field{
+			{Name: "100", Type: arrow.PrimitiveTypes.Int32},
+			{Name: "101", Type: arrow.PrimitiveTypes.Int64},
+		}, nil)
+		actual := arrow.NewSchema([]arrow.Field{
+			{Name: "100", Type: arrow.PrimitiveTypes.Int32},
+		}, nil)
+		assert.NoError(t, ValidateSchemaConsistency(expected, actual))
+	})
+}
+
+func TestExpectedBufferCount(t *testing.T) {
+	tests := []struct {
+		name     string
+		dt       arrow.DataType
+		expected int
+	}{
+		{"null", arrow.Null, 0},
+		{"bool", arrow.FixedWidthTypes.Boolean, 2},
+		{"int32", arrow.PrimitiveTypes.Int32, 2},
+		{"int64", arrow.PrimitiveTypes.Int64, 2},
+		{"float32", arrow.PrimitiveTypes.Float32, 2},
+		{"float64", arrow.PrimitiveTypes.Float64, 2},
+		{"string", arrow.BinaryTypes.String, 3},
+		{"binary", arrow.BinaryTypes.Binary, 3},
+		{"large_string", arrow.BinaryTypes.LargeString, 3},
+		{"large_binary", arrow.BinaryTypes.LargeBinary, 3},
+		{"fixed_size_binary", &arrow.FixedSizeBinaryType{ByteWidth: 16}, 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, expectedBufferCount(tt.dt))
+		})
+	}
+}
+
+func TestValidateCArrayBufferLayout(t *testing.T) {
+	t.Run("nil inputs", func(t *testing.T) {
+		assert.NoError(t, validateCArrayBufferLayout(nil, nil))
+		schema := arrow.NewSchema([]arrow.Field{
+			{Name: "100", Type: arrow.PrimitiveTypes.Int64},
+		}, nil)
+		assert.NoError(t, validateCArrayBufferLayout(nil, schema))
+	})
+
+	t.Run("matching layout - all int64", func(t *testing.T) {
+		schema := arrow.NewSchema([]arrow.Field{
+			{Name: "100", Type: arrow.PrimitiveTypes.Int32},
+			{Name: "101", Type: arrow.PrimitiveTypes.Int64},
+		}, nil)
+		// Int32 and Int64 both expect 2 buffers (validity + values)
+		arr, cleanup := newFakeCArrowArray([]int{2, 2})
+		defer cleanup()
+
+		assert.NoError(t, validateCArrayBufferLayout(unsafe.Pointer(arr), schema))
+	})
+
+	t.Run("matching layout - string fields", func(t *testing.T) {
+		schema := arrow.NewSchema([]arrow.Field{
+			{Name: "100", Type: arrow.BinaryTypes.String},
+			{Name: "101", Type: arrow.BinaryTypes.LargeString},
+		}, nil)
+		// String and LargeString both expect 3 buffers (validity + offsets + data)
+		arr, cleanup := newFakeCArrowArray([]int{3, 3})
+		defer cleanup()
+
+		assert.NoError(t, validateCArrayBufferLayout(unsafe.Pointer(arr), schema))
+	})
+
+	t.Run("mismatch - schema says Int64 but data is String", func(t *testing.T) {
+		// This is the exact backup/restore crash scenario:
+		// field 102 is Int64 in target schema, but source data is JSON/String (3 buffers)
+		schema := arrow.NewSchema([]arrow.Field{
+			{Name: "100", Type: arrow.PrimitiveTypes.Int32},
+			{Name: "101", Type: arrow.PrimitiveTypes.Int64},
+			{Name: "102", Type: arrow.PrimitiveTypes.Int64}, // expects 2 buffers
+		}, nil)
+		// Data: field 102 actually has 3 buffers (String/JSON layout)
+		arr, cleanup := newFakeCArrowArray([]int{2, 2, 3})
+		defer cleanup()
+
+		err := validateCArrayBufferLayout(unsafe.Pointer(arr), schema)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "102")
+		assert.Contains(t, err.Error(), "expected 2 buffers but data has 3")
+	})
+
+	t.Run("mismatch - schema says String but data is Int64", func(t *testing.T) {
+		schema := arrow.NewSchema([]arrow.Field{
+			{Name: "100", Type: arrow.BinaryTypes.String}, // expects 3 buffers
+		}, nil)
+		// Data: actually has 2 buffers (Int64 layout)
+		arr, cleanup := newFakeCArrowArray([]int{2})
+		defer cleanup()
+
+		err := validateCArrayBufferLayout(unsafe.Pointer(arr), schema)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "100")
+		assert.Contains(t, err.Error(), "expected 3 buffers but data has 2")
+	})
+
+	t.Run("field count mismatch", func(t *testing.T) {
+		schema := arrow.NewSchema([]arrow.Field{
+			{Name: "100", Type: arrow.PrimitiveTypes.Int32},
+			{Name: "101", Type: arrow.PrimitiveTypes.Int64},
+		}, nil)
+		arr, cleanup := newFakeCArrowArray([]int{2, 2, 3})
+		defer cleanup()
+
+		err := validateCArrayBufferLayout(unsafe.Pointer(arr), schema)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "field count mismatch")
+	})
+
+	t.Run("multiple mismatches reported", func(t *testing.T) {
+		schema := arrow.NewSchema([]arrow.Field{
+			{Name: "100", Type: arrow.PrimitiveTypes.Int64}, // expects 2
+			{Name: "101", Type: arrow.PrimitiveTypes.Int32}, // expects 2
+		}, nil)
+		arr, cleanup := newFakeCArrowArray([]int{3, 3})
+		defer cleanup()
+
+		err := validateCArrayBufferLayout(unsafe.Pointer(arr), schema)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "100")
+		assert.Contains(t, err.Error(), "101")
+	})
+}

--- a/internal/storagev2/packed/type.go
+++ b/internal/storagev2/packed/type.go
@@ -49,9 +49,10 @@ type PackedReader struct {
 }
 
 type FFIPackedReader struct {
-	cPackedReader C.CFFIPackedReader
-	recordReader  arrio.Reader
-	schema        *arrow.Schema
+	cPackedReader   C.CFFIPackedReader
+	recordReader    arrio.Reader
+	schema          *arrow.Schema
+	schemaValidated bool
 }
 
 type (


### PR DESCRIPTION
Related to #48141

In backup/restore scenarios, field IDs can be reused with different types (e.g., field 102 is JSON in source but Int64 in target). C++ PackedRecordBatchReader produces a broken RecordBatch: the exported CArrowSchema uses expected types (lies), but data buffers are laid out for actual parquet types. ImportCRecordBatch interprets String buffers (3 buffers) as Int64 (2 buffers), reading beyond buffer bounds → SIGSEGV that Go's recover() cannot catch.

Fix: inspect CArrowArray.children[i].n_buffers (which reflects true buffer layout) against expected buffer counts from the schema type before calling ImportCRecordBatch. Mismatch returns merr.WrapErrImportFailed instead of crashing.