### PR TITLE
fix: add shadow probe in LookAsideBalancer to recover isolated nodes

### DIFF
--- a/examples/telemetry_e2e_test/go.mod
+++ b/examples/telemetry_e2e_test/go.mod
@@ -1,9 +1,9 @@
 module github.com/milvus-io/milvus/examples/telemetry_e2e_test
 
-go 1.24
+go 1.24.12
 
 require (
-	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20251215075310-deda9c0dcece
+	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260304062516-e7e54d966ef2
 	github.com/milvus-io/milvus/client/v2 v2.6.4-0.20251104142533-a2ce70d25256
 	google.golang.org/grpc v1.71.0
 )

--- a/examples/telemetry_e2e_test/go.sum
+++ b/examples/telemetry_e2e_test/go.sum
@@ -1,0 +1,2 @@
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260304062516-e7e54d966ef2/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
+google.golang.org/grpc v1.71.0/go.mod h1:H0GRtasmQOh9LkFoCPDu3ZrwUtD1YGE+b2vYBYd/8Ec=

--- a/internal/proxy/shardclient/look_aside_balancer.go
+++ b/internal/proxy/shardclient/look_aside_balancer.go
@@ -230,10 +230,13 @@ func (b *LookAsideBalancer) checkQueryNodeHealthLoop(ctx context.Context) {
 	defer b.wg.Done()
 
 	checkHealthInterval := paramtable.Get().ProxyCfg.CheckQueryNodeHealthInterval.GetAsDuration(time.Millisecond)
+	shadowProbeInterval := paramtable.Get().ProxyCfg.ShadowProbeInterval.GetAsDuration(time.Millisecond)
 	ticker := time.NewTicker(checkHealthInterval)
 	defer ticker.Stop()
 	log.Info("Start check query node health loop")
 	pool := conc.NewDefaultPool[any]()
+
+	var lastShadowProbeTime time.Time
 	for {
 		select {
 		case <-b.closeCh:
@@ -243,6 +246,40 @@ func (b *LookAsideBalancer) checkQueryNodeHealthLoop(ctx context.Context) {
 		case <-ticker.C:
 			var futures []*conc.Future[any]
 			now := time.Now()
+
+			// Define the interval at the beginning of the loop or get from params
+			runShadowProbe := now.Sub(lastShadowProbeTime) >= shadowProbeInterval
+			if runShadowProbe {
+				lastShadowProbeTime = now
+				// Iterate through metricsMap to find nodes that are NOT in knownNodeInfos
+				b.metricsMap.Range(func(nodeID int64, metrics *CostMetrics) bool {
+					if _, active := b.knownNodeInfos.Get(nodeID); !active {
+						// Found an isolated node! Try to recover it.
+						nodeID := nodeID
+						futures = append(futures, pool.Submit(func() (any, error) {
+							checkTimeout := paramtable.Get().ProxyCfg.HealthCheckTimeout.GetAsDuration(time.Millisecond)
+							ctx, cancel := context.WithTimeout(context.Background(), checkTimeout)
+							defer cancel()
+
+							// Use a dummy NodeInfo to trigger the clientMgr's lookup
+							qn, err := b.clientMgr.GetClient(ctx, NodeInfo{NodeID: nodeID})
+							if err != nil {
+								return struct{}{}, nil
+							}
+
+							resp, err := qn.GetComponentStates(ctx, &milvuspb.GetComponentStatesRequest{})
+							if err == nil && resp.GetState().GetStateCode() == commonpb.StateCode_Healthy {
+								log.Info("Shadow probe detected node recovered, promoting to active", zap.Int64("node", nodeID))
+								// This will move the node from 'unserviceable' to 'active'
+								b.trySetQueryNodeReachable(nodeID)
+							}
+							return struct{}{}, nil
+						}))
+					}
+					return true
+				})
+			}
+
 			b.knownNodeInfos.Range(func(node int64, info NodeInfo) bool {
 				futures = append(futures, pool.Submit(func() (any, error) {
 					metrics, ok := b.metricsMap.Get(node)
@@ -287,6 +324,26 @@ func (b *LookAsideBalancer) checkQueryNodeHealthLoop(ctx context.Context) {
 			})
 			conc.AwaitAll(futures...)
 		}
+	}
+}
+
+func (b *LookAsideBalancer) probeAndRecoverNode(node int64, info NodeInfo, log *log.MLogger) {
+	checkTimeout := paramtable.Get().ProxyCfg.HealthCheckTimeout.GetAsDuration(time.Millisecond)
+	// Use Background context to avoid being affected by the main loop's context
+	ctx, cancel := context.WithTimeout(context.Background(), checkTimeout)
+	defer cancel()
+
+	qn, err := b.clientMgr.GetClient(ctx, info)
+	if err != nil {
+		return
+	}
+
+	resp, err := qn.GetComponentStates(ctx, &milvuspb.GetComponentStatesRequest{})
+	if err == nil && resp.GetState().GetStateCode() == commonpb.StateCode_Healthy {
+		log.Info("Shadow probe detected node recovered, promoting to reachable", zap.Int64("node", node))
+		// This is the key: once set to reachable, it will be added to knownNodeInfos
+		// and picked up by the main high-frequency loop in the next tick.
+		b.trySetQueryNodeReachable(node)
 	}
 }
 

--- a/internal/proxy/shardclient/look_aside_balancer_test.go
+++ b/internal/proxy/shardclient/look_aside_balancer_test.go
@@ -565,6 +565,55 @@ func BenchmarkSelectNode_QNWithDifferentWorkload(b *testing.B) {
 	})
 }
 
+func (suite *LookAsideBalancerSuite) TestShadowProbingRecovery() {
+	// 1. Setup params: Set ShadowProbeInterval to a very short time for testing
+	params := paramtable.Get()
+	// Ensure these keys match your ParamTable implementation
+	params.Save(params.ProxyCfg.CheckQueryNodeHealthInterval.Key, "100")
+	params.Save(params.ProxyCfg.ShadowProbeInterval.Key, "200")
+	params.Save(params.ProxyCfg.HealthCheckTimeout.Key, "100")
+
+	nodeID := int64(3)
+
+	// 2. Mock QueryNode 3 to be Healthy
+	qn3 := mocks.NewMockQueryNodeClient(suite.T())
+	qn3.EXPECT().GetComponentStates(mock.Anything, mock.Anything).Return(&milvuspb.ComponentStates{
+		State: &milvuspb.ComponentInfo{
+			StateCode: commonpb.StateCode_Healthy,
+		},
+	}, nil).Maybe()
+
+	// 3. Mock ClientManager to return qn3
+	suite.clientMgr.ExpectedCalls = nil
+	suite.clientMgr.EXPECT().GetClient(mock.Anything, mock.Anything).Return(qn3, nil).Maybe()
+
+	// 4. Simulate the "Inconsistent State":
+	// Node 3 is in metricsMap (Proxy remembers it) but NOT in knownNodeInfos (Proxy won't use it)
+	metrics3 := &CostMetrics{}
+	metrics3.ts.Store(time.Now().UnixMilli())
+	metrics3.unavailable.Store(true) // Initially marked as unavailable
+	suite.balancer.metricsMap.Insert(nodeID, metrics3)
+
+	// Ensure knownNodeInfos DOES NOT have node 3
+	suite.balancer.knownNodeInfos.Remove(nodeID)
+	_, isActive := suite.balancer.knownNodeInfos.Get(nodeID)
+	suite.False(isActive, "Node 3 should be isolated from active list initially")
+
+	// 5. Wait for Shadow Probing to detect and promote the node
+	// It should trigger within ~200ms based on our config
+	suite.Eventually(func() bool {
+		_, isActive := suite.balancer.knownNodeInfos.Get(nodeID)
+		metrics, ok := suite.balancer.metricsMap.Get(nodeID)
+		// Success criteria: Node 3 is back in knownNodeInfos and marked as available
+		return isActive && ok && !metrics.unavailable.Load()
+	}, 5*time.Second, 100*time.Millisecond)
+
+	// 6. Final Verification: SelectNode should now work for Node 3
+	targetNode, err := suite.balancer.SelectNode(context.Background(), []int64{nodeID}, 1)
+	suite.NoError(err)
+	suite.Equal(nodeID, targetNode)
+}
+
 func TestLookAsideBalancerSuite(t *testing.T) {
 	suite.Run(t, new(LookAsideBalancerSuite))
 }

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -1917,6 +1917,7 @@ type proxyConfig struct {
 	ShardLeaderCacheInterval        ParamItem `refreshable:"false"`
 	ReplicaSelectionPolicy          ParamItem `refreshable:"false"`
 	CheckQueryNodeHealthInterval    ParamItem `refreshable:"false"`
+	ShadowProbeInterval             ParamItem `refreshable:"false"`
 	CostMetricsExpireTime           ParamItem `refreshable:"false"`
 	CheckWorkloadRequestNum         ParamItem `refreshable:"false"`
 	WorkloadToleranceFactor         ParamItem `refreshable:"false"`
@@ -2280,6 +2281,14 @@ please adjust in embedded Milvus: false`,
 		Doc:          "time interval to check health for query node, in ms",
 	}
 	p.CheckQueryNodeHealthInterval.Init(base.mgr)
+
+	p.ShadowProbeInterval = ParamItem{
+		Key:          "proxy.healthCheck.shadowProbeInterval",
+		Version:      "2.6.13",
+		DefaultValue: "10000",
+		Doc:          "time interval to probe unreachable or isolated query nodes, in ms",
+	}
+	p.ShadowProbeInterval.Init(base.mgr)
 
 	p.CostMetricsExpireTime = ParamItem{
 		Key:          "proxy.costMetricsExpireTime",

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -227,6 +227,11 @@ func TestComponentParam(t *testing.T) {
 		params.Save("proxy.replicaBlacklistDuration", "60s")
 		assert.Equal(t, 60*time.Second, Params.ReplicaBlacklistDuration.GetAsDurationByParse())
 
+		// Test ShadowProbeInterval default value and dynamic update
+		assert.Equal(t, 10000*time.Millisecond, Params.ShadowProbeInterval.GetAsDurationByParse())
+		params.Save(Params.ShadowProbeInterval.Key, "5000ms")
+		assert.Equal(t, 5000*time.Millisecond, Params.ShadowProbeInterval.GetAsDurationByParse())
+
 		// Test ReplicaBlacklistCleanupInterval default value
 		assert.Equal(t, 10*time.Second, Params.ReplicaBlacklistCleanupInterval.GetAsDurationByParse())
 		params.Save("proxy.replicaBlacklistCleanupInterval", "30s")


### PR DESCRIPTION
The LookAsideBalancer currently only checks nodes in 'knownNodeInfos'. If a node is removed due to transient failures, it enters a 'blind spot'.

This commit introduces a 'Shadow Probe' mechanism:
1. Scans 'metricsMap' for nodes missing from 'knownNodeInfos'.
2. Probes orphaned nodes at a configurable 'ShadowProbeInterval'.
3. Automatically reintegrates healthy nodes.

Fixes: #48398