### PR TITLE
fix: propagate EntityTtlPhysicalTime in search request shallow copy

### DIFF
--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -280,6 +280,7 @@ func (sd *shardDelegator) shallowCopySearchRequest(req *internalpb.SearchRequest
 		IsTopkReduce:            req.IsTopkReduce,
 		IsRecallEvaluation:      req.IsRecallEvaluation,
 		CollectionTtlTimestamps: req.CollectionTtlTimestamps,
+		EntityTtlPhysicalTime:  req.EntityTtlPhysicalTime,
 	}
 
 	return nodeReq
@@ -499,6 +500,7 @@ func (sd *shardDelegator) Search(ctx context.Context, req *querypb.SearchRequest
 				IsTopkReduce:            req.GetReq().GetIsTopkReduce(),
 				IsIterator:              req.GetReq().GetIsIterator(),
 				CollectionTtlTimestamps: req.GetReq().GetCollectionTtlTimestamps(),
+				EntityTtlPhysicalTime:  req.GetReq().GetEntityTtlPhysicalTime(),
 				AnalyzerName:            subReq.GetAnalyzerName(),
 			}
 			future := conc.Go(func() (*internalpb.SearchResults, error) {

--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -280,7 +280,7 @@ func (sd *shardDelegator) shallowCopySearchRequest(req *internalpb.SearchRequest
 		IsTopkReduce:            req.IsTopkReduce,
 		IsRecallEvaluation:      req.IsRecallEvaluation,
 		CollectionTtlTimestamps: req.CollectionTtlTimestamps,
-		EntityTtlPhysicalTime:  req.EntityTtlPhysicalTime,
+		EntityTtlPhysicalTime:   req.EntityTtlPhysicalTime,
 	}
 
 	return nodeReq
@@ -500,7 +500,7 @@ func (sd *shardDelegator) Search(ctx context.Context, req *querypb.SearchRequest
 				IsTopkReduce:            req.GetReq().GetIsTopkReduce(),
 				IsIterator:              req.GetReq().GetIsIterator(),
 				CollectionTtlTimestamps: req.GetReq().GetCollectionTtlTimestamps(),
-				EntityTtlPhysicalTime:  req.GetReq().GetEntityTtlPhysicalTime(),
+				EntityTtlPhysicalTime:   req.GetReq().GetEntityTtlPhysicalTime(),
 				AnalyzerName:            subReq.GetAnalyzerName(),
 			}
 			future := conc.Go(func() (*internalpb.SearchResults, error) {

--- a/internal/querynodev2/delegator/shallow_copy_test.go
+++ b/internal/querynodev2/delegator/shallow_copy_test.go
@@ -1,0 +1,48 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package delegator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/internalpb"
+)
+
+func TestShallowCopySearchRequest_EntityTtlPhysicalTime(t *testing.T) {
+	sd := &shardDelegator{}
+
+	req := &internalpb.SearchRequest{
+		Base:                    &commonpb.MsgBase{TargetID: 1},
+		CollectionID:            1000,
+		MvccTimestamp:           100000,
+		GuaranteeTimestamp:      99999,
+		CollectionTtlTimestamps: 50000,
+		EntityTtlPhysicalTime:  1773682085500000,
+	}
+
+	copied := sd.shallowCopySearchRequest(req, 2)
+
+	assert.Equal(t, req.EntityTtlPhysicalTime, copied.EntityTtlPhysicalTime,
+		"EntityTtlPhysicalTime must be preserved in shallow copy")
+	assert.Equal(t, int64(2), copied.Base.TargetID)
+	assert.Equal(t, req.CollectionID, copied.CollectionID)
+	assert.Equal(t, req.MvccTimestamp, copied.MvccTimestamp)
+	assert.Equal(t, req.CollectionTtlTimestamps, copied.CollectionTtlTimestamps)
+}

--- a/internal/querynodev2/delegator/shallow_copy_test.go
+++ b/internal/querynodev2/delegator/shallow_copy_test.go
@@ -34,7 +34,7 @@ func TestShallowCopySearchRequest_EntityTtlPhysicalTime(t *testing.T) {
 		MvccTimestamp:           100000,
 		GuaranteeTimestamp:      99999,
 		CollectionTtlTimestamps: 50000,
-		EntityTtlPhysicalTime:  1773682085500000,
+		EntityTtlPhysicalTime:   1773682085500000,
 	}
 
 	copied := sd.shallowCopySearchRequest(req, 2)


### PR DESCRIPTION
## Summary
- `shallowCopySearchRequest` omits `EntityTtlPhysicalTime` when distributing search requests to worker nodes
- The fallback computes physical time from `MvccTimestamp`, which may lag behind when `speedupGuranteeTS` reduces the guarantee timestamp (e.g. no writes after flush with local WAL)
- This causes entity-level TTL filtering to use a stale timestamp, allowing expired entities to appear in search results
- Add `EntityTtlPhysicalTime` to both `shallowCopySearchRequest` and the advanced search request construction path

issue: #48260

## Test plan
- [x] Unit test added: `TestShallowCopySearchRequest_EntityTtlPhysicalTime`
- [ ] Existing entity TTL e2e tests pass (`test_search_without_filter_expired_entity_data`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)