### PR TITLE
fix: fix swallowed errors and missing error handling in multiple modules

### DIFF
--- a/internal/datanode/compactor/segment_writer.go
+++ b/internal/datanode/compactor/segment_writer.go
@@ -433,7 +433,10 @@ func (w *SegmentWriter) GetTotalSize() int64 {
 func (w *SegmentWriter) clear() {
 	w.syncedSize.Add(int64(w.writer.GetWrittenUncompressed()))
 
-	writer, closers, _ := newBinlogWriter(w.collectionID, w.partitionID, w.segmentID, w.sch, w.batchSize)
+	writer, closers, err := newBinlogWriter(w.collectionID, w.partitionID, w.segmentID, w.sch, w.batchSize)
+	if err != nil {
+		log.Warn("failed to create new binlog writer in clear", zap.Error(err))
+	}
 	w.writer = writer
 	w.closers = closers
 	w.tsFrom = math.MaxUint64

--- a/internal/datanode/compactor/segment_writer.go
+++ b/internal/datanode/compactor/segment_writer.go
@@ -436,6 +436,7 @@ func (w *SegmentWriter) clear() {
 	writer, closers, err := newBinlogWriter(w.collectionID, w.partitionID, w.segmentID, w.sch, w.batchSize)
 	if err != nil {
 		log.Warn("failed to create new binlog writer in clear", zap.Error(err))
+		return
 	}
 	w.writer = writer
 	w.closers = closers

--- a/internal/datanode/compactor/segment_writer.go
+++ b/internal/datanode/compactor/segment_writer.go
@@ -421,7 +421,9 @@ func (w *SegmentWriter) SerializeYield() ([]*storage.Blob, *writebuffer.TimeRang
 	}
 
 	tr := w.GetTimeRange()
-	w.clear()
+	if err := w.clear(); err != nil {
+		return nil, nil, err
+	}
 
 	return fieldData, tr, nil
 }
@@ -430,18 +432,18 @@ func (w *SegmentWriter) GetTotalSize() int64 {
 	return w.syncedSize.Load() + int64(w.writer.GetWrittenUncompressed())
 }
 
-func (w *SegmentWriter) clear() {
+func (w *SegmentWriter) clear() error {
 	w.syncedSize.Add(int64(w.writer.GetWrittenUncompressed()))
 
 	writer, closers, err := newBinlogWriter(w.collectionID, w.partitionID, w.segmentID, w.sch, w.batchSize)
 	if err != nil {
-		log.Warn("failed to create new binlog writer in clear", zap.Error(err))
-		return
+		return err
 	}
 	w.writer = writer
 	w.closers = closers
 	w.tsFrom = math.MaxUint64
 	w.tsTo = 0
+	return nil
 }
 
 // deprecated: use NewMultiSegmentWriter instead

--- a/internal/proxy/validate_util.go
+++ b/internal/proxy/validate_util.go
@@ -650,7 +650,7 @@ func FillWithDefaultValue(field *schemapb.FieldData, fieldSchema *schemapb.Field
 			}
 			sd.TimestamptzData.Data, err = fillWithDefaultValueImpl(sd.TimestamptzData.Data, defaultValue, field.GetValidData())
 			if err != nil {
-				return nil
+				return err
 			}
 
 		case *schemapb.ScalarField_StringData:

--- a/internal/querynodev2/pipeline/insert_node.go
+++ b/internal/querynodev2/pipeline/insert_node.go
@@ -45,7 +45,7 @@ type insertNode struct {
 func (iNode *insertNode) addInsertData(insertDatas map[UniqueID]*delegator.InsertData, msg *InsertMsg, collection *Collection) {
 	insertRecord, err := storage.TransferInsertMsgToInsertRecord(collection.Schema(), msg)
 	if err != nil {
-		err = fmt.Errorf("failed to get primary keys, err = %d", err)
+		err = fmt.Errorf("failed to get primary keys, err = %v", err)
 		log.Error(err.Error(), zap.Int64("collectionID", iNode.collectionID), zap.String("channel", iNode.channel))
 		panic(err)
 	}

--- a/internal/storage/delta_data.go
+++ b/internal/storage/delta_data.go
@@ -225,6 +225,8 @@ func (dl *DeleteLog) UnmarshalJSON(data []byte) error {
 		dl.Pk = &Int64PrimaryKey{}
 	case schemapb.DataType_VarChar:
 		dl.Pk = &VarCharPrimaryKey{}
+	default:
+		return fmt.Errorf("unsupported primary key type: %v", schemapb.DataType(dl.PkType))
 	}
 
 	if err = json.Unmarshal(*messageMap["pk"], dl.Pk); err != nil {

--- a/internal/storage/print_binlog.go
+++ b/internal/storage/print_binlog.go
@@ -59,7 +59,7 @@ func printBinlogFile(filename string) error {
 
 	at, err := mmap.Open(filename)
 	if err != nil {
-		return nil
+		return err
 	}
 	defer at.Close()
 


### PR DESCRIPTION
## Summary
- **validate_util.go:653**: `return nil` → `return err` in TimestamptzData branch of `FillWithDefaultValue`. All other branches correctly return `err`; this was a copy-paste bug that silently swallows errors when filling default values for timestamptz fields.
- **print_binlog.go:62**: `return nil` → `return err` when `mmap.Open` fails. All other error paths in the same function correctly return `err`.
- **delta_data.go:228**: Add `default` case in `DeleteLog.UnmarshalJSON()` switch to return error on unsupported PK types, preventing nil pointer panic on line 230.
- **segment_writer.go:436**: Check and log error from `newBinlogWriter()` in `clear()` instead of ignoring with `_`. If this fails, `w.writer` becomes nil causing panic on next use.
- **insert_node.go:48**: Fix wrong format specifier `%d` → `%v` for error type. `%d` produces garbled output like `%!d(*errors.errorString=...)`.

## Test plan
- [ ] Existing unit tests pass (no behavioral change for success paths)
- [ ] Each fix is a minimal one-line change with clear before/after comparison

issue: https://github.com/milvus-io/milvus/issues/39893

🤖 Generated with [Claude Code](https://claude.com/claude-code)