### PR TITLE
fix: [hotfix] prevent CASCachedValue permanent failure with FallbackKeys (#48313)

### DIFF
--- a/pkg/util/paramtable/param_item.go
+++ b/pkg/util/paramtable/param_item.go
@@ -129,8 +129,10 @@ func (pi *ParamItem) getWithRaw() (result, raw string, err error) {
 	if pi.manager == nil {
 		panic(fmt.Sprintf("manager is nil %s", pi.Key))
 	}
-	// raw value set only once
+	// raw is always the primary key's value, used for CAS comparison.
+	// effectiveRaw is the value actually used for computing result (may come from fallback).
 	_, raw, err = pi.manager.GetConfig(pi.Key)
+	effectiveRaw := raw
 	if err != nil || raw == pi.DefaultValue {
 		// try fallback if the entry is not exist or default value,
 		//  because default value may already defined in milvus.yaml
@@ -139,16 +141,17 @@ func (pi *ParamItem) getWithRaw() (result, raw string, err error) {
 			var fallbackRaw string
 			_, fallbackRaw, err = pi.manager.GetConfig(key)
 			if err == nil {
-				raw = fallbackRaw
+				effectiveRaw = fallbackRaw
 				break
 			}
 		}
 	}
 	if err != nil {
 		// use default value
+		effectiveRaw = pi.DefaultValue
 		raw = pi.DefaultValue
 	}
-	result = raw
+	result = effectiveRaw
 	if pi.Formatter != nil {
 		result = pi.Formatter(result)
 	}

--- a/pkg/util/paramtable/param_item_test.go
+++ b/pkg/util/paramtable/param_item_test.go
@@ -1,0 +1,123 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package paramtable
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/pkg/v2/config"
+)
+
+func TestGetWithRaw_FallbackKeyCacheSuccess(t *testing.T) {
+	// When primary key equals DefaultValue and a fallback key has a different value,
+	// getWithRaw should return the fallback value as result but the primary key's
+	// raw value for CAS, so CASCachedValue succeeds and the cache is populated.
+	t.Run("primary_equals_default_fallback_exists", func(t *testing.T) {
+		manager := config.NewManager()
+		fallbackKey := "test.fallback.key"
+		primaryKey := "test.primary.key"
+		defaultVal := "100"
+		fallbackVal := "200"
+
+		// Set primary key to the default value, and fallback to a different value.
+		manager.SetConfig(primaryKey, defaultVal)
+		manager.SetConfig(fallbackKey, fallbackVal)
+
+		param := &ParamItem{
+			Key:          primaryKey,
+			DefaultValue: defaultVal,
+			FallbackKeys: []string{fallbackKey},
+		}
+		param.Init(manager)
+
+		// First call: should return fallback value and cache it via CAS.
+		result := param.GetAsInt()
+		assert.Equal(t, 200, result)
+
+		// Verify cache was populated (second call should hit cache).
+		cached, exist := manager.GetCachedValue(primaryKey)
+		assert.True(t, exist)
+		assert.Equal(t, 200, cached)
+
+		// Second call should return the same value from cache.
+		result2 := param.GetAsInt()
+		assert.Equal(t, 200, result2)
+	})
+
+	t.Run("primary_not_exist_fallback_exists", func(t *testing.T) {
+		manager := config.NewManager()
+		fallbackKey := "test.fallback.key2"
+		primaryKey := "test.primary.key2"
+
+		manager.SetConfig(fallbackKey, "300")
+
+		param := &ParamItem{
+			Key:          primaryKey,
+			DefaultValue: "50",
+			FallbackKeys: []string{fallbackKey},
+		}
+		param.Init(manager)
+
+		result := param.GetAsInt()
+		assert.Equal(t, 300, result)
+
+		// CAS should succeed (ErrKeyNotFound branch in CASCachedValue).
+		cached, exist := manager.GetCachedValue(primaryKey)
+		assert.True(t, exist)
+		assert.Equal(t, 300, cached)
+	})
+
+	t.Run("primary_exists_not_default_no_fallback_used", func(t *testing.T) {
+		manager := config.NewManager()
+		primaryKey := "test.primary.key3"
+		fallbackKey := "test.fallback.key3"
+
+		manager.SetConfig(primaryKey, "500")
+		manager.SetConfig(fallbackKey, "600")
+
+		param := &ParamItem{
+			Key:          primaryKey,
+			DefaultValue: "100",
+			FallbackKeys: []string{fallbackKey},
+		}
+		param.Init(manager)
+
+		// Primary key value != DefaultValue, so fallback is NOT used.
+		result := param.GetAsInt()
+		assert.Equal(t, 500, result)
+
+		cached, exist := manager.GetCachedValue(primaryKey)
+		assert.True(t, exist)
+		assert.Equal(t, 500, cached)
+	})
+
+	t.Run("nothing_exists_use_default", func(t *testing.T) {
+		manager := config.NewManager()
+
+		param := &ParamItem{
+			Key:          "test.primary.key4",
+			DefaultValue: "42",
+			FallbackKeys: []string{"test.fallback.key4"},
+		}
+		param.Init(manager)
+
+		result := param.GetAsInt()
+		assert.Equal(t, 42, result)
+	})
+}


### PR DESCRIPTION
When a ParamItem's primary key equals DefaultValue and a FallbackKey has a different value, getWithRaw() overwrote `raw` with the fallback value. CASCachedValue then re-reads the primary key and compares it against `raw` — mismatch causes CAS to permanently fail. The cache is never populated, forcing every call through the write-lock path and causing goroutine contention on proxy search hot paths.

Introduce `effectiveRaw` to separate the CAS comparison value (always the primary key's raw value) from the computation value (may come from fallback), so CAS succeeds and the cache is properly populated.

Related to #48312