### PR TITLE
enhance: increase force merge memory safety factor from 1/3 to 1/4

### DIFF
--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -5198,8 +5198,8 @@ During compaction, the size of segment # of rows is able to exceed segment max #
 	p.CompactionForceMergeDataNodeMemoryFactor = ParamItem{
 		Key:          "dataCoord.compaction.forceMerge.dataNodeMemoryFactor",
 		Version:      "2.6.8",
-		DefaultValue: "3.0",
-		Doc:          "Memory safety factor for DataNode during force merge compaction. Max segment size = DataNode memory / factor. Default 3.0 means segments can use up to 1/3 of DataNode memory. Must be >= 1.0.",
+		DefaultValue: "4.0",
+		Doc:          "Memory safety factor for DataNode during force merge compaction. Max segment size = DataNode memory / factor. Default 4.0 means segments can use up to 1/4 of DataNode memory. Must be >= 1.0.",
 		Export:       false,
 		Formatter: func(value string) string {
 			factor, err := strconv.ParseFloat(value, 64)
@@ -5214,8 +5214,8 @@ During compaction, the size of segment # of rows is able to exceed segment max #
 	p.CompactionForceMergeQueryNodeMemoryFactor = ParamItem{
 		Key:          "dataCoord.compaction.forceMerge.queryNodeMemoryFactor",
 		Version:      "2.6.8",
-		DefaultValue: "3.0",
-		Doc:          "Memory safety factor for QueryNode when loading segments after force merge. Max segment size = QueryNode memory / factor. Default 3.0 means segments can use up to 40% of QueryNode memory. Must be >= 1.0.",
+		DefaultValue: "4.0",
+		Doc:          "Memory safety factor for QueryNode when loading segments after force merge. Max segment size = QueryNode memory / factor. Default 4.0 means segments can use up to 1/4 of QueryNode memory. Must be >= 1.0.",
 		Export:       false,
 		Formatter: func(value string) string {
 			factor, err := strconv.ParseFloat(value, 64)


### PR DESCRIPTION
- Increase `forceMerge.dataNodeMemoryFactor` and
`forceMerge.queryNodeMemoryFactor` defaults from 3.0 to 4.0
- This reduces the max segment size produced by force merge compaction
(from 1/3 to 1/4 of node memory), preventing DataNode from producing
segments too large to index

pr: #48474

Signed-off-by: yangxuan <xuan.yang@zilliz.com>