### PR TITLE
enhance: fallback file resource manager to close mode when no storage address configured in yaml

### DIFF
--- a/internal/datanode/data_node.go
+++ b/internal/datanode/data_node.go
@@ -200,13 +200,19 @@ func (node *DataNode) Init() error {
 
 		fileMode := fileresource.ParseMode(paramtable.Get().CommonCfg.DNFileResourceMode.GetValue())
 		if fileMode == fileresource.SyncMode {
-			cm, err := node.storageFactory.NewChunkManager(node.ctx, compaction.CreateStorageConfig())
-			if err != nil {
-				log.Error("Init chunk manager for file resource manager failed", zap.Error(err))
-				initError = err
-				return
+			storageConfig := compaction.CreateStorageConfig()
+			if storageConfig.GetStorageType() != "local" && storageConfig.GetAddress() == "" {
+				log.Info("No storage address configured in yaml, file resource sync mode is disabled")
+				fileresource.InitManager(nil, fileresource.CloseMode)
+			} else {
+				cm, err := node.storageFactory.NewChunkManager(node.ctx, storageConfig)
+				if err != nil {
+					log.Error("Init chunk manager for file resource manager failed", zap.Error(err))
+					initError = err
+					return
+				}
+				fileresource.InitManager(cm, fileMode)
 			}
-			fileresource.InitManager(cm, fileMode)
 		} else {
 			fileresource.InitManager(nil, fileMode)
 		}


### PR DESCRIPTION
## Summary
When DataNode is configured with `sync` mode for file resource manager but no storage address is set in yaml (i.e., remote storage type with empty address), the initialization previously attempted to create a ChunkManager and failed with an error, causing the node to fail to start. This change detects the missing address upfront and gracefully falls back to `close` mode instead.