### PR TITLE
test: remove xfail for element_filter search after #48617 fix

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_element_search.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_element_search.py
@@ -413,7 +413,6 @@ class TestStructArrayElementFilterSearch(TestMilvusClientV2Base):
         # Distance ordering (L2: ascending)
         _assert_distance_order(results, "L2")
 
-    @pytest.mark.xfail(reason="flaky: element-level search on growing segment intermittently returns 0 hits")
     @pytest.mark.tags(CaseLabel.L0)
     def test_element_filter_with_doc_level_filter(self):
         """


### PR DESCRIPTION
## Summary
- Remove `@pytest.mark.xfail` from `test_element_filter_with_doc_level_filter` since the underlying bug (#48617) has been fixed

issue: #48617

## Test plan
- [ ] Verify `test_element_filter_with_doc_level_filter` passes without xfail marker

🤖 Generated with [Claude Code](https://claude.com/claude-code)