### PR TITLE
fix: fix multiple flaky tests in CI

### DIFF
--- a/internal/distributed/mixcoord/client/client_test.go
+++ b/internal/distributed/mixcoord/client/client_test.go
@@ -664,9 +664,8 @@ func Test_Flush(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.Flush(ctx, &datapb.FlushRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -718,9 +717,8 @@ func Test_GetSegmentStates(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.GetSegmentStates(ctx, &datapb.GetSegmentStatesRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -772,9 +770,8 @@ func Test_GetInsertBinlogPaths(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.GetInsertBinlogPaths(ctx, &datapb.GetInsertBinlogPathsRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -826,9 +823,8 @@ func Test_GetCollectionStatistics(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.GetCollectionStatistics(ctx, &datapb.GetCollectionStatisticsRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -880,9 +876,8 @@ func Test_GetPartitionStatistics(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.GetPartitionStatistics(ctx, &datapb.GetPartitionStatisticsRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -935,9 +930,8 @@ func Test_GetSegmentInfo(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.GetSegmentInfo(ctx, &datapb.GetSegmentInfoRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -990,9 +984,8 @@ func Test_SaveBinlogPaths(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.GetSegmentInfo(ctx, &datapb.GetSegmentInfoRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -1045,9 +1038,8 @@ func Test_GetRecoveryInfo(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.GetRecoveryInfo(ctx, &datapb.GetRecoveryInfoRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -1099,9 +1091,8 @@ func Test_GetRecoveryInfoV2(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.GetRecoveryInfoV2(ctx, &datapb.GetRecoveryInfoRequestV2{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -1154,9 +1145,8 @@ func Test_GetFlushedSegments(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.GetFlushedSegments(ctx, &datapb.GetFlushedSegmentsRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -1209,9 +1199,8 @@ func Test_GetSegmentsByStates(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.GetSegmentsByStates(ctx, &datapb.GetSegmentsByStatesRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -1263,9 +1252,8 @@ func Test_ManualCompaction(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.ManualCompaction(ctx, &milvuspb.ManualCompactionRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -1317,9 +1305,8 @@ func Test_GetCompactionState(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.GetCompactionState(ctx, &milvuspb.GetCompactionStateRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -1371,9 +1358,8 @@ func Test_GetCompactionStateWithPlans(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.GetCompactionStateWithPlans(ctx, &milvuspb.GetCompactionPlansRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -1425,9 +1411,8 @@ func Test_WatchChannels(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.WatchChannels(ctx, &datapb.WatchChannelsRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -1479,9 +1464,8 @@ func Test_GetFlushState(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.GetFlushState(ctx, &datapb.GetFlushStateRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -1533,9 +1517,8 @@ func Test_GetFlushAllState(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.GetFlushAllState(ctx, &milvuspb.GetFlushAllStateRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -1588,9 +1571,12 @@ func Test_DropVirtualChannel(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	mockDC.ExpectedCalls = nil
+	mockDC.EXPECT().DropVirtualChannel(mock1.Anything, mock1.Anything).Return(&datapb.DropVirtualChannelResponse{
+		Status: merr.Success(),
+	}, nil)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.DropVirtualChannel(ctx, &datapb.DropVirtualChannelRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -1643,9 +1629,8 @@ func Test_SetSegmentState(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.SetSegmentState(ctx, &datapb.SetSegmentStateRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -1692,9 +1677,8 @@ func Test_UpdateSegmentStatistics(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.UpdateSegmentStatistics(ctx, &datapb.UpdateSegmentStatisticsRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -1741,9 +1725,8 @@ func Test_UpdateChannelCheckpoint(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.UpdateChannelCheckpoint(ctx, &datapb.UpdateChannelCheckpointRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -1791,9 +1774,8 @@ func Test_MarkSegmentsDropped(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.MarkSegmentsDropped(ctx, &datapb.MarkSegmentsDroppedRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -1840,9 +1822,8 @@ func Test_BroadcastAlteredCollection(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.BroadcastAlteredCollection(ctx, &datapb.AlterCollectionRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -1890,9 +1871,8 @@ func Test_GcConfirm(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.GcConfirm(ctx, &datapb.GcConfirmRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -1945,9 +1925,8 @@ func Test_CreateIndex(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.CreateIndex(ctx, &indexpb.CreateIndexRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -2004,9 +1983,8 @@ func Test_GetSegmentIndexState(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.GetSegmentIndexState(ctx, &indexpb.GetSegmentIndexStateRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -2062,9 +2040,8 @@ func Test_GetIndexState(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.GetIndexState(ctx, &indexpb.GetIndexStateRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -2121,9 +2098,8 @@ func Test_GetIndexInfos(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.GetIndexInfos(ctx, &indexpb.GetIndexInfoRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -2180,9 +2156,8 @@ func Test_DescribeIndex(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.DescribeIndex(ctx, &indexpb.DescribeIndexRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -2239,9 +2214,8 @@ func Test_GetIndexStatistics(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.GetIndexStatistics(ctx, &indexpb.GetIndexStatisticsRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -2298,9 +2272,8 @@ func Test_GetIndexBuildProgress(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.GetIndexBuildProgress(ctx, &indexpb.GetIndexBuildProgressRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -2354,9 +2327,8 @@ func Test_DropIndex(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.DropIndex(ctx, &indexpb.DropIndexRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -2403,9 +2375,8 @@ func Test_ReportDataNodeTtMsgs(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.ReportDataNodeTtMsgs(ctx, &datapb.ReportDataNodeTtMsgsRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -2452,9 +2423,8 @@ func Test_GcControl(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.GcControl(ctx, &datapb.GcControlRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -2641,9 +2611,8 @@ func Test_FlushAll(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.FlushAll(ctx, &datapb.FlushAllRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -2696,9 +2665,8 @@ func TestClient_TruncateCollection(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.TruncateCollection(ctx, &milvuspb.TruncateCollectionRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -2756,9 +2724,8 @@ func TestClient_GetRestoreSnapshotState(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.GetRestoreSnapshotState(ctx, &datapb.GetRestoreSnapshotStateRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -2814,9 +2781,8 @@ func TestClient_ListRestoreSnapshotJobs(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.ListRestoreSnapshotJobs(ctx, &datapb.ListRestoreSnapshotJobsRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -2877,9 +2843,8 @@ func TestClient_BatchUpdateManifest(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.BatchUpdateManifest(ctx, &datapb.BatchUpdateManifestRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }

--- a/internal/distributed/proxy/client/client_test.go
+++ b/internal/distributed/proxy/client/client_test.go
@@ -83,9 +83,8 @@ func Test_GetComponentStates(t *testing.T) {
 	assert.Nil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.GetComponentStates(ctx, &milvuspb.GetComponentStatesRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -124,9 +123,8 @@ func Test_GetStatisticsChannel(t *testing.T) {
 	assert.Nil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.GetStatisticsChannel(ctx, &internalpb.GetStatisticsChannelRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -162,9 +160,8 @@ func Test_InvalidateCollectionMetaCache(t *testing.T) {
 	assert.Nil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.InvalidateCollectionMetaCache(ctx, &proxypb.InvalidateCollMetaCacheRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -200,9 +197,8 @@ func Test_InvalidateCredentialCache(t *testing.T) {
 	assert.Nil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.InvalidateCredentialCache(ctx, &proxypb.InvalidateCredCacheRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -238,9 +234,8 @@ func Test_UpdateCredentialCache(t *testing.T) {
 	assert.Nil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.UpdateCredentialCache(ctx, &proxypb.UpdateCredCacheRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -276,9 +271,8 @@ func Test_RefreshPolicyInfoCache(t *testing.T) {
 	assert.Nil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.RefreshPolicyInfoCache(ctx, &proxypb.RefreshPolicyInfoCacheRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -314,9 +308,8 @@ func Test_GetProxyMetrics(t *testing.T) {
 	assert.Nil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.GetProxyMetrics(ctx, &milvuspb.GetMetricsRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -352,9 +345,8 @@ func Test_SetRates(t *testing.T) {
 	assert.Nil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.SetRates(ctx, &proxypb.SetRatesRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -390,9 +382,8 @@ func Test_ListClientInfos(t *testing.T) {
 	assert.Nil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.ListClientInfos(ctx, &proxypb.ListClientInfosRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -427,9 +418,8 @@ func Test_GetDdChannel(t *testing.T) {
 	assert.Nil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.GetDdChannel(ctx, &internalpb.GetDdChannelRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -493,9 +483,8 @@ func Test_InvalidateShardLeaderCache(t *testing.T) {
 	assert.Nil(t, err)
 
 	// test ctx done
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer cancel()
-	time.Sleep(20 * time.Millisecond)
 	_, err = client.InvalidateShardLeaderCache(ctx, &proxypb.InvalidateShardLeaderCacheRequest{})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }

--- a/internal/kv/etcd/etcd_kv_test.go
+++ b/internal/kv/etcd/etcd_kv_test.go
@@ -687,7 +687,7 @@ func (s *EtcdKVSuite) TestRevisionBytes() {
 		resp := <-ch
 		s.Equal(1, len(resp.Events))
 		s.Equal(string(test.secondValue), string(resp.Events[0].Kv.Value))
-		s.Equal(revision+1, resp.Header.Revision)
+		s.GreaterOrEqual(resp.Header.Revision, revision+1)
 	}
 
 	success, err := etcdKV.CompareVersionAndSwapBytes(context.TODO(), "a/b/c", 0, []byte("1"))

--- a/internal/metastore/kv/querycoord/kv_catalog_test.go
+++ b/internal/metastore/kv/querycoord/kv_catalog_test.go
@@ -47,6 +47,7 @@ func (suite *CatalogTestSuite) SetupTest() {
 
 func (suite *CatalogTestSuite) TearDownTest() {
 	if suite.kv != nil {
+		suite.kv.RemoveWithPrefix(context.Background(), "")
 		suite.kv.Close()
 	}
 }
@@ -197,23 +198,28 @@ func (suite *CatalogTestSuite) TestReleaseManyPartitions() {
 
 func (suite *CatalogTestSuite) TestReplica() {
 	ctx := context.Background()
-	suite.catalog.SaveReplica(ctx, &querypb.Replica{
+	err := suite.catalog.SaveReplica(ctx, &querypb.Replica{
 		CollectionID: 1,
 		ID:           1,
 	})
+	suite.NoError(err)
 
-	suite.catalog.SaveReplica(ctx, &querypb.Replica{
+	err = suite.catalog.SaveReplica(ctx, &querypb.Replica{
 		CollectionID: 1,
 		ID:           2,
 	})
+	suite.NoError(err)
 
-	suite.catalog.SaveReplica(ctx, &querypb.Replica{
+	err = suite.catalog.SaveReplica(ctx, &querypb.Replica{
 		CollectionID: 1,
 		ID:           3,
 	})
+	suite.NoError(err)
 
-	suite.catalog.ReleaseReplica(ctx, 1, 1)
-	suite.catalog.ReleaseReplica(ctx, 1, 2)
+	err = suite.catalog.ReleaseReplica(ctx, 1, 1)
+	suite.NoError(err)
+	err = suite.catalog.ReleaseReplica(ctx, 1, 2)
+	suite.NoError(err)
 
 	replicas, err := suite.catalog.GetReplicas(ctx)
 	suite.NoError(err)

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1908,10 +1908,10 @@ func TestProxy(t *testing.T) {
 
 		{
 			Params.Save(Params.ProxyCfg.MustUsePartitionKey.Key, "true")
+			defer Params.Reset(Params.ProxyCfg.MustUsePartitionKey.Key)
 			resp, err := proxy.Search(ctx, req)
 			assert.NoError(t, err)
 			assert.NotEqual(t, commonpb.ErrorCode_Success, resp.Status.ErrorCode)
-			Params.Reset(Params.ProxyCfg.MustUsePartitionKey.Key)
 		}
 	})
 
@@ -1931,10 +1931,10 @@ func TestProxy(t *testing.T) {
 
 		{
 			Params.Save(Params.ProxyCfg.MustUsePartitionKey.Key, "true")
+			defer Params.Reset(Params.ProxyCfg.MustUsePartitionKey.Key)
 			resp, err := proxy.Search(ctx, req)
 			assert.NoError(t, err)
 			assert.NotEqual(t, commonpb.ErrorCode_Success, resp.Status.ErrorCode)
-			Params.Reset(Params.ProxyCfg.MustUsePartitionKey.Key)
 		}
 	})
 


### PR DESCRIPTION
## Summary
- **proxy.TestProxy/search**: use `defer` for `Params.Reset` to prevent `MustUsePartitionKey` config pollution when test fails early
- **etcd.TestEtcdKV/TestRevisionBytes**: use `GreaterOrEqual` instead of `Equal` for etcd revision comparison since revision is a global counter shared across concurrent tests
- **querycoord.TestCatalogSuite/TestReplica**: add error checks for `SaveReplica`/`ReleaseReplica` calls and clean up etcd data in `TearDownTest`
- **mixcoord/client and proxy/client tests**: replace timing-dependent `context.WithTimeout(10ms) + time.Sleep(20ms)` with `context.WithDeadline(time.Now().Add(-1s))` to create already-expired contexts, eliminating race conditions on busy CI machines

issue: https://github.com/milvus-io/milvus/issues/39726

## Test plan
- [ ] CI build-ut-ciloop passes
- [ ] No new test failures introduced
- [ ] Existing flaky tests stabilized


🤖 Generated with [Claude Code](https://claude.ai/code)