### PR TITLE
fix: Fix inverted index load failure caused by sliced files

### DIFF
--- a/internal/core/src/index/InvertedIndexTantivy.cpp
+++ b/internal/core/src/index/InvertedIndexTantivy.cpp
@@ -20,6 +20,7 @@
 #include <exception>
 #include <list>
 #include <map>
+#include <optional>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -285,19 +286,23 @@ InvertedIndexTantivy<T>::LoadIndexMetas(
         return;
     }
     std::vector<std::string> null_offset_files;
+    std::optional<std::string> slice_meta_file;
     for (auto& file : index_files) {
         auto file_name = boost::filesystem::path(file).filename().string();
         if (file_name.find(INDEX_NULL_OFFSET_FILE_NAME) != std::string::npos) {
             null_offset_files.push_back(file);
         }
 
-        // add slice meta file for null offset file compact
         if (file_name == INDEX_FILE_SLICE_META) {
-            null_offset_files.push_back(file);
+            slice_meta_file = file;
         }
     }
 
     if (null_offset_files.size() > 0) {
+        // slice meta is only needed when there are null_offset slices to compact.
+        if (slice_meta_file.has_value()) {
+            null_offset_files.push_back(slice_meta_file.value());
+        }
         // null offset file is sliced
         auto index_datas = this->file_manager_->LoadIndexToMemory(
             null_offset_files, load_priority);

--- a/internal/core/src/index/InvertedIndexTantivy.cpp
+++ b/internal/core/src/index/InvertedIndexTantivy.cpp
@@ -299,10 +299,9 @@ InvertedIndexTantivy<T>::LoadIndexMetas(
     }
 
     if (null_offset_files.size() > 0) {
-        // slice meta is only needed when there are null_offset slices to compact.
-        if (slice_meta_file.has_value()) {
-            null_offset_files.push_back(slice_meta_file.value());
-        }
+        AssertInfo(slice_meta_file.has_value(),
+                   "null offset slices found but _meta_slice is missing");
+        null_offset_files.push_back(slice_meta_file.value());
         // null offset file is sliced
         auto index_datas = this->file_manager_->LoadIndexToMemory(
             null_offset_files, load_priority);

--- a/internal/core/src/index/InvertedIndexTantivy.cpp
+++ b/internal/core/src/index/InvertedIndexTantivy.cpp
@@ -302,9 +302,11 @@ InvertedIndexTantivy<T>::LoadIndexMetas(
         auto index_datas = this->file_manager_->LoadIndexToMemory(
             null_offset_files, load_priority);
 
-        auto null_offsets_data = CompactIndexDatas(index_datas);
-        auto null_offsets_data_codecs =
-            std::move(null_offsets_data.at(INDEX_NULL_OFFSET_FILE_NAME));
+        auto slice_meta = std::move(index_datas.at(INDEX_FILE_SLICE_META));
+        auto null_offsets_data_codecs = CompactIndexDatasByKey(
+            INDEX_NULL_OFFSET_FILE_NAME, std::move(slice_meta), index_datas);
+        AssertInfo(null_offsets_data_codecs.codecs_.size() > 0,
+                   "null offset file is empty");
         for (auto&& null_offsets_codec : null_offsets_data_codecs.codecs_) {
             fill_null_offsets(null_offsets_codec->PayloadData(),
                               null_offsets_codec->PayloadSize());

--- a/internal/core/src/index/JsonInvertedIndex.cpp
+++ b/internal/core/src/index/JsonInvertedIndex.cpp
@@ -153,11 +153,14 @@ JsonInvertedIndex<T>::LoadIndexMetas(
         auto index_datas = this->file_manager_->LoadIndexToMemory(
             non_exist_offset_files, load_priority);
 
-        auto non_exist_offset_data = CompactIndexDatas(index_datas);
-        auto non_exist_offset_data_codecs = std::move(
-            non_exist_offset_data.at(INDEX_NON_EXIST_OFFSET_FILE_NAME));
-        for (auto&& non_exist_offset_codec :
-             non_exist_offset_data_codecs.codecs_) {
+        auto slice_meta = std::move(index_datas.at(INDEX_FILE_SLICE_META));
+        auto non_exist_offset_data =
+            CompactIndexDatasByKey(INDEX_NON_EXIST_OFFSET_FILE_NAME,
+                                   std::move(slice_meta),
+                                   index_datas);
+        AssertInfo(non_exist_offset_data.codecs_.size() > 0,
+                   "non exist offset file is empty");
+        for (auto&& non_exist_offset_codec : non_exist_offset_data.codecs_) {
             fill_non_exist_offset(non_exist_offset_codec->PayloadData(),
                                   non_exist_offset_codec->PayloadSize());
         }

--- a/internal/core/src/index/JsonInvertedIndex.cpp
+++ b/internal/core/src/index/JsonInvertedIndex.cpp
@@ -149,11 +149,10 @@ JsonInvertedIndex<T>::LoadIndexMetas(
         }
     }
     if (non_exist_offset_files.size() > 0) {
-        // slice meta is only needed when there are non_exist_offset slices to compact.
-        if (slice_meta_file.has_value()) {
-            non_exist_offset_files.push_back(slice_meta_file.value());
-        }
-        // null offset file is sliced
+        AssertInfo(slice_meta_file.has_value(),
+                   "non_exist_offset slices found but _meta_slice is missing");
+        non_exist_offset_files.push_back(slice_meta_file.value());
+        // non_exist offset file is sliced
         auto index_datas = this->file_manager_->LoadIndexToMemory(
             non_exist_offset_files, load_priority);
 

--- a/internal/core/src/index/JsonInvertedIndex.cpp
+++ b/internal/core/src/index/JsonInvertedIndex.cpp
@@ -137,18 +137,22 @@ JsonInvertedIndex<T>::LoadIndexMetas(
         return;
     }
     std::vector<std::string> non_exist_offset_files;
+    std::optional<std::string> slice_meta_file;
     for (auto& file : index_files) {
         auto file_name = boost::filesystem::path(file).filename().string();
         if (file_name.find(INDEX_NON_EXIST_OFFSET_FILE_NAME) !=
             std::string::npos) {
             non_exist_offset_files.push_back(file);
         }
-        // add slice meta file for null offset file compact
         if (file_name == INDEX_FILE_SLICE_META) {
-            non_exist_offset_files.push_back(file);
+            slice_meta_file = file;
         }
     }
     if (non_exist_offset_files.size() > 0) {
+        // slice meta is only needed when there are non_exist_offset slices to compact.
+        if (slice_meta_file.has_value()) {
+            non_exist_offset_files.push_back(slice_meta_file.value());
+        }
         // null offset file is sliced
         auto index_datas = this->file_manager_->LoadIndexToMemory(
             non_exist_offset_files, load_priority);

--- a/internal/core/src/index/JsonInvertedIndexTest.cpp
+++ b/internal/core/src/index/JsonInvertedIndexTest.cpp
@@ -9,9 +9,6 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
-#include <boost/filesystem.hpp>
-#include <gtest/gtest.h>
-#include <simdjson.h>
 #include <cstdint>
 #include <map>
 #include <memory>
@@ -20,6 +17,11 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+
+#include <arrow/api.h>
+#include <boost/filesystem.hpp>
+#include <gtest/gtest.h>
+#include <simdjson.h>
 
 #include "NamedType/named_type_impl.hpp"
 #include "bitset/bitset.h"
@@ -445,10 +447,23 @@ TEST(JsonIndexTest, TestSlicedOffsetFilesLoadIndependently) {
     for (size_t i = 0; i < 20; ++i) {
         valid_data[i / 8] &= ~(1U << (i % 8));
     }
-    json_field->FillFieldData(jsons.data(),
-                              valid_data.data(),
-                              jsons.size(),
-                              0);
+
+    arrow::BinaryBuilder builder;
+    for (size_t i = 0; i < jsons.size(); ++i) {
+        auto is_valid = (valid_data[i / 8] >> (i % 8)) & 1U;
+        if (!is_valid) {
+            ASSERT_TRUE(builder.AppendNull().ok());
+            continue;
+        }
+        auto data = jsons[i].data();
+        ASSERT_TRUE(
+            builder.Append(data.data(), static_cast<int32_t>(data.size()))
+                .ok());
+    }
+
+    std::shared_ptr<arrow::Array> json_array;
+    ASSERT_TRUE(builder.Finish(&json_array).ok());
+    json_field->FillFieldData(json_array);
     json_index->BuildWithFieldData({json_field});
     json_index->finish();
 
@@ -464,9 +479,9 @@ TEST(JsonIndexTest, TestSlicedOffsetFilesLoadIndependently) {
         << "non_exist_offset should be sliced into parts";
 
     auto slice_meta_bin = binary_set.binary_map_.at(INDEX_FILE_SLICE_META);
-    auto slice_meta = Config::parse(std::string(
-        reinterpret_cast<const char*>(slice_meta_bin->data.get()),
-        slice_meta_bin->size));
+    auto slice_meta = Config::parse(
+        std::string(reinterpret_cast<const char*>(slice_meta_bin->data.get()),
+                    slice_meta_bin->size));
 
     auto slice_num_for = [&](const std::string& target_key) {
         for (const auto& item : slice_meta[META]) {
@@ -486,8 +501,8 @@ TEST(JsonIndexTest, TestSlicedOffsetFilesLoadIndependently) {
         for (int i = 0; i < slice_num_for(target_key); ++i) {
             auto slice_name = GenSlicedFileName(target_key, i);
             auto bin = binary_set.binary_map_.at(slice_name);
-            result[slice_name] =
-                std::make_unique<storage::IndexData>(bin->data.get(), bin->size);
+            result[slice_name] = std::make_unique<storage::IndexData>(
+                bin->data.get(), bin->size);
         }
         return result;
     };

--- a/internal/core/src/index/JsonInvertedIndexTest.cpp
+++ b/internal/core/src/index/JsonInvertedIndexTest.cpp
@@ -9,6 +9,7 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
+#include <boost/filesystem.hpp>
 #include <gtest/gtest.h>
 #include <simdjson.h>
 #include <cstdint>
@@ -53,11 +54,96 @@
 #include "storage/FileManager.h"
 #include "storage/RemoteChunkManagerSingleton.h"
 #include "storage/Types.h"
+#include "storage/Util.h"
 #include "test_utils/cachinglayer_test_utils.h"
 #include "test_utils/storage_test_utils.h"
 
 using namespace milvus;
 using namespace milvus::index;
+
+namespace {
+
+struct FileSliceSizeGuard {
+    explicit FileSliceSizeGuard(int64_t slice_size)
+        : old_slice_size_(FILE_SLICE_SIZE.load()) {
+        FILE_SLICE_SIZE.store(slice_size);
+    }
+
+    ~FileSliceSizeGuard() {
+        FILE_SLICE_SIZE.store(old_slice_size_);
+    }
+
+    int64_t old_slice_size_;
+};
+
+int64_t
+BuildAndLoadJsonInvertedIndexForOffsetRegression(
+    const std::vector<std::string>& json_raw_data) {
+    constexpr int64_t collection_id = 1;
+    constexpr int64_t partition_id = 2;
+    constexpr int64_t segment_id = 3;
+    constexpr int64_t field_id = 101;
+    constexpr int64_t index_build_id = 4000;
+    constexpr int64_t index_version = 4000;
+
+    auto field_meta = milvus::segcore::gen_field_meta(collection_id,
+                                                      partition_id,
+                                                      segment_id,
+                                                      field_id,
+                                                      DataType::JSON);
+    auto index_meta =
+        gen_index_meta(segment_id, field_id, index_build_id, index_version);
+
+    auto root_path =
+        (boost::filesystem::path(TestLocalPath) /
+         boost::filesystem::unique_path("json-offset-regression-%%%%-%%%%"))
+            .string();
+    auto storage_config = gen_local_storage_config(root_path);
+    auto cm = storage::CreateChunkManager(storage_config);
+    auto fs = storage::InitArrowFileSystem(storage_config);
+    ChunkManagerWrapper cm_w(cm);
+
+    storage::FileManagerContext build_ctx(field_meta, index_meta, cm, fs);
+    index::CreateIndexInfo create_index_info;
+    create_index_info.index_type = index::INVERTED_INDEX_TYPE;
+    create_index_info.json_cast_type = JsonCastType::FromString("DOUBLE");
+    create_index_info.json_path = "/a";
+
+    auto build_index = index::IndexFactory::GetInstance().CreateJsonIndex(
+        create_index_info, build_ctx);
+    auto json_index = std::unique_ptr<JsonInvertedIndex<double>>(
+        static_cast<JsonInvertedIndex<double>*>(build_index.release()));
+
+    std::vector<milvus::Json> jsons;
+    jsons.reserve(json_raw_data.size());
+    for (auto& json : json_raw_data) {
+        jsons.push_back(milvus::Json(simdjson::padded_string(json)));
+    }
+
+    auto json_field =
+        std::make_shared<FieldData<milvus::Json>>(DataType::JSON, false);
+    json_field->add_json_data(jsons);
+    json_index->BuildWithFieldData({json_field});
+
+    auto stats = json_index->Upload();
+    auto index_files = stats->GetIndexFiles();
+
+    build_ctx.set_for_loading_index(true);
+    auto load_index = index::IndexFactory::GetInstance().CreateJsonIndex(
+        create_index_info, build_ctx);
+    auto loaded_json_index = std::unique_ptr<JsonInvertedIndex<double>>(
+        static_cast<JsonInvertedIndex<double>*>(load_index.release()));
+
+    Config load_config;
+    load_config[index::INDEX_FILES] = index_files;
+    load_config[milvus::LOAD_PRIORITY] =
+        milvus::proto::common::LoadPriority::HIGH;
+
+    loaded_json_index->Load(milvus::tracer::TraceContext{}, load_config);
+    return loaded_json_index->Count();
+}
+
+}  // namespace
 
 TEST(JsonIndexTest, TestJSONErrRecorder) {
     std::vector<std::string> json_raw_data = {
@@ -315,8 +401,7 @@ TEST(JsonIndexTest, TestJsonCast) {
 // find ALL slices referenced in _meta_slice, not just the target key's.
 TEST(JsonIndexTest, TestSlicedOffsetFilesLoadIndependently) {
     // Use a small slice size so both offset files get sliced.
-    auto old_slice_size = FILE_SLICE_SIZE.load();
-    FILE_SLICE_SIZE.store(64);
+    FileSliceSizeGuard slice_size_guard(64);
 
     auto schema = std::make_shared<Schema>();
     auto json_fid = schema->AddDebugField("json", DataType::JSON);
@@ -416,5 +501,36 @@ TEST(JsonIndexTest, TestSlicedOffsetFilesLoadIndependently) {
         EXPECT_EQ(result.size_, 20 * sizeof(size_t));
     }
 
-    FILE_SLICE_SIZE.store(old_slice_size);
+}
+
+TEST(JsonIndexTest, TestLoadWithOnlySlicedNonExistOffsets) {
+    FileSliceSizeGuard slice_size_guard(64);
+
+    std::vector<std::string> json_raw_data;
+    for (int i = 0; i < 20; ++i) {
+        json_raw_data.emplace_back(R"({"b": 1})");
+    }
+    for (int i = 0; i < 10; ++i) {
+        json_raw_data.emplace_back(R"({"a": 1.0})");
+    }
+
+    EXPECT_EQ(
+        BuildAndLoadJsonInvertedIndexForOffsetRegression(json_raw_data),
+        json_raw_data.size());
+}
+
+TEST(JsonIndexTest, TestLoadWithOnlySlicedNullOffsets) {
+    FileSliceSizeGuard slice_size_guard(64);
+
+    std::vector<std::string> json_raw_data;
+    for (int i = 0; i < 20; ++i) {
+        json_raw_data.emplace_back(R"({"a": null})");
+    }
+    for (int i = 0; i < 10; ++i) {
+        json_raw_data.emplace_back(R"({"a": 1.0})");
+    }
+
+    EXPECT_EQ(
+        BuildAndLoadJsonInvertedIndexForOffsetRegression(json_raw_data),
+        json_raw_data.size());
 }

--- a/internal/core/src/index/JsonInvertedIndexTest.cpp
+++ b/internal/core/src/index/JsonInvertedIndexTest.cpp
@@ -86,11 +86,8 @@ BuildAndLoadJsonInvertedIndexForOffsetRegression(
     constexpr int64_t index_build_id = 4000;
     constexpr int64_t index_version = 4000;
 
-    auto field_meta = milvus::segcore::gen_field_meta(collection_id,
-                                                      partition_id,
-                                                      segment_id,
-                                                      field_id,
-                                                      DataType::JSON);
+    auto field_meta = milvus::segcore::gen_field_meta(
+        collection_id, partition_id, segment_id, field_id, DataType::JSON);
     auto index_meta =
         gen_index_meta(segment_id, field_id, index_build_id, index_version);
 
@@ -416,8 +413,8 @@ TEST(JsonIndexTest, TestSlicedOffsetFilesLoadIndependently) {
     cii.index_type = index::INVERTED_INDEX_TYPE;
     cii.json_cast_type = JsonCastType::FromString("DOUBLE");
     cii.json_path = "/a";
-    auto inv_index =
-        index::IndexFactory::GetInstance().CreateJsonIndex(cii, file_manager_ctx);
+    auto inv_index = index::IndexFactory::GetInstance().CreateJsonIndex(
+        cii, file_manager_ctx);
     auto json_index = std::unique_ptr<JsonInvertedIndex<double>>(
         static_cast<JsonInvertedIndex<double>*>(inv_index.release()));
 
@@ -433,12 +430,10 @@ TEST(JsonIndexTest, TestSlicedOffsetFilesLoadIndependently) {
             milvus::Json(simdjson::padded_string(R"({"a": null})")));
     }
     for (int i = 0; i < 20; i++) {
-        jsons.push_back(
-            milvus::Json(simdjson::padded_string(R"({"b": 1})")));
+        jsons.push_back(milvus::Json(simdjson::padded_string(R"({"b": 1})")));
     }
     for (int i = 0; i < 10; i++) {
-        jsons.push_back(
-            milvus::Json(simdjson::padded_string(R"({"a": 1.0})")));
+        jsons.push_back(milvus::Json(simdjson::padded_string(R"({"a": 1.0})")));
     }
 
     auto json_field =
@@ -500,7 +495,6 @@ TEST(JsonIndexTest, TestSlicedOffsetFilesLoadIndependently) {
         EXPECT_GT(result.codecs_.size(), 0);
         EXPECT_EQ(result.size_, 20 * sizeof(size_t));
     }
-
 }
 
 TEST(JsonIndexTest, TestLoadWithOnlySlicedNonExistOffsets) {
@@ -514,9 +508,8 @@ TEST(JsonIndexTest, TestLoadWithOnlySlicedNonExistOffsets) {
         json_raw_data.emplace_back(R"({"a": 1.0})");
     }
 
-    EXPECT_EQ(
-        BuildAndLoadJsonInvertedIndexForOffsetRegression(json_raw_data),
-        json_raw_data.size());
+    EXPECT_EQ(BuildAndLoadJsonInvertedIndexForOffsetRegression(json_raw_data),
+              json_raw_data.size());
 }
 
 TEST(JsonIndexTest, TestLoadWithOnlySlicedNullOffsets) {
@@ -530,7 +523,6 @@ TEST(JsonIndexTest, TestLoadWithOnlySlicedNullOffsets) {
         json_raw_data.emplace_back(R"({"a": 1.0})");
     }
 
-    EXPECT_EQ(
-        BuildAndLoadJsonInvertedIndexForOffsetRegression(json_raw_data),
-        json_raw_data.size());
+    EXPECT_EQ(BuildAndLoadJsonInvertedIndexForOffsetRegression(json_raw_data),
+              json_raw_data.size());
 }

--- a/internal/core/src/index/JsonInvertedIndexTest.cpp
+++ b/internal/core/src/index/JsonInvertedIndexTest.cpp
@@ -22,7 +22,10 @@
 
 #include "NamedType/named_type_impl.hpp"
 #include "bitset/bitset.h"
+#include "common/Common.h"
 #include "common/Consts.h"
+#include "common/Slice.h"
+#include "storage/IndexData.h"
 #include "common/FieldData.h"
 #include "common/Json.h"
 #include "common/JsonCastType.h"
@@ -300,4 +303,118 @@ TEST(JsonIndexTest, TestJsonCast) {
             EXPECT_TRUE(result[id]);
         }
     }
+}
+
+// Verify that JsonInvertedIndex::Serialize correctly produces sliced
+// null_offset and non_exist_offset files, and that CompactIndexDatasByKey
+// can reassemble each independently from the shared _meta_slice.
+//
+// This reproduces the bug where both offset files shared a single
+// _meta_slice after Disassemble, but LoadIndexMetas downloaded them
+// separately. The old CompactIndexDatas fails because it tries to
+// find ALL slices referenced in _meta_slice, not just the target key's.
+TEST(JsonIndexTest, TestSlicedOffsetFilesLoadIndependently) {
+    // Use a small slice size so both offset files get sliced.
+    auto old_slice_size = FILE_SLICE_SIZE.load();
+    FILE_SLICE_SIZE.store(64);
+
+    auto schema = std::make_shared<Schema>();
+    auto json_fid = schema->AddDebugField("json", DataType::JSON);
+
+    auto file_manager_ctx = storage::FileManagerContext();
+    file_manager_ctx.fieldDataMeta.field_schema.set_data_type(
+        milvus::proto::schema::JSON);
+    file_manager_ctx.fieldDataMeta.field_schema.set_fieldid(json_fid.get());
+    file_manager_ctx.fieldDataMeta.field_id = json_fid.get();
+
+    index::CreateIndexInfo cii;
+    cii.index_type = index::INVERTED_INDEX_TYPE;
+    cii.json_cast_type = JsonCastType::FromString("DOUBLE");
+    cii.json_path = "/a";
+    auto inv_index =
+        index::IndexFactory::GetInstance().CreateJsonIndex(cii, file_manager_ctx);
+    auto json_index = std::unique_ptr<JsonInvertedIndex<double>>(
+        static_cast<JsonInvertedIndex<double>*>(inv_index.release()));
+
+    // Build with enough rows to produce large null_offset and
+    // non_exist_offset arrays (each > FILE_SLICE_SIZE = 64 bytes).
+    // - {"a": null}  → null_offset  (8 bytes per entry)
+    // - {"b": 1}     → non_exist_offset (key "a" doesn't exist)
+    // - {"a": 1.0}   → valid data (neither offset)
+    // 20 nulls + 20 non-exist → 160 bytes each, well above 64.
+    std::vector<milvus::Json> jsons;
+    for (int i = 0; i < 20; i++) {
+        jsons.push_back(
+            milvus::Json(simdjson::padded_string(R"({"a": null})")));
+    }
+    for (int i = 0; i < 20; i++) {
+        jsons.push_back(
+            milvus::Json(simdjson::padded_string(R"({"b": 1})")));
+    }
+    for (int i = 0; i < 10; i++) {
+        jsons.push_back(
+            milvus::Json(simdjson::padded_string(R"({"a": 1.0})")));
+    }
+
+    auto json_field =
+        std::make_shared<FieldData<milvus::Json>>(DataType::JSON, false);
+    json_field->add_json_data(jsons);
+    json_index->BuildWithFieldData({json_field});
+    json_index->finish();
+
+    // Serialize calls Disassemble which creates a shared _meta_slice.
+    auto binary_set = json_index->Serialize({});
+
+    // Verify slicing occurred: _meta_slice exists, originals are gone.
+    ASSERT_TRUE(binary_set.Contains(INDEX_FILE_SLICE_META))
+        << "_meta_slice should exist when both offset files are sliced";
+    ASSERT_FALSE(binary_set.Contains(INDEX_NULL_OFFSET_FILE_NAME))
+        << "null_offset should be sliced into parts";
+    ASSERT_FALSE(binary_set.Contains(INDEX_NON_EXIST_OFFSET_FILE_NAME))
+        << "non_exist_offset should be sliced into parts";
+
+    // Helper: build a partial index_datas map containing only slices for
+    // the given key plus _meta_slice (simulates LoadIndexToMemory).
+    auto make_partial_datas = [&](const std::string& target_key) {
+        std::map<std::string, std::unique_ptr<storage::DataCodec>> result;
+        for (auto& [name, bin] : binary_set.binary_map_) {
+            if (name == INDEX_FILE_SLICE_META ||
+                name.find(target_key) != std::string::npos) {
+                result[name] = std::make_unique<storage::IndexData>(
+                    bin->data.get(), bin->size);
+            }
+        }
+        return result;
+    };
+
+    // --- Verify the bug: old CompactIndexDatas fails with partial data ---
+    {
+        auto partial = make_partial_datas(INDEX_NULL_OFFSET_FILE_NAME);
+        ASSERT_GT(partial.size(), 1);
+        // _meta_slice references both null_offset and non_exist_offset slices,
+        // but only null_offset slices are in the map → assertion failure.
+        EXPECT_THROW(CompactIndexDatas(partial), std::exception);
+    }
+
+    // --- Verify the fix: CompactIndexDatasByKey with null_offset ---
+    {
+        auto partial = make_partial_datas(INDEX_NULL_OFFSET_FILE_NAME);
+        auto slice_meta = std::move(partial.at(INDEX_FILE_SLICE_META));
+        auto result = CompactIndexDatasByKey(
+            INDEX_NULL_OFFSET_FILE_NAME, std::move(slice_meta), partial);
+        EXPECT_GT(result.codecs_.size(), 0);
+        EXPECT_EQ(result.size_, 20 * sizeof(size_t));
+    }
+
+    // --- Verify the fix: CompactIndexDatasByKey with non_exist_offset ---
+    {
+        auto partial = make_partial_datas(INDEX_NON_EXIST_OFFSET_FILE_NAME);
+        auto slice_meta = std::move(partial.at(INDEX_FILE_SLICE_META));
+        auto result = CompactIndexDatasByKey(
+            INDEX_NON_EXIST_OFFSET_FILE_NAME, std::move(slice_meta), partial);
+        EXPECT_GT(result.codecs_.size(), 0);
+        EXPECT_EQ(result.size_, 20 * sizeof(size_t));
+    }
+
+    FILE_SLICE_SIZE.store(old_slice_size);
 }

--- a/internal/core/src/index/JsonInvertedIndexTest.cpp
+++ b/internal/core/src/index/JsonInvertedIndexTest.cpp
@@ -407,6 +407,7 @@ TEST(JsonIndexTest, TestSlicedOffsetFilesLoadIndependently) {
     file_manager_ctx.fieldDataMeta.field_schema.set_data_type(
         milvus::proto::schema::JSON);
     file_manager_ctx.fieldDataMeta.field_schema.set_fieldid(json_fid.get());
+    file_manager_ctx.fieldDataMeta.field_schema.set_nullable(true);
     file_manager_ctx.fieldDataMeta.field_id = json_fid.get();
 
     index::CreateIndexInfo cii;
@@ -420,14 +421,14 @@ TEST(JsonIndexTest, TestSlicedOffsetFilesLoadIndependently) {
 
     // Build with enough rows to produce large null_offset and
     // non_exist_offset arrays (each > FILE_SLICE_SIZE = 64 bytes).
-    // - {"a": null}  → null_offset  (8 bytes per entry)
-    // - {"b": 1}     → non_exist_offset (key "a" doesn't exist)
-    // - {"a": 1.0}   → valid data (neither offset)
-    // 20 nulls + 20 non-exist → 160 bytes each, well above 64.
+    // - invalid row   → null_offset + non_exist_offset (8 bytes per entry)
+    // - {"b": 1}      → non_exist_offset only (key "a" doesn't exist)
+    // - {"a": 1.0}    → valid data (neither offset)
+    // 20 invalid + 20 missing-path rows make both files slice reliably.
     std::vector<milvus::Json> jsons;
     for (int i = 0; i < 20; i++) {
         jsons.push_back(milvus::Json(
-            simdjson::padded_string(std::string_view(R"({"a": null})"))));
+            simdjson::padded_string(std::string_view(R"({"a": 1.0})"))));
     }
     for (int i = 0; i < 20; i++) {
         jsons.push_back(milvus::Json(
@@ -439,8 +440,15 @@ TEST(JsonIndexTest, TestSlicedOffsetFilesLoadIndependently) {
     }
 
     auto json_field =
-        std::make_shared<FieldData<milvus::Json>>(DataType::JSON, false);
-    json_field->add_json_data(jsons);
+        std::make_shared<FieldData<milvus::Json>>(DataType::JSON, true);
+    std::vector<uint8_t> valid_data((jsons.size() + 7) / 8, 0xFF);
+    for (size_t i = 0; i < 20; ++i) {
+        valid_data[i / 8] &= ~(1U << (i % 8));
+    }
+    json_field->FillFieldData(jsons.data(),
+                              valid_data.data(),
+                              jsons.size(),
+                              0);
     json_index->BuildWithFieldData({json_field});
     json_index->finish();
 
@@ -455,16 +463,31 @@ TEST(JsonIndexTest, TestSlicedOffsetFilesLoadIndependently) {
     ASSERT_FALSE(binary_set.Contains(INDEX_NON_EXIST_OFFSET_FILE_NAME))
         << "non_exist_offset should be sliced into parts";
 
+    auto slice_meta_bin = binary_set.binary_map_.at(INDEX_FILE_SLICE_META);
+    auto slice_meta = Config::parse(std::string(
+        reinterpret_cast<const char*>(slice_meta_bin->data.get()),
+        slice_meta_bin->size));
+
+    auto slice_num_for = [&](const std::string& target_key) {
+        for (const auto& item : slice_meta[META]) {
+            if (item[NAME] == target_key) {
+                return static_cast<int>(item[SLICE_NUM]);
+            }
+        }
+        return 0;
+    };
+
     // Helper: build a partial index_datas map containing only slices for
     // the given key plus _meta_slice (simulates LoadIndexToMemory).
     auto make_partial_datas = [&](const std::string& target_key) {
         std::map<std::string, std::unique_ptr<storage::DataCodec>> result;
-        for (auto& [name, bin] : binary_set.binary_map_) {
-            if (name == INDEX_FILE_SLICE_META ||
-                name.find(target_key) != std::string::npos) {
-                result[name] = std::make_unique<storage::IndexData>(
-                    bin->data.get(), bin->size);
-            }
+        result[INDEX_FILE_SLICE_META] = std::make_unique<storage::IndexData>(
+            slice_meta_bin->data.get(), slice_meta_bin->size);
+        for (int i = 0; i < slice_num_for(target_key); ++i) {
+            auto slice_name = GenSlicedFileName(target_key, i);
+            auto bin = binary_set.binary_map_.at(slice_name);
+            result[slice_name] =
+                std::make_unique<storage::IndexData>(bin->data.get(), bin->size);
         }
         return result;
     };
@@ -495,7 +518,7 @@ TEST(JsonIndexTest, TestSlicedOffsetFilesLoadIndependently) {
         auto result = CompactIndexDatasByKey(
             INDEX_NON_EXIST_OFFSET_FILE_NAME, std::move(slice_meta), partial);
         EXPECT_GT(result.codecs_.size(), 0);
-        EXPECT_EQ(result.size_, 20 * sizeof(size_t));
+        EXPECT_EQ(result.size_, 40 * sizeof(size_t));
     }
 }
 

--- a/internal/core/src/index/JsonInvertedIndexTest.cpp
+++ b/internal/core/src/index/JsonInvertedIndexTest.cpp
@@ -426,14 +426,16 @@ TEST(JsonIndexTest, TestSlicedOffsetFilesLoadIndependently) {
     // 20 nulls + 20 non-exist → 160 bytes each, well above 64.
     std::vector<milvus::Json> jsons;
     for (int i = 0; i < 20; i++) {
-        jsons.push_back(
-            milvus::Json(simdjson::padded_string(R"({"a": null})")));
+        jsons.push_back(milvus::Json(
+            simdjson::padded_string(std::string_view(R"({"a": null})"))));
     }
     for (int i = 0; i < 20; i++) {
-        jsons.push_back(milvus::Json(simdjson::padded_string(R"({"b": 1})")));
+        jsons.push_back(milvus::Json(
+            simdjson::padded_string(std::string_view(R"({"b": 1})"))));
     }
     for (int i = 0; i < 10; i++) {
-        jsons.push_back(milvus::Json(simdjson::padded_string(R"({"a": 1.0})")));
+        jsons.push_back(milvus::Json(
+            simdjson::padded_string(std::string_view(R"({"a": 1.0})"))));
     }
 
     auto json_field =

--- a/internal/core/src/index/Utils.cpp
+++ b/internal/core/src/index/Utils.cpp
@@ -342,6 +342,46 @@ CompactIndexDatas(
     return index_file_slices;
 }
 
+IndexDataCodec
+CompactIndexDatasByKey(
+    const std::string& key,
+    std::unique_ptr<storage::DataCodec> slice_meta,
+    std::map<std::string, std::unique_ptr<storage::DataCodec>>& index_datas) {
+    Config meta_data = Config::parse(
+        std::string(reinterpret_cast<const char*>(slice_meta->PayloadData()),
+                    slice_meta->PayloadSize()));
+
+    int slice_num = 0;
+    size_t total_len = 0;
+    bool found = false;
+    for (const auto& item : meta_data[META]) {
+        if (item[NAME] == key) {
+            slice_num = item[SLICE_NUM];
+            total_len = static_cast<size_t>(item[TOTAL_LEN]);
+            found = true;
+            break;
+        }
+    }
+
+    if (!found) {
+        return {};
+    }
+
+    IndexDataCodec index_data_codec;
+    size_t data_len = 0;
+    for (auto i = 0; i < slice_num; ++i) {
+        std::string file_name = GenSlicedFileName(key, i);
+        auto it = index_datas.find(file_name);
+        AssertInfo(it != index_datas.end(), "lost index slice data");
+        index_data_codec.codecs_.push_back(std::move(it->second));
+        data_len += index_data_codec.codecs_.back()->PayloadSize();
+    }
+    AssertInfo(total_len == data_len,
+               "index len is inconsistent after disassemble and assemble");
+    index_data_codec.size_ = data_len;
+    return index_data_codec;
+}
+
 void
 AssembleIndexDatas(
     std::map<std::string, std::unique_ptr<storage::DataCodec>>& index_datas,

--- a/internal/core/src/index/Utils.h
+++ b/internal/core/src/index/Utils.h
@@ -196,6 +196,12 @@ std::map<std::string, IndexDataCodec>
 CompactIndexDatas(
     std::map<std::string, std::unique_ptr<storage::DataCodec>>& index_datas);
 
+IndexDataCodec
+CompactIndexDatasByKey(
+    const std::string& key,
+    std::unique_ptr<storage::DataCodec> slice_meta,
+    std::map<std::string, std::unique_ptr<storage::DataCodec>>& index_datas);
+
 void
 AssembleIndexDatas(
     std::map<std::string, std::unique_ptr<storage::DataCodec>>& index_datas,


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/48294
In CompactIndexDatas, slice meta may contain files that are not in index_datas. So compact will fail. Now we specify key when loading inverted index to avoid it.