### PR TITLE
enhance: mmap bloom filter to reduce Go heap pressure

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -1036,6 +1036,7 @@ common:
   bloomFilterType: BlockedBloomFilter # bloom filter type, support BasicBloomFilter and BlockedBloomFilter
   maxBloomFalsePositive: 0.001 # max false positive rate for bloom filter
   bloomFilterApplyBatchSize: 1000 # batch size when to apply pk to bloom filter
+  bloomFilterMmapEnabled: false # if true, mmap bloom filter data to local file to reduce Go heap pressure
   usePartitionKeyAsClusteringKey: false # if true, do clustering compaction and segment prune on partition key field
   useVectorAsClusteringKey: false # if true, do clustering compaction and segment prune on vector field
   enableVectorClusteringKey: false # if true, enable vector clustering key and vector clustering compaction

--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -541,11 +541,18 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 		return err
 	}
 
+	refundCandidatesOnErr := func(err error) error {
+		for _, c := range candidates {
+			c.Refund()
+		}
+		return err
+	}
+
 	// Load BM25 stats BEFORE loadStreamDelete so stats are ready before segment becomes visible
 	err = sd.loadBM25Stats(ctx, infos, req)
 	if err != nil {
 		log.Warn("failed to load BM25 stats", zap.Error(err))
-		return err
+		return refundCandidatesOnErr(err)
 	}
 
 	// Build a map from segmentID to BloomFilterSet
@@ -585,7 +592,7 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 			})
 			sd.idfOracle.UnregisterSealed(segmentIDs...)
 		}
-		return err
+		return refundCandidatesOnErr(err)
 	}
 
 	return nil

--- a/internal/querynodev2/pkoracle/bloom_filter_set.go
+++ b/internal/querynodev2/pkoracle/bloom_filter_set.go
@@ -51,6 +51,11 @@ type BloomFilterSet struct {
 	// Resource tracking
 	trackedSize     int64 // memory size that was charged
 	resourceCharged bool  // tracks whether memory resources were charged for this bloom filter set
+
+	// Mmap tracking
+	mmapPath    string                          // remote path used as mmap key
+	mmapManager *bloomfilter.PkStatsMmapManager // shared mmap manager, nil if not using mmap
+	isMmapped   bool                            // whether this BFS uses mmap'd bloom filters
 }
 
 // MayPkExist returns whether any bloom filters returns positive.
@@ -181,36 +186,68 @@ func (s *BloomFilterSet) Charge() {
 
 	size := s.memSizeLocked()
 	if size > 0 {
-		C.ChargeLoadedResource(C.CResourceUsage{
-			memory_bytes: C.int64_t(size),
-			disk_bytes:   0,
-		})
+		var usage C.CResourceUsage
+		if s.isMmapped {
+			usage = C.CResourceUsage{
+				memory_bytes: 0,
+				disk_bytes:   C.int64_t(size),
+			}
+		} else {
+			usage = C.CResourceUsage{
+				memory_bytes: C.int64_t(size),
+				disk_bytes:   0,
+			}
+		}
+		C.ChargeLoadedResource(usage)
 		s.trackedSize = size
 		s.resourceCharged = true
 		log.Debug("charged bloom filter resource",
 			zap.Int64("segmentID", s.segmentID),
-			zap.Int64("size", size))
+			zap.Int64("size", size),
+			zap.Bool("isMmapped", s.isMmapped))
 	}
 }
 
-// Refund refunds any charged resources. Safe to call multiple times.
+// Refund refunds any charged resources and releases mmap references.
+// Safe to call multiple times.
 func (s *BloomFilterSet) Refund() {
 	s.statsMutex.Lock()
 	defer s.statsMutex.Unlock()
 
-	if !s.resourceCharged || s.trackedSize <= 0 {
-		return
+	if s.resourceCharged && s.trackedSize > 0 {
+		var usage C.CResourceUsage
+		if s.isMmapped {
+			usage = C.CResourceUsage{
+				memory_bytes: 0,
+				disk_bytes:   C.int64_t(s.trackedSize),
+			}
+		} else {
+			usage = C.CResourceUsage{
+				memory_bytes: C.int64_t(s.trackedSize),
+				disk_bytes:   0,
+			}
+		}
+		C.RefundLoadedResource(usage)
+		log.Debug("refunded bloom filter resource",
+			zap.Int64("segmentID", s.segmentID),
+			zap.Int64("size", s.trackedSize),
+			zap.Bool("isMmapped", s.isMmapped))
 	}
-
-	C.RefundLoadedResource(C.CResourceUsage{
-		memory_bytes: C.int64_t(s.trackedSize),
-		disk_bytes:   0,
-	})
-	log.Debug("refunded bloom filter resource",
-		zap.Int64("segmentID", s.segmentID),
-		zap.Int64("size", s.trackedSize))
 	s.trackedSize = 0
 	s.resourceCharged = false
+
+	// Release mmap reference
+	if s.isMmapped && s.mmapManager != nil && s.mmapPath != "" {
+		s.mmapManager.Release(s.mmapPath)
+		s.isMmapped = false
+		s.mmapPath = ""
+	}
+
+	// Nil out stats to prevent use-after-unmap. If the mmap'd memory was freed,
+	// any MmapBloomFilter objects in these stats point at invalid memory.
+	// A nil dereference gives a clear stack trace rather than a SIGSEGV.
+	s.historyStats = nil
+	s.currentStat = nil
 }
 
 // IsResourceCharged returns whether memory resources have been charged for this bloom filter set.
@@ -246,6 +283,28 @@ func (s *BloomFilterSet) memSizeLocked() int64 {
 		}
 	}
 	return size
+}
+
+// SetMmapPaths sets the remote path used as a key for the mmap manager.
+func (s *BloomFilterSet) SetMmapPaths(remotePath string) {
+	s.statsMutex.Lock()
+	defer s.statsMutex.Unlock()
+	s.mmapPath = remotePath
+	s.isMmapped = true
+}
+
+// SetMmapManager sets the mmap manager reference for this bloom filter set.
+func (s *BloomFilterSet) SetMmapManager(mgr *bloomfilter.PkStatsMmapManager) {
+	s.statsMutex.Lock()
+	defer s.statsMutex.Unlock()
+	s.mmapManager = mgr
+}
+
+// IsMmapped returns whether this bloom filter set uses mmap'd data.
+func (s *BloomFilterSet) IsMmapped() bool {
+	s.statsMutex.RLock()
+	defer s.statsMutex.RUnlock()
+	return s.isMmapped
 }
 
 // NewBloomFilterSet returns a new BloomFilterSet.

--- a/internal/querynodev2/pkoracle/bloom_filter_set_test.go
+++ b/internal/querynodev2/pkoracle/bloom_filter_set_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/util/bloomfilter"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
@@ -187,4 +188,20 @@ func TestMemSize(t *testing.T) {
 		size := bfs.MemSize()
 		assert.Greater(t, size, int64(0))
 	})
+}
+
+func TestRefundReleasesMmapWithoutCharge(t *testing.T) {
+	mgr := bloomfilter.NewPkStatsMmapManager(t.TempDir(), false)
+	_, err := mgr.GetOrLoad("stats-path", []byte("binary-stats"))
+	assert.NoError(t, err)
+
+	bfs := NewBloomFilterSet(1, 1, commonpb.SegmentState_Sealed)
+	bfs.SetMmapManager(mgr)
+	bfs.SetMmapPaths("stats-path")
+
+	// Refund should release mmap references even if Charge() never happened.
+	bfs.Refund()
+
+	_, ok := mgr.TryAddRef("stats-path")
+	assert.False(t, ok)
 }

--- a/internal/querynodev2/segments/mock_loader.go
+++ b/internal/querynodev2/segments/mock_loader.go
@@ -7,6 +7,10 @@ import (
 
 	commonpb "github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 
+	bloomfilter "github.com/milvus-io/milvus/internal/util/bloomfilter"
+
+	datapb "github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+
 	mock "github.com/stretchr/testify/mock"
 
 	pkoracle "github.com/milvus-io/milvus/internal/querynodev2/pkoracle"
@@ -445,6 +449,31 @@ func (_c *MockLoader_ReopenSegments_Call) Return(_a0 error) *MockLoader_ReopenSe
 func (_c *MockLoader_ReopenSegments_Call) RunAndReturn(run func(context.Context, []*querypb.SegmentLoadInfo) error) *MockLoader_ReopenSegments_Call {
 	_c.Call.Return(run)
 	return _c
+}
+
+// GetPkStatsMmapManager provides a mock function with no fields
+func (_m *MockLoader) GetPkStatsMmapManager() *bloomfilter.PkStatsMmapManager {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetPkStatsMmapManager")
+	}
+
+	var r0 *bloomfilter.PkStatsMmapManager
+	if rf, ok := ret.Get(0).(func() *bloomfilter.PkStatsMmapManager); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*bloomfilter.PkStatsMmapManager)
+		}
+	}
+
+	return r0
+}
+
+// Close provides a mock function for the Close method.
+func (_m *MockLoader) Close() {
+	_m.Called()
 }
 
 // NewMockLoader creates a new instance of MockLoader. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -29,6 +29,7 @@ import (
 	"io"
 	"math"
 	"path"
+	"path/filepath"
 	"strconv"
 	"sync"
 	"time"
@@ -46,6 +47,7 @@ import (
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/storagecommon"
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
+	"github.com/milvus-io/milvus/internal/util/bloomfilter"
 	"github.com/milvus-io/milvus/internal/util/indexparamcheck"
 	"github.com/milvus-io/milvus/internal/util/vecindexmgr"
 	"github.com/milvus-io/milvus/pkg/v2/common"
@@ -78,6 +80,9 @@ type Loader interface {
 	// NOTE: make sure the ref count of the corresponding collection will never go down to 0 during this
 	Load(ctx context.Context, collectionID int64, segmentType SegmentType, version int64, segments ...*querypb.SegmentLoadInfo) ([]Segment, error)
 
+	// GetPkStatsMmapManager returns the shared bloom filter mmap manager.
+	GetPkStatsMmapManager() *bloomfilter.PkStatsMmapManager
+
 	// LoadDeltaLogs load deltalog and write delta data into provided segment.
 	// it also executes resource protection logic in case of OOM.
 	LoadDeltaLogs(ctx context.Context, segment Segment, loadInfo *querypb.SegmentLoadInfo) error
@@ -102,6 +107,9 @@ type Loader interface {
 	ReopenSegments(ctx context.Context,
 		loadInfos []*querypb.SegmentLoadInfo,
 	) error
+
+	// Close releases resources held by the loader.
+	Close()
 }
 
 type ResourceEstimate struct {
@@ -185,12 +193,21 @@ func NewLoader(
 	duf := NewDiskUsageFetcher(ctx)
 	go duf.Start()
 
+	fileBacked := paramtable.Get().CommonCfg.BloomFilterMmapEnabled.GetAsBool()
+	mmapDir := paramtable.Get().QueryNodeCfg.MmapDirPath.GetValue()
+	if mmapDir == "" {
+		mmapDir = filepath.Join(paramtable.Get().ServiceParam.LocalStorageCfg.Path.GetValue(), "bf_mmap")
+	}
+	pkStatsMmapMgr := bloomfilter.NewPkStatsMmapManager(mmapDir, fileBacked)
+	log.Info("bloom filter manager created", zap.Bool("fileBacked", fileBacked), zap.String("mmapDir", mmapDir))
+
 	loader := &segmentLoader{
 		manager:                   manager,
 		cm:                        cm,
 		loadingSegments:           typeutil.NewConcurrentMap[int64, *loadResult](),
 		committedResourceNotifier: syncutil.NewVersionedNotifier(),
 		duf:                       duf,
+		pkStatsMmapMgr:            pkStatsMmapMgr,
 	}
 
 	return loader
@@ -235,6 +252,8 @@ type segmentLoader struct {
 	committedResourceNotifier *syncutil.VersionedNotifier
 
 	duf *diskUsageFetcher
+
+	pkStatsMmapMgr *bloomfilter.PkStatsMmapManager
 }
 
 var _ Loader = (*segmentLoader)(nil)
@@ -766,7 +785,11 @@ func (loader *segmentLoader) LoadBloomFilterSet(ctx context.Context, collectionI
 
 	err := funcutil.ProcessFuncParallel(segmentNum, segmentNum, loadRemoteFunc, "loadRemoteFunc")
 	if err != nil {
-		// no partial success here
+		// Refund any successfully loaded bloom filters to release mmap references.
+		loadedBfs.Range(func(bfs *pkoracle.BloomFilterSet) bool {
+			bfs.Refund()
+			return true
+		})
 		log.Warn("failed to load remote segment", zap.Error(err))
 		return nil, err
 	}
@@ -1128,6 +1151,33 @@ func (loader *segmentLoader) loadBloomFilter(ctx context.Context, segmentID int6
 	}
 
 	startTs := time.Now()
+	cacheKey := binlogPaths[0]
+
+	// Fast path: if this segment's BF data is already in the manager
+	// (e.g. delegator loaded it first), reuse without downloading from S3.
+	if cachedData, ok := loader.pkStatsMmapMgr.TryAddRef(cacheKey); ok {
+		mmapStats, err := storage.DeserializeBinaryStats(cachedData)
+		if err == nil {
+			var size uint
+			for _, stat := range mmapStats {
+				pkStat := &storage.PkStatistics{
+					PkFilter: stat.BF,
+					MinPK:    stat.MinPk,
+					MaxPK:    stat.MaxPk,
+				}
+				size += stat.BF.Cap()
+				bfs.AddHistoricalStats(pkStat)
+			}
+			bfs.SetMmapPaths(cacheKey)
+			bfs.SetMmapManager(loader.pkStatsMmapMgr)
+			log.Info("Reused cached pk stats", zap.Duration("time", time.Since(startTs)), zap.Uint("size", size))
+			return nil
+		}
+		loader.pkStatsMmapMgr.Release(cacheKey)
+		log.Warn("failed to deserialize cached stats, reloading from storage", zap.Error(err))
+	}
+
+	// Normal path: download from storage and deserialize
 	values, err := loader.cm.MultiRead(ctx, binlogPaths)
 	if err != nil {
 		return err
@@ -1143,6 +1193,31 @@ func (loader *segmentLoader) loadBloomFilter(ctx context.Context, segmentID int6
 		return err
 	}
 
+	// Convert in-heap BFs to manager-backed BFs (file-mmap or memory-dedup).
+	// Serialize to local binary format, store via manager, then re-deserialize
+	// to get MmapBloomFilter instances pointing to the shared data.
+	if len(stats) > 0 && allBlockedBF(stats) {
+		binaryData, serErr := storage.SerializeBinaryStats(stats)
+		if serErr == nil {
+			sharedData, loadErr := loader.pkStatsMmapMgr.GetOrLoad(cacheKey, binaryData)
+			if loadErr == nil {
+				sharedStats, desErr := storage.DeserializeBinaryStats(sharedData)
+				if desErr == nil {
+					stats = sharedStats
+					bfs.SetMmapPaths(cacheKey)
+					bfs.SetMmapManager(loader.pkStatsMmapMgr)
+				} else {
+					loader.pkStatsMmapMgr.Release(cacheKey)
+					log.Warn("failed to deserialize binary stats, using heap", zap.Error(desErr))
+				}
+			} else {
+				log.Warn("failed to store stats in manager, using heap", zap.Error(loadErr))
+			}
+		} else {
+			log.Warn("failed to serialize stats to binary, using heap", zap.Error(serErr))
+		}
+	}
+
 	var size uint
 	for _, stat := range stats {
 		pkStat := &storage.PkStatistics{
@@ -1155,6 +1230,28 @@ func (loader *segmentLoader) loadBloomFilter(ctx context.Context, segmentID int6
 	}
 	log.Info("Successfully load pk stats", zap.Duration("time", time.Since(startTs)), zap.Uint("size", size))
 	return nil
+}
+
+// allBlockedBF returns true if every stat in the slice uses BlockedBF type.
+func allBlockedBF(stats []*storage.PrimaryKeyStats) bool {
+	for _, s := range stats {
+		if s.BFType != bloomfilter.BlockedBF {
+			return false
+		}
+	}
+	return true
+}
+
+// GetPkStatsMmapManager returns the bloom filter mmap manager for shared access.
+func (loader *segmentLoader) GetPkStatsMmapManager() *bloomfilter.PkStatsMmapManager {
+	return loader.pkStatsMmapMgr
+}
+
+// Close releases resources held by the segment loader.
+func (loader *segmentLoader) Close() {
+	if loader.pkStatsMmapMgr != nil {
+		loader.pkStatsMmapMgr.Close()
+	}
 }
 
 // loadDeltalogs performs the internal actions of `LoadDeltaLogs`

--- a/internal/querynodev2/server.go
+++ b/internal/querynodev2/server.go
@@ -520,8 +520,17 @@ func (node *QueryNode) Stop() error {
 		if node.dispClient != nil {
 			node.dispClient.Close()
 		}
+		if node.delegators != nil {
+			node.delegators.Range(func(_ string, sd delegator.ShardDelegator) bool {
+				sd.Close()
+				return true
+			})
+		}
 		if node.manager != nil {
 			node.manager.Segment.Clear(context.Background())
+		}
+		if node.loader != nil {
+			node.loader.Close()
 		}
 
 		node.CloseSegcore()

--- a/internal/storage/binary_stats_test.go
+++ b/internal/storage/binary_stats_test.go
@@ -1,0 +1,273 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/util/bloomfilter"
+	"github.com/milvus-io/milvus/pkg/v2/common"
+)
+
+func TestIsBinaryStatsFormat(t *testing.T) {
+	assert.False(t, IsBinaryStatsFormat(nil))
+	assert.False(t, IsBinaryStatsFormat([]byte{}))
+	assert.False(t, IsBinaryStatsFormat([]byte(`[{"fieldID":100}]`)))
+	assert.True(t, IsBinaryStatsFormat([]byte("mpkstats"+"xxxxxxxx")))
+}
+
+func TestSerializeDeserializeBinaryStats_Int64(t *testing.T) {
+	// Build a bloom filter with known data
+	bf := bloomfilter.NewBloomFilterWithType(10000, 0.001, "BlockedBloomFilter")
+
+	// Add some int64 PKs
+	numKeys := 100
+	for i := 0; i < numKeys; i++ {
+		key := make([]byte, 8)
+		common.Endian.PutUint64(key, uint64(i))
+		bf.Add(key)
+	}
+
+	stats := []*PrimaryKeyStats{
+		{
+			FieldID: 100,
+			PkType:  int64(schemapb.DataType_Int64),
+			BFType:  bloomfilter.BlockedBF,
+			BF:      bf,
+			MinPk:   NewInt64PrimaryKey(0),
+			MaxPk:   NewInt64PrimaryKey(int64(numKeys - 1)),
+		},
+	}
+
+	// Serialize to binary
+	data, err := SerializeBinaryStats(stats)
+	require.NoError(t, err)
+	require.NotNil(t, data)
+
+	// Verify magic
+	assert.True(t, IsBinaryStatsFormat(data))
+
+	// Deserialize
+	result, err := DeserializeBinaryStats(data)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+
+	r := result[0]
+	assert.Equal(t, int64(100), r.FieldID)
+	assert.Equal(t, int64(schemapb.DataType_Int64), r.PkType)
+	assert.Equal(t, bloomfilter.BlockedBF, r.BFType)
+
+	// Verify min/max PK
+	assert.Equal(t, int64(0), r.MinPk.(*Int64PrimaryKey).Value)
+	assert.Equal(t, int64(numKeys-1), r.MaxPk.(*Int64PrimaryKey).Value)
+
+	// Verify bloom filter correctness
+	for i := 0; i < numKeys; i++ {
+		key := make([]byte, 8)
+		common.Endian.PutUint64(key, uint64(i))
+		assert.True(t, r.BF.Test(key), "key %d should be found", i)
+	}
+
+	// Verify false positive rate
+	falsePositives := 0
+	for i := numKeys; i < numKeys+10000; i++ {
+		key := make([]byte, 8)
+		common.Endian.PutUint64(key, uint64(i))
+		if r.BF.Test(key) {
+			falsePositives++
+		}
+	}
+	assert.Less(t, falsePositives, 20, "too many false positives: %d/10000", falsePositives)
+}
+
+func TestSerializeDeserializeBinaryStats_VarChar(t *testing.T) {
+	bf := bloomfilter.NewBloomFilterWithType(10000, 0.001, "BlockedBloomFilter")
+
+	strings := []string{"apple", "banana", "cherry", "date", "elderberry"}
+	for _, s := range strings {
+		bf.AddString(s)
+	}
+
+	stats := []*PrimaryKeyStats{
+		{
+			FieldID: 200,
+			PkType:  int64(schemapb.DataType_VarChar),
+			BFType:  bloomfilter.BlockedBF,
+			BF:      bf,
+			MinPk:   NewVarCharPrimaryKey("apple"),
+			MaxPk:   NewVarCharPrimaryKey("elderberry"),
+		},
+	}
+
+	data, err := SerializeBinaryStats(stats)
+	require.NoError(t, err)
+
+	result, err := DeserializeBinaryStats(data)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+
+	r := result[0]
+	assert.Equal(t, int64(200), r.FieldID)
+	assert.Equal(t, int64(schemapb.DataType_VarChar), r.PkType)
+	assert.Equal(t, "apple", r.MinPk.(*VarCharPrimaryKey).Value)
+	assert.Equal(t, "elderberry", r.MaxPk.(*VarCharPrimaryKey).Value)
+
+	// Verify bloom filter correctness
+	for _, s := range strings {
+		assert.True(t, r.BF.TestString(s), "string %q should be found", s)
+	}
+}
+
+func TestSerializeDeserializeBinaryStats_VarChar_LongKeys(t *testing.T) {
+	bf := bloomfilter.NewBloomFilterWithType(10000, 0.001, "BlockedBloomFilter")
+
+	// Use PKs that exceed the old 48-byte limit (56 bytes minus two 4-byte length headers)
+	longMin := "this-is-a-very-long-primary-key-value-that-exceeds-the-old-48-byte-limit-for-varchar-pks"
+	longMax := "ZZZZ-another-very-long-primary-key-value-that-would-be-truncated-in-the-old-fixed-buffer"
+	bf.AddString(longMin)
+	bf.AddString(longMax)
+
+	stats := []*PrimaryKeyStats{
+		{
+			FieldID: 200,
+			PkType:  int64(schemapb.DataType_VarChar),
+			BFType:  bloomfilter.BlockedBF,
+			BF:      bf,
+			MinPk:   NewVarCharPrimaryKey(longMin),
+			MaxPk:   NewVarCharPrimaryKey(longMax),
+		},
+	}
+
+	data, err := SerializeBinaryStats(stats)
+	require.NoError(t, err)
+
+	result, err := DeserializeBinaryStats(data)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+
+	r := result[0]
+	assert.Equal(t, longMin, r.MinPk.(*VarCharPrimaryKey).Value)
+	assert.Equal(t, longMax, r.MaxPk.(*VarCharPrimaryKey).Value)
+
+	// Verify bloom filter correctness
+	assert.True(t, r.BF.TestString(longMin))
+	assert.True(t, r.BF.TestString(longMax))
+}
+
+func TestSerializeDeserializeBinaryStats_MultiEntry(t *testing.T) {
+	// Create multiple entries
+	stats := make([]*PrimaryKeyStats, 3)
+	for idx := 0; idx < 3; idx++ {
+		bf := bloomfilter.NewBloomFilterWithType(5000, 0.001, "BlockedBloomFilter")
+		base := idx * 1000
+		for i := 0; i < 1000; i++ {
+			key := make([]byte, 8)
+			binary.LittleEndian.PutUint64(key, uint64(base+i))
+			bf.Add(key)
+		}
+		stats[idx] = &PrimaryKeyStats{
+			FieldID: 100,
+			PkType:  int64(schemapb.DataType_Int64),
+			BFType:  bloomfilter.BlockedBF,
+			BF:      bf,
+			MinPk:   NewInt64PrimaryKey(int64(base)),
+			MaxPk:   NewInt64PrimaryKey(int64(base + 999)),
+		}
+	}
+
+	data, err := SerializeBinaryStats(stats)
+	require.NoError(t, err)
+
+	result, err := DeserializeBinaryStats(data)
+	require.NoError(t, err)
+	require.Len(t, result, 3)
+
+	// Verify each entry
+	for idx, r := range result {
+		base := idx * 1000
+		assert.Equal(t, int64(base), r.MinPk.(*Int64PrimaryKey).Value)
+		assert.Equal(t, int64(base+999), r.MaxPk.(*Int64PrimaryKey).Value)
+
+		// Check bloom filter
+		for i := 0; i < 1000; i++ {
+			key := make([]byte, 8)
+			binary.LittleEndian.PutUint64(key, uint64(base+i))
+			assert.True(t, r.BF.Test(key), "entry %d, key %d should be found", idx, base+i)
+		}
+	}
+}
+
+func TestDeserializeStatsList_AutoDetectBinary(t *testing.T) {
+	bf := bloomfilter.NewBloomFilterWithType(10000, 0.001, "BlockedBloomFilter")
+
+	key := make([]byte, 8)
+	common.Endian.PutUint64(key, uint64(42))
+	bf.Add(key)
+
+	stats := []*PrimaryKeyStats{
+		{
+			FieldID: 100,
+			PkType:  int64(schemapb.DataType_Int64),
+			BFType:  bloomfilter.BlockedBF,
+			BF:      bf,
+			MinPk:   NewInt64PrimaryKey(42),
+			MaxPk:   NewInt64PrimaryKey(42),
+		},
+	}
+
+	// Serialize to binary
+	data, err := SerializeBinaryStats(stats)
+	require.NoError(t, err)
+
+	// Use DeserializeStatsList which should auto-detect binary format
+	result, err := DeserializeStatsList(&Blob{Value: data})
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.True(t, result[0].BF.Test(key))
+}
+
+func TestSerializeBinaryStats_Empty(t *testing.T) {
+	_, err := SerializeBinaryStats(nil)
+	assert.Error(t, err)
+
+	_, err = SerializeBinaryStats([]*PrimaryKeyStats{})
+	assert.Error(t, err)
+}
+
+func TestDeserializeBinaryStats_InvalidData(t *testing.T) {
+	// Too short
+	_, err := DeserializeBinaryStats([]byte("short"))
+	assert.Error(t, err)
+
+	// Wrong magic
+	data := make([]byte, BinaryFileHeaderSize)
+	copy(data[:8], "wrongmgc")
+	_, err = DeserializeBinaryStats(data)
+	assert.Error(t, err)
+
+	// Wrong version
+	data2 := make([]byte, BinaryFileHeaderSize)
+	copy(data2[:8], BinaryStatsMagic)
+	binary.LittleEndian.PutUint32(data2[8:12], 99) // bad version
+	_, err = DeserializeBinaryStats(data2)
+	assert.Error(t, err)
+}

--- a/internal/storage/stats.go
+++ b/internal/storage/stats.go
@@ -19,6 +19,7 @@ package storage
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"io"
 	"maps"
 	"math"
@@ -536,6 +537,9 @@ func DeserializeStatsList(blob *Blob) ([]*PrimaryKeyStats, error) {
 	if len(blob.Value) == 0 {
 		return []*PrimaryKeyStats{}, nil
 	}
+	if IsBinaryStatsFormat(blob.Value) {
+		return DeserializeBinaryStats(blob.Value)
+	}
 	sr := &StatsReader{}
 	sr.SetBuffer(blob.Value)
 	stats, err := sr.GetPrimaryKeyStatsList()
@@ -543,4 +547,268 @@ func DeserializeStatsList(blob *Blob) ([]*PrimaryKeyStats, error) {
 		return nil, err
 	}
 	return stats, nil
+}
+
+// Binary stats format constants
+const (
+	BinaryStatsMagic      = "mpkstats"
+	BinaryStatsVersion    = uint32(1)
+	BinaryFileHeaderSize  = 64
+	BinaryEntryHeaderSize = 64
+	BinaryBlockSize       = 64 // 16 uint32 × 4 bytes
+)
+
+// IsBinaryStatsFormat checks if the data starts with the binary stats magic number.
+func IsBinaryStatsFormat(data []byte) bool {
+	return len(data) >= 8 && string(data[:8]) == BinaryStatsMagic
+}
+
+// SerializeBinaryStats serializes a list of PrimaryKeyStats into the binary format.
+//
+// File Header (64 bytes):
+//
+//	[0:8]    magic    "mpkstats"
+//	[8:12]   version  uint32 LE (= 1)
+//	[12:16]  numEntries  uint32 LE
+//	[16:20]  pkType   uint32 LE
+//	[20:24]  fieldID  int32 LE
+//	[24:64]  reserved
+//
+// For each entry:
+//
+//	Entry Header (64 bytes):
+//	  [0:4]    numBlocks  uint32 LE
+//	  [4:8]    k          uint32 LE (hash function count)
+//	  For Int64:
+//	    [8:16]   minPk  int64 LE
+//	    [16:24]  maxPk  int64 LE
+//	    [24:64]  reserved
+//	  For VarChar:
+//	    [8:12]   pkDataSize uint32 LE (total bytes of PK data after header)
+//	    [12:64]  reserved
+//	VarChar PK Data (variable length, only present for VarChar):
+//	  [4-byte minLen][minData...][4-byte maxLen][maxData...]
+//	BF Data:
+//	  numBlocks × 64 bytes
+func SerializeBinaryStats(stats []*PrimaryKeyStats) ([]byte, error) {
+	if len(stats) == 0 {
+		return nil, errors.New("cannot serialize empty stats list")
+	}
+
+	// Calculate total size
+	totalSize := BinaryFileHeaderSize
+	for _, s := range stats {
+		numBlocks := uint32(s.BF.Cap() / 512)
+		entrySize := BinaryEntryHeaderSize + int(numBlocks)*BinaryBlockSize
+		if schemapb.DataType(s.PkType) == schemapb.DataType_VarChar {
+			entrySize += varCharPKDataSize(s.MinPk, s.MaxPk)
+		}
+		totalSize += entrySize
+	}
+
+	buf := make([]byte, totalSize)
+
+	// Write file header
+	copy(buf[0:8], BinaryStatsMagic)
+	binary.LittleEndian.PutUint32(buf[8:12], BinaryStatsVersion)
+	binary.LittleEndian.PutUint32(buf[12:16], uint32(len(stats)))
+	binary.LittleEndian.PutUint32(buf[16:20], uint32(stats[0].PkType))
+	binary.LittleEndian.PutUint32(buf[20:24], uint32(stats[0].FieldID))
+
+	offset := BinaryFileHeaderSize
+	for _, s := range stats {
+		numBlocks := uint32(s.BF.Cap() / 512)
+		k := uint32(s.BF.K())
+
+		// Write entry header
+		binary.LittleEndian.PutUint32(buf[offset:offset+4], numBlocks)
+		binary.LittleEndian.PutUint32(buf[offset+4:offset+8], k)
+
+		// Write min/max PK
+		switch schemapb.DataType(s.PkType) {
+		case schemapb.DataType_Int64:
+			pkOff := offset + 8
+			if s.MinPk != nil {
+				binary.LittleEndian.PutUint64(buf[pkOff:pkOff+8], uint64(s.MinPk.(*Int64PrimaryKey).Value))
+			}
+			if s.MaxPk != nil {
+				binary.LittleEndian.PutUint64(buf[pkOff+8:pkOff+16], uint64(s.MaxPk.(*Int64PrimaryKey).Value))
+			}
+			offset += BinaryEntryHeaderSize
+		case schemapb.DataType_VarChar:
+			pkSize := varCharPKDataSize(s.MinPk, s.MaxPk)
+			binary.LittleEndian.PutUint32(buf[offset+8:offset+12], uint32(pkSize))
+			offset += BinaryEntryHeaderSize
+			writeVarCharPK(buf[offset:offset+pkSize], s.MinPk, s.MaxPk)
+			offset += pkSize
+		default:
+			offset += BinaryEntryHeaderSize
+		}
+
+		// Write BF block data - marshal from the bloom filter
+		if err := marshalBFBlocks(buf[offset:offset+int(numBlocks)*BinaryBlockSize], s.BF); err != nil {
+			return nil, fmt.Errorf("failed to marshal BF blocks for entry: %w", err)
+		}
+		offset += int(numBlocks) * BinaryBlockSize
+	}
+
+	return buf, nil
+}
+
+// varCharPKDataSize returns the total bytes needed to encode min and max VarChar PKs.
+func varCharPKDataSize(minPk, maxPk PrimaryKey) int {
+	size := 8 // two 4-byte length headers
+	if minPk != nil {
+		size += len(minPk.(*VarCharPrimaryKey).Value)
+	}
+	if maxPk != nil {
+		size += len(maxPk.(*VarCharPrimaryKey).Value)
+	}
+	return size
+}
+
+// writeVarCharPK writes min and max VarChar PKs into the provided buffer.
+// Layout: [4-byte minLen][minData...][4-byte maxLen][maxData...]
+// The buffer must be large enough to hold all PK data.
+func writeVarCharPK(buf []byte, minPk, maxPk PrimaryKey) {
+	off := 0
+	if minPk != nil {
+		s := minPk.(*VarCharPrimaryKey).Value
+		binary.LittleEndian.PutUint32(buf[off:off+4], uint32(len(s)))
+		off += 4
+		copy(buf[off:off+len(s)], s)
+		off += len(s)
+	} else {
+		binary.LittleEndian.PutUint32(buf[off:off+4], 0)
+		off += 4
+	}
+	if maxPk != nil {
+		s := maxPk.(*VarCharPrimaryKey).Value
+		binary.LittleEndian.PutUint32(buf[off:off+4], uint32(len(s)))
+		off += 4
+		copy(buf[off:off+len(s)], s)
+	} else {
+		binary.LittleEndian.PutUint32(buf[off:off+4], 0)
+	}
+}
+
+// marshalBFBlocks serializes a bloom filter's block data into the provided buffer.
+// Uses blobloom's Dump format to extract block data.
+func marshalBFBlocks(dst []byte, bf bloomfilter.BloomFilterInterface) error {
+	if bf.Type() != bloomfilter.BlockedBF {
+		return fmt.Errorf("binary stats format only supports BlockedBF, got %v", bf.Type())
+	}
+
+	blockData, err := bloomfilter.DumpBlockData(bf)
+	if err != nil {
+		return err
+	}
+	copy(dst, blockData)
+	return nil
+}
+
+// DeserializeBinaryStats parses binary stats format and creates MmapBloomFilter instances.
+// The data can be mmap'd memory, and MmapBloomFilter will reference it directly (zero-copy).
+func DeserializeBinaryStats(data []byte) ([]*PrimaryKeyStats, error) {
+	if len(data) < BinaryFileHeaderSize {
+		return nil, errors.New("binary stats data too short for header")
+	}
+
+	if string(data[:8]) != BinaryStatsMagic {
+		return nil, errors.New("invalid binary stats magic")
+	}
+
+	version := binary.LittleEndian.Uint32(data[8:12])
+	if version != BinaryStatsVersion {
+		return nil, fmt.Errorf("unsupported binary stats version: %d", version)
+	}
+
+	numEntries := binary.LittleEndian.Uint32(data[12:16])
+	pkType := int64(binary.LittleEndian.Uint32(data[16:20]))
+	fieldID := int64(int32(binary.LittleEndian.Uint32(data[20:24])))
+
+	results := make([]*PrimaryKeyStats, 0, numEntries)
+	offset := BinaryFileHeaderSize
+
+	for i := uint32(0); i < numEntries; i++ {
+		if offset+BinaryEntryHeaderSize > len(data) {
+			return nil, fmt.Errorf("binary stats data truncated at entry %d", i)
+		}
+
+		numBlocks := binary.LittleEndian.Uint32(data[offset : offset+4])
+		k := int(binary.LittleEndian.Uint32(data[offset+4 : offset+8]))
+
+		// Parse min/max PK
+		var minPk, maxPk PrimaryKey
+		var pkDataSize int
+
+		switch schemapb.DataType(pkType) {
+		case schemapb.DataType_Int64:
+			pkOff := offset + 8
+			minVal := int64(binary.LittleEndian.Uint64(data[pkOff : pkOff+8]))
+			maxVal := int64(binary.LittleEndian.Uint64(data[pkOff+8 : pkOff+16]))
+			minPk = NewInt64PrimaryKey(minVal)
+			maxPk = NewInt64PrimaryKey(maxVal)
+		case schemapb.DataType_VarChar:
+			pkDataSize = int(binary.LittleEndian.Uint32(data[offset+8 : offset+12]))
+			pkStart := offset + BinaryEntryHeaderSize
+			if pkStart+pkDataSize > len(data) {
+				return nil, fmt.Errorf("binary stats data truncated at entry %d VarChar PK data", i)
+			}
+			var err error
+			minPk, maxPk, err = readVarCharPKs(data[pkStart : pkStart+pkDataSize])
+			if err != nil {
+				return nil, fmt.Errorf("failed to read VarChar PKs at entry %d: %w", i, err)
+			}
+		}
+
+		dataOffset := offset + BinaryEntryHeaderSize + pkDataSize
+		dataEnd := dataOffset + int(numBlocks)*BinaryBlockSize
+		if dataEnd > len(data) {
+			return nil, fmt.Errorf("binary stats data truncated at entry %d block data", i)
+		}
+
+		// Create MmapBloomFilter directly referencing the data slice
+		bf := bloomfilter.NewMmapBloomFilter(data, dataOffset, numBlocks, k)
+
+		results = append(results, &PrimaryKeyStats{
+			FieldID: fieldID,
+			PkType:  pkType,
+			BFType:  bloomfilter.BlockedBF,
+			BF:      bf,
+			MinPk:   minPk,
+			MaxPk:   maxPk,
+		})
+
+		offset = dataEnd
+	}
+
+	return results, nil
+}
+
+// readVarCharPKs reads min and max VarChar primary keys from the buffer.
+func readVarCharPKs(buf []byte) (PrimaryKey, PrimaryKey, error) {
+	off := 0
+	if off+4 > len(buf) {
+		return nil, nil, errors.New("buffer too short for minPk length")
+	}
+	minLen := int(binary.LittleEndian.Uint32(buf[off : off+4]))
+	off += 4
+	if off+minLen > len(buf) {
+		return nil, nil, errors.New("buffer too short for minPk data")
+	}
+	minPk := NewVarCharPrimaryKey(string(buf[off : off+minLen]))
+	off += minLen
+
+	if off+4 > len(buf) {
+		return nil, nil, errors.New("buffer too short for maxPk length")
+	}
+	maxLen := int(binary.LittleEndian.Uint32(buf[off : off+4]))
+	off += 4
+	if off+maxLen > len(buf) {
+		return nil, nil, errors.New("buffer too short for maxPk data")
+	}
+	maxPk := NewVarCharPrimaryKey(string(buf[off : off+maxLen]))
+
+	return minPk, maxPk, nil
 }

--- a/internal/util/bloomfilter/bloom_filter.go
+++ b/internal/util/bloomfilter/bloom_filter.go
@@ -16,6 +16,8 @@
 package bloomfilter
 
 import (
+	"bytes"
+
 	"github.com/bits-and-blooms/bloom/v3"
 	"github.com/cockroachdb/errors"
 	"github.com/greatroar/blobloom"
@@ -336,4 +338,39 @@ func Locations(data []byte, k uint, bfType BFType) []uint64 {
 		log.Info("unsupported bloom filter type, using block bloom filter", zap.String("type", bfType.String()))
 		return nil
 	}
+}
+
+// blobloomHeaderSize is the size of blobloom's binary Dump header.
+const blobloomHeaderSize = 64
+
+// blobloomMagic is the expected magic bytes at the start of blobloom's Dump output.
+const blobloomMagic = "blobloom"
+
+// DumpBlockData extracts the raw block data from a BlockedBF bloom filter.
+// Uses blobloom's Dump function to get the binary representation, then strips the 64-byte header.
+// Returns the raw block data (numBlocks × 64 bytes).
+func DumpBlockData(bf BloomFilterInterface) ([]byte, error) {
+	bbf, ok := bf.(*blockedBloomFilter)
+	if !ok {
+		return nil, errors.New("DumpBlockData only supports blockedBloomFilter")
+	}
+
+	var buf bytes.Buffer
+	_, err := blobloom.Dump(&buf, bbf.inner, "")
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to dump bloom filter")
+	}
+
+	raw := buf.Bytes()
+	if len(raw) < blobloomHeaderSize {
+		return nil, errors.New("dump output too short")
+	}
+
+	// Validate the magic bytes to detect blobloom format changes
+	if string(raw[:len(blobloomMagic)]) != blobloomMagic {
+		return nil, errors.Errorf("unexpected blobloom dump header magic: %q", string(raw[:8]))
+	}
+
+	// Strip the 64-byte blobloom header, return only block data
+	return raw[blobloomHeaderSize:], nil
 }

--- a/internal/util/bloomfilter/mmap_bloom_filter.go
+++ b/internal/util/bloomfilter/mmap_bloom_filter.go
@@ -1,0 +1,146 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package bloomfilter
+
+import (
+	"encoding/binary"
+
+	"github.com/zeebo/xxh3"
+)
+
+const (
+	bfWordSize   = 32
+	bfBlockWords = 16 // BlockBits(512) / wordSize(32)
+	bfBlockBytes = bfBlockWords * 4
+)
+
+// MmapBloomFilter is a read-only bloom filter backed by mmap'd memory.
+// It implements BloomFilterInterface for testing operations only.
+// Add operations will panic since this is a read-only view.
+type MmapBloomFilter struct {
+	data      []byte // mmap'd memory region containing BF block data
+	offset    int    // start offset of block data within data
+	numBlocks uint32 // number of 512-bit blocks
+	k         int    // number of hash functions
+}
+
+// NewMmapBloomFilter creates a new MmapBloomFilter from mmap'd data.
+// data is the mmap'd memory, offset is where the block data starts,
+// numBlocks is the number of 512-bit blocks, and k is the hash count.
+func NewMmapBloomFilter(data []byte, offset int, numBlocks uint32, k int) *MmapBloomFilter {
+	return &MmapBloomFilter{
+		data:      data,
+		offset:    offset,
+		numBlocks: numBlocks,
+		k:         k,
+	}
+}
+
+func (m *MmapBloomFilter) Type() BFType {
+	return BlockedBF
+}
+
+func (m *MmapBloomFilter) Cap() uint {
+	return uint(m.numBlocks) * 512 // BlockBits per block
+}
+
+func (m *MmapBloomFilter) K() uint {
+	return uint(m.k)
+}
+
+func (m *MmapBloomFilter) Add(_ []byte) {
+	panic("MmapBloomFilter is read-only, Add not supported")
+}
+
+func (m *MmapBloomFilter) AddString(_ string) {
+	panic("MmapBloomFilter is read-only, AddString not supported")
+}
+
+func (m *MmapBloomFilter) Test(data []byte) bool {
+	h := xxh3.Hash(data)
+	return m.testHash(h)
+}
+
+func (m *MmapBloomFilter) TestString(data string) bool {
+	h := xxh3.HashString(data)
+	return m.testHash(h)
+}
+
+func (m *MmapBloomFilter) TestLocations(locs []uint64) bool {
+	if len(locs) != 1 {
+		return true
+	}
+	return m.testHash(locs[0])
+}
+
+func (m *MmapBloomFilter) BatchTestLocations(locs [][]uint64, hits []bool) []bool {
+	ret := make([]bool, len(locs))
+	n := len(hits)
+	if len(locs) < n {
+		n = len(locs)
+	}
+	for i := 0; i < n; i++ {
+		if !hits[i] {
+			if len(locs[i]) != 1 {
+				ret[i] = true
+				continue
+			}
+			ret[i] = m.testHash(locs[i][0])
+		}
+	}
+	return ret
+}
+
+func (m *MmapBloomFilter) MarshalJSON() ([]byte, error) {
+	panic("MmapBloomFilter is read-only, MarshalJSON not supported")
+}
+
+func (m *MmapBloomFilter) UnmarshalJSON(_ []byte) error {
+	panic("MmapBloomFilter is read-only, UnmarshalJSON not supported")
+}
+
+// testHash implements the blocked bloom filter Has logic, directly reading
+// from the mmap'd byte slice. This mirrors blobloom's Filter.Has().
+func (m *MmapBloomFilter) testHash(h uint64) bool {
+	h1, h2 := uint32(h>>32), uint32(h)
+	blockIdx := reducerange(h2, m.numBlocks)
+	blockOff := m.offset + int(blockIdx)*bfBlockBytes
+
+	for i := 1; i < m.k; i++ {
+		h1, h2 = doublehash(h1, h2, i)
+		wordIdx := (h1 / bfWordSize) % bfBlockWords
+		bitPos := h1 % bfWordSize
+		word := binary.LittleEndian.Uint32(m.data[blockOff+int(wordIdx)*4:])
+		if word&(1<<bitPos) == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// reducerange maps i to an integer in the range [0,n).
+// https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/
+func reducerange(i, n uint32) uint32 {
+	return uint32((uint64(i) * uint64(n)) >> 32)
+}
+
+// doublehash generates the hash values for enhanced double hashing.
+// See https://www.ccs.neu.edu/home/pete/pub/bloom-filters-verification.pdf
+func doublehash(h1, h2 uint32, i int) (uint32, uint32) {
+	h1 = h1 + h2
+	h2 = h2 + uint32(i)
+	return h1, h2
+}

--- a/internal/util/bloomfilter/mmap_bloom_filter_test.go
+++ b/internal/util/bloomfilter/mmap_bloom_filter_test.go
@@ -1,0 +1,224 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package bloomfilter
+
+import (
+	"encoding/binary"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zeebo/xxh3"
+)
+
+// buildBinaryFromBlockedBF converts a blockedBloomFilter to binary block data
+// and returns (data, numBlocks, k) for constructing a MmapBloomFilter.
+func buildBinaryFromBlockedBF(t *testing.T, bf *blockedBloomFilter) ([]byte, uint32, int) {
+	data, err := DumpBlockData(bf)
+	require.NoError(t, err)
+
+	numBlocks := uint32(len(data) / bfBlockBytes)
+	k := int(bf.K())
+
+	return data, numBlocks, k
+}
+
+func TestMmapBloomFilter_Consistency(t *testing.T) {
+	// Build a blocked bloom filter with known data
+	bf := newBlockedBloomFilter(10000, 0.001)
+
+	// Add a set of int64 keys
+	keys := make([][]byte, 1000)
+	for i := 0; i < 1000; i++ {
+		key := make([]byte, 8)
+		binary.LittleEndian.PutUint64(key, uint64(i))
+		bf.Add(key)
+		keys[i] = key
+	}
+
+	// Build MmapBloomFilter from the same data
+	data, numBlocks, k := buildBinaryFromBlockedBF(t, bf)
+	mmapBF := NewMmapBloomFilter(data, 0, numBlocks, k)
+
+	// Verify all added keys test positive in both
+	for i, key := range keys {
+		origResult := bf.Test(key)
+		mmapResult := mmapBF.Test(key)
+		assert.Equal(t, origResult, mmapResult, "key %d: original=%v, mmap=%v", i, origResult, mmapResult)
+		assert.True(t, mmapResult, "key %d should be found", i)
+	}
+
+	// Verify non-existent keys have same behavior
+	falsePositives := 0
+	for i := 1000; i < 2000; i++ {
+		key := make([]byte, 8)
+		binary.LittleEndian.PutUint64(key, uint64(i))
+		origResult := bf.Test(key)
+		mmapResult := mmapBF.Test(key)
+		assert.Equal(t, origResult, mmapResult, "non-existent key %d: original=%v, mmap=%v", i, origResult, mmapResult)
+		if mmapResult {
+			falsePositives++
+		}
+	}
+	// FPR should be reasonable (< 1% with our settings)
+	assert.Less(t, falsePositives, 20, "too many false positives: %d/1000", falsePositives)
+}
+
+func TestMmapBloomFilter_TestString(t *testing.T) {
+	bf := newBlockedBloomFilter(10000, 0.001)
+
+	strings := []string{"hello", "world", "foo", "bar", "milvus"}
+	for _, s := range strings {
+		bf.AddString(s)
+	}
+
+	data, numBlocks, k := buildBinaryFromBlockedBF(t, bf)
+	mmapBF := NewMmapBloomFilter(data, 0, numBlocks, k)
+
+	for _, s := range strings {
+		assert.Equal(t, bf.TestString(s), mmapBF.TestString(s), "string %q", s)
+		assert.True(t, mmapBF.TestString(s), "string %q should be found", s)
+	}
+}
+
+func TestMmapBloomFilter_TestLocations(t *testing.T) {
+	bf := newBlockedBloomFilter(10000, 0.001)
+
+	key := []byte("test_key")
+	bf.Add(key)
+
+	data, numBlocks, k := buildBinaryFromBlockedBF(t, bf)
+	mmapBF := NewMmapBloomFilter(data, 0, numBlocks, k)
+
+	h := xxh3.Hash(key)
+	locs := []uint64{h}
+
+	assert.Equal(t, bf.TestLocations(locs), mmapBF.TestLocations(locs))
+	assert.True(t, mmapBF.TestLocations(locs))
+
+	// Empty locs should return true (false positive by convention)
+	assert.True(t, mmapBF.TestLocations(nil))
+	assert.True(t, mmapBF.TestLocations([]uint64{h, 0})) // len != 1
+}
+
+func TestMmapBloomFilter_BatchTestLocations(t *testing.T) {
+	bf := newBlockedBloomFilter(10000, 0.001)
+
+	keys := make([][]byte, 100)
+	for i := 0; i < 100; i++ {
+		key := make([]byte, 8)
+		binary.LittleEndian.PutUint64(key, uint64(i))
+		bf.Add(key)
+		keys[i] = key
+	}
+
+	data, numBlocks, k := buildBinaryFromBlockedBF(t, bf)
+	mmapBF := NewMmapBloomFilter(data, 0, numBlocks, k)
+
+	locs := make([][]uint64, len(keys))
+	for i, key := range keys {
+		locs[i] = []uint64{xxh3.Hash(key)}
+	}
+
+	hits := make([]bool, len(keys))
+	origResult := bf.BatchTestLocations(locs, hits)
+
+	hits2 := make([]bool, len(keys))
+	mmapResult := mmapBF.BatchTestLocations(locs, hits2)
+
+	for i := range origResult {
+		assert.Equal(t, origResult[i], mmapResult[i], "batch result %d mismatch", i)
+	}
+}
+
+func TestMmapBloomFilter_Cap(t *testing.T) {
+	bf := newBlockedBloomFilter(10000, 0.001)
+	data, numBlocks, k := buildBinaryFromBlockedBF(t, bf)
+	mmapBF := NewMmapBloomFilter(data, 0, numBlocks, k)
+
+	assert.Equal(t, bf.Cap(), mmapBF.Cap())
+	assert.Equal(t, BlockedBF, mmapBF.Type())
+	assert.Equal(t, bf.K(), mmapBF.K())
+}
+
+func TestMmapBloomFilter_Offset(t *testing.T) {
+	// Test that MmapBloomFilter works with a non-zero offset
+	bf := newBlockedBloomFilter(10000, 0.001)
+
+	key := []byte("offset_test")
+	bf.Add(key)
+
+	rawData, numBlocks, k := buildBinaryFromBlockedBF(t, bf)
+
+	// Prepend some header data
+	header := make([]byte, 128)
+	copy(header, "some_header_data")
+	dataWithHeader := append(header, rawData...)
+
+	mmapBF := NewMmapBloomFilter(dataWithHeader, 128, numBlocks, k)
+	assert.True(t, mmapBF.Test(key))
+
+	// Should not find non-existent key
+	notFound := mmapBF.Test([]byte("not_in_filter"))
+	_ = notFound // may or may not be false positive
+}
+
+func TestMmapBloomFilter_ReadOnly(t *testing.T) {
+	bf := newBlockedBloomFilter(100, 0.01)
+	data, numBlocks, k := buildBinaryFromBlockedBF(t, bf)
+	mmapBF := NewMmapBloomFilter(data, 0, numBlocks, k)
+
+	assert.Panics(t, func() { mmapBF.Add([]byte("test")) })
+	assert.Panics(t, func() { mmapBF.AddString("test") })
+	assert.Panics(t, func() { mmapBF.MarshalJSON() })
+	assert.Panics(t, func() { mmapBF.UnmarshalJSON([]byte("{}")) })
+}
+
+func TestMmapBloomFilter_LargeScale(t *testing.T) {
+	// Test with larger data to ensure correctness at scale
+	bf := newBlockedBloomFilter(200000, 0.001)
+
+	numKeys := 100000
+	keys := make([][]byte, numKeys)
+	for i := 0; i < numKeys; i++ {
+		key := make([]byte, 8)
+		binary.LittleEndian.PutUint64(key, uint64(i))
+		bf.Add(key)
+		keys[i] = key
+	}
+
+	data, numBlocks, k := buildBinaryFromBlockedBF(t, bf)
+	mmapBF := NewMmapBloomFilter(data, 0, numBlocks, k)
+
+	// Sample check - verify 1000 random keys
+	for i := 0; i < numKeys; i += 100 {
+		assert.True(t, mmapBF.Test(keys[i]), "key %d should be found", i)
+	}
+
+	// Check some non-existent keys
+	mismatches := 0
+	for i := numKeys; i < numKeys+10000; i++ {
+		key := make([]byte, 8)
+		binary.LittleEndian.PutUint64(key, uint64(i))
+		if bf.Test(key) != mmapBF.Test(key) {
+			mismatches++
+		}
+	}
+	assert.Equal(t, 0, mismatches, "all non-existent key results should match")
+
+	fmt.Printf("MmapBF: numBlocks=%d, k=%d, cap=%d bits\n", numBlocks, k, mmapBF.Cap())
+}

--- a/internal/util/bloomfilter/mmap_manager.go
+++ b/internal/util/bloomfilter/mmap_manager.go
@@ -1,0 +1,238 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package bloomfilter
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/cockroachdb/errors"
+	"github.com/zeebo/xxh3"
+	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
+
+	"github.com/milvus-io/milvus/pkg/v2/log"
+)
+
+// mmapEntry holds a reference-counted data region (file-mmap or memory).
+type mmapEntry struct {
+	data     []byte // mmap'd region or in-memory buffer
+	refCount int32  // protected by PkStatsMmapManager.mu
+	fileSize int64
+	filePath string // local cache file path (empty for memory mode)
+}
+
+// PkStatsMmapManager manages bloom filter data with reference counting.
+// It supports two modes:
+//   - file-backed: writes data to a local file and mmaps it (off Go heap)
+//   - memory-backed: keeps data as a Go []byte (on heap, but deduplicated)
+//
+// Both modes share the same data across multiple callers via ref counting,
+// eliminating duplicate bloom filter copies (e.g. delegator + segment).
+type PkStatsMmapManager struct {
+	mu         sync.RWMutex
+	cacheDir   string
+	fileBacked bool
+	mappings   map[string]*mmapEntry // remotePath → entry
+}
+
+// NewPkStatsMmapManager creates a new manager.
+// If fileBacked is true, data is written to cacheDir and mmap'd (off Go heap).
+// If fileBacked is false, data is kept in memory (on Go heap, but deduplicated).
+func NewPkStatsMmapManager(cacheDir string, fileBacked bool) *PkStatsMmapManager {
+	return &PkStatsMmapManager{
+		cacheDir:   cacheDir,
+		fileBacked: fileBacked,
+		mappings:   make(map[string]*mmapEntry),
+	}
+}
+
+// GetOrLoad returns the data for a bloom filter identified by remotePath.
+// If already loaded, it increments the refcount and returns the existing data.
+// Otherwise, it stores the provided data (via file-mmap or in-memory) and returns it.
+func (m *PkStatsMmapManager) GetOrLoad(remotePath string, data []byte) ([]byte, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Fast path: already loaded, just bump refcount
+	if entry, ok := m.mappings[remotePath]; ok {
+		entry.refCount++
+		return entry.data, nil
+	}
+
+	if m.fileBacked {
+		return m.loadFileBacked(remotePath, data)
+	}
+	return m.loadMemoryBacked(remotePath, data)
+}
+
+// loadFileBacked writes data to a local file and mmaps it.
+// Caller must hold m.mu write lock.
+func (m *PkStatsMmapManager) loadFileBacked(remotePath string, data []byte) ([]byte, error) {
+	localPath := m.localCachePath(remotePath)
+
+	dir := filepath.Dir(localPath)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, errors.Wrapf(err, "failed to create cache directory %s", dir)
+	}
+
+	if err := os.WriteFile(localPath, data, 0o644); err != nil {
+		return nil, errors.Wrapf(err, "failed to write cache file %s", localPath)
+	}
+
+	mmapData, err := m.mmapFile(localPath, int64(len(data)))
+	if err != nil {
+		os.Remove(localPath)
+		return nil, err
+	}
+
+	entry := &mmapEntry{
+		data:     mmapData,
+		refCount: 1,
+		fileSize: int64(len(data)),
+		filePath: localPath,
+	}
+	m.mappings[remotePath] = entry
+
+	log.Info("file-mmap'd bloom filter",
+		zap.String("remotePath", remotePath),
+		zap.String("localPath", localPath),
+		zap.Int("size", len(data)))
+
+	return mmapData, nil
+}
+
+// loadMemoryBacked stores data directly in memory.
+// Caller must hold m.mu write lock.
+func (m *PkStatsMmapManager) loadMemoryBacked(remotePath string, data []byte) ([]byte, error) {
+	entry := &mmapEntry{
+		data:     data,
+		refCount: 1,
+		fileSize: int64(len(data)),
+	}
+	m.mappings[remotePath] = entry
+
+	log.Info("memory-cached bloom filter",
+		zap.String("remotePath", remotePath),
+		zap.Int("size", len(data)))
+
+	return data, nil
+}
+
+// TryAddRef attempts to increment the refcount for an already-loaded path.
+// If the path is loaded, returns the data and true.
+// If not loaded, returns nil and false.
+func (m *PkStatsMmapManager) TryAddRef(remotePath string) ([]byte, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	entry, ok := m.mappings[remotePath]
+	if !ok {
+		return nil, false
+	}
+	entry.refCount++
+	return entry.data, true
+}
+
+// Release decrements the refcount for a remote path.
+// When refcount reaches zero, the entry is removed (and unmapped if file-backed).
+func (m *PkStatsMmapManager) Release(remotePath string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	entry, ok := m.mappings[remotePath]
+	if !ok {
+		return
+	}
+
+	entry.refCount--
+	newRef := entry.refCount
+	if newRef <= 0 {
+		if m.fileBacked && entry.filePath != "" {
+			if err := unix.Munmap(entry.data); err != nil {
+				log.Warn("failed to munmap bloom filter",
+					zap.String("remotePath", remotePath),
+					zap.Error(err))
+			}
+			os.Remove(entry.filePath)
+		}
+		delete(m.mappings, remotePath)
+
+		log.Info("released bloom filter entry",
+			zap.String("remotePath", remotePath),
+			zap.Bool("fileBacked", m.fileBacked))
+	}
+}
+
+// AddRef increments the refcount for an already-loaded remote path.
+// Returns false if the path is not loaded.
+func (m *PkStatsMmapManager) AddRef(remotePath string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	entry, ok := m.mappings[remotePath]
+	if !ok {
+		return false
+	}
+	entry.refCount++
+	return true
+}
+
+// Close releases all entries and cleans up.
+func (m *PkStatsMmapManager) Close() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for remotePath, entry := range m.mappings {
+		if m.fileBacked && entry.filePath != "" {
+			if err := unix.Munmap(entry.data); err != nil {
+				log.Warn("failed to munmap bloom filter during close",
+					zap.String("remotePath", remotePath),
+					zap.Error(err))
+			}
+			os.Remove(entry.filePath)
+		}
+	}
+	m.mappings = make(map[string]*mmapEntry)
+}
+
+// localCachePath generates a local cache file path from the remote path.
+func (m *PkStatsMmapManager) localCachePath(remotePath string) string {
+	h := xxh3.HashString128(remotePath)
+	var b [16]byte
+	binary.BigEndian.PutUint64(b[:8], h.Hi)
+	binary.BigEndian.PutUint64(b[8:], h.Lo)
+	return filepath.Join(m.cacheDir, "bf_cache", hex.EncodeToString(b[:]))
+}
+
+// mmapFile opens a file and mmaps it read-only.
+func (m *PkStatsMmapManager) mmapFile(path string, size int64) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to open file %s", path)
+	}
+	defer f.Close()
+
+	data, err := unix.Mmap(int(f.Fd()), 0, int(size), unix.PROT_READ, unix.MAP_SHARED)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to mmap file %s", path)
+	}
+
+	return data, nil
+}

--- a/internal/util/bloomfilter/mmap_manager_test.go
+++ b/internal/util/bloomfilter/mmap_manager_test.go
@@ -1,0 +1,234 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package bloomfilter
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPkStatsMmapManager_FileBacked_GetOrLoadAndRelease(t *testing.T) {
+	tmpDir := t.TempDir()
+	mgr := NewPkStatsMmapManager(tmpDir, true)
+	defer mgr.Close()
+
+	data := []byte("test bloom filter data for mmap manager")
+
+	// First load
+	result, err := mgr.GetOrLoad("remote/path/stats", data)
+	require.NoError(t, err)
+	assert.Equal(t, len(data), len(result))
+	assert.Equal(t, string(data), string(result))
+
+	// Second load should return same data with increased refcount
+	result2, err := mgr.GetOrLoad("remote/path/stats", data)
+	require.NoError(t, err)
+	assert.Equal(t, len(data), len(result2))
+
+	// Release once - should not unmap yet
+	mgr.Release("remote/path/stats")
+
+	// Still accessible via refcount
+	ok := mgr.AddRef("remote/path/stats")
+	assert.True(t, ok)
+
+	// Release two more times (original + AddRef)
+	mgr.Release("remote/path/stats")
+	mgr.Release("remote/path/stats")
+
+	// Should be unmapped now
+	ok = mgr.AddRef("remote/path/stats")
+	assert.False(t, ok)
+}
+
+func TestPkStatsMmapManager_MemoryBacked_GetOrLoadAndRelease(t *testing.T) {
+	mgr := NewPkStatsMmapManager("", false)
+	defer mgr.Close()
+
+	data := []byte("test bloom filter data for memory manager")
+
+	// First load
+	result, err := mgr.GetOrLoad("remote/path/stats", data)
+	require.NoError(t, err)
+	assert.Equal(t, len(data), len(result))
+	assert.Equal(t, string(data), string(result))
+
+	// Second load should return same data with increased refcount
+	result2, err := mgr.GetOrLoad("remote/path/stats", data)
+	require.NoError(t, err)
+	assert.Equal(t, string(data), string(result2))
+
+	// Release once
+	mgr.Release("remote/path/stats")
+
+	// Still accessible
+	ok := mgr.AddRef("remote/path/stats")
+	assert.True(t, ok)
+
+	// Release remaining refs
+	mgr.Release("remote/path/stats")
+	mgr.Release("remote/path/stats")
+
+	// Should be gone now
+	ok = mgr.AddRef("remote/path/stats")
+	assert.False(t, ok)
+}
+
+func TestPkStatsMmapManager_TryAddRef(t *testing.T) {
+	mgr := NewPkStatsMmapManager("", false)
+	defer mgr.Close()
+
+	// Not loaded yet
+	data, ok := mgr.TryAddRef("path/a")
+	assert.False(t, ok)
+	assert.Nil(t, data)
+
+	// Load it
+	original := []byte("bloom filter data")
+	_, err := mgr.GetOrLoad("path/a", original)
+	require.NoError(t, err)
+
+	// TryAddRef should succeed and return same data
+	data, ok = mgr.TryAddRef("path/a")
+	assert.True(t, ok)
+	assert.Equal(t, string(original), string(data))
+
+	// Release all refs (GetOrLoad + TryAddRef)
+	mgr.Release("path/a")
+	mgr.Release("path/a")
+
+	// Should be gone
+	data, ok = mgr.TryAddRef("path/a")
+	assert.False(t, ok)
+	assert.Nil(t, data)
+}
+
+func TestPkStatsMmapManager_DifferentPaths(t *testing.T) {
+	tmpDir := t.TempDir()
+	mgr := NewPkStatsMmapManager(tmpDir, true)
+	defer mgr.Close()
+
+	data1 := []byte("bloom filter data 1")
+	data2 := []byte("bloom filter data 2 - different content")
+
+	result1, err := mgr.GetOrLoad("path/a", data1)
+	require.NoError(t, err)
+
+	result2, err := mgr.GetOrLoad("path/b", data2)
+	require.NoError(t, err)
+
+	assert.Equal(t, string(data1), string(result1))
+	assert.Equal(t, string(data2), string(result2))
+
+	mgr.Release("path/a")
+	mgr.Release("path/b")
+}
+
+func TestPkStatsMmapManager_Concurrent(t *testing.T) {
+	tmpDir := t.TempDir()
+	mgr := NewPkStatsMmapManager(tmpDir, true)
+	defer mgr.Close()
+
+	data := make([]byte, 4096) // Page-aligned
+	for i := range data {
+		data[i] = byte(i % 256)
+	}
+
+	var wg sync.WaitGroup
+	const goroutines = 20
+
+	// Concurrent GetOrLoad
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			result, err := mgr.GetOrLoad("concurrent/path", data)
+			assert.NoError(t, err)
+			assert.Equal(t, len(data), len(result))
+		}()
+	}
+	wg.Wait()
+
+	// Concurrent Release
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			mgr.Release("concurrent/path")
+		}()
+	}
+	wg.Wait()
+
+	// Should be fully released
+	ok := mgr.AddRef("concurrent/path")
+	assert.False(t, ok)
+}
+
+func TestPkStatsMmapManager_Close(t *testing.T) {
+	tmpDir := t.TempDir()
+	mgr := NewPkStatsMmapManager(tmpDir, true)
+
+	data := []byte("test data")
+	_, err := mgr.GetOrLoad("path1", data)
+	require.NoError(t, err)
+	_, err = mgr.GetOrLoad("path2", data)
+	require.NoError(t, err)
+
+	mgr.Close()
+
+	ok := mgr.AddRef("path1")
+	assert.False(t, ok)
+	ok = mgr.AddRef("path2")
+	assert.False(t, ok)
+}
+
+func TestPkStatsMmapManager_ReleaseNonExistent(t *testing.T) {
+	tmpDir := t.TempDir()
+	mgr := NewPkStatsMmapManager(tmpDir, true)
+	defer mgr.Close()
+
+	// Should not panic
+	mgr.Release("non/existent/path")
+}
+
+func TestPkStatsMmapManager_MemoryBacked_SharedData(t *testing.T) {
+	mgr := NewPkStatsMmapManager("", false)
+	defer mgr.Close()
+
+	data := []byte("shared bloom filter data")
+
+	// Simulate delegator loading first
+	result1, err := mgr.GetOrLoad("segment/100/stats", data)
+	require.NoError(t, err)
+
+	// Simulate segment loader hitting cache via TryAddRef
+	result2, ok := mgr.TryAddRef("segment/100/stats")
+	require.True(t, ok)
+
+	// Both should reference the same underlying data
+	assert.Equal(t, string(result1), string(result2))
+
+	// Release both refs
+	mgr.Release("segment/100/stats")
+	mgr.Release("segment/100/stats")
+
+	// Should be cleaned up
+	_, ok = mgr.TryAddRef("segment/100/stats")
+	assert.False(t, ok)
+}

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -306,6 +306,7 @@ type commonConfig struct {
 	BloomFilterType           ParamItem `refreshable:"true"`
 	MaxBloomFalsePositive     ParamItem `refreshable:"true"`
 	BloomFilterApplyBatchSize ParamItem `refreshable:"true"`
+	BloomFilterMmapEnabled   ParamItem `refreshable:"false"`
 	PanicWhenPluginFail       ParamItem `refreshable:"false"`
 
 	UsePartitionKeyAsClusteringKey ParamItem `refreshable:"true"`
@@ -1127,6 +1128,15 @@ The default value is 1, which is enough for most cases.`,
 		},
 	}
 	p.BloomFilterApplyBatchSize.Init(base.mgr)
+
+	p.BloomFilterMmapEnabled = ParamItem{
+		Key:          "common.bloomFilterMmapEnabled",
+		Version:      "2.5.6",
+		DefaultValue: "false",
+		Doc:          "if true, mmap bloom filter data to local file to reduce Go heap pressure",
+		Export:       true,
+	}
+	p.BloomFilterMmapEnabled.Init(base.mgr)
 
 	p.PanicWhenPluginFail = ParamItem{
 		Key:          "common.panicWhenPluginFail",


### PR DESCRIPTION
issue: #48486

Add optional mmap-backed bloom filter storage for query nodes, controlled by `common.bloomFilterMmapEnabled`. When enabled, bloom filter data is serialized into a compact binary format ("mpkstats") and memory-mapped from local files instead of living on the Go heap, significantly reducing GC pressure for large-scale deployments.

Key changes:
- Introduce MmapBloomFilter wrapping memory-mapped byte regions that satisfy the existing BloomFilterInterface
- Add PkStatsMmapManager for ref-counted lifecycle management of mmap'd bloom filter files with dedup support
- Add binary serialization format ("mpkstats") for PrimaryKeyStats with zero-copy deserialization into MmapBloomFilter instances
- Integrate mmap manager into segment loader with a fast-path cache hit to avoid redundant S3 downloads
- Add Refund() calls on error paths in delegator LoadSegments to properly release mmap references on failure
- Add Close() to Loader interface and QueryNode shutdown to clean up mmap resources