### PR TITLE
fix: Set useCRC32C default config to false

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -123,7 +123,7 @@ minio:
     # When set to "default", the SDK/runtime default is used (typically TLS 1.2).
     # We recommend using version 1.2 and above.
     tlsMinVersion: default
-    useCRC32C: true # Whether to use CRC32C checksum for data integrity validation on MinIO/S3 PutObject requests.
+    useCRC32C: false # Whether to use CRC32C checksum for data integrity validation on MinIO/S3 PutObject requests.
   # Name of the bucket where Milvus stores data in MinIO or S3.
   # Milvus 2.0.0 does not support storing data in multiple buckets.
   # Bucket with this name will be created if it does not exist. If the bucket already exists and is accessible, it will be used directly. Otherwise, there will be an error.

--- a/pkg/util/paramtable/service_param.go
+++ b/pkg/util/paramtable/service_param.go
@@ -1630,7 +1630,7 @@ Leave it empty if you want to use AWS default endpoint`,
 	p.UseCRC32C = ParamItem{
 		Key:          "minio.ssl.useCRC32C",
 		Version:      "2.6.11",
-		DefaultValue: "true",
+		DefaultValue: "false",
 		Doc:          "Whether to use CRC32C checksum for data integrity validation on MinIO/S3 PutObject requests.",
 		Export:       true,
 	}


### PR DESCRIPTION
Default to ture cuases other cloud provider unable to work.
We should enable it and restart if needed.

See also: #48360 
pr: #48476 