### PR TITLE
feat: add scalar index version management with MaxVersion support

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -653,6 +653,11 @@ dataCoord:
   # if param forceRebuildSegmentIndex is not enabled, the newly created vector index will be aligned with the newer one of index engine's version and targetVecIndexVersion.
   # if param targetVecIndexVersion is not set, the default value is -1, which means no target vec index version, then the vector index will be aligned with index engine's version 
   targetVecIndexVersion: -1
+  forceRebuildScalarSegmentIndex: false # force rebuild scalar segment index to specified scalar index engine's version
+  # if param forceRebuildScalarSegmentIndex is enabled, the scalar index will be rebuilt to aligned with targetScalarIndexVersion.
+  # if param forceRebuildScalarSegmentIndex is not enabled, the newly created scalar index will be aligned with the newer one of scalar index engine's version and targetScalarIndexVersion.
+  # if param targetScalarIndexVersion is not set, the default value is -1, which means no target scalar index version, then the scalar index will be aligned with scalar index engine's version
+  targetScalarIndexVersion: -1
   segmentFlushInterval: 2 # the minimal interval duration(unit: Seconds) between flushing operation on same segment
   # Switch value to control if to enable segment compaction.
   # Compaction merges small-size segments into a large segment, and clears the entities deleted beyond the rentention duration of Time Travel.

--- a/internal/datacoord/compaction_task_mix.go
+++ b/internal/datacoord/compaction_task_mix.go
@@ -381,7 +381,7 @@ func (t *mixCompactionTask) BuildCompactionRequest() (*datapb.CompactionPlan, er
 		SlotUsage:                 t.GetSlotUsage(),
 		MaxSize:                   taskProto.GetMaxSize(),
 		JsonParams:                compactionParams,
-		CurrentScalarIndexVersion: t.ievm.GetCurrentScalarIndexEngineVersion(),
+		CurrentScalarIndexVersion: t.ievm.ResolveScalarIndexVersion(),
 	}
 
 	// set analyzer resource for text match index if use ref mode

--- a/internal/datacoord/compaction_trigger.go
+++ b/internal/datacoord/compaction_trigger.go
@@ -826,7 +826,7 @@ func (t *compactionTrigger) ShouldRebuildSegmentIndex(segment *SegmentInfo) bool
 
 	// enable force rebuild index with target index version (only for vector index)
 	if Params.DataCoordCfg.ForceRebuildSegmentIndex.GetAsBool() && Params.DataCoordCfg.TargetVecIndexVersion.GetAsInt64() != -1 {
-		// index version of segment lower than current version and IndexFileKeys should have value, trigger compaction
+		resolvedVecTarget := t.indexEngineVersionManager.ResolveVecIndexVersion()
 		indexIDToSegIdxes := t.meta.indexMeta.GetSegmentIndexes(segment.CollectionID, segment.ID)
 		for _, index := range indexIDToSegIdxes {
 			if len(index.IndexFileKeys) == 0 {
@@ -842,14 +842,43 @@ func (t *compactionTrigger) ShouldRebuildSegmentIndex(segment *SegmentInfo) bool
 				continue
 			}
 
-			if index.CurrentIndexVersion != Params.DataCoordCfg.TargetVecIndexVersion.GetAsInt32() {
+			if index.CurrentIndexVersion != resolvedVecTarget {
 				log.Info("index version is not equal to target vec index version, trigger compaction",
 					zap.Int64("segmentID", segment.ID),
 					zap.Int64("indexID", index.IndexID),
 					zap.String("indexType", indexType),
 					zap.Strings("indexFileKeys", index.IndexFileKeys),
 					zap.Int32("currentIndexVersion", index.CurrentIndexVersion),
-					zap.Int32("targetIndexVersion", Params.DataCoordCfg.TargetVecIndexVersion.GetAsInt32()))
+					zap.Int32("resolvedTargetVersion", resolvedVecTarget))
+				return true
+			}
+		}
+	}
+
+	// enable force rebuild scalar index with target scalar index version
+	if Params.DataCoordCfg.ForceRebuildScalarSegmentIndex.GetAsBool() && Params.DataCoordCfg.TargetScalarIndexVersion.GetAsInt64() != -1 {
+		resolvedScalarTarget := t.indexEngineVersionManager.ResolveScalarIndexVersion()
+		indexIDToSegIdxes := t.meta.indexMeta.GetSegmentIndexes(segment.CollectionID, segment.ID)
+		for _, index := range indexIDToSegIdxes {
+			if len(index.IndexFileKeys) == 0 {
+				continue
+			}
+
+			indexParams := t.meta.indexMeta.GetIndexParams(segment.CollectionID, index.IndexID)
+			indexType := GetIndexType(indexParams)
+			isVectorIndex := vecindexmgr.GetVecIndexMgrInstance().IsVecIndex(indexType)
+
+			if isVectorIndex {
+				continue
+			}
+
+			if index.CurrentScalarIndexVersion != resolvedScalarTarget {
+				log.Info("scalar index version != target, trigger compaction",
+					zap.Int64("segmentID", segment.ID),
+					zap.Int64("indexID", index.IndexID),
+					zap.String("indexType", indexType),
+					zap.Int32("currentScalarIndexVersion", index.CurrentScalarIndexVersion),
+					zap.Int32("resolvedTargetVersion", resolvedScalarTarget))
 				return true
 			}
 		}

--- a/internal/datacoord/index_engine_version_manager.go
+++ b/internal/datacoord/index_engine_version_manager.go
@@ -38,9 +38,17 @@ type IndexEngineVersionManager interface {
 	GetCurrentIndexEngineVersion() int32
 	GetMinimalIndexEngineVersion() int32
 
+	// Maximum version methods
+	GetMaximumIndexEngineVersion() int32
+	GetMaximumScalarIndexEngineVersion() int32
+
 	// Scalar index version methods (Milvus-defined)
 	GetCurrentScalarIndexEngineVersion() int32
 	GetMinimalScalarIndexEngineVersion() int32
+
+	// Resolve methods: compute final build version considering target override and max clamp
+	ResolveVecIndexVersion() int32
+	ResolveScalarIndexVersion() int32
 
 	GetIndexNonEncoding() bool
 
@@ -118,7 +126,9 @@ func (m *versionManagerImpl) addOrUpdate(session *sessionutil.Session) {
 		zap.String("sessionVersion", session.Version.String()),
 		zap.Int32("minimal", session.IndexEngineVersion.MinimalIndexVersion),
 		zap.Int32("current", session.IndexEngineVersion.CurrentIndexVersion),
-		zap.Int32("currentScalar", session.ScalarIndexEngineVersion.CurrentIndexVersion))
+		zap.Int32("maximum", session.IndexEngineVersion.MaximumIndexVersion),
+		zap.Int32("currentScalar", session.ScalarIndexEngineVersion.CurrentIndexVersion),
+		zap.Int32("maximumScalar", session.ScalarIndexEngineVersion.MaximumIndexVersion))
 	m.versions[session.ServerID] = session.IndexEngineVersion
 	m.scalarIndexVersions[session.ServerID] = session.ScalarIndexEngineVersion
 	m.indexNonEncoding[session.ServerID] = session.IndexNonEncoding
@@ -199,6 +209,78 @@ func (m *versionManagerImpl) GetMinimalScalarIndexEngineVersion() int32 {
 	}
 	log.Info("Merged minimal scalar index version", zap.Int32("minimal", minimal))
 	return minimal
+}
+
+func (m *versionManagerImpl) GetMaximumIndexEngineVersion() int32 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	maximum := int32(math.MaxInt32)
+	for _, version := range m.versions {
+		if version.MaximumIndexVersion == 0 {
+			continue
+		}
+		if version.MaximumIndexVersion < maximum {
+			maximum = version.MaximumIndexVersion
+		}
+	}
+	if maximum == math.MaxInt32 {
+		return math.MaxInt32
+	}
+	return maximum
+}
+
+func (m *versionManagerImpl) GetMaximumScalarIndexEngineVersion() int32 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	maximum := int32(math.MaxInt32)
+	for _, version := range m.scalarIndexVersions {
+		if version.MaximumIndexVersion == 0 {
+			continue
+		}
+		if version.MaximumIndexVersion < maximum {
+			maximum = version.MaximumIndexVersion
+		}
+	}
+	if maximum == math.MaxInt32 {
+		return math.MaxInt32
+	}
+	return maximum
+}
+
+func (m *versionManagerImpl) ResolveVecIndexVersion() int32 {
+	version := m.GetCurrentIndexEngineVersion()
+	if Params.DataCoordCfg.TargetVecIndexVersion.GetAsInt64() != -1 {
+		if Params.DataCoordCfg.ForceRebuildSegmentIndex.GetAsBool() {
+			version = Params.DataCoordCfg.TargetVecIndexVersion.GetAsInt32()
+		} else {
+			version = max(version, Params.DataCoordCfg.TargetVecIndexVersion.GetAsInt32())
+		}
+	}
+	if maxVersion := m.GetMaximumIndexEngineVersion(); version > maxVersion {
+		log.Warn("targetVecIndexVersion exceeds cluster maximum, clamping",
+			zap.Int32("target", version), zap.Int32("maximum", maxVersion))
+		version = maxVersion
+	}
+	return version
+}
+
+func (m *versionManagerImpl) ResolveScalarIndexVersion() int32 {
+	version := m.GetCurrentScalarIndexEngineVersion()
+	if Params.DataCoordCfg.TargetScalarIndexVersion.GetAsInt64() != -1 {
+		if Params.DataCoordCfg.ForceRebuildScalarSegmentIndex.GetAsBool() {
+			version = Params.DataCoordCfg.TargetScalarIndexVersion.GetAsInt32()
+		} else {
+			version = max(version, Params.DataCoordCfg.TargetScalarIndexVersion.GetAsInt32())
+		}
+	}
+	if maxVersion := m.GetMaximumScalarIndexEngineVersion(); version > maxVersion {
+		log.Warn("targetScalarIndexVersion exceeds cluster maximum, clamping",
+			zap.Int32("target", version), zap.Int32("maximum", maxVersion))
+		version = maxVersion
+	}
+	return version
 }
 
 func (m *versionManagerImpl) GetIndexNonEncoding() bool {

--- a/internal/datacoord/mock_index_engine_version_manager.go
+++ b/internal/datacoord/mock_index_engine_version_manager.go
@@ -280,6 +280,186 @@ func (_c *MockVersionManager_GetMinimalScalarIndexEngineVersion_Call) RunAndRetu
 	return _c
 }
 
+// GetMaximumIndexEngineVersion provides a mock function with no fields
+func (_m *MockVersionManager) GetMaximumIndexEngineVersion() int32 {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetMaximumIndexEngineVersion")
+	}
+
+	var r0 int32
+	if rf, ok := ret.Get(0).(func() int32); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(int32)
+	}
+
+	return r0
+}
+
+// MockVersionManager_GetMaximumIndexEngineVersion_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetMaximumIndexEngineVersion'
+type MockVersionManager_GetMaximumIndexEngineVersion_Call struct {
+	*mock.Call
+}
+
+// GetMaximumIndexEngineVersion is a helper method to define mock.On call
+func (_e *MockVersionManager_Expecter) GetMaximumIndexEngineVersion() *MockVersionManager_GetMaximumIndexEngineVersion_Call {
+	return &MockVersionManager_GetMaximumIndexEngineVersion_Call{Call: _e.mock.On("GetMaximumIndexEngineVersion")}
+}
+
+func (_c *MockVersionManager_GetMaximumIndexEngineVersion_Call) Run(run func()) *MockVersionManager_GetMaximumIndexEngineVersion_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockVersionManager_GetMaximumIndexEngineVersion_Call) Return(_a0 int32) *MockVersionManager_GetMaximumIndexEngineVersion_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockVersionManager_GetMaximumIndexEngineVersion_Call) RunAndReturn(run func() int32) *MockVersionManager_GetMaximumIndexEngineVersion_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetMaximumScalarIndexEngineVersion provides a mock function with no fields
+func (_m *MockVersionManager) GetMaximumScalarIndexEngineVersion() int32 {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetMaximumScalarIndexEngineVersion")
+	}
+
+	var r0 int32
+	if rf, ok := ret.Get(0).(func() int32); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(int32)
+	}
+
+	return r0
+}
+
+// MockVersionManager_GetMaximumScalarIndexEngineVersion_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetMaximumScalarIndexEngineVersion'
+type MockVersionManager_GetMaximumScalarIndexEngineVersion_Call struct {
+	*mock.Call
+}
+
+// GetMaximumScalarIndexEngineVersion is a helper method to define mock.On call
+func (_e *MockVersionManager_Expecter) GetMaximumScalarIndexEngineVersion() *MockVersionManager_GetMaximumScalarIndexEngineVersion_Call {
+	return &MockVersionManager_GetMaximumScalarIndexEngineVersion_Call{Call: _e.mock.On("GetMaximumScalarIndexEngineVersion")}
+}
+
+func (_c *MockVersionManager_GetMaximumScalarIndexEngineVersion_Call) Run(run func()) *MockVersionManager_GetMaximumScalarIndexEngineVersion_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockVersionManager_GetMaximumScalarIndexEngineVersion_Call) Return(_a0 int32) *MockVersionManager_GetMaximumScalarIndexEngineVersion_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockVersionManager_GetMaximumScalarIndexEngineVersion_Call) RunAndReturn(run func() int32) *MockVersionManager_GetMaximumScalarIndexEngineVersion_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ResolveVecIndexVersion provides a mock function with no fields
+func (_m *MockVersionManager) ResolveVecIndexVersion() int32 {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for ResolveVecIndexVersion")
+	}
+
+	var r0 int32
+	if rf, ok := ret.Get(0).(func() int32); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(int32)
+	}
+
+	return r0
+}
+
+// MockVersionManager_ResolveVecIndexVersion_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ResolveVecIndexVersion'
+type MockVersionManager_ResolveVecIndexVersion_Call struct {
+	*mock.Call
+}
+
+// ResolveVecIndexVersion is a helper method to define mock.On call
+func (_e *MockVersionManager_Expecter) ResolveVecIndexVersion() *MockVersionManager_ResolveVecIndexVersion_Call {
+	return &MockVersionManager_ResolveVecIndexVersion_Call{Call: _e.mock.On("ResolveVecIndexVersion")}
+}
+
+func (_c *MockVersionManager_ResolveVecIndexVersion_Call) Run(run func()) *MockVersionManager_ResolveVecIndexVersion_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockVersionManager_ResolveVecIndexVersion_Call) Return(_a0 int32) *MockVersionManager_ResolveVecIndexVersion_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockVersionManager_ResolveVecIndexVersion_Call) RunAndReturn(run func() int32) *MockVersionManager_ResolveVecIndexVersion_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ResolveScalarIndexVersion provides a mock function with no fields
+func (_m *MockVersionManager) ResolveScalarIndexVersion() int32 {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for ResolveScalarIndexVersion")
+	}
+
+	var r0 int32
+	if rf, ok := ret.Get(0).(func() int32); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(int32)
+	}
+
+	return r0
+}
+
+// MockVersionManager_ResolveScalarIndexVersion_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ResolveScalarIndexVersion'
+type MockVersionManager_ResolveScalarIndexVersion_Call struct {
+	*mock.Call
+}
+
+// ResolveScalarIndexVersion is a helper method to define mock.On call
+func (_e *MockVersionManager_Expecter) ResolveScalarIndexVersion() *MockVersionManager_ResolveScalarIndexVersion_Call {
+	return &MockVersionManager_ResolveScalarIndexVersion_Call{Call: _e.mock.On("ResolveScalarIndexVersion")}
+}
+
+func (_c *MockVersionManager_ResolveScalarIndexVersion_Call) Run(run func()) *MockVersionManager_ResolveScalarIndexVersion_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockVersionManager_ResolveScalarIndexVersion_Call) Return(_a0 int32) *MockVersionManager_ResolveScalarIndexVersion_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockVersionManager_ResolveScalarIndexVersion_Call) RunAndReturn(run func() int32) *MockVersionManager_ResolveScalarIndexVersion_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetMinimalSessionVer provides a mock function with no fields
 func (_m *MockVersionManager) GetMinimalSessionVer() semver.Version {
 	ret := _m.Called()

--- a/internal/datacoord/task_index.go
+++ b/internal/datacoord/task_index.go
@@ -300,17 +300,8 @@ func (it *indexBuildTask) prepareJobRequest(ctx context.Context, segment *Segmen
 		Value: indexNonEncoding,
 	})
 
-	currentVecIndexVersion := it.indexEngineVersionManager.GetCurrentIndexEngineVersion()
-	// if specify target vec index version, use it with high priority
-	if Params.DataCoordCfg.TargetVecIndexVersion.GetAsInt64() != -1 {
-		// if force rebuild segment index is true, use target vec index version directly
-		if Params.DataCoordCfg.ForceRebuildSegmentIndex.GetAsBool() {
-			currentVecIndexVersion = Params.DataCoordCfg.TargetVecIndexVersion.GetAsInt32()
-		} else {
-			// if force rebuild segment index is not enabled, use newer index version between current index version and target index version
-			currentVecIndexVersion = max(currentVecIndexVersion, Params.DataCoordCfg.TargetVecIndexVersion.GetAsInt32())
-		}
-	}
+	currentVecIndexVersion := it.indexEngineVersionManager.ResolveVecIndexVersion()
+	currentScalarIndexVersion := it.indexEngineVersionManager.ResolveScalarIndexVersion()
 
 	// Create the job request
 	req := &workerpb.CreateJobRequest{
@@ -323,7 +314,7 @@ func (it *indexBuildTask) prepareJobRequest(ctx context.Context, segment *Segmen
 		TypeParams:                typeParams,
 		NumRows:                   segIndex.NumRows,
 		CurrentIndexVersion:       currentVecIndexVersion,
-		CurrentScalarIndexVersion: it.indexEngineVersionManager.GetCurrentScalarIndexEngineVersion(),
+		CurrentScalarIndexVersion: currentScalarIndexVersion,
 		CollectionID:              segment.GetCollectionID(),
 		PartitionID:               segment.GetPartitionID(),
 		SegmentID:                 segment.GetID(),

--- a/internal/datacoord/task_stats.go
+++ b/internal/datacoord/task_stats.go
@@ -339,7 +339,7 @@ func (st *statsTask) prepareJobRequest(ctx context.Context, segment *SegmentInfo
 		JsonKeyStatsDataFormat:           common.JSONStatsDataFormatVersion,
 		TaskSlot:                         st.taskSlot,
 		StorageVersion:                   segment.StorageVersion,
-		CurrentScalarIndexVersion:        st.ievm.GetCurrentScalarIndexEngineVersion(),
+		CurrentScalarIndexVersion:        st.ievm.ResolveScalarIndexVersion(),
 		JsonStatsMaxShreddingColumns:     Params.DataCoordCfg.JSONStatsMaxShreddingColumns.GetAsInt64(),
 		JsonStatsShreddingRatioThreshold: Params.DataCoordCfg.JSONStatsShreddingRatioThreshold.GetAsFloat(),
 		JsonStatsWriteBatchSize:          Params.DataCoordCfg.JSONStatsWriteBatchSize.GetAsInt64(),

--- a/internal/datanode/compactor/sort_compaction.go
+++ b/internal/datanode/compactor/sort_compaction.go
@@ -586,6 +586,10 @@ func (t *sortCompactionTask) createTextIndex(ctx context.Context,
 
 			mu.Lock()
 			totalSize := lo.SumBy(lo.Values(uploaded), func(fileSize int64) int64 { return fileSize })
+			scalarIndexVersion := t.plan.GetCurrentScalarIndexVersion()
+			if scalarIndexVersion > common.MaximumScalarIndexEngineVersion {
+				scalarIndexVersion = common.MaximumScalarIndexEngineVersion
+			}
 			textIndexLogs[field.GetFieldID()] = &datapb.TextIndexStats{
 				FieldID:                   field.GetFieldID(),
 				Version:                   0,
@@ -593,7 +597,7 @@ func (t *sortCompactionTask) createTextIndex(ctx context.Context,
 				Files:                     lo.Keys(uploaded),
 				LogSize:                   totalSize,
 				MemorySize:                totalSize,
-				CurrentScalarIndexVersion: common.CurrentScalarIndexEngineVersion,
+				CurrentScalarIndexVersion: scalarIndexVersion,
 			}
 			mu.Unlock()
 

--- a/internal/datanode/index/task_stats.go
+++ b/internal/datanode/index/task_stats.go
@@ -534,7 +534,7 @@ func (st *statsTask) createTextIndex(ctx context.Context,
 				Files:                     lo.Keys(uploaded),
 				LogSize:                   totalSize,
 				MemorySize:                totalSize,
-				CurrentScalarIndexVersion: common.CurrentScalarIndexEngineVersion,
+				CurrentScalarIndexVersion: getCurrentScalarIndexVersion(st.req.GetCurrentScalarIndexVersion()),
 			}
 			mu.Unlock()
 

--- a/internal/datanode/index/util.go
+++ b/internal/datanode/index/util.go
@@ -47,9 +47,9 @@ func getCurrentIndexVersion(v int32) int32 {
 }
 
 func getCurrentScalarIndexVersion(v int32) int32 {
-	cCurrent := common.CurrentScalarIndexEngineVersion
-	if cCurrent < v {
-		return cCurrent
+	cMaximum := common.MaximumScalarIndexEngineVersion
+	if cMaximum < v {
+		return cMaximum
 	}
 	return v
 }

--- a/internal/querynodev2/segments/utils.go
+++ b/internal/querynodev2/segments/utils.go
@@ -179,13 +179,13 @@ func mergeRequestCost(requestCosts []*internalpb.CostAggregation) *internalpb.Co
 	return result
 }
 
-func getIndexEngineVersion() (minimal, current int32) {
+func getIndexEngineVersion() (minimal, current, maximum int32) {
 	GetDynamicPool().Submit(func() (any, error) {
-		cMinimal, cCurrent := C.GetMinimalIndexVersion(), C.GetCurrentIndexVersion()
-		minimal, current = int32(cMinimal), int32(cCurrent)
+		cMinimal, cCurrent, cMaximum := C.GetMinimalIndexVersion(), C.GetCurrentIndexVersion(), C.GetMaximumIndexVersion()
+		minimal, current, maximum = int32(cMinimal), int32(cCurrent), int32(cMaximum)
 		return nil, nil
 	}).Await()
-	return minimal, current
+	return minimal, current, maximum
 }
 
 // getSegmentMetricLabel returns the label for segment metrics.

--- a/internal/querynodev2/server.go
+++ b/internal/querynodev2/server.go
@@ -162,10 +162,13 @@ func NewQueryNode(ctx context.Context, factory dependency.Factory) *QueryNode {
 }
 
 func (node *QueryNode) initSession() error {
-	minimalIndexVersion, currentIndexVersion := getIndexEngineVersion()
+	minimalIndexVersion, currentIndexVersion, maximumIndexVersion := getIndexEngineVersion()
 	node.session = sessionutil.NewSession(node.ctx,
-		sessionutil.WithIndexEngineVersion(minimalIndexVersion, currentIndexVersion),
-		sessionutil.WithScalarIndexEngineVersion(common.MinimalScalarIndexEngineVersion, common.CurrentScalarIndexEngineVersion),
+		sessionutil.WithIndexEngineVersion(minimalIndexVersion, currentIndexVersion, maximumIndexVersion),
+		sessionutil.WithScalarIndexEngineVersion(
+			common.MinimalScalarIndexEngineVersion,
+			common.CurrentScalarIndexEngineVersion,
+			common.MaximumScalarIndexEngineVersion),
 		sessionutil.WithIndexNonEncoding())
 	if node.session == nil {
 		return errors.New("session is nil, the etcd client connection may have failed")
@@ -237,9 +240,9 @@ func (node *QueryNode) RegisterSegcoreConfigWatcher() {
 		config.NewHandler("common.diskWriteRateLimiter.lowPriorityRatio", node.ReconfigDiskFileWriterParams))
 }
 
-func getIndexEngineVersion() (minimal, current int32) {
-	cMinimal, cCurrent := C.GetMinimalIndexVersion(), C.GetCurrentIndexVersion()
-	return int32(cMinimal), int32(cCurrent)
+func getIndexEngineVersion() (minimal, current, maximum int32) {
+	cMinimal, cCurrent, cMaximum := C.GetMinimalIndexVersion(), C.GetCurrentIndexVersion(), C.GetMaximumIndexVersion()
+	return int32(cMinimal), int32(cCurrent), int32(cMaximum)
 }
 
 func (node *QueryNode) GetNodeID() int64 {

--- a/internal/util/segcore/segcore_init.go
+++ b/internal/util/segcore/segcore_init.go
@@ -16,13 +16,15 @@ import "C"
 type IndexEngineInfo struct {
 	MinIndexVersion     int32
 	CurrentIndexVersion int32
+	MaxIndexVersion     int32
 }
 
-// GetIndexEngineInfo returns the minimal and current version of the index engine.
+// GetIndexEngineInfo returns the minimal, current, and maximum version of the index engine.
 func GetIndexEngineInfo() IndexEngineInfo {
-	cMinimal, cCurrent := C.GetMinimalIndexVersion(), C.GetCurrentIndexVersion()
+	cMinimal, cCurrent, cMaximum := C.GetMinimalIndexVersion(), C.GetCurrentIndexVersion(), C.GetMaximumIndexVersion()
 	return IndexEngineInfo{
 		MinIndexVersion:     int32(cMinimal),
 		CurrentIndexVersion: int32(cCurrent),
+		MaxIndexVersion:     int32(cMaximum),
 	}
 }

--- a/internal/util/segcore/segcore_init_test.go
+++ b/internal/util/segcore/segcore_init_test.go
@@ -10,4 +10,6 @@ func TestGetIndexEngineInfo(t *testing.T) {
 	r := GetIndexEngineInfo()
 	assert.NotZero(t, r.CurrentIndexVersion)
 	assert.Zero(t, r.MinIndexVersion)
+	assert.NotZero(t, r.MaxIndexVersion)
+	assert.GreaterOrEqual(t, r.MaxIndexVersion, r.CurrentIndexVersion)
 }

--- a/internal/util/sessionutil/session_util.go
+++ b/internal/util/sessionutil/session_util.go
@@ -110,6 +110,7 @@ const (
 type IndexEngineVersion struct {
 	MinimalIndexVersion int32 `json:"MinimalIndexVersion,omitempty"`
 	CurrentIndexVersion int32 `json:"CurrentIndexVersion,omitempty"`
+	MaximumIndexVersion int32 `json:"MaximumIndexVersion,omitempty"`
 }
 
 // SessionRaw the persistent part of Session.
@@ -198,18 +199,20 @@ func WithResueNodeID(b bool) SessionOption {
 }
 
 // WithIndexEngineVersion should be only used by querynode.
-func WithIndexEngineVersion(minimal, current int32) SessionOption {
+func WithIndexEngineVersion(minimal, current, maximum int32) SessionOption {
 	return func(session *Session) {
 		session.IndexEngineVersion.MinimalIndexVersion = minimal
 		session.IndexEngineVersion.CurrentIndexVersion = current
+		session.IndexEngineVersion.MaximumIndexVersion = maximum
 	}
 }
 
 // WithScalarIndexEngineVersion should be only used by querynode.
-func WithScalarIndexEngineVersion(minimal, current int32) SessionOption {
+func WithScalarIndexEngineVersion(minimal, current, maximum int32) SessionOption {
 	return func(session *Session) {
 		session.ScalarIndexEngineVersion.MinimalIndexVersion = minimal
 		session.ScalarIndexEngineVersion.CurrentIndexVersion = current
+		session.ScalarIndexEngineVersion.MaximumIndexVersion = maximum
 	}
 }
 

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -94,6 +94,7 @@ const (
 	// TODO: scalar index version 3 is still in development, so we use 2 as the current version.
 	// Do not use version 3 until this TODO is resolved.
 	CurrentScalarIndexEngineVersion = int32(2)
+	MaximumScalarIndexEngineVersion = int32(2)
 )
 
 const DefaultTimezone = "UTC"

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -4616,9 +4616,11 @@ type dataCoordConfig struct {
 	SegmentMinSizeFromIdleToSealed ParamItem `refreshable:"false"`
 	SegmentMaxBinlogFileNumber     ParamItem `refreshable:"false"`
 	GrowingSegmentsMemSizeInMB     ParamItem `refreshable:"true"`
-	AutoUpgradeSegmentIndex        ParamItem `refreshable:"true"`
-	ForceRebuildSegmentIndex       ParamItem `refreshable:"true"`
-	TargetVecIndexVersion          ParamItem `refreshable:"true"`
+	AutoUpgradeSegmentIndex             ParamItem `refreshable:"true"`
+	ForceRebuildSegmentIndex            ParamItem `refreshable:"true"`
+	TargetVecIndexVersion               ParamItem `refreshable:"true"`
+	ForceRebuildScalarSegmentIndex      ParamItem `refreshable:"true"`
+	TargetScalarIndexVersion            ParamItem `refreshable:"true"`
 	SegmentFlushInterval           ParamItem `refreshable:"true"`
 	BlockingL0EntryNum             ParamItem `refreshable:"true"`
 	BlockingL0SizeInMB             ParamItem `refreshable:"true"`
@@ -5694,6 +5696,28 @@ if param targetVecIndexVersion is not set, the default value is -1, which means 
 		Export: true,
 	}
 	p.TargetVecIndexVersion.Init(base.mgr)
+
+	p.ForceRebuildScalarSegmentIndex = ParamItem{
+		Key:          "dataCoord.forceRebuildScalarSegmentIndex",
+		Version:      "2.5.10",
+		DefaultValue: "false",
+		PanicIfEmpty: true,
+		Doc:          "force rebuild scalar segment index to specified scalar index engine's version",
+		Export:       true,
+	}
+	p.ForceRebuildScalarSegmentIndex.Init(base.mgr)
+
+	p.TargetScalarIndexVersion = ParamItem{
+		Key:          "dataCoord.targetScalarIndexVersion",
+		Version:      "2.5.10",
+		DefaultValue: "-1",
+		PanicIfEmpty: true,
+		Doc: `if param forceRebuildScalarSegmentIndex is enabled, the scalar index will be rebuilt to aligned with targetScalarIndexVersion.
+if param forceRebuildScalarSegmentIndex is not enabled, the newly created scalar index will be aligned with the newer one of scalar index engine's version and targetScalarIndexVersion.
+if param targetScalarIndexVersion is not set, the default value is -1, which means no target scalar index version, then the scalar index will be aligned with scalar index engine's version`,
+		Export: true,
+	}
+	p.TargetScalarIndexVersion.Init(base.mgr)
 
 	p.SegmentFlushInterval = ParamItem{
 		Key:          "dataCoord.segmentFlushInterval",


### PR DESCRIPTION
## Summary
- Introduce full scalar index version management parity with vector indexes, including `targetScalarIndexVersion`, `forceRebuildScalarSegmentIndex` config params, and `MaximumVersion` propagation/clamping for both vector and scalar indexes.
- Add `ResolveVecIndexVersion()` and `ResolveScalarIndexVersion()` to centralize version resolution logic (target override + MaxVersion clamp), used by task_index, task_stats, compaction_task_mix, and compaction_trigger.
- Fix DataNode scalar version clamp to use `MaximumScalarIndexEngineVersion` instead of `CurrentScalarIndexEngineVersion`, and fix DataNode text index paths to use request-carried version instead of hardcoded constants.

issue: https://github.com/milvus-io/milvus/issues/XXXXX

## Test plan
- [ ] Unit tests for `GetMaximumIndexEngineVersion()` and `GetMaximumScalarIndexEngineVersion()` aggregation
- [ ] Unit tests for `ResolveVecIndexVersion()` and `ResolveScalarIndexVersion()` with various target/force/max combinations
- [ ] Unit tests for scalar force-rebuild compaction trigger path
- [ ] Integration test: set `targetScalarIndexVersion` and verify scalar indexes are built with correct version
- [ ] Integration test: set `forceRebuildScalarSegmentIndex=true` and verify all scalar indexes are rebuilt
- [ ] Verify rolling upgrade compatibility: old QN (no MaximumIndexVersion) + new DataCoord works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)