### PR TITLE
feat: add scalar index version management with MaxVersion support

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -654,6 +654,11 @@ dataCoord:
   # if param forceRebuildSegmentIndex is not enabled, the newly created vector index will be aligned with the newer one of index engine's version and targetVecIndexVersion.
   # if param targetVecIndexVersion is not set, the default value is -1, which means no target vec index version, then the vector index will be aligned with index engine's version 
   targetVecIndexVersion: -1
+  forceRebuildScalarSegmentIndex: false # force rebuild scalar segment index to specified scalar index engine's version
+  # if param forceRebuildScalarSegmentIndex is enabled, the scalar index will be rebuilt to aligned with targetScalarIndexVersion.
+  # if param forceRebuildScalarSegmentIndex is not enabled, the newly created scalar index will be aligned with the newer one of scalar index engine's version and targetScalarIndexVersion.
+  # if param targetScalarIndexVersion is not set, the default value is -1, which means no target scalar index version, then the scalar index will be aligned with scalar index engine's version
+  targetScalarIndexVersion: -1
   segmentFlushInterval: 2 # the minimal interval duration(unit: Seconds) between flushing operation on same segment
   # Switch value to control if to enable segment compaction.
   # Compaction merges small-size segments into a large segment, and clears the entities deleted beyond the rentention duration of Time Travel.

--- a/internal/datacoord/compaction_task_mix.go
+++ b/internal/datacoord/compaction_task_mix.go
@@ -381,7 +381,7 @@ func (t *mixCompactionTask) BuildCompactionRequest() (*datapb.CompactionPlan, er
 		SlotUsage:                 t.GetSlotUsage(),
 		MaxSize:                   taskProto.GetMaxSize(),
 		JsonParams:                compactionParams,
-		CurrentScalarIndexVersion: t.ievm.GetCurrentScalarIndexEngineVersion(),
+		CurrentScalarIndexVersion: t.ievm.ResolveScalarIndexVersion(),
 	}
 
 	// set analyzer resource for text match index if use ref mode

--- a/internal/datacoord/compaction_trigger.go
+++ b/internal/datacoord/compaction_trigger.go
@@ -804,20 +804,23 @@ func (t *compactionTrigger) ShouldRebuildSegmentIndex(segment *SegmentInfo) bool
 			isVectorIndex := vecindexmgr.GetVecIndexMgrInstance().IsVecIndex(indexType)
 
 			var currentEngineVersion int32
+			var segmentIndexVersion int32
 			if isVectorIndex {
 				currentEngineVersion = t.indexEngineVersionManager.GetCurrentIndexEngineVersion()
+				segmentIndexVersion = index.CurrentIndexVersion
 			} else {
 				currentEngineVersion = t.indexEngineVersionManager.GetCurrentScalarIndexEngineVersion()
+				segmentIndexVersion = index.CurrentScalarIndexVersion
 			}
 
-			if index.CurrentIndexVersion < currentEngineVersion {
+			if segmentIndexVersion < currentEngineVersion {
 				log.Info("index version is too old, trigger compaction",
 					zap.Int64("segmentID", segment.ID),
 					zap.Int64("indexID", index.IndexID),
 					zap.String("indexType", indexType),
 					zap.Bool("isVectorIndex", isVectorIndex),
 					zap.Strings("indexFileKeys", index.IndexFileKeys),
-					zap.Int32("currentIndexVersion", index.CurrentIndexVersion),
+					zap.Int32("segmentIndexVersion", segmentIndexVersion),
 					zap.Int32("currentEngineVersion", currentEngineVersion))
 				return true
 			}
@@ -826,7 +829,7 @@ func (t *compactionTrigger) ShouldRebuildSegmentIndex(segment *SegmentInfo) bool
 
 	// enable force rebuild index with target index version (only for vector index)
 	if Params.DataCoordCfg.ForceRebuildSegmentIndex.GetAsBool() && Params.DataCoordCfg.TargetVecIndexVersion.GetAsInt64() != -1 {
-		// index version of segment lower than current version and IndexFileKeys should have value, trigger compaction
+		resolvedVecTarget := t.indexEngineVersionManager.ResolveVecIndexVersion()
 		indexIDToSegIdxes := t.meta.indexMeta.GetSegmentIndexes(segment.CollectionID, segment.ID)
 		for _, index := range indexIDToSegIdxes {
 			if len(index.IndexFileKeys) == 0 {
@@ -842,14 +845,43 @@ func (t *compactionTrigger) ShouldRebuildSegmentIndex(segment *SegmentInfo) bool
 				continue
 			}
 
-			if index.CurrentIndexVersion != Params.DataCoordCfg.TargetVecIndexVersion.GetAsInt32() {
+			if index.CurrentIndexVersion != resolvedVecTarget {
 				log.Info("index version is not equal to target vec index version, trigger compaction",
 					zap.Int64("segmentID", segment.ID),
 					zap.Int64("indexID", index.IndexID),
 					zap.String("indexType", indexType),
 					zap.Strings("indexFileKeys", index.IndexFileKeys),
 					zap.Int32("currentIndexVersion", index.CurrentIndexVersion),
-					zap.Int32("targetIndexVersion", Params.DataCoordCfg.TargetVecIndexVersion.GetAsInt32()))
+					zap.Int32("resolvedTargetVersion", resolvedVecTarget))
+				return true
+			}
+		}
+	}
+
+	// enable force rebuild scalar index with target scalar index version
+	if Params.DataCoordCfg.ForceRebuildScalarSegmentIndex.GetAsBool() && Params.DataCoordCfg.TargetScalarIndexVersion.GetAsInt64() != -1 {
+		resolvedScalarTarget := t.indexEngineVersionManager.ResolveScalarIndexVersion()
+		indexIDToSegIdxes := t.meta.indexMeta.GetSegmentIndexes(segment.CollectionID, segment.ID)
+		for _, index := range indexIDToSegIdxes {
+			if len(index.IndexFileKeys) == 0 {
+				continue
+			}
+
+			indexParams := t.meta.indexMeta.GetIndexParams(segment.CollectionID, index.IndexID)
+			indexType := GetIndexType(indexParams)
+			isVectorIndex := vecindexmgr.GetVecIndexMgrInstance().IsVecIndex(indexType)
+
+			if isVectorIndex {
+				continue
+			}
+
+			if index.CurrentScalarIndexVersion != resolvedScalarTarget {
+				log.Info("scalar index version != target, trigger compaction",
+					zap.Int64("segmentID", segment.ID),
+					zap.Int64("indexID", index.IndexID),
+					zap.String("indexType", indexType),
+					zap.Int32("currentScalarIndexVersion", index.CurrentScalarIndexVersion),
+					zap.Int32("resolvedTargetVersion", resolvedScalarTarget))
 				return true
 			}
 		}

--- a/internal/datacoord/compaction_trigger_test.go
+++ b/internal/datacoord/compaction_trigger_test.go
@@ -1827,6 +1827,7 @@ func Test_compactionTrigger_shouldDoSingleCompaction(t *testing.T) {
 	mockVersionManager := NewMockVersionManager(t)
 	mockVersionManager.On("GetCurrentIndexEngineVersion").Return(int32(2)).Maybe()
 	mockVersionManager.On("GetCurrentScalarIndexEngineVersion").Return(int32(2)).Maybe()
+	mockVersionManager.On("ResolveVecIndexVersion").Return(int32(5)).Maybe()
 	trigger.indexEngineVersionManager = mockVersionManager
 	info4 := &SegmentInfo{
 		SegmentInfo: &datapb.SegmentInfo{

--- a/internal/datacoord/compaction_trigger_test.go
+++ b/internal/datacoord/compaction_trigger_test.go
@@ -3159,3 +3159,217 @@ func Test_compactionTrigger_ShouldCompactExpiryWithTTLField(t *testing.T) {
 	shouldCompact = trigger.ShouldCompactExpiryWithTTLField(ct, segment2)
 	assert.False(t, shouldCompact)
 }
+
+func newTestIndexMeta(collID, segID, indexID int64, indexType string, segIdx *model.SegmentIndex) *indexMeta {
+	im := newSegmentIndexMeta(nil)
+	im.indexes[collID] = map[UniqueID]*model.Index{
+		indexID: {
+			CollectionID: collID,
+			IndexID:      indexID,
+			IndexName:    "test_idx",
+			IndexParams: []*commonpb.KeyValuePair{
+				{Key: common.IndexTypeKey, Value: indexType},
+			},
+		},
+	}
+	segIdxMap := typeutil.NewConcurrentMap[UniqueID, *model.SegmentIndex]()
+	segIdxMap.Insert(indexID, segIdx)
+	im.segmentIndexes.Insert(segID, segIdxMap)
+	return im
+}
+
+func Test_ShouldRebuildSegmentIndex_AutoUpgrade_ScalarUsesCorrectField(t *testing.T) {
+	paramtable.Init()
+	Params.Save("dataCoord.autoUpgradeSegmentIndex", "true")
+
+	collID, segID, indexID := int64(1), int64(100), int64(10)
+
+	t.Run("scalar auto-upgrade compares CurrentScalarIndexVersion", func(t *testing.T) {
+		// Scalar index with CurrentIndexVersion=5 (vector field) but CurrentScalarIndexVersion=1
+		// Engine scalar version is 2, so 1 < 2 should trigger rebuild
+		segIdx := &model.SegmentIndex{
+			SegmentID:                 segID,
+			CollectionID:              collID,
+			IndexID:                   indexID,
+			IndexFileKeys:             []string{"file1"},
+			CurrentIndexVersion:       5, // vector version field - should NOT be used for scalar
+			CurrentScalarIndexVersion: 1, // scalar version field - should be used
+		}
+		im := newTestIndexMeta(collID, segID, indexID, "INVERTED", segIdx)
+
+		mockVM := NewMockVersionManager(t)
+		mockVM.On("GetCurrentScalarIndexEngineVersion").Return(int32(2)).Maybe()
+		mockVM.On("GetCurrentIndexEngineVersion").Return(int32(5)).Maybe()
+
+		trigger := &compactionTrigger{
+			meta:                       &meta{indexMeta: im, channelCPs: newChannelCps()},
+			indexEngineVersionManager: mockVM,
+		}
+
+		segment := &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{ID: segID, CollectionID: collID}}
+		assert.True(t, trigger.ShouldRebuildSegmentIndex(segment))
+	})
+
+	t.Run("scalar auto-upgrade no rebuild when version matches", func(t *testing.T) {
+		segIdx := &model.SegmentIndex{
+			SegmentID:                 segID,
+			CollectionID:              collID,
+			IndexID:                   indexID,
+			IndexFileKeys:             []string{"file1"},
+			CurrentIndexVersion:       1, // vector version - irrelevant
+			CurrentScalarIndexVersion: 2, // matches engine version
+		}
+		im := newTestIndexMeta(collID, segID, indexID, "INVERTED", segIdx)
+
+		mockVM := NewMockVersionManager(t)
+		mockVM.On("GetCurrentScalarIndexEngineVersion").Return(int32(2)).Maybe()
+		mockVM.On("GetCurrentIndexEngineVersion").Return(int32(5)).Maybe()
+
+		trigger := &compactionTrigger{
+			meta:                       &meta{indexMeta: im, channelCPs: newChannelCps()},
+			indexEngineVersionManager: mockVM,
+		}
+
+		segment := &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{ID: segID, CollectionID: collID}}
+		assert.False(t, trigger.ShouldRebuildSegmentIndex(segment))
+	})
+
+	Params.Save("dataCoord.autoUpgradeSegmentIndex", "false")
+}
+
+func Test_ShouldRebuildSegmentIndex_ForceRebuild_ScalarUsesCorrectField(t *testing.T) {
+	paramtable.Init()
+	Params.Save("dataCoord.autoUpgradeSegmentIndex", "false")
+
+	collID, segID, indexID := int64(1), int64(100), int64(10)
+
+	t.Run("scalar force-rebuild compares CurrentScalarIndexVersion", func(t *testing.T) {
+		Params.Save("dataCoord.forceRebuildScalarSegmentIndex", "true")
+		Params.Save("dataCoord.targetScalarIndexVersion", "3")
+		defer func() {
+			Params.Save("dataCoord.forceRebuildScalarSegmentIndex", "false")
+			Params.Save("dataCoord.targetScalarIndexVersion", "-1")
+		}()
+
+		// CurrentScalarIndexVersion=2 != resolved target=3, should trigger
+		segIdx := &model.SegmentIndex{
+			SegmentID:                 segID,
+			CollectionID:              collID,
+			IndexID:                   indexID,
+			IndexFileKeys:             []string{"file1"},
+			CurrentIndexVersion:       3, // vector version - should NOT be used
+			CurrentScalarIndexVersion: 2, // scalar version - should be used
+		}
+		im := newTestIndexMeta(collID, segID, indexID, "INVERTED", segIdx)
+
+		mockVM := NewMockVersionManager(t)
+		mockVM.On("ResolveScalarIndexVersion").Return(int32(3)).Maybe()
+
+		trigger := &compactionTrigger{
+			meta:                       &meta{indexMeta: im, channelCPs: newChannelCps()},
+			indexEngineVersionManager: mockVM,
+		}
+
+		segment := &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{ID: segID, CollectionID: collID}}
+		assert.True(t, trigger.ShouldRebuildSegmentIndex(segment))
+	})
+
+	t.Run("scalar force-rebuild no trigger when version matches resolved target", func(t *testing.T) {
+		Params.Save("dataCoord.forceRebuildScalarSegmentIndex", "true")
+		Params.Save("dataCoord.targetScalarIndexVersion", "3")
+		defer func() {
+			Params.Save("dataCoord.forceRebuildScalarSegmentIndex", "false")
+			Params.Save("dataCoord.targetScalarIndexVersion", "-1")
+		}()
+
+		segIdx := &model.SegmentIndex{
+			SegmentID:                 segID,
+			CollectionID:              collID,
+			IndexID:                   indexID,
+			IndexFileKeys:             []string{"file1"},
+			CurrentIndexVersion:       1, // irrelevant
+			CurrentScalarIndexVersion: 3, // matches resolved target
+		}
+		im := newTestIndexMeta(collID, segID, indexID, "INVERTED", segIdx)
+
+		mockVM := NewMockVersionManager(t)
+		mockVM.On("ResolveScalarIndexVersion").Return(int32(3)).Maybe()
+
+		trigger := &compactionTrigger{
+			meta:                       &meta{indexMeta: im, channelCPs: newChannelCps()},
+			indexEngineVersionManager: mockVM,
+		}
+
+		segment := &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{ID: segID, CollectionID: collID}}
+		assert.False(t, trigger.ShouldRebuildSegmentIndex(segment))
+	})
+}
+
+func Test_ShouldRebuildSegmentIndex_ForceRebuild_TargetExceedsMax_Converges(t *testing.T) {
+	paramtable.Init()
+	Params.Save("dataCoord.autoUpgradeSegmentIndex", "false")
+
+	collID, segID, indexID := int64(1), int64(100), int64(10)
+
+	t.Run("vec force-rebuild with target>max converges after clamp", func(t *testing.T) {
+		Params.Save("dataCoord.forceRebuildSegmentIndex", "true")
+		Params.Save("dataCoord.targetVecIndexVersion", "30")
+		defer func() {
+			Params.Save("dataCoord.forceRebuildSegmentIndex", "false")
+			Params.Save("dataCoord.targetVecIndexVersion", "-1")
+		}()
+
+		// Index was already rebuilt to clamped version (20), should NOT trigger again
+		segIdx := &model.SegmentIndex{
+			SegmentID:     segID,
+			CollectionID:  collID,
+			IndexID:       indexID,
+			IndexFileKeys: []string{"file1"},
+			CurrentIndexVersion: 20, // matches resolved (clamped) target
+		}
+		im := newTestIndexMeta(collID, segID, indexID, "HNSW", segIdx)
+
+		mockVM := NewMockVersionManager(t)
+		// ResolveVecIndexVersion clamps target=30 to max=20
+		mockVM.On("ResolveVecIndexVersion").Return(int32(20)).Maybe()
+
+		trigger := &compactionTrigger{
+			meta:                       &meta{indexMeta: im, channelCPs: newChannelCps()},
+			indexEngineVersionManager: mockVM,
+		}
+
+		segment := &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{ID: segID, CollectionID: collID}}
+		assert.False(t, trigger.ShouldRebuildSegmentIndex(segment))
+	})
+
+	t.Run("scalar force-rebuild with target>max converges after clamp", func(t *testing.T) {
+		Params.Save("dataCoord.forceRebuildScalarSegmentIndex", "true")
+		Params.Save("dataCoord.targetScalarIndexVersion", "10")
+		defer func() {
+			Params.Save("dataCoord.forceRebuildScalarSegmentIndex", "false")
+			Params.Save("dataCoord.targetScalarIndexVersion", "-1")
+		}()
+
+		// Index was already rebuilt to clamped version (5), should NOT trigger again
+		segIdx := &model.SegmentIndex{
+			SegmentID:                 segID,
+			CollectionID:              collID,
+			IndexID:                   indexID,
+			IndexFileKeys:             []string{"file1"},
+			CurrentScalarIndexVersion: 5, // matches resolved (clamped) target
+		}
+		im := newTestIndexMeta(collID, segID, indexID, "INVERTED", segIdx)
+
+		mockVM := NewMockVersionManager(t)
+		// ResolveScalarIndexVersion clamps target=10 to max=5
+		mockVM.On("ResolveScalarIndexVersion").Return(int32(5)).Maybe()
+
+		trigger := &compactionTrigger{
+			meta:                       &meta{indexMeta: im, channelCPs: newChannelCps()},
+			indexEngineVersionManager: mockVM,
+		}
+
+		segment := &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{ID: segID, CollectionID: collID}}
+		assert.False(t, trigger.ShouldRebuildSegmentIndex(segment))
+	})
+}

--- a/internal/datacoord/compaction_trigger_test.go
+++ b/internal/datacoord/compaction_trigger_test.go
@@ -3202,7 +3202,7 @@ func Test_ShouldRebuildSegmentIndex_AutoUpgrade_ScalarUsesCorrectField(t *testin
 		mockVM.On("GetCurrentIndexEngineVersion").Return(int32(5)).Maybe()
 
 		trigger := &compactionTrigger{
-			meta:                       &meta{indexMeta: im, channelCPs: newChannelCps()},
+			meta:                      &meta{indexMeta: im, channelCPs: newChannelCps()},
 			indexEngineVersionManager: mockVM,
 		}
 
@@ -3226,7 +3226,7 @@ func Test_ShouldRebuildSegmentIndex_AutoUpgrade_ScalarUsesCorrectField(t *testin
 		mockVM.On("GetCurrentIndexEngineVersion").Return(int32(5)).Maybe()
 
 		trigger := &compactionTrigger{
-			meta:                       &meta{indexMeta: im, channelCPs: newChannelCps()},
+			meta:                      &meta{indexMeta: im, channelCPs: newChannelCps()},
 			indexEngineVersionManager: mockVM,
 		}
 
@@ -3266,7 +3266,7 @@ func Test_ShouldRebuildSegmentIndex_ForceRebuild_ScalarUsesCorrectField(t *testi
 		mockVM.On("ResolveScalarIndexVersion").Return(int32(3)).Maybe()
 
 		trigger := &compactionTrigger{
-			meta:                       &meta{indexMeta: im, channelCPs: newChannelCps()},
+			meta:                      &meta{indexMeta: im, channelCPs: newChannelCps()},
 			indexEngineVersionManager: mockVM,
 		}
 
@@ -3296,7 +3296,7 @@ func Test_ShouldRebuildSegmentIndex_ForceRebuild_ScalarUsesCorrectField(t *testi
 		mockVM.On("ResolveScalarIndexVersion").Return(int32(3)).Maybe()
 
 		trigger := &compactionTrigger{
-			meta:                       &meta{indexMeta: im, channelCPs: newChannelCps()},
+			meta:                      &meta{indexMeta: im, channelCPs: newChannelCps()},
 			indexEngineVersionManager: mockVM,
 		}
 
@@ -3321,10 +3321,10 @@ func Test_ShouldRebuildSegmentIndex_ForceRebuild_TargetExceedsMax_Converges(t *t
 
 		// Index was already rebuilt to clamped version (20), should NOT trigger again
 		segIdx := &model.SegmentIndex{
-			SegmentID:     segID,
-			CollectionID:  collID,
-			IndexID:       indexID,
-			IndexFileKeys: []string{"file1"},
+			SegmentID:           segID,
+			CollectionID:        collID,
+			IndexID:             indexID,
+			IndexFileKeys:       []string{"file1"},
 			CurrentIndexVersion: 20, // matches resolved (clamped) target
 		}
 		im := newTestIndexMeta(collID, segID, indexID, "HNSW", segIdx)
@@ -3334,7 +3334,7 @@ func Test_ShouldRebuildSegmentIndex_ForceRebuild_TargetExceedsMax_Converges(t *t
 		mockVM.On("ResolveVecIndexVersion").Return(int32(20)).Maybe()
 
 		trigger := &compactionTrigger{
-			meta:                       &meta{indexMeta: im, channelCPs: newChannelCps()},
+			meta:                      &meta{indexMeta: im, channelCPs: newChannelCps()},
 			indexEngineVersionManager: mockVM,
 		}
 
@@ -3365,7 +3365,7 @@ func Test_ShouldRebuildSegmentIndex_ForceRebuild_TargetExceedsMax_Converges(t *t
 		mockVM.On("ResolveScalarIndexVersion").Return(int32(5)).Maybe()
 
 		trigger := &compactionTrigger{
-			meta:                       &meta{indexMeta: im, channelCPs: newChannelCps()},
+			meta:                      &meta{indexMeta: im, channelCPs: newChannelCps()},
 			indexEngineVersionManager: mockVM,
 		}
 

--- a/internal/datacoord/index_engine_version_manager.go
+++ b/internal/datacoord/index_engine_version_manager.go
@@ -38,9 +38,17 @@ type IndexEngineVersionManager interface {
 	GetCurrentIndexEngineVersion() int32
 	GetMinimalIndexEngineVersion() int32
 
+	// Maximum version methods
+	GetMaximumIndexEngineVersion() int32
+	GetMaximumScalarIndexEngineVersion() int32
+
 	// Scalar index version methods (Milvus-defined)
 	GetCurrentScalarIndexEngineVersion() int32
 	GetMinimalScalarIndexEngineVersion() int32
+
+	// Resolve methods: compute final build version considering target override and max clamp
+	ResolveVecIndexVersion() int32
+	ResolveScalarIndexVersion() int32
 
 	GetIndexNonEncoding() bool
 
@@ -118,7 +126,9 @@ func (m *versionManagerImpl) addOrUpdate(session *sessionutil.Session) {
 		zap.String("sessionVersion", session.Version.String()),
 		zap.Int32("minimal", session.IndexEngineVersion.MinimalIndexVersion),
 		zap.Int32("current", session.IndexEngineVersion.CurrentIndexVersion),
-		zap.Int32("currentScalar", session.ScalarIndexEngineVersion.CurrentIndexVersion))
+		zap.Int32("maximum", session.IndexEngineVersion.MaximumIndexVersion),
+		zap.Int32("currentScalar", session.ScalarIndexEngineVersion.CurrentIndexVersion),
+		zap.Int32("maximumScalar", session.ScalarIndexEngineVersion.MaximumIndexVersion))
 	m.versions[session.ServerID] = session.IndexEngineVersion
 	m.scalarIndexVersions[session.ServerID] = session.ScalarIndexEngineVersion
 	m.indexNonEncoding[session.ServerID] = session.IndexNonEncoding
@@ -199,6 +209,78 @@ func (m *versionManagerImpl) GetMinimalScalarIndexEngineVersion() int32 {
 	}
 	log.Info("Merged minimal scalar index version", zap.Int32("minimal", minimal))
 	return minimal
+}
+
+func (m *versionManagerImpl) GetMaximumIndexEngineVersion() int32 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	maximum := int32(math.MaxInt32)
+	for _, version := range m.versions {
+		if version.MaximumIndexVersion == 0 {
+			continue
+		}
+		if version.MaximumIndexVersion < maximum {
+			maximum = version.MaximumIndexVersion
+		}
+	}
+	if maximum == math.MaxInt32 {
+		return math.MaxInt32
+	}
+	return maximum
+}
+
+func (m *versionManagerImpl) GetMaximumScalarIndexEngineVersion() int32 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	maximum := int32(math.MaxInt32)
+	for _, version := range m.scalarIndexVersions {
+		if version.MaximumIndexVersion == 0 {
+			continue
+		}
+		if version.MaximumIndexVersion < maximum {
+			maximum = version.MaximumIndexVersion
+		}
+	}
+	if maximum == math.MaxInt32 {
+		return math.MaxInt32
+	}
+	return maximum
+}
+
+func (m *versionManagerImpl) ResolveVecIndexVersion() int32 {
+	version := m.GetCurrentIndexEngineVersion()
+	if Params.DataCoordCfg.TargetVecIndexVersion.GetAsInt64() != -1 {
+		if Params.DataCoordCfg.ForceRebuildSegmentIndex.GetAsBool() {
+			version = Params.DataCoordCfg.TargetVecIndexVersion.GetAsInt32()
+		} else {
+			version = max(version, Params.DataCoordCfg.TargetVecIndexVersion.GetAsInt32())
+		}
+	}
+	if maxVersion := m.GetMaximumIndexEngineVersion(); version > maxVersion {
+		log.Warn("targetVecIndexVersion exceeds cluster maximum, clamping",
+			zap.Int32("target", version), zap.Int32("maximum", maxVersion))
+		version = maxVersion
+	}
+	return version
+}
+
+func (m *versionManagerImpl) ResolveScalarIndexVersion() int32 {
+	version := m.GetCurrentScalarIndexEngineVersion()
+	if Params.DataCoordCfg.TargetScalarIndexVersion.GetAsInt64() != -1 {
+		if Params.DataCoordCfg.ForceRebuildScalarSegmentIndex.GetAsBool() {
+			version = Params.DataCoordCfg.TargetScalarIndexVersion.GetAsInt32()
+		} else {
+			version = max(version, Params.DataCoordCfg.TargetScalarIndexVersion.GetAsInt32())
+		}
+	}
+	if maxVersion := m.GetMaximumScalarIndexEngineVersion(); version > maxVersion {
+		log.Warn("targetScalarIndexVersion exceeds cluster maximum, clamping",
+			zap.Int32("target", version), zap.Int32("maximum", maxVersion))
+		version = maxVersion
+	}
+	return version
 }
 
 func (m *versionManagerImpl) GetIndexNonEncoding() bool {

--- a/internal/datacoord/index_engine_version_manager.go
+++ b/internal/datacoord/index_engine_version_manager.go
@@ -8,6 +8,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
+	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/util/lock"
 )
@@ -274,6 +275,11 @@ func (m *versionManagerImpl) ResolveScalarIndexVersion() int32 {
 		} else {
 			version = max(version, Params.DataCoordCfg.TargetScalarIndexVersion.GetAsInt32())
 		}
+	}
+	if version < common.MinimalScalarIndexEngineVersion {
+		log.Warn("targetScalarIndexVersion below minimum, clamping",
+			zap.Int32("target", version), zap.Int32("minimum", common.MinimalScalarIndexEngineVersion))
+		version = common.MinimalScalarIndexEngineVersion
 	}
 	if maxVersion := m.GetMaximumScalarIndexEngineVersion(); version > maxVersion {
 		log.Warn("targetScalarIndexVersion exceeds cluster maximum, clamping",

--- a/internal/datacoord/index_engine_version_manager.go
+++ b/internal/datacoord/index_engine_version_manager.go
@@ -8,7 +8,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
-	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/util/lock"
 )
@@ -250,43 +249,55 @@ func (m *versionManagerImpl) GetMaximumScalarIndexEngineVersion() int32 {
 	return maximum
 }
 
+// clampVersion clamps v into [minV, maxV], logging a warning on each adjustment.
+func clampVersion(v, minV, maxV int32, name string) int32 {
+	if v < minV {
+		log.Warn(name+" below cluster minimum, clamping",
+			zap.Int32("target", v), zap.Int32("minimum", minV))
+		v = minV
+	}
+	if v > maxV {
+		log.Warn(name+" exceeds cluster maximum, clamping",
+			zap.Int32("target", v), zap.Int32("maximum", maxV))
+		v = maxV
+	}
+	return v
+}
+
 func (m *versionManagerImpl) ResolveVecIndexVersion() int32 {
 	version := m.GetCurrentIndexEngineVersion()
 	if Params.DataCoordCfg.TargetVecIndexVersion.GetAsInt64() != -1 {
+		target := Params.DataCoordCfg.TargetVecIndexVersion.GetAsInt32()
 		if Params.DataCoordCfg.ForceRebuildSegmentIndex.GetAsBool() {
-			version = Params.DataCoordCfg.TargetVecIndexVersion.GetAsInt32()
+			version = target
 		} else {
-			version = max(version, Params.DataCoordCfg.TargetVecIndexVersion.GetAsInt32())
+			version = max(version, target)
 		}
 	}
-	if maxVersion := m.GetMaximumIndexEngineVersion(); version > maxVersion {
-		log.Warn("targetVecIndexVersion exceeds cluster maximum, clamping",
-			zap.Int32("target", version), zap.Int32("maximum", maxVersion))
-		version = maxVersion
-	}
-	return version
+	return clampVersion(
+		version,
+		m.GetMinimalIndexEngineVersion(),
+		m.GetMaximumIndexEngineVersion(),
+		"targetVecIndexVersion",
+	)
 }
 
 func (m *versionManagerImpl) ResolveScalarIndexVersion() int32 {
 	version := m.GetCurrentScalarIndexEngineVersion()
 	if Params.DataCoordCfg.TargetScalarIndexVersion.GetAsInt64() != -1 {
+		target := Params.DataCoordCfg.TargetScalarIndexVersion.GetAsInt32()
 		if Params.DataCoordCfg.ForceRebuildScalarSegmentIndex.GetAsBool() {
-			version = Params.DataCoordCfg.TargetScalarIndexVersion.GetAsInt32()
+			version = target
 		} else {
-			version = max(version, Params.DataCoordCfg.TargetScalarIndexVersion.GetAsInt32())
+			version = max(version, target)
 		}
 	}
-	if version < common.MinimalScalarIndexEngineVersion {
-		log.Warn("targetScalarIndexVersion below minimum, clamping",
-			zap.Int32("target", version), zap.Int32("minimum", common.MinimalScalarIndexEngineVersion))
-		version = common.MinimalScalarIndexEngineVersion
-	}
-	if maxVersion := m.GetMaximumScalarIndexEngineVersion(); version > maxVersion {
-		log.Warn("targetScalarIndexVersion exceeds cluster maximum, clamping",
-			zap.Int32("target", version), zap.Int32("maximum", maxVersion))
-		version = maxVersion
-	}
-	return version
+	return clampVersion(
+		version,
+		m.GetMinimalScalarIndexEngineVersion(),
+		m.GetMaximumScalarIndexEngineVersion(),
+		"targetScalarIndexVersion",
+	)
 }
 
 func (m *versionManagerImpl) GetIndexNonEncoding() bool {

--- a/internal/datacoord/index_engine_version_manager_test.go
+++ b/internal/datacoord/index_engine_version_manager_test.go
@@ -490,19 +490,34 @@ func Test_IndexEngineVersionManager_ResolveVecIndexVersion(t *testing.T) {
 		assert.Equal(t, int32(15), m.ResolveVecIndexVersion())
 	})
 
-	t.Run("force rebuild uses target directly", func(t *testing.T) {
+	t.Run("force rebuild with target in safe range", func(t *testing.T) {
 		m := newIndexEngineVersionManager()
 		m.AddNode(&sessionutil.Session{
 			SessionRaw: sessionutil.SessionRaw{
 				ServerID:           1,
-				IndexEngineVersion: sessionutil.IndexEngineVersion{CurrentIndexVersion: 10, MaximumIndexVersion: 20},
+				IndexEngineVersion: sessionutil.IndexEngineVersion{MinimalIndexVersion: 3, CurrentIndexVersion: 10, MaximumIndexVersion: 20},
 			},
 		})
 		Params.Save("dataCoord.targetVecIndexVersion", "5")
 		Params.Save("dataCoord.forceRebuildSegmentIndex", "true")
 
-		// force rebuild: use target=5 directly even though current=10
+		// force rebuild: target=5 is within [minimal=3, max=20], use directly
 		assert.Equal(t, int32(5), m.ResolveVecIndexVersion())
+	})
+
+	t.Run("force rebuild with target below cluster minimal - clamped to minimal", func(t *testing.T) {
+		m := newIndexEngineVersionManager()
+		m.AddNode(&sessionutil.Session{
+			SessionRaw: sessionutil.SessionRaw{
+				ServerID:           1,
+				IndexEngineVersion: sessionutil.IndexEngineVersion{MinimalIndexVersion: 8, CurrentIndexVersion: 10, MaximumIndexVersion: 20},
+			},
+		})
+		Params.Save("dataCoord.targetVecIndexVersion", "5")
+		Params.Save("dataCoord.forceRebuildSegmentIndex", "true")
+
+		// force rebuild: target=5 < clusterMinimal=8, clamped to 8
+		assert.Equal(t, int32(8), m.ResolveVecIndexVersion())
 	})
 
 	t.Run("target exceeds maximum - clamped", func(t *testing.T) {
@@ -510,7 +525,7 @@ func Test_IndexEngineVersionManager_ResolveVecIndexVersion(t *testing.T) {
 		m.AddNode(&sessionutil.Session{
 			SessionRaw: sessionutil.SessionRaw{
 				ServerID:           1,
-				IndexEngineVersion: sessionutil.IndexEngineVersion{CurrentIndexVersion: 10, MaximumIndexVersion: 20},
+				IndexEngineVersion: sessionutil.IndexEngineVersion{MinimalIndexVersion: 3, CurrentIndexVersion: 10, MaximumIndexVersion: 20},
 			},
 		})
 		Params.Save("dataCoord.targetVecIndexVersion", "25")
@@ -518,6 +533,44 @@ func Test_IndexEngineVersionManager_ResolveVecIndexVersion(t *testing.T) {
 
 		// target=25 > max=20, clamped to 20
 		assert.Equal(t, int32(20), m.ResolveVecIndexVersion())
+	})
+
+	t.Run("multi-node force rebuild clamped to cluster minimal", func(t *testing.T) {
+		m := newIndexEngineVersionManager()
+		// QN1: Min=5, QN2: Min=8 => cluster minimal = MAX(5,8) = 8
+		m.AddNode(&sessionutil.Session{
+			SessionRaw: sessionutil.SessionRaw{
+				ServerID:           1,
+				IndexEngineVersion: sessionutil.IndexEngineVersion{MinimalIndexVersion: 5, CurrentIndexVersion: 15, MaximumIndexVersion: 25},
+			},
+		})
+		m.AddNode(&sessionutil.Session{
+			SessionRaw: sessionutil.SessionRaw{
+				ServerID:           2,
+				IndexEngineVersion: sessionutil.IndexEngineVersion{MinimalIndexVersion: 8, CurrentIndexVersion: 12, MaximumIndexVersion: 30},
+			},
+		})
+		Params.Save("dataCoord.targetVecIndexVersion", "6")
+		Params.Save("dataCoord.forceRebuildSegmentIndex", "true")
+
+		// force rebuild: target=6 < clusterMinimal=8, clamped to 8
+		// clusterMax = MIN(25,30) = 25
+		assert.Equal(t, int32(8), m.ResolveVecIndexVersion())
+	})
+
+	t.Run("all old QNs - no upper bound check", func(t *testing.T) {
+		m := newIndexEngineVersionManager()
+		m.AddNode(&sessionutil.Session{
+			SessionRaw: sessionutil.SessionRaw{
+				ServerID:           1,
+				IndexEngineVersion: sessionutil.IndexEngineVersion{MinimalIndexVersion: 0, CurrentIndexVersion: 10, MaximumIndexVersion: 0},
+			},
+		})
+		Params.Save("dataCoord.targetVecIndexVersion", "15")
+		Params.Save("dataCoord.forceRebuildSegmentIndex", "false")
+
+		// old QN (Max=0) => GetMaximum returns MaxInt32, no upper clamp
+		assert.Equal(t, int32(15), m.ResolveVecIndexVersion())
 	})
 }
 
@@ -553,19 +606,34 @@ func Test_IndexEngineVersionManager_ResolveScalarIndexVersion(t *testing.T) {
 		assert.Equal(t, int32(3), m.ResolveScalarIndexVersion())
 	})
 
-	t.Run("force rebuild uses target directly", func(t *testing.T) {
+	t.Run("force rebuild with target in safe range", func(t *testing.T) {
 		m := newIndexEngineVersionManager()
 		m.AddNode(&sessionutil.Session{
 			SessionRaw: sessionutil.SessionRaw{
 				ServerID:                 1,
-				ScalarIndexEngineVersion: sessionutil.IndexEngineVersion{CurrentIndexVersion: 3, MaximumIndexVersion: 5},
+				ScalarIndexEngineVersion: sessionutil.IndexEngineVersion{MinimalIndexVersion: 1, CurrentIndexVersion: 3, MaximumIndexVersion: 5},
+			},
+		})
+		Params.Save("dataCoord.targetScalarIndexVersion", "2")
+		Params.Save("dataCoord.forceRebuildScalarSegmentIndex", "true")
+
+		// force rebuild: target=2 is within [minimal=1, max=5], use directly
+		assert.Equal(t, int32(2), m.ResolveScalarIndexVersion())
+	})
+
+	t.Run("force rebuild with target below cluster minimal - clamped to minimal", func(t *testing.T) {
+		m := newIndexEngineVersionManager()
+		m.AddNode(&sessionutil.Session{
+			SessionRaw: sessionutil.SessionRaw{
+				ServerID:                 1,
+				ScalarIndexEngineVersion: sessionutil.IndexEngineVersion{MinimalIndexVersion: 2, CurrentIndexVersion: 3, MaximumIndexVersion: 5},
 			},
 		})
 		Params.Save("dataCoord.targetScalarIndexVersion", "1")
 		Params.Save("dataCoord.forceRebuildScalarSegmentIndex", "true")
 
-		// force rebuild: use target=1 directly
-		assert.Equal(t, int32(1), m.ResolveScalarIndexVersion())
+		// force rebuild: target=1 < clusterMinimal=2, clamped to 2
+		assert.Equal(t, int32(2), m.ResolveScalarIndexVersion())
 	})
 
 	t.Run("target exceeds maximum - clamped", func(t *testing.T) {
@@ -573,7 +641,7 @@ func Test_IndexEngineVersionManager_ResolveScalarIndexVersion(t *testing.T) {
 		m.AddNode(&sessionutil.Session{
 			SessionRaw: sessionutil.SessionRaw{
 				ServerID:                 1,
-				ScalarIndexEngineVersion: sessionutil.IndexEngineVersion{CurrentIndexVersion: 2, MaximumIndexVersion: 5},
+				ScalarIndexEngineVersion: sessionutil.IndexEngineVersion{MinimalIndexVersion: 1, CurrentIndexVersion: 2, MaximumIndexVersion: 5},
 			},
 		})
 		Params.Save("dataCoord.targetScalarIndexVersion", "10")
@@ -581,6 +649,29 @@ func Test_IndexEngineVersionManager_ResolveScalarIndexVersion(t *testing.T) {
 
 		// target=10 > max=5, clamped to 5
 		assert.Equal(t, int32(5), m.ResolveScalarIndexVersion())
+	})
+
+	t.Run("multi-node force rebuild clamped to cluster minimal", func(t *testing.T) {
+		m := newIndexEngineVersionManager()
+		// QN1: Min=1, QN2: Min=2 => cluster minimal = MAX(1,2) = 2
+		m.AddNode(&sessionutil.Session{
+			SessionRaw: sessionutil.SessionRaw{
+				ServerID:                 1,
+				ScalarIndexEngineVersion: sessionutil.IndexEngineVersion{MinimalIndexVersion: 1, CurrentIndexVersion: 3, MaximumIndexVersion: 5},
+			},
+		})
+		m.AddNode(&sessionutil.Session{
+			SessionRaw: sessionutil.SessionRaw{
+				ServerID:                 2,
+				ScalarIndexEngineVersion: sessionutil.IndexEngineVersion{MinimalIndexVersion: 2, CurrentIndexVersion: 4, MaximumIndexVersion: 6},
+			},
+		})
+		Params.Save("dataCoord.targetScalarIndexVersion", "1")
+		Params.Save("dataCoord.forceRebuildScalarSegmentIndex", "true")
+
+		// force rebuild: target=1 < clusterMinimal=2, clamped to 2
+		// clusterCurrent = MIN(3,4) = 3, clusterMax = MIN(5,6) = 5
+		assert.Equal(t, int32(2), m.ResolveScalarIndexVersion())
 	})
 }
 

--- a/internal/datacoord/index_engine_version_manager_test.go
+++ b/internal/datacoord/index_engine_version_manager_test.go
@@ -1,12 +1,14 @@
 package datacoord
 
 import (
+	"math"
 	"testing"
 
 	"github.com/blang/semver/v4"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
 func Test_IndexEngineVersionManager_GetMergedIndexVersion(t *testing.T) {
@@ -378,6 +380,208 @@ func Test_IndexEngineVersionManager_GetMinimalSessionVer(t *testing.T) {
 	assert.True(t, exists, "node 2 should exist in sessionVersion map")
 	_, exists = vm.sessionVersion[3]
 	assert.True(t, exists, "node 3 should exist in sessionVersion map")
+}
+
+func Test_IndexEngineVersionManager_GetMaximumIndexEngineVersion(t *testing.T) {
+	m := newIndexEngineVersionManager()
+
+	// empty - returns MaxInt32 (no upper bound)
+	assert.Equal(t, int32(math.MaxInt32), m.GetMaximumIndexEngineVersion())
+
+	// all nodes report Maximum=0 (old QNs) - returns MaxInt32
+	m.Startup(map[string]*sessionutil.Session{
+		"1": {
+			SessionRaw: sessionutil.SessionRaw{
+				ServerID:           1,
+				IndexEngineVersion: sessionutil.IndexEngineVersion{CurrentIndexVersion: 20, MaximumIndexVersion: 0},
+			},
+		},
+	})
+	assert.Equal(t, int32(math.MaxInt32), m.GetMaximumIndexEngineVersion())
+
+	// mix of old QN (Max=0) and new QN (Max=30) - skip old, return 30
+	m.AddNode(&sessionutil.Session{
+		SessionRaw: sessionutil.SessionRaw{
+			ServerID:           2,
+			IndexEngineVersion: sessionutil.IndexEngineVersion{CurrentIndexVersion: 15, MaximumIndexVersion: 30},
+		},
+	})
+	assert.Equal(t, int32(30), m.GetMaximumIndexEngineVersion())
+
+	// add another new QN with lower Max - returns MIN
+	m.AddNode(&sessionutil.Session{
+		SessionRaw: sessionutil.SessionRaw{
+			ServerID:           3,
+			IndexEngineVersion: sessionutil.IndexEngineVersion{CurrentIndexVersion: 18, MaximumIndexVersion: 25},
+		},
+	})
+	assert.Equal(t, int32(25), m.GetMaximumIndexEngineVersion())
+
+	// remove the node with lower Max - returns 30
+	m.RemoveNode(&sessionutil.Session{SessionRaw: sessionutil.SessionRaw{ServerID: 3}})
+	assert.Equal(t, int32(30), m.GetMaximumIndexEngineVersion())
+}
+
+func Test_IndexEngineVersionManager_GetMaximumScalarIndexEngineVersion(t *testing.T) {
+	m := newIndexEngineVersionManager()
+
+	// empty - returns MaxInt32
+	assert.Equal(t, int32(math.MaxInt32), m.GetMaximumScalarIndexEngineVersion())
+
+	// all nodes report Maximum=0 (old QNs)
+	m.Startup(map[string]*sessionutil.Session{
+		"1": {
+			SessionRaw: sessionutil.SessionRaw{
+				ServerID:                 1,
+				ScalarIndexEngineVersion: sessionutil.IndexEngineVersion{CurrentIndexVersion: 2, MaximumIndexVersion: 0},
+			},
+		},
+	})
+	assert.Equal(t, int32(math.MaxInt32), m.GetMaximumScalarIndexEngineVersion())
+
+	// new QN with Maximum set
+	m.AddNode(&sessionutil.Session{
+		SessionRaw: sessionutil.SessionRaw{
+			ServerID:                 2,
+			ScalarIndexEngineVersion: sessionutil.IndexEngineVersion{CurrentIndexVersion: 2, MaximumIndexVersion: 5},
+		},
+	})
+	assert.Equal(t, int32(5), m.GetMaximumScalarIndexEngineVersion())
+
+	// another QN with lower Maximum
+	m.AddNode(&sessionutil.Session{
+		SessionRaw: sessionutil.SessionRaw{
+			ServerID:                 3,
+			ScalarIndexEngineVersion: sessionutil.IndexEngineVersion{CurrentIndexVersion: 2, MaximumIndexVersion: 3},
+		},
+	})
+	assert.Equal(t, int32(3), m.GetMaximumScalarIndexEngineVersion())
+}
+
+func Test_IndexEngineVersionManager_ResolveVecIndexVersion(t *testing.T) {
+	paramtable.Init()
+
+	t.Run("no target override", func(t *testing.T) {
+		m := newIndexEngineVersionManager()
+		m.AddNode(&sessionutil.Session{
+			SessionRaw: sessionutil.SessionRaw{
+				ServerID:           1,
+				IndexEngineVersion: sessionutil.IndexEngineVersion{CurrentIndexVersion: 10, MaximumIndexVersion: 20},
+			},
+		})
+		Params.Save("dataCoord.targetVecIndexVersion", "-1")
+		Params.Save("dataCoord.forceRebuildSegmentIndex", "false")
+
+		assert.Equal(t, int32(10), m.ResolveVecIndexVersion())
+	})
+
+	t.Run("target override without force rebuild", func(t *testing.T) {
+		m := newIndexEngineVersionManager()
+		m.AddNode(&sessionutil.Session{
+			SessionRaw: sessionutil.SessionRaw{
+				ServerID:           1,
+				IndexEngineVersion: sessionutil.IndexEngineVersion{CurrentIndexVersion: 10, MaximumIndexVersion: 20},
+			},
+		})
+		Params.Save("dataCoord.targetVecIndexVersion", "15")
+		Params.Save("dataCoord.forceRebuildSegmentIndex", "false")
+
+		// max(current=10, target=15) = 15
+		assert.Equal(t, int32(15), m.ResolveVecIndexVersion())
+	})
+
+	t.Run("force rebuild uses target directly", func(t *testing.T) {
+		m := newIndexEngineVersionManager()
+		m.AddNode(&sessionutil.Session{
+			SessionRaw: sessionutil.SessionRaw{
+				ServerID:           1,
+				IndexEngineVersion: sessionutil.IndexEngineVersion{CurrentIndexVersion: 10, MaximumIndexVersion: 20},
+			},
+		})
+		Params.Save("dataCoord.targetVecIndexVersion", "5")
+		Params.Save("dataCoord.forceRebuildSegmentIndex", "true")
+
+		// force rebuild: use target=5 directly even though current=10
+		assert.Equal(t, int32(5), m.ResolveVecIndexVersion())
+	})
+
+	t.Run("target exceeds maximum - clamped", func(t *testing.T) {
+		m := newIndexEngineVersionManager()
+		m.AddNode(&sessionutil.Session{
+			SessionRaw: sessionutil.SessionRaw{
+				ServerID:           1,
+				IndexEngineVersion: sessionutil.IndexEngineVersion{CurrentIndexVersion: 10, MaximumIndexVersion: 20},
+			},
+		})
+		Params.Save("dataCoord.targetVecIndexVersion", "25")
+		Params.Save("dataCoord.forceRebuildSegmentIndex", "true")
+
+		// target=25 > max=20, clamped to 20
+		assert.Equal(t, int32(20), m.ResolveVecIndexVersion())
+	})
+}
+
+func Test_IndexEngineVersionManager_ResolveScalarIndexVersion(t *testing.T) {
+	paramtable.Init()
+
+	t.Run("no target override", func(t *testing.T) {
+		m := newIndexEngineVersionManager()
+		m.AddNode(&sessionutil.Session{
+			SessionRaw: sessionutil.SessionRaw{
+				ServerID:                 1,
+				ScalarIndexEngineVersion: sessionutil.IndexEngineVersion{CurrentIndexVersion: 2, MaximumIndexVersion: 5},
+			},
+		})
+		Params.Save("dataCoord.targetScalarIndexVersion", "-1")
+		Params.Save("dataCoord.forceRebuildScalarSegmentIndex", "false")
+
+		assert.Equal(t, int32(2), m.ResolveScalarIndexVersion())
+	})
+
+	t.Run("target override without force rebuild", func(t *testing.T) {
+		m := newIndexEngineVersionManager()
+		m.AddNode(&sessionutil.Session{
+			SessionRaw: sessionutil.SessionRaw{
+				ServerID:                 1,
+				ScalarIndexEngineVersion: sessionutil.IndexEngineVersion{CurrentIndexVersion: 2, MaximumIndexVersion: 5},
+			},
+		})
+		Params.Save("dataCoord.targetScalarIndexVersion", "3")
+		Params.Save("dataCoord.forceRebuildScalarSegmentIndex", "false")
+
+		// max(current=2, target=3) = 3
+		assert.Equal(t, int32(3), m.ResolveScalarIndexVersion())
+	})
+
+	t.Run("force rebuild uses target directly", func(t *testing.T) {
+		m := newIndexEngineVersionManager()
+		m.AddNode(&sessionutil.Session{
+			SessionRaw: sessionutil.SessionRaw{
+				ServerID:                 1,
+				ScalarIndexEngineVersion: sessionutil.IndexEngineVersion{CurrentIndexVersion: 3, MaximumIndexVersion: 5},
+			},
+		})
+		Params.Save("dataCoord.targetScalarIndexVersion", "1")
+		Params.Save("dataCoord.forceRebuildScalarSegmentIndex", "true")
+
+		// force rebuild: use target=1 directly
+		assert.Equal(t, int32(1), m.ResolveScalarIndexVersion())
+	})
+
+	t.Run("target exceeds maximum - clamped", func(t *testing.T) {
+		m := newIndexEngineVersionManager()
+		m.AddNode(&sessionutil.Session{
+			SessionRaw: sessionutil.SessionRaw{
+				ServerID:                 1,
+				ScalarIndexEngineVersion: sessionutil.IndexEngineVersion{CurrentIndexVersion: 2, MaximumIndexVersion: 5},
+			},
+		})
+		Params.Save("dataCoord.targetScalarIndexVersion", "10")
+		Params.Save("dataCoord.forceRebuildScalarSegmentIndex", "true")
+
+		// target=10 > max=5, clamped to 5
+		assert.Equal(t, int32(5), m.ResolveScalarIndexVersion())
+	})
 }
 
 func Test_IndexEngineVersionManager_SessionVersionCleanupOnStartup(t *testing.T) {

--- a/internal/datacoord/mock_index_engine_version_manager.go
+++ b/internal/datacoord/mock_index_engine_version_manager.go
@@ -280,6 +280,186 @@ func (_c *MockVersionManager_GetMinimalScalarIndexEngineVersion_Call) RunAndRetu
 	return _c
 }
 
+// GetMaximumIndexEngineVersion provides a mock function with no fields
+func (_m *MockVersionManager) GetMaximumIndexEngineVersion() int32 {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetMaximumIndexEngineVersion")
+	}
+
+	var r0 int32
+	if rf, ok := ret.Get(0).(func() int32); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(int32)
+	}
+
+	return r0
+}
+
+// MockVersionManager_GetMaximumIndexEngineVersion_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetMaximumIndexEngineVersion'
+type MockVersionManager_GetMaximumIndexEngineVersion_Call struct {
+	*mock.Call
+}
+
+// GetMaximumIndexEngineVersion is a helper method to define mock.On call
+func (_e *MockVersionManager_Expecter) GetMaximumIndexEngineVersion() *MockVersionManager_GetMaximumIndexEngineVersion_Call {
+	return &MockVersionManager_GetMaximumIndexEngineVersion_Call{Call: _e.mock.On("GetMaximumIndexEngineVersion")}
+}
+
+func (_c *MockVersionManager_GetMaximumIndexEngineVersion_Call) Run(run func()) *MockVersionManager_GetMaximumIndexEngineVersion_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockVersionManager_GetMaximumIndexEngineVersion_Call) Return(_a0 int32) *MockVersionManager_GetMaximumIndexEngineVersion_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockVersionManager_GetMaximumIndexEngineVersion_Call) RunAndReturn(run func() int32) *MockVersionManager_GetMaximumIndexEngineVersion_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetMaximumScalarIndexEngineVersion provides a mock function with no fields
+func (_m *MockVersionManager) GetMaximumScalarIndexEngineVersion() int32 {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetMaximumScalarIndexEngineVersion")
+	}
+
+	var r0 int32
+	if rf, ok := ret.Get(0).(func() int32); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(int32)
+	}
+
+	return r0
+}
+
+// MockVersionManager_GetMaximumScalarIndexEngineVersion_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetMaximumScalarIndexEngineVersion'
+type MockVersionManager_GetMaximumScalarIndexEngineVersion_Call struct {
+	*mock.Call
+}
+
+// GetMaximumScalarIndexEngineVersion is a helper method to define mock.On call
+func (_e *MockVersionManager_Expecter) GetMaximumScalarIndexEngineVersion() *MockVersionManager_GetMaximumScalarIndexEngineVersion_Call {
+	return &MockVersionManager_GetMaximumScalarIndexEngineVersion_Call{Call: _e.mock.On("GetMaximumScalarIndexEngineVersion")}
+}
+
+func (_c *MockVersionManager_GetMaximumScalarIndexEngineVersion_Call) Run(run func()) *MockVersionManager_GetMaximumScalarIndexEngineVersion_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockVersionManager_GetMaximumScalarIndexEngineVersion_Call) Return(_a0 int32) *MockVersionManager_GetMaximumScalarIndexEngineVersion_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockVersionManager_GetMaximumScalarIndexEngineVersion_Call) RunAndReturn(run func() int32) *MockVersionManager_GetMaximumScalarIndexEngineVersion_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ResolveVecIndexVersion provides a mock function with no fields
+func (_m *MockVersionManager) ResolveVecIndexVersion() int32 {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for ResolveVecIndexVersion")
+	}
+
+	var r0 int32
+	if rf, ok := ret.Get(0).(func() int32); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(int32)
+	}
+
+	return r0
+}
+
+// MockVersionManager_ResolveVecIndexVersion_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ResolveVecIndexVersion'
+type MockVersionManager_ResolveVecIndexVersion_Call struct {
+	*mock.Call
+}
+
+// ResolveVecIndexVersion is a helper method to define mock.On call
+func (_e *MockVersionManager_Expecter) ResolveVecIndexVersion() *MockVersionManager_ResolveVecIndexVersion_Call {
+	return &MockVersionManager_ResolveVecIndexVersion_Call{Call: _e.mock.On("ResolveVecIndexVersion")}
+}
+
+func (_c *MockVersionManager_ResolveVecIndexVersion_Call) Run(run func()) *MockVersionManager_ResolveVecIndexVersion_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockVersionManager_ResolveVecIndexVersion_Call) Return(_a0 int32) *MockVersionManager_ResolveVecIndexVersion_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockVersionManager_ResolveVecIndexVersion_Call) RunAndReturn(run func() int32) *MockVersionManager_ResolveVecIndexVersion_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ResolveScalarIndexVersion provides a mock function with no fields
+func (_m *MockVersionManager) ResolveScalarIndexVersion() int32 {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for ResolveScalarIndexVersion")
+	}
+
+	var r0 int32
+	if rf, ok := ret.Get(0).(func() int32); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(int32)
+	}
+
+	return r0
+}
+
+// MockVersionManager_ResolveScalarIndexVersion_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ResolveScalarIndexVersion'
+type MockVersionManager_ResolveScalarIndexVersion_Call struct {
+	*mock.Call
+}
+
+// ResolveScalarIndexVersion is a helper method to define mock.On call
+func (_e *MockVersionManager_Expecter) ResolveScalarIndexVersion() *MockVersionManager_ResolveScalarIndexVersion_Call {
+	return &MockVersionManager_ResolveScalarIndexVersion_Call{Call: _e.mock.On("ResolveScalarIndexVersion")}
+}
+
+func (_c *MockVersionManager_ResolveScalarIndexVersion_Call) Run(run func()) *MockVersionManager_ResolveScalarIndexVersion_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockVersionManager_ResolveScalarIndexVersion_Call) Return(_a0 int32) *MockVersionManager_ResolveScalarIndexVersion_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockVersionManager_ResolveScalarIndexVersion_Call) RunAndReturn(run func() int32) *MockVersionManager_ResolveScalarIndexVersion_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetMinimalSessionVer provides a mock function with no fields
 func (_m *MockVersionManager) GetMinimalSessionVer() semver.Version {
 	ret := _m.Called()

--- a/internal/datacoord/task_index.go
+++ b/internal/datacoord/task_index.go
@@ -300,17 +300,8 @@ func (it *indexBuildTask) prepareJobRequest(ctx context.Context, segment *Segmen
 		Value: indexNonEncoding,
 	})
 
-	currentVecIndexVersion := it.indexEngineVersionManager.GetCurrentIndexEngineVersion()
-	// if specify target vec index version, use it with high priority
-	if Params.DataCoordCfg.TargetVecIndexVersion.GetAsInt64() != -1 {
-		// if force rebuild segment index is true, use target vec index version directly
-		if Params.DataCoordCfg.ForceRebuildSegmentIndex.GetAsBool() {
-			currentVecIndexVersion = Params.DataCoordCfg.TargetVecIndexVersion.GetAsInt32()
-		} else {
-			// if force rebuild segment index is not enabled, use newer index version between current index version and target index version
-			currentVecIndexVersion = max(currentVecIndexVersion, Params.DataCoordCfg.TargetVecIndexVersion.GetAsInt32())
-		}
-	}
+	currentVecIndexVersion := it.indexEngineVersionManager.ResolveVecIndexVersion()
+	currentScalarIndexVersion := it.indexEngineVersionManager.ResolveScalarIndexVersion()
 
 	// Create the job request
 	req := &workerpb.CreateJobRequest{
@@ -323,7 +314,7 @@ func (it *indexBuildTask) prepareJobRequest(ctx context.Context, segment *Segmen
 		TypeParams:                typeParams,
 		NumRows:                   segIndex.NumRows,
 		CurrentIndexVersion:       currentVecIndexVersion,
-		CurrentScalarIndexVersion: it.indexEngineVersionManager.GetCurrentScalarIndexEngineVersion(),
+		CurrentScalarIndexVersion: currentScalarIndexVersion,
 		CollectionID:              segment.GetCollectionID(),
 		PartitionID:               segment.GetPartitionID(),
 		SegmentID:                 segment.GetID(),

--- a/internal/datacoord/task_stats.go
+++ b/internal/datacoord/task_stats.go
@@ -339,7 +339,7 @@ func (st *statsTask) prepareJobRequest(ctx context.Context, segment *SegmentInfo
 		JsonKeyStatsDataFormat:           common.JSONStatsDataFormatVersion,
 		TaskSlot:                         st.taskSlot,
 		StorageVersion:                   segment.StorageVersion,
-		CurrentScalarIndexVersion:        st.ievm.GetCurrentScalarIndexEngineVersion(),
+		CurrentScalarIndexVersion:        st.ievm.ResolveScalarIndexVersion(),
 		JsonStatsMaxShreddingColumns:     Params.DataCoordCfg.JSONStatsMaxShreddingColumns.GetAsInt64(),
 		JsonStatsShreddingRatioThreshold: Params.DataCoordCfg.JSONStatsShreddingRatioThreshold.GetAsFloat(),
 		JsonStatsWriteBatchSize:          Params.DataCoordCfg.JSONStatsWriteBatchSize.GetAsInt64(),

--- a/internal/datanode/compactor/sort_compaction.go
+++ b/internal/datanode/compactor/sort_compaction.go
@@ -626,7 +626,7 @@ func (t *sortCompactionTask) createTextIndex(ctx context.Context,
 				Files:                     lo.Keys(uploaded),
 				LogSize:                   totalSize,
 				MemorySize:                totalSize,
-				CurrentScalarIndexVersion: common.CurrentScalarIndexEngineVersion,
+				CurrentScalarIndexVersion: common.ClampScalarIndexVersion(t.plan.GetCurrentScalarIndexVersion()),
 			}
 			mu.Unlock()
 

--- a/internal/datanode/compactor/sort_compaction.go
+++ b/internal/datanode/compactor/sort_compaction.go
@@ -595,7 +595,7 @@ func (t *sortCompactionTask) createTextIndex(ctx context.Context,
 				InsertFiles:               files,
 				FieldSchema:               field,
 				StorageConfig:             newStorageConfig,
-				CurrentScalarIndexVersion: t.plan.GetCurrentScalarIndexVersion(),
+				CurrentScalarIndexVersion: common.ClampScalarIndexVersion(t.plan.GetCurrentScalarIndexVersion()),
 				StorageVersion:            t.storageVersion,
 				Manifest:                  segment.GetManifest(),
 			}

--- a/internal/datanode/index/task_index.go
+++ b/internal/datanode/index/task_index.go
@@ -214,7 +214,7 @@ func (it *indexBuildTask) PreExecute(ctx context.Context) error {
 	}
 
 	it.req.CurrentIndexVersion = getCurrentIndexVersion(it.req.GetCurrentIndexVersion())
-	it.req.CurrentScalarIndexVersion = getCurrentScalarIndexVersion(it.req.GetCurrentScalarIndexVersion())
+	it.req.CurrentScalarIndexVersion = common.ClampScalarIndexVersion(it.req.GetCurrentScalarIndexVersion())
 
 	log.Ctx(ctx).Info("Successfully prepare indexBuildTask", zap.Int64("buildID", it.req.GetBuildID()),
 		zap.Int64("collectionID", it.req.GetCollectionID()), zap.Int64("segmentID", it.req.GetSegmentID()),

--- a/internal/datanode/index/task_stats.go
+++ b/internal/datanode/index/task_stats.go
@@ -787,7 +787,7 @@ func buildIndexParams(
 		InsertFiles:                      files,
 		FieldSchema:                      field,
 		StorageConfig:                    storageConfig,
-		CurrentScalarIndexVersion:        req.GetCurrentScalarIndexVersion(),
+		CurrentScalarIndexVersion:        getCurrentScalarIndexVersion(req.GetCurrentScalarIndexVersion()),
 		StorageVersion:                   req.GetStorageVersion(),
 		JsonStatsMaxShreddingColumns:     options.JsonStatsMaxShreddingColumns,
 		JsonStatsShreddingRatioThreshold: options.JsonStatsShreddingRatio,

--- a/internal/datanode/index/task_stats.go
+++ b/internal/datanode/index/task_stats.go
@@ -567,7 +567,7 @@ func (st *statsTask) createTextIndex(ctx context.Context,
 				Files:                     lo.Keys(uploaded),
 				LogSize:                   totalSize,
 				MemorySize:                totalSize,
-				CurrentScalarIndexVersion: getCurrentScalarIndexVersion(st.req.GetCurrentScalarIndexVersion()),
+				CurrentScalarIndexVersion: common.ClampScalarIndexVersion(st.req.GetCurrentScalarIndexVersion()),
 			}
 			mu.Unlock()
 
@@ -787,7 +787,7 @@ func buildIndexParams(
 		InsertFiles:                      files,
 		FieldSchema:                      field,
 		StorageConfig:                    storageConfig,
-		CurrentScalarIndexVersion:        getCurrentScalarIndexVersion(req.GetCurrentScalarIndexVersion()),
+		CurrentScalarIndexVersion:        common.ClampScalarIndexVersion(req.GetCurrentScalarIndexVersion()),
 		StorageVersion:                   req.GetStorageVersion(),
 		JsonStatsMaxShreddingColumns:     options.JsonStatsMaxShreddingColumns,
 		JsonStatsShreddingRatioThreshold: options.JsonStatsShreddingRatio,

--- a/internal/datanode/index/task_stats.go
+++ b/internal/datanode/index/task_stats.go
@@ -567,7 +567,7 @@ func (st *statsTask) createTextIndex(ctx context.Context,
 				Files:                     lo.Keys(uploaded),
 				LogSize:                   totalSize,
 				MemorySize:                totalSize,
-				CurrentScalarIndexVersion: common.CurrentScalarIndexEngineVersion,
+				CurrentScalarIndexVersion: getCurrentScalarIndexVersion(st.req.GetCurrentScalarIndexVersion()),
 			}
 			mu.Unlock()
 

--- a/internal/datanode/index/util.go
+++ b/internal/datanode/index/util.go
@@ -46,10 +46,6 @@ func getCurrentIndexVersion(v int32) int32 {
 	return v
 }
 
-func getCurrentScalarIndexVersion(v int32) int32 {
-	return common.ClampScalarIndexVersion(v)
-}
-
 func estimateFieldDataSize(dim int64, numRows int64, dataType schemapb.DataType) (uint64, error) {
 	switch dataType {
 	case schemapb.DataType_BinaryVector:

--- a/internal/datanode/index/util.go
+++ b/internal/datanode/index/util.go
@@ -47,11 +47,7 @@ func getCurrentIndexVersion(v int32) int32 {
 }
 
 func getCurrentScalarIndexVersion(v int32) int32 {
-	cCurrent := common.CurrentScalarIndexEngineVersion
-	if cCurrent < v {
-		return cCurrent
-	}
-	return v
+	return common.ClampScalarIndexVersion(v)
 }
 
 func estimateFieldDataSize(dim int64, numRows int64, dataType schemapb.DataType) (uint64, error) {

--- a/internal/datanode/index/util_test.go
+++ b/internal/datanode/index/util_test.go
@@ -20,10 +20,7 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-
-	"github.com/milvus-io/milvus/pkg/v2/common"
 )
 
 type utilSuite struct {
@@ -42,20 +39,6 @@ func (s *utilSuite) Test_mapToKVPairs() {
 
 func Test_utilSuite(t *testing.T) {
 	suite.Run(t, new(utilSuite))
-}
-
-func Test_getCurrentScalarIndexVersion(t *testing.T) {
-	// getCurrentScalarIndexVersion delegates to common.ClampScalarIndexVersion.
-	// This test verifies the delegation is correct and hasn't been changed
-	// to use CurrentScalarIndexEngineVersion (which would be wrong).
-	maximum := common.MaximumScalarIndexEngineVersion
-
-	assert.Equal(t, int32(0), getCurrentScalarIndexVersion(0))
-	assert.Equal(t, maximum, getCurrentScalarIndexVersion(maximum))
-	assert.Equal(t, maximum, getCurrentScalarIndexVersion(maximum+1))
-
-	// Verify it matches the shared helper
-	assert.Equal(t, common.ClampScalarIndexVersion(maximum+5), getCurrentScalarIndexVersion(maximum+5))
 }
 
 func generateFloats(num int) []float32 {

--- a/internal/datanode/index/util_test.go
+++ b/internal/datanode/index/util_test.go
@@ -20,7 +20,10 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/milvus-io/milvus/pkg/v2/common"
 )
 
 type utilSuite struct {
@@ -39,6 +42,20 @@ func (s *utilSuite) Test_mapToKVPairs() {
 
 func Test_utilSuite(t *testing.T) {
 	suite.Run(t, new(utilSuite))
+}
+
+func Test_getCurrentScalarIndexVersion(t *testing.T) {
+	// getCurrentScalarIndexVersion delegates to common.ClampScalarIndexVersion.
+	// This test verifies the delegation is correct and hasn't been changed
+	// to use CurrentScalarIndexEngineVersion (which would be wrong).
+	maximum := common.MaximumScalarIndexEngineVersion
+
+	assert.Equal(t, int32(0), getCurrentScalarIndexVersion(0))
+	assert.Equal(t, maximum, getCurrentScalarIndexVersion(maximum))
+	assert.Equal(t, maximum, getCurrentScalarIndexVersion(maximum+1))
+
+	// Verify it matches the shared helper
+	assert.Equal(t, common.ClampScalarIndexVersion(maximum+5), getCurrentScalarIndexVersion(maximum+5))
 }
 
 func generateFloats(num int) []float32 {

--- a/internal/querynodev2/segments/utils.go
+++ b/internal/querynodev2/segments/utils.go
@@ -179,13 +179,13 @@ func mergeRequestCost(requestCosts []*internalpb.CostAggregation) *internalpb.Co
 	return result
 }
 
-func getIndexEngineVersion() (minimal, current int32) {
+func getIndexEngineVersion() (minimal, current, maximum int32) {
 	GetDynamicPool().Submit(func() (any, error) {
-		cMinimal, cCurrent := C.GetMinimalIndexVersion(), C.GetCurrentIndexVersion()
-		minimal, current = int32(cMinimal), int32(cCurrent)
+		cMinimal, cCurrent, cMaximum := C.GetMinimalIndexVersion(), C.GetCurrentIndexVersion(), C.GetMaximumIndexVersion()
+		minimal, current, maximum = int32(cMinimal), int32(cCurrent), int32(cMaximum)
 		return nil, nil
 	}).Await()
-	return minimal, current
+	return minimal, current, maximum
 }
 
 // getSegmentMetricLabel returns the label for segment metrics.

--- a/internal/querynodev2/server.go
+++ b/internal/querynodev2/server.go
@@ -162,10 +162,13 @@ func NewQueryNode(ctx context.Context, factory dependency.Factory) *QueryNode {
 }
 
 func (node *QueryNode) initSession() error {
-	minimalIndexVersion, currentIndexVersion := getIndexEngineVersion()
+	minimalIndexVersion, currentIndexVersion, maximumIndexVersion := getIndexEngineVersion()
 	node.session = sessionutil.NewSession(node.ctx,
-		sessionutil.WithIndexEngineVersion(minimalIndexVersion, currentIndexVersion),
-		sessionutil.WithScalarIndexEngineVersion(common.MinimalScalarIndexEngineVersion, common.CurrentScalarIndexEngineVersion),
+		sessionutil.WithIndexEngineVersion(minimalIndexVersion, currentIndexVersion, maximumIndexVersion),
+		sessionutil.WithScalarIndexEngineVersion(
+			common.MinimalScalarIndexEngineVersion,
+			common.CurrentScalarIndexEngineVersion,
+			common.MaximumScalarIndexEngineVersion),
 		sessionutil.WithIndexNonEncoding())
 	if node.session == nil {
 		return errors.New("session is nil, the etcd client connection may have failed")
@@ -270,9 +273,9 @@ func (node *QueryNode) RegisterSegcoreConfigWatcher() {
 		config.NewHandler("common.diskWriteRateLimiter.lowPriorityRatio", node.ReconfigDiskFileWriterParams))
 }
 
-func getIndexEngineVersion() (minimal, current int32) {
-	cMinimal, cCurrent := C.GetMinimalIndexVersion(), C.GetCurrentIndexVersion()
-	return int32(cMinimal), int32(cCurrent)
+func getIndexEngineVersion() (minimal, current, maximum int32) {
+	cMinimal, cCurrent, cMaximum := C.GetMinimalIndexVersion(), C.GetCurrentIndexVersion(), C.GetMaximumIndexVersion()
+	return int32(cMinimal), int32(cCurrent), int32(cMaximum)
 }
 
 func (node *QueryNode) GetNodeID() int64 {

--- a/internal/util/segcore/segcore_init.go
+++ b/internal/util/segcore/segcore_init.go
@@ -16,13 +16,15 @@ import "C"
 type IndexEngineInfo struct {
 	MinIndexVersion     int32
 	CurrentIndexVersion int32
+	MaxIndexVersion     int32
 }
 
-// GetIndexEngineInfo returns the minimal and current version of the index engine.
+// GetIndexEngineInfo returns the minimal, current, and maximum version of the index engine.
 func GetIndexEngineInfo() IndexEngineInfo {
-	cMinimal, cCurrent := C.GetMinimalIndexVersion(), C.GetCurrentIndexVersion()
+	cMinimal, cCurrent, cMaximum := C.GetMinimalIndexVersion(), C.GetCurrentIndexVersion(), C.GetMaximumIndexVersion()
 	return IndexEngineInfo{
 		MinIndexVersion:     int32(cMinimal),
 		CurrentIndexVersion: int32(cCurrent),
+		MaxIndexVersion:     int32(cMaximum),
 	}
 }

--- a/internal/util/segcore/segcore_init_test.go
+++ b/internal/util/segcore/segcore_init_test.go
@@ -10,4 +10,6 @@ func TestGetIndexEngineInfo(t *testing.T) {
 	r := GetIndexEngineInfo()
 	assert.NotZero(t, r.CurrentIndexVersion)
 	assert.Zero(t, r.MinIndexVersion)
+	assert.NotZero(t, r.MaxIndexVersion)
+	assert.GreaterOrEqual(t, r.MaxIndexVersion, r.CurrentIndexVersion)
 }

--- a/internal/util/sessionutil/session_util.go
+++ b/internal/util/sessionutil/session_util.go
@@ -113,6 +113,7 @@ const (
 type IndexEngineVersion struct {
 	MinimalIndexVersion int32 `json:"MinimalIndexVersion,omitempty"`
 	CurrentIndexVersion int32 `json:"CurrentIndexVersion,omitempty"`
+	MaximumIndexVersion int32 `json:"MaximumIndexVersion,omitempty"`
 }
 
 // SessionRaw the persistent part of Session.
@@ -197,18 +198,20 @@ func WithResueNodeID(b bool) SessionOption {
 }
 
 // WithIndexEngineVersion should be only used by querynode.
-func WithIndexEngineVersion(minimal, current int32) SessionOption {
+func WithIndexEngineVersion(minimal, current, maximum int32) SessionOption {
 	return func(session *Session) {
 		session.IndexEngineVersion.MinimalIndexVersion = minimal
 		session.IndexEngineVersion.CurrentIndexVersion = current
+		session.IndexEngineVersion.MaximumIndexVersion = maximum
 	}
 }
 
 // WithScalarIndexEngineVersion should be only used by querynode.
-func WithScalarIndexEngineVersion(minimal, current int32) SessionOption {
+func WithScalarIndexEngineVersion(minimal, current, maximum int32) SessionOption {
 	return func(session *Session) {
 		session.ScalarIndexEngineVersion.MinimalIndexVersion = minimal
 		session.ScalarIndexEngineVersion.CurrentIndexVersion = current
+		session.ScalarIndexEngineVersion.MaximumIndexVersion = maximum
 	}
 }
 

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -94,7 +94,18 @@ const (
 	// TODO: scalar index version 3 is still in development, so we use 2 as the current version.
 	// Do not use version 3 until this TODO is resolved.
 	CurrentScalarIndexEngineVersion = int32(2)
+	MaximumScalarIndexEngineVersion = int32(2)
 )
+
+// ClampScalarIndexVersion clamps the given scalar index version to MaximumScalarIndexEngineVersion.
+// Used by DataNode to ensure the version written back to metadata does not exceed
+// what the cluster can handle.
+func ClampScalarIndexVersion(v int32) int32 {
+	if v > MaximumScalarIndexEngineVersion {
+		return MaximumScalarIndexEngineVersion
+	}
+	return v
+}
 
 const DefaultTimezone = "UTC"
 

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -439,6 +439,19 @@ func TestIsBigTopKOptimizationEnabled(t *testing.T) {
 	})
 }
 
+func TestClampScalarIndexVersion(t *testing.T) {
+	max := MaximumScalarIndexEngineVersion
+
+	// Values at or below maximum pass through unchanged
+	assert.Equal(t, int32(0), ClampScalarIndexVersion(0))
+	assert.Equal(t, int32(1), ClampScalarIndexVersion(1))
+	assert.Equal(t, max, ClampScalarIndexVersion(max))
+
+	// Values above maximum are clamped
+	assert.Equal(t, max, ClampScalarIndexVersion(max+1))
+	assert.Equal(t, max, ClampScalarIndexVersion(max+100))
+}
+
 func TestWKTWKBConversion(t *testing.T) {
 	testCases := []struct {
 		name string

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -4667,11 +4667,11 @@ type dataCoordConfig struct {
 	SegmentMinSizeFromIdleToSealed ParamItem `refreshable:"false"`
 	SegmentMaxBinlogFileNumber     ParamItem `refreshable:"false"`
 	GrowingSegmentsMemSizeInMB     ParamItem `refreshable:"true"`
-	AutoUpgradeSegmentIndex             ParamItem `refreshable:"true"`
-	ForceRebuildSegmentIndex            ParamItem `refreshable:"true"`
-	TargetVecIndexVersion               ParamItem `refreshable:"true"`
-	ForceRebuildScalarSegmentIndex      ParamItem `refreshable:"true"`
-	TargetScalarIndexVersion            ParamItem `refreshable:"true"`
+	AutoUpgradeSegmentIndex        ParamItem `refreshable:"true"`
+	ForceRebuildSegmentIndex       ParamItem `refreshable:"true"`
+	TargetVecIndexVersion          ParamItem `refreshable:"true"`
+	ForceRebuildScalarSegmentIndex ParamItem `refreshable:"true"`
+	TargetScalarIndexVersion       ParamItem `refreshable:"true"`
 	SegmentFlushInterval           ParamItem `refreshable:"true"`
 	BlockingL0EntryNum             ParamItem `refreshable:"true"`
 	BlockingL0SizeInMB             ParamItem `refreshable:"true"`

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -5750,7 +5750,7 @@ if param targetVecIndexVersion is not set, the default value is -1, which means 
 
 	p.ForceRebuildScalarSegmentIndex = ParamItem{
 		Key:          "dataCoord.forceRebuildScalarSegmentIndex",
-		Version:      "2.5.10",
+		Version:      "3.0.0",
 		DefaultValue: "false",
 		PanicIfEmpty: true,
 		Doc:          "force rebuild scalar segment index to specified scalar index engine's version",
@@ -5760,7 +5760,7 @@ if param targetVecIndexVersion is not set, the default value is -1, which means 
 
 	p.TargetScalarIndexVersion = ParamItem{
 		Key:          "dataCoord.targetScalarIndexVersion",
-		Version:      "2.5.10",
+		Version:      "3.0.0",
 		DefaultValue: "-1",
 		PanicIfEmpty: true,
 		Doc: `if param forceRebuildScalarSegmentIndex is enabled, the scalar index will be rebuilt to aligned with targetScalarIndexVersion.

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -4667,9 +4667,11 @@ type dataCoordConfig struct {
 	SegmentMinSizeFromIdleToSealed ParamItem `refreshable:"false"`
 	SegmentMaxBinlogFileNumber     ParamItem `refreshable:"false"`
 	GrowingSegmentsMemSizeInMB     ParamItem `refreshable:"true"`
-	AutoUpgradeSegmentIndex        ParamItem `refreshable:"true"`
-	ForceRebuildSegmentIndex       ParamItem `refreshable:"true"`
-	TargetVecIndexVersion          ParamItem `refreshable:"true"`
+	AutoUpgradeSegmentIndex             ParamItem `refreshable:"true"`
+	ForceRebuildSegmentIndex            ParamItem `refreshable:"true"`
+	TargetVecIndexVersion               ParamItem `refreshable:"true"`
+	ForceRebuildScalarSegmentIndex      ParamItem `refreshable:"true"`
+	TargetScalarIndexVersion            ParamItem `refreshable:"true"`
 	SegmentFlushInterval           ParamItem `refreshable:"true"`
 	BlockingL0EntryNum             ParamItem `refreshable:"true"`
 	BlockingL0SizeInMB             ParamItem `refreshable:"true"`
@@ -5745,6 +5747,28 @@ if param targetVecIndexVersion is not set, the default value is -1, which means 
 		Export: true,
 	}
 	p.TargetVecIndexVersion.Init(base.mgr)
+
+	p.ForceRebuildScalarSegmentIndex = ParamItem{
+		Key:          "dataCoord.forceRebuildScalarSegmentIndex",
+		Version:      "2.5.10",
+		DefaultValue: "false",
+		PanicIfEmpty: true,
+		Doc:          "force rebuild scalar segment index to specified scalar index engine's version",
+		Export:       true,
+	}
+	p.ForceRebuildScalarSegmentIndex.Init(base.mgr)
+
+	p.TargetScalarIndexVersion = ParamItem{
+		Key:          "dataCoord.targetScalarIndexVersion",
+		Version:      "2.5.10",
+		DefaultValue: "-1",
+		PanicIfEmpty: true,
+		Doc: `if param forceRebuildScalarSegmentIndex is enabled, the scalar index will be rebuilt to aligned with targetScalarIndexVersion.
+if param forceRebuildScalarSegmentIndex is not enabled, the newly created scalar index will be aligned with the newer one of scalar index engine's version and targetScalarIndexVersion.
+if param targetScalarIndexVersion is not set, the default value is -1, which means no target scalar index version, then the scalar index will be aligned with scalar index engine's version`,
+		Export: true,
+	}
+	p.TargetScalarIndexVersion.Init(base.mgr)
 
 	p.SegmentFlushInterval = ParamItem{
 		Key:          "dataCoord.segmentFlushInterval",


### PR DESCRIPTION
Introduce full scalar index version management parity with vector indexes:
- Add MaximumScalarIndexEngineVersion constant and MaximumIndexVersion to session
- Add targetScalarIndexVersion and forceRebuildScalarSegmentIndex config params
- Add GetMaximum*Version() and Resolve*IndexVersion() to IndexEngineVersionManager
- Propagate MaximumIndexVersion from knowhere C++ to Go layer via session
- Add scalar forceRebuild path in compaction trigger
- Fix DataNode scalar version clamp to use Maximum instead of Current
- Fix sort_compaction and stats task to use request-carried version
- Use resolved (clamped) target version in compaction trigger to prevent infinite rebuild loops

issue: https://github.com/milvus-io/milvus/issues/47417
design doc: https://github.com/milvus-io/milvus-design-docs/blob/main/design_docs/20260313-scalar_index_version_management.md