### PR TITLE
fix:  avoid unordered_map::at on sorted lazy segment delta load

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -277,6 +277,16 @@ ChunkedSegmentSealedImpl::LoadFieldData(FieldId field_id, FieldDataInfo& data) {
         auto system_field_type =
             SystemProperty::Instance().GetSystemFieldType(field_id);
         if (system_field_type == SystemFieldType::Timestamp) {
+            {
+                std::unique_lock lck(mutex_);
+                if (timestamp_field_ready_.load()) {
+                    lck.unlock();
+                    std::shared_ptr<milvus::ArrowDataWrapper> r;
+                    while (data.arrow_reader_channel->pop(r)) {
+                    }
+                    return;
+                }
+            }
             std::vector<Timestamp> timestamps(num_rows);
             int64_t offset = 0;
             FieldMeta field_meta(
@@ -309,6 +319,9 @@ ChunkedSegmentSealedImpl::LoadFieldData(FieldId field_id, FieldDataInfo& data) {
 
             // use special index
             std::unique_lock lck(mutex_);
+            if (timestamp_field_ready_.load()) {
+                return;
+            }
             AssertInfo(insert_record_.timestamps_.empty(), "already exists");
             insert_record_.timestamps_.set_data_raw(
                 0, timestamps.data(), timestamps.size());
@@ -316,16 +329,31 @@ ChunkedSegmentSealedImpl::LoadFieldData(FieldId field_id, FieldDataInfo& data) {
             AssertInfo(insert_record_.timestamps_.num_chunk() == 1,
                        "num chunk not equal to 1 for sealed segment");
             stats_.mem_size += sizeof(Timestamp) * data.row_count;
+            timestamp_field_ready_.store(true);
         } else {
             AssertInfo(system_field_type == SystemFieldType::RowId,
                        "System field type of id column is not RowId");
+            {
+                std::unique_lock lck(mutex_);
+                if (rowid_field_ready_.load()) {
+                    lck.unlock();
+                    std::shared_ptr<milvus::ArrowDataWrapper> r;
+                    while (data.arrow_reader_channel->pop(r)) {
+                    }
+                    return;
+                }
+            }
             // Consume rowid field data but not really load it
             // storage::CollectFieldDataChannel(data.arrow_reader_channel);
             std::shared_ptr<milvus::ArrowDataWrapper> r;
             while (data.arrow_reader_channel->pop(r)) {
             }
+            std::unique_lock lck(mutex_);
+            if (rowid_field_ready_.load()) {
+                return;
+            }
+            rowid_field_ready_.store(true);
         }
-        ++system_ready_count_;
     } else {
         // prepare data
         auto& field_meta = (*schema_)[field_id];
@@ -1098,9 +1126,11 @@ ChunkedSegmentSealedImpl::DropFieldData(const FieldId field_id) {
             SystemProperty::Instance().GetSystemFieldType(field_id);
 
         std::unique_lock lck(mutex_);
-        --system_ready_count_;
         if (system_field_type == SystemFieldType::Timestamp) {
+            timestamp_field_ready_.store(false);
             insert_record_.timestamps_.clear();
+        } else {
+            rowid_field_ready_.store(false);
         }
         lck.unlock();
     } else {
@@ -1463,7 +1493,8 @@ ChunkedSegmentSealedImpl::ClearData() {
         field_data_ready_bitset_.reset();
         index_ready_bitset_.reset();
         binlog_index_bitset_.reset();
-        system_ready_count_ = 0;
+        timestamp_field_ready_.store(false);
+        rowid_field_ready_.store(false);
         num_rows_ = std::nullopt;
         scalar_indexings_.clear();
         vector_indexings_.clear();
@@ -1854,7 +1885,12 @@ bool
 ChunkedSegmentSealedImpl::HasFieldData(FieldId field_id) const {
     std::shared_lock lck(mutex_);
     if (SystemProperty::Instance().IsSystem(field_id)) {
-        return is_system_field_ready();
+        auto system_field_type =
+            SystemProperty::Instance().GetSystemFieldType(field_id);
+        if (system_field_type == SystemFieldType::Timestamp) {
+            return timestamp_field_ready_.load();
+        }
+        return rowid_field_ready_.load();
     } else {
         return get_bit(field_data_ready_bitset_, field_id);
     }

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -371,7 +371,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
 
     bool
     is_system_field_ready() const {
-        return system_ready_count_ == 2;
+        return timestamp_field_ready_.load() && rowid_field_ready_.load();
     }
 
     std::pair<std::unique_ptr<IdArray>, std::vector<SegOffset>>
@@ -399,7 +399,8 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     BitsetType field_data_ready_bitset_;
     BitsetType index_ready_bitset_;
     BitsetType binlog_index_bitset_;
-    std::atomic<int> system_ready_count_ = 0;
+    std::atomic<bool> timestamp_field_ready_ = false;
+    std::atomic<bool> rowid_field_ready_ = false;
     // segment data
 
     // TODO: generate index for scalar

--- a/internal/core/src/segcore/SegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/SegmentSealedImpl.cpp
@@ -352,6 +352,14 @@ SegmentSealedImpl::LoadFieldData(FieldId field_id, FieldDataInfo& data) {
         auto system_field_type =
             SystemProperty::Instance().GetSystemFieldType(field_id);
         if (system_field_type == SystemFieldType::Timestamp) {
+            {
+                std::unique_lock lck(mutex_);
+                if (timestamp_field_ready_.load()) {
+                    lck.unlock();
+                    storage::CollectFieldDataChannel(data.channel);
+                    return;
+                }
+            }
             std::vector<Timestamp> timestamps(num_rows);
             int64_t offset = 0;
             auto field_data = storage::CollectFieldDataChannel(data.channel);
@@ -373,19 +381,35 @@ SegmentSealedImpl::LoadFieldData(FieldId field_id, FieldDataInfo& data) {
 
             // use special index
             std::unique_lock lck(mutex_);
+            if (timestamp_field_ready_.load()) {
+                return;
+            }
             AssertInfo(insert_record_.timestamps_.empty(), "already exists");
             insert_record_.timestamps_.fill_chunk_data(field_data);
             insert_record_.timestamp_index_ = std::move(index);
             AssertInfo(insert_record_.timestamps_.num_chunk() == 1,
                        "num chunk not equal to 1 for sealed segment");
             stats_.mem_size += sizeof(Timestamp) * data.row_count;
+            timestamp_field_ready_.store(true);
         } else {
             AssertInfo(system_field_type == SystemFieldType::RowId,
                        "System field type of id column is not RowId");
+            {
+                std::unique_lock lck(mutex_);
+                if (rowid_field_ready_.load()) {
+                    lck.unlock();
+                    storage::CollectFieldDataChannel(data.channel);
+                    return;
+                }
+            }
             // Consume rowid field data but not really load it
             storage::CollectFieldDataChannel(data.channel);
+            std::unique_lock lck(mutex_);
+            if (rowid_field_ready_.load()) {
+                return;
+            }
+            rowid_field_ready_.store(true);
         }
-        ++system_ready_count_;
     } else {
         // prepare data
         auto& field_meta = (*schema_)[field_id];
@@ -1201,9 +1225,11 @@ SegmentSealedImpl::DropFieldData(const FieldId field_id) {
             SystemProperty::Instance().GetSystemFieldType(field_id);
 
         std::unique_lock lck(mutex_);
-        --system_ready_count_;
         if (system_field_type == SystemFieldType::Timestamp) {
+            timestamp_field_ready_.store(false);
             insert_record_.timestamps_.clear();
+        } else {
+            rowid_field_ready_.store(false);
         }
         lck.unlock();
     } else {
@@ -1425,7 +1451,8 @@ SegmentSealedImpl::ClearData() {
         field_data_ready_bitset_.reset();
         index_ready_bitset_.reset();
         binlog_index_bitset_.reset();
-        system_ready_count_ = 0;
+        timestamp_field_ready_.store(false);
+        rowid_field_ready_.store(false);
         num_rows_ = std::nullopt;
         scalar_indexings_.clear();
         vector_indexings_.clear();
@@ -1734,7 +1761,12 @@ bool
 SegmentSealedImpl::HasFieldData(FieldId field_id) const {
     std::shared_lock lck(mutex_);
     if (SystemProperty::Instance().IsSystem(field_id)) {
-        return is_system_field_ready();
+        auto system_field_type =
+            SystemProperty::Instance().GetSystemFieldType(field_id);
+        if (system_field_type == SystemFieldType::Timestamp) {
+            return timestamp_field_ready_.load();
+        }
+        return rowid_field_ready_.load();
     } else {
         return get_bit(field_data_ready_bitset_, field_id);
     }

--- a/internal/core/src/segcore/SegmentSealedImpl.h
+++ b/internal/core/src/segcore/SegmentSealedImpl.h
@@ -364,7 +364,7 @@ class SegmentSealedImpl : public SegmentSealed {
 
     bool
     is_system_field_ready() const {
-        return system_ready_count_ == 2;
+        return timestamp_field_ready_.load() && rowid_field_ready_.load();
     }
 
     std::pair<std::unique_ptr<IdArray>, std::vector<SegOffset>>
@@ -392,7 +392,8 @@ class SegmentSealedImpl : public SegmentSealed {
     BitsetType field_data_ready_bitset_;
     BitsetType index_ready_bitset_;
     BitsetType binlog_index_bitset_;
-    std::atomic<int> system_ready_count_ = 0;
+    std::atomic<bool> timestamp_field_ready_ = false;
+    std::atomic<bool> rowid_field_ready_ = false;
     // segment data
 
     // TODO: generate index for scalar

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -77,6 +77,8 @@ const (
 
 var ErrSegmentUnhealthy = errors.New("segment unhealthy")
 
+var ensureSortedSegmentPKLoadedFn = ensureSortedSegmentPKLoaded
+
 // IndexedFieldInfo contains binlog info of vector field
 type IndexedFieldInfo struct {
 	FieldBinlog *datapb.FieldBinlog
@@ -298,6 +300,7 @@ func (s *baseSegment) SetNeedUpdatedVersion(version int64) {
 type FieldInfo struct {
 	*datapb.FieldBinlog
 	RowCount int64
+	Loaded   atomic.Bool
 }
 
 var _ Segment = (*LocalSegment)(nil)
@@ -317,6 +320,8 @@ type LocalSegment struct {
 
 	deltaMut           sync.Mutex
 	lastDeltaTimestamp *atomic.Uint64
+	fieldDataInfoAdded *atomic.Bool
+	fieldDataInfoMu    sync.Mutex
 	fields             *typeutil.ConcurrentMap[int64, *FieldInfo]
 	fieldIndexes       *typeutil.ConcurrentMap[int64, *IndexedFieldInfo] // indexID -> IndexedFieldInfo
 	warmupDispatcher   *AsyncWarmupDispatcher
@@ -385,6 +390,7 @@ func NewSegment(ctx context.Context,
 		ptr:                C.CSegmentInterface(csegment.RawPointer()),
 		csegment:           csegment,
 		lastDeltaTimestamp: atomic.NewUint64(0),
+		fieldDataInfoAdded: atomic.NewBool(false),
 		fields:             typeutil.NewConcurrentMap[int64, *FieldInfo](),
 		fieldIndexes:       typeutil.NewConcurrentMap[int64, *IndexedFieldInfo](),
 
@@ -424,6 +430,7 @@ func (s *LocalSegment) initializeSegment() error {
 			s.fields.Insert(fieldID, &FieldInfo{
 				FieldBinlog: info.FieldBinlog,
 				RowCount:    loadInfo.GetNumOfRows(),
+				Loaded:      *atomic.NewBool(false),
 			})
 		}
 	}
@@ -432,6 +439,7 @@ func (s *LocalSegment) initializeSegment() error {
 		s.fields.Insert(binlogs.FieldID, &FieldInfo{
 			FieldBinlog: binlogs,
 			RowCount:    loadInfo.GetNumOfRows(),
+			Loaded:      *atomic.NewBool(false),
 		})
 	}
 
@@ -739,6 +747,10 @@ func (s *LocalSegment) Delete(ctx context.Context, primaryKeys storage.PrimaryKe
 	}
 	defer s.ptrLock.Unpin()
 
+	if err := ensureSortedSegmentPKLoadedFn(ctx, s); err != nil {
+		return err
+	}
+
 	s.deltaMut.Lock()
 	defer s.deltaMut.Unlock()
 
@@ -876,6 +888,15 @@ func (s *LocalSegment) LoadFieldData(ctx context.Context, fieldID int64, rowCoun
 		log.Warn("LoadFieldData failed", zap.Error(err))
 		return err
 	}
+	if info, ok := s.fields.Get(fieldID); ok {
+		info.Loaded.Store(true)
+	} else {
+		s.fields.Insert(fieldID, &FieldInfo{
+			FieldBinlog: field,
+			RowCount:    rowCount,
+			Loaded:      *atomic.NewBool(true),
+		})
+	}
 	log.Info("load field done")
 	return nil
 }
@@ -913,11 +934,16 @@ func (s *LocalSegment) AddFieldDataInfo(ctx context.Context, rowCount int64, fie
 		log.Warn("AddFieldDataInfo failed", zap.Error(err))
 		return err
 	}
+	s.fieldDataInfoAdded.Store(true)
 	log.Info("add field data info done")
 	return nil
 }
 
 func (s *LocalSegment) LoadDeltaData(ctx context.Context, deltaData *storage.DeltaData) error {
+	if err := ensureSortedSegmentPKLoadedFn(ctx, s); err != nil {
+		return err
+	}
+
 	pks, tss := deltaData.DeletePks(), deltaData.DeleteTimestamps()
 	rowNum := deltaData.DeleteRowCount()
 

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -1325,6 +1325,12 @@ func (loader *segmentLoader) loadDeltalogs(ctx context.Context, segment Segment,
 		}
 	}
 
+	// Sorted segments need PK raw data for delete application.
+	// In lazy-load mode, field data may not be loaded yet when delta-only sync happens.
+	if err := ensureSortedSegmentPKLoaded(ctx, segment); err != nil {
+		return err
+	}
+
 	err = segment.LoadDeltaData(ctx, deltaData)
 	if err != nil {
 		return err

--- a/internal/querynodev2/segments/segment_loader_test.go
+++ b/internal/querynodev2/segments/segment_loader_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/metric"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
 type SegmentLoaderSuite struct {
@@ -590,6 +591,314 @@ func (suite *SegmentLoaderSuite) TestLoadIndexWithLimitedResource() {
 	defer paramtable.Get().Reset(paramtable.Get().QueryNodeCfg.DiskCapacityLimit.Key)
 	err := suite.loader.LoadIndex(ctx, segment, loadInfo, 0)
 	suite.Error(err)
+}
+
+func (suite *SegmentLoaderSuite) TestEnsureSortedSegmentPKLoadedForLazySegment() {
+	// Sorted sealed lazy segment should preload PK field before applying delta logs.
+	ctx := context.Background()
+
+	pkField := GetPkField(suite.schema)
+	pkFieldID := pkField.GetFieldID()
+	pkBinlog := &datapb.FieldBinlog{
+		FieldID: pkFieldID,
+		Binlogs: []*datapb.Binlog{{
+			LogPath:    "mock-pk-binlog-path",
+			EntriesNum: 10,
+			LogSize:    10,
+			MemorySize: 10,
+		}},
+	}
+	tsBinlog := &datapb.FieldBinlog{
+		FieldID: common.TimeStampField,
+		Binlogs: []*datapb.Binlog{{
+			LogPath:    "mock-ts-binlog-path",
+			EntriesNum: 10,
+			LogSize:    10,
+			MemorySize: 10,
+		}},
+	}
+
+	loadInfo := &querypb.SegmentLoadInfo{
+		SegmentID:     suite.segmentID,
+		PartitionID:   suite.partitionID,
+		CollectionID:  suite.collectionID,
+		BinlogPaths:   []*datapb.FieldBinlog{tsBinlog, pkBinlog},
+		NumOfRows:     10,
+		InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", suite.collectionID),
+		IsSorted:      true,
+	}
+
+	localSeg := &LocalSegment{
+		baseSegment: baseSegment{
+			collection:  suite.manager.Collection.Get(suite.collectionID),
+			loadInfo:    atomic.NewPointer[querypb.SegmentLoadInfo](loadInfo),
+			segmentType: SegmentTypeSealed,
+			isLazyLoad:  true,
+		},
+		fieldDataInfoAdded: atomic.NewBool(false),
+		fields:             typeutil.NewConcurrentMap[int64, *FieldInfo](),
+	}
+
+	addInfoCalled := false
+	loadedFieldIDs := make([]int64, 0, 2)
+	originAddInfo := addSegmentFieldDataInfoFn
+	originLoad := loadSegmentFieldDataFn
+	addSegmentFieldDataInfoFn = func(ctx context.Context, segment *LocalSegment, rowCount int64, fields []*datapb.FieldBinlog) error {
+		addInfoCalled = true
+		suite.Equal(localSeg, segment)
+		suite.Equal(loadInfo.GetNumOfRows(), rowCount)
+		suite.Equal(loadInfo.GetBinlogPaths(), fields)
+		segment.fieldDataInfoAdded.Store(true)
+		return nil
+	}
+	loadSegmentFieldDataFn = func(ctx context.Context, segment *LocalSegment, fieldID int64, rowCount int64, field *datapb.FieldBinlog) error {
+		loadedFieldIDs = append(loadedFieldIDs, fieldID)
+		suite.Equal(localSeg, segment)
+		suite.Equal(loadInfo.GetNumOfRows(), rowCount)
+		switch fieldID {
+		case pkFieldID:
+			suite.Equal(pkBinlog, field)
+		case common.TimeStampField:
+			suite.Equal(tsBinlog, field)
+		default:
+			suite.FailNow("unexpected field loaded", fmt.Sprintf("fieldID=%d", fieldID))
+		}
+		return nil
+	}
+	defer func() {
+		addSegmentFieldDataInfoFn = originAddInfo
+		loadSegmentFieldDataFn = originLoad
+	}()
+
+	err := ensureSortedSegmentPKLoaded(ctx, localSeg)
+	suite.NoError(err)
+	suite.True(addInfoCalled)
+	suite.ElementsMatch([]int64{pkFieldID, common.TimeStampField}, loadedFieldIDs)
+}
+
+func (suite *SegmentLoaderSuite) TestEnsureSortedSegmentPKLoadedSkipForUnsortedSegment() {
+	// Unsorted segment does not require sorted PK lookup path and should skip preload.
+	ctx := context.Background()
+
+	pkField := GetPkField(suite.schema)
+	pkFieldID := pkField.GetFieldID()
+	pkBinlog := &datapb.FieldBinlog{
+		FieldID: pkFieldID,
+		Binlogs: []*datapb.Binlog{{
+			LogPath:    "mock-pk-binlog-path",
+			EntriesNum: 10,
+			LogSize:    10,
+			MemorySize: 10,
+		}},
+	}
+	tsBinlog := &datapb.FieldBinlog{
+		FieldID: common.TimeStampField,
+		Binlogs: []*datapb.Binlog{{
+			LogPath:    "mock-ts-binlog-path",
+			EntriesNum: 10,
+			LogSize:    10,
+			MemorySize: 10,
+		}},
+	}
+
+	loadInfo := &querypb.SegmentLoadInfo{
+		SegmentID:     suite.segmentID,
+		PartitionID:   suite.partitionID,
+		CollectionID:  suite.collectionID,
+		BinlogPaths:   []*datapb.FieldBinlog{tsBinlog, pkBinlog},
+		NumOfRows:     10,
+		InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", suite.collectionID),
+		IsSorted:      false,
+	}
+
+	localSeg := &LocalSegment{
+		baseSegment: baseSegment{
+			collection:  suite.manager.Collection.Get(suite.collectionID),
+			loadInfo:    atomic.NewPointer[querypb.SegmentLoadInfo](loadInfo),
+			segmentType: SegmentTypeSealed,
+			isLazyLoad:  true,
+		},
+		fieldDataInfoAdded: atomic.NewBool(false),
+		fields:             typeutil.NewConcurrentMap[int64, *FieldInfo](),
+	}
+
+	addInfoCalled := false
+	loadCalled := false
+	originAddInfo := addSegmentFieldDataInfoFn
+	originLoad := loadSegmentFieldDataFn
+	addSegmentFieldDataInfoFn = func(ctx context.Context, segment *LocalSegment, rowCount int64, fields []*datapb.FieldBinlog) error {
+		addInfoCalled = true
+		return nil
+	}
+	loadSegmentFieldDataFn = func(ctx context.Context, segment *LocalSegment, fieldID int64, rowCount int64, field *datapb.FieldBinlog) error {
+		loadCalled = true
+		return nil
+	}
+	defer func() {
+		addSegmentFieldDataInfoFn = originAddInfo
+		loadSegmentFieldDataFn = originLoad
+	}()
+
+	err := ensureSortedSegmentPKLoaded(ctx, localSeg)
+	suite.NoError(err)
+	suite.False(addInfoCalled)
+	suite.False(loadCalled)
+}
+
+func (suite *SegmentLoaderSuite) TestEnsureSortedSegmentPKLoadedSkipWhenPKAlreadyLoaded() {
+	ctx := context.Background()
+
+	pkField := GetPkField(suite.schema)
+	pkFieldID := pkField.GetFieldID()
+	pkBinlog := &datapb.FieldBinlog{
+		FieldID: pkFieldID,
+		Binlogs: []*datapb.Binlog{{
+			LogPath:    "mock-pk-binlog-path",
+			EntriesNum: 10,
+			LogSize:    10,
+			MemorySize: 10,
+		}},
+	}
+	tsBinlog := &datapb.FieldBinlog{
+		FieldID: common.TimeStampField,
+		Binlogs: []*datapb.Binlog{{
+			LogPath:    "mock-ts-binlog-path",
+			EntriesNum: 10,
+			LogSize:    10,
+			MemorySize: 10,
+		}},
+	}
+
+	loadInfo := &querypb.SegmentLoadInfo{
+		SegmentID:     suite.segmentID,
+		PartitionID:   suite.partitionID,
+		CollectionID:  suite.collectionID,
+		BinlogPaths:   []*datapb.FieldBinlog{tsBinlog, pkBinlog},
+		NumOfRows:     10,
+		InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", suite.collectionID),
+		IsSorted:      true,
+	}
+
+	localSeg := &LocalSegment{
+		baseSegment: baseSegment{
+			collection:  suite.manager.Collection.Get(suite.collectionID),
+			loadInfo:    atomic.NewPointer[querypb.SegmentLoadInfo](loadInfo),
+			segmentType: SegmentTypeSealed,
+			isLazyLoad:  true,
+		},
+		fieldDataInfoAdded: atomic.NewBool(true),
+		fields:             typeutil.NewConcurrentMap[int64, *FieldInfo](),
+	}
+	localSeg.fields.Insert(pkFieldID, &FieldInfo{
+		FieldBinlog: pkBinlog,
+		RowCount:    loadInfo.GetNumOfRows(),
+		Loaded:      *atomic.NewBool(true),
+	})
+	localSeg.fields.Insert(common.TimeStampField, &FieldInfo{
+		FieldBinlog: tsBinlog,
+		RowCount:    loadInfo.GetNumOfRows(),
+		Loaded:      *atomic.NewBool(true),
+	})
+
+	addInfoCalled := false
+	loadCalled := false
+	originAddInfo := addSegmentFieldDataInfoFn
+	originLoad := loadSegmentFieldDataFn
+	addSegmentFieldDataInfoFn = func(ctx context.Context, segment *LocalSegment, rowCount int64, fields []*datapb.FieldBinlog) error {
+		addInfoCalled = true
+		return nil
+	}
+	loadSegmentFieldDataFn = func(ctx context.Context, segment *LocalSegment, fieldID int64, rowCount int64, field *datapb.FieldBinlog) error {
+		loadCalled = true
+		return nil
+	}
+	defer func() {
+		addSegmentFieldDataInfoFn = originAddInfo
+		loadSegmentFieldDataFn = originLoad
+	}()
+
+	err := ensureSortedSegmentPKLoaded(ctx, localSeg)
+	suite.NoError(err)
+	suite.False(addInfoCalled)
+	suite.False(loadCalled)
+}
+
+func (suite *SegmentLoaderSuite) TestEnsureSortedSegmentPKLoadedLoadsTimestampWhenOnlyPKLoaded() {
+	ctx := context.Background()
+
+	pkField := GetPkField(suite.schema)
+	pkFieldID := pkField.GetFieldID()
+	pkBinlog := &datapb.FieldBinlog{
+		FieldID: pkFieldID,
+		Binlogs: []*datapb.Binlog{{
+			LogPath:    "mock-pk-binlog-path",
+			EntriesNum: 10,
+			LogSize:    10,
+			MemorySize: 10,
+		}},
+	}
+	tsBinlog := &datapb.FieldBinlog{
+		FieldID: common.TimeStampField,
+		Binlogs: []*datapb.Binlog{{
+			LogPath:    "mock-ts-binlog-path",
+			EntriesNum: 10,
+			LogSize:    10,
+			MemorySize: 10,
+		}},
+	}
+
+	loadInfo := &querypb.SegmentLoadInfo{
+		SegmentID:     suite.segmentID,
+		PartitionID:   suite.partitionID,
+		CollectionID:  suite.collectionID,
+		BinlogPaths:   []*datapb.FieldBinlog{tsBinlog, pkBinlog},
+		NumOfRows:     10,
+		InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", suite.collectionID),
+		IsSorted:      true,
+	}
+
+	localSeg := &LocalSegment{
+		baseSegment: baseSegment{
+			collection:  suite.manager.Collection.Get(suite.collectionID),
+			loadInfo:    atomic.NewPointer[querypb.SegmentLoadInfo](loadInfo),
+			segmentType: SegmentTypeSealed,
+			isLazyLoad:  true,
+		},
+		fieldDataInfoAdded: atomic.NewBool(true),
+		fields:             typeutil.NewConcurrentMap[int64, *FieldInfo](),
+	}
+	localSeg.fields.Insert(pkFieldID, &FieldInfo{
+		FieldBinlog: pkBinlog,
+		RowCount:    loadInfo.GetNumOfRows(),
+		Loaded:      *atomic.NewBool(true),
+	})
+	localSeg.fields.Insert(common.TimeStampField, &FieldInfo{
+		FieldBinlog: tsBinlog,
+		RowCount:    loadInfo.GetNumOfRows(),
+		Loaded:      *atomic.NewBool(false),
+	})
+
+	addInfoCalled := false
+	loadCalls := make([]int64, 0, 2)
+	originAddInfo := addSegmentFieldDataInfoFn
+	originLoad := loadSegmentFieldDataFn
+	addSegmentFieldDataInfoFn = func(ctx context.Context, segment *LocalSegment, rowCount int64, fields []*datapb.FieldBinlog) error {
+		addInfoCalled = true
+		return nil
+	}
+	loadSegmentFieldDataFn = func(ctx context.Context, segment *LocalSegment, fieldID int64, rowCount int64, field *datapb.FieldBinlog) error {
+		loadCalls = append(loadCalls, fieldID)
+		return nil
+	}
+	defer func() {
+		addSegmentFieldDataInfoFn = originAddInfo
+		loadSegmentFieldDataFn = originLoad
+	}()
+
+	err := ensureSortedSegmentPKLoaded(ctx, localSeg)
+	suite.NoError(err)
+	suite.False(addInfoCalled)
+	suite.Equal([]int64{common.TimeStampField}, loadCalls)
 }
 
 func (suite *SegmentLoaderSuite) TestLoadWithMmap() {

--- a/internal/querynodev2/segments/segment_test.go
+++ b/internal/querynodev2/segments/segment_test.go
@@ -2,6 +2,7 @@ package segments
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"testing"
@@ -197,6 +198,27 @@ func (suite *SegmentSuite) TestHasRawData() {
 	suite.True(has)
 	has = suite.sealed.HasRawData(mock_segcore.SimpleFloatVecField.ID)
 	suite.True(has)
+}
+
+func (suite *SegmentSuite) TestLoadDeltaDataPreloadsSortedSegmentPK() {
+	localSeg := suite.sealed.(*LocalSegment)
+	pks := storage.NewInt64PrimaryKeys(1)
+	pks.AppendRaw(1)
+	deltaData, err := storage.NewDeltaDataWithData(pks, []uint64{1000})
+	suite.Require().NoError(err)
+
+	expected := errors.New("preload pk")
+	originEnsure := ensureSortedSegmentPKLoadedFn
+	ensureSortedSegmentPKLoadedFn = func(ctx context.Context, segment Segment) error {
+		suite.Equal(localSeg, segment)
+		return expected
+	}
+	defer func() {
+		ensureSortedSegmentPKLoadedFn = originEnsure
+	}()
+
+	err = localSeg.LoadDeltaData(context.Background(), deltaData)
+	suite.ErrorIs(err, expected)
 }
 
 func (suite *SegmentSuite) TestCASVersion() {

--- a/internal/querynodev2/segments/utils.go
+++ b/internal/querynodev2/segments/utils.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
+	"github.com/samber/lo"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
@@ -42,6 +43,14 @@ import (
 )
 
 var errLazyLoadTimeout = merr.WrapErrServiceInternal("lazy load time out")
+
+var addSegmentFieldDataInfoFn = func(ctx context.Context, segment *LocalSegment, rowCount int64, fields []*datapb.FieldBinlog) error {
+	return segment.AddFieldDataInfo(ctx, rowCount, fields)
+}
+
+var loadSegmentFieldDataFn = func(ctx context.Context, segment *LocalSegment, fieldID int64, rowCount int64, field *datapb.FieldBinlog) error {
+	return segment.LoadFieldData(ctx, fieldID, rowCount, field)
+}
 
 func GetPkField(schema *schemapb.CollectionSchema) *schemapb.FieldSchema {
 	for _, field := range schema.GetFields() {
@@ -260,6 +269,78 @@ func getFieldSchema(schema *schemapb.CollectionSchema, fieldID int64) (*schemapb
 		}
 	}
 	return nil, fmt.Errorf("field %d not found in schema", fieldID)
+}
+
+// ensureSortedSegmentPKLoaded guarantees the prerequisite field data is available
+// before applying delta logs on sorted sealed lazy segments. Sorted delete replay
+// needs both PK field data and system timestamps to resolve delete offsets.
+func ensureSortedSegmentPKLoaded(ctx context.Context, segment Segment) error {
+	if !segment.IsSorted() {
+		return nil
+	}
+	if segment.Type() != SegmentTypeSealed {
+		return nil
+	}
+	if !segment.IsLazyLoad() {
+		return nil
+	}
+
+	localSegment, ok := segment.(*LocalSegment)
+	if !ok {
+		return nil
+	}
+
+	pkField := GetPkField(localSegment.collection.Schema())
+	if pkField == nil {
+		return merr.WrapErrServiceInternal(fmt.Sprintf("segment(%d) pk field not found", segment.ID()))
+	}
+	pkFieldID := pkField.GetFieldID()
+
+	loadInfo := segment.LoadInfo()
+	if loadInfo == nil {
+		return merr.WrapErrServiceInternal(fmt.Sprintf("segment(%d) load info is nil", segment.ID()))
+	}
+	localSegment.fieldDataInfoMu.Lock()
+	defer localSegment.fieldDataInfoMu.Unlock()
+	if localSegment.fieldDataInfoAdded == nil || !localSegment.fieldDataInfoAdded.Load() {
+		if err := addSegmentFieldDataInfoFn(ctx, localSegment, loadInfo.GetNumOfRows(), loadInfo.GetBinlogPaths()); err != nil {
+			return err
+		}
+	}
+
+	fieldBinlogs := lo.SliceToMap(loadInfo.GetBinlogPaths(), func(fieldBinlog *datapb.FieldBinlog) (int64, *datapb.FieldBinlog) {
+		return fieldBinlog.GetFieldID(), fieldBinlog
+	})
+
+	// Serialize sorted lazy prerequisite loads per segment so concurrent delete
+	// replay requests do not race through the Loaded check and trigger duplicate
+	// PK/timestamp loads.
+	ensureFieldLoaded := func(fieldID int64, fieldName string) error {
+		if fieldInfo, ok := localSegment.fields.Get(fieldID); ok && fieldInfo.Loaded.Load() {
+			return nil
+		}
+		fieldBinlog, ok := fieldBinlogs[fieldID]
+		if !ok {
+			return merr.WrapErrServiceInternal(fmt.Sprintf("segment(%d) lacks %s(%d) binlog for sorted delta load", segment.ID(), fieldName, fieldID))
+		}
+		log.Ctx(ctx).Info("load field for sorted segment before delta load",
+			zap.Int64("collectionID", segment.Collection()),
+			zap.Int64("segmentID", segment.ID()),
+			zap.Int64("fieldID", fieldID),
+			zap.String("fieldName", fieldName),
+		)
+		return loadSegmentFieldDataFn(ctx, localSegment, fieldID, loadInfo.GetNumOfRows(), fieldBinlog)
+	}
+
+	if err := ensureFieldLoaded(pkFieldID, "pk"); err != nil {
+		return err
+	}
+
+	if err := ensureFieldLoaded(common.TimeStampField, common.TimeStampFieldName); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func isIndexMmapEnable(fieldSchema *schemapb.FieldSchema, indexInfo *querypb.FieldIndexInfo) bool {


### PR DESCRIPTION
see also #48274

When a sealed sorted segment is lazy-loaded, a delta-only sync can reach LoadDeletedRecord before pk field raw data is loaded.

segcore sorted pk lookup then hits fields_.at(pkFieldID) and returns unordered_map::at. Preload the pk field from segment binlogs before applying delta logs in this specific path (sorted + sealed + lazy + missing pk raw data).

Also add focused tests for preload-on-sorted and no-op-on-unsorted behavior.