### PR TITLE
fix: clear stale sessions in sessionDiscoverer.initDiscover on retry

### DIFF
--- a/internal/util/streamingutil/service/discoverer/session_discoverer.go
+++ b/internal/util/streamingutil/service/discoverer/session_discoverer.go
@@ -172,6 +172,10 @@ func (sw *sessionDiscoverer) initDiscover(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	// Clear stale sessions before re-populating.
+	// On retry (e.g. after etcd watch compaction), sessions deleted during the
+	// watch gap would otherwise persist forever because initDiscover only adds entries.
+	sw.peerSessions = make(map[string]*sessionutil.SessionRaw, len(resp.Kvs))
 	for _, kv := range resp.Kvs {
 		logger := sw.Logger().With(zap.String("sessionKey", string(kv.Key)), zap.String("sessionValue", string(kv.Value)))
 		session, err := sw.parseSession(kv.Value)

--- a/internal/util/streamingutil/service/discoverer/session_discoverer_test.go
+++ b/internal/util/streamingutil/service/discoverer/session_discoverer_test.go
@@ -19,6 +19,44 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
+func TestSessionDiscovererClearsStaleSessionsOnRetry(t *testing.T) {
+	etcdClient, _ := kvfactory.GetEtcdAndPath()
+	prefix := funcutil.RandomString(10) + "/"
+	ctx := context.Background()
+
+	// Put 3 sessions into etcd.
+	sessions := map[int64]*sessionutil.SessionRaw{
+		1: {ServerID: 1, Address: "127.0.0.1:12345", Version: "0.2.0"},
+		2: {ServerID: 2, Address: "127.0.0.1:12346", Version: "0.3.0"},
+		3: {ServerID: 3, Address: "127.0.0.1:12347", Version: "0.4.0"},
+	}
+	for id, s := range sessions {
+		val, err := json.Marshal(s)
+		assert.NoError(t, err)
+		_, err = etcdClient.Put(ctx, fmt.Sprintf("%s%d", prefix, id), string(val))
+		assert.NoError(t, err)
+	}
+
+	d := NewSessionDiscoverer(etcdClient, OptSDPrefix(prefix), OptSDVersionRange(">=0.1.0"))
+
+	// First initDiscover: should see all 3 sessions.
+	err := d.initDiscover(ctx)
+	assert.NoError(t, err)
+	assert.Len(t, d.peerSessions, 3)
+
+	// Delete session 2 from etcd (simulating a node going down during watch gap).
+	_, err = etcdClient.Delete(ctx, fmt.Sprintf("%s%d", prefix, 2))
+	assert.NoError(t, err)
+
+	// Second initDiscover (retry after watch break): stale session 2 must be gone.
+	err = d.initDiscover(ctx)
+	assert.NoError(t, err)
+	assert.Len(t, d.peerSessions, 2)
+	for _, s := range d.peerSessions {
+		assert.NotEqual(t, int64(2), s.ServerID, "stale session should have been cleared")
+	}
+}
+
 func TestSessionDiscoverer(t *testing.T) {
 	etcdClient, _ := kvfactory.GetEtcdAndPath()
 	targetVersion := "0.1.0"


### PR DESCRIPTION
When etcd watch breaks (compaction/network) and initDiscover retries, sessions deleted during the watch gap persisted forever because initDiscover only added entries to peerSessions without clearing old ones. This caused the resolver to permanently report dead nodes as alive, blocking the streaming balancer indefinitely.

Fix: reset peerSessions map before re-populating from etcd Get response.

issue: #48564