### PR TITLE
fix: [2.5]dynamic update of replica number

### DIFF
--- a/internal/querycoordv2/job/job_update.go
+++ b/internal/querycoordv2/job/job_update.go
@@ -160,6 +160,9 @@ func (job *UpdateLoadConfigJob) Execute() error {
 	// 6. recover node distribution among replicas
 	utils.RecoverReplicaOfCollection(job.ctx, job.meta, job.collectionID)
 
+	// Remove RONodes with empty channel/segment from the replica.
+	job.meta.ResourceManager.HandleNodeChangeOnReplica()
+
 	// 7. update replica number in meta
 	err = job.meta.UpdateReplicaNumber(job.ctx, job.collectionID, job.newReplicaNumber, job.userSpecifiedReplicaMode)
 	if err != nil {

--- a/internal/querycoordv2/meta/replica_manager.go
+++ b/internal/querycoordv2/meta/replica_manager.go
@@ -44,6 +44,7 @@ type ReplicaManager struct {
 	replicas      map[typeutil.UniqueID]*Replica
 	coll2Replicas map[typeutil.UniqueID]*collectionReplicas // typeutil.UniqueSet
 	catalog       metastore.QueryCoordCatalog
+	distMgr       *DistributionManager
 }
 
 // collectionReplicas maintains collection secondary index mapping
@@ -77,7 +78,13 @@ func NewReplicaManager(idAllocator func() (int64, error), catalog metastore.Quer
 		replicas:      make(map[int64]*Replica),
 		coll2Replicas: make(map[int64]*collectionReplicas),
 		catalog:       catalog,
+		distMgr:       nil,
 	}
+}
+
+// set distribution manager
+func (m *ReplicaManager) SetDistributionManager(distMgr *DistributionManager) {
+	m.distMgr = distMgr
 }
 
 // Recover recovers the replicas for given collections from meta store
@@ -418,7 +425,7 @@ func (m *ReplicaManager) RecoverNodesInCollection(ctx context.Context, collectio
 	// recover node by resource group.
 	helper.RangeOverResourceGroup(func(replicaHelper *replicasInSameRGAssignmentHelper) {
 		replicaHelper.RangeOverReplicas(func(assignment *replicaAssignmentInfo) {
-			roNodes := assignment.GetNewRONodes()
+			roNodes := assignment.GetNewRONodesHeuristic(m.distMgr, m.replicas[assignment.GetReplicaID()])
 			recoverableNodes, incomingNodeCount := assignment.GetRecoverNodesAndIncomingNodeCount()
 			// There may be not enough incoming nodes for current replica,
 			// Even we filtering the nodes that are used by other replica of same collection in other resource group,

--- a/internal/querycoordv2/meta/replica_manager_helper.go
+++ b/internal/querycoordv2/meta/replica_manager_helper.go
@@ -243,7 +243,7 @@ func (s *replicaAssignmentInfo) GetNewRONodesHeuristic(distMgr *DistributionMana
 			scoredNodes = append(scoredNodes, nodeScore{nodeID: node, score: len(channels)*weight + len(segments)})
 			return true
 		})
-		sort.Slice(scoredNodes, func(i, j int) bool {
+		sort.SliceStable(scoredNodes, func(i, j int) bool {
 			return scoredNodes[i].score < scoredNodes[j].score
 		})
 		for i := 0; i < cnt; i++ {

--- a/internal/querycoordv2/meta/replica_manager_helper.go
+++ b/internal/querycoordv2/meta/replica_manager_helper.go
@@ -217,6 +217,42 @@ func (s *replicaAssignmentInfo) GetNewRONodes() []int64 {
 	return newRONodes
 }
 
+// Prioritize retaining the shard leader in the replicas.
+func (s *replicaAssignmentInfo) GetNewRONodesHeuristic(distMgr *DistributionManager, replica *Replica) []int64 {
+	if distMgr == nil {
+		return s.GetNewRONodes()
+	}
+	newRONodes := make([]int64, 0, s.newRONodes.Len())
+	// not in current resource group must be set ro.
+	for nodeID := range s.newRONodes {
+		newRONodes = append(newRONodes, nodeID)
+	}
+
+	// too much node is occupied by current replica, then set some node to ro.
+	if s.rwNodes.Len() > s.expectedNodeCount {
+		cnt := s.rwNodes.Len() - s.expectedNodeCount
+		type nodeScore struct {
+			nodeID int64
+			score  int
+		}
+		var scoredNodes []nodeScore = make([]nodeScore, 0, s.rwNodes.Len())
+		const weight = 10000
+		s.rwNodes.Range(func(node int64) bool {
+			channels := distMgr.ChannelDistManager.GetByCollectionAndFilter(replica.GetCollectionID(), WithNodeID2Channel(node))
+			segments := distMgr.SegmentDistManager.GetByFilter(WithCollectionID(replica.GetCollectionID()), WithNodeID(node))
+			scoredNodes = append(scoredNodes, nodeScore{nodeID: node, score: len(channels)*weight + len(segments)})
+			return true
+		})
+		sort.Slice(scoredNodes, func(i, j int) bool {
+			return scoredNodes[i].score < scoredNodes[j].score
+		})
+		for i := 0; i < cnt; i++ {
+			newRONodes = append(newRONodes, scoredNodes[i].nodeID)
+		}
+	}
+	return newRONodes
+}
+
 // GetRecoverNodesAndIncomingNodeCount returns the recoverable ro nodes and incoming node count for these replica.
 func (s *replicaAssignmentInfo) GetRecoverNodesAndIncomingNodeCount() (recoverNodes []int64, incomingNodeCount int) {
 	recoverNodes = make([]int64, 0, s.recoverableRONodes.Len())

--- a/internal/querycoordv2/meta/resource_manager.go
+++ b/internal/querycoordv2/meta/resource_manager.go
@@ -512,6 +512,12 @@ func (rm *ResourceManager) handleNodeDown(ctx context.Context, node int64) {
 	)
 }
 
+func (rm *ResourceManager) HandleNodeChangeOnReplica() {
+	rm.rwmutex.Lock()
+	defer rm.rwmutex.Unlock()
+	rm.nodeChangedNotifier.NotifyAll()
+}
+
 func (rm *ResourceManager) HandleNodeStopping(ctx context.Context, node int64) {
 	rm.rwmutex.Lock()
 	defer rm.rwmutex.Unlock()

--- a/internal/querycoordv2/observers/replica_observer.go
+++ b/internal/querycoordv2/observers/replica_observer.go
@@ -153,4 +153,9 @@ func (ob *ReplicaObserver) checkNodesInReplica() {
 			)
 		}
 	}
+
+	// Add unused nodes to the replica promptly.
+	for _, collectionID := range collections {
+		utils.RecoverReplicaOfCollection(ctx, ob.meta, collectionID)
+	}
 }

--- a/internal/querycoordv2/observers/target_observer.go
+++ b/internal/querycoordv2/observers/target_observer.go
@@ -393,6 +393,7 @@ func (ob *TargetObserver) shouldUpdateCurrentTarget(ctx context.Context, collect
 		return false
 	}
 
+	allChannelsReady := true
 	collectionReadyLeaders := make([]*meta.LeaderView, 0)
 	for channel := range channelNames {
 		channelReadyLeaders := lo.Filter(ob.distMgr.LeaderViewManager.GetByFilter(meta.WithChannelName2LeaderView(channel)), func(leader *meta.LeaderView, _ int) bool {
@@ -405,7 +406,7 @@ func (ob *TargetObserver) shouldUpdateCurrentTarget(ctx context.Context, collect
 				zap.Int("readyReplicaNum", len(channelReadyLeaders)),
 				zap.String("channelName", channel),
 			)
-			return false
+			allChannelsReady = false
 		}
 		collectionReadyLeaders = append(collectionReadyLeaders, channelReadyLeaders...)
 	}
@@ -444,7 +445,7 @@ func (ob *TargetObserver) shouldUpdateCurrentTarget(ctx context.Context, collect
 			return false
 		}
 	}
-	return true
+	return allChannelsReady
 }
 
 func (ob *TargetObserver) sync(ctx context.Context, replica *meta.Replica, leaderView *meta.LeaderView, diffs []*querypb.SyncAction,

--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -469,6 +469,9 @@ func (s *Server) initMeta() error {
 		ChannelDistManager: meta.NewChannelDistManager(),
 		LeaderViewManager:  meta.NewLeaderViewManager(),
 	}
+
+	s.meta.ReplicaManager.SetDistributionManager(s.dist)
+
 	s.targetMgr = meta.NewTargetManager(s.broker, s.meta)
 	err = s.targetMgr.Recover(s.ctx, s.store)
 	if err != nil {

--- a/internal/querycoordv2/task/scheduler.go
+++ b/internal/querycoordv2/task/scheduler.go
@@ -791,6 +791,11 @@ func (scheduler *taskScheduler) schedule(node int64) {
 		scheduler.remove(task)
 	}
 
+	// After completing the migration task, check whether RONodes with empty channels/segments need to be migrated out of the replica.
+	if len(toRemove) > 0 {
+		scheduler.meta.ResourceManager.HandleNodeChangeOnReplica()
+	}
+
 	scheduler.updateTaskMetrics()
 
 	log.Info("processed tasks",


### PR DESCRIPTION
Fix: Deadlock issue caused by dynamically updating replica numbers

In Milvus 2.5, when dynamically updating the replica number of a collection, a complete channel migration requires updating the shard leader's leader view. However, updating the distribution requires all channels to complete the migration. This circular dependency can lead to a deadlock issue when dynamically updating the collection's replica number.

A solution is to partially update the shard leader's distribution to advance the target version, thereby completing the channel migration task. Finally, after all channel tasks have been migrated, the target switch is sent.

Additionally, the algorithm for removing redundant RWNodes from the replica list has been optimized, prioritizing keeping the leader among the replicas.