### PR TITLE
fix: unify raw data lifecycle management via LoadDiff to prevent SIGSEGV on column groups

### DIFF
--- a/internal/core/src/mmap/ChunkedColumnGroup.h
+++ b/internal/core/src/mmap/ChunkedColumnGroup.h
@@ -195,6 +195,11 @@ class ProxyChunkColumn : public ChunkedColumnInterface {
         CancelWarmup();
     }
 
+    bool
+    IsInMultiFieldColumnGroup() const override {
+        return group_->NumFieldsInGroup() > 1;
+    }
+
     void
     ManualEvictCache() const override {
         if (group_->NumFieldsInGroup() == 1) {

--- a/internal/core/src/mmap/ChunkedColumnInterface.h
+++ b/internal/core/src/mmap/ChunkedColumnInterface.h
@@ -27,6 +27,13 @@ class ChunkedColumnInterface {
  public:
     virtual ~ChunkedColumnInterface() = default;
 
+    // Check if this column is part of a multi-field column group.
+    // Used to guard DropFieldData from breaking shared storage.
+    virtual bool
+    IsInMultiFieldColumnGroup() const {
+        return false;
+    }
+
     // Default implementation does nothing.
     virtual void
     ManualEvictCache() const {

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -2951,7 +2951,6 @@ ChunkedSegmentSealedImpl::load_field_data_common(
             auto column = get_column(field_id);
             if (column) {
                 column->CancelWarmup();
-                column->ManualEvictCache();
             }
         }
         if (data_type == DataType::GEOMETRY &&

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -1112,21 +1112,6 @@ ChunkedSegmentSealedImpl::DropFieldData(const FieldId field_id) {
     std::unique_lock<std::shared_mutex> lck(mutex_);
     if (get_bit(field_data_ready_bitset_, field_id)) {
         auto column = get_column(field_id);
-        // Multi-field column group: skip drop to avoid breaking shared storage.
-        // The memory stays but queries will use index raw data path instead.
-        if (column && column->IsInMultiFieldColumnGroup()) {
-            LOG_INFO(
-                "Skip dropping field {} in segment {}: multi-field column "
-                "group",
-                field_id.get(),
-                id_);
-            // Still drop binlog index if present
-            if (get_bit(binlog_index_bitset_, field_id)) {
-                set_bit(binlog_index_bitset_, field_id, false);
-                vector_indexings_.drop_field_indexing(field_id);
-            }
-            return;
-        }
         // PK field: skip drop because insert record reload depends on PK data
         if (schema_->get_primary_field_id().has_value() &&
             schema_->get_primary_field_id().value() == field_id) {
@@ -2933,7 +2918,8 @@ ChunkedSegmentSealedImpl::load_field_data_common(
         // TODO: handle PK replacement for insert_record_ in future
     }
 
-    bool generated_interim_index = generate_interim_index(field_id, num_rows);
+    // now interim index does not touch column warmup
+    generate_interim_index(field_id, num_rows);
 
     std::string struct_name;
     const FieldMeta* field_meta_ptr = nullptr;
@@ -2947,12 +2933,7 @@ ChunkedSegmentSealedImpl::load_field_data_common(
         }
         set_bit(field_data_ready_bitset_, field_id, true);
         update_row_count(num_rows);
-        if (generated_interim_index) {
-            auto column = get_column(field_id);
-            if (column) {
-                column->CancelWarmup();
-            }
-        }
+
         if (data_type == DataType::GEOMETRY &&
             segcore_config_.get_enable_geometry_cache()) {
             // Construct GeometryCache for the entire field

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -207,10 +207,9 @@ ChunkedSegmentSealedImpl::LoadVecIndex(LoadIndexInfo& info, bool is_replace) {
             info.num_rows,
             info.dim);
 
-    if (request.has_raw_data && get_bit(field_data_ready_bitset_, field_id)) {
-        fields_.rlock()->at(field_id)->CancelWarmup();
-        fields_.rlock()->at(field_id)->ManualEvictCache();
-    }
+    // Note: raw data lifecycle (eviction/drop) is handled by LoadDiff + ApplyLoadDiff,
+    // not here. This avoids unsafe ManualEvictCache on column groups.
+
     if (get_bit(binlog_index_bitset_, field_id)) {
         set_bit(binlog_index_bitset_, field_id, false);
         vector_indexings_.drop_field_indexing(field_id);
@@ -309,15 +308,8 @@ ChunkedSegmentSealedImpl::LoadScalarIndex(LoadIndexInfo& info,
 
     set_bit(index_ready_bitset_, field_id, true);
     index_has_raw_data_[field_id] = request.has_raw_data;
-    // release field column if the index contains raw data
-    // only release non-primary field when in pk sorted mode
-    if (request.has_raw_data && get_bit(field_data_ready_bitset_, field_id) &&
-        !is_pk) {
-        // We do not erase the primary key field: if insert record is evicted from memory, when reloading it'll
-        // need the pk field again.
-        fields_.rlock()->at(field_id)->CancelWarmup();
-        fields_.rlock()->at(field_id)->ManualEvictCache();
-    }
+    // Note: raw data lifecycle (eviction/drop) is handled by LoadDiff + ApplyLoadDiff,
+    // not here. This avoids unsafe ManualEvictCache on column groups.
     LOG_INFO(
         "Has load scalar index done, fieldID:{}. segmentID:{}, has_raw_data:{}",
         info.field_id,
@@ -1119,7 +1111,38 @@ ChunkedSegmentSealedImpl::DropFieldData(const FieldId field_id) {
                field_id.get());
     std::unique_lock<std::shared_mutex> lck(mutex_);
     if (get_bit(field_data_ready_bitset_, field_id)) {
-        fields_.rlock()->at(field_id)->CancelWarmup();
+        auto column = get_column(field_id);
+        // Multi-field column group: skip drop to avoid breaking shared storage.
+        // The memory stays but queries will use index raw data path instead.
+        if (column && column->IsInMultiFieldColumnGroup()) {
+            LOG_INFO(
+                "Skip dropping field {} in segment {}: multi-field column "
+                "group",
+                field_id.get(),
+                id_);
+            // Still drop binlog index if present
+            if (get_bit(binlog_index_bitset_, field_id)) {
+                set_bit(binlog_index_bitset_, field_id, false);
+                vector_indexings_.drop_field_indexing(field_id);
+            }
+            return;
+        }
+        // PK field: skip drop because insert record reload depends on PK data
+        if (schema_->get_primary_field_id().has_value() &&
+            schema_->get_primary_field_id().value() == field_id) {
+            LOG_INFO(
+                "Skip dropping pk field {} in segment {}", field_id.get(), id_);
+            // Still drop binlog index if present
+            if (get_bit(binlog_index_bitset_, field_id)) {
+                set_bit(binlog_index_bitset_, field_id, false);
+                vector_indexings_.drop_field_indexing(field_id);
+            }
+            return;
+        }
+        // Single-field column: fully erase + clear bitset
+        if (column) {
+            column->CancelWarmup();
+        }
         fields_.wlock()->erase(field_id);
         set_bit(field_data_ready_bitset_, field_id, false);
     }
@@ -3091,22 +3114,13 @@ ChunkedSegmentSealedImpl::ApplyLoadDiff(SegmentLoadInfo& segment_load_info,
         LoadBatchIndexes(trace_ctx, diff.indexes_to_replace, op_ctx, true);
     }
 
-    // reload fields
+    // reload fields (warmup for fields already in memory)
     if (!diff.fields_to_reload.empty()) {
         ReloadColumns(diff.fields_to_reload, op_ctx);
     }
 
-    // drop index, must after reload binlog
-    if (!diff.indexes_to_drop.empty()) {
-        for (auto field_id : diff.indexes_to_drop) {
-            // Skip drop if this field already has a replacement or new index loaded
-            if (diff.indexes_to_replace.count(field_id) > 0 ||
-                diff.indexes_to_load.count(field_id) > 0) {
-                continue;
-            }
-            DropIndex(field_id);
-        }
-    }
+    // Load field data from storage BEFORE dropping indexes, so that queries
+    // always have a data source available during the transition.
 
     // load column groups
     bool has_cg_changes = !diff.column_groups_to_load.empty() ||
@@ -3159,11 +3173,6 @@ ChunkedSegmentSealedImpl::ApplyLoadDiff(SegmentLoadInfo& segment_load_info,
         }
     }
 
-    // load pre-built text indexes
-    if (!diff.text_indexes_to_load.empty()) {
-        LoadBatchTextIndexes(op_ctx, diff.text_indexes_to_load);
-    }
-
     // Load new field binlogs
     if (!diff.binlogs_to_load.empty()) {
         LoadBatchFieldData(trace_ctx, diff.binlogs_to_load, op_ctx);
@@ -3171,6 +3180,24 @@ ChunkedSegmentSealedImpl::ApplyLoadDiff(SegmentLoadInfo& segment_load_info,
     // Replace field binlogs
     if (!diff.binlogs_to_replace.empty()) {
         LoadBatchFieldData(trace_ctx, diff.binlogs_to_replace, op_ctx, true);
+    }
+
+    // drop index — field data is already loaded/restored above, so queries
+    // can fall back to raw data after the index is dropped.
+    if (!diff.indexes_to_drop.empty()) {
+        for (auto field_id : diff.indexes_to_drop) {
+            // Skip drop if this field already has a replacement or new index loaded
+            if (diff.indexes_to_replace.count(field_id) > 0 ||
+                diff.indexes_to_load.count(field_id) > 0) {
+                continue;
+            }
+            DropIndex(field_id);
+        }
+    }
+
+    // load pre-built text indexes
+    if (!diff.text_indexes_to_load.empty()) {
+        LoadBatchTextIndexes(op_ctx, diff.text_indexes_to_load);
     }
 
     // fill default values for fields without data sources (schema evolution)
@@ -3186,7 +3213,8 @@ ChunkedSegmentSealedImpl::ApplyLoadDiff(SegmentLoadInfo& segment_load_info,
         }
     }
 
-    // drop field
+    // Drop field data last — only for fields whose new index has raw data.
+    // DropFieldData guards against multi-field column groups and PK fields.
     if (!diff.field_data_to_drop.empty()) {
         for (auto field_id : diff.field_data_to_drop) {
             DropFieldData(field_id);

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -3213,8 +3213,8 @@ ChunkedSegmentSealedImpl::ApplyLoadDiff(SegmentLoadInfo& segment_load_info,
         }
     }
 
-    // Drop field data last — only for fields whose new index has raw data.
-    // DropFieldData guards against multi-field column groups and PK fields.
+    // Drop field data — only for schema evolution scenarios where
+    // the field has been removed from the data source (binlogs/column_groups).
     if (!diff.field_data_to_drop.empty()) {
         for (auto field_id : diff.field_data_to_drop) {
             DropFieldData(field_id);

--- a/internal/core/src/segcore/SegmentLoadInfo.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfo.cpp
@@ -398,14 +398,22 @@ SegmentLoadInfo::ComputeDiffReloadFields(LoadDiff& diff,
     // These fields need their raw data restored since the index no longer
     // provides it. We put them into load paths (binlogs/column_groups) so
     // that ApplyLoadDiff can rebuild the data from storage.
+    // Collect fields that need reload (index no longer has raw data)
+    std::set<FieldId> fields_to_reload;
     for (const auto& field_id : field_index_has_raw_data_) {
-        if (new_info.field_index_has_raw_data_.find(field_id) !=
+        if (new_info.field_index_has_raw_data_.find(field_id) ==
             new_info.field_index_has_raw_data_.end()) {
-            continue;  // Still has raw data in index, no action needed
+            fields_to_reload.emplace(field_id);
         }
+    }
 
-        if (!new_info.HasManifestPath()) {
-            // Binlog mode: find the field's binlog and add to binlogs_to_load
+    if (fields_to_reload.empty()) {
+        return;
+    }
+
+    if (!new_info.HasManifestPath()) {
+        // Binlog mode: find each field's binlog and add to binlogs_to_replace
+        for (const auto& field_id : fields_to_reload) {
             for (int i = 0; i < new_info.GetBinlogPathCount(); i++) {
                 auto& binlog = new_info.GetBinlogPath(i);
                 std::vector<int64_t> child_fields(binlog.child_fields().begin(),
@@ -413,36 +421,42 @@ SegmentLoadInfo::ComputeDiffReloadFields(LoadDiff& diff,
                 if (child_fields.empty()) {
                     child_fields.emplace_back(binlog.fieldid());
                 }
+                bool found = false;
                 for (auto child_id : child_fields) {
                     if (FieldId(child_id) == field_id) {
-                        // Use replace since the field may still exist
-                        // (e.g. multi-field group where drop was skipped)
-                        diff.binlogs_to_replace.emplace_back(
-                            std::vector<FieldId>{field_id}, binlog);
-                        goto next_field;
+                        found = true;
+                        break;
                     }
                 }
-            }
-        } else {
-            // Manifest mode: find the field's column group
-            auto column_groups = new_info.GetColumnGroups();
-            if (column_groups) {
-                for (size_t i = 0; i < column_groups->size(); i++) {
-                    auto cg = column_groups->at(i);
-                    for (const auto& column : cg->columns) {
-                        if (FieldId(std::stoll(column)) == field_id) {
-                            // Use replace since the field may still exist
-                            diff.column_groups_to_replace.emplace_back(
-                                static_cast<int>(i),
-                                std::vector<FieldId>{field_id});
-                            goto next_field;
-                        }
-                    }
+                if (found) {
+                    // Use replace since the field may still exist
+                    // (e.g. multi-field group where drop was skipped)
+                    diff.binlogs_to_replace.emplace_back(
+                        std::vector<FieldId>{field_id}, binlog);
+                    break;
                 }
             }
         }
-
-    next_field:;
+    } else {
+        // Manifest mode: collect fields per column group, emplace each
+        // group index only once
+        auto column_groups = new_info.GetColumnGroups();
+        if (column_groups) {
+            std::map<int, std::vector<FieldId>> cg_fields;
+            for (size_t i = 0; i < column_groups->size(); i++) {
+                auto cg = column_groups->at(i);
+                for (const auto& column : cg->columns) {
+                    FieldId fid(std::stoll(column));
+                    if (fields_to_reload.count(fid) > 0) {
+                        cg_fields[static_cast<int>(i)].emplace_back(fid);
+                    }
+                }
+            }
+            for (auto& [cg_idx, fids] : cg_fields) {
+                diff.column_groups_to_replace.emplace_back(cg_idx,
+                                                           std::move(fids));
+            }
+        }
     }
 }
 

--- a/internal/core/src/segcore/SegmentLoadInfo.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfo.cpp
@@ -231,6 +231,16 @@ SegmentLoadInfo::ComputeDiffIndexes(LoadDiff& diff, SegmentLoadInfo& new_info) {
             diff.indexes_to_drop.insert(FieldId(load_index_info.field_id));
         }
     }
+
+    // When a new/replaced index has raw data, mark the field data for drop.
+    // The actual drop is safe: DropFieldData guards against multi-field column
+    // groups and PK fields.
+    for (const auto& field_id : new_info.field_index_has_raw_data_) {
+        if (diff.indexes_to_load.count(field_id) > 0 ||
+            diff.indexes_to_replace.count(field_id) > 0) {
+            diff.field_data_to_drop.emplace(field_id);
+        }
+    }
 }
 
 void
@@ -384,14 +394,55 @@ void
 SegmentLoadInfo::ComputeDiffReloadFields(LoadDiff& diff,
                                          SegmentLoadInfo& new_info) {
     // Find fields that were previously skipped (index had raw data)
-    // but now need loading (index no longer has raw data or was dropped)
+    // but now need loading (index no longer has raw data or was dropped).
+    // These fields need their raw data restored since the index no longer
+    // provides it. We put them into load paths (binlogs/column_groups) so
+    // that ApplyLoadDiff can rebuild the data from storage.
     for (const auto& field_id : field_index_has_raw_data_) {
-        // If new_info doesn't have this field in index_has_raw_data_,
-        // we need to reload the field data
-        if (new_info.field_index_has_raw_data_.find(field_id) ==
+        if (new_info.field_index_has_raw_data_.find(field_id) !=
             new_info.field_index_has_raw_data_.end()) {
-            diff.fields_to_reload.emplace_back(field_id);
+            continue;  // Still has raw data in index, no action needed
         }
+
+        if (!new_info.HasManifestPath()) {
+            // Binlog mode: find the field's binlog and add to binlogs_to_load
+            for (int i = 0; i < new_info.GetBinlogPathCount(); i++) {
+                auto& binlog = new_info.GetBinlogPath(i);
+                std::vector<int64_t> child_fields(binlog.child_fields().begin(),
+                                                  binlog.child_fields().end());
+                if (child_fields.empty()) {
+                    child_fields.emplace_back(binlog.fieldid());
+                }
+                for (auto child_id : child_fields) {
+                    if (FieldId(child_id) == field_id) {
+                        // Use replace since the field may still exist
+                        // (e.g. multi-field group where drop was skipped)
+                        diff.binlogs_to_replace.emplace_back(
+                            std::vector<FieldId>{field_id}, binlog);
+                        goto next_field;
+                    }
+                }
+            }
+        } else {
+            // Manifest mode: find the field's column group
+            auto column_groups = new_info.GetColumnGroups();
+            if (column_groups) {
+                for (size_t i = 0; i < column_groups->size(); i++) {
+                    auto cg = column_groups->at(i);
+                    for (const auto& column : cg->columns) {
+                        if (FieldId(std::stoll(column)) == field_id) {
+                            // Use replace since the field may still exist
+                            diff.column_groups_to_replace.emplace_back(
+                                static_cast<int>(i),
+                                std::vector<FieldId>{field_id});
+                            goto next_field;
+                        }
+                    }
+                }
+            }
+        }
+
+    next_field:;
     }
 }
 

--- a/internal/core/src/segcore/SegmentLoadInfo.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfo.cpp
@@ -231,16 +231,6 @@ SegmentLoadInfo::ComputeDiffIndexes(LoadDiff& diff, SegmentLoadInfo& new_info) {
             diff.indexes_to_drop.insert(FieldId(load_index_info.field_id));
         }
     }
-
-    // When a new/replaced index has raw data, mark the field data for drop.
-    // The actual drop is safe: DropFieldData guards against multi-field column
-    // groups and PK fields.
-    for (const auto& field_id : new_info.field_index_has_raw_data_) {
-        if (diff.indexes_to_load.count(field_id) > 0 ||
-            diff.indexes_to_replace.count(field_id) > 0) {
-            diff.field_data_to_drop.emplace(field_id);
-        }
-    }
 }
 
 void
@@ -349,8 +339,9 @@ SegmentLoadInfo::ComputeDiffColumnGroups(LoadDiff& diff,
                 // Field not in current and not default-filled → new load
                 if (field_id < START_USER_FIELDID ||
                     (schema_->ShouldLoadField(FieldId(field_id)) &&
-                     field_index_has_raw_data_.find(FieldId(field_id)) ==
-                         field_index_has_raw_data_.end())) {
+                     new_info.field_index_has_raw_data_.find(
+                         FieldId(field_id)) ==
+                         new_info.field_index_has_raw_data_.end())) {
                     fields.emplace_back(field_id);
                 } else {
                     lazy_fields.emplace_back(field_id);
@@ -359,10 +350,19 @@ SegmentLoadInfo::ComputeDiffColumnGroups(LoadDiff& diff,
                 // Field was default-filled or moved between groups → replace
                 if (field_id < START_USER_FIELDID ||
                     (schema_->ShouldLoadField(FieldId(field_id)) &&
-                     field_index_has_raw_data_.find(FieldId(field_id)) ==
-                         field_index_has_raw_data_.end())) {
+                     new_info.field_index_has_raw_data_.find(
+                         FieldId(field_id)) ==
+                         new_info.field_index_has_raw_data_.end())) {
                     replace_fields.emplace_back(field_id);
                 } else {
+                    lazy_replace_fields.emplace_back(field_id);
+                }
+            } else {
+                // Field at same position — check if needs lazification
+                // (transitioning from no-raw-data-index to raw-data-index)
+                if (new_info.field_index_has_raw_data_.count(
+                        FieldId(field_id)) > 0 &&
+                    field_index_has_raw_data_.count(FieldId(field_id)) == 0) {
                     lazy_replace_fields.emplace_back(field_id);
                 }
             }

--- a/internal/core/src/segcore/SegmentLoadInfoTest.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfoTest.cpp
@@ -1892,9 +1892,11 @@ TEST_F(SegmentLoadInfoTest, ComputeDiffDefaultFilledFieldBecomesReplace) {
 // ==================== Raw Data Lifecycle Tests ====================
 // Tests for field_data_to_drop generation and ComputeDiffReloadFields behavior
 
-TEST_F(SegmentLoadInfoTest, ComputeDiffNewIndexWithRawDataDropsFieldData) {
+TEST_F(SegmentLoadInfoTest, ComputeDiffNewIndexWithRawDataNoFieldDrop) {
     // Test 1.1: When a new index has raw data (ASCENDING_SORT for scalar),
-    // field_data_to_drop should include that field.
+    // field_data_to_drop should NOT include that field.
+    // Raw-data indexes no longer trigger field drop; field data is kept
+    // (binlog mode) or lazified (column groups mode).
     // Scenario: current has no index -> new has ASCENDING_SORT index (raw=true)
 
     // Current: only binlog for field 108 (INT64, extra_field1)
@@ -1934,13 +1936,15 @@ TEST_F(SegmentLoadInfoTest, ComputeDiffNewIndexWithRawDataDropsFieldData) {
 
     // Index should be in indexes_to_load
     EXPECT_TRUE(diff.indexes_to_load.count(FieldId(108)) > 0);
-    // field_data_to_drop should include field 108 (index has raw data)
-    EXPECT_TRUE(diff.field_data_to_drop.count(FieldId(108)) > 0);
+    // field_data_to_drop should NOT include field 108
+    // (raw-data index no longer triggers drop)
+    EXPECT_TRUE(diff.field_data_to_drop.count(FieldId(108)) == 0);
 }
 
-TEST_F(SegmentLoadInfoTest, ComputeDiffReplaceIndexWithRawDataDropsFieldData) {
+TEST_F(SegmentLoadInfoTest, ComputeDiffReplaceIndexWithRawDataNoFieldDrop) {
     // Test 1.2: When replacing an index and the new one has raw data,
-    // field_data_to_drop should include that field.
+    // field_data_to_drop should NOT include that field.
+    // Raw-data indexes no longer trigger field drop.
     // Scenario: current has INVERTED index -> new has ASCENDING_SORT index
 
     // Current: field 108 has INVERTED index (no raw data)
@@ -1986,8 +1990,9 @@ TEST_F(SegmentLoadInfoTest, ComputeDiffReplaceIndexWithRawDataDropsFieldData) {
 
     // Index should be in indexes_to_replace
     EXPECT_TRUE(diff.indexes_to_replace.count(FieldId(108)) > 0);
-    // field_data_to_drop should include field 108
-    EXPECT_TRUE(diff.field_data_to_drop.count(FieldId(108)) > 0);
+    // field_data_to_drop should NOT include field 108
+    // (raw-data index no longer triggers drop)
+    EXPECT_TRUE(diff.field_data_to_drop.count(FieldId(108)) == 0);
 }
 
 TEST_F(SegmentLoadInfoTest, ComputeDiffNewIndexNoRawDataNoFieldDrop) {

--- a/internal/core/src/segcore/SegmentLoadInfoTest.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfoTest.cpp
@@ -1888,3 +1888,330 @@ TEST_F(SegmentLoadInfoTest, ComputeDiffDefaultFilledFieldBecomesReplace) {
         EXPECT_NE(fid.get(), 101);
     }
 }
+
+// ==================== Raw Data Lifecycle Tests ====================
+// Tests for field_data_to_drop generation and ComputeDiffReloadFields behavior
+
+TEST_F(SegmentLoadInfoTest, ComputeDiffNewIndexWithRawDataDropsFieldData) {
+    // Test 1.1: When a new index has raw data (ASCENDING_SORT for scalar),
+    // field_data_to_drop should include that field.
+    // Scenario: current has no index -> new has ASCENDING_SORT index (raw=true)
+
+    // Current: only binlog for field 108 (INT64, extra_field1)
+    proto::segcore::SegmentLoadInfo current_proto;
+    current_proto.set_segmentid(100);
+    current_proto.set_num_of_rows(1000);
+    auto* cur_binlog = current_proto.add_binlog_paths();
+    cur_binlog->set_fieldid(108);
+    auto* cur_log = cur_binlog->add_binlogs();
+    cur_log->set_log_path("/path/to/binlog_108");
+    cur_log->set_entries_num(1000);
+
+    // New: same binlog + ASCENDING_SORT index for field 108 (has raw data)
+    proto::segcore::SegmentLoadInfo new_proto;
+    new_proto.set_segmentid(100);
+    new_proto.set_num_of_rows(1000);
+    auto* new_binlog = new_proto.add_binlog_paths();
+    new_binlog->set_fieldid(108);
+    auto* new_log = new_binlog->add_binlogs();
+    new_log->set_log_path("/path/to/binlog_108");
+    new_log->set_entries_num(1000);
+
+    auto* index_info = new_proto.add_index_infos();
+    index_info->set_fieldid(108);
+    index_info->set_indexid(5001);
+    index_info->add_index_file_paths("/path/to/sort_index");
+    auto* param = index_info->add_index_params();
+    param->set_key("index_type");
+    param->set_value(milvus::index::ASCENDING_SORT);
+
+    SegmentLoadInfo current_info(current_proto, schema_);
+    // Initialize default fields
+    (void)current_info.GetLoadDiff();
+    SegmentLoadInfo new_info(new_proto, schema_);
+    auto diff = current_info.ComputeDiff(new_info);
+    std::cout << "New index with raw data diff: " << diff.ToString() << "\n";
+
+    // Index should be in indexes_to_load
+    EXPECT_TRUE(diff.indexes_to_load.count(FieldId(108)) > 0);
+    // field_data_to_drop should include field 108 (index has raw data)
+    EXPECT_TRUE(diff.field_data_to_drop.count(FieldId(108)) > 0);
+}
+
+TEST_F(SegmentLoadInfoTest, ComputeDiffReplaceIndexWithRawDataDropsFieldData) {
+    // Test 1.2: When replacing an index and the new one has raw data,
+    // field_data_to_drop should include that field.
+    // Scenario: current has INVERTED index -> new has ASCENDING_SORT index
+
+    // Current: field 108 has INVERTED index (no raw data)
+    proto::segcore::SegmentLoadInfo current_proto;
+    current_proto.set_segmentid(100);
+    current_proto.set_num_of_rows(1000);
+    auto* cur_binlog = current_proto.add_binlog_paths();
+    cur_binlog->set_fieldid(108);
+    auto* cur_log = cur_binlog->add_binlogs();
+    cur_log->set_log_path("/path/to/binlog_108");
+    cur_log->set_entries_num(1000);
+    auto* cur_index = current_proto.add_index_infos();
+    cur_index->set_fieldid(108);
+    cur_index->set_indexid(5001);
+    cur_index->add_index_file_paths("/path/to/inverted_index");
+    auto* cur_param = cur_index->add_index_params();
+    cur_param->set_key("index_type");
+    cur_param->set_value(milvus::index::INVERTED_INDEX_TYPE);
+
+    // New: field 108 has ASCENDING_SORT index (has raw data), different index_id
+    proto::segcore::SegmentLoadInfo new_proto;
+    new_proto.set_segmentid(100);
+    new_proto.set_num_of_rows(1000);
+    auto* new_binlog = new_proto.add_binlog_paths();
+    new_binlog->set_fieldid(108);
+    auto* new_log = new_binlog->add_binlogs();
+    new_log->set_log_path("/path/to/binlog_108");
+    new_log->set_entries_num(1000);
+    auto* new_index = new_proto.add_index_infos();
+    new_index->set_fieldid(108);
+    new_index->set_indexid(5002);
+    new_index->add_index_file_paths("/path/to/sort_index");
+    auto* new_param = new_index->add_index_params();
+    new_param->set_key("index_type");
+    new_param->set_value(milvus::index::ASCENDING_SORT);
+
+    SegmentLoadInfo current_info(current_proto, schema_);
+    (void)current_info.GetLoadDiff();
+    SegmentLoadInfo new_info(new_proto, schema_);
+    auto diff = current_info.ComputeDiff(new_info);
+    std::cout << "Replace index with raw data diff: " << diff.ToString()
+              << "\n";
+
+    // Index should be in indexes_to_replace
+    EXPECT_TRUE(diff.indexes_to_replace.count(FieldId(108)) > 0);
+    // field_data_to_drop should include field 108
+    EXPECT_TRUE(diff.field_data_to_drop.count(FieldId(108)) > 0);
+}
+
+TEST_F(SegmentLoadInfoTest, ComputeDiffNewIndexNoRawDataNoFieldDrop) {
+    // Test 1.3: When a new index has no raw data (INVERTED_INDEX_TYPE),
+    // field_data_to_drop should NOT include that field.
+
+    // Current: only binlog for field 108
+    proto::segcore::SegmentLoadInfo current_proto;
+    current_proto.set_segmentid(100);
+    current_proto.set_num_of_rows(1000);
+    auto* cur_binlog = current_proto.add_binlog_paths();
+    cur_binlog->set_fieldid(108);
+    auto* cur_log = cur_binlog->add_binlogs();
+    cur_log->set_log_path("/path/to/binlog_108");
+    cur_log->set_entries_num(1000);
+
+    // New: same binlog + INVERTED index for field 108 (no raw data)
+    proto::segcore::SegmentLoadInfo new_proto;
+    new_proto.set_segmentid(100);
+    new_proto.set_num_of_rows(1000);
+    auto* new_binlog = new_proto.add_binlog_paths();
+    new_binlog->set_fieldid(108);
+    auto* new_log = new_binlog->add_binlogs();
+    new_log->set_log_path("/path/to/binlog_108");
+    new_log->set_entries_num(1000);
+    auto* index_info = new_proto.add_index_infos();
+    index_info->set_fieldid(108);
+    index_info->set_indexid(5001);
+    index_info->add_index_file_paths("/path/to/inverted_index");
+    auto* param = index_info->add_index_params();
+    param->set_key("index_type");
+    param->set_value(milvus::index::INVERTED_INDEX_TYPE);
+
+    SegmentLoadInfo current_info(current_proto, schema_);
+    (void)current_info.GetLoadDiff();
+    SegmentLoadInfo new_info(new_proto, schema_);
+    auto diff = current_info.ComputeDiff(new_info);
+    std::cout << "New index no raw data diff: " << diff.ToString() << "\n";
+
+    // Index should be in indexes_to_load
+    EXPECT_TRUE(diff.indexes_to_load.count(FieldId(108)) > 0);
+    // field_data_to_drop should NOT include field 108 (no raw data)
+    EXPECT_TRUE(diff.field_data_to_drop.count(FieldId(108)) == 0);
+}
+
+TEST_F(SegmentLoadInfoTest, ComputeDiffUnchangedIndexNoFieldDrop) {
+    // Test 1.4: When the index is unchanged (same index_id),
+    // field_data_to_drop should be empty.
+
+    // Both current and new: field 108 has ASCENDING_SORT index with same id
+    proto::segcore::SegmentLoadInfo proto;
+    proto.set_segmentid(100);
+    proto.set_num_of_rows(1000);
+    auto* binlog = proto.add_binlog_paths();
+    binlog->set_fieldid(108);
+    auto* log = binlog->add_binlogs();
+    log->set_log_path("/path/to/binlog_108");
+    log->set_entries_num(1000);
+    auto* index_info = proto.add_index_infos();
+    index_info->set_fieldid(108);
+    index_info->set_indexid(5001);
+    index_info->add_index_file_paths("/path/to/sort_index");
+    auto* param = index_info->add_index_params();
+    param->set_key("index_type");
+    param->set_value(milvus::index::ASCENDING_SORT);
+
+    SegmentLoadInfo current_info(proto, schema_);
+    (void)current_info.GetLoadDiff();
+    SegmentLoadInfo new_info(proto, schema_);
+    auto diff = current_info.ComputeDiff(new_info);
+
+    // No index changes
+    EXPECT_TRUE(diff.indexes_to_load.empty());
+    EXPECT_TRUE(diff.indexes_to_replace.empty());
+    EXPECT_TRUE(diff.indexes_to_drop.empty());
+    // field_data_to_drop should be empty (no change)
+    EXPECT_TRUE(diff.field_data_to_drop.empty());
+}
+
+TEST_F(SegmentLoadInfoTest, ComputeDiffReloadFieldRawToNoRaw) {
+    // Test 1.5: When index changes from raw=true to raw=false,
+    // binlogs_to_replace should include the field's binlog.
+    // Scenario: current has ASCENDING_SORT (raw=true) -> new has INVERTED (raw=false)
+
+    // Current: field 108 with ASCENDING_SORT index + binlog
+    proto::segcore::SegmentLoadInfo current_proto;
+    current_proto.set_segmentid(100);
+    current_proto.set_num_of_rows(1000);
+    auto* cur_binlog = current_proto.add_binlog_paths();
+    cur_binlog->set_fieldid(108);
+    auto* cur_log = cur_binlog->add_binlogs();
+    cur_log->set_log_path("/path/to/binlog_108");
+    cur_log->set_entries_num(1000);
+    auto* cur_index = current_proto.add_index_infos();
+    cur_index->set_fieldid(108);
+    cur_index->set_indexid(5001);
+    cur_index->add_index_file_paths("/path/to/sort_index");
+    auto* cur_param = cur_index->add_index_params();
+    cur_param->set_key("index_type");
+    cur_param->set_value(milvus::index::ASCENDING_SORT);
+
+    // New: field 108 with INVERTED index (no raw) + same binlog
+    proto::segcore::SegmentLoadInfo new_proto;
+    new_proto.set_segmentid(100);
+    new_proto.set_num_of_rows(1000);
+    auto* new_binlog = new_proto.add_binlog_paths();
+    new_binlog->set_fieldid(108);
+    auto* new_log = new_binlog->add_binlogs();
+    new_log->set_log_path("/path/to/binlog_108");
+    new_log->set_entries_num(1000);
+    auto* new_index = new_proto.add_index_infos();
+    new_index->set_fieldid(108);
+    new_index->set_indexid(5002);
+    new_index->add_index_file_paths("/path/to/inverted_index");
+    auto* new_param = new_index->add_index_params();
+    new_param->set_key("index_type");
+    new_param->set_value(milvus::index::INVERTED_INDEX_TYPE);
+
+    SegmentLoadInfo current_info(current_proto, schema_);
+    (void)current_info.GetLoadDiff();
+    SegmentLoadInfo new_info(new_proto, schema_);
+    auto diff = current_info.ComputeDiff(new_info);
+    std::cout << "Raw->NoRaw reload diff: " << diff.ToString() << "\n";
+
+    // Index should be replaced
+    EXPECT_TRUE(diff.indexes_to_replace.count(FieldId(108)) > 0);
+
+    // binlogs_to_replace should include field 108 (need to reload raw data)
+    bool found_108_in_replace = false;
+    for (const auto& [field_ids, binlog] : diff.binlogs_to_replace) {
+        for (const auto& fid : field_ids) {
+            if (fid.get() == 108) {
+                found_108_in_replace = true;
+            }
+        }
+    }
+    EXPECT_TRUE(found_108_in_replace);
+
+    // fields_to_reload should be empty (new path uses binlogs_to_replace)
+    EXPECT_TRUE(diff.fields_to_reload.empty());
+}
+
+TEST_F(SegmentLoadInfoTest, ComputeDiffReloadFieldIndexDropped) {
+    // Test 1.6: When an index is dropped and it had raw data,
+    // binlogs_to_replace should include the field's binlog.
+    // Scenario: current has ASCENDING_SORT (raw=true) -> new has no index
+
+    // Current: field 108 with ASCENDING_SORT index + binlog
+    proto::segcore::SegmentLoadInfo current_proto;
+    current_proto.set_segmentid(100);
+    current_proto.set_num_of_rows(1000);
+    auto* cur_binlog = current_proto.add_binlog_paths();
+    cur_binlog->set_fieldid(108);
+    auto* cur_log = cur_binlog->add_binlogs();
+    cur_log->set_log_path("/path/to/binlog_108");
+    cur_log->set_entries_num(1000);
+    auto* cur_index = current_proto.add_index_infos();
+    cur_index->set_fieldid(108);
+    cur_index->set_indexid(5001);
+    cur_index->add_index_file_paths("/path/to/sort_index");
+    auto* cur_param = cur_index->add_index_params();
+    cur_param->set_key("index_type");
+    cur_param->set_value(milvus::index::ASCENDING_SORT);
+
+    // New: field 108 with binlog only (no index)
+    proto::segcore::SegmentLoadInfo new_proto;
+    new_proto.set_segmentid(100);
+    new_proto.set_num_of_rows(1000);
+    auto* new_binlog = new_proto.add_binlog_paths();
+    new_binlog->set_fieldid(108);
+    auto* new_log = new_binlog->add_binlogs();
+    new_log->set_log_path("/path/to/binlog_108");
+    new_log->set_entries_num(1000);
+
+    SegmentLoadInfo current_info(current_proto, schema_);
+    (void)current_info.GetLoadDiff();
+    SegmentLoadInfo new_info(new_proto, schema_);
+    auto diff = current_info.ComputeDiff(new_info);
+    std::cout << "Index dropped reload diff: " << diff.ToString() << "\n";
+
+    // Index should be dropped
+    EXPECT_TRUE(diff.indexes_to_drop.count(FieldId(108)) > 0);
+
+    // binlogs_to_replace should include field 108
+    bool found_108_in_replace = false;
+    for (const auto& [field_ids, binlog] : diff.binlogs_to_replace) {
+        for (const auto& fid : field_ids) {
+            if (fid.get() == 108) {
+                found_108_in_replace = true;
+            }
+        }
+    }
+    EXPECT_TRUE(found_108_in_replace);
+}
+
+TEST_F(SegmentLoadInfoTest, ComputeDiffNoReloadWhenIndexStaysRaw) {
+    // Test 1.7: When index stays raw=true (same index_id),
+    // no reload should happen.
+
+    // Both: field 108 with same ASCENDING_SORT index
+    proto::segcore::SegmentLoadInfo proto;
+    proto.set_segmentid(100);
+    proto.set_num_of_rows(1000);
+    auto* binlog = proto.add_binlog_paths();
+    binlog->set_fieldid(108);
+    auto* log = binlog->add_binlogs();
+    log->set_log_path("/path/to/binlog_108");
+    log->set_entries_num(1000);
+    auto* index_info = proto.add_index_infos();
+    index_info->set_fieldid(108);
+    index_info->set_indexid(5001);
+    index_info->add_index_file_paths("/path/to/sort_index");
+    auto* param = index_info->add_index_params();
+    param->set_key("index_type");
+    param->set_value(milvus::index::ASCENDING_SORT);
+
+    SegmentLoadInfo current_info(proto, schema_);
+    (void)current_info.GetLoadDiff();
+    SegmentLoadInfo new_info(proto, schema_);
+    auto diff = current_info.ComputeDiff(new_info);
+
+    // No changes at all
+    EXPECT_FALSE(diff.HasChanges());
+    EXPECT_TRUE(diff.binlogs_to_replace.empty());
+    EXPECT_TRUE(diff.fields_to_reload.empty());
+    EXPECT_TRUE(diff.field_data_to_drop.empty());
+}

--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -2664,3 +2664,83 @@ INSTANTIATE_TEST_SUITE_P(
     [](const ::testing::TestParamInfo<VectorArrayTestParam>& info) {
         return std::get<3>(info.param);
     });
+
+// ==================== DropFieldData Guard Tests ====================
+
+TEST(SealedDropFieldData, SkipPKField) {
+    // DropFieldData should skip dropping PK field data
+    auto schema = std::make_shared<Schema>();
+    auto dim = 4;
+    auto metric_type = knowhere::metric::L2;
+    auto vec_id = schema->AddDebugField(
+        "fakevec", DataType::VECTOR_FLOAT, dim, metric_type);
+    auto pk_id = schema->AddDebugField("pk", DataType::INT64);
+    schema->set_primary_field_id(pk_id);
+
+    auto N = 100;
+    auto dataset = DataGen(schema, N);
+
+    auto segment = CreateSealedWithFieldDataLoaded(schema, dataset);
+
+    // PK field data should be present
+    EXPECT_TRUE(segment->HasFieldData(pk_id));
+
+    // Try to drop PK field - should be skipped
+    segment->DropFieldData(pk_id);
+
+    // PK field data should still be present (protected)
+    EXPECT_TRUE(segment->HasFieldData(pk_id));
+}
+
+TEST(SealedDropFieldData, DropNonPKField) {
+    // DropFieldData should successfully drop non-PK, non-column-group fields
+    auto schema = std::make_shared<Schema>();
+    auto dim = 4;
+    auto metric_type = knowhere::metric::L2;
+    auto vec_id = schema->AddDebugField(
+        "fakevec", DataType::VECTOR_FLOAT, dim, metric_type);
+    auto pk_id = schema->AddDebugField("pk", DataType::INT64);
+    schema->set_primary_field_id(pk_id);
+
+    auto N = 100;
+    auto dataset = DataGen(schema, N);
+
+    auto segment = CreateSealedWithFieldDataLoaded(schema, dataset);
+
+    // Vec field data should be present
+    EXPECT_TRUE(segment->HasFieldData(vec_id));
+
+    // Drop vec field - should succeed (not PK, not column group)
+    segment->DropFieldData(vec_id);
+
+    // Vec field data should be gone
+    EXPECT_FALSE(segment->HasFieldData(vec_id));
+}
+
+TEST(SealedDropFieldData, PKFieldStillDropsBinlogIndex) {
+    // When dropping PK field, field data is preserved but binlog index
+    // (if present) should still be cleared.
+    auto schema = std::make_shared<Schema>();
+    auto dim = 4;
+    auto metric_type = knowhere::metric::L2;
+    auto vec_id = schema->AddDebugField(
+        "fakevec", DataType::VECTOR_FLOAT, dim, metric_type);
+    auto pk_id = schema->AddDebugField("pk", DataType::INT64);
+    schema->set_primary_field_id(pk_id);
+
+    auto N = 100;
+    auto dataset = DataGen(schema, N);
+
+    auto segment = CreateSealedWithFieldDataLoaded(schema, dataset);
+
+    // PK field data should be present
+    EXPECT_TRUE(segment->HasFieldData(pk_id));
+
+    // Drop PK field - field data should remain
+    segment->DropFieldData(pk_id);
+    EXPECT_TRUE(segment->HasFieldData(pk_id));
+
+    // Drop again - should be a no-op (idempotent)
+    segment->DropFieldData(pk_id);
+    EXPECT_TRUE(segment->HasFieldData(pk_id));
+}


### PR DESCRIPTION
Remove direct ManualEvictCache calls from LoadVecIndex/LoadScalarIndex and move raw data lifecycle management entirely into the LoadDiff + ApplyLoadDiff pipeline. This fixes unsafe cache eviction on multi-field column groups that could cause SIGSEGV in GroupChunk::GetChunk, and eliminates data vacuum windows during index transitions.

Key changes:
- Remove ManualEvictCache from LoadVecIndex and LoadScalarIndex
- Add IsInMultiFieldColumnGroup() guard to DropFieldData
- Add PK field protection to DropFieldData
- ComputeDiffIndexes: mark field_data_to_drop when new index has raw data
- ComputeDiffReloadFields: rebuild field data from storage (binlogs/column_groups) instead of just warmup when index loses raw data
- ApplyLoadDiff: reorder to load field data BEFORE dropping indexes

issue: #47738