### PR TITLE
fix: handle nil VectorField.Data in MergeFieldData for nullable vectors

### DIFF
--- a/pkg/util/typeutil/schema.go
+++ b/pkg/util/typeutil/schema.go
@@ -2095,6 +2095,8 @@ func MergeFieldData(dst []*schemapb.FieldData, src []*schemapb.FieldData) error 
 				} else {
 					dstVector.GetVectorArray().Data = append(dstVector.GetVectorArray().Data, srcVector.VectorArray.Data...)
 				}
+			case nil:
+				// nullable vector field where all rows are null — no vector data to merge
 			default:
 				return errors.New("unsupported data type: " + srcFieldData.Type.String())
 			}

--- a/pkg/util/typeutil/schema_test.go
+++ b/pkg/util/typeutil/schema_test.go
@@ -2124,6 +2124,46 @@ func TestMergeFieldData(t *testing.T) {
 		err := MergeFieldData([]*schemapb.FieldData{emptyField}, []*schemapb.FieldData{emptyField})
 		assert.Error(t, err)
 	})
+
+	t.Run("nullable float vector - all null src", func(t *testing.T) {
+		dim := int64(4)
+		dstFields := []*schemapb.FieldData{
+			{
+				Type:      schemapb.DataType_FloatVector,
+				FieldName: "nullable_vec",
+				FieldId:   200,
+				ValidData: []bool{true},
+				Field: &schemapb.FieldData_Vectors{
+					Vectors: &schemapb.VectorField{
+						Dim: dim,
+						Data: &schemapb.VectorField_FloatVector{
+							FloatVector: &schemapb.FloatArray{
+								Data: []float32{1, 2, 3, 4},
+							},
+						},
+					},
+				},
+			},
+		}
+		// src: all rows are null -> VectorField.Data = nil
+		srcFields := []*schemapb.FieldData{
+			{
+				Type:      schemapb.DataType_FloatVector,
+				FieldName: "nullable_vec",
+				FieldId:   200,
+				ValidData: []bool{false},
+				Field: &schemapb.FieldData_Vectors{
+					Vectors: &schemapb.VectorField{
+						Dim:  dim,
+						Data: nil, // all null -> no FloatVector oneof set
+					},
+				},
+			},
+		}
+
+		err := MergeFieldData(dstFields, srcFields)
+		assert.NoError(t, err, "MergeFieldData should handle nullable FloatVector with nil VectorField.Data")
+	})
 }
 
 type FieldDataSuite struct {


### PR DESCRIPTION
## Summary

When a nullable vector field has all rows null, `VectorField.Data` is `nil` (protobuf oneof not set). `MergeFieldData`'s switch on `Vectors.Data` type hits the `default` branch, returning `"unsupported data type: FloatVector"`, which causes `embeddingNode` to panic.

This adds a `case nil` to skip vector data merge when the source batch has no vector data (all rows null).

## Root Cause

- Nullable FloatVector with all-null rows → `VectorField.Data = nil`
- `MergeFieldData` switch cannot match any concrete vector type → falls through to `default`
- `embeddingNode.Operate()` calls `panic(err)` on the returned error

## Fix

- Add `case nil:` in the Vectors type switch to skip merging when source data is nil
- Add unit test reproducing the exact scenario

Fixes #48520
related: https://github.com/milvus-io/milvus/issues/45993

## Test plan

- [x] Unit test `TestMergeFieldData/nullable_float_vector_-_all_null_src` passes
- [x] Local standalone: insert 2000 rows with all-null nullable FloatVector + BM25 function — no panic
- [x] Without fix: same script triggers `panic: unsupported data type: FloatVector`

🤖 Generated with [Claude Code](https://claude.com/claude-code)