### PR TITLE
fix: validate clustering key type in addCollectionFieldTask

### DIFF
--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -690,6 +690,11 @@ func (t *addCollectionFieldTask) PreExecute(ctx context.Context) error {
 		return merr.WrapErrParameterInvalidMsg("not support to add partition key field, field name  = %s", t.fieldSchema.Name)
 	}
 	if t.fieldSchema.GetIsClusteringKey() {
+		if !typeutil.IsClusteringKeyType(t.fieldSchema.GetDataType()) {
+			return merr.WrapErrParameterInvalidMsg(
+				fmt.Sprintf("clustering key field %s has unsupported data type %s",
+					t.fieldSchema.GetName(), t.fieldSchema.GetDataType().String()))
+		}
 		for _, f := range t.oldSchema.Fields {
 			if f.GetIsClusteringKey() {
 				return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("already has another clutering key field, field name: %s", t.fieldSchema.GetName()))

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -1148,8 +1148,11 @@ func TestAddFieldTask(t *testing.T) {
 		assert.Error(t, err)
 		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
 
-		// more ClusteringKey field
+		// more ClusteringKey field — use a valid type so the duplicate-key check is the gate
 		fSchema = &schemapb.FieldSchema{
+			Name:            "ck_field",
+			DataType:        schemapb.DataType_Int64,
+			Nullable:        true,
 			IsClusteringKey: true,
 		}
 		bytes, err = proto.Marshal(fSchema)
@@ -1188,6 +1191,20 @@ func TestAddFieldTask(t *testing.T) {
 			assert.Error(t, err, "expected error for unsupported clustering key type %v", unsupportedType)
 			assert.ErrorIs(t, err, merr.ErrParameterInvalid)
 		}
+
+		// valid clustering key type (Int64) should be accepted
+		fSchema = &schemapb.FieldSchema{
+			Name:            "valid_ck",
+			DataType:        schemapb.DataType_Int64,
+			Nullable:        true,
+			IsClusteringKey: true,
+		}
+		bytes, err = proto.Marshal(fSchema)
+		assert.NoError(t, err)
+		task.Schema = bytes
+		task.oldSchema = freshSchema // no existing clustering key
+		err = task.PreExecute(ctx)
+		assert.NoError(t, err)
 
 		// fieldName invalid
 		fSchema = &schemapb.FieldSchema{

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -1163,6 +1163,32 @@ func TestAddFieldTask(t *testing.T) {
 		assert.Error(t, err)
 		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
 
+		// unsupported clustering key type (JSON, Bool, Array)
+		// Use a fresh schema (no existing clustering key) so the type check is the only gate
+		freshSchema := constructCollectionSchemaByDataType(collectionName, fieldName2Type, int64Field, false)
+		task.oldSchema = freshSchema
+		for _, unsupportedType := range []schemapb.DataType{
+			schemapb.DataType_JSON,
+			schemapb.DataType_Bool,
+			schemapb.DataType_Array,
+		} {
+			fSchema = &schemapb.FieldSchema{
+				Name:            "ck_field",
+				DataType:        unsupportedType,
+				Nullable:        true,
+				IsClusteringKey: true,
+			}
+			if unsupportedType == schemapb.DataType_Array {
+				fSchema.ElementType = schemapb.DataType_Int64
+			}
+			bytes, err = proto.Marshal(fSchema)
+			assert.NoError(t, err)
+			task.Schema = bytes
+			err = task.PreExecute(ctx)
+			assert.Error(t, err, "expected error for unsupported clustering key type %v", unsupportedType)
+			assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		}
+
 		// fieldName invalid
 		fSchema = &schemapb.FieldSchema{
 			Name: "",


### PR DESCRIPTION
## What this PR does

`addCollectionFieldTask.PreExecute()` was missing the `IsClusteringKeyType()` validation that was added to `createCollectionTask.validateClusteringKey()` in PR #48184.

This allowed users to add fields with unsupported data types (JSON, Bool, Array, etc.) as clustering keys via the `AddCollectionField` (schema evolution) API. During clustering compaction, `NewScalarFieldValue()` panics on these types, crashing the DataNode.

## Root cause

PR #48184 fixed the type check only in the collection-creation path. The schema-evolution path (`addCollectionFieldTask`) was not updated with the same guard.

## Fix

Add `typeutil.IsClusteringKeyType()` check before the duplicate clustering-key loop in `addCollectionFieldTask.PreExecute()`, consistent with `createCollectionTask.validateClusteringKey()`.

```go
if t.fieldSchema.GetIsClusteringKey() {
    if !typeutil.IsClusteringKeyType(t.fieldSchema.GetDataType()) {
        return merr.WrapErrParameterInvalidMsg(...)  // ← added
    }
    for _, f := range t.oldSchema.Fields { ... }    // existing duplicate check
}
```

## Tests

- Added test cases for JSON, Bool, and Array fields with `IsClusteringKey=true` — all must return `ErrParameterInvalid`
- Added positive test case: valid Int64 clustering key must be accepted
- Fixed pre-existing "more ClusteringKey field" test to use explicit `DataType_Int64` so it exercises the duplicate-key branch (not the new type check)

issue: #48285