### PR TITLE
fix: prevent node panic when unsupported types used as ClusteringKey

### DIFF
--- a/internal/datacoord/compaction_inspector.go
+++ b/internal/datacoord/compaction_inspector.go
@@ -178,19 +178,20 @@ func (c *compactionInspector) getCompactionTasksNumBySignalID(triggerID int64) i
 }
 
 func newCompactionInspector(meta CompactionMeta,
-	allocator allocator.Allocator, handler Handler, scheduler task.GlobalScheduler, ievm IndexEngineVersionManager,
+	allocator allocator.Allocator, handler Handler, scheduler task.GlobalScheduler, analyzeScheduler task.GlobalScheduler, ievm IndexEngineVersionManager,
 ) *compactionInspector {
 	capacity := paramtable.Get().DataCoordCfg.CompactionTaskQueueCapacity.GetAsInt()
 	return &compactionInspector{
-		queueTasks:     NewCompactionQueue(capacity, getPrioritizer()),
-		meta:           meta,
-		allocator:      allocator,
-		stopCh:         make(chan struct{}),
-		executingTasks: make(map[int64]CompactionTask),
-		cleaningTasks:  make(map[int64]CompactionTask),
-		handler:        handler,
-		scheduler:      scheduler,
-		ievm:           ievm,
+		queueTasks:       NewCompactionQueue(capacity, getPrioritizer()),
+		meta:             meta,
+		allocator:        allocator,
+		stopCh:           make(chan struct{}),
+		executingTasks:   make(map[int64]CompactionTask),
+		cleaningTasks:    make(map[int64]CompactionTask),
+		handler:          handler,
+		scheduler:        scheduler,
+		analyzeScheduler: analyzeScheduler,
+		ievm:             ievm,
 	}
 }
 

--- a/internal/datacoord/compaction_inspector_test.go
+++ b/internal/datacoord/compaction_inspector_test.go
@@ -58,7 +58,7 @@ func (s *CompactionPlanHandlerSuite) SetupTest() {
 	s.mockMeta.EXPECT().SaveCompactionTask(mock.Anything, mock.Anything).Return(nil).Maybe()
 	s.mockAlloc = allocator.NewMockAllocator(s.T())
 	mockScheduler := task.NewMockGlobalScheduler(s.T())
-	s.handler = newCompactionInspector(s.mockMeta, s.mockAlloc, nil, mockScheduler, newMockVersionManager())
+	s.handler = newCompactionInspector(s.mockMeta, s.mockAlloc, nil, mockScheduler, mockScheduler, newMockVersionManager())
 	s.mockHandler = NewNMockHandler(s.T())
 	s.mockHandler.EXPECT().GetCollection(mock.Anything, mock.Anything).Return(&collectionInfo{}, nil).Maybe()
 }
@@ -461,7 +461,7 @@ func (s *CompactionPlanHandlerSuite) TestCompactionQueueFull() {
 			t.QueryTaskOnWorker(cluster)
 		}
 	}).Maybe()
-	s.handler = newCompactionInspector(s.mockMeta, s.mockAlloc, nil, mockScheduler, newMockVersionManager())
+	s.handler = newCompactionInspector(s.mockMeta, s.mockAlloc, nil, mockScheduler, mockScheduler, newMockVersionManager())
 
 	t1 := newMixCompactionTask(&datapb.CompactionTask{
 		TriggerID: 1,
@@ -495,7 +495,7 @@ func (s *CompactionPlanHandlerSuite) TestExecCompactionPlan() {
 			t.QueryTaskOnWorker(cluster)
 		}
 	}).Maybe()
-	handler := newCompactionInspector(s.mockMeta, s.mockAlloc, nil, mockScheduler, newMockVersionManager())
+	handler := newCompactionInspector(s.mockMeta, s.mockAlloc, nil, mockScheduler, mockScheduler, newMockVersionManager())
 
 	task := &datapb.CompactionTask{
 		TriggerID: 1,

--- a/internal/datacoord/server.go
+++ b/internal/datacoord/server.go
@@ -760,7 +760,7 @@ func (s *Server) initExternalCollectionInspector() {
 }
 
 func (s *Server) initCompaction() {
-	cph := newCompactionInspector(s.meta, s.allocator, s.handler, s.globalScheduler, s.indexEngineVersionManager)
+	cph := newCompactionInspector(s.meta, s.allocator, s.handler, s.globalScheduler, s.globalScheduler, s.indexEngineVersionManager)
 	cph.loadMeta()
 	s.compactionInspector = cph
 	s.compactionTriggerManager = NewCompactionTriggerManager(s.allocator, s.handler, s.compactionInspector, s.meta, s.indexEngineVersionManager)

--- a/internal/datacoord/server_test.go
+++ b/internal/datacoord/server_test.go
@@ -1652,7 +1652,7 @@ func TestGetCompactionState(t *testing.T) {
 				{State: datapb.CompactionTaskState_timeout},
 				{State: datapb.CompactionTaskState_timeout},
 			})
-		mockHandler := newCompactionInspector(mockMeta, nil, nil, nil, newMockVersionManager())
+		mockHandler := newCompactionInspector(mockMeta, nil, nil, nil, nil, newMockVersionManager())
 		svr.compactionInspector = mockHandler
 		resp, err := svr.GetCompactionState(context.Background(), &milvuspb.GetCompactionStateRequest{CompactionID: 1})
 		assert.NoError(t, err)

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -327,6 +327,10 @@ func (t *createCollectionTask) validateClusteringKey(ctx context.Context) error 
 	idx := -1
 	for i, field := range t.schema.Fields {
 		if field.GetIsClusteringKey() {
+			if !typeutil.IsClusteringKeyType(field.GetDataType()) {
+				return merr.WrapErrCollectionIllegalSchema(t.CollectionName,
+					fmt.Sprintf("clustering key field %s has unsupported data type %s", field.Name, field.GetDataType().String()))
+			}
 			if typeutil.IsVectorType(field.GetDataType()) &&
 				!paramtable.Get().CommonCfg.EnableVectorClusteringKey.GetAsBool() {
 				return merr.WrapErrCollectionVectorClusteringKeyNotAllowed(t.CollectionName)

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -4841,6 +4841,145 @@ func TestClusteringKey(t *testing.T) {
 		err = createCollectionTask.PreExecute(ctx)
 		assert.Error(t, err)
 	})
+
+	t.Run("create collection with json clustering key not supported", func(t *testing.T) {
+		fieldName2Type := make(map[string]schemapb.DataType)
+		fieldName2Type["int64_field"] = schemapb.DataType_Int64
+		fieldName2Type["varChar_field"] = schemapb.DataType_VarChar
+		schema := constructCollectionSchemaByDataType(collectionName, fieldName2Type, "int64_field", false)
+		jsonField := &schemapb.FieldSchema{
+			Name:            "json_field",
+			DataType:        schemapb.DataType_JSON,
+			IsClusteringKey: true,
+		}
+		schema.Fields = append(schema.Fields, jsonField)
+		vecField := &schemapb.FieldSchema{
+			Name:     "fvec_field",
+			DataType: schemapb.DataType_FloatVector,
+			TypeParams: []*commonpb.KeyValuePair{
+				{
+					Key:   common.DimKey,
+					Value: strconv.Itoa(testVecDim),
+				},
+			},
+		}
+		schema.Fields = append(schema.Fields, vecField)
+		marshaledSchema, err := proto.Marshal(schema)
+		assert.NoError(t, err)
+
+		createCollectionTask := &createCollectionTask{
+			Condition: NewTaskCondition(ctx),
+			CreateCollectionRequest: &milvuspb.CreateCollectionRequest{
+				Base: &commonpb.MsgBase{
+					MsgID:     UniqueID(uniquegenerator.GetUniqueIntGeneratorIns().GetInt()),
+					Timestamp: Timestamp(time.Now().UnixNano()),
+				},
+				DbName:         "",
+				CollectionName: collectionName,
+				Schema:         marshaledSchema,
+				ShardsNum:      shardsNum,
+			},
+			ctx:      ctx,
+			mixCoord: qc,
+			result:   nil,
+			schema:   nil,
+		}
+		err = createCollectionTask.PreExecute(ctx)
+		assert.Error(t, err)
+	})
+
+	t.Run("create collection with bool clustering key not supported", func(t *testing.T) {
+		fieldName2Type := make(map[string]schemapb.DataType)
+		fieldName2Type["int64_field"] = schemapb.DataType_Int64
+		fieldName2Type["varChar_field"] = schemapb.DataType_VarChar
+		schema := constructCollectionSchemaByDataType(collectionName, fieldName2Type, "int64_field", false)
+		boolField := &schemapb.FieldSchema{
+			Name:            "bool_field",
+			DataType:        schemapb.DataType_Bool,
+			IsClusteringKey: true,
+		}
+		schema.Fields = append(schema.Fields, boolField)
+		vecField := &schemapb.FieldSchema{
+			Name:     "fvec_field",
+			DataType: schemapb.DataType_FloatVector,
+			TypeParams: []*commonpb.KeyValuePair{
+				{
+					Key:   common.DimKey,
+					Value: strconv.Itoa(testVecDim),
+				},
+			},
+		}
+		schema.Fields = append(schema.Fields, vecField)
+		marshaledSchema, err := proto.Marshal(schema)
+		assert.NoError(t, err)
+
+		createCollectionTask := &createCollectionTask{
+			Condition: NewTaskCondition(ctx),
+			CreateCollectionRequest: &milvuspb.CreateCollectionRequest{
+				Base: &commonpb.MsgBase{
+					MsgID:     UniqueID(uniquegenerator.GetUniqueIntGeneratorIns().GetInt()),
+					Timestamp: Timestamp(time.Now().UnixNano()),
+				},
+				DbName:         "",
+				CollectionName: collectionName,
+				Schema:         marshaledSchema,
+				ShardsNum:      shardsNum,
+			},
+			ctx:      ctx,
+			mixCoord: qc,
+			result:   nil,
+			schema:   nil,
+		}
+		err = createCollectionTask.PreExecute(ctx)
+		assert.Error(t, err)
+	})
+
+	t.Run("create collection with array clustering key not supported", func(t *testing.T) {
+		fieldName2Type := make(map[string]schemapb.DataType)
+		fieldName2Type["int64_field"] = schemapb.DataType_Int64
+		fieldName2Type["varChar_field"] = schemapb.DataType_VarChar
+		schema := constructCollectionSchemaByDataType(collectionName, fieldName2Type, "int64_field", false)
+		arrayField := &schemapb.FieldSchema{
+			Name:            "array_field",
+			DataType:        schemapb.DataType_Array,
+			IsClusteringKey: true,
+			ElementType:     schemapb.DataType_Int64,
+		}
+		schema.Fields = append(schema.Fields, arrayField)
+		vecField := &schemapb.FieldSchema{
+			Name:     "fvec_field",
+			DataType: schemapb.DataType_FloatVector,
+			TypeParams: []*commonpb.KeyValuePair{
+				{
+					Key:   common.DimKey,
+					Value: strconv.Itoa(testVecDim),
+				},
+			},
+		}
+		schema.Fields = append(schema.Fields, vecField)
+		marshaledSchema, err := proto.Marshal(schema)
+		assert.NoError(t, err)
+
+		createCollectionTask := &createCollectionTask{
+			Condition: NewTaskCondition(ctx),
+			CreateCollectionRequest: &milvuspb.CreateCollectionRequest{
+				Base: &commonpb.MsgBase{
+					MsgID:     UniqueID(uniquegenerator.GetUniqueIntGeneratorIns().GetInt()),
+					Timestamp: Timestamp(time.Now().UnixNano()),
+				},
+				DbName:         "",
+				CollectionName: collectionName,
+				Schema:         marshaledSchema,
+				ShardsNum:      shardsNum,
+			},
+			ctx:      ctx,
+			mixCoord: qc,
+			result:   nil,
+			schema:   nil,
+		}
+		err = createCollectionTask.PreExecute(ctx)
+		assert.Error(t, err)
+	})
 }
 
 func TestAlterCollectionCheckLoaded(t *testing.T) {

--- a/pkg/util/typeutil/schema.go
+++ b/pkg/util/typeutil/schema.go
@@ -635,6 +635,20 @@ func IsVectorArrayType(dataType schemapb.DataType) bool {
 	return dataType == schemapb.DataType_ArrayOfVector
 }
 
+// IsClusteringKeyType returns true if the data type is supported as a clustering key.
+// Supported scalar types: Int8, Int16, Int32, Int64, Float, Double, VarChar, String, FloatVector.
+func IsClusteringKeyType(dataType schemapb.DataType) bool {
+	switch dataType {
+	case schemapb.DataType_Int8, schemapb.DataType_Int16,
+		schemapb.DataType_Int32, schemapb.DataType_Int64,
+		schemapb.DataType_Float, schemapb.DataType_Double,
+		schemapb.DataType_VarChar, schemapb.DataType_String:
+		return true
+	default:
+		return dataType == schemapb.DataType_FloatVector
+	}
+}
+
 // IsIntegerType returns true if input is an integer type, otherwise false
 func IsIntegerType(dataType schemapb.DataType) bool {
 	switch dataType {

--- a/pkg/util/typeutil/schema_test.go
+++ b/pkg/util/typeutil/schema_test.go
@@ -5549,3 +5549,29 @@ func TestUpdateFieldDataByColumn(t *testing.T) {
 		assert.Equal(t, [][]byte{{10}, {2}, {20}}, base.GetVectors().GetSparseFloatVector().Contents)
 	})
 }
+
+func TestIsClusteringKeyType(t *testing.T) {
+	// Supported scalar types
+	assert.True(t, IsClusteringKeyType(schemapb.DataType_Int8))
+	assert.True(t, IsClusteringKeyType(schemapb.DataType_Int16))
+	assert.True(t, IsClusteringKeyType(schemapb.DataType_Int32))
+	assert.True(t, IsClusteringKeyType(schemapb.DataType_Int64))
+	assert.True(t, IsClusteringKeyType(schemapb.DataType_Float))
+	assert.True(t, IsClusteringKeyType(schemapb.DataType_Double))
+	assert.True(t, IsClusteringKeyType(schemapb.DataType_VarChar))
+	assert.True(t, IsClusteringKeyType(schemapb.DataType_String))
+
+	// Supported vector types
+	assert.True(t, IsClusteringKeyType(schemapb.DataType_FloatVector))
+
+	// Unsupported types
+	assert.False(t, IsClusteringKeyType(schemapb.DataType_JSON))
+	assert.False(t, IsClusteringKeyType(schemapb.DataType_Bool))
+	assert.False(t, IsClusteringKeyType(schemapb.DataType_Array))
+	assert.False(t, IsClusteringKeyType(schemapb.DataType_Geometry))
+	assert.False(t, IsClusteringKeyType(schemapb.DataType_Text))
+	assert.False(t, IsClusteringKeyType(schemapb.DataType_Timestamptz))
+	assert.False(t, IsClusteringKeyType(schemapb.DataType_BinaryVector))
+	assert.False(t, IsClusteringKeyType(schemapb.DataType_Float16Vector))
+	assert.False(t, IsClusteringKeyType(schemapb.DataType_BFloat16Vector))
+}


### PR DESCRIPTION
## Summary

Fixes #47540

- **Bug 1 (MixCoord panic):** `compactionInspector.analyzeScheduler` was never initialized in production code. When FloatVector is used as ClusteringKey, the `doAnalyze()` path calls `analyzeScheduler.Enqueue()` on a nil pointer → panic. Fixed by passing `analyzeScheduler` to `newCompactionInspector`.
- **Bug 2 (DataNode round-robin panic):** `validateClusteringKey()` had no field type whitelist, so JSON/Bool/Array passed schema validation. During clustering compaction, `NewScalarFieldValue()` panics on unsupported types. Fixed by adding `IsClusteringKeyType()` check to reject unsupported types at collection creation time.

## Test plan

- [x] `TestIsClusteringKeyType` — verifies supported/unsupported type classification
- [x] `TestClusteringKey` — new sub-tests for JSON, Bool, Array as ClusteringKey (all rejected)
- [ ] Existing `TestClusteringKey` sub-tests (normal, multiple keys, vector key) still pass
- [ ] `TestCompactionPlanHandler*` tests pass with updated `newCompactionInspector` signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)