### PR TITLE
fix: [2.5] Set replica field in balance plans to prevent panic (#45722)

### DIFF
--- a/internal/querycoordv2/balance/multi_target_balance.go
+++ b/internal/querycoordv2/balance/multi_target_balance.go
@@ -540,7 +540,11 @@ func (b *MultiTargetBalancer) genSegmentPlan(ctx context.Context, replica *meta.
 		globalNodeSegments[node] = b.dist.SegmentDistManager.GetByFilter(meta.WithNodeID(node))
 	}
 
-	return b.genPlanByDistributions(nodeSegments, globalNodeSegments)
+	plans := b.genPlanByDistributions(nodeSegments, globalNodeSegments)
+	for i := range plans {
+		plans[i].Replica = replica
+	}
+	return plans
 }
 
 func (b *MultiTargetBalancer) genPlanByDistributions(nodeSegments, globalNodeSegments map[int64][]*meta.Segment) []SegmentAssignPlan {

--- a/tests/integration/balance/balance_test.go
+++ b/tests/integration/balance/balance_test.go
@@ -378,10 +378,9 @@ func (s *BalanceTestSuit) TestConcurrentBalanceChannelAndSegment() {
 
 func (s *BalanceTestSuit) TestMultiTargetBalancePolicy() {
 	// Set balance policy to MultipleTargetBalancer
-	revertGuard := s.Cluster.MustModifyMilvusConfig(map[string]string{
-		paramtable.Get().QueryCoordCfg.Balancer.Key: "MultipleTargetBalancer",
-	})
-	defer revertGuard()
+	key := paramtable.Get().QueryCoordCfg.Balancer.Key
+	paramtable.Get().Save(key, "MultipleTargetBalancer")
+	defer paramtable.Get().Reset(key)
 
 	testBalanceOnSingleReplica(s)
 }

--- a/tests/integration/balance/balance_test.go
+++ b/tests/integration/balance/balance_test.go
@@ -172,6 +172,10 @@ func (s *BalanceTestSuit) initCollection(collectionName string, replica int, cha
 }
 
 func (s *BalanceTestSuit) TestBalanceOnSingleReplica() {
+	testBalanceOnSingleReplica(s)
+}
+
+func testBalanceOnSingleReplica(s *BalanceTestSuit) {
 	name := "test_balance_" + funcutil.GenRandomStr()
 	s.initCollection(name, 1, 2, 2, 2000, 500)
 
@@ -370,6 +374,16 @@ func (s *BalanceTestSuit) TestConcurrentBalanceChannelAndSegment() {
 	close(stopSearchCh)
 	wg.Wait()
 	s.Equal(int64(0), failCounter.Load())
+}
+
+func (s *BalanceTestSuit) TestMultiTargetBalancePolicy() {
+	// Set balance policy to MultipleTargetBalancer
+	revertGuard := s.Cluster.MustModifyMilvusConfig(map[string]string{
+		paramtable.Get().QueryCoordCfg.Balancer.Key: "MultipleTargetBalancer",
+	})
+	defer revertGuard()
+
+	testBalanceOnSingleReplica(s)
 }
 
 func TestBalance(t *testing.T) {


### PR DESCRIPTION
## Summary
- Cherry-pick of #45722 to `2.5` branch
- Fix nil pointer dereference in `MultiTargetBalancer.genSegmentPlan()` that causes MixCoord crash when using `MultipleTargetBalancer`

pr: https://github.com/milvus-io/milvus/pull/45722
issue: https://github.com/milvus-io/milvus/issues/48054, https://github.com/milvus-io/milvus/issues/45598

## Root Cause
`genPlanByDistributions()` returns `SegmentAssignPlan` without setting the `Replica` field. When `PrintNewBalancePlans()` logs these plans, `SegmentAssignPlan.String()` dereferences the nil `Replica` pointer, causing SIGSEGV.

## Fix
Set `Replica` field for all plans returned by `genPlanByDistributions()` before returning from `genSegmentPlan()`.