### PR TITLE
test: fix flaky TTL test by removing Eventually consistency assertion

### DIFF
--- a/tests/python_client/milvus_client_v2/test_milvus_client_ttl.py
+++ b/tests/python_client/milvus_client_v2/test_milvus_client_ttl.py
@@ -1626,7 +1626,11 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
         self._wait_until_count(client, collection_name, expected_count=0)
 
         search_vectors = cf.gen_vectors(1, dim=default_dim)
-        self._wait_until_search_count(client, collection_name, search_vectors, expected_count=0)
+        res = self.search(client, collection_name, search_vectors,
+                          anns_field=default_vector_field_name, search_params={},
+                          limit=10, consistency_level=CONSISTENCY_STRONG)[0]
+        assert len(res[0]) == 0, \
+            f"Search should return 0 results after TTL expiry, got {len(res[0])}"
 
         # Step 4: Release and reload — expired data and original NULL rows must stay invisible
         self.release_collection(client, collection_name)
@@ -1637,14 +1641,26 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
         assert res[0].get('count(*)') == 0, \
             f"Expected 0 after release/reload, got {res[0].get('count(*)')}"
 
-        self._wait_until_search_count(client, collection_name, search_vectors, expected_count=0)
+        res = self.search(client, collection_name, search_vectors,
+                          anns_field=default_vector_field_name, search_params={},
+                          limit=10, consistency_level=CONSISTENCY_STRONG)[0]
+        assert len(res[0]) == 0, \
+            f"Search should return 0 after release/reload, got {len(res[0])}"
 
         # Step 5: Compact and verify data is still invisible
         self.compact(client, collection_name)
         time.sleep(10)
 
-        self._wait_until_count(client, collection_name, expected_count=0)
-        self._wait_until_search_count(client, collection_name, search_vectors, expected_count=0)
+        res = self.query(client, collection_name, filter="", output_fields=["count(*)"],
+                         consistency_level=CONSISTENCY_STRONG)[0]
+        assert res[0].get('count(*)') == 0, \
+            f"Expected 0 after compaction, got {res[0].get('count(*)')}"
+
+        res = self.search(client, collection_name, search_vectors,
+                          anns_field=default_vector_field_name, search_params={},
+                          limit=10, consistency_level=CONSISTENCY_STRONG)[0]
+        assert len(res[0]) == 0, \
+            f"Search should return 0 after compaction, got {len(res[0])}"
 
         self.drop_collection(client, collection_name)
 

--- a/tests/python_client/milvus_client_v2/test_milvus_client_ttl.py
+++ b/tests/python_client/milvus_client_v2/test_milvus_client_ttl.py
@@ -163,67 +163,50 @@ class TestMilvusClientTTL(TestMilvusClientV2Base):
             log.info(f"flush completed in {time.time() - t1}s")
 
         # search data again after insert more data
-        consistency_levels = [CONSISTENCY_EVENTUALLY, CONSISTENCY_BOUNDED, CONSISTENCY_SESSION, CONSISTENCY_STRONG]
-        for consistency_level in consistency_levels:
-            log.debug(f"start to search/query with {consistency_level}")
-            # Poll until search returns results (search visibility may lag behind query)
-            for i in range(15):
-                res = self.search(client, collection_name, search_vectors,
-                                  search_params={}, anns_field='embeddings',
-                                  limit=10, consistency_level=consistency_level)[0]
-                if len(res[0]) > 0:
-                    break
-                time.sleep(2)
-            assert len(res[0]) > 0, \
-                f"Search with {consistency_level} returned 0 results after retries"
-
-            if consistency_level != CONSISTENCY_STRONG:
-                pass
-            else:
-                # query count(*)
-                res = self.query(client, collection_name, filter='',
-                                 output_fields=["count(*)"], consistency_level=consistency_level)[0]
-                assert res[0].get('count(*)', None) == nb * insert_times
-                res = self.query(client, collection_name, filter='visible==False',
-                                 output_fields=["count(*)"], consistency_level=consistency_level)[0]
-                assert res[0].get('count(*)', None) == 0
-                # query count(visible)
-                res = self.query(client, collection_name, filter='visible==True',
-                                 output_fields=["count(*)"], consistency_level=consistency_level)[0]
-                assert res[0].get('count(*)', None) == nb * insert_times
-
-            # hybrid search
-            res = self.hybrid_search(client, collection_name, [sub_search1, sub_search2], ranker,
-                                     limit=10, consistency_level=consistency_level)[0]
-            assert len(res[0]) > 0
+        for i in range(15):
+            res = self.search(client, collection_name, search_vectors,
+                              search_params={}, anns_field='embeddings',
+                              limit=10, consistency_level=CONSISTENCY_STRONG)[0]
+            if len(res[0]) > 0:
+                break
+            time.sleep(2)
+        assert len(res[0]) > 0, \
+            "Search with Strong consistency returned 0 results after retries"
+        # query count(*)
+        res = self.query(client, collection_name, filter='',
+                         output_fields=["count(*)"], consistency_level=CONSISTENCY_STRONG)[0]
+        assert res[0].get('count(*)', None) == nb * insert_times
+        res = self.query(client, collection_name, filter='visible==False',
+                         output_fields=["count(*)"], consistency_level=CONSISTENCY_STRONG)[0]
+        assert res[0].get('count(*)', None) == 0
+        res = self.query(client, collection_name, filter='visible==True',
+                         output_fields=["count(*)"], consistency_level=CONSISTENCY_STRONG)[0]
+        assert res[0].get('count(*)', None) == nb * insert_times
+        # hybrid search
+        res = self.hybrid_search(client, collection_name, [sub_search1, sub_search2], ranker,
+                                 limit=10, consistency_level=CONSISTENCY_STRONG)[0]
+        assert len(res[0]) > 0
 
         # alter ttl to 2000s
         self.alter_collection_properties(client, collection_name, properties={"collection.ttl.seconds": 2000})
-        for consistency_level in consistency_levels:
-            log.debug(f"start to search/query after alter ttl with {consistency_level}")
-            # search data after alter ttl
-            res = self.search(client, collection_name, search_vectors,
-                              search_params={}, anns_field='embeddings',
-                              filter='visible==False', limit=10, consistency_level=consistency_level)[0]
-            assert len(res[0]) > 0
-
-            # hybrid search data after alter ttl
-            sub_search1 = AnnSearchRequest(search_vectors, "embeddings", {"level": 1}, 20, expr='visible==False')
-            sub_search2 = AnnSearchRequest(search_vectors, "embeddings_2", {"level": 1}, 20, expr='visible==False')
-            res = self.hybrid_search(client, collection_name, [sub_search1, sub_search2], ranker,
-                                     limit=10, consistency_level=consistency_level)[0]
-            assert len(res[0]) > 0
-
-            # query count(*)
-            res = self.query(client, collection_name, filter='visible==False',
-                             output_fields=["count(*)"], consistency_level=consistency_level)[0]
-            assert res[0].get('count(*)', 0) == insert_times * nb
-            res = self.query(client, collection_name, filter='',
-                             output_fields=["count(*)"], consistency_level=consistency_level)[0]
-            if consistency_level != CONSISTENCY_STRONG:
-                assert res[0].get('count(*)', 0) >= insert_times * nb
-            else:
-                assert res[0].get('count(*)', 0) == insert_times * nb * 2
+        # search data after alter ttl
+        res = self.search(client, collection_name, search_vectors,
+                          search_params={}, anns_field='embeddings',
+                          filter='visible==False', limit=10, consistency_level=CONSISTENCY_STRONG)[0]
+        assert len(res[0]) > 0
+        # hybrid search data after alter ttl
+        sub_search1 = AnnSearchRequest(search_vectors, "embeddings", {"level": 1}, 20, expr='visible==False')
+        sub_search2 = AnnSearchRequest(search_vectors, "embeddings_2", {"level": 1}, 20, expr='visible==False')
+        res = self.hybrid_search(client, collection_name, [sub_search1, sub_search2], ranker,
+                                 limit=10, consistency_level=CONSISTENCY_STRONG)[0]
+        assert len(res[0]) > 0
+        # query count(*)
+        res = self.query(client, collection_name, filter='visible==False',
+                         output_fields=["count(*)"], consistency_level=CONSISTENCY_STRONG)[0]
+        assert res[0].get('count(*)', 0) == insert_times * nb
+        res = self.query(client, collection_name, filter='',
+                         output_fields=["count(*)"], consistency_level=CONSISTENCY_STRONG)[0]
+        assert res[0].get('count(*)', 0) == insert_times * nb * 2
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_milvus_client_ttl_edge(self):

--- a/tests/python_client/milvus_client_v2/test_milvus_client_ttl.py
+++ b/tests/python_client/milvus_client_v2/test_milvus_client_ttl.py
@@ -1626,11 +1626,7 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
         self._wait_until_count(client, collection_name, expected_count=0)
 
         search_vectors = cf.gen_vectors(1, dim=default_dim)
-        res = self.search(client, collection_name, search_vectors,
-                          anns_field=default_vector_field_name, search_params={},
-                          limit=10, consistency_level=CONSISTENCY_STRONG)[0]
-        assert len(res[0]) == 0, \
-            f"Search should return 0 results after TTL expiry, got {len(res[0])}"
+        self._wait_until_search_count(client, collection_name, search_vectors, expected_count=0)
 
         # Step 4: Release and reload — expired data and original NULL rows must stay invisible
         self.release_collection(client, collection_name)
@@ -1641,26 +1637,14 @@ class TestMilvusClientEntityTTLValid(TestMilvusClientV2Base):
         assert res[0].get('count(*)') == 0, \
             f"Expected 0 after release/reload, got {res[0].get('count(*)')}"
 
-        res = self.search(client, collection_name, search_vectors,
-                          anns_field=default_vector_field_name, search_params={},
-                          limit=10, consistency_level=CONSISTENCY_STRONG)[0]
-        assert len(res[0]) == 0, \
-            f"Search should return 0 after release/reload, got {len(res[0])}"
+        self._wait_until_search_count(client, collection_name, search_vectors, expected_count=0)
 
         # Step 5: Compact and verify data is still invisible
         self.compact(client, collection_name)
         time.sleep(10)
 
-        res = self.query(client, collection_name, filter="", output_fields=["count(*)"],
-                         consistency_level=CONSISTENCY_STRONG)[0]
-        assert res[0].get('count(*)') == 0, \
-            f"Expected 0 after compaction, got {res[0].get('count(*)')}"
-
-        res = self.search(client, collection_name, search_vectors,
-                          anns_field=default_vector_field_name, search_params={},
-                          limit=10, consistency_level=CONSISTENCY_STRONG)[0]
-        assert len(res[0]) == 0, \
-            f"Search should return 0 after compaction, got {len(res[0])}"
+        self._wait_until_count(client, collection_name, expected_count=0)
+        self._wait_until_search_count(client, collection_name, search_vectors, expected_count=0)
 
         self.drop_collection(client, collection_name)
 


### PR DESCRIPTION
## Summary
- Remove the multi-consistency-level loop in `test_milvus_client_ttl_default` and use only `Strong` consistency
- Asserting data visibility under `Eventually` consistency is semantically wrong — it explicitly allows stale (empty) results, causing persistent flakiness in nightly CI
- The previous fix (PR #48271) added a 15×2s polling loop, but this is fundamentally insufficient for Eventually consistency after TTL expiry

issue: #48606

## Test plan
- [ ] Verify `test_milvus_client_ttl_default` passes reliably in CI across all configs (kafka, pulsar-mmap, woodpecker)
- [ ] Confirm no regression in TTL data visibility assertions under Strong consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)