### PR TITLE
fix: remove manual bucket name concatenation in deltalog reader

### DIFF
--- a/internal/storage/rw.go
+++ b/internal/storage/rw.go
@@ -21,7 +21,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"path/filepath"
 	"sort"
 
 	"github.com/samber/lo"
@@ -491,13 +490,6 @@ func NewDeltalogReader(
 				},
 			},
 		}
-		bucketName := rwOptions.storageConfig.BucketName
-		paths = lo.Map(paths, func(path string, _ int) string {
-			if rwOptions.storageConfig.StorageType != "local" {
-				return filepath.Join(bucketName, path)
-			}
-			return path
-		})
 		return &IterativeRecordReader{
 			iterate: func() (RecordReader, error) {
 				if pathPos >= len(paths) {


### PR DESCRIPTION
Related to #44956
Previous PR #45279 #48095

The bucket name prefix should be handled by the storage layer automatically, not manually concatenated in the deltalog reader paths.