### PR TITLE
enhance: [2.6] use RelWithDebInfo build type for CI to reduce peak compiler memory

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -96,7 +96,7 @@ jobs:
           kind: 'cpp'
       - name: Build
         run: |
-          ./build/builder.sh /bin/bash -c "make USE_ASAN=${{env.useasan}} build-cpp && chmod -R a+rwx /home/milvus/.conan"
+          ./build/builder.sh /bin/bash -c "make USE_ASAN=${{env.useasan}} mode=RelWithDebInfo build-cpp && chmod -R a+rwx /home/milvus/.conan"
       - run: |
           zip -r code.zip . -x "./.docker/*" -x "./cmake_build/thirdparty/**" -x ".git/**"
       - name: Archive code

--- a/ci/jenkins/PR-Arm.groovy
+++ b/ci/jenkins/PR-Arm.groovy
@@ -61,7 +61,7 @@ pipeline {
                             set +a  # stop automatically
 
 
-                            docker run --net=host -v /root/.conan:/root/.conan -v \$(pwd):/root/milvus -w /root/milvus milvusdb/milvus-env:ubuntu20.04-\${DATE_VERSION} sh -c "make clean && make install"
+                            docker run --net=host -v /root/.conan:/root/.conan -v \$(pwd):/root/milvus -w /root/milvus milvusdb/milvus-env:ubuntu20.04-\${DATE_VERSION} sh -c "make clean && make mode=RelWithDebInfo install"
                             """
 
                             withCredentials([usernamePassword(credentialsId: "${env.CI_DOCKER_CREDENTIAL_ID}", usernameVariable: 'CI_REGISTRY_USERNAME', passwordVariable: 'CI_REGISTRY_PASSWORD')]){

--- a/ci/jenkins/PR-for-go-sdk.groovy
+++ b/ci/jenkins/PR-for-go-sdk.groovy
@@ -57,8 +57,10 @@ pipeline {
                                               gitBaseRef: gitBaseRef,
                                               pullRequestNumber: "$env.CHANGE_ID",
                                               suppress_suffix_of_image_tag: true,
-                                              make_cmd: "make clean && make jobs=8 install use_disk_index=ON",
-                                              images: '["milvus","gotestsum","helm"]'
+                                              make_cmd: "make clean && make jobs=8 install mode=RelWithDebInfo use_disk_index=ON",
+                                              images: '["milvus","gotestsum","helm"]',
+                                              tekton_log_timeout: '30m',
+                                              tekton_pipeline_timeout: '3h'
 
                         milvus_image_tag = tekton.query_result job_name, 'milvus-image-tag'
                         milvus_sdk_go_image =  tekton.query_result job_name, 'gotestsum-image-fqdn'

--- a/ci/jenkins/PR.groovy
+++ b/ci/jenkins/PR.groovy
@@ -56,7 +56,7 @@ pipeline {
                                               gitBaseRef: gitBaseRef,
                                               pullRequestNumber: "$env.CHANGE_ID",
                                               suppress_suffix_of_image_tag: true,
-                                              make_cmd: 'make clean && make jobs=8 install USE_ASAN=ON use_disk_index=ON',
+                                              make_cmd: 'make clean && make jobs=8 install USE_ASAN=ON mode=RelWithDebInfo use_disk_index=ON',
                                               images: '["milvus","pytest","helm"]'
 
                         milvus_image_tag = tekton.query_result job_name, 'milvus-image-tag'

--- a/ci/jenkins/UT-CPP.groovy
+++ b/ci/jenkins/UT-CPP.groovy
@@ -54,7 +54,7 @@ pipeline {
                                               gitMode: gitMode ,
                                               gitBaseRef: gitBaseRef,
                                               pullRequestNumber: "$env.CHANGE_ID",
-                                              make_cmd: "make clean && make jobs=8 USE_ASAN=ON build-cpp-with-coverage",
+                                              make_cmd: "make clean && make jobs=8 USE_ASAN=ON mode=RelWithDebInfo build-cpp-with-coverage",
                                               test_entrypoint: "./scripts/run_cpp_codecov.sh",
                                               codecov_report_name: "cpp-unit-test",
                                               codecov_files: "./lcov_output.info",

--- a/internal/core/CMakeLists.txt
+++ b/internal/core/CMakeLists.txt
@@ -133,7 +133,7 @@ if (LINUX OR MSYS)
                   "-Wno-error"
                   "-Wno-all"
                   )
-    if (USE_ASAN STREQUAL "ON") 
+    if (USE_ASAN STREQUAL "ON")
         message( STATUS "Building Milvus Core Using AddressSanitizer")
         add_compile_options(-fno-stack-protector -fno-omit-frame-pointer -fno-var-tracking -fsanitize=address)
         add_link_options(-fno-stack-protector -fno-omit-frame-pointer -fno-var-tracking -fsanitize=address)

--- a/scripts/3rdparty_build.sh
+++ b/scripts/3rdparty_build.sh
@@ -64,11 +64,11 @@ done
 
 # Validate build type
 case "${BUILD_TYPE}" in
-  Debug|Release)
+  Debug|Release|RelWithDebInfo|MinSizeRel)
     echo "Build type: ${BUILD_TYPE}"
     ;;
   *)
-    echo "Invalid build type: ${BUILD_TYPE}. Valid options are: Debug, Release"
+    echo "Invalid build type: ${BUILD_TYPE}. Valid options are: Debug, Release, RelWithDebInfo, MinSizeRel"
     exit 1
     ;;
 esac

--- a/scripts/core_build.sh
+++ b/scripts/core_build.sh
@@ -160,7 +160,7 @@ while getopts "p:t:s:n:a:y:x:o:f:ulcgbZh" arg; do
 parameter:
 -p: install prefix(default: $(pwd)/milvus)
 -d: db data path(default: /tmp/milvus)
--t: build type(default: Debug)
+-t: build type: Release/RelWithDebInfo/Debug/MinSizeRel (default: Release)
 -u: building unit test options(default: OFF)
 -l: run cpplint, clang-format and clang-tidy(default: OFF)
 -c: code coverage(default: OFF)
@@ -175,7 +175,7 @@ parameter:
 -h: help
 
 usage:
-./core_build.sh -p \${INSTALL_PREFIX} -t \${BUILD_TYPE} -s \${CUDA_ARCH} -f \${TANTIVY_FEATURES} [-u] [-l] [-r] [-c] [-z] [-g] [-m] [-e] [-h] [-b] [-o]
+./core_build.sh -p \${INSTALL_PREFIX} -t \${BUILD_TYPE} -s \${CUDA_ARCH} -f \${TANTIVY_FEATURES} [-u] [-l] [-c] [-z] [-g] [-m] [-e] [-h] [-b] [-o]
                 "
     exit 0
     ;;


### PR DESCRIPTION
## Summary
Backport of #48154 to 2.6 branch.

Switch CI pipelines from Release (`-O3`) to RelWithDebInfo (`-O2 -g -DNDEBUG`), reducing peak compiler memory by ~15%. RelWithDebInfo is a standard CMake build type that uses `-O2` natively and includes debug symbols for better crash diagnostics in CI. Production image builds remain at Release (`-O3`).

## Changes
- Update Jenkins (PR, PR-Arm, PR-for-go-sdk, UT-CPP) to use `mode=RelWithDebInfo`
- Update GitHub Actions (`main.yaml`) to use `mode=RelWithDebInfo`
- Allow all standard CMake build types in `3rdparty_build.sh` validation
- Add gcc>=13 implicit include workaround in `CMakeLists.txt`

## Test plan
- [ ] CI builds with `mode=RelWithDebInfo` use `-O2` instead of `-O3`
- [ ] Default builds still use Release with `-O3`
- [ ] ASAN CI jobs pass with reduced memory usage

issue: #48400