### PR TITLE
fix: backfill nil ElementIndices for empty search results in element-level reduce

### DIFF
--- a/internal/querynodev2/segments/search_reduce.go
+++ b/internal/querynodev2/segments/search_reduce.go
@@ -47,15 +47,28 @@ func (scr *SearchCommonReduce) ReduceSearchResultData(ctx context.Context, searc
 		Topks:      make([]int64, 0, nq),
 	}
 
-	// Check element-level consistency: all results must have ElementIndices or none
-	hasElementIndices := searchResultData[0].ElementIndices != nil
-	for i, data := range searchResultData {
-		if (data.ElementIndices != nil) != hasElementIndices {
-			return nil, fmt.Errorf("inconsistent element-level flag in search results: result[0] has ElementIndices=%v, but result[%d] has ElementIndices=%v",
-				hasElementIndices, i, data.ElementIndices != nil)
+	// Determine element-level flag: any result having ElementIndices means element-level search.
+	hasElementIndices := false
+	for _, data := range searchResultData {
+		if data.ElementIndices != nil {
+			hasElementIndices = true
+			break
 		}
 	}
 	if hasElementIndices {
+		for i, data := range searchResultData {
+			// If any result has ElementIndices, all results must have ElementIndices or no doc is hit in the segment
+			if data.ElementIndices == nil {
+				ids := data.GetIds()
+				// When a segment returns 0 hits, C++ reduce creates an empty LongArray
+				// which proto3 serializes as absent (nil). Back-fill for uniformity.
+				if ids == nil || typeutil.GetSizeOfIDs(ids) == 0 {
+					data.ElementIndices = &schemapb.LongArray{}
+				} else {
+					return nil, fmt.Errorf("inconsistent element-level flag in search results: result has data but missing ElementIndices at index %d", i)
+				}
+			}
+		}
 		ret.ElementIndices = &schemapb.LongArray{
 			Data: make([]int64, 0),
 		}
@@ -163,15 +176,28 @@ func (sbr *SearchGroupByReduce) ReduceSearchResultData(ctx context.Context, sear
 		Topks:      make([]int64, 0, nq),
 	}
 
-	// Check element-level consistency: all results must have ElementIndices or none
-	hasElementIndices := searchResultData[0].ElementIndices != nil
-	for i, data := range searchResultData {
-		if (data.ElementIndices != nil) != hasElementIndices {
-			return nil, fmt.Errorf("inconsistent element-level flag in search results: result[0] has ElementIndices=%v, but result[%d] has ElementIndices=%v",
-				hasElementIndices, i, data.ElementIndices != nil)
+	// Determine element-level flag: any result having ElementIndices means element-level search.
+	hasElementIndices := false
+	for _, data := range searchResultData {
+		if data.ElementIndices != nil {
+			hasElementIndices = true
+			break
 		}
 	}
 	if hasElementIndices {
+		// If any result has ElementIndices, all results must have ElementIndices or no doc is hit in the segment
+		for i, data := range searchResultData {
+			if data.ElementIndices == nil {
+				ids := data.GetIds()
+				// When a segment returns 0 hits, C++ reduce creates an empty LongArray
+				// which proto3 serializes as absent (nil). Back-fill for uniformity.
+				if ids == nil || typeutil.GetSizeOfIDs(ids) == 0 {
+					data.ElementIndices = &schemapb.LongArray{}
+				} else {
+					return nil, fmt.Errorf("inconsistent element-level flag in search results: result has data but missing ElementIndices at index %d", i)
+				}
+			}
+		}
 		ret.ElementIndices = &schemapb.LongArray{
 			Data: make([]int64, 0),
 		}

--- a/internal/querynodev2/segments/search_reduce_test.go
+++ b/internal/querynodev2/segments/search_reduce_test.go
@@ -254,6 +254,149 @@ func (suite *SearchReduceSuite) TestResult_SearchGroupByResult() {
 	})
 }
 
+func (suite *SearchReduceSuite) TestElementIndices_BackfillNilForEmptyResult() {
+	// Reproduces the bug in issue #48602: when one segment returns 0 hits for an
+	// element_filter search, C++ reduce creates an empty LongArray for ElementIndices
+	// which proto3 serializes as absent (nil). The other segment returns hits with
+	// ElementIndices set. The reduce should back-fill nil with empty LongArray.
+	const (
+		nq   = 1
+		topk = 4
+	)
+
+	suite.Run("common_reduce", func() {
+		// data1: has hits with ElementIndices
+		data1 := mock_segcore.GenSearchResultData(nq, topk,
+			[]int64{1, 2, 3, 4},
+			[]float32{-1.0, -2.0, -3.0, -4.0},
+			[]int64{4},
+		)
+		data1.ElementIndices = &schemapb.LongArray{Data: []int64{0, 1, 2, 3}}
+
+		// data2: 0 hits, ElementIndices nil (proto3 lost the empty LongArray)
+		data2 := mock_segcore.GenSearchResultData(nq, topk,
+			[]int64{},
+			[]float32{},
+			[]int64{0},
+		)
+		data2.Ids = nil
+		data2.ElementIndices = nil // simulates proto3 deserialization of empty LongArray
+
+		reduceInfo := reduce.NewReduceSearchResultInfo(nq, topk).WithGroupSize(1)
+		searchReduce := &SearchCommonReduce{}
+		res, err := searchReduce.ReduceSearchResultData(context.TODO(), []*schemapb.SearchResultData{data1, data2}, reduceInfo)
+		suite.NoError(err)
+		suite.NotNil(res.ElementIndices)
+		suite.Equal([]int64{0, 1, 2, 3}, res.ElementIndices.Data)
+		suite.Equal([]int64{1, 2, 3, 4}, res.Ids.GetIntId().Data)
+	})
+
+	suite.Run("common_reduce_reversed_order", func() {
+		// Empty result first, then result with hits — order should not matter
+		data1 := mock_segcore.GenSearchResultData(nq, topk,
+			[]int64{},
+			[]float32{},
+			[]int64{0},
+		)
+		data1.Ids = nil
+		data1.ElementIndices = nil
+
+		data2 := mock_segcore.GenSearchResultData(nq, topk,
+			[]int64{1, 2},
+			[]float32{-1.0, -2.0},
+			[]int64{2},
+		)
+		data2.ElementIndices = &schemapb.LongArray{Data: []int64{5, 6}}
+
+		reduceInfo := reduce.NewReduceSearchResultInfo(nq, topk).WithGroupSize(1)
+		searchReduce := &SearchCommonReduce{}
+		res, err := searchReduce.ReduceSearchResultData(context.TODO(), []*schemapb.SearchResultData{data1, data2}, reduceInfo)
+		suite.NoError(err)
+		suite.NotNil(res.ElementIndices)
+		suite.Equal([]int64{5, 6}, res.ElementIndices.Data)
+	})
+
+	suite.Run("group_by_reduce", func() {
+		data1 := mock_segcore.GenSearchResultData(nq, topk,
+			[]int64{1, 2},
+			[]float32{-1.0, -2.0},
+			[]int64{2},
+		)
+		data1.ElementIndices = &schemapb.LongArray{Data: []int64{10, 11}}
+		data1.GroupByFieldValue = &schemapb.FieldData{
+			Type: schemapb.DataType_Int64,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{100, 200}}},
+				},
+			},
+		}
+
+		data2 := mock_segcore.GenSearchResultData(nq, topk,
+			[]int64{},
+			[]float32{},
+			[]int64{0},
+		)
+		data2.Ids = nil
+		data2.ElementIndices = nil
+		data2.GroupByFieldValue = &schemapb.FieldData{
+			Type: schemapb.DataType_Int64,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{}}},
+				},
+			},
+		}
+
+		reduceInfo := reduce.NewReduceSearchResultInfo(nq, topk).WithGroupSize(1).WithGroupByField(101)
+		searchReduce := &SearchGroupByReduce{}
+		res, err := searchReduce.ReduceSearchResultData(context.TODO(), []*schemapb.SearchResultData{data1, data2}, reduceInfo)
+		suite.NoError(err)
+		suite.NotNil(res.ElementIndices)
+		suite.Equal([]int64{10, 11}, res.ElementIndices.Data)
+	})
+}
+
+func (suite *SearchReduceSuite) TestElementIndices_NoElementLevel() {
+	// When no result has ElementIndices, ret.ElementIndices should remain nil.
+	const (
+		nq   = 1
+		topk = 4
+	)
+	data1 := mock_segcore.GenSearchResultData(nq, topk,
+		[]int64{1, 2}, []float32{-1.0, -2.0}, []int64{2})
+	data2 := mock_segcore.GenSearchResultData(nq, topk,
+		[]int64{3, 4}, []float32{-3.0, -4.0}, []int64{2})
+
+	reduceInfo := reduce.NewReduceSearchResultInfo(nq, topk).WithGroupSize(1)
+	searchReduce := &SearchCommonReduce{}
+	res, err := searchReduce.ReduceSearchResultData(context.TODO(), []*schemapb.SearchResultData{data1, data2}, reduceInfo)
+	suite.NoError(err)
+	suite.Nil(res.ElementIndices)
+}
+
+func (suite *SearchReduceSuite) TestElementIndices_InconsistentWithData() {
+	// If a result has IDs (actual hits) but missing ElementIndices while others have it,
+	// this is a real inconsistency and should return error.
+	const (
+		nq   = 1
+		topk = 4
+	)
+	data1 := mock_segcore.GenSearchResultData(nq, topk,
+		[]int64{1, 2}, []float32{-1.0, -2.0}, []int64{2})
+	data1.ElementIndices = &schemapb.LongArray{Data: []int64{0, 1}}
+
+	data2 := mock_segcore.GenSearchResultData(nq, topk,
+		[]int64{3, 4}, []float32{-3.0, -4.0}, []int64{2})
+	data2.ElementIndices = nil // has data but no ElementIndices — inconsistent
+
+	reduceInfo := reduce.NewReduceSearchResultInfo(nq, topk).WithGroupSize(1)
+	searchReduce := &SearchCommonReduce{}
+	_, err := searchReduce.ReduceSearchResultData(context.TODO(), []*schemapb.SearchResultData{data1, data2}, reduceInfo)
+	suite.Error(err)
+	suite.Contains(err.Error(), "inconsistent element-level flag")
+}
+
 func TestSearchReduce(t *testing.T) {
 	paramtable.Init()
 	suite.Run(t, new(SearchReduceSuite))


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/48602
ref: https://github.com/milvus-io/milvus/issues/42148

This PR fixes issue: When performing element_filter search across multiple segments, if one segment returns 0 hits, C++ reduce creates an empty `LongArray` for `ElementIndices` which proto3 serializes as absent (nil). The Go-side reduce then sees inconsistent `ElementIndices` (nil vs non-nil) across segment results and returns an "inconsistent element-level flag" error.