### PR TITLE
enhance: optimize TermExpr IN with SIMD batch filter for numeric types

### DIFF
--- a/internal/core/src/common/SimdUtil.h
+++ b/internal/core/src/common/SimdUtil.h
@@ -15,6 +15,8 @@
 // limitations under the License.
 #pragma once
 
+#include <cstdint>
+#include <type_traits>
 #include <xsimd/xsimd.hpp>
 #include "common/BitUtil.h"
 
@@ -23,21 +25,18 @@ namespace milvus {
 // Generic fallback implementation for toBitMask when no architecture-specific
 // implementation is available
 template <typename T, typename A>
-int
+uint64_t
 genericToBitMask(xsimd::batch_bool<T, A> mask) {
     constexpr size_t size = xsimd::batch_bool<T, A>::size;
-    int result = 0;
-    // Convert batch_bool to integer batch and extract each element
-    // Using select to convert boolean mask to integer values
+    uint64_t result = 0;
     auto ones = xsimd::batch<T, A>(T(1));
     auto zeros = xsimd::batch<T, A>(T(0));
     auto int_batch = xsimd::select(mask, ones, zeros);
-    // Extract each element and set corresponding bit in result
     alignas(A::alignment()) T values[size];
     int_batch.store_aligned(values);
     for (size_t i = 0; i < size; ++i) {
         if (values[i] != T(0)) {
-            result |= (1 << i);
+            result |= (uint64_t(1) << i);
         }
     }
     return result;
@@ -46,29 +45,42 @@ genericToBitMask(xsimd::batch_bool<T, A> mask) {
 template <typename T, typename A, size_t kSizeT = sizeof(T)>
 struct BitMask;
 
+// ═══════════════════════════════════════════════════════════════════════════
+// sizeof(T) == 1  (int8_t / uint8_t)
+// AVX512BW: __mmask64 — already a bitmask, zero-cost extract.
+// AVX2:     _mm256_movemask_epi8 → 32 bits, 1 per byte lane.
+// NEON:     shift-and-add per 8-byte half.
+// ═══════════════════════════════════════════════════════════════════════════
 template <typename T, typename A>
 struct BitMask<T, A, 1> {
-    static constexpr int kAllSet =
+    static constexpr uint64_t kAllSet =
         milvus::bits::lowMask(xsimd::batch_bool<T, A>::size);
 
+#if XSIMD_WITH_AVX512BW
+    static uint64_t
+    toBitMask(xsimd::batch_bool<T, A> mask, const xsimd::avx512bw&) {
+        return static_cast<uint64_t>(mask.data);
+    }
+#endif
+
 #if XSIMD_WITH_AVX2
-    static int
+    static uint64_t
     toBitMask(xsimd::batch_bool<T, A> mask, const xsimd::avx2&) {
-        return _mm256_movemask_epi8(mask);
+        return static_cast<uint32_t>(_mm256_movemask_epi8(mask));
     }
 #endif
 
 #if XSIMD_WITH_SSE2
-    static int
+    static uint64_t
     toBitMask(xsimd::batch_bool<T, A> mask, const xsimd::sse2&) {
-        return _mm_movemask_epi8(mask);
+        return static_cast<uint16_t>(_mm_movemask_epi8(mask));
     }
 #endif
 
 #if XSIMD_WITH_NEON
-    static int
+    static uint64_t
     toBitMask(xsimd::batch_bool<T, A> mask, const xsimd::neon&) {
-        alignas(A::alignment()) static const int8_t kShift[] = {
+        alignas(16) static const int8_t kShift[] = {
             -7, -6, -5, -4, -3, -2, -1, 0, -7, -6, -5, -4, -3, -2, -1, 0};
         int8x16_t vshift = vld1q_s8(kShift);
         uint8x16_t vmask = vshlq_u8(vandq_u8(mask, vdupq_n_u8(0x80)), vshift);
@@ -77,96 +89,188 @@ struct BitMask<T, A, 1> {
     }
 #endif
 
-    static int
+    static uint64_t
     toBitMask(xsimd::batch_bool<T, A> mask, const xsimd::generic&) {
         return genericToBitMask(mask);
     }
 };
 
+// ═══════════════════════════════════════════════════════════════════════════
+// sizeof(T) == 2  (int16_t)
+// AVX512BW: __mmask32 — direct extract.
+// AVX2:     movemask_epi8 → extract every 2nd bit.
+// NEON:     narrow 16→8, then shift-and-add.
+// ═══════════════════════════════════════════════════════════════════════════
 template <typename T, typename A>
 struct BitMask<T, A, 2> {
-    static constexpr int kAllSet =
+    static constexpr uint64_t kAllSet =
         milvus::bits::lowMask(xsimd::batch_bool<T, A>::size);
 
+#if XSIMD_WITH_AVX512BW
+    static uint64_t
+    toBitMask(xsimd::batch_bool<T, A> mask, const xsimd::avx512bw&) {
+        return static_cast<uint64_t>(mask.data);
+    }
+#endif
+
 #if XSIMD_WITH_AVX2
-    static int
+    static uint64_t
     toBitMask(xsimd::batch_bool<T, A> mask, const xsimd::avx2&) {
-        // There is no intrinsic for extracting high bits of a 16x16
-        // vector.  Hence take every second bit of the high bits of a 32x1
-        // vector.
-        //
-        // NOTE: TVL might have a more efficient implementation for this.
         return bits::extractBits<uint32_t>(_mm256_movemask_epi8(mask),
                                            0xAAAAAAAA);
     }
 #endif
 
 #if XSIMD_WITH_SSE2
-    static int
+    static uint64_t
     toBitMask(xsimd::batch_bool<T, A> mask, const xsimd::sse2&) {
         return milvus::bits::extractBits<uint32_t>(_mm_movemask_epi8(mask),
                                                    0xAAAA);
     }
 #endif
 
-    static int
+#if XSIMD_WITH_NEON
+    static uint64_t
+    toBitMask(xsimd::batch_bool<T, A> mask, const xsimd::neon&) {
+        // Narrow: top byte of each 16-bit all-1s/all-0s lane → 0xFF/0x00
+        uint8x16_t raw = vreinterpretq_u8_u16(mask.data);
+        uint16x8_t u16 = vreinterpretq_u16_u8(raw);
+        uint8x8_t narrowed = vshrn_n_u16(u16, 8);
+        // 8 bytes → 8 bits via shift-and-add
+        alignas(8) static const int8_t kShift[] = {
+            -7, -6, -5, -4, -3, -2, -1, 0};
+        int8x8_t vshift = vld1_s8(kShift);
+        uint8x8_t bits = vshl_u8(vand_u8(narrowed, vdup_n_u8(0x80)), vshift);
+        return vaddv_u8(bits);
+    }
+#endif
+
+    static uint64_t
     toBitMask(xsimd::batch_bool<T, A> mask, const xsimd::generic&) {
         return genericToBitMask(mask);
     }
 };
 
+// ═══════════════════════════════════════════════════════════════════════════
+// sizeof(T) == 4  (int32_t / float)
+// AVX512F:  __mmask16 — direct extract (only needs Foundation, not BW).
+// AVX:      _mm256_movemask_ps → 8 bits, 1 per float lane.
+// NEON:     high-bit shift + positional weighting + horizontal add.
+// ═══════════════════════════════════════════════════════════════════════════
 template <typename T, typename A>
 struct BitMask<T, A, 4> {
-    static constexpr int kAllSet =
+    static constexpr uint64_t kAllSet =
         milvus::bits::lowMask(xsimd::batch_bool<T, A>::size);
 
+#if XSIMD_WITH_AVX512F
+    static uint64_t
+    toBitMask(xsimd::batch_bool<T, A> mask, const xsimd::avx512f&) {
+        return static_cast<uint64_t>(mask.data);
+    }
+#endif
+
 #if XSIMD_WITH_AVX
-    static int
+    static uint64_t
     toBitMask(xsimd::batch_bool<T, A> mask, const xsimd::avx&) {
-        return _mm256_movemask_ps(reinterpret_cast<__m256>(mask.data));
+        if constexpr (std::is_same_v<decltype(mask.data), __m256>) {
+            return _mm256_movemask_ps(mask.data);
+        } else {
+            return _mm256_movemask_ps(_mm256_castsi256_ps(mask.data));
+        }
     }
 #endif
 
 #if XSIMD_WITH_SSE2
-    static int
+    static uint64_t
     toBitMask(xsimd::batch_bool<T, A> mask, const xsimd::sse2&) {
-        return _mm_movemask_ps(reinterpret_cast<__m128>(mask.data));
+        if constexpr (std::is_same_v<decltype(mask.data), __m128>) {
+            return _mm_movemask_ps(mask.data);
+        } else {
+            return _mm_movemask_ps(_mm_castsi128_ps(mask.data));
+        }
     }
 #endif
 
-    static int
+#if XSIMD_WITH_NEON
+    static uint64_t
+    toBitMask(xsimd::batch_bool<T, A> mask, const xsimd::neon&) {
+        uint8x16_t raw = vreinterpretq_u8_u32(mask.data);
+        uint32x4_t u32 = vreinterpretq_u32_u8(raw);
+        uint32x4_t bits = vshrq_n_u32(u32, 31);
+        alignas(16) static const int32_t kShift[] = {0, 1, 2, 3};
+        int32x4_t shifts = vld1q_s32(kShift);
+        uint32x4_t weighted = vshlq_u32(bits, shifts);
+        return vaddvq_u32(weighted);
+    }
+#endif
+
+    static uint64_t
     toBitMask(xsimd::batch_bool<T, A> mask, const xsimd::generic&) {
         return genericToBitMask(mask);
     }
 };
 
+// ═══════════════════════════════════════════════════════════════════════════
+// sizeof(T) == 8  (int64_t / double)
+// AVX512F:  __mmask8 — direct extract (only needs Foundation, not BW).
+// AVX:      _mm256_movemask_pd → 4 bits, 1 per double lane.
+// NEON:     extract high bit of each 64-bit lane (only 2 lanes).
+// ═══════════════════════════════════════════════════════════════════════════
 template <typename T, typename A>
 struct BitMask<T, A, 8> {
-    static constexpr int kAllSet =
+    static constexpr uint64_t kAllSet =
         milvus::bits::lowMask(xsimd::batch_bool<T, A>::size);
 
+#if XSIMD_WITH_AVX512F
+    static uint64_t
+    toBitMask(xsimd::batch_bool<T, A> mask, const xsimd::avx512f&) {
+        return static_cast<uint64_t>(mask.data);
+    }
+#endif
+
 #if XSIMD_WITH_AVX
-    static int
+    static uint64_t
     toBitMask(xsimd::batch_bool<T, A> mask, const xsimd::avx&) {
-        return _mm256_movemask_pd(reinterpret_cast<__m256d>(mask.data));
+        if constexpr (std::is_same_v<decltype(mask.data), __m256d>) {
+            return _mm256_movemask_pd(mask.data);
+        } else {
+            return _mm256_movemask_pd(_mm256_castsi256_pd(mask.data));
+        }
     }
 #endif
 
 #if XSIMD_WITH_SSE2
-    static int
+    static uint64_t
     toBitMask(xsimd::batch_bool<T, A> mask, const xsimd::sse2&) {
-        return _mm_movemask_pd(reinterpret_cast<__m128d>(mask.data));
+        if constexpr (std::is_same_v<decltype(mask.data), __m128d>) {
+            return _mm_movemask_pd(mask.data);
+        } else {
+            return _mm_movemask_pd(_mm_castsi128_pd(mask.data));
+        }
     }
 #endif
 
-    static int
+#if XSIMD_WITH_NEON
+    static uint64_t
+    toBitMask(xsimd::batch_bool<T, A> mask, const xsimd::neon&) {
+        uint8x16_t raw = vreinterpretq_u8_u64(mask.data);
+        uint64x2_t u64 = vreinterpretq_u64_u8(raw);
+        return (vgetq_lane_u64(u64, 0) >> 63) |
+               ((vgetq_lane_u64(u64, 1) >> 63) << 1);
+    }
+#endif
+
+    static uint64_t
     toBitMask(xsimd::batch_bool<T, A> mask, const xsimd::generic&) {
         return genericToBitMask(mask);
     }
 };
 
+// ═══════════════════════════════════════════════════════════════════════════
+// Free-function dispatcher — selects best overload for the default arch.
+// ═══════════════════════════════════════════════════════════════════════════
 template <typename T, typename A = xsimd::default_arch>
-auto
+uint64_t
 toBitMask(xsimd::batch_bool<T, A> mask, const A& arch = {}) {
     return BitMask<T, A>::toBitMask(mask, arch);
 }

--- a/internal/core/src/exec/CMakeLists.txt
+++ b/internal/core/src/exec/CMakeLists.txt
@@ -11,3 +11,24 @@
 
 add_source_at_current_directory_recursively()
 add_library(milvus_exec OBJECT ${SOURCE_FILES})
+
+# ── Per-arch SIMD compile flags for runtime dispatch ──
+# Each SimdFilter*.cpp is compiled with arch-specific flags so xsimd
+# generates the correct instructions. The dispatcher (SimdFilter.cpp)
+# is compiled with default flags and selects the best impl at runtime.
+if (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64")
+    # Baseline must stay SSE2-only even if project adds global -mavx2.
+    # -mno-avx prevents auto-vectorization from emitting AVX instructions.
+    # SKIP_PRECOMPILE_HEADERS disables PCH for these files because the PCH
+    # is built with different target features, causing clang to reject the
+    # AST file.
+    set_source_files_properties(
+        expression/SimdFilter.cpp
+        PROPERTIES COMPILE_FLAGS "-mno-avx" SKIP_PRECOMPILE_HEADERS ON)
+    set_source_files_properties(
+        expression/SimdFilterAvx2.cpp
+        PROPERTIES COMPILE_FLAGS "-mavx2 -mfma" SKIP_PRECOMPILE_HEADERS ON)
+    set_source_files_properties(
+        expression/SimdFilterAvx512.cpp
+        PROPERTIES COMPILE_FLAGS "-mavx512f -mavx512bw -mavx512vl -mavx512dq" SKIP_PRECOMPILE_HEADERS ON)
+endif()

--- a/internal/core/src/exec/HashTable.cpp
+++ b/internal/core/src/exec/HashTable.cpp
@@ -82,7 +82,8 @@ class ProbeState {
     firstProbe(const Table& table) {
         tagsInTable_ = BaseHashTable::loadTags(
             reinterpret_cast<uint8_t*>(table.table_), bucketOffset_);
-        hits_ = milvus::toBitMask(tagsInTable_ == wantedTags_);
+        hits_ = static_cast<BaseHashTable::MaskType>(
+            milvus::toBitMask(tagsInTable_ == wantedTags_));
         if (hits_) {
             loadNextHit<op>(table);
         }
@@ -116,7 +117,8 @@ class ProbeState {
             }
             bucketOffset_ = table.nextBucketOffset(bucketOffset_);
             tagsInTable_ = table.loadTags(bucketOffset_);
-            hits_ = milvus::toBitMask(tagsInTable_ == wantedTags_);
+            hits_ = static_cast<BaseHashTable::MaskType>(
+                milvus::toBitMask(tagsInTable_ == wantedTags_));
         }
         ThrowInfo(UnexpectedError,
                   "Slots in hash table is not enough for hash operation, fail "

--- a/internal/core/src/exec/expression/Element.h
+++ b/internal/core/src/exec/expression/Element.h
@@ -17,8 +17,10 @@
 #pragma once
 
 #include <algorithm>
+#include <cstring>
 #include <memory>
 #include <string>
+#include <type_traits>
 
 #include "common/Types.h"
 #include "exec/expression/EvalCtx.h"
@@ -27,6 +29,8 @@
 #include "expr/ITypeExpr.h"
 #include "query/PlanProto.h"
 #include "ankerl/unordered_dense.h"
+
+#include "exec/expression/SimdFilter.h"
 
 namespace milvus {
 namespace exec {
@@ -270,12 +274,14 @@ class SetElement : public MultiElement {
 
  public:
     explicit SetElement(const std::vector<proto::plan::GenericValue>& values) {
+        values_.max_load_factor(0.5f);
         for (auto& value : values) {
             values_.insert(GetValueWithCastNumber<T>(value));
         }
     }
 
     explicit SetElement(const std::vector<T>& values) {
+        values_.max_load_factor(0.5f);
         for (const auto& value : values) {
             values_.insert(value);
         }
@@ -310,6 +316,39 @@ class SetElement : public MultiElement {
         return values_.size();
     }
 
+    // Batch filter: bypass ValueType variant construction.
+    // Looks up each data[i] directly in the hash set (zero-copy for strings
+    // via transparent hash).
+    void
+    FilterChunk(const T* data, const int size, TargetBitmapView res) const {
+        for (int i = 0; i < size; ++i) {
+            if constexpr (std::is_same_v<T, std::string>) {
+                // Use string_view to avoid copying into the hash function
+                if (values_.find(std::string_view(data[i])) != values_.end()) {
+                    res[i] = true;
+                }
+            } else {
+                if (values_.find(data[i]) != values_.end()) {
+                    res[i] = true;
+                }
+            }
+        }
+    }
+
+    // string_view data overload for sealed/mmap segments (T=string only).
+    template <typename U = T,
+              typename = std::enable_if_t<std::is_same_v<U, std::string>>>
+    void
+    FilterChunk(const std::string_view* data,
+                const int size,
+                TargetBitmapView res) const {
+        for (int i = 0; i < size; ++i) {
+            if (values_.find(data[i]) != values_.end()) {
+                res[i] = true;
+            }
+        }
+    }
+
     std::vector<T>
     GetElements() const {
         return std::vector<T>(values_.begin(), values_.end());
@@ -319,40 +358,43 @@ class SetElement : public MultiElement {
     SetType values_;
 };
 
+// SetElement<bool> specialization: avoids ankerl::unordered_dense::set<bool>
+// whose wyhash reads 8 bytes from a 1-byte bool, causing ASAN
+// stack-use-after-scope.  Bool has at most 2 distinct values, so two flags
+// are both faster and correct.
 template <>
 class SetElement<bool> : public MultiElement {
  public:
     explicit SetElement(const std::vector<proto::plan::GenericValue>& values) {
         for (auto& value : values) {
-            bool v = GetValueFromProto<bool>(value);
+            bool v = GetValueWithCastNumber<bool>(value);
             if (v) {
-                contains_true = true;
+                has_true_ = true;
             } else {
-                contains_false = true;
+                has_false_ = true;
             }
         }
     }
 
     explicit SetElement(const std::vector<bool>& values) {
-        for (const auto& value : values) {
-            if (value) {
-                contains_true = true;
+        for (bool v : values) {
+            if (v) {
+                has_true_ = true;
             } else {
-                contains_false = true;
+                has_false_ = true;
             }
         }
     }
 
     bool
     Empty() const override {
-        return !contains_true && !contains_false;
+        return !has_true_ && !has_false_;
     }
 
     bool
     In(const ValueType& value) const override {
-        if (std::holds_alternative<bool>(value)) {
-            bool v = std::get<bool>(value);
-            return (v && contains_true) || (!v && contains_false);
+        if (auto* b = std::get_if<bool>(&value)) {
+            return *b ? has_true_ : has_false_;
         }
         return false;
     }
@@ -360,26 +402,151 @@ class SetElement<bool> : public MultiElement {
     void
     AddElement(const bool& value) {
         if (value) {
-            contains_true = true;
+            has_true_ = true;
         } else {
-            contains_false = true;
+            has_false_ = true;
         }
     }
 
     size_t
     Size() const override {
-        return (contains_true ? 1 : 0) + (contains_false ? 1 : 0);
+        return static_cast<size_t>(has_true_) + static_cast<size_t>(has_false_);
     }
 
     std::vector<bool>
     GetElements() const {
-        return {contains_true, contains_false};
+        std::vector<bool> result;
+        if (has_true_) {
+            result.push_back(true);
+        }
+        if (has_false_) {
+            result.push_back(false);
+        }
+        return result;
     }
 
  private:
-    bool contains_true = false;
-    bool contains_false = false;
+    bool has_true_ = false;
+    bool has_false_ = false;
 };
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SimdBatchElement: SIMD batch-data comparison for all numeric types.
+// Supports: int8, int16, int32, int64, float, double.
+//
+// Uses runtime-dispatched SIMD — at startup selects the best instruction set
+// available on the current CPU (AVX512, AVX2, SSE2, NEON).
+//
+// Two execution modes:
+//   In()          — per-row fallback (linear scan, no hash overhead)
+//   FilterChunk() — batch SIMD via simdFilterChunk() (preferred)
+// ═══════════════════════════════════════════════════════════════════════════
+template <typename T>
+class SimdBatchElement : public MultiElement {
+    static_assert(std::is_same_v<T, int8_t> || std::is_same_v<T, uint8_t> ||
+                      std::is_same_v<T, int16_t> ||
+                      std::is_same_v<T, int32_t> ||
+                      std::is_same_v<T, int64_t> || std::is_same_v<T, float> ||
+                      std::is_same_v<T, double>,
+                  "SimdBatchElement supports numeric types only");
+
+    // Sorted and deduplicated by the Go rewriter layer
+    // (sortTermValues in rewriter/util.go).
+    std::vector<T> vals_;
+
+ public:
+    explicit SimdBatchElement(
+        const std::vector<proto::plan::GenericValue>& values) {
+        vals_.reserve(values.size());
+        for (auto& value : values) {
+            vals_.push_back(GetValueWithCastNumber<T>(value));
+        }
+    }
+
+    explicit SimdBatchElement(const std::vector<T>& values) : vals_(values) {
+    }
+
+    bool
+    Empty() const override {
+        return vals_.empty();
+    }
+
+    size_t
+    Size() const override {
+        return vals_.size();
+    }
+
+    // Per-row fallback: binary search (vals_ is pre-sorted by Go rewriter)
+    // Callers should use std::in_place_type<T> when constructing ValueType
+    // to avoid implicit integer promotion (e.g. int8_t -> int32_t).
+    bool
+    In(const ValueType& value) const override {
+        T v = std::get<T>(value);
+        return std::binary_search(vals_.begin(), vals_.end(), v);
+    }
+
+    // Batch SIMD filter — delegates to runtime-dispatched simdFilterChunk().
+    void
+    FilterChunk(const T* data, const int size, TargetBitmapView res) const {
+        if (vals_.empty() || size <= 0) {
+            return;
+        }
+
+        int offset = res.offset();
+        int start = 0;
+
+        // Head: scalar for unaligned leading bits (up to 7 rows)
+        int bit_offset = offset % 8;
+        if (bit_offset != 0) {
+            int head = std::min(size, 8 - bit_offset);
+            for (int i = 0; i < head; ++i) {
+                if (std::binary_search(vals_.begin(), vals_.end(), data[i])) {
+                    res[i] = true;
+                }
+            }
+            start = head;
+        }
+
+        // Middle: SIMD for the byte-aligned bulk
+        int remaining = size - start;
+        if (remaining > 0) {
+            uint8_t* bitmap =
+                reinterpret_cast<uint8_t*>(res.data()) + (start + offset) / 8;
+            simdFilterChunk<T>(data + start,
+                               remaining,
+                               bitmap,
+                               vals_.data(),
+                               static_cast<int>(vals_.size()));
+        }
+    }
+
+    std::vector<T>
+    GetElements() const {
+        return vals_;
+    }
+};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// GetElementValues: extract typed element vector from any MultiElement.
+// Used by skip index to get IN values regardless of element type.
+// ═══════════════════════════════════════════════════════════════════════════
+template <typename T>
+std::vector<T>
+GetElementValues(const std::shared_ptr<MultiElement>& ptr) {
+    if (auto p = std::dynamic_pointer_cast<SetElement<T>>(ptr)) {
+        return p->GetElements();
+    }
+    if constexpr (!std::is_same_v<T, bool> && !std::is_same_v<T, std::string> &&
+                  !std::is_same_v<T, std::string_view>) {
+        if (auto p = std::dynamic_pointer_cast<SimdBatchElement<T>>(ptr)) {
+            return p->GetElements();
+        }
+    }
+    if (auto p = std::dynamic_pointer_cast<SortVectorElement<T>>(ptr)) {
+        return p->GetElements();
+    }
+    return {};
+}
 
 }  //namespace exec
 }  // namespace milvus

--- a/internal/core/src/exec/expression/ElementTest.cpp
+++ b/internal/core/src/exec/expression/ElementTest.cpp
@@ -1,0 +1,1838 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <algorithm>
+#include <cstdint>
+#include <numeric>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "exec/expression/Element.h"
+#include <xsimd/xsimd.hpp>
+#include "common/SimdUtil.h"
+
+using namespace milvus::exec;
+using VT = MultiElement::ValueType;
+
+// Construct ValueType with explicit type to avoid implicit integer promotion
+// (e.g. int8_t -> int in std::variant). This matches how TermExpr.cpp calls
+// In() using std::in_place_type<T>.
+template <typename T>
+VT
+MakeVT(T v) {
+    return VT(std::in_place_type<T>, v);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SimdBatchElement::In() tests — per-row lookup
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(SimdBatchElementTest, Int8) {
+    std::vector<int8_t> vals = {-128, -1, 0, 1, 127};
+    SimdBatchElement<int8_t> sb(vals);
+    EXPECT_EQ(sb.Size(), 5);
+    for (auto v : vals) {
+        EXPECT_TRUE(sb.In(MakeVT(v)));
+    }
+    EXPECT_FALSE(sb.In(MakeVT(int8_t(2))));
+    EXPECT_FALSE(sb.In(MakeVT(int8_t(100))));
+}
+
+TEST(SimdBatchElementTest, Int16) {
+    std::vector<int16_t> vals = {-32768, -1, 0, 1, 32767};
+    SimdBatchElement<int16_t> sb(vals);
+    for (auto v : vals) {
+        EXPECT_TRUE(sb.In(MakeVT(v)));
+    }
+    EXPECT_FALSE(sb.In(MakeVT(int16_t(2))));
+}
+
+TEST(SimdBatchElementTest, Int32) {
+    std::vector<int32_t> vals = {-100000, -1, 0, 1, 42, 100000};
+    SimdBatchElement<int32_t> sb(vals);
+    for (auto v : vals) {
+        EXPECT_TRUE(sb.In(MakeVT(v)));
+    }
+    EXPECT_FALSE(sb.In(MakeVT(int32_t(2))));
+}
+
+TEST(SimdBatchElementTest, Int64) {
+    std::vector<int64_t> vals = {-1000000000LL, -1, 0, 1, 1000000000LL};
+    SimdBatchElement<int64_t> sb(vals);
+    for (auto v : vals) {
+        EXPECT_TRUE(sb.In(MakeVT(v)));
+    }
+    EXPECT_FALSE(sb.In(MakeVT(int64_t(2))));
+}
+
+TEST(SimdBatchElementTest, Float) {
+    std::vector<float> vals = {-1.5f, 0.0f, 1.5f, 1e10f};
+    SimdBatchElement<float> sb(vals);
+    for (auto v : vals) {
+        EXPECT_TRUE(sb.In(MakeVT(v)));
+    }
+    EXPECT_FALSE(sb.In(MakeVT(1.6f)));
+    EXPECT_FALSE(sb.In(MakeVT(0.1f)));
+}
+
+TEST(SimdBatchElementTest, Double) {
+    std::vector<double> vals = {-1.5, 0.0, 1.5, 1e100};
+    SimdBatchElement<double> sb(vals);
+    for (auto v : vals) {
+        EXPECT_TRUE(sb.In(MakeVT(v)));
+    }
+    EXPECT_FALSE(sb.In(MakeVT(1.6)));
+}
+
+TEST(SimdBatchElementTest, Empty) {
+    SimdBatchElement<int32_t> sb(std::vector<int32_t>{});
+    EXPECT_TRUE(sb.Empty());
+    EXPECT_FALSE(sb.In(MakeVT(int32_t(0))));
+}
+
+TEST(SimdBatchElementTest, SingleElement) {
+    SimdBatchElement<int64_t> sb(std::vector<int64_t>{42});
+    EXPECT_TRUE(sb.In(MakeVT(int64_t(42))));
+    EXPECT_FALSE(sb.In(MakeVT(int64_t(0))));
+    EXPECT_FALSE(sb.In(MakeVT(int64_t(43))));
+}
+
+TEST(SimdBatchElementTest, GetElements) {
+    std::vector<int32_t> vals = {1, 2, 3};
+    SimdBatchElement<int32_t> sb(vals);
+    auto result = sb.GetElements();
+    std::vector<int32_t> expected = {1, 2, 3};
+    EXPECT_EQ(result, expected);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SimdBatchElement::FilterChunk() tests — batch SIMD path
+//
+// For each numeric type: fill a data buffer, run FilterChunk, verify that
+// the result bitmap matches element-wise In() exactly.
+// ═══════════════════════════════════════════════════════════════════════════
+
+// Helper: run FilterChunk and verify against per-row In() as ground truth.
+template <typename T>
+void
+VerifyFilterChunk(const std::vector<T>& in_vals,
+                  const std::vector<T>& data,
+                  const std::string& label = "") {
+    // SimdBatchElement requires pre-sorted, deduplicated input
+    auto sorted = in_vals;
+    std::sort(sorted.begin(), sorted.end());
+    sorted.erase(std::unique(sorted.begin(), sorted.end()), sorted.end());
+    SimdBatchElement<T> sb(sorted);
+    SetElement<T> se(in_vals);
+
+    const int n = static_cast<int>(data.size());
+    milvus::TargetBitmap bm_filter(n, false);
+    milvus::TargetBitmap bm_in(n, false);
+
+    milvus::TargetBitmapView view_filter(bm_filter.data(), n);
+    milvus::TargetBitmapView view_in(bm_in.data(), n);
+
+    sb.FilterChunk(data.data(), n, view_filter);
+
+    // Ground truth: per-row In() via SetElement (hash-based, known correct)
+    for (int i = 0; i < n; ++i) {
+        view_in[i] = se.In(MakeVT(data[i]));
+    }
+
+    for (int i = 0; i < n; ++i) {
+        EXPECT_EQ(view_filter[i], view_in[i])
+            << label << " mismatch at index " << i << " data=" << data[i];
+    }
+}
+
+TEST(FilterChunkTest, Int8Basic) {
+    std::vector<int8_t> in_vals = {-128, -1, 0, 1, 127};
+    // Data: sequential -128..127 covers all int8 values
+    std::vector<int8_t> data(256);
+    for (int i = 0; i < 256; ++i) {
+        data[i] = static_cast<int8_t>(i - 128);
+    }
+    VerifyFilterChunk(in_vals, data, "Int8Basic");
+}
+
+TEST(FilterChunkTest, Int16Basic) {
+    std::vector<int16_t> in_vals = {-32768, -1000, -1, 0, 1, 1000, 32767};
+    std::vector<int16_t> data(512);
+    for (int i = 0; i < 512; ++i) {
+        data[i] = static_cast<int16_t>(i - 256);
+    }
+    VerifyFilterChunk(in_vals, data, "Int16Basic");
+}
+
+TEST(FilterChunkTest, Int32Basic) {
+    std::vector<int32_t> in_vals = {-999999, -1, 0, 1, 42, 999999};
+    std::vector<int32_t> data(1024);
+    std::iota(data.begin(), data.end(), -512);
+    VerifyFilterChunk(in_vals, data, "Int32Basic");
+}
+
+TEST(FilterChunkTest, Int64Basic) {
+    std::vector<int64_t> in_vals = {-1000000000LL, -1, 0, 1, 1000000000LL};
+    std::vector<int64_t> data(512);
+    std::iota(data.begin(), data.end(), -256);
+    VerifyFilterChunk(in_vals, data, "Int64Basic");
+}
+
+TEST(FilterChunkTest, FloatBasic) {
+    std::vector<float> in_vals = {-1.5f, 0.0f, 1.5f, 100.0f};
+    std::vector<float> data(256);
+    for (int i = 0; i < 256; ++i) {
+        data[i] = static_cast<float>(i) * 0.5f - 64.0f;
+    }
+    VerifyFilterChunk(in_vals, data, "FloatBasic");
+}
+
+TEST(FilterChunkTest, DoubleBasic) {
+    std::vector<double> in_vals = {-1.5, 0.0, 1.5, 100.0};
+    std::vector<double> data(256);
+    for (int i = 0; i < 256; ++i) {
+        data[i] = static_cast<double>(i) * 0.5 - 64.0;
+    }
+    VerifyFilterChunk(in_vals, data, "DoubleBasic");
+}
+
+// Empty IN list — FilterChunk should leave bitmap all-false.
+TEST(FilterChunkTest, EmptyInList) {
+    SimdBatchElement<int32_t> sb(std::vector<int32_t>{});
+    std::vector<int32_t> data = {1, 2, 3, 4, 5};
+    milvus::TargetBitmap bm(5, false);
+    milvus::TargetBitmapView view(bm.data(), 5);
+    sb.FilterChunk(data.data(), 5, view);
+    for (int i = 0; i < 5; ++i) {
+        EXPECT_FALSE(view[i]);
+    }
+}
+
+// Single element — tests broadcast correctness.
+TEST(FilterChunkTest, SingleInValue) {
+    std::vector<int64_t> in_vals = {42};
+    std::vector<int64_t> data = {41, 42, 43, 42, 0, 42};
+    VerifyFilterChunk(in_vals, data, "SingleInValue");
+}
+
+// All data matches — every bit should be set.
+TEST(FilterChunkTest, AllMatch) {
+    std::vector<int32_t> in_vals = {7};
+    std::vector<int32_t> data(128, 7);
+    VerifyFilterChunk(in_vals, data, "AllMatch");
+}
+
+// No data matches — bitmap should stay all-false.
+TEST(FilterChunkTest, NoneMatch) {
+    std::vector<int32_t> in_vals = {999};
+    std::vector<int32_t> data(128);
+    std::iota(data.begin(), data.end(), 0);
+    VerifyFilterChunk(in_vals, data, "NoneMatch");
+}
+
+// Scalar tail: data size not a multiple of SIMD lane width.
+// Tests sizes 1..kLanes+1 to exercise all tail lengths.
+TEST(FilterChunkTest, ScalarTailAllSizes) {
+    using Batch = xsimd::batch<int32_t>;
+    constexpr int kLanes = Batch::size;
+    std::vector<int32_t> in_vals = {3, 7, 15};
+
+    for (int sz = 1; sz <= kLanes + 1; ++sz) {
+        std::vector<int32_t> data(sz);
+        std::iota(data.begin(), data.end(), 0);
+        VerifyFilterChunk(in_vals, data, "TailSize=" + std::to_string(sz));
+    }
+}
+
+// Large data: multiple full SIMD chunks + tail.
+TEST(FilterChunkTest, LargeData) {
+    std::vector<int32_t> in_vals = {10, 100, 500, 999};
+    std::vector<int32_t> data(8192);
+    std::iota(data.begin(), data.end(), 0);
+    VerifyFilterChunk(in_vals, data, "LargeData");
+}
+
+// IN list at threshold boundary (64 — the SIMD/hash cutover).
+TEST(FilterChunkTest, MaxSimdSize) {
+    constexpr size_t kMax = 64;
+    std::vector<int32_t> in_vals(kMax);
+    std::iota(in_vals.begin(), in_vals.end(), 0);
+
+    // Data contains some IN values and some not.
+    std::vector<int32_t> data(kMax * 2);
+    std::iota(data.begin(), data.end(), -static_cast<int32_t>(kMax / 2));
+    VerifyFilterChunk(in_vals, data, "MaxSimdSize");
+}
+
+// Randomized stress test: random data + random IN values.
+TEST(FilterChunkTest, RandomizedInt32) {
+    std::mt19937 rng(42);
+    std::uniform_int_distribution<int32_t> dist(-1000, 1000);
+
+    std::vector<int32_t> in_vals(20);
+    for (auto& v : in_vals) v = dist(rng);
+
+    std::vector<int32_t> data(4096);
+    for (auto& v : data) v = dist(rng);
+
+    VerifyFilterChunk(in_vals, data, "RandomizedInt32");
+}
+
+TEST(FilterChunkTest, RandomizedInt8) {
+    std::mt19937 rng(123);
+    std::uniform_int_distribution<int16_t> dist(-128, 127);
+
+    std::vector<int8_t> in_vals(10);
+    for (auto& v : in_vals) v = static_cast<int8_t>(dist(rng));
+
+    std::vector<int8_t> data(1024);
+    for (auto& v : data) v = static_cast<int8_t>(dist(rng));
+
+    VerifyFilterChunk(in_vals, data, "RandomizedInt8");
+}
+
+TEST(FilterChunkTest, RandomizedFloat) {
+    std::mt19937 rng(77);
+    std::uniform_real_distribution<float> dist(-100.0f, 100.0f);
+
+    std::vector<float> in_vals(15);
+    for (auto& v : in_vals) v = dist(rng);
+
+    // Embed some known matches into data
+    std::vector<float> data(2048);
+    for (auto& v : data) v = dist(rng);
+    for (size_t i = 0; i < in_vals.size(); ++i) {
+        data[i * 100] = in_vals[i];
+    }
+
+    VerifyFilterChunk(in_vals, data, "RandomizedFloat");
+}
+
+TEST(FilterChunkTest, RandomizedDouble) {
+    std::mt19937 rng(99);
+    std::uniform_real_distribution<double> dist(-1e6, 1e6);
+
+    std::vector<double> in_vals(8);
+    for (auto& v : in_vals) v = dist(rng);
+
+    std::vector<double> data(1024);
+    for (auto& v : data) v = dist(rng);
+    for (size_t i = 0; i < in_vals.size(); ++i) {
+        data[i * 50] = in_vals[i];
+    }
+
+    VerifyFilterChunk(in_vals, data, "RandomizedDouble");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Non-zero-offset BitsetView — verifies the scalar fallback path in
+// FilterChunk when the bitmap has a non-zero bit offset.
+// ═══════════════════════════════════════════════════════════════════════════
+
+template <typename T>
+void
+VerifyFilterChunkWithOffset(const std::vector<T>& in_vals,
+                            const std::vector<T>& data,
+                            int offset,
+                            const std::string& label = "") {
+    // SimdBatchElement requires pre-sorted, deduplicated input
+    auto sorted = in_vals;
+    std::sort(sorted.begin(), sorted.end());
+    sorted.erase(std::unique(sorted.begin(), sorted.end()), sorted.end());
+    SimdBatchElement<T> sb(sorted);
+    SetElement<T> se(in_vals);
+
+    const int n = static_cast<int>(data.size());
+
+    // Create a bitmap larger than needed, with a non-zero bit offset.
+    // BitsetView(data, offset, size) — offset shifts bit position 0.
+    milvus::TargetBitmap bm_backing(n + offset, false);
+    milvus::TargetBitmapView view_with_offset(bm_backing.data(), offset, n);
+
+    sb.FilterChunk(data.data(), n, view_with_offset);
+
+    // Ground truth
+    for (int i = 0; i < n; ++i) {
+        bool expected = se.In(MakeVT(data[i]));
+        EXPECT_EQ(bool(view_with_offset[i]), expected)
+            << label << " offset=" << offset << " mismatch at index " << i
+            << " data=" << data[i];
+    }
+}
+
+TEST(FilterChunkTest, NonZeroOffset_Int32) {
+    std::vector<int32_t> in_vals = {-1, 0, 1, 42, 999};
+    std::vector<int32_t> data(512);
+    std::iota(data.begin(), data.end(), -256);
+    for (int off : {1, 3, 7, 8, 13, 31, 63}) {
+        VerifyFilterChunkWithOffset(
+            in_vals, data, off, "Int32_off" + std::to_string(off));
+    }
+}
+
+TEST(FilterChunkTest, NonZeroOffset_Int8) {
+    std::vector<int8_t> in_vals = {-128, -1, 0, 1, 127};
+    std::vector<int8_t> data(256);
+    for (int i = 0; i < 256; ++i) data[i] = static_cast<int8_t>(i - 128);
+    for (int off : {1, 5, 7}) {
+        VerifyFilterChunkWithOffset(
+            in_vals, data, off, "Int8_off" + std::to_string(off));
+    }
+}
+
+TEST(FilterChunkTest, NonZeroOffset_Double) {
+    std::vector<double> in_vals = {-1.5, 0.0, 1.5, 100.0};
+    std::vector<double> data(256);
+    for (int i = 0; i < 256; ++i) data[i] = static_cast<double>(i) * 0.5 - 64.0;
+    for (int off : {1, 4, 7}) {
+        VerifyFilterChunkWithOffset(
+            in_vals, data, off, "Double_off" + std::to_string(off));
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// toBitMask tests — verify the SimdUtil.h bitmask extraction
+//
+// Uses xsimd::batch_bool for the default arch to test whichever SIMD path
+// the build machine supports (AVX512, AVX2, SSE2, NEON, or generic).
+// ═══════════════════════════════════════════════════════════════════════════
+
+template <typename T>
+void
+VerifyToBitMask() {
+    using Batch = xsimd::batch<T>;
+    using BatchBool = xsimd::batch_bool<T>;
+    constexpr int kLanes = Batch::size;
+
+    // All-false mask → 0
+    {
+        BatchBool mask(false);
+        uint64_t result = milvus::toBitMask(mask);
+        EXPECT_EQ(result, 0u) << "all-false should be 0";
+    }
+
+    // All-true mask → (1 << kLanes) - 1
+    {
+        BatchBool mask(true);
+        uint64_t result = milvus::toBitMask(mask);
+        uint64_t expected =
+            (kLanes == 64) ? ~uint64_t(0) : (uint64_t(1) << kLanes) - 1;
+        EXPECT_EQ(result, expected)
+            << "all-true should set " << kLanes << " bits";
+    }
+
+    // Single lane set: broadcast a value, compare equal, check mask.
+    // Put the target value at each position and verify the right bit is set.
+    for (int pos = 0; pos < kLanes; ++pos) {
+        alignas(64) T data[64] = {};  // zero-initialized
+        data[pos] = T(42);
+
+        auto d = Batch::load_unaligned(data);
+        auto target = Batch::broadcast(T(42));
+        auto mask = (d == target);
+        uint64_t result = milvus::toBitMask(mask);
+
+        EXPECT_EQ(result, uint64_t(1) << pos)
+            << "only bit " << pos << " should be set";
+    }
+
+    // Multiple lanes set
+    {
+        alignas(64) T data[64] = {};
+        // Set lanes 0 and kLanes-1
+        data[0] = T(99);
+        data[kLanes - 1] = T(99);
+
+        auto d = Batch::load_unaligned(data);
+        auto target = Batch::broadcast(T(99));
+        auto mask = (d == target);
+        uint64_t result = milvus::toBitMask(mask);
+
+        uint64_t expected = uint64_t(1) | (uint64_t(1) << (kLanes - 1));
+        EXPECT_EQ(result, expected)
+            << "bits 0 and " << (kLanes - 1) << " should be set";
+    }
+}
+
+TEST(ToBitMaskTest, Int8) {
+    VerifyToBitMask<int8_t>();
+}
+
+TEST(ToBitMaskTest, Int16) {
+    VerifyToBitMask<int16_t>();
+}
+
+TEST(ToBitMaskTest, Int32) {
+    VerifyToBitMask<int32_t>();
+}
+
+TEST(ToBitMaskTest, Int64) {
+    VerifyToBitMask<int64_t>();
+}
+
+TEST(ToBitMaskTest, Float) {
+    VerifyToBitMask<float>();
+}
+
+TEST(ToBitMaskTest, Double) {
+    VerifyToBitMask<double>();
+}
+
+// Verify kAllSet matches expected value for each type.
+TEST(ToBitMaskTest, KAllSetConsistency) {
+    auto check = [](auto kAllSet, int lanes, const char* name) {
+        uint64_t expected =
+            (lanes == 64) ? ~uint64_t(0) : (uint64_t(1) << lanes) - 1;
+        EXPECT_EQ(kAllSet, expected) << name << " kAllSet mismatch";
+    };
+
+    using A = xsimd::default_arch;
+    check(milvus::BitMask<int8_t, A>::kAllSet,
+          xsimd::batch_bool<int8_t, A>::size,
+          "int8");
+    check(milvus::BitMask<int16_t, A>::kAllSet,
+          xsimd::batch_bool<int16_t, A>::size,
+          "int16");
+    check(milvus::BitMask<int32_t, A>::kAllSet,
+          xsimd::batch_bool<int32_t, A>::size,
+          "int32");
+    check(milvus::BitMask<int64_t, A>::kAllSet,
+          xsimd::batch_bool<int64_t, A>::size,
+          "int64");
+    check(milvus::BitMask<float, A>::kAllSet,
+          xsimd::batch_bool<float, A>::size,
+          "float");
+    check(milvus::BitMask<double, A>::kAllSet,
+          xsimd::batch_bool<double, A>::size,
+          "double");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SetElement<std::string> tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(SetElementStringTest, Basic) {
+    std::vector<std::string> vals = {"hello", "world", "test"};
+    SetElement<std::string> fh(vals);
+    EXPECT_EQ(fh.Size(), 3);
+    EXPECT_TRUE(fh.In(MakeVT(std::string("hello"))));
+    EXPECT_TRUE(fh.In(MakeVT(std::string("world"))));
+    EXPECT_FALSE(fh.In(MakeVT(std::string("Hello"))));
+    EXPECT_FALSE(fh.In(MakeVT(std::string(""))));
+}
+
+TEST(SetElementStringTest, StringView) {
+    SetElement<std::string> fh(std::vector<std::string>{"alpha", "beta"});
+    EXPECT_TRUE(fh.In(MakeVT(std::string_view("alpha"))));
+    EXPECT_FALSE(fh.In(MakeVT(std::string_view("gamma"))));
+}
+
+TEST(SetElementStringTest, LongStrings) {
+    std::string s1(1000, 'a');
+    std::string s2(1000, 'b');
+    std::string s3 = s1;
+    s3[999] = 'z';  // differs at end (beyond 8-byte hash window)
+
+    SetElement<std::string> fh(std::vector<std::string>{s1, s2});
+    EXPECT_TRUE(fh.In(MakeVT(s1)));
+    EXPECT_TRUE(fh.In(MakeVT(s2)));
+    // s3 has same first 8 bytes as s1 but differs — hash may collide,
+    // but full strcmp in ankerl ensures correctness
+    EXPECT_FALSE(fh.In(MakeVT(s3)));
+}
+
+TEST(SetElementStringTest, Empty) {
+    SetElement<std::string> fh(std::vector<std::string>{});
+    EXPECT_TRUE(fh.Empty());
+    EXPECT_FALSE(fh.In(MakeVT(std::string(""))));
+}
+
+TEST(SetElementStringTest, EmptyString) {
+    SetElement<std::string> fh(std::vector<std::string>{""});
+    EXPECT_TRUE(fh.In(MakeVT(std::string(""))));
+    EXPECT_FALSE(fh.In(MakeVT(std::string("x"))));
+}
+
+// Strings that share first 8 bytes but differ later — stress CheapStringHash.
+TEST(SetElementStringTest, SharedPrefixCollision) {
+    std::string prefix(8, 'A');  // exactly 8 bytes shared
+    std::vector<std::string> vals;
+    for (int i = 0; i < 100; ++i) {
+        vals.push_back(prefix + std::to_string(i));
+    }
+    SetElement<std::string> fh(vals);
+    for (auto& v : vals) {
+        EXPECT_TRUE(fh.In(MakeVT(v))) << "should find: " << v;
+    }
+    EXPECT_FALSE(fh.In(MakeVT(prefix + "999")));
+    EXPECT_FALSE(fh.In(MakeVT(prefix)));
+}
+
+// Duplicates in input — Size() should deduplicate.
+TEST(SetElementStringTest, Duplicates) {
+    SetElement<std::string> fh(
+        std::vector<std::string>{"dup", "dup", "dup", "other"});
+    EXPECT_EQ(fh.Size(), 2);
+    EXPECT_TRUE(fh.In(MakeVT(std::string("dup"))));
+    EXPECT_TRUE(fh.In(MakeVT(std::string("other"))));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// GetElementValues helper
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(GetElementValuesTest, FromSimdBatch) {
+    auto elem = std::make_shared<SimdBatchElement<int64_t>>(
+        std::vector<int64_t>{10, 20, 30});
+    auto result =
+        GetElementValues<int64_t>(std::static_pointer_cast<MultiElement>(elem));
+    EXPECT_EQ(result, (std::vector<int64_t>{10, 20, 30}));
+}
+
+TEST(GetElementValuesTest, FromSetElement) {
+    auto elem = std::make_shared<SetElement<int32_t>>(
+        std::vector<int32_t>{100, 200, 300});
+    auto result =
+        GetElementValues<int32_t>(std::static_pointer_cast<MultiElement>(elem));
+    std::sort(result.begin(), result.end());
+    EXPECT_EQ(result, (std::vector<int32_t>{100, 200, 300}));
+}
+
+TEST(GetElementValuesTest, FromFixedHashStr) {
+    auto elem = std::make_shared<SetElement<std::string>>(
+        std::vector<std::string>{"x", "y"});
+    auto result = GetElementValues<std::string>(
+        std::static_pointer_cast<MultiElement>(elem));
+    std::sort(result.begin(), result.end());
+    EXPECT_EQ(result, (std::vector<std::string>{"x", "y"}));
+}
+
+TEST(GetElementValuesTest, FromSortVectorElement) {
+    auto elem = std::make_shared<SortVectorElement<int64_t>>(
+        std::vector<int64_t>{30, 10, 20});
+    auto result =
+        GetElementValues<int64_t>(std::static_pointer_cast<MultiElement>(elem));
+    // SortVectorElement sorts on construction
+    EXPECT_EQ(result, (std::vector<int64_t>{10, 20, 30}));
+}
+
+TEST(GetElementValuesTest, UnknownTypeReturnsEmpty) {
+    // FlatVectorElement is not handled by GetElementValues — should return {}
+    auto elem = std::make_shared<FlatVectorElement<int32_t>>(
+        std::vector<int32_t>{1, 2, 3});
+    auto result =
+        GetElementValues<int32_t>(std::static_pointer_cast<MultiElement>(elem));
+    EXPECT_TRUE(result.empty());
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Cross-validation: new element types must agree with SetElement
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(CrossValidationTest, Int8SimdVsSet) {
+    std::vector<int8_t> vals = {-128, -5, 0, 5, 10, 127};
+    SimdBatchElement<int8_t> sb(vals);
+    SetElement<int8_t> se(vals);
+    for (int v = -128; v <= 127; ++v) {
+        EXPECT_EQ(sb.In(MakeVT(int8_t(v))), se.In(MakeVT(int8_t(v))))
+            << "Mismatch for " << v;
+    }
+}
+
+TEST(CrossValidationTest, Int16SimdVsSet) {
+    std::vector<int16_t> vals = {-32768, -100, 0, 100, 256, 32767};
+    SimdBatchElement<int16_t> sb(vals);
+    SetElement<int16_t> se(vals);
+    for (int v = -500; v <= 500; ++v) {
+        EXPECT_EQ(sb.In(MakeVT(int16_t(v))), se.In(MakeVT(int16_t(v))))
+            << "Mismatch for " << v;
+    }
+}
+
+TEST(CrossValidationTest, Int32SimdVsSet) {
+    std::vector<int32_t> vals = {-100, -1, 0, 1, 42, 1000, 999999};
+    SimdBatchElement<int32_t> sb(vals);
+    SetElement<int32_t> se(vals);
+    std::vector<int32_t> probes = {-101,
+                                   -100,
+                                   -99,
+                                   -2,
+                                   -1,
+                                   0,
+                                   1,
+                                   2,
+                                   41,
+                                   42,
+                                   43,
+                                   999,
+                                   1000,
+                                   1001,
+                                   999998,
+                                   999999,
+                                   1000000};
+    for (auto v : probes) {
+        EXPECT_EQ(sb.In(MakeVT(v)), se.In(MakeVT(v))) << "Mismatch for " << v;
+    }
+}
+
+TEST(CrossValidationTest, Int64SimdVsSet) {
+    std::vector<int64_t> vals = {-(1LL << 40), -1, 0, 1, 1LL << 40};
+    SimdBatchElement<int64_t> sb(vals);
+    SetElement<int64_t> se(vals);
+    std::vector<int64_t> probes = {
+        -2, -1, 0, 1, 2, 1LL << 40, (1LL << 40) + 1, -(1LL << 40)};
+    for (auto v : probes) {
+        EXPECT_EQ(sb.In(MakeVT(v)), se.In(MakeVT(v))) << "Mismatch for " << v;
+    }
+}
+
+TEST(CrossValidationTest, FloatSimdVsSet) {
+    std::vector<float> vals = {-1.5f, 0.0f, 1.5f, 1e10f};
+    SimdBatchElement<float> sb(vals);
+    SetElement<float> se(vals);
+    std::vector<float> probes = {0.0f, -0.0f, 1.5f, 1.6f, -1.5f, 1e10f, 1e9f};
+    for (auto v : probes) {
+        EXPECT_EQ(sb.In(MakeVT(v)), se.In(MakeVT(v))) << "Mismatch for " << v;
+    }
+}
+
+TEST(CrossValidationTest, DoubleSimdVsSet) {
+    std::vector<double> vals = {-1.5, 0.0, 1e-100, 1.5, 1e100};
+    SimdBatchElement<double> sb(vals);
+    SetElement<double> se(vals);
+    std::vector<double> probes = {
+        0.0, -0.0, 1.5, 1.6, -1.5, 1e100, 1e99, 1e-100, 1e-99};
+    for (auto v : probes) {
+        EXPECT_EQ(sb.In(MakeVT(v)), se.In(MakeVT(v))) << "Mismatch for " << v;
+    }
+}
+
+TEST(CrossValidationTest, StringFixedHashVsSet) {
+    std::vector<std::string> vals = {"foo", "bar", std::string(500, 'x')};
+    SetElement<std::string> fh(vals);
+    SetElement<std::string> se(vals);
+    std::vector<std::string> probes = {"foo",
+                                       "bar",
+                                       "baz",
+                                       "",
+                                       "fo",
+                                       "fooo",
+                                       std::string(500, 'x'),
+                                       std::string(500, 'y'),
+                                       std::string(499, 'x'),
+                                       std::string(501, 'x')};
+    for (auto& v : probes) {
+        EXPECT_EQ(fh.In(MakeVT(v)), se.In(MakeVT(v)))
+            << "Mismatch for '" << v.substr(0, 20) << "'";
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// FilterChunk vs In() cross-validation for all numeric types
+//
+// Both paths (SIMD batch and per-row linear scan) must produce identical
+// results. This catches mask extraction bugs, broadcast errors, and
+// scalar-tail mismatches.
+// ═══════════════════════════════════════════════════════════════════════════
+
+template <typename T>
+void
+FilterChunkVsIn(const std::vector<T>& in_vals,
+                const std::vector<T>& data,
+                const std::string& label) {
+    auto sorted = in_vals;
+    std::sort(sorted.begin(), sorted.end());
+    sorted.erase(std::unique(sorted.begin(), sorted.end()), sorted.end());
+    SimdBatchElement<T> sb(sorted);
+    const int n = static_cast<int>(data.size());
+
+    milvus::TargetBitmap bm_chunk(n, false);
+    milvus::TargetBitmap bm_in(n, false);
+    milvus::TargetBitmapView view_chunk(bm_chunk.data(), n);
+    milvus::TargetBitmapView view_in(bm_in.data(), n);
+
+    sb.FilterChunk(data.data(), n, view_chunk);
+    for (int i = 0; i < n; ++i) {
+        view_in[i] = sb.In(MakeVT(data[i]));
+    }
+
+    for (int i = 0; i < n; ++i) {
+        EXPECT_EQ(view_chunk[i], view_in[i])
+            << label << " FilterChunk vs In mismatch at " << i;
+    }
+}
+
+TEST(FilterChunkVsInTest, Int8) {
+    std::vector<int8_t> data(256);
+    for (int i = 0; i < 256; ++i) data[i] = static_cast<int8_t>(i - 128);
+    FilterChunkVsIn<int8_t>({-128, -1, 0, 1, 127}, data, "Int8");
+}
+
+TEST(FilterChunkVsInTest, Int16) {
+    std::vector<int16_t> data(512);
+    for (int i = 0; i < 512; ++i) data[i] = static_cast<int16_t>(i - 256);
+    FilterChunkVsIn<int16_t>({-256, 0, 255, -32768, 32767}, data, "Int16");
+}
+
+TEST(FilterChunkVsInTest, Int32) {
+    std::vector<int32_t> data(1024);
+    std::iota(data.begin(), data.end(), -512);
+    FilterChunkVsIn<int32_t>({-512, 0, 42, 511}, data, "Int32");
+}
+
+TEST(FilterChunkVsInTest, Int64) {
+    std::vector<int64_t> data(256);
+    std::iota(data.begin(), data.end(), -128);
+    FilterChunkVsIn<int64_t>({-128, 0, 42, 127}, data, "Int64");
+}
+
+TEST(FilterChunkVsInTest, Float) {
+    std::vector<float> data(256);
+    for (int i = 0; i < 256; ++i) data[i] = i * 0.25f;
+    FilterChunkVsIn<float>({0.0f, 1.0f, 10.25f, 63.75f}, data, "Float");
+}
+
+TEST(FilterChunkVsInTest, Double) {
+    std::vector<double> data(128);
+    for (int i = 0; i < 128; ++i) data[i] = i * 0.1;
+    FilterChunkVsIn<double>({0.0, 1.0, 5.0, 12.7}, data, "Double");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SortVectorElement tests
+// Production usage: JsonContainsExpr creates SortVectorElement for
+// JSON_CONTAINS / JSON_CONTAINS_ALL / JSON_CONTAINS_ANY queries.
+// Always constructed with full vector (constructor sorts automatically).
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(SortVectorElementTest, Basic) {
+    SortVectorElement<int32_t> sv(std::vector<int32_t>{5, 3, 1, 4, 2});
+    EXPECT_EQ(sv.Size(), 5);
+    for (int v : {1, 2, 3, 4, 5}) {
+        EXPECT_TRUE(sv.In(MakeVT(int32_t(v))));
+    }
+    EXPECT_FALSE(sv.In(MakeVT(int32_t(0))));
+    EXPECT_FALSE(sv.In(MakeVT(int32_t(6))));
+}
+
+TEST(SortVectorElementTest, StringWithStringView) {
+    SortVectorElement<std::string> sv(
+        std::vector<std::string>{"cherry", "apple", "banana"});
+    EXPECT_TRUE(sv.In(MakeVT(std::string("apple"))));
+    EXPECT_TRUE(sv.In(MakeVT(std::string_view("banana"))));
+    EXPECT_FALSE(sv.In(MakeVT(std::string("grape"))));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// FlatVectorElement tests
+// Production usage: TermExpr index path creates FlatVectorElement with
+// IndexInnerType or uint8_t (for bool). Only In() and direct values_ access
+// are used. GetElements()/Size() are part of MultiElement interface but
+// not called directly in production.
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(FlatVectorElementTest, Basic) {
+    FlatVectorElement<int64_t> fv(std::vector<int64_t>{10, 20, 30});
+    EXPECT_TRUE(fv.In(MakeVT(int64_t(10))));
+    EXPECT_TRUE(fv.In(MakeVT(int64_t(30))));
+    EXPECT_FALSE(fv.In(MakeVT(int64_t(15))));
+}
+
+TEST(FlatVectorElementTest, DirectValuesAccess) {
+    // Production code accesses values_ directly (TermExpr.cpp:938,971)
+    FlatVectorElement<int32_t> fv(std::vector<int32_t>{10, 20, 30});
+    EXPECT_EQ(fv.values_.size(), 3);
+    EXPECT_EQ(fv.values_[0], 10);
+}
+
+// SetElement<bool> uses a specialized two-flag implementation (has_true_/
+// has_false_) to avoid ankerl::unordered_dense::set<bool> whose wyhash
+// reads 8 bytes from a 1-byte bool, causing ASAN stack-use-after-scope.
+
+TEST(SetElementBoolTest, GenericHashSet) {
+    SetElement<bool> se(std::vector<bool>{true, false});
+    EXPECT_TRUE(se.In(MakeVT(true)));
+    EXPECT_TRUE(se.In(MakeVT(false)));
+    EXPECT_EQ(se.Size(), 2);
+}
+
+TEST(SetElementBoolTest, GenericHashSetSingleTrue) {
+    SetElement<bool> se(std::vector<bool>{true});
+    EXPECT_TRUE(se.In(MakeVT(true)));
+    EXPECT_FALSE(se.In(MakeVT(false)));
+}
+
+TEST(SetElementBoolTest, GenericHashSetEmpty) {
+    SetElement<bool> se(std::vector<bool>{});
+    EXPECT_TRUE(se.Empty());
+}
+
+// Test the GenericValue constructor — this is the path used by
+// JsonContainsExpr::ExecJsonContains<bool> (the e2e crash path).
+TEST(SetElementBoolTest, FromGenericValue) {
+    using GV = milvus::proto::plan::GenericValue;
+    GV gv_true, gv_false;
+    gv_true.set_bool_val(true);
+    gv_false.set_bool_val(false);
+
+    SetElement<bool> se(std::vector<GV>{gv_true, gv_false});
+    EXPECT_TRUE(se.In(MakeVT(true)));
+    EXPECT_TRUE(se.In(MakeVT(false)));
+    EXPECT_EQ(se.Size(), 2);
+}
+
+TEST(SetElementBoolTest, FromGenericValueSingleTrue) {
+    using GV = milvus::proto::plan::GenericValue;
+    GV gv_true;
+    gv_true.set_bool_val(true);
+
+    SetElement<bool> se(std::vector<GV>{gv_true});
+    EXPECT_TRUE(se.In(MakeVT(true)));
+    EXPECT_FALSE(se.In(MakeVT(false)));
+    EXPECT_EQ(se.Size(), 1);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SingleElement tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(SingleElementTest, SetAndGetInt64) {
+    SingleElement se;
+    se.SetValue<int64_t>(int64_t(42));
+    EXPECT_EQ(se.GetValue<int64_t>(), 42);
+}
+
+TEST(SingleElementTest, SetAndGetString) {
+    SingleElement se;
+    se.SetValue<std::string>(std::string("hello"));
+    EXPECT_EQ(se.GetValue<std::string>(), "hello");
+}
+
+TEST(SingleElementTest, SetAndGetDouble) {
+    SingleElement se;
+    se.SetValue<double>(3.14);
+    EXPECT_DOUBLE_EQ(se.GetValue<double>(), 3.14);
+}
+
+// SetElement<bool> specialization uses has_true_/has_false_ flags.
+// GetElements() returns [true] and/or [false] based on flags.
+
+// ═══════════════════════════════════════════════════════════════════════════
+// P1: SimdBatchElement dedup — duplicates in IN list should be removed
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(FilterChunkTest, DeduplicatedFilterChunk) {
+    // Go rewriter pre-sorts and deduplicates; test with sorted unique vals
+    std::vector<int32_t> vals = {7, 42};
+    std::vector<int32_t> data(128);
+    std::iota(data.begin(), data.end(), 0);
+    VerifyFilterChunk(vals, data, "DeduplicatedFilterChunk");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// P1: FilterChunk OR-only semantic — only sets bits, never clears
+//
+// FilterChunk assumes the bitmap is zero-initialized and only sets bits
+// to true. If bits are already set, they must be preserved (OR semantic).
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(FilterChunkTest, PreservesExistingTrueBits) {
+    std::vector<int32_t> in_vals = {42};
+    std::vector<int32_t> data = {1, 2, 3, 42, 5, 6, 7, 8};
+    const int n = static_cast<int>(data.size());
+
+    milvus::TargetBitmap bm(n, false);
+    milvus::TargetBitmapView view(bm.data(), n);
+
+    // Pre-set some bits that are NOT in the IN list
+    view[0] = true;  // data[0]=1, not in IN list
+    view[2] = true;  // data[2]=3, not in IN list
+
+    SimdBatchElement<int32_t> sb(in_vals);
+    sb.FilterChunk(data.data(), n, view);
+
+    // Pre-set bits should be preserved (OR semantic)
+    EXPECT_TRUE(view[0]) << "pre-set bit at index 0 should be preserved";
+    EXPECT_TRUE(view[2]) << "pre-set bit at index 2 should be preserved";
+    // Matched value should be set
+    EXPECT_TRUE(view[3]) << "data[3]=42 should match";
+    // Unmatched, non-pre-set should remain false
+    EXPECT_FALSE(view[1]) << "data[1]=2 should not match";
+    EXPECT_FALSE(view[4]) << "data[4]=5 should not match";
+}
+
+TEST(FilterChunkTest, PreservesExistingTrueBitsFloat) {
+    std::vector<float> in_vals = {1.0f};
+    std::vector<float> data = {0.0f, 1.0f, 2.0f, 3.0f};
+    const int n = 4;
+
+    milvus::TargetBitmap bm(n, false);
+    milvus::TargetBitmapView view(bm.data(), n);
+    view[2] = true;  // pre-set, not a match
+
+    SimdBatchElement<float> sb(in_vals);
+    sb.FilterChunk(data.data(), n, view);
+
+    EXPECT_FALSE(view[0]);
+    EXPECT_TRUE(view[1]);  // matched
+    EXPECT_TRUE(view[2]);  // preserved
+    EXPECT_FALSE(view[3]);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// P1: Adversarial string prefix test — CheapStringHash correctness
+//
+// 1000 strings with identical first 8 bytes. After removing is_avalanching,
+// ankerl's mixer produces distinct fingerprints, preventing O(N) probe.
+// This test validates correctness (not performance) under collision.
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(SetElementStringTest, AdversarialPrefixLarge) {
+    // 1000 strings with identical first 8 bytes and same length
+    std::string prefix(8, 'X');
+    std::vector<std::string> vals;
+    for (int i = 0; i < 1000; ++i) {
+        // Pad to same length (20 chars) to make CheapStringHash
+        // produce identical hash values for all (prefix + length match)
+        std::string s = prefix + std::to_string(10000 + i);
+        vals.push_back(s);
+    }
+
+    SetElement<std::string> fh(vals);
+    EXPECT_EQ(fh.Size(), 1000);
+
+    // All inserted values must be found
+    for (auto& v : vals) {
+        EXPECT_TRUE(fh.In(MakeVT(v))) << "should find: " << v;
+    }
+
+    // Values NOT in the set must not be found (even with same prefix)
+    for (int i = 1000; i < 1100; ++i) {
+        std::string s = prefix + std::to_string(10000 + i);
+        EXPECT_FALSE(fh.In(MakeVT(s))) << "should not find: " << s;
+    }
+}
+
+TEST(SetElementStringTest, AdversarialSameHashSameLength) {
+    // All strings have identical first 8 bytes AND identical length.
+    // CheapStringHash produces exactly the same hash for all of them.
+    // Without the ankerl mixer (is_avalanching removed), the fingerprints
+    // should still differentiate thanks to wyhash mixing.
+    constexpr int kCount = 500;
+    constexpr int kStrLen = 16;
+    std::string base(kStrLen, 'Z');
+
+    std::vector<std::string> vals;
+    for (int i = 0; i < kCount; ++i) {
+        std::string s = base;
+        // Encode i into bytes 8-11 (beyond the 8-byte hash window)
+        auto suffix = std::to_string(i);
+        for (size_t j = 0; j < suffix.size() && 8 + j < s.size(); ++j) {
+            s[8 + j] = suffix[j];
+        }
+        vals.push_back(s);
+    }
+
+    SetElement<std::string> fh(vals);
+    EXPECT_EQ(fh.Size(), kCount);
+
+    // Cross-validate against SetElement<string> (known-correct, uses wyhash)
+    SetElement<std::string> se(vals);
+    for (auto& v : vals) {
+        EXPECT_TRUE(fh.In(MakeVT(v))) << "FixedHash should find: " << v;
+        EXPECT_TRUE(se.In(MakeVT(v))) << "SetElement should find: " << v;
+    }
+
+    // Probe with non-existent same-prefix strings
+    for (int i = kCount; i < kCount + 100; ++i) {
+        std::string s = base;
+        auto suffix = std::to_string(i);
+        for (size_t j = 0; j < suffix.size() && 8 + j < s.size(); ++j) {
+            s[8 + j] = suffix[j];
+        }
+        EXPECT_EQ(fh.In(MakeVT(s)), se.In(MakeVT(s)))
+            << "Disagreement for: " << s;
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Type boundary value tests — INT_MIN, INT_MAX, FLT_MAX, denormals, -0.0
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(SimdBatchElementTest, Int8Boundaries) {
+    std::vector<int8_t> vals = {INT8_MIN, -1, 0, 1, INT8_MAX};
+    SimdBatchElement<int8_t> sb(vals);
+    for (auto v : vals) {
+        EXPECT_TRUE(sb.In(MakeVT(v))) << "Missing: " << (int)v;
+    }
+    EXPECT_FALSE(sb.In(MakeVT(int8_t(2))));
+}
+
+TEST(SimdBatchElementTest, Int16Boundaries) {
+    std::vector<int16_t> vals = {INT16_MIN, -1, 0, 1, INT16_MAX};
+    SimdBatchElement<int16_t> sb(vals);
+    for (auto v : vals) {
+        EXPECT_TRUE(sb.In(MakeVT(v))) << "Missing: " << v;
+    }
+    EXPECT_FALSE(sb.In(MakeVT(int16_t(2))));
+}
+
+TEST(SimdBatchElementTest, Int32Boundaries) {
+    std::vector<int32_t> vals = {INT32_MIN, -1, 0, 1, INT32_MAX};
+    SimdBatchElement<int32_t> sb(vals);
+    for (auto v : vals) {
+        EXPECT_TRUE(sb.In(MakeVT(v))) << "Missing: " << v;
+    }
+    EXPECT_FALSE(sb.In(MakeVT(int32_t(2))));
+}
+
+TEST(SimdBatchElementTest, Int64Boundaries) {
+    std::vector<int64_t> vals = {INT64_MIN, -1, 0, 1, INT64_MAX};
+    SimdBatchElement<int64_t> sb(vals);
+    for (auto v : vals) {
+        EXPECT_TRUE(sb.In(MakeVT(v))) << "Missing: " << v;
+    }
+    EXPECT_FALSE(sb.In(MakeVT(int64_t(2))));
+}
+
+TEST(SimdBatchElementTest, FloatSpecialValues) {
+    // Pre-sorted; -0.0 and 0.0 compare equal in IEEE 754
+    std::vector<float> vals = {
+        std::numeric_limits<float>::lowest(),
+        0.0f,
+        std::numeric_limits<float>::denorm_min(),  // smallest positive denormal
+        std::numeric_limits<float>::min(),         // smallest positive normal
+        std::numeric_limits<float>::max(),
+    };
+    SimdBatchElement<float> sb(vals);
+    EXPECT_TRUE(sb.In(MakeVT(0.0f)));
+    EXPECT_TRUE(sb.In(MakeVT(-0.0f)));  // -0.0 == 0.0
+    EXPECT_TRUE(sb.In(MakeVT(std::numeric_limits<float>::max())));
+    EXPECT_TRUE(sb.In(MakeVT(std::numeric_limits<float>::lowest())));
+    EXPECT_TRUE(sb.In(MakeVT(std::numeric_limits<float>::min())));
+    EXPECT_TRUE(sb.In(MakeVT(std::numeric_limits<float>::denorm_min())));
+    EXPECT_FALSE(sb.In(MakeVT(1.0f)));
+}
+
+TEST(SimdBatchElementTest, DoubleSpecialValues) {
+    // Pre-sorted; -0.0 and 0.0 compare equal in IEEE 754
+    std::vector<double> vals = {std::numeric_limits<double>::lowest(),
+                                0.0,
+                                std::numeric_limits<double>::denorm_min(),
+                                std::numeric_limits<double>::min(),
+                                std::numeric_limits<double>::max()};
+    SimdBatchElement<double> sb(vals);
+    EXPECT_TRUE(sb.In(MakeVT(0.0)));
+    EXPECT_TRUE(sb.In(MakeVT(-0.0)));
+    EXPECT_TRUE(sb.In(MakeVT(std::numeric_limits<double>::max())));
+    EXPECT_TRUE(sb.In(MakeVT(std::numeric_limits<double>::lowest())));
+    EXPECT_FALSE(sb.In(MakeVT(1.0)));
+}
+
+// Boundary values through FilterChunk
+TEST(FilterChunkTest, Int32BoundaryValues) {
+    std::vector<int32_t> in_vals = {INT32_MIN, 0, INT32_MAX};
+    std::vector<int32_t> data = {
+        INT32_MIN, INT32_MIN + 1, -1, 0, 1, INT32_MAX - 1, INT32_MAX};
+    VerifyFilterChunk(in_vals, data, "Int32Boundary");
+}
+
+TEST(FilterChunkTest, FloatBoundaryValues) {
+    float fmax = std::numeric_limits<float>::max();
+    float fmin = std::numeric_limits<float>::lowest();
+    std::vector<float> in_vals = {fmin, -0.0f, 0.0f, fmax};
+    std::vector<float> data = {fmax, fmin, 0.0f, -0.0f, 1.0f, -1.0f};
+    VerifyFilterChunk(in_vals, data, "FloatBoundary");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// FilterChunk edge cases
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(FilterChunkTest, SizeZero) {
+    std::vector<int32_t> in_vals = {1, 2, 3};
+    SimdBatchElement<int32_t> sb(in_vals);
+    milvus::TargetBitmap bm(0, false);
+    milvus::TargetBitmapView view(bm.data(), 0);
+    // Should not crash with size=0
+    sb.FilterChunk(static_cast<const int32_t*>(nullptr), 0, view);
+}
+
+TEST(FilterChunkTest, SizeOne) {
+    std::vector<int32_t> in_vals = {42};
+    std::vector<int32_t> data = {42};
+    VerifyFilterChunk(in_vals, data, "SizeOne");
+}
+
+TEST(FilterChunkTest, AllSameDataAllMatch) {
+    // All data elements are the same value and it's in IN list
+    std::vector<int32_t> in_vals = {7, 8, 9};
+    std::vector<int32_t> data(256, 7);
+    VerifyFilterChunk(in_vals, data, "AllSameDataAllMatch");
+}
+
+TEST(FilterChunkTest, AllSameDataNoMatch) {
+    std::vector<int32_t> in_vals = {1, 2, 3};
+    std::vector<int32_t> data(256, 99);
+    VerifyFilterChunk(in_vals, data, "AllSameDataNoMatch");
+}
+
+TEST(FilterChunkTest, LargeInListNearThreshold) {
+    // IN list size = 63 (just below kSimdThreshold=64), still uses SIMD path
+    constexpr int kInSize = 63;
+    std::vector<int32_t> in_vals(kInSize);
+    for (int i = 0; i < kInSize; ++i) {
+        in_vals[i] = i * 3;  // 0, 3, 6, 9, ...
+    }
+    std::vector<int32_t> data(2048);
+    std::iota(data.begin(), data.end(), 0);
+    VerifyFilterChunk(in_vals, data, "LargeInListNearThreshold");
+}
+
+TEST(FilterChunkTest, SingleINValueAllTypes) {
+    // Regression: single-element IN list across all types
+    {
+        std::vector<int8_t> data = {0, 1, 2, 3, 4, 5};
+        VerifyFilterChunk<int8_t>({int8_t(3)}, data, "SingleIN_int8");
+    }
+    {
+        std::vector<int16_t> data = {0, 1, 2, 3, 4, 5};
+        VerifyFilterChunk<int16_t>({int16_t(3)}, data, "SingleIN_int16");
+    }
+    {
+        std::vector<double> data = {0.0, 1.0, 2.0, 3.0};
+        VerifyFilterChunk<double>({3.0}, data, "SingleIN_double");
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Wrong-type variant — In() should return false for type mismatch
+// ═══════════════════════════════════════════════════════════════════════════
+
+// SimdBatchElement does not check variant type — production code
+// guarantees correct type via std::in_place_type<T>.
+
+TEST(SetElementTest, WrongTypeVariant) {
+    SetElement<int64_t> se(std::vector<int64_t>{42});
+    EXPECT_TRUE(se.In(MakeVT(int64_t(42))));
+    EXPECT_FALSE(se.In(MakeVT(int32_t(42))));
+    EXPECT_FALSE(se.In(MakeVT(float(42.0f))));
+    EXPECT_FALSE(se.In(MakeVT(std::monostate{})));
+}
+
+TEST(SortVectorElementTest, WrongTypeVariant) {
+    SortVectorElement<int32_t> sv(std::vector<int32_t>{10});
+    EXPECT_TRUE(sv.In(MakeVT(int32_t(10))));
+    EXPECT_FALSE(sv.In(MakeVT(int64_t(10))));
+    EXPECT_FALSE(sv.In(MakeVT(std::monostate{})));
+}
+
+TEST(FlatVectorElementTest, WrongTypeVariant) {
+    FlatVectorElement<int64_t> fv(std::vector<int64_t>{5});
+    EXPECT_TRUE(fv.In(MakeVT(int64_t(5))));
+    EXPECT_FALSE(fv.In(MakeVT(int32_t(5))));
+    EXPECT_FALSE(fv.In(MakeVT(std::monostate{})));
+}
+
+// Production uses FlatVectorElement<uint8_t> for bool index path
+TEST(FlatVectorElementTest, Uint8ForBoolIndex) {
+    FlatVectorElement<uint8_t> fv(std::vector<uint8_t>{1, 0});
+    EXPECT_TRUE(fv.In(MakeVT(uint8_t(1))));
+    EXPECT_TRUE(fv.In(MakeVT(uint8_t(0))));
+    EXPECT_FALSE(fv.In(MakeVT(uint8_t(2))));
+    EXPECT_EQ(fv.values_.size(), 2);
+    EXPECT_EQ(fv.values_[0], 1);
+    EXPECT_EQ(fv.values_[1], 0);
+}
+
+TEST(SetElementStringTest, WrongTypeVariant) {
+    SetElement<std::string> fh(std::vector<std::string>{"hello"});
+    EXPECT_TRUE(fh.In(MakeVT(std::string("hello"))));
+    EXPECT_TRUE(fh.In(MakeVT(std::string_view("hello"))));
+    EXPECT_FALSE(fh.In(MakeVT(int32_t(0))));
+    EXPECT_FALSE(fh.In(MakeVT(bool(true))));
+    EXPECT_FALSE(fh.In(MakeVT(std::monostate{})));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SetElement<string> — direct tests with string_view heterogeneous lookup
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(SetElementTest, StringWithStringView) {
+    SetElement<std::string> se(
+        std::vector<std::string>{"alpha", "beta", "gamma"});
+    EXPECT_TRUE(se.In(MakeVT(std::string("alpha"))));
+    EXPECT_TRUE(se.In(MakeVT(std::string_view("beta"))));
+    EXPECT_FALSE(se.In(MakeVT(std::string("delta"))));
+    EXPECT_FALSE(se.In(MakeVT(std::string_view("ALPHA"))));
+}
+
+TEST(SetElementTest, DeduplicatesOnInsert) {
+    SetElement<int32_t> se(std::vector<int32_t>{1, 2, 2, 3, 3, 3});
+    EXPECT_EQ(se.Size(), 3);
+}
+
+TEST(SetElementTest, StringDeduplicates) {
+    SetElement<std::string> se(std::vector<std::string>{"dup", "dup", "other"});
+    EXPECT_EQ(se.Size(), 2);
+}
+
+TEST(SetElementTest, EmptyAndSize) {
+    SetElement<int32_t> empty_se(std::vector<int32_t>{});
+    EXPECT_TRUE(empty_se.Empty());
+    EXPECT_EQ(empty_se.Size(), 0);
+
+    SetElement<int32_t> non_empty(std::vector<int32_t>{1});
+    EXPECT_FALSE(non_empty.Empty());
+    EXPECT_EQ(non_empty.Size(), 1);
+}
+
+TEST(SetElementTest, GetElementsInt) {
+    SetElement<int32_t> se(std::vector<int32_t>{3, 1, 2});
+    auto elems = se.GetElements();
+    std::sort(elems.begin(), elems.end());
+    EXPECT_EQ(elems, (std::vector<int32_t>{1, 2, 3}));
+}
+
+TEST(SetElementTest, GetElementsString) {
+    SetElement<std::string> se(std::vector<std::string>{"z", "a", "m"});
+    auto elems = se.GetElements();
+    std::sort(elems.begin(), elems.end());
+    EXPECT_EQ(elems, (std::vector<std::string>{"a", "m", "z"}));
+}
+
+// Generic hash set deduplicates on insert.
+TEST(SetElementBoolTest, GenericDeduplicates) {
+    SetElement<bool> se(std::vector<bool>{true, true, true});
+    EXPECT_EQ(se.Size(), 1);
+    EXPECT_TRUE(se.In(MakeVT(true)));
+    EXPECT_FALSE(se.In(MakeVT(false)));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SortVectorElement — via constructor (production path)
+// Production: JsonContainsExpr always constructs with full vector
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(SortVectorElementTest, EmptyAndSize) {
+    SortVectorElement<int32_t> sv(std::vector<int32_t>{});
+    EXPECT_TRUE(sv.Empty());
+    EXPECT_EQ(sv.Size(), 0);
+}
+
+TEST(SortVectorElementTest, LargeList) {
+    std::vector<int32_t> vals(1000);
+    for (int i = 0; i < 1000; ++i) vals[i] = 1000 - i;  // reverse order
+    SortVectorElement<int32_t> sv(vals);
+    for (int v : {1, 500, 1000}) {
+        EXPECT_TRUE(sv.In(MakeVT(int32_t(v))));
+    }
+    EXPECT_FALSE(sv.In(MakeVT(int32_t(0))));
+    EXPECT_FALSE(sv.In(MakeVT(int32_t(1001))));
+}
+
+TEST(SortVectorElementTest, GetElements) {
+    SortVectorElement<int32_t> sv(std::vector<int32_t>{30, 10, 20});
+    auto elems = sv.GetElements();
+    EXPECT_EQ(elems, (std::vector<int32_t>{10, 20, 30}));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SetElement<std::string> — GetElements, direct CheapStringHash boundary tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(SetElementStringTest, GetElements) {
+    SetElement<std::string> fh(std::vector<std::string>{"z", "a", "m"});
+    auto elems = fh.GetElements();
+    std::sort(elems.begin(), elems.end());
+    EXPECT_EQ(elems, (std::vector<std::string>{"a", "m", "z"}));
+}
+
+TEST(SetElementStringTest, BoundaryStringLengths) {
+    // Test strings of length 0, 1, 7, 8, 9 — around the 8-byte hash window
+    std::vector<std::string> vals = {
+        "",           // 0 bytes
+        "a",          // 1 byte
+        "1234567",    // 7 bytes
+        "12345678",   // exactly 8 bytes
+        "123456789",  // 9 bytes (1 byte beyond hash window)
+    };
+    SetElement<std::string> fh(vals);
+    EXPECT_EQ(fh.Size(), 5);
+    for (auto& v : vals) {
+        EXPECT_TRUE(fh.In(MakeVT(v))) << "Missing: '" << v << "'";
+    }
+    // Near-misses
+    EXPECT_FALSE(fh.In(MakeVT(std::string("b"))));
+    EXPECT_FALSE(fh.In(MakeVT(std::string("1234567x"))));   // differ at byte 7
+    EXPECT_FALSE(fh.In(MakeVT(std::string("12345679"))));   // differ at byte 8
+    EXPECT_FALSE(fh.In(MakeVT(std::string("12345678x"))));  // differ beyond 8
+}
+
+TEST(SetElementStringTest, StringViewLookup) {
+    SetElement<std::string> fh(std::vector<std::string>{"hello", "world"});
+    EXPECT_TRUE(fh.In(MakeVT(std::string_view("hello"))));
+    EXPECT_TRUE(fh.In(MakeVT(std::string_view("world"))));
+    EXPECT_FALSE(fh.In(MakeVT(std::string_view("HELLO"))));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// GetElementValues<bool> — through SetElement<bool>
+// ═══════════════════════════════════════════════════════════════════════════
+
+// GetElementValues<bool> works with the SetElement<bool> specialization.
+TEST(GetElementValuesTest, FromSetElementBool) {
+    auto elem =
+        std::make_shared<SetElement<bool>>(std::vector<bool>{true, false});
+    auto result =
+        GetElementValues<bool>(std::static_pointer_cast<MultiElement>(elem));
+    EXPECT_EQ(result.size(), 2);
+}
+
+TEST(GetElementValuesTest, NullptrReturnsEmpty) {
+    auto result = GetElementValues<int32_t>(nullptr);
+    EXPECT_TRUE(result.empty());
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SetElement<T>::FilterChunk — batch hash lookup without variant overhead
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(SetElementFilterChunkTest, Int32) {
+    std::vector<int32_t> in_vals = {-1, 0, 1, 42, 999};
+    SetElement<int32_t> se(in_vals);
+
+    std::vector<int32_t> data = {-1, 2, 0, 42, 100, 999, -2, 1};
+    const int n = static_cast<int>(data.size());
+    milvus::TargetBitmap bm(n, false);
+    milvus::TargetBitmapView view(bm.data(), n);
+    se.FilterChunk(data.data(), n, view);
+
+    // Expected: indices 0(-1), 2(0), 3(42), 5(999), 7(1) match
+    EXPECT_TRUE(view[0]);
+    EXPECT_FALSE(view[1]);
+    EXPECT_TRUE(view[2]);
+    EXPECT_TRUE(view[3]);
+    EXPECT_FALSE(view[4]);
+    EXPECT_TRUE(view[5]);
+    EXPECT_FALSE(view[6]);
+    EXPECT_TRUE(view[7]);
+}
+
+TEST(SetElementFilterChunkTest, Int64) {
+    std::vector<int64_t> in_vals = {100, 200, 300};
+    SetElement<int64_t> se(in_vals);
+
+    std::vector<int64_t> data = {100, 101, 200, 201, 300};
+    const int n = static_cast<int>(data.size());
+    milvus::TargetBitmap bm(n, false);
+    milvus::TargetBitmapView view(bm.data(), n);
+    se.FilterChunk(data.data(), n, view);
+
+    EXPECT_TRUE(view[0]);
+    EXPECT_FALSE(view[1]);
+    EXPECT_TRUE(view[2]);
+    EXPECT_FALSE(view[3]);
+    EXPECT_TRUE(view[4]);
+}
+
+TEST(SetElementFilterChunkTest, StringDirect) {
+    std::vector<std::string> in_vals = {"hello", "world", "foo"};
+    SetElement<std::string> se(in_vals);
+
+    std::vector<std::string> data = {"hello", "bar", "world", "baz", "foo"};
+    const int n = static_cast<int>(data.size());
+    milvus::TargetBitmap bm(n, false);
+    milvus::TargetBitmapView view(bm.data(), n);
+    se.FilterChunk(data.data(), n, view);
+
+    EXPECT_TRUE(view[0]);
+    EXPECT_FALSE(view[1]);
+    EXPECT_TRUE(view[2]);
+    EXPECT_FALSE(view[3]);
+    EXPECT_TRUE(view[4]);
+}
+
+TEST(SetElementFilterChunkTest, StringViewData) {
+    std::vector<std::string> in_vals = {"alpha", "beta"};
+    SetElement<std::string> se(in_vals);
+
+    // Simulate sealed segment: data is string_view array
+    std::string backing[] = {"alpha", "gamma", "beta", "delta"};
+    std::vector<std::string_view> data;
+    for (auto& s : backing) data.push_back(s);
+
+    const int n = static_cast<int>(data.size());
+    milvus::TargetBitmap bm(n, false);
+    milvus::TargetBitmapView view(bm.data(), n);
+    se.FilterChunk(data.data(), n, view);
+
+    EXPECT_TRUE(view[0]);   // alpha
+    EXPECT_FALSE(view[1]);  // gamma
+    EXPECT_TRUE(view[2]);   // beta
+    EXPECT_FALSE(view[3]);  // delta
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// FlatVectorElement<string> — small IN linear scan correctness
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(FlatVectorElementTest, StringSmallIN) {
+    std::vector<std::string> in_vals = {"a", "bb", "ccc"};
+    FlatVectorElement<std::string> fv(in_vals);
+
+    EXPECT_TRUE(fv.In(MakeVT(std::string("a"))));
+    EXPECT_TRUE(fv.In(MakeVT(std::string("bb"))));
+    EXPECT_TRUE(fv.In(MakeVT(std::string("ccc"))));
+    EXPECT_FALSE(fv.In(MakeVT(std::string("d"))));
+    EXPECT_FALSE(fv.In(MakeVT(std::string(""))));
+}
+
+TEST(FlatVectorElementTest, StringViewLookup) {
+    std::vector<std::string> in_vals = {"hello", "world"};
+    FlatVectorElement<std::string> fv(in_vals);
+
+    // string_view lookup
+    EXPECT_TRUE(fv.In(MakeVT(std::string_view("hello"))));
+    EXPECT_FALSE(fv.In(MakeVT(std::string_view("other"))));
+}
+
+TEST(FlatVectorElementTest, Empty) {
+    FlatVectorElement<std::string> fv(std::vector<std::string>{});
+    EXPECT_TRUE(fv.Empty());
+    EXPECT_FALSE(fv.In(MakeVT(std::string("x"))));
+}
+
+TEST(FlatVectorElementTest, SingleValue) {
+    FlatVectorElement<std::string> fv(std::vector<std::string>{"only"});
+    EXPECT_EQ(fv.Size(), 1);
+    EXPECT_TRUE(fv.In(MakeVT(std::string("only"))));
+    EXPECT_FALSE(fv.In(MakeVT(std::string("other"))));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SimdBatchElement — all-duplicates IN list
+// ═══════════════════════════════════════════════════════════════════════════
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SingleElement — additional type coverage
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(SingleElementTest, SetAndGetInt8) {
+    SingleElement se;
+    se.SetValue<int8_t>(int8_t(-128));
+    EXPECT_EQ(se.GetValue<int8_t>(), -128);
+}
+
+TEST(SingleElementTest, SetAndGetFloat) {
+    SingleElement se;
+    se.SetValue<float>(1.5f);
+    EXPECT_FLOAT_EQ(se.GetValue<float>(), 1.5f);
+}
+
+TEST(SingleElementTest, SetAndGetBool) {
+    SingleElement se;
+    se.SetValue<bool>(true);
+    EXPECT_EQ(se.GetValue<bool>(), true);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Remainder loop coverage — data size that is NOT a multiple of kStep
+// but IS a multiple of kLanes + some extra.
+//
+// When kUnroll > 1, the code has three loops:
+//   1. Main loop:      processes kStep elements per iteration
+//   2. Remainder loop: processes kLanes elements per iteration
+//   3. Scalar tail:    processes 1 element per iteration
+//
+// These tests ensure the remainder loop is exercised for every type.
+// ═══════════════════════════════════════════════════════════════════════════
+
+// Helper: compute kStep for a given type (same logic as FilterChunk)
+template <typename T>
+constexpr int
+GetKStep() {
+    constexpr int kLanes = xsimd::batch<T>::size;
+    constexpr int kMaxUnroll = 8;
+    constexpr int kIdealUnroll = (kLanes >= 64) ? 1 : 64 / kLanes;
+    constexpr int kUnroll =
+        (kIdealUnroll <= kMaxUnroll) ? kIdealUnroll : kMaxUnroll;
+    return kLanes * kUnroll;
+}
+
+template <typename T>
+void
+VerifyRemainderLoop(const std::string& label) {
+    constexpr int kLanes = xsimd::batch<T>::size;
+    constexpr int kStep = GetKStep<T>();
+
+    // Data size = kStep + kLanes + 3 (exercises main + remainder + scalar)
+    const int data_size = kStep + kLanes + 3;
+    std::mt19937 rng(42);
+
+    std::vector<T> data(data_size);
+    if constexpr (std::is_floating_point_v<T>) {
+        for (int i = 0; i < data_size; ++i) data[i] = static_cast<T>(i);
+    } else {
+        for (int i = 0; i < data_size; ++i)
+            data[i] = static_cast<T>(i % 256 - 128);
+    }
+
+    // IN values that hit across all three loop sections
+    std::vector<T> in_vals;
+    in_vals.push_back(data[0]);               // in main loop
+    in_vals.push_back(data[kStep]);           // in remainder loop
+    in_vals.push_back(data[kStep + kLanes]);  // in scalar tail
+    in_vals.push_back(data[data_size - 1]);   // last element (scalar tail)
+
+    VerifyFilterChunk(in_vals, data, label + " remainder");
+
+    // Also test with larger IN list to stress remainder with more comparisons
+    std::vector<T> big_in;
+    for (int i = 0; i < 30; ++i) {
+        big_in.push_back(data[i * data_size / 30]);
+    }
+    VerifyFilterChunk(big_in, data, label + " remainder_big_IN");
+
+    // Test data size = kStep * 2 + kLanes * (kUnroll - 1) + kLanes/2
+    // This maximizes remainder iterations: kUnroll - 1 remainder steps.
+    constexpr int kUnroll = kStep / kLanes;
+    if constexpr (kUnroll > 1) {
+        const int max_remainder_size =
+            kStep * 2 + kLanes * (kUnroll - 1) + kLanes / 2;
+        std::vector<T> data2(max_remainder_size);
+        for (int i = 0; i < max_remainder_size; ++i) {
+            if constexpr (std::is_floating_point_v<T>)
+                data2[i] = static_cast<T>(i);
+            else
+                data2[i] = static_cast<T>(i % 256 - 128);
+        }
+        std::vector<T> in2 = {data2[0],
+                              data2[kStep * 2],
+                              data2[kStep * 2 + kLanes],
+                              data2[max_remainder_size - 1]};
+        VerifyFilterChunk(in2, data2, label + " max_remainder");
+    }
+}
+
+TEST(FilterChunkTest, RemainderLoop_Int8) {
+    VerifyRemainderLoop<int8_t>("int8");
+}
+
+TEST(FilterChunkTest, RemainderLoop_Int16) {
+    VerifyRemainderLoop<int16_t>("int16");
+}
+
+TEST(FilterChunkTest, RemainderLoop_Int32) {
+    VerifyRemainderLoop<int32_t>("int32");
+}
+
+TEST(FilterChunkTest, RemainderLoop_Int64) {
+    VerifyRemainderLoop<int64_t>("int64");
+}
+
+TEST(FilterChunkTest, RemainderLoop_Float) {
+    VerifyRemainderLoop<float>("float");
+}
+
+TEST(FilterChunkTest, RemainderLoop_Double) {
+    VerifyRemainderLoop<double>("double");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SIMD dispatch selection: verify SimdBatchElement vs SetElement choice
+// based on IN list size relative to simdLaneCount<T>() * 8 threshold.
+// ═══════════════════════════════════════════════════════════════════════════
+
+template <typename T>
+void
+VerifyDispatchChoice(const std::string& label) {
+    const size_t threshold =
+        static_cast<size_t>(milvus::exec::simdLaneCount<T>()) * 8;
+
+    // Below threshold → SimdBatchElement
+    {
+        std::vector<T> vals(threshold);
+        std::iota(vals.begin(), vals.end(), T(0));
+        auto ptr = std::make_shared<SimdBatchElement<T>>(vals);
+        // Verify it's actually a SimdBatchElement
+        ASSERT_NE(std::dynamic_pointer_cast<SimdBatchElement<T>>(ptr), nullptr)
+            << label << " below threshold should be SimdBatchElement";
+        // Verify FilterChunk correctness at threshold boundary
+        std::vector<T> data(256);
+        std::iota(data.begin(), data.end(), T(0));
+        VerifyFilterChunk(vals, data, label + " at_threshold");
+    }
+
+    // Above threshold → SetElement (hash)
+    {
+        std::vector<T> vals(threshold + 1);
+        std::iota(vals.begin(), vals.end(), T(0));
+        auto ptr = std::make_shared<SetElement<T>>(vals);
+        ASSERT_NE(std::dynamic_pointer_cast<SetElement<T>>(ptr), nullptr)
+            << label << " above threshold should be SetElement";
+    }
+}
+
+TEST(DispatchSelectionTest, Int8) {
+    VerifyDispatchChoice<int8_t>("int8");
+}
+
+TEST(DispatchSelectionTest, Int16) {
+    VerifyDispatchChoice<int16_t>("int16");
+}
+
+TEST(DispatchSelectionTest, Int32) {
+    VerifyDispatchChoice<int32_t>("int32");
+}
+
+TEST(DispatchSelectionTest, Int64) {
+    VerifyDispatchChoice<int64_t>("int64");
+}
+
+TEST(DispatchSelectionTest, Float) {
+    VerifyDispatchChoice<float>("float");
+}
+
+TEST(DispatchSelectionTest, Double) {
+    VerifyDispatchChoice<double>("double");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SetElement<string> FilterChunk with string_view — edge cases
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(SetElementFilterChunkTest, StringViewEmptyStrings) {
+    std::vector<std::string> in_vals = {""};
+    SetElement<std::string> se(in_vals);
+
+    std::string backing[] = {"", "notempty", ""};
+    std::vector<std::string_view> data;
+    for (auto& s : backing) data.push_back(s);
+
+    const int n = static_cast<int>(data.size());
+    milvus::TargetBitmap bm(n, false);
+    milvus::TargetBitmapView view(bm.data(), n);
+    se.FilterChunk(data.data(), n, view);
+
+    EXPECT_TRUE(view[0]);
+    EXPECT_FALSE(view[1]);
+    EXPECT_TRUE(view[2]);
+}
+
+TEST(SetElementFilterChunkTest, StringViewAllMatch) {
+    std::vector<std::string> in_vals = {"a", "b", "c"};
+    SetElement<std::string> se(in_vals);
+
+    std::string backing[] = {"a", "b", "c", "a", "b"};
+    std::vector<std::string_view> data;
+    for (auto& s : backing) data.push_back(s);
+
+    const int n = static_cast<int>(data.size());
+    milvus::TargetBitmap bm(n, false);
+    milvus::TargetBitmapView view(bm.data(), n);
+    se.FilterChunk(data.data(), n, view);
+
+    for (int i = 0; i < n; ++i) {
+        EXPECT_TRUE(view[i]) << "index " << i;
+    }
+}
+
+TEST(SetElementFilterChunkTest, StringViewNoneMatch) {
+    std::vector<std::string> in_vals = {"x", "y"};
+    SetElement<std::string> se(in_vals);
+
+    std::string backing[] = {"a", "b", "c"};
+    std::vector<std::string_view> data;
+    for (auto& s : backing) data.push_back(s);
+
+    const int n = static_cast<int>(data.size());
+    milvus::TargetBitmap bm(n, false);
+    milvus::TargetBitmapView view(bm.data(), n);
+    se.FilterChunk(data.data(), n, view);
+
+    for (int i = 0; i < n; ++i) {
+        EXPECT_FALSE(view[i]) << "index " << i;
+    }
+}
+
+TEST(SetElementFilterChunkTest, StringViewLongStrings) {
+    // Long strings to exercise hash quality beyond short-string optimization
+    std::string long1(256, 'a');
+    std::string long2(256, 'b');
+    std::string long3(256, 'c');
+    std::vector<std::string> in_vals = {long1, long3};
+    SetElement<std::string> se(in_vals);
+
+    std::string backing[] = {long1, long2, long3, long2};
+    std::vector<std::string_view> data;
+    for (auto& s : backing) data.push_back(s);
+
+    const int n = static_cast<int>(data.size());
+    milvus::TargetBitmap bm(n, false);
+    milvus::TargetBitmapView view(bm.data(), n);
+    se.FilterChunk(data.data(), n, view);
+
+    EXPECT_TRUE(view[0]);   // long1
+    EXPECT_FALSE(view[1]);  // long2
+    EXPECT_TRUE(view[2]);   // long3
+    EXPECT_FALSE(view[3]);  // long2
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Numeric FilterChunk: varying IN list sizes × data sizes
+// Cross-validates SimdBatchElement (SIMD) against SetElement (hash).
+// ═══════════════════════════════════════════════════════════════════════════
+
+template <typename T>
+void
+VerifyFilterChunkVaryingSizes(const std::string& label) {
+    const std::vector<int> in_sizes = {1, 2, 5, 16, 32, 60};
+    const std::vector<int> data_sizes = {1, 7, 64, 255, 1024, 4096};
+
+    for (int in_sz : in_sizes) {
+        std::vector<T> in_vals(in_sz);
+        for (int j = 0; j < in_sz; ++j) {
+            in_vals[j] = static_cast<T>(j * 7);  // spread out values
+        }
+        std::sort(in_vals.begin(), in_vals.end());
+
+        for (int data_sz : data_sizes) {
+            std::vector<T> data(data_sz);
+            for (int i = 0; i < data_sz; ++i) {
+                data[i] = static_cast<T>(i % 512);
+            }
+            VerifyFilterChunk(in_vals,
+                              data,
+                              label + " in=" + std::to_string(in_sz) +
+                                  " data=" + std::to_string(data_sz));
+        }
+    }
+}
+
+TEST(FilterChunkCrossTest, Int32VaryingSizes) {
+    VerifyFilterChunkVaryingSizes<int32_t>("int32");
+}
+
+TEST(FilterChunkCrossTest, Int64VaryingSizes) {
+    VerifyFilterChunkVaryingSizes<int64_t>("int64");
+}
+
+TEST(FilterChunkCrossTest, FloatVaryingSizes) {
+    VerifyFilterChunkVaryingSizes<float>("float");
+}

--- a/internal/core/src/exec/expression/ExprTermTest.cpp
+++ b/internal/core/src/exec/expression/ExprTermTest.cpp
@@ -455,3 +455,63 @@ TEST_P(ExprTest, TestTermNullable) {
         }
     }
 }
+
+// Verify that TermExpr supports TIMESTAMPTZ data type (stored as int64).
+// Before the fix, TermExpr.cpp had no case for DataType::TIMESTAMPTZ,
+// which caused "unsupported data type: TIMESTAMPTZ" when any term/IN
+// expression was executed on a Timestamptz field.
+TEST_P(ExprTest, TestTermTimestamptz) {
+    std::vector<std::tuple<std::string, std::function<bool(int64_t)>>>
+        testcases = {
+            {"ts in [100, 200]",
+             [](int64_t v) { return v == 100 || v == 200; }},
+            {"ts in [100]", [](int64_t v) { return v == 100; }},
+            {"ts in []", [](int64_t v) { return false; }},
+            {"ts in [0, 1, 2, 3, 4, 5]",
+             [](int64_t v) { return v >= 0 && v <= 5; }},
+        };
+
+    auto schema = std::make_shared<Schema>();
+    schema->AddDebugField("fakevec", data_type, 16, metric_type);
+    auto i64_fid = schema->AddDebugField("id", DataType::INT64);
+    auto ts_fid = schema->AddDebugField("ts", DataType::TIMESTAMPTZ);
+    schema->set_primary_field_id(i64_fid);
+
+    auto seg = CreateGrowingSegment(schema, empty_index_meta);
+    int N = 1000;
+    std::vector<int64_t> ts_col;
+    int num_iters = 1;
+    for (int iter = 0; iter < num_iters; ++iter) {
+        auto raw_data = DataGen(schema, N, iter);
+        auto new_ts_col = raw_data.get_col<int64_t>(ts_fid);
+        ts_col.insert(ts_col.end(), new_ts_col.begin(), new_ts_col.end());
+        seg->PreInsert(N);
+        seg->Insert(iter * N,
+                    N,
+                    raw_data.row_ids_.data(),
+                    raw_data.timestamps_.data(),
+                    raw_data.raw_);
+    }
+
+    auto seg_promote = dynamic_cast<SegmentGrowingImpl*>(seg.get());
+    SetSchema(schema);
+    for (auto [expr_str, ref_func] : testcases) {
+        auto plan_str = create_search_plan_from_expr(expr_str);
+        auto plan =
+            CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
+        BitsetType final;
+        final = ExecuteQueryExpr(
+            plan->plan_node_->plannodes_->sources()[0]->sources()[0],
+            seg_promote,
+            N * num_iters,
+            MAX_TIMESTAMP);
+        EXPECT_EQ(final.size(), N * num_iters);
+
+        for (int i = 0; i < N * num_iters; ++i) {
+            auto ans = final[i];
+            auto val = ts_col[i];
+            auto ref = ref_func(val);
+            ASSERT_EQ(ans, ref) << expr_str << "@" << i << "!!" << val;
+        }
+    }
+}

--- a/internal/core/src/exec/expression/JsonContainsExpr.cpp
+++ b/internal/core/src/exec/expression/JsonContainsExpr.cpp
@@ -330,7 +330,7 @@ PhyJsonContainsFilterExpr::ExecArrayContains(EvalCtx& context) {
     TargetBitmapView valid_res(res_vec->GetValidRawData(), real_batch_size);
 
     if (!arg_inited_) {
-        arg_set_ = std::make_shared<SortVectorElement<GetType>>(expr_->vals_);
+        arg_set_ = std::make_shared<SetElement<GetType>>(expr_->vals_);
         arg_inited_ = true;
     }
 
@@ -435,7 +435,7 @@ PhyJsonContainsFilterExpr::ExecJsonContains(EvalCtx& context) {
 
     auto pointer = milvus::Json::pointer(expr_->column_.nested_path_);
     if (!arg_inited_) {
-        arg_set_ = std::make_shared<SortVectorElement<GetType>>(expr_->vals_);
+        arg_set_ = std::make_shared<SetElement<GetType>>(expr_->vals_);
         arg_inited_ = true;
     }
 
@@ -542,18 +542,17 @@ PhyJsonContainsFilterExpr::ExecJsonContainsByStats() {
     std::unordered_set<GetType> elements;
     auto pointer = milvus::Json::pointer(expr_->column_.nested_path_);
     if (!arg_inited_) {
-        arg_set_ = std::make_shared<SortVectorElement<GetType>>(expr_->vals_);
+        arg_set_ = std::make_shared<SetElement<GetType>>(expr_->vals_);
         if constexpr (std::is_same_v<GetType, int64_t>) {
             // for int64_t, we need to a double vector to store the values
-            auto sort_arg_set =
-                std::dynamic_pointer_cast<SortVectorElement<int64_t>>(arg_set_);
+            auto int_arg_set =
+                std::dynamic_pointer_cast<SetElement<int64_t>>(arg_set_);
             std::vector<double> double_vals;
-            double_vals.reserve(sort_arg_set->GetElements().size());
-            for (const auto& val : sort_arg_set->GetElements()) {
+            double_vals.reserve(int_arg_set->GetElements().size());
+            for (const auto& val : int_arg_set->GetElements()) {
                 double_vals.emplace_back(static_cast<double>(val));
             }
-            arg_set_double_ =
-                std::make_shared<SortVectorElement<double>>(double_vals);
+            arg_set_double_ = std::make_shared<SetElement<double>>(double_vals);
         } else if constexpr (std::is_same_v<GetType, double>) {
             arg_set_double_ = arg_set_;
         }

--- a/internal/core/src/exec/expression/SimdFilter.cpp
+++ b/internal/core/src/exec/expression/SimdFilter.cpp
@@ -1,0 +1,241 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Runtime dispatcher + baseline SIMD implementation.
+//
+// Compiled with default flags (no extra -mavx2 etc.), so the baseline uses:
+//   x86-64 → SSE2 (always available)
+//   aarch64 → NEON (always available)
+//
+// At first call, detects CPU features and selects the best per-arch impl.
+// ═══════════════════════════════════════════════════════════════════════════
+
+#include "SimdFilter.h"
+#include "SimdFilterImpl.h"
+
+// ── CPU feature detection ───────────────────────────────────────────────
+
+#if defined(__x86_64__)
+#include <cpuid.h>
+
+// Read XCR0 via XGETBV to check which SIMD state the OS has enabled.
+// Without this, CPUID may report AVX/AVX-512 support but executing those
+// instructions will SIGILL in VMs or containers where the OS hasn't
+// enabled the corresponding state-save bits.
+static unsigned int
+xgetbv(unsigned int xcr) {
+    unsigned int eax, edx;
+    __asm__ volatile("xgetbv" : "=a"(eax), "=d"(edx) : "c"(xcr));
+    return eax;
+}
+
+static bool
+osSupportsAvx() {
+    unsigned int eax, ebx, ecx, edx;
+    // Check OSXSAVE (bit 27 of ECX from CPUID leaf 1)
+    if (!__get_cpuid(1, &eax, &ebx, &ecx, &edx)) {
+        return false;
+    }
+    if (!(ecx & (1u << 27))) {
+        return false;  // XGETBV not enabled by OS
+    }
+    // XCR0 bit 1 (SSE state) + bit 2 (AVX state)
+    unsigned int xcr0 = xgetbv(0);
+    return (xcr0 & 0x6) == 0x6;
+}
+
+static bool
+osSupportsAvx512() {
+    if (!osSupportsAvx()) {
+        return false;
+    }
+    // XCR0 bits 5 (opmask), 6 (ZMM_Hi256), 7 (Hi16_ZMM)
+    unsigned int xcr0 = xgetbv(0);
+    return (xcr0 & 0xE0) == 0xE0;
+}
+
+static bool
+hasAvx512bw() {
+    if (!osSupportsAvx512()) {
+        return false;
+    }
+    unsigned int eax, ebx, ecx, edx;
+    if (!__get_cpuid_count(7, 0, &eax, &ebx, &ecx, &edx)) {
+        return false;
+    }
+    // Must match flags in CMakeLists.txt: -mavx512f -mavx512bw -mavx512vl -mavx512dq
+    constexpr unsigned int kAvx512F = 1u << 16;
+    constexpr unsigned int kAvx512DQ = 1u << 17;
+    constexpr unsigned int kAvx512BW = 1u << 30;
+    constexpr unsigned int kAvx512VL = 1u << 31;
+    return (ebx & (kAvx512F | kAvx512DQ | kAvx512BW | kAvx512VL)) ==
+           (kAvx512F | kAvx512DQ | kAvx512BW | kAvx512VL);
+}
+
+static bool
+hasAvx2() {
+    if (!osSupportsAvx()) {
+        return false;
+    }
+    unsigned int eax, ebx, ecx, edx;
+    if (!__get_cpuid_count(7, 0, &eax, &ebx, &ecx, &edx)) {
+        return false;
+    }
+    return (ebx & (1u << 5));  // AVX2 = bit 5 of EBX
+}
+
+#endif
+
+// ── Baseline implementation (SSE2 / NEON) ───────────────────────────────
+
+namespace milvus {
+namespace exec {
+namespace baseline {
+
+// Explicitly use the guaranteed-available baseline arch so that this code
+// remains SSE2/NEON even if the project adds global -mavx2 flags.
+#if defined(__x86_64__)
+using Arch = xsimd::sse2;
+#elif defined(__aarch64__)
+using Arch = xsimd::neon64;
+#else
+using Arch = xsimd::default_arch;
+#endif
+
+template <typename T>
+void
+filterChunk(
+    const T* data, int size, uint8_t* bitmap, const T* vals, int num_vals) {
+    detail::filterChunkImpl<T, Arch>(data, size, bitmap, vals, num_vals);
+}
+
+template <typename T>
+int
+laneCount() {
+    return xsimd::batch<T, Arch>::size;
+}
+
+#define INSTANTIATE(T)                                                    \
+    template void filterChunk<T>(const T*, int, uint8_t*, const T*, int); \
+    template int laneCount<T>();
+
+INSTANTIATE(int8_t)
+INSTANTIATE(uint8_t)
+INSTANTIATE(int16_t)
+INSTANTIATE(int32_t)
+INSTANTIATE(int64_t)
+INSTANTIATE(float)
+INSTANTIATE(double)
+#undef INSTANTIATE
+
+}  // namespace baseline
+
+// ── Forward declarations for higher-tier implementations ────────────────
+
+#if defined(__x86_64__)
+namespace avx2 {
+template <typename T>
+void
+filterChunk(const T*, int, uint8_t*, const T*, int);
+template <typename T>
+int
+laneCount();
+}  // namespace avx2
+namespace avx512 {
+template <typename T>
+void
+filterChunk(const T*, int, uint8_t*, const T*, int);
+template <typename T>
+int
+laneCount();
+}  // namespace avx512
+#endif
+
+// ── Dispatcher ──────────────────────────────────────────────────────────
+
+namespace {
+
+template <typename T>
+using FilterFn = void (*)(const T*, int, uint8_t*, const T*, int);
+
+template <typename T>
+FilterFn<T>
+selectFilterImpl() {
+#if defined(__x86_64__)
+    if (hasAvx512bw()) {
+        return avx512::filterChunk<T>;
+    }
+    if (hasAvx2()) {
+        return avx2::filterChunk<T>;
+    }
+#endif
+    return baseline::filterChunk<T>;
+}
+
+template <typename T>
+using LaneCountFn = int (*)();
+
+template <typename T>
+LaneCountFn<T>
+selectLaneCountImpl() {
+#if defined(__x86_64__)
+    if (hasAvx512bw()) {
+        return avx512::laneCount<T>;
+    }
+    if (hasAvx2()) {
+        return avx2::laneCount<T>;
+    }
+#endif
+    return baseline::laneCount<T>;
+}
+
+}  // anonymous namespace
+
+// ── Public API ──────────────────────────────────────────────────────────
+
+template <typename T>
+void
+simdFilterChunk(
+    const T* data, int size, uint8_t* bitmap, const T* vals, int num_vals) {
+    // Resolved once on first call, cached in static local.
+    static const auto impl = selectFilterImpl<T>();
+    impl(data, size, bitmap, vals, num_vals);
+}
+
+template <typename T>
+int
+simdLaneCount() {
+    static const auto impl = selectLaneCountImpl<T>();
+    return impl();
+}
+
+// Explicit instantiations for all supported numeric types.
+#define INSTANTIATE(T)                                                        \
+    template void simdFilterChunk<T>(const T*, int, uint8_t*, const T*, int); \
+    template int simdLaneCount<T>();
+
+INSTANTIATE(int8_t)
+INSTANTIATE(uint8_t)
+INSTANTIATE(int16_t)
+INSTANTIATE(int32_t)
+INSTANTIATE(int64_t)
+INSTANTIATE(float)
+INSTANTIATE(double)
+#undef INSTANTIATE
+
+}  // namespace exec
+}  // namespace milvus

--- a/internal/core/src/exec/expression/SimdFilter.h
+++ b/internal/core/src/exec/expression/SimdFilter.h
@@ -1,0 +1,41 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+
+namespace milvus {
+namespace exec {
+
+// Runtime-dispatched SIMD filter for TermExpr IN evaluation.
+// Checks each data[i] against sorted vals[], OR's matching bits into bitmap.
+// bitmap must be byte-aligned (no bit offset). vals must be sorted and
+// deduplicated. At startup, the best available instruction set is selected
+// (AVX-512 > AVX2 > SSE2 on x86; NEON on ARM).
+template <typename T>
+void
+simdFilterChunk(
+    const T* data, int size, uint8_t* bitmap, const T* vals, int num_vals);
+
+// Returns the SIMD lane count for type T on the best available instruction set.
+// E.g. AVX2 + int32 → 8, NEON + int32 → 4.
+template <typename T>
+int
+simdLaneCount();
+
+}  // namespace exec
+}  // namespace milvus

--- a/internal/core/src/exec/expression/SimdFilterAvx2.cpp
+++ b/internal/core/src/exec/expression/SimdFilterAvx2.cpp
@@ -1,0 +1,57 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Compiled with: -mavx2 -mfma (set by CMakeLists.txt)
+
+#if defined(__x86_64__)
+
+#include "SimdFilterImpl.h"
+
+namespace milvus {
+namespace exec {
+namespace avx2 {
+
+template <typename T>
+void
+filterChunk(
+    const T* data, int size, uint8_t* bitmap, const T* vals, int num_vals) {
+    detail::filterChunkImpl<T, xsimd::avx2>(data, size, bitmap, vals, num_vals);
+}
+
+template <typename T>
+int
+laneCount() {
+    return xsimd::batch<T, xsimd::avx2>::size;
+}
+
+#define INSTANTIATE(T)                                                    \
+    template void filterChunk<T>(const T*, int, uint8_t*, const T*, int); \
+    template int laneCount<T>();
+
+INSTANTIATE(int8_t)
+INSTANTIATE(uint8_t)
+INSTANTIATE(int16_t)
+INSTANTIATE(int32_t)
+INSTANTIATE(int64_t)
+INSTANTIATE(float)
+INSTANTIATE(double)
+#undef INSTANTIATE
+
+}  // namespace avx2
+}  // namespace exec
+}  // namespace milvus
+
+#endif  // __x86_64__

--- a/internal/core/src/exec/expression/SimdFilterAvx512.cpp
+++ b/internal/core/src/exec/expression/SimdFilterAvx512.cpp
@@ -1,0 +1,58 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Compiled with: -mavx512f -mavx512bw -mavx512vl -mavx512dq (set by CMakeLists.txt)
+
+#if defined(__x86_64__)
+
+#include "SimdFilterImpl.h"
+
+namespace milvus {
+namespace exec {
+namespace avx512 {
+
+template <typename T>
+void
+filterChunk(
+    const T* data, int size, uint8_t* bitmap, const T* vals, int num_vals) {
+    detail::filterChunkImpl<T, xsimd::avx512bw>(
+        data, size, bitmap, vals, num_vals);
+}
+
+template <typename T>
+int
+laneCount() {
+    return xsimd::batch<T, xsimd::avx512bw>::size;
+}
+
+#define INSTANTIATE(T)                                                    \
+    template void filterChunk<T>(const T*, int, uint8_t*, const T*, int); \
+    template int laneCount<T>();
+
+INSTANTIATE(int8_t)
+INSTANTIATE(uint8_t)
+INSTANTIATE(int16_t)
+INSTANTIATE(int32_t)
+INSTANTIATE(int64_t)
+INSTANTIATE(float)
+INSTANTIATE(double)
+#undef INSTANTIATE
+
+}  // namespace avx512
+}  // namespace exec
+}  // namespace milvus
+
+#endif  // __x86_64__

--- a/internal/core/src/exec/expression/SimdFilterImpl.h
+++ b/internal/core/src/exec/expression/SimdFilterImpl.h
@@ -1,0 +1,165 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Internal header — included ONLY from per-arch .cpp files (SimdFilterAvx2.cpp,
+// SimdFilterAvx512.cpp, etc.). Each .cpp is compiled with arch-specific flags
+// (e.g. -mavx2), so xsimd generates the correct instructions.
+//
+// Do NOT include this header from other headers or general .cpp files.
+// ═══════════════════════════════════════════════════════════════════════════
+
+#pragma once
+
+#include <algorithm>
+#include <cstring>
+#include <vector>
+#include <xsimd/xsimd.hpp>
+#include "common/SimdUtil.h"
+
+namespace milvus {
+namespace exec {
+namespace detail {
+
+// Core SIMD filter kernel, parameterized on architecture.
+// For each data[i], checks if data[i] is in vals[0..num_vals) and OR's
+// the result bit into bitmap. vals must be sorted.
+template <typename T, typename Arch>
+void
+filterChunkImpl(
+    const T* data, int size, uint8_t* bitmap, const T* vals, int num_vals) {
+    if (num_vals <= 0 || size <= 0) {
+        return;
+    }
+
+    using Batch = xsimd::batch<T, Arch>;
+    using BatchBool = xsimd::batch_bool<T, Arch>;
+    constexpr int kLanes = Batch::size;
+
+    // Pre-compute broadcast vectors (one per IN value).
+    // Heap-allocated once per FilterChunk call. Acceptable because:
+    //   - FilterChunk is called once per segment, not per row
+    //   - num_vals is typically small (< 256, bounded by kSimdThreshold)
+    //   - broadcast() is one SIMD instruction each
+    std::vector<Batch> broadcast;
+    broadcast.reserve(num_vals);
+    for (int j = 0; j < num_vals; ++j) {
+        broadcast.emplace_back(Batch::broadcast(vals[j]));
+    }
+
+    // Choose unroll factor to target 64-bit (8-byte) bitmap writes.
+    // Cap at 8 to avoid excessive register pressure.
+    constexpr int kMaxUnroll = 8;
+    constexpr int kIdealUnroll = (kLanes >= 64) ? 1 : 64 / kLanes;
+    constexpr int kUnroll =
+        (kIdealUnroll <= kMaxUnroll) ? kIdealUnroll : kMaxUnroll;
+    constexpr int kStep = kLanes * kUnroll;
+
+    int i = 0;
+
+    // ── Unrolled main loop ──────────────────────────────────────────────
+    for (; i + kStep <= size; i += kStep) {
+        Batch d[kUnroll];
+        BatchBool acc[kUnroll];
+        for (int u = 0; u < kUnroll; ++u) {
+            d[u] = Batch::load_unaligned(data + i + u * kLanes);
+            acc[u] = BatchBool(false);
+        }
+
+        for (const auto& bcast : broadcast) {
+            for (int u = 0; u < kUnroll; ++u) {
+                acc[u] = acc[u] | (d[u] == bcast);
+            }
+        }
+
+        uint64_t combined = 0;
+        for (int u = 0; u < kUnroll; ++u) {
+            uint64_t m = milvus::toBitMask(acc[u]);
+            combined |= (m << (u * kLanes));
+        }
+
+        if (combined == 0) {
+            continue;
+        }
+
+        const int byte_pos = i / 8;
+        if constexpr (kStep >= 64) {
+            uint64_t word;
+            std::memcpy(&word, bitmap + byte_pos, sizeof(word));
+            word |= combined;
+            std::memcpy(bitmap + byte_pos, &word, sizeof(word));
+        } else if constexpr (kStep >= 32) {
+            uint32_t word;
+            std::memcpy(&word, bitmap + byte_pos, sizeof(word));
+            word |= static_cast<uint32_t>(combined);
+            std::memcpy(bitmap + byte_pos, &word, sizeof(word));
+        } else if constexpr (kStep >= 16) {
+            uint16_t word;
+            std::memcpy(&word, bitmap + byte_pos, sizeof(word));
+            word |= static_cast<uint16_t>(combined);
+            std::memcpy(bitmap + byte_pos, &word, sizeof(word));
+        } else {
+            bitmap[byte_pos] |= static_cast<uint8_t>(combined);
+        }
+    }
+
+    // ── Single-register remainder loop ──────────────────────────────────
+    if constexpr (kUnroll > 1) {
+        for (; i + kLanes <= size; i += kLanes) {
+            auto d0 = Batch::load_unaligned(data + i);
+            BatchBool acc0(false);
+            for (const auto& bcast : broadcast) {
+                acc0 = acc0 | (d0 == bcast);
+            }
+            uint64_t mask = milvus::toBitMask(acc0);
+            if (mask) {
+                const int byte_pos = i / 8;
+                if constexpr (kLanes >= 32) {
+                    uint32_t word;
+                    std::memcpy(&word, bitmap + byte_pos, sizeof(word));
+                    word |= static_cast<uint32_t>(mask);
+                    std::memcpy(bitmap + byte_pos, &word, sizeof(word));
+                } else if constexpr (kLanes >= 16) {
+                    uint16_t word;
+                    std::memcpy(&word, bitmap + byte_pos, sizeof(word));
+                    word |= static_cast<uint16_t>(mask);
+                    std::memcpy(bitmap + byte_pos, &word, sizeof(word));
+                } else if constexpr (kLanes >= 8) {
+                    bitmap[byte_pos] |= static_cast<uint8_t>(mask);
+                } else {
+                    const int bit_shift = i % 8;
+                    uint64_t shifted = mask << bit_shift;
+                    bitmap[byte_pos] |= static_cast<uint8_t>(shifted);
+                    if ((kLanes + bit_shift) > 8) {
+                        bitmap[byte_pos + 1] |=
+                            static_cast<uint8_t>(shifted >> 8);
+                    }
+                }
+            }
+        }
+    }
+
+    // ── Scalar tail ─────────────────────────────────────────────────────
+    for (; i < size; ++i) {
+        if (std::binary_search(vals, vals + num_vals, data[i])) {
+            bitmap[i / 8] |= static_cast<uint8_t>(1 << (i % 8));
+        }
+    }
+}
+
+}  // namespace detail
+}  // namespace exec
+}  // namespace milvus

--- a/internal/core/src/exec/expression/TermExpr.cpp
+++ b/internal/core/src/exec/expression/TermExpr.cpp
@@ -88,7 +88,8 @@ PhyTermFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
             result = ExecVisitorImpl<int32_t>(context);
             break;
         }
-        case DataType::INT64: {
+        case DataType::INT64:
+        case DataType::TIMESTAMPTZ: {
             result = ExecVisitorImpl<int64_t>(context);
             break;
         }
@@ -1001,14 +1002,78 @@ PhyTermFilterExpr::ExecVisitorImplForData(EvalCtx& context) {
                 vals.emplace_back(converted_val);
             }
         }
-        arg_set_ = std::make_shared<SetElement<T>>(vals);
+
+        // Select optimal element type based on data type and IN list size.
+        if constexpr (std::is_same_v<T, std::string> ||
+                      std::is_same_v<T, std::string_view>) {
+            // Convert to owned strings (T may be string_view into proto data)
+            std::vector<std::string> str_vals;
+            str_vals.reserve(vals.size());
+            for (const auto& v : vals) {
+                str_vals.emplace_back(v);
+            }
+            constexpr size_t kLinearScanThreshold = 4;
+            if (str_vals.size() <= kLinearScanThreshold) {
+                // Small IN: linear scan with length check + memcmp
+                arg_set_ =
+                    std::make_shared<FlatVectorElement<std::string>>(str_vals);
+            } else {
+                arg_set_ = std::make_shared<SetElement<std::string>>(str_vals);
+            }
+        } else if constexpr (std::is_same_v<T, bool>) {
+            // Bool: use specialized SetElement<bool> (two flags, O(1)).
+            arg_set_ = std::make_shared<SetElement<T>>(vals);
+        } else {
+            // All numeric types: SIMD for small IN, hash for large IN.
+            // Crossover benchmarked with ankerl hash at load_factor=0.5.
+            // Automatically adapts to all architectures:
+            //   AVX512 int32 (kLanes=16): threshold=128
+            //   AVX2   int32 (kLanes=8):  threshold=64
+            //   AVX2   int64 (kLanes=4):  threshold=32
+            //   NEON   int32 (kLanes=4):  threshold=32
+            //   NEON   int64 (kLanes=2):  threshold=16
+            const size_t kSimdThreshold =
+                static_cast<size_t>(simdLaneCount<T>()) * 8;
+            if (vals.size() <= kSimdThreshold) {
+                arg_set_ = std::make_shared<SimdBatchElement<T>>(vals);
+            } else {
+                arg_set_ = std::make_shared<SetElement<T>>(vals);
+            }
+        }
+        // Cache SIMD FilterChunk dispatch (numeric types only).
+        // SIMD path runs batch filter first, then applies validity/bitmap
+        // masks — avoids per-row variant construction entirely.
+        if constexpr (!std::is_same_v<T, bool> &&
+                      !std::is_same_v<T, std::string> &&
+                      !std::is_same_v<T, std::string_view>) {
+            if (auto simd_elem =
+                    std::dynamic_pointer_cast<SimdBatchElement<T>>(arg_set_)) {
+                cached_filter_chunk_ = [simd_elem](const void* data,
+                                                   int size,
+                                                   TargetBitmapView res) {
+                    simd_elem->FilterChunk(
+                        static_cast<const T*>(data), size, res);
+                };
+            }
+        }
+        // Cache string SetElement pointer for per-row direct lookup.
+        if constexpr (std::is_same_v<T, std::string> ||
+                      std::is_same_v<T, std::string_view>) {
+            cached_str_set_elem_ =
+                dynamic_cast<SetElement<std::string>*>(arg_set_.get());
+        }
+        // Cache element values for skip_index (avoids per-chunk copy)
+        cached_skip_elements_ = GetElementValues<T>(arg_set_);
         arg_inited_ = true;
     }
 
+    const auto& simd_filter_fn = cached_filter_chunk_;
+    const auto str_set_elem = cached_str_set_elem_;
+
     int processed_cursor = 0;
     auto execute_sub_batch =
-        [&processed_cursor, &
-         bitmap_input ]<FilterType filter_type = FilterType::sequential>(
+        [&processed_cursor, &bitmap_input, &simd_filter_fn,
+         str_set_elem ]<FilterType filter_type = FilterType::sequential>(
             const T* data,
             const bool* valid_data,
             const int32_t* offsets,
@@ -1016,14 +1081,40 @@ PhyTermFilterExpr::ExecVisitorImplForData(EvalCtx& context) {
             TargetBitmapView res,
             TargetBitmapView valid_res,
             const std::shared_ptr<MultiElement>& vals) {
-        // If data is nullptr, this chunk was skipped by SkipIndex.
-        // We only need to update processed_cursor for bitmap_input indexing.
         if (data == nullptr) {
             processed_cursor += size;
             return;
         }
         bool has_bitmap_input = !bitmap_input.empty();
-        for (size_t i = 0; i < size; ++i) {
+
+        // ── Path 1: SIMD batch (numeric, sequential, within threshold) ──
+        if constexpr (filter_type == FilterType::sequential) {
+            if (simd_filter_fn) {
+                simd_filter_fn(data, size, res);
+                // Apply validity mask
+                if (valid_data != nullptr) {
+                    for (int i = 0; i < size; ++i) {
+                        if (!valid_data[i]) {
+                            res[i] = valid_res[i] = false;
+                        }
+                    }
+                }
+                // Apply bitmap mask
+                if (has_bitmap_input) {
+                    for (int i = 0; i < size; ++i) {
+                        if (!bitmap_input[i + processed_cursor]) {
+                            res[i] = false;
+                        }
+                    }
+                }
+                processed_cursor += size;
+                return;
+            }
+        }
+
+        // ── Path 2: Per-row (string, bool, large numeric, random access) ──
+        // Check validity and bitmap first, then direct lookup without variant.
+        for (int i = 0; i < size; ++i) {
             auto offset = i;
             if constexpr (filter_type == FilterType::random) {
                 offset = (offsets) ? offsets[i] : i;
@@ -1035,16 +1126,34 @@ PhyTermFilterExpr::ExecVisitorImplForData(EvalCtx& context) {
             if (has_bitmap_input && !bitmap_input[i + processed_cursor]) {
                 continue;
             }
-            res[i] = vals->In(data[offset]);
+            // Direct lookup: skip variant construction
+            if constexpr (std::is_same_v<T, std::string> ||
+                          std::is_same_v<T, std::string_view>) {
+                if (str_set_elem) {
+                    // Hash lookup via string_view (zero copy)
+                    res[i] = str_set_elem->values_.find(std::string_view(
+                                 data[offset])) != str_set_elem->values_.end();
+                } else {
+                    // FlatVectorElement path (small IN ≤4)
+                    res[i] = vals->In(MultiElement::ValueType(
+                        std::string_view(data[offset])));
+                }
+            } else {
+                res[i] = vals->In(MultiElement::ValueType(std::in_place_type<T>,
+                                                          data[offset]));
+            }
         }
         processed_cursor += size;
     };
 
-    auto set = std::static_pointer_cast<SetElement<T>>(arg_set_);
     auto skip_index_func =
-        [set](const SkipIndex& skip_index, FieldId field_id, int64_t chunk_id) {
-            return skip_index.CanSkipInQuery<T>(
-                field_id, chunk_id, set->GetElements());
+        [&cached_elements = cached_skip_elements_](
+            const SkipIndex& skip_index, FieldId field_id, int64_t chunk_id) {
+            auto* elements = std::any_cast<std::vector<T>>(&cached_elements);
+            if (elements == nullptr) {
+                return false;
+            }
+            return skip_index.CanSkipInQuery<T>(field_id, chunk_id, *elements);
         };
 
     int64_t processed_size;

--- a/internal/core/src/exec/expression/TermExpr.h
+++ b/internal/core/src/exec/expression/TermExpr.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <any>
+#include <functional>
 #include <fmt/core.h>
 
 #include "common/EasyAssert.h"
@@ -163,6 +165,19 @@ class PhyTermFilterExpr : public SegmentExpr {
     std::shared_ptr<MultiElement> arg_set_double_;
     SingleElement arg_val_;
     PinWrapper<index::BsonInvertedIndex*> bson_index_{nullptr};
+
+    // Type-safe cached FilterChunk dispatch (avoids per-call dynamic_cast).
+    // Set once during arg_inited_; empty when arg_set_ is not SimdBatch.
+    // Captures a typed SimdBatchElement<T>* inside the lambda at init time.
+    using FilterChunkFn =
+        std::function<void(const void* data, int size, TargetBitmapView res)>;
+    FilterChunkFn cached_filter_chunk_;
+    // Cached SetElement<string> pointer for per-row string lookup without
+    // variant construction. Set once during init; nullptr when arg_set_ is not
+    // SetElement<string> (e.g. FlatVectorElement for small IN).
+    SetElement<std::string>* cached_str_set_elem_{nullptr};
+    // Cached element values for skip_index (avoids per-chunk vector copy).
+    std::any cached_skip_elements_;
 };
 }  //namespace exec
 }  // namespace milvus

--- a/internal/parser/planparserv2/rewriter/entry.go
+++ b/internal/parser/planparserv2/rewriter/entry.go
@@ -85,15 +85,17 @@ func (v *visitor) visitBinaryExpr(expr *planpb.BinaryExpr) interface{} {
 }
 
 func (v *visitor) visitUnaryExpr(expr *planpb.UnaryExpr) interface{} {
-	// Handle NOT(TermExpr) before visiting child, so we can split not in → != and
+	// Handle NOT(TermExpr) before visiting child.
 	// Skip bool types here — they are handled via visitTermExpr bool optimization + NOT simplification.
 	if expr.GetOp() == planpb.UnaryExpr_Not {
 		if te := expr.GetChild().GetTermExpr(); te != nil {
 			sortTermValues(te)
-			if v.optimizeEnabled && effectiveDataType(te.GetColumnInfo()) == schemapb.DataType_Bool {
+			col := te.GetColumnInfo()
+			if v.optimizeEnabled && effectiveDataType(col) == schemapb.DataType_Bool {
 				// Let bool NOT IN flow through to visitTermExpr for bool-specific optimization
-			} else if !shouldUseInExprWithPK(te.GetColumnInfo().GetDataType(), len(te.GetValues()), te.GetColumnInfo().GetIsPrimaryKey()) {
-				return splitTermToAndNotEquals(te)
+			} else if col != nil && len(te.GetValues()) == 1 {
+				// Single-value NOT IN → != (avoids SIMD setup overhead for trivial case)
+				return newUnaryRangeExpr(col, planpb.OpType_NotEqual, te.GetValues()[0])
 			}
 		}
 	}
@@ -167,9 +169,9 @@ func (v *visitor) visitTermExpr(expr *planpb.TermExpr) interface{} {
 		}
 	}
 
-	// Split in → == or when shouldUseInExpr returns false
-	if !shouldUseInExprWithPK(expr.GetColumnInfo().GetDataType(), len(expr.GetValues()), expr.GetColumnInfo().GetIsPrimaryKey()) {
-		return splitTermToOrEquals(expr)
+	// Single-value IN → == (avoids SIMD setup overhead for trivial case)
+	if len(expr.GetValues()) == 1 {
+		return newUnaryRangeExpr(expr.GetColumnInfo(), planpb.OpType_Equal, expr.GetValues()[0])
 	}
 
 	return &planpb.Expr{Expr: &planpb.Expr_TermExpr{TermExpr: expr}}

--- a/internal/parser/planparserv2/rewriter/term_in.go
+++ b/internal/parser/planparserv2/rewriter/term_in.go
@@ -42,7 +42,7 @@ func (v *visitor) combineOrEqualsToIn(parts []*planpb.Expr) []*planpb.Expr {
 	out := make([]*planpb.Expr, 0, len(parts))
 	out = append(out, others...)
 	for _, g := range groups {
-		if shouldUseInExprWithPK(g.col.GetDataType(), len(g.values), g.col.GetIsPrimaryKey()) {
+		if len(g.values) >= 2 {
 			g.values = sortGenericValues(g.values)
 			out = append(out, newTermExpr(g.col, g.values))
 		} else {
@@ -92,7 +92,7 @@ func (v *visitor) combineAndNotEqualsToNotIn(parts []*planpb.Expr) []*planpb.Exp
 	out := make([]*planpb.Expr, 0, len(parts))
 	out = append(out, others...)
 	for _, g := range groups {
-		if shouldUseInExprWithPK(g.col.GetDataType(), len(g.values), g.col.GetIsPrimaryKey()) {
+		if len(g.values) >= 2 {
 			g.values = sortGenericValues(g.values)
 			in := newTermExpr(g.col, g.values)
 			out = append(out, notExpr(in))
@@ -103,90 +103,6 @@ func (v *visitor) combineAndNotEqualsToNotIn(parts []*planpb.Expr) []*planpb.Exp
 		}
 	}
 	return out
-}
-
-// splitTermToOrEquals converts TermExpr(in [v1, v2, ...]) to
-// v == v1 OR v == v2 OR ... (left-associative binary OR tree).
-func splitTermToOrEquals(expr *planpb.TermExpr) *planpb.Expr {
-	col := expr.GetColumnInfo()
-	values := expr.GetValues()
-
-	if len(values) == 0 {
-		return &planpb.Expr{Expr: &planpb.Expr_TermExpr{TermExpr: expr}}
-	}
-
-	equals := make([]*planpb.Expr, len(values))
-	for i, val := range values {
-		equals[i] = &planpb.Expr{
-			Expr: &planpb.Expr_UnaryRangeExpr{
-				UnaryRangeExpr: &planpb.UnaryRangeExpr{
-					ColumnInfo: col,
-					Op:         planpb.OpType_Equal,
-					Value:      val,
-				},
-			},
-		}
-	}
-
-	if len(equals) == 1 {
-		return equals[0]
-	}
-
-	result := equals[0]
-	for i := 1; i < len(equals); i++ {
-		result = &planpb.Expr{
-			Expr: &planpb.Expr_BinaryExpr{
-				BinaryExpr: &planpb.BinaryExpr{
-					Left:  result,
-					Right: equals[i],
-					Op:    planpb.BinaryExpr_LogicalOr,
-				},
-			},
-		}
-	}
-	return result
-}
-
-// splitTermToAndNotEquals converts NOT(in [v1, v2, ...]) to
-// v != v1 AND v != v2 AND ... (left-associative binary AND tree).
-func splitTermToAndNotEquals(expr *planpb.TermExpr) *planpb.Expr {
-	col := expr.GetColumnInfo()
-	values := expr.GetValues()
-
-	if len(values) == 0 {
-		return notExpr(&planpb.Expr{Expr: &planpb.Expr_TermExpr{TermExpr: expr}})
-	}
-
-	notEquals := make([]*planpb.Expr, len(values))
-	for i, val := range values {
-		notEquals[i] = &planpb.Expr{
-			Expr: &planpb.Expr_UnaryRangeExpr{
-				UnaryRangeExpr: &planpb.UnaryRangeExpr{
-					ColumnInfo: col,
-					Op:         planpb.OpType_NotEqual,
-					Value:      val,
-				},
-			},
-		}
-	}
-
-	if len(notEquals) == 1 {
-		return notEquals[0]
-	}
-
-	result := notEquals[0]
-	for i := 1; i < len(notEquals); i++ {
-		result = &planpb.Expr{
-			Expr: &planpb.Expr_BinaryExpr{
-				BinaryExpr: &planpb.BinaryExpr{
-					Left:  result,
-					Right: notEquals[i],
-					Op:    planpb.BinaryExpr_LogicalAnd,
-				},
-			},
-		}
-	}
-	return result
 }
 
 func notExpr(child *planpb.Expr) *planpb.Expr {
@@ -351,8 +267,8 @@ func (v *visitor) combineOrInWithEqual(parts []*planpb.Expr) []*planpb.Expr {
 		if g.term == nil || len(g.eqIdxs) == 0 {
 			continue
 		}
-		// union all equal values into term set
-		union := g.term.GetValues()
+		// union all equal values into term set; copy to avoid aliasing proto's backing array
+		union := append([]*planpb.GenericValue(nil), g.term.GetValues()...)
 		for i, ev := range g.eqVals {
 			union = append(union, ev)
 			used[g.eqIdxs[i]] = true

--- a/internal/parser/planparserv2/rewriter/term_in_test.go
+++ b/internal/parser/planparserv2/rewriter/term_in_test.go
@@ -55,11 +55,11 @@ func buildSchemaHelperForRewriteNullableT(t *testing.T) *typeutil.SchemaHelper {
 	return helper
 }
 
-// --- shouldUseInExpr threshold tests ---
+// --- OR-equals merge tests (all merge to IN, SIMD-optimized) ---
 
 func TestRewrite_OREquals_ToIN_VarChar_AboveThreshold(t *testing.T) {
 	helper := buildSchemaHelperForRewriteT(t)
-	// varchar threshold is 3, so 3 values should produce IN
+	// 3 varchar OR-equals should merge to IN
 	expr, err := parser.ParseExpr(helper, `VarCharField == "a" or VarCharField == "b" or VarCharField == "c"`, nil)
 	require.NoError(t, err)
 	require.NotNil(t, expr)
@@ -68,63 +68,54 @@ func TestRewrite_OREquals_ToIN_VarChar_AboveThreshold(t *testing.T) {
 	require.Equal(t, 3, len(term.GetValues()))
 }
 
-func TestRewrite_OREquals_NotMerged_VarChar_BelowThreshold(t *testing.T) {
+func TestRewrite_OREquals_Merged_VarChar_TwoValues(t *testing.T) {
 	helper := buildSchemaHelperForRewriteT(t)
-	// varchar threshold is 3, so 2 values should NOT produce IN
+	// All OR-equals always merge to IN (SIMD-optimized)
 	expr, err := parser.ParseExpr(helper, `VarCharField == "a" or VarCharField == "b"`, nil)
 	require.NoError(t, err)
 	require.NotNil(t, expr)
-	require.Nil(t, expr.GetTermExpr(), "2 varchar OR-equals should not merge to IN")
-	be := expr.GetBinaryExpr()
-	require.NotNil(t, be)
-	require.Equal(t, planpb.BinaryExpr_LogicalOr, be.GetOp())
+	term := expr.GetTermExpr()
+	require.NotNil(t, term, "2 varchar OR-equals should merge to IN")
+	require.Equal(t, 2, len(term.GetValues()))
 }
 
-func TestRewrite_OREquals_NotMerged_Int_BelowThreshold(t *testing.T) {
+func TestRewrite_OREquals_Merged_Int_TwoValues(t *testing.T) {
 	helper := buildSchemaHelperForRewriteT(t)
-	// int threshold is 10, so 2 values should NOT merge
+	// All OR-equals always merge to IN (SIMD-optimized)
 	expr, err := parser.ParseExpr(helper, `Int64Field == 1 or Int64Field == 2`, nil)
 	require.NoError(t, err)
 	require.NotNil(t, expr)
-	require.Nil(t, expr.GetTermExpr(), "numeric OR-equals should not merge to IN under threshold")
-	be := expr.GetBinaryExpr()
-	require.NotNil(t, be)
-	require.Equal(t, planpb.BinaryExpr_LogicalOr, be.GetOp())
-	require.NotNil(t, be.GetLeft().GetUnaryRangeExpr())
-	require.NotNil(t, be.GetRight().GetUnaryRangeExpr())
-	require.Equal(t, planpb.OpType_Equal, be.GetLeft().GetUnaryRangeExpr().GetOp())
-	require.Equal(t, planpb.OpType_Equal, be.GetRight().GetUnaryRangeExpr().GetOp())
+	term := expr.GetTermExpr()
+	require.NotNil(t, term, "2 int OR-equals should merge to IN")
+	require.Equal(t, 2, len(term.GetValues()))
 }
 
-func TestRewrite_OREquals_Merged_Int_AtThreshold(t *testing.T) {
+func TestRewrite_OREquals_Merged_Int_TenValues(t *testing.T) {
 	helper := buildSchemaHelperForRewriteT(t)
-	// int threshold is 10, so exactly 10 values should merge
 	expr, err := parser.ParseExpr(helper, `Int64Field == 1 or Int64Field == 2 or Int64Field == 3 or Int64Field == 4 or Int64Field == 5 or Int64Field == 6 or Int64Field == 7 or Int64Field == 8 or Int64Field == 9 or Int64Field == 10`, nil)
 	require.NoError(t, err)
 	require.NotNil(t, expr)
 	term := expr.GetTermExpr()
-	require.NotNil(t, term, "10 int OR-equals should merge to IN (threshold=10)")
+	require.NotNil(t, term, "10 int OR-equals should merge to IN")
 	require.Equal(t, 10, len(term.GetValues()))
 }
 
-// --- in → == or split tests ---
+// --- IN kept tests (no splitting, SIMD-optimized) ---
 
-func TestRewrite_InSplit_Int_BelowThreshold(t *testing.T) {
+func TestRewrite_InKept_Int_SmallCount(t *testing.T) {
 	helper := buildSchemaHelperForRewriteT(t)
-	// int in [1,2,3] → 3 values < 10 → split to == or
+	// All IN expressions stay as IN (SIMD-optimized)
 	expr, err := parser.ParseExpr(helper, `Int64Field in [1,2,3]`, nil)
 	require.NoError(t, err)
 	require.NotNil(t, expr)
-	require.Nil(t, expr.GetTermExpr(), "int in with 3 values should be split to == or")
-	// Should be an OR tree
-	be := expr.GetBinaryExpr()
-	require.NotNil(t, be)
-	require.Equal(t, planpb.BinaryExpr_LogicalOr, be.GetOp())
+	term := expr.GetTermExpr()
+	require.NotNil(t, term, "int in with 3 values should stay as IN")
+	require.Equal(t, 3, len(term.GetValues()))
 }
 
-func TestRewrite_InSplit_Int_SingleValue(t *testing.T) {
+func TestRewrite_InSingle_Int_BecomesEqual(t *testing.T) {
 	helper := buildSchemaHelperForRewriteT(t)
-	// int in [5] → split to == 5
+	// Single-value IN → == (avoids SIMD overhead)
 	expr, err := parser.ParseExpr(helper, `Int64Field in [5]`, nil)
 	require.NoError(t, err)
 	require.NotNil(t, expr)
@@ -134,7 +125,7 @@ func TestRewrite_InSplit_Int_SingleValue(t *testing.T) {
 	require.Equal(t, int64(5), ure.GetValue().GetInt64Val())
 }
 
-func TestRewrite_InKept_Int_AboveThreshold(t *testing.T) {
+func TestRewrite_InKept_Int_TenValues(t *testing.T) {
 	helper := buildSchemaHelperForRewriteT(t)
 	expr, err := parser.ParseExpr(helper, `Int64Field in [1,2,3,4,5,6,7,8,9,10]`, nil)
 	require.NoError(t, err)
@@ -144,24 +135,25 @@ func TestRewrite_InKept_Int_AboveThreshold(t *testing.T) {
 	require.Equal(t, 10, len(term.GetValues()))
 }
 
-// --- not in split tests ---
+// --- NOT IN kept tests (no splitting, SIMD-optimized) ---
 
-func TestRewrite_NotInSplit_Int_BelowThreshold(t *testing.T) {
+func TestRewrite_NotInKept_Int_TwoValues(t *testing.T) {
 	helper := buildSchemaHelperForRewriteT(t)
-	// not in [3,4] → 2 values < 10 → split to != 3 AND != 4
+	// All NOT IN stay as NOT(IN) (SIMD-optimized)
 	expr, err := parser.ParseExpr(helper, `Int64Field not in [4,3]`, nil)
 	require.NoError(t, err)
 	require.NotNil(t, expr)
-	// Should be AND tree of !=
-	be := expr.GetBinaryExpr()
-	require.NotNil(t, be, "not in with 2 int values should split to != AND !=")
-	require.Equal(t, planpb.BinaryExpr_LogicalAnd, be.GetOp())
-	require.Equal(t, planpb.OpType_NotEqual, be.GetLeft().GetUnaryRangeExpr().GetOp())
-	require.Equal(t, planpb.OpType_NotEqual, be.GetRight().GetUnaryRangeExpr().GetOp())
+	unary := expr.GetUnaryExpr()
+	require.NotNil(t, unary, "not in should stay as NOT(IN)")
+	require.Equal(t, planpb.UnaryExpr_Not, unary.GetOp())
+	term := unary.GetChild().GetTermExpr()
+	require.NotNil(t, term)
+	require.Equal(t, 2, len(term.GetValues()))
 }
 
-func TestRewrite_NotInSplit_Int_SingleValue(t *testing.T) {
+func TestRewrite_NotInSingle_Int_BecomesNotEqual(t *testing.T) {
 	helper := buildSchemaHelperForRewriteT(t)
+	// Single-value NOT IN → != (avoids SIMD overhead)
 	expr, err := parser.ParseExpr(helper, `Int64Field not in [5]`, nil)
 	require.NoError(t, err)
 	require.NotNil(t, expr)
@@ -171,22 +163,25 @@ func TestRewrite_NotInSplit_Int_SingleValue(t *testing.T) {
 	require.Equal(t, int64(5), ure.GetValue().GetInt64Val())
 }
 
-func TestRewrite_NotInSplit_Float_BelowThreshold(t *testing.T) {
+func TestRewrite_NotInKept_Float_TwoValues(t *testing.T) {
 	helper := buildSchemaHelperForRewriteT(t)
-	// float threshold is 15, so 2 values → split
+	// Float NOT IN also stays as NOT(IN)
 	expr, err := parser.ParseExpr(helper, `FloatField not in [4.0,3.0]`, nil)
 	require.NoError(t, err)
 	require.NotNil(t, expr)
-	be := expr.GetBinaryExpr()
-	require.NotNil(t, be, "not in with 2 float values should split to != AND !=")
-	require.Equal(t, planpb.BinaryExpr_LogicalAnd, be.GetOp())
+	unary := expr.GetUnaryExpr()
+	require.NotNil(t, unary, "float not in should stay as NOT(IN)")
+	require.Equal(t, planpb.UnaryExpr_Not, unary.GetOp())
+	term := unary.GetChild().GetTermExpr()
+	require.NotNil(t, term)
+	require.Equal(t, 2, len(term.GetValues()))
 }
 
-// --- sort/dedup tests (use values above threshold) ---
+// --- sort/dedup tests ---
 
 func TestRewrite_Term_SortAndDedup_String(t *testing.T) {
 	helper := buildSchemaHelperForRewriteT(t)
-	// varchar threshold is 3, use 3+ unique values
+	// dedup + sort: 5 values with dups → 3 unique sorted
 	expr, err := parser.ParseExpr(helper, `VarCharField in ["c","b","a","b","a"]`, nil)
 	require.NoError(t, err)
 	require.NotNil(t, expr)
@@ -200,7 +195,7 @@ func TestRewrite_Term_SortAndDedup_String(t *testing.T) {
 
 func TestRewrite_Term_SortAndDedup_Int(t *testing.T) {
 	helper := buildSchemaHelperForRewriteT(t)
-	// int threshold is 10, use 10+ unique values
+	// dedup + sort: 11 values with one dup → 10 unique sorted
 	expr, err := parser.ParseExpr(helper, `Int64Field in [10,9,4,6,6,7,1,2,3,5,8]`, nil)
 	require.NoError(t, err)
 	require.NotNil(t, expr)
@@ -209,7 +204,10 @@ func TestRewrite_Term_SortAndDedup_Int(t *testing.T) {
 	require.Equal(t, 10, len(term.GetValues()))
 }
 
-func TestRewrite_In_SortAndDedup_Bool(t *testing.T) {
+// Bool IN — no special rewriting, handled by execution layer.
+// Single-value IN still folds to == via the generic single-value optimization.
+
+func TestRewrite_BoolIn_BothValues_StaysAsIn(t *testing.T) {
 	helper := buildSchemaHelperForRewriteT(t)
 	// BoolField in [true, false] covers all possible bool values → AlwaysTrueExpr
 	expr, err := parser.ParseExpr(helper, `BoolField in [true,false,false,true]`, nil)
@@ -324,7 +322,7 @@ func TestRewrite_Bool_NotIn_SingleFalse_ToNotEqual(t *testing.T) {
 
 func TestRewrite_Flatten_Then_OR_ToIN(t *testing.T) {
 	helper := buildSchemaHelperForRewriteT(t)
-	// varchar threshold is 3, so 4 values should merge
+	// nested OR-equals should flatten and merge to IN
 	expr, err := parser.ParseExpr(helper, `VarCharField == "a" or (VarCharField == "b" or VarCharField == "c") or VarCharField == "d"`, nil)
 	require.NoError(t, err)
 	require.NotNil(t, expr)
@@ -340,7 +338,7 @@ func TestRewrite_Flatten_Then_OR_ToIN(t *testing.T) {
 	require.ElementsMatch(t, []string{"a", "b", "c", "d"}, got)
 }
 
-// --- combine tests (use values above threshold to keep IN form) ---
+// --- combine tests ---
 
 func TestRewrite_And_In_And_Equal_VInSet_ReducesToEqual(t *testing.T) {
 	helper := buildSchemaHelperForRewriteT(t)
@@ -507,4 +505,153 @@ func TestRewrite_And_Equal_String_Contradiction_CurrentLimitation(t *testing.T) 
 	be := expr.GetBinaryExpr()
 	require.NotNil(t, be, "should remain as AND (not optimized)")
 	require.Equal(t, planpb.BinaryExpr_LogicalAnd, be.GetOp())
+}
+
+func buildSchemaWithTimestamptz(t *testing.T) *typeutil.SchemaHelper {
+	fields := []*schemapb.FieldSchema{
+		{FieldID: 101, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+		{FieldID: 102, Name: "ts", DataType: schemapb.DataType_Timestamptz},
+	}
+	schema := &schemapb.CollectionSchema{
+		Name:   "timestamptz_test",
+		AutoID: false,
+		Fields: fields,
+	}
+	helper, err := typeutil.CreateSchemaHelper(schema)
+	require.NoError(t, err)
+	return helper
+}
+
+// findTermExpr recursively checks if any node in the plan tree is a TermExpr.
+func findTermExpr(expr *planpb.Expr) *planpb.TermExpr {
+	if expr == nil {
+		return nil
+	}
+	if te := expr.GetTermExpr(); te != nil {
+		return te
+	}
+	if be := expr.GetBinaryExpr(); be != nil {
+		if found := findTermExpr(be.GetLeft()); found != nil {
+			return found
+		}
+		return findTermExpr(be.GetRight())
+	}
+	if ue := expr.GetUnaryExpr(); ue != nil {
+		return findTermExpr(ue.GetChild())
+	}
+	return nil
+}
+
+// TestTimestamptz_NotEqual_InAndContext verifies that a single != on a
+// Timestamptz field inside an AND expression stays as UnaryRangeExpr.
+// combineAndNotEqualsToNotIn requires 2+ values to merge into NOT(IN),
+// so a single != is left as-is.
+func TestTimestamptz_NotEqual_InAndContext(t *testing.T) {
+	helper := buildSchemaWithTimestamptz(t)
+
+	// This is the exact pattern from the failing e2e test:
+	// pk_range AND ts != ISO '...'
+	expr, err := parser.ParseExpr(helper,
+		`id >= 30 and id <= 35 and ts != ISO '9999-12-31T23:46:05Z'`, nil)
+	require.NoError(t, err)
+	require.NotNil(t, expr)
+
+	// Single != should NOT be merged into TermExpr.
+	te := findTermExpr(expr)
+	require.Nil(t, te,
+		"single Timestamptz != should remain as UnaryRangeExpr, not be merged into TermExpr")
+}
+
+// TestTimestamptz_NotEqual_Standalone verifies a standalone != on Timestamptz
+// stays as UnaryRangeExpr (no AND context means combineAndNotEqualsToNotIn
+// is not triggered).
+func TestTimestamptz_NotEqual_Standalone(t *testing.T) {
+	helper := buildSchemaWithTimestamptz(t)
+
+	expr, err := parser.ParseExpr(helper,
+		`ts != ISO '2025-01-01T00:00:00Z'`, nil)
+	require.NoError(t, err)
+	require.NotNil(t, expr)
+
+	ure := expr.GetUnaryRangeExpr()
+	require.NotNil(t, ure, "standalone != should be UnaryRangeExpr")
+	require.Equal(t, planpb.OpType_NotEqual, ure.GetOp())
+	require.Equal(t, schemapb.DataType_Timestamptz, ure.GetColumnInfo().GetDataType())
+}
+
+// TestTimestamptz_MultipleNotEquals_BecomesTermExpr verifies that multiple
+// != on the same Timestamptz field in an AND context are merged into a
+// single NOT(TermExpr). This confirms that C++ TermExpr.cpp must support
+// TIMESTAMPTZ (which we added in this PR).
+func TestTimestamptz_MultipleNotEquals_BecomesTermExpr(t *testing.T) {
+	helper := buildSchemaWithTimestamptz(t)
+
+	// Use 2 != on ts (same field) in an AND.
+	// Both != should be merged into NOT(IN [v1, v2]).
+	expr, err := parser.ParseExpr(helper,
+		`ts != ISO '2025-01-01T00:00:00Z' and ts != ISO '2025-06-01T00:00:00Z'`, nil)
+	require.NoError(t, err)
+	require.NotNil(t, expr)
+
+	// Should be rewritten to NOT(TermExpr) — which requires C++ TIMESTAMPTZ support.
+	te := findTermExpr(expr)
+	require.NotNil(t, te,
+		"Timestamptz != should be merged into NOT(TermExpr); "+
+			"C++ TermExpr.cpp TIMESTAMPTZ case is required for this to work")
+	require.Equal(t, schemapb.DataType_Timestamptz, te.GetColumnInfo().GetDataType())
+	require.Len(t, te.GetValues(), 2)
+}
+
+// TestTimestamptz_InExpr_ProducesTermExpr verifies that an explicit IN
+// expression on a Timestamptz field produces a TermExpr. Before the C++
+// TIMESTAMPTZ fix, this would have crashed at query time even on master —
+// it was just never tested because no e2e test used IN on Timestamptz
+// and the parser doesn't support `IN [ISO '...']` syntax directly.
+// Instead we test via multiple == OR that get merged into IN by the rewriter.
+func TestTimestamptz_InExpr_ProducesTermExpr(t *testing.T) {
+	helper := buildSchemaWithTimestamptz(t)
+
+	// 2 == on the same Timestamptz field in OR -> merged to IN by combineOrEqualsToIn
+	expr, err := parser.ParseExpr(helper,
+		`ts == ISO '2025-01-01T00:00:00Z' or ts == ISO '2025-06-01T00:00:00Z'`, nil)
+	require.NoError(t, err)
+	require.NotNil(t, expr)
+
+	te := findTermExpr(expr)
+	require.NotNil(t, te,
+		"OR of Timestamptz == should be merged into TermExpr (IN)")
+	require.Equal(t, schemapb.DataType_Timestamptz, te.GetColumnInfo().GetDataType())
+	require.Len(t, te.GetValues(), 2,
+		"IN should contain both timestamp values")
+}
+
+// TestGeometryAndText_BlockedAtParser verifies that Geometry and Text fields
+// cannot be used in term/comparison expressions. These types have no case in
+// C++ TermExpr.cpp or UnaryExpr.cpp, so the parser must reject them.
+func TestGeometryAndText_BlockedAtParser(t *testing.T) {
+	fields := []*schemapb.FieldSchema{
+		{FieldID: 101, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+		{FieldID: 102, Name: "geo", DataType: schemapb.DataType_Geometry},
+		{FieldID: 103, Name: "txt", DataType: schemapb.DataType_Text},
+	}
+	schema := &schemapb.CollectionSchema{Name: "block_test", Fields: fields}
+	helper, err := typeutil.CreateSchemaHelper(schema)
+	require.NoError(t, err)
+
+	// Geometry: == and IN should be rejected at parser level
+	_, err = parser.ParseExpr(helper, `geo == "POINT(1 2)"`, nil)
+	require.Error(t, err, "Geometry == should be rejected by parser")
+
+	_, err = parser.ParseExpr(helper, `geo in ["POINT(1 2)", "POINT(3 4)"]`, nil)
+	require.Error(t, err, "Geometry IN should be rejected by parser")
+
+	// Text: any filter expression should be rejected at parser level
+	_, err = parser.ParseExpr(helper, `txt == "hello"`, nil)
+	require.Error(t, err, "Text == should be rejected by parser")
+
+	_, err = parser.ParseExpr(helper, `txt in ["hello", "world"]`, nil)
+	require.Error(t, err, "Text IN should be rejected by parser")
+
+	_, err = parser.ParseExpr(helper, `txt != "hello"`, nil)
+	require.Error(t, err, "Text != should be rejected by parser")
 }

--- a/internal/parser/planparserv2/rewriter/util.go
+++ b/internal/parser/planparserv2/rewriter/util.go
@@ -2,6 +2,7 @@ package rewriter
 
 import (
 	"fmt"
+	"math"
 	"sort"
 	"strings"
 
@@ -92,30 +93,6 @@ func isNumericType(dt schemapb.DataType) bool {
 	return typeutil.IsArithmetic(dt)
 }
 
-// shouldUseInExpr determines whether a multi-value equality match should use
-// TermExpr (IN) or individual UnaryRangeExpr (== or).
-// Used bidirectionally:
-//   - combineOrEqualsToIn: merge == or → in when returns true
-//   - combineAndNotEqualsToNotIn: merge != and → not in when returns true
-//   - visitTermExpr: split in → == or when returns false
-func shouldUseInExpr(dt schemapb.DataType, count int) bool {
-	return shouldUseInExprWithPK(dt, count, false)
-}
-
-func shouldUseInExprWithPK(dt schemapb.DataType, count int, isPrimaryKey bool) bool {
-	if isPrimaryKey {
-		return true
-	}
-	switch {
-	case typeutil.IsIntegerType(dt):
-		return count >= 10
-	case typeutil.IsFloatingType(dt):
-		return count >= 15
-	default:
-		return count >= 3
-	}
-}
-
 func sortTermValues(term *planpb.TermExpr) {
 	if term == nil || len(term.GetValues()) <= 1 {
 		return
@@ -151,7 +128,15 @@ func sortGenericValues(values []*planpb.GenericValue) []*planpb.GenericValue {
 		values = lo.UniqBy(values, func(v *planpb.GenericValue) int64 { return v.GetInt64Val() })
 	case "float":
 		sort.Slice(values, func(i, j int) bool {
-			return values[i].GetFloatVal() < values[j].GetFloatVal()
+			a, b := values[i].GetFloatVal(), values[j].GetFloatVal()
+			// NaN sorts last to maintain strict weak ordering required by sort.Slice
+			if math.IsNaN(a) {
+				return false
+			}
+			if math.IsNaN(b) {
+				return true
+			}
+			return a < b
 		})
 		values = lo.UniqBy(values, func(v *planpb.GenericValue) float64 { return v.GetFloatVal() })
 	case "string":

--- a/internal/util/exprutil/expr_checker_test.go
+++ b/internal/util/exprutil/expr_checker_test.go
@@ -300,32 +300,35 @@ func TestValidatePartitionKeyIsolation(t *testing.T) {
 		{
 			name:                "partition key isolation equal OR with same field equal",
 			expr:                "key_field == 10 || key_field == 11",
-			expectedErrorString: "partition key isolation does not support OR",
+			expectedErrorString: "partition key isolation does not support",
 		},
 		{
 			name:                "partition key isolation equal OR with same field equal Reversed",
 			expr:                "key_field == 11 || key_field == 10",
-			expectedErrorString: "partition key isolation does not support OR",
+			expectedErrorString: "partition key isolation does not support",
 		},
 		{
 			name:                "partition key isolation equal OR with other field equal",
 			expr:                "key_field == 10 || varChar_field == 'a'",
-			expectedErrorString: "partition key isolation does not support OR",
+			expectedErrorString: "partition key isolation does not support",
 		},
 		{
 			name:                "partition key isolation equal OR with other field equal Reversed",
 			expr:                "varChar_field == 'a' || key_field == 10",
-			expectedErrorString: "partition key isolation does not support OR",
+			expectedErrorString: "partition key isolation does not support",
 		},
 		{
 			name:                "partition key isolation equal OR with other field equal",
 			expr:                "key_field == 10 || varChar_field == 'a'",
-			expectedErrorString: "partition key isolation does not support OR",
+			expectedErrorString: "partition key isolation does not support",
 		},
 		{
+			// Rewriter merges OR into IN, then AND+IN+Equal simplifies:
+			// key_field == 10 && key_field in [10, 11] → key_field == 10
+			// Final plan is just ==, so isolation validation passes.
 			name:                "partition key isolation equal AND",
 			expr:                "key_field == 10 && (key_field == 10 || key_field == 11)",
-			expectedErrorString: "partition key isolation does not support OR",
+			expectedErrorString: "",
 		},
 		{
 			name:                "partition key isolation other field equal",
@@ -340,7 +343,7 @@ func TestValidatePartitionKeyIsolation(t *testing.T) {
 		{
 			name:                "partition key isolation complex OR",
 			expr:                "(key_field == 10 and int64_field == 11) or (key_field == 10 and varChar_field == 'a')",
-			expectedErrorString: "partition key isolation does not support OR",
+			expectedErrorString: "partition key isolation does not support",
 		},
 	}
 

--- a/tests/integration/hellomilvus/partition_key_test.go
+++ b/tests/integration/hellomilvus/partition_key_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/metric"
 	"github.com/milvus-io/milvus/tests/integration"
 )
@@ -259,5 +260,254 @@ func (s *HelloMilvusSuite) TestPartitionKey() {
 		}
 		s.NoError(err)
 		s.Equal(commonpb.ErrorCode_Success, deleteResult.GetStatus().GetErrorCode())
+	}
+}
+
+// TestPartitionKeyIsolation verifies that partition key isolation mode works
+// correctly with various filter expressions: equality (==), IN list, and OR
+// of equalities on the partition key field.
+func (s *HelloMilvusSuite) TestPartitionKeyIsolation() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c := s.Cluster
+
+	const (
+		dim    = 128
+		dbName = ""
+		rowNum = 1000
+	)
+
+	collectionName := "TestPartitionKeyIsolation" + funcutil.GenRandomStr()
+	schema := integration.ConstructSchema(collectionName, dim, false)
+	schema.Fields = append(schema.Fields, &schemapb.FieldSchema{
+		FieldID:        102,
+		Name:           "pid",
+		DataType:       schemapb.DataType_Int64,
+		IsPartitionKey: true,
+	})
+	marshaledSchema, err := proto.Marshal(schema)
+	s.NoError(err)
+
+	// Create collection
+	createStatus, err := c.MilvusClient.CreateCollection(ctx, &milvuspb.CreateCollectionRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		Schema:         marshaledSchema,
+		ShardsNum:      common.DefaultShardsNum,
+	})
+	s.NoError(err)
+	s.Equal(commonpb.ErrorCode_Success, createStatus.GetErrorCode())
+
+	// Enable partition key isolation
+	alterStatus, err := c.MilvusClient.AlterCollection(ctx, &milvuspb.AlterCollectionRequest{
+		CollectionName: collectionName,
+		Properties: []*commonpb.KeyValuePair{
+			{Key: common.PartitionKeyIsolationKey, Value: "true"},
+		},
+	})
+	s.NoError(err)
+	s.True(merr.Ok(alterStatus))
+
+	// Insert 3 batches with different pid values: 1, 10, 100
+	for _, pid := range []int64{1, 10, 100} {
+		pkColumn := integration.NewInt64FieldDataWithStart(integration.Int64Field, rowNum, (pid-1)*int64(rowNum))
+		fVecColumn := integration.NewFloatVectorFieldData(integration.FloatVecField, rowNum, dim)
+		partitionKeyColumn := integration.NewInt64SameFieldData("pid", rowNum, pid)
+		hashKeys := integration.GenerateHashKeys(rowNum)
+		insertResult, err := c.MilvusClient.Insert(ctx, &milvuspb.InsertRequest{
+			DbName:         dbName,
+			CollectionName: collectionName,
+			FieldsData:     []*schemapb.FieldData{pkColumn, fVecColumn, partitionKeyColumn},
+			HashKeys:       hashKeys,
+			NumRows:        uint32(rowNum),
+		})
+		s.NoError(err)
+		s.Equal(commonpb.ErrorCode_Success, insertResult.GetStatus().GetErrorCode())
+	}
+
+	// Flush
+	flushResp, err := c.MilvusClient.Flush(ctx, &milvuspb.FlushRequest{
+		DbName:          dbName,
+		CollectionNames: []string{collectionName},
+	})
+	s.NoError(err)
+	segmentIDs, has := flushResp.GetCollSegIDs()[collectionName]
+	ids := segmentIDs.GetData()
+	s.Require().NotEmpty(segmentIDs)
+	s.Require().True(has)
+	flushTs, has := flushResp.GetCollFlushTs()[collectionName]
+	s.True(has)
+	s.WaitForFlush(ctx, ids, flushTs, dbName, collectionName)
+
+	// Create index
+	createIndexStatus, err := c.MilvusClient.CreateIndex(ctx, &milvuspb.CreateIndexRequest{
+		CollectionName: collectionName,
+		FieldName:      integration.FloatVecField,
+		IndexName:      "_default",
+		ExtraParams:    integration.ConstructIndexParam(dim, integration.IndexFaissIvfFlat, metric.L2),
+	})
+	s.NoError(err)
+	s.Equal(commonpb.ErrorCode_Success, createIndexStatus.GetErrorCode())
+	s.WaitForIndexBuilt(ctx, collectionName, integration.FloatVecField)
+
+	// Load
+	loadStatus, err := c.MilvusClient.LoadCollection(ctx, &milvuspb.LoadCollectionRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+	})
+	s.NoError(err)
+	s.Equal(commonpb.ErrorCode_Success, loadStatus.GetErrorCode())
+	s.WaitForLoad(ctx, collectionName)
+
+	// Helper: query with count(*) and return the count
+	queryCount := func(expr string) int64 {
+		queryResult, err := c.MilvusClient.Query(ctx, &milvuspb.QueryRequest{
+			DbName:         dbName,
+			CollectionName: collectionName,
+			Expr:           expr,
+			OutputFields:   []string{"count(*)"},
+		})
+		s.NoError(err)
+		s.Equal(commonpb.ErrorCode_Success, queryResult.GetStatus().GetErrorCode())
+		return queryResult.GetFieldsData()[0].GetScalars().GetLongData().GetData()[0]
+	}
+
+	// Helper: query that should fail with an error
+	queryExpectError := func(expr string) {
+		queryResult, err := c.MilvusClient.Query(ctx, &milvuspb.QueryRequest{
+			DbName:         dbName,
+			CollectionName: collectionName,
+			Expr:           expr,
+			OutputFields:   []string{"count(*)"},
+		})
+		s.NoError(err)
+		s.NotEqual(commonpb.ErrorCode_Success, queryResult.GetStatus().GetErrorCode(),
+			"expr %q should fail under partition key isolation", expr)
+		log.Info("partition key isolation: correctly rejected",
+			zap.String("expr", expr),
+			zap.String("reason", queryResult.GetStatus().GetReason()))
+	}
+
+	// Helper: search that should fail with an error
+	searchExpectError := func(expr string) {
+		nq := 10
+		topk := 10
+		roundDecimal := -1
+		params := integration.GetSearchParams(integration.IndexFaissIvfFlat, metric.L2)
+		searchReq := integration.ConstructSearchRequest("", collectionName, expr,
+			integration.FloatVecField, schemapb.DataType_FloatVector, nil, metric.L2, params, nq, dim, topk, roundDecimal)
+
+		searchResult, err := c.MilvusClient.Search(ctx, searchReq)
+		s.NoError(err)
+		s.NotEqual(commonpb.ErrorCode_Success, searchResult.GetStatus().GetErrorCode(),
+			"search with expr %q should fail under partition key isolation", expr)
+		log.Info("partition key isolation: search correctly rejected",
+			zap.String("expr", expr),
+			zap.String("reason", searchResult.GetStatus().GetReason()))
+	}
+
+	// ── Valid expressions (only == on partition key) ──
+
+	// Test 1: pid == 1 (single equality — the only supported form)
+	count := queryCount("pid == 1")
+	s.Equal(int64(rowNum), count, "pid == 1 should return %d rows", rowNum)
+	log.Info("partition key isolation: pid == 1", zap.Int64("count", count))
+
+	// Test 2: pid == 1 && additional filter (AND with equality)
+	count = queryCount(fmt.Sprintf("pid == 1 && %s >= 0", integration.Int64Field))
+	s.Equal(int64(rowNum), count, "pid == 1 with AND filter should return %d rows", rowNum)
+	log.Info("partition key isolation: pid == 1 && pk >= 0", zap.Int64("count", count))
+
+	// Test 3: search with pid == 1 (valid)
+	{
+		expr := "pid == 1"
+		nq := 10
+		topk := 10
+		roundDecimal := -1
+		params := integration.GetSearchParams(integration.IndexFaissIvfFlat, metric.L2)
+		searchReq := integration.ConstructSearchRequest("", collectionName, expr,
+			integration.FloatVecField, schemapb.DataType_FloatVector, nil, metric.L2, params, nq, dim, topk, roundDecimal)
+
+		searchResult, err := c.MilvusClient.Search(ctx, searchReq)
+		s.NoError(err)
+		s.Equal(commonpb.ErrorCode_Success, searchResult.GetStatus().GetErrorCode())
+		log.Info("partition key isolation: search with pid == 1",
+			zap.Int("numResults", len(searchResult.GetResults().GetScores())))
+	}
+
+	// ── Invalid expressions (IN and OR are rejected under isolation) ──
+
+	// Test 4: pid in [1, 10] — rejected (IN not supported)
+	queryExpectError("pid in [1, 10]")
+
+	// Test 5: pid == 1 || pid == 10 — rejected (OR not supported;
+	// rewriter may merge to IN, which is also rejected)
+	queryExpectError("pid == 1 || pid == 10")
+
+	// Test 6: pid in [1, 10, 100] — rejected
+	queryExpectError("pid in [1, 10, 100]")
+
+	// Test 7: pid == 1 || pid == 10 || pid == 100 — rejected
+	queryExpectError("pid == 1 || pid == 10 || pid == 100")
+
+	// Test 8: search with pid in [1, 10] — rejected
+	searchExpectError("pid in [1, 10]")
+
+	// Test 9: search with pid == 1 || pid == 10 — rejected
+	searchExpectError("pid == 1 || pid == 10")
+
+	// ── Edge cases ──
+
+	// Test 10: pid == 1 && pid in [1, 10] — rejected (contains IN on partition key)
+	queryExpectError("pid == 1 && pid in [1, 10]")
+
+	// Test 11: pid == 1 && pid == 1 — redundant equality, should still be valid
+	count = queryCount("pid == 1 && pid == 1")
+	s.Equal(int64(rowNum), count, "pid == 1 && pid == 1 should return %d rows", rowNum)
+	log.Info("partition key isolation: pid == 1 && pid == 1", zap.Int64("count", count))
+
+	// Test 12: no partition key filter at all — rejected under isolation
+	queryExpectError(fmt.Sprintf("%s >= 0", integration.Int64Field))
+
+	// Test 13: search without partition key filter — rejected under isolation
+	searchExpectError(fmt.Sprintf("%s >= 0", integration.Int64Field))
+
+	// ── Non-partition-key expressions should not be affected when pid is given ──
+
+	// Test 14: pid == 1 && pk IN list — IN on non-partition-key field is fine
+	count = queryCount("pid == 1 && int64Field in [0, 1, 2, 3, 4]")
+	s.Equal(int64(5), count, "pid == 1 && int64Field in [0..4] should return 5 rows")
+	log.Info("partition key isolation: pid == 1 && pk IN list", zap.Int64("count", count))
+
+	// Test 15: pid == 1 && pk OR conditions — OR on non-partition-key field is fine
+	count = queryCount("pid == 1 && (int64Field == 0 || int64Field == 1)")
+	s.Equal(int64(2), count, "pid == 1 && (pk==0 || pk==1) should return 2 rows")
+	log.Info("partition key isolation: pid == 1 && pk OR", zap.Int64("count", count))
+
+	// Test 16: pid == 1 && complex non-pk expression (range + IN)
+	count = queryCount("pid == 1 && int64Field >= 0 && int64Field < 500")
+	s.Equal(int64(500), count, "pid == 1 && pk range [0,500) should return 500 rows")
+	log.Info("partition key isolation: pid == 1 && pk range", zap.Int64("count", count))
+
+	// Test 17: pid == 1 && non-pk NOT IN
+	count = queryCount("pid == 1 && int64Field not in [0, 1, 2]")
+	s.Equal(int64(rowNum-3), count, "pid == 1 && pk not in [0,1,2] should return %d rows", rowNum-3)
+	log.Info("partition key isolation: pid == 1 && pk NOT IN", zap.Int64("count", count))
+
+	// Test 18: search with pid == 1 && non-pk complex filter — should succeed
+	{
+		expr := "pid == 1 && int64Field >= 0"
+		nq := 10
+		topk := 10
+		roundDecimal := -1
+		params := integration.GetSearchParams(integration.IndexFaissIvfFlat, metric.L2)
+		searchReq := integration.ConstructSearchRequest("", collectionName, expr,
+			integration.FloatVecField, schemapb.DataType_FloatVector, nil, metric.L2, params, nq, dim, topk, roundDecimal)
+
+		searchResult, err := c.MilvusClient.Search(ctx, searchReq)
+		s.NoError(err)
+		s.Equal(commonpb.ErrorCode_Success, searchResult.GetStatus().GetErrorCode())
+		log.Info("partition key isolation: search with pid == 1 && non-pk filter",
+			zap.Int("numResults", len(searchResult.GetResults().GetScores())))
 	}
 }


### PR DESCRIPTION
## Summary

- **SIMD batch filter** for numeric TermExpr IN: runtime-dispatched (AVX-512 / AVX2 / SSE2 / NEON), significantly faster than hash set for small-to-medium IN lists, auto-switches to hash for large IN lists based on `simdLaneCount<T>() * 8` threshold
- **Go rewriter optimizations**: removed `shouldUseInExpr` threshold-based IN splitting (all IN now kept for SIMD), single-value IN \u2192 equality, OR-equals always merge to IN (\u2265 2 values), sort/dedup of IN values with NaN handling fix
- **String FilterChunk**: bypasses ValueType variant construction, supports heterogeneous `string_view` lookup via transparent hash (zero-copy for sealed/mmap segments)
- **SetElement\<bool\> specialization**: two-flag (`has_true_`/`has_false_`) implementation to avoid `ankerl::unordered_dense::hash<bool>` ASAN crash (wyhash reads 8 bytes from 1-byte bool). Unifies TermExpr and JsonContainsExpr bool paths through the same specialization
- **SetElement load factor**: set to 0.5 for better hash lookup performance

## Test plan

- Go unit tests: threshold removal, single-value folding, OR/AND combining, Timestamptz support, Geometry/Text blocking
- C++ unit tests: SimdBatchElement In() and FilterChunk for all numeric types, SetElement\<bool\> specialization (both `vector<bool>` and `GenericValue` constructors), string/string_view FilterChunk edge cases
- CI: ut-cpp, ut-go, e2e

issue: #48609
