### PR TITLE
fix: [2.6] prevent heap-use-after-free in Reopen by pinning segment (#48265)

### DIFF
--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -1373,6 +1373,11 @@ func (s *LocalSegment) Load(ctx context.Context) error {
 }
 
 func (s *LocalSegment) Reopen(ctx context.Context, newLoadInfo *querypb.SegmentLoadInfo) error {
+	if !s.ptrLock.PinIfNotReleased() {
+		return merr.WrapErrSegmentNotLoaded(s.ID(), "segment released during reopen")
+	}
+	defer s.ptrLock.Unpin()
+
 	err := s.csegment.Reopen(ctx, &segcore.ReopenRequest{
 		LoadInfo: newLoadInfo,
 	})


### PR DESCRIPTION
Cherry-pick from master
pr: #48265

LocalSegment.Reopen() calls into C++ (ApplyLoadDiff → LoadBatchIndexes) which submits tasks to a thread pool that capture the segment's `this` pointer. Without holding a pin on the LoadStateLock, a concurrent Release() can call DeleteSegment while those tasks are still running, causing a heap-use-after-free on schema_.

Add PinIfNotReleased/Unpin around the Reopen CGO call so that StartReleaseAll (which waits for refCnt == 0) cannot proceed until all C++ thread pool work completes.

issue: #48264