### PR TITLE
fix: add configurable retry limit for manifest transaction commits

### DIFF
--- a/internal/storagev2/packed/manifest_ffi.go
+++ b/internal/storagev2/packed/manifest_ffi.go
@@ -76,9 +76,9 @@ func CreateManifestForSegment(
 	cBasePath := C.CString(basePath)
 	defer C.free(unsafe.Pointer(cBasePath))
 
-	// Begin transaction (read_version=-1 for latest, retry_limit=1)
+	// Begin transaction (read_version=-1 for latest, retry_limit=10)
 	var transactionHandle C.LoonTransactionHandle
-	result := C.loon_transaction_begin(cBasePath, cProperties, C.int64_t(-1), C.uint32_t(1), &transactionHandle)
+	result := C.loon_transaction_begin(cBasePath, cProperties, C.int64_t(-1), getRetryLimit(), &transactionHandle)
 	if err := HandleLoonFFIResult(result); err != nil {
 		return "", fmt.Errorf("loon_transaction_begin failed: %w", err)
 	}

--- a/internal/storagev2/packed/packed_writer_ffi.go
+++ b/internal/storagev2/packed/packed_writer_ffi.go
@@ -178,7 +178,7 @@ func (pw *FFIPackedWriter) Close() (string, error) {
 	defer C.free(unsafe.Pointer(cBasePath))
 	var transationHandle C.LoonTransactionHandle
 
-	result = C.loon_transaction_begin(cBasePath, pw.cProperties, C.int64_t(pw.baseVersion), 1, &transationHandle)
+	result = C.loon_transaction_begin(cBasePath, pw.cProperties, C.int64_t(pw.baseVersion), getRetryLimit(), &transationHandle)
 	if err := HandleLoonFFIResult(result); err != nil {
 		return "", err
 	}

--- a/internal/storagev2/packed/transaction.go
+++ b/internal/storagev2/packed/transaction.go
@@ -24,13 +24,31 @@ import "C"
 
 import (
 	"fmt"
+	"math"
 	"unsafe"
 
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
+
+// getRetryLimit returns the configured manifest transaction retry limit.
+// Multiple stats tasks (text index, JSON key, BM25) can write to the same
+// segment's manifest concurrently, causing optimistic transaction conflicts.
+// The retry mechanism re-reads the latest manifest version and re-applies
+// the changes on each attempt.
+func getRetryLimit() C.uint32_t {
+	val := paramtable.Get().CommonCfg.ManifestTransactionRetryLimit.GetAsInt64()
+	if val <= 0 {
+		val = 10
+	}
+	if val > math.MaxUint32 {
+		val = math.MaxUint32
+	}
+	return C.uint32_t(val)
+}
 
 // DeltaLogEntry represents a delta log to be added to the manifest
 type DeltaLogEntry struct {
@@ -74,7 +92,7 @@ func AddDeltaLogsToManifest(
 
 	// Start transaction
 	var transactionHandle C.LoonTransactionHandle
-	result := C.loon_transaction_begin(cBasePath, cProperties, C.int64_t(version), 1, &transactionHandle)
+	result := C.loon_transaction_begin(cBasePath, cProperties, C.int64_t(version), getRetryLimit(), &transactionHandle)
 	if err := HandleLoonFFIResult(result); err != nil {
 		return "", fmt.Errorf("failed to begin transaction: %w", err)
 	}
@@ -203,7 +221,7 @@ func AddStatsToManifest(
 	defer C.free(unsafe.Pointer(cBasePath))
 
 	var transactionHandle C.LoonTransactionHandle
-	result := C.loon_transaction_begin(cBasePath, cProperties, C.int64_t(version), 1, &transactionHandle)
+	result := C.loon_transaction_begin(cBasePath, cProperties, C.int64_t(version), getRetryLimit(), &transactionHandle)
 	if err := HandleLoonFFIResult(result); err != nil {
 		return "", fmt.Errorf("failed to begin transaction: %w", err)
 	}

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -245,8 +245,9 @@ type commonConfig struct {
 	GracefulStopTimeout                 ParamItem `refreshable:"true"`
 	ParquetStatsSkipIndex               ParamItem `refreshable:"true"`
 
-	StorageType ParamItem `refreshable:"false"`
-	SimdType    ParamItem `refreshable:"false"`
+	StorageType                   ParamItem `refreshable:"false"`
+	ManifestTransactionRetryLimit ParamItem `refreshable:"true"`
+	SimdType                      ParamItem `refreshable:"false"`
 
 	DiskWriteMode         ParamItem `refreshable:"true"`
 	DiskWriteBufferSizeKb ParamItem `refreshable:"true"`
@@ -641,6 +642,15 @@ This configuration is only used by querynode and indexnode, it selects CPU instr
 		Export:       true,
 	}
 	p.StorageType.Init(base.mgr)
+
+	p.ManifestTransactionRetryLimit = ParamItem{
+		Key:          "common.storage.manifestTransactionRetryLimit",
+		Version:      "2.6.10",
+		DefaultValue: "10",
+		Doc:          "Maximum number of retry attempts for V3 storage manifest transaction commits on optimistic concurrency conflicts",
+		Export:       true,
+	}
+	p.ManifestTransactionRetryLimit.Init(base.mgr)
 
 	p.HighPriorityThreadCoreCoefficient = ParamItem{
 		Key:          "common.threadCoreCoefficient.highPriority",


### PR DESCRIPTION
## Summary
- Replace hardcoded `retry_limit=1` in all `loon_transaction_begin` calls with configurable `getRetryLimit()` (default 10)
- Add `common.storage.manifestTransactionRetryLimit` config parameter
- Add `math.MaxUint32` clamp to prevent int64→uint32 silent narrowing wraparound

issue: #48500

## Test plan
- [ ] Existing CI tests pass
- [ ] Concurrent stats tasks (text index, JSON key, BM25) on same segment no longer fail due to optimistic conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)