### PR TITLE
enhance: prioritize index raw data over field data in bulk_subscript retrieve path

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedBinlogIndexTest.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedBinlogIndexTest.cpp
@@ -832,6 +832,18 @@ TEST_P(BinlogIndexTest, AccuracyWithLoadFieldData) {
 
             indexing->BuildWithDataset(raw_dataset, build_conf);
 
+            // IVF-series indexes need a Serialize/Load round-trip before
+            // GetVectorByIds works (faiss DirectMap is set up on load).
+            {
+                auto vec_indexing_for_serde =
+                    dynamic_cast<milvus::index::VectorIndex*>(indexing.get());
+                ASSERT_NE(vec_indexing_for_serde, nullptr);
+                knowhere::Json load_conf{
+                    {knowhere::meta::METRIC_TYPE, metric_type}};
+                auto binary_set = indexing->Serialize(load_conf);
+                vec_indexing_for_serde->Load(binary_set, load_conf);
+            }
+
             if (nullable) {
                 auto vec_indexing =
                     dynamic_cast<milvus::index::VectorIndex*>(indexing.get());
@@ -1107,6 +1119,18 @@ TEST_P(BinlogIndexTest, AccuracyWithMapFieldData) {
 
             indexing->BuildWithDataset(raw_dataset, build_conf);
 
+            // IVF-series indexes need a Serialize/Load round-trip before
+            // GetVectorByIds works (faiss DirectMap is set up on load).
+            {
+                auto vec_indexing_for_serde =
+                    dynamic_cast<milvus::index::VectorIndex*>(indexing.get());
+                ASSERT_NE(vec_indexing_for_serde, nullptr);
+                knowhere::Json load_conf{
+                    {knowhere::meta::METRIC_TYPE, metric_type}};
+                auto binary_set = indexing->Serialize(load_conf);
+                vec_indexing_for_serde->Load(binary_set, load_conf);
+            }
+
             if (nullable) {
                 auto vec_indexing =
                     dynamic_cast<milvus::index::VectorIndex*>(indexing.get());
@@ -1241,6 +1265,18 @@ TEST_P(BinlogIndexTest, DisableInterimIndex) {
                            {knowhere::indexparam::NLIST, "64"}};
 
         indexing->BuildWithDataset(raw_dataset, build_conf);
+
+        // IVF-series indexes need a Serialize/Load round-trip before
+        // GetVectorByIds works (faiss DirectMap is set up on load).
+        {
+            auto vec_indexing_for_serde =
+                dynamic_cast<milvus::index::VectorIndex*>(indexing.get());
+            ASSERT_NE(vec_indexing_for_serde, nullptr);
+            knowhere::Json load_conf{
+                {knowhere::meta::METRIC_TYPE, metric_type}};
+            auto binary_set = indexing->Serialize(load_conf);
+            vec_indexing_for_serde->Load(binary_set, load_conf);
+        }
 
         if (nullable) {
             auto vec_indexing =

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -2575,7 +2575,7 @@ ChunkedSegmentSealedImpl::bulk_subscript(milvus::OpContext* op_ctx,
         auto scalar_indexes = PinIndex(op_ctx, field_id);
         if (!scalar_indexes.empty()) {
             pin_scalar_index_ptr = std::move(scalar_indexes[0]);
-            if (HasRawData(field_id.get())) {
+            if (IndexHasRawData(field_id)) {
                 return ReverseDataFromIndex(
                     pin_scalar_index_ptr.get(), seg_offsets, count, field_meta);
             }
@@ -2591,9 +2591,7 @@ ChunkedSegmentSealedImpl::bulk_subscript(milvus::OpContext* op_ctx,
 
     std::unique_ptr<DataArray> vector{nullptr};
     // Try index first: if vector index exists and has raw data, read from index
-    bool has_vector_index = get_bit(index_ready_bitset_, field_id) ||
-                            get_bit(binlog_index_bitset_, field_id);
-    if (has_vector_index && HasRawData(field_id.get())) {
+    if (IndexHasRawData(field_id)) {
         vector = get_vector(op_ctx, field_id, seg_offsets, count);
     } else {
         // Fallback to field data
@@ -2724,6 +2722,16 @@ ChunkedSegmentSealedImpl::HasRawData(int64_t field_id) const {
         }
     }
     return true;
+}
+
+bool
+ChunkedSegmentSealedImpl::IndexHasRawData(FieldId field_id) const {
+    std::shared_lock lck(mutex_);
+    auto it = index_has_raw_data_.find(field_id);
+    if (it == index_has_raw_data_.end()) {
+        return false;
+    }
+    return it->second;
 }
 
 DataType

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -2568,37 +2568,36 @@ ChunkedSegmentSealedImpl::bulk_subscript(milvus::OpContext* op_ctx,
         return fill_with_empty(field_id, count);
     }
 
-    // hold field shared_ptr here, preventing field got destroyed
-    auto [field, exist] = GetFieldDataIfExist(field_id);
-    if (exist) {
-        Assert(get_bit(field_data_ready_bitset_, field_id));
-        return get_raw_data(op_ctx, field_id, field_meta, seg_offsets, count);
-    }
-
-    PinWrapper<const index::IndexBase*> pin_scalar_index_ptr;
-    auto scalar_indexes = PinIndex(op_ctx, field_id);
-    if (!scalar_indexes.empty()) {
-        pin_scalar_index_ptr = std::move(scalar_indexes[0]);
-    }
-
-    auto index_has_raw = HasRawData(field_id.get());
-
     if (!IsVectorDataType(field_meta.get_data_type())) {
-        // if field has load scalar index, reverse raw data from index
-        if (index_has_raw) {
-            return ReverseDataFromIndex(
-                pin_scalar_index_ptr.get(), seg_offsets, count, field_meta);
+        // === Scalar field ===
+        // Try index first: if scalar index exists and has raw data, read from index
+        PinWrapper<const index::IndexBase*> pin_scalar_index_ptr;
+        auto scalar_indexes = PinIndex(op_ctx, field_id);
+        if (!scalar_indexes.empty()) {
+            pin_scalar_index_ptr = std::move(scalar_indexes[0]);
+            if (HasRawData(field_id.get())) {
+                return ReverseDataFromIndex(
+                    pin_scalar_index_ptr.get(), seg_offsets, count, field_meta);
+            }
         }
+        // Fallback to field data
+        auto [field, exist] = GetFieldDataIfExist(field_id);
         return get_raw_data(op_ctx, field_id, field_meta, seg_offsets, count);
     }
 
+    // === Vector field ===
     std::chrono::high_resolution_clock::time_point get_vector_start =
         std::chrono::high_resolution_clock::now();
 
     std::unique_ptr<DataArray> vector{nullptr};
-    if (index_has_raw) {
+    // Try index first: if vector index exists and has raw data, read from index
+    bool has_vector_index = get_bit(index_ready_bitset_, field_id) ||
+                            get_bit(binlog_index_bitset_, field_id);
+    if (has_vector_index && HasRawData(field_id.get())) {
         vector = get_vector(op_ctx, field_id, seg_offsets, count);
     } else {
+        // Fallback to field data
+        auto [field, exist] = GetFieldDataIfExist(field_id);
         vector = get_raw_data(op_ctx, field_id, field_meta, seg_offsets, count);
     }
 

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -160,6 +160,11 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     bool
     HasRawData(int64_t field_id) const override;
 
+    // Returns true only if the index itself contains raw data,
+    // without considering whether field data is loaded.
+    bool
+    IndexHasRawData(FieldId field_id) const;
+
     DataType
     GetFieldDataType(FieldId fieldId) const override;
 


### PR DESCRIPTION
Related to #48384

When both index raw data and field data are available, prefer reading from the index to reduce memory pressure from loaded field data.