### PR TITLE
fix: [2.6] reduce CPU spike during load by streaming row groups per-cell

### DIFF
--- a/internal/core/src/segcore/memory_planner.cpp
+++ b/internal/core/src/segcore/memory_planner.cpp
@@ -251,7 +251,7 @@ LoadWithStrategy(const std::vector<std::string>& remote_files,
 std::vector<std::future<void>>
 LoadCellBatchAsync(milvus::OpContext* op_ctx,
                    std::vector<CellSpec> cell_specs,
-                   BatchReaderFactory reader_factory,
+                   StreamingReaderFactory reader_factory,
                    std::shared_ptr<CellReaderChannel>& channel,
                    int64_t memory_limit,
                    milvus::proto::common::LoadPriority priority) {
@@ -323,7 +323,7 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
         std::max<int64_t>(memory_limit / static_cast<int64_t>(batches.size()),
                           FILE_SLICE_SIZE.load());
     auto shared_factory =
-        std::make_shared<BatchReaderFactory>(std::move(reader_factory));
+        std::make_shared<StreamingReaderFactory>(std::move(reader_factory));
 
     std::vector<std::future<void>> futures;
     futures.reserve(batches.size());
@@ -342,30 +342,30 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
             });
             CheckCancellation(op_ctx, -1, "LoadCellBatchAsync");
 
-            auto tables_result = (*shared_factory)(batch.file_idx,
+            auto reader_result = (*shared_factory)(batch.file_idx,
                                                    batch.rg_offset,
                                                    batch.rg_count,
                                                    reader_memory_limit);
-            AssertInfo(tables_result.ok(),
-                       "[StorageV2] Failed to read batch: " +
-                           tables_result.status().ToString());
-            auto all_tables = std::move(tables_result).ValueOrDie();
-            AssertInfo(all_tables.size() == static_cast<size_t>(batch.rg_count),
-                       "reader returns less tables than expected, batch rg "
-                       "count: {}, result size: {}",
-                       batch.rg_count,
-                       all_tables.size());
+            AssertInfo(reader_result.ok(),
+                       "[StorageV2] Failed to create streaming reader: " +
+                           reader_result.status().ToString());
+            auto reader = std::move(reader_result).ValueOrDie();
 
-            int64_t table_offset = 0;
+            // Stream row groups per-cell: read only what each cell needs,
+            // push immediately, so previous cell's tables can be freed
+            // before next cell is read.
             for (const auto& cell : batch.cells) {
                 auto cell_result = std::make_shared<CellLoadResult>();
                 cell_result->cid = cell.cid;
                 cell_result->tables.reserve(cell.rg_count);
                 for (int64_t i = 0; i < cell.rg_count; ++i) {
+                    auto table_result = reader->ReadNext();
+                    AssertInfo(table_result.ok(),
+                               "[StorageV2] Failed to read row group: " +
+                                   table_result.status().ToString());
                     cell_result->tables.push_back(
-                        std::move(all_tables[table_offset + i]));
+                        std::move(table_result).ValueOrDie());
                 }
-                table_offset += cell.rg_count;
                 channel->push(std::move(cell_result));
             }
         }));
@@ -374,16 +374,40 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
     return futures;
 }
 
-BatchReaderFactory
-MakeFileReaderFactory(std::vector<std::string> remote_files,
-                      milvus_storage::ArrowFileSystemPtr fs) {
+// ---- File-based streaming reader ----
+
+class FileSequentialReader : public SequentialRowGroupReader {
+ public:
+    explicit FileSequentialReader(
+        std::shared_ptr<milvus_storage::FileRowGroupReader> reader)
+        : reader_(std::move(reader)) {
+    }
+
+    ~FileSequentialReader() override {
+        (void)reader_->Close();
+    }
+
+    arrow::Result<std::shared_ptr<arrow::Table>>
+    ReadNext() override {
+        std::shared_ptr<arrow::Table> table;
+        ARROW_RETURN_NOT_OK(reader_->ReadNextRowGroup(&table));
+        return table;
+    }
+
+ private:
+    std::shared_ptr<milvus_storage::FileRowGroupReader> reader_;
+};
+
+StreamingReaderFactory
+MakeFileStreamingFactory(std::vector<std::string> remote_files,
+                         milvus_storage::ArrowFileSystemPtr fs) {
     auto files =
         std::make_shared<std::vector<std::string>>(std::move(remote_files));
     return [files, fs](size_t batch_key,
                        int64_t rg_offset,
                        int64_t total_rg_count,
                        int64_t reader_memory_limit)
-               -> arrow::Result<std::vector<std::shared_ptr<arrow::Table>>> {
+               -> arrow::Result<std::unique_ptr<SequentialRowGroupReader>> {
         ARROW_ASSIGN_OR_RAISE(auto reader,
                               milvus_storage::FileRowGroupReader::Make(
                                   fs,
@@ -391,29 +415,42 @@ MakeFileReaderFactory(std::vector<std::string> remote_files,
                                   nullptr,
                                   reader_memory_limit,
                                   milvus::storage::GetReaderProperties()));
-        auto close_guard =
-            folly::makeGuard([&reader]() { (void)reader->Close(); });
         ARROW_RETURN_NOT_OK(
             reader->SetRowGroupOffsetAndCount(rg_offset, total_rg_count));
-        std::vector<std::shared_ptr<arrow::Table>> tables;
-        tables.reserve(total_rg_count);
-        for (int64_t i = 0; i < total_rg_count; ++i) {
-            std::shared_ptr<arrow::Table> table;
-            ARROW_RETURN_NOT_OK(reader->ReadNextRowGroup(&table));
-            tables.push_back(std::move(table));
-        }
-        return tables;
+        return std::make_unique<FileSequentialReader>(std::move(reader));
     };
 }
 
-BatchReaderFactory
-MakeChunkReaderFactory(
+// ---- ChunkReader-based streaming reader ----
+
+class ChunkSequentialReader : public SequentialRowGroupReader {
+ public:
+    explicit ChunkSequentialReader(
+        std::vector<std::shared_ptr<arrow::Table>> tables)
+        : tables_(std::move(tables)), pos_(0) {
+    }
+
+    arrow::Result<std::shared_ptr<arrow::Table>>
+    ReadNext() override {
+        if (pos_ >= tables_.size()) {
+            return nullptr;
+        }
+        return std::move(tables_[pos_++]);
+    }
+
+ private:
+    std::vector<std::shared_ptr<arrow::Table>> tables_;
+    size_t pos_;
+};
+
+StreamingReaderFactory
+MakeChunkStreamingFactory(
     std::shared_ptr<milvus_storage::api::ChunkReader> chunk_reader) {
     return [chunk_reader](size_t /*batch_key*/,
                           int64_t rg_offset,
                           int64_t total_rg_count,
                           int64_t /*reader_memory_limit*/)
-               -> arrow::Result<std::vector<std::shared_ptr<arrow::Table>>> {
+               -> arrow::Result<std::unique_ptr<SequentialRowGroupReader>> {
         std::vector<int64_t> rg_indices(total_rg_count);
         std::iota(rg_indices.begin(), rg_indices.end(), rg_offset);
         ARROW_ASSIGN_OR_RAISE(
@@ -427,7 +464,7 @@ MakeChunkReaderFactory(
                 arrow::Table::FromRecordBatches({std::move(batch)}));
             tables.push_back(std::move(table));
         }
-        return tables;
+        return std::make_unique<ChunkSequentialReader>(std::move(tables));
     };
 }
 

--- a/internal/core/src/segcore/memory_planner.h
+++ b/internal/core/src/segcore/memory_planner.h
@@ -119,28 +119,39 @@ struct CellLoadResult {
 
 using CellReaderChannel = milvus::Channel<std::shared_ptr<CellLoadResult>>;
 
-// Creates a batch reader for a range of contiguous row groups.
-// Returns all row groups as a vector of tables in one call.
+// Sequential reader interface for streaming row group reads.
+// Each ReadNext() call returns the next row group as an Arrow Table.
+class SequentialRowGroupReader {
+ public:
+    virtual ~SequentialRowGroupReader() = default;
+    virtual arrow::Result<std::shared_ptr<arrow::Table>>
+    ReadNext() = 0;
+};
+
+// Factory that creates a SequentialRowGroupReader for a given batch of
+// contiguous row groups. The reader allows streaming reads one row group
+// at a time, avoiding holding all tables in memory simultaneously.
 // batch_key: grouping key (file_idx for files, 0 for single reader)
 // rg_offset: start row group index for this batch
 // total_rg_count: total row groups across all cells in this batch
 // reader_memory_limit: memory budget for this batch's reader
-using BatchReaderFactory =
-    std::function<arrow::Result<std::vector<std::shared_ptr<arrow::Table>>>(
+using StreamingReaderFactory =
+    std::function<arrow::Result<std::unique_ptr<SequentialRowGroupReader>>(
         size_t batch_key,
         int64_t rg_offset,
         int64_t total_rg_count,
         int64_t reader_memory_limit)>;
 
 /**
- * Load cells in batches using a pluggable reader factory. Cells are sorted by
- * (file_idx, local_rg_offset) and grouped into IO-merged batches.
- * Each completed cell is pushed to the channel immediately, enabling
- * streaming consumption without accumulating all ArrowTables.
+ * Load cells in batches using a pluggable streaming reader factory.
+ * Cells are sorted by (file_idx, local_rg_offset) and grouped into
+ * IO-merged batches. Each completed cell is pushed to the channel
+ * immediately, enabling streaming consumption without accumulating
+ * all ArrowTables in memory.
  *
  * @param op_ctx operation context for cancellation
  * @param cell_specs cell specifications (sorted internally)
- * @param reader_factory factory that reads all row groups for a batch
+ * @param reader_factory factory that creates a streaming reader per batch
  * @param channel channel to receive loaded cell data; closed when all done
  * @param memory_limit total memory limit for readers
  * @param priority load priority
@@ -149,29 +160,28 @@ using BatchReaderFactory =
 std::vector<std::future<void>>
 LoadCellBatchAsync(milvus::OpContext* op_ctx,
                    std::vector<CellSpec> cell_specs,
-                   BatchReaderFactory reader_factory,
+                   StreamingReaderFactory reader_factory,
                    std::shared_ptr<CellReaderChannel>& channel,
                    int64_t memory_limit,
                    milvus::proto::common::LoadPriority priority =
                        milvus::proto::common::LoadPriority::HIGH);
 
 /**
- * Creates a BatchReaderFactory that reads from Parquet files via FileRowGroupReader.
- * The returned factory owns a copy of remote_files, so the caller's vector
- * need not outlive the factory.
+ * Creates a StreamingReaderFactory that reads from Parquet files via
+ * FileRowGroupReader. The returned factory owns a copy of remote_files,
+ * so the caller's vector need not outlive the factory.
  */
-BatchReaderFactory
-MakeFileReaderFactory(std::vector<std::string> remote_files,
-                      milvus_storage::ArrowFileSystemPtr fs);
+StreamingReaderFactory
+MakeFileStreamingFactory(std::vector<std::string> remote_files,
+                         milvus_storage::ArrowFileSystemPtr fs);
 
 /**
- * Creates a BatchReaderFactory that reads from a ChunkReader via batch
- * get_chunks(). Row groups are loaded in a single IO call for IO merging
- * and returned as a vector of tables. The factory captures the shared_ptr
- * by value, extending the ChunkReader's lifetime automatically.
+ * Creates a StreamingReaderFactory that reads from a ChunkReader.
+ * Row groups are loaded via get_chunks() and wrapped in a sequential
+ * reader for streaming consumption.
  */
-BatchReaderFactory
-MakeChunkReaderFactory(
+StreamingReaderFactory
+MakeChunkStreamingFactory(
     std::shared_ptr<milvus_storage::api::ChunkReader> chunk_reader);
 
 }  // namespace milvus::segcore

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
@@ -339,7 +339,7 @@ GroupChunkTranslator::get_cells(milvus::OpContext* ctx,
     auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
                   .GetArrowFileSystem();
 
-    auto factory = milvus::segcore::MakeFileReaderFactory(insert_files_, fs);
+    auto factory = milvus::segcore::MakeFileStreamingFactory(insert_files_, fs);
     auto load_futures =
         milvus::segcore::LoadCellBatchAsync(ctx,
                                             std::move(cell_specs),

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
@@ -222,8 +222,8 @@ ManifestGroupTranslator::get_cells(
                               static_cast<int64_t>(end - start)});
     }
 
-    // Create factory using ChunkReader — reads a batch of row groups at once
-    auto factory = milvus::segcore::MakeChunkReaderFactory(chunk_reader_);
+    // Create factory using ChunkReader — reads row groups via streaming reader
+    auto factory = milvus::segcore::MakeChunkStreamingFactory(chunk_reader_);
 
     // Submit cell-batch loading tasks
     auto& pool = milvus::ThreadPools::GetThreadPool(


### PR DESCRIPTION
Cherry-pick from master
pr: #48161
Related to #48060

BatchReaderFactory (introduced in #47954) reads ALL row groups for a batch into a vector before distributing to cells. This causes all Arrow tables to be held in memory simultaneously, leading to excessive jemalloc ReallocateAligned (11.52% CPU), page faults (13.51%), and cgroup memory accounting overhead (3.86%), which starves Go-side goroutines and causes etcd keepalive timeouts.

Replace BatchReaderFactory with StreamingReaderFactory that returns a SequentialRowGroupReader. LoadCellBatchAsync now reads row groups per-cell and pushes each cell to the channel immediately, allowing previous cells' Arrow tables to be freed before the next cell is read.

Key changes:
- Add SequentialRowGroupReader interface for streaming reads
- Replace BatchReaderFactory with StreamingReaderFactory
- FileSequentialReader wraps FileRowGroupReader for per-row-group reads
- ChunkSequentialReader wraps pre-loaded tables for ManifestGroupTranslator
- LoadCellBatchAsync streams per-cell instead of bulk-reading all tables