### PR TITLE
fix: pickNode should deduct task slots instead of zeroing available slots

### DIFF
--- a/internal/datacoord/task/global_scheduler.go
+++ b/internal/datacoord/task/global_scheduler.go
@@ -138,19 +138,23 @@ func (s *globalTaskScheduler) Stop() {
 }
 
 func (s *globalTaskScheduler) pickNode(workerSlots map[int64]*session.WorkerSlots, taskSlot int64) int64 {
+	var fallbackNodeID int64 = NullNodeID
 	var maxAvailable int64 = -1
-	var nodeID int64 = NullNodeID
 
-	for id, ws := range workerSlots {
+	for nodeID, ws := range workerSlots {
+		if ws.AvailableSlots >= taskSlot {
+			ws.AvailableSlots -= taskSlot
+			return nodeID
+		}
 		if ws.AvailableSlots > maxAvailable && ws.AvailableSlots > 0 {
 			maxAvailable = ws.AvailableSlots
-			nodeID = id
+			fallbackNodeID = nodeID
 		}
 	}
 
-	if nodeID != NullNodeID {
-		workerSlots[nodeID].AvailableSlots = 0
-		return nodeID
+	if fallbackNodeID != NullNodeID {
+		workerSlots[fallbackNodeID].AvailableSlots = 0
+		return fallbackNodeID
 	}
 	return NullNodeID
 }

--- a/internal/datacoord/task/global_scheduler_test.go
+++ b/internal/datacoord/task/global_scheduler_test.go
@@ -101,17 +101,24 @@ func TestGlobalScheduler_pickNode(t *testing.T) {
 	}, 1)
 	assert.True(t, nodeID == int64(1) || nodeID == int64(2)) // random
 
-	nodeID = scheduler.pickNode(map[int64]*session.WorkerSlots{
-		1: {
-			NodeID:         1,
-			AvailableSlots: 20,
-		},
-		2: {
-			NodeID:         2,
-			AvailableSlots: 30,
-		},
-	}, 100)
-	assert.Equal(t, int64(2), nodeID) // taskSlot > available, but node 2 has more available slots
+	slotsNoEnough := map[int64]*session.WorkerSlots{
+		1: {NodeID: 1, AvailableSlots: 20},
+		2: {NodeID: 2, AvailableSlots: 30},
+	}
+	nodeID = scheduler.pickNode(slotsNoEnough, 100)
+	assert.Equal(t, int64(2), nodeID) // fallback: pick node with max slots when none >= taskSlot
+	assert.Equal(t, int64(0), slotsNoEnough[2].AvailableSlots)
+
+	slots := map[int64]*session.WorkerSlots{
+		1: {NodeID: 1, AvailableSlots: 100},
+	}
+	assert.Equal(t, int64(1), scheduler.pickNode(slots, 10))
+	assert.Equal(t, int64(90), slots[1].AvailableSlots)
+	assert.Equal(t, int64(1), scheduler.pickNode(slots, 10))
+	assert.Equal(t, int64(80), slots[1].AvailableSlots)
+	nodeID = scheduler.pickNode(slots, 100) // 80 < 100, use fallback
+	assert.Equal(t, int64(1), nodeID)
+	assert.Equal(t, int64(0), slots[1].AvailableSlots)
 
 	nodeID = scheduler.pickNode(map[int64]*session.WorkerSlots{
 		1: {


### PR DESCRIPTION
## Summary
- **Bug**: `pickNode` always set `AvailableSlots=0` for the selected node, limiting the scheduler to at most one task per node per scheduling cycle regardless of actual capacity
- **Fix**: Deduct only the required slot count (`AvailableSlots -= taskSlot`) when a node has sufficient capacity; zero-out only as a fallback when no node has enough slots
- **Tests**: Updated `TestGlobalScheduler_pickNode` to verify proper slot deduction across multiple consecutive picks and fallback behavior

issue: #48169
master pr: #48170