### PR TITLE
enhance: bump milvus-storage to align 3.0

### DIFF
--- a/internal/core/thirdparty/milvus-storage/CMakeLists.txt
+++ b/internal/core/thirdparty/milvus-storage/CMakeLists.txt
@@ -14,7 +14,7 @@
 # Update milvus-storage_VERSION for the first occurrence
 milvus_add_pkg_config("milvus-storage")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( milvus-storage_VERSION b08080f)
+set( milvus-storage_VERSION 4351a0c)
 set( GIT_REPOSITORY  "https://github.com/milvus-io/milvus-storage.git")
 message(STATUS "milvus-storage repo: ${GIT_REPOSITORY}")
 message(STATUS "milvus-storage version: ${milvus-storage_VERSION}")


### PR DESCRIPTION
issue: #48623

bump b08080f([enhance: make CRC32C checksum configurable and extend to all supported S3 requests](https://github.com/milvus-io/milvus-storage/commit/b08080f15212df076ebfa518df2ded28fa8383c3)) -> 4351a0c([fix: resolve type mismatch in ExtractExternalFsProperties causing bad_variant_access crash](https://github.com/milvus-io/milvus-storage/pull/465))