### PR TITLE
test: add woodpecker chaos test yamls for all chaos categories

### DIFF
--- a/tests/python_client/chaos/chaos_objects/io_latency/chaos_woodpecker_io_latency.yaml
+++ b/tests/python_client/chaos/chaos_objects/io_latency/chaos_woodpecker_io_latency.yaml
@@ -1,0 +1,22 @@
+kind: IOChaos
+apiVersion: chaos-mesh.org/v1alpha1
+metadata:
+  name: test-woodpecker-io-latency
+  namespace: chaos-testing
+spec:
+  selector:
+    namespaces:
+      - chaos-testing
+    labelSelectors:
+      app.kubernetes.io/instance: milvus-chaos
+      app.kubernetes.io/name: milvus
+      component: woodpecker
+  mode: all
+  action: latency
+  delay: 10ms
+  methods:
+    - read
+    - write
+    - flush
+  percent: 100
+  volumePath: /milvus/data

--- a/tests/python_client/chaos/chaos_objects/io_latency/testcases.yaml
+++ b/tests/python_client/chaos/chaos_objects/io_latency/testcases.yaml
@@ -37,3 +37,15 @@ Collections:
           index: fail
           search: fail
           query: fail
+  -
+    testcase:
+      name: test_woodpecker_io_latency
+      chaos: chaos_woodpecker_io_latency.yaml
+      expectation:
+        cluster_1_node:
+          create: fail
+          insert: fail
+          flush: fail
+          index: fail
+          search: fail
+          query: fail

--- a/tests/python_client/chaos/chaos_objects/mem_stress/chaos_woodpecker_mem_stress.yaml
+++ b/tests/python_client/chaos/chaos_objects/mem_stress/chaos_woodpecker_mem_stress.yaml
@@ -1,0 +1,22 @@
+kind: StressChaos
+apiVersion: chaos-mesh.org/v1alpha1
+metadata:
+  name: test-woodpecker-memory-stress
+  namespace: chaos-testing
+spec:
+  selector:
+    namespaces:
+      - chaos-testing
+    labelSelectors:
+      app.kubernetes.io/instance: milvus-chaos
+      app.kubernetes.io/name: milvus
+      component: woodpecker
+  mode: one
+  stressors:
+    cpu:
+      workers: 4
+      load: 80
+    memory:
+      workers: 4
+      size: 2048Mi
+  duration: 5m

--- a/tests/python_client/chaos/chaos_objects/mem_stress/testcases.yaml
+++ b/tests/python_client/chaos/chaos_objects/mem_stress/testcases.yaml
@@ -83,3 +83,12 @@ Collections:
             flush: fail
           cluster_n_nodes:
             flush: degrade
+  -
+    testcase:
+      name: test_woodpecker_mem_stress
+      chaos: chaos_woodpecker_mem_stress.yaml
+      expectation:
+          cluster_1_node:
+            flush: fail
+          cluster_n_nodes:
+            flush: degrade

--- a/tests/python_client/chaos/chaos_objects/network_latency/chaos_woodpecker_network_latency.yaml
+++ b/tests/python_client/chaos/chaos_objects/network_latency/chaos_woodpecker_network_latency.yaml
@@ -1,0 +1,27 @@
+kind: NetworkChaos
+apiVersion: chaos-mesh.org/v1alpha1
+metadata:
+  name: test-woodpecker-network-latency
+  namespace: chaos-testing
+spec:
+  selector:
+    namespaces:
+      - chaos-testing
+    labelSelectors:
+      app.kubernetes.io/instance: milvus-chaos
+      app.kubernetes.io/name: milvus
+      component: woodpecker
+  mode: all
+  action: delay
+  delay:
+    latency: 200ms
+    correlation: '100'
+    jitter: 0ms
+  direction: both
+  target:
+    selector:
+      namespaces:
+        - chaos-testing
+      labelSelectors:
+        app.kubernetes.io/instance: milvus-chaos
+    mode: all

--- a/tests/python_client/chaos/chaos_objects/network_latency/testcases.yaml
+++ b/tests/python_client/chaos/chaos_objects/network_latency/testcases.yaml
@@ -124,3 +124,15 @@ Collections:
           index: fail
           search: fail
           query: fail
+  -
+    testcase:
+      name: test_woodpecker_network_latency
+      chaos: chaos_woodpecker_network_latency.yaml
+      expectation:
+        cluster_1_node:
+          create: fail
+          insert: fail
+          flush: fail
+          index: fail
+          search: fail
+          query: fail

--- a/tests/python_client/chaos/chaos_objects/network_partition/chaos_woodpecker_network_partition.yaml
+++ b/tests/python_client/chaos/chaos_objects/network_partition/chaos_woodpecker_network_partition.yaml
@@ -1,0 +1,25 @@
+apiVersion: chaos-mesh.org/v1alpha1
+kind: NetworkChaos
+metadata:
+  name: test-woodpecker-network-partition
+  namespace: chaos-testing
+spec:
+  action: partition
+  mode: all
+  selector:
+    namespaces:
+      - chaos-testing
+    labelSelectors:
+      app.kubernetes.io/instance: chaos-testing
+      app.kubernetes.io/name: milvus
+  duration: 5m
+  direction: both
+  target:
+    selector:
+      namespaces:
+        - chaos-testing
+      labelSelectors:
+        app.kubernetes.io/instance: milvus-chaos
+        app.kubernetes.io/name: milvus
+        component: woodpecker
+    mode: one

--- a/tests/python_client/chaos/chaos_objects/network_partition/testcases.yaml
+++ b/tests/python_client/chaos/chaos_objects/network_partition/testcases.yaml
@@ -144,3 +144,15 @@ Collections:
           index: fail
           search: fail
           query: fail
+  -
+    testcase:
+      name: test_woodpecker_network_partition
+      chaos: chaos_woodpecker_network_partition.yaml
+      expectation:
+        cluster_1_node:
+          create: fail
+          insert: fail
+          flush: fail
+          index: fail
+          search: fail
+          query: fail

--- a/tests/python_client/chaos/chaos_objects/pod_failure/chaos_woodpecker_pod_failure.yaml
+++ b/tests/python_client/chaos/chaos_objects/pod_failure/chaos_woodpecker_pod_failure.yaml
@@ -1,0 +1,18 @@
+apiVersion: chaos-mesh.org/v1alpha1
+kind: PodChaos
+metadata:
+  name: test-woodpecker-pod-failure
+  namespace: chaos-testing
+spec:
+  selector:
+    namespaces:
+      - chaos-testing
+    labelSelectors:
+      app.kubernetes.io/instance: milvus-chaos
+      app.kubernetes.io/name: milvus
+      component: woodpecker
+  mode: fixed
+  value: "1"
+  action: pod-failure
+  duration: 2m
+  gracePeriod: 0

--- a/tests/python_client/chaos/chaos_objects/pod_failure/testcases.yaml
+++ b/tests/python_client/chaos/chaos_objects/pod_failure/testcases.yaml
@@ -182,3 +182,15 @@ Collections:
           index: fail
           search: fail
           query: fail
+  -
+    testcase:
+      name: test_woodpecker_pod_failure
+      chaos: chaos_woodpecker_pod_failure.yaml
+      expectation:
+        cluster_1_node:
+          create: fail
+          insert: fail
+          flush: fail
+          index: fail
+          search: fail
+          query: fail

--- a/tests/python_client/chaos/chaos_objects/pod_kill/chaos_woodpecker_pod_kill.yaml
+++ b/tests/python_client/chaos/chaos_objects/pod_kill/chaos_woodpecker_pod_kill.yaml
@@ -1,0 +1,25 @@
+kind: Schedule
+apiVersion: chaos-mesh.org/v1alpha1
+metadata:
+  name: test-woodpecker-pod-kill
+  namespace: chaos-testing
+  annotations:
+    experiment.chaos-mesh.org/pause: 'false'
+spec:
+  schedule: '*/5 * * * * *'
+  startingDeadlineSeconds: 60
+  concurrencyPolicy: Forbid
+  historyLimit: 1
+  type: PodChaos
+  podChaos:
+    selector:
+      namespaces:
+        - chaos-testing
+      labelSelectors:
+        app.kubernetes.io/instance: milvus-chaos
+        app.kubernetes.io/name: milvus
+        component: woodpecker
+    mode: fixed
+    value: "1"
+    action: pod-kill
+    gracePeriod: 0

--- a/tests/python_client/chaos/chaos_objects/pod_kill/testcases.yaml
+++ b/tests/python_client/chaos/chaos_objects/pod_kill/testcases.yaml
@@ -182,3 +182,15 @@ Collections:
           index: fail
           search: fail
           query: fail
+  -
+    testcase:
+      name: test_woodpecker_pod_kill
+      chaos: chaos_woodpecker_pod_kill.yaml
+      expectation:
+        cluster_1_node:
+          create: fail
+          insert: fail
+          flush: fail
+          index: fail
+          search: fail
+          query: fail


### PR DESCRIPTION
## Summary
- Add chaos mesh YAML files for the woodpecker component across 5 chaos categories: pod_failure, network_partition, network_latency, mem_stress, and io_latency
- Add corresponding test case entries in each category's testcases.yaml
- Add woodpecker test case entry to pod_kill/testcases.yaml (yaml already existed)
- Woodpecker acts as the message queue (like pulsar), so chaos expectations mirror pulsar's behavior

issue: #48483

## Test plan
- [ ] Verify woodpecker chaos yamls apply correctly via chaos-mesh
- [ ] Validate label selectors match woodpecker pods in chaos-testing namespace
- [ ] Run chaos tests for each category to confirm expected behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)