### PR TITLE
enhance: align error mapping across all cloud storage providers

### DIFF
--- a/internal/storage/azure_object_storage_test.go
+++ b/internal/storage/azure_object_storage_test.go
@@ -590,6 +590,11 @@ func TestMapObjectStorageError_Azure_NewErrors(t *testing.T) {
 			expectedError: merr.ErrIoPermissionDenied,
 		},
 		{
+			name:          "AuthorizationFailure",
+			inputError:    &azcore.ResponseError{ErrorCode: "AuthorizationFailure"},
+			expectedError: merr.ErrIoPermissionDenied,
+		},
+		{
 			name:          "ContainerNotFound",
 			inputError:    &azcore.ResponseError{ErrorCode: "ContainerNotFound"},
 			expectedError: merr.ErrIoBucketNotFound,
@@ -603,6 +608,11 @@ func TestMapObjectStorageError_Azure_NewErrors(t *testing.T) {
 			name:          "InvalidRange",
 			inputError:    &azcore.ResponseError{ErrorCode: "InvalidRange"},
 			expectedError: merr.ErrIoInvalidRange,
+		},
+		{
+			name:          "RequestBodyTooLarge",
+			inputError:    &azcore.ResponseError{ErrorCode: "RequestBodyTooLarge"},
+			expectedError: merr.ErrIoEntityTooLarge,
 		},
 	}
 

--- a/internal/storage/gcp_native_object_storage_test.go
+++ b/internal/storage/gcp_native_object_storage_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"testing"
 
+	cstorage "cloud.google.com/go/storage"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -538,9 +539,19 @@ func TestMapObjectStorageError_GCP_NewErrors(t *testing.T) {
 			expectedError: merr.ErrIoPermissionDenied,
 		},
 		{
+			name:          "Unauthorized",
+			statusCode:    http.StatusUnauthorized,
+			expectedError: merr.ErrIoInvalidCredentials,
+		},
+		{
 			name:          "BadRequest",
 			statusCode:    http.StatusBadRequest,
 			expectedError: merr.ErrIoInvalidArgument,
+		},
+		{
+			name:          "RangeNotSatisfiable",
+			statusCode:    http.StatusRequestedRangeNotSatisfiable,
+			expectedError: merr.ErrIoInvalidRange,
 		},
 		{
 			name:          "RequestEntityTooLarge",
@@ -556,4 +567,22 @@ func TestMapObjectStorageError_GCP_NewErrors(t *testing.T) {
 			assert.True(t, errors.Is(result, tt.expectedError))
 		})
 	}
+}
+
+func TestMapObjectStorageError_GCP_SentinelErrors(t *testing.T) {
+	t.Run("ErrObjectNotExist", func(t *testing.T) {
+		result := mapObjectStorageError("test/path", cstorage.ErrObjectNotExist)
+		assert.ErrorIs(t, result, merr.ErrIoKeyNotFound)
+	})
+
+	t.Run("ErrBucketNotExist", func(t *testing.T) {
+		result := mapObjectStorageError("test/path", cstorage.ErrBucketNotExist)
+		assert.ErrorIs(t, result, merr.ErrIoBucketNotFound)
+	})
+
+	t.Run("WrappedErrObjectNotExist", func(t *testing.T) {
+		wrappedErr := errors.Wrap(cstorage.ErrObjectNotExist, "get attrs failed")
+		result := mapObjectStorageError("test/path", wrappedErr)
+		assert.ErrorIs(t, result, merr.ErrIoKeyNotFound)
+	})
 }

--- a/internal/storage/minio_object_storage_test.go
+++ b/internal/storage/minio_object_storage_test.go
@@ -482,6 +482,17 @@ func TestMapObjectStorageError_MinIO_NewErrors(t *testing.T) {
 			inputError:    minio.ErrorResponse{Code: "MaxMessageLengthExceeded"},
 			expectedError: merr.ErrIoEntityTooLarge,
 		},
+		// Aliyun OSS specific error codes
+		{
+			name:          "AliyunSecurityTokenExpired",
+			inputError:    minio.ErrorResponse{Code: "SecurityTokenExpired"},
+			expectedError: merr.ErrIoInvalidCredentials,
+		},
+		{
+			name:          "AliyunInvalidAccessKeyIdInactive",
+			inputError:    minio.ErrorResponse{Code: "InvalidAccessKeyId.Inactive"},
+			expectedError: merr.ErrIoPermissionDenied,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/storage/remote_chunk_manager.go
+++ b/internal/storage/remote_chunk_manager.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"syscall"
 
+	cstorage "cloud.google.com/go/storage"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/cockroachdb/errors"
 	"github.com/minio/minio-go/v7"
@@ -452,15 +453,19 @@ func (mcm *RemoteChunkManager) copyObject(ctx context.Context, bucketName, srcOb
 	return err
 }
 
-// Performance: Pre-allocate common error code strings to avoid repeated allocations
+// Error code constants for cloud provider error mapping.
 const (
+	// Azure Blob Storage error codes
 	azureBlobNotFound      = "BlobNotFound"
 	azureServerBusy        = "ServerBusy"
 	azureAuthFailed        = "AuthenticationFailed"
+	azureAuthFailure       = "AuthorizationFailure"
 	azureContainerNotFound = "ContainerNotFound"
 	azureInvalidParam      = "InvalidParameterValue"
 	azureInvalidRange      = "InvalidRange"
+	azureRequestBodyTooLg  = "RequestBodyTooLarge"
 
+	// S3-compatible error codes (AWS S3, MinIO, Aliyun OSS, Tencent COS, etc.)
 	minioNoSuchKey      = "NoSuchKey"
 	minioSlowDown       = "SlowDown"
 	minioTooMany        = "TooManyRequestsException"
@@ -475,6 +480,9 @@ const (
 	minioInvalidRange   = "InvalidRange"
 	minioEntityTooLarge = "EntityTooLarge"
 	minioMaxMessage     = "MaxMessageLengthExceeded"
+	// Aliyun OSS specific error codes (S3-compatible, via MinIO client)
+	ossSecurityTokenExpired = "SecurityTokenExpired"
+	ossInvalidAccessKeyId   = "InvalidAccessKeyId.Inactive"
 )
 
 func mapObjectStorageError(fileName string, err error) error {
@@ -487,16 +495,14 @@ func mapObjectStorageError(fileName string, err error) error {
 		return err
 	}
 
-	// Performance: Type switch is efficient - Go compiler optimizes this to a jump table
 	switch err := err.(type) {
 	case *azcore.ResponseError:
-		// Performance: Compare against const instead of calling string() repeatedly
 		switch err.ErrorCode {
 		case azureBlobNotFound:
 			return merr.WrapErrIoKeyNotFound(fileName, err.Error())
 		case azureServerBusy:
 			return merr.WrapErrIoTooManyRequests(fileName, err)
-		case azureAuthFailed:
+		case azureAuthFailed, azureAuthFailure:
 			return merr.WrapErrIoPermissionDenied(fileName, err)
 		case azureContainerNotFound:
 			return merr.WrapErrIoBucketNotFound(fileName, err)
@@ -504,21 +510,22 @@ func mapObjectStorageError(fileName string, err error) error {
 			return merr.WrapErrIoInvalidArgument(fileName, err)
 		case azureInvalidRange:
 			return merr.WrapErrIoInvalidRange(fileName, err)
+		case azureRequestBodyTooLg:
+			return merr.WrapErrIoEntityTooLarge(fileName, err)
 		default:
 			return merr.WrapErrIoFailed(fileName, err)
 		}
 	case minio.ErrorResponse:
-		// Performance: Use switch for better branch prediction than multiple ifs
 		switch err.Code {
 		case minioNoSuchKey:
 			return merr.WrapErrIoKeyNotFound(fileName, err.Error())
 		case minioSlowDown, minioTooMany:
 			return merr.WrapErrIoTooManyRequests(fileName, err)
-		case minioAccessDenied, minioInvalidKeyId, minioSigMismatch:
+		case minioAccessDenied, minioInvalidKeyId, minioSigMismatch, ossInvalidAccessKeyId:
 			return merr.WrapErrIoPermissionDenied(fileName, err)
 		case minioNoSuchBucket:
 			return merr.WrapErrIoBucketNotFound(fileName, err)
-		case minioInvalidToken, minioExpiredToken:
+		case minioInvalidToken, minioExpiredToken, ossSecurityTokenExpired:
 			return merr.WrapErrIoInvalidCredentials(fileName, err)
 		case minioInvalidArg, minioInvalidRequest:
 			return merr.WrapErrIoInvalidArgument(fileName, err)
@@ -530,7 +537,6 @@ func mapObjectStorageError(fileName string, err error) error {
 			return merr.WrapErrIoFailed(fileName, err)
 		}
 	case *googleapi.Error:
-		// Performance: Integer comparison is faster than string comparison
 		switch err.Code {
 		case http.StatusNotFound:
 			return merr.WrapErrIoKeyNotFound(fileName, err.Error())
@@ -538,8 +544,12 @@ func mapObjectStorageError(fileName string, err error) error {
 			return merr.WrapErrIoTooManyRequests(fileName, err)
 		case http.StatusForbidden:
 			return merr.WrapErrIoPermissionDenied(fileName, err)
+		case http.StatusUnauthorized:
+			return merr.WrapErrIoInvalidCredentials(fileName, err)
 		case http.StatusBadRequest:
 			return merr.WrapErrIoInvalidArgument(fileName, err)
+		case http.StatusRequestedRangeNotSatisfiable:
+			return merr.WrapErrIoInvalidRange(fileName, err)
 		case http.StatusRequestEntityTooLarge:
 			return merr.WrapErrIoEntityTooLarge(fileName, err)
 		default:
@@ -547,10 +557,16 @@ func mapObjectStorageError(fileName string, err error) error {
 		}
 	}
 
-	// Performance: Check specific errors before generic fallback
-	// errors.Is() with syscall errors is optimized in Go stdlib
+	// GCP cloud.google.com/go/storage sentinel errors (not *googleapi.Error)
+	if errors.Is(err, cstorage.ErrObjectNotExist) {
+		return merr.WrapErrIoKeyNotFound(fileName, err.Error())
+	}
+	if errors.Is(err, cstorage.ErrBucketNotExist) {
+		return merr.WrapErrIoBucketNotFound(fileName, err)
+	}
+
+	// syscall.ECONNRESET is typically triggered by rate limiting
 	if errors.Is(err, syscall.ECONNRESET) {
-		// syscall.ECONNRESET is typically triggered by rate limiting
 		return merr.WrapErrIoTooManyRequests(fileName, err)
 	}
 	if err == io.ErrUnexpectedEOF {

--- a/internal/util/importutilv2/common/retryable_reader.go
+++ b/internal/util/importutilv2/common/retryable_reader.go
@@ -68,6 +68,10 @@ func (r *retryableReader) Read(p []byte) (int, error) {
 		if errors.Is(err, io.EOF) {
 			return false, err
 		}
+		// Context canceled or deadline exceeded - don't retry
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return false, err
+		}
 		log.Ctx(r.ctx).Warn("retryable reader read failed",
 			zap.String("path", r.path),
 			zap.Error(err),

--- a/internal/util/importutilv2/common/retryable_reader_test.go
+++ b/internal/util/importutilv2/common/retryable_reader_test.go
@@ -220,3 +220,52 @@ func TestRetryableReader_DenylistRetry_EOFHandling(t *testing.T) {
 	assert.Equal(t, 0, n)
 	assert.Equal(t, 1, mockReader.callCount, "EOF should not be retried")
 }
+
+func TestRetryableReader_ContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	mockReader := &customMockReader{
+		readFunc: func(p []byte) (int, error) {
+			return 0, context.Canceled
+		},
+	}
+
+	reader := &retryableReader{
+		FileReader:    mockReader,
+		ctx:           ctx,
+		path:          "test/path",
+		retryAttempts: 10,
+	}
+
+	buf := make([]byte, 10)
+	n, err := reader.Read(buf)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 0, n)
+	assert.Equal(t, 1, mockReader.callCount, "context.Canceled should not be retried")
+}
+
+func TestRetryableReader_ContextDeadlineExceeded(t *testing.T) {
+	ctx := context.Background()
+
+	mockReader := &customMockReader{
+		readFunc: func(p []byte) (int, error) {
+			return 0, context.DeadlineExceeded
+		},
+	}
+
+	reader := &retryableReader{
+		FileReader:    mockReader,
+		ctx:           ctx,
+		path:          "test/path",
+		retryAttempts: 10,
+	}
+
+	buf := make([]byte, 10)
+	n, err := reader.Read(buf)
+
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 0, n)
+	assert.Equal(t, 1, mockReader.callCount, "context.DeadlineExceeded should not be retried")
+}

--- a/internal/util/importutilv2/common/retryable_reader_test.go
+++ b/internal/util/importutilv2/common/retryable_reader_test.go
@@ -222,8 +222,7 @@ func TestRetryableReader_DenylistRetry_EOFHandling(t *testing.T) {
 }
 
 func TestRetryableReader_ContextCanceled(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // cancel immediately
+	ctx := context.Background()
 
 	mockReader := &customMockReader{
 		readFunc: func(p []byte) (int, error) {


### PR DESCRIPTION
## Summary
- Complete the error mapping coverage introduced in #48152 for all supported cloud storage backends
- **GCP**: add 401→InvalidCredentials, 416→InvalidRange, `storage.ErrObjectNotExist`→KeyNotFound, `storage.ErrBucketNotExist`→BucketNotFound
- **Azure**: add AuthorizationFailure→PermissionDenied, RequestBodyTooLarge→EntityTooLarge
- **S3/MinIO**: add Aliyun OSS specific error codes (SecurityTokenExpired→InvalidCredentials, InvalidAccessKeyId.Inactive→PermissionDenied)
- **RetryableReader**: skip retry on `context.Canceled` / `context.DeadlineExceeded`

## Test plan
- [ ] Unit tests for all new GCP error mappings (HTTP status codes + sentinel errors)
- [ ] Unit tests for new Azure error mappings (AuthorizationFailure, RequestBodyTooLarge)
- [ ] Unit tests for Aliyun OSS error codes via MinIO client
- [ ] Unit tests for context.Canceled / DeadlineExceeded no-retry behavior
- [ ] CI passes (ut-go, code-check)

issue: #48153

🤖 Generated with [Claude Code](https://claude.com/claude-code)