### PR TITLE
fix: split GetAllStreamingNodes and GetAvailableStreamingNodes in balancer

### DIFF
--- a/internal/coordinator/snmanager/streaming_node_manager.go
+++ b/internal/coordinator/snmanager/streaming_node_manager.go
@@ -150,7 +150,7 @@ func (s *StreamingNodeManager) GetStreamingQueryNodeIDs() typeutil.UniqueSet {
 	if err != nil {
 		panic(err)
 	}
-	streamingNodes, err := balancer.GetAllStreamingNodes(context.Background())
+	streamingNodes, err := balancer.GetAvailableStreamingNodes(context.Background())
 	if err != nil {
 		// when the streaming coord is on shutdown, the balancer will return an error,
 		// causing panic, so we need to return the previous node ids.

--- a/internal/coordinator/snmanager/streaming_node_manager_test.go
+++ b/internal/coordinator/snmanager/streaming_node_manager_test.go
@@ -26,7 +26,7 @@ func TestStreamingNodeManager(t *testing.T) {
 	b := mock_balancer.NewMockBalancer(t)
 
 	ch := make(chan pChannelInfoAssigned, 1)
-	b.EXPECT().GetAllStreamingNodes(mock.Anything).Return(map[int64]*types.StreamingNodeInfo{}, nil)
+	b.EXPECT().GetAvailableStreamingNodes(mock.Anything).Return(map[int64]*types.StreamingNodeInfo{}, nil)
 	b.EXPECT().WatchChannelAssignments(mock.Anything, mock.Anything).RunAndReturn(
 		func(ctx context.Context, cb balancer.WatchChannelAssignmentsCallback) error {
 			for {
@@ -68,8 +68,8 @@ func TestStreamingNodeManager(t *testing.T) {
 	node := m.GetWALLocated("a_test")
 	assert.Equal(t, node, int64(1))
 
-	b.EXPECT().GetAllStreamingNodes(mock.Anything).Unset()
-	b.EXPECT().GetAllStreamingNodes(mock.Anything).Return(map[int64]*types.StreamingNodeInfo{
+	b.EXPECT().GetAvailableStreamingNodes(mock.Anything).Unset()
+	b.EXPECT().GetAvailableStreamingNodes(mock.Anything).Return(map[int64]*types.StreamingNodeInfo{
 		1: {ServerID: 1, Address: "localhost:1"},
 	}, nil)
 	streamingNodes = m.GetStreamingQueryNodeIDs()

--- a/internal/coordinator/snmanager/test_utility.go
+++ b/internal/coordinator/snmanager/test_utility.go
@@ -29,5 +29,6 @@ func ResetDoNothingStreamingNodeManager(t *testing.T) {
 		return ctx.Err()
 	}).Maybe()
 	b.EXPECT().GetAllStreamingNodes(mock.Anything).Return(map[int64]*types.StreamingNodeInfo{}, nil).Maybe()
+	b.EXPECT().GetAvailableStreamingNodes(mock.Anything).Return(map[int64]*types.StreamingNodeInfo{}, nil).Maybe()
 	balance.Register(b)
 }

--- a/internal/mocks/distributed/mock_streaming/mock_ReplicateService.go
+++ b/internal/mocks/distributed/mock_streaming/mock_ReplicateService.go
@@ -7,9 +7,9 @@ import (
 
 	commonpb "github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 
-	milvuspb "github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
-
 	message "github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
+
+	milvuspb "github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 
 	mock "github.com/stretchr/testify/mock"
 

--- a/internal/mocks/streamingcoord/mock_client/mock_AssignmentService.go
+++ b/internal/mocks/streamingcoord/mock_client/mock_AssignmentService.go
@@ -5,9 +5,9 @@ package mock_client
 import (
 	assignment "github.com/milvus-io/milvus/internal/streamingcoord/client/assignment"
 
-	milvuspb "github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
-
 	context "context"
+
+	milvuspb "github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 
 	mock "github.com/stretchr/testify/mock"
 

--- a/internal/mocks/streamingcoord/server/mock_balancer/mock_Balancer.go
+++ b/internal/mocks/streamingcoord/server/mock_balancer/mock_Balancer.go
@@ -182,6 +182,64 @@ func (_c *MockBalancer_GetAllStreamingNodes_Call) RunAndReturn(run func(context.
 	return _c
 }
 
+// GetAvailableStreamingNodes provides a mock function with given fields: ctx
+func (_m *MockBalancer) GetAvailableStreamingNodes(ctx context.Context) (map[int64]*types.StreamingNodeInfo, error) {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAvailableStreamingNodes")
+	}
+
+	var r0 map[int64]*types.StreamingNodeInfo
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context) (map[int64]*types.StreamingNodeInfo, error)); ok {
+		return rf(ctx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) map[int64]*types.StreamingNodeInfo); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[int64]*types.StreamingNodeInfo)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockBalancer_GetAvailableStreamingNodes_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAvailableStreamingNodes'
+type MockBalancer_GetAvailableStreamingNodes_Call struct {
+	*mock.Call
+}
+
+// GetAvailableStreamingNodes is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *MockBalancer_Expecter) GetAvailableStreamingNodes(ctx interface{}) *MockBalancer_GetAvailableStreamingNodes_Call {
+	return &MockBalancer_GetAvailableStreamingNodes_Call{Call: _e.mock.On("GetAvailableStreamingNodes", ctx)}
+}
+
+func (_c *MockBalancer_GetAvailableStreamingNodes_Call) Run(run func(ctx context.Context)) *MockBalancer_GetAvailableStreamingNodes_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context))
+	})
+	return _c
+}
+
+func (_c *MockBalancer_GetAvailableStreamingNodes_Call) Return(_a0 map[int64]*types.StreamingNodeInfo, _a1 error) *MockBalancer_GetAvailableStreamingNodes_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockBalancer_GetAvailableStreamingNodes_Call) RunAndReturn(run func(context.Context) (map[int64]*types.StreamingNodeInfo, error)) *MockBalancer_GetAvailableStreamingNodes_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetLatestChannelAssignment provides a mock function with no fields
 func (_m *MockBalancer) GetLatestChannelAssignment() (*balancer.WatchChannelAssignmentsCallbackParam, error) {
 	ret := _m.Called()

--- a/internal/querycoordv2/observers/replica_observer_test.go
+++ b/internal/querycoordv2/observers/replica_observer_test.go
@@ -226,7 +226,7 @@ func (suite *ReplicaObserverSuite) TestCheckSQnodesInReplica() {
 		<-ctx.Done()
 		return ctx.Err()
 	})
-	b.EXPECT().GetAllStreamingNodes(mock.Anything).RunAndReturn(func(ctx context.Context) (map[int64]*types.StreamingNodeInfo, error) {
+	b.EXPECT().GetAvailableStreamingNodes(mock.Anything).RunAndReturn(func(ctx context.Context) (map[int64]*types.StreamingNodeInfo, error) {
 		pchans := []map[int64]*types.StreamingNodeInfo{
 			{
 				1: {ServerID: 1, Address: "localhost:1"},

--- a/internal/streamingcoord/server/balancer/balancer.go
+++ b/internal/streamingcoord/server/balancer/balancer.go
@@ -32,8 +32,11 @@ type Balancer interface {
 	// GetLatestChannelAssignment returns the latest channel assignment.
 	GetLatestChannelAssignment() (*WatchChannelAssignmentsCallbackParam, error)
 
-	// GetAllStreamingNodes fetches all streaming node info.
+	// GetAllStreamingNodes fetches all streaming node info (including frozen nodes).
 	GetAllStreamingNodes(ctx context.Context) (map[int64]*types.StreamingNodeInfo, error)
+
+	// GetAvailableStreamingNodes fetches streaming node info excluding frozen nodes.
+	GetAvailableStreamingNodes(ctx context.Context) (map[int64]*types.StreamingNodeInfo, error)
 
 	// AllocVirtualChannels allocates virtual channels for a collection.
 	AllocVirtualChannels(ctx context.Context, param AllocVChannelParam) ([]string, error)

--- a/internal/streamingcoord/server/balancer/balancer_impl.go
+++ b/internal/streamingcoord/server/balancer/balancer_impl.go
@@ -116,10 +116,13 @@ func (b *balancerImpl) ReplicateRole() replicateutil.Role {
 	return b.channelMetaManager.ReplicateRole()
 }
 
-// GetAllStreamingNodes fetches all streaming node info.
-// Filter out frozen nodes to prevent downstream consumers (e.g., ReplicaObserver)
-// from treating frozen nodes as available.
+// GetAllStreamingNodes fetches all streaming node info (including frozen nodes).
 func (b *balancerImpl) GetAllStreamingNodes(ctx context.Context) (map[int64]*types.StreamingNodeInfo, error) {
+	return resource.Resource().StreamingNodeManagerClient().GetAllStreamingNodes(ctx)
+}
+
+// GetAvailableStreamingNodes fetches streaming node info excluding frozen nodes.
+func (b *balancerImpl) GetAvailableStreamingNodes(ctx context.Context) (map[int64]*types.StreamingNodeInfo, error) {
 	nodes, err := resource.Resource().StreamingNodeManagerClient().GetAllStreamingNodes(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/streamingcoord/server/balancer/balancer_test.go
+++ b/internal/streamingcoord/server/balancer/balancer_test.go
@@ -231,12 +231,19 @@ func TestBalancer(t *testing.T) {
 	})
 	assert.ErrorIs(t, err, doneErr)
 
-	// Verify GetAllStreamingNodes filters out frozen node 1.
-	nodes, err := b.GetAllStreamingNodes(ctx)
+	// Verify GetAvailableStreamingNodes filters out frozen node 1.
+	nodes, err := b.GetAvailableStreamingNodes(ctx)
 	assert.NoError(t, err)
 	assert.NotContains(t, nodes, int64(1))
 	assert.Contains(t, nodes, int64(2))
 	assert.Contains(t, nodes, int64(3))
+
+	// Verify GetAllStreamingNodes still returns all nodes including frozen.
+	allNodes, err := b.GetAllStreamingNodes(ctx)
+	assert.NoError(t, err)
+	assert.Contains(t, allNodes, int64(1))
+	assert.Contains(t, allNodes, int64(2))
+	assert.Contains(t, allNodes, int64(3))
 
 	resp, err = b.UpdateBalancePolicy(ctx, &streamingpb.UpdateWALBalancePolicyRequest{
 		Config: &streamingpb.WALBalancePolicyConfig{
@@ -269,8 +276,8 @@ func TestBalancer(t *testing.T) {
 	assert.NoError(t, err)
 	b.Trigger(ctx)
 
-	// Verify GetAllStreamingNodes returns all nodes after defreeze.
-	nodes, err = b.GetAllStreamingNodes(ctx)
+	// Verify GetAvailableStreamingNodes returns all nodes after defreeze.
+	nodes, err = b.GetAvailableStreamingNodes(ctx)
 	assert.NoError(t, err)
 	assert.Contains(t, nodes, int64(1))
 	assert.Contains(t, nodes, int64(2))

--- a/internal/streamingcoord/server/broadcaster/broadcast/singleton_test.go
+++ b/internal/streamingcoord/server/broadcaster/broadcast/singleton_test.go
@@ -26,6 +26,7 @@ func newMockBalancerForTest(t *testing.T) *mock_balancer.MockBalancer {
 		return ctx.Err()
 	}).Maybe()
 	mb.EXPECT().GetAllStreamingNodes(mock.Anything).Return(map[int64]*types.StreamingNodeInfo{}, nil).Maybe()
+	mb.EXPECT().GetAvailableStreamingNodes(mock.Anything).Return(map[int64]*types.StreamingNodeInfo{}, nil).Maybe()
 	return mb
 }
 


### PR DESCRIPTION
issue: #47831

GetAllStreamingNodes now returns all nodes (including frozen) for REST API listing, while GetAvailableStreamingNodes filters frozen nodes for scheduling use (replica observer, query node ID lookup).