### PR TITLE
enhance: improve replica and node assignment stability during scale-up/down

### DIFF
--- a/internal/distributed/streaming/forward.go
+++ b/internal/distributed/streaming/forward.go
@@ -273,14 +273,26 @@ func (fs *forwardServiceImpl) markForwardDisabled() {
 // the dml cannot be executed at new 2.6.x proxy until all 2.5.x proxies are down.
 //
 // so we need to forward the request to the 2.5.x proxy.
+//
+// DQL requests (Search/HybridSearch/Query) are only forwarded in standalone mode,
+// because in cluster mode the 2.6.x proxy can execute DQL locally via query nodes
+// without depending on the streaming service readiness.
 func ForwardLegacyProxyUnaryServerInterceptor(opts ...ForwardOption) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-		if info.FullMethod != milvuspb.MilvusService_Insert_FullMethodName &&
-			info.FullMethod != milvuspb.MilvusService_Delete_FullMethodName &&
-			info.FullMethod != milvuspb.MilvusService_Upsert_FullMethodName &&
-			info.FullMethod != milvuspb.MilvusService_Search_FullMethodName &&
-			info.FullMethod != milvuspb.MilvusService_HybridSearch_FullMethodName &&
-			info.FullMethod != milvuspb.MilvusService_Query_FullMethodName {
+		isDQL := info.FullMethod == milvuspb.MilvusService_Search_FullMethodName ||
+			info.FullMethod == milvuspb.MilvusService_HybridSearch_FullMethodName ||
+			info.FullMethod == milvuspb.MilvusService_Query_FullMethodName
+		isDML := info.FullMethod == milvuspb.MilvusService_Insert_FullMethodName ||
+			info.FullMethod == milvuspb.MilvusService_Delete_FullMethodName ||
+			info.FullMethod == milvuspb.MilvusService_Upsert_FullMethodName
+
+		if !isDML && !isDQL {
+			return handler(ctx, req)
+		}
+
+		// DQL is only forwarded in standalone mode; in cluster mode the current
+		// proxy can serve DQL directly without the streaming service being ready.
+		if isDQL && !paramtable.IsStandalone() {
 			return handler(ctx, req)
 		}
 

--- a/internal/distributed/streaming/forward_test.go
+++ b/internal/distributed/streaming/forward_test.go
@@ -39,6 +39,10 @@ import (
 )
 
 func TestForwardDMLToLegacyProxy(t *testing.T) {
+	// Run in standalone mode so DQL forwarding is also enabled.
+	paramtable.SetRole(typeutil.StandaloneRole)
+	defer paramtable.SetRole("")
+
 	etcdCli, _ := kvfactory.GetEtcdAndPath()
 	oldProxyPort := paramtable.Get().ProxyGrpcClientCfg.Port.SwapTempValue("19588")
 	defer paramtable.Get().ProxyGrpcClientCfg.Port.SwapTempValue(oldProxyPort)
@@ -94,7 +98,7 @@ func TestForwardDMLToLegacyProxy(t *testing.T) {
 		assert.Nil(t, resp)
 	}
 
-	// Only DML requests will be handled by the forward service.
+	// Only DML/DQL requests will be handled by the forward service.
 	resp, err := interceptor(context.Background(), &milvuspb.CreateCollectionRequest{}, &grpc.UnaryServerInfo{
 		FullMethod: milvuspb.MilvusService_CreateCollection_FullMethodName,
 	}, func(ctx context.Context, req any) (any, error) {
@@ -132,5 +136,35 @@ func TestForwardDMLToLegacyProxy(t *testing.T) {
 			return merr.Success(), nil
 		})
 		assert.NoError(t, merr.CheckRPCCall(resp, err))
+	}
+}
+
+func TestForwardDQLSkippedInClusterMode(t *testing.T) {
+	// In cluster mode (non-standalone), DQL should not be forwarded.
+	paramtable.SetRole("proxy")
+	defer paramtable.SetRole("")
+
+	// No need to set up a real forward service — DQL should never reach it in cluster mode.
+
+	interceptor := ForwardLegacyProxyUnaryServerInterceptor()
+
+	// DQL requests should go directly to handler, not forwarded.
+	dqlReqs := []any{
+		&milvuspb.SearchRequest{},
+		&milvuspb.HybridSearchRequest{},
+		&milvuspb.QueryRequest{},
+	}
+	dqlMethods := []string{
+		milvuspb.MilvusService_Search_FullMethodName,
+		milvuspb.MilvusService_HybridSearch_FullMethodName,
+		milvuspb.MilvusService_Query_FullMethodName,
+	}
+	for idx, req := range dqlReqs {
+		resp, err := interceptor(context.Background(), req, &grpc.UnaryServerInfo{
+			FullMethod: dqlMethods[idx],
+		}, func(ctx context.Context, req any) (any, error) {
+			return merr.Success(), nil
+		})
+		assert.NoError(t, merr.CheckRPCCall(resp, err), "DQL should not be forwarded in cluster mode")
 	}
 }

--- a/internal/querycoordv2/ddl_callbacks_alter_load_info.go
+++ b/internal/querycoordv2/ddl_callbacks_alter_load_info.go
@@ -28,7 +28,7 @@ import (
 func (s *Server) alterLoadConfigV2AckCallback(ctx context.Context, result message.BroadcastResultAlterLoadConfigMessageV2) error {
 	// currently, we only sent the put load config message to the control channel
 	// TODO: after we support query view in 3.0, we should broadcast the put load config message to all vchannels.
-	job := job.NewLoadCollectionJob(ctx, result, s.dist, s.meta, s.broker, s.targetMgr, s.targetObserver, s.collectionObserver, s.checkerController, s.nodeMgr)
+	job := job.NewLoadCollectionJob(ctx, result, s.dist, s.meta, s.broker, s.targetMgr, s.targetObserver, s.collectionObserver, s.checkerController, s.nodeMgr, s.proxyClientManager)
 	if err := job.Execute(); err != nil {
 		return err
 	}

--- a/internal/querycoordv2/job/job_load.go
+++ b/internal/querycoordv2/job/job_load.go
@@ -32,10 +32,12 @@ import (
 	"github.com/milvus-io/milvus/internal/querycoordv2/observers"
 	"github.com/milvus-io/milvus/internal/querycoordv2/session"
 	"github.com/milvus-io/milvus/internal/querycoordv2/utils"
+	"github.com/milvus-io/milvus/internal/util/proxyutil"
 	"github.com/milvus-io/milvus/pkg/v2/eventlog"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/metrics"
 	"github.com/milvus-io/milvus/pkg/v2/proto/messagespb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/proxypb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
@@ -56,6 +58,7 @@ type LoadCollectionJob struct {
 	collectionObserver *observers.CollectionObserver
 	checkerController  *checkers.CheckerController
 	nodeMgr            *session.NodeManager
+	proxyManager       proxyutil.ProxyClientManagerInterface
 }
 
 func NewLoadCollectionJob(
@@ -69,6 +72,7 @@ func NewLoadCollectionJob(
 	collectionObserver *observers.CollectionObserver,
 	checkerController *checkers.CheckerController,
 	nodeMgr *session.NodeManager,
+	proxyManager proxyutil.ProxyClientManagerInterface,
 ) *LoadCollectionJob {
 	return &LoadCollectionJob{
 		BaseJob:            NewBaseJob(ctx, 0, result.Message.Header().GetCollectionId()),
@@ -82,6 +86,7 @@ func NewLoadCollectionJob(
 		collectionObserver: collectionObserver,
 		checkerController:  checkerController,
 		nodeMgr:            nodeMgr,
+		proxyManager:       proxyManager,
 	}
 }
 
@@ -110,13 +115,21 @@ func (job *LoadCollectionJob) Execute() error {
 			zap.Int("localReplicaCount", len(localReplicas)))
 	}
 
-	// 2. create replica if not exist
+	// 2. create replica if not exist (may also remove redundant replicas)
 	if _, err := utils.SpawnReplicasWithReplicaConfig(job.ctx, job.meta, meta.SpawnWithReplicaConfigParams{
 		CollectionID: req.GetCollectionId(),
 		Channels:     collInfo.GetVirtualChannelNames(),
 		Configs:      replicas,
 	}); err != nil {
 		return err
+	}
+
+	// 2.1 invalidate shard leader cache after replica changes, so proxies stop
+	// routing to released replicas' shard leaders before async cleanup happens.
+	if job.proxyManager != nil {
+		job.proxyManager.InvalidateShardLeaderCache(job.ctx, &proxypb.InvalidateShardLeaderCacheRequest{
+			CollectionIDs: []int64{req.GetCollectionId()},
+		})
 	}
 
 	// 3. put load info meta

--- a/internal/querycoordv2/job/job_load_test.go
+++ b/internal/querycoordv2/job/job_load_test.go
@@ -81,7 +81,7 @@ func (suite *LoadCollectionJobSuite) TestDescribeCollectionNotFound() {
 		Return(nil, merr.WrapErrCollectionNotFound(collectionID))
 
 	result := suite.buildBroadcastResult(collectionID, []int64{100, 101})
-	job := NewLoadCollectionJob(ctx, result, nil, nil, broker, nil, nil, nil, nil, nil)
+	job := NewLoadCollectionJob(ctx, result, nil, nil, broker, nil, nil, nil, nil, nil, nil)
 
 	err := job.Execute()
 	suite.NoError(err)
@@ -98,7 +98,7 @@ func (suite *LoadCollectionJobSuite) TestDescribeCollectionOtherError() {
 		Return(nil, expectedErr)
 
 	result := suite.buildBroadcastResult(collectionID, []int64{200, 201})
-	job := NewLoadCollectionJob(ctx, result, nil, nil, broker, nil, nil, nil, nil, nil)
+	job := NewLoadCollectionJob(ctx, result, nil, nil, broker, nil, nil, nil, nil, nil, nil)
 
 	err := job.Execute()
 	suite.Error(err)
@@ -121,7 +121,7 @@ func (suite *LoadCollectionJobSuite) TestDescribeCollectionSuccess() {
 	result := suite.buildBroadcastResult(collectionID, []int64{300, 301})
 	// We pass nil for meta to test that DescribeCollection is called before SpawnReplicasWithReplicaConfig.
 	// SpawnReplicasWithReplicaConfig will panic on nil meta, proving that DescribeCollection was called first.
-	job := NewLoadCollectionJob(ctx, result, nil, nil, broker, nil, nil, nil, nil, nil)
+	job := NewLoadCollectionJob(ctx, result, nil, nil, broker, nil, nil, nil, nil, nil, nil)
 
 	// This should panic at SpawnReplicasWithReplicaConfig because meta is nil,
 	// but this proves DescribeCollection was called and returned successfully first.
@@ -191,7 +191,7 @@ func (suite *LoadCollectionJobSuite) TestUseLocalReplicaConfigWithLocalConfigSet
 
 	// Will panic at SpawnReplicasWithReplicaConfig (nil catalog in ReplicaManager.SpawnWithReplicaConfig),
 	// proving that getLocalReplicaConfig was called and produced replicas.
-	job := NewLoadCollectionJob(ctx, result, nil, m, broker, nil, nil, nil, nil, nil)
+	job := NewLoadCollectionJob(ctx, result, nil, m, broker, nil, nil, nil, nil, nil, nil)
 	suite.Panics(func() {
 		job.Execute()
 	})
@@ -229,7 +229,7 @@ func (suite *LoadCollectionJobSuite) TestUseLocalReplicaConfigWithoutLocalConfig
 
 	// Will panic at SpawnReplicasWithReplicaConfig (nil catalog in ReplicaManager.SpawnWithReplicaConfig),
 	// proving that getLocalReplicaConfig was called and produced default replicas (1 replica in default RG).
-	job := NewLoadCollectionJob(ctx, result, nil, m, broker, nil, nil, nil, nil, nil)
+	job := NewLoadCollectionJob(ctx, result, nil, m, broker, nil, nil, nil, nil, nil, nil)
 	suite.Panics(func() {
 		job.Execute()
 	})
@@ -259,7 +259,7 @@ func (suite *LoadCollectionJobSuite) TestUseLocalReplicaConfigFlagFalse() {
 	result := suite.buildBroadcastResultWithLocalReplicaConfig(collectionID, []int64{402}, false)
 
 	// Will panic at SpawnReplicasWithReplicaConfig with nil meta (using primary's replicas)
-	job := NewLoadCollectionJob(ctx, result, nil, nil, broker, nil, nil, nil, nil, nil)
+	job := NewLoadCollectionJob(ctx, result, nil, nil, broker, nil, nil, nil, nil, nil, nil)
 	suite.Panics(func() {
 		job.Execute()
 	})

--- a/internal/querycoordv2/job/job_update.go
+++ b/internal/querycoordv2/job/job_update.go
@@ -173,7 +173,7 @@ func (job *UpdateLoadConfigJob) Execute() error {
 	// 5.1 invalidate shard leader cache on all proxies after removing replicas,
 	// so that proxies stop routing requests to the released replicas' shard leaders
 	// before the async checker releases channels on those nodes.
-	if len(toRelease) > 0 {
+	if len(toRelease) > 0 && job.proxyManager != nil {
 		job.proxyManager.InvalidateShardLeaderCache(job.ctx, &proxypb.InvalidateShardLeaderCacheRequest{
 			CollectionIDs: []int64{job.collectionID},
 		})

--- a/internal/querycoordv2/job/job_update.go
+++ b/internal/querycoordv2/job/job_update.go
@@ -26,7 +26,9 @@ import (
 	"github.com/milvus-io/milvus/internal/querycoordv2/meta"
 	"github.com/milvus-io/milvus/internal/querycoordv2/observers"
 	"github.com/milvus-io/milvus/internal/querycoordv2/utils"
+	"github.com/milvus-io/milvus/internal/util/proxyutil"
 	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/proto/proxypb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 )
@@ -40,6 +42,7 @@ type UpdateLoadConfigJob struct {
 	targetMgr                meta.TargetManagerInterface
 	targetObserver           *observers.TargetObserver
 	collectionObserver       *observers.CollectionObserver
+	proxyManager             proxyutil.ProxyClientManagerInterface
 	userSpecifiedReplicaMode bool
 }
 
@@ -49,6 +52,7 @@ func NewUpdateLoadConfigJob(ctx context.Context,
 	targetMgr meta.TargetManagerInterface,
 	targetObserver *observers.TargetObserver,
 	collectionObserver *observers.CollectionObserver,
+	proxyManager proxyutil.ProxyClientManagerInterface,
 	userSpecifiedReplicaMode bool,
 ) *UpdateLoadConfigJob {
 	collectionID := req.GetCollectionIDs()[0]
@@ -58,6 +62,7 @@ func NewUpdateLoadConfigJob(ctx context.Context,
 		targetMgr:                targetMgr,
 		targetObserver:           targetObserver,
 		collectionObserver:       collectionObserver,
+		proxyManager:             proxyManager,
 		collectionID:             collectionID,
 		newReplicaNumber:         req.GetReplicaNumber(),
 		newResourceGroups:        req.GetResourceGroups(),
@@ -156,6 +161,15 @@ func (job *UpdateLoadConfigJob) Execute() error {
 	if err != nil {
 		log.Warn("failed to remove replicas", zap.Int64s("replicaIDs", toRelease), zap.Error(err))
 		return err
+	}
+
+	// 5.1 invalidate shard leader cache on all proxies after removing replicas,
+	// so that proxies stop routing requests to the released replicas' shard leaders
+	// before the async checker releases channels on those nodes.
+	if len(toRelease) > 0 {
+		job.proxyManager.InvalidateShardLeaderCache(job.ctx, &proxypb.InvalidateShardLeaderCacheRequest{
+			CollectionIDs: []int64{job.collectionID},
+		})
 	}
 
 	// 6. recover node distribution among replicas

--- a/internal/querycoordv2/job/job_update.go
+++ b/internal/querycoordv2/job/job_update.go
@@ -44,6 +44,7 @@ type UpdateLoadConfigJob struct {
 	collectionObserver       *observers.CollectionObserver
 	proxyManager             proxyutil.ProxyClientManagerInterface
 	userSpecifiedReplicaMode bool
+	needWaitRGReady          bool
 }
 
 func NewUpdateLoadConfigJob(ctx context.Context,
@@ -54,6 +55,7 @@ func NewUpdateLoadConfigJob(ctx context.Context,
 	collectionObserver *observers.CollectionObserver,
 	proxyManager proxyutil.ProxyClientManagerInterface,
 	userSpecifiedReplicaMode bool,
+	needWaitRGReady bool,
 ) *UpdateLoadConfigJob {
 	collectionID := req.GetCollectionIDs()[0]
 	return &UpdateLoadConfigJob{
@@ -67,6 +69,7 @@ func NewUpdateLoadConfigJob(ctx context.Context,
 		newReplicaNumber:         req.GetReplicaNumber(),
 		newResourceGroups:        req.GetResourceGroups(),
 		userSpecifiedReplicaMode: userSpecifiedReplicaMode,
+		needWaitRGReady:          needWaitRGReady,
 	}
 }
 
@@ -108,7 +111,11 @@ func (job *UpdateLoadConfigJob) Execute() error {
 
 	// 3. try to spawn new replica
 	channels := job.targetMgr.GetDmChannelsByCollection(job.ctx, job.collectionID, meta.CurrentTargetFirst)
-	newReplicas, spawnErr := job.meta.ReplicaManager.Spawn(job.ctx, job.collectionID, toSpawn, lo.Keys(channels), commonpb.LoadPriority_LOW)
+	var spawnOpts []meta.SpawnOption
+	if job.needWaitRGReady {
+		spawnOpts = append(spawnOpts, meta.WithNeedWaitRGReady())
+	}
+	newReplicas, spawnErr := job.meta.ReplicaManager.Spawn(job.ctx, job.collectionID, toSpawn, lo.Keys(channels), commonpb.LoadPriority_LOW, spawnOpts...)
 	if spawnErr != nil {
 		log.Warn("failed to spawn replica", zap.Error(spawnErr))
 		err := spawnErr

--- a/internal/querycoordv2/load_config_watcher.go
+++ b/internal/querycoordv2/load_config_watcher.go
@@ -135,7 +135,7 @@ func (w *LoadConfigWatcher) applyLoadConfigChanges() error {
 		w.Logger().Info("no collection to update load config, skip it")
 	}
 
-	if err := w.s.updateLoadConfig(w.notifier.Context(), collectionIDs, newReplicaNum, newRGs); err != nil {
+	if err := w.s.updateLoadConfig(w.notifier.Context(), collectionIDs, newReplicaNum, newRGs, true); err != nil {
 		w.Logger().Warn("failed to update load config", zap.Error(err))
 		return err
 	}

--- a/internal/querycoordv2/meta/replica.go
+++ b/internal/querycoordv2/meta/replica.go
@@ -77,6 +77,13 @@ type Replica struct {
 	// node used by replica but cannot add more channel on it.
 	// include the rebalance node.
 	loadPriority commonpb.LoadPriority
+
+	// needWaitRGReady is an in-memory only flag (not persisted).
+	// When true, the first node assignment for this replica should wait until
+	// its resource group has all requested nodes ready (MissingNumOfNodes == 0).
+	// This prevents unbalanced segment loading during replica scale-up.
+	// The flag is explicitly cleared after the first successful node assignment.
+	needWaitRGReady bool
 }
 
 // Deprecated: may break the consistency of ReplicaManager, use `Spawn` of `ReplicaManager` or `newReplica` instead.
@@ -115,6 +122,12 @@ func NewReplicaWithPriority(replica *querypb.Replica, priority commonpb.LoadPrio
 
 func (replica *Replica) LoadPriority() commonpb.LoadPriority {
 	return replica.loadPriority // TODO: the load priority doesn't persisted into the replica recovery info.
+}
+
+// NeedWaitRGReady returns whether this replica should wait for its resource group
+// to have all requested nodes before the first node assignment.
+func (replica *Replica) NeedWaitRGReady() bool {
+	return replica.needWaitRGReady
 }
 
 // GetID returns the id of the replica.
@@ -270,12 +283,13 @@ func (replica *Replica) CopyForWrite() *mutableReplica {
 
 	return &mutableReplica{
 		Replica: &Replica{
-			replicaPB:    proto.Clone(replica.replicaPB).(*querypb.Replica),
-			rwNodes:      typeutil.NewUniqueSet(replica.replicaPB.Nodes...),
-			roNodes:      typeutil.NewUniqueSet(replica.replicaPB.RoNodes...),
-			rwSQNodes:    typeutil.NewUniqueSet(replica.replicaPB.RwSqNodes...),
-			roSQNodes:    typeutil.NewUniqueSet(replica.replicaPB.RoSqNodes...),
-			loadPriority: replica.LoadPriority(),
+			replicaPB:       proto.Clone(replica.replicaPB).(*querypb.Replica),
+			rwNodes:         typeutil.NewUniqueSet(replica.replicaPB.Nodes...),
+			roNodes:         typeutil.NewUniqueSet(replica.replicaPB.RoNodes...),
+			rwSQNodes:       typeutil.NewUniqueSet(replica.replicaPB.RwSqNodes...),
+			roSQNodes:       typeutil.NewUniqueSet(replica.replicaPB.RoSqNodes...),
+			loadPriority:    replica.LoadPriority(),
+			needWaitRGReady: replica.needWaitRGReady,
 		},
 		exclusiveRWNodeToChannel: exclusiveRWNodeToChannel,
 	}
@@ -295,6 +309,12 @@ type mutableReplica struct {
 // SetResourceGroup sets the resource group name of the replica.
 func (replica *mutableReplica) SetResourceGroup(resourceGroup string) {
 	replica.replicaPB.ResourceGroup = resourceGroup
+}
+
+// SetNeedWaitRGReady sets the in-memory flag indicating this replica should wait
+// for its resource group to be fully ready before the first node assignment.
+func (replica *mutableReplica) SetNeedWaitRGReady(need bool) {
+	replica.needWaitRGReady = need
 }
 
 // AddRWNode adds the node to rw nodes of the replica.

--- a/internal/querycoordv2/meta/replica.go
+++ b/internal/querycoordv2/meta/replica.go
@@ -2,6 +2,7 @@ package meta
 
 import (
 	"sort"
+	"time"
 
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
@@ -78,12 +79,13 @@ type Replica struct {
 	// include the rebalance node.
 	loadPriority commonpb.LoadPriority
 
-	// needWaitRGReady is an in-memory only flag (not persisted).
-	// When true, the first node assignment for this replica should wait until
-	// its resource group has all requested nodes ready (MissingNumOfNodes == 0).
+	// waitRGReadyAt is an in-memory only timestamp (not persisted).
+	// When non-zero, the first node assignment for this replica should wait until
+	// its resource group has all requested nodes ready (MissingNumOfNodes == 0),
+	// or until the configured timeout has elapsed since this timestamp.
 	// This prevents unbalanced segment loading during replica scale-up.
-	// The flag is explicitly cleared after the first successful node assignment.
-	needWaitRGReady bool
+	// The field is explicitly cleared after the first successful node assignment.
+	waitRGReadyAt time.Time
 }
 
 // Deprecated: may break the consistency of ReplicaManager, use `Spawn` of `ReplicaManager` or `newReplica` instead.
@@ -126,8 +128,13 @@ func (replica *Replica) LoadPriority() commonpb.LoadPriority {
 
 // NeedWaitRGReady returns whether this replica should wait for its resource group
 // to have all requested nodes before the first node assignment.
+// Returns false if the wait has expired.
 func (replica *Replica) NeedWaitRGReady() bool {
-	return replica.needWaitRGReady
+	if replica.waitRGReadyAt.IsZero() {
+		return false
+	}
+	timeout := paramtable.Get().QueryCoordCfg.ClusterLevelLoadWaitRGReadyTimeout.GetAsDurationByParse()
+	return time.Since(replica.waitRGReadyAt) < timeout
 }
 
 // GetID returns the id of the replica.
@@ -283,13 +290,13 @@ func (replica *Replica) CopyForWrite() *mutableReplica {
 
 	return &mutableReplica{
 		Replica: &Replica{
-			replicaPB:       proto.Clone(replica.replicaPB).(*querypb.Replica),
-			rwNodes:         typeutil.NewUniqueSet(replica.replicaPB.Nodes...),
-			roNodes:         typeutil.NewUniqueSet(replica.replicaPB.RoNodes...),
-			rwSQNodes:       typeutil.NewUniqueSet(replica.replicaPB.RwSqNodes...),
-			roSQNodes:       typeutil.NewUniqueSet(replica.replicaPB.RoSqNodes...),
-			loadPriority:    replica.LoadPriority(),
-			needWaitRGReady: replica.needWaitRGReady,
+			replicaPB:     proto.Clone(replica.replicaPB).(*querypb.Replica),
+			rwNodes:       typeutil.NewUniqueSet(replica.replicaPB.Nodes...),
+			roNodes:       typeutil.NewUniqueSet(replica.replicaPB.RoNodes...),
+			rwSQNodes:     typeutil.NewUniqueSet(replica.replicaPB.RwSqNodes...),
+			roSQNodes:     typeutil.NewUniqueSet(replica.replicaPB.RoSqNodes...),
+			loadPriority:  replica.LoadPriority(),
+			waitRGReadyAt: replica.waitRGReadyAt,
 		},
 		exclusiveRWNodeToChannel: exclusiveRWNodeToChannel,
 	}
@@ -311,10 +318,11 @@ func (replica *mutableReplica) SetResourceGroup(resourceGroup string) {
 	replica.replicaPB.ResourceGroup = resourceGroup
 }
 
-// SetNeedWaitRGReady sets the in-memory flag indicating this replica should wait
-// for its resource group to be fully ready before the first node assignment.
-func (replica *mutableReplica) SetNeedWaitRGReady(need bool) {
-	replica.needWaitRGReady = need
+// SetWaitRGReadyAt sets the timestamp from which this replica should wait for
+// its resource group to be fully ready before the first node assignment.
+// Pass zero time to clear the wait.
+func (replica *mutableReplica) SetWaitRGReadyAt(t time.Time) {
+	replica.waitRGReadyAt = t
 }
 
 // AddRWNode adds the node to rw nodes of the replica.

--- a/internal/querycoordv2/meta/replica_manager.go
+++ b/internal/querycoordv2/meta/replica_manager.go
@@ -45,7 +45,7 @@ type ReplicaManagerInterface interface {
 	Recover(ctx context.Context, collections []int64) error
 	Get(ctx context.Context, id typeutil.UniqueID) *Replica
 	Spawn(ctx context.Context, collection int64,
-		replicaNumInRG map[string]int, channels []string, loadPriority commonpb.LoadPriority) ([]*Replica, error)
+		replicaNumInRG map[string]int, channels []string, loadPriority commonpb.LoadPriority, opts ...SpawnOption) ([]*Replica, error)
 
 	// Replica manipulation
 	TransferReplica(ctx context.Context, collectionID typeutil.UniqueID, srcRGName string, dstRGName string, replicaNum int) error
@@ -60,7 +60,7 @@ type ReplicaManagerInterface interface {
 	GetByResourceGroup(ctx context.Context, rgName string) []*Replica
 
 	// Node management
-	RecoverNodesInCollection(ctx context.Context, collectionID typeutil.UniqueID, rgs map[string]typeutil.UniqueSet) error
+	RecoverNodesInCollection(ctx context.Context, collectionID typeutil.UniqueID, rgs map[string]*ResourceGroup) error
 	RemoveNode(ctx context.Context, replicaID typeutil.UniqueID, nodes ...typeutil.UniqueID) error
 	RemoveSQNode(ctx context.Context, replicaID typeutil.UniqueID, nodes ...typeutil.UniqueID) error
 
@@ -239,10 +239,32 @@ func (m *ReplicaManager) AllocateReplicaID(ctx context.Context) (int64, error) {
 	return m.idAllocator()
 }
 
+// SpawnOption is a functional option for Spawn.
+type SpawnOption func(*spawnConfig)
+
+type spawnConfig struct {
+	needWaitRGReady bool
+}
+
+// WithNeedWaitRGReady returns a SpawnOption that sets the needWaitRGReady flag on spawned replicas.
+// When enabled, the first node assignment for these replicas will be deferred
+// until their resource groups have all requested nodes ready (MissingNumOfNodes == 0).
+// This prevents unbalanced segment loading during replica scale-up.
+func WithNeedWaitRGReady() SpawnOption {
+	return func(cfg *spawnConfig) {
+		cfg.needWaitRGReady = true
+	}
+}
+
 // Spawn spawns N replicas at resource group for given collection in ReplicaManager.
 func (m *ReplicaManager) Spawn(ctx context.Context, collection int64, replicaNumInRG map[string]int,
-	channels []string, loadPriority commonpb.LoadPriority,
+	channels []string, loadPriority commonpb.LoadPriority, opts ...SpawnOption,
 ) ([]*Replica, error) {
+	cfg := &spawnConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
 	m.rwmutex.Lock()
 	defer m.rwmutex.Unlock()
 
@@ -262,11 +284,14 @@ func (m *ReplicaManager) Spawn(ctx context.Context, collection int64, replicaNum
 				CollectionID:  collection,
 				ResourceGroup: rgName,
 			}, loadPriority)
-			if enableChannelExclusiveMode {
-				mutableReplica := replica.CopyForWrite()
-				mutableReplica.TryEnableChannelExclusiveMode(channels...)
-				replica = mutableReplica.IntoReplica()
+			mutableReplica := replica.CopyForWrite()
+			if cfg.needWaitRGReady {
+				mutableReplica.SetNeedWaitRGReady(true)
 			}
+			if enableChannelExclusiveMode {
+				mutableReplica.TryEnableChannelExclusiveMode(channels...)
+			}
+			replica = mutableReplica.IntoReplica()
 			replicas = append(replicas, replica)
 		}
 	}
@@ -517,8 +542,18 @@ func (m *ReplicaManager) GetByResourceGroup(ctx context.Context, rgName string) 
 // 1. Move the rw nodes to ro nodes if they are not in related resource group.
 // 2. Add new incoming nodes into the replica if they are not in-used by other replicas of same collection.
 // 3. replicas in same resource group will shared the nodes in resource group fairly.
-func (m *ReplicaManager) RecoverNodesInCollection(ctx context.Context, collectionID typeutil.UniqueID, rgs map[string]typeutil.UniqueSet) error {
-	if err := m.validateResourceGroups(rgs); err != nil {
+func (m *ReplicaManager) RecoverNodesInCollection(ctx context.Context, collectionID typeutil.UniqueID, rgs map[string]*ResourceGroup) error {
+	// Build node sets from resource groups.
+	rgNodeSets := make(map[string]typeutil.UniqueSet, len(rgs))
+	for rgName, rg := range rgs {
+		if rg == nil {
+			rgNodeSets[rgName] = typeutil.NewUniqueSet()
+		} else {
+			rgNodeSets[rgName] = typeutil.NewUniqueSet(rg.GetNodes()...)
+		}
+	}
+
+	if err := m.validateResourceGroups(rgNodeSets); err != nil {
 		return err
 	}
 
@@ -526,7 +561,7 @@ func (m *ReplicaManager) RecoverNodesInCollection(ctx context.Context, collectio
 	defer m.rwmutex.Unlock()
 
 	// create a helper to do the recover.
-	helper, err := m.getCollectionAssignmentHelper(collectionID, rgs)
+	helper, err := m.getCollectionAssignmentHelper(collectionID, rgNodeSets)
 	if err != nil {
 		return err
 	}
@@ -535,6 +570,21 @@ func (m *ReplicaManager) RecoverNodesInCollection(ctx context.Context, collectio
 	// recover node by resource group.
 	helper.RangeOverResourceGroup(func(replicaHelper *replicasInSameRGAssignmentHelper) {
 		replicaHelper.RangeOverReplicas(func(assignment *replicaAssignmentInfo) {
+			replica := m.replicas[assignment.GetReplicaID()]
+			// For replicas with needWaitRGReady flag, skip assignment if the RG still has missing nodes.
+			if replica.NeedWaitRGReady() {
+				rgName := replica.GetResourceGroup()
+				if rg := rgs[rgName]; rg != nil && rg.MissingNumOfNodes() > 0 {
+					log.RatedInfo(10, "defer node assignment for new replica, resource group not ready",
+						zap.Int64("collectionID", collectionID),
+						zap.Int64("replicaID", replica.GetID()),
+						zap.String("rgName", rgName),
+						zap.Int("missingNodes", rg.MissingNumOfNodes()),
+					)
+					return
+				}
+			}
+
 			roNodes := assignment.GetNewRONodes()
 			recoverableNodes, incomingNodeCount := assignment.GetRecoverNodesAndIncomingNodeCount()
 			// There may be not enough incoming nodes for current replica,
@@ -545,10 +595,14 @@ func (m *ReplicaManager) RecoverNodesInCollection(ctx context.Context, collectio
 				// nothing to do.
 				return
 			}
-			mutableReplica := m.replicas[assignment.GetReplicaID()].CopyForWrite()
+			mutableReplica := replica.CopyForWrite()
 			mutableReplica.AddRONode(roNodes...)          // rw -> ro
 			mutableReplica.AddRWNode(recoverableNodes...) // ro -> rw
 			mutableReplica.AddRWNode(incomingNode...)     // unused -> rw
+			// Clear needWaitRGReady flag after first successful node assignment.
+			if mutableReplica.NeedWaitRGReady() {
+				mutableReplica.SetNeedWaitRGReady(false)
+			}
 			log.Info(
 				"new replica recovery found",
 				zap.Int64("collectionID", collectionID),

--- a/internal/querycoordv2/meta/replica_manager.go
+++ b/internal/querycoordv2/meta/replica_manager.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
@@ -243,16 +244,17 @@ func (m *ReplicaManager) AllocateReplicaID(ctx context.Context) (int64, error) {
 type SpawnOption func(*spawnConfig)
 
 type spawnConfig struct {
-	needWaitRGReady bool
+	waitRGReady bool
 }
 
-// WithNeedWaitRGReady returns a SpawnOption that sets the needWaitRGReady flag on spawned replicas.
+// WithNeedWaitRGReady returns a SpawnOption that enables waiting for resource group readiness.
 // When enabled, the first node assignment for these replicas will be deferred
-// until their resource groups have all requested nodes ready (MissingNumOfNodes == 0).
+// until their resource groups have all requested nodes ready (MissingNumOfNodes == 0),
+// or until the configured timeout (queryCoord.waitRGReadyTimeout) has elapsed.
 // This prevents unbalanced segment loading during replica scale-up.
 func WithNeedWaitRGReady() SpawnOption {
 	return func(cfg *spawnConfig) {
-		cfg.needWaitRGReady = true
+		cfg.waitRGReady = true
 	}
 }
 
@@ -285,8 +287,8 @@ func (m *ReplicaManager) Spawn(ctx context.Context, collection int64, replicaNum
 				ResourceGroup: rgName,
 			}, loadPriority)
 			mutableReplica := replica.CopyForWrite()
-			if cfg.needWaitRGReady {
-				mutableReplica.SetNeedWaitRGReady(true)
+			if cfg.waitRGReady {
+				mutableReplica.SetWaitRGReadyAt(time.Now())
 			}
 			if enableChannelExclusiveMode {
 				mutableReplica.TryEnableChannelExclusiveMode(channels...)
@@ -599,9 +601,9 @@ func (m *ReplicaManager) RecoverNodesInCollection(ctx context.Context, collectio
 			mutableReplica.AddRONode(roNodes...)          // rw -> ro
 			mutableReplica.AddRWNode(recoverableNodes...) // ro -> rw
 			mutableReplica.AddRWNode(incomingNode...)     // unused -> rw
-			// Clear needWaitRGReady flag after first successful node assignment.
+			// Clear waitRGReady after first successful node assignment.
 			if mutableReplica.NeedWaitRGReady() {
-				mutableReplica.SetNeedWaitRGReady(false)
+				mutableReplica.SetWaitRGReadyAt(time.Time{})
 			}
 			log.Info(
 				"new replica recovery found",

--- a/internal/querycoordv2/meta/replica_manager_test.go
+++ b/internal/querycoordv2/meta/replica_manager_test.go
@@ -43,6 +43,15 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
+// newTestResourceGroup creates a ResourceGroup for testing with given nodes.
+func newTestResourceGroup(name string, nodes typeutil.UniqueSet) *ResourceGroup {
+	return &ResourceGroup{
+		name:  name,
+		nodes: nodes,
+		cfg:   newResourceGroupConfig(int32(nodes.Len()), int32(nodes.Len())),
+	}
+}
+
 type collectionLoadConfig struct {
 	spawnConfig map[string]int
 }
@@ -59,7 +68,7 @@ func (c *collectionLoadConfig) getTotalSpawn() int {
 type ReplicaManagerSuite struct {
 	suite.Suite
 
-	rgs         map[string]typeutil.UniqueSet
+	rgNodes     map[string]typeutil.UniqueSet
 	collections map[int64]collectionLoadConfig
 	idAllocator func() (int64, error)
 	kv          kv.MetaKv
@@ -71,7 +80,7 @@ type ReplicaManagerSuite struct {
 func (suite *ReplicaManagerSuite) SetupSuite() {
 	paramtable.Init()
 
-	suite.rgs = map[string]typeutil.UniqueSet{
+	suite.rgNodes = map[string]typeutil.UniqueSet{
 		"RG1": typeutil.NewUniqueSet(1),
 		"RG2": typeutil.NewUniqueSet(2, 3),
 		"RG3": typeutil.NewUniqueSet(4, 5, 6),
@@ -199,7 +208,7 @@ func (suite *ReplicaManagerSuite) TestGet() {
 
 		expectedNodes := make([]int64, 0)
 		for rg := range collectionCfg.spawnConfig {
-			expectedNodes = append(expectedNodes, suite.rgs[rg].Collect()...)
+			expectedNodes = append(expectedNodes, suite.rgNodes[rg].Collect()...)
 		}
 		suite.ElementsMatch(nodes, expectedNodes)
 
@@ -291,7 +300,7 @@ func (suite *ReplicaManagerSuite) TestNodeManipulate() {
 	ctx := suite.ctx
 
 	// add node into rg.
-	rgs := map[string]typeutil.UniqueSet{
+	rgNodes := map[string]typeutil.UniqueSet{
 		"RG1": typeutil.NewUniqueSet(1, 7),
 		"RG2": typeutil.NewUniqueSet(2, 3, 8),
 		"RG3": typeutil.NewUniqueSet(4, 5, 6, 9),
@@ -299,13 +308,13 @@ func (suite *ReplicaManagerSuite) TestNodeManipulate() {
 
 	// Add node into rg.
 	for collectionID, cfg := range suite.collections {
-		rgsOfCollection := make(map[string]typeutil.UniqueSet)
+		rgsOfCollection := make(map[string]*ResourceGroup)
 		for rg := range cfg.spawnConfig {
-			rgsOfCollection[rg] = rgs[rg]
+			rgsOfCollection[rg] = newTestResourceGroup(rg, rgNodes[rg])
 		}
 		mgr.RecoverNodesInCollection(ctx, collectionID, rgsOfCollection)
 		for rg := range cfg.spawnConfig {
-			for _, node := range rgs[rg].Collect() {
+			for _, node := range rgNodes[rg].Collect() {
 				replica := mgr.GetByCollectionAndNode(ctx, collectionID, node)
 				suite.Contains(replica.GetNodes(), node)
 			}
@@ -317,7 +326,7 @@ func (suite *ReplicaManagerSuite) TestNodeManipulate() {
 	mgr.Recover(ctx, lo.Keys(suite.collections))
 	for collectionID, cfg := range suite.collections {
 		for rg := range cfg.spawnConfig {
-			for _, node := range rgs[rg].Collect() {
+			for _, node := range rgNodes[rg].Collect() {
 				replica := mgr.GetByCollectionAndNode(ctx, collectionID, node)
 				suite.Contains(replica.GetNodes(), node)
 			}
@@ -333,10 +342,10 @@ func (suite *ReplicaManagerSuite) spawnAll() {
 		replicas, err := mgr.Spawn(ctx, id, cfg.spawnConfig, nil, commonpb.LoadPriority_LOW)
 		suite.NoError(err)
 		totalSpawn := 0
-		rgsOfCollection := make(map[string]typeutil.UniqueSet)
+		rgsOfCollection := make(map[string]*ResourceGroup)
 		for rg, spawnNum := range cfg.spawnConfig {
 			totalSpawn += spawnNum
-			rgsOfCollection[rg] = suite.rgs[rg]
+			rgsOfCollection[rg] = newTestResourceGroup(rg, suite.rgNodes[rg])
 		}
 		mgr.RecoverNodesInCollection(ctx, id, rgsOfCollection)
 		suite.Len(replicas, totalSpawn)
@@ -370,7 +379,7 @@ func (suite *ReplicaManagerSuite) clearMemory() {
 type ReplicaManagerV2Suite struct {
 	suite.Suite
 
-	rgs             map[string]typeutil.UniqueSet
+	rgNodes         map[string]typeutil.UniqueSet
 	sqNodes         typeutil.UniqueSet
 	outboundSQNodes []int64
 	collections     map[int64]collectionLoadConfig
@@ -383,7 +392,7 @@ type ReplicaManagerV2Suite struct {
 func (suite *ReplicaManagerV2Suite) SetupSuite() {
 	paramtable.Init()
 
-	suite.rgs = map[string]typeutil.UniqueSet{
+	suite.rgNodes = map[string]typeutil.UniqueSet{
 		"RG1": typeutil.NewUniqueSet(1),
 		"RG2": typeutil.NewUniqueSet(2, 3),
 		"RG3": typeutil.NewUniqueSet(4, 5, 6),
@@ -443,14 +452,14 @@ func (suite *ReplicaManagerV2Suite) TestSpawn() {
 	for id, cfg := range suite.collections {
 		replicas, err := mgr.Spawn(ctx, id, cfg.spawnConfig, nil, commonpb.LoadPriority_LOW)
 		suite.NoError(err)
-		rgsOfCollection := make(map[string]typeutil.UniqueSet)
+		rgsOfCollection := make(map[string]*ResourceGroup)
 		for rg := range cfg.spawnConfig {
-			rgsOfCollection[rg] = suite.rgs[rg]
+			rgsOfCollection[rg] = newTestResourceGroup(rg, suite.rgNodes[rg])
 		}
 		mgr.RecoverNodesInCollection(ctx, id, rgsOfCollection)
 		mgr.RecoverSQNodesInCollection(ctx, id, suite.sqNodes)
 		for rg := range cfg.spawnConfig {
-			for _, node := range suite.rgs[rg].Collect() {
+			for _, node := range suite.rgNodes[rg].Collect() {
 				replica := mgr.GetByCollectionAndNode(ctx, id, node)
 				suite.Contains(replica.GetNodes(), node)
 			}
@@ -480,7 +489,7 @@ func (suite *ReplicaManagerV2Suite) testIfBalanced() {
 			minimumNodes := -1
 			nodes := make([]int64, 0)
 			for _, r := range replicas {
-				availableNodes := suite.rgs[r.GetResourceGroup()]
+				availableNodes := suite.rgNodes[r.GetResourceGroup()]
 				if maximumNodes == -1 || r.RWNodesCount() > maximumNodes {
 					maximumNodes = r.RWNodesCount()
 				}
@@ -503,7 +512,7 @@ func (suite *ReplicaManagerV2Suite) testIfBalanced() {
 					return true
 				})
 			}
-			suite.ElementsMatch(nodes, suite.rgs[replicas[0].GetResourceGroup()].Collect())
+			suite.ElementsMatch(nodes, suite.rgNodes[replicas[0].GetResourceGroup()].Collect())
 			suite.True(maximumNodes-minimumNodes <= 1)
 		}
 		availableSQNodes := suite.sqNodes.Clone()
@@ -533,15 +542,15 @@ func (suite *ReplicaManagerV2Suite) TestTransferReplicaAndAddNode() {
 	ctx := suite.ctx
 	suite.mgr.TransferReplica(ctx, 1005, "RG4", "RG5", 1)
 	suite.recoverReplica(1, false)
-	suite.rgs["RG5"].Insert(16, 17, 18)
+	suite.rgNodes["RG5"].Insert(16, 17, 18)
 	suite.sqNodes.Insert(20, 21, 22)
 	suite.recoverReplica(2, true)
 	suite.testIfBalanced()
 }
 
 func (suite *ReplicaManagerV2Suite) TestTransferNode() {
-	suite.rgs["RG4"].Remove(7)
-	suite.rgs["RG5"].Insert(7)
+	suite.rgNodes["RG4"].Remove(7)
+	suite.rgNodes["RG5"].Insert(7)
 	suite.outboundSQNodes = []int64{16, 17, 18}
 	suite.recoverReplica(2, true)
 	suite.testIfBalanced()
@@ -554,9 +563,9 @@ func (suite *ReplicaManagerV2Suite) recoverReplica(k int, clearOutbound bool) {
 	for i := 0; i < k; i++ {
 		// do a recover
 		for id, cfg := range suite.collections {
-			rgsOfCollection := make(map[string]typeutil.UniqueSet)
+			rgsOfCollection := make(map[string]*ResourceGroup)
 			for rg := range cfg.spawnConfig {
-				rgsOfCollection[rg] = suite.rgs[rg]
+				rgsOfCollection[rg] = newTestResourceGroup(rg, suite.rgNodes[rg])
 			}
 			sqNodes := suite.sqNodes.Clone()
 			sqNodes.Remove(suite.outboundSQNodes...)

--- a/internal/querycoordv2/meta/replica_test.go
+++ b/internal/querycoordv2/meta/replica_test.go
@@ -839,6 +839,33 @@ func (suite *ReplicaSuite) TestTryEnableChannelExclusiveModeInsufficientNodes() 
 	}
 }
 
+func (suite *ReplicaSuite) TestNeedWaitRGReady() {
+	// Default replica should not have the flag set
+	r := newReplica(&querypb.Replica{
+		ID:            1,
+		CollectionID:  2,
+		ResourceGroup: DefaultResourceGroupName,
+	})
+	suite.False(r.NeedWaitRGReady(), "default replica should not need to wait for RG ready")
+
+	// Set the flag via mutableReplica
+	mutable := r.CopyForWrite()
+	mutable.SetNeedWaitRGReady(true)
+	r2 := mutable.IntoReplica()
+	suite.True(r2.NeedWaitRGReady(), "flag should be set after SetNeedWaitRGReady(true)")
+
+	// CopyForWrite should carry the flag
+	mutable2 := r2.CopyForWrite()
+	r3 := mutable2.IntoReplica()
+	suite.True(r3.NeedWaitRGReady(), "CopyForWrite should carry needWaitRGReady flag")
+
+	// Explicitly clear the flag
+	mutable3 := r3.CopyForWrite()
+	mutable3.SetNeedWaitRGReady(false)
+	r4 := mutable3.IntoReplica()
+	suite.False(r4.NeedWaitRGReady(), "flag should be cleared after SetNeedWaitRGReady(false)")
+}
+
 func TestReplica(t *testing.T) {
 	suite.Run(t, new(ReplicaSuite))
 }

--- a/internal/querycoordv2/meta/replica_test.go
+++ b/internal/querycoordv2/meta/replica_test.go
@@ -2,6 +2,7 @@ package meta
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 
@@ -839,7 +840,10 @@ func (suite *ReplicaSuite) TestTryEnableChannelExclusiveModeInsufficientNodes() 
 	}
 }
 
-func (suite *ReplicaSuite) TestNeedWaitRGReady() {
+func (suite *ReplicaSuite) TestWaitRGReady() {
+	paramtable.Get().Save(paramtable.Get().QueryCoordCfg.ClusterLevelLoadWaitRGReadyTimeout.Key, "1m")
+	defer paramtable.Get().Reset(paramtable.Get().QueryCoordCfg.ClusterLevelLoadWaitRGReadyTimeout.Key)
+
 	// Default replica should not have the flag set
 	r := newReplica(&querypb.Replica{
 		ID:            1,
@@ -848,22 +852,28 @@ func (suite *ReplicaSuite) TestNeedWaitRGReady() {
 	})
 	suite.False(r.NeedWaitRGReady(), "default replica should not need to wait for RG ready")
 
-	// Set the flag via mutableReplica
+	// Set the timestamp via mutableReplica
 	mutable := r.CopyForWrite()
-	mutable.SetNeedWaitRGReady(true)
+	mutable.SetWaitRGReadyAt(time.Now())
 	r2 := mutable.IntoReplica()
-	suite.True(r2.NeedWaitRGReady(), "flag should be set after SetNeedWaitRGReady(true)")
+	suite.True(r2.NeedWaitRGReady(), "should need to wait when timestamp is recent")
 
-	// CopyForWrite should carry the flag
+	// CopyForWrite should carry the timestamp
 	mutable2 := r2.CopyForWrite()
 	r3 := mutable2.IntoReplica()
-	suite.True(r3.NeedWaitRGReady(), "CopyForWrite should carry needWaitRGReady flag")
+	suite.True(r3.NeedWaitRGReady(), "CopyForWrite should carry waitRGReadyAt")
 
-	// Explicitly clear the flag
+	// Explicitly clear the timestamp
 	mutable3 := r3.CopyForWrite()
-	mutable3.SetNeedWaitRGReady(false)
+	mutable3.SetWaitRGReadyAt(time.Time{})
 	r4 := mutable3.IntoReplica()
-	suite.False(r4.NeedWaitRGReady(), "flag should be cleared after SetNeedWaitRGReady(false)")
+	suite.False(r4.NeedWaitRGReady(), "should not wait after clearing timestamp")
+
+	// Expired timestamp should return false
+	mutable4 := r.CopyForWrite()
+	mutable4.SetWaitRGReadyAt(time.Now().Add(-120 * time.Second))
+	r5 := mutable4.IntoReplica()
+	suite.False(r5.NeedWaitRGReady(), "should not wait when timestamp has expired")
 }
 
 func TestReplica(t *testing.T) {

--- a/internal/querycoordv2/meta/resource_group.go
+++ b/internal/querycoordv2/meta/resource_group.go
@@ -97,6 +97,11 @@ func (rg *ResourceGroup) GetConfigCloned() *rgpb.ResourceGroupConfig {
 	return proto.Clone(rg.cfg).(*rgpb.ResourceGroupConfig)
 }
 
+// GetAllNodes return all physical nodes of resource group, bypassing node label filter.
+func (rg *ResourceGroup) GetAllNodes() []int64 {
+	return rg.nodes.Collect()
+}
+
 // GetNodes return nodes of resource group which match required node labels
 func (rg *ResourceGroup) GetNodes() []int64 {
 	requiredNodeLabels := rg.GetConfig().GetNodeFilter().GetNodeLabels()

--- a/internal/querycoordv2/meta/resource_manager.go
+++ b/internal/querycoordv2/meta/resource_manager.go
@@ -96,18 +96,20 @@ func (rm *ResourceManager) Recover(ctx context.Context) error {
 
 	// Resource group meta upgrade to latest version.
 	upgrades := make([]*querypb.ResourceGroup, 0)
+	nodeToRG := make(map[int64]string) // local map for duplicate node detection during recovery
 	for _, meta := range rgs {
 		needUpgrade := meta.Config == nil
 
 		rg := NewResourceGroupFromMeta(meta, rm.nodeMgr)
-		rm.setupInMemResourceGroup(rg)
+		// Check for duplicate node assignments before committing to memory.
 		for _, node := range rg.GetNodes() {
-			if _, ok := rm.nodeIDMap[node]; ok {
+			if existingRG, ok := nodeToRG[node]; ok {
 				// unreachable code, should never happen.
-				panic(fmt.Sprintf("dirty meta, node has been assign to multi resource group, %s, %s", rm.nodeIDMap[node], rg.GetName()))
+				panic(fmt.Sprintf("dirty meta, node has been assign to multi resource group, %s, %s", existingRG, rg.GetName()))
 			}
-			rm.nodeIDMap[node] = rg.GetName()
+			nodeToRG[node] = rg.GetName()
 		}
+		rm.setupInMemResourceGroup(rg)
 		log.Info("Recover resource group",
 			zap.String("rgName", rg.GetName()),
 			zap.Int64s("nodes", rm.groups[rg.GetName()].GetNodes()),
@@ -306,7 +308,6 @@ func (rm *ResourceManager) transferNodesOnRGSwap(modifiedRGs []*ResourceGroup) {
 			for _, node := range nodes {
 				donorMut.UnassignNode(node)
 				recipientMut.AssignNode(node)
-				rm.nodeIDMap[node] = candidate.GetName()
 			}
 			modifiedRGs[i] = donorMut.ToResourceGroup()
 			modifiedRGs[j] = recipientMut.ToResourceGroup()
@@ -1056,7 +1057,6 @@ func (rm *ResourceManager) transferNode(ctx context.Context, rgName string, node
 	for _, rg := range modifiedRG {
 		rm.setupInMemResourceGroup(rg)
 	}
-	rm.nodeIDMap[node] = rgName
 	log.Info("transfer node to resource group",
 		zap.String("rgName", rgName),
 		zap.String("originalRG", originalRG),
@@ -1086,8 +1086,7 @@ func (rm *ResourceManager) unassignNode(ctx context.Context, node int64) (string
 
 		// Commit updates to memory.
 		rm.setupInMemResourceGroup(rg)
-		delete(rm.nodeIDMap, node)
-		log.Info("unassign node to resource group",
+		log.Info("unassign node from resource group",
 			zap.String("rgName", rg.GetName()),
 			zap.Int64("node", node),
 		)
@@ -1168,21 +1167,25 @@ func (rm *ResourceManager) validateResourceGroupIsDeletable(rgName string) error
 
 // setupInMemResourceGroup setup resource group in memory.
 func (rm *ResourceManager) setupInMemResourceGroup(r *ResourceGroup) {
-	// clear old metrics.
+	// clear old metrics and nodeIDMap entries.
+	// Use GetAllNodes (bypasses label filter) to ensure all physical nodes are cleaned up,
+	// even when the RG's label filter has changed.
 	if oldR, ok := rm.groups[r.GetName()]; ok {
-		for _, nodeID := range oldR.GetNodes() {
+		for _, nodeID := range oldR.GetAllNodes() {
 			metrics.QueryCoordResourceGroupInfo.DeletePartialMatch(prometheus.Labels{
 				metrics.ResourceGroupLabelName: r.GetName(),
 				metrics.NodeIDLabelName:        strconv.FormatInt(nodeID, 10),
 			})
+			delete(rm.nodeIDMap, nodeID)
 		}
 	}
-	// add new metrics.
-	for _, nodeID := range r.GetNodes() {
+	// add new metrics and nodeIDMap entries.
+	for _, nodeID := range r.GetAllNodes() {
 		metrics.QueryCoordResourceGroupInfo.WithLabelValues(
 			r.GetName(),
 			strconv.FormatInt(nodeID, 10),
 		).Set(1)
+		rm.nodeIDMap[nodeID] = r.GetName()
 	}
 	rm.groups[r.GetName()] = r
 }

--- a/internal/querycoordv2/meta/resource_manager.go
+++ b/internal/querycoordv2/meta/resource_manager.go
@@ -454,17 +454,17 @@ func (rm *ResourceManager) DropResourceGroup(ctx context.Context, rgName string)
 	return nil
 }
 
-// GetNodesOfMultiRG return nodes of multi rg, it can be used to get a consistent view of nodes of multi rg.
-func (rm *ResourceManager) GetNodesOfMultiRG(ctx context.Context, rgName []string) (map[string]typeutil.UniqueSet, error) {
+// GetResourceGroups return snapshots of multi resource groups, it can be used to get a consistent view of multi rg.
+func (rm *ResourceManager) GetResourceGroups(ctx context.Context, rgNames []string) (map[string]*ResourceGroup, error) {
 	rm.rwmutex.RLock()
 	defer rm.rwmutex.RUnlock()
 
-	ret := make(map[string]typeutil.UniqueSet)
-	for _, name := range rgName {
+	ret := make(map[string]*ResourceGroup, len(rgNames))
+	for _, name := range rgNames {
 		if rm.groups[name] == nil {
 			return nil, merr.WrapErrResourceGroupNotFound(name)
 		}
-		ret[name] = typeutil.NewUniqueSet(rm.groups[name].GetNodes()...)
+		ret[name] = rm.groups[name].Snapshot()
 	}
 	return ret, nil
 }

--- a/internal/querycoordv2/meta/resource_manager.go
+++ b/internal/querycoordv2/meta/resource_manager.go
@@ -19,6 +19,7 @@ package meta
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strconv"
 	"sync"
 
@@ -215,6 +216,17 @@ func (rm *ResourceManager) updateResourceGroups(ctx context.Context, rgs map[str
 		modifiedRG = append(modifiedRG, rg)
 	}
 
+	// Detect node transfer intent: if rgA is being zeroed (old request=N,limit=N → new 0,0)
+	// and rgB's new config matches rgA's old (new request=N,limit=N), directly move rgA's
+	// nodes to rgB. This preserves node assignment stability during RG transitions.
+	rm.transferNodesOnRGSwap(modifiedRG)
+
+	// Rebuild updates slice since node lists may have changed.
+	updates = updates[:0]
+	for _, rg := range modifiedRG {
+		updates = append(updates, rg.GetMeta())
+	}
+
 	if err := rm.catalog.SaveResourceGroup(ctx, updates...); err != nil {
 		for rgName, cfg := range rgs {
 			log.Warn("failed to update resource group",
@@ -238,6 +250,77 @@ func (rm *ResourceManager) updateResourceGroups(ctx context.Context, rgs map[str
 	// notify that resource group config has been changed.
 	rm.rgChangedNotifier.NotifyAll()
 	return nil
+}
+
+// transferNodesOnRGSwap detects "RG rename" intent in a batch config update and
+// directly transfers nodes between paired RGs to preserve node assignment stability.
+//
+// During replica scale-up/down, the external control plane changes RG names
+// (e.g., __default_resource_group → rg_for_replica_1). Without this optimization,
+// nodes would first be pushed to __recycle_resource_group by the async resource_observer,
+// then pulled into rg_for_replica_1 — with non-deterministic node selection at each hop,
+// breaking the original node-to-replica mapping and potentially causing replica unavailability.
+//
+// Detection: for each RG being zeroed (old config request=N,limit=N → new 0,0),
+// find the first unmatched RG in the same batch whose new config matches (request=N,limit=N).
+// RGs are sorted by name so the lexicographically smallest recipient wins.
+func (rm *ResourceManager) transferNodesOnRGSwap(modifiedRGs []*ResourceGroup) {
+	// Sort by name for deterministic matching order.
+	sort.Slice(modifiedRGs, func(i, j int) bool {
+		return modifiedRGs[i].GetName() < modifiedRGs[j].GetName()
+	})
+
+	matched := make(map[int]bool)
+	for i, rg := range modifiedRGs {
+		// Find a zeroed RG: new config (0,0) but old config had (N,N) with nodes.
+		newReq := rg.GetConfig().GetRequests().GetNodeNum()
+		newLim := rg.GetConfig().GetLimits().GetNodeNum()
+		if newReq != 0 || newLim != 0 {
+			continue
+		}
+		oldRG := rm.groups[rg.GetName()]
+		if oldRG == nil {
+			continue
+		}
+		oldReq := oldRG.GetConfig().GetRequests().GetNodeNum()
+		oldLim := oldRG.GetConfig().GetLimits().GetNodeNum()
+		nodes := oldRG.GetNodes()
+		if oldReq <= 0 || oldLim <= 0 || len(nodes) == 0 {
+			continue
+		}
+
+		// Find the first unmatched recipient whose new (request, limit) == old (request, limit).
+		for j, candidate := range modifiedRGs {
+			if j == i || matched[j] || candidate.NodeNum() > 0 {
+				continue
+			}
+			cReq := candidate.GetConfig().GetRequests().GetNodeNum()
+			cLim := candidate.GetConfig().GetLimits().GetNodeNum()
+			if cReq != oldReq || cLim != oldLim {
+				continue
+			}
+
+			// Swap nodes from donor to recipient.
+			donorMut := rg.CopyForWrite()
+			recipientMut := candidate.CopyForWrite()
+			for _, node := range nodes {
+				donorMut.UnassignNode(node)
+				recipientMut.AssignNode(node)
+				rm.nodeIDMap[node] = candidate.GetName()
+			}
+			modifiedRGs[i] = donorMut.ToResourceGroup()
+			modifiedRGs[j] = recipientMut.ToResourceGroup()
+			matched[i] = true
+			matched[j] = true
+
+			log.Info("direct node transfer on RG swap",
+				zap.String("from", rg.GetName()),
+				zap.String("to", candidate.GetName()),
+				zap.Int64s("nodes", nodes),
+			)
+			break
+		}
+	}
 }
 
 // Deprecated: only for compatibility with unittest.

--- a/internal/querycoordv2/meta/resource_manager_test.go
+++ b/internal/querycoordv2/meta/resource_manager_test.go
@@ -1352,3 +1352,164 @@ func (suite *ResourceManagerSuite) TestTransferNodesOnRGSwap_LexOrder() {
 	rg1Nodes := suite.manager.GetResourceGroup(ctx, "rg1").GetNodes()
 	suite.ElementsMatch(originalNodes, rg1Nodes, "lex-smallest rg1 should get the nodes")
 }
+
+func (suite *ResourceManagerSuite) TestTransferNodesOnRGSwap_MultipleDonors() {
+	ctx := suite.ctx
+	// Setup: rg1(2,2) with 2 nodes, rg2(3,3) with 3 nodes.
+	suite.manager.AddResourceGroup(ctx, "rg1", newResourceGroupConfig(2, 2))
+	suite.manager.AddResourceGroup(ctx, "rg2", newResourceGroupConfig(3, 3))
+	for i := int64(1); i <= 5; i++ {
+		suite.manager.nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{
+			NodeID:   i,
+			Address:  "localhost",
+			Hostname: "localhost",
+		}))
+		suite.manager.HandleNodeUp(ctx, i)
+	}
+	suite.manager.AutoRecoverResourceGroup(ctx, "rg1")
+	suite.manager.AutoRecoverResourceGroup(ctx, "rg2")
+	rg1Nodes := suite.manager.GetResourceGroup(ctx, "rg1").GetNodes()
+	rg2Nodes := suite.manager.GetResourceGroup(ctx, "rg2").GetNodes()
+
+	// Both donors zeroed, both recipients match respective configs.
+	suite.manager.AddResourceGroup(ctx, "rg3", newResourceGroupConfig(0, 0))
+	suite.manager.AddResourceGroup(ctx, "rg4", newResourceGroupConfig(0, 0))
+	suite.manager.AlterResourceGroups(ctx, map[string]*rgpb.ResourceGroupConfig{
+		"rg1": newResourceGroupConfig(0, 0),
+		"rg2": newResourceGroupConfig(0, 0),
+		"rg3": newResourceGroupConfig(2, 2),
+		"rg4": newResourceGroupConfig(3, 3),
+	})
+
+	suite.Equal(0, suite.manager.GetResourceGroup(ctx, "rg1").NodeNum())
+	suite.Equal(0, suite.manager.GetResourceGroup(ctx, "rg2").NodeNum())
+	suite.Equal(2, suite.manager.GetResourceGroup(ctx, "rg3").NodeNum())
+	suite.Equal(3, suite.manager.GetResourceGroup(ctx, "rg4").NodeNum())
+	suite.ElementsMatch(rg1Nodes, suite.manager.GetResourceGroup(ctx, "rg3").GetNodes())
+	suite.ElementsMatch(rg2Nodes, suite.manager.GetResourceGroup(ctx, "rg4").GetNodes())
+}
+
+func (suite *ResourceManagerSuite) TestTransferNodesOnRGSwap_RecipientAlreadyHasNodes() {
+	ctx := suite.ctx
+	// Setup: default(2,2) with 2 nodes, rg1(1,3) with 1 node.
+	suite.manager.AlterResourceGroups(ctx, map[string]*rgpb.ResourceGroupConfig{
+		DefaultResourceGroupName: newResourceGroupConfig(2, 2),
+	})
+	suite.manager.AddResourceGroup(ctx, "rg1", newResourceGroupConfig(1, 3))
+	for i := int64(1); i <= 3; i++ {
+		suite.manager.nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{
+			NodeID:   i,
+			Address:  "localhost",
+			Hostname: "localhost",
+		}))
+		suite.manager.HandleNodeUp(ctx, i)
+	}
+	suite.manager.AutoRecoverResourceGroup(ctx, "rg1")
+	suite.Positive(suite.manager.GetResourceGroup(ctx, "rg1").NodeNum())
+
+	// default(2,2) -> (0,0), rg1 -> (2,2). But rg1 already has nodes, so no swap.
+	suite.manager.AlterResourceGroups(ctx, map[string]*rgpb.ResourceGroupConfig{
+		DefaultResourceGroupName: newResourceGroupConfig(0, 0),
+		"rg1":                    newResourceGroupConfig(2, 2),
+	})
+
+	// Nodes should NOT be transferred since recipient already has nodes.
+	suite.Equal(2, suite.manager.GetResourceGroup(ctx, DefaultResourceGroupName).NodeNum())
+	suite.Positive(suite.manager.GetResourceGroup(ctx, "rg1").NodeNum())
+}
+
+func (suite *ResourceManagerSuite) TestTransferNodesOnRGSwap_NodeIDMapConsistency() {
+	ctx := suite.ctx
+	// Setup: default(3,3) with nodes 1,2,3.
+	suite.manager.AlterResourceGroups(ctx, map[string]*rgpb.ResourceGroupConfig{
+		DefaultResourceGroupName: newResourceGroupConfig(3, 3),
+	})
+	suite.manager.AddResourceGroup(ctx, "rg1", newResourceGroupConfig(0, 0))
+	for i := int64(1); i <= 3; i++ {
+		suite.manager.nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{
+			NodeID:   i,
+			Address:  "localhost",
+			Hostname: "localhost",
+		}))
+		suite.manager.HandleNodeUp(ctx, i)
+	}
+
+	// Verify nodeIDMap before swap.
+	for i := int64(1); i <= 3; i++ {
+		suite.Equal(DefaultResourceGroupName, suite.manager.nodeIDMap[i])
+	}
+
+	// Swap: default(3,3) -> (0,0), rg1(0,0) -> (3,3).
+	suite.manager.AlterResourceGroups(ctx, map[string]*rgpb.ResourceGroupConfig{
+		DefaultResourceGroupName: newResourceGroupConfig(0, 0),
+		"rg1":                    newResourceGroupConfig(3, 3),
+	})
+
+	// Verify nodeIDMap is updated correctly after swap.
+	for i := int64(1); i <= 3; i++ {
+		suite.Equal("rg1", suite.manager.nodeIDMap[i],
+			"nodeIDMap[%d] should point to rg1 after swap", i)
+	}
+	// Donor should have no entries left.
+	for _, node := range suite.manager.GetResourceGroup(ctx, DefaultResourceGroupName).GetNodes() {
+		suite.Fail("default RG should have no nodes, but found node %d", node)
+	}
+}
+
+func (suite *ResourceManagerSuite) TestGetResourceGroups() {
+	ctx := suite.ctx
+	suite.manager.AddResourceGroup(ctx, "rg1", newResourceGroupConfig(2, 2))
+	suite.manager.AddResourceGroup(ctx, "rg2", newResourceGroupConfig(3, 3))
+	for i := int64(1); i <= 5; i++ {
+		suite.manager.nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{
+			NodeID:   i,
+			Address:  "localhost",
+			Hostname: "localhost",
+		}))
+		suite.manager.HandleNodeUp(ctx, i)
+	}
+
+	// Get multiple RGs.
+	rgs, err := suite.manager.GetResourceGroups(ctx, []string{"rg1", "rg2"})
+	suite.NoError(err)
+	suite.Len(rgs, 2)
+	suite.NotNil(rgs["rg1"])
+	suite.NotNil(rgs["rg2"])
+	suite.Equal(int32(2), rgs["rg1"].GetConfig().GetRequests().GetNodeNum())
+	suite.Equal(int32(3), rgs["rg2"].GetConfig().GetRequests().GetNodeNum())
+
+	// Snapshots should have correct nodes.
+	suite.Equal(2, rgs["rg1"].NodeNum())
+	suite.Equal(3, rgs["rg2"].NodeNum())
+
+	// Non-existent RG should return error.
+	_, err = suite.manager.GetResourceGroups(ctx, []string{"rg1", "nonexistent"})
+	suite.Error(err)
+}
+
+func (suite *ResourceManagerSuite) TestSetupInMemResourceGroup_NodeIDMapCleanup() {
+	ctx := suite.ctx
+	// Setup: rg1(2,2) with nodes 1,2.
+	suite.manager.AddResourceGroup(ctx, "rg1", newResourceGroupConfig(2, 2))
+	for i := int64(1); i <= 2; i++ {
+		suite.manager.nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{
+			NodeID:   i,
+			Address:  "localhost",
+			Hostname: "localhost",
+		}))
+		suite.manager.HandleNodeUp(ctx, i)
+	}
+	suite.Equal("rg1", suite.manager.nodeIDMap[1])
+	suite.Equal("rg1", suite.manager.nodeIDMap[2])
+
+	// Simulate rg1 losing node 2 via setupInMemResourceGroup with new RG snapshot.
+	rg := suite.manager.GetResourceGroup(ctx, "rg1")
+	mutable := rg.CopyForWrite()
+	mutable.UnassignNode(2)
+	suite.manager.setupInMemResourceGroup(mutable.ToResourceGroup())
+
+	// node 1 should still map to rg1, node 2 should be cleaned up.
+	suite.Equal("rg1", suite.manager.nodeIDMap[1])
+	_, exists := suite.manager.nodeIDMap[2]
+	suite.False(exists, "nodeIDMap should not contain node 2 after it was removed from rg1")
+}

--- a/internal/querycoordv2/meta/resource_manager_test.go
+++ b/internal/querycoordv2/meta/resource_manager_test.go
@@ -1233,3 +1233,122 @@ func TestResourceManager_CheckNodesInResourceGroup_AllNodesHealthy(t *testing.T)
 	assert.Contains(t, finalNodes, int64(1002), "Healthy node should remain")
 	assert.Equal(t, 2, len(finalNodes), "Should have exactly 2 nodes")
 }
+
+func (suite *ResourceManagerSuite) TestTransferNodesOnRGSwap_ScaleUp() {
+	ctx := suite.ctx
+	// Setup: default(3,3) with 3 nodes.
+	suite.manager.AlterResourceGroups(ctx, map[string]*rgpb.ResourceGroupConfig{
+		DefaultResourceGroupName: newResourceGroupConfig(3, 3),
+	})
+	suite.manager.AddResourceGroup(ctx, "rg1", newResourceGroupConfig(0, 0))
+	for i := int64(1); i <= 3; i++ {
+		suite.manager.nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{
+			NodeID:   i,
+			Address:  "localhost",
+			Hostname: "localhost",
+		}))
+		suite.manager.HandleNodeUp(ctx, i)
+	}
+	suite.Equal(3, suite.manager.GetResourceGroup(ctx, DefaultResourceGroupName).NodeNum())
+	originalNodes := suite.manager.GetResourceGroup(ctx, DefaultResourceGroupName).GetNodes()
+
+	// Scale-up: default(3,3) -> (0,0), rg1(0,0) -> (3,3) in one batch.
+	// transferNodesOnRGSwap should move default's nodes directly to rg1.
+	suite.manager.AlterResourceGroups(ctx, map[string]*rgpb.ResourceGroupConfig{
+		DefaultResourceGroupName: newResourceGroupConfig(0, 0),
+		"rg1":                    newResourceGroupConfig(3, 3),
+	})
+
+	suite.Equal(0, suite.manager.GetResourceGroup(ctx, DefaultResourceGroupName).NodeNum())
+	suite.Equal(3, suite.manager.GetResourceGroup(ctx, "rg1").NodeNum())
+	// Verify the exact same nodes were transferred.
+	rg1Nodes := suite.manager.GetResourceGroup(ctx, "rg1").GetNodes()
+	suite.ElementsMatch(originalNodes, rg1Nodes, "rg1 should have the exact same nodes as original default")
+}
+
+func (suite *ResourceManagerSuite) TestTransferNodesOnRGSwap_ScaleDown() {
+	ctx := suite.ctx
+	// Setup: rg1(3,3) with 3 nodes, default(0,0).
+	suite.manager.AddResourceGroup(ctx, "rg1", newResourceGroupConfig(3, 3))
+	for i := int64(1); i <= 3; i++ {
+		suite.manager.nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{
+			NodeID:   i,
+			Address:  "localhost",
+			Hostname: "localhost",
+		}))
+		suite.manager.HandleNodeUp(ctx, i)
+	}
+	suite.manager.AutoRecoverResourceGroup(ctx, "rg1")
+	suite.Equal(3, suite.manager.GetResourceGroup(ctx, "rg1").NodeNum())
+	originalNodes := suite.manager.GetResourceGroup(ctx, "rg1").GetNodes()
+
+	// Scale-down: rg1(3,3) -> (0,0), default(0,0) -> (3,3).
+	suite.manager.AlterResourceGroups(ctx, map[string]*rgpb.ResourceGroupConfig{
+		"rg1":                    newResourceGroupConfig(0, 0),
+		DefaultResourceGroupName: newResourceGroupConfig(3, 3),
+	})
+
+	suite.Equal(3, suite.manager.GetResourceGroup(ctx, DefaultResourceGroupName).NodeNum())
+	suite.Equal(0, suite.manager.GetResourceGroup(ctx, "rg1").NodeNum())
+	defaultNodes := suite.manager.GetResourceGroup(ctx, DefaultResourceGroupName).GetNodes()
+	suite.ElementsMatch(originalNodes, defaultNodes, "default should have the exact same nodes as original rg1")
+}
+
+func (suite *ResourceManagerSuite) TestTransferNodesOnRGSwap_NoMatchWhenConfigDiffers() {
+	ctx := suite.ctx
+	// Setup: default(3,3) with 3 nodes.
+	suite.manager.AlterResourceGroups(ctx, map[string]*rgpb.ResourceGroupConfig{
+		DefaultResourceGroupName: newResourceGroupConfig(3, 3),
+	})
+	for i := int64(1); i <= 3; i++ {
+		suite.manager.nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{
+			NodeID:   i,
+			Address:  "localhost",
+			Hostname: "localhost",
+		}))
+		suite.manager.HandleNodeUp(ctx, i)
+	}
+	suite.manager.AddResourceGroup(ctx, "rg1", newResourceGroupConfig(0, 0))
+
+	// No match: default(3,3) -> (0,0), but rg1 -> (5,5) != (3,3).
+	suite.manager.AlterResourceGroups(ctx, map[string]*rgpb.ResourceGroupConfig{
+		DefaultResourceGroupName: newResourceGroupConfig(0, 0),
+		"rg1":                    newResourceGroupConfig(5, 5),
+	})
+
+	// No swap should happen; nodes remain in default (now redundant, but not moved).
+	suite.Equal(3, suite.manager.GetResourceGroup(ctx, DefaultResourceGroupName).NodeNum())
+	suite.Equal(0, suite.manager.GetResourceGroup(ctx, "rg1").NodeNum())
+}
+
+func (suite *ResourceManagerSuite) TestTransferNodesOnRGSwap_LexOrder() {
+	ctx := suite.ctx
+	// Setup: default(3,3) with 3 nodes, rg1 and rg2 both want (3,3).
+	suite.manager.AlterResourceGroups(ctx, map[string]*rgpb.ResourceGroupConfig{
+		DefaultResourceGroupName: newResourceGroupConfig(3, 3),
+	})
+	suite.manager.AddResourceGroup(ctx, "rg1", newResourceGroupConfig(0, 0))
+	suite.manager.AddResourceGroup(ctx, "rg2", newResourceGroupConfig(0, 0))
+	for i := int64(1); i <= 3; i++ {
+		suite.manager.nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{
+			NodeID:   i,
+			Address:  "localhost",
+			Hostname: "localhost",
+		}))
+		suite.manager.HandleNodeUp(ctx, i)
+	}
+	originalNodes := suite.manager.GetResourceGroup(ctx, DefaultResourceGroupName).GetNodes()
+
+	// Both rg1 and rg2 match default's old config. Lex-smallest (rg1) should win.
+	suite.manager.AlterResourceGroups(ctx, map[string]*rgpb.ResourceGroupConfig{
+		DefaultResourceGroupName: newResourceGroupConfig(0, 0),
+		"rg1":                    newResourceGroupConfig(3, 3),
+		"rg2":                    newResourceGroupConfig(3, 3),
+	})
+
+	suite.Equal(0, suite.manager.GetResourceGroup(ctx, DefaultResourceGroupName).NodeNum())
+	suite.Equal(3, suite.manager.GetResourceGroup(ctx, "rg1").NodeNum())
+	suite.Equal(0, suite.manager.GetResourceGroup(ctx, "rg2").NodeNum())
+	rg1Nodes := suite.manager.GetResourceGroup(ctx, "rg1").GetNodes()
+	suite.ElementsMatch(originalNodes, rg1Nodes, "lex-smallest rg1 should get the nodes")
+}

--- a/internal/querycoordv2/observers/resource_observer.go
+++ b/internal/querycoordv2/observers/resource_observer.go
@@ -18,6 +18,7 @@ package observers
 
 import (
 	"context"
+	"sort"
 	"sync"
 	"time"
 
@@ -104,6 +105,10 @@ func (ob *ResourceObserver) checkAndRecoverResourceGroup(ctx context.Context) {
 
 	log.Debug("recover resource groups...")
 	// Recover all resource group into expected configuration.
+	// Sort RG names lexicographically so that nodes from __default_resource_group are
+	// preferentially allocated to the lexicographically smallest RG first, maintaining
+	// QN assignment stability during scale-up.
+	sort.Strings(rgNames)
 	for _, rgName := range rgNames {
 		if err := manager.MeetRequirement(ctx, rgName); err != nil {
 			log.Info("found resource group need to be recovered",

--- a/internal/querycoordv2/server_test.go
+++ b/internal/querycoordv2/server_test.go
@@ -431,7 +431,7 @@ func TestApplyLoadConfigChanges(t *testing.T) {
 		var capturedCollectionIDs []int64
 		var capturedReplicaNum int32
 		var capturedRGs []string
-		mockey.Mock((*Server).updateLoadConfig).To(func(s *Server, ctx context.Context, collectionIDs []int64, newReplicaNum int32, newRGs []string) error {
+		mockey.Mock((*Server).updateLoadConfig).To(func(s *Server, ctx context.Context, collectionIDs []int64, newReplicaNum int32, newRGs []string, needWaitRGReady ...bool) error {
 			updateLoadConfigCalled = true
 			capturedCollectionIDs = collectionIDs
 			capturedReplicaNum = newReplicaNum

--- a/internal/querycoordv2/services.go
+++ b/internal/querycoordv2/services.go
@@ -1094,7 +1094,7 @@ func (s *Server) UpdateLoadConfig(ctx context.Context, req *querypb.UpdateLoadCo
 	return merr.Success(), nil
 }
 
-func (s *Server) updateLoadConfig(ctx context.Context, collectionIDs []int64, newReplicaNum int32, newRGs []string) error {
+func (s *Server) updateLoadConfig(ctx context.Context, collectionIDs []int64, newReplicaNum int32, newRGs []string, needWaitRGReady ...bool) error {
 	jobs := make([]job.Job, 0, len(collectionIDs))
 	for _, collectionID := range collectionIDs {
 		collection := s.meta.GetCollection(ctx, collectionID)
@@ -1129,6 +1129,7 @@ func (s *Server) updateLoadConfig(ctx context.Context, collectionIDs []int64, ne
 			continue
 		}
 
+		waitRG := len(needWaitRGReady) > 0 && needWaitRGReady[0]
 		updateJob := job.NewUpdateLoadConfigJob(
 			ctx,
 			subReq,
@@ -1138,6 +1139,7 @@ func (s *Server) updateLoadConfig(ctx context.Context, collectionIDs []int64, ne
 			s.collectionObserver,
 			s.proxyClientManager,
 			false,
+			waitRG,
 		)
 
 		jobs = append(jobs, updateJob)

--- a/internal/querycoordv2/services.go
+++ b/internal/querycoordv2/services.go
@@ -1136,6 +1136,7 @@ func (s *Server) updateLoadConfig(ctx context.Context, collectionIDs []int64, ne
 			s.targetMgr,
 			s.targetObserver,
 			s.collectionObserver,
+			s.proxyClientManager,
 			false,
 		)
 

--- a/internal/querycoordv2/services_test.go
+++ b/internal/querycoordv2/services_test.go
@@ -1594,7 +1594,8 @@ func (suite *ServiceSuite) TestLoadBalanceFailed() {
 		suite.Equal(commonpb.ErrorCode_UnexpectedError, resp.ErrorCode)
 		suite.Contains(resp.Reason, "mock error")
 
-		suite.meta.ReplicaManager.RecoverNodesInCollection(ctx, collection, map[string]typeutil.UniqueSet{meta.DefaultResourceGroupName: typeutil.NewUniqueSet(10)})
+		rgs, _ := suite.meta.ResourceManager.GetResourceGroups(ctx, []string{meta.DefaultResourceGroupName})
+		suite.meta.ReplicaManager.RecoverNodesInCollection(ctx, collection, rgs)
 		req.SourceNodeIDs = []int64{10}
 		resp, err = server.LoadBalance(ctx, req)
 		suite.NoError(err)

--- a/internal/querycoordv2/utils/meta.go
+++ b/internal/querycoordv2/utils/meta.go
@@ -89,7 +89,7 @@ func RecoverReplicaOfCollection(ctx context.Context, m *meta.Meta, collectionID 
 		logger.Error("no resource group found for collection")
 		return
 	}
-	rgs, err := m.ResourceManager.GetNodesOfMultiRG(ctx, rgNames.Collect())
+	rgs, err := m.ResourceManager.GetResourceGroups(ctx, rgNames.Collect())
 	if err != nil {
 		logger.Error("unreachable code as expected, fail to get resource group for replica", zap.Error(err))
 		return

--- a/internal/querycoordv2/utils/meta.go
+++ b/internal/querycoordv2/utils/meta.go
@@ -19,6 +19,7 @@ package utils
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/samber/lo"
@@ -209,8 +210,11 @@ func ReassignReplicaToRG(
 	})
 
 	// if rg doesn't exist in newResourceGroups, add all replicas to candidateToRelease
+	// Sort outRg in reverse lexicographic order so that replicas from lexicographically larger RGs
+	// are added first (released first during scale-down), preserving replicas from smaller RGs.
 	candidateToRelease := make([]*meta.Replica, 0)
 	outRg, _ := lo.Difference(lo.Keys(replicasInRG), newResourceGroups)
+	sort.Sort(sort.Reverse(sort.StringSlice(outRg)))
 	if len(outRg) > 0 {
 		for _, rgName := range outRg {
 			candidateToRelease = append(candidateToRelease, replicasInRG[rgName]...)
@@ -219,8 +223,12 @@ func ReassignReplicaToRG(
 
 	// if rg has more replicas than newAssignment's replica number, add the rest replicas to candidateToMove
 	// also set the lacked replica number as rg's replicaToSpawn value
+	// Sort newAssignment keys for deterministic behavior.
 	replicaToSpawn := make(map[string]int, len(newAssignment))
-	for rgName, count := range newAssignment {
+	sortedAssignmentRGs := lo.Keys(newAssignment)
+	sort.Strings(sortedAssignmentRGs)
+	for _, rgName := range sortedAssignmentRGs {
+		count := newAssignment[rgName]
 		if len(replicasInRG[rgName]) > count {
 			candidateToRelease = append(candidateToRelease, replicasInRG[rgName][count:]...)
 		} else {
@@ -243,9 +251,13 @@ func ReassignReplicaToRG(
 
 	// if candidateToMove is not empty, pick replica from candidate add add it to replicaToTransfer
 	// which means if rg has less replicas than expected, we transfer some existed replica to it.
+	// Sort RGs in lexicographic order so that existing replicas are preferentially transferred to
+	// the lexicographically smallest RG, maintaining QN assignment stability during scale-up.
 	replicaToTransfer := make(map[string][]*meta.Replica)
+	sortedSpawnRGs := lo.Keys(replicaToSpawn)
+	sort.Strings(sortedSpawnRGs)
 	if candidateIdx < len(candidateToRelease) {
-		for rg := range replicaToSpawn {
+		for _, rg := range sortedSpawnRGs {
 			for replicaToSpawn[rg] > 0 && candidateIdx < len(candidateToRelease) {
 				if replicaToTransfer[rg] == nil {
 					replicaToTransfer[rg] = make([]*meta.Replica, 0)

--- a/internal/querycoordv2/utils/meta_test.go
+++ b/internal/querycoordv2/utils/meta_test.go
@@ -136,6 +136,104 @@ func TestSpawnReplicasWithRG(t *testing.T) {
 	}
 }
 
+func TestReassignReplicaToRG_ScaleUpTransfersToSmallestRG(t *testing.T) {
+	paramtable.Init()
+	ctx := context.Background()
+
+	store := mocks.NewQueryCoordCatalog(t)
+	store.EXPECT().SaveCollection(mock.Anything, mock.Anything).Return(nil)
+	store.EXPECT().SaveReplica(mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	store.EXPECT().SaveResourceGroup(mock.Anything, mock.Anything).Return(nil)
+	store.EXPECT().SaveResourceGroup(mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	nodeMgr := session.NewNodeManager()
+	m := meta.NewMeta(RandomIncrementIDAllocator(), store, nodeMgr)
+
+	// Setup: 1 replica in __default_resource_group
+	m.CollectionManager.PutCollection(ctx, CreateTestCollection(100, 1))
+	m.ReplicaManager.Put(ctx, meta.NewReplica(
+		&querypb.Replica{
+			ID:            10,
+			CollectionID:  100,
+			Nodes:         []int64{1, 2, 3},
+			ResourceGroup: meta.DefaultResourceGroupName,
+		},
+		typeutil.NewUniqueSet(),
+	))
+
+	// Create rg_for_replica_1, rg_for_replica_2, rg_for_replica_3
+	for _, rg := range []string{"rg_for_replica_1", "rg_for_replica_2", "rg_for_replica_3"} {
+		m.ResourceManager.AddResourceGroup(ctx, rg, &rgpb.ResourceGroupConfig{
+			Requests: &rgpb.ResourceGroupLimit{NodeNum: 3},
+			Limits:   &rgpb.ResourceGroupLimit{NodeNum: 3},
+		})
+	}
+
+	// Scale up: 1 replica -> 3 replicas on rg1/rg2/rg3
+	toSpawn, toTransfer, toRelease, err := ReassignReplicaToRG(
+		ctx, m, 100, 3,
+		[]string{"rg_for_replica_1", "rg_for_replica_2", "rg_for_replica_3"},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, toRelease, "should not release any replica during scale-up")
+
+	// The old replica (from __default_resource_group) should be transferred to rg_for_replica_1 (lex smallest)
+	assert.Contains(t, toTransfer, "rg_for_replica_1", "old replica should be transferred to lex-smallest RG")
+	assert.Equal(t, int64(10), toTransfer["rg_for_replica_1"][0].GetID(), "the transferred replica should be the original one")
+
+	// rg_for_replica_2 and rg_for_replica_3 should spawn new replicas
+	assert.Equal(t, 1, toSpawn["rg_for_replica_2"], "rg2 should spawn 1 new replica")
+	assert.Equal(t, 1, toSpawn["rg_for_replica_3"], "rg3 should spawn 1 new replica")
+}
+
+func TestReassignReplicaToRG_ScaleDownPreservesSmallestRG(t *testing.T) {
+	paramtable.Init()
+	ctx := context.Background()
+
+	store := mocks.NewQueryCoordCatalog(t)
+	store.EXPECT().SaveCollection(mock.Anything, mock.Anything).Return(nil)
+	store.EXPECT().SaveReplica(mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	store.EXPECT().SaveResourceGroup(mock.Anything, mock.Anything).Return(nil)
+	store.EXPECT().SaveResourceGroup(mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	nodeMgr := session.NewNodeManager()
+	m := meta.NewMeta(RandomIncrementIDAllocator(), store, nodeMgr)
+
+	// Setup: 3 replicas in rg1/rg2/rg3
+	m.CollectionManager.PutCollection(ctx, CreateTestCollection(100, 3))
+	for i, rg := range []string{"rg_for_replica_1", "rg_for_replica_2", "rg_for_replica_3"} {
+		m.ResourceManager.AddResourceGroup(ctx, rg, &rgpb.ResourceGroupConfig{
+			Requests: &rgpb.ResourceGroupLimit{NodeNum: 3},
+			Limits:   &rgpb.ResourceGroupLimit{NodeNum: 3},
+		})
+		m.ReplicaManager.Put(ctx, meta.NewReplica(
+			&querypb.Replica{
+				ID:            int64(10 + i),
+				CollectionID:  100,
+				Nodes:         []int64{},
+				ResourceGroup: rg,
+			},
+			typeutil.NewUniqueSet(),
+		))
+	}
+
+	// Scale down: 3 replicas -> 1 replica on __default_resource_group
+	_, toTransfer, toRelease, err := ReassignReplicaToRG(
+		ctx, m, 100, 1,
+		[]string{meta.DefaultResourceGroupName},
+	)
+	require.NoError(t, err)
+
+	// Should release 2 replicas (from rg3 and rg2, in that order)
+	assert.Len(t, toRelease, 2, "should release 2 replicas")
+	// The replica from rg_for_replica_1 (lex smallest, ID=10) should be preserved (transferred to __default)
+	assert.Contains(t, toTransfer, meta.DefaultResourceGroupName)
+	assert.Equal(t, int64(10), toTransfer[meta.DefaultResourceGroupName][0].GetID(),
+		"replica from lex-smallest RG should be preserved and transferred to __default")
+
+	// The released replicas should be from rg3 (ID=12) first, then rg2 (ID=11)
+	assert.Equal(t, int64(12), toRelease[0], "rg3's replica should be released first")
+	assert.Equal(t, int64(11), toRelease[1], "rg2's replica should be released second")
+}
+
 func TestAddNodesToCollectionsInRGFailed(t *testing.T) {
 	paramtable.Init()
 	ctx := context.Background()

--- a/internal/querycoordv2/utils/meta_test.go
+++ b/internal/querycoordv2/utils/meta_test.go
@@ -301,6 +301,192 @@ func TestAddNodesToCollectionsInRGFailed(t *testing.T) {
 	assert.Len(t, m.ReplicaManager.Get(ctx, 4).GetNodes(), 0)
 }
 
+func TestRecoverReplicaOfCollection_WaitRGReady(t *testing.T) {
+	paramtable.Init()
+	ctx := context.Background()
+
+	store := mocks.NewQueryCoordCatalog(t)
+	store.EXPECT().SaveCollection(mock.Anything, mock.Anything).Return(nil)
+	store.EXPECT().SaveReplica(mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	store.EXPECT().SaveResourceGroup(mock.Anything, mock.Anything).Return(nil)
+	store.EXPECT().SaveResourceGroup(mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	nodeMgr := session.NewNodeManager()
+	m := meta.NewMeta(RandomIncrementIDAllocator(), store, nodeMgr)
+
+	collectionID := int64(1000)
+	m.CollectionManager.PutCollection(ctx, CreateTestCollection(collectionID, 2))
+
+	// Create rg1 first and fill it completely before creating rg2,
+	// so that HandleNodeUp assigns nodes to the correct RG.
+	m.ResourceManager.AddResourceGroup(ctx, "rg1", &rgpb.ResourceGroupConfig{
+		Requests: &rgpb.ResourceGroupLimit{NodeNum: 2},
+		Limits:   &rgpb.ResourceGroupLimit{NodeNum: 2},
+	})
+
+	// Add 2 nodes to rg1 (fully ready)
+	for i := 1; i <= 2; i++ {
+		nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{
+			NodeID:   int64(i),
+			Address:  "127.0.0.1",
+			Hostname: "localhost",
+		}))
+		m.ResourceManager.HandleNodeUp(ctx, int64(i))
+	}
+	rg1 := m.ResourceManager.GetResourceGroup(ctx, "rg1")
+	require.Equal(t, 0, rg1.MissingNumOfNodes(), "rg1 should be fully ready")
+
+	// Now create rg2 (new, nodes not ready yet)
+	m.ResourceManager.AddResourceGroup(ctx, "rg2", &rgpb.ResourceGroupConfig{
+		Requests: &rgpb.ResourceGroupLimit{NodeNum: 2},
+		Limits:   &rgpb.ResourceGroupLimit{NodeNum: 2},
+	})
+
+	// Add only 1 node to rg2 (not ready, missing 1 node)
+	nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{
+		NodeID:   3,
+		Address:  "127.0.0.1",
+		Hostname: "localhost",
+	}))
+	m.ResourceManager.HandleNodeUp(ctx, 3)
+
+	// Verify rg2 is missing nodes
+	rg2 := m.ResourceManager.GetResourceGroup(ctx, "rg2")
+	require.Equal(t, 1, rg2.MissingNumOfNodes(), "rg2 should be missing 1 node")
+
+	// Put existing replica in rg1 (has RW nodes, should recover normally)
+	m.ReplicaManager.Put(ctx, meta.NewReplica(
+		&querypb.Replica{
+			ID:            1,
+			CollectionID:  collectionID,
+			Nodes:         []int64{1, 2},
+			ResourceGroup: "rg1",
+		},
+	))
+
+	// Spawn a new replica in rg2 with NeedWaitRGReady option
+	newReplicas, err := m.ReplicaManager.Spawn(ctx, collectionID, map[string]int{"rg2": 1}, nil, commonpb.LoadPriority_LOW, meta.WithNeedWaitRGReady())
+	require.NoError(t, err)
+	require.Len(t, newReplicas, 1)
+	newReplicaID := newReplicas[0].GetID()
+
+	// Verify the new replica has the NeedWaitRGReady flag set
+	newReplica := m.ReplicaManager.Get(ctx, newReplicaID)
+	require.True(t, newReplica.NeedWaitRGReady(), "newly spawned replica should have NeedWaitRGReady flag")
+
+	// First recovery: rg2 is not ready (missing 1 node), new replica should NOT get nodes
+	RecoverReplicaOfCollection(ctx, m, collectionID)
+
+	newReplica = m.ReplicaManager.Get(ctx, newReplicaID)
+	assert.Empty(t, newReplica.GetRWNodes(), "new replica should have no RW nodes while RG is not ready")
+	assert.True(t, newReplica.NeedWaitRGReady(), "flag should still be set since no nodes were assigned")
+
+	// Existing replica in rg1 should still have its nodes
+	existingReplica := m.ReplicaManager.Get(ctx, 1)
+	assert.Len(t, existingReplica.GetRWNodes(), 2, "existing replica should keep its nodes")
+
+	// Now add the second node to rg2 (RG becomes ready)
+	nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{
+		NodeID:   4,
+		Address:  "127.0.0.1",
+		Hostname: "localhost",
+	}))
+	m.ResourceManager.HandleNodeUp(ctx, 4)
+
+	rg2 = m.ResourceManager.GetResourceGroup(ctx, "rg2")
+	require.Equal(t, 0, rg2.MissingNumOfNodes(), "rg2 should now be fully ready")
+
+	// Second recovery: rg2 is ready, new replica should now get all nodes and flag should be cleared
+	RecoverReplicaOfCollection(ctx, m, collectionID)
+
+	newReplica = m.ReplicaManager.Get(ctx, newReplicaID)
+	assert.Len(t, newReplica.GetRWNodes(), 2, "new replica should now have 2 RW nodes")
+	assert.False(t, newReplica.NeedWaitRGReady(), "flag should be explicitly cleared after first node assignment")
+}
+
+func TestRecoverReplicaOfCollection_ExistingReplicaNotAffectedByMissingNodes(t *testing.T) {
+	paramtable.Init()
+	ctx := context.Background()
+
+	store := mocks.NewQueryCoordCatalog(t)
+	store.EXPECT().SaveCollection(mock.Anything, mock.Anything).Return(nil)
+	store.EXPECT().SaveReplica(mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	store.EXPECT().SaveResourceGroup(mock.Anything, mock.Anything).Return(nil)
+	store.EXPECT().SaveResourceGroup(mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	nodeMgr := session.NewNodeManager()
+	m := meta.NewMeta(RandomIncrementIDAllocator(), store, nodeMgr)
+
+	collectionID := int64(2000)
+	m.CollectionManager.PutCollection(ctx, CreateTestCollection(collectionID, 1))
+
+	// Create RG with 3 requested nodes but only 2 available (simulates rolling update)
+	m.ResourceManager.AddResourceGroup(ctx, "rg1", &rgpb.ResourceGroupConfig{
+		Requests: &rgpb.ResourceGroupLimit{NodeNum: 3},
+		Limits:   &rgpb.ResourceGroupLimit{NodeNum: 3},
+	})
+
+	for i := 1; i <= 2; i++ {
+		nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{
+			NodeID:   int64(i),
+			Address:  "127.0.0.1",
+			Hostname: "localhost",
+		}))
+		m.ResourceManager.HandleNodeUp(ctx, int64(i))
+	}
+
+	// Existing replica (has RW nodes, does NOT have NeedWaitRGReady flag)
+	m.ReplicaManager.Put(ctx, meta.NewReplica(
+		&querypb.Replica{
+			ID:            1,
+			CollectionID:  collectionID,
+			Nodes:         []int64{1, 2},
+			ResourceGroup: "rg1",
+		},
+	))
+
+	// rg1 is missing 1 node
+	rg1 := m.ResourceManager.GetResourceGroup(ctx, "rg1")
+	require.Equal(t, 1, rg1.MissingNumOfNodes())
+
+	// Recovery should still work for existing replica (no NeedWaitRGReady flag)
+	RecoverReplicaOfCollection(ctx, m, collectionID)
+
+	existingReplica := m.ReplicaManager.Get(ctx, 1)
+	assert.Len(t, existingReplica.GetRWNodes(), 2, "existing replica should keep its nodes during rolling update")
+}
+
+func TestSpawnWithoutWaitRGReadyOption(t *testing.T) {
+	paramtable.Init()
+	ctx := context.Background()
+
+	store := mocks.NewQueryCoordCatalog(t)
+	store.EXPECT().SaveCollection(mock.Anything, mock.Anything).Return(nil)
+	store.EXPECT().SaveReplica(mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	store.EXPECT().SaveResourceGroup(mock.Anything, mock.Anything).Return(nil)
+	store.EXPECT().SaveResourceGroup(mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	nodeMgr := session.NewNodeManager()
+	m := meta.NewMeta(RandomIncrementIDAllocator(), store, nodeMgr)
+
+	collectionID := int64(3000)
+	m.CollectionManager.PutCollection(ctx, CreateTestCollection(collectionID, 1))
+
+	m.ResourceManager.AddResourceGroup(ctx, "rg1", &rgpb.ResourceGroupConfig{
+		Requests: &rgpb.ResourceGroupLimit{NodeNum: 2},
+		Limits:   &rgpb.ResourceGroupLimit{NodeNum: 2},
+	})
+
+	// Spawn without WithNeedWaitRGReady — should NOT set the flag
+	replicas, err := m.ReplicaManager.Spawn(ctx, collectionID, map[string]int{"rg1": 1}, nil, commonpb.LoadPriority_LOW)
+	require.NoError(t, err)
+	require.Len(t, replicas, 1)
+	assert.False(t, replicas[0].NeedWaitRGReady(), "spawn without option should not set NeedWaitRGReady")
+
+	// Spawn with WithNeedWaitRGReady — should set the flag
+	replicas2, err := m.ReplicaManager.Spawn(ctx, collectionID, map[string]int{"rg1": 1}, nil, commonpb.LoadPriority_LOW, meta.WithNeedWaitRGReady())
+	require.NoError(t, err)
+	require.Len(t, replicas2, 1)
+	assert.True(t, replicas2[0].NeedWaitRGReady(), "spawn with option should set NeedWaitRGReady")
+}
+
 func TestAddNodesToCollectionsInRG(t *testing.T) {
 	paramtable.Init()
 	ctx := context.Background()

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -7172,11 +7172,12 @@ so we set 1 second here as a threshold.`,
 
 // runtimeConfig is just a private environment value table.
 type runtimeConfig struct {
-	createTime atomic.Time
-	updateTime atomic.Time
-	role       atomic.String
-	nodeID     atomic.Int64
-	components typeutil.ConcurrentSet[string]
+	createTime   atomic.Time
+	updateTime   atomic.Time
+	role         atomic.String
+	nodeID       atomic.Int64
+	isStandalone atomic.Bool // cached flag derived from role, avoids repeated string comparison
+	components   typeutil.ConcurrentSet[string]
 }
 
 type integrationTestConfig struct {

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2554,6 +2554,7 @@ type queryCoordConfig struct {
 	UpdateCollectionLoadStatusInterval ParamItem `refreshable:"false"`
 	ClusterLevelLoadReplicaNumber      ParamItem `refreshable:"true"`
 	ClusterLevelLoadResourceGroups     ParamItem `refreshable:"true"`
+	ClusterLevelLoadWaitRGReadyTimeout ParamItem `refreshable:"true"`
 
 	// balance batch size in one trigger
 	BalanceSegmentBatchSize            ParamItem `refreshable:"true"`
@@ -3163,6 +3164,15 @@ If this parameter is set false, Milvus simply searches the growing segments with
 		Export:       false,
 	}
 	p.ClusterLevelLoadResourceGroups.Init(base.mgr)
+
+	p.ClusterLevelLoadWaitRGReadyTimeout = ParamItem{
+		Key:          "queryCoord.clusterLevelLoadWaitRGReadyTimeout",
+		Version:      "2.6.13",
+		DefaultValue: "3m",
+		Doc:          "timeout for waiting resource group to have all requested nodes before assigning nodes to new replicas during cluster-level load config scale-up. 0 means no waiting.",
+		Export:       false,
+	}
+	p.ClusterLevelLoadWaitRGReadyTimeout.Init(base.mgr)
 
 	p.AutoBalanceInterval = ParamItem{
 		Key:          "queryCoord.autoBalanceInterval",

--- a/pkg/util/paramtable/runtime.go
+++ b/pkg/util/paramtable/runtime.go
@@ -99,10 +99,17 @@ func GetStringNodeID() string {
 
 func SetRole(role string) {
 	runtimeParam.role.Store(role)
+	runtimeParam.isStandalone.Store(role == typeutil.StandaloneRole)
 }
 
 func GetRole() string {
 	return runtimeParam.role.Load()
+}
+
+// IsStandalone returns true if the current node is running in standalone mode.
+// This is a fast path that avoids string comparison on every call.
+func IsStandalone() bool {
+	return runtimeParam.isStandalone.Load()
 }
 
 func SetCreateTime(d time.Time) {


### PR DESCRIPTION
issue: #48239

Problem:
During replica scale-up/down, RG name changes cause cross-RG node migration. The async resource_observer uses non-deterministic map iteration to select which nodes go to which RG, breaking the original node-to-replica mapping. This can leave a newly created replica without QN nodes, causing query unavailability when the old replicas are released.

Root cause:
1. ReassignReplicaToRG iterates maps non-deterministically, so the existing replica may be transferred to any RG rather than the lexicographically smallest one.
2. When UpdateResourceGroups zeroes an RG and creates new ones, nodes transit through __recycle_resource_group with non-deterministic selection at each hop, scrambling the original node assignment.

Fix:
1. Sort RG iteration in ReassignReplicaToRG and resource_observer to ensure deterministic replica-to-RG mapping: existing replica goes to lex-smallest RG during scale-up, lex-smallest RG's replica is preserved during scale-down.
2. Add transferNodesOnRGSwap in updateResourceGroups: when a batch update zeroes an RG (old request=N,limit=N -> new 0,0) and another RG takes the same config (new request=N,limit=N), directly swap their node lists before persisting, bypassing the async observer entirely.

Extra fix:
- Skip DQL forwarding to legacy proxy in cluster mode to avoid legacy-proxy overloading. The API proto GetShardLeader is only lost in standalone mode.