### PR TITLE
enhance: unify TextMatchIndex build path through ScalarIndexCreator

### DIFF
--- a/internal/core/src/index/IndexFactory.cpp
+++ b/internal/core/src/index/IndexFactory.cpp
@@ -36,6 +36,7 @@
 #include "index/Index.h"
 #include "index/IndexInfo.h"
 #include "index/InvertedIndexTantivy.h"
+#include "index/TextMatchIndex.h"
 #include "index/JsonFlatIndex.h"
 #include "index/JsonInvertedIndex.h"
 #include "index/Meta.h"
@@ -92,6 +93,16 @@ IndexFactory::CreatePrimitiveScalarIndex<std::string>(
 #if defined(__linux__) || defined(__APPLE__)
     if (index_type == INVERTED_INDEX_TYPE) {
         assert(create_index_info.tantivy_index_version != 0);
+        if (create_index_info.is_text_match) {
+            auto field_schema = FieldMeta::ParseFrom(
+                file_manager_context.fieldDataMeta.field_schema);
+            return std::make_unique<TextMatchIndex>(
+                file_manager_context,
+                create_index_info.tantivy_index_version,
+                "milvus_tokenizer",
+                field_schema.get_analyzer_params().c_str(),
+                create_index_info.analyzer_extra_info.c_str());
+        }
         // scalar_index_engine_version 0 means we should built tantivy index within single segment
         return std::make_unique<InvertedIndexTantivy<std::string>>(
             create_index_info.tantivy_index_version,

--- a/internal/core/src/index/IndexInfo.h
+++ b/internal/core/src/index/IndexInfo.h
@@ -40,6 +40,8 @@ struct CreateIndexInfo {
     std::string json_path;
     std::string json_cast_function{UNKNOW_CAST_FUNCTION_NAME};
     std::optional<NgramParams> ngram_params{std::nullopt};
+    bool is_text_match{false};
+    std::string analyzer_extra_info;
 };
 
 }  // namespace milvus::index

--- a/internal/core/src/index/TextMatchIndex.cpp
+++ b/internal/core/src/index/TextMatchIndex.cpp
@@ -142,8 +142,22 @@ TextMatchIndex::Load(const Config& config) {
         GetValueFromConfig<std::vector<std::string>>(config, INDEX_FILES);
     AssertInfo(index_files.has_value(),
                "index file paths is empty when load text log index");
+
+    // Detect V3 format: single file ending with ".v3"
+    auto& files_value = index_files.value();
+    if (files_value.size() == 1) {
+        const auto& file = files_value[0];
+        auto filename = file.substr(file.find_last_of('/') + 1);
+        if (filename.size() > 3 &&
+            filename.substr(filename.size() - 3) == ".v3") {
+            LOG_INFO("TextMatchIndex::Load V3 format detected: {}", file);
+            InvertedIndexTantivy<std::string>::LoadV3(config);
+            return;
+        }
+    }
+
+    // V2: existing multi-file load path
     auto prefix = disk_file_manager_->GetLocalTextIndexPrefix();
-    auto files_value = index_files.value();
     auto it = std::find_if(
         files_value.begin(), files_value.end(), [](const std::string& file) {
             return file.substr(file.find_last_of('/') + 1) ==

--- a/internal/core/src/indexbuilder/ScalarIndexCreator.cpp
+++ b/internal/core/src/indexbuilder/ScalarIndexCreator.cpp
@@ -72,6 +72,16 @@ ScalarIndexCreator::ScalarIndexCreator(
             config, milvus::index::TANTIVY_INDEX_VERSION)
             .value_or(milvus::index::TANTIVY_INDEX_LATEST_VERSION);
 
+    auto is_text_match_str =
+        milvus::index::GetValueFromConfig<std::string>(config, "is_text_match")
+            .value_or("false");
+    index_info.is_text_match = (is_text_match_str == "true");
+
+    index_info.analyzer_extra_info =
+        milvus::index::GetValueFromConfig<std::string>(config,
+                                                       "analyzer_extra_info")
+            .value_or("");
+
     index_info.field_type = dtype_;
     index_info.index_type = index_type();
     if (dtype == DataType::JSON) {

--- a/internal/core/src/indexbuilder/index_c.cpp
+++ b/internal/core/src/indexbuilder/index_c.cpp
@@ -199,6 +199,10 @@ get_config(std::unique_ptr<milvus::proto::indexcgo::BuildIndexInfo>& info) {
     config[DATA_TYPE_KEY] = info->field_schema().data_type();
     config[ELEMENT_TYPE_KEY] = info->field_schema().element_type();
 
+    if (!info->analyzer_extra_info().empty()) {
+        config["analyzer_extra_info"] = info->analyzer_extra_info();
+    }
+
     return config;
 }
 
@@ -407,114 +411,6 @@ BuildJsonKeyIndex(ProtoLayoutInterface result,
             build_index_info->json_stats_shredding_ratio_threshold(),
             build_index_info->json_stats_write_batch_size(),
             tantivy_index_version);
-        index->Build(config);
-        auto create_index_result = index->Upload(config);
-        create_index_result->SerializeAt(
-            reinterpret_cast<milvus::ProtoLayout*>(result));
-        auto status = CStatus();
-        status.error_code = Success;
-        status.error_msg = "";
-        return status;
-    } catch (SegcoreError& e) {
-        auto status = CStatus();
-        status.error_code = e.get_error_code();
-        status.error_msg = strdup(e.what());
-        return status;
-    } catch (std::exception& e) {
-        auto status = CStatus();
-        status.error_code = UnexpectedError;
-        status.error_msg = strdup(e.what());
-        return status;
-    }
-}
-
-CStatus
-BuildTextIndex(ProtoLayoutInterface result,
-               const uint8_t* serialized_build_index_info,
-               const uint64_t len) {
-    SCOPE_CGO_CALL_METRIC();
-
-    try {
-        auto build_index_info =
-            std::make_unique<milvus::proto::indexcgo::BuildIndexInfo>();
-        auto res =
-            build_index_info->ParseFromArray(serialized_build_index_info, len);
-        AssertInfo(res, "Unmarshal build index info failed");
-
-        auto field_type = static_cast<milvus::DataType>(
-            build_index_info->field_schema().data_type());
-
-        auto storage_config =
-            get_storage_config(build_index_info->storage_config());
-        auto config = get_config(build_index_info);
-
-        // init file manager
-        milvus::storage::FieldDataMeta field_meta{
-            build_index_info->collectionid(),
-            build_index_info->partitionid(),
-            build_index_info->segmentid(),
-            build_index_info->field_schema().fieldid(),
-            build_index_info->field_schema()};
-
-        milvus::storage::IndexMeta index_meta{
-            build_index_info->segmentid(),
-            build_index_info->field_schema().fieldid(),
-            build_index_info->buildid(),
-            build_index_info->index_version(),
-            "",
-            build_index_info->field_schema().name(),
-            field_type,
-            build_index_info->dim(),
-        };
-        auto chunk_manager =
-            milvus::storage::CreateChunkManager(storage_config);
-        auto fs = milvus::storage::InitArrowFileSystem(storage_config);
-
-        milvus::storage::FileManagerContext fileManagerContext(
-            field_meta, index_meta, chunk_manager, fs);
-
-        if (build_index_info->manifest() != "") {
-            auto loon_properties = MakeInternalPropertiesFromStorageConfig(
-                ToCStorageConfig(storage_config));
-            fileManagerContext.set_loon_ffi_properties(loon_properties);
-        }
-
-        if (build_index_info->has_storage_plugin_context()) {
-            auto cipherPlugin =
-                milvus::storage::PluginLoader::GetInstance().getCipherPlugin();
-            AssertInfo(cipherPlugin != nullptr, "failed to get cipher plugin");
-            cipherPlugin->Update(
-                build_index_info->storage_plugin_context().encryption_zone_id(),
-                build_index_info->storage_plugin_context().collection_id(),
-                build_index_info->storage_plugin_context().encryption_key());
-            auto plugin_context = std::make_shared<CPluginContext>();
-            plugin_context->ez_id =
-                build_index_info->storage_plugin_context().encryption_zone_id();
-            plugin_context->collection_id =
-                build_index_info->storage_plugin_context().collection_id();
-            fileManagerContext.set_plugin_context(plugin_context);
-        }
-
-        auto scalar_index_engine_version =
-            build_index_info->current_scalar_index_version();
-        config[milvus::index::SCALAR_INDEX_ENGINE_VERSION] =
-            scalar_index_engine_version;
-        auto tantivy_index_version =
-            scalar_index_engine_version <= 1
-                ? milvus::index::TANTIVY_INDEX_MINIMUM_VERSION
-                : milvus::index::TANTIVY_INDEX_LATEST_VERSION;
-        config[milvus::index::TANTIVY_INDEX_VERSION] = tantivy_index_version;
-
-        auto field_schema =
-            FieldMeta::ParseFrom(build_index_info->field_schema());
-
-        auto index = std::make_unique<index::TextMatchIndex>(
-            fileManagerContext,
-            tantivy_index_version,
-            "milvus_tokenizer",
-            field_schema.get_analyzer_params().c_str(),
-            build_index_info->analyzer_extra_info().c_str());
-
         index->Build(config);
         auto create_index_result = index->Upload(config);
         create_index_result->SerializeAt(

--- a/internal/core/src/indexbuilder/index_c.h
+++ b/internal/core/src/indexbuilder/index_c.h
@@ -38,11 +38,6 @@ BuildJsonKeyIndex(ProtoLayoutInterface c_binary_set,
                   const uint64_t len);
 
 CStatus
-BuildTextIndex(ProtoLayoutInterface c_binary_set,
-               const uint8_t* serialized_build_index_info,
-               const uint64_t len);
-
-CStatus
 CleanLocalData(CIndex index);
 
 CStatus

--- a/internal/datanode/compactor/sort_compaction.go
+++ b/internal/datanode/compactor/sort_compaction.go
@@ -30,6 +30,7 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/allocator"
 	"github.com/milvus-io/milvus/internal/compaction"
@@ -598,6 +599,10 @@ func (t *sortCompactionTask) createTextIndex(ctx context.Context,
 				CurrentScalarIndexVersion: common.ClampScalarIndexVersion(t.plan.GetCurrentScalarIndexVersion()),
 				StorageVersion:            t.storageVersion,
 				Manifest:                  segment.GetManifest(),
+				IndexParams: []*commonpb.KeyValuePair{
+					{Key: "index_type", Value: "INVERTED"},
+					{Key: "is_text_match", Value: "true"},
+				},
 			}
 
 			if len(analyzerExtraInfo) > 0 {
@@ -612,9 +617,21 @@ func (t *sortCompactionTask) createTextIndex(ctx context.Context,
 					partitionID,
 					segmentID)
 			}
-			uploaded, err := indexcgowrapper.CreateTextIndex(egCtx, buildIndexParams)
+
+			index, err := indexcgowrapper.CreateIndex(egCtx, buildIndexParams)
 			if err != nil {
 				return err
+			}
+			defer index.Delete()
+
+			indexStats, err := index.UpLoad()
+			if err != nil {
+				return err
+			}
+
+			uploaded := make(map[string]int64)
+			for _, info := range indexStats.GetSerializedIndexInfos() {
+				uploaded[info.FileName] = info.FileSize
 			}
 
 			mu.Lock()

--- a/internal/datanode/index/task_stats.go
+++ b/internal/datanode/index/task_stats.go
@@ -31,6 +31,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/allocator"
 	"github.com/milvus-io/milvus/internal/compaction"
@@ -550,15 +551,30 @@ func (st *statsTask) createTextIndex(ctx context.Context,
 			req.InsertLogs = insertBinlogs
 			req.ManifestPath = st.manifestPath
 			buildIndexParams := buildIndexParams(req, files, field, newStorageConfig, nil)
+			buildIndexParams.IndexParams = []*commonpb.KeyValuePair{
+				{Key: "index_type", Value: "INVERTED"},
+				{Key: "is_text_match", Value: "true"},
+			}
 
 			// set analyzer extra info
 			if len(analyzerExtraInfo) > 0 {
 				buildIndexParams.AnalyzerExtraInfo = analyzerExtraInfo
 			}
 
-			uploaded, err := indexcgowrapper.CreateTextIndex(egCtx, buildIndexParams)
+			index, err := indexcgowrapper.CreateIndex(egCtx, buildIndexParams)
 			if err != nil {
 				return err
+			}
+			defer index.Delete()
+
+			indexStats, err := index.UpLoad()
+			if err != nil {
+				return err
+			}
+
+			uploaded := make(map[string]int64)
+			for _, info := range indexStats.GetSerializedIndexInfos() {
+				uploaded[info.FileName] = info.FileSize
 			}
 
 			mu.Lock()

--- a/internal/util/indexcgowrapper/index.go
+++ b/internal/util/indexcgowrapper/index.go
@@ -130,33 +130,6 @@ func CreateIndex(ctx context.Context, buildIndexInfo *indexcgopb.BuildIndexInfo)
 	return index, nil
 }
 
-func CreateTextIndex(ctx context.Context, buildIndexInfo *indexcgopb.BuildIndexInfo) (map[string]int64, error) {
-	buildIndexInfoBlob, err := proto.Marshal(buildIndexInfo)
-	if err != nil {
-		log.Ctx(ctx).Warn("marshal buildIndexInfo failed",
-			zap.String("clusterID", buildIndexInfo.GetClusterID()),
-			zap.Int64("buildID", buildIndexInfo.GetBuildID()),
-			zap.Error(err))
-		return nil, err
-	}
-	result := C.CreateProtoLayout()
-	defer C.ReleaseProtoLayout(result)
-	status := C.BuildTextIndex(result, (*C.uint8_t)(unsafe.Pointer(&buildIndexInfoBlob[0])), (C.uint64_t)(len(buildIndexInfoBlob)))
-	if err := HandleCStatus(&status, "failed to build text index"); err != nil {
-		return nil, err
-	}
-	var indexStats cgopb.IndexStats
-	if err := segcore.UnmarshalProtoLayout(result, &indexStats); err != nil {
-		return nil, err
-	}
-
-	res := make(map[string]int64)
-	for _, indexInfo := range indexStats.GetSerializedIndexInfos() {
-		res[indexInfo.FileName] = indexInfo.FileSize
-	}
-	return res, nil
-}
-
 type JSONKeyStatsResult struct {
 	// MemSize is the actual memory size when loaded
 	MemSize int64


### PR DESCRIPTION
issue: #47417

Consolidate TextMatchIndex build/upload from standalone BuildTextIndex CGO function into the unified CreateIndex → ScalarIndexCreator path. Remove the deprecated BuildTextIndex CGO entry point and add V3 Load support for text match indexes.