### PR TITLE
enhance: separate C++ executor pools for load/search and convert Load/Reopen to async futures

### DIFF
--- a/internal/core/src/futures/Executor.cpp
+++ b/internal/core/src/futures/Executor.cpp
@@ -21,13 +21,28 @@ namespace milvus::futures {
 const int kNumPriority = 3;
 
 folly::CPUThreadPoolExecutor*
-getGlobalCPUExecutor() {
+getSearchCPUExecutor() {
     auto thread_num = std::thread::hardware_concurrency();
     static folly::CPUThreadPoolExecutor executor(
         thread_num,
         folly::CPUThreadPoolExecutor::makeDefaultPriorityQueue(kNumPriority),
-        std::make_shared<folly::NamedThreadFactory>("MILVUS_CPU_"));
+        std::make_shared<folly::NamedThreadFactory>("MILVUS_SEARCH_"));
     return &executor;
+}
+
+folly::CPUThreadPoolExecutor*
+getLoadCPUExecutor() {
+    auto thread_num = std::thread::hardware_concurrency();
+    static folly::CPUThreadPoolExecutor executor(
+        thread_num,
+        folly::CPUThreadPoolExecutor::makeDefaultPriorityQueue(kNumPriority),
+        std::make_shared<folly::NamedThreadFactory>("MILVUS_LOAD_"));
+    return &executor;
+}
+
+folly::CPUThreadPoolExecutor*
+getGlobalCPUExecutor() {
+    return getSearchCPUExecutor();
 }
 
 };  // namespace milvus::futures

--- a/internal/core/src/futures/Executor.h
+++ b/internal/core/src/futures/Executor.h
@@ -27,4 +27,10 @@ const int HIGH = 0;
 folly::CPUThreadPoolExecutor*
 getGlobalCPUExecutor();
 
+folly::CPUThreadPoolExecutor*
+getSearchCPUExecutor();
+
+folly::CPUThreadPoolExecutor*
+getLoadCPUExecutor();
+
 };  // namespace milvus::futures

--- a/internal/core/src/futures/future_c.cpp
+++ b/internal/core/src/futures/future_c.cpp
@@ -56,8 +56,20 @@ future_destroy(CFuture* future) {
 
 extern "C" void
 executor_set_thread_num(int thread_num) {
-    milvus::futures::getGlobalCPUExecutor()->setNumThreads(thread_num);
+    executor_set_search_thread_num(thread_num);
+}
+
+extern "C" void
+executor_set_search_thread_num(int thread_num) {
+    milvus::futures::getSearchCPUExecutor()->setNumThreads(thread_num);
     milvus::monitor::internal_cgo_pool_size_all.Set(thread_num);
-    LOG_INFO("future executor setup cpu executor with thread num: {}",
+    LOG_INFO("future executor setup search cpu executor with thread num: {}",
+             thread_num);
+}
+
+extern "C" void
+executor_set_load_thread_num(int thread_num) {
+    milvus::futures::getLoadCPUExecutor()->setNumThreads(thread_num);
+    LOG_INFO("future executor setup load cpu executor with thread num: {}",
              thread_num);
 }

--- a/internal/core/src/futures/future_c.h
+++ b/internal/core/src/futures/future_c.h
@@ -43,6 +43,12 @@ future_destroy(CFuture* future);
 void
 executor_set_thread_num(int thread_num);
 
+void
+executor_set_search_thread_num(int thread_num);
+
+void
+executor_set_load_thread_num(int thread_num);
+
 #ifdef __cplusplus
 }
 #endif

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -3177,6 +3177,7 @@ ChunkedSegmentSealedImpl::Reopen(SchemaPtr sch) {
 
 void
 ChunkedSegmentSealedImpl::Reopen(
+    milvus::OpContext* op_ctx,
     const milvus::proto::segcore::SegmentLoadInfo& new_load_info) {
     SegmentLoadInfo new_seg_load_info(new_load_info, schema_);
 
@@ -3188,15 +3189,15 @@ ChunkedSegmentSealedImpl::Reopen(
     // compute load diff
     auto diff = current.ComputeDiff(new_seg_load_info);
     LOG_INFO("Reopen segment {} with diff {}", id_, diff.ToString());
-    ApplyLoadDiff(new_seg_load_info, diff);
+    ApplyLoadDiff(op_ctx, new_seg_load_info, diff);
 
     LOG_INFO("Reopen segment {} done", id_);
 }
 
 void
-ChunkedSegmentSealedImpl::ApplyLoadDiff(SegmentLoadInfo& segment_load_info,
-                                        LoadDiff& diff,
-                                        milvus::OpContext* op_ctx) {
+ChunkedSegmentSealedImpl::ApplyLoadDiff(milvus::OpContext* op_ctx,
+                                        SegmentLoadInfo& segment_load_info,
+                                        LoadDiff& diff) {
     // TODO: pass trace_ctx separately when needed
     milvus::tracer::TraceContext trace_ctx;
 
@@ -3872,7 +3873,7 @@ ChunkedSegmentSealedImpl::Load(milvus::tracer::TraceContext& trace_ctx,
 
     auto diff = segment_load_info_.GetLoadDiff();
     LOG_WARN("Load segment {} with diff {}", id_, diff.ToString());
-    ApplyLoadDiff(segment_load_info_, diff, op_ctx);
+    ApplyLoadDiff(op_ctx, segment_load_info_, diff);
 
     LOG_INFO("Successfully loaded segment {} with {} rows", id_, num_rows);
 }

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -230,6 +230,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
 
     void
     Reopen(
+        milvus::OpContext* op_ctx,
         const milvus::proto::segcore::SegmentLoadInfo& new_load_info) override;
 
     void
@@ -1139,14 +1140,14 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
      * updating the segment's loaded fields and indexes accordingly. It handles
      * incremental updates during segment reopen operations.
      *
+     * @param op_ctx The operation context
      * @param segment_load_info The segment load information to be updated
      * @param load_diff The differences to apply, containing fields and indexes to add/remove
-     * @param op_ctx The operation context
      */
     void
-    ApplyLoadDiff(SegmentLoadInfo& segment_load_info,
-                  LoadDiff& load_diff,
-                  milvus::OpContext* op_ctx = nullptr);
+    ApplyLoadDiff(milvus::OpContext* op_ctx,
+                  SegmentLoadInfo& segment_load_info,
+                  LoadDiff& load_diff);
 
     void
     load_field_data_common(

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -1921,6 +1921,7 @@ SegmentGrowingImpl::Reopen(SchemaPtr sch) {
 
 void
 SegmentGrowingImpl::Reopen(
+    milvus::OpContext* op_ctx,
     const milvus::proto::segcore::SegmentLoadInfo& new_load_info) {
     ThrowInfo(milvus::UnexpectedError,
               "Unexpected reopening growing segment {} with load info",

--- a/internal/core/src/segcore/SegmentGrowingImpl.h
+++ b/internal/core/src/segcore/SegmentGrowingImpl.h
@@ -145,6 +145,7 @@ class SegmentGrowingImpl : public SegmentGrowing {
 
     void
     Reopen(
+        milvus::OpContext* op_ctx,
         const milvus::proto::segcore::SegmentLoadInfo& new_load_info) override;
 
     void

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -251,7 +251,8 @@ class SegmentInterface {
     Reopen(SchemaPtr sch) = 0;
 
     virtual void
-    Reopen(const milvus::proto::segcore::SegmentLoadInfo& new_load_info) = 0;
+    Reopen(milvus::OpContext* op_ctx,
+           const milvus::proto::segcore::SegmentLoadInfo& new_load_info) = 0;
 
     virtual void
     SetLoadInfo(const milvus::proto::segcore::SegmentLoadInfo& load_info) = 0;

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -163,27 +163,29 @@ NewSegmentWithLoadInfo(CCollection collection,
     }
 }
 
-CStatus
-ReopenSegment(CTraceContext c_trace,
-              CSegmentInterface c_segment,
-              const uint8_t* load_info_blob,
-              const int64_t load_info_length) {
-    SCOPE_CGO_CALL_METRIC();
+CFuture*
+AsyncReopenSegment(CTraceContext c_trace,
+                   CSegmentInterface c_segment,
+                   const uint8_t* load_info_blob,
+                   const int64_t load_info_length) {
+    AssertInfo(load_info_blob, "load info is null");
+    milvus::proto::segcore::SegmentLoadInfo load_info;
+    auto suc = load_info.ParseFromArray(load_info_blob, load_info_length);
+    AssertInfo(suc, "unmarshal load info failed");
 
-    try {
-        AssertInfo(load_info_blob, "load info is null");
-        milvus::proto::segcore::SegmentLoadInfo load_info;
-        auto suc = load_info.ParseFromArray(load_info_blob, load_info_length);
-        AssertInfo(suc, "unmarshal load info failed");
+    auto segment = static_cast<milvus::segcore::SegmentInterface*>(c_segment);
 
-        auto segment =
-            static_cast<milvus::segcore::SegmentInterface*>(c_segment);
-
-        segment->Reopen(load_info);
-        return milvus::SuccessCStatus();
-    } catch (std::exception& e) {
-        return milvus::FailureCStatus(&e);
-    }
+    auto future = milvus::futures::Future<bool>::async(
+        milvus::futures::getLoadCPUExecutor(),
+        milvus::futures::ExecutePriority::NORMAL,
+        [c_trace, segment, load_info = std::move(load_info)](
+            folly::CancellationToken cancel_token) -> bool* {
+            milvus::OpContext op_ctx(cancel_token);
+            segment->Reopen(&op_ctx, load_info);
+            return nullptr;
+        });
+    return static_cast<CFuture*>(static_cast<void*>(
+        static_cast<milvus::futures::IFuture*>(future.release())));
 }
 
 CLoadCancellationSource
@@ -232,6 +234,26 @@ SegmentLoad(CTraceContext c_trace,
     }
 }
 
+CFuture*
+AsyncSegmentLoad(CTraceContext c_trace, CSegmentInterface c_segment) {
+    auto segment = static_cast<milvus::segcore::SegmentInterface*>(c_segment);
+
+    auto future = milvus::futures::Future<bool>::async(
+        milvus::futures::getLoadCPUExecutor(),
+        milvus::futures::ExecutePriority::NORMAL,
+        [c_trace, segment](folly::CancellationToken cancel_token) -> bool* {
+            auto trace_ctx = milvus::tracer::TraceContext{
+                c_trace.traceID, c_trace.spanID, c_trace.traceFlags};
+
+            milvus::OpContext op_ctx(cancel_token);
+            segment->Load(trace_ctx, &op_ctx);
+
+            return nullptr;
+        });
+    return static_cast<CFuture*>(static_cast<void*>(
+        static_cast<milvus::futures::IFuture*>(future.release())));
+}
+
 void
 DeleteSegment(CSegmentInterface c_segment) {
     SCOPE_CGO_CALL_METRIC();
@@ -271,7 +293,7 @@ AsyncSearch(CTraceContext c_trace,
         c_placeholder_group);
 
     auto future = milvus::futures::Future<milvus::SearchResult>::async(
-        milvus::futures::getGlobalCPUExecutor(),
+        milvus::futures::getSearchCPUExecutor(),
         milvus::futures::ExecutePriority::HIGH,
         [c_trace,
          segment,
@@ -353,7 +375,7 @@ AsyncRetrieve(CTraceContext c_trace,
     auto segment = static_cast<milvus::segcore::SegmentInterface*>(c_segment);
     auto plan = static_cast<const milvus::query::RetrievePlan*>(c_plan);
     auto future = milvus::futures::Future<CRetrieveResult>::async(
-        milvus::futures::getGlobalCPUExecutor(),
+        milvus::futures::getSearchCPUExecutor(),
         milvus::futures::ExecutePriority::HIGH,
         [c_trace,
          segment,
@@ -398,7 +420,7 @@ AsyncRetrieveByOffsets(CTraceContext c_trace,
     auto plan = static_cast<const milvus::query::RetrievePlan*>(c_plan);
 
     auto future = milvus::futures::Future<CRetrieveResult>::async(
-        milvus::futures::getGlobalCPUExecutor(),
+        milvus::futures::getSearchCPUExecutor(),
         milvus::futures::ExecutePriority::HIGH,
         [c_trace, segment, plan, offsets, len](
             folly::CancellationToken cancel_token) {

--- a/internal/core/src/segcore/segment_c.h
+++ b/internal/core/src/segcore/segment_c.h
@@ -106,25 +106,27 @@ SegmentLoad(CTraceContext c_trace,
             CLoadCancellationSource source);
 
 /**
- * @brief Reopen an existing segment with updated load information
- *
- * This function reopens a segment with new load configuration, typically used
- * when the segment needs to be reconfigured due to schema changes or updated
- * load parameters. The segment will be reinitialized with the provided load info
- * while preserving its identity (segment_id).
- *
- * @param c_trace Tracing context for distributed tracing and debugging
- * @param c_segment The segment handle to be reopened
- * @param load_info_blob Serialized SegmentLoadInfo protobuf message containing
- *                       the new load configuration (field data info, index info, etc.)
- * @param load_info_length Length of the load_info_blob in bytes
- * @return CStatus indicating success or failure with error details
+ * @brief Async load segment using Future mechanism with built-in cancellation
+ * @param c_trace: tracing context param
+ * @param c_segment: segment handle indicate which segment to load
+ * @return CFuture* that resolves when load completes (result pointer is nullptr)
  */
-CStatus
-ReopenSegment(CTraceContext c_trace,
-              CSegmentInterface c_segment,
-              const uint8_t* load_info_blob,
-              const int64_t load_info_length);
+CFuture*
+AsyncSegmentLoad(CTraceContext c_trace, CSegmentInterface c_segment);
+
+/**
+ * @brief Async reopen segment using Future mechanism with built-in cancellation
+ * @param c_trace: tracing context param
+ * @param c_segment: segment handle to reopen
+ * @param load_info_blob: serialized SegmentLoadInfo protobuf message
+ * @param load_info_length: length of load_info_blob in bytes
+ * @return CFuture* that resolves when reopen completes (result pointer is nullptr)
+ */
+CFuture*
+AsyncReopenSegment(CTraceContext c_trace,
+                   CSegmentInterface c_segment,
+                   const uint8_t* load_info_blob,
+                   const int64_t load_info_length);
 
 void
 DeleteSegment(CSegmentInterface c_segment);

--- a/internal/util/cgo/executor.go
+++ b/internal/util/cgo/executor.go
@@ -14,23 +14,40 @@ import (
 
 	"github.com/milvus-io/milvus/pkg/v2/config"
 	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/util/hardware"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
-// initExecutor initialize underlying cgo thread pool.
+// initExecutor initialize underlying cgo thread pools.
 func initExecutor() {
 	pt := paramtable.Get()
-	initPoolSize := int(math.Ceil(pt.QueryNodeCfg.MaxReadConcurrency.GetAsFloat() * pt.QueryNodeCfg.CGOPoolSizeRatio.GetAsFloat()))
-	C.executor_set_thread_num(C.int(initPoolSize))
 
-	resetThreadNum := func(evt *config.Event) {
+	// Initialize search executor pool.
+	searchPoolSize := int(math.Ceil(pt.QueryNodeCfg.MaxReadConcurrency.GetAsFloat() * pt.QueryNodeCfg.CGOPoolSizeRatio.GetAsFloat()))
+	C.executor_set_search_thread_num(C.int(searchPoolSize))
+
+	resetSearchThreadNum := func(evt *config.Event) {
 		if evt.HasUpdated {
 			pt := paramtable.Get()
 			newSize := int(math.Ceil(pt.QueryNodeCfg.MaxReadConcurrency.GetAsFloat() * pt.QueryNodeCfg.CGOPoolSizeRatio.GetAsFloat()))
-			log.Info("reset cgo thread num", zap.Int("thread_num", newSize))
-			C.executor_set_thread_num(C.int(newSize))
+			log.Info("reset cgo search thread num", zap.Int("thread_num", newSize))
+			C.executor_set_search_thread_num(C.int(newSize))
 		}
 	}
-	pt.Watch(pt.QueryNodeCfg.MaxReadConcurrency.Key, config.NewHandler("cgo."+pt.QueryNodeCfg.MaxReadConcurrency.Key, resetThreadNum))
-	pt.Watch(pt.QueryNodeCfg.CGOPoolSizeRatio.Key, config.NewHandler("cgo."+pt.QueryNodeCfg.CGOPoolSizeRatio.Key, resetThreadNum))
+	pt.Watch(pt.QueryNodeCfg.MaxReadConcurrency.Key, config.NewHandler("cgo.search."+pt.QueryNodeCfg.MaxReadConcurrency.Key, resetSearchThreadNum))
+	pt.Watch(pt.QueryNodeCfg.CGOPoolSizeRatio.Key, config.NewHandler("cgo.search."+pt.QueryNodeCfg.CGOPoolSizeRatio.Key, resetSearchThreadNum))
+
+	// Initialize load executor pool.
+	loadPoolSize := hardware.GetCPUNum() * pt.CommonCfg.MiddlePriorityThreadCoreCoefficient.GetAsInt()
+	C.executor_set_load_thread_num(C.int(loadPoolSize))
+
+	resetLoadThreadNum := func(evt *config.Event) {
+		if evt.HasUpdated {
+			pt := paramtable.Get()
+			newSize := hardware.GetCPUNum() * pt.CommonCfg.MiddlePriorityThreadCoreCoefficient.GetAsInt()
+			log.Info("reset cgo load thread num", zap.Int("thread_num", newSize))
+			C.executor_set_load_thread_num(C.int(newSize))
+		}
+	}
+	pt.Watch(pt.CommonCfg.MiddlePriorityThreadCoreCoefficient.Key, config.NewHandler("cgo.load."+pt.CommonCfg.MiddlePriorityThreadCoreCoefficient.Key, resetLoadThreadNum))
 }

--- a/internal/util/segcore/segment.go
+++ b/internal/util/segcore/segment.go
@@ -315,14 +315,18 @@ func (s *cSegmentImpl) Load(ctx context.Context) error {
 	traceCtx := ParseCTraceContext(ctx)
 	defer runtime.KeepAlive(traceCtx)
 
-	// Create cancellation guard for this load operation
-	guard := NewCancellationGuard(ctx)
-	defer guard.Close()
-
-	// Perform the load with cancellation support
-	status := C.SegmentLoad(traceCtx.ctx, s.ptr, (C.CLoadCancellationSource)(guard.Source()))
-
-	return ConsumeCStatusIntoError(&status)
+	future := cgo.Async(ctx,
+		func() cgo.CFuturePtr {
+			return (cgo.CFuturePtr)(C.AsyncSegmentLoad(
+				traceCtx.ctx,
+				s.ptr,
+			))
+		},
+		cgo.WithName("segment-load"),
+	)
+	defer future.Release()
+	_, err := future.BlockAndLeakyGet()
+	return err
 }
 
 func (s *cSegmentImpl) Reopen(ctx context.Context, req *ReopenRequest) error {
@@ -336,8 +340,20 @@ func (s *cSegmentImpl) Reopen(ctx context.Context, req *ReopenRequest) error {
 		return err
 	}
 
-	status := C.ReopenSegment(traceCtx.ctx, s.ptr, (*C.uint8_t)(unsafe.Pointer(&loadInfoBlob[0])), C.int64_t(len(loadInfoBlob)))
-	return ConsumeCStatusIntoError(&status)
+	future := cgo.Async(ctx,
+		func() cgo.CFuturePtr {
+			return (cgo.CFuturePtr)(C.AsyncReopenSegment(
+				traceCtx.ctx,
+				s.ptr,
+				(*C.uint8_t)(unsafe.Pointer(&loadInfoBlob[0])),
+				C.int64_t(len(loadInfoBlob)),
+			))
+		},
+		cgo.WithName("segment-reopen"),
+	)
+	defer future.Release()
+	_, err = future.BlockAndLeakyGet()
+	return err
 }
 
 func (s *cSegmentImpl) DropIndex(ctx context.Context, fieldID int64) error {


### PR DESCRIPTION
Split the single global CPUThreadPoolExecutor into two isolated pools (MILVUS_SEARCH_ and MILVUS_LOAD_) so that segment load operations cannot starve search/retrieve and vice versa.

Convert SegmentLoad and ReopenSegment from synchronous CGO calls to the async future mechanism (cgo.Async + Future<R>) already used by AsyncSearch/AsyncRetrieve. This gives Load/Reopen proper context cancellation via folly::CancellationToken, replacing the manual CancellationGuard goroutine pattern.

Add OpContext parameter to Reopen(SegmentLoadInfo) so the cancellation token is propagated through the load path.

issue: #33132 #46358