### PR TITLE
fix: [cphotfix-2.5.13] apply denylist retry to writeLog and binlog import

### DIFF
--- a/internal/flushcommon/syncmgr/task.go
+++ b/internal/flushcommon/syncmgr/task.go
@@ -393,10 +393,14 @@ func (t *SyncTask) appendDeltalog(deltalog *datapb.Binlog) {
 func (t *SyncTask) writeLogs(ctx context.Context) error {
 	return retry.Handle(ctx, func() (bool, error) {
 		err := t.chunkManager.MultiWrite(ctx, t.segmentData)
-		if err != nil {
-			return !merr.IsCanceledOrTimeout(err), err
+		if err == nil {
+			return false, nil
 		}
-		return false, nil
+		err = storage.ToMilvusIoError("", err)
+		if merr.IsNonRetryableErr(err) {
+			return false, err
+		}
+		return true, err
 	}, t.writeRetryOpts...)
 }
 

--- a/internal/flushcommon/syncmgr/task_test.go
+++ b/internal/flushcommon/syncmgr/task_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/metricsinfo"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/retry"
@@ -353,7 +354,7 @@ func (s *SyncTaskSuite) TestRunError() {
 		handler := func(_ error) { flag = true }
 		s.chunkManager.ExpectedCalls = nil
 		s.chunkManager.EXPECT().RootPath().Return("files")
-		s.chunkManager.EXPECT().MultiWrite(mock.Anything, mock.Anything).Return(retry.Unrecoverable(errors.New("mocked")))
+		s.chunkManager.EXPECT().MultiWrite(mock.Anything, mock.Anything).Return(merr.WrapErrIoPermissionDenied("mocked-key", errors.New("mocked")))
 		task := s.getSuiteSyncTask().WithFailureCallback(handler)
 		task.binlogBlobs[100] = &storage.Blob{
 			Key:   "100",

--- a/internal/util/importutilv2/binlog/reader_test.go
+++ b/internal/util/importutilv2/binlog/reader_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/util/testutil"
 	"github.com/milvus-io/milvus/pkg/v2/common"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
@@ -420,6 +421,32 @@ func (suite *ReaderSuite) TestVector() {
 	suite.run(schemapb.DataType_Int32, schemapb.DataType_None, false)
 	suite.vecDataType = schemapb.DataType_SparseFloatVector
 	suite.run(schemapb.DataType_Int32, schemapb.DataType_None, false)
+}
+
+func (suite *ReaderSuite) TestNewBinlogReaderRetryOnTransientError() {
+	ctx := context.Background()
+	cm := mocks.NewChunkManager(suite.T())
+	path := "test/binlog/path"
+	transientErr := fmt.Errorf("connection reset by peer")
+	permErr := merr.WrapErrIoPermissionDenied(path, fmt.Errorf("access denied"))
+
+	// Transient errors should be retried; non-retryable errors should stop immediately.
+	suite.Run("transient_error_exhausts_attempts", func() {
+		paramtable.Get().Save(paramtable.Get().CommonCfg.StorageReadRetryAttempts.Key, "2")
+		defer paramtable.Get().Reset(paramtable.Get().CommonCfg.StorageReadRetryAttempts.Key)
+		cm.EXPECT().Read(mock.Anything, path).Return(nil, transientErr).Times(2)
+		_, err := newBinlogReader(ctx, cm, path)
+		suite.Error(err)
+	})
+
+	suite.Run("non_retryable_error_stops_immediately", func() {
+		paramtable.Get().Save(paramtable.Get().CommonCfg.StorageReadRetryAttempts.Key, "3")
+		defer paramtable.Get().Reset(paramtable.Get().CommonCfg.StorageReadRetryAttempts.Key)
+		cm2 := mocks.NewChunkManager(suite.T())
+		cm2.EXPECT().Read(mock.Anything, path).Return(nil, permErr).Times(1)
+		_, err := newBinlogReader(ctx, cm2, path)
+		suite.Error(err)
+	})
 }
 
 func TestUtil(t *testing.T) {

--- a/internal/util/importutilv2/binlog/util.go
+++ b/internal/util/importutilv2/binlog/util.go
@@ -27,6 +27,8 @@ import (
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v2/util/retry"
 )
 
 func readData(reader *storage.BinlogReader, et storage.EventTypeCode) ([]any, [][]bool, error) {
@@ -54,15 +56,27 @@ func readData(reader *storage.BinlogReader, et storage.EventTypeCode) ([]any, []
 	return rowsSet, validDataRowsSet, nil
 }
 
-func newBinlogReader(ctx context.Context, cm storage.ChunkManager, path string) (*storage.BinlogReader, error) {
-	bytes, err := cm.Read(ctx, path) // TODO: dyh, checks if the error is a retryable error
+func newBinlogReader(ctx context.Context, cm storage.ChunkManager, filePath string) (*storage.BinlogReader, error) {
+	retryAttempts := paramtable.Get().CommonCfg.StorageReadRetryAttempts.GetAsUint()
+	var bytes []byte
+	err := retry.Handle(ctx, func() (bool, error) {
+		var e error
+		bytes, e = cm.Read(ctx, filePath)
+		if e == nil {
+			return false, nil
+		}
+		e = storage.ToMilvusIoError(filePath, e)
+		if merr.IsNonRetryableErr(e) {
+			return false, e
+		}
+		return true, e
+	}, retry.Attempts(retryAttempts))
 	if err != nil {
-		return nil, merr.WrapErrImportFailed(fmt.Sprintf("failed to open binlog %s", path))
+		return nil, merr.WrapErrImportFailed(fmt.Sprintf("failed to open binlog %s", filePath))
 	}
-	var reader *storage.BinlogReader
-	reader, err = storage.NewBinlogReader(bytes)
+	reader, err := storage.NewBinlogReader(bytes)
 	if err != nil {
-		return nil, merr.WrapErrImportFailed(fmt.Sprintf("failed to create reader, binlog:%s, error:%v", path, err))
+		return nil, merr.WrapErrImportFailed(fmt.Sprintf("failed to create reader, binlog:%s, error:%v", filePath, err))
 	}
 	return reader, nil
 }

--- a/pkg/util/merr/utils.go
+++ b/pkg/util/merr/utils.go
@@ -91,12 +91,8 @@ func IsNonRetryableErr(err error) bool {
 }
 
 func IsMilvusError(err error) bool {
-	if err == nil {
-		return false
-	}
-	cause := errors.Cause(err)
-	_, ok := cause.(milvusError)
-	return ok
+	var me milvusError
+	return errors.As(err, &me)
 }
 
 func IsCanceledOrTimeout(err error) bool {

--- a/pkg/util/merr/utils_test.go
+++ b/pkg/util/merr/utils_test.go
@@ -74,3 +74,24 @@ func TestIsNonRetryableErr_WrappedErrors(t *testing.T) {
 	wrappedRetryable := fmt.Errorf("network issue: %w", ErrIoUnexpectEOF)
 	assert.False(t, IsNonRetryableErr(wrappedRetryable))
 }
+
+func TestIsMilvusError_WrappedChain(t *testing.T) {
+	// Direct milvus error
+	assert.True(t, IsMilvusError(ErrCollectionNotFound))
+
+	// Wrapped via errors.Wrap — milvusError is root, both impls handle this
+	assert.True(t, IsMilvusError(errors.Wrap(ErrCollectionNotFound, "context")))
+
+	// Combined: plain error first, milvusError second.
+	// errors.Cause: multiErrors has no Cause() method, returns multiErrors itself — type
+	// assertion to milvusError fails. errors.As: multiErrors.Unwrap() returns errs[1] directly
+	// (ErrCollectionNotFound), so errors.As finds it.
+	// Known limitation: Combine(milvusErr, plain) is NOT covered — Unwrap exposes errs[1:] only,
+	// so milvusError at index 0 would not be found by errors.As either.
+	combined := Combine(errors.New("plain"), ErrCollectionNotFound)
+	assert.True(t, IsMilvusError(combined), "milvusError at tail of Combine chain should be detected")
+
+	// Non-milvus error
+	assert.False(t, IsMilvusError(errors.New("plain error")))
+	assert.False(t, IsMilvusError(nil))
+}


### PR DESCRIPTION
Cherry-pick from master PR #48402

pr: #48402
issue: #48153

## Summary

- `pkg/util/merr/utils.go`: `IsMilvusError` uses `errors.As` (full chain traversal) instead of `errors.Cause` (root cause only)
- `internal/flushcommon/syncmgr/task.go`: `writeLogs` now uses denylist strategy (`IsNonRetryableErr` + `ToMilvusIoError`) instead of allowlist (`!IsCanceledOrTimeout`)
- `internal/util/importutilv2/binlog/util.go`: `newBinlogReader` now wraps `cm.Read` with denylist retry (resolves TODO comment left in the code)

**Hotfix adaptations** (since `pack_writer.go` and the `WithDownloader` code path don't exist in 2.5.x):
- `pack_writer.go` writeLog fix → applied to `task.go` `writeLogs` (equivalent write path in 2.5.x)
- binlog `WithDownloader` retry fix → applied to `util.go` `newBinlogReader` `cm.Read` call (equivalent read path in 2.5.x)

## Verification

- [x] `go vet` passes for all changed packages
- [x] No conflict markers
- [x] Tests updated to use denylist-compatible errors (`WrapErrIoPermissionDenied`)
- [x] New tests added for `newBinlogReader` retry behavior