### PR TITLE
fix: [hotfix] use gin.Context thread-safe methods to prevent concurrent map read/write on Keys

### DIFF
--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -376,7 +376,7 @@ func wrapperPost(newReq newReqFunc, v2 handlerFuncV2) gin.HandlerFunc {
 		ctx = proxy.NewContextWithMetadata(ctx, username.(string), dbName)
 		traceID := span.SpanContext().TraceID().String()
 		ctx = log.WithTraceID(ctx, traceID)
-		gCtx.Keys["traceID"] = traceID
+		gCtx.Set("traceID", traceID)
 		log.Ctx(ctx).Debug("high level restful api, read parameters from request body, then start to handle.",
 			zap.Any("url", gCtx.Request.URL.Path))
 

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -1912,30 +1912,61 @@ func MetricsHandlerFunc(c *gin.Context) {
 }
 
 func LoggerHandlerFunc() gin.HandlerFunc {
-	return gin.LoggerWithConfig(gin.LoggerConfig{
-		SkipPaths: proxy.Params.ProxyCfg.GinLogSkipPaths.GetAsStrings(),
-		Formatter: func(param gin.LogFormatterParams) string {
-			if param.Latency > time.Minute {
-				param.Latency = param.Latency.Truncate(time.Second)
-			}
-			traceID, ok := param.Keys["traceID"]
-			if !ok {
-				traceID = ""
-			}
+	notlogged := proxy.Params.ProxyCfg.GinLogSkipPaths.GetAsStrings()
+	var skip map[string]struct{}
+	if length := len(notlogged); length > 0 {
+		skip = make(map[string]struct{}, length)
+		for _, p := range notlogged {
+			skip[p] = struct{}{}
+		}
+	}
 
-			accesslog.SetHTTPParams(&param)
-			return fmt.Sprintf("[%v] [GIN] [%s] [traceID=%s] [code=%3d] [latency=%v] [client=%s] [method=%s] [error=%s]\n",
-				param.TimeStamp.Format("2006/01/02 15:04:05.000 Z07:00"),
-				param.Path,
-				traceID,
-				param.StatusCode,
-				param.Latency,
-				param.ClientIP,
-				param.Method,
-				param.ErrorMessage,
-			)
-		},
-	})
+	return func(c *gin.Context) {
+		start := time.Now()
+		path := c.Request.URL.Path
+		raw := c.Request.URL.RawQuery
+
+		c.Next()
+
+		if _, ok := skip[path]; ok {
+			return
+		}
+
+		param := gin.LogFormatterParams{
+			Request:      c.Request,
+			TimeStamp:    time.Now(),
+			ClientIP:     c.ClientIP(),
+			Method:       c.Request.Method,
+			StatusCode:   c.Writer.Status(),
+			ErrorMessage: c.Errors.ByType(gin.ErrorTypePrivate).String(),
+			BodySize:     c.Writer.Size(),
+		}
+		param.Latency = param.TimeStamp.Sub(start)
+		if param.Latency > time.Minute {
+			param.Latency = param.Latency.Truncate(time.Second)
+		}
+		if raw != "" {
+			path = path + "?" + raw
+		}
+		param.Path = path
+
+		traceID, _ := c.Get("traceID")
+		if traceID == nil {
+			traceID = ""
+		}
+
+		accesslog.SetHTTPParams(c, &param)
+		fmt.Fprintf(gin.DefaultWriter, "[%v] [GIN] [%s] [traceID=%s] [code=%3d] [latency=%v] [client=%s] [method=%s] [error=%s]\n",
+			param.TimeStamp.Format("2006/01/02 15:04:05.000 Z07:00"),
+			param.Path,
+			traceID,
+			param.StatusCode,
+			param.Latency,
+			param.ClientIP,
+			param.Method,
+			param.ErrorMessage,
+		)
+	}
 }
 
 func RequestHandlerFunc(c *gin.Context) {

--- a/internal/proxy/accesslog/info/restful_info.go
+++ b/internal/proxy/accesslog/info/restful_info.go
@@ -40,6 +40,7 @@ const (
 )
 
 type RestfulInfo struct {
+	ctx    *gin.Context
 	params *gin.LogFormatterParams
 	start  time.Time
 	req    interface{}
@@ -48,8 +49,8 @@ type RestfulInfo struct {
 	actualConsistencyLevel *commonpb.ConsistencyLevel
 }
 
-func NewRestfulInfo() *RestfulInfo {
-	return &RestfulInfo{start: time.Now(), params: &gin.LogFormatterParams{}}
+func NewRestfulInfo(ctx *gin.Context) *RestfulInfo {
+	return &RestfulInfo{ctx: ctx, start: time.Now(), params: &gin.LogFormatterParams{}}
 }
 
 func (i *RestfulInfo) SetParams(p *gin.LogFormatterParams) {
@@ -57,7 +58,7 @@ func (i *RestfulInfo) SetParams(p *gin.LogFormatterParams) {
 }
 
 func (i *RestfulInfo) InitReq() {
-	req, ok := i.params.Keys[ContextRequest]
+	req, ok := i.ctx.Get(ContextRequest)
 	if !ok {
 		return
 	}
@@ -92,7 +93,7 @@ func (i *RestfulInfo) Address() string {
 }
 
 func (i *RestfulInfo) TraceID() string {
-	traceID, ok := i.params.Keys["traceID"]
+	traceID, ok := i.ctx.Get("traceID")
 	if !ok {
 		return Unknown
 	}
@@ -104,7 +105,7 @@ func (i *RestfulInfo) MethodStatus() string {
 		return fmt.Sprintf("HttpError%d", i.params.StatusCode)
 	}
 
-	value, ok := i.params.Keys[ContextReturnCode]
+	value, ok := i.ctx.Get(ContextReturnCode)
 	if !ok {
 		return Unknown
 	}
@@ -122,7 +123,7 @@ func (i *RestfulInfo) MethodStatus() string {
 }
 
 func (i *RestfulInfo) UserName() string {
-	username, ok := i.params.Keys[ContextUsername]
+	username, ok := i.ctx.Get(ContextUsername)
 	if !ok || username == "" {
 		return Unknown
 	}
@@ -135,7 +136,7 @@ func (i *RestfulInfo) ResponseSize() string {
 }
 
 func (i *RestfulInfo) ErrorCode() string {
-	code, ok := i.params.Keys[ContextReturnCode]
+	code, ok := i.ctx.Get(ContextReturnCode)
 	if !ok {
 		return Unknown
 	}
@@ -143,7 +144,7 @@ func (i *RestfulInfo) ErrorCode() string {
 }
 
 func (i *RestfulInfo) ErrorMsg() string {
-	message, ok := i.params.Keys[ContextReturnMessage]
+	message, ok := i.ctx.Get(ContextReturnMessage)
 	if !ok {
 		return ""
 	}

--- a/internal/proxy/accesslog/info/restful_info_test.go
+++ b/internal/proxy/accesslog/info/restful_info_test.go
@@ -37,6 +37,7 @@ type RestfulAccessInfoSuite struct {
 
 	username string
 	traceID  string
+	ctx      *gin.Context
 	info     *RestfulInfo
 }
 
@@ -47,7 +48,9 @@ func (s *RestfulAccessInfoSuite) SetupSuite() {
 func (s *RestfulAccessInfoSuite) SetupTest() {
 	s.username = "test-user"
 	s.traceID = "test-trace"
-	s.info = &RestfulInfo{}
+	s.ctx = &gin.Context{}
+	s.ctx.Keys = make(map[any]any)
+	s.info = &RestfulInfo{ctx: s.ctx}
 	s.info.SetParams(
 		&gin.LogFormatterParams{
 			Keys: make(map[string]any),
@@ -96,9 +99,9 @@ func (s *RestfulAccessInfoSuite) TestTraceID() {
 	result := Get(s.info, "$trace_id")
 	s.Equal(Unknown, result[0])
 
-	s.info.params.Keys["traceID"] = "testtrace"
+	s.ctx.Set("traceID", "testtrace")
 	result = Get(s.info, "$trace_id")
-	s.Equal(s.info.params.Keys["traceID"], result[0])
+	s.Equal("testtrace", result[0])
 }
 
 func (s *RestfulAccessInfoSuite) TestStatus() {
@@ -107,12 +110,12 @@ func (s *RestfulAccessInfoSuite) TestStatus() {
 	s.Equal("HttpError400", result[0])
 
 	s.info.params.StatusCode = http.StatusOK
-	s.info.params.Keys[ContextReturnCode] = merr.Code(merr.ErrChannelLack)
+	s.ctx.Set(ContextReturnCode, merr.Code(merr.ErrChannelLack))
 	result = Get(s.info, "$method_status")
 	s.Equal("Failed", result[0])
 
 	s.info.params.StatusCode = http.StatusOK
-	s.info.params.Keys[ContextReturnCode] = merr.Code(nil)
+	s.ctx.Set(ContextReturnCode, merr.Code(nil))
 	result = Get(s.info, "$method_status")
 	s.Equal("Successful", result[0])
 }
@@ -121,17 +124,17 @@ func (s *RestfulAccessInfoSuite) TestErrorCode() {
 	result := Get(s.info, "$error_code")
 	s.Equal(Unknown, result[0])
 
-	s.info.params.Keys[ContextReturnCode] = 200
+	s.ctx.Set(ContextReturnCode, 200)
 	result = Get(s.info, "$error_code")
 	s.Equal(fmt.Sprint(200), result[0])
 }
 
 func (s *RestfulAccessInfoSuite) TestErrorMsg() {
-	s.info.params.Keys[ContextReturnMessage] = merr.ErrChannelLack.Error()
+	s.ctx.Set(ContextReturnMessage, merr.ErrChannelLack.Error())
 	result := Get(s.info, "$error_msg")
 	s.Equal(merr.ErrChannelLack.Error(), result[0])
 
-	s.info.params.Keys[ContextReturnMessage] = "test error. stack: 1:\n 2:\n 3:\n"
+	s.ctx.Set(ContextReturnMessage, "test error. stack: 1:\n 2:\n 3:\n")
 	result = Get(s.info, "$error_msg")
 	s.Equal("test error. stack: 1:\\n 2:\\n 3:\\n", result[0])
 }
@@ -176,9 +179,9 @@ func (s *RestfulAccessInfoSuite) TestOutputFields() {
 	s.Equal(Unknown, result[0])
 
 	fields := []string{"pk"}
-	s.info.params.Keys[ContextRequest] = &milvuspb.QueryRequest{
+	s.ctx.Set(ContextRequest, &milvuspb.QueryRequest{
 		OutputFields: fields,
-	}
+	})
 	s.info.InitReq()
 	result = Get(s.info, "$output_fields")
 	s.Equal(fmt.Sprint(fields), result[0])
@@ -188,9 +191,9 @@ func (s *RestfulAccessInfoSuite) TestConsistencyLevel() {
 	result := Get(s.info, "$consistency_level")
 	s.Equal(Unknown, result[0])
 
-	s.info.params.Keys[ContextRequest] = &milvuspb.QueryRequest{
+	s.ctx.Set(ContextRequest, &milvuspb.QueryRequest{
 		ConsistencyLevel: commonpb.ConsistencyLevel_Bounded,
-	}
+	})
 	s.info.InitReq()
 	result = Get(s.info, "$consistency_level")
 	s.Equal(commonpb.ConsistencyLevel_Bounded.String(), result[0])

--- a/internal/proxy/accesslog/util.go
+++ b/internal/proxy/accesslog/util.go
@@ -56,8 +56,8 @@ func AccessLogMiddleware(ctx *gin.Context) {
 	_globalL.Write(accessInfo)
 }
 
-func SetHTTPParams(p *gin.LogFormatterParams) {
-	value, ok := p.Keys[ContextLogKey]
+func SetHTTPParams(ctx *gin.Context, p *gin.LogFormatterParams) {
+	value, ok := ctx.Get(ContextLogKey)
 	if !ok {
 		return
 	}

--- a/internal/proxy/accesslog/util.go
+++ b/internal/proxy/accesslog/util.go
@@ -49,7 +49,7 @@ func UnaryUpdateAccessInfoInterceptor(ctx context.Context, req any, rpcInfonfo *
 }
 
 func AccessLogMiddleware(ctx *gin.Context) {
-	accessInfo := info.NewRestfulInfo()
+	accessInfo := info.NewRestfulInfo(ctx)
 	ctx.Set(ContextLogKey, accessInfo)
 	ctx.Next()
 	accessInfo.InitReq()


### PR DESCRIPTION
Cherry-pick from master
pr: #48393

timeoutMiddleware runs handlers in a separate goroutine, which writes to gCtx.Keys directly (e.g. gCtx.Keys["traceID"] = traceID). Meanwhile AccessLogMiddleware reads from the same map via RestfulInfo in the original goroutine. Both bypass gin.Context's built-in RWMutex, causing "concurrent map read and map write" panics.

Fix: store a *gin.Context reference in RestfulInfo and replace all direct map reads (i.params.Keys[...]) with i.ctx.Get(), and replace the direct map write with gCtx.Set(). These methods use gin's internal RWMutex for safe concurrent access.

issue: #48316