### PR TITLE
fix: [hotfix] replace panic with log+return in timeoutMiddleware Write error (#48270)

### DIFF
--- a/internal/distributed/proxy/httpserver/timeout_middleware.go
+++ b/internal/distributed/proxy/httpserver/timeout_middleware.go
@@ -28,9 +28,11 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
 
 	mhttp "github.com/milvus-io/milvus/internal/http"
 	"github.com/milvus-io/milvus/internal/json"
+	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
@@ -221,7 +223,10 @@ func timeoutMiddleware(handler gin.HandlerFunc) gin.HandlerFunc {
 			}
 
 			if _, err := tw.ResponseWriter.Write(buffer.Bytes()); err != nil {
-				panic(err)
+				log.Warn("failed to write response body", zap.Error(err))
+				tw.FreeBuffer()
+				bufPool.Put(buffer)
+				return
 			}
 			tw.FreeBuffer()
 			bufPool.Put(buffer)


### PR DESCRIPTION
Cherry-pick from master
pr: #48270

When ResponseWriter.Write fails in timeoutMiddleware (e.g., client disconnected), the code panics. While gin.Recovery() catches it, mass concurrent failures cause excessive panic/recover overhead (stack traces, goroutine scheduling), leading to high system load.

Replace panic(err) with log.Warn + proper resource cleanup + return, consistent with error handling in the rest of the HTTP handler layer.

issue: #48269