### PR TITLE
test: [CP2.6] Fix flaky compact_with_added_field test

### DIFF
--- a/tests/python_client/milvus_client/test_add_field_feature.py
+++ b/tests/python_client/milvus_client/test_add_field_feature.py
@@ -100,7 +100,7 @@ class TestMilvusClientAddFieldFeature(TestMilvusClientV2Base):
         vectors_to_search = [vectors[0]]
         # 4. insert new field after add field
         rows_new = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
-                     default_string_field_name: str(i), default_new_field_name: random.randint(1, 1000)}
+                     default_string_field_name: str(i), default_new_field_name: random.randint(default_value + 1, 1000)}
                      for i in range(10*default_nb, 11*default_nb)]
         self.insert(client, collection_name, rows_new)
         # 5. compact


### PR DESCRIPTION
## Summary
- Cherry-pick one-line fix from master PR #47907 to 2.6 branch
- Change `random.randint(1, 1000)` to `random.randint(default_value + 1, 1000)` in `test_milvus_client_compact_with_added_field`
- Prevents second batch from generating `field_new == default_value (1)`, which causes the id-partition assertion to fail intermittently in nightly CI

pr: #47907

## Test plan
- [x] Verified on Milvus 2.6 (`10.104.13.163`): 5/5 passes
- [x] Original checkpoint preserved: batch1 ids for `field_new == 1`, batch2 ids for `field_new != 1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)