### PR TITLE
fix: enforce group limit only at Proxy level for GROUP BY aggregation

### DIFF
--- a/internal/agg/aggregate_reducer.go
+++ b/internal/agg/aggregate_reducer.go
@@ -285,6 +285,9 @@ func (reducer *GroupAggReducer) Reduce(ctx context.Context, results []*Aggregati
 	}
 
 	if len(results) == 1 {
+		if reducer.groupLimit > 0 {
+			return truncateAggResult(results[0], reducer.groupLimit), nil
+		}
 		return results[0], nil
 	}
 
@@ -345,14 +348,18 @@ func (reducer *GroupAggReducer) Reduce(ctx context.Context, results []*Aggregati
 	}
 
 	// 2. compute hash values for all rows in the result retrieved
+	// When aggregation exists, we must merge ALL rows across all shards before
+	// truncating — early-stop would produce incorrect aggregation values (e.g.,
+	// SUM/COUNT only from partial shards). When no aggregation exists (group-by
+	// only), early-stop is safe since there are no values to merge.
+	hasAgg := numAggs > 0
+	canEarlyStop := !hasAgg && reducer.groupLimit > 0
 	var totalRowCount int64 = 0
 processResults:
 	for _, result := range results {
-		// Check limit before processing each shard to avoid unnecessary work
-		if reducer.groupLimit != -1 && totalRowCount >= reducer.groupLimit {
+		if canEarlyStop && totalRowCount >= reducer.groupLimit {
 			break processResults
 		}
-
 		if result == nil {
 			return nil, fmt.Errorf("input result from any sources cannot be nil")
 		}
@@ -386,8 +393,7 @@ processResults:
 		}
 
 		for row := 0; row < rowCount; row++ {
-			// Check limit before processing each row to avoid unnecessary hashing and copying
-			if reducer.groupLimit != -1 && totalRowCount >= reducer.groupLimit {
+			if canEarlyStop && totalRowCount >= reducer.groupLimit {
 				break processResults
 			}
 			rowFieldValues := make([]*FieldValue, outputColumnCount)
@@ -440,7 +446,8 @@ processResults:
 			return nil, err
 		}
 	}
-	return reducedResult, nil
+	// Apply groupLimit truncation after full merge to ensure correct aggregation
+	return truncateAggResult(reducedResult, reducer.groupLimit), nil
 }
 
 func InternalResult2AggResult(results []*internalpb.RetrieveResults) []*AggregationResult {

--- a/internal/agg/aggregate_reducer_test.go
+++ b/internal/agg/aggregate_reducer_test.go
@@ -9,7 +9,12 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/planpb"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
+
+func init() {
+	paramtable.Init()
+}
 
 func makeTestSchema() *schemapb.CollectionSchema {
 	return &schemapb.CollectionSchema{
@@ -36,31 +41,28 @@ func makeGroupAggReducer() *GroupAggReducer {
 func TestReduceNilResultReturnsError(t *testing.T) {
 	reducer := makeGroupAggReducer()
 
-	validResult := &AggregationResult{
-		fieldDatas: []*schemapb.FieldData{
-			{
-				Type: schemapb.DataType_VarChar,
-				Field: &schemapb.FieldData_Scalars{
-					Scalars: &schemapb.ScalarField{
-						Data: &schemapb.ScalarField_StringData{
-							StringData: &schemapb.StringArray{Data: []string{"a"}},
-						},
-					},
-				},
-			},
-			{
-				Type: schemapb.DataType_Int64,
-				Field: &schemapb.FieldData_Scalars{
-					Scalars: &schemapb.ScalarField{
-						Data: &schemapb.ScalarField_LongData{
-							LongData: &schemapb.LongArray{Data: []int64{10}},
-						},
+	validResult := NewAggregationResult([]*schemapb.FieldData{
+		{
+			Type: schemapb.DataType_VarChar,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_StringData{
+						StringData: &schemapb.StringArray{Data: []string{"a"}},
 					},
 				},
 			},
 		},
-		allRetrieveCount: 1,
-	}
+		{
+			Type: schemapb.DataType_Int64,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_LongData{
+						LongData: &schemapb.LongArray{Data: []int64{10}},
+					},
+				},
+			},
+		},
+	}, 1)
 
 	// A nil entry in the results slice should return an error, not panic.
 	results := []*AggregationResult{validResult, nil}
@@ -97,31 +99,28 @@ func TestReduceWithValidGroupResults(t *testing.T) {
 	reducer := makeGroupAggReducer()
 
 	makeResult := func(key string, val int64) *AggregationResult {
-		return &AggregationResult{
-			fieldDatas: []*schemapb.FieldData{
-				{
-					Type: schemapb.DataType_VarChar,
-					Field: &schemapb.FieldData_Scalars{
-						Scalars: &schemapb.ScalarField{
-							Data: &schemapb.ScalarField_StringData{
-								StringData: &schemapb.StringArray{Data: []string{key}},
-							},
-						},
-					},
-				},
-				{
-					Type: schemapb.DataType_Int64,
-					Field: &schemapb.FieldData_Scalars{
-						Scalars: &schemapb.ScalarField{
-							Data: &schemapb.ScalarField_LongData{
-								LongData: &schemapb.LongArray{Data: []int64{val}},
-							},
+		return NewAggregationResult([]*schemapb.FieldData{
+			{
+				Type: schemapb.DataType_VarChar,
+				Field: &schemapb.FieldData_Scalars{
+					Scalars: &schemapb.ScalarField{
+						Data: &schemapb.ScalarField_StringData{
+							StringData: &schemapb.StringArray{Data: []string{key}},
 						},
 					},
 				},
 			},
-			allRetrieveCount: 1,
-		}
+			{
+				Type: schemapb.DataType_Int64,
+				Field: &schemapb.FieldData_Scalars{
+					Scalars: &schemapb.ScalarField{
+						Data: &schemapb.ScalarField_LongData{
+							LongData: &schemapb.LongArray{Data: []int64{val}},
+						},
+					},
+				},
+			},
+		}, 1)
 	}
 
 	results := []*AggregationResult{
@@ -147,33 +146,358 @@ func TestReduceEmptyResults(t *testing.T) {
 // TestReduceSingleResult verifies that reduce returns the single input unchanged.
 func TestReduceSingleResult(t *testing.T) {
 	reducer := makeGroupAggReducer()
-	singleResult := &AggregationResult{
-		fieldDatas: []*schemapb.FieldData{
-			{
-				Type: schemapb.DataType_VarChar,
-				Field: &schemapb.FieldData_Scalars{
-					Scalars: &schemapb.ScalarField{
-						Data: &schemapb.ScalarField_StringData{
-							StringData: &schemapb.StringArray{Data: []string{"a"}},
-						},
-					},
-				},
-			},
-			{
-				Type: schemapb.DataType_Int64,
-				Field: &schemapb.FieldData_Scalars{
-					Scalars: &schemapb.ScalarField{
-						Data: &schemapb.ScalarField_LongData{
-							LongData: &schemapb.LongArray{Data: []int64{42}},
-						},
+	singleResult := NewAggregationResult([]*schemapb.FieldData{
+		{
+			Type: schemapb.DataType_VarChar,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_StringData{
+						StringData: &schemapb.StringArray{Data: []string{"a"}},
 					},
 				},
 			},
 		},
-		allRetrieveCount: 1,
-	}
+		{
+			Type: schemapb.DataType_Int64,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_LongData{
+						LongData: &schemapb.LongArray{Data: []int64{42}},
+					},
+				},
+			},
+		},
+	}, 1)
 
 	out, err := reducer.Reduce(context.Background(), []*AggregationResult{singleResult})
 	require.NoError(t, err)
 	assert.Equal(t, singleResult, out)
+}
+
+// TestReduceSingleResultWithGroupLimit verifies that when Reduce receives
+// a single result and groupLimit > 0, the result is truncated to groupLimit rows.
+func TestReduceSingleResultWithGroupLimit(t *testing.T) {
+	groupByFieldIds := []int64{101}
+	aggregates := []*planpb.Aggregate{
+		{Op: planpb.AggregateOp_count, FieldId: 102},
+	}
+	schema := &schemapb.CollectionSchema{
+		Name: "test",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 101, Name: "gk", DataType: schemapb.DataType_Int64},
+			{FieldID: 102, Name: "cnt", DataType: schemapb.DataType_Int64},
+		},
+	}
+
+	groupLimit := int64(3)
+	reducer := NewGroupAggReducer(groupByFieldIds, aggregates, groupLimit, schema)
+
+	// Build a single AggregationResult with 5 groups
+	result := NewAggregationResult([]*schemapb.FieldData{
+		{
+			Type: schemapb.DataType_Int64,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_LongData{
+						LongData: &schemapb.LongArray{Data: []int64{1, 2, 3, 4, 5}},
+					},
+				},
+			},
+		},
+		{
+			Type: schemapb.DataType_Int64,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_LongData{
+						LongData: &schemapb.LongArray{Data: []int64{10, 20, 30, 40, 50}},
+					},
+				},
+			},
+		},
+	}, 5)
+
+	reduced, err := reducer.Reduce(context.Background(), []*AggregationResult{result})
+	assert.NoError(t, err)
+	assert.NotNil(t, reduced)
+
+	// Should be truncated to 3 groups
+	keys := reduced.GetFieldDatas()[0].GetScalars().GetLongData().GetData()
+	vals := reduced.GetFieldDatas()[1].GetScalars().GetLongData().GetData()
+	assert.Equal(t, 3, len(keys))
+	assert.Equal(t, 3, len(vals))
+	assert.Equal(t, []int64{1, 2, 3}, keys)
+	assert.Equal(t, []int64{10, 20, 30}, vals)
+}
+
+// TestReduceSingleResultWithoutGroupLimit verifies that when groupLimit <= 0,
+// a single result is returned as-is without truncation.
+func TestReduceSingleResultWithoutGroupLimit(t *testing.T) {
+	groupByFieldIds := []int64{101}
+	aggregates := []*planpb.Aggregate{
+		{Op: planpb.AggregateOp_count, FieldId: 102},
+	}
+	schema := &schemapb.CollectionSchema{
+		Name: "test",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 101, Name: "gk", DataType: schemapb.DataType_Int64},
+			{FieldID: 102, Name: "cnt", DataType: schemapb.DataType_Int64},
+		},
+	}
+
+	// groupLimit = -1 means no limit (QN level)
+	reducer := NewGroupAggReducer(groupByFieldIds, aggregates, -1, schema)
+
+	result := NewAggregationResult([]*schemapb.FieldData{
+		{
+			Type: schemapb.DataType_Int64,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_LongData{
+						LongData: &schemapb.LongArray{Data: []int64{1, 2, 3, 4, 5}},
+					},
+				},
+			},
+		},
+		{
+			Type: schemapb.DataType_Int64,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_LongData{
+						LongData: &schemapb.LongArray{Data: []int64{10, 20, 30, 40, 50}},
+					},
+				},
+			},
+		},
+	}, 5)
+
+	reduced, err := reducer.Reduce(context.Background(), []*AggregationResult{result})
+	assert.NoError(t, err)
+	assert.NotNil(t, reduced)
+
+	// Should NOT be truncated
+	keys := reduced.GetFieldDatas()[0].GetScalars().GetLongData().GetData()
+	assert.Equal(t, 5, len(keys))
+}
+
+// TestReduceSingleResultGroupLimitLargerThanData verifies that when groupLimit
+// exceeds the number of rows, the result is returned as-is.
+func TestReduceSingleResultGroupLimitLargerThanData(t *testing.T) {
+	groupByFieldIds := []int64{101}
+	aggregates := []*planpb.Aggregate{
+		{Op: planpb.AggregateOp_count, FieldId: 102},
+	}
+	schema := &schemapb.CollectionSchema{
+		Name: "test",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 101, Name: "gk", DataType: schemapb.DataType_Int64},
+			{FieldID: 102, Name: "cnt", DataType: schemapb.DataType_Int64},
+		},
+	}
+
+	reducer := NewGroupAggReducer(groupByFieldIds, aggregates, 100, schema)
+
+	result := NewAggregationResult([]*schemapb.FieldData{
+		{
+			Type: schemapb.DataType_Int64,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_LongData{
+						LongData: &schemapb.LongArray{Data: []int64{1, 2, 3}},
+					},
+				},
+			},
+		},
+		{
+			Type: schemapb.DataType_Int64,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_LongData{
+						LongData: &schemapb.LongArray{Data: []int64{10, 20, 30}},
+					},
+				},
+			},
+		},
+	}, 3)
+
+	reduced, err := reducer.Reduce(context.Background(), []*AggregationResult{result})
+	assert.NoError(t, err)
+	keys := reduced.GetFieldDatas()[0].GetScalars().GetLongData().GetData()
+	assert.Equal(t, 3, len(keys))
+}
+
+// TestReduceMultipleResultsAggValuesCorrect verifies that cross-shard merge
+// produces correct aggregation values even with groupLimit truncation.
+// The early-stop bug would have returned SUM=10 for key=1 instead of 110.
+func TestReduceMultipleResultsAggValuesCorrect(t *testing.T) {
+	groupByFieldIds := []int64{101}
+	aggregates := []*planpb.Aggregate{
+		{Op: planpb.AggregateOp_sum, FieldId: 102},
+	}
+	schema := &schemapb.CollectionSchema{
+		Name: "test",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 101, Name: "gk", DataType: schemapb.DataType_Int64},
+			{FieldID: 102, Name: "agg", DataType: schemapb.DataType_Int64},
+		},
+	}
+
+	// No limit — verify full merge correctness first
+	reducer := NewGroupAggReducer(groupByFieldIds, aggregates, -1, schema)
+
+	// Shard 1: groups {1:10, 2:20, 3:30}
+	result1 := NewAggregationResult([]*schemapb.FieldData{
+		{
+			Type: schemapb.DataType_Int64,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_LongData{
+						LongData: &schemapb.LongArray{Data: []int64{1, 2, 3}},
+					},
+				},
+			},
+		},
+		{
+			Type: schemapb.DataType_Int64,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_LongData{
+						LongData: &schemapb.LongArray{Data: []int64{10, 20, 30}},
+					},
+				},
+			},
+		},
+	}, 3)
+
+	// Shard 2: groups {1:100, 4:40, 5:50}
+	result2 := NewAggregationResult([]*schemapb.FieldData{
+		{
+			Type: schemapb.DataType_Int64,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_LongData{
+						LongData: &schemapb.LongArray{Data: []int64{1, 4, 5}},
+					},
+				},
+			},
+		},
+		{
+			Type: schemapb.DataType_Int64,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_LongData{
+						LongData: &schemapb.LongArray{Data: []int64{100, 40, 50}},
+					},
+				},
+			},
+		},
+	}, 3)
+
+	reduced, err := reducer.Reduce(context.Background(), []*AggregationResult{result1, result2})
+	assert.NoError(t, err)
+	assert.NotNil(t, reduced)
+
+	// Expected merged groups: {1:110, 2:20, 3:30, 4:40, 5:50}
+	keys := reduced.GetFieldDatas()[0].GetScalars().GetLongData().GetData()
+	vals := reduced.GetFieldDatas()[1].GetScalars().GetLongData().GetData()
+	assert.Equal(t, 5, len(keys))
+	assert.Equal(t, 5, len(vals))
+
+	// Build map from key->val for order-independent comparison
+	aggMap := make(map[int64]int64, len(keys))
+	for i := range keys {
+		aggMap[keys[i]] = vals[i]
+	}
+	assert.Equal(t, int64(110), aggMap[1], "key=1 should be SUM(10+100)=110")
+	assert.Equal(t, int64(20), aggMap[2])
+	assert.Equal(t, int64(30), aggMap[3])
+	assert.Equal(t, int64(40), aggMap[4])
+	assert.Equal(t, int64(50), aggMap[5])
+}
+
+// TestReduceMultipleResultsGroupLimitApplied verifies that groupLimit truncation
+// happens AFTER full merge, preserving correct aggregation values.
+func TestReduceMultipleResultsGroupLimitApplied(t *testing.T) {
+	groupByFieldIds := []int64{101}
+	aggregates := []*planpb.Aggregate{
+		{Op: planpb.AggregateOp_sum, FieldId: 102},
+	}
+	schema := &schemapb.CollectionSchema{
+		Name: "test",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 101, Name: "gk", DataType: schemapb.DataType_Int64},
+			{FieldID: 102, Name: "agg", DataType: schemapb.DataType_Int64},
+		},
+	}
+
+	groupLimit := int64(2)
+	reducer := NewGroupAggReducer(groupByFieldIds, aggregates, groupLimit, schema)
+
+	// Shard 1: groups {1:10, 2:20, 3:30}
+	result1 := NewAggregationResult([]*schemapb.FieldData{
+		{
+			Type: schemapb.DataType_Int64,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_LongData{
+						LongData: &schemapb.LongArray{Data: []int64{1, 2, 3}},
+					},
+				},
+			},
+		},
+		{
+			Type: schemapb.DataType_Int64,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_LongData{
+						LongData: &schemapb.LongArray{Data: []int64{10, 20, 30}},
+					},
+				},
+			},
+		},
+	}, 3)
+
+	// Shard 2: groups {1:100, 4:40, 5:50}
+	result2 := NewAggregationResult([]*schemapb.FieldData{
+		{
+			Type: schemapb.DataType_Int64,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_LongData{
+						LongData: &schemapb.LongArray{Data: []int64{1, 4, 5}},
+					},
+				},
+			},
+		},
+		{
+			Type: schemapb.DataType_Int64,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_LongData{
+						LongData: &schemapb.LongArray{Data: []int64{100, 40, 50}},
+					},
+				},
+			},
+		},
+	}, 3)
+
+	reduced, err := reducer.Reduce(context.Background(), []*AggregationResult{result1, result2})
+	assert.NoError(t, err)
+	assert.NotNil(t, reduced)
+
+	// groupLimit=2 means at most 2 groups in output
+	keys := reduced.GetFieldDatas()[0].GetScalars().GetLongData().GetData()
+	vals := reduced.GetFieldDatas()[1].GetScalars().GetLongData().GetData()
+	assert.Equal(t, 2, len(keys))
+	assert.Equal(t, 2, len(vals))
+
+	// Verify aggregation values are fully merged (not early-stopped).
+	// If key=1 is in the output, its SUM must be 110 (10+100), not 10.
+	aggMap := make(map[int64]int64, len(keys))
+	for i := range keys {
+		aggMap[keys[i]] = vals[i]
+	}
+	expectedFullMerge := map[int64]int64{1: 110, 2: 20, 3: 30, 4: 40, 5: 50}
+	for k, v := range aggMap {
+		assert.Equal(t, expectedFullMerge[k], v, "group key=%d should have correct merged value", k)
+	}
 }

--- a/internal/agg/aggregate_util.go
+++ b/internal/agg/aggregate_util.go
@@ -496,6 +496,18 @@ func (aggMap *AggregationFieldMap) NameAt(idx int) string {
 	return aggMap.userOriginalOutputFields[idx]
 }
 
+// Validate checks that every user-requested output field maps to at least one
+// internal field index. Returns an error identifying the first unmapped field.
+func (aggMap *AggregationFieldMap) Validate() error {
+	for i, indices := range aggMap.userOriginalOutputFieldIdxes {
+		if len(indices) == 0 {
+			return fmt.Errorf("field '%s' is not allowed in output_fields for GROUP BY queries: "+
+				"only group_by fields and aggregation results are permitted", aggMap.userOriginalOutputFields[i])
+		}
+	}
+	return nil
+}
+
 func NewAggregationFieldMap(originalUserOutputFields []string, groupByFields []string, aggs []AggregateBase) *AggregationFieldMap {
 	numGroupingKeys := len(groupByFields)
 
@@ -608,4 +620,62 @@ func ComputeAvgFromSumAndCount(sumFieldData *schemapb.FieldData, countFieldData 
 
 	result.GetScalars().GetDoubleData().Data = resultData
 	return result, nil
+}
+
+// truncateFieldData truncates a FieldData to at most limit rows in place.
+// Only scalar types used in aggregation are supported; unsupported types are left unchanged.
+func truncateFieldData(fd *schemapb.FieldData, limit int) {
+	if fd == nil || limit <= 0 {
+		return
+	}
+	if len(fd.ValidData) > limit {
+		fd.ValidData = fd.ValidData[:limit]
+	}
+	scalars := fd.GetScalars()
+	if scalars == nil {
+		return
+	}
+	switch data := scalars.Data.(type) {
+	case *schemapb.ScalarField_BoolData:
+		if d := data.BoolData; d != nil && len(d.Data) > limit {
+			d.Data = d.Data[:limit]
+		}
+	case *schemapb.ScalarField_IntData:
+		if d := data.IntData; d != nil && len(d.Data) > limit {
+			d.Data = d.Data[:limit]
+		}
+	case *schemapb.ScalarField_LongData:
+		if d := data.LongData; d != nil && len(d.Data) > limit {
+			d.Data = d.Data[:limit]
+		}
+	case *schemapb.ScalarField_TimestamptzData:
+		if d := data.TimestamptzData; d != nil && len(d.Data) > limit {
+			d.Data = d.Data[:limit]
+		}
+	case *schemapb.ScalarField_FloatData:
+		if d := data.FloatData; d != nil && len(d.Data) > limit {
+			d.Data = d.Data[:limit]
+		}
+	case *schemapb.ScalarField_DoubleData:
+		if d := data.DoubleData; d != nil && len(d.Data) > limit {
+			d.Data = d.Data[:limit]
+		}
+	case *schemapb.ScalarField_StringData:
+		if d := data.StringData; d != nil && len(d.Data) > limit {
+			d.Data = d.Data[:limit]
+		}
+	}
+}
+
+// truncateAggResult truncates an AggregationResult to at most limit groups in place.
+// The input result's fieldDatas slices are modified directly.
+func truncateAggResult(result *AggregationResult, limit int64) *AggregationResult {
+	if result == nil || limit <= 0 {
+		return result
+	}
+	l := int(limit)
+	for _, fd := range result.GetFieldDatas() {
+		truncateFieldData(fd, l)
+	}
+	return result
 }

--- a/internal/agg/aggregate_util_test.go
+++ b/internal/agg/aggregate_util_test.go
@@ -1,0 +1,242 @@
+package agg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+)
+
+func TestTruncateFieldData_NilInput(t *testing.T) {
+	// Should not panic on nil
+	truncateFieldData(nil, 5)
+}
+
+func TestTruncateFieldData_NilScalars(t *testing.T) {
+	fd := &schemapb.FieldData{Type: schemapb.DataType_Int64}
+	truncateFieldData(fd, 2)
+	// No scalars set — nothing to truncate, should not panic
+}
+
+func TestTruncateFieldData_BoolData(t *testing.T) {
+	fd := &schemapb.FieldData{
+		Type: schemapb.DataType_Bool,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_BoolData{
+					BoolData: &schemapb.BoolArray{Data: []bool{true, false, true, false, true}},
+				},
+			},
+		},
+	}
+	truncateFieldData(fd, 3)
+	assert.Equal(t, 3, len(fd.GetScalars().GetBoolData().GetData()))
+}
+
+func TestTruncateFieldData_IntData(t *testing.T) {
+	fd := &schemapb.FieldData{
+		Type: schemapb.DataType_Int32,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_IntData{
+					IntData: &schemapb.IntArray{Data: []int32{1, 2, 3, 4, 5}},
+				},
+			},
+		},
+	}
+	truncateFieldData(fd, 2)
+	assert.Equal(t, []int32{1, 2}, fd.GetScalars().GetIntData().GetData())
+}
+
+func TestTruncateFieldData_LongData(t *testing.T) {
+	fd := &schemapb.FieldData{
+		Type: schemapb.DataType_Int64,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{
+					LongData: &schemapb.LongArray{Data: []int64{10, 20, 30, 40}},
+				},
+			},
+		},
+	}
+	truncateFieldData(fd, 2)
+	assert.Equal(t, []int64{10, 20}, fd.GetScalars().GetLongData().GetData())
+}
+
+func TestTruncateFieldData_FloatData(t *testing.T) {
+	fd := &schemapb.FieldData{
+		Type: schemapb.DataType_Float,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_FloatData{
+					FloatData: &schemapb.FloatArray{Data: []float32{1.1, 2.2, 3.3}},
+				},
+			},
+		},
+	}
+	truncateFieldData(fd, 2)
+	assert.Equal(t, []float32{1.1, 2.2}, fd.GetScalars().GetFloatData().GetData())
+}
+
+func TestTruncateFieldData_DoubleData(t *testing.T) {
+	fd := &schemapb.FieldData{
+		Type: schemapb.DataType_Double,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_DoubleData{
+					DoubleData: &schemapb.DoubleArray{Data: []float64{1.1, 2.2, 3.3}},
+				},
+			},
+		},
+	}
+	truncateFieldData(fd, 1)
+	assert.Equal(t, []float64{1.1}, fd.GetScalars().GetDoubleData().GetData())
+}
+
+func TestTruncateFieldData_StringData(t *testing.T) {
+	fd := &schemapb.FieldData{
+		Type: schemapb.DataType_VarChar,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_StringData{
+					StringData: &schemapb.StringArray{Data: []string{"a", "b", "c", "d"}},
+				},
+			},
+		},
+	}
+	truncateFieldData(fd, 2)
+	assert.Equal(t, []string{"a", "b"}, fd.GetScalars().GetStringData().GetData())
+}
+
+func TestTruncateFieldData_ValidData(t *testing.T) {
+	fd := &schemapb.FieldData{
+		Type:      schemapb.DataType_Int64,
+		ValidData: []bool{true, true, false, true},
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{
+					LongData: &schemapb.LongArray{Data: []int64{10, 20, 30, 40}},
+				},
+			},
+		},
+	}
+	truncateFieldData(fd, 2)
+	assert.Equal(t, []bool{true, true}, fd.ValidData)
+	assert.Equal(t, []int64{10, 20}, fd.GetScalars().GetLongData().GetData())
+}
+
+func TestTruncateFieldData_DataShorterThanLimit(t *testing.T) {
+	fd := &schemapb.FieldData{
+		Type: schemapb.DataType_Int64,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{
+					LongData: &schemapb.LongArray{Data: []int64{10, 20}},
+				},
+			},
+		},
+	}
+	truncateFieldData(fd, 100)
+	assert.Equal(t, []int64{10, 20}, fd.GetScalars().GetLongData().GetData())
+}
+
+func TestTruncateFieldData_TimestamptzData(t *testing.T) {
+	fd := &schemapb.FieldData{
+		Type: schemapb.DataType_Timestamptz,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_TimestamptzData{
+					TimestamptzData: &schemapb.TimestamptzArray{Data: []int64{1704067200, 1704153600, 1704240000}},
+				},
+			},
+		},
+	}
+	truncateFieldData(fd, 1)
+	assert.Equal(t, []int64{1704067200}, fd.GetScalars().GetTimestamptzData().GetData())
+}
+
+func TestTruncateAggResult_NilResult(t *testing.T) {
+	result := truncateAggResult(nil, 10)
+	assert.Nil(t, result)
+}
+
+func TestTruncateAggResult_ZeroLimit(t *testing.T) {
+	aggResult := &AggregationResult{
+		fieldDatas: []*schemapb.FieldData{
+			{
+				Type: schemapb.DataType_Int64,
+				Field: &schemapb.FieldData_Scalars{
+					Scalars: &schemapb.ScalarField{
+						Data: &schemapb.ScalarField_LongData{
+							LongData: &schemapb.LongArray{Data: []int64{1, 2, 3}},
+						},
+					},
+				},
+			},
+		},
+	}
+	result := truncateAggResult(aggResult, 0)
+	// limit <= 0, should return as-is without truncation
+	assert.Equal(t, 3, len(result.GetFieldDatas()[0].GetScalars().GetLongData().GetData()))
+}
+
+func TestTruncateAggResult_NegativeLimit(t *testing.T) {
+	aggResult := &AggregationResult{
+		fieldDatas: []*schemapb.FieldData{
+			{
+				Type: schemapb.DataType_Int64,
+				Field: &schemapb.FieldData_Scalars{
+					Scalars: &schemapb.ScalarField{
+						Data: &schemapb.ScalarField_LongData{
+							LongData: &schemapb.LongArray{Data: []int64{1, 2, 3}},
+						},
+					},
+				},
+			},
+		},
+	}
+	result := truncateAggResult(aggResult, -1)
+	assert.Equal(t, 3, len(result.GetFieldDatas()[0].GetScalars().GetLongData().GetData()))
+}
+
+func TestTruncateAggResult_MultipleFields(t *testing.T) {
+	aggResult := &AggregationResult{
+		fieldDatas: []*schemapb.FieldData{
+			{
+				Type: schemapb.DataType_Int32,
+				Field: &schemapb.FieldData_Scalars{
+					Scalars: &schemapb.ScalarField{
+						Data: &schemapb.ScalarField_IntData{
+							IntData: &schemapb.IntArray{Data: []int32{1, 2, 3, 4, 5}},
+						},
+					},
+				},
+			},
+			{
+				Type: schemapb.DataType_Int64,
+				Field: &schemapb.FieldData_Scalars{
+					Scalars: &schemapb.ScalarField{
+						Data: &schemapb.ScalarField_LongData{
+							LongData: &schemapb.LongArray{Data: []int64{10, 20, 30, 40, 50}},
+						},
+					},
+				},
+			},
+			{
+				Type: schemapb.DataType_Double,
+				Field: &schemapb.FieldData_Scalars{
+					Scalars: &schemapb.ScalarField{
+						Data: &schemapb.ScalarField_DoubleData{
+							DoubleData: &schemapb.DoubleArray{Data: []float64{1.1, 2.2, 3.3, 4.4, 5.5}},
+						},
+					},
+				},
+			},
+		},
+	}
+	result := truncateAggResult(aggResult, 3)
+	assert.Equal(t, []int32{1, 2, 3}, result.GetFieldDatas()[0].GetScalars().GetIntData().GetData())
+	assert.Equal(t, []int64{10, 20, 30}, result.GetFieldDatas()[1].GetScalars().GetLongData().GetData())
+	assert.Equal(t, []float64{1.1, 2.2, 3.3}, result.GetFieldDatas()[2].GetScalars().GetDoubleData().GetData())
+}

--- a/internal/proxy/agg_reducer.go
+++ b/internal/proxy/agg_reducer.go
@@ -42,7 +42,7 @@ func (reducer *MilvusAggReducer) Reduce(results []*internalpb.RetrieveResults) (
 	for i := 0; i < fieldCount; i++ {
 		indices := reducer.outputMap.IndexesAt(i)
 		if len(indices) == 0 {
-			return nil, fmt.Errorf("no indices found for output field at index %d", i)
+			return nil, fmt.Errorf("field '%s' is not allowed in output_fields: only group_by fields and aggregation results are permitted", reducer.outputMap.NameAt(i))
 		} else if len(indices) == 1 {
 			// Single index: direct copy (non-avg aggregation or group-by field)
 			reOrganizedFieldDatas[i] = reducedFieldDatas[indices[0]]

--- a/internal/proxy/task_query.go
+++ b/internal/proxy/task_query.go
@@ -401,6 +401,9 @@ func (t *queryTask) createPlanArgs(ctx context.Context, visitorArgs *planparserv
 		t.RetrieveRequest.OutputFieldsId = emptyOutputFields
 		t.plan.OutputFieldIds = emptyOutputFields
 		t.aggregationFieldMap = agg.NewAggregationFieldMap(originalOuputFields, t.queryParams.groupByFields, t.userAggregates)
+		if err := t.aggregationFieldMap.Validate(); err != nil {
+			return merr.WrapErrAsInputError(merr.WrapErrParameterInvalidMsg(err.Error()))
+		}
 	} else {
 		outputFieldIDs, err := translateToOutputFieldIDs(t.translatedOutputFields, schema.CollectionSchema)
 		if err != nil {

--- a/internal/querynodev2/segments/agg_reducer_test.go
+++ b/internal/querynodev2/segments/agg_reducer_test.go
@@ -8,8 +8,11 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/agg"
 	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/planpb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/segcorepb"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
@@ -650,6 +653,160 @@ func (s *AggReduceSuite) TestSegCoreAggReduceGlobalAgg() {
 	s.Equal(1, len(reducedRes.GetFieldsData()[1].GetScalars().GetLongData().GetData()))
 	s.Equal(int64(460), reducedRes.GetFieldsData()[0].GetScalars().GetLongData().GetData()[0])
 	s.Equal(int64(250), reducedRes.GetFieldsData()[1].GetScalars().GetLongData().GetData()[0])
+}
+
+// TestCreateReducerGroupByOnlyPushesDownLimit verifies that when only GROUP BY
+// is present (no aggregation), the user limit IS pushed down to QN level.
+// Uses 2 results to exercise the multi-result path where canEarlyStop=true.
+func (s *AggReduceSuite) TestCreateReducerGroupByOnlyPushesDownLimit() {
+	schema := &schemapb.CollectionSchema{
+		Name: "test_collection",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 101, Name: "gk", DataType: schemapb.DataType_Int64},
+		},
+	}
+	req := &querypb.QueryRequest{
+		Req: &internalpb.RetrieveRequest{
+			GroupByFieldIds: []int64{101},
+			Limit:           3,
+		},
+	}
+
+	// Group-by only: limit should be pushed down
+	segcoreReducer := CreateSegCoreReducer(req, schema, nil)
+	s.IsType(&SegcoreAggReducer{}, segcoreReducer)
+	internalReducer := CreateInternalReducer(req, schema)
+	s.IsType(&InternalAggReducer{}, internalReducer)
+
+	// Two segment results with distinct keys (no aggregation, just group-by dedup).
+	// Segment 1: keys {1,2,3,4,5}, Segment 2: keys {6,7,8,9,10}
+	// Total 10 distinct groups, but groupLimit=3 → early-stop should kick in.
+	seg1 := agg.AggResult2internalResult(agg.NewAggregationResult([]*schemapb.FieldData{
+		{
+			Type: schemapb.DataType_Int64,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_LongData{
+						LongData: &schemapb.LongArray{Data: []int64{1, 2, 3, 4, 5}},
+					},
+				},
+			},
+		},
+	}, 5))
+	seg2 := agg.AggResult2internalResult(agg.NewAggregationResult([]*schemapb.FieldData{
+		{
+			Type: schemapb.DataType_Int64,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_LongData{
+						LongData: &schemapb.LongArray{Data: []int64{6, 7, 8, 9, 10}},
+					},
+				},
+			},
+		},
+	}, 5))
+
+	reduced, err := internalReducer.(*InternalAggReducer).Reduce(context.Background(),
+		[]*internalpb.RetrieveResults{seg1, seg2})
+	s.NoError(err)
+	s.NotNil(reduced)
+	// groupLimit=3: multi-result path with canEarlyStop=true should produce at most 3 groups
+	keys := reduced.GetFieldsData()[0].GetScalars().GetLongData().GetData()
+	s.LessOrEqual(len(keys), 3)
+}
+
+// TestCreateReducerWithAggDisablesLimitPushDown verifies that when aggregation
+// is present, limit is NOT pushed down (set to -1) to avoid incorrect aggregation.
+// Uses 2 results with overlapping keys to exercise the multi-result merge path.
+func (s *AggReduceSuite) TestCreateReducerWithAggDisablesLimitPushDown() {
+	schema := &schemapb.CollectionSchema{
+		Name: "test_collection",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 101, Name: "gk", DataType: schemapb.DataType_Int64},
+			{FieldID: 102, Name: "val", DataType: schemapb.DataType_Int64},
+		},
+	}
+	req := &querypb.QueryRequest{
+		Req: &internalpb.RetrieveRequest{
+			GroupByFieldIds: []int64{101},
+			Aggregates: []*planpb.Aggregate{
+				{Op: planpb.AggregateOp_sum, FieldId: 102},
+			},
+			Limit: 2,
+		},
+	}
+
+	// Group-by + aggregation: limit should NOT be pushed down (groupLimit=-1 at QN)
+	internalReducer := CreateInternalReducer(req, schema)
+	s.IsType(&InternalAggReducer{}, internalReducer)
+
+	// Two segment results with overlapping key=1.
+	// Segment 1: {1:10, 2:20, 3:30}, Segment 2: {1:100, 4:40, 5:50}
+	// If limit were wrongly pushed down (groupLimit=2), early-stop could miss key=1
+	// from segment 2, producing SUM=10 instead of 110.
+	seg1 := agg.AggResult2internalResult(agg.NewAggregationResult([]*schemapb.FieldData{
+		{
+			Type: schemapb.DataType_Int64,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_LongData{
+						LongData: &schemapb.LongArray{Data: []int64{1, 2, 3}},
+					},
+				},
+			},
+		},
+		{
+			Type: schemapb.DataType_Int64,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_LongData{
+						LongData: &schemapb.LongArray{Data: []int64{10, 20, 30}},
+					},
+				},
+			},
+		},
+	}, 3))
+	seg2 := agg.AggResult2internalResult(agg.NewAggregationResult([]*schemapb.FieldData{
+		{
+			Type: schemapb.DataType_Int64,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_LongData{
+						LongData: &schemapb.LongArray{Data: []int64{1, 4, 5}},
+					},
+				},
+			},
+		},
+		{
+			Type: schemapb.DataType_Int64,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_LongData{
+						LongData: &schemapb.LongArray{Data: []int64{100, 40, 50}},
+					},
+				},
+			},
+		},
+	}, 3))
+
+	reduced, err := internalReducer.(*InternalAggReducer).Reduce(context.Background(),
+		[]*internalpb.RetrieveResults{seg1, seg2})
+	s.NoError(err)
+	s.NotNil(reduced)
+	// With aggregation, QN level groupLimit=-1 → all 5 distinct groups must survive,
+	// and key=1 must have the fully merged SUM(10+100)=110.
+	keys := reduced.GetFieldsData()[0].GetScalars().GetLongData().GetData()
+	vals := reduced.GetFieldsData()[1].GetScalars().GetLongData().GetData()
+	s.Equal(5, len(keys))
+	aggMap := make(map[int64]int64, len(keys))
+	for i := range keys {
+		aggMap[keys[i]] = vals[i]
+	}
+	s.Equal(int64(110), aggMap[1], "key=1 SUM must be 10+100=110, not partially merged")
+	s.Equal(int64(20), aggMap[2])
+	s.Equal(int64(30), aggMap[3])
+	s.Equal(int64(40), aggMap[4])
+	s.Equal(int64(50), aggMap[5])
 }
 
 func TestAggReduce(t *testing.T) {

--- a/internal/querynodev2/segments/reducer.go
+++ b/internal/querynodev2/segments/reducer.go
@@ -21,7 +21,15 @@ type internalReducer interface {
 
 func CreateInternalReducer(req *querypb.QueryRequest, schema *schemapb.CollectionSchema) internalReducer {
 	if len(req.GetReq().GetAggregates()) > 0 || len(req.GetReq().GetGroupByFieldIds()) > 0 {
-		return NewInternalAggReducer(req.GetReq().GetGroupByFieldIds(), req.GetReq().GetAggregates(), req.GetReq().GetLimit(), schema)
+		groupLimit := req.GetReq().GetLimit()
+		if len(req.GetReq().GetAggregates()) > 0 {
+			// When aggregation exists, do not push down limit — intermediate
+			// reduce with limit produces incorrect aggregation values when the
+			// same group key exists across multiple shards. Only the final
+			// Proxy-level reduce should truncate.
+			groupLimit = -1
+		}
+		return NewInternalAggReducer(req.GetReq().GetGroupByFieldIds(), req.GetReq().GetAggregates(), groupLimit, schema)
 	}
 	return newDefaultLimitReducer(req, schema)
 }
@@ -32,7 +40,15 @@ type segCoreReducer interface {
 
 func CreateSegCoreReducer(req *querypb.QueryRequest, schema *schemapb.CollectionSchema, manager *Manager) segCoreReducer {
 	if len(req.GetReq().GetGroupByFieldIds()) > 0 || len(req.GetReq().GetAggregates()) > 0 {
-		return NewSegcoreAggReducer(req.GetReq().GetGroupByFieldIds(), req.GetReq().GetAggregates(), req.GetReq().GetLimit(), schema)
+		groupLimit := req.GetReq().GetLimit()
+		if len(req.GetReq().GetAggregates()) > 0 {
+			// When aggregation exists, do not push down limit — intermediate
+			// reduce with limit produces incorrect aggregation values when the
+			// same group key exists across multiple segments. Only the final
+			// Proxy-level reduce should truncate.
+			groupLimit = -1
+		}
+		return NewSegcoreAggReducer(req.GetReq().GetGroupByFieldIds(), req.GetReq().GetAggregates(), groupLimit, schema)
 	}
 
 	return newDefaultLimitReducerSegcore(req, schema, manager)

--- a/tests/go_client/testcases/query_iterator_test.go
+++ b/tests/go_client/testcases/query_iterator_test.go
@@ -175,7 +175,7 @@ func TestQueryIteratorInvalid(t *testing.T) {
 
 	// query iterator with count(*)
 	_, errOutput := mc.QueryIterator(ctx, client.NewQueryIteratorOption(schema.CollectionName).WithOutputFields(common.QueryCountFieldName))
-	common.CheckErr(t, errOutput, false, "count entities with pagination is not allowed", "count(*)")
+	common.CheckErr(t, errOutput, false, "not allowed in output_fields")
 
 	// query iterator with invalid batch size
 	for _, batch := range []int{-1, 0} {

--- a/tests/python_client/testcases/test_query_aggregation.py
+++ b/tests/python_client/testcases/test_query_aggregation.py
@@ -1168,8 +1168,7 @@ class TestQueryAggregationSharedV2(TestMilvusClientV2Base):
         client = self._client()
 
         # Try to mix regular field (c3) with aggregation - c3 is not in group_by_fields
-        # Note: The error message is not precise enough, should be improved (see GitHub issue)
-        error = {ct.err_code: 65535, ct.err_msg: "no indices found for output field"}
+        error = {ct.err_code: 65535, ct.err_msg: "is not allowed in output_fields"}
         self.query(
             client,
             self.collection_name,


### PR DESCRIPTION
## Summary
- Fix `limit` parameter being completely ignored in GROUP BY aggregation queries
- Remove groupLimit from QN-level reducers (SegcoreAggReducer, InternalAggReducer) — intermediate truncation produces incorrect aggregation values when the same group key exists across multiple segments/shards
- Add truncation in the `len(results)==1` shortcut path so Proxy-level MilvusAggReducer correctly enforces the user's limit

## Root Cause
`GroupAggReducer.Reduce()` has a shortcut at `aggregate_reducer.go:288`:
```go
if len(results) == 1 {
    return results[0], nil  // groupLimit completely bypassed
}
```
In standalone/small deployments, all three reduce levels (Segcore→Internal→Proxy) get `len(results)==1`, so the user's `limit` is never applied.

Additionally, applying groupLimit at QN level is incorrect — truncating intermediate results discards groups that need accumulation from other segments/shards, producing wrong aggregation values.

## Test plan
- [ ] GROUP BY aggregation with `limit=2` returns exactly 2 groups (was returning all groups)
- [ ] GROUP BY aggregation without `limit` still returns all groups
- [ ] Multi-shard scenario: aggregation values are correct when same group key spans multiple shards
- [ ] Existing aggregation unit tests pass

issue: #47326
issue: #47329

🤖 Generated with [Claude Code](https://claude.com/claude-code)