### PR TITLE
fix: [cp2.6]add denylist retry to WalkWithPrefix in binlog import

### DIFF
--- a/internal/util/importutilv2/binlog/reader.go
+++ b/internal/util/importutilv2/binlog/reader.go
@@ -29,6 +29,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/util/hookutil"
+	importcommon "github.com/milvus-io/milvus/internal/util/importutilv2/common"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
@@ -107,7 +108,7 @@ func (r *reader) init(paths []string, tsStart, tsEnd uint64, storageConfig *inde
 		return merr.WrapErrImportFailed(fmt.Sprintf("too many input paths for binlog import. "+
 			"Valid paths length should be one or two, but got paths:%s", paths))
 	}
-	insertLogs, err := listInsertLogs(r.ctx, r.cm, paths[0])
+	insertLogs, err := listInsertLogs(r.ctx, r.cm, paths[0], r.retryAttempts)
 	if err != nil {
 		return err
 	}
@@ -155,7 +156,15 @@ func (r *reader) init(paths []string, tsStart, tsEnd uint64, storageConfig *inde
 	if len(paths) < 2 {
 		return nil
 	}
-	deltaLogs, _, err := storage.ListAllChunkWithPrefix(context.Background(), r.cm, paths[1], true)
+	var deltaLogs []string
+	err = importcommon.WalkWithPrefixRetry(r.ctx, r.cm, paths[1], true, r.retryAttempts,
+		func() {
+			deltaLogs = nil
+		},
+		func(chunkInfo *storage.ChunkObjectInfo) bool {
+			deltaLogs = append(deltaLogs, chunkInfo.FilePath)
+			return true
+		})
 	if err != nil {
 		return err
 	}

--- a/internal/util/importutilv2/binlog/reader_test.go
+++ b/internal/util/importutilv2/binlog/reader_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -819,6 +820,87 @@ func (suite *ReaderSuite) TestZeroDeltaRead() {
 
 func TestBinlogReader(t *testing.T) {
 	suite.Run(t, new(ReaderSuite))
+}
+
+func TestDeltaLogListing_RetryOnTransientError(t *testing.T) {
+	paramtable.Init()
+	ctx := context.Background()
+	cm := mocks.NewChunkManager(t)
+
+	insertPrefix := "backup/insert_log/seg/"
+	deltaPrefix := "backup/delta_log/seg/"
+
+	// Insert walk succeeds immediately with one field
+	cm.EXPECT().WalkWithPrefix(mock.Anything, insertPrefix, true, mock.Anything).
+		RunAndReturn(func(ctx context.Context, prefix string, recursive bool, walkFunc storage.ChunkObjectWalkFunc) error {
+			walkFunc(&storage.ChunkObjectInfo{FilePath: insertPrefix + "0/file1"})
+			walkFunc(&storage.ChunkObjectInfo{FilePath: insertPrefix + "1/file1"})
+			return nil
+		}).Once()
+
+	// Delta walk: first call returns partial results + transient error, second call succeeds with empty result
+	// Empty result triggers early return (len(deltaLogs) == 0) so readDelete is never called.
+	deltaCallCount := 0
+	cm.EXPECT().WalkWithPrefix(mock.Anything, deltaPrefix, true, mock.Anything).
+		RunAndReturn(func(ctx context.Context, prefix string, recursive bool, walkFunc storage.ChunkObjectWalkFunc) error {
+			deltaCallCount++
+			if deltaCallCount == 1 {
+				walkFunc(&storage.ChunkObjectInfo{FilePath: deltaPrefix + "partial"})
+				return errors.New("net/http: timeout awaiting response headers")
+			}
+			// Second attempt: empty walk (no delta logs) — triggers early nil return
+			return nil
+		}).Times(2)
+
+	r := &reader{
+		ctx:            ctx,
+		cm:             cm,
+		schema:         &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{{FieldID: 0}, {FieldID: 1}}},
+		storageVersion: storage.StorageV1,
+		retryAttempts:  5,
+	}
+
+	err := r.init([]string{insertPrefix, deltaPrefix}, 0, math.MaxUint64)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, deltaCallCount, "delta log WalkWithPrefix should have retried on transient error")
+}
+
+func TestDeltaLogListing_NonRetryableErrorFailsFast(t *testing.T) {
+	paramtable.Init()
+	ctx := context.Background()
+	cm := mocks.NewChunkManager(t)
+
+	insertPrefix := "backup/insert_log/seg/"
+	deltaPrefix := "backup/delta_log/seg/"
+
+	// Insert walk succeeds
+	cm.EXPECT().WalkWithPrefix(mock.Anything, insertPrefix, true, mock.Anything).
+		RunAndReturn(func(ctx context.Context, prefix string, recursive bool, walkFunc storage.ChunkObjectWalkFunc) error {
+			walkFunc(&storage.ChunkObjectInfo{FilePath: insertPrefix + "0/file1"})
+			walkFunc(&storage.ChunkObjectInfo{FilePath: insertPrefix + "1/file1"})
+			return nil
+		}).Once()
+
+	// Delta walk: return non-retryable error
+	deltaCallCount := 0
+	cm.EXPECT().WalkWithPrefix(mock.Anything, deltaPrefix, true, mock.Anything).
+		RunAndReturn(func(ctx context.Context, prefix string, recursive bool, walkFunc storage.ChunkObjectWalkFunc) error {
+			deltaCallCount++
+			return merr.WrapErrIoPermissionDenied(deltaPrefix, errors.New("access denied"))
+		}).Once()
+
+	r := &reader{
+		ctx:            ctx,
+		cm:             cm,
+		schema:         &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{{FieldID: 0}, {FieldID: 1}}},
+		storageVersion: storage.StorageV1,
+		retryAttempts:  5,
+	}
+
+	err := r.init([]string{insertPrefix, deltaPrefix}, 0, math.MaxUint64)
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, merr.ErrIoPermissionDenied))
+	assert.Equal(t, 1, deltaCallCount, "non-retryable error should not retry")
 }
 
 func TestMultiReadWithRetry_NonRetryableError(t *testing.T) {

--- a/internal/util/importutilv2/binlog/reader_test.go
+++ b/internal/util/importutilv2/binlog/reader_test.go
@@ -860,7 +860,7 @@ func TestDeltaLogListing_RetryOnTransientError(t *testing.T) {
 		retryAttempts:  5,
 	}
 
-	err := r.init([]string{insertPrefix, deltaPrefix}, 0, math.MaxUint64)
+	err := r.init([]string{insertPrefix, deltaPrefix}, 0, math.MaxUint64, nil, "")
 	assert.NoError(t, err)
 	assert.Equal(t, 2, deltaCallCount, "delta log WalkWithPrefix should have retried on transient error")
 }
@@ -897,7 +897,7 @@ func TestDeltaLogListing_NonRetryableErrorFailsFast(t *testing.T) {
 		retryAttempts:  5,
 	}
 
-	err := r.init([]string{insertPrefix, deltaPrefix}, 0, math.MaxUint64)
+	err := r.init([]string{insertPrefix, deltaPrefix}, 0, math.MaxUint64, nil, "")
 	assert.Error(t, err)
 	assert.True(t, errors.Is(err, merr.ErrIoPermissionDenied))
 	assert.Equal(t, 1, deltaCallCount, "non-retryable error should not retry")

--- a/internal/util/importutilv2/binlog/util.go
+++ b/internal/util/importutilv2/binlog/util.go
@@ -28,6 +28,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/storagecommon"
+	importcommon "github.com/milvus-io/milvus/internal/util/importutilv2/common"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
@@ -73,20 +74,25 @@ func newBinlogReader(ctx context.Context, cm storage.ChunkManager, path string) 
 	return reader, nil
 }
 
-func listInsertLogs(ctx context.Context, cm storage.ChunkManager, insertPrefix string) (map[int64][]string, error) {
-	insertLogs := make(map[int64][]string)
+func listInsertLogs(ctx context.Context, cm storage.ChunkManager, insertPrefix string, retryAttempts uint) (map[int64][]string, error) {
+	var insertLogs map[int64][]string
 	var walkErr error
-	if err := cm.WalkWithPrefix(ctx, insertPrefix, true, func(insertLog *storage.ChunkObjectInfo) bool {
-		fieldPath := path.Dir(insertLog.FilePath)
-		fieldStrID := path.Base(fieldPath)
-		fieldID, err := strconv.ParseInt(fieldStrID, 10, 64)
-		if err != nil {
-			walkErr = merr.WrapErrImportFailed(fmt.Sprintf("failed to parse field id from log, error: %v", err))
-			return false
-		}
-		insertLogs[fieldID] = append(insertLogs[fieldID], insertLog.FilePath)
-		return true
-	}); err != nil {
+	if err := importcommon.WalkWithPrefixRetry(ctx, cm, insertPrefix, true, retryAttempts,
+		func() {
+			insertLogs = make(map[int64][]string)
+			walkErr = nil
+		},
+		func(insertLog *storage.ChunkObjectInfo) bool {
+			fieldPath := path.Dir(insertLog.FilePath)
+			fieldStrID := path.Base(fieldPath)
+			fieldID, err := strconv.ParseInt(fieldStrID, 10, 64)
+			if err != nil {
+				walkErr = merr.WrapErrImportFailed(fmt.Sprintf("failed to parse field id from log, error: %v", err))
+				return false
+			}
+			insertLogs[fieldID] = append(insertLogs[fieldID], insertLog.FilePath)
+			return true
+		}); err != nil {
 		return nil, err
 	}
 

--- a/internal/util/importutilv2/binlog/util_test.go
+++ b/internal/util/importutilv2/binlog/util_test.go
@@ -1,0 +1,125 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package binlog
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/milvus-io/milvus/internal/mocks"
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+)
+
+func TestListInsertLogs_Success(t *testing.T) {
+	paramtable.Init()
+	ctx := context.Background()
+	cm := mocks.NewChunkManager(t)
+
+	// Files under two different field IDs; field 100 gets two files (out of order) to verify sorting.
+	cm.EXPECT().WalkWithPrefix(mock.Anything, "prefix/", true, mock.Anything).
+		RunAndReturn(func(ctx context.Context, prefix string, recursive bool, walkFunc storage.ChunkObjectWalkFunc) error {
+			walkFunc(&storage.ChunkObjectInfo{FilePath: "prefix/100/file2"})
+			walkFunc(&storage.ChunkObjectInfo{FilePath: "prefix/101/file1"})
+			walkFunc(&storage.ChunkObjectInfo{FilePath: "prefix/100/file1"})
+			return nil
+		}).Once()
+
+	result, err := listInsertLogs(ctx, cm, "prefix/", 3)
+
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"prefix/100/file1", "prefix/100/file2"}, result[100])
+	assert.Equal(t, []string{"prefix/101/file1"}, result[101])
+}
+
+func TestListInsertLogs_RetryWithReset(t *testing.T) {
+	paramtable.Init()
+	ctx := context.Background()
+	cm := mocks.NewChunkManager(t)
+
+	callCount := 0
+	cm.EXPECT().WalkWithPrefix(mock.Anything, "prefix/", true, mock.Anything).
+		RunAndReturn(func(ctx context.Context, prefix string, recursive bool, walkFunc storage.ChunkObjectWalkFunc) error {
+			callCount++
+			if callCount == 1 {
+				// Partial walk: emit two files then fail with a transient error.
+				walkFunc(&storage.ChunkObjectInfo{FilePath: "prefix/100/file1"})
+				walkFunc(&storage.ChunkObjectInfo{FilePath: "prefix/101/file1"})
+				return errors.New("net/http: timeout awaiting response headers")
+			}
+			// Second call succeeds with the full three-file set.
+			walkFunc(&storage.ChunkObjectInfo{FilePath: "prefix/100/file1"})
+			walkFunc(&storage.ChunkObjectInfo{FilePath: "prefix/100/file2"})
+			walkFunc(&storage.ChunkObjectInfo{FilePath: "prefix/101/file1"})
+			return nil
+		}).Times(2)
+
+	result, err := listInsertLogs(ctx, cm, "prefix/", 3)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, callCount, "should have retried exactly once")
+	// The map must contain exactly 3 files — no duplicates from the first partial walk.
+	assert.Equal(t, []string{"prefix/100/file1", "prefix/100/file2"}, result[100])
+	assert.Equal(t, []string{"prefix/101/file1"}, result[101])
+	totalFiles := 0
+	for _, paths := range result {
+		totalFiles += len(paths)
+	}
+	assert.Equal(t, 3, totalFiles, "accumulated map must be reset between retries; no duplicates expected")
+}
+
+func TestListInsertLogs_NonRetryableError(t *testing.T) {
+	paramtable.Init()
+	ctx := context.Background()
+	cm := mocks.NewChunkManager(t)
+
+	callCount := 0
+	cm.EXPECT().WalkWithPrefix(mock.Anything, "prefix/", true, mock.Anything).
+		RunAndReturn(func(ctx context.Context, prefix string, recursive bool, walkFunc storage.ChunkObjectWalkFunc) error {
+			callCount++
+			return merr.WrapErrIoPermissionDenied("prefix/", errors.New("access denied"))
+		}).Once()
+
+	_, err := listInsertLogs(ctx, cm, "prefix/", 5)
+
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, merr.ErrIoPermissionDenied))
+	assert.Equal(t, 1, callCount, "non-retryable error must fail fast without retrying")
+}
+
+func TestListInsertLogs_ParseFieldIDError(t *testing.T) {
+	paramtable.Init()
+	ctx := context.Background()
+	cm := mocks.NewChunkManager(t)
+
+	// File path where the parent directory is a non-numeric string ("badID").
+	cm.EXPECT().WalkWithPrefix(mock.Anything, "prefix/", true, mock.Anything).
+		RunAndReturn(func(ctx context.Context, prefix string, recursive bool, walkFunc storage.ChunkObjectWalkFunc) error {
+			walkFunc(&storage.ChunkObjectInfo{FilePath: "prefix/badID/file1"})
+			return nil
+		}).Once()
+
+	_, err := listInsertLogs(ctx, cm, "prefix/", 3)
+
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, merr.ErrImportFailed), "parse error must be wrapped as an import failure")
+}

--- a/internal/util/importutilv2/common/retryable_walk.go
+++ b/internal/util/importutilv2/common/retryable_walk.go
@@ -1,0 +1,56 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+	"github.com/milvus-io/milvus/pkg/v2/util/retry"
+)
+
+// WalkWithPrefixRetry wraps WalkWithPrefix with denylist retry.
+// resetFunc is called before each attempt to reset caller-side accumulators,
+// preventing duplicates from partial walks on retry.
+func WalkWithPrefixRetry(ctx context.Context, cm storage.ChunkManager,
+	prefix string, recursive bool, retryAttempts uint,
+	resetFunc func(),
+	walkFunc storage.ChunkObjectWalkFunc,
+) error {
+	return retry.Do(ctx, func() error {
+		resetFunc()
+		err := cm.WalkWithPrefix(ctx, prefix, recursive, walkFunc)
+		if err == nil {
+			return nil
+		}
+		log.Ctx(ctx).Warn("WalkWithPrefix failed, checking retryability",
+			zap.String("prefix", prefix),
+			zap.Error(err),
+		)
+		// Map raw storage error to Milvus IO error for consistent classification
+		err = storage.ToMilvusIoError(prefix, err)
+		// Denylist: don't retry permanent/validation errors
+		if merr.IsNonRetryableErr(err) {
+			return retry.Unrecoverable(err)
+		}
+		return err
+	}, retry.Attempts(retryAttempts))
+}

--- a/internal/util/importutilv2/common/retryable_walk_test.go
+++ b/internal/util/importutilv2/common/retryable_walk_test.go
@@ -1,0 +1,160 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/milvus-io/milvus/internal/mocks"
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+)
+
+func TestWalkWithPrefixRetry_Success(t *testing.T) {
+	paramtable.Init()
+	ctx := context.Background()
+	cm := mocks.NewChunkManager(t)
+
+	var collected []string
+	cm.EXPECT().WalkWithPrefix(mock.Anything, "prefix/", true, mock.Anything).
+		RunAndReturn(func(ctx context.Context, prefix string, recursive bool, walkFunc storage.ChunkObjectWalkFunc) error {
+			walkFunc(&storage.ChunkObjectInfo{FilePath: "prefix/file1"})
+			walkFunc(&storage.ChunkObjectInfo{FilePath: "prefix/file2"})
+			return nil
+		}).Once()
+
+	err := WalkWithPrefixRetry(ctx, cm, "prefix/", true, 3,
+		func() { collected = nil },
+		func(info *storage.ChunkObjectInfo) bool {
+			collected = append(collected, info.FilePath)
+			return true
+		})
+
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"prefix/file1", "prefix/file2"}, collected)
+}
+
+func TestWalkWithPrefixRetry_TransientErrorRetried(t *testing.T) {
+	paramtable.Init()
+	ctx := context.Background()
+	cm := mocks.NewChunkManager(t)
+
+	callCount := 0
+	var collected []string
+	cm.EXPECT().WalkWithPrefix(mock.Anything, "prefix/", true, mock.Anything).
+		RunAndReturn(func(ctx context.Context, prefix string, recursive bool, walkFunc storage.ChunkObjectWalkFunc) error {
+			callCount++
+			if callCount < 3 {
+				// Simulate partial walk then timeout
+				walkFunc(&storage.ChunkObjectInfo{FilePath: "prefix/partial"})
+				return errors.New("net/http: timeout awaiting response headers")
+			}
+			walkFunc(&storage.ChunkObjectInfo{FilePath: "prefix/file1"})
+			walkFunc(&storage.ChunkObjectInfo{FilePath: "prefix/file2"})
+			return nil
+		}).Times(3)
+
+	err := WalkWithPrefixRetry(ctx, cm, "prefix/", true, 5,
+		func() { collected = nil },
+		func(info *storage.ChunkObjectInfo) bool {
+			collected = append(collected, info.FilePath)
+			return true
+		})
+
+	assert.NoError(t, err)
+	assert.Equal(t, 3, callCount, "should have retried twice then succeeded")
+	// Verify reset worked: only final attempt's results, no partial duplicates
+	assert.Equal(t, []string{"prefix/file1", "prefix/file2"}, collected)
+}
+
+func TestWalkWithPrefixRetry_NonRetryableErrorFailsFast(t *testing.T) {
+	paramtable.Init()
+	ctx := context.Background()
+	cm := mocks.NewChunkManager(t)
+
+	callCount := 0
+	cm.EXPECT().WalkWithPrefix(mock.Anything, "prefix/", true, mock.Anything).
+		RunAndReturn(func(ctx context.Context, prefix string, recursive bool, walkFunc storage.ChunkObjectWalkFunc) error {
+			callCount++
+			return merr.WrapErrIoPermissionDenied("prefix/", errors.New("access denied"))
+		}).Once()
+
+	err := WalkWithPrefixRetry(ctx, cm, "prefix/", true, 5,
+		func() {},
+		func(info *storage.ChunkObjectInfo) bool {
+			return true
+		})
+
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, merr.ErrIoPermissionDenied))
+	assert.Equal(t, 1, callCount, "should not retry non-retryable errors")
+}
+
+func TestWalkWithPrefixRetry_ExhaustsRetries(t *testing.T) {
+	paramtable.Init()
+	ctx := context.Background()
+	cm := mocks.NewChunkManager(t)
+
+	callCount := 0
+	cm.EXPECT().WalkWithPrefix(mock.Anything, "prefix/", true, mock.Anything).
+		RunAndReturn(func(ctx context.Context, prefix string, recursive bool, walkFunc storage.ChunkObjectWalkFunc) error {
+			callCount++
+			return errors.New("net/http: timeout awaiting response headers")
+		}).Times(3)
+
+	err := WalkWithPrefixRetry(ctx, cm, "prefix/", true, 3,
+		func() {},
+		func(info *storage.ChunkObjectInfo) bool {
+			return true
+		})
+
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, merr.ErrIoFailed), "timeout should be mapped to ErrIoFailed")
+	assert.Equal(t, 3, callCount, "should exhaust all retry attempts")
+}
+
+func TestWalkWithPrefixRetry_ResetCalledEachAttempt(t *testing.T) {
+	paramtable.Init()
+	ctx := context.Background()
+	cm := mocks.NewChunkManager(t)
+
+	resetCount := 0
+	callCount := 0
+	cm.EXPECT().WalkWithPrefix(mock.Anything, "prefix/", true, mock.Anything).
+		RunAndReturn(func(ctx context.Context, prefix string, recursive bool, walkFunc storage.ChunkObjectWalkFunc) error {
+			callCount++
+			if callCount < 2 {
+				return errors.New("transient error")
+			}
+			return nil
+		}).Times(2)
+
+	err := WalkWithPrefixRetry(ctx, cm, "prefix/", true, 3,
+		func() { resetCount++ },
+		func(info *storage.ChunkObjectInfo) bool {
+			return true
+		})
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, resetCount, "resetFunc should be called before each attempt")
+}


### PR DESCRIPTION
Cherry-pick from master

pr: #48649
issue: #48153

## Summary

Cherry-picked from master PR #48649 (open - preemptive backport)

**Note**: Original PR is still open. This CP PR should be updated if the original PR changes.

## Verification

- [x] File count matches original PR (6/6)
- [x] Code changes verified (+453/-15)
- [x] No conflict markers