### PR TITLE
enhance: [2.6] add async warmup policy support for caching layer

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -487,9 +487,10 @@ queryNode:
     enableGeometryCache: false # Enable geometry cache for geometry data
     tieredStorage:
       warmup:
-        # options: sync, disable.
+        # options: sync, async, disable.
         # Specifies the timing for warming up the Tiered Storage cache.
         # - "sync": data will be loaded into the cache before a segment is considered loaded.
+        # - "async": data will be loaded into the cache asynchronously in the background after a segment is loaded.
         # - "disable": data will not be proactively loaded into the cache, and loaded only if needed by search/query tasks.
         # Defaults to "sync", except for vector field which defaults to "disable".
         scalarField: sync

--- a/internal/core/src/common/LoadInfo.h
+++ b/internal/core/src/common/LoadInfo.h
@@ -31,7 +31,7 @@ struct FieldBinlogInfo {
     // estimated memory size for each binlog file, in bytes, used by caching layer
     std::vector<int64_t> memory_sizes;
     bool enable_mmap{false};
-    // "disable" or "sync", empty means use global config
+    // "disable", "sync", or "async"; empty means use global config
     std::string warmup_policy;
     std::vector<std::string> insert_files;
     std::vector<int64_t> child_field_ids;

--- a/internal/core/src/common/Schema.h
+++ b/internal/core/src/common/Schema.h
@@ -456,7 +456,7 @@ class Schema {
     std::unordered_map<FieldId, bool> mmap_fields_;
 
     // warmup policy settings
-    // Valid values: "disable", "sync" (empty string means no setting)
+    // Valid values: "disable", "sync", "async" (empty string means no setting)
     // Collection-level warmup policies for different data types
     std::optional<std::string> warmup_vector_index_ = std::nullopt;
     std::optional<std::string> warmup_scalar_index_ = std::nullopt;

--- a/internal/core/src/mmap/ChunkedColumn.h
+++ b/internal/core/src/mmap/ChunkedColumn.h
@@ -126,7 +126,14 @@ class ChunkedColumnBase : public ChunkedColumnInterface {
         num_rows_ = GetNumRowsUntilChunk().back();
     }
 
-    virtual ~ChunkedColumnBase() = default;
+    virtual ~ChunkedColumnBase() {
+        slot_->CancelWarmup();
+    }
+
+    void
+    CancelWarmup() override {
+        slot_->CancelWarmup();
+    }
 
     PinWrapper<const char*>
     DataOfChunk(milvus::OpContext* op_ctx, int chunk_id) const override {

--- a/internal/core/src/mmap/ChunkedColumnGroup.h
+++ b/internal/core/src/mmap/ChunkedColumnGroup.h
@@ -53,7 +53,14 @@ class ChunkedColumnGroup {
         num_rows_ = GetNumRowsUntilChunk().back();
     }
 
-    virtual ~ChunkedColumnGroup() = default;
+    virtual ~ChunkedColumnGroup() {
+        slot_->CancelWarmup();
+    }
+
+    void
+    CancelWarmup() {
+        slot_->CancelWarmup();
+    }
 
     // Get the number of group chunks
     size_t
@@ -179,9 +186,20 @@ class ProxyChunkColumn : public ChunkedColumnInterface {
           data_type_(field_meta.get_data_type()) {
     }
 
+    ~ProxyChunkColumn() override {
+        CancelWarmup();
+    }
+
     bool
     IsInMultiFieldColumnGroup() const override {
         return group_->NumFieldsInGroup() > 1;
+    }
+
+    void
+    CancelWarmup() override {
+        if (group_->NumFieldsInGroup() == 1) {
+            group_->CancelWarmup();
+        }
     }
 
     PinWrapper<const char*>

--- a/internal/core/src/mmap/ChunkedColumnInterface.h
+++ b/internal/core/src/mmap/ChunkedColumnInterface.h
@@ -34,6 +34,12 @@ class ChunkedColumnInterface {
         return false;
     }
 
+    // Cancel any pending async warmup for this column's cache slot.
+    // Default implementation does nothing.
+    virtual void
+    CancelWarmup() {
+    }
+
     // Get raw data pointer of a specific chunk
     virtual cachinglayer::PinWrapper<const char*>
     DataOfChunk(milvus::OpContext* op_ctx, int chunk_id) const = 0;

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -975,6 +975,7 @@ ChunkedSegmentSealedImpl::drop_field_data_locked(const FieldId field_id) {
                 id_);
             return;
         }
+        fields_.rlock()->at(field_id)->CancelWarmup();
         fields_.wlock()->erase(field_id);
         set_bit(field_data_ready_bitset_, field_id, false);
     }
@@ -2929,7 +2930,7 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
     bool has_mmap_setting = false;
     bool mmap_enabled = false;
     bool has_warmup_setting = false;
-    bool warmup_sync = false;
+    std::string aggregated_warmup_policy = "disable";
     for (auto& [field_id, field_meta] : field_metas) {
         if (IsVectorDataType(field_meta.get_data_type())) {
             is_vector = true;
@@ -2947,21 +2948,26 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
 
         // if field has warmup setting, use it
         // - warmup setting at collection level, uses appropriate key based on field type
-        // - warmup setting at field level, use the most aggressive policy (sync > disable)
+        // - warmup setting at field level, use the most aggressive policy (sync > async > disable)
         // Note: this is for field data loading, not index (is_index = false)
         bool field_is_vector = IsVectorDataType(field_meta.get_data_type());
         auto [field_has_warmup, field_warmup_policy] = schema_->WarmupPolicy(
             field_id, field_is_vector, /*is_index=*/false);
         if (field_has_warmup) {
             has_warmup_setting = true;
-            warmup_sync = warmup_sync || (field_warmup_policy == "sync");
+            if (field_warmup_policy == "sync") {
+                aggregated_warmup_policy = "sync";
+            } else if (field_warmup_policy == "async" &&
+                       aggregated_warmup_policy != "sync") {
+                aggregated_warmup_policy = "async";
+            }
         }
     }
 
     // Determine warmup policy: use per-field settings if any,
     // otherwise pass empty string to fall back to global config
     std::string warmup_policy =
-        has_warmup_setting ? (warmup_sync ? "sync" : "disable") : "";
+        has_warmup_setting ? aggregated_warmup_policy : "";
 
     auto& mmap_config = storage::MmapManager::GetInstance().GetMmapConfig();
     bool global_use_mmap = is_vector ? mmap_config.GetVectorFieldEnableMmap()
@@ -3142,7 +3148,7 @@ ChunkedSegmentSealedImpl::LoadBatchFieldData(
         bool is_vector = false;
 
         bool has_warmup_setting = false;
-        bool warmup_sync = false;
+        std::string aggregated_warmup_policy = "disable";
         for (const auto& child_field_id : field_ids) {
             auto& field_meta = schema_->operator[](child_field_id);
             if (IsVectorDataType(field_meta.get_data_type())) {
@@ -3171,7 +3177,12 @@ ChunkedSegmentSealedImpl::LoadBatchFieldData(
                     /*is_index=*/false);
             if (field_has_warmup) {
                 has_warmup_setting = true;
-                warmup_sync = warmup_sync || (field_warmup_policy == "sync");
+                if (field_warmup_policy == "sync") {
+                    aggregated_warmup_policy = "sync";
+                } else if (field_warmup_policy == "async" &&
+                           aggregated_warmup_policy != "sync") {
+                    aggregated_warmup_policy = "async";
+                }
             }
         }
 
@@ -3215,7 +3226,7 @@ ChunkedSegmentSealedImpl::LoadBatchFieldData(
         // Determine group warmup policy: use per-field settings if any,
         // otherwise fall back to global warmup policy
         field_binlog_info.warmup_policy =
-            has_warmup_setting ? (warmup_sync ? "sync" : "disable") : "";
+            has_warmup_setting ? aggregated_warmup_policy : "";
 
         // Store in map
         load_field_data_info.field_infos[group_id] = field_binlog_info;

--- a/internal/core/src/segcore/SealedIndexingRecord.h
+++ b/internal/core/src/segcore/SealedIndexingRecord.h
@@ -54,7 +54,13 @@ struct SealedIndexingRecord {
     void
     drop_field_indexing(FieldId field_id) {
         std::unique_lock lck(mutex_);
-        field_indexings_.erase(field_id);
+        auto it = field_indexings_.find(field_id);
+        if (it != field_indexings_.end()) {
+            if (it->second && it->second->indexing_) {
+                it->second->indexing_->CancelWarmup();
+            }
+            field_indexings_.erase(it);
+        }
     }
 
     bool
@@ -66,6 +72,11 @@ struct SealedIndexingRecord {
     void
     clear() {
         std::unique_lock lck(mutex_);
+        for (auto& [_, entry] : field_indexings_) {
+            if (entry && entry->indexing_) {
+                entry->indexing_->CancelWarmup();
+            }
+        }
         field_indexings_.clear();
     }
 

--- a/internal/core/src/segcore/Types.h
+++ b/internal/core/src/segcore/Types.h
@@ -57,7 +57,7 @@ struct LoadIndexInfo {
     int64_t num_rows;
     int64_t dim;
     std::string
-        warmup_policy;  // "disable" or "sync", empty means use global config
+        warmup_policy;  // "disable", "sync", or "async"; empty means use global config
 
     // Default constructor
     LoadIndexInfo() = default;

--- a/internal/core/src/segcore/Utils.cpp
+++ b/internal/core/src/segcore/Utils.cpp
@@ -1198,6 +1198,8 @@ getCacheWarmupPolicy(const std::string& warmup_policy,
             return CacheWarmupPolicy::CacheWarmupPolicy_Disable;
         } else if (warmup_policy == "sync") {
             return CacheWarmupPolicy::CacheWarmupPolicy_Sync;
+        } else if (warmup_policy == "async") {
+            return CacheWarmupPolicy::CacheWarmupPolicy_Async;
         }
         // Unknown policy string, should not happen, been checked by milvus proxy side
         AssertInfo(false, "Unknown warmup policy '{}'", warmup_policy);

--- a/internal/core/src/segcore/load_field_data_c.cpp
+++ b/internal/core/src/segcore/load_field_data_c.cpp
@@ -127,6 +127,8 @@ WarmupPolicyToString(CacheWarmupPolicy policy) {
     switch (policy) {
         case CacheWarmupPolicy_Sync:
             return "sync";
+        case CacheWarmupPolicy_Async:
+            return "async";
         case CacheWarmupPolicy_Disable:
             return "disable";
         default:

--- a/internal/core/src/segcore/segcore_init_c.cpp
+++ b/internal/core/src/segcore/segcore_init_c.cpp
@@ -220,7 +220,8 @@ ConfigureTieredStorage(const CacheWarmupPolicy scalarFieldCacheWarmupPolicy,
                        const float loading_resource_factor,
                        const float max_disk_usage_percentage,
                        const char* disk_path,
-                       const int64_t loading_timeout_ms) {
+                       const int64_t loading_timeout_ms,
+                       const uint32_t prefetch_pool_threads) {
     std::string disk_path_str(disk_path);
     milvus::cachinglayer::Manager::ConfigureTieredStorage(
         {scalarFieldCacheWarmupPolicy,
@@ -243,7 +244,8 @@ ConfigureTieredStorage(const CacheWarmupPolicy scalarFieldCacheWarmupPolicy,
          max_disk_usage_percentage,
          disk_path_str,
          loading_resource_factor},
-        std::chrono::milliseconds(loading_timeout_ms));
+        std::chrono::milliseconds(loading_timeout_ms),
+        prefetch_pool_threads);
 }
 
 }  // namespace milvus::segcore

--- a/internal/core/src/segcore/segcore_init_c.h
+++ b/internal/core/src/segcore/segcore_init_c.h
@@ -125,7 +125,9 @@ ConfigureTieredStorage(
     const float loading_resource_factor,
     const float max_disk_usage_percentage,
     const char* disk_path,
-    const int64_t loading_timeout_ms);
+    const int64_t loading_timeout_ms,
+    // async warmup prefetch pool threads
+    const uint32_t prefetch_pool_threads);
 
 #ifdef __cplusplus
 }

--- a/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.h
+++ b/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.h
@@ -71,7 +71,7 @@ class SealedIndexTranslator
         int64_t num_rows;
         int64_t dim;
         std::string
-            warmup_policy;  // "disable" or "sync", empty means use global config
+            warmup_policy;  // "disable", "sync", or "async"; empty means use global config
     };
 
     milvus::index::CreateIndexInfo index_info_;

--- a/internal/core/src/segcore/storagev1translator/TextMatchIndexTranslator.h
+++ b/internal/core/src/segcore/storagev1translator/TextMatchIndexTranslator.h
@@ -30,7 +30,7 @@ struct TextMatchIndexLoadInfo {
     std::string analyzer_params;
     int64_t index_size;
     std::string
-        warmup_policy;  // "disable" or "sync", empty means use global config
+        warmup_policy;  // "disable", "sync", or "async"; empty means use global config
 };
 
 // Translator for TextMatchIndex (non-knowhere index). It loads a single-cell

--- a/internal/core/src/segcore/storagev2translator/JsonStatsTranslator.h
+++ b/internal/core/src/segcore/storagev2translator/JsonStatsTranslator.h
@@ -30,7 +30,7 @@ struct JsonStatsLoadInfo {
     int64_t field_id;
     int64_t stats_size;
     std::string
-        warmup_policy;  // "disable" or "sync", empty means use global config
+        warmup_policy;  // "disable", "sync", or "async"; empty means use global config
 };
 
 // Translator for JSON Key Stats (non-knowhere index). It loads a single-cell

--- a/internal/core/thirdparty/knowhere/CMakeLists.txt
+++ b/internal/core/thirdparty/knowhere/CMakeLists.txt
@@ -14,7 +14,7 @@
 # Update KNOWHERE_VERSION for the first occurrence
 milvus_add_pkg_config("knowhere")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( KNOWHERE_VERSION v2.6.10 )
+set( KNOWHERE_VERSION b20270c )
 set( GIT_REPOSITORY  "https://github.com/zilliztech/knowhere.git")
 
 message(STATUS "Knowhere repo: ${GIT_REPOSITORY}")

--- a/internal/core/thirdparty/milvus-common/CMakeLists.txt
+++ b/internal/core/thirdparty/milvus-common/CMakeLists.txt
@@ -13,7 +13,7 @@
 
 milvus_add_pkg_config("milvus-common")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( MILVUS-COMMON-VERSION f192a19 )
+set( MILVUS-COMMON-VERSION e16257c )
 set( GIT_REPOSITORY "https://github.com/zilliztech/milvus-common.git")
 
 message(STATUS "milvus-common repo: ${GIT_REPOSITORY}")

--- a/internal/core/unittest/test_async_warmup.cpp
+++ b/internal/core/unittest/test_async_warmup.cpp
@@ -1,0 +1,177 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+// Unit tests for the async-warmup cancellation integration:
+//   SealedIndexingRecord::drop_field_indexing() and ::clear() must call
+//   CancelWarmup() on every evicted CacheSlot before releasing the pointer.
+
+#include <memory>
+#include <string>
+
+#include <gtest/gtest.h>
+#include <knowhere/comp/index_param.h>
+
+#include "common/Tracer.h"
+#include "common/Types.h"
+#include "index/Index.h"
+#include "index/IndexStats.h"
+#include "segcore/SealedIndexingRecord.h"
+#include "test_utils/cachinglayer_test_utils.h"
+
+// ─── Minimal IndexBase stub ───────────────────────────────────────────────────
+// Lives in milvus::index so it can use the type aliases (BinarySet, Config,
+// DatasetPtr) that common/Types.h injects into the milvus:: namespace and
+// that are visible in milvus::index:: as an enclosing namespace.
+
+namespace milvus::index {
+
+class StubIndex : public IndexBase {
+ public:
+    StubIndex() : IndexBase("STUB") {
+    }
+
+    BinarySet
+    Serialize(const Config& /*config*/) override {
+        return {};
+    }
+
+    void
+    Load(const BinarySet& /*binary_set*/,
+         const Config& /*config*/ = {}) override {
+    }
+
+    void
+    Load(milvus::tracer::TraceContext /*ctx*/,
+         const Config& /*config*/ = {}) override {
+    }
+
+    void
+    BuildWithRawDataForUT(size_t /*n*/,
+                          const void* /*values*/,
+                          const Config& /*config*/ = {}) override {
+    }
+
+    void
+    BuildWithDataset(const DatasetPtr& /*dataset*/,
+                     const Config& /*config*/ = {}) override {
+    }
+
+    void
+    Build(const Config& /*config*/ = {}) override {
+    }
+
+    int64_t
+    Count() override {
+        return 0;
+    }
+
+    IndexStatsPtr
+    Upload(const Config& /*config*/ = {}) override {
+        return nullptr;
+    }
+
+    const bool
+    HasRawData() const override {
+        return false;
+    }
+
+    bool
+    IsMmapSupported() const override {
+        return false;
+    }
+};
+
+}  // namespace milvus::index
+
+// ─── Helper ──────────────────────────────────────────────────────────────────
+
+namespace {
+
+milvus::index::CacheIndexBasePtr
+MakeStubCacheIndex(const std::string& key) {
+    return milvus::CreateTestCacheIndex(
+        key, std::make_unique<milvus::index::StubIndex>());
+}
+
+}  // namespace
+
+// ─── SealedIndexingRecord tests ──────────────────────────────────────────────
+
+using milvus::FieldId;
+using milvus::segcore::SealedIndexingRecord;
+
+class SealedIndexingRecordTest : public ::testing::Test {
+ protected:
+    SealedIndexingRecord record_;
+};
+
+// After append + drop, is_ready() must return false.
+TEST_F(SealedIndexingRecordTest, DropFieldIndexingRemovesEntry) {
+    const FieldId fid{100};
+    record_.append_field_indexing(
+        fid, knowhere::metric::L2, MakeStubCacheIndex("key-drop-1"));
+
+    ASSERT_TRUE(record_.is_ready(fid));
+
+    record_.drop_field_indexing(fid);
+    ASSERT_FALSE(record_.is_ready(fid));
+}
+
+// Dropping the same field twice must not crash (idempotent).
+TEST_F(SealedIndexingRecordTest, DropFieldIndexingIsIdempotent) {
+    const FieldId fid{101};
+    record_.append_field_indexing(
+        fid, knowhere::metric::L2, MakeStubCacheIndex("key-drop-2"));
+    record_.drop_field_indexing(fid);
+    ASSERT_NO_THROW(record_.drop_field_indexing(fid));
+}
+
+// Dropping a field that was never appended must be a no-op.
+TEST_F(SealedIndexingRecordTest, DropNonexistentFieldIsNoOp) {
+    ASSERT_NO_THROW(record_.drop_field_indexing(FieldId{999}));
+}
+
+// clear() must remove all entries.
+TEST_F(SealedIndexingRecordTest, ClearRemovesAllEntries) {
+    const FieldId fid1{200}, fid2{201}, fid3{202};
+    record_.append_field_indexing(
+        fid1, knowhere::metric::L2, MakeStubCacheIndex("key-clear-1"));
+    record_.append_field_indexing(
+        fid2, knowhere::metric::IP, MakeStubCacheIndex("key-clear-2"));
+    record_.append_field_indexing(
+        fid3, knowhere::metric::COSINE, MakeStubCacheIndex("key-clear-3"));
+
+    ASSERT_TRUE(record_.is_ready(fid1));
+    ASSERT_TRUE(record_.is_ready(fid2));
+    ASSERT_TRUE(record_.is_ready(fid3));
+
+    record_.clear();
+
+    ASSERT_FALSE(record_.is_ready(fid1));
+    ASSERT_FALSE(record_.is_ready(fid2));
+    ASSERT_FALSE(record_.is_ready(fid3));
+}
+
+// clear() on an empty record must be a no-op.
+TEST_F(SealedIndexingRecordTest, ClearEmptyRecordIsNoOp) {
+    ASSERT_NO_THROW(record_.clear());
+}
+
+// Replacing a field's index must not crash: CancelWarmup fires on the old
+// slot before its shared_ptr drops to zero.
+TEST_F(SealedIndexingRecordTest, AppendReplaceExistingEntryNocrash) {
+    const FieldId fid{300};
+    record_.append_field_indexing(
+        fid, knowhere::metric::L2, MakeStubCacheIndex("key-replace-old"));
+    ASSERT_NO_THROW(record_.append_field_indexing(
+        fid, knowhere::metric::L2, MakeStubCacheIndex("key-replace-new")));
+    ASSERT_TRUE(record_.is_ready(fid));
+}

--- a/internal/querynodev2/segments/utils_test.go
+++ b/internal/querynodev2/segments/utils_test.go
@@ -228,6 +228,16 @@ func TestGetFieldWarmupPolicy(t *testing.T) {
 		assert.Equal(t, common.WarmupDisable, policy)
 	})
 
+	t.Run("async policy in TypeParams is returned", func(t *testing.T) {
+		policy := getFieldWarmupPolicy(&schemapb.FieldSchema{
+			DataType: schemapb.DataType_String,
+			TypeParams: []*commonpb.KeyValuePair{
+				{Key: common.WarmupKey, Value: common.WarmupAsync},
+			},
+		})
+		assert.Equal(t, common.WarmupAsync, policy)
+	})
+
 	t.Run("fallback to global config for scalar field", func(t *testing.T) {
 		paramtable.Get().Save(paramtable.Get().QueryNodeCfg.TieredWarmupScalarField.Key, common.WarmupSync)
 		defer paramtable.Get().Reset(paramtable.Get().QueryNodeCfg.TieredWarmupScalarField.Key)
@@ -237,6 +247,15 @@ func TestGetFieldWarmupPolicy(t *testing.T) {
 		assert.Equal(t, common.WarmupSync, policy)
 	})
 
+	t.Run("fallback to global config for scalar field async", func(t *testing.T) {
+		paramtable.Get().Save(paramtable.Get().QueryNodeCfg.TieredWarmupScalarField.Key, common.WarmupAsync)
+		defer paramtable.Get().Reset(paramtable.Get().QueryNodeCfg.TieredWarmupScalarField.Key)
+		policy := getFieldWarmupPolicy(&schemapb.FieldSchema{
+			DataType: schemapb.DataType_String,
+		})
+		assert.Equal(t, common.WarmupAsync, policy)
+	})
+
 	t.Run("fallback to global config for vector field", func(t *testing.T) {
 		paramtable.Get().Save(paramtable.Get().QueryNodeCfg.TieredWarmupVectorField.Key, common.WarmupDisable)
 		defer paramtable.Get().Reset(paramtable.Get().QueryNodeCfg.TieredWarmupVectorField.Key)
@@ -244,6 +263,15 @@ func TestGetFieldWarmupPolicy(t *testing.T) {
 			DataType: schemapb.DataType_FloatVector,
 		})
 		assert.Equal(t, common.WarmupDisable, policy)
+	})
+
+	t.Run("fallback to global config for vector field async", func(t *testing.T) {
+		paramtable.Get().Save(paramtable.Get().QueryNodeCfg.TieredWarmupVectorField.Key, common.WarmupAsync)
+		defer paramtable.Get().Reset(paramtable.Get().QueryNodeCfg.TieredWarmupVectorField.Key)
+		policy := getFieldWarmupPolicy(&schemapb.FieldSchema{
+			DataType: schemapb.DataType_FloatVector,
+		})
+		assert.Equal(t, common.WarmupAsync, policy)
 	})
 }
 
@@ -274,6 +302,18 @@ func TestGetIndexWarmupPolicy(t *testing.T) {
 		assert.Equal(t, common.WarmupDisable, policy)
 	})
 
+	t.Run("async policy in index params is returned", func(t *testing.T) {
+		policy := getIndexWarmupPolicy(
+			&schemapb.FieldSchema{DataType: schemapb.DataType_String},
+			&querypb.FieldIndexInfo{
+				IndexParams: []*commonpb.KeyValuePair{
+					{Key: common.WarmupKey, Value: common.WarmupAsync},
+				},
+			},
+		)
+		assert.Equal(t, common.WarmupAsync, policy)
+	})
+
 	t.Run("fallback to global config for scalar index", func(t *testing.T) {
 		paramtable.Get().Save(paramtable.Get().QueryNodeCfg.TieredWarmupScalarIndex.Key, common.WarmupSync)
 		defer paramtable.Get().Reset(paramtable.Get().QueryNodeCfg.TieredWarmupScalarIndex.Key)
@@ -282,6 +322,16 @@ func TestGetIndexWarmupPolicy(t *testing.T) {
 			&querypb.FieldIndexInfo{},
 		)
 		assert.Equal(t, common.WarmupSync, policy)
+	})
+
+	t.Run("fallback to global config for scalar index async", func(t *testing.T) {
+		paramtable.Get().Save(paramtable.Get().QueryNodeCfg.TieredWarmupScalarIndex.Key, common.WarmupAsync)
+		defer paramtable.Get().Reset(paramtable.Get().QueryNodeCfg.TieredWarmupScalarIndex.Key)
+		policy := getIndexWarmupPolicy(
+			&schemapb.FieldSchema{DataType: schemapb.DataType_String},
+			&querypb.FieldIndexInfo{},
+		)
+		assert.Equal(t, common.WarmupAsync, policy)
 	})
 
 	t.Run("fallback to global config for vector index", func(t *testing.T) {
@@ -293,12 +343,62 @@ func TestGetIndexWarmupPolicy(t *testing.T) {
 		)
 		assert.Equal(t, common.WarmupDisable, policy)
 	})
+
+	t.Run("fallback to global config for vector index async", func(t *testing.T) {
+		paramtable.Get().Save(paramtable.Get().QueryNodeCfg.TieredWarmupVectorIndex.Key, common.WarmupAsync)
+		defer paramtable.Get().Reset(paramtable.Get().QueryNodeCfg.TieredWarmupVectorIndex.Key)
+		policy := getIndexWarmupPolicy(
+			&schemapb.FieldSchema{DataType: schemapb.DataType_FloatVector},
+			&querypb.FieldIndexInfo{},
+		)
+		assert.Equal(t, common.WarmupAsync, policy)
+	})
 }
 
 func TestGetScalarDataWarmupPolicy(t *testing.T) {
 	paramtable.Init()
 
-	t.Run("field TypeParams has warmup", func(t *testing.T) {
+	t.Run("TypeParams warmup key takes priority over global config", func(t *testing.T) {
+		paramtable.Get().Save(paramtable.Get().QueryNodeCfg.TieredWarmupScalarField.Key, common.WarmupSync)
+		defer paramtable.Get().Reset(paramtable.Get().QueryNodeCfg.TieredWarmupScalarField.Key)
+		policy := getScalarDataWarmupPolicy(&schemapb.FieldSchema{
+			DataType: schemapb.DataType_String,
+			TypeParams: []*commonpb.KeyValuePair{
+				{Key: common.WarmupKey, Value: common.WarmupDisable},
+			},
+		})
+		assert.Equal(t, common.WarmupDisable, policy)
+	})
+
+	t.Run("async in TypeParams is returned", func(t *testing.T) {
+		policy := getScalarDataWarmupPolicy(&schemapb.FieldSchema{
+			DataType: schemapb.DataType_String,
+			TypeParams: []*commonpb.KeyValuePair{
+				{Key: common.WarmupKey, Value: common.WarmupAsync},
+			},
+		})
+		assert.Equal(t, common.WarmupAsync, policy)
+	})
+
+	t.Run("fallback to global scalar field config async", func(t *testing.T) {
+		paramtable.Get().Save(paramtable.Get().QueryNodeCfg.TieredWarmupScalarField.Key, common.WarmupAsync)
+		defer paramtable.Get().Reset(paramtable.Get().QueryNodeCfg.TieredWarmupScalarField.Key)
+		policy := getScalarDataWarmupPolicy(&schemapb.FieldSchema{
+			DataType: schemapb.DataType_String,
+		})
+		assert.Equal(t, common.WarmupAsync, policy)
+	})
+
+	t.Run("fallback to global scalar field config disable", func(t *testing.T) {
+		paramtable.Get().Save(paramtable.Get().QueryNodeCfg.TieredWarmupScalarField.Key, common.WarmupDisable)
+		defer paramtable.Get().Reset(paramtable.Get().QueryNodeCfg.TieredWarmupScalarField.Key)
+		policy := getScalarDataWarmupPolicy(&schemapb.FieldSchema{
+			DataType: schemapb.DataType_String,
+		})
+		assert.Equal(t, common.WarmupDisable, policy)
+	})
+
+	t.Run("field TypeParams has warmup sync", func(t *testing.T) {
 		policy := getScalarDataWarmupPolicy(&schemapb.FieldSchema{
 			DataType: schemapb.DataType_String,
 			TypeParams: []*commonpb.KeyValuePair{
@@ -308,7 +408,7 @@ func TestGetScalarDataWarmupPolicy(t *testing.T) {
 		assert.Equal(t, common.WarmupSync, policy)
 	})
 
-	t.Run("fallback to global config", func(t *testing.T) {
+	t.Run("fallback to global config sync", func(t *testing.T) {
 		paramtable.Get().Save(paramtable.Get().QueryNodeCfg.TieredWarmupScalarField.Key, common.WarmupSync)
 		defer paramtable.Get().Reset(paramtable.Get().QueryNodeCfg.TieredWarmupScalarField.Key)
 		policy := getScalarDataWarmupPolicy(&schemapb.FieldSchema{

--- a/internal/util/initcore/init_core.go
+++ b/internal/util/initcore/init_core.go
@@ -294,6 +294,8 @@ func ConvertCacheWarmupPolicy(policy string) (C.CacheWarmupPolicy, error) {
 	switch policy {
 	case "sync":
 		return C.CacheWarmupPolicy_Sync, nil
+	case "async":
+		return C.CacheWarmupPolicy_Async, nil
 	case "disable":
 		return C.CacheWarmupPolicy_Disable, nil
 	default:
@@ -379,6 +381,8 @@ func InitTieredStorage(params *paramtable.ComponentParam) error {
 	diskPath := C.CString(params.LocalStorageCfg.Path.GetValue())
 	defer C.free(unsafe.Pointer(diskPath))
 
+	prefetchPoolThreads := C.uint32_t(hardware.GetCPUNum() * params.CommonCfg.LowPriorityThreadCoreCoefficient.GetAsInt())
+
 	C.ConfigureTieredStorage(scalarFieldCacheWarmupPolicy,
 		vectorFieldCacheWarmupPolicy,
 		scalarIndexCacheWarmupPolicy,
@@ -388,7 +392,8 @@ func InitTieredStorage(params *paramtable.ComponentParam) error {
 		storageUsageTrackingEnabled,
 		evictionEnabled, cacheTouchWindowMs,
 		backgroundEvictionEnabled, evictionIntervalMs, cacheCellUnaccessedSurvivalTime,
-		overloadedMemoryThresholdPercentage, loadingResourceFactor, maxDiskUsagePercentage, diskPath, loadingTimeoutMs)
+		overloadedMemoryThresholdPercentage, loadingResourceFactor, maxDiskUsagePercentage, diskPath, loadingTimeoutMs,
+		prefetchPoolThreads)
 
 	tieredEvictableMemoryCacheRatio := params.QueryNodeCfg.TieredEvictableMemoryCacheRatio.GetAsFloat()
 	tieredEvictableDiskCacheRatio := params.QueryNodeCfg.TieredEvictableDiskCacheRatio.GetAsFloat()

--- a/internal/util/segcore/requests.go
+++ b/internal/util/segcore/requests.go
@@ -49,7 +49,7 @@ type LoadFieldDataRequest struct {
 type LoadFieldDataInfo struct {
 	Field        *datapb.FieldBinlog
 	EnableMMap   bool
-	WarmupPolicy string // Per-field warmup policy: "disable", "sync", or empty for default
+	WarmupPolicy string // Per-field warmup policy: "disable", "sync", "async", or empty for default
 }
 
 func (req *LoadFieldDataRequest) getCLoadFieldDataRequest() (result *cLoadFieldDataRequest, err error) {

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -272,6 +272,7 @@ const (
 	WarmupVectorIndexKey = "warmup.vectorIndex"
 	WarmupDisable        = "disable"
 	WarmupSync           = "sync"
+	WarmupAsync          = "async"
 )
 
 const (
@@ -355,8 +356,8 @@ func IsCollectionWarmupKey(key string) bool {
 
 // ValidateWarmupPolicy validates that the warmup policy value is valid
 func ValidateWarmupPolicy(value string) error {
-	if value != WarmupDisable && value != WarmupSync {
-		return fmt.Errorf("invalid warmup policy: %s, must be '%s' or '%s'", value, WarmupDisable, WarmupSync)
+	if value != WarmupDisable && value != WarmupSync && value != WarmupAsync {
+		return fmt.Errorf("invalid warmup policy: %s, must be '%s', '%s' or '%s'", value, WarmupDisable, WarmupSync, WarmupAsync)
 	}
 	return nil
 }

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -424,11 +424,11 @@ func TestWarmupPolicy(t *testing.T) {
 		// Valid values
 		assert.NoError(t, ValidateWarmupPolicy(WarmupSync))
 		assert.NoError(t, ValidateWarmupPolicy(WarmupDisable))
+		assert.NoError(t, ValidateWarmupPolicy(WarmupAsync))
 
 		// Invalid values
 		assert.Error(t, ValidateWarmupPolicy("invalid"))
 		assert.Error(t, ValidateWarmupPolicy(""))
-		assert.Error(t, ValidateWarmupPolicy("async"))
 	})
 
 	t.Run("IsWarmupKey", func(t *testing.T) {

--- a/pkg/proto/index_cgo_msg.proto
+++ b/pkg/proto/index_cgo_msg.proto
@@ -122,7 +122,7 @@ message LoadTextIndexInfo {
   common.LoadPriority load_priority = 8;
   bool enable_mmap = 9;
   int64 index_size = 10;
-  string warmup_policy = 12;  // "disable" or "sync", empty means use global config
+  string warmup_policy = 12;  // "disable", "sync" or "async", empty means use global config
 }
 
 message LoadJsonKeyIndexInfo {
@@ -137,5 +137,5 @@ message LoadJsonKeyIndexInfo {
   bool enable_mmap = 9;
   string mmap_dir_path = 10;
   int64 stats_size = 11;
-  string warmup_policy = 12;  // "disable" or "sync", empty means use global config
+  string warmup_policy = 12;  // "disable", "sync", or "async"; empty means use global config
 }

--- a/pkg/proto/indexcgopb/index_cgo_msg.pb.go
+++ b/pkg/proto/indexcgopb/index_cgo_msg.pb.go
@@ -1022,7 +1022,7 @@ type LoadTextIndexInfo struct {
 	LoadPriority commonpb.LoadPriority `protobuf:"varint,8,opt,name=load_priority,json=loadPriority,proto3,enum=milvus.proto.common.LoadPriority" json:"load_priority,omitempty"`
 	EnableMmap   bool                  `protobuf:"varint,9,opt,name=enable_mmap,json=enableMmap,proto3" json:"enable_mmap,omitempty"`
 	IndexSize    int64                 `protobuf:"varint,10,opt,name=index_size,json=indexSize,proto3" json:"index_size,omitempty"`
-	WarmupPolicy string                `protobuf:"bytes,12,opt,name=warmup_policy,json=warmupPolicy,proto3" json:"warmup_policy,omitempty"` // "disable" or "sync", empty means use global config
+	WarmupPolicy string                `protobuf:"bytes,12,opt,name=warmup_policy,json=warmupPolicy,proto3" json:"warmup_policy,omitempty"` // "disable", "sync" or "async", empty means use global config
 }
 
 func (x *LoadTextIndexInfo) Reset() {
@@ -1150,7 +1150,7 @@ type LoadJsonKeyIndexInfo struct {
 	EnableMmap   bool                  `protobuf:"varint,9,opt,name=enable_mmap,json=enableMmap,proto3" json:"enable_mmap,omitempty"`
 	MmapDirPath  string                `protobuf:"bytes,10,opt,name=mmap_dir_path,json=mmapDirPath,proto3" json:"mmap_dir_path,omitempty"`
 	StatsSize    int64                 `protobuf:"varint,11,opt,name=stats_size,json=statsSize,proto3" json:"stats_size,omitempty"`
-	WarmupPolicy string                `protobuf:"bytes,12,opt,name=warmup_policy,json=warmupPolicy,proto3" json:"warmup_policy,omitempty"` // "disable" or "sync", empty means use global config
+	WarmupPolicy string                `protobuf:"bytes,12,opt,name=warmup_policy,json=warmupPolicy,proto3" json:"warmup_policy,omitempty"` // "disable", "sync", or "async"; empty means use global config
 }
 
 func (x *LoadJsonKeyIndexInfo) Reset() {

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3478,9 +3478,10 @@ func (p *queryNodeConfig) init(base *BaseTable) {
 		Version:      "2.6.0",
 		DefaultValue: "sync",
 		Forbidden:    true,
-		Doc: `options: sync, disable.
+		Doc: `options: sync, async, disable.
 Specifies the timing for warming up the Tiered Storage cache.
 - "sync": data will be loaded into the cache before a segment is considered loaded.
+- "async": data will be loaded into the cache asynchronously in the background after a segment is loaded.
 - "disable": data will not be proactively loaded into the cache, and loaded only if needed by search/query tasks.
 Defaults to "sync", except for vector field which defaults to "disable".`,
 		Export: true,


### PR DESCRIPTION
issue: #47902
pr: #47627

Integrate milvus-common commit 7b54b6e which adds
CacheWarmupPolicy_Async and a prefetch thread pool for background cache warmup. This enables segments to be marked as loaded immediately while cache warming happens asynchronously, reducing load latency.