### PR TITLE
fix: resolve race in adaptive rate limit controller notify ordering

### DIFF
--- a/pkg/streaming/util/ratelimit/adaptive_rate_limit_controller.go
+++ b/pkg/streaming/util/ratelimit/adaptive_rate_limit_controller.go
@@ -412,10 +412,13 @@ func (c *AdaptiveRateLimitController) enterRejectMode(state *controllerState) {
 
 // notify notifies the observer with the current state and updates observable fields.
 func (c *AdaptiveRateLimitController) notify(state *controllerState) {
-	// Update observable atomic fields for external callers.
-	c.mode.Store(int32(state.mode))
+	// Update currentRate first (may be read by observer callbacks).
 	c.currentRate.Store(state.currentRate)
 
+	// Notify observers BEFORE updating mode, so that by the time external
+	// callers observe the mode change via getMode(), the observers have
+	// already been notified. This prevents a race where a caller sees the
+	// new mode but the observer notification hasn't completed yet.
 	switch state.mode {
 	case adaptiveRateLimitModeSlowdown, adaptiveRateLimitModeRecovery:
 		c.rateLimitRegistry.NotifySourceRateLimitState(c.sourceName, RateLimitState{
@@ -433,6 +436,9 @@ func (c *AdaptiveRateLimitController) notify(state *controllerState) {
 			Rate:  0,
 		})
 	}
+
+	// Update mode AFTER observer notification to ensure consistency.
+	c.mode.Store(int32(state.mode))
 	c.clearMetrics()
 	metrics.WALRateLimitControllerState.WithLabelValues(
 		paramtable.GetStringNodeID(),


### PR DESCRIPTION
## Summary
- Fix flaky `TestAdaptiveRateLimitController_EnterRejectMode` in `pkg/streaming/util/ratelimit`
- Root cause: `notify()` stored mode atomically BEFORE notifying observers. Tests checking `getMode()` via `Eventually` could see the mode change and call `AssertExpectations` before the backgroundLoop goroutine finished the observer notification
- Fix: move `mode.Store()` after observer notification in `notify()`, ensuring observers are notified before the mode change is externally visible

## Test plan
- [x] Reproduced: 4/100 failures with `-race` on unmodified code
- [x] Verified: 0/100 failures with `-race` after fix
- [x] All `streaming/util/ratelimit` tests pass with `-race`

issue: https://github.com/milvus-io/milvus/issues/39893

🤖 Generated with [Claude Code](https://claude.com/claude-code)