### PR TITLE
fix: [2.6] Use AlwaysTrueExpr instead of ValueExpr in combineOrInWithNotEqual

### DIFF
--- a/internal/parser/planparserv2/rewriter/term_in.go
+++ b/internal/parser/planparserv2/rewriter/term_in.go
@@ -651,7 +651,7 @@ func (v *visitor) combineOrInWithNotEqual(parts []*planpb.Expr) []*planpb.Expr {
 			for _, ni := range g.neqIdxs {
 				used[ni] = true
 			}
-			out = append(out, newBoolConstExpr(true))
+			out = append(out, newAlwaysTrueExpr())
 		} else {
 			// drop the IN; keep != as-is
 			used[g.termIdx] = true

--- a/internal/parser/planparserv2/rewriter/term_in_test.go
+++ b/internal/parser/planparserv2/rewriter/term_in_test.go
@@ -258,9 +258,17 @@ func TestRewrite_Or_In_Or_NotEqual_VInSet_ToTrue(t *testing.T) {
 	expr, err := parser.ParseExpr(helper, `Int64Field in [1,2] or Int64Field != 2`, nil)
 	require.NoError(t, err)
 	require.NotNil(t, expr)
-	val := expr.GetValueExpr()
-	require.NotNil(t, val)
-	require.Equal(t, true, val.GetValue().GetBoolVal())
+	require.True(t, rewriter.IsAlwaysTrueExpr(expr),
+		"OR(IN, !=) tautology should be rewritten to AlwaysTrueExpr")
+}
+
+func TestRewrite_Or_In_Or_NotEqual_VarChar_Tautology(t *testing.T) {
+	helper := buildSchemaHelperForRewriteT(t)
+	expr, err := parser.ParseExpr(helper, `VarCharField in ["", "a", "b"] or VarCharField != ""`, nil)
+	require.NoError(t, err)
+	require.NotNil(t, expr)
+	require.True(t, rewriter.IsAlwaysTrueExpr(expr),
+		"OR(IN, !=) tautology with VarChar should be rewritten to AlwaysTrueExpr")
 }
 
 func TestRewrite_Or_In_Or_NotEqual_VNotInSet_ToNotEqual(t *testing.T) {


### PR DESCRIPTION
combineOrInWithNotEqual used `newBoolConstExpr(true) (a ValueExpr)` when detecting tautologies like `(a IN S) OR (a != d) where d ∈ S`. This ValueExpr was not recognized by foldBinary's `IsAlwaysTrueExpr` check, causing it to pass through to the C++ execution engine. The C++ side compiled it into `PhyValueExpr` which returns a ConstantVector<bool>, but FilterBitsNode expects a ColumnVector, resulting in an assertion error.

Fix by using `newAlwaysTrueExpr()` so the expression is properly recognized and handled throughout the pipeline.

issue: #47997
master pr: #48113