### PR TITLE
fix: use unique mmap file paths to prevent SIGBUS during column group replacement

### DIFF
--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
@@ -17,6 +17,7 @@
 
 #include <assert.h>
 #include <algorithm>
+#include <atomic>
 #include <cstdint>
 #include <filesystem>
 #include <memory>
@@ -53,6 +54,13 @@
 #include "storage/Util.h"
 
 namespace milvus::segcore::storagev2translator {
+
+// Monotonic counter to generate unique mmap file paths across translator
+// instances. When a column group is replaced (e.g., via ApplyLoadDiff), the new
+// translator must write to a different file path than the old one. Otherwise the
+// FileWriter's O_TRUNC truncates the file while the old translator's MAP_SHARED
+// mmap is still active, causing SIGBUS on concurrent reads.
+static std::atomic<uint64_t> g_mmap_path_generation{0};
 
 GroupChunkTranslator::GroupChunkTranslator(
     int64_t segment_id,
@@ -464,24 +472,32 @@ GroupChunkTranslator::load_group_chunk(
         chunks = create_group_chunk(
             field_ids, field_metas, array_vecs, mmap_populate_);
     } else {
+        // Use a unique generation suffix to avoid file path collision when a
+        // column group is replaced.  Without this, the new FileWriter would
+        // O_TRUNC the same file that the old translator's MAP_SHARED mmap
+        // still references, causing SIGBUS on concurrent reads.
+        auto gen =
+            g_mmap_path_generation.fetch_add(1, std::memory_order_relaxed);
         std::filesystem::path filepath;
         switch (group_chunk_type_) {
             case GroupChunkType::DEFAULT:
                 filepath =
                     std::filesystem::path(column_group_info_.mmap_dir_path) /
-                    fmt::format("seg_{}_cg_{}_{}",
+                    fmt::format("seg_{}_cg_{}_{}_{}",
                                 segment_id_,
                                 column_group_info_.field_id,
-                                cid);
+                                cid,
+                                gen);
                 break;
             case GroupChunkType::JSON_KEY_STATS:
                 filepath =
                     std::filesystem::path(column_group_info_.mmap_dir_path) /
-                    fmt::format("seg_{}_jks_{}_cg_{}_{}",
+                    fmt::format("seg_{}_jks_{}_cg_{}_{}_{}",
                                 segment_id_,
                                 column_group_info_.main_field_id,
                                 column_group_info_.field_id,
-                                cid);
+                                cid,
+                                gen);
                 break;
             default:
                 ThrowInfo(ErrorCode::UnexpectedError,

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslatorTest.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslatorTest.cpp
@@ -200,25 +200,18 @@ TEST_P(GroupChunkTranslatorTest, TestWithMmap) {
     EXPECT_EQ(meta->chunk_memory_size_.size(), num_cells);
     EXPECT_EQ(expected_total_size, chunked_column_group->memory_size());
 
-    // Verify the mmap files for all cells are created
-    std::vector<std::string> mmap_paths;
-    for (size_t i = 0; i < num_cells; ++i) {
-        mmap_paths.push_back(
-            (temp_dir / ("seg_0_cg_0_" + std::to_string(i))).string());
-    }
-    // Verify mmap directory and files if in mmap mode
+    // Verify mmap files are created (file names include a generation suffix)
     if (use_mmap) {
-        for (const auto& mmap_path : mmap_paths) {
-            EXPECT_TRUE(std::filesystem::exists(mmap_path));
+        size_t mmap_file_count = 0;
+        for (const auto& entry :
+             std::filesystem::directory_iterator(temp_dir)) {
+            auto name = entry.path().filename().string();
+            if (name.rfind("seg_0_cg_0_", 0) == 0) {
+                mmap_file_count++;
+            }
         }
-    }
-
-    // Clean up mmap files
-    if (use_mmap) {
-        for (const auto& mmap_path : mmap_paths) {
-            std::filesystem::remove(mmap_path);
-        }
-        std::filesystem::remove(temp_dir);
+        EXPECT_EQ(mmap_file_count, num_cells);
+        std::filesystem::remove_all(temp_dir);
     }
 }
 

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
@@ -50,7 +50,12 @@
 #include "segcore/storagev2translator/GroupCTMeta.h"
 #include "storage/Util.h"
 
+#include <atomic>
+
 namespace milvus::segcore::storagev2translator {
+
+// See GroupChunkTranslator.cpp for explanation of g_mmap_path_generation.
+static std::atomic<uint64_t> g_mmap_path_generation{0};
 
 // Convert LIST or FIXED_SIZE_LIST arrays to FixedSizeBinary.
 // External parquet files store vectors in list format; Milvus expects
@@ -465,26 +470,31 @@ ManifestGroupTranslator::load_group_chunk(
         chunks = create_group_chunk(
             field_ids, field_metas, array_vecs, mmap_populate_);
     } else {
-        // Mmap mode
+        // Mmap mode — use unique generation suffix to avoid truncating files
+        // that old MAP_SHARED mmaps still reference (see #48658).
+        auto gen =
+            g_mmap_path_generation.fetch_add(1, std::memory_order_relaxed);
         std::filesystem::path filepath;
         switch (group_chunk_type_) {
             case GroupChunkType::DEFAULT:
                 filepath = std::filesystem::path(mmap_dir_path_) /
-                           fmt::format("seg_{}_cg_{}_{}",
+                           fmt::format("seg_{}_cg_{}_{}_{}",
                                        segment_id_,
                                        column_group_index_,
-                                       cid);
+                                       cid,
+                                       gen);
                 break;
             case GroupChunkType::JSON_KEY_STATS:
                 filepath =
                     std::filesystem::path(mmap_dir_path_) /
                     fmt::format(
-                        "seg_{}_jks_{}_cg_{}_{}",
+                        "seg_{}_jks_{}_cg_{}_{}_{}",
                         segment_id_,
                         // NOTE: here we assume the first field is the main field for json key stats group chunk
                         std::to_string(field_metas[0].get_main_field_id()),
                         column_group_index_,
-                        cid);
+                        cid,
+                        gen);
                 break;
             default:
                 ThrowInfo(ErrorCode::UnexpectedError,

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslatorTest.cpp
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslatorTest.cpp
@@ -163,14 +163,17 @@ TEST_P(ManifestGroupTranslatorTest, TestScalarColumnGroup) {
     EXPECT_EQ(meta->chunk_memory_size_.size(), saved_num_cells);
     EXPECT_EQ(expected_total_size, chunked_column_group->memory_size());
 
-    // Verify mmap files if in mmap mode
+    // Verify mmap files if in mmap mode (file names include generation suffix)
     if (use_mmap) {
-        for (size_t i = 0; i < saved_num_cells; ++i) {
-            auto mmap_path = std::filesystem::path(mmap_dir_) /
-                             ("seg_0_cg_0_" + std::to_string(i));
-            EXPECT_TRUE(std::filesystem::exists(mmap_path))
-                << "mmap file missing: " << mmap_path;
+        size_t mmap_file_count = 0;
+        for (const auto& entry :
+             std::filesystem::directory_iterator(mmap_dir_)) {
+            auto name = entry.path().filename().string();
+            if (name.rfind("seg_0_cg_0_", 0) == 0) {
+                mmap_file_count++;
+            }
         }
+        EXPECT_EQ(mmap_file_count, saved_num_cells);
     }
 }
 
@@ -225,14 +228,17 @@ TEST_P(ManifestGroupTranslatorTest, TestVectorColumnGroup) {
     EXPECT_EQ(chunked_column_group->num_chunks(), saved_num_cells);
     EXPECT_GT(chunked_column_group->memory_size(), 0);
 
-    // Verify mmap files if in mmap mode
+    // Verify mmap files if in mmap mode (file names include generation suffix)
     if (use_mmap) {
-        for (size_t i = 0; i < saved_num_cells; ++i) {
-            auto mmap_path = std::filesystem::path(mmap_dir_) /
-                             ("seg_0_cg_1_" + std::to_string(i));
-            EXPECT_TRUE(std::filesystem::exists(mmap_path))
-                << "mmap file missing: " << mmap_path;
+        size_t mmap_file_count = 0;
+        for (const auto& entry :
+             std::filesystem::directory_iterator(mmap_dir_)) {
+            auto name = entry.path().filename().string();
+            if (name.rfind("seg_0_cg_1_", 0) == 0) {
+                mmap_file_count++;
+            }
         }
+        EXPECT_EQ(mmap_file_count, saved_num_cells);
     }
 }
 


### PR DESCRIPTION
When a column group is replaced via ApplyLoadDiff, the new GroupChunkTranslator creates a MmapChunkTarget at the same file path as the old one. The FileWriter opens the file with O_TRUNC, truncating it to 0 bytes while the old translator's MAP_SHARED mmap is still active. Concurrent reads on pages not in the page cache then cause SIGBUS.

Fix by appending a monotonic generation counter to the mmap file path, ensuring old and new column groups never collide. The old file is cleaned up by ChunkMmapGuard destructor (munmap + unlink) when the last reference is released.

issue: #48658