### PR TITLE
fix: fix defer cancel in loop causing context leak

### DIFF
--- a/internal/datacoord/garbage_collector.go
+++ b/internal/datacoord/garbage_collector.go
@@ -880,8 +880,8 @@ func (gc *garbageCollector) recycleChannelCPMeta(ctx context.Context, signal <-c
 				return
 			}
 			timeoutCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
-			defer cancel()
 			has, err := gc.option.broker.HasCollection(timeoutCtx, collectionID)
+			cancel()
 			if err == nil && !has {
 				collectionID2GcStatus[collectionID] = gc.meta.catalog.GcConfirm(ctx, collectionID, -1)
 			} else {

--- a/internal/storage/payload_reader.go
+++ b/internal/storage/payload_reader.go
@@ -1451,8 +1451,8 @@ func ReadData[T any, E interface {
 	for i, field := range schema.Fields() {
 		// Spawn a new context to ignore cancellation from parental context.
 		newCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
 		columnReader, err := fileReader.GetColumn(newCtx, i)
+		cancel()
 		if err != nil {
 			log.Warn("get column reader failed", zap.String("fieldName", field.Name), zap.Error(err))
 			return -1, err

--- a/internal/streamingcoord/server/balancer/balancer_impl.go
+++ b/internal/streamingcoord/server/balancer/balancer_impl.go
@@ -574,8 +574,9 @@ func (b *balancerImpl) applyBalanceResultToStreamingNode(ctx context.Context, mo
 			// all history channels should be remove from related nodes.
 			for _, assignment := range channel.AssignHistories() {
 				opCtx, cancel := context.WithTimeout(ctx, opTimeout)
-				defer cancel()
-				if err := resource.Resource().StreamingNodeManagerClient().Remove(opCtx, assignment); err != nil {
+				err := resource.Resource().StreamingNodeManagerClient().Remove(opCtx, assignment)
+				cancel()
+				if err != nil {
 					b.Logger().Warn("fail to remove channel", zap.String("assignment", assignment.String()), zap.Error(err))
 					return err
 				}


### PR DESCRIPTION
## Summary
- **garbage_collector.go:883**: `defer cancel()` inside channel checkpoint GC loop causes context cancel functions to pile up until function returns. Changed to explicit `cancel()` after use.
- **balancer_impl.go:577**: `defer cancel()` inside channel assignment history loop causes context cancel functions to accumulate in each goroutine. Changed to explicit `cancel()` after use.
- **payload_reader.go:1454**: `defer cancel()` inside schema field iteration loop causes context cancel functions to pile up. Changed to explicit `cancel()` after use.

## Test plan
- [ ] Existing unit tests pass
- [ ] Each fix preserves the same context timeout semantics

issue: https://github.com/milvus-io/milvus/issues/39893

🤖 Generated with [Claude Code](https://claude.com/claude-code)