### PR TITLE
fix: partialResultRequiredDataRatio=0.0 should guarantee search never fails

### DIFF
--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -1455,6 +1455,6 @@ func NewRowCountBasedEvaluator(sealedRowCount map[int64]int64) PartialResultEval
 		}
 
 		accessedDataRatio := float64(successRowCount) / float64(totalRowCount)
-		return accessedDataRatio > partialResultRequiredDataRatio, accessedDataRatio
+		return accessedDataRatio >= partialResultRequiredDataRatio, accessedDataRatio
 	}
 }

--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -652,24 +652,16 @@ func (sd *shardDelegator) Query(ctx context.Context, req *querypb.QueryRequest) 
 		req.Req.GetIsIterator(),
 	)
 
-	partialResultRequiredDataRatio := paramtable.Get().QueryNodeCfg.PartialResultRequiredDataRatio.GetAsFloat()
 	// wait tsafe
 	waitTr := timerecord.NewTimeRecorder("wait tSafe")
-	var tSafe uint64
-	var err error
-	if partialResultRequiredDataRatio >= 1.0 {
-		tSafe, err = sd.waitTSafe(ctx, req.Req.GuaranteeTimestamp)
-	} else {
-		// partial search enabled, could ignore streaming data
-		tSafe = sd.GetTSafe()
-	}
+	tSafe, err := sd.waitTSafe(ctx, req.Req.GuaranteeTimestamp)
 
 	metrics.QueryNodeSQLatencyWaitTSafe.WithLabelValues(
 		paramtable.GetStringNodeID(), metrics.QueryLabel).
 		Observe(float64(waitTr.ElapseSpan().Milliseconds()))
 
 	if err != nil {
-		log.Warn("delegator search failed to wait tsafe", zap.Error(err))
+		log.Warn("delegator query failed to wait tsafe", zap.Error(err))
 		return nil, err
 	}
 
@@ -678,7 +670,7 @@ func (sd *shardDelegator) Query(ctx context.Context, req *querypb.QueryRequest) 
 		req.Req.MvccTimestamp = tSafe
 	}
 
-	sealed, growing, sealedRowCount, version, err := sd.distribution.PinReadableSegments(partialResultRequiredDataRatio, req.GetReq().GetPartitionIDs()...)
+	sealed, growing, sealedRowCount, version, err := sd.distribution.PinReadableSegments(float64(1.0), req.GetReq().GetPartitionIDs()...)
 	if err != nil {
 		log.Warn("delegator failed to query, current distribution is not serviceable", zap.Error(err))
 		return nil, err
@@ -877,7 +869,7 @@ func executeSubTasks[T any, R interface {
 	defer cancel()
 
 	var partialResultRequiredDataRatio float64
-	if taskType == "Query" || taskType == "Search" {
+	if taskType == "Search" {
 		partialResultRequiredDataRatio = paramtable.Get().QueryNodeCfg.PartialResultRequiredDataRatio.GetAsFloat()
 	} else {
 		partialResultRequiredDataRatio = 1.0
@@ -1430,7 +1422,7 @@ type PartialResultEvaluator func(taskType string, successSegments typeutil.Set[i
 func NewRowCountBasedEvaluator(sealedRowCount map[int64]int64) PartialResultEvaluator {
 	return func(taskType string, successSegments typeutil.Set[int64], failureSegments []int64, errors []error) (bool, float64) {
 		var partialResultRequiredDataRatio float64
-		if taskType == "Query" || taskType == "Search" {
+		if taskType == "Search" {
 			partialResultRequiredDataRatio = paramtable.Get().QueryNodeCfg.PartialResultRequiredDataRatio.GetAsFloat()
 		} else {
 			partialResultRequiredDataRatio = 1.0

--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -618,13 +618,13 @@ func (sd *shardDelegator) QueryStream(ctx context.Context, req *querypb.QueryReq
 			sd.markSegmentOffline(req.GetSegmentIDs()...)
 		}
 		return nil, err
-	}, "Query", log)
+	}, "QueryStream", log)
 	if err != nil {
-		log.Warn("Delegator query failed", zap.Error(err))
+		log.Warn("Delegator query stream failed", zap.Error(err))
 		return err
 	}
 
-	log.Info("Delegator Query done")
+	log.Info("Delegator QueryStream done")
 
 	return nil
 }

--- a/internal/querynodev2/delegator/delegator_test.go
+++ b/internal/querynodev2/delegator/delegator_test.go
@@ -2044,6 +2044,85 @@ func TestNewRowCountBasedEvaluator_PartialResultAcceptance(t *testing.T) {
 	})
 }
 
+func TestNewRowCountBasedEvaluator_ZeroRatioBoundary(t *testing.T) {
+	mockey.PatchConvey("TestNewRowCountBasedEvaluator_ZeroRatioBoundary", t, func() {
+		sealedRowCount := map[int64]int64{
+			1: 1000,
+			2: 2000,
+			3: 3000,
+			4: 4000,
+		}
+		// Total: 10000 rows
+
+		// Mock ratio=0.0: search should never fail, even with empty results
+		mockParamTable := mockey.Mock(mockey.GetMethod(&paramtable.ParamItem{}, "GetAsFloat")).Return(0.0).Build()
+		defer mockParamTable.UnPatch()
+
+		evaluator := NewRowCountBasedEvaluator(sealedRowCount)
+
+		// All segments failed (accessedDataRatio=0.0, ratio=0.0)
+		// 0.0 >= 0.0 should return true
+		successSegments := typeutil.NewSet[int64]()
+		failureSegments := []int64{1, 2, 3, 4}
+		testErrors := []error{
+			errors.New("node 1 failed"),
+			errors.New("node 2 failed"),
+			errors.New("node 3 failed"),
+			errors.New("node 4 failed"),
+		}
+
+		shouldReturn, accessedRatio := evaluator("Search", successSegments, failureSegments, testErrors)
+		assert.True(t, shouldReturn, "ratio=0.0 with all segments failed should still return partial result")
+		assert.Equal(t, 0.0, accessedRatio)
+
+		// Some segments succeeded (accessedDataRatio=0.3 > 0.0)
+		successSegments = typeutil.NewSet[int64]()
+		successSegments.Insert(1, 2) // 3000/10000 = 0.3
+		failureSegments = []int64{3, 4}
+		testErrors = []error{errors.New("node 3 failed"), errors.New("node 4 failed")}
+
+		shouldReturn, accessedRatio = evaluator("Search", successSegments, failureSegments, testErrors)
+		assert.True(t, shouldReturn)
+		assert.Equal(t, 0.3, accessedRatio)
+
+		// Query task with ratio=0.0 and all failed
+		successSegments = typeutil.NewSet[int64]()
+		failureSegments = []int64{1, 2, 3, 4}
+		testErrors = []error{errors.New("all failed")}
+
+		shouldReturn, accessedRatio = evaluator("Query", successSegments, failureSegments, testErrors)
+		assert.True(t, shouldReturn, "ratio=0.0 with all segments failed should return partial for Query too")
+		assert.Equal(t, 0.0, accessedRatio)
+	})
+}
+
+func TestNewRowCountBasedEvaluator_ExactRatioBoundary(t *testing.T) {
+	mockey.PatchConvey("TestNewRowCountBasedEvaluator_ExactRatioBoundary", t, func() {
+		sealedRowCount := map[int64]int64{
+			1: 5000,
+			2: 5000,
+		}
+		// Total: 10000 rows
+
+		// Mock ratio=0.5: exactly 50% available should pass
+		mockParamTable := mockey.Mock(mockey.GetMethod(&paramtable.ParamItem{}, "GetAsFloat")).Return(0.5).Build()
+		defer mockParamTable.UnPatch()
+
+		evaluator := NewRowCountBasedEvaluator(sealedRowCount)
+
+		// Exactly 50% data available (accessedDataRatio=0.5, ratio=0.5)
+		// 0.5 >= 0.5 should return true
+		successSegments := typeutil.NewSet[int64]()
+		successSegments.Insert(1) // 5000/10000 = 0.5
+		failureSegments := []int64{2}
+		testErrors := []error{errors.New("segment 2 failed")}
+
+		shouldReturn, accessedRatio := evaluator("Search", successSegments, failureSegments, testErrors)
+		assert.True(t, shouldReturn, "exact ratio boundary (0.5 >= 0.5) should return partial result")
+		assert.Equal(t, 0.5, accessedRatio)
+	})
+}
+
 func TestDelegatorCatchingUpStreamingData(t *testing.T) {
 	paramtable.Init()
 

--- a/internal/querynodev2/delegator/delegator_test.go
+++ b/internal/querynodev2/delegator/delegator_test.go
@@ -1961,22 +1961,21 @@ func TestNewRowCountBasedEvaluator_SearchAndQueryTasks(t *testing.T) {
 		successSegments := typeutil.NewSet[int64]()
 		successSegments.Insert(1, 2) // 3000 rows out of 6000 total = 0.5
 		failureSegments := []int64{3}
-		errors := []error{errors.New("segment 3 failed")}
+		testErrors := []error{errors.New("segment 3 failed")}
 
-		shouldReturn, accessedRatio := evaluator("Search", successSegments, failureSegments, errors)
+		shouldReturn, accessedRatio := evaluator("Search", successSegments, failureSegments, testErrors)
 		assert.False(t, shouldReturn) // 0.5 < 0.8, should not return partial
 		assert.Equal(t, 0.5, accessedRatio)
 
-		// Test Query task - success segments meet required ratio
+		// Test Query task - Query never allows partial results (only Search does)
 		successSegments = typeutil.NewSet[int64]()
-		successSegments.Insert(1, 2, 3) // 6000 rows out of 6000 total = 1.0
-		failureSegments = []int64{}
-		errors = []error{}
+		successSegments.Insert(1, 2) // 3000 rows out of 6000 total = 0.5
+		failureSegments = []int64{3}
+		testErrors = []error{errors.New("segment 3 failed")}
 
-		shouldReturn, accessedRatio = evaluator("Query", successSegments, failureSegments, errors)
-		assert.True(t, shouldReturn)
-		assert.True(t, accessedRatio >= 0.8) // All segments succeeded
-		assert.Equal(t, 1.0, accessedRatio)
+		shouldReturn, accessedRatio = evaluator("Query", successSegments, failureSegments, testErrors)
+		assert.False(t, shouldReturn, "Query should never return partial results")
+		assert.Equal(t, 0.0, accessedRatio) // ratio forced to 1.0, early return
 	})
 }
 
@@ -2032,15 +2031,20 @@ func TestNewRowCountBasedEvaluator_PartialResultAcceptance(t *testing.T) {
 		assert.False(t, shouldReturn) // 0.6 < 0.7, should not return partial
 		assert.Equal(t, 0.6, accessedRatio)
 
-		// Test case: 90% data available (should accept partial result)
+		// Test case: 90% data available with Search (should accept partial result)
 		successSegments = typeutil.NewSet[int64]()
 		successSegments.Insert(2, 3, 4) // 9000 rows out of 10000 = 0.9
 		failureSegments = []int64{1}
 		testErrors = []error{errors.New("segment 1 failed")}
 
-		shouldReturn, accessedRatio = evaluator("Query", successSegments, failureSegments, testErrors)
-		assert.True(t, shouldReturn) // 0.9 > 0.7, should return partial
+		shouldReturn, accessedRatio = evaluator("Search", successSegments, failureSegments, testErrors)
+		assert.True(t, shouldReturn) // 0.9 >= 0.7, should return partial for Search
 		assert.Equal(t, 0.9, accessedRatio)
+
+		// Test case: same 90% with Query (should NOT accept partial result)
+		shouldReturn, accessedRatio = evaluator("Query", successSegments, failureSegments, testErrors)
+		assert.False(t, shouldReturn, "Query should never return partial results")
+		assert.Equal(t, 0.0, accessedRatio)
 	})
 }
 
@@ -2085,13 +2089,13 @@ func TestNewRowCountBasedEvaluator_ZeroRatioBoundary(t *testing.T) {
 		assert.True(t, shouldReturn)
 		assert.Equal(t, 0.3, accessedRatio)
 
-		// Query task with ratio=0.0 and all failed
+		// Query task with ratio=0.0 and all failed - Query never allows partial
 		successSegments = typeutil.NewSet[int64]()
 		failureSegments = []int64{1, 2, 3, 4}
 		testErrors = []error{errors.New("all failed")}
 
 		shouldReturn, accessedRatio = evaluator("Query", successSegments, failureSegments, testErrors)
-		assert.True(t, shouldReturn, "ratio=0.0 with all segments failed should return partial for Query too")
+		assert.False(t, shouldReturn, "Query should never return partial results, even with ratio=0.0")
 		assert.Equal(t, 0.0, accessedRatio)
 	})
 }
@@ -2147,9 +2151,13 @@ func TestNewRowCountBasedEvaluator_QueryStreamDisablesPartialResult(t *testing.T
 		shouldReturn, _ := evaluator("QueryStream", successSegments, failureSegments, testErrors)
 		assert.False(t, shouldReturn, "QueryStream should never return partial results, even with ratio=0.0")
 
-		// Verify Query with same setup DOES allow partial results
-		shouldReturn, accessedRatio := evaluator("Query", successSegments, failureSegments, testErrors)
-		assert.True(t, shouldReturn, "Query should allow partial results with ratio=0.0")
+		// Query also does NOT allow partial results (only Search does)
+		shouldReturn, _ = evaluator("Query", successSegments, failureSegments, testErrors)
+		assert.False(t, shouldReturn, "Query should never return partial results, even with ratio=0.0")
+
+		// Only Search allows partial results
+		shouldReturn, accessedRatio := evaluator("Search", successSegments, failureSegments, testErrors)
+		assert.True(t, shouldReturn, "Search should allow partial results with ratio=0.0")
 		assert.Equal(t, 0.5, accessedRatio)
 	})
 }

--- a/internal/querynodev2/delegator/delegator_test.go
+++ b/internal/querynodev2/delegator/delegator_test.go
@@ -2123,6 +2123,37 @@ func TestNewRowCountBasedEvaluator_ExactRatioBoundary(t *testing.T) {
 	})
 }
 
+func TestNewRowCountBasedEvaluator_QueryStreamDisablesPartialResult(t *testing.T) {
+	mockey.PatchConvey("TestNewRowCountBasedEvaluator_QueryStreamDisablesPartialResult", t, func() {
+		sealedRowCount := map[int64]int64{
+			1: 5000,
+			2: 5000,
+		}
+		// Total: 10000 rows
+
+		// Even with ratio=0.0, QueryStream should NOT return partial results
+		mockParamTable := mockey.Mock(mockey.GetMethod(&paramtable.ParamItem{}, "GetAsFloat")).Return(0.0).Build()
+		defer mockParamTable.UnPatch()
+
+		evaluator := NewRowCountBasedEvaluator(sealedRowCount)
+
+		// 50% data available, ratio=0.0, but taskType=QueryStream
+		// QueryStream must NOT allow partial results (used by delete-by-expr)
+		successSegments := typeutil.NewSet[int64]()
+		successSegments.Insert(1) // 5000/10000 = 0.5
+		failureSegments := []int64{2}
+		testErrors := []error{errors.New("segment 2 failed")}
+
+		shouldReturn, _ := evaluator("QueryStream", successSegments, failureSegments, testErrors)
+		assert.False(t, shouldReturn, "QueryStream should never return partial results, even with ratio=0.0")
+
+		// Verify Query with same setup DOES allow partial results
+		shouldReturn, accessedRatio := evaluator("Query", successSegments, failureSegments, testErrors)
+		assert.True(t, shouldReturn, "Query should allow partial results with ratio=0.0")
+		assert.Equal(t, 0.5, accessedRatio)
+	})
+}
+
 func TestDelegatorCatchingUpStreamingData(t *testing.T) {
 	paramtable.Init()
 


### PR DESCRIPTION
## Summary

- Fix strict greater-than comparison (`>`) to greater-than-or-equal (`>=`) in `NewRowCountBasedEvaluator` so that `partialResultRequiredDataRatio=0.0` correctly allows empty search results
- **Restrict partial result to Search only** — disable for Query and QueryStream to prevent silent data inconsistency in write paths (delete-by-expr, upsert)

issue: https://github.com/milvus-io/milvus/issues/48628
issue: https://github.com/milvus-io/milvus/issues/48660

## Root Cause

### Issue 1: Comparison operator (#48628)

In `NewRowCountBasedEvaluator`, the comparison uses `>` (strict greater-than). When `ratio=0.0` and all QueryNodes are unavailable, `0.0 > 0.0 = false` rejects the partial result, causing DEADLINE_EXCEEDED. Fixed to `>=`.

### Issue 2: Query/QueryStream allow partial results (#48660)

`Query` and `QueryStream` are used by **write paths**:
- **`QueryStream`** → `delete-by-expr` (complex delete): queries rows matching a non-PK filter, then deletes them
- **`Query`** → `upsert`'s `retrieveByPKs`: queries existing rows by PK to determine insert vs update

When `partialResultRequiredDataRatio < 1.0` and a QueryNode is unavailable:
- **delete-by-expr**: returns partial PKs → only deletes rows on available QNs → silent data loss
- **upsert**: misses existing rows on unavailable QN → treats them as new → inserts duplicates

**Fix:** Only `Search` is allowed to use partial results. Both `Query` and `QueryStream` now enforce full segment coverage (`ratio=1.0`).

### Changes

| Location | Change |
|----------|--------|
| `NewRowCountBasedEvaluator` | `>` → `>=` for boundary correctness |
| `delegator.Query()` | Remove partial result logic, always `waitTSafe` + `PinReadableSegments(1.0)` |
| `delegator.QueryStream()` | Change taskType from `"Query"` to `"QueryStream"` |
| `executeSubTasks` | `"Query" \|\| "Search"` → `"Search"` only |
| `NewRowCountBasedEvaluator` | `"Query" \|\| "Search"` → `"Search"` only |

## Test plan

- [x] Unit test: `ratio=0.0` with all segments failed → Search returns partial (empty OK)
- [x] Unit test: `ratio=0.5` with exactly 50% data → Search returns partial (boundary OK)
- [x] Unit test: Query with `ratio=0.0` and partial data → does NOT return partial
- [x] Unit test: QueryStream with `ratio=0.0` and partial data → does NOT return partial
- [x] Unit test: Search with `ratio=0.0` and partial data → returns partial (control comparison)
- [ ] Integration: deploy with `ratio=0.5`, NetworkChaos 1 QN, verify delete-by-expr fails instead of silently partial-deleting

🤖 Generated with [Claude Code](https://claude.com/claude-code)