### PR TITLE
test: [2.6] fix 4 flaky tests across Go and Python (#47907)

### DIFF
--- a/internal/proxy/impl_test.go
+++ b/internal/proxy/impl_test.go
@@ -984,6 +984,13 @@ func TestProxyDropDatabase(t *testing.T) {
 		mix.EXPECT().DropDatabase(mock.Anything, mock.Anything).Return(merr.Success(), nil)
 		node.mixCoord = mix
 		node.UpdateStateCode(commonpb.StateCode_Healthy)
+
+		cacheBak := globalMetaCache
+		defer func() { globalMetaCache = cacheBak }()
+		cache := NewMockCache(t)
+		cache.EXPECT().RemoveDatabase(mock.Anything, mock.AnythingOfType("string")).Return()
+		globalMetaCache = cache
+
 		ctx := context.Background()
 
 		resp, err := node.DropDatabase(ctx, &milvuspb.DropDatabaseRequest{DbName: "db"})

--- a/internal/streamingcoord/server/balancer/balancer_test.go
+++ b/internal/streamingcoord/server/balancer/balancer_test.go
@@ -381,6 +381,7 @@ func TestBalancer_WithRecoveryLag(t *testing.T) {
 	b, err := balancer.RecoverBalancer(ctx, newStaticChannelProvider("test-channel-1"))
 	assert.NoError(t, err)
 	assert.NotNil(t, b)
+	defer b.Close()
 
 	b.Trigger(context.Background())
 	ctx2, cancel := context.WithTimeout(ctx, 2*time.Second)

--- a/internal/util/grpcclient/client_test.go
+++ b/internal/util/grpcclient/client_test.go
@@ -423,10 +423,10 @@ func (s *server) SayHello(ctx context.Context, in *helloworld.HelloRequest) (*he
 func TestClientBase_RetryPolicy(t *testing.T) {
 	// server
 	lis, err := net.Listen("tcp", "localhost:")
-	address := lis.Addr()
 	if err != nil {
-		log.Fatalf("failed to listen: %v", err)
+		t.Fatalf("failed to listen: %v", err)
 	}
+	address := lis.Addr()
 	kaep := keepalive.EnforcementPolicy{
 		MinTime:             5 * time.Second,
 		PermitWithoutStream: true,
@@ -444,9 +444,8 @@ func TestClientBase_RetryPolicy(t *testing.T) {
 	helloworld.RegisterGreeterServer(s, &server{SuccessCount: uint(maxAttempts)})
 	reflection.Register(s)
 	go func() {
-		if err := s.Serve(lis); err != nil {
-			log.Fatalf("failed to serve: %v", err)
-		}
+		// s.Stop() causes Serve to return; ignore the error
+		s.Serve(lis)
 	}()
 	defer s.Stop()
 
@@ -485,10 +484,10 @@ func TestClientBase_RetryPolicy(t *testing.T) {
 
 func TestClientBase_Compression(t *testing.T) {
 	lis, err := net.Listen("tcp", "localhost:")
-	address := lis.Addr()
 	if err != nil {
-		log.Fatalf("failed to listen: %v", err)
+		t.Fatalf("failed to listen: %v", err)
 	}
+	address := lis.Addr()
 	kaep := keepalive.EnforcementPolicy{
 		MinTime:             5 * time.Second,
 		PermitWithoutStream: true,
@@ -506,9 +505,8 @@ func TestClientBase_Compression(t *testing.T) {
 	helloworld.RegisterGreeterServer(s, &server{SuccessCount: uint(1)})
 	reflection.Register(s)
 	go func() {
-		if err := s.Serve(lis); err != nil {
-			log.Fatalf("failed to serve: %v", err)
-		}
+		// s.Stop() causes Serve to return; ignore the error
+		s.Serve(lis)
 	}()
 	defer s.Stop()
 

--- a/tests/python_client/milvus_client/test_add_field_feature.py
+++ b/tests/python_client/milvus_client/test_add_field_feature.py
@@ -99,9 +99,10 @@ class TestMilvusClientAddFieldFeature(TestMilvusClientV2Base):
         vectors = cf.gen_vectors(default_nb, dim, vector_data_type=DataType.FLOAT_VECTOR)
         vectors_to_search = [vectors[0]]
         # 4. insert new field after add field
-        rows_new = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
-                     default_string_field_name: str(i), default_new_field_name: random.randint(default_value + 1, 1000)}
-                     for i in range(10*default_nb, 11*default_nb)]
+        rows_new = [
+            {default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
+             default_string_field_name: str(i), default_new_field_name: random.randint(default_value + 1, 1000)}
+            for i in range(10 * default_nb, 11 * default_nb)]
         self.insert(client, collection_name, rows_new)
         # 5. compact
         compact_id = self.compact(client, collection_name)[0]

--- a/tests/python_client/milvus_client_v2/test_milvus_client_ttl.py
+++ b/tests/python_client/milvus_client_v2/test_milvus_client_ttl.py
@@ -287,24 +287,25 @@ class TestMilvusClientTTL(TestMilvusClientV2Base):
         expected: Step 5 should success
         """
         # step 1: create collection
-        ttl_time = 5
+        ttl_time = 20
+        margin = 2  # margin zone around TTL boundaries to avoid timing races
         client = self._client()
         schema = self.create_schema(client, enable_dynamic_field=False)[0]
         schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
         schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
         schema.add_field(default_int32_field_name, DataType.INT32, nullable=True)
-        index_params = self.prepare_index_params(client)[0] 
+        index_params = self.prepare_index_params(client)[0]
         index_params.add_index(default_primary_key_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_vector_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_int32_field_name, index_type="AUTOINDEX")
         collection_name = cf.gen_collection_name_by_testcase_name(module_index=1)
-        self.create_collection(client, collection_name, default_dim, schema=schema, 
+        self.create_collection(client, collection_name, default_dim, schema=schema,
                                properties={"collection.ttl.seconds": ttl_time}, consistency_level="Strong", index_params=index_params)
 
         # step 2: Insert rows
         rows = cf.gen_row_data_by_schema(nb=default_nb, schema=schema)
         self.insert(client, collection_name, rows)
-        start_time = time.time()
+        start_time = time.time()  # start timing right after insert to align with server-side TTL calculation
         self.flush(client, collection_name)
         self.release_collection(client, collection_name)
         self.load_collection(client, collection_name)
@@ -321,33 +322,36 @@ class TestMilvusClientTTL(TestMilvusClientV2Base):
             # before ttl_time, the count(*) should be default_nb
             # before new_ttl_time, and after ttl_time the count(*) should be update_nb
             # after new_ttl_time, the count(*) should be 0
+            elapsed = time.time() - start_time
             res = self.query(client, collection_name, filter=default_search_exp, output_fields=["count(*)"])
-            if time.time() - start_time <= ttl_time:
+            # Skip assertions near TTL boundaries to avoid timing races
+            if elapsed < ttl_time - margin:
                 assert res[0][0].get('count(*)') == default_nb
-            elif time.time() - start_time > ttl_time and time.time() - start_time <= new_ttl_time:
+            elif elapsed > ttl_time + margin and elapsed < new_ttl_time - margin:
                 assert res[0][0].get('count(*)') == update_nb
-            else:
+            elif elapsed > new_ttl_time + margin:
                 assert res[0][0].get('count(*)') == 0
 
             # search
             # before new_ttl_time, the search result should be 10
             # after new_ttl_time, the search result should be 0
             search_vectors = cf.gen_vectors(1, dim=default_dim)
+            elapsed = time.time() - start_time
             res = self.search(client, collection_name, search_vectors, anns_field=default_vector_field_name, search_params={}, limit=10)
-            if time.time() - start_time <= new_ttl_time:
+            if elapsed < new_ttl_time - margin:
                 assert len(res[0][0]) == 10
-            else:
+            elif elapsed > new_ttl_time + margin:
                 assert len(res[0][0]) == 0
 
             time.sleep(1)
             # upsert
             if pu and time.time() - start_time >= upsert_time:
                 if partial_update:
-                    new_rows = cf.gen_row_data_by_schema(nb=update_nb, schema=schema, 
+                    new_rows = cf.gen_row_data_by_schema(nb=update_nb, schema=schema,
                                                         desired_field_names=[default_primary_key_field_name, default_vector_field_name])
                 else:
                     new_rows = cf.gen_row_data_by_schema(nb=update_nb, schema=schema)
-                
+
                 self.upsert(client, collection_name, new_rows, partial_update=partial_update)
                 pu_time = time.time() - start_time
                 new_ttl_time = pu_time + ttl_time


### PR DESCRIPTION
Cherry-pick from master
pr: #47907

- **balancer_test**: use `defer b.Close()` immediately after creation in `TestBalancer_WithRecoveryLag` to prevent goroutine leak causing DATA RACE with next test's `resource.InitForTest()`
- **impl_test**: initialize `globalMetaCache` mock in `TestProxyDropDatabase` to avoid nil pointer from stale global state
- **client_test**: replace `log.Fatalf` with `t.Fatalf` for listen errors, silence `s.Serve()` return on `s.Stop()`, fix `lis.Addr()` called before error check
- **test_milvus_client_ttl**: increase TTL from 5s to 20s with 2s margin zones around TTL boundaries to ensure all assertion phases have meaningful windows

- [ ] CI ut-go passes (covers fixes 1-3)
- [ ] CI e2e passes (covers fix 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---------