### PR TITLE
fix: [hotfix] reject compaction requests without params instead of falling back to defaults

### DIFF
--- a/internal/compaction/params.go
+++ b/internal/compaction/params.go
@@ -59,10 +59,6 @@ func GenerateJSONParams() (string, error) {
 func ParseParamsFromJSON(jsonStr string) (Params, error) {
 	var compactionParams Params
 	err := json.Unmarshal([]byte(jsonStr), &compactionParams)
-	if err != nil && jsonStr == "" {
-		// Ensure the compatibility with the legacy requests sent by the old datacoord.
-		return GenParams(), nil
-	}
 	return compactionParams, err
 }
 

--- a/internal/compaction/params_test.go
+++ b/internal/compaction/params_test.go
@@ -78,15 +78,6 @@ func TestGetParamsFromJSON_InvalidJSON(t *testing.T) {
 func TestGetParamsFromJSON_EmptyJSON(t *testing.T) {
 	// Test compatibility
 	emptyJSON := ``
-	result, err := ParseParamsFromJSON(emptyJSON)
-	assert.NoError(t, err)
-	assert.Equal(t, Params{
-		StorageVersion:            storage.StorageV2,
-		BinLogMaxSize:             paramtable.Get().DataNodeCfg.BinLogMaxSize.GetAsUint64(),
-		UseMergeSort:              paramtable.Get().DataNodeCfg.UseMergeSort.GetAsBool(),
-		MaxSegmentMergeSort:       paramtable.Get().DataNodeCfg.MaxSegmentMergeSort.GetAsInt(),
-		PreferSegmentSizeRatio:    paramtable.Get().DataCoordCfg.ClusteringCompactionPreferSegmentSizeRatio.GetAsFloat(),
-		BloomFilterApplyBatchSize: paramtable.Get().CommonCfg.BloomFilterApplyBatchSize.GetAsInt(),
-		StorageConfig:             CreateStorageConfig(),
-	}, result)
+	_, err := ParseParamsFromJSON(emptyJSON)
+	assert.Error(t, err)
 }


### PR DESCRIPTION
Remove legacy compatibility code that silently generated default v3 compaction params when the request from an old datacoord had empty params. This caused datanode to produce v2 segments unexpectedly. Now ParseParamsFromJSON returns an error on empty input, forcing the caller to provide valid compaction params.

issue: #48570