### PR TITLE
enhance: [2.6] optimize unfiltered search on sealed segments

### DIFF
--- a/internal/core/CMakeLists.txt
+++ b/internal/core/CMakeLists.txt
@@ -56,6 +56,14 @@ endif ()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
 
+# Enable hardware popcnt for all compilation units.
+# PopCountHelper in bitset/detail/popcount.h is header-only and compiled
+# wherever CustomBitset.h is included (query, exec, segcore, etc.).
+# Without this flag, __builtin_popcountll falls back to __popcountdi2 software.
+if (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mpopcnt")
+endif()
+
 if (CMAKE_COMPILER_IS_GNUCC)
     if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 11.99)
         # ignore deprecated declarations for gcc>=12

--- a/internal/core/src/exec/QueryContext.h
+++ b/internal/core/src/exec/QueryContext.h
@@ -303,6 +303,16 @@ class QueryContext : public Context {
         return plan_options_;
     }
 
+    void
+    set_skip_filter(bool v) {
+        skip_filter_ = v;
+    }
+
+    bool
+    get_skip_filter() const {
+        return skip_filter_;
+    }
+
  private:
     folly::Executor* executor_;
     //folly::Executor::KeepAlive<> executor_keepalive_;
@@ -331,6 +341,11 @@ class QueryContext : public Context {
     int32_t consistency_level_ = 0;
 
     query::PlanOptions plan_options_;
+
+    // Set by MvccNode when no filtering is needed (sealed, no filter,
+    // no deletes, no TTL). VectorSearchNode checks this to pass empty
+    // BitsetView to Knowhere (IDSelectorAll fast path).
+    bool skip_filter_{false};
 };
 
 // Represent the state of one thread of query execution.

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -336,6 +336,15 @@ class SegmentExpr : public Expr {
         } else {
             current_rows = current_chunk * size_per_chunk_ + current_chunk_pos;
         }
+        // OPT-K: When single index chunk at position 0, return all
+        // remaining rows so ProcessIndexChunks fast path and caller
+        // assertions stay consistent.
+        if (SegmentExpr::CanUseIndex() && use_index_ &&
+            num_index_chunk_ == 1 && current_index_chunk_ == 0 &&
+            current_index_chunk_pos_ == 0) {
+            return active_count_ - current_rows;
+        }
+
         return current_rows + batch_size_ >= active_count_
                    ? active_count_ - current_rows
                    : batch_size_;
@@ -1075,6 +1084,27 @@ class SegmentExpr : public Expr {
         TargetBitmap result;
         TargetBitmap valid_result;
         int processed_rows = 0;
+
+        // OPT-K: Fast path for single-chunk sealed segments.
+        // When there's exactly one index chunk and we're at position 0,
+        // return the full index result directly without batch slicing.
+        // This avoids 1221 iterations of ProcessIndexOneChunk + append.
+        if (num_index_chunk_ == 1 && current_index_chunk_ == 0 &&
+            current_index_chunk_pos_ == 0) {
+            auto index_result = GetIndexPtrForChunk<IndexInnerType>(0);
+            Index* index_ptr = index_result.index_ptr;
+
+            auto index_res = func(index_ptr, values...);
+            auto valid_res = index_ptr->IsNotNull();
+
+            // Advance cursor past entire chunk so subsequent Eval()
+            // calls (if any) see we're done and fall through to
+            // the original batched path.
+            current_index_chunk_pos_ = index_res.size();
+
+            return std::make_shared<ColumnVector>(
+                std::move(index_res), std::move(valid_res));
+        }
 
         for (size_t i = current_index_chunk_; i < num_index_chunk_; i++) {
             // This cache result help getting result for every batch loop.

--- a/internal/core/src/exec/operator/FilterBitsNode.cpp
+++ b/internal/core/src/exec/operator/FilterBitsNode.cpp
@@ -16,6 +16,7 @@
 
 #include "FilterBitsNode.h"
 #include "common/Tracer.h"
+#include "expr/ITypeExpr.h"
 #include "fmt/format.h"
 
 #include "monitor/Monitor.h"
@@ -35,6 +36,8 @@ PhyFilterBitsNode::PhyFilterBitsNode(
     query_context_ = exec_context->get_query_context();
     std::vector<expr::TypedExprPtr> filters;
     filters.emplace_back(filter->filter());
+    is_always_true_ = (std::dynamic_pointer_cast<const expr::AlwaysTrueExpr>(
+                            filter->filter()) != nullptr);
     exprs_ = std::make_unique<ExprSet>(filters, exec_context);
     need_process_rows_ = query_context_->get_active_count();
     num_processed_rows_ = 0;
@@ -67,6 +70,18 @@ PhyFilterBitsNode::GetOutput() {
         return nullptr;
     }
 
+    // Fast path: AlwaysTrueExpr means no filtering needed.
+    // Directly produce all-zero bitmap (no rows excluded) + all-one valid bitmap.
+    if (is_always_true_) {
+        num_processed_rows_ = need_process_rows_;
+        TargetBitmap bitset(need_process_rows_, false);
+        TargetBitmap valid_bitset(need_process_rows_, true);
+        std::vector<VectorPtr> col_res;
+        col_res.push_back(std::make_shared<ColumnVector>(
+            std::move(bitset), std::move(valid_bitset)));
+        return std::make_shared<RowVector>(col_res);
+    }
+
     tracer::AutoSpan span(
         "PhyFilterBitsNode::Execute", tracer::GetRootSpan(), true);
     tracer::AddEvent(fmt::format("input_rows: {}", need_process_rows_));
@@ -89,6 +104,20 @@ PhyFilterBitsNode::GetOutput() {
                 std::dynamic_pointer_cast<ColumnVector>(results_[0])) {
             if (col_vec->IsBitmap()) {
                 auto col_vec_size = col_vec->size();
+                // OPT-K: If expression returned full-segment result
+                // (e.g., from index fast path), take it directly and
+                // skip remaining loop iterations.
+                if (col_vec_size == need_process_rows_ &&
+                    bitset.size() == 0) {
+                    TargetBitmapView view(col_vec->GetRawData(),
+                                          col_vec_size);
+                    bitset.append(view);
+                    TargetBitmapView valid_view(
+                        col_vec->GetValidRawData(), col_vec_size);
+                    valid_bitset.append(valid_view);
+                    num_processed_rows_ = need_process_rows_;
+                    break;
+                }
                 TargetBitmapView view(col_vec->GetRawData(), col_vec_size);
                 bitset.append(view);
                 TargetBitmapView valid_view(col_vec->GetValidRawData(),

--- a/internal/core/src/exec/operator/FilterBitsNode.h
+++ b/internal/core/src/exec/operator/FilterBitsNode.h
@@ -76,6 +76,7 @@ class PhyFilterBitsNode : public Operator {
     QueryContext* query_context_;
     int64_t num_processed_rows_;
     int64_t need_process_rows_;
+    bool is_always_true_{false};
 };
 }  // namespace exec
 }  // namespace milvus

--- a/internal/core/src/exec/operator/MvccNode.cpp
+++ b/internal/core/src/exec/operator/MvccNode.cpp
@@ -63,22 +63,63 @@ PhyMvccNode::GetOutput() {
         return nullptr;
     }
 
+    // ── Sealed + no-filter fast paths ──────────────────────────────
+    // Split into two independent optimizations so each applies on its own:
+    //   Level 1: no deletes → skip everything (QueryContext flag + thread-local bitmap)
+    //   Level 2: has deletes → skip timestamp mask, only apply delete mask
+    // Both require: source node (no scalar filter), sealed segment, no TTL.
+    // mask_with_timestamps is redundant on sealed segments without TTL
+    // because all rows are committed before the query timestamp.
+    if (is_source_node_ &&
+        segment_->type() == SegmentType::Sealed &&
+        collection_ttl_timestamp_ == 0) {
+
+        // Level 1: no deletes — every row is visible.
+        // Return a thread-local full-size zero bitmap (satisfies Driver +
+        // ExecPlanNodeVisitor assertions) and set skip_filter flag so
+        // VectorSearchNode passes empty BitsetView to Knowhere.
+        if (segment_->get_deleted_count() == 0) {
+            is_finished_ = true;
+            auto* qctx =
+                operator_context_->get_exec_context()->get_query_context();
+            qctx->set_skip_filter(true);
+
+            thread_local int64_t cached_size = 0;
+            thread_local RowVectorPtr cached_output;
+            if (cached_size != active_count_) {
+                auto col = std::make_shared<ColumnVector>(
+                    TargetBitmap(active_count_),
+                    TargetBitmap(active_count_));
+                cached_output = std::make_shared<RowVector>(
+                    std::vector<VectorPtr>{col});
+                cached_size = active_count_;
+            }
+            return cached_output;
+        }
+
+        // Level 2: has deletes — allocate bitmap, apply delete mask only
+        auto col_input = std::make_shared<ColumnVector>(
+            TargetBitmap(active_count_), TargetBitmap(active_count_));
+        TargetBitmapView data(col_input->GetRawData(), col_input->size());
+        segment_->mask_with_delete(data, active_count_, query_timestamp_);
+        is_finished_ = true;
+        return std::make_shared<RowVector>(
+            std::vector<VectorPtr>{col_input});
+    }
+
+    // ── Level 3: default path (has filter / growing / TTL) ────────
     tracer::AddEvent(fmt::format("input_rows: {}", active_count_));
-    // the first vector is filtering result and second bitset is a valid bitset
-    // if valid_bitset[i]==false, means result[i] is null
     auto col_input = is_source_node_ ? std::make_shared<ColumnVector>(
                                            TargetBitmap(active_count_),
                                            TargetBitmap(active_count_))
                                      : GetColumnVector(input_);
 
     TargetBitmapView data(col_input->GetRawData(), col_input->size());
-    // need to expose null?
     segment_->mask_with_timestamps(
         data, query_timestamp_, collection_ttl_timestamp_);
     segment_->mask_with_delete(data, active_count_, query_timestamp_);
     is_finished_ = true;
 
-    // input_ have already been updated
     return std::make_shared<RowVector>(std::vector<VectorPtr>{col_input});
 }
 

--- a/internal/core/src/exec/operator/VectorSearchNode.cpp
+++ b/internal/core/src/exec/operator/VectorSearchNode.cpp
@@ -83,6 +83,38 @@ PhyVectorSearchNode::GetOutput() {
     milvus::SearchResult search_result;
 
     auto col_input = GetColumnVector(input_);
+
+    // Fast path: MvccNode set skip_filter flag on QueryContext, meaning
+    // no filtering is needed (sealed segment, no deletes, no scalar filter,
+    // no TTL). Pass an empty BitsetView to Knowhere so it uses
+    // IDSelectorAll — the fastest search path.
+    if (query_context_->get_skip_filter()) {
+        milvus::BitsetView empty_view;
+        auto op_context = query_context_->get_op_context();
+        segment_->vector_search(search_info_,
+                                src_data,
+                                src_offsets,
+                                num_queries,
+                                query_timestamp_,
+                                empty_view,
+                                op_context,
+                                search_result);
+        search_result.total_data_cnt_ = active_count_;
+        span.GetSpan()->SetAttribute(
+            "result_count",
+            static_cast<int>(search_result.seg_offsets_.size()));
+        query_context_->set_search_result(std::move(search_result));
+        std::chrono::high_resolution_clock::time_point vector_end =
+            std::chrono::high_resolution_clock::now();
+        double vector_cost =
+            std::chrono::duration<double, std::micro>(
+                vector_end - vector_start)
+                .count();
+        milvus::monitor::internal_core_search_latency_vector.Observe(
+            vector_cost / 1000);
+        return input_;
+    }
+
     TargetBitmapView view(col_input->GetRawData(), col_input->size());
     if (view.all()) {
         query_context_->set_search_result(

--- a/internal/core/src/query/ExecPlanNodeVisitor.cpp
+++ b/internal/core/src/query/ExecPlanNodeVisitor.cpp
@@ -39,7 +39,8 @@ empty_search_result(int64_t num_queries) {
 BitsetType
 ExecPlanNodeVisitor::ExecuteTask(
     plan::PlanFragment& plan,
-    std::shared_ptr<milvus::exec::QueryContext> query_context) {
+    std::shared_ptr<milvus::exec::QueryContext> query_context,
+    bool collect_bitset) {
     tracer::AutoSpan span("ExecuteTask", tracer::GetRootSpan(), true);
     span.GetSpan()->SetAttribute("active_count",
                                  query_context->get_active_count());
@@ -64,15 +65,16 @@ ExecPlanNodeVisitor::ExecuteTask(
         LOG_DEBUG("output result length:{}", childrens[0]->size());
         if (auto vec = std::dynamic_pointer_cast<ColumnVector>(childrens[0])) {
             processed_num += vec->size();
-            BitsetTypeView view(vec->GetRawData(), vec->size());
-            bitset_holder.append(view);
+            if (collect_bitset) {
+                BitsetTypeView view(vec->GetRawData(), vec->size());
+                bitset_holder.append(view);
+            }
         } else {
             ThrowInfo(UnexpectedError, "expr return type not matched");
         }
     }
 
     span.GetSpan()->SetAttribute("total_rows", processed_num);
-    span.GetSpan()->SetAttribute("matched_rows", bitset_holder.count());
 
     return bitset_holder;
 }
@@ -189,8 +191,8 @@ ExecPlanNodeVisitor::visit(VectorPlanNode& node) {
     auto op_context = milvus::OpContext(cancel_token_);
     query_context->set_op_context(&op_context);
 
-    // Do plan fragment task work
-    auto result = ExecuteTask(plan, query_context);
+    // Do plan fragment task work (search doesn't use bitset return value)
+    ExecuteTask(plan, query_context, false);
 
     // Store result
     search_result_opt_ = std::move(query_context->get_search_result());

--- a/internal/core/src/query/ExecPlanNodeVisitor.h
+++ b/internal/core/src/query/ExecPlanNodeVisitor.h
@@ -97,7 +97,8 @@ class ExecPlanNodeVisitor : public PlanNodeVisitor {
 
     static BitsetType
     ExecuteTask(plan::PlanFragment& plan,
-                std::shared_ptr<milvus::exec::QueryContext> query_context);
+                std::shared_ptr<milvus::exec::QueryContext> query_context,
+                bool collect_bitset = true);
 
  private:
     const segcore::SegmentInterface& segment_;

--- a/internal/proxy/search_pipeline.go
+++ b/internal/proxy/search_pipeline.go
@@ -677,7 +677,7 @@ func (p *pipeline) AddNodes(t *searchTask, nodes ...*nodeDef) error {
 }
 
 func (p *pipeline) Run(ctx context.Context, span trace.Span, toReduceResults []*internalpb.SearchResults, storageCost segcore.StorageCost) (*milvuspb.SearchResults, segcore.StorageCost, error) {
-	log.Ctx(ctx).Debug("SearchPipeline run", zap.String("pipeline", p.String()))
+	log.Ctx(ctx).Debug("SearchPipeline run", zap.String("pipeline", p.name))
 	msg := opMsg{}
 	msg[pipelineInput] = toReduceResults
 	msg[pipelineStorageCost] = storageCost

--- a/internal/proxy/task_scheduler.go
+++ b/internal/proxy/task_scheduler.go
@@ -159,13 +159,11 @@ func (queue *baseTaskQueue) getTaskByReqID(reqID UniqueID) task {
 	queue.utLock.RUnlock()
 
 	queue.atLock.RLock()
-	for tID, t := range queue.activeTasks {
-		if tID == reqID {
-			queue.atLock.RUnlock()
-			return t
-		}
-	}
+	t, ok := queue.activeTasks[reqID]
 	queue.atLock.RUnlock()
+	if ok {
+		return t
+	}
 	return nil
 }
 

--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -419,7 +419,7 @@ func (sd *shardDelegator) Search(ctx context.Context, req *querypb.SearchRequest
 	}
 
 	metrics.QueryNodeSQLatencyWaitTSafe.WithLabelValues(
-		fmt.Sprint(paramtable.GetNodeID()), metrics.SearchLabel).
+		paramtable.GetStringNodeID(), metrics.SearchLabel).
 		Observe(float64(waitTr.ElapseSpan().Milliseconds()))
 
 	sealed, growing, sealedRowCount, version, err := sd.distribution.PinReadableSegments(partialResultRequiredDataRatio, req.GetReq().GetPartitionIDs()...)


### PR DESCRIPTION
pr: https://github.com/milvus-io/milvus/pull/48272
issue: #48279

Seven independent optimizations for the sealed-segment search path:

1. Skip bitset_holder.append() in search path (backport PR#44394)
2. Remove redundant bitset_holder.count() in ExecPlanNodeVisitor
3. Go search path optimizations (backport PR#47734)
4. Three-level MVCC fast path (MvccNode + QueryContext + VectorSearchNode)
5. Hardware -mpopcnt for x86_64
6. Skip FilterBitsNode for AlwaysTrueExpr
7. Index fast path skipping batch loop in ProcessIndexChunks

