### PR TITLE
test: add 3.0 branch CI rules to mergify

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -17,6 +17,7 @@ pull_request_rules:
       - or: &BRANCHES
           - &MASTER_BRANCH base=master
           - &2X_BRANCH base~=^2(\.\d+){1,2}$
+          - &3X_BRANCH base=3.0
 
 # ==============================================================================
 # PULL REQUEST RULES
@@ -106,12 +107,39 @@ pull_request_rules:
         add:
           - ci-passed
 
+  - name: Test passed for code changed on 3.0 branch
+    conditions:
+      - *3X_BRANCH
+      - or:
+          - 'status-success=ci-v2/build-ut-cov'
+      - or:
+          - 'status-success=ci-v2/e2e-amd'
+      - or:
+          - 'status-success=ci-v2/go-sdk'
+      - or: *WHEN_CODE_CHECK_MACOS_SUCCESS
+    actions:
+      label:
+        add:
+          - ci-passed
+
   # Special cases for minimal testing requirements
   - name: Test passed for tests changed
     conditions:
-      - or: *BRANCHES
+      - or:
+          - *MASTER_BRANCH
+          - *2X_BRANCH
       - -files~=^(?!tests\/python_client).+
       - or: *WHEN_E2E_TEST_SUCCESS
+    actions:
+      label:
+        add:
+          - ci-passed
+
+  - name: Test passed for tests changed on 3.0
+    conditions:
+      - *3X_BRANCH
+      - -files~=^(?!tests\/python_client).+
+      - 'status-success=ci-v2/e2e-amd'
     actions:
       label:
         add:
@@ -128,7 +156,9 @@ pull_request_rules:
 
   - name: Test passed for non rust go or c++ code changed
     conditions:
-      - or: *BRANCHES
+      - or:
+          - *MASTER_BRANCH
+          - *2X_BRANCH
       - or: *WHEN_E2E_TEST_SUCCESS
       - &no_source_code_files -files~=^(?=.*((\.(rs|go|h|cpp)|go.sum|go.mod|CMakeLists.txt|conanfile\.*))).*$
     actions:
@@ -136,14 +166,37 @@ pull_request_rules:
         add:
           - ci-passed
 
+  - name: Test passed for non source code changed on 3.0
+    conditions:
+      - *3X_BRANCH
+      - 'status-success=ci-v2/e2e-amd'
+      - *no_source_code_files
+    actions:
+      label:
+        add:
+          - ci-passed
+
   - name: Test passed for go unittest code changed-master
     conditions:
-      - or: *BRANCHES
+      - or:
+          - *MASTER_BRANCH
+          - *2X_BRANCH
       - &only_go_unittest_files -files~=^(?!(client|internal|pkg|tests)\/.*_test\.go).*$
       - or: *WHEN_BUILD_SUCCESS
       - or: *WHEN_CODE_CHECK_UBUNTU_SUCCESS
       - or: *WHEN_CODE_CHECK_MACOS_SUCCESS
       - or: *WHEN_GO_UNIT_TEST_SUCCESS
+    actions:
+      label:
+        add:
+          - ci-passed
+
+  - name: Test passed for go unittest code changed on 3.0
+    conditions:
+      - *3X_BRANCH
+      - *only_go_unittest_files
+      - 'status-success=ci-v2/build-ut-cov'
+      - or: *WHEN_CODE_CHECK_MACOS_SUCCESS
     actions:
       label:
         add:
@@ -172,7 +225,9 @@ pull_request_rules:
 
   - name: Test passed for skip e2e when source code changed
     conditions:
-      - or: *BRANCHES
+      - or:
+          - *MASTER_BRANCH
+          - *2X_BRANCH
       - or: *WHEN_BUILD_SUCCESS
       - title~=\[skip e2e\]
       - or: *WHEN_CPP_UNIT_TEST_SUCCESS
@@ -186,6 +241,18 @@ pull_request_rules:
         add:
           - ci-passed
 
+  - name: Test passed for skip e2e when source code changed on 3.0
+    conditions:
+      - *3X_BRANCH
+      - title~=\[skip e2e\]
+      - 'status-success=ci-v2/build-ut-cov'
+      - or: *WHEN_CODE_CHECK_MACOS_SUCCESS
+      - *source_code_files
+    actions:
+      label:
+        add:
+          - ci-passed
+
   # ==========================================================================
   # CI FAILURE HANDLING
   # Remove ci-passed labels when tests fail
@@ -193,7 +260,9 @@ pull_request_rules:
 
   - name: Remove ci-passed when E2E test not success for tests changed
     conditions:
-      - or: *BRANCHES
+      - or:
+          - *MASTER_BRANCH
+          - *2X_BRANCH
       - -files~=^(?!tests\/python_client).+
       - label!=manual-pass
       - label=ci-passed
@@ -201,6 +270,18 @@ pull_request_rules:
           or:
             - status-success=cpu-e2e
             - status-success=ci-v2/e2e-default
+    actions:
+      label:
+        remove:
+          - ci-passed
+
+  - name: Remove ci-passed when E2E test not success for tests changed on 3.0
+    conditions:
+      - *3X_BRANCH
+      - -files~=^(?!tests\/python_client).+
+      - label!=manual-pass
+      - label=ci-passed
+      - -status-success=ci-v2/e2e-amd
     actions:
       label:
         remove:
@@ -300,6 +381,34 @@ pull_request_rules:
         remove:
           - ci-passed
 
+  - name: Remove ci-passed when any CI fails on 3.0 branch
+    conditions:
+      - *3X_BRANCH
+      - label!=manual-pass
+      - *source_code_files
+      - or:
+          - and:
+              - -status-success = ci-v2/build-ut-cov
+              - status-failure = ci-v2/build-ut-cov
+          - and:
+              - -status-success = ci-v2/e2e-amd
+              - status-failure = ci-v2/e2e-amd
+          - and:
+              - -status-success = ci-v2/go-sdk
+              - status-failure = ci-v2/go-sdk
+          - and:
+              - not:
+                  or:
+                    - status-success = Code Checker MacOS 13
+                    - status-success = Code Checker MacOS
+              - or:
+                  - status-failure = Code Checker MacOS 13
+                  - status-failure = Code Checker MacOS
+    actions:
+      label:
+        remove:
+          - ci-passed
+
   # ==========================================================================
   # PR VALIDATION AND BLOCKING RULES
   # Ensure PRs meet project standards before merging
@@ -345,7 +454,9 @@ pull_request_rules:
 
   - name: Blocking PR if missing a related master PR or doesn't have kind/branch-feature label
     conditions:
-      - *2X_BRANCH
+      - or:
+          - *2X_BRANCH
+          - *3X_BRANCH
       - and:
           - -body~=pr\:\ \#[0-9]{1,6}(\s+|$)
           - -body~=https://github.com/milvus-io/milvus/pull/[0-9]{1,6}(\s+|$)
@@ -361,7 +472,9 @@ pull_request_rules:
 
   - name: Dismiss block label if related pr be added into PR
     conditions:
-      - *2X_BRANCH
+      - or:
+          - *2X_BRANCH
+          - *3X_BRANCH
       - or:
           - body~=pr\:\ \#[0-9]{1,6}(\s+|$)
           - body~=https://github.com/milvus-io/milvus/pull/[0-9]{1,6}(\s+|$)


### PR DESCRIPTION
## Summary
Add mergify rules for 3.0 branch CI (must be on master since mergify reads config from default branch only).

**3.0 ci-passed requires 4 checkers:**
- `ci-v2/build-ut-cov` (ciloop build + unit tests)
- `ci-v2/e2e-amd` (e2e-pool-dispatcher)
- `ci-v2/go-sdk` (Go SDK E2E)
- `Code Checker MacOS`

**Exemption rules** (split from master/2.x to use 3.0 checker names):
- tests only → `ci-v2/e2e-amd`
- non-source code → `ci-v2/e2e-amd`
- go unittest only → `ci-v2/build-ut-cov` + MacOS
- skip e2e + source → `ci-v2/build-ut-cov` + MacOS
- docs/mergify only → direct ci-passed

**Failure removal:** any of 4 checkers fail → remove ci-passed
**PR validation:** 3.0 PRs require related master PR (same as 2.x)

## Test plan
- [ ] PR targeting 3.0: verify ci-passed added when all 4 checkers pass
- [ ] PR targeting 3.0: verify ci-passed removed when any checker fails
- [ ] PR targeting master: verify existing rules unchanged