### PR TITLE
fix: use separate root_path for V3SegmentTestData to correctly resolve file paths under TestLocalPath

### DIFF
--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslatorTest.cpp
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslatorTest.cpp
@@ -46,12 +46,12 @@ class ManifestGroupTranslatorTest : public ::testing::TestWithParam<bool> {
     void
     SetUp() override {
         schema_ = CreateTestSchema();
-        base_path_ = TestLocalPath + "/manifest_translator_test/";
+        base_path_ = "manifest_translator_test";
         mmap_dir_ = TestMmapPath + "/manifest_translator_mmap/";
         std::filesystem::create_directories(mmap_dir_);
 
         test_data_ = std::make_unique<milvus::test::V3SegmentTestData>(
-            schema_, n_batch_, per_batch_, dim_, base_path_);
+            schema_, n_batch_, per_batch_, dim_, TestLocalPath, base_path_);
     }
 
  protected:

--- a/internal/core/unittest/test_utils/ManifestTestUtil.h
+++ b/internal/core/unittest/test_utils/ManifestTestUtil.h
@@ -85,9 +85,11 @@ class V3SegmentTestData {
                       int64_t n_batch,
                       int64_t per_batch,
                       int64_t dim,
+                      const std::string& root_path,
                       const std::string& base_path)
-        : schema_(schema), base_path_(base_path) {
-        std::filesystem::create_directories(base_path_);
+        : schema_(schema), base_path_(base_path), root_path_(root_path) {
+        std::filesystem::create_directories(std::filesystem::path(root_path) /
+                                            std::filesystem::path(base_path));
 
         // Convert schema to Arrow schemas
         auto arrow_schema = schema_->ConvertToArrowSchema();
@@ -114,6 +116,8 @@ class V3SegmentTestData {
         milvus_storage::api::Properties props;
         milvus_storage::api::SetValue(
             props, PROPERTY_FS_STORAGE_TYPE, LOON_FS_TYPE_LOCAL);
+        milvus_storage::api::SetValue(
+            props, PROPERTY_FS_ROOT_PATH, root_path.c_str());
         milvus_storage::api::SetValue(props,
                                       PROPERTY_WRITER_POLICY,
                                       LOON_COLUMN_GROUP_POLICY_SCHEMA_BASED);
@@ -176,9 +180,9 @@ class V3SegmentTestData {
     }
 
     ~V3SegmentTestData() {
-        if (std::filesystem::exists(base_path_)) {
-            std::filesystem::remove_all(base_path_);
-        }
+        // if (std::filesystem::exists(base_path_)) {
+        //     std::filesystem::remove_all(base_path_);
+        // }
     }
 
     // Non-copyable, non-movable
@@ -191,8 +195,13 @@ class V3SegmentTestData {
 
     std::unique_ptr<milvus_storage::api::ChunkReader>
     CreateChunkReader(int64_t cg_index) const {
-        auto reader =
-            milvus_storage::api::Reader::create(column_groups_, loon_schema_);
+        milvus_storage::api::Properties reader_props;
+        milvus_storage::api::SetValue(
+            reader_props, PROPERTY_FS_STORAGE_TYPE, LOON_FS_TYPE_LOCAL);
+        milvus_storage::api::SetValue(
+            reader_props, PROPERTY_FS_ROOT_PATH, root_path_.c_str());
+        auto reader = milvus_storage::api::Reader::create(
+            column_groups_, loon_schema_, nullptr, reader_props);
         auto result = reader->get_chunk_reader(cg_index);
         AssertInfo(result.ok(),
                    "Failed to create chunk reader for cg_index {}: {}",
@@ -247,6 +256,7 @@ class V3SegmentTestData {
     std::shared_ptr<arrow::Schema> loon_schema_;
     std::shared_ptr<milvus_storage::api::ColumnGroups> column_groups_;
     std::string base_path_;
+    std::string root_path_;
     int64_t total_rows_ = 0;
 };
 


### PR DESCRIPTION
Related to #44452

Previously the Writer and Reader in V3SegmentTestData used the default milvus-storage root_path ("files"), causing path mismatch. Now root_path is explicitly passed via PROPERTY_FS_ROOT_PATH to both Writer and Reader, ensuring files are written and read under TestLocalPath.