### PR TITLE
fix: [hotfix] add missing GEOMETRY case in DefaultValueChunkTranslator::value_size() (#48556)

### DIFF
--- a/internal/core/src/segcore/storagev1translator/DefaultValueChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/DefaultValueChunkTranslator.cpp
@@ -154,6 +154,7 @@ DefaultValueChunkTranslator::value_size() const {
         case milvus::DataType::VARCHAR:
         case milvus::DataType::STRING:
         case milvus::DataType::TEXT:
+        case milvus::DataType::GEOMETRY:
             if (field_meta_.default_value().has_value()) {
                 auto default_value = field_meta_.default_value().value();
                 value_size = default_value.string_data().size() +


### PR DESCRIPTION
Cherry-pick from master
pr: #48556
Related to #48555

GEOMETRY is a string-based data type but was not handled in the value_size() switch, causing DataTypeInvalid to be thrown when loading segments with default-valued GEOMETRY fields.