### PR TITLE
fix: reject compaction requests without params instead of falling back to defaults

### DIFF
--- a/internal/compaction/params.go
+++ b/internal/compaction/params.go
@@ -63,10 +63,6 @@ func GenerateJSONParams() (string, error) {
 func ParseParamsFromJSON(jsonStr string) (Params, error) {
 	var compactionParams Params
 	err := json.Unmarshal([]byte(jsonStr), &compactionParams)
-	if err != nil && jsonStr == "" {
-		// Ensure the compatibility with the legacy requests sent by the old datacoord.
-		return GenParams(), nil
-	}
 	return compactionParams, err
 }
 

--- a/internal/compaction/params_test.go
+++ b/internal/compaction/params_test.go
@@ -84,16 +84,6 @@ func TestGetParamsFromJSON_InvalidJSON(t *testing.T) {
 func TestGetParamsFromJSON_EmptyJSON(t *testing.T) {
 	// Test compatibility
 	emptyJSON := ``
-	result, err := ParseParamsFromJSON(emptyJSON)
-	assert.NoError(t, err)
-	assert.Equal(t, Params{
-		StorageVersion:            storage.StorageV3,
-		UseLoonFFI:                true,
-		BinLogMaxSize:             paramtable.Get().DataNodeCfg.BinLogMaxSize.GetAsUint64(),
-		UseMergeSort:              paramtable.Get().DataNodeCfg.UseMergeSort.GetAsBool(),
-		MaxSegmentMergeSort:       paramtable.Get().DataNodeCfg.MaxSegmentMergeSort.GetAsInt(),
-		PreferSegmentSizeRatio:    paramtable.Get().DataCoordCfg.ClusteringCompactionPreferSegmentSizeRatio.GetAsFloat(),
-		BloomFilterApplyBatchSize: paramtable.Get().CommonCfg.BloomFilterApplyBatchSize.GetAsInt(),
-		StorageConfig:             CreateStorageConfig(),
-	}, result)
+	_, err := ParseParamsFromJSON(emptyJSON)
+	assert.Error(t, err)
 }

--- a/internal/datanode/compactor/l0_compactor_test.go
+++ b/internal/datanode/compactor/l0_compactor_test.go
@@ -73,9 +73,7 @@ func (s *LevelZeroCompactionTaskSuite) SetupTest() {
 		},
 	}
 	s.task = NewLevelZeroCompactionTask(context.Background(), s.mockBinlogIO, nil, plan, compaction.GenParams())
-	var err error
-	s.task.compactionParams, err = compaction.ParseParamsFromJSON("")
-	s.Require().NoError(err)
+	s.task.compactionParams = compaction.GenParams()
 
 	s.dData = storage.NewDeleteData([]storage.PrimaryKey{
 		storage.NewInt64PrimaryKey(1),

--- a/internal/datanode/services_test.go
+++ b/internal/datanode/services_test.go
@@ -261,6 +261,9 @@ func (s *DataNodeServicesSuite) TestCompaction() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
+		jsonParams, err := compaction.GenerateJSONParams()
+		s.Require().NoError(err)
+
 		req := &datapb.CompactionPlan{
 			PlanID:  1000,
 			Channel: dmChannelName,
@@ -272,6 +275,7 @@ func (s *DataNodeServicesSuite) TestCompaction() {
 			BeginLogID:             100,
 			PreAllocatedSegmentIDs: &datapb.IDRange{Begin: 100, End: 200},
 			PreAllocatedLogIDs:     &datapb.IDRange{Begin: 200, End: 2000},
+			JsonParams:             jsonParams,
 		}
 
 		resp, err := node.CompactionV2(ctx, req)
@@ -308,6 +312,9 @@ func (s *DataNodeServicesSuite) TestCompaction() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
+		jsonParams, err := compaction.GenerateJSONParams()
+		s.Require().NoError(err)
+
 		req := &datapb.CompactionPlan{
 			PlanID:  1000,
 			Channel: dmChannelName,
@@ -319,6 +326,7 @@ func (s *DataNodeServicesSuite) TestCompaction() {
 			BeginLogID:             100,
 			PreAllocatedSegmentIDs: &datapb.IDRange{Begin: 0, End: 0},
 			PreAllocatedLogIDs:     &datapb.IDRange{Begin: 200, End: 2000},
+			JsonParams:             jsonParams,
 		}
 
 		resp, err := node.CompactionV2(ctx, req)

--- a/internal/datanode/services_test.go
+++ b/internal/datanode/services_test.go
@@ -235,6 +235,9 @@ func (s *DataNodeServicesSuite) TestCompaction() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
+		jsonParams, err := compaction.GenerateJSONParams()
+		s.Require().NoError(err)
+
 		req := &datapb.CompactionPlan{
 			PlanID:  1000,
 			Channel: dmChannelName,
@@ -244,6 +247,7 @@ func (s *DataNodeServicesSuite) TestCompaction() {
 			},
 			BeginLogID:         100,
 			PreAllocatedLogIDs: &datapb.IDRange{Begin: 200, End: 2000},
+			JsonParams:         jsonParams,
 		}
 
 		resp, err := node.CompactionV2(ctx, req)


### PR DESCRIPTION
Remove legacy compatibility code that silently generated default v3 compaction params when the request from an old datacoord had empty params. This caused datanode to produce v2 segments unexpectedly. Now ParseParamsFromJSON returns an error on empty input, forcing the caller to provide valid compaction params.

issue: #48570