### PR TITLE
fix: fix compilation error in ExecPlanNodeVisitor for element-level query

### DIFF
--- a/internal/core/src/query/ExecPlanNodeVisitor.cpp
+++ b/internal/core/src/query/ExecPlanNodeVisitor.cpp
@@ -338,7 +338,7 @@ ExecPlanNodeVisitor::setupRetrieveResult(
     tmp_retrieve_result.total_data_cnt_ = first_column->size();
     if (first_column->IsBitmap()) {
         BitsetTypeView view(first_column->GetRawData(), first_column->size());
-        if (query_context->element_level_query()) {
+        if (query_context->bitset_is_element_level()) {
             // Element-level query: bitset is element-level, need to convert to (doc_id, element_index)
             tmp_retrieve_result.element_level_ = true;
             tracer::AutoSpan _(


### PR DESCRIPTION
## Summary

- Fix master branch compilation error introduced by PR #47906
- `QueryContext::element_level_query()` does not exist, replaced with `bitset_is_element_level()` which is the correct method defined in `QueryContext.h`

## Test plan

- [ ] CI build passes (currently master is broken)
- [ ] Existing StructArray e2e tests pass

issue: #48253

🤖 Generated with [Claude Code](https://claude.com/claude-code)