### PR TITLE
fix: update tantivy to fix -0.0 range query in INVERTED index

### DIFF
--- a/internal/core/thirdparty/tantivy/tantivy-binding/Cargo.lock
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/Cargo.lock
@@ -3003,7 +3003,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.7.0"
-source = "git+https://github.com/zilliztech/tantivy.git#6670c135ddc8ea5b75dbb8383ad5c7e4208a062f"
+source = "git+https://github.com/zilliztech/tantivy.git#96f3335ab5f061926c5b44cf246e81243e1dedc5"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -3960,7 +3960,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.23.0"
-source = "git+https://github.com/zilliztech/tantivy.git#6670c135ddc8ea5b75dbb8383ad5c7e4208a062f"
+source = "git+https://github.com/zilliztech/tantivy.git#96f3335ab5f061926c5b44cf246e81243e1dedc5"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -4067,7 +4067,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.6.0"
-source = "git+https://github.com/zilliztech/tantivy.git#6670c135ddc8ea5b75dbb8383ad5c7e4208a062f"
+source = "git+https://github.com/zilliztech/tantivy.git#96f3335ab5f061926c5b44cf246e81243e1dedc5"
 dependencies = [
  "bitpacking 0.9.2",
 ]
@@ -4090,7 +4090,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.3.0"
-source = "git+https://github.com/zilliztech/tantivy.git#6670c135ddc8ea5b75dbb8383ad5c7e4208a062f"
+source = "git+https://github.com/zilliztech/tantivy.git#96f3335ab5f061926c5b44cf246e81243e1dedc5"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -4117,7 +4117,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.7.0"
-source = "git+https://github.com/zilliztech/tantivy.git#6670c135ddc8ea5b75dbb8383ad5c7e4208a062f"
+source = "git+https://github.com/zilliztech/tantivy.git#96f3335ab5f061926c5b44cf246e81243e1dedc5"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -4160,7 +4160,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.22.0"
-source = "git+https://github.com/zilliztech/tantivy.git#6670c135ddc8ea5b75dbb8383ad5c7e4208a062f"
+source = "git+https://github.com/zilliztech/tantivy.git#96f3335ab5f061926c5b44cf246e81243e1dedc5"
 dependencies = [
  "nom",
 ]
@@ -4178,7 +4178,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.3.0"
-source = "git+https://github.com/zilliztech/tantivy.git#6670c135ddc8ea5b75dbb8383ad5c7e4208a062f"
+source = "git+https://github.com/zilliztech/tantivy.git#96f3335ab5f061926c5b44cf246e81243e1dedc5"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -4200,7 +4200,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.3.0"
-source = "git+https://github.com/zilliztech/tantivy.git#6670c135ddc8ea5b75dbb8383ad5c7e4208a062f"
+source = "git+https://github.com/zilliztech/tantivy.git#96f3335ab5f061926c5b44cf246e81243e1dedc5"
 dependencies = [
  "murmurhash32",
  "rand_distr",
@@ -4218,7 +4218,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.3.0"
-source = "git+https://github.com/zilliztech/tantivy.git#6670c135ddc8ea5b75dbb8383ad5c7e4208a062f"
+source = "git+https://github.com/zilliztech/tantivy.git#96f3335ab5f061926c5b44cf246e81243e1dedc5"
 dependencies = [
  "serde",
 ]


### PR DESCRIPTION
Update tantivy dependency from 6670c135 to 96f3335a which includes the fix for f64_to_u64 encoding that treats -0.0 and +0.0 as equal per IEEE 754 semantics.

issue: https://github.com/milvus-io/milvus/issues/48614