### PR TITLE
fix: force promote RPC hangs forever due to missing doAckCallback invocation

### DIFF
--- a/internal/streamingcoord/server/broadcaster/ack_callback_scheduler.go
+++ b/internal/streamingcoord/server/broadcaster/ack_callback_scheduler.go
@@ -148,15 +148,12 @@ func (s *ackCallbackScheduler) triggerAckCallback() {
 		}
 
 		if task.IsForcePromoteMessage() {
-			// Force promote: fix incomplete broadcasts in background (BlockUntilAllAck → fix).
+			// Force promote: fix incomplete broadcasts, then run normal ack callback.
 			// Launch goroutine only after FastLock succeeds to prevent duplicate processing.
+			// doAckCallback handles g.Unlock() internally via its defer.
 			go func() {
-				defer func() {
-					s.rkLockerMu.Lock()
-					g.Unlock()
-					s.rkLockerMu.Unlock()
-				}()
 				s.doForcePromoteFixIncompleteBroadcasts(task)
+				s.doAckCallback(task, g)
 			}()
 			continue
 		}
@@ -168,7 +165,7 @@ func (s *ackCallbackScheduler) triggerAckCallback() {
 }
 
 // doForcePromoteFixIncompleteBroadcasts waits for all acks, then fixes incomplete broadcasts.
-// The actual ack callback is handled by the normal doAckCallback path.
+// After this returns, the caller must invoke doAckCallback to close the done channel and unblock the RPC.
 func (s *ackCallbackScheduler) doForcePromoteFixIncompleteBroadcasts(bt *broadcastTask) {
 	logger := s.Logger().With(zap.Uint64("broadcastID", bt.Header().BroadcastID))
 

--- a/internal/streamingcoord/server/service/assignment.go
+++ b/internal/streamingcoord/server/service/assignment.go
@@ -241,8 +241,14 @@ func (s *assignmentServiceImpl) handleForcePromote(ctx context.Context, config *
 	}
 	defer broadcaster.Close()
 
-	// Validate and construct force promote configuration
-	forcePromoteConfig, pchannels, err := s.validateForcePromoteConfiguration(ctx)
+	// Validate the caller-supplied config.
+	currentClusterID := paramtable.Get().CommonCfg.ClusterPrefix.GetValue()
+	if err := validateForcePromoteConfiguration(config, currentClusterID); err != nil {
+		return nil, err
+	}
+
+	// Derive and construct the actual force-promote config from current etcd state.
+	forcePromoteConfig, pchannels, err := s.buildForcePromoteConfiguration(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -281,9 +287,9 @@ func (s *assignmentServiceImpl) handleForcePromote(ctx context.Context, config *
 	return &streamingpb.UpdateReplicateConfigurationResponse{}, nil
 }
 
-// validateForcePromoteConfiguration validates the current cluster state and constructs
+// buildForcePromoteConfiguration reads the current cluster state from etcd and constructs
 // the force promote configuration. It returns the new config and the list of pchannels.
-func (s *assignmentServiceImpl) validateForcePromoteConfiguration(ctx context.Context) (*commonpb.ReplicateConfiguration, []string, error) {
+func (s *assignmentServiceImpl) buildForcePromoteConfiguration(ctx context.Context) (*commonpb.ReplicateConfiguration, []string, error) {
 	balancer, err := balance.GetWithContext(ctx)
 	if err != nil {
 		return nil, nil, err

--- a/internal/streamingcoord/server/service/assignment_test.go
+++ b/internal/streamingcoord/server/service/assignment_test.go
@@ -346,10 +346,14 @@ func TestForcePromoteSuccess(t *testing.T) {
 
 	as := NewAssignmentService()
 
-	// Force promote with empty config (configuration is auto-constructed)
+	// Force promote with config specifying only the current cluster (no topology)
 	resp, err := as.UpdateReplicateConfiguration(context.Background(), &streamingpb.UpdateReplicateConfigurationRequest{
-		Configuration: &commonpb.ReplicateConfiguration{},
-		ForcePromote:  true,
+		Configuration: &commonpb.ReplicateConfiguration{
+			Clusters: []*commonpb.MilvusCluster{
+				{ClusterId: "by-dev"},
+			},
+		},
+		ForcePromote: true,
 	})
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
@@ -407,10 +411,14 @@ func TestForcePromoteIdempotent(t *testing.T) {
 
 	as := NewAssignmentService()
 
-	// Force promote with empty config - auto-constructed config matches existing
+	// Force promote with config specifying only the current cluster (no topology)
 	resp, err := as.UpdateReplicateConfiguration(context.Background(), &streamingpb.UpdateReplicateConfigurationRequest{
-		Configuration: &commonpb.ReplicateConfiguration{},
-		ForcePromote:  true,
+		Configuration: &commonpb.ReplicateConfiguration{
+			Clusters: []*commonpb.MilvusCluster{
+				{ClusterId: "by-dev"},
+			},
+		},
+		ForcePromote: true,
 	})
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
@@ -609,10 +617,14 @@ func TestForcePromoteBroadcastAppendError(t *testing.T) {
 	broadcast.Register(mb)
 
 	as := NewAssignmentService()
-	// Force promote with empty config
+	// Force promote with config specifying only the current cluster (no topology)
 	_, err := as.UpdateReplicateConfiguration(context.Background(), &streamingpb.UpdateReplicateConfigurationRequest{
-		Configuration: &commonpb.ReplicateConfiguration{},
-		ForcePromote:  true,
+		Configuration: &commonpb.ReplicateConfiguration{
+			Clusters: []*commonpb.MilvusCluster{
+				{ClusterId: "by-dev"},
+			},
+		},
+		ForcePromote: true,
 	})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "broadcast append failed")
@@ -994,10 +1006,14 @@ func TestHandleForcePromoteGetAssignmentError(t *testing.T) {
 	broadcast.Register(mb)
 
 	as := NewAssignmentService()
-	// Force promote with empty config
+	// Force promote with config specifying only the current cluster (no topology)
 	_, err := as.UpdateReplicateConfiguration(context.Background(), &streamingpb.UpdateReplicateConfigurationRequest{
-		Configuration: &commonpb.ReplicateConfiguration{},
-		ForcePromote:  true,
+		Configuration: &commonpb.ReplicateConfiguration{
+			Clusters: []*commonpb.MilvusCluster{
+				{ClusterId: "by-dev"},
+			},
+		},
+		ForcePromote: true,
 	})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "assignment error")
@@ -1058,10 +1074,14 @@ func TestHandleForcePromoteSameConfigAfterBroadcasterCheck(t *testing.T) {
 	broadcast.Register(mb)
 
 	as := NewAssignmentService()
-	// Force promote with empty config
+	// Force promote with config specifying only the current cluster (no topology)
 	resp, err := as.UpdateReplicateConfiguration(context.Background(), &streamingpb.UpdateReplicateConfigurationRequest{
-		Configuration: &commonpb.ReplicateConfiguration{},
-		ForcePromote:  true,
+		Configuration: &commonpb.ReplicateConfiguration{
+			Clusters: []*commonpb.MilvusCluster{
+				{ClusterId: "by-dev"},
+			},
+		},
+		ForcePromote: true,
 	})
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
@@ -1117,10 +1137,14 @@ func TestHandleForcePromoteValidatorError(t *testing.T) {
 	broadcast.Register(mb)
 
 	as := NewAssignmentService()
-	// Force promote with empty config
+	// Force promote with config specifying only the current cluster (no topology)
 	_, err := as.UpdateReplicateConfiguration(context.Background(), &streamingpb.UpdateReplicateConfigurationRequest{
-		Configuration: &commonpb.ReplicateConfiguration{},
-		ForcePromote:  true,
+		Configuration: &commonpb.ReplicateConfiguration{
+			Clusters: []*commonpb.MilvusCluster{
+				{ClusterId: "by-dev"},
+			},
+		},
+		ForcePromote: true,
 	})
 	assert.Error(t, err)
 }
@@ -1165,8 +1189,12 @@ func TestHandleForcePromoteNoCurrentConfig(t *testing.T) {
 
 	as := NewAssignmentService()
 	_, err := as.UpdateReplicateConfiguration(context.Background(), &streamingpb.UpdateReplicateConfigurationRequest{
-		Configuration: &commonpb.ReplicateConfiguration{},
-		ForcePromote:  true,
+		Configuration: &commonpb.ReplicateConfiguration{
+			Clusters: []*commonpb.MilvusCluster{
+				{ClusterId: "by-dev"},
+			},
+		},
+		ForcePromote: true,
 	})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "force promote requires existing replicate configuration")
@@ -1216,8 +1244,12 @@ func TestHandleForcePromoteClusterNotFound(t *testing.T) {
 
 	as := NewAssignmentService()
 	_, err := as.UpdateReplicateConfiguration(context.Background(), &streamingpb.UpdateReplicateConfigurationRequest{
-		Configuration: &commonpb.ReplicateConfiguration{},
-		ForcePromote:  true,
+		Configuration: &commonpb.ReplicateConfiguration{
+			Clusters: []*commonpb.MilvusCluster{
+				{ClusterId: "by-dev"},
+			},
+		},
+		ForcePromote: true,
 	})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "force promote requires current cluster in existing configuration")
@@ -1384,10 +1416,14 @@ func TestForcePromoteMultiplePChannels(t *testing.T) {
 	broadcast.Register(mb)
 
 	as := NewAssignmentService()
-	// Force promote with empty config - config auto-constructed from meta with all pchannels
+	// Force promote with config specifying only the current cluster (no topology)
 	resp, err := as.UpdateReplicateConfiguration(context.Background(), &streamingpb.UpdateReplicateConfigurationRequest{
-		Configuration: &commonpb.ReplicateConfiguration{},
-		ForcePromote:  true,
+		Configuration: &commonpb.ReplicateConfiguration{
+			Clusters: []*commonpb.MilvusCluster{
+				{ClusterId: "by-dev"},
+			},
+		},
+		ForcePromote: true,
 	})
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)


### PR DESCRIPTION
## What does this PR do?

Fixes two bugs in the force promote path of `UpdateReplicateConfiguration`.

### Bug 1: Force promote RPC hangs forever

**Root Cause**

In `ack_callback_scheduler.go`, `triggerAckCallback` handles force promote messages by launching a goroutine to call `doForcePromoteFixIncompleteBroadcasts`. The goroutine had its own `defer g.Unlock()` but never called `doAckCallback`.

`doAckCallback` is the only function that invokes `MarkAckCallbackDone()`, which closes the broadcast task's `done` channel. `broadcastScheduler.AddTask` calls `task.BlockUntilDone()` on this channel, so without `doAckCallback` being called, `BlockUntilDone()` blocks forever — leaving the force promote RPC permanently hung.

**Fix**

Chain `doAckCallback(task, g)` after `doForcePromoteFixIncompleteBroadcasts(task)` in the same goroutine. `doAckCallback` already handles `g.Unlock()` via its internal defer, so the separate unlock defer in the goroutine is also removed.

```go
// Before (buggy):
go func() {
    defer func() {
        s.rkLockerMu.Lock()
        g.Unlock()
        s.rkLockerMu.Unlock()
    }()
    s.doForcePromoteFixIncompleteBroadcasts(task)
}()

// After (fixed):
go func() {
    s.doForcePromoteFixIncompleteBroadcasts(task)
    s.doAckCallback(task, g)  // closes done channel, unblocks BlockUntilDone()
}()
```

### Bug 2: Missing caller-supplied config validation

**Root Cause**

In `assignment.go`, `validateForcePromoteConfiguration(config, currentClusterID)` existed but was never called in `handleForcePromote`. The caller-supplied config was passed through without any validation.

**Fix**

Call `validateForcePromoteConfiguration(config, currentClusterID)` after broadcaster acquisition to validate the caller-supplied config (must contain exactly the current cluster with no topology) before proceeding with the promotion.

Also rename the instance method `validateForcePromoteConfiguration(ctx)` to `buildForcePromoteConfiguration(ctx)` to avoid confusion with the static validation function.

## Tests

Verified with E2E tests covering the full force promote lifecycle:
- Force promote on primary cluster rejected
- Force promote with invalid config rejected
- Force promote succeeds on secondary with data integrity (1000 rows replicated + 500 new rows post-promote)
- Force promote on already-promoted cluster rejected

issue: #47352