### PR TITLE
fix: address review feedback for index version management

### DIFF
--- a/internal/datacoord/index_engine_version_manager.go
+++ b/internal/datacoord/index_engine_version_manager.go
@@ -139,8 +139,11 @@ func (m *versionManagerImpl) GetCurrentIndexEngineVersion() int32 {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	return m.getCurrentVersion()
+}
+
+func (m *versionManagerImpl) getCurrentVersion() int32 {
 	if len(m.versions) == 0 {
-		log.Info("index versions is empty")
 		return 0
 	}
 
@@ -150,7 +153,6 @@ func (m *versionManagerImpl) GetCurrentIndexEngineVersion() int32 {
 			current = version.CurrentIndexVersion
 		}
 	}
-	log.Info("Merged current version", zap.Int32("current", current))
 	return current
 }
 
@@ -158,8 +160,11 @@ func (m *versionManagerImpl) GetMinimalIndexEngineVersion() int32 {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	return m.getMinimalVersion()
+}
+
+func (m *versionManagerImpl) getMinimalVersion() int32 {
 	if len(m.versions) == 0 {
-		log.Info("index versions is empty")
 		return 0
 	}
 
@@ -169,7 +174,6 @@ func (m *versionManagerImpl) GetMinimalIndexEngineVersion() int32 {
 			minimal = version.MinimalIndexVersion
 		}
 	}
-	log.Info("Merged minimal version", zap.Int32("minimal", minimal))
 	return minimal
 }
 
@@ -177,8 +181,11 @@ func (m *versionManagerImpl) GetCurrentScalarIndexEngineVersion() int32 {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	return m.getCurrentScalarVersion()
+}
+
+func (m *versionManagerImpl) getCurrentScalarVersion() int32 {
 	if len(m.scalarIndexVersions) == 0 {
-		log.Info("scalar index versions is empty")
 		return 0
 	}
 
@@ -188,7 +195,6 @@ func (m *versionManagerImpl) GetCurrentScalarIndexEngineVersion() int32 {
 			current = version.CurrentIndexVersion
 		}
 	}
-	log.Info("Merged current scalar index version", zap.Int32("current", current))
 	return current
 }
 
@@ -196,8 +202,11 @@ func (m *versionManagerImpl) GetMinimalScalarIndexEngineVersion() int32 {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	return m.getMinimalScalarVersion()
+}
+
+func (m *versionManagerImpl) getMinimalScalarVersion() int32 {
 	if len(m.scalarIndexVersions) == 0 {
-		log.Info("scalar index versions is empty")
 		return 0
 	}
 
@@ -207,13 +216,20 @@ func (m *versionManagerImpl) GetMinimalScalarIndexEngineVersion() int32 {
 			minimal = version.MinimalIndexVersion
 		}
 	}
-	log.Info("Merged minimal scalar index version", zap.Int32("minimal", minimal))
 	return minimal
 }
 
 func (m *versionManagerImpl) GetMaximumIndexEngineVersion() int32 {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	return m.getMaximumVersion()
+}
+
+func (m *versionManagerImpl) getMaximumVersion() int32 {
+	if len(m.versions) == 0 {
+		return math.MaxInt32
+	}
 
 	maximum := int32(math.MaxInt32)
 	for _, version := range m.versions {
@@ -223,9 +239,6 @@ func (m *versionManagerImpl) GetMaximumIndexEngineVersion() int32 {
 		if version.MaximumIndexVersion < maximum {
 			maximum = version.MaximumIndexVersion
 		}
-	}
-	if maximum == math.MaxInt32 {
-		return math.MaxInt32
 	}
 	return maximum
 }
@@ -234,6 +247,14 @@ func (m *versionManagerImpl) GetMaximumScalarIndexEngineVersion() int32 {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	return m.getMaximumScalarVersion()
+}
+
+func (m *versionManagerImpl) getMaximumScalarVersion() int32 {
+	if len(m.scalarIndexVersions) == 0 {
+		return math.MaxInt32
+	}
+
 	maximum := int32(math.MaxInt32)
 	for _, version := range m.scalarIndexVersions {
 		if version.MaximumIndexVersion == 0 {
@@ -243,21 +264,18 @@ func (m *versionManagerImpl) GetMaximumScalarIndexEngineVersion() int32 {
 			maximum = version.MaximumIndexVersion
 		}
 	}
-	if maximum == math.MaxInt32 {
-		return math.MaxInt32
-	}
 	return maximum
 }
 
-// clampVersion clamps v into [minV, maxV], logging a warning on each adjustment.
+// clampVersion clamps v into [minV, maxV], logging a rate-limited warning on each adjustment.
 func clampVersion(v, minV, maxV int32, name string) int32 {
 	if v < minV {
-		log.Warn(name+" below cluster minimum, clamping",
+		log.RatedWarn(60, name+" below cluster minimum, clamping",
 			zap.Int32("target", v), zap.Int32("minimum", minV))
 		v = minV
 	}
 	if v > maxV {
-		log.Warn(name+" exceeds cluster maximum, clamping",
+		log.RatedWarn(60, name+" exceeds cluster maximum, clamping",
 			zap.Int32("target", v), zap.Int32("maximum", maxV))
 		v = maxV
 	}
@@ -265,7 +283,11 @@ func clampVersion(v, minV, maxV int32, name string) int32 {
 }
 
 func (m *versionManagerImpl) ResolveVecIndexVersion() int32 {
-	version := m.GetCurrentIndexEngineVersion()
+	m.mu.Lock()
+	current, minimal, maximum := m.getCurrentVersion(), m.getMinimalVersion(), m.getMaximumVersion()
+	m.mu.Unlock()
+
+	version := current
 	if Params.DataCoordCfg.TargetVecIndexVersion.GetAsInt64() != -1 {
 		target := Params.DataCoordCfg.TargetVecIndexVersion.GetAsInt32()
 		if Params.DataCoordCfg.ForceRebuildSegmentIndex.GetAsBool() {
@@ -274,16 +296,15 @@ func (m *versionManagerImpl) ResolveVecIndexVersion() int32 {
 			version = max(version, target)
 		}
 	}
-	return clampVersion(
-		version,
-		m.GetMinimalIndexEngineVersion(),
-		m.GetMaximumIndexEngineVersion(),
-		"targetVecIndexVersion",
-	)
+	return clampVersion(version, minimal, maximum, "targetVecIndexVersion")
 }
 
 func (m *versionManagerImpl) ResolveScalarIndexVersion() int32 {
-	version := m.GetCurrentScalarIndexEngineVersion()
+	m.mu.Lock()
+	current, minimal, maximum := m.getCurrentScalarVersion(), m.getMinimalScalarVersion(), m.getMaximumScalarVersion()
+	m.mu.Unlock()
+
+	version := current
 	if Params.DataCoordCfg.TargetScalarIndexVersion.GetAsInt64() != -1 {
 		target := Params.DataCoordCfg.TargetScalarIndexVersion.GetAsInt32()
 		if Params.DataCoordCfg.ForceRebuildScalarSegmentIndex.GetAsBool() {
@@ -292,12 +313,7 @@ func (m *versionManagerImpl) ResolveScalarIndexVersion() int32 {
 			version = max(version, target)
 		}
 	}
-	return clampVersion(
-		version,
-		m.GetMinimalScalarIndexEngineVersion(),
-		m.GetMaximumScalarIndexEngineVersion(),
-		"targetScalarIndexVersion",
-	)
+	return clampVersion(version, minimal, maximum, "targetScalarIndexVersion")
 }
 
 func (m *versionManagerImpl) GetIndexNonEncoding() bool {

--- a/internal/datacoord/index_engine_version_manager_test.go
+++ b/internal/datacoord/index_engine_version_manager_test.go
@@ -558,6 +558,21 @@ func Test_IndexEngineVersionManager_ResolveVecIndexVersion(t *testing.T) {
 		assert.Equal(t, int32(8), m.ResolveVecIndexVersion())
 	})
 
+	t.Run("target below current without force", func(t *testing.T) {
+		m := newIndexEngineVersionManager()
+		m.AddNode(&sessionutil.Session{
+			SessionRaw: sessionutil.SessionRaw{
+				ServerID:           1,
+				IndexEngineVersion: sessionutil.IndexEngineVersion{MinimalIndexVersion: 3, CurrentIndexVersion: 10, MaximumIndexVersion: 20},
+			},
+		})
+		Params.Save("dataCoord.targetVecIndexVersion", "5")
+		Params.Save("dataCoord.forceRebuildSegmentIndex", "false")
+
+		// max(current=10, target=5) = 10
+		assert.Equal(t, int32(10), m.ResolveVecIndexVersion())
+	})
+
 	t.Run("all old QNs - no upper bound check", func(t *testing.T) {
 		m := newIndexEngineVersionManager()
 		m.AddNode(&sessionutil.Session{

--- a/internal/querynodev2/segments/utils.go
+++ b/internal/querynodev2/segments/utils.go
@@ -1,16 +1,5 @@
 package segments
 
-/*
-#cgo pkg-config: milvus_core
-
-#include "segcore/collection_c.h"
-#include "segcore/segment_c.h"
-#include "segcore/segcore_init_c.h"
-#include "common/init_c.h"
-
-*/
-import "C"
-
 import (
 	"bytes"
 	"encoding/binary"
@@ -177,15 +166,6 @@ func mergeRequestCost(requestCosts []*internalpb.CostAggregation) *internalpb.Co
 	}
 
 	return result
-}
-
-func getIndexEngineVersion() (minimal, current, maximum int32) {
-	GetDynamicPool().Submit(func() (any, error) {
-		cMinimal, cCurrent, cMaximum := C.GetMinimalIndexVersion(), C.GetCurrentIndexVersion(), C.GetMaximumIndexVersion()
-		minimal, current, maximum = int32(cMinimal), int32(cCurrent), int32(cMaximum)
-		return nil, nil
-	}).Await()
-	return minimal, current, maximum
 }
 
 // getSegmentMetricLabel returns the label for segment metrics.


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/47417

- Fix TOCTOU: snapshot current/minimal/maximum under single lock in Resolve*IndexVersion()
- Use log.RatedWarn in clampVersion() to avoid log flooding on hot path
- Remove dead code getIndexEngineVersion() from segments/utils.go
- Add explicit empty-map checks in getMaximumVersion/getMaximumScalarVersion
- Remove verbose per-call log.Info from internal version methods
- Add test case: target < current with force=false