### PR TITLE
fix: fix defer in loop causing resource leak in fileresource, importv2, and idf_oracle

### DIFF
--- a/internal/datanode/importv2/util.go
+++ b/internal/datanode/importv2/util.go
@@ -502,8 +502,6 @@ func RunBm25Function(task *ImportTask, data *storage.InsertData) error {
 			continue
 		}
 
-		defer runner.Close()
-
 		inputFieldIDs := lo.Map(runner.GetInputFields(), func(field *schemapb.FieldSchema, _ int) int64 { return field.GetFieldID() })
 		inputDatas := make([]any, 0, len(inputFieldIDs))
 		for _, inputFieldID := range inputFieldIDs {
@@ -511,6 +509,7 @@ func RunBm25Function(task *ImportTask, data *storage.InsertData) error {
 		}
 
 		outputFieldData, err := runner.BatchRun(inputDatas...)
+		runner.Close()
 		if err != nil {
 			return err
 		}
@@ -557,8 +556,6 @@ func RunMinHashFunction(task *ImportTask, data *storage.InsertData) error {
 			continue
 		}
 
-		defer runner.Close()
-
 		inputFieldIDs := lo.Map(runner.GetInputFields(), func(field *schemapb.FieldSchema, _ int) int64 { return field.GetFieldID() })
 		inputDatas := make([]any, 0, len(inputFieldIDs))
 		for _, inputFieldID := range inputFieldIDs {
@@ -566,6 +563,7 @@ func RunMinHashFunction(task *ImportTask, data *storage.InsertData) error {
 		}
 
 		output, err := runner.BatchRun(inputDatas...)
+		runner.Close()
 		if err != nil {
 			return err
 		}

--- a/internal/querynodev2/delegator/idf_oracle.go
+++ b/internal/querynodev2/delegator/idf_oracle.go
@@ -130,21 +130,19 @@ func (s *sealedBm25Stats) writeFile(localDir string) (error, bool) {
 	// RUnlock when stats serialize and write to file
 	// to avoid block remove stats too long when sync distribution
 	for fieldID, stats := range stats {
-		file, err := os.Create(path.Join(localDir, fmt.Sprintf("%d.data", fieldID)))
-		if err != nil {
-			return err, false
-		}
+		if err := func() error {
+			file, err := os.Create(path.Join(localDir, fmt.Sprintf("%d.data", fieldID)))
+			if err != nil {
+				return err
+			}
+			defer file.Close()
 
-		defer file.Close()
-		writer := bufio.NewWriter(file)
-
-		err = stats.SerializeToWriter(writer)
-		if err != nil {
-			return err, false
-		}
-
-		err = writer.Flush()
-		if err != nil {
+			writer := bufio.NewWriter(file)
+			if err = stats.SerializeToWriter(writer); err != nil {
+				return err
+			}
+			return writer.Flush()
+		}(); err != nil {
 			return err, false
 		}
 	}

--- a/internal/util/fileresource/manager.go
+++ b/internal/util/fileresource/manager.go
@@ -150,25 +150,30 @@ func (m *SyncManager) Sync(version uint64, resourceList []*internalpb.FileResour
 			return err
 		}
 
-		reader, err := m.downloader.Reader(ctx, resource.GetPath())
-		if err != nil {
-			log.Info("download resource failed", zap.String("path", resource.GetPath()), zap.Error(err))
-			return err
-		}
-		defer reader.Close()
+		if err := func() error {
+			reader, err := m.downloader.Reader(ctx, resource.GetPath())
+			if err != nil {
+				log.Info("download resource failed", zap.String("path", resource.GetPath()), zap.Error(err))
+				return err
+			}
+			defer reader.Close()
 
-		fileName := path.Join(localResourcePath, path.Base(resource.GetPath()))
-		file, err := os.Create(fileName)
-		if err != nil {
-			return err
-		}
-		defer file.Close()
+			fileName := path.Join(localResourcePath, path.Base(resource.GetPath()))
+			file, err := os.Create(fileName)
+			if err != nil {
+				return err
+			}
+			defer file.Close()
 
-		if _, err = io.Copy(file, reader); err != nil {
-			log.Info("download resource failed", zap.String("path", resource.GetPath()), zap.Error(err))
+			if _, err = io.Copy(file, reader); err != nil {
+				log.Info("download resource failed", zap.String("path", resource.GetPath()), zap.Error(err))
+				return err
+			}
+			log.Info("sync file to local", zap.String("name", fileName), zap.Int64("id", resource.GetId()))
+			return nil
+		}(); err != nil {
 			return err
 		}
-		log.Info("sync file to local", zap.String("name", fileName), zap.Int64("id", resource.GetId()))
 	}
 
 	for name, id := range m.resourceMap {


### PR DESCRIPTION
## Summary
- **fileresource/manager.go**: `defer reader.Close()` and `defer file.Close()` inside a for loop cause all readers and file handles to pile up until the function returns. Wrapped loop body in a closure so resources are released per iteration.
- **importv2/util.go**: `defer runner.Close()` inside for loops in `RunBm25Function` and `RunMinHashFunction` cause FunctionRunner resources to accumulate. Changed to explicit `runner.Close()` after use.
- **idf_oracle.go**: `defer file.Close()` inside a for loop causes file handles to pile up. Wrapped loop body in a closure for proper per-iteration cleanup.

## Test plan
- [ ] Existing unit tests pass
- [ ] Each fix preserves the same error handling semantics (errors still propagate correctly)

issue: https://github.com/milvus-io/milvus/issues/39893

🤖 Generated with [Claude Code](https://claude.com/claude-code)