### PR TITLE
fix: add nil check in CloseFFIReader to prevent heap-use-after-free on double close

### DIFF
--- a/internal/core/src/storage/loon_ffi/ffi_reader_c.cpp
+++ b/internal/core/src/storage/loon_ffi/ffi_reader_c.cpp
@@ -192,8 +192,12 @@ CloseFFIReader(CFFIPackedReader c_packed_reader) {
     SCOPE_CGO_CALL_METRIC();
 
     try {
+        if (c_packed_reader == nullptr) {
+            return milvus::SuccessCStatus();
+        }
         auto reader =
             static_cast<milvus_storage::api::Reader*>(c_packed_reader);
+        AssertInfo(reader, "cannot close nullptr ffi reader");
         delete reader;
         return milvus::SuccessCStatus();
     } catch (std::exception& e) {

--- a/internal/storagev2/packed/packed_reader_ffi.go
+++ b/internal/storagev2/packed/packed_reader_ffi.go
@@ -162,6 +162,10 @@ func (r *FFIPackedReader) ReadNext() (arrow.Record, error) {
 
 // Close closes the FFI reader
 func (r *FFIPackedReader) Close() error {
+	if r.cPackedReader == nil {
+		return nil
+	}
+
 	// no need to manual release current batch
 	// stream reader handles it
 
@@ -170,6 +174,7 @@ func (r *FFIPackedReader) Close() error {
 	}
 
 	status := C.CloseFFIReader(r.cPackedReader)
+	r.cPackedReader = nil
 	return ConsumeCStatusIntoError(&status)
 }
 


### PR DESCRIPTION
Guard against double-close in both C++ and Go layers of FFIPackedReader. The C++ CloseFFIReader now returns early when given a nullptr, and the Go Close() method nil-checks before calling into C and nils out the pointer after close. This prevents ASAN heap-use-after-free crashes when Close() or Release() is called more than once.

issue: milvus-io/milvus-storage#456