### PR TITLE
fix: correct nullable vector field merge to prevent panic on empty ValidData

### DIFF
--- a/internal/proxy/query_pipeline.go
+++ b/internal/proxy/query_pipeline.go
@@ -119,7 +119,7 @@ func buildPlainQueryPipeline(
 	reduceType reduce.IReduceType,
 ) *queryutil.Pipeline {
 	b := queryutil.NewPipelineBuilder("proxy-query-plain")
-	b.Add(queryutil.OpReduceByPK, in(), ch(chanReduced), queryutil.NewSortAndCheckPKOperator(reduceType))
+	b.Add(queryutil.OpReduceByPK, in(), ch(chanReduced), queryutil.NewSortAndCheckPKOperator(reduceType, schema))
 	b.Add(queryutil.OpSlice, ch(chanReduced), ch(chanSliced), queryutil.NewSliceOperator(limit, offset))
 	b.Add("complement_fields", ch(chanSliced), out(), newComplementFieldOperator(schema))
 	return b.Build()
@@ -133,7 +133,7 @@ func buildOrderByPipeline(
 	outputFieldIDs []int64,
 ) *queryutil.Pipeline {
 	b := queryutil.NewPipelineBuilder("proxy-query-orderby")
-	b.Add(queryutil.OpConcatAndCheckPK, in(), ch(chanReduced), queryutil.NewConcatAndCheckPKOperator())
+	b.Add(queryutil.OpConcatAndCheckPK, in(), ch(chanReduced), queryutil.NewConcatAndCheckPKOperator(schema))
 	b.Add(queryutil.OpOrderByLimit, ch(chanReduced), ch(chanSorted), queryutil.NewOrderByLimitOperator(orderByFields, offset+limit))
 	b.Add(queryutil.OpSlice, ch(chanSorted), ch(chanSliced), queryutil.NewSliceOperator(limit, offset))
 

--- a/internal/util/queryutil/dedup_pk_op.go
+++ b/internal/util/queryutil/dedup_pk_op.go
@@ -23,6 +23,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
@@ -44,10 +45,11 @@ import (
 // Output[0]: *internalpb.RetrieveResults (concatenated + deduplicated)
 type DeduplicatePKOperator struct {
 	maxOutputSize int64
+	schema        *schemapb.CollectionSchema
 }
 
-func NewDeduplicatePKOperator(maxOutputSize int64) *DeduplicatePKOperator {
-	return &DeduplicatePKOperator{maxOutputSize: maxOutputSize}
+func NewDeduplicatePKOperator(maxOutputSize int64, schema *schemapb.CollectionSchema) *DeduplicatePKOperator {
+	return &DeduplicatePKOperator{maxOutputSize: maxOutputSize, schema: schema}
 }
 
 func (op *DeduplicatePKOperator) Name() string {
@@ -130,7 +132,8 @@ func (op *DeduplicatePKOperator) Run(ctx context.Context, span trace.Span, input
 		return []any{&internalpb.RetrieveResults{HasMoreResult: hasMoreResult}}, nil
 	}
 
-	merged, err := buildMergedRetrieveResults(origResults, selectedRows)
+	nullableFields := buildNullableFieldMap(op.schema)
+	merged, err := buildMergedRetrieveResults(origResults, selectedRows, nullableFields)
 	if err != nil {
 		return nil, err
 	}
@@ -160,10 +163,12 @@ func extractTimestamps(r *internalpb.RetrieveResults) []int64 {
 //
 // Input[0]: []*internalpb.RetrieveResults
 // Output[0]: *internalpb.RetrieveResults (concatenated)
-type ConcatAndCheckPKOperator struct{}
+type ConcatAndCheckPKOperator struct {
+	schema *schemapb.CollectionSchema
+}
 
-func NewConcatAndCheckPKOperator() *ConcatAndCheckPKOperator {
-	return &ConcatAndCheckPKOperator{}
+func NewConcatAndCheckPKOperator(schema *schemapb.CollectionSchema) *ConcatAndCheckPKOperator {
+	return &ConcatAndCheckPKOperator{schema: schema}
 }
 
 func (op *ConcatAndCheckPKOperator) Name() string {
@@ -217,7 +222,8 @@ func (op *ConcatAndCheckPKOperator) Run(ctx context.Context, span trace.Span, in
 		}
 	}
 
-	merged, err := buildMergedRetrieveResults(validResults, selectedRows)
+	nullableFields := buildNullableFieldMap(op.schema)
+	merged, err := buildMergedRetrieveResults(validResults, selectedRows, nullableFields)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/util/queryutil/dedup_pk_op_test.go
+++ b/internal/util/queryutil/dedup_pk_op_test.go
@@ -62,12 +62,12 @@ func makeDedupInt64Field(fieldID int64, name string, vals []int64) *schemapb.Fie
 }
 
 func TestDeduplicatePKOperator_Name(t *testing.T) {
-	op := NewDeduplicatePKOperator(0)
+	op := NewDeduplicatePKOperator(0, nil)
 	assert.Equal(t, OpDeduplicatePK, op.Name())
 }
 
 func TestDeduplicatePKOperator_EmptyInput(t *testing.T) {
-	op := NewDeduplicatePKOperator(0)
+	op := NewDeduplicatePKOperator(0, nil)
 	ctx := context.Background()
 
 	outputs, err := op.Run(ctx, nil, []*internalpb.RetrieveResults{})
@@ -77,7 +77,7 @@ func TestDeduplicatePKOperator_EmptyInput(t *testing.T) {
 }
 
 func TestDeduplicatePKOperator_NilResults(t *testing.T) {
-	op := NewDeduplicatePKOperator(0)
+	op := NewDeduplicatePKOperator(0, nil)
 	ctx := context.Background()
 
 	outputs, err := op.Run(ctx, nil, []*internalpb.RetrieveResults{nil, nil})
@@ -87,7 +87,7 @@ func TestDeduplicatePKOperator_NilResults(t *testing.T) {
 }
 
 func TestDeduplicatePKOperator_SingleResult(t *testing.T) {
-	op := NewDeduplicatePKOperator(0)
+	op := NewDeduplicatePKOperator(0, nil)
 	ctx := context.Background()
 
 	r := &internalpb.RetrieveResults{
@@ -102,7 +102,7 @@ func TestDeduplicatePKOperator_SingleResult(t *testing.T) {
 }
 
 func TestDeduplicatePKOperator_MultipleResults_NoDuplicates(t *testing.T) {
-	op := NewDeduplicatePKOperator(0)
+	op := NewDeduplicatePKOperator(0, nil)
 	ctx := context.Background()
 
 	r1 := &internalpb.RetrieveResults{
@@ -120,7 +120,7 @@ func TestDeduplicatePKOperator_MultipleResults_NoDuplicates(t *testing.T) {
 }
 
 func TestDeduplicatePKOperator_DuplicatePK_HigherTimestampWins(t *testing.T) {
-	op := NewDeduplicatePKOperator(0)
+	op := NewDeduplicatePKOperator(0, nil)
 	ctx := context.Background()
 
 	// r1: PK=1 with ts=100, val=10
@@ -147,7 +147,7 @@ func TestDeduplicatePKOperator_DuplicatePK_HigherTimestampWins(t *testing.T) {
 }
 
 func TestDeduplicatePKOperator_DuplicatePK_LowerTimestampLoses(t *testing.T) {
-	op := NewDeduplicatePKOperator(0)
+	op := NewDeduplicatePKOperator(0, nil)
 	ctx := context.Background()
 
 	// r1: PK=1 with ts=200, val=10 (should win)
@@ -174,7 +174,7 @@ func TestDeduplicatePKOperator_DuplicatePK_LowerTimestampLoses(t *testing.T) {
 }
 
 func TestDeduplicatePKOperator_DuplicateWithinSingleResult(t *testing.T) {
-	op := NewDeduplicatePKOperator(0)
+	op := NewDeduplicatePKOperator(0, nil)
 	ctx := context.Background()
 
 	// Single result with duplicate PK=1 (ts=100 then ts=200)
@@ -194,7 +194,7 @@ func TestDeduplicatePKOperator_DuplicateWithinSingleResult(t *testing.T) {
 
 func TestDeduplicatePKOperator_MaxOutputSize(t *testing.T) {
 	// Very small maxOutputSize should trigger error
-	op := NewDeduplicatePKOperator(1) // 1 byte limit
+	op := NewDeduplicatePKOperator(1, nil) // 1 byte limit
 	ctx := context.Background()
 
 	r := &internalpb.RetrieveResults{
@@ -207,7 +207,7 @@ func TestDeduplicatePKOperator_MaxOutputSize(t *testing.T) {
 }
 
 func TestDeduplicatePKOperator_HasMoreResult(t *testing.T) {
-	op := NewDeduplicatePKOperator(0)
+	op := NewDeduplicatePKOperator(0, nil)
 	ctx := context.Background()
 
 	r1 := &internalpb.RetrieveResults{
@@ -227,7 +227,7 @@ func TestDeduplicatePKOperator_HasMoreResult(t *testing.T) {
 }
 
 func TestDeduplicatePKOperator_StringPK(t *testing.T) {
-	op := NewDeduplicatePKOperator(0)
+	op := NewDeduplicatePKOperator(0, nil)
 	ctx := context.Background()
 
 	r1 := &internalpb.RetrieveResults{
@@ -250,7 +250,7 @@ func TestDeduplicatePKOperator_StringPK(t *testing.T) {
 // =========================================================================
 
 func TestConcatAndCheckPKOperator_DuplicatePK_ReturnsError(t *testing.T) {
-	op := NewConcatAndCheckPKOperator()
+	op := NewConcatAndCheckPKOperator(nil)
 	ctx := context.Background()
 
 	r1 := &internalpb.RetrieveResults{
@@ -267,7 +267,7 @@ func TestConcatAndCheckPKOperator_DuplicatePK_ReturnsError(t *testing.T) {
 }
 
 func TestConcatAndCheckPKOperator_SingleResult(t *testing.T) {
-	op := NewConcatAndCheckPKOperator()
+	op := NewConcatAndCheckPKOperator(nil)
 	ctx := context.Background()
 
 	r := &internalpb.RetrieveResults{
@@ -283,7 +283,7 @@ func TestConcatAndCheckPKOperator_SingleResult(t *testing.T) {
 // TestConcatAndCheckPKOperator_HasMoreResult_MultiResult verifies HasMoreResult is propagated
 // when multiple non-empty results are concatenated.
 func TestConcatAndCheckPKOperator_HasMoreResult_MultiResult(t *testing.T) {
-	op := NewConcatAndCheckPKOperator()
+	op := NewConcatAndCheckPKOperator(nil)
 	ctx := context.Background()
 
 	r1 := &internalpb.RetrieveResults{
@@ -305,7 +305,7 @@ func TestConcatAndCheckPKOperator_HasMoreResult_MultiResult(t *testing.T) {
 // TestConcatAndCheckPKOperator_HasMoreResult_EmptyResultPropagates verifies that HasMoreResult
 // from an empty (filtered-out) result is still propagated to the merged output.
 func TestConcatAndCheckPKOperator_HasMoreResult_EmptyResultPropagates(t *testing.T) {
-	op := NewConcatAndCheckPKOperator()
+	op := NewConcatAndCheckPKOperator(nil)
 	ctx := context.Background()
 
 	// r1 is empty (no rows) but has HasMoreResult=true
@@ -328,7 +328,7 @@ func TestConcatAndCheckPKOperator_HasMoreResult_EmptyResultPropagates(t *testing
 // TestConcatAndCheckPKOperator_HasMoreResult_AllEmpty verifies HasMoreResult is set on
 // the empty output when all inputs are empty.
 func TestConcatAndCheckPKOperator_HasMoreResult_AllEmpty(t *testing.T) {
-	op := NewConcatAndCheckPKOperator()
+	op := NewConcatAndCheckPKOperator(nil)
 	ctx := context.Background()
 
 	r1 := &internalpb.RetrieveResults{HasMoreResult: true}
@@ -347,7 +347,7 @@ func TestDeduplicatePKOperator_MaxOutputSize_ExactlyAtLimit(t *testing.T) {
 	const rowCount = 3
 	const exactLimit = rowSize * rowCount // 24 bytes
 
-	op := NewDeduplicatePKOperator(exactLimit)
+	op := NewDeduplicatePKOperator(exactLimit, nil)
 	ctx := context.Background()
 
 	r := &internalpb.RetrieveResults{
@@ -367,7 +367,7 @@ func TestDeduplicatePKOperator_MaxOutputSize_OneBelowLimit(t *testing.T) {
 	const rowCount = 3
 	const limitOneByte = rowSize*rowCount - 1 // 23 bytes — one below total
 
-	op := NewDeduplicatePKOperator(limitOneByte)
+	op := NewDeduplicatePKOperator(limitOneByte, nil)
 	ctx := context.Background()
 
 	r := &internalpb.RetrieveResults{

--- a/internal/util/queryutil/helpers.go
+++ b/internal/util/queryutil/helpers.go
@@ -56,8 +56,28 @@ func comparePK(a, b any) int {
 	return 0
 }
 
+// buildNullableFieldMap builds a fieldID→nullable map from schema.
+// Returns nil if schema is nil (all fields treated as non-nullable by callers).
+// Callers pass the returned map to buildMergedRetrieveResults; field lookup
+// uses FieldID so it is robust to FieldsData ordering differences across results.
+func buildNullableFieldMap(schema *schemapb.CollectionSchema) map[int64]bool {
+	if schema == nil {
+		return nil
+	}
+	m := make(map[int64]bool)
+	for _, f := range schema.GetFields() {
+		if f.GetNullable() {
+			m[f.GetFieldID()] = true
+		}
+	}
+	return m
+}
+
 // buildMergedRetrieveResults builds merged result from selected rows.
-func buildMergedRetrieveResults(results []*internalpb.RetrieveResults, selectedRows []rowRef) (*internalpb.RetrieveResults, error) {
+// nullableFields maps fieldID→true for nullable fields (from schema).
+// Pass nil to treat all fields as non-nullable (QN-side / non-schema-aware callers).
+// Reading a nil map in Go returns the zero value (false), so nil is safe.
+func buildMergedRetrieveResults(results []*internalpb.RetrieveResults, selectedRows []rowRef, nullableFields map[int64]bool) (*internalpb.RetrieveResults, error) {
 	if len(selectedRows) == 0 || len(results) == 0 {
 		return &internalpb.RetrieveResults{}, nil
 	}
@@ -94,7 +114,9 @@ func buildMergedRetrieveResults(results []*internalpb.RetrieveResults, selectedR
 
 	// Build merged field data
 	for fieldIdx := 0; fieldIdx < numFields; fieldIdx++ {
-		merged.FieldsData[fieldIdx] = buildMergedFieldData(results, selectedRows, fieldIdx)
+		fieldID := template.GetFieldsData()[fieldIdx].GetFieldId()
+		isNullable := nullableFields[fieldID] // false for nil map or absent fieldID
+		merged.FieldsData[fieldIdx] = buildMergedFieldData(results, selectedRows, fieldIdx, isNullable)
 	}
 
 	// Propagate element-level metadata
@@ -177,7 +199,9 @@ func buildMergedIDs(results []*internalpb.RetrieveResults, selectedRows []rowRef
 }
 
 // buildMergedFieldData builds merged field data from selected rows.
-func buildMergedFieldData(results []*internalpb.RetrieveResults, selectedRows []rowRef, fieldIdx int) *schemapb.FieldData {
+// isNullable indicates whether this field is nullable (from schema).
+// When isNullable=true, absent ValidData in a result means all rows in that result are null.
+func buildMergedFieldData(results []*internalpb.RetrieveResults, selectedRows []rowRef, fieldIdx int, isNullable bool) *schemapb.FieldData {
 	template := results[selectedRows[0].resultIdx].GetFieldsData()[fieldIdx]
 
 	newFd := &schemapb.FieldData{
@@ -194,7 +218,7 @@ func buildMergedFieldData(results []*internalpb.RetrieveResults, selectedRows []
 		}
 	case *schemapb.FieldData_Vectors:
 		newFd.Field = &schemapb.FieldData_Vectors{
-			Vectors: buildMergedVectorField(results, selectedRows, fieldIdx),
+			Vectors: buildMergedVectorField(results, selectedRows, fieldIdx, isNullable),
 		}
 		// Note: FieldData_StructArrays is intentionally not handled here.
 		// Segcore returns struct sub-fields as flat, independent FieldData entries.
@@ -203,18 +227,15 @@ func buildMergedFieldData(results []*internalpb.RetrieveResults, selectedRows []
 	}
 
 	// Preserve ValidData (nullable bitmap) for nullable fields.
-	// Each source result may have its own ValidData; merge them by selectedRows.
-	if hasValidData(results, selectedRows, fieldIdx) {
+	// Use schema-based nullability: empty ValidData means all rows in that result are null.
+	if isNullable {
 		validData := make([]bool, len(selectedRows))
 		for i, ref := range selectedRows {
 			vd := results[ref.resultIdx].GetFieldsData()[fieldIdx].GetValidData()
-			if len(vd) > int(ref.rowIdx) {
+			if len(vd) > 0 && int(ref.rowIdx) < len(vd) {
 				validData[i] = vd[ref.rowIdx]
-			} else {
-				// No ValidData means all values are valid (non-nullable field
-				// or source result that doesn't carry the bitmap).
-				validData[i] = true
 			}
+			// ValidData absent or rowIdx out of bounds: keep false (null semantics)
 		}
 		newFd.ValidData = validData
 	}
@@ -222,8 +243,10 @@ func buildMergedFieldData(results []*internalpb.RetrieveResults, selectedRows []
 	return newFd
 }
 
-// hasValidData checks if any source result has ValidData for the given field.
-func hasValidData(results []*internalpb.RetrieveResults, selectedRows []rowRef, fieldIdx int) bool {
+// hasAnyValidData checks if any source result has ValidData for the given field.
+// Used only for StructArray sub-field nullable detection as a conservative fallback.
+// For top-level fields, use schema-based isNullable instead.
+func hasAnyValidData(results []*internalpb.RetrieveResults, selectedRows []rowRef, fieldIdx int) bool {
 	for _, ref := range selectedRows {
 		fd := results[ref.resultIdx].GetFieldsData()[fieldIdx]
 		if len(fd.GetValidData()) > 0 {
@@ -268,15 +291,17 @@ func buildMergedStructArrayField(results []*internalpb.RetrieveResults, selected
 				Scalars: buildMergedScalarField(virtualResults, selectedRows, 0),
 			}
 		case *schemapb.FieldData_Vectors:
+			// Use hasAnyValidData as a conservative nullable check for StructArray sub-fields.
+			// Sub-field schema-aware nullable is deferred to a follow-up PR.
 			newSubFd.Field = &schemapb.FieldData_Vectors{
-				Vectors: buildMergedVectorField(virtualResults, selectedRows, 0),
+				Vectors: buildMergedVectorField(virtualResults, selectedRows, 0, hasAnyValidData(virtualResults, selectedRows, 0)),
 			}
 		}
 
 		// Preserve ValidData for sub-fields.
 		// Check the sub-field's own ValidData (not the parent StructArray's),
 		// since segcore returns sub-fields as flat FieldData with independent validity bitmaps.
-		if hasValidData(virtualResults, selectedRows, 0) {
+		if hasAnyValidData(virtualResults, selectedRows, 0) {
 			validData := make([]bool, len(selectedRows))
 			for i, ref := range selectedRows {
 				subFields := results[ref.resultIdx].GetFieldsData()[fieldIdx].GetStructArrays().GetFields()
@@ -299,6 +324,9 @@ func buildMergedStructArrayField(results []*internalpb.RetrieveResults, selected
 }
 
 // buildMergedScalarField builds merged scalar field from selected rows.
+// Bounds-checks each row access: nullable fields with all-null results may have an empty
+// Data array (segcore omits the storage); out-of-bounds rows keep the Go zero value.
+// The corresponding ValidData entry will be false, so users never see zero-filled nulls.
 func buildMergedScalarField(results []*internalpb.RetrieveResults, selectedRows []rowRef, fieldIdx int) *schemapb.ScalarField {
 	template := results[selectedRows[0].resultIdx].GetFieldsData()[fieldIdx].GetScalars()
 	newSf := &schemapb.ScalarField{}
@@ -307,63 +335,81 @@ func buildMergedScalarField(results []*internalpb.RetrieveResults, selectedRows 
 	case *schemapb.ScalarField_BoolData:
 		data := make([]bool, len(selectedRows))
 		for i, ref := range selectedRows {
-			data[i] = results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetBoolData().GetData()[ref.rowIdx]
+			if src := results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetBoolData().GetData(); int(ref.rowIdx) < len(src) {
+				data[i] = src[ref.rowIdx]
+			}
 		}
 		newSf.Data = &schemapb.ScalarField_BoolData{BoolData: &schemapb.BoolArray{Data: data}}
 
 	case *schemapb.ScalarField_IntData:
 		data := make([]int32, len(selectedRows))
 		for i, ref := range selectedRows {
-			data[i] = results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetIntData().GetData()[ref.rowIdx]
+			if src := results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetIntData().GetData(); int(ref.rowIdx) < len(src) {
+				data[i] = src[ref.rowIdx]
+			}
 		}
 		newSf.Data = &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: data}}
 
 	case *schemapb.ScalarField_LongData:
 		data := make([]int64, len(selectedRows))
 		for i, ref := range selectedRows {
-			data[i] = results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetLongData().GetData()[ref.rowIdx]
+			if src := results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetLongData().GetData(); int(ref.rowIdx) < len(src) {
+				data[i] = src[ref.rowIdx]
+			}
 		}
 		newSf.Data = &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: data}}
 
 	case *schemapb.ScalarField_FloatData:
 		data := make([]float32, len(selectedRows))
 		for i, ref := range selectedRows {
-			data[i] = results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetFloatData().GetData()[ref.rowIdx]
+			if src := results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetFloatData().GetData(); int(ref.rowIdx) < len(src) {
+				data[i] = src[ref.rowIdx]
+			}
 		}
 		newSf.Data = &schemapb.ScalarField_FloatData{FloatData: &schemapb.FloatArray{Data: data}}
 
 	case *schemapb.ScalarField_DoubleData:
 		data := make([]float64, len(selectedRows))
 		for i, ref := range selectedRows {
-			data[i] = results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetDoubleData().GetData()[ref.rowIdx]
+			if src := results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetDoubleData().GetData(); int(ref.rowIdx) < len(src) {
+				data[i] = src[ref.rowIdx]
+			}
 		}
 		newSf.Data = &schemapb.ScalarField_DoubleData{DoubleData: &schemapb.DoubleArray{Data: data}}
 
 	case *schemapb.ScalarField_StringData:
 		data := make([]string, len(selectedRows))
 		for i, ref := range selectedRows {
-			data[i] = results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetStringData().GetData()[ref.rowIdx]
+			if src := results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetStringData().GetData(); int(ref.rowIdx) < len(src) {
+				data[i] = src[ref.rowIdx]
+			}
 		}
 		newSf.Data = &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: data}}
 
 	case *schemapb.ScalarField_BytesData:
 		data := make([][]byte, len(selectedRows))
 		for i, ref := range selectedRows {
-			data[i] = results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetBytesData().GetData()[ref.rowIdx]
+			if src := results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetBytesData().GetData(); int(ref.rowIdx) < len(src) {
+				data[i] = src[ref.rowIdx]
+			}
 		}
 		newSf.Data = &schemapb.ScalarField_BytesData{BytesData: &schemapb.BytesArray{Data: data}}
 
 	case *schemapb.ScalarField_JsonData:
 		data := make([][]byte, len(selectedRows))
 		for i, ref := range selectedRows {
-			data[i] = results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetJsonData().GetData()[ref.rowIdx]
+			if src := results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetJsonData().GetData(); int(ref.rowIdx) < len(src) {
+				data[i] = src[ref.rowIdx]
+			}
 		}
 		newSf.Data = &schemapb.ScalarField_JsonData{JsonData: &schemapb.JSONArray{Data: data}}
 
 	case *schemapb.ScalarField_ArrayData:
 		data := make([]*schemapb.ScalarField, len(selectedRows))
 		for i, ref := range selectedRows {
-			data[i] = results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetArrayData().GetData()[ref.rowIdx]
+			if src := results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetArrayData().GetData(); int(ref.rowIdx) < len(src) {
+				data[i] = src[ref.rowIdx]
+			}
 		}
 		newSf.Data = &schemapb.ScalarField_ArrayData{ArrayData: &schemapb.ArrayArray{
 			Data:        data,
@@ -373,28 +419,36 @@ func buildMergedScalarField(results []*internalpb.RetrieveResults, selectedRows 
 	case *schemapb.ScalarField_GeometryData:
 		data := make([][]byte, len(selectedRows))
 		for i, ref := range selectedRows {
-			data[i] = results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetGeometryData().GetData()[ref.rowIdx]
+			if src := results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetGeometryData().GetData(); int(ref.rowIdx) < len(src) {
+				data[i] = src[ref.rowIdx]
+			}
 		}
 		newSf.Data = &schemapb.ScalarField_GeometryData{GeometryData: &schemapb.GeometryArray{Data: data}}
 
 	case *schemapb.ScalarField_GeometryWktData:
 		data := make([]string, len(selectedRows))
 		for i, ref := range selectedRows {
-			data[i] = results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetGeometryWktData().GetData()[ref.rowIdx]
+			if src := results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetGeometryWktData().GetData(); int(ref.rowIdx) < len(src) {
+				data[i] = src[ref.rowIdx]
+			}
 		}
 		newSf.Data = &schemapb.ScalarField_GeometryWktData{GeometryWktData: &schemapb.GeometryWktArray{Data: data}}
 
 	case *schemapb.ScalarField_TimestamptzData:
 		data := make([]int64, len(selectedRows))
 		for i, ref := range selectedRows {
-			data[i] = results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetTimestamptzData().GetData()[ref.rowIdx]
+			if src := results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetTimestamptzData().GetData(); int(ref.rowIdx) < len(src) {
+				data[i] = src[ref.rowIdx]
+			}
 		}
 		newSf.Data = &schemapb.ScalarField_TimestamptzData{TimestamptzData: &schemapb.TimestamptzArray{Data: data}}
 
 	case *schemapb.ScalarField_MolData:
 		data := make([][]byte, len(selectedRows))
 		for i, ref := range selectedRows {
-			data[i] = results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetMolData().GetData()[ref.rowIdx]
+			if src := results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetMolData().GetData(); int(ref.rowIdx) < len(src) {
+				data[i] = src[ref.rowIdx]
+			}
 		}
 		newSf.Data = &schemapb.ScalarField_MolData{MolData: &schemapb.MolArray{Data: data}}
 	}
@@ -406,32 +460,38 @@ func buildMergedScalarField(results []*internalpb.RetrieveResults, selectedRows 
 // In compact mode (nullable vectors), the data array only contains entries for valid rows.
 // compactIdx[resultIdx][logicalRowIdx] = data array index, or -1 if null.
 // Returns nil for non-nullable fields (data index = row index).
-func buildCompactIndices(results []*internalpb.RetrieveResults, fieldIdx int) [][]int {
-	hasAny := false
-	for _, r := range results {
-		if len(r.GetFieldsData()[fieldIdx].GetValidData()) > 0 {
-			hasAny = true
-			break
-		}
-	}
-	if !hasAny {
+//
+// Key correctness rules:
+//   - Use isNullable (from schema) to decide whether to build compact mapping, NOT ValidData presence.
+//     Segcore may omit ValidData entirely for a nullable field when all rows are null.
+//   - Iterate numRows times (not len(vd)) to cover all logical rows. When len(vd) < numRows,
+//     the extra rows are null (keep idx[i] = -1). Using range vd would leave idx[len(vd):]
+//     at the Go zero value 0, which getVecDataIdx would misinterpret as valid dataIdx=0.
+func buildCompactIndices(results []*internalpb.RetrieveResults, fieldIdx int, isNullable bool) [][]int {
+	if !isNullable {
 		return nil // non-nullable field, no compact mapping needed
 	}
 
 	indices := make([][]int, len(results))
 	for ri, r := range results {
+		numRows := int(typeutil.GetSizeOfIDs(r.GetIds()))
 		vd := r.GetFieldsData()[fieldIdx].GetValidData()
+		idx := make([]int, numRows)
+
 		if len(vd) == 0 {
-			continue // this result is non-nullable, use rowIdx directly
-		}
-		idx := make([]int, len(vd))
-		dataIdx := 0
-		for i, valid := range vd {
-			if valid {
-				idx[i] = dataIdx
-				dataIdx++
-			} else {
+			// Empty ValidData for nullable field = all rows are null
+			for i := range idx {
 				idx[i] = -1
+			}
+		} else {
+			dataIdx := 0
+			for i := 0; i < numRows; i++ {
+				if i < len(vd) && vd[i] {
+					idx[i] = dataIdx
+					dataIdx++
+				} else {
+					idx[i] = -1
+				}
 			}
 		}
 		indices[ri] = idx
@@ -460,14 +520,15 @@ func getVecDataIdx(compactIndices [][]int, ref rowRef) int {
 // contains entries for valid (non-null) rows, and ValidData bitmap marks which
 // logical rows are null. Null rows don't occupy space in the data array.
 // buildCompactIndices/getVecDataIdx handle the logical→data index mapping.
-func buildMergedVectorField(results []*internalpb.RetrieveResults, selectedRows []rowRef, fieldIdx int) *schemapb.VectorField {
+// isNullable must come from schema, not from ValidData presence in results.
+func buildMergedVectorField(results []*internalpb.RetrieveResults, selectedRows []rowRef, fieldIdx int, isNullable bool) *schemapb.VectorField {
 	template := results[selectedRows[0].resultIdx].GetFieldsData()[fieldIdx].GetVectors()
 	dim := int(template.GetDim())
 
 	newVf := &schemapb.VectorField{Dim: template.GetDim()}
 
 	// Pre-compute compact index mapping for nullable vector fields (O(N) once).
-	compactIdx := buildCompactIndices(results, fieldIdx)
+	compactIdx := buildCompactIndices(results, fieldIdx, isNullable)
 
 	switch template.GetData().(type) {
 	case *schemapb.VectorField_FloatVector:

--- a/internal/util/queryutil/helpers_test.go
+++ b/internal/util/queryutil/helpers_test.go
@@ -18,6 +18,8 @@ package queryutil
 
 import (
 	"context"
+	"encoding/binary"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -65,7 +67,7 @@ func TestBuildMergedFieldData_ValidData(t *testing.T) {
 		{resultIdx: 1, rowIdx: 0}, // r2 row 0 (valid)
 	}
 
-	merged, err := buildMergedRetrieveResults(results, selectedRows)
+	merged, err := buildMergedRetrieveResults(results, selectedRows, map[int64]bool{100: true})
 	require.NoError(t, err)
 	require.Len(t, merged.FieldsData, 1)
 
@@ -75,7 +77,8 @@ func TestBuildMergedFieldData_ValidData(t *testing.T) {
 }
 
 func TestBuildMergedFieldData_ValidData_MixedNullable(t *testing.T) {
-	// r1 has ValidData (nullable), r2 does not (non-nullable)
+	// r1 has ValidData (nullable), r2 has explicit ValidData=[true] (all valid)
+	// This tests that explicit all-valid ValidData is preserved correctly.
 	r1 := &internalpb.RetrieveResults{
 		Ids: &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{1}}}},
 		FieldsData: []*schemapb.FieldData{
@@ -96,7 +99,7 @@ func TestBuildMergedFieldData_ValidData_MixedNullable(t *testing.T) {
 				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{
 					Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{20}}},
 				}},
-				// No ValidData — non-nullable
+				ValidData: []bool{true}, // explicit valid (segcore always includes ValidData for nullable fields)
 			},
 		},
 	}
@@ -104,14 +107,13 @@ func TestBuildMergedFieldData_ValidData_MixedNullable(t *testing.T) {
 	results := []*internalpb.RetrieveResults{r1, r2}
 	selectedRows := []rowRef{
 		{resultIdx: 0, rowIdx: 0}, // r1 (null)
-		{resultIdx: 1, rowIdx: 0}, // r2 (no ValidData → valid=true)
+		{resultIdx: 1, rowIdx: 0}, // r2 (valid=true)
 	}
 
-	merged, err := buildMergedRetrieveResults(results, selectedRows)
+	merged, err := buildMergedRetrieveResults(results, selectedRows, map[int64]bool{100: true})
 	require.NoError(t, err)
 
 	fd := merged.FieldsData[0]
-	// r1 row is null, r2 row has no ValidData so defaults to true
 	assert.Equal(t, []bool{false, true}, fd.ValidData)
 }
 
@@ -141,7 +143,7 @@ func TestBuildMergedScalarField_ArrayElementType(t *testing.T) {
 	results := []*internalpb.RetrieveResults{r1}
 	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 0}, {resultIdx: 0, rowIdx: 1}}
 
-	merged, err := buildMergedRetrieveResults(results, selectedRows)
+	merged, err := buildMergedRetrieveResults(results, selectedRows, nil)
 	require.NoError(t, err)
 
 	arrayField := merged.FieldsData[0].GetScalars().GetArrayData()
@@ -171,7 +173,7 @@ func TestBuildMergedScalarField_GeometryWktData(t *testing.T) {
 	results := []*internalpb.RetrieveResults{r1}
 	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 1}}
 
-	merged, err := buildMergedRetrieveResults(results, selectedRows)
+	merged, err := buildMergedRetrieveResults(results, selectedRows, nil)
 	require.NoError(t, err)
 
 	wktData := merged.FieldsData[0].GetScalars().GetGeometryWktData().GetData()
@@ -196,7 +198,7 @@ func TestBuildMergedScalarField_GeometryData(t *testing.T) {
 	results := []*internalpb.RetrieveResults{r1}
 	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 0}}
 
-	merged, err := buildMergedRetrieveResults(results, selectedRows)
+	merged, err := buildMergedRetrieveResults(results, selectedRows, nil)
 	require.NoError(t, err)
 
 	geoData := merged.FieldsData[0].GetScalars().GetGeometryData().GetData()
@@ -225,7 +227,7 @@ func TestBuildMergedScalarField_TimestamptzData(t *testing.T) {
 	results := []*internalpb.RetrieveResults{r1}
 	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 0}, {resultIdx: 0, rowIdx: 1}}
 
-	merged, err := buildMergedRetrieveResults(results, selectedRows)
+	merged, err := buildMergedRetrieveResults(results, selectedRows, nil)
 	require.NoError(t, err)
 
 	tsData := merged.FieldsData[0].GetScalars().GetTimestamptzData().GetData()
@@ -250,7 +252,7 @@ func TestBuildMergedScalarField_MolData(t *testing.T) {
 	results := []*internalpb.RetrieveResults{r1}
 	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 0}}
 
-	merged, err := buildMergedRetrieveResults(results, selectedRows)
+	merged, err := buildMergedRetrieveResults(results, selectedRows, nil)
 	require.NoError(t, err)
 
 	molData := merged.FieldsData[0].GetScalars().GetMolData().GetData()
@@ -279,7 +281,7 @@ func TestBuildMergedVectorField_Int8Vector(t *testing.T) {
 	results := []*internalpb.RetrieveResults{r1}
 	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 1}} // select row 1 only
 
-	merged, err := buildMergedRetrieveResults(results, selectedRows)
+	merged, err := buildMergedRetrieveResults(results, selectedRows, nil)
 	require.NoError(t, err)
 
 	vecData := merged.FieldsData[0].GetVectors().GetInt8Vector()
@@ -439,7 +441,7 @@ func TestBuildMergedRetrieveResults_ElementIndices(t *testing.T) {
 	results := []*internalpb.RetrieveResults{r1}
 	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 1}, {resultIdx: 0, rowIdx: 0}}
 
-	merged, err := buildMergedRetrieveResults(results, selectedRows)
+	merged, err := buildMergedRetrieveResults(results, selectedRows, nil)
 	require.NoError(t, err)
 
 	assert.True(t, merged.GetElementLevel())
@@ -484,7 +486,7 @@ func TestRangeSliceRetrieveResults_ElementIndices(t *testing.T) {
 // =========================================================================
 
 func TestConcatAndCheckPKOperator_NoDuplicate(t *testing.T) {
-	op := NewConcatAndCheckPKOperator()
+	op := NewConcatAndCheckPKOperator(nil)
 	ctx := context.Background()
 
 	r1 := &internalpb.RetrieveResults{
@@ -520,7 +522,7 @@ func TestConcatAndCheckPKOperator_NoDuplicate(t *testing.T) {
 }
 
 func TestConcatAndCheckPKOperator_DuplicateFails(t *testing.T) {
-	op := NewConcatAndCheckPKOperator()
+	op := NewConcatAndCheckPKOperator(nil)
 	ctx := context.Background()
 
 	r1 := &internalpb.RetrieveResults{
@@ -596,7 +598,7 @@ func TestBuildMergedFieldData_CommonScalarTypes(t *testing.T) {
 	}
 
 	selectedRows := []rowRef{{0, 0}, {1, 0}, {0, 1}} // r1[0], r2[0], r1[1]
-	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1, r2}, selectedRows)
+	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1, r2}, selectedRows, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, []int64{1, 3, 2}, merged.GetIds().GetIntId().GetData())
@@ -635,7 +637,7 @@ func TestBuildMergedFieldData_FloatVector(t *testing.T) {
 	}
 
 	selectedRows := []rowRef{{1, 0}, {0, 1}} // r2[0], r1[1]
-	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1, r2}, selectedRows)
+	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1, r2}, selectedRows, nil)
 	require.NoError(t, err)
 
 	vecData := merged.GetFieldsData()[0].GetVectors().GetFloatVector().GetData()
@@ -954,7 +956,7 @@ func TestBuildMergedVectorField_VectorArray(t *testing.T) {
 	results := []*internalpb.RetrieveResults{r1, r2}
 	selectedRows := []rowRef{{resultIdx: 1, rowIdx: 0}, {resultIdx: 0, rowIdx: 0}}
 
-	merged, err := buildMergedRetrieveResults(results, selectedRows)
+	merged, err := buildMergedRetrieveResults(results, selectedRows, nil)
 	require.NoError(t, err)
 
 	va := merged.FieldsData[0].GetVectors().GetVectorArray()
@@ -1076,7 +1078,7 @@ func TestBuildMergedScalarField_BoolData(t *testing.T) {
 		}},
 	})
 	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 1}, {resultIdx: 0, rowIdx: 0}}
-	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows)
+	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows, nil)
 	require.NoError(t, err)
 	assert.Equal(t, []bool{false, true}, merged.FieldsData[0].GetScalars().GetBoolData().GetData())
 }
@@ -1089,7 +1091,7 @@ func TestBuildMergedScalarField_IntData(t *testing.T) {
 		}},
 	})
 	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 1}}
-	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows)
+	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows, nil)
 	require.NoError(t, err)
 	assert.Equal(t, []int32{20}, merged.FieldsData[0].GetScalars().GetIntData().GetData())
 }
@@ -1102,7 +1104,7 @@ func TestBuildMergedScalarField_FloatData(t *testing.T) {
 		}},
 	})
 	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 0}}
-	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows)
+	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows, nil)
 	require.NoError(t, err)
 	assert.Equal(t, []float32{1.5}, merged.FieldsData[0].GetScalars().GetFloatData().GetData())
 }
@@ -1115,7 +1117,7 @@ func TestBuildMergedScalarField_DoubleData(t *testing.T) {
 		}},
 	})
 	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 1}}
-	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows)
+	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows, nil)
 	require.NoError(t, err)
 	assert.Equal(t, []float64{2.71}, merged.FieldsData[0].GetScalars().GetDoubleData().GetData())
 }
@@ -1128,7 +1130,7 @@ func TestBuildMergedScalarField_BytesData(t *testing.T) {
 		}},
 	})
 	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 0}, {resultIdx: 0, rowIdx: 1}}
-	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows)
+	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows, nil)
 	require.NoError(t, err)
 	assert.Equal(t, [][]byte{{0x01}, {0x02}}, merged.FieldsData[0].GetScalars().GetBytesData().GetData())
 }
@@ -1141,7 +1143,7 @@ func TestBuildMergedScalarField_JsonData(t *testing.T) {
 		}},
 	})
 	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 1}}
-	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows)
+	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows, nil)
 	require.NoError(t, err)
 	assert.Equal(t, [][]byte{[]byte(`{"b":2}`)}, merged.FieldsData[0].GetScalars().GetJsonData().GetData())
 }
@@ -1158,7 +1160,7 @@ func TestBuildMergedIDs_StringPK(t *testing.T) {
 		},
 	}
 	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 1}, {resultIdx: 0, rowIdx: 0}}
-	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows)
+	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows, nil)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"b", "a"}, merged.GetIds().GetStrId().GetData())
 }
@@ -1177,7 +1179,7 @@ func TestBuildMergedVectorField_BinaryVector(t *testing.T) {
 		}},
 	})
 	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 1}}
-	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows)
+	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows, nil)
 	require.NoError(t, err)
 	assert.Equal(t, []byte{0xCC, 0xDD}, merged.FieldsData[0].GetVectors().GetBinaryVector())
 }
@@ -1192,7 +1194,7 @@ func TestBuildMergedVectorField_Float16Vector(t *testing.T) {
 		}},
 	})
 	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 1}}
-	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows)
+	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows, nil)
 	require.NoError(t, err)
 	assert.Equal(t, []byte{5, 6, 7, 8}, merged.FieldsData[0].GetVectors().GetFloat16Vector())
 }
@@ -1207,7 +1209,7 @@ func TestBuildMergedVectorField_BFloat16Vector(t *testing.T) {
 		}},
 	})
 	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 0}}
-	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows)
+	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows, nil)
 	require.NoError(t, err)
 	assert.Equal(t, []byte{10, 20, 30, 40}, merged.FieldsData[0].GetVectors().GetBfloat16Vector())
 }
@@ -1224,7 +1226,7 @@ func TestBuildMergedVectorField_SparseFloatVector(t *testing.T) {
 		}},
 	})
 	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 1}}
-	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows)
+	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows, nil)
 	require.NoError(t, err)
 	assert.Equal(t, [][]byte{{0x03, 0x04}}, merged.FieldsData[0].GetVectors().GetSparseFloatVector().GetContents())
 }
@@ -1235,6 +1237,7 @@ func TestBuildMergedVectorField_SparseFloatVector(t *testing.T) {
 
 func TestBuildCompactIndices_NullableVector(t *testing.T) {
 	r1 := &internalpb.RetrieveResults{
+		Ids: &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{1, 2, 3}}}},
 		FieldsData: []*schemapb.FieldData{
 			{
 				Type: schemapb.DataType_FloatVector, FieldId: 100,
@@ -1246,7 +1249,7 @@ func TestBuildCompactIndices_NullableVector(t *testing.T) {
 			},
 		},
 	}
-	indices := buildCompactIndices([]*internalpb.RetrieveResults{r1}, 0)
+	indices := buildCompactIndices([]*internalpb.RetrieveResults{r1}, 0, true)
 	require.NotNil(t, indices)
 	assert.Equal(t, []int{0, -1, 1}, indices[0])
 }
@@ -1264,7 +1267,7 @@ func TestBuildCompactIndices_NonNullable(t *testing.T) {
 			},
 		},
 	}
-	indices := buildCompactIndices([]*internalpb.RetrieveResults{r1}, 0)
+	indices := buildCompactIndices([]*internalpb.RetrieveResults{r1}, 0, false)
 	assert.Nil(t, indices) // non-nullable → nil
 }
 
@@ -2363,7 +2366,8 @@ func TestBuildMergedVectorField_NullableCompact_FloatVector(t *testing.T) {
 		},
 	}
 	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 2}, {resultIdx: 0, rowIdx: 0}}
-	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows)
+	// fieldIdx 0 is nullable (ValidData present); pass correct nullable flag
+	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows, map[int64]bool{100: true})
 	require.NoError(t, err)
 	assert.Equal(t, []float32{3, 4, 1, 2}, merged.FieldsData[0].GetVectors().GetFloatVector().GetData())
 }
@@ -2444,4 +2448,204 @@ func TestValidateElementLevelConsistency_LengthMismatch(t *testing.T) {
 	err := validateElementLevelConsistency([]*internalpb.RetrieveResults{r}, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "element_indices length")
+}
+
+// =========================================================================
+// Nullable vector / scalar merge correctness tests
+// =========================================================================
+
+// makeTestIntIDs is a helper to build IDs for test results.
+func makeTestIntIDs(ids ...int64) *schemapb.IDs {
+	return &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: ids}}}
+}
+
+// makeTestSparseVec builds a knowhere sparse vector binary: [dim uint32][val float32], little-endian.
+func makeTestSparseVec(dim uint32, val float32) []byte {
+	b := make([]byte, 8)
+	binary.LittleEndian.PutUint32(b[0:4], dim)
+	binary.LittleEndian.PutUint32(b[4:8], math.Float32bits(val))
+	return b
+}
+
+// TestBuildMergedVectorField_NullableSparseVector_AllNull_EmptyValidData validates Bug 1 fix:
+// when a nullable sparse vector field has empty ValidData + empty Contents, merge must not panic,
+// and the merged output must correctly mark those rows as null (ValidData=false).
+func TestBuildMergedVectorField_NullableSparseVector_AllNull_EmptyValidData(t *testing.T) {
+	nullableFields := map[int64]bool{100: true}
+
+	// rA: 1 row, has valid data
+	rA := &internalpb.RetrieveResults{
+		Ids: makeTestIntIDs(1),
+		FieldsData: []*schemapb.FieldData{{
+			FieldId: 100,
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Data: &schemapb.VectorField_SparseFloatVector{
+					SparseFloatVector: &schemapb.SparseFloatArray{
+						Contents: [][]byte{makeTestSparseVec(1, 0.5)},
+					},
+				},
+			}},
+			ValidData: []bool{true},
+		}},
+	}
+
+	// rB: 1 row, ValidData absent, Contents absent (segcore get_vector early return)
+	rB := &internalpb.RetrieveResults{
+		Ids: makeTestIntIDs(2),
+		FieldsData: []*schemapb.FieldData{{
+			FieldId: 100,
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Data: &schemapb.VectorField_SparseFloatVector{
+					SparseFloatVector: &schemapb.SparseFloatArray{Contents: nil},
+				},
+			}},
+			ValidData: nil,
+		}},
+	}
+
+	results := []*internalpb.RetrieveResults{rA, rB}
+	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 0}, {resultIdx: 1, rowIdx: 0}}
+
+	merged, err := buildMergedRetrieveResults(results, selectedRows, nullableFields)
+	require.NoError(t, err)
+	require.Len(t, merged.FieldsData, 1)
+	assert.Equal(t, []bool{true, false}, merged.FieldsData[0].ValidData)
+	assert.Len(t, merged.FieldsData[0].GetVectors().GetSparseFloatVector().GetContents(), 1)
+}
+
+// TestBuildMergedVectorField_NullableSparseVector_MultipleRowsFromNullResult validates that
+// multiple rows selected from a null result are all marked null.
+func TestBuildMergedVectorField_NullableSparseVector_MultipleRowsFromNullResult(t *testing.T) {
+	nullableFields := map[int64]bool{100: true}
+
+	rA := &internalpb.RetrieveResults{
+		Ids: makeTestIntIDs(1),
+		FieldsData: []*schemapb.FieldData{{
+			FieldId: 100,
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Data: &schemapb.VectorField_SparseFloatVector{
+					SparseFloatVector: &schemapb.SparseFloatArray{
+						Contents: [][]byte{makeTestSparseVec(1, 0.1)},
+					},
+				},
+			}},
+			ValidData: []bool{true},
+		}},
+	}
+
+	rB := &internalpb.RetrieveResults{
+		Ids: makeTestIntIDs(2, 3),
+		FieldsData: []*schemapb.FieldData{{
+			FieldId: 100,
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Data: &schemapb.VectorField_SparseFloatVector{
+					SparseFloatVector: &schemapb.SparseFloatArray{Contents: nil},
+				},
+			}},
+			ValidData: nil,
+		}},
+	}
+
+	results := []*internalpb.RetrieveResults{rA, rB}
+	selectedRows := []rowRef{
+		{resultIdx: 0, rowIdx: 0},
+		{resultIdx: 1, rowIdx: 0},
+		{resultIdx: 1, rowIdx: 1},
+	}
+
+	merged, err := buildMergedRetrieveResults(results, selectedRows, nullableFields)
+	require.NoError(t, err)
+	assert.Equal(t, []bool{true, false, false}, merged.FieldsData[0].ValidData)
+	assert.Len(t, merged.FieldsData[0].GetVectors().GetSparseFloatVector().GetContents(), 1)
+}
+
+// TestBuildMergedVectorField_NullableSparseVector_AllNullWithValidData validates compact path
+// when ValidData is present and all false (explicit all-null).
+func TestBuildMergedVectorField_NullableSparseVector_AllNullWithValidData(t *testing.T) {
+	nullableFields := map[int64]bool{100: true}
+	r := &internalpb.RetrieveResults{
+		Ids: makeTestIntIDs(1, 2),
+		FieldsData: []*schemapb.FieldData{{
+			FieldId: 100,
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Data: &schemapb.VectorField_SparseFloatVector{
+					SparseFloatVector: &schemapb.SparseFloatArray{Contents: nil},
+				},
+			}},
+			ValidData: []bool{false, false},
+		}},
+	}
+	results := []*internalpb.RetrieveResults{r}
+	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 0}, {resultIdx: 0, rowIdx: 1}}
+
+	merged, err := buildMergedRetrieveResults(results, selectedRows, nullableFields)
+	require.NoError(t, err)
+	assert.Equal(t, []bool{false, false}, merged.FieldsData[0].ValidData)
+	assert.Empty(t, merged.FieldsData[0].GetVectors().GetSparseFloatVector().GetContents())
+}
+
+// TestBuildMergedVectorField_NullableSparseVector_Mixed validates compact index mapping when
+// some rows are valid and some are null within the same result.
+func TestBuildMergedVectorField_NullableSparseVector_Mixed(t *testing.T) {
+	nullableFields := map[int64]bool{100: true}
+	// 3 rows: ValidData=[true,false,true], Contents=[vec0, vec2] (compact)
+	r := &internalpb.RetrieveResults{
+		Ids: makeTestIntIDs(1, 2, 3),
+		FieldsData: []*schemapb.FieldData{{
+			FieldId: 100,
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Data: &schemapb.VectorField_SparseFloatVector{
+					SparseFloatVector: &schemapb.SparseFloatArray{
+						Contents: [][]byte{makeTestSparseVec(1, 0.1), makeTestSparseVec(3, 0.3)},
+					},
+				},
+			}},
+			ValidData: []bool{true, false, true},
+		}},
+	}
+	results := []*internalpb.RetrieveResults{r}
+	// Select row 0 (valid) and row 1 (null)
+	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 0}, {resultIdx: 0, rowIdx: 1}}
+
+	merged, err := buildMergedRetrieveResults(results, selectedRows, nullableFields)
+	require.NoError(t, err)
+	assert.Equal(t, []bool{true, false}, merged.FieldsData[0].ValidData)
+	// Only 1 non-null row in output
+	assert.Len(t, merged.FieldsData[0].GetVectors().GetSparseFloatVector().GetContents(), 1)
+}
+
+// TestBuildMergedFieldData_NullableScalar_EmptyValidData_TreatedAsNull validates Bug 2 fix:
+// for a nullable scalar field, absent ValidData must produce false (null), not true.
+func TestBuildMergedFieldData_NullableScalar_EmptyValidData_TreatedAsNull(t *testing.T) {
+	nullableFields := map[int64]bool{100: true}
+
+	rA := &internalpb.RetrieveResults{
+		Ids: makeTestIntIDs(1),
+		FieldsData: []*schemapb.FieldData{{
+			FieldId: 100,
+			Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{10}}},
+			}},
+			ValidData: []bool{true},
+		}},
+	}
+	// rB: ValidData absent, Data empty (all null, segcore may omit both)
+	rB := &internalpb.RetrieveResults{
+		Ids: makeTestIntIDs(2),
+		FieldsData: []*schemapb.FieldData{{
+			FieldId: 100,
+			Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{}}},
+			}},
+			ValidData: nil,
+		}},
+	}
+
+	results := []*internalpb.RetrieveResults{rA, rB}
+	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 0}, {resultIdx: 1, rowIdx: 0}}
+
+	merged, err := buildMergedRetrieveResults(results, selectedRows, nullableFields)
+	require.NoError(t, err)
+	// rA valid=true, rB valid=false (empty ValidData → null, NOT true)
+	assert.Equal(t, []bool{true, false}, merged.FieldsData[0].ValidData)
 }

--- a/internal/util/queryutil/pipeline_builders.go
+++ b/internal/util/queryutil/pipeline_builders.go
@@ -54,22 +54,22 @@ func BuildQueryReducePipeline(
 	} else if hasGroupBy {
 		return buildGroupByReducePipeline(name, schema, topK, groupByFieldIDs, aggregates), nil
 	} else if hasOrderBy {
-		return buildOrderByReducePipeline(name, topK, orderByFields, maxOutputSize), nil
+		return buildOrderByReducePipeline(name, schema, topK, orderByFields, maxOutputSize), nil
 	}
-	return buildPlainReducePipeline(name, topK, reduceType, maxOutputSize), nil
+	return buildPlainReducePipeline(name, schema, topK, reduceType, maxOutputSize), nil
 }
 
 // buildPlainReducePipeline: [ReduceByPKTS(topK)] → output
-func buildPlainReducePipeline(name string, topK int64, reduceType reduce.IReduceType, maxOutputSize int64) *Pipeline {
+func buildPlainReducePipeline(name string, schema *schemapb.CollectionSchema, topK int64, reduceType reduce.IReduceType, maxOutputSize int64) *Pipeline {
 	b := NewPipelineBuilder(name)
-	b.Add(OpReduceByPKTS, pin(), pout(), NewReduceByPKWithTimestampOperator(reduceType, maxOutputSize, topK))
+	b.Add(OpReduceByPKTS, pin(), pout(), NewReduceByPKWithTimestampOperator(reduceType, maxOutputSize, topK, schema))
 	return b.Build()
 }
 
 // buildOrderByReducePipeline: [DeduplicatePK] → [OrderByLimit(topK)] → output
-func buildOrderByReducePipeline(name string, topK int64, orderByFields []*orderby.OrderByField, maxOutputSize int64) *Pipeline {
+func buildOrderByReducePipeline(name string, schema *schemapb.CollectionSchema, topK int64, orderByFields []*orderby.OrderByField, maxOutputSize int64) *Pipeline {
 	b := NewPipelineBuilder(name)
-	b.Add(OpDeduplicatePK, pin(), pch(ChannelDeduped), NewDeduplicatePKOperator(maxOutputSize))
+	b.Add(OpDeduplicatePK, pin(), pch(ChannelDeduped), NewDeduplicatePKOperator(maxOutputSize, schema))
 	b.Add(OpOrderByLimit, pch(ChannelDeduped), pout(), NewOrderByLimitOperator(orderByFields, topK))
 	return b.Build()
 }

--- a/internal/util/queryutil/reduce_by_pk_op.go
+++ b/internal/util/queryutil/reduce_by_pk_op.go
@@ -41,13 +41,16 @@ import (
 // (IReduceInOrder/IReduceInOrderForBest) stop early to maintain page boundaries.
 type ReduceByPKOperator struct {
 	reduceType reduce.IReduceType
+	schema     *schemapb.CollectionSchema
 }
 
 // NewSortAndCheckPKOperator creates a reduce-by-PK operator for proxy level.
 // It sorts by PK ASC and returns an error if duplicate PKs are detected
 // across shards (indicating a data integrity issue).
-func NewSortAndCheckPKOperator(reduceType reduce.IReduceType) *ReduceByPKOperator {
-	return &ReduceByPKOperator{reduceType: reduceType}
+// schema is used to determine per-field nullable flags for correct merge semantics.
+// Pass nil to treat all fields as non-nullable (QN-side / schema-unaware callers).
+func NewSortAndCheckPKOperator(reduceType reduce.IReduceType, schema *schemapb.CollectionSchema) *ReduceByPKOperator {
+	return &ReduceByPKOperator{reduceType: reduceType, schema: schema}
 }
 
 func (op *ReduceByPKOperator) Name() string {
@@ -129,8 +132,11 @@ func (op *ReduceByPKOperator) mergeByPK(results []*internalpb.RetrieveResults, h
 		return &internalpb.RetrieveResults{HasMoreResult: hasMoreResult}, nil
 	}
 
+	// Build nullable flag array from schema once, before merging
+	nullableFields := buildNullableFieldMap(op.schema)
+
 	// Build merged result
-	merged, err := buildMergedRetrieveResults(results, selectedRows)
+	merged, err := buildMergedRetrieveResults(results, selectedRows, nullableFields)
 	if err != nil {
 		return nil, err
 	}
@@ -156,16 +162,19 @@ type ReduceByPKWithTimestampOperator struct {
 	reduceType    reduce.IReduceType
 	maxOutputSize int64
 	limit         int64
+	schema        *schemapb.CollectionSchema
 }
 
 // NewReduceByPKWithTimestampOperator creates an operator with timestamp-based deduplication.
 // maxOutputSize: maximum allowed output size in bytes; <= 0 disables the check.
 // limit: maximum rows/elements to keep; <= 0 means unlimited.
-func NewReduceByPKWithTimestampOperator(reduceType reduce.IReduceType, maxOutputSize int64, limit int64) *ReduceByPKWithTimestampOperator {
+// schema is used to determine per-field nullable flags. Pass nil for QN-side callers.
+func NewReduceByPKWithTimestampOperator(reduceType reduce.IReduceType, maxOutputSize int64, limit int64, schema *schemapb.CollectionSchema) *ReduceByPKWithTimestampOperator {
 	return &ReduceByPKWithTimestampOperator{
 		reduceType:    reduceType,
 		maxOutputSize: maxOutputSize,
 		limit:         limit,
+		schema:        schema,
 	}
 }
 
@@ -305,7 +314,10 @@ func (op *ReduceByPKWithTimestampOperator) mergeByPKWithTimestamp(results []*tim
 		origResults[i] = tr.result
 	}
 
-	merged, err := buildMergedRetrieveResults(origResults, selectedRows)
+	// Build nullable flag array from schema once, before merging
+	nullableFields := buildNullableFieldMap(op.schema)
+
+	merged, err := buildMergedRetrieveResults(origResults, selectedRows, nullableFields)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/util/queryutil/reduce_by_pk_op_test.go
+++ b/internal/util/queryutil/reduce_by_pk_op_test.go
@@ -29,12 +29,12 @@ import (
 )
 
 func TestReduceByPKOperator_Name(t *testing.T) {
-	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder)
+	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder, nil)
 	assert.Equal(t, OpReduceByPK, op.Name())
 }
 
 func TestReduceByPKOperator_EmptyInput(t *testing.T) {
-	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder)
+	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder, nil)
 	ctx := context.Background()
 
 	// Test with nil input
@@ -45,7 +45,7 @@ func TestReduceByPKOperator_EmptyInput(t *testing.T) {
 }
 
 func TestReduceByPKOperator_SingleResult(t *testing.T) {
-	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder)
+	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder, nil)
 	ctx := context.Background()
 
 	result := &internalpb.RetrieveResults{
@@ -82,7 +82,7 @@ func TestReduceByPKOperator_SingleResult(t *testing.T) {
 }
 
 func TestReduceByPKOperator_MultipleResults(t *testing.T) {
-	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder)
+	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder, nil)
 	ctx := context.Background()
 
 	result1 := &internalpb.RetrieveResults{
@@ -147,7 +147,7 @@ func TestReduceByPKOperator_MultipleResults(t *testing.T) {
 }
 
 func TestReduceByPKOperator_StringPK(t *testing.T) {
-	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder)
+	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder, nil)
 	ctx := context.Background()
 
 	result1 := &internalpb.RetrieveResults{
@@ -209,7 +209,7 @@ func TestReduceByPKOperator_StringPK(t *testing.T) {
 }
 
 func TestReduceByPKOperator_DuplicatePK(t *testing.T) {
-	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder)
+	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder, nil)
 	ctx := context.Background()
 
 	// Two results with overlapping PKs (2, 3 are duplicated)
@@ -265,7 +265,7 @@ func TestReduceByPKOperator_DuplicatePK(t *testing.T) {
 }
 
 func TestReduceByPKOperator_HasMoreResult(t *testing.T) {
-	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder)
+	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder, nil)
 	ctx := context.Background()
 
 	result1 := &internalpb.RetrieveResults{
@@ -322,7 +322,7 @@ func TestReduceByPKOperator_HasMoreResult(t *testing.T) {
 }
 
 func TestSortAndCheckPKOperator_NoDuplicate(t *testing.T) {
-	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder)
+	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder, nil)
 	ctx := context.Background()
 
 	result1 := &internalpb.RetrieveResults{
@@ -377,7 +377,7 @@ func TestSortAndCheckPKOperator_NoDuplicate(t *testing.T) {
 }
 
 func TestSortAndCheckPKOperator_FailOnDuplicate(t *testing.T) {
-	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder)
+	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder, nil)
 	ctx := context.Background()
 
 	result1 := &internalpb.RetrieveResults{
@@ -431,7 +431,7 @@ func TestSortAndCheckPKOperator_FailOnDuplicate(t *testing.T) {
 
 func TestReduceByPKOperator_DrainResultWithInOrder(t *testing.T) {
 	// IReduceInOrder should stop when one result is drained but has HasMoreResult=true
-	op := NewSortAndCheckPKOperator(reduce.IReduceInOrder)
+	op := NewSortAndCheckPKOperator(reduce.IReduceInOrder, nil)
 	ctx := context.Background()
 
 	result1 := &internalpb.RetrieveResults{
@@ -491,7 +491,7 @@ func TestReduceByPKOperator_DrainResultWithInOrder(t *testing.T) {
 
 func TestReduceByPKOperator_DrainResultWithNoOrder(t *testing.T) {
 	// Use IReduceNoOrder which should NOT stop when one result is drained
-	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder) // Default is IReduceNoOrder
+	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder, nil) // Default is IReduceNoOrder
 	ctx := context.Background()
 
 	result1 := &internalpb.RetrieveResults{
@@ -549,12 +549,12 @@ func TestReduceByPKOperator_DrainResultWithNoOrder(t *testing.T) {
 }
 
 func TestReduceByPKWithTimestampOperator_Name(t *testing.T) {
-	op := NewReduceByPKWithTimestampOperator(reduce.IReduceNoOrder, 0, 0)
+	op := NewReduceByPKWithTimestampOperator(reduce.IReduceNoOrder, 0, 0, nil)
 	assert.Equal(t, OpReduceByPKTS, op.Name())
 }
 
 func TestReduceByPKWithTimestampOperator_DuplicatePKWithHigherTimestamp(t *testing.T) {
-	op := NewReduceByPKWithTimestampOperator(reduce.IReduceNoOrder, 0, 0)
+	op := NewReduceByPKWithTimestampOperator(reduce.IReduceNoOrder, 0, 0, nil)
 	ctx := context.Background()
 
 	const timestampFieldID int64 = 1 // common.TimeStampField
@@ -646,7 +646,7 @@ func TestReduceByPKWithTimestampOperator_DuplicatePKWithHigherTimestamp(t *testi
 }
 
 func TestReduceByPKWithTimestampOperator_NoTimestampField(t *testing.T) {
-	op := NewReduceByPKWithTimestampOperator(reduce.IReduceNoOrder, 0, 0)
+	op := NewReduceByPKWithTimestampOperator(reduce.IReduceNoOrder, 0, 0, nil)
 	ctx := context.Background()
 
 	// Results without timestamp field - should still work (fallback to first seen)
@@ -743,7 +743,7 @@ func makeElementLevelResult(pks []int64, timestamps []int64, elemIndices [][]int
 }
 
 func TestReduceByPKWithTimestamp_ElementLevel_MergeAndDedup(t *testing.T) {
-	op := NewReduceByPKWithTimestampOperator(reduce.IReduceNoOrder, 0, 0)
+	op := NewReduceByPKWithTimestampOperator(reduce.IReduceNoOrder, 0, 0, nil)
 	ctx := context.Background()
 
 	// r1: pk=1 (ts=100, elements [0,1]), pk=3 (ts=100, elements [2])
@@ -777,7 +777,7 @@ func TestReduceByPKWithTimestamp_ElementLevel_MergeAndDedup(t *testing.T) {
 }
 
 func TestReduceByPKOperator_ElementLevel_Propagation(t *testing.T) {
-	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder)
+	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder, nil)
 	ctx := context.Background()
 
 	// Two element-level results with no overlapping PKs
@@ -859,7 +859,7 @@ func TestReduceByPKWithTimestampOperator_MaxOutputSize_ExactlyAtLimit(t *testing
 	const rowCount = 3
 	const exactLimit int64 = rowSize * rowCount // 24 bytes
 
-	op := NewReduceByPKWithTimestampOperator(reduce.IReduceNoOrder, exactLimit, 0)
+	op := NewReduceByPKWithTimestampOperator(reduce.IReduceNoOrder, exactLimit, 0, nil)
 	ctx := context.Background()
 
 	r := &internalpb.RetrieveResults{
@@ -891,7 +891,7 @@ func TestReduceByPKWithTimestampOperator_MaxOutputSize_Exceeded(t *testing.T) {
 	const rowCount = 3
 	const limitOneByte int64 = rowSize*rowCount - 1 // 23 bytes
 
-	op := NewReduceByPKWithTimestampOperator(reduce.IReduceNoOrder, limitOneByte, 0)
+	op := NewReduceByPKWithTimestampOperator(reduce.IReduceNoOrder, limitOneByte, 0, nil)
 	ctx := context.Background()
 
 	r := &internalpb.RetrieveResults{


### PR DESCRIPTION
## Summary

- Fix panic in `buildMergedVectorField` for nullable sparse vector fields when segcore returns empty ValidData + empty Contents (e.g. index not ready path via `fill_with_empty`)
- Fix incorrect `validData[i]=true` fallback in `buildMergedFieldData` when ValidData is absent for a nullable field — correct semantics: absent ValidData = all null
- Use `map[fieldID]bool` built from schema as the authoritative source of nullability, instead of inferring from ValidData presence in result data
- Pass schema through to all reduce operators (ReduceByPKTS, DeduplicatePK, ReduceByPK, ConcatAndCheckPK) so nullable fields are handled correctly at both QN and proxy level
- Add bounds checks to `buildMergedScalarField` for all scalar types to guard against nullable fields with empty Data arrays

## Test plan

- [ ] Run `go test ./internal/util/queryutil/...` — all existing + 5 new nullable test cases pass
- [ ] New tests cover: nullable sparse vector with empty ValidData (the panic scenario), multiple null rows from empty result, all-null with explicit ValidData, mixed compact mapping, nullable scalar with empty ValidData treated as null

issue: #48700

🤖 Generated with [Claude Code](https://claude.com/claude-code)