### PR TITLE
enhance: reduce memory allocations in BM25Stats.Deserialize

### DIFF
--- a/internal/storage/stats.go
+++ b/internal/storage/stats.go
@@ -463,24 +463,21 @@ func (m *BM25Stats) Deserialize(bs []byte) error {
 		return err
 	}
 
-	var keys []uint32 = make([]uint32, dim)
-	var values []int32 = make([]int32, dim)
+	var key uint32
+	var value int32
 	for i := 0; i < dim; i++ {
-		if err := binary.Read(buffer, common.Endian, &keys[i]); err != nil {
+		if err := binary.Read(buffer, common.Endian, &key); err != nil {
 			return err
 		}
 
-		if err := binary.Read(buffer, common.Endian, &values[i]); err != nil {
+		if err := binary.Read(buffer, common.Endian, &value); err != nil {
 			return err
 		}
+		m.rowsWithToken[key] += value
 	}
 
 	m.numRow += numRow
 	m.numToken += tokenNum
-	for i := 0; i < dim; i++ {
-		m.rowsWithToken[keys[i]] += values[i]
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
enhance: reduce transient memory allocations in BM25Stats.Deserialize

issue: #48176

## Summary

- Remove two O(N) temporary slices (`keys []uint32`, `values []int32`) in `BM25Stats.Deserialize`
- Read key/value directly into scalar variables and write to the map in one pass
- No behavioral change; eliminates `2 × dim × 4` bytes of short-lived allocation per call

## Background

`Deserialize` is called from `FetchStats()` inside `SyncDistribution()` on streamingnode delegators. With large BM25 collections (119M rows, 119 sealed segments), each sync that activates segments triggers these redundant allocations, causing transient heap spikes observed in production monitoring.

## Test plan

- [ ] Existing `TestBM25Stats` unit tests pass
- [ ] Manual verification: serialize → deserialize round-trip produces identical results