### PR TITLE
fix: resolve flaky TestWait in vralloc due to missed cond signal

### DIFF
--- a/pkg/util/vralloc/alloc_test.go
+++ b/pkg/util/vralloc/alloc_test.go
@@ -20,8 +20,10 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/pkg/v2/log"
@@ -112,11 +114,13 @@ func TestWait(t *testing.T) {
 	assert.False(t, allocated)
 	close(waitCh) // start release a1
 
-	for !allocated {
-		a.Wait() // alloc after wait
+	// Use polling instead of cond.Wait() to avoid missed-signal race:
+	// all Broadcast() calls from Reallocate can complete before Wait()
+	// is called, causing Wait() to block forever.
+	require.Eventually(t, func() bool {
 		allocated, _ = a.Allocate("a2", &Resource{100, 100, 100})
-	}
-	assert.True(t, allocated)
+		return allocated
+	}, 5*time.Second, 10*time.Millisecond)
 }
 
 func TestPhysicalAwareFixedSizeAllocator(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fix flaky `TestWait` in `pkg/util/vralloc` that caused CI timeouts (10 min) on the 2.6 branch (`ut-go` pipeline #9359)
- Root cause: classic missed-signal race — `close(waitCh)` starts the release goroutine which can complete all 100 `Reallocate` calls (each calling `cond.Broadcast()`) before the main goroutine reaches `cond.Wait()`, causing it to block forever
- Replace `cond.Wait()` loop with `require.Eventually` polling (5s timeout, 10ms interval)

## Test plan
- [x] Forced-race repro (sleep + Gosched before Wait) fails 100% on old code, passes on new code
- [x] 500 consecutive runs pass
- [x] Full vralloc test suite passes

issue: https://github.com/milvus-io/milvus/issues/39893

🤖 Generated with [Claude Code](https://claude.com/claude-code)