### PR TITLE
fix: split macOS RPATH into separate -r flags for linker compatibility

### DIFF
--- a/scripts/setenv.sh
+++ b/scripts/setenv.sh
@@ -109,7 +109,7 @@ case "${unameOut}" in
 
       export PKG_CONFIG_PATH="${PKG_CONFIG_PATH:-}:$ROOT_DIR/internal/core/output/lib/pkgconfig"
       export DYLD_LIBRARY_PATH=$ROOT_DIR/cmake_build/lib:$ROOT_DIR/internal/core/output/lib
-      export RPATH=$DYLD_LIBRARY_PATH;;
+      export RPATH=$(echo "$DYLD_LIBRARY_PATH" | sed 's/:/ -r /g');;
     MINGW*)
       extra_path=$(cygpath -w "$ROOT_DIR/internal/core/output/lib")
       export PKG_CONFIG_PATH="${PKG_CONFIG_PATH:+$PKG_CONFIG_PATH;}${extra_path}\pkgconfig"


### PR DESCRIPTION
## Summary
- macOS `ld` treats each `-r` flag as a single directory path, unlike Linux `ld` which accepts colon-separated paths
- Since d69bdd288c added `cmake_build/lib` to `DYLD_LIBRARY_PATH`, `RPATH=$DYLD_LIBRARY_PATH` produces a colon-separated value like `path1:path2`
- The Makefile's `-r $RPATH` embeds this as a single invalid path in the binary, causing `Library not loaded: @rpath/libmilvus-storage.dylib` at runtime
- Fix: emit two separate `-r` flags so the Makefile expands to `-r path1 -r path2`

## Test plan
- [x] Verified `RPATH` variable output: `path1 -r path2` (correct)
- [x] Verified binary loads correctly after fix (`otool -l` shows two separate `LC_RPATH` entries)
- [x] Verified Milvus standalone starts and serves requests successfully

issue: #47809