### PR TITLE
fix(core): improve SCANN range search accuracy using refine_ratio

### DIFF
--- a/internal/core/src/index/Utils.cpp
+++ b/internal/core/src/index/Utils.cpp
@@ -446,10 +446,17 @@ CheckAndUpdateKnowhereRangeSearchParam(const SearchInfo& search_info,
     }
 
     search_config[RADIUS] = radius.value();
-    // `range_search_k` is only used as one of the conditions for iterator early termination.
-    // not gurantee to return exactly `range_search_k` results, which may be more or less.
+    // `range_search_k` is used as one of the conditions for iterator early termination.
+    // for index with refinement, it is also used as the budget for refinement.
     // set it to -1 will return all results in the range.
-    search_config[knowhere::meta::RANGE_SEARCH_K] = topk;
+    const auto refine_ratio_opt = GetValueFromConfig<float>(
+        search_info.search_params_, knowhere::indexparam::REFINE_RATIO);
+    if (refine_ratio_opt.has_value() && topk > 0) {
+        search_config[knowhere::meta::RANGE_SEARCH_K] =
+            (int64_t)(topk * refine_ratio_opt.value());
+    } else {
+        search_config[knowhere::meta::RANGE_SEARCH_K] = topk;
+    }
 
     const auto range_filter =
         GetValueFromConfig<float>(search_info.search_params_, RANGE_FILTER);


### PR DESCRIPTION
### Why is this change needed?
In Knowhere-based indexes (like SCANN), the `RANGE_SEARCH_K` parameter acts as a candidate pool budget for the refinement (reordering) stage during a range search. Previously, Milvus set this parameter equal to the requested `topk`, leaving no additional budget for refinement.

As `nprobe` increases, more approximate results are identified during quantization. With `RANGE_SEARCH_K` strictly capped, true neighbors with poor quantized scores were often displaced by "noisy" approximate candidates, lowering recall.

### What was changed?
- Modified `CheckAndUpdateKnowhereRangeSearchParam` in `internal/core/src/index/Utils.cpp`.
- Updated the calculation of `RANGE_SEARCH_K` to multiply `topk` by the `refine_ratio` provided in search parameters.
- Ensures the refinement stage has enough candidates to maintain accuracy even as `nprobe` grows.

### How was it tested?
- Tested SCANN range search on large datasets; recall@7000 improved significantly after this change.
- Verified standard range searches without refinement continue to work as expected.