### PR TITLE
fix: add shard-aware bucket names to storage unit tests

### DIFF
--- a/internal/core/src/storage/RemoteChunkManagerTest.cpp
+++ b/internal/core/src/storage/RemoteChunkManagerTest.cpp
@@ -20,9 +20,16 @@ using namespace std;
 using namespace milvus;
 using namespace milvus::storage;
 
+// Append GTEST_SHARD_INDEX to bucket name to avoid conflicts when
+// multiple shards run in parallel against the same MinIO instance.
 const string
 get_default_bucket_name() {
-    return "a-bucket";
+    std::string base = "a-bucket";
+    const char* shard = std::getenv("GTEST_SHARD_INDEX");
+    if (shard) {
+        return base + "-s" + std::string(shard);
+    }
+    return base;
 }
 
 StorageConfig

--- a/internal/core/src/storage/azure/AzureChunkManagerTest.cpp
+++ b/internal/core/src/storage/azure/AzureChunkManagerTest.cpp
@@ -55,7 +55,13 @@ get_default_storage_config(bool useIam) {
     auto useSSL = false;
     auto sslCACert = "";
     auto iamEndPoint = "";
-    auto bucketName = "a-bucket";
+    // Append GTEST_SHARD_INDEX to bucket name to avoid conflicts when
+    // multiple shards run in parallel against the same Azurite instance.
+    std::string bucketName = "a-bucket";
+    const char* shard = std::getenv("GTEST_SHARD_INDEX");
+    if (shard) {
+        bucketName += "-s" + std::string(shard);
+    }
 
     return StorageConfig{endpoint,
                          bucketName,
@@ -119,7 +125,7 @@ TEST_F(AzureChunkManagerTest, BasicFunctions) {
 }
 
 TEST_F(AzureChunkManagerTest, BucketPositive) {
-    string testBucketName = "test-bucket";
+    string testBucketName = configs_.bucket_name;
     bool exist = chunk_manager_->BucketExists(testBucketName);
     EXPECT_EQ(exist, false);
     chunk_manager_->CreateBucket(testBucketName);
@@ -131,7 +137,8 @@ TEST_F(AzureChunkManagerTest, BucketPositive) {
 }
 
 TEST_F(AzureChunkManagerTest, BucketNegtive) {
-    string testBucketName = "test-bucket-ng";
+    // Use config bucket name with shard suffix to avoid conflicts in parallel shards
+    string testBucketName = configs_.bucket_name + "-ng";
     try {
         chunk_manager_->DeleteBucket(testBucketName);
     } catch (SegcoreError& e) {

--- a/internal/core/src/storage/gcp-native-storage/GcpNativeChunkManagerTest.cpp
+++ b/internal/core/src/storage/gcp-native-storage/GcpNativeChunkManagerTest.cpp
@@ -21,6 +21,17 @@ using namespace std;
 using namespace milvus;
 using namespace milvus::storage;
 
+// Append GTEST_SHARD_INDEX to bucket name to avoid conflicts when
+// multiple shards run in parallel against the same fake-GCS instance.
+static std::string
+shardBucketName(const std::string& base) {
+    const char* shard = std::getenv("GTEST_SHARD_INDEX");
+    if (shard) {
+        return base + "-s" + std::string(shard);
+    }
+    return base;
+}
+
 StorageConfig
 get_default_storage_config() {
     auto endpoint = "storage.gcs.127.0.0.1.nip.io:4443";
@@ -30,7 +41,7 @@ get_default_storage_config() {
     auto use_ssl = false;
     auto ssl_ca_cert = "";
     auto iam_endpoint = "";
-    auto bucket_name = "sample-bucket";
+    auto bucket_name = shardBucketName("sample-bucket");
     bool use_iam = false;
     bool gcp_native_without_auth = true;
 
@@ -80,7 +91,7 @@ TEST_F(GcpNativeChunkManagerTest, BasicFunctions) {
 }
 
 TEST_F(GcpNativeChunkManagerTest, BucketPositive) {
-    string test_bucket_name = "bucket-not-exist";
+    string test_bucket_name = shardBucketName("bucket-not-exist");
     EXPECT_EQ(chunk_manager_->BucketExists(test_bucket_name), false);
     EXPECT_EQ(chunk_manager_->CreateBucket(test_bucket_name), true);
     EXPECT_EQ(chunk_manager_->BucketExists(test_bucket_name), true);

--- a/internal/core/src/storage/minio/MinioChunkManagerTest.cpp
+++ b/internal/core/src/storage/minio/MinioChunkManagerTest.cpp
@@ -20,6 +20,17 @@ using namespace std;
 using namespace milvus;
 using namespace milvus::storage;
 
+// Append GTEST_SHARD_INDEX to bucket name to avoid conflicts when
+// multiple shards run in parallel against the same MinIO instance.
+static std::string
+shardBucketName(const std::string& base) {
+    const char* shard = std::getenv("GTEST_SHARD_INDEX");
+    if (shard) {
+        return base + "-s" + std::string(shard);
+    }
+    return base;
+}
+
 class MinioChunkManagerTest : public testing::Test {
  public:
     MinioChunkManagerTest() {
@@ -30,6 +41,8 @@ class MinioChunkManagerTest : public testing::Test {
     virtual void
     SetUp() {
         configs_ = StorageConfig{};
+        // Append shard index to default bucket name for parallel safety
+        configs_.bucket_name = shardBucketName(configs_.bucket_name);
         chunk_manager_ = std::make_unique<MinioChunkManager>(configs_);
     }
 
@@ -93,7 +106,7 @@ TEST_F(MinioChunkManagerTest, InitFailed) {
 }
 
 TEST_F(MinioChunkManagerTest, BucketPositive) {
-    string testBucketName = "test-bucket";
+    string testBucketName = shardBucketName("test-bucket");
     chunk_manager_->SetBucketName(testBucketName);
     bool exist = chunk_manager_->BucketExists(testBucketName);
     EXPECT_EQ(exist, false);
@@ -104,7 +117,7 @@ TEST_F(MinioChunkManagerTest, BucketPositive) {
 }
 
 TEST_F(MinioChunkManagerTest, BucketNegtive) {
-    string testBucketName = "test-bucket-ng";
+    string testBucketName = shardBucketName("test-bucket-ng");
     chunk_manager_->SetBucketName(testBucketName);
     chunk_manager_->DeleteBucket(testBucketName);
 
@@ -236,7 +249,7 @@ TEST_F(MinioChunkManagerTest, ReadNotExist) {
 }
 
 TEST_F(MinioChunkManagerTest, RemovePositive) {
-    string testBucketName = "test-remove";
+    string testBucketName = shardBucketName("test-remove");
     chunk_manager_->SetBucketName(testBucketName);
     EXPECT_EQ(chunk_manager_->GetBucketName(), testBucketName);
 
@@ -264,7 +277,7 @@ TEST_F(MinioChunkManagerTest, RemovePositive) {
 }
 
 TEST_F(MinioChunkManagerTest, ListWithPrefixPositive) {
-    string testBucketName = "test-listprefix";
+    string testBucketName = shardBucketName("test-listprefix");
     chunk_manager_->SetBucketName(testBucketName);
     EXPECT_EQ(chunk_manager_->GetBucketName(), testBucketName);
 


### PR DESCRIPTION
## Summary
- When running C++ unit tests with `GTEST_TOTAL_SHARDS` (parallel sharding), multiple test processes share the same storage emulator (MinIO/Azurite/fake-GCS)
- Tests that create/delete buckets with hardcoded names (e.g., `"test-bucket"`, `"a-bucket"`) race against each other, causing flaky failures like "bucket already exists" or "bucket not found"
- Fix by appending `GTEST_SHARD_INDEX` to all bucket names used in tests. When not sharding (`GTEST_SHARD_INDEX` not set), behavior is unchanged

## Affected test suites
- `AzureChunkManagerTest` — Azurite buckets
- `MinioChunkManagerTest` — MinIO buckets
- `RemoteChunkManagerTest` — MinIO buckets
- `GcpNativeChunkManagerTest` — fake-GCS buckets

## Test plan
- [ ] Verify tests pass without sharding (no env var set — unchanged behavior)
- [ ] Verify tests pass with `GTEST_TOTAL_SHARDS=4` parallel execution
- [ ] Confirm no bucket name collision errors in CI parallel runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)