### PR TITLE
fix: use sliding window for old version message lastConfirmedMessageID to prevent long catchup

### DIFF
--- a/internal/streamingnode/server/wal/adaptor/scanner_switchable.go
+++ b/internal/streamingnode/server/wal/adaptor/scanner_switchable.go
@@ -70,12 +70,50 @@ func (s *switchableScannerImpl) HandleMessage(ctx context.Context, msg message.I
 	}
 }
 
+// oldVersionLastConfirmedTracker tracks recent message IDs to provide a delayed
+// lastConfirmedMessageID for old version (v0) messages.
+// Old version messages don't carry lastConfirmedMessageID, so we must synthesize one.
+// Using the first-ever v0 message ID (as before) causes the scanner to restart from
+// a very old WAL position when tailing→catchup fallback occurs, leading to long catchup
+// times and search unavailability.
+// Instead, we keep a sliding window and use the message ID from N messages ago,
+// so that fallback only replays a bounded number of messages.
+type oldVersionLastConfirmedTracker struct {
+	window     []message.MessageID
+	windowSize int
+}
+
+func newOldVersionLastConfirmedTracker(windowSize int) *oldVersionLastConfirmedTracker {
+	if windowSize <= 0 {
+		windowSize = 30
+	}
+	return &oldVersionLastConfirmedTracker{
+		window:     make([]message.MessageID, 0, windowSize+1),
+		windowSize: windowSize,
+	}
+}
+
+// Track records a new message ID and returns the delayed lastConfirmedMessageID.
+// It returns the message ID from windowSize messages ago, or the earliest recorded
+// ID if fewer than windowSize messages have been tracked.
+func (t *oldVersionLastConfirmedTracker) Track(msgID message.MessageID) message.MessageID {
+	t.window = append(t.window, msgID)
+	if len(t.window) > t.windowSize {
+		confirmed := t.window[0]
+		// Trim the oldest entry to prevent unbounded growth.
+		t.window = t.window[1:]
+		return confirmed
+	}
+	// Not enough messages yet, return the first one.
+	return t.window[0]
+}
+
 // catchupScanner is a scanner that make a read at underlying wal, and try to catchup the writeahead buffer then switch to tailing mode.
 type catchupScanner struct {
 	switchableScannerImpl
-	deliverPolicy                       options.DeliverPolicy
-	exclusiveStartTimeTick              uint64 // scanner should filter out the message that less than or equal to this time tick.
-	lastConfirmedMessageIDForOldVersion message.MessageID
+	deliverPolicy                  options.DeliverPolicy
+	exclusiveStartTimeTick         uint64 // scanner should filter out the message that less than or equal to this time tick.
+	oldVersionLastConfirmedTracker *oldVersionLastConfirmedTracker
 }
 
 func (s *catchupScanner) Do(ctx context.Context) (switchableScanner, error) {
@@ -109,22 +147,18 @@ func (s *catchupScanner) consumeWithScanner(ctx context.Context, scanner walimpl
 			}
 
 			if msg.Version() == message.VersionOld {
-				if s.lastConfirmedMessageIDForOldVersion == nil {
-					s.logger.Info(
-						"scanner find a old version message, set it as the last confirmed message id for all old version message",
-						zap.Stringer("messageID", msg.MessageID()),
-					)
-					s.lastConfirmedMessageIDForOldVersion = msg.MessageID()
+				if s.oldVersionLastConfirmedTracker == nil {
+					windowSize := paramtable.Get().StreamingCfg.OldVersionLastConfirmedWindowSize.GetAsInt()
+					s.oldVersionLastConfirmedTracker = newOldVersionLastConfirmedTracker(windowSize)
 				}
-				// We always use first consumed message as the last confirmed message id for old version message.
-				// After upgrading from old milvus:
-				// The wal will be read at consuming side as following:
-				// msgv0, msgv0 ..., msgv0, msgv1, msgv1, msgv1, ...
-				// the msgv1 will be read after all msgv0 is consumed as soon as possible.
-				// so the last confirm is set to the first msgv0 message for all old version message is ok.
+				// Use a sliding-window tracker to provide a delayed lastConfirmedMessageID.
+				// This ensures that when a tailing scanner falls back to catchup mode,
+				// it only needs to replay a bounded number of recent messages instead of
+				// the entire WAL from the very first v0 message.
+				lastConfirmedMessageID := s.oldVersionLastConfirmedTracker.Track(msg.MessageID())
 				var err error
 				messageID := msg.MessageID()
-				msg, err = newOldVersionImmutableMessage(ctx, s.innerWAL.Channel().Name, s.lastConfirmedMessageIDForOldVersion, msg)
+				msg, err = newOldVersionImmutableMessage(ctx, s.innerWAL.Channel().Name, lastConfirmedMessageID, msg)
 				if errors.Is(err, vchantempstore.ErrNotFound) {
 					// Skip the message's vchannel is not found in the vchannel temp store.
 					s.logger.Info("skip the old version message because vchannel not found", zap.Stringer("messageID", messageID))

--- a/internal/streamingnode/server/wal/adaptor/scanner_switchable_test.go
+++ b/internal/streamingnode/server/wal/adaptor/scanner_switchable_test.go
@@ -1,0 +1,108 @@
+package adaptor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	mock_message "github.com/milvus-io/milvus/pkg/v2/mocks/streaming/util/mock_message"
+)
+
+func TestOldVersionLastConfirmedTracker_DefaultWindowSize(t *testing.T) {
+	tracker := newOldVersionLastConfirmedTracker(0)
+	assert.Equal(t, 30, tracker.windowSize)
+}
+
+func TestOldVersionLastConfirmedTracker_BeforeWindowFull(t *testing.T) {
+	tracker := newOldVersionLastConfirmedTracker(3)
+
+	ids := make([]*mock_message.MockMessageID, 3)
+	for i := range ids {
+		ids[i] = mock_message.NewMockMessageID(t)
+	}
+
+	// First message: should return itself (the first one)
+	result := tracker.Track(ids[0])
+	assert.Equal(t, ids[0], result)
+
+	// Second message: still returns the first one (window not full)
+	result = tracker.Track(ids[1])
+	assert.Equal(t, ids[0], result)
+
+	// Third message: still returns the first one (window size = 3, need 4th to start sliding)
+	result = tracker.Track(ids[2])
+	assert.Equal(t, ids[0], result)
+}
+
+func TestOldVersionLastConfirmedTracker_WindowSliding(t *testing.T) {
+	tracker := newOldVersionLastConfirmedTracker(3)
+
+	ids := make([]*mock_message.MockMessageID, 6)
+	for i := range ids {
+		ids[i] = mock_message.NewMockMessageID(t)
+	}
+
+	// Fill the window: track ids[0], ids[1], ids[2]
+	tracker.Track(ids[0])
+	tracker.Track(ids[1])
+	tracker.Track(ids[2])
+
+	// 4th message (ids[3]): window is now [ids[0], ids[1], ids[2], ids[3]]
+	// len=4 > windowSize=3, return ids[4-3-1] = ids[0]
+	result := tracker.Track(ids[3])
+	assert.Equal(t, ids[0], result, "should return the message 3 positions back")
+
+	// 5th message (ids[4]): window is [ids[0]..ids[4]]
+	// return ids[5-3-1] = ids[1]
+	result = tracker.Track(ids[4])
+	assert.Equal(t, ids[1], result, "should return the message 3 positions back")
+
+	// 6th message (ids[5]): window is [ids[0]..ids[5]]
+	// return ids[6-3-1] = ids[2]
+	result = tracker.Track(ids[5])
+	assert.Equal(t, ids[2], result, "should return the message 3 positions back")
+}
+
+func TestOldVersionLastConfirmedTracker_WindowSizeOne(t *testing.T) {
+	tracker := newOldVersionLastConfirmedTracker(1)
+
+	ids := make([]*mock_message.MockMessageID, 3)
+	for i := range ids {
+		ids[i] = mock_message.NewMockMessageID(t)
+	}
+
+	// First message: returns itself
+	result := tracker.Track(ids[0])
+	assert.Equal(t, ids[0], result)
+
+	// Second message: returns the one 1 position back = ids[0]
+	result = tracker.Track(ids[1])
+	assert.Equal(t, ids[0], result)
+
+	// Third message: returns ids[1]
+	result = tracker.Track(ids[2])
+	assert.Equal(t, ids[1], result)
+}
+
+func TestOldVersionLastConfirmedTracker_LargeWindow(t *testing.T) {
+	windowSize := 30
+	tracker := newOldVersionLastConfirmedTracker(windowSize)
+
+	totalMessages := 100
+	ids := make([]*mock_message.MockMessageID, totalMessages)
+	for i := range ids {
+		ids[i] = mock_message.NewMockMessageID(t)
+	}
+
+	for i := 0; i < totalMessages; i++ {
+		result := tracker.Track(ids[i])
+		if i < windowSize {
+			// Before window is full, always return the first ID
+			assert.Equal(t, ids[0], result, "before window full, should return first ID at i=%d", i)
+		} else {
+			// After window is full, return the ID from windowSize positions back
+			expected := ids[i-windowSize]
+			assert.Equal(t, expected, result, "should return ID from %d positions back at i=%d", windowSize, i)
+		}
+	}
+}

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -6650,6 +6650,9 @@ type streamingConfig struct {
 	WALRecoveryGracefulCloseTimeout      ParamItem `refreshable:"true"`
 	WALRecoverySchemaExpirationTolerance ParamItem `refreshable:"true"`
 
+	// Old version message lastConfirmedMessageID window size
+	OldVersionLastConfirmedWindowSize ParamItem `refreshable:"true"`
+
 	// Empty TimeTick Filtering configration
 	DelegatorEmptyTimeTickMaxFilterInterval ParamItem `refreshable:"true"`
 	FlushEmptyTimeTickMaxFilterInterval     ParamItem `refreshable:"true"`
@@ -7025,6 +7028,19 @@ If the schema is older than (the channel checkpoint - tolerance), it will be rem
 		Export:       false,
 	}
 	p.WALRecoverySchemaExpirationTolerance.Init(base.mgr)
+
+	p.OldVersionLastConfirmedWindowSize = ParamItem{
+		Key:     "streaming.walScanner.oldVersionLastConfirmedWindowSize",
+		Version: "2.6.13",
+		Doc: `The sliding window size for synthesizing lastConfirmedMessageID on old version (v0) WAL messages.
+Old version messages lack lastConfirmedMessageID, so the scanner synthesizes one using the message ID
+from N messages ago. This bounds the WAL replay distance when a tailing scanner falls back to catchup
+mode. A larger value means more replay on fallback but better data safety; a smaller value means faster
+recovery but slightly more risk of missing messages.`,
+		DefaultValue: "30",
+		Export:       false,
+	}
+	p.OldVersionLastConfirmedWindowSize.Init(base.mgr)
 
 	p.DelegatorEmptyTimeTickMaxFilterInterval = ParamItem{
 		Key:     "streaming.delegator.emptyTimeTick.maxFilterInterval",

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -711,6 +711,7 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, 10*time.Minute, params.StreamingCfg.FlushL0MaxLifetime.GetAsDurationByParse())
 		assert.Equal(t, 500000, params.StreamingCfg.FlushL0MaxRowNum.GetAsInt())
 		assert.Equal(t, int64(32*1024*1024), params.StreamingCfg.FlushL0MaxSize.GetAsSize())
+		assert.Equal(t, 30, params.StreamingCfg.OldVersionLastConfirmedWindowSize.GetAsInt())
 		assert.Equal(t, 2*time.Second, params.StreamingCfg.DelegatorEmptyTimeTickMaxFilterInterval.GetAsDurationByParse())
 		assert.Equal(t, 1*time.Second, params.StreamingCfg.FlushEmptyTimeTickMaxFilterInterval.GetAsDurationByParse())
 		assert.Equal(t, 0, params.StreamingCfg.WALBalancerExpectedInitialStreamingNodeNum.GetAsInt())


### PR DESCRIPTION
issue: #48389
pr: #48390

Previously, all old version (v0) WAL messages shared the same lastConfirmedMessageID pointing to the very first v0 message. When a tailing scanner fell back to catchup mode (e.g., due to WAL ownership change), it would restart from this extremely old position, causing catchup times of 14+ minutes during which tsafe could not advance and all search requests would timeout.

This change replaces the fixed first-message ID with a configurable sliding window (default size 30). The lastConfirmedMessageID now points to the message N positions back, bounding the WAL replay distance on fallback to at most N messages.