### PR TITLE
fix: add nil guard for GoRegistry and CRegistry in MilvusRegistry.Gather

### DIFF
--- a/internal/util/metrics/milvus_registry.go
+++ b/internal/util/metrics/milvus_registry.go
@@ -43,16 +43,20 @@ type MilvusRegistry struct {
 
 // Gather implements Gatherer.
 func (r *MilvusRegistry) Gather() ([]*dto.MetricFamily, error) {
-	var res []*dto.MetricFamily
+	if r.GoRegistry == nil {
+		return nil, nil
+	}
 	resGo, err := r.GoRegistry.Gather()
 	if err != nil {
-		return res, err
+		return nil, err
+	}
+	if r.CRegistry == nil {
+		return resGo, nil
 	}
 	resC, err := r.CRegistry.Gather()
 	if err != nil {
 		// if gather c metrics fail, ignore the error and return go metrics
 		return resGo, nil
 	}
-	res = append(resGo, resC...)
-	return res, nil
+	return append(resGo, resC...), nil
 }

--- a/internal/util/metrics/milvus_registry_test.go
+++ b/internal/util/metrics/milvus_registry_test.go
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the LF AI & Data foundation under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMilvusRegistryGather_NilGoRegistry(t *testing.T) {
+	r := &MilvusRegistry{
+		GoRegistry: nil,
+		CRegistry:  nil,
+	}
+	res, err := r.Gather()
+	assert.NoError(t, err)
+	assert.Nil(t, res)
+}
+
+func TestMilvusRegistryGather_NilCRegistry(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(prometheus.NewGoCollector())
+	r := &MilvusRegistry{
+		GoRegistry: reg,
+		CRegistry:  nil,
+	}
+	res, err := r.Gather()
+	assert.NoError(t, err)
+	assert.NotNil(t, res)
+	assert.Greater(t, len(res), 0)
+}


### PR DESCRIPTION
## Summary

Fix nil pointer dereference in `MilvusRegistry.Gather()` that occurs during QueryTask after etcd chaos recovery, caused by CGo memory corruption overwriting the `GoRegistry` pointer to nil.

- Add nil guard for `GoRegistry` before calling `GoRegistry.Gather()` — if nil, return `(nil, nil)` instead of panicking
- Add nil guard for `CRegistry` before calling `CRegistry.Gather()` — if nil, return Go metrics only
- Change error return from uninitialized `res` variable to explicit `nil` for clarity

issue: #48383

## Test plan

- [x] `TestMilvusRegistryGather_NilGoRegistry` — verifies no panic when both `GoRegistry` and `CRegistry` are nil
- [x] `TestMilvusRegistryGather_NilCRegistry` — verifies Go metrics are returned correctly when only `CRegistry` is nil

🤖 Generated with [Claude Code](https://claude.com/claude-code)