### PR TITLE
fix: correct fullMethod for OperatePrivilegeV2 REST endpoints

### DIFF
--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -133,8 +133,8 @@ var routeToMethod = map[string]string{
 	"/v2/vectordb/roles/drop":                "DropRole",
 	"/v2/vectordb/roles/grant_privilege":     "OperatePrivilege",
 	"/v2/vectordb/roles/revoke_privilege":    "OperatePrivilege",
-	"/v2/vectordb/roles/grant_privilege_v2":  "OperatePrivilege",
-	"/v2/vectordb/roles/revoke_privilege_v2": "OperatePrivilege",
+	"/v2/vectordb/roles/grant_privilege_v2":  "OperatePrivilegeV2",
+	"/v2/vectordb/roles/revoke_privilege_v2": "OperatePrivilegeV2",
 
 	"/v2/vectordb/privilege_groups/create":                       "CreatePrivilegeGroup",
 	"/v2/vectordb/privilege_groups/drop":                         "DropPrivilegeGroup",
@@ -2567,7 +2567,7 @@ func (h *HandlersV2) operatePrivilegeToRoleV2(ctx context.Context, c *gin.Contex
 		DbName:         httpReq.DbName,
 		CollectionName: httpReq.CollectionName,
 	}
-	resp, err := wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/OperatePrivilege", func(reqCtx context.Context, req any) (interface{}, error) {
+	resp, err := wrapperProxy(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/OperatePrivilegeV2", func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.OperatePrivilegeV2(reqCtx, req.(*milvuspb.OperatePrivilegeV2Request))
 	})
 	if err == nil {


### PR DESCRIPTION
## Summary
- REST handlers for `/roles/grant_privilege_v2` and `/roles/revoke_privilege_v2` pass V1 fullMethod `OperatePrivilege` instead of `OperatePrivilegeV2` to `wrapperProxy`, causing Hook interceptors to reject the request as a denied API
- Also fix `routeToMethod` metrics map entries for the same endpoints

issue: #48115