### PR TITLE
fix: remove redundant config cache eviction via event dispatcher

### DIFF
--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -106,11 +106,6 @@ func NewManager() *Manager {
 		immutableKeys: typeutil.NewConcurrentSet[string](),
 		configCache:   make(map[string]any),
 	}
-	resetConfigCacheFunc := NewHandler("reset.config.cache", func(event *Event) {
-		keyToRemove := strings.NewReplacer("/", ".").Replace(event.Key)
-		manager.EvictCachedValue(keyToRemove)
-	})
-	manager.Dispatcher.RegisterForKeyPrefix("", resetConfigCacheFunc)
 	return manager
 }
 

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -301,6 +301,37 @@ func TestCachedConfig(t *testing.T) {
 	}
 }
 
+func TestNoDuplicateCacheEviction(t *testing.T) {
+	// Verify that the dispatcher does not have a redundant config cache reset handler.
+	// Cache eviction is handled directly by EvictCacheValueByFormat in source update(),
+	// so the dispatcher should not also clear the cache on every event.
+	mgr, _ := Init()
+
+	// Set up a cached value
+	mgr.SetConfig("x.y", "val1")
+	ok := mgr.CASCachedValue("x.y", "val1", "cached-val")
+	require.True(t, ok)
+	val, exist := mgr.GetCachedValue("x.y")
+	require.True(t, exist)
+	assert.Equal(t, "cached-val", val)
+
+	// Dispatch an event directly through the dispatcher (simulating the event path).
+	// After the fix, the dispatcher should NOT clear the config cache because
+	// that responsibility belongs to the source's update() method.
+	mgr.Dispatcher.Dispatch(&Event{
+		EventSource: "TestSource",
+		EventType:   UpdateType,
+		Key:         "unrelated.key",
+		Value:       "some-value",
+	})
+
+	// The cached value should still be present because the dispatcher no longer
+	// has a handler that clears the cache on every event.
+	val, exist = mgr.GetCachedValue("x.y")
+	assert.True(t, exist, "cached value should not be evicted by dispatcher event")
+	assert.Equal(t, "cached-val", val)
+}
+
 type ErrSource struct{}
 
 func (e ErrSource) Close() {


### PR DESCRIPTION
## Summary

Remove the redundant `resetConfigCacheFunc` event dispatcher handler from `NewManager()` that causes the config cache to be cleared twice on every configuration change.

### Problem

The config cache (`configCache` in `pkg/config/manager.go`) is evicted **twice** on every config change due to two independent eviction paths:

**Path 1** (direct call, before events are fired):
```
FileSource.update() / EtcdSource.update()
  └── manager.EvictCacheValueByFormat(changedKeys) → clear(configCache)
```

**Path 2** (via event dispatcher, after events are fired):
```
FileSource.update() / EtcdSource.update()
  └── fireEvents()
        └── dispatcher → resetConfigCacheFunc → manager.EvictCachedValue(key) → clear(configCache)
```

Both paths call `clear(configCache)`, making the second eviction completely redundant. The double eviction also means every event acquires and releases the `cacheMutex` lock an extra time.

### Fix

Remove the `resetConfigCacheFunc` dispatcher handler from `NewManager()`. The `EvictCacheValueByFormat` call in `FileSource.update()` and `EtcdSource.update()` already handles cache eviction correctly (and with the `len(keys) == 0` guard added in #48187/#48188, it skips eviction when nothing changed).

### Testing

Added `TestNoDuplicateCacheEviction` to verify that the dispatcher no longer clears the cache on event dispatch — cache eviction is solely the responsibility of the source's `update()` method.

issue: https://github.com/milvus-io/milvus/issues/48193