### PR TITLE
fix: [cp2.6]skip segment dist existence check during preProcess to avoid canceling in-flight RPCs

### DIFF
--- a/internal/querycoordv2/task/scheduler.go
+++ b/internal/querycoordv2/task/scheduler.go
@@ -658,7 +658,7 @@ func (scheduler *taskScheduler) promote(task Task) error {
 		zap.String("source", task.Source().String()),
 	)
 
-	if err := scheduler.check(task); err != nil {
+	if err := scheduler.check(task, true); err != nil {
 		log.Info("failed to promote task", zap.Error(err))
 		return err
 	}
@@ -937,7 +937,7 @@ func (scheduler *taskScheduler) preProcess(task Task) bool {
 	if task.IsFinished(scheduler.distMgr) {
 		task.SetStatus(TaskStatusSucceeded)
 	} else {
-		if err := scheduler.check(task); err != nil {
+		if err := scheduler.check(task, false); err != nil {
 			task.Cancel(err)
 		}
 	}
@@ -968,10 +968,10 @@ func (scheduler *taskScheduler) process(task Task) bool {
 	return executor.Execute(task, step)
 }
 
-func (scheduler *taskScheduler) check(task Task) error {
+func (scheduler *taskScheduler) check(task Task, checkDistExist bool) error {
 	err := task.Context().Err()
 	if err == nil {
-		err = scheduler.checkStale(task)
+		err = scheduler.checkStale(task, checkDistExist)
 	}
 
 	return err
@@ -1127,7 +1127,7 @@ func WrapTaskLog(task Task, fields ...zap.Field) []zap.Field {
 	return res
 }
 
-func (scheduler *taskScheduler) checkStale(task Task) error {
+func (scheduler *taskScheduler) checkStale(task Task, checkDistExist bool) error {
 	log := log.Ctx(task.Context()).With(
 		zap.String("task", task.String()),
 	)
@@ -1144,18 +1144,23 @@ func (scheduler *taskScheduler) checkStale(task Task) error {
 	}
 
 	// For segment grow tasks, check if segment is already loaded in dist.
-	// This prevents duplicate load tasks when checker generates tasks using stale dist snapshot
-	// but dist has been updated before the task is processed.
-	if segmentTask, ok := task.(*SegmentTask); ok && GetTaskType(task) == TaskTypeGrow && replica != nil {
-		existsInDist := scheduler.distMgr.SegmentDistManager.GetByFilter(
-			meta.WithCollectionID(task.CollectionID()),
-			meta.WithReplica(replica),
-			meta.WithSegmentID(segmentTask.SegmentID()),
-		)
-		if len(existsInDist) > 0 {
-			log.Info("task stale due to segment already loaded in dist",
-				zap.Int64("segmentID", segmentTask.SegmentID()))
-			return merr.WrapErrServiceInternal("segment already loaded in dist")
+	// This prevents duplicate load RPCs when the checker creates tasks from a stale dist snapshot
+	// but the segment has already been loaded before the task is dispatched.
+	// Only checked during promote (waitQueue → processQueue), not during preProcess,
+	// because during preProcess the segment may have been loaded by this task's own in-flight RPC,
+	// and canceling the task would kill that RPC with a misleading "context canceled" error.
+	if checkDistExist {
+		if segmentTask, ok := task.(*SegmentTask); ok && GetTaskType(task) == TaskTypeGrow && replica != nil {
+			existsInDist := scheduler.distMgr.SegmentDistManager.GetByFilter(
+				meta.WithCollectionID(task.CollectionID()),
+				meta.WithReplica(replica),
+				meta.WithSegmentID(segmentTask.SegmentID()),
+			)
+			if len(existsInDist) > 0 {
+				log.Info("task stale due to segment already loaded in dist",
+					zap.Int64("segmentID", segmentTask.SegmentID()))
+				return merr.WrapErrServiceInternal("segment already loaded in dist")
+			}
 		}
 	}
 


### PR DESCRIPTION
Cherry-pick from master
pr: #48721

## Summary

- Move the segment dist existence check (`existsInDist`) in `checkStale` from running in both `promote` and `preProcess` to only running during `promote`.
- During `preProcess`, the task's LoadSegments RPC may already be in-flight. If QueryNode loads the segment and reports it via heartbeat before the RPC returns, `preProcess` would incorrectly cancel the task — killing the in-flight RPC with a misleading `context canceled` error.

issue: #48722