### PR TITLE
enhance: [ExternalTable Part7] support take() fast path for retrieve and search

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -40,7 +40,10 @@
 #include "NamedType/named_type_impl.hpp"
 #include "Types.h"
 #include "Utils.h"
+#include "arrow/array.h"
 #include "arrow/result.h"
+#include "arrow/table.h"
+#include "arrow/type.h"
 #include "bitset/bitset.h"
 #include "cachinglayer/CacheSlot.h"
 #include "cachinglayer/Manager.h"
@@ -3761,7 +3764,7 @@ ChunkedSegmentSealedImpl::LoadBatchTextIndexes(
     for (auto& [field_id, load_text_index_info] : text_indexes_to_load) {
         auto future = pool.Submit(
             [this, op_ctx, info = std::move(load_text_index_info)]() mutable
-            -> void { LoadTextIndex(op_ctx, std::move(info)); });
+                -> void { LoadTextIndex(op_ctx, std::move(info)); });
         load_index_futures.emplace_back(std::move(future));
     }
 
@@ -3967,6 +3970,713 @@ ChunkedSegmentSealedImpl::Load(milvus::tracer::TraceContext& trace_ctx,
     ApplyLoadDiff(op_ctx, segment_load_info_, diff);
 
     LOG_INFO("Successfully loaded segment {} with {} rows", id_, num_rows);
+}
+
+void
+ChunkedSegmentSealedImpl::FillTargetEntry(const query::Plan* plan,
+                                          SearchResult& results) const {
+    std::shared_lock lck(mutex_);
+    AssertInfo(plan, "empty plan");
+    auto size = results.distances_.size();
+    AssertInfo(results.seg_offsets_.size() == size,
+               "Size of result distances is not equal to size of ids");
+
+    // Try take() for external fields; fills output_fields_data_ for
+    // external fields only. Non-external fields still go through
+    // bulk_subscript below.
+    bool used_take =
+        TryTakeForSearch(plan, results.seg_offsets_.data(), size, results);
+
+    std::unique_ptr<DataArray> field_data;
+    milvus::OpContext op_ctx;
+    for (auto field_id : plan->target_entries_) {
+        // Skip fields already filled by take
+        if (used_take && results.output_fields_data_.count(field_id) > 0) {
+            continue;
+        }
+        auto& field_meta = plan->schema_->operator[](field_id);
+        if (plan->schema_->get_dynamic_field_id().has_value() &&
+            plan->schema_->get_dynamic_field_id().value() == field_id &&
+            !plan->target_dynamic_fields_.empty()) {
+            auto& target_dynamic_fields = plan->target_dynamic_fields_;
+            field_data = bulk_subscript(&op_ctx,
+                                        field_id,
+                                        results.seg_offsets_.data(),
+                                        size,
+                                        target_dynamic_fields);
+        } else if (!is_field_exist(field_id)) {
+            field_data = bulk_subscript_not_exist_field(field_meta, size);
+        } else {
+            field_data = bulk_subscript(
+                &op_ctx, field_id, results.seg_offsets_.data(), size);
+        }
+        results.output_fields_data_[field_id] = std::move(field_data);
+    }
+    results.search_storage_cost_.scanned_remote_bytes +=
+        op_ctx.storage_usage.scanned_cold_bytes.load();
+    results.search_storage_cost_.scanned_total_bytes +=
+        op_ctx.storage_usage.scanned_total_bytes.load();
+}
+
+// ---- Shared helpers for TryTakeForRetrieve / TryTakeForSearch ----
+
+ChunkedSegmentSealedImpl::TakeContext
+ChunkedSegmentSealedImpl::BuildTakeContext(const int64_t* offsets,
+                                           int64_t size) {
+    struct OffsetEntry {
+        int64_t offset;
+        int64_t orig_pos;
+    };
+    std::vector<OffsetEntry> entries;
+    entries.reserve(size);
+    for (int64_t i = 0; i < size; i++) {
+        entries.push_back({offsets[i], i});
+    }
+    std::sort(entries.begin(),
+              entries.end(),
+              [](const OffsetEntry& a, const OffsetEntry& b) {
+                  return a.offset < b.offset;
+              });
+
+    TakeContext ctx;
+    ctx.unique_offsets.reserve(size);
+    ctx.result_mapping.resize(size);
+    for (auto& e : entries) {
+        if (ctx.unique_offsets.empty() ||
+            ctx.unique_offsets.back() != e.offset) {
+            ctx.unique_offsets.push_back(e.offset);
+        }
+        ctx.result_mapping[e.orig_pos] =
+            static_cast<int64_t>(ctx.unique_offsets.size() - 1);
+    }
+    return ctx;
+}
+
+std::unique_ptr<DataArray>
+ChunkedSegmentSealedImpl::ArrowToDataArray(
+    const std::shared_ptr<arrow::Array>& arr_in,
+    const FieldMeta& field_meta,
+    const std::vector<int64_t>& result_mapping,
+    int64_t size) {
+    // Normalize dense vector arrays (List/FixedSizeList → FixedSizeBinary),
+    // matching the Load path (ManifestGroupTranslator / GetFieldDatasFromManifest).
+    auto arr = arr_in;
+    auto dt = field_meta.get_data_type();
+    if (IsVectorDataType(dt) && !IsSparseFloatVectorDataType(dt) &&
+        !IsVectorArrayDataType(dt) &&
+        arr->type_id() != arrow::Type::FIXED_SIZE_BINARY) {
+        auto normalized = storage::NormalizeVectorArraysToFixedSizeBinary(
+            {arr}, dt, field_meta.get_dim());
+        arr = normalized[0];
+    }
+
+    // Normalize VectorArray: outer List stays, inner List<Float> → FixedSizeBinary.
+    // External Parquet stores as list(list(float)), Milvus expects list(fixed_size_binary).
+    if (IsVectorArrayDataType(dt) && arr->type_id() == arrow::Type::LIST) {
+        auto outer_list = std::static_pointer_cast<arrow::ListArray>(arr);
+        auto inner_values = outer_list->values();
+        if (inner_values->type_id() != arrow::Type::FIXED_SIZE_BINARY) {
+            auto normalized = storage::NormalizeVectorArraysToFixedSizeBinary(
+                {inner_values},
+                field_meta.get_element_type(),
+                field_meta.get_dim());
+            auto result = arrow::ListArray::FromArrays(*outer_list->offsets(),
+                                                       *normalized[0]);
+            AssertInfo(result.ok(),
+                       "Failed to rebuild ListArray for VectorArray: {}",
+                       result.status().ToString());
+            arr = *result;
+        }
+    }
+
+    auto data_array = std::make_unique<DataArray>();
+    data_array->set_type(static_cast<proto::schema::DataType>(dt));
+
+    switch (dt) {
+        case DataType::BOOL: {
+            auto typed = std::static_pointer_cast<arrow::BooleanArray>(arr);
+            auto obj = data_array->mutable_scalars()->mutable_bool_data();
+            for (int64_t i = 0; i < size; i++) {
+                obj->add_data(typed->Value(result_mapping[i]));
+            }
+            break;
+        }
+        case DataType::INT8: {
+            auto typed = std::static_pointer_cast<arrow::Int8Array>(arr);
+            auto obj = data_array->mutable_scalars()->mutable_int_data();
+            for (int64_t i = 0; i < size; i++) {
+                obj->add_data(
+                    static_cast<int32_t>(typed->Value(result_mapping[i])));
+            }
+            break;
+        }
+        case DataType::INT16: {
+            auto typed = std::static_pointer_cast<arrow::Int16Array>(arr);
+            auto obj = data_array->mutable_scalars()->mutable_int_data();
+            for (int64_t i = 0; i < size; i++) {
+                obj->add_data(
+                    static_cast<int32_t>(typed->Value(result_mapping[i])));
+            }
+            break;
+        }
+        case DataType::INT32: {
+            auto typed = std::static_pointer_cast<arrow::Int32Array>(arr);
+            auto obj = data_array->mutable_scalars()->mutable_int_data();
+            for (int64_t i = 0; i < size; i++) {
+                obj->add_data(typed->Value(result_mapping[i]));
+            }
+            break;
+        }
+        case DataType::INT64: {
+            auto typed = std::static_pointer_cast<arrow::Int64Array>(arr);
+            auto obj = data_array->mutable_scalars()->mutable_long_data();
+            for (int64_t i = 0; i < size; i++) {
+                obj->add_data(typed->Value(result_mapping[i]));
+            }
+            break;
+        }
+        case DataType::FLOAT: {
+            auto typed = std::static_pointer_cast<arrow::FloatArray>(arr);
+            auto obj = data_array->mutable_scalars()->mutable_float_data();
+            for (int64_t i = 0; i < size; i++) {
+                obj->add_data(typed->Value(result_mapping[i]));
+            }
+            break;
+        }
+        case DataType::DOUBLE: {
+            auto typed = std::static_pointer_cast<arrow::DoubleArray>(arr);
+            auto obj = data_array->mutable_scalars()->mutable_double_data();
+            for (int64_t i = 0; i < size; i++) {
+                obj->add_data(typed->Value(result_mapping[i]));
+            }
+            break;
+        }
+        case DataType::VARCHAR:
+        case DataType::STRING:
+        case DataType::TEXT: {
+            auto typed = std::static_pointer_cast<arrow::StringArray>(arr);
+            auto obj = data_array->mutable_scalars()->mutable_string_data();
+            for (int64_t i = 0; i < size; i++) {
+                obj->add_data(typed->GetString(result_mapping[i]));
+            }
+            break;
+        }
+        case DataType::VECTOR_FLOAT: {
+            // Always FixedSizeBinary after normalization.
+            auto typed =
+                std::static_pointer_cast<arrow::FixedSizeBinaryArray>(arr);
+            int byte_width = typed->byte_width();
+            int dim = byte_width / sizeof(float);
+            AssertInfo(dim == field_meta.get_dim(),
+                       "VECTOR_FLOAT dim mismatch: arrow={}, schema={}",
+                       dim,
+                       field_meta.get_dim());
+            auto vectors = data_array->mutable_vectors();
+            vectors->set_dim(dim);
+            auto* dst = vectors->mutable_float_vector()->mutable_data();
+            dst->Reserve(size * dim);
+            for (int64_t i = 0; i < size; i++) {
+                auto val = typed->Value(result_mapping[i]);
+                auto floats = reinterpret_cast<const float*>(val);
+                dst->Add(floats, floats + dim);
+            }
+            break;
+        }
+        case DataType::VECTOR_BINARY: {
+            auto typed =
+                std::static_pointer_cast<arrow::FixedSizeBinaryArray>(arr);
+            int byte_width = typed->byte_width();
+            AssertInfo(
+                byte_width == (field_meta.get_dim() + 7) / 8,
+                "VECTOR_BINARY byte_width mismatch: arrow={}, expected={}",
+                byte_width,
+                (field_meta.get_dim() + 7) / 8);
+            auto vectors = data_array->mutable_vectors();
+            vectors->set_dim(field_meta.get_dim());
+            auto* dst = vectors->mutable_binary_vector();
+            dst->reserve(size * byte_width);
+            for (int64_t i = 0; i < size; i++) {
+                auto val = typed->Value(result_mapping[i]);
+                dst->append(reinterpret_cast<const char*>(val), byte_width);
+            }
+            break;
+        }
+        case DataType::VECTOR_FLOAT16: {
+            auto typed =
+                std::static_pointer_cast<arrow::FixedSizeBinaryArray>(arr);
+            int byte_width = typed->byte_width();
+            int dim = byte_width / 2;
+            AssertInfo(dim == field_meta.get_dim(),
+                       "VECTOR_FLOAT16 dim mismatch: arrow={}, schema={}",
+                       dim,
+                       field_meta.get_dim());
+            auto vectors = data_array->mutable_vectors();
+            vectors->set_dim(dim);
+            auto* dst = vectors->mutable_float16_vector();
+            dst->reserve(size * byte_width);
+            for (int64_t i = 0; i < size; i++) {
+                auto val = typed->Value(result_mapping[i]);
+                dst->append(reinterpret_cast<const char*>(val), byte_width);
+            }
+            break;
+        }
+        case DataType::VECTOR_BFLOAT16: {
+            auto typed =
+                std::static_pointer_cast<arrow::FixedSizeBinaryArray>(arr);
+            int byte_width = typed->byte_width();
+            int dim = byte_width / 2;
+            AssertInfo(dim == field_meta.get_dim(),
+                       "VECTOR_BFLOAT16 dim mismatch: arrow={}, schema={}",
+                       dim,
+                       field_meta.get_dim());
+            auto vectors = data_array->mutable_vectors();
+            vectors->set_dim(dim);
+            auto* dst = vectors->mutable_bfloat16_vector();
+            dst->reserve(size * byte_width);
+            for (int64_t i = 0; i < size; i++) {
+                auto val = typed->Value(result_mapping[i]);
+                dst->append(reinterpret_cast<const char*>(val), byte_width);
+            }
+            break;
+        }
+        case DataType::VECTOR_INT8: {
+            auto typed =
+                std::static_pointer_cast<arrow::FixedSizeBinaryArray>(arr);
+            int byte_width = typed->byte_width();
+            AssertInfo(byte_width == field_meta.get_dim(),
+                       "VECTOR_INT8 dim mismatch: arrow={}, schema={}",
+                       byte_width,
+                       field_meta.get_dim());
+            auto vectors = data_array->mutable_vectors();
+            vectors->set_dim(byte_width);
+            auto* dst = vectors->mutable_int8_vector();
+            dst->reserve(size * byte_width);
+            for (int64_t i = 0; i < size; i++) {
+                auto val = typed->Value(result_mapping[i]);
+                dst->append(reinterpret_cast<const char*>(val), byte_width);
+            }
+            break;
+        }
+        case DataType::JSON: {
+            // External Parquet stores JSON as UTF-8 string (StringArray).
+            // Internal binlog stores as raw bytes (BinaryArray).
+            // Both contain identical UTF-8 bytes, just different Arrow type.
+            auto obj = data_array->mutable_scalars()->mutable_json_data();
+            if (arr->type_id() == arrow::Type::STRING) {
+                auto typed = std::static_pointer_cast<arrow::StringArray>(arr);
+                for (int64_t i = 0; i < size; i++) {
+                    auto val = typed->GetView(result_mapping[i]);
+                    obj->add_data(val.data(), val.size());
+                }
+            } else {
+                AssertInfo(arr->type_id() == arrow::Type::BINARY,
+                           "JSON field: unexpected Arrow type {}",
+                           arr->type()->ToString());
+                auto typed = std::static_pointer_cast<arrow::BinaryArray>(arr);
+                for (int64_t i = 0; i < size; i++) {
+                    auto val = typed->Value(result_mapping[i]);
+                    obj->add_data(val.data(), val.size());
+                }
+            }
+            break;
+        }
+        case DataType::GEOMETRY: {
+            // External Parquet may store as WKT text (StringArray) or
+            // WKB binary (BinaryArray). Both are passed through as raw bytes.
+            auto obj = data_array->mutable_scalars()->mutable_geometry_data();
+            if (arr->type_id() == arrow::Type::STRING) {
+                auto typed = std::static_pointer_cast<arrow::StringArray>(arr);
+                for (int64_t i = 0; i < size; i++) {
+                    auto val = typed->GetView(result_mapping[i]);
+                    obj->add_data(val.data(), val.size());
+                }
+            } else {
+                AssertInfo(arr->type_id() == arrow::Type::BINARY,
+                           "GEOMETRY field: unexpected Arrow type {}",
+                           arr->type()->ToString());
+                auto typed = std::static_pointer_cast<arrow::BinaryArray>(arr);
+                for (int64_t i = 0; i < size; i++) {
+                    auto val = typed->Value(result_mapping[i]);
+                    obj->add_data(val.data(), val.size());
+                }
+            }
+            break;
+        }
+        case DataType::TIMESTAMPTZ: {
+            auto obj =
+                data_array->mutable_scalars()->mutable_timestamptz_data();
+            if (arr->type_id() == arrow::Type::TIMESTAMP) {
+                auto typed =
+                    std::static_pointer_cast<arrow::TimestampArray>(arr);
+                auto ts_type =
+                    std::static_pointer_cast<arrow::TimestampType>(
+                        arr->type());
+                auto unit = ts_type->unit();
+                for (int64_t i = 0; i < size; i++) {
+                    obj->add_data(storage::ConvertToMicroseconds(
+                        typed->Value(result_mapping[i]), unit));
+                }
+            } else {
+                auto typed =
+                    std::static_pointer_cast<arrow::Int64Array>(arr);
+                for (int64_t i = 0; i < size; i++) {
+                    obj->add_data(typed->Value(result_mapping[i]));
+                }
+            }
+            break;
+        }
+        case DataType::ARRAY: {
+            auto obj = data_array->mutable_scalars()->mutable_array_data();
+            if (arr->type_id() == arrow::Type::LIST) {
+                auto list_arr =
+                    std::static_pointer_cast<arrow::ListArray>(arr);
+                for (int64_t i = 0; i < size; i++) {
+                    *obj->add_data() =
+                        storage::ArrowListToScalarFieldProto(
+                            list_arr, result_mapping[i]);
+                }
+            } else {
+                auto typed =
+                    std::static_pointer_cast<arrow::BinaryArray>(arr);
+                for (int64_t i = 0; i < size; i++) {
+                    auto val = typed->Value(result_mapping[i]);
+                    auto* sf = obj->add_data();
+                    sf->ParseFromArray(val.data(),
+                                       static_cast<int>(val.size()));
+                }
+            }
+            break;
+        }
+        case DataType::VECTOR_ARRAY: {
+            // After normalize, arr is List<FixedSizeBinaryArray>.
+            auto outer_list = std::static_pointer_cast<arrow::ListArray>(arr);
+            auto inner_values =
+                std::static_pointer_cast<arrow::FixedSizeBinaryArray>(
+                    outer_list->values());
+            int byte_width = inner_values->byte_width();
+            int dim = field_meta.get_dim();
+            auto element_type = field_meta.get_element_type();
+            auto* va = data_array->mutable_vectors()
+                           ->mutable_vector_array()
+                           ->mutable_data();
+            data_array->mutable_vectors()->set_dim(dim);
+            for (int64_t i = 0; i < size; i++) {
+                auto idx = result_mapping[i];
+                int64_t start = outer_list->value_offset(idx);
+                int64_t end = outer_list->value_offset(idx + 1);
+                int64_t num_vectors = end - start;
+                auto* vf = va->Add();
+                if (num_vectors == 0) {
+                    // Empty list row — add empty VectorField proto.
+                    continue;
+                }
+                VectorArray vec_arr(inner_values->GetValue(start),
+                                    num_vectors,
+                                    dim,
+                                    element_type);
+                *vf = vec_arr.output_data();
+            }
+            break;
+        }
+        default:
+            return nullptr;
+    }
+    return data_array;
+}
+
+std::shared_ptr<arrow::Table>
+ChunkedSegmentSealedImpl::ExecuteTake(
+    const std::vector<int64_t>& unique_offsets,
+    const std::shared_ptr<std::vector<std::string>>& needed_columns,
+    const char* caller_tag,
+    double& elapsed_ms) const {
+    // Reader is NOT thread-safe; serialize concurrent take() calls.
+    std::lock_guard<std::mutex> lock(reader_mutex_);
+    if (!reader_) {
+        LOG_WARN("[TakeAPI] {} reader is null for segment {}", caller_tag, id_);
+        return nullptr;
+    }
+    auto take_start = std::chrono::high_resolution_clock::now();
+    auto result = reader_->take(unique_offsets, 1, needed_columns);
+    elapsed_ms = std::chrono::duration<double, std::milli>(
+                     std::chrono::high_resolution_clock::now() - take_start)
+                     .count();
+    if (!result.ok()) {
+        LOG_WARN("[TakeAPI] {} take() failed for segment {}: {}",
+                 caller_tag,
+                 id_,
+                 result.status().ToString());
+        return nullptr;
+    }
+    return *result;
+}
+
+// ---- End shared helpers ----
+
+bool
+ChunkedSegmentSealedImpl::TryTakeForRetrieve(
+    const query::RetrievePlan* plan,
+    const std::unique_ptr<proto::segcore::RetrieveResults>& results,
+    const int64_t* offsets,
+    int64_t size,
+    bool ignore_non_pk,
+    bool fill_ids) const {
+    if (!schema_->is_external_collection() || size == 0) {
+        return false;
+    }
+    constexpr int64_t kTakeThreshold = 10000;
+    if (size > kTakeThreshold) {
+        return false;
+    }
+
+    auto pk_field_id = plan->schema_->get_primary_field_id();
+    auto is_pk_field = [&](const FieldId& fid) {
+        return pk_field_id.has_value() && pk_field_id.value() == fid;
+    };
+
+    // Collect needed external columns and their field IDs
+    auto needed_columns = std::make_shared<std::vector<std::string>>();
+    std::vector<FieldId> take_field_ids;
+    std::vector<const FieldMeta*> take_field_metas;
+    for (auto field_id : plan->field_ids_) {
+        if (SystemProperty::Instance().IsSystem(field_id)) {
+            continue;
+        }
+        if (ignore_non_pk && !is_pk_field(field_id)) {
+            continue;
+        }
+        auto& field_meta = schema_->operator[](field_id);
+        if (!field_meta.is_external_field()) {
+            continue;
+        }
+        needed_columns->push_back(field_meta.get_external_field());
+        take_field_ids.push_back(field_id);
+        take_field_metas.push_back(&field_meta);
+    }
+    if (take_field_ids.empty()) {
+        return false;
+    }
+
+    auto ctx = BuildTakeContext(offsets, size);
+
+    double take_elapsed_ms = 0;
+    auto table = ExecuteTake(
+        ctx.unique_offsets, needed_columns, "retrieve", take_elapsed_ms);
+    if (!table) {
+        return false;
+    }
+
+    // Convert Arrow Table columns to DataArray results
+    auto fields_data = results->mutable_fields_data();
+    auto ids = results->mutable_ids();
+
+    // Build lookup from field_id to index in take_field_ids/take_field_metas
+    std::unordered_map<int64_t, size_t> ext_field_idx;
+    for (size_t fi = 0; fi < take_field_ids.size(); fi++) {
+        ext_field_idx[take_field_ids[fi].get()] = fi;
+    }
+
+    // Pre-combine Arrow chunks for each external column
+    std::vector<std::shared_ptr<arrow::Array>> combined_arrays(
+        take_field_ids.size());
+    for (size_t fi = 0; fi < take_field_ids.size(); fi++) {
+        auto ext_name = take_field_metas[fi]->get_external_field();
+        auto col = table->GetColumnByName(ext_name);
+        if (!col || col->num_chunks() == 0) {
+            LOG_WARN(
+                "[TakeAPI] column '{}' not found in take result for "
+                "segment {}",
+                ext_name,
+                id_);
+            return false;
+        }
+        if (col->num_chunks() == 1) {
+            combined_arrays[fi] = col->chunk(0);
+        } else {
+            auto combined_result = arrow::Concatenate(col->chunks());
+            if (!combined_result.ok()) {
+                LOG_WARN("[TakeAPI] concatenate failed: {}",
+                         combined_result.status().ToString());
+                return false;
+            }
+            combined_arrays[fi] = *combined_result;
+        }
+    }
+
+    // Emit fields in plan->field_ids_ order so the positional index
+    // matches outputFieldsID in the Proxy's afterReduce.
+    for (auto field_id : plan->field_ids_) {
+        if (SystemProperty::Instance().IsSystem(field_id)) {
+            auto system_type =
+                SystemProperty::Instance().GetSystemFieldType(field_id);
+            FixedVector<int64_t> output(size);
+            milvus::OpContext op_ctx;
+            bulk_subscript(&op_ctx, system_type, offsets, size, output.data());
+            auto data_array = std::make_unique<DataArray>();
+            data_array->set_field_id(field_id.get());
+            data_array->set_type(milvus::proto::schema::DataType::Int64);
+            auto obj = data_array->mutable_scalars()->mutable_long_data();
+            auto data = reinterpret_cast<const int64_t*>(output.data());
+            obj->mutable_data()->Add(data, data + size);
+            fields_data->AddAllocated(data_array.release());
+            continue;
+        }
+
+        if (ignore_non_pk && !is_pk_field(field_id)) {
+            continue;
+        }
+
+        auto& field_meta = schema_->operator[](field_id);
+
+        // Virtual PK field (not external, computed on-the-fly)
+        if (!field_meta.is_external_field()) {
+            if (is_pk_field(field_id) &&
+                field_meta.get_data_type() == DataType::INT64) {
+                auto data_array = std::make_unique<DataArray>();
+                data_array->set_field_id(field_id.get());
+                data_array->set_type(milvus::proto::schema::DataType::Int64);
+                auto obj = data_array->mutable_scalars()->mutable_long_data();
+                for (int64_t i = 0; i < size; i++) {
+                    obj->add_data(GetVirtualPK(id_, offsets[i]));
+                }
+                if (!ignore_non_pk) {
+                    fields_data->AddAllocated(data_array.release());
+                }
+                if (fill_ids) {
+                    auto int_ids = ids->mutable_int_id();
+                    for (int64_t i = 0; i < size; i++) {
+                        int_ids->add_data(GetVirtualPK(id_, offsets[i]));
+                    }
+                }
+            }
+            continue;
+        }
+
+        // External field — convert from take() result
+        auto it = ext_field_idx.find(field_id.get());
+        if (it == ext_field_idx.end()) {
+            continue;
+        }
+        size_t fi = it->second;
+        auto& arr = combined_arrays[fi];
+
+        auto data_array =
+            ArrowToDataArray(arr, field_meta, ctx.result_mapping, size);
+        if (!data_array) {
+            LOG_WARN(
+                "[TakeAPI] unsupported data type {} for field '{}', "
+                "falling back",
+                static_cast<int>(field_meta.get_data_type()),
+                field_meta.get_external_field());
+            results->clear_fields_data();
+            results->clear_ids();
+            return false;
+        }
+        data_array->set_field_id(field_id.get());
+
+        if (!ignore_non_pk) {
+            fields_data->AddAllocated(data_array.release());
+        }
+    }
+
+    LOG_DEBUG(
+        "[TakeAPI] segment {} used take() for {} rows ({} unique), "
+        "{} fields, elapsed={:.2f}ms",
+        id_,
+        size,
+        ctx.unique_offsets.size(),
+        take_field_ids.size(),
+        take_elapsed_ms);
+    return true;
+}
+
+bool
+ChunkedSegmentSealedImpl::TryTakeForSearch(const query::Plan* plan,
+                                           const int64_t* seg_offsets,
+                                           int64_t size,
+                                           SearchResult& results) const {
+    if (!schema_->is_external_collection() || size == 0) {
+        return false;
+    }
+    constexpr int64_t kTakeThreshold = 10000;
+    if (size > kTakeThreshold) {
+        return false;
+    }
+
+    // Collect needed external columns
+    auto needed_columns = std::make_shared<std::vector<std::string>>();
+    std::vector<FieldId> take_field_ids;
+    std::vector<const FieldMeta*> take_field_metas;
+    for (auto field_id : plan->target_entries_) {
+        auto& field_meta = schema_->operator[](field_id);
+        if (!field_meta.is_external_field()) {
+            continue;
+        }
+        needed_columns->push_back(field_meta.get_external_field());
+        take_field_ids.push_back(field_id);
+        take_field_metas.push_back(&field_meta);
+    }
+    if (take_field_ids.empty()) {
+        return false;
+    }
+
+    auto ctx = BuildTakeContext(seg_offsets, size);
+
+    double take_elapsed_ms = 0;
+    auto table = ExecuteTake(
+        ctx.unique_offsets, needed_columns, "search", take_elapsed_ms);
+    if (!table) {
+        return false;
+    }
+
+    // Convert Arrow Table columns to DataArray and store in SearchResult
+    for (size_t fi = 0; fi < take_field_ids.size(); fi++) {
+        auto field_id = take_field_ids[fi];
+        auto& field_meta = *take_field_metas[fi];
+        auto ext_name = field_meta.get_external_field();
+        auto col = table->GetColumnByName(ext_name);
+        if (!col || col->num_chunks() == 0) {
+            LOG_WARN("[TakeAPI] search column '{}' not found for segment {}",
+                     ext_name,
+                     id_);
+            return false;
+        }
+
+        std::shared_ptr<arrow::Array> arr;
+        if (col->num_chunks() == 1) {
+            arr = col->chunk(0);
+        } else {
+            auto combined_result = arrow::Concatenate(col->chunks());
+            if (!combined_result.ok()) {
+                return false;
+            }
+            arr = *combined_result;
+        }
+
+        auto data_array =
+            ArrowToDataArray(arr, field_meta, ctx.result_mapping, size);
+        if (!data_array) {
+            LOG_WARN(
+                "[TakeAPI] search: unsupported type {} for '{}', "
+                "falling back",
+                static_cast<int>(field_meta.get_data_type()),
+                ext_name);
+            results.output_fields_data_.clear();
+            return false;
+        }
+        data_array->set_field_id(field_id.get());
+        results.output_fields_data_[field_id] = std::move(data_array);
+    }
+
+    LOG_DEBUG(
+        "[TakeAPI] search: segment {} used take() for {} rows ({} unique), "
+        "{} fields, elapsed={:.2f}ms",
+        id_,
+        size,
+        ctx.unique_offsets.size(),
+        take_field_ids.size(),
+        take_elapsed_ms);
+    return true;
 }
 
 }  // namespace milvus::segcore

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -3764,7 +3764,7 @@ ChunkedSegmentSealedImpl::LoadBatchTextIndexes(
     for (auto& [field_id, load_text_index_info] : text_indexes_to_load) {
         auto future = pool.Submit(
             [this, op_ctx, info = std::move(load_text_index_info)]() mutable
-                -> void { LoadTextIndex(op_ctx, std::move(info)); });
+            -> void { LoadTextIndex(op_ctx, std::move(info)); });
         load_index_futures.emplace_back(std::move(future));
     }
 
@@ -4309,16 +4309,14 @@ ChunkedSegmentSealedImpl::ArrowToDataArray(
                 auto typed =
                     std::static_pointer_cast<arrow::TimestampArray>(arr);
                 auto ts_type =
-                    std::static_pointer_cast<arrow::TimestampType>(
-                        arr->type());
+                    std::static_pointer_cast<arrow::TimestampType>(arr->type());
                 auto unit = ts_type->unit();
                 for (int64_t i = 0; i < size; i++) {
                     obj->add_data(storage::ConvertToMicroseconds(
                         typed->Value(result_mapping[i]), unit));
                 }
             } else {
-                auto typed =
-                    std::static_pointer_cast<arrow::Int64Array>(arr);
+                auto typed = std::static_pointer_cast<arrow::Int64Array>(arr);
                 for (int64_t i = 0; i < size; i++) {
                     obj->add_data(typed->Value(result_mapping[i]));
                 }
@@ -4328,16 +4326,13 @@ ChunkedSegmentSealedImpl::ArrowToDataArray(
         case DataType::ARRAY: {
             auto obj = data_array->mutable_scalars()->mutable_array_data();
             if (arr->type_id() == arrow::Type::LIST) {
-                auto list_arr =
-                    std::static_pointer_cast<arrow::ListArray>(arr);
+                auto list_arr = std::static_pointer_cast<arrow::ListArray>(arr);
                 for (int64_t i = 0; i < size; i++) {
-                    *obj->add_data() =
-                        storage::ArrowListToScalarFieldProto(
-                            list_arr, result_mapping[i]);
+                    *obj->add_data() = storage::ArrowListToScalarFieldProto(
+                        list_arr, result_mapping[i]);
                 }
             } else {
-                auto typed =
-                    std::static_pointer_cast<arrow::BinaryArray>(arr);
+                auto typed = std::static_pointer_cast<arrow::BinaryArray>(arr);
                 for (int64_t i = 0; i < size; i++) {
                     auto val = typed->Value(result_mapping[i]);
                     auto* sf = obj->add_data();

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -313,6 +313,17 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
             callback) const;
 
  public:
+    // Non-virtual helper called via dynamic_cast from SegmentInterface.
+    // Must be public for cross-class access.
+    bool
+    TryTakeForRetrieve(
+        const query::RetrievePlan* plan,
+        const std::unique_ptr<proto::segcore::RetrieveResults>& results,
+        const int64_t* offsets,
+        int64_t size,
+        bool ignore_non_pk,
+        bool fill_ids) const;
+
     // count of chunk that has raw data
     int64_t
     num_chunk_data(FieldId field_id) const override;
@@ -439,6 +450,43 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                    void* data,
                    TargetBitmap& valid_map,
                    bool small_int_raw_type = false) const override;
+
+    // Override to inject take() fast path for Search on external tables.
+    // Uses existing vtable slot — no layout change.
+    void
+    FillTargetEntry(const query::Plan* plan,
+                    SearchResult& results) const override;
+
+    bool
+    TryTakeForSearch(const query::Plan* plan,
+                     const int64_t* seg_offsets,
+                     int64_t size,
+                     SearchResult& results) const;
+
+    // Shared helpers for TryTakeForRetrieve / TryTakeForSearch
+    struct TakeContext {
+        std::vector<int64_t> unique_offsets;
+        std::vector<int64_t> result_mapping;  // orig_pos → unique index
+    };
+
+    static TakeContext
+    BuildTakeContext(const int64_t* offsets, int64_t size);
+
+    // Converts a combined Arrow array into a proto DataArray using
+    // result_mapping for reorder.  Returns nullptr on unsupported type.
+    static std::unique_ptr<DataArray>
+    ArrowToDataArray(const std::shared_ptr<arrow::Array>& arr,
+                     const FieldMeta& field_meta,
+                     const std::vector<int64_t>& result_mapping,
+                     int64_t size);
+
+    // Calls reader_->take() with timing. Returns the table on success,
+    // or nullptr on failure (logs a warning).
+    std::shared_ptr<arrow::Table>
+    ExecuteTake(const std::vector<int64_t>& unique_offsets,
+                const std::shared_ptr<std::vector<std::string>>& needed_columns,
+                const char* caller_tag,
+                double& elapsed_ms) const;
 
     void
     check_search(const query::Plan* plan) const override;
@@ -1173,6 +1221,29 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         return res;
     }
 
+#ifdef MILVUS_UNIT_TEST
+ public:
+    // Test-only: inject a mock Reader for unit testing take() paths.
+    void
+    SetReaderForTesting(std::unique_ptr<milvus_storage::api::Reader> r) {
+        reader_ = std::move(r);
+    }
+
+    // Wrappers for protected methods to enable direct unit testing.
+    void
+    TestFillTargetEntry(const query::Plan* plan, SearchResult& results) const {
+        FillTargetEntry(plan, results);
+    }
+
+    bool
+    TestTryTakeForSearch(const query::Plan* plan,
+                         const int64_t* seg_offsets,
+                         int64_t size,
+                         SearchResult& results) const {
+        return TryTakeForSearch(plan, seg_offsets, size, results);
+    }
+#endif
+
  private:
     // InsertRecord needs to pin pk column.
     friend class storagev1translator::InsertRecordTranslator;
@@ -1236,8 +1307,12 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     // 1. will skip index loading for primary key field
     bool is_sorted_by_pk_ = false;
 
-    // milvus storage internal api reader instance
+    // milvus storage internal api reader instance (NOT thread-safe).
+    // Load-time access (get_chunk_reader, SetReader) is safe: single-threaded,
+    // completes before the segment is visible to queries.
+    // Query-time access (take) must be serialized via reader_mutex_.
     std::unique_ptr<milvus_storage::api::Reader> reader_;
+    mutable std::mutex reader_mutex_;
 
     // ArrayOffsetsSealed for element-level filtering on array fields
     // field_id -> ArrayOffsetsSealed mapping

--- a/internal/core/src/segcore/SegmentInterface.cpp
+++ b/internal/core/src/segcore/SegmentInterface.cpp
@@ -20,6 +20,7 @@
 #include <type_traits>
 #include <unordered_set>
 
+#include "ChunkedSegmentSealedImpl.h"
 #include "NamedType/named_type_impl.hpp"
 #include "Utils.h"
 #include "bitset/bitset.h"
@@ -192,6 +193,7 @@ SegmentInternalInterface::Retrieve(tracer::TraceContext* trace_ctx,
                                        collection_ttl,
                                        entity_ttl_physical_time_us);
     auto retrieve_results = visitor.get_retrieve_result(*plan->plan_node_);
+
     retrieve_results.segment_ = (void*)this;
     results->set_has_more_result(retrieve_results.has_more_result);
     results->set_scanned_remote_bytes(
@@ -255,6 +257,7 @@ SegmentInternalInterface::Retrieve(tracer::TraceContext* trace_ctx,
                                 .count();
     milvus::monitor::internal_core_retrieve_get_target_entry_latency.Observe(
         get_entry_cost / 1000);
+
     milvus::futures::throwIfCancelled(cancel_token);
     return results;
 }
@@ -414,6 +417,16 @@ SegmentInternalInterface::FillTargetEntry(
     bool ignore_non_pk,
     bool fill_ids) const {
     tracer::AutoSpan span("FillTargetEntry", tracer::GetRootSpan());
+
+    // Fast path: use take() API for external tables with small result sets.
+    // Use dynamic_cast to avoid adding new virtual methods (vtable layout
+    // change causes SIGSEGV in cgo boundary).
+    if (auto* chunked = dynamic_cast<const ChunkedSegmentSealedImpl*>(this)) {
+        if (chunked->TryTakeForRetrieve(
+                plan, results, offsets, size, ignore_non_pk, fill_ids)) {
+            return;
+        }
+    }
 
     auto fields_data = results->mutable_fields_data();
     auto ids = results->mutable_ids();

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
@@ -40,6 +40,7 @@
 #include "common/GroupChunk.h"
 #include "common/Types.h"
 #include "fmt/core.h"
+#include "fmt/ranges.h"
 #include "glog/logging.h"
 #include "log/Log.h"
 #include "milvus-storage/common/constants.h"
@@ -56,87 +57,6 @@ namespace milvus::segcore::storagev2translator {
 
 // See GroupChunkTranslator.cpp for explanation of g_mmap_path_generation.
 static std::atomic<uint64_t> g_mmap_path_generation{0};
-
-// Convert LIST or FIXED_SIZE_LIST arrays to FixedSizeBinary.
-// External parquet files store vectors in list format; Milvus expects
-// FixedSizeBinary (raw bytes). Supports all fixed-width vector types
-// (FLOAT, FLOAT16, BFLOAT16, BINARY, INT8). Returns the input unchanged
-// if already FixedSizeBinary.
-static arrow::ArrayVector
-NormalizeVectorArraysToFixedSizeBinary(const arrow::ArrayVector& arrays,
-                                       const milvus::FieldMeta& field_meta) {
-    int dim = field_meta.get_dim();
-    int byte_width = GetDataTypeSize(field_meta.get_data_type(), dim);
-    auto fsb_type = arrow::fixed_size_binary(byte_width);
-
-    arrow::ArrayVector result;
-    result.reserve(arrays.size());
-
-    for (const auto& array : arrays) {
-        auto type_id = array->type_id();
-        if (type_id == arrow::Type::FIXED_SIZE_BINARY) {
-            result.push_back(array);
-            continue;
-        }
-
-        int64_t num_rows = array->length();
-        AssertInfo(array->null_count() == 0,
-                   "Null values in vector columns are not supported for "
-                   "external collections, field: {}",
-                   field_meta.get_name().get());
-        auto buffer_result = arrow::AllocateBuffer(num_rows * byte_width);
-        AssertInfo(buffer_result.ok(),
-                   "Failed to allocate buffer for vector normalization");
-        auto buffer = std::move(*buffer_result);
-        auto dst = buffer->mutable_data();
-
-        if (type_id == arrow::Type::LIST) {
-            auto list_array = std::static_pointer_cast<arrow::ListArray>(array);
-            auto values = list_array->values();
-            int elem_bit_width = values->type()->bit_width();
-            AssertInfo(elem_bit_width > 0 && elem_bit_width % 8 == 0,
-                       "Vector list element must be fixed-width byte-aligned "
-                       "type, got bit_width={}",
-                       elem_bit_width);
-            int elem_byte_size = elem_bit_width / 8;
-            auto raw = reinterpret_cast<const uint8_t*>(
-                values->data()->buffers[1]->data());
-            for (int64_t i = 0; i < num_rows; i++) {
-                auto offset = list_array->value_offset(i);
-                memcpy(dst + i * byte_width,
-                       raw + offset * elem_byte_size,
-                       byte_width);
-            }
-        } else if (type_id == arrow::Type::FIXED_SIZE_LIST) {
-            auto fsl_array =
-                std::static_pointer_cast<arrow::FixedSizeListArray>(array);
-            auto values = fsl_array->values();
-            int elem_bit_width = values->type()->bit_width();
-            AssertInfo(elem_bit_width > 0 && elem_bit_width % 8 == 0,
-                       "Vector list element must be fixed-width byte-aligned "
-                       "type, got bit_width={}",
-                       elem_bit_width);
-            int elem_byte_size = elem_bit_width / 8;
-            auto raw = reinterpret_cast<const uint8_t*>(
-                values->data()->buffers[1]->data());
-            for (int64_t i = 0; i < num_rows; i++) {
-                auto offset = fsl_array->value_offset(i);
-                memcpy(dst + i * byte_width,
-                       raw + offset * elem_byte_size,
-                       byte_width);
-            }
-        } else {
-            ThrowInfo(ErrorCode::Unsupported,
-                      "Unsupported arrow type for vector normalization: {}",
-                      array->type()->ToString());
-        }
-
-        auto fsb_array = std::make_shared<arrow::FixedSizeBinaryArray>(
-            fsb_type, num_rows, std::move(buffer));
-        result.push_back(std::move(fsb_array));
-    }
-    return result;
-}
 
 ManifestGroupTranslator::ManifestGroupTranslator(
     int64_t segment_id,
@@ -330,12 +250,23 @@ ManifestGroupTranslator::get_cells(
                                             DEFAULT_FIELD_MAX_MEMORY_LIMIT,
                                             load_priority_);
 
-    LOG_INFO(
-        "[StorageV2] translator {} submits {} batch tasks for manifest column "
-        "group {}",
-        key_,
-        load_futures.size(),
-        column_group_index_);
+    {
+        std::string rg_info;
+        for (size_t i = 0; i < cids.size(); ++i) {
+            auto [start, end] = meta_.get_row_group_range(cids[i]);
+            if (i > 0)
+                rg_info += ", ";
+            rg_info += fmt::format("cid{}:[{},{})", cids[i], start, end);
+        }
+        LOG_INFO(
+            "[StorageV2] translator {} submits {} batch tasks for manifest "
+            "column group {}, loading cids=[{}], row_group_ranges=[{}]",
+            key_,
+            load_futures.size(),
+            column_group_index_,
+            fmt::join(cids, ","),
+            rg_info);
+    }
 
     // Pop loop — convert each cell immediately, no ArrowTable accumulation
     std::unordered_map<milvus::cachinglayer::cid_t,
@@ -459,8 +390,10 @@ ManifestGroupTranslator::load_group_chunk(
             !IsVectorArrayDataType(field_metas[idx].get_data_type()) &&
             !array_vecs[idx].empty() &&
             array_vecs[idx][0]->type_id() != arrow::Type::FIXED_SIZE_BINARY) {
-            array_vecs[idx] = NormalizeVectorArraysToFixedSizeBinary(
-                array_vecs[idx], field_metas[idx]);
+            array_vecs[idx] = storage::NormalizeVectorArraysToFixedSizeBinary(
+                array_vecs[idx],
+                field_metas[idx].get_data_type(),
+                field_metas[idx].get_dim());
         }
     }
 

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -1594,18 +1594,6 @@ GetFieldDatasFromManifest(
         }
 
         auto raw_column = batch->GetColumnByName(column_name);
-        // External files may store vectors as List<Float32> or
-        // FixedSizeList<Float32, dim>. Normalize to FixedSizeBinary
-        // before FillFieldData which expects that format.
-        if (IsVectorDataType(data_type.value()) &&
-            !IsSparseFloatVectorDataType(data_type.value()) &&
-            !IsVectorArrayDataType(data_type.value()) &&
-            raw_column->type_id() != arrow::Type::FIXED_SIZE_BINARY) {
-            arrow::ArrayVector normalized =
-                NormalizeVectorArraysToFixedSizeBinary(
-                    {raw_column}, data_type.value(), dim);
-            raw_column = normalized[0];
-        }
         auto chunked_array = std::make_shared<arrow::ChunkedArray>(raw_column);
         auto field_data = CreateFieldData(data_type.value(),
                                           element_type.value(),

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -1552,11 +1552,8 @@ GetFieldDatasFromManifest(
                 data_type.value(), static_cast<int>(dim), nullable);
         }
     } else if (data_type.value() == DataType::ARRAY) {
-        // For ARRAY types, we use binary representation
-        // Element type information is encoded in the data itself
         arrow_schema = CreateArrowSchema(data_type.value(), nullable);
     } else {
-        // For scalar types
         arrow_schema = CreateArrowSchema(data_type.value(), nullable);
     }
 
@@ -1596,61 +1593,20 @@ GetFieldDatasFromManifest(
             continue;
         }
 
-        auto column = batch->GetColumnByName(column_name);
-
-        // External parquet files store vectors as List<float> or
-        // FixedSizeList<float>, but Milvus expects FixedSizeBinary.
-        // Normalize here so that FillFieldData sees the right Arrow type.
-        if (!field_meta.field_schema.external_field().empty() &&
-            IsVectorDataType(data_type.value()) &&
+        auto raw_column = batch->GetColumnByName(column_name);
+        // External files may store vectors as List<Float32> or
+        // FixedSizeList<Float32, dim>. Normalize to FixedSizeBinary
+        // before FillFieldData which expects that format.
+        if (IsVectorDataType(data_type.value()) &&
             !IsSparseFloatVectorDataType(data_type.value()) &&
-            column->type_id() != arrow::Type::FIXED_SIZE_BINARY) {
-            int byte_width = GetDataTypeSize(data_type.value(), dim);
-            auto fsb_type = arrow::fixed_size_binary(byte_width);
-            int64_t n = column->length();
-
-            auto buf_res = arrow::AllocateBuffer(n * byte_width);
-            AssertInfo(buf_res.ok(),
-                       "Failed to allocate buffer for vector normalization");
-            auto buffer = std::move(*buf_res);
-            auto dst = buffer->mutable_data();
-
-            if (column->type_id() == arrow::Type::LIST) {
-                auto list_arr =
-                    std::static_pointer_cast<arrow::ListArray>(column);
-                auto values = list_arr->values();
-                int elem_bytes = values->type()->bit_width() / 8;
-                auto raw = reinterpret_cast<const uint8_t*>(
-                    values->data()->buffers[1]->data());
-                for (int64_t i = 0; i < n; i++) {
-                    memcpy(dst + i * byte_width,
-                           raw + list_arr->value_offset(i) * elem_bytes,
-                           byte_width);
-                }
-            } else if (column->type_id() == arrow::Type::FIXED_SIZE_LIST) {
-                auto fsl_arr =
-                    std::static_pointer_cast<arrow::FixedSizeListArray>(column);
-                auto values = fsl_arr->values();
-                int elem_bytes = values->type()->bit_width() / 8;
-                auto raw = reinterpret_cast<const uint8_t*>(
-                    values->data()->buffers[1]->data());
-                for (int64_t i = 0; i < n; i++) {
-                    memcpy(dst + i * byte_width,
-                           raw + fsl_arr->value_offset(i) * elem_bytes,
-                           byte_width);
-                }
-            } else {
-                ThrowInfo(Unsupported,
-                          "Unsupported arrow type for external vector "
-                          "normalization: {}",
-                          column->type()->ToString());
-            }
-
-            column = std::make_shared<arrow::FixedSizeBinaryArray>(
-                fsb_type, n, std::move(buffer));
+            !IsVectorArrayDataType(data_type.value()) &&
+            raw_column->type_id() != arrow::Type::FIXED_SIZE_BINARY) {
+            arrow::ArrayVector normalized =
+                NormalizeVectorArraysToFixedSizeBinary(
+                    {raw_column}, data_type.value(), dim);
+            raw_column = normalized[0];
         }
-
-        auto chunked_array = std::make_shared<arrow::ChunkedArray>(column);
+        auto chunked_array = std::make_shared<arrow::ChunkedArray>(raw_column);
         auto field_data = CreateFieldData(data_type.value(),
                                           element_type.value(),
                                           batch->schema()->field(0)->nullable(),
@@ -1738,6 +1694,154 @@ GetFieldIDList(FieldId column_group_id,
                "failed to close file reader when get field id list from {}",
                filepath);
     return field_id_list;
+}
+
+arrow::ArrayVector
+NormalizeVectorArraysToFixedSizeBinary(const arrow::ArrayVector& arrays,
+                                       DataType data_type,
+                                       int dim) {
+    int byte_width = GetDataTypeSize(data_type, dim);
+    auto fsb_type = arrow::fixed_size_binary(byte_width);
+
+    arrow::ArrayVector result;
+    result.reserve(arrays.size());
+
+    for (const auto& array : arrays) {
+        auto type_id = array->type_id();
+        if (type_id == arrow::Type::FIXED_SIZE_BINARY) {
+            result.push_back(array);
+            continue;
+        }
+
+        int64_t num_rows = array->length();
+        AssertInfo(array->null_count() == 0,
+                   "Null values in vector columns are not supported for "
+                   "external collections");
+        auto buffer_result = arrow::AllocateBuffer(num_rows * byte_width);
+        AssertInfo(buffer_result.ok(),
+                   "Failed to allocate buffer for vector normalization");
+        auto buffer = std::move(*buffer_result);
+        auto dst = buffer->mutable_data();
+
+        if (type_id == arrow::Type::LIST) {
+            auto list_array = std::static_pointer_cast<arrow::ListArray>(array);
+            auto values = list_array->values();
+            int elem_bit_width = values->type()->bit_width();
+            AssertInfo(elem_bit_width > 0 && elem_bit_width % 8 == 0,
+                       "Vector list element must be fixed-width byte-aligned "
+                       "type, got bit_width={}",
+                       elem_bit_width);
+            int elem_byte_size = elem_bit_width / 8;
+            auto raw = reinterpret_cast<const uint8_t*>(
+                values->data()->buffers[1]->data());
+            for (int64_t i = 0; i < num_rows; i++) {
+                auto offset = list_array->value_offset(i);
+                memcpy(dst + i * byte_width,
+                       raw + offset * elem_byte_size,
+                       byte_width);
+            }
+        } else if (type_id == arrow::Type::FIXED_SIZE_LIST) {
+            auto fsl_array =
+                std::static_pointer_cast<arrow::FixedSizeListArray>(array);
+            auto values = fsl_array->values();
+            int elem_bit_width = values->type()->bit_width();
+            AssertInfo(elem_bit_width > 0 && elem_bit_width % 8 == 0,
+                       "Vector list element must be fixed-width byte-aligned "
+                       "type, got bit_width={}",
+                       elem_bit_width);
+            int elem_byte_size = elem_bit_width / 8;
+            auto raw = reinterpret_cast<const uint8_t*>(
+                values->data()->buffers[1]->data());
+            for (int64_t i = 0; i < num_rows; i++) {
+                auto offset = fsl_array->value_offset(i);
+                memcpy(dst + i * byte_width,
+                       raw + offset * elem_byte_size,
+                       byte_width);
+            }
+        } else {
+            ThrowInfo(ErrorCode::Unsupported,
+                      "Unsupported arrow type for vector normalization: {}",
+                      array->type()->ToString());
+        }
+
+        auto fsb_array = std::make_shared<arrow::FixedSizeBinaryArray>(
+            fsb_type, num_rows, std::move(buffer));
+        result.push_back(std::move(fsb_array));
+    }
+    return result;
+}
+
+proto::schema::ScalarField
+ArrowListToScalarFieldProto(const std::shared_ptr<arrow::ListArray>& list_array,
+                            int64_t row_index) {
+    proto::schema::ScalarField sf;
+    int64_t start = list_array->value_offset(row_index);
+    int64_t end = list_array->value_offset(row_index + 1);
+    auto values = list_array->values();
+
+    switch (values->type_id()) {
+        case arrow::Type::BOOL: {
+            auto typed = std::static_pointer_cast<arrow::BooleanArray>(values);
+            auto* d = sf.mutable_bool_data();
+            for (int64_t j = start; j < end; j++)
+                d->add_data(typed->Value(j));
+            break;
+        }
+        case arrow::Type::INT8: {
+            auto typed = std::static_pointer_cast<arrow::Int8Array>(values);
+            auto* d = sf.mutable_int_data();
+            for (int64_t j = start; j < end; j++)
+                d->add_data(static_cast<int32_t>(typed->Value(j)));
+            break;
+        }
+        case arrow::Type::INT16: {
+            auto typed = std::static_pointer_cast<arrow::Int16Array>(values);
+            auto* d = sf.mutable_int_data();
+            for (int64_t j = start; j < end; j++)
+                d->add_data(static_cast<int32_t>(typed->Value(j)));
+            break;
+        }
+        case arrow::Type::INT32: {
+            auto typed = std::static_pointer_cast<arrow::Int32Array>(values);
+            auto* d = sf.mutable_int_data();
+            for (int64_t j = start; j < end; j++)
+                d->add_data(typed->Value(j));
+            break;
+        }
+        case arrow::Type::INT64: {
+            auto typed = std::static_pointer_cast<arrow::Int64Array>(values);
+            auto* d = sf.mutable_long_data();
+            for (int64_t j = start; j < end; j++)
+                d->add_data(typed->Value(j));
+            break;
+        }
+        case arrow::Type::FLOAT: {
+            auto typed = std::static_pointer_cast<arrow::FloatArray>(values);
+            auto* d = sf.mutable_float_data();
+            for (int64_t j = start; j < end; j++)
+                d->add_data(typed->Value(j));
+            break;
+        }
+        case arrow::Type::DOUBLE: {
+            auto typed = std::static_pointer_cast<arrow::DoubleArray>(values);
+            auto* d = sf.mutable_double_data();
+            for (int64_t j = start; j < end; j++)
+                d->add_data(typed->Value(j));
+            break;
+        }
+        case arrow::Type::STRING: {
+            auto typed = std::static_pointer_cast<arrow::StringArray>(values);
+            auto* d = sf.mutable_string_data();
+            for (int64_t j = start; j < end; j++)
+                d->add_data(typed->GetString(j));
+            break;
+        }
+        default:
+            ThrowInfo(ErrorCode::Unsupported,
+                      "Unsupported element type for ArrowListToScalarFieldProto: {}",
+                      values->type()->ToString());
+    }
+    return sf;
 }
 
 }  // namespace milvus::storage

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -1783,8 +1783,7 @@ ArrowListToScalarFieldProto(const std::shared_ptr<arrow::ListArray>& list_array,
         case arrow::Type::BOOL: {
             auto typed = std::static_pointer_cast<arrow::BooleanArray>(values);
             auto* d = sf.mutable_bool_data();
-            for (int64_t j = start; j < end; j++)
-                d->add_data(typed->Value(j));
+            for (int64_t j = start; j < end; j++) d->add_data(typed->Value(j));
             break;
         }
         case arrow::Type::INT8: {
@@ -1804,29 +1803,25 @@ ArrowListToScalarFieldProto(const std::shared_ptr<arrow::ListArray>& list_array,
         case arrow::Type::INT32: {
             auto typed = std::static_pointer_cast<arrow::Int32Array>(values);
             auto* d = sf.mutable_int_data();
-            for (int64_t j = start; j < end; j++)
-                d->add_data(typed->Value(j));
+            for (int64_t j = start; j < end; j++) d->add_data(typed->Value(j));
             break;
         }
         case arrow::Type::INT64: {
             auto typed = std::static_pointer_cast<arrow::Int64Array>(values);
             auto* d = sf.mutable_long_data();
-            for (int64_t j = start; j < end; j++)
-                d->add_data(typed->Value(j));
+            for (int64_t j = start; j < end; j++) d->add_data(typed->Value(j));
             break;
         }
         case arrow::Type::FLOAT: {
             auto typed = std::static_pointer_cast<arrow::FloatArray>(values);
             auto* d = sf.mutable_float_data();
-            for (int64_t j = start; j < end; j++)
-                d->add_data(typed->Value(j));
+            for (int64_t j = start; j < end; j++) d->add_data(typed->Value(j));
             break;
         }
         case arrow::Type::DOUBLE: {
             auto typed = std::static_pointer_cast<arrow::DoubleArray>(values);
             auto* d = sf.mutable_double_data();
-            for (int64_t j = start; j < end; j++)
-                d->add_data(typed->Value(j));
+            for (int64_t j = start; j < end; j++) d->add_data(typed->Value(j));
             break;
         }
         case arrow::Type::STRING: {
@@ -1837,9 +1832,10 @@ ArrowListToScalarFieldProto(const std::shared_ptr<arrow::ListArray>& list_array,
             break;
         }
         default:
-            ThrowInfo(ErrorCode::Unsupported,
-                      "Unsupported element type for ArrowListToScalarFieldProto: {}",
-                      values->type()->ToString());
+            ThrowInfo(
+                ErrorCode::Unsupported,
+                "Unsupported element type for ArrowListToScalarFieldProto: {}",
+                values->type()->ToString());
     }
     return sf;
 }

--- a/internal/core/src/storage/Util.h
+++ b/internal/core/src/storage/Util.h
@@ -423,4 +423,35 @@ GetFieldIDList(FieldId column_group_id,
                const std::shared_ptr<arrow::Schema>& arrow_schema,
                milvus_storage::ArrowFileSystemPtr fs);
 
+// Convert LIST or FIXED_SIZE_LIST arrays to FixedSizeBinary.
+// External files store vectors in list format (e.g. List<Float32>);
+// Milvus expects FixedSizeBinary (raw bytes). Returns the input
+// unchanged if already FixedSizeBinary.
+arrow::ArrayVector
+NormalizeVectorArraysToFixedSizeBinary(const arrow::ArrayVector& arrays,
+                                       DataType data_type,
+                                       int dim);
+
+// Convert a single row of an Arrow ListArray to a protobuf ScalarField.
+proto::schema::ScalarField
+ArrowListToScalarFieldProto(const std::shared_ptr<arrow::ListArray>& list_array,
+                            int64_t row_index);
+
+// Convert a timestamp value to microseconds based on its Arrow TimeUnit.
+inline int64_t
+ConvertToMicroseconds(int64_t value, arrow::TimeUnit::type unit) {
+    switch (unit) {
+        case arrow::TimeUnit::SECOND:
+            return value * 1000000;
+        case arrow::TimeUnit::MILLI:
+            return value * 1000;
+        case arrow::TimeUnit::MICRO:
+            return value;
+        case arrow::TimeUnit::NANO:
+            return value / 1000;
+        default:
+            return value;
+    }
+}
+
 }  // namespace milvus::storage

--- a/internal/core/unittest/CMakeLists.txt
+++ b/internal/core/unittest/CMakeLists.txt
@@ -64,6 +64,7 @@ set(MILVUS_TEST_FILES
         test_query_order_by.cpp
         test_determine_use_index.cpp
         test_virtual_pk.cpp
+        test_external_take.cpp
         )
 
 if ( NOT (INDEX_ENGINE STREQUAL "cardinal") )
@@ -115,7 +116,8 @@ if (LINUX)
 endif()
 
 add_compile_definitions(
-        MILVUS_CPPUT_OUTPUT_DIR="${CMAKE_INSTALL_PREFIX}/cpput_output")
+        MILVUS_CPPUT_OUTPUT_DIR="${CMAKE_INSTALL_PREFIX}/cpput_output"
+        MILVUS_UNIT_TEST)
 
 add_executable(all_tests
         ${MILVUS_TEST_FILES}

--- a/internal/core/unittest/test_external_take.cpp
+++ b/internal/core/unittest/test_external_take.cpp
@@ -16,6 +16,7 @@
 
 #include <arrow/array.h>
 #include <arrow/builder.h>
+#include <arrow/compute/api.h>
 #include <arrow/table.h>
 #include <arrow/type.h>
 #include <cstdint>
@@ -100,174 +101,20 @@ class MockTakeReader : public milvus_storage::api::Reader {
     }
 
  private:
-    // Select rows from table at given indices
+    // Select rows from table at given indices using arrow::compute::Take.
     static arrow::Result<std::shared_ptr<arrow::Table>>
     SelectRows(const std::shared_ptr<arrow::Table>& table,
                const std::vector<int64_t>& indices) {
         if (indices.empty()) {
             return table->Slice(0, 0);
         }
-        // Build a take indices array
         arrow::Int64Builder idx_builder;
         ARROW_RETURN_NOT_OK(idx_builder.AppendValues(indices));
         std::shared_ptr<arrow::Array> idx_arr;
         ARROW_RETURN_NOT_OK(idx_builder.Finish(&idx_arr));
-
-        std::vector<std::shared_ptr<arrow::ChunkedArray>> result_columns;
-        for (int i = 0; i < table->num_columns(); i++) {
-            auto chunked = table->column(i);
-            // Combine chunks for simplicity
-            auto combined = arrow::Concatenate(chunked->chunks());
-            if (!combined.ok()) {
-                return combined.status();
-            }
-            auto arr = *combined;
-            // Manual take: select values at indices
-            auto type = arr->type();
-            if (type->Equals(arrow::boolean())) {
-                auto typed = std::static_pointer_cast<arrow::BooleanArray>(arr);
-                arrow::BooleanBuilder b;
-                for (auto idx : indices)
-                    ARROW_RETURN_NOT_OK(b.Append(typed->Value(idx)));
-                std::shared_ptr<arrow::Array> out;
-                ARROW_RETURN_NOT_OK(b.Finish(&out));
-                result_columns.push_back(
-                    std::make_shared<arrow::ChunkedArray>(out));
-            } else if (type->Equals(arrow::int8())) {
-                auto typed = std::static_pointer_cast<arrow::Int8Array>(arr);
-                arrow::Int8Builder b;
-                for (auto idx : indices)
-                    ARROW_RETURN_NOT_OK(b.Append(typed->Value(idx)));
-                std::shared_ptr<arrow::Array> out;
-                ARROW_RETURN_NOT_OK(b.Finish(&out));
-                result_columns.push_back(
-                    std::make_shared<arrow::ChunkedArray>(out));
-            } else if (type->Equals(arrow::int16())) {
-                auto typed = std::static_pointer_cast<arrow::Int16Array>(arr);
-                arrow::Int16Builder b;
-                for (auto idx : indices)
-                    ARROW_RETURN_NOT_OK(b.Append(typed->Value(idx)));
-                std::shared_ptr<arrow::Array> out;
-                ARROW_RETURN_NOT_OK(b.Finish(&out));
-                result_columns.push_back(
-                    std::make_shared<arrow::ChunkedArray>(out));
-            } else if (type->Equals(arrow::int32())) {
-                auto typed = std::static_pointer_cast<arrow::Int32Array>(arr);
-                arrow::Int32Builder b;
-                for (auto idx : indices)
-                    ARROW_RETURN_NOT_OK(b.Append(typed->Value(idx)));
-                std::shared_ptr<arrow::Array> out;
-                ARROW_RETURN_NOT_OK(b.Finish(&out));
-                result_columns.push_back(
-                    std::make_shared<arrow::ChunkedArray>(out));
-            } else if (type->Equals(arrow::int64())) {
-                auto typed = std::static_pointer_cast<arrow::Int64Array>(arr);
-                arrow::Int64Builder b;
-                for (auto idx : indices)
-                    ARROW_RETURN_NOT_OK(b.Append(typed->Value(idx)));
-                std::shared_ptr<arrow::Array> out;
-                ARROW_RETURN_NOT_OK(b.Finish(&out));
-                result_columns.push_back(
-                    std::make_shared<arrow::ChunkedArray>(out));
-            } else if (type->Equals(arrow::float32())) {
-                auto typed = std::static_pointer_cast<arrow::FloatArray>(arr);
-                arrow::FloatBuilder b;
-                for (auto idx : indices)
-                    ARROW_RETURN_NOT_OK(b.Append(typed->Value(idx)));
-                std::shared_ptr<arrow::Array> out;
-                ARROW_RETURN_NOT_OK(b.Finish(&out));
-                result_columns.push_back(
-                    std::make_shared<arrow::ChunkedArray>(out));
-            } else if (type->Equals(arrow::float64())) {
-                auto typed = std::static_pointer_cast<arrow::DoubleArray>(arr);
-                arrow::DoubleBuilder b;
-                for (auto idx : indices)
-                    ARROW_RETURN_NOT_OK(b.Append(typed->Value(idx)));
-                std::shared_ptr<arrow::Array> out;
-                ARROW_RETURN_NOT_OK(b.Finish(&out));
-                result_columns.push_back(
-                    std::make_shared<arrow::ChunkedArray>(out));
-            } else if (type->Equals(arrow::utf8())) {
-                auto typed = std::static_pointer_cast<arrow::StringArray>(arr);
-                arrow::StringBuilder b;
-                for (auto idx : indices)
-                    ARROW_RETURN_NOT_OK(b.Append(typed->GetString(idx)));
-                std::shared_ptr<arrow::Array> out;
-                ARROW_RETURN_NOT_OK(b.Finish(&out));
-                result_columns.push_back(
-                    std::make_shared<arrow::ChunkedArray>(out));
-            } else if (type->id() == arrow::Type::TIMESTAMP) {
-                auto typed =
-                    std::static_pointer_cast<arrow::TimestampArray>(arr);
-                auto ts_type =
-                    std::static_pointer_cast<arrow::TimestampType>(type);
-                arrow::TimestampBuilder b(ts_type,
-                                          arrow::default_memory_pool());
-                for (auto idx : indices)
-                    ARROW_RETURN_NOT_OK(b.Append(typed->Value(idx)));
-                std::shared_ptr<arrow::Array> out;
-                ARROW_RETURN_NOT_OK(b.Finish(&out));
-                result_columns.push_back(
-                    std::make_shared<arrow::ChunkedArray>(out));
-            } else if (type->id() == arrow::Type::BINARY) {
-                auto typed = std::static_pointer_cast<arrow::BinaryArray>(arr);
-                arrow::BinaryBuilder b;
-                for (auto idx : indices) {
-                    ARROW_RETURN_NOT_OK(b.Append(typed->Value(idx)));
-                }
-                std::shared_ptr<arrow::Array> out;
-                ARROW_RETURN_NOT_OK(b.Finish(&out));
-                result_columns.push_back(
-                    std::make_shared<arrow::ChunkedArray>(out));
-            } else if (type->id() == arrow::Type::FIXED_SIZE_BINARY) {
-                auto typed =
-                    std::static_pointer_cast<arrow::FixedSizeBinaryArray>(arr);
-                auto fsb_type =
-                    std::static_pointer_cast<arrow::FixedSizeBinaryType>(type);
-                arrow::FixedSizeBinaryBuilder b(fsb_type);
-                for (auto idx : indices)
-                    ARROW_RETURN_NOT_OK(b.Append(typed->Value(idx)));
-                std::shared_ptr<arrow::Array> out;
-                ARROW_RETURN_NOT_OK(b.Finish(&out));
-                result_columns.push_back(
-                    std::make_shared<arrow::ChunkedArray>(out));
-            } else if (type->id() == arrow::Type::LIST) {
-                // List<T> — rebuild by selecting rows from the original.
-                auto typed = std::static_pointer_cast<arrow::ListArray>(arr);
-                auto list_type =
-                    std::static_pointer_cast<arrow::ListType>(type);
-                auto value_builder_result =
-                    arrow::MakeBuilder(list_type->value_type());
-                ARROW_RETURN_NOT_OK(value_builder_result.status());
-                auto value_builder = std::move(*value_builder_result);
-                arrow::Int32Builder offset_builder;
-                ARROW_RETURN_NOT_OK(offset_builder.Append(0));
-                int32_t current_offset = 0;
-                for (auto idx : indices) {
-                    auto slice_start = typed->value_offset(idx);
-                    auto slice_len = typed->value_length(idx);
-                    auto slice = typed->values()->Slice(slice_start, slice_len);
-                    ARROW_RETURN_NOT_OK(value_builder->AppendArraySlice(
-                        *slice->data(), 0, slice_len));
-                    current_offset += slice_len;
-                    ARROW_RETURN_NOT_OK(offset_builder.Append(current_offset));
-                }
-                std::shared_ptr<arrow::Array> values_out, offsets_out;
-                ARROW_RETURN_NOT_OK(value_builder->Finish(&values_out));
-                ARROW_RETURN_NOT_OK(offset_builder.Finish(&offsets_out));
-                auto list_result =
-                    arrow::ListArray::FromArrays(*offsets_out, *values_out);
-                ARROW_RETURN_NOT_OK(list_result.status());
-                result_columns.push_back(
-                    std::make_shared<arrow::ChunkedArray>(*list_result));
-            } else {
-                return arrow::Status::NotImplemented(
-                    "MockTakeReader: unsupported Arrow type ",
-                    type->ToString());
-            }
-        }
-        auto schema = table->schema();
-        return arrow::Table::Make(schema, result_columns);
+        ARROW_ASSIGN_OR_RAISE(auto result,
+                              arrow::compute::Take(table, idx_arr));
+        return result.table();
     }
 };
 

--- a/internal/core/unittest/test_external_take.cpp
+++ b/internal/core/unittest/test_external_take.cpp
@@ -213,9 +213,7 @@ class MockTakeReader : public milvus_storage::api::Reader {
                 auto typed = std::static_pointer_cast<arrow::BinaryArray>(arr);
                 arrow::BinaryBuilder b;
                 for (auto idx : indices) {
-                    auto val = typed->Value(idx);
-                    auto len = typed->value_length(idx);
-                    ARROW_RETURN_NOT_OK(b.Append(val, len));
+                    ARROW_RETURN_NOT_OK(b.Append(typed->Value(idx)));
                 }
                 std::shared_ptr<arrow::Array> out;
                 ARROW_RETURN_NOT_OK(b.Finish(&out));

--- a/internal/core/unittest/test_external_take.cpp
+++ b/internal/core/unittest/test_external_take.cpp
@@ -236,8 +236,8 @@ class MockTakeReader : public milvus_storage::api::Reader {
                 auto typed = std::static_pointer_cast<arrow::ListArray>(arr);
                 auto list_type =
                     std::static_pointer_cast<arrow::ListType>(type);
-                auto value_builder_result = arrow::MakeBuilder(
-                    arrow::default_memory_pool(), list_type->value_type());
+                auto value_builder_result =
+                    arrow::MakeBuilder(list_type->value_type());
                 ARROW_RETURN_NOT_OK(value_builder_result.status());
                 auto value_builder = std::move(*value_builder_result);
                 arrow::Int32Builder offset_builder;

--- a/internal/core/unittest/test_external_take.cpp
+++ b/internal/core/unittest/test_external_take.cpp
@@ -1,0 +1,2440 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <arrow/array.h>
+#include <arrow/builder.h>
+#include <arrow/table.h>
+#include <arrow/type.h>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "common/FieldMeta.h"
+#include "common/Schema.h"
+#include "common/Types.h"
+#include "common/VirtualPK.h"
+#include "gtest/gtest.h"
+#include "knowhere/comp/index_param.h"
+#include "milvus-storage/reader.h"
+#include "query/PlanImpl.h"
+#include "segcore/ChunkedSegmentSealedImpl.h"
+#include "segcore/SegmentSealed.h"
+
+using namespace milvus;
+using namespace milvus::segcore;
+
+namespace {
+
+constexpr int64_t kTestRows = 5;
+constexpr int64_t kVecDim = 4;
+
+// Mock Reader that returns a pre-built Arrow Table from take().
+class MockTakeReader : public milvus_storage::api::Reader {
+ public:
+    std::shared_ptr<arrow::Table> table_;
+
+    explicit MockTakeReader(std::shared_ptr<arrow::Table> table)
+        : table_(std::move(table)) {
+    }
+
+    std::shared_ptr<milvus_storage::api::ColumnGroups>
+    get_column_groups() const override {
+        return nullptr;
+    }
+
+    arrow::Result<std::shared_ptr<arrow::RecordBatchReader>>
+    get_record_batch_reader(const std::string&) const override {
+        return arrow::Status::NotImplemented("mock");
+    }
+
+    arrow::Result<std::unique_ptr<milvus_storage::api::ChunkReader>>
+    get_chunk_reader(int64_t, const std::shared_ptr<std::vector<std::string>>&)
+        const override {
+        return arrow::Status::NotImplemented("mock");
+    }
+
+    arrow::Result<std::shared_ptr<arrow::Table>>
+    take(const std::vector<int64_t>& row_indices,
+         size_t,
+         const std::shared_ptr<std::vector<std::string>>& needed_columns)
+        override {
+        if (!table_) {
+            return arrow::Status::Invalid("no table");
+        }
+        // Select columns matching needed_columns
+        if (needed_columns && !needed_columns->empty()) {
+            std::vector<std::shared_ptr<arrow::Field>> fields;
+            std::vector<std::shared_ptr<arrow::ChunkedArray>> columns;
+            for (const auto& name : *needed_columns) {
+                auto col = table_->GetColumnByName(name);
+                if (col) {
+                    fields.push_back(table_->schema()->GetFieldByName(name));
+                    columns.push_back(col);
+                }
+            }
+            auto schema = arrow::schema(fields);
+            auto filtered = arrow::Table::Make(schema, columns);
+            // Select rows by indices
+            return SelectRows(filtered, row_indices);
+        }
+        return SelectRows(table_, row_indices);
+    }
+
+    void
+    set_keyretriever(
+        const std::function<std::string(const std::string&)>&) override {
+    }
+
+ private:
+    // Select rows from table at given indices
+    static arrow::Result<std::shared_ptr<arrow::Table>>
+    SelectRows(const std::shared_ptr<arrow::Table>& table,
+               const std::vector<int64_t>& indices) {
+        if (indices.empty()) {
+            return table->Slice(0, 0);
+        }
+        // Build a take indices array
+        arrow::Int64Builder idx_builder;
+        ARROW_RETURN_NOT_OK(idx_builder.AppendValues(indices));
+        std::shared_ptr<arrow::Array> idx_arr;
+        ARROW_RETURN_NOT_OK(idx_builder.Finish(&idx_arr));
+
+        std::vector<std::shared_ptr<arrow::ChunkedArray>> result_columns;
+        for (int i = 0; i < table->num_columns(); i++) {
+            auto chunked = table->column(i);
+            // Combine chunks for simplicity
+            auto combined = arrow::Concatenate(chunked->chunks());
+            if (!combined.ok()) {
+                return combined.status();
+            }
+            auto arr = *combined;
+            // Manual take: select values at indices
+            auto type = arr->type();
+            if (type->Equals(arrow::boolean())) {
+                auto typed = std::static_pointer_cast<arrow::BooleanArray>(arr);
+                arrow::BooleanBuilder b;
+                for (auto idx : indices)
+                    ARROW_RETURN_NOT_OK(b.Append(typed->Value(idx)));
+                std::shared_ptr<arrow::Array> out;
+                ARROW_RETURN_NOT_OK(b.Finish(&out));
+                result_columns.push_back(
+                    std::make_shared<arrow::ChunkedArray>(out));
+            } else if (type->Equals(arrow::int8())) {
+                auto typed = std::static_pointer_cast<arrow::Int8Array>(arr);
+                arrow::Int8Builder b;
+                for (auto idx : indices)
+                    ARROW_RETURN_NOT_OK(b.Append(typed->Value(idx)));
+                std::shared_ptr<arrow::Array> out;
+                ARROW_RETURN_NOT_OK(b.Finish(&out));
+                result_columns.push_back(
+                    std::make_shared<arrow::ChunkedArray>(out));
+            } else if (type->Equals(arrow::int16())) {
+                auto typed = std::static_pointer_cast<arrow::Int16Array>(arr);
+                arrow::Int16Builder b;
+                for (auto idx : indices)
+                    ARROW_RETURN_NOT_OK(b.Append(typed->Value(idx)));
+                std::shared_ptr<arrow::Array> out;
+                ARROW_RETURN_NOT_OK(b.Finish(&out));
+                result_columns.push_back(
+                    std::make_shared<arrow::ChunkedArray>(out));
+            } else if (type->Equals(arrow::int32())) {
+                auto typed = std::static_pointer_cast<arrow::Int32Array>(arr);
+                arrow::Int32Builder b;
+                for (auto idx : indices)
+                    ARROW_RETURN_NOT_OK(b.Append(typed->Value(idx)));
+                std::shared_ptr<arrow::Array> out;
+                ARROW_RETURN_NOT_OK(b.Finish(&out));
+                result_columns.push_back(
+                    std::make_shared<arrow::ChunkedArray>(out));
+            } else if (type->Equals(arrow::int64())) {
+                auto typed = std::static_pointer_cast<arrow::Int64Array>(arr);
+                arrow::Int64Builder b;
+                for (auto idx : indices)
+                    ARROW_RETURN_NOT_OK(b.Append(typed->Value(idx)));
+                std::shared_ptr<arrow::Array> out;
+                ARROW_RETURN_NOT_OK(b.Finish(&out));
+                result_columns.push_back(
+                    std::make_shared<arrow::ChunkedArray>(out));
+            } else if (type->Equals(arrow::float32())) {
+                auto typed = std::static_pointer_cast<arrow::FloatArray>(arr);
+                arrow::FloatBuilder b;
+                for (auto idx : indices)
+                    ARROW_RETURN_NOT_OK(b.Append(typed->Value(idx)));
+                std::shared_ptr<arrow::Array> out;
+                ARROW_RETURN_NOT_OK(b.Finish(&out));
+                result_columns.push_back(
+                    std::make_shared<arrow::ChunkedArray>(out));
+            } else if (type->Equals(arrow::float64())) {
+                auto typed = std::static_pointer_cast<arrow::DoubleArray>(arr);
+                arrow::DoubleBuilder b;
+                for (auto idx : indices)
+                    ARROW_RETURN_NOT_OK(b.Append(typed->Value(idx)));
+                std::shared_ptr<arrow::Array> out;
+                ARROW_RETURN_NOT_OK(b.Finish(&out));
+                result_columns.push_back(
+                    std::make_shared<arrow::ChunkedArray>(out));
+            } else if (type->Equals(arrow::utf8())) {
+                auto typed = std::static_pointer_cast<arrow::StringArray>(arr);
+                arrow::StringBuilder b;
+                for (auto idx : indices)
+                    ARROW_RETURN_NOT_OK(b.Append(typed->GetString(idx)));
+                std::shared_ptr<arrow::Array> out;
+                ARROW_RETURN_NOT_OK(b.Finish(&out));
+                result_columns.push_back(
+                    std::make_shared<arrow::ChunkedArray>(out));
+            } else if (type->id() == arrow::Type::TIMESTAMP) {
+                auto typed =
+                    std::static_pointer_cast<arrow::TimestampArray>(arr);
+                auto ts_type =
+                    std::static_pointer_cast<arrow::TimestampType>(type);
+                arrow::TimestampBuilder b(ts_type,
+                                          arrow::default_memory_pool());
+                for (auto idx : indices)
+                    ARROW_RETURN_NOT_OK(b.Append(typed->Value(idx)));
+                std::shared_ptr<arrow::Array> out;
+                ARROW_RETURN_NOT_OK(b.Finish(&out));
+                result_columns.push_back(
+                    std::make_shared<arrow::ChunkedArray>(out));
+            } else if (type->id() == arrow::Type::BINARY) {
+                auto typed = std::static_pointer_cast<arrow::BinaryArray>(arr);
+                arrow::BinaryBuilder b;
+                for (auto idx : indices) {
+                    auto val = typed->Value(idx);
+                    auto len = typed->value_length(idx);
+                    ARROW_RETURN_NOT_OK(b.Append(val, len));
+                }
+                std::shared_ptr<arrow::Array> out;
+                ARROW_RETURN_NOT_OK(b.Finish(&out));
+                result_columns.push_back(
+                    std::make_shared<arrow::ChunkedArray>(out));
+            } else if (type->id() == arrow::Type::FIXED_SIZE_BINARY) {
+                auto typed =
+                    std::static_pointer_cast<arrow::FixedSizeBinaryArray>(arr);
+                auto fsb_type =
+                    std::static_pointer_cast<arrow::FixedSizeBinaryType>(type);
+                arrow::FixedSizeBinaryBuilder b(fsb_type);
+                for (auto idx : indices)
+                    ARROW_RETURN_NOT_OK(b.Append(typed->Value(idx)));
+                std::shared_ptr<arrow::Array> out;
+                ARROW_RETURN_NOT_OK(b.Finish(&out));
+                result_columns.push_back(
+                    std::make_shared<arrow::ChunkedArray>(out));
+            } else if (type->id() == arrow::Type::LIST) {
+                // List<T> — rebuild by selecting rows from the original.
+                auto typed = std::static_pointer_cast<arrow::ListArray>(arr);
+                auto list_type =
+                    std::static_pointer_cast<arrow::ListType>(type);
+                auto value_builder_result = arrow::MakeBuilder(
+                    arrow::default_memory_pool(), list_type->value_type());
+                ARROW_RETURN_NOT_OK(value_builder_result.status());
+                auto value_builder = std::move(*value_builder_result);
+                arrow::Int32Builder offset_builder;
+                ARROW_RETURN_NOT_OK(offset_builder.Append(0));
+                int32_t current_offset = 0;
+                for (auto idx : indices) {
+                    auto slice_start = typed->value_offset(idx);
+                    auto slice_len = typed->value_length(idx);
+                    auto slice = typed->values()->Slice(slice_start, slice_len);
+                    ARROW_RETURN_NOT_OK(value_builder->AppendArraySlice(
+                        *slice->data(), 0, slice_len));
+                    current_offset += slice_len;
+                    ARROW_RETURN_NOT_OK(offset_builder.Append(current_offset));
+                }
+                std::shared_ptr<arrow::Array> values_out, offsets_out;
+                ARROW_RETURN_NOT_OK(value_builder->Finish(&values_out));
+                ARROW_RETURN_NOT_OK(offset_builder.Finish(&offsets_out));
+                auto list_result =
+                    arrow::ListArray::FromArrays(*offsets_out, *values_out);
+                ARROW_RETURN_NOT_OK(list_result.status());
+                result_columns.push_back(
+                    std::make_shared<arrow::ChunkedArray>(*list_result));
+            } else {
+                return arrow::Status::NotImplemented(
+                    "MockTakeReader: unsupported Arrow type ",
+                    type->ToString());
+            }
+        }
+        auto schema = table->schema();
+        return arrow::Table::Make(schema, result_columns);
+    }
+};
+
+// Build a test Arrow Table with kTestRows rows and all supported types.
+std::shared_ptr<arrow::Table>
+BuildTestArrowTable() {
+    // BOOL
+    arrow::BooleanBuilder bool_b;
+    for (int i = 0; i < kTestRows; i++)
+        EXPECT_TRUE(bool_b.Append(i % 2 == 0).ok());
+    auto bool_arr = bool_b.Finish().ValueOrDie();
+
+    // INT8
+    arrow::Int8Builder int8_b;
+    for (int i = 0; i < kTestRows; i++)
+        EXPECT_TRUE(int8_b.Append(static_cast<int8_t>(i * 10)).ok());
+    auto int8_arr = int8_b.Finish().ValueOrDie();
+
+    // INT16
+    arrow::Int16Builder int16_b;
+    for (int i = 0; i < kTestRows; i++)
+        EXPECT_TRUE(int16_b.Append(static_cast<int16_t>(i * 100)).ok());
+    auto int16_arr = int16_b.Finish().ValueOrDie();
+
+    // INT32
+    arrow::Int32Builder int32_b;
+    for (int i = 0; i < kTestRows; i++)
+        EXPECT_TRUE(int32_b.Append(i * 1000).ok());
+    auto int32_arr = int32_b.Finish().ValueOrDie();
+
+    // INT64
+    arrow::Int64Builder int64_b;
+    for (int i = 0; i < kTestRows; i++)
+        EXPECT_TRUE(int64_b.Append(i * 10000).ok());
+    auto int64_arr = int64_b.Finish().ValueOrDie();
+
+    // FLOAT
+    arrow::FloatBuilder float_b;
+    for (int i = 0; i < kTestRows; i++)
+        EXPECT_TRUE(float_b.Append(i * 1.1f).ok());
+    auto float_arr = float_b.Finish().ValueOrDie();
+
+    // DOUBLE
+    arrow::DoubleBuilder double_b;
+    for (int i = 0; i < kTestRows; i++)
+        EXPECT_TRUE(double_b.Append(i * 2.2).ok());
+    auto double_arr = double_b.Finish().ValueOrDie();
+
+    // VARCHAR
+    arrow::StringBuilder str_b;
+    for (int i = 0; i < kTestRows; i++)
+        EXPECT_TRUE(str_b.Append("row_" + std::to_string(i)).ok());
+    auto str_arr = str_b.Finish().ValueOrDie();
+
+    // VECTOR_FLOAT (dim=4, 16 bytes per vector)
+    auto fsb_type = arrow::fixed_size_binary(kVecDim * sizeof(float));
+    arrow::FixedSizeBinaryBuilder vec_b(fsb_type);
+    for (int i = 0; i < kTestRows; i++) {
+        float v[kVecDim];
+        for (int d = 0; d < kVecDim; d++)
+            v[d] = static_cast<float>(i * kVecDim + d);
+        EXPECT_TRUE(vec_b.Append(reinterpret_cast<const uint8_t*>(v)).ok());
+    }
+    auto vec_arr = vec_b.Finish().ValueOrDie();
+
+    auto schema = arrow::schema({
+        arrow::field("bool_col", arrow::boolean()),
+        arrow::field("int8_col", arrow::int8()),
+        arrow::field("int16_col", arrow::int16()),
+        arrow::field("int32_col", arrow::int32()),
+        arrow::field("int64_col", arrow::int64()),
+        arrow::field("float_col", arrow::float32()),
+        arrow::field("double_col", arrow::float64()),
+        arrow::field("varchar_col", arrow::utf8()),
+        arrow::field("vec_col", fsb_type),
+    });
+
+    return arrow::Table::Make(schema,
+                              {bool_arr,
+                               int8_arr,
+                               int16_arr,
+                               int32_arr,
+                               int64_arr,
+                               float_arr,
+                               double_arr,
+                               str_arr,
+                               vec_arr});
+}
+
+// Build an external schema with all supported types.
+// Returns {schema, field_ids} where field_ids are in order:
+// bool, int8, int16, int32, int64, float, double, varchar, vec
+struct ExternalSchemaInfo {
+    SchemaPtr schema;
+    FieldId bool_id, int8_id, int16_id, int32_id, int64_id;
+    FieldId float_id, double_id, varchar_id, vec_id;
+};
+
+ExternalSchemaInfo
+BuildExternalSchema() {
+    auto schema = std::make_shared<Schema>();
+
+    // System fields (required by segment)
+    schema->AddField(
+        FieldName("RowID"), RowFieldID, DataType::INT64, false, std::nullopt);
+    schema->AddField(FieldName("Timestamp"),
+                     TimestampFieldID,
+                     DataType::INT64,
+                     false,
+                     std::nullopt);
+
+    // User fields with external_field_mapping
+    ExternalSchemaInfo info;
+    info.bool_id = FieldId(100);
+    info.int8_id = FieldId(101);
+    info.int16_id = FieldId(102);
+    info.int32_id = FieldId(103);
+    info.int64_id = FieldId(104);
+    info.float_id = FieldId(105);
+    info.double_id = FieldId(106);
+    info.varchar_id = FieldId(107);
+    info.vec_id = FieldId(108);
+
+    // Scalar fields: FieldMeta(name, id, type, nullable, default_value, external_field)
+    schema->AddField(FieldMeta(FieldName("bool_col"),
+                               info.bool_id,
+                               DataType::BOOL,
+                               false,
+                               std::nullopt,
+                               "bool_col"));
+    schema->AddField(FieldMeta(FieldName("int8_col"),
+                               info.int8_id,
+                               DataType::INT8,
+                               false,
+                               std::nullopt,
+                               "int8_col"));
+    schema->AddField(FieldMeta(FieldName("int16_col"),
+                               info.int16_id,
+                               DataType::INT16,
+                               false,
+                               std::nullopt,
+                               "int16_col"));
+    schema->AddField(FieldMeta(FieldName("int32_col"),
+                               info.int32_id,
+                               DataType::INT32,
+                               false,
+                               std::nullopt,
+                               "int32_col"));
+    schema->AddField(FieldMeta(FieldName("int64_col"),
+                               info.int64_id,
+                               DataType::INT64,
+                               false,
+                               std::nullopt,
+                               "int64_col"));
+    schema->AddField(FieldMeta(FieldName("float_col"),
+                               info.float_id,
+                               DataType::FLOAT,
+                               false,
+                               std::nullopt,
+                               "float_col"));
+    schema->AddField(FieldMeta(FieldName("double_col"),
+                               info.double_id,
+                               DataType::DOUBLE,
+                               false,
+                               std::nullopt,
+                               "double_col"));
+    // String field: FieldMeta(name, id, type, max_length, nullable, default_value, external_field)
+    schema->AddField(FieldMeta(FieldName("varchar_col"),
+                               info.varchar_id,
+                               DataType::VARCHAR,
+                               65535,
+                               false,
+                               std::nullopt,
+                               "varchar_col"));
+    // Vector field: FieldMeta(name, id, type, dim, metric_type, nullable, default_value, external_field)
+    schema->AddField(FieldMeta(FieldName("vec_col"),
+                               info.vec_id,
+                               DataType::VECTOR_FLOAT,
+                               kVecDim,
+                               knowhere::metric::L2,
+                               false,
+                               std::nullopt,
+                               "vec_col"));
+
+    schema->set_primary_field_id(info.int64_id);
+    schema->set_external_source("s3://test-bucket/data");
+    schema->set_external_spec(R"({"format":"parquet"})");
+
+    info.schema = schema;
+    return info;
+}
+
+// Helper: create a ChunkedSegmentSealedImpl with external schema
+// Note: reader_ must be injected via SetReaderForTesting (MILVUS_UNIT_TEST)
+ChunkedSegmentSealedImpl*
+CreateExternalSegment(SegmentSealedUPtr& holder,
+                      const SchemaPtr& schema,
+                      int64_t segment_id = 1) {
+    holder = CreateSealedSegment(schema, nullptr, segment_id);
+    return dynamic_cast<ChunkedSegmentSealedImpl*>(holder.get());
+}
+
+// Mock Reader that always returns an error from take().
+class ErrorMockTakeReader : public milvus_storage::api::Reader {
+ public:
+    std::shared_ptr<milvus_storage::api::ColumnGroups>
+    get_column_groups() const override {
+        return nullptr;
+    }
+    arrow::Result<std::shared_ptr<arrow::RecordBatchReader>>
+    get_record_batch_reader(const std::string&) const override {
+        return arrow::Status::NotImplemented("mock");
+    }
+    arrow::Result<std::unique_ptr<milvus_storage::api::ChunkReader>>
+    get_chunk_reader(int64_t, const std::shared_ptr<std::vector<std::string>>&)
+        const override {
+        return arrow::Status::NotImplemented("mock");
+    }
+    arrow::Result<std::shared_ptr<arrow::Table>>
+    take(const std::vector<int64_t>&,
+         size_t,
+         const std::shared_ptr<std::vector<std::string>>&) override {
+        return arrow::Status::Invalid("simulated take failure");
+    }
+    void
+    set_keyretriever(
+        const std::function<std::string(const std::string&)>&) override {
+    }
+};
+
+// Schema with virtual PK (non-external) + external fields.
+struct ExternalSchemaWithVirtualPK {
+    SchemaPtr schema;
+    FieldId pk_id;       // virtual PK, non-external
+    FieldId int32_id;    // external
+    FieldId varchar_id;  // external
+    FieldId vec_id;      // external
+};
+
+ExternalSchemaWithVirtualPK
+BuildExternalSchemaWithVirtualPK() {
+    auto schema = std::make_shared<Schema>();
+    schema->AddField(
+        FieldName("RowID"), RowFieldID, DataType::INT64, false, std::nullopt);
+    schema->AddField(FieldName("Timestamp"),
+                     TimestampFieldID,
+                     DataType::INT64,
+                     false,
+                     std::nullopt);
+
+    ExternalSchemaWithVirtualPK info;
+    info.pk_id = FieldId(100);
+    info.int32_id = FieldId(101);
+    info.varchar_id = FieldId(102);
+    info.vec_id = FieldId(103);
+
+    // Virtual PK: INT64 with NO external_field_mapping
+    schema->AddField(FieldMeta(FieldName("virtual_pk"),
+                               info.pk_id,
+                               DataType::INT64,
+                               false,
+                               std::nullopt));
+    // External fields
+    schema->AddField(FieldMeta(FieldName("int32_col"),
+                               info.int32_id,
+                               DataType::INT32,
+                               false,
+                               std::nullopt,
+                               "int32_col"));
+    schema->AddField(FieldMeta(FieldName("varchar_col"),
+                               info.varchar_id,
+                               DataType::VARCHAR,
+                               65535,
+                               false,
+                               std::nullopt,
+                               "varchar_col"));
+    schema->AddField(FieldMeta(FieldName("vec_col"),
+                               info.vec_id,
+                               DataType::VECTOR_FLOAT,
+                               kVecDim,
+                               knowhere::metric::L2,
+                               false,
+                               std::nullopt,
+                               "vec_col"));
+
+    schema->set_primary_field_id(info.pk_id);
+    schema->set_external_source("s3://test-bucket/data");
+    schema->set_external_spec(R"({"format":"parquet"})");
+    info.schema = schema;
+    return info;
+}
+
+// Build table for virtual PK schema (only external field columns).
+std::shared_ptr<arrow::Table>
+BuildVirtualPKTestTable() {
+    arrow::Int32Builder int32_b;
+    for (int i = 0; i < kTestRows; i++)
+        EXPECT_TRUE(int32_b.Append(i * 1000).ok());
+    auto int32_arr = int32_b.Finish().ValueOrDie();
+
+    arrow::StringBuilder str_b;
+    for (int i = 0; i < kTestRows; i++)
+        EXPECT_TRUE(str_b.Append("row_" + std::to_string(i)).ok());
+    auto str_arr = str_b.Finish().ValueOrDie();
+
+    auto fsb_type = arrow::fixed_size_binary(kVecDim * sizeof(float));
+    arrow::FixedSizeBinaryBuilder vec_b(fsb_type);
+    for (int i = 0; i < kTestRows; i++) {
+        float v[kVecDim];
+        for (int d = 0; d < kVecDim; d++)
+            v[d] = static_cast<float>(i * kVecDim + d);
+        EXPECT_TRUE(vec_b.Append(reinterpret_cast<const uint8_t*>(v)).ok());
+    }
+    auto vec_arr = vec_b.Finish().ValueOrDie();
+
+    auto schema = arrow::schema({
+        arrow::field("int32_col", arrow::int32()),
+        arrow::field("varchar_col", arrow::utf8()),
+        arrow::field("vec_col", fsb_type),
+    });
+    return arrow::Table::Make(schema, {int32_arr, str_arr, vec_arr});
+}
+
+// Additional vector types: VECTOR_BINARY, VECTOR_FLOAT16, VECTOR_BFLOAT16,
+// VECTOR_INT8.
+constexpr int64_t kBinVecDim =
+    16;  // binary vector dimension (must be multiple of 8)
+
+struct VectorTypesSchemaInfo {
+    SchemaPtr schema;
+    FieldId int64_id;     // PK
+    FieldId bin_vec_id;   // VECTOR_BINARY
+    FieldId f16_vec_id;   // VECTOR_FLOAT16
+    FieldId bf16_vec_id;  // VECTOR_BFLOAT16
+    FieldId int8_vec_id;  // VECTOR_INT8
+};
+
+VectorTypesSchemaInfo
+BuildVectorTypesSchema() {
+    auto schema = std::make_shared<Schema>();
+    schema->AddField(
+        FieldName("RowID"), RowFieldID, DataType::INT64, false, std::nullopt);
+    schema->AddField(FieldName("Timestamp"),
+                     TimestampFieldID,
+                     DataType::INT64,
+                     false,
+                     std::nullopt);
+
+    VectorTypesSchemaInfo info;
+    info.int64_id = FieldId(200);
+    info.bin_vec_id = FieldId(205);
+    info.f16_vec_id = FieldId(206);
+    info.bf16_vec_id = FieldId(207);
+    info.int8_vec_id = FieldId(208);
+
+    // PK
+    schema->AddField(FieldMeta(FieldName("int64_col"),
+                               info.int64_id,
+                               DataType::INT64,
+                               false,
+                               std::nullopt,
+                               "int64_col"));
+    // VECTOR_BINARY (dim=16 => 2 bytes per vector)
+    schema->AddField(FieldMeta(FieldName("bin_vec_col"),
+                               info.bin_vec_id,
+                               DataType::VECTOR_BINARY,
+                               kBinVecDim,
+                               knowhere::metric::HAMMING,
+                               false,
+                               std::nullopt,
+                               "bin_vec_col"));
+    // VECTOR_FLOAT16 (dim=4 => 8 bytes per vector)
+    schema->AddField(FieldMeta(FieldName("f16_vec_col"),
+                               info.f16_vec_id,
+                               DataType::VECTOR_FLOAT16,
+                               kVecDim,
+                               knowhere::metric::L2,
+                               false,
+                               std::nullopt,
+                               "f16_vec_col"));
+    // VECTOR_BFLOAT16 (dim=4 => 8 bytes per vector)
+    schema->AddField(FieldMeta(FieldName("bf16_vec_col"),
+                               info.bf16_vec_id,
+                               DataType::VECTOR_BFLOAT16,
+                               kVecDim,
+                               knowhere::metric::L2,
+                               false,
+                               std::nullopt,
+                               "bf16_vec_col"));
+    // VECTOR_INT8 (dim=4 => 4 bytes per vector)
+    schema->AddField(FieldMeta(FieldName("int8_vec_col"),
+                               info.int8_vec_id,
+                               DataType::VECTOR_INT8,
+                               kVecDim,
+                               knowhere::metric::L2,
+                               false,
+                               std::nullopt,
+                               "int8_vec_col"));
+
+    schema->set_primary_field_id(info.int64_id);
+    schema->set_external_source("s3://test-bucket/data");
+    schema->set_external_spec(R"({"format":"parquet"})");
+    info.schema = schema;
+    return info;
+}
+
+// Build a test Arrow Table with kTestRows rows for the 4 vector types + PK.
+std::shared_ptr<arrow::Table>
+BuildVectorTypesTable() {
+    // INT64 (PK)
+    arrow::Int64Builder int64_b;
+    for (int i = 0; i < kTestRows; i++)
+        EXPECT_TRUE(int64_b.Append(i * 10000).ok());
+    auto int64_arr = int64_b.Finish().ValueOrDie();
+
+    // VECTOR_BINARY (dim=16, 2 bytes per vector)
+    int bin_byte_width = kBinVecDim / 8;
+    auto bin_vec_type = arrow::fixed_size_binary(bin_byte_width);
+    arrow::FixedSizeBinaryBuilder bin_vec_b(bin_vec_type);
+    for (int i = 0; i < kTestRows; i++) {
+        uint8_t bytes[2] = {static_cast<uint8_t>(i),
+                            static_cast<uint8_t>(i + 1)};
+        EXPECT_TRUE(bin_vec_b.Append(bytes).ok());
+    }
+    auto bin_vec_arr = bin_vec_b.Finish().ValueOrDie();
+
+    // VECTOR_FLOAT16 (dim=4, 8 bytes per vector)
+    auto f16_type = arrow::fixed_size_binary(kVecDim * 2);
+    arrow::FixedSizeBinaryBuilder f16_b(f16_type);
+    for (int i = 0; i < kTestRows; i++) {
+        uint16_t f16[kVecDim];
+        for (int d = 0; d < kVecDim; d++)
+            f16[d] = static_cast<uint16_t>(i * kVecDim + d);
+        EXPECT_TRUE(f16_b.Append(reinterpret_cast<const uint8_t*>(f16)).ok());
+    }
+    auto f16_arr = f16_b.Finish().ValueOrDie();
+
+    // VECTOR_BFLOAT16 (dim=4, 8 bytes per vector)
+    auto bf16_type = arrow::fixed_size_binary(kVecDim * 2);
+    arrow::FixedSizeBinaryBuilder bf16_b(bf16_type);
+    for (int i = 0; i < kTestRows; i++) {
+        uint16_t bf16[kVecDim];
+        for (int d = 0; d < kVecDim; d++)
+            bf16[d] = static_cast<uint16_t>(i * kVecDim + d + 100);
+        EXPECT_TRUE(bf16_b.Append(reinterpret_cast<const uint8_t*>(bf16)).ok());
+    }
+    auto bf16_arr = bf16_b.Finish().ValueOrDie();
+
+    // VECTOR_INT8 (dim=4, 4 bytes per vector)
+    auto int8_vec_type = arrow::fixed_size_binary(kVecDim);
+    arrow::FixedSizeBinaryBuilder int8_vec_b(int8_vec_type);
+    for (int i = 0; i < kTestRows; i++) {
+        int8_t vals[kVecDim];
+        for (int d = 0; d < kVecDim; d++)
+            vals[d] = static_cast<int8_t>(i * kVecDim + d);
+        EXPECT_TRUE(
+            int8_vec_b.Append(reinterpret_cast<const uint8_t*>(vals)).ok());
+    }
+    auto int8_vec_arr = int8_vec_b.Finish().ValueOrDie();
+
+    auto schema = arrow::schema({
+        arrow::field("int64_col", arrow::int64()),
+        arrow::field("bin_vec_col", bin_vec_type),
+        arrow::field("f16_vec_col", f16_type),
+        arrow::field("bf16_vec_col", bf16_type),
+        arrow::field("int8_vec_col", int8_vec_type),
+    });
+
+    return arrow::Table::Make(
+        schema, {int64_arr, bin_vec_arr, f16_arr, bf16_arr, int8_vec_arr});
+}
+
+}  // namespace
+
+// Test TryTakeForRetrieve with all supported data types
+TEST(ExternalTakeTest, TryTakeForRetrieve_MultiTypes) {
+    auto [schema,
+          bool_id,
+          int8_id,
+          int16_id,
+          int32_id,
+          int64_id,
+          float_id,
+          double_id,
+          varchar_id,
+          vec_id] = BuildExternalSchema();
+    auto table = BuildTestArrowTable();
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, schema);
+    segment->SetReaderForTesting(std::make_unique<MockTakeReader>(table));
+
+    // Build RetrievePlan with all external fields
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
+    plan->field_ids_ = {bool_id,
+                        int8_id,
+                        int16_id,
+                        int32_id,
+                        int64_id,
+                        float_id,
+                        double_id,
+                        varchar_id,
+                        vec_id};
+
+    auto results = std::make_unique<proto::segcore::RetrieveResults>();
+
+    // Use offsets [0, 2, 4] to test non-contiguous access + dedup
+    std::vector<int64_t> offsets = {0, 2, 4};
+    int64_t size = offsets.size();
+
+    bool ok = segment->TryTakeForRetrieve(
+        plan.get(), results, offsets.data(), size, false, false);
+    ASSERT_TRUE(ok);
+
+    // Verify all fields are present
+    ASSERT_EQ(results->fields_data_size(), 9);
+
+    // Verify BOOL field
+    auto& bool_data = results->fields_data(0);
+    ASSERT_EQ(bool_data.field_id(), bool_id.get());
+    ASSERT_EQ(bool_data.scalars().bool_data().data_size(), size);
+    EXPECT_EQ(bool_data.scalars().bool_data().data(0), true);  // row 0
+    EXPECT_EQ(bool_data.scalars().bool_data().data(1), true);  // row 2
+    EXPECT_EQ(bool_data.scalars().bool_data().data(2), true);  // row 4
+
+    // Verify INT8 field (promoted to int32 in protobuf)
+    auto& int8_data = results->fields_data(1);
+    ASSERT_EQ(int8_data.field_id(), int8_id.get());
+    ASSERT_EQ(int8_data.scalars().int_data().data_size(), size);
+    EXPECT_EQ(int8_data.scalars().int_data().data(0), 0);   // 0*10
+    EXPECT_EQ(int8_data.scalars().int_data().data(1), 20);  // 2*10
+    EXPECT_EQ(int8_data.scalars().int_data().data(2), 40);  // 4*10
+
+    // Verify INT16 field (promoted to int32)
+    auto& int16_data = results->fields_data(2);
+    ASSERT_EQ(int16_data.field_id(), int16_id.get());
+    ASSERT_EQ(int16_data.scalars().int_data().data_size(), size);
+    EXPECT_EQ(int16_data.scalars().int_data().data(0), 0);
+    EXPECT_EQ(int16_data.scalars().int_data().data(1), 200);
+    EXPECT_EQ(int16_data.scalars().int_data().data(2), 400);
+
+    // Verify INT32 field
+    auto& int32_data = results->fields_data(3);
+    ASSERT_EQ(int32_data.field_id(), int32_id.get());
+    ASSERT_EQ(int32_data.scalars().int_data().data_size(), size);
+    EXPECT_EQ(int32_data.scalars().int_data().data(0), 0);
+    EXPECT_EQ(int32_data.scalars().int_data().data(1), 2000);
+    EXPECT_EQ(int32_data.scalars().int_data().data(2), 4000);
+
+    // Verify INT64 field
+    auto& int64_data = results->fields_data(4);
+    ASSERT_EQ(int64_data.field_id(), int64_id.get());
+    ASSERT_EQ(int64_data.scalars().long_data().data_size(), size);
+    EXPECT_EQ(int64_data.scalars().long_data().data(0), 0);
+    EXPECT_EQ(int64_data.scalars().long_data().data(1), 20000);
+    EXPECT_EQ(int64_data.scalars().long_data().data(2), 40000);
+
+    // Verify FLOAT field
+    auto& float_data = results->fields_data(5);
+    ASSERT_EQ(float_data.field_id(), float_id.get());
+    ASSERT_EQ(float_data.scalars().float_data().data_size(), size);
+    EXPECT_FLOAT_EQ(float_data.scalars().float_data().data(0), 0.0f);
+    EXPECT_FLOAT_EQ(float_data.scalars().float_data().data(1), 2.2f);
+    EXPECT_FLOAT_EQ(float_data.scalars().float_data().data(2), 4.4f);
+
+    // Verify DOUBLE field
+    auto& double_data = results->fields_data(6);
+    ASSERT_EQ(double_data.field_id(), double_id.get());
+    ASSERT_EQ(double_data.scalars().double_data().data_size(), size);
+    EXPECT_DOUBLE_EQ(double_data.scalars().double_data().data(0), 0.0);
+    EXPECT_DOUBLE_EQ(double_data.scalars().double_data().data(1), 4.4);
+    EXPECT_DOUBLE_EQ(double_data.scalars().double_data().data(2), 8.8);
+
+    // Verify VARCHAR field
+    auto& str_data = results->fields_data(7);
+    ASSERT_EQ(str_data.field_id(), varchar_id.get());
+    ASSERT_EQ(str_data.scalars().string_data().data_size(), size);
+    EXPECT_EQ(str_data.scalars().string_data().data(0), "row_0");
+    EXPECT_EQ(str_data.scalars().string_data().data(1), "row_2");
+    EXPECT_EQ(str_data.scalars().string_data().data(2), "row_4");
+
+    // Verify VECTOR_FLOAT field
+    auto& vec_data = results->fields_data(8);
+    ASSERT_EQ(vec_data.field_id(), vec_id.get());
+    ASSERT_EQ(vec_data.vectors().dim(), kVecDim);
+    auto& fv = vec_data.vectors().float_vector();
+    ASSERT_EQ(fv.data_size(), size * kVecDim);
+    // Row 0: [0,1,2,3], Row 2: [8,9,10,11], Row 4: [16,17,18,19]
+    EXPECT_FLOAT_EQ(fv.data(0), 0.0f);
+    EXPECT_FLOAT_EQ(fv.data(4), 8.0f);
+    EXPECT_FLOAT_EQ(fv.data(8), 16.0f);
+}
+
+// Test TryTakeForSearch with all supported data types
+TEST(ExternalTakeTest, TryTakeForSearch_MultiTypes) {
+    auto [schema,
+          bool_id,
+          int8_id,
+          int16_id,
+          int32_id,
+          int64_id,
+          float_id,
+          double_id,
+          varchar_id,
+          vec_id] = BuildExternalSchema();
+    auto table = BuildTestArrowTable();
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, schema);
+    segment->SetReaderForTesting(std::make_unique<MockTakeReader>(table));
+
+    // Build Search Plan with target entries
+    auto plan = std::make_unique<query::Plan>(schema);
+    plan->target_entries_ = {bool_id,
+                             int8_id,
+                             int16_id,
+                             int32_id,
+                             int64_id,
+                             float_id,
+                             double_id,
+                             varchar_id,
+                             vec_id};
+
+    std::vector<int64_t> seg_offsets = {1, 3};
+    int64_t size = seg_offsets.size();
+
+    SearchResult results;
+    bool ok = segment->TestTryTakeForSearch(
+        plan.get(), seg_offsets.data(), size, results);
+    ASSERT_TRUE(ok);
+
+    // Verify all fields are populated
+    ASSERT_EQ(results.output_fields_data_.size(), 9u);
+
+    // Verify BOOL
+    auto& bool_arr = results.output_fields_data_.at(bool_id);
+    ASSERT_EQ(bool_arr->scalars().bool_data().data_size(), size);
+    EXPECT_EQ(bool_arr->scalars().bool_data().data(0), false);  // row 1
+    EXPECT_EQ(bool_arr->scalars().bool_data().data(1), false);  // row 3
+
+    // Verify INT8
+    auto& int8_arr = results.output_fields_data_.at(int8_id);
+    ASSERT_EQ(int8_arr->scalars().int_data().data_size(), size);
+    EXPECT_EQ(int8_arr->scalars().int_data().data(0), 10);
+    EXPECT_EQ(int8_arr->scalars().int_data().data(1), 30);
+
+    // Verify INT16
+    auto& int16_arr = results.output_fields_data_.at(int16_id);
+    ASSERT_EQ(int16_arr->scalars().int_data().data_size(), size);
+    EXPECT_EQ(int16_arr->scalars().int_data().data(0), 100);
+    EXPECT_EQ(int16_arr->scalars().int_data().data(1), 300);
+
+    // Verify INT32
+    auto& int32_arr = results.output_fields_data_.at(int32_id);
+    ASSERT_EQ(int32_arr->scalars().int_data().data_size(), size);
+    EXPECT_EQ(int32_arr->scalars().int_data().data(0), 1000);
+    EXPECT_EQ(int32_arr->scalars().int_data().data(1), 3000);
+
+    // Verify INT64
+    auto& int64_arr = results.output_fields_data_.at(int64_id);
+    ASSERT_EQ(int64_arr->scalars().long_data().data_size(), size);
+    EXPECT_EQ(int64_arr->scalars().long_data().data(0), 10000);
+    EXPECT_EQ(int64_arr->scalars().long_data().data(1), 30000);
+
+    // Verify VARCHAR
+    auto& str_arr = results.output_fields_data_.at(varchar_id);
+    ASSERT_EQ(str_arr->scalars().string_data().data_size(), size);
+    EXPECT_EQ(str_arr->scalars().string_data().data(0), "row_1");
+    EXPECT_EQ(str_arr->scalars().string_data().data(1), "row_3");
+
+    // Verify VECTOR_FLOAT
+    auto& vec_arr = results.output_fields_data_.at(vec_id);
+    ASSERT_EQ(vec_arr->vectors().dim(), kVecDim);
+    ASSERT_EQ(vec_arr->vectors().float_vector().data_size(), size * kVecDim);
+    // Row 1: [4,5,6,7], Row 3: [12,13,14,15]
+    EXPECT_FLOAT_EQ(vec_arr->vectors().float_vector().data(0), 4.0f);
+    EXPECT_FLOAT_EQ(vec_arr->vectors().float_vector().data(4), 12.0f);
+}
+
+// Test fallback: returns false for non-external collection
+TEST(ExternalTakeTest, TryTakeForRetrieve_FallbackNonExternal) {
+    auto schema = std::make_shared<Schema>();
+    auto pk_id = schema->AddDebugField("pk", DataType::INT64);
+    schema->set_primary_field_id(pk_id);
+    // No external_source set => not external
+
+    auto holder = CreateSealedSegment(schema);
+    auto* segment = dynamic_cast<ChunkedSegmentSealedImpl*>(holder.get());
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
+    plan->field_ids_ = {pk_id};
+
+    auto results = std::make_unique<proto::segcore::RetrieveResults>();
+    int64_t offset = 0;
+    bool ok = segment->TryTakeForRetrieve(
+        plan.get(), results, &offset, 1, false, false);
+    EXPECT_FALSE(ok);
+}
+
+// Test fallback: returns false when size exceeds threshold
+TEST(ExternalTakeTest, TryTakeForRetrieve_FallbackOverThreshold) {
+    auto [schema,
+          bool_id,
+          int8_id,
+          int16_id,
+          int32_id,
+          int64_id,
+          float_id,
+          double_id,
+          varchar_id,
+          vec_id] = BuildExternalSchema();
+    auto holder = CreateSealedSegment(schema);
+    auto* segment = dynamic_cast<ChunkedSegmentSealedImpl*>(holder.get());
+
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
+    plan->field_ids_ = {int64_id};
+
+    auto results = std::make_unique<proto::segcore::RetrieveResults>();
+    // Size > 10000 threshold
+    std::vector<int64_t> offsets(10001, 0);
+    bool ok = segment->TryTakeForRetrieve(
+        plan.get(), results, offsets.data(), 10001, false, false);
+    EXPECT_FALSE(ok);
+}
+
+// Test fallback: returns false when reader is null
+TEST(ExternalTakeTest, TryTakeForRetrieve_FallbackNullReader) {
+    auto [schema,
+          bool_id,
+          int8_id,
+          int16_id,
+          int32_id,
+          int64_id,
+          float_id,
+          double_id,
+          varchar_id,
+          vec_id] = BuildExternalSchema();
+    auto holder = CreateSealedSegment(schema);
+    auto* segment = dynamic_cast<ChunkedSegmentSealedImpl*>(holder.get());
+    // reader_ is null by default
+
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
+    plan->field_ids_ = {int64_id};
+
+    auto results = std::make_unique<proto::segcore::RetrieveResults>();
+    int64_t offset = 0;
+    bool ok = segment->TryTakeForRetrieve(
+        plan.get(), results, &offset, 1, false, false);
+    EXPECT_FALSE(ok);
+}
+
+// Test FillTargetEntry override delegates to TryTakeForSearch
+TEST(ExternalTakeTest, FillTargetEntry_DelegatesToTake) {
+    auto [schema,
+          bool_id,
+          int8_id,
+          int16_id,
+          int32_id,
+          int64_id,
+          float_id,
+          double_id,
+          varchar_id,
+          vec_id] = BuildExternalSchema();
+    auto table = BuildTestArrowTable();
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, schema);
+    segment->SetReaderForTesting(std::make_unique<MockTakeReader>(table));
+
+    auto plan = std::make_unique<query::Plan>(schema);
+    plan->target_entries_ = {int64_id, varchar_id};
+
+    SearchResult results;
+    results.distances_ = {0.1f, 0.2f};
+    results.seg_offsets_ = {0, 3};
+
+    segment->TestFillTargetEntry(plan.get(), results);
+
+    // Should have filled via TryTakeForSearch
+    ASSERT_EQ(results.output_fields_data_.size(), 2u);
+
+    auto& int64_arr = results.output_fields_data_.at(int64_id);
+    ASSERT_EQ(int64_arr->scalars().long_data().data_size(), 2);
+    EXPECT_EQ(int64_arr->scalars().long_data().data(0), 0);
+    EXPECT_EQ(int64_arr->scalars().long_data().data(1), 30000);
+
+    auto& str_arr = results.output_fields_data_.at(varchar_id);
+    ASSERT_EQ(str_arr->scalars().string_data().data_size(), 2);
+    EXPECT_EQ(str_arr->scalars().string_data().data(0), "row_0");
+    EXPECT_EQ(str_arr->scalars().string_data().data(1), "row_3");
+}
+
+// ---------- TryTakeForRetrieve: error & edge-case paths ----------
+
+// take() returns error → fallback
+TEST(ExternalTakeTest, TryTakeForRetrieve_TakeFailure) {
+    auto [schema,
+          bool_id,
+          int8_id,
+          int16_id,
+          int32_id,
+          int64_id,
+          float_id,
+          double_id,
+          varchar_id,
+          vec_id] = BuildExternalSchema();
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, schema);
+    segment->SetReaderForTesting(std::make_unique<ErrorMockTakeReader>());
+
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
+    plan->field_ids_ = {int64_id};
+
+    auto results = std::make_unique<proto::segcore::RetrieveResults>();
+    int64_t offset = 0;
+    bool ok = segment->TryTakeForRetrieve(
+        plan.get(), results, &offset, 1, false, false);
+    EXPECT_FALSE(ok);
+}
+
+// Returned table missing expected column → fallback
+TEST(ExternalTakeTest, TryTakeForRetrieve_ColumnNotFound) {
+    auto [schema,
+          bool_id,
+          int8_id,
+          int16_id,
+          int32_id,
+          int64_id,
+          float_id,
+          double_id,
+          varchar_id,
+          vec_id] = BuildExternalSchema();
+
+    // Table with only int64_col; varchar_col is missing
+    arrow::Int64Builder b;
+    for (int i = 0; i < kTestRows; i++) EXPECT_TRUE(b.Append(i * 10000).ok());
+    auto arr = b.Finish().ValueOrDie();
+    auto partial_table = arrow::Table::Make(
+        arrow::schema({arrow::field("int64_col", arrow::int64())}), {arr});
+
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, schema);
+    segment->SetReaderForTesting(
+        std::make_unique<MockTakeReader>(partial_table));
+
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
+    plan->field_ids_ = {int64_id, varchar_id};  // varchar_col not in table
+
+    auto results = std::make_unique<proto::segcore::RetrieveResults>();
+    int64_t offset = 0;
+    bool ok = segment->TryTakeForRetrieve(
+        plan.get(), results, &offset, 1, false, false);
+    EXPECT_FALSE(ok);
+}
+
+// size == 0 → early return false
+TEST(ExternalTakeTest, TryTakeForRetrieve_EmptySize) {
+    auto [schema,
+          bool_id,
+          int8_id,
+          int16_id,
+          int32_id,
+          int64_id,
+          float_id,
+          double_id,
+          varchar_id,
+          vec_id] = BuildExternalSchema();
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, schema);
+
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
+    plan->field_ids_ = {int64_id};
+
+    auto results = std::make_unique<proto::segcore::RetrieveResults>();
+    bool ok = segment->TryTakeForRetrieve(
+        plan.get(), results, nullptr, 0, false, false);
+    EXPECT_FALSE(ok);
+}
+
+// Virtual PK generation + fill_ids
+TEST(ExternalTakeTest, TryTakeForRetrieve_VirtualPK_FillIds) {
+    auto [schema, pk_id, int32_id, varchar_id, vec_id] =
+        BuildExternalSchemaWithVirtualPK();
+    auto table = BuildVirtualPKTestTable();
+    constexpr int64_t kSegId = 42;
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, schema, kSegId);
+    segment->SetReaderForTesting(std::make_unique<MockTakeReader>(table));
+
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
+    plan->field_ids_ = {pk_id, int32_id, varchar_id};
+
+    auto results = std::make_unique<proto::segcore::RetrieveResults>();
+    std::vector<int64_t> offsets = {0, 3};
+    int64_t size = offsets.size();
+
+    bool ok = segment->TryTakeForRetrieve(
+        plan.get(), results, offsets.data(), size, false, true);
+    ASSERT_TRUE(ok);
+
+    // Virtual PK should be in fields_data (ignore_non_pk=false)
+    bool found_pk = false;
+    for (int i = 0; i < results->fields_data_size(); i++) {
+        if (results->fields_data(i).field_id() == pk_id.get()) {
+            found_pk = true;
+            auto& pk_data = results->fields_data(i);
+            ASSERT_EQ(pk_data.scalars().long_data().data_size(), size);
+            EXPECT_EQ(pk_data.scalars().long_data().data(0),
+                      GetVirtualPK(kSegId, 0));
+            EXPECT_EQ(pk_data.scalars().long_data().data(1),
+                      GetVirtualPK(kSegId, 3));
+        }
+    }
+    EXPECT_TRUE(found_pk);
+
+    // fill_ids=true: ids should be populated
+    ASSERT_EQ(results->ids().int_id().data_size(), size);
+    EXPECT_EQ(results->ids().int_id().data(0), GetVirtualPK(kSegId, 0));
+    EXPECT_EQ(results->ids().int_id().data(1), GetVirtualPK(kSegId, 3));
+
+    // External fields should also be present
+    bool found_int32 = false;
+    for (int i = 0; i < results->fields_data_size(); i++) {
+        if (results->fields_data(i).field_id() == int32_id.get()) {
+            found_int32 = true;
+            EXPECT_EQ(results->fields_data(i).scalars().int_data().data(0), 0);
+            EXPECT_EQ(results->fields_data(i).scalars().int_data().data(1),
+                      3000);
+        }
+    }
+    EXPECT_TRUE(found_int32);
+}
+
+// ignore_non_pk=true with external PK: PK taken but not added to fields_data
+// (by design: !ignore_non_pk guard prevents AddAllocated for external PK).
+// With virtual PK + ignore_non_pk, the PK is generated and fill_ids populates ids.
+TEST(ExternalTakeTest, TryTakeForRetrieve_IgnoreNonPK_VirtualPK) {
+    auto [schema, pk_id, int32_id, varchar_id, vec_id] =
+        BuildExternalSchemaWithVirtualPK();
+    auto table = BuildVirtualPKTestTable();
+    constexpr int64_t kSegId = 7;
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, schema, kSegId);
+    segment->SetReaderForTesting(std::make_unique<MockTakeReader>(table));
+
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
+    plan->field_ids_ = {pk_id, int32_id, varchar_id};
+
+    auto results = std::make_unique<proto::segcore::RetrieveResults>();
+    std::vector<int64_t> offsets = {1, 4};
+    int64_t size = offsets.size();
+
+    // ignore_non_pk=true, fill_ids=true
+    bool ok = segment->TryTakeForRetrieve(
+        plan.get(), results, offsets.data(), size, true, true);
+    // Virtual PK (non-external) + ignore_non_pk → take_field_ids empty → false
+    // Because all external fields are skipped (ignore_non_pk && !is_pk_field)
+    // and PK itself is non-external → also skipped in take collection
+    EXPECT_FALSE(ok);
+}
+
+// Duplicate offsets: dedup + result_mapping
+TEST(ExternalTakeTest, TryTakeForRetrieve_DuplicateOffsets) {
+    auto [schema,
+          bool_id,
+          int8_id,
+          int16_id,
+          int32_id,
+          int64_id,
+          float_id,
+          double_id,
+          varchar_id,
+          vec_id] = BuildExternalSchema();
+    auto table = BuildTestArrowTable();
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, schema);
+    segment->SetReaderForTesting(std::make_unique<MockTakeReader>(table));
+
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
+    plan->field_ids_ = {int64_id};
+
+    auto results = std::make_unique<proto::segcore::RetrieveResults>();
+    // Offsets with duplicates: [2, 0, 2]
+    std::vector<int64_t> offsets = {2, 0, 2};
+    int64_t size = offsets.size();
+
+    bool ok = segment->TryTakeForRetrieve(
+        plan.get(), results, offsets.data(), size, false, false);
+    ASSERT_TRUE(ok);
+
+    ASSERT_EQ(results->fields_data_size(), 1);
+    auto& data = results->fields_data(0);
+    ASSERT_EQ(data.scalars().long_data().data_size(), 3);
+    // Expected: values at offsets 2, 0, 2 → 20000, 0, 20000
+    EXPECT_EQ(data.scalars().long_data().data(0), 20000);
+    EXPECT_EQ(data.scalars().long_data().data(1), 0);
+    EXPECT_EQ(data.scalars().long_data().data(2), 20000);
+}
+
+// Test TryTakeForRetrieve with the 4 additional vector types
+TEST(ExternalTakeTest, TryTakeForRetrieve_VectorTypes) {
+    auto [schema, int64_id, bin_vec_id, f16_vec_id, bf16_vec_id, int8_vec_id] =
+        BuildVectorTypesSchema();
+    auto table = BuildVectorTypesTable();
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, schema);
+    segment->SetReaderForTesting(std::make_unique<MockTakeReader>(table));
+
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
+    plan->field_ids_ = {
+        int64_id, bin_vec_id, f16_vec_id, bf16_vec_id, int8_vec_id};
+
+    auto results = std::make_unique<proto::segcore::RetrieveResults>();
+    std::vector<int64_t> offsets = {0, 2, 4};
+    int64_t size = offsets.size();
+
+    bool ok = segment->TryTakeForRetrieve(
+        plan.get(), results, offsets.data(), size, false, false);
+    ASSERT_TRUE(ok);
+    ASSERT_EQ(results->fields_data_size(), 5);
+
+    // Helper: find field data by field_id
+    auto find_field = [&](int64_t fid) -> const proto::schema::FieldData* {
+        for (int i = 0; i < results->fields_data_size(); i++) {
+            if (results->fields_data(i).field_id() == fid)
+                return &results->fields_data(i);
+        }
+        return nullptr;
+    };
+
+    // Verify INT64 (PK)
+    auto* pk = find_field(int64_id.get());
+    ASSERT_NE(pk, nullptr);
+    ASSERT_EQ(pk->scalars().long_data().data_size(), size);
+    EXPECT_EQ(pk->scalars().long_data().data(0), 0);      // row 0
+    EXPECT_EQ(pk->scalars().long_data().data(1), 20000);  // row 2
+    EXPECT_EQ(pk->scalars().long_data().data(2), 40000);  // row 4
+
+    // Verify VECTOR_BINARY
+    auto* bin_vec = find_field(bin_vec_id.get());
+    ASSERT_NE(bin_vec, nullptr);
+    EXPECT_EQ(bin_vec->vectors().dim(), kBinVecDim);
+    auto& bv = bin_vec->vectors().binary_vector();
+    int bin_bytes = kBinVecDim / 8;  // 2 bytes per vector
+    ASSERT_EQ(static_cast<int>(bv.size()), size * bin_bytes);
+    // Row 0: bytes [0, 1]
+    EXPECT_EQ(static_cast<uint8_t>(bv[0]), 0);
+    EXPECT_EQ(static_cast<uint8_t>(bv[1]), 1);
+    // Row 2: bytes [2, 3]
+    EXPECT_EQ(static_cast<uint8_t>(bv[2]), 2);
+    EXPECT_EQ(static_cast<uint8_t>(bv[3]), 3);
+
+    // Verify VECTOR_FLOAT16
+    auto* f16 = find_field(f16_vec_id.get());
+    ASSERT_NE(f16, nullptr);
+    EXPECT_EQ(f16->vectors().dim(), kVecDim);
+    auto& f16v = f16->vectors().float16_vector();
+    ASSERT_EQ(static_cast<int>(f16v.size()), size * kVecDim * 2);
+    // Row 0: uint16 values [0, 1, 2, 3]
+    auto f16_data = reinterpret_cast<const uint16_t*>(f16v.data());
+    EXPECT_EQ(f16_data[0], 0);
+    EXPECT_EQ(f16_data[1], 1);
+
+    // Verify VECTOR_BFLOAT16
+    auto* bf16 = find_field(bf16_vec_id.get());
+    ASSERT_NE(bf16, nullptr);
+    EXPECT_EQ(bf16->vectors().dim(), kVecDim);
+    auto& bf16v = bf16->vectors().bfloat16_vector();
+    ASSERT_EQ(static_cast<int>(bf16v.size()), size * kVecDim * 2);
+    // Row 0: uint16 values [100, 101, 102, 103]
+    auto bf16_data = reinterpret_cast<const uint16_t*>(bf16v.data());
+    EXPECT_EQ(bf16_data[0], 100);
+    EXPECT_EQ(bf16_data[1], 101);
+
+    // Verify VECTOR_INT8
+    auto* i8v = find_field(int8_vec_id.get());
+    ASSERT_NE(i8v, nullptr);
+    EXPECT_EQ(i8v->vectors().dim(), kVecDim);
+    auto& i8data = i8v->vectors().int8_vector();
+    ASSERT_EQ(static_cast<int>(i8data.size()), size * kVecDim);
+    // Row 0: [0, 1, 2, 3]
+    EXPECT_EQ(static_cast<int8_t>(i8data[0]), 0);
+    EXPECT_EQ(static_cast<int8_t>(i8data[1]), 1);
+    // Row 2: [8, 9, 10, 11]
+    EXPECT_EQ(static_cast<int8_t>(i8data[kVecDim]), 8);
+}
+
+// ---------- TryTakeForSearch: error & edge-case paths ----------
+
+// Null reader → returns false
+TEST(ExternalTakeTest, TryTakeForSearch_NullReader) {
+    auto [schema,
+          bool_id,
+          int8_id,
+          int16_id,
+          int32_id,
+          int64_id,
+          float_id,
+          double_id,
+          varchar_id,
+          vec_id] = BuildExternalSchema();
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, schema);
+    // reader_ is null by default
+
+    auto plan = std::make_unique<query::Plan>(schema);
+    plan->target_entries_ = {int64_id};
+
+    SearchResult results;
+    int64_t offset = 0;
+    bool ok = segment->TestTryTakeForSearch(plan.get(), &offset, 1, results);
+    EXPECT_FALSE(ok);
+}
+
+// take() failure → returns false
+TEST(ExternalTakeTest, TryTakeForSearch_TakeFailure) {
+    auto [schema,
+          bool_id,
+          int8_id,
+          int16_id,
+          int32_id,
+          int64_id,
+          float_id,
+          double_id,
+          varchar_id,
+          vec_id] = BuildExternalSchema();
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, schema);
+    segment->SetReaderForTesting(std::make_unique<ErrorMockTakeReader>());
+
+    auto plan = std::make_unique<query::Plan>(schema);
+    plan->target_entries_ = {int64_id};
+
+    SearchResult results;
+    int64_t offset = 0;
+    bool ok = segment->TestTryTakeForSearch(plan.get(), &offset, 1, results);
+    EXPECT_FALSE(ok);
+}
+
+// Column not found in search take result → returns false
+TEST(ExternalTakeTest, TryTakeForSearch_ColumnNotFound) {
+    auto [schema,
+          bool_id,
+          int8_id,
+          int16_id,
+          int32_id,
+          int64_id,
+          float_id,
+          double_id,
+          varchar_id,
+          vec_id] = BuildExternalSchema();
+
+    // Table with only int64_col
+    arrow::Int64Builder b;
+    for (int i = 0; i < kTestRows; i++) EXPECT_TRUE(b.Append(i).ok());
+    auto arr = b.Finish().ValueOrDie();
+    auto partial_table = arrow::Table::Make(
+        arrow::schema({arrow::field("int64_col", arrow::int64())}), {arr});
+
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, schema);
+    segment->SetReaderForTesting(
+        std::make_unique<MockTakeReader>(partial_table));
+
+    auto plan = std::make_unique<query::Plan>(schema);
+    plan->target_entries_ = {int64_id, varchar_id};  // varchar_col missing
+
+    SearchResult results;
+    int64_t offset = 0;
+    bool ok = segment->TestTryTakeForSearch(plan.get(), &offset, 1, results);
+    EXPECT_FALSE(ok);
+}
+
+// No external fields in target_entries → returns false
+TEST(ExternalTakeTest, TryTakeForSearch_EmptyTargetEntries) {
+    auto schema = std::make_shared<Schema>();
+    auto pk_id = schema->AddDebugField("pk", DataType::INT64);
+    schema->set_primary_field_id(pk_id);
+    schema->set_external_source("s3://test-bucket/data");
+    schema->set_external_spec(R"({"format":"parquet"})");
+    // pk has no external_field_mapping → is_external_field() false
+
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, schema);
+
+    auto plan = std::make_unique<query::Plan>(schema);
+    plan->target_entries_ = {pk_id};  // not external
+
+    SearchResult results;
+    int64_t offset = 0;
+    bool ok = segment->TestTryTakeForSearch(plan.get(), &offset, 1, results);
+    EXPECT_FALSE(ok);
+}
+
+// Non-external collection → returns false
+TEST(ExternalTakeTest, TryTakeForSearch_FallbackNonExternal) {
+    auto schema = std::make_shared<Schema>();
+    auto pk_id = schema->AddDebugField("pk", DataType::INT64);
+    schema->set_primary_field_id(pk_id);
+
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, schema);
+
+    auto plan = std::make_unique<query::Plan>(schema);
+    plan->target_entries_ = {pk_id};
+
+    SearchResult results;
+    int64_t offset = 0;
+    bool ok = segment->TestTryTakeForSearch(plan.get(), &offset, 1, results);
+    EXPECT_FALSE(ok);
+}
+
+// size > threshold → returns false
+TEST(ExternalTakeTest, TryTakeForSearch_FallbackOverThreshold) {
+    auto [schema,
+          bool_id,
+          int8_id,
+          int16_id,
+          int32_id,
+          int64_id,
+          float_id,
+          double_id,
+          varchar_id,
+          vec_id] = BuildExternalSchema();
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, schema);
+
+    auto plan = std::make_unique<query::Plan>(schema);
+    plan->target_entries_ = {int64_id};
+
+    SearchResult results;
+    std::vector<int64_t> offsets(10001, 0);
+    bool ok = segment->TestTryTakeForSearch(
+        plan.get(), offsets.data(), 10001, results);
+    EXPECT_FALSE(ok);
+}
+
+// Test TryTakeForSearch with the 4 additional vector types
+TEST(ExternalTakeTest, TryTakeForSearch_VectorTypes) {
+    auto [schema, int64_id, bin_vec_id, f16_vec_id, bf16_vec_id, int8_vec_id] =
+        BuildVectorTypesSchema();
+    auto table = BuildVectorTypesTable();
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, schema);
+    segment->SetReaderForTesting(std::make_unique<MockTakeReader>(table));
+
+    auto plan = std::make_unique<query::Plan>(schema);
+    plan->target_entries_ = {
+        int64_id, bin_vec_id, f16_vec_id, bf16_vec_id, int8_vec_id};
+
+    std::vector<int64_t> seg_offsets = {1, 3};
+    int64_t size = seg_offsets.size();
+
+    SearchResult results;
+    bool ok = segment->TestTryTakeForSearch(
+        plan.get(), seg_offsets.data(), size, results);
+    ASSERT_TRUE(ok);
+    ASSERT_EQ(results.output_fields_data_.size(), 5u);
+
+    // Verify VECTOR_BINARY
+    auto& bv_arr = results.output_fields_data_.at(bin_vec_id);
+    EXPECT_EQ(bv_arr->vectors().dim(), kBinVecDim);
+    auto& bvd = bv_arr->vectors().binary_vector();
+    int bin_bytes = kBinVecDim / 8;
+    ASSERT_EQ(static_cast<int>(bvd.size()), size * bin_bytes);
+    // Row 1: bytes [1, 2]
+    EXPECT_EQ(static_cast<uint8_t>(bvd[0]), 1);
+    EXPECT_EQ(static_cast<uint8_t>(bvd[1]), 2);
+
+    // Verify VECTOR_FLOAT16
+    auto& f16_arr = results.output_fields_data_.at(f16_vec_id);
+    EXPECT_EQ(f16_arr->vectors().dim(), kVecDim);
+    ASSERT_EQ(static_cast<int>(f16_arr->vectors().float16_vector().size()),
+              size * kVecDim * 2);
+
+    // Verify VECTOR_BFLOAT16
+    auto& bf16_arr = results.output_fields_data_.at(bf16_vec_id);
+    EXPECT_EQ(bf16_arr->vectors().dim(), kVecDim);
+    ASSERT_EQ(static_cast<int>(bf16_arr->vectors().bfloat16_vector().size()),
+              size * kVecDim * 2);
+
+    // Verify VECTOR_INT8
+    auto& i8_arr = results.output_fields_data_.at(int8_vec_id);
+    EXPECT_EQ(i8_arr->vectors().dim(), kVecDim);
+    ASSERT_EQ(static_cast<int>(i8_arr->vectors().int8_vector().size()),
+              size * kVecDim);
+}
+
+// ---------------------------------------------------------------------------
+// Tests for JSON, GEOMETRY (dual Arrow-type branches), and TEXT
+// ---------------------------------------------------------------------------
+
+// Schema with JSON (binary), GEOMETRY (binary), TEXT fields.
+struct ScalarExtSchemaInfo {
+    SchemaPtr schema;
+    FieldId int64_id;
+    FieldId json_id;
+    FieldId geo_id;
+    FieldId text_id;
+};
+
+ScalarExtSchemaInfo
+BuildScalarExtSchema() {
+    auto schema = std::make_shared<Schema>();
+    schema->AddField(
+        FieldName("RowID"), RowFieldID, DataType::INT64, false, std::nullopt);
+    schema->AddField(FieldName("Timestamp"),
+                     TimestampFieldID,
+                     DataType::INT64,
+                     false,
+                     std::nullopt);
+
+    ScalarExtSchemaInfo info;
+    info.int64_id = FieldId(300);
+    info.json_id = FieldId(301);
+    info.geo_id = FieldId(302);
+    info.text_id = FieldId(303);
+
+    schema->AddField(FieldMeta(FieldName("int64_col"),
+                               info.int64_id,
+                               DataType::INT64,
+                               false,
+                               std::nullopt,
+                               "int64_col"));
+    schema->AddField(FieldMeta(FieldName("json_col"),
+                               info.json_id,
+                               DataType::JSON,
+                               false,
+                               std::nullopt,
+                               "json_col"));
+    schema->AddField(FieldMeta(FieldName("geo_col"),
+                               info.geo_id,
+                               DataType::GEOMETRY,
+                               false,
+                               std::nullopt,
+                               "geo_col"));
+    schema->AddField(FieldMeta(FieldName("text_col"),
+                               info.text_id,
+                               DataType::TEXT,
+                               65535,
+                               false,
+                               std::nullopt,
+                               "text_col"));
+
+    schema->set_primary_field_id(info.int64_id);
+    schema->set_external_source("s3://test-bucket/data");
+    schema->set_external_spec(R"({"format":"parquet"})");
+    info.schema = schema;
+    return info;
+}
+
+// Table using BinaryArray for JSON/GEOMETRY (internal binlog format).
+std::shared_ptr<arrow::Table>
+BuildScalarExtTable_Binary() {
+    arrow::Int64Builder int64_b;
+    for (int i = 0; i < kTestRows; i++)
+        EXPECT_TRUE(int64_b.Append(i * 10000).ok());
+    auto int64_arr = int64_b.Finish().ValueOrDie();
+
+    // JSON as binary (raw JSON bytes)
+    arrow::BinaryBuilder json_b;
+    for (int i = 0; i < kTestRows; i++) {
+        std::string json = R"({"k":)" + std::to_string(i) + "}";
+        EXPECT_TRUE(json_b.Append(json).ok());
+    }
+    auto json_arr = json_b.Finish().ValueOrDie();
+
+    // GEOMETRY as binary (WKB-like bytes)
+    arrow::BinaryBuilder geo_b;
+    for (int i = 0; i < kTestRows; i++) {
+        std::string wkt = "POINT(" + std::to_string(i) + " 0)";
+        EXPECT_TRUE(geo_b.Append(wkt).ok());
+    }
+    auto geo_arr = geo_b.Finish().ValueOrDie();
+
+    // TEXT as utf8
+    arrow::StringBuilder text_b;
+    for (int i = 0; i < kTestRows; i++)
+        EXPECT_TRUE(text_b.Append("text_" + std::to_string(i)).ok());
+    auto text_arr = text_b.Finish().ValueOrDie();
+
+    auto schema = arrow::schema({
+        arrow::field("int64_col", arrow::int64()),
+        arrow::field("json_col", arrow::binary()),
+        arrow::field("geo_col", arrow::binary()),
+        arrow::field("text_col", arrow::utf8()),
+    });
+    return arrow::Table::Make(schema, {int64_arr, json_arr, geo_arr, text_arr});
+}
+
+// Table using StringArray for JSON/GEOMETRY (external Parquet format).
+std::shared_ptr<arrow::Table>
+BuildScalarExtTable_String() {
+    arrow::Int64Builder int64_b;
+    for (int i = 0; i < kTestRows; i++)
+        EXPECT_TRUE(int64_b.Append(i * 10000).ok());
+    auto int64_arr = int64_b.Finish().ValueOrDie();
+
+    // JSON as utf8 string
+    arrow::StringBuilder json_b;
+    for (int i = 0; i < kTestRows; i++) {
+        std::string json = R"({"k":)" + std::to_string(i) + "}";
+        EXPECT_TRUE(json_b.Append(json).ok());
+    }
+    auto json_arr = json_b.Finish().ValueOrDie();
+
+    // GEOMETRY as utf8 string (WKT)
+    arrow::StringBuilder geo_b;
+    for (int i = 0; i < kTestRows; i++) {
+        std::string wkt = "POINT(" + std::to_string(i) + " 0)";
+        EXPECT_TRUE(geo_b.Append(wkt).ok());
+    }
+    auto geo_arr = geo_b.Finish().ValueOrDie();
+
+    // TEXT as utf8
+    arrow::StringBuilder text_b;
+    for (int i = 0; i < kTestRows; i++)
+        EXPECT_TRUE(text_b.Append("text_" + std::to_string(i)).ok());
+    auto text_arr = text_b.Finish().ValueOrDie();
+
+    auto schema = arrow::schema({
+        arrow::field("int64_col", arrow::int64()),
+        arrow::field("json_col", arrow::utf8()),
+        arrow::field("geo_col", arrow::utf8()),
+        arrow::field("text_col", arrow::utf8()),
+    });
+    return arrow::Table::Make(schema, {int64_arr, json_arr, geo_arr, text_arr});
+}
+
+// JSON(BinaryArray) + GEOMETRY(BinaryArray) + TEXT — internal binlog format
+TEST(ExternalTakeTest, TryTakeForRetrieve_ScalarExt_BinaryPath) {
+    auto [schema, int64_id, json_id, geo_id, text_id] = BuildScalarExtSchema();
+    auto table = BuildScalarExtTable_Binary();
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, schema);
+    segment->SetReaderForTesting(std::make_unique<MockTakeReader>(table));
+
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
+    plan->field_ids_ = {int64_id, json_id, geo_id, text_id};
+
+    auto results = std::make_unique<proto::segcore::RetrieveResults>();
+    std::vector<int64_t> offsets = {0, 2, 4};
+    int64_t size = offsets.size();
+
+    bool ok = segment->TryTakeForRetrieve(
+        plan.get(), results, offsets.data(), size, false, false);
+    ASSERT_TRUE(ok);
+    ASSERT_EQ(results->fields_data_size(), 4);
+
+    auto find_field = [&](int64_t fid) -> const proto::schema::FieldData* {
+        for (int i = 0; i < results->fields_data_size(); i++) {
+            if (results->fields_data(i).field_id() == fid)
+                return &results->fields_data(i);
+        }
+        return nullptr;
+    };
+
+    // JSON
+    auto* json = find_field(json_id.get());
+    ASSERT_NE(json, nullptr);
+    ASSERT_EQ(json->scalars().json_data().data_size(), size);
+    EXPECT_EQ(json->scalars().json_data().data(0), R"({"k":0})");
+    EXPECT_EQ(json->scalars().json_data().data(1), R"({"k":2})");
+    EXPECT_EQ(json->scalars().json_data().data(2), R"({"k":4})");
+
+    // GEOMETRY
+    auto* geo = find_field(geo_id.get());
+    ASSERT_NE(geo, nullptr);
+    ASSERT_EQ(geo->scalars().geometry_data().data_size(), size);
+    EXPECT_EQ(geo->scalars().geometry_data().data(0), "POINT(0 0)");
+    EXPECT_EQ(geo->scalars().geometry_data().data(1), "POINT(2 0)");
+    EXPECT_EQ(geo->scalars().geometry_data().data(2), "POINT(4 0)");
+
+    // TEXT
+    auto* txt = find_field(text_id.get());
+    ASSERT_NE(txt, nullptr);
+    ASSERT_EQ(txt->scalars().string_data().data_size(), size);
+    EXPECT_EQ(txt->scalars().string_data().data(0), "text_0");
+    EXPECT_EQ(txt->scalars().string_data().data(1), "text_2");
+    EXPECT_EQ(txt->scalars().string_data().data(2), "text_4");
+}
+
+// JSON(StringArray) + GEOMETRY(StringArray) — external Parquet format
+TEST(ExternalTakeTest, TryTakeForRetrieve_ScalarExt_StringPath) {
+    auto [schema, int64_id, json_id, geo_id, text_id] = BuildScalarExtSchema();
+    auto table = BuildScalarExtTable_String();
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, schema);
+    segment->SetReaderForTesting(std::make_unique<MockTakeReader>(table));
+
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
+    plan->field_ids_ = {int64_id, json_id, geo_id, text_id};
+
+    auto results = std::make_unique<proto::segcore::RetrieveResults>();
+    std::vector<int64_t> offsets = {1, 3};
+    int64_t size = offsets.size();
+
+    bool ok = segment->TryTakeForRetrieve(
+        plan.get(), results, offsets.data(), size, false, false);
+    ASSERT_TRUE(ok);
+    ASSERT_EQ(results->fields_data_size(), 4);
+
+    auto find_field = [&](int64_t fid) -> const proto::schema::FieldData* {
+        for (int i = 0; i < results->fields_data_size(); i++) {
+            if (results->fields_data(i).field_id() == fid)
+                return &results->fields_data(i);
+        }
+        return nullptr;
+    };
+
+    // JSON via StringArray
+    auto* json = find_field(json_id.get());
+    ASSERT_NE(json, nullptr);
+    ASSERT_EQ(json->scalars().json_data().data_size(), size);
+    EXPECT_EQ(json->scalars().json_data().data(0), R"({"k":1})");
+    EXPECT_EQ(json->scalars().json_data().data(1), R"({"k":3})");
+
+    // GEOMETRY via StringArray
+    auto* geo = find_field(geo_id.get());
+    ASSERT_NE(geo, nullptr);
+    ASSERT_EQ(geo->scalars().geometry_data().data_size(), size);
+    EXPECT_EQ(geo->scalars().geometry_data().data(0), "POINT(1 0)");
+    EXPECT_EQ(geo->scalars().geometry_data().data(1), "POINT(3 0)");
+
+    // TEXT (always StringArray, same in both tests)
+    auto* txt = find_field(text_id.get());
+    ASSERT_NE(txt, nullptr);
+    ASSERT_EQ(txt->scalars().string_data().data_size(), size);
+    EXPECT_EQ(txt->scalars().string_data().data(0), "text_1");
+    EXPECT_EQ(txt->scalars().string_data().data(1), "text_3");
+}
+
+// ---------------------------------------------------------------------------
+// VECTOR_ARRAY (List<FixedSizeBinary>) test
+// ---------------------------------------------------------------------------
+
+// Build schema with a VECTOR_ARRAY field (element_type = VECTOR_FLOAT, dim=4).
+struct VectorArraySchemaInfo {
+    SchemaPtr schema;
+    FieldId int64_id;
+    FieldId vec_arr_id;
+};
+
+VectorArraySchemaInfo
+BuildVectorArraySchema() {
+    auto schema = std::make_shared<Schema>();
+    schema->AddField(
+        FieldName("RowID"), RowFieldID, DataType::INT64, false, std::nullopt);
+    schema->AddField(FieldName("Timestamp"),
+                     TimestampFieldID,
+                     DataType::INT64,
+                     false,
+                     std::nullopt);
+
+    VectorArraySchemaInfo info;
+    info.int64_id = FieldId(400);
+    info.vec_arr_id = FieldId(401);
+
+    schema->AddField(FieldMeta(FieldName("int64_col"),
+                               info.int64_id,
+                               DataType::INT64,
+                               false,
+                               std::nullopt,
+                               "int64_col"));
+    // VECTOR_ARRAY: element_type=VECTOR_FLOAT, dim=4
+    schema->AddField(FieldMeta(FieldName("vec_arr_col"),
+                               info.vec_arr_id,
+                               DataType::VECTOR_ARRAY,
+                               DataType::VECTOR_FLOAT,
+                               kVecDim,
+                               knowhere::metric::L2,
+                               "vec_arr_col"));
+
+    schema->set_primary_field_id(info.int64_id);
+    schema->set_external_source("s3://test-bucket/data");
+    schema->set_external_spec(R"({"format":"parquet"})");
+    info.schema = schema;
+    return info;
+}
+
+// Build table with List<FixedSizeBinary(dim*4)> for VECTOR_ARRAY.
+// Each row has (i+1) vectors, each vector is dim=4 floats.
+std::shared_ptr<arrow::Table>
+BuildVectorArrayTable() {
+    // INT64 PK
+    arrow::Int64Builder int64_b;
+    for (int i = 0; i < kTestRows; i++)
+        EXPECT_TRUE(int64_b.Append(i * 10000).ok());
+    auto int64_arr = int64_b.Finish().ValueOrDie();
+
+    // VECTOR_ARRAY as List<FixedSizeBinary(dim*4)>
+    int byte_width = kVecDim * sizeof(float);
+    auto fsb_type = arrow::fixed_size_binary(byte_width);
+    arrow::FixedSizeBinaryBuilder value_builder(fsb_type);
+    arrow::Int32Builder offset_builder;
+    EXPECT_TRUE(offset_builder.Append(0).ok());
+    int32_t offset = 0;
+    for (int i = 0; i < kTestRows; i++) {
+        int num_vecs = i + 1;  // row i has (i+1) vectors
+        for (int v = 0; v < num_vecs; v++) {
+            // Each vector: [i*100+v*10+d] for d in 0..dim-1
+            float vals[kVecDim];
+            for (int d = 0; d < kVecDim; d++)
+                vals[d] = static_cast<float>(i * 100 + v * 10 + d);
+            EXPECT_TRUE(
+                value_builder.Append(reinterpret_cast<const uint8_t*>(vals))
+                    .ok());
+        }
+        offset += num_vecs;
+        EXPECT_TRUE(offset_builder.Append(offset).ok());
+    }
+    auto values = value_builder.Finish().ValueOrDie();
+    auto offsets = offset_builder.Finish().ValueOrDie();
+    auto list_result = arrow::ListArray::FromArrays(*offsets, *values);
+    EXPECT_TRUE(list_result.ok());
+    auto vec_arr_arr = *list_result;
+
+    auto schema = arrow::schema({
+        arrow::field("int64_col", arrow::int64()),
+        arrow::field("vec_arr_col", arrow::list(fsb_type)),
+    });
+    return arrow::Table::Make(schema, {int64_arr, vec_arr_arr});
+}
+
+TEST(ExternalTakeTest, TryTakeForRetrieve_VectorArrayType) {
+    auto [schema, int64_id, vec_arr_id] = BuildVectorArraySchema();
+    auto table = BuildVectorArrayTable();
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, schema);
+    segment->SetReaderForTesting(std::make_unique<MockTakeReader>(table));
+
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
+    plan->field_ids_ = {int64_id, vec_arr_id};
+
+    auto results = std::make_unique<proto::segcore::RetrieveResults>();
+    std::vector<int64_t> offsets = {0, 2, 4};
+    int64_t size = offsets.size();
+
+    bool ok = segment->TryTakeForRetrieve(
+        plan.get(), results, offsets.data(), size, false, false);
+    ASSERT_TRUE(ok);
+    ASSERT_EQ(results->fields_data_size(), 2);
+
+    auto find_field = [&](int64_t fid) -> const proto::schema::FieldData* {
+        for (int i = 0; i < results->fields_data_size(); i++) {
+            if (results->fields_data(i).field_id() == fid)
+                return &results->fields_data(i);
+        }
+        return nullptr;
+    };
+
+    auto* va = find_field(vec_arr_id.get());
+    ASSERT_NE(va, nullptr);
+    EXPECT_EQ(va->vectors().dim(), kVecDim);
+    auto& va_data = va->vectors().vector_array().data();
+    ASSERT_EQ(va_data.size(), size);
+
+    // Row 0: 1 vector [0,1,2,3]
+    EXPECT_EQ(va_data[0].float_vector().data_size(), kVecDim);
+    EXPECT_FLOAT_EQ(va_data[0].float_vector().data(0), 0.0f);
+    EXPECT_FLOAT_EQ(va_data[0].float_vector().data(3), 3.0f);
+
+    // Row 2: 3 vectors, first=[200,201,202,203], second=[210,211,212,213]
+    EXPECT_EQ(va_data[1].float_vector().data_size(), 3 * kVecDim);
+    EXPECT_FLOAT_EQ(va_data[1].float_vector().data(0), 200.0f);
+    EXPECT_FLOAT_EQ(va_data[1].float_vector().data(kVecDim), 210.0f);
+
+    // Row 4: 5 vectors
+    EXPECT_EQ(va_data[2].float_vector().data_size(), 5 * kVecDim);
+    EXPECT_FLOAT_EQ(va_data[2].float_vector().data(0), 400.0f);
+}
+
+// ---------------------------------------------------------------------------
+// TEXT type test (verifies TEXT case label reaches StringArray handler)
+// ---------------------------------------------------------------------------
+
+TEST(ExternalTakeTest, TryTakeForRetrieve_TextType) {
+    auto schema = std::make_shared<Schema>();
+    schema->AddField(
+        FieldName("RowID"), RowFieldID, DataType::INT64, false, std::nullopt);
+    schema->AddField(FieldName("Timestamp"),
+                     TimestampFieldID,
+                     DataType::INT64,
+                     false,
+                     std::nullopt);
+
+    FieldId pk_id(500);
+    FieldId text_id(501);
+    schema->AddField(FieldMeta(FieldName("pk_col"),
+                               pk_id,
+                               DataType::INT64,
+                               false,
+                               std::nullopt,
+                               "pk_col"));
+    schema->AddField(FieldMeta(FieldName("text_col"),
+                               text_id,
+                               DataType::TEXT,
+                               65535,
+                               false,
+                               std::nullopt,
+                               "text_col"));
+    schema->set_primary_field_id(pk_id);
+    schema->set_external_source("s3://test-bucket/data");
+    schema->set_external_spec(R"({"format":"parquet"})");
+
+    arrow::Int64Builder int64_b;
+    for (int i = 0; i < kTestRows; i++) EXPECT_TRUE(int64_b.Append(i).ok());
+    auto int64_arr = int64_b.Finish().ValueOrDie();
+
+    arrow::StringBuilder str_b;
+    for (int i = 0; i < kTestRows; i++)
+        EXPECT_TRUE(str_b.Append("text_" + std::to_string(i)).ok());
+    auto str_arr = str_b.Finish().ValueOrDie();
+
+    auto arrow_schema = arrow::schema({
+        arrow::field("pk_col", arrow::int64()),
+        arrow::field("text_col", arrow::utf8()),
+    });
+    auto table = arrow::Table::Make(arrow_schema, {int64_arr, str_arr});
+
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, schema);
+    segment->SetReaderForTesting(std::make_unique<MockTakeReader>(table));
+
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
+    plan->field_ids_ = {pk_id, text_id};
+
+    auto results = std::make_unique<proto::segcore::RetrieveResults>();
+    std::vector<int64_t> offsets = {0, 3};
+    int64_t size = offsets.size();
+
+    bool ok = segment->TryTakeForRetrieve(
+        plan.get(), results, offsets.data(), size, false, false);
+    ASSERT_TRUE(ok);
+
+    auto find_field = [&](int64_t fid) -> const proto::schema::FieldData* {
+        for (int i = 0; i < results->fields_data_size(); i++) {
+            if (results->fields_data(i).field_id() == fid)
+                return &results->fields_data(i);
+        }
+        return nullptr;
+    };
+
+    auto* txt = find_field(text_id.get());
+    ASSERT_NE(txt, nullptr);
+    ASSERT_EQ(txt->scalars().string_data().data_size(), size);
+    EXPECT_EQ(txt->scalars().string_data().data(0), "text_0");
+    EXPECT_EQ(txt->scalars().string_data().data(1), "text_3");
+}
+
+// ---------------------------------------------------------------------------
+// TIMESTAMPTZ tests (TimestampArray + Int64Array branches)
+// ---------------------------------------------------------------------------
+
+struct TimestamptzSchemaInfo {
+    SchemaPtr schema;
+    FieldId int64_id;
+    FieldId ts_id;
+};
+
+TimestamptzSchemaInfo
+BuildTimestamptzSchema() {
+    auto schema = std::make_shared<Schema>();
+    schema->AddField(
+        FieldName("RowID"), RowFieldID, DataType::INT64, false, std::nullopt);
+    schema->AddField(FieldName("Timestamp"),
+                     TimestampFieldID,
+                     DataType::INT64,
+                     false,
+                     std::nullopt);
+
+    TimestamptzSchemaInfo info;
+    info.int64_id = FieldId(600);
+    info.ts_id = FieldId(601);
+
+    schema->AddField(FieldMeta(FieldName("int64_col"),
+                               info.int64_id,
+                               DataType::INT64,
+                               false,
+                               std::nullopt,
+                               "int64_col"));
+    schema->AddField(FieldMeta(FieldName("ts_col"),
+                               info.ts_id,
+                               DataType::TIMESTAMPTZ,
+                               false,
+                               std::nullopt,
+                               "ts_col"));
+
+    schema->set_primary_field_id(info.int64_id);
+    schema->set_external_source("s3://test-bucket/data");
+    schema->set_external_spec(R"({"format":"parquet"})");
+    info.schema = schema;
+    return info;
+}
+
+// TIMESTAMPTZ via Int64Array (internal binlog format, already microseconds)
+TEST(ExternalTakeTest, TryTakeForRetrieve_Timestamptz_Int64Path) {
+    auto [schema, int64_id, ts_id] = BuildTimestamptzSchema();
+
+    arrow::Int64Builder int64_b, ts_b;
+    for (int i = 0; i < kTestRows; i++) {
+        EXPECT_TRUE(int64_b.Append(i * 10000).ok());
+        EXPECT_TRUE(ts_b.Append(i * 1000000).ok());  // microseconds
+    }
+    auto int64_arr = int64_b.Finish().ValueOrDie();
+    auto ts_arr = ts_b.Finish().ValueOrDie();
+
+    auto table = arrow::Table::Make(
+        arrow::schema({arrow::field("int64_col", arrow::int64()),
+                       arrow::field("ts_col", arrow::int64())}),
+        {int64_arr, ts_arr});
+
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, schema);
+    segment->SetReaderForTesting(std::make_unique<MockTakeReader>(table));
+
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
+    plan->field_ids_ = {int64_id, ts_id};
+
+    auto results = std::make_unique<proto::segcore::RetrieveResults>();
+    std::vector<int64_t> offsets = {0, 2, 4};
+    int64_t size = offsets.size();
+
+    bool ok = segment->TryTakeForRetrieve(
+        plan.get(), results, offsets.data(), size, false, false);
+    ASSERT_TRUE(ok);
+
+    auto find_field = [&](int64_t fid) -> const proto::schema::FieldData* {
+        for (int i = 0; i < results->fields_data_size(); i++)
+            if (results->fields_data(i).field_id() == fid)
+                return &results->fields_data(i);
+        return nullptr;
+    };
+
+    auto* ts = find_field(ts_id.get());
+    ASSERT_NE(ts, nullptr);
+    ASSERT_EQ(ts->scalars().timestamptz_data().data_size(), size);
+    EXPECT_EQ(ts->scalars().timestamptz_data().data(0), 0);        // row 0
+    EXPECT_EQ(ts->scalars().timestamptz_data().data(1), 2000000);  // row 2
+    EXPECT_EQ(ts->scalars().timestamptz_data().data(2), 4000000);  // row 4
+}
+
+// TIMESTAMPTZ via TimestampArray with NANO unit (external Parquet format)
+// Verifies NANO → MICRO conversion: 1e9 ns → 1e6 us
+TEST(ExternalTakeTest, TryTakeForRetrieve_Timestamptz_NanosConversion) {
+    auto [schema, int64_id, ts_id] = BuildTimestamptzSchema();
+
+    arrow::Int64Builder int64_b;
+    for (int i = 0; i < kTestRows; i++)
+        EXPECT_TRUE(int64_b.Append(i * 10000).ok());
+    auto int64_arr = int64_b.Finish().ValueOrDie();
+
+    auto ts_type = arrow::timestamp(arrow::TimeUnit::NANO, "UTC");
+    arrow::TimestampBuilder ts_b(ts_type, arrow::default_memory_pool());
+    for (int i = 0; i < kTestRows; i++)
+        EXPECT_TRUE(ts_b.Append(i * 1000000000LL).ok());  // nanoseconds
+    auto ts_arr = ts_b.Finish().ValueOrDie();
+
+    auto table = arrow::Table::Make(
+        arrow::schema({arrow::field("int64_col", arrow::int64()),
+                       arrow::field("ts_col", ts_type)}),
+        {int64_arr, ts_arr});
+
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, schema);
+    segment->SetReaderForTesting(std::make_unique<MockTakeReader>(table));
+
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
+    plan->field_ids_ = {int64_id, ts_id};
+
+    auto results = std::make_unique<proto::segcore::RetrieveResults>();
+    std::vector<int64_t> offsets = {0, 1, 3};
+    int64_t size = offsets.size();
+
+    bool ok = segment->TryTakeForRetrieve(
+        plan.get(), results, offsets.data(), size, false, false);
+    ASSERT_TRUE(ok);
+
+    auto find_field = [&](int64_t fid) -> const proto::schema::FieldData* {
+        for (int i = 0; i < results->fields_data_size(); i++)
+            if (results->fields_data(i).field_id() == fid)
+                return &results->fields_data(i);
+        return nullptr;
+    };
+
+    auto* ts = find_field(ts_id.get());
+    ASSERT_NE(ts, nullptr);
+    ASSERT_EQ(ts->scalars().timestamptz_data().data_size(), size);
+    EXPECT_EQ(ts->scalars().timestamptz_data().data(0), 0);  // 0 ns → 0 us
+    EXPECT_EQ(ts->scalars().timestamptz_data().data(1),
+              1000000);  // 1e9 ns → 1e6 us
+    EXPECT_EQ(ts->scalars().timestamptz_data().data(2),
+              3000000);  // 3e9 ns → 3e6 us
+}
+
+// ---------------------------------------------------------------------------
+// ARRAY tests (ListArray + BinaryArray branches)
+// ---------------------------------------------------------------------------
+
+struct ArraySchemaInfo {
+    SchemaPtr schema;
+    FieldId int64_id;
+    FieldId array_id;
+};
+
+ArraySchemaInfo
+BuildArraySchema() {
+    auto schema = std::make_shared<Schema>();
+    schema->AddField(
+        FieldName("RowID"), RowFieldID, DataType::INT64, false, std::nullopt);
+    schema->AddField(FieldName("Timestamp"),
+                     TimestampFieldID,
+                     DataType::INT64,
+                     false,
+                     std::nullopt);
+
+    ArraySchemaInfo info;
+    info.int64_id = FieldId(700);
+    info.array_id = FieldId(701);
+
+    schema->AddField(FieldMeta(FieldName("int64_col"),
+                               info.int64_id,
+                               DataType::INT64,
+                               false,
+                               std::nullopt,
+                               "int64_col"));
+    schema->AddField(FieldMeta(FieldName("array_col"),
+                               info.array_id,
+                               DataType::ARRAY,
+                               DataType::INT32,
+                               false,
+                               std::nullopt,
+                               "array_col"));
+
+    schema->set_primary_field_id(info.int64_id);
+    schema->set_external_source("s3://test-bucket/data");
+    schema->set_external_spec(R"({"format":"parquet"})");
+    info.schema = schema;
+    return info;
+}
+
+// ARRAY via Arrow ListArray (external Parquet native format: list<int32>)
+TEST(ExternalTakeTest, TryTakeForRetrieve_Array_ListPath) {
+    auto [schema, int64_id, array_id] = BuildArraySchema();
+
+    arrow::Int64Builder int64_b;
+    for (int i = 0; i < kTestRows; i++)
+        EXPECT_TRUE(int64_b.Append(i * 10000).ok());
+    auto int64_arr = int64_b.Finish().ValueOrDie();
+
+    // Build List<Int32>: row i has elements [i*10, i*10+1, i*10+2]
+    arrow::Int32Builder value_builder;
+    arrow::Int32Builder offset_builder;
+    EXPECT_TRUE(offset_builder.Append(0).ok());
+    int32_t offset = 0;
+    for (int i = 0; i < kTestRows; i++) {
+        for (int j = 0; j < 3; j++)
+            EXPECT_TRUE(value_builder.Append(i * 10 + j).ok());
+        offset += 3;
+        EXPECT_TRUE(offset_builder.Append(offset).ok());
+    }
+    auto values = value_builder.Finish().ValueOrDie();
+    auto offsets_arr = offset_builder.Finish().ValueOrDie();
+    auto list_result = arrow::ListArray::FromArrays(*offsets_arr, *values);
+    EXPECT_TRUE(list_result.ok());
+    auto list_arr = *list_result;
+
+    auto table = arrow::Table::Make(
+        arrow::schema({arrow::field("int64_col", arrow::int64()),
+                       arrow::field("array_col", arrow::list(arrow::int32()))}),
+        {int64_arr, list_arr});
+
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, schema);
+    segment->SetReaderForTesting(std::make_unique<MockTakeReader>(table));
+
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
+    plan->field_ids_ = {int64_id, array_id};
+
+    auto results = std::make_unique<proto::segcore::RetrieveResults>();
+    std::vector<int64_t> offsets = {0, 2, 4};
+    int64_t size = offsets.size();
+
+    bool ok = segment->TryTakeForRetrieve(
+        plan.get(), results, offsets.data(), size, false, false);
+    ASSERT_TRUE(ok);
+
+    auto find_field = [&](int64_t fid) -> const proto::schema::FieldData* {
+        for (int i = 0; i < results->fields_data_size(); i++)
+            if (results->fields_data(i).field_id() == fid)
+                return &results->fields_data(i);
+        return nullptr;
+    };
+
+    auto* arr = find_field(array_id.get());
+    ASSERT_NE(arr, nullptr);
+    ASSERT_EQ(arr->scalars().array_data().data_size(), size);
+
+    // Row 0: [0, 1, 2]
+    auto& a0 = arr->scalars().array_data().data(0);
+    ASSERT_EQ(a0.int_data().data_size(), 3);
+    EXPECT_EQ(a0.int_data().data(0), 0);
+    EXPECT_EQ(a0.int_data().data(1), 1);
+    EXPECT_EQ(a0.int_data().data(2), 2);
+
+    // Row 2: [20, 21, 22]
+    auto& a2 = arr->scalars().array_data().data(1);
+    EXPECT_EQ(a2.int_data().data(0), 20);
+    EXPECT_EQ(a2.int_data().data(1), 21);
+
+    // Row 4: [40, 41, 42]
+    auto& a4 = arr->scalars().array_data().data(2);
+    EXPECT_EQ(a4.int_data().data(0), 40);
+}
+
+// ARRAY via BinaryArray (internal binlog format: protobuf-encoded ScalarField)
+TEST(ExternalTakeTest, TryTakeForRetrieve_Array_BinaryPath) {
+    auto [schema, int64_id, array_id] = BuildArraySchema();
+
+    arrow::Int64Builder int64_b;
+    for (int i = 0; i < kTestRows; i++)
+        EXPECT_TRUE(int64_b.Append(i * 10000).ok());
+    auto int64_arr = int64_b.Finish().ValueOrDie();
+
+    // Build BinaryArray with proto-encoded ScalarField
+    arrow::BinaryBuilder bin_b;
+    for (int i = 0; i < kTestRows; i++) {
+        proto::schema::ScalarField sf;
+        auto* int_data = sf.mutable_int_data();
+        int_data->add_data(i * 10);
+        int_data->add_data(i * 10 + 1);
+        int_data->add_data(i * 10 + 2);
+        std::string serialized;
+        sf.SerializeToString(&serialized);
+        EXPECT_TRUE(bin_b.Append(serialized).ok());
+    }
+    auto bin_arr = bin_b.Finish().ValueOrDie();
+
+    auto table = arrow::Table::Make(
+        arrow::schema({arrow::field("int64_col", arrow::int64()),
+                       arrow::field("array_col", arrow::binary())}),
+        {int64_arr, bin_arr});
+
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, schema);
+    segment->SetReaderForTesting(std::make_unique<MockTakeReader>(table));
+
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
+    plan->field_ids_ = {int64_id, array_id};
+
+    auto results = std::make_unique<proto::segcore::RetrieveResults>();
+    std::vector<int64_t> offsets = {1, 3};
+    int64_t size = offsets.size();
+
+    bool ok = segment->TryTakeForRetrieve(
+        plan.get(), results, offsets.data(), size, false, false);
+    ASSERT_TRUE(ok);
+
+    auto find_field = [&](int64_t fid) -> const proto::schema::FieldData* {
+        for (int i = 0; i < results->fields_data_size(); i++)
+            if (results->fields_data(i).field_id() == fid)
+                return &results->fields_data(i);
+        return nullptr;
+    };
+
+    auto* arr = find_field(array_id.get());
+    ASSERT_NE(arr, nullptr);
+    ASSERT_EQ(arr->scalars().array_data().data_size(), size);
+
+    // Row 1: [10, 11, 12]
+    auto& a1 = arr->scalars().array_data().data(0);
+    ASSERT_EQ(a1.int_data().data_size(), 3);
+    EXPECT_EQ(a1.int_data().data(0), 10);
+    EXPECT_EQ(a1.int_data().data(1), 11);
+
+    // Row 3: [30, 31, 32]
+    auto& a3 = arr->scalars().array_data().data(1);
+    EXPECT_EQ(a3.int_data().data(0), 30);
+}
+
+// ---------------------------------------------------------------------------
+// VECTOR_ARRAY empty list row regression test (P1 bug fix)
+// ---------------------------------------------------------------------------
+
+TEST(ExternalTakeTest, TryTakeForRetrieve_VectorArray_EmptyRow) {
+    auto [schema, int64_id, vec_arr_id] = BuildVectorArraySchema();
+
+    arrow::Int64Builder int64_b;
+    for (int i = 0; i < kTestRows; i++) EXPECT_TRUE(int64_b.Append(i).ok());
+    auto int64_arr = int64_b.Finish().ValueOrDie();
+
+    // Build List<FixedSizeBinary(dim*4)> with row 0 = empty, row 1 = 2 vecs
+    int byte_width = kVecDim * sizeof(float);
+    auto fsb_type = arrow::fixed_size_binary(byte_width);
+    arrow::FixedSizeBinaryBuilder value_builder(fsb_type);
+    arrow::Int32Builder offset_builder;
+    EXPECT_TRUE(offset_builder.Append(0).ok());
+
+    // Row 0: empty (0 vectors)
+    EXPECT_TRUE(offset_builder.Append(0).ok());
+
+    // Row 1: 2 vectors
+    for (int v = 0; v < 2; v++) {
+        float vals[kVecDim];
+        for (int d = 0; d < kVecDim; d++)
+            vals[d] = static_cast<float>(v * 10 + d);
+        EXPECT_TRUE(
+            value_builder.Append(reinterpret_cast<const uint8_t*>(vals)).ok());
+    }
+    EXPECT_TRUE(offset_builder.Append(2).ok());
+
+    // Row 2-4: 1 vector each
+    for (int i = 2; i < kTestRows; i++) {
+        float vals[kVecDim] = {static_cast<float>(i), 0, 0, 0};
+        EXPECT_TRUE(
+            value_builder.Append(reinterpret_cast<const uint8_t*>(vals)).ok());
+        EXPECT_TRUE(offset_builder.Append(2 + (i - 1)).ok());
+    }
+
+    auto values = value_builder.Finish().ValueOrDie();
+    auto offsets_arr = offset_builder.Finish().ValueOrDie();
+    auto list_result = arrow::ListArray::FromArrays(*offsets_arr, *values);
+    EXPECT_TRUE(list_result.ok());
+    auto vec_arr_arr = *list_result;
+
+    auto table = arrow::Table::Make(
+        arrow::schema({arrow::field("int64_col", arrow::int64()),
+                       arrow::field("vec_arr_col", arrow::list(fsb_type))}),
+        {int64_arr, vec_arr_arr});
+
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, schema);
+    segment->SetReaderForTesting(std::make_unique<MockTakeReader>(table));
+
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
+    plan->field_ids_ = {int64_id, vec_arr_id};
+
+    auto results = std::make_unique<proto::segcore::RetrieveResults>();
+    // Include row 0 (empty) and row 1 (2 vectors) — should NOT crash
+    std::vector<int64_t> offsets = {0, 1};
+    int64_t size = offsets.size();
+
+    bool ok = segment->TryTakeForRetrieve(
+        plan.get(), results, offsets.data(), size, false, false);
+    ASSERT_TRUE(ok);
+
+    auto find_field = [&](int64_t fid) -> const proto::schema::FieldData* {
+        for (int i = 0; i < results->fields_data_size(); i++)
+            if (results->fields_data(i).field_id() == fid)
+                return &results->fields_data(i);
+        return nullptr;
+    };
+
+    auto* va = find_field(vec_arr_id.get());
+    ASSERT_NE(va, nullptr);
+    auto& va_data = va->vectors().vector_array().data();
+    ASSERT_EQ(va_data.size(), size);
+
+    // Row 0: empty list → empty VectorField (0 floats)
+    EXPECT_EQ(va_data[0].float_vector().data_size(), 0);
+
+    // Row 1: 2 vectors → 2*dim floats
+    EXPECT_EQ(va_data[1].float_vector().data_size(), 2 * kVecDim);
+    EXPECT_FLOAT_EQ(va_data[1].float_vector().data(0), 0.0f);
+    EXPECT_FLOAT_EQ(va_data[1].float_vector().data(kVecDim), 10.0f);
+}
+
+// NormalizeVectorArraysToFixedSizeBinary tests are skipped in this file
+// because storage/Util.cpp requires additional runtime initialization that
+// the standalone test binary does not provide.
+// The LIST/FixedSizeList/passthrough/error paths are covered by the
+// integration test that exercises GetFieldDatasFromManifest end-to-end.

--- a/tests/go_client/testcases/external_table_benchmark_test.go
+++ b/tests/go_client/testcases/external_table_benchmark_test.go
@@ -1,0 +1,1800 @@
+package testcases
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/memory"
+	"github.com/apache/arrow/go/v17/parquet/pqarrow"
+	miniogo "github.com/minio/minio-go/v7"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus/client/v2/column"
+	"github.com/milvus-io/milvus/client/v2/entity"
+	"github.com/milvus-io/milvus/client/v2/index"
+	client "github.com/milvus-io/milvus/client/v2/milvusclient"
+	"github.com/milvus-io/milvus/tests/go_client/base"
+	"github.com/milvus-io/milvus/tests/go_client/common"
+	hp "github.com/milvus-io/milvus/tests/go_client/testcases/helper"
+)
+
+// ============================================================================
+// Benchmark Configuration
+// ============================================================================
+
+type scaleConfig struct {
+	TotalRows   int64
+	NumFiles    int
+	RowsPerFile int64
+}
+
+var scalePresets = map[string]scaleConfig{
+	"100k": {TotalRows: 100_000, NumFiles: 10, RowsPerFile: 10_000},
+	"500k": {TotalRows: 500_000, NumFiles: 10, RowsPerFile: 50_000},
+	"1m":   {TotalRows: 1_000_000, NumFiles: 10, RowsPerFile: 100_000},
+	"10m":  {TotalRows: 10_000_000, NumFiles: 100, RowsPerFile: 100_000},
+	"100m": {TotalRows: 100_000_000, NumFiles: 1000, RowsPerFile: 100_000},
+}
+
+type benchConfig struct {
+	Scale           string
+	TotalRows       int64
+	NumFiles        int
+	RowsPerFile     int64
+	VecDim          int
+	TopK            int
+	QueryIterations int
+	Concurrency     int
+}
+
+// loadBenchScales parses BENCH_SCALE which supports comma-separated values.
+// e.g. BENCH_SCALE=small,medium,large
+func loadBenchScales() []string {
+	scaleStr := envOrDefault("BENCH_SCALE", "100k")
+	parts := strings.Split(scaleStr, ",")
+	var scales []string
+	for _, s := range parts {
+		s = strings.TrimSpace(s)
+		if _, ok := scalePresets[s]; ok {
+			scales = append(scales, s)
+		}
+	}
+	if len(scales) == 0 {
+		return []string{"100k"}
+	}
+	return scales
+}
+
+func loadBenchConfigForScale(scale string) benchConfig {
+	preset, ok := scalePresets[scale]
+	if !ok {
+		preset = scalePresets["100k"]
+	}
+
+	cfg := benchConfig{
+		Scale:           scale,
+		TotalRows:       preset.TotalRows,
+		NumFiles:        preset.NumFiles,
+		RowsPerFile:     preset.RowsPerFile,
+		VecDim:          benchEnvInt("BENCH_VEC_DIM", testVecDim),
+		TopK:            benchEnvInt("BENCH_TOPK", 10),
+		QueryIterations: benchEnvInt("BENCH_QUERY_ITERATIONS", 10),
+		Concurrency:     benchEnvInt("BENCH_CONCURRENCY", 1),
+	}
+
+	if v := os.Getenv("BENCH_TOTAL_ROWS"); v != "" {
+		cfg.TotalRows, _ = strconv.ParseInt(v, 10, 64)
+	}
+	if v := os.Getenv("BENCH_NUM_FILES"); v != "" {
+		cfg.NumFiles, _ = strconv.Atoi(v)
+	}
+	if cfg.NumFiles > 0 {
+		cfg.RowsPerFile = cfg.TotalRows / int64(cfg.NumFiles)
+	}
+
+	return cfg
+}
+
+func benchEnvInt(key string, defaultVal int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return defaultVal
+}
+
+func (c benchConfig) String() string {
+	return fmt.Sprintf("scale=%s rows=%d files=%d rowsPerFile=%d dim=%d topK=%d iterations=%d concurrency=%d",
+		c.Scale, c.TotalRows, c.NumFiles, c.RowsPerFile, c.VecDim, c.TopK, c.QueryIterations, c.Concurrency)
+}
+
+// ============================================================================
+// Multi-Scale Test Runners
+// ============================================================================
+
+// forEachScale runs fn for each configured scale, creating subtests.
+func forEachScale(t *testing.T, fn func(t *testing.T, env *benchEnv)) {
+	scales := loadBenchScales()
+	for _, scale := range scales {
+		scale := scale
+		t.Run("scale_"+scale, func(t *testing.T) {
+			cfg := loadBenchConfigForScale(scale)
+			globalReport.addConfig(scale, cfg)
+			globalReport.setCurrentScale(scale)
+			t.Logf("=== Scale: %s Config: %s ===", scale, cfg)
+			env := newBenchEnvWithConfig(t, cfg)
+			fn(t, env)
+		})
+	}
+}
+
+// forEachScaleConfig runs fn for each configured scale without creating a benchEnv.
+func forEachScaleConfig(t *testing.T, fn func(t *testing.T, cfg benchConfig)) {
+	scales := loadBenchScales()
+	for _, scale := range scales {
+		scale := scale
+		t.Run("scale_"+scale, func(t *testing.T) {
+			cfg := loadBenchConfigForScale(scale)
+			globalReport.addConfig(scale, cfg)
+			globalReport.setCurrentScale(scale)
+			t.Logf("=== Scale: %s Config: %s ===", scale, cfg)
+			fn(t, cfg)
+		})
+	}
+}
+
+// ============================================================================
+// Latency Measurement & Report
+// ============================================================================
+
+type latencyStats struct {
+	Name    string
+	Count   int
+	Min     time.Duration
+	Max     time.Duration
+	Mean    time.Duration
+	P50     time.Duration
+	P95     time.Duration
+	P99     time.Duration
+	Stddev  time.Duration
+	Samples []time.Duration
+}
+
+// benchReport collects all benchmark results and generates a Markdown report.
+type benchReport struct {
+	mu           sync.Mutex
+	entries      []reportEntry
+	configs      map[string]benchConfig // scale -> config
+	currentScale string
+	started      time.Time
+}
+
+type reportEntry struct {
+	TestName string
+	Scale    string
+	Stats    latencyStats
+	Extra    string // optional extra info (e.g. throughput)
+}
+
+var globalReport = &benchReport{
+	started: time.Now(),
+	configs: make(map[string]benchConfig),
+}
+
+func (r *benchReport) add(testName string, stats latencyStats, extra string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.entries = append(r.entries, reportEntry{
+		TestName: testName,
+		Scale:    r.currentScale,
+		Stats:    stats,
+		Extra:    extra,
+	})
+}
+
+func (r *benchReport) setCurrentScale(scale string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.currentScale = scale
+}
+
+func (r *benchReport) addConfig(scale string, cfg benchConfig) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.configs[scale] = cfg
+}
+
+func fmtDuration(d time.Duration) string {
+	if d < time.Millisecond {
+		return fmt.Sprintf("%.1fus", float64(d)/float64(time.Microsecond))
+	}
+	if d < time.Second {
+		return fmt.Sprintf("%.1fms", float64(d)/float64(time.Millisecond))
+	}
+	return fmt.Sprintf("%.2fs", float64(d)/float64(time.Second))
+}
+
+// writeMarkdownReport generates a Markdown report file.
+// When multiple scales are configured, it generates a comparison table with scalability ratios.
+func (r *benchReport) writeMarkdownReport(t *testing.T) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if len(r.entries) == 0 {
+		t.Log("No benchmark entries collected, skipping report generation")
+		return
+	}
+
+	// Collect all scales that actually have data
+	scaleSet := make(map[string]bool)
+	for _, e := range r.entries {
+		if e.Scale != "" {
+			scaleSet[e.Scale] = true
+		}
+	}
+	var scales []string
+	for s := range scaleSet {
+		scales = append(scales, s)
+	}
+	sort.Slice(scales, func(i, j int) bool {
+		return r.configs[scales[i]].TotalRows < r.configs[scales[j]].TotalRows
+	})
+	multiScale := len(scales) > 1
+
+	reportDir := envOrDefault("BENCH_REPORT_DIR", ".")
+	scaleLabel := strings.Join(scales, "_")
+	ts := time.Now().Format("20060102_150405")
+	filename := fmt.Sprintf("%s/bench_report_%s_%s.md", reportDir, scaleLabel, ts)
+
+	var buf bytes.Buffer
+	buf.WriteString("# External Table Benchmark Report\n\n")
+	buf.WriteString(fmt.Sprintf("**Date:** %s\n\n", time.Now().Format("2006-01-02 15:04:05")))
+	buf.WriteString(fmt.Sprintf("**Scales:** %s\n\n", strings.Join(scales, ", ")))
+	buf.WriteString(fmt.Sprintf("**Total Duration:** %s\n\n", fmtDuration(time.Since(r.started))))
+
+	// Configuration table — one column per scale
+	buf.WriteString("## Configuration\n\n")
+	if multiScale {
+		buf.WriteString("| Parameter |")
+		for _, s := range scales {
+			buf.WriteString(fmt.Sprintf(" %s |", s))
+		}
+		buf.WriteString("\n|-----------|")
+		for range scales {
+			buf.WriteString("-------|")
+		}
+		buf.WriteString("\n")
+		for _, param := range []string{"Total Rows", "Num Files", "Rows/File", "Vec Dim", "TopK", "Iterations", "Concurrency"} {
+			buf.WriteString(fmt.Sprintf("| %s |", param))
+			for _, s := range scales {
+				cfg := r.configs[s]
+				var val string
+				switch param {
+				case "Total Rows":
+					val = fmt.Sprintf("%d", cfg.TotalRows)
+				case "Num Files":
+					val = fmt.Sprintf("%d", cfg.NumFiles)
+				case "Rows/File":
+					val = fmt.Sprintf("%d", cfg.RowsPerFile)
+				case "Vec Dim":
+					val = fmt.Sprintf("%d", cfg.VecDim)
+				case "TopK":
+					val = fmt.Sprintf("%d", cfg.TopK)
+				case "Iterations":
+					val = fmt.Sprintf("%d", cfg.QueryIterations)
+				case "Concurrency":
+					val = fmt.Sprintf("%d", cfg.Concurrency)
+				}
+				buf.WriteString(fmt.Sprintf(" %s |", val))
+			}
+			buf.WriteString("\n")
+		}
+	} else {
+		cfg := r.configs[scales[0]]
+		buf.WriteString("| Parameter | Value |\n")
+		buf.WriteString("|-----------|-------|\n")
+		buf.WriteString(fmt.Sprintf("| Total Rows | %d |\n", cfg.TotalRows))
+		buf.WriteString(fmt.Sprintf("| Num Files | %d |\n", cfg.NumFiles))
+		buf.WriteString(fmt.Sprintf("| Rows/File | %d |\n", cfg.RowsPerFile))
+		buf.WriteString(fmt.Sprintf("| Vec Dim | %d |\n", cfg.VecDim))
+		buf.WriteString(fmt.Sprintf("| TopK | %d |\n", cfg.TopK))
+		buf.WriteString(fmt.Sprintf("| Query Iterations | %d |\n", cfg.QueryIterations))
+		buf.WriteString(fmt.Sprintf("| Concurrency | %d |\n", cfg.Concurrency))
+	}
+	buf.WriteString("\n")
+
+	// Per-scale detailed results
+	for _, scale := range scales {
+		if multiScale {
+			cfg := r.configs[scale]
+			buf.WriteString(fmt.Sprintf("## Results — %s (%d rows)\n\n", scale, cfg.TotalRows))
+		} else {
+			buf.WriteString("## Results\n\n")
+		}
+		buf.WriteString("| Benchmark | Iterations | Min | Mean | P50 | P95 | P99 | Max | Stddev | Extra |\n")
+		buf.WriteString("|-----------|-----------|-----|------|-----|-----|-----|-----|--------|-------|\n")
+		for _, e := range r.entries {
+			if e.Scale != scale {
+				continue
+			}
+			s := e.Stats
+			buf.WriteString(fmt.Sprintf("| %s | %d | %s | %s | %s | %s | %s | %s | %s | %s |\n",
+				s.Name, s.Count,
+				fmtDuration(s.Min), fmtDuration(s.Mean), fmtDuration(s.P50),
+				fmtDuration(s.P95), fmtDuration(s.P99), fmtDuration(s.Max),
+				fmtDuration(s.Stddev), e.Extra))
+		}
+		buf.WriteString("\n")
+	}
+
+	// Multi-scale comparison table
+	if multiScale {
+		buf.WriteString("## Scale Comparison\n\n")
+
+		// Collect unique benchmark names in order
+		var benchNames []string
+		seen := make(map[string]bool)
+		for _, e := range r.entries {
+			if !seen[e.Stats.Name] {
+				benchNames = append(benchNames, e.Stats.Name)
+				seen[e.Stats.Name] = true
+			}
+		}
+
+		// Build lookup: benchName -> scale -> entry
+		lookup := make(map[string]map[string]*reportEntry)
+		for i := range r.entries {
+			e := &r.entries[i]
+			if _, ok := lookup[e.Stats.Name]; !ok {
+				lookup[e.Stats.Name] = make(map[string]*reportEntry)
+			}
+			lookup[e.Stats.Name][e.Scale] = e
+		}
+
+		// Header
+		buf.WriteString("| Benchmark |")
+		for _, s := range scales {
+			buf.WriteString(fmt.Sprintf(" %s (Mean) |", s))
+		}
+		if len(scales) >= 2 {
+			buf.WriteString(fmt.Sprintf(" Ratio (%s/%s) |", scales[len(scales)-1], scales[0]))
+		}
+		buf.WriteString("\n|-----------|")
+		for range scales {
+			buf.WriteString("------------|")
+		}
+		if len(scales) >= 2 {
+			buf.WriteString("------------|")
+		}
+		buf.WriteString("\n")
+
+		// Rows
+		for _, name := range benchNames {
+			buf.WriteString(fmt.Sprintf("| %s |", name))
+			var firstMean, lastMean time.Duration
+			for i, s := range scales {
+				if e, ok := lookup[name][s]; ok {
+					buf.WriteString(fmt.Sprintf(" %s |", fmtDuration(e.Stats.Mean)))
+					if i == 0 {
+						firstMean = e.Stats.Mean
+					}
+					lastMean = e.Stats.Mean
+				} else {
+					buf.WriteString(" - |")
+				}
+			}
+			if len(scales) >= 2 && firstMean > 0 {
+				ratio := float64(lastMean) / float64(firstMean)
+				buf.WriteString(fmt.Sprintf(" %.2fx |", ratio))
+			} else if len(scales) >= 2 {
+				buf.WriteString(" - |")
+			}
+			buf.WriteString("\n")
+		}
+		buf.WriteString("\n")
+
+		// Scalability analysis
+		buf.WriteString("## Scalability Analysis\n\n")
+		smallestScale := scales[0]
+		largestScale := scales[len(scales)-1]
+		dataRatio := float64(r.configs[largestScale].TotalRows) / float64(r.configs[smallestScale].TotalRows)
+		buf.WriteString(fmt.Sprintf("**Data scale ratio** (%s → %s): **%.1fx** (%d → %d rows)\n\n",
+			smallestScale, largestScale, dataRatio,
+			r.configs[smallestScale].TotalRows, r.configs[largestScale].TotalRows))
+		buf.WriteString("| Benchmark | Latency Ratio | Scaling | Assessment |\n")
+		buf.WriteString("|-----------|:---:|:---:|:---:|\n")
+		for _, name := range benchNames {
+			small := lookup[name][smallestScale]
+			large := lookup[name][largestScale]
+			if small == nil || large == nil || small.Stats.Mean == 0 {
+				continue
+			}
+			latRatio := float64(large.Stats.Mean) / float64(small.Stats.Mean)
+			var scaling, assessment string
+			switch {
+			case latRatio <= 1.2:
+				scaling = "O(1)"
+				assessment = "Excellent"
+			case latRatio <= dataRatio*0.5:
+				scaling = "Sub-linear"
+				assessment = "Good"
+			case latRatio <= dataRatio*1.2:
+				scaling = "Linear"
+				assessment = "Expected"
+			default:
+				scaling = "Super-linear"
+				assessment = "Needs investigation"
+			}
+			buf.WriteString(fmt.Sprintf("| %s | %.2fx | %s | %s |\n", name, latRatio, scaling, assessment))
+		}
+	}
+
+	buf.WriteString("\n## Summary\n\n")
+	buf.WriteString(fmt.Sprintf("- **Total benchmarks:** %d\n", len(r.entries)))
+	buf.WriteString(fmt.Sprintf("- **Scales tested:** %s\n", strings.Join(scales, ", ")))
+	buf.WriteString("- **Generated by:** `go test -run TestBenchmarkExternal`\n")
+
+	if err := os.WriteFile(filename, buf.Bytes(), 0o600); err != nil {
+		t.Logf("WARNING: failed to write report to %s: %v", filename, err)
+		t.Logf("\n%s", buf.String())
+		return
+	}
+	t.Logf("=== Benchmark report written to: %s ===", filename)
+}
+
+func measureLatency(t *testing.T, name string, iterations int, fn func()) latencyStats {
+	t.Helper()
+	samples := make([]time.Duration, 0, iterations)
+	for i := 0; i < iterations; i++ {
+		start := time.Now()
+		fn()
+		samples = append(samples, time.Since(start))
+	}
+	stats := computeStats(name, samples)
+	t.Logf("=== %s === iterations=%d min=%v max=%v mean=%v p50=%v p95=%v p99=%v stddev=%v",
+		name, stats.Count, stats.Min, stats.Max, stats.Mean, stats.P50, stats.P95, stats.P99, stats.Stddev)
+	globalReport.add(t.Name(), stats, "")
+	return stats
+}
+
+func recordSingleMeasurement(t *testing.T, name string, duration time.Duration, extra string) {
+	t.Helper()
+	stats := computeStats(name, []time.Duration{duration})
+	globalReport.add(t.Name(), stats, extra)
+}
+
+func computeStats(name string, samples []time.Duration) latencyStats {
+	n := len(samples)
+	if n == 0 {
+		return latencyStats{Name: name}
+	}
+	sorted := make([]time.Duration, n)
+	copy(sorted, samples)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+
+	var sum float64
+	for _, s := range sorted {
+		sum += float64(s)
+	}
+	mean := sum / float64(n)
+
+	var variance float64
+	for _, s := range sorted {
+		diff := float64(s) - mean
+		variance += diff * diff
+	}
+	variance /= float64(n)
+
+	return latencyStats{
+		Name:    name,
+		Count:   n,
+		Min:     sorted[0],
+		Max:     sorted[n-1],
+		Mean:    time.Duration(mean),
+		P50:     sorted[int(float64(n)*0.50)],
+		P95:     sorted[int(math.Min(float64(n)*0.95, float64(n-1)))],
+		P99:     sorted[int(math.Min(float64(n)*0.99, float64(n-1)))],
+		Stddev:  time.Duration(math.Sqrt(variance)),
+		Samples: samples,
+	}
+}
+
+// ============================================================================
+// Parquet Generation with Configurable Dimension
+// ============================================================================
+
+func generateParquetBytesWithDim(numRows, startID int64, dim int) ([]byte, error) {
+	// Milvus expects FloatVector stored as FixedSizeBinary(dim*4) in Parquet,
+	// not as FixedSizeList<Float32>.
+	vecByteWidth := dim * 4
+	arrowSchema := arrow.NewSchema(
+		[]arrow.Field{
+			{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+			{Name: "value", Type: arrow.PrimitiveTypes.Float32},
+			{Name: "embedding", Type: &arrow.FixedSizeBinaryType{ByteWidth: vecByteWidth}},
+		},
+		nil,
+	)
+
+	var buf bytes.Buffer
+	writer, err := pqarrow.NewFileWriter(arrowSchema, &buf, nil, pqarrow.DefaultWriterProps())
+	if err != nil {
+		return nil, fmt.Errorf("create parquet writer: %w", err)
+	}
+
+	pool := memory.NewGoAllocator()
+	builder := array.NewRecordBuilder(pool, arrowSchema)
+	defer builder.Release()
+
+	idBuilder := builder.Field(0).(*array.Int64Builder)
+	valueBuilder := builder.Field(1).(*array.Float32Builder)
+	embeddingBuilder := builder.Field(2).(*array.FixedSizeBinaryBuilder)
+
+	vecBuf := make([]byte, vecByteWidth)
+	for i := int64(0); i < numRows; i++ {
+		idx := startID + i
+		idBuilder.Append(idx)
+		valueBuilder.Append(float32(idx) * 1.5)
+		for d := 0; d < dim; d++ {
+			binary.LittleEndian.PutUint32(vecBuf[d*4:], math.Float32bits(float32(idx)*0.1+float32(d)))
+		}
+		embeddingBuilder.Append(vecBuf)
+	}
+
+	record := builder.NewRecord()
+	defer record.Release()
+
+	if err := writer.Write(record); err != nil {
+		return nil, fmt.Errorf("write record: %w", err)
+	}
+	if err := writer.Close(); err != nil {
+		return nil, fmt.Errorf("close writer: %w", err)
+	}
+
+	return buf.Bytes(), nil
+}
+
+// ============================================================================
+// Benchmark Setup Helpers
+// ============================================================================
+
+type benchEnv struct {
+	ctx         context.Context
+	mc          *base.MilvusClient
+	minioClient *miniogo.Client
+	minioCfg    minioConfig
+	cfg         benchConfig
+}
+
+func newBenchEnvWithConfig(t *testing.T, cfg benchConfig) *benchEnv {
+	t.Helper()
+	t.Logf("=== Benchmark Config: %s ===", cfg)
+
+	ctx := hp.CreateContext(t, time.Second*3600) // 1h max
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	minioCfg := getMinIOConfig()
+	minioClient, err := newMinIOClient(minioCfg)
+	if err != nil {
+		t.Skipf("Failed to create MinIO client: %v", err)
+	}
+
+	exists, err := minioClient.BucketExists(ctx, minioCfg.bucket)
+	if err != nil || !exists {
+		t.Skipf("MinIO bucket %q not accessible", minioCfg.bucket)
+	}
+
+	return &benchEnv{ctx: ctx, mc: mc, minioClient: minioClient, minioCfg: minioCfg, cfg: cfg}
+}
+
+// setupExternalCollection creates an external collection with data uploaded to MinIO,
+// refreshed, indexed (scalar + vector), and loaded. Returns collection name.
+func (env *benchEnv) setupExternalCollection(t *testing.T) string {
+	t.Helper()
+	return env.setupExternalCollectionWithOptions(t, env.cfg.NumFiles, env.cfg.RowsPerFile, env.cfg.VecDim)
+}
+
+func (env *benchEnv) setupExternalCollectionWithOptions(t *testing.T, numFiles int, rowsPerFile int64, dim int) string {
+	t.Helper()
+	collName := common.GenRandomString("bench_ext", 6)
+	extPath := fmt.Sprintf("external-bench/%s", collName)
+	totalRows := int64(numFiles) * rowsPerFile
+
+	// Upload Parquet files
+	t.Logf("Uploading %d Parquet files (%d rows each, dim=%d)...", numFiles, rowsPerFile, dim)
+	uploadStart := time.Now()
+	for i := 0; i < numFiles; i++ {
+		data, err := generateParquetBytesWithDim(rowsPerFile, int64(i)*rowsPerFile, dim)
+		require.NoError(t, err, "generate parquet file %d", i)
+		objectKey := fmt.Sprintf("%s/data%d.parquet", extPath, i)
+		uploadParquetToMinIO(t, env.ctx, env.minioClient, env.minioCfg.bucket, objectKey, data)
+	}
+	t.Logf("Upload complete: %v", time.Since(uploadStart))
+
+	t.Cleanup(func() {
+		cleanupMinIOPrefix(context.Background(), env.minioClient, env.minioCfg.bucket, extPath+"/")
+		_ = env.mc.DropCollection(context.Background(), client.NewDropCollectionOption(collName))
+	})
+
+	// Create external collection
+	schema := entity.NewSchema().
+		WithName(collName).
+		WithExternalSource(extPath).
+		WithExternalSpec(`{"format":"parquet"}`).
+		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithExternalField("id")).
+		WithField(entity.NewField().WithName("value").WithDataType(entity.FieldTypeFloat).WithExternalField("value")).
+		WithField(entity.NewField().WithName("embedding").WithDataType(entity.FieldTypeFloatVector).WithDim(int64(dim)).WithExternalField("embedding"))
+
+	err := env.mc.CreateCollection(env.ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, true)
+
+	// Refresh
+	refreshAndWait(env.ctx, t, env.mc, collName)
+
+	// Index + Load
+	indexAndLoadCollectionWithScalarAndVector(env.ctx, t, env.mc, collName, totalRows)
+
+	return collName
+}
+
+func (env *benchEnv) makeQueryVec() []float32 {
+	vec := make([]float32, env.cfg.VecDim)
+	for i := range vec {
+		vec[i] = float32(i) * 0.1
+	}
+	return vec
+}
+
+func (env *benchEnv) makeRandomQueryVec() []float32 {
+	vec := make([]float32, env.cfg.VecDim)
+	for i := range vec {
+		vec[i] = rand.Float32()
+	}
+	return vec
+}
+
+// ============================================================================
+// B1: CreateCollection Latency
+// ============================================================================
+
+func TestBenchmarkExternalCreateCollection(t *testing.T) {
+	forEachScaleConfig(t, func(t *testing.T, cfg benchConfig) {
+		ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+		mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+		measureLatency(t, "B1_CreateCollection_SimpleSchema", cfg.QueryIterations, func() {
+			collName := common.GenRandomString("bench_create", 6)
+			schema := entity.NewSchema().
+				WithName(collName).
+				WithExternalSource("s3://test-bucket/bench/").
+				WithExternalSpec(`{"format":"parquet"}`).
+				WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithExternalField("id")).
+				WithField(entity.NewField().WithName("embedding").WithDataType(entity.FieldTypeFloatVector).WithDim(int64(cfg.VecDim)).WithExternalField("embedding"))
+
+			err := mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
+			common.CheckErr(t, err, true)
+
+			_ = mc.DropCollection(ctx, client.NewDropCollectionOption(collName))
+		})
+
+		measureLatency(t, "B1_CreateCollection_MultiTypeSchema", cfg.QueryIterations, func() {
+			collName := common.GenRandomString("bench_create_mt", 6)
+			schema := entity.NewSchema().
+				WithName(collName).
+				WithExternalSource("s3://test-bucket/bench/").
+				WithExternalSpec(`{"format":"parquet"}`).
+				WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithExternalField("id")).
+				WithField(entity.NewField().WithName("bool_val").WithDataType(entity.FieldTypeBool).WithExternalField("bool_val")).
+				WithField(entity.NewField().WithName("int8_val").WithDataType(entity.FieldTypeInt8).WithExternalField("int8_val")).
+				WithField(entity.NewField().WithName("int16_val").WithDataType(entity.FieldTypeInt16).WithExternalField("int16_val")).
+				WithField(entity.NewField().WithName("int32_val").WithDataType(entity.FieldTypeInt32).WithExternalField("int32_val")).
+				WithField(entity.NewField().WithName("float_val").WithDataType(entity.FieldTypeFloat).WithExternalField("float_val")).
+				WithField(entity.NewField().WithName("double_val").WithDataType(entity.FieldTypeDouble).WithExternalField("double_val")).
+				WithField(entity.NewField().WithName("varchar_val").WithDataType(entity.FieldTypeVarChar).WithMaxLength(64).WithExternalField("varchar_val")).
+				WithField(entity.NewField().WithName("embedding").WithDataType(entity.FieldTypeFloatVector).WithDim(int64(cfg.VecDim)).WithExternalField("embedding"))
+
+			err := mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
+			common.CheckErr(t, err, true)
+
+			_ = mc.DropCollection(ctx, client.NewDropCollectionOption(collName))
+		})
+	})
+}
+
+// ============================================================================
+// B2: RefreshExternalCollection Latency
+// ============================================================================
+
+func TestBenchmarkExternalRefresh(t *testing.T) {
+	forEachScale(t, func(t *testing.T, env *benchEnv) {
+		testBenchmarkExternalRefresh(t, env)
+	})
+}
+
+func testBenchmarkExternalRefresh(t *testing.T, env *benchEnv) {
+	collName := common.GenRandomString("bench_refresh", 6)
+	extPath := fmt.Sprintf("external-bench/%s", collName)
+
+	// Upload data
+	t.Logf("Uploading %d files (%d rows each)...", env.cfg.NumFiles, env.cfg.RowsPerFile)
+	for i := 0; i < env.cfg.NumFiles; i++ {
+		data, err := generateParquetBytesWithDim(env.cfg.RowsPerFile, int64(i)*env.cfg.RowsPerFile, env.cfg.VecDim)
+		require.NoError(t, err)
+		objectKey := fmt.Sprintf("%s/data%d.parquet", extPath, i)
+		uploadParquetToMinIO(t, env.ctx, env.minioClient, env.minioCfg.bucket, objectKey, data)
+	}
+
+	t.Cleanup(func() {
+		cleanupMinIOPrefix(context.Background(), env.minioClient, env.minioCfg.bucket, extPath+"/")
+		_ = env.mc.DropCollection(context.Background(), client.NewDropCollectionOption(collName))
+	})
+
+	// Create collection
+	schema := entity.NewSchema().
+		WithName(collName).
+		WithExternalSource(extPath).
+		WithExternalSpec(`{"format":"parquet"}`).
+		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithExternalField("id")).
+		WithField(entity.NewField().WithName("value").WithDataType(entity.FieldTypeFloat).WithExternalField("value")).
+		WithField(entity.NewField().WithName("embedding").WithDataType(entity.FieldTypeFloatVector).WithDim(int64(env.cfg.VecDim)).WithExternalField("embedding"))
+
+	err := env.mc.CreateCollection(env.ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, true)
+
+	// Measure refresh
+	start := time.Now()
+	refreshAndWait(env.ctx, t, env.mc, collName)
+	refreshDuration := time.Since(start)
+	t.Logf("=== B2_Refresh === rows=%d duration=%v", env.cfg.TotalRows, refreshDuration)
+	recordSingleMeasurement(t, "B2_Refresh", refreshDuration, fmt.Sprintf("rows=%d", env.cfg.TotalRows))
+
+	// Verify row count
+	stats, err := env.mc.GetCollectionStats(env.ctx, client.NewGetCollectionStatsOption(collName))
+	common.CheckErr(t, err, true)
+	rowCountStr := stats["row_count"]
+	rowCount, _ := strconv.ParseInt(rowCountStr, 10, 64)
+	require.Equal(t, env.cfg.TotalRows, rowCount)
+}
+
+// ============================================================================
+// B3: Incremental Refresh Performance
+// ============================================================================
+
+func TestBenchmarkExternalIncrementalRefresh(t *testing.T) {
+	forEachScale(t, benchIncrementalRefresh)
+}
+
+func benchIncrementalRefresh(t *testing.T, env *benchEnv) {
+	collName := common.GenRandomString("bench_incr", 6)
+	extPath := fmt.Sprintf("external-bench/%s", collName)
+
+	// Upload initial data (use half of configured files)
+	initialFiles := env.cfg.NumFiles / 2
+	if initialFiles < 1 {
+		initialFiles = 1
+	}
+
+	for i := 0; i < initialFiles; i++ {
+		data, err := generateParquetBytesWithDim(env.cfg.RowsPerFile, int64(i)*env.cfg.RowsPerFile, env.cfg.VecDim)
+		require.NoError(t, err)
+		objectKey := fmt.Sprintf("%s/data%d.parquet", extPath, i)
+		uploadParquetToMinIO(t, env.ctx, env.minioClient, env.minioCfg.bucket, objectKey, data)
+	}
+
+	t.Cleanup(func() {
+		cleanupMinIOPrefix(context.Background(), env.minioClient, env.minioCfg.bucket, extPath+"/")
+		_ = env.mc.DropCollection(context.Background(), client.NewDropCollectionOption(collName))
+	})
+
+	schema := entity.NewSchema().
+		WithName(collName).
+		WithExternalSource(extPath).
+		WithExternalSpec(`{"format":"parquet"}`).
+		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithExternalField("id")).
+		WithField(entity.NewField().WithName("value").WithDataType(entity.FieldTypeFloat).WithExternalField("value")).
+		WithField(entity.NewField().WithName("embedding").WithDataType(entity.FieldTypeFloatVector).WithDim(int64(env.cfg.VecDim)).WithExternalField("embedding"))
+
+	err := env.mc.CreateCollection(env.ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, true)
+
+	// Initial refresh
+	start := time.Now()
+	refreshAndWait(env.ctx, t, env.mc, collName)
+	initialRefreshDuration := time.Since(start)
+	t.Logf("=== B3_InitialRefresh === files=%d rows=%d duration=%v",
+		initialFiles, int64(initialFiles)*env.cfg.RowsPerFile, initialRefreshDuration)
+	recordSingleMeasurement(t, "B3_InitialRefresh", initialRefreshDuration,
+		fmt.Sprintf("files=%d rows=%d", initialFiles, int64(initialFiles)*env.cfg.RowsPerFile))
+
+	// Add one more file
+	newFileIdx := initialFiles
+	data, err := generateParquetBytesWithDim(env.cfg.RowsPerFile, int64(newFileIdx)*env.cfg.RowsPerFile, env.cfg.VecDim)
+	require.NoError(t, err)
+	objectKey := fmt.Sprintf("%s/data%d.parquet", extPath, newFileIdx)
+	uploadParquetToMinIO(t, env.ctx, env.minioClient, env.minioCfg.bucket, objectKey, data)
+
+	// Incremental refresh (add file)
+	start = time.Now()
+	refreshAndWait(env.ctx, t, env.mc, collName)
+	incrAddDuration := time.Since(start)
+	t.Logf("=== B3_IncrementalRefresh_AddFile === duration=%v (vs initial=%v)", incrAddDuration, initialRefreshDuration)
+	recordSingleMeasurement(t, "B3_IncrementalRefresh_AddFile", incrAddDuration,
+		fmt.Sprintf("vs_initial=%v", initialRefreshDuration))
+
+	// Verify row count
+	stats, err := env.mc.GetCollectionStats(env.ctx, client.NewGetCollectionStatsOption(collName))
+	common.CheckErr(t, err, true)
+	rowCountStr := stats["row_count"]
+	rowCount, _ := strconv.ParseInt(rowCountStr, 10, 64)
+	expectedRows := int64(initialFiles+1) * env.cfg.RowsPerFile
+	require.Equal(t, expectedRows, rowCount)
+}
+
+// ============================================================================
+// B4: Index Building Latency
+// ============================================================================
+
+func TestBenchmarkExternalIndexBuilding(t *testing.T) {
+	forEachScale(t, benchIndexBuilding)
+}
+
+func benchIndexBuilding(t *testing.T, env *benchEnv) {
+	collName := common.GenRandomString("bench_idx", 6)
+	extPath := fmt.Sprintf("external-bench/%s", collName)
+
+	// Upload and create collection
+	for i := 0; i < env.cfg.NumFiles; i++ {
+		data, err := generateParquetBytesWithDim(env.cfg.RowsPerFile, int64(i)*env.cfg.RowsPerFile, env.cfg.VecDim)
+		require.NoError(t, err)
+		objectKey := fmt.Sprintf("%s/data%d.parquet", extPath, i)
+		uploadParquetToMinIO(t, env.ctx, env.minioClient, env.minioCfg.bucket, objectKey, data)
+	}
+
+	t.Cleanup(func() {
+		cleanupMinIOPrefix(context.Background(), env.minioClient, env.minioCfg.bucket, extPath+"/")
+		_ = env.mc.DropCollection(context.Background(), client.NewDropCollectionOption(collName))
+	})
+
+	schema := entity.NewSchema().
+		WithName(collName).
+		WithExternalSource(extPath).
+		WithExternalSpec(`{"format":"parquet"}`).
+		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithExternalField("id")).
+		WithField(entity.NewField().WithName("value").WithDataType(entity.FieldTypeFloat).WithExternalField("value")).
+		WithField(entity.NewField().WithName("embedding").WithDataType(entity.FieldTypeFloatVector).WithDim(int64(env.cfg.VecDim)).WithExternalField("embedding"))
+
+	err := env.mc.CreateCollection(env.ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, true)
+	refreshAndWait(env.ctx, t, env.mc, collName)
+
+	// Measure scalar index on "id"
+	start := time.Now()
+	idIdxTask, err := env.mc.CreateIndex(env.ctx, client.NewCreateIndexOption(collName, "id", index.NewAutoIndex(entity.IP)))
+	common.CheckErr(t, err, true)
+	err = idIdxTask.Await(env.ctx)
+	common.CheckErr(t, err, true)
+	scalarIdxDuration := time.Since(start)
+	t.Logf("=== B4_ScalarIndex_id === rows=%d duration=%v", env.cfg.TotalRows, scalarIdxDuration)
+	recordSingleMeasurement(t, "B4_ScalarIndex_id", scalarIdxDuration, fmt.Sprintf("rows=%d", env.cfg.TotalRows))
+
+	// Measure scalar index on "value"
+	start = time.Now()
+	valIdxTask, err := env.mc.CreateIndex(env.ctx, client.NewCreateIndexOption(collName, "value", index.NewAutoIndex(entity.IP)))
+	common.CheckErr(t, err, true)
+	err = valIdxTask.Await(env.ctx)
+	common.CheckErr(t, err, true)
+	scalarValIdxDuration := time.Since(start)
+	t.Logf("=== B4_ScalarIndex_value === rows=%d duration=%v", env.cfg.TotalRows, scalarValIdxDuration)
+	recordSingleMeasurement(t, "B4_ScalarIndex_value", scalarValIdxDuration, fmt.Sprintf("rows=%d", env.cfg.TotalRows))
+
+	// Measure vector index
+	start = time.Now()
+	vecIdxTask, err := env.mc.CreateIndex(env.ctx, client.NewCreateIndexOption(collName, "embedding", index.NewAutoIndex(entity.L2)))
+	common.CheckErr(t, err, true)
+	err = vecIdxTask.Await(env.ctx)
+	common.CheckErr(t, err, true)
+	vectorIdxDuration := time.Since(start)
+	t.Logf("=== B4_VectorIndex === rows=%d dim=%d duration=%v", env.cfg.TotalRows, env.cfg.VecDim, vectorIdxDuration)
+	recordSingleMeasurement(t, "B4_VectorIndex", vectorIdxDuration, fmt.Sprintf("rows=%d dim=%d", env.cfg.TotalRows, env.cfg.VecDim))
+
+	// Verify indexes
+	for _, fieldName := range []string{"id", "value", "embedding"} {
+		descIdx, err := env.mc.DescribeIndex(env.ctx, client.NewDescribeIndexOption(collName, fieldName))
+		common.CheckErr(t, err, true)
+		require.Equal(t, index.IndexState(3), descIdx.State, "index on %s should be Finished", fieldName)
+		require.Equal(t, env.cfg.TotalRows, descIdx.TotalRows, "index on %s TotalRows", fieldName)
+	}
+}
+
+// ============================================================================
+// B5: LoadCollection Latency
+// ============================================================================
+
+func TestBenchmarkExternalLoadCollection(t *testing.T) {
+	forEachScale(t, benchLoadCollection)
+}
+
+func benchLoadCollection(t *testing.T, env *benchEnv) {
+	collName := common.GenRandomString("bench_load", 6)
+	extPath := fmt.Sprintf("external-bench/%s", collName)
+
+	for i := 0; i < env.cfg.NumFiles; i++ {
+		data, err := generateParquetBytesWithDim(env.cfg.RowsPerFile, int64(i)*env.cfg.RowsPerFile, env.cfg.VecDim)
+		require.NoError(t, err)
+		objectKey := fmt.Sprintf("%s/data%d.parquet", extPath, i)
+		uploadParquetToMinIO(t, env.ctx, env.minioClient, env.minioCfg.bucket, objectKey, data)
+	}
+
+	t.Cleanup(func() {
+		cleanupMinIOPrefix(context.Background(), env.minioClient, env.minioCfg.bucket, extPath+"/")
+		_ = env.mc.DropCollection(context.Background(), client.NewDropCollectionOption(collName))
+	})
+
+	schema := entity.NewSchema().
+		WithName(collName).
+		WithExternalSource(extPath).
+		WithExternalSpec(`{"format":"parquet"}`).
+		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithExternalField("id")).
+		WithField(entity.NewField().WithName("value").WithDataType(entity.FieldTypeFloat).WithExternalField("value")).
+		WithField(entity.NewField().WithName("embedding").WithDataType(entity.FieldTypeFloatVector).WithDim(int64(env.cfg.VecDim)).WithExternalField("embedding"))
+
+	err := env.mc.CreateCollection(env.ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, true)
+	refreshAndWait(env.ctx, t, env.mc, collName)
+
+	// Create indexes (required before load)
+	indexAndLoadCollectionWithScalarAndVector(env.ctx, t, env.mc, collName, env.cfg.TotalRows)
+	// Release to re-measure load
+	err = env.mc.ReleaseCollection(env.ctx, client.NewReleaseCollectionOption(collName))
+	require.NoError(t, err)
+	time.Sleep(2 * time.Second)
+
+	// Measure load
+	start := time.Now()
+	loadTask, err := env.mc.LoadCollection(env.ctx, client.NewLoadCollectionOption(collName))
+	common.CheckErr(t, err, true)
+	err = loadTask.Await(env.ctx)
+	common.CheckErr(t, err, true)
+	loadDuration := time.Since(start)
+	t.Logf("=== B5_LoadCollection === rows=%d dim=%d duration=%v", env.cfg.TotalRows, env.cfg.VecDim, loadDuration)
+	recordSingleMeasurement(t, "B5_LoadCollection", loadDuration, fmt.Sprintf("rows=%d dim=%d", env.cfg.TotalRows, env.cfg.VecDim))
+
+	// Verify loaded — query count
+	countRes, err := env.mc.Query(env.ctx, client.NewQueryOption(collName).
+		WithConsistencyLevel(entity.ClStrong).
+		WithOutputFields(common.QueryCountFieldName))
+	common.CheckErr(t, err, true)
+	count, _ := countRes.GetColumn(common.QueryCountFieldName).GetAsInt64(0)
+	require.Equal(t, env.cfg.TotalRows, count)
+}
+
+// ============================================================================
+// B6: Count Query
+// ============================================================================
+
+func TestBenchmarkExternalCountQuery(t *testing.T) {
+	forEachScale(t, benchCountQuery)
+}
+
+func benchCountQuery(t *testing.T, env *benchEnv) {
+	collName := env.setupExternalCollection(t)
+
+	measureLatency(t, "B6_CountQuery", env.cfg.QueryIterations, func() {
+		countRes, err := env.mc.Query(env.ctx, client.NewQueryOption(collName).
+			WithConsistencyLevel(entity.ClStrong).
+			WithOutputFields(common.QueryCountFieldName))
+		common.CheckErr(t, err, true)
+		count, _ := countRes.GetColumn(common.QueryCountFieldName).GetAsInt64(0)
+		require.Equal(t, env.cfg.TotalRows, count)
+	})
+}
+
+// ============================================================================
+// B7: Scalar Filter Query
+// ============================================================================
+
+func TestBenchmarkExternalScalarFilter(t *testing.T) {
+	forEachScale(t, benchScalarFilter)
+}
+
+func benchScalarFilter(t *testing.T, env *benchEnv) {
+	collName := env.setupExternalCollection(t)
+
+	totalRows := env.cfg.TotalRows
+
+	// High selectivity: single row
+	measureLatency(t, "B7_ScalarFilter_SingleRow", env.cfg.QueryIterations, func() {
+		res, err := env.mc.Query(env.ctx, client.NewQueryOption(collName).
+			WithConsistencyLevel(entity.ClStrong).
+			WithFilter("id == 42").
+			WithOutputFields("id", "value"))
+		common.CheckErr(t, err, true)
+		require.Equal(t, 1, res.GetColumn("id").Len())
+	})
+
+	// 1% selectivity
+	top1pct := totalRows / 100
+	measureLatency(t, "B7_ScalarFilter_1pct", env.cfg.QueryIterations, func() {
+		res, err := env.mc.Query(env.ctx, client.NewQueryOption(collName).
+			WithConsistencyLevel(entity.ClStrong).
+			WithFilter(fmt.Sprintf("id < %d", top1pct)).
+			WithOutputFields("id"))
+		common.CheckErr(t, err, true)
+		require.Equal(t, int(top1pct), res.GetColumn("id").Len())
+	})
+
+	// 10% selectivity
+	top10pct := totalRows / 10
+	measureLatency(t, "B7_ScalarFilter_10pct", env.cfg.QueryIterations, func() {
+		res, err := env.mc.Query(env.ctx, client.NewQueryOption(collName).
+			WithConsistencyLevel(entity.ClStrong).
+			WithFilter(fmt.Sprintf("id < %d", top10pct)).
+			WithOutputFields(common.QueryCountFieldName))
+		common.CheckErr(t, err, true)
+		count, _ := res.GetColumn(common.QueryCountFieldName).GetAsInt64(0)
+		require.Equal(t, top10pct, count)
+	})
+
+	// Range filter
+	rangeLow := totalRows / 4
+	rangeHigh := totalRows / 2
+	measureLatency(t, "B7_ScalarFilter_Range25pct", env.cfg.QueryIterations, func() {
+		res, err := env.mc.Query(env.ctx, client.NewQueryOption(collName).
+			WithConsistencyLevel(entity.ClStrong).
+			WithFilter(fmt.Sprintf("id >= %d && id < %d", rangeLow, rangeHigh)).
+			WithOutputFields(common.QueryCountFieldName))
+		common.CheckErr(t, err, true)
+		count, _ := res.GetColumn(common.QueryCountFieldName).GetAsInt64(0)
+		require.Equal(t, rangeHigh-rangeLow, count)
+	})
+}
+
+// ============================================================================
+// B8: Vector Search
+// ============================================================================
+
+func TestBenchmarkExternalVectorSearch(t *testing.T) {
+	forEachScale(t, benchVectorSearch)
+}
+
+func benchVectorSearch(t *testing.T, env *benchEnv) {
+	collName := env.setupExternalCollection(t)
+
+	vec := env.makeQueryVec()
+
+	for _, topK := range []int{5, 10, 50, 100} {
+		name := fmt.Sprintf("B8_VectorSearch_topK%d", topK)
+		measureLatency(t, name, env.cfg.QueryIterations, func() {
+			searchRes, err := env.mc.Search(env.ctx, client.NewSearchOption(collName, topK,
+				[]entity.Vector{entity.FloatVector(vec)}).
+				WithConsistencyLevel(entity.ClStrong).
+				WithANNSField("embedding").
+				WithOutputFields("id"))
+			common.CheckErr(t, err, true)
+			require.Equal(t, 1, len(searchRes))
+			require.Greater(t, searchRes[0].ResultCount, 0)
+		})
+	}
+}
+
+// ============================================================================
+// B9: Hybrid Search (Vector + Scalar Filter)
+// ============================================================================
+
+func TestBenchmarkExternalHybridSearch(t *testing.T) {
+	forEachScale(t, benchHybridSearch)
+}
+
+func benchHybridSearch(t *testing.T, env *benchEnv) {
+	collName := env.setupExternalCollection(t)
+
+	vec := env.makeQueryVec()
+	halfRows := env.cfg.TotalRows / 2
+
+	// Range filter — 50% selectivity
+	measureLatency(t, "B9_HybridSearch_Range50pct", env.cfg.QueryIterations, func() {
+		searchRes, err := env.mc.Search(env.ctx, client.NewSearchOption(collName, env.cfg.TopK,
+			[]entity.Vector{entity.FloatVector(vec)}).
+			WithConsistencyLevel(entity.ClStrong).
+			WithANNSField("embedding").
+			WithFilter(fmt.Sprintf("id >= %d", halfRows)).
+			WithOutputFields("id"))
+		common.CheckErr(t, err, true)
+		require.Greater(t, searchRes[0].ResultCount, 0)
+		// Verify filter
+		for i := 0; i < searchRes[0].GetColumn("id").Len(); i++ {
+			val, _ := searchRes[0].GetColumn("id").GetAsInt64(i)
+			require.GreaterOrEqual(t, val, halfRows)
+		}
+	})
+
+	// Range filter — 10% selectivity
+	top10pct := env.cfg.TotalRows / 10
+	measureLatency(t, "B9_HybridSearch_Range10pct", env.cfg.QueryIterations, func() {
+		searchRes, err := env.mc.Search(env.ctx, client.NewSearchOption(collName, env.cfg.TopK,
+			[]entity.Vector{entity.FloatVector(vec)}).
+			WithConsistencyLevel(entity.ClStrong).
+			WithANNSField("embedding").
+			WithFilter(fmt.Sprintf("id < %d", top10pct)).
+			WithOutputFields("id"))
+		common.CheckErr(t, err, true)
+		require.Greater(t, searchRes[0].ResultCount, 0)
+	})
+}
+
+// ============================================================================
+// B10: Multi-Vector Search
+// ============================================================================
+
+func TestBenchmarkExternalMultiVectorSearch(t *testing.T) {
+	forEachScale(t, benchMultiVectorSearch)
+}
+
+func benchMultiVectorSearch(t *testing.T, env *benchEnv) {
+	collName := env.setupExternalCollection(t)
+
+	for _, nq := range []int{1, 5, 10, 50} {
+		vectors := make([]entity.Vector, nq)
+		for i := range vectors {
+			vectors[i] = entity.FloatVector(env.makeRandomQueryVec())
+		}
+
+		name := fmt.Sprintf("B10_MultiVectorSearch_nq%d", nq)
+		measureLatency(t, name, env.cfg.QueryIterations, func() {
+			searchRes, err := env.mc.Search(env.ctx, client.NewSearchOption(collName, env.cfg.TopK, vectors).
+				WithConsistencyLevel(entity.ClStrong).
+				WithANNSField("embedding").
+				WithOutputFields("id"))
+			common.CheckErr(t, err, true)
+			require.Equal(t, nq, len(searchRes))
+			for _, r := range searchRes {
+				require.Greater(t, r.ResultCount, 0)
+			}
+		})
+	}
+}
+
+// ============================================================================
+// B11: Query with Pagination
+// ============================================================================
+
+func TestBenchmarkExternalPagination(t *testing.T) {
+	forEachScale(t, benchPagination)
+}
+
+func benchPagination(t *testing.T, env *benchEnv) {
+	collName := env.setupExternalCollection(t)
+
+	pageSize := int64(100)
+	offsets := []int64{0, 100, 1000}
+	if env.cfg.TotalRows > 10000 {
+		offsets = append(offsets, 5000, 10000)
+	}
+
+	for _, offset := range offsets {
+		name := fmt.Sprintf("B11_Pagination_offset%d_limit%d", offset, pageSize)
+		measureLatency(t, name, env.cfg.QueryIterations, func() {
+			res, err := env.mc.Query(env.ctx, client.NewQueryOption(collName).
+				WithConsistencyLevel(entity.ClStrong).
+				WithFilter("id >= 0").
+				WithOutputFields("id").
+				WithOffset(int(offset)).
+				WithLimit(int(pageSize)))
+			common.CheckErr(t, err, true)
+			require.Equal(t, int(pageSize), res.GetColumn("id").Len())
+		})
+	}
+}
+
+// ============================================================================
+// B12: Query with Output Fields
+// ============================================================================
+
+func TestBenchmarkExternalOutputFields(t *testing.T) {
+	forEachScale(t, benchOutputFields)
+}
+
+func benchOutputFields(t *testing.T, env *benchEnv) {
+	collName := env.setupExternalCollection(t)
+
+	limit := int64(100)
+
+	// IDs only (no output fields)
+	measureLatency(t, "B12_OutputFields_IDsOnly", env.cfg.QueryIterations, func() {
+		_, err := env.mc.Query(env.ctx, client.NewQueryOption(collName).
+			WithConsistencyLevel(entity.ClStrong).
+			WithFilter(fmt.Sprintf("id < %d", limit)).
+			WithOutputFields("id"))
+		common.CheckErr(t, err, true)
+	})
+
+	// Scalar fields
+	measureLatency(t, "B12_OutputFields_Scalar", env.cfg.QueryIterations, func() {
+		_, err := env.mc.Query(env.ctx, client.NewQueryOption(collName).
+			WithConsistencyLevel(entity.ClStrong).
+			WithFilter(fmt.Sprintf("id < %d", limit)).
+			WithOutputFields("id", "value"))
+		common.CheckErr(t, err, true)
+	})
+
+	// Vector field
+	measureLatency(t, "B12_OutputFields_Vector", env.cfg.QueryIterations, func() {
+		_, err := env.mc.Query(env.ctx, client.NewQueryOption(collName).
+			WithConsistencyLevel(entity.ClStrong).
+			WithFilter(fmt.Sprintf("id < %d", limit)).
+			WithOutputFields("id", "embedding"))
+		common.CheckErr(t, err, true)
+	})
+
+	// All fields
+	measureLatency(t, "B12_OutputFields_All", env.cfg.QueryIterations, func() {
+		_, err := env.mc.Query(env.ctx, client.NewQueryOption(collName).
+			WithConsistencyLevel(entity.ClStrong).
+			WithFilter(fmt.Sprintf("id < %d", limit)).
+			WithOutputFields("id", "value", "embedding"))
+		common.CheckErr(t, err, true)
+	})
+}
+
+// ============================================================================
+// B13: External vs Regular Collection — Query Performance
+// ============================================================================
+
+func TestBenchmarkExternalVsRegularQuery(t *testing.T) {
+	forEachScale(t, benchVsRegularQuery)
+}
+
+func benchVsRegularQuery(t *testing.T, env *benchEnv) {
+	// Setup external collection
+	extCollName := env.setupExternalCollection(t)
+
+	// Setup regular collection with same data
+	regCollName := common.GenRandomString("bench_reg", 6)
+	t.Logf("Creating regular collection for comparison: %s", regCollName)
+
+	regSchema := entity.NewSchema().
+		WithName(regCollName).
+		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithIsPrimaryKey(true)).
+		WithField(entity.NewField().WithName("value").WithDataType(entity.FieldTypeFloat)).
+		WithField(entity.NewField().WithName("embedding").WithDataType(entity.FieldTypeFloatVector).WithDim(int64(env.cfg.VecDim)))
+
+	err := env.mc.CreateCollection(env.ctx, client.NewCreateCollectionOption(regCollName, regSchema))
+	common.CheckErr(t, err, true)
+
+	t.Cleanup(func() {
+		_ = env.mc.DropCollection(context.Background(), client.NewDropCollectionOption(regCollName))
+	})
+
+	// Insert data into regular collection in batches
+	batchSize := int64(10000)
+	for batchOffset := int64(0); batchOffset < env.cfg.TotalRows; batchOffset += batchSize {
+		remaining := env.cfg.TotalRows - batchOffset
+		if remaining > batchSize {
+			remaining = batchSize
+		}
+		ids := make([]int64, remaining)
+		values := make([]float32, remaining)
+		embeddings := make([][]float32, remaining)
+		for i := int64(0); i < remaining; i++ {
+			idx := batchOffset + i
+			ids[i] = idx
+			values[i] = float32(idx) * 1.5
+			vec := make([]float32, env.cfg.VecDim)
+			for d := range vec {
+				vec[d] = float32(idx)*0.1 + float32(d)
+			}
+			embeddings[i] = vec
+		}
+
+		insertOpt := client.NewColumnBasedInsertOption(regCollName).
+			WithInt64Column("id", ids).
+			WithColumns(column.NewColumnFloat("value", values)).
+			WithFloatVectorColumn("embedding", env.cfg.VecDim, embeddings)
+
+		_, err := env.mc.Insert(env.ctx, insertOpt)
+		common.CheckErr(t, err, true)
+	}
+
+	// Flush
+	flushTask, err := env.mc.Flush(env.ctx, client.NewFlushOption(regCollName))
+	common.CheckErr(t, err, true)
+	err = flushTask.Await(env.ctx)
+	common.CheckErr(t, err, true)
+
+	// Index + Load regular collection
+	vecIdx := index.NewAutoIndex(entity.L2)
+	vecIdxTask, err := env.mc.CreateIndex(env.ctx, client.NewCreateIndexOption(regCollName, "embedding", vecIdx))
+	common.CheckErr(t, err, true)
+	err = vecIdxTask.Await(env.ctx)
+	common.CheckErr(t, err, true)
+
+	loadTask, err := env.mc.LoadCollection(env.ctx, client.NewLoadCollectionOption(regCollName))
+	common.CheckErr(t, err, true)
+	err = loadTask.Await(env.ctx)
+	common.CheckErr(t, err, true)
+
+	vec := env.makeQueryVec()
+
+	// Compare: Count Query
+	extCountStats := measureLatency(t, "B13_CountQuery_External", env.cfg.QueryIterations, func() {
+		res, err := env.mc.Query(env.ctx, client.NewQueryOption(extCollName).
+			WithConsistencyLevel(entity.ClStrong).
+			WithOutputFields(common.QueryCountFieldName))
+		common.CheckErr(t, err, true)
+		count, _ := res.GetColumn(common.QueryCountFieldName).GetAsInt64(0)
+		require.Equal(t, env.cfg.TotalRows, count)
+	})
+
+	regCountStats := measureLatency(t, "B13_CountQuery_Regular", env.cfg.QueryIterations, func() {
+		res, err := env.mc.Query(env.ctx, client.NewQueryOption(regCollName).
+			WithConsistencyLevel(entity.ClStrong).
+			WithOutputFields(common.QueryCountFieldName))
+		common.CheckErr(t, err, true)
+		count, _ := res.GetColumn(common.QueryCountFieldName).GetAsInt64(0)
+		require.Equal(t, env.cfg.TotalRows, count)
+	})
+	t.Logf("B13 Count: External=%v Regular=%v ratio=%.2fx",
+		extCountStats.Mean, regCountStats.Mean,
+		float64(extCountStats.Mean)/float64(regCountStats.Mean))
+
+	// Compare: Vector Search
+	extSearchStats := measureLatency(t, "B13_VectorSearch_External", env.cfg.QueryIterations, func() {
+		searchRes, err := env.mc.Search(env.ctx, client.NewSearchOption(extCollName, env.cfg.TopK,
+			[]entity.Vector{entity.FloatVector(vec)}).
+			WithConsistencyLevel(entity.ClStrong).
+			WithANNSField("embedding").
+			WithOutputFields("id"))
+		common.CheckErr(t, err, true)
+		require.Greater(t, searchRes[0].ResultCount, 0)
+	})
+
+	regSearchStats := measureLatency(t, "B13_VectorSearch_Regular", env.cfg.QueryIterations, func() {
+		searchRes, err := env.mc.Search(env.ctx, client.NewSearchOption(regCollName, env.cfg.TopK,
+			[]entity.Vector{entity.FloatVector(vec)}).
+			WithConsistencyLevel(entity.ClStrong).
+			WithANNSField("embedding").
+			WithOutputFields("id"))
+		common.CheckErr(t, err, true)
+		require.Greater(t, searchRes[0].ResultCount, 0)
+	})
+	t.Logf("B13 Search: External=%v Regular=%v ratio=%.2fx",
+		extSearchStats.Mean, regSearchStats.Mean,
+		float64(extSearchStats.Mean)/float64(regSearchStats.Mean))
+
+	// Compare: Scalar filter
+	filterExpr := fmt.Sprintf("id < %d", env.cfg.TotalRows/10)
+	extFilterStats := measureLatency(t, "B13_ScalarFilter_External", env.cfg.QueryIterations, func() {
+		_, err := env.mc.Query(env.ctx, client.NewQueryOption(extCollName).
+			WithConsistencyLevel(entity.ClStrong).
+			WithFilter(filterExpr).
+			WithOutputFields(common.QueryCountFieldName))
+		common.CheckErr(t, err, true)
+	})
+
+	regFilterStats := measureLatency(t, "B13_ScalarFilter_Regular", env.cfg.QueryIterations, func() {
+		_, err := env.mc.Query(env.ctx, client.NewQueryOption(regCollName).
+			WithConsistencyLevel(entity.ClStrong).
+			WithFilter(filterExpr).
+			WithOutputFields(common.QueryCountFieldName))
+		common.CheckErr(t, err, true)
+	})
+	t.Logf("B13 Filter: External=%v Regular=%v ratio=%.2fx",
+		extFilterStats.Mean, regFilterStats.Mean,
+		float64(extFilterStats.Mean)/float64(regFilterStats.Mean))
+}
+
+// ============================================================================
+// B15: Large Number of Files
+// ============================================================================
+
+func TestBenchmarkExternalManyFiles(t *testing.T) {
+	forEachScale(t, benchManyFiles)
+}
+
+func benchManyFiles(t *testing.T, env *benchEnv) {
+	// Use 100 small files regardless of BENCH_SCALE
+	numFiles := 100
+	rowsPerFile := env.cfg.TotalRows / int64(numFiles)
+	if rowsPerFile < 100 {
+		rowsPerFile = 100
+	}
+
+	collName := common.GenRandomString("bench_manyfiles", 6)
+	extPath := fmt.Sprintf("external-bench/%s", collName)
+	totalRows := int64(numFiles) * rowsPerFile
+
+	t.Logf("Uploading %d files (%d rows each = %d total)", numFiles, rowsPerFile, totalRows)
+
+	for i := 0; i < numFiles; i++ {
+		data, err := generateParquetBytesWithDim(rowsPerFile, int64(i)*rowsPerFile, env.cfg.VecDim)
+		require.NoError(t, err)
+		objectKey := fmt.Sprintf("%s/data%d.parquet", extPath, i)
+		uploadParquetToMinIO(t, env.ctx, env.minioClient, env.minioCfg.bucket, objectKey, data)
+	}
+
+	t.Cleanup(func() {
+		cleanupMinIOPrefix(context.Background(), env.minioClient, env.minioCfg.bucket, extPath+"/")
+		_ = env.mc.DropCollection(context.Background(), client.NewDropCollectionOption(collName))
+	})
+
+	schema := entity.NewSchema().
+		WithName(collName).
+		WithExternalSource(extPath).
+		WithExternalSpec(`{"format":"parquet"}`).
+		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithExternalField("id")).
+		WithField(entity.NewField().WithName("value").WithDataType(entity.FieldTypeFloat).WithExternalField("value")).
+		WithField(entity.NewField().WithName("embedding").WithDataType(entity.FieldTypeFloatVector).WithDim(int64(env.cfg.VecDim)).WithExternalField("embedding"))
+
+	err := env.mc.CreateCollection(env.ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, true)
+
+	start := time.Now()
+	refreshAndWait(env.ctx, t, env.mc, collName)
+	refreshDuration := time.Since(start)
+	t.Logf("=== B15_ManyFiles_Refresh === files=%d rows=%d duration=%v", numFiles, totalRows, refreshDuration)
+	recordSingleMeasurement(t, "B15_ManyFiles_Refresh", refreshDuration, fmt.Sprintf("files=%d rows=%d", numFiles, totalRows))
+
+	// Verify
+	stats, err := env.mc.GetCollectionStats(env.ctx, client.NewGetCollectionStatsOption(collName))
+	common.CheckErr(t, err, true)
+	rowCount, _ := strconv.ParseInt(stats["row_count"], 10, 64)
+	require.Equal(t, totalRows, rowCount)
+}
+
+// ============================================================================
+// B16: Large Single File
+// ============================================================================
+
+func TestBenchmarkExternalLargeSingleFile(t *testing.T) {
+	forEachScale(t, benchLargeSingleFile)
+}
+
+func benchLargeSingleFile(t *testing.T, env *benchEnv) {
+	collName := common.GenRandomString("bench_bigfile", 6)
+	extPath := fmt.Sprintf("external-bench/%s", collName)
+	totalRows := env.cfg.TotalRows
+
+	t.Logf("Uploading 1 file with %d rows", totalRows)
+
+	data, err := generateParquetBytesWithDim(totalRows, 0, env.cfg.VecDim)
+	require.NoError(t, err)
+	objectKey := fmt.Sprintf("%s/data.parquet", extPath)
+	uploadParquetToMinIO(t, env.ctx, env.minioClient, env.minioCfg.bucket, objectKey, data)
+
+	t.Cleanup(func() {
+		cleanupMinIOPrefix(context.Background(), env.minioClient, env.minioCfg.bucket, extPath+"/")
+		_ = env.mc.DropCollection(context.Background(), client.NewDropCollectionOption(collName))
+	})
+
+	schema := entity.NewSchema().
+		WithName(collName).
+		WithExternalSource(extPath).
+		WithExternalSpec(`{"format":"parquet"}`).
+		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithExternalField("id")).
+		WithField(entity.NewField().WithName("value").WithDataType(entity.FieldTypeFloat).WithExternalField("value")).
+		WithField(entity.NewField().WithName("embedding").WithDataType(entity.FieldTypeFloatVector).WithDim(int64(env.cfg.VecDim)).WithExternalField("embedding"))
+
+	err = env.mc.CreateCollection(env.ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, true)
+
+	start := time.Now()
+	refreshAndWait(env.ctx, t, env.mc, collName)
+	refreshDuration := time.Since(start)
+	t.Logf("=== B16_LargeSingleFile_Refresh === rows=%d duration=%v", totalRows, refreshDuration)
+	recordSingleMeasurement(t, "B16_LargeSingleFile_Refresh", refreshDuration, fmt.Sprintf("rows=%d", totalRows))
+
+	// Verify
+	stats, err := env.mc.GetCollectionStats(env.ctx, client.NewGetCollectionStatsOption(collName))
+	common.CheckErr(t, err, true)
+	rowCount, _ := strconv.ParseInt(stats["row_count"], 10, 64)
+	require.Equal(t, totalRows, rowCount)
+
+	// Load and verify query works
+	indexAndLoadCollection(env.ctx, t, env.mc, collName, "embedding")
+
+	countRes, err := env.mc.Query(env.ctx, client.NewQueryOption(collName).
+		WithConsistencyLevel(entity.ClStrong).
+		WithOutputFields(common.QueryCountFieldName))
+	common.CheckErr(t, err, true)
+	count, _ := countRes.GetColumn(common.QueryCountFieldName).GetAsInt64(0)
+	require.Equal(t, totalRows, count)
+	t.Logf("=== B16_LargeSingleFile === verified count=%d", count)
+}
+
+// ============================================================================
+// B17: Concurrent Query Load
+// ============================================================================
+
+func TestBenchmarkExternalConcurrentQuery(t *testing.T) {
+	forEachScale(t, benchConcurrentQuery)
+}
+
+func benchConcurrentQuery(t *testing.T, env *benchEnv) {
+	collName := env.setupExternalCollection(t)
+
+	vec := env.makeQueryVec()
+
+	concurrencyLevels := []int{1, 5, 10, 20}
+	if env.cfg.Concurrency > 0 {
+		concurrencyLevels = []int{env.cfg.Concurrency}
+	}
+
+	for _, concurrency := range concurrencyLevels {
+		t.Run(fmt.Sprintf("concurrency_%d", concurrency), func(t *testing.T) {
+			var wg sync.WaitGroup
+			var mu sync.Mutex
+			var allLatencies []time.Duration
+			errCount := 0
+
+			totalOps := env.cfg.QueryIterations * concurrency
+			start := time.Now()
+
+			for g := 0; g < concurrency; g++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					for i := 0; i < env.cfg.QueryIterations; i++ {
+						opStart := time.Now()
+						searchRes, err := env.mc.Search(env.ctx, client.NewSearchOption(collName, env.cfg.TopK,
+							[]entity.Vector{entity.FloatVector(vec)}).
+							WithConsistencyLevel(entity.ClStrong).
+							WithANNSField("embedding").
+							WithOutputFields("id"))
+						elapsed := time.Since(opStart)
+
+						mu.Lock()
+						if err != nil {
+							errCount++
+						} else {
+							if len(searchRes) > 0 && searchRes[0].ResultCount > 0 {
+								allLatencies = append(allLatencies, elapsed)
+							}
+						}
+						mu.Unlock()
+					}
+				}()
+			}
+
+			wg.Wait()
+			totalDuration := time.Since(start)
+
+			stats := computeStats(fmt.Sprintf("B17_ConcurrentSearch_c%d", concurrency), allLatencies)
+			throughput := float64(len(allLatencies)) / totalDuration.Seconds()
+
+			t.Logf("=== B17_ConcurrentSearch === concurrency=%d totalOps=%d successOps=%d errors=%d",
+				concurrency, totalOps, len(allLatencies), errCount)
+			t.Logf("  throughput=%.1f ops/s totalDuration=%v", throughput, totalDuration)
+			t.Logf("  latency: min=%v max=%v mean=%v p50=%v p95=%v p99=%v",
+				stats.Min, stats.Max, stats.Mean, stats.P50, stats.P95, stats.P99)
+
+			require.Zero(t, errCount, "no errors expected in concurrent search")
+
+			globalReport.add(t.Name(), stats, fmt.Sprintf("throughput=%.1f ops/s, concurrency=%d", throughput, concurrency))
+		})
+	}
+}
+
+// ============================================================================
+// B19: Multiple Refreshes (Idempotency)
+// ============================================================================
+
+func TestBenchmarkExternalIdempotentRefresh(t *testing.T) {
+	forEachScale(t, benchIdempotentRefresh)
+}
+
+func benchIdempotentRefresh(t *testing.T, env *benchEnv) {
+	collName := common.GenRandomString("bench_idemp", 6)
+	extPath := fmt.Sprintf("external-bench/%s", collName)
+
+	// Upload data (smaller set for idempotency test)
+	numFiles := 5
+	rowsPerFile := env.cfg.RowsPerFile
+	totalRows := int64(numFiles) * rowsPerFile
+
+	for i := 0; i < numFiles; i++ {
+		data, err := generateParquetBytesWithDim(rowsPerFile, int64(i)*rowsPerFile, env.cfg.VecDim)
+		require.NoError(t, err)
+		objectKey := fmt.Sprintf("%s/data%d.parquet", extPath, i)
+		uploadParquetToMinIO(t, env.ctx, env.minioClient, env.minioCfg.bucket, objectKey, data)
+	}
+
+	t.Cleanup(func() {
+		cleanupMinIOPrefix(context.Background(), env.minioClient, env.minioCfg.bucket, extPath+"/")
+		_ = env.mc.DropCollection(context.Background(), client.NewDropCollectionOption(collName))
+	})
+
+	schema := entity.NewSchema().
+		WithName(collName).
+		WithExternalSource(extPath).
+		WithExternalSpec(`{"format":"parquet"}`).
+		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithExternalField("id")).
+		WithField(entity.NewField().WithName("value").WithDataType(entity.FieldTypeFloat).WithExternalField("value")).
+		WithField(entity.NewField().WithName("embedding").WithDataType(entity.FieldTypeFloatVector).WithDim(int64(env.cfg.VecDim)).WithExternalField("embedding"))
+
+	err := env.mc.CreateCollection(env.ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, true)
+
+	// First refresh
+	start := time.Now()
+	refreshAndWait(env.ctx, t, env.mc, collName)
+	firstRefreshDuration := time.Since(start)
+	t.Logf("=== B19_FirstRefresh === rows=%d duration=%v", totalRows, firstRefreshDuration)
+	recordSingleMeasurement(t, "B19_FirstRefresh", firstRefreshDuration, fmt.Sprintf("rows=%d", totalRows))
+
+	// Second refresh (no changes)
+	start = time.Now()
+	refreshAndWait(env.ctx, t, env.mc, collName)
+	secondRefreshDuration := time.Since(start)
+	t.Logf("=== B19_SecondRefresh_NoChange === duration=%v (vs first=%v)", secondRefreshDuration, firstRefreshDuration)
+	recordSingleMeasurement(t, "B19_SecondRefresh_NoChange", secondRefreshDuration, fmt.Sprintf("vs_first=%v", firstRefreshDuration))
+
+	// Verify row count unchanged
+	stats, err := env.mc.GetCollectionStats(env.ctx, client.NewGetCollectionStatsOption(collName))
+	common.CheckErr(t, err, true)
+	rowCount, _ := strconv.ParseInt(stats["row_count"], 10, 64)
+	require.Equal(t, totalRows, rowCount, "row count should be unchanged after idempotent refresh")
+
+	// Third refresh (still no changes)
+	start = time.Now()
+	refreshAndWait(env.ctx, t, env.mc, collName)
+	thirdRefreshDuration := time.Since(start)
+	t.Logf("=== B19_ThirdRefresh_NoChange === duration=%v", thirdRefreshDuration)
+	recordSingleMeasurement(t, "B19_ThirdRefresh_NoChange", thirdRefreshDuration, "")
+
+	// Verify still same
+	stats, err = env.mc.GetCollectionStats(env.ctx, client.NewGetCollectionStatsOption(collName))
+	common.CheckErr(t, err, true)
+	rowCount, _ = strconv.ParseInt(stats["row_count"], 10, 64)
+	require.Equal(t, totalRows, rowCount)
+}
+
+// ============================================================================
+// B20: All Supported Data Types
+// ============================================================================
+
+func TestBenchmarkExternalMultiDataTypes(t *testing.T) {
+	forEachScale(t, benchMultiDataTypes)
+}
+
+func benchMultiDataTypes(t *testing.T, env *benchEnv) {
+	collName := common.GenRandomString("bench_types", 6)
+	extPath := fmt.Sprintf("external-bench/%s", collName)
+
+	// Use smaller dataset for type coverage test
+	numRows := env.cfg.TotalRows
+	if numRows > 100_000 {
+		numRows = 100_000
+	}
+
+	data, err := generateMultiTypeParquetBytes(numRows, 0)
+	require.NoError(t, err)
+	objectKey := fmt.Sprintf("%s/data.parquet", extPath)
+	uploadParquetToMinIO(t, env.ctx, env.minioClient, env.minioCfg.bucket, objectKey, data)
+
+	t.Cleanup(func() {
+		cleanupMinIOPrefix(context.Background(), env.minioClient, env.minioCfg.bucket, extPath+"/")
+		_ = env.mc.DropCollection(context.Background(), client.NewDropCollectionOption(collName))
+	})
+
+	schema := entity.NewSchema().
+		WithName(collName).
+		WithExternalSource(extPath).
+		WithExternalSpec(`{"format":"parquet"}`).
+		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithExternalField("id")).
+		WithField(entity.NewField().WithName("bool_val").WithDataType(entity.FieldTypeBool).WithExternalField("bool_val")).
+		WithField(entity.NewField().WithName("int8_val").WithDataType(entity.FieldTypeInt8).WithExternalField("int8_val")).
+		WithField(entity.NewField().WithName("int16_val").WithDataType(entity.FieldTypeInt16).WithExternalField("int16_val")).
+		WithField(entity.NewField().WithName("int32_val").WithDataType(entity.FieldTypeInt32).WithExternalField("int32_val")).
+		WithField(entity.NewField().WithName("float_val").WithDataType(entity.FieldTypeFloat).WithExternalField("float_val")).
+		WithField(entity.NewField().WithName("double_val").WithDataType(entity.FieldTypeDouble).WithExternalField("double_val")).
+		WithField(entity.NewField().WithName("varchar_val").WithDataType(entity.FieldTypeVarChar).WithMaxLength(64).WithExternalField("varchar_val")).
+		WithField(entity.NewField().WithName("embedding").WithDataType(entity.FieldTypeFloatVector).WithDim(testVecDim).WithExternalField("embedding"))
+
+	err = env.mc.CreateCollection(env.ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, true)
+
+	// Refresh
+	start := time.Now()
+	refreshAndWait(env.ctx, t, env.mc, collName)
+	refreshDuration := time.Since(start)
+	t.Logf("=== B20_Refresh === rows=%d fields=9 duration=%v", numRows, refreshDuration)
+	recordSingleMeasurement(t, "B20_Refresh_MultiType", refreshDuration, fmt.Sprintf("rows=%d fields=9", numRows))
+
+	// Index + Load
+	indexAndLoadCollection(env.ctx, t, env.mc, collName, "embedding")
+
+	// Count
+	measureLatency(t, "B20_CountQuery_MultiType", env.cfg.QueryIterations, func() {
+		res, err := env.mc.Query(env.ctx, client.NewQueryOption(collName).
+			WithConsistencyLevel(entity.ClStrong).
+			WithOutputFields(common.QueryCountFieldName))
+		common.CheckErr(t, err, true)
+		count, _ := res.GetColumn(common.QueryCountFieldName).GetAsInt64(0)
+		require.Equal(t, numRows, count)
+	})
+
+	// Bool filter
+	measureLatency(t, "B20_BoolFilter", env.cfg.QueryIterations, func() {
+		res, err := env.mc.Query(env.ctx, client.NewQueryOption(collName).
+			WithConsistencyLevel(entity.ClStrong).
+			WithFilter("bool_val == true").
+			WithOutputFields(common.QueryCountFieldName))
+		common.CheckErr(t, err, true)
+		count, _ := res.GetColumn(common.QueryCountFieldName).GetAsInt64(0)
+		require.Equal(t, numRows/2, count)
+	})
+
+	// VarChar filter
+	measureLatency(t, "B20_VarCharFilter", env.cfg.QueryIterations, func() {
+		res, err := env.mc.Query(env.ctx, client.NewQueryOption(collName).
+			WithConsistencyLevel(entity.ClStrong).
+			WithFilter(`varchar_val like "str_004%"`).
+			WithOutputFields("id"))
+		common.CheckErr(t, err, true)
+		require.Greater(t, res.GetColumn("id").Len(), 0)
+	})
+
+	// Compound filter
+	measureLatency(t, "B20_CompoundFilter", env.cfg.QueryIterations, func() {
+		res, err := env.mc.Query(env.ctx, client.NewQueryOption(collName).
+			WithConsistencyLevel(entity.ClStrong).
+			WithFilter("bool_val == true && int32_val < 5000").
+			WithOutputFields(common.QueryCountFieldName))
+		common.CheckErr(t, err, true)
+		count, _ := res.GetColumn(common.QueryCountFieldName).GetAsInt64(0)
+		require.Greater(t, count, int64(0))
+	})
+
+	// Vector search
+	vec := make([]float32, testVecDim)
+	for i := range vec {
+		vec[i] = float32(42)*0.1 + float32(i)
+	}
+	measureLatency(t, "B20_VectorSearch_MultiType", env.cfg.QueryIterations, func() {
+		searchRes, err := env.mc.Search(env.ctx, client.NewSearchOption(collName, env.cfg.TopK,
+			[]entity.Vector{entity.FloatVector(vec)}).
+			WithConsistencyLevel(entity.ClStrong).
+			WithANNSField("embedding").
+			WithOutputFields("id", "bool_val", "varchar_val"))
+		common.CheckErr(t, err, true)
+		require.Greater(t, searchRes[0].ResultCount, 0)
+	})
+
+	// Verify specific row
+	row42, err := env.mc.Query(env.ctx, client.NewQueryOption(collName).
+		WithConsistencyLevel(entity.ClStrong).
+		WithFilter("id == 42").
+		WithOutputFields("id", "bool_val", "int8_val", "int16_val", "int32_val", "float_val", "double_val", "varchar_val"))
+	common.CheckErr(t, err, true)
+	require.Equal(t, 1, row42.GetColumn("id").Len())
+
+	boolVal, _ := row42.GetColumn("bool_val").GetAsBool(0)
+	require.Equal(t, true, boolVal, "id=42 (even) → bool_val=true")
+
+	varcharVal, _ := row42.GetColumn("varchar_val").GetAsString(0)
+	require.Equal(t, "str_0042", varcharVal)
+
+	t.Log("B20: All data types verified successfully")
+}
+
+// ============================================================================
+// Report Generator — runs last alphabetically among TestBenchmarkExternal*
+// ============================================================================
+
+func TestBenchmarkExternalZZReport(t *testing.T) {
+	globalReport.writeMarkdownReport(t)
+}

--- a/tests/go_client/testcases/external_table_benchmark_test.go
+++ b/tests/go_client/testcases/external_table_benchmark_test.go
@@ -621,7 +621,7 @@ func (env *benchEnv) setupExternalCollectionWithOptions(t *testing.T, numFiles i
 		data, err := generateParquetBytesWithDim(rowsPerFile, int64(i)*rowsPerFile, dim)
 		require.NoError(t, err, "generate parquet file %d", i)
 		objectKey := fmt.Sprintf("%s/data%d.parquet", extPath, i)
-		uploadParquetToMinIO(t, env.ctx, env.minioClient, env.minioCfg.bucket, objectKey, data)
+		uploadParquetToMinIO(env.ctx, t, env.minioClient, env.minioCfg.bucket, objectKey, data)
 	}
 	t.Logf("Upload complete: %v", time.Since(uploadStart))
 
@@ -735,7 +735,7 @@ func testBenchmarkExternalRefresh(t *testing.T, env *benchEnv) {
 		data, err := generateParquetBytesWithDim(env.cfg.RowsPerFile, int64(i)*env.cfg.RowsPerFile, env.cfg.VecDim)
 		require.NoError(t, err)
 		objectKey := fmt.Sprintf("%s/data%d.parquet", extPath, i)
-		uploadParquetToMinIO(t, env.ctx, env.minioClient, env.minioCfg.bucket, objectKey, data)
+		uploadParquetToMinIO(env.ctx, t, env.minioClient, env.minioCfg.bucket, objectKey, data)
 	}
 
 	t.Cleanup(func() {
@@ -792,7 +792,7 @@ func benchIncrementalRefresh(t *testing.T, env *benchEnv) {
 		data, err := generateParquetBytesWithDim(env.cfg.RowsPerFile, int64(i)*env.cfg.RowsPerFile, env.cfg.VecDim)
 		require.NoError(t, err)
 		objectKey := fmt.Sprintf("%s/data%d.parquet", extPath, i)
-		uploadParquetToMinIO(t, env.ctx, env.minioClient, env.minioCfg.bucket, objectKey, data)
+		uploadParquetToMinIO(env.ctx, t, env.minioClient, env.minioCfg.bucket, objectKey, data)
 	}
 
 	t.Cleanup(func() {
@@ -825,7 +825,7 @@ func benchIncrementalRefresh(t *testing.T, env *benchEnv) {
 	data, err := generateParquetBytesWithDim(env.cfg.RowsPerFile, int64(newFileIdx)*env.cfg.RowsPerFile, env.cfg.VecDim)
 	require.NoError(t, err)
 	objectKey := fmt.Sprintf("%s/data%d.parquet", extPath, newFileIdx)
-	uploadParquetToMinIO(t, env.ctx, env.minioClient, env.minioCfg.bucket, objectKey, data)
+	uploadParquetToMinIO(env.ctx, t, env.minioClient, env.minioCfg.bucket, objectKey, data)
 
 	// Incremental refresh (add file)
 	start = time.Now()
@@ -861,7 +861,7 @@ func benchIndexBuilding(t *testing.T, env *benchEnv) {
 		data, err := generateParquetBytesWithDim(env.cfg.RowsPerFile, int64(i)*env.cfg.RowsPerFile, env.cfg.VecDim)
 		require.NoError(t, err)
 		objectKey := fmt.Sprintf("%s/data%d.parquet", extPath, i)
-		uploadParquetToMinIO(t, env.ctx, env.minioClient, env.minioCfg.bucket, objectKey, data)
+		uploadParquetToMinIO(env.ctx, t, env.minioClient, env.minioCfg.bucket, objectKey, data)
 	}
 
 	t.Cleanup(func() {
@@ -936,7 +936,7 @@ func benchLoadCollection(t *testing.T, env *benchEnv) {
 		data, err := generateParquetBytesWithDim(env.cfg.RowsPerFile, int64(i)*env.cfg.RowsPerFile, env.cfg.VecDim)
 		require.NoError(t, err)
 		objectKey := fmt.Sprintf("%s/data%d.parquet", extPath, i)
-		uploadParquetToMinIO(t, env.ctx, env.minioClient, env.minioCfg.bucket, objectKey, data)
+		uploadParquetToMinIO(env.ctx, t, env.minioClient, env.minioCfg.bucket, objectKey, data)
 	}
 
 	t.Cleanup(func() {
@@ -1423,7 +1423,7 @@ func benchManyFiles(t *testing.T, env *benchEnv) {
 		data, err := generateParquetBytesWithDim(rowsPerFile, int64(i)*rowsPerFile, env.cfg.VecDim)
 		require.NoError(t, err)
 		objectKey := fmt.Sprintf("%s/data%d.parquet", extPath, i)
-		uploadParquetToMinIO(t, env.ctx, env.minioClient, env.minioCfg.bucket, objectKey, data)
+		uploadParquetToMinIO(env.ctx, t, env.minioClient, env.minioCfg.bucket, objectKey, data)
 	}
 
 	t.Cleanup(func() {
@@ -1473,7 +1473,7 @@ func benchLargeSingleFile(t *testing.T, env *benchEnv) {
 	data, err := generateParquetBytesWithDim(totalRows, 0, env.cfg.VecDim)
 	require.NoError(t, err)
 	objectKey := fmt.Sprintf("%s/data.parquet", extPath)
-	uploadParquetToMinIO(t, env.ctx, env.minioClient, env.minioCfg.bucket, objectKey, data)
+	uploadParquetToMinIO(env.ctx, t, env.minioClient, env.minioCfg.bucket, objectKey, data)
 
 	t.Cleanup(func() {
 		cleanupMinIOPrefix(context.Background(), env.minioClient, env.minioCfg.bucket, extPath+"/")
@@ -1609,7 +1609,7 @@ func benchIdempotentRefresh(t *testing.T, env *benchEnv) {
 		data, err := generateParquetBytesWithDim(rowsPerFile, int64(i)*rowsPerFile, env.cfg.VecDim)
 		require.NoError(t, err)
 		objectKey := fmt.Sprintf("%s/data%d.parquet", extPath, i)
-		uploadParquetToMinIO(t, env.ctx, env.minioClient, env.minioCfg.bucket, objectKey, data)
+		uploadParquetToMinIO(env.ctx, t, env.minioClient, env.minioCfg.bucket, objectKey, data)
 	}
 
 	t.Cleanup(func() {
@@ -1683,7 +1683,7 @@ func benchMultiDataTypes(t *testing.T, env *benchEnv) {
 	data, err := generateMultiTypeParquetBytes(numRows, 0)
 	require.NoError(t, err)
 	objectKey := fmt.Sprintf("%s/data.parquet", extPath)
-	uploadParquetToMinIO(t, env.ctx, env.minioClient, env.minioCfg.bucket, objectKey, data)
+	uploadParquetToMinIO(env.ctx, t, env.minioClient, env.minioCfg.bucket, objectKey, data)
 
 	t.Cleanup(func() {
 		cleanupMinIOPrefix(context.Background(), env.minioClient, env.minioCfg.bucket, extPath+"/")

--- a/tests/go_client/testcases/external_table_refresh_test.go
+++ b/tests/go_client/testcases/external_table_refresh_test.go
@@ -1668,3 +1668,176 @@ func TestExternalCollectionVortexFormat(t *testing.T) {
 
 	t.Log("Vortex format external collection test passed!")
 }
+
+// TestExternalCollectionFloat32ListVector verifies that external collections
+// whose files store vectors as FixedSizeList<Float32, dim> (native float list)
+// can be refreshed, indexed, loaded, and queried correctly.
+// Currently only Parquet is tested because Parquet readers return native Arrow
+// types regardless of the output schema.  Vortex and Lance require schema-level
+// changes to support float32 list vectors (tracked separately).
+func TestExternalCollectionFloat32ListVector(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*600)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	// Connect to MinIO
+	minioCfg := getMinIOConfig()
+	minioClient, err := newMinIOClient(minioCfg)
+	if err != nil {
+		t.Skipf("Failed to create MinIO client, skipping: %v", err)
+	}
+	exists, err := minioClient.BucketExists(ctx, minioCfg.bucket)
+	if err != nil || !exists {
+		t.Skipf("MinIO bucket %q not accessible, skipping", minioCfg.bucket)
+	}
+
+	const numRows = 2000
+
+	type formatCase struct {
+		name      string
+		specJSON  string
+		setupData func(t *testing.T, extPath string)
+		cleanup   func(extPath string)
+	}
+
+	formats := []formatCase{
+		{
+			name:     "parquet",
+			specJSON: `{"format":"parquet"}`,
+			setupData: func(t *testing.T, extPath string) {
+				t.Helper()
+				data, genErr := generateParquetBytes(numRows, 0)
+				require.NoError(t, genErr, "generate parquet")
+				objectKey := fmt.Sprintf("%s/data.parquet", extPath)
+				_, putErr := minioClient.PutObject(ctx, minioCfg.bucket, objectKey,
+					bytes.NewReader(data), int64(len(data)),
+					miniogo.PutObjectOptions{ContentType: "application/octet-stream"})
+				require.NoError(t, putErr, "upload parquet to MinIO")
+				t.Logf("Uploaded %s/%s (%d bytes, %d rows)", minioCfg.bucket, objectKey, len(data), numRows)
+			},
+			cleanup: func(extPath string) {
+				cleanupMinIOPrefix(context.Background(), minioClient, minioCfg.bucket, extPath+"/")
+			},
+		},
+	}
+
+	for _, fc := range formats {
+		fc := fc // capture for subtest closure
+		t.Run(fc.name, func(t *testing.T) {
+			// Replace hyphens with underscores for valid collection names
+			safePrefix := strings.ReplaceAll(fc.name, "-", "_")
+			collName := common.GenRandomString("ext_f32_"+safePrefix, 6)
+			extPath := fmt.Sprintf("external-e2e-test/%s", collName)
+
+			// Step 1: Generate and upload data
+			fc.setupData(t, extPath)
+			t.Cleanup(func() { fc.cleanup(extPath) })
+
+			// Step 2: Create external collection
+			schema := entity.NewSchema().
+				WithName(collName).
+				WithExternalSource(extPath).
+				WithExternalSpec(fc.specJSON).
+				WithField(entity.NewField().
+					WithName("id").
+					WithDataType(entity.FieldTypeInt64).
+					WithExternalField("id")).
+				WithField(entity.NewField().
+					WithName("value").
+					WithDataType(entity.FieldTypeFloat).
+					WithExternalField("value")).
+				WithField(entity.NewField().
+					WithName("embedding").
+					WithDataType(entity.FieldTypeFloatVector).
+					WithDim(testVecDim).
+					WithExternalField("embedding"))
+
+			err := mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
+			common.CheckErr(t, err, true)
+			t.Logf("Created external collection [%s]: %s", fc.name, collName)
+
+			t.Cleanup(func() {
+				_ = mc.DropCollection(context.Background(), client.NewDropCollectionOption(collName))
+			})
+
+			// Step 3: Refresh and wait
+			refreshAndWait(t, mc, ctx, collName)
+
+			// Verify row count via stats
+			stats, err := mc.GetCollectionStats(ctx, client.NewGetCollectionStatsOption(collName))
+			common.CheckErr(t, err, true)
+			rowCountStr, ok := stats["row_count"]
+			require.True(t, ok, "stats should contain row_count")
+			rowCount, err := strconv.ParseInt(rowCountStr, 10, 64)
+			require.NoError(t, err)
+			require.Equal(t, int64(numRows), rowCount,
+				"row_count should match uploaded data")
+			t.Logf("Refresh complete: row_count=%d", rowCount)
+
+			// Step 4: Index + Load
+			indexAndLoadCollectionWithScalarAndVector(t, mc, ctx, collName, int64(numRows))
+
+			// Step 5: Query count(*)
+			countRes, err := mc.Query(ctx, client.NewQueryOption(collName).
+				WithConsistencyLevel(entity.ClStrong).
+				WithOutputFields(common.QueryCountFieldName))
+			common.CheckErr(t, err, true)
+			count, err := countRes.GetColumn(common.QueryCountFieldName).GetAsInt64(0)
+			require.NoError(t, err)
+			require.Equal(t, int64(numRows), count,
+				"count(*) should match uploaded rows")
+			t.Logf("count(*) = %d", count)
+
+			// Step 6: Query with filter + output fields
+			filterRes, err := mc.Query(ctx, client.NewQueryOption(collName).
+				WithConsistencyLevel(entity.ClStrong).
+				WithFilter("id < 100").
+				WithOutputFields("id", "value"))
+			common.CheckErr(t, err, true)
+			require.Equal(t, 100, filterRes.GetColumn("id").Len(),
+				"filter id < 100 should return 100 rows")
+			t.Logf("Query with filter returned %d rows", filterRes.GetColumn("id").Len())
+
+			// Verify a specific value (id=42 → value=42*1.5=63.0)
+			val42, err := filterRes.GetColumn("value").GetAsDouble(42)
+			require.NoError(t, err)
+			require.InDelta(t, float64(42)*1.5, val42, 0.01,
+				"value for id=42 should be 63.0")
+
+			// Step 7: Vector search
+			vec := make([]float32, testVecDim)
+			for i := range vec {
+				vec[i] = float32(i) * 0.1 // matches id=0's embedding
+			}
+			searchRes, err := mc.Search(ctx, client.NewSearchOption(collName, 5,
+				[]entity.Vector{entity.FloatVector(vec)}).
+				WithConsistencyLevel(entity.ClStrong).
+				WithANNSField("embedding").
+				WithOutputFields("id", "value"))
+			common.CheckErr(t, err, true)
+			require.Equal(t, 1, len(searchRes), "1 result set for 1 query vector")
+			require.Greater(t, searchRes[0].ResultCount, 0, "search should return results")
+			nearestID, _ := searchRes[0].GetColumn("id").GetAsInt64(0)
+			t.Logf("Search nearest: id=%d", nearestID)
+
+			// Step 8: Hybrid search (vector + filter)
+			hybridRes, err := mc.Search(ctx, client.NewSearchOption(collName, 5,
+				[]entity.Vector{entity.FloatVector(vec)}).
+				WithConsistencyLevel(entity.ClStrong).
+				WithANNSField("embedding").
+				WithFilter("id >= 500 && id < 1500").
+				WithOutputFields("id"))
+			common.CheckErr(t, err, true)
+			require.Equal(t, 1, len(hybridRes))
+			require.Greater(t, hybridRes[0].ResultCount, 0, "hybrid search should return results")
+			hybridIDCol := hybridRes[0].GetColumn("id")
+			for i := 0; i < hybridIDCol.Len(); i++ {
+				val, _ := hybridIDCol.GetAsInt64(i)
+				require.GreaterOrEqual(t, val, int64(500), "id should be >= 500")
+				require.Less(t, val, int64(1500), "id should be < 1500")
+			}
+			t.Logf("Hybrid search (id in [500,1500)) returned %d results", hybridRes[0].ResultCount)
+
+			t.Logf("[%s] All checks passed!", fc.name)
+		})
+	}
+}

--- a/tests/go_client/testcases/external_table_refresh_test.go
+++ b/tests/go_client/testcases/external_table_refresh_test.go
@@ -1760,7 +1760,7 @@ func TestExternalCollectionFloat32ListVector(t *testing.T) {
 			})
 
 			// Step 3: Refresh and wait
-			refreshAndWait(t, mc, ctx, collName)
+			refreshAndWait(ctx, t, mc, collName)
 
 			// Verify row count via stats
 			stats, err := mc.GetCollectionStats(ctx, client.NewGetCollectionStatsOption(collName))
@@ -1774,7 +1774,7 @@ func TestExternalCollectionFloat32ListVector(t *testing.T) {
 			t.Logf("Refresh complete: row_count=%d", rowCount)
 
 			// Step 4: Index + Load
-			indexAndLoadCollectionWithScalarAndVector(t, mc, ctx, collName, int64(numRows))
+			indexAndLoadCollectionWithScalarAndVector(ctx, t, mc, collName, int64(numRows))
 
 			// Step 5: Query count(*)
 			countRes, err := mc.Query(ctx, client.NewQueryOption(collName).


### PR DESCRIPTION
## Summary

- Add `Reader::take()` API for small result sets (<10K rows), bypassing full column materialization during retrieve and search — significantly reducing latency for point queries and low-topK searches on external collections
- Extract shared helpers (`ArrowToDataArray`, `BuildTakeContext`, `ExecuteTake`) to eliminate type-switch duplication between retrieve and search paths
- Move `NormalizeVectorArraysToFixedSizeBinary` to `storage/Util` for reuse across `ManifestGroupTranslator` and take() path
- Add eager refresh job state persistence to eliminate race window where `HasActiveJob` sees `InProgress` while all tasks completed
- Add 20 C++ unit tests covering all data types, error paths, virtual PK, and edge cases
- Add E2E benchmark framework and refresh test enhancements

Also includes [ExternalTable Part5] which enables loading and querying external collections (schema validation, segment loading, brute-force search, virtual PK support).

issue: https://github.com/milvus-io/milvus/issues/45881

## Test plan

- [ ] C++ unit tests: `test_external_take` (20 tests covering all data types, error paths, virtual PK, edge cases)
- [ ] E2E benchmark tests: `external_table_benchmark_test.go` (retrieve/search latency, scalability)
- [ ] E2E refresh tests: enhanced `external_table_refresh_test.go` (eager state persistence, concurrent refresh)
- [ ] Verify retrieve with small result sets uses take() fast path
- [ ] Verify search with low topK uses take() fast path
- [ ] Verify fallback to full materialization for large result sets