### PR TITLE
fix: use Microseconds() instead of Milliseconds() to preserve sub-ms precision in latency metrics

### DIFF
--- a/internal/proxy/task_delete.go
+++ b/internal/proxy/task_delete.go
@@ -298,10 +298,10 @@ func (dr *deleteRunner) Init(ctx context.Context) error {
 	start := time.Now()
 	dr.plan, err = planparserv2.CreateRetrievePlanArgs(dr.schema.schemaHelper, dr.req.GetExpr(), dr.req.GetExprTemplateValues(), visitorArgs)
 	if err != nil {
-		metrics.ProxyParseExpressionLatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), "delete", metrics.FailLabel).Observe(float64(time.Since(start).Milliseconds()))
+		metrics.ProxyParseExpressionLatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), "delete", metrics.FailLabel).Observe(float64(time.Since(start).Microseconds()) / 1000.0)
 		return merr.WrapErrAsInputError(merr.WrapErrParameterInvalidMsg("failed to create delete plan: %v", err))
 	}
-	metrics.ProxyParseExpressionLatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), "delete", metrics.SuccessLabel).Observe(float64(time.Since(start).Milliseconds()))
+	metrics.ProxyParseExpressionLatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), "delete", metrics.SuccessLabel).Observe(float64(time.Since(start).Microseconds()) / 1000.0)
 
 	if planparserv2.IsAlwaysTruePlan(dr.plan) {
 		return merr.WrapErrAsInputError(merr.WrapErrParameterInvalidMsg("delete plan can't be empty or always true : %s", dr.req.GetExpr()))

--- a/internal/proxy/task_insert.go
+++ b/internal/proxy/task_insert.go
@@ -167,7 +167,7 @@ func (it *insertTask) PreExecute(ctx context.Context) error {
 	tr := timerecord.NewTimeRecorder("applyPK")
 	clusterID := Params.CommonCfg.ClusterID.GetAsUint64()
 	rowIDBegin, rowIDEnd, AllocErr := common.AllocAutoID(it.idAllocator.Alloc, rowNums, clusterID)
-	metrics.ProxyApplyPrimaryKeyLatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10)).Observe(float64(tr.ElapseSpan().Milliseconds()))
+	metrics.ProxyApplyPrimaryKeyLatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10)).Observe(float64(tr.ElapseSpan().Microseconds()) / 1000.0)
 	if AllocErr != nil {
 		log.Ctx(ctx).Warn("failed to allocate auto id",
 			zap.String("collectionName", collectionName),

--- a/internal/proxy/task_query.go
+++ b/internal/proxy/task_query.go
@@ -467,10 +467,10 @@ func createCntPlan(expr string, schemaHelper *typeutil.SchemaHelper, exprTemplat
 	start := time.Now()
 	plan, err := planparserv2.CreateRetrievePlan(schemaHelper, expr, exprTemplateValues)
 	if err != nil {
-		metrics.ProxyParseExpressionLatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), metrics.QueryLabel, metrics.FailLabel).Observe(float64(time.Since(start).Milliseconds()))
+		metrics.ProxyParseExpressionLatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), metrics.QueryLabel, metrics.FailLabel).Observe(float64(time.Since(start).Microseconds()) / 1000.0)
 		return nil, merr.WrapErrAsInputError(merr.WrapErrParameterInvalidMsg("failed to create query plan: %v", err))
 	}
-	metrics.ProxyParseExpressionLatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), metrics.QueryLabel, metrics.SuccessLabel).Observe(float64(time.Since(start).Milliseconds()))
+	metrics.ProxyParseExpressionLatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), metrics.QueryLabel, metrics.SuccessLabel).Observe(float64(time.Since(start).Microseconds()) / 1000.0)
 	plan.Node.(*planpb.PlanNode_Query).Query.IsCount = true
 
 	return plan, nil
@@ -487,10 +487,10 @@ func (t *queryTask) createPlanArgs(ctx context.Context, visitorArgs *planparserv
 		start := time.Now()
 		t.plan, err = planparserv2.CreateRetrievePlanArgs(schema.schemaHelper, t.request.Expr, t.request.GetExprTemplateValues(), visitorArgs)
 		if err != nil {
-			metrics.ProxyParseExpressionLatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), metrics.QueryLabel, metrics.FailLabel).Observe(float64(time.Since(start).Milliseconds()))
+			metrics.ProxyParseExpressionLatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), metrics.QueryLabel, metrics.FailLabel).Observe(float64(time.Since(start).Microseconds()) / 1000.0)
 			return merr.WrapErrAsInputError(merr.WrapErrParameterInvalidMsg("failed to create query plan: %v", err))
 		}
-		metrics.ProxyParseExpressionLatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), metrics.QueryLabel, metrics.SuccessLabel).Observe(float64(time.Since(start).Milliseconds()))
+		metrics.ProxyParseExpressionLatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), metrics.QueryLabel, metrics.SuccessLabel).Observe(float64(time.Since(start).Microseconds()) / 1000.0)
 	}
 	// parse output fields names
 	originalOuputFields := t.request.GetOutputFields()
@@ -953,7 +953,7 @@ func (t *queryTask) PostExecute(ctx context.Context) error {
 
 	t.result.CollectionName = t.collectionName
 	t.result.PrimaryFieldName = primaryFieldSchema.GetName()
-	metrics.ProxyReduceResultLatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), t.getQueryLabel()).Observe(float64(tr.RecordSpan().Milliseconds()))
+	metrics.ProxyReduceResultLatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), t.getQueryLabel()).Observe(float64(tr.RecordSpan().Microseconds()) / 1000.0)
 
 	if t.queryParams.isIterator && t.request.GetGuaranteeTimestamp() == 0 {
 		// first page for iteration, need to set up sessionTs for iterator

--- a/internal/proxy/task_scheduler.go
+++ b/internal/proxy/task_scheduler.go
@@ -492,7 +492,7 @@ func (sched *taskScheduler) processTask(t task, q taskQueue) {
 	waitDuration := t.GetDurationInQueue()
 	metrics.ProxyReqInQueueLatency.
 		WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), t.Type().String()).
-		Observe(float64(waitDuration.Milliseconds()))
+		Observe(float64(waitDuration.Microseconds()) / 1000.0)
 
 	err := t.PreExecute(ctx)
 

--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -838,10 +838,10 @@ func (t *searchTask) tryGeneratePlan(params []*commonpb.KeyValuePair, dsl string
 		log.Ctx(t.ctx).Warn("failed to create query plan", zap.Error(planErr),
 			zap.String("dsl", dsl), // may be very large if large term passed.
 			zap.String("anns field", annsFieldName), zap.Any("query info", searchInfo.planInfo))
-		metrics.ProxyParseExpressionLatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), "search", metrics.FailLabel).Observe(float64(time.Since(start).Milliseconds()))
+		metrics.ProxyParseExpressionLatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), "search", metrics.FailLabel).Observe(float64(time.Since(start).Microseconds()) / 1000.0)
 		return nil, nil, 0, false, nil, merr.WrapErrParameterInvalidMsg("failed to create query plan: %v", planErr)
 	}
-	metrics.ProxyParseExpressionLatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), "search", metrics.SuccessLabel).Observe(float64(time.Since(start).Milliseconds()))
+	metrics.ProxyParseExpressionLatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), "search", metrics.SuccessLabel).Observe(float64(time.Since(start).Microseconds()) / 1000.0)
 	log.Ctx(t.ctx).Debug("create query plan",
 		zap.String("dsl", t.request.Dsl), // may be very large if large term passed.
 		zap.String("anns field", annsFieldName), zap.Any("query info", searchInfo.planInfo))
@@ -1030,7 +1030,7 @@ func (t *searchTask) PostExecute(ctx context.Context) error {
 		t.result.SessionTs = getMaxMvccTsFromChannels(t.queryChannelsTs, t.BeginTs())
 	}
 
-	metrics.ProxyReduceResultLatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), metrics.SearchLabel).Observe(float64(tr.RecordSpan().Milliseconds()))
+	metrics.ProxyReduceResultLatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), metrics.SearchLabel).Observe(float64(tr.RecordSpan().Microseconds()) / 1000.0)
 
 	timeFields := parseTimeFields(t.request.SearchParams)
 	if timeFields != nil {

--- a/internal/proxy/task_upsert.go
+++ b/internal/proxy/task_upsert.go
@@ -1063,7 +1063,7 @@ func (it *upsertTask) insertPreExecute(ctx context.Context) error {
 	tr := timerecord.NewTimeRecorder("applyPK")
 	clusterID := Params.CommonCfg.ClusterID.GetAsUint64()
 	rowIDBegin, rowIDEnd, allocateErr := common.AllocAutoID(it.idAllocator.Alloc, rowNums, clusterID)
-	metrics.ProxyApplyPrimaryKeyLatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10)).Observe(float64(tr.ElapseSpan().Milliseconds()))
+	metrics.ProxyApplyPrimaryKeyLatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10)).Observe(float64(tr.ElapseSpan().Microseconds()) / 1000.0)
 	if allocateErr != nil {
 		log.Ctx(ctx).Warn("failed to allocate auto id for upsert",
 			zap.String("collectionName", collectionName),

--- a/internal/proxy/timestamp.go
+++ b/internal/proxy/timestamp.go
@@ -61,7 +61,7 @@ func (ta *timestampAllocator) alloc(ctx context.Context, count uint32) ([]Timest
 
 	resp, err := ta.tso.AllocTimestamp(ctx, req)
 	defer func() {
-		metrics.ProxyApplyTimestampLatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10)).Observe(float64(tr.ElapseSpan().Milliseconds()))
+		metrics.ProxyApplyTimestampLatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10)).Observe(float64(tr.ElapseSpan().Microseconds()) / 1000.0)
 	}()
 
 	if err != nil {

--- a/internal/querynodev2/delegator/delta_forward.go
+++ b/internal/querynodev2/delegator/delta_forward.go
@@ -275,8 +275,8 @@ func (sd *shardDelegator) forwardStreamingByBF(ctx context.Context, deleteData [
 		sd.markSegmentOffline(offlineSegIDs...)
 	}
 
-	metrics.QueryNodeApplyBFCost.WithLabelValues("ProcessDelete", paramtable.GetStringNodeID()).Observe(float64(bfCost.Milliseconds()))
-	metrics.QueryNodeForwardDeleteCost.WithLabelValues("ProcessDelete", paramtable.GetStringNodeID()).Observe(float64(forwardDeleteCost.Milliseconds()))
+	metrics.QueryNodeApplyBFCost.WithLabelValues("ProcessDelete", paramtable.GetStringNodeID()).Observe(float64(bfCost.Microseconds()) / 1000.0)
+	metrics.QueryNodeForwardDeleteCost.WithLabelValues("ProcessDelete", paramtable.GetStringNodeID()).Observe(float64(forwardDeleteCost.Microseconds()) / 1000.0)
 }
 
 func (sd *shardDelegator) forwardStreamingDirect(ctx context.Context, deleteData []*DeleteData) {
@@ -353,7 +353,7 @@ func (sd *shardDelegator) forwardStreamingDirect(ctx context.Context, deleteData
 		sd.markSegmentOffline(offlineSegIDs...)
 	}
 
-	metrics.QueryNodeForwardDeleteCost.WithLabelValues("ProcessDelete", paramtable.GetStringNodeID()).Observe(float64(forwardDeleteCost.Milliseconds()))
+	metrics.QueryNodeForwardDeleteCost.WithLabelValues("ProcessDelete", paramtable.GetStringNodeID()).Observe(float64(forwardDeleteCost.Microseconds()) / 1000.0)
 }
 
 // applyDeleteBatch handles delete record and apply them to corresponding workers in batch.

--- a/internal/querynodev2/handlers.go
+++ b/internal/querynodev2/handlers.go
@@ -478,7 +478,7 @@ func (node *QueryNode) searchChannel(ctx context.Context, req *querypb.SearchReq
 	reduceLatency := tr.RecordSpan()
 	metrics.QueryNodeReduceLatency.
 		WithLabelValues(nodeIDStr, metrics.SearchLabel, metrics.ReduceShards, metrics.BatchReduce).
-		Observe(float64(reduceLatency.Milliseconds()))
+		Observe(float64(reduceLatency.Microseconds()) / 1000.0)
 
 	if err != nil {
 		return nil, err

--- a/internal/querynodev2/segments/retrieve.go
+++ b/internal/querynodev2/segments/retrieve.go
@@ -86,7 +86,7 @@ func retrieveOnSegments(ctx context.Context, mgr *Manager, segments []Segment, s
 			s,
 		}
 		metrics.QueryNodeSQSegmentLatency.WithLabelValues(paramtable.GetStringNodeID(),
-			contextutil.GetQueryLabel(ctx), label).Observe(float64(tr.ElapseSpan().Milliseconds()))
+			contextutil.GetQueryLabel(ctx), label).Observe(float64(tr.ElapseSpan().Microseconds()) / 1000.0)
 		return nil
 	}
 
@@ -160,7 +160,7 @@ func retrieveOnSegmentsWithStream(ctx context.Context, mgr *Manager, segments []
 
 			errs[i] = nil
 			metrics.QueryNodeSQSegmentLatency.WithLabelValues(paramtable.GetStringNodeID(),
-				contextutil.GetQueryLabel(ctx), label).Observe(float64(tr.ElapseSpan().Milliseconds()))
+				contextutil.GetQueryLabel(ctx), label).Observe(float64(tr.ElapseSpan().Microseconds()) / 1000.0)
 		}(segment, i)
 	}
 	wg.Wait()

--- a/internal/querynodev2/segments/search.go
+++ b/internal/querynodev2/segments/search.go
@@ -48,11 +48,11 @@ func searchSegments(ctx context.Context, mgr *Manager, segments []Segment, segTy
 			return err
 		}
 		searchResults[idx] = searchResult
-		elapsed := tr.ElapseSpan().Milliseconds()
+		elapsed := float64(tr.ElapseSpan().Microseconds()) / 1000.0
 		metrics.QueryNodeSQSegmentLatency.WithLabelValues(nodeIDStr,
-			metrics.SearchLabel, searchLabel).Observe(float64(elapsed))
+			metrics.SearchLabel, searchLabel).Observe(elapsed)
 		metrics.QueryNodeSegmentSearchLatencyPerVector.WithLabelValues(nodeIDStr,
-			metrics.SearchLabel, searchLabel).Observe(float64(elapsed) / float64(searchReq.GetNumOfQuery()))
+			metrics.SearchLabel, searchLabel).Observe(elapsed / float64(searchReq.GetNumOfQuery()))
 		return nil
 	}
 

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -651,7 +651,7 @@ func (s *LocalSegment) Search(ctx context.Context, searchReq *segcore.SearchRequ
 		log.Warn("Search failed")
 		return nil, err
 	}
-	metrics.QueryNodeSQSegmentLatencyInCore.WithLabelValues(paramtable.GetStringNodeID(), metrics.SearchLabel).Observe(float64(tr.ElapseSpan().Milliseconds()))
+	metrics.QueryNodeSQSegmentLatencyInCore.WithLabelValues(paramtable.GetStringNodeID(), metrics.SearchLabel).Observe(float64(tr.ElapseSpan().Microseconds()) / 1000.0)
 	log.Debug("search segment done")
 	return result, nil
 }
@@ -672,7 +672,7 @@ func (s *LocalSegment) retrieve(ctx context.Context, plan *segcore.RetrievePlan,
 		return nil, err
 	}
 	metrics.QueryNodeSQSegmentLatencyInCore.WithLabelValues(paramtable.GetStringNodeID(),
-		contextutil.GetQueryLabel(ctx)).Observe(float64(tr.ElapseSpan().Milliseconds()))
+		contextutil.GetQueryLabel(ctx)).Observe(float64(tr.ElapseSpan().Microseconds()) / 1000.0)
 	return result, nil
 }
 
@@ -718,7 +718,7 @@ func (s *LocalSegment) retrieveByOffsets(ctx context.Context, plan *segcore.Retr
 		return nil, err
 	}
 	metrics.QueryNodeSQSegmentLatencyInCore.WithLabelValues(paramtable.GetStringNodeID(),
-		contextutil.GetQueryLabel(ctx)).Observe(float64(tr.ElapseSpan().Milliseconds()))
+		contextutil.GetQueryLabel(ctx)).Observe(float64(tr.ElapseSpan().Microseconds()) / 1000.0)
 	return result, nil
 }
 

--- a/internal/querynodev2/tasks/query_task.go
+++ b/internal/querynodev2/tasks/query_task.go
@@ -148,7 +148,7 @@ func (t *QueryTask) Execute() error {
 		paramtable.GetStringNodeID(),
 		contextutil.GetQueryLabel(t.ctx),
 		metrics.ReduceSegments,
-		metrics.BatchReduce).Observe(float64(time.Since(beforeReduce).Milliseconds()))
+		metrics.BatchReduce).Observe(float64(time.Since(beforeReduce).Microseconds()) / 1000.0)
 	if err != nil {
 		return err
 	}

--- a/internal/querynodev2/tasks/search_task.go
+++ b/internal/querynodev2/tasks/search_task.go
@@ -257,12 +257,13 @@ func (t *SearchTask) Execute() error {
 		metrics.SearchLabel,
 		metrics.ReduceSegments,
 		metrics.BatchReduce).
-		Observe(float64(tr.RecordSpan().Milliseconds()))
+		Observe(float64(tr.RecordSpan().Microseconds()) / 1000.0)
 
 	zeroCopy := paramtable.Get().QueryNodeCfg.EnableResultZeroCopy.GetAsBool()
 
 	// Phase 1: build all results.
 	var phaseErr error
+
 	for i := range t.originNqs {
 		blob, cost, err := segcore.GetSearchResultDataBlob(t.ctx, blobs, i)
 		if err != nil {

--- a/internal/rootcoord/root_coord.go
+++ b/internal/rootcoord/root_coord.go
@@ -1124,7 +1124,7 @@ func (c *Core) HasCollection(ctx context.Context, in *milvuspb.HasCollectionRequ
 
 	metrics.RootCoordDDLReqCounter.WithLabelValues("HasCollection", metrics.SuccessLabel).Inc()
 	metrics.RootCoordDDLReqLatency.WithLabelValues("HasCollection").Observe(float64(tr.ElapseSpan().Milliseconds()))
-	metrics.RootCoordDDLReqLatencyInQueue.WithLabelValues("HasCollection").Observe(float64(t.queueDur.Milliseconds()))
+	metrics.RootCoordDDLReqLatencyInQueue.WithLabelValues("HasCollection").Observe(float64(t.queueDur.Microseconds()) / 1000.0)
 
 	return t.Rsp, nil
 }
@@ -1240,7 +1240,7 @@ func (c *Core) describeCollectionImpl(ctx context.Context, in *milvuspb.Describe
 
 	metrics.RootCoordDDLReqCounter.WithLabelValues("DescribeCollection", metrics.SuccessLabel).Inc()
 	metrics.RootCoordDDLReqLatency.WithLabelValues("DescribeCollection").Observe(float64(tr.ElapseSpan().Milliseconds()))
-	metrics.RootCoordDDLReqLatencyInQueue.WithLabelValues("DescribeCollection").Observe(float64(t.queueDur.Milliseconds()))
+	metrics.RootCoordDDLReqLatencyInQueue.WithLabelValues("DescribeCollection").Observe(float64(t.queueDur.Microseconds()) / 1000.0)
 
 	return t.Rsp, nil
 }
@@ -1299,7 +1299,7 @@ func (c *Core) ShowCollections(ctx context.Context, in *milvuspb.ShowCollections
 
 	metrics.RootCoordDDLReqCounter.WithLabelValues("ShowCollections", metrics.SuccessLabel).Inc()
 	metrics.RootCoordDDLReqLatency.WithLabelValues("ShowCollections").Observe(float64(tr.ElapseSpan().Milliseconds()))
-	metrics.RootCoordDDLReqLatencyInQueue.WithLabelValues("ShowCollections").Observe(float64(t.queueDur.Milliseconds()))
+	metrics.RootCoordDDLReqLatencyInQueue.WithLabelValues("ShowCollections").Observe(float64(t.queueDur.Microseconds()) / 1000.0)
 
 	return t.Rsp, nil
 }
@@ -1704,7 +1704,7 @@ func (c *Core) HasPartition(ctx context.Context, in *milvuspb.HasPartitionReques
 
 	metrics.RootCoordDDLReqCounter.WithLabelValues("HasPartition", metrics.SuccessLabel).Inc()
 	metrics.RootCoordDDLReqLatency.WithLabelValues("HasPartition").Observe(float64(tr.ElapseSpan().Milliseconds()))
-	metrics.RootCoordDDLReqLatencyInQueue.WithLabelValues("HasPartition").Observe(float64(t.queueDur.Milliseconds()))
+	metrics.RootCoordDDLReqLatencyInQueue.WithLabelValues("HasPartition").Observe(float64(t.queueDur.Microseconds()) / 1000.0)
 
 	return t.Rsp, nil
 }
@@ -1751,7 +1751,7 @@ func (c *Core) showPartitionsImpl(ctx context.Context, in *milvuspb.ShowPartitio
 
 	metrics.RootCoordDDLReqCounter.WithLabelValues("ShowPartitions", metrics.SuccessLabel).Inc()
 	metrics.RootCoordDDLReqLatency.WithLabelValues("ShowPartitions").Observe(float64(tr.ElapseSpan().Milliseconds()))
-	metrics.RootCoordDDLReqLatencyInQueue.WithLabelValues("ShowPartitions").Observe(float64(t.queueDur.Milliseconds()))
+	metrics.RootCoordDDLReqLatencyInQueue.WithLabelValues("ShowPartitions").Observe(float64(t.queueDur.Microseconds()) / 1000.0)
 
 	return t.Rsp, nil
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -153,6 +153,11 @@ var (
 	// [1 2 4 8 16 32 64 128 256 512 1024 2048 4096 8192 16384 32768 65536 1.31072e+05]
 	buckets = prometheus.ExponentialBuckets(1, 2, 18)
 
+	// subMsBuckets extends buckets with sub-millisecond boundaries for histograms
+	// whose observations can fall below 1ms (e.g. in-memory or queue-wait paths).
+	// [0.1 0.25 0.5 1 2 4 8 16 32 64 128 256 512 1024 2048 4096 8192 16384 32768 65536 1.31072e+05]
+	subMsBuckets = append([]float64{0.1, 0.25, 0.5}, prometheus.ExponentialBuckets(1, 2, 18)...)
+
 	// longTaskBuckets provides long task duration in milliseconds
 	longTaskBuckets = []float64{1, 100, 500, 1000, 5000, 10000, 20000, 50000, 100000, 250000, 500000, 1000000, 3600000, 5000000, 10000000} // unit milliseconds
 

--- a/pkg/metrics/proxy_metrics.go
+++ b/pkg/metrics/proxy_metrics.go
@@ -126,7 +126,7 @@ var (
 			Subsystem: typeutil.ProxyRole,
 			Name:      "sq_reduce_result_latency",
 			Help:      "latency that proxy reduces search result",
-			Buckets:   buckets, // unit: ms
+			Buckets:   subMsBuckets, // unit: ms
 		}, []string{nodeIDLabelName, queryTypeLabelName})
 
 	// ProxyDecodeResultLatency record the time that the proxy decodes the search result.
@@ -213,7 +213,7 @@ var (
 			Subsystem: typeutil.ProxyRole,
 			Name:      "apply_pk_latency",
 			Help:      "latency that apply primary key",
-			Buckets:   buckets, // unit: ms
+			Buckets:   subMsBuckets, // unit: ms
 		}, []string{nodeIDLabelName})
 
 	// ProxyApplyTimestampLatency record the latency that proxy apply timestamp.
@@ -223,7 +223,7 @@ var (
 			Subsystem: typeutil.ProxyRole,
 			Name:      "apply_timestamp_latency",
 			Help:      "latency that proxy apply timestamp",
-			Buckets:   buckets, // unit: ms
+			Buckets:   subMsBuckets, // unit: ms
 		}, []string{nodeIDLabelName})
 
 	// ProxyFunctionCall records the number of times the function of the DDL operation was executed, like `CreateCollection`.
@@ -389,7 +389,7 @@ var (
 			Subsystem: typeutil.ProxyRole,
 			Name:      "req_in_queue_latency",
 			Help:      "latency which request waits in the queue",
-			Buckets:   buckets, // unit: ms
+			Buckets:   subMsBuckets, // unit: ms
 		}, []string{nodeIDLabelName, functionLabelName})
 
 	MaxInsertRate = prometheus.NewGaugeVec(
@@ -453,7 +453,7 @@ var (
 			Subsystem: typeutil.ProxyRole,
 			Name:      "parse_expr_latency",
 			Help:      "the latency of parse expression",
-			Buckets:   buckets,
+			Buckets:   subMsBuckets,
 		}, []string{nodeIDLabelName, functionLabelName, statusLabelName})
 	// ProxyFunctionlatency records the latency of function
 	ProxyFunctionlatency = prometheus.NewHistogramVec(

--- a/pkg/metrics/querynode_metrics.go
+++ b/pkg/metrics/querynode_metrics.go
@@ -65,7 +65,7 @@ var (
 			Subsystem: typeutil.QueryNodeRole,
 			Name:      "apply_bf_latency",
 			Help:      "apply bf cost in ms",
-			Buckets:   buckets,
+			Buckets:   subMsBuckets,
 		}, []string{
 			functionLabelName,
 			nodeIDLabelName,
@@ -77,7 +77,7 @@ var (
 			Subsystem: typeutil.QueryNodeRole,
 			Name:      "forward_delete_latency",
 			Help:      "forward delete cost in ms",
-			Buckets:   buckets,
+			Buckets:   subMsBuckets,
 		}, []string{
 			functionLabelName,
 			nodeIDLabelName,
@@ -194,7 +194,7 @@ var (
 			Subsystem: typeutil.QueryNodeRole,
 			Name:      "sq_queue_latency",
 			Help:      "latency of search or query in queue",
-			Buckets:   buckets,
+			Buckets:   subMsBuckets,
 		}, []string{
 			nodeIDLabelName,
 			queryTypeLabelName,
@@ -208,7 +208,7 @@ var (
 			Subsystem: typeutil.QueryNodeRole,
 			Name:      "sq_queue_user_latency",
 			Help:      "latency per user of search or query in queue",
-			Buckets:   buckets,
+			Buckets:   subMsBuckets,
 		}, []string{
 			nodeIDLabelName,
 			queryTypeLabelName,
@@ -222,7 +222,7 @@ var (
 			Subsystem: typeutil.QueryNodeRole,
 			Name:      "sq_segment_latency",
 			Help:      "latency of search or query per segment",
-			Buckets:   buckets,
+			Buckets:   subMsBuckets,
 		}, []string{
 			nodeIDLabelName,
 			queryTypeLabelName,
@@ -235,7 +235,7 @@ var (
 			Subsystem: typeutil.QueryNodeRole,
 			Name:      "sq_core_latency",
 			Help:      "latency of search or query latency in segcore",
-			Buckets:   buckets,
+			Buckets:   subMsBuckets,
 		}, []string{
 			nodeIDLabelName,
 			queryTypeLabelName,
@@ -247,7 +247,7 @@ var (
 			Subsystem: typeutil.QueryNodeRole,
 			Name:      "sq_reduce_latency",
 			Help:      "latency of reduce search or query result",
-			Buckets:   buckets,
+			Buckets:   subMsBuckets,
 		}, []string{
 			nodeIDLabelName,
 			queryTypeLabelName,
@@ -516,7 +516,7 @@ var (
 			Subsystem: typeutil.QueryNodeRole,
 			Name:      "segment_latency_per_vector",
 			Help:      "one vector's search latency per segment",
-			Buckets:   buckets,
+			Buckets:   subMsBuckets,
 		}, []string{
 			nodeIDLabelName,
 			queryTypeLabelName,

--- a/pkg/metrics/rootcoord_metrics.go
+++ b/pkg/metrics/rootcoord_metrics.go
@@ -203,6 +203,7 @@ var (
 			Subsystem: typeutil.RootCoordRole,
 			Name:      "ddl_req_latency_in_queue",
 			Help:      "latency of each DDL operations in queue",
+			Buckets:   subMsBuckets,
 		}, []string{functionLabelName})
 
 	RootCoordNumEntities = prometheus.NewGaugeVec(


### PR DESCRIPTION
issue: #48646

## Problem

`time.Duration.Milliseconds()` returns `int64`, truncating sub-millisecond
observations to 0 and destroying low-end histogram resolution for fast paths.

## Scope

Targeted, not a blanket sweep. Only metrics whose observations can fall below
1ms are converted; multi-ms metrics are left as-is.

## Converted metrics

Call sites switched to `float64(d.Microseconds()) / 1000.0`, histograms
switched to the new `subMsBuckets`:

- `ProxyApplyPrimaryKeyLatency`
- `ProxyApplyTimestampLatency`
- `ProxyParseExpressionLatency`
- `ProxyReduceResultLatency`
- `ProxyReqInQueueLatency`
- `QueryNodeApplyBFCost`
- `QueryNodeForwardDeleteCost`
- `QueryNodeReduceLatency`
- `QueryNodeSQLatencyInQueue`
- `QueryNodeSQPerUserLatencyInQueue`
- `QueryNodeSQSegmentLatency`
- `QueryNodeSQSegmentLatencyInCore`
- `QueryNodeSegmentSearchLatencyPerVector`
- `RootCoordDDLReqLatencyInQueue`

`QueryNodeSQLatencyInQueue` / `QueryNodeSQPerUserLatencyInQueue` already had
float observations via `Seconds() * 1000`; only the bucket needed fixing.
`RootCoordDDLReqLatencyInQueue` previously had no `Buckets:` field at all and
used the Prometheus default — also fixed here.

## `subMsBuckets`

New variable in `pkg/metrics/metrics.go`: existing exponential `buckets` with
`0.1, 0.25, 0.5` prepended. Only the 14 in-scope histograms reference it; the
global `buckets` is unchanged, so other histograms gain no extra cardinality.
The change is purely additive at the low end — existing boundaries are not
removed or shifted, P95/P99 queries return identical values.

## Operator note

`RootCoordDDLReqLatencyInQueue` is a special case: before this PR it had no
`Buckets:` field (used Prometheus default `[0.005, 0.01, ..., 10]`) and was
observed via `Milliseconds()`, so all sub-ms samples were truncated to 0 and
piled into the `le=0.005` bucket. After this PR, true sub-ms values are
observed accurately and bucketed via `subMsBuckets`. As a result, dashboards
querying P50/P99 of this metric will show a one-time corrective jump (typical
P50 moves from ~0.003 ms to ~0.3–0.5 ms) on the deployment cut-over.

This is **not a regression** — it is the metric becoming accurate. On-call
engineers should be told to expect this jump and not page on it.

The other 13 in-scope metrics previously used `buckets` (1 ms minimum), so
their truncated sub-ms samples were already piled into the `le=1` bucket;
their post-PR P50/P99 will shift slightly (typically downward as resolution
improves), not jump dramatically. No special operator action is needed for
those.

## Not in this PR

- Multi-ms paths: `RootCoordDDLReqLatency`, `proxy/impl.go` per-RPC, segment
  loading, etcd/tikv kv ops.
- `QueryNodeCGOCallLatency` — mixed latency profile across call types; needs
  per-call-type analysis.
- `QueryNodeDiskCache*` / `QueryNodeSegmentAccess*GlobalDuration` — deliberately
  use `longTaskBuckets`, not `buckets`.
- `DataNode*LatencyInQueue` — background task queues, not request-path.