### PR TITLE
fix: [cp2.5.13] OR binary expr is prunable only when both children are prunable

### DIFF
--- a/internal/util/exprutil/expr_checker_test.go
+++ b/internal/util/exprutil/expr_checker_test.go
@@ -108,9 +108,9 @@ func TestParsePartitionKeys(t *testing.T) {
 		{
 			name:                 "binary_expr_or with term and not 2",
 			expr:                 "partition_key_field in [7, 8] or int64_field not in [10, 20]",
-			expected:             2,
-			validPartitionKeys:   []int64{7, 8},
-			invalidPartitionKeys: []int64{10, 20},
+			expected:             0,
+			validPartitionKeys:   []int64{},
+			invalidPartitionKeys: []int64{},
 		},
 	}
 


### PR DESCRIPTION
## Summary
- Cherry-pick #42915 (master PR #42912) to hotfix-2.5.13
- Fix partition key pruning bug: when an OR expression has one side with a partition key constraint and the other without, the optimizer incorrectly prunes to only the constrained partition instead of scanning all partitions

pr: #42912
issue: #42903

## Test plan
- [x] Reproduced the bug on 2.5.13: `partition_key == val || other_field in [...]` returns wrong count
- [x] Verified master branch already contains the fix
- [x] Cherry-pick applied cleanly with no conflicts

Signed-off-by: yanliang567 <yanliang.qiao@zilliz.com>