### PR TITLE
enhance: add default etcd auth credentials and startup validation

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -60,9 +60,9 @@ etcd:
   data:
     dir: default.etcd # Embedded Etcd only. please adjust in embedded Milvus: /tmp/milvus/etcdData/
   auth:
-    enabled: false # Whether to enable authentication
-    userName:  # username for etcd authentication
-    password:  # password for etcd authentication
+    enabled: true # Whether to enable authentication
+    userName: etcdadmin # username for etcd authentication
+    password: etcdadmin # password for etcd authentication
 
 metastore:
   type: etcd # Default value: etcd, Valid values: [etcd, tikv]

--- a/internal/kv/etcd/embed_etcd_config_test.go
+++ b/internal/kv/etcd/embed_etcd_config_test.go
@@ -34,6 +34,7 @@ func TestEtcdConfigLoad(te *testing.T) {
 	param := new(paramtable.ComponentParam)
 
 	te.Setenv("etcd.use.embed", "true")
+	te.Setenv("etcd.auth.enabled", "false") // embedded etcd does not support auth
 	te.Setenv("etcd.config.path", "../../../configs/advanced/etcd.yaml")
 	te.Setenv("etcd.data.dir", "etcd.test.data.dir")
 

--- a/internal/kv/etcd/embed_etcd_kv_test.go
+++ b/internal/kv/etcd/embed_etcd_kv_test.go
@@ -41,6 +41,7 @@ func TestEmbedEtcd(te *testing.T) {
 	te.Setenv(metricsinfo.DeployModeEnvKey, metricsinfo.StandaloneDeployMode)
 	param := new(paramtable.ComponentParam)
 	te.Setenv("etcd.use.embed", "true")
+	te.Setenv("etcd.auth.enabled", "false") // embedded etcd does not support auth
 	te.Setenv("etcd.config.path", "../../../configs/advanced/etcd.yaml")
 
 	dir := te.TempDir()
@@ -847,6 +848,7 @@ func (s *EmbedEtcdKVSuite) SetupSuite() {
 	te.Setenv(metricsinfo.DeployModeEnvKey, metricsinfo.StandaloneDeployMode)
 	param := new(paramtable.ComponentParam)
 	te.Setenv("etcd.use.embed", "true")
+	te.Setenv("etcd.auth.enabled", "false") // embedded etcd does not support auth
 	te.Setenv("etcd.config.path", "../../../configs/advanced/etcd.yaml")
 
 	dir := te.TempDir()

--- a/pkg/util/paramtable/service_param.go
+++ b/pkg/util/paramtable/service_param.go
@@ -310,7 +310,7 @@ We recommend using version 1.2 and above.`,
 
 	p.EtcdEnableAuth = ParamItem{
 		Key:          "etcd.auth.enabled",
-		DefaultValue: "false",
+		DefaultValue: "true",
 		Version:      "2.3.7",
 		Doc:          "Whether to enable authentication",
 		Export:       true,
@@ -322,20 +322,30 @@ We recommend using version 1.2 and above.`,
 	}
 
 	p.EtcdAuthUserName = ParamItem{
-		Key:     "etcd.auth.userName",
-		Version: "2.3.7",
-		Doc:     "username for etcd authentication",
-		Export:  true,
+		Key:          "etcd.auth.userName",
+		Version:      "2.3.7",
+		DefaultValue: "etcdadmin",
+		Doc:          "username for etcd authentication",
+		Export:       true,
 	}
 	p.EtcdAuthUserName.Init(base.mgr)
 
 	p.EtcdAuthPassword = ParamItem{
-		Key:     "etcd.auth.password",
-		Version: "2.3.7",
-		Doc:     "password for etcd authentication",
-		Export:  true,
+		Key:          "etcd.auth.password",
+		Version:      "2.3.7",
+		DefaultValue: "etcdadmin",
+		Doc:          "password for etcd authentication",
+		Export:       true,
 	}
 	p.EtcdAuthPassword.Init(base.mgr)
+
+	if p.EtcdEnableAuth.GetAsBool() && !p.UseEmbedEtcd.GetAsBool() {
+		if p.EtcdAuthUserName.GetValue() == "" || p.EtcdAuthPassword.GetValue() == "" {
+			panic("etcd auth is enabled but userName or password is empty. " +
+				"Set etcd.auth.userName and etcd.auth.password in milvus.yaml, " +
+				"or via environment variables etcd_auth_userName and etcd_auth_password")
+		}
+	}
 }
 
 func (p *EtcdConfig) GetAll() map[string]string {

--- a/pkg/util/paramtable/service_param.go
+++ b/pkg/util/paramtable/service_param.go
@@ -318,7 +318,8 @@ We recommend using version 1.2 and above.`,
 	p.EtcdEnableAuth.Init(base.mgr)
 
 	if p.UseEmbedEtcd.GetAsBool() && p.EtcdEnableAuth.GetAsBool() {
-		panic("embedded etcd can not enable auth")
+		log.Warn("embedded etcd does not support auth, disabling etcd auth automatically")
+		p.EtcdEnableAuth.SwapTempValue("false")
 	}
 
 	p.EtcdAuthUserName = ParamItem{

--- a/pkg/util/paramtable/service_param_test.go
+++ b/pkg/util/paramtable/service_param_test.go
@@ -68,6 +68,11 @@ func TestServiceParam(t *testing.T) {
 		assert.NotEmpty(t, Params.EtcdTLSMinVersion.GetValue())
 		t.Logf("tls minVersion = %s", Params.EtcdTLSMinVersion.GetValue())
 
+		// test etcd auth default values
+		assert.Equal(t, "etcdadmin", Params.EtcdAuthUserName.GetValue())
+		assert.Equal(t, "etcdadmin", Params.EtcdAuthPassword.GetValue())
+		assert.True(t, Params.EtcdEnableAuth.GetAsBool())
+
 		// test UseEmbedEtcd
 		t.Setenv("etcd.use.embed", "true")
 		t.Setenv(metricsinfo.DeployModeEnvKey, metricsinfo.ClusterDeployMode)
@@ -75,8 +80,25 @@ func TestServiceParam(t *testing.T) {
 			NewBaseTable()
 		})
 
-		t.Setenv(metricsinfo.DeployModeEnvKey, metricsinfo.StandaloneDeployMode)
+		// test etcd auth enabled with empty credentials should panic
 		t.Setenv("etcd.use.embed", "false")
+		t.Setenv("etcd.auth.enabled", "true")
+		t.Setenv("etcd.auth.userName", "")
+		t.Setenv("etcd.auth.password", "")
+		assert.Panics(t, func() {
+			NewBaseTable()
+		})
+
+		// test etcd auth enabled with valid credentials should not panic
+		t.Setenv("etcd.auth.enabled", "true")
+		t.Setenv("etcd.auth.userName", "milvus")
+		t.Setenv("etcd.auth.password", "milvuspass")
+		assert.NotPanics(t, func() {
+			NewBaseTable()
+		})
+
+		t.Setenv("etcd.auth.enabled", "false")
+		t.Setenv(metricsinfo.DeployModeEnvKey, metricsinfo.StandaloneDeployMode)
 		SParams.init(bt)
 	})
 

--- a/pkg/util/paramtable/service_param_test.go
+++ b/pkg/util/paramtable/service_param_test.go
@@ -73,10 +73,11 @@ func TestServiceParam(t *testing.T) {
 		assert.Equal(t, "etcdadmin", Params.EtcdAuthPassword.GetValue())
 		assert.True(t, Params.EtcdEnableAuth.GetAsBool())
 
-		// test UseEmbedEtcd
+		// test UseEmbedEtcd with auth enabled — should auto-disable auth, not panic
 		t.Setenv("etcd.use.embed", "true")
-		t.Setenv(metricsinfo.DeployModeEnvKey, metricsinfo.ClusterDeployMode)
-		assert.Panics(t, func() {
+		t.Setenv("etcd.auth.enabled", "true")
+		t.Setenv(metricsinfo.DeployModeEnvKey, metricsinfo.StandaloneDeployMode)
+		assert.NotPanics(t, func() {
 			NewBaseTable()
 		})
 


### PR DESCRIPTION
 related: #48587

Provide default userName/password (etcdadmin) for etcd authentication and add fail-fast validation that panics with a clear message when etcd.auth.enabled=true but credentials are empty, instead of failing with an opaque etcd connection error.