### PR TITLE
enhance: shallow copy SearchRequest to avoid deep-copying large fields per shard

### DIFF
--- a/internal/proxy/task_query.go
+++ b/internal/proxy/task_query.go
@@ -24,6 +24,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/reduce"
 	"github.com/milvus-io/milvus/internal/util/reduce/orderby"
 	"github.com/milvus-io/milvus/internal/util/segcore"
+	"github.com/milvus-io/milvus/internal/util/shallowcopy"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/metrics"
@@ -995,8 +996,7 @@ func (t *queryTask) queryShard(ctx context.Context, nodeID int64, qn types.Query
 		}
 	}
 
-	retrieveReq := typeutil.Clone(t.RetrieveRequest)
-	retrieveReq.GetBase().TargetID = nodeID
+	retrieveReq := shallowcopy.ShallowCopyRetrieveRequest(t.RetrieveRequest, nodeID)
 	if needOverrideMvcc && mvccTs > 0 {
 		retrieveReq.MvccTimestamp = mvccTs
 		retrieveReq.GuaranteeTimestamp = mvccTs

--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -27,6 +27,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/function/models"
 	"github.com/milvus-io/milvus/internal/util/function/rerank"
 	"github.com/milvus-io/milvus/internal/util/segcore"
+	"github.com/milvus-io/milvus/internal/util/shallowcopy"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/metrics"
@@ -601,7 +602,9 @@ func (t *searchTask) fillResult() {
 
 func (t *searchTask) getBM25SearchTexts(placeholder []byte) ([]string, error) {
 	pb := &commonpb.PlaceholderGroup{}
-	proto.Unmarshal(placeholder, pb)
+	if err := proto.Unmarshal(placeholder, pb); err != nil {
+		return nil, merr.WrapErrServiceInternal("failed to unmarshal BM25 search placeholder group", err.Error())
+	}
 
 	if len(pb.Placeholders) != 1 || len(pb.Placeholders[0].Values) == 0 {
 		return nil, merr.WrapErrParameterInvalidMsg("please provide varchar/text for BM25 Function based search")
@@ -1090,8 +1093,7 @@ func (t *searchTask) PostExecute(ctx context.Context) error {
 }
 
 func (t *searchTask) searchShard(ctx context.Context, nodeID int64, qn types.QueryNodeClient, channel string) error {
-	searchReq := typeutil.Clone(t.SearchRequest)
-	searchReq.GetBase().TargetID = nodeID
+	searchReq := shallowcopy.ShallowCopySearchRequest(t.SearchRequest, nodeID)
 	req := &querypb.SearchRequest{
 		Req:             searchReq,
 		DmlChannels:     []string{channel},

--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -46,6 +46,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/function"
 	"github.com/milvus-io/milvus/internal/util/reduce"
 	"github.com/milvus-io/milvus/internal/util/searchutil/optimizers"
+	"github.com/milvus-io/milvus/internal/util/shallowcopy"
 	"github.com/milvus-io/milvus/internal/util/streamrpc"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/log"
@@ -250,92 +251,21 @@ func (sd *shardDelegator) GetPartitionStatsVersions(ctx context.Context) map[int
 	return partStatMap
 }
 
-func (sd *shardDelegator) shallowCopySearchRequest(req *internalpb.SearchRequest, targetID int64) *internalpb.SearchRequest {
-	// Create a new SearchRequest with the same fields
-	nodeReq := &internalpb.SearchRequest{
-		Base:                    &commonpb.MsgBase{TargetID: targetID},
-		ReqID:                   req.ReqID,
-		DbID:                    req.DbID,
-		CollectionID:            req.CollectionID,
-		PartitionIDs:            req.PartitionIDs, // Shallow copy: Same underlying slice
-		Dsl:                     req.Dsl,
-		PlaceholderGroup:        req.PlaceholderGroup, // Shallow copy: Same underlying byte slice
-		DslType:                 req.DslType,
-		SerializedExprPlan:      req.SerializedExprPlan, // Shallow copy: Same underlying byte slice
-		OutputFieldsId:          req.OutputFieldsId,     // Shallow copy: Same underlying slice
-		MvccTimestamp:           req.MvccTimestamp,
-		GuaranteeTimestamp:      req.GuaranteeTimestamp,
-		TimeoutTimestamp:        req.TimeoutTimestamp,
-		Nq:                      req.Nq,
-		Topk:                    req.Topk,
-		MetricType:              req.MetricType,
-		IgnoreGrowing:           req.IgnoreGrowing,
-		Username:                req.Username,
-		SubReqs:                 req.SubReqs, // Shallow copy: Same underlying slice of pointers
-		IsAdvanced:              req.IsAdvanced,
-		Offset:                  req.Offset,
-		ConsistencyLevel:        req.ConsistencyLevel,
-		GroupByFieldId:          req.GroupByFieldId,
-		GroupSize:               req.GroupSize,
-		FieldId:                 req.FieldId,
-		IsTopkReduce:            req.IsTopkReduce,
-		IsRecallEvaluation:      req.IsRecallEvaluation,
-		CollectionTtlTimestamps: req.CollectionTtlTimestamps,
-		EntityTtlPhysicalTime:   req.EntityTtlPhysicalTime,
-		PkFilter:                req.PkFilter,
-	}
-
-	return nodeReq
-}
-
 func (sd *shardDelegator) modifySearchRequest(req *querypb.SearchRequest, scope querypb.DataScope, segmentIDs []int64, targetID int64) *querypb.SearchRequest {
 	nodeReq := &querypb.SearchRequest{
 		DmlChannels:     []string{sd.vchannelName},
 		SegmentIDs:      segmentIDs,
 		Scope:           scope,
-		Req:             sd.shallowCopySearchRequest(req.GetReq(), targetID),
+		Req:             shallowcopy.ShallowCopySearchRequest(req.GetReq(), targetID),
 		FromShardLeader: req.FromShardLeader,
 		TotalChannelNum: req.TotalChannelNum,
 	}
 	return nodeReq
 }
 
-func (sd *shardDelegator) shallowCopyRetrieveRequest(req *internalpb.RetrieveRequest, targetID int64) *internalpb.RetrieveRequest {
-	// Create a new RetrieveRequest with the same fields
-	// Base must be a new object since each copy needs different TargetID
-	// Slices are shallow copied (same underlying array) since they are read-only after copy
-	return &internalpb.RetrieveRequest{
-		Base:                         &commonpb.MsgBase{TargetID: targetID},
-		ReqID:                        req.ReqID,
-		DbID:                         req.DbID,
-		CollectionID:                 req.CollectionID,
-		PartitionIDs:                 req.PartitionIDs,       // Shallow copy: Same underlying slice
-		SerializedExprPlan:           req.SerializedExprPlan, // Shallow copy: Same underlying byte slice
-		OutputFieldsId:               req.OutputFieldsId,     // Shallow copy: Same underlying slice
-		MvccTimestamp:                req.MvccTimestamp,
-		GuaranteeTimestamp:           req.GuaranteeTimestamp,
-		TimeoutTimestamp:             req.TimeoutTimestamp,
-		Limit:                        req.Limit,
-		IgnoreGrowing:                req.IgnoreGrowing,
-		IsCount:                      req.IsCount,
-		IterationExtensionReduceRate: req.IterationExtensionReduceRate,
-		Username:                     req.Username,
-		ReduceStopForBest:            req.ReduceStopForBest,
-		ReduceType:                   req.ReduceType,
-		ConsistencyLevel:             req.ConsistencyLevel,
-		IsIterator:                   req.IsIterator,
-		CollectionTtlTimestamps:      req.CollectionTtlTimestamps,
-		GroupByFieldIds:              req.GroupByFieldIds, // Shallow copy: Same underlying slice
-		Aggregates:                   req.Aggregates,      // Shallow copy: Same underlying slice of pointers
-		EntityTtlPhysicalTime:        req.EntityTtlPhysicalTime,
-		OrderByFields:                req.OrderByFields, // Shallow copy: Same underlying slice of pointers
-		PkFilter:                     req.PkFilter,
-	}
-}
-
 func (sd *shardDelegator) modifyQueryRequest(req *querypb.QueryRequest, scope querypb.DataScope, segmentIDs []int64, targetID int64) *querypb.QueryRequest {
 	return &querypb.QueryRequest{
-		Req:             sd.shallowCopyRetrieveRequest(req.GetReq(), targetID),
+		Req:             shallowcopy.ShallowCopyRetrieveRequest(req.GetReq(), targetID),
 		DmlChannels:     []string{sd.vchannelName},
 		SegmentIDs:      segmentIDs,
 		FromShardLeader: req.FromShardLeader,

--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -1037,7 +1037,9 @@ func (sd *shardDelegator) TryCleanExcludedSegments(ts uint64) {
 
 func (sd *shardDelegator) buildBM25IDF(req *internalpb.SearchRequest) (float64, error) {
 	pb := &commonpb.PlaceholderGroup{}
-	proto.Unmarshal(req.GetPlaceholderGroup(), pb)
+	if err := proto.Unmarshal(req.GetPlaceholderGroup(), pb); err != nil {
+		return 0, merr.WrapErrServiceInternal("failed to unmarshal BM25 IDF placeholder group", err.Error())
+	}
 
 	if len(pb.Placeholders) != 1 || len(pb.Placeholders[0].Values) == 0 {
 		return 0, merr.WrapErrParameterInvalidMsg("please provide varchar/text for BM25 Function based search")
@@ -1104,7 +1106,9 @@ func (sd *shardDelegator) buildBM25IDF(req *internalpb.SearchRequest) (float64, 
 
 func (sd *shardDelegator) parseMinHash(req *internalpb.SearchRequest) error {
 	pb := &commonpb.PlaceholderGroup{}
-	proto.Unmarshal(req.GetPlaceholderGroup(), pb)
+	if err := proto.Unmarshal(req.GetPlaceholderGroup(), pb); err != nil {
+		return merr.WrapErrServiceInternal("failed to unmarshal MinHash placeholder group", err.Error())
+	}
 
 	if len(pb.Placeholders) != 1 || len(pb.Placeholders[0].Values) == 0 {
 		return merr.WrapErrParameterInvalidMsg("please provide varchar/text for MinHash Function based search")

--- a/internal/querynodev2/delegator/shallow_copy_benchmark_test.go
+++ b/internal/querynodev2/delegator/shallow_copy_benchmark_test.go
@@ -23,6 +23,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus/internal/util/shallowcopy"
 	"github.com/milvus-io/milvus/pkg/v2/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/planpb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/querypb"
@@ -245,8 +246,7 @@ func TestShallowCopyRetrieveRequest_OrderByFields(t *testing.T) {
 		OrderByFields: orderByFields,
 	}
 
-	sd := &shardDelegator{}
-	copied := sd.shallowCopyRetrieveRequest(req, 99)
+	copied := shallowcopy.ShallowCopyRetrieveRequest(req, 99)
 
 	// Verify OrderByFields is shallow-copied
 	assert.Equal(t, len(req.OrderByFields), len(copied.OrderByFields))
@@ -292,8 +292,7 @@ func TestShallowCopyRetrieveRequest_AllFields(t *testing.T) {
 		OrderByFields:                []*planpb.OrderByField{{FieldId: 101, Ascending: true}},
 	}
 
-	sd := &shardDelegator{}
-	copied := sd.shallowCopyRetrieveRequest(req, 99)
+	copied := shallowcopy.ShallowCopyRetrieveRequest(req, 99)
 
 	assert.Equal(t, int64(99), copied.Base.TargetID)
 	assert.Equal(t, req.ReqID, copied.ReqID)

--- a/internal/querynodev2/delegator/shallow_copy_test.go
+++ b/internal/querynodev2/delegator/shallow_copy_test.go
@@ -22,12 +22,11 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus/internal/util/shallowcopy"
 	"github.com/milvus-io/milvus/pkg/v2/proto/internalpb"
 )
 
 func TestShallowCopySearchRequest_EntityTtlPhysicalTime(t *testing.T) {
-	sd := &shardDelegator{}
-
 	req := &internalpb.SearchRequest{
 		Base:                    &commonpb.MsgBase{TargetID: 1},
 		CollectionID:            1000,
@@ -37,7 +36,7 @@ func TestShallowCopySearchRequest_EntityTtlPhysicalTime(t *testing.T) {
 		EntityTtlPhysicalTime:   1773682085500000,
 	}
 
-	copied := sd.shallowCopySearchRequest(req, 2)
+	copied := shallowcopy.ShallowCopySearchRequest(req, 2)
 
 	assert.Equal(t, req.EntityTtlPhysicalTime, copied.EntityTtlPhysicalTime,
 		"EntityTtlPhysicalTime must be preserved in shallow copy")

--- a/internal/util/shallowcopy/shallowcopy.go
+++ b/internal/util/shallowcopy/shallowcopy.go
@@ -1,0 +1,81 @@
+package shallowcopy
+
+import (
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/internalpb"
+)
+
+// ShallowCopySearchRequest creates a lightweight copy of SearchRequest that shares
+// all slice/bytes fields with the original. Only Base is newly allocated with TargetID set.
+func ShallowCopySearchRequest(src *internalpb.SearchRequest, targetID int64) *internalpb.SearchRequest {
+	if src == nil {
+		return nil
+	}
+	return &internalpb.SearchRequest{
+		Base:                    &commonpb.MsgBase{TargetID: targetID},
+		ReqID:                   src.ReqID,
+		DbID:                    src.DbID,
+		CollectionID:            src.CollectionID,
+		PartitionIDs:            src.PartitionIDs,
+		Dsl:                     src.Dsl,
+		PlaceholderGroup:        src.PlaceholderGroup,
+		DslType:                 src.DslType,
+		SerializedExprPlan:      src.SerializedExprPlan,
+		OutputFieldsId:          src.OutputFieldsId,
+		MvccTimestamp:           src.MvccTimestamp,
+		GuaranteeTimestamp:      src.GuaranteeTimestamp,
+		TimeoutTimestamp:        src.TimeoutTimestamp,
+		Nq:                      src.Nq,
+		Topk:                    src.Topk,
+		MetricType:              src.MetricType,
+		IgnoreGrowing:           src.IgnoreGrowing,
+		Username:                src.Username,
+		SubReqs:                 src.SubReqs,
+		IsAdvanced:              src.IsAdvanced,
+		Offset:                  src.Offset,
+		ConsistencyLevel:        src.ConsistencyLevel,
+		GroupByFieldId:          src.GroupByFieldId,
+		GroupSize:               src.GroupSize,
+		FieldId:                 src.FieldId,
+		IsTopkReduce:            src.IsTopkReduce,
+		IsRecallEvaluation:      src.IsRecallEvaluation,
+		IsIterator:              src.IsIterator,
+		AnalyzerName:            src.AnalyzerName,
+		CollectionTtlTimestamps: src.CollectionTtlTimestamps,
+		EntityTtlPhysicalTime:   src.EntityTtlPhysicalTime,
+	}
+}
+
+// ShallowCopyRetrieveRequest creates a lightweight copy of RetrieveRequest that shares
+// all slice/bytes fields with the original. Only Base is newly allocated with TargetID set.
+func ShallowCopyRetrieveRequest(src *internalpb.RetrieveRequest, targetID int64) *internalpb.RetrieveRequest {
+	if src == nil {
+		return nil
+	}
+	return &internalpb.RetrieveRequest{
+		Base:                         &commonpb.MsgBase{TargetID: targetID},
+		ReqID:                        src.ReqID,
+		DbID:                         src.DbID,
+		CollectionID:                 src.CollectionID,
+		PartitionIDs:                 src.PartitionIDs,
+		SerializedExprPlan:           src.SerializedExprPlan,
+		OutputFieldsId:               src.OutputFieldsId,
+		MvccTimestamp:                src.MvccTimestamp,
+		GuaranteeTimestamp:           src.GuaranteeTimestamp,
+		TimeoutTimestamp:             src.TimeoutTimestamp,
+		Limit:                        src.Limit,
+		IgnoreGrowing:                src.IgnoreGrowing,
+		IsCount:                      src.IsCount,
+		IterationExtensionReduceRate: src.IterationExtensionReduceRate,
+		Username:                     src.Username,
+		ReduceStopForBest:            src.ReduceStopForBest,
+		ReduceType:                   src.ReduceType,
+		ConsistencyLevel:             src.ConsistencyLevel,
+		IsIterator:                   src.IsIterator,
+		CollectionTtlTimestamps:      src.CollectionTtlTimestamps,
+		GroupByFieldIds:              src.GroupByFieldIds,
+		Aggregates:                   src.Aggregates,
+		EntityTtlPhysicalTime:        src.EntityTtlPhysicalTime,
+		OrderByFields:                src.OrderByFields,
+	}
+}

--- a/internal/util/shallowcopy/shallowcopy.go
+++ b/internal/util/shallowcopy/shallowcopy.go
@@ -77,5 +77,6 @@ func ShallowCopyRetrieveRequest(src *internalpb.RetrieveRequest, targetID int64)
 		Aggregates:                   src.Aggregates,
 		EntityTtlPhysicalTime:        src.EntityTtlPhysicalTime,
 		OrderByFields:                src.OrderByFields,
+		QueryLabel:                   src.QueryLabel,
 	}
 }

--- a/internal/util/shallowcopy/shallowcopy.go
+++ b/internal/util/shallowcopy/shallowcopy.go
@@ -43,6 +43,7 @@ func ShallowCopySearchRequest(src *internalpb.SearchRequest, targetID int64) *in
 		AnalyzerName:            src.AnalyzerName,
 		CollectionTtlTimestamps: src.CollectionTtlTimestamps,
 		EntityTtlPhysicalTime:   src.EntityTtlPhysicalTime,
+		PkFilter:                src.PkFilter,
 	}
 }
 
@@ -78,5 +79,6 @@ func ShallowCopyRetrieveRequest(src *internalpb.RetrieveRequest, targetID int64)
 		EntityTtlPhysicalTime:        src.EntityTtlPhysicalTime,
 		OrderByFields:                src.OrderByFields,
 		QueryLabel:                   src.QueryLabel,
+		PkFilter:                     src.PkFilter,
 	}
 }

--- a/internal/util/shallowcopy/shallowcopy_test.go
+++ b/internal/util/shallowcopy/shallowcopy_test.go
@@ -1,0 +1,106 @@
+package shallowcopy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/internalpb"
+)
+
+func TestShallowCopySearchRequest(t *testing.T) {
+	t.Run("nil input", func(t *testing.T) {
+		assert.Nil(t, ShallowCopySearchRequest(nil, 1))
+	})
+
+	t.Run("copies all fields and sets targetID", func(t *testing.T) {
+		src := &internalpb.SearchRequest{
+			Base:                    &commonpb.MsgBase{TargetID: 100, SourceID: 200},
+			ReqID:                   1,
+			DbID:                    2,
+			CollectionID:            3,
+			PartitionIDs:            []int64{10, 20},
+			Dsl:                     "dsl",
+			PlaceholderGroup:        []byte("placeholder"),
+			SerializedExprPlan:      []byte("plan"),
+			OutputFieldsId:          []int64{1, 2},
+			MvccTimestamp:           100,
+			Nq:                      5,
+			Topk:                    10,
+			MetricType:              "L2",
+			IgnoreGrowing:           true,
+			Username:                "user",
+			IsAdvanced:              true,
+			Offset:                  5,
+			GroupByFieldId:          7,
+			GroupSize:               3,
+			FieldId:                 8,
+			IsTopkReduce:            true,
+			IsRecallEvaluation:      true,
+			IsIterator:              true,
+			AnalyzerName:            "analyzer",
+			CollectionTtlTimestamps: 999,
+			EntityTtlPhysicalTime:   888,
+		}
+
+		dst := ShallowCopySearchRequest(src, 42)
+
+		// Base is new with correct TargetID
+		assert.Equal(t, int64(42), dst.Base.TargetID)
+		// Original Base not modified
+		assert.Equal(t, int64(100), src.Base.TargetID)
+
+		// Scalar fields copied
+		assert.Equal(t, src.ReqID, dst.ReqID)
+		assert.Equal(t, src.CollectionID, dst.CollectionID)
+		assert.Equal(t, src.Nq, dst.Nq)
+		assert.Equal(t, src.Topk, dst.Topk)
+		assert.Equal(t, src.IsIterator, dst.IsIterator)
+		assert.Equal(t, src.AnalyzerName, dst.AnalyzerName)
+		assert.Equal(t, src.EntityTtlPhysicalTime, dst.EntityTtlPhysicalTime)
+
+		// Slices share underlying array (shallow copy)
+		assert.Equal(t, src.PartitionIDs, dst.PartitionIDs)
+		assert.Equal(t, src.PlaceholderGroup, dst.PlaceholderGroup)
+		assert.Equal(t, src.SerializedExprPlan, dst.SerializedExprPlan)
+	})
+}
+
+func TestShallowCopyRetrieveRequest(t *testing.T) {
+	t.Run("nil input", func(t *testing.T) {
+		assert.Nil(t, ShallowCopyRetrieveRequest(nil, 1))
+	})
+
+	t.Run("copies all fields and sets targetID", func(t *testing.T) {
+		src := &internalpb.RetrieveRequest{
+			Base:                    &commonpb.MsgBase{TargetID: 100},
+			ReqID:                   1,
+			CollectionID:            3,
+			PartitionIDs:            []int64{10, 20},
+			SerializedExprPlan:      []byte("plan"),
+			OutputFieldsId:          []int64{1, 2},
+			MvccTimestamp:           100,
+			Limit:                   50,
+			IgnoreGrowing:           true,
+			IsCount:                 true,
+			Username:                "user",
+			IsIterator:              true,
+			CollectionTtlTimestamps: 999,
+			EntityTtlPhysicalTime:   888,
+			QueryLabel:              "query",
+		}
+
+		dst := ShallowCopyRetrieveRequest(src, 42)
+
+		assert.Equal(t, int64(42), dst.Base.TargetID)
+		assert.Equal(t, int64(100), src.Base.TargetID)
+		assert.Equal(t, src.ReqID, dst.ReqID)
+		assert.Equal(t, src.CollectionID, dst.CollectionID)
+		assert.Equal(t, src.Limit, dst.Limit)
+		assert.Equal(t, src.IsIterator, dst.IsIterator)
+		assert.Equal(t, src.EntityTtlPhysicalTime, dst.EntityTtlPhysicalTime)
+		assert.Equal(t, src.QueryLabel, dst.QueryLabel)
+		assert.Equal(t, src.PartitionIDs, dst.PartitionIDs)
+	})
+}


### PR DESCRIPTION
## Summary
- Replace `proto.Clone` (deep copy) with a manual shallow copy for `SearchRequest` in `searchShard`. The shallow copy shares slice/bytes fields (`PlaceholderGroup` ~600KB+, `SerializedExprPlan`, etc.) with the original, only allocating a new `MsgBase` for the per-shard `TargetID`. For 16 shards this avoids ~10MB of unnecessary allocation and memcpy per search.
- Fix three swallowed `proto.Unmarshal` errors in BM25/MinHash paths that previously silently ignored deserialization failures.

issue: #8818

## Test plan
- [ ] Existing search unit tests pass (`make test-proxy`)
- [ ] Existing delegator tests pass (`make test-querynode`)
- [ ] Manual verification with BM25/MinHash search to confirm error propagation

🤖 Generated with [Claude Code](https://claude.com/claude-code)