### PR TITLE
fix: reset inner index ptr before remove_all in JsonKeyStats destructor

### DIFF
--- a/internal/core/src/index/json_stats/JsonKeyStats.cpp
+++ b/internal/core/src/index/json_stats/JsonKeyStats.cpp
@@ -137,6 +137,8 @@ JsonKeyStats::JsonKeyStats(const storage::FileManagerContext& ctx,
 }
 
 JsonKeyStats::~JsonKeyStats() {
+    bson_inverted_index_.reset();
+    bson_index_cache_slot_.reset();
     boost::filesystem::remove_all(path_);
     LOG_INFO("remove json key stats with path: {}", path_);
 }


### PR DESCRIPTION
JsonKeyStats::~JsonKeyStats() has a TOCTOU race condition. In the Load path, bson_index_cache_slot_ holds a CacheSlot<BsonInvertedIndex> whose tantivy background threads (file watcher, reader reload) are still running when boost::filesystem::remove_all(path_) executes. The file watcher detects deletions and attempts to reload, potentially recreating files between remove_all's traversal and the final rmdir, causing "Directory not empty" exception in destructor → std::terminate().

Reset bson_index_cache_slot_ alongside bson_inverted_index_ before remove_all to ensure all tantivy threads are stopped before file deletion begins.

issue: #48368