### PR TITLE
fix: [2.6] correct SelectNode fast-path loop and tolerance division by zero(#48212)

### DIFF
--- a/internal/proxy/shardclient/look_aside_balancer.go
+++ b/internal/proxy/shardclient/look_aside_balancer.go
@@ -110,9 +110,10 @@ func (b *LookAsideBalancer) SelectNode(ctx context.Context, availableNodes []int
 	idx := b.idx.Load()
 	if idx%b.checkWorkloadRequestNum != 0 {
 		for i := 0; i < len(availableNodes); i++ {
-			targetNode = availableNodes[int(idx)%len(availableNodes)]
-			targetMetrics, ok := b.metricsMap.Get(targetNode)
+			node := availableNodes[(int(idx)+i)%len(availableNodes)]
+			targetMetrics, ok := b.metricsMap.Get(node)
 			if !ok || !targetMetrics.unavailable.Load() {
+				targetNode = node
 				break
 			}
 		}
@@ -156,7 +157,7 @@ func (b *LookAsideBalancer) SelectNode(ctx context.Context, availableNodes []int
 		}
 	}
 
-	if float64(maxScore-minScore)/float64(minScore) <= b.workloadToleranceFactor {
+	if minScore <= 0 || float64(maxScore-minScore)/float64(minScore) <= b.workloadToleranceFactor {
 		// if all query node has nearly same workload, just fall back to round_robin
 		b.idx.Inc()
 	}

--- a/internal/proxy/shardclient/look_aside_balancer_test.go
+++ b/internal/proxy/shardclient/look_aside_balancer_test.go
@@ -289,6 +289,59 @@ func (suite *LookAsideBalancerSuite) TestSelectNode() {
 	}
 }
 
+func (suite *LookAsideBalancerSuite) TestSelectNodeFastPathSkipsUnavailable() {
+	// Set up 3 nodes, mark node 1 and 2 as unavailable
+	for _, node := range []int64{1, 2, 3} {
+		suite.balancer.UpdateCostMetrics(node, &internalpb.CostAggregation{})
+	}
+	metrics1, _ := suite.balancer.metricsMap.Get(int64(1))
+	metrics1.unavailable.Store(true)
+	metrics2, _ := suite.balancer.metricsMap.Get(int64(2))
+	metrics2.unavailable.Store(true)
+
+	// Force fast path by ensuring idx % checkWorkloadRequestNum != 0
+	suite.balancer.idx.Store(1)
+
+	node, err := suite.balancer.SelectNode(context.TODO(), []int64{1, 2, 3}, 1)
+	suite.NoError(err)
+	suite.Equal(int64(3), node)
+}
+
+func (suite *LookAsideBalancerSuite) TestSelectNodeFastPathAllUnavailable() {
+	// Set up 3 nodes, mark all as unavailable
+	for _, node := range []int64{1, 2, 3} {
+		suite.balancer.UpdateCostMetrics(node, &internalpb.CostAggregation{})
+		metrics, _ := suite.balancer.metricsMap.Get(node)
+		metrics.unavailable.Store(true)
+	}
+
+	// Force fast path
+	suite.balancer.idx.Store(1)
+
+	node, err := suite.balancer.SelectNode(context.TODO(), []int64{1, 2, 3}, 1)
+	suite.ErrorIs(err, merr.ErrServiceUnavailable)
+	suite.Equal(int64(-1), node)
+}
+
+func (suite *LookAsideBalancerSuite) TestSelectNodeZeroScoreRoundRobin() {
+	// When all nodes have zero score (no metrics), the tolerance check should
+	// still fall back to round-robin (idx gets incremented).
+	// This tests the minScore <= 0 guard against division by zero.
+	suite.balancer.idx.Store(0) // force slow path (idx % checkWorkloadRequestNum == 0)
+
+	counter := make(map[int64]int64)
+	for i := 0; i < 30; i++ {
+		node, err := suite.balancer.SelectNode(context.TODO(), []int64{1, 2, 3}, 1)
+		suite.NoError(err)
+		counter[node]++
+	}
+
+	// With round-robin fallback, requests should be distributed across nodes
+	suite.True(counter[1] >= 8, "node 1 should get roughly 1/3 of requests, got %d", counter[1])
+	suite.True(counter[2] >= 8, "node 2 should get roughly 1/3 of requests, got %d", counter[2])
+	suite.True(counter[3] >= 8, "node 3 should get roughly 1/3 of requests, got %d", counter[3])
+}
+
 func (suite *LookAsideBalancerSuite) TestCancelWorkload() {
 	node, err := suite.balancer.SelectNode(context.TODO(), []int64{1, 2, 3}, 10)
 	suite.NoError(err)


### PR DESCRIPTION
Cherry-pick from master
pr: #48212

The fast-path round-robin loop in LookAsideBalancer.SelectNode had three bugs:

1. Loop variable `i` was unused — every iteration checked the same node index. Changed to `(int(idx)+i) % len(availableNodes)` so the loop actually advances through available nodes.

2. `targetNode` was unconditionally assigned on the first iteration, making the post-loop `targetNode == -1` error check dead code. Now only assigns `targetNode` when a non-unavailable node is found, so all-unavailable correctly returns ErrServiceUnavailable.

3. Workload tolerance check divided by `minScore` without guarding against zero, producing +Inf in Go and skipping round-robin fallback. Added `minScore <= 0` guard so zero-workload clusters correctly fall back to round-robin distribution.

issue: #48211