### PR TITLE
feat: add MiniMax as text embedding provider

### DIFF
--- a/internal/util/function/embedding/minimax_embedding_provider.go
+++ b/internal/util/function/embedding/minimax_embedding_provider.go
@@ -1,0 +1,137 @@
+/*
+ * # Licensed to the LF AI & Data foundation under one
+ * # or more contributor license agreements. See the NOTICE file
+ * # distributed with this work for additional information
+ * # regarding copyright ownership. The ASF licenses this file
+ * # to you under the Apache License, Version 2.0 (the
+ * # "License"); you may not use this file except in compliance
+ * # with the License. You may obtain a copy of the License at
+ * #
+ * #     http://www.apache.org/licenses/LICENSE-2.0
+ * #
+ * # Unless required by applicable law or agreed to in writing, software
+ * # distributed under the License is distributed on an "AS IS" BASIS,
+ * # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * # See the License for the specific language governing permissions and
+ * # limitations under the License.
+ */
+
+package embedding
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/util/credentials"
+	"github.com/milvus-io/milvus/internal/util/function/models"
+	"github.com/milvus-io/milvus/internal/util/function/models/minimax"
+	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
+)
+
+type MiniMaxEmbeddingProvider struct {
+	fieldDim int64
+
+	client    *minimax.MiniMaxClient
+	url       string
+	modelName string
+
+	maxBatch   int
+	timeoutSec int64
+	extraInfo  *models.ModelExtraInfo
+}
+
+func NewMiniMaxEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSchema *schemapb.FunctionSchema, params map[string]string, credentials *credentials.Credentials, extraInfo *models.ModelExtraInfo) (*MiniMaxEmbeddingProvider, error) {
+	fieldDim, err := typeutil.GetDim(fieldSchema)
+	if err != nil {
+		return nil, err
+	}
+
+	if fieldSchema.DataType != schemapb.DataType_FloatVector {
+		return nil, fmt.Errorf("MiniMax embedding only supports FloatVector output, but got %s", schemapb.DataType_name[int32(fieldSchema.DataType)])
+	}
+
+	apiKey, url, err := models.ParseAKAndURL(credentials, functionSchema.Params, params, models.MiniMaxAKEnvStr, extraInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	var modelName string
+	for _, param := range functionSchema.Params {
+		switch strings.ToLower(param.Key) {
+		case models.ModelNameParamKey:
+			modelName = param.Value
+		case models.DimParamKey:
+			_, err = models.ParseAndCheckFieldDim(param.Value, fieldDim, fieldSchema.Name)
+			if err != nil {
+				return nil, err
+			}
+		default:
+		}
+	}
+
+	c, err := minimax.NewMiniMaxClient(apiKey)
+	if err != nil {
+		return nil, err
+	}
+
+	if url == "" {
+		url = "https://api.minimax.io/v1/embeddings"
+	}
+
+	provider := MiniMaxEmbeddingProvider{
+		client:     c,
+		url:        url,
+		fieldDim:   fieldDim,
+		modelName:  modelName,
+		maxBatch:   128,
+		timeoutSec: 30,
+		extraInfo:  extraInfo,
+	}
+	return &provider, nil
+}
+
+func (provider *MiniMaxEmbeddingProvider) MaxBatch() int {
+	return provider.extraInfo.BatchFactor * provider.maxBatch
+}
+
+func (provider *MiniMaxEmbeddingProvider) FieldDim() int64 {
+	return provider.fieldDim
+}
+
+func (provider *MiniMaxEmbeddingProvider) CallEmbedding(ctx context.Context, texts []string, mode models.TextEmbeddingMode) (any, error) {
+	numRows := len(texts)
+	var textType string
+	if mode == models.InsertMode {
+		textType = "db"
+	} else {
+		textType = "query"
+	}
+
+	embRet := models.NewEmbdResult(numRows, models.Float32Embd)
+	for i := 0; i < numRows; i += provider.maxBatch {
+		end := i + provider.maxBatch
+		if end > numRows {
+			end = numRows
+		}
+		resp, err := provider.client.Embedding(provider.url, provider.modelName, texts[i:end], textType, provider.timeoutSec)
+		if err != nil {
+			return nil, err
+		}
+		if resp.BaseResp.StatusCode != 0 {
+			return nil, fmt.Errorf("MiniMax embedding API error: %s (code: %d)", resp.BaseResp.StatusMsg, resp.BaseResp.StatusCode)
+		}
+		if end-i != len(resp.Vectors) {
+			return nil, fmt.Errorf("Get embedding failed. The number of texts and embeddings does not match text:[%d], embedding:[%d]", end-i, len(resp.Vectors))
+		}
+		for _, vec := range resp.Vectors {
+			if len(vec) != int(provider.fieldDim) {
+				return nil, fmt.Errorf("The required embedding dim is [%d], but the embedding obtained from the model is [%d]",
+					provider.fieldDim, len(vec))
+			}
+			embRet.Append(vec)
+		}
+	}
+	return embRet.FloatEmbds, nil
+}

--- a/internal/util/function/embedding/minimax_embedding_provider_test.go
+++ b/internal/util/function/embedding/minimax_embedding_provider_test.go
@@ -1,0 +1,233 @@
+/*
+ * # Licensed to the LF AI & Data foundation under one
+ * # or more contributor license agreements. See the NOTICE file
+ * # distributed with this work for additional information
+ * # regarding copyright ownership. The ASF licenses this file
+ * # to you under the Apache License, Version 2.0 (the
+ * # "License"); you may not use this file except in compliance
+ * # with the License. You may obtain a copy of the License at
+ * #
+ * #     http://www.apache.org/licenses/LICENSE-2.0
+ * #
+ * # Unless required by applicable law or agreed to in writing, software
+ * # distributed under the License is distributed on an "AS IS" BASIS,
+ * # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * # See the License for the specific language governing permissions and
+ * # limitations under the License.
+ */
+
+package embedding
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/util/credentials"
+	"github.com/milvus-io/milvus/internal/util/function/models"
+	"github.com/milvus-io/milvus/internal/util/function/models/minimax"
+)
+
+func TestMiniMaxTextEmbeddingProvider(t *testing.T) {
+	suite.Run(t, new(MiniMaxTextEmbeddingProviderSuite))
+}
+
+type MiniMaxTextEmbeddingProviderSuite struct {
+	suite.Suite
+	schema    *schemapb.CollectionSchema
+	providers []string
+}
+
+func (s *MiniMaxTextEmbeddingProviderSuite) SetupTest() {
+	s.schema = &schemapb.CollectionSchema{
+		Name: "test",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "int64", DataType: schemapb.DataType_Int64},
+			{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar},
+			{
+				FieldID: 102, Name: "vector", DataType: schemapb.DataType_FloatVector,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: "dim", Value: "1536"},
+				},
+			},
+		},
+	}
+	s.providers = []string{minimaxProvider}
+}
+
+func createMiniMaxProvider(url string, schema *schemapb.FieldSchema, providerName string) (textEmbeddingProvider, error) {
+	functionSchema := &schemapb.FunctionSchema{
+		Name:             "test",
+		Type:             schemapb.FunctionType_Unknown,
+		InputFieldNames:  []string{"text"},
+		OutputFieldNames: []string{"vector"},
+		InputFieldIds:    []int64{101},
+		OutputFieldIds:   []int64{102},
+		Params: []*commonpb.KeyValuePair{
+			{Key: models.ModelNameParamKey, Value: "embo-01"},
+			{Key: models.CredentialParamKey, Value: "mock"},
+			{Key: models.DimParamKey, Value: "1536"},
+		},
+	}
+	switch providerName {
+	case minimaxProvider:
+		return NewMiniMaxEmbeddingProvider(schema, functionSchema, map[string]string{models.URLParamKey: url}, credentials.NewCredentials(map[string]string{"mock.apikey": "mock"}), &models.ModelExtraInfo{ClusterID: "test-cluster", DBName: "test-db", BatchFactor: 5})
+	default:
+		return nil, errors.New("Unknown provider")
+	}
+}
+
+func (s *MiniMaxTextEmbeddingProviderSuite) TestEmbedding() {
+	ts := CreateMiniMaxEmbeddingServer(1536)
+	defer ts.Close()
+
+	for _, providerName := range s.providers {
+		provider, err := createMiniMaxProvider(ts.URL, s.schema.Fields[2], providerName)
+		s.NoError(err)
+		{
+			data := []string{"sentence"}
+			r, err2 := provider.CallEmbedding(context.Background(), data, models.InsertMode)
+			ret := r.([][]float32)
+			s.NoError(err2)
+			s.Equal(1, len(ret))
+			s.Equal(1536, len(ret[0]))
+		}
+		{
+			data := []string{"sentence 1", "sentence 2", "sentence 3"}
+			_, err := provider.CallEmbedding(context.Background(), data, models.SearchMode)
+			s.NoError(err)
+		}
+	}
+}
+
+func (s *MiniMaxTextEmbeddingProviderSuite) TestEmbeddingDimNotMatch() {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		res := minimax.EmbeddingResponse{
+			Vectors:     [][]float32{{1.0, 1.0, 1.0, 1.0}, {1.0, 1.0}},
+			TotalTokens: 100,
+			BaseResp: minimax.BaseResp{
+				StatusCode: 0,
+				StatusMsg:  "success",
+			},
+		}
+		w.WriteHeader(http.StatusOK)
+		data, _ := json.Marshal(res)
+		w.Write(data)
+	}))
+	defer ts.Close()
+
+	for _, providerName := range s.providers {
+		provider, err := createMiniMaxProvider(ts.URL, s.schema.Fields[2], providerName)
+		s.NoError(err)
+
+		data := []string{"sentence", "sentence"}
+		_, err2 := provider.CallEmbedding(context.Background(), data, models.InsertMode)
+		s.Error(err2)
+	}
+}
+
+func (s *MiniMaxTextEmbeddingProviderSuite) TestEmbeddingNumberNotMatch() {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		res := minimax.EmbeddingResponse{
+			Vectors:     [][]float32{{1.0, 1.0, 1.0, 1.0}},
+			TotalTokens: 100,
+			BaseResp: minimax.BaseResp{
+				StatusCode: 0,
+				StatusMsg:  "success",
+			},
+		}
+		w.WriteHeader(http.StatusOK)
+		data, _ := json.Marshal(res)
+		w.Write(data)
+	}))
+	defer ts.Close()
+
+	for _, providerName := range s.providers {
+		provider, err := createMiniMaxProvider(ts.URL, s.schema.Fields[2], providerName)
+		s.NoError(err)
+
+		data := []string{"sentence", "sentence2"}
+		_, err2 := provider.CallEmbedding(context.Background(), data, models.InsertMode)
+		s.Error(err2)
+	}
+}
+
+func (s *MiniMaxTextEmbeddingProviderSuite) TestEmbeddingAPIError() {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		res := minimax.EmbeddingResponse{
+			Vectors: nil,
+			BaseResp: minimax.BaseResp{
+				StatusCode: 1001,
+				StatusMsg:  "invalid api key",
+			},
+		}
+		w.WriteHeader(http.StatusOK)
+		data, _ := json.Marshal(res)
+		w.Write(data)
+	}))
+	defer ts.Close()
+
+	for _, providerName := range s.providers {
+		provider, err := createMiniMaxProvider(ts.URL, s.schema.Fields[2], providerName)
+		s.NoError(err)
+
+		data := []string{"sentence"}
+		_, err2 := provider.CallEmbedding(context.Background(), data, models.InsertMode)
+		s.Error(err2)
+		s.Contains(err2.Error(), "invalid api key")
+	}
+}
+
+func (s *MiniMaxTextEmbeddingProviderSuite) TestNewMiniMaxEmbeddingProvider() {
+	functionSchema := &schemapb.FunctionSchema{
+		Name:             "test",
+		Type:             schemapb.FunctionType_Unknown,
+		InputFieldNames:  []string{"text"},
+		OutputFieldNames: []string{"vector"},
+		InputFieldIds:    []int64{101},
+		OutputFieldIds:   []int64{102},
+		Params: []*commonpb.KeyValuePair{
+			{Key: models.ModelNameParamKey, Value: "embo-01"},
+			{Key: models.CredentialParamKey, Value: "mock"},
+			{Key: models.DimParamKey, Value: "1536"},
+		},
+	}
+	provider, err := NewMiniMaxEmbeddingProvider(s.schema.Fields[2], functionSchema, map[string]string{models.URLParamKey: "mock"}, credentials.NewCredentials(map[string]string{"mock.apikey": "mock"}), &models.ModelExtraInfo{ClusterID: "test-cluster", DBName: "test-db", BatchFactor: 5})
+	s.NoError(err)
+	s.Equal(provider.FieldDim(), int64(1536))
+	s.True(provider.MaxBatch() > 0)
+
+	// Invalid dim
+	{
+		functionSchema.Params[2] = &commonpb.KeyValuePair{Key: models.DimParamKey, Value: "9"}
+		_, err := NewMiniMaxEmbeddingProvider(s.schema.Fields[2], functionSchema, map[string]string{}, credentials.NewCredentials(map[string]string{"mock.apikey": "mock"}), &models.ModelExtraInfo{ClusterID: "test-cluster", DBName: "test-db"})
+		s.Error(err)
+	}
+
+	// Invalid dim type
+	{
+		functionSchema.Params[2] = &commonpb.KeyValuePair{Key: models.DimParamKey, Value: "Invalid"}
+		_, err := NewMiniMaxEmbeddingProvider(s.schema.Fields[2], functionSchema, map[string]string{}, credentials.NewCredentials(map[string]string{"mock.apikey": "mock"}), &models.ModelExtraInfo{ClusterID: "test-cluster", DBName: "test-db"})
+		s.Error(err)
+	}
+
+	// Int8Vector not supported
+	{
+		int8Field := &schemapb.FieldSchema{
+			FieldID: 102, Name: "vector", DataType: schemapb.DataType_Int8Vector,
+			TypeParams: []*commonpb.KeyValuePair{
+				{Key: "dim", Value: "1536"},
+			},
+		}
+		functionSchema.Params[2] = &commonpb.KeyValuePair{Key: models.DimParamKey, Value: "1536"}
+		_, err := NewMiniMaxEmbeddingProvider(int8Field, functionSchema, map[string]string{}, credentials.NewCredentials(map[string]string{"mock.apikey": "mock"}), &models.ModelExtraInfo{ClusterID: "test-cluster", DBName: "test-db"})
+		s.Error(err)
+	}
+}

--- a/internal/util/function/embedding/mock_embedding_service.go
+++ b/internal/util/function/embedding/mock_embedding_service.go
@@ -35,6 +35,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/function/models/ali"
 	"github.com/milvus-io/milvus/internal/util/function/models/cohere"
 	"github.com/milvus-io/milvus/internal/util/function/models/gemini"
+	"github.com/milvus-io/milvus/internal/util/function/models/minimax"
 	"github.com/milvus-io/milvus/internal/util/function/models/openai"
 	"github.com/milvus-io/milvus/internal/util/function/models/siliconflow"
 	"github.com/milvus-io/milvus/internal/util/function/models/tei"
@@ -308,6 +309,28 @@ func (c *MockBedrockClient) InvokeModel(ctx context.Context, params *bedrockrunt
 	resp.InputTextTokenCount = 2
 	body, _ := json.Marshal(resp)
 	return &bedrockruntime.InvokeModelOutput{Body: body}, nil
+}
+
+func CreateMiniMaxEmbeddingServer(dim int) *httptest.Server {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req minimax.EmbeddingRequest
+		body, _ := io.ReadAll(r.Body)
+		defer r.Body.Close()
+		json.Unmarshal(body, &req)
+		embs := mockEmbedding[float32](req.Texts, dim)
+		res := minimax.EmbeddingResponse{
+			Vectors:     embs,
+			TotalTokens: 100,
+			BaseResp: minimax.BaseResp{
+				StatusCode: 0,
+				StatusMsg:  "success",
+			},
+		}
+		w.WriteHeader(http.StatusOK)
+		data, _ := json.Marshal(res)
+		w.Write(data)
+	}))
+	return ts
 }
 
 func CreateGeminiEmbeddingServer(dim int) *httptest.Server {

--- a/internal/util/function/embedding/text_embedding_function.go
+++ b/internal/util/function/embedding/text_embedding_function.go
@@ -51,6 +51,7 @@ const (
 	ycProvider           string = "yc"
 	zillizProvider       string = "zilliz"
 	geminiProvider       string = "gemini"
+	minimaxProvider      string = "minimax"
 )
 
 func hasEmptyString(texts []string) bool {
@@ -145,8 +146,10 @@ func NewTextEmbeddingFunction(coll *schemapb.CollectionSchema, functionSchema *s
 		embP, newProviderErr = NewZillizEmbeddingProvider(base.outputFields[0], functionSchema, conf, extraInfo)
 	case geminiProvider:
 		embP, newProviderErr = NewGeminiEmbeddingProvider(base.outputFields[0], functionSchema, conf, credentials, extraInfo)
+	case minimaxProvider:
+		embP, newProviderErr = NewMiniMaxEmbeddingProvider(base.outputFields[0], functionSchema, conf, credentials, extraInfo)
 	default:
-		return nil, fmt.Errorf("Unsupported text embedding service provider: [%s] , list of supported [%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s]", base.provider, openAIProvider, azureOpenAIProvider, aliDashScopeProvider, bedrockProvider, vertexAIProvider, voyageAIProvider, cohereProvider, siliconflowProvider, teiProvider, ycProvider, zillizProvider, geminiProvider)
+		return nil, fmt.Errorf("Unsupported text embedding service provider: [%s] , list of supported [%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s]", base.provider, openAIProvider, azureOpenAIProvider, aliDashScopeProvider, bedrockProvider, vertexAIProvider, voyageAIProvider, cohereProvider, siliconflowProvider, teiProvider, ycProvider, zillizProvider, geminiProvider, minimaxProvider)
 	}
 
 	if newProviderErr != nil {

--- a/internal/util/function/models/common.go
+++ b/internal/util/function/models/common.go
@@ -136,6 +136,12 @@ const (
 	GeminiAKEnvStr string = "MILVUS_GEMINI_API_KEY"
 )
 
+// MiniMax
+
+const (
+	MiniMaxAKEnvStr string = "MILVUS_MINIMAX_API_KEY"
+)
+
 // TEI and vllm
 
 const (

--- a/internal/util/function/models/minimax/minimax_client.go
+++ b/internal/util/function/models/minimax/minimax_client.go
@@ -1,0 +1,83 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package minimax
+
+import (
+	"fmt"
+
+	"github.com/milvus-io/milvus/internal/util/function/models"
+)
+
+type MiniMaxClient struct {
+	apiKey string
+}
+
+func NewMiniMaxClient(apiKey string) (*MiniMaxClient, error) {
+	if apiKey == "" {
+		return nil, fmt.Errorf("Missing credentials config or configure the %s environment variable in the Milvus service.", models.MiniMaxAKEnvStr)
+	}
+	return &MiniMaxClient{
+		apiKey: apiKey,
+	}, nil
+}
+
+func (c *MiniMaxClient) headers() map[string]string {
+	return map[string]string{
+		"Content-Type":  "application/json",
+		"Authorization": fmt.Sprintf("Bearer %s", c.apiKey),
+	}
+}
+
+func (c *MiniMaxClient) Embedding(url string, modelName string, texts []string, textType string, timeoutSec int64) (*EmbeddingResponse, error) {
+	r := EmbeddingRequest{
+		Model: modelName,
+		Texts: texts,
+		Type:  textType,
+	}
+	return models.PostRequest[EmbeddingResponse](r, url, c.headers(), timeoutSec)
+}
+
+// EmbeddingRequest represents a MiniMax embedding API request.
+// MiniMax uses "texts" (not "input") and "type" (not "input_type").
+type EmbeddingRequest struct {
+	// ID of the model to use.
+	Model string `json:"model"`
+
+	// Input texts to embed.
+	Texts []string `json:"texts"`
+
+	// Type of the text: "db" for storage, "query" for search.
+	Type string `json:"type"`
+}
+
+// EmbeddingResponse represents a MiniMax embedding API response.
+type EmbeddingResponse struct {
+	// The embedding vectors, one per input text.
+	Vectors [][]float32 `json:"vectors"`
+
+	// Total tokens used.
+	TotalTokens int `json:"total_tokens"`
+
+	// Base response with status info.
+	BaseResp BaseResp `json:"base_resp"`
+}
+
+// BaseResp contains the status of the API response.
+type BaseResp struct {
+	StatusCode int    `json:"status_code"`
+	StatusMsg  string `json:"status_msg"`
+}

--- a/pkg/util/paramtable/function_param.go
+++ b/pkg/util/paramtable/function_param.go
@@ -108,6 +108,12 @@ func (p *functionConfig) init(base *BaseTable) {
 				return "Your Gemini embedding url, Default is the official embedding url"
 			case "gemini.enable":
 				return "Whether to enable Gemini model service"
+			case "minimax.credential":
+				return "The name in the credential configuration item"
+			case "minimax.url":
+				return "Your MiniMax embedding url, Default is the official embedding url"
+			case "minimax.enable":
+				return "Whether to enable MiniMax model service"
 			default:
 				return ""
 			}


### PR DESCRIPTION
## Summary

Add [MiniMax](https://www.minimax.io) as a new text embedding service provider in the Milvus function framework.

- **New provider**: `minimax` — uses the MiniMax embo-01 model (1536 dimensions) via a non-OpenAI-compatible embedding API
- **API distinction**: MiniMax uses `"type": "db"` for storage/insert and `"type": "query"` for search, mapping to Milvus InsertMode/SearchMode
- **Float32 only**: MiniMax embo-01 returns float32 vectors; Int8Vector is explicitly rejected with a clear error message
- **Environment variable**: `MILVUS_MINIMAX_API_KEY` for API key configuration
- **Configuration**: Supports `minimax.credential`, `minimax.url`, and `minimax.enable` in milvus.yaml

### Files changed

**New files:**
- `internal/util/function/models/minimax/minimax_client.go` — MiniMax API client with request/response types
- `internal/util/function/embedding/minimax_embedding_provider.go` — Embedding provider implementation
- `internal/util/function/embedding/minimax_embedding_provider_test.go` — Unit tests

**Modified files:**
- `internal/util/function/embedding/text_embedding_function.go` — Register minimax in provider switch
- `internal/util/function/models/common.go` — Add `MILVUS_MINIMAX_API_KEY` env constant
- `internal/util/function/embedding/mock_embedding_service.go` — Add `CreateMiniMaxEmbeddingServer` mock
- `pkg/util/paramtable/function_param.go` — Add MiniMax config documentation

### Usage

```sql
CREATE COLLECTION test (
  id INT64 PRIMARY KEY,
  text VARCHAR(65535),
  vector FLOAT_VECTOR(1536)
) WITH FUNCTION text_embedding(
  provider = "minimax",
  model_name = "embo-01",
  api_key = "your-minimax-api-key"
) INPUT(text) OUTPUT(vector);
```

## Test plan

- [x] Unit tests for embedding call (InsertMode/SearchMode)
- [x] Unit tests for dimension mismatch error handling
- [x] Unit tests for embedding count mismatch error handling
- [x] Unit tests for API error response handling
- [x] Unit tests for provider creation (valid, invalid dim, Int8Vector rejection)
- [ ] CI pipeline validation