### PR TITLE
test: Refactor search_load from 33 tests to parametrize-driven

### DIFF
--- a/tests/python_client/milvus_client_v2/test_milvus_client_search_load.py
+++ b/tests/python_client/milvus_client_v2/test_milvus_client_search_load.py
@@ -1,1255 +1,612 @@
-
-from utils.util_pymilvus import *
+import pytest
+from pymilvus import DataType
 from common.common_type import CaseLabel, CheckTasks
 from common import common_type as ct
 from common import common_func as cf
-from base.client_base import TestcaseBase
+from base.client_v2_base import TestMilvusClientV2Base
 
-import random
-import pytest
-import pandas as pd
-from faker import Faker
-
-Faker.seed(19530)
-fake_en = Faker("en_US")
-fake_zh = Faker("zh_CN")
-
-# patch faker to generate text with specific distribution
-cf.patch_faker_text(fake_en, cf.en_vocabularies_distribution)
-cf.patch_faker_text(fake_zh, cf.zh_vocabularies_distribution)
-
-pd.set_option("expand_frame_repr", False)
-
-prefix = "search_collection"
-search_num = 10
-max_dim = ct.max_dim
-min_dim = ct.min_dim
-epsilon = ct.epsilon
-hybrid_search_epsilon = 0.01
-gracefulTime = ct.gracefulTime
-default_nb = ct.default_nb
-default_nb_medium = ct.default_nb_medium
-default_nq = ct.default_nq
 default_dim = ct.default_dim
 default_limit = ct.default_limit
-max_limit = ct.max_limit
-default_search_exp = "int64 >= 0"
-default_search_string_exp = "varchar >= \"0\""
-default_search_mix_exp = "int64 >= 0 && varchar >= \"0\""
-default_invaild_string_exp = "varchar >= 0"
-default_json_search_exp = "json_field[\"number\"] >= 0"
-perfix_expr = 'varchar like "0%"'
 default_search_field = ct.default_float_vec_field_name
 default_search_params = ct.default_search_params
-default_int64_field_name = ct.default_int64_field_name
-default_float_field_name = ct.default_float_field_name
-default_bool_field_name = ct.default_bool_field_name
-default_string_field_name = ct.default_string_field_name
-default_json_field_name = ct.default_json_field_name
-default_index_params = ct.default_index
-vectors = [[random.random() for _ in range(default_dim)] for _ in range(default_nq)]
-uid = "test_search"
-nq = 1
-epsilon = 0.001
-field_name = default_float_vec_field_name
-binary_field_name = default_binary_vec_field_name
-search_param = {"nprobe": 1}
-entity = gen_entities(1, is_normal=True)
-entities = gen_entities(default_nb, is_normal=True)
-raw_vectors, binary_entities = gen_binary_entities(default_nb)
-default_query, _ = gen_search_vectors_params(field_name, entities, default_top_k, nq)
-index_name1 = cf.gen_unique_str("float")
-index_name2 = cf.gen_unique_str("varhar")
-half_nb = ct.default_nb // 2
-max_hybrid_search_req_num = ct.max_hybrid_search_req_num
+field_name = ct.default_float_vec_field_name
+
+# Sentinel values for expected search results
+NOT_LOADED = "not_loaded"
+NOT_FOUND = "not_found"
+# Special sentinel: search on [p1, p2] with a specific error code/msg
+NOT_LOADED_999 = "not_loaded_999"
+NOT_FOUND_999 = "not_found_999"
 
 
-class TestCollectionLoadOperation(TestcaseBase):
+class TestSearchLoadIndependent(TestMilvusClientV2Base):
     """ Test case of search combining load and other functions """
 
-    @pytest.mark.tags(CaseLabel.L2)
-    def test_delete_load_collection_release_partition(self):
+    def _create_collection_with_partitions_and_data(self, client, nb=200, partition_num=1,
+                                                     is_index=False, dim=default_dim):
         """
-        target: test delete load collection release partition
-        method: 1. create a collection and 2 partitions
-                2. insert data
-                3. delete half data in each partition
-                4. load the collection
-                5. release one partition
-                6. search
-        expected: No exception
+        Helper: create a collection with default schema, partition_num extra partitions,
+        insert data split evenly across all partitions (including _default), optionally create
+        index and load.
+        Returns (collection_name, partition_names_list, data_per_partition_count).
+        partition_names_list[0] = "_default", partition_names_list[1] = "search_partition_0", etc.
         """
-        # insert data
-        collection_w = self.init_collection_general(
-            prefix, True, 200, partition_num=1, is_index=False)[0]
-        partition_w1, partition_w2 = collection_w.partitions
-        collection_w.create_index(default_search_field, ct.default_flat_index)
-        # delete data
-        delete_ids = [i for i in range(50, 150)]
-        collection_w.delete(f"int64 in {delete_ids}")
-        # load && release
-        collection_w.load()
-        partition_w1.release()
-        # search on collection, partition1, partition2
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": 1, "limit": 50})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w1.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not loaded'})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w2.name],
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": 1, "limit": 50})
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        # Create schema
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        schema.add_field(ct.default_int64_field_name, DataType.INT64, is_primary=True)
+        schema.add_field(ct.default_float_field_name, DataType.FLOAT)
+        schema.add_field(ct.default_string_field_name, DataType.VARCHAR, max_length=65535)
+        schema.add_field(ct.default_json_field_name, DataType.JSON)
+        schema.add_field(ct.default_float_vec_field_name, DataType.FLOAT_VECTOR, dim=dim)
+        self.create_collection(client, collection_name, schema=schema)
+
+        # Create extra partitions
+        partition_names = ["_default"]
+        for i in range(partition_num):
+            p_name = f"search_partition_{i}"
+            self.create_partition(client, collection_name, partition_name=p_name)
+            partition_names.append(p_name)
+
+        total_partitions = len(partition_names)
+        per_partition = nb // total_partitions
+
+        # Insert data evenly across partitions
+        if nb > 0:
+            start = 0
+            for p_name in partition_names:
+                data = cf.gen_default_rows_data(nb=per_partition, dim=dim, start=start, with_json=True)
+                self.insert(client, collection_name, data=data, partition_name=p_name)
+                start += per_partition
+            self.flush(client, collection_name)
+
+        if is_index:
+            idx = self.prepare_index_params(client)[0]
+            idx.add_index(field_name=ct.default_float_vec_field_name, metric_type="COSINE",
+                          index_type="FLAT", params={})
+            self.create_index(client, collection_name, index_params=idx)
+            self.load_collection(client, collection_name)
+
+        return collection_name, partition_names, per_partition
+
+    def _create_index_flat(self, client, collection_name):
+        """Helper: create a FLAT index on the default float vector field."""
+        idx = self.prepare_index_params(client)[0]
+        idx.add_index(field_name=ct.default_float_vec_field_name, metric_type="COSINE",
+                      index_type="FLAT", params={})
+        self.create_index(client, collection_name, index_params=idx)
+
+    def _do_search(self, client, collection_name, partition_names, limit, expected):
+        """Execute a single search and verify against expected result."""
+        if expected == NOT_LOADED:
+            self.search(client, collection_name, data=cf.gen_vectors(1, default_dim),
+                        anns_field=field_name, search_params=default_search_params, limit=limit,
+                        partition_names=partition_names,
+                        check_task=CheckTasks.err_res,
+                        check_items={ct.err_code: 1, ct.err_msg: 'not loaded',
+                                     "enable_milvus_client_api": True})
+        elif expected == NOT_FOUND:
+            self.search(client, collection_name, data=cf.gen_vectors(1, default_dim),
+                        anns_field=field_name, search_params=default_search_params, limit=limit,
+                        partition_names=partition_names,
+                        check_task=CheckTasks.err_res,
+                        check_items={ct.err_code: 1, ct.err_msg: 'not found',
+                                     "enable_milvus_client_api": True})
+        elif expected == NOT_LOADED_999:
+            self.search(client, collection_name, data=cf.gen_vectors(1, default_dim),
+                        anns_field=field_name, search_params=default_search_params, limit=limit,
+                        partition_names=partition_names,
+                        check_task=CheckTasks.err_res,
+                        check_items={ct.err_code: 999,
+                                     ct.err_msg: 'failed to search: collection not loaded',
+                                     "enable_milvus_client_api": True})
+        elif expected == NOT_FOUND_999:
+            # partition not found with error code 999, msg includes partition name
+            p2_name = partition_names[-1] if partition_names else ""
+            self.search(client, collection_name, data=cf.gen_vectors(1, default_dim),
+                        anns_field=field_name, search_params=default_search_params, limit=limit,
+                        partition_names=partition_names,
+                        check_task=CheckTasks.err_res,
+                        check_items={ct.err_code: 999,
+                                     ct.err_msg: f'partition name {p2_name} not found',
+                                     "enable_milvus_client_api": True})
+        elif isinstance(expected, str) and expected == "not_loaded_65535":
+            self.search(client, collection_name, data=cf.gen_vectors(1, default_dim),
+                        anns_field=field_name, search_params=default_search_params, limit=limit,
+                        partition_names=partition_names,
+                        check_task=CheckTasks.err_res,
+                        check_items={ct.err_code: 65535,
+                                     ct.err_msg: "collection not loaded",
+                                     "enable_milvus_client_api": True})
+        else:
+            # expected is an integer: the expected result count
+            self.search(client, collection_name, data=cf.gen_vectors(1, default_dim),
+                        anns_field=field_name, search_params=default_search_params, limit=limit,
+                        partition_names=partition_names,
+                        check_task=CheckTasks.check_search_results,
+                        check_items={"nq": 1, "limit": expected, "enable_milvus_client_api": True,
+                                     "metric": "COSINE", "pk_name": ct.default_int64_field_name})
+
+    def _run_search_assertions(self, client, collection_name, p1_name, p2_name, limit,
+                               expected_collection, expected_p1, expected_p2,
+                               search_collection_partitions=None):
+        """
+        Run search on collection (no partition filter), p1, and p2 and verify expected results.
+        search_collection_partitions: if set, override partition_names for the collection-level search.
+        """
+        # Search on collection
+        coll_partitions = search_collection_partitions
+        self._do_search(client, collection_name, coll_partitions, limit, expected_collection)
+        # Search on p1
+        self._do_search(client, collection_name, [p1_name], limit, expected_p1)
+        # Search on p2
+        self._do_search(client, collection_name, [p2_name], limit, expected_p2)
+
+    # ==================================================================================
+    # Group 1: Delete-based tests (nb=200, partition_num=1, delete IDs 50-150)
+    # Each test: create collection, create index, execute ops, then search on collection/p1/p2
+    # ==================================================================================
+
+    # Parameters: (test_name, ops_sequence, expected_collection, expected_p1, expected_p2,
+    #              search_collection_partitions_override)
+    # ops_sequence is a list of operation tuples: (op_name, *args)
+    # search_collection_partitions_override: None means no partition filter on collection search,
+    #   "both" means [p1, p2], "p1p2" means [p1, p2]
+
+    _DELETE_IDS = list(range(50, 150))
 
     @pytest.mark.tags(CaseLabel.L1)
-    def test_delete_load_collection_release_collection(self):
-        """
-        target: test delete load collection release collection
-        method: 1. create a collection and 2 partitions
-                2. insert data
-                3. delete half data in each partition
-                4. load the collection
-                5. release the collection
-                6. load one partition
-                7. search
-        expected: No exception
-        """
-        # insert data
-        collection_w = self.init_collection_general(
-            prefix, True, 200, partition_num=1, is_index=False)[0]
-        partition_w1, partition_w2 = collection_w.partitions
-        collection_w.create_index(default_search_field, ct.default_flat_index)
-        # delete data
-        delete_ids = [i for i in range(50, 150)]
-        collection_w.delete(f"int64 in {delete_ids}")
-        # load && release
-        collection_w.load()
-        collection_w.release()
-        partition_w2.load()
-        # search on collection, partition1, partition2
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": 1, "limit": 50})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w1.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not loaded'})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w2.name],
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": 1, "limit": 50})
+    @pytest.mark.parametrize("ops,expected_coll,expected_p1,expected_p2,coll_search_parts", [
+        # test_delete_load_collection_release_collection
+        pytest.param(
+            [("delete",), ("load_collection",), ("release_collection",), ("load_p2",)],
+            50, NOT_LOADED, 50, None,
+            id="delete_load_collection_release_collection_load_p2"),
+        # test_load_collection_delete_release_partition
+        pytest.param(
+            [("load_collection",), ("delete",), ("release_p1",)],
+            NOT_LOADED, NOT_LOADED, 50, "both",
+            id="load_collection_delete_release_partition"),
+        # test_load_partition_delete_release_collection (uses query, handled separately below)
+        # test_load_collection_release_partition_delete
+        pytest.param(
+            [("load_collection",), ("release_p1",), ("delete",)],
+            50, NOT_LOADED, 50, None,
+            id="load_collection_release_partition_delete"),
+    ])
+    def test_search_after_delete_ops_l1(self, ops, expected_coll, expected_p1, expected_p2,
+                                        coll_search_parts):
+        """Parametrized L1 tests: delete + load/release operation sequences."""
+        client = self._client()
+        collection_name, partition_names, _ = \
+            self._create_collection_with_partitions_and_data(client, nb=200, partition_num=1, is_index=False)
+        p1_name, p2_name = partition_names[0], partition_names[1]
+        self._create_index_flat(client, collection_name)
+        delete_ids = self._DELETE_IDS
+        for op in ops:
+            self._execute_op(client, collection_name, p1_name, p2_name, delete_ids, op)
+        parts = [p1_name, p2_name] if coll_search_parts == "both" else None
+        self._run_search_assertions(client, collection_name, p1_name, p2_name, 200,
+                                    expected_coll, expected_p1, expected_p2,
+                                    search_collection_partitions=parts)
 
     @pytest.mark.tags(CaseLabel.L2)
-    def test_delete_load_partition_release_collection(self):
-        """
-        target: test delete load partition release collection
-        method: 1. create a collection and 2 partitions
-                2. insert data
-                3. delete half data in each partition
-                4. load one partition
-                5. release the collection
-                6. search
-        expected: No exception
-        """
-        # insert data
-        collection_w = self.init_collection_general(
-            prefix, True, 200, partition_num=1, is_index=False)[0]
-        partition_w1, partition_w2 = collection_w.partitions
-        collection_w.create_index(default_search_field, ct.default_flat_index)
-        # delete data
-        delete_ids = [i for i in range(50, 150)]
-        collection_w.delete(f"int64 in {delete_ids}")
-        # load && release
-        partition_w1.load()
-        collection_w.release()
-        # search on collection, partition1, partition2
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not loaded'})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w1.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not loaded'})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w2.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not loaded'})
-
-    @pytest.mark.tags(CaseLabel.L2)
-    def test_delete_release_collection_load_partition(self):
-        """
-        target: test delete load collection release collection
-        method: 1. create a collection and 2 partitions
-                2. insert data
-                3. delete half data in each partition
-                4. load one partition
-                5. release the collection
-                6. load the other partition
-                7. search
-        expected: No exception
-        """
-        # insert data
-        collection_w = self.init_collection_general(
-            prefix, True, 200, partition_num=1, is_index=False)[0]
-        partition_w1, partition_w2 = collection_w.partitions
-        collection_w.create_index(default_search_field, ct.default_flat_index)
-        # delete data
-        delete_ids = [i for i in range(50, 150)]
-        collection_w.delete(f"int64 in {delete_ids}")
-        # load && release
-        partition_w1.load()
-        collection_w.release()
-        partition_w2.load()
-        # search on collection, partition1, partition2
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": 1, "limit": 50})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w1.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not loaded'})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w2.name],
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": 1, "limit": 50})
-
-    @pytest.mark.tags(CaseLabel.L2)
-    def test_delete_load_partition_drop_partition(self):
-        """
-        target: test delete load partition drop partition
-        method: 1. create a collection and 2 partitions
-                2. insert data
-                3. delete half data in each partition
-                4. load one partition
-                5. release the collection
-                6. search
-        expected: No exception
-        """
-        # insert data
-        collection_w = self.init_collection_general(
-            prefix, True, 200, partition_num=1, is_index=False)[0]
-        partition_w1, partition_w2 = collection_w.partitions
-        collection_w.create_index(default_search_field, default_index_params)
-        # delete data
-        delete_ids = [i for i in range(50, 150)]
-        collection_w.delete(f"int64 in {delete_ids}")
-        # load && release
-        partition_w2.load()
-        partition_w2.release()
-        partition_w2.drop()
-        # search on collection, partition1, partition2
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not loaded'})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w1.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not loaded'})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w2.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not found'})
-
-    @pytest.mark.tags(CaseLabel.L1)
-    def test_load_collection_delete_release_partition(self):
-        """
-        target: test delete load collection release partition
-        method: 1. create a collection and 2 partitions
-                2. insert data
-                3. load the collection
-                4. delete half data in each partition
-                5. release one partition
-                6. search
-        expected: No exception
-        """
-        # insert data
-        collection_w = self.init_collection_general(
-            prefix, True, 200, partition_num=1, is_index=False)[0]
-        partition_w1, partition_w2 = collection_w.partitions
-        collection_w.create_index(default_search_field, ct.default_flat_index)
-        # load
-        collection_w.load()
-        # delete data
-        delete_ids = [i for i in range(50, 150)]
-        collection_w.delete(f"int64 in {delete_ids}")
-        # release
-        partition_w1.release()
-        # search on collection, partition1, partition2
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[
-                                partition_w1.name, partition_w2.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not loaded'})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w1.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not loaded'})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w2.name],
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": 1, "limit": 50})
+    @pytest.mark.parametrize("ops,expected_coll,expected_p1,expected_p2,coll_search_parts", [
+        # test_delete_load_collection_release_partition
+        pytest.param(
+            [("delete",), ("load_collection",), ("release_p1",)],
+            50, NOT_LOADED, 50, None,
+            id="delete_load_collection_release_partition"),
+        # test_delete_load_partition_release_collection
+        pytest.param(
+            [("delete",), ("load_p1",), ("release_collection",)],
+            NOT_LOADED, NOT_LOADED, NOT_LOADED, None,
+            id="delete_load_partition_release_collection"),
+        # test_delete_release_collection_load_partition
+        pytest.param(
+            [("delete",), ("load_p1",), ("release_collection",), ("load_p2",)],
+            50, NOT_LOADED, 50, None,
+            id="delete_release_collection_load_partition"),
+        # test_delete_load_partition_drop_partition
+        pytest.param(
+            [("delete",), ("load_p2",), ("release_p2",), ("drop_p2",)],
+            NOT_LOADED, NOT_LOADED, NOT_FOUND, None,
+            id="delete_load_partition_drop_partition"),
+        # test_load_partition_delete_drop_partition
+        pytest.param(
+            [("load_p1",), ("delete",), ("drop_p2",)],
+            50, 50, NOT_FOUND, None,
+            id="load_partition_delete_drop_partition"),
+        # test_load_partition_release_collection_delete
+        pytest.param(
+            [("load_p1",), ("release_collection",), ("delete",), ("load_collection",)],
+            100, 50, 50, "both",
+            id="load_partition_release_collection_delete"),
+    ])
+    def test_search_after_delete_ops_l2(self, ops, expected_coll, expected_p1, expected_p2,
+                                        coll_search_parts):
+        """Parametrized L2 tests: delete + load/release operation sequences."""
+        client = self._client()
+        collection_name, partition_names, _ = \
+            self._create_collection_with_partitions_and_data(client, nb=200, partition_num=1, is_index=False)
+        p1_name, p2_name = partition_names[0], partition_names[1]
+        self._create_index_flat(client, collection_name)
+        delete_ids = self._DELETE_IDS
+        for op in ops:
+            self._execute_op(client, collection_name, p1_name, p2_name, delete_ids, op)
+        parts = [p1_name, p2_name] if coll_search_parts == "both" else None
+        self._run_search_assertions(client, collection_name, p1_name, p2_name, 200,
+                                    expected_coll, expected_p1, expected_p2,
+                                    search_collection_partitions=parts)
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_load_partition_delete_release_collection(self):
         """
-        target: test delete load collection release partition
-        method: 1. create a collection and 2 partitions
-                2. insert data
-                3. load one partition
-                4. delete half data in each partition
-                5. release the collection and load one partition
-                6. search
-        expected: No exception
+        target: test load partition, delete, release collection, reload partition, then query/search
+        method: Uses query (count) on collection and p1, search on p2
+        expected: count=50 on collection and p1, not_loaded on p2
         """
-        # insert data
-        collection_w = self.init_collection_general(
-            prefix, True, 200, partition_num=1, is_index=False)[0]
-        partition_w1, partition_w2 = collection_w.partitions
-        collection_w.create_index(default_search_field, default_index_params)
-        # load
-        partition_w1.load()
-        # delete data
-        delete_ids = [i for i in range(50, 150)]
-        collection_w.delete(f"int64 in {delete_ids}")
-        # release
-        collection_w.release()
-        partition_w1.load()
-        # search on collection, partition1, partition2
-        collection_w.query(expr='', output_fields=[ct.default_count_output],
-                           check_task=CheckTasks.check_query_results,
-                           check_items={"exp_res": [{ct.default_count_output: 50}]})
-        partition_w1.query(expr='', output_fields=[ct.default_count_output],
-                           check_task=CheckTasks.check_query_results,
-                           check_items={"exp_res": [{ct.default_count_output: 50}]})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w2.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not loaded'})
-
-    @pytest.mark.tags(CaseLabel.L2)
-    def test_load_partition_delete_drop_partition(self):
-        """
-        target: test load partition delete drop partition
-        method: 1. create a collection and 2 partitions
-                2. insert data
-                3. load one partition
-                4. delete half data in each partition
-                5. drop the non-loaded partition
-                6. search
-        expected: No exception
-        """
-        # insert data
-        collection_w = self.init_collection_general(
-            prefix, True, 200, partition_num=1, is_index=False)[0]
-        partition_w1, partition_w2 = collection_w.partitions
-        collection_w.create_index(default_search_field, ct.default_flat_index)
-        # load
-        partition_w1.load()
-        # delete data
-        delete_ids = [i for i in range(50, 150)]
-        collection_w.delete(f"int64 in {delete_ids}")
-        # release
-        partition_w2.drop()
-        # search on collection, partition1, partition2
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": 1, "limit": 50})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w1.name],
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": 1, "limit": 50})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w2.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not found'})
-
-    @pytest.mark.tags(CaseLabel.L1)
-    def test_load_collection_release_partition_delete(self):
-        """
-        target: test load collection release partition delete
-        method: 1. create a collection and 2 partitions
-                2. insert data
-                3. load the collection
-                4. release one partition
-                5. delete half data in each partition
-                6. search
-        expected: No exception
-        """
-        # insert data
-        collection_w = self.init_collection_general(
-            prefix, True, 200, partition_num=1, is_index=False)[0]
-        partition_w1, partition_w2 = collection_w.partitions
-        collection_w.create_index(default_search_field, ct.default_flat_index)
-        # load && release
-        collection_w.load()
-        partition_w1.release()
-        # delete data
-        delete_ids = [i for i in range(50, 150)]
-        collection_w.delete(f"int64 in {delete_ids}")
-        # search on collection, partition1, partition2
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": 1, "limit": 50})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w1.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not loaded'})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w2.name],
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": 1, "limit": 50})
-
-    @pytest.mark.tags(CaseLabel.L2)
-    def test_load_partition_release_collection_delete(self):
-        """
-        target: test load partition release collection delete
-        method: 1. create a collection and 2 partitions
-                2. insert data
-                3. load one partition
-                4. release the collection
-                5. delete half data in each partition
-                6. search
-        expected: No exception
-        """
-        # insert data
-        collection_w = self.init_collection_general(
-            prefix, True, 200, partition_num=1, is_index=False)[0]
-        partition_w1, partition_w2 = collection_w.partitions
-        collection_w.create_index(default_search_field, ct.default_flat_index)
-        # load && release
-        partition_w1.load()
-        collection_w.release()
-        # delete data
-        delete_ids = [i for i in range(50, 150)]
-        collection_w.delete(f"int64 in {delete_ids}")
-        collection_w.load()
-        # search on collection, partition1, partition2
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[
-                                partition_w1.name, partition_w2.name],
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": 1, "limit": 100})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w1.name],
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": 1, "limit": 50})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w2.name],
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": 1, "limit": 50})
+        client = self._client()
+        collection_name, partition_names, _ = \
+            self._create_collection_with_partitions_and_data(client, nb=200, partition_num=1, is_index=False)
+        p1_name, p2_name = partition_names[0], partition_names[1]
+        self._create_index_flat(client, collection_name)
+        self.load_partitions(client, collection_name, partition_names=[p1_name])
+        delete_ids = self._DELETE_IDS
+        self.delete(client, collection_name, filter=f"{ct.default_int64_field_name} in {delete_ids}")
+        self.release_collection(client, collection_name)
+        self.load_partitions(client, collection_name, partition_names=[p1_name])
+        # query on collection and p1
+        self.query(client, collection_name, filter='',
+                   output_fields=[ct.default_count_output],
+                   check_task=CheckTasks.check_query_results,
+                   check_items={"exp_res": [{ct.default_count_output: 50}],
+                                "enable_milvus_client_api": True})
+        self.query(client, collection_name, filter='',
+                   output_fields=[ct.default_count_output],
+                   partition_names=[p1_name],
+                   check_task=CheckTasks.check_query_results,
+                   check_items={"exp_res": [{ct.default_count_output: 50}],
+                                "enable_milvus_client_api": True})
+        self.search(client, collection_name, data=cf.gen_vectors(1, default_dim),
+                    anns_field=field_name, search_params=default_search_params, limit=200,
+                    partition_names=[p2_name],
+                    check_task=CheckTasks.err_res,
+                    check_items={ct.err_code: 1, ct.err_msg: 'not loaded',
+                                 "enable_milvus_client_api": True})
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_load_partition_drop_partition_delete(self):
         """
-        target: test load partition drop partition delete
-        method: 1. create a collection and 2 partitions
-                2. insert data
-                3. load one partition
-                4. release and drop the partition
-                5. delete half data in each partition
-                6. search
-        expected: No exception
+        target: test load partition drop partition delete (custom schema, no data inserted)
+        method: create collection with 2 custom partitions, load p2, release+drop p2, search
+        expected: p1+p2 search returns partition not found, p1 returns not loaded, p2 returns not found
         """
-        # insert data
-        collection_w = self.init_collection_wrap(name=prefix)
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        schema.add_field(ct.default_int64_field_name, DataType.INT64, is_primary=True)
+        schema.add_field(ct.default_float_field_name, DataType.FLOAT)
+        schema.add_field(ct.default_string_field_name, DataType.VARCHAR, max_length=65535)
+        schema.add_field(ct.default_json_field_name, DataType.JSON)
+        schema.add_field(ct.default_float_vec_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
+        self.create_collection(client, collection_name, schema=schema)
         p1_name = cf.gen_unique_str("par1")
-        partition_w1 = self.init_partition_wrap(collection_w, name=p1_name)
+        self.create_partition(client, collection_name, partition_name=p1_name)
         p2_name = cf.gen_unique_str("par2")
-        partition_w2 = self.init_partition_wrap(collection_w, name=p2_name)
-        collection_w.create_index(default_search_field, default_index_params)
-        # load && release
-        partition_w2.load()
-        partition_w2.release()
-        partition_w2.drop()
-        # search on collection, partition1, partition2
-        collection_w.search(vectors[:1], field_name, default_search_params, 10,
-                            partition_names=[partition_w1.name, partition_w2.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 999, ct.err_msg: f'partition name {partition_w2.name} not found'})
-        collection_w.search(vectors[:1], field_name, default_search_params, 10,
-                            partition_names=[partition_w1.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 999, ct.err_msg: 'failed to search: collection not loaded'})
-        collection_w.search(vectors[:1], field_name, default_search_params, 10,
-                            partition_names=[partition_w2.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 999, ct.err_msg: f'partition name {partition_w2.name} not found'})
+        self.create_partition(client, collection_name, partition_name=p2_name)
+        self._create_index_flat(client, collection_name)
+        self.load_partitions(client, collection_name, partition_names=[p2_name])
+        self.release_partitions(client, collection_name, partition_names=[p2_name])
+        self.drop_partition(client, collection_name, partition_name=p2_name)
+        # search on [p1, p2]
+        self._do_search(client, collection_name, [p1_name, p2_name], 10, NOT_FOUND_999)
+        # search on p1
+        self._do_search(client, collection_name, [p1_name], 10, NOT_LOADED_999)
+        # search on p2
+        self._do_search(client, collection_name, [p2_name], 10, NOT_FOUND_999)
 
-    @pytest.mark.tags(CaseLabel.L2)
-    def test_compact_load_collection_release_partition(self):
-        """
-        target: test compact load collection release partition
-        method: 1. create a collection and 2 partitions
-                2. insert data multi times
-                3. compact
-                4. load the collection
-                5. release one partition
-                6. search
-        expected: No exception
-        """
-        collection_w = self.init_collection_general(prefix, partition_num=1)[0]
-        partition_w1, partition_w2 = collection_w.partitions
-        df = cf.gen_default_dataframe_data()
-        # insert data
-        partition_w1.insert(df[:100])
-        partition_w1.insert(df[100:200])
-        partition_w2.insert(df[200:300])
-        # compact
-        collection_w.compact()
-        collection_w.get_compaction_state()
-        # load && release
-        collection_w.load()
-        partition_w1.release()
-        # search on collection, partition1, partition2
-        collection_w.search(vectors[:1], field_name, default_search_params, 300,
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": 1, "limit": 100})
-        collection_w.search(vectors[:1], field_name, default_search_params, 300,
-                            partition_names=[partition_w1.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not loaded'})
-        collection_w.search(vectors[:1], field_name, default_search_params, 300,
-                            partition_names=[partition_w2.name],
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": 1, "limit": 100})
+    # ==================================================================================
+    # Group 2: Compact-based tests (nb=0, multi-batch insert, compact)
+    # Data: 200 rows in p1 (2 batches of 100), 100 rows in p2
+    # ==================================================================================
 
-    @pytest.mark.tags(CaseLabel.L2)
-    def test_compact_load_collection_release_collection(self):
-        """
-        target: test compact load collection release collection
-        method: 1. create a collection and 2 partitions
-                2. insert data multi times
-                3. compact
-                4. load the collection
-                5. release the collection
-                6. load one partition
-                7. search
-        expected: No exception
-        """
-        collection_w = self.init_collection_general(prefix, partition_num=1)[0]
-        partition_w1, partition_w2 = collection_w.partitions
-        df = cf.gen_default_dataframe_data()
-        # insert data
-        partition_w1.insert(df[:100])
-        partition_w1.insert(df[100:200])
-        partition_w2.insert(df[200:300])
-        # compact
-        collection_w.compact()
-        collection_w.get_compaction_state()
-        # load && release
-        collection_w.load()
-        collection_w.release()
-        partition_w1.load()
-        # search on collection, partition1, partition2
-        collection_w.search(vectors[:1], field_name, default_search_params, 300,
-                            partition_names=[
-                                partition_w1.name, partition_w2.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not loaded'})
-        collection_w.search(vectors[:1], field_name, default_search_params, 300,
-                            partition_names=[partition_w1.name],
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": 1, "limit": 200})
-        collection_w.search(vectors[:1], field_name, default_search_params, 300,
-                            partition_names=[partition_w2.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not loaded'})
-
-    @pytest.mark.tags(CaseLabel.L2)
-    def test_compact_load_partition_release_collection(self):
-        """
-        target: test compact load partition release collection
-        method: 1. create a collection and 2 partitions
-                2. insert data multi times
-                3. compact
-                4. load one partition
-                5. release the collection
-                6. search
-        expected: No exception
-        """
-        collection_w = self.init_collection_general(prefix, partition_num=1)[0]
-        partition_w1, partition_w2 = collection_w.partitions
-        df = cf.gen_default_dataframe_data()
-        # insert data
-        partition_w1.insert(df[:100])
-        partition_w1.insert(df[100:200])
-        partition_w2.insert(df[200:300])
-        # compact
-        collection_w.compact()
-        collection_w.get_compaction_state()
-        # load && release
-        partition_w2.load()
-        collection_w.release()
-        partition_w1.load()
-        partition_w2.load()
-        # search on collection, partition1, partition2
-        collection_w.search(vectors[:1], field_name, default_search_params, 300,
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": 1, "limit": 300})
-        collection_w.search(vectors[:1], field_name, default_search_params, 300,
-                            partition_names=[partition_w1.name],
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": 1, "limit": 200})
-        collection_w.search(vectors[:1], field_name, default_search_params, 300,
-                            partition_names=[partition_w2.name],
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": 1, "limit": 100})
-
-    @pytest.mark.tags(CaseLabel.L2)
-    def test_load_collection_compact_drop_partition(self):
-        """
-        target: test load collection compact drop partition
-        method: 1. create a collection and 2 partitions
-                2. insert data multi times
-                3. load the collection
-                4. compact
-                5. release one partition and drop
-                6. search
-        expected: No exception
-        """
-        collection_w = self.init_collection_general(prefix, partition_num=1)[0]
-        partition_w1, partition_w2 = collection_w.partitions
-        df = cf.gen_default_dataframe_data()
-        # insert data
-        partition_w1.insert(df[:100])
-        partition_w1.insert(df[100:200])
-        partition_w2.insert(df[200:300])
-        # load
-        collection_w.load()
-        # compact
-        collection_w.compact()
-        collection_w.get_compaction_state()
-        # release
-        partition_w2.release()
-        partition_w2.drop()
-        # search on collection, partition1, partition2
-        collection_w.search(vectors[:1], field_name, default_search_params, 300,
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": 1, "limit": 200})
-        collection_w.search(vectors[:1], field_name, default_search_params, 300,
-                            partition_names=[partition_w1.name],
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": 1, "limit": 200})
-        collection_w.search(vectors[:1], field_name, default_search_params, 300,
-                            partition_names=[partition_w2.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not found'})
-
-    @pytest.mark.tags(CaseLabel.L2)
-    def test_load_partition_compact_release_collection(self):
-        """
-        target: test load partition compact release collection
-        method: 1. create a collection and 2 partitions
-                2. insert data multi times
-                3. load one partition
-                4. compact
-                5. release the collection
-                6. search
-        expected: No exception
-        """
-        collection_w = self.init_collection_general(prefix, partition_num=1)[0]
-        partition_w1, partition_w2 = collection_w.partitions
-        df = cf.gen_default_dataframe_data()
-        # insert data
-        partition_w1.insert(df[:100])
-        partition_w1.insert(df[100:200])
-        partition_w2.insert(df[200:300])
-        # load
-        partition_w2.load()
-        # compact
-        collection_w.compact()
-        collection_w.get_compaction_state()
-        # release
-        collection_w.release()
-        partition_w2.release()
-        # search on collection, partition1, partition2
-        collection_w.search(vectors[:1], field_name, default_search_params, 300,
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not loaded'})
-        collection_w.search(vectors[:1], field_name, default_search_params, 300,
-                            partition_names=[partition_w1.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not loaded'})
-        collection_w.search(vectors[:1], field_name, default_search_params, 300,
-                            partition_names=[partition_w2.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not loaded'})
+    def _setup_compact_test(self, client):
+        """Setup for compact tests: create collection, insert multi-batch, flush."""
+        collection_name, partition_names, _ = \
+            self._create_collection_with_partitions_and_data(client, nb=0, partition_num=1, is_index=True)
+        p1_name, p2_name = partition_names[0], partition_names[1]
+        self.release_collection(client, collection_name)
+        data1 = cf.gen_default_rows_data(nb=100, dim=default_dim, start=0, with_json=True)
+        self.insert(client, collection_name, data=data1, partition_name=p1_name)
+        data2 = cf.gen_default_rows_data(nb=100, dim=default_dim, start=100, with_json=True)
+        self.insert(client, collection_name, data=data2, partition_name=p1_name)
+        data3 = cf.gen_default_rows_data(nb=100, dim=default_dim, start=200, with_json=True)
+        self.insert(client, collection_name, data=data3, partition_name=p2_name)
+        self.flush(client, collection_name)
+        return collection_name, p1_name, p2_name
 
     @pytest.mark.tags(CaseLabel.L1)
-    def test_load_collection_release_partition_compact(self):
-        """
-        target: test load collection release partition compact
-        method: 1. create a collection and 2 partitions
-                2. insert data multi times
-                3. load the collection
-                4. release one partition
-                5. compact
-                6. search
-        expected: No exception
-        """
-        collection_w = self.init_collection_general(prefix, partition_num=1)[0]
-        partition_w1, partition_w2 = collection_w.partitions
-        df = cf.gen_default_dataframe_data()
-        # insert data
-        partition_w1.insert(df[:100])
-        partition_w1.insert(df[100:200])
-        partition_w2.insert(df[200:300])
-        # load && release
-        collection_w.load()
-        partition_w1.release()
-        # compact
-        collection_w.compact()
-        collection_w.get_compaction_state()
-        # search on collection, partition1, partition2
-        collection_w.search(vectors[:1], field_name, default_search_params, 300,
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": 1, "limit": 100})
-        collection_w.search(vectors[:1], field_name, default_search_params, 300,
-                            partition_names=[partition_w1.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not loaded'})
-        collection_w.search(vectors[:1], field_name, default_search_params, 300,
-                            partition_names=[partition_w2.name],
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": 1, "limit": 100})
+    @pytest.mark.parametrize("ops,expected_coll,expected_p1,expected_p2,coll_search_parts", [
+        # test_load_collection_release_partition_compact
+        pytest.param(
+            [("load_collection",), ("release_p1",), ("compact",)],
+            100, NOT_LOADED, 100, None,
+            id="load_collection_release_partition_compact"),
+    ])
+    def test_search_after_compact_ops_l1(self, ops, expected_coll, expected_p1, expected_p2,
+                                          coll_search_parts):
+        """Parametrized L1 tests: compact + load/release operation sequences."""
+        client = self._client()
+        collection_name, p1_name, p2_name = self._setup_compact_test(client)
+        for op in ops:
+            self._execute_compact_op(client, collection_name, p1_name, p2_name, op)
+        parts = [p1_name, p2_name] if coll_search_parts == "both" else None
+        self._run_search_assertions(client, collection_name, p1_name, p2_name, 300,
+                                    expected_coll, expected_p1, expected_p2,
+                                    search_collection_partitions=parts)
 
     @pytest.mark.tags(CaseLabel.L2)
-    def test_flush_load_collection_release_partition(self):
-        """
-        target: test delete load collection release partition
-        method: 1. create a collection and 2 partitions
-                2. insert data
-                3. flush
-                4. load the collection
-                5. release one partition
-                6. search
-        expected: No exception
-        """
-        # insert data
-        collection_w = self.init_collection_general(
-            prefix, True, 200, partition_num=1, is_index=False)[0]
-        partition_w1, partition_w2 = collection_w.partitions
-        collection_w.create_index(default_search_field, ct.default_flat_index)
-        # flush
-        collection_w.flush()
-        # load && release
-        collection_w.load()
-        partition_w1.release()
-        # search on collection, partition1, partition2
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": 1, "limit": 100})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w1.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not loaded'})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w2.name],
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": 1, "limit": 100})
+    @pytest.mark.parametrize("ops,expected_coll,expected_p1,expected_p2,coll_search_parts", [
+        # test_compact_load_collection_release_partition
+        pytest.param(
+            [("compact",), ("load_collection",), ("release_p1",)],
+            100, NOT_LOADED, 100, None,
+            id="compact_load_collection_release_partition"),
+        # test_compact_load_collection_release_collection
+        pytest.param(
+            [("compact",), ("load_collection",), ("release_collection",), ("load_p1",)],
+            NOT_LOADED, 200, NOT_LOADED, "both",
+            id="compact_load_collection_release_collection_load_p1"),
+        # test_compact_load_partition_release_collection
+        pytest.param(
+            [("compact",), ("load_p2",), ("release_collection",), ("load_p1",), ("load_p2",)],
+            300, 200, 100, None,
+            id="compact_load_partition_release_collection_load_both"),
+        # test_load_collection_compact_drop_partition
+        pytest.param(
+            [("load_collection",), ("compact",), ("release_p2",), ("drop_p2",)],
+            200, 200, NOT_FOUND, None,
+            id="load_collection_compact_drop_partition"),
+        # test_load_partition_compact_release_collection
+        pytest.param(
+            [("load_p2",), ("compact",), ("release_collection",), ("release_p2",)],
+            NOT_LOADED, NOT_LOADED, NOT_LOADED, None,
+            id="load_partition_compact_release_collection"),
+    ])
+    def test_search_after_compact_ops_l2(self, ops, expected_coll, expected_p1, expected_p2,
+                                          coll_search_parts):
+        """Parametrized L2 tests: compact + load/release operation sequences."""
+        client = self._client()
+        collection_name, p1_name, p2_name = self._setup_compact_test(client)
+        for op in ops:
+            self._execute_compact_op(client, collection_name, p1_name, p2_name, op)
+        parts = [p1_name, p2_name] if coll_search_parts == "both" else None
+        self._run_search_assertions(client, collection_name, p1_name, p2_name, 300,
+                                    expected_coll, expected_p1, expected_p2,
+                                    search_collection_partitions=parts)
+
+    # ==================================================================================
+    # Group 3: Flush-based tests (nb=200, partition_num=1, flush + load/release)
+    # Each partition has 100 rows (200 / 2 partitions)
+    # ==================================================================================
+
+    @pytest.mark.tags(CaseLabel.L1)
+    @pytest.mark.parametrize("ops,expected_coll,expected_p1,expected_p2,coll_search_parts", [
+        # test_load_partition_release_collection_flush
+        pytest.param(
+            [("flush",), ("load_p2",), ("release_collection",), ("flush",)],
+            NOT_LOADED, NOT_LOADED, NOT_LOADED, None,
+            id="load_partition_release_collection_flush"),
+        # test_load_partition_drop_partition_flush
+        pytest.param(
+            [("flush",), ("load_p2",), ("release_p2",), ("drop_p2",), ("flush",)],
+            NOT_LOADED, NOT_LOADED, NOT_FOUND, None,
+            id="load_partition_drop_partition_flush"),
+    ])
+    def test_search_after_flush_ops_l1(self, ops, expected_coll, expected_p1, expected_p2,
+                                        coll_search_parts):
+        """Parametrized L1 tests: flush + load/release operation sequences."""
+        client = self._client()
+        collection_name, partition_names, _ = \
+            self._create_collection_with_partitions_and_data(client, nb=200, partition_num=1, is_index=False)
+        p1_name, p2_name = partition_names[0], partition_names[1]
+        self._create_index_flat(client, collection_name)
+        for op in ops:
+            self._execute_op(client, collection_name, p1_name, p2_name, None, op)
+        parts = [p1_name, p2_name] if coll_search_parts == "both" else None
+        self._run_search_assertions(client, collection_name, p1_name, p2_name, 200,
+                                    expected_coll, expected_p1, expected_p2,
+                                    search_collection_partitions=parts)
 
     @pytest.mark.tags(CaseLabel.L2)
-    def test_flush_load_collection_release_collection(self):
-        """
-        target: test delete load collection release partition
-        method: 1. create a collection and 2 partitions
-                2. insert data
-                3. flush
-                4. load the collection
-                5. release the collection
-                6. load one partition
-                7. search
-        expected: No exception
-        """
-        # insert data
-        collection_w = self.init_collection_general(
-            prefix, True, 200, partition_num=1, is_index=False)[0]
-        partition_w1, partition_w2 = collection_w.partitions
-        collection_w.create_index(default_search_field, ct.default_flat_index)
-        # flush
-        collection_w.flush()
-        # load && release
-        collection_w.load()
-        collection_w.release()
-        partition_w2.load()
-        # search on collection, partition1, partition2
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": 1, "limit": 100})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w1.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not loaded'})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w2.name],
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": 1, "limit": 100})
-
-    @pytest.mark.tags(CaseLabel.L2)
-    def test_flush_load_partition_release_collection(self):
-        """
-        target: test delete load collection release partition
-        method: 1. create a collection and 2 partitions
-                2. insert data
-                3. flush
-                4. load one partition
-                5. release the collection
-                6. search
-        expected: No exception
-        """
-        # insert data
-        collection_w = self.init_collection_general(
-            prefix, True, 200, partition_num=1, is_index=False)[0]
-        partition_w1, partition_w2 = collection_w.partitions
-        collection_w.create_index(default_search_field, ct.default_flat_index)
-        # flush
-        collection_w.flush()
-        # load && release
-        partition_w2.load()
-        collection_w.release()
-        # search on collection, partition1, partition2
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not loaded'})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w1.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not loaded'})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w2.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not loaded'})
-
-    @pytest.mark.tags(CaseLabel.L2)
-    def test_flush_load_partition_drop_partition(self):
-        """
-        target: test delete load collection release partition
-        method: 1. create a collection and 2 partitions
-                2. insert data
-                3. flush
-                4. load one partition
-                5. release and drop the partition
-                6. search
-        expected: No exception
-        """
-        # insert data
-        collection_w = self.init_collection_general(
-            prefix, True, 200, partition_num=1, is_index=False)[0]
-        partition_w1, partition_w2 = collection_w.partitions
-        collection_w.create_index(default_search_field, default_index_params)
-        # flush
-        collection_w.flush()
-        # load && release
-        partition_w2.load()
-        partition_w2.release()
-        partition_w2.drop()
-        # search on collection, partition1, partition2
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[
-                                partition_w1.name, partition_w2.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not found'})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w1.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not loaded'})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w2.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not found'})
-
-    @pytest.mark.tags(CaseLabel.L2)
-    def test_flush_load_collection_drop_partition(self):
-        """
-        target: test delete load collection release partition
-        method: 1. create a collection and 2 partitions
-                2. insert data
-                3. flush
-                4. load collection
-                5. release and drop one partition
-                6. search
-        expected: No exception
-        """
-        # insert data
-        collection_w = self.init_collection_general(
-            prefix, True, 200, partition_num=1, is_index=False)[0]
-        partition_w1, partition_w2 = collection_w.partitions
-        collection_w.create_index(default_search_field, ct.default_flat_index)
-        # flush
-        collection_w.flush()
-        # load && release
-        collection_w.load()
-        partition_w2.release()
-        partition_w2.drop()
-        # search on collection, partition1, partition2
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": 1, "limit": 100})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w1.name],
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": 1, "limit": 100})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w2.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not found'})
+    @pytest.mark.parametrize("ops,expected_coll,expected_p1,expected_p2,coll_search_parts", [
+        # test_flush_load_collection_release_partition
+        pytest.param(
+            [("flush",), ("load_collection",), ("release_p1",)],
+            100, NOT_LOADED, 100, None,
+            id="flush_load_collection_release_partition"),
+        # test_flush_load_collection_release_collection
+        pytest.param(
+            [("flush",), ("load_collection",), ("release_collection",), ("load_p2",)],
+            100, NOT_LOADED, 100, None,
+            id="flush_load_collection_release_collection_load_p2"),
+        # test_flush_load_partition_release_collection
+        pytest.param(
+            [("flush",), ("load_p2",), ("release_collection",)],
+            NOT_LOADED, NOT_LOADED, NOT_LOADED, None,
+            id="flush_load_partition_release_collection"),
+        # test_flush_load_partition_drop_partition
+        pytest.param(
+            [("flush",), ("load_p2",), ("release_p2",), ("drop_p2",)],
+            NOT_FOUND, NOT_LOADED, NOT_FOUND, "both",
+            id="flush_load_partition_drop_partition"),
+        # test_flush_load_collection_drop_partition
+        pytest.param(
+            [("flush",), ("load_collection",), ("release_p2",), ("drop_p2",)],
+            100, 100, NOT_FOUND, None,
+            id="flush_load_collection_drop_partition"),
+        # test_load_collection_release_partition_flush
+        pytest.param(
+            [("load_collection",), ("release_p2",), ("flush",)],
+            100, 100, NOT_LOADED, None,
+            id="load_collection_release_partition_flush"),
+        # test_load_collection_release_collection_flush
+        pytest.param(
+            [("load_collection",), ("release_collection",), ("load_p2",), ("flush",)],
+            NOT_LOADED, NOT_LOADED, 100, "both",
+            id="load_collection_release_collection_flush_load_p2"),
+        # test_load_partition_flush_release_collection
+        pytest.param(
+            [("load_p2",), ("flush",), ("release_collection",)],
+            NOT_LOADED, NOT_LOADED, NOT_LOADED, "both",
+            id="load_partition_flush_release_collection"),
+        # test_load_collection_flush_drop_partition
+        pytest.param(
+            [("load_p1",), ("flush",), ("drop_p2",)],
+            100, 100, NOT_FOUND, None,
+            id="load_collection_flush_drop_partition"),
+    ])
+    def test_search_after_flush_ops_l2(self, ops, expected_coll, expected_p1, expected_p2,
+                                        coll_search_parts):
+        """Parametrized L2 tests: flush + load/release operation sequences."""
+        client = self._client()
+        collection_name, partition_names, _ = \
+            self._create_collection_with_partitions_and_data(client, nb=200, partition_num=1, is_index=False)
+        p1_name, p2_name = partition_names[0], partition_names[1]
+        self._create_index_flat(client, collection_name)
+        for op in ops:
+            self._execute_op(client, collection_name, p1_name, p2_name, None, op)
+        parts = [p1_name, p2_name] if coll_search_parts == "both" else None
+        self._run_search_assertions(client, collection_name, p1_name, p2_name, 200,
+                                    expected_coll, expected_p1, expected_p2,
+                                    search_collection_partitions=parts)
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_load_collection_flush_release_partition(self):
         """
-        target: test delete load collection release partition
-        method: 1. create a collection and 2 partitions
-                2. insert data
-                3. load the collection
-                4. flush
-                5. search on the collection -> len(res)==200
-                5. release one partition
-                6. search
-        expected: No exception
+        target: test load collection, flush, search (200 results), release partition, search again
+        method: load collection first, flush, verify 200 results, release p2, verify reduced results
+        expected: first search returns 200, after release p2 returns 100 on collection, p1=100, p2=not_loaded
         """
-        # insert data
-        collection_w = self.init_collection_general(
-            prefix, True, 200, partition_num=1, is_index=False)[0]
-        partition_w1, partition_w2 = collection_w.partitions
-        collection_w.create_index(default_search_field, ct.default_flat_index)
-        # load
-        collection_w.load()
-        # flush
-        collection_w.flush()
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": 1, "limit": 200})
-        # release
-        partition_w2.release()
-        # search on collection, partition1, partition2
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not loaded'})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w1.name],
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": 1, "limit": 100})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w2.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not loaded'})
+        client = self._client()
+        collection_name, partition_names, _ = \
+            self._create_collection_with_partitions_and_data(client, nb=200, partition_num=1, is_index=False)
+        p1_name, p2_name = partition_names[0], partition_names[1]
+        self._create_index_flat(client, collection_name)
+        self.load_collection(client, collection_name)
+        self.flush(client, collection_name)
+        # first search: all loaded, 200 results
+        self._do_search(client, collection_name, None, 200, 200)
+        # release p2
+        self.release_partitions(client, collection_name, partition_names=[p2_name])
+        # search after release
+        self._do_search(client, collection_name, None, 200, 100)
+        self._do_search(client, collection_name, [p1_name], 200, 100)
+        self._do_search(client, collection_name, [p2_name], 200, NOT_LOADED)
 
-    @pytest.mark.tags(CaseLabel.L2)
-    def test_load_partition_flush_release_collection(self):
-        """
-        target: test delete load collection release partition
-        method: 1. create a collection and 2 partitions
-                2. insert data
-                3. load one partition
-                4. flush
-                5. release the collection
-                6. search
-        expected: No exception
-        """
-        # insert data
-        collection_w = self.init_collection_general(
-            prefix, True, 200, partition_num=1, is_index=False)[0]
-        partition_w1, partition_w2 = collection_w.partitions
-        collection_w.create_index(default_search_field, default_index_params)
-        # load
-        partition_w2.load()
-        # flush
-        collection_w.flush()
-        # release
-        collection_w.release()
-        # search on collection, partition1, partition2
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[
-                                partition_w1.name, partition_w2.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not loaded'})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w1.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not loaded'})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w2.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not loaded'})
-
-    @pytest.mark.tags(CaseLabel.L2)
-    def test_load_collection_flush_release_partition(self):
-        """
-        target: test delete load collection release partition
-        method: 1. create a collection and 2 partitions
-                2. insert data
-                3. load one partition
-                4. flush
-                5. drop the non-loaded partition
-                6. search
-        expected: No exception
-        """
-        # insert data
-        collection_w = self.init_collection_general(
-            prefix, True, 200, partition_num=1, is_index=False)[0]
-        partition_w1, partition_w2 = collection_w.partitions
-        collection_w.create_index(default_search_field, ct.default_flat_index)
-        # load
-        partition_w1.load()
-        # flush
-        collection_w.flush()
-        # release
-        partition_w2.drop()
-        # search on collection, partition1, partition2
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": 1, "limit": 100})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w1.name],
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": 1, "limit": 100})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w2.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not found'})
-
-    @pytest.mark.tags(CaseLabel.L2)
-    def test_load_collection_release_partition_flush(self):
-        """
-        target: test delete load collection release partition
-        method: 1. create a collection and 2 partitions
-                2. insert data
-                3. load the collection
-                4. release one partition
-                5. flush
-                6. search
-        expected: No exception
-        """
-        # insert data
-        collection_w = self.init_collection_general(
-            prefix, True, 200, partition_num=1, is_index=False)[0]
-        partition_w1, partition_w2 = collection_w.partitions
-        collection_w.create_index(default_search_field, ct.default_flat_index)
-        # load && release
-        collection_w.load()
-        partition_w2.release()
-        # flush
-        collection_w.flush()
-        # search on collection, partition1, partition2
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": 1, "limit": 100})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w1.name],
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": 1, "limit": 100})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w2.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not loaded'})
-
-    @pytest.mark.tags(CaseLabel.L2)
-    def test_load_collection_release_collection_flush(self):
-        """
-        target: test delete load collection release partition
-        method: 1. create a collection and 2 partitions
-                2. insert data
-                3. load the collection
-                4. release the collection
-                5. load one partition
-                6. flush
-                7. search
-        expected: No exception
-        """
-        # insert data
-        collection_w = self.init_collection_general(
-            prefix, True, 200, partition_num=1, is_index=False)[0]
-        partition_w1, partition_w2 = collection_w.partitions
-        collection_w.create_index(default_search_field, ct.default_flat_index)
-        # load && release
-        collection_w.load()
-        collection_w.release()
-        partition_w2.load()
-        # flush
-        collection_w.flush()
-        # search on collection, partition1, partition2
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[
-                                partition_w1.name, partition_w2.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not loaded'})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w1.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not loaded'})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w2.name],
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": 1, "limit": 100})
-
-    @pytest.mark.tags(CaseLabel.L1)
-    def test_load_partition_release_collection_flush(self):
-        """
-        target: test delete load collection release partition
-        method: 1. create a collection and 2 partitions
-                2. insert data
-                3. load the partition
-                4. release the collection
-                5. flush
-                6. search
-        expected: No exception
-        """
-        # insert data
-        collection_w = self.init_collection_general(
-            prefix, True, 200, partition_num=1, is_index=False)[0]
-        partition_w1, partition_w2 = collection_w.partitions
-        collection_w.create_index(default_search_field, default_index_params)
-        # load && release
-        partition_w2.load()
-        collection_w.release()
-        # flush
-        collection_w.flush()
-        # search on collection, partition1, partition2
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not loaded'})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w1.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not loaded'})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w2.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not loaded'})
-
-    @pytest.mark.tags(CaseLabel.L1)
-    def test_load_partition_drop_partition_flush(self):
-        """
-        target: test delete load collection release partition
-        method: 1. create a collection and 2 partitions
-                2. insert data
-                3. load one partition
-                4. release and drop the partition
-                5. flush
-                6. search
-        expected: No exception
-        """
-        # insert data
-        collection_w = self.init_collection_general(
-            prefix, True, 200, partition_num=1, is_index=False)[0]
-        partition_w1, partition_w2 = collection_w.partitions
-        collection_w.create_index(default_search_field, default_index_params)
-        # load && release
-        partition_w2.load()
-        partition_w2.release()
-        partition_w2.drop()
-        # flush
-        collection_w.flush()
-        # search on collection, partition1, partition2
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not loaded'})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w1.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not loaded'})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w2.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not found'})
+    # ==================================================================================
+    # Group 4: Special / miscellaneous tests
+    # ==================================================================================
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_load_release_collection_multi_times(self):
         """
         target: test load and release multiple times
-        method: 1. create a collection and 2 partitions
-                2. load and release multiple times
-                3. search
-        expected: No exception
+        method: release and load p2 five times, then search
+        expected: collection=100 (p2 only), p1=not_loaded, p2=100
         """
-        # init the collection
-        collection_w = self.init_collection_general(
-            prefix, True, 200, partition_num=1, is_index=False)[0]
-        partition_w1, partition_w2 = collection_w.partitions
-        collection_w.create_index(default_search_field, ct.default_flat_index)
-        # load and release
-        for i in range(5):
-            collection_w.release()
-            partition_w2.load()
-        # search on collection, partition1, partition2
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": 1, "limit": 100})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w1.name],
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 1, ct.err_msg: 'not loaded'})
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            partition_names=[partition_w2.name],
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": 1, "limit": 100})
+        client = self._client()
+        collection_name, partition_names, _ = \
+            self._create_collection_with_partitions_and_data(client, nb=200, partition_num=1, is_index=False)
+        p1_name, p2_name = partition_names[0], partition_names[1]
+        self._create_index_flat(client, collection_name)
+        for _ in range(5):
+            self.release_collection(client, collection_name)
+            self.load_partitions(client, collection_name, partition_names=[p2_name])
+        self._run_search_assertions(client, collection_name, p1_name, p2_name, 200,
+                                    100, NOT_LOADED, 100)
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_load_collection_release_all_partitions(self):
         """
         target: test load and release all partitions
-        method: 1. create a collection and 2 partitions
-                2. load collection and release all partitions
-                3. search
-        expected: No exception
+        method: load collection and release all partitions one by one
+        expected: collection search returns error code 65535, collection not loaded
         """
-        # init the collection
-        collection_w = self.init_collection_general(prefix, True, 200, partition_num=1, is_index=False)[0]
-        partition_w1, partition_w2 = collection_w.partitions
-        collection_w.create_index(default_search_field, default_index_params)
-        # load and release
-        collection_w.load()
-        partition_w1.release()
-        partition_w2.release()
-        # search on collection
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            check_task=CheckTasks.err_res,
-                            check_items={ct.err_code: 65535,
-                                         ct.err_msg: "collection not loaded"})
+        client = self._client()
+        collection_name, partition_names, _ = \
+            self._create_collection_with_partitions_and_data(client, nb=200, partition_num=1, is_index=False)
+        p1_name, p2_name = partition_names[0], partition_names[1]
+        self._create_index_flat(client, collection_name)
+        self.load_collection(client, collection_name)
+        self.release_partitions(client, collection_name, partition_names=[p1_name])
+        self.release_partitions(client, collection_name, partition_names=[p2_name])
+        self._do_search(client, collection_name, None, 200, "not_loaded_65535")
 
     @pytest.mark.tags(CaseLabel.L2)
-    @pytest.mark.skip(reason="issue #24446")
     def test_search_load_collection_create_partition(self):
         """
         target: test load collection and create partition and search
-        method: 1. create a collection and 2 partitions
-                2. load collection and create a partition
-                3. search
-        expected: No exception
+        method: load collection, create a new partition, search
+        expected: search returns 200 results
         """
-        # init the collection
-        collection_w = self.init_collection_general(
-            prefix, True, 200, partition_num=1, is_index=False)[0]
-        partition_w1, partition_w2 = collection_w.partitions
-        collection_w.create_index(default_search_field, ct.default_flat_index)
-        # load and release
-        collection_w.load()
-        partition_w3 = collection_w.create_partition("_default3")[0]
-        # search on collection
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": 1, "limit": 200})
+        client = self._client()
+        collection_name, _, _ = \
+            self._create_collection_with_partitions_and_data(client, nb=200, partition_num=1, is_index=False)
+        self._create_index_flat(client, collection_name)
+        self.load_collection(client, collection_name)
+        self.create_partition(client, collection_name, partition_name=cf.gen_unique_str("partition3"))
+        self._do_search(client, collection_name, None, 200, 200)
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_search_load_partition_create_partition(self):
         """
         target: test load partition and create partition and search
-        method: 1. create a collection and 2 partitions
-                2. load partition and create a partition
-                3. search
-        expected: No exception
+        method: load p1, create a new partition, search
+        expected: search returns 100 results (p1 only)
         """
-        # init the collection
-        collection_w = self.init_collection_general(
-            prefix, True, 200, partition_num=1, is_index=False)[0]
-        partition_w1, partition_w2 = collection_w.partitions
-        collection_w.create_index(default_search_field, ct.default_flat_index)
-        # load and release
-        partition_w1.load()
-        partition_w3 = collection_w.create_partition("_default3")[0]
-        # search on collection
-        collection_w.search(vectors[:1], field_name, default_search_params, 200,
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": 1, "limit": 100})
+        client = self._client()
+        collection_name, partition_names, _ = \
+            self._create_collection_with_partitions_and_data(client, nb=200, partition_num=1, is_index=False)
+        p1_name = partition_names[0]
+        self._create_index_flat(client, collection_name)
+        self.load_partitions(client, collection_name, partition_names=[p1_name])
+        self.create_partition(client, collection_name, partition_name=cf.gen_unique_str("partition3"))
+        self._do_search(client, collection_name, None, 200, 100)
+
+    # ==================================================================================
+    # Operation executors
+    # ==================================================================================
+
+    def _execute_op(self, client, collection_name, p1_name, p2_name, delete_ids, op):
+        """Execute a single operation tuple for delete/flush-based tests."""
+        op_name = op[0]
+        if op_name == "delete":
+            self.delete(client, collection_name,
+                        filter=f"{ct.default_int64_field_name} in {delete_ids}")
+        elif op_name == "load_collection":
+            self.load_collection(client, collection_name)
+        elif op_name == "release_collection":
+            self.release_collection(client, collection_name)
+        elif op_name == "release_p1":
+            self.release_partitions(client, collection_name, partition_names=[p1_name])
+        elif op_name == "release_p2":
+            self.release_partitions(client, collection_name, partition_names=[p2_name])
+        elif op_name == "load_p1":
+            self.load_partitions(client, collection_name, partition_names=[p1_name])
+        elif op_name == "load_p2":
+            self.load_partitions(client, collection_name, partition_names=[p2_name])
+        elif op_name == "drop_p2":
+            self.drop_partition(client, collection_name, partition_name=p2_name)
+        elif op_name == "flush":
+            self.flush(client, collection_name)
+        elif op_name == "compact":
+            self.compact(client, collection_name)
+        else:
+            raise ValueError(f"Unknown operation: {op_name}")
+
+    def _execute_compact_op(self, client, collection_name, p1_name, p2_name, op):
+        """Execute a single operation tuple for compact-based tests."""
+        # Reuses the same logic
+        self._execute_op(client, collection_name, p1_name, p2_name, None, op)

--- a/tests/python_client/milvus_client_v2/test_milvus_client_search_load.py
+++ b/tests/python_client/milvus_client_v2/test_milvus_client_search_load.py
@@ -223,6 +223,7 @@ class TestSearchLoadIndependent(TestMilvusClientV2Base):
             100, 50, 50, "both",
             id="load_partition_release_collection_delete"),
     ])
+    @pytest.mark.tags(CaseLabel.L2)
     def test_search_after_delete_ops_l2(self, ops, expected_coll, expected_p1, expected_p2,
                                         coll_search_parts):
         """Parametrized L2 tests: delete + load/release operation sequences."""
@@ -374,6 +375,7 @@ class TestSearchLoadIndependent(TestMilvusClientV2Base):
             NOT_LOADED, NOT_LOADED, NOT_LOADED, None,
             id="load_partition_compact_release_collection"),
     ])
+    @pytest.mark.tags(CaseLabel.L2)
     def test_search_after_compact_ops_l2(self, ops, expected_coll, expected_p1, expected_p2,
                                           coll_search_parts):
         """Parametrized L2 tests: compact + load/release operation sequences."""
@@ -467,6 +469,7 @@ class TestSearchLoadIndependent(TestMilvusClientV2Base):
             100, 100, NOT_FOUND, None,
             id="load_collection_flush_drop_partition"),
     ])
+    @pytest.mark.tags(CaseLabel.L2)
     def test_search_after_flush_ops_l2(self, ops, expected_coll, expected_p1, expected_p2,
                                         coll_search_parts):
         """Parametrized L2 tests: flush + load/release operation sequences."""


### PR DESCRIPTION
## Summary
Collapse 33 near-identical load/release/delete permutation tests into parametrize-driven design (1479→612 lines, -59%).

issue: #48048
🤖 Generated with [Claude Code](https://claude.com/claude-code)