### PR TITLE
fix: guard FFIPackedWriter against double close to prevent heap-use-after-free

### DIFF
--- a/internal/storagev2/packed/packed_writer_ffi.go
+++ b/internal/storagev2/packed/packed_writer_ffi.go
@@ -168,9 +168,14 @@ func (pw *FFIPackedWriter) WriteRecordBatch(recordBatch arrow.Record) error {
 }
 
 func (pw *FFIPackedWriter) Close() (string, error) {
+	if pw.cWriterHandle == nil {
+		return "", nil
+	}
+
 	var cColumnGroups *C.LoonColumnGroups
 
 	result := C.loon_writer_close(pw.cWriterHandle, nil, nil, 0, &cColumnGroups)
+	pw.cWriterHandle = nil
 	if err := HandleLoonFFIResult(result); err != nil {
 		return "", err
 	}
@@ -198,6 +203,7 @@ func (pw *FFIPackedWriter) Close() (string, error) {
 
 	log.Info("FFI writer closed", zap.Int64("version", int64(cCommitVersion)))
 
-	defer C.loon_properties_free(pw.cProperties)
+	C.loon_properties_free(pw.cProperties)
+	pw.cProperties = nil
 	return MarshalManifestPath(pw.basePath, int64(cCommitVersion)), nil
 }


### PR DESCRIPTION
Add nil guard and nil-out cWriterHandle/cProperties after close in FFIPackedWriter, matching the FFIPackedReader fix in #48473.

issue: #48560