### PR TITLE
enhance: skip remote and env config sources in yaml generation

### DIFF
--- a/cmd/tools/config/generate.go
+++ b/cmd/tools/config/generate.go
@@ -29,7 +29,7 @@ type DocContent struct {
 
 func collect() []DocContent {
 	params := &paramtable.ComponentParam{}
-	params.Init(paramtable.NewBaseTable())
+	params.Init(paramtable.NewBaseTable(paramtable.SkipRemote(true), paramtable.SkipEnv(true)))
 
 	val := reflect.ValueOf(params).Elem()
 	data := make([]DocContent, 0)


### PR DESCRIPTION
The config gen-yaml tool initialized BaseTable with default options, which connected to etcd and loaded environment variables. This caused runtime config values (e.g. mq.type=pulsar from etcd) to override code-defined defaults, producing incorrect generated yaml files.