### PR TITLE
enhance: enable Go BoringCrypto (FIPS 140-2) for milvus binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,12 @@ use_opendal = OFF
 ifdef USE_OPENDAL
 	use_opendal = ${USE_OPENDAL}
 endif
+
+# FIPS: default OFF. Set MILVUS_FIPS_ENABLED=ON to enable BoringCrypto.
+GOEXPERIMENT_FLAG :=
+ifeq ($(MILVUS_FIPS_ENABLED),ON)
+	GOEXPERIMENT_FLAG := GOEXPERIMENT=boringcrypto
+endif
 # golangci-lint
 GOLANGCI_LINT_VERSION := 1.64.7
 GOLANGCI_LINT_OUTPUT := $(shell $(INSTALL_PATH)/golangci-lint --version 2>/dev/null)
@@ -102,7 +108,7 @@ build-go:
 	@echo "Building Milvus ..."
 	@source $(PWD)/scripts/setenv.sh && \
 		mkdir -p $(INSTALL_PATH) && go env -w CGO_ENABLED="1" && \
-		CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CFLAGS="$(CGO_CFLAGS)" GO111MODULE=on $(GO) build -pgo=$(PGO_PATH)/default.pgo -ldflags="-r $${RPATH} -X '$(OBJPREFIX).BuildTags=$(BUILD_TAGS)' -X '$(OBJPREFIX).BuildTime=$(BUILD_TIME)' -X '$(OBJPREFIX).GitCommit=$(GIT_COMMIT)' -X '$(OBJPREFIX).GoVersion=$(GO_VERSION)'" \
+		$(GOEXPERIMENT_FLAG) CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CFLAGS="$(CGO_CFLAGS)" GO111MODULE=on $(GO) build -pgo=$(PGO_PATH)/default.pgo -ldflags="-r $${RPATH} -X '$(OBJPREFIX).BuildTags=$(BUILD_TAGS)' -X '$(OBJPREFIX).BuildTime=$(BUILD_TIME)' -X '$(OBJPREFIX).GitCommit=$(GIT_COMMIT)' -X '$(OBJPREFIX).GoVersion=$(GO_VERSION)'" \
 		-tags $(MILVUS_GO_BUILD_TAGS) -o $(INSTALL_PATH)/milvus $(PWD)/cmd/main.go 1>/dev/null
 
 milvus-gpu: build-cpp-gpu print-gpu-build-info

--- a/build/docker/milvus/amazonlinux2023/Dockerfile
+++ b/build/docker/milvus/amazonlinux2023/Dockerfile
@@ -28,11 +28,14 @@ COPY --chown=root:root --chmod=774 ./configs/ /milvus/configs/
 
 COPY --chown=root:root --chmod=774 ./lib/ /milvus/lib/
 
+RUN openssl fipsinstall -out /milvus/configs/ssl/fipsmodule.cnf -module /milvus/lib/ossl-modules/fips.so
 
 ENV PATH=/milvus/bin:$PATH
 ENV LD_LIBRARY_PATH=/milvus/lib:$LD_LIBRARY_PATH:/usr/lib
 ENV LD_PRELOAD=${MILVUS_ASAN_LIB}:/milvus/lib/libjemalloc.so
 ENV MALLOC_CONF=background_thread:true
+ENV OPENSSL_CONF=/milvus/configs/ssl/openssl-fips.cnf
+ENV OPENSSL_MODULES=/milvus/lib/ossl-modules
 
 ENTRYPOINT ["/tini", "--"]
 

--- a/build/docker/milvus/amazonlinux2023/Dockerfile
+++ b/build/docker/milvus/amazonlinux2023/Dockerfile
@@ -34,8 +34,9 @@ ENV PATH=/milvus/bin:$PATH
 ENV LD_LIBRARY_PATH=/milvus/lib:$LD_LIBRARY_PATH:/usr/lib
 ENV LD_PRELOAD=${MILVUS_ASAN_LIB}:/milvus/lib/libjemalloc.so
 ENV MALLOC_CONF=background_thread:true
-ENV OPENSSL_CONF=/milvus/configs/ssl/openssl-fips.cnf
 ENV OPENSSL_MODULES=/milvus/lib/ossl-modules
+# OPENSSL_CONF is not set here — deployment decides whether to enable FIPS.
+# To enable: set OPENSSL_CONF=/milvus/configs/ssl/openssl-fips.cnf at deployment.
 
 ENTRYPOINT ["/tini", "--"]
 

--- a/build/docker/milvus/gpu/ubuntu22.04/Dockerfile
+++ b/build/docker/milvus/gpu/ubuntu22.04/Dockerfile
@@ -23,10 +23,14 @@ COPY --chown=root:root --chmod=774 ./bin/milvus /milvus/bin/milvus
 COPY --chown=root:root --chmod=774 ./configs/ /milvus/configs/
 COPY --chown=root:root --chmod=774 ./lib/ /milvus/lib/
 
+RUN openssl fipsinstall -out /milvus/configs/ssl/fipsmodule.cnf -module /milvus/lib/ossl-modules/fips.so
+
 ENV PATH=/milvus/bin:$PATH
 ENV LD_LIBRARY_PATH=/milvus/lib:$LD_LIBRARY_PATH:/usr/lib
 ENV LD_PRELOAD=/milvus/lib/libjemalloc.so
 ENV MALLOC_CONF=background_thread:true
+ENV OPENSSL_CONF=/milvus/configs/ssl/openssl-fips.cnf
+ENV OPENSSL_MODULES=/milvus/lib/ossl-modules
 
 ENTRYPOINT ["/tini", "--"]
 

--- a/build/docker/milvus/gpu/ubuntu22.04/Dockerfile
+++ b/build/docker/milvus/gpu/ubuntu22.04/Dockerfile
@@ -29,8 +29,9 @@ ENV PATH=/milvus/bin:$PATH
 ENV LD_LIBRARY_PATH=/milvus/lib:$LD_LIBRARY_PATH:/usr/lib
 ENV LD_PRELOAD=/milvus/lib/libjemalloc.so
 ENV MALLOC_CONF=background_thread:true
-ENV OPENSSL_CONF=/milvus/configs/ssl/openssl-fips.cnf
 ENV OPENSSL_MODULES=/milvus/lib/ossl-modules
+# OPENSSL_CONF is not set here — deployment decides whether to enable FIPS.
+# To enable: set OPENSSL_CONF=/milvus/configs/ssl/openssl-fips.cnf at deployment.
 
 ENTRYPOINT ["/tini", "--"]
 

--- a/build/docker/milvus/rockylinux8/Dockerfile
+++ b/build/docker/milvus/rockylinux8/Dockerfile
@@ -39,8 +39,9 @@ ENV PATH=/milvus/bin:$PATH
 ENV LD_LIBRARY_PATH=/milvus/lib:$LD_LIBRARY_PATH:/usr/lib
 ENV LD_PRELOAD=${MILVUS_ASAN_LIB}:/milvus/lib/libjemalloc.so
 ENV MALLOC_CONF=background_thread:true
-ENV OPENSSL_CONF=/milvus/configs/ssl/openssl-fips.cnf
 ENV OPENSSL_MODULES=/milvus/lib/ossl-modules
+# OPENSSL_CONF is not set here — deployment decides whether to enable FIPS.
+# To enable: set OPENSSL_CONF=/milvus/configs/ssl/openssl-fips.cnf at deployment.
 
 ENTRYPOINT ["/tini", "--"]
 

--- a/build/docker/milvus/rockylinux8/Dockerfile
+++ b/build/docker/milvus/rockylinux8/Dockerfile
@@ -33,10 +33,14 @@ COPY ./configs/ /milvus/configs/
 
 COPY ./lib/ /milvus/lib/
 
+RUN openssl fipsinstall -out /milvus/configs/ssl/fipsmodule.cnf -module /milvus/lib/ossl-modules/fips.so
+
 ENV PATH=/milvus/bin:$PATH
 ENV LD_LIBRARY_PATH=/milvus/lib:$LD_LIBRARY_PATH:/usr/lib
 ENV LD_PRELOAD=${MILVUS_ASAN_LIB}:/milvus/lib/libjemalloc.so
 ENV MALLOC_CONF=background_thread:true
+ENV OPENSSL_CONF=/milvus/configs/ssl/openssl-fips.cnf
+ENV OPENSSL_MODULES=/milvus/lib/ossl-modules
 
 ENTRYPOINT ["/tini", "--"]
 

--- a/build/docker/milvus/ubuntu22.04/Dockerfile
+++ b/build/docker/milvus/ubuntu22.04/Dockerfile
@@ -38,10 +38,14 @@ COPY --chown=root:root --chmod=774 ./configs/ /milvus/configs/
 
 COPY --chown=root:root --chmod=774 ./lib/ /milvus/lib/
 
+RUN openssl fipsinstall -out /milvus/configs/ssl/fipsmodule.cnf -module /milvus/lib/ossl-modules/fips.so
+
 ENV PATH=/milvus/bin:$PATH
 ENV LD_LIBRARY_PATH=/milvus/lib:$LD_LIBRARY_PATH:/usr/lib
 ENV LD_PRELOAD=${MILVUS_ASAN_LIB}:/milvus/lib/libjemalloc.so
 ENV MALLOC_CONF=background_thread:true
+ENV OPENSSL_CONF=/milvus/configs/ssl/openssl-fips.cnf
+ENV OPENSSL_MODULES=/milvus/lib/ossl-modules
 
 ENTRYPOINT ["/tini", "--"]
 

--- a/build/docker/milvus/ubuntu22.04/Dockerfile
+++ b/build/docker/milvus/ubuntu22.04/Dockerfile
@@ -44,8 +44,9 @@ ENV PATH=/milvus/bin:$PATH
 ENV LD_LIBRARY_PATH=/milvus/lib:$LD_LIBRARY_PATH:/usr/lib
 ENV LD_PRELOAD=${MILVUS_ASAN_LIB}:/milvus/lib/libjemalloc.so
 ENV MALLOC_CONF=background_thread:true
-ENV OPENSSL_CONF=/milvus/configs/ssl/openssl-fips.cnf
 ENV OPENSSL_MODULES=/milvus/lib/ossl-modules
+# OPENSSL_CONF is not set here — deployment decides whether to enable FIPS.
+# To enable: set OPENSSL_CONF=/milvus/configs/ssl/openssl-fips.cnf at deployment.
 
 ENTRYPOINT ["/tini", "--"]
 

--- a/cmd/milvus/boring_disabled.go
+++ b/cmd/milvus/boring_disabled.go
@@ -1,0 +1,7 @@
+//go:build !boringcrypto
+
+package milvus
+
+func boringEnabled() bool {
+	return false
+}

--- a/cmd/milvus/boring_enabled.go
+++ b/cmd/milvus/boring_enabled.go
@@ -1,0 +1,9 @@
+//go:build boringcrypto
+
+package milvus
+
+import "crypto/boring"
+
+func boringEnabled() bool {
+	return boring.Enabled()
+}

--- a/cmd/milvus/run.go
+++ b/cmd/milvus/run.go
@@ -60,6 +60,7 @@ func (c *run) printBanner(w io.Writer) {
 	fmt.Fprintln(w, "Built:     "+BuildTime)
 	fmt.Fprintln(w, "GitCommit: "+GitCommit)
 	fmt.Fprintln(w, "GoVersion: "+GoVersion)
+	fmt.Fprintf(w, "Milvus FIPS in Go: BoringCrypto %v\n", boringEnabled())
 	fmt.Fprintln(w)
 	metrics.BuildInfo.WithLabelValues(common.Version.String(), BuildTime, GitCommit).Set(1)
 }

--- a/configs/ssl/openssl-fips.cnf
+++ b/configs/ssl/openssl-fips.cnf
@@ -1,0 +1,21 @@
+config_diagnostics = 1
+openssl_conf = openssl_init
+
+.include /milvus/configs/ssl/fipsmodule.cnf
+
+[openssl_init]
+providers = provider_sect
+alg_section = algorithm_sect
+
+[provider_sect]
+fips = fips_sect
+base = base_sect
+
+[fips_sect]
+activate = 1
+
+[base_sect]
+activate = 1
+
+[algorithm_sect]
+default_properties = fips=yes

--- a/internal/core/src/common/init_c.cpp
+++ b/internal/core/src/common/init_c.cpp
@@ -101,7 +101,7 @@ SetExprResCacheCapacityBytes(int64_t bytes) {
 void
 LogOpenSSLFIPSStatus() {
     std::call_once(fipsFlag, []() {
-        LOG_INFO("OpenSSL FIPS mode: {}",
+        LOG_INFO("Milvus FIPS in OpenSSL: {}",
                  EVP_default_properties_is_fips_enabled(NULL) ? "enabled"
                                                               : "disabled");
     });

--- a/internal/core/src/common/init_c.cpp
+++ b/internal/core/src/common/init_c.cpp
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 #include <mutex>
+#include <openssl/evp.h>
 #include "common/init_c.h"
 #include "common/Common.h"
 #include "common/Tracer.h"
@@ -24,6 +25,7 @@
 
 std::once_flag traceFlag;
 std::once_flag cpuNumFlag;
+std::once_flag fipsFlag;
 
 void
 InitCpuNum(const int value) {
@@ -94,6 +96,15 @@ void
 SetExprResCacheCapacityBytes(int64_t bytes) {
     milvus::exec::ExprResCacheManager::Instance().SetCapacityBytes(
         static_cast<size_t>(bytes));
+}
+
+void
+LogOpenSSLFIPSStatus() {
+    std::call_once(fipsFlag, []() {
+        LOG_INFO("OpenSSL FIPS mode: {}",
+                 EVP_default_properties_is_fips_enabled(NULL) ? "enabled"
+                                                              : "disabled");
+    });
 }
 
 void

--- a/internal/core/src/common/init_c.h
+++ b/internal/core/src/common/init_c.h
@@ -67,6 +67,10 @@ InitTrace(CTraceConfig* config);
 void
 SetTrace(CTraceConfig* config);
 
+// OpenSSL FIPS status
+void
+LogOpenSSLFIPSStatus();
+
 // Expr result cache
 void
 SetExprResCacheEnable(bool val);

--- a/internal/datanode/index/init_segcore.go
+++ b/internal/datanode/index/init_segcore.go
@@ -44,6 +44,8 @@ func InitSegcore(nodeID int64) error {
 	C.IndexBuilderInit(cGlogConf)
 	C.free(unsafe.Pointer(cGlogConf))
 
+	C.LogOpenSSLFIPSStatus()
+
 	// update log level based on current setup
 	initcore.UpdateLogLevel(paramtable.Get().LogCfg.Level.GetValue())
 

--- a/internal/util/initcore/query_node.go
+++ b/internal/util/initcore/query_node.go
@@ -65,6 +65,8 @@ func doInitQueryNodeOnce(ctx context.Context) error {
 	C.SegcoreInit(cGlogConf)
 	C.free(unsafe.Pointer(cGlogConf))
 
+	C.LogOpenSSLFIPSStatus()
+
 	// update log level based on current setup
 	UpdateLogLevel(paramtable.Get().LogCfg.Level.GetValue())
 

--- a/scripts/install_milvus.sh
+++ b/scripts/install_milvus.sh
@@ -23,6 +23,7 @@ mkdir -p "$LIBRARY_PATH"
 cp $PWD"/internal/core/output/lib/"*.dylib* "$LIBRARY_PATH" 2>/dev/null || true
 cp $PWD"/internal/core/output/lib/"*.so* "$LIBRARY_PATH" || true
 cp $PWD"/internal/core/output/lib64/"*.so* "$LIBRARY_PATH" 2>/dev/null || true
+cp -r $PWD"/internal/core/output/lib/ossl-modules" "$LIBRARY_PATH" 2>/dev/null || true
 
 for LIB_PATH in $(ldd ./bin/milvus | grep -E '(asan|atomic)' | awk '{print $3}'); do
     cp "$LIB_PATH" "$LIBRARY_PATH" 2>/dev/null


### PR DESCRIPTION
- Add GOEXPERIMENT=boringcrypto to build-go target in Makefile
- Log BoringCrypto status in startup banner via build-tagged files
- Copy ossl-modules/fips.so to lib/ during install (was missing)
- Ship openssl-fips.cnf for OpenSSL FIPS provider activation

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: yangxuan <xuan.yang@zilliz.com>