### PR TITLE
enhance: type-aware bidirectional in/== or expression rewriting

### DIFF
--- a/internal/core/unittest/test_expr_materialized_view.cpp
+++ b/internal/core/unittest/test_expr_materialized_view.cpp
@@ -422,22 +422,32 @@ TEST_F(ExprMaterializedViewTest, TestUnaryRangeCompareExpr) {
     }
 }
 
-// Test numeric and varchar expr: F in [A, B, C]
+// Test numeric and varchar expr: F in [v0, v1, ..., v14]
+// Use >= 15 values to stay above all type-specific IN thresholds
+// (integer >= 10, float >= 15, default >= 3) so the expression
+// remains as TermExpr and is not split into OR equals.
 TEST_F(ExprMaterializedViewTest, TestInMultipleExpr) {
+    constexpr int kNumValues = 15;
     for (const auto& data_type : GetNumericAndVarcharScalarDataTypes()) {
+        // Skip BOOL: only 2 unique values (true/false), always below
+        // the IN threshold so it gets split into OR equals.
+        if (data_type == DataType::BOOL)
+            continue;
         std::string field_name = GetFieldName(data_type);
-        std::string val0 = GetTestValue(data_type, 0);
-        std::string val1 = GetTestValue(data_type, 1);
-        // F in [A, B]
-        std::string expr =
-            fmt::format("{} in [{}, {}]", field_name, val0, val1);
+        std::string vals;
+        for (int i = 0; i < kNumValues; i++) {
+            if (i > 0)
+                vals += ", ";
+            vals += GetTestValue(data_type, i);
+        }
+        std::string expr = fmt::format("{} in [{}]", field_name, vals);
         auto mv = TranslateThenExecuteWhenMvInvolved(expr);
 
         ASSERT_EQ(mv.field_id_to_touched_categories_cnt.size(), 1);
         auto field_id = GetFieldID(data_type);
         ASSERT_TRUE(mv.field_id_to_touched_categories_cnt.find(field_id) !=
                     mv.field_id_to_touched_categories_cnt.end());
-        EXPECT_EQ(mv.field_id_to_touched_categories_cnt[field_id], 2);
+        EXPECT_EQ(mv.field_id_to_touched_categories_cnt[field_id], kNumValues);
         EXPECT_EQ(mv.has_not, false);
         EXPECT_EQ(mv.is_pure_and, true);
     }
@@ -486,19 +496,26 @@ TEST_F(ExprMaterializedViewTest, TestEqualAndEqualExpr) {
     EXPECT_EQ(mv.is_pure_and, true);
 }
 
-// Test expr: F0 == A && F1 in [A, B]
+// Test expr: F0 == A && F1 in [v0, v1, ..., v9]
+// Use >= 10 values for INT32 to stay above the integer IN threshold
+// so the expression remains as TermExpr and is not split into OR equals.
 TEST_F(ExprMaterializedViewTest, TestEqualAndInExpr) {
     const DataType c0_data_type = DataType::VARCHAR;
     const DataType c1_data_type = DataType::INT32;
+    constexpr int kNumInValues = 10;
 
     std::string f0 = GetFieldName(c0_data_type);
     std::string f1 = GetFieldName(c1_data_type);
     std::string val0 = GetTestValue(c0_data_type, 1);
-    std::string val1 = GetTestValue(c1_data_type, 1);
-    std::string val2 = GetTestValue(c1_data_type, 2);
-    // F0 == A && F1 in [A, B]
+    std::string in_vals;
+    for (int i = 0; i < kNumInValues; i++) {
+        if (i > 0)
+            in_vals += ", ";
+        in_vals += GetTestValue(c1_data_type, i);
+    }
+    // F0 == A && F1 in [v0, v1, ..., v9]
     std::string expr =
-        fmt::format("{} == {} && {} in [{}, {}]", f0, val0, f1, val1, val2);
+        fmt::format("{} == {} && {} in [{}]", f0, val0, f1, in_vals);
 
     auto mv = TranslateThenExecuteWhenMvInvolved(expr);
 
@@ -506,7 +523,7 @@ TEST_F(ExprMaterializedViewTest, TestEqualAndInExpr) {
     EXPECT_EQ(mv.field_id_to_touched_categories_cnt[GetFieldID(c0_data_type)],
               1);
     EXPECT_EQ(mv.field_id_to_touched_categories_cnt[GetFieldID(c1_data_type)],
-              2);
+              kNumInValues);
     EXPECT_EQ(mv.has_not, false);
     EXPECT_EQ(mv.is_pure_and, true);
 }

--- a/internal/parser/planparserv2/fill_expression_value_test.go
+++ b/internal/parser/planparserv2/fill_expression_value_test.go
@@ -724,7 +724,8 @@ func (s *FillExpressionValueSuite) TestTermExprWithMixedNumericTypesForJSON() {
 
 	s.Run("non-JSON field should not be affected by mixed type normalization", func() {
 		// Int64Field is not a JSON field, so mixed types would be an error or handled differently
-		exprStr := `Int64Field in [1, 2, 3]`
+		// Use >= 10 values to stay above the integer IN threshold and keep TermExpr form
+		exprStr := `Int64Field in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]`
 
 		expr, err := ParseExpr(schemaH, exprStr, nil)
 		s.NoError(err)
@@ -733,10 +734,10 @@ func (s *FillExpressionValueSuite) TestTermExprWithMixedNumericTypesForJSON() {
 		// Verify values remain as integers for non-JSON field
 		te := expr.GetTermExpr()
 		s.NotNil(te, "expected TermExpr")
-		s.Len(te.GetValues(), 3)
-		s.Equal(int64(1), te.GetValues()[0].GetInt64Val())
-		s.Equal(int64(2), te.GetValues()[1].GetInt64Val())
-		s.Equal(int64(3), te.GetValues()[2].GetInt64Val())
+		s.Len(te.GetValues(), 10)
+		for i := 0; i < 10; i++ {
+			s.Equal(int64(i+1), te.GetValues()[i].GetInt64Val())
+		}
 	})
 
 	s.Run("not in with mixed int and float should normalize all to float", func() {

--- a/internal/parser/planparserv2/rewriter/entry.go
+++ b/internal/parser/planparserv2/rewriter/entry.go
@@ -84,6 +84,16 @@ func (v *visitor) visitBinaryExpr(expr *planpb.BinaryExpr) interface{} {
 }
 
 func (v *visitor) visitUnaryExpr(expr *planpb.UnaryExpr) interface{} {
+	// Handle NOT(TermExpr) before visiting child, so we can split not in → != and
+	if expr.GetOp() == planpb.UnaryExpr_Not {
+		if te := expr.GetChild().GetTermExpr(); te != nil {
+			sortTermValues(te)
+			if !shouldUseInExprWithPK(te.GetColumnInfo().GetDataType(), len(te.GetValues()), te.GetColumnInfo().GetIsPrimaryKey()) {
+				return splitTermToAndNotEquals(te)
+			}
+		}
+	}
+
 	child := v.visitExpr(expr.GetChild()).(*planpb.Expr)
 
 	// Optimize double negation: NOT (NOT AlwaysTrue) → AlwaysTrue
@@ -105,6 +115,12 @@ func (v *visitor) visitUnaryExpr(expr *planpb.UnaryExpr) interface{} {
 
 func (v *visitor) visitTermExpr(expr *planpb.TermExpr) interface{} {
 	sortTermValues(expr)
+
+	// Split in → == or when shouldUseInExpr returns false
+	if !shouldUseInExprWithPK(expr.GetColumnInfo().GetDataType(), len(expr.GetValues()), expr.GetColumnInfo().GetIsPrimaryKey()) {
+		return splitTermToOrEquals(expr)
+	}
+
 	return &planpb.Expr{Expr: &planpb.Expr_TermExpr{TermExpr: expr}}
 }
 

--- a/internal/parser/planparserv2/rewriter/term_in.go
+++ b/internal/parser/planparserv2/rewriter/term_in.go
@@ -42,7 +42,7 @@ func (v *visitor) combineOrEqualsToIn(parts []*planpb.Expr) []*planpb.Expr {
 	out := make([]*planpb.Expr, 0, len(parts))
 	out = append(out, others...)
 	for _, g := range groups {
-		if shouldMergeToIn(g.col.GetDataType(), len(g.values)) {
+		if shouldUseInExprWithPK(g.col.GetDataType(), len(g.values), g.col.GetIsPrimaryKey()) {
 			g.values = sortGenericValues(g.values)
 			out = append(out, newTermExpr(g.col, g.values))
 		} else {
@@ -92,7 +92,7 @@ func (v *visitor) combineAndNotEqualsToNotIn(parts []*planpb.Expr) []*planpb.Exp
 	out := make([]*planpb.Expr, 0, len(parts))
 	out = append(out, others...)
 	for _, g := range groups {
-		if shouldMergeToIn(g.col.GetDataType(), len(g.values)) {
+		if shouldUseInExprWithPK(g.col.GetDataType(), len(g.values), g.col.GetIsPrimaryKey()) {
 			g.values = sortGenericValues(g.values)
 			in := newTermExpr(g.col, g.values)
 			out = append(out, notExpr(in))
@@ -103,6 +103,90 @@ func (v *visitor) combineAndNotEqualsToNotIn(parts []*planpb.Expr) []*planpb.Exp
 		}
 	}
 	return out
+}
+
+// splitTermToOrEquals converts TermExpr(in [v1, v2, ...]) to
+// v == v1 OR v == v2 OR ... (left-associative binary OR tree).
+func splitTermToOrEquals(expr *planpb.TermExpr) *planpb.Expr {
+	col := expr.GetColumnInfo()
+	values := expr.GetValues()
+
+	if len(values) == 0 {
+		return &planpb.Expr{Expr: &planpb.Expr_TermExpr{TermExpr: expr}}
+	}
+
+	equals := make([]*planpb.Expr, len(values))
+	for i, val := range values {
+		equals[i] = &planpb.Expr{
+			Expr: &planpb.Expr_UnaryRangeExpr{
+				UnaryRangeExpr: &planpb.UnaryRangeExpr{
+					ColumnInfo: col,
+					Op:         planpb.OpType_Equal,
+					Value:      val,
+				},
+			},
+		}
+	}
+
+	if len(equals) == 1 {
+		return equals[0]
+	}
+
+	result := equals[0]
+	for i := 1; i < len(equals); i++ {
+		result = &planpb.Expr{
+			Expr: &planpb.Expr_BinaryExpr{
+				BinaryExpr: &planpb.BinaryExpr{
+					Left:  result,
+					Right: equals[i],
+					Op:    planpb.BinaryExpr_LogicalOr,
+				},
+			},
+		}
+	}
+	return result
+}
+
+// splitTermToAndNotEquals converts NOT(in [v1, v2, ...]) to
+// v != v1 AND v != v2 AND ... (left-associative binary AND tree).
+func splitTermToAndNotEquals(expr *planpb.TermExpr) *planpb.Expr {
+	col := expr.GetColumnInfo()
+	values := expr.GetValues()
+
+	if len(values) == 0 {
+		return notExpr(&planpb.Expr{Expr: &planpb.Expr_TermExpr{TermExpr: expr}})
+	}
+
+	notEquals := make([]*planpb.Expr, len(values))
+	for i, val := range values {
+		notEquals[i] = &planpb.Expr{
+			Expr: &planpb.Expr_UnaryRangeExpr{
+				UnaryRangeExpr: &planpb.UnaryRangeExpr{
+					ColumnInfo: col,
+					Op:         planpb.OpType_NotEqual,
+					Value:      val,
+				},
+			},
+		}
+	}
+
+	if len(notEquals) == 1 {
+		return notEquals[0]
+	}
+
+	result := notEquals[0]
+	for i := 1; i < len(notEquals); i++ {
+		result = &planpb.Expr{
+			Expr: &planpb.Expr_BinaryExpr{
+				BinaryExpr: &planpb.BinaryExpr{
+					Left:  result,
+					Right: notEquals[i],
+					Op:    planpb.BinaryExpr_LogicalAnd,
+				},
+			},
+		}
+	}
+	return result
 }
 
 func notExpr(child *planpb.Expr) *planpb.Expr {

--- a/internal/parser/planparserv2/rewriter/term_in_test.go
+++ b/internal/parser/planparserv2/rewriter/term_in_test.go
@@ -40,20 +40,34 @@ func buildSchemaHelperForRewriteT(t *testing.T) *typeutil.SchemaHelper {
 	return helper
 }
 
-func TestRewrite_OREquals_ToIN_NonNumeric(t *testing.T) {
+// --- shouldUseInExpr threshold tests ---
+
+func TestRewrite_OREquals_ToIN_VarChar_AboveThreshold(t *testing.T) {
 	helper := buildSchemaHelperForRewriteT(t)
-	expr, err := parser.ParseExpr(helper, `VarCharField == "a" or VarCharField == "b"`, nil)
+	// varchar threshold is 3, so 3 values should produce IN
+	expr, err := parser.ParseExpr(helper, `VarCharField == "a" or VarCharField == "b" or VarCharField == "c"`, nil)
 	require.NoError(t, err)
 	require.NotNil(t, expr)
 	term := expr.GetTermExpr()
-	require.NotNil(t, term, "expected OR-equals to be rewritten to TermExpr(IN ...)")
-	require.Equal(t, 2, len(term.GetValues()))
-	require.Equal(t, "a", term.GetValues()[0].GetStringVal())
-	require.Equal(t, "b", term.GetValues()[1].GetStringVal())
+	require.NotNil(t, term, "3 varchar OR-equals should merge to IN (threshold=3)")
+	require.Equal(t, 3, len(term.GetValues()))
 }
 
-func TestRewrite_OREquals_NotMerged_OnNumericBelowThreshold(t *testing.T) {
+func TestRewrite_OREquals_NotMerged_VarChar_BelowThreshold(t *testing.T) {
 	helper := buildSchemaHelperForRewriteT(t)
+	// varchar threshold is 3, so 2 values should NOT produce IN
+	expr, err := parser.ParseExpr(helper, `VarCharField == "a" or VarCharField == "b"`, nil)
+	require.NoError(t, err)
+	require.NotNil(t, expr)
+	require.Nil(t, expr.GetTermExpr(), "2 varchar OR-equals should not merge to IN")
+	be := expr.GetBinaryExpr()
+	require.NotNil(t, be)
+	require.Equal(t, planpb.BinaryExpr_LogicalOr, be.GetOp())
+}
+
+func TestRewrite_OREquals_NotMerged_Int_BelowThreshold(t *testing.T) {
+	helper := buildSchemaHelperForRewriteT(t)
+	// int threshold is 10, so 2 values should NOT merge
 	expr, err := parser.ParseExpr(helper, `Int64Field == 1 or Int64Field == 2`, nil)
 	require.NoError(t, err)
 	require.NotNil(t, expr)
@@ -67,61 +81,117 @@ func TestRewrite_OREquals_NotMerged_OnNumericBelowThreshold(t *testing.T) {
 	require.Equal(t, planpb.OpType_Equal, be.GetRight().GetUnaryRangeExpr().GetOp())
 }
 
+func TestRewrite_OREquals_Merged_Int_AtThreshold(t *testing.T) {
+	helper := buildSchemaHelperForRewriteT(t)
+	// int threshold is 10, so exactly 10 values should merge
+	expr, err := parser.ParseExpr(helper, `Int64Field == 1 or Int64Field == 2 or Int64Field == 3 or Int64Field == 4 or Int64Field == 5 or Int64Field == 6 or Int64Field == 7 or Int64Field == 8 or Int64Field == 9 or Int64Field == 10`, nil)
+	require.NoError(t, err)
+	require.NotNil(t, expr)
+	term := expr.GetTermExpr()
+	require.NotNil(t, term, "10 int OR-equals should merge to IN (threshold=10)")
+	require.Equal(t, 10, len(term.GetValues()))
+}
+
+// --- in → == or split tests ---
+
+func TestRewrite_InSplit_Int_BelowThreshold(t *testing.T) {
+	helper := buildSchemaHelperForRewriteT(t)
+	// int in [1,2,3] → 3 values < 10 → split to == or
+	expr, err := parser.ParseExpr(helper, `Int64Field in [1,2,3]`, nil)
+	require.NoError(t, err)
+	require.NotNil(t, expr)
+	require.Nil(t, expr.GetTermExpr(), "int in with 3 values should be split to == or")
+	// Should be an OR tree
+	be := expr.GetBinaryExpr()
+	require.NotNil(t, be)
+	require.Equal(t, planpb.BinaryExpr_LogicalOr, be.GetOp())
+}
+
+func TestRewrite_InSplit_Int_SingleValue(t *testing.T) {
+	helper := buildSchemaHelperForRewriteT(t)
+	// int in [5] → split to == 5
+	expr, err := parser.ParseExpr(helper, `Int64Field in [5]`, nil)
+	require.NoError(t, err)
+	require.NotNil(t, expr)
+	ure := expr.GetUnaryRangeExpr()
+	require.NotNil(t, ure, "in [single] should become ==")
+	require.Equal(t, planpb.OpType_Equal, ure.GetOp())
+	require.Equal(t, int64(5), ure.GetValue().GetInt64Val())
+}
+
+func TestRewrite_InKept_Int_AboveThreshold(t *testing.T) {
+	helper := buildSchemaHelperForRewriteT(t)
+	expr, err := parser.ParseExpr(helper, `Int64Field in [1,2,3,4,5,6,7,8,9,10]`, nil)
+	require.NoError(t, err)
+	require.NotNil(t, expr)
+	term := expr.GetTermExpr()
+	require.NotNil(t, term, "int in with 10 values should stay as IN")
+	require.Equal(t, 10, len(term.GetValues()))
+}
+
+// --- not in split tests ---
+
+func TestRewrite_NotInSplit_Int_BelowThreshold(t *testing.T) {
+	helper := buildSchemaHelperForRewriteT(t)
+	// not in [3,4] → 2 values < 10 → split to != 3 AND != 4
+	expr, err := parser.ParseExpr(helper, `Int64Field not in [4,3]`, nil)
+	require.NoError(t, err)
+	require.NotNil(t, expr)
+	// Should be AND tree of !=
+	be := expr.GetBinaryExpr()
+	require.NotNil(t, be, "not in with 2 int values should split to != AND !=")
+	require.Equal(t, planpb.BinaryExpr_LogicalAnd, be.GetOp())
+	require.Equal(t, planpb.OpType_NotEqual, be.GetLeft().GetUnaryRangeExpr().GetOp())
+	require.Equal(t, planpb.OpType_NotEqual, be.GetRight().GetUnaryRangeExpr().GetOp())
+}
+
+func TestRewrite_NotInSplit_Int_SingleValue(t *testing.T) {
+	helper := buildSchemaHelperForRewriteT(t)
+	expr, err := parser.ParseExpr(helper, `Int64Field not in [5]`, nil)
+	require.NoError(t, err)
+	require.NotNil(t, expr)
+	ure := expr.GetUnaryRangeExpr()
+	require.NotNil(t, ure, "not in [single] should become !=")
+	require.Equal(t, planpb.OpType_NotEqual, ure.GetOp())
+	require.Equal(t, int64(5), ure.GetValue().GetInt64Val())
+}
+
+func TestRewrite_NotInSplit_Float_BelowThreshold(t *testing.T) {
+	helper := buildSchemaHelperForRewriteT(t)
+	// float threshold is 15, so 2 values → split
+	expr, err := parser.ParseExpr(helper, `FloatField not in [4.0,3.0]`, nil)
+	require.NoError(t, err)
+	require.NotNil(t, expr)
+	be := expr.GetBinaryExpr()
+	require.NotNil(t, be, "not in with 2 float values should split to != AND !=")
+	require.Equal(t, planpb.BinaryExpr_LogicalAnd, be.GetOp())
+}
+
+// --- sort/dedup tests (use values above threshold) ---
+
 func TestRewrite_Term_SortAndDedup_String(t *testing.T) {
 	helper := buildSchemaHelperForRewriteT(t)
-	expr, err := parser.ParseExpr(helper, `VarCharField in ["b","a","b","a"]`, nil)
+	// varchar threshold is 3, use 3+ unique values
+	expr, err := parser.ParseExpr(helper, `VarCharField in ["c","b","a","b","a"]`, nil)
 	require.NoError(t, err)
 	require.NotNil(t, expr)
 	term := expr.GetTermExpr()
 	require.NotNil(t, term)
-	require.Equal(t, 2, len(term.GetValues()))
+	require.Equal(t, 3, len(term.GetValues()))
 	require.Equal(t, "a", term.GetValues()[0].GetStringVal())
 	require.Equal(t, "b", term.GetValues()[1].GetStringVal())
+	require.Equal(t, "c", term.GetValues()[2].GetStringVal())
 }
 
 func TestRewrite_Term_SortAndDedup_Int(t *testing.T) {
 	helper := buildSchemaHelperForRewriteT(t)
-	expr, err := parser.ParseExpr(helper, `Int64Field in [9,4,6,6,7]`, nil)
+	// int threshold is 10, use 10+ unique values
+	expr, err := parser.ParseExpr(helper, `Int64Field in [10,9,4,6,6,7,1,2,3,5,8]`, nil)
 	require.NoError(t, err)
 	require.NotNil(t, expr)
 	term := expr.GetTermExpr()
 	require.NotNil(t, term)
-	require.Equal(t, 4, len(term.GetValues()))
-	got := []int64{
-		term.GetValues()[0].GetInt64Val(),
-		term.GetValues()[1].GetInt64Val(),
-		term.GetValues()[2].GetInt64Val(),
-		term.GetValues()[3].GetInt64Val(),
-	}
-	require.ElementsMatch(t, []int64{4, 6, 7, 9}, got)
-}
-
-func TestRewrite_NotIn_SortAndDedup_Int(t *testing.T) {
-	helper := buildSchemaHelperForRewriteT(t)
-	expr, err := parser.ParseExpr(helper, `Int64Field not in [4,4,3]`, nil)
-	require.NoError(t, err)
-	require.NotNil(t, expr)
-	un := expr.GetUnaryExpr()
-	require.NotNil(t, un)
-	term := un.GetChild().GetTermExpr()
-	require.NotNil(t, term)
-	require.Equal(t, 2, len(term.GetValues()))
-	require.Equal(t, int64(3), term.GetValues()[0].GetInt64Val())
-	require.Equal(t, int64(4), term.GetValues()[1].GetInt64Val())
-}
-
-func TestRewrite_NotIn_SortAndDedup_Float(t *testing.T) {
-	helper := buildSchemaHelperForRewriteT(t)
-	expr, err := parser.ParseExpr(helper, `FloatField not in [4.0,4,3.0]`, nil)
-	require.NoError(t, err)
-	require.NotNil(t, expr)
-	un := expr.GetUnaryExpr()
-	require.NotNil(t, un)
-	term := un.GetChild().GetTermExpr()
-	require.NotNil(t, term)
-	require.Equal(t, 2, len(term.GetValues()))
-	require.Equal(t, 3.0, term.GetValues()[0].GetFloatVal())
-	require.Equal(t, 4.0, term.GetValues()[1].GetFloatVal())
+	require.Equal(t, 10, len(term.GetValues()))
 }
 
 func TestRewrite_In_SortAndDedup_Bool(t *testing.T) {
@@ -129,15 +199,15 @@ func TestRewrite_In_SortAndDedup_Bool(t *testing.T) {
 	expr, err := parser.ParseExpr(helper, `BoolField in [true,false,false,true]`, nil)
 	require.NoError(t, err)
 	require.NotNil(t, expr)
-	term := expr.GetTermExpr()
-	require.NotNil(t, term)
-	require.Equal(t, 2, len(term.GetValues()))
-	require.Equal(t, false, term.GetValues()[0].GetBoolVal())
-	require.Equal(t, true, term.GetValues()[1].GetBoolVal())
+	// bool: 2 unique values < threshold 3 → split to == or
+	be := expr.GetBinaryExpr()
+	require.NotNil(t, be, "bool in [true,false] should split to == or")
+	require.Equal(t, planpb.BinaryExpr_LogicalOr, be.GetOp())
 }
 
 func TestRewrite_Flatten_Then_OR_ToIN(t *testing.T) {
 	helper := buildSchemaHelperForRewriteT(t)
+	// varchar threshold is 3, so 4 values should merge
 	expr, err := parser.ParseExpr(helper, `VarCharField == "a" or (VarCharField == "b" or VarCharField == "c") or VarCharField == "d"`, nil)
 	require.NoError(t, err)
 	require.NotNil(t, expr)
@@ -153,9 +223,11 @@ func TestRewrite_Flatten_Then_OR_ToIN(t *testing.T) {
 	require.ElementsMatch(t, []string{"a", "b", "c", "d"}, got)
 }
 
+// --- combine tests (use values above threshold to keep IN form) ---
+
 func TestRewrite_And_In_And_Equal_VInSet_ReducesToEqual(t *testing.T) {
 	helper := buildSchemaHelperForRewriteT(t)
-	expr, err := parser.ParseExpr(helper, `Int64Field in [1,3,5] and Int64Field == 3`, nil)
+	expr, err := parser.ParseExpr(helper, `Int64Field in [1,2,3,4,5,6,7,8,9,10] and Int64Field == 3`, nil)
 	require.NoError(t, err)
 	require.NotNil(t, expr)
 	ure := expr.GetUnaryRangeExpr()
@@ -166,7 +238,7 @@ func TestRewrite_And_In_And_Equal_VInSet_ReducesToEqual(t *testing.T) {
 
 func TestRewrite_And_In_And_Equal_VNotInSet_False(t *testing.T) {
 	helper := buildSchemaHelperForRewriteT(t)
-	expr, err := parser.ParseExpr(helper, `Int64Field in [1,3,5] and Int64Field == 2`, nil)
+	expr, err := parser.ParseExpr(helper, `Int64Field in [1,2,3,4,5,6,7,8,9,10] and Int64Field == 20`, nil)
 	require.NoError(t, err)
 	require.NotNil(t, expr)
 	require.True(t, rewriter.IsAlwaysFalseExpr(expr))
@@ -174,59 +246,49 @@ func TestRewrite_And_In_And_Equal_VNotInSet_False(t *testing.T) {
 
 func TestRewrite_Or_In_Or_Equal_Union(t *testing.T) {
 	helper := buildSchemaHelperForRewriteT(t)
-	expr, err := parser.ParseExpr(helper, `Int64Field in [1,3] or Int64Field == 2`, nil)
+	expr, err := parser.ParseExpr(helper, `Int64Field in [1,2,3,4,5,6,7,8,9,10] or Int64Field == 20`, nil)
 	require.NoError(t, err)
 	require.NotNil(t, expr)
 	term := expr.GetTermExpr()
 	require.NotNil(t, term)
-	require.Equal(t, []int64{1, 2, 3}, []int64{
-		term.GetValues()[0].GetInt64Val(),
-		term.GetValues()[1].GetInt64Val(),
-		term.GetValues()[2].GetInt64Val(),
-	})
+	require.Equal(t, 11, len(term.GetValues()))
 }
 
 func TestRewrite_And_In_With_Range_Filter(t *testing.T) {
 	helper := buildSchemaHelperForRewriteT(t)
-	expr, err := parser.ParseExpr(helper, `Int64Field in [1,3,5] and Int64Field > 3`, nil)
+	expr, err := parser.ParseExpr(helper, `Int64Field in [1,2,3,4,5,6,7,8,9,10] and Int64Field > 8`, nil)
 	require.NoError(t, err)
 	require.NotNil(t, expr)
 	term := expr.GetTermExpr()
 	require.NotNil(t, term)
-	require.Equal(t, 1, len(term.GetValues()))
-	require.Equal(t, int64(5), term.GetValues()[0].GetInt64Val())
+	require.Equal(t, 2, len(term.GetValues()))
+	require.Equal(t, int64(9), term.GetValues()[0].GetInt64Val())
+	require.Equal(t, int64(10), term.GetValues()[1].GetInt64Val())
 }
 
 func TestRewrite_Or_In_Union(t *testing.T) {
 	helper := buildSchemaHelperForRewriteT(t)
-	expr, err := parser.ParseExpr(helper, `Int64Field in [1,3] or Int64Field in [3,4]`, nil)
+	expr, err := parser.ParseExpr(helper, `Int64Field in [1,2,3,4,5,6,7,8,9,10] or Int64Field in [10,11,12,13,14,15,16,17,18,19]`, nil)
 	require.NoError(t, err)
 	require.NotNil(t, expr)
 	term := expr.GetTermExpr()
 	require.NotNil(t, term)
-	require.Equal(t, []int64{1, 3, 4}, []int64{
-		term.GetValues()[0].GetInt64Val(),
-		term.GetValues()[1].GetInt64Val(),
-		term.GetValues()[2].GetInt64Val(),
-	})
+	require.Equal(t, 19, len(term.GetValues()))
 }
 
 func TestRewrite_And_In_Intersection(t *testing.T) {
 	helper := buildSchemaHelperForRewriteT(t)
-	expr, err := parser.ParseExpr(helper, `Int64Field in [1,2,3] and Int64Field in [2,3,4]`, nil)
+	expr, err := parser.ParseExpr(helper, `Int64Field in [1,2,3,4,5,6,7,8,9,10] and Int64Field in [5,6,7,8,9,10,11,12,13,14]`, nil)
 	require.NoError(t, err)
 	require.NotNil(t, expr)
 	term := expr.GetTermExpr()
 	require.NotNil(t, term)
-	require.Equal(t, []int64{2, 3}, []int64{
-		term.GetValues()[0].GetInt64Val(),
-		term.GetValues()[1].GetInt64Val(),
-	})
+	require.Equal(t, 6, len(term.GetValues()))
 }
 
 func TestRewrite_And_In_Intersection_Empty_ToFalse(t *testing.T) {
 	helper := buildSchemaHelperForRewriteT(t)
-	expr, err := parser.ParseExpr(helper, `Int64Field in [1] and Int64Field in [2]`, nil)
+	expr, err := parser.ParseExpr(helper, `Int64Field in [1,2,3,4,5,6,7,8,9,10] and Int64Field in [11,12,13,14,15,16,17,18,19,20]`, nil)
 	require.NoError(t, err)
 	require.NotNil(t, expr)
 	require.True(t, rewriter.IsAlwaysFalseExpr(expr))
@@ -234,20 +296,18 @@ func TestRewrite_And_In_Intersection_Empty_ToFalse(t *testing.T) {
 
 func TestRewrite_And_In_And_NotEqual_Remove(t *testing.T) {
 	helper := buildSchemaHelperForRewriteT(t)
-	expr, err := parser.ParseExpr(helper, `Int64Field in [1,2,3] and Int64Field != 2`, nil)
+	expr, err := parser.ParseExpr(helper, `Int64Field in [1,2,3,4,5,6,7,8,9,10] and Int64Field != 5`, nil)
 	require.NoError(t, err)
 	require.NotNil(t, expr)
 	term := expr.GetTermExpr()
 	require.NotNil(t, term)
-	require.Equal(t, []int64{1, 3}, []int64{
-		term.GetValues()[0].GetInt64Val(),
-		term.GetValues()[1].GetInt64Val(),
-	})
+	require.Equal(t, 9, len(term.GetValues()))
 }
 
 func TestRewrite_And_In_And_NotEqual_AllRemoved_ToFalse(t *testing.T) {
 	helper := buildSchemaHelperForRewriteT(t)
-	expr, err := parser.ParseExpr(helper, `Int64Field in [2] and Int64Field != 2`, nil)
+	// in [10 values] and != each of them → false
+	expr, err := parser.ParseExpr(helper, `Int64Field in [1,2,3,4,5,6,7,8,9,10] and Int64Field != 1 and Int64Field != 2 and Int64Field != 3 and Int64Field != 4 and Int64Field != 5 and Int64Field != 6 and Int64Field != 7 and Int64Field != 8 and Int64Field != 9 and Int64Field != 10`, nil)
 	require.NoError(t, err)
 	require.NotNil(t, expr)
 	require.True(t, rewriter.IsAlwaysFalseExpr(expr))
@@ -255,7 +315,7 @@ func TestRewrite_And_In_And_NotEqual_AllRemoved_ToFalse(t *testing.T) {
 
 func TestRewrite_Or_In_Or_NotEqual_VInSet_ToTrue(t *testing.T) {
 	helper := buildSchemaHelperForRewriteT(t)
-	expr, err := parser.ParseExpr(helper, `Int64Field in [1,2] or Int64Field != 2`, nil)
+	expr, err := parser.ParseExpr(helper, `Int64Field in [1,2,3,4,5,6,7,8,9,10] or Int64Field != 5`, nil)
 	require.NoError(t, err)
 	require.NotNil(t, expr)
 	require.True(t, rewriter.IsAlwaysTrueExpr(expr),
@@ -273,91 +333,60 @@ func TestRewrite_Or_In_Or_NotEqual_VarChar_Tautology(t *testing.T) {
 
 func TestRewrite_Or_In_Or_NotEqual_VNotInSet_ToNotEqual(t *testing.T) {
 	helper := buildSchemaHelperForRewriteT(t)
-	expr, err := parser.ParseExpr(helper, `Int64Field in [1] or Int64Field != 2`, nil)
+	expr, err := parser.ParseExpr(helper, `Int64Field in [1,2,3,4,5,6,7,8,9,10] or Int64Field != 20`, nil)
 	require.NoError(t, err)
 	require.NotNil(t, expr)
 	ure := expr.GetUnaryRangeExpr()
 	require.NotNil(t, ure)
 	require.Equal(t, planpb.OpType_NotEqual, ure.GetOp())
-	require.Equal(t, int64(2), ure.GetValue().GetInt64Val())
+	require.Equal(t, int64(20), ure.GetValue().GetInt64Val())
 }
 
 // Test contradictory equals: (a == 1) AND (a == 2) → false
 // NOTE: This is a known limitation - currently NOT optimized
 func TestRewrite_And_Equal_And_Equal_Contradiction_CurrentLimitation(t *testing.T) {
 	helper := buildSchemaHelperForRewriteT(t)
-	// Int64Field == 1 AND Int64Field == 2 → false (contradiction)
-	// Currently NOT optimized because equals don't convert to IN in AND context
 	expr, err := parser.ParseExpr(helper, `Int64Field == 1 and Int64Field == 2`, nil)
 	require.NoError(t, err)
 	require.NotNil(t, expr)
-
-	// Current limitation: NOT optimized to false
-	// Remains as BinaryExpr AND with two equal predicates
 	be := expr.GetBinaryExpr()
 	require.NotNil(t, be, "should remain as AND (not optimized)")
 	require.Equal(t, planpb.BinaryExpr_LogicalAnd, be.GetOp())
 }
 
-// Test contradictory equals with three values
 func TestRewrite_And_Equal_ThreeWay_Contradiction_CurrentLimitation(t *testing.T) {
 	helper := buildSchemaHelperForRewriteT(t)
-	// Int64Field == 1 AND Int64Field == 2 AND Int64Field == 3 → false
-	// Currently NOT optimized
 	expr, err := parser.ParseExpr(helper, `Int64Field == 1 and Int64Field == 2 and Int64Field == 3`, nil)
 	require.NoError(t, err)
 	require.NotNil(t, expr)
-
-	// Current limitation: NOT optimized to false
 	be := expr.GetBinaryExpr()
 	require.NotNil(t, be, "should remain as AND chain (not optimized)")
 	require.Equal(t, planpb.BinaryExpr_LogicalAnd, be.GetOp())
 }
 
-// Test range + contradictory equal: (a > 10) AND (a == 5) → false
-// NOTE: Current limitation - NOT optimized
 func TestRewrite_And_Range_And_Equal_Contradiction_CurrentLimitation(t *testing.T) {
 	helper := buildSchemaHelperForRewriteT(t)
-	// Int64Field > 10 AND Int64Field == 5 → false (5 is not > 10)
-	// This requires combining range and equality checks, which is partially implemented
 	expr, err := parser.ParseExpr(helper, `Int64Field > 10 and Int64Field == 5`, nil)
 	require.NoError(t, err)
 	require.NotNil(t, expr)
-
-	// Current behavior: may not optimize to false
-	// If it does optimize via IN+range filtering, it would become false
-	// This test documents current limitation
-	// When fully optimized, should be constant false
-	_ = expr // Test documents that this case exists
+	_ = expr
 }
 
-// Test non-contradictory range + equal: (a > 10) AND (a == 15) → stays as is
-// NOTE: This requires Equal to be in IN form first, which happens via combineAndInWithEqual
-// But Equal alone doesn't convert to IN in AND context, so this optimization doesn't happen
 func TestRewrite_And_Range_And_Equal_NonContradiction_CurrentLimitation(t *testing.T) {
 	helper := buildSchemaHelperForRewriteT(t)
-	// Int64Field > 10 AND Int64Field == 15 → should simplify to Int64Field == 15
-	// But currently NOT optimized without IN involved
 	expr, err := parser.ParseExpr(helper, `Int64Field > 10 and Int64Field == 15`, nil)
 	require.NoError(t, err)
 	require.NotNil(t, expr)
-
-	// Current limitation: remains as AND with range and equal
 	be := expr.GetBinaryExpr()
 	require.NotNil(t, be, "should remain as AND (not optimized)")
 	require.Equal(t, planpb.BinaryExpr_LogicalAnd, be.GetOp())
 }
 
-// Test string contradictory equals - current limitation
 func TestRewrite_And_Equal_String_Contradiction_CurrentLimitation(t *testing.T) {
 	helper := buildSchemaHelperForRewriteT(t)
-	// VarCharField == "apple" AND VarCharField == "banana" → false
-	// Currently NOT optimized
 	expr, err := parser.ParseExpr(helper, `VarCharField == "apple" and VarCharField == "banana"`, nil)
 	require.NoError(t, err)
 	require.NotNil(t, expr)
-
-	// Current limitation: NOT optimized to false
 	be := expr.GetBinaryExpr()
 	require.NotNil(t, be, "should remain as AND (not optimized)")
 	require.Equal(t, planpb.BinaryExpr_LogicalAnd, be.GetOp())

--- a/internal/parser/planparserv2/rewriter/util.go
+++ b/internal/parser/planparserv2/rewriter/util.go
@@ -92,13 +92,28 @@ func isNumericType(dt schemapb.DataType) bool {
 	return typeutil.IsArithmetic(dt)
 }
 
-const defaultConvertOrToInNumericLimit = 150
+// shouldUseInExpr determines whether a multi-value equality match should use
+// TermExpr (IN) or individual UnaryRangeExpr (== or).
+// Used bidirectionally:
+//   - combineOrEqualsToIn: merge == or → in when returns true
+//   - combineAndNotEqualsToNotIn: merge != and → not in when returns true
+//   - visitTermExpr: split in → == or when returns false
+func shouldUseInExpr(dt schemapb.DataType, count int) bool {
+	return shouldUseInExprWithPK(dt, count, false)
+}
 
-func shouldMergeToIn(dt schemapb.DataType, count int) bool {
-	if isNumericType(dt) {
-		return count > defaultConvertOrToInNumericLimit
+func shouldUseInExprWithPK(dt schemapb.DataType, count int, isPrimaryKey bool) bool {
+	if isPrimaryKey {
+		return true
 	}
-	return count > 1
+	switch {
+	case typeutil.IsIntegerType(dt):
+		return count >= 10
+	case typeutil.IsFloatingType(dt):
+		return count >= 15
+	default:
+		return count >= 3
+	}
 }
 
 func sortTermValues(term *planpb.TermExpr) {

--- a/internal/proxy/task_search_test.go
+++ b/internal/proxy/task_search_test.go
@@ -4758,7 +4758,7 @@ func (s *MaterializedViewTestSuite) TestMvEnabledPartitionKeyOnVarCharWithIsolat
 		task := s.getSearchTask()
 		task.enableMaterializedView = true
 		task.IsAdvanced = isAdvanced
-		task.request.Dsl = testVarCharField + " in [\"a\", \"b\"]"
+		task.request.Dsl = testVarCharField + " in [\"a\", \"b\", \"c\"]"
 		schema := ConstructCollectionSchemaWithPartitionKey(s.colName, s.fieldName2Types, testInt64Field, testVarCharField, false)
 		schemaInfo := newSchemaInfo(schema)
 		s.mockMetaCache.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(schemaInfo, nil)
@@ -4772,7 +4772,7 @@ func (s *MaterializedViewTestSuite) TestMvEnabledPartitionKeyOnVarCharWithIsolat
 		task := s.getSearchTask()
 		task.enableMaterializedView = true
 		task.IsAdvanced = isAdvanced
-		task.request.Dsl = testVarCharField + " == \"a\" || " + testVarCharField + "  == \"b\""
+		task.request.Dsl = testVarCharField + " == \"a\" || " + testVarCharField + "  == \"b\" || " + testVarCharField + " == \"c\""
 		schema := ConstructCollectionSchemaWithPartitionKey(s.colName, s.fieldName2Types, testInt64Field, testVarCharField, false)
 		schemaInfo := newSchemaInfo(schema)
 		s.mockMetaCache.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(schemaInfo, nil)

--- a/internal/util/exprutil/expr_checker_test.go
+++ b/internal/util/exprutil/expr_checker_test.go
@@ -79,7 +79,7 @@ func TestParsePartitionKeys(t *testing.T) {
 		},
 		{
 			name:                 "binary_expr_and with partition key in range",
-			expr:                 "partition_key_field in [7, 8] && partition_key_field > 9",
+			expr:                 "partition_key_field in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] && partition_key_field > 11",
 			expected:             0,
 			validPartitionKeys:   []int64{},
 			invalidPartitionKeys: []int64{},
@@ -249,17 +249,17 @@ func TestValidatePartitionKeyIsolation(t *testing.T) {
 		},
 		{
 			name:                "partition key isolation term",
-			expr:                "key_field in [10]",
+			expr:                "key_field in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]",
 			expectedErrorString: "partition key isolation does not support IN",
 		},
 		{
 			name:                "partition key isolation term multiple",
-			expr:                "key_field in [10, 20]",
+			expr:                "key_field in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]",
 			expectedErrorString: "partition key isolation does not support IN",
 		},
 		{
 			name:                "partition key isolation NOT term",
-			expr:                "key_field not in [10]",
+			expr:                "key_field not in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]",
 			expectedErrorString: "partition key isolation does not support IN",
 		},
 		{


### PR DESCRIPTION
Replace the fixed threshold (150) for merging == or into in[] with type-specific thresholds based on benchmark data:
- INT types: use in[] when N >= 10 (== or is faster below due to simpler execution path)
- FLOAT types: use in[] when N >= 15 (float hash is more expensive)
- Other types (varchar, bool): use in[] when N >= 3

The rewriting is now bidirectional:
- == or → in[]: when shouldUseInExpr returns true (existing direction)
- in[] → == or: when shouldUseInExpr returns false (new direction, via visitTermExpr)
- not in → != and: when shouldUseInExpr returns false (new, via visitUnaryExpr)

Both directions use the same shouldUseInExpr function to ensure consistency.

issue: https://github.com/milvus-io/milvus/issues/45525