### PR TITLE
test: Add emb list index type and vector type coverage for struct array

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_struct_array.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array.py
@@ -47,6 +47,10 @@ EMB_LIST_INDEX_CONFIGS = {
         "build_params": {"M": 16, "efConstruction": 200},
         "search_params": {"ef": 64},
     },
+    "IVF_FLAT": {
+        "build_params": {"nlist": 128},
+        "search_params": {"nprobe": 10},
+    },
     "IVF_FLAT_CC": {
         "build_params": {"nlist": 128},
         "search_params": {"nprobe": 10},
@@ -2256,15 +2260,13 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
                     f"but ratio {ratio} has recall {recall}"
 
     @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.parametrize("index_type", ["HNSW_SQ", "DISKANN"])
+    @pytest.mark.parametrize("index_type", EMB_LIST_INDEX_TYPES)
     def test_search_emb_list_with_different_index_types(self, index_type):
         """
         target: test search with full CRUD path for different emb list index types
         method: insert (flushed + growing) → index → load → search → upsert → delete → search → verify
         expected: all CRUD operations and search work correctly for each index type
         """
-        if index_type == "DISKANN":
-            pytest.xfail("DISKANN emb_list index build fails: https://github.com/milvus-io/milvus/issues/49014")
         collection_name = cf.gen_unique_str(
             f"{prefix}_search_{index_type.lower()}"
         )
@@ -2476,7 +2478,8 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize(
         "vector_type",
-        [DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR, DataType.INT8_VECTOR],
+        [DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR, DataType.INT8_VECTOR,
+         DataType.BINARY_VECTOR],
     )
     def test_search_emb_list_with_different_vector_types(self, vector_type):
         """
@@ -2484,6 +2487,12 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
         method: insert (flushed + growing) → HNSW index → load → search → upsert → delete → search → verify
         expected: all CRUD operations and search work correctly for each vector type
         """
+        # Select metric based on vector type
+        if vector_type == DataType.BINARY_VECTOR:
+            emb_list_metric = "MAX_SIM_HAMMING"
+        else:
+            emb_list_metric = "MAX_SIM_COSINE"
+
         type_name = vector_type.name.lower()
         collection_name = cf.gen_unique_str(f"{prefix}_search_vtype_{type_name}")
         client = self._client()
@@ -2576,7 +2585,7 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
         assert check
         assert res["insert_count"] == nb_growing
 
-        # Create HNSW index with MAX_SIM_COSINE (works for float16/bfloat16/int8)
+        # Create HNSW index with appropriate metric for vector type
         index_params = client.prepare_index_params()
         index_params.add_index(
             field_name="normal_vector",
@@ -2588,7 +2597,7 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
             field_name="clips[clip_embedding1]",
             index_name="struct_vector_index",
             index_type="HNSW",
-            metric_type="MAX_SIM_COSINE",
+            metric_type=emb_list_metric,
             params=INDEX_PARAMS,
         )
 
@@ -2609,7 +2618,7 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
             collection_name,
             data=[embedding_list],
             anns_field="clips[clip_embedding1]",
-            search_params={"metric_type": "MAX_SIM_COSINE"},
+            search_params={"metric_type": emb_list_metric},
             limit=10,
             output_fields=["id", "clips"],
         )
@@ -2682,7 +2691,7 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
             collection_name,
             data=[embedding_list],
             anns_field="clips[clip_embedding1]",
-            search_params={"metric_type": "MAX_SIM_COSINE"},
+            search_params={"metric_type": emb_list_metric},
             limit=10,
             output_fields=["id"],
         )

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array.py
@@ -33,6 +33,51 @@ default_capacity = 100
 METRICS = ["MAX_SIM", "MAX_SIM_IP", "MAX_SIM_COSINE", "MAX_SIM_L2"]
 INDEX_PARAMS = {"M": 16, "efConstruction": 200}
 
+# EmbList index type configs: {index_type: {build_params, search_params}}
+EMB_LIST_INDEX_CONFIGS = {
+    "HNSW_SQ": {
+        "build_params": {"M": 16, "efConstruction": 200, "sq_type": "SQ8"},
+        "search_params": {"ef": 64},
+    },
+    "HNSW_PQ": {
+        "build_params": {"M": 16, "efConstruction": 200},
+        "search_params": {"ef": 64},
+    },
+    "HNSW_PRQ": {
+        "build_params": {"M": 16, "efConstruction": 200},
+        "search_params": {"ef": 64},
+    },
+    "IVF_FLAT_CC": {
+        "build_params": {"nlist": 128},
+        "search_params": {"nprobe": 10},
+    },
+    "DISKANN": {
+        "build_params": {},
+        "search_params": {"search_list": 30},
+    },
+}
+EMB_LIST_INDEX_TYPES = list(EMB_LIST_INDEX_CONFIGS.keys())
+
+# Supported vector types per emb list index type (for MaxSim metrics)
+EMB_LIST_VECTOR_TYPES = {
+    "HNSW": [DataType.FLOAT_VECTOR, DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR,
+             DataType.INT8_VECTOR, DataType.BINARY_VECTOR],
+    "HNSW_SQ": [DataType.FLOAT_VECTOR, DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR,
+                DataType.INT8_VECTOR],
+    "HNSW_PQ": [DataType.FLOAT_VECTOR, DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR,
+                DataType.INT8_VECTOR],
+    "HNSW_PRQ": [DataType.FLOAT_VECTOR, DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR,
+                 DataType.INT8_VECTOR],
+    "IVF_FLAT": [DataType.FLOAT_VECTOR, DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR],
+    "IVF_FLAT_CC": [DataType.FLOAT_VECTOR, DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR],
+    "DISKANN": [DataType.FLOAT_VECTOR, DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR],
+}
+
+# Metric type for binary vectors vs float vectors
+BINARY_METRIC = "MAX_SIM_HAMMING"
+FLOAT_METRIC = "MAX_SIM_COSINE"
+INT8_METRIC = "MAX_SIM_COSINE"
+
 
 class TestMilvusClientStructArrayBasic(TestMilvusClientV2Base):
     """Test case of struct array basic functionality"""
@@ -1420,6 +1465,296 @@ class TestMilvusClientStructArrayIndex(TestMilvusClientV2Base):
         res, check = self.create_index(client, collection_name, index_params)
         assert check
 
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_create_emb_list_hnsw_sq_index(self):
+        """
+        target: test create HNSW_SQ index on struct array vector field
+        method: create HNSW_SQ index with MAX_SIM_COSINE metric
+        expected: index creation successful
+        """
+        collection_name = cf.gen_unique_str(f"{prefix}_index_hnsw_sq")
+        client = self._client()
+        self.create_collection_with_data(client, collection_name)
+
+        index_params = client.prepare_index_params()
+        index_params.add_index(
+            field_name="normal_vector",
+            index_type="IVF_FLAT",
+            metric_type="L2",
+            params={"nlist": 128},
+        )
+        index_params.add_index(
+            field_name="clips[clip_embedding1]",
+            index_name="struct_vector_index_hnsw_sq",
+            index_type="HNSW_SQ",
+            metric_type="MAX_SIM_COSINE",
+            params=EMB_LIST_INDEX_CONFIGS["HNSW_SQ"]["build_params"],
+        )
+
+        res, check = self.create_index(client, collection_name, index_params)
+        assert check
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_create_emb_list_hnsw_pq_index(self):
+        """
+        target: test create HNSW_PQ index on struct array vector field
+        method: create HNSW_PQ index with MAX_SIM_COSINE metric
+        expected: index creation successful
+        """
+        collection_name = cf.gen_unique_str(f"{prefix}_index_hnsw_pq")
+        client = self._client()
+        self.create_collection_with_data(client, collection_name)
+
+        index_params = client.prepare_index_params()
+        index_params.add_index(
+            field_name="normal_vector",
+            index_type="IVF_FLAT",
+            metric_type="L2",
+            params={"nlist": 128},
+        )
+        index_params.add_index(
+            field_name="clips[clip_embedding1]",
+            index_name="struct_vector_index_hnsw_pq",
+            index_type="HNSW_PQ",
+            metric_type="MAX_SIM_COSINE",
+            params=EMB_LIST_INDEX_CONFIGS["HNSW_PQ"]["build_params"],
+        )
+
+        res, check = self.create_index(client, collection_name, index_params)
+        assert check
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_create_emb_list_hnsw_prq_index(self):
+        """
+        target: test create HNSW_PRQ index on struct array vector field
+        method: create HNSW_PRQ index with MAX_SIM_COSINE metric
+        expected: index creation successful
+        """
+        collection_name = cf.gen_unique_str(f"{prefix}_index_hnsw_prq")
+        client = self._client()
+        self.create_collection_with_data(client, collection_name)
+
+        index_params = client.prepare_index_params()
+        index_params.add_index(
+            field_name="normal_vector",
+            index_type="IVF_FLAT",
+            metric_type="L2",
+            params={"nlist": 128},
+        )
+        index_params.add_index(
+            field_name="clips[clip_embedding1]",
+            index_name="struct_vector_index_hnsw_prq",
+            index_type="HNSW_PRQ",
+            metric_type="MAX_SIM_COSINE",
+            params=EMB_LIST_INDEX_CONFIGS["HNSW_PRQ"]["build_params"],
+        )
+
+        res, check = self.create_index(client, collection_name, index_params)
+        assert check
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_create_emb_list_ivf_flat_cc_index(self):
+        """
+        target: test create IVF_FLAT_CC index on struct array vector field
+        method: create IVF_FLAT_CC index with MAX_SIM_COSINE metric
+        expected: index creation successful
+        """
+        collection_name = cf.gen_unique_str(f"{prefix}_index_ivf_flat_cc")
+        client = self._client()
+        self.create_collection_with_data(client, collection_name)
+
+        index_params = client.prepare_index_params()
+        index_params.add_index(
+            field_name="normal_vector",
+            index_type="IVF_FLAT",
+            metric_type="L2",
+            params={"nlist": 128},
+        )
+        index_params.add_index(
+            field_name="clips[clip_embedding1]",
+            index_name="struct_vector_index_ivf_flat_cc",
+            index_type="IVF_FLAT_CC",
+            metric_type="MAX_SIM_COSINE",
+            params=EMB_LIST_INDEX_CONFIGS["IVF_FLAT_CC"]["build_params"],
+        )
+
+        res, check = self.create_index(client, collection_name, index_params)
+        assert check
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_create_emb_list_diskann_index(self):
+        """
+        target: test create DISKANN index on struct array vector field
+        method: create DISKANN index with MAX_SIM_COSINE metric
+        expected: index creation successful
+        """
+        collection_name = cf.gen_unique_str(f"{prefix}_index_diskann")
+        client = self._client()
+        self.create_collection_with_data(client, collection_name)
+
+        index_params = client.prepare_index_params()
+        index_params.add_index(
+            field_name="normal_vector",
+            index_type="IVF_FLAT",
+            metric_type="L2",
+            params={"nlist": 128},
+        )
+        index_params.add_index(
+            field_name="clips[clip_embedding1]",
+            index_name="struct_vector_index_diskann",
+            index_type="DISKANN",
+            metric_type="MAX_SIM_COSINE",
+            params=EMB_LIST_INDEX_CONFIGS["DISKANN"]["build_params"],
+        )
+
+        res, check = self.create_index(client, collection_name, index_params)
+        assert check
+
+    @pytest.mark.tags(CaseLabel.L2)
+    @pytest.mark.parametrize("index_type", EMB_LIST_INDEX_TYPES)
+    @pytest.mark.parametrize("metric_type", METRICS)
+    def test_emb_list_index_different_types_and_metrics(self, index_type, metric_type):
+        """
+        target: test different emb list index types with different metric types
+        method: create index with various index type and metric combinations
+        expected: index creation successful for all supported combinations
+        """
+        collection_name = cf.gen_unique_str(
+            f"{prefix}_idx_{index_type.lower()}_{metric_type.lower()}"
+        )
+        client = self._client()
+        self.create_collection_with_data(client, collection_name)
+
+        build_params = EMB_LIST_INDEX_CONFIGS[index_type]["build_params"]
+
+        index_params = client.prepare_index_params()
+        index_params.add_index(
+            field_name="normal_vector",
+            index_type="IVF_FLAT",
+            metric_type="L2",
+            params={"nlist": 128},
+        )
+        index_params.add_index(
+            field_name="clips[clip_embedding1]",
+            index_name=f"struct_index_{index_type.lower()}_{metric_type.lower()}",
+            index_type=index_type,
+            metric_type=metric_type,
+            params=build_params,
+        )
+
+        res, check = self.create_index(client, collection_name, index_params)
+        assert check
+
+    def _create_collection_with_vector_type(
+        self, client, collection_name, vector_type, dim=default_dim, nb=default_nb
+    ):
+        """Create collection with struct array using specified vector type"""
+        schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
+        schema.add_field(field_name="id", datatype=DataType.INT64, is_primary=True)
+        schema.add_field(
+            field_name="normal_vector", datatype=DataType.FLOAT_VECTOR, dim=dim
+        )
+
+        struct_schema = client.create_struct_field_schema()
+        struct_schema.add_field("clip_embedding1", vector_type, dim=dim)
+        struct_schema.add_field("scalar_field", DataType.INT64)
+
+        schema.add_field(
+            "clips",
+            datatype=DataType.ARRAY,
+            element_type=DataType.STRUCT,
+            struct_schema=struct_schema,
+            max_capacity=100,
+        )
+
+        res, check = self.create_collection(client, collection_name, schema=schema)
+        assert check
+
+        # Generate and insert data with the specified vector type
+        data = []
+        for i in range(nb):
+            array_length = random.randint(1, 10)
+            struct_array = []
+            for j in range(array_length):
+                vec = cf.gen_vectors(1, dim, vector_type)[0]
+                struct_element = {
+                    "clip_embedding1": vec,
+                    "scalar_field": i * 10 + j,
+                }
+                struct_array.append(struct_element)
+
+            row = {
+                "id": i,
+                "normal_vector": [random.random() for _ in range(dim)],
+                "clips": struct_array,
+            }
+            data.append(row)
+
+        res, check = self.insert(client, collection_name, data)
+        assert check
+        return data
+
+    @pytest.mark.tags(CaseLabel.L2)
+    @pytest.mark.parametrize("index_type", list(EMB_LIST_VECTOR_TYPES.keys()))
+    def test_emb_list_index_with_different_vector_types(self, index_type):
+        """
+        target: test emb list index creation with different vector data types
+        method: create index on struct array vector field with float16/bfloat16/int8/binary types
+        expected: index creation successful for all supported vector types per index
+        """
+        client = self._client()
+        supported_types = EMB_LIST_VECTOR_TYPES[index_type]
+
+        # Get build params
+        if index_type in EMB_LIST_INDEX_CONFIGS:
+            build_params = EMB_LIST_INDEX_CONFIGS[index_type]["build_params"]
+        elif index_type == "HNSW":
+            build_params = INDEX_PARAMS
+        elif index_type == "IVF_FLAT":
+            build_params = {"nlist": 128}
+        else:
+            build_params = {}
+
+        for vector_type in supported_types:
+            # Skip FLOAT_VECTOR since it is already tested
+            if vector_type == DataType.FLOAT_VECTOR:
+                continue
+
+            type_name = vector_type.name.lower()
+            collection_name = cf.gen_unique_str(
+                f"{prefix}_vtype_{index_type.lower()}_{type_name}"
+            )
+
+            self._create_collection_with_vector_type(
+                client, collection_name, vector_type
+            )
+
+            # Choose metric based on vector type
+            if vector_type == DataType.BINARY_VECTOR:
+                metric_type = BINARY_METRIC
+            else:
+                metric_type = FLOAT_METRIC
+
+            index_params = client.prepare_index_params()
+            index_params.add_index(
+                field_name="normal_vector",
+                index_type="IVF_FLAT",
+                metric_type="L2",
+                params={"nlist": 128},
+            )
+            index_params.add_index(
+                field_name="clips[clip_embedding1]",
+                index_name=f"struct_idx_{type_name}",
+                index_type=index_type,
+                metric_type=metric_type,
+                params=build_params,
+            )
+
+            res, check = self.create_index(client, collection_name, index_params)
+            assert check, (
+                f"Failed to create {index_type} index with {type_name} vector type"
+            )
+
 
 class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
     """Test case of struct array search functionality"""
@@ -1518,6 +1853,99 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
             vector = [random.random() for _ in range(dim)]
             embedding_list.add(vector)
         return embedding_list
+
+    def create_collection_with_configurable_index(
+        self,
+        client: MilvusClient,
+        collection_name: str,
+        index_type: str = "HNSW",
+        metric_type: str = "MAX_SIM_COSINE",
+        build_params: dict = None,
+        dim: int = default_dim,
+        nb: int = default_nb,
+    ):
+        """Create collection with struct array, insert data and create configurable index"""
+        # Create schema
+        schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
+        schema.add_field(field_name="id", datatype=DataType.INT64, is_primary=True)
+        schema.add_field(
+            field_name="normal_vector", datatype=DataType.FLOAT_VECTOR, dim=dim
+        )
+
+        # Create struct schema
+        struct_schema = client.create_struct_field_schema()
+        struct_schema.add_field("clip_embedding1", DataType.FLOAT_VECTOR, dim=dim)
+        struct_schema.add_field("scalar_field", DataType.INT64)
+        struct_schema.add_field("category", DataType.VARCHAR, max_length=128)
+
+        schema.add_field(
+            "clips",
+            datatype=DataType.ARRAY,
+            element_type=DataType.STRUCT,
+            struct_schema=struct_schema,
+            max_capacity=100,
+        )
+
+        schema.add_field("scalar_field", datatype=DataType.INT64)
+        schema.add_field("category", datatype=DataType.VARCHAR, max_length=128)
+        schema.add_field("score", datatype=DataType.FLOAT)
+        # Create collection
+        res, check = self.create_collection(client, collection_name, schema=schema)
+        assert check
+
+        # Insert data
+        data = []
+        for i in range(nb):
+            array_length = random.randint(1, 5)
+            struct_array = []
+            for j in range(array_length):
+                struct_element = {
+                    "clip_embedding1": [random.random() for _ in range(dim)],
+                    "scalar_field": i * 10 + j,
+                    "category": f"cat_{i % 5}",
+                }
+                struct_array.append(struct_element)
+
+            row = {
+                "id": i,
+                "normal_vector": [random.random() for _ in range(dim)],
+                "clips": struct_array,
+                "scalar_field": i * 10 + j,
+                "category": f"cat_{i % 5}",
+                "score": random.uniform(0.1, 10.0),
+            }
+            data.append(row)
+
+        res, check = self.insert(client, collection_name, data)
+        assert check
+
+        # Create indexes
+        if build_params is None:
+            build_params = INDEX_PARAMS
+
+        index_params = client.prepare_index_params()
+        index_params.add_index(
+            field_name="normal_vector",
+            index_type="IVF_FLAT",
+            metric_type="L2",
+            params={"nlist": 128},
+        )
+        index_params.add_index(
+            field_name="clips[clip_embedding1]",
+            index_name="struct_vector_index",
+            index_type=index_type,
+            metric_type=metric_type,
+            params=build_params,
+        )
+
+        res, check = self.create_index(client, collection_name, index_params)
+        assert check
+
+        # Load collection
+        res, check = self.load_collection(client, collection_name)
+        assert check
+
+        return data
 
     @pytest.mark.tags(CaseLabel.L0)
     def test_search_struct_array_vector_single(self):
@@ -2113,6 +2541,154 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
                 assert recall >= 0.8, \
                     f"Recall should be >= 0.8 when retrieval_ann_ratio >= 3, " \
                     f"but ratio {ratio} has recall {recall}"
+
+    @pytest.mark.tags(CaseLabel.L1)
+    @pytest.mark.parametrize("index_type", EMB_LIST_INDEX_TYPES)
+    def test_search_emb_list_with_different_index_types(self, index_type):
+        """
+        target: test search with different emb list index types
+        method: create collection with configurable index type, search with EmbeddingList
+        expected: search returns non-empty results for all supported index types
+        """
+        collection_name = cf.gen_unique_str(
+            f"{prefix}_search_{index_type.lower()}"
+        )
+        client = self._client()
+
+        config = EMB_LIST_INDEX_CONFIGS[index_type]
+        self.create_collection_with_configurable_index(
+            client,
+            collection_name,
+            index_type=index_type,
+            metric_type="MAX_SIM_COSINE",
+            build_params=config["build_params"],
+        )
+
+        # Create EmbeddingList with multiple vectors
+        embedding_list = self.create_embedding_list(default_dim, 3)
+
+        # Search using EmbeddingList
+        results, check = self.search(
+            client,
+            collection_name,
+            data=[embedding_list],
+            anns_field="clips[clip_embedding1]",
+            search_params={
+                "metric_type": "MAX_SIM_COSINE",
+                "params": config["search_params"],
+            },
+            limit=10,
+        )
+        assert check
+        assert len(results[0]) > 0
+
+    @pytest.mark.tags(CaseLabel.L2)
+    @pytest.mark.parametrize(
+        "vector_type",
+        [DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR, DataType.INT8_VECTOR],
+    )
+    def test_search_emb_list_with_different_vector_types(self, vector_type):
+        """
+        target: test search with different vector data types in struct array
+        method: create collection with float16/bfloat16/int8 vectors, build HNSW index, search
+        expected: search returns non-empty results
+        """
+        type_name = vector_type.name.lower()
+        collection_name = cf.gen_unique_str(f"{prefix}_search_vtype_{type_name}")
+        client = self._client()
+
+        # Create schema with specified vector type
+        schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
+        schema.add_field(field_name="id", datatype=DataType.INT64, is_primary=True)
+        schema.add_field(
+            field_name="normal_vector", datatype=DataType.FLOAT_VECTOR, dim=default_dim
+        )
+
+        struct_schema = client.create_struct_field_schema()
+        struct_schema.add_field("clip_embedding1", vector_type, dim=default_dim)
+        struct_schema.add_field("scalar_field", DataType.INT64)
+        struct_schema.add_field("category", DataType.VARCHAR, max_length=128)
+
+        schema.add_field(
+            "clips",
+            datatype=DataType.ARRAY,
+            element_type=DataType.STRUCT,
+            struct_schema=struct_schema,
+            max_capacity=100,
+        )
+
+        schema.add_field("scalar_field", datatype=DataType.INT64)
+        schema.add_field("category", datatype=DataType.VARCHAR, max_length=128)
+        schema.add_field("score", datatype=DataType.FLOAT)
+
+        res, check = self.create_collection(client, collection_name, schema=schema)
+        assert check
+
+        # Insert data
+        data = []
+        for i in range(default_nb):
+            array_length = random.randint(1, 5)
+            struct_array = []
+            for j in range(array_length):
+                vec = cf.gen_vectors(1, default_dim, vector_type)[0]
+                struct_element = {
+                    "clip_embedding1": vec,
+                    "scalar_field": i * 10 + j,
+                    "category": f"cat_{i % 5}",
+                }
+                struct_array.append(struct_element)
+
+            row = {
+                "id": i,
+                "normal_vector": [random.random() for _ in range(default_dim)],
+                "clips": struct_array,
+                "scalar_field": i * 10 + j,
+                "category": f"cat_{i % 5}",
+                "score": random.uniform(0.1, 10.0),
+            }
+            data.append(row)
+
+        res, check = self.insert(client, collection_name, data)
+        assert check
+
+        # Create HNSW index with MAX_SIM_COSINE (works for float16/bfloat16/int8)
+        index_params = client.prepare_index_params()
+        index_params.add_index(
+            field_name="normal_vector",
+            index_type="IVF_FLAT",
+            metric_type="L2",
+            params={"nlist": 128},
+        )
+        index_params.add_index(
+            field_name="clips[clip_embedding1]",
+            index_name="struct_vector_index",
+            index_type="HNSW",
+            metric_type="MAX_SIM_COSINE",
+            params=INDEX_PARAMS,
+        )
+
+        res, check = self.create_index(client, collection_name, index_params)
+        assert check
+
+        res, check = self.load_collection(client, collection_name)
+        assert check
+
+        # Search with EmbeddingList using the same vector type
+        search_vecs = cf.gen_vectors(3, default_dim, vector_type)
+        embedding_list = EmbeddingList(
+            [np.array(v) if not isinstance(v, np.ndarray) else v for v in search_vecs]
+        )
+
+        results, check = self.search(
+            client,
+            collection_name,
+            data=[embedding_list],
+            anns_field="clips[clip_embedding1]",
+            search_params={"metric_type": "MAX_SIM_COSINE"},
+            limit=10,
+        )
+        assert check
+        assert len(results[0]) > 0
 
 
 class TestMilvusClientStructArrayHybridSearch(TestMilvusClientV2Base):

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array.py
@@ -2609,9 +2609,14 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
 
         # Search with EmbeddingList and verify results
         search_vecs = cf.gen_vectors(3, EMB_LIST_DIM, vector_type)
-        embedding_list = EmbeddingList(
-            [np.array(v) if not isinstance(v, np.ndarray) else v for v in search_vecs]
-        )
+        if vector_type == DataType.BINARY_VECTOR:
+            embedding_list = EmbeddingList(
+                [np.frombuffer(v, dtype=np.uint8) if isinstance(v, bytes) else v for v in search_vecs]
+            )
+        else:
+            embedding_list = EmbeddingList(
+                [np.array(v) if not isinstance(v, np.ndarray) else v for v in search_vecs]
+            )
 
         results, check = self.search(
             client,

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array.py
@@ -73,6 +73,9 @@ EMB_LIST_VECTOR_TYPES = {
     "DISKANN": [DataType.FLOAT_VECTOR, DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR],
 }
 
+# Dim for emb list index tests (smaller for faster index building)
+EMB_LIST_DIM = 32
+
 # Metric type for binary vectors vs float vectors
 BINARY_METRIC = "MAX_SIM_HAMMING"
 FLOAT_METRIC = "MAX_SIM_COSINE"
@@ -1465,431 +1468,6 @@ class TestMilvusClientStructArrayIndex(TestMilvusClientV2Base):
         res, check = self.create_index(client, collection_name, index_params)
         assert check
 
-    @pytest.mark.tags(CaseLabel.L2)
-    @pytest.mark.parametrize("index_type", EMB_LIST_INDEX_TYPES)
-    @pytest.mark.parametrize("metric_type", METRICS)
-    def test_emb_list_index_different_types_and_metrics(self, index_type, metric_type):
-        """
-        target: test emb list index with full CRUD path for different index types and metrics
-        method: insert (flushed + growing) → create index → load → search → upsert → delete → verify
-        expected: all CRUD operations successful with correct search results
-        """
-        collection_name = cf.gen_unique_str(
-            f"{prefix}_idx_{index_type.lower()}_{metric_type.lower()}"
-        )
-        client = self._client()
-
-        # Create collection schema with label field for upsert verification
-        schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
-        schema.add_field(field_name="id", datatype=DataType.INT64, is_primary=True)
-        schema.add_field(
-            field_name="normal_vector", datatype=DataType.FLOAT_VECTOR, dim=default_dim
-        )
-
-        struct_schema = client.create_struct_field_schema()
-        struct_schema.add_field("clip_embedding1", DataType.FLOAT_VECTOR, dim=default_dim)
-        struct_schema.add_field("scalar_field", DataType.INT64)
-        struct_schema.add_field("label", DataType.VARCHAR, max_length=128)
-
-        schema.add_field(
-            "clips",
-            datatype=DataType.ARRAY,
-            element_type=DataType.STRUCT,
-            struct_schema=struct_schema,
-            max_capacity=100,
-        )
-
-        res, check = self.create_collection(client, collection_name, schema=schema)
-        assert check
-
-        # Insert 200 records and flush (sealed segments)
-        nb_flushed = 200
-        flushed_data = []
-        for i in range(nb_flushed):
-            array_length = random.randint(1, 5)
-            struct_array = [
-                {
-                    "clip_embedding1": [random.random() for _ in range(default_dim)],
-                    "scalar_field": i * 10 + j,
-                    "label": f"flushed_{i}",
-                }
-                for j in range(array_length)
-            ]
-            row = {
-                "id": i,
-                "normal_vector": [random.random() for _ in range(default_dim)],
-                "clips": struct_array,
-            }
-            flushed_data.append(row)
-
-        res, check = self.insert(client, collection_name, flushed_data)
-        assert check
-        assert res["insert_count"] == nb_flushed
-
-        res, check = self.flush(client, collection_name)
-        assert check
-
-        # Insert 100 more growing records
-        nb_growing = 100
-        growing_data = []
-        for i in range(nb_flushed, nb_flushed + nb_growing):
-            array_length = random.randint(1, 5)
-            struct_array = [
-                {
-                    "clip_embedding1": [random.random() for _ in range(default_dim)],
-                    "scalar_field": i * 10 + j,
-                    "label": f"growing_{i}",
-                }
-                for j in range(array_length)
-            ]
-            row = {
-                "id": i,
-                "normal_vector": [random.random() for _ in range(default_dim)],
-                "clips": struct_array,
-            }
-            growing_data.append(row)
-
-        res, check = self.insert(client, collection_name, growing_data)
-        assert check
-        assert res["insert_count"] == nb_growing
-
-        # Create index with specified type and metric
-        build_params = EMB_LIST_INDEX_CONFIGS[index_type]["build_params"]
-        search_params = EMB_LIST_INDEX_CONFIGS[index_type]["search_params"]
-
-        index_params = client.prepare_index_params()
-        index_params.add_index(
-            field_name="normal_vector",
-            index_type="IVF_FLAT",
-            metric_type="L2",
-            params={"nlist": 128},
-        )
-        index_params.add_index(
-            field_name="clips[clip_embedding1]",
-            index_name=f"struct_idx_{index_type.lower()}_{metric_type.lower()}",
-            index_type=index_type,
-            metric_type=metric_type,
-            params=build_params,
-        )
-
-        res, check = self.create_index(client, collection_name, index_params)
-        assert check
-
-        # Load collection
-        res, check = self.load_collection(client, collection_name)
-        assert check
-
-        # Search with EmbeddingList and verify results
-        embedding_list = EmbeddingList()
-        for _ in range(3):
-            embedding_list.add([random.random() for _ in range(default_dim)])
-
-        results, check = self.search(
-            client,
-            collection_name,
-            data=[embedding_list],
-            anns_field="clips[clip_embedding1]",
-            search_params={"metric_type": metric_type, "params": search_params},
-            limit=10,
-            output_fields=["id", "clips"],
-        )
-        assert check
-        assert len(results[0]) > 0
-        for hit in results[0]:
-            assert "id" in hit
-            assert 0 <= hit["id"] < nb_flushed + nb_growing
-
-        # Upsert 10 records from flushed segment
-        upsert_data = []
-        for i in range(10):
-            row = {
-                "id": i,
-                "normal_vector": [random.random() for _ in range(default_dim)],
-                "clips": [
-                    {
-                        "clip_embedding1": [random.random() for _ in range(default_dim)],
-                        "scalar_field": i + 10000,
-                        "label": f"upserted_{i}",
-                    }
-                ],
-            }
-            upsert_data.append(row)
-
-        res, check = self.upsert(client, collection_name, upsert_data)
-        assert check
-
-        # Verify upsert via query
-        res, check = self.flush(client, collection_name)
-        assert check
-
-        results, check = self.query(
-            client, collection_name, filter="id < 10", output_fields=["id", "clips"]
-        )
-        assert check
-        assert len(results) == 10
-        for result in results:
-            assert "upserted" in result["clips"][0]["label"]
-
-        # Delete 5 records from growing segment
-        delete_ids = list(range(nb_flushed, nb_flushed + 5))
-        res, check = self.delete(client, collection_name, filter=f"id in {delete_ids}")
-        assert check
-
-        # Verify deletion
-        res, check = self.flush(client, collection_name)
-        assert check
-
-        results, check = self.query(
-            client, collection_name, filter="id >= 0", output_fields=["id"]
-        )
-        assert check
-        remaining_ids = {r["id"] for r in results}
-        for del_id in delete_ids:
-            assert del_id not in remaining_ids
-        assert len(results) == nb_flushed + nb_growing - 5
-
-        # Search again after CRUD operations to verify index still works
-        results, check = self.search(
-            client,
-            collection_name,
-            data=[embedding_list],
-            anns_field="clips[clip_embedding1]",
-            search_params={"metric_type": metric_type, "params": search_params},
-            limit=10,
-            output_fields=["id"],
-        )
-        assert check
-        assert len(results[0]) > 0
-        for hit in results[0]:
-            assert hit["id"] not in delete_ids
-
-    @pytest.mark.tags(CaseLabel.L2)
-    @pytest.mark.parametrize("index_type", list(EMB_LIST_VECTOR_TYPES.keys()))
-    def test_emb_list_index_with_different_vector_types(self, index_type):
-        """
-        target: test emb list index with full CRUD path for different vector data types
-        method: for each supported vector type per index: insert (flushed + growing) → index → load → search → upsert → delete → verify
-        expected: all CRUD operations successful for all supported vector types
-        """
-        client = self._client()
-        supported_types = EMB_LIST_VECTOR_TYPES[index_type]
-
-        # Get build/search params
-        if index_type in EMB_LIST_INDEX_CONFIGS:
-            build_params = EMB_LIST_INDEX_CONFIGS[index_type]["build_params"]
-            search_params = EMB_LIST_INDEX_CONFIGS[index_type]["search_params"]
-        elif index_type == "HNSW":
-            build_params = INDEX_PARAMS
-            search_params = {"ef": 64}
-        elif index_type == "IVF_FLAT":
-            build_params = {"nlist": 128}
-            search_params = {"nprobe": 10}
-        else:
-            build_params = {}
-            search_params = {}
-
-        for vector_type in supported_types:
-            # Skip FLOAT_VECTOR since it is already tested
-            if vector_type == DataType.FLOAT_VECTOR:
-                continue
-
-            type_name = vector_type.name.lower()
-            collection_name = cf.gen_unique_str(
-                f"{prefix}_vtype_{index_type.lower()}_{type_name}"
-            )
-
-            # Choose metric based on vector type
-            if vector_type == DataType.BINARY_VECTOR:
-                metric_type = BINARY_METRIC
-            else:
-                metric_type = FLOAT_METRIC
-
-            # Create collection with struct array schema including label field
-            schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
-            schema.add_field(field_name="id", datatype=DataType.INT64, is_primary=True)
-            schema.add_field(
-                field_name="normal_vector", datatype=DataType.FLOAT_VECTOR, dim=default_dim
-            )
-
-            struct_schema = client.create_struct_field_schema()
-            struct_schema.add_field("clip_embedding1", vector_type, dim=default_dim)
-            struct_schema.add_field("scalar_field", DataType.INT64)
-            struct_schema.add_field("label", DataType.VARCHAR, max_length=128)
-
-            schema.add_field(
-                "clips",
-                datatype=DataType.ARRAY,
-                element_type=DataType.STRUCT,
-                struct_schema=struct_schema,
-                max_capacity=100,
-            )
-
-            res, check = self.create_collection(client, collection_name, schema=schema)
-            assert check
-
-            # Insert 100 records and flush (sealed segments)
-            nb_flushed = 100
-            flushed_data = []
-            for i in range(nb_flushed):
-                array_length = random.randint(1, 5)
-                struct_array = [
-                    {
-                        "clip_embedding1": cf.gen_vectors(1, default_dim, vector_type)[0],
-                        "scalar_field": i * 10 + j,
-                        "label": f"flushed_{i}",
-                    }
-                    for j in range(array_length)
-                ]
-                row = {
-                    "id": i,
-                    "normal_vector": [random.random() for _ in range(default_dim)],
-                    "clips": struct_array,
-                }
-                flushed_data.append(row)
-
-            res, check = self.insert(client, collection_name, flushed_data)
-            assert check
-            assert res["insert_count"] == nb_flushed
-
-            res, check = self.flush(client, collection_name)
-            assert check
-
-            # Insert 50 more growing records
-            nb_growing = 50
-            growing_data = []
-            for i in range(nb_flushed, nb_flushed + nb_growing):
-                array_length = random.randint(1, 5)
-                struct_array = [
-                    {
-                        "clip_embedding1": cf.gen_vectors(1, default_dim, vector_type)[0],
-                        "scalar_field": i * 10 + j,
-                        "label": f"growing_{i}",
-                    }
-                    for j in range(array_length)
-                ]
-                row = {
-                    "id": i,
-                    "normal_vector": [random.random() for _ in range(default_dim)],
-                    "clips": struct_array,
-                }
-                growing_data.append(row)
-
-            res, check = self.insert(client, collection_name, growing_data)
-            assert check
-            assert res["insert_count"] == nb_growing
-
-            # Create index
-            index_params = client.prepare_index_params()
-            index_params.add_index(
-                field_name="normal_vector",
-                index_type="IVF_FLAT",
-                metric_type="L2",
-                params={"nlist": 128},
-            )
-            index_params.add_index(
-                field_name="clips[clip_embedding1]",
-                index_name=f"struct_idx_{type_name}",
-                index_type=index_type,
-                metric_type=metric_type,
-                params=build_params,
-            )
-
-            res, check = self.create_index(client, collection_name, index_params)
-            assert check, (
-                f"Failed to create {index_type} index with {type_name} vector type"
-            )
-
-            # Load collection
-            res, check = self.load_collection(client, collection_name)
-            assert check
-
-            # Search with EmbeddingList and verify results
-            search_vecs = cf.gen_vectors(3, default_dim, vector_type)
-            embedding_list = EmbeddingList(
-                [np.frombuffer(v, dtype=np.uint8) if isinstance(v, bytes) else
-                 (np.array(v) if not isinstance(v, np.ndarray) else v) for v in search_vecs]
-            )
-
-            results, check = self.search(
-                client,
-                collection_name,
-                data=[embedding_list],
-                anns_field="clips[clip_embedding1]",
-                search_params={"metric_type": metric_type, "params": search_params},
-                limit=10,
-                output_fields=["id", "clips"],
-            )
-            assert check
-            assert len(results[0]) > 0
-            for hit in results[0]:
-                assert 0 <= hit["id"] < nb_flushed + nb_growing
-
-            # Upsert 5 records from flushed segment
-            upsert_data = []
-            for i in range(5):
-                row = {
-                    "id": i,
-                    "normal_vector": [random.random() for _ in range(default_dim)],
-                    "clips": [
-                        {
-                            "clip_embedding1": cf.gen_vectors(1, default_dim, vector_type)[0],
-                            "scalar_field": i + 10000,
-                            "label": f"upserted_{i}",
-                        }
-                    ],
-                }
-                upsert_data.append(row)
-
-            res, check = self.upsert(client, collection_name, upsert_data)
-            assert check
-
-            # Verify upsert via query
-            res, check = self.flush(client, collection_name)
-            assert check
-
-            results, check = self.query(
-                client, collection_name, filter="id < 5", output_fields=["id", "clips"]
-            )
-            assert check
-            assert len(results) == 5
-            for result in results:
-                assert "upserted" in result["clips"][0]["label"]
-
-            # Delete 3 records from growing segment
-            delete_ids = list(range(nb_flushed, nb_flushed + 3))
-            res, check = self.delete(
-                client, collection_name, filter=f"id in {delete_ids}"
-            )
-            assert check
-
-            # Verify deletion
-            res, check = self.flush(client, collection_name)
-            assert check
-
-            results, check = self.query(
-                client, collection_name, filter="id >= 0", output_fields=["id"]
-            )
-            assert check
-            remaining_ids = {r["id"] for r in results}
-            for del_id in delete_ids:
-                assert del_id not in remaining_ids
-            assert len(results) == nb_flushed + nb_growing - 3
-
-            # Search again after CRUD operations
-            results, check = self.search(
-                client,
-                collection_name,
-                data=[embedding_list],
-                anns_field="clips[clip_embedding1]",
-                search_params={"metric_type": metric_type, "params": search_params},
-                limit=10,
-                output_fields=["id"],
-            )
-            assert check
-            assert len(results[0]) > 0
-            for hit in results[0]:
-                assert hit["id"] not in delete_ids
-
 
 class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
     """Test case of struct array search functionality"""
@@ -2678,13 +2256,15 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
                     f"but ratio {ratio} has recall {recall}"
 
     @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.parametrize("index_type", EMB_LIST_INDEX_TYPES)
+    @pytest.mark.parametrize("index_type", ["HNSW_SQ", "DISKANN"])
     def test_search_emb_list_with_different_index_types(self, index_type):
         """
         target: test search with full CRUD path for different emb list index types
         method: insert (flushed + growing) → index → load → search → upsert → delete → search → verify
         expected: all CRUD operations and search work correctly for each index type
         """
+        if index_type == "DISKANN":
+            pytest.xfail("DISKANN emb_list index build fails: https://github.com/milvus-io/milvus/issues/49014")
         collection_name = cf.gen_unique_str(
             f"{prefix}_search_{index_type.lower()}"
         )
@@ -2696,11 +2276,11 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
         schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
         schema.add_field(field_name="id", datatype=DataType.INT64, is_primary=True)
         schema.add_field(
-            field_name="normal_vector", datatype=DataType.FLOAT_VECTOR, dim=default_dim
+            field_name="normal_vector", datatype=DataType.FLOAT_VECTOR, dim=EMB_LIST_DIM
         )
 
         struct_schema = client.create_struct_field_schema()
-        struct_schema.add_field("clip_embedding1", DataType.FLOAT_VECTOR, dim=default_dim)
+        struct_schema.add_field("clip_embedding1", DataType.FLOAT_VECTOR, dim=EMB_LIST_DIM)
         struct_schema.add_field("scalar_field", DataType.INT64)
         struct_schema.add_field("category", DataType.VARCHAR, max_length=128)
 
@@ -2719,15 +2299,15 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
         res, check = self.create_collection(client, collection_name, schema=schema)
         assert check
 
-        # Insert 200 records and flush (sealed segments)
-        nb_flushed = 200
+        # Insert 3000 records and flush (sealed segments)
+        nb_flushed = 3000
         flushed_data = []
         for i in range(nb_flushed):
             array_length = random.randint(1, 5)
             struct_array = []
             for j in range(array_length):
                 struct_element = {
-                    "clip_embedding1": [random.random() for _ in range(default_dim)],
+                    "clip_embedding1": [random.random() for _ in range(EMB_LIST_DIM)],
                     "scalar_field": i * 10 + j,
                     "category": f"cat_{i % 5}",
                 }
@@ -2735,7 +2315,7 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
 
             row = {
                 "id": i,
-                "normal_vector": [random.random() for _ in range(default_dim)],
+                "normal_vector": [random.random() for _ in range(EMB_LIST_DIM)],
                 "clips": struct_array,
                 "scalar_field": i * 10 + j,
                 "category": f"cat_{i % 5}",
@@ -2750,15 +2330,15 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
         res, check = self.flush(client, collection_name)
         assert check
 
-        # Insert 100 more growing records
-        nb_growing = 100
+        # Insert 500 more growing records
+        nb_growing = 500
         growing_data = []
         for i in range(nb_flushed, nb_flushed + nb_growing):
             array_length = random.randint(1, 5)
             struct_array = []
             for j in range(array_length):
                 struct_element = {
-                    "clip_embedding1": [random.random() for _ in range(default_dim)],
+                    "clip_embedding1": [random.random() for _ in range(EMB_LIST_DIM)],
                     "scalar_field": i * 10 + j,
                     "category": f"cat_{i % 5}",
                 }
@@ -2766,7 +2346,7 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
 
             row = {
                 "id": i,
-                "normal_vector": [random.random() for _ in range(default_dim)],
+                "normal_vector": [random.random() for _ in range(EMB_LIST_DIM)],
                 "clips": struct_array,
                 "scalar_field": i * 10 + j,
                 "category": f"cat_{i % 5}",
@@ -2802,7 +2382,7 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
         assert check
 
         # Search with EmbeddingList and verify results
-        embedding_list = self.create_embedding_list(default_dim, 3)
+        embedding_list = self.create_embedding_list(EMB_LIST_DIM, 3)
 
         results, check = self.search(
             client,
@@ -2826,10 +2406,10 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
         for i in range(10):
             row = {
                 "id": i,
-                "normal_vector": [random.random() for _ in range(default_dim)],
+                "normal_vector": [random.random() for _ in range(EMB_LIST_DIM)],
                 "clips": [
                     {
-                        "clip_embedding1": [random.random() for _ in range(default_dim)],
+                        "clip_embedding1": [random.random() for _ in range(EMB_LIST_DIM)],
                         "scalar_field": i + 10000,
                         "category": f"upserted_{i}",
                     }
@@ -2912,11 +2492,11 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
         schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
         schema.add_field(field_name="id", datatype=DataType.INT64, is_primary=True)
         schema.add_field(
-            field_name="normal_vector", datatype=DataType.FLOAT_VECTOR, dim=default_dim
+            field_name="normal_vector", datatype=DataType.FLOAT_VECTOR, dim=EMB_LIST_DIM
         )
 
         struct_schema = client.create_struct_field_schema()
-        struct_schema.add_field("clip_embedding1", vector_type, dim=default_dim)
+        struct_schema.add_field("clip_embedding1", vector_type, dim=EMB_LIST_DIM)
         struct_schema.add_field("scalar_field", DataType.INT64)
         struct_schema.add_field("category", DataType.VARCHAR, max_length=128)
 
@@ -2935,14 +2515,14 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
         res, check = self.create_collection(client, collection_name, schema=schema)
         assert check
 
-        # Insert 200 records and flush (sealed segments)
-        nb_flushed = 200
+        # Insert 3000 records and flush (sealed segments)
+        nb_flushed = 3000
         flushed_data = []
         for i in range(nb_flushed):
             array_length = random.randint(1, 5)
             struct_array = []
             for j in range(array_length):
-                vec = cf.gen_vectors(1, default_dim, vector_type)[0]
+                vec = cf.gen_vectors(1, EMB_LIST_DIM, vector_type)[0]
                 struct_element = {
                     "clip_embedding1": vec,
                     "scalar_field": i * 10 + j,
@@ -2952,7 +2532,7 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
 
             row = {
                 "id": i,
-                "normal_vector": [random.random() for _ in range(default_dim)],
+                "normal_vector": [random.random() for _ in range(EMB_LIST_DIM)],
                 "clips": struct_array,
                 "scalar_field": i * 10 + j,
                 "category": f"flushed_{i}",
@@ -2967,14 +2547,14 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
         res, check = self.flush(client, collection_name)
         assert check
 
-        # Insert 100 more growing records
-        nb_growing = 100
+        # Insert 500 more growing records
+        nb_growing = 500
         growing_data = []
         for i in range(nb_flushed, nb_flushed + nb_growing):
             array_length = random.randint(1, 5)
             struct_array = []
             for j in range(array_length):
-                vec = cf.gen_vectors(1, default_dim, vector_type)[0]
+                vec = cf.gen_vectors(1, EMB_LIST_DIM, vector_type)[0]
                 struct_element = {
                     "clip_embedding1": vec,
                     "scalar_field": i * 10 + j,
@@ -2984,7 +2564,7 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
 
             row = {
                 "id": i,
-                "normal_vector": [random.random() for _ in range(default_dim)],
+                "normal_vector": [random.random() for _ in range(EMB_LIST_DIM)],
                 "clips": struct_array,
                 "scalar_field": i * 10 + j,
                 "category": f"growing_{i}",
@@ -3019,7 +2599,7 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
         assert check
 
         # Search with EmbeddingList and verify results
-        search_vecs = cf.gen_vectors(3, default_dim, vector_type)
+        search_vecs = cf.gen_vectors(3, EMB_LIST_DIM, vector_type)
         embedding_list = EmbeddingList(
             [np.array(v) if not isinstance(v, np.ndarray) else v for v in search_vecs]
         )
@@ -3043,10 +2623,10 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
         for i in range(10):
             row = {
                 "id": i,
-                "normal_vector": [random.random() for _ in range(default_dim)],
+                "normal_vector": [random.random() for _ in range(EMB_LIST_DIM)],
                 "clips": [
                     {
-                        "clip_embedding1": cf.gen_vectors(1, default_dim, vector_type)[0],
+                        "clip_embedding1": cf.gen_vectors(1, EMB_LIST_DIM, vector_type)[0],
                         "scalar_field": i + 10000,
                         "category": f"upserted_{i}",
                     }

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array.py
@@ -1465,199 +1465,31 @@ class TestMilvusClientStructArrayIndex(TestMilvusClientV2Base):
         res, check = self.create_index(client, collection_name, index_params)
         assert check
 
-    @pytest.mark.tags(CaseLabel.L1)
-    def test_create_emb_list_hnsw_sq_index(self):
-        """
-        target: test create HNSW_SQ index on struct array vector field
-        method: create HNSW_SQ index with MAX_SIM_COSINE metric
-        expected: index creation successful
-        """
-        collection_name = cf.gen_unique_str(f"{prefix}_index_hnsw_sq")
-        client = self._client()
-        self.create_collection_with_data(client, collection_name)
-
-        index_params = client.prepare_index_params()
-        index_params.add_index(
-            field_name="normal_vector",
-            index_type="IVF_FLAT",
-            metric_type="L2",
-            params={"nlist": 128},
-        )
-        index_params.add_index(
-            field_name="clips[clip_embedding1]",
-            index_name="struct_vector_index_hnsw_sq",
-            index_type="HNSW_SQ",
-            metric_type="MAX_SIM_COSINE",
-            params=EMB_LIST_INDEX_CONFIGS["HNSW_SQ"]["build_params"],
-        )
-
-        res, check = self.create_index(client, collection_name, index_params)
-        assert check
-
-    @pytest.mark.tags(CaseLabel.L1)
-    def test_create_emb_list_hnsw_pq_index(self):
-        """
-        target: test create HNSW_PQ index on struct array vector field
-        method: create HNSW_PQ index with MAX_SIM_COSINE metric
-        expected: index creation successful
-        """
-        collection_name = cf.gen_unique_str(f"{prefix}_index_hnsw_pq")
-        client = self._client()
-        self.create_collection_with_data(client, collection_name)
-
-        index_params = client.prepare_index_params()
-        index_params.add_index(
-            field_name="normal_vector",
-            index_type="IVF_FLAT",
-            metric_type="L2",
-            params={"nlist": 128},
-        )
-        index_params.add_index(
-            field_name="clips[clip_embedding1]",
-            index_name="struct_vector_index_hnsw_pq",
-            index_type="HNSW_PQ",
-            metric_type="MAX_SIM_COSINE",
-            params=EMB_LIST_INDEX_CONFIGS["HNSW_PQ"]["build_params"],
-        )
-
-        res, check = self.create_index(client, collection_name, index_params)
-        assert check
-
-    @pytest.mark.tags(CaseLabel.L1)
-    def test_create_emb_list_hnsw_prq_index(self):
-        """
-        target: test create HNSW_PRQ index on struct array vector field
-        method: create HNSW_PRQ index with MAX_SIM_COSINE metric
-        expected: index creation successful
-        """
-        collection_name = cf.gen_unique_str(f"{prefix}_index_hnsw_prq")
-        client = self._client()
-        self.create_collection_with_data(client, collection_name)
-
-        index_params = client.prepare_index_params()
-        index_params.add_index(
-            field_name="normal_vector",
-            index_type="IVF_FLAT",
-            metric_type="L2",
-            params={"nlist": 128},
-        )
-        index_params.add_index(
-            field_name="clips[clip_embedding1]",
-            index_name="struct_vector_index_hnsw_prq",
-            index_type="HNSW_PRQ",
-            metric_type="MAX_SIM_COSINE",
-            params=EMB_LIST_INDEX_CONFIGS["HNSW_PRQ"]["build_params"],
-        )
-
-        res, check = self.create_index(client, collection_name, index_params)
-        assert check
-
-    @pytest.mark.tags(CaseLabel.L1)
-    def test_create_emb_list_ivf_flat_cc_index(self):
-        """
-        target: test create IVF_FLAT_CC index on struct array vector field
-        method: create IVF_FLAT_CC index with MAX_SIM_COSINE metric
-        expected: index creation successful
-        """
-        collection_name = cf.gen_unique_str(f"{prefix}_index_ivf_flat_cc")
-        client = self._client()
-        self.create_collection_with_data(client, collection_name)
-
-        index_params = client.prepare_index_params()
-        index_params.add_index(
-            field_name="normal_vector",
-            index_type="IVF_FLAT",
-            metric_type="L2",
-            params={"nlist": 128},
-        )
-        index_params.add_index(
-            field_name="clips[clip_embedding1]",
-            index_name="struct_vector_index_ivf_flat_cc",
-            index_type="IVF_FLAT_CC",
-            metric_type="MAX_SIM_COSINE",
-            params=EMB_LIST_INDEX_CONFIGS["IVF_FLAT_CC"]["build_params"],
-        )
-
-        res, check = self.create_index(client, collection_name, index_params)
-        assert check
-
-    @pytest.mark.tags(CaseLabel.L1)
-    def test_create_emb_list_diskann_index(self):
-        """
-        target: test create DISKANN index on struct array vector field
-        method: create DISKANN index with MAX_SIM_COSINE metric
-        expected: index creation successful
-        """
-        collection_name = cf.gen_unique_str(f"{prefix}_index_diskann")
-        client = self._client()
-        self.create_collection_with_data(client, collection_name)
-
-        index_params = client.prepare_index_params()
-        index_params.add_index(
-            field_name="normal_vector",
-            index_type="IVF_FLAT",
-            metric_type="L2",
-            params={"nlist": 128},
-        )
-        index_params.add_index(
-            field_name="clips[clip_embedding1]",
-            index_name="struct_vector_index_diskann",
-            index_type="DISKANN",
-            metric_type="MAX_SIM_COSINE",
-            params=EMB_LIST_INDEX_CONFIGS["DISKANN"]["build_params"],
-        )
-
-        res, check = self.create_index(client, collection_name, index_params)
-        assert check
-
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("index_type", EMB_LIST_INDEX_TYPES)
     @pytest.mark.parametrize("metric_type", METRICS)
     def test_emb_list_index_different_types_and_metrics(self, index_type, metric_type):
         """
-        target: test different emb list index types with different metric types
-        method: create index with various index type and metric combinations
-        expected: index creation successful for all supported combinations
+        target: test emb list index with full CRUD path for different index types and metrics
+        method: insert (flushed + growing) → create index → load → search → upsert → delete → verify
+        expected: all CRUD operations successful with correct search results
         """
         collection_name = cf.gen_unique_str(
             f"{prefix}_idx_{index_type.lower()}_{metric_type.lower()}"
         )
         client = self._client()
-        self.create_collection_with_data(client, collection_name)
 
-        build_params = EMB_LIST_INDEX_CONFIGS[index_type]["build_params"]
-
-        index_params = client.prepare_index_params()
-        index_params.add_index(
-            field_name="normal_vector",
-            index_type="IVF_FLAT",
-            metric_type="L2",
-            params={"nlist": 128},
-        )
-        index_params.add_index(
-            field_name="clips[clip_embedding1]",
-            index_name=f"struct_index_{index_type.lower()}_{metric_type.lower()}",
-            index_type=index_type,
-            metric_type=metric_type,
-            params=build_params,
-        )
-
-        res, check = self.create_index(client, collection_name, index_params)
-        assert check
-
-    def _create_collection_with_vector_type(
-        self, client, collection_name, vector_type, dim=default_dim, nb=default_nb
-    ):
-        """Create collection with struct array using specified vector type"""
+        # Create collection schema with label field for upsert verification
         schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
         schema.add_field(field_name="id", datatype=DataType.INT64, is_primary=True)
         schema.add_field(
-            field_name="normal_vector", datatype=DataType.FLOAT_VECTOR, dim=dim
+            field_name="normal_vector", datatype=DataType.FLOAT_VECTOR, dim=default_dim
         )
 
         struct_schema = client.create_struct_field_schema()
-        struct_schema.add_field("clip_embedding1", vector_type, dim=dim)
+        struct_schema.add_field("clip_embedding1", DataType.FLOAT_VECTOR, dim=default_dim)
         struct_schema.add_field("scalar_field", DataType.INT64)
+        struct_schema.add_field("label", DataType.VARCHAR, max_length=128)
 
         schema.add_field(
             "clips",
@@ -1670,50 +1502,191 @@ class TestMilvusClientStructArrayIndex(TestMilvusClientV2Base):
         res, check = self.create_collection(client, collection_name, schema=schema)
         assert check
 
-        # Generate and insert data with the specified vector type
-        data = []
-        for i in range(nb):
-            array_length = random.randint(1, 10)
-            struct_array = []
-            for j in range(array_length):
-                vec = cf.gen_vectors(1, dim, vector_type)[0]
-                struct_element = {
-                    "clip_embedding1": vec,
+        # Insert 200 records and flush (sealed segments)
+        nb_flushed = 200
+        flushed_data = []
+        for i in range(nb_flushed):
+            array_length = random.randint(1, 5)
+            struct_array = [
+                {
+                    "clip_embedding1": [random.random() for _ in range(default_dim)],
                     "scalar_field": i * 10 + j,
+                    "label": f"flushed_{i}",
                 }
-                struct_array.append(struct_element)
-
+                for j in range(array_length)
+            ]
             row = {
                 "id": i,
-                "normal_vector": [random.random() for _ in range(dim)],
+                "normal_vector": [random.random() for _ in range(default_dim)],
                 "clips": struct_array,
             }
-            data.append(row)
+            flushed_data.append(row)
 
-        res, check = self.insert(client, collection_name, data)
+        res, check = self.insert(client, collection_name, flushed_data)
         assert check
-        return data
+        assert res["insert_count"] == nb_flushed
+
+        res, check = self.flush(client, collection_name)
+        assert check
+
+        # Insert 100 more growing records
+        nb_growing = 100
+        growing_data = []
+        for i in range(nb_flushed, nb_flushed + nb_growing):
+            array_length = random.randint(1, 5)
+            struct_array = [
+                {
+                    "clip_embedding1": [random.random() for _ in range(default_dim)],
+                    "scalar_field": i * 10 + j,
+                    "label": f"growing_{i}",
+                }
+                for j in range(array_length)
+            ]
+            row = {
+                "id": i,
+                "normal_vector": [random.random() for _ in range(default_dim)],
+                "clips": struct_array,
+            }
+            growing_data.append(row)
+
+        res, check = self.insert(client, collection_name, growing_data)
+        assert check
+        assert res["insert_count"] == nb_growing
+
+        # Create index with specified type and metric
+        build_params = EMB_LIST_INDEX_CONFIGS[index_type]["build_params"]
+        search_params = EMB_LIST_INDEX_CONFIGS[index_type]["search_params"]
+
+        index_params = client.prepare_index_params()
+        index_params.add_index(
+            field_name="normal_vector",
+            index_type="IVF_FLAT",
+            metric_type="L2",
+            params={"nlist": 128},
+        )
+        index_params.add_index(
+            field_name="clips[clip_embedding1]",
+            index_name=f"struct_idx_{index_type.lower()}_{metric_type.lower()}",
+            index_type=index_type,
+            metric_type=metric_type,
+            params=build_params,
+        )
+
+        res, check = self.create_index(client, collection_name, index_params)
+        assert check
+
+        # Load collection
+        res, check = self.load_collection(client, collection_name)
+        assert check
+
+        # Search with EmbeddingList and verify results
+        embedding_list = EmbeddingList()
+        for _ in range(3):
+            embedding_list.add([random.random() for _ in range(default_dim)])
+
+        results, check = self.search(
+            client,
+            collection_name,
+            data=[embedding_list],
+            anns_field="clips[clip_embedding1]",
+            search_params={"metric_type": metric_type, "params": search_params},
+            limit=10,
+            output_fields=["id", "clips"],
+        )
+        assert check
+        assert len(results[0]) > 0
+        for hit in results[0]:
+            assert "id" in hit
+            assert 0 <= hit["id"] < nb_flushed + nb_growing
+
+        # Upsert 10 records from flushed segment
+        upsert_data = []
+        for i in range(10):
+            row = {
+                "id": i,
+                "normal_vector": [random.random() for _ in range(default_dim)],
+                "clips": [
+                    {
+                        "clip_embedding1": [random.random() for _ in range(default_dim)],
+                        "scalar_field": i + 10000,
+                        "label": f"upserted_{i}",
+                    }
+                ],
+            }
+            upsert_data.append(row)
+
+        res, check = self.upsert(client, collection_name, upsert_data)
+        assert check
+
+        # Verify upsert via query
+        res, check = self.flush(client, collection_name)
+        assert check
+
+        results, check = self.query(
+            client, collection_name, filter="id < 10", output_fields=["id", "clips"]
+        )
+        assert check
+        assert len(results) == 10
+        for result in results:
+            assert "upserted" in result["clips"][0]["label"]
+
+        # Delete 5 records from growing segment
+        delete_ids = list(range(nb_flushed, nb_flushed + 5))
+        res, check = self.delete(client, collection_name, filter=f"id in {delete_ids}")
+        assert check
+
+        # Verify deletion
+        res, check = self.flush(client, collection_name)
+        assert check
+
+        results, check = self.query(
+            client, collection_name, filter="id >= 0", output_fields=["id"]
+        )
+        assert check
+        remaining_ids = {r["id"] for r in results}
+        for del_id in delete_ids:
+            assert del_id not in remaining_ids
+        assert len(results) == nb_flushed + nb_growing - 5
+
+        # Search again after CRUD operations to verify index still works
+        results, check = self.search(
+            client,
+            collection_name,
+            data=[embedding_list],
+            anns_field="clips[clip_embedding1]",
+            search_params={"metric_type": metric_type, "params": search_params},
+            limit=10,
+            output_fields=["id"],
+        )
+        assert check
+        assert len(results[0]) > 0
+        for hit in results[0]:
+            assert hit["id"] not in delete_ids
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("index_type", list(EMB_LIST_VECTOR_TYPES.keys()))
     def test_emb_list_index_with_different_vector_types(self, index_type):
         """
-        target: test emb list index creation with different vector data types
-        method: create index on struct array vector field with float16/bfloat16/int8/binary types
-        expected: index creation successful for all supported vector types per index
+        target: test emb list index with full CRUD path for different vector data types
+        method: for each supported vector type per index: insert (flushed + growing) → index → load → search → upsert → delete → verify
+        expected: all CRUD operations successful for all supported vector types
         """
         client = self._client()
         supported_types = EMB_LIST_VECTOR_TYPES[index_type]
 
-        # Get build params
+        # Get build/search params
         if index_type in EMB_LIST_INDEX_CONFIGS:
             build_params = EMB_LIST_INDEX_CONFIGS[index_type]["build_params"]
+            search_params = EMB_LIST_INDEX_CONFIGS[index_type]["search_params"]
         elif index_type == "HNSW":
             build_params = INDEX_PARAMS
+            search_params = {"ef": 64}
         elif index_type == "IVF_FLAT":
             build_params = {"nlist": 128}
+            search_params = {"nprobe": 10}
         else:
             build_params = {}
+            search_params = {}
 
         for vector_type in supported_types:
             # Skip FLOAT_VECTOR since it is already tested
@@ -1725,16 +1698,87 @@ class TestMilvusClientStructArrayIndex(TestMilvusClientV2Base):
                 f"{prefix}_vtype_{index_type.lower()}_{type_name}"
             )
 
-            self._create_collection_with_vector_type(
-                client, collection_name, vector_type
-            )
-
             # Choose metric based on vector type
             if vector_type == DataType.BINARY_VECTOR:
                 metric_type = BINARY_METRIC
             else:
                 metric_type = FLOAT_METRIC
 
+            # Create collection with struct array schema including label field
+            schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
+            schema.add_field(field_name="id", datatype=DataType.INT64, is_primary=True)
+            schema.add_field(
+                field_name="normal_vector", datatype=DataType.FLOAT_VECTOR, dim=default_dim
+            )
+
+            struct_schema = client.create_struct_field_schema()
+            struct_schema.add_field("clip_embedding1", vector_type, dim=default_dim)
+            struct_schema.add_field("scalar_field", DataType.INT64)
+            struct_schema.add_field("label", DataType.VARCHAR, max_length=128)
+
+            schema.add_field(
+                "clips",
+                datatype=DataType.ARRAY,
+                element_type=DataType.STRUCT,
+                struct_schema=struct_schema,
+                max_capacity=100,
+            )
+
+            res, check = self.create_collection(client, collection_name, schema=schema)
+            assert check
+
+            # Insert 100 records and flush (sealed segments)
+            nb_flushed = 100
+            flushed_data = []
+            for i in range(nb_flushed):
+                array_length = random.randint(1, 5)
+                struct_array = [
+                    {
+                        "clip_embedding1": cf.gen_vectors(1, default_dim, vector_type)[0],
+                        "scalar_field": i * 10 + j,
+                        "label": f"flushed_{i}",
+                    }
+                    for j in range(array_length)
+                ]
+                row = {
+                    "id": i,
+                    "normal_vector": [random.random() for _ in range(default_dim)],
+                    "clips": struct_array,
+                }
+                flushed_data.append(row)
+
+            res, check = self.insert(client, collection_name, flushed_data)
+            assert check
+            assert res["insert_count"] == nb_flushed
+
+            res, check = self.flush(client, collection_name)
+            assert check
+
+            # Insert 50 more growing records
+            nb_growing = 50
+            growing_data = []
+            for i in range(nb_flushed, nb_flushed + nb_growing):
+                array_length = random.randint(1, 5)
+                struct_array = [
+                    {
+                        "clip_embedding1": cf.gen_vectors(1, default_dim, vector_type)[0],
+                        "scalar_field": i * 10 + j,
+                        "label": f"growing_{i}",
+                    }
+                    for j in range(array_length)
+                ]
+                row = {
+                    "id": i,
+                    "normal_vector": [random.random() for _ in range(default_dim)],
+                    "clips": struct_array,
+                }
+                growing_data.append(row)
+
+            res, check = self.insert(client, collection_name, growing_data)
+            assert check
+            assert res["insert_count"] == nb_growing
+
+            # Create index
             index_params = client.prepare_index_params()
             index_params.add_index(
                 field_name="normal_vector",
@@ -1754,6 +1798,97 @@ class TestMilvusClientStructArrayIndex(TestMilvusClientV2Base):
             assert check, (
                 f"Failed to create {index_type} index with {type_name} vector type"
             )
+
+            # Load collection
+            res, check = self.load_collection(client, collection_name)
+            assert check
+
+            # Search with EmbeddingList and verify results
+            search_vecs = cf.gen_vectors(3, default_dim, vector_type)
+            embedding_list = EmbeddingList(
+                [np.frombuffer(v, dtype=np.uint8) if isinstance(v, bytes) else
+                 (np.array(v) if not isinstance(v, np.ndarray) else v) for v in search_vecs]
+            )
+
+            results, check = self.search(
+                client,
+                collection_name,
+                data=[embedding_list],
+                anns_field="clips[clip_embedding1]",
+                search_params={"metric_type": metric_type, "params": search_params},
+                limit=10,
+                output_fields=["id", "clips"],
+            )
+            assert check
+            assert len(results[0]) > 0
+            for hit in results[0]:
+                assert 0 <= hit["id"] < nb_flushed + nb_growing
+
+            # Upsert 5 records from flushed segment
+            upsert_data = []
+            for i in range(5):
+                row = {
+                    "id": i,
+                    "normal_vector": [random.random() for _ in range(default_dim)],
+                    "clips": [
+                        {
+                            "clip_embedding1": cf.gen_vectors(1, default_dim, vector_type)[0],
+                            "scalar_field": i + 10000,
+                            "label": f"upserted_{i}",
+                        }
+                    ],
+                }
+                upsert_data.append(row)
+
+            res, check = self.upsert(client, collection_name, upsert_data)
+            assert check
+
+            # Verify upsert via query
+            res, check = self.flush(client, collection_name)
+            assert check
+
+            results, check = self.query(
+                client, collection_name, filter="id < 5", output_fields=["id", "clips"]
+            )
+            assert check
+            assert len(results) == 5
+            for result in results:
+                assert "upserted" in result["clips"][0]["label"]
+
+            # Delete 3 records from growing segment
+            delete_ids = list(range(nb_flushed, nb_flushed + 3))
+            res, check = self.delete(
+                client, collection_name, filter=f"id in {delete_ids}"
+            )
+            assert check
+
+            # Verify deletion
+            res, check = self.flush(client, collection_name)
+            assert check
+
+            results, check = self.query(
+                client, collection_name, filter="id >= 0", output_fields=["id"]
+            )
+            assert check
+            remaining_ids = {r["id"] for r in results}
+            for del_id in delete_ids:
+                assert del_id not in remaining_ids
+            assert len(results) == nb_flushed + nb_growing - 3
+
+            # Search again after CRUD operations
+            results, check = self.search(
+                client,
+                collection_name,
+                data=[embedding_list],
+                anns_field="clips[clip_embedding1]",
+                search_params={"metric_type": metric_type, "params": search_params},
+                limit=10,
+                output_fields=["id"],
+            )
+            assert check
+            assert len(results[0]) > 0
+            for hit in results[0]:
+                assert hit["id"] not in delete_ids
 
 
 class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
@@ -2546,9 +2681,9 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
     @pytest.mark.parametrize("index_type", EMB_LIST_INDEX_TYPES)
     def test_search_emb_list_with_different_index_types(self, index_type):
         """
-        target: test search with different emb list index types
-        method: create collection with configurable index type, search with EmbeddingList
-        expected: search returns non-empty results for all supported index types
+        target: test search with full CRUD path for different emb list index types
+        method: insert (flushed + growing) → index → load → search → upsert → delete → search → verify
+        expected: all CRUD operations and search work correctly for each index type
         """
         collection_name = cf.gen_unique_str(
             f"{prefix}_search_{index_type.lower()}"
@@ -2556,18 +2691,119 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
         client = self._client()
 
         config = EMB_LIST_INDEX_CONFIGS[index_type]
-        self.create_collection_with_configurable_index(
-            client,
-            collection_name,
-            index_type=index_type,
-            metric_type="MAX_SIM_COSINE",
-            build_params=config["build_params"],
+
+        # Create collection with full schema
+        schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
+        schema.add_field(field_name="id", datatype=DataType.INT64, is_primary=True)
+        schema.add_field(
+            field_name="normal_vector", datatype=DataType.FLOAT_VECTOR, dim=default_dim
         )
 
-        # Create EmbeddingList with multiple vectors
+        struct_schema = client.create_struct_field_schema()
+        struct_schema.add_field("clip_embedding1", DataType.FLOAT_VECTOR, dim=default_dim)
+        struct_schema.add_field("scalar_field", DataType.INT64)
+        struct_schema.add_field("category", DataType.VARCHAR, max_length=128)
+
+        schema.add_field(
+            "clips",
+            datatype=DataType.ARRAY,
+            element_type=DataType.STRUCT,
+            struct_schema=struct_schema,
+            max_capacity=100,
+        )
+
+        schema.add_field("scalar_field", datatype=DataType.INT64)
+        schema.add_field("category", datatype=DataType.VARCHAR, max_length=128)
+        schema.add_field("score", datatype=DataType.FLOAT)
+
+        res, check = self.create_collection(client, collection_name, schema=schema)
+        assert check
+
+        # Insert 200 records and flush (sealed segments)
+        nb_flushed = 200
+        flushed_data = []
+        for i in range(nb_flushed):
+            array_length = random.randint(1, 5)
+            struct_array = []
+            for j in range(array_length):
+                struct_element = {
+                    "clip_embedding1": [random.random() for _ in range(default_dim)],
+                    "scalar_field": i * 10 + j,
+                    "category": f"cat_{i % 5}",
+                }
+                struct_array.append(struct_element)
+
+            row = {
+                "id": i,
+                "normal_vector": [random.random() for _ in range(default_dim)],
+                "clips": struct_array,
+                "scalar_field": i * 10 + j,
+                "category": f"cat_{i % 5}",
+                "score": random.uniform(0.1, 10.0),
+            }
+            flushed_data.append(row)
+
+        res, check = self.insert(client, collection_name, flushed_data)
+        assert check
+        assert res["insert_count"] == nb_flushed
+
+        res, check = self.flush(client, collection_name)
+        assert check
+
+        # Insert 100 more growing records
+        nb_growing = 100
+        growing_data = []
+        for i in range(nb_flushed, nb_flushed + nb_growing):
+            array_length = random.randint(1, 5)
+            struct_array = []
+            for j in range(array_length):
+                struct_element = {
+                    "clip_embedding1": [random.random() for _ in range(default_dim)],
+                    "scalar_field": i * 10 + j,
+                    "category": f"cat_{i % 5}",
+                }
+                struct_array.append(struct_element)
+
+            row = {
+                "id": i,
+                "normal_vector": [random.random() for _ in range(default_dim)],
+                "clips": struct_array,
+                "scalar_field": i * 10 + j,
+                "category": f"cat_{i % 5}",
+                "score": random.uniform(0.1, 10.0),
+            }
+            growing_data.append(row)
+
+        res, check = self.insert(client, collection_name, growing_data)
+        assert check
+        assert res["insert_count"] == nb_growing
+
+        # Create index with configurable type
+        index_params = client.prepare_index_params()
+        index_params.add_index(
+            field_name="normal_vector",
+            index_type="IVF_FLAT",
+            metric_type="L2",
+            params={"nlist": 128},
+        )
+        index_params.add_index(
+            field_name="clips[clip_embedding1]",
+            index_name="struct_vector_index",
+            index_type=index_type,
+            metric_type="MAX_SIM_COSINE",
+            params=config["build_params"],
+        )
+
+        res, check = self.create_index(client, collection_name, index_params)
+        assert check
+
+        # Load collection
+        res, check = self.load_collection(client, collection_name)
+        assert check
+
+        # Search with EmbeddingList and verify results
         embedding_list = self.create_embedding_list(default_dim, 3)
 
-        # Search using EmbeddingList
         results, check = self.search(
             client,
             collection_name,
@@ -2578,9 +2814,84 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
                 "params": config["search_params"],
             },
             limit=10,
+            output_fields=["id", "clips"],
         )
         assert check
         assert len(results[0]) > 0
+        for hit in results[0]:
+            assert 0 <= hit["id"] < nb_flushed + nb_growing
+
+        # Upsert 10 records from flushed segment
+        upsert_data = []
+        for i in range(10):
+            row = {
+                "id": i,
+                "normal_vector": [random.random() for _ in range(default_dim)],
+                "clips": [
+                    {
+                        "clip_embedding1": [random.random() for _ in range(default_dim)],
+                        "scalar_field": i + 10000,
+                        "category": f"upserted_{i}",
+                    }
+                ],
+                "scalar_field": i + 10000,
+                "category": f"upserted_{i}",
+                "score": random.uniform(10.0, 20.0),
+            }
+            upsert_data.append(row)
+
+        res, check = self.upsert(client, collection_name, upsert_data)
+        assert check
+
+        # Verify upsert via query
+        res, check = self.flush(client, collection_name)
+        assert check
+
+        results, check = self.query(
+            client, collection_name, filter="id < 10",
+            output_fields=["id", "category", "clips"],
+        )
+        assert check
+        assert len(results) == 10
+        for result in results:
+            assert "upserted" in result["category"]
+            assert "upserted" in result["clips"][0]["category"]
+
+        # Delete 5 records from growing segment
+        delete_ids = list(range(nb_flushed, nb_flushed + 5))
+        res, check = self.delete(client, collection_name, filter=f"id in {delete_ids}")
+        assert check
+
+        # Verify deletion
+        res, check = self.flush(client, collection_name)
+        assert check
+
+        results, check = self.query(
+            client, collection_name, filter="id >= 0", output_fields=["id"]
+        )
+        assert check
+        remaining_ids = {r["id"] for r in results}
+        for del_id in delete_ids:
+            assert del_id not in remaining_ids
+        assert len(results) == nb_flushed + nb_growing - 5
+
+        # Search again after CRUD operations
+        results, check = self.search(
+            client,
+            collection_name,
+            data=[embedding_list],
+            anns_field="clips[clip_embedding1]",
+            search_params={
+                "metric_type": "MAX_SIM_COSINE",
+                "params": config["search_params"],
+            },
+            limit=10,
+            output_fields=["id"],
+        )
+        assert check
+        assert len(results[0]) > 0
+        for hit in results[0]:
+            assert hit["id"] not in delete_ids
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize(
@@ -2589,9 +2900,9 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
     )
     def test_search_emb_list_with_different_vector_types(self, vector_type):
         """
-        target: test search with different vector data types in struct array
-        method: create collection with float16/bfloat16/int8 vectors, build HNSW index, search
-        expected: search returns non-empty results
+        target: test search with full CRUD path for different vector data types in struct array
+        method: insert (flushed + growing) → HNSW index → load → search → upsert → delete → search → verify
+        expected: all CRUD operations and search work correctly for each vector type
         """
         type_name = vector_type.name.lower()
         collection_name = cf.gen_unique_str(f"{prefix}_search_vtype_{type_name}")
@@ -2624,9 +2935,10 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
         res, check = self.create_collection(client, collection_name, schema=schema)
         assert check
 
-        # Insert data
-        data = []
-        for i in range(default_nb):
+        # Insert 200 records and flush (sealed segments)
+        nb_flushed = 200
+        flushed_data = []
+        for i in range(nb_flushed):
             array_length = random.randint(1, 5)
             struct_array = []
             for j in range(array_length):
@@ -2634,7 +2946,7 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
                 struct_element = {
                     "clip_embedding1": vec,
                     "scalar_field": i * 10 + j,
-                    "category": f"cat_{i % 5}",
+                    "category": f"flushed_{i}",
                 }
                 struct_array.append(struct_element)
 
@@ -2643,13 +2955,46 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
                 "normal_vector": [random.random() for _ in range(default_dim)],
                 "clips": struct_array,
                 "scalar_field": i * 10 + j,
-                "category": f"cat_{i % 5}",
+                "category": f"flushed_{i}",
                 "score": random.uniform(0.1, 10.0),
             }
-            data.append(row)
+            flushed_data.append(row)
 
-        res, check = self.insert(client, collection_name, data)
+        res, check = self.insert(client, collection_name, flushed_data)
         assert check
+        assert res["insert_count"] == nb_flushed
+
+        res, check = self.flush(client, collection_name)
+        assert check
+
+        # Insert 100 more growing records
+        nb_growing = 100
+        growing_data = []
+        for i in range(nb_flushed, nb_flushed + nb_growing):
+            array_length = random.randint(1, 5)
+            struct_array = []
+            for j in range(array_length):
+                vec = cf.gen_vectors(1, default_dim, vector_type)[0]
+                struct_element = {
+                    "clip_embedding1": vec,
+                    "scalar_field": i * 10 + j,
+                    "category": f"growing_{i}",
+                }
+                struct_array.append(struct_element)
+
+            row = {
+                "id": i,
+                "normal_vector": [random.random() for _ in range(default_dim)],
+                "clips": struct_array,
+                "scalar_field": i * 10 + j,
+                "category": f"growing_{i}",
+                "score": random.uniform(0.1, 10.0),
+            }
+            growing_data.append(row)
+
+        res, check = self.insert(client, collection_name, growing_data)
+        assert check
+        assert res["insert_count"] == nb_growing
 
         # Create HNSW index with MAX_SIM_COSINE (works for float16/bfloat16/int8)
         index_params = client.prepare_index_params()
@@ -2673,7 +3018,7 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
         res, check = self.load_collection(client, collection_name)
         assert check
 
-        # Search with EmbeddingList using the same vector type
+        # Search with EmbeddingList and verify results
         search_vecs = cf.gen_vectors(3, default_dim, vector_type)
         embedding_list = EmbeddingList(
             [np.array(v) if not isinstance(v, np.ndarray) else v for v in search_vecs]
@@ -2686,9 +3031,85 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
             anns_field="clips[clip_embedding1]",
             search_params={"metric_type": "MAX_SIM_COSINE"},
             limit=10,
+            output_fields=["id", "clips"],
         )
         assert check
         assert len(results[0]) > 0
+        for hit in results[0]:
+            assert 0 <= hit["id"] < nb_flushed + nb_growing
+
+        # Upsert 10 records from flushed segment
+        upsert_data = []
+        for i in range(10):
+            row = {
+                "id": i,
+                "normal_vector": [random.random() for _ in range(default_dim)],
+                "clips": [
+                    {
+                        "clip_embedding1": cf.gen_vectors(1, default_dim, vector_type)[0],
+                        "scalar_field": i + 10000,
+                        "category": f"upserted_{i}",
+                    }
+                ],
+                "scalar_field": i + 10000,
+                "category": f"upserted_{i}",
+                "score": random.uniform(10.0, 20.0),
+            }
+            upsert_data.append(row)
+
+        res, check = self.upsert(client, collection_name, upsert_data)
+        assert check
+
+        # Verify upsert via query
+        res, check = self.flush(client, collection_name)
+        assert check
+
+        results, check = self.query(
+            client, collection_name, filter="id < 10",
+            output_fields=["id", "category", "clips"],
+        )
+        assert check
+        assert len(results) == 10
+        for result in results:
+            assert "upserted" in result["category"]
+            assert "upserted" in result["clips"][0]["category"]
+
+        # Delete 5 records from flushed segment and 3 from growing segment
+        delete_flushed_ids = [10, 11, 12, 13, 14]
+        delete_growing_ids = list(range(nb_flushed, nb_flushed + 3))
+        all_delete_ids = delete_flushed_ids + delete_growing_ids
+        res, check = self.delete(
+            client, collection_name, filter=f"id in {all_delete_ids}"
+        )
+        assert check
+
+        # Verify deletion
+        res, check = self.flush(client, collection_name)
+        assert check
+
+        results, check = self.query(
+            client, collection_name, filter="id >= 0", output_fields=["id"]
+        )
+        assert check
+        remaining_ids = {r["id"] for r in results}
+        for del_id in all_delete_ids:
+            assert del_id not in remaining_ids
+        assert len(results) == nb_flushed + nb_growing - len(all_delete_ids)
+
+        # Search again after CRUD operations
+        results, check = self.search(
+            client,
+            collection_name,
+            data=[embedding_list],
+            anns_field="clips[clip_embedding1]",
+            search_params={"metric_type": "MAX_SIM_COSINE"},
+            limit=10,
+            output_fields=["id"],
+        )
+        assert check
+        assert len(results[0]) > 0
+        for hit in results[0]:
+            assert hit["id"] not in all_delete_ids
 
 
 class TestMilvusClientStructArrayHybridSearch(TestMilvusClientV2Base):


### PR DESCRIPTION
## Summary
- Add comprehensive test coverage for emb list (ArrayOfVector) index types in struct array tests
- Cover all supported index types: **HNSW**, **HNSW_SQ**, **HNSW_PQ**, **HNSW_PRQ**, **IVF_FLAT**, **IVF_FLAT_CC**, **DISKANN**
- Cover all supported vector data types: **FloatVector**, **Float16Vector**, **BFloat16Vector**, **Int8Vector**, **BinaryVector**
- Cover all MaxSim metric types: **MAX_SIM**, **MAX_SIM_COSINE**, **MAX_SIM_IP**, **MAX_SIM_L2**, **MAX_SIM_HAMMING** (binary)
- Use `EMB_LIST_DIM=32` for faster index building, `nb_flushed=3000` to meet index creation threshold (>2048)
- Full CRUD path in search tests: insert (flushed + growing) → index → load → search → upsert → delete → verify

### Coverage Matrix

| | HNSW | HNSW_SQ | HNSW_PQ | HNSW_PRQ | IVF_FLAT | IVF_FLAT_CC | DISKANN |
|---|---|---|---|---|---|---|---|
| **FloatVector** | ✅ L0 | ✅ L1 | ✅ L1 | ✅ L1 | ✅ L1 | ✅ L1 | ✅ L1 |
| **Float16Vector** | ✅ L2 | - | - | - | - | - | - |
| **BFloat16Vector** | ✅ L2 | - | - | - | - | - | - |
| **Int8Vector** | ✅ L2 | - | - | - | - | - | - |
| **BinaryVector** | ✅ L2 | N/A | N/A | N/A | N/A | N/A | N/A |

### Test Cases
| Test Method | Level | Parameters | Count |
|---|---|---|---|
| `test_create_emb_list_hnsw_index_cosine/ip` | L0 | HNSW + COSINE/IP | 2 |
| `test_emb_list_hnsw_different_metrics` | L2 | 4 metrics | 4 |
| `test_search_emb_list_with_different_index_types` | L1 | 6 index types | 6 |
| `test_search_emb_list_with_different_vector_types` | L2 | 4 vector types (float16/bfloat16/int8/binary) | 4 |

## Test plan
- [x] All 14 emb_list test cases passed (6 workers, 78s)
- [x] DISKANN emb_list index build verified after fix PR #48843
- [x] BinaryVector with MAX_SIM_HAMMING metric verified
- [x] Full CRUD path (insert/flush/index/load/search/upsert/delete) verified for all index types

