### PR TITLE
enhance: add all-replicas-ready checkpoint metric for query coord

### DIFF
--- a/internal/querycoordv2/meta/target_manager.go
+++ b/internal/querycoordv2/meta/target_manager.go
@@ -219,6 +219,10 @@ func (mgr *TargetManager) RemoveCollection(ctx context.Context, collectionID int
 				paramtable.GetStringNodeID(),
 				channelName,
 			)
+			metrics.QueryCoordCurrentTargetAllReplicasCheckpointUnixSeconds.DeleteLabelValues(
+				paramtable.GetStringNodeID(),
+				channelName,
+			)
 		}
 	}
 

--- a/internal/querycoordv2/observers/target_observer.go
+++ b/internal/querycoordv2/observers/target_observer.go
@@ -31,12 +31,14 @@ import (
 	"github.com/milvus-io/milvus/internal/querycoordv2/session"
 	"github.com/milvus-io/milvus/internal/querycoordv2/utils"
 	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/metrics"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v2/util/commonpbutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/lock"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v2/util/tsoutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
@@ -286,6 +288,9 @@ func (ob *TargetObserver) check(ctx context.Context, collectionID int64) {
 			ob.syncNextTargetToDelegator(ctx, collectionID, ob.distMgr.ChannelDistManager.GetByFilter(meta.WithCollectionID2Channel(collectionID)), newVersion)
 		}
 	}
+
+	// Update the all-replicas checkpoint metric
+	ob.updateAllReplicasCheckpointMetric(ctx, collectionID)
 }
 
 func (ob *TargetObserver) init(ctx context.Context, collectionID int64) {
@@ -591,6 +596,47 @@ func (ob *TargetObserver) genSyncAction(ctx context.Context, leaderView *meta.Le
 	}
 
 	return action
+}
+
+func (ob *TargetObserver) updateAllReplicasCheckpointMetric(ctx context.Context, collectionID int64) {
+	channels := ob.targetMgr.GetDmChannelsByCollection(ctx, collectionID, meta.CurrentTarget)
+	if len(channels) == 0 {
+		return
+	}
+	currentVersion := ob.targetMgr.GetCollectionTargetVersion(ctx, collectionID, meta.CurrentTarget)
+	if currentVersion == 0 {
+		return
+	}
+	replicas := ob.meta.ReplicaManager.GetByCollection(ctx, collectionID)
+	if len(replicas) == 0 {
+		return
+	}
+
+	for channelName, dmlChannel := range channels {
+		allReady := true
+		for _, replica := range replicas {
+			delegators := ob.distMgr.ChannelDistManager.GetByFilter(
+				meta.WithReplica2Channel(replica),
+				meta.WithChannelName2Channel(channelName),
+			)
+			hasReady := lo.ContainsBy(delegators, func(ch *meta.DmChannel) bool {
+				return ch.View != nil &&
+					ch.View.TargetVersion >= currentVersion &&
+					ch.IsServiceable()
+			})
+			if !hasReady {
+				allReady = false
+				break
+			}
+		}
+		if allReady {
+			ts, _ := tsoutil.ParseTS(dmlChannel.GetSeekPosition().GetTimestamp())
+			metrics.QueryCoordCurrentTargetAllReplicasCheckpointUnixSeconds.WithLabelValues(
+				paramtable.GetStringNodeID(),
+				channelName,
+			).Set(float64(ts.Unix()))
+		}
+	}
 }
 
 func (ob *TargetObserver) updateCurrentTarget(ctx context.Context, collectionID int64) {

--- a/internal/querycoordv2/observers/target_observer_test.go
+++ b/internal/querycoordv2/observers/target_observer_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	io_prometheus_client "github.com/prometheus/client_model/go"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -37,6 +38,7 @@ import (
 	"github.com/milvus-io/milvus/internal/querycoordv2/utils"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/kv"
+	"github.com/milvus-io/milvus/pkg/v2/metrics"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v2/util/etcd"
@@ -1089,6 +1091,127 @@ func TestShouldUpdateCurrentTarget_NoReadyDelegators(t *testing.T) {
 	// channelNames keys = ["channel-1"]
 	// lo.Every([], ["channel-1"]) = false (empty does not contain all)
 	assert.False(t, result, "Expected false when NO ready delegators exist")
+}
+
+// TestUpdateAllReplicasCheckpointMetric tests the all-replicas checkpoint metric behavior
+func TestUpdateAllReplicasCheckpointMetric(t *testing.T) {
+	paramtable.Init()
+	ctx := context.Background()
+	collectionID := int64(1000)
+	currentVersion := int64(100)
+
+	nodeMgr := session.NewNodeManager()
+	nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{NodeID: 1}))
+	nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{NodeID: 2}))
+
+	targetMgr := meta.NewMockTargetManager(t)
+	distMgr := meta.NewDistributionManager(nodeMgr)
+	broker := meta.NewMockBroker(t)
+	cluster := session.NewMockCluster(t)
+
+	// Create two replicas: replica1 on node1, replica2 on node2
+	replica1 := meta.NewReplica(&querypb.Replica{
+		ID:            1,
+		CollectionID:  collectionID,
+		ResourceGroup: meta.DefaultResourceGroupName,
+		Nodes:         []int64{1},
+	})
+	replica2 := meta.NewReplica(&querypb.Replica{
+		ID:            2,
+		CollectionID:  collectionID,
+		ResourceGroup: meta.DefaultResourceGroupName,
+		Nodes:         []int64{2},
+	})
+
+	mockCatalog := mocks.NewQueryCoordCatalog(t)
+	mockCatalog.EXPECT().SaveReplica(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockCatalog.EXPECT().SaveReplica(mock.Anything, mock.Anything).Return(nil).Maybe()
+	replicaMgr := meta.NewReplicaManager(nil, mockCatalog)
+	err := replicaMgr.Put(ctx, replica1, replica2)
+	assert.NoError(t, err)
+
+	metaInstance := &meta.Meta{
+		CollectionManager: meta.NewCollectionManager(nil),
+		ReplicaManager:    replicaMgr,
+	}
+
+	observer := NewTargetObserver(metaInstance, targetMgr, distMgr, broker, cluster, nodeMgr)
+
+	channelName := "channel-1"
+	seekTimestamp := uint64(1000 << 18) // some timestamp
+	channels := map[string]*meta.DmChannel{
+		channelName: {
+			VchannelInfo: &datapb.VchannelInfo{
+				CollectionID: collectionID,
+				ChannelName:  channelName,
+				SeekPosition: &msgpb.MsgPosition{
+					Timestamp: seekTimestamp,
+				},
+			},
+		},
+	}
+
+	targetMgr.EXPECT().GetDmChannelsByCollection(mock.Anything, collectionID, meta.CurrentTarget).Return(channels)
+	targetMgr.EXPECT().GetCollectionTargetVersion(mock.Anything, collectionID, meta.CurrentTarget).Return(currentVersion)
+
+	// Reset metric before test
+	metrics.QueryCoordCurrentTargetAllReplicasCheckpointUnixSeconds.Reset()
+
+	// Case 1: Only replica1 ready, replica2 not ready -> metric should NOT update
+	distMgr.ChannelDistManager.Update(1, &meta.DmChannel{
+		VchannelInfo: &datapb.VchannelInfo{
+			CollectionID: collectionID,
+			ChannelName:  channelName,
+		},
+		Node: 1,
+		View: &meta.LeaderView{
+			ID:            1,
+			CollectionID:  collectionID,
+			Channel:       channelName,
+			TargetVersion: currentVersion,
+			Status:        &querypb.LeaderViewStatus{Serviceable: true},
+		},
+	})
+	// Node 2 has no delegator for channel-1
+
+	observer.updateAllReplicasCheckpointMetric(ctx, collectionID)
+
+	// Metric should not have been set (no gauge value or still 0)
+	gauge, err := metrics.QueryCoordCurrentTargetAllReplicasCheckpointUnixSeconds.GetMetricWithLabelValues(
+		paramtable.GetStringNodeID(), channelName,
+	)
+	assert.NoError(t, err)
+	dto := &io_prometheus_client.Metric{}
+	gauge.Write(dto)
+	assert.Equal(t, float64(0), dto.GetGauge().GetValue(),
+		"metric should not update when not all replicas are ready")
+
+	// Case 2: Both replicas ready -> metric should update
+	distMgr.ChannelDistManager.Update(2, &meta.DmChannel{
+		VchannelInfo: &datapb.VchannelInfo{
+			CollectionID: collectionID,
+			ChannelName:  channelName,
+		},
+		Node: 2,
+		View: &meta.LeaderView{
+			ID:            2,
+			CollectionID:  collectionID,
+			Channel:       channelName,
+			TargetVersion: currentVersion,
+			Status:        &querypb.LeaderViewStatus{Serviceable: true},
+		},
+	})
+
+	observer.updateAllReplicasCheckpointMetric(ctx, collectionID)
+
+	gauge, err = metrics.QueryCoordCurrentTargetAllReplicasCheckpointUnixSeconds.GetMetricWithLabelValues(
+		paramtable.GetStringNodeID(), channelName,
+	)
+	assert.NoError(t, err)
+	dto = &io_prometheus_client.Metric{}
+	gauge.Write(dto)
+	assert.Greater(t, dto.GetGauge().GetValue(), float64(0),
+		"metric should update when all replicas are ready")
 }
 
 func TestTargetObserver(t *testing.T) {

--- a/pkg/metrics/querycoord_metrics.go
+++ b/pkg/metrics/querycoord_metrics.go
@@ -125,6 +125,17 @@ var (
 			channelNameLabelName,
 		})
 
+	QueryCoordCurrentTargetAllReplicasCheckpointUnixSeconds = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryCoordRole,
+			Name:      "current_target_all_replicas_checkpoint_unix_seconds",
+			Help:      "current target checkpoint unix seconds, only advances when all replicas are ready",
+		}, []string{
+			nodeIDLabelName,
+			channelNameLabelName,
+		})
+
 	QueryCoordTaskLatency = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: milvusNamespace,
@@ -178,6 +189,7 @@ func RegisterQueryCoord(registry *prometheus.Registry) {
 	registry.MustRegister(QueryCoordTaskNum)
 	registry.MustRegister(QueryCoordNumQueryNodes)
 	registry.MustRegister(QueryCoordCurrentTargetCheckpointUnixSeconds)
+	registry.MustRegister(QueryCoordCurrentTargetAllReplicasCheckpointUnixSeconds)
 	registry.MustRegister(QueryCoordTaskLatency)
 	registry.MustRegister(QueryCoordResourceGroupInfo)
 	registry.MustRegister(QueryCoordResourceGroupReplicaTotal)


### PR DESCRIPTION
The existing current_target_checkpoint_unix_seconds metric advances as soon as any single replica is ready per channel, which does not reflect the true minimum state of the cluster in multi-replica mode.

Add a new metric current_target_all_replicas_checkpoint_unix_seconds that only updates when all replicas have at least one ready delegator for a given channel, correctly reflecting the cluster-wide minimum checkpoint state.

issue: #48304