### PR TITLE
fix: remove IsTriggerKill SIGINT from datacoord and querycoord session watchers

### DIFF
--- a/cmd/tools/migration/migration/runner.go
+++ b/cmd/tools/migration/migration/runner.go
@@ -97,7 +97,7 @@ func (r *Runner) init() {
 	// address not important here.
 	address := time.Now().String()
 	r.address = address
-	r.session.Init(Role, address, true, true)
+	r.session.Init(Role, address, true)
 	r.WatchSessions()
 }
 

--- a/internal/coordinator/mix_coord.go
+++ b/internal/coordinator/mix_coord.go
@@ -350,6 +350,10 @@ func (s *mixCoordImpl) Stop() error {
 		log.Error("Failed to stop rootCoord", zap.Error(err))
 	}
 
+	// All coordinators have stopped. Now stop the session.
+	s.session.SetMixCoordMode(false)
+	s.session.Stop()
+
 	s.fileResourceObserver.Stop()
 	s.cancel()
 	return nil
@@ -369,8 +373,11 @@ func (s *mixCoordImpl) initStreamingCoord() {
 
 func (s *mixCoordImpl) initSession() error {
 	s.session = sessionutil.NewSession(s.ctx)
-	s.session.Init(typeutil.MixCoordRole, s.address, true, true)
+	s.session.Init(typeutil.MixCoordRole, s.address, true)
 	s.session.SetEnableActiveStandBy(true)
+	// Mark session as MixCoord mode so individual coordinator Stop() calls won't cancel it.
+	// MixCoord owns the session lifecycle and stops it after all coordinators have stopped.
+	s.session.SetMixCoordMode(true)
 	s.rootcoordServer.SetSession(s.session)
 	s.datacoordServer.SetSession(s.session)
 	s.queryCoordServer.SetSession(s.session)

--- a/internal/coordinator/mix_coord_test.go
+++ b/internal/coordinator/mix_coord_test.go
@@ -80,7 +80,6 @@ func TestMixcoord_EnableActiveStandby(t *testing.T) {
 	err = core.Init()
 	assert.NoError(t, err)
 	assert.Equal(t, commonpb.StateCode_StandBy, core.GetStateCode())
-	core.session.TriggerKill = false
 	err = core.Register()
 	assert.NoError(t, err)
 	err = core.Start()

--- a/internal/datacoord/server.go
+++ b/internal/datacoord/server.go
@@ -879,7 +879,7 @@ func (s *Server) stopServiceWatch() {
 		// Force exit so the process can be restarted by the orchestrator (e.g. K8s).
 		log.Ctx(s.ctx).Error("force exit due to unexpected watch service failure")
 		log.Cleanup()
-		os.Exit(1)
+		os.Exit(sessionutil.ExitCodeEtcd)
 	}
 }
 

--- a/internal/datacoord/server.go
+++ b/internal/datacoord/server.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"sync"
 	"sync/atomic"
-	"syscall"
 	"time"
 
 	"github.com/blang/semver/v4"
@@ -674,13 +673,13 @@ func (s *Server) initSegmentManager() error {
 func (s *Server) initSession() error {
 	if s.icSession == nil {
 		s.icSession = sessionutil.NewSession(s.ctx)
-		s.icSession.Init(typeutil.IndexCoordRole, s.address, true, true)
+		s.icSession.Init(typeutil.IndexCoordRole, s.address, true)
 		s.icSession.SetEnableActiveStandBy(s.enableActiveStandBy)
 	}
 	if s.session == nil {
 		s.session = sessionutil.NewSession(s.ctx)
 
-		s.session.Init(typeutil.DataCoordRole, s.address, true, true)
+		s.session.Init(typeutil.DataCoordRole, s.address, true)
 		s.session.SetEnableActiveStandBy(s.enableActiveStandBy)
 	}
 	return nil
@@ -875,11 +874,12 @@ func (s *Server) startWatchService(ctx context.Context) {
 func (s *Server) stopServiceWatch() {
 	// ErrCompacted is handled inside SessionWatcher, which means there is some other error occurred, closing server.
 	log.Ctx(s.ctx).Error("watch service channel closed", zap.Int64("serverID", paramtable.GetNodeID()))
-	go s.Stop()
-	if s.session.IsTriggerKill() {
-		if p, err := os.FindProcess(os.Getpid()); err == nil {
-			p.Signal(syscall.SIGINT)
-		}
+	if s.ctx.Err() == nil {
+		// ctx is still active, meaning this is not a normal shutdown but a genuine watch failure.
+		// Force exit so the process can be restarted by the orchestrator (e.g. K8s).
+		log.Ctx(s.ctx).Error("force exit due to unexpected watch service failure")
+		log.Cleanup()
+		os.Exit(1)
 	}
 }
 

--- a/internal/datacoord/server_test.go
+++ b/internal/datacoord/server_test.go
@@ -21,11 +21,9 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
-	"os/signal"
 	"path"
 	"strconv"
 	"sync"
-	"syscall"
 	"testing"
 	"time"
 
@@ -724,14 +722,10 @@ func TestGetSegmentsByStates(t *testing.T) {
 }
 
 func TestService_WatchServices(t *testing.T) {
-	sc := make(chan os.Signal, 1)
-	signal.Notify(sc, syscall.SIGINT)
-	defer signal.Reset(syscall.SIGINT)
 	factory := dependency.NewDefaultFactory(true)
-	svr := CreateServer(context.TODO(), factory)
-	svr.session = &sessionutil.Session{
-		SessionRaw: sessionutil.SessionRaw{TriggerKill: true},
-	}
+	svrCtx, svrCancel := context.WithCancel(context.Background())
+	svr := CreateServer(svrCtx, factory)
+	svr.session = &sessionutil.Session{}
 	svr.serverLoopWg.Add(1)
 
 	ech := make(chan *sessionutil.SessionEvent)
@@ -743,26 +737,20 @@ func TestService_WatchServices(t *testing.T) {
 	svr.qnSessionWatcher = mockQnWatcher
 
 	flag := false
-	closed := false
-	sigDone := make(chan struct{}, 1)
-	sigQuit := make(chan struct{}, 1)
+	done := make(chan struct{}, 1)
 
 	go func() {
 		svr.watchService(context.Background())
 		flag = true
-		sigDone <- struct{}{}
-	}()
-	go func() {
-		<-sc
-		closed = true
-		sigQuit <- struct{}{}
+		done <- struct{}{}
 	}()
 
+	// Cancel svr.ctx before closing the channel so stopServiceWatch sees ctx.Err() != nil
+	// and skips os.Exit (simulating normal shutdown).
+	svrCancel()
 	close(ech)
-	<-sigDone
-	<-sigQuit
+	<-done
 	assert.True(t, flag)
-	assert.True(t, closed)
 
 	ech = make(chan *sessionutil.SessionEvent)
 
@@ -776,12 +764,12 @@ func TestService_WatchServices(t *testing.T) {
 	go func() {
 		svr.watchService(ctx)
 		flag = true
-		sigDone <- struct{}{}
+		done <- struct{}{}
 	}()
 
 	ech <- nil
 	cancel()
-	<-sigDone
+	<-done
 	assert.True(t, flag)
 }
 

--- a/internal/datanode/data_node.go
+++ b/internal/datanode/data_node.go
@@ -168,7 +168,7 @@ func (node *DataNode) initSession() error {
 	if node.session == nil {
 		return errors.New("failed to initialize session")
 	}
-	node.session.Init(typeutil.DataNodeRole, node.address, false, true)
+	node.session.Init(typeutil.DataNodeRole, node.address, false)
 	sessionutil.SaveServerInfo(typeutil.DataNodeRole, node.session.ServerID)
 	return nil
 }

--- a/internal/distributed/streamingnode/service.go
+++ b/internal/distributed/streamingnode/service.go
@@ -261,7 +261,7 @@ func (s *Server) initSession() error {
 	if s.session == nil {
 		return errors.New("session is nil, the etcd client connection may have failed")
 	}
-	s.session.Init(typeutil.StreamingNodeRole, s.listener.Address(), false, true)
+	s.session.Init(typeutil.StreamingNodeRole, s.listener.Address(), false)
 	paramtable.SetNodeID(s.session.ServerID)
 	log.Ctx(s.ctx).Info("StreamingNode init session", zap.Int64("nodeID", paramtable.GetNodeID()), zap.String("node address", s.listener.Address()))
 	return nil

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -166,7 +166,7 @@ func (node *Proxy) initSession() error {
 	if node.session == nil {
 		return errors.New("new session failed, maybe etcd cannot be connected")
 	}
-	node.session.Init(typeutil.ProxyRole, node.address, false, true)
+	node.session.Init(typeutil.ProxyRole, node.address, false)
 	sessionutil.SaveServerInfo(typeutil.ProxyRole, node.session.ServerID)
 	return nil
 }

--- a/internal/querycoordv2/mocks/querynode.go
+++ b/internal/querycoordv2/mocks/querynode.go
@@ -131,7 +131,7 @@ func (node *MockQueryNode) Start() error {
 	}).Maybe()
 
 	// Register
-	node.session.Init(typeutil.QueryNodeRole, node.addr, false, true)
+	node.session.Init(typeutil.QueryNodeRole, node.addr, false)
 	node.session.ServerID = node.ID
 	node.session.Register()
 	log.Ctx(context.TODO()).Debug("mock QueryNode started",

--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -658,7 +658,7 @@ func (s *Server) watchNodes(revision int64) {
 					// Force exit so the process can be restarted by the orchestrator (e.g. K8s).
 					log.Ctx(s.ctx).Error("force exit due to unexpected session watcher failure")
 					log.Cleanup()
-					os.Exit(1)
+					os.Exit(sessionutil.ExitCodeEtcd)
 				}
 				return
 			}

--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/blang/semver/v4"
@@ -256,7 +255,7 @@ func (s *Server) initSession() error {
 	// Init QueryCoord session
 	if s.session == nil {
 		s.session = sessionutil.NewSession(s.ctx)
-		s.session.Init(typeutil.QueryCoordRole, s.address, true, true)
+		s.session.Init(typeutil.QueryCoordRole, s.address, true)
 		s.enableActiveStandBy = Params.QueryCoordCfg.EnableActiveStandby.GetAsBool()
 		s.session.SetEnableActiveStandBy(s.enableActiveStandBy)
 	}
@@ -639,7 +638,6 @@ func (s *Server) SetQueryNodeCreator(f func(ctx context.Context, addr string, no
 }
 
 func (s *Server) watchNodes(revision int64) {
-	log := log.Ctx(s.ctx)
 	defer s.wg.Done()
 
 	s.sessionWatcherMu.Lock()
@@ -654,12 +652,13 @@ func (s *Server) watchNodes(revision int64) {
 		case event, ok := <-s.sessionWatcher.EventChannel():
 			if !ok {
 				// ErrCompacted is handled inside SessionWatcher
-				log.Warn("Session Watcher channel closed", zap.Int64("serverID", paramtable.GetNodeID()))
-				go s.Stop()
-				if s.session.IsTriggerKill() {
-					if p, err := os.FindProcess(os.Getpid()); err == nil {
-						p.Signal(syscall.SIGINT)
-					}
+				log.Ctx(s.ctx).Warn("Session Watcher channel closed", zap.Int64("serverID", paramtable.GetNodeID()))
+				if s.ctx.Err() == nil {
+					// ctx is still active, meaning this is not a normal shutdown but a genuine watch failure.
+					// Force exit so the process can be restarted by the orchestrator (e.g. K8s).
+					log.Ctx(s.ctx).Error("force exit due to unexpected session watcher failure")
+					log.Cleanup()
+					os.Exit(1)
 				}
 				return
 			}

--- a/internal/querynodev2/server.go
+++ b/internal/querynodev2/server.go
@@ -170,7 +170,7 @@ func (node *QueryNode) initSession() error {
 	if node.session == nil {
 		return errors.New("session is nil, the etcd client connection may have failed")
 	}
-	node.session.Init(typeutil.QueryNodeRole, node.address, false, true)
+	node.session.Init(typeutil.QueryNodeRole, node.address, false)
 	sessionutil.SaveServerInfo(typeutil.QueryNodeRole, node.session.ServerID)
 	paramtable.SetNodeID(node.session.ServerID)
 	node.serverID = node.session.ServerID

--- a/internal/querynodev2/server_test.go
+++ b/internal/querynodev2/server_test.go
@@ -112,7 +112,6 @@ func (suite *QueryNodeSuite) TestBasic() {
 	suite.True(suite.node.lifetime.GetState() == commonpb.StateCode_Healthy)
 
 	// register node to etcd
-	suite.node.session.TriggerKill = false
 	err = suite.node.Register()
 	suite.NoError(err)
 

--- a/internal/util/sessionutil/mock_session.go
+++ b/internal/util/sessionutil/mock_session.go
@@ -379,9 +379,9 @@ func (_c *MockSession_GoingStop_Call) RunAndReturn(run func() error) *MockSessio
 	return _c
 }
 
-// Init provides a mock function with given fields: serverName, address, exclusive, triggerKill
-func (_m *MockSession) Init(serverName string, address string, exclusive bool, triggerKill bool) {
-	_m.Called(serverName, address, exclusive, triggerKill)
+// Init provides a mock function with given fields: serverName, address, exclusive
+func (_m *MockSession) Init(serverName string, address string, exclusive bool) {
+	_m.Called(serverName, address, exclusive)
 }
 
 // MockSession_Init_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Init'
@@ -393,14 +393,13 @@ type MockSession_Init_Call struct {
 //   - serverName string
 //   - address string
 //   - exclusive bool
-//   - triggerKill bool
-func (_e *MockSession_Expecter) Init(serverName interface{}, address interface{}, exclusive interface{}, triggerKill interface{}) *MockSession_Init_Call {
-	return &MockSession_Init_Call{Call: _e.mock.On("Init", serverName, address, exclusive, triggerKill)}
+func (_e *MockSession_Expecter) Init(serverName interface{}, address interface{}, exclusive interface{}) *MockSession_Init_Call {
+	return &MockSession_Init_Call{Call: _e.mock.On("Init", serverName, address, exclusive)}
 }
 
-func (_c *MockSession_Init_Call) Run(run func(serverName string, address string, exclusive bool, triggerKill bool)) *MockSession_Init_Call {
+func (_c *MockSession_Init_Call) Run(run func(serverName string, address string, exclusive bool)) *MockSession_Init_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string), args[2].(bool), args[3].(bool))
+		run(args[0].(string), args[1].(string), args[2].(bool))
 	})
 	return _c
 }
@@ -410,53 +409,8 @@ func (_c *MockSession_Init_Call) Return() *MockSession_Init_Call {
 	return _c
 }
 
-func (_c *MockSession_Init_Call) RunAndReturn(run func(string, string, bool, bool)) *MockSession_Init_Call {
+func (_c *MockSession_Init_Call) RunAndReturn(run func(string, string, bool)) *MockSession_Init_Call {
 	_c.Run(run)
-	return _c
-}
-
-// IsTriggerKill provides a mock function with no fields
-func (_m *MockSession) IsTriggerKill() bool {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for IsTriggerKill")
-	}
-
-	var r0 bool
-	if rf, ok := ret.Get(0).(func() bool); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-
-	return r0
-}
-
-// MockSession_IsTriggerKill_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsTriggerKill'
-type MockSession_IsTriggerKill_Call struct {
-	*mock.Call
-}
-
-// IsTriggerKill is a helper method to define mock.On call
-func (_e *MockSession_Expecter) IsTriggerKill() *MockSession_IsTriggerKill_Call {
-	return &MockSession_IsTriggerKill_Call{Call: _e.mock.On("IsTriggerKill")}
-}
-
-func (_c *MockSession_IsTriggerKill_Call) Run(run func()) *MockSession_IsTriggerKill_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *MockSession_IsTriggerKill_Call) Return(_a0 bool) *MockSession_IsTriggerKill_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockSession_IsTriggerKill_Call) RunAndReturn(run func() bool) *MockSession_IsTriggerKill_Call {
-	_c.Call.Return(run)
 	return _c
 }
 

--- a/internal/util/sessionutil/session.go
+++ b/internal/util/sessionutil/session.go
@@ -25,7 +25,7 @@ type SessionInterface interface {
 	UnmarshalJSON(data []byte) error
 	MarshalJSON() ([]byte, error)
 
-	Init(serverName, address string, exclusive bool, triggerKill bool)
+	Init(serverName, address string, exclusive bool)
 	String() string
 	Register()
 
@@ -46,7 +46,6 @@ type SessionInterface interface {
 	GetAddress() string
 	GetServerID() int64
 	GetRegisteredRevision() int64
-	IsTriggerKill() bool
 }
 
 type SessionWatcher interface {

--- a/internal/util/sessionutil/session_util.go
+++ b/internal/util/sessionutil/session_util.go
@@ -51,9 +51,12 @@ const (
 	// DefaultServiceRoot default root path used in kv by Session
 	DefaultServiceRoot = "session/"
 	// DefaultIDKey default id key for Session
-	DefaultIDKey                = "id"
-	MilvusNodeIDForTesting      = "MILVUS_NODE_ID_FOR_TESTING"
-	exitCodeSessionLeaseExpired = 1
+	DefaultIDKey           = "id"
+	MilvusNodeIDForTesting = "MILVUS_NODE_ID_FOR_TESTING"
+	// ExitCodeEtcd is the exit code used when the process must terminate due to
+	// an unrecoverable etcd failure (session lease expired, watch channel closed, etc.).
+	// Using a distinctive code (80) so K8s pod status can identify etcd-related crashes.
+	ExitCodeEtcd = 80
 
 	serverVersionKey = "version"
 )
@@ -631,19 +634,19 @@ func (s *Session) checkKeepaliveTTL(nextKeepaliveInstant time.Time) error {
 		if errors.Is(err, v3rpc.ErrLeaseNotFound) {
 			s.Logger().Error("confirm the lease is not found, the session is expired without activing closing", zap.Error(err))
 			log.Cleanup()
-			os.Exit(exitCodeSessionLeaseExpired)
+			os.Exit(ExitCodeEtcd)
 		}
 		if ctx.Err() != nil && errors.Is(context.Cause(ctx), errSessionExpiredAtClientSide) {
 			s.Logger().Error("session expired at client side, the session is expired without activing closing", zap.Error(err))
 			log.Cleanup()
-			os.Exit(exitCodeSessionLeaseExpired)
+			os.Exit(ExitCodeEtcd)
 		}
 		return errors.Wrap(err, "failed to check TTL")
 	}
 	if ttlResp.TTL <= 0 {
 		s.Logger().Error("confirm the lease is expired, the session is expired without activing closing", zap.Error(err))
 		log.Cleanup()
-		os.Exit(exitCodeSessionLeaseExpired)
+		os.Exit(ExitCodeEtcd)
 	}
 	s.Logger().Info("check TTL success, try to keep alive...", zap.Int64("ttl", ttlResp.TTL))
 	return nil

--- a/internal/util/sessionutil/session_util.go
+++ b/internal/util/sessionutil/session_util.go
@@ -114,12 +114,11 @@ type IndexEngineVersion struct {
 
 // SessionRaw the persistent part of Session.
 type SessionRaw struct {
-	ServerID                 int64  `json:"ServerID,omitempty"`
-	ServerName               string `json:"ServerName,omitempty"`
-	Address                  string `json:"Address,omitempty"`
-	Exclusive                bool   `json:"Exclusive,omitempty"`
-	Stopping                 bool   `json:"Stopping,omitempty"`
-	TriggerKill              bool
+	ServerID                 int64              `json:"ServerID,omitempty"`
+	ServerName               string             `json:"ServerName,omitempty"`
+	Address                  string             `json:"Address,omitempty"`
+	Exclusive                bool               `json:"Exclusive,omitempty"`
+	Stopping                 bool               `json:"Stopping,omitempty"`
 	Version                  string             `json:"Version"`
 	IndexEngineVersion       IndexEngineVersion `json:"IndexEngineVersion,omitempty"`
 	ScalarIndexEngineVersion IndexEngineVersion `json:"ScalarIndexEngineVersion,omitempty"`
@@ -140,10 +139,6 @@ func (s *SessionRaw) GetServerID() int64 {
 
 func (s *SessionRaw) GetServerLabel() map[string]string {
 	return s.ServerLabels
-}
-
-func (s *SessionRaw) IsTriggerKill() bool {
-	return s.TriggerKill
 }
 
 // Session is a struct to store service's session, including ServerID, ServerName,
@@ -168,6 +163,7 @@ type Session struct {
 	wg                sync.WaitGroup
 
 	metaRoot string
+	isMixCoordMode atomic.Bool
 
 	registered         atomic.Value
 	registeredRevision atomic.Int64
@@ -297,11 +293,10 @@ func NewSessionWithEtcd(ctx context.Context, metaRoot string, client *clientv3.C
 
 // Init will initialize base struct of the Session, including ServerName, ServerID,
 // Address, Exclusive. ServerID is obtained in getServerID.
-func (s *Session) Init(serverName, address string, exclusive bool, triggerKill bool) {
+func (s *Session) Init(serverName, address string, exclusive bool) {
 	s.ServerName = serverName
 	s.Address = address
 	s.Exclusive = exclusive
-	s.TriggerKill = triggerKill
 	s.checkIDExist()
 	serverID, err := s.getServerID()
 	if err != nil {
@@ -943,7 +938,18 @@ func (w *sessionWatcher) EventChannel() <-chan *SessionEvent {
 	return w.eventCh
 }
 
+// SetMixCoordMode marks this session as shared across multiple coordinators in MixCoord mode.
+// When in MixCoord mode, Stop() is a no-op — MixCoord is responsible for calling Stop() after
+// clearing the flag.
+func (s *Session) SetMixCoordMode(enable bool) {
+	s.isMixCoordMode.Store(enable)
+}
+
 func (s *Session) Stop() {
+	if s.isMixCoordMode.Load() {
+		log.Info("session stop skipped, session is in MixCoord mode", zap.String("serverName", s.ServerName))
+		return
+	}
 	log.Info("session stopping", zap.String("serverName", s.ServerName))
 	if s.cancel != nil {
 		s.cancel()

--- a/internal/util/sessionutil/session_util.go
+++ b/internal/util/sessionutil/session_util.go
@@ -162,7 +162,7 @@ type Session struct {
 	watchCancel       atomic.Pointer[context.CancelFunc]
 	wg                sync.WaitGroup
 
-	metaRoot string
+	metaRoot       string
 	isMixCoordMode atomic.Bool
 
 	registered         atomic.Value

--- a/internal/util/sessionutil/session_util_test.go
+++ b/internal/util/sessionutil/session_util_test.go
@@ -916,8 +916,8 @@ func TestForceKill(t *testing.T) {
 
 	// 子进程退出码
 	if e, ok := err.(*exec.ExitError); ok {
-		if e.ExitCode() != 1 {
-			t.Fatalf("expected exit 1, got %d", e.ExitCode())
+		if e.ExitCode() != ExitCodeEtcd {
+			t.Fatalf("expected exit %d, got %d", ExitCodeEtcd, e.ExitCode())
 		}
 	} else {
 		t.Fatalf("unexpected error: %#v", err)

--- a/internal/util/sessionutil/session_util_test.go
+++ b/internal/util/sessionutil/session_util_test.go
@@ -84,7 +84,7 @@ func TestInit(t *testing.T) {
 	defer etcdKV.RemoveWithPrefix(ctx, "")
 
 	s := NewSessionWithEtcd(ctx, metaRoot, etcdCli)
-	s.Init("inittest", "testAddr", false, false)
+	s.Init("inittest", "testAddr", false)
 	assert.NotEqual(t, int64(0), s.LeaseID)
 	assert.NotEqual(t, int64(0), s.ServerID)
 	s.Register()
@@ -107,7 +107,7 @@ func TestInitNoArgs(t *testing.T) {
 	defer etcdKV.RemoveWithPrefix(ctx, "")
 
 	s := NewSession(ctx)
-	s.Init("inittest", "testAddr", false, false)
+	s.Init("inittest", "testAddr", false)
 	assert.NotEqual(t, int64(0), s.LeaseID)
 	assert.NotEqual(t, int64(0), s.ServerID)
 	s.Register()
@@ -140,7 +140,7 @@ func TestUpdateSessions(t *testing.T) {
 
 	getIDFunc := func() {
 		singleS := NewSessionWithEtcd(ctx, metaRoot, etcdCli, WithResueNodeID(false))
-		singleS.Init("test", "testAddr", false, false)
+		singleS.Init("test", "testAddr", false)
 		singleS.Register()
 		muList.Lock()
 		sList = append(sList, singleS)
@@ -383,7 +383,7 @@ func (suite *SessionWithVersionSuite) SetupTest() {
 
 	s1 := NewSessionWithEtcd(ctx, suite.metaRoot, suite.client, WithResueNodeID(false))
 	s1.Version.Major, s1.Version.Minor, s1.Version.Patch = 0, 0, 0
-	s1.Init(suite.serverName, "s1", false, false)
+	s1.Init(suite.serverName, "s1", false)
 	assert.Panics(suite.T(), func() {
 		s1.GetRegisteredRevision()
 	})
@@ -394,7 +394,7 @@ func (suite *SessionWithVersionSuite) SetupTest() {
 
 	s2 := NewSessionWithEtcd(ctx, suite.metaRoot, suite.client, WithResueNodeID(false))
 	s2.Version.Major, s2.Version.Minor, s2.Version.Patch = 2, 1, 0
-	s2.Init(suite.serverName, "s2", false, false)
+	s2.Init(suite.serverName, "s2", false)
 	s2.Register()
 
 	suite.sessions = append(suite.sessions, s2)
@@ -402,7 +402,7 @@ func (suite *SessionWithVersionSuite) SetupTest() {
 	s3 := NewSessionWithEtcd(ctx, suite.metaRoot, suite.client, WithResueNodeID(false))
 	s3.Version.Major, s3.Version.Minor, s3.Version.Patch = 2, 2, 0
 	s3.Version.Build = []string{"dev"}
-	s3.Init(suite.serverName, "s3", false, false)
+	s3.Init(suite.serverName, "s3", false)
 	s3.Register()
 
 	suite.sessions = append(suite.sessions, s3)
@@ -515,7 +515,7 @@ func TestSessionProcessActiveStandBy(t *testing.T) {
 	ctx1 := context.Background()
 	s1 := NewSessionWithEtcd(ctx1, metaRoot, etcdCli, WithResueNodeID(false))
 
-	s1.Init("inittest", "testAddr", true, true)
+	s1.Init("inittest", "testAddr", true)
 	s1.SetEnableActiveStandBy(true)
 	s1.Register()
 	assert.Panics(t, func() {
@@ -534,7 +534,7 @@ func TestSessionProcessActiveStandBy(t *testing.T) {
 	// register session 2, will be standby
 	ctx2 := context.Background()
 	s2 := NewSessionWithEtcd(ctx2, metaRoot, etcdCli, WithResueNodeID(false))
-	s2.Init("inittest", "testAddr", true, true)
+	s2.Init("inittest", "testAddr", true)
 	s2.SetEnableActiveStandBy(true)
 	s2.Register()
 	wg.Add(1)
@@ -640,8 +640,8 @@ func TestIntegrationMode(t *testing.T) {
 	assert.Equal(t, false, s1.reuseNodeID)
 	s2 := NewSessionWithEtcd(ctx, metaRoot, etcdCli)
 	assert.Equal(t, false, s2.reuseNodeID)
-	s1.Init("inittest1", "testAddr1", false, false)
-	s1.Init("inittest2", "testAddr2", false, false)
+	s1.Init("inittest1", "testAddr1", false)
+	s1.Init("inittest2", "testAddr2", false)
 	assert.NotEqual(t, s1.ServerID, s2.ServerID)
 }
 
@@ -700,7 +700,7 @@ func (s *SessionSuite) TestGoingStop() {
 	sdisconnect.SetDisconnected(true)
 
 	sess := NewSessionWithEtcd(ctx, s.metaRoot, s.client)
-	sess.Init("test", "normal", false, false)
+	sess.Init("test", "normal", false)
 	sess.Register()
 
 	cases := []struct {
@@ -729,7 +729,7 @@ func (s *SessionSuite) TestGoingStop() {
 func (s *SessionSuite) TestKeepAliveRetryActiveCancel() {
 	ctx := context.Background()
 	session := NewSessionWithEtcd(ctx, s.metaRoot, s.client)
-	session.Init("test", "normal", false, false)
+	session.Init("test", "normal", false)
 
 	// Register
 	err := session.registerService()
@@ -744,7 +744,7 @@ func (s *SessionSuite) TestKeepAliveRetryActiveCancel() {
 func (s *SessionSuite) TestKeepAliveRetryChannelClose() {
 	ctx := context.Background()
 	session := NewSessionWithEtcd(ctx, s.metaRoot, s.client)
-	session.Init("test", "normal", false, false)
+	session.Init("test", "normal", false)
 
 	// Register
 	err := session.registerService()
@@ -803,7 +803,7 @@ func (s *SessionSuite) TestGetSessions() {
 func (s *SessionSuite) TestVersionKey() {
 	ctx := context.Background()
 	session := NewSessionWithEtcd(ctx, s.metaRoot, s.client)
-	session.Init(typeutil.MixCoordRole, "normal", false, false)
+	session.Init(typeutil.MixCoordRole, "normal", false)
 
 	session.Register()
 
@@ -816,7 +816,7 @@ func (s *SessionSuite) TestVersionKey() {
 
 	s.Panics(func() {
 		session2 := NewSessionWithEtcd(ctx, s.metaRoot, s.client)
-		session2.Init(typeutil.MixCoordRole, "normal", false, false)
+		session2.Init(typeutil.MixCoordRole, "normal", false)
 		session2.Register()
 
 		resp, err = s.client.Get(ctx, session2.versionKey)
@@ -829,7 +829,7 @@ func (s *SessionSuite) TestVersionKey() {
 
 	common.Version = semver.MustParse("2.6.4")
 	session = NewSessionWithEtcd(ctx, s.metaRoot, s.client)
-	session.Init(typeutil.MixCoordRole, "normal", false, false)
+	session.Init(typeutil.MixCoordRole, "normal", false)
 	session.Register()
 
 	resp, err = s.client.Get(ctx, session.versionKey)
@@ -841,7 +841,7 @@ func (s *SessionSuite) TestVersionKey() {
 
 	common.Version = semver.MustParse("2.6.7")
 	session = NewSessionWithEtcd(ctx, s.metaRoot, s.client)
-	session.Init(typeutil.MixCoordRole, "normal", false, false)
+	session.Init(typeutil.MixCoordRole, "normal", false)
 	session.Register()
 
 	resp, err = s.client.Get(ctx, session.versionKey)
@@ -852,7 +852,7 @@ func (s *SessionSuite) TestVersionKey() {
 
 	common.Version = semver.MustParse("3.0.0")
 	session = NewSessionWithEtcd(ctx, s.metaRoot, s.client)
-	session.Init(typeutil.MixCoordRole, "normal", false, false)
+	session.Init(typeutil.MixCoordRole, "normal", false)
 	session.Register()
 
 	resp, err = s.client.Get(ctx, session.versionKey)
@@ -864,7 +864,7 @@ func (s *SessionSuite) TestVersionKey() {
 func (s *SessionSuite) TestSessionLifetime() {
 	ctx := context.Background()
 	session := NewSessionWithEtcd(ctx, s.metaRoot, s.client)
-	session.Init("test", "normal", false, false)
+	session.Init("test", "normal", false)
 	session.Register()
 
 	resp, err := s.client.Get(ctx, session.getCompleteKey())
@@ -927,7 +927,7 @@ func TestForceKill(t *testing.T) {
 func testForceKill(serverName string) {
 	etcdCli, _ := kvfactory.GetEtcdAndPath()
 	session := NewSessionWithEtcd(context.Background(), "test", etcdCli)
-	session.Init(serverName, "normal", false, false)
+	session.Init(serverName, "normal", false)
 	session.Register()
 
 	// trigger a force kill


### PR DESCRIPTION
## Summary

Removes the `IsTriggerKill` / SIGINT block from `datacoord.stopServiceWatch()` and `querycoordv2.watchNodes()`.

### Root Cause

In MixCoord mode all three coordinators share the same etcd `Session` object. During shutdown, when any coordinator calls `session.Stop()` it cancels the shared context, closing the other coordinators' etcd watches — triggering `stopServiceWatch()` / `watchNodes()` which sent SIGINT to the process during a normal, coordinated teardown.

### Why remove SIGINT?

- `go s.Stop()` already handles unexpected session loss — SIGINT was just a backstop in case `Stop()` hangs
- No other component (rootcoord, proxy, datanode, querynode) has this logic
- The false-positive risk (killing the process during normal shutdown) outweighs the marginal benefit

issue: #48242