### PR TITLE
fix: support V2/V3 column group in getBinLogIDs and getTotalBinlogRows

### DIFF
--- a/internal/datacoord/util.go
+++ b/internal/datacoord/util.go
@@ -276,10 +276,22 @@ func getCompactionMergeInfo(task *datapb.CompactionTask) *milvuspb.CompactionMer
 	}
 }
 
+func matchFieldBinlog(fieldBinLog *datapb.FieldBinlog, fieldID int64) bool {
+	if fieldBinLog.GetFieldID() == fieldID {
+		return true
+	}
+	for _, childField := range fieldBinLog.GetChildFields() {
+		if childField == fieldID {
+			return true
+		}
+	}
+	return false
+}
+
 func getBinLogIDs(segment *SegmentInfo, fieldID int64) []int64 {
 	binlogIDs := make([]int64, 0)
 	for _, fieldBinLog := range segment.GetBinlogs() {
-		if fieldBinLog.GetFieldID() == fieldID {
+		if matchFieldBinlog(fieldBinLog, fieldID) {
 			for _, binLog := range fieldBinLog.GetBinlogs() {
 				binlogIDs = append(binlogIDs, binLog.GetLogID())
 			}
@@ -292,7 +304,7 @@ func getBinLogIDs(segment *SegmentInfo, fieldID int64) []int64 {
 func getTotalBinlogRows(segment *SegmentInfo, fieldID int64) int64 {
 	var total int64
 	for _, fieldBinLog := range segment.GetBinlogs() {
-		if fieldBinLog.GetFieldID() == fieldID {
+		if matchFieldBinlog(fieldBinLog, fieldID) {
 			for _, binLog := range fieldBinLog.GetBinlogs() {
 				total += binLog.EntriesNum
 			}

--- a/internal/datacoord/util_test.go
+++ b/internal/datacoord/util_test.go
@@ -176,3 +176,130 @@ func (suite *UtilSuite) TestCalculateL0SegmentSize() {
 
 	suite.Equal(calculateL0SegmentSize(fields), float64(logsize))
 }
+
+func (suite *UtilSuite) TestMatchFieldBinlog() {
+	// Direct field ID match
+	fb := &datapb.FieldBinlog{FieldID: 100}
+	suite.True(matchFieldBinlog(fb, 100))
+	suite.False(matchFieldBinlog(fb, 200))
+
+	// Match via ChildFields (V2/V3 column group)
+	fb = &datapb.FieldBinlog{
+		FieldID:     0, // column group ID
+		ChildFields: []int64{100, 101, 102},
+	}
+	suite.True(matchFieldBinlog(fb, 100))
+	suite.True(matchFieldBinlog(fb, 101))
+	suite.True(matchFieldBinlog(fb, 102))
+	suite.False(matchFieldBinlog(fb, 200))
+}
+
+func (suite *UtilSuite) TestGetBinLogIDs_ColumnGroup() {
+	// V1 storage: FieldID == fieldID
+	seg := &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			Binlogs: []*datapb.FieldBinlog{
+				{
+					FieldID: 100,
+					Binlogs: []*datapb.Binlog{
+						{LogID: 1},
+						{LogID: 2},
+					},
+				},
+				{
+					FieldID: 101,
+					Binlogs: []*datapb.Binlog{
+						{LogID: 3},
+					},
+				},
+			},
+		},
+	}
+
+	ids := getBinLogIDs(seg, 100)
+	suite.Equal([]int64{1, 2}, ids)
+
+	ids = getBinLogIDs(seg, 101)
+	suite.Equal([]int64{3}, ids)
+
+	ids = getBinLogIDs(seg, 999)
+	suite.Empty(ids)
+
+	// V2/V3 storage: field in composite column group
+	seg = &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			Binlogs: []*datapb.FieldBinlog{
+				{
+					FieldID:     0, // column group ID
+					ChildFields: []int64{100, 101, 106},
+					Binlogs: []*datapb.Binlog{
+						{LogID: 10},
+						{LogID: 11},
+					},
+				},
+				{
+					FieldID: 200, // individual field (e.g. vector)
+					Binlogs: []*datapb.Binlog{
+						{LogID: 20},
+					},
+				},
+			},
+		},
+	}
+
+	// Field 106 is inside column group 0
+	ids = getBinLogIDs(seg, 106)
+	suite.Equal([]int64{10, 11}, ids)
+
+	// Field 100 is also inside column group 0
+	ids = getBinLogIDs(seg, 100)
+	suite.Equal([]int64{10, 11}, ids)
+
+	// Field 200 matches directly
+	ids = getBinLogIDs(seg, 200)
+	suite.Equal([]int64{20}, ids)
+
+	// Field 999 not found
+	ids = getBinLogIDs(seg, 999)
+	suite.Empty(ids)
+}
+
+func (suite *UtilSuite) TestGetTotalBinlogRows_ColumnGroup() {
+	// V1 storage
+	seg := &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			Binlogs: []*datapb.FieldBinlog{
+				{
+					FieldID: 100,
+					Binlogs: []*datapb.Binlog{
+						{EntriesNum: 500},
+						{EntriesNum: 300},
+					},
+				},
+			},
+		},
+	}
+	suite.Equal(int64(800), getTotalBinlogRows(seg, 100))
+	suite.Equal(int64(0), getTotalBinlogRows(seg, 999))
+
+	// V2/V3 storage: field in composite column group
+	seg = &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			Binlogs: []*datapb.FieldBinlog{
+				{
+					FieldID:     0,
+					ChildFields: []int64{100, 101, 106},
+					Binlogs: []*datapb.Binlog{
+						{EntriesNum: 1000},
+						{EntriesNum: 2000},
+					},
+				},
+			},
+		},
+	}
+
+	// Field 106 is inside column group 0
+	suite.Equal(int64(3000), getTotalBinlogRows(seg, 106))
+	suite.Equal(int64(3000), getTotalBinlogRows(seg, 100))
+	suite.Equal(int64(0), getTotalBinlogRows(seg, 999))
+}


### PR DESCRIPTION
## Summary

- `getBinLogIDs` and `getTotalBinlogRows` in datacoord only matched `FieldBinlog.FieldID`, which fails for V2/V3 storage where scalar fields are grouped into composite column groups with actual field IDs stored in `ChildFields`.
- Extracted a `matchFieldBinlog` helper that checks both `FieldID` and `ChildFields`, fixing Geometry RTREE index crashes (DataNode panic + QueryNode SIGSEGV) caused by empty binlog IDs during index building.
- Added comprehensive unit tests for `matchFieldBinlog`, `getBinLogIDs`, and `getTotalBinlogRows` covering both V1 and V2/V3 storage formats.

issue: #48375

## Test plan

- [x] Unit tests for `matchFieldBinlog` direct field ID match and ChildFields match
- [x] Unit tests for `getBinLogIDs` with V1 (per-field binlogs) and V2/V3 (column group) storage
- [x] Unit tests for `getTotalBinlogRows` with V1 and V2/V3 storage
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)