### PR TITLE
fix: filter git tags with --match 'v*' to avoid pkg/ submodule tags in MILVUS_VERSION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -254,7 +254,7 @@ BUILD_TIME = $(shell date -u)
 GIT_COMMIT = $(shell git rev-parse --short HEAD)
 GO_VERSION = $(shell go version)
 BUILD_DATE = $(shell date -u +%Y%m%d)
-MILVUS_VERSION := $(shell tag=$$(git describe --exact-match --tags 2>/dev/null) && echo "$$tag" | sed 's/^v//' || echo "$(GIT_BRANCH_SAFE)-$(BUILD_DATE)-$(GIT_COMMIT)")
+MILVUS_VERSION := $(shell tag=$$(git describe --exact-match --tags --match 'v*' 2>/dev/null) && echo "$$tag" | sed 's/^v//' || echo "$(GIT_BRANCH_SAFE)-$(BUILD_DATE)-$(GIT_COMMIT)")
 
 print-build-info:
 	@echo "Build Tag: $(BUILD_TAGS)"


### PR DESCRIPTION
## Summary

Cherry-pick of #48418 to 2.6 branch.

- Add `--match 'v*'` to `git describe --exact-match --tags` in `MILVUS_VERSION` calculation
- Prevents `pkg/v2.6.13` (Go submodule tag) from being picked instead of `v2.6.13` on release builds
- Without this fix, `GetVersion` returns `pkg/v2.6.13` instead of `2.6.13`

pr: #48418

issue: #47823

## Test plan

- [ ] Verify on a tagged commit with both `v*` and `pkg/v*` tags: `git describe --exact-match --tags --match 'v*'` returns only the root tag
- [ ] Dev builds unaffected (no exact tag match, falls through to branch-date-commit format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)