### PR TITLE
fix: [RBAC][2.6] grant cleanup on drop and migration on rename and meta cache interceptor

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -332,12 +332,12 @@ proxy:
   ddlConcurrency: 16 # The concurrent execution number of DDL at proxy.
   dclConcurrency: 16 # The concurrent execution number of DCL at proxy.
   mustUsePartitionKey: false # switch for whether proxy must use partition key for the collection
-  resolveAliasForPrivilege: true # switch for whether proxy shall resolve alias to actual collection name during RBAC privilege checks
   # maximum number of result entries, typically Nq * TopK * GroupSize. 
   # It costs additional memory and time to process a large number of result entries. 
   # If the number of result entries exceeds this limit, the search will be rejected.
   # Disabled if the value is less or equal to 0.
   maxResultEntries: -1
+  resolveAliasForPrivilege: true # switch for whether proxy shall resolve alias to actual collection name during RBAC privilege checks
   accessLog:
     enable: false # Whether to enable the access log feature.
     minioEnable: false # Whether to upload local access log files to MinIO. This parameter can be specified when proxy.accessLog.filename is not empty.

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -332,12 +332,12 @@ proxy:
   ddlConcurrency: 16 # The concurrent execution number of DDL at proxy.
   dclConcurrency: 16 # The concurrent execution number of DCL at proxy.
   mustUsePartitionKey: false # switch for whether proxy must use partition key for the collection
+  resolveAliasForPrivilege: true # switch for whether proxy shall resolve alias to actual collection name during RBAC privilege checks
   # maximum number of result entries, typically Nq * TopK * GroupSize. 
   # It costs additional memory and time to process a large number of result entries. 
   # If the number of result entries exceeds this limit, the search will be rejected.
   # Disabled if the value is less or equal to 0.
   maxResultEntries: -1
-  resolveAliasForPrivilege: true # switch for whether proxy shall resolve alias to actual collection name during RBAC privilege checks
   accessLog:
     enable: false # Whether to enable the access log feature.
     minioEnable: false # Whether to upload local access log files to MinIO. This parameter can be specified when proxy.accessLog.filename is not empty.

--- a/internal/metastore/kv/rootcoord/kv_catalog.go
+++ b/internal/metastore/kv/rootcoord/kv_catalog.go
@@ -1442,7 +1442,7 @@ func (kc *Catalog) DeleteGrantByCollectionName(ctx context.Context, tenant strin
 			continue
 		}
 		grantDB, grantObj := funcutil.SplitObjectName(grantInfos[2])
-		if grantObj == collectionName && (grantDB == dbName || grantDB == util.AnyWord) {
+		if grantObj == collectionName && grantDB == dbName {
 			// Reconstruct logical key (without etcd rootPath) for deletion.
 			// LoadWithPrefix returns full etcd keys (with rootPath prefix),
 			// but MultiSaveAndRemove prepends rootPath again, so we must
@@ -1503,7 +1503,7 @@ func (kc *Catalog) MigrateGrantCollectionName(ctx context.Context, tenant string
 			continue
 		}
 		grantDB, grantObj := funcutil.SplitObjectName(grantInfos[2])
-		if grantObj == oldName && (grantDB == oldDBName || grantDB == util.AnyWord) {
+		if grantObj == oldName && grantDB == oldDBName {
 			oldIdStr := values[i]
 
 			// Load GranteeIDPrefix entries FIRST, before queuing the parent key
@@ -1520,12 +1520,7 @@ func (kc *Catalog) MigrateGrantCollectionName(ctx context.Context, tenant string
 			// Build new key with new collection name and recompute idStr
 			// to avoid sharing permission space with a future collection
 			// that reuses the old name.
-			// Preserve the original dbName (e.g., keep "*" for wildcard grants).
-			migrateDB := newDBName
-			if grantDB == util.AnyWord {
-				migrateDB = util.AnyWord
-			}
-			newObjName := funcutil.CombineObjectName(migrateDB, newName)
+			newObjName := funcutil.CombineObjectName(newDBName, newName)
 			newKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant,
 				fmt.Sprintf("%s/%s/%s", grantInfos[0], grantInfos[1], newObjName))
 			newIdStr := crypto.MD5(newKey)

--- a/internal/metastore/kv/rootcoord/kv_catalog.go
+++ b/internal/metastore/kv/rootcoord/kv_catalog.go
@@ -1442,9 +1442,14 @@ func (kc *Catalog) DeleteGrantByCollectionName(ctx context.Context, tenant strin
 			continue
 		}
 		grantDB, grantObj := funcutil.SplitObjectName(grantInfos[2])
-		if grantObj == collectionName && grantDB == dbName {
-			// Use exact deletion for the grantee key
-			exactRemoveKeys = append(exactRemoveKeys, key)
+		if grantObj == collectionName && (grantDB == dbName || grantDB == util.AnyWord) {
+			// Reconstruct logical key (without etcd rootPath) for deletion.
+			// LoadWithPrefix returns full etcd keys (with rootPath prefix),
+			// but MultiSaveAndRemove prepends rootPath again, so we must
+			// use the logical key to avoid double-prefix.
+			logicalKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant,
+				fmt.Sprintf("%s/%s/%s", grantInfos[0], grantInfos[1], grantInfos[2]))
+			exactRemoveKeys = append(exactRemoveKeys, logicalKey)
 			// Use prefix deletion for the granteeID key (has sub-keys)
 			granteeIDKey := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, values[i]+"/")
 			prefixRemoveKeys = append(prefixRemoveKeys, granteeIDKey)
@@ -1498,18 +1503,29 @@ func (kc *Catalog) MigrateGrantCollectionName(ctx context.Context, tenant string
 			continue
 		}
 		grantDB, grantObj := funcutil.SplitObjectName(grantInfos[2])
-		if grantObj == oldName && grantDB == oldDBName {
+		if grantObj == oldName && (grantDB == oldDBName || grantDB == util.AnyWord) {
 			oldIdStr := values[i]
 
 			// Build new key with new collection name and recompute idStr
 			// to avoid sharing permission space with a future collection
 			// that reuses the old name.
-			newObjName := funcutil.CombineObjectName(newDBName, newName)
+			// Preserve the original dbName (e.g., keep "*" for wildcard grants).
+			migrateDB := newDBName
+			if grantDB == util.AnyWord {
+				migrateDB = util.AnyWord
+			}
+			newObjName := funcutil.CombineObjectName(migrateDB, newName)
 			newKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant,
 				fmt.Sprintf("%s/%s/%s", grantInfos[0], grantInfos[1], newObjName))
 			newIdStr := crypto.MD5(newKey)
 			saves[newKey] = newIdStr
-			removeKeys = append(removeKeys, key)
+			// Reconstruct logical key (without etcd rootPath) for deletion.
+			// LoadWithPrefix returns full etcd keys (with rootPath prefix),
+			// but MultiSaveAndRemove prepends rootPath again, so we must
+			// use the logical key to avoid double-prefix.
+			oldKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant,
+				fmt.Sprintf("%s/%s/%s", grantInfos[0], grantInfos[1], grantInfos[2]))
+			removeKeys = append(removeKeys, oldKey)
 
 			// Migrate GranteeIDPrefix entries from oldIdStr to newIdStr
 			oldGranteeIDKey := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, oldIdStr+"/")
@@ -1520,11 +1536,21 @@ func (kc *Catalog) MigrateGrantCollectionName(ctx context.Context, tenant string
 				continue
 			}
 			for j, idKey := range idKeys {
-				privilegeName := idKey[len(oldGranteeIDKey):]
+				// Use AfterN to extract privilege name correctly regardless of
+				// etcd rootPath prefix in the returned key.
+				privilegeName := typeutil.After(idKey, oldGranteeIDKey)
+				if privilegeName == "" {
+					log.Ctx(ctx).Warn("failed to extract privilege name from grantee id key",
+						zap.String("idKey", idKey), zap.String("prefix", oldGranteeIDKey))
+					continue
+				}
 				newIDKey := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant,
 					fmt.Sprintf("%s/%s", newIdStr, privilegeName))
 				saves[newIDKey] = idValues[j]
-				removeKeys = append(removeKeys, idKey)
+				// Reconstruct logical key for deletion
+				oldIDKey := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant,
+					fmt.Sprintf("%s/%s", oldIdStr, privilegeName))
+				removeKeys = append(removeKeys, oldIDKey)
 			}
 		}
 	}

--- a/internal/metastore/kv/rootcoord/kv_catalog.go
+++ b/internal/metastore/kv/rootcoord/kv_catalog.go
@@ -1506,6 +1506,17 @@ func (kc *Catalog) MigrateGrantCollectionName(ctx context.Context, tenant string
 		if grantObj == oldName && (grantDB == oldDBName || grantDB == util.AnyWord) {
 			oldIdStr := values[i]
 
+			// Load GranteeIDPrefix entries FIRST, before queuing the parent key
+			// for migration. If this load fails, we skip both parent and child
+			// to avoid half-migration (parent migrated, children lost).
+			oldGranteeIDKey := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, oldIdStr+"/")
+			idKeys, idValues, loadErr := kc.Txn.LoadWithPrefix(ctx, oldGranteeIDKey)
+			if loadErr != nil {
+				log.Ctx(ctx).Warn("fail to load grantee id entries for migration, skipping this grant entirely",
+					zap.String("key", oldGranteeIDKey), zap.Error(loadErr))
+				continue
+			}
+
 			// Build new key with new collection name and recompute idStr
 			// to avoid sharing permission space with a future collection
 			// that reuses the old name.
@@ -1528,13 +1539,6 @@ func (kc *Catalog) MigrateGrantCollectionName(ctx context.Context, tenant string
 			removeKeys = append(removeKeys, oldKey)
 
 			// Migrate GranteeIDPrefix entries from oldIdStr to newIdStr
-			oldGranteeIDKey := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, oldIdStr+"/")
-			idKeys, idValues, loadErr := kc.Txn.LoadWithPrefix(ctx, oldGranteeIDKey)
-			if loadErr != nil {
-				log.Ctx(ctx).Warn("fail to load grantee id entries for migration",
-					zap.String("key", oldGranteeIDKey), zap.Error(loadErr))
-				continue
-			}
 			for j, idKey := range idKeys {
 				// Use AfterN to extract privilege name correctly regardless of
 				// etcd rootPath prefix in the returned key.

--- a/internal/metastore/kv/rootcoord/kv_catalog_test.go
+++ b/internal/metastore/kv/rootcoord/kv_catalog_test.go
@@ -3335,6 +3335,29 @@ func TestDeleteGrantByCollectionName(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("deletes wildcard dbName grants", func(t *testing.T) {
+		kvmock := mocks.NewTxnKV(t)
+		c := NewCatalog(kvmock, nil)
+		granteeKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, "")
+
+		// Grant with wildcard dbName "*" should also be matched
+		key1 := granteeKey + "/role1/Collection/*.col1"
+		key2 := granteeKey + "/role1/Collection/default.col1"
+
+		kvmock.EXPECT().LoadWithPrefix(mock.Anything, granteeKey).Return(
+			[]string{key1, key2}, []string{"gid1", "gid2"}, nil)
+
+		gid1Key := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, "gid1/")
+		gid2Key := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, "gid2/")
+		kvmock.EXPECT().MultiSaveAndRemoveWithPrefix(mock.Anything, (map[string]string)(nil),
+			[]string{gid1Key, gid2Key}).Return(nil)
+		kvmock.EXPECT().MultiSaveAndRemove(mock.Anything, (map[string]string)(nil),
+			[]string{key1, key2}).Return(nil)
+
+		err := c.DeleteGrantByCollectionName(ctx, tenant, "default", "col1")
+		assert.NoError(t, err)
+	})
+
 	t.Run("MultiSaveAndRemoveWithPrefix error", func(t *testing.T) {
 		kvmock := mocks.NewTxnKV(t)
 		c := NewCatalog(kvmock, nil)
@@ -3474,6 +3497,40 @@ func TestMigrateGrantCollectionName(t *testing.T) {
 			[]string{key1}).Return(nil)
 
 		err := c.MigrateGrantCollectionName(ctx, tenant, "db1", "col1", "db2", "col2")
+		assert.NoError(t, err)
+	})
+
+	t.Run("migrates wildcard dbName grants preserving wildcard", func(t *testing.T) {
+		kvmock := mocks.NewTxnKV(t)
+		c := NewCatalog(kvmock, nil)
+		granteeKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, "")
+
+		// Grant with wildcard dbName "*" should also be migrated
+		key1 := granteeKey + "/role1/Collection/*.old_col"
+		kvmock.EXPECT().LoadWithPrefix(mock.Anything, granteeKey).Return(
+			[]string{key1}, []string{"gid1"}, nil)
+
+		// The new key should preserve "*" as dbName, not use the real newDBName
+		newKey1 := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant,
+			fmt.Sprintf("role1/Collection/%s", funcutil.CombineObjectName("*", "new_col")))
+		newIdStr1 := crypto.MD5(newKey1)
+
+		oldGranteeIDKey1 := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, "gid1/")
+		oldIDEntry1 := oldGranteeIDKey1 + "Search"
+		kvmock.EXPECT().LoadWithPrefix(mock.Anything, oldGranteeIDKey1).Return(
+			[]string{oldIDEntry1}, []string{"root"}, nil)
+
+		newIDKey1 := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant,
+			fmt.Sprintf("%s/Search", newIdStr1))
+
+		kvmock.EXPECT().MultiSaveAndRemove(mock.Anything,
+			map[string]string{
+				newKey1:   newIdStr1,
+				newIDKey1: "root",
+			},
+			[]string{key1, oldIDEntry1}).Return(nil)
+
+		err := c.MigrateGrantCollectionName(ctx, tenant, "default", "old_col", "default", "new_col")
 		assert.NoError(t, err)
 	})
 

--- a/internal/metastore/kv/rootcoord/kv_catalog_test.go
+++ b/internal/metastore/kv/rootcoord/kv_catalog_test.go
@@ -3335,24 +3335,50 @@ func TestDeleteGrantByCollectionName(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("deletes wildcard dbName grants", func(t *testing.T) {
+	t.Run("skips wildcard dbName grants on drop", func(t *testing.T) {
 		kvmock := mocks.NewTxnKV(t)
 		c := NewCatalog(kvmock, nil)
 		granteeKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, "")
 
-		// Grant with wildcard dbName "*" should also be matched
+		// Wildcard grant *.col1 should NOT be deleted when dropping db1.col1,
+		// because it may also protect col1 in other databases.
 		key1 := granteeKey + "/role1/Collection/*.col1"
 		key2 := granteeKey + "/role1/Collection/default.col1"
 
 		kvmock.EXPECT().LoadWithPrefix(mock.Anything, granteeKey).Return(
 			[]string{key1, key2}, []string{"gid1", "gid2"}, nil)
 
-		gid1Key := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, "gid1/")
+		// Only key2 (default.col1) should be deleted, not key1 (*.col1)
 		gid2Key := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, "gid2/")
 		kvmock.EXPECT().MultiSaveAndRemoveWithPrefix(mock.Anything, (map[string]string)(nil),
-			[]string{gid1Key, gid2Key}).Return(nil)
+			[]string{gid2Key}).Return(nil)
 		kvmock.EXPECT().MultiSaveAndRemove(mock.Anything, (map[string]string)(nil),
-			[]string{key1, key2}).Return(nil)
+			[]string{key2}).Return(nil)
+
+		err := c.DeleteGrantByCollectionName(ctx, tenant, "default", "col1")
+		assert.NoError(t, err)
+	})
+
+	t.Run("handles rootPath prefix in etcd keys", func(t *testing.T) {
+		kvmock := mocks.NewTxnKV(t)
+		c := NewCatalog(kvmock, nil)
+		granteeKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, "")
+
+		// Simulate etcd returning keys WITH rootPath prefix (as real etcd does)
+		rootPath := "by-dev/meta/"
+		key1 := rootPath + granteeKey + "/role1/Collection/default.col1"
+
+		kvmock.EXPECT().LoadWithPrefix(mock.Anything, granteeKey).Return(
+			[]string{key1}, []string{"gid1"}, nil)
+
+		// The logical key (without rootPath) should be used for deletion
+		logicalKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant,
+			"role1/Collection/default.col1")
+		gid1Key := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, "gid1/")
+		kvmock.EXPECT().MultiSaveAndRemoveWithPrefix(mock.Anything, (map[string]string)(nil),
+			[]string{gid1Key}).Return(nil)
+		kvmock.EXPECT().MultiSaveAndRemove(mock.Anything, (map[string]string)(nil),
+			[]string{logicalKey}).Return(nil)
 
 		err := c.DeleteGrantByCollectionName(ctx, tenant, "default", "col1")
 		assert.NoError(t, err)
@@ -3500,35 +3526,30 @@ func TestMigrateGrantCollectionName(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("migrates wildcard dbName grants preserving wildcard", func(t *testing.T) {
+	t.Run("skips wildcard dbName grants on rename", func(t *testing.T) {
 		kvmock := mocks.NewTxnKV(t)
 		c := NewCatalog(kvmock, nil)
 		granteeKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, "")
 
-		// Grant with wildcard dbName "*" should also be migrated
+		// Wildcard grant *.old_col should NOT be migrated when renaming db1.old_col,
+		// because it may also apply to old_col in other databases.
 		key1 := granteeKey + "/role1/Collection/*.old_col"
+		key2 := granteeKey + "/role1/Collection/default.old_col"
 		kvmock.EXPECT().LoadWithPrefix(mock.Anything, granteeKey).Return(
-			[]string{key1}, []string{"gid1"}, nil)
+			[]string{key1, key2}, []string{"gid1", "gid2"}, nil)
 
-		// The new key should preserve "*" as dbName, not use the real newDBName
-		newKey1 := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant,
-			fmt.Sprintf("role1/Collection/%s", funcutil.CombineObjectName("*", "new_col")))
-		newIdStr1 := crypto.MD5(newKey1)
+		// Only key2 (default.old_col) should be migrated
+		oldGranteeIDKey2 := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, "gid2/")
+		kvmock.EXPECT().LoadWithPrefix(mock.Anything, oldGranteeIDKey2).Return(
+			nil, nil, nil)
 
-		oldGranteeIDKey1 := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, "gid1/")
-		oldIDEntry1 := oldGranteeIDKey1 + "Search"
-		kvmock.EXPECT().LoadWithPrefix(mock.Anything, oldGranteeIDKey1).Return(
-			[]string{oldIDEntry1}, []string{"root"}, nil)
-
-		newIDKey1 := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant,
-			fmt.Sprintf("%s/Search", newIdStr1))
+		newKey2 := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant,
+			fmt.Sprintf("role1/Collection/%s", funcutil.CombineObjectName("default", "new_col")))
+		newIdStr2 := crypto.MD5(newKey2)
 
 		kvmock.EXPECT().MultiSaveAndRemove(mock.Anything,
-			map[string]string{
-				newKey1:   newIdStr1,
-				newIDKey1: "root",
-			},
-			[]string{key1, oldIDEntry1}).Return(nil)
+			map[string]string{newKey2: newIdStr2},
+			[]string{key2}).Return(nil)
 
 		err := c.MigrateGrantCollectionName(ctx, tenant, "default", "old_col", "default", "new_col")
 		assert.NoError(t, err)

--- a/internal/proxy/meta_cache.go
+++ b/internal/proxy/meta_cache.go
@@ -1002,9 +1002,6 @@ func (m *MetaCache) removeCollectionByID(ctx context.Context, collectionID Uniqu
 				if version == 0 || curVersion <= version {
 					delete(m.collInfo[database], k)
 					collNames = append(collNames, k)
-<<<<<<< HEAD
-					m.removeAliasesForCollectionLocked(database, k)
-=======
 					m.sfGlobal.Forget(buildSfKeyByName(database, k))
 					m.sfGlobal.Forget(buildSfKeyById(database, v.collID))
 					realName := k
@@ -1012,7 +1009,6 @@ func (m *MetaCache) removeCollectionByID(ctx context.Context, collectionID Uniqu
 						realName = v.schema.CollectionSchema.GetName()
 					}
 					m.removeAliasesForCollectionLocked(database, realName)
->>>>>>> c19d6728c6 (fix: fix RBAC grant cleanup on drop and migration on rename)
 				}
 			}
 		}

--- a/internal/proxy/meta_cache.go
+++ b/internal/proxy/meta_cache.go
@@ -465,8 +465,11 @@ func (m *MetaCache) update(ctx context.Context, database, collectionName string,
 		}
 	})
 
-	if collectionName == "" {
-		collectionName = collection.Schema.GetName()
+	realName := collection.Schema.GetName()
+	originalName := collectionName
+	isAlias := realName != "" && realName != collectionName
+	if collectionName == "" || isAlias {
+		collectionName = realName
 	}
 	if database == "" {
 		log.Ctx(ctx).Warn("database is empty, use default database name", zap.String("collectionName", collectionName), zap.Stack("stack"))
@@ -509,7 +512,17 @@ func (m *MetaCache) update(ctx context.Context, database, collectionName string,
 		m.collInfo[database] = make(map[string]*collectionInfo)
 	}
 
+
 	replicateID, _ := common.GetReplicateID(collection.Properties)
+
+	if isAlias {
+		// Caller passed an alias; record the alias→realName mapping so
+		// subsequent ResolveCollectionAlias calls hit Level 2 cache.
+		m.setAliasLocked(database, originalName, &aliasEntry{collectionName: realName, cachedAt: time.Now()})
+		// Remove any stale collInfo entry that was previously cached under the alias key.
+		delete(m.collInfo[database], originalName)
+	}
+
 	m.collInfo[database][collectionName] = &collectionInfo{
 		collID:                collection.CollectionID,
 		schema:                schemaInfo,
@@ -710,8 +723,13 @@ func (m *MetaCache) RemoveAlias(ctx context.Context, database, alias string) {
 }
 
 func (m *MetaCache) ResolveCollectionAlias(ctx context.Context, database, nameOrAlias string) (string, error) {
-	// Level 1: Found in collection cache, return as-is
-	if _, ok := m.getCollection(database, nameOrAlias, 0); ok {
+	// Level 1: Found in collection cache — but the key might be an alias because
+	// DescribeCollection accepts aliases and update() caches under the caller's name.
+	// Compare with the schema's real collection name to detect this.
+	if collInfo, ok := m.getCollection(database, nameOrAlias, 0); ok {
+		if realName := collInfo.schema.CollectionSchema.GetName(); realName != "" && realName != nameOrAlias {
+			return realName, nil
+		}
 		return nameOrAlias, nil
 	}
 
@@ -984,7 +1002,17 @@ func (m *MetaCache) removeCollectionByID(ctx context.Context, collectionID Uniqu
 				if version == 0 || curVersion <= version {
 					delete(m.collInfo[database], k)
 					collNames = append(collNames, k)
+<<<<<<< HEAD
 					m.removeAliasesForCollectionLocked(database, k)
+=======
+					m.sfGlobal.Forget(buildSfKeyByName(database, k))
+					m.sfGlobal.Forget(buildSfKeyById(database, v.collID))
+					realName := k
+					if v.schema != nil && v.schema.CollectionSchema.GetName() != "" {
+						realName = v.schema.CollectionSchema.GetName()
+					}
+					m.removeAliasesForCollectionLocked(database, realName)
+>>>>>>> c19d6728c6 (fix: fix RBAC grant cleanup on drop and migration on rename)
 				}
 			}
 		}

--- a/internal/proxy/meta_cache.go
+++ b/internal/proxy/meta_cache.go
@@ -467,7 +467,7 @@ func (m *MetaCache) update(ctx context.Context, database, collectionName string,
 
 	realName := collection.Schema.GetName()
 	originalName := collectionName
-	isAlias := realName != "" && realName != collectionName
+	isAlias := collectionName != "" && realName != "" && realName != collectionName
 	if collectionName == "" || isAlias {
 		collectionName = realName
 	}

--- a/internal/proxy/meta_cache.go
+++ b/internal/proxy/meta_cache.go
@@ -512,7 +512,6 @@ func (m *MetaCache) update(ctx context.Context, database, collectionName string,
 		m.collInfo[database] = make(map[string]*collectionInfo)
 	}
 
-
 	replicateID, _ := common.GetReplicateID(collection.Properties)
 
 	if isAlias {

--- a/internal/proxy/meta_cache.go
+++ b/internal/proxy/meta_cache.go
@@ -726,8 +726,10 @@ func (m *MetaCache) ResolveCollectionAlias(ctx context.Context, database, nameOr
 	// DescribeCollection accepts aliases and update() caches under the caller's name.
 	// Compare with the schema's real collection name to detect this.
 	if collInfo, ok := m.getCollection(database, nameOrAlias, 0); ok {
-		if realName := collInfo.schema.CollectionSchema.GetName(); realName != "" && realName != nameOrAlias {
-			return realName, nil
+		if collInfo.schema != nil {
+			if realName := collInfo.schema.GetName(); realName != "" && realName != nameOrAlias {
+				return realName, nil
+			}
 		}
 		return nameOrAlias, nil
 	}
@@ -1004,8 +1006,8 @@ func (m *MetaCache) removeCollectionByID(ctx context.Context, collectionID Uniqu
 					m.sfGlobal.Forget(buildSfKeyByName(database, k))
 					m.sfGlobal.Forget(buildSfKeyById(database, v.collID))
 					realName := k
-					if v.schema != nil && v.schema.CollectionSchema.GetName() != "" {
-						realName = v.schema.CollectionSchema.GetName()
+					if v.schema != nil && v.schema.GetName() != "" {
+						realName = v.schema.GetName()
 					}
 					m.removeAliasesForCollectionLocked(database, realName)
 				}

--- a/internal/rootcoord/constrant_test.go
+++ b/internal/rootcoord/constrant_test.go
@@ -41,6 +41,7 @@ func TestCheckGeneralCapacity(t *testing.T) {
 	catalog.EXPECT().ListAliases(mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
 	catalog.EXPECT().CreateDatabase(mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	catalog.EXPECT().AlterCollection(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	catalog.EXPECT().DeleteGrantByCollectionName(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	allocator := mocktso.NewAllocator(t)
 	allocator.EXPECT().GenerateTSO(mock.Anything).Return(1000, nil)

--- a/internal/rootcoord/ddl_callbacks_drop_collection.go
+++ b/internal/rootcoord/ddl_callbacks_drop_collection.go
@@ -27,7 +27,6 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster/registry"
-	"github.com/milvus-io/milvus/internal/util/proxyutil"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
@@ -130,7 +129,15 @@ func (c *DDLCallback) dropCollectionV1AckCallback(ctx context.Context, result me
 		}
 	}
 	// add the collection tombstone to the sweeper.
-	c.tombstoneSweeper.AddTombstone(newCollectionTombstone(c.meta, c.broker, header.CollectionId, c.proxyClientManager))
+	c.tombstoneSweeper.AddTombstone(newCollectionTombstone(c.meta, c.broker, header.CollectionId))
+	// DropCollection already deleted grants for the dropped collection.
+	// Refresh the RBAC policy cache on all proxies so they stop using stale grant entries.
+	if err := c.proxyClientManager.RefreshPolicyInfoCache(ctx, &proxypb.RefreshPolicyInfoCacheRequest{
+		OpType: int32(typeutil.CacheRefresh),
+	}); err != nil {
+		log.Ctx(ctx).Warn("failed to refresh RBAC policy cache after collection drop, skipping",
+			zap.Int64("collectionID", header.CollectionId), zap.Error(err))
+	}
 	// expire the collection meta cache on proxy.
 	return c.ExpireCaches(ctx, ce.NewBuilder().WithLegacyProxyCollectionMetaCache(
 		ce.OptLPCMDBName(body.DbName),
@@ -140,20 +147,18 @@ func (c *DDLCallback) dropCollectionV1AckCallback(ctx context.Context, result me
 }
 
 // newCollectionTombstone creates a new collection tombstone.
-func newCollectionTombstone(meta IMetaTable, broker Broker, collectionID int64, proxyClientManager proxyutil.ProxyClientManagerInterface) *collectionTombstone {
+func newCollectionTombstone(meta IMetaTable, broker Broker, collectionID int64) *collectionTombstone {
 	return &collectionTombstone{
-		meta:               meta,
-		broker:             broker,
-		collectionID:       collectionID,
-		proxyClientManager: proxyClientManager,
+		meta:         meta,
+		broker:       broker,
+		collectionID: collectionID,
 	}
 }
 
 type collectionTombstone struct {
-	meta               IMetaTable
-	broker             Broker
-	collectionID       int64
-	proxyClientManager proxyutil.ProxyClientManagerInterface
+	meta         IMetaTable
+	broker       Broker
+	collectionID int64
 }
 
 func (t *collectionTombstone) ID() string {
@@ -165,16 +170,5 @@ func (t *collectionTombstone) ConfirmCanBeRemoved(ctx context.Context) (bool, er
 }
 
 func (t *collectionTombstone) Remove(ctx context.Context) error {
-	if err := t.meta.RemoveCollection(ctx, t.collectionID, 0); err != nil {
-		return err
-	}
-	// RemoveCollection deletes grants associated with the dropped collection.
-	// Refresh the RBAC policy cache on all proxies so they stop using stale grant entries.
-	if err := t.proxyClientManager.RefreshPolicyInfoCache(ctx, &proxypb.RefreshPolicyInfoCacheRequest{
-		OpType: int32(typeutil.CacheRefresh),
-	}); err != nil {
-		log.Ctx(ctx).Warn("failed to refresh RBAC policy cache after collection removal, skipping",
-			zap.Int64("collectionID", t.collectionID), zap.Error(err))
-	}
-	return nil
+	return t.meta.RemoveCollection(ctx, t.collectionID, 0)
 }

--- a/internal/rootcoord/meta_table.go
+++ b/internal/rootcoord/meta_table.go
@@ -584,6 +584,14 @@ func (mt *MetaTable) DropCollection(ctx context.Context, collectionID UniqueID, 
 
 	log.Ctx(ctx).Info("drop collection from meta table", zap.Int64("collection", collectionID),
 		zap.String("state", coll.State.String()), zap.Uint64("ts", ts))
+
+	// Delete all grants referencing this collection immediately so they don't
+	// linger until the tombstone sweeper runs (which can take minutes).
+	if err := mt.catalog.DeleteGrantByCollectionName(ctx1, util.DefaultTenant, db.Name, coll.Name); err != nil {
+		log.Ctx(ctx).Warn("failed to delete grants for dropped collection, skipping",
+			zap.String("dbName", db.Name), zap.String("collectionName", coll.Name), zap.Error(err))
+	}
+
 	return nil
 }
 
@@ -660,12 +668,6 @@ func (mt *MetaTable) RemoveCollection(ctx context.Context, collectionID UniqueID
 	}
 	if err := mt.catalog.DropCollection(ctx1, newColl, ts); err != nil {
 		return err
-	}
-
-	tenant := Params.CommonCfg.ClusterName.GetValue()
-	if err := mt.catalog.DeleteGrantByCollectionName(ctx1, tenant, coll.DBName, coll.Name); err != nil {
-		log.Ctx(ctx).Warn("failed to delete grants for dropped collection, skipping",
-			zap.String("dbName", coll.DBName), zap.String("collectionName", coll.Name), zap.Error(err))
 	}
 
 	allNames := common.CloneStringList(aliases)
@@ -1004,8 +1006,7 @@ func (mt *MetaTable) AlterCollection(ctx context.Context, result message.Broadca
 	}
 
 	if oldColl.Name != newColl.Name || oldColl.DBName != newColl.DBName {
-		tenant := Params.CommonCfg.ClusterName.GetValue()
-		if err := mt.catalog.MigrateGrantCollectionName(ctx1, tenant, oldColl.DBName, oldColl.Name, newColl.DBName, newColl.Name); err != nil {
+		if err := mt.catalog.MigrateGrantCollectionName(ctx1, util.DefaultTenant, oldColl.DBName, oldColl.Name, newColl.DBName, newColl.Name); err != nil {
 			log.Ctx(ctx).Warn("failed to migrate grants for renamed collection, skipping",
 				zap.String("oldDBName", oldColl.DBName), zap.String("oldName", oldColl.Name),
 				zap.String("newDBName", newColl.DBName), zap.String("newName", newColl.Name), zap.Error(err))

--- a/internal/rootcoord/meta_table.go
+++ b/internal/rootcoord/meta_table.go
@@ -670,6 +670,11 @@ func (mt *MetaTable) RemoveCollection(ctx context.Context, collectionID UniqueID
 		return err
 	}
 
+	if err := mt.catalog.DeleteGrantByCollectionName(ctx1, util.DefaultTenant, coll.DBName, coll.Name); err != nil {
+		log.Ctx(ctx).Warn("failed to delete grants for dropped collection, skipping",
+			zap.String("dbName", coll.DBName), zap.String("collectionName", coll.Name), zap.Error(err))
+	}
+
 	allNames := common.CloneStringList(aliases)
 	allNames = append(allNames, coll.Name)
 

--- a/internal/rootcoord/meta_table_test.go
+++ b/internal/rootcoord/meta_table_test.go
@@ -1194,9 +1194,6 @@ func TestMetaTable_RemoveCollection(t *testing.T) {
 			mock.Anything, // model.Collection
 			mock.AnythingOfType("uint64"),
 		).Return(nil)
-		catalog.On("DeleteGrantByCollectionName",
-			mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-		).Return(nil)
 		meta := &MetaTable{
 			catalog: catalog,
 			names:   newNameDb(),
@@ -1216,32 +1213,66 @@ func TestMetaTable_RemoveCollection(t *testing.T) {
 	})
 }
 
-func TestMetaTable_RemoveCollection_GrantDeleteBestEffort(t *testing.T) {
-	// When DeleteGrantByCollectionName fails, RemoveCollection should still succeed (best-effort)
-	catalog := mocks.NewRootCoordCatalog(t)
-	catalog.On("DropCollection",
-		mock.Anything,
-		mock.Anything,
-		mock.AnythingOfType("uint64"),
-	).Return(nil)
-	catalog.On("DeleteGrantByCollectionName",
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-	).Return(errors.New("grant delete failed"))
+func TestMetaTable_DropCollection_GrantCleanup(t *testing.T) {
+	t.Run("grant cleanup on drop", func(t *testing.T) {
+		catalog := mocks.NewRootCoordCatalog(t)
+		catalog.On("AlterCollection",
+			mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+		).Return(nil)
+		catalog.On("DeleteGrantByCollectionName",
+			mock.Anything, mock.Anything, "testdb", "collection",
+		).Return(nil)
 
-	meta := &MetaTable{
-		catalog: catalog,
-		names:   newNameDb(),
-		aliases: newNameDb(),
-		collID2Meta: map[typeutil.UniqueID]*model.Collection{
-			100: {Name: "collection", State: pb.CollectionState_CollectionDropping},
-		},
-	}
-	channel.ResetStaticPChannelStatsManager()
-	channel.RecoverPChannelStatsManager([]string{})
-	meta.names.insert("", "collection", 100)
-	ctx := context.Background()
-	err := meta.RemoveCollection(ctx, 100, 9999)
-	assert.NoError(t, err)
+		meta := &MetaTable{
+			catalog: catalog,
+			names:   newNameDb(),
+			aliases: newNameDb(),
+			collID2Meta: map[typeutil.UniqueID]*model.Collection{
+				100: {Name: "collection", DBID: 1, State: pb.CollectionState_CollectionCreated},
+			},
+			dbName2Meta: map[string]*model.Database{
+				"testdb": {ID: 1, Name: "testdb"},
+			},
+			fileResourceRefCnt: make(map[int64]int),
+		}
+		channel.ResetStaticPChannelStatsManager()
+		channel.RecoverPChannelStatsManager([]string{})
+		meta.names.insert("testdb", "collection", 100)
+		ctx := context.Background()
+		err := meta.DropCollection(ctx, 100, 9999)
+		assert.NoError(t, err)
+		catalog.AssertCalled(t, "DeleteGrantByCollectionName", mock.Anything, mock.Anything, "testdb", "collection")
+	})
+
+	t.Run("grant cleanup best-effort on drop", func(t *testing.T) {
+		// When DeleteGrantByCollectionName fails, DropCollection should still succeed
+		catalog := mocks.NewRootCoordCatalog(t)
+		catalog.On("AlterCollection",
+			mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+		).Return(nil)
+		catalog.On("DeleteGrantByCollectionName",
+			mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+		).Return(errors.New("grant delete failed"))
+
+		meta := &MetaTable{
+			catalog: catalog,
+			names:   newNameDb(),
+			aliases: newNameDb(),
+			collID2Meta: map[typeutil.UniqueID]*model.Collection{
+				100: {Name: "collection", DBID: 1, State: pb.CollectionState_CollectionCreated},
+			},
+			dbName2Meta: map[string]*model.Database{
+				"default": {ID: 1, Name: "default"},
+			},
+			fileResourceRefCnt: make(map[int64]int),
+		}
+		channel.ResetStaticPChannelStatsManager()
+		channel.RecoverPChannelStatsManager([]string{})
+		meta.names.insert("default", "collection", 100)
+		ctx := context.Background()
+		err := meta.DropCollection(ctx, 100, 9999)
+		assert.NoError(t, err)
+	})
 }
 
 func TestMetaTable_RemovePartition(t *testing.T) {

--- a/internal/rootcoord/meta_table_test.go
+++ b/internal/rootcoord/meta_table_test.go
@@ -1194,6 +1194,9 @@ func TestMetaTable_RemoveCollection(t *testing.T) {
 			mock.Anything, // model.Collection
 			mock.AnythingOfType("uint64"),
 		).Return(nil)
+		catalog.On("DeleteGrantByCollectionName",
+			mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+		).Return(nil)
 		meta := &MetaTable{
 			catalog: catalog,
 			names:   newNameDb(),
@@ -1233,7 +1236,6 @@ func TestMetaTable_DropCollection_GrantCleanup(t *testing.T) {
 			dbName2Meta: map[string]*model.Database{
 				"testdb": {ID: 1, Name: "testdb"},
 			},
-			fileResourceRefCnt: make(map[int64]int),
 		}
 		channel.ResetStaticPChannelStatsManager()
 		channel.RecoverPChannelStatsManager([]string{})
@@ -1264,7 +1266,6 @@ func TestMetaTable_DropCollection_GrantCleanup(t *testing.T) {
 			dbName2Meta: map[string]*model.Database{
 				"default": {ID: 1, Name: "default"},
 			},
-			fileResourceRefCnt: make(map[int64]int),
 		}
 		channel.ResetStaticPChannelStatsManager()
 		channel.RecoverPChannelStatsManager([]string{})

--- a/internal/rootcoord/meta_table_test.go
+++ b/internal/rootcoord/meta_table_test.go
@@ -1216,6 +1216,34 @@ func TestMetaTable_RemoveCollection(t *testing.T) {
 	})
 }
 
+func TestMetaTable_RemoveCollection_GrantDeleteBestEffort(t *testing.T) {
+	// When DeleteGrantByCollectionName fails, RemoveCollection should still succeed (best-effort)
+	catalog := mocks.NewRootCoordCatalog(t)
+	catalog.On("DropCollection",
+		mock.Anything,
+		mock.Anything,
+		mock.AnythingOfType("uint64"),
+	).Return(nil)
+	catalog.On("DeleteGrantByCollectionName",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+	).Return(errors.New("grant delete failed"))
+
+	meta := &MetaTable{
+		catalog: catalog,
+		names:   newNameDb(),
+		aliases: newNameDb(),
+		collID2Meta: map[typeutil.UniqueID]*model.Collection{
+			100: {Name: "collection", State: pb.CollectionState_CollectionDropping},
+		},
+	}
+	channel.ResetStaticPChannelStatsManager()
+	channel.RecoverPChannelStatsManager([]string{})
+	meta.names.insert("", "collection", 100)
+	ctx := context.Background()
+	err := meta.RemoveCollection(ctx, 100, 9999)
+	assert.NoError(t, err)
+}
+
 func TestMetaTable_DropCollection_GrantCleanup(t *testing.T) {
 	t.Run("grant cleanup on drop", func(t *testing.T) {
 		catalog := mocks.NewRootCoordCatalog(t)

--- a/internal/rootcoord/root_coord.go
+++ b/internal/rootcoord/root_coord.go
@@ -631,7 +631,7 @@ func (c *Core) restore(ctx context.Context) error {
 			// CollectionCreating is a deprecated status,
 			// we cannot promise the coordinator handle it correctly, so just treat it as a tombstone.
 			if coll.State == pb.CollectionState_CollectionDropping || coll.State == pb.CollectionState_CollectionCreating {
-				c.tombstoneSweeper.AddTombstone(newCollectionTombstone(c.meta, c.broker, coll.CollectionID, c.proxyClientManager))
+				c.tombstoneSweeper.AddTombstone(newCollectionTombstone(c.meta, c.broker, coll.CollectionID))
 				continue
 			}
 			for _, part := range coll.Partitions {


### PR DESCRIPTION
pr: https://github.com/milvus-io/milvus/pull/48140

related: https://github.com/milvus-io/milvus/issues/48061
related: https://github.com/milvus-io/milvus/issues/48062
related: https://github.com/milvus-io/milvus/pull/48137

Reconstruct logical etcd keys to avoid double rootPath prefix in
delete/migrate operations
Use typeutil.After for privilege name extraction instead of broken
length-based substring
Match wildcard dbName and use DefaultTenant consistently
Move grant cleanup to DropCollection ack callback
Enable resolveAliasForPrivilege by default and fix alias cache
passed rbac alias e2e tests