### PR TITLE
fix: use manifest version comparison to prevent target promotion stagnation

### DIFF
--- a/internal/querycoordv2/checkers/segment_checker.go
+++ b/internal/querycoordv2/checkers/segment_checker.go
@@ -33,6 +33,7 @@ import (
 	"github.com/milvus-io/milvus/internal/querycoordv2/session"
 	"github.com/milvus-io/milvus/internal/querycoordv2/task"
 	"github.com/milvus-io/milvus/internal/querycoordv2/utils"
+	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
@@ -329,7 +330,22 @@ func (c *SegmentChecker) getSealedSegmentDiff(
 	}
 	isSegmentUpdate := func(segment *datapb.SegmentInfo) bool {
 		segInDist, existInDist := distMap[segment.ID]
-		return existInDist && segInDist.ManifestPath != segment.GetManifestPath()
+		if !existInDist {
+			return false
+		}
+		// Only trigger reopen when dist manifest is older than target manifest.
+		// If dist manifest is same or newer (e.g., loaded after L0 compaction updated DataCoord),
+		// the data is already up-to-date and no reopen is needed.
+		cmp, err := packed.CompareManifestPath(segInDist.ManifestPath, segment.GetManifestPath())
+		if err != nil {
+			log.Ctx(ctx).RatedWarn(10, "manifest path not comparable, skip reopen",
+				zap.Int64("segmentID", segment.GetID()),
+				zap.String("distManifest", segInDist.ManifestPath),
+				zap.String("targetManifest", segment.GetManifestPath()),
+				zap.Error(err))
+			return false
+		}
+		return cmp < 0
 	}
 
 	nextTargetExist := c.targetMgr.IsNextTargetExist(ctx, collectionID)

--- a/internal/querycoordv2/utils/util.go
+++ b/internal/querycoordv2/utils/util.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/milvus-io/milvus/internal/querycoordv2/meta"
 	"github.com/milvus-io/milvus/internal/querycoordv2/session"
+	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
@@ -102,13 +103,24 @@ func CheckSegmentDataReady(ctx context.Context, collectionID int64, distManager 
 		}
 
 		for _, segment := range segments {
-			// Compare manifest path for now
-			// alternative is to compare version, but it's not recommended to add extra info in segmentinfo
-			// we may use data view version in the future
-			if segment.ManifestPath != segmentInfo.GetManifestPath() {
-				log.RatedInfo(10, "segment is not updated", zap.Int64("segmentID", segmentID))
+			cmp, err := packed.CompareManifestPath(segment.ManifestPath, segmentInfo.GetManifestPath())
+			if err != nil {
+				log.RatedWarn(10, "segment manifest path not comparable",
+					zap.Int64("segmentID", segmentID),
+					zap.String("distManifest", segment.ManifestPath),
+					zap.String("targetManifest", segmentInfo.GetManifestPath()),
+					zap.Error(err))
+				return err
+			}
+			if cmp < 0 {
+				// dist manifest is older than target, segment data is not ready yet
+				log.RatedInfo(10, "segment manifest is outdated",
+					zap.Int64("segmentID", segmentID),
+					zap.String("distManifest", segment.ManifestPath),
+					zap.String("targetManifest", segmentInfo.GetManifestPath()))
 				return merr.WrapErrSegmentNotLoaded(segmentID)
 			}
+			// cmp >= 0: dist manifest is same or newer than target, segment data is ready
 		}
 	}
 	return nil

--- a/internal/querycoordv2/utils/util_test.go
+++ b/internal/querycoordv2/utils/util_test.go
@@ -17,6 +17,7 @@
 package utils
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -27,6 +28,7 @@ import (
 
 	"github.com/milvus-io/milvus/internal/querycoordv2/meta"
 	"github.com/milvus-io/milvus/internal/querycoordv2/session"
+	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/querypb"
 )
@@ -265,6 +267,71 @@ func (suite *UtilTestSuite) TestFilterOutNodeLessThan260() {
 	}))
 	filteredNodes = filterNodeLessThan260(nodes, nodeManager)
 	suite.ElementsMatch(filteredNodes, []int64{1, 4, 5})
+}
+
+func (suite *UtilTestSuite) TestCheckSegmentDataReady_ManifestComparison() {
+	basePath := "/data/insert_log/col/part/seg"
+	collectionID := int64(100)
+	segmentID := int64(200)
+	nodeID := int64(1)
+
+	newDistManager := func(manifestPath string) *meta.DistributionManager {
+		dm := meta.NewDistributionManager(session.NewNodeManager())
+		dm.SegmentDistManager.Update(nodeID, &meta.Segment{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:           segmentID,
+				CollectionID: collectionID,
+			},
+			Node:         nodeID,
+			ManifestPath: manifestPath,
+		})
+		return dm
+	}
+
+	newTargetMgr := func(manifestPath string) meta.TargetManagerInterface {
+		m := meta.NewMockTargetManager(suite.T())
+		m.EXPECT().GetSealedSegmentsByCollection(mock.Anything, collectionID, mock.Anything).
+			Return(map[int64]*datapb.SegmentInfo{
+				segmentID: {
+					ID:           segmentID,
+					CollectionID: collectionID,
+					ManifestPath: manifestPath,
+				},
+			}).Maybe()
+		return m
+	}
+
+	suite.Run("same manifest version - ready", func() {
+		manifest := packed.MarshalManifestPath(basePath, 5)
+		err := CheckSegmentDataReady(context.Background(), collectionID, newDistManager(manifest), newTargetMgr(manifest), meta.NextTarget)
+		suite.NoError(err)
+	})
+
+	suite.Run("dist newer than target - ready", func() {
+		distManifest := packed.MarshalManifestPath(basePath, 10)
+		targetManifest := packed.MarshalManifestPath(basePath, 5)
+		err := CheckSegmentDataReady(context.Background(), collectionID, newDistManager(distManifest), newTargetMgr(targetManifest), meta.NextTarget)
+		suite.NoError(err)
+	})
+
+	suite.Run("dist older than target - not ready", func() {
+		distManifest := packed.MarshalManifestPath(basePath, 1)
+		targetManifest := packed.MarshalManifestPath(basePath, 5)
+		err := CheckSegmentDataReady(context.Background(), collectionID, newDistManager(distManifest), newTargetMgr(targetManifest), meta.NextTarget)
+		suite.Error(err)
+	})
+
+	suite.Run("both empty manifest - ready", func() {
+		err := CheckSegmentDataReady(context.Background(), collectionID, newDistManager(""), newTargetMgr(""), meta.NextTarget)
+		suite.NoError(err)
+	})
+
+	suite.Run("segment not in dist - not ready", func() {
+		dm := meta.NewDistributionManager(session.NewNodeManager())
+		targetManifest := packed.MarshalManifestPath(basePath, 5)
+		err := CheckSegmentDataReady(context.Background(), collectionID, dm, newTargetMgr(targetManifest), meta.NextTarget)
+		suite.Error(err)
+	})
 }
 
 func TestUtilSuite(t *testing.T) {

--- a/internal/storagev2/packed/exttable_test.go
+++ b/internal/storagev2/packed/exttable_test.go
@@ -369,6 +369,69 @@ func TestMarshalManifestPath_EmptyBasePath(t *testing.T) {
 	assert.Equal(t, int64(0), ver)
 }
 
+func TestCompareManifestPath(t *testing.T) {
+	base := "/base/path/to/segment"
+
+	t.Run("equal paths", func(t *testing.T) {
+		a := MarshalManifestPath(base, 5)
+		cmp, err := CompareManifestPath(a, a)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, cmp)
+	})
+
+	t.Run("both empty", func(t *testing.T) {
+		cmp, err := CompareManifestPath("", "")
+		assert.NoError(t, err)
+		assert.Equal(t, 0, cmp)
+	})
+
+	t.Run("a older than b", func(t *testing.T) {
+		a := MarshalManifestPath(base, 1)
+		b := MarshalManifestPath(base, 5)
+		cmp, err := CompareManifestPath(a, b)
+		assert.NoError(t, err)
+		assert.Equal(t, -1, cmp)
+	})
+
+	t.Run("a newer than b", func(t *testing.T) {
+		a := MarshalManifestPath(base, 10)
+		b := MarshalManifestPath(base, 3)
+		cmp, err := CompareManifestPath(a, b)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, cmp)
+	})
+
+	t.Run("different base paths returns error", func(t *testing.T) {
+		a := MarshalManifestPath("/path/a", 1)
+		b := MarshalManifestPath("/path/b", 1)
+		_, err := CompareManifestPath(a, b)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "different base paths")
+	})
+
+	t.Run("invalid json a returns error", func(t *testing.T) {
+		b := MarshalManifestPath(base, 1)
+		_, err := CompareManifestPath("not-json", b)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse manifest path")
+	})
+
+	t.Run("invalid json b returns error", func(t *testing.T) {
+		a := MarshalManifestPath(base, 1)
+		_, err := CompareManifestPath(a, "not-json")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse manifest path")
+	})
+
+	t.Run("negative version", func(t *testing.T) {
+		a := MarshalManifestPath(base, -1)
+		b := MarshalManifestPath(base, 0)
+		cmp, err := CompareManifestPath(a, b)
+		assert.NoError(t, err)
+		assert.Equal(t, -1, cmp)
+	})
+}
+
 func TestCreateSegmentManifest_CanceledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel immediately

--- a/internal/storagev2/packed/ffi_common.go
+++ b/internal/storagev2/packed/ffi_common.go
@@ -280,3 +280,39 @@ func UnmarshalManifestPath(manifestPath string) (string, int64, error) {
 	}
 	return manifestJSON.BasePath, manifestJSON.ManifestVersion, nil
 }
+
+// CompareManifestPath compares two manifest paths by their version.
+// Returns:
+//
+//	-1 if a < b (a is older)
+//	 0 if a == b (same version or both empty)
+//	 1 if a > b (a is newer)
+//	 error if the paths are not comparable (parse failure or different base paths)
+func CompareManifestPath(a, b string) (int, error) {
+	if a == b {
+		return 0, nil
+	}
+
+	aBase, aVer, aErr := UnmarshalManifestPath(a)
+	bBase, bVer, bErr := UnmarshalManifestPath(b)
+
+	if aErr != nil {
+		return 0, fmt.Errorf("failed to parse manifest path %q: %w", a, aErr)
+	}
+	if bErr != nil {
+		return 0, fmt.Errorf("failed to parse manifest path %q: %w", b, bErr)
+	}
+
+	if aBase != bBase {
+		return 0, fmt.Errorf("manifest paths have different base paths: %q vs %q", aBase, bBase)
+	}
+
+	switch {
+	case aVer < bVer:
+		return -1, nil
+	case aVer > bVer:
+		return 1, nil
+	default:
+		return 0, nil
+	}
+}


### PR DESCRIPTION
## Summary
- Fix sporadic query failures caused by L0 compaction updating ManifestPath on storage v3 segments
- Replace exact-match (`!=`) with version comparison (`CompareManifestPath`) in `CheckSegmentDataReady` and `isSegmentUpdate`
- A dist manifest newer than the target is now considered ready, preventing the dead loop that blocked target promotion for 300s

## Root Cause
When L0 compaction applies deletes to a storage v3 segment (#45279), it updates the segment's ManifestPath in DataCoord (V1→V2). If the next target was pulled before the L0 compaction, it holds stale ManifestPath V1. The Grow task loads the segment with V2 from DataCoord, creating a permanent mismatch: dist=V2, target=V1. `CheckSegmentDataReady` used `!=` exact match, so it persistently failed with "segment is not updated", blocking `shouldUpdateCurrentTarget` for 300s (`NextTargetSurviveTime`). After expiry, the refreshed next target no longer contained the segment (consumed by subsequent compaction), causing immediate segment release before `SyncTargetVersion` reached the delegator — resulting in `serviceable=false` and query failures.

## Test plan
- [x] Unit tests for `CompareManifestPath` (equal, older, newer, different base, invalid JSON, negative version)
- [x] Unit tests for `CheckSegmentDataReady` manifest comparison (same version, dist newer, dist older, both empty, segment missing)
- [x] All existing `TestUtilSuite` tests pass
- [ ] CI: `make test-querycoord`

issue: #48117

🤖 Generated with [Claude Code](https://claude.com/claude-code)