### PR TITLE
enhance: [loon] move storage v3 deltalog files under basePath/_delta/ to align with loon convention

### DIFF
--- a/internal/datanode/compactor/l0_compactor.go
+++ b/internal/datanode/compactor/l0_compactor.go
@@ -257,13 +257,21 @@ func (t *LevelZeroCompactionTask) splitAndWrite(
 				return nil, err
 			}
 
-			path := metautil.BuildDeltaLogPath(
-				t.compactionParams.StorageConfig.GetRootPath(), segment.GetCollectionID(), segment.GetPartitionID(), segment.GetSegmentID(), logID)
-
 			// Use V2 storage for segments with manifest, V1 otherwise
 			storageVersion := storage.StorageV1
+			var path string
 			if segment.GetManifest() != "" {
 				storageVersion = storage.StorageV2
+				// V3: build deltalog path under basePath/_delta/
+				basePath, _, err := packed.UnmarshalManfestPath(segment.GetManifest())
+				if err != nil {
+					log.Warn("L0 compaction failed to parse manifest path", zap.Int64("segmentID", segmentID), zap.Error(err))
+					return nil, err
+				}
+				path = metautil.BuildDeltaLogPathV3(basePath, logID)
+			} else {
+				path = metautil.BuildDeltaLogPath(
+					t.compactionParams.StorageConfig.GetRootPath(), segment.GetCollectionID(), segment.GetPartitionID(), segment.GetSegmentID(), logID)
 			}
 
 			writer, err := storage.NewDeltalogWriter(ctx,

--- a/internal/flushcommon/syncmgr/pack_writer_v3.go
+++ b/internal/flushcommon/syncmgr/pack_writer_v3.go
@@ -211,14 +211,12 @@ func (bw *BulkPackWriterV3) writeDelta(ctx context.Context, pack *SyncPack) (str
 		return "", err
 	}
 
-	// Build deltalog path
-	deltaPath := metautil.BuildDeltaLogPath(
-		bw.storageConfig.GetRootPath(),
-		pack.collectionID,
-		pack.partitionID,
-		pack.segmentID,
-		logID,
-	)
+	// Build deltalog path under basePath/_delta/
+	basePath, _, err := packed.UnmarshalManfestPath(bw.manifestPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse manifest path: %w", err)
+	}
+	deltaPath := metautil.BuildDeltaLogPathV3(basePath, logID)
 
 	// Create deltalog writer with V2 storage
 	writer, err := storage.NewDeltalogWriter(

--- a/internal/storage/record_reader.go
+++ b/internal/storage/record_reader.go
@@ -94,7 +94,12 @@ func (ir *IterativeRecordReader) Close() error {
 	return nil
 }
 
-func (ir *IterativeRecordReader) Next() (Record, error) {
+func (ir *IterativeRecordReader) Next() (rec Record, err error) {
+	defer func() {
+		if x := recover(); x != nil {
+			rec, err = nil, fmt.Errorf("internal error recovered: %v", x)
+		}
+	}()
 	if ir.cur == nil {
 		r, err := ir.iterate()
 		if err != nil {
@@ -102,7 +107,7 @@ func (ir *IterativeRecordReader) Next() (Record, error) {
 		}
 		ir.cur = r
 	}
-	rec, err := ir.cur.Next()
+	rec, err = ir.cur.Next()
 	if err == io.EOF {
 		closeErr := ir.cur.Close()
 		if closeErr != nil {

--- a/internal/storagev2/packed/transaction.go
+++ b/internal/storagev2/packed/transaction.go
@@ -170,15 +170,23 @@ func GetDeltaLogPathsFromManifest(
 	return paths, nil
 }
 
-// toRelativePath converts a full path to a path relative to the base path.
-// The deltalog path format is: {rootPath}/delta_log/{collectionID}/{partitionID}/{segmentID}/{logID}
-// The basePath format is: {rootPath}/insert_log/{collectionID}/{partitionID}/{segmentID}
-//
+// toRelativePath converts a full path to a path relative to basePath/_delta/.
 // The C loon library stores delta log paths relative to basePath/_delta/ (the kDeltaPath convention).
 // When deserializing, it prepends basePath/_delta/ to the relative path and normalizes.
-// So we need baseDepth + 1 levels of "../" (the +1 accounts for the _delta/ subdirectory).
+//
+// For V3 delta paths ({basePath}/_delta/{logID}), the file is already under basePath/_delta/,
+// so the relative path is simply the filename ({logID}).
+//
+// For legacy delta paths ({rootPath}/delta_log/{collID}/{partID}/{segID}/{logID}),
+// we need baseDepth + 1 levels of "../" to escape basePath/_delta/ back to rootPath.
 func toRelativePath(fullPath, basePath, rootPath string) string {
-	// If fullPath starts with rootPath, make it relative to basePath/_delta/
+	// V3 path: if fullPath is under basePath/_delta/, just return the filename
+	deltaDir := filepath.Join(basePath, "_delta") + "/"
+	if strings.HasPrefix(fullPath, deltaDir) {
+		return strings.TrimPrefix(fullPath, deltaDir)
+	}
+
+	// Legacy path: compute relative path from basePath/_delta/ via "../" traversal
 	if strings.HasPrefix(fullPath, rootPath) {
 		// Get the path relative to rootPath for both
 		fullRel := strings.TrimPrefix(fullPath, rootPath)

--- a/internal/storagev2/packed/transaction_test.go
+++ b/internal/storagev2/packed/transaction_test.go
@@ -53,6 +53,13 @@ func TestToRelativePath(t *testing.T) {
 			expected: "../../../../../delta_log/100/200/300/5",
 		},
 		{
+			name:     "v3 deltalog under basePath/_delta/",
+			fullPath: "/data/insert_log/123/456/789/_delta/1",
+			basePath: "/data/insert_log/123/456/789",
+			rootPath: "/data",
+			expected: "1",
+		},
+		{
 			name:     "path without rootPath prefix",
 			fullPath: "/other/path/file",
 			basePath: "/data/insert_log/123/456/789",
@@ -65,6 +72,13 @@ func TestToRelativePath(t *testing.T) {
 			basePath: "insert_log/123/456/789",
 			rootPath: "",
 			expected: "../../../../../delta_log/123/456/789/1",
+		},
+		{
+			name:     "v3 deltalog with empty rootPath",
+			fullPath: "insert_log/123/456/789/_delta/1",
+			basePath: "insert_log/123/456/789",
+			rootPath: "",
+			expected: "1",
 		},
 	}
 
@@ -187,6 +201,23 @@ func TestGetDeltaLogPathsFromManifest(t *testing.T) {
 		require.Equal(t, 2, len(paths))
 		assert.Contains(t, paths[0], "delta_log/1/2/3/201")
 		assert.Contains(t, paths[1], "delta_log/1/2/3/202")
+	})
+
+	t.Run("v3 delta log under basePath/_delta/", func(t *testing.T) {
+		bp := filepath.Join(dir, "insert_log/1/2/3_v3delta")
+		manifestPath := createBaseManifest(t, bp, storageConfig)
+
+		// V3 deltaPath: basePath/_delta/{logID}
+		deltaFullPath := filepath.Join(bp, "_delta/501")
+		newManifest, err := AddDeltaLogsToManifest(manifestPath, storageConfig, []DeltaLogEntry{
+			{Path: deltaFullPath, NumEntries: 8},
+		})
+		require.NoError(t, err)
+
+		paths, err := GetDeltaLogPathsFromManifest(newManifest, storageConfig)
+		assert.NoError(t, err)
+		require.Equal(t, 1, len(paths))
+		assert.Contains(t, paths[0], "_delta/501")
 	})
 
 	t.Run("empty deltaLogs input returns original manifest", func(t *testing.T) {

--- a/pkg/util/metautil/binlog.go
+++ b/pkg/util/metautil/binlog.go
@@ -67,6 +67,13 @@ func BuildDeltaLogPath(rootPath string, collectionID, partitionID, segmentID, lo
 	return path.Join(rootPath, common.SegmentDeltaLogPath, k)
 }
 
+// BuildDeltaLogPathV3 builds a deltalog path under the segment's basePath/_delta/ directory.
+// This places the deltalog alongside the insert data instead of under a separate delta_log/ prefix.
+// The resulting path is: {basePath}/_delta/{logID}
+func BuildDeltaLogPathV3(basePath string, logID typeutil.UniqueID) string {
+	return path.Join(basePath, "_delta", strconv.FormatInt(logID, 10))
+}
+
 func GetSegmentIDFromDeltaLogPath(logPath string) typeutil.UniqueID {
 	return getSegmentIDFromPath(logPath, 2)
 }

--- a/pkg/util/metautil/binlog_test.go
+++ b/pkg/util/metautil/binlog_test.go
@@ -142,6 +142,37 @@ func TestParseInsertLogPath(t *testing.T) {
 	}
 }
 
+func TestBuildDeltaLogPathV3(t *testing.T) {
+	tests := []struct {
+		name     string
+		basePath string
+		logID    typeutil.UniqueID
+		expected string
+	}{
+		{
+			name:     "basic path",
+			basePath: "rootPath/insert_log/123/456/789",
+			logID:    1001,
+			expected: "rootPath/insert_log/123/456/789/_delta/1001",
+		},
+		{
+			name:     "absolute path",
+			basePath: "/data/insert_log/100/200/300",
+			logID:    42,
+			expected: "/data/insert_log/100/200/300/_delta/42",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := BuildDeltaLogPathV3(tt.basePath, tt.logID)
+			if result != tt.expected {
+				t.Errorf("BuildDeltaLogPathV3() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
 func TestExtractTextLogFilenames(t *testing.T) {
 	textStatsLogs := map[int64]*datapb.TextIndexStats{
 		100: {


### PR DESCRIPTION
Related to #44956

Previously, V3 deltalogs were written to {rootPath}/delta_log/{collID}/{partID}/{segID}/{logID}, separate from the segment's basePath. The manifest used complex "../" relative paths to bridge the two locations. This change writes V3 deltalogs directly to {basePath}/_delta/{logID}, aligning with the C loon library's native _delta/ convention and simplifying the manifest relative path to just the logID filename. Legacy V1 segments and existing manifests remain backward compatible.