### PR TITLE
enhance: add GetCollectionName() to RESTful request types for metrics

### DIFF
--- a/internal/distributed/proxy/httpserver/request_v2.go
+++ b/internal/distributed/proxy/httpserver/request_v2.go
@@ -162,7 +162,8 @@ type RenameCollectionReq struct {
 	NewDbName         string `json:"newDbName"`
 }
 
-func (req *RenameCollectionReq) GetDbName() string { return req.DbName }
+func (req *RenameCollectionReq) GetDbName() string         { return req.DbName }
+func (req *RenameCollectionReq) GetCollectionName() string { return req.CollectionName }
 
 type DropCollectionPropertiesReq struct {
 	DbName         string   `json:"dbName"`
@@ -296,7 +297,8 @@ type QueryReqV2 struct {
 	ConsistencyLevel string                 `json:"consistencyLevel"`
 }
 
-func (req *QueryReqV2) GetDbName() string { return req.DbName }
+func (req *QueryReqV2) GetDbName() string         { return req.DbName }
+func (req *QueryReqV2) GetCollectionName() string { return req.CollectionName }
 
 type CollectionIDReq struct {
 	DbName           string      `json:"dbName"`
@@ -308,7 +310,8 @@ type CollectionIDReq struct {
 	ConsistencyLevel string      `json:"consistencyLevel"`
 }
 
-func (req *CollectionIDReq) GetDbName() string { return req.DbName }
+func (req *CollectionIDReq) GetDbName() string         { return req.DbName }
+func (req *CollectionIDReq) GetCollectionName() string { return req.CollectionName }
 
 type CollectionFilterReq struct {
 	DbName         string                 `json:"dbName"`
@@ -318,7 +321,8 @@ type CollectionFilterReq struct {
 	ExprParams     map[string]interface{} `json:"exprParams"`
 }
 
-func (req *CollectionFilterReq) GetDbName() string { return req.DbName }
+func (req *CollectionFilterReq) GetDbName() string         { return req.DbName }
+func (req *CollectionFilterReq) GetCollectionName() string { return req.CollectionName }
 
 type CollectionDataReq struct {
 	DbName         string                   `json:"dbName"`
@@ -328,7 +332,8 @@ type CollectionDataReq struct {
 	PartialUpdate  bool                     `json:"partialUpdate"`
 }
 
-func (req *CollectionDataReq) GetDbName() string { return req.DbName }
+func (req *CollectionDataReq) GetDbName() string         { return req.DbName }
+func (req *CollectionDataReq) GetCollectionName() string { return req.CollectionName }
 
 type SearchReqV2 struct {
 	DbName           string                 `json:"dbName"`
@@ -352,7 +357,8 @@ type SearchReqV2 struct {
 	Params map[string]float64 `json:"params"`
 }
 
-func (req *SearchReqV2) GetDbName() string { return req.DbName }
+func (req *SearchReqV2) GetDbName() string         { return req.DbName }
+func (req *SearchReqV2) GetCollectionName() string { return req.CollectionName }
 
 type Rand struct {
 	Strategy string                 `json:"strategy"`
@@ -387,7 +393,8 @@ type HybridSearchReq struct {
 	FunctionScore    FunctionScore  `json:"functionScore"`
 }
 
-func (req *HybridSearchReq) GetDbName() string { return req.DbName }
+func (req *HybridSearchReq) GetDbName() string         { return req.DbName }
+func (req *HybridSearchReq) GetCollectionName() string { return req.CollectionName }
 
 type ReturnErrMsg struct {
 	Code    int32  `json:"code"`
@@ -401,7 +408,8 @@ type PartitionsReq struct {
 	PartitionNames []string `json:"partitionNames" binding:"required"`
 }
 
-func (req *PartitionsReq) GetDbName() string { return req.DbName }
+func (req *PartitionsReq) GetDbName() string         { return req.DbName }
+func (req *PartitionsReq) GetCollectionName() string { return req.CollectionName }
 
 type UserReq struct {
 	UserName string `json:"userName" binding:"required"`
@@ -475,6 +483,9 @@ type GrantV2Req struct {
 	Privilege      string `json:"privilege" binding:"required"`
 }
 
+func (req *GrantV2Req) GetDbName() string         { return req.DbName }
+func (req *GrantV2Req) GetCollectionName() string { return req.CollectionName }
+
 type GrantReq struct {
 	RoleName   string `json:"roleName" binding:"required"`
 	ObjectType string `json:"objectType" binding:"required"`
@@ -499,7 +510,8 @@ type IndexParamReq struct {
 	IndexParams    []IndexParam `json:"indexParams" binding:"required"`
 }
 
-func (req *IndexParamReq) GetDbName() string { return req.DbName }
+func (req *IndexParamReq) GetDbName() string         { return req.DbName }
+func (req *IndexParamReq) GetCollectionName() string { return req.CollectionName }
 
 type IndexReq struct {
 	DbName         string `json:"dbName"`
@@ -643,7 +655,8 @@ type CollectionReq struct {
 	Description      string                 `json:"description"`
 }
 
-func (req *CollectionReq) GetDbName() string { return req.DbName }
+func (req *CollectionReq) GetDbName() string         { return req.DbName }
+func (req *CollectionReq) GetCollectionName() string { return req.CollectionName }
 
 type AliasReq struct {
 	DbName    string `json:"dbName"`
@@ -832,4 +845,5 @@ type RunAnalyzerReq struct {
 	AnalyzerNames  []string `json:"analyzerNames"`
 }
 
-func (req *RunAnalyzerReq) GetDbName() string { return req.DbName }
+func (req *RunAnalyzerReq) GetDbName() string         { return req.DbName }
+func (req *RunAnalyzerReq) GetCollectionName() string { return req.CollectionName }

--- a/internal/distributed/proxy/httpserver/request_v2_test.go
+++ b/internal/distributed/proxy/httpserver/request_v2_test.go
@@ -1,0 +1,52 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/pkg/v2/util/requestutil"
+)
+
+func TestRequestV2_GetCollectionName(t *testing.T) {
+	tests := []struct {
+		name string
+		req  requestutil.CollectionNameGetter
+		want string
+	}{
+		{"RenameCollectionReq", &RenameCollectionReq{CollectionName: "col1"}, "col1"},
+		{"QueryReqV2", &QueryReqV2{CollectionName: "col2"}, "col2"},
+		{"CollectionIDReq", &CollectionIDReq{CollectionName: "col3"}, "col3"},
+		{"CollectionFilterReq", &CollectionFilterReq{CollectionName: "col4"}, "col4"},
+		{"CollectionDataReq", &CollectionDataReq{CollectionName: "col5"}, "col5"},
+		{"SearchReqV2", &SearchReqV2{CollectionName: "col6"}, "col6"},
+		{"HybridSearchReq", &HybridSearchReq{CollectionName: "col7"}, "col7"},
+		{"PartitionsReq", &PartitionsReq{CollectionName: "col8"}, "col8"},
+		{"GrantV2Req", &GrantV2Req{CollectionName: "col9"}, "col9"},
+		{"IndexParamReq", &IndexParamReq{CollectionName: "col10"}, "col10"},
+		{"CollectionReq", &CollectionReq{CollectionName: "col11"}, "col11"},
+		{"RunAnalyzerReq", &RunAnalyzerReq{CollectionName: "col12"}, "col12"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.req.GetCollectionName())
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add `GetCollectionName()` method to 12 RESTful API request types that were missing it
- Ensures `ProxyFunctionCall` metrics report the correct collection name label for all RESTful endpoints
- Affected types: `RenameCollectionReq`, `QueryReqV2`, `CollectionIDReq`, `CollectionFilterReq`, `CollectionDataReq`, `SearchReqV2`, `HybridSearchReq`, `PartitionsReq`, `GrantV2Req`, `IndexParamReq`, `CollectionReq`, `RunAnalyzerReq`

issue: #48461

## Test plan
- [ ] Verify existing unit tests pass
- [ ] Confirm RESTful API metrics now include collection name for search/query/hybrid_search endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)