### PR TITLE
test: Inject trace ID into V2 test framework for server log correlation

### DIFF
--- a/tests/python_client/base/client_v2_base.py
+++ b/tests/python_client/base/client_v2_base.py
@@ -1,11 +1,16 @@
 import sys
 import time
 from typing import Optional
+
+import grpc
 from pymilvus import MilvusClient, DataType
+from pymilvus.orm.connections import connections
+from pymilvus.grpc_gen import milvus_pb2_grpc
 
 sys.path.append("..")
 from check.func_check import ResponseChecker
 from utils.api_request import api_request
+from utils.trace_interceptor import TraceInterceptor
 from utils.wrapper import trace
 from utils.util_log import test_log as log
 from common import common_func as cf, common_type as ct
@@ -19,6 +24,20 @@ class TestMilvusClientV2Base(Base):
 
     # milvus_client = None
     active_trace = False
+    _current_test_name = None
+    _trace_interceptor = None
+
+    def setup_method(self, method):
+        self._current_test_name = method.__name__
+        super().setup_method(method)
+
+    def teardown_method(self, method):
+        if self._trace_interceptor:
+            log.info(
+                f"[TRACE] trace_id_prefix={self._trace_interceptor.trace_prefix}  "
+                f"test={method.__name__}"
+            )
+        super().teardown_method(method)
 
     def init_async_milvus_client(self):
         uri = cf.param_info.param_uri or f"http://{cf.param_info.param_host}:{cf.param_info.param_port}"
@@ -40,9 +59,25 @@ class TestMilvusClientV2Base(Base):
             uri = "http://" + cf.param_info.param_host + ":" + str(cf.param_info.param_port)
         res, is_succ = self.init_milvus_client(uri=uri, token=cf.param_info.param_token, active_trace=active_trace, **kwargs)
         if is_succ:
-            # self.milvus_client = res
             log.info(f"server version: {res.get_server_version()}")
+            self._inject_trace_interceptor(res)
         return res
+
+    def _inject_trace_interceptor(self, client):
+        """Inject TraceInterceptor into the MilvusClient's underlying gRPC channel."""
+        test_name = self._current_test_name or "unknown"
+        self._trace_interceptor = TraceInterceptor(test_name)
+        try:
+            handler = connections._fetch_handler(client._using)
+            # Save the original channel on first injection to avoid stacking interceptors
+            if not hasattr(handler, '_original_channel'):
+                handler._original_channel = handler._final_channel
+            handler._final_channel = grpc.intercept_channel(
+                handler._original_channel, self._trace_interceptor
+            )
+            handler._stub = milvus_pb2_grpc.MilvusServiceStub(handler._final_channel)
+        except Exception as e:
+            log.warning(f"[TRACE] failed to inject trace interceptor: {e}")
 
     def init_milvus_client(self, uri, user="", password="", db_name="", token="", timeout=None,
                            check_task=None, check_items=None, active_trace=False, **kwargs):

--- a/tests/python_client/utils/trace_interceptor.py
+++ b/tests/python_client/utils/trace_interceptor.py
@@ -1,0 +1,60 @@
+import hashlib
+import os
+from collections import namedtuple
+
+import grpc
+
+from utils.util_log import test_log as log
+
+
+class _ClientCallDetails(
+    namedtuple("_ClientCallDetails", ["method", "timeout", "metadata", "credentials"]),
+    grpc.ClientCallDetails,
+):
+    pass
+
+
+class TraceInterceptor(
+    grpc.UnaryUnaryClientInterceptor,
+    grpc.UnaryStreamClientInterceptor,
+):
+    """gRPC interceptor: inject W3C traceparent into every call.
+
+    - trace_id prefix (8 hex): derived from test name hash, same test always gets the same prefix
+    - trace_id suffix (24 hex): random per gRPC call, so each call has a unique trace_id
+    - On the server side, grep by prefix to find all requests from the same test case
+    """
+
+    def __init__(self, test_name: str):
+        super().__init__()
+        self.trace_prefix = hashlib.md5(test_name.encode(), usedforsecurity=False).hexdigest()[:8]
+        log.info(f"[TRACE] test={test_name}  trace_id_prefix={self.trace_prefix}")
+
+    def _inject(self, client_call_details):
+        trace_id = self.trace_prefix + os.urandom(12).hex()
+        span_id = os.urandom(8).hex()
+        traceparent = f"00-{trace_id}-{span_id}-01"
+
+        metadata = list(client_call_details.metadata or [])
+        metadata.append(("traceparent", traceparent))
+
+        new_details = _ClientCallDetails(
+            client_call_details.method,
+            client_call_details.timeout,
+            metadata,
+            client_call_details.credentials,
+        )
+
+        method = client_call_details.method
+        if isinstance(method, bytes):
+            method = method.decode("utf-8", errors="replace")
+        short = method.rsplit("/", 1)[-1] if "/" in method else method
+
+        log.info(f"[TRACE] trace_id={trace_id}  method={short}")
+        return new_details
+
+    def intercept_unary_unary(self, continuation, client_call_details, request):
+        return continuation(self._inject(client_call_details), request)
+
+    def intercept_unary_stream(self, continuation, client_call_details, request):
+        return continuation(self._inject(client_call_details), request)


### PR DESCRIPTION
## Summary
- Add a gRPC client interceptor (`TraceInterceptor`) that injects W3C `traceparent` header into every gRPC call from V2 test cases
- Each gRPC call gets a unique trace ID (32 hex chars). The first 8 chars are derived from the test name hash — the **same test case always shares the same trace ID prefix** across runs, making it easy to find all requests from one test case on the server side
- trace ID prefix is automatically logged at setup and teardown, zero changes needed in existing test code

## Effect

**Client-side test logs (automatic, no test code changes):**
```
[TRACE] test=test_milvus_client_alias_search_query  trace_id_prefix=bb03a1c9
[TRACE] trace_id=bb03a1c942d5eeae5a79e9ddfc29b8b7  method=CreateCollection
[TRACE] trace_id=bb03a1c975175234457354deab4de846  method=Insert
[TRACE] trace_id=bb03a1c99137b80182c5be4996037fda  method=Search
[TRACE] trace_id=bb03a1c985a2acac3c0ccb13e2862597  method=DropCollection
[TRACE] trace_id_prefix=bb03a1c9  test=test_milvus_client_alias_search_query
                ^^^^^^^^
                same prefix, different suffix per gRPC call
```

**Server-side proxy logs (grep by prefix):**
```
kubectl logs <proxy-pod> | grep "bb03a1c9"

[INFO] ["CreateCollection received"] [traceID=bb03a1c942d5eeae5a79e9ddfc29b8b7] ...
[INFO] ["CreateIndex received"]      [traceID=bb03a1c937a7ff4a8c9b2868a152528c] ...
[INFO] ["LoadCollection received"]   [traceID=bb03a1c9bdf17d5527511f7972138250] ...
[INFO] ["DropCollection received"]   [traceID=bb03a1c985a2acac3c0ccb13e2862597] ...
```

Each server-side request has a unique traceID for pinpointing, while the shared prefix `bb03a1c9` links them all back to the same test case.

## Related Issues
#48218

## Test plan
- [x] Verified trace ID prefix appears in test logs automatically for existing V2 test cases
- [x] Verified each gRPC call gets a unique trace ID with shared prefix in Milvus server proxy logs
- [x] Verified no changes needed in existing test code — fully non-invasive

🤖 Generated with [Claude Code](https://claude.com/claude-code)