### PR TITLE
fix: switch gRPC to shared linking and exclude unsecure variants

### DIFF
--- a/internal/core/conanfile.py
+++ b/internal/core/conanfile.py
@@ -76,6 +76,8 @@ class MilvusConan(ConanFile):
         "arrow:with_s3": True,
         "arrow:encryption": True,
         "protobuf:shared": True,
+        "grpc:shared": True,
+        "grpc:secure": True,
         "aws-sdk-cpp:config": True,
         "aws-sdk-cpp:text-to-speech": False,
         "aws-sdk-cpp:transfer": False,

--- a/internal/core/lsan_suppressions.txt
+++ b/internal/core/lsan_suppressions.txt
@@ -10,3 +10,13 @@
 # See: https://github.com/google/sanitizers/wiki/AddressSanitizerLeakSanitizer#suppressions
 
 leak:__cxa_allocate_exception
+
+# gRPC global singletons (e.g. AuditLoggerRegistry) are intentionally
+# never destroyed to avoid the static destruction order fiasco.
+# When gRPC is dynamically linked (libgrpc.so), LSAN cannot scan the
+# .bss segment of uninstrumented shared libraries, so these reachable
+# pointers appear as leaks. This is a known gRPC design choice, not a bug.
+# See: https://github.com/grpc/grpc/issues/40389
+#      https://github.com/grpc/grpc/issues/24488
+leak:_GLOBAL__sub_I_audit_logging.cc
+leak:grpc_core::experimental::AuditLoggerRegistry


### PR DESCRIPTION
## Summary

- Switch gRPC to shared linking (`grpc:shared=True`) to prevent `libmilvus_core.so` and `libmilvus-common.so` from each embedding a full gRPC runtime, which causes metric duplicate registration crash on Linux
- Set `grpc:secure=True` to exclude `grpc_unsecure` and `grpc++_unsecure` from `CONAN_LIBS`, preventing both secure and unsecure gRPC variants from being loaded simultaneously

issue: https://github.com/milvus-io/milvus/issues/48457

## Test plan

- [x] Built VDC image with fix, verified `libmilvus_core.so` no longer links `grpc_unsecure`
- [x] Verified fixed image starts normally on Linux (no SIGABRT)
- [x] Verified old image without fix crashes with `Metric name grpc.lb.pick_first.disconnections has already been registered`


🤖 Generated with [Claude Code](https://claude.com/claude-code)