### PR TITLE
fix: skip TLS hostname verification for internal proxy-to-proxy forwarding during upgrade

### DIFF
--- a/internal/distributed/streaming/forward.go
+++ b/internal/distributed/streaming/forward.go
@@ -219,7 +219,7 @@ func getDialOptions(rb resolver.Builder) []grpc.DialOption {
 	opts = append(opts, grpc.WithResolvers(rb))
 
 	if paramtable.Get().ProxyGrpcServerCfg.TLSMode.GetAsInt() == 1 || paramtable.Get().ProxyGrpcServerCfg.TLSMode.GetAsInt() == 2 {
-		opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{})))
+		opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{InsecureSkipVerify: true})))
 	} else {
 		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	}


### PR DESCRIPTION
The forward service's gRPC client used an empty tls.Config{}, causing TLS handshake failures when the resolver-provided ServerName ("proxy") didn't match the server certificate's SAN. Since this is a temporary internal connection only used during 2.5→2.6 rolling upgrades, skip certificate verification to avoid the mismatch.

issue: #48224
pr: #48225