### PR TITLE
enhance: add gRPC authority support to CDC replicate client

### DIFF
--- a/client/milvusclient/client_config.go
+++ b/client/milvusclient/client_config.go
@@ -160,3 +160,10 @@ func (c *ClientConfig) WithTLSConfig(tlsConfig *tls.Config) *ClientConfig {
 	c.EnableTLSAuth = true
 	return c
 }
+
+// WithGrpcAuthority sets the gRPC :authority header, used for proxy-based routing.
+// Preserves all DefaultGrpcOpts.
+func (c *ClientConfig) WithGrpcAuthority(authority string) *ClientConfig {
+	c.DialOptions = append(append([]grpc.DialOption{}, DefaultGrpcOpts...), grpc.WithAuthority(authority))
+	return c
+}

--- a/client/milvusclient/client_config_test.go
+++ b/client/milvusclient/client_config_test.go
@@ -1,0 +1,34 @@
+package milvusclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithGrpcAuthority(t *testing.T) {
+	t.Run("sets authority and preserves default opts", func(t *testing.T) {
+		config := &ClientConfig{}
+		result := config.WithGrpcAuthority("proxy.example.com")
+
+		assert.Same(t, config, result)
+		// DefaultGrpcOpts + grpc.WithAuthority = len(DefaultGrpcOpts) + 1
+		assert.Equal(t, len(DefaultGrpcOpts)+1, len(config.DialOptions))
+	})
+
+	t.Run("does not mutate DefaultGrpcOpts", func(t *testing.T) {
+		originalLen := len(DefaultGrpcOpts)
+		config := &ClientConfig{}
+		config.WithGrpcAuthority("proxy.example.com")
+
+		assert.Equal(t, originalLen, len(DefaultGrpcOpts))
+	})
+
+	t.Run("successive calls replace previous options", func(t *testing.T) {
+		config := &ClientConfig{}
+		config.WithGrpcAuthority("first.example.com")
+		config.WithGrpcAuthority("second.example.com")
+
+		assert.Equal(t, len(DefaultGrpcOpts)+1, len(config.DialOptions))
+	})
+}

--- a/internal/cdc/cluster/milvus_client.go
+++ b/internal/cdc/cluster/milvus_client.go
@@ -58,6 +58,13 @@ func NewMilvusClient(ctx context.Context, cluster *commonpb.MilvusCluster) (Milv
 		config.WithTLSConfig(tlsConfig)
 	}
 
+	if authority := paramtable.Get().ProxyGrpcServerCfg.GetClusterAuthority(cluster.GetClusterId()); authority != "" {
+		config.WithGrpcAuthority(authority)
+		log.Info("CDC outbound gRPC authority set",
+			zap.String("targetCluster", cluster.GetClusterId()),
+			zap.String("authority", authority))
+	}
+
 	cli, err := milvusclient.New(ctx, config)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create milvus client")

--- a/internal/cdc/cluster/milvus_client_test.go
+++ b/internal/cdc/cluster/milvus_client_test.go
@@ -17,10 +17,13 @@
 package cluster
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
@@ -88,5 +91,46 @@ func TestBuildCDCTLSConfig(t *testing.T) {
 		tlsConfig, err = buildCDCTLSConfig("cluster-c")
 		assert.NoError(t, err)
 		assert.Nil(t, tlsConfig)
+	})
+}
+
+func TestNewMilvusClientWithAuthority(t *testing.T) {
+	paramtable.Init()
+
+	t.Run("authority not set does not add dial options", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+
+		cluster := &commonpb.MilvusCluster{
+			ClusterId: "test-cluster",
+			ConnectionParam: &commonpb.ConnectionParam{
+				Uri:   "localhost:19530",
+				Token: "",
+			},
+		}
+
+		_, err := NewMilvusClient(ctx, cluster)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create milvus client")
+	})
+
+	t.Run("authority set via paramtable adds dial option", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+
+		paramtable.Get().Save("grpc.clusters.proxy-cluster.authority", "milvus.internal.example.com")
+		defer paramtable.Get().Save("grpc.clusters.proxy-cluster.authority", "")
+
+		cluster := &commonpb.MilvusCluster{
+			ClusterId: "proxy-cluster",
+			ConnectionParam: &commonpb.ConnectionParam{
+				Uri:   "localhost:19530",
+				Token: "test-token",
+			},
+		}
+
+		_, err := NewMilvusClient(ctx, cluster)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create milvus client")
 	})
 }

--- a/pkg/util/paramtable/grpc_param.go
+++ b/pkg/util/paramtable/grpc_param.go
@@ -149,6 +149,13 @@ func (p *grpcConfig) GetClusterTLSConfig(clusterID string) (caPemPath, clientPem
 	return
 }
 
+// GetClusterAuthority returns the gRPC :authority header for CDC outbound connections.
+// Reads from grpc.clusters.<clusterID>.authority.
+// Returns empty string if not configured.
+func (p *grpcConfig) GetClusterAuthority(clusterID string) string {
+	return p.base.Get("grpc.clusters." + clusterID + ".authority")
+}
+
 // GetAddress return grpc address
 func (p *grpcConfig) GetAddress() string {
 	return p.IP + ":" + p.Port.GetValue()

--- a/pkg/util/paramtable/grpc_param_test.go
+++ b/pkg/util/paramtable/grpc_param_test.go
@@ -192,6 +192,15 @@ func TestGrpcClientParams(t *testing.T) {
 	assert.Equal(t, "", caPem)
 	assert.Equal(t, "", clientPem)
 	assert.Equal(t, "", clientKey)
+
+	// Per-cluster gRPC authority config lookup
+	base.Save("grpc.clusters.cluster-b.authority", "proxy.example.com")
+	authority := clientConfig.GetClusterAuthority("cluster-b")
+	assert.Equal(t, "proxy.example.com", authority)
+
+	// Unknown cluster returns empty string
+	authority = clientConfig.GetClusterAuthority("unknown-cluster")
+	assert.Equal(t, "", authority)
 }
 
 func TestInternalTLSParams(t *testing.T) {


### PR DESCRIPTION
I'm trying to add the capability of configuring the authority on the CDC replicate config. This is needed when the milvus clusters are behind the proxies in a multi milvus clusters setup. Without this field the target milvus can not be reached and routed to.

Issue: https://github.com/milvus-io/milvus/issues/48423