### PR TITLE
fix: suppress gosec G204 in test helper runShellCommand

### DIFF
--- a/tests/go_client/testcases/external_table_refresh_test.go
+++ b/tests/go_client/testcases/external_table_refresh_test.go
@@ -1168,7 +1168,7 @@ func generateLanceDataOnMinIO(t *testing.T, s3URI string, numRows, startID int) 
 // runShellCommand runs a shell command and returns its combined output.
 func runShellCommand(t *testing.T, cmd string) (string, error) {
 	t.Helper()
-	c := exec.Command("bash", "-c", cmd)
+	c := exec.Command("bash", "-c", cmd) //nolint:gosec
 	output, err := c.CombinedOutput()
 	return string(output), err
 }


### PR DESCRIPTION
## Summary
- Suppress gosec G204 warning in `runShellCommand` test helper in `external_table_refresh_test.go`
- This is a test-only helper where the command is always constructed by the test itself, so the subprocess-with-variable warning is a false positive
- This lint error is currently blocking all PR code-check pipelines on master

## Test plan
- [x] No functional change — test-only `nolint` annotation

issue: https://github.com/milvus-io/milvus/issues/39893

🤖 Generated with [Claude Code](https://claude.com/claude-code)