### PR TITLE
fix: [2.6] clamp targetVecIndexVersion to cluster maximum to prevent QN load failure during rolling upgrade

### DIFF
--- a/internal/datacoord/compaction_trigger.go
+++ b/internal/datacoord/compaction_trigger.go
@@ -29,6 +29,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
+	"github.com/milvus-io/milvus/internal/util/vecindexmgr"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
@@ -746,11 +747,23 @@ func (t *compactionTrigger) ShouldRebuildSegmentIndex(segment *SegmentInfo) bool
 		// index version of segment lower than current version and IndexFileKeys should have value, trigger compaction
 		indexIDToSegIdxes := t.meta.indexMeta.GetSegmentIndexes(segment.CollectionID, segment.ID)
 		for _, index := range indexIDToSegIdxes {
-			if index.CurrentIndexVersion < t.indexEngineVersionManager.GetCurrentIndexEngineVersion() &&
-				len(index.IndexFileKeys) > 0 {
+			if len(index.IndexFileKeys) == 0 {
+				continue
+			}
+
+			indexParams := t.meta.indexMeta.GetIndexParams(segment.CollectionID, index.IndexID)
+			indexType := GetIndexType(indexParams)
+			isVectorIndex := vecindexmgr.GetVecIndexMgrInstance().IsVecIndex(indexType)
+
+			if !isVectorIndex {
+				continue
+			}
+
+			if index.CurrentIndexVersion < t.indexEngineVersionManager.GetCurrentIndexEngineVersion() {
 				log.Info("index version is too old, trigger compaction",
 					zap.Int64("segmentID", segment.ID),
 					zap.Int64("indexID", index.IndexID),
+					zap.String("indexType", indexType),
 					zap.Strings("indexFileKeys", index.IndexFileKeys),
 					zap.Int32("currentIndexVersion", index.CurrentIndexVersion),
 					zap.Int32("currentEngineVersion", t.indexEngineVersionManager.GetCurrentIndexEngineVersion()))
@@ -759,19 +772,32 @@ func (t *compactionTrigger) ShouldRebuildSegmentIndex(segment *SegmentInfo) bool
 		}
 	}
 
-	// enable force rebuild index with target index version
+	// enable force rebuild index with target index version (only for vector index)
 	if Params.DataCoordCfg.ForceRebuildSegmentIndex.GetAsBool() && Params.DataCoordCfg.TargetVecIndexVersion.GetAsInt64() != -1 {
-		// index version of segment lower than current version and IndexFileKeys should have value, trigger compaction
+		resolvedVecTarget := t.indexEngineVersionManager.ResolveVecIndexVersion()
 		indexIDToSegIdxes := t.meta.indexMeta.GetSegmentIndexes(segment.CollectionID, segment.ID)
 		for _, index := range indexIDToSegIdxes {
-			if index.CurrentIndexVersion != Params.DataCoordCfg.TargetVecIndexVersion.GetAsInt32() &&
-				len(index.IndexFileKeys) > 0 {
+			if len(index.IndexFileKeys) == 0 {
+				continue
+			}
+
+			indexParams := t.meta.indexMeta.GetIndexParams(segment.CollectionID, index.IndexID)
+			indexType := GetIndexType(indexParams)
+			isVectorIndex := vecindexmgr.GetVecIndexMgrInstance().IsVecIndex(indexType)
+
+			// ForceRebuildSegmentIndex with TargetVecIndexVersion only applies to vector indexes
+			if !isVectorIndex {
+				continue
+			}
+
+			if index.CurrentIndexVersion != resolvedVecTarget {
 				log.Info("index version is not equal to target vec index version, trigger compaction",
 					zap.Int64("segmentID", segment.ID),
 					zap.Int64("indexID", index.IndexID),
+					zap.String("indexType", indexType),
 					zap.Strings("indexFileKeys", index.IndexFileKeys),
 					zap.Int32("currentIndexVersion", index.CurrentIndexVersion),
-					zap.Int32("targetIndexVersion", Params.DataCoordCfg.TargetVecIndexVersion.GetAsInt32()))
+					zap.Int32("resolvedTargetVersion", resolvedVecTarget))
 				return true
 			}
 		}

--- a/internal/datacoord/compaction_trigger_test.go
+++ b/internal/datacoord/compaction_trigger_test.go
@@ -1825,7 +1825,8 @@ func Test_compactionTrigger_shouldDoSingleCompaction(t *testing.T) {
 	assert.True(t, couldDo)
 
 	mockVersionManager := NewMockVersionManager(t)
-	mockVersionManager.On("GetCurrentIndexEngineVersion", mock.Anything).Return(int32(2), nil)
+	mockVersionManager.On("GetCurrentIndexEngineVersion").Return(int32(2)).Maybe()
+	mockVersionManager.On("ResolveVecIndexVersion").Return(int32(5)).Maybe()
 	trigger.indexEngineVersionManager = mockVersionManager
 	info4 := &SegmentInfo{
 		SegmentInfo: &datapb.SegmentInfo{
@@ -1881,6 +1882,9 @@ func Test_compactionTrigger_shouldDoSingleCompaction(t *testing.T) {
 			101: {
 				CollectionID: 2,
 				IndexID:      101,
+				IndexParams: []*commonpb.KeyValuePair{
+					{Key: common.IndexTypeKey, Value: "HNSW"},
+				},
 			},
 		},
 	}
@@ -3076,4 +3080,55 @@ func Test_compactionTrigger_generatePlansByTime(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_ShouldRebuildSegmentIndex_ForceRebuild_TargetExceedsMax_Converges(t *testing.T) {
+	paramtable.Init()
+	Params.Save("dataCoord.autoUpgradeSegmentIndex", "false")
+
+	collID, segID, indexID := int64(1), int64(100), int64(10)
+
+	t.Run("vec force-rebuild with target>max converges after clamp", func(t *testing.T) {
+		Params.Save("dataCoord.forceRebuildSegmentIndex", "true")
+		Params.Save("dataCoord.targetVecIndexVersion", "30")
+		defer func() {
+			Params.Save("dataCoord.forceRebuildSegmentIndex", "false")
+			Params.Save("dataCoord.targetVecIndexVersion", "-1")
+		}()
+
+		// Index was already rebuilt to clamped version (20), should NOT trigger again
+		segIdx := &model.SegmentIndex{
+			SegmentID:           segID,
+			CollectionID:        collID,
+			IndexID:             indexID,
+			IndexFileKeys:       []string{"file1"},
+			CurrentIndexVersion: 20, // matches resolved (clamped) target
+		}
+		im := newSegmentIndexMeta(nil)
+		im.indexes[collID] = map[UniqueID]*model.Index{
+			indexID: {
+				CollectionID: collID,
+				IndexID:      indexID,
+				IndexName:    "test_idx",
+				IndexParams: []*commonpb.KeyValuePair{
+					{Key: common.IndexTypeKey, Value: "HNSW"},
+				},
+			},
+		}
+		segIdxMap := typeutil.NewConcurrentMap[UniqueID, *model.SegmentIndex]()
+		segIdxMap.Insert(indexID, segIdx)
+		im.segmentIndexes.Insert(segID, segIdxMap)
+
+		mockVM := NewMockVersionManager(t)
+		// ResolveVecIndexVersion clamps target=30 to max=20
+		mockVM.On("ResolveVecIndexVersion").Return(int32(20)).Maybe()
+
+		trigger := &compactionTrigger{
+			meta:                      &meta{indexMeta: im, channelCPs: newChannelCps()},
+			indexEngineVersionManager: mockVM,
+		}
+
+		segment := &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{ID: segID, CollectionID: collID}}
+		assert.False(t, trigger.ShouldRebuildSegmentIndex(segment))
+	})
 }

--- a/internal/datacoord/index_engine_version_manager.go
+++ b/internal/datacoord/index_engine_version_manager.go
@@ -19,9 +19,14 @@ type IndexEngineVersionManager interface {
 
 	GetCurrentIndexEngineVersion() int32
 	GetMinimalIndexEngineVersion() int32
+	GetMaximumIndexEngineVersion() int32
 
 	GetCurrentScalarIndexEngineVersion() int32
 	GetMinimalScalarIndexEngineVersion() int32
+
+	// ResolveVecIndexVersion computes the final build version considering target override and max clamp
+	ResolveVecIndexVersion() int32
+
 	GetIndexNonEncoding() bool
 }
 
@@ -89,7 +94,11 @@ func (m *versionManagerImpl) Update(session *sessionutil.Session) {
 }
 
 func (m *versionManagerImpl) addOrUpdate(session *sessionutil.Session) {
-	log.Info("addOrUpdate version", zap.Int64("nodeId", session.ServerID), zap.Int32("minimal", session.IndexEngineVersion.MinimalIndexVersion), zap.Int32("current", session.IndexEngineVersion.CurrentIndexVersion))
+	log.Info("addOrUpdate version",
+		zap.Int64("nodeId", session.ServerID),
+		zap.Int32("minimal", session.IndexEngineVersion.MinimalIndexVersion),
+		zap.Int32("current", session.IndexEngineVersion.CurrentIndexVersion),
+		zap.Int32("maximum", session.IndexEngineVersion.MaximumIndexVersion))
 	m.versions[session.ServerID] = session.IndexEngineVersion
 	m.scalarIndexVersions[session.ServerID] = session.ScalarIndexEngineVersion
 	m.indexNonEncoding[session.ServerID] = session.IndexNonEncoding
@@ -99,8 +108,11 @@ func (m *versionManagerImpl) GetCurrentIndexEngineVersion() int32 {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	return m.getCurrentVersion()
+}
+
+func (m *versionManagerImpl) getCurrentVersion() int32 {
 	if len(m.versions) == 0 {
-		log.Info("index versions is empty")
 		return 0
 	}
 
@@ -110,7 +122,6 @@ func (m *versionManagerImpl) GetCurrentIndexEngineVersion() int32 {
 			current = version.CurrentIndexVersion
 		}
 	}
-	log.Info("Merged current version", zap.Int32("current", current))
 	return current
 }
 
@@ -118,8 +129,11 @@ func (m *versionManagerImpl) GetMinimalIndexEngineVersion() int32 {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	return m.getMinimalVersion()
+}
+
+func (m *versionManagerImpl) getMinimalVersion() int32 {
 	if len(m.versions) == 0 {
-		log.Info("index versions is empty")
 		return 0
 	}
 
@@ -129,7 +143,6 @@ func (m *versionManagerImpl) GetMinimalIndexEngineVersion() int32 {
 			minimal = version.MinimalIndexVersion
 		}
 	}
-	log.Info("Merged minimal version", zap.Int32("minimal", minimal))
 	return minimal
 }
 
@@ -169,6 +182,64 @@ func (m *versionManagerImpl) GetMinimalScalarIndexEngineVersion() int32 {
 	}
 	log.Info("Merged minimal scalar index version", zap.Int32("minimal", minimal))
 	return minimal
+}
+
+func (m *versionManagerImpl) GetMaximumIndexEngineVersion() int32 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.getMaximumVersion()
+}
+
+func (m *versionManagerImpl) getMaximumVersion() int32 {
+	if len(m.versions) == 0 {
+		return math.MaxInt32
+	}
+
+	maximum := int32(math.MaxInt32)
+	for _, version := range m.versions {
+		if version.MaximumIndexVersion == 0 {
+			continue
+		}
+		if version.MaximumIndexVersion < maximum {
+			maximum = version.MaximumIndexVersion
+		}
+	}
+	return maximum
+}
+
+// clampVersion clamps v into [minV, maxV], logging a rate-limited warning on each adjustment.
+func clampVersion(v, minV, maxV int32, name string) int32 {
+	if v < minV {
+		log.RatedWarn(60, name+" below cluster minimum, clamping",
+			zap.Int32("target", v), zap.Int32("minimum", minV))
+		v = minV
+	}
+	if v > maxV {
+		log.RatedWarn(60, name+" exceeds cluster maximum, clamping",
+			zap.Int32("target", v), zap.Int32("maximum", maxV))
+		v = maxV
+	}
+	return v
+}
+
+func (m *versionManagerImpl) ResolveVecIndexVersion() int32 {
+	m.mu.Lock()
+	current := m.getCurrentVersion()
+	minimal := m.getMinimalVersion()
+	maximum := m.getMaximumVersion()
+	m.mu.Unlock()
+
+	version := current
+	if Params.DataCoordCfg.TargetVecIndexVersion.GetAsInt64() != -1 {
+		target := Params.DataCoordCfg.TargetVecIndexVersion.GetAsInt32()
+		if Params.DataCoordCfg.ForceRebuildSegmentIndex.GetAsBool() {
+			version = target
+		} else {
+			version = max(version, target)
+		}
+	}
+	return clampVersion(version, minimal, maximum, "targetVecIndexVersion")
 }
 
 func (m *versionManagerImpl) GetIndexNonEncoding() bool {

--- a/internal/datacoord/index_engine_version_manager_test.go
+++ b/internal/datacoord/index_engine_version_manager_test.go
@@ -1,11 +1,13 @@
 package datacoord
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
 func Test_IndexEngineVersionManager_GetMergedIndexVersion(t *testing.T) {
@@ -315,4 +317,174 @@ func Test_IndexEngineVersionManager_removeNodeByID(t *testing.T) {
 	assert.False(t, exists, "node should be removed from scalarIndexVersions map")
 	_, exists = vm.indexNonEncoding[1]
 	assert.False(t, exists, "node should be removed from indexNonEncoding map")
+}
+
+func Test_IndexEngineVersionManager_GetMaximumIndexEngineVersion(t *testing.T) {
+	m := newIndexEngineVersionManager()
+
+	// empty - returns MaxInt32 (no upper bound)
+	assert.Equal(t, int32(math.MaxInt32), m.GetMaximumIndexEngineVersion())
+
+	// all nodes report Maximum=0 (old QNs) - returns MaxInt32
+	m.Startup(map[string]*sessionutil.Session{
+		"1": {
+			SessionRaw: sessionutil.SessionRaw{
+				ServerID:           1,
+				IndexEngineVersion: sessionutil.IndexEngineVersion{CurrentIndexVersion: 20, MaximumIndexVersion: 0},
+			},
+		},
+	})
+	assert.Equal(t, int32(math.MaxInt32), m.GetMaximumIndexEngineVersion())
+
+	// mix of old QN (Max=0) and new QN (Max=30) - skip old, return 30
+	m.AddNode(&sessionutil.Session{
+		SessionRaw: sessionutil.SessionRaw{
+			ServerID:           2,
+			IndexEngineVersion: sessionutil.IndexEngineVersion{CurrentIndexVersion: 15, MaximumIndexVersion: 30},
+		},
+	})
+	assert.Equal(t, int32(30), m.GetMaximumIndexEngineVersion())
+
+	// add another new QN with lower Max - returns MIN
+	m.AddNode(&sessionutil.Session{
+		SessionRaw: sessionutil.SessionRaw{
+			ServerID:           3,
+			IndexEngineVersion: sessionutil.IndexEngineVersion{CurrentIndexVersion: 18, MaximumIndexVersion: 25},
+		},
+	})
+	assert.Equal(t, int32(25), m.GetMaximumIndexEngineVersion())
+
+	// remove the node with lower Max - returns 30
+	m.RemoveNode(&sessionutil.Session{SessionRaw: sessionutil.SessionRaw{ServerID: 3}})
+	assert.Equal(t, int32(30), m.GetMaximumIndexEngineVersion())
+}
+
+func Test_IndexEngineVersionManager_ResolveVecIndexVersion(t *testing.T) {
+	paramtable.Init()
+
+	t.Run("no target override", func(t *testing.T) {
+		m := newIndexEngineVersionManager()
+		m.AddNode(&sessionutil.Session{
+			SessionRaw: sessionutil.SessionRaw{
+				ServerID:           1,
+				IndexEngineVersion: sessionutil.IndexEngineVersion{CurrentIndexVersion: 10, MaximumIndexVersion: 20},
+			},
+		})
+		Params.Save("dataCoord.targetVecIndexVersion", "-1")
+		Params.Save("dataCoord.forceRebuildSegmentIndex", "false")
+
+		assert.Equal(t, int32(10), m.ResolveVecIndexVersion())
+	})
+
+	t.Run("target override without force rebuild", func(t *testing.T) {
+		m := newIndexEngineVersionManager()
+		m.AddNode(&sessionutil.Session{
+			SessionRaw: sessionutil.SessionRaw{
+				ServerID:           1,
+				IndexEngineVersion: sessionutil.IndexEngineVersion{CurrentIndexVersion: 10, MaximumIndexVersion: 20},
+			},
+		})
+		Params.Save("dataCoord.targetVecIndexVersion", "15")
+		Params.Save("dataCoord.forceRebuildSegmentIndex", "false")
+
+		// max(current=10, target=15) = 15
+		assert.Equal(t, int32(15), m.ResolveVecIndexVersion())
+	})
+
+	t.Run("target below current without force rebuild", func(t *testing.T) {
+		m := newIndexEngineVersionManager()
+		m.AddNode(&sessionutil.Session{
+			SessionRaw: sessionutil.SessionRaw{
+				ServerID:           1,
+				IndexEngineVersion: sessionutil.IndexEngineVersion{CurrentIndexVersion: 10, MaximumIndexVersion: 20},
+			},
+		})
+		Params.Save("dataCoord.targetVecIndexVersion", "5")
+		Params.Save("dataCoord.forceRebuildSegmentIndex", "false")
+
+		// max(current=10, target=5) = 10, no downgrade without force
+		assert.Equal(t, int32(10), m.ResolveVecIndexVersion())
+	})
+
+	t.Run("force rebuild with target in safe range", func(t *testing.T) {
+		m := newIndexEngineVersionManager()
+		m.AddNode(&sessionutil.Session{
+			SessionRaw: sessionutil.SessionRaw{
+				ServerID:           1,
+				IndexEngineVersion: sessionutil.IndexEngineVersion{MinimalIndexVersion: 3, CurrentIndexVersion: 10, MaximumIndexVersion: 20},
+			},
+		})
+		Params.Save("dataCoord.targetVecIndexVersion", "5")
+		Params.Save("dataCoord.forceRebuildSegmentIndex", "true")
+
+		// force rebuild: target=5 is within [minimal=3, max=20], use directly
+		assert.Equal(t, int32(5), m.ResolveVecIndexVersion())
+	})
+
+	t.Run("force rebuild with target below cluster minimal - clamped to minimal", func(t *testing.T) {
+		m := newIndexEngineVersionManager()
+		m.AddNode(&sessionutil.Session{
+			SessionRaw: sessionutil.SessionRaw{
+				ServerID:           1,
+				IndexEngineVersion: sessionutil.IndexEngineVersion{MinimalIndexVersion: 8, CurrentIndexVersion: 10, MaximumIndexVersion: 20},
+			},
+		})
+		Params.Save("dataCoord.targetVecIndexVersion", "5")
+		Params.Save("dataCoord.forceRebuildSegmentIndex", "true")
+
+		// force rebuild: target=5 < clusterMinimal=8, clamped to 8
+		assert.Equal(t, int32(8), m.ResolveVecIndexVersion())
+	})
+
+	t.Run("target exceeds maximum - clamped", func(t *testing.T) {
+		m := newIndexEngineVersionManager()
+		m.AddNode(&sessionutil.Session{
+			SessionRaw: sessionutil.SessionRaw{
+				ServerID:           1,
+				IndexEngineVersion: sessionutil.IndexEngineVersion{MinimalIndexVersion: 3, CurrentIndexVersion: 10, MaximumIndexVersion: 20},
+			},
+		})
+		Params.Save("dataCoord.targetVecIndexVersion", "25")
+		Params.Save("dataCoord.forceRebuildSegmentIndex", "true")
+
+		// target=25 > max=20, clamped to 20
+		assert.Equal(t, int32(20), m.ResolveVecIndexVersion())
+	})
+
+	t.Run("multi-node force rebuild clamped to cluster minimal", func(t *testing.T) {
+		m := newIndexEngineVersionManager()
+		m.AddNode(&sessionutil.Session{
+			SessionRaw: sessionutil.SessionRaw{
+				ServerID:           1,
+				IndexEngineVersion: sessionutil.IndexEngineVersion{MinimalIndexVersion: 5, CurrentIndexVersion: 15, MaximumIndexVersion: 25},
+			},
+		})
+		m.AddNode(&sessionutil.Session{
+			SessionRaw: sessionutil.SessionRaw{
+				ServerID:           2,
+				IndexEngineVersion: sessionutil.IndexEngineVersion{MinimalIndexVersion: 8, CurrentIndexVersion: 12, MaximumIndexVersion: 30},
+			},
+		})
+		Params.Save("dataCoord.targetVecIndexVersion", "6")
+		Params.Save("dataCoord.forceRebuildSegmentIndex", "true")
+
+		// force rebuild: target=6 < clusterMinimal=8, clamped to 8
+		// clusterMax = MIN(25,30) = 25
+		assert.Equal(t, int32(8), m.ResolveVecIndexVersion())
+	})
+
+	t.Run("all old QNs - no upper bound check", func(t *testing.T) {
+		m := newIndexEngineVersionManager()
+		m.AddNode(&sessionutil.Session{
+			SessionRaw: sessionutil.SessionRaw{
+				ServerID:           1,
+				IndexEngineVersion: sessionutil.IndexEngineVersion{MinimalIndexVersion: 0, CurrentIndexVersion: 10, MaximumIndexVersion: 0},
+			},
+		})
+		Params.Save("dataCoord.targetVecIndexVersion", "15")
+		Params.Save("dataCoord.forceRebuildSegmentIndex", "false")
+
+		// old QN (Max=0) => GetMaximum returns MaxInt32, no upper clamp
+		assert.Equal(t, int32(15), m.ResolveVecIndexVersion())
+	})
 }

--- a/internal/datacoord/mock_index_engine_version_manager.go
+++ b/internal/datacoord/mock_index_engine_version_manager.go
@@ -278,6 +278,96 @@ func (_c *MockVersionManager_GetMinimalScalarIndexEngineVersion_Call) RunAndRetu
 	return _c
 }
 
+// GetMaximumIndexEngineVersion provides a mock function with no fields
+func (_m *MockVersionManager) GetMaximumIndexEngineVersion() int32 {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetMaximumIndexEngineVersion")
+	}
+
+	var r0 int32
+	if rf, ok := ret.Get(0).(func() int32); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(int32)
+	}
+
+	return r0
+}
+
+// MockVersionManager_GetMaximumIndexEngineVersion_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetMaximumIndexEngineVersion'
+type MockVersionManager_GetMaximumIndexEngineVersion_Call struct {
+	*mock.Call
+}
+
+// GetMaximumIndexEngineVersion is a helper method to define mock.On call
+func (_e *MockVersionManager_Expecter) GetMaximumIndexEngineVersion() *MockVersionManager_GetMaximumIndexEngineVersion_Call {
+	return &MockVersionManager_GetMaximumIndexEngineVersion_Call{Call: _e.mock.On("GetMaximumIndexEngineVersion")}
+}
+
+func (_c *MockVersionManager_GetMaximumIndexEngineVersion_Call) Run(run func()) *MockVersionManager_GetMaximumIndexEngineVersion_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockVersionManager_GetMaximumIndexEngineVersion_Call) Return(_a0 int32) *MockVersionManager_GetMaximumIndexEngineVersion_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockVersionManager_GetMaximumIndexEngineVersion_Call) RunAndReturn(run func() int32) *MockVersionManager_GetMaximumIndexEngineVersion_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ResolveVecIndexVersion provides a mock function with no fields
+func (_m *MockVersionManager) ResolveVecIndexVersion() int32 {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for ResolveVecIndexVersion")
+	}
+
+	var r0 int32
+	if rf, ok := ret.Get(0).(func() int32); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(int32)
+	}
+
+	return r0
+}
+
+// MockVersionManager_ResolveVecIndexVersion_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ResolveVecIndexVersion'
+type MockVersionManager_ResolveVecIndexVersion_Call struct {
+	*mock.Call
+}
+
+// ResolveVecIndexVersion is a helper method to define mock.On call
+func (_e *MockVersionManager_Expecter) ResolveVecIndexVersion() *MockVersionManager_ResolveVecIndexVersion_Call {
+	return &MockVersionManager_ResolveVecIndexVersion_Call{Call: _e.mock.On("ResolveVecIndexVersion")}
+}
+
+func (_c *MockVersionManager_ResolveVecIndexVersion_Call) Run(run func()) *MockVersionManager_ResolveVecIndexVersion_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockVersionManager_ResolveVecIndexVersion_Call) Return(_a0 int32) *MockVersionManager_ResolveVecIndexVersion_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockVersionManager_ResolveVecIndexVersion_Call) RunAndReturn(run func() int32) *MockVersionManager_ResolveVecIndexVersion_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // RemoveNode provides a mock function with given fields: session
 func (_m *MockVersionManager) RemoveNode(session *sessionutil.Session) {
 	_m.Called(session)

--- a/internal/datacoord/task_index.go
+++ b/internal/datacoord/task_index.go
@@ -288,17 +288,7 @@ func (it *indexBuildTask) prepareJobRequest(ctx context.Context, segment *Segmen
 		Value: indexNonEncoding,
 	})
 
-	currentVecIndexVersion := it.indexEngineVersionManager.GetCurrentIndexEngineVersion()
-	// if specify target vec index version, use it with high priority
-	if Params.DataCoordCfg.TargetVecIndexVersion.GetAsInt64() != -1 {
-		// if force rebuild segment index is true, use target vec index version directly
-		if Params.DataCoordCfg.ForceRebuildSegmentIndex.GetAsBool() {
-			currentVecIndexVersion = Params.DataCoordCfg.TargetVecIndexVersion.GetAsInt32()
-		} else {
-			// if force rebuild segment index is not enabled, use newer index version between current index version and target index version
-			currentVecIndexVersion = max(currentVecIndexVersion, Params.DataCoordCfg.TargetVecIndexVersion.GetAsInt32())
-		}
-	}
+	currentVecIndexVersion := it.indexEngineVersionManager.ResolveVecIndexVersion()
 
 	// Create the job request
 	req := &workerpb.CreateJobRequest{

--- a/internal/querynodev2/segments/utils.go
+++ b/internal/querynodev2/segments/utils.go
@@ -1,16 +1,5 @@
 package segments
 
-/*
-#cgo pkg-config: milvus_core
-
-#include "segcore/collection_c.h"
-#include "segcore/segment_c.h"
-#include "segcore/segcore_init_c.h"
-#include "common/init_c.h"
-
-*/
-import "C"
-
 import (
 	"bytes"
 	"context"
@@ -181,15 +170,6 @@ func mergeRequestCost(requestCosts []*internalpb.CostAggregation) *internalpb.Co
 	}
 
 	return result
-}
-
-func getIndexEngineVersion() (minimal, current int32) {
-	GetDynamicPool().Submit(func() (any, error) {
-		cMinimal, cCurrent := C.GetMinimalIndexVersion(), C.GetCurrentIndexVersion()
-		minimal, current = int32(cMinimal), int32(cCurrent)
-		return nil, nil
-	}).Await()
-	return minimal, current
 }
 
 // getSegmentMetricLabel returns the label for segment metrics.

--- a/internal/querynodev2/server.go
+++ b/internal/querynodev2/server.go
@@ -160,9 +160,9 @@ func NewQueryNode(ctx context.Context, factory dependency.Factory) *QueryNode {
 }
 
 func (node *QueryNode) initSession() error {
-	minimalIndexVersion, currentIndexVersion := getIndexEngineVersion()
+	minimalIndexVersion, currentIndexVersion, maximumIndexVersion := getIndexEngineVersion()
 	node.session = sessionutil.NewSession(node.ctx,
-		sessionutil.WithIndexEngineVersion(minimalIndexVersion, currentIndexVersion),
+		sessionutil.WithIndexEngineVersion(minimalIndexVersion, currentIndexVersion, maximumIndexVersion),
 		sessionutil.WithScalarIndexEngineVersion(common.MinimalScalarIndexEngineVersion, common.CurrentScalarIndexEngineVersion),
 		sessionutil.WithIndexNonEncoding())
 	if node.session == nil {
@@ -235,9 +235,9 @@ func (node *QueryNode) RegisterSegcoreConfigWatcher() {
 		config.NewHandler("common.diskWriteRateLimiter.lowPriorityRatio", node.ReconfigDiskFileWriterParams))
 }
 
-func getIndexEngineVersion() (minimal, current int32) {
-	cMinimal, cCurrent := C.GetMinimalIndexVersion(), C.GetCurrentIndexVersion()
-	return int32(cMinimal), int32(cCurrent)
+func getIndexEngineVersion() (minimal, current, maximum int32) {
+	cMinimal, cCurrent, cMaximum := C.GetMinimalIndexVersion(), C.GetCurrentIndexVersion(), C.GetMaximumIndexVersion()
+	return int32(cMinimal), int32(cCurrent), int32(cMaximum)
 }
 
 func (node *QueryNode) GetNodeID() int64 {

--- a/internal/util/segcore/segcore_init.go
+++ b/internal/util/segcore/segcore_init.go
@@ -16,13 +16,15 @@ import "C"
 type IndexEngineInfo struct {
 	MinIndexVersion     int32
 	CurrentIndexVersion int32
+	MaxIndexVersion     int32
 }
 
-// GetIndexEngineInfo returns the minimal and current version of the index engine.
+// GetIndexEngineInfo returns the minimal, current, and maximum version of the index engine.
 func GetIndexEngineInfo() IndexEngineInfo {
-	cMinimal, cCurrent := C.GetMinimalIndexVersion(), C.GetCurrentIndexVersion()
+	cMinimal, cCurrent, cMaximum := C.GetMinimalIndexVersion(), C.GetCurrentIndexVersion(), C.GetMaximumIndexVersion()
 	return IndexEngineInfo{
 		MinIndexVersion:     int32(cMinimal),
 		CurrentIndexVersion: int32(cCurrent),
+		MaxIndexVersion:     int32(cMaximum),
 	}
 }

--- a/internal/util/segcore/segcore_init_test.go
+++ b/internal/util/segcore/segcore_init_test.go
@@ -10,4 +10,6 @@ func TestGetIndexEngineInfo(t *testing.T) {
 	r := GetIndexEngineInfo()
 	assert.NotZero(t, r.CurrentIndexVersion)
 	assert.Zero(t, r.MinIndexVersion)
+	assert.NotZero(t, r.MaxIndexVersion)
+	assert.GreaterOrEqual(t, r.MaxIndexVersion, r.CurrentIndexVersion)
 }

--- a/internal/util/sessionutil/session_util.go
+++ b/internal/util/sessionutil/session_util.go
@@ -110,6 +110,7 @@ const (
 type IndexEngineVersion struct {
 	MinimalIndexVersion int32 `json:"MinimalIndexVersion,omitempty"`
 	CurrentIndexVersion int32 `json:"CurrentIndexVersion,omitempty"`
+	MaximumIndexVersion int32 `json:"MaximumIndexVersion,omitempty"`
 }
 
 // SessionRaw the persistent part of Session.
@@ -198,10 +199,11 @@ func WithResueNodeID(b bool) SessionOption {
 }
 
 // WithIndexEngineVersion should be only used by querynode.
-func WithIndexEngineVersion(minimal, current int32) SessionOption {
+func WithIndexEngineVersion(minimal, current, maximum int32) SessionOption {
 	return func(session *Session) {
 		session.IndexEngineVersion.MinimalIndexVersion = minimal
 		session.IndexEngineVersion.CurrentIndexVersion = current
+		session.IndexEngineVersion.MaximumIndexVersion = maximum
 	}
 }
 


### PR DESCRIPTION
## Summary

During rolling upgrade, `targetVecIndexVersion` can exceed old QueryNodes'
`maximum_version`. The `max(merged, target)` operation bypasses the
`GetCurrentIndexEngineVersion()` MIN safety mechanism, producing index
versions that old QNs cannot load.

- QN now reports `MaximumIndexVersion` via session
- DataCoord computes cluster-wide max via `GetMaximumIndexEngineVersion()`
- New `ResolveVecIndexVersion()` clamps target to `[cluster_min, cluster_max]`
- `task_index.go` and `compaction_trigger.go` use the clamped version

issue: #48470
pr: #48249