### PR TITLE
enhance: support dynamic update access log configuration

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -361,10 +361,10 @@ proxy:
         format: "[$time_now] [ACCESS] <$user_name: $user_addr> $method_name [status: $method_status] [code: $error_code] [sdk: $sdk_version] [msg: $error_msg] [traceID: $trace_id] [timeCost: $time_cost]"
       query:
         format: "[$time_now] [ACCESS] <$user_name: $user_addr> $method_name [status: $method_status] [code: $error_code] [sdk: $sdk_version] [msg: $error_msg] [traceID: $trace_id] [timeCost: $time_cost] [database: $database_name] [collection: $collection_name] [partitions: $partition_name] [expr: $method_expr] [params: $query_params]"
-        methods: "Query, Delete"
+        methods: "Query, Delete, /query, /v2/vectordb/entities/query, /v2/vectordb/entities/get, /v2/vectordb/entities/delete"
       search:
         format: "[$time_now] [ACCESS] <$user_name: $user_addr> $method_name [status: $method_status] [code: $error_code] [sdk: $sdk_version] [msg: $error_msg] [traceID: $trace_id] [timeCost: $time_cost] [database: $database_name] [collection: $collection_name] [partitions: $partition_name] [expr: $method_expr] [nq: $nq] [params: $search_params]"
-        methods: "HybridSearch, Search"
+        methods: "HybridSearch, Search, /search, /v2/vectordb/entities/search, /v2/vectordb/entities/advanced_search, /v2/vectordb/entities/hybrid_search"
       upsert:
         format: "[$time_now] [ACCESS] <$user_name: $user_addr> $method_name [status: $method_status] [code: $error_code] [sdk: $sdk_version] [msg: $error_msg] [traceID: $trace_id] [timeCost: $time_cost] [database: $database_name] [collection: $collection_name] [partitions: $partition_name] [partial_update: $partial_update]"
         methods: Upsert

--- a/internal/proxy/accesslog/global.go
+++ b/internal/proxy/accesslog/global.go
@@ -18,7 +18,6 @@ package accesslog
 
 import (
 	"io"
-	"strconv"
 	"sync"
 	"time"
 
@@ -76,27 +75,37 @@ func (l *AccessLogger) Init(params *paramtable.ComponentParam) error {
 	return nil
 }
 
-func (l *AccessLogger) SetEnable(enable bool) error {
+func (l *AccessLogger) Update(enable bool) error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	if l.enable.Load() == enable {
+	// close logger
+	if !enable {
+		if l.enable.Load() != enable {
+			log.Info("start close access log")
+			if write, ok := l.writer.(*RotateWriter); ok {
+				write.Close()
+				l.writer = nil
+			}
+			l.enable.Store(enable)
+		}
 		return nil
 	}
 
-	if enable {
-		log.Info("start enable access log")
-		params := paramtable.Get()
-		err := l.init(params)
-		if err != nil {
-			log.Warn("enable access log failed", zap.Error(err))
-			return err
+	// close old writer before re-init
+	if l.writer != nil {
+		if rw, ok := l.writer.(*RotateWriter); ok {
+			rw.Close()
 		}
-	} else {
-		log.Info("start close access log")
-		if write, ok := l.writer.(*RotateWriter); ok {
-			write.Close()
-		}
+	}
+
+	// update access log params
+	log.Info("start update access log params")
+	params := paramtable.Get()
+	err := l.init(params)
+	if err != nil {
+		log.Warn("enable access log failed", zap.Error(err))
+		return err
 	}
 
 	l.enable.Store(enable)
@@ -128,13 +137,11 @@ func InitAccessLogger(params *paramtable.ComponentParam) {
 	once.Do(func() {
 		logger := NewAccessLogger()
 		// support dynamic param
-		params.Watch(params.ProxyCfg.AccessLog.Enable.Key, configEvent.NewHandler("enable accesslog", func(event *configEvent.Event) {
-			value, err := strconv.ParseBool(event.Value)
-			if err != nil {
-				log.Warn("Failed to parse bool value", zap.String("v", event.Value), zap.Error(err))
-				return
+		params.WatchKeyPrefix("proxy.accessLog", configEvent.NewHandler("update accesslog", func(event *configEvent.Event) {
+			enable := params.ProxyCfg.AccessLog.Enable.GetAsBool()
+			if err := logger.Update(enable); err != nil {
+				log.Warn("update access log failed", zap.Error(err))
 			}
-			logger.SetEnable(value)
 		}))
 
 		err := logger.Init(params)

--- a/internal/proxy/accesslog/global_test.go
+++ b/internal/proxy/accesslog/global_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus/internal/proxy/accesslog/info"
-	"github.com/milvus-io/milvus/pkg/v3/util/etcd"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -72,21 +71,48 @@ func TestAccessLogger_InitFailed(t *testing.T) {
 	assert.False(t, ok)
 
 	// init minio error cause init writter failed
-	Params.Init(paramtable.NewBaseTable(paramtable.SkipRemote(true)))
-	Params.Save(Params.ProxyCfg.AccessLog.MinioEnable.Key, "true")
-	Params.Save(Params.MinioCfg.Address.Key, "")
+	// Use a fresh once and params to avoid the watch registered above from firing on param changes
+	once = sync.Once{}
+	var Params2 paramtable.ComponentParam
+	Params2.Init(paramtable.NewBaseTable(paramtable.SkipRemote(true)))
+	Params2.Save(Params2.ProxyCfg.AccessLog.Enable.Key, "true")
+	Params2.Save(Params2.ProxyCfg.AccessLog.Filename.Key, "test_access")
+	Params2.Save(Params2.ProxyCfg.AccessLog.LocalPath.Key, t.TempDir())
+	Params2.Save(Params2.ProxyCfg.AccessLog.MinioEnable.Key, "true")
+	Params2.Save(Params2.MinioCfg.Address.Key, "")
 
-	InitAccessLogger(&Params)
+	InitAccessLogger(&Params2)
 	rpcInfo = &grpc.UnaryServerInfo{Server: nil, FullMethod: "testMethod"}
 	accessInfo = info.NewGrpcAccessInfo(context.Background(), rpcInfo, nil)
 	ok = _globalL.Write(accessInfo)
 	assert.False(t, ok)
 }
 
+func TestAccessLogger_UpdateDisableClearsRotateWriter(t *testing.T) {
+	var Params paramtable.ComponentParam
+	Params.Init(paramtable.NewBaseTable(paramtable.SkipRemote(true)))
+	Params.Save(Params.ProxyCfg.AccessLog.Enable.Key, "true")
+	Params.Save(Params.ProxyCfg.AccessLog.Filename.Key, "test_access")
+	Params.Save(Params.ProxyCfg.AccessLog.LocalPath.Key, t.TempDir())
+	Params.Save(Params.ProxyCfg.AccessLog.CacheSize.Key, "0")
+
+	logger := NewAccessLogger()
+	require.NoError(t, logger.Init(&Params))
+	writer, ok := logger.writer.(*RotateWriter)
+	require.True(t, ok)
+
+	require.NoError(t, logger.Update(false))
+	assert.False(t, logger.enable.Load())
+	assert.Nil(t, logger.writer)
+	assert.True(t, writer.closed)
+
+	require.NoError(t, logger.Update(false))
+}
+
 func TestAccessLogger_DynamicEnable(t *testing.T) {
 	once = sync.Once{}
 	var Params paramtable.ComponentParam
-	Params.Init(paramtable.NewBaseTable())
+	Params.Init(paramtable.NewBaseTable(paramtable.SkipRemote(true)))
 	Params.Save(Params.ProxyCfg.AccessLog.Enable.Key, "false")
 	// init with close accesslog
 	InitAccessLogger(&Params)
@@ -95,21 +121,8 @@ func TestAccessLogger_DynamicEnable(t *testing.T) {
 	ok := _globalL.Write(accessInfo)
 	assert.False(t, ok)
 
-	etcdCli, err := etcd.GetEtcdClient(
-		Params.EtcdCfg.UseEmbedEtcd.GetAsBool(),
-		Params.EtcdCfg.EtcdUseSSL.GetAsBool(),
-		Params.EtcdCfg.Endpoints.GetAsStrings(),
-		Params.EtcdCfg.EtcdTLSCert.GetValue(),
-		Params.EtcdCfg.EtcdTLSKey.GetValue(),
-		Params.EtcdCfg.EtcdTLSCACert.GetValue(),
-		Params.EtcdCfg.EtcdTLSMinVersion.GetValue())
-	require.NoError(t, err)
-
 	// enable access log
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	etcdCli.Put(ctx, "by-dev/config/proxy/accessLog/enable", "true")
-	defer etcdCli.Delete(ctx, "by-dev/config/proxy/accessLog/enable")
+	require.NoError(t, Params.Save(Params.ProxyCfg.AccessLog.Enable.Key, "true"))
 
 	assert.Eventually(t, func() bool {
 		accessInfo := info.NewGrpcAccessInfo(context.Background(), rpcInfo, nil)
@@ -118,7 +131,7 @@ func TestAccessLogger_DynamicEnable(t *testing.T) {
 	}, 10*time.Second, 500*time.Millisecond)
 
 	// disable access log
-	etcdCli.Put(ctx, "by-dev/config/proxy/accessLog/enable", "false")
+	require.NoError(t, Params.Save(Params.ProxyCfg.AccessLog.Enable.Key, "false"))
 	assert.Eventually(t, func() bool {
 		accessInfo := info.NewGrpcAccessInfo(context.Background(), rpcInfo, nil)
 		ok := _globalL.Write(accessInfo)


### PR DESCRIPTION
issue: #50206

## Summary
- Support dynamically updating access log configuration (formatters, methods, writer settings) without restarting, by watching all `proxy.accessLog` config keys instead of only the enable switch.
- Add RESTful API paths (`/search`, `/query`, `/v2/vectordb/entities/*`) to the default search/query formatter methods, so RESTful requests also get detailed access log formatting.
- Fix resource leak: close old `RotateWriter` before re-initializing when config changes.