### PR TITLE
fix: pass response instead of status to CheckRPCCall to prevent nil deref

### DIFF
--- a/internal/datacoord/ddl_callbacks_import.go
+++ b/internal/datacoord/ddl_callbacks_import.go
@@ -160,7 +160,7 @@ func (s *Server) broadcastImport(ctx context.Context,
 	defer broadcaster.Close()
 
 	coll, err := s.broker.DescribeCollectionInternal(ctx, collectionID)
-	if err := merr.CheckRPCCall(coll.Status, err); err != nil {
+	if err := merr.CheckRPCCall(coll, err); err != nil {
 		return err
 	}
 	// Build import message without deprecated MsgBase

--- a/internal/datacoord/index_service.go
+++ b/internal/datacoord/index_service.go
@@ -74,7 +74,7 @@ func (s *Server) defaultIndexNameByID(schema *schemapb.CollectionSchema, fieldID
 
 func (s *Server) getSchema(ctx context.Context, collID int64) (*schemapb.CollectionSchema, error) {
 	resp, err := s.broker.DescribeCollectionInternal(ctx, collID)
-	if err := merr.CheckRPCCall(resp.Status, err); err != nil {
+	if err := merr.CheckRPCCall(resp, err); err != nil {
 		return nil, err
 	}
 	return resp.GetSchema(), nil
@@ -151,7 +151,7 @@ func (s *Server) CreateIndex(ctx context.Context, req *indexpb.CreateIndexReques
 	defer broadcaster.Close()
 
 	coll, err := s.broker.DescribeCollectionInternal(ctx, req.GetCollectionID())
-	if err := merr.CheckRPCCall(coll.Status, err); err != nil {
+	if err := merr.CheckRPCCall(coll, err); err != nil {
 		return merr.Status(err), nil
 	}
 	schema := coll.GetSchema()


### PR DESCRIPTION
Pass whole response to merr.CheckRPCCall instead of resp.Status to prevent nil pointer dereference when broker returns (nil, err).

issue: #48538