### PR TITLE
feat: add TruncateCollection to Go SDK client

### DIFF
--- a/client/milvusclient/collection.go
+++ b/client/milvusclient/collection.go
@@ -131,6 +131,14 @@ func (c *Client) DropCollection(ctx context.Context, option DropCollectionOption
 	return err
 }
 
+func (c *Client) TruncateCollection(ctx context.Context, option TruncateCollectionOption, callOptions ...grpc.CallOption) error {
+	req := option.Request()
+	return c.callService(func(milvusService milvuspb.MilvusServiceClient) error {
+		resp, err := milvusService.TruncateCollection(ctx, req, callOptions...)
+		return merr.CheckRPCCall(resp, err)
+	})
+}
+
 func (c *Client) RenameCollection(ctx context.Context, option RenameCollectionOption, callOptions ...grpc.CallOption) error {
 	req := option.Request()
 

--- a/client/milvusclient/collection_options.go
+++ b/client/milvusclient/collection_options.go
@@ -385,6 +385,25 @@ func NewAlterCollectionFieldPropertiesOption(collectionName string, fieldName st
 	}
 }
 
+// TruncateCollectionOption is the interface builds TruncateCollectionRequest.
+type TruncateCollectionOption interface {
+	Request() *milvuspb.TruncateCollectionRequest
+}
+
+type truncateCollectionOption struct {
+	name string
+}
+
+func (opt *truncateCollectionOption) Request() *milvuspb.TruncateCollectionRequest {
+	return &milvuspb.TruncateCollectionRequest{
+		CollectionName: opt.name,
+	}
+}
+
+func NewTruncateCollectionOption(name string) *truncateCollectionOption {
+	return &truncateCollectionOption{name: name}
+}
+
 type GetCollectionOption interface {
 	Request() *milvuspb.GetCollectionStatisticsRequest
 }

--- a/client/milvusclient/collection_test.go
+++ b/client/milvusclient/collection_test.go
@@ -261,6 +261,26 @@ func (s *CollectionSuite) TestDropCollection() {
 	})
 }
 
+func (s *CollectionSuite) TestTruncateCollection() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s.Run("success", func() {
+		s.mock.EXPECT().TruncateCollection(mock.Anything, mock.Anything).
+			Return(&milvuspb.TruncateCollectionResponse{Status: merr.Success()}, nil).Once()
+
+		err := s.client.TruncateCollection(ctx, NewTruncateCollectionOption("test_collection"))
+		s.NoError(err)
+	})
+
+	s.Run("failure", func() {
+		s.mock.EXPECT().TruncateCollection(mock.Anything, mock.Anything).Return(nil, merr.WrapErrServiceInternal("mocked")).Once()
+
+		err := s.client.TruncateCollection(ctx, NewTruncateCollectionOption("test_collection"))
+		s.Error(err)
+	})
+}
+
 func (s *CollectionSuite) TestRenameCollection() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
## Summary
- Add `TruncateCollection` method to the Go SDK client (`client/milvusclient`)
- Add `TruncateCollectionOption` interface and `NewTruncateCollectionOption` constructor
- Add unit tests covering success and failure cases

pr: #48334
issue: #46166
doc: https://github.com/milvus-io/milvus-design-docs/blob/main/design_docs/20260129-truncate_collection.md

## Test plan
- [x] Unit tests pass (`TestTruncateCollection` success/failure)
- [x] E2E verified: insert → truncate → verify empty → re-insert → verify data
- [x] E2E verified: truncate loaded collection + search returns empty
- [x] E2E verified: truncate empty collection succeeds
- [x] E2E verified: truncate non-existent collection returns error

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)