### PR TITLE
enhance: [loon] support V3 storage segment GC with basePath-based deletion

### DIFF
--- a/internal/datacoord/garbage_collector.go
+++ b/internal/datacoord/garbage_collector.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -33,6 +35,7 @@ import (
 	"github.com/milvus-io/milvus/internal/metastore/kv/binlog"
 	"github.com/milvus-io/milvus/internal/metastore/model"
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/metrics"
@@ -607,6 +610,16 @@ func (gc *garbageCollector) recycleUnusedBinLogWithChecker(ctx context.Context, 
 		// TODO: Does all files in the same segment have the same segmentID?
 		segmentID, err := storage.ParseSegmentIDByBinlog(gc.option.cli.RootPath(), chunkInfo.FilePath)
 		if err != nil {
+			// Try V3 path format: insert_log/{coll}/{part}/{seg}/...
+			// V3 orphan files are managed by loon (milvus-storage), skip them.
+			if v3SegID, parseErr := parseV3SegmentID(gc.option.cli.RootPath(), chunkInfo.FilePath); parseErr == nil {
+				v3Seg := gc.meta.GetSegment(ctx, v3SegID)
+				if v3Seg == nil || v3Seg.GetStorageVersion() == storage.StorageV3 {
+					// V3 segment file or orphan V3 file — skip, managed by loon
+					valid++
+					return true
+				}
+			}
 			unexpectedFailure.Inc()
 			logger.Warn("garbageCollector recycleUnusedBinlogFiles parse segment id error",
 				zap.String("filePath", chunkInfo.FilePath),
@@ -615,6 +628,13 @@ func (gc *garbageCollector) recycleUnusedBinLogWithChecker(ctx context.Context, 
 		}
 
 		segment := gc.meta.GetSegment(ctx, segmentID)
+
+		// Skip V3 segments — orphan files managed by loon
+		if segment != nil && segment.GetStorageVersion() == storage.StorageV3 {
+			valid++
+			return true
+		}
+
 		if checker(chunkInfo, segment) {
 			valid++
 			logger.Info("garbageCollector recycleUnusedBinlogFiles skip file since it is valid", zap.String("filePath", chunkInfo.FilePath), zap.Int64("segmentID", segmentID))
@@ -813,6 +833,37 @@ func (gc *garbageCollector) recycleDroppedSegments(ctx context.Context, signal <
 		}
 
 		cloned := segment.Clone()
+
+		// V3 segment: delete entire basePath recursively
+		if cloned.GetStorageVersion() == storage.StorageV3 {
+			basePath, _, err := packed.UnmarshalManifestPath(cloned.GetManifestPath())
+			if err != nil {
+				log.Warn("GC V3 segment failed to parse manifest path",
+					zap.String("manifestPath", cloned.GetManifestPath()),
+					zap.Error(err))
+				cloned = nil
+				continue
+			}
+			log.Info("GC V3 segment start, removing basePath...",
+				zap.String("basePath", basePath))
+			if err := gc.option.cli.RemoveWithPrefix(ctx, basePath); err != nil {
+				log.Warn("GC V3 segment remove basePath failed",
+					zap.String("basePath", basePath),
+					zap.Error(err))
+				cloned = nil
+				continue
+			}
+			if err := gc.meta.DropSegment(ctx, cloned.GetID()); err != nil {
+				log.Warn("GC segment meta failed to drop segment", zap.Error(err))
+				cloned = nil
+				continue
+			}
+			log.Info("GC V3 segment done")
+			cloned = nil
+			continue
+		}
+
+		// V1/V2 segment: delete individual log files
 		binlog.DecompressBinLogs(cloned.SegmentInfo)
 
 		logs := getLogs(cloned)
@@ -914,6 +965,22 @@ func (gc *garbageCollector) recycleChannelCPMeta(ctx context.Context, signal <-c
 func (gc *garbageCollector) isExpire(dropts Timestamp) bool {
 	droptime := time.Unix(0, int64(dropts))
 	return time.Since(droptime) > gc.option.dropTolerance
+}
+
+// parseV3SegmentID attempts to parse segmentID from a V3 path format.
+// V3 paths: {root}/insert_log/{coll}/{part}/{seg}/...
+// Returns segmentID or error if path doesn't match.
+func parseV3SegmentID(rootPath, filePath string) (int64, error) {
+	if !strings.HasPrefix(filePath, rootPath) {
+		return 0, fmt.Errorf("path %q does not contain rootPath %q", filePath, rootPath)
+	}
+	p := strings.TrimPrefix(filePath[len(rootPath):], "/")
+	parts := strings.Split(p, "/")
+	// Minimum: insert_log/coll/part/seg/something
+	if len(parts) < 5 || parts[0] != common.SegmentInsertLogPath {
+		return 0, fmt.Errorf("not a V3 insert_log path: %s", filePath)
+	}
+	return strconv.ParseInt(parts[3], 10, 64)
 }
 
 func getLogs(sinfo *SegmentInfo) map[string]struct{} {

--- a/internal/datacoord/garbage_collector_test.go
+++ b/internal/datacoord/garbage_collector_test.go
@@ -49,6 +49,7 @@ import (
 	"github.com/milvus-io/milvus/internal/metastore/model"
 	"github.com/milvus-io/milvus/internal/mocks"
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/objectstorage"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
@@ -2972,4 +2973,264 @@ func TestGarbageCollector_recycleUnusedJSONStatsFiles_SnapshotReference(t *testi
 
 	assert.Empty(t, removedFiles,
 		"JSON stats files should not be removed when segment is referenced by snapshot")
+}
+
+func Test_parseV3SegmentID(t *testing.T) {
+	rootPath := "files"
+
+	t.Run("valid V3 data path", func(t *testing.T) {
+		segID, err := parseV3SegmentID(rootPath, "files/insert_log/1/10/100/_data/0_abc.parquet")
+		assert.NoError(t, err)
+		assert.Equal(t, int64(100), segID)
+	})
+
+	t.Run("valid V3 stats path", func(t *testing.T) {
+		segID, err := parseV3SegmentID(rootPath, "files/insert_log/1/10/200/_stats/bloom_filter.101/42")
+		assert.NoError(t, err)
+		assert.Equal(t, int64(200), segID)
+	})
+
+	t.Run("valid V3 delta path", func(t *testing.T) {
+		segID, err := parseV3SegmentID(rootPath, "files/insert_log/1/10/300/_delta/501")
+		assert.NoError(t, err)
+		assert.Equal(t, int64(300), segID)
+	})
+
+	t.Run("valid V3 metadata path", func(t *testing.T) {
+		segID, err := parseV3SegmentID(rootPath, "files/insert_log/1/10/400/_metadata/manifest-5.avro")
+		assert.NoError(t, err)
+		assert.Equal(t, int64(400), segID)
+	})
+
+	t.Run("not insert_log prefix", func(t *testing.T) {
+		_, err := parseV3SegmentID(rootPath, "files/delta_log/1/10/100/501")
+		assert.Error(t, err)
+	})
+
+	t.Run("too few parts", func(t *testing.T) {
+		_, err := parseV3SegmentID(rootPath, "files/insert_log/1/10")
+		assert.Error(t, err)
+	})
+
+	t.Run("wrong rootPath", func(t *testing.T) {
+		_, err := parseV3SegmentID("other_root", "files/insert_log/1/10/100/_data/file")
+		assert.Error(t, err)
+	})
+
+	t.Run("non-numeric segmentID", func(t *testing.T) {
+		_, err := parseV3SegmentID(rootPath, "files/insert_log/1/10/not-a-number/_data/file")
+		assert.Error(t, err)
+	})
+}
+
+func TestGarbageCollector_recycleDroppedSegments_V3(t *testing.T) {
+	ctx := context.Background()
+
+	cli := storage.NewLocalChunkManager(objectstorage.RootPath("/tmp/test-gc-v3"))
+
+	catalog := &datacoord.Catalog{}
+	smMeta := &snapshotMeta{}
+
+	m := &meta{
+		catalog:      catalog,
+		snapshotMeta: smMeta,
+		segments: &SegmentsInfo{
+			segments: make(map[int64]*SegmentInfo),
+		},
+		channelCPs: newChannelCps(),
+	}
+
+	basePath := "/tmp/test-gc-v3/insert_log/100/10/2001"
+	manifestPath := packed.MarshalManifestPath(basePath, 1)
+
+	// V3 dropped segment with ManifestPath and StorageVersion=3
+	v3Segment := &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:             2001,
+			CollectionID:   100,
+			PartitionID:    10,
+			State:          commonpb.SegmentState_Dropped,
+			DroppedAt:      uint64(time.Now().Add(-time.Hour).UnixNano()),
+			InsertChannel:  "ch1",
+			StorageVersion: storage.StorageV3,
+			ManifestPath:   manifestPath,
+		},
+	}
+
+	// V1 dropped segment (no ManifestPath, StorageVersion=0)
+	v1Segment := &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:            2002,
+			CollectionID:  100,
+			PartitionID:   10,
+			State:         commonpb.SegmentState_Dropped,
+			DroppedAt:     uint64(time.Now().Add(-time.Hour).UnixNano()),
+			InsertChannel: "ch1",
+			Binlogs: []*datapb.FieldBinlog{
+				{
+					FieldID: 1,
+					Binlogs: []*datapb.Binlog{{LogPath: "log1", LogSize: 100}},
+				},
+			},
+		},
+	}
+
+	m.segments.segments[2001] = v3Segment
+	m.segments.segments[2002] = v1Segment
+
+	gc := newGarbageCollector(m, &ServerHandler{}, GcOption{
+		cli:              cli,
+		enabled:          true,
+		checkInterval:    time.Millisecond * 10,
+		scanInterval:     time.Hour * 7 * 24,
+		missingTolerance: time.Hour * 24,
+		dropTolerance:    0,
+	})
+
+	// Track calls
+	removeWithPrefixCalled := false
+	var removeWithPrefixArg string
+	removeObjectFilesCalled := false
+	droppedSegmentIDs := []int64{}
+
+	mockIsRefIndexLoaded := mockey.Mock((*snapshotMeta).IsRefIndexLoadedForCollection).Return(true).Build()
+	defer mockIsRefIndexLoaded.UnPatch()
+	mockGetSnapshotBySegment := mockey.Mock((*snapshotMeta).GetSnapshotBySegment).Return([]int64{}).Build()
+	defer mockGetSnapshotBySegment.UnPatch()
+	mockListLoaded := mockey.Mock((*ServerHandler).ListLoadedSegments).Return([]int64{}, nil).Build()
+	defer mockListLoaded.UnPatch()
+	mockChannelExists := mockey.Mock((*datacoord.Catalog).ChannelExists).Return(true).Build()
+	defer mockChannelExists.UnPatch()
+	mockDropSegment := mockey.Mock((*datacoord.Catalog).DropSegment).To(func(c *datacoord.Catalog, ctx context.Context, segment *datapb.SegmentInfo) error {
+		droppedSegmentIDs = append(droppedSegmentIDs, segment.ID)
+		return nil
+	}).Build()
+	defer mockDropSegment.UnPatch()
+
+	// Mock RemoveWithPrefix for V3 segment
+	mockRemoveWithPrefix := mockey.Mock((*storage.LocalChunkManager).RemoveWithPrefix).To(
+		func(cm *storage.LocalChunkManager, ctx context.Context, prefix string) error {
+			removeWithPrefixCalled = true
+			removeWithPrefixArg = prefix
+			return nil
+		}).Build()
+	defer mockRemoveWithPrefix.UnPatch()
+
+	// Mock removeObjectFiles for V1 segment
+	mockRemoveObjectFiles := mockey.Mock((*garbageCollector).removeObjectFiles).To(
+		func(gc *garbageCollector, ctx context.Context, logs map[string]struct{}) error {
+			removeObjectFilesCalled = true
+			return nil
+		}).Build()
+	defer mockRemoveObjectFiles.UnPatch()
+
+	gc.recycleDroppedSegments(ctx, nil)
+
+	// V3 segment should use RemoveWithPrefix with basePath
+	assert.True(t, removeWithPrefixCalled, "V3 segment should use RemoveWithPrefix")
+	assert.Equal(t, basePath, removeWithPrefixArg, "RemoveWithPrefix should be called with basePath")
+
+	// V1 segment should use removeObjectFiles
+	assert.True(t, removeObjectFilesCalled, "V1 segment should use removeObjectFiles")
+
+	// Both segments should be dropped from meta
+	assert.Contains(t, droppedSegmentIDs, int64(2001))
+	assert.Contains(t, droppedSegmentIDs, int64(2002))
+	assert.Nil(t, m.GetSegment(ctx, 2001))
+	assert.Nil(t, m.GetSegment(ctx, 2002))
+}
+
+func TestGarbageCollector_recycleUnusedBinlogFiles_SkipV3(t *testing.T) {
+	ctx := context.Background()
+
+	rootPath := "gc"
+	cli := storage.NewLocalChunkManager(objectstorage.RootPath("/tmp/test-gc-v3-orphan"))
+
+	m := &meta{
+		segments: &SegmentsInfo{
+			segments: make(map[int64]*SegmentInfo),
+		},
+		channelCPs:   newChannelCps(),
+		snapshotMeta: &snapshotMeta{},
+	}
+
+	// Add a V3 segment to meta
+	v3Segment := &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:             500,
+			CollectionID:   1,
+			PartitionID:    10,
+			State:          commonpb.SegmentState_Flushed,
+			StorageVersion: storage.StorageV3,
+			ManifestPath:   packed.MarshalManifestPath(rootPath+"/insert_log/1/10/500", 1),
+		},
+	}
+	m.segments.segments[500] = v3Segment
+
+	gc := newGarbageCollector(m, &ServerHandler{}, GcOption{
+		cli:              cli,
+		enabled:          true,
+		checkInterval:    time.Millisecond * 10,
+		scanInterval:     time.Hour * 7 * 24,
+		missingTolerance: 0,
+		dropTolerance:    0,
+	})
+
+	removedFiles := []string{}
+
+	// Mock snapshot methods to avoid nil pointer on snapshotMeta internals
+	mockAllLoaded := mockey.Mock((*snapshotMeta).IsAllRefIndexLoaded).Return(true).Build()
+	defer mockAllLoaded.UnPatch()
+	mockCollLoaded := mockey.Mock((*snapshotMeta).IsRefIndexLoadedForCollection).Return(true).Build()
+	defer mockCollLoaded.UnPatch()
+	mockGetSnapshotBySegment := mockey.Mock((*snapshotMeta).GetSnapshotBySegment).Return([]int64{}).Build()
+	defer mockGetSnapshotBySegment.UnPatch()
+
+	// Mock WalkWithPrefix to return V3 files under insert_log
+	mockWalk := mockey.Mock((*storage.LocalChunkManager).WalkWithPrefix).To(
+		func(cm *storage.LocalChunkManager, ctx context.Context, prefix string,
+			recursive bool, fn storage.ChunkObjectWalkFunc,
+		) error {
+			if strings.Contains(prefix, common.SegmentInsertLogPath) {
+				// V3 file that matches 6-part format (ParseSegmentIDByBinlog will succeed)
+				fn(&storage.ChunkObjectInfo{
+					FilePath:   rootPath + "/insert_log/1/10/500/0/data.parquet",
+					ModifyTime: time.Now().Add(-time.Hour),
+				})
+				// V3 file under _data/ (ParseSegmentIDByBinlog will fail, fallback to parseV3SegmentID)
+				fn(&storage.ChunkObjectInfo{
+					FilePath:   rootPath + "/insert_log/1/10/500/_data/0_abc.parquet",
+					ModifyTime: time.Now().Add(-time.Hour),
+				})
+				// V3 file under _stats/ (ParseSegmentIDByBinlog will fail)
+				fn(&storage.ChunkObjectInfo{
+					FilePath:   rootPath + "/insert_log/1/10/500/_stats/bloom_filter.101/42",
+					ModifyTime: time.Now().Add(-time.Hour),
+				})
+				// V3 file under _delta/ (ParseSegmentIDByBinlog will fail)
+				fn(&storage.ChunkObjectInfo{
+					FilePath:   rootPath + "/insert_log/1/10/500/_delta/501",
+					ModifyTime: time.Now().Add(-time.Hour),
+				})
+				// V3 file under _metadata/ (ParseSegmentIDByBinlog will fail)
+				fn(&storage.ChunkObjectInfo{
+					FilePath:   rootPath + "/insert_log/1/10/500/_metadata/manifest-1.avro",
+					ModifyTime: time.Now().Add(-time.Hour),
+				})
+			}
+			return nil
+		}).Build()
+	defer mockWalk.UnPatch()
+
+	mockRemove := mockey.Mock((*storage.LocalChunkManager).Remove).To(
+		func(cm *storage.LocalChunkManager, ctx context.Context, filePath string) error {
+			removedFiles = append(removedFiles, filePath)
+			return nil
+		}).Build()
+	defer mockRemove.UnPatch()
+
+	gc.recycleUnusedBinlogFiles(ctx)
+
+	// None of the V3 files should be removed — they are managed by loon
+	assert.Empty(t, removedFiles, "V3 segment files should not be removed by orphan scan")
 }


### PR DESCRIPTION
Related to #44956

V3 (loon/manifest) segments store all data under a single basePath (insert_log/{coll}/{part}/{seg}/) with _data/, _metadata/, _stats/, _delta/ subdirectories. The existing GC only handled V1/V2 per-file binlog paths, leaving V3 segment files leaked after drop.

- recycleDroppedSegments: add V3 branch that uses RemoveWithPrefix(basePath) to recursively delete the entire segment directory, instead of removing individual log files which are incomplete for V3 (stats/delta/metadata are embedded in manifest, not tracked in proto fields)
- recycleUnusedBinlogFiles: skip V3 segment files during orphan scan, as V3 orphan file lifecycle is managed by loon (milvus-storage)
- Add parseV3SegmentID helper to extract segmentID from variable-depth V3 paths that fail ParseSegmentIDByBinlog's fixed-depth format
- Use StorageVersion == StorageV3 as the canonical V3 check