### PR TITLE
fix: dual-write V3 text index and JSON key stats to prevent redundant stats tasks

### DIFF
--- a/internal/datanode/compactor/sort_compaction.go
+++ b/internal/datanode/compactor/sort_compaction.go
@@ -480,7 +480,9 @@ func (t *sortCompactionTask) Compact() (*datapb.CompactionPlanResult, error) {
 				}, nil
 			}
 			resultSegment.Manifest = newManifest
-			textStatsLogs = nil
+			// Dual-write: V3 segments store text index stats in both manifest and segment metadata.
+			// Manifest is the source of truth at load time; metadata acts as a placeholder so that
+			// needDoTextIndex() in stats_inspector.go won't trigger a redundant TextIndexJob.
 		}
 		resultSegment.TextStatsLogs = textStatsLogs
 	}

--- a/internal/datanode/index/task_stats.go
+++ b/internal/datanode/index/task_stats.go
@@ -627,7 +627,9 @@ func (st *statsTask) createTextIndex(ctx context.Context,
 			return fmt.Errorf("failed to add text index stats to manifest: %w", err)
 		}
 		st.manifestPath = newManifest
-		clear(textIndexLogs)
+		// Dual-write: keep textIndexLogs populated so it is stored in segment metadata as a
+		// placeholder. This prevents stats_inspector from re-triggering TextIndexJob for V3
+		// segments that already have text index stats in the manifest.
 	}
 
 	st.manager.StoreStatsTextIndexResult(st.req.GetClusterID(),
@@ -798,7 +800,9 @@ func (st *statsTask) createJSONKeyStats(ctx context.Context,
 			return fmt.Errorf("failed to add JSON key stats to manifest: %w", err)
 		}
 		st.manifestPath = newManifest
-		clear(jsonKeyIndexStats)
+		// Dual-write: keep jsonKeyIndexStats populated so it is stored in segment metadata as a
+		// placeholder. This prevents stats_inspector from re-triggering JsonKeyIndexJob for V3
+		// segments that already have JSON key stats in the manifest.
 	}
 
 	totalElapse := st.tr.RecordSpan()


### PR DESCRIPTION
Related to #48713

For V3 segments, sort compaction and stats tasks previously cleared TextStatsLogs/JsonKeyStats from segment metadata after writing them to the manifest. This caused needDoTextIndex()/needDoJsonKeyIndex() in stats_inspector to see nil entries and repeatedly trigger redundant TextIndexJob/JsonKeyIndexJob tasks.

Keep the stats populated in segment metadata as placeholders (dual-write) so the inspector recognizes work already done. The manifest remains the source of truth at load time; the StatsResolver ignores metadata for V3.