### PR TITLE
fix: fix flaky TestCheckCtxValid and TestProxy port binding

### DIFF
--- a/internal/proxy/proxy_rpc_test.go
+++ b/internal/proxy/proxy_rpc_test.go
@@ -44,11 +44,11 @@ func TestProxyRpcLimit(t *testing.T) {
 	assert.NotNil(t, proxy)
 
 	testServer := newProxyTestServer(proxy)
-	testServer.Proxy.SetAddress(p.GetAddress())
 	go testServer.startGrpc(ctx, &p)
 	assert.NoError(t, testServer.waitForGrpcReady())
+	testServer.Proxy.SetAddress(testServer.lisAddr)
 	defer testServer.grpcServer.Stop()
-	client, err := grpcproxyclient.NewClient(ctx, "localhost:"+p.Port.GetValue(), 1)
+	client, err := grpcproxyclient.NewClient(ctx, testServer.lisAddr, 1)
 	assert.NoError(t, err)
 	proxy.UpdateStateCode(commonpb.StateCode_Healthy)
 

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -212,6 +212,7 @@ type proxyTestServer struct {
 	*Proxy
 	grpcServer *grpc.Server
 	ch         chan error
+	lisAddr    string // actual listen address (set after startGrpc binds to :0)
 }
 
 func newProxyTestServer(node *Proxy) *proxyTestServer {
@@ -252,13 +253,14 @@ func (s *proxyTestServer) startGrpc(ctx context.Context, p *paramtable.GrpcServe
 	}
 
 	log.Debug("Proxy server listen on tcp", zap.Int("port", p.Port.GetAsInt()))
-	lis, err := net.Listen("tcp", ":"+p.Port.GetValue())
+	lis, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
-		log.Warn("Proxy server failed to listen on", zap.Error(err), zap.Int("port", p.Port.GetAsInt()))
+		log.Warn("Proxy server failed to listen on", zap.Error(err))
 		s.ch <- err
 		return
 	}
-	log.Debug("Proxy server already listen on tcp", zap.Int("port", p.Port.GetAsInt()))
+	s.lisAddr = lis.Addr().String()
+	log.Debug("Proxy server listening on", zap.String("addr", s.lisAddr))
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -984,11 +986,10 @@ func TestProxy(t *testing.T) {
 	base.Init(bt)
 	var p paramtable.GrpcServerConfig
 	p.Init(typeutil.ProxyRole, bt)
-	testServer.Proxy.SetAddress(p.GetAddress())
-	assert.Equal(t, p.GetAddress(), testServer.Proxy.GetAddress())
 
 	go testServer.startGrpc(ctx, &p)
 	assert.NoError(t, testServer.waitForGrpcReady())
+	testServer.Proxy.SetAddress(testServer.lisAddr)
 
 	rootCoordClient, err := mixc.NewClient(ctx)
 	assert.NoError(t, err)

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -252,7 +252,7 @@ func (s *proxyTestServer) startGrpc(ctx context.Context, p *paramtable.GrpcServe
 		Timeout: 10 * time.Second, // Wait 10 second for the ping ack before assuming the connection is dead
 	}
 
-	log.Debug("Proxy server listen on tcp", zap.Int("port", p.Port.GetAsInt()))
+	log.Debug("Proxy server about to listen on localhost:0")
 	lis, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		log.Warn("Proxy server failed to listen on", zap.Error(err))
@@ -990,6 +990,7 @@ func TestProxy(t *testing.T) {
 	go testServer.startGrpc(ctx, &p)
 	assert.NoError(t, testServer.waitForGrpcReady())
 	testServer.Proxy.SetAddress(testServer.lisAddr)
+	assert.Equal(t, testServer.lisAddr, testServer.Proxy.GetAddress())
 
 	rootCoordClient, err := mixc.NewClient(ctx)
 	assert.NoError(t, err)

--- a/pkg/util/funcutil/func_test.go
+++ b/pkg/util/funcutil/func_test.go
@@ -252,12 +252,13 @@ func TestGetCollectionIDFromVChannel(t *testing.T) {
 func TestCheckCtxValid(t *testing.T) {
 	bgCtx := context.Background()
 	timeout := 20 * time.Millisecond
-	deltaTime := 5 * time.Millisecond
+
 	ctx1, cancel1 := context.WithTimeout(bgCtx, timeout)
 	defer cancel1()
 	assert.True(t, CheckCtxValid(ctx1))
-	time.Sleep(timeout + deltaTime)
-	assert.False(t, CheckCtxValid(ctx1))
+	assert.Eventually(t, func() bool {
+		return !CheckCtxValid(ctx1)
+	}, time.Second, time.Millisecond)
 
 	ctx2, cancel2 := context.WithTimeout(bgCtx, timeout)
 	assert.True(t, CheckCtxValid(ctx2))
@@ -268,8 +269,9 @@ func TestCheckCtxValid(t *testing.T) {
 	ctx3, cancel3 := context.WithDeadline(bgCtx, futureTime)
 	defer cancel3()
 	assert.True(t, CheckCtxValid(ctx3))
-	time.Sleep(timeout + deltaTime)
-	assert.False(t, CheckCtxValid(ctx3))
+	assert.Eventually(t, func() bool {
+		return !CheckCtxValid(ctx3)
+	}, time.Second, time.Millisecond)
 }
 
 func TestCheckPortAvailable(t *testing.T) {


### PR DESCRIPTION
## Summary
- **TestCheckCtxValid**: replace `time.Sleep(25ms)` with `assert.Eventually` to eliminate timing dependency — 5ms margin between sleep and context deadline was too tight on busy CI nodes (build-ut-ciloop #91)
- **TestProxy/TestProxyRpcLimit**: bind to `localhost:0` instead of hardcoded port 19530 to avoid TCP TIME_WAIT conflicts when ciloop reruns tests (build-ut-ciloop #123)

## Test plan
- [x] TestCheckCtxValid: 500/500 passed post-fix
- [ ] TestProxy: syntax verified (gofmt OK), CI will validate full compilation

issue: https://github.com/milvus-io/milvus/issues/48118

🤖 Generated with [Claude Code](https://claude.com/claude-code)