### PR TITLE
fix: resolve flaky TestBalancer_DynamicChannelFromProvider test

### DIFF
--- a/internal/streamingcoord/server/balancer/balancer_test.go
+++ b/internal/streamingcoord/server/balancer/balancer_test.go
@@ -480,7 +480,7 @@ func TestBalancer_DynamicChannelFromProvider(t *testing.T) {
 		}
 		return nil
 	})
-	assert.ErrorIs(t, err, doneErr)
+	assert.ErrorIs(t, err, doneErr, "initial channel assignment did not stabilize within timeout")
 
 	// Send dynamic channels through the provider.
 	provider.ch <- []string{"dynamic-channel-1", "dynamic-channel-2"}
@@ -494,7 +494,7 @@ func TestBalancer_DynamicChannelFromProvider(t *testing.T) {
 		}
 		return nil
 	})
-	assert.ErrorIs(t, err, doneErr)
+	assert.ErrorIs(t, err, doneErr, "dynamic channel assignment did not stabilize within timeout")
 
 	b.Close()
 }

--- a/internal/streamingcoord/server/balancer/balancer_test.go
+++ b/internal/streamingcoord/server/balancer/balancer_test.go
@@ -32,6 +32,7 @@ import (
 func TestBalancer(t *testing.T) {
 	paramtable.Init()
 	paramtable.Get().StreamingCfg.WALBalancerExpectedInitialStreamingNodeNum.SwapTempValue("3")
+	defer paramtable.Get().StreamingCfg.WALBalancerExpectedInitialStreamingNodeNum.SwapTempValue("")
 	etcdClient, _ := kvfactory.GetEtcdAndPath()
 	channel.ResetStaticPChannelStatsManager()
 	channel.RecoverPChannelStatsManager([]string{})
@@ -416,6 +417,8 @@ func TestBalancer_WithRecoveryLag(t *testing.T) {
 
 func TestBalancer_DynamicChannelFromProvider(t *testing.T) {
 	paramtable.Init()
+	paramtable.Get().StreamingCfg.WALBalancerExpectedInitialStreamingNodeNum.SwapTempValue("0")
+	defer paramtable.Get().StreamingCfg.WALBalancerExpectedInitialStreamingNodeNum.SwapTempValue("")
 	etcdClient, _ := kvfactory.GetEtcdAndPath()
 	channel.ResetStaticPChannelStatsManager()
 	channel.RecoverPChannelStatsManager([]string{})
@@ -445,7 +448,7 @@ func TestBalancer_DynamicChannelFromProvider(t *testing.T) {
 	catalog.EXPECT().GetCChannel(mock.Anything).Return(nil, nil)
 	catalog.EXPECT().SaveCChannel(mock.Anything, mock.Anything).Return(nil)
 	catalog.EXPECT().GetVersion(mock.Anything).Return(nil, nil)
-	catalog.EXPECT().SaveVersion(mock.Anything, mock.Anything).Return(nil)
+	catalog.EXPECT().SaveVersion(mock.Anything, mock.Anything).Return(nil).Maybe()
 	catalog.EXPECT().ListPChannel(mock.Anything).Unset()
 	catalog.EXPECT().ListPChannel(mock.Anything).Return([]*streamingpb.PChannelMeta{
 		{
@@ -469,7 +472,9 @@ func TestBalancer_DynamicChannelFromProvider(t *testing.T) {
 
 	// Wait for initial assignment to stabilize (1 channel assigned).
 	doneErr := errors.New("done")
-	err = b.WatchChannelAssignments(ctx, func(param balancer.WatchChannelAssignmentsCallbackParam) error {
+	ctx1, cancel1 := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel1()
+	err = b.WatchChannelAssignments(ctx1, func(param balancer.WatchChannelAssignmentsCallbackParam) error {
 		if len(param.Relations) >= 1 {
 			return doneErr
 		}
@@ -481,7 +486,9 @@ func TestBalancer_DynamicChannelFromProvider(t *testing.T) {
 	provider.ch <- []string{"dynamic-channel-1", "dynamic-channel-2"}
 
 	// The balancer should pick them up and assign them.
-	err = b.WatchChannelAssignments(ctx, func(param balancer.WatchChannelAssignmentsCallbackParam) error {
+	ctx2, cancel2 := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel2()
+	err = b.WatchChannelAssignments(ctx2, func(param balancer.WatchChannelAssignmentsCallbackParam) error {
 		if len(param.Relations) >= 3 {
 			return doneErr
 		}
@@ -494,6 +501,8 @@ func TestBalancer_DynamicChannelFromProvider(t *testing.T) {
 
 func TestBalancer_DynamicChannelProviderClosed(t *testing.T) {
 	paramtable.Init()
+	paramtable.Get().StreamingCfg.WALBalancerExpectedInitialStreamingNodeNum.SwapTempValue("0")
+	defer paramtable.Get().StreamingCfg.WALBalancerExpectedInitialStreamingNodeNum.SwapTempValue("")
 	etcdClient, _ := kvfactory.GetEtcdAndPath()
 	channel.ResetStaticPChannelStatsManager()
 	channel.RecoverPChannelStatsManager([]string{})
@@ -521,7 +530,7 @@ func TestBalancer_DynamicChannelProviderClosed(t *testing.T) {
 	catalog.EXPECT().GetCChannel(mock.Anything).Return(nil, nil)
 	catalog.EXPECT().SaveCChannel(mock.Anything, mock.Anything).Return(nil)
 	catalog.EXPECT().GetVersion(mock.Anything).Return(nil, nil)
-	catalog.EXPECT().SaveVersion(mock.Anything, mock.Anything).Return(nil)
+	catalog.EXPECT().SaveVersion(mock.Anything, mock.Anything).Return(nil).Maybe()
 	catalog.EXPECT().ListPChannel(mock.Anything).Unset()
 	catalog.EXPECT().ListPChannel(mock.Anything).Return([]*streamingpb.PChannelMeta{
 		{


### PR DESCRIPTION
## Summary
- Fix flaky `TestBalancer_DynamicChannelFromProvider` and `TestBalancer_DynamicChannelProviderClosed` tests in `internal/streamingcoord/server/balancer`
- Root cause: `TestBalancer` leaked `WALBalancerExpectedInitialStreamingNodeNum=3` via `SwapTempValue` without restoring, causing subsequent tests to hang waiting for 3 streaming nodes when mocks only provided 2
- Secondary cause: shared embedded etcd state with stale proxy sessions caused `SaveVersion` mock expectation failures
- Added 30s timeout protection to `WatchChannelAssignments` calls that previously used `context.Background()` with no deadline

## Test plan
- [x] Reproduced failure locally (1/1 = 100% failure rate on unmodified code)
- [x] Verified fix: `TestBalancer_DynamicChannelFromProvider` 10/10 passes
- [x] Verified fix: `TestBalancer_DynamicChannelProviderClosed` 10/10 passes
- [x] Both tests combined 10/10 passes

issue: https://github.com/milvus-io/milvus/issues/39893

🤖 Generated with [Claude Code](https://claude.com/claude-code)