### PR TITLE
fix: clone arrow string/binary values to prevent dangling references

### DIFF
--- a/internal/compaction/common.go
+++ b/internal/compaction/common.go
@@ -19,7 +19,6 @@ package compaction
 import (
 	"context"
 	"io"
-	"strings"
 
 	"github.com/apache/arrow/go/v17/arrow/array"
 	"github.com/cockroachdb/errors"
@@ -51,7 +50,7 @@ func readFromReader(reader storage.RecordReader, pkType schemapb.DataType) ([]st
 			if pkType == schemapb.DataType_Int64 {
 				pk = storage.NewInt64PrimaryKey(rec.Column(0).(*array.Int64).Value(i))
 			} else {
-				pk = storage.NewVarCharPrimaryKey(strings.Clone(rec.Column(0).(*array.String).Value(i)))
+				pk = storage.NewVarCharPrimaryKey(rec.Column(0).(*array.String).Value(i))
 			}
 			ts := typeutil.Timestamp(rec.Column(1).(*array.Int64).Value(i))
 			pks = append(pks, pk)

--- a/internal/datanode/compactor/clustering_compactor.go
+++ b/internal/datanode/compactor/clustering_compactor.go
@@ -660,7 +660,7 @@ func (t *clusteringCompactionTask) mappingSegment(
 		}
 
 		vs := make([]*storage.Value, r.Len())
-		if err = storage.ValueDeserializerWithSchema(r, vs, t.plan.Schema, false); err != nil {
+		if err = storage.ValueDeserializerWithSchema(r, vs, t.plan.Schema, true); err != nil {
 			log.Warn("compact wrong, failed to deserialize data", zap.Error(err))
 			return err
 		}

--- a/internal/datanode/compactor/segment_writer.go
+++ b/internal/datanode/compactor/segment_writer.go
@@ -305,9 +305,7 @@ func (w *SegmentWriter) WriteRecord(r storage.Record) error {
 			w.pkstats.Update(pk)
 		case schemapb.DataType_VarChar:
 			pkArray := r.Column(w.GetPkID()).(*array.String)
-			pk := &storage.VarCharPrimaryKey{
-				Value: pkArray.Value(i),
-			}
+			pk := storage.NewVarCharPrimaryKey(pkArray.Value(i))
 			w.pkstats.Update(pk)
 		default:
 			panic("invalid data type")

--- a/internal/storage/payload_reader.go
+++ b/internal/storage/payload_reader.go
@@ -1074,7 +1074,7 @@ func (r *PayloadReader) GetSparseFloatVectorFromPayload() (*SparseFloatVectorFie
 					if len(value)%8 != 0 {
 						return nil, -1, nil, errors.New("invalid bytesData length")
 					}
-					fieldData.Contents = append(fieldData.Contents, value)
+					fieldData.Contents = append(fieldData.Contents, append([]byte{}, value...))
 					rowDim := typeutil.SparseFloatRowDim(value)
 					if rowDim > fieldData.Dim {
 						fieldData.Dim = rowDim

--- a/internal/storage/primary_key.go
+++ b/internal/storage/primary_key.go
@@ -166,7 +166,7 @@ type VarCharPrimaryKey struct {
 
 func NewVarCharPrimaryKey(v string) *VarCharPrimaryKey {
 	return &VarCharPrimaryKey{
-		Value: v,
+		Value: strings.Clone(v),
 	}
 }
 

--- a/internal/storage/stats_collector.go
+++ b/internal/storage/stats_collector.go
@@ -70,9 +70,7 @@ func (c *PkStatsCollector) Collect(r Record) error {
 			c.pkstats.Update(pk)
 		case schemapb.DataType_VarChar:
 			pkArray := r.Column(c.pkstats.FieldID).(*array.String)
-			pk := &VarCharPrimaryKey{
-				Value: pkArray.Value(i),
-			}
+			pk := NewVarCharPrimaryKey(pkArray.Value(i))
 			c.pkstats.Update(pk)
 		default:
 			panic("invalid data type")

--- a/internal/util/importutilv2/binlog/reader.go
+++ b/internal/util/importutilv2/binlog/reader.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"strings"
 
 	"github.com/apache/arrow/go/v17/arrow/array"
 	"github.com/samber/lo"
@@ -228,7 +229,7 @@ func (r *reader) readDelete(deltaLogs []string, tsStart, tsEnd uint64) (map[any]
 				case schemapb.DataType_Int64:
 					pk = rec.Column(0).(*array.Int64).Value(i)
 				case schemapb.DataType_VarChar:
-					pk = rec.Column(0).(*array.String).Value(i)
+					pk = strings.Clone(rec.Column(0).(*array.String).Value(i))
 				}
 				if tsExisting, ok := tempData[pk]; ok && tsExisting > ts {
 					// skip if existing entry is newer

--- a/internal/util/importutilv2/parquet/struct_field_reader.go
+++ b/internal/util/importutilv2/parquet/struct_field_reader.go
@@ -19,6 +19,7 @@ package parquet
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/array"
@@ -259,7 +260,7 @@ func (r *StructFieldReader) readArrayField(chunked *arrow.Chunked) (any, any, er
 					}
 				case *array.String:
 					if !field.IsNull(int(structIdx)) {
-						combinedData = append(combinedData, field.Value(int(structIdx)))
+						combinedData = append(combinedData, strings.Clone(field.Value(int(structIdx))))
 					}
 				}
 			}


### PR DESCRIPTION
issue: #48297

Arrow array Value() returns references to underlying buffers. When
records are released (especially CGo-backed packed readers), these
references become dangling pointers causing use-after-free.

- NewVarCharPrimaryKey now always clones input string via
  strings.Clone, making all callers safe by default
- Direct VarCharPrimaryKey struct inits from arrow arrays replaced
  with constructor call (segment_writer, stats_collector)
- Clone string map key in binlog delta reader
- Copy sparse vector binary value in payload reader
- Fix clustering compactor shouldCopy=false to true since values
  are buffered in SerializeWriterImpl beyond record lifetime
- Clone arrow string values in parquet struct field reader
- Remove redundant strings.Clone in compaction/common.go since
  NewVarCharPrimaryKey now clones internally

Signed-off-by: Ted Xu <ted.xu@zilliz.com>