### PR TITLE
enhance: make thread pool max threads size configurable

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -929,6 +929,7 @@ common:
     middlePriority: 5 # This parameter specify how many times the number of threads is the number of cores in middle priority pool
     lowPriority: 1 # This parameter specify how many times the number of threads is the number of cores in low priority pool
     bm25Load: 1 # This parameter specify how many times the number of threads is the number of cores in BM25 load pool
+    maxThreadsSize: 16 # The maximum number of threads in the thread pool, only effective when greater than 0
   buildIndexThreadPoolRatio: 0.75
   DiskIndex:
     MaxDegree: 56

--- a/internal/core/src/common/init_c.cpp
+++ b/internal/core/src/common/init_c.cpp
@@ -52,6 +52,11 @@ SetLowPriorityThreadCoreCoefficient(const float value) {
 }
 
 void
+SetThreadPoolMaxThreadsSize(const int value) {
+    milvus::SetThreadPoolMaxThreadsSize(value);
+}
+
+void
 SetDefaultExprEvalBatchSize(int64_t val) {
     milvus::SetDefaultExecEvalExprBatchSize(val);
 }

--- a/internal/core/src/common/init_c.h
+++ b/internal/core/src/common/init_c.h
@@ -41,6 +41,9 @@ void
 SetLowPriorityThreadCoreCoefficient(const float);
 
 void
+SetThreadPoolMaxThreadsSize(const int);
+
+void
 SetDefaultExprEvalBatchSize(int64_t val);
 
 void

--- a/internal/core/src/storage/ThreadPool.cpp
+++ b/internal/core/src/storage/ThreadPool.cpp
@@ -24,6 +24,8 @@
 namespace milvus {
 
 int CPU_NUM = DEFAULT_CPU_NUM;
+std::atomic<int> THREAD_POOL_MAX_THREADS_SIZE(
+    DEFAULT_THREAD_POOL_MAX_THREADS_SIZE);
 
 std::atomic<float> HIGH_PRIORITY_THREAD_CORE_COEFFICIENT(
     DEFAULT_HIGH_PRIORITY_THREAD_CORE_COEFFICIENT);
@@ -56,6 +58,12 @@ SetLowPriorityThreadCoreCoefficient(const float coefficient) {
 void
 InitCpuNum(const int num) {
     CPU_NUM = num;
+}
+
+void
+SetThreadPoolMaxThreadsSize(const int size) {
+    THREAD_POOL_MAX_THREADS_SIZE.store(size);
+    LOG_INFO("set thread pool max threads size: {}", size);
 }
 
 void

--- a/internal/core/src/storage/ThreadPool.h
+++ b/internal/core/src/storage/ThreadPool.h
@@ -44,11 +44,14 @@ const int64_t DEFAULT_HIGH_PRIORITY_THREAD_CORE_COEFFICIENT = 10;
 const int64_t DEFAULT_MIDDLE_PRIORITY_THREAD_CORE_COEFFICIENT = 5;
 const int64_t DEFAULT_LOW_PRIORITY_THREAD_CORE_COEFFICIENT = 1;
 
+const int DEFAULT_THREAD_POOL_MAX_THREADS_SIZE = 16;
+
 extern std::atomic<float> HIGH_PRIORITY_THREAD_CORE_COEFFICIENT;
 extern std::atomic<float> MIDDLE_PRIORITY_THREAD_CORE_COEFFICIENT;
 extern std::atomic<float> LOW_PRIORITY_THREAD_CORE_COEFFICIENT;
 
 extern int CPU_NUM;
+extern std::atomic<int> THREAD_POOL_MAX_THREADS_SIZE;
 
 void
 SetHighPriorityThreadCoreCoefficient(const float coefficient);
@@ -62,6 +65,9 @@ SetLowPriorityThreadCoreCoefficient(const float coefficient);
 void
 InitCpuNum(const int core);
 
+void
+SetThreadPoolMaxThreadsSize(const int size);
+
 class ThreadPool {
  public:
     explicit ThreadPool(const float thread_core_coefficient, std::string name)
@@ -73,11 +79,9 @@ class ThreadPool {
             1,
             static_cast<int>(std::round(CPU_NUM * thread_core_coefficient))));
 
-        // only IO pool will set large limit, but the CPU helps nothing to IO operations,
-        // we need to limit the max thread num, each thread will download 16~64 MiB data,
-        // according to our benchmark, 16 threads is enough to saturate the network bandwidth.
-        if (max_threads_size_.load() > 16) {
-            max_threads_size_.store(16);
+        int max_limit = THREAD_POOL_MAX_THREADS_SIZE.load();
+        if (max_limit > 0 && max_threads_size_.load() > max_limit) {
+            max_threads_size_.store(max_limit);
         }
         LOG_INFO("Init thread pool:{}", name_)
             << " with min worker num:" << min_threads_size_
@@ -151,8 +155,9 @@ class ThreadPool {
         //no need to hold mutex here as we don't require
         //max_threads_size to take effect instantly, just guaranteed atomic
         new_size = std::max(1, new_size);
-        if (new_size > 16) {
-            new_size = 16;
+        int max_limit = THREAD_POOL_MAX_THREADS_SIZE.load();
+        if (max_limit > 0 && new_size > max_limit) {
+            new_size = max_limit;
         }
         max_threads_size_.store(new_size);
     }

--- a/internal/core/src/storage/ThreadPoolTest.cpp
+++ b/internal/core/src/storage/ThreadPoolTest.cpp
@@ -28,6 +28,8 @@ class ThreadPoolTest : public testing::Test {
     SetUp() override {
         // Ensure CPU_NUM is initialized
         InitCpuNum(4);
+        // Reset to default max threads size
+        SetThreadPoolMaxThreadsSize(16);
     }
 };
 
@@ -71,6 +73,69 @@ TEST_F(ThreadPoolTest, ResizeAboveMaximum) {
 
     pool.Resize(1000);
     EXPECT_EQ(pool.GetMaxThreadNum(), 16);
+}
+
+TEST_F(ThreadPoolTest, ConfigurableMaxThreadsSize) {
+    // Set a custom max threads size
+    SetThreadPoolMaxThreadsSize(32);
+
+    ThreadPool pool(10.0, "test_pool");
+    // CPU_NUM=4, coefficient=10.0, so computed=40, clamped to 32
+    EXPECT_EQ(pool.GetMaxThreadNum(), 32);
+
+    // Resize should also respect the new limit
+    pool.Resize(40);
+    EXPECT_EQ(pool.GetMaxThreadNum(), 32);
+
+    pool.Resize(20);
+    EXPECT_EQ(pool.GetMaxThreadNum(), 20);
+}
+
+TEST_F(ThreadPoolTest, DisableMaxThreadsLimit) {
+    // Set to 0 to disable the limit
+    SetThreadPoolMaxThreadsSize(0);
+
+    ThreadPool pool(10.0, "test_pool");
+    // CPU_NUM=4, coefficient=10.0, so computed=40, no limit applied
+    EXPECT_EQ(pool.GetMaxThreadNum(), 40);
+
+    // Resize should also have no limit
+    pool.Resize(100);
+    EXPECT_EQ(pool.GetMaxThreadNum(), 100);
+}
+
+TEST_F(ThreadPoolTest, SetThreadPoolMaxThreadsSize) {
+    // Default is 16
+    EXPECT_EQ(THREAD_POOL_MAX_THREADS_SIZE.load(), 16);
+
+    // Set to a positive value
+    SetThreadPoolMaxThreadsSize(64);
+    EXPECT_EQ(THREAD_POOL_MAX_THREADS_SIZE.load(), 64);
+
+    // Set to 0 (disable limit)
+    SetThreadPoolMaxThreadsSize(0);
+    EXPECT_EQ(THREAD_POOL_MAX_THREADS_SIZE.load(), 0);
+
+    // Set to negative (also disables limit)
+    SetThreadPoolMaxThreadsSize(-1);
+    EXPECT_EQ(THREAD_POOL_MAX_THREADS_SIZE.load(), -1);
+}
+
+TEST_F(ThreadPoolTest, DynamicMaxThreadsSizeUpdate) {
+    // Start with limit=16, create pool with coefficient that exceeds it
+    ThreadPool pool(10.0, "test_pool");
+    // CPU_NUM=4, coefficient=10.0, computed=40, clamped to 16
+    EXPECT_EQ(pool.GetMaxThreadNum(), 16);
+
+    // Increase limit and resize - should now allow larger size
+    SetThreadPoolMaxThreadsSize(64);
+    pool.Resize(40);
+    EXPECT_EQ(pool.GetMaxThreadNum(), 40);
+
+    // Decrease limit and resize - should clamp to new limit
+    SetThreadPoolMaxThreadsSize(8);
+    pool.Resize(20);
+    EXPECT_EQ(pool.GetMaxThreadNum(), 8);
 }
 
 }  // namespace milvus

--- a/internal/datanode/index/init_segcore.go
+++ b/internal/datanode/index/init_segcore.go
@@ -63,6 +63,8 @@ func InitSegcore(nodeID int64) error {
 	C.SetMiddlePriorityThreadCoreCoefficient(cMiddlePriorityThreadCoreCoefficient)
 	cLowPriorityThreadCoreCoefficient := C.float(paramtable.Get().CommonCfg.LowPriorityThreadCoreCoefficient.GetAsFloat())
 	C.SetLowPriorityThreadCoreCoefficient(cLowPriorityThreadCoreCoefficient)
+	cThreadPoolMaxThreadsSize := C.int(paramtable.Get().CommonCfg.ThreadPoolMaxThreadsSize.GetAsInt())
+	C.SetThreadPoolMaxThreadsSize(cThreadPoolMaxThreadsSize)
 
 	cCPUNum := C.int(hardware.GetCPUNum())
 	C.InitCpuNum(cCPUNum)

--- a/internal/querynodev2/server.go
+++ b/internal/querynodev2/server.go
@@ -194,6 +194,33 @@ func ResizeHighPriorityPool(evt *config.Event) {
 	}
 }
 
+func ResizeMiddlePriorityPool(evt *config.Event) {
+	if evt.HasUpdated {
+		pt := paramtable.Get()
+		newRatio := pt.CommonCfg.MiddlePriorityThreadCoreCoefficient.GetAsFloat()
+		C.ResizeTheadPool(C.int64_t(1), C.float(newRatio))
+	}
+}
+
+func ResizeLowPriorityPool(evt *config.Event) {
+	if evt.HasUpdated {
+		pt := paramtable.Get()
+		newRatio := pt.CommonCfg.LowPriorityThreadCoreCoefficient.GetAsFloat()
+		C.ResizeTheadPool(C.int64_t(2), C.float(newRatio))
+	}
+}
+
+func ResizeAllPools(evt *config.Event) {
+	if evt.HasUpdated {
+		pt := paramtable.Get()
+		// Update the max threads size first to ensure the new limit is applied during resize
+		C.SetThreadPoolMaxThreadsSize(C.int(pt.CommonCfg.ThreadPoolMaxThreadsSize.GetAsInt()))
+		C.ResizeTheadPool(C.int64_t(0), C.float(pt.CommonCfg.HighPriorityThreadCoreCoefficient.GetAsFloat()))
+		C.ResizeTheadPool(C.int64_t(1), C.float(pt.CommonCfg.MiddlePriorityThreadCoreCoefficient.GetAsFloat()))
+		C.ResizeTheadPool(C.int64_t(2), C.float(pt.CommonCfg.LowPriorityThreadCoreCoefficient.GetAsFloat()))
+	}
+}
+
 func (node *QueryNode) ReconfigDiskFileWriterParams(evt *config.Event) {
 	if evt.HasUpdated {
 		if err := initcore.InitDiskFileWriterConfig(paramtable.Get()); err != nil {
@@ -217,6 +244,12 @@ func (node *QueryNode) RegisterSegcoreConfigWatcher() {
 	pt := paramtable.Get()
 	pt.Watch(pt.CommonCfg.HighPriorityThreadCoreCoefficient.Key,
 		config.NewHandler("common.threadCoreCoefficient.highPriority", ResizeHighPriorityPool))
+	pt.Watch(pt.CommonCfg.MiddlePriorityThreadCoreCoefficient.Key,
+		config.NewHandler("common.threadCoreCoefficient.middlePriority", ResizeMiddlePriorityPool))
+	pt.Watch(pt.CommonCfg.LowPriorityThreadCoreCoefficient.Key,
+		config.NewHandler("common.threadCoreCoefficient.lowPriority", ResizeLowPriorityPool))
+	pt.Watch(pt.CommonCfg.ThreadPoolMaxThreadsSize.Key,
+		config.NewHandler("common.threadCoreCoefficient.maxThreadsSize", ResizeAllPools))
 	pt.Watch(pt.CommonCfg.DiskWriteMode.Key,
 		config.NewHandler("common.diskWriteMode", node.ReconfigDiskFileWriterParams))
 	pt.Watch(pt.CommonCfg.DiskWriteBufferSizeKb.Key,

--- a/internal/querynodev2/server_test.go
+++ b/internal/querynodev2/server_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -38,6 +39,7 @@ import (
 	"github.com/milvus-io/milvus/internal/querynodev2/segments"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/util/dependency"
+	"github.com/milvus-io/milvus/pkg/v2/config"
 	"github.com/milvus-io/milvus/pkg/v2/objectstorage"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/querypb"
@@ -250,6 +252,46 @@ func (suite *QueryNodeSuite) TestStop() {
 	err = suite.node.Stop()
 	suite.NoError(err)
 	suite.True(suite.node.manager.Segment.Empty())
+}
+
+func TestResizeThreadPools(t *testing.T) {
+	paramtable.Init()
+
+	// not updated event should be no-op
+	evt := &config.Event{HasUpdated: false}
+	assert.NotPanics(t, func() { ResizeHighPriorityPool(evt) })
+	assert.NotPanics(t, func() { ResizeMiddlePriorityPool(evt) })
+	assert.NotPanics(t, func() { ResizeLowPriorityPool(evt) })
+	assert.NotPanics(t, func() { ResizeAllPools(evt) })
+
+	// updated event should resize without panic
+	evt = &config.Event{HasUpdated: true}
+	assert.NotPanics(t, func() { ResizeHighPriorityPool(evt) })
+	assert.NotPanics(t, func() { ResizeMiddlePriorityPool(evt) })
+	assert.NotPanics(t, func() { ResizeLowPriorityPool(evt) })
+	assert.NotPanics(t, func() { ResizeAllPools(evt) })
+}
+
+func TestRegisterSegcoreConfigWatcher(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	node := &QueryNode{}
+
+	assert.NotPanics(t, func() { node.RegisterSegcoreConfigWatcher() })
+
+	// verify watchers are triggered by saving config values
+	assert.NotPanics(t, func() {
+		pt.Save(pt.CommonCfg.HighPriorityThreadCoreCoefficient.Key, "10")
+	})
+	assert.NotPanics(t, func() {
+		pt.Save(pt.CommonCfg.MiddlePriorityThreadCoreCoefficient.Key, "5")
+	})
+	assert.NotPanics(t, func() {
+		pt.Save(pt.CommonCfg.LowPriorityThreadCoreCoefficient.Key, "1")
+	})
+	assert.NotPanics(t, func() {
+		pt.Save(pt.CommonCfg.ThreadPoolMaxThreadsSize.Key, "32")
+	})
 }
 
 func TestQueryNode(t *testing.T) {

--- a/internal/util/initcore/init_core.go
+++ b/internal/util/initcore/init_core.go
@@ -515,6 +515,15 @@ func SetupCoreConfigChangelCallback() {
 			return nil
 		})
 
+		paramtable.Get().CommonCfg.ThreadPoolMaxThreadsSize.RegisterCallback(func(ctx context.Context, key, oldValue, newValue string) error {
+			size, err := strconv.Atoi(newValue)
+			if err != nil {
+				return err
+			}
+			UpdateThreadPoolMaxThreadsSize(size)
+			return nil
+		})
+
 		paramtable.Get().CommonCfg.EnabledOptimizeExpr.RegisterCallback(func(ctx context.Context, key, oldValue, newValue string) error {
 			enable, err := strconv.ParseBool(newValue)
 			if err != nil {

--- a/internal/util/initcore/init_core_test.go
+++ b/internal/util/initcore/init_core_test.go
@@ -46,6 +46,26 @@ func TestOtlpHang(t *testing.T) {
 	})
 }
 
+func TestSetupCoreConfigChangeCallback(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+
+	assert.NotPanics(t, func() { SetupCoreConfigChangelCallback() })
+
+	// verify thread pool callbacks are triggered by saving valid values
+	assert.NoError(t, pt.Save(pt.CommonCfg.HighPriorityThreadCoreCoefficient.Key, "8"))
+	assert.Equal(t, "8", pt.CommonCfg.HighPriorityThreadCoreCoefficient.GetValue())
+
+	assert.NoError(t, pt.Save(pt.CommonCfg.MiddlePriorityThreadCoreCoefficient.Key, "4"))
+	assert.Equal(t, "4", pt.CommonCfg.MiddlePriorityThreadCoreCoefficient.GetValue())
+
+	assert.NoError(t, pt.Save(pt.CommonCfg.LowPriorityThreadCoreCoefficient.Key, "2"))
+	assert.Equal(t, "2", pt.CommonCfg.LowPriorityThreadCoreCoefficient.GetValue())
+
+	assert.NoError(t, pt.Save(pt.CommonCfg.ThreadPoolMaxThreadsSize.Key, "32"))
+	assert.Equal(t, "32", pt.CommonCfg.ThreadPoolMaxThreadsSize.GetValue())
+}
+
 func TestInitStorageV2FileSystem(t *testing.T) {
 	// init local storage
 	paramtable.Init()

--- a/internal/util/initcore/query_node.go
+++ b/internal/util/initcore/query_node.go
@@ -99,6 +99,8 @@ func doInitQueryNodeOnce(ctx context.Context) error {
 	C.SetMiddlePriorityThreadCoreCoefficient(cMiddlePriorityThreadCoreCoefficient)
 	cLowPriorityThreadCoreCoefficient := C.float(paramtable.Get().CommonCfg.LowPriorityThreadCoreCoefficient.GetAsFloat())
 	C.SetLowPriorityThreadCoreCoefficient(cLowPriorityThreadCoreCoefficient)
+	cThreadPoolMaxThreadsSize := C.int(paramtable.Get().CommonCfg.ThreadPoolMaxThreadsSize.GetAsInt())
+	C.SetThreadPoolMaxThreadsSize(cThreadPoolMaxThreadsSize)
 
 	cCPUNum := C.int(hardware.GetCPUNum())
 	C.InitCpuNum(cCPUNum)

--- a/internal/util/initcore/util.go
+++ b/internal/util/initcore/util.go
@@ -56,6 +56,10 @@ func UpdateLowPriorityThreadCoreCoefficient(coefficient float64) {
 	C.SetLowPriorityThreadCoreCoefficient(C.float(coefficient))
 }
 
+func UpdateThreadPoolMaxThreadsSize(size int) {
+	C.SetThreadPoolMaxThreadsSize(C.int(size))
+}
+
 func UpdateDefaultExprEvalBatchSize(size int) {
 	C.SetDefaultExprEvalBatchSize(C.int64_t(size))
 }

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -49,6 +49,7 @@ const (
 	DefaultMiddlePriorityThreadCoreCoefficient = 5
 	DefaultLowPriorityThreadCoreCoefficient    = 1
 	DefaultBM25LoadThreadCoreCoefficient       = 1
+	DefaultThreadPoolMaxThreadsSize            = 16
 
 	DefaultSessionTTL        = 15 // s
 	DefaultSessionRetryTimes = 30
@@ -230,6 +231,7 @@ type commonConfig struct {
 	MiddlePriorityThreadCoreCoefficient ParamItem `refreshable:"true"`
 	LowPriorityThreadCoreCoefficient    ParamItem `refreshable:"true"`
 	BM25LoadThreadCoreCoefficient       ParamItem `refreshable:"true"`
+	ThreadPoolMaxThreadsSize            ParamItem `refreshable:"true"`
 	EnableMaterializedView              ParamItem `refreshable:"false"`
 	BuildIndexThreadPoolRatio           ParamItem `refreshable:"false"`
 	MaxDegree                           ParamItem `refreshable:"true"`
@@ -676,6 +678,15 @@ This configuration is only used by querynode and indexnode, it selects CPU instr
 		Export: true,
 	}
 	p.BM25LoadThreadCoreCoefficient.Init(base.mgr)
+
+	p.ThreadPoolMaxThreadsSize = ParamItem{
+		Key:          "common.threadCoreCoefficient.maxThreadsSize",
+		Version:      "2.6.13",
+		DefaultValue: strconv.Itoa(DefaultThreadPoolMaxThreadsSize),
+		Doc:          "The maximum number of threads in the thread pool, only effective when greater than 0",
+		Export:       true,
+	}
+	p.ThreadPoolMaxThreadsSize.Init(base.mgr)
 
 	p.DiskWriteMode = ParamItem{
 		Key:          "common.diskWriteMode",


### PR DESCRIPTION
## Summary

- Replace the hardcoded thread pool max threads limit (16) with a configurable parameter `common.threadCoreCoefficient.maxThreadsSize`, default 16, only effective when greater than 0
- Add missing Resize watchers for middle and low priority thread pools
- When `maxThreadsSize` changes dynamically, update the limit first then resize all pools to ensure correct ordering

issue: #48378