### PR TITLE
enhance: mmap bloom filter to reduce Go heap pressure

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -1054,6 +1054,7 @@ common:
   bloomFilterType: BlockedBloomFilter # bloom filter type, support BasicBloomFilter and BlockedBloomFilter
   maxBloomFalsePositive: 0.001 # max false positive rate for bloom filter
   bloomFilterApplyBatchSize: 1000 # batch size when to apply pk to bloom filter
+  bloomFilterMmapEnabled: false # if true, mmap PK stats bloom filter data from local cache files; otherwise keep binary stats memory-backed
   usePartitionKeyAsClusteringKey: false # if true, do clustering compaction and segment prune on partition key field
   useVectorAsClusteringKey: false # if true, do clustering compaction and segment prune on vector field
   enableVectorClusteringKey: false # if true, enable vector clustering key and vector clustering compaction

--- a/internal/querynodev2/pkoracle/bloom_filter_set.go
+++ b/internal/querynodev2/pkoracle/bloom_filter_set.go
@@ -51,6 +51,11 @@ type BloomFilterSet struct {
 	// Resource tracking
 	trackedSize     int64 // memory size that was charged
 	resourceCharged bool  // tracks whether memory resources were charged for this bloom filter set
+
+	// Binary backing tracking for delegator-side PK stats.
+	mmapHandle     *bloomfilter.PkStatsMmapHandle
+	mmapManager    *bloomfilter.PkStatsMmapManager
+	mmapFileBacked bool
 }
 
 // MayPkExist returns whether any bloom filters returns positive.
@@ -229,36 +234,48 @@ func (s *BloomFilterSet) Charge() {
 
 	size := s.memSizeLocked()
 	if size > 0 {
-		C.ChargeLoadedResource(C.CResourceUsage{
-			memory_bytes: C.int64_t(size),
-			disk_bytes:   0,
-		})
+		usage := C.CResourceUsage{memory_bytes: C.int64_t(size)}
+		if s.mmapFileBacked {
+			usage = C.CResourceUsage{disk_bytes: C.int64_t(size)}
+		}
+		C.ChargeLoadedResource(usage)
 		s.trackedSize = size
 		s.resourceCharged = true
 		log.Debug("charged bloom filter resource",
 			zap.Int64("segmentID", s.segmentID),
-			zap.Int64("size", size))
+			zap.Int64("size", size),
+			zap.Bool("mmapFileBacked", s.mmapFileBacked))
 	}
 }
 
-// Refund refunds any charged resources. Safe to call multiple times.
+// Refund refunds any charged resources and releases mmap references.
+// Safe to call multiple times.
 func (s *BloomFilterSet) Refund() {
 	s.statsMutex.Lock()
 	defer s.statsMutex.Unlock()
 
-	if !s.resourceCharged || s.trackedSize <= 0 {
-		return
+	if s.resourceCharged && s.trackedSize > 0 {
+		usage := C.CResourceUsage{memory_bytes: C.int64_t(s.trackedSize)}
+		if s.mmapFileBacked {
+			usage = C.CResourceUsage{disk_bytes: C.int64_t(s.trackedSize)}
+		}
+		C.RefundLoadedResource(usage)
+		log.Debug("refunded bloom filter resource",
+			zap.Int64("segmentID", s.segmentID),
+			zap.Int64("size", s.trackedSize),
+			zap.Bool("mmapFileBacked", s.mmapFileBacked))
 	}
 
-	C.RefundLoadedResource(C.CResourceUsage{
-		memory_bytes: C.int64_t(s.trackedSize),
-		disk_bytes:   0,
-	})
-	log.Debug("refunded bloom filter resource",
-		zap.Int64("segmentID", s.segmentID),
-		zap.Int64("size", s.trackedSize))
 	s.trackedSize = 0
 	s.resourceCharged = false
+	if s.mmapManager != nil && s.mmapHandle != nil {
+		s.mmapManager.Release(s.mmapHandle)
+		s.mmapHandle = nil
+		s.mmapManager = nil
+		s.mmapFileBacked = false
+		s.historyStats = nil
+		s.currentStat = nil
+	}
 }
 
 // IsResourceCharged returns whether memory resources have been charged for this bloom filter set.
@@ -294,6 +311,16 @@ func (s *BloomFilterSet) memSizeLocked() int64 {
 		}
 	}
 	return size
+}
+
+// SetMmapReference records the binary stats backing handle owned by this bloom filter set.
+func (s *BloomFilterSet) SetMmapReference(handle *bloomfilter.PkStatsMmapHandle, mgr *bloomfilter.PkStatsMmapManager, fileBacked bool) {
+	s.statsMutex.Lock()
+	defer s.statsMutex.Unlock()
+
+	s.mmapHandle = handle
+	s.mmapManager = mgr
+	s.mmapFileBacked = fileBacked
 }
 
 // NewBloomFilterSet returns a new BloomFilterSet.

--- a/internal/querynodev2/pkoracle/bloom_filter_set_test.go
+++ b/internal/querynodev2/pkoracle/bloom_filter_set_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/util/bloomfilter"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -187,4 +188,18 @@ func TestMemSize(t *testing.T) {
 		size := bfs.MemSize()
 		assert.Greater(t, size, int64(0))
 	})
+}
+
+func TestRefundReleasesMmapWithoutCharge(t *testing.T) {
+	mgr := bloomfilter.NewPkStatsMmapManager(t.TempDir(), true)
+	handle, err := mgr.Load("stats-path", []byte("binary-stats"))
+	assert.NoError(t, err)
+
+	bfs := NewBloomFilterSet(1, 1, commonpb.SegmentState_Sealed)
+	bfs.SetMmapReference(handle, mgr, true)
+
+	bfs.Refund()
+
+	assert.Nil(t, handle.Data())
+	assert.Equal(t, 0, mgr.ActiveHandles())
 }

--- a/internal/querynodev2/segments/retrieve_test.go
+++ b/internal/querynodev2/segments/retrieve_test.go
@@ -94,7 +94,6 @@ func (suite *RetrieveSuite) SetupTest() {
 		},
 	)
 	suite.collection = suite.manager.Collection.Get(suite.collectionID)
-	loader := NewLoader(suite.ctx, suite.manager, suite.chunkManager)
 
 	binlogs, statslogs, err := mock_segcore.SaveBinLog(suite.ctx,
 		suite.collectionID,
@@ -126,10 +125,6 @@ func (suite *RetrieveSuite) SetupTest() {
 	)
 	suite.Require().NoError(err)
 
-	bfs, err := loader.loadSingleBloomFilterSet(suite.ctx, suite.collectionID, &sealLoadInfo, SegmentTypeSealed)
-	suite.Require().NoError(err)
-	suite.sealed.SetPKCandidate(bfs)
-
 	for _, binlog := range binlogs {
 		err = suite.sealed.(*LocalSegment).LoadFieldData(suite.ctx, binlog.FieldID, int64(msgLength), binlog)
 		suite.Require().NoError(err)
@@ -155,9 +150,6 @@ func (suite *RetrieveSuite) SetupTest() {
 		Level:         datapb.SegmentLevel_Legacy,
 	}
 
-	// allow growing segment use the bloom filter
-	paramtable.Get().QueryNodeCfg.SkipGrowingSegmentBF.SwapTempValue("false")
-
 	suite.growing, err = NewSegment(suite.ctx,
 		suite.collection,
 		suite.manager.Segment,
@@ -166,10 +158,6 @@ func (suite *RetrieveSuite) SetupTest() {
 		&growingLoadInfo,
 	)
 	suite.Require().NoError(err)
-
-	bfs, err = loader.loadSingleBloomFilterSet(suite.ctx, suite.collectionID, &growingLoadInfo, SegmentTypeGrowing)
-	suite.Require().NoError(err)
-	suite.growing.SetPKCandidate(bfs)
 
 	insertMsg, err := mock_segcore.GenInsertMsg(suite.collection.GetCCollection(), suite.partitionID, suite.growing.ID(), msgLength)
 	suite.Require().NoError(err)
@@ -222,14 +210,13 @@ func (suite *RetrieveSuite) TestRetrieveWithFilter() {
 	suite.NoError(err)
 
 	suite.Run("SegmentFilterRules", func() {
-		// create more 10 seal segments to test BF
+		// create more 10 sealed segments to verify worker-side retrieval
 		// The pk in seg range is {segN [0...N-1]}
 		// ex.
 		//  seg1 [0]
 		//  seg2 [0, 1]
 		//  ...
 		//  seg10 [0, 1, 2, ..., 9]
-		loader := NewLoader(suite.ctx, suite.manager, suite.chunkManager)
 		for i := range 10 {
 			segid := int64(i + 1)
 			msgLen := i + 1
@@ -263,11 +250,6 @@ func (suite *RetrieveSuite) TestRetrieveWithFilter() {
 			)
 			suite.Require().NoError(err)
 
-			bfs, err := loader.loadSingleBloomFilterSet(suite.ctx, suite.collectionID,
-				&sealLoadInfo, SegmentTypeSealed)
-			suite.Require().NoError(err)
-			sealseg.SetPKCandidate(bfs)
-
 			suite.manager.Segment.Put(suite.ctx, SegmentTypeSealed, sealseg)
 		}
 
@@ -281,7 +263,7 @@ func (suite *RetrieveSuite) TestRetrieveWithFilter() {
 			Scope:      querypb.DataScope_Historical,
 		}
 
-		// PK filtering now happens at the delegator layer, not at the worker layer.
+		// PK filtering happens at the delegator layer, not at the worker layer.
 		// All requested segments are returned regardless of the expression.
 		res, segments, err := Retrieve(context.TODO(), suite.manager, plan, req)
 		suite.NoError(err)
@@ -326,7 +308,6 @@ func (suite *RetrieveSuite) TestRetrieveStreamWithFilterDoesNotPruneGrowing() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	loader := NewLoader(ctx, suite.manager, suite.chunkManager)
 	growingSegIDs := make([]int64, 0, 10)
 	for i := range 10 {
 		segID := int64(i + 3000)
@@ -359,10 +340,6 @@ func (suite *RetrieveSuite) TestRetrieveStreamWithFilterDoesNotPruneGrowing() {
 			loadInfo,
 		)
 		suite.Require().NoError(err)
-
-		bfs, err := loader.loadSingleBloomFilterSet(ctx, suite.collectionID, loadInfo, SegmentTypeGrowing)
-		suite.Require().NoError(err)
-		seg.SetPKCandidate(bfs)
 
 		insertMsg, err := mock_segcore.GenInsertMsg(suite.collection.GetCCollection(), suite.partitionID, segID, msgLen)
 		suite.Require().NoError(err)
@@ -414,7 +391,6 @@ func (suite *RetrieveSuite) TestRetrieveStreamWithFilterDoesNotPruneGrowing() {
 
 func (suite *RetrieveSuite) TestRetrieveWithFilterDoesNotPruneGrowing() {
 	ctx := context.Background()
-	loader := NewLoader(ctx, suite.manager, suite.chunkManager)
 
 	growingSegIDs := make([]int64, 0, 10)
 	for i := range 10 {
@@ -448,10 +424,6 @@ func (suite *RetrieveSuite) TestRetrieveWithFilterDoesNotPruneGrowing() {
 			loadInfo,
 		)
 		suite.Require().NoError(err)
-
-		bfs, err := loader.loadSingleBloomFilterSet(ctx, suite.collectionID, loadInfo, SegmentTypeGrowing)
-		suite.Require().NoError(err)
-		seg.SetPKCandidate(bfs)
 
 		insertMsg, err := mock_segcore.GenInsertMsg(suite.collection.GetCCollection(), suite.partitionID, segID, msgLen)
 		suite.Require().NoError(err)
@@ -540,7 +512,6 @@ func (suite *RetrieveSuite) TestRetrieveStreamWithFilter() {
 	defer cancel()
 
 	// create more sealed segments for testing
-	loader := NewLoader(ctx, suite.manager, suite.chunkManager)
 	for i := range 10 {
 		segID := int64(i + 2000)
 		msgLen := i + 1
@@ -573,10 +544,6 @@ func (suite *RetrieveSuite) TestRetrieveStreamWithFilter() {
 			loadInfo,
 		)
 		suite.Require().NoError(err)
-
-		bfs, err := loader.loadSingleBloomFilterSet(ctx, suite.collectionID, loadInfo, SegmentTypeSealed)
-		suite.Require().NoError(err)
-		seg.SetPKCandidate(bfs)
 
 		for _, binlog := range binlogs {
 			err = seg.(*LocalSegment).LoadFieldData(ctx, binlog.FieldID, int64(msgLen), binlog)

--- a/internal/querynodev2/segments/search_test.go
+++ b/internal/querynodev2/segments/search_test.go
@@ -175,7 +175,6 @@ func (suite *SearchSuite) TestSearchWithFilter() {
 
 	// create more sealed segments with different pk ranges for testing
 	// seg1: pk [0], seg2: pk [0,1], ..., seg10: pk [0..9]
-	loader := NewLoader(ctx, suite.manager, suite.chunkManager)
 	for i := range 10 {
 		segID := int64(i + 1000)
 		msgLen := i + 1
@@ -208,10 +207,6 @@ func (suite *SearchSuite) TestSearchWithFilter() {
 			loadInfo,
 		)
 		suite.Require().NoError(err)
-
-		bfs, err := loader.loadSingleBloomFilterSet(ctx, suite.collectionID, loadInfo, SegmentTypeSealed)
-		suite.Require().NoError(err)
-		seg.SetPKCandidate(bfs)
 
 		for _, binlog := range binlogs {
 			err = seg.(*LocalSegment).LoadFieldData(ctx, binlog.FieldID, int64(msgLen), binlog)
@@ -248,7 +243,6 @@ func (suite *SearchSuite) TestSearchWithFilter() {
 
 func (suite *SearchSuite) TestSearchStreamingWithFilterDoesNotPruneGrowing() {
 	ctx := context.Background()
-	loader := NewLoader(ctx, suite.manager, suite.chunkManager)
 
 	growingSegIDs := make([]int64, 0, 10)
 	for i := range 10 {
@@ -282,10 +276,6 @@ func (suite *SearchSuite) TestSearchStreamingWithFilterDoesNotPruneGrowing() {
 			loadInfo,
 		)
 		suite.Require().NoError(err)
-
-		bfs, err := loader.loadSingleBloomFilterSet(ctx, suite.collectionID, loadInfo, SegmentTypeGrowing)
-		suite.Require().NoError(err)
-		seg.SetPKCandidate(bfs)
 
 		insertMsg, err := mock_segcore.GenInsertMsg(suite.collection.GetCCollection(), suite.partitionID, segID, msgLen)
 		suite.Require().NoError(err)

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -91,7 +91,7 @@ type baseSegment struct {
 	version    *atomic.Int64
 
 	segmentType   SegmentType
-	pkCandidate   pkoracle.Candidate // PK candidate: BloomFilterSet for regular collections, ExternalSegmentCandidate for external collections
+	pkCandidate   pkoracle.Candidate // PK candidate for external collections; regular worker segments rely on PK index.
 	loadInfo      *atomic.Pointer[querypb.SegmentLoadInfo]
 	skipGrowingBF bool // Skip generating or maintaining BF for growing segments; deletion checks will be handled in segcore.
 	channel       metautil.Channel
@@ -113,7 +113,6 @@ func newBaseSegment(collection *Collection, segmentType SegmentType, version int
 		loadInfo:      atomic.NewPointer[querypb.SegmentLoadInfo](loadInfo),
 		version:       atomic.NewInt64(version),
 		segmentType:   segmentType,
-		pkCandidate:   pkoracle.NewBloomFilterSet(loadInfo.GetSegmentID(), loadInfo.GetPartitionID(), segmentType),
 		bm25Stats:     make(map[int64]*storage.BM25Stats),
 		channel:       channel,
 		skipGrowingBF: segmentType == SegmentTypeGrowing && paramtable.Get().QueryNodeCfg.SkipGrowingSegmentBF.GetAsBool(),
@@ -557,7 +556,7 @@ func (s *LocalSegment) advanceLastDeltaTimestamp(tss []typeutil.Timestamp) {
 // UpdatePkCandidate updates the PK candidate with provided pks and charges resource.
 // Overrides baseSegment.UpdatePkCandidate to handle resource charging for growing segments.
 func (s *LocalSegment) UpdatePkCandidate(pks []storage.PrimaryKey) {
-	if s.skipGrowingBF {
+	if s.skipGrowingBF || s.pkCandidate == nil {
 		return
 	}
 
@@ -1474,7 +1473,9 @@ func (s *LocalSegment) Release(ctx context.Context, opts ...releaseOption) {
 	// s.manager.SubLogicalResource(usage)
 
 	// Refund PK candidate resource
-	s.pkCandidate.Refund()
+	if s.pkCandidate != nil {
+		s.pkCandidate.Refund()
+	}
 
 	binlogSize := s.binlogSize.Load()
 	if binlogSize > 0 {

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -29,7 +29,9 @@ import (
 	"io"
 	"math"
 	"path"
+	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -47,6 +49,7 @@ import (
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/storagecommon"
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
+	"github.com/milvus-io/milvus/internal/util/bloomfilter"
 	"github.com/milvus-io/milvus/internal/util/indexparamcheck"
 	"github.com/milvus-io/milvus/internal/util/vecindexmgr"
 	"github.com/milvus-io/milvus/pkg/v3/common"
@@ -173,12 +176,26 @@ func NewLoader(
 	duf := NewDiskUsageFetcher(ctx)
 	go duf.Start()
 
+	fileBackedPkStats := paramtable.Get().CommonCfg.BloomFilterMmapEnabled.GetAsBool()
+	mmapDir := ""
+	if fileBackedPkStats {
+		mmapDir = paramtable.Get().QueryNodeCfg.MmapDirPath.GetValue()
+		if mmapDir == "" {
+			mmapDir = filepath.Join(paramtable.Get().LocalStorageCfg.Path.GetValue(), "bf_mmap")
+		}
+	}
+	pkStatsMmapMgr := bloomfilter.NewPkStatsMmapManager(mmapDir, fileBackedPkStats)
+	log.Info("pk stats mmap manager created",
+		zap.Bool("fileBacked", fileBackedPkStats),
+		zap.String("mmapDir", mmapDir))
+
 	loader := &segmentLoader{
 		manager:                   manager,
 		cm:                        cm,
 		loadingSegments:           typeutil.NewConcurrentMap[int64, *loadResult](),
 		committedResourceNotifier: syncutil.NewVersionedNotifier(),
 		duf:                       duf,
+		pkStatsMmapMgr:            pkStatsMmapMgr,
 	}
 
 	return loader
@@ -223,6 +240,8 @@ type segmentLoader struct {
 	committedResourceNotifier *syncutil.VersionedNotifier
 
 	duf *diskUsageFetcher
+
+	pkStatsMmapMgr *bloomfilter.PkStatsMmapManager
 }
 
 var _ Loader = (*segmentLoader)(nil)
@@ -363,35 +382,23 @@ func (loader *segmentLoader) Load(ctx context.Context,
 			}
 		}
 
-		if !segment.PkCandidateExist() {
-			log.Debug("loading PK candidate for segment", zap.Int64("segmentID", segment.ID()))
-			// For external collections, use ExternalSegmentCandidate instead of BloomFilterSet
-			if typeutil.IsExternalCollection(collection.Schema()) {
-				candidate := pkoracle.NewExternalSegmentCandidate(
-					loadInfo.GetSegmentID(),
-					loadInfo.GetPartitionID(),
-					segment.Type(),
-				)
-				segment.SetPKCandidate(candidate)
-				log.Info("using ExternalSegmentCandidate for external collection",
-					zap.Int64("segmentID", loadInfo.GetSegmentID()))
+		if !segment.PkCandidateExist() && typeutil.IsExternalCollection(collection.Schema()) {
+			candidate := pkoracle.NewExternalSegmentCandidate(
+				loadInfo.GetSegmentID(),
+				loadInfo.GetPartitionID(),
+				segment.Type(),
+			)
+			segment.SetPKCandidate(candidate)
+			log.Info("using ExternalSegmentCandidate for external collection",
+				zap.Int64("segmentID", loadInfo.GetSegmentID()))
 
-				// Check for truncated segment ID collision with other segments being loaded.
-				collisions := detectVirtualPKCollisions(loadInfo.GetSegmentID(), infos)
-				for _, collidingID := range collisions {
-					log.Warn("virtual PK collision detected: two segments share truncated segment ID",
-						zap.Int64("segmentID1", loadInfo.GetSegmentID()),
-						zap.Int64("segmentID2", collidingID),
-						zap.Int64("truncatedID", loadInfo.GetSegmentID()&0xFFFFFFFF))
-				}
-			} else if paramtable.Get().CommonCfg.BloomFilterEnabled.GetAsBool() {
-				bfs, err := loader.loadSingleBloomFilterSet(ctx, loadInfo.GetCollectionID(), loadInfo, segment.Type())
-				if err != nil {
-					return errors.Wrap(err, "At LoadBloomFilter")
-				}
-				segment.SetPKCandidate(bfs)
-				// Charge bloom filter resource
-				bfs.Charge()
+			// Check for truncated segment ID collision with other segments being loaded.
+			collisions := detectVirtualPKCollisions(loadInfo.GetSegmentID(), infos)
+			for _, collidingID := range collisions {
+				log.Warn("virtual PK collision detected: two segments share truncated segment ID",
+					zap.Int64("segmentID1", loadInfo.GetSegmentID()),
+					zap.Int64("segmentID2", collidingID),
+					zap.Int64("truncatedID", loadInfo.GetSegmentID()&0xFFFFFFFF))
 			}
 		}
 
@@ -636,57 +643,10 @@ func (loader *segmentLoader) GetChunkManager() storage.ChunkManager {
 	return loader.cm
 }
 
-// load single bloom filter
-func (loader *segmentLoader) loadSingleBloomFilterSet(ctx context.Context, collectionID int64, loadInfo *querypb.SegmentLoadInfo, segtype SegmentType) (*pkoracle.BloomFilterSet, error) {
-	log := log.Ctx(ctx).With(
-		zap.Int64("collectionID", collectionID),
-		zap.Int64("segmentIDs", loadInfo.GetSegmentID()))
-
-	partitionID := loadInfo.PartitionID
-	segmentID := loadInfo.SegmentID
-	bfs := pkoracle.NewBloomFilterSet(segmentID, partitionID, segtype)
-
-	if !paramtable.Get().CommonCfg.BloomFilterEnabled.GetAsBool() {
-		log.Info("skip loading bloom filter for remote segment because bloom filter is disabled")
-		return bfs, nil
+func (loader *segmentLoader) Close() {
+	if loader.pkStatsMmapMgr != nil {
+		loader.pkStatsMmapMgr.Close()
 	}
-
-	collection := loader.manager.Collection.Get(collectionID)
-	if collection == nil {
-		err := merr.WrapErrCollectionNotFound(collectionID)
-		log.Warn("failed to get collection while loading segment", zap.Error(err))
-		return nil, err
-	}
-	pkField := GetPkField(collection.Schema())
-
-	log.Info("start loading remote...", zap.Int("segmentNum", 1))
-
-	// For external collections, return empty bloom filter set.
-	// External collections use ExternalSegmentCandidate for PK checking (set on segment)
-	// and don't have stats logs, so we skip loading bloom filters.
-	// NOTE: This is a defensive guard. Normal external collection load path uses
-	// ExternalSegmentCandidate directly and should not reach here.
-	if typeutil.IsExternalCollection(collection.Schema()) {
-		log.Debug("external collection: returning empty bloom filter set (defensive path)")
-		return bfs, nil
-	}
-
-	log.Info("loading bloom filter for remote...")
-	pkStatsBinlogs, err := packed.NewStatsResolverFromLoadInfo(loadInfo).BloomFilterPaths(pkField.GetFieldID())
-	if err != nil {
-		return nil, err
-	}
-	err = loader.loadBloomFilter(ctx, segmentID, bfs, pkStatsBinlogs)
-	if err != nil {
-		log.Warn("load remote segment bloom filter failed",
-			zap.Int64("partitionID", partitionID),
-			zap.Int64("segmentID", segmentID),
-			zap.Error(err),
-		)
-		return nil, err
-	}
-
-	return bfs, nil
 }
 
 func (loader *segmentLoader) LoadBloomFilterSet(ctx context.Context, collectionID int64, infos ...*querypb.SegmentLoadInfo) ([]*pkoracle.BloomFilterSet, error) {
@@ -731,33 +691,44 @@ func (loader *segmentLoader) LoadBloomFilterSet(ctx context.Context, collectionI
 		return bfSets, nil
 	}
 
-	// Calculate total memory size needed for bloom filters (PK stats)
-	var totalMemorySize int64
+	// Calculate total size needed for bloom filters (PK stats)
+	var totalBFSize int64
 	for _, info := range infos {
 		memSize, _ := packed.NewStatsResolverFromLoadInfo(info).BloomFilterMemorySize(pkFieldID)
-		totalMemorySize += memSize
+		totalBFSize += memSize
 	}
 
-	// Reserve memory resource if tiered eviction is enabled
-	if paramtable.Get().QueryNodeCfg.TieredEvictionEnabled.GetAsBool() && totalMemorySize > 0 {
-		if ok := C.TryReserveLoadingResourceWithTimeout(C.CResourceUsage{
-			// double loading memory size for bloom filters to avoid OOM during loading
-			memory_bytes: C.int64_t(totalMemorySize * 2),
-			disk_bytes:   C.int64_t(0),
-		}, 1000); !ok {
-			return nil, fmt.Errorf("failed to reserve loading resource for bloom filters, totalMemorySize = %v MB",
-				logutil.ToMB(float64(totalMemorySize)))
+	fileBackedPkStats := loader.pkStatsMmapMgr != nil && loader.pkStatsMmapMgr.FileBacked()
+	bfReserve := C.CResourceUsage{
+		// double loading memory size for bloom filters to avoid OOM during loading
+		memory_bytes: C.int64_t(totalBFSize * 2),
+		disk_bytes:   C.int64_t(0),
+	}
+	if fileBackedPkStats {
+		bfReserve = C.CResourceUsage{
+			// loaded BF is file-backed, but conversion still needs temporary memory
+			memory_bytes: C.int64_t(totalBFSize),
+			disk_bytes:   C.int64_t(totalBFSize),
 		}
-		log.Info("reserved loading resource for bloom filters", zap.Float64("totalMemorySizeMB", logutil.ToMB(float64(totalMemorySize))))
+	}
+
+	// Reserve resource if tiered eviction is enabled
+	if paramtable.Get().QueryNodeCfg.TieredEvictionEnabled.GetAsBool() && totalBFSize > 0 {
+		if ok := C.TryReserveLoadingResourceWithTimeout(bfReserve, 1000); !ok {
+			return nil, fmt.Errorf("failed to reserve loading resource for bloom filters, totalBFSize = %v MB, fileBackedMmap = %v",
+				logutil.ToMB(float64(totalBFSize)), fileBackedPkStats)
+		}
+		log.Info("reserved loading resource for bloom filters",
+			zap.Float64("totalBFSizeMB", logutil.ToMB(float64(totalBFSize))),
+			zap.Bool("fileBackedMmap", fileBackedPkStats))
 	}
 
 	defer func() {
-		if paramtable.Get().QueryNodeCfg.TieredEvictionEnabled.GetAsBool() && totalMemorySize > 0 {
-			C.ReleaseLoadingResource(C.CResourceUsage{
-				memory_bytes: C.int64_t(totalMemorySize * 2),
-				disk_bytes:   C.int64_t(0),
-			})
-			log.Info("released loading resource for bloom filters", zap.Float64("totalMemorySizeMB", logutil.ToMB(float64(totalMemorySize))))
+		if paramtable.Get().QueryNodeCfg.TieredEvictionEnabled.GetAsBool() && totalBFSize > 0 {
+			C.ReleaseLoadingResource(bfReserve)
+			log.Info("released loading resource for bloom filters",
+				zap.Float64("totalBFSizeMB", logutil.ToMB(float64(totalBFSize))),
+				zap.Bool("fileBackedMmap", fileBackedPkStats))
 		}
 	}()
 
@@ -786,7 +757,9 @@ func (loader *segmentLoader) LoadBloomFilterSet(ctx context.Context, collectionI
 
 	err := funcutil.ProcessFuncParallel(segmentNum, segmentNum, loadRemoteFunc, "loadRemoteFunc")
 	if err != nil {
-		// no partial success here
+		for _, bfs := range bfSets {
+			bfs.Refund()
+		}
 		log.Warn("failed to load remote segment", zap.Error(err))
 		return nil, err
 	}
@@ -1090,6 +1063,15 @@ func (loader *segmentLoader) loadSealedSegment(ctx context.Context, loadInfo *qu
 	return nil
 }
 
+func allBlockedBF(stats []*storage.PrimaryKeyStats) bool {
+	for _, stat := range stats {
+		if stat == nil || stat.BF == nil || stat.BF.Type() != bloomfilter.BlockedBF {
+			return false
+		}
+	}
+	return true
+}
+
 func (loader *segmentLoader) LoadSegment(ctx context.Context,
 	seg Segment,
 	loadInfo *querypb.SegmentLoadInfo,
@@ -1134,9 +1116,9 @@ func (loader *segmentLoader) LoadSegment(ctx context.Context,
 
 	// load statslog if it's growing segment
 	if segment.segmentType == SegmentTypeGrowing {
+		resolver := packed.NewStatsResolverFromLoadInfo(loadInfo)
 		if bf, ok := segment.pkCandidate.(*pkoracle.BloomFilterSet); ok {
-			log.Info("loading statslog...")
-			resolver := packed.NewStatsResolverFromLoadInfo(loadInfo)
+			log.Info("loading pk statslog...")
 			bfPaths, err := resolver.BloomFilterPaths(pkField.GetFieldID())
 			if err != nil {
 				return err
@@ -1144,14 +1126,14 @@ func (loader *segmentLoader) LoadSegment(ctx context.Context,
 			if err := loader.loadBloomFilter(ctx, segment.ID(), bf, bfPaths); err != nil {
 				return err
 			}
+		}
 
-			bm25Paths, err := resolver.BM25StatsPaths()
-			if err != nil {
-				return err
-			}
-			if err := loader.loadBm25Stats(ctx, segment.ID(), segment.bm25Stats, bm25Paths); err != nil {
-				return err
-			}
+		bm25Paths, err := resolver.BM25StatsPaths()
+		if err != nil {
+			return err
+		}
+		if err := loader.loadBm25Stats(ctx, segment.ID(), segment.bm25Stats, bm25Paths); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -1321,6 +1303,32 @@ func (loader *segmentLoader) loadBloomFilter(ctx context.Context, segmentID int6
 		return err
 	}
 
+	if len(stats) > 0 && allBlockedBF(stats) {
+		pkStatsMmapMgr := loader.pkStatsMmapMgr
+		if pkStatsMmapMgr == nil {
+			pkStatsMmapMgr = bloomfilter.NewPkStatsMmapManager("", false)
+		}
+		cacheKey := strings.Join(binlogPaths, "\x00")
+		binaryData, err := binaryStatsData(stats, values)
+		if err != nil {
+			log.Warn("failed to serialize pk stats to binary format, using heap bloom filter", zap.Error(err))
+		} else {
+			handle, err := pkStatsMmapMgr.Load(cacheKey, binaryData)
+			if err != nil {
+				log.Warn("failed to load binary pk stats backing data, using heap bloom filter", zap.Error(err))
+			} else {
+				sharedStats, err := storage.DeserializeBinaryStats(handle.Data())
+				if err != nil {
+					pkStatsMmapMgr.Release(handle)
+					log.Warn("failed to deserialize binary pk stats, using heap bloom filter", zap.Error(err))
+				} else {
+					stats = sharedStats
+					bfs.SetMmapReference(handle, pkStatsMmapMgr, pkStatsMmapMgr.FileBacked())
+				}
+			}
+		}
+	}
+
 	var size uint
 	for _, stat := range stats {
 		pkStat := &storage.PkStatistics{
@@ -1333,6 +1341,13 @@ func (loader *segmentLoader) loadBloomFilter(ctx context.Context, segmentID int6
 	}
 	log.Info("Successfully load pk stats", zap.Duration("time", time.Since(startTs)), zap.Uint("size", size))
 	return nil
+}
+
+func binaryStatsData(stats []*storage.PrimaryKeyStats, values [][]byte) ([]byte, error) {
+	if len(values) == 1 && storage.IsBinaryStatsFormat(values[0]) {
+		return values[0], nil
+	}
+	return storage.SerializeBinaryStats(stats)
 }
 
 // loadDeltalogs performs the internal actions of `LoadDeltaLogs`

--- a/internal/querynodev2/segments/segment_loader_test.go
+++ b/internal/querynodev2/segments/segment_loader_test.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -28,14 +30,18 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/atomic"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/mocks/mock_storage"
 	"github.com/milvus-io/milvus/internal/mocks/util/mock_segcore"
+	"github.com/milvus-io/milvus/internal/querynodev2/pkoracle"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
+	"github.com/milvus-io/milvus/internal/util/bloomfilter"
 	"github.com/milvus-io/milvus/internal/util/indexparamcheck"
 	"github.com/milvus-io/milvus/internal/util/initcore"
 	"github.com/milvus-io/milvus/pkg/v3/common"
@@ -46,6 +52,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/metric"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
 type SegmentLoaderSuite struct {
@@ -163,6 +170,46 @@ func (suite *SegmentLoaderSuite) TestLoad() {
 	suite.NoError(err)
 }
 
+func (suite *SegmentLoaderSuite) TestLoadExternalL0SetsPKCandidate() {
+	ctx := context.Background()
+	collectionID := suite.collectionID + 100
+	schema := mock_segcore.GenTestCollectionSchema("external", schemapb.DataType_Int64, false)
+	schema.ExternalSource = "s3://bucket/path"
+	schema.ExternalSpec = `{"format":"parquet"}`
+	schema.Fields[0].ExternalField = schema.Fields[0].Name
+	indexMeta := mock_segcore.GenTestIndexMeta(collectionID, schema)
+	loadMeta := &querypb.LoadMetaInfo{
+		LoadType:     querypb.LoadType_LoadCollection,
+		CollectionID: collectionID,
+		PartitionIDs: []int64{suite.partitionID},
+	}
+	suite.manager.Collection.PutOrRef(collectionID, schema, indexMeta, loadMeta)
+
+	segmentID := int64(1)
+	collidingID := segmentID + (1 << 32)
+	segments, err := suite.loader.Load(ctx, collectionID, SegmentTypeSealed, 0,
+		&querypb.SegmentLoadInfo{
+			SegmentID:     segmentID,
+			PartitionID:   suite.partitionID,
+			CollectionID:  collectionID,
+			Level:         datapb.SegmentLevel_L0,
+			InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", collectionID),
+		},
+		&querypb.SegmentLoadInfo{
+			SegmentID:     collidingID,
+			PartitionID:   suite.partitionID,
+			CollectionID:  collectionID,
+			Level:         datapb.SegmentLevel_L0,
+			InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", collectionID),
+		},
+	)
+	suite.NoError(err)
+	suite.Len(segments, 2)
+	for _, segment := range segments {
+		suite.True(segment.PkCandidateExist())
+	}
+}
+
 func (suite *SegmentLoaderSuite) TestLoadFail() {
 	ctx := context.Background()
 
@@ -229,12 +276,12 @@ func (suite *SegmentLoaderSuite) TestLoadMultipleSegments() {
 	segments, err := suite.loader.Load(ctx, suite.collectionID, SegmentTypeSealed, 0, loadInfos...)
 	suite.NoError(err)
 
-	// Will load bloom filter with sealed segments
+	// Regular worker segments do not load bloom filters. They rely on the
+	// delegator for PK pruning and conservatively keep all local segments.
 	for _, segment := range segments {
 		for pk := 0; pk < 100; pk++ {
 			lc := storage.NewLocationsCache(storage.NewInt64PrimaryKey(int64(pk)))
-			pkReady := segment.PkCandidateExist()
-			suite.Require().True(pkReady)
+			suite.Require().False(segment.PkCandidateExist())
 			exist := segment.MayPkExist(lc)
 			suite.Require().True(exist)
 		}
@@ -266,12 +313,12 @@ func (suite *SegmentLoaderSuite) TestLoadMultipleSegments() {
 
 	segments, err = suite.loader.Load(ctx, suite.collectionID, SegmentTypeGrowing, 0, loadInfos...)
 	suite.NoError(err)
-	// Should load bloom filter with growing segments
+	// Growing worker segments also skip bloom filters; deletes/searches use
+	// the segment data or delegator-side pruning.
 	for _, segment := range segments {
 		for pk := 0; pk < 100; pk++ {
 			lc := storage.NewLocationsCache(storage.NewInt64PrimaryKey(int64(pk)))
-			pkReady := segment.PkCandidateExist()
-			suite.True(pkReady)
+			suite.False(segment.PkCandidateExist())
 			exist := segment.MayPkExist(lc)
 			suite.True(exist)
 		}
@@ -534,6 +581,125 @@ func (suite *SegmentLoaderSuite) TestLoadWithoutBloomFilter() {
 	suite.NotNil(bfs)
 	suite.Len(bfs, 1)
 	suite.False(bfs[0].PkCandidateExist()) // metadata-only stub when BF disabled
+}
+
+func (suite *SegmentLoaderSuite) TestWorkerLoadDoesNotReadPKStats() {
+	ctx := context.Background()
+	msgLength := 100
+
+	binlogs, statsLogs, err := mock_segcore.SaveBinLog(ctx,
+		suite.collectionID,
+		suite.partitionID,
+		suite.segmentID,
+		msgLength,
+		suite.schema,
+		suite.chunkManager,
+	)
+	suite.NoError(err)
+
+	for _, fieldBinlog := range statsLogs {
+		for _, binlog := range fieldBinlog.GetBinlogs() {
+			binlog.LogPath = "missing/pkstats/worker-should-not-read"
+		}
+	}
+
+	loadInfo := &querypb.SegmentLoadInfo{
+		SegmentID:     suite.segmentID,
+		PartitionID:   suite.partitionID,
+		CollectionID:  suite.collectionID,
+		BinlogPaths:   binlogs,
+		Statslogs:     statsLogs,
+		NumOfRows:     int64(msgLength),
+		InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", suite.collectionID),
+	}
+
+	segments, err := suite.loader.Load(ctx, suite.collectionID, SegmentTypeSealed, 0, loadInfo)
+	suite.NoError(err)
+	suite.Len(segments, 1)
+	suite.False(segments[0].PkCandidateExist())
+	suite.True(segments[0].MayPkExist(storage.NewLocationsCache(storage.NewInt64PrimaryKey(42))))
+}
+
+func (suite *SegmentLoaderSuite) TestLoadBloomFilterSetMmapReleasesOnRefund() {
+	paramtable.Get().Save(paramtable.Get().CommonCfg.BloomFilterMmapEnabled.Key, "true")
+	defer paramtable.Get().Reset(paramtable.Get().CommonCfg.BloomFilterMmapEnabled.Key)
+
+	ctx := context.Background()
+	loader := NewLoader(ctx, suite.manager, suite.chunkManager)
+	defer loader.Close()
+	suite.True(loader.pkStatsMmapMgr.FileBacked())
+
+	msgLength := 100
+	binlogs, statsLogs, err := mock_segcore.SaveBinLog(ctx,
+		suite.collectionID,
+		suite.partitionID,
+		suite.segmentID,
+		msgLength,
+		suite.schema,
+		suite.chunkManager,
+	)
+	suite.NoError(err)
+
+	loadInfo := &querypb.SegmentLoadInfo{
+		SegmentID:     suite.segmentID,
+		PartitionID:   suite.partitionID,
+		CollectionID:  suite.collectionID,
+		BinlogPaths:   binlogs,
+		Statslogs:     statsLogs,
+		NumOfRows:     int64(msgLength),
+		InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", suite.collectionID),
+	}
+
+	bfs, err := loader.LoadBloomFilterSet(ctx, suite.collectionID, loadInfo)
+	suite.NoError(err)
+	suite.Len(bfs, 1)
+	suite.True(bfs[0].PkCandidateExist())
+
+	suite.Equal(1, loader.pkStatsMmapMgr.ActiveHandles())
+
+	bfs[0].Refund()
+	suite.Equal(0, loader.pkStatsMmapMgr.ActiveHandles())
+}
+
+func (suite *SegmentLoaderSuite) TestLoadBloomFilterSetMemoryBackedBinaryReleasesOnRefund() {
+	paramtable.Get().Save(paramtable.Get().CommonCfg.BloomFilterMmapEnabled.Key, "false")
+	defer paramtable.Get().Reset(paramtable.Get().CommonCfg.BloomFilterMmapEnabled.Key)
+
+	ctx := context.Background()
+	loader := NewLoader(ctx, suite.manager, suite.chunkManager)
+	defer loader.Close()
+	suite.False(loader.pkStatsMmapMgr.FileBacked())
+
+	msgLength := 100
+	segmentID := suite.segmentID + 100
+	binlogs, statsLogs, err := mock_segcore.SaveBinLog(ctx,
+		suite.collectionID,
+		suite.partitionID,
+		segmentID,
+		msgLength,
+		suite.schema,
+		suite.chunkManager,
+	)
+	suite.NoError(err)
+
+	loadInfo := &querypb.SegmentLoadInfo{
+		SegmentID:     segmentID,
+		PartitionID:   suite.partitionID,
+		CollectionID:  suite.collectionID,
+		BinlogPaths:   binlogs,
+		Statslogs:     statsLogs,
+		NumOfRows:     int64(msgLength),
+		InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", suite.collectionID),
+	}
+
+	bfs, err := loader.LoadBloomFilterSet(ctx, suite.collectionID, loadInfo)
+	suite.NoError(err)
+	suite.Len(bfs, 1)
+	suite.True(bfs[0].PkCandidateExist())
+	suite.Equal(1, loader.pkStatsMmapMgr.ActiveHandles())
+
+	bfs[0].Refund()
+	suite.Equal(0, loader.pkStatsMmapMgr.ActiveHandles())
 }
 
 func (suite *SegmentLoaderSuite) TestLoadDeltaLogs() {
@@ -1845,6 +2011,230 @@ func (suite *ExternalSegmentEstimateSuite) TestLazyLoadSubtractsRawData() {
 
 	suite.True(lazyUsage.MemorySize <= nonLazyUsage.MemorySize,
 		"lazy load memory (%d) should be <= non-lazy (%d)", lazyUsage.MemorySize, nonLazyUsage.MemorySize)
+}
+
+func TestSegmentLoaderMmapHelpers(t *testing.T) {
+	blockedBF := bloomfilter.NewBloomFilterWithType(100, 0.01, "BlockedBloomFilter")
+	blockedStat := &storage.PrimaryKeyStats{
+		FieldID: 100,
+		PkType:  int64(schemapb.DataType_Int64),
+		BFType:  bloomfilter.BlockedBF,
+		BF:      blockedBF,
+		MinPk:   storage.NewInt64PrimaryKey(1),
+		MaxPk:   storage.NewInt64PrimaryKey(2),
+	}
+
+	assert.True(t, allBlockedBF([]*storage.PrimaryKeyStats{blockedStat}))
+	assert.False(t, allBlockedBF([]*storage.PrimaryKeyStats{nil}))
+	assert.False(t, allBlockedBF([]*storage.PrimaryKeyStats{{BF: nil}}))
+	assert.False(t, allBlockedBF([]*storage.PrimaryKeyStats{{
+		FieldID: 100,
+		PkType:  int64(schemapb.DataType_Int64),
+		BF:      bloomfilter.NewBloomFilterWithType(100, 0.01, "BasicBloomFilter"),
+	}}))
+
+	binaryData, err := storage.SerializeBinaryStats([]*storage.PrimaryKeyStats{blockedStat})
+	require.NoError(t, err)
+
+	passthrough, err := binaryStatsData([]*storage.PrimaryKeyStats{blockedStat}, [][]byte{binaryData})
+	require.NoError(t, err)
+	assert.Equal(t, binaryData, passthrough)
+
+	serialized, err := binaryStatsData([]*storage.PrimaryKeyStats{blockedStat}, [][]byte{[]byte("legacy-json")})
+	require.NoError(t, err)
+	assert.True(t, storage.IsBinaryStatsFormat(serialized))
+
+	_, err = binaryStatsData([]*storage.PrimaryKeyStats{{
+		FieldID: 100,
+		PkType:  int64(schemapb.DataType_Int64),
+		BF:      bloomfilter.NewBloomFilterWithType(100, 0.01, "BasicBloomFilter"),
+		MinPk:   storage.NewInt64PrimaryKey(1),
+		MaxPk:   storage.NewInt64PrimaryKey(2),
+	}}, [][]byte{[]byte("legacy-json")})
+	assert.Error(t, err)
+}
+
+func TestSegmentLoaderLoadBloomFilterMmapFallbacks(t *testing.T) {
+	ctx := context.Background()
+	paths := []string{"stats/0"}
+
+	t.Run("serialize error falls back to heap stats", func(t *testing.T) {
+		stat1 := newLoaderTestPKStat(t, 100, 1)
+		stat2 := newLoaderTestPKStat(t, 101, 2)
+		values := [][]byte{
+			loaderTestPKStatBlob(t, stat1),
+			loaderTestPKStatBlob(t, stat2),
+		}
+		cm := mock_storage.NewMockChunkManager(t)
+		cm.EXPECT().MultiRead(mock.Anything, mock.Anything).Return(values, nil)
+
+		loader := &segmentLoader{
+			cm:             cm,
+			pkStatsMmapMgr: bloomfilter.NewPkStatsMmapManager("", false),
+		}
+		bfs := pkoracle.NewBloomFilterSet(1, 10, commonpb.SegmentState_Sealed)
+
+		err := loader.loadBloomFilter(ctx, 1, bfs, []string{"stats/a", "stats/b"})
+		require.NoError(t, err)
+		assert.True(t, bfs.PkCandidateExist())
+	})
+
+	t.Run("mmap manager error falls back to heap stats", func(t *testing.T) {
+		stat := newLoaderTestPKStat(t, 100, 3)
+		cm := mock_storage.NewMockChunkManager(t)
+		cm.EXPECT().MultiRead(mock.Anything, mock.Anything).Return([][]byte{loaderTestPKStatBlob(t, stat)}, nil)
+
+		blocker := filepath.Join(t.TempDir(), "file")
+		require.NoError(t, os.WriteFile(blocker, []byte("not a directory"), 0o600))
+		loader := &segmentLoader{
+			cm:             cm,
+			pkStatsMmapMgr: bloomfilter.NewPkStatsMmapManager(blocker, true),
+		}
+		bfs := pkoracle.NewBloomFilterSet(1, 10, commonpb.SegmentState_Sealed)
+
+		err := loader.loadBloomFilter(ctx, 1, bfs, paths)
+		require.NoError(t, err)
+		assert.True(t, bfs.PkCandidateExist())
+	})
+
+	t.Run("mmap deserialize error releases mapping and falls back", func(t *testing.T) {
+		stat := newLoaderTestPKStat(t, 100, 4)
+		cm := mock_storage.NewMockChunkManager(t)
+		cm.EXPECT().MultiRead(mock.Anything, mock.Anything).Return([][]byte{loaderTestPKStatBlob(t, stat)}, nil)
+
+		mgr := bloomfilter.NewPkStatsMmapManager("", false)
+		loader := &segmentLoader{
+			cm:             cm,
+			pkStatsMmapMgr: mgr,
+		}
+		bfs := pkoracle.NewBloomFilterSet(1, 10, commonpb.SegmentState_Sealed)
+
+		patch := mockey.Mock(storage.DeserializeBinaryStats).To(
+			func([]byte) ([]*storage.PrimaryKeyStats, error) {
+				return nil, errors.New("forced mmap deserialize failure")
+			},
+		).Build()
+		defer patch.UnPatch()
+
+		err := loader.loadBloomFilter(ctx, 1, bfs, paths)
+		require.NoError(t, err)
+		assert.True(t, bfs.PkCandidateExist())
+		assert.Equal(t, 0, mgr.ActiveHandles())
+	})
+}
+
+func TestSegmentLoaderLoadSegmentGrowingLoadsBloomFilterCandidate(t *testing.T) {
+	ctx := context.Background()
+	paramtable.Init()
+
+	manager := NewManager()
+	collectionID := int64(100)
+	partitionID := int64(10)
+	segmentID := int64(1)
+	schema := mock_segcore.GenTestCollectionSchema("test", schemapb.DataType_Int64, false)
+	indexMeta := mock_segcore.GenTestIndexMeta(collectionID, schema)
+	loadMeta := &querypb.LoadMetaInfo{
+		LoadType:     querypb.LoadType_LoadCollection,
+		CollectionID: collectionID,
+		PartitionIDs: []int64{partitionID},
+	}
+	manager.Collection.PutOrRef(collectionID, schema, indexMeta, loadMeta)
+	collection := manager.Collection.Get(collectionID)
+	require.NotNil(t, collection)
+
+	loadInfo := &querypb.SegmentLoadInfo{
+		SegmentID:     segmentID,
+		PartitionID:   partitionID,
+		CollectionID:  collectionID,
+		InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", collectionID),
+	}
+	base, err := newBaseSegment(collection, SegmentTypeGrowing, 0, loadInfo)
+	require.NoError(t, err)
+	segment := &LocalSegment{
+		baseSegment:        base,
+		manager:            manager.Segment,
+		lastDeltaTimestamp: atomic.NewUint64(0),
+		fields:             typeutil.NewConcurrentMap[int64, *FieldInfo](),
+		fieldIndexes:       typeutil.NewConcurrentMap[int64, *IndexedFieldInfo](),
+		fieldJSONStats:     make(map[int64]*querypb.JsonStatsInfo),
+		memSize:            atomic.NewInt64(-1),
+		binlogSize:         atomic.NewInt64(0),
+		rowNum:             atomic.NewInt64(-1),
+		insertCount:        atomic.NewInt64(0),
+	}
+	segment.pkCandidate = pkoracle.NewBloomFilterSet(segmentID, partitionID, SegmentTypeGrowing)
+	loader := &segmentLoader{
+		manager: manager,
+	}
+
+	patch := mockey.Mock((*LocalSegment).Load).To(func(*LocalSegment, context.Context) error {
+		return nil
+	}).Build()
+	defer patch.UnPatch()
+
+	err = loader.LoadSegment(ctx, segment, loadInfo)
+	require.NoError(t, err)
+}
+
+func TestSegmentLoaderSmallBranches(t *testing.T) {
+	resource := &LoadResource{}
+	assert.True(t, resource.IsZero())
+	resource.MemorySize = 1
+	assert.False(t, resource.IsZero())
+
+	collisions := detectVirtualPKCollisions(1, []*querypb.SegmentLoadInfo{
+		{SegmentID: 1},
+		{SegmentID: 1 + (1 << 32)},
+		{SegmentID: 2},
+	})
+	assert.Equal(t, []int64{1 + (1 << 32)}, collisions)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	paramtable.Init()
+
+	paramtable.Get().Save(paramtable.Get().CommonCfg.BloomFilterMmapEnabled.Key, "false")
+	memoryLoader := NewLoader(ctx, NewManager(), nil)
+	require.NotNil(t, memoryLoader.pkStatsMmapMgr)
+	assert.False(t, memoryLoader.pkStatsMmapMgr.FileBacked())
+	assert.Nil(t, memoryLoader.GetChunkManager())
+	memoryLoader.Close()
+
+	paramtable.Get().Save(paramtable.Get().CommonCfg.BloomFilterMmapEnabled.Key, "true")
+	defer paramtable.Get().Reset(paramtable.Get().CommonCfg.BloomFilterMmapEnabled.Key)
+	paramtable.Get().Save(paramtable.Get().QueryNodeCfg.MmapDirPath.Key, "")
+	defer paramtable.Get().Reset(paramtable.Get().QueryNodeCfg.MmapDirPath.Key)
+	paramtable.Get().Save(paramtable.Get().LocalStorageCfg.Path.Key, t.TempDir())
+	defer paramtable.Get().Reset(paramtable.Get().LocalStorageCfg.Path.Key)
+
+	loader := NewLoader(ctx, NewManager(), nil)
+	require.NotNil(t, loader.pkStatsMmapMgr)
+	assert.True(t, loader.pkStatsMmapMgr.FileBacked())
+	assert.Nil(t, loader.GetChunkManager())
+	loader.Close()
+}
+
+func newLoaderTestPKStat(t *testing.T, fieldID int64, pk int64) *storage.PrimaryKeyStats {
+	t.Helper()
+	bf := bloomfilter.NewBloomFilterWithType(100, 0.01, "BlockedBloomFilter")
+	key := make([]byte, 8)
+	common.Endian.PutUint64(key, uint64(pk))
+	bf.Add(key)
+	return &storage.PrimaryKeyStats{
+		FieldID: fieldID,
+		PkType:  int64(schemapb.DataType_Int64),
+		BFType:  bloomfilter.BlockedBF,
+		BF:      bf,
+		MinPk:   storage.NewInt64PrimaryKey(pk),
+		MaxPk:   storage.NewInt64PrimaryKey(pk),
+	}
+}
+
+func loaderTestPKStatBlob(t *testing.T, stat *storage.PrimaryKeyStats) []byte {
+	t.Helper()
+	writer := &storage.StatsWriter{}
+	require.NoError(t, writer.Generate(stat))
+	return writer.GetBuffer()
 }
 
 func TestSegmentLoader(t *testing.T) {

--- a/internal/querynodev2/segments/segment_test.go
+++ b/internal/querynodev2/segments/segment_test.go
@@ -688,3 +688,16 @@ func TestBaseSegment_SkipGrowingBF(t *testing.T) {
 	results := bs.BatchPkExist(blc)
 	assert.Equal(t, []bool{true, true, true}, results)
 }
+
+func TestLocalSegment_UpdatePkCandidateSkipAndNil(t *testing.T) {
+	segment := &LocalSegment{
+		baseSegment: newTestBaseSegment(100, 10),
+	}
+
+	segment.UpdatePkCandidate([]storage.PrimaryKey{storage.NewInt64PrimaryKey(1)})
+
+	segment.pkCandidate = pkoracle.NewBloomFilterSet(100, 10, SegmentTypeGrowing)
+	segment.skipGrowingBF = true
+	segment.UpdatePkCandidate([]storage.PrimaryKey{storage.NewInt64PrimaryKey(2)})
+	assert.False(t, segment.pkCandidate.PkCandidateExist())
+}

--- a/internal/querynodev2/server.go
+++ b/internal/querynodev2/server.go
@@ -550,6 +550,9 @@ func (node *QueryNode) Stop() error {
 		if node.manager != nil {
 			node.manager.Segment.Clear(context.Background())
 		}
+		if closer, ok := node.loader.(interface{ Close() }); ok {
+			closer.Close()
+		}
 
 		node.CloseSegcore()
 

--- a/internal/storage/binary_stats_test.go
+++ b/internal/storage/binary_stats_test.go
@@ -1,0 +1,682 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/util/bloomfilter"
+	"github.com/milvus-io/milvus/pkg/v3/common"
+)
+
+func TestIsBinaryStatsFormat(t *testing.T) {
+	assert.False(t, IsBinaryStatsFormat(nil))
+	assert.False(t, IsBinaryStatsFormat([]byte{}))
+	assert.False(t, IsBinaryStatsFormat([]byte(`[{"fieldID":100}]`)))
+	assert.True(t, IsBinaryStatsFormat([]byte("mpkstats"+"xxxxxxxx")))
+}
+
+func TestSerializeDeserializeBinaryStats_Int64(t *testing.T) {
+	// Build a bloom filter with known data
+	bf := bloomfilter.NewBloomFilterWithType(10000, 0.001, "BlockedBloomFilter")
+
+	// Add some int64 PKs
+	numKeys := 100
+	for i := 0; i < numKeys; i++ {
+		key := make([]byte, 8)
+		common.Endian.PutUint64(key, uint64(i))
+		bf.Add(key)
+	}
+
+	stats := []*PrimaryKeyStats{
+		{
+			FieldID: 100,
+			PkType:  int64(schemapb.DataType_Int64),
+			BFType:  bloomfilter.BlockedBF,
+			BF:      bf,
+			MinPk:   NewInt64PrimaryKey(0),
+			MaxPk:   NewInt64PrimaryKey(int64(numKeys - 1)),
+		},
+	}
+
+	// Serialize to binary
+	data, err := SerializeBinaryStats(stats)
+	require.NoError(t, err)
+	require.NotNil(t, data)
+
+	// Verify magic
+	assert.True(t, IsBinaryStatsFormat(data))
+
+	// Deserialize
+	result, err := DeserializeBinaryStats(data)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+
+	r := result[0]
+	assert.Equal(t, int64(100), r.FieldID)
+	assert.Equal(t, int64(schemapb.DataType_Int64), r.PkType)
+	assert.Equal(t, bloomfilter.BlockedBF, r.BFType)
+
+	// Verify min/max PK
+	assert.Equal(t, int64(0), r.MinPk.(*Int64PrimaryKey).Value)
+	assert.Equal(t, int64(numKeys-1), r.MaxPk.(*Int64PrimaryKey).Value)
+
+	// Verify bloom filter correctness
+	for i := 0; i < numKeys; i++ {
+		key := make([]byte, 8)
+		common.Endian.PutUint64(key, uint64(i))
+		assert.True(t, r.BF.Test(key), "key %d should be found", i)
+	}
+
+	// Verify false positive rate
+	falsePositives := 0
+	for i := numKeys; i < numKeys+10000; i++ {
+		key := make([]byte, 8)
+		common.Endian.PutUint64(key, uint64(i))
+		if r.BF.Test(key) {
+			falsePositives++
+		}
+	}
+	assert.Less(t, falsePositives, 20, "too many false positives: %d/10000", falsePositives)
+}
+
+func TestSerializeDeserializeBinaryStats_VarChar(t *testing.T) {
+	bf := bloomfilter.NewBloomFilterWithType(10000, 0.001, "BlockedBloomFilter")
+
+	strings := []string{"apple", "banana", "cherry", "date", "elderberry"}
+	for _, s := range strings {
+		bf.AddString(s)
+	}
+
+	stats := []*PrimaryKeyStats{
+		{
+			FieldID: 200,
+			PkType:  int64(schemapb.DataType_VarChar),
+			BFType:  bloomfilter.BlockedBF,
+			BF:      bf,
+			MinPk:   NewVarCharPrimaryKey("apple"),
+			MaxPk:   NewVarCharPrimaryKey("elderberry"),
+		},
+	}
+
+	data, err := SerializeBinaryStats(stats)
+	require.NoError(t, err)
+
+	result, err := DeserializeBinaryStats(data)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+
+	r := result[0]
+	assert.Equal(t, int64(200), r.FieldID)
+	assert.Equal(t, int64(schemapb.DataType_VarChar), r.PkType)
+	assert.Equal(t, "apple", r.MinPk.(*VarCharPrimaryKey).Value)
+	assert.Equal(t, "elderberry", r.MaxPk.(*VarCharPrimaryKey).Value)
+
+	// Verify bloom filter correctness
+	for _, s := range strings {
+		assert.True(t, r.BF.TestString(s), "string %q should be found", s)
+	}
+}
+
+func TestSerializeDeserializeBinaryStats_VarChar_LongKeys(t *testing.T) {
+	bf := bloomfilter.NewBloomFilterWithType(10000, 0.001, "BlockedBloomFilter")
+
+	// Use PKs that exceed the old 48-byte limit (56 bytes minus two 4-byte length headers)
+	longMin := "this-is-a-very-long-primary-key-value-that-exceeds-the-old-48-byte-limit-for-varchar-pks"
+	longMax := "ZZZZ-another-very-long-primary-key-value-that-would-be-truncated-in-the-old-fixed-buffer"
+	bf.AddString(longMin)
+	bf.AddString(longMax)
+
+	stats := []*PrimaryKeyStats{
+		{
+			FieldID: 200,
+			PkType:  int64(schemapb.DataType_VarChar),
+			BFType:  bloomfilter.BlockedBF,
+			BF:      bf,
+			MinPk:   NewVarCharPrimaryKey(longMin),
+			MaxPk:   NewVarCharPrimaryKey(longMax),
+		},
+	}
+
+	data, err := SerializeBinaryStats(stats)
+	require.NoError(t, err)
+
+	result, err := DeserializeBinaryStats(data)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+
+	r := result[0]
+	assert.Equal(t, longMin, r.MinPk.(*VarCharPrimaryKey).Value)
+	assert.Equal(t, longMax, r.MaxPk.(*VarCharPrimaryKey).Value)
+
+	// Verify bloom filter correctness
+	assert.True(t, r.BF.TestString(longMin))
+	assert.True(t, r.BF.TestString(longMax))
+}
+
+func TestSerializeDeserializeBinaryStats_MultiEntry(t *testing.T) {
+	// Create multiple entries
+	stats := make([]*PrimaryKeyStats, 3)
+	for idx := 0; idx < 3; idx++ {
+		bf := bloomfilter.NewBloomFilterWithType(5000, 0.001, "BlockedBloomFilter")
+		base := idx * 1000
+		for i := 0; i < 1000; i++ {
+			key := make([]byte, 8)
+			binary.LittleEndian.PutUint64(key, uint64(base+i))
+			bf.Add(key)
+		}
+		stats[idx] = &PrimaryKeyStats{
+			FieldID: 100,
+			PkType:  int64(schemapb.DataType_Int64),
+			BFType:  bloomfilter.BlockedBF,
+			BF:      bf,
+			MinPk:   NewInt64PrimaryKey(int64(base)),
+			MaxPk:   NewInt64PrimaryKey(int64(base + 999)),
+		}
+	}
+
+	data, err := SerializeBinaryStats(stats)
+	require.NoError(t, err)
+
+	result, err := DeserializeBinaryStats(data)
+	require.NoError(t, err)
+	require.Len(t, result, 3)
+
+	// Verify each entry
+	for idx, r := range result {
+		base := idx * 1000
+		assert.Equal(t, int64(base), r.MinPk.(*Int64PrimaryKey).Value)
+		assert.Equal(t, int64(base+999), r.MaxPk.(*Int64PrimaryKey).Value)
+
+		// Check bloom filter
+		for i := 0; i < 1000; i++ {
+			key := make([]byte, 8)
+			binary.LittleEndian.PutUint64(key, uint64(base+i))
+			assert.True(t, r.BF.Test(key), "entry %d, key %d should be found", idx, base+i)
+		}
+	}
+}
+
+func TestSerializeDeserializeBinaryStats_NilPrimaryKeys(t *testing.T) {
+	t.Run("int64 nil min max encodes as zero", func(t *testing.T) {
+		bf := bloomfilter.NewBloomFilterWithType(100, 0.01, "BlockedBloomFilter")
+		stats := []*PrimaryKeyStats{
+			{
+				FieldID: 100,
+				PkType:  int64(schemapb.DataType_Int64),
+				BFType:  bloomfilter.BlockedBF,
+				BF:      bf,
+			},
+		}
+
+		data, err := SerializeBinaryStats(stats)
+		require.NoError(t, err)
+
+		result, err := DeserializeBinaryStats(data)
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		assert.Equal(t, int64(0), result[0].MinPk.(*Int64PrimaryKey).Value)
+		assert.Equal(t, int64(0), result[0].MaxPk.(*Int64PrimaryKey).Value)
+	})
+
+	t.Run("varchar nil min max encodes as empty strings", func(t *testing.T) {
+		bf := bloomfilter.NewBloomFilterWithType(100, 0.01, "BlockedBloomFilter")
+		stats := []*PrimaryKeyStats{
+			{
+				FieldID: 200,
+				PkType:  int64(schemapb.DataType_VarChar),
+				BFType:  bloomfilter.BlockedBF,
+				BF:      bf,
+			},
+		}
+
+		data, err := SerializeBinaryStats(stats)
+		require.NoError(t, err)
+
+		result, err := DeserializeBinaryStats(data)
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		assert.Equal(t, "", result[0].MinPk.(*VarCharPrimaryKey).Value)
+		assert.Equal(t, "", result[0].MaxPk.(*VarCharPrimaryKey).Value)
+	})
+}
+
+func TestDeserializeStatsList_AutoDetectBinary(t *testing.T) {
+	bf := bloomfilter.NewBloomFilterWithType(10000, 0.001, "BlockedBloomFilter")
+
+	key := make([]byte, 8)
+	common.Endian.PutUint64(key, uint64(42))
+	bf.Add(key)
+
+	stats := []*PrimaryKeyStats{
+		{
+			FieldID: 100,
+			PkType:  int64(schemapb.DataType_Int64),
+			BFType:  bloomfilter.BlockedBF,
+			BF:      bf,
+			MinPk:   NewInt64PrimaryKey(42),
+			MaxPk:   NewInt64PrimaryKey(42),
+		},
+	}
+
+	// Serialize to binary
+	data, err := SerializeBinaryStats(stats)
+	require.NoError(t, err)
+
+	// Use DeserializeStatsList which should auto-detect binary format
+	result, err := DeserializeStatsList(&Blob{Value: data})
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.True(t, result[0].BF.Test(key))
+}
+
+func TestDeserializeBloomFilterStats_AutoDetectBinaryDefaultPath(t *testing.T) {
+	bf := bloomfilter.NewBloomFilterWithType(10000, 0.001, "BlockedBloomFilter")
+
+	key := make([]byte, 8)
+	common.Endian.PutUint64(key, uint64(42))
+	bf.Add(key)
+
+	stats := []*PrimaryKeyStats{
+		{
+			FieldID: 100,
+			PkType:  int64(schemapb.DataType_Int64),
+			BFType:  bloomfilter.BlockedBF,
+			BF:      bf,
+			MinPk:   NewInt64PrimaryKey(42),
+			MaxPk:   NewInt64PrimaryKey(42),
+		},
+	}
+
+	data, err := SerializeBinaryStats(stats)
+	require.NoError(t, err)
+
+	result, err := DeserializeBloomFilterStats([]string{"root/stats/0"}, []*Blob{{Value: data}})
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.True(t, result[0].BF.Test(key))
+}
+
+func TestSerializeBinaryStats_Empty(t *testing.T) {
+	_, err := SerializeBinaryStats(nil)
+	assert.Error(t, err)
+
+	_, err = SerializeBinaryStats([]*PrimaryKeyStats{})
+	assert.Error(t, err)
+}
+
+func TestSerializeBinaryStats_InvalidStats(t *testing.T) {
+	bf := bloomfilter.NewBloomFilterWithType(10000, 0.001, "BlockedBloomFilter")
+	stat := &PrimaryKeyStats{
+		FieldID: 100,
+		PkType:  int64(schemapb.DataType_Int64),
+		BFType:  bloomfilter.BlockedBF,
+		BF:      bf,
+		MinPk:   NewInt64PrimaryKey(0),
+		MaxPk:   NewInt64PrimaryKey(1),
+	}
+
+	_, err := SerializeBinaryStats([]*PrimaryKeyStats{nil})
+	assert.Error(t, err)
+
+	nilBF := *stat
+	nilBF.BF = nil
+	_, err = SerializeBinaryStats([]*PrimaryKeyStats{&nilBF})
+	assert.Error(t, err)
+
+	mixedField := *stat
+	mixedField.FieldID = 101
+	_, err = SerializeBinaryStats([]*PrimaryKeyStats{stat, &mixedField})
+	assert.Error(t, err)
+
+	mixedType := *stat
+	mixedType.PkType = int64(schemapb.DataType_VarChar)
+	_, err = SerializeBinaryStats([]*PrimaryKeyStats{stat, &mixedType})
+	assert.Error(t, err)
+
+	unsupportedType := *stat
+	unsupportedType.PkType = int64(schemapb.DataType_Bool)
+	_, err = SerializeBinaryStats([]*PrimaryKeyStats{&unsupportedType})
+	assert.Error(t, err)
+
+	wrongMinPkType := *stat
+	wrongMinPkType.MinPk = NewVarCharPrimaryKey("wrong")
+	_, err = SerializeBinaryStats([]*PrimaryKeyStats{&wrongMinPkType})
+	assert.Error(t, err)
+
+	wrongMaxPkType := *stat
+	wrongMaxPkType.MaxPk = NewVarCharPrimaryKey("wrong")
+	_, err = SerializeBinaryStats([]*PrimaryKeyStats{&wrongMaxPkType})
+	assert.Error(t, err)
+
+	wrongMinPkImpl := *stat
+	wrongMinPkImpl.MinPk = fakeBinaryStatsPrimaryKey{typ: schemapb.DataType_Int64}
+	_, err = SerializeBinaryStats([]*PrimaryKeyStats{&wrongMinPkImpl})
+	assert.Error(t, err)
+
+	vcStat := &PrimaryKeyStats{
+		FieldID: 200,
+		PkType:  int64(schemapb.DataType_VarChar),
+		BFType:  bloomfilter.BlockedBF,
+		BF:      bf,
+		MinPk:   NewVarCharPrimaryKey("a"),
+		MaxPk:   NewVarCharPrimaryKey("z"),
+	}
+	wrongVarcharPkImpl := *vcStat
+	wrongVarcharPkImpl.MaxPk = fakeBinaryStatsPrimaryKey{typ: schemapb.DataType_VarChar}
+	_, err = SerializeBinaryStats([]*PrimaryKeyStats{&wrongVarcharPkImpl})
+	assert.Error(t, err)
+
+	basicBF := *stat
+	basicBF.BF = bloomfilter.NewBloomFilterWithType(100, 0.01, "BasicBloomFilter")
+	_, err = SerializeBinaryStats([]*PrimaryKeyStats{&basicBF})
+	assert.Error(t, err)
+
+	zeroCapacity := *stat
+	zeroCapacity.BF = fakeBinaryStatsBloomFilter{capacity: 0, k: 1}
+	_, err = SerializeBinaryStats([]*PrimaryKeyStats{&zeroCapacity})
+	assert.Error(t, err)
+
+	unsupportedDump := *stat
+	unsupportedDump.BF = fakeBinaryStatsBloomFilter{capacity: 512, k: 1}
+	_, err = SerializeBinaryStats([]*PrimaryKeyStats{&unsupportedDump})
+	assert.Error(t, err)
+
+	_, err = SerializeBinaryStats([]*PrimaryKeyStats{stat, nil})
+	assert.Error(t, err)
+
+	if ^uint(0) > uint(^uint32(0)) {
+		overflowBlocks := uint64(^uint32(0)) + 1
+		overflowBlockCount := *stat
+		overflowBlockCount.BF = fakeBinaryStatsBloomFilter{capacity: uint(overflowBlocks * BinaryBlockSize * 8), k: 1}
+		_, err = SerializeBinaryStats([]*PrimaryKeyStats{&overflowBlockCount})
+		assert.Error(t, err)
+	}
+}
+
+func TestDeserializeBinaryStats_InvalidData(t *testing.T) {
+	// Too short
+	_, err := DeserializeBinaryStats([]byte("short"))
+	assert.Error(t, err)
+
+	// Wrong magic
+	data := make([]byte, BinaryFileHeaderSize)
+	copy(data[:8], "wrongmgc")
+	_, err = DeserializeBinaryStats(data)
+	assert.Error(t, err)
+
+	// Wrong version
+	data2 := make([]byte, BinaryFileHeaderSize)
+	copy(data2[:8], BinaryStatsMagic)
+	binary.LittleEndian.PutUint32(data2[8:12], 99) // bad version
+	_, err = DeserializeBinaryStats(data2)
+	assert.Error(t, err)
+
+	// Zero blocks
+	data3 := makeBinaryStatsHeaderForTest()
+	binary.LittleEndian.PutUint32(data3[BinaryFileHeaderSize:BinaryFileHeaderSize+4], 0)
+	binary.LittleEndian.PutUint32(data3[BinaryFileHeaderSize+4:BinaryFileHeaderSize+8], 3)
+	_, err = DeserializeBinaryStats(data3)
+	assert.Error(t, err)
+
+	// Zero hash function count
+	data4 := makeBinaryStatsHeaderForTest()
+	binary.LittleEndian.PutUint32(data4[BinaryFileHeaderSize:BinaryFileHeaderSize+4], 1)
+	binary.LittleEndian.PutUint32(data4[BinaryFileHeaderSize+4:BinaryFileHeaderSize+8], 0)
+	_, err = DeserializeBinaryStats(data4)
+	assert.Error(t, err)
+
+	// Truncated block data
+	data5 := makeBinaryStatsHeaderForTest()
+	binary.LittleEndian.PutUint32(data5[BinaryFileHeaderSize:BinaryFileHeaderSize+4], 1)
+	binary.LittleEndian.PutUint32(data5[BinaryFileHeaderSize+4:BinaryFileHeaderSize+8], 3)
+	_, err = DeserializeBinaryStats(data5)
+	assert.Error(t, err)
+
+	// Unsupported PK type
+	data6 := makeBinaryStatsHeaderForTest()
+	binary.LittleEndian.PutUint32(data6[16:20], uint32(schemapb.DataType_Bool))
+	binary.LittleEndian.PutUint32(data6[BinaryFileHeaderSize:BinaryFileHeaderSize+4], 1)
+	binary.LittleEndian.PutUint32(data6[BinaryFileHeaderSize+4:BinaryFileHeaderSize+8], 3)
+	_, err = DeserializeBinaryStats(data6)
+	assert.Error(t, err)
+
+	// Header declares an entry, but no entry header bytes follow.
+	data7 := make([]byte, BinaryFileHeaderSize)
+	copy(data7[:8], BinaryStatsMagic)
+	binary.LittleEndian.PutUint32(data7[8:12], BinaryStatsVersion)
+	binary.LittleEndian.PutUint32(data7[12:16], 1)
+	binary.LittleEndian.PutUint32(data7[16:20], uint32(schemapb.DataType_Int64))
+	_, err = DeserializeBinaryStats(data7)
+	assert.Error(t, err)
+
+	// VarChar entry declares PK bytes that are not present.
+	data8 := make([]byte, BinaryFileHeaderSize+BinaryEntryHeaderSize)
+	copy(data8[:8], BinaryStatsMagic)
+	binary.LittleEndian.PutUint32(data8[8:12], BinaryStatsVersion)
+	binary.LittleEndian.PutUint32(data8[12:16], 1)
+	binary.LittleEndian.PutUint32(data8[16:20], uint32(schemapb.DataType_VarChar))
+	binary.LittleEndian.PutUint32(data8[BinaryFileHeaderSize:BinaryFileHeaderSize+4], 1)
+	binary.LittleEndian.PutUint32(data8[BinaryFileHeaderSize+4:BinaryFileHeaderSize+8], 3)
+	binary.LittleEndian.PutUint32(data8[BinaryFileHeaderSize+8:BinaryFileHeaderSize+12], 8)
+	_, err = DeserializeBinaryStats(data8)
+	assert.Error(t, err)
+
+	// VarChar PK data exists but is malformed.
+	data9 := make([]byte, BinaryFileHeaderSize+BinaryEntryHeaderSize+4+BinaryBlockSize)
+	copy(data9[:8], BinaryStatsMagic)
+	binary.LittleEndian.PutUint32(data9[8:12], BinaryStatsVersion)
+	binary.LittleEndian.PutUint32(data9[12:16], 1)
+	binary.LittleEndian.PutUint32(data9[16:20], uint32(schemapb.DataType_VarChar))
+	binary.LittleEndian.PutUint32(data9[BinaryFileHeaderSize:BinaryFileHeaderSize+4], 1)
+	binary.LittleEndian.PutUint32(data9[BinaryFileHeaderSize+4:BinaryFileHeaderSize+8], 3)
+	binary.LittleEndian.PutUint32(data9[BinaryFileHeaderSize+8:BinaryFileHeaderSize+12], 4)
+	_, err = DeserializeBinaryStats(data9)
+	assert.Error(t, err)
+}
+
+func TestReadVarCharPKs_InvalidBuffers(t *testing.T) {
+	_, _, err := readVarCharPKs([]byte{1, 2, 3})
+	assert.Error(t, err)
+
+	buf := make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf, 1)
+	_, _, err = readVarCharPKs(buf)
+	assert.Error(t, err)
+
+	buf = []byte{0, 0, 0, 0}
+	_, _, err = readVarCharPKs(buf)
+	assert.Error(t, err)
+
+	buf = make([]byte, 8)
+	binary.LittleEndian.PutUint32(buf[4:], 1)
+	_, _, err = readVarCharPKs(buf)
+	assert.Error(t, err)
+}
+
+func TestDeserializeStats_AutoDetectBinaryAndJSON(t *testing.T) {
+	bf := bloomfilter.NewBloomFilterWithType(100, 0.01, "BlockedBloomFilter")
+	key := make([]byte, 8)
+	common.Endian.PutUint64(key, uint64(7))
+	bf.Add(key)
+
+	stat := &PrimaryKeyStats{
+		FieldID: 100,
+		PkType:  int64(schemapb.DataType_Int64),
+		BFType:  bloomfilter.BlockedBF,
+		BF:      bf,
+		MinPk:   NewInt64PrimaryKey(7),
+		MaxPk:   NewInt64PrimaryKey(7),
+	}
+	binaryData, err := SerializeBinaryStats([]*PrimaryKeyStats{stat})
+	require.NoError(t, err)
+
+	jsonWriter := &StatsWriter{}
+	require.NoError(t, jsonWriter.Generate(stat))
+
+	stats, err := DeserializeStats([]*Blob{
+		{Value: nil},
+		{Value: binaryData},
+		{Value: jsonWriter.GetBuffer()},
+	})
+	require.NoError(t, err)
+	require.Len(t, stats, 2)
+	assert.True(t, stats[0].BF.Test(key))
+	assert.True(t, stats[1].BF.Test(key))
+
+	_, err = DeserializeStats([]*Blob{{Value: []byte("{bad-json")}})
+	assert.Error(t, err)
+
+	_, err = DeserializeStats([]*Blob{{Value: []byte(BinaryStatsMagic + "short")}})
+	assert.Error(t, err)
+}
+
+func TestDeserializeStatsList_EmptyAndJSON(t *testing.T) {
+	stats, err := DeserializeStatsList(&Blob{})
+	require.NoError(t, err)
+	assert.Empty(t, stats)
+
+	stat, err := NewPrimaryKeyStats(100, int64(schemapb.DataType_Int64), 10)
+	require.NoError(t, err)
+	stat.Update(NewInt64PrimaryKey(1))
+
+	writer := &StatsWriter{}
+	require.NoError(t, writer.GenerateList([]*PrimaryKeyStats{stat}))
+
+	stats, err = DeserializeStatsList(&Blob{Value: writer.GetBuffer()})
+	require.NoError(t, err)
+	require.Len(t, stats, 1)
+	assert.True(t, stats[0].MinPk.EQ(NewInt64PrimaryKey(1)))
+}
+
+func TestMarshalBFBlocks_InvalidInputs(t *testing.T) {
+	err := marshalBFBlocks(make([]byte, BinaryBlockSize), bloomfilter.NewBloomFilterWithType(100, 0.01, "BasicBloomFilter"))
+	assert.Error(t, err)
+
+	err = marshalBFBlocks(make([]byte, 1), bloomfilter.NewBloomFilterWithType(100, 0.01, "BlockedBloomFilter"))
+	assert.Error(t, err)
+}
+
+func makeBinaryStatsHeaderForTest() []byte {
+	data := make([]byte, BinaryFileHeaderSize+BinaryEntryHeaderSize)
+	copy(data[:8], BinaryStatsMagic)
+	binary.LittleEndian.PutUint32(data[8:12], BinaryStatsVersion)
+	binary.LittleEndian.PutUint32(data[12:16], 1)
+	binary.LittleEndian.PutUint32(data[16:20], uint32(schemapb.DataType_Int64))
+	binary.LittleEndian.PutUint32(data[20:24], 100)
+	return data
+}
+
+type fakeBinaryStatsBloomFilter struct {
+	capacity uint
+	k        uint
+}
+
+func (f fakeBinaryStatsBloomFilter) Type() bloomfilter.BFType {
+	return bloomfilter.BlockedBF
+}
+
+func (f fakeBinaryStatsBloomFilter) Cap() uint {
+	return f.capacity
+}
+
+func (f fakeBinaryStatsBloomFilter) K() uint {
+	return f.k
+}
+
+func (f fakeBinaryStatsBloomFilter) Add([]byte) {
+}
+
+func (f fakeBinaryStatsBloomFilter) AddString(string) {
+}
+
+func (f fakeBinaryStatsBloomFilter) Test([]byte) bool {
+	return false
+}
+
+func (f fakeBinaryStatsBloomFilter) TestString(string) bool {
+	return false
+}
+
+func (f fakeBinaryStatsBloomFilter) TestLocations([]uint64) bool {
+	return false
+}
+
+func (f fakeBinaryStatsBloomFilter) BatchTestLocations(locs [][]uint64, _ []bool) []bool {
+	return make([]bool, len(locs))
+}
+
+func (f fakeBinaryStatsBloomFilter) MarshalJSON() ([]byte, error) {
+	return nil, nil
+}
+
+func (f fakeBinaryStatsBloomFilter) UnmarshalJSON([]byte) error {
+	return nil
+}
+
+type fakeBinaryStatsPrimaryKey struct {
+	typ schemapb.DataType
+}
+
+func (f fakeBinaryStatsPrimaryKey) GT(PrimaryKey) bool {
+	return false
+}
+
+func (f fakeBinaryStatsPrimaryKey) GE(PrimaryKey) bool {
+	return false
+}
+
+func (f fakeBinaryStatsPrimaryKey) LT(PrimaryKey) bool {
+	return false
+}
+
+func (f fakeBinaryStatsPrimaryKey) LE(PrimaryKey) bool {
+	return false
+}
+
+func (f fakeBinaryStatsPrimaryKey) EQ(PrimaryKey) bool {
+	return false
+}
+
+func (f fakeBinaryStatsPrimaryKey) MarshalJSON() ([]byte, error) {
+	return nil, nil
+}
+
+func (f fakeBinaryStatsPrimaryKey) UnmarshalJSON([]byte) error {
+	return nil
+}
+
+func (f fakeBinaryStatsPrimaryKey) SetValue(interface{}) error {
+	return nil
+}
+
+func (f fakeBinaryStatsPrimaryKey) GetValue() interface{} {
+	return nil
+}
+
+func (f fakeBinaryStatsPrimaryKey) Type() schemapb.DataType {
+	return f.typ
+}
+
+func (f fakeBinaryStatsPrimaryKey) Size() int64 {
+	return 0
+}

--- a/internal/storage/data_codec.go
+++ b/internal/storage/data_codec.go
@@ -149,15 +149,12 @@ func (insertCodec *InsertCodec) SerializePkStats(stats *PrimaryKeyStats, rowNum 
 		return nil, errors.New("sericalize empty pk stats")
 	}
 
-	// Serialize by pk stats
 	blobKey := fmt.Sprintf("%d", stats.FieldID)
-	statsWriter := &StatsWriter{}
-	err := statsWriter.Generate(stats)
+	buffer, err := SerializeBinaryStats([]*PrimaryKeyStats{stats})
 	if err != nil {
 		return nil, err
 	}
 
-	buffer := statsWriter.GetBuffer()
 	return &Blob{
 		Key:        blobKey,
 		Value:      buffer,
@@ -172,18 +169,17 @@ func (insertCodec *InsertCodec) SerializePkStatsList(stats []*PrimaryKeyStats, r
 		return nil, merr.WrapErrServiceInternal("shall not serialize zero length statslog list")
 	}
 
-	blobKey := fmt.Sprintf("%d", stats[0].FieldID)
-	statsWriter := &StatsWriter{}
-	err := statsWriter.GenerateList(stats)
+	buffer, err := SerializeBinaryStats(stats)
 	if err != nil {
 		return nil, err
 	}
 
-	buffer := statsWriter.GetBuffer()
+	blobKey := fmt.Sprintf("%d", stats[0].FieldID)
 	return &Blob{
-		Key:    blobKey,
-		Value:  buffer,
-		RowNum: rowNum,
+		Key:        blobKey,
+		Value:      buffer,
+		RowNum:     rowNum,
+		MemorySize: int64(len(buffer)),
 	}, nil
 }
 
@@ -204,18 +200,12 @@ func (insertCodec *InsertCodec) SerializePkStatsByData(data *InsertData) (*Blob,
 			continue
 		}
 		singleData := data.Data[field.FieldID]
-		blobKey := fmt.Sprintf("%d", field.FieldID)
-		statsWriter := &StatsWriter{}
-		err := statsWriter.GenerateByData(field.FieldID, field.DataType, singleData)
+		stats, err := NewPrimaryKeyStats(field.FieldID, int64(field.DataType), rowNum)
 		if err != nil {
 			return nil, err
 		}
-		buffer := statsWriter.GetBuffer()
-		return &Blob{
-			Key:    blobKey,
-			Value:  buffer,
-			RowNum: rowNum,
-		}, nil
+		stats.UpdateByMsgs(singleData)
+		return insertCodec.SerializePkStats(stats, rowNum)
 	}
 	return nil, errors.New("there is no pk field")
 }

--- a/internal/storage/data_codec_test.go
+++ b/internal/storage/data_codec_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/util/bloomfilter"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/proto/etcdpb"
@@ -1266,16 +1267,53 @@ func TestInsertCodec(t *testing.T) {
 
 	statsBlob1, err := insertCodec.SerializePkStatsByData(insertData1)
 	assert.NoError(t, err)
-	_, err = DeserializeStats([]*Blob{statsBlob1})
+	assert.True(t, IsBinaryStatsFormat(statsBlob1.Value))
+	stats1, err := DeserializeStats([]*Blob{statsBlob1})
 	assert.NoError(t, err)
+	require.Len(t, stats1, 1)
+	assert.IsType(t, &bloomfilter.MmapBloomFilter{}, stats1[0].BF)
 
 	statsBlob2, err := insertCodec.SerializePkStatsByData(insertData2)
 	assert.NoError(t, err)
-	_, err = DeserializeStats([]*Blob{statsBlob2})
+	assert.True(t, IsBinaryStatsFormat(statsBlob2.Value))
+	stats2, err := DeserializeStats([]*Blob{statsBlob2})
 	assert.NoError(t, err)
+	require.Len(t, stats2, 1)
+	assert.IsType(t, &bloomfilter.MmapBloomFilter{}, stats2[0].BF)
 
 	_, err = insertCodec.SerializePkStatsList([]*PrimaryKeyStats{}, 0)
 	assert.Error(t, err, "SerializePkStatsList zero length pkstats list shall return error")
+}
+
+func TestInsertCodecSerializePkStatsUsesBinaryFormat(t *testing.T) {
+	codec := NewInsertCodec()
+	stats1, err := NewPrimaryKeyStats(Int64Field, int64(schemapb.DataType_Int64), 10)
+	require.NoError(t, err)
+	stats1.Update(NewInt64PrimaryKey(1))
+	stats1.Update(NewInt64PrimaryKey(2))
+	stats2, err := NewPrimaryKeyStats(Int64Field, int64(schemapb.DataType_Int64), 10)
+	require.NoError(t, err)
+	stats2.Update(NewInt64PrimaryKey(10))
+	stats2.Update(NewInt64PrimaryKey(20))
+
+	blob, err := codec.SerializePkStats(stats1, 2)
+	require.NoError(t, err)
+	require.True(t, IsBinaryStatsFormat(blob.Value))
+	require.Equal(t, int64(len(blob.Value)), blob.MemorySize)
+	decoded, err := DeserializeStats([]*Blob{blob})
+	require.NoError(t, err)
+	require.Len(t, decoded, 1)
+	assert.IsType(t, &bloomfilter.MmapBloomFilter{}, decoded[0].BF)
+
+	listBlob, err := codec.SerializePkStatsList([]*PrimaryKeyStats{stats1, stats2}, 4)
+	require.NoError(t, err)
+	require.True(t, IsBinaryStatsFormat(listBlob.Value))
+	require.Equal(t, int64(len(listBlob.Value)), listBlob.MemorySize)
+	listDecoded, err := DeserializeStatsList(listBlob)
+	require.NoError(t, err)
+	require.Len(t, listDecoded, 2)
+	assert.IsType(t, &bloomfilter.MmapBloomFilter{}, listDecoded[0].BF)
+	assert.IsType(t, &bloomfilter.MmapBloomFilter{}, listDecoded[1].BF)
 }
 
 func TestDeleteCodec(t *testing.T) {

--- a/internal/storage/stats.go
+++ b/internal/storage/stats.go
@@ -19,6 +19,7 @@ package storage
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"io"
 	"maps"
 	"math"
@@ -566,6 +567,14 @@ func DeserializeStats(blobs []*Blob) ([]*PrimaryKeyStats, error) {
 		if len(blob.Value) == 0 {
 			continue
 		}
+		if IsBinaryStatsFormat(blob.Value) {
+			stats, err := DeserializeBinaryStats(blob.Value)
+			if err != nil {
+				return nil, err
+			}
+			results = append(results, stats...)
+			continue
+		}
 		sr := &StatsReader{}
 		sr.SetBuffer(blob.Value)
 		stats, err := sr.GetPrimaryKeyStats()
@@ -581,6 +590,9 @@ func DeserializeStatsList(blob *Blob) ([]*PrimaryKeyStats, error) {
 	if len(blob.Value) == 0 {
 		return []*PrimaryKeyStats{}, nil
 	}
+	if IsBinaryStatsFormat(blob.Value) {
+		return DeserializeBinaryStats(blob.Value)
+	}
 	sr := &StatsReader{}
 	sr.SetBuffer(blob.Value)
 	stats, err := sr.GetPrimaryKeyStatsList()
@@ -588,4 +600,345 @@ func DeserializeStatsList(blob *Blob) ([]*PrimaryKeyStats, error) {
 		return nil, err
 	}
 	return stats, nil
+}
+
+// Binary stats format constants
+const (
+	BinaryStatsMagic      = "mpkstats"
+	BinaryStatsVersion    = uint32(1)
+	BinaryFileHeaderSize  = 64
+	BinaryEntryHeaderSize = 64
+	BinaryBlockSize       = 64 // 16 uint32 * 4 bytes
+)
+
+// IsBinaryStatsFormat checks if the data starts with the binary stats magic number.
+func IsBinaryStatsFormat(data []byte) bool {
+	return len(data) >= 8 && string(data[:8]) == BinaryStatsMagic
+}
+
+// SerializeBinaryStats serializes a list of PrimaryKeyStats into the binary format.
+//
+// File Header (64 bytes):
+//
+//	[0:8]    magic    "mpkstats"
+//	[8:12]   version  uint32 LE (= 1)
+//	[12:16]  numEntries  uint32 LE
+//	[16:20]  pkType   uint32 LE
+//	[20:24]  fieldID  int32 LE
+//	[24:64]  reserved
+//
+// For each entry:
+//
+//	Entry Header (64 bytes):
+//	  [0:4]    numBlocks  uint32 LE
+//	  [4:8]    k          uint32 LE (hash function count)
+//	  For Int64:
+//	    [8:16]   minPk  int64 LE
+//	    [16:24]  maxPk  int64 LE
+//	    [24:64]  reserved
+//	  For VarChar:
+//	    [8:12]   pkDataSize uint32 LE (total bytes of PK data after header)
+//	    [12:64]  reserved
+//	VarChar PK Data (variable length, only present for VarChar):
+//	  [4-byte minLen][minData...][4-byte maxLen][maxData...]
+//	BF Data:
+//	  numBlocks * 64 bytes
+func SerializeBinaryStats(stats []*PrimaryKeyStats) ([]byte, error) {
+	if len(stats) == 0 {
+		return nil, errors.New("cannot serialize empty stats list")
+	}
+	if stats[0] == nil {
+		return nil, errors.New("cannot serialize nil stats entry at index 0")
+	}
+	pkType := stats[0].PkType
+	fieldID := stats[0].FieldID
+
+	// Calculate total size
+	totalSize := BinaryFileHeaderSize
+	for i, s := range stats {
+		numBlocks, err := validateBinaryStat(s, pkType, fieldID, i)
+		if err != nil {
+			return nil, err
+		}
+		entrySize := BinaryEntryHeaderSize + int(numBlocks)*BinaryBlockSize
+		if schemapb.DataType(s.PkType) == schemapb.DataType_VarChar {
+			entrySize += varCharPKDataSize(s.MinPk, s.MaxPk)
+		}
+		totalSize += entrySize
+	}
+
+	buf := make([]byte, totalSize)
+
+	// Write file header
+	copy(buf[0:8], BinaryStatsMagic)
+	binary.LittleEndian.PutUint32(buf[8:12], BinaryStatsVersion)
+	binary.LittleEndian.PutUint32(buf[12:16], uint32(len(stats)))
+	binary.LittleEndian.PutUint32(buf[16:20], uint32(pkType))
+	binary.LittleEndian.PutUint32(buf[20:24], uint32(fieldID))
+
+	offset := BinaryFileHeaderSize
+	for _, s := range stats {
+		numBlocks := uint32(s.BF.Cap() / 512)
+		k := uint32(s.BF.K())
+
+		// Write entry header
+		binary.LittleEndian.PutUint32(buf[offset:offset+4], numBlocks)
+		binary.LittleEndian.PutUint32(buf[offset+4:offset+8], k)
+
+		// Write min/max PK
+		switch schemapb.DataType(s.PkType) {
+		case schemapb.DataType_Int64:
+			pkOff := offset + 8
+			if s.MinPk != nil {
+				binary.LittleEndian.PutUint64(buf[pkOff:pkOff+8], uint64(s.MinPk.(*Int64PrimaryKey).Value))
+			}
+			if s.MaxPk != nil {
+				binary.LittleEndian.PutUint64(buf[pkOff+8:pkOff+16], uint64(s.MaxPk.(*Int64PrimaryKey).Value))
+			}
+			offset += BinaryEntryHeaderSize
+		case schemapb.DataType_VarChar:
+			pkSize := varCharPKDataSize(s.MinPk, s.MaxPk)
+			binary.LittleEndian.PutUint32(buf[offset+8:offset+12], uint32(pkSize))
+			offset += BinaryEntryHeaderSize
+			writeVarCharPK(buf[offset:offset+pkSize], s.MinPk, s.MaxPk)
+			offset += pkSize
+		default:
+			offset += BinaryEntryHeaderSize
+		}
+
+		// Write BF block data - marshal from the bloom filter
+		if err := marshalBFBlocks(buf[offset:offset+int(numBlocks)*BinaryBlockSize], s.BF); err != nil {
+			return nil, fmt.Errorf("failed to marshal BF blocks for entry: %w", err)
+		}
+		offset += int(numBlocks) * BinaryBlockSize
+	}
+
+	return buf, nil
+}
+
+func validateBinaryStat(s *PrimaryKeyStats, pkType, fieldID int64, idx int) (uint32, error) {
+	if s == nil {
+		return 0, fmt.Errorf("cannot serialize nil stats entry at index %d", idx)
+	}
+	if s.FieldID != fieldID {
+		return 0, fmt.Errorf("mixed fieldID in binary stats at index %d: %d != %d", idx, s.FieldID, fieldID)
+	}
+	if s.PkType != pkType {
+		return 0, fmt.Errorf("mixed pkType in binary stats at index %d: %d != %d", idx, s.PkType, pkType)
+	}
+	switch schemapb.DataType(pkType) {
+	case schemapb.DataType_Int64, schemapb.DataType_VarChar:
+	default:
+		return 0, fmt.Errorf("unsupported binary stats pkType at index %d: %d", idx, pkType)
+	}
+	if err := validateBinaryStatsPK(s.MinPk, pkType, "MinPk", idx); err != nil {
+		return 0, err
+	}
+	if err := validateBinaryStatsPK(s.MaxPk, pkType, "MaxPk", idx); err != nil {
+		return 0, err
+	}
+	if s.BF == nil {
+		return 0, fmt.Errorf("nil bloom filter in binary stats at index %d", idx)
+	}
+	if s.BF.Type() != bloomfilter.BlockedBF {
+		return 0, fmt.Errorf("binary stats format only supports BlockedBF at index %d, got %v", idx, s.BF.Type())
+	}
+	capacity := s.BF.Cap()
+	if capacity == 0 || capacity%512 != 0 {
+		return 0, fmt.Errorf("invalid bloom filter capacity at index %d: %d", idx, capacity)
+	}
+	numBlocks := capacity / 512
+	if numBlocks > uint(^uint32(0)) {
+		return 0, fmt.Errorf("bloom filter block count overflows uint32 at index %d: %d", idx, numBlocks)
+	}
+	return uint32(numBlocks), nil
+}
+
+func validateBinaryStatsPK(pk PrimaryKey, pkType int64, name string, idx int) error {
+	if pk == nil {
+		return nil
+	}
+	if pk.Type() != schemapb.DataType(pkType) {
+		return fmt.Errorf("binary stats %s type mismatch at index %d: %v != %v", name, idx, pk.Type(), schemapb.DataType(pkType))
+	}
+	switch schemapb.DataType(pkType) {
+	case schemapb.DataType_Int64:
+		if _, ok := pk.(*Int64PrimaryKey); !ok {
+			return fmt.Errorf("binary stats %s has unexpected Int64 implementation at index %d: %T", name, idx, pk)
+		}
+	case schemapb.DataType_VarChar:
+		if _, ok := pk.(*VarCharPrimaryKey); !ok {
+			return fmt.Errorf("binary stats %s has unexpected VarChar implementation at index %d: %T", name, idx, pk)
+		}
+	}
+	return nil
+}
+
+// varCharPKDataSize returns the total bytes needed to encode min and max VarChar PKs.
+func varCharPKDataSize(minPk, maxPk PrimaryKey) int {
+	size := 8 // two 4-byte length headers
+	if minPk != nil {
+		size += len(minPk.(*VarCharPrimaryKey).Value)
+	}
+	if maxPk != nil {
+		size += len(maxPk.(*VarCharPrimaryKey).Value)
+	}
+	return size
+}
+
+// writeVarCharPK writes min and max VarChar PKs into the provided buffer.
+// Layout: [4-byte minLen][minData...][4-byte maxLen][maxData...]
+// The buffer must be large enough to hold all PK data.
+func writeVarCharPK(buf []byte, minPk, maxPk PrimaryKey) {
+	off := 0
+	if minPk != nil {
+		s := minPk.(*VarCharPrimaryKey).Value
+		binary.LittleEndian.PutUint32(buf[off:off+4], uint32(len(s)))
+		off += 4
+		copy(buf[off:off+len(s)], s)
+		off += len(s)
+	} else {
+		binary.LittleEndian.PutUint32(buf[off:off+4], 0)
+		off += 4
+	}
+	if maxPk != nil {
+		s := maxPk.(*VarCharPrimaryKey).Value
+		binary.LittleEndian.PutUint32(buf[off:off+4], uint32(len(s)))
+		off += 4
+		copy(buf[off:off+len(s)], s)
+	} else {
+		binary.LittleEndian.PutUint32(buf[off:off+4], 0)
+	}
+}
+
+// marshalBFBlocks serializes a bloom filter's block data into the provided buffer.
+// Uses blobloom's Dump format to extract block data.
+func marshalBFBlocks(dst []byte, bf bloomfilter.BloomFilterInterface) error {
+	if bf.Type() != bloomfilter.BlockedBF {
+		return fmt.Errorf("binary stats format only supports BlockedBF, got %v", bf.Type())
+	}
+
+	blockData, err := bloomfilter.DumpBlockData(bf)
+	if err != nil {
+		return err
+	}
+	if len(blockData) != len(dst) {
+		return fmt.Errorf("unexpected BF block data size: got %d, want %d", len(blockData), len(dst))
+	}
+	copy(dst, blockData)
+	return nil
+}
+
+// DeserializeBinaryStats parses binary stats format and creates MmapBloomFilter instances.
+// The data can be mmap'd memory, and MmapBloomFilter will reference it directly (zero-copy).
+func DeserializeBinaryStats(data []byte) ([]*PrimaryKeyStats, error) {
+	if len(data) < BinaryFileHeaderSize {
+		return nil, errors.New("binary stats data too short for header")
+	}
+
+	if string(data[:8]) != BinaryStatsMagic {
+		return nil, errors.New("invalid binary stats magic")
+	}
+
+	version := binary.LittleEndian.Uint32(data[8:12])
+	if version != BinaryStatsVersion {
+		return nil, fmt.Errorf("unsupported binary stats version: %d", version)
+	}
+
+	numEntries := binary.LittleEndian.Uint32(data[12:16])
+	pkType := int64(binary.LittleEndian.Uint32(data[16:20]))
+	fieldID := int64(int32(binary.LittleEndian.Uint32(data[20:24])))
+
+	results := make([]*PrimaryKeyStats, 0, numEntries)
+	offset := BinaryFileHeaderSize
+
+	for i := uint32(0); i < numEntries; i++ {
+		if offset+BinaryEntryHeaderSize > len(data) {
+			return nil, fmt.Errorf("binary stats data truncated at entry %d", i)
+		}
+
+		numBlocks := binary.LittleEndian.Uint32(data[offset : offset+4])
+		k := int(binary.LittleEndian.Uint32(data[offset+4 : offset+8]))
+		if numBlocks == 0 {
+			return nil, fmt.Errorf("binary stats entry %d has zero bloom filter blocks", i)
+		}
+		if k <= 0 {
+			return nil, fmt.Errorf("binary stats entry %d has invalid hash function count: %d", i, k)
+		}
+
+		// Parse min/max PK
+		var minPk, maxPk PrimaryKey
+		var pkDataSize int
+
+		switch schemapb.DataType(pkType) {
+		case schemapb.DataType_Int64:
+			pkOff := offset + 8
+			minVal := int64(binary.LittleEndian.Uint64(data[pkOff : pkOff+8]))
+			maxVal := int64(binary.LittleEndian.Uint64(data[pkOff+8 : pkOff+16]))
+			minPk = NewInt64PrimaryKey(minVal)
+			maxPk = NewInt64PrimaryKey(maxVal)
+		case schemapb.DataType_VarChar:
+			pkDataSize = int(binary.LittleEndian.Uint32(data[offset+8 : offset+12]))
+			pkStart := offset + BinaryEntryHeaderSize
+			if pkStart+pkDataSize > len(data) {
+				return nil, fmt.Errorf("binary stats data truncated at entry %d VarChar PK data", i)
+			}
+			var err error
+			minPk, maxPk, err = readVarCharPKs(data[pkStart : pkStart+pkDataSize])
+			if err != nil {
+				return nil, fmt.Errorf("failed to read VarChar PKs at entry %d: %w", i, err)
+			}
+		default:
+			return nil, fmt.Errorf("unsupported binary stats pkType: %d", pkType)
+		}
+
+		dataOffset := offset + BinaryEntryHeaderSize + pkDataSize
+		if dataOffset > len(data) || int(numBlocks) > (len(data)-dataOffset)/BinaryBlockSize {
+			return nil, fmt.Errorf("binary stats data truncated at entry %d block data", i)
+		}
+		dataEnd := dataOffset + int(numBlocks)*BinaryBlockSize
+
+		// Create MmapBloomFilter directly referencing the data slice
+		bf := bloomfilter.NewMmapBloomFilter(data, dataOffset, numBlocks, k)
+
+		results = append(results, &PrimaryKeyStats{
+			FieldID: fieldID,
+			PkType:  pkType,
+			BFType:  bloomfilter.BlockedBF,
+			BF:      bf,
+			MinPk:   minPk,
+			MaxPk:   maxPk,
+		})
+
+		offset = dataEnd
+	}
+
+	return results, nil
+}
+
+// readVarCharPKs reads min and max VarChar primary keys from the buffer.
+func readVarCharPKs(buf []byte) (PrimaryKey, PrimaryKey, error) {
+	off := 0
+	if off+4 > len(buf) {
+		return nil, nil, errors.New("buffer too short for minPk length")
+	}
+	minLen := int(binary.LittleEndian.Uint32(buf[off : off+4]))
+	off += 4
+	if off+minLen > len(buf) {
+		return nil, nil, errors.New("buffer too short for minPk data")
+	}
+	minPk := NewVarCharPrimaryKey(string(buf[off : off+minLen]))
+	off += minLen
+
+	if off+4 > len(buf) {
+		return nil, nil, errors.New("buffer too short for maxPk length")
+	}
+	maxLen := int(binary.LittleEndian.Uint32(buf[off : off+4]))
+	off += 4
+	if off+maxLen > len(buf) {
+		return nil, nil, errors.New("buffer too short for maxPk data")
+	}
+	maxPk := NewVarCharPrimaryKey(string(buf[off : off+maxLen]))
+
+	return minPk, maxPk, nil
 }

--- a/internal/util/bloomfilter/bloom_filter.go
+++ b/internal/util/bloomfilter/bloom_filter.go
@@ -16,6 +16,8 @@
 package bloomfilter
 
 import (
+	"bytes"
+
 	"github.com/bits-and-blooms/bloom/v3"
 	"github.com/cockroachdb/errors"
 	"github.com/greatroar/blobloom"
@@ -336,4 +338,39 @@ func Locations(data []byte, k uint, bfType BFType) []uint64 {
 		log.Info("unsupported bloom filter type, using block bloom filter", zap.String("type", bfType.String()))
 		return nil
 	}
+}
+
+// blobloomHeaderSize is the size of blobloom's binary Dump header.
+const blobloomHeaderSize = 64
+
+// blobloomMagic is the expected magic bytes at the start of blobloom's Dump output.
+const blobloomMagic = "blobloom"
+
+// DumpBlockData extracts the raw block data from a BlockedBF bloom filter.
+// Uses blobloom's Dump function to get the binary representation, then strips the 64-byte header.
+// Returns the raw block data (numBlocks * 64 bytes).
+func DumpBlockData(bf BloomFilterInterface) ([]byte, error) {
+	bbf, ok := bf.(*blockedBloomFilter)
+	if !ok {
+		return nil, errors.New("DumpBlockData only supports blockedBloomFilter")
+	}
+
+	var buf bytes.Buffer
+	_, err := blobloom.Dump(&buf, bbf.inner, "")
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to dump bloom filter")
+	}
+
+	raw := buf.Bytes()
+	if len(raw) < blobloomHeaderSize {
+		return nil, errors.New("dump output too short")
+	}
+
+	// Validate the magic bytes to detect blobloom format changes
+	if string(raw[:len(blobloomMagic)]) != blobloomMagic {
+		return nil, errors.Errorf("unexpected blobloom dump header magic: %q", string(raw[:8]))
+	}
+
+	// Strip the 64-byte blobloom header, return only block data
+	return raw[blobloomHeaderSize:], nil
 }

--- a/internal/util/bloomfilter/bloom_filter_test.go
+++ b/internal/util/bloomfilter/bloom_filter_test.go
@@ -17,10 +17,13 @@ package bloomfilter
 
 import (
 	"fmt"
+	"io"
 	"testing"
 	"time"
 
 	"github.com/bits-and-blooms/bloom/v3"
+	"github.com/bytedance/mockey"
+	"github.com/greatroar/blobloom"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
@@ -310,4 +313,77 @@ func TestMarshal(t *testing.T) {
 	for _, key := range keys {
 		assert.True(t, emptyBF2.Test(key))
 	}
+}
+
+func TestBloomFilterUtilityBranches(t *testing.T) {
+	assert.Equal(t, BasicBFName, BasicBF.String())
+	assert.Equal(t, BasicBF, BFTypeFromString(BasicBFName))
+	assert.Equal(t, BlockedBF, BFTypeFromString(BlockBFName))
+	assert.Equal(t, AlwaysTrueBF, BFTypeFromString(AlwaysTrueBFName))
+	assert.Equal(t, UnsupportedBF, BFTypeFromString("bad"))
+
+	basicBF := NewBloomFilterWithType(100, 0.01, BasicBFName)
+	basicBF.AddString("pk")
+	assert.Equal(t, BasicBF, basicBF.Type())
+	assert.Greater(t, basicBF.Cap(), uint(0))
+	assert.True(t, basicBF.TestString("pk"))
+	_, err := DumpBlockData(basicBF)
+	assert.Error(t, err)
+
+	blockedBF := NewBloomFilterWithType(100, 0.01, BlockBFName)
+	assert.Equal(t, BlockedBF, blockedBF.Type())
+
+	fallbackBF := NewBloomFilterWithType(100, 0.01, "unknown")
+	assert.Equal(t, BlockedBF, fallbackBF.Type())
+
+	assert.Nil(t, Locations([]byte("pk"), 1, AlwaysTrueBF))
+	assert.Nil(t, Locations([]byte("pk"), 1, UnsupportedBF))
+	_, err = UnmarshalJSON([]byte("{}"), UnsupportedBF)
+	assert.Error(t, err)
+
+	alwaysTrue := AlwaysTrueBloomFilter
+	alwaysTrue.Add([]byte("pk"))
+	alwaysTrue.AddString("pk")
+	assert.Equal(t, AlwaysTrueBF, alwaysTrue.Type())
+	assert.Equal(t, uint(0), alwaysTrue.Cap())
+	assert.Equal(t, uint(0), alwaysTrue.K())
+	assert.True(t, alwaysTrue.TestString("pk"))
+	assert.True(t, alwaysTrue.TestLocations([]uint64{1}))
+	assert.Equal(t, []bool{true, true}, alwaysTrue.BatchTestLocations([][]uint64{{1}, {2}}, []bool{false, false}))
+	assert.NoError(t, alwaysTrue.UnmarshalJSON(nil))
+}
+
+func TestDumpBlockData_InvalidDumpOutput(t *testing.T) {
+	bf := newBlockedBloomFilter(100, 0.01)
+
+	patch := mockey.Mock(blobloom.Dump).To(
+		func(io.Writer, *blobloom.Filter, string) (int64, error) {
+			return 0, assert.AnError
+		},
+	).Build()
+	_, err := DumpBlockData(bf)
+	assert.Error(t, err)
+	patch.UnPatch()
+
+	patch = mockey.Mock(blobloom.Dump).To(
+		func(w io.Writer, _ *blobloom.Filter, _ string) (int64, error) {
+			n, err := w.Write([]byte("short"))
+			return int64(n), err
+		},
+	).Build()
+	_, err = DumpBlockData(bf)
+	assert.Error(t, err)
+	patch.UnPatch()
+
+	patch = mockey.Mock(blobloom.Dump).To(
+		func(w io.Writer, _ *blobloom.Filter, _ string) (int64, error) {
+			raw := make([]byte, blobloomHeaderSize)
+			copy(raw, "badmagic")
+			n, err := w.Write(raw)
+			return int64(n), err
+		},
+	).Build()
+	_, err = DumpBlockData(bf)
+	assert.Error(t, err)
+	patch.UnPatch()
 }

--- a/internal/util/bloomfilter/mmap_bloom_filter.go
+++ b/internal/util/bloomfilter/mmap_bloom_filter.go
@@ -1,0 +1,146 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package bloomfilter
+
+import (
+	"encoding/binary"
+
+	"github.com/zeebo/xxh3"
+)
+
+const (
+	bfWordSize   = 32
+	bfBlockWords = 16 // BlockBits(512) / wordSize(32)
+	bfBlockBytes = bfBlockWords * 4
+)
+
+// MmapBloomFilter is a read-only bloom filter backed by mmap'd memory.
+// It implements BloomFilterInterface for testing operations only.
+// Add operations will panic since this is a read-only view.
+type MmapBloomFilter struct {
+	data      []byte // mmap'd memory region containing BF block data
+	offset    int    // start offset of block data within data
+	numBlocks uint32 // number of 512-bit blocks
+	k         int    // number of hash functions
+}
+
+// NewMmapBloomFilter creates a new MmapBloomFilter from mmap'd data.
+// data is the mmap'd memory, offset is where the block data starts,
+// numBlocks is the number of 512-bit blocks, and k is the hash count.
+func NewMmapBloomFilter(data []byte, offset int, numBlocks uint32, k int) *MmapBloomFilter {
+	return &MmapBloomFilter{
+		data:      data,
+		offset:    offset,
+		numBlocks: numBlocks,
+		k:         k,
+	}
+}
+
+func (m *MmapBloomFilter) Type() BFType {
+	return BlockedBF
+}
+
+func (m *MmapBloomFilter) Cap() uint {
+	return uint(m.numBlocks) * 512 // BlockBits per block
+}
+
+func (m *MmapBloomFilter) K() uint {
+	return uint(m.k)
+}
+
+func (m *MmapBloomFilter) Add(_ []byte) {
+	panic("MmapBloomFilter is read-only, Add not supported")
+}
+
+func (m *MmapBloomFilter) AddString(_ string) {
+	panic("MmapBloomFilter is read-only, AddString not supported")
+}
+
+func (m *MmapBloomFilter) Test(data []byte) bool {
+	h := xxh3.Hash(data)
+	return m.testHash(h)
+}
+
+func (m *MmapBloomFilter) TestString(data string) bool {
+	h := xxh3.HashString(data)
+	return m.testHash(h)
+}
+
+func (m *MmapBloomFilter) TestLocations(locs []uint64) bool {
+	if len(locs) != 1 {
+		return true
+	}
+	return m.testHash(locs[0])
+}
+
+func (m *MmapBloomFilter) BatchTestLocations(locs [][]uint64, hits []bool) []bool {
+	ret := make([]bool, len(locs))
+	n := len(hits)
+	if len(locs) < n {
+		n = len(locs)
+	}
+	for i := 0; i < n; i++ {
+		if !hits[i] {
+			if len(locs[i]) != 1 {
+				ret[i] = true
+				continue
+			}
+			ret[i] = m.testHash(locs[i][0])
+		}
+	}
+	return ret
+}
+
+func (m *MmapBloomFilter) MarshalJSON() ([]byte, error) {
+	panic("MmapBloomFilter is read-only, MarshalJSON not supported")
+}
+
+func (m *MmapBloomFilter) UnmarshalJSON(_ []byte) error {
+	panic("MmapBloomFilter is read-only, UnmarshalJSON not supported")
+}
+
+// testHash implements the blocked bloom filter Has logic, directly reading
+// from the mmap'd byte slice. This mirrors blobloom's Filter.Has().
+func (m *MmapBloomFilter) testHash(h uint64) bool {
+	h1, h2 := uint32(h>>32), uint32(h)
+	blockIdx := reducerange(h2, m.numBlocks)
+	blockOff := m.offset + int(blockIdx)*bfBlockBytes
+
+	for i := 1; i < m.k; i++ {
+		h1, h2 = doublehash(h1, h2, i)
+		wordIdx := (h1 / bfWordSize) % bfBlockWords
+		bitPos := h1 % bfWordSize
+		word := binary.LittleEndian.Uint32(m.data[blockOff+int(wordIdx)*4:])
+		if word&(1<<bitPos) == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// reducerange maps i to an integer in the range [0,n).
+// https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/
+func reducerange(i, n uint32) uint32 {
+	return uint32((uint64(i) * uint64(n)) >> 32)
+}
+
+// doublehash generates the hash values for enhanced double hashing.
+// See https://www.ccs.neu.edu/home/pete/pub/bloom-filters-verification.pdf
+func doublehash(h1, h2 uint32, i int) (uint32, uint32) {
+	h1 = h1 + h2
+	h2 = h2 + uint32(i)
+	return h1, h2
+}

--- a/internal/util/bloomfilter/mmap_bloom_filter_test.go
+++ b/internal/util/bloomfilter/mmap_bloom_filter_test.go
@@ -1,0 +1,238 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package bloomfilter
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zeebo/xxh3"
+)
+
+// buildBinaryFromBlockedBF converts a blockedBloomFilter to binary block data
+// and returns (data, numBlocks, k) for constructing a MmapBloomFilter.
+func buildBinaryFromBlockedBF(t *testing.T, bf *blockedBloomFilter) ([]byte, uint32, int) {
+	data, err := DumpBlockData(bf)
+	require.NoError(t, err)
+
+	numBlocks := uint32(len(data) / bfBlockBytes)
+	k := int(bf.K())
+
+	return data, numBlocks, k
+}
+
+func TestMmapBloomFilter_Consistency(t *testing.T) {
+	// Build a blocked bloom filter with known data
+	bf := newBlockedBloomFilter(10000, 0.001)
+
+	// Add a set of int64 keys
+	keys := make([][]byte, 1000)
+	for i := 0; i < 1000; i++ {
+		key := make([]byte, 8)
+		binary.LittleEndian.PutUint64(key, uint64(i))
+		bf.Add(key)
+		keys[i] = key
+	}
+
+	// Build MmapBloomFilter from the same data
+	data, numBlocks, k := buildBinaryFromBlockedBF(t, bf)
+	mmapBF := NewMmapBloomFilter(data, 0, numBlocks, k)
+
+	// Verify all added keys test positive in both
+	for i, key := range keys {
+		origResult := bf.Test(key)
+		mmapResult := mmapBF.Test(key)
+		assert.Equal(t, origResult, mmapResult, "key %d: original=%v, mmap=%v", i, origResult, mmapResult)
+		assert.True(t, mmapResult, "key %d should be found", i)
+	}
+
+	// Verify non-existent keys have same behavior
+	falsePositives := 0
+	for i := 1000; i < 2000; i++ {
+		key := make([]byte, 8)
+		binary.LittleEndian.PutUint64(key, uint64(i))
+		origResult := bf.Test(key)
+		mmapResult := mmapBF.Test(key)
+		assert.Equal(t, origResult, mmapResult, "non-existent key %d: original=%v, mmap=%v", i, origResult, mmapResult)
+		if mmapResult {
+			falsePositives++
+		}
+	}
+	// FPR should be reasonable (< 1% with our settings)
+	assert.Less(t, falsePositives, 20, "too many false positives: %d/1000", falsePositives)
+}
+
+func TestMmapBloomFilter_TestString(t *testing.T) {
+	bf := newBlockedBloomFilter(10000, 0.001)
+
+	strings := []string{"hello", "world", "foo", "bar", "milvus"}
+	for _, s := range strings {
+		bf.AddString(s)
+	}
+
+	data, numBlocks, k := buildBinaryFromBlockedBF(t, bf)
+	mmapBF := NewMmapBloomFilter(data, 0, numBlocks, k)
+
+	for _, s := range strings {
+		assert.Equal(t, bf.TestString(s), mmapBF.TestString(s), "string %q", s)
+		assert.True(t, mmapBF.TestString(s), "string %q should be found", s)
+	}
+}
+
+func TestMmapBloomFilter_TestLocations(t *testing.T) {
+	bf := newBlockedBloomFilter(10000, 0.001)
+
+	key := []byte("test_key")
+	bf.Add(key)
+
+	data, numBlocks, k := buildBinaryFromBlockedBF(t, bf)
+	mmapBF := NewMmapBloomFilter(data, 0, numBlocks, k)
+
+	h := xxh3.Hash(key)
+	locs := []uint64{h}
+
+	assert.Equal(t, bf.TestLocations(locs), mmapBF.TestLocations(locs))
+	assert.True(t, mmapBF.TestLocations(locs))
+
+	// Empty locs should return true (false positive by convention)
+	assert.True(t, mmapBF.TestLocations(nil))
+	assert.True(t, mmapBF.TestLocations([]uint64{h, 0})) // len != 1
+}
+
+func TestMmapBloomFilter_BatchTestLocations(t *testing.T) {
+	bf := newBlockedBloomFilter(10000, 0.001)
+
+	keys := make([][]byte, 100)
+	for i := 0; i < 100; i++ {
+		key := make([]byte, 8)
+		binary.LittleEndian.PutUint64(key, uint64(i))
+		bf.Add(key)
+		keys[i] = key
+	}
+
+	data, numBlocks, k := buildBinaryFromBlockedBF(t, bf)
+	mmapBF := NewMmapBloomFilter(data, 0, numBlocks, k)
+
+	locs := make([][]uint64, len(keys))
+	for i, key := range keys {
+		locs[i] = []uint64{xxh3.Hash(key)}
+	}
+
+	hits := make([]bool, len(keys))
+	origResult := bf.BatchTestLocations(locs, hits)
+
+	hits2 := make([]bool, len(keys))
+	mmapResult := mmapBF.BatchTestLocations(locs, hits2)
+
+	for i := range origResult {
+		assert.Equal(t, origResult[i], mmapResult[i], "batch result %d mismatch", i)
+	}
+}
+
+func TestMmapBloomFilter_BatchTestLocationsShortAndInvalidInputs(t *testing.T) {
+	bf := newBlockedBloomFilter(100, 0.01)
+	key := []byte("batch-short-input")
+	bf.Add(key)
+	data, numBlocks, k := buildBinaryFromBlockedBF(t, bf)
+	mmapBF := NewMmapBloomFilter(data, 0, numBlocks, k)
+
+	shortResult := mmapBF.BatchTestLocations([][]uint64{{xxh3.Hash(key)}}, []bool{false, false})
+	assert.Len(t, shortResult, 1)
+	assert.True(t, shortResult[0])
+
+	invalidResult := mmapBF.BatchTestLocations([][]uint64{{xxh3.Hash(key), 0}, nil}, []bool{false, false})
+	assert.Equal(t, []bool{true, true}, invalidResult)
+}
+
+func TestMmapBloomFilter_Cap(t *testing.T) {
+	bf := newBlockedBloomFilter(10000, 0.001)
+	data, numBlocks, k := buildBinaryFromBlockedBF(t, bf)
+	mmapBF := NewMmapBloomFilter(data, 0, numBlocks, k)
+
+	assert.Equal(t, bf.Cap(), mmapBF.Cap())
+	assert.Equal(t, BlockedBF, mmapBF.Type())
+	assert.Equal(t, bf.K(), mmapBF.K())
+}
+
+func TestMmapBloomFilter_Offset(t *testing.T) {
+	// Test that MmapBloomFilter works with a non-zero offset
+	bf := newBlockedBloomFilter(10000, 0.001)
+
+	key := []byte("offset_test")
+	bf.Add(key)
+
+	rawData, numBlocks, k := buildBinaryFromBlockedBF(t, bf)
+
+	// Prepend some header data
+	header := make([]byte, 128)
+	copy(header, "some_header_data")
+	dataWithHeader := append(header, rawData...)
+
+	mmapBF := NewMmapBloomFilter(dataWithHeader, 128, numBlocks, k)
+	assert.True(t, mmapBF.Test(key))
+
+	// Should not find non-existent key
+	notFound := mmapBF.Test([]byte("not_in_filter"))
+	_ = notFound // may or may not be false positive
+}
+
+func TestMmapBloomFilter_ReadOnly(t *testing.T) {
+	bf := newBlockedBloomFilter(100, 0.01)
+	data, numBlocks, k := buildBinaryFromBlockedBF(t, bf)
+	mmapBF := NewMmapBloomFilter(data, 0, numBlocks, k)
+
+	assert.Panics(t, func() { mmapBF.Add([]byte("test")) })
+	assert.Panics(t, func() { mmapBF.AddString("test") })
+	assert.Panics(t, func() { mmapBF.MarshalJSON() })
+	assert.Panics(t, func() { mmapBF.UnmarshalJSON([]byte("{}")) })
+}
+
+func TestMmapBloomFilter_LargeScale(t *testing.T) {
+	// Test with larger data to ensure correctness at scale
+	bf := newBlockedBloomFilter(200000, 0.001)
+
+	numKeys := 100000
+	keys := make([][]byte, numKeys)
+	for i := 0; i < numKeys; i++ {
+		key := make([]byte, 8)
+		binary.LittleEndian.PutUint64(key, uint64(i))
+		bf.Add(key)
+		keys[i] = key
+	}
+
+	data, numBlocks, k := buildBinaryFromBlockedBF(t, bf)
+	mmapBF := NewMmapBloomFilter(data, 0, numBlocks, k)
+
+	// Sample check - verify 1000 random keys
+	for i := 0; i < numKeys; i += 100 {
+		assert.True(t, mmapBF.Test(keys[i]), "key %d should be found", i)
+	}
+
+	// Check some non-existent keys
+	mismatches := 0
+	for i := numKeys; i < numKeys+10000; i++ {
+		key := make([]byte, 8)
+		binary.LittleEndian.PutUint64(key, uint64(i))
+		if bf.Test(key) != mmapBF.Test(key) {
+			mismatches++
+		}
+	}
+	assert.Equal(t, 0, mismatches, "all non-existent key results should match")
+
+	t.Logf("MmapBF: numBlocks=%d, k=%d, cap=%d bits", numBlocks, k, mmapBF.Cap())
+}

--- a/internal/util/bloomfilter/mmap_manager.go
+++ b/internal/util/bloomfilter/mmap_manager.go
@@ -1,0 +1,258 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package bloomfilter
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+
+	"github.com/cockroachdb/errors"
+	"github.com/zeebo/xxh3"
+	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
+
+	"github.com/milvus-io/milvus/pkg/v3/log"
+)
+
+// PkStatsMmapHandle owns one loaded PK stats data region.
+type PkStatsMmapHandle struct {
+	key      string
+	data     []byte
+	filePath string // local cache file path (empty for memory mode)
+}
+
+// Data returns the loaded PK stats data.
+func (h *PkStatsMmapHandle) Data() []byte {
+	if h == nil {
+		return nil
+	}
+	return h.data
+}
+
+// mmapEntry holds one owned data region (file-mmap or memory).
+type mmapEntry struct {
+	handle   *PkStatsMmapHandle
+	data     []byte // mmap'd region or in-memory buffer
+	fileSize int64
+	filePath string // local cache file path (empty for memory mode)
+}
+
+// PkStatsMmapManager manages loaded bloom filter data.
+// It supports two modes:
+//   - file-backed: writes data to a local file and mmaps it (off Go heap)
+//   - memory-backed: keeps binary stats as a Go []byte for zero-copy BF reads
+type PkStatsMmapManager struct {
+	mu         sync.RWMutex
+	cacheDir   string
+	fileBacked bool
+	nextID     uint64
+	mappings   map[string]*mmapEntry // handle key to entry
+}
+
+// NewPkStatsMmapManager creates a new manager.
+// If fileBacked is true, data is written to cacheDir and mmap'd (off Go heap).
+// If fileBacked is false, binary stats data is kept in memory (on Go heap).
+func NewPkStatsMmapManager(cacheDir string, fileBacked bool) *PkStatsMmapManager {
+	return &PkStatsMmapManager{
+		cacheDir:   cacheDir,
+		fileBacked: fileBacked,
+		mappings:   make(map[string]*mmapEntry),
+	}
+}
+
+// FileBacked returns whether this manager stores data in local mmap files.
+func (m *PkStatsMmapManager) FileBacked() bool {
+	return m.fileBacked
+}
+
+// ActiveHandles returns the number of live loaded handles.
+func (m *PkStatsMmapManager) ActiveHandles() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return len(m.mappings)
+}
+
+// Load stores the provided data (via file-mmap or in-memory) and returns an
+// owned handle. Each call returns an independent handle; callers must release it.
+func (m *PkStatsMmapManager) Load(remotePath string, data []byte) (*PkStatsMmapHandle, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := m.nextEntryKeyLocked(remotePath)
+
+	if m.fileBacked {
+		return m.loadFileBacked(remotePath, key, data)
+	}
+	return m.loadMemoryBacked(remotePath, key, data)
+}
+
+// loadFileBacked writes data to a local file and mmaps it.
+// Caller must hold m.mu write lock.
+func (m *PkStatsMmapManager) loadFileBacked(remotePath string, key string, data []byte) (*PkStatsMmapHandle, error) {
+	localPath := m.localCachePath(key)
+
+	dir := filepath.Dir(localPath)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, errors.Wrapf(err, "failed to create cache directory %s", dir)
+	}
+
+	if err := os.WriteFile(localPath, data, 0o600); err != nil {
+		return nil, errors.Wrapf(err, "failed to write cache file %s", localPath)
+	}
+
+	mmapData, err := m.mmapFile(localPath, int64(len(data)))
+	if err != nil {
+		os.Remove(localPath)
+		return nil, err
+	}
+
+	entry := &mmapEntry{
+		data:     mmapData,
+		fileSize: int64(len(data)),
+		filePath: localPath,
+	}
+	handle := &PkStatsMmapHandle{
+		key:      key,
+		data:     mmapData,
+		filePath: localPath,
+	}
+	entry.handle = handle
+	m.mappings[key] = entry
+
+	log.Info("file-mmap'd bloom filter",
+		zap.String("remotePath", remotePath),
+		zap.String("localPath", localPath),
+		zap.Int("size", len(data)))
+
+	return handle, nil
+}
+
+// loadMemoryBacked stores data directly in memory.
+// Caller must hold m.mu write lock.
+func (m *PkStatsMmapManager) loadMemoryBacked(remotePath string, key string, data []byte) (*PkStatsMmapHandle, error) {
+	entry := &mmapEntry{
+		data:     data,
+		fileSize: int64(len(data)),
+	}
+	handle := &PkStatsMmapHandle{
+		key:  key,
+		data: data,
+	}
+	entry.handle = handle
+	m.mappings[key] = entry
+
+	log.Info("memory-cached bloom filter",
+		zap.String("remotePath", remotePath),
+		zap.Int("size", len(data)))
+
+	return handle, nil
+}
+
+// Release releases an owned PK stats data handle.
+func (m *PkStatsMmapManager) Release(handle *PkStatsMmapHandle) {
+	if handle == nil || handle.key == "" {
+		return
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	entry, ok := m.mappings[handle.key]
+	if !ok {
+		clearMmapHandle(handle)
+		return
+	}
+
+	if m.fileBacked && entry.filePath != "" {
+		if err := unix.Munmap(entry.data); err != nil {
+			log.Warn("failed to munmap bloom filter",
+				zap.String("key", handle.key),
+				zap.Error(err))
+		}
+		os.Remove(entry.filePath)
+	}
+	delete(m.mappings, handle.key)
+	clearMmapHandle(handle)
+
+	log.Info("released bloom filter entry",
+		zap.Bool("fileBacked", m.fileBacked))
+}
+
+// Close releases all entries and cleans up.
+func (m *PkStatsMmapManager) Close() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for key, entry := range m.mappings {
+		if m.fileBacked && entry.filePath != "" {
+			if err := unix.Munmap(entry.data); err != nil {
+				log.Warn("failed to munmap bloom filter during close",
+					zap.String("key", key),
+					zap.Error(err))
+			}
+			os.Remove(entry.filePath)
+		}
+		clearMmapHandle(entry.handle)
+	}
+	m.mappings = make(map[string]*mmapEntry)
+}
+
+func clearMmapHandle(handle *PkStatsMmapHandle) {
+	if handle == nil {
+		return
+	}
+	handle.key = ""
+	handle.data = nil
+	handle.filePath = ""
+}
+
+func (m *PkStatsMmapManager) nextEntryKeyLocked(remotePath string) string {
+	m.nextID++
+	return makeMmapEntryKey(remotePath, m.nextID)
+}
+
+func makeMmapEntryKey(remotePath string, id uint64) string {
+	h := xxh3.HashString128(remotePath)
+	var b [16]byte
+	binary.BigEndian.PutUint64(b[:8], h.Hi)
+	binary.BigEndian.PutUint64(b[8:], h.Lo)
+	return hex.EncodeToString(b[:]) + "-" + strconv.FormatUint(id, 10)
+}
+
+// localCachePath generates a local cache file path from a handle key.
+func (m *PkStatsMmapManager) localCachePath(key string) string {
+	return filepath.Join(m.cacheDir, "bf_cache", key)
+}
+
+// mmapFile opens a file and mmaps it read-only.
+func (m *PkStatsMmapManager) mmapFile(path string, size int64) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to open file %s", path)
+	}
+	defer f.Close()
+
+	data, err := unix.Mmap(int(f.Fd()), 0, int(size), unix.PROT_READ, unix.MAP_SHARED)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to mmap file %s", path)
+	}
+
+	return data, nil
+}

--- a/internal/util/bloomfilter/mmap_manager_test.go
+++ b/internal/util/bloomfilter/mmap_manager_test.go
@@ -1,0 +1,253 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package bloomfilter
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPkStatsMmapManager_FileBacked_LoadAndRelease(t *testing.T) {
+	tmpDir := t.TempDir()
+	mgr := NewPkStatsMmapManager(tmpDir, true)
+	defer mgr.Close()
+
+	data := []byte("test bloom filter data for mmap manager")
+
+	handle, err := mgr.Load("remote/path/stats", data)
+	require.NoError(t, err)
+	assert.Equal(t, len(data), len(handle.Data()))
+	assert.Equal(t, string(data), string(handle.Data()))
+	filePath := handle.filePath
+	stat, err := os.Stat(filePath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), stat.Mode().Perm())
+	assert.Equal(t, 1, mgr.ActiveHandles())
+
+	mgr.Release(handle)
+	assert.Nil(t, handle.Data())
+	assert.Equal(t, 0, mgr.ActiveHandles())
+	_, err = os.Stat(filePath)
+	assert.Error(t, err)
+}
+
+func TestPkStatsMmapManager_FileBacked_RepeatedLoadIndependentHandles(t *testing.T) {
+	tmpDir := t.TempDir()
+	mgr := NewPkStatsMmapManager(tmpDir, true)
+	defer mgr.Close()
+
+	data := []byte("test bloom filter data for repeated mmap loads")
+
+	handle1, err := mgr.Load("remote/path/stats", data)
+	require.NoError(t, err)
+	handle2, err := mgr.Load("remote/path/stats", data)
+	require.NoError(t, err)
+	assert.NotEqual(t, handle1.key, handle2.key)
+	assert.NotEqual(t, handle1.filePath, handle2.filePath)
+	assert.Equal(t, 2, mgr.ActiveHandles())
+
+	mgr.Release(handle1)
+	assert.Equal(t, 1, mgr.ActiveHandles())
+	assert.Equal(t, string(data), string(handle2.Data()))
+
+	mgr.Release(handle2)
+	assert.Equal(t, 0, mgr.ActiveHandles())
+}
+
+func TestPkStatsMmapManager_MemoryBacked_LoadAndRelease(t *testing.T) {
+	mgr := NewPkStatsMmapManager("", false)
+	defer mgr.Close()
+
+	data := []byte("test bloom filter data for memory manager")
+
+	handle, err := mgr.Load("remote/path/stats", data)
+	require.NoError(t, err)
+	assert.Equal(t, len(data), len(handle.Data()))
+	assert.Equal(t, string(data), string(handle.Data()))
+	assert.Equal(t, 1, mgr.ActiveHandles())
+
+	mgr.Release(handle)
+	assert.Nil(t, handle.Data())
+	assert.Equal(t, 0, mgr.ActiveHandles())
+}
+
+func TestPkStatsMmapManager_DifferentPaths(t *testing.T) {
+	tmpDir := t.TempDir()
+	mgr := NewPkStatsMmapManager(tmpDir, true)
+	defer mgr.Close()
+
+	data1 := []byte("bloom filter data 1")
+	data2 := []byte("bloom filter data 2 - different content")
+
+	handle1, err := mgr.Load("path/a", data1)
+	require.NoError(t, err)
+
+	handle2, err := mgr.Load("path/b", data2)
+	require.NoError(t, err)
+
+	assert.Equal(t, string(data1), string(handle1.Data()))
+	assert.Equal(t, string(data2), string(handle2.Data()))
+	assert.Equal(t, 2, mgr.ActiveHandles())
+
+	mgr.Release(handle1)
+	mgr.Release(handle2)
+	assert.Equal(t, 0, mgr.ActiveHandles())
+}
+
+func TestPkStatsMmapManager_Concurrent(t *testing.T) {
+	tmpDir := t.TempDir()
+	mgr := NewPkStatsMmapManager(tmpDir, true)
+	defer mgr.Close()
+
+	data := make([]byte, 4096) // Page-aligned
+	for i := range data {
+		data[i] = byte(i % 256)
+	}
+
+	var wg sync.WaitGroup
+	const goroutines = 20
+	handles := make([]*PkStatsMmapHandle, goroutines)
+
+	// Concurrent Load
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			handle, err := mgr.Load("concurrent/path", data)
+			assert.NoError(t, err)
+			assert.Equal(t, len(data), len(handle.Data()))
+			handles[idx] = handle
+		}(i)
+	}
+	wg.Wait()
+	assert.Equal(t, goroutines, mgr.ActiveHandles())
+
+	// Concurrent Release
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(handle *PkStatsMmapHandle) {
+			defer wg.Done()
+			mgr.Release(handle)
+		}(handles[i])
+	}
+	wg.Wait()
+
+	assert.Equal(t, 0, mgr.ActiveHandles())
+}
+
+func TestPkStatsMmapManager_Close(t *testing.T) {
+	tmpDir := t.TempDir()
+	mgr := NewPkStatsMmapManager(tmpDir, true)
+
+	data := []byte("test data")
+	handle1, err := mgr.Load("path1", data)
+	require.NoError(t, err)
+	handle2, err := mgr.Load("path2", data)
+	require.NoError(t, err)
+	assert.Equal(t, 2, mgr.ActiveHandles())
+
+	mgr.Close()
+
+	assert.Equal(t, 0, mgr.ActiveHandles())
+	mgr.Release(handle1)
+	mgr.Release(handle2)
+}
+
+func TestPkStatsMmapManager_ReleaseNonExistent(t *testing.T) {
+	tmpDir := t.TempDir()
+	mgr := NewPkStatsMmapManager(tmpDir, true)
+	defer mgr.Close()
+
+	// Should not panic
+	mgr.Release(nil)
+	mgr.Release(&PkStatsMmapHandle{key: "non/existent/path"})
+}
+
+func TestPkStatsMmapManager_MemoryBacked_RepeatedLoadIndependentHandles(t *testing.T) {
+	mgr := NewPkStatsMmapManager("", false)
+	defer mgr.Close()
+
+	data := []byte("independent bloom filter data")
+
+	handle1, err := mgr.Load("segment/100/stats", data)
+	require.NoError(t, err)
+	handle2, err := mgr.Load("segment/100/stats", data)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, handle1.key, handle2.key)
+	assert.Equal(t, string(handle1.Data()), string(handle2.Data()))
+	assert.Equal(t, 2, mgr.ActiveHandles())
+
+	mgr.Release(handle1)
+	assert.Equal(t, 1, mgr.ActiveHandles())
+	assert.Equal(t, string(data), string(handle2.Data()))
+
+	mgr.Release(handle2)
+	assert.Equal(t, 0, mgr.ActiveHandles())
+}
+
+func TestPkStatsMmapManager_FileBackedFailureBranches(t *testing.T) {
+	tmpDir := t.TempDir()
+	blocker := filepath.Join(tmpDir, "file")
+	require.NoError(t, os.WriteFile(blocker, []byte("not a dir"), 0o600))
+
+	mgr := NewPkStatsMmapManager(blocker, true)
+	_, err := mgr.Load("path/a", []byte("data"))
+	assert.Error(t, err)
+
+	_, err = mgr.mmapFile(filepath.Join(tmpDir, "missing"), 1)
+	assert.Error(t, err)
+
+	emptyFile := filepath.Join(tmpDir, "empty")
+	require.NoError(t, os.WriteFile(emptyFile, nil, 0o600))
+	_, err = mgr.mmapFile(emptyFile, 0)
+	assert.Error(t, err)
+
+	writeErrMgr := NewPkStatsMmapManager(t.TempDir(), true)
+	localPath := writeErrMgr.localCachePath(makeMmapEntryKey("write-error", 1))
+	require.NoError(t, os.MkdirAll(localPath, 0o755))
+	_, err = writeErrMgr.Load("write-error", []byte("data"))
+	assert.Error(t, err)
+
+	mmapErrMgr := NewPkStatsMmapManager(t.TempDir(), true)
+	_, err = mmapErrMgr.Load("empty-data", nil)
+	assert.Error(t, err)
+	assert.Equal(t, 0, mmapErrMgr.ActiveHandles())
+}
+
+func TestPkStatsMmapManager_InvalidMunmapWarnings(t *testing.T) {
+	releaseMgr := NewPkStatsMmapManager(t.TempDir(), true)
+	releaseHandle := &PkStatsMmapHandle{key: "bad-release"}
+	releaseMgr.mappings[releaseHandle.key] = &mmapEntry{
+		data:     []byte("not mmap data"),
+		filePath: filepath.Join(t.TempDir(), "release-cache"),
+	}
+	releaseMgr.Release(releaseHandle)
+	assert.Equal(t, 0, releaseMgr.ActiveHandles())
+
+	closeMgr := NewPkStatsMmapManager(t.TempDir(), true)
+	closeMgr.mappings["bad-close"] = &mmapEntry{
+		data:     []byte("not mmap data"),
+		filePath: filepath.Join(t.TempDir(), "close-cache"),
+	}
+	closeMgr.Close()
+	assert.Equal(t, 0, closeMgr.ActiveHandles())
+}

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -320,6 +320,7 @@ type commonConfig struct {
 	BloomFilterType           ParamItem `refreshable:"true"`
 	MaxBloomFalsePositive     ParamItem `refreshable:"true"`
 	BloomFilterApplyBatchSize ParamItem `refreshable:"true"`
+	BloomFilterMmapEnabled    ParamItem `refreshable:"false"`
 	PanicWhenPluginFail       ParamItem `refreshable:"false"`
 
 	UsePartitionKeyAsClusteringKey ParamItem `refreshable:"true"`
@@ -1232,6 +1233,15 @@ The default value is 1, which is enough for most cases.`,
 		},
 	}
 	p.BloomFilterApplyBatchSize.Init(base.mgr)
+
+	p.BloomFilterMmapEnabled = ParamItem{
+		Key:          "common.bloomFilterMmapEnabled",
+		Version:      "2.5.6",
+		DefaultValue: "false",
+		Doc:          "if true, mmap PK stats bloom filter data from local cache files; otherwise keep binary stats memory-backed",
+		Export:       true,
+	}
+	p.BloomFilterMmapEnabled.Init(base.mgr)
 
 	p.PanicWhenPluginFail = ParamItem{
 		Key:          "common.panicWhenPluginFail",


### PR DESCRIPTION
issue: #48486

Previously each segment's bloom filter was deserialized independently for the delegator and the segment loader, resulting in two full heap copies per segment and two S3 downloads of the same data.

This commit introduces a ref-counted PkStatsMmapManager that deduplicates bloom filter data across callers. It supports two modes controlled by common.bloomFilterMmapEnabled:

- false (default): memory-backed — data stays on Go heap but is shared via ref-counting, halving BF memory with zero configuration
- true: file-backed — data is written to a local file and mmap'd, both deduplicating AND moving BF data off the Go heap entirely