### PR TITLE
fix: replace hard-coded -1 manifest version with named constants

### DIFF
--- a/internal/datacoord/segment_manager.go
+++ b/internal/datacoord/segment_manager.go
@@ -425,7 +425,7 @@ func (s *SegmentManager) openNewSegmentWithGivenSegmentID(ctx context.Context, r
 	if req.StorageVersion == storage.StorageV3 {
 		k := metautil.JoinIDPath(req.CollectionID, req.PartitionID, req.SegmentID)
 		basePath := path.Join(paramtable.Get().MinioCfg.RootPath.GetValue(), common.SegmentInsertLogPath, k)
-		manifestPath = packed.MarshalManifestPath(basePath, -1)
+		manifestPath = packed.MarshalManifestPath(basePath, packed.ManifestEarliest)
 	}
 
 	segmentInfo := &datapb.SegmentInfo{

--- a/internal/datacoord/segment_manager_test.go
+++ b/internal/datacoord/segment_manager_test.go
@@ -1126,7 +1126,7 @@ func TestAllocNewGrowingSegment_ManifestPath(t *testing.T) {
 		basePath, ver, unmarshalErr := packed.UnmarshalManifestPath(segment.ManifestPath)
 		assert.NoError(t, unmarshalErr)
 		assert.NotEmpty(t, basePath)
-		assert.Equal(t, int64(-1), ver)
+		assert.Equal(t, int64(packed.ManifestEarliest), ver)
 	})
 
 	t.Run("StorageV2 segment has no manifest path", func(t *testing.T) {

--- a/internal/datanode/importv2/util.go
+++ b/internal/datanode/importv2/util.go
@@ -81,8 +81,8 @@ func NewSyncTask(ctx context.Context,
 		if useLoonFFI {
 			k := metautil.JoinIDPath(collectionID, partitionID, segmentID)
 			basePath := path.Join(storageConfig.GetRootPath(), common.SegmentInsertLogPath, k)
-			// -1 for first write
-			segment.ManifestPath = packed.MarshalManifestPath(basePath, -1)
+			// ManifestEarliest for first write
+			segment.ManifestPath = packed.MarshalManifestPath(basePath, packed.ManifestEarliest)
 		}
 		metaCache.AddSegment(segment, func(info *datapb.SegmentInfo) pkoracle.PkStat {
 			bfs := pkoracle.NewBloomFilterSet()

--- a/internal/flushcommon/syncmgr/pack_writer_v3_test.go
+++ b/internal/flushcommon/syncmgr/pack_writer_v3_test.go
@@ -142,7 +142,7 @@ func (s *PackWriterV3Suite) TestPackWriterV3_Write() {
 
 	k := metautil.JoinIDPath(collectionID, partitionID, segmentID)
 	basePath := path.Join(common.SegmentInsertLogPath, k)
-	manifestPath := packed.MarshalManifestPath(basePath, -1)
+	manifestPath := packed.MarshalManifestPath(basePath, packed.ManifestEarliest)
 
 	seg := metacache.NewSegmentInfo(&datapb.SegmentInfo{
 		ManifestPath: manifestPath,
@@ -188,7 +188,7 @@ func (s *PackWriterV3Suite) TestWriteEmptyInsertData() {
 
 	k := metautil.JoinIDPath(collectionID, partitionID, segmentID)
 	basePath := path.Join(common.SegmentInsertLogPath, k)
-	manifestPath := packed.MarshalManifestPath(basePath, -1)
+	manifestPath := packed.MarshalManifestPath(basePath, packed.ManifestEarliest)
 
 	pack := new(SyncPack).WithCollectionID(collectionID).WithPartitionID(partitionID).WithSegmentID(segmentID).WithChannelName(channelName)
 	bw := NewBulkPackWriterV3(mc, s.schema, s.cm, s.logIDAlloc, packed.DefaultWriteBufferSize, 0, s.storageConfig, s.currentSplit, manifestPath)
@@ -212,7 +212,7 @@ func (s *PackWriterV3Suite) TestNoPkField() {
 
 	k := metautil.JoinIDPath(collectionID, partitionID, segmentID)
 	basePath := path.Join(common.SegmentInsertLogPath, k)
-	manifestPath := packed.MarshalManifestPath(basePath, -1)
+	manifestPath := packed.MarshalManifestPath(basePath, packed.ManifestEarliest)
 
 	channelName := fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", collectionID)
 	mc := metacache.NewMockMetaCache(s.T())
@@ -240,7 +240,7 @@ func (s *PackWriterV3Suite) TestWriteInsertDataError() {
 
 	k := metautil.JoinIDPath(collectionID, partitionID, segmentID)
 	basePath := path.Join(common.SegmentInsertLogPath, k)
-	manifestPath := packed.MarshalManifestPath(basePath, -1)
+	manifestPath := packed.MarshalManifestPath(basePath, packed.ManifestEarliest)
 
 	mc := metacache.NewMockMetaCache(s.T())
 	mc.EXPECT().GetSchema(mock.Anything).Return(s.schema).Maybe()
@@ -289,7 +289,7 @@ func (s *PackWriterV3Suite) TestWriteWithDeleteData() {
 
 	k := metautil.JoinIDPath(collectionID, partitionID, segmentID)
 	basePath := path.Join(common.SegmentInsertLogPath, k)
-	manifestPath := packed.MarshalManifestPath(basePath, -1)
+	manifestPath := packed.MarshalManifestPath(basePath, packed.ManifestEarliest)
 
 	seg := metacache.NewSegmentInfo(&datapb.SegmentInfo{
 		ManifestPath: manifestPath,
@@ -334,7 +334,7 @@ func (s *PackWriterV3Suite) TestV3InheritsV2Fields() {
 
 	k := metautil.JoinIDPath(collectionID, partitionID, segmentID)
 	basePath := path.Join(common.SegmentInsertLogPath, k)
-	manifestPath := packed.MarshalManifestPath(basePath, -1)
+	manifestPath := packed.MarshalManifestPath(basePath, packed.ManifestEarliest)
 
 	mc := metacache.NewMockMetaCache(s.T())
 
@@ -395,7 +395,7 @@ func (s *PackWriterV3Suite) TestMultiBatchStatsAccumulation() {
 
 	k := metautil.JoinIDPath(collectionID, partitionID, segmentID)
 	basePath := path.Join(common.SegmentInsertLogPath, k)
-	manifestPath := packed.MarshalManifestPath(basePath, -1)
+	manifestPath := packed.MarshalManifestPath(basePath, packed.ManifestEarliest)
 
 	seg := metacache.NewSegmentInfo(&datapb.SegmentInfo{
 		ManifestPath: manifestPath,
@@ -481,7 +481,7 @@ func (s *PackWriterV3Suite) TestMultiBatchBM25StatsAccumulation() {
 
 	k := metautil.JoinIDPath(collectionID, partitionID, segmentID)
 	basePath := path.Join(common.SegmentInsertLogPath, k)
-	manifestPath := packed.MarshalManifestPath(basePath, -1)
+	manifestPath := packed.MarshalManifestPath(basePath, packed.ManifestEarliest)
 
 	seg := metacache.NewSegmentInfo(&datapb.SegmentInfo{
 		ManifestPath: manifestPath,

--- a/internal/flushcommon/syncmgr/pack_writer_v3_test.go
+++ b/internal/flushcommon/syncmgr/pack_writer_v3_test.go
@@ -70,7 +70,8 @@ type PackWriterV3Suite struct {
 func (s *PackWriterV3Suite) SetupTest() {
 	s.ctx = context.Background()
 	s.logIDAlloc = allocator.NewLocalAllocator(1, math.MaxInt64)
-	s.rootPath = "/tmp"
+	s.rootPath = s.T().TempDir()
+	initcore.CleanArrowFileSystemSingleton()
 	initcore.InitLocalArrowFileSystem(s.rootPath)
 	paramtable.Get().Init(paramtable.NewBaseTable())
 	paramtable.Get().Save(paramtable.Get().MinioCfg.RootPath.Key, "/tmp")

--- a/internal/flushcommon/syncmgr/task_test.go
+++ b/internal/flushcommon/syncmgr/task_test.go
@@ -194,8 +194,8 @@ func (s *SyncTaskSuite) createSegment(storageVersion int64) *metacache.SegmentIn
 	if storageVersion == storage.StorageV3 {
 		k := fmt.Sprintf("%d/%d/%d", s.collectionID, s.partitionID, s.segmentID)
 		basePath := fmt.Sprintf("insert_log/%s", k)
-		// Use JSON format for manifest path: {"ver": -1, "base_path": "..."}
-		segInfo.ManifestPath = packed.MarshalManifestPath(basePath, -1)
+		// Use JSON format for manifest path: {"ver": 0, "base_path": "..."}
+		segInfo.ManifestPath = packed.MarshalManifestPath(basePath, packed.ManifestEarliest)
 	}
 
 	seg := metacache.NewSegmentInfo(segInfo, bfs, nil)

--- a/internal/flushcommon/writebuffer/write_buffer.go
+++ b/internal/flushcommon/writebuffer/write_buffer.go
@@ -533,8 +533,8 @@ func (wb *writeBufferBase) CreateNewGrowingSegment(partitionID int64, segmentID 
 			// set manifest path when creating segment
 			k := metautil.JoinIDPath(wb.collectionID, partitionID, segmentID)
 			basePath := path.Join(paramtable.Get().ServiceParam.MinioCfg.RootPath.GetValue(), common.SegmentInsertLogPath, k)
-			// -1 for first write
-			manifestPath = packed.MarshalManifestPath(basePath, -1)
+			// ManifestEarliest for first write
+			manifestPath = packed.MarshalManifestPath(basePath, packed.ManifestEarliest)
 		}
 		segmentInfo := &datapb.SegmentInfo{
 			ID:             segmentID,

--- a/internal/storage/binlog_record_writer.go
+++ b/internal/storage/binlog_record_writer.go
@@ -425,7 +425,7 @@ func (pw *PackedManifestRecordWriter) initWriters(r Record) error {
 		var err error
 		k := metautil.JoinIDPath(pw.collectionID, pw.partitionID, pw.segmentID)
 		basePath := path.Join(pw.storageConfig.GetRootPath(), common.SegmentInsertLogPath, k)
-		pw.writer, err = NewPackedRecordManifestWriter(basePath, -1, pw.schema, pw.bufferSize, pw.multiPartUploadSize, pw.columnGroups, pw.storageConfig, pw.storagePluginContext)
+		pw.writer, err = NewPackedRecordManifestWriter(basePath, packed.ManifestEarliest, pw.schema, pw.bufferSize, pw.multiPartUploadSize, pw.columnGroups, pw.storageConfig, pw.storagePluginContext)
 		if err != nil {
 			return merr.WrapErrServiceInternal(fmt.Sprintf("can not new packed record writer %s", err.Error()))
 		}

--- a/internal/storagev2/packed/constant.go
+++ b/internal/storagev2/packed/constant.go
@@ -25,4 +25,9 @@ const (
 	DefaultMultiPartUploadSize = 10 * 1024 * 1024 // 10MB
 	// Arrow will convert these field IDs to a metadata key named PARQUET:field_id on the appropriate field.
 	ArrowFieldIdMetadataKey = "PARQUET:field_id"
+
+	// ManifestLatest points to the latest available version in wanted base path
+	ManifestLatest int64 = -1
+	// ManifestEarliest points to the earliest version(empty), used by write new segment
+	ManifestEarliest int64 = 0
 )

--- a/internal/storagev2/packed/manifest_ffi.go
+++ b/internal/storagev2/packed/manifest_ffi.go
@@ -76,9 +76,9 @@ func CreateManifestForSegment(
 	cBasePath := C.CString(basePath)
 	defer C.free(unsafe.Pointer(cBasePath))
 
-	// Begin transaction (read_version=-1 for latest, retry_limit=10)
+	// Begin transaction (read_version=0 for earliest, retry_limit=10)
 	var transactionHandle C.LoonTransactionHandle
-	result := C.loon_transaction_begin(cBasePath, cProperties, C.int64_t(-1), C.int32_t(0) /* resolve_id */, getRetryLimit() /* retry_limit */, &transactionHandle)
+	result := C.loon_transaction_begin(cBasePath, cProperties, C.int64_t(0), C.LOON_TRANSACTION_RESOLVE_OVERWRITE /* resolve_id */, getRetryLimit() /* retry_limit */, &transactionHandle)
 	if err := HandleLoonFFIResult(result); err != nil {
 		return "", fmt.Errorf("loon_transaction_begin failed: %w", err)
 	}

--- a/internal/storagev2/packed/packed_writer_ffi.go
+++ b/internal/storagev2/packed/packed_writer_ffi.go
@@ -179,7 +179,7 @@ func (pw *FFIPackedWriter) Close() (string, error) {
 	defer C.free(unsafe.Pointer(cBasePath))
 	var transationHandle C.LoonTransactionHandle
 
-	result = C.loon_transaction_begin(cBasePath, pw.cProperties, C.int64_t(pw.baseVersion), C.int32_t(0) /* resolve_id */, getRetryLimit() /* retry_limit */, &transationHandle)
+	result = C.loon_transaction_begin(cBasePath, pw.cProperties, C.int64_t(pw.baseVersion), C.LOON_TRANSACTION_RESOLVE_OVERWRITE /* resolve_id */, getRetryLimit() /* retry_limit */, &transationHandle)
 	if err := HandleLoonFFIResult(result); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Replace all hard-coded `-1` literal used as manifest version with the named constant `packed.ManifestEarliest` (value `0`) for new segment creation, making the intent explicit and consistent across the codebase.

Key changes:
- Define `ManifestLatest` (-1) and `ManifestEarliest` (0) constants in `internal/storagev2/packed/constant.go`
- Update all production code (segment_manager, write_buffer, importv2/util, binlog_record_writer) to use `packed.ManifestEarliest`
- Update all test code (pack_writer_v3_test, task_test) to use `packed.ManifestEarliest` instead of raw `-1`
- Fix `CreateManifestForSegment` FFI call: use version `0` (earliest) instead of `-1` (latest) and use `LOON_TRANSACTION_RESOLVE_OVERWRITE` resolve strategy
- Fix `FFIPackedWriter.Close` to use `LOON_TRANSACTION_RESOLVE_OVERWRITE` resolve strategy

issue: #48543