### PR TITLE
fix: handle full-size format in GetDataIterator for nullable GROUP BY fields [2.6]

### DIFF
--- a/internal/proxy/task_search_test.go
+++ b/internal/proxy/task_search_test.go
@@ -2554,8 +2554,8 @@ func TestTaskSearch_reduceGroupBySearchResultData(t *testing.T) {
 		{
 			name: "nullable group_by values",
 			inputs: []*schemapb.SearchResultData{
-				makePartialResult(ids[0], scores[0], []int64{1, 2, 3, 4, 1, 2, 3, 4}, []bool{true, true, true, true, false, true, true, true, true, false}),
-				makePartialResult(ids[1], scores[1], []int64{1, 2, 3, 4, 1, 2, 3, 4}, []bool{true, true, true, true, false, true, true, true, true, false}),
+				makePartialResult(ids[0], scores[0], []int64{1, 2, 3, 4, 0, 1, 2, 3, 4, 0}, []bool{true, true, true, true, false, true, true, true, true, false}),
+				makePartialResult(ids[1], scores[1], []int64{1, 2, 3, 4, 0, 1, 2, 3, 4, 0}, []bool{true, true, true, true, false, true, true, true, true, false}),
 			},
 			expectedIDs:    []int64{1, 3, 5, 7, 9, 1, 3, 5, 7, 9},
 			expectedScores: []float32{-10, -8, -6, -4, -2, -10, -8, -6, -4, -2},

--- a/pkg/util/typeutil/schema.go
+++ b/pkg/util/typeutil/schema.go
@@ -1918,13 +1918,26 @@ func GetPK(data *schemapb.IDs, idx int64) interface{} {
 
 func GetDataIterator(field *schemapb.FieldData) func(int) any {
 	if field.GetValidData() != nil {
-		// unpack valid data
-		idxs := make([]int, len(field.ValidData))
-		validCnt := 0
-		for i, valid := range field.ValidData {
+		validData := field.GetValidData()
+		dataLen := getScalarDataLen(field)
+		if dataLen == len(validData) {
+			// Full-size format: data array has the same length as ValidData,
+			// values at invalid positions are zero-filled. Use direct indexing.
+			return func(idx int) any {
+				if !validData[idx] {
+					return nil
+				}
+				return getData(field, idx)
+			}
+		}
+		// Compact format: data array only contains valid entries.
+		// Build a mapping from logical index to physical index.
+		idxs := make([]int, len(validData))
+		cnt := 0
+		for i, valid := range validData {
 			if valid {
-				idxs[i] = validCnt
-				validCnt++
+				idxs[i] = cnt
+				cnt++
 			} else {
 				idxs[i] = -1
 			}
@@ -1939,6 +1952,28 @@ func GetDataIterator(field *schemapb.FieldData) func(int) any {
 	return func(idx int) any {
 		return getData(field, idx)
 	}
+}
+
+// getScalarDataLen returns the length of the scalar data array in a FieldData.
+// For vector types or unrecognized types, returns -1.
+func getScalarDataLen(field *schemapb.FieldData) int {
+	switch field.GetType() {
+	case schemapb.DataType_Bool:
+		return len(field.GetScalars().GetBoolData().GetData())
+	case schemapb.DataType_Int8, schemapb.DataType_Int16, schemapb.DataType_Int32:
+		return len(field.GetScalars().GetIntData().GetData())
+	case schemapb.DataType_Int64:
+		return len(field.GetScalars().GetLongData().GetData())
+	case schemapb.DataType_Float:
+		return len(field.GetScalars().GetFloatData().GetData())
+	case schemapb.DataType_Double:
+		return len(field.GetScalars().GetDoubleData().GetData())
+	case schemapb.DataType_Timestamptz:
+		return len(field.GetScalars().GetTimestamptzData().GetData())
+	case schemapb.DataType_VarChar, schemapb.DataType_Text:
+		return len(field.GetScalars().GetStringData().GetData())
+	}
+	return -1
 }
 
 func getData(field *schemapb.FieldData, idx int) any {

--- a/pkg/util/typeutil/schema_test.go
+++ b/pkg/util/typeutil/schema_test.go
@@ -3023,7 +3023,7 @@ func TestGetDataIterator(t *testing.T) {
 			want: []any{int64(1), int64(2), int64(3)},
 		},
 		{
-			name: "ints with nulls",
+			name: "ints with nulls compact",
 			field: &schemapb.FieldData{
 				Type: schemapb.DataType_Int64,
 				Field: &schemapb.FieldData_Scalars{
@@ -3038,6 +3038,57 @@ func TestGetDataIterator(t *testing.T) {
 				ValidData: []bool{true, false, true, true},
 			},
 			want: []any{int64(1), nil, int64(2), int64(3)},
+		},
+		{
+			name: "ints with nulls full-size",
+			field: &schemapb.FieldData{
+				Type: schemapb.DataType_Int64,
+				Field: &schemapb.FieldData_Scalars{
+					Scalars: &schemapb.ScalarField{
+						Data: &schemapb.ScalarField_LongData{
+							LongData: &schemapb.LongArray{
+								Data: []int64{1, 0, 2, 3},
+							},
+						},
+					},
+				},
+				ValidData: []bool{true, false, true, true},
+			},
+			want: []any{int64(1), nil, int64(2), int64(3)},
+		},
+		{
+			name: "strings with nulls full-size",
+			field: &schemapb.FieldData{
+				Type: schemapb.DataType_VarChar,
+				Field: &schemapb.FieldData_Scalars{
+					Scalars: &schemapb.ScalarField{
+						Data: &schemapb.ScalarField_StringData{
+							StringData: &schemapb.StringArray{
+								Data: []string{"a", "b", "", "c", ""},
+							},
+						},
+					},
+				},
+				ValidData: []bool{true, true, false, true, false},
+			},
+			want: []any{"a", "b", nil, "c", nil},
+		},
+		{
+			name: "strings with nulls compact",
+			field: &schemapb.FieldData{
+				Type: schemapb.DataType_VarChar,
+				Field: &schemapb.FieldData_Scalars{
+					Scalars: &schemapb.ScalarField{
+						Data: &schemapb.ScalarField_StringData{
+							StringData: &schemapb.StringArray{
+								Data: []string{"a", "b", "c"},
+							},
+						},
+					},
+				},
+				ValidData: []bool{true, true, false, true, false},
+			},
+			want: []any{"a", "b", nil, "c", nil},
 		},
 	}
 	for _, tt := range tests {

--- a/tests/python_client/milvus_client_v2/test_milvus_client_search_group_by.py
+++ b/tests/python_client/milvus_client_v2/test_milvus_client_search_group_by.py
@@ -406,7 +406,7 @@ class TestGroupSearch(TestMilvusClientV2Base):
                     output_fields=[DataType.VARCHAR.name],
                     check_task=CheckTasks.err_res, check_items=error)
 
-    @pytest.mark.tags(CaseLabel.L2)
+    @pytest.mark.tags(CaseLabel.L0)
     @pytest.mark.parametrize("support_field", [DataType.INT8.name, DataType.INT64.name,
                                                DataType.BOOL.name, DataType.VARCHAR.name,
                                                DataType.TIMESTAMPTZ.name])


### PR DESCRIPTION
pr: #48219

## Summary
- Cherry-pick of #48219 to the 2.6 branch
- Fixes `GetDataIterator` to handle both full-size and compact nullable data formats, which caused incorrect GROUP BY results (returning more results than the specified `group_size`)

## Related Issue
https://github.com/milvus-io/milvus/issues/46734

## Test plan
- [x] Existing unit tests updated (`TestGetDataIterator`, `TestTaskSearch_reduceGroupBySearchResultData`)
- [ ] Verify `test_hybrid_search_group_size` and `test_search_pagination_group_size` pass in 2.6 nightly CI