### PR TITLE
fix: replace endPositions with remainingCounts in MergeSort to prevent index out of range panic

### DIFF
--- a/internal/storage/sort.go
+++ b/internal/storage/sort.go
@@ -339,7 +339,7 @@ func MergeSort(batchSize uint64, schema *schemapb.CollectionSchema, rr []RecordR
 			case *array.Int64:
 				for j := 1; j < r.Len(); j++ {
 					if col.Value(j) < col.Value(j-1) {
-						log.Warn("MergeSort: batch not sorted by sort key, output order may be incorrect",
+						log.Error("MergeSort: batch not sorted by sort key, output order may be incorrect",
 							zap.Int("ri", ri), zap.Int("row", j),
 							zap.Int64("prev", col.Value(j-1)), zap.Int64("curr", col.Value(j)),
 							zap.Int("batchLen", r.Len()))
@@ -349,7 +349,7 @@ func MergeSort(batchSize uint64, schema *schemapb.CollectionSchema, rr []RecordR
 			case *array.String:
 				for j := 1; j < r.Len(); j++ {
 					if col.Value(j) < col.Value(j-1) {
-						log.Warn("MergeSort: batch not sorted by sort key, output order may be incorrect",
+						log.Error("MergeSort: batch not sorted by sort key, output order may be incorrect",
 							zap.Int("ri", ri), zap.Int("row", j),
 							zap.String("prev", col.Value(j-1)), zap.String("curr", col.Value(j)),
 							zap.Int("batchLen", r.Len()))

--- a/internal/storage/sort.go
+++ b/internal/storage/sort.go
@@ -23,8 +23,10 @@ import (
 	"time"
 
 	"github.com/apache/arrow/go/v17/arrow/array"
+	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 )
 
@@ -301,12 +303,11 @@ func MergeSort(batchSize uint64, schema *schemapb.CollectionSchema, rr []RecordR
 		return x.i < y.i
 	})
 
-	endPositions := make([]int, len(recs))
+	remainingCounts := make([]int, len(recs))
 	var enqueueAll func(ri int) error
 	enqueueAll = func(ri int) error {
 		r := recs[ri]
-		hasValid := false
-		endPosition := 0
+		count := 0
 		for j := 0; j < r.Len(); j++ {
 			if predicate(r, ri, j) {
 				pq.Enqueue(&index{
@@ -314,11 +315,10 @@ func MergeSort(batchSize uint64, schema *schemapb.CollectionSchema, rr []RecordR
 					i:  j,
 				})
 				numRows++
-				hasValid = true
-				endPosition = j
+				count++
 			}
 		}
-		if !hasValid {
+		if count == 0 {
 			err := advanceRecord(ri)
 			if err == io.EOF {
 				return nil
@@ -328,7 +328,37 @@ func MergeSort(batchSize uint64, schema *schemapb.CollectionSchema, rr []RecordR
 			}
 			return enqueueAll(ri)
 		}
-		endPositions[ri] = endPosition
+		remainingCounts[ri] = count
+
+		// Warn if the batch is not sorted by the first sort field.
+		// MergeSort assumes each batch is pre-sorted; unsorted batches produce
+		// incorrect output order (though the remainingCounts fix prevents panics).
+		if len(sortedByFieldIDs) > 0 {
+			fid := sortedByFieldIDs[0]
+			switch col := r.Column(fid).(type) {
+			case *array.Int64:
+				for j := 1; j < r.Len(); j++ {
+					if col.Value(j) < col.Value(j-1) {
+						log.Warn("MergeSort: batch not sorted by sort key, output order may be incorrect",
+							zap.Int("ri", ri), zap.Int("row", j),
+							zap.Int64("prev", col.Value(j-1)), zap.Int64("curr", col.Value(j)),
+							zap.Int("batchLen", r.Len()))
+						break
+					}
+				}
+			case *array.String:
+				for j := 1; j < r.Len(); j++ {
+					if col.Value(j) < col.Value(j-1) {
+						log.Warn("MergeSort: batch not sorted by sort key, output order may be incorrect",
+							zap.Int("ri", ri), zap.Int("row", j),
+							zap.String("prev", col.Value(j-1)), zap.String("curr", col.Value(j)),
+							zap.Int("batchLen", r.Len()))
+						break
+					}
+				}
+			}
+		}
+
 		return nil
 	}
 
@@ -362,8 +392,9 @@ func MergeSort(batchSize uint64, schema *schemapb.CollectionSchema, rr []RecordR
 			}
 		}
 
-		// If the popped idx reaches the last valid data of the segment, invalidate the cache and advance to the next record
-		if idx.i == endPositions[idx.ri] {
+		// When all enqueued rows from the current batch have been dequeued, advance to the next record batch
+		remainingCounts[idx.ri]--
+		if remainingCounts[idx.ri] == 0 {
 			err := advanceRecord(idx.ri)
 			if err == io.EOF {
 				continue

--- a/internal/storage/sort_test.go
+++ b/internal/storage/sort_test.go
@@ -18,12 +18,17 @@ package storage
 
 import (
 	"fmt"
+	"io"
+	"sort"
 	"testing"
 
+	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/memory"
 	"github.com/bytedance/mockey"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 )
 
@@ -265,4 +270,155 @@ func TestSortByMoreThanOneField(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, batchSize*2, gotNumRows)
 	assert.NoError(t, rw.Close())
+}
+
+// buildInt64Array creates an arrow Int64 array from a slice.
+func buildInt64Array(values []int64) *array.Int64 {
+	builder := array.NewInt64Builder(memory.DefaultAllocator)
+	defer builder.Release()
+	builder.AppendValues(values, nil)
+	return builder.NewInt64Array()
+}
+
+// makeRecord creates a Record with two Int64 fields (fieldA=100, fieldB=101).
+func makeRecord(fieldA, fieldB []int64) Record {
+	arrA := buildInt64Array(fieldA)
+	arrB := buildInt64Array(fieldB)
+	nRows := int64(len(fieldA))
+	fields := []arrow.Field{
+		{Name: "fieldA", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "fieldB", Type: arrow.PrimitiveTypes.Int64},
+	}
+	rec := array.NewRecord(arrow.NewSchema(fields, nil), []arrow.Array{arrA, arrB}, nRows)
+	return NewSimpleArrowRecord(rec, map[FieldID]int{100: 0, 101: 1})
+}
+
+// sliceRecordReader is a RecordReader that returns pre-built records in order.
+type sliceRecordReader struct {
+	records []Record
+	pos     int
+}
+
+func (r *sliceRecordReader) Next() (Record, error) {
+	if r.pos >= len(r.records) {
+		return nil, io.EOF
+	}
+	rec := r.records[r.pos]
+	r.pos++
+	return rec, nil
+}
+
+func (r *sliceRecordReader) Close() error { return nil }
+
+// TestMergeSortBatchNotSortedBySortKey_NoPanic verifies that MergeSort does
+// not panic when the last row of a batch (by index) is dequeued before other
+// rows from the same batch. This is the root cause of issue #48322: the old
+// endPositions mechanism assumed the row at the highest valid index would be
+// the last dequeued; when sorting by a different key than the data order, this
+// assumption is violated, causing premature advanceRecord and stale PQ entries
+// that access a replaced (shorter) batch → out-of-range panic.
+//
+// This test constructs the exact triggering scenario:
+//   - Batch 1 has 5 rows with fieldB=[50,10,40,20,1]. The last row (index 4)
+//     has the SMALLEST sort key, so it's dequeued FIRST.
+//   - Batch 2 has only 2 rows, shorter than batch 1.
+//   - With the old endPositions code, dequeuing index 4 triggers advanceRecord,
+//     replacing recs[0] with the 2-row batch. Stale entries at index 3 then
+//     access batch 2 at index 3 → panic: index out of range [3] with length 2.
+func TestMergeSortBatchNotSortedBySortKey_NoPanic(t *testing.T) {
+	const fieldA FieldID = 100
+	const fieldB FieldID = 101
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: fieldA, Name: "fieldA", DataType: schemapb.DataType_Int64},
+			{FieldID: fieldB, Name: "fieldB", DataType: schemapb.DataType_Int64},
+		},
+	}
+
+	// Reader 0: batch 1 has the last row (index 4) with the smallest fieldB.
+	// Batch 2 is shorter (2 rows) — stale index 3 from batch 1 would be OOB.
+	reader0 := &sliceRecordReader{records: []Record{
+		makeRecord([]int64{1, 2, 3, 4, 5}, []int64{50, 10, 40, 20, 1}),
+		makeRecord([]int64{6, 7}, []int64{60, 70}),
+	}}
+
+	// Reader 1: interleaves with reader 0 to exercise cross-reader comparisons.
+	reader1 := &sliceRecordReader{records: []Record{
+		makeRecord([]int64{10, 11, 12}, []int64{5, 25, 55}),
+	}}
+
+	var outputRows []int64
+	rw := &MockRecordWriter{
+		writefn: func(r Record) error {
+			col := r.Column(fieldB).(*array.Int64)
+			for i := 0; i < col.Len(); i++ {
+				outputRows = append(outputRows, col.Value(i))
+			}
+			return nil
+		},
+		closefn: func() error { return nil },
+	}
+
+	numRows, err := MergeSort(64*1024*1024, schema, []RecordReader{reader0, reader1}, rw, func(r Record, ri, i int) bool {
+		return true
+	}, []int64{fieldB})
+
+	assert.NoError(t, err)
+	assert.Equal(t, 10, numRows) // 5 + 2 + 3 = 10 total rows
+
+	// Verify all values are present (no data loss). Sort order may not be
+	// globally correct since the input batches aren't sorted by the sort key,
+	// but no rows should be missing or duplicated.
+	sort.Slice(outputRows, func(i, j int) bool { return outputRows[i] < outputRows[j] })
+	expected := []int64{1, 5, 10, 20, 25, 40, 50, 55, 60, 70}
+	assert.Equal(t, expected, outputRows)
+}
+
+// TestMergeSortBatchNotSortedWithPredicate verifies the fix works when some
+// rows are filtered out by the predicate, ensuring remainingCounts correctly
+// tracks only valid (non-filtered) rows.
+func TestMergeSortBatchNotSortedWithPredicate(t *testing.T) {
+	const fieldA FieldID = 100
+	const fieldB FieldID = 101
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: fieldA, Name: "fieldA", DataType: schemapb.DataType_Int64},
+			{FieldID: fieldB, Name: "fieldB", DataType: schemapb.DataType_Int64},
+		},
+	}
+
+	reader0 := &sliceRecordReader{records: []Record{
+		makeRecord([]int64{1, 2, 3, 4, 5}, []int64{50, 10, 40, 20, 1}),
+		makeRecord([]int64{6, 7}, []int64{60, 70}),
+	}}
+
+	reader1 := &sliceRecordReader{records: []Record{
+		makeRecord([]int64{10, 11, 12}, []int64{5, 25, 55}),
+	}}
+
+	var outputRows []int64
+	rw := &MockRecordWriter{
+		writefn: func(r Record) error {
+			col := r.Column(fieldB).(*array.Int64)
+			for i := 0; i < col.Len(); i++ {
+				outputRows = append(outputRows, col.Value(i))
+			}
+			return nil
+		},
+		closefn: func() error { return nil },
+	}
+
+	// Predicate: exclude fieldB >= 50
+	numRows, err := MergeSort(64*1024*1024, schema, []RecordReader{reader0, reader1}, rw, func(r Record, ri, i int) bool {
+		val := r.Column(fieldB).(*array.Int64).Value(i)
+		return val < 50
+	}, []int64{fieldB})
+
+	assert.NoError(t, err)
+	// Filtered out: 50, 55, 60, 70. Remaining: 1,10,40,20 + 5,25 = 6
+	assert.Equal(t, 6, numRows)
+
+	sort.Slice(outputRows, func(i, j int) bool { return outputRows[i] < outputRows[j] })
+	expected := []int64{1, 5, 10, 20, 25, 40}
+	assert.Equal(t, expected, outputRows)
 }

--- a/internal/storage/sort_test.go
+++ b/internal/storage/sort_test.go
@@ -320,7 +320,7 @@ func makeStringRecord(fieldA []int64, fieldB []string) Record {
 type errorRecordReader struct{}
 
 func (r *errorRecordReader) Next() (Record, error) { return nil, fmt.Errorf("read error") }
-func (r *errorRecordReader) Close() error           { return nil }
+func (r *errorRecordReader) Close() error          { return nil }
 
 // sliceRecordReader is a RecordReader that returns pre-built records in order.
 type sliceRecordReader struct {

--- a/internal/storage/sort_test.go
+++ b/internal/storage/sort_test.go
@@ -280,6 +280,16 @@ func buildInt64Array(values []int64) *array.Int64 {
 	return builder.NewInt64Array()
 }
 
+// buildStringArray creates an arrow String array from a slice.
+func buildStringArray(values []string) *array.String {
+	builder := array.NewStringBuilder(memory.DefaultAllocator)
+	defer builder.Release()
+	for _, v := range values {
+		builder.Append(v)
+	}
+	return builder.NewStringArray()
+}
+
 // makeRecord creates a Record with two Int64 fields (fieldA=100, fieldB=101).
 func makeRecord(fieldA, fieldB []int64) Record {
 	arrA := buildInt64Array(fieldA)
@@ -292,6 +302,25 @@ func makeRecord(fieldA, fieldB []int64) Record {
 	rec := array.NewRecord(arrow.NewSchema(fields, nil), []arrow.Array{arrA, arrB}, nRows)
 	return NewSimpleArrowRecord(rec, map[FieldID]int{100: 0, 101: 1})
 }
+
+// makeStringRecord creates a Record with an Int64 field (100) and a String field (101).
+func makeStringRecord(fieldA []int64, fieldB []string) Record {
+	arrA := buildInt64Array(fieldA)
+	arrB := buildStringArray(fieldB)
+	nRows := int64(len(fieldA))
+	fields := []arrow.Field{
+		{Name: "fieldA", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "fieldB", Type: &arrow.StringType{}},
+	}
+	rec := array.NewRecord(arrow.NewSchema(fields, nil), []arrow.Array{arrA, arrB}, nRows)
+	return NewSimpleArrowRecord(rec, map[FieldID]int{100: 0, 101: 1})
+}
+
+// errorRecordReader is a RecordReader that always returns an error.
+type errorRecordReader struct{}
+
+func (r *errorRecordReader) Next() (Record, error) { return nil, fmt.Errorf("read error") }
+func (r *errorRecordReader) Close() error           { return nil }
 
 // sliceRecordReader is a RecordReader that returns pre-built records in order.
 type sliceRecordReader struct {
@@ -421,4 +450,320 @@ func TestMergeSortBatchNotSortedWithPredicate(t *testing.T) {
 	sort.Slice(outputRows, func(i, j int) bool { return outputRows[i] < outputRows[j] })
 	expected := []int64{1, 5, 10, 20, 25, 40}
 	assert.Equal(t, expected, outputRows)
+}
+
+func TestMergeSortEmptyReaders(t *testing.T) {
+	rw := &MockRecordWriter{
+		writefn: func(r Record) error { return nil },
+		closefn: func() error { return nil },
+	}
+	numRows, err := MergeSort(64*1024*1024, generateTestSchema(), []RecordReader{}, rw, func(r Record, ri, i int) bool {
+		return true
+	}, []int64{common.RowIDField})
+	assert.NoError(t, err)
+	assert.Equal(t, 0, numRows)
+}
+
+func TestMergeSortReaderInitError(t *testing.T) {
+	rw := &MockRecordWriter{
+		writefn: func(r Record) error { return nil },
+		closefn: func() error { return nil },
+	}
+	numRows, err := MergeSort(64*1024*1024, generateTestSchema(), []RecordReader{&errorRecordReader{}}, rw, func(r Record, ri, i int) bool {
+		return true
+	}, []int64{common.RowIDField})
+	assert.Error(t, err)
+	assert.Equal(t, 0, numRows)
+}
+
+func TestMergeSortOneReaderEmpty(t *testing.T) {
+	const fieldA FieldID = 100
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: fieldA, Name: "fieldA", DataType: schemapb.DataType_Int64},
+		},
+	}
+
+	emptyReader := &sliceRecordReader{records: nil}
+	dataReader := &sliceRecordReader{records: []Record{
+		func() Record {
+			arr := buildInt64Array([]int64{1, 2, 3})
+			rec := array.NewRecord(
+				arrow.NewSchema([]arrow.Field{{Name: "fieldA", Type: arrow.PrimitiveTypes.Int64}}, nil),
+				[]arrow.Array{arr}, 3)
+			return NewSimpleArrowRecord(rec, map[FieldID]int{fieldA: 0})
+		}(),
+	}}
+
+	var outputRows []int64
+	rw := &MockRecordWriter{
+		writefn: func(r Record) error {
+			col := r.Column(fieldA).(*array.Int64)
+			for i := 0; i < col.Len(); i++ {
+				outputRows = append(outputRows, col.Value(i))
+			}
+			return nil
+		},
+		closefn: func() error { return nil },
+	}
+
+	numRows, err := MergeSort(64*1024*1024, schema, []RecordReader{dataReader, emptyReader}, rw, func(r Record, ri, i int) bool {
+		return true
+	}, []int64{fieldA})
+	assert.NoError(t, err)
+	assert.Equal(t, 3, numRows)
+	assert.Equal(t, []int64{1, 2, 3}, outputRows)
+}
+
+func TestMergeSortAllRowsFiltered(t *testing.T) {
+	const fieldA FieldID = 100
+	const fieldB FieldID = 101
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: fieldA, Name: "fieldA", DataType: schemapb.DataType_Int64},
+			{FieldID: fieldB, Name: "fieldB", DataType: schemapb.DataType_Int64},
+		},
+	}
+
+	// Batch 1: all rows filtered. Batch 2: has valid rows.
+	// This exercises the recursive enqueueAll path (count == 0 → advance → retry).
+	reader := &sliceRecordReader{records: []Record{
+		makeRecord([]int64{1, 2, 3}, []int64{100, 200, 300}),
+		makeRecord([]int64{4, 5}, []int64{10, 20}),
+	}}
+
+	var outputRows []int64
+	rw := &MockRecordWriter{
+		writefn: func(r Record) error {
+			col := r.Column(fieldB).(*array.Int64)
+			for i := 0; i < col.Len(); i++ {
+				outputRows = append(outputRows, col.Value(i))
+			}
+			return nil
+		},
+		closefn: func() error { return nil },
+	}
+
+	// Filter: only fieldB < 50
+	numRows, err := MergeSort(64*1024*1024, schema, []RecordReader{reader}, rw, func(r Record, ri, i int) bool {
+		return r.Column(fieldB).(*array.Int64).Value(i) < 50
+	}, []int64{fieldB})
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, numRows)
+	assert.Equal(t, []int64{10, 20}, outputRows)
+}
+
+func TestMergeSortStringKey(t *testing.T) {
+	const fieldA FieldID = 100
+	const fieldB FieldID = 101
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: fieldA, Name: "fieldA", DataType: schemapb.DataType_Int64},
+			{FieldID: fieldB, Name: "fieldB", DataType: schemapb.DataType_VarChar},
+		},
+	}
+
+	reader0 := &sliceRecordReader{records: []Record{
+		makeStringRecord([]int64{1, 2, 3}, []string{"apple", "cherry", "grape"}),
+	}}
+	reader1 := &sliceRecordReader{records: []Record{
+		makeStringRecord([]int64{4, 5}, []string{"banana", "fig"}),
+	}}
+
+	var outputRows []string
+	rw := &MockRecordWriter{
+		writefn: func(r Record) error {
+			col := r.Column(fieldB).(*array.String)
+			for i := 0; i < col.Len(); i++ {
+				outputRows = append(outputRows, col.Value(i))
+			}
+			return nil
+		},
+		closefn: func() error { return nil },
+	}
+
+	numRows, err := MergeSort(64*1024*1024, schema, []RecordReader{reader0, reader1}, rw, func(r Record, ri, i int) bool {
+		return true
+	}, []int64{fieldB})
+
+	assert.NoError(t, err)
+	assert.Equal(t, 5, numRows)
+	assert.Equal(t, []string{"apple", "banana", "cherry", "fig", "grape"}, outputRows)
+}
+
+func TestMergeSortStringKeyUnsorted(t *testing.T) {
+	const fieldA FieldID = 100
+	const fieldB FieldID = 101
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: fieldA, Name: "fieldA", DataType: schemapb.DataType_Int64},
+			{FieldID: fieldB, Name: "fieldB", DataType: schemapb.DataType_VarChar},
+		},
+	}
+
+	// String data NOT sorted — should trigger error log, but no panic.
+	reader := &sliceRecordReader{records: []Record{
+		makeStringRecord([]int64{1, 2, 3}, []string{"cherry", "apple", "banana"}),
+	}}
+
+	var outputRows []string
+	rw := &MockRecordWriter{
+		writefn: func(r Record) error {
+			col := r.Column(fieldB).(*array.String)
+			for i := 0; i < col.Len(); i++ {
+				outputRows = append(outputRows, col.Value(i))
+			}
+			return nil
+		},
+		closefn: func() error { return nil },
+	}
+
+	numRows, err := MergeSort(64*1024*1024, schema, []RecordReader{reader}, rw, func(r Record, ri, i int) bool {
+		return true
+	}, []int64{fieldB})
+
+	assert.NoError(t, err)
+	assert.Equal(t, 3, numRows)
+	sort.Strings(outputRows)
+	assert.Equal(t, []string{"apple", "banana", "cherry"}, outputRows)
+}
+
+func TestMergeSortWriteError(t *testing.T) {
+	const fieldA FieldID = 100
+	const fieldB FieldID = 101
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: fieldA, Name: "fieldA", DataType: schemapb.DataType_Int64},
+			{FieldID: fieldB, Name: "fieldB", DataType: schemapb.DataType_Int64},
+		},
+	}
+
+	reader := &sliceRecordReader{records: []Record{
+		makeRecord([]int64{1, 2, 3}, []int64{10, 20, 30}),
+	}}
+
+	// Small batchSize to trigger mid-loop write error
+	errWriter := &MockRecordWriter{
+		writefn: func(r Record) error { return fmt.Errorf("write error") },
+		closefn: func() error { return nil },
+	}
+
+	_, err := MergeSort(1, schema, []RecordReader{reader}, errWriter, func(r Record, ri, i int) bool {
+		return true
+	}, []int64{fieldB})
+	assert.Error(t, err)
+}
+
+func TestMergeSortFinalWriteError(t *testing.T) {
+	const fieldA FieldID = 100
+	const fieldB FieldID = 101
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: fieldA, Name: "fieldA", DataType: schemapb.DataType_Int64},
+			{FieldID: fieldB, Name: "fieldB", DataType: schemapb.DataType_Int64},
+		},
+	}
+
+	reader := &sliceRecordReader{records: []Record{
+		makeRecord([]int64{1, 2}, []int64{10, 20}),
+	}}
+
+	// Large batchSize — all data fits in one batch, error on final write
+	errWriter := &MockRecordWriter{
+		writefn: func(r Record) error { return fmt.Errorf("write error") },
+		closefn: func() error { return nil },
+	}
+
+	_, err := MergeSort(64*1024*1024, schema, []RecordReader{reader}, errWriter, func(r Record, ri, i int) bool {
+		return true
+	}, []int64{fieldB})
+	assert.Error(t, err)
+}
+
+func TestMergeSortAdvanceRecordErrorDuringDequeue(t *testing.T) {
+	const fieldA FieldID = 100
+	const fieldB FieldID = 101
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: fieldA, Name: "fieldA", DataType: schemapb.DataType_Int64},
+			{FieldID: fieldB, Name: "fieldB", DataType: schemapb.DataType_Int64},
+		},
+	}
+
+	// Reader returns one valid batch, then an error (not EOF) on the next Next() call.
+	reader := &sliceRecordReader{records: []Record{
+		makeRecord([]int64{1}, []int64{10}),
+	}}
+	// Override Next to return error after first record
+	wrappedReader := &errorAfterNReader{inner: reader, errorAfter: 1}
+
+	rw := &MockRecordWriter{
+		writefn: func(r Record) error { return nil },
+		closefn: func() error { return nil },
+	}
+
+	_, err := MergeSort(64*1024*1024, schema, []RecordReader{wrappedReader}, rw, func(r Record, ri, i int) bool {
+		return true
+	}, []int64{fieldB})
+	assert.Error(t, err)
+}
+
+// errorAfterNReader wraps a RecordReader and returns an error after N successful reads.
+type errorAfterNReader struct {
+	inner      RecordReader
+	errorAfter int
+	count      int
+}
+
+func (r *errorAfterNReader) Next() (Record, error) {
+	if r.count >= r.errorAfter {
+		return nil, fmt.Errorf("simulated read error")
+	}
+	rec, err := r.inner.Next()
+	if err == nil {
+		r.count++
+	}
+	return rec, err
+}
+
+func (r *errorAfterNReader) Close() error { return r.inner.Close() }
+
+func TestMergeSortSmallBatchSize(t *testing.T) {
+	const fieldA FieldID = 100
+	const fieldB FieldID = 101
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: fieldA, Name: "fieldA", DataType: schemapb.DataType_Int64},
+			{FieldID: fieldB, Name: "fieldB", DataType: schemapb.DataType_Int64},
+		},
+	}
+
+	reader0 := &sliceRecordReader{records: []Record{
+		makeRecord([]int64{1, 3, 5}, []int64{10, 30, 50}),
+	}}
+	reader1 := &sliceRecordReader{records: []Record{
+		makeRecord([]int64{2, 4}, []int64{20, 40}),
+	}}
+
+	var outputRows []int64
+	rw := &MockRecordWriter{
+		writefn: func(r Record) error {
+			col := r.Column(fieldB).(*array.Int64)
+			for i := 0; i < col.Len(); i++ {
+				outputRows = append(outputRows, col.Value(i))
+			}
+			return nil
+		},
+		closefn: func() error { return nil },
+	}
+
+	// batchSize=1 forces a write after every row
+	numRows, err := MergeSort(1, schema, []RecordReader{reader0, reader1}, rw, func(r Record, ri, i int) bool {
+		return true
+	}, []int64{fieldB})
+
+	assert.NoError(t, err)
+	assert.Equal(t, 5, numRows)
+	assert.Equal(t, []int64{10, 20, 30, 40, 50}, outputRows)
 }


### PR DESCRIPTION
## Summary
- Replace `endPositions` with `remainingCounts` in `MergeSort` to fix index-out-of-range panic during mix compaction (#48322)
- The old `endPositions` mechanism assumed the last valid row by index would be the last dequeued from the priority queue, which breaks when the sort key doesn't match the batch data order (e.g., namespace compaction sorting by `[partitionKey, PK]` on PK-only-sorted batches)
- Add warning log when a batch is not sorted by the merge sort key, to help diagnose incorrect output order

issue: #48322

## Test plan
- [x] Existing `TestMergeSort` and `TestMergeSort/merge_sort_with_predicate` pass (no regression)
- [x] New `TestMergeSortBatchNotSortedBySortKey_NoPanic` — constructs exact panic scenario: batch with last index having smallest sort key + shorter next batch → old code panics, new code works
- [x] New `TestMergeSortBatchNotSortedWithPredicate` — same scenario with predicate filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>