### PR TITLE
fix: remove incorrect RootPath stripping from packed writer/reader

### DIFF
--- a/internal/storagev2/packed/packed_reader.go
+++ b/internal/storagev2/packed/packed_reader.go
@@ -27,7 +27,6 @@ import "C"
 import (
 	"fmt"
 	"io"
-	"strings"
 	"unsafe"
 
 	"github.com/apache/arrow/go/v17/arrow"
@@ -38,15 +37,6 @@ import (
 )
 
 func NewPackedReader(filePaths []string, schema *arrow.Schema, bufferSize int64, storageConfig *indexpb.StorageConfig, storagePluginContext *indexcgopb.StoragePluginContext) (*PackedReader, error) {
-	// The C++ packed reader prepends root_path from storageConfig to file paths.
-	// Stored binlog paths already include root_path, so strip it to avoid double-append.
-	if storageConfig != nil && storageConfig.GetRootPath() != "" {
-		prefix := storageConfig.GetRootPath() + "/"
-		for i, p := range filePaths {
-			filePaths[i] = strings.TrimPrefix(p, prefix)
-		}
-	}
-
 	cFilePaths := make([]*C.char, len(filePaths))
 	for i, path := range filePaths {
 		cFilePaths[i] = C.CString(path)

--- a/internal/storagev2/packed/packed_writer.go
+++ b/internal/storagev2/packed/packed_writer.go
@@ -26,7 +26,6 @@ package packed
 import "C"
 
 import (
-	"strings"
 	"unsafe"
 
 	"github.com/apache/arrow/go/v17/arrow"
@@ -39,15 +38,6 @@ import (
 )
 
 func NewPackedWriter(filePaths []string, schema *arrow.Schema, bufferSize int64, multiPartUploadSize int64, columnGroups []storagecommon.ColumnGroup, storageConfig *indexpb.StorageConfig, storagePluginContext *indexcgopb.StoragePluginContext) (*PackedWriter, error) {
-	// The C++ packed writer prepends root_path from storageConfig to file paths.
-	// Stored binlog paths already include root_path, so strip it to avoid double-append.
-	if storageConfig != nil && storageConfig.GetRootPath() != "" {
-		prefix := storageConfig.GetRootPath() + "/"
-		for i, p := range filePaths {
-			filePaths[i] = strings.TrimPrefix(p, prefix)
-		}
-	}
-
 	cFilePaths := make([]*C.char, len(filePaths))
 	for i, path := range filePaths {
 		cFilePaths[i] = C.CString(path)


### PR DESCRIPTION
Related to #48477

The Go-side NewPackedWriter and NewPackedReader stripped RootPath from file paths before passing to C++, based on an incorrect assumption that C++ would prepend RootPath internally. This in-place slice modification caused the caller's pathsMap to also lose RootPath, resulting in binlog LogPath being stored without RootPath in segment metadata.

This path mismatch caused downstream components that directly use LogPath (without going through DecompressBinLog) to fail to resolve the actual binlog file location.

Remove the stripping logic from both packed_writer.go and packed_reader.go to ensure binlog paths consistently include RootPath.