### PR TITLE
fix: [hf] force load priority to HIGH at querynode CGO entry layer

### DIFF
--- a/internal/util/segcore/requests.go
+++ b/internal/util/segcore/requests.go
@@ -102,7 +102,7 @@ func (req *LoadFieldDataRequest) getCLoadFieldDataRequest() (result *cLoadFieldD
 			C.SetFieldWarmupPolicy(cLoadFieldDataInfo, cFieldID, C.CacheWarmupPolicy(fieldWarmupPolicy))
 		}
 	}
-	C.SetLoadPriority(cLoadFieldDataInfo, C.int32_t(req.LoadPriority))
+	C.SetLoadPriority(cLoadFieldDataInfo, C.int32_t(commonpb.LoadPriority_HIGH))
 
 	return &cLoadFieldDataRequest{
 		cLoadFieldDataInfo: cLoadFieldDataInfo,

--- a/internal/util/segcore/segment.go
+++ b/internal/util/segcore/segment.go
@@ -390,7 +390,7 @@ func ConvertToSegcoreSegmentLoadInfo(src *querypb.SegmentLoadInfo) *segcorepb.Se
 		TextStatsLogs:    convertTextIndexStats(src.GetTextStatsLogs()),
 		Bm25Logs:         convertFieldBinlogs(src.GetBm25Logs()),
 		JsonKeyStatsLogs: convertJSONKeyStats(src.GetJsonKeyStatsLogs()),
-		Priority:         src.GetPriority(),
+		Priority:         commonpb.LoadPriority_HIGH,
 		ManifestPath:     src.GetManifestPath(),
 	}
 }


### PR DESCRIPTION
Override the load priority to always use HIGH in both ConvertToSegcoreSegmentLoadInfo and getCLoadFieldDataRequest, ignoring the value propagated from upper layers.