### PR TITLE
fix: support struct array fields in partial update

### DIFF
--- a/internal/proxy/task_upsert.go
+++ b/internal/proxy/task_upsert.go
@@ -291,6 +291,13 @@ func (it *upsertTask) queryPreExecute(ctx context.Context) error {
 		zap.Int("resultNum", typeutil.GetSizeOfIDs(existIDs)),
 		zap.Int64("latency", tr.ElapseSpan().Milliseconds()))
 
+	// Partial update merge works on flattened struct-array subfields.
+	// Flatten before field-ID lookup so schemaHelper can resolve struct members.
+	if err := checkAndFlattenStructFieldData(it.schema.CollectionSchema, it.upsertMsg.InsertMsg); err != nil {
+		log.Info("check and flatten struct field data failed", zap.Error(err))
+		return err
+	}
+
 	// set field id for user passed field data, prepare for merge logic
 	if len(it.upsertMsg.InsertMsg.GetFieldsData()) == 0 {
 		return merr.WrapErrParameterInvalidMsg("upsert field data is empty")

--- a/internal/proxy/task_upsert_test.go
+++ b/internal/proxy/task_upsert_test.go
@@ -3067,3 +3067,98 @@ func TestUpsertTask_queryPreExecute_DynamicFieldValidData(t *testing.T) {
 			"queryPreExecute auto-fills ValidData, merge produces correct length 3")
 	})
 }
+
+func TestUpsertTask_queryPreExecute_StructArrayField(t *testing.T) {
+	rawSchema := constructCollectionSchemaWithStructArrayField("test_partial_update_struct_array", testStructArrayField, false)
+	upsertStructData := newStructArrayFieldData(rawSchema.StructArrayFields[0], testStructArrayField, 1, testVecDim)
+	existStructData := newStructArrayFieldData(rawSchema.StructArrayFields[0], testStructArrayField, 1, testVecDim)
+
+	assert.NoError(t, transformStructFieldNames(rawSchema))
+	schema := newSchemaInfo(rawSchema)
+
+	existStructMsg := &msgstream.InsertMsg{
+		InsertRequest: &msgpb.InsertRequest{
+			CollectionName: rawSchema.Name,
+			FieldsData:     []*schemapb.FieldData{existStructData},
+		},
+	}
+	assert.NoError(t, checkAndFlattenStructFieldData(rawSchema, existStructMsg))
+
+	upsertVector := newFloatVectorFieldData(testFloatVecField, 1, testVecDim)
+	upsertVector.FieldId = 101
+	existVector := newFloatVectorFieldData(testFloatVecField, 1, testVecDim)
+	existVector.FieldId = 101
+
+	upsertData := []*schemapb.FieldData{
+		{
+			FieldName: testInt64Field,
+			FieldId:   100,
+			Type:      schemapb.DataType_Int64,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_LongData{
+						LongData: &schemapb.LongArray{Data: []int64{1}},
+					},
+				},
+			},
+		},
+		upsertVector,
+		upsertStructData,
+	}
+
+	mockQueryResult := &milvuspb.QueryResults{
+		Status: merr.Success(),
+		FieldsData: append([]*schemapb.FieldData{
+			{
+				FieldName: testInt64Field,
+				FieldId:   100,
+				Type:      schemapb.DataType_Int64,
+				Field: &schemapb.FieldData_Scalars{
+					Scalars: &schemapb.ScalarField{
+						Data: &schemapb.ScalarField_LongData{
+							LongData: &schemapb.LongArray{Data: []int64{1}},
+						},
+					},
+				},
+			},
+			existVector,
+		}, existStructMsg.GetFieldsData()...),
+	}
+
+	task := &upsertTask{
+		ctx:    context.Background(),
+		schema: schema,
+		req: &milvuspb.UpsertRequest{
+			CollectionName: rawSchema.Name,
+			FieldsData:     upsertData,
+			NumRows:        1,
+			PartialUpdate:  true,
+		},
+		upsertMsg: &msgstream.UpsertMsg{
+			InsertMsg: &msgstream.InsertMsg{
+				InsertRequest: &msgpb.InsertRequest{
+					CollectionName: rawSchema.Name,
+					FieldsData:     upsertData,
+					NumRows:        1,
+					Version:        msgpb.InsertDataVersion_ColumnBased,
+				},
+			},
+		},
+		node: &Proxy{},
+	}
+
+	mockRetrieve := mockey.Mock(retrieveByPKs).Return(mockQueryResult, segcore.StorageCost{}, nil).Build()
+	defer mockRetrieve.UnPatch()
+
+	err := task.queryPreExecute(context.Background())
+	assert.NoError(t, err)
+
+	fieldNames := make([]string, 0, len(task.insertFieldData))
+	for _, field := range task.insertFieldData {
+		fieldNames = append(fieldNames, field.GetFieldName())
+	}
+
+	assert.Contains(t, fieldNames, typeutil.ConcatStructFieldName(testStructArrayField, "sub_text_array"))
+	assert.Contains(t, fieldNames, typeutil.ConcatStructFieldName(testStructArrayField, "sub_int_array"))
+	assert.Contains(t, fieldNames, typeutil.ConcatStructFieldName(testStructArrayField, "sub_float_vector_array"))
+}

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -1958,8 +1958,13 @@ func checkFieldsDataBySchema(allFields []*schemapb.FieldSchema, schema *schemapb
 // and then flattens the data so that data node and query node have not to handle the struct array field data.
 func checkAndFlattenStructFieldData(schema *schemapb.CollectionSchema, insertMsg *msgstream.InsertMsg) error {
 	structSchemaMap := make(map[string]*schemapb.StructArrayFieldSchema, len(schema.GetStructArrayFields()))
+	flattenedStructFieldMap := make(map[string]struct{})
 	for _, structField := range schema.GetStructArrayFields() {
 		structSchemaMap[structField.Name] = structField
+		for _, subField := range structField.GetFields() {
+			flattenedStructFieldMap[subField.GetName()] = struct{}{}
+			flattenedStructFieldMap[typeutil.ConcatStructFieldName(structField.Name, subField.GetName())] = struct{}{}
+		}
 	}
 
 	fieldSchemaMap := make(map[string]*schemapb.FieldSchema, len(schema.GetFields()))
@@ -1972,6 +1977,10 @@ func checkAndFlattenStructFieldData(schema *schemapb.CollectionSchema, insertMsg
 
 	for _, fieldData := range insertMsg.GetFieldsData() {
 		if _, ok := fieldSchemaMap[fieldData.FieldName]; ok {
+			flattenedFields = append(flattenedFields, fieldData)
+			continue
+		}
+		if _, ok := flattenedStructFieldMap[fieldData.FieldName]; ok {
 			flattenedFields = append(flattenedFields, fieldData)
 			continue
 		}
@@ -2039,7 +2048,7 @@ func checkAndFlattenStructFieldData(schema *schemapb.CollectionSchema, insertMsg
 		}
 	}
 
-	if len(schema.GetStructArrayFields()) != structFieldCount {
+	if structFieldCount > 0 && len(schema.GetStructArrayFields()) != structFieldCount {
 		return fmt.Errorf("the number of struct array fields is not the same as needed, expected: %d, actual: %d",
 			len(schema.GetStructArrayFields()), structFieldCount)
 	}

--- a/internal/proxy/util_test.go
+++ b/internal/proxy/util_test.go
@@ -3785,6 +3785,49 @@ func TestCheckAndFlattenStructFieldData(t *testing.T) {
 		assert.Contains(t, fieldNames, "metadata[tags]")
 	})
 
+	t.Run("success - already flattened struct fields are preserved", func(t *testing.T) {
+		structField := &schemapb.StructArrayFieldSchema{
+			Name: "user_info",
+			Fields: []*schemapb.FieldSchema{
+				{
+					Name:        "age_array",
+					DataType:    schemapb.DataType_Array,
+					ElementType: schemapb.DataType_Int32,
+				},
+				{
+					Name:        "score_array",
+					DataType:    schemapb.DataType_Array,
+					ElementType: schemapb.DataType_Float,
+				},
+			},
+		}
+		schema := createTestSchema("test_collection", []*schemapb.StructArrayFieldSchema{structField}, nil)
+
+		ageArrayData := createScalarArrayFieldData("age_array", []*schemapb.ScalarField{
+			{Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: []int32{20, 25}}}},
+		})
+		scoreArrayData := createScalarArrayFieldData("score_array", []*schemapb.ScalarField{
+			{Data: &schemapb.ScalarField_FloatData{FloatData: &schemapb.FloatArray{Data: []float32{85.5, 90.0}}}},
+		})
+		structFieldData := createStructArrayFieldData("user_info", []*schemapb.FieldData{
+			ageArrayData, scoreArrayData,
+		})
+
+		assert.NoError(t, transformStructFieldNames(schema))
+
+		insertMsg := createTestInsertMsg("test_collection", []*schemapb.FieldData{structFieldData})
+		err := checkAndFlattenStructFieldData(schema, insertMsg)
+		assert.NoError(t, err)
+
+		fieldNames := []string{insertMsg.FieldsData[0].FieldName, insertMsg.FieldsData[1].FieldName}
+
+		err = checkAndFlattenStructFieldData(schema, insertMsg)
+		assert.NoError(t, err)
+		assert.Len(t, insertMsg.FieldsData, 2)
+		assert.Equal(t, fieldNames[0], insertMsg.FieldsData[0].FieldName)
+		assert.Equal(t, fieldNames[1], insertMsg.FieldsData[1].FieldName)
+	})
+
 	t.Run("success - empty struct array fields", func(t *testing.T) {
 		normalField := &schemapb.FieldSchema{
 			Name:     "normal_field",


### PR DESCRIPTION
issue: #48502

### Summary
- flatten struct array field data before partial-update field lookup in `queryPreExecute`
- make struct-array flattening idempotent so the insert path can safely re-run it
- add regression tests for already-flattened struct data and partial-update query pre-execution

### Root Cause
Partial update merges retrieved row data before the insert pre-execute phase runs. Struct array fields were still in their top-level form at that point, so proxy looked up `array_struct` before the schema helper had access to the flattened subfields, which triggered `failed to get field schema by name`.

### Test Plan
- add regression tests for struct-array partial update handling
- run gofmt on touched files
