### PR TITLE
fix: [2.6] use memory-aware batch splitting in LoadCellBatchAsync to prevent OOM (#48404)

### DIFF
--- a/internal/core/src/segcore/MemoryPlannerTest.cpp
+++ b/internal/core/src/segcore/MemoryPlannerTest.cpp
@@ -14,6 +14,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include <cstddef>
+#include <cstdint>
+#include <future>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "arrow/api.h"
+#include "gtest/gtest.h"
 #include "milvus-storage/common/metadata.h"
 #include "segcore/memory_planner.h"
 #include <gtest/gtest.h>
@@ -168,4 +176,136 @@ TEST(ParallelDegreeSplitStrategy, ContinuousExceedingAvgSize) {
     EXPECT_EQ(blocks.size(), 2);
     EXPECT_EQ(blocks[0], (RowGroupBlock{1, 4}));
     EXPECT_EQ(blocks[1], (RowGroupBlock{5, 4}));
+}
+
+// ---- LoadCellBatchAsync tests ----
+
+namespace {
+
+// Helper: create a BatchReaderFactory that returns empty Arrow tables.
+// Records (batch_key, rg_offset, total_rg_count) for each call.
+BatchReaderFactory
+MakeMockReaderFactory() {
+    return [](size_t /*batch_key*/,
+              int64_t /*rg_offset*/,
+              int64_t total_rg_count,
+              int64_t /*reader_memory_limit*/)
+               -> arrow::Result<std::vector<std::shared_ptr<arrow::Table>>> {
+        // Return one empty table per row group
+        auto schema = arrow::schema({arrow::field("x", arrow::int64())});
+        std::vector<std::shared_ptr<arrow::Table>> tables;
+        for (int64_t i = 0; i < total_rg_count; ++i) {
+            tables.push_back(arrow::Table::MakeEmpty(schema).ValueOrDie());
+        }
+        return tables;
+    };
+}
+
+// Helper to run LoadCellBatchAsync and return future count (= batch count).
+size_t
+RunAndCountBatches(std::vector<CellSpec> cell_specs, int64_t memory_limit) {
+    auto channel = std::make_shared<CellReaderChannel>(64);
+    auto futures = LoadCellBatchAsync(nullptr,
+                                      std::move(cell_specs),
+                                      MakeMockReaderFactory(),
+                                      channel,
+                                      memory_limit);
+    for (auto& f : futures) {
+        f.get();
+    }
+    return futures.size();
+}
+
+}  // namespace
+
+TEST(LoadCellBatchAsync, MemoryBasedSplit) {
+    // 10 cells x 64MB each, limit=128MB -> 5 batches (2 cells each)
+    constexpr int64_t MB = 1 << 20;
+    std::vector<CellSpec> specs;
+    for (int i = 0; i < 10; ++i) {
+        specs.push_back({/*cid=*/i,
+                         /*file_idx=*/0,
+                         /*local_rg_offset=*/i,
+                         /*rg_count=*/1,
+                         /*memory_size=*/64 * MB});
+    }
+    auto batches = RunAndCountBatches(specs, 128 * MB);
+    EXPECT_EQ(batches, 5);
+}
+
+TEST(LoadCellBatchAsync, ZeroMemorySizeAsserts) {
+    // memory_size=0 must trigger assertion failure
+    constexpr int64_t MB = 1 << 20;
+    std::vector<CellSpec> specs = {{/*cid=*/0,
+                                    /*file_idx=*/0,
+                                    /*local_rg_offset=*/0,
+                                    /*rg_count=*/1,
+                                    /*memory_size=*/0}};
+    EXPECT_ANY_THROW(RunAndCountBatches(specs, 128 * MB));
+}
+
+TEST(LoadCellBatchAsync, UnevenCellSizes) {
+    // Cells with different memory sizes are batched by memory limit
+    // 2 small cells (16MB each) fit in one batch, 1 large cell (96MB) alone
+    constexpr int64_t MB = 1 << 20;
+    std::vector<CellSpec> specs = {
+        {0, 0, 0, 1, 16 * MB},
+        {1, 0, 1, 1, 16 * MB},
+        {2, 0, 2, 1, 96 * MB},
+        {3, 0, 3, 1, 16 * MB},
+        {4, 0, 4, 1, 16 * MB},
+    };
+    // limit=48MB: first batch [0,1]=32MB, second [2]=96MB (single cell > limit),
+    // third [3,4]=32MB -> 3 batches
+    auto batches = RunAndCountBatches(specs, 48 * MB);
+    EXPECT_EQ(batches, 3);
+}
+
+TEST(LoadCellBatchAsync, SingleCellExceedsLimit) {
+    // 1 cell of 256MB with limit=128MB -> 1 batch (can't split a cell)
+    constexpr int64_t MB = 1 << 20;
+    std::vector<CellSpec> specs = {{/*cid=*/0,
+                                    /*file_idx=*/0,
+                                    /*local_rg_offset=*/0,
+                                    /*rg_count=*/1,
+                                    /*memory_size=*/256 * MB}};
+    auto batches = RunAndCountBatches(specs, 128 * MB);
+    EXPECT_EQ(batches, 1);
+}
+
+TEST(LoadCellBatchAsync, FileBoundarySplit) {
+    // 4 cells x 32MB across 2 files, limit=128MB
+    // File boundary forces a split even though memory fits
+    constexpr int64_t MB = 1 << 20;
+    std::vector<CellSpec> specs = {
+        {0, /*file_idx=*/0, 0, 1, 32 * MB},
+        {1, /*file_idx=*/0, 1, 1, 32 * MB},
+        {2, /*file_idx=*/1, 0, 1, 32 * MB},
+        {3, /*file_idx=*/1, 1, 1, 32 * MB},
+    };
+    auto batches = RunAndCountBatches(specs, 128 * MB);
+    // Should be at least 2 batches (one per file)
+    EXPECT_GE(batches, 2);
+}
+
+TEST(LoadCellBatchAsync, ContiguityBreak) {
+    // Cells with rg_offset gap -> split at gap
+    constexpr int64_t MB = 1 << 20;
+    std::vector<CellSpec> specs = {
+        {0, 0, /*local_rg_offset=*/0, 1, 32 * MB},
+        {1, 0, /*local_rg_offset=*/1, 1, 32 * MB},
+        // gap: offset 3 instead of 2
+        {2, 0, /*local_rg_offset=*/3, 1, 32 * MB},
+        {3, 0, /*local_rg_offset=*/4, 1, 32 * MB},
+    };
+    auto batches = RunAndCountBatches(specs, 256 * MB);
+    // Should split at the contiguity break
+    EXPECT_EQ(batches, 2);
+}
+
+TEST(LoadCellBatchAsync, EmptyCells) {
+    auto channel = std::make_shared<CellReaderChannel>(64);
+    auto futures = LoadCellBatchAsync(
+        nullptr, {}, MakeMockReaderFactory(), channel, 128 << 20);
+    EXPECT_EQ(futures.size(), 0);
 }

--- a/internal/core/src/segcore/memory_planner.cpp
+++ b/internal/core/src/segcore/memory_planner.cpp
@@ -270,17 +270,20 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
                   return a.local_rg_offset < b.local_rg_offset;
               });
 
-    // Determine batch size based on parallel degree
-    auto parallel_degree =
-        static_cast<size_t>(memory_limit / FILE_SLICE_SIZE.load());
-    size_t cells_per_batch = std::max<size_t>(
-        1, (cell_specs.size() + parallel_degree - 1) / parallel_degree);
+    for (const auto& spec : cell_specs) {
+        AssertInfo(spec.memory_size > 0,
+                   "[StorageV2] CellSpec cid={} has memory_size={}, "
+                   "callers must provide actual memory size",
+                   spec.cid,
+                   spec.memory_size);
+    }
 
     // Group consecutive, same-key cells into batches for IO merging
     struct CellBatch {
         size_t file_idx;
         int64_t rg_offset;
         int64_t rg_count;
+        int64_t batch_memory = 0;
         std::vector<CellSpec> cells;
     };
 
@@ -290,9 +293,11 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
     for (const auto& spec : cell_specs) {
         bool should_split = false;
         if (!current.cells.empty()) {
+            bool batch_full =
+                (current.batch_memory + spec.memory_size > memory_limit);
             if (spec.file_idx != current.file_idx ||
                 spec.local_rg_offset != current.rg_offset + current.rg_count ||
-                current.cells.size() >= cells_per_batch) {
+                batch_full) {
                 should_split = true;
             }
         }
@@ -304,13 +309,22 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
             current.file_idx = spec.file_idx;
             current.rg_offset = spec.local_rg_offset;
             current.rg_count = 0;
+            current.batch_memory = 0;
         }
         current.rg_count += spec.rg_count;
+        current.batch_memory += spec.memory_size;
         current.cells.push_back(spec);
     }
     if (!current.cells.empty()) {
         batches.push_back(std::move(current));
     }
+
+    LOG_INFO(
+        "[StorageV2] LoadCellBatchAsync: {} cells -> {} batches "
+        "(memory_limit={}MB)",
+        cell_specs.size(),
+        batches.size(),
+        memory_limit >> 20);
 
     if (batches.empty()) {
         channel->close();

--- a/internal/core/src/segcore/memory_planner.h
+++ b/internal/core/src/segcore/memory_planner.h
@@ -109,6 +109,7 @@ struct CellSpec {
     size_t file_idx;          // index into the remote_files list
     int64_t local_rg_offset;  // file-local row group start offset
     int64_t rg_count;         // number of row groups in this cell
+    int64_t memory_size = 0;  // estimated Arrow memory in bytes; 0 = unknown
 };
 
 // Result of loading a single cell: cid + the arrow tables read.

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
@@ -328,7 +328,8 @@ GroupChunkTranslator::get_cells(milvus::OpContext* ctx,
         cell_specs.push_back({cid,
                               file_idx,
                               static_cast<int64_t>(local_off),
-                              static_cast<int64_t>(rg_end - rg_start)});
+                              static_cast<int64_t>(rg_end - rg_start),
+                              meta_.chunk_memory_size_[cid]});
     }
 
     // Submit cell-batch loading tasks

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
@@ -219,7 +219,8 @@ ManifestGroupTranslator::get_cells(
         cell_specs.push_back({cid,
                               /*file_idx=*/0,
                               static_cast<int64_t>(start),
-                              static_cast<int64_t>(end - start)});
+                              static_cast<int64_t>(end - start),
+                              meta_.chunk_memory_size_[cid]});
     }
 
     // Create factory using ChunkReader — reads a batch of row groups at once


### PR DESCRIPTION
Cherry-pick from master
pr: #48404

LoadCellBatchAsync previously split cells into batches by cell count (cells_per_batch = ceil(total / parallel_degree)), ignoring actual per-cell Arrow memory size. For large segments with variable-size fields (ARRAY, JSON, large VARCHAR), cells can have highly uneven memory footprints. A large segment (512MB+ on disk) with ARRAY fields can produce batches where each batch reader allocates hundreds of GB, far exceeding memory_limit and causing OOM on QueryNodes.

Add memory_size field to CellSpec and use it for memory-aware batch splitting: each batch is capped at memory_limit bytes of estimated Arrow memory. Falls back to count-based splitting when memory info is unavailable (memory_size == 0).

issue: #48403

---------