### PR TITLE
feat: add MiniMax as text embedding provider

### DIFF
--- a/internal/util/function/embedding/minimax_embedding_provider.go
+++ b/internal/util/function/embedding/minimax_embedding_provider.go
@@ -1,0 +1,123 @@
+/*
+ * # Licensed to the LF AI & Data foundation under one
+ * # or more contributor license agreements. See the NOTICE file
+ * # distributed with this work for additional information
+ * # regarding copyright ownership. The ASF licenses this file
+ * # to you under the Apache License, Version 2.0 (the
+ * # "License"); you may not use this file except in compliance
+ * # with the License. You may obtain a copy of the License at
+ * #
+ * #     http://www.apache.org/licenses/LICENSE-2.0
+ * #
+ * # Unless required by applicable law or agreed to in writing, software
+ * # distributed under the License is distributed on an "AS IS" BASIS,
+ * # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * # See the License for the specific language governing permissions and
+ * # limitations under the License.
+ */
+
+package embedding
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/util/credentials"
+	"github.com/milvus-io/milvus/internal/util/function/models"
+	"github.com/milvus-io/milvus/internal/util/function/models/minimax"
+	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
+)
+
+type MiniMaxEmbeddingProvider struct {
+	fieldDim int64
+
+	client    *minimax.MiniMaxClient
+	url       string
+	modelName string
+
+	maxBatch   int
+	timeoutSec int64
+	extraInfo  *models.ModelExtraInfo
+}
+
+func NewMiniMaxEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSchema *schemapb.FunctionSchema, params map[string]string, credentials *credentials.Credentials, extraInfo *models.ModelExtraInfo) (*MiniMaxEmbeddingProvider, error) {
+	fieldDim, err := typeutil.GetDim(fieldSchema)
+	if err != nil {
+		return nil, err
+	}
+	apiKey, url, err := models.ParseAKAndURL(credentials, functionSchema.Params, params, models.MiniMaxAKEnvStr, extraInfo)
+	if err != nil {
+		return nil, err
+	}
+	var modelName string
+
+	for _, param := range functionSchema.Params {
+		switch strings.ToLower(param.Key) {
+		case models.ModelNameParamKey:
+			modelName = param.Value
+		default:
+		}
+	}
+
+	c, err := minimax.NewMiniMaxClient(apiKey)
+	if err != nil {
+		return nil, err
+	}
+
+	if url == "" {
+		url = "https://api.minimax.io/v1/embeddings"
+	}
+
+	provider := MiniMaxEmbeddingProvider{
+		client:     c,
+		url:        url,
+		fieldDim:   fieldDim,
+		modelName:  modelName,
+		maxBatch:   32,
+		timeoutSec: 30,
+		extraInfo:  extraInfo,
+	}
+	return &provider, nil
+}
+
+func (provider *MiniMaxEmbeddingProvider) MaxBatch() int {
+	return provider.extraInfo.BatchFactor * provider.maxBatch
+}
+
+func (provider *MiniMaxEmbeddingProvider) FieldDim() int64 {
+	return provider.fieldDim
+}
+
+func (provider *MiniMaxEmbeddingProvider) CallEmbedding(ctx context.Context, texts []string, mode models.TextEmbeddingMode) (any, error) {
+	// MiniMax uses "db" type for storage/indexing and "query" type for search queries.
+	embType := "db"
+	if mode == models.SearchMode {
+		embType = "query"
+	}
+
+	numRows := len(texts)
+	data := make([][]float32, 0, numRows)
+	for i := 0; i < numRows; i += provider.maxBatch {
+		end := i + provider.maxBatch
+		if end > numRows {
+			end = numRows
+		}
+		resp, err := provider.client.Embedding(provider.url, provider.modelName, texts[i:end], embType, provider.timeoutSec)
+		if err != nil {
+			return nil, err
+		}
+		if end-i != len(resp.Vectors) {
+			return nil, fmt.Errorf("Get embedding failed. The number of texts and embeddings does not match text:[%d], embedding:[%d]", end-i, len(resp.Vectors))
+		}
+		for _, emb := range resp.Vectors {
+			if len(emb) != int(provider.fieldDim) {
+				return nil, fmt.Errorf("The required embedding dim is [%d], but the embedding obtained from the model is [%d]",
+					provider.fieldDim, len(emb))
+			}
+			data = append(data, emb)
+		}
+	}
+	return data, nil
+}

--- a/internal/util/function/embedding/minimax_embedding_provider_test.go
+++ b/internal/util/function/embedding/minimax_embedding_provider_test.go
@@ -1,0 +1,183 @@
+/*
+ * # Licensed to the LF AI & Data foundation under one
+ * # or more contributor license agreements. See the NOTICE file
+ * # distributed with this work for additional information
+ * # regarding copyright ownership. The ASF licenses this file
+ * # to you under the Apache License, Version 2.0 (the
+ * # "License"); you may not use this file except in compliance
+ * # with the License. You may obtain a copy of the License at
+ * #
+ * #     http://www.apache.org/licenses/LICENSE-2.0
+ * #
+ * # Unless required by applicable law or agreed to in writing, software
+ * # distributed under the License is distributed on an "AS IS" BASIS,
+ * # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * # See the License for the specific language governing permissions and
+ * # limitations under the License.
+ */
+
+package embedding
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/util/credentials"
+	"github.com/milvus-io/milvus/internal/util/function/models"
+	"github.com/milvus-io/milvus/internal/util/function/models/minimax"
+)
+
+func TestMiniMaxTextEmbeddingProvider(t *testing.T) {
+	suite.Run(t, new(MiniMaxTextEmbeddingProviderSuite))
+}
+
+type MiniMaxTextEmbeddingProviderSuite struct {
+	suite.Suite
+	schema    *schemapb.CollectionSchema
+	providers []string
+}
+
+func (s *MiniMaxTextEmbeddingProviderSuite) SetupTest() {
+	s.schema = &schemapb.CollectionSchema{
+		Name: "test",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "int64", DataType: schemapb.DataType_Int64},
+			{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar},
+			{
+				FieldID: 102, Name: "vector", DataType: schemapb.DataType_FloatVector,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: "dim", Value: "4"},
+				},
+			},
+		},
+	}
+	s.providers = []string{minimaxProvider}
+}
+
+func createMiniMaxProvider(url string, schema *schemapb.FieldSchema, providerName string) (textEmbeddingProvider, error) {
+	functionSchema := &schemapb.FunctionSchema{
+		Name:             "test",
+		Type:             schemapb.FunctionType_Unknown,
+		InputFieldNames:  []string{"text"},
+		OutputFieldNames: []string{"vector"},
+		InputFieldIds:    []int64{101},
+		OutputFieldIds:   []int64{102},
+		Params: []*commonpb.KeyValuePair{
+			{Key: models.ModelNameParamKey, Value: TestModel},
+			{Key: models.CredentialParamKey, Value: "mock"},
+		},
+	}
+	switch providerName {
+	case minimaxProvider:
+		return NewMiniMaxEmbeddingProvider(schema, functionSchema, map[string]string{models.URLParamKey: url}, credentials.NewCredentials(map[string]string{"mock.apikey": "mock"}), &models.ModelExtraInfo{BatchFactor: 5})
+	default:
+		return nil, errors.New("Unknown provider")
+	}
+}
+
+func (s *MiniMaxTextEmbeddingProviderSuite) TestEmbedding() {
+	ts := CreateMiniMaxEmbeddingServer(4)
+
+	defer ts.Close()
+	for _, providerName := range s.providers {
+		provider, err := createMiniMaxProvider(ts.URL, s.schema.Fields[2], providerName)
+		s.NoError(err)
+		{
+			data := []string{"sentence"}
+			r, err2 := provider.CallEmbedding(context.Background(), data, models.InsertMode)
+			ret := r.([][]float32)
+			s.NoError(err2)
+			s.Equal(1, len(ret))
+			s.Equal(4, len(ret[0]))
+		}
+		{
+			data := []string{"sentence 1", "sentence 2", "sentence 3"}
+			_, err := provider.CallEmbedding(context.Background(), data, models.SearchMode)
+			s.NoError(err)
+		}
+	}
+}
+
+func (s *MiniMaxTextEmbeddingProviderSuite) TestEmbeddingDimNotMatch() {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		res := minimax.EmbeddingResponse{
+			Vectors: [][]float32{
+				{1.0, 1.0, 1.0, 1.0},
+				{1.0, 1.0},
+			},
+			TotalTokens: 100,
+			BaseResp: minimax.BaseResp{
+				StatusCode: 0,
+				StatusMsg:  "success",
+			},
+		}
+		w.WriteHeader(http.StatusOK)
+		data, _ := json.Marshal(res)
+		w.Write(data)
+	}))
+
+	defer ts.Close()
+	for _, providerName := range s.providers {
+		provider, err := createMiniMaxProvider(ts.URL, s.schema.Fields[2], providerName)
+		s.NoError(err)
+
+		data := []string{"sentence", "sentence"}
+		_, err2 := provider.CallEmbedding(context.Background(), data, models.InsertMode)
+		s.Error(err2)
+	}
+}
+
+func (s *MiniMaxTextEmbeddingProviderSuite) TestEmbeddingNumberNotMatch() {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		res := minimax.EmbeddingResponse{
+			Vectors: [][]float32{
+				{1.0, 1.0, 1.0, 1.0},
+			},
+			TotalTokens: 100,
+			BaseResp: minimax.BaseResp{
+				StatusCode: 0,
+				StatusMsg:  "success",
+			},
+		}
+		w.WriteHeader(http.StatusOK)
+		data, _ := json.Marshal(res)
+		w.Write(data)
+	}))
+
+	defer ts.Close()
+	for _, providerName := range s.providers {
+		provider, err := createMiniMaxProvider(ts.URL, s.schema.Fields[2], providerName)
+		s.NoError(err)
+
+		data := []string{"sentence", "sentence2"}
+		_, err2 := provider.CallEmbedding(context.Background(), data, models.InsertMode)
+		s.Error(err2)
+	}
+}
+
+func (s *MiniMaxTextEmbeddingProviderSuite) TestNewMiniMaxEmbeddingProvider() {
+	functionSchema := &schemapb.FunctionSchema{
+		Name:             "test",
+		Type:             schemapb.FunctionType_Unknown,
+		InputFieldNames:  []string{"text"},
+		OutputFieldNames: []string{"vector"},
+		InputFieldIds:    []int64{101},
+		OutputFieldIds:   []int64{102},
+		Params: []*commonpb.KeyValuePair{
+			{Key: models.ModelNameParamKey, Value: TestModel},
+			{Key: models.CredentialParamKey, Value: "mock"},
+		},
+	}
+	provider, err := NewMiniMaxEmbeddingProvider(s.schema.Fields[2], functionSchema, map[string]string{models.URLParamKey: "mock"}, credentials.NewCredentials(map[string]string{"mock.apikey": "mock"}), &models.ModelExtraInfo{BatchFactor: 5})
+	s.NoError(err)
+	s.Equal(provider.FieldDim(), int64(4))
+	s.True(provider.MaxBatch() > 0)
+}

--- a/internal/util/function/embedding/mock_embedding_service.go
+++ b/internal/util/function/embedding/mock_embedding_service.go
@@ -35,6 +35,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/function/models/ali"
 	"github.com/milvus-io/milvus/internal/util/function/models/cohere"
 	"github.com/milvus-io/milvus/internal/util/function/models/gemini"
+	"github.com/milvus-io/milvus/internal/util/function/models/minimax"
 	"github.com/milvus-io/milvus/internal/util/function/models/openai"
 	"github.com/milvus-io/milvus/internal/util/function/models/siliconflow"
 	"github.com/milvus-io/milvus/internal/util/function/models/tei"
@@ -308,6 +309,28 @@ func (c *MockBedrockClient) InvokeModel(ctx context.Context, params *bedrockrunt
 	resp.InputTextTokenCount = 2
 	body, _ := json.Marshal(resp)
 	return &bedrockruntime.InvokeModelOutput{Body: body}, nil
+}
+
+func CreateMiniMaxEmbeddingServer(dim int) *httptest.Server {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req minimax.EmbeddingRequest
+		body, _ := io.ReadAll(r.Body)
+		defer r.Body.Close()
+		json.Unmarshal(body, &req)
+		embs := mockEmbedding[float32](req.Texts, dim)
+		res := minimax.EmbeddingResponse{
+			Vectors:     embs,
+			TotalTokens: 100,
+			BaseResp: minimax.BaseResp{
+				StatusCode: 0,
+				StatusMsg:  "success",
+			},
+		}
+		w.WriteHeader(http.StatusOK)
+		data, _ := json.Marshal(res)
+		w.Write(data)
+	}))
+	return ts
 }
 
 func CreateGeminiEmbeddingServer(dim int) *httptest.Server {

--- a/internal/util/function/embedding/text_embedding_function.go
+++ b/internal/util/function/embedding/text_embedding_function.go
@@ -51,6 +51,7 @@ const (
 	ycProvider           string = "yc"
 	zillizProvider       string = "zilliz"
 	geminiProvider       string = "gemini"
+	minimaxProvider      string = "minimax"
 )
 
 func hasEmptyString(texts []string) bool {
@@ -145,8 +146,10 @@ func NewTextEmbeddingFunction(coll *schemapb.CollectionSchema, functionSchema *s
 		embP, newProviderErr = NewZillizEmbeddingProvider(base.outputFields[0], functionSchema, conf, extraInfo)
 	case geminiProvider:
 		embP, newProviderErr = NewGeminiEmbeddingProvider(base.outputFields[0], functionSchema, conf, credentials, extraInfo)
+	case minimaxProvider:
+		embP, newProviderErr = NewMiniMaxEmbeddingProvider(base.outputFields[0], functionSchema, conf, credentials, extraInfo)
 	default:
-		return nil, fmt.Errorf("Unsupported text embedding service provider: [%s] , list of supported [%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s]", base.provider, openAIProvider, azureOpenAIProvider, aliDashScopeProvider, bedrockProvider, vertexAIProvider, voyageAIProvider, cohereProvider, siliconflowProvider, teiProvider, ycProvider, zillizProvider, geminiProvider)
+		return nil, fmt.Errorf("Unsupported text embedding service provider: [%s] , list of supported [%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s]", base.provider, openAIProvider, azureOpenAIProvider, aliDashScopeProvider, bedrockProvider, vertexAIProvider, voyageAIProvider, cohereProvider, siliconflowProvider, teiProvider, ycProvider, zillizProvider, geminiProvider, minimaxProvider)
 	}
 
 	if newProviderErr != nil {

--- a/internal/util/function/models/common.go
+++ b/internal/util/function/models/common.go
@@ -136,6 +136,12 @@ const (
 	GeminiAKEnvStr string = "MILVUS_GEMINI_API_KEY"
 )
 
+// MiniMax
+
+const (
+	MiniMaxAKEnvStr string = "MILVUS_MINIMAX_API_KEY"
+)
+
 // TEI and vllm
 
 const (

--- a/internal/util/function/models/minimax/minimax_client.go
+++ b/internal/util/function/models/minimax/minimax_client.go
@@ -1,0 +1,111 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package minimax
+
+import (
+	"fmt"
+
+	"github.com/milvus-io/milvus/internal/util/function/models"
+)
+
+type MiniMaxClient struct {
+	apiKey string
+}
+
+func NewMiniMaxClient(apiKey string) (*MiniMaxClient, error) {
+	if apiKey == "" {
+		return nil, fmt.Errorf("Missing credentials config or configure the %s environment variable in the Milvus service.", models.MiniMaxAKEnvStr)
+	}
+
+	return &MiniMaxClient{
+		apiKey: apiKey,
+	}, nil
+}
+
+func (c *MiniMaxClient) headers() map[string]string {
+	return map[string]string{
+		"Content-Type":  "application/json",
+		"Authorization": fmt.Sprintf("Bearer %s", c.apiKey),
+	}
+}
+
+func (c *MiniMaxClient) Embedding(url string, modelName string, texts []string, embType string, timeoutSec int64) (*EmbeddingResponse, error) {
+	embClient := newMiniMaxEmbedding(c.apiKey, url)
+	return embClient.embedding(modelName, texts, embType, c.headers(), timeoutSec)
+}
+
+// EmbeddingRequest represents a MiniMax embedding API request.
+// MiniMax uses "texts" instead of "input" and requires a "type" field.
+type EmbeddingRequest struct {
+	// Model ID to use (e.g., "embo-01").
+	Model string `json:"model"`
+
+	// Input texts to embed.
+	Texts []string `json:"texts"`
+
+	// Embedding type: "db" for storage/indexing, "query" for search queries.
+	Type string `json:"type"`
+}
+
+// BaseResp contains the MiniMax API status information.
+type BaseResp struct {
+	StatusCode int    `json:"status_code"`
+	StatusMsg  string `json:"status_msg"`
+}
+
+// EmbeddingResponse represents a MiniMax embedding API response.
+// MiniMax returns embeddings in a "vectors" field as a 2D array.
+type EmbeddingResponse struct {
+	// Embedding vectors, one per input text.
+	Vectors [][]float32 `json:"vectors"`
+
+	// Total tokens consumed.
+	TotalTokens int `json:"total_tokens"`
+
+	// API status information.
+	BaseResp BaseResp `json:"base_resp"`
+}
+
+type miniMaxEmbedding struct {
+	apiKey string
+	url    string
+}
+
+func newMiniMaxEmbedding(apiKey string, url string) *miniMaxEmbedding {
+	return &miniMaxEmbedding{
+		apiKey: apiKey,
+		url:    url,
+	}
+}
+
+func (c *miniMaxEmbedding) embedding(modelName string, texts []string, embType string, headers map[string]string, timeoutSec int64) (*EmbeddingResponse, error) {
+	var r EmbeddingRequest
+	r.Model = modelName
+	r.Texts = texts
+	r.Type = embType
+
+	res, err := models.PostRequest[EmbeddingResponse](r, c.url, headers, timeoutSec)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.BaseResp.StatusCode != 0 {
+		return nil, fmt.Errorf("MiniMax embedding API error: status_code=%d, status_msg=%s", res.BaseResp.StatusCode, res.BaseResp.StatusMsg)
+	}
+
+	return res, nil
+}

--- a/internal/util/function/models/minimax/minimax_client_test.go
+++ b/internal/util/function/models/minimax/minimax_client_test.go
@@ -1,0 +1,139 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package minimax
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEmbeddingOK(t *testing.T) {
+	var res EmbeddingResponse
+	repStr := `{
+  "vectors": [
+    [0.0, 0.1],
+    [1.0, 1.1],
+    [2.0, 2.1]
+  ],
+  "total_tokens": 10,
+  "base_resp": {
+    "status_code": 0,
+    "status_msg": "success"
+  }
+}`
+	err := json.Unmarshal([]byte(repStr), &res)
+	assert.NoError(t, err)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		data, _ := json.Marshal(res)
+		w.Write(data)
+	}))
+
+	defer ts.Close()
+	url := ts.URL
+
+	{
+		c, _ := NewMiniMaxClient("mock_key")
+		ret, err := c.Embedding(url, "embo-01", []string{"sentence1", "sentence2", "sentence3"}, "db", 0)
+		assert.NoError(t, err)
+		assert.Equal(t, 3, len(ret.Vectors))
+		assert.Equal(t, []float32{0.0, 0.1}, ret.Vectors[0])
+		assert.Equal(t, []float32{1.0, 1.1}, ret.Vectors[1])
+		assert.Equal(t, []float32{2.0, 2.1}, ret.Vectors[2])
+		assert.Equal(t, 10, ret.TotalTokens)
+		assert.Equal(t, 0, ret.BaseResp.StatusCode)
+	}
+}
+
+func TestEmbeddingFailed(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+
+	defer ts.Close()
+	url := ts.URL
+
+	{
+		c, _ := NewMiniMaxClient("mock_key")
+		_, err := c.Embedding(url, "embo-01", []string{"sentence"}, "db", 0)
+		assert.Error(t, err)
+	}
+}
+
+func TestEmbeddingAPIError(t *testing.T) {
+	res := EmbeddingResponse{
+		Vectors:     nil,
+		TotalTokens: 0,
+		BaseResp: BaseResp{
+			StatusCode: 1004,
+			StatusMsg:  "invalid api key",
+		},
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		data, _ := json.Marshal(res)
+		w.Write(data)
+	}))
+
+	defer ts.Close()
+	url := ts.URL
+
+	{
+		c, _ := NewMiniMaxClient("mock_key")
+		_, err := c.Embedding(url, "embo-01", []string{"sentence"}, "db", 0)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid api key")
+	}
+}
+
+func TestNewMiniMaxClientEmptyKey(t *testing.T) {
+	_, err := NewMiniMaxClient("")
+	assert.Error(t, err)
+}
+
+func TestEmbeddingQueryType(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req EmbeddingRequest
+		decoder := json.NewDecoder(r.Body)
+		decoder.Decode(&req)
+		assert.Equal(t, "query", req.Type)
+		assert.Equal(t, "embo-01", req.Model)
+
+		res := EmbeddingResponse{
+			Vectors:     [][]float32{{0.1, 0.2}},
+			TotalTokens: 5,
+			BaseResp: BaseResp{
+				StatusCode: 0,
+				StatusMsg:  "success",
+			},
+		}
+		w.WriteHeader(http.StatusOK)
+		data, _ := json.Marshal(res)
+		w.Write(data)
+	}))
+
+	defer ts.Close()
+
+	c, _ := NewMiniMaxClient("mock_key")
+	ret, err := c.Embedding(ts.URL, "embo-01", []string{"search query"}, "query", 0)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(ret.Vectors))
+}


### PR DESCRIPTION
## Summary

Add [MiniMax](https://www.minimaxi.com) as a new text embedding provider for Milvus, supporting the **embo-01** embedding model (1536 dimensions).

MiniMax uses a native (non-OpenAI-compatible) embedding API with distinct features:
- `texts` array input (vs `input`)
- `type` field (`"db"` for storage/indexing, `"query"` for search queries) — optimized embeddings for different use cases
- `vectors` response format (vs `data[].embedding`)

### Changes

**New files (4):**
- `internal/util/function/models/minimax/minimax_client.go` — MiniMax API client with native request/response types
- `internal/util/function/models/minimax/minimax_client_test.go` — 5 unit tests for the client
- `internal/util/function/embedding/minimax_embedding_provider.go` — Embedding provider implementing `textEmbeddingProvider` interface
- `internal/util/function/embedding/minimax_embedding_provider_test.go` — 4 test suites for the provider

**Modified files (3):**
- `internal/util/function/models/common.go` — Added `MILVUS_MINIMAX_API_KEY` env variable constant
- `internal/util/function/embedding/text_embedding_function.go` — Registered `"minimax"` provider in the factory switch
- `internal/util/function/embedding/mock_embedding_service.go` — Added `CreateMiniMaxEmbeddingServer` test helper

### Usage



Configure the API key via environment variable:


Or via Milvus credential configuration in `milvus.yaml`.

## Test plan

- [x] Unit tests for MiniMax client (5 tests: OK/failed/API-error/empty-key/query-type)
- [x] Unit tests for embedding provider (4 test suites: embedding/dim-mismatch/number-mismatch/constructor)
- [x] Mock embedding server for integration testing
- [ ] CI pipeline validation
