### PR TITLE
fix: [cp2.6] validate clustering key type in addCollectionFieldTask

### DIFF
--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -623,6 +623,11 @@ func (t *addCollectionFieldTask) PreExecute(ctx context.Context) error {
 		return merr.WrapErrParameterInvalidMsg("not support to add partition key field, field name  = %s", t.fieldSchema.Name)
 	}
 	if t.fieldSchema.GetIsClusteringKey() {
+		if !typeutil.IsClusteringKeyType(t.fieldSchema.GetDataType()) {
+			return merr.WrapErrParameterInvalidMsg(
+				fmt.Sprintf("clustering key field %s has unsupported data type %s",
+					t.fieldSchema.GetName(), t.fieldSchema.GetDataType().String()))
+		}
 		for _, f := range t.oldSchema.Fields {
 			if f.GetIsClusteringKey() {
 				return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("already has another clutering key field, field name: %s", t.fieldSchema.GetName()))

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -1084,8 +1084,11 @@ func TestAddFieldTask(t *testing.T) {
 		assert.Error(t, err)
 		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
 
-		// more ClusteringKey field
+		// more ClusteringKey field — use a valid type so the duplicate-key check is the gate
 		fSchema = &schemapb.FieldSchema{
+			Name:            "ck_field",
+			DataType:        schemapb.DataType_Int64,
+			Nullable:        true,
 			IsClusteringKey: true,
 		}
 		bytes, err = proto.Marshal(fSchema)
@@ -1098,6 +1101,46 @@ func TestAddFieldTask(t *testing.T) {
 		err = task.PreExecute(ctx)
 		assert.Error(t, err)
 		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+
+		// unsupported clustering key type (JSON, Bool, Array)
+		// Use a fresh schema (no existing clustering key) so the type check is the only gate
+		freshSchema := constructCollectionSchemaByDataType(collectionName, fieldName2Type, int64Field, false)
+		task.oldSchema = freshSchema
+		for _, unsupportedType := range []schemapb.DataType{
+			schemapb.DataType_JSON,
+			schemapb.DataType_Bool,
+			schemapb.DataType_Array,
+		} {
+			fSchema = &schemapb.FieldSchema{
+				Name:            "ck_field",
+				DataType:        unsupportedType,
+				Nullable:        true,
+				IsClusteringKey: true,
+			}
+			if unsupportedType == schemapb.DataType_Array {
+				fSchema.ElementType = schemapb.DataType_Int64
+			}
+			bytes, err = proto.Marshal(fSchema)
+			assert.NoError(t, err)
+			task.Schema = bytes
+			err = task.PreExecute(ctx)
+			assert.Error(t, err, "expected error for unsupported clustering key type %v", unsupportedType)
+			assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		}
+
+		// valid clustering key type (Int64) should be accepted
+		fSchema = &schemapb.FieldSchema{
+			Name:            "valid_ck",
+			DataType:        schemapb.DataType_Int64,
+			Nullable:        true,
+			IsClusteringKey: true,
+		}
+		bytes, err = proto.Marshal(fSchema)
+		assert.NoError(t, err)
+		task.Schema = bytes
+		task.oldSchema = freshSchema // no existing clustering key
+		err = task.PreExecute(ctx)
+		assert.NoError(t, err)
 
 		// fieldName invalid
 		fSchema = &schemapb.FieldSchema{

--- a/pkg/util/typeutil/schema.go
+++ b/pkg/util/typeutil/schema.go
@@ -618,6 +618,20 @@ func IsVectorArrayType(dataType schemapb.DataType) bool {
 	return dataType == schemapb.DataType_ArrayOfVector
 }
 
+// IsClusteringKeyType returns true if the data type is supported as a clustering key.
+// Supported scalar types: Int8, Int16, Int32, Int64, Float, Double, VarChar, String, FloatVector.
+func IsClusteringKeyType(dataType schemapb.DataType) bool {
+	switch dataType {
+	case schemapb.DataType_Int8, schemapb.DataType_Int16,
+		schemapb.DataType_Int32, schemapb.DataType_Int64,
+		schemapb.DataType_Float, schemapb.DataType_Double,
+		schemapb.DataType_VarChar, schemapb.DataType_String:
+		return true
+	default:
+		return dataType == schemapb.DataType_FloatVector
+	}
+}
+
 // IsIntegerType returns true if input is an integer type, otherwise false
 func IsIntegerType(dataType schemapb.DataType) bool {
 	switch dataType {


### PR DESCRIPTION
Cherry-pick from master (PR still open)

pr: #48289
issue: #48285

## Summary

Cherry-picked from master PR #48289 (open - preemptive backport)

**Note**: Original PR is still open. This CP PR should be updated if the original PR changes.

Fixes missing `IsClusteringKeyType()` validation in `addCollectionFieldTask.PreExecute()` (schema evolution path), preventing DataNode panics when unsupported types (JSON, Bool, Array, etc.) are used as clustering keys via `AddCollectionField`.

## Verification

- [x] File count matches original PR (2 files)
- [x] Code changes verified — clean cherry-pick, no conflicts
- [x] No conflict markers