### PR TITLE
enhance: [loon] route index checker tasks through LoadDiff-based reopen pipeline

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -3049,6 +3049,11 @@ ChunkedSegmentSealedImpl::ApplyLoadDiff(SegmentLoadInfo& segment_load_info,
     // drop index, must after reload binlog
     if (!diff.indexes_to_drop.empty()) {
         for (auto field_id : diff.indexes_to_drop) {
+            // Skip drop if this field already has a replacement or new index loaded
+            if (diff.indexes_to_replace.count(field_id) > 0 ||
+                diff.indexes_to_load.count(field_id) > 0) {
+                continue;
+            }
             DropIndex(field_id);
         }
     }

--- a/internal/core/src/segcore/SegmentLoadInfoTest.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfoTest.cpp
@@ -1646,6 +1646,61 @@ TEST_F(SegmentLoadInfoTest, ComputeDiffIndexReplaceMixed) {
     EXPECT_TRUE(diff.indexes_to_drop.count(FieldId(101)) > 0);
 }
 
+TEST_F(SegmentLoadInfoTest, ComputeDiffIndexReplaceDropConflict) {
+    // Verify that when a field has both indexes_to_replace and indexes_to_drop,
+    // the drop should be skipped during ApplyLoadDiff to avoid dropping the
+    // just-loaded replacement index. ComputeDiff correctly produces both entries;
+    // ApplyLoadDiff filters the drop.
+
+    // Current: field 101 has index 1001
+    proto::segcore::SegmentLoadInfo current_proto;
+    current_proto.set_segmentid(100);
+    current_proto.set_num_of_rows(1000);
+    auto* cur_index = current_proto.add_index_infos();
+    cur_index->set_fieldid(101);
+    cur_index->set_indexid(1001);
+    cur_index->add_index_file_paths("/path/to/old_index");
+    auto* cur_param = cur_index->add_index_params();
+    cur_param->set_key("index_type");
+    cur_param->set_value(knowhere::IndexEnum::INDEX_FAISS_IVFSQ8);
+
+    // New: field 101 has different index 2001 (replacement)
+    proto::segcore::SegmentLoadInfo new_proto;
+    new_proto.set_segmentid(100);
+    new_proto.set_num_of_rows(1000);
+    auto* new_index = new_proto.add_index_infos();
+    new_index->set_fieldid(101);
+    new_index->set_indexid(2001);
+    new_index->add_index_file_paths("/path/to/new_index");
+    auto* new_param = new_index->add_index_params();
+    new_param->set_key("index_type");
+    new_param->set_value(knowhere::IndexEnum::INDEX_FAISS_IVFSQ8);
+
+    SegmentLoadInfo current_info(current_proto, schema_);
+    SegmentLoadInfo new_info(new_proto, schema_);
+    auto diff = current_info.ComputeDiff(new_info);
+
+    // ComputeDiff should produce BOTH replace and drop for field 101
+    EXPECT_TRUE(diff.indexes_to_replace.count(FieldId(101)) > 0);
+    EXPECT_TRUE(diff.indexes_to_drop.count(FieldId(101)) > 0);
+
+    // Verify the replacement has the correct new index_id
+    EXPECT_EQ(diff.indexes_to_replace[FieldId(101)][0].index_id, 2001);
+
+    // Simulate the ApplyLoadDiff filter: fields with replace should be skipped
+    // in the drop loop
+    std::vector<FieldId> actually_dropped;
+    for (auto field_id : diff.indexes_to_drop) {
+        if (diff.indexes_to_replace.count(field_id) > 0 ||
+            diff.indexes_to_load.count(field_id) > 0) {
+            continue;
+        }
+        actually_dropped.push_back(field_id);
+    }
+    // Field 101 has a replacement, so it should NOT be dropped
+    EXPECT_TRUE(actually_dropped.empty());
+}
+
 TEST_F(SegmentLoadInfoTest, ComputeDiffBinlogReplace) {
     // When a field's binlog group changes, it goes to binlogs_to_replace
 

--- a/internal/querycoordv2/checkers/index_checker.go
+++ b/internal/querycoordv2/checkers/index_checker.go
@@ -128,8 +128,7 @@ func (c *IndexChecker) checkReplica(ctx context.Context, collection *meta.Collec
 
 	idSegmentsStats := make(map[int64]*meta.Segment)
 	targetsStats := make(map[int64][]int64) // segmentID => FieldID
-	redundant := make(map[int64][]int64)    // segmentID => indexIDs
-	redundantSegments := make(map[int64]*meta.Segment)
+	segmentsToUpdate := typeutil.NewSet[int64]()
 	for _, segment := range segments {
 		// skip update index in read only node
 		if roNodeSet.Contain(segment.Node) {
@@ -147,12 +146,10 @@ func (c *IndexChecker) checkReplica(ctx context.Context, collection *meta.Collec
 
 		redundantIndices := c.checkRedundantIndices(segment, indexInfos)
 		if len(redundantIndices) > 0 {
-			redundant[segment.GetID()] = redundantIndices
-			redundantSegments[segment.GetID()] = segment
+			segmentsToUpdate.Insert(segment.GetID())
 		}
 	}
 
-	segmentsToUpdate := typeutil.NewSet[int64]()
 	for _, segmentIDs := range lo.Chunk(lo.Keys(idSegments), MaxSegmentNumPerGetIndexInfoRPC) {
 		segmentIndexInfos, err := c.broker.GetIndexInfo(ctx, collection.GetCollectionID(), segmentIDs...)
 		if err != nil {
@@ -199,11 +196,6 @@ func (c *IndexChecker) checkReplica(ctx context.Context, collection *meta.Collec
 	})
 	tasks = append(tasks, tasksStats...)
 
-	dropTasks := lo.FilterMap(lo.Values(redundantSegments), func(segment *meta.Segment, _ int) (task.Task, bool) {
-		return c.createSegmentIndexDropTasks(ctx, replica, segment, redundant[segment.GetID()]), true
-	})
-	tasks = append(tasks, dropTasks...)
-
 	return tasks
 }
 
@@ -242,7 +234,7 @@ func (c *IndexChecker) checkRedundantIndices(segment *meta.Segment, indexInfos [
 }
 
 func (c *IndexChecker) createSegmentUpdateTask(ctx context.Context, segment *meta.Segment, replica *meta.Replica) (task.Task, bool) {
-	action := task.NewSegmentActionWithScope(segment.Node, task.ActionTypeUpdate, segment.GetInsertChannel(), segment.GetID(), querypb.DataScope_Historical, int(segment.GetNumOfRows()))
+	action := task.NewSegmentActionWithScope(segment.Node, task.ActionTypeReopen, segment.GetInsertChannel(), segment.GetID(), querypb.DataScope_Historical, int(segment.GetNumOfRows()))
 	t, err := task.NewSegmentTask(
 		ctx,
 		params.Params.QueryCoordCfg.SegmentTaskTimeout.GetAsDuration(time.Millisecond),
@@ -319,15 +311,4 @@ func (c *IndexChecker) createSegmentStatsUpdateTask(ctx context.Context, segment
 	t.SetPriority(task.TaskPriorityLow)
 	t.SetReason("missing json stats")
 	return t, true
-}
-
-func (c *IndexChecker) createSegmentIndexDropTasks(ctx context.Context, replica *meta.Replica, segment *meta.Segment, indexIDs []int64) task.Task {
-	if len(indexIDs) == 0 {
-		return nil
-	}
-	action := task.NewDropIndexAction(segment.Node, task.ActionTypeDropIndex, segment.GetInsertChannel(), indexIDs)
-	t := task.NewDropIndexTask(ctx, c.ID(), replica.GetCollectionID(), replica, segment.GetID(), action)
-	t.SetPriority(task.TaskPriorityLow)
-	t.SetReason("drop index")
-	return t
 }

--- a/internal/querycoordv2/checkers/index_checker_test.go
+++ b/internal/querycoordv2/checkers/index_checker_test.go
@@ -151,7 +151,7 @@ func (suite *IndexCheckerSuite) TestLoadIndex() {
 	action, ok := t.Actions()[0].(*task.SegmentAction)
 	suite.Require().True(ok)
 	suite.EqualValues(200, t.ReplicaID())
-	suite.Equal(task.ActionTypeUpdate, action.Type())
+	suite.Equal(task.ActionTypeReopen, action.Type())
 	suite.EqualValues(2, action.GetSegmentID())
 
 	// test skip load index for read only node
@@ -351,7 +351,7 @@ func (suite *IndexCheckerSuite) TestCreateNewIndex() {
 	tasks := checker.Check(context.Background())
 	suite.Len(tasks, 1)
 	suite.Len(tasks[0].Actions(), 1)
-	suite.Equal(tasks[0].Actions()[0].(*task.SegmentAction).Type(), task.ActionTypeUpdate)
+	suite.Equal(tasks[0].Actions()[0].(*task.SegmentAction).Type(), task.ActionTypeReopen)
 }
 
 func (suite *IndexCheckerSuite) TestLoadJsonIndex() {

--- a/internal/querycoordv2/task/utils.go
+++ b/internal/querycoordv2/task/utils.go
@@ -97,7 +97,7 @@ func GetTaskType(task Task) Type {
 		return TaskTypeGrow
 	case task.Actions()[0].Type() == ActionTypeReduce:
 		return TaskTypeReduce
-	case task.Actions()[0].Type() == ActionTypeUpdate:
+	case task.Actions()[0].Type() == ActionTypeUpdate || task.Actions()[0].Type() == ActionTypeReopen:
 		return TaskTypeUpdate
 	case task.Actions()[0].Type() == ActionTypeStatsUpdate:
 		return TaskTypeStatsUpdate

--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -527,7 +527,7 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 	log.Debug("work loads segments done")
 
 	// load index segment need no stream delete and distribution change
-	if req.GetLoadScope() == querypb.LoadScope_Index {
+	if req.GetLoadScope() == querypb.LoadScope_Index || req.GetLoadScope() == querypb.LoadScope_Reopen {
 		return nil
 	}
 


### PR DESCRIPTION
Related to #44956

- Change index checker to create ActionTypeReopen instead of ActionTypeUpdate, so index loading goes through C++ ComputeDiff + ApplyLoadDiff reopen path
- Map ActionTypeReopen to TaskTypeUpdate in GetTaskType() for task dedup
- Add LoadScope_Reopen early return in delegator to skip unnecessary bloom filter / distribution updates
- Remove dead DropIndex code from index checker, redundant index removal is now handled via reopen's ComputeDiff