### PR TITLE
test: Fix search_v2 series verification and add index constant

### DIFF
--- a/tests/python_client/common/common_type.py
+++ b/tests/python_client/common/common_type.py
@@ -298,6 +298,9 @@ all_index_types = ["FLAT", "IVF_FLAT", "IVF_SQ8", "IVF_PQ",
                    "SPARSE_INVERTED_INDEX", "SPARSE_WAND",
                    "GPU_IVF_FLAT", "GPU_IVF_PQ"]
 
+all_dense_float_index_types = ["FLAT", "IVF_FLAT", "IVF_SQ8", "IVF_PQ",
+                               "IVF_RABITQ", "HNSW", "SCANN", "DISKANN"]
+
 inverted_index_algo = ['TAAT_NAIVE', 'DAAT_WAND', 'DAAT_MAXSCORE']
 
 int8_vector_index = ["HNSW"]

--- a/tests/python_client/milvus_client_v2/test_milvus_client_search_v2.py
+++ b/tests/python_client/milvus_client_v2/test_milvus_client_search_v2.py
@@ -1,60 +1,20 @@
-import numpy as np
-from pymilvus.orm.types import CONSISTENCY_STRONG, CONSISTENCY_BOUNDED, CONSISTENCY_SESSION, CONSISTENCY_EVENTUALLY
-from pymilvus import AnnSearchRequest, RRFRanker, WeightedRanker, Function, FunctionType
-from pymilvus import (
-    FieldSchema, CollectionSchema, DataType,
-    Collection
-)
-from common.constants import *
+import random
+import pytest
+import math
+import threading
+from pymilvus import DataType
 from utils.util_pymilvus import *
 from common.common_type import CaseLabel, CheckTasks
 from common import common_type as ct
 from common import common_func as cf
 from utils.util_log import test_log as log
-from base.client_base import TestcaseBase
-import heapq
-from time import sleep
-from decimal import Decimal, getcontext
-import decimal
-import multiprocessing
-import numbers
-import random
-import math
-import numpy
-import threading
-import pytest
-import pandas as pd
-from faker import Faker
+from base.client_v2_base import TestMilvusClientV2Base
 
-Faker.seed(19530)
-fake_en = Faker("en_US")
-fake_zh = Faker("zh_CN")
-
-# patch faker to generate text with specific distribution
-cf.patch_faker_text(fake_en, cf.en_vocabularies_distribution)
-cf.patch_faker_text(fake_zh, cf.zh_vocabularies_distribution)
-
-pd.set_option("expand_frame_repr", False)
-
-prefix = "search_collection"
-search_num = 10
-max_dim = ct.max_dim
-min_dim = ct.min_dim
-epsilon = ct.epsilon
-hybrid_search_epsilon = 0.01
-gracefulTime = ct.gracefulTime
 default_nb = ct.default_nb
-default_nb_medium = ct.default_nb_medium
 default_nq = ct.default_nq
 default_dim = ct.default_dim
 default_limit = ct.default_limit
-max_limit = ct.max_limit
-default_search_exp = "int64 >= 0"
-default_search_string_exp = "varchar >= \"0\""
-default_search_mix_exp = "int64 >= 0 && varchar >= \"0\""
-default_invaild_string_exp = "varchar >= 0"
-default_json_search_exp = "json_field[\"number\"] >= 0"
-perfix_expr = 'varchar like "0%"'
+default_search_exp = f"{ct.default_int64_field_name} >= 0"
 default_search_field = ct.default_float_vec_field_name
 default_search_params = ct.default_search_params
 default_int64_field_name = ct.default_int64_field_name
@@ -62,978 +22,1071 @@ default_float_field_name = ct.default_float_field_name
 default_bool_field_name = ct.default_bool_field_name
 default_string_field_name = ct.default_string_field_name
 default_json_field_name = ct.default_json_field_name
-default_index_params = ct.default_index
-vectors = [[random.random() for _ in range(default_dim)] for _ in range(default_nq)]
-uid = "test_search"
-nq = 1
-epsilon = 0.001
-binary_field_name = default_binary_vec_field_name
-search_param = {"nprobe": 1}
-entity = gen_entities(1, is_normal=True)
-entities = gen_entities(default_nb, is_normal=True)
-raw_vectors, binary_entities = gen_binary_entities(default_nb)
-index_name1 = cf.gen_unique_str("float")
-index_name2 = cf.gen_unique_str("varhar")
-half_nb = ct.default_nb // 2
-max_hybrid_search_req_num = ct.max_hybrid_search_req_num
 
 
-
-class TestCollectionSearch(TestcaseBase):
-    """ Test case of search interface """
-
-    @pytest.fixture(scope="function", params=[default_nb_medium])
-    def nb(self, request):
-        yield request.param
-
-    @pytest.fixture(scope="function", params=[200])
-    def nq(self, request):
-        yield request.param
-
-    @pytest.fixture(scope="function", params=[32, 128])
-    def dim(self, request):
-        yield request.param
-
-    @pytest.fixture(scope="function", params=[False, True])
-    def auto_id(self, request):
-        yield request.param
-
-    @pytest.fixture(scope="function", params=[False, True])
-    def _async(self, request):
-        yield request.param
-
-    @pytest.fixture(scope="function", params=["JACCARD", "HAMMING"])
-    def metrics(self, request):
-        yield request.param
-
-    @pytest.fixture(scope="function", params=[False, True])
-    def is_flush(self, request):
-        yield request.param
-
-    @pytest.fixture(scope="function", params=[True, False])
-    def enable_dynamic_field(self, request):
-        yield request.param
-
-    @pytest.fixture(scope="function", params=["IP", "COSINE", "L2"])
-    def metric_type(self, request):
-        yield request.param
-
-    @pytest.fixture(scope="function", params=[True, False])
-    def random_primary_key(self, request):
-        yield request.param
-
-    @pytest.fixture(scope="function", params=ct.all_dense_vector_types)
-    def vector_data_type(self, request):
-        yield request.param
-
-    @pytest.fixture(scope="function", params=["STL_SORT", "INVERTED"])
-    def scalar_index(self, request):
-        yield request.param
-
-    @pytest.fixture(scope="function", params=[0, 0.5, 1])
-    def null_data_percent(self, request):
-        yield request.param
-
+@pytest.mark.xdist_group("TestSearchV2Shared")
+@pytest.mark.tags(CaseLabel.GPU)
+class TestSearchV2Shared(TestMilvusClientV2Base):
+    """Test search with shared enriched collection.
+    Schema: int64(PK), int32, int16, int8, bool(nullable), float(nullable), double,
+            varchar(65535), json, int32_array(100), float_array(100), string_array(100, nullable),
+            float_vector(128), float16_vector(128), bfloat16_vector(128)
+    Data: 10000 rows, gen_row_data_by_schema + 20% nulls for nullable fields + dynamic "new_added_field"
+    Index: FLAT / COSINE on all 3 vector fields
+    Dynamic: True
     """
-    ******************************************************************
-    #  The following are valid base cases
-    ******************************************************************
-    """
+
+    shared_alias = "TestSearchV2Shared"
+
+    def setup_class(self):
+        super().setup_class(self)
+        self.collection_name = "TestSearchV2Shared" + cf.gen_unique_str("_")
+
+    @pytest.fixture(scope="class", autouse=True)
+    def prepare_collection(self, request):
+        client = self._client(alias=self.shared_alias)
+        schema = self.create_schema(client, enable_dynamic_field=True)[0]
+        # Scalar fields (float, bool, string_array are nullable for nullable coverage)
+        schema.add_field(ct.default_int64_field_name, DataType.INT64, is_primary=True)
+        schema.add_field(ct.default_int32_field_name, DataType.INT32)
+        schema.add_field(ct.default_int16_field_name, DataType.INT16)
+        schema.add_field(ct.default_int8_field_name, DataType.INT8)
+        schema.add_field(ct.default_bool_field_name, DataType.BOOL, nullable=True)
+        schema.add_field(ct.default_float_field_name, DataType.FLOAT, nullable=True)
+        schema.add_field(ct.default_double_field_name, DataType.DOUBLE)
+        schema.add_field(ct.default_string_field_name, DataType.VARCHAR, max_length=65535)
+        schema.add_field(ct.default_json_field_name, DataType.JSON)
+        # Array fields (string_array is nullable)
+        schema.add_field(ct.default_int32_array_field_name, DataType.ARRAY,
+                         element_type=DataType.INT32, max_capacity=ct.default_max_capacity)
+        schema.add_field(ct.default_float_array_field_name, DataType.ARRAY,
+                         element_type=DataType.FLOAT, max_capacity=ct.default_max_capacity)
+        schema.add_field(ct.default_string_array_field_name, DataType.ARRAY,
+                         element_type=DataType.VARCHAR, max_capacity=ct.default_max_capacity,
+                         max_length=100, nullable=True)
+        # Vector fields
+        schema.add_field(ct.default_float_vec_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
+        schema.add_field(ct.default_float16_vec_field_name, DataType.FLOAT16_VECTOR, dim=default_dim)
+        schema.add_field(ct.default_bfloat16_vec_field_name, DataType.BFLOAT16_VECTOR, dim=default_dim)
+        self.create_collection(client, self.collection_name, schema=schema, force_teardown=False)
+
+        self.__class__.shared_nb = 10000
+        self.__class__.shared_dim = default_dim
+        data = cf.gen_row_data_by_schema(nb=self.shared_nb, schema=schema)
+        # Inject ~20% null values for nullable fields (float, bool, string_array)
+        null_ratio = 0.2
+        null_count = int(self.shared_nb * null_ratio)
+        for i in range(null_count):
+            data[i][ct.default_float_field_name] = None
+            data[i][ct.default_bool_field_name] = None
+            data[i][ct.default_string_array_field_name] = None
+        # Add dynamic field for exists test
+        for i in range(self.shared_nb):
+            data[i]["new_added_field"] = i
+        self.__class__.shared_data = data
+        self.__class__.shared_insert_ids = [i for i in range(self.shared_nb)]
+        self.__class__.shared_vector_fields = [
+            (ct.default_float_vec_field_name, DataType.FLOAT_VECTOR),
+            (ct.default_float16_vec_field_name, DataType.FLOAT16_VECTOR),
+            (ct.default_bfloat16_vec_field_name, DataType.BFLOAT16_VECTOR),
+        ]
+        self.insert(client, self.collection_name, data=data)
+        self.flush(client, self.collection_name)
+
+        idx = self.prepare_index_params(client)[0]
+        idx.add_index(field_name=ct.default_float_vec_field_name, metric_type="COSINE",
+                      index_type="FLAT", params={})
+        idx.add_index(field_name=ct.default_float16_vec_field_name, metric_type="COSINE",
+                      index_type="FLAT", params={})
+        idx.add_index(field_name=ct.default_bfloat16_vec_field_name, metric_type="COSINE",
+                      index_type="FLAT", params={})
+        self.create_index(client, self.collection_name, index_params=idx)
+        self.load_collection(client, self.collection_name)
+
+        def teardown():
+            self.drop_collection(self._client(alias=self.shared_alias), self.collection_name)
+        request.addfinalizer(teardown)
+
+    # ==================== Expression filter tests ====================
+
     @pytest.mark.tags(CaseLabel.L1)
-    def test_search_with_expression(self, null_data_percent):
+    def test_search_with_expression(self):
         """
-        target: test search with different expressions
-        method: test search with different expressions
-        expected: searched successfully with correct limit(topK)
+        target: verify filter expressions return only matching results and templates produce equivalent results
+        method: 1. search with each expression from gen_normal_expressions_and_templates
+                2. compute expected filter_ids locally using eval
+                3. verify returned IDs match filter_ids exactly (FLAT index, 100% recall)
+                4. repeat with expression template and with iterative_filter hint
+        expected: exact ID match for FLAT index, distances in descending order (COSINE)
         """
-        # 1. initialize with data
-        nb = 2000
-        dim = 64
-        enable_dynamic_field = False
-        collection_w, _vectors, _, insert_ids = \
-            self.init_collection_general(prefix, True, nb, dim=dim, is_index=False,
-                                         enable_dynamic_field=enable_dynamic_field,
-                                         nullable_fields={ct.default_float_field_name: null_data_percent})[0:4]
-        # 2. create index
-        index_param = {"index_type": "FLAT", "metric_type": "COSINE", "params": {}}
-        collection_w.create_index("float_vector", index_param)
-        collection_w.load()
+        nb = self.shared_nb
+        dim = self.shared_dim
+        client = self._client(alias=self.shared_alias)
+        data = self.shared_data
+        insert_ids = self.shared_insert_ids
 
-        # filter result with expression in collection
-        _vectors = _vectors[0]
-        for _async in [False, True]:
-            for expressions in cf.gen_normal_expressions_and_templates():
-                log.debug(f"test_search_with_expression: {expressions}")
-                expr = expressions[0].replace("&&", "and").replace("||", "or")
-                filter_ids = []
-                for i, _id in enumerate(insert_ids):
-                    if enable_dynamic_field:
-                        int64 = _vectors[i][ct.default_int64_field_name]
-                        float = _vectors[i][ct.default_float_field_name]
-                    else:
-                        int64 = _vectors.int64[i]
-                        float = _vectors.float[i]
-                    if float is None and "float <=" in expr:
-                        continue
-                    if null_data_percent == 1 and "and float" in expr:
-                        continue
-                    if not expr or eval(expr):
-                        filter_ids.append(_id)
+        # NULL sentinel: all comparisons return False (SQL NULL semantics)
+        _null = type('_Null', (), {
+            '__eq__': lambda s, o: False, '__ne__': lambda s, o: False,
+            '__lt__': lambda s, o: False, '__le__': lambda s, o: False,
+            '__gt__': lambda s, o: False, '__ge__': lambda s, o: False,
+            '__hash__': lambda s: hash(None)})()
 
-                # 3. search with expression
-                vectors = [[random.random() for _ in range(dim)] for _ in range(default_nq)]
-                search_res, _ = collection_w.search(vectors[:default_nq], default_search_field,
-                                                    default_search_params, nb,
-                                                    expr=expr, _async=_async,
-                                                    check_task=CheckTasks.check_search_results,
-                                                    check_items={"nq": default_nq,
-                                                                 "ids": insert_ids,
-                                                                 "limit": min(nb, len(filter_ids)),
-                                                                 "_async": _async})
-                if _async:
-                    search_res.done()
-                    search_res = search_res.result()
-                filter_ids_set = set(filter_ids)
-                for hits in search_res:
-                    ids = hits.ids
-                    assert set(ids).issubset(filter_ids_set)
+        for expressions in cf.gen_normal_expressions_and_templates():
+            log.debug(f"test_search_with_expression: {expressions}")
+            expr = expressions[0].replace("&&", "and").replace("||", "or")
+            filter_ids = []
+            for i, _id in enumerate(insert_ids):
+                float_val = data[i][ct.default_float_field_name]
+                local_vars = {ct.default_int64_field_name: data[i][ct.default_int64_field_name],
+                              ct.default_float_field_name: float_val if float_val is not None else _null}
+                if not expr or eval(expr, {}, local_vars):
+                    filter_ids.append(_id)
+            expected_limit = min(nb, len(filter_ids))
 
-                # 4. search again with expression template
-                expr = cf.get_expr_from_template(expressions[1]).replace("&&", "and").replace("||", "or")
-                expr_params = cf.get_expr_params_from_template(expressions[1])
-                search_res, _ = collection_w.search(vectors[:default_nq], default_search_field,
-                                                    default_search_params, nb,
-                                                    expr=expr, expr_params=expr_params, _async=_async,
-                                                    check_task=CheckTasks.check_search_results,
-                                                    check_items={"nq": default_nq,
-                                                                 "ids": insert_ids,
-                                                                 "limit": min(nb, len(filter_ids)),
-                                                                 "_async": _async})
-                if _async:
-                    search_res.done()
-                    search_res = search_res.result()
-                filter_ids_set = set(filter_ids)
-                for hits in search_res:
-                    ids = hits.ids
-                    assert set(ids).issubset(filter_ids_set)
+            # 3. search with expression
+            search_vectors = cf.gen_vectors(default_nq, dim)
+            search_res, _ = self.search(client, self.collection_name,
+                                        data=search_vectors[:default_nq],
+                                        anns_field=default_search_field,
+                                        search_params=default_search_params,
+                                        limit=nb,
+                                        filter=expr)
+            filter_ids_set = set(filter_ids)
+            for hits in search_res:
+                ids = [hit[ct.default_int64_field_name] for hit in hits]
+                assert set(ids) == filter_ids_set
+                assert len(hits) == expected_limit
+                # verify distance ordering (COSINE: descending)
+                distances = [hit["distance"] for hit in hits]
+                assert all(distances[j] >= distances[j+1] for j in range(len(distances)-1)), \
+                    "distances not in descending order for COSINE metric"
 
-                # 5. search again with expression template and search hints
-                search_param = default_search_params.copy()
-                search_param.update({"hints": "iterative_filter"})
-                search_res, _ = collection_w.search(vectors[:default_nq], default_search_field,
-                                                    search_param, nb,
-                                                    expr=expr, expr_params=expr_params, _async=_async,
-                                                    check_task=CheckTasks.check_search_results,
-                                                    check_items={"nq": default_nq,
-                                                                 "ids": insert_ids,
-                                                                 "limit": min(nb, len(filter_ids)),
-                                                                 "_async": _async})
-                if _async:
-                    search_res.done()
-                    search_res = search_res.result()
-                filter_ids_set = set(filter_ids)
-                for hits in search_res:
-                    ids = hits.ids
-                    assert set(ids).issubset(filter_ids_set)
+            # 4. search again with expression template
+            expr = cf.get_expr_from_template(expressions[1]).replace("&&", "and").replace("||", "or")
+            expr_params = cf.get_expr_params_from_template(expressions[1])
+            search_res, _ = self.search(client, self.collection_name,
+                                        data=search_vectors[:default_nq],
+                                        anns_field=default_search_field,
+                                        search_params=default_search_params,
+                                        limit=nb,
+                                        filter=expr, filter_params=expr_params,
+                                        check_task=CheckTasks.check_search_results,
+                                        check_items={"nq": default_nq, "limit": expected_limit,
+                                                     "metric": "COSINE",
+                                                     "enable_milvus_client_api": True,
+                                                     "pk_name": ct.default_int64_field_name})
+            for hits in search_res:
+                ids = [hit[ct.default_int64_field_name] for hit in hits]
+                assert set(ids) == filter_ids_set
+
+            # 5. search again with expression template and search hints
+            search_param = default_search_params.copy()
+            search_param.update({"hints": "iterative_filter"})
+            search_res, _ = self.search(client, self.collection_name,
+                                        data=search_vectors[:default_nq],
+                                        anns_field=default_search_field,
+                                        search_params=search_param,
+                                        limit=nb,
+                                        filter=expr, filter_params=expr_params,
+                                        check_task=CheckTasks.check_search_results,
+                                        check_items={"nq": default_nq, "limit": expected_limit,
+                                                     "metric": "COSINE",
+                                                     "enable_milvus_client_api": True,
+                                                     "pk_name": ct.default_int64_field_name})
+            for hits in search_res:
+                ids = [hit[ct.default_int64_field_name] for hit in hits]
+                assert set(ids) == filter_ids_set
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("bool_type", [True, False, "true", "false"])
-    def test_search_with_expression_bool(self, _async, bool_type, null_data_percent):
+    def test_search_with_expression_bool(self, bool_type):
         """
-        target: test search with different bool expressions
-        method: search with different bool expressions
-        expected: searched successfully with correct limit(topK)
+        target: verify search with bool filter returns only rows matching the bool condition
+        method: 1. search shared collection with bool == True/False/"true"/"false"
+                2. compute expected filter_ids locally
+                3. verify returned IDs match exactly (FLAT, 100% recall)
+        expected: exact match on filter_ids for bool filter (NULL bools excluded)
         """
-        # 1. initialize with data
-        nb = 1000
-        dim = 64
-        auto_id = True
-        enable_dynamic_field = False
-        collection_w, _vectors, _, insert_ids = \
-            self.init_collection_general(prefix, True, nb, is_all_data_type=True, auto_id=auto_id,
-                                         dim=dim, is_index=False, enable_dynamic_field=enable_dynamic_field,
-                                         nullable_fields={ct.default_bool_field_name: null_data_percent})[0:4]
-        # 2. create index and load
-        vector_name_list = cf.extract_vector_field_name_list(collection_w)
-        vector_name_list.append(ct.default_float_vec_field_name)
-        index_param = {"index_type": "FLAT", "metric_type": "COSINE", "params": {"nlist": 100}}
-        for vector_name in vector_name_list:
-            collection_w.create_index(vector_name, index_param)
-        collection_w.load()
+        nb = self.shared_nb
+        dim = self.shared_dim
+        client = self._client(alias=self.shared_alias)
+        data = self.shared_data
+        insert_ids = self.shared_insert_ids
 
-        # 3. filter result with expression in collection
         filter_ids = []
         bool_type_cmp = bool_type
         if bool_type == "true":
             bool_type_cmp = True
         if bool_type == "false":
             bool_type_cmp = False
-        if enable_dynamic_field:
-            for i, _id in enumerate(insert_ids):
-                if _vectors[0][i][f"{ct.default_bool_field_name}"] == bool_type_cmp:
-                    filter_ids.append(_id)
-        else:
-            for i in range(len(_vectors[0])):
-                if _vectors[0][i].dtype == bool:
-                    num = i
-                    break
-            for i, _id in enumerate(insert_ids):
-                if _vectors[0][num][i] == bool_type_cmp:
-                    filter_ids.append(_id)
+        for i, _id in enumerate(insert_ids):
+            # NULL bool values are excluded from == comparison (SQL NULL semantics)
+            val = data[i].get(ct.default_bool_field_name)
+            if val is not None and val == bool_type_cmp:
+                filter_ids.append(_id)
 
-        # 4. search with different expressions
         expression = f"{default_bool_field_name} == {bool_type}"
-        log.info("test_search_with_expression_bool: searching with bool expression: %s" % expression)
-        vectors = [[random.random() for _ in range(dim)] for _ in range(default_nq)]
+        log.info("test_search_with_expression_bool: searching with expression: %s" % expression)
+        search_vectors = cf.gen_vectors(default_nq, dim)
 
-        search_res, _ = collection_w.search(vectors[:default_nq], default_search_field,
-                                            default_search_params, nb, expression,
-                                            _async=_async,
-                                            check_task=CheckTasks.check_search_results,
-                                            check_items={"nq": default_nq,
-                                                         "ids": insert_ids,
-                                                         "limit": min(nb, len(filter_ids)),
-                                                         "_async": _async})
-        if _async:
-            search_res.done()
-            search_res = search_res.result()
-
+        expected_limit = min(nb, len(filter_ids))
+        search_res, _ = self.search(client, self.collection_name,
+                                    data=search_vectors[:default_nq],
+                                    anns_field=default_search_field,
+                                    search_params=default_search_params,
+                                    limit=nb,
+                                    filter=expression)
         filter_ids_set = set(filter_ids)
         for hits in search_res:
-            ids = hits.ids
-            assert set(ids).issubset(filter_ids_set)
-
-    @pytest.mark.tags(CaseLabel.L2)
-    def test_search_with_expression_array(self, null_data_percent):
-        """
-        target: test search with different expressions
-        method: test search with different expressions
-        expected: searched successfully with correct limit(topK)
-        """
-        enable_dynamic_field = False
-        # 1. create a collection
-        nb = ct.default_nb
-        schema = cf.gen_array_collection_schema()
-        collection_w = self.init_collection_wrap(schema=schema, enable_dynamic_field=enable_dynamic_field)
-
-        # 2. insert data
-        array_length = 10
-        data = []
-        for i in range(int(nb * (1 - null_data_percent))):
-            arr = {ct.default_int64_field_name: i,
-                   ct.default_float_vec_field_name: cf.gen_vectors(1, ct.default_dim)[0],
-                   ct.default_int32_array_field_name: [np.int32(i) for i in range(array_length)],
-                   ct.default_float_array_field_name: [np.float32(i) for i in range(array_length)],
-                   ct.default_string_array_field_name: [str(i) for i in range(array_length)]}
-            data.append(arr)
-        for i in range(int(nb * (1 - null_data_percent)), nb):
-            arr = {ct.default_int64_field_name: i,
-                   ct.default_float_vec_field_name: cf.gen_vectors(1, ct.default_dim)[0],
-                   ct.default_int32_array_field_name: [np.int32(i) for i in range(array_length)],
-                   ct.default_float_array_field_name: [np.float32(i) for i in range(array_length)],
-                   ct.default_string_array_field_name: None}
-            data.append(arr)
-        collection_w.insert(data)
-
-        # 3. create index
-        collection_w.create_index("float_vector", ct.default_index)
-        collection_w.load()
-
-        # 4. filter result with expression in collection
-        for _async in [False, True]:
-            for expressions in cf.gen_array_field_expressions_and_templates():
-                log.debug(f"search with expression: {expressions} with async={_async}")
-                expr = expressions[0].replace("&&", "and").replace("||", "or")
-                filter_ids = []
-                for i in range(nb):
-                    int32_array = data[i][ct.default_int32_array_field_name]
-                    float_array = data[i][ct.default_float_array_field_name]
-                    string_array = data[i][ct.default_string_array_field_name]
-                    if ct.default_string_array_field_name in expr and string_array is None:
-                        continue
-                    if not expr or eval(expr):
-                        filter_ids.append(i)
-
-                # 5. search with expression
-                search_res, _ = collection_w.search(vectors[:default_nq], default_search_field,
-                                                    default_search_params, limit=nb,
-                                                    expr=expr, _async=_async)
-                if _async:
-                    search_res.done()
-                    search_res = search_res.result()
-                for hits in search_res:
-                    ids = hits.ids
-                    assert set(ids) == set(filter_ids)
-
-                # 6. search again with expression template
-                expr = cf.get_expr_from_template(expressions[1]).replace("&&", "and").replace("||", "or")
-                expr_params = cf.get_expr_params_from_template(expressions[1])
-                search_res, _ = collection_w.search(vectors[:default_nq], default_search_field,
-                                                    default_search_params, limit=nb,
-                                                    expr=expr, expr_params=expr_params,
-                                                    _async=_async)
-                if _async:
-                    search_res.done()
-                    search_res = search_res.result()
-                for hits in search_res:
-                    ids = hits.ids
-                    assert set(ids) == set(filter_ids)
-
-                # 7. search again with expression template and hints
-                search_params = default_search_params.copy()
-                search_params.update({"hints": "iterative_filter"})
-                search_res, _ = collection_w.search(vectors[:default_nq], default_search_field,
-                                                    search_params, limit=nb,
-                                                    expr=expr, expr_params=expr_params,
-                                                    _async=_async)
-                if _async:
-                    search_res.done()
-                    search_res = search_res.result()
-                for hits in search_res:
-                    ids = hits.ids
-                    assert set(ids) == set(filter_ids)
-
-    @pytest.mark.tags(CaseLabel.L2)
-    @pytest.mark.parametrize("exists", ["exists"])
-    @pytest.mark.parametrize("json_field_name", ["json_field", "json_field['number']", "json_field['name']",
-                                                 "float_array", "not_exist_field", "new_added_field"])
-    def test_search_with_expression_exists(self, exists, json_field_name, _async):
-        """
-        target: test search with different expressions
-        method: test search with different expressions
-        expected: searched successfully with correct limit(topK)
-        """
-        enable_dynamic_field = True
-        if not enable_dynamic_field:
-            pytest.skip("not allowed")
-        # 1. initialize with data
-        nb = 100
-        schema = cf.gen_array_collection_schema(with_json=True, enable_dynamic_field=enable_dynamic_field)
-        collection_w = self.init_collection_wrap(schema=schema, enable_dynamic_field=enable_dynamic_field)
-        log.info(schema.fields)
-        if enable_dynamic_field:
-            data = cf.gen_row_data_by_schema(nb, schema=schema)
-            for i in range(nb):
-                data[i]["new_added_field"] = i
-            log.info(data[0])
-        else:
-            data = cf.gen_array_dataframe_data(nb, with_json=True)
-            log.info(data.head(1))
-        collection_w.insert(data)
-
-        # 2. create index
-        index_param = {"index_type": "FLAT", "metric_type": "COSINE", "params": {}}
-        collection_w.create_index("float_vector", index_param)
-        collection_w.load()
-
-        # 3. search with expression
-        expression = exists + " " + json_field_name
-        if enable_dynamic_field:
-            limit = nb if json_field_name in data[0].keys() else 0
-        else:
-            limit = nb if json_field_name in data.columns.to_list() else 0
-        log.info("test_search_with_expression: searching with expression: %s" % expression)
-        search_res, _ = collection_w.search(vectors[:default_nq], default_search_field,
-                                            default_search_params, nb, expression,
-                                            _async=_async,
-                                            check_task=CheckTasks.check_search_results,
-                                            check_items={"nq": default_nq,
-                                                         "limit": limit,
-                                                         "_async": _async})
-
-    @pytest.mark.tags(CaseLabel.L2)
-    def test_search_with_expression_auto_id(self, _async):
-        """
-        target: test search with different expressions
-        method: test search with different expressions with auto id
-        expected: searched successfully with correct limit(topK)
-        """
-        # 1. initialize with data
-        nb = 1000
-        dim = 64
-        enable_dynamic_field = True
-        collection_w, _vectors, _, insert_ids = \
-            self.init_collection_general(prefix, True, nb, auto_id=True, dim=dim,
-                                         is_index=False, enable_dynamic_field=enable_dynamic_field)[0:4]
-
-        # 2. create index
-        index_param = {"index_type": "IVF_FLAT",
-                       "metric_type": "COSINE", "params": {"nlist": 100}}
-        collection_w.create_index("float_vector", index_param)
-        collection_w.load()
-
-        # filter result with expression in collection
-        search_vectors = [[random.random() for _ in range(dim)]
-                          for _ in range(default_nq)]
-        _vectors = _vectors[0]
-        for expressions in cf.gen_normal_expressions_and_templates_field(default_float_field_name):
-            log.debug(f"search with expression: {expressions}")
-            expr = expressions[0].replace("&&", "and").replace("||", "or")
-            filter_ids = []
-            for i, _id in enumerate(insert_ids):
-                if enable_dynamic_field:
-                    exec(
-                        f"{default_float_field_name} = _vectors[i][f'{default_float_field_name}']")
-                else:
-                    exec(
-                        f"{default_float_field_name} = _vectors.{default_float_field_name}[i]")
-                if not expr or eval(expr):
-                    filter_ids.append(_id)
-            # 3. search expressions
-            search_res, _ = collection_w.search(search_vectors[:default_nq], default_search_field,
-                                                default_search_params,
-                                                limit=nb, expr=expr,
-                                                _async=_async,
-                                                check_task=CheckTasks.check_search_results,
-                                                check_items={"nq": default_nq,
-                                                             "ids": insert_ids,
-                                                             "limit": min(nb, len(filter_ids)),
-                                                             "_async": _async})
-            if _async:
-                search_res.done()
-                search_res = search_res.result()
-            filter_ids_set = set(filter_ids)
-            for hits in search_res:
-                ids = hits.ids
-                assert set(ids).issubset(filter_ids_set)
-
-            # search again with expression template
-            expr = cf.get_expr_from_template(expressions[1]).replace("&&", "and").replace("||", "or")
-            expr_params = cf.get_expr_params_from_template(expressions[1])
-            search_res, _ = collection_w.search(search_vectors[:default_nq], default_search_field,
-                                                default_search_params,
-                                                limit=nb, expr=expr, expr_params=expr_params,
-                                                _async=_async,
-                                                check_task=CheckTasks.check_search_results,
-                                                check_items={"nq": default_nq,
-                                                             "ids": insert_ids,
-                                                             "limit": min(nb, len(filter_ids)),
-                                                             "_async": _async})
-            if _async:
-                search_res.done()
-                search_res = search_res.result()
-            filter_ids_set = set(filter_ids)
-            for hits in search_res:
-                ids = hits.ids
-                assert set(ids).issubset(filter_ids_set)
+            ids = [hit[ct.default_int64_field_name] for hit in hits]
+            assert set(ids) == filter_ids_set
+            assert len(hits) == expected_limit
 
     @pytest.mark.tags(CaseLabel.L1)
-    def test_search_expr_json_field(self):
+    @pytest.mark.parametrize("field", [DataType.INT8, DataType.INT16, DataType.INT32])
+    def test_search_expression_different_data_type(self, field):
         """
-        target: test delete entities using normal expression
-        method: delete using normal expression
-        expected: delete successfully
+        target: verify search with out-of-bound integer filter returns empty and normal search returns correct output fields
+        method: 1. search with expression where field value exceeds its type range (expect 0 results)
+                2. search without filter, verify output_fields contains the requested scalar field
+        expected: out-of-bound filter returns 0 results; normal search returns correct output fields
         """
-        # init collection with nb default data
-        nb = 2000
-        dim = 64
-        collection_w, _vectors, _, insert_ids = \
-            self.init_collection_general(prefix, True, nb=nb, dim=dim, enable_dynamic_field=True)[0:4]
-
-        # filter result with expression in collection
-        search_vectors = [[random.random() for _ in range(dim)] for _ in range(default_nq)]
-        _vectors = _vectors[0]
-        for expressions in cf.gen_json_field_expressions_and_templates():
-            expr = expressions[0].replace("&&", "and").replace("||", "or")
-            filter_ids = []
-            json_field = {}
-            for i, _id in enumerate(insert_ids):
-                json_field['number'] = _vectors[i][ct.default_json_field_name]['number']
-                json_field['float'] = _vectors[i][ct.default_json_field_name]['float']
-                if not expr or eval(expr):
-                    filter_ids.append(_id)
-
-            # 3. search expressions
-            search_res, _ = collection_w.search(search_vectors[:default_nq], default_search_field,
-                                                default_search_params,
-                                                limit=nb, expr=expr,
-                                                check_task=CheckTasks.check_search_results,
-                                                check_items={"nq": default_nq,
-                                                             "ids": insert_ids,
-                                                             "limit": min(nb, len(filter_ids))})
-            filter_ids_set = set(filter_ids)
-            for hits in search_res:
-                ids = hits.ids
-                assert set(ids).issubset(filter_ids_set)
-
-            # 4. search again with expression template
-            expr = cf.get_expr_from_template(expressions[1]).replace("&&", "and").replace("||", "or")
-            expr_params = cf.get_expr_params_from_template(expressions[1])
-            search_res, _ = collection_w.search(search_vectors[:default_nq], default_search_field,
-                                                default_search_params,
-                                                limit=nb, expr=expr, expr_params=expr_params,
-                                                check_task=CheckTasks.check_search_results,
-                                                check_items={"nq": default_nq,
-                                                             "ids": insert_ids,
-                                                             "limit": min(nb, len(filter_ids))})
-            filter_ids_set = set(filter_ids)
-            for hits in search_res:
-                ids = hits.ids
-                assert set(ids).issubset(filter_ids_set)
-
-            # 5. search again with expression template and hint
-            search_params = default_search_params.copy()
-            search_params.update({"hints": "iterative_filter"})
-            search_res, _ = collection_w.search(search_vectors[:default_nq], default_search_field,
-                                                search_params,
-                                                limit=nb, expr=expr, expr_params=expr_params,
-                                                check_task=CheckTasks.check_search_results,
-                                                check_items={"nq": default_nq,
-                                                             "ids": insert_ids,
-                                                             "limit": min(nb, len(filter_ids))})
-            filter_ids_set = set(filter_ids)
-            for hits in search_res:
-                ids = hits.ids
-                assert set(ids).issubset(filter_ids_set)
-            # 6. search again with expression template and hint
-            search_params = default_search_params.copy()
-            search_params.update({"hints": "iterative_filter"})
-            search_res, _ = collection_w.search(search_vectors[:default_nq], default_search_field,
-                                                search_params,
-                                                limit=nb, expr=expr, expr_params=expr_params,
-                                                check_task=CheckTasks.check_search_results,
-                                                check_items={"nq": default_nq,
-                                                             "ids": insert_ids,
-                                                             "limit": min(nb, len(filter_ids))})
-            filter_ids_set = set(filter_ids)
-            for hits in search_res:
-                ids = hits.ids
-                assert set(ids).issubset(filter_ids_set)
-            # 7. create json index
-            default_json_path_index = {"index_type": "INVERTED",
-                                       "params": {"json_cast_type": "double",
-                                                  "json_path": f"{ct.default_json_field_name}['number']"}}
-            collection_w.create_index(ct.default_json_field_name, default_json_path_index,
-                                      index_name=f"{ct.default_json_field_name}_0")
-            default_json_path_index = {"index_type": "AUTOINDEX",
-                                       "params": {"json_cast_type": "double",
-                                                  "json_path": f"{ct.default_json_field_name}['float']"}}
-            collection_w.create_index(ct.default_json_field_name, default_json_path_index,
-                                      index_name=f"{ct.default_json_field_name}_1")
-            # 8. release and load to make sure the new index is loaded
-            collection_w.release()
-            collection_w.load()
-            # 9. search expressions after json path index
-            expr = expressions[0].replace("&&", "and").replace("||", "or")
-            search_res, _ = collection_w.search(search_vectors[:default_nq], default_search_field,
-                                                default_search_params,
-                                                limit=nb, expr=expr,
-                                                check_task=CheckTasks.check_search_results,
-                                                check_items={"nq": default_nq,
-                                                             "ids": insert_ids,
-                                                             "limit": min(nb, len(filter_ids))})
-            filter_ids_set = set(filter_ids)
-            for hits in search_res:
-                ids = hits.ids
-                assert set(ids).issubset(filter_ids_set)
-
-            # 10. search again with expression template after json path index
-            expr = cf.get_expr_from_template(expressions[1]).replace("&&", "and").replace("||", "or")
-            expr_params = cf.get_expr_params_from_template(expressions[1])
-            search_res, _ = collection_w.search(search_vectors[:default_nq], default_search_field,
-                                                default_search_params,
-                                                limit=nb, expr=expr, expr_params=expr_params,
-                                                check_task=CheckTasks.check_search_results,
-                                                check_items={"nq": default_nq,
-                                                             "ids": insert_ids,
-                                                             "limit": min(nb, len(filter_ids))})
-            filter_ids_set = set(filter_ids)
-            for hits in search_res:
-                ids = hits.ids
-                assert set(ids).issubset(filter_ids_set)
-
-            # 11. search again with expression template and hint after json path index
-            search_params = default_search_params.copy()
-            search_params.update({"hints": "iterative_filter"})
-            search_res, _ = collection_w.search(search_vectors[:default_nq], default_search_field,
-                                                search_params,
-                                                limit=nb, expr=expr, expr_params=expr_params,
-                                                check_task=CheckTasks.check_search_results,
-                                                check_items={"nq": default_nq,
-                                                             "ids": insert_ids,
-                                                             "limit": min(nb, len(filter_ids))})
-            filter_ids_set = set(filter_ids)
-            for hits in search_res:
-                ids = hits.ids
-                # log.info(ids)
-                # log.info(filter_ids_set)
-                assert set(ids).issubset(filter_ids_set)
-
-    @pytest.mark.tags(CaseLabel.L2)
-    def test_search_expression_all_data_type(self, nq, _async, null_data_percent):
-        """
-        target: test search using all supported data types
-        method: search using different supported data types
-        expected: search success
-        """
-        # 1. initialize with data
-        nb = 3000
-        dim = 64
-        auto_id = False
-        nullable_fields = {ct.default_int32_field_name: null_data_percent,
-                           ct.default_int16_field_name: null_data_percent,
-                           ct.default_int8_field_name: null_data_percent,
-                           ct.default_bool_field_name: null_data_percent,
-                           ct.default_float_field_name: null_data_percent,
-                           ct.default_double_field_name: null_data_percent,
-                           ct.default_string_field_name: null_data_percent}
-        collection_w, _, _, insert_ids = \
-            self.init_collection_general(prefix, True, nb, is_all_data_type=True,
-                                         auto_id=auto_id, dim=dim, multiple_dim_array=[dim, dim],
-                                         nullable_fields=nullable_fields)[0:4]
-        # 2. search
-        search_exp = "int64 >= 0 && int32 >= 0 && int16 >= 0 " \
-                     "&& int8 >= 0 && float >= 0 && double >= 0"
-        limit = default_limit
-        if null_data_percent == 1:
-            limit = 0
-            insert_ids = []
-        vector_name_list = cf.extract_vector_field_name_list(collection_w)
-        for vector_field_name in vector_name_list:
-            vector_data_type = cf.get_field_dtype_by_field_name(collection_w.schema, vector_field_name)
-            vectors = cf.gen_vectors(nq, dim, vector_data_type)
-            res = collection_w.search(vectors[:nq], vector_field_name,
-                                      default_search_params, default_limit,
-                                      search_exp, _async=_async,
-                                      output_fields=[default_int64_field_name,
-                                                     default_float_field_name,
-                                                     default_bool_field_name],
-                                      check_task=CheckTasks.check_search_results,
-                                      check_items={"nq": nq,
-                                                   "ids": insert_ids,
-                                                   "limit": limit,
-                                                   "_async": _async})[0]
-        if _async:
-            res.done()
-            res = res.result()
-        if limit:
-            assert (default_int64_field_name and default_float_field_name
-                    and default_bool_field_name) in res[0][0].fields
-
-    @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.parametrize("field", ct.all_scalar_data_types[:3])
-    def test_search_expression_different_data_type(self, field, null_data_percent):
-        """
-        target: test search expression using different supported data types
-        method: search using different supported data types
-        expected: search success
-        """
-        # 1. initialize with data
-        field_name = field.name.lower()
-        num = int(field_name[3:])
+        field_name_str = field.name.lower()
+        num = int(field_name_str[3:])
         offset = 2 ** (num - 1)
-        nullable_fields = {field_name: null_data_percent}
-        default_schema = cf.gen_collection_schema_all_datatype(nullable_fields=nullable_fields)
-        collection_w = self.init_collection_wrap(schema=default_schema)
-        collection_w = cf.insert_data(collection_w, is_all_data_type=True, insert_offset=offset - 1000,
-                                      nullable_fields=nullable_fields)[0]
 
-        # 2. create index and load
-        vector_name_list = cf.extract_vector_field_name_list(collection_w)
-        vector_name_list.append(ct.default_float_vec_field_name)
-        index_param = {"index_type": "FLAT", "metric_type": "COSINE", "params": {"nlist": 100}}
-        for vector_name in vector_name_list:
-            collection_w.create_index(vector_name, index_param)
-        collection_w.load()
+        client = self._client(alias=self.shared_alias)
+        search_vectors = cf.gen_vectors(default_nq, self.shared_dim)
 
-        # 3. search using expression which field value is out of bound
-        expression = f"{field_name} >= {offset}"
-        collection_w.search(vectors, default_search_field, default_search_params,
-                            default_limit, expression, output_fields=[field_name],
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": default_nq, "limit": 0})
-        # 4. search normal using all the scalar type as output fields
-        collection_w.search(vectors, default_search_field, default_search_params,
-                            default_limit, output_fields=[field_name],
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": default_nq,
-                                         "limit": default_limit,
-                                         "output_fields": [field_name]})
+        expression = f"{field_name_str} >= {offset}"
+        self.search(client, self.collection_name,
+                    data=search_vectors,
+                    anns_field=default_search_field,
+                    search_params=default_search_params,
+                    limit=default_limit,
+                    filter=expression,
+                    output_fields=[field_name_str],
+                    check_task=CheckTasks.check_search_results,
+                    check_items={"nq": default_nq, "limit": 0,
+                                 "metric": "COSINE",
+                                 "enable_milvus_client_api": True,
+                                 "pk_name": ct.default_int64_field_name})
+        self.search(client, self.collection_name,
+                    data=search_vectors,
+                    anns_field=default_search_field,
+                    search_params=default_search_params,
+                    limit=default_limit,
+                    output_fields=[field_name_str],
+                    check_task=CheckTasks.check_search_results,
+                    check_items={"nq": default_nq,
+                                 "limit": default_limit,
+                                 "metric": "COSINE",
+                                 "output_fields": [field_name_str],
+                                 "enable_milvus_client_api": True,
+                                 "pk_name": ct.default_int64_field_name})
 
-    @pytest.mark.tags(CaseLabel.L1)
-    def test_search_with_comparative_expression(self, _async):
-        """
-        target: test search with expression comparing two fields
-        method: create a collection, insert data and search with comparative expression
-        expected: search successfully
-        """
-        # 1. create a collection
-        nb = 10
-        dim = 2
-        fields = [cf.gen_int64_field("int64_1"), cf.gen_int64_field("int64_2"),
-                  cf.gen_float_vec_field(dim=dim)]
-        schema = cf.gen_collection_schema(fields=fields, primary_field="int64_1")
-        collection_w = self.init_collection_wrap(name=cf.gen_unique_str("comparison"), schema=schema)
-
-        # 2. inset data
-        values = pd.Series(data=[i for i in range(0, nb)])
-        dataframe = pd.DataFrame({"int64_1": values, "int64_2": values,
-                                  ct.default_float_vec_field_name: cf.gen_vectors(nb, dim)})
-        insert_res = collection_w.insert(dataframe)[0]
-
-        insert_ids = []
-        filter_ids = []
-        insert_ids.extend(insert_res.primary_keys)
-        for _id in enumerate(insert_ids):
-            filter_ids.extend(_id)
-
-        # 3. search with expression
-        collection_w.create_index(ct.default_float_vec_field_name, index_params=ct.default_flat_index)
-        collection_w.load()
-        expression = "int64_1 <= int64_2"
-        vectors = [[random.random() for _ in range(dim)]
-                   for _ in range(default_nq)]
-        res = collection_w.search(vectors[:nq], default_search_field,
-                                  default_search_params, default_limit,
-                                  expression, _async=_async,
-                                  check_task=CheckTasks.check_search_results,
-                                  check_items={"nq": nq,
-                                               "ids": insert_ids,
-                                               "limit": default_limit,
-                                               "_async": _async})[0]
-        if _async:
-            res.done()
-            res = res.result()
-        filter_ids_set = set(filter_ids)
-        for hits in res:
-            ids = hits.ids
-            assert set(ids).issubset(filter_ids_set)
-
-    @pytest.mark.tags(CaseLabel.L2)
-    def test_search_expression_with_double_quotes(self):
-        """
-        target: test search with expressions with double quotes
-        method: test search with expressions with double quotes
-        expected: searched successfully with correct limit(topK)
-        """
-        # 1. initialize with data
-        collection_w = self.init_collection_general(prefix)[0]
-        string_value = [(f"'{cf.gen_str_by_length(3)}'{cf.gen_str_by_length(3)}\""
-                         f"{cf.gen_str_by_length(3)}\"") for _ in range(default_nb)]
-        data = cf.gen_default_dataframe_data()
-        data[default_string_field_name] = string_value
-        insert_ids = data[default_int64_field_name]
-        collection_w.insert(data)
-
-        # 2. create index
-        index_param = {"index_type": "FLAT", "metric_type": "COSINE", "params": {}}
-        collection_w.create_index("float_vector", index_param)
-        collection_w.load()
-
-        # 3. search with expression
-        _id = random.randint(0, default_nb)
-        string_value[_id] = string_value[_id].replace("\"", "\\\"")
-        expression = f"{default_string_field_name} == \"{string_value[_id]}\""
-        log.debug("test_search_with_expression: searching with expression: %s" % expression)
-        search_res, _ = collection_w.search(vectors[:default_nq], default_search_field,
-                                            default_search_params, default_limit, expression,
-                                            check_task=CheckTasks.check_search_results,
-                                            check_items={"nq": default_nq,
-                                                         "ids": insert_ids,
-                                                         "limit": 1})
-        assert search_res[0].ids == [_id]
-
-    @pytest.mark.tags(CaseLabel.L2)
-    @pytest.mark.skip(reason="issue 37113")
-    def test_search_concurrent_two_collections_nullable(self, nq, _async):
-        """
-        target: test concurrent load/search with multi-processes between two collections with null data in json field
-        method: concurrent load, and concurrent search with 10 processes, each process uses dependent connection
-        expected: status ok and the returned vectors should be query_records
-        """
-        # 1. initialize with data
-        nb = 3000
-        dim = 64
-        auto_id = False
-        enable_dynamic_field = False
-        threads_num = 10
-        threads = []
-        collection_w_1, _, _, insert_ids = \
-            self.init_collection_general(prefix, False, nb, auto_id=True, dim=dim,
-                                         enable_dynamic_field=enable_dynamic_field,
-                                         nullable_fields={ct.default_json_field_name: 1})[0:4]
-        collection_w_2, _, _, insert_ids = \
-            self.init_collection_general(prefix, False, nb, auto_id=True, dim=dim,
-                                         enable_dynamic_field=enable_dynamic_field,
-                                         nullable_fields={ct.default_json_field_name: 1})[0:4]
-        collection_w_1.release()
-        collection_w_2.release()
-        # insert data
-        vectors = [[random.random() for _ in range(dim)] for _ in range(default_nb)]
-        data = [[np.float32(i) for i in range(default_nb)], [str(i) for i in range(default_nb)], [], vectors]
-        collection_w_1.insert(data)
-        collection_w_2.insert(data)
-        collection_w_1.num_entities
-        collection_w_2.num_entities
-        collection_w_1.load(_async=True)
-        collection_w_2.load(_async=True)
-        res = {'loading_progress': '0%'}
-        res_1 = {'loading_progress': '0%'}
-        while ((res['loading_progress'] != '100%') or (res_1['loading_progress'] != '100%')):
-            res = self.utility_wrap.loading_progress(collection_w_1.name)[0]
-            log.info("collection %s: loading progress: %s " % (collection_w_1.name, res))
-            res_1 = self.utility_wrap.loading_progress(collection_w_2.name)[0]
-            log.info("collection %s: loading progress: %s " % (collection_w_1.name, res_1))
-
-        def search(collection_w):
-            vectors = [[random.random() for _ in range(dim)]
-                       for _ in range(nq)]
-            collection_w.search(vectors[:nq], default_search_field,
-                                default_search_params, default_limit,
-                                default_search_exp, _async=_async,
-                                check_task=CheckTasks.check_search_results,
-                                check_items={"nq": nq,
-                                             "ids": insert_ids,
-                                             "limit": default_limit,
-                                             "_async": _async})
-
-        # 2. search with multi-processes
-        log.info("test_search_concurrent_two_collections_nullable: searching with %s processes" % threads_num)
-        for i in range(threads_num):
-            t = threading.Thread(target=search, args=(collection_w_1))
-            threads.append(t)
-            t.start()
-            time.sleep(0.2)
-        for t in threads:
-            t.join()
-
-    @pytest.mark.skip(reason="Not running for now")
-    @pytest.mark.tags(CaseLabel.L2)
-    def test_search_insert_in_parallel(self):
-        """
-        target: test search and insert in parallel
-        method: One process do search while other process do insert
-        expected: No exception
-        """
-        c_name = cf.gen_unique_str(prefix)
-        collection_w = self.init_collection_wrap(name=c_name)
-        default_index = {"index_type": "IVF_FLAT", "params": {"nlist": 128}, "metric_type": "L2"}
-        collection_w.create_index(ct.default_float_vec_field_name, default_index)
-        collection_w.load()
-
-        def do_insert():
-            df = cf.gen_default_dataframe_data(10000)
-            for i in range(11):
-                collection_w.insert(df)
-                log.info(f'Collection num entities is : {collection_w.num_entities}')
-
-        def do_search():
-            while True:
-                results, _ = collection_w.search(cf.gen_vectors(nq, ct.default_dim), default_search_field,
-                                                 default_search_params, default_limit, default_search_exp, timeout=30)
-                ids = []
-                for res in results:
-                    ids.extend(res.ids)
-                expr = f'{ct.default_int64_field_name} in {ids}'
-                collection_w.query(expr, output_fields=[ct.default_int64_field_name, ct.default_float_field_name],
-                                   timeout=30)
-
-        p_insert = multiprocessing.Process(target=do_insert, args=())
-        p_search = multiprocessing.Process(target=do_search, args=(), daemon=True)
-
-        p_insert.start()
-        p_search.start()
-
-        p_insert.join()
+    # ==================== Round decimal / nq / output fields ====================
 
     @pytest.mark.tags(CaseLabel.L1)
     @pytest.mark.parametrize("round_decimal", [0, 1, 2, 3, 4, 5, 6])
     def test_search_round_decimal(self, round_decimal):
         """
-        target: test search with valid round decimal
-        method: search with valid round decimal
-        expected: search successfully
+        target: verify search with round_decimal returns distances rounded to specified precision
+        method: 1. search without round_decimal to get reference distances
+                2. search with round_decimal and compare distances match expected rounding
+        expected: rounded distances match Python's round() within abs_tol
         """
-        import math
-        tmp_nb = 500
         tmp_nq = 1
         tmp_limit = 5
-        enable_dynamic_field = False
-        # 1. initialize with data
-        collection_w = self.init_collection_general(prefix, True, nb=tmp_nb,
-                                                    enable_dynamic_field=enable_dynamic_field)[0]
-        # 2. search
-        log.info("test_search_round_decimal: Searching collection %s" % collection_w.name)
-        res, _ = collection_w.search(vectors[:tmp_nq], default_search_field,
-                                     default_search_params, tmp_limit)
+        client = self._client(alias=self.shared_alias)
+        search_vectors = cf.gen_vectors(tmp_nq, self.shared_dim)
 
-        res_round, _ = collection_w.search(vectors[:tmp_nq], default_search_field,
-                                           default_search_params, tmp_limit, round_decimal=round_decimal)
+        res, _ = self.search(client, self.collection_name,
+                             data=search_vectors[:tmp_nq],
+                             anns_field=default_search_field,
+                             search_params=default_search_params,
+                             limit=tmp_limit)
+
+        res_round, _ = self.search(client, self.collection_name,
+                                   data=search_vectors[:tmp_nq],
+                                   anns_field=default_search_field,
+                                   search_params=default_search_params,
+                                   limit=tmp_limit,
+                                   round_decimal=round_decimal)
 
         abs_tol = pow(10, 1 - round_decimal)
-        for i in range(tmp_limit):
-            dis_expect = round(res[0][i].distance, round_decimal)
-            dis_actual = res_round[0][i].distance
-            # log.debug(f'actual: {dis_actual}, expect: {dis_expect}')
-            # abs(a-b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
-            assert math.isclose(dis_actual, dis_expect, rel_tol=0, abs_tol=abs_tol)
+        pk = ct.default_int64_field_name
+        dist_map = {res[0][i][pk]: res[0][i]["distance"] for i in range(tmp_limit)}
+        matched_count = 0
+        for i in range(len(res_round[0])):
+            _id = res_round[0][i][pk]
+            if _id in dist_map:
+                dis_expect = round(dist_map[_id], round_decimal)
+                dis_actual = res_round[0][i]["distance"]
+                assert math.isclose(dis_actual, dis_expect, rel_tol=0, abs_tol=abs_tol)
+                matched_count += 1
+        assert matched_count > 0, "no matching PKs found between rounded and unrounded results"
+
+    @pytest.mark.tags(CaseLabel.L2)
+    @pytest.mark.parametrize("nq", [1, 10, 100])
+    def test_search_with_different_nq(self, nq):
+        """
+        target: verify search returns correct results for various nq values
+        method: 1. search shared collection with nq=1/10/100
+                2. verify nq, limit, and distance ordering via check_task
+        expected: each query returns correct number of results with proper distance ordering
+        """
+        client = self._client(alias=self.shared_alias)
+        search_vectors = cf.gen_vectors(nq, self.shared_dim)
+        self.search(client, self.collection_name,
+                    data=search_vectors,
+                    anns_field=default_search_field,
+                    search_params=default_search_params,
+                    limit=default_limit,
+                    check_task=CheckTasks.check_search_results,
+                    check_items={"nq": nq,
+                                 "limit": default_limit,
+                                 "metric": "COSINE",
+                                 "enable_milvus_client_api": True,
+                                 "pk_name": ct.default_int64_field_name})
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_search_with_output_fields_all(self):
+        """
+        target: verify search with output_fields=["*"] returns all schema fields
+        method: 1. search shared collection with output_fields=["*"]
+                2. verify all schema fields are present in each result hit via check_task
+        expected: every result contains all schema fields
+        """
+        client = self._client(alias=self.shared_alias)
+        search_vectors = cf.gen_vectors(default_nq, self.shared_dim)
+        expected_output_fields = [
+            ct.default_int64_field_name, ct.default_int32_field_name,
+            ct.default_int16_field_name, ct.default_int8_field_name,
+            ct.default_bool_field_name, ct.default_float_field_name,
+            ct.default_double_field_name, ct.default_string_field_name,
+            ct.default_json_field_name,
+            ct.default_int32_array_field_name, ct.default_float_array_field_name,
+            ct.default_string_array_field_name,
+            ct.default_float_vec_field_name, ct.default_float16_vec_field_name,
+            ct.default_bfloat16_vec_field_name,
+        ]
+        self.search(client, self.collection_name,
+                    data=search_vectors,
+                    anns_field=default_search_field,
+                    search_params=default_search_params,
+                    limit=default_limit,
+                    output_fields=["*"],
+                    check_task=CheckTasks.check_search_results,
+                    check_items={"nq": default_nq,
+                                 "limit": default_limit,
+                                 "metric": "COSINE",
+                                 "output_fields": expected_output_fields,
+                                 "enable_milvus_client_api": True,
+                                 "pk_name": ct.default_int64_field_name})
+
+    # ==================== Array expression tests ====================
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_search_with_expression_array(self):
+        """
+        target: verify search with array field expressions returns exact matching results
+        method: 1. search with each array expression from gen_array_field_expressions_and_templates
+                2. compute expected filter_ids locally using eval on array data
+                3. verify exact ID match (FLAT index, 100% recall)
+                4. repeat with expression template and iterative_filter hint
+        expected: exact match between expected and returned IDs
+        """
+        nb = self.shared_nb
+        dim = self.shared_dim
+        client = self._client(alias=self.shared_alias)
+        data = self.shared_data
+
+        for expressions in cf.gen_array_field_expressions_and_templates():
+            log.debug(f"search with expression: {expressions}")
+            expr = expressions[0].replace("&&", "and").replace("||", "or")
+            filter_ids = []
+            for i in range(nb):
+                int32_array = data[i][ct.default_int32_array_field_name]
+                float_array = data[i][ct.default_float_array_field_name]
+                string_array = data[i][ct.default_string_array_field_name]
+                # Skip rows with null string_array when expression references it
+                if ct.default_string_array_field_name in expr and string_array is None:
+                    continue
+                if not expr or eval(expr):
+                    filter_ids.append(i)
+
+            search_vectors = cf.gen_vectors(default_nq, dim)
+            search_res, _ = self.search(client, self.collection_name,
+                                        data=search_vectors[:default_nq],
+                                        anns_field=default_search_field,
+                                        search_params=default_search_params,
+                                        limit=nb,
+                                        filter=expr)
+            for hits in search_res:
+                ids = [hit[ct.default_int64_field_name] for hit in hits]
+                assert set(ids) == set(filter_ids)
+
+            # search again with expression template
+            expr = cf.get_expr_from_template(expressions[1]).replace("&&", "and").replace("||", "or")
+            expr_params = cf.get_expr_params_from_template(expressions[1])
+            search_res, _ = self.search(client, self.collection_name,
+                                        data=search_vectors[:default_nq],
+                                        anns_field=default_search_field,
+                                        search_params=default_search_params,
+                                        limit=nb,
+                                        filter=expr, filter_params=expr_params)
+            for hits in search_res:
+                ids = [hit[ct.default_int64_field_name] for hit in hits]
+                assert set(ids) == set(filter_ids)
+
+            # search again with expression template and hints
+            search_params = default_search_params.copy()
+            search_params.update({"hints": "iterative_filter"})
+            search_res, _ = self.search(client, self.collection_name,
+                                        data=search_vectors[:default_nq],
+                                        anns_field=default_search_field,
+                                        search_params=search_params,
+                                        limit=nb,
+                                        filter=expr, filter_params=expr_params)
+            for hits in search_res:
+                ids = [hit[ct.default_int64_field_name] for hit in hits]
+                assert set(ids) == set(filter_ids)
+
+    # ==================== Exists expression tests ====================
+
+    @pytest.mark.tags(CaseLabel.L2)
+    @pytest.mark.parametrize("json_field_name", ["json_field", "json_field['name']", "json_field['number']",
+                                                 "float_array", "not_exist_field", "new_added_field"])
+    def test_search_with_expression_exists(self, json_field_name):
+        """
+        target: verify 'exists' expression returns correct results for existing and non-existing fields
+        method: 1. search with 'exists <field>' for json fields, json subfields, arrays, dynamic fields
+                2. compute expected limit based on actual data field/subfield existence
+        expected: existing fields/subfields return all rows, non-existing return empty
+        """
+        exists = "exists"
+        nb = self.shared_nb
+        dim = self.shared_dim
+        client = self._client(alias=self.shared_alias)
+        data = self.shared_data
+
+        expression = exists + " " + json_field_name
+        # Determine expected limit: check top-level field or JSON subfield existence
+        if json_field_name in data[0]:
+            limit = nb
+        elif "'" in json_field_name:
+            # JSON subfield: extract base field and key, e.g. "json_field['name']" → ("json_field", "name")
+            base = json_field_name.split("[")[0]
+            key = json_field_name.split("'")[1]
+            if base in data[0] and isinstance(data[0][base], dict) and key in data[0][base]:
+                limit = nb
+            else:
+                limit = 0
+        else:
+            limit = 0
+        log.info("test_search_with_expression_exists: expression=%s, expected_limit=%d" % (expression, limit))
+        search_vectors = cf.gen_vectors(default_nq, dim)
+        self.search(client, self.collection_name,
+                    data=search_vectors[:default_nq],
+                    anns_field=default_search_field,
+                    search_params=default_search_params,
+                    limit=nb,
+                    filter=expression,
+                    check_task=CheckTasks.check_search_results,
+                    check_items={"nq": default_nq,
+                                 "limit": limit,
+                                 "metric": "COSINE",
+                                 "enable_milvus_client_api": True,
+                                 "pk_name": ct.default_int64_field_name})
+
+    # ==================== Multi-vector type tests ====================
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_search_expression_all_vector_types(self):
+        """
+        target: verify search works across all vector field types (float, float16, bfloat16) with scalar filter
+        method: 1. search each vector field with scalar filter on shared enriched collection
+                2. verify nq, limit, metric, and output fields via check_task
+        expected: correct results for each vector type with proper output fields
+        """
+        client = self._client(alias=self.shared_alias)
+        nq = 10
+        search_exp = (f"{ct.default_int64_field_name} >= 0 && {ct.default_int32_field_name} >= 0 && "
+                      f"{ct.default_int16_field_name} >= 0 && {ct.default_int8_field_name} >= 0 && "
+                      f"{ct.default_float_field_name} >= 0 && {ct.default_double_field_name} >= 0")
+
+        for vec_field, vec_dtype in self.shared_vector_fields:
+            search_vectors = cf.gen_vectors(nq, self.shared_dim, vec_dtype)
+            res, _ = self.search(client, self.collection_name,
+                                 data=search_vectors[:nq],
+                                 anns_field=vec_field,
+                                 search_params=default_search_params,
+                                 limit=default_limit,
+                                 filter=search_exp,
+                                 output_fields=[default_int64_field_name,
+                                                default_float_field_name,
+                                                default_bool_field_name],
+                                 check_task=CheckTasks.check_search_results,
+                                 check_items={"nq": nq,
+                                              "limit": default_limit,
+                                              "metric": "COSINE",
+                                              "enable_milvus_client_api": True,
+                                              "pk_name": ct.default_int64_field_name})
+            assert default_int64_field_name in res[0][0]["entity"]
+            assert default_float_field_name in res[0][0]["entity"]
+            assert default_bool_field_name in res[0][0]["entity"]
+
+    # ==================== Large-scale expression tests ====================
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_search_with_expression_large(self):
         """
-        target: test search with large expression
-        method: test search with large expression
-        expected: searched successfully
+        target: verify search with large nq (5000) and range filter works correctly
+        method: 1. search shared collection with nq=5000 and range filter "0 < int64 < 5001"
+                2. verify via check_task and manual filter assertion
+        expected: all returned IDs satisfy the range filter
         """
-        # 1. initialize with data
-        nb = 10000
-        dim = 64
-        enable_dynamic_field = True
-        collection_w, _, _, insert_ids = \
-            self.init_collection_general(prefix, True, nb, dim=dim, is_index=False,
-                                         enable_dynamic_field=enable_dynamic_field,
-                                         with_json=False)[0:4]
+        dim = self.shared_dim
+        client = self._client(alias=self.shared_alias)
+        insert_ids = self.shared_insert_ids
 
-        # 2. create index
-        index_param = {"index_type": "IVF_FLAT", "metric_type": "COSINE", "params": {"nlist": 100}}
-        collection_w.create_index("float_vector", index_param)
-        collection_w.load()
-
-        # 3. search with expression
         expression = f"0 < {default_int64_field_name} < 5001"
-        log.info("test_search_with_expression: searching with expression: %s" % expression)
+        log.info("test_search_with_expression_large: searching with expression: %s" % expression)
 
         nums = 5000
-        vectors = [[random.random() for _ in range(dim)] for _ in range(nums)]
-        search_res, _ = collection_w.search(vectors, default_search_field,
-                                            default_search_params, default_limit, expression,
-                                            check_task=CheckTasks.check_search_results,
-                                            check_items={"nq": nums,
-                                                         "ids": insert_ids,
-                                                         "limit": default_limit})
+        search_vectors = cf.gen_vectors(nums, dim)
+        search_res, _ = self.search(client, self.collection_name,
+                                    data=search_vectors,
+                                    anns_field=default_search_field,
+                                    search_params=default_search_params,
+                                    limit=default_limit,
+                                    filter=expression,
+                                    check_task=CheckTasks.check_search_results,
+                                    check_items={"nq": nums,
+                                                 "ids": insert_ids,
+                                                 "limit": default_limit,
+                                                 "metric": "COSINE",
+                                                 "enable_milvus_client_api": True,
+                                                 "pk_name": ct.default_int64_field_name})
+        # Manual filter verification
+        for hits in search_res:
+            for hit in hits:
+                pk = hit[ct.default_int64_field_name]
+                assert 0 < pk < 5001, f"filter violation: id={pk} not in range (0, 5001)"
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_search_with_expression_large_two(self):
         """
-        target: test search with large expression
-        method: test one of the collection ids to another collection search for it, with the large expression
-        expected: searched successfully
+        target: verify search with large 'in' expression (5000 random IDs) works correctly
+        method: 1. search shared collection with nq=5000 and 'int64 in [...]' filter
+                2. verify via check_task and manual filter assertion
+        expected: all returned IDs are within the specified ID list
         """
-        # 1. initialize with data
-        nb = 10000
-        dim = 64
-        enable_dynamic_field = True
-        collection_w, _, _, insert_ids = \
-            self.init_collection_general(prefix, True, nb, dim=dim, is_index=False,
-                                         enable_dynamic_field=enable_dynamic_field,
-                                         with_json=False)[0:4]
-
-        # 2. create index
-        index_param = {"index_type": "IVF_FLAT", "metric_type": "COSINE", "params": {"nlist": 100}}
-        collection_w.create_index("float_vector", index_param)
-        collection_w.load()
+        dim = self.shared_dim
+        client = self._client(alias=self.shared_alias)
+        insert_ids = self.shared_insert_ids
 
         nums = 5000
-        vectors = [[random.random() for _ in range(dim)] for _ in range(nums)]
+        search_vectors = cf.gen_vectors(nums, dim)
         vectors_id = [random.randint(0, nums) for _ in range(nums)]
         expression = f"{default_int64_field_name} in {vectors_id}"
-        search_res, _ = collection_w.search(vectors, default_search_field,
-                                            default_search_params, default_limit, expression,
-                                            check_task=CheckTasks.check_search_results,
-                                            check_items={
-                                                "nq": nums,
-                                                "ids": insert_ids,
-                                                "limit": default_limit,
-                                            })
+        search_res, _ = self.search(client, self.collection_name,
+                                    data=search_vectors,
+                                    anns_field=default_search_field,
+                                    search_params=default_search_params,
+                                    limit=default_limit,
+                                    filter=expression,
+                                    check_task=CheckTasks.check_search_results,
+                                    check_items={
+                                        "nq": nums,
+                                        "ids": insert_ids,
+                                        "limit": default_limit,
+                                        "metric": "COSINE",
+                                        "enable_milvus_client_api": True,
+                                        "pk_name": ct.default_int64_field_name,
+                                    })
+        # Manual filter verification
+        vectors_id_set = set(vectors_id)
+        for hits in search_res:
+            for hit in hits:
+                assert hit[ct.default_int64_field_name] in vectors_id_set, \
+                    f"filter violation: id={hit[ct.default_int64_field_name]} not in filter list"
 
-   
+
+class TestSearchV2LegacyIndependent(TestMilvusClientV2Base):
+    """ Test cases that require independent collections (auto_id, state modification, custom schema/data) """
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_search_with_expression_auto_id(self):
+        """
+        target: verify filter expressions work correctly with auto_id primary key
+        method: 1. create collection with auto_id=True and dynamic fields
+                2. search with each float-field expression, compute expected filter_ids
+                3. verify returned IDs are subset of filter_ids (IVF_FLAT recall tolerance)
+                4. repeat with expression template
+        expected: all returned IDs satisfy the filter, recall >= 80% for IVF_FLAT
+        """
+        nb = 2000
+        dim = 64
+        search_limit = nb // 2
+        enable_dynamic_field = True
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+
+        schema = self.create_schema(client, enable_dynamic_field=enable_dynamic_field)[0]
+        schema.add_field(ct.default_int64_field_name, DataType.INT64, is_primary=True, auto_id=True)
+        schema.add_field(ct.default_float_field_name, DataType.FLOAT)
+        schema.add_field(ct.default_string_field_name, DataType.VARCHAR, max_length=65535)
+        schema.add_field(ct.default_json_field_name, DataType.JSON)
+        schema.add_field(ct.default_float_vec_field_name, DataType.FLOAT_VECTOR, dim=dim)
+        self.create_collection(client, collection_name, schema=schema)
+
+        data = cf.gen_row_data_by_schema(nb=nb, schema=schema)
+        insert_res, _ = self.insert(client, collection_name, data=data)
+        insert_ids = insert_res["ids"]
+        self.flush(client, collection_name)
+
+        idx = self.prepare_index_params(client)[0]
+        idx.add_index(field_name=ct.default_float_vec_field_name, metric_type="COSINE",
+                      index_type="IVF_FLAT", params={"nlist": 100})
+        self.create_index(client, collection_name, index_params=idx)
+        self.load_collection(client, collection_name)
+
+        search_vectors = cf.gen_vectors(default_nq, dim)
+        for expressions in cf.gen_normal_expressions_and_templates_field(default_float_field_name):
+            log.debug(f"search with expression: {expressions}")
+            expr = expressions[0].replace("&&", "and").replace("||", "or")
+            filter_ids = []
+            for i, _id in enumerate(insert_ids):
+                local_vars = {default_float_field_name: data[i][default_float_field_name]}
+                if not expr or eval(expr, {}, local_vars):
+                    filter_ids.append(_id)
+            expected_limit = min(search_limit, len(filter_ids))
+            search_res, _ = self.search(client, collection_name,
+                                        data=search_vectors[:default_nq],
+                                        anns_field=default_search_field,
+                                        search_params=default_search_params,
+                                        limit=search_limit,
+                                        filter=expr)
+            filter_ids_set = set(filter_ids)
+            for hits in search_res:
+                ids = [hit[ct.default_int64_field_name] for hit in hits]
+                assert set(ids).issubset(filter_ids_set)
+                assert len(hits) >= expected_limit * 0.8, \
+                    f"recall too low: got {len(hits)}, expected >= {expected_limit * 0.8}"
+
+            # search again with expression template
+            expr = cf.get_expr_from_template(expressions[1]).replace("&&", "and").replace("||", "or")
+            expr_params = cf.get_expr_params_from_template(expressions[1])
+            search_res, _ = self.search(client, collection_name,
+                                        data=search_vectors[:default_nq],
+                                        anns_field=default_search_field,
+                                        search_params=default_search_params,
+                                        limit=search_limit,
+                                        filter=expr, filter_params=expr_params)
+            filter_ids_set = set(filter_ids)
+            for hits in search_res:
+                ids = [hit[ct.default_int64_field_name] for hit in hits]
+                assert set(ids).issubset(filter_ids_set)
+                assert len(hits) >= expected_limit * 0.8, \
+                    f"recall too low: got {len(hits)}, expected >= {expected_limit * 0.8}"
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_search_expr_json_field(self):
+        """
+        target: verify search with JSON field expressions works before and after JSON path index creation
+        method: 1. create collection with JSON field, insert data with number/float JSON keys
+                2. search with JSON expressions, verify via check_task and manual subset assertion
+                3. create JSON path indexes (INVERTED on number, AUTOINDEX on float)
+                4. release/load and repeat searches to verify JSON index correctness
+        expected: all returned IDs satisfy the JSON filter, results consistent before and after JSON indexing
+        """
+        nb = 2000
+        dim = 64
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+
+        schema = self.create_schema(client, enable_dynamic_field=True)[0]
+        schema.add_field(ct.default_int64_field_name, DataType.INT64, is_primary=True)
+        schema.add_field(ct.default_float_field_name, DataType.FLOAT)
+        schema.add_field(ct.default_string_field_name, DataType.VARCHAR, max_length=65535)
+        schema.add_field(ct.default_json_field_name, DataType.JSON)
+        schema.add_field(ct.default_float_vec_field_name, DataType.FLOAT_VECTOR, dim=dim)
+        self.create_collection(client, collection_name, schema=schema)
+
+        # Insert data - use gen_default_rows_data to get json with {"number": i, "float": i*1.0}
+        data = cf.gen_default_rows_data(nb=nb, dim=dim, with_json=True)
+        self.insert(client, collection_name, data=data)
+        insert_ids = [i for i in range(nb)]
+        self.flush(client, collection_name)
+
+        idx = self.prepare_index_params(client)[0]
+        idx.add_index(field_name=ct.default_float_vec_field_name, metric_type="COSINE",
+                      index_type="FLAT")
+        self.create_index(client, collection_name, index_params=idx)
+        self.load_collection(client, collection_name)
+
+        search_vectors = cf.gen_vectors(default_nq, dim)
+        for expressions in cf.gen_json_field_expressions_and_templates():
+            expr = expressions[0].replace("&&", "and").replace("||", "or")
+            filter_ids = []
+            json_field = {}
+            for i, _id in enumerate(insert_ids):
+                json_field['number'] = data[i][ct.default_json_field_name]['number']
+                json_field['float'] = data[i][ct.default_json_field_name]['float']
+                if not expr or eval(expr):
+                    filter_ids.append(_id)
+
+            # 3. search expressions
+            search_res, _ = self.search(client, collection_name,
+                                        data=search_vectors[:default_nq],
+                                        anns_field=default_search_field,
+                                        search_params=default_search_params,
+                                        limit=nb,
+                                        filter=expr,
+                                        check_task=CheckTasks.check_search_results,
+                                        check_items={"nq": default_nq,
+                                                     "ids": insert_ids,
+                                                     "limit": min(nb, len(filter_ids)),
+                                                     "metric": "COSINE",
+                                                     "enable_milvus_client_api": True,
+                                                     "pk_name": ct.default_int64_field_name})
+            filter_ids_set = set(filter_ids)
+            for hits in search_res:
+                ids = [hit[ct.default_int64_field_name] for hit in hits]
+                assert set(ids).issubset(filter_ids_set)
+
+            # 4. search again with expression template
+            expr = cf.get_expr_from_template(expressions[1]).replace("&&", "and").replace("||", "or")
+            expr_params = cf.get_expr_params_from_template(expressions[1])
+            search_res, _ = self.search(client, collection_name,
+                                        data=search_vectors[:default_nq],
+                                        anns_field=default_search_field,
+                                        search_params=default_search_params,
+                                        limit=nb,
+                                        filter=expr, filter_params=expr_params,
+                                        check_task=CheckTasks.check_search_results,
+                                        check_items={"nq": default_nq,
+                                                     "ids": insert_ids,
+                                                     "limit": min(nb, len(filter_ids)),
+                                                     "metric": "COSINE",
+                                                     "enable_milvus_client_api": True,
+                                                     "pk_name": ct.default_int64_field_name})
+            filter_ids_set = set(filter_ids)
+            for hits in search_res:
+                ids = [hit[ct.default_int64_field_name] for hit in hits]
+                assert set(ids).issubset(filter_ids_set)
+
+            # 5. search again with expression template and hint
+            search_params = default_search_params.copy()
+            search_params.update({"hints": "iterative_filter"})
+            search_res, _ = self.search(client, collection_name,
+                                        data=search_vectors[:default_nq],
+                                        anns_field=default_search_field,
+                                        search_params=search_params,
+                                        limit=nb,
+                                        filter=expr, filter_params=expr_params,
+                                        check_task=CheckTasks.check_search_results,
+                                        check_items={"nq": default_nq,
+                                                     "ids": insert_ids,
+                                                     "limit": min(nb, len(filter_ids)),
+                                                     "metric": "COSINE",
+                                                     "enable_milvus_client_api": True,
+                                                     "pk_name": ct.default_int64_field_name})
+            filter_ids_set = set(filter_ids)
+            for hits in search_res:
+                ids = [hit[ct.default_int64_field_name] for hit in hits]
+                assert set(ids).issubset(filter_ids_set)
+
+            # 6. create json index
+            idx2 = self.prepare_index_params(client)[0]
+            idx2.add_index(field_name=ct.default_json_field_name,
+                           index_type="INVERTED",
+                           index_name=f"{ct.default_json_field_name}_0",
+                           params={"json_cast_type": "double",
+                                   "json_path": f"{ct.default_json_field_name}['number']"})
+            self.create_index(client, collection_name, index_params=idx2)
+
+            idx3 = self.prepare_index_params(client)[0]
+            idx3.add_index(field_name=ct.default_json_field_name,
+                           index_type="AUTOINDEX",
+                           index_name=f"{ct.default_json_field_name}_1",
+                           params={"json_cast_type": "double",
+                                   "json_path": f"{ct.default_json_field_name}['float']"})
+            self.create_index(client, collection_name, index_params=idx3)
+
+            # 7. release and load to make sure the new index is loaded
+            self.release_collection(client, collection_name)
+            self.load_collection(client, collection_name)
+            # 8. search expressions after json path index
+            expr = expressions[0].replace("&&", "and").replace("||", "or")
+            search_res, _ = self.search(client, collection_name,
+                                        data=search_vectors[:default_nq],
+                                        anns_field=default_search_field,
+                                        search_params=default_search_params,
+                                        limit=nb,
+                                        filter=expr,
+                                        check_task=CheckTasks.check_search_results,
+                                        check_items={"nq": default_nq,
+                                                     "ids": insert_ids,
+                                                     "limit": min(nb, len(filter_ids)),
+                                                     "metric": "COSINE",
+                                                     "enable_milvus_client_api": True,
+                                                     "pk_name": ct.default_int64_field_name})
+            filter_ids_set = set(filter_ids)
+            for hits in search_res:
+                ids = [hit[ct.default_int64_field_name] for hit in hits]
+                assert set(ids).issubset(filter_ids_set)
+
+            # 9. search again with expression template after json path index
+            expr = cf.get_expr_from_template(expressions[1]).replace("&&", "and").replace("||", "or")
+            expr_params = cf.get_expr_params_from_template(expressions[1])
+            search_res, _ = self.search(client, collection_name,
+                                        data=search_vectors[:default_nq],
+                                        anns_field=default_search_field,
+                                        search_params=default_search_params,
+                                        limit=nb,
+                                        filter=expr, filter_params=expr_params,
+                                        check_task=CheckTasks.check_search_results,
+                                        check_items={"nq": default_nq,
+                                                     "ids": insert_ids,
+                                                     "limit": min(nb, len(filter_ids)),
+                                                     "metric": "COSINE",
+                                                     "enable_milvus_client_api": True,
+                                                     "pk_name": ct.default_int64_field_name})
+            filter_ids_set = set(filter_ids)
+            for hits in search_res:
+                ids = [hit[ct.default_int64_field_name] for hit in hits]
+                assert set(ids).issubset(filter_ids_set)
+
+            # 10. search again with expression template and hint after json path index
+            search_params = default_search_params.copy()
+            search_params.update({"hints": "iterative_filter"})
+            search_res, _ = self.search(client, collection_name,
+                                        data=search_vectors[:default_nq],
+                                        anns_field=default_search_field,
+                                        search_params=search_params,
+                                        limit=nb,
+                                        filter=expr, filter_params=expr_params,
+                                        check_task=CheckTasks.check_search_results,
+                                        check_items={"nq": default_nq,
+                                                     "ids": insert_ids,
+                                                     "limit": min(nb, len(filter_ids)),
+                                                     "metric": "COSINE",
+                                                     "enable_milvus_client_api": True,
+                                                     "pk_name": ct.default_int64_field_name})
+            filter_ids_set = set(filter_ids)
+            for hits in search_res:
+                ids = [hit[ct.default_int64_field_name] for hit in hits]
+                assert set(ids).issubset(filter_ids_set)
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_search_with_comparative_expression(self):
+        """
+        target: verify search with cross-field comparison expression (int64_1 <= int64_2)
+        method: 1. create collection with two int64 fields, insert data where int64_1 == int64_2
+                2. search with filter "int64_1 <= int64_2", verify all rows match
+        expected: all rows returned since int64_1 always equals int64_2
+        """
+        nb = 2000
+        dim = 2
+        nq = 1
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+
+        schema = self.create_schema(client)[0]
+        schema.add_field("int64_1", DataType.INT64, is_primary=True)
+        schema.add_field("int64_2", DataType.INT64)
+        schema.add_field(ct.default_float_vec_field_name, DataType.FLOAT_VECTOR, dim=dim)
+        self.create_collection(client, collection_name, schema=schema)
+
+        all_vectors = cf.gen_vectors(nb, dim)
+        data = [{"int64_1": i, "int64_2": i,
+                 ct.default_float_vec_field_name: all_vectors[i]} for i in range(nb)]
+        insert_ids = list(range(nb))
+        self.insert(client, collection_name, data=data)
+        self.flush(client, collection_name)
+
+        filter_ids = []
+        for i in range(nb):
+            if data[i]["int64_1"] <= data[i]["int64_2"]:
+                filter_ids.append(data[i]["int64_1"])
+
+        idx = self.prepare_index_params(client)[0]
+        idx.add_index(field_name=ct.default_float_vec_field_name, metric_type="COSINE",
+                      index_type="FLAT", params={})
+        self.create_index(client, collection_name, index_params=idx)
+        self.load_collection(client, collection_name)
+
+        expression = "int64_1 <= int64_2"
+        search_vectors = cf.gen_vectors(nq, dim)
+        res, _ = self.search(client, collection_name,
+                             data=search_vectors[:nq],
+                             anns_field=default_search_field,
+                             search_params=default_search_params,
+                             limit=default_limit,
+                             filter=expression,
+                             check_task=CheckTasks.check_search_results,
+                             check_items={"nq": nq,
+                                          "ids": insert_ids,
+                                          "limit": default_limit,
+                                          "metric": "COSINE",
+                                          "enable_milvus_client_api": True,
+                                          "pk_name": "int64_1"})
+        filter_ids_set = set(filter_ids)
+        for hits in res:
+            ids = [hit["int64_1"] for hit in hits]
+            assert set(ids).issubset(filter_ids_set)
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_search_expression_with_double_quotes(self):
+        """
+        target: verify search with varchar filter containing escaped double quotes returns exact match
+        method: 1. insert data with varchar values containing single and double quotes
+                2. search with escaped double-quote filter for a random row
+                3. verify exactly 1 result returned with correct PK
+        expected: exact match on the escaped string, returns the correct single row
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+
+        schema = self.create_schema(client)[0]
+        schema.add_field(ct.default_int64_field_name, DataType.INT64, is_primary=True)
+        schema.add_field(ct.default_float_field_name, DataType.FLOAT)
+        schema.add_field(ct.default_string_field_name, DataType.VARCHAR, max_length=65535)
+        schema.add_field(ct.default_json_field_name, DataType.JSON)
+        schema.add_field(ct.default_float_vec_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
+        self.create_collection(client, collection_name, schema=schema)
+
+        data = cf.gen_row_data_by_schema(nb=default_nb, schema=schema)
+        string_value = [(f"'{cf.gen_str_by_length(3)}'{cf.gen_str_by_length(3)}\""
+                         f"{cf.gen_str_by_length(3)}\"") for _ in range(default_nb)]
+        for i in range(default_nb):
+            data[i][default_string_field_name] = string_value[i]
+        insert_ids = [i for i in range(default_nb)]
+        self.insert(client, collection_name, data=data)
+        self.flush(client, collection_name)
+
+        idx = self.prepare_index_params(client)[0]
+        idx.add_index(field_name=ct.default_float_vec_field_name, metric_type="COSINE",
+                      index_type="FLAT", params={})
+        self.create_index(client, collection_name, index_params=idx)
+        self.load_collection(client, collection_name)
+
+        _id = random.randint(0, default_nb - 1)
+        string_value[_id] = string_value[_id].replace("\"", "\\\"")
+        expression = f"{default_string_field_name} == \"{string_value[_id]}\""
+        log.debug("test_search_expression_with_double_quotes: searching with expression: %s" % expression)
+        search_vectors = cf.gen_vectors(default_nq, default_dim)
+        search_res, _ = self.search(client, collection_name,
+                                    data=search_vectors[:default_nq],
+                                    anns_field=default_search_field,
+                                    search_params=default_search_params,
+                                    limit=default_limit,
+                                    filter=expression,
+                                    check_task=CheckTasks.check_search_results,
+                                    check_items={"nq": default_nq,
+                                                 "ids": insert_ids,
+                                                 "limit": 1,
+                                                 "metric": "COSINE",
+                                                 "enable_milvus_client_api": True,
+                                                 "pk_name": ct.default_int64_field_name})
+        assert search_res[0][0][ct.default_int64_field_name] == _id
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_search_concurrent_two_collections_nullable(self):
+        """
+        target: verify concurrent search across two collections with all-null JSON field is thread-safe
+        method: 1. create two collections with nullable JSON, insert data with all JSON=None
+                2. launch 10 threads searching collection_1 concurrently
+                3. verify each thread gets correct results via check_task
+        expected: all concurrent searches succeed with correct nq/limit
+        """
+        nq = 200
+        dim = 64
+        enable_dynamic_field = False
+        threads_num = 10
+        threads = []
+
+        client = self._client()
+        collection_name_1 = cf.gen_collection_name_by_testcase_name() + "_1"
+        collection_name_2 = cf.gen_collection_name_by_testcase_name() + "_2"
+
+        schema = self.create_schema(client, enable_dynamic_field=enable_dynamic_field)[0]
+        schema.add_field(ct.default_int64_field_name, DataType.INT64, is_primary=True, auto_id=True)
+        schema.add_field(ct.default_float_field_name, DataType.FLOAT)
+        schema.add_field(ct.default_string_field_name, DataType.VARCHAR, max_length=65535)
+        schema.add_field(ct.default_json_field_name, DataType.JSON, nullable=True)
+        schema.add_field(ct.default_float_vec_field_name, DataType.FLOAT_VECTOR, dim=dim)
+        self.create_collection(client, collection_name_1, schema=schema)
+        self.create_collection(client, collection_name_2, schema=schema)
+
+        data = cf.gen_row_data_by_schema(nb=default_nb, schema=schema)
+        for row in data:
+            row[ct.default_json_field_name] = None
+        insert_res_1, _ = self.insert(client, collection_name_1, data=data)
+        insert_ids = insert_res_1["ids"]
+        self.insert(client, collection_name_2, data=data)
+        self.flush(client, collection_name_1)
+        self.flush(client, collection_name_2)
+
+        idx = self.prepare_index_params(client)[0]
+        idx.add_index(field_name=ct.default_float_vec_field_name, metric_type="COSINE")
+        self.create_index(client, collection_name_1, index_params=idx)
+        self.create_index(client, collection_name_2, index_params=idx)
+        self.load_collection(client, collection_name_1)
+        self.load_collection(client, collection_name_2)
+
+        def search(coll_name):
+            search_vectors = cf.gen_vectors(nq, dim)
+            self.search(client, coll_name,
+                        data=search_vectors[:nq],
+                        anns_field=default_search_field,
+                        search_params=default_search_params,
+                        limit=default_limit,
+                        filter=default_search_exp,
+                        check_task=CheckTasks.check_search_results,
+                        check_items={"nq": nq,
+                                     "ids": insert_ids,
+                                     "limit": default_limit,
+                                     "metric": "COSINE",
+                                     "enable_milvus_client_api": True,
+                                     "pk_name": ct.default_int64_field_name})
+
+        log.info("test_search_concurrent_two_collections_nullable: searching with %s threads" % threads_num)
+        for _ in range(threads_num):
+            t = threading.Thread(target=search, args=(collection_name_1,))
+            threads.append(t)
+            t.start()
+        for t in threads:
+            t.join()
+
+    @pytest.mark.tags(CaseLabel.L2)
+    @pytest.mark.parametrize("metric_type", ["JACCARD", "HAMMING"])
+    def test_search_with_invalid_metric_type(self, metric_type):
+        """
+        target: verify creating index with unsupported metric type for float vector raises error
+        method: 1. create collection with float_vector field
+                2. attempt to create index with JACCARD/HAMMING metric (unsupported for float vectors)
+        expected: index creation raises an error with err_code 1100
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+
+        schema = self.create_schema(client)[0]
+        schema.add_field(ct.default_int64_field_name, DataType.INT64, is_primary=True)
+        schema.add_field(ct.default_float_vec_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
+        self.create_collection(client, collection_name, schema=schema)
+
+        data = cf.gen_row_data_by_schema(nb=100, schema=schema)
+        self.insert(client, collection_name, data=data)
+        self.flush(client, collection_name)
+
+        idx = self.prepare_index_params(client)[0]
+        idx.add_index(field_name=ct.default_float_vec_field_name, metric_type=metric_type,
+                      index_type="FLAT", params={})
+        self.create_index(client, collection_name, index_params=idx,
+                          check_task=CheckTasks.err_res,
+                          check_items={"err_code": 1100})

--- a/tests/python_client/milvus_client_v2/test_milvus_client_search_v2_new.py
+++ b/tests/python_client/milvus_client_v2/test_milvus_client_search_v2_new.py
@@ -4,39 +4,18 @@ from common import common_type as ct
 from common import common_func as cf
 from utils.util_log import test_log as log
 from base.client_v2_base import TestMilvusClientV2Base
-from concurrent.futures import ThreadPoolExecutor, as_completed
 import random
 import pytest
-import pandas as pd
-from faker import Faker
 import numpy as np
 
-Faker.seed(19530)
-fake_en = Faker("en_US")
-fake_zh = Faker("zh_CN")
-
-# patch faker to generate text with specific distribution
-cf.patch_faker_text(fake_en, cf.en_vocabularies_distribution)
-cf.patch_faker_text(fake_zh, cf.zh_vocabularies_distribution)
-
-pd.set_option("expand_frame_repr", False)
-
-prefix = "search_collection"
 default_nb = ct.default_nb
 default_nq = ct.default_nq
 default_dim = ct.default_dim
 default_limit = ct.default_limit
-default_search_exp = "int64 >= 0"
-default_search_string_exp = "varchar >= \"0\""
-default_search_mix_exp = "int64 >= 0 && varchar >= \"0\""
-default_json_search_exp = "json_field[\"number\"] >= 0"
-perfix_expr = 'varchar like "0%"'
-
-default_vector_field_name = "vector"
 
 
 @pytest.mark.xdist_group("TestMilvusClientSearchBasicV2")
-@pytest.mark.tags(CaseLabel.GPU)
+@pytest.mark.tags(CaseLabel.L1)
 class TestMilvusClientSearchBasicV2(TestMilvusClientV2Base):
     """Test search functionality with new client API"""
 
@@ -62,8 +41,8 @@ class TestMilvusClientSearchBasicV2(TestMilvusClientV2Base):
         self.binary_vector_index = "BIN_IVF_FLAT"
         self.primary_keys = []
         self.enable_dynamic_field = True
-        self.dyna_filed_name1 = "dyna_filed_name1"
-        self.dyna_filed_name2 = "dyna_filed_name2"
+        self.dyna_field_name1 = "dyna_field_name1"
+        self.dyna_field_name2 = "dyna_field_name2"
         self.datas = []
 
     @pytest.fixture(scope="class", autouse=True)
@@ -115,8 +94,8 @@ class TestMilvusClientSearchBasicV2(TestMilvusClientV2Base):
                     self.binary_vector_field_name: binary_vectors[pk],
                     ct.default_float_field_name: pk * 1.0 if pk % 5 == 0 else None,
                     ct.default_string_field_name: str(pk) if pk % 5 == 0 else None,
-                    self.dyna_filed_name1: f"dyna_value_{pk}",
-                    self.dyna_filed_name2: pk * 1.0
+                    self.dyna_field_name1: f"dyna_value_{pk}",
+                    self.dyna_field_name2: pk * 1.0
                 }
                 self.datas.append(row)
 
@@ -230,7 +209,7 @@ class TestMilvusClientSearchBasicV2(TestMilvusClientV2Base):
         search_res, _ = self.search(
             client,
             collection_name,
-            vectors_to_search[:default_nq],
+            vectors_to_search,
             anns_field=self.bfloat16_vector_field_name,
             search_params=search_params,
             limit=default_limit,
@@ -262,7 +241,7 @@ class TestMilvusClientSearchBasicV2(TestMilvusClientV2Base):
         search_res, _ = self.search(
             client,
             collection_name,
-            vectors_to_search[:default_nq],
+            vectors_to_search,
             anns_field=self.sparse_vector_field_name,
             search_params=search_params,
             limit=default_limit,
@@ -280,7 +259,7 @@ class TestMilvusClientSearchBasicV2(TestMilvusClientV2Base):
         search_res, _ = self.search(
             client,
             collection_name,
-            vectors_to_search[:default_nq],
+            vectors_to_search,
             search_params=search_params,
             limit=default_limit,
             check_task=CheckTasks.err_res,
@@ -330,7 +309,7 @@ class TestMilvusClientSearchBasicV2(TestMilvusClientV2Base):
         search_res, _ = self.search(
             client,
             collection_name,
-            vectors_to_search[:default_nq],
+            vectors_to_search,
             anns_field=self.binary_vector_field_name,
             search_params=search_params,
             limit=default_limit,
@@ -345,7 +324,6 @@ class TestMilvusClientSearchBasicV2(TestMilvusClientV2Base):
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("limit, nq", zip([1, 1000, ct.max_limit], [ct.max_nq, 10, 1]))
-    # @pytest.mark.parametrize("limit, nq", zip([ct.max_limit], [1]))
     def test_search_with_different_nq_limits(self, limit, nq):
         """
         target: test search with different nq and limit values
@@ -365,7 +343,7 @@ class TestMilvusClientSearchBasicV2(TestMilvusClientV2Base):
         search_res, _ = self.search(
             client,
             collection_name,
-            vectors_to_search[:nq],
+            vectors_to_search,
             anns_field=self.float_vector_field_name,
             search_params=search_params,
             limit=limit,
@@ -398,18 +376,18 @@ class TestMilvusClientSearchBasicV2(TestMilvusClientV2Base):
         search_res, _ = self.search(
             client,
             collection_name,
-            vectors_to_search[:default_nq],
+            vectors_to_search,
             anns_field=self.float_vector_field_name,
             search_params=search_params,
             limit=default_limit,
             consistency_level=consistency_level,
-            output_fields=[ct.default_string_field_name, self.dyna_filed_name1, self.dyna_filed_name2],
+            output_fields=[ct.default_string_field_name, self.dyna_field_name1, self.dyna_field_name2],
             check_task=CheckTasks.check_search_results,
             check_items={"enable_milvus_client_api": True,
                          "nq": default_nq,
                          "limit": default_limit,
                          "metric": self.float_vector_metric,
-                         "output_fields": [ct.default_string_field_name, self.dyna_filed_name1, self.dyna_filed_name2],
+                         "output_fields": [ct.default_string_field_name, self.dyna_field_name1, self.dyna_field_name2],
                          "original_entities": self.datas,
                          "pk_name": self.pk_field_name
                          }
@@ -437,7 +415,7 @@ class TestMilvusClientSearchBasicV2(TestMilvusClientV2Base):
         search_res, _ = self.search(
             client,
             collection_name,
-            vectors_to_search[:default_nq],
+            vectors_to_search,
             anns_field=self.float_vector_field_name,
             search_params=search_params,
             limit=default_limit,
@@ -447,7 +425,7 @@ class TestMilvusClientSearchBasicV2(TestMilvusClientV2Base):
                          "nq": default_nq,
                          "limit": default_limit,
                          "metric": self.float_vector_metric,
-                         "output_fields": field_names.extend([self.dyna_filed_name1, self.dyna_filed_name2]),
+                         "output_fields": field_names + [self.dyna_field_name1, self.dyna_field_name2],
                          "original_entities": self.datas,
                          "pk_name": self.pk_field_name
                          }
@@ -474,12 +452,12 @@ class TestMilvusClientSearchBasicV2(TestMilvusClientV2Base):
 
         # search with output fields
         expected_outputs = cf.get_wildcard_output_field_names(collection_info, wildcard_output_fields)
-        expected_outputs.extend([self.dyna_filed_name1, self.dyna_filed_name2])
+        expected_outputs.extend([self.dyna_field_name1, self.dyna_field_name2])
         log.info(f"search with output fields: {wildcard_output_fields}")
         search_res, _ = self.search(
             client,
             collection_name,
-            vectors_to_search[:default_nq],
+            vectors_to_search,
             partition_names=[partition_name],
             anns_field=self.float_vector_field_name,
             search_params=search_params,
@@ -489,6 +467,7 @@ class TestMilvusClientSearchBasicV2(TestMilvusClientV2Base):
             check_items={"enable_milvus_client_api": True,
                          "nq": default_nq,
                          "pk_name": self.pk_field_name,
+                         "metric": self.float_vector_metric,
                          "limit": default_limit,
                          "output_fields": expected_outputs})
 
@@ -511,7 +490,7 @@ class TestMilvusClientSearchBasicV2(TestMilvusClientV2Base):
             error1 = {ct.err_code: 999, ct.err_msg: f"parse output field name failed: {field[0]}"}
             error2 = {ct.err_code: 999, ct.err_msg: f"`output_fields` value {field} is illegal"}
             error = error2 if field == [""] else error1
-            self.search(client, collection_name, vectors_to_search[:default_nq],
+            self.search(client, collection_name, vectors_to_search,
                         anns_field=self.float_vector_field_name,
                         search_params=search_params,
                         limit=default_limit,
@@ -519,7 +498,7 @@ class TestMilvusClientSearchBasicV2(TestMilvusClientV2Base):
                         check_task=CheckTasks.err_res, check_items=error)
 
         # verify non-exist field as output field is valid as dynamic field enabled
-        self.search(client, collection_name, vectors_to_search[:default_nq],
+        self.search(client, collection_name, vectors_to_search,
                     anns_field=self.float_vector_field_name,
                     search_params=search_params,
                     limit=default_limit,
@@ -552,7 +531,7 @@ class TestMilvusClientSearchBasicV2(TestMilvusClientV2Base):
         search_res, _ = self.search(
             client,
             collection_name,
-            vectors_to_search[:default_nq],
+            vectors_to_search,
             anns_field=self.float_vector_field_name,
             search_params=search_params,
             limit=ct.max_limit + 1,
@@ -602,6 +581,7 @@ class TestMilvusClientSearchBasicV2(TestMilvusClientV2Base):
         search_params = {"metric_type": self.float_vector_metric, "params": {"nprobe": 100}}
 
         # search with concurrent threads using thread pool
+        from concurrent.futures import ThreadPoolExecutor, as_completed
         num_threads = 10
         with ThreadPoolExecutor(max_workers=num_threads) as executor:
             futures = []
@@ -610,7 +590,7 @@ class TestMilvusClientSearchBasicV2(TestMilvusClientV2Base):
                     self.search,
                     client,
                     collection_name,
-                    vectors_to_search[:default_nq],
+                    vectors_to_search,
                     anns_field=self.float_vector_field_name,
                     search_params=search_params,
                     limit=default_limit,
@@ -680,7 +660,7 @@ class TestMilvusClientSearchBasicV2(TestMilvusClientV2Base):
         search_res, _ = self.search(
             client,
             collection_name,
-            vectors_to_search[:default_nq],
+            vectors_to_search,
             anns_field=self.float_vector_field_name,
             search_params=search_params,
             limit=default_limit,
@@ -689,24 +669,24 @@ class TestMilvusClientSearchBasicV2(TestMilvusClientV2Base):
         )
 
     @pytest.mark.tags(CaseLabel.L2)
-    def test_search_with_dismatched_metric_type(self):
+    def test_search_with_mismatched_metric_type(self):
         """
-        target: test search with dismatched metric type
+        target: test search with mismatched metric type
         method: 1. connect and create a collection
-                2. search with dismatched metric type
-        expected: search successfully with dismatched metric type
+                2. search with mismatched metric type
+        expected: search successfully with mismatched metric type
         """
         client = self._client()
         collection_name = self.collection_name
         vectors_to_search = cf.gen_vectors(default_nq, self.float_vector_dim)
         search_params = {"metric_type": self.sparse_vector_metric, "params": {"nprobe": 100}}
 
-        # search with dismatched metric type
+        # search with mismatched metric type
         error = {"err_code": 999, "err_msg": "metric type not match: invalid parameter[expected=COSINE][actual=IP]"}
         search_res, _ = self.search(
             client,
             collection_name,
-            vectors_to_search[:default_nq],
+            vectors_to_search,
             anns_field=self.float_vector_field_name,
             search_params=search_params,
             limit=default_limit,
@@ -733,7 +713,7 @@ class TestMilvusClientSearchBasicV2(TestMilvusClientV2Base):
         search_res, _ = self.search(
             client,
             collection_name,
-            vectors_to_search[:default_nq],
+            vectors_to_search,
             anns_field=self.float_vector_field_name,
             search_params=search_params,
             partition_names=[partition_name],
@@ -744,17 +724,6 @@ class TestMilvusClientSearchBasicV2(TestMilvusClientV2Base):
 
 class TestSearchV2Independent(TestMilvusClientV2Base):
     """Test search functionality with independent collections"""
-
-    @pytest.mark.tags(CaseLabel.L2)
-    def test_search_dense_vectors_indices_metrics_growing(self):
-        """
-        target: test search with different dense vector types, indices and metrics
-        method: create connection, collection, insert data and search
-        expected: searched successfully
-        """
-        # basic search on dense vectors,
-        # indices and metrics are covered in test_search_pagination_dense_vectors_indices_metrics_growing
-        pass
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_search_on_empty_partition(self):
@@ -779,7 +748,7 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
         search_res, _ = self.search(
             client,
             collection_name,
-            vectors_to_search[:default_nq],
+            vectors_to_search,
             search_params=search_params,
             limit=default_limit,
             partition_names=[partition_name],
@@ -787,8 +756,9 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
             check_items={"enable_milvus_client_api": True,
                          "nq": default_nq,
                          "limit": 0,
-                         "pk_name": 'id',
-                         "ids": []})
+                         "pk_name": ct.default_primary_key_field_name,
+                         "ids": [],
+                         "metric": "COSINE"})
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_search_cosine_results_same_as_l2_and_ip(self):
@@ -828,7 +798,7 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
         search_res_cosine, _ = self.search(
             client,
             collection_name,
-            vectors_to_search[:default_nq],
+            vectors_to_search,
             anns_field=ct.default_float_vec_field_name,
             search_params=search_params,
             limit=default_limit,
@@ -858,7 +828,7 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
         search_res_l2, _ = self.search(
             client,
             collection_name,
-            vectors_to_search[:default_nq],
+            vectors_to_search,
             anns_field=ct.default_float_vec_field_name,
             search_params=search_params,
             limit=default_limit,
@@ -889,7 +859,7 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
         search_res_ip, _ = self.search(
             client,
             collection_name,
-            vectors_to_search[:default_nq],
+            vectors_to_search,
             anns_field=ct.default_float_vec_field_name,
             search_params=search_params,
             limit=default_limit,
@@ -920,12 +890,9 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
         self.create_collection(client, collection_name, dimension=dim)
 
         # insert data with duplicate primary key
-        data = []
-        for i in range(default_nb):
-            data.append({
-                "id": i if i % 2 == 0 else i + 1,
-                "vector": cf.gen_vectors(1, dim)[0],
-            })
+        all_vectors = cf.gen_vectors(default_nb, dim)
+        data = [{ct.default_primary_key_field_name: i if i % 2 == 0 else i + 1,
+                 ct.default_vector_field_name: all_vectors[i]} for i in range(default_nb)]
         self.insert(client, collection_name, data)
         client.flush(collection_name)
 
@@ -935,14 +902,15 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
         search_res, _ = self.search(
             client,
             collection_name,
-            vectors_to_search[:default_nq],
-            anns_field="vector",
+            vectors_to_search,
+            anns_field=ct.default_vector_field_name,
             search_params=search_params,
             limit=default_limit,
             check_task=CheckTasks.check_search_results,
             check_items={"enable_milvus_client_api": True,
                          "nq": default_nq,
-                         "pk_name": "id",
+                         "pk_name": ct.default_primary_key_field_name,
+                         "metric": "COSINE",
                          "limit": default_limit}
         )
 
@@ -965,16 +933,13 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
         self.create_collection(client, collection_name, dimension=ct.default_dim)
 
         # insert data
-        data = []
-        for i in range(default_nb):
-            data.append({
-                "id": i,
-                "vector": cf.gen_vectors(1, ct.default_dim)[0],
-            })
+        all_vectors = cf.gen_vectors(default_nb, ct.default_dim)
+        data = [{ct.default_primary_key_field_name: i,
+                 ct.default_vector_field_name: all_vectors[i]} for i in range(default_nb)]
         self.insert(client, collection_name, data)
         if flush:
             self.flush(client, collection_name)
-            self.wait_for_index_ready(client, collection_name, index_name='vector')
+            self.wait_for_index_ready(client, collection_name, index_name=ct.default_vector_field_name)
 
         # release collection
         self.release_collection(client, collection_name)
@@ -985,8 +950,8 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
         search_res, _ = self.search(
             client,
             collection_name,
-            vectors_to_search[:default_nq],
-            anns_field="vector",
+            vectors_to_search,
+            anns_field=ct.default_vector_field_name,
             search_params=search_params,
             limit=default_limit,
             check_task=CheckTasks.err_res,
@@ -1001,17 +966,18 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
         search_res, _ = self.search(
             client,
             collection_name,
-            vectors_to_search[:default_nq],
-            anns_field="vector",
+            vectors_to_search,
+            anns_field=ct.default_vector_field_name,
             search_params=search_params,
             limit=default_limit,
             check_task=CheckTasks.check_search_results,
             check_items={"enable_milvus_client_api": True,
                          "nq": default_nq,
-                         "pk_name": "id",
+                         "pk_name": ct.default_primary_key_field_name,
+                         "metric": "COSINE",
                          "limit": default_limit})
 
-    @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.tags(CaseLabel.L1)
     def test_search_after_partition_release(self):
         """
         target: test search after partition release     
@@ -1051,8 +1017,8 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
             for i in range(ct.default_nb):
                 pk = i + j * ct.default_nb
                 row = {
-                    'id': pk,
-                    'vector': float_vectors[pk]
+                    ct.default_primary_key_field_name: pk,
+                    ct.default_vector_field_name: float_vectors[pk]
                 }
 
                 # Distribute to partitions based on pk mod 3
@@ -1072,7 +1038,7 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
                 self.insert(client, collection_name, data=partition2_rows, partition_name=partition_names[1])
 
         self.flush(client, collection_name)
-        self.wait_for_index_ready(client, collection_name, index_name='vector')
+        self.wait_for_index_ready(client, collection_name, index_name=ct.default_vector_field_name)
 
         # search in the collection
         vectors_to_search = cf.gen_vectors(1, ct.default_dim)
@@ -1081,14 +1047,15 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
         search_res1, _ = self.search(
             client,
             collection_name,
-            vectors_to_search[:1],
-            anns_field="vector",
+            vectors_to_search,
+            anns_field=ct.default_vector_field_name,
             search_params=search_params,
             limit=limit,
             check_task=CheckTasks.check_search_results,
             check_items={"enable_milvus_client_api": True,
                          "nq": 1,
-                         "pk_name": "id",
+                         "pk_name": ct.default_primary_key_field_name,
+                         "metric": "COSINE",
                          "limit": limit})
 
         # find one result that not in default partition
@@ -1120,14 +1087,15 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
         search_res2, _ = self.search(
             client,
             collection_name,
-            vectors_to_search[:1],
-            anns_field="vector",
+            vectors_to_search,
+            anns_field=ct.default_vector_field_name,
             search_params=search_params,
             limit=limit,
             check_task=CheckTasks.check_search_results,
             check_items={"enable_milvus_client_api": True,
                          "nq": 1,
-                         "pk_name": "id",
+                         "pk_name": ct.default_primary_key_field_name,
+                         "metric": "COSINE",
                          "limit": limit})
         # verify no results are from the released partition
         for i in range(limit):
@@ -1138,15 +1106,16 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
         search_res3, _ = self.search(
             client,
             collection_name,
-            vectors_to_search[:1],
-            anns_field="vector",
+            vectors_to_search,
+            anns_field=ct.default_vector_field_name,
             partition_names=[ct.default_partition_name, the_other_partition],
             search_params=search_params,
             limit=limit,
             check_task=CheckTasks.check_search_results,
             check_items={"enable_milvus_client_api": True,
                          "nq": 1,
-                         "pk_name": "id",
+                         "pk_name": ct.default_primary_key_field_name,
+                         "metric": "COSINE",
                          "limit": limit})
         # verify the results are same as the 2nd search results
         assert search_res3[0].ids == search_res2[0].ids
@@ -1156,14 +1125,15 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
         search_res4, _ = self.search(
             client,
             collection_name,
-            vectors_to_search[:1],
-            anns_field="vector",
+            vectors_to_search,
+            anns_field=ct.default_vector_field_name,
             search_params=search_params,
             limit=limit,
             check_task=CheckTasks.check_search_results,
             check_items={"enable_milvus_client_api": True,
                          "nq": 1,
-                         "pk_name": "id",
+                         "pk_name": ct.default_primary_key_field_name,
+                         "metric": "COSINE",
                          "limit": limit})
         # verify the results are same as the first search results
         # assert search_res4[0].ids == search_res1[0].ids
@@ -1177,14 +1147,15 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
         search_res5, _ = self.search(
             client,
             collection_name,
-            vectors_to_search[:1],
-            anns_field="vector",
+            vectors_to_search,
+            anns_field=ct.default_vector_field_name,
             search_params=search_params,
             limit=limit,
             check_task=CheckTasks.check_search_results,
             check_items={"enable_milvus_client_api": True,
                          "nq": 1,
-                         "pk_name": "id",
+                         "pk_name": ct.default_primary_key_field_name,
+                         "metric": "COSINE",
                          "limit": limit})
         # verify the results are same as the first search results
         assert search_res5[0].ids == search_res4[0].ids
@@ -1204,13 +1175,9 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
         self.create_collection(client, collection_name, dimension=dim)
 
         # insert data
-        data = []
         nb = 200
-        for i in range(nb):
-            data.append({
-                "id": i,
-                "vector": cf.gen_vectors(1, dim)[0]
-            })
+        all_vectors = cf.gen_vectors(nb, dim)
+        data = [{"id": i, "vector": all_vectors[i]} for i in range(nb)]
         self.insert(client, collection_name, data)
 
         # search
@@ -1219,7 +1186,7 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
         search_res, _ = self.search(
             client,
             collection_name,
-            vectors_to_search[:ct.default_nq],
+            vectors_to_search,
             anns_field="vector",
             search_params=search_params,
             limit=ct.default_limit,
@@ -1227,6 +1194,7 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
             check_items={"enable_milvus_client_api": True,
                          "nq": ct.default_nq,
                          "pk_name": "id",
+                         "metric": "COSINE",
                          "limit": ct.default_limit})
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -1243,12 +1211,8 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
         self.create_collection(client, collection_name, dimension=ct.default_dim)
 
         # insert data
-        data = []
-        for i in range(ct.default_nb):
-            data.append({
-                "id": i,
-                "vector": cf.gen_vectors(1, ct.default_dim)[0]
-            })
+        all_vectors = cf.gen_vectors(ct.default_nb, ct.default_dim)
+        data = [{"id": i, "vector": all_vectors[i]} for i in range(ct.default_nb)]
         self.insert(client, collection_name, data)
 
         self.flush(client, collection_name)
@@ -1260,7 +1224,7 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
         search_res, _ = self.search(
             client,
             collection_name,
-            vectors_to_search[:ct.default_nq],
+            vectors_to_search,
             anns_field="vector",
             search_params=search_params,
             limit=ct.default_limit,
@@ -1268,6 +1232,7 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
             check_items={"enable_milvus_client_api": True,
                          "nq": ct.default_nq,
                          "pk_name": "id",
+                         "metric": "COSINE",
                          "limit": ct.default_limit})
 
         # recreate index
@@ -1282,11 +1247,11 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
         self.wait_for_index_ready(client, collection_name, index_name='vector')
         self.load_collection(client, collection_name)
 
-        # search
+        # search after recreate with L2
         search_res, _ = self.search(
             client,
             collection_name,
-            vectors_to_search[:ct.default_nq],
+            vectors_to_search,
             anns_field="vector",
             search_params=search_params,
             limit=ct.default_limit,
@@ -1294,10 +1259,11 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
             check_items={"enable_milvus_client_api": True,
                          "nq": ct.default_nq,
                          "pk_name": "id",
+                         "metric": "L2",
                          "limit": ct.default_limit})
 
     @pytest.mark.tags(CaseLabel.L2)
-    @pytest.mark.parametrize("index", ct.all_index_types[:6])
+    @pytest.mark.parametrize("index", ct.all_dense_float_index_types)
     def test_each_index_with_mmap_enabled_search(self, index):
         """
         target: test each index with mmap enabled search
@@ -1315,12 +1281,8 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
         self.create_collection(client, collection_name, schema=schema)
 
         # insert data
-        data = []
-        for i in range(ct.default_nb):
-            data.append({
-                "id": i,
-                "vector": cf.gen_vectors(1, dim)[0]
-            })
+        all_vectors = cf.gen_vectors(ct.default_nb, dim)
+        data = [{"id": i, "vector": all_vectors[i]} for i in range(ct.default_nb)]
         self.insert(client, collection_name, data)
         self.flush(client, collection_name)
         # create index
@@ -1345,7 +1307,8 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
                     check_items={"enable_milvus_client_api": True,
                                  "nq": ct.default_nq,
                                  "limit": ct.default_limit,
-                                 "pk_name": "id"})
+                                 "pk_name": "id",
+                                 "metric": "L2"})
         # disable mmap
         self.release_collection(client, collection_name)
         self.alter_index_properties(client, collection_name, index_name='vector', properties={"mmap.enabled": False})
@@ -1359,10 +1322,11 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
                     check_items={"enable_milvus_client_api": True,
                                  "nq": ct.default_nq,
                                  "limit": ct.default_limit,
-                                 "pk_name": "id"})
+                                 "pk_name": "id",
+                                 "metric": "L2"})
 
     @pytest.mark.tags(CaseLabel.L2)
-    @pytest.mark.parametrize("index", ct.all_index_types[8:10])
+    @pytest.mark.parametrize("index", ct.binary_supported_index_types)
     def test_enable_mmap_search_for_binary_indexes(self, index):
         """
         Test enabling mmap for binary indexes in Milvus.
@@ -1391,12 +1355,8 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
         self.create_collection(client, collection_name, schema=schema)
 
         # insert data
-        data = []
-        for i in range(ct.default_nb):
-            data.append({
-                "id": i,
-                "vector": cf.gen_binary_vectors(1, dim)[1][0]
-            })
+        _, binary_vectors = cf.gen_binary_vectors(ct.default_nb, dim)
+        data = [{"id": i, "vector": binary_vectors[i]} for i in range(ct.default_nb)]
         self.insert(client, collection_name, data)
         self.flush(client, collection_name)
         # create index
@@ -1423,7 +1383,8 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
                     check_items={"enable_milvus_client_api": True,
                                  "nq": ct.default_nq,
                                  "limit": ct.default_limit,
-                                 "pk_name": "id"})
+                                 "pk_name": "id",
+                                 "metric": "JACCARD"})
         # disable mmap
         self.release_collection(client, collection_name)
         self.alter_index_properties(client, collection_name, index_name='vector', properties={"mmap.enabled": False})
@@ -1437,7 +1398,8 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
                     check_items={"enable_milvus_client_api": True,
                                  "nq": ct.default_nq,
                                  "limit": ct.default_limit,
-                                 "pk_name": "id"})
+                                 "pk_name": "id",
+                                 "metric": "JACCARD"})
     
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("num_shards", [-256, 0, ct.max_shards_num // 2, ct.max_shards_num])
@@ -1475,12 +1437,8 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
         expected_num_shards = ct.default_shards_num if num_shards <= 0 else num_shards
         assert collection_info["num_shards"] == expected_num_shards
         # insert
-        data = []
-        for i in range(ct.default_nb):
-            data.append({
-                "id": i,
-                "vector": cf.gen_vectors(1, dim)[0]
-            })
+        all_vectors = cf.gen_vectors(ct.default_nb, dim)
+        data = [{"id": i, "vector": all_vectors[i]} for i in range(ct.default_nb)]
         self.insert(client, collection_name, data)
         # create index
         index_params = self.prepare_index_params(client)[0]
@@ -1498,11 +1456,12 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
                     check_items={"enable_milvus_client_api": True,
                                  "nq": ct.default_nq,
                                  "limit": ct.default_limit,
-                                 "pk_name": "id"})
-    
+                                 "pk_name": "id",
+                                 "metric": "COSINE"})
+
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize('vector_dtype', ct.all_dense_vector_types)
-    @pytest.mark.parametrize('index', ct.all_index_types[:8])
+    @pytest.mark.parametrize('index', ct.all_dense_float_index_types)
     def test_search_output_field_vector_with_dense_vector_and_index(self, vector_dtype, index):
         """
         Test search with output vector field after different index types.
@@ -1571,7 +1530,7 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
             self.create_index(client, collection_name, index_params=index_params)
 
             # load the collection with index
-            assert self.wait_for_index_ready(client, collection_name, default_vector_field_name, timeout=120)
+            assert self.wait_for_index_ready(client, collection_name, "vector", timeout=120)
             self.load_collection(client, collection_name)
 
             # search with output field vector
@@ -1587,6 +1546,7 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
                                      "pk_name": "id",
                                      "nq": ct.default_nq,
                                      "limit": limit,
+                                     "metric": metrics,
                                      "output_fields": ["id", "vector", "float_vector2", "float_array", "json_field", "string_field"]})
             # search output specify all fields
             self.search(client, collection_name, vectors, anns_field="vector",
@@ -1597,6 +1557,7 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
                                      "pk_name": "id",
                                      "nq": ct.default_nq,
                                      "limit": limit,
+                                     "metric": metrics,
                                      "output_fields": ["id", "vector", "float_vector2", "float_array", "json_field", "string_field"]})
             # search output specify some fields
             self.search(client, collection_name, vectors, anns_field="vector",
@@ -1607,6 +1568,7 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
                                      "pk_name": "id",
                                      "nq": ct.default_nq,
                                      "limit": limit,
+                                     "metric": metrics,
                                      "output_fields": ["id", "vector", "float_vector2", "json_field"]})
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -1676,6 +1638,7 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
                                  "pk_name": "id",
                                  "nq": ct.default_nq,
                                  "limit": ct.default_limit,
+                                 "metric": "JACCARD",
                                  "output_fields": ["id", "vector"]})
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -1691,12 +1654,8 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
         # create collection with fast mode
         self.create_collection(client, collection_name, dimension=dim)
         # insert data
-        data = []
-        for i in range(ct.default_nb):
-            data.append({
-                "id": i,
-                "vector": cf.gen_vectors(1, dim)[0]
-            })
+        all_vectors = cf.gen_vectors(ct.default_nb, dim)
+        data = [{"id": i, "vector": all_vectors[i]} for i in range(ct.default_nb)]
         self.insert(client, collection_name, data)
         self.flush(client, collection_name)
         # search with empty output fields
@@ -1709,6 +1668,7 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
                     check_items={"enable_milvus_client_api": True,
                                  "pk_name": "id",
                                  "nq": ct.default_nq,
+                                 "metric": "COSINE",
                                  "limit": ct.default_limit})
         self.search(client, collection_name, vectors, anns_field="vector",
                     search_params=search_params, limit=ct.default_limit,
@@ -1717,10 +1677,11 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
                     check_items={"enable_milvus_client_api": True,
                                  "pk_name": "id",
                                  "nq": ct.default_nq,
+                                 "metric": "COSINE",
                                  "limit": ct.default_limit})
 
     @pytest.mark.tags(CaseLabel.L2)
-    @pytest.mark.parametrize("index", ct.all_index_types[1:8])
+    @pytest.mark.parametrize("index", ct.all_dense_float_index_types[1:])
     def test_search_repeatedly_with_different_index(self, index):
         """
         Test searching repeatedly with different index types to ensure consistent results.
@@ -1865,7 +1826,7 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
         search_params = {}
         search_exp = "expr_field >= 0"
         output_fields = ["id", "expr_field", "double_field"]
-        self.search(client, collection_name, search_vectors, anns_field="vector",
+        search_res, _ = self.search(client, collection_name, search_vectors, anns_field="vector",
                     search_params=search_params, limit=ct.default_limit,
                     filter=search_exp,
                     output_fields=output_fields,
@@ -1874,7 +1835,12 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
                                  "nq": ct.default_nq,
                                  "limit": ct.default_limit,
                                  "pk_name": "id",
+                                 "metric": "COSINE",
                                  "output_fields": output_fields})
+        # verify returned entities satisfy the filter
+        for hits in search_res:
+            for hit in hits:
+                assert hit.get("expr_field", 0) >= 0
         # 4. drop collection
         self.drop_collection(client, collection_name)
         # 5. create the same collection name with same field name but varchar field type
@@ -1911,7 +1877,7 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
         collection_name = cf.gen_collection_name_by_testcase_name()
         dim = 32
         schema = self.create_schema(client)[0]
-        self.add_field(schema, field_name='pk', datatype=DataType.INT64, is_primary=True)
+        self.add_field(schema, field_name=ct.default_primary_field_name, datatype=DataType.INT64, is_primary=True)
         self.add_field(schema, field_name=ct.default_float_vec_field_name, datatype=DataType.FLOAT_VECTOR, dim=dim)
         self.add_field(schema, field_name=ct.default_int8_field_name, datatype=DataType.INT8, default_value=np.int8(8))
         self.add_field(schema, field_name=ct.default_int16_field_name, datatype=DataType.INT16, default_value=np.int16(16))
@@ -1943,7 +1909,8 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
                           check_task=CheckTasks.check_search_results,
                           check_items={"enable_milvus_client_api": True,
                                        "nq": ct.default_nq,
-                                       "pk_name": "pk",
+                                       "pk_name": ct.default_primary_field_name,
+                                       "metric": "COSINE",
                                        "limit": ct.default_limit})[0]
         for res in res[0]:
             res = res.entity
@@ -1970,7 +1937,7 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
         collection_name = cf.gen_collection_name_by_testcase_name()
         dim = 64
         schema = self.create_schema(client)[0]
-        self.add_field(schema, field_name='pk', datatype=DataType.INT64, is_primary=True)
+        self.add_field(schema, field_name=ct.default_primary_field_name, datatype=DataType.INT64, is_primary=True)
         self.add_field(schema, field_name=ct.default_float_vec_field_name, datatype=DataType.FLOAT_VECTOR, dim=dim)
         self.create_collection(client, collection_name, schema=schema)
 
@@ -2002,7 +1969,8 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
                            check_items={"enable_milvus_client_api": True,
                                         "nq": ct.default_nq,
                                         "limit": ct.default_limit,
-                                        "pk_name": "pk"})[0]
+                                        "pk_name": ct.default_primary_field_name,
+                                        "metric": "COSINE"})[0]
         search_params = {"ignore_growing": True}
         res2 = self.search(client, collection_name, search_vectors,
                            anns_field=ct.default_float_vec_field_name,
@@ -2012,7 +1980,8 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
                            check_items={"enable_milvus_client_api": True,
                                         "nq": ct.default_nq,
                                         "limit": ct.default_limit,
-                                        "pk_name": "pk"})[0]
+                                        "pk_name": ct.default_primary_field_name,
+                                        "metric": "COSINE"})[0]
         for i in range(ct.default_nq):
             assert max(res1[i].ids) < ct.default_nb * 5
             assert max(res2[i].ids) < ct.default_nb * 5
@@ -2039,7 +2008,7 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
         collection_name = cf.gen_collection_name_by_testcase_name()
         dim = 64
         schema = self.create_schema(client)[0]
-        self.add_field(schema, field_name='pk', datatype=DataType.INT64, is_primary=True)
+        self.add_field(schema, field_name=ct.default_primary_field_name, datatype=DataType.INT64, is_primary=True)
         self.add_field(schema, field_name=ct.default_float_vec_field_name, datatype=DataType.FLOAT_VECTOR, dim=dim)
         self.add_field(schema, field_name='json_field1', datatype=DataType.JSON, is_nullable=True)
         self.add_field(schema, field_name='json_field2', datatype=DataType.JSON, is_nullable=True)


### PR DESCRIPTION
## Summary
- Add `ct.all_dense_float_index_types` constant (replaces fragile `[:8]` slices)
- Fix metric, duplicate keys, GPU→L1, IVF_FLAT→FLAT, spelling

issue: #48048
🤖 Generated with [Claude Code](https://claude.com/claude-code)