### PR TITLE
fix: [2.6] update tantivy to fix -0.0 range query in INVERTED index

### DIFF
--- a/internal/core/thirdparty/tantivy/tantivy-binding/Cargo.lock
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/Cargo.lock
@@ -3003,7 +3003,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.7.0"
-source = "git+https://github.com/zilliztech/tantivy.git#6670c135ddc8ea5b75dbb8383ad5c7e4208a062f"
+source = "git+https://github.com/zilliztech/tantivy.git#96f3335ab5f061926c5b44cf246e81243e1dedc5"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -3954,7 +3954,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.23.0"
-source = "git+https://github.com/zilliztech/tantivy.git#6670c135ddc8ea5b75dbb8383ad5c7e4208a062f"
+source = "git+https://github.com/zilliztech/tantivy.git#96f3335ab5f061926c5b44cf246e81243e1dedc5"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -4060,7 +4060,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.6.0"
-source = "git+https://github.com/zilliztech/tantivy.git#6670c135ddc8ea5b75dbb8383ad5c7e4208a062f"
+source = "git+https://github.com/zilliztech/tantivy.git#96f3335ab5f061926c5b44cf246e81243e1dedc5"
 dependencies = [
  "bitpacking 0.9.2",
 ]
@@ -4083,7 +4083,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.3.0"
-source = "git+https://github.com/zilliztech/tantivy.git#6670c135ddc8ea5b75dbb8383ad5c7e4208a062f"
+source = "git+https://github.com/zilliztech/tantivy.git#96f3335ab5f061926c5b44cf246e81243e1dedc5"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -4110,7 +4110,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.7.0"
-source = "git+https://github.com/zilliztech/tantivy.git#6670c135ddc8ea5b75dbb8383ad5c7e4208a062f"
+source = "git+https://github.com/zilliztech/tantivy.git#96f3335ab5f061926c5b44cf246e81243e1dedc5"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -4153,7 +4153,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.22.0"
-source = "git+https://github.com/zilliztech/tantivy.git#6670c135ddc8ea5b75dbb8383ad5c7e4208a062f"
+source = "git+https://github.com/zilliztech/tantivy.git#96f3335ab5f061926c5b44cf246e81243e1dedc5"
 dependencies = [
  "nom",
 ]
@@ -4171,7 +4171,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.3.0"
-source = "git+https://github.com/zilliztech/tantivy.git#6670c135ddc8ea5b75dbb8383ad5c7e4208a062f"
+source = "git+https://github.com/zilliztech/tantivy.git#96f3335ab5f061926c5b44cf246e81243e1dedc5"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -4193,7 +4193,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.3.0"
-source = "git+https://github.com/zilliztech/tantivy.git#6670c135ddc8ea5b75dbb8383ad5c7e4208a062f"
+source = "git+https://github.com/zilliztech/tantivy.git#96f3335ab5f061926c5b44cf246e81243e1dedc5"
 dependencies = [
  "murmurhash32",
  "rand_distr",
@@ -4211,7 +4211,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.3.0"
-source = "git+https://github.com/zilliztech/tantivy.git#6670c135ddc8ea5b75dbb8383ad5c7e4208a062f"
+source = "git+https://github.com/zilliztech/tantivy.git#96f3335ab5f061926c5b44cf246e81243e1dedc5"
 dependencies = [
  "serde",
 ]


### PR DESCRIPTION
Update tantivy dependency from 6670c135 to 96f3335a which includes the fix for f64_to_u64 encoding that treats -0.0 and +0.0 as equal per IEEE 754 semantics.

issue: https://github.com/milvus-io/milvus/issues/48614
pr: #48624