### PR TITLE
fix: no-train indexes (FLAT/BIN_FLAT) hang when worker slots exhausted

### DIFF
--- a/internal/datacoord/index_inspector.go
+++ b/internal/datacoord/index_inspector.go
@@ -211,6 +211,25 @@ func (i *indexInspector) createIndexForSegment(ctx context.Context, segment *Seg
 	if err = i.meta.indexMeta.AddSegmentIndex(ctx, segIndex); err != nil {
 		return err
 	}
+
+	// For no-train indexes (FLAT, BIN_FLAT), mark as finished directly without
+	// scheduling a build task. These indexes don't need a worker node, but the
+	// scheduler requires available worker slots before dispatching any task.
+	// When all worker slots are occupied, no-train index tasks would be stuck
+	// in the pending queue indefinitely, causing index build to appear hung.
+	if isNoTrainIndex(indexType) {
+		if err := i.meta.indexMeta.UpdateIndexState(segIndex.BuildID, commonpb.IndexState_Finished, "fake finished index success"); err != nil {
+			log.Warn("indexInspector: failed to fake finish no-train index", zap.Int64("segmentID", segment.ID),
+				zap.Int64("indexID", indexID), zap.Int64("buildID", segIndex.BuildID), zap.Error(err))
+			return err
+		}
+		log.Info("indexInspector: no-train index fake finished directly",
+			zap.Int64("segmentID", segment.ID),
+			zap.Int64("indexID", indexID),
+			zap.String("indexType", indexType))
+		return nil
+	}
+
 	i.scheduler.Enqueue(newIndexBuildTask(model.CloneSegmentIndex(segIndex),
 		taskSlot,
 		i.meta,

--- a/internal/datacoord/index_inspector_test.go
+++ b/internal/datacoord/index_inspector_test.go
@@ -230,3 +230,91 @@ func TestIndexInspector_CreateIndexForSegment_OverrideIndexType(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, "DISKANN", segIdx.IndexType)
 }
+
+func TestIndexInspector_CreateIndexForSegment_NoTrainIndex(t *testing.T) {
+	ctx := context.Background()
+	notifyChan := make(chan int64, 1)
+	scheduler := task.NewMockGlobalScheduler(t)
+	alloc := allocator.NewMockAllocator(t)
+	handler := NewNMockHandler(t)
+	storage := mocks.NewChunkManager(t)
+	versionManager := newIndexEngineVersionManager()
+	catalog := mocks2.NewDataCoordCatalog(t)
+
+	meta := &meta{
+		segments:    NewSegmentsInfo(),
+		collections: typeutil.NewConcurrentMap[UniqueID, *collectionInfo](),
+		indexMeta: &indexMeta{
+			keyLock:          lock.NewKeyLock[UniqueID](),
+			catalog:          catalog,
+			segmentBuildInfo: newSegmentIndexBuildInfo(),
+			indexes:          make(map[UniqueID]map[UniqueID]*model.Index),
+			segmentIndexes:   typeutil.NewConcurrentMap[UniqueID, *typeutil.ConcurrentMap[UniqueID, *model.SegmentIndex]](),
+		},
+	}
+
+	segment := &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:           1,
+			CollectionID: 2,
+			PartitionID:  3,
+			NumOfRows:    10000,
+			State:        commonpb.SegmentState_Flushed,
+			IsSorted:     true,
+			Level:        datapb.SegmentLevel_L1,
+		},
+	}
+	meta.segments.SetSegment(segment.GetID(), segment)
+
+	// Test BIN_FLAT (no-train index) - should be fake finished without scheduling
+	meta.indexMeta.indexes[2] = map[UniqueID]*model.Index{
+		5: {
+			CollectionID: 2,
+			FieldID:      101,
+			IndexID:      5,
+			IndexName:    "bin_flat_idx",
+			IndexParams: []*commonpb.KeyValuePair{
+				{Key: common.IndexTypeKey, Value: "BIN_FLAT"},
+			},
+		},
+	}
+
+	inspector := newIndexInspector(ctx, notifyChan, meta, scheduler, alloc, handler, storage, versionManager)
+
+	alloc.EXPECT().AllocID(mock.Anything).Return(int64(12345), nil)
+	catalog.EXPECT().CreateSegmentIndex(mock.Anything, mock.Anything).Return(nil)
+	catalog.EXPECT().AlterSegmentIndexes(mock.Anything, mock.Anything).Return(nil)
+	// scheduler.Enqueue should NOT be called for no-train indexes
+
+	err := inspector.createIndexForSegment(ctx, segment, 5)
+	assert.NoError(t, err)
+
+	// Verify the index was marked as finished directly
+	segIndexes := meta.indexMeta.GetSegmentIndexes(segment.CollectionID, segment.ID)
+	segIdx, ok := segIndexes[5]
+	assert.True(t, ok)
+	assert.Equal(t, commonpb.IndexState_Finished, segIdx.IndexState)
+	assert.Equal(t, "BIN_FLAT", segIdx.IndexType)
+
+	// Also test FLAT index
+	meta.indexMeta.indexes[2][6] = &model.Index{
+		CollectionID: 2,
+		FieldID:      102,
+		IndexID:      6,
+		IndexName:    "flat_idx",
+		IndexParams: []*commonpb.KeyValuePair{
+			{Key: common.IndexTypeKey, Value: "FLAT"},
+		},
+	}
+
+	alloc.EXPECT().AllocID(mock.Anything).Return(int64(12346), nil)
+
+	err = inspector.createIndexForSegment(ctx, segment, 6)
+	assert.NoError(t, err)
+
+	segIndexes = meta.indexMeta.GetSegmentIndexes(segment.CollectionID, segment.ID)
+	segIdx, ok = segIndexes[6]
+	assert.True(t, ok)
+	assert.Equal(t, commonpb.IndexState_Finished, segIdx.IndexState)
+	assert.Equal(t, "FLAT", segIdx.IndexType)
+}


### PR DESCRIPTION
## Summary
- No-train indexes (FLAT, BIN_FLAT) could hang indefinitely when all index worker slots were occupied
- Root cause: the global task scheduler calls `pickNode()` before `CreateTaskOnWorker()`. When no worker slot is available, `pickNode()` returns `NullNodeID` and the task is pushed back to the pending queue — even though no-train indexes don't need a worker at all (they are fake-finished immediately)
- This was observed in CI where `BinaryVector_BIN_FLAT_0%null_sealed` index build hung for 93+ minutes, causing go-sdk shard-1 to timeout

## Fix
- Handle no-train indexes in `createIndexForSegment()` directly, marking them as `Finished` in meta without entering the scheduler queue
- The existing fake-finish logic in `CreateTaskOnWorker()` is retained as defense-in-depth

## Test plan
- [x] Added unit test `TestIndexInspector_CreateIndexForSegment_NoTrainIndex` verifying BIN_FLAT and FLAT indexes are fake-finished without scheduling
- [x] Code compiles cleanly
- [ ] CI e2e tests pass

issue: https://github.com/milvus-io/milvus/issues/48463

🤖 Generated with [Claude Code](https://claude.com/claude-code)