### PR TITLE
fix: upgrade minio image from minio/minio:RELEASE.2024-05-28T17-19-04…

### DIFF
--- a/deployments/docker/cluster-distributed-deployment/roles/deploy-minio/tasks/main.yml
+++ b/deployments/docker/cluster-distributed-deployment/roles/deploy-minio/tasks/main.yml
@@ -5,7 +5,7 @@
 - name: "minio"
   docker_container:
     name: minio
-    image: minio/minio:RELEASE.2024-05-28T17-19-04Z
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
     env:
       MINIO_ACCESS_KEY: minioadmin
       MINIO_SECRET_KEY: minioadmin

--- a/deployments/docker/dev/docker-compose-apple-silicon.yml
+++ b/deployments/docker/dev/docker-compose-apple-silicon.yml
@@ -34,7 +34,7 @@ services:
       - "18080:8080"
 
   minio:
-    image: minio/minio:RELEASE.2024-05-28T17-19-04Z
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
     ports:
       - "9000:9000"
       - "9001:9001"

--- a/deployments/docker/dev/docker-compose.yml
+++ b/deployments/docker/dev/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       - "18080:8080"
 
   minio:
-    image: minio/minio:RELEASE.2024-05-28T17-19-04Z
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
     ports:
       - "9000:9000"
       - "9001:9001"

--- a/deployments/docker/gpu/standalone/docker-compose.yml
+++ b/deployments/docker/gpu/standalone/docker-compose.yml
@@ -20,7 +20,7 @@ services:
 
   minio:
     container_name: milvus-minio
-    image: minio/minio:RELEASE.2024-05-28T17-19-04Z
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
     environment:
       MINIO_ACCESS_KEY: minioadmin
       MINIO_SECRET_KEY: minioadmin

--- a/deployments/docker/standalone/docker-compose.yml
+++ b/deployments/docker/standalone/docker-compose.yml
@@ -20,7 +20,7 @@ services:
 
   minio:
     container_name: milvus-minio
-    image: minio/minio:RELEASE.2024-05-28T17-19-04Z
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
     environment:
       MINIO_ACCESS_KEY: minioadmin
       MINIO_SECRET_KEY: minioadmin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,7 +121,7 @@ services:
       - PULSAR_GC=-XX:+UseG1GC
 
   minio:
-    image: minio/minio:RELEASE.2024-05-28T17-19-04Z
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
     environment:
       MINIO_ACCESS_KEY: minioadmin
       MINIO_SECRET_KEY: minioadmin

--- a/tests/python_client/deploy/cluster/docker-compose.yml
+++ b/tests/python_client/deploy/cluster/docker-compose.yml
@@ -29,7 +29,7 @@ services:
 
   minio:
     container_name: milvus-minio
-    image: minio/minio:RELEASE.2024-05-28T17-19-04Z
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
     environment:
       MINIO_ACCESS_KEY: minioadmin
       MINIO_SECRET_KEY: minioadmin

--- a/tests/python_client/deploy/standalone/docker-compose.yml
+++ b/tests/python_client/deploy/standalone/docker-compose.yml
@@ -14,7 +14,7 @@ services:
 
   minio:
     container_name: milvus-minio
-    image: minio/minio:RELEASE.2024-05-28T17-19-04Z
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
     environment:
       MINIO_ACCESS_KEY: minioadmin
       MINIO_SECRET_KEY: minioadmin


### PR DESCRIPTION
…Z to minio/minio:RELEASE.2025-09-07T16-13-09Z because minio/minio:RELEASE.2024-05-28T17-19-04Z does not have curl that's needed for compose healthcheck (#45643).

fixes #45643 