### PR TITLE
fix: [cp2.6] force promote RPC hangs forever due to missing doAckCallback invocation

### DIFF
--- a/internal/streamingcoord/server/broadcaster/ack_callback_scheduler.go
+++ b/internal/streamingcoord/server/broadcaster/ack_callback_scheduler.go
@@ -148,15 +148,12 @@ func (s *ackCallbackScheduler) triggerAckCallback() {
 		}
 
 		if task.IsForcePromoteMessage() {
-			// Force promote: fix incomplete broadcasts in background (BlockUntilAllAck → fix).
+			// Force promote: fix incomplete broadcasts, then run normal ack callback.
 			// Launch goroutine only after FastLock succeeds to prevent duplicate processing.
+			// doAckCallback handles g.Unlock() internally via its defer.
 			go func() {
-				defer func() {
-					s.rkLockerMu.Lock()
-					g.Unlock()
-					s.rkLockerMu.Unlock()
-				}()
 				s.doForcePromoteFixIncompleteBroadcasts(task)
+				s.doAckCallback(task, g)
 			}()
 			continue
 		}
@@ -168,7 +165,7 @@ func (s *ackCallbackScheduler) triggerAckCallback() {
 }
 
 // doForcePromoteFixIncompleteBroadcasts waits for all acks, then fixes incomplete broadcasts.
-// The actual ack callback is handled by the normal doAckCallback path.
+// After this returns, the caller must invoke doAckCallback to close the done channel and unblock the RPC.
 func (s *ackCallbackScheduler) doForcePromoteFixIncompleteBroadcasts(bt *broadcastTask) {
 	logger := s.Logger().With(zap.Uint64("broadcastID", bt.Header().BroadcastID))
 

--- a/internal/streamingcoord/server/service/assignment.go
+++ b/internal/streamingcoord/server/service/assignment.go
@@ -241,8 +241,14 @@ func (s *assignmentServiceImpl) handleForcePromote(ctx context.Context, config *
 	}
 	defer broadcaster.Close()
 
-	// Validate and construct force promote configuration
-	forcePromoteConfig, pchannels, err := s.validateForcePromoteConfiguration(ctx)
+	// Validate the caller-supplied config.
+	currentClusterID := paramtable.Get().CommonCfg.ClusterPrefix.GetValue()
+	if err := validateForcePromoteConfiguration(config, currentClusterID); err != nil {
+		return nil, err
+	}
+
+	// Derive and construct the actual force-promote config from current etcd state.
+	forcePromoteConfig, pchannels, err := s.buildForcePromoteConfiguration(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -281,9 +287,9 @@ func (s *assignmentServiceImpl) handleForcePromote(ctx context.Context, config *
 	return &streamingpb.UpdateReplicateConfigurationResponse{}, nil
 }
 
-// validateForcePromoteConfiguration validates the current cluster state and constructs
+// buildForcePromoteConfiguration reads the current cluster state from etcd and constructs
 // the force promote configuration. It returns the new config and the list of pchannels.
-func (s *assignmentServiceImpl) validateForcePromoteConfiguration(ctx context.Context) (*commonpb.ReplicateConfiguration, []string, error) {
+func (s *assignmentServiceImpl) buildForcePromoteConfiguration(ctx context.Context) (*commonpb.ReplicateConfiguration, []string, error) {
 	balancer, err := balance.GetWithContext(ctx)
 	if err != nil {
 		return nil, nil, err

--- a/internal/streamingcoord/server/service/assignment_test.go
+++ b/internal/streamingcoord/server/service/assignment_test.go
@@ -346,10 +346,14 @@ func TestForcePromoteSuccess(t *testing.T) {
 
 	as := NewAssignmentService()
 
-	// Force promote with empty config (configuration is auto-constructed)
+	// Force promote with config specifying only the current cluster (no topology)
 	resp, err := as.UpdateReplicateConfiguration(context.Background(), &streamingpb.UpdateReplicateConfigurationRequest{
-		Configuration: &commonpb.ReplicateConfiguration{},
-		ForcePromote:  true,
+		Configuration: &commonpb.ReplicateConfiguration{
+			Clusters: []*commonpb.MilvusCluster{
+				{ClusterId: "by-dev"},
+			},
+		},
+		ForcePromote: true,
 	})
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
@@ -407,10 +411,14 @@ func TestForcePromoteIdempotent(t *testing.T) {
 
 	as := NewAssignmentService()
 
-	// Force promote with empty config - auto-constructed config matches existing
+	// Force promote with config specifying only the current cluster (no topology)
 	resp, err := as.UpdateReplicateConfiguration(context.Background(), &streamingpb.UpdateReplicateConfigurationRequest{
-		Configuration: &commonpb.ReplicateConfiguration{},
-		ForcePromote:  true,
+		Configuration: &commonpb.ReplicateConfiguration{
+			Clusters: []*commonpb.MilvusCluster{
+				{ClusterId: "by-dev"},
+			},
+		},
+		ForcePromote: true,
 	})
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
@@ -609,10 +617,14 @@ func TestForcePromoteBroadcastAppendError(t *testing.T) {
 	broadcast.Register(mb)
 
 	as := NewAssignmentService()
-	// Force promote with empty config
+	// Force promote with config specifying only the current cluster (no topology)
 	_, err := as.UpdateReplicateConfiguration(context.Background(), &streamingpb.UpdateReplicateConfigurationRequest{
-		Configuration: &commonpb.ReplicateConfiguration{},
-		ForcePromote:  true,
+		Configuration: &commonpb.ReplicateConfiguration{
+			Clusters: []*commonpb.MilvusCluster{
+				{ClusterId: "by-dev"},
+			},
+		},
+		ForcePromote: true,
 	})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "broadcast append failed")
@@ -994,10 +1006,14 @@ func TestHandleForcePromoteGetAssignmentError(t *testing.T) {
 	broadcast.Register(mb)
 
 	as := NewAssignmentService()
-	// Force promote with empty config
+	// Force promote with config specifying only the current cluster (no topology)
 	_, err := as.UpdateReplicateConfiguration(context.Background(), &streamingpb.UpdateReplicateConfigurationRequest{
-		Configuration: &commonpb.ReplicateConfiguration{},
-		ForcePromote:  true,
+		Configuration: &commonpb.ReplicateConfiguration{
+			Clusters: []*commonpb.MilvusCluster{
+				{ClusterId: "by-dev"},
+			},
+		},
+		ForcePromote: true,
 	})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "assignment error")
@@ -1058,10 +1074,14 @@ func TestHandleForcePromoteSameConfigAfterBroadcasterCheck(t *testing.T) {
 	broadcast.Register(mb)
 
 	as := NewAssignmentService()
-	// Force promote with empty config
+	// Force promote with config specifying only the current cluster (no topology)
 	resp, err := as.UpdateReplicateConfiguration(context.Background(), &streamingpb.UpdateReplicateConfigurationRequest{
-		Configuration: &commonpb.ReplicateConfiguration{},
-		ForcePromote:  true,
+		Configuration: &commonpb.ReplicateConfiguration{
+			Clusters: []*commonpb.MilvusCluster{
+				{ClusterId: "by-dev"},
+			},
+		},
+		ForcePromote: true,
 	})
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
@@ -1117,10 +1137,14 @@ func TestHandleForcePromoteValidatorError(t *testing.T) {
 	broadcast.Register(mb)
 
 	as := NewAssignmentService()
-	// Force promote with empty config
+	// Force promote with config specifying only the current cluster (no topology)
 	_, err := as.UpdateReplicateConfiguration(context.Background(), &streamingpb.UpdateReplicateConfigurationRequest{
-		Configuration: &commonpb.ReplicateConfiguration{},
-		ForcePromote:  true,
+		Configuration: &commonpb.ReplicateConfiguration{
+			Clusters: []*commonpb.MilvusCluster{
+				{ClusterId: "by-dev"},
+			},
+		},
+		ForcePromote: true,
 	})
 	assert.Error(t, err)
 }
@@ -1165,8 +1189,12 @@ func TestHandleForcePromoteNoCurrentConfig(t *testing.T) {
 
 	as := NewAssignmentService()
 	_, err := as.UpdateReplicateConfiguration(context.Background(), &streamingpb.UpdateReplicateConfigurationRequest{
-		Configuration: &commonpb.ReplicateConfiguration{},
-		ForcePromote:  true,
+		Configuration: &commonpb.ReplicateConfiguration{
+			Clusters: []*commonpb.MilvusCluster{
+				{ClusterId: "by-dev"},
+			},
+		},
+		ForcePromote: true,
 	})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "force promote requires existing replicate configuration")
@@ -1216,8 +1244,12 @@ func TestHandleForcePromoteClusterNotFound(t *testing.T) {
 
 	as := NewAssignmentService()
 	_, err := as.UpdateReplicateConfiguration(context.Background(), &streamingpb.UpdateReplicateConfigurationRequest{
-		Configuration: &commonpb.ReplicateConfiguration{},
-		ForcePromote:  true,
+		Configuration: &commonpb.ReplicateConfiguration{
+			Clusters: []*commonpb.MilvusCluster{
+				{ClusterId: "by-dev"},
+			},
+		},
+		ForcePromote: true,
 	})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "force promote requires current cluster in existing configuration")
@@ -1384,10 +1416,14 @@ func TestForcePromoteMultiplePChannels(t *testing.T) {
 	broadcast.Register(mb)
 
 	as := NewAssignmentService()
-	// Force promote with empty config - config auto-constructed from meta with all pchannels
+	// Force promote with config specifying only the current cluster (no topology)
 	resp, err := as.UpdateReplicateConfiguration(context.Background(), &streamingpb.UpdateReplicateConfigurationRequest{
-		Configuration: &commonpb.ReplicateConfiguration{},
-		ForcePromote:  true,
+		Configuration: &commonpb.ReplicateConfiguration{
+			Clusters: []*commonpb.MilvusCluster{
+				{ClusterId: "by-dev"},
+			},
+		},
+		ForcePromote: true,
 	})
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)


### PR DESCRIPTION
Cherry-pick from master

pr: #48535
issue: #47352

## Summary

Cherry-picked from master PR #48535 (open - preemptive backport)

**Note**: Original PR is still open. This CP PR should be updated if the original PR changes.

Fixes two bugs in the force promote path of `UpdateReplicateConfiguration`:

1. **Force promote RPC hangs forever**: goroutine in `triggerAckCallback` called `doForcePromoteFixIncompleteBroadcasts` but never `doAckCallback`, so the broadcast task's `done` channel was never closed and `BlockUntilDone()` hung forever. Fixed by chaining `doAckCallback(task, g)` after `doForcePromoteFixIncompleteBroadcasts`.

2. **Missing caller-supplied config validation**: `validateForcePromoteConfiguration` was never called in `handleForcePromote`. Fixed by calling it after broadcaster acquisition. Renamed instance method to `buildForcePromoteConfiguration` to avoid confusion.

## Verification

- [x] File count matches original PR (3 files)
- [x] Code changes verified (+75/-36)
- [x] No conflict markers