### PR TITLE
fix: check CStatus return from InitLocalChunkManagerSingleton

### DIFF
--- a/internal/datanode/index/init_segcore.go
+++ b/internal/datanode/index/init_segcore.go
@@ -82,7 +82,9 @@ func InitSegcore(nodeID int64) error {
 	C.SegcoreSetKnowhereBuildThreadPoolNum(cKnowhereThreadPoolSize)
 
 	localDataRootPath := pathutil.GetPath(pathutil.LocalChunkPath, nodeID)
-	initcore.InitLocalChunkManager(localDataRootPath)
+	if err := initcore.InitLocalChunkManager(localDataRootPath); err != nil {
+		return err
+	}
 	cGpuMemoryPoolInitSize := C.uint32_t(paramtable.Get().GpuConfig.InitSize.GetAsUint32())
 	cGpuMemoryPoolMaxSize := C.uint32_t(paramtable.Get().GpuConfig.MaxSize.GetAsUint32())
 	C.SegcoreSetKnowhereGpuMemoryPoolSize(cGpuMemoryPoolInitSize, cGpuMemoryPoolMaxSize)

--- a/internal/util/initcore/init_core.go
+++ b/internal/util/initcore/init_core.go
@@ -54,10 +54,11 @@ func InitExecExpressionFunctionFactory() {
 	C.InitExecExpressionFunctionFactory()
 }
 
-func InitLocalChunkManager(path string) {
+func InitLocalChunkManager(path string) error {
 	CLocalRootPath := C.CString(path)
 	defer C.free(unsafe.Pointer(CLocalRootPath))
-	C.InitLocalChunkManagerSingleton(CLocalRootPath)
+	status := C.InitLocalChunkManagerSingleton(CLocalRootPath)
+	return HandleCStatus(&status, "InitLocalChunkManagerSingleton failed")
 }
 
 func InitTraceConfig(params *paramtable.ComponentParam) {

--- a/internal/util/initcore/query_node.go
+++ b/internal/util/initcore/query_node.go
@@ -153,7 +153,9 @@ func doInitQueryNodeOnce(ctx context.Context) error {
 
 	localDataRootPath := pathutil.GetPath(pathutil.LocalChunkPath, nodeID)
 
-	InitLocalChunkManager(localDataRootPath)
+	if err := InitLocalChunkManager(localDataRootPath); err != nil {
+		return err
+	}
 
 	err := InitRemoteChunkManager(paramtable.Get())
 	if err != nil {


### PR DESCRIPTION
Check CStatus return value from InitLocalChunkManagerSingleton to propagate initialization errors instead of silently ignoring them.

issue: #48549