### PR TITLE
enhance: reject woodpecker with local storage in cluster mode

### DIFF
--- a/internal/util/streamingutil/util/wal_selector.go
+++ b/internal/util/streamingutil/util/wal_selector.go
@@ -63,6 +63,11 @@ func mustSelectWALName(standalone bool, mqType string, enable walEnable) message
 		return message.WALNameKafka
 	}
 	if enable.Woodpecker {
+		// woodpecker with local storage cannot work in cluster mode,
+		// because local storage is not shared across nodes.
+		if !standalone && paramtable.Get().WoodpeckerCfg.StorageType.GetValue() == "local" && !paramtable.Get().WoodpeckerCfg.ForceLocalStorage.GetAsBool() {
+			panic(errors.Newf("woodpecker with local storage is not supported in cluster mode, set woodpecker.storage.forceLocalStorage to true to override"))
+		}
 		return message.WALNameWoodpecker
 	}
 	panic(errors.Errorf("no available wal config found, %s, enable: %+v", mqType, enable))
@@ -80,6 +85,11 @@ func validateWALName(standalone bool, mqType string) (message.WALName, error) {
 	// only check standalone type.
 	if !standalone && mqName == message.WALNameRocksmq {
 		return mqName, errors.Newf("mq %s is only valid in standalone mode", mqType)
+	}
+	// woodpecker with local storage cannot work in cluster mode,
+	// because local storage is not shared across nodes.
+	if !standalone && mqName == message.WALNameWoodpecker && paramtable.Get().WoodpeckerCfg.StorageType.GetValue() == "local" && !paramtable.Get().WoodpeckerCfg.ForceLocalStorage.GetAsBool() {
+		return mqName, errors.Newf("woodpecker with local storage is not supported in cluster mode, set woodpecker.storage.forceLocalStorage to true to override")
 	}
 	return mqName, nil
 }

--- a/internal/util/streamingutil/util/wal_selector_test.go
+++ b/internal/util/streamingutil/util/wal_selector_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
 func TestValidateWALType(t *testing.T) {
@@ -33,4 +34,54 @@ func TestSelectWALType(t *testing.T) {
 	assert.Equal(t, mustSelectWALName(false, message.WALNamePulsar.String(), walEnable{true, true, true, true}), message.WALNamePulsar)
 	assert.Equal(t, mustSelectWALName(false, message.WALNameKafka.String(), walEnable{true, true, true, true}), message.WALNameKafka)
 	assert.Equal(t, mustSelectWALName(false, message.WALNameWoodpecker.String(), walEnable{true, true, true, true}), message.WALNameWoodpecker)
+}
+
+func TestWoodpeckerLocalStorageInClusterMode(t *testing.T) {
+	paramtable.Init()
+	storageTypeKey := paramtable.Get().WoodpeckerCfg.StorageType.Key
+	forceLocalKey := paramtable.Get().WoodpeckerCfg.ForceLocalStorage.Key
+
+	// save original values and restore after test
+	originalStorageType := paramtable.Get().WoodpeckerCfg.StorageType.GetValue()
+	originalForceLocal := paramtable.Get().WoodpeckerCfg.ForceLocalStorage.GetValue()
+	defer func() {
+		paramtable.Get().Save(storageTypeKey, originalStorageType)
+		paramtable.Get().Save(forceLocalKey, originalForceLocal)
+	}()
+
+	t.Run("cluster_woodpecker_local_should_panic", func(t *testing.T) {
+		paramtable.Get().Save(storageTypeKey, "local")
+		paramtable.Get().Save(forceLocalKey, "false")
+		// auto-select path
+		assert.Panics(t, func() {
+			mustSelectWALName(false, walTypeDefault, walEnable{false, false, false, true})
+		})
+		// explicit path
+		assert.Panics(t, func() {
+			mustSelectWALName(false, message.WALNameWoodpecker.String(), walEnable{true, true, true, true})
+		})
+	})
+
+	t.Run("cluster_woodpecker_local_force_should_pass", func(t *testing.T) {
+		paramtable.Get().Save(storageTypeKey, "local")
+		paramtable.Get().Save(forceLocalKey, "true")
+		// auto-select path
+		assert.Equal(t, message.WALNameWoodpecker, mustSelectWALName(false, walTypeDefault, walEnable{false, false, false, true}))
+		// explicit path
+		assert.Equal(t, message.WALNameWoodpecker, mustSelectWALName(false, message.WALNameWoodpecker.String(), walEnable{true, true, true, true}))
+	})
+
+	t.Run("cluster_woodpecker_minio_should_pass", func(t *testing.T) {
+		paramtable.Get().Save(storageTypeKey, "minio")
+		paramtable.Get().Save(forceLocalKey, "false")
+		assert.Equal(t, message.WALNameWoodpecker, mustSelectWALName(false, walTypeDefault, walEnable{false, false, false, true}))
+		assert.Equal(t, message.WALNameWoodpecker, mustSelectWALName(false, message.WALNameWoodpecker.String(), walEnable{true, true, true, true}))
+	})
+
+	t.Run("standalone_woodpecker_local_should_pass", func(t *testing.T) {
+		paramtable.Get().Save(storageTypeKey, "local")
+		paramtable.Get().Save(forceLocalKey, "false")
+		assert.Equal(t, message.WALNameWoodpecker, mustSelectWALName(true, walTypeDefault, walEnable{false, false, false, true}))
+		assert.Equal(t, message.WALNameWoodpecker, mustSelectWALName(true, message.WALNameWoodpecker.String(), walEnable{true, true, true, true}))
+	})
 }

--- a/pkg/util/paramtable/service_param.go
+++ b/pkg/util/paramtable/service_param.go
@@ -753,8 +753,9 @@ type WoodpeckerConfig struct {
 	FencePolicyConditionWrite      ParamItem `refreshable:"true"`
 
 	// storage
-	StorageType ParamItem `refreshable:"false"`
-	RootPath    ParamItem `refreshable:"false"`
+	StorageType       ParamItem `refreshable:"false"`
+	ForceLocalStorage ParamItem `refreshable:"false"`
+	RootPath          ParamItem `refreshable:"false"`
 }
 
 func (p *WoodpeckerConfig) Init(base *BaseTable) {
@@ -1049,6 +1050,15 @@ Valid values: [auto, enable, disable]`,
 		Export:       true,
 	}
 	p.StorageType.Init(base.mgr)
+
+	p.ForceLocalStorage = ParamItem{
+		Key:          "woodpecker.storage.forceLocalStorage",
+		Version:      "2.6.14",
+		DefaultValue: "false",
+		Doc:          "Force using local storage in cluster mode. Not recommended unless you know what you are doing.",
+		Export:       false,
+	}
+	p.ForceLocalStorage.Init(base.mgr)
 
 	p.RootPath = ParamItem{
 		Key:          "woodpecker.storage.rootPath",

--- a/pkg/util/paramtable/service_param_test.go
+++ b/pkg/util/paramtable/service_param_test.go
@@ -137,6 +137,7 @@ func TestServiceParam(t *testing.T) {
 		assert.Equal(t, wpCfg.FencePolicyConditionWrite.GetValue(), "auto")
 
 		assert.Equal(t, wpCfg.StorageType.GetValue(), "minio")
+		assert.Equal(t, wpCfg.ForceLocalStorage.GetAsBool(), false)
 		assert.Equal(t, wpCfg.RootPath.GetValue(), "default")
 	})
 


### PR DESCRIPTION
issue: #48247 

Cluster mode requires shared storage across nodes, so woodpecker with local storage type is not supported. 
Add validation in WAL selection (both explicit and auto-select paths) to panic early at startup with a clear error message. 
A hidden config is provided to override this check if needed.

# BREAKING CHANGE

> [!CAUTION]
> **Cluster mode requires shared storage across nodes.**
> Woodpecker configurations using the `local` storage type are **not supported by default** in cluster mode to prevent data inconsistency.

### Impact & Validation
- **Startup Panic:** We've added strict validation in the WAL selection (covering both explicit and auto-select paths). The service will now **panic early at startup** with a clear error message if an incompatible storage configuration is detected in a clustered environment.
- **Override Option:** A hidden configuration is provided to override this check if you have a specialized, single-node cluster setup or understand the specific risks involved.

---

---