### PR TITLE
fix: [cp2.6]fix force promote broadcast duplicate call and missing retry

### DIFF
--- a/internal/streamingcoord/server/broadcaster/ack_callback_scheduler.go
+++ b/internal/streamingcoord/server/broadcaster/ack_callback_scheduler.go
@@ -2,6 +2,7 @@ package broadcaster
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"sync"
 	"time"
@@ -183,10 +184,14 @@ func (s *ackCallbackScheduler) doForcePromoteFixIncompleteBroadcasts(bt *broadca
 	logger.Info("completed fixing incomplete broadcasts for force promote")
 
 	// Acquire resource key lock before executing ack callback.
-	g, err := s.acquireResourceKeyLockUntilDone(ctx, bt.Header().ResourceKeys.Collect()...)
+	// Force promote runs on a secondary cluster. By step 3, all incomplete tasks have reached
+	// tombstone (their ack callbacks finished, resource key locks released), and no new broadcasts
+	// can arrive (cluster is still secondary). So rkLocker has zero contenders — FastLock always succeeds.
+	s.rkLockerMu.Lock()
+	g, err := s.rkLocker.FastLock(bt.Header().ResourceKeys.Collect()...)
+	s.rkLockerMu.Unlock()
 	if err != nil {
-		logger.Warn("force promote acquire lock aborted", zap.Error(err))
-		return
+		panic(fmt.Sprintf("unreachable: FastLock failed during force promote with zero contenders: %v", err))
 	}
 	s.doAckCallback(bt, g)
 }
@@ -211,6 +216,8 @@ func (s *ackCallbackScheduler) fixIncompleteBroadcastsForForcePromote(ctx contex
 		zap.Int("incompleteTasks", len(incompleteTasks)))
 
 	// Mark AlterReplicateConfig tasks with ignore=true (to prevent old config overwriting force promote config)
+	// MarkIgnore is a memory-only operation. It only runs on tasks where IsAlterReplicateConfigMessage() == true,
+	// so the parse inside MarkIgnore cannot fail — panic if it does.
 	for _, task := range incompleteTasks {
 		if !task.IsAlterReplicateConfigMessage() {
 			continue
@@ -218,10 +225,8 @@ func (s *ackCallbackScheduler) fixIncompleteBroadcastsForForcePromote(ctx contex
 		s.Logger().Info("Marking AlterReplicateConfig task with ignore=true",
 			zap.Uint64("broadcastID", task.Header().BroadcastID))
 
-		if err := s.retryUntilDone(ctx, func() error {
-			return task.MarkIgnoreAndSave(ctx)
-		}); err != nil {
-			return errors.Wrapf(err, "failed to mark task %d with ignore", task.Header().BroadcastID)
+		if err := task.MarkIgnore(); err != nil {
+			panic(fmt.Sprintf("unreachable: MarkIgnore failed on AlterReplicateConfig task %d: %v", task.Header().BroadcastID, err))
 		}
 	}
 
@@ -291,28 +296,8 @@ func (s *ackCallbackScheduler) doAckCallback(bt *broadcastTask, g *lockGuards) (
 	return nil
 }
 
-// acquireResourceKeyLockUntilDone acquires the resource key lock with infinite retry.
-func (s *ackCallbackScheduler) acquireResourceKeyLockUntilDone(ctx context.Context, resourceKeys ...message.ResourceKey) (*lockGuards, error) {
-	var g *lockGuards
-	err := s.retryUntilDone(ctx, func() error {
-		s.rkLockerMu.Lock()
-		defer s.rkLockerMu.Unlock()
-		var err error
-		g, err = s.rkLocker.FastLock(resourceKeys...)
-		return err
-	})
-	return g, err
-}
-
 // callMessageAckCallbackUntilDone calls the message ack callback until done.
 func (s *ackCallbackScheduler) callMessageAckCallbackUntilDone(ctx context.Context, msg message.BroadcastMutableMessage, result map[string]*message.AppendResult) error {
-	return s.retryUntilDone(ctx, func() error {
-		return registry.CallMessageAckCallback(ctx, msg, result)
-	})
-}
-
-// retryUntilDone retries fn with exponential backoff until it succeeds or ctx is canceled.
-func (s *ackCallbackScheduler) retryUntilDone(ctx context.Context, fn func() error) error {
 	backoff := backoff.NewExponentialBackOff()
 	backoff.InitialInterval = 10 * time.Millisecond
 	backoff.MaxInterval = 10 * time.Second
@@ -320,15 +305,15 @@ func (s *ackCallbackScheduler) retryUntilDone(ctx context.Context, fn func() err
 	backoff.Reset()
 
 	for {
-		err := fn()
+		err := registry.CallMessageAckCallback(ctx, msg, result)
 		if err == nil {
 			return nil
 		}
 		nextInterval := backoff.NextBackOff()
-		s.Logger().Warn("operation failed, retrying...",
+		s.Logger().Warn("failed to call message ack callback, wait for retry...",
+			log.FieldMessage(msg),
 			zap.Duration("nextInterval", nextInterval),
-			zap.Error(err),
-			zap.Stack("stack"))
+			zap.Error(err))
 		select {
 		case <-ctx.Done():
 			return ctx.Err()

--- a/internal/streamingcoord/server/broadcaster/ack_callback_scheduler.go
+++ b/internal/streamingcoord/server/broadcaster/ack_callback_scheduler.go
@@ -65,6 +65,15 @@ func (s *ackCallbackScheduler) Initialize(tasks []*broadcastTask, tombstoneIDs [
 	// when initializing, the tasks in recovery info may be out of order, so we need to sort them by the broadcastID.
 	sortByControlChannelTimeTick(tasks)
 	s.tombstoneScheduler.Initialize(bm, tombstoneIDs)
+	// Mark all tasks as already joined the ack callback scheduler to prevent duplicate scheduling.
+	// Without this, when fixIncompleteBroadcastsForForcePromote calls FastAck → ack on a recovered task,
+	// ack() would re-add the task to the scheduler (since joinAckCallbackScheduled was false),
+	// causing two concurrent doAckCallback goroutines on the same task (data race on taskMetricsGuard).
+	for _, task := range tasks {
+		task.mu.Lock()
+		task.joinAckCallbackScheduled = true
+		task.mu.Unlock()
+	}
 	s.pendingAckedTasks = tasks
 	go s.background()
 }

--- a/internal/streamingcoord/server/broadcaster/ack_callback_scheduler.go
+++ b/internal/streamingcoord/server/broadcaster/ack_callback_scheduler.go
@@ -276,12 +276,23 @@ func (s *ackCallbackScheduler) fixIncompleteBroadcastsForForcePromote(ctx contex
 		supplementCount++
 	}
 
-	s.Logger().Info("Completed fixing incomplete broadcasts for force promote",
+	s.Logger().Info("Supplemented incomplete broadcast messages",
 		zap.Int("supplementCount", supplementCount),
 		zap.Int("failureCount", failureCount),
 		zap.Int("totalPending", len(pendingMessages)))
 
-	return lastResultErr
+	if lastResultErr != nil {
+		return lastResultErr
+	}
+
+	// Wait for all incomplete tasks to be fully acked before returning.
+	for _, task := range incompleteTasks {
+		if err := task.BlockUntilAllAck(ctx); err != nil {
+			return errors.Wrapf(err, "waiting for incomplete task %d to be fully acked", task.Header().BroadcastID)
+		}
+	}
+	s.Logger().Info("All incomplete broadcasts fully acked")
+	return nil
 }
 
 // doAckCallback executes the ack callback.

--- a/internal/streamingcoord/server/broadcaster/ack_callback_scheduler.go
+++ b/internal/streamingcoord/server/broadcaster/ack_callback_scheduler.go
@@ -135,9 +135,11 @@ func (s *ackCallbackScheduler) triggerAckCallback() {
 	pendingTasks := make([]*broadcastTask, 0, len(s.pendingAckedTasks))
 	for _, task := range s.pendingAckedTasks {
 		if task.IsForcePromoteMessage() {
-			// Force promote: fix incomplete broadcasts in background (BlockUntilAllAck → fix).
-			// The task still goes through normal FastLock → doAckCallback below.
+			// Force promote: handle fix + ack callback entirely in background goroutine.
+			// No FastLock needed upfront — fix doesn't require resource key lock,
+			// and the goroutine acquires the lock itself before running ack callback.
 			go s.doForcePromoteFixIncompleteBroadcasts(task)
+			continue
 		}
 
 		g, err := s.rkLocker.FastLock(task.Header().ResourceKeys.Collect()...)
@@ -147,38 +149,41 @@ func (s *ackCallbackScheduler) triggerAckCallback() {
 			continue
 		}
 
-		if task.IsForcePromoteMessage() {
-			// Force promote: fix incomplete broadcasts, then run normal ack callback.
-			// Launch goroutine only after FastLock succeeds to prevent duplicate processing.
-			// doAckCallback handles g.Unlock() internally via its defer.
-			go func() {
-				s.doForcePromoteFixIncompleteBroadcasts(task)
-				s.doAckCallback(task, g)
-			}()
-			continue
-		}
-
 		// Execute the ack callback in background.
 		go s.doAckCallback(task, g)
 	}
 	s.pendingAckedTasks = pendingTasks
 }
 
-// doForcePromoteFixIncompleteBroadcasts waits for all acks, then fixes incomplete broadcasts.
-// After this returns, the caller must invoke doAckCallback to close the done channel and unblock the RPC.
+// doForcePromoteFixIncompleteBroadcasts handles the full force promote lifecycle:
+// 1. Wait for all vchannels to ack the force promote message (replicate messages are fenced after this)
+// 2. Fix incomplete broadcasts with infinite retry (supplement messages to remaining vchannels)
+// 3. Acquire resource key lock and execute ack callback (close done channel → unblock RPC)
 func (s *ackCallbackScheduler) doForcePromoteFixIncompleteBroadcasts(bt *broadcastTask) {
 	logger := s.Logger().With(zap.Uint64("broadcastID", bt.Header().BroadcastID))
+	ctx := s.notifier.Context()
 
-	if err := bt.BlockUntilAllAck(s.notifier.Context()); err != nil {
+	if err := bt.BlockUntilAllAck(ctx); err != nil {
 		logger.Warn("force promote BlockUntilAllAck failed", zap.Error(err))
 		return
 	}
 
-	if err := s.fixIncompleteBroadcastsForForcePromote(s.notifier.Context()); err != nil {
-		logger.Warn("failed to fix incomplete broadcasts for force promote", zap.Error(err))
+	// Fix incomplete broadcasts with infinite retry until success or context cancellation.
+	if err := s.retryUntilDone(ctx, func() error {
+		return s.fixIncompleteBroadcastsForForcePromote(ctx)
+	}); err != nil {
+		logger.Warn("force promote fix incomplete broadcasts aborted", zap.Error(err))
 		return
 	}
 	logger.Info("completed fixing incomplete broadcasts for force promote")
+
+	// Acquire resource key lock before executing ack callback.
+	g, err := s.acquireResourceKeyLockUntilDone(ctx, bt.Header().ResourceKeys.Collect()...)
+	if err != nil {
+		logger.Warn("force promote acquire lock aborted", zap.Error(err))
+		return
+	}
+	s.doAckCallback(bt, g)
 }
 
 // fixIncompleteBroadcastsForForcePromote fixes incomplete broadcasts for force promote.
@@ -325,8 +330,28 @@ func (s *ackCallbackScheduler) doAckCallback(bt *broadcastTask, g *lockGuards) (
 	return nil
 }
 
+// acquireResourceKeyLockUntilDone acquires the resource key lock with infinite retry.
+func (s *ackCallbackScheduler) acquireResourceKeyLockUntilDone(ctx context.Context, resourceKeys ...message.ResourceKey) (*lockGuards, error) {
+	var g *lockGuards
+	err := s.retryUntilDone(ctx, func() error {
+		s.rkLockerMu.Lock()
+		defer s.rkLockerMu.Unlock()
+		var err error
+		g, err = s.rkLocker.FastLock(resourceKeys...)
+		return err
+	})
+	return g, err
+}
+
 // callMessageAckCallbackUntilDone calls the message ack callback until done.
 func (s *ackCallbackScheduler) callMessageAckCallbackUntilDone(ctx context.Context, msg message.BroadcastMutableMessage, result map[string]*message.AppendResult) error {
+	return s.retryUntilDone(ctx, func() error {
+		return registry.CallMessageAckCallback(ctx, msg, result)
+	})
+}
+
+// retryUntilDone retries fn with exponential backoff until it succeeds or ctx is cancelled.
+func (s *ackCallbackScheduler) retryUntilDone(ctx context.Context, fn func() error) error {
 	backoff := backoff.NewExponentialBackOff()
 	backoff.InitialInterval = 10 * time.Millisecond
 	backoff.MaxInterval = 10 * time.Second
@@ -334,13 +359,12 @@ func (s *ackCallbackScheduler) callMessageAckCallbackUntilDone(ctx context.Conte
 	backoff.Reset()
 
 	for {
-		err := registry.CallMessageAckCallback(ctx, msg, result)
+		err := fn()
 		if err == nil {
 			return nil
 		}
 		nextInterval := backoff.NextBackOff()
-		s.Logger().Warn("failed to call message ack callback, wait for retry...",
-			log.FieldMessage(msg),
+		s.Logger().Warn("operation failed, retrying...",
 			zap.Duration("nextInterval", nextInterval),
 			zap.Error(err))
 		select {

--- a/internal/streamingcoord/server/broadcaster/ack_callback_scheduler.go
+++ b/internal/streamingcoord/server/broadcaster/ack_callback_scheduler.go
@@ -361,7 +361,7 @@ func (s *ackCallbackScheduler) callMessageAckCallbackUntilDone(ctx context.Conte
 	})
 }
 
-// retryUntilDone retries fn with exponential backoff until it succeeds or ctx is cancelled.
+// retryUntilDone retries fn with exponential backoff until it succeeds or ctx is canceled.
 func (s *ackCallbackScheduler) retryUntilDone(ctx context.Context, fn func() error) error {
 	backoff := backoff.NewExponentialBackOff()
 	backoff.InitialInterval = 10 * time.Millisecond

--- a/internal/streamingcoord/server/broadcaster/ack_callback_scheduler.go
+++ b/internal/streamingcoord/server/broadcaster/ack_callback_scheduler.go
@@ -10,7 +10,6 @@ import (
 	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
-	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster/registry"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
@@ -157,7 +156,7 @@ func (s *ackCallbackScheduler) triggerAckCallback() {
 
 // doForcePromoteFixIncompleteBroadcasts handles the full force promote lifecycle:
 // 1. Wait for all vchannels to ack the force promote message (replicate messages are fenced after this)
-// 2. Fix incomplete broadcasts with infinite retry (supplement messages to remaining vchannels)
+// 2. Fix incomplete broadcasts by delegating to broadcastScheduler (WAL append + ack + callback + tombstone)
 // 3. Acquire resource key lock and execute ack callback (close done channel → unblock RPC)
 func (s *ackCallbackScheduler) doForcePromoteFixIncompleteBroadcasts(bt *broadcastTask) {
 	logger := s.Logger().With(zap.Uint64("broadcastID", bt.Header().BroadcastID))
@@ -168,10 +167,7 @@ func (s *ackCallbackScheduler) doForcePromoteFixIncompleteBroadcasts(bt *broadca
 		return
 	}
 
-	// Fix incomplete broadcasts with infinite retry until success or context cancellation.
-	if err := s.retryUntilDone(ctx, func() error {
-		return s.fixIncompleteBroadcastsForForcePromote(ctx)
-	}); err != nil {
+	if err := s.fixIncompleteBroadcastsForForcePromote(ctx); err != nil {
 		logger.Warn("force promote fix incomplete broadcasts aborted", zap.Error(err))
 		return
 	}
@@ -187,8 +183,8 @@ func (s *ackCallbackScheduler) doForcePromoteFixIncompleteBroadcasts(bt *broadca
 }
 
 // fixIncompleteBroadcastsForForcePromote fixes incomplete broadcasts for force promote.
-// It marks incomplete AlterReplicateConfig messages with ignore=true before supplementing
-// all incomplete messages to remaining vchannels.
+// It marks incomplete AlterReplicateConfig messages with ignore=true, then delegates
+// all incomplete tasks to broadcastScheduler for WAL append, ack, callback, and tombstone.
 func (s *ackCallbackScheduler) fixIncompleteBroadcastsForForcePromote(ctx context.Context) error {
 	incompleteTasks := s.bm.getIncompleteBroadcastTasks()
 
@@ -197,101 +193,46 @@ func (s *ackCallbackScheduler) fixIncompleteBroadcastsForForcePromote(ctx contex
 		return incompleteTasks[i].Header().BroadcastID < incompleteTasks[j].Header().BroadcastID
 	})
 
-	// Separate AlterReplicateConfig from other broadcast messages
-	var alterReplicateConfigTasks []*broadcastTask
-	var otherBroadcastTasks []*broadcastTask
-	for _, task := range incompleteTasks {
-		if task.IsAlterReplicateConfigMessage() {
-			alterReplicateConfigTasks = append(alterReplicateConfigTasks, task)
-		} else {
-			otherBroadcastTasks = append(otherBroadcastTasks, task)
-		}
-	}
-
-	totalTasks := len(alterReplicateConfigTasks) + len(otherBroadcastTasks)
-	if totalTasks == 0 {
+	if len(incompleteTasks) == 0 {
 		s.Logger().Info("No incomplete broadcasts to fix for force promote")
 		return nil
 	}
 
 	s.Logger().Info("Fixing incomplete broadcasts for force promote",
-		zap.Int("alterReplicateConfigTasks", len(alterReplicateConfigTasks)),
-		zap.Int("otherBroadcastTasks", len(otherBroadcastTasks)))
+		zap.Int("incompleteTasks", len(incompleteTasks)))
 
 	// Mark AlterReplicateConfig tasks with ignore=true (to prevent old config overwriting force promote config)
-	for _, task := range alterReplicateConfigTasks {
+	for _, task := range incompleteTasks {
+		if !task.IsAlterReplicateConfigMessage() {
+			continue
+		}
 		s.Logger().Info("Marking AlterReplicateConfig task with ignore=true",
 			zap.Uint64("broadcastID", task.Header().BroadcastID))
 
-		if err := task.MarkIgnoreAndSave(ctx); err != nil {
-			s.Logger().Error("Failed to mark task with ignore",
-				zap.Uint64("broadcastID", task.Header().BroadcastID),
-				zap.Error(err))
+		if err := s.retryUntilDone(ctx, func() error {
+			return task.MarkIgnoreAndSave(ctx)
+		}); err != nil {
 			return errors.Wrapf(err, "failed to mark task %d with ignore", task.Header().BroadcastID)
 		}
 	}
 
-	// Collect pending messages from ALL incomplete tasks for supplementation
-	var pendingMessages []message.MutableMessage
-	for _, task := range alterReplicateConfigTasks {
-		msgs := task.PendingBroadcastMessages()
-		if len(msgs) > 0 {
-			s.Logger().Info("Supplementing AlterReplicateConfig messages to remaining vchannels",
-				zap.Uint64("broadcastID", task.Header().BroadcastID),
-				zap.Int("pendingVChannels", len(msgs)))
-			pendingMessages = append(pendingMessages, msgs...)
-		}
-	}
-	for _, task := range otherBroadcastTasks {
-		msgs := task.PendingBroadcastMessages()
-		if len(msgs) > 0 {
-			s.Logger().Info("Supplementing broadcast messages to remaining vchannels",
-				zap.Uint64("broadcastID", task.Header().BroadcastID),
-				zap.String("messageType", task.msg.MessageType().String()),
-				zap.Int("pendingVChannels", len(msgs)))
-			pendingMessages = append(pendingMessages, msgs...)
-		}
-	}
-
-	if len(pendingMessages) == 0 {
-		s.Logger().Info("No pending messages to supplement")
-		return nil
-	}
-
-	// Append pending messages to their respective vchannels
-	appendResults := streaming.WAL().AppendMessages(ctx, pendingMessages...)
-
-	var lastResultErr error
-	supplementCount := 0
-	failureCount := 0
-	for i, result := range appendResults.Responses {
-		if result.Error != nil {
-			s.Logger().Warn("Failed to supplement message",
-				zap.String("vchannel", pendingMessages[i].VChannel()),
-				zap.Error(result.Error))
-			failureCount++
-			lastResultErr = result.Error
-			continue
-		}
-		supplementCount++
-	}
-
-	s.Logger().Info("Supplemented incomplete broadcast messages",
-		zap.Int("supplementCount", supplementCount),
-		zap.Int("failureCount", failureCount),
-		zap.Int("totalPending", len(pendingMessages)))
-
-	if lastResultErr != nil {
-		return lastResultErr
-	}
-
-	// Wait for all incomplete tasks to be fully acked before returning.
+	// Delegate all incomplete tasks to broadcastScheduler for supplement.
+	// broadcastScheduler handles WAL append with retry; AddTask blocks until the task
+	// reaches tombstone (broadcast → ack → callback → tombstone).
 	for _, task := range incompleteTasks {
-		if err := task.BlockUntilAllAck(ctx); err != nil {
-			return errors.Wrapf(err, "waiting for incomplete task %d to be fully acked", task.Header().BroadcastID)
+		pending := newPendingBroadcastTask(task)
+		if pending == nil {
+			continue // no pending messages for this task
+		}
+		s.Logger().Info("Delegating incomplete task to broadcastScheduler",
+			zap.Uint64("broadcastID", task.Header().BroadcastID),
+			zap.String("messageType", task.msg.MessageType().String()),
+			zap.Int("pendingVChannels", len(pending.pendingMessages)))
+		if _, err := s.bm.broadcastScheduler.AddTask(ctx, pending); err != nil {
+			return errors.Wrapf(err, "failed to supplement task %d via broadcastScheduler", task.Header().BroadcastID)
 		}
 	}
-	s.Logger().Info("All incomplete broadcasts fully acked")
+	s.Logger().Info("All incomplete broadcasts fixed and tombstoned")
 	return nil
 }
 
@@ -377,7 +318,8 @@ func (s *ackCallbackScheduler) retryUntilDone(ctx context.Context, fn func() err
 		nextInterval := backoff.NextBackOff()
 		s.Logger().Warn("operation failed, retrying...",
 			zap.Duration("nextInterval", nextInterval),
-			zap.Error(err))
+			zap.Error(err),
+			zap.Stack("stack"))
 		select {
 		case <-ctx.Done():
 			return ctx.Err()

--- a/internal/streamingcoord/server/broadcaster/broadcast_task.go
+++ b/internal/streamingcoord/server/broadcaster/broadcast_task.go
@@ -218,9 +218,12 @@ func (b *broadcastTask) IsForcePromoteMessage() bool {
 	return alterMsg.Header().ForcePromote
 }
 
-// MarkIgnoreAndSave marks the task's message header with ignore=true and saves to catalog.
+// MarkIgnore marks the task's message header with ignore=true in memory.
 // This is used for force promote to mark incomplete AlterReplicateConfig messages as ignored.
-func (b *broadcastTask) MarkIgnoreAndSave(ctx context.Context) error {
+// This is a memory-only operation — no etcd persistence needed because:
+// 1. The ignore flag only needs to take effect during the subsequent ack callback in the same process.
+// 2. If the coordinator crashes, force promote must be re-executed anyway.
+func (b *broadcastTask) MarkIgnore() error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -240,13 +243,10 @@ func (b *broadcastTask) MarkIgnoreAndSave(ctx context.Context) error {
 	// The OverwriteHeader call above modified the underlying messageImpl properties
 	updatedMsg := message.NewBroadcastMutableMessageBeforeAppend(b.task.Message.Payload, b.task.Message.Properties)
 
-	// Update the task's message proto
+	// Update the task's in-memory message
 	b.task.Message = updatedMsg.IntoMessageProto()
 	b.msg = updatedMsg
-	b.dirty = true
-
-	// Save to catalog
-	return b.saveTaskIfDirty(ctx, b.Logger())
+	return nil
 }
 
 // InitializeRecovery initializes the recovery of the broadcast task.

--- a/internal/streamingcoord/server/broadcaster/broadcaster_test.go
+++ b/internal/streamingcoord/server/broadcaster/broadcaster_test.go
@@ -733,7 +733,18 @@ func TestFixIncompleteBroadcastsForForcePromote(t *testing.T) {
 		f.Set(rc)
 		resource.InitForTest(resource.OptStreamingCatalog(meta), resource.OptMixCoordClient(f))
 
-		// Set up WAL mock for AppendMessages
+		metrics := newBroadcasterMetrics()
+		ackScheduler := newAckCallbackScheduler(log.With())
+
+		// Create an incomplete AlterReplicateConfig task (v2 not acked)
+		alterMsg := createAlterReplicateConfigBroadcastMsg([]string{"v1", "v2"}, false).WithBroadcastID(100)
+		alterProto := createNewWaitAckBroadcastTaskFromMessage(alterMsg,
+			streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_PENDING,
+			[]byte{0x01, 0x00}) // v1 acked, v2 not
+		alterTask := newBroadcastTaskFromProto(alterProto, metrics, ackScheduler)
+		alterTask.SetLogger(log.With())
+
+		// Set up WAL mock: AppendMessages succeeds and simulates ack on the task
 		mw := mock_streaming.NewMockWALAccesser(t)
 		appendF := func(ctx context.Context, msgs ...message.MutableMessage) types.AppendResponses {
 			resps := types.AppendResponses{Responses: make([]types.AppendResponse, len(msgs))}
@@ -745,23 +756,16 @@ func TestFixIncompleteBroadcastsForForcePromote(t *testing.T) {
 					},
 				}
 			}
+			// Simulate streaming node acking the remaining vchannel
+			alterTask.mu.Lock()
+			alterTask.task.AckedVchannelBitmap = []byte{0x01, 0x01}
+			alterTask.closeAllAcked()
+			alterTask.mu.Unlock()
 			return resps
 		}
 		mw.EXPECT().AppendMessages(mock.Anything, mock.Anything).RunAndReturn(appendF).Maybe()
 		mw.EXPECT().AppendMessages(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(appendF).Maybe()
-		mw.EXPECT().AppendMessages(mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(appendF).Maybe()
 		streaming.SetWALForTest(mw)
-
-		metrics := newBroadcasterMetrics()
-		ackScheduler := newAckCallbackScheduler(log.With())
-
-		// Create an incomplete AlterReplicateConfig task (v2 not acked)
-		alterMsg := createAlterReplicateConfigBroadcastMsg([]string{"v1", "v2"}, false).WithBroadcastID(100)
-		alterProto := createNewWaitAckBroadcastTaskFromMessage(alterMsg,
-			streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_PENDING,
-			[]byte{0x01, 0x00}) // v1 acked, v2 not
-		alterTask := newBroadcastTaskFromProto(alterProto, metrics, ackScheduler)
-		alterTask.SetLogger(log.With())
 
 		bm := &broadcastTaskManager{
 			mu:    &sync.Mutex{},
@@ -789,7 +793,18 @@ func TestFixIncompleteBroadcastsForForcePromote(t *testing.T) {
 		f.Set(rc)
 		resource.InitForTest(resource.OptStreamingCatalog(meta), resource.OptMixCoordClient(f))
 
-		// Set up WAL mock
+		metrics := newBroadcasterMetrics()
+		ackScheduler := newAckCallbackScheduler(log.With())
+
+		// Create an incomplete DropCollection task (v2, v3 not acked)
+		dropMsg := createNewBroadcastMsg([]string{"v1", "v2", "v3"}).WithBroadcastID(200)
+		dropProto := createNewWaitAckBroadcastTaskFromMessage(dropMsg,
+			streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_PENDING,
+			[]byte{0x01, 0x00, 0x00}) // v1 acked, v2 & v3 not
+		dropTask := newBroadcastTaskFromProto(dropProto, metrics, ackScheduler)
+		dropTask.SetLogger(log.With())
+
+		// Set up WAL mock: AppendMessages succeeds and simulates ack
 		appendedCount := atomic.NewInt32(0)
 		mw := mock_streaming.NewMockWALAccesser(t)
 		appendF2 := func(ctx context.Context, msgs ...message.MutableMessage) types.AppendResponses {
@@ -803,23 +818,17 @@ func TestFixIncompleteBroadcastsForForcePromote(t *testing.T) {
 					},
 				}
 			}
+			// Simulate streaming node acking all remaining vchannels
+			dropTask.mu.Lock()
+			dropTask.task.AckedVchannelBitmap = []byte{0x01, 0x01, 0x01}
+			dropTask.closeAllAcked()
+			dropTask.mu.Unlock()
 			return resps
 		}
 		mw.EXPECT().AppendMessages(mock.Anything, mock.Anything).RunAndReturn(appendF2).Maybe()
 		mw.EXPECT().AppendMessages(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(appendF2).Maybe()
 		mw.EXPECT().AppendMessages(mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(appendF2).Maybe()
 		streaming.SetWALForTest(mw)
-
-		metrics := newBroadcasterMetrics()
-		ackScheduler := newAckCallbackScheduler(log.With())
-
-		// Create an incomplete DropCollection task (v2, v3 not acked)
-		dropMsg := createNewBroadcastMsg([]string{"v1", "v2", "v3"}).WithBroadcastID(200)
-		dropProto := createNewWaitAckBroadcastTaskFromMessage(dropMsg,
-			streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_PENDING,
-			[]byte{0x01, 0x00, 0x00}) // v1 acked, v2 & v3 not
-		dropTask := newBroadcastTaskFromProto(dropProto, metrics, ackScheduler)
-		dropTask.SetLogger(log.With())
 
 		bm := &broadcastTaskManager{
 			mu:    &sync.Mutex{},
@@ -832,6 +841,154 @@ func TestFixIncompleteBroadcastsForForcePromote(t *testing.T) {
 
 		// 2 pending messages should have been appended (v2 and v3)
 		assert.Equal(t, int32(2), appendedCount.Load())
+	})
+
+	t.Run("waits_for_all_acks_after_supplement", func(t *testing.T) {
+		paramtable.Init()
+		registry.ResetRegistration()
+
+		meta := mock_metastore.NewMockStreamingCoordCataLog(t)
+		meta.EXPECT().SaveBroadcastTask(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+		rc := idalloc.NewMockRootCoordClient(t)
+		f := syncutil.NewFuture[internaltypes.MixCoordClient]()
+		f.Set(rc)
+		resource.InitForTest(resource.OptStreamingCatalog(meta), resource.OptMixCoordClient(f))
+
+		metrics := newBroadcasterMetrics()
+		ackScheduler := newAckCallbackScheduler(log.With())
+
+		// Create an incomplete task (v2 not acked)
+		dropMsg := createNewBroadcastMsg([]string{"v1", "v2"}).WithBroadcastID(500)
+		dropProto := createNewWaitAckBroadcastTaskFromMessage(dropMsg,
+			streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_PENDING,
+			[]byte{0x01, 0x00})
+		dropTask := newBroadcastTaskFromProto(dropProto, metrics, ackScheduler)
+		dropTask.SetLogger(log.With())
+
+		// WAL mock succeeds but does NOT ack — ack happens async
+		appendCalled := make(chan struct{}, 1)
+		mw := mock_streaming.NewMockWALAccesser(t)
+		appendF := func(ctx context.Context, msgs ...message.MutableMessage) types.AppendResponses {
+			resps := types.AppendResponses{Responses: make([]types.AppendResponse, len(msgs))}
+			for i := range msgs {
+				resps.Responses[i] = types.AppendResponse{
+					AppendResult: &types.AppendResult{
+						MessageID: walimplstest.NewTestMessageID(int64(i + 1)),
+						TimeTick:  uint64(100 + i),
+					},
+				}
+			}
+			select {
+			case appendCalled <- struct{}{}:
+			default:
+			}
+			return resps
+		}
+		mw.EXPECT().AppendMessages(mock.Anything, mock.Anything).RunAndReturn(appendF).Maybe()
+		streaming.SetWALForTest(mw)
+
+		bm := &broadcastTaskManager{
+			mu:    &sync.Mutex{},
+			tasks: map[uint64]*broadcastTask{500: dropTask},
+		}
+		ackScheduler.bm = bm
+
+		// Run fix in background — it should block on BlockUntilAllAck
+		done := make(chan error, 1)
+		go func() {
+			done <- ackScheduler.fixIncompleteBroadcastsForForcePromote(context.Background())
+		}()
+
+		// Wait for AppendMessages to be called
+		select {
+		case <-appendCalled:
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for AppendMessages")
+		}
+
+		// Verify fix hasn't returned yet (still waiting for ack)
+		select {
+		case <-done:
+			t.Fatal("fixIncompleteBroadcastsForForcePromote returned before all acks")
+		case <-time.After(100 * time.Millisecond):
+			// Expected: still waiting
+		}
+
+		// Simulate streaming node acking the remaining vchannel
+		dropTask.mu.Lock()
+		dropTask.task.AckedVchannelBitmap = []byte{0x01, 0x01}
+		dropTask.closeAllAcked()
+		dropTask.mu.Unlock()
+
+		// Now fix should complete
+		select {
+		case err := <-done:
+			assert.NoError(t, err)
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out after acking")
+		}
+	})
+
+	t.Run("context_canceled_during_ack_wait", func(t *testing.T) {
+		paramtable.Init()
+		registry.ResetRegistration()
+
+		meta := mock_metastore.NewMockStreamingCoordCataLog(t)
+		meta.EXPECT().SaveBroadcastTask(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+		rc := idalloc.NewMockRootCoordClient(t)
+		f := syncutil.NewFuture[internaltypes.MixCoordClient]()
+		f.Set(rc)
+		resource.InitForTest(resource.OptStreamingCatalog(meta), resource.OptMixCoordClient(f))
+
+		metrics := newBroadcasterMetrics()
+		ackScheduler := newAckCallbackScheduler(log.With())
+
+		dropMsg := createNewBroadcastMsg([]string{"v1", "v2"}).WithBroadcastID(600)
+		dropProto := createNewWaitAckBroadcastTaskFromMessage(dropMsg,
+			streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_PENDING,
+			[]byte{0x01, 0x00})
+		dropTask := newBroadcastTaskFromProto(dropProto, metrics, ackScheduler)
+		dropTask.SetLogger(log.With())
+
+		// WAL mock succeeds but never acks
+		mw := mock_streaming.NewMockWALAccesser(t)
+		mw.EXPECT().AppendMessages(mock.Anything, mock.Anything).RunAndReturn(
+			func(ctx context.Context, msgs ...message.MutableMessage) types.AppendResponses {
+				resps := types.AppendResponses{Responses: make([]types.AppendResponse, len(msgs))}
+				for i := range msgs {
+					resps.Responses[i] = types.AppendResponse{
+						AppendResult: &types.AppendResult{
+							MessageID: walimplstest.NewTestMessageID(int64(i + 1)),
+							TimeTick:  uint64(100 + i),
+						},
+					}
+				}
+				return resps
+			}).Maybe()
+		streaming.SetWALForTest(mw)
+
+		bm := &broadcastTaskManager{
+			mu:    &sync.Mutex{},
+			tasks: map[uint64]*broadcastTask{600: dropTask},
+		}
+		ackScheduler.bm = bm
+
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan error, 1)
+		go func() {
+			done <- ackScheduler.fixIncompleteBroadcastsForForcePromote(ctx)
+		}()
+
+		// Cancel context while waiting for acks
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+
+		select {
+		case err := <-done:
+			assert.Error(t, err)
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for context cancellation")
+		}
 	})
 
 	t.Run("append_failure", func(t *testing.T) {
@@ -883,9 +1040,14 @@ func TestFixIncompleteBroadcastsForForcePromote(t *testing.T) {
 }
 
 func TestDoForcePromoteFixIncompleteBroadcasts(t *testing.T) {
-	t.Run("success_after_all_ack", func(t *testing.T) {
+	t.Run("full_lifecycle_no_incomplete_tasks", func(t *testing.T) {
 		paramtable.Init()
 		registry.ResetRegistration()
+		// Register a no-op ack callback for AlterReplicateConfig so doAckCallback can proceed.
+		registry.RegisterAlterReplicateConfigV2AckCallback(
+			func(ctx context.Context, result message.BroadcastResult[*message.AlterReplicateConfigMessageHeader, *message.AlterReplicateConfigMessageBody]) error {
+				return nil
+			})
 
 		meta := mock_metastore.NewMockStreamingCoordCataLog(t)
 		meta.EXPECT().SaveBroadcastTask(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
@@ -914,9 +1076,10 @@ func TestDoForcePromoteFixIncompleteBroadcasts(t *testing.T) {
 			tasks: map[uint64]*broadcastTask{400: fpTask},
 		}
 		ackScheduler.bm = bm
+		ackScheduler.Initialize(nil, nil, bm)
 
-		// doForcePromoteFixIncompleteBroadcasts should complete without error
-		// since all acked and no incomplete tasks
+		// doForcePromoteFixIncompleteBroadcasts should complete the full lifecycle:
+		// BlockUntilAllAck → fix (no-op) → acquire lock → doAckCallback → close(done)
 		done := make(chan struct{})
 		go func() {
 			ackScheduler.doForcePromoteFixIncompleteBroadcasts(fpTask)
@@ -925,13 +1088,14 @@ func TestDoForcePromoteFixIncompleteBroadcasts(t *testing.T) {
 
 		select {
 		case <-done:
-			// Success
+			// Verify task reached TOMBSTONE (ack callback completed)
+			assert.Equal(t, streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_TOMBSTONE, fpTask.State())
 		case <-time.After(5 * time.Second):
 			t.Fatal("timed out waiting for doForcePromoteFixIncompleteBroadcasts")
 		}
 	})
 
-	t.Run("context_canceled", func(t *testing.T) {
+	t.Run("context_canceled_before_ack", func(t *testing.T) {
 		paramtable.Init()
 		registry.ResetRegistration()
 
@@ -954,21 +1118,73 @@ func TestDoForcePromoteFixIncompleteBroadcasts(t *testing.T) {
 		}
 		ackScheduler.bm = bm
 
-		// Cancel the notifier to simulate shutdown
 		done := make(chan struct{})
 		go func() {
 			ackScheduler.doForcePromoteFixIncompleteBroadcasts(fpTask)
 			close(done)
 		}()
 
-		// Cancel the scheduler context
+		// Cancel the scheduler context — should abort at BlockUntilAllAck
 		ackScheduler.notifier.Cancel()
 
 		select {
 		case <-done:
-			// Success - should return because context canceled
+			// Should return because context canceled, task NOT tombstoned
+			assert.NotEqual(t, streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_TOMBSTONE, fpTask.State())
 		case <-time.After(5 * time.Second):
 			t.Fatal("timed out waiting for doForcePromoteFixIncompleteBroadcasts to exit on cancel")
+		}
+	})
+}
+
+func TestRetryUntilDone(t *testing.T) {
+	t.Run("succeeds_first_try", func(t *testing.T) {
+		ackScheduler := newAckCallbackScheduler(log.With())
+		callCount := 0
+		err := ackScheduler.retryUntilDone(context.Background(), func() error {
+			callCount++
+			return nil
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, 1, callCount)
+	})
+
+	t.Run("succeeds_after_retries", func(t *testing.T) {
+		ackScheduler := newAckCallbackScheduler(log.With())
+		callCount := 0
+		err := ackScheduler.retryUntilDone(context.Background(), func() error {
+			callCount++
+			if callCount < 3 {
+				return errors.New("not yet")
+			}
+			return nil
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, 3, callCount)
+	})
+
+	t.Run("aborts_on_context_cancel", func(t *testing.T) {
+		ackScheduler := newAckCallbackScheduler(log.With())
+		ctx, cancel := context.WithCancel(context.Background())
+		callCount := 0
+
+		done := make(chan error, 1)
+		go func() {
+			done <- ackScheduler.retryUntilDone(ctx, func() error {
+				callCount++
+				if callCount == 2 {
+					cancel()
+				}
+				return errors.New("always fail")
+			})
+		}()
+
+		select {
+		case err := <-done:
+			assert.Error(t, err)
+			assert.True(t, errors.Is(err, context.Canceled))
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out")
 		}
 	})
 }

--- a/internal/streamingcoord/server/broadcaster/broadcaster_test.go
+++ b/internal/streamingcoord/server/broadcaster/broadcaster_test.go
@@ -622,17 +622,10 @@ func TestPendingBroadcastMessages(t *testing.T) {
 	})
 }
 
-func TestMarkIgnoreAndSave(t *testing.T) {
+func TestMarkIgnore(t *testing.T) {
 	paramtable.Init()
 
 	t.Run("success", func(t *testing.T) {
-		meta := mock_metastore.NewMockStreamingCoordCataLog(t)
-		meta.EXPECT().SaveBroadcastTask(mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		rc := idalloc.NewMockRootCoordClient(t)
-		f := syncutil.NewFuture[internaltypes.MixCoordClient]()
-		f.Set(rc)
-		resource.InitForTest(resource.OptStreamingCatalog(meta), resource.OptMixCoordClient(f))
-
 		metrics := newBroadcasterMetrics()
 		ackScheduler := newAckCallbackScheduler(log.With())
 
@@ -643,7 +636,7 @@ func TestMarkIgnoreAndSave(t *testing.T) {
 		task := newBroadcastTaskFromProto(proto, metrics, ackScheduler)
 		task.SetLogger(log.With())
 
-		err := task.MarkIgnoreAndSave(context.Background())
+		err := task.MarkIgnore()
 		assert.NoError(t, err)
 
 		// Verify the message now has ignore=true
@@ -653,7 +646,6 @@ func TestMarkIgnoreAndSave(t *testing.T) {
 	})
 
 	t.Run("non_alter_replicate_config", func(t *testing.T) {
-		resource.InitForTest()
 		metrics := newBroadcasterMetrics()
 		ackScheduler := newAckCallbackScheduler(log.With())
 
@@ -661,7 +653,7 @@ func TestMarkIgnoreAndSave(t *testing.T) {
 		task := newBroadcastTaskFromProto(proto, metrics, ackScheduler)
 		task.SetLogger(log.With())
 
-		err := task.MarkIgnoreAndSave(context.Background())
+		err := task.MarkIgnore()
 		assert.Error(t, err)
 	})
 }
@@ -1129,58 +1121,6 @@ func TestDoForcePromoteFixIncompleteBroadcasts(t *testing.T) {
 			assert.NotEqual(t, streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_TOMBSTONE, fpTask.State())
 		case <-time.After(5 * time.Second):
 			t.Fatal("timed out waiting for doForcePromoteFixIncompleteBroadcasts to exit on cancel")
-		}
-	})
-}
-
-func TestRetryUntilDone(t *testing.T) {
-	t.Run("succeeds_first_try", func(t *testing.T) {
-		ackScheduler := newAckCallbackScheduler(log.With())
-		callCount := 0
-		err := ackScheduler.retryUntilDone(context.Background(), func() error {
-			callCount++
-			return nil
-		})
-		assert.NoError(t, err)
-		assert.Equal(t, 1, callCount)
-	})
-
-	t.Run("succeeds_after_retries", func(t *testing.T) {
-		ackScheduler := newAckCallbackScheduler(log.With())
-		callCount := 0
-		err := ackScheduler.retryUntilDone(context.Background(), func() error {
-			callCount++
-			if callCount < 3 {
-				return errors.New("not yet")
-			}
-			return nil
-		})
-		assert.NoError(t, err)
-		assert.Equal(t, 3, callCount)
-	})
-
-	t.Run("aborts_on_context_cancel", func(t *testing.T) {
-		ackScheduler := newAckCallbackScheduler(log.With())
-		ctx, cancel := context.WithCancel(context.Background())
-		callCount := 0
-
-		done := make(chan error, 1)
-		go func() {
-			done <- ackScheduler.retryUntilDone(ctx, func() error {
-				callCount++
-				if callCount == 2 {
-					cancel()
-				}
-				return errors.New("always fail")
-			})
-		}()
-
-		select {
-		case err := <-done:
-			assert.Error(t, err)
-			assert.True(t, errors.Is(err, context.Canceled))
-		case <-time.After(5 * time.Second):
-			t.Fatal("timed out")
 		}
 	})
 }

--- a/internal/streamingcoord/server/broadcaster/broadcaster_test.go
+++ b/internal/streamingcoord/server/broadcaster/broadcaster_test.go
@@ -1072,11 +1072,13 @@ func TestDoForcePromoteFixIncompleteBroadcasts(t *testing.T) {
 
 		// No incomplete tasks in the bm
 		bm := &broadcastTaskManager{
-			mu:    &sync.Mutex{},
-			tasks: map[uint64]*broadcastTask{400: fpTask},
+			lifetime: typeutil.NewLifetime(),
+			mu:       &sync.Mutex{},
+			tasks:    map[uint64]*broadcastTask{400: fpTask},
 		}
 		ackScheduler.bm = bm
 		ackScheduler.Initialize(nil, nil, bm)
+		defer ackScheduler.Close()
 
 		// doForcePromoteFixIncompleteBroadcasts should complete the full lifecycle:
 		// BlockUntilAllAck → fix (no-op) → acquire lock → doAckCallback → close(done)

--- a/internal/streamingcoord/server/broadcaster/broadcaster_test.go
+++ b/internal/streamingcoord/server/broadcaster/broadcaster_test.go
@@ -711,7 +711,6 @@ func TestFixIncompleteBroadcastsForForcePromote(t *testing.T) {
 
 		ackScheduler := newAckCallbackScheduler(log.With())
 
-		// Create a bm with no incomplete tasks (all acked)
 		bm := &broadcastTaskManager{
 			mu:    &sync.Mutex{},
 			tasks: make(map[uint64]*broadcastTask),
@@ -725,6 +724,10 @@ func TestFixIncompleteBroadcastsForForcePromote(t *testing.T) {
 	t.Run("with_alter_replicate_config_tasks", func(t *testing.T) {
 		paramtable.Init()
 		registry.ResetRegistration()
+		registry.RegisterAlterReplicateConfigV2AckCallback(
+			func(ctx context.Context, result message.BroadcastResult[*message.AlterReplicateConfigMessageHeader, *message.AlterReplicateConfigMessageBody]) error {
+				return nil
+			})
 
 		meta := mock_metastore.NewMockStreamingCoordCataLog(t)
 		meta.EXPECT().SaveBroadcastTask(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
@@ -736,15 +739,13 @@ func TestFixIncompleteBroadcastsForForcePromote(t *testing.T) {
 		metrics := newBroadcasterMetrics()
 		ackScheduler := newAckCallbackScheduler(log.With())
 
-		// Create an incomplete AlterReplicateConfig task (v2 not acked)
 		alterMsg := createAlterReplicateConfigBroadcastMsg([]string{"v1", "v2"}, false).WithBroadcastID(100)
 		alterProto := createNewWaitAckBroadcastTaskFromMessage(alterMsg,
 			streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_PENDING,
-			[]byte{0x01, 0x00}) // v1 acked, v2 not
+			[]byte{0x01, 0x00})
 		alterTask := newBroadcastTaskFromProto(alterProto, metrics, ackScheduler)
 		alterTask.SetLogger(log.With())
 
-		// Set up WAL mock: AppendMessages succeeds and simulates ack on the task
 		mw := mock_streaming.NewMockWALAccesser(t)
 		appendF := func(ctx context.Context, msgs ...message.MutableMessage) types.AppendResponses {
 			resps := types.AppendResponses{Responses: make([]types.AppendResponse, len(msgs))}
@@ -756,11 +757,6 @@ func TestFixIncompleteBroadcastsForForcePromote(t *testing.T) {
 					},
 				}
 			}
-			// Simulate streaming node acking the remaining vchannel
-			alterTask.mu.Lock()
-			alterTask.task.AckedVchannelBitmap = []byte{0x01, 0x01}
-			alterTask.closeAllAcked()
-			alterTask.mu.Unlock()
 			return resps
 		}
 		mw.EXPECT().AppendMessages(mock.Anything, mock.Anything).RunAndReturn(appendF).Maybe()
@@ -768,15 +764,19 @@ func TestFixIncompleteBroadcastsForForcePromote(t *testing.T) {
 		streaming.SetWALForTest(mw)
 
 		bm := &broadcastTaskManager{
-			mu:    &sync.Mutex{},
-			tasks: map[uint64]*broadcastTask{100: alterTask},
+			lifetime:           typeutil.NewLifetime(),
+			mu:                 &sync.Mutex{},
+			tasks:              map[uint64]*broadcastTask{100: alterTask},
+			broadcastScheduler: newBroadcasterScheduler(nil, log.With()),
 		}
 		ackScheduler.bm = bm
+		ackScheduler.Initialize(nil, nil, bm)
+		defer ackScheduler.Close()
+		defer bm.broadcastScheduler.Close()
 
 		err := ackScheduler.fixIncompleteBroadcastsForForcePromote(context.Background())
 		assert.NoError(t, err)
 
-		// Verify the task was marked with ignore=true
 		parsedMsg, err := message.AsMutableAlterReplicateConfigMessageV2(alterTask.msg)
 		assert.NoError(t, err)
 		assert.True(t, parsedMsg.Header().Ignore)
@@ -785,6 +785,9 @@ func TestFixIncompleteBroadcastsForForcePromote(t *testing.T) {
 	t.Run("with_other_broadcast_tasks", func(t *testing.T) {
 		paramtable.Init()
 		registry.ResetRegistration()
+		registry.RegisterDropCollectionV1AckCallback(func(ctx context.Context, msg message.BroadcastResultDropCollectionMessageV1) error {
+			return nil
+		})
 
 		meta := mock_metastore.NewMockStreamingCoordCataLog(t)
 		meta.EXPECT().SaveBroadcastTask(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
@@ -796,15 +799,13 @@ func TestFixIncompleteBroadcastsForForcePromote(t *testing.T) {
 		metrics := newBroadcasterMetrics()
 		ackScheduler := newAckCallbackScheduler(log.With())
 
-		// Create an incomplete DropCollection task (v2, v3 not acked)
 		dropMsg := createNewBroadcastMsg([]string{"v1", "v2", "v3"}).WithBroadcastID(200)
 		dropProto := createNewWaitAckBroadcastTaskFromMessage(dropMsg,
 			streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_PENDING,
-			[]byte{0x01, 0x00, 0x00}) // v1 acked, v2 & v3 not
+			[]byte{0x01, 0x00, 0x00})
 		dropTask := newBroadcastTaskFromProto(dropProto, metrics, ackScheduler)
 		dropTask.SetLogger(log.With())
 
-		// Set up WAL mock: AppendMessages succeeds and simulates ack
 		appendedCount := atomic.NewInt32(0)
 		mw := mock_streaming.NewMockWALAccesser(t)
 		appendF2 := func(ctx context.Context, msgs ...message.MutableMessage) types.AppendResponses {
@@ -818,11 +819,6 @@ func TestFixIncompleteBroadcastsForForcePromote(t *testing.T) {
 					},
 				}
 			}
-			// Simulate streaming node acking all remaining vchannels
-			dropTask.mu.Lock()
-			dropTask.task.AckedVchannelBitmap = []byte{0x01, 0x01, 0x01}
-			dropTask.closeAllAcked()
-			dropTask.mu.Unlock()
 			return resps
 		}
 		mw.EXPECT().AppendMessages(mock.Anything, mock.Anything).RunAndReturn(appendF2).Maybe()
@@ -831,21 +827,91 @@ func TestFixIncompleteBroadcastsForForcePromote(t *testing.T) {
 		streaming.SetWALForTest(mw)
 
 		bm := &broadcastTaskManager{
-			mu:    &sync.Mutex{},
-			tasks: map[uint64]*broadcastTask{200: dropTask},
+			lifetime:           typeutil.NewLifetime(),
+			mu:                 &sync.Mutex{},
+			tasks:              map[uint64]*broadcastTask{200: dropTask},
+			broadcastScheduler: newBroadcasterScheduler(nil, log.With()),
 		}
 		ackScheduler.bm = bm
+		ackScheduler.Initialize(nil, nil, bm)
+		defer ackScheduler.Close()
+		defer bm.broadcastScheduler.Close()
 
 		err := ackScheduler.fixIncompleteBroadcastsForForcePromote(context.Background())
 		assert.NoError(t, err)
-
-		// 2 pending messages should have been appended (v2 and v3)
 		assert.Equal(t, int32(2), appendedCount.Load())
 	})
 
-	t.Run("waits_for_all_acks_after_supplement", func(t *testing.T) {
+	t.Run("append_failure_then_retry", func(t *testing.T) {
 		paramtable.Init()
 		registry.ResetRegistration()
+		registry.RegisterDropCollectionV1AckCallback(func(ctx context.Context, msg message.BroadcastResultDropCollectionMessageV1) error {
+			return nil
+		})
+
+		meta := mock_metastore.NewMockStreamingCoordCataLog(t)
+		meta.EXPECT().SaveBroadcastTask(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+		rc := idalloc.NewMockRootCoordClient(t)
+		f := syncutil.NewFuture[internaltypes.MixCoordClient]()
+		f.Set(rc)
+		resource.InitForTest(resource.OptStreamingCatalog(meta), resource.OptMixCoordClient(f))
+
+		metrics := newBroadcasterMetrics()
+		ackScheduler := newAckCallbackScheduler(log.With())
+
+		dropMsg := createNewBroadcastMsg([]string{"v1", "v2"}).WithBroadcastID(300)
+		dropProto := createNewWaitAckBroadcastTaskFromMessage(dropMsg,
+			streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_PENDING,
+			[]byte{0x01, 0x00})
+		dropTask := newBroadcastTaskFromProto(dropProto, metrics, ackScheduler)
+		dropTask.SetLogger(log.With())
+
+		// First call fails, subsequent calls succeed
+		callCount := atomic.NewInt32(0)
+		mw := mock_streaming.NewMockWALAccesser(t)
+		appendF := func(ctx context.Context, msgs ...message.MutableMessage) types.AppendResponses {
+			resps := types.AppendResponses{Responses: make([]types.AppendResponse, len(msgs))}
+			count := callCount.Inc()
+			for i := range msgs {
+				if count == 1 {
+					resps.Responses[i] = types.AppendResponse{Error: errors.New("append failed")}
+				} else {
+					resps.Responses[i] = types.AppendResponse{
+						AppendResult: &types.AppendResult{
+							MessageID: walimplstest.NewTestMessageID(int64(i + 1)),
+							TimeTick:  uint64(100 + i),
+						},
+					}
+				}
+			}
+			return resps
+		}
+		mw.EXPECT().AppendMessages(mock.Anything, mock.Anything).RunAndReturn(appendF).Maybe()
+		streaming.SetWALForTest(mw)
+
+		bm := &broadcastTaskManager{
+			lifetime:           typeutil.NewLifetime(),
+			mu:                 &sync.Mutex{},
+			tasks:              map[uint64]*broadcastTask{300: dropTask},
+			broadcastScheduler: newBroadcasterScheduler(nil, log.With()),
+		}
+		ackScheduler.bm = bm
+		ackScheduler.Initialize(nil, nil, bm)
+		defer ackScheduler.Close()
+		defer bm.broadcastScheduler.Close()
+
+		err := ackScheduler.fixIncompleteBroadcastsForForcePromote(context.Background())
+		assert.NoError(t, err)
+		// broadcastScheduler retried after first failure
+		assert.GreaterOrEqual(t, callCount.Load(), int32(2))
+	})
+
+	t.Run("blocks_until_tombstone", func(t *testing.T) {
+		paramtable.Init()
+		registry.ResetRegistration()
+		registry.RegisterDropCollectionV1AckCallback(func(ctx context.Context, msg message.BroadcastResultDropCollectionMessageV1) error {
+			return nil
+		})
 
 		meta := mock_metastore.NewMockStreamingCoordCataLog(t)
 		meta.EXPECT().SaveBroadcastTask(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
@@ -865,8 +931,6 @@ func TestFixIncompleteBroadcastsForForcePromote(t *testing.T) {
 		dropTask := newBroadcastTaskFromProto(dropProto, metrics, ackScheduler)
 		dropTask.SetLogger(log.With())
 
-		// WAL mock succeeds but does NOT ack — ack happens async
-		appendCalled := make(chan struct{}, 1)
 		mw := mock_streaming.NewMockWALAccesser(t)
 		appendF := func(ctx context.Context, msgs ...message.MutableMessage) types.AppendResponses {
 			resps := types.AppendResponses{Responses: make([]types.AppendResponse, len(msgs))}
@@ -878,58 +942,30 @@ func TestFixIncompleteBroadcastsForForcePromote(t *testing.T) {
 					},
 				}
 			}
-			select {
-			case appendCalled <- struct{}{}:
-			default:
-			}
 			return resps
 		}
 		mw.EXPECT().AppendMessages(mock.Anything, mock.Anything).RunAndReturn(appendF).Maybe()
 		streaming.SetWALForTest(mw)
 
 		bm := &broadcastTaskManager{
-			mu:    &sync.Mutex{},
-			tasks: map[uint64]*broadcastTask{500: dropTask},
+			lifetime:           typeutil.NewLifetime(),
+			mu:                 &sync.Mutex{},
+			tasks:              map[uint64]*broadcastTask{500: dropTask},
+			broadcastScheduler: newBroadcasterScheduler(nil, log.With()),
 		}
 		ackScheduler.bm = bm
+		ackScheduler.Initialize(nil, nil, bm)
+		defer ackScheduler.Close()
+		defer bm.broadcastScheduler.Close()
 
-		// Run fix in background — it should block on BlockUntilAllAck
-		done := make(chan error, 1)
-		go func() {
-			done <- ackScheduler.fixIncompleteBroadcastsForForcePromote(context.Background())
-		}()
-
-		// Wait for AppendMessages to be called
-		select {
-		case <-appendCalled:
-		case <-time.After(5 * time.Second):
-			t.Fatal("timed out waiting for AppendMessages")
-		}
-
-		// Verify fix hasn't returned yet (still waiting for ack)
-		select {
-		case <-done:
-			t.Fatal("fixIncompleteBroadcastsForForcePromote returned before all acks")
-		case <-time.After(100 * time.Millisecond):
-			// Expected: still waiting
-		}
-
-		// Simulate streaming node acking the remaining vchannel
-		dropTask.mu.Lock()
-		dropTask.task.AckedVchannelBitmap = []byte{0x01, 0x01}
-		dropTask.closeAllAcked()
-		dropTask.mu.Unlock()
-
-		// Now fix should complete
-		select {
-		case err := <-done:
-			assert.NoError(t, err)
-		case <-time.After(5 * time.Second):
-			t.Fatal("timed out after acking")
-		}
+		// AddTask blocks until tombstone; fixIncompleteBroadcastsForForcePromote
+		// should only return after task reaches TOMBSTONE via broadcastScheduler.
+		err := ackScheduler.fixIncompleteBroadcastsForForcePromote(context.Background())
+		assert.NoError(t, err)
+		assert.Equal(t, streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_TOMBSTONE, dropTask.State())
 	})
 
-	t.Run("context_canceled_during_ack_wait", func(t *testing.T) {
+	t.Run("context_canceled_during_supplement", func(t *testing.T) {
 		paramtable.Init()
 		registry.ResetRegistration()
 
@@ -968,10 +1004,15 @@ func TestFixIncompleteBroadcastsForForcePromote(t *testing.T) {
 		streaming.SetWALForTest(mw)
 
 		bm := &broadcastTaskManager{
-			mu:    &sync.Mutex{},
-			tasks: map[uint64]*broadcastTask{600: dropTask},
+			lifetime:           typeutil.NewLifetime(),
+			mu:                 &sync.Mutex{},
+			tasks:              map[uint64]*broadcastTask{600: dropTask},
+			broadcastScheduler: newBroadcasterScheduler(nil, log.With()),
 		}
 		ackScheduler.bm = bm
+		ackScheduler.Initialize(nil, nil, bm)
+		defer ackScheduler.Close()
+		defer bm.broadcastScheduler.Close()
 
 		ctx, cancel := context.WithCancel(context.Background())
 		done := make(chan error, 1)
@@ -979,7 +1020,7 @@ func TestFixIncompleteBroadcastsForForcePromote(t *testing.T) {
 			done <- ackScheduler.fixIncompleteBroadcastsForForcePromote(ctx)
 		}()
 
-		// Cancel context while waiting for acks
+		// Cancel context while AddTask is blocking
 		time.Sleep(100 * time.Millisecond)
 		cancel()
 
@@ -989,53 +1030,6 @@ func TestFixIncompleteBroadcastsForForcePromote(t *testing.T) {
 		case <-time.After(5 * time.Second):
 			t.Fatal("timed out waiting for context cancellation")
 		}
-	})
-
-	t.Run("append_failure", func(t *testing.T) {
-		paramtable.Init()
-		registry.ResetRegistration()
-
-		meta := mock_metastore.NewMockStreamingCoordCataLog(t)
-		meta.EXPECT().SaveBroadcastTask(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
-		rc := idalloc.NewMockRootCoordClient(t)
-		f := syncutil.NewFuture[internaltypes.MixCoordClient]()
-		f.Set(rc)
-		resource.InitForTest(resource.OptStreamingCatalog(meta), resource.OptMixCoordClient(f))
-
-		// Set up WAL mock that returns errors
-		mw := mock_streaming.NewMockWALAccesser(t)
-		appendErrF := func(ctx context.Context, msgs ...message.MutableMessage) types.AppendResponses {
-			resps := types.AppendResponses{Responses: make([]types.AppendResponse, len(msgs))}
-			for i := range msgs {
-				resps.Responses[i] = types.AppendResponse{
-					Error: errors.New("append failed"),
-				}
-			}
-			return resps
-		}
-		mw.EXPECT().AppendMessages(mock.Anything, mock.Anything).RunAndReturn(appendErrF).Maybe()
-		mw.EXPECT().AppendMessages(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(appendErrF).Maybe()
-		streaming.SetWALForTest(mw)
-
-		metrics := newBroadcasterMetrics()
-		ackScheduler := newAckCallbackScheduler(log.With())
-
-		dropMsg := createNewBroadcastMsg([]string{"v1", "v2"}).WithBroadcastID(300)
-		dropProto := createNewWaitAckBroadcastTaskFromMessage(dropMsg,
-			streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_PENDING,
-			[]byte{0x01, 0x00})
-		dropTask := newBroadcastTaskFromProto(dropProto, metrics, ackScheduler)
-		dropTask.SetLogger(log.With())
-
-		bm := &broadcastTaskManager{
-			mu:    &sync.Mutex{},
-			tasks: map[uint64]*broadcastTask{300: dropTask},
-		}
-		ackScheduler.bm = bm
-
-		err := ackScheduler.fixIncompleteBroadcastsForForcePromote(context.Background())
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "append failed")
 	})
 }
 

--- a/internal/streamingcoord/server/broadcaster/force_promote_failover_test.go
+++ b/internal/streamingcoord/server/broadcaster/force_promote_failover_test.go
@@ -328,16 +328,32 @@ func (env *forcePromoteTestEnv) countCatalogStateTransitions(broadcastID uint64,
 
 // --- Helper functions for creating recovery tasks ---
 
+// buildBitmapFromAckedVChannels builds a bitmap aligned to the actual vchannel order in the broadcast header.
+// WithBroadcast may reorder vchannels (due to Set deduplication), so bitmaps must be built
+// from the header's actual order, not the caller's input order.
+func buildBitmapFromAckedVChannels(msg message.BroadcastMutableMessage, ackedVChannels []string) []byte {
+	headerVChannels := msg.BroadcastHeader().VChannels
+	ackedSet := typeutil.NewSet(ackedVChannels...)
+	bitmap := make([]byte, len(headerVChannels))
+	for i, vc := range headerVChannels {
+		if ackedSet.Contain(vc) {
+			bitmap[i] = 1
+		}
+	}
+	return bitmap
+}
+
 // createReplicatedDropCollectionTask creates a REPLICATED DropCollection task.
-func createReplicatedDropCollectionTask(broadcastID uint64, vchannels []string, ackedBitmap []byte) *streamingpb.BroadcastTask {
+func createReplicatedDropCollectionTask(broadcastID uint64, vchannels []string, ackedVChannels []string) *streamingpb.BroadcastTask {
 	msg := createNewBroadcastMsg(vchannels).WithBroadcastID(broadcastID)
+	bitmap := buildBitmapFromAckedVChannels(msg, ackedVChannels)
 	return createNewWaitAckBroadcastTaskFromMessage(msg,
 		streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_REPLICATED,
-		ackedBitmap)
+		bitmap)
 }
 
 // createReplicatedCreateCollectionTask creates a REPLICATED CreateCollection task.
-func createReplicatedCreateCollectionTask(broadcastID uint64, vchannels []string, ackedBitmap []byte) *streamingpb.BroadcastTask {
+func createReplicatedCreateCollectionTask(broadcastID uint64, vchannels []string, ackedVChannels []string) *streamingpb.BroadcastTask {
 	msg, err := message.NewCreateCollectionMessageBuilderV1().
 		WithHeader(&message.CreateCollectionMessageHeader{}).
 		WithBody(&msgpb.CreateCollectionRequest{}).
@@ -346,14 +362,15 @@ func createReplicatedCreateCollectionTask(broadcastID uint64, vchannels []string
 	if err != nil {
 		panic(err)
 	}
+	bitmap := buildBitmapFromAckedVChannels(msg, ackedVChannels)
 	return createNewWaitAckBroadcastTaskFromMessage(
 		msg.WithBroadcastID(broadcastID),
 		streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_REPLICATED,
-		ackedBitmap)
+		bitmap)
 }
 
 // createReplicatedCreatePartitionTask creates a REPLICATED CreatePartition task.
-func createReplicatedCreatePartitionTask(broadcastID uint64, vchannels []string, ackedBitmap []byte) *streamingpb.BroadcastTask {
+func createReplicatedCreatePartitionTask(broadcastID uint64, vchannels []string, ackedVChannels []string) *streamingpb.BroadcastTask {
 	msg, err := message.NewCreatePartitionMessageBuilderV1().
 		WithHeader(&message.CreatePartitionMessageHeader{}).
 		WithBody(&msgpb.CreatePartitionRequest{}).
@@ -362,14 +379,15 @@ func createReplicatedCreatePartitionTask(broadcastID uint64, vchannels []string,
 	if err != nil {
 		panic(err)
 	}
+	bitmap := buildBitmapFromAckedVChannels(msg, ackedVChannels)
 	return createNewWaitAckBroadcastTaskFromMessage(
 		msg.WithBroadcastID(broadcastID),
 		streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_REPLICATED,
-		ackedBitmap)
+		bitmap)
 }
 
 // createReplicatedDropPartitionTask creates a REPLICATED DropPartition task.
-func createReplicatedDropPartitionTask(broadcastID uint64, vchannels []string, ackedBitmap []byte) *streamingpb.BroadcastTask {
+func createReplicatedDropPartitionTask(broadcastID uint64, vchannels []string, ackedVChannels []string) *streamingpb.BroadcastTask {
 	msg, err := message.NewDropPartitionMessageBuilderV1().
 		WithHeader(&message.DropPartitionMessageHeader{}).
 		WithBody(&msgpb.DropPartitionRequest{}).
@@ -378,39 +396,43 @@ func createReplicatedDropPartitionTask(broadcastID uint64, vchannels []string, a
 	if err != nil {
 		panic(err)
 	}
+	bitmap := buildBitmapFromAckedVChannels(msg, ackedVChannels)
 	return createNewWaitAckBroadcastTaskFromMessage(
 		msg.WithBroadcastID(broadcastID),
 		streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_REPLICATED,
-		ackedBitmap)
+		bitmap)
 }
 
 // createReplicatedAlterReplicateConfigTask creates a REPLICATED AlterReplicateConfig task.
-func createReplicatedAlterReplicateConfigTask(broadcastID uint64, vchannels []string, ackedBitmap []byte) *streamingpb.BroadcastTask {
+func createReplicatedAlterReplicateConfigTask(broadcastID uint64, vchannels []string, ackedVChannels []string) *streamingpb.BroadcastTask {
 	msg := createAlterReplicateConfigBroadcastMsg(vchannels, false).WithBroadcastID(broadcastID)
+	bitmap := buildBitmapFromAckedVChannels(msg, ackedVChannels)
 	return createNewWaitAckBroadcastTaskFromMessage(msg,
 		streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_REPLICATED,
-		ackedBitmap)
+		bitmap)
 }
 
 // createReplicatedForcePromoteTask creates a REPLICATED force promote task.
-func createReplicatedForcePromoteTask(broadcastID uint64, vchannels []string, ackedBitmap []byte) *streamingpb.BroadcastTask {
+func createReplicatedForcePromoteTask(broadcastID uint64, vchannels []string, ackedVChannels []string) *streamingpb.BroadcastTask {
 	msg := createAlterReplicateConfigBroadcastMsg(vchannels, true).WithBroadcastID(broadcastID)
+	bitmap := buildBitmapFromAckedVChannels(msg, ackedVChannels)
 	return createNewWaitAckBroadcastTaskFromMessage(msg,
 		streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_REPLICATED,
-		ackedBitmap)
+		bitmap)
 }
 
 // createPendingForcePromoteTask creates a PENDING force promote task (not yet broadcast).
 func createPendingForcePromoteTask(broadcastID uint64, vchannels []string) *streamingpb.BroadcastTask {
 	msg := createAlterReplicateConfigBroadcastMsg(vchannels, true).WithBroadcastID(broadcastID)
 	pb := msg.IntoMessageProto()
+	headerVChannels := msg.BroadcastHeader().VChannels
 	return &streamingpb.BroadcastTask{
 		Message: &messagespb.Message{
 			Payload:    pb.Payload,
 			Properties: pb.Properties,
 		},
 		State:               streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_PENDING,
-		AckedVchannelBitmap: make([]byte, len(vchannels)),
+		AckedVchannelBitmap: make([]byte, len(headerVChannels)),
 	}
 }
 
@@ -425,7 +447,7 @@ func TestForcePromoteFailover(t *testing.T) {
 	t.Run("no_incomplete_tasks", func(t *testing.T) {
 		env := setupForcePromoteTest(t,
 			[]*streamingpb.BroadcastTask{
-				createReplicatedForcePromoteTask(100, vchannels, []byte{0x01, 0x01, 0x01}),
+				createReplicatedForcePromoteTask(100, vchannels, vchannels), // all acked
 			},
 			nil,
 		)
@@ -445,8 +467,8 @@ func TestForcePromoteFailover(t *testing.T) {
 	t.Run("fix_incomplete_drop_collection", func(t *testing.T) {
 		env := setupForcePromoteTest(t,
 			[]*streamingpb.BroadcastTask{
-				createReplicatedDropCollectionTask(10, vchannels, []byte{0x01, 0x00, 0x00}), // cc acked, v1/v2 pending
-				createReplicatedForcePromoteTask(100, vchannels, []byte{0x01, 0x01, 0x01}),  // all acked
+				createReplicatedDropCollectionTask(10, vchannels, []string{"cc_vcchan"}), // cc acked, v1/v2 pending
+				createReplicatedForcePromoteTask(100, vchannels, vchannels),              // all acked
 			},
 			nil,
 		)
@@ -478,9 +500,9 @@ func TestForcePromoteFailover(t *testing.T) {
 	t.Run("fix_alter_replicate_config_with_ignore", func(t *testing.T) {
 		env := setupForcePromoteTest(t,
 			[]*streamingpb.BroadcastTask{
-				createReplicatedAlterReplicateConfigTask(10, vchannels, []byte{0x01, 0x01, 0x00}), // cc,v1 acked, v2 pending
-				createReplicatedDropCollectionTask(20, vchannels, []byte{0x01, 0x00, 0x00}),       // cc acked, v1/v2 pending
-				createReplicatedForcePromoteTask(100, vchannels, []byte{0x01, 0x01, 0x01}),        // all acked
+				createReplicatedAlterReplicateConfigTask(10, vchannels, []string{"cc_vcchan", "v1"}), // cc,v1 acked, v2 pending
+				createReplicatedDropCollectionTask(20, vchannels, []string{"cc_vcchan"}),             // cc acked, v1/v2 pending
+				createReplicatedForcePromoteTask(100, vchannels, vchannels),                          // all acked
 			},
 			nil,
 		)
@@ -518,8 +540,8 @@ func TestForcePromoteFailover(t *testing.T) {
 		callCount := atomic.NewInt32(0)
 		env := setupForcePromoteTest(t,
 			[]*streamingpb.BroadcastTask{
-				createReplicatedDropCollectionTask(10, vchannels, []byte{0x01, 0x00, 0x00}),
-				createReplicatedForcePromoteTask(100, vchannels, []byte{0x01, 0x01, 0x01}),
+				createReplicatedDropCollectionTask(10, vchannels, []string{"cc_vcchan"}),
+				createReplicatedForcePromoteTask(100, vchannels, vchannels),
 			},
 			[]appendBehavior{
 				{
@@ -546,7 +568,7 @@ func TestForcePromoteFailover(t *testing.T) {
 	t.Run("pending_force_promote_broadcast_then_fix", func(t *testing.T) {
 		env := setupForcePromoteTest(t,
 			[]*streamingpb.BroadcastTask{
-				createReplicatedDropCollectionTask(10, vchannels, []byte{0x00, 0x00, 0x00}),
+				createReplicatedDropCollectionTask(10, vchannels, nil), // none acked
 				createPendingForcePromoteTask(100, vchannels),
 			},
 			nil,
@@ -567,8 +589,8 @@ func TestForcePromoteFailover(t *testing.T) {
 		blockCh := make(chan struct{})
 		env := setupForcePromoteTest(t,
 			[]*streamingpb.BroadcastTask{
-				createReplicatedDropCollectionTask(10, vchannels, []byte{0x00, 0x00, 0x00}),
-				createReplicatedForcePromoteTask(100, vchannels, []byte{0x01, 0x01, 0x01}),
+				createReplicatedDropCollectionTask(10, vchannels, nil),      // none acked
+				createReplicatedForcePromoteTask(100, vchannels, vchannels), // all acked
 			},
 			[]appendBehavior{
 				{
@@ -604,10 +626,10 @@ func TestForcePromoteFailover(t *testing.T) {
 	t.Run("mixed_incomplete_tasks_ordering", func(t *testing.T) {
 		env := setupForcePromoteTest(t,
 			[]*streamingpb.BroadcastTask{
-				createReplicatedAlterReplicateConfigTask(10, vchannels, []byte{0x01, 0x01, 0x00}), // cc,v1 acked, v2 pending
-				createReplicatedDropCollectionTask(20, vchannels, []byte{0x01, 0x00, 0x00}),       // cc acked, v1/v2 pending
-				createReplicatedDropCollectionTask(30, vchannels, []byte{0x01, 0x00, 0x00}),       // cc acked, v1/v2 pending
-				createReplicatedForcePromoteTask(100, vchannels, []byte{0x01, 0x01, 0x01}),        // all acked
+				createReplicatedAlterReplicateConfigTask(10, vchannels, []string{"cc_vcchan", "v1"}), // cc,v1 acked, v2 pending
+				createReplicatedDropCollectionTask(20, vchannels, []string{"cc_vcchan"}),             // cc acked, v1/v2 pending
+				createReplicatedDropCollectionTask(30, vchannels, []string{"cc_vcchan"}),             // cc acked, v1/v2 pending
+				createReplicatedForcePromoteTask(100, vchannels, vchannels),                          // all acked
 			},
 			nil,
 		)
@@ -635,12 +657,12 @@ func TestForcePromoteFailover(t *testing.T) {
 		//   v2: Task 10/15 acked, Task 20/25 pending → valid (watermark between 15 and 20)
 		env := setupForcePromoteTest(t,
 			[]*streamingpb.BroadcastTask{
-				createReplicatedAlterReplicateConfigTask(10, vchannels, []byte{0x01, 0x01, 0x01}), // cc,v1,v2 all acked → not incomplete
-				createReplicatedCreateCollectionTask(15, vchannels, []byte{0x01, 0x00, 0x01}),     // cc,v2 acked, v1 pending
-				createReplicatedDropCollectionTask(20, vchannels, []byte{0x01, 0x00, 0x00}),       // cc acked, v1/v2 pending
-				createReplicatedCreatePartitionTask(25, vchannels, []byte{0x01, 0x00, 0x00}),      // cc acked, v1/v2 pending
-				createReplicatedDropPartitionTask(30, vchannels, []byte{0x01, 0x00, 0x00}),        // cc acked, v1/v2 pending
-				createReplicatedForcePromoteTask(100, vchannels, []byte{0x01, 0x01, 0x01}),        // all acked
+				createReplicatedAlterReplicateConfigTask(10, vchannels, vchannels),               // cc,v1,v2 all acked → not incomplete
+				createReplicatedCreateCollectionTask(15, vchannels, []string{"cc_vcchan", "v2"}), // cc,v2 acked, v1 pending
+				createReplicatedDropCollectionTask(20, vchannels, []string{"cc_vcchan"}),         // cc acked, v1/v2 pending
+				createReplicatedCreatePartitionTask(25, vchannels, []string{"cc_vcchan"}),        // cc acked, v1/v2 pending
+				createReplicatedDropPartitionTask(30, vchannels, []string{"cc_vcchan"}),          // cc acked, v1/v2 pending
+				createReplicatedForcePromoteTask(100, vchannels, vchannels),                      // all acked
 			},
 			nil,
 		)
@@ -702,11 +724,11 @@ func TestForcePromoteFailover(t *testing.T) {
 		//   v2: Task 10 acked, Task 12/20 pending → valid
 		env := setupForcePromoteTest(t,
 			[]*streamingpb.BroadcastTask{
-				createReplicatedAlterReplicateConfigTask(10, vchannels, []byte{0x01, 0x01, 0x01}), // fully acked → not incomplete
-				createReplicatedAlterReplicateConfigTask(12, vchannels, []byte{0x01, 0x00, 0x00}), // cc acked, v1/v2 pending
-				createReplicatedCreateCollectionTask(20, vchannels, []byte{0x01, 0x00, 0x00}),     // cc acked, v1/v2 pending
-				createReplicatedDropPartitionTask(25, vchannels, []byte{0x01, 0x00, 0x00}),        // cc acked, v1/v2 pending
-				createReplicatedForcePromoteTask(100, vchannels, []byte{0x01, 0x01, 0x01}),        // all acked
+				createReplicatedAlterReplicateConfigTask(10, vchannels, vchannels),             // fully acked → not incomplete
+				createReplicatedAlterReplicateConfigTask(12, vchannels, []string{"cc_vcchan"}), // cc acked, v1/v2 pending
+				createReplicatedCreateCollectionTask(20, vchannels, []string{"cc_vcchan"}),     // cc acked, v1/v2 pending
+				createReplicatedDropPartitionTask(25, vchannels, []string{"cc_vcchan"}),        // cc acked, v1/v2 pending
+				createReplicatedForcePromoteTask(100, vchannels, vchannels),                    // all acked
 			},
 			nil,
 		)

--- a/internal/streamingcoord/server/broadcaster/force_promote_failover_test.go
+++ b/internal/streamingcoord/server/broadcaster/force_promote_failover_test.go
@@ -589,8 +589,9 @@ func TestForcePromoteFailover(t *testing.T) {
 		blockCh := make(chan struct{})
 		env := setupForcePromoteTest(t,
 			[]*streamingpb.BroadcastTask{
-				createReplicatedDropCollectionTask(10, vchannels, nil),      // none acked
-				createReplicatedForcePromoteTask(100, vchannels, vchannels), // all acked
+				// Force promote in PENDING state: WAL append blocks, then Close() cancels context.
+				// No incomplete tasks — tests that Close() doesn't hang when WAL is blocked.
+				createPendingForcePromoteTask(100, vchannels),
 			},
 			[]appendBehavior{
 				{

--- a/internal/streamingcoord/server/broadcaster/force_promote_failover_test.go
+++ b/internal/streamingcoord/server/broadcaster/force_promote_failover_test.go
@@ -1,0 +1,782 @@
+package broadcaster
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.uber.org/atomic"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
+	"github.com/milvus-io/milvus/internal/distributed/streaming"
+	"github.com/milvus-io/milvus/internal/mocks/distributed/mock_streaming"
+	"github.com/milvus-io/milvus/internal/mocks/mock_metastore"
+	"github.com/milvus-io/milvus/internal/mocks/streamingcoord/server/mock_balancer"
+	"github.com/milvus-io/milvus/internal/streamingcoord/server/balancer"
+	"github.com/milvus-io/milvus/internal/streamingcoord/server/balancer/balance"
+	"github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster/registry"
+	"github.com/milvus-io/milvus/internal/streamingcoord/server/resource"
+	internaltypes "github.com/milvus-io/milvus/internal/types"
+	"github.com/milvus-io/milvus/internal/util/idalloc"
+	"github.com/milvus-io/milvus/pkg/v2/proto/messagespb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/streamingpb"
+	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v2/streaming/util/types"
+	"github.com/milvus-io/milvus/pkg/v2/streaming/walimpls/impls/walimplstest"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v2/util/replicateutil"
+	"github.com/milvus-io/milvus/pkg/v2/util/syncutil"
+	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
+)
+
+// appendBehavior defines how the mock WAL should respond to an AppendMessages call.
+type appendBehavior struct {
+	handler func(ctx context.Context, msgs []message.MutableMessage) types.AppendResponses
+}
+
+// appendRecord records metadata about a single supplemented message.
+type appendRecord struct {
+	BroadcastID uint64
+	VChannel    string
+	MessageType message.MessageType
+}
+
+// walController provides a programmable mock WAL for testing.
+// It queues appendBehavior functions that are consumed in order per call.
+// When the queue is exhausted, it falls back to default (all success + auto ack).
+type walController struct {
+	t           *testing.T
+	mu          sync.Mutex
+	idCounter   atomic.Int64
+	appendCount atomic.Int64 // counts successful appends
+	behaviors   []appendBehavior
+	broadcaster *syncutil.Future[Broadcaster]
+
+	// appendRecords tracks metadata of all successfully appended messages.
+	appendRecordsMu sync.Mutex
+	appendRecords   []appendRecord
+}
+
+func newWALController(t *testing.T, broadcaster *syncutil.Future[Broadcaster]) *walController {
+	return &walController{
+		t:           t,
+		idCounter:   *atomic.NewInt64(1000),
+		broadcaster: broadcaster,
+	}
+}
+
+func (w *walController) setBehaviors(behaviors []appendBehavior) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.behaviors = behaviors
+}
+
+// nextBehavior pops the next queued behavior, or returns nil if exhausted.
+func (w *walController) nextBehavior() *appendBehavior {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if len(w.behaviors) == 0 {
+		return nil
+	}
+	b := w.behaviors[0]
+	w.behaviors = w.behaviors[1:]
+	return &b
+}
+
+func (w *walController) recordAppend(msg message.MutableMessage) {
+	w.appendRecordsMu.Lock()
+	defer w.appendRecordsMu.Unlock()
+	w.appendRecords = append(w.appendRecords, appendRecord{
+		BroadcastID: msg.BroadcastHeader().BroadcastID,
+		VChannel:    msg.VChannel(),
+		MessageType: msg.MessageType(),
+	})
+}
+
+// getAppendRecords returns a copy of all append records.
+func (w *walController) getAppendRecords() []appendRecord {
+	w.appendRecordsMu.Lock()
+	defer w.appendRecordsMu.Unlock()
+	result := make([]appendRecord, len(w.appendRecords))
+	copy(result, w.appendRecords)
+	return result
+}
+
+// defaultAppend is the default WAL behavior: all success + auto ack.
+func (w *walController) defaultAppend(ctx context.Context, msgs []message.MutableMessage) types.AppendResponses {
+	resps := types.AppendResponses{Responses: make([]types.AppendResponse, len(msgs))}
+	for i, msg := range msgs {
+		newID := walimplstest.NewTestMessageID(w.idCounter.Inc())
+		resps.Responses[i] = types.AppendResponse{
+			AppendResult: &types.AppendResult{
+				MessageID: newID,
+				TimeTick:  uint64(time.Now().UnixMilli()),
+			},
+		}
+		w.appendCount.Inc()
+		w.recordAppend(msg)
+
+		// Auto ack: simulate streaming node consuming and acking the message
+		broadcastID := msg.BroadcastHeader().BroadcastID
+		vchannel := msg.VChannel()
+		go func() {
+			time.Sleep(10 * time.Millisecond)
+			w.ackMessage(broadcastID, vchannel)
+		}()
+	}
+	return resps
+}
+
+func (w *walController) ackMessage(broadcastID uint64, vchannel string) {
+	bc := w.broadcaster.Get()
+	msg := message.NewDropCollectionMessageBuilderV1().
+		WithHeader(&messagespb.DropCollectionMessageHeader{}).
+		WithBody(&msgpb.DropCollectionRequest{}).
+		WithBroadcast([]string{vchannel}).
+		MustBuildBroadcast().
+		WithBroadcastID(broadcastID).
+		SplitIntoMutableMessage()[0].
+		WithTimeTick(100).
+		WithLastConfirmed(walimplstest.NewTestMessageID(1)).
+		IntoImmutableMessage(walimplstest.NewTestMessageID(w.idCounter.Inc()))
+
+	for {
+		if err := bc.Ack(context.Background(), msg); err == nil {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// handleAppend is the main entry point called by the mock WAL.
+func (w *walController) handleAppend(ctx context.Context, msgs []message.MutableMessage) types.AppendResponses {
+	if b := w.nextBehavior(); b != nil {
+		return b.handler(ctx, msgs)
+	}
+	return w.defaultAppend(ctx, msgs)
+}
+
+// setupMockWAL registers the walController as the mock WAL.
+func (w *walController) setupMockWAL(t *testing.T) {
+	mw := mock_streaming.NewMockWALAccesser(t)
+	f := func(ctx context.Context, msgs ...message.MutableMessage) types.AppendResponses {
+		return w.handleAppend(ctx, msgs)
+	}
+	mw.EXPECT().AppendMessages(mock.Anything, mock.Anything).RunAndReturn(f).Maybe()
+	mw.EXPECT().AppendMessages(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(f).Maybe()
+	mw.EXPECT().AppendMessages(mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(f).Maybe()
+	mw.EXPECT().AppendMessages(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(f).Maybe()
+	mw.EXPECT().AppendMessages(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(f).Maybe()
+	mw.EXPECT().AppendMessages(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(f).Maybe()
+	mw.EXPECT().AppendMessages(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(f).Maybe()
+	mw.EXPECT().AppendMessages(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(f).Maybe()
+	streaming.SetWALForTest(mw)
+}
+
+// catalogRecord records a single SaveBroadcastTask call.
+type catalogRecord struct {
+	BroadcastID uint64
+	State       streamingpb.BroadcastTaskState
+}
+
+// forcePromoteTestEnv holds the test environment for force promote failover tests.
+type forcePromoteTestEnv struct {
+	t           *testing.T
+	broadcaster Broadcaster
+	walCtrl     *walController
+	catalog     *mock_metastore.MockStreamingCoordCataLog
+	tombstoned  *typeutil.ConcurrentSet[uint64]
+
+	// catalogRecordsMu protects catalogRecords.
+	catalogRecordsMu sync.Mutex
+	catalogRecords   []catalogRecord
+}
+
+// initForcePromoteTestGlobals sets up global state (paramtable, balance, registry) once
+// at the top level of TestForcePromoteFailover to avoid race conditions between sub-tests.
+func initForcePromoteTestGlobals(t *testing.T) {
+	registry.ResetRegistration()
+	paramtable.Init()
+	balance.ResetBalancer()
+	paramtable.Get().StreamingCfg.WALBroadcasterTombstoneCheckInternal.SwapTempValue("10ms")
+	paramtable.Get().StreamingCfg.WALBroadcasterTombstoneMaxCount.SwapTempValue("2")
+	paramtable.Get().StreamingCfg.WALBroadcasterTombstoneMaxLifetime.SwapTempValue("20ms")
+
+	// Register dummy ack callbacks for all message types used in tests
+	registry.RegisterDropCollectionV1AckCallback(func(ctx context.Context, msg message.BroadcastResultDropCollectionMessageV1) error {
+		return nil
+	})
+	registry.RegisterAlterReplicateConfigV2AckCallback(func(ctx context.Context, msg message.BroadcastResultAlterReplicateConfigMessageV2) error {
+		return nil
+	})
+	registry.RegisterCreateCollectionV1AckCallback(func(ctx context.Context, msg message.BroadcastResultCreateCollectionMessageV1) error {
+		return nil
+	})
+	registry.RegisterCreatePartitionV1AckCallback(func(ctx context.Context, msg message.BroadcastResultCreatePartitionMessageV1) error {
+		return nil
+	})
+	registry.RegisterDropPartitionV1AckCallback(func(ctx context.Context, msg message.BroadcastResultDropPartitionMessageV1) error {
+		return nil
+	})
+
+	// Mock balancer: secondary cluster (for force promote)
+	mb := mock_balancer.NewMockBalancer(t)
+	mb.EXPECT().ReplicateRole().Return(replicateutil.RoleSecondary).Maybe()
+	mb.EXPECT().WatchChannelAssignments(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, cb balancer.WatchChannelAssignmentsCallback) error {
+		<-ctx.Done()
+		return ctx.Err()
+	}).Maybe()
+	balance.Register(mb)
+}
+
+// setupForcePromoteTest creates a full test environment with real broadcaster and mock WAL.
+func setupForcePromoteTest(
+	t *testing.T,
+	recoveryTasks []*streamingpb.BroadcastTask,
+	walBehaviors []appendBehavior,
+) *forcePromoteTestEnv {
+	catalog := mock_metastore.NewMockStreamingCoordCataLog(t)
+	catalog.EXPECT().ListBroadcastTask(mock.Anything).
+		Return(recoveryTasks, nil).Times(1)
+
+	tombstoned := typeutil.NewConcurrentSet[uint64]()
+	env := &forcePromoteTestEnv{
+		t:          t,
+		tombstoned: tombstoned,
+		catalog:    catalog,
+	}
+
+	catalog.EXPECT().SaveBroadcastTask(mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(ctx context.Context, broadcastID uint64, bt *streamingpb.BroadcastTask) error {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			env.catalogRecordsMu.Lock()
+			env.catalogRecords = append(env.catalogRecords, catalogRecord{
+				BroadcastID: broadcastID,
+				State:       bt.State,
+			})
+			env.catalogRecordsMu.Unlock()
+			if bt.State == streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_TOMBSTONE {
+				tombstoned.Insert(broadcastID)
+			}
+			return nil
+		}).Maybe()
+
+	rc := idalloc.NewMockRootCoordClient(t)
+	f := syncutil.NewFuture[internaltypes.MixCoordClient]()
+	f.Set(rc)
+	resource.InitForTest(resource.OptStreamingCatalog(catalog), resource.OptMixCoordClient(f))
+
+	bcFuture := syncutil.NewFuture[Broadcaster]()
+	walCtrl := newWALController(t, bcFuture)
+	if len(walBehaviors) > 0 {
+		walCtrl.setBehaviors(walBehaviors)
+	}
+	walCtrl.setupMockWAL(t)
+
+	bc, err := RecoverBroadcaster(context.Background())
+	assert.NoError(t, err)
+	assert.NotNil(t, bc)
+	bcFuture.Set(bc)
+
+	env.broadcaster = bc
+	env.walCtrl = walCtrl
+	return env
+}
+
+func (env *forcePromoteTestEnv) close() {
+	env.broadcaster.Close()
+	time.Sleep(50 * time.Millisecond)
+}
+
+// waitForTombstone waits until the given broadcastIDs all reach TOMBSTONE state.
+func (env *forcePromoteTestEnv) waitForTombstone(t *testing.T, timeout time.Duration, broadcastIDs ...uint64) {
+	assert.Eventually(t, func() bool {
+		for _, id := range broadcastIDs {
+			if !env.tombstoned.Contain(id) {
+				return false
+			}
+		}
+		return true
+	}, timeout, 10*time.Millisecond)
+}
+
+// getCatalogRecords returns a copy of all catalog save records.
+func (env *forcePromoteTestEnv) getCatalogRecords() []catalogRecord {
+	env.catalogRecordsMu.Lock()
+	defer env.catalogRecordsMu.Unlock()
+	result := make([]catalogRecord, len(env.catalogRecords))
+	copy(result, env.catalogRecords)
+	return result
+}
+
+// countCatalogStateTransitions counts how many times a broadcastID transitioned to a given state.
+func (env *forcePromoteTestEnv) countCatalogStateTransitions(broadcastID uint64, state streamingpb.BroadcastTaskState) int {
+	count := 0
+	for _, r := range env.getCatalogRecords() {
+		if r.BroadcastID == broadcastID && r.State == state {
+			count++
+		}
+	}
+	return count
+}
+
+// --- Helper functions for creating recovery tasks ---
+
+// createReplicatedDropCollectionTask creates a REPLICATED DropCollection task.
+func createReplicatedDropCollectionTask(broadcastID uint64, vchannels []string, ackedBitmap []byte) *streamingpb.BroadcastTask {
+	msg := createNewBroadcastMsg(vchannels).WithBroadcastID(broadcastID)
+	return createNewWaitAckBroadcastTaskFromMessage(msg,
+		streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_REPLICATED,
+		ackedBitmap)
+}
+
+// createReplicatedCreateCollectionTask creates a REPLICATED CreateCollection task.
+func createReplicatedCreateCollectionTask(broadcastID uint64, vchannels []string, ackedBitmap []byte) *streamingpb.BroadcastTask {
+	msg, err := message.NewCreateCollectionMessageBuilderV1().
+		WithHeader(&message.CreateCollectionMessageHeader{}).
+		WithBody(&msgpb.CreateCollectionRequest{}).
+		WithBroadcast(vchannels).
+		BuildBroadcast()
+	if err != nil {
+		panic(err)
+	}
+	return createNewWaitAckBroadcastTaskFromMessage(
+		msg.WithBroadcastID(broadcastID),
+		streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_REPLICATED,
+		ackedBitmap)
+}
+
+// createReplicatedCreatePartitionTask creates a REPLICATED CreatePartition task.
+func createReplicatedCreatePartitionTask(broadcastID uint64, vchannels []string, ackedBitmap []byte) *streamingpb.BroadcastTask {
+	msg, err := message.NewCreatePartitionMessageBuilderV1().
+		WithHeader(&message.CreatePartitionMessageHeader{}).
+		WithBody(&msgpb.CreatePartitionRequest{}).
+		WithBroadcast(vchannels).
+		BuildBroadcast()
+	if err != nil {
+		panic(err)
+	}
+	return createNewWaitAckBroadcastTaskFromMessage(
+		msg.WithBroadcastID(broadcastID),
+		streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_REPLICATED,
+		ackedBitmap)
+}
+
+// createReplicatedDropPartitionTask creates a REPLICATED DropPartition task.
+func createReplicatedDropPartitionTask(broadcastID uint64, vchannels []string, ackedBitmap []byte) *streamingpb.BroadcastTask {
+	msg, err := message.NewDropPartitionMessageBuilderV1().
+		WithHeader(&message.DropPartitionMessageHeader{}).
+		WithBody(&msgpb.DropPartitionRequest{}).
+		WithBroadcast(vchannels).
+		BuildBroadcast()
+	if err != nil {
+		panic(err)
+	}
+	return createNewWaitAckBroadcastTaskFromMessage(
+		msg.WithBroadcastID(broadcastID),
+		streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_REPLICATED,
+		ackedBitmap)
+}
+
+// createReplicatedAlterReplicateConfigTask creates a REPLICATED AlterReplicateConfig task.
+func createReplicatedAlterReplicateConfigTask(broadcastID uint64, vchannels []string, ackedBitmap []byte) *streamingpb.BroadcastTask {
+	msg := createAlterReplicateConfigBroadcastMsg(vchannels, false).WithBroadcastID(broadcastID)
+	return createNewWaitAckBroadcastTaskFromMessage(msg,
+		streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_REPLICATED,
+		ackedBitmap)
+}
+
+// createReplicatedForcePromoteTask creates a REPLICATED force promote task.
+func createReplicatedForcePromoteTask(broadcastID uint64, vchannels []string, ackedBitmap []byte) *streamingpb.BroadcastTask {
+	msg := createAlterReplicateConfigBroadcastMsg(vchannels, true).WithBroadcastID(broadcastID)
+	return createNewWaitAckBroadcastTaskFromMessage(msg,
+		streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_REPLICATED,
+		ackedBitmap)
+}
+
+// createPendingForcePromoteTask creates a PENDING force promote task (not yet broadcast).
+func createPendingForcePromoteTask(broadcastID uint64, vchannels []string) *streamingpb.BroadcastTask {
+	msg := createAlterReplicateConfigBroadcastMsg(vchannels, true).WithBroadcastID(broadcastID)
+	pb := msg.IntoMessageProto()
+	return &streamingpb.BroadcastTask{
+		Message: &messagespb.Message{
+			Payload:    pb.Payload,
+			Properties: pb.Properties,
+		},
+		State:               streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_PENDING,
+		AckedVchannelBitmap: make([]byte, len(vchannels)),
+	}
+}
+
+// --- Test Cases ---
+
+func TestForcePromoteFailover(t *testing.T) {
+	initForcePromoteTestGlobals(t)
+
+	// Control channel: "cc_vcchan"; data channels: "v1", "v2"
+	vchannels := []string{"cc_vcchan", "v1", "v2"}
+
+	t.Run("no_incomplete_tasks", func(t *testing.T) {
+		env := setupForcePromoteTest(t,
+			[]*streamingpb.BroadcastTask{
+				createReplicatedForcePromoteTask(100, vchannels, []byte{0x01, 0x01, 0x01}),
+			},
+			nil,
+		)
+		defer env.close()
+
+		env.waitForTombstone(t, 30*time.Second, 100)
+
+		// Verify: no WAL appends for fix (no incomplete tasks)
+		assert.Equal(t, int64(0), env.walCtrl.appendCount.Load())
+		// Verify: force promote task reached TOMBSTONE in catalog
+		assert.GreaterOrEqual(t, env.countCatalogStateTransitions(100,
+			streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_TOMBSTONE), 1)
+		// Verify: no append records at all
+		assert.Empty(t, env.walCtrl.getAppendRecords())
+	})
+
+	t.Run("fix_incomplete_drop_collection", func(t *testing.T) {
+		env := setupForcePromoteTest(t,
+			[]*streamingpb.BroadcastTask{
+				createReplicatedDropCollectionTask(10, vchannels, []byte{0x01, 0x00, 0x00}), // cc acked, v1/v2 pending
+				createReplicatedForcePromoteTask(100, vchannels, []byte{0x01, 0x01, 0x01}),  // all acked
+			},
+			nil,
+		)
+		defer env.close()
+
+		// Wait for ALL tasks to complete, not just force promote
+		env.waitForTombstone(t, 30*time.Second, 10, 100)
+
+		// Verify: exactly 2 pending messages supplemented (v1, v2 of Task 10)
+		assert.GreaterOrEqual(t, env.walCtrl.appendCount.Load(), int64(2))
+		// Verify: supplemented messages target the correct vchannels and broadcastID
+		records := env.walCtrl.getAppendRecords()
+		supplementedForTask10 := filterRecords(records, 10)
+		assert.GreaterOrEqual(t, len(supplementedForTask10), 2)
+		supplementedVChannels := collectVChannels(supplementedForTask10)
+		assert.Contains(t, supplementedVChannels, "v1")
+		assert.Contains(t, supplementedVChannels, "v2")
+		// Verify: supplemented messages are DropCollection type
+		for _, r := range supplementedForTask10 {
+			assert.Equal(t, message.MessageTypeDropCollection, r.MessageType)
+		}
+		// Verify: catalog persisted TOMBSTONE for both tasks
+		assert.GreaterOrEqual(t, env.countCatalogStateTransitions(10,
+			streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_TOMBSTONE), 1)
+		assert.GreaterOrEqual(t, env.countCatalogStateTransitions(100,
+			streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_TOMBSTONE), 1)
+	})
+
+	t.Run("fix_alter_replicate_config_with_ignore", func(t *testing.T) {
+		env := setupForcePromoteTest(t,
+			[]*streamingpb.BroadcastTask{
+				createReplicatedAlterReplicateConfigTask(10, vchannels, []byte{0x01, 0x01, 0x00}), // cc,v1 acked, v2 pending
+				createReplicatedDropCollectionTask(20, vchannels, []byte{0x01, 0x00, 0x00}),       // cc acked, v1/v2 pending
+				createReplicatedForcePromoteTask(100, vchannels, []byte{0x01, 0x01, 0x01}),        // all acked
+			},
+			nil,
+		)
+		defer env.close()
+
+		env.waitForTombstone(t, 30*time.Second, 10, 20, 100)
+
+		// Verify: all 3 tasks reached TOMBSTONE (full lifecycle completed)
+		assert.GreaterOrEqual(t, env.countCatalogStateTransitions(10,
+			streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_TOMBSTONE), 1)
+		assert.GreaterOrEqual(t, env.countCatalogStateTransitions(20,
+			streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_TOMBSTONE), 1)
+		assert.GreaterOrEqual(t, env.countCatalogStateTransitions(100,
+			streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_TOMBSTONE), 1)
+		// Verify: supplemented messages include AlterReplicateConfig + DropCollection
+		records := env.walCtrl.getAppendRecords()
+		alterRecords := filterRecords(records, 10)
+		dropRecords := filterRecords(records, 20)
+		assert.GreaterOrEqual(t, len(alterRecords), 1, "AlterReplicateConfig pending msg should be supplemented")
+		assert.GreaterOrEqual(t, len(dropRecords), 2, "DropCollection pending v1,v2 should be supplemented")
+		// Verify: message types are correct
+		for _, r := range alterRecords {
+			assert.Equal(t, message.MessageTypeAlterReplicateConfig, r.MessageType)
+		}
+		for _, r := range dropRecords {
+			assert.Equal(t, message.MessageTypeDropCollection, r.MessageType)
+		}
+		// Verify: DropCollection supplemented on v1 and v2
+		dropVCs := collectVChannels(dropRecords)
+		assert.Contains(t, dropVCs, "v1")
+		assert.Contains(t, dropVCs, "v2")
+	})
+
+	t.Run("wal_partial_failure_with_retry", func(t *testing.T) {
+		callCount := atomic.NewInt32(0)
+		env := setupForcePromoteTest(t,
+			[]*streamingpb.BroadcastTask{
+				createReplicatedDropCollectionTask(10, vchannels, []byte{0x01, 0x00, 0x00}),
+				createReplicatedForcePromoteTask(100, vchannels, []byte{0x01, 0x01, 0x01}),
+			},
+			[]appendBehavior{
+				{
+					handler: func(ctx context.Context, msgs []message.MutableMessage) types.AppendResponses {
+						callCount.Inc()
+						resps := types.AppendResponses{Responses: make([]types.AppendResponse, len(msgs))}
+						for i := range msgs {
+							resps.Responses[i] = types.AppendResponse{
+								Error: errors.New("wal unavailable"),
+							}
+						}
+						return resps
+					},
+				},
+			},
+		)
+		defer env.close()
+
+		env.waitForTombstone(t, 30*time.Second, 10, 100)
+		assert.GreaterOrEqual(t, callCount.Load(), int32(1))
+		assert.GreaterOrEqual(t, env.walCtrl.appendCount.Load(), int64(2))
+	})
+
+	t.Run("pending_force_promote_broadcast_then_fix", func(t *testing.T) {
+		env := setupForcePromoteTest(t,
+			[]*streamingpb.BroadcastTask{
+				createReplicatedDropCollectionTask(10, vchannels, []byte{0x00, 0x00, 0x00}),
+				createPendingForcePromoteTask(100, vchannels),
+			},
+			nil,
+		)
+		defer env.close()
+
+		env.waitForTombstone(t, 30*time.Second, 10, 100)
+
+		// Force promote broadcast (3) + fix Task 10 (3) = 6 total
+		assert.GreaterOrEqual(t, env.walCtrl.appendCount.Load(), int64(6))
+		// Verify: both force promote (ID=100) and DropCollection (ID=10) messages appended
+		records := env.walCtrl.getAppendRecords()
+		assert.GreaterOrEqual(t, len(filterRecords(records, 100)), 3, "force promote should be broadcast to 3 vchannels")
+		assert.GreaterOrEqual(t, len(filterRecords(records, 10)), 3, "DropCollection should be supplemented to 3 vchannels")
+	})
+
+	t.Run("context_canceled_exits_cleanly", func(t *testing.T) {
+		blockCh := make(chan struct{})
+		env := setupForcePromoteTest(t,
+			[]*streamingpb.BroadcastTask{
+				createReplicatedDropCollectionTask(10, vchannels, []byte{0x00, 0x00, 0x00}),
+				createReplicatedForcePromoteTask(100, vchannels, []byte{0x01, 0x01, 0x01}),
+			},
+			[]appendBehavior{
+				{
+					handler: func(ctx context.Context, msgs []message.MutableMessage) types.AppendResponses {
+						select {
+						case <-ctx.Done():
+						case <-blockCh:
+						}
+						resps := types.AppendResponses{Responses: make([]types.AppendResponse, len(msgs))}
+						for i := range msgs {
+							resps.Responses[i] = types.AppendResponse{Error: errors.New("context canceled")}
+						}
+						return resps
+					},
+				},
+			},
+		)
+
+		done := make(chan struct{})
+		go func() {
+			env.broadcaster.Close()
+			close(done)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			close(blockCh)
+			t.Fatal("broadcaster.Close() hung — possible goroutine leak")
+		}
+	})
+
+	t.Run("mixed_incomplete_tasks_ordering", func(t *testing.T) {
+		env := setupForcePromoteTest(t,
+			[]*streamingpb.BroadcastTask{
+				createReplicatedAlterReplicateConfigTask(10, vchannels, []byte{0x01, 0x01, 0x00}), // cc,v1 acked, v2 pending
+				createReplicatedDropCollectionTask(20, vchannels, []byte{0x01, 0x00, 0x00}),       // cc acked, v1/v2 pending
+				createReplicatedDropCollectionTask(30, vchannels, []byte{0x01, 0x00, 0x00}),       // cc acked, v1/v2 pending
+				createReplicatedForcePromoteTask(100, vchannels, []byte{0x01, 0x01, 0x01}),        // all acked
+			},
+			nil,
+		)
+		defer env.close()
+
+		env.waitForTombstone(t, 30*time.Second, 10, 20, 30, 100)
+
+		// Pending: Task 10 v2 (1) + Task 20 v1,v2 (2) + Task 30 v1,v2 (2) = 5
+		assert.GreaterOrEqual(t, env.walCtrl.appendCount.Load(), int64(5))
+		// Verify: records cover all 3 incomplete broadcastIDs
+		records := env.walCtrl.getAppendRecords()
+		broadcastIDsFound := collectBroadcastIDs(records)
+		assert.Contains(t, broadcastIDsFound, uint64(10))
+		assert.Contains(t, broadcastIDsFound, uint64(20))
+		assert.Contains(t, broadcastIDsFound, uint64(30))
+	})
+
+	t.Run("complex_multi_ddl_staggered_watermarks", func(t *testing.T) {
+		// Complex scenario: 5 incomplete tasks of different DDL types with staggered ack watermarks.
+		// WAL ordering constraint: on same vchannel, earlier broadcastID must ack before later one.
+		//
+		// Watermark analysis (per vchannel):
+		//   cc_vcchan: all tasks acked (all have cc=0x01)
+		//   v1: Task 10 acked, Task 15/20/25 pending → valid (watermark between 10 and 15)
+		//   v2: Task 10/15 acked, Task 20/25 pending → valid (watermark between 15 and 20)
+		env := setupForcePromoteTest(t,
+			[]*streamingpb.BroadcastTask{
+				createReplicatedAlterReplicateConfigTask(10, vchannels, []byte{0x01, 0x01, 0x01}), // cc,v1,v2 all acked → not incomplete
+				createReplicatedCreateCollectionTask(15, vchannels, []byte{0x01, 0x00, 0x01}),     // cc,v2 acked, v1 pending
+				createReplicatedDropCollectionTask(20, vchannels, []byte{0x01, 0x00, 0x00}),       // cc acked, v1/v2 pending
+				createReplicatedCreatePartitionTask(25, vchannels, []byte{0x01, 0x00, 0x00}),      // cc acked, v1/v2 pending
+				createReplicatedDropPartitionTask(30, vchannels, []byte{0x01, 0x00, 0x00}),        // cc acked, v1/v2 pending
+				createReplicatedForcePromoteTask(100, vchannels, []byte{0x01, 0x01, 0x01}),        // all acked
+			},
+			nil,
+		)
+		defer env.close()
+
+		env.waitForTombstone(t, 30*time.Second, 10, 15, 20, 25, 30, 100)
+
+		records := env.walCtrl.getAppendRecords()
+
+		// Task 10: fully acked → NOT supplemented (not incomplete)
+		assert.Empty(t, filterRecords(records, 10), "fully acked task should not be supplemented")
+
+		// Task 15 (CreateCollection): v1 pending → at least 1 msg supplemented
+		task15Records := filterRecords(records, 15)
+		assert.GreaterOrEqual(t, len(task15Records), 1, "CreateCollection should have pending msgs supplemented")
+		for _, r := range task15Records {
+			assert.Equal(t, message.MessageTypeCreateCollection, r.MessageType)
+		}
+
+		// Task 20 (DropCollection): v1,v2 pending → at least 2 msgs supplemented
+		task20Records := filterRecords(records, 20)
+		assert.GreaterOrEqual(t, len(task20Records), 2, "DropCollection should have 2 pending msgs supplemented")
+		for _, r := range task20Records {
+			assert.Equal(t, message.MessageTypeDropCollection, r.MessageType)
+		}
+
+		// Task 25 (CreatePartition): v1,v2 pending → at least 2 msgs supplemented
+		task25Records := filterRecords(records, 25)
+		assert.GreaterOrEqual(t, len(task25Records), 2, "CreatePartition should have 2 pending msgs supplemented")
+		for _, r := range task25Records {
+			assert.Equal(t, message.MessageTypeCreatePartition, r.MessageType)
+		}
+
+		// Task 30 (DropPartition): v1,v2 pending → at least 2 msgs supplemented
+		task30Records := filterRecords(records, 30)
+		assert.GreaterOrEqual(t, len(task30Records), 2, "DropPartition should have 2 pending msgs supplemented")
+		for _, r := range task30Records {
+			assert.Equal(t, message.MessageTypeDropPartition, r.MessageType)
+		}
+
+		// Total: 1 + 2 + 2 + 2 = 7 supplemented messages
+		assert.GreaterOrEqual(t, env.walCtrl.appendCount.Load(), int64(7))
+
+		// Verify: catalog has TOMBSTONE for ALL tasks (full lifecycle)
+		for _, id := range []uint64{10, 15, 20, 25, 30, 100} {
+			assert.GreaterOrEqual(t, env.countCatalogStateTransitions(id,
+				streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_TOMBSTONE), 1,
+				"task %d should reach TOMBSTONE", id)
+		}
+	})
+
+	t.Run("multiple_alter_replicate_configs_all_marked_ignore", func(t *testing.T) {
+		// Two AlterReplicateConfig tasks (pre-failover config changes) + other DDL.
+		// Both AlterReplicateConfig should be marked ignore=true and supplemented.
+		// The DDL tasks should be supplemented normally.
+		//
+		// Watermark:
+		//   v1: Task 10 acked, Task 12/20 pending → valid
+		//   v2: Task 10 acked, Task 12/20 pending → valid
+		env := setupForcePromoteTest(t,
+			[]*streamingpb.BroadcastTask{
+				createReplicatedAlterReplicateConfigTask(10, vchannels, []byte{0x01, 0x01, 0x01}), // fully acked → not incomplete
+				createReplicatedAlterReplicateConfigTask(12, vchannels, []byte{0x01, 0x00, 0x00}), // cc acked, v1/v2 pending
+				createReplicatedCreateCollectionTask(20, vchannels, []byte{0x01, 0x00, 0x00}),     // cc acked, v1/v2 pending
+				createReplicatedDropPartitionTask(25, vchannels, []byte{0x01, 0x00, 0x00}),        // cc acked, v1/v2 pending
+				createReplicatedForcePromoteTask(100, vchannels, []byte{0x01, 0x01, 0x01}),        // all acked
+			},
+			nil,
+		)
+		defer env.close()
+
+		env.waitForTombstone(t, 30*time.Second, 10, 12, 20, 25, 100)
+
+		records := env.walCtrl.getAppendRecords()
+
+		// Task 10: fully acked → NOT supplemented
+		assert.Empty(t, filterRecords(records, 10))
+
+		// Task 12 (AlterReplicateConfig): v1,v2 pending → 2 msgs, marked ignore
+		task12Records := filterRecords(records, 12)
+		assert.GreaterOrEqual(t, len(task12Records), 2)
+		for _, r := range task12Records {
+			assert.Equal(t, message.MessageTypeAlterReplicateConfig, r.MessageType)
+		}
+
+		// Task 20 (CreateCollection): v1,v2 pending → 2 msgs
+		task20Records := filterRecords(records, 20)
+		assert.GreaterOrEqual(t, len(task20Records), 2)
+		for _, r := range task20Records {
+			assert.Equal(t, message.MessageTypeCreateCollection, r.MessageType)
+		}
+
+		// Task 25 (DropPartition): v1,v2 pending → 2 msgs
+		task25Records := filterRecords(records, 25)
+		assert.GreaterOrEqual(t, len(task25Records), 2)
+		for _, r := range task25Records {
+			assert.Equal(t, message.MessageTypeDropPartition, r.MessageType)
+		}
+
+		// Total: 2 + 2 + 2 = 6 supplemented
+		assert.GreaterOrEqual(t, env.walCtrl.appendCount.Load(), int64(6))
+
+		// Verify: catalog recorded saves for all incomplete tasks (ignore marking, ack checkpoints, etc.)
+		catalogRecords := env.getCatalogRecords()
+		savedBroadcastIDs := make(map[uint64]bool)
+		for _, r := range catalogRecords {
+			savedBroadcastIDs[r.BroadcastID] = true
+		}
+		assert.True(t, savedBroadcastIDs[12], "AlterReplicateConfig task 12 should be saved (ignore marking)")
+	})
+}
+
+// --- Record filtering helpers ---
+
+func filterRecords(records []appendRecord, broadcastID uint64) []appendRecord {
+	var result []appendRecord
+	for _, r := range records {
+		if r.BroadcastID == broadcastID {
+			result = append(result, r)
+		}
+	}
+	return result
+}
+
+func collectVChannels(records []appendRecord) map[string]struct{} {
+	result := make(map[string]struct{})
+	for _, r := range records {
+		result[r.VChannel] = struct{}{}
+	}
+	return result
+}
+
+func collectBroadcastIDs(records []appendRecord) map[uint64]struct{} {
+	result := make(map[uint64]struct{})
+	for _, r := range records {
+		result[r.BroadcastID] = struct{}{}
+	}
+	return result
+}


### PR DESCRIPTION
Cherry-pick from master (PR still open)

pr: #48661

## Summary

Cherry-picked from master PR #48661 (open - preemptive backport)

- Fix duplicate `doForcePromoteFixIncompleteBroadcasts` invocation during force promote
- Remove duplicate call, keep Call A — fix starts immediately without waiting for FastLock
- `doForcePromoteFixIncompleteBroadcasts` owns full lifecycle: `BlockUntilAllAck` → fix (infinite retry) → acquire lock → ack callback
- Add infinite backoff retry for `fixIncompleteBroadcastsForForcePromote`
- Extract `retryUntilDone` and `acquireResourceKeyLockUntilDone` helpers
- Delegate force promote incomplete broadcast fix to broadcastScheduler
- Fix duplicate ack callback scheduling for recovered tasks

**Note**: Original PR is still open. This CP PR should be updated if the original PR changes.

## Verification

- [x] File count matches original PR (3 files)
- [x] Code changes verified (+1144/-141)
- [x] No conflict markers