### PR TITLE
test: fix minhash bulk import negative test assertion for updated error message

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_minhash.py
+++ b/tests/python_client/milvus_client/test_milvus_client_minhash.py
@@ -3794,8 +3794,8 @@ class TestMinHashBulkImport(TestMilvusClientV2Base):
 
         assert result["state"] == "Failed", \
             f"Import should have failed when providing function output field, but got: {result['state']}"
-        assert "output by function" in result["reason"], \
-            f"Error should mention 'output by function', got: {result['reason']}"
+        assert "not allowed to provide data for function output field" in result["reason"], \
+            f"Error should mention 'not allowed to provide data for function output field', got: {result['reason']}"
         log.info(f"Import correctly failed: {result['reason']}")
 
 class TestMilvusClientMinHashHybridSearch(TestMilvusClientV2Base):


### PR DESCRIPTION
## Summary
- Update `test_minhash_bulk_import_with_output_field_negative` assertion to match the updated server error message
- Server error changed from `"output by function"` to `"not allowed to provide data for function output field"`
- This test has been failing consistently across all 3 nightly configs (kafka, pulsar-mmap, woodpecker) since build 650

## Test plan
- [x] Ran `test_minhash_bulk_import_with_output_field_negative[PARQUET]` — PASSED
- [x] Ran `test_minhash_bulk_import_with_output_field_negative[JSON]` — PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)