### PR TITLE
enhance: [2.6] optimize unfiltered search on sealed segments

### DIFF
--- a/internal/core/CMakeLists.txt
+++ b/internal/core/CMakeLists.txt
@@ -56,6 +56,11 @@ endif ()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
 
+# Enable hardware popcnt for all compilation units.
+if (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mpopcnt")
+endif()
+
 if (CMAKE_COMPILER_IS_GNUCC)
     if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 11.99)
         # ignore deprecated declarations for gcc>=12

--- a/internal/core/src/exec/QueryContext.h
+++ b/internal/core/src/exec/QueryContext.h
@@ -303,6 +303,16 @@ class QueryContext : public Context {
         return plan_options_;
     }
 
+    void
+    set_all_rows_visible(bool v) {
+        all_rows_visible_ = v;
+    }
+
+    bool
+    get_all_rows_visible() const {
+        return all_rows_visible_;
+    }
+
  private:
     folly::Executor* executor_;
     //folly::Executor::KeepAlive<> executor_keepalive_;
@@ -331,6 +341,11 @@ class QueryContext : public Context {
     int32_t consistency_level_ = 0;
 
     query::PlanOptions plan_options_;
+
+    // Set by MvccNode when no filtering is needed (sealed, no filter,
+    // no deletes, no TTL). VectorSearchNode checks this to pass empty
+    // BitsetView to Knowhere (IDSelectorAll fast path).
+    bool all_rows_visible_{false};
 };
 
 // Represent the state of one thread of query execution.

--- a/internal/core/src/exec/operator/FilterBitsNode.cpp
+++ b/internal/core/src/exec/operator/FilterBitsNode.cpp
@@ -16,6 +16,7 @@
 
 #include "FilterBitsNode.h"
 #include "common/Tracer.h"
+#include "expr/ITypeExpr.h"
 #include "fmt/format.h"
 
 #include "monitor/Monitor.h"
@@ -35,6 +36,8 @@ PhyFilterBitsNode::PhyFilterBitsNode(
     query_context_ = exec_context->get_query_context();
     std::vector<expr::TypedExprPtr> filters;
     filters.emplace_back(filter->filter());
+    is_always_true_ = (std::dynamic_pointer_cast<const expr::AlwaysTrueExpr>(
+                           filter->filter()) != nullptr);
     exprs_ = std::make_unique<ExprSet>(filters, exec_context);
     need_process_rows_ = query_context_->get_active_count();
     num_processed_rows_ = 0;
@@ -65,6 +68,18 @@ PhyFilterBitsNode::GetOutput() {
 
     if (AllInputProcessed()) {
         return nullptr;
+    }
+
+    // Fast path: AlwaysTrueExpr means no filtering needed.
+    // Directly produce all-zero bitmap (no rows excluded) + all-one valid bitmap.
+    if (is_always_true_) {
+        num_processed_rows_ = need_process_rows_;
+        TargetBitmap bitset(need_process_rows_, false);
+        TargetBitmap valid_bitset(need_process_rows_, true);
+        std::vector<VectorPtr> col_res;
+        col_res.push_back(std::make_shared<ColumnVector>(
+            std::move(bitset), std::move(valid_bitset)));
+        return std::make_shared<RowVector>(col_res);
     }
 
     tracer::AutoSpan span(

--- a/internal/core/src/exec/operator/FilterBitsNode.h
+++ b/internal/core/src/exec/operator/FilterBitsNode.h
@@ -76,6 +76,7 @@ class PhyFilterBitsNode : public Operator {
     QueryContext* query_context_;
     int64_t num_processed_rows_;
     int64_t need_process_rows_;
+    bool is_always_true_{false};
 };
 }  // namespace exec
 }  // namespace milvus

--- a/internal/core/src/exec/operator/MvccNode.cpp
+++ b/internal/core/src/exec/operator/MvccNode.cpp
@@ -16,7 +16,11 @@
 
 #include "MvccNode.h"
 #include "common/Tracer.h"
+#include "exec/QueryContext.h"
+#include "exec/expression/Utils.h"
 #include "fmt/format.h"
+#include "plan/PlanNode.h"
+#include "segcore/SegmentInterface.h"
 namespace milvus {
 namespace exec {
 
@@ -54,31 +58,52 @@ PhyMvccNode::GetOutput() {
 
     tracer::AutoSpan span("PhyMvccNode::Execute", tracer::GetRootSpan(), true);
 
-    if (!is_source_node_ && input_ == nullptr) {
-        return nullptr;
-    }
-
     if (active_count_ == 0) {
         is_finished_ = true;
         return nullptr;
     }
 
+    if (!is_source_node_ && input_ == nullptr) {
+        return nullptr;
+    }
+
     tracer::AddEvent(fmt::format("input_rows: {}", active_count_));
-    // the first vector is filtering result and second bitset is a valid bitset
-    // if valid_bitset[i]==false, means result[i] is null
+
+    // ── Three-level fast path for sealed segments without filters ──
+    if (is_source_node_ && segment_->type() == SegmentType::Sealed &&
+        collection_ttl_timestamp_ == 0 &&
+        query_timestamp_ >= segment_->get_max_timestamp()) {
+        // Level 1: Sealed + no deletes → all rows visible, skip everything
+        if (segment_->get_deleted_count() == 0) {
+            is_finished_ = true;
+            query_context->set_all_rows_visible(true);
+
+            auto col = std::make_shared<ColumnVector>(
+                TargetBitmap(active_count_), TargetBitmap(active_count_));
+            return std::make_shared<RowVector>(std::vector<VectorPtr>{col});
+        }
+
+        // Level 2: Sealed + has deletes → only apply delete mask, skip timestamps
+        auto col_input = std::make_shared<ColumnVector>(
+            TargetBitmap(active_count_), TargetBitmap(active_count_));
+        TargetBitmapView data(col_input->GetRawData(), col_input->size());
+        segment_->mask_with_delete(data, active_count_, query_timestamp_);
+        is_finished_ = true;
+        return std::make_shared<RowVector>(std::vector<VectorPtr>{col_input});
+    }
+
+    // Level 3: Default path (has filter / growing / TTL)
     auto col_input = is_source_node_ ? std::make_shared<ColumnVector>(
                                            TargetBitmap(active_count_),
                                            TargetBitmap(active_count_))
                                      : GetColumnVector(input_);
 
     TargetBitmapView data(col_input->GetRawData(), col_input->size());
-    // need to expose null?
     segment_->mask_with_timestamps(
         data, query_timestamp_, collection_ttl_timestamp_);
     segment_->mask_with_delete(data, active_count_, query_timestamp_);
     is_finished_ = true;
 
-    // input_ have already been updated
     return std::make_shared<RowVector>(std::vector<VectorPtr>{col_input});
 }
 

--- a/internal/core/src/exec/operator/MvccNode.cpp
+++ b/internal/core/src/exec/operator/MvccNode.cpp
@@ -69,30 +69,29 @@ PhyMvccNode::GetOutput() {
 
     tracer::AddEvent(fmt::format("input_rows: {}", active_count_));
 
-    // ── Three-level fast path for sealed segments without filters ──
+    // ── Sealed-segment fast path (skip timestamp mask) ──
+    // On a sealed segment without TTL, when query_ts covers all inserts,
+    // mask_with_timestamps is redundant (all rows pass).  Only apply the
+    // delete mask — which is a no-op when no deletes exist.  Then decide
+    // all_rows_visible from the actual bitmap instead of a racy
+    // get_deleted_count() check.
     if (is_source_node_ && segment_->type() == SegmentType::Sealed &&
         collection_ttl_timestamp_ == 0 &&
         query_timestamp_ >= segment_->get_max_timestamp()) {
-        // Level 1: Sealed + no deletes → all rows visible, skip everything
-        if (segment_->get_deleted_count() == 0) {
-            is_finished_ = true;
-            query_context->set_all_rows_visible(true);
-
-            auto col = std::make_shared<ColumnVector>(
-                TargetBitmap(active_count_), TargetBitmap(active_count_));
-            return std::make_shared<RowVector>(std::vector<VectorPtr>{col});
-        }
-
-        // Level 2: Sealed + has deletes → only apply delete mask, skip timestamps
         auto col_input = std::make_shared<ColumnVector>(
             TargetBitmap(active_count_), TargetBitmap(active_count_));
         TargetBitmapView data(col_input->GetRawData(), col_input->size());
         segment_->mask_with_delete(data, active_count_, query_timestamp_);
+
+        if (data.none()) {
+            query_context->set_all_rows_visible(true);
+        }
+
         is_finished_ = true;
         return std::make_shared<RowVector>(std::vector<VectorPtr>{col_input});
     }
 
-    // Level 3: Default path (has filter / growing / TTL)
+    // Default path (has filter / growing / TTL)
     auto col_input = is_source_node_ ? std::make_shared<ColumnVector>(
                                            TargetBitmap(active_count_),
                                            TargetBitmap(active_count_))

--- a/internal/core/src/exec/operator/VectorSearchNode.cpp
+++ b/internal/core/src/exec/operator/VectorSearchNode.cpp
@@ -80,66 +80,50 @@ PhyVectorSearchNode::GetOutput() {
     auto src_data = ph.get_blob();
     auto src_offsets = ph.get_offsets();
     auto num_queries = ph.num_of_queries_;
-    milvus::SearchResult search_result;
-
     auto col_input = GetColumnVector(input_);
 
-    // Fast path: MvccNode set all_rows_visible flag, pass empty BitsetView
-    // to Knowhere (IDSelectorAll — fastest search path).
+    // Prepare BitsetView for search.
+    // Fast path: all_rows_visible → empty BitsetView
+    //            (IDSelectorAll in Knowhere, skips per-vector bit test).
+    // Normal path: build BitsetView from the bitmap produced upstream.
+    milvus::BitsetView search_view;
+    int64_t data_cnt = active_count_;
+
     if (query_context_->get_all_rows_visible()) {
-        milvus::BitsetView empty_view;
-        auto op_context = query_context_->get_op_context();
-        segment_->vector_search(search_info_,
-                                src_data,
-                                src_offsets,
-                                num_queries,
-                                query_timestamp_,
-                                empty_view,
-                                op_context,
-                                search_result);
-        search_result.total_data_cnt_ = active_count_;
+        // search_view stays default-constructed (empty)
+    } else {
+        TargetBitmapView view(col_input->GetRawData(), col_input->size());
 
-        span.GetSpan()->SetAttribute(
-            "result_count",
-            static_cast<int>(search_result.seg_offsets_.size()));
-        query_context_->set_search_result(std::move(search_result));
+        if (view.all()) {
+            query_context_->set_search_result(
+                std::move(empty_search_result(num_queries)));
+            return input_;
+        }
 
-        std::chrono::high_resolution_clock::time_point vector_end =
-            std::chrono::high_resolution_clock::now();
-        double vector_cost =
-            std::chrono::duration<double, std::micro>(vector_end - vector_start)
-                .count();
-        milvus::monitor::internal_core_search_latency_vector.Observe(
-            vector_cost / 1000);
-        return input_;
+        // TODO: uniform knowhere BitsetView and milvus BitsetView
+        search_view = milvus::BitsetView((uint8_t*)col_input->GetRawData(),
+                                         col_input->size());
+        data_cnt = search_view.size();
     }
 
-    TargetBitmapView view(col_input->GetRawData(), col_input->size());
-    if (view.all()) {
-        query_context_->set_search_result(
-            std::move(empty_search_result(num_queries)));
-        return input_;
-    }
-
-    // TODO: uniform knowhere BitsetView and milvus BitsetView
-    milvus::BitsetView final_view((uint8_t*)col_input->GetRawData(),
-                                  col_input->size());
+    // Single search + metrics path
+    milvus::SearchResult search_result;
     auto op_context = query_context_->get_op_context();
     segment_->vector_search(search_info_,
                             src_data,
                             src_offsets,
                             num_queries,
                             query_timestamp_,
-                            final_view,
+                            search_view,
                             op_context,
                             search_result);
 
-    search_result.total_data_cnt_ = final_view.size();
+    search_result.total_data_cnt_ = data_cnt;
 
     span.GetSpan()->SetAttribute(
         "result_count", static_cast<int>(search_result.seg_offsets_.size()));
-
     query_context_->set_search_result(std::move(search_result));
+
     std::chrono::high_resolution_clock::time_point vector_end =
         std::chrono::high_resolution_clock::now();
     double vector_cost =
@@ -147,8 +131,8 @@ PhyVectorSearchNode::GetOutput() {
             .count();
     milvus::monitor::internal_core_search_latency_vector.Observe(vector_cost /
                                                                  1000);
-    // for now, vector search store result in query_context
-    // this node interface just return bitset
+    // vector search stores result in query_context;
+    // this node returns the bitset for downstream operators
     return input_;
 }
 

--- a/internal/core/src/exec/operator/VectorSearchNode.cpp
+++ b/internal/core/src/exec/operator/VectorSearchNode.cpp
@@ -83,6 +83,37 @@ PhyVectorSearchNode::GetOutput() {
     milvus::SearchResult search_result;
 
     auto col_input = GetColumnVector(input_);
+
+    // Fast path: MvccNode set all_rows_visible flag, pass empty BitsetView
+    // to Knowhere (IDSelectorAll — fastest search path).
+    if (query_context_->get_all_rows_visible()) {
+        milvus::BitsetView empty_view;
+        auto op_context = query_context_->get_op_context();
+        segment_->vector_search(search_info_,
+                                src_data,
+                                src_offsets,
+                                num_queries,
+                                query_timestamp_,
+                                empty_view,
+                                op_context,
+                                search_result);
+        search_result.total_data_cnt_ = active_count_;
+
+        span.GetSpan()->SetAttribute(
+            "result_count",
+            static_cast<int>(search_result.seg_offsets_.size()));
+        query_context_->set_search_result(std::move(search_result));
+
+        std::chrono::high_resolution_clock::time_point vector_end =
+            std::chrono::high_resolution_clock::now();
+        double vector_cost =
+            std::chrono::duration<double, std::micro>(vector_end - vector_start)
+                .count();
+        milvus::monitor::internal_core_search_latency_vector.Observe(
+            vector_cost / 1000);
+        return input_;
+    }
+
     TargetBitmapView view(col_input->GetRawData(), col_input->size());
     if (view.all()) {
         query_context_->set_search_result(

--- a/internal/core/src/query/ExecPlanNodeVisitor.cpp
+++ b/internal/core/src/query/ExecPlanNodeVisitor.cpp
@@ -39,7 +39,8 @@ empty_search_result(int64_t num_queries) {
 BitsetType
 ExecPlanNodeVisitor::ExecuteTask(
     plan::PlanFragment& plan,
-    std::shared_ptr<milvus::exec::QueryContext> query_context) {
+    std::shared_ptr<milvus::exec::QueryContext> query_context,
+    bool collect_bitset) {
     tracer::AutoSpan span("ExecuteTask", tracer::GetRootSpan(), true);
     span.GetSpan()->SetAttribute("active_count",
                                  query_context->get_active_count());
@@ -64,15 +65,16 @@ ExecPlanNodeVisitor::ExecuteTask(
         LOG_DEBUG("output result length:{}", childrens[0]->size());
         if (auto vec = std::dynamic_pointer_cast<ColumnVector>(childrens[0])) {
             processed_num += vec->size();
-            BitsetTypeView view(vec->GetRawData(), vec->size());
-            bitset_holder.append(view);
+            if (collect_bitset) {
+                BitsetTypeView view(vec->GetRawData(), vec->size());
+                bitset_holder.append(view);
+            }
         } else {
             ThrowInfo(UnexpectedError, "expr return type not matched");
         }
     }
 
     span.GetSpan()->SetAttribute("total_rows", processed_num);
-    span.GetSpan()->SetAttribute("matched_rows", bitset_holder.count());
 
     return bitset_holder;
 }
@@ -190,7 +192,7 @@ ExecPlanNodeVisitor::visit(VectorPlanNode& node) {
     query_context->set_op_context(&op_context);
 
     // Do plan fragment task work
-    auto result = ExecuteTask(plan, query_context);
+    ExecuteTask(plan, query_context, false);
 
     // Store result
     search_result_opt_ = std::move(query_context->get_search_result());

--- a/internal/core/src/query/ExecPlanNodeVisitor.h
+++ b/internal/core/src/query/ExecPlanNodeVisitor.h
@@ -97,7 +97,8 @@ class ExecPlanNodeVisitor : public PlanNodeVisitor {
 
     static BitsetType
     ExecuteTask(plan::PlanFragment& plan,
-                std::shared_ptr<milvus::exec::QueryContext> query_context);
+                std::shared_ptr<milvus::exec::QueryContext> query_context,
+                bool collect_bitset = true);
 
  private:
     const segcore::SegmentInterface& segment_;

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -219,6 +219,11 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     int64_t
     get_deleted_count() const override;
 
+    Timestamp
+    get_max_timestamp() const override {
+        return insert_record_.timestamp_index_.get_max_timestamp();
+    }
+
     const Schema&
     get_schema() const override;
 

--- a/internal/core/src/segcore/SegmentGrowingImpl.h
+++ b/internal/core/src/segcore/SegmentGrowingImpl.h
@@ -221,6 +221,11 @@ class SegmentGrowingImpl : public SegmentGrowing {
         return deleted_record_.size();
     }
 
+    Timestamp
+    get_max_timestamp() const override {
+        return insert_record_.timestamp_index_.get_max_timestamp();
+    }
+
     int64_t
     get_active_count(Timestamp ts) const override;
 

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -139,6 +139,9 @@ class SegmentInterface {
     virtual int64_t
     get_deleted_count() const = 0;
 
+    virtual Timestamp
+    get_max_timestamp() const = 0;
+
     virtual int64_t
     get_real_count() const = 0;
 

--- a/internal/core/src/segcore/TimestampIndex.h
+++ b/internal/core/src/segcore/TimestampIndex.h
@@ -45,6 +45,11 @@ class TimestampIndex {
                       Timestamp expire_ts,
                       std::pair<int64_t, int64_t> active_range);
 
+    Timestamp
+    get_max_timestamp() const {
+        return max_timestamp_;
+    }
+
     size_t
     memory_size() const {
         return sizeof(*this) + lengths_.size() * sizeof(int64_t) +


### PR DESCRIPTION
pr: https://github.com/milvus-io/milvus/pull/48272
issue: #48279

Five independent optimizations for the sealed-segment search path:

  1. Skip bitset_holder.append() in search path (backport PR#44394)
  2. Remove redundant bitset_holder.count() in ExecPlanNodeVisitor
  3. Sealed-segment MVCC fast path: skip mask_with_timestamps when redundant, derive all_rows_visible from mask_with_delete
  result, pass empty BitsetView to Knowhere (IDSelectorAll)
  4. Hardware -mpopcnt for x86_64
  5. Skip FilterBitsNode for AlwaysTrueExpr + index fast path skipping batch loop in ProcessIndexChunks
 

The Sealed.BF_Overflow failure is caused by a known k=1 overflow bug in Knowhere that is exposed when passing an empty BitsetView (the IDSelectorAll path). This was already fixed on master by bumping Knowhere to 3b330dd0 in PR #48272. However, upgrading Knowhere on the 2.6 release branch may introduce too large a change surface for a stable release, so this is not included here.  