### PR TITLE
fix: resolve flaky TestChannelCPUpdater and TestRevisionBytes tests

### DIFF
--- a/internal/flushcommon/util/checkpoint_updater_test.go
+++ b/internal/flushcommon/util/checkpoint_updater_test.go
@@ -79,7 +79,7 @@ func (s *ChannelCPUpdaterSuite) TestUpdate() {
 	wg.Wait()
 	s.Eventually(func() bool {
 		return counter.Load() == int64(tasksNum)
-	}, time.Second*10, time.Millisecond*100)
+	}, time.Second*30, time.Millisecond*100)
 }
 
 func TestChannelCPUpdater(t *testing.T) {

--- a/internal/kv/etcd/etcd_kv_test.go
+++ b/internal/kv/etcd/etcd_kv_test.go
@@ -687,7 +687,7 @@ func (s *EtcdKVSuite) TestRevisionBytes() {
 		resp := <-ch
 		s.Equal(1, len(resp.Events))
 		s.Equal(string(test.secondValue), string(resp.Events[0].Kv.Value))
-		s.Equal(revision+1, resp.Header.Revision)
+		s.GreaterOrEqual(resp.Header.Revision, revision+1)
 	}
 
 	success, err := etcdKV.CompareVersionAndSwapBytes(context.TODO(), "a/b/c", 0, []byte("1"))


### PR DESCRIPTION
## Summary
- **TestChannelCPUpdater/TestUpdate**: increase `Eventually` timeout from 10s to 30s — the test adds 100k tasks with 10ms mock sleep per batch call, which can exceed 10s on busy CI machines
- **TestEtcdKV/TestRevisionBytes**: use `GreaterOrEqual` instead of `Equal` for etcd `resp.Header.Revision` check — the header revision reflects the cluster's global revision which can be higher than `revision+1` when other tests write to etcd concurrently

## Test plan
- [x] `TestChannelCPUpdater` 5/5 passes
- [x] `TestEtcdKV/TestRevisionBytes` 5/5 passes

issue: https://github.com/milvus-io/milvus/issues/39893

🤖 Generated with [Claude Code](https://claude.com/claude-code)