### PR TITLE
enhance: Log level for varchar length validation error should be warning instead of info

### DIFF
--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -2829,7 +2829,7 @@ func (node *Proxy) Upsert(ctx context.Context, request *milvuspb.UpsertRequest) 
 		zap.Uint64("EndTS", it.EndTs()))
 
 	if err := it.WaitToFinish(); err != nil {
-		log.Info("Failed to execute insert task in task scheduler",
+		log.Warn("Failed to execute insert task in task scheduler",
 			zap.Error(err))
 		// Not every error case changes the status internally
 		// change status there to handle it


### PR DESCRIPTION
cherry-pick from master
pr: #48233

## Summary
Cherry-pick of #48233 to the 2.6 branch.

- Changed log level from Info to Warn for failed insert task execution in `Proxy.Upsert` (`internal/proxy/impl.go`)

fix: https://github.com/milvus-io/milvus/issues/48130

Signed-off-by: Sammy Huang <sammy.huang@zilliz.com>