### PR TITLE
enhance: optimize C++ build speed by ~25% (3.0)

### DIFF
--- a/internal/core/CMakeLists.txt
+++ b/internal/core/CMakeLists.txt
@@ -54,7 +54,17 @@ else ()
     message(FATAL_ERROR "Unsupported platform!" )
 endif ()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
+# Use -g1 (minimal debug info) for Release to speed up compile & link;
+# full -g for Debug/RelWithDebInfo where detailed debugging matters.
+if (CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g1")
+else ()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
+endif ()
+
+# Use pipes between compiler stages instead of temp files (faster I/O)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pipe")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pipe")
 
 # Enable hardware popcnt for all compilation units on x86_64.
 # PopCountHelper in bitset/detail/popcount.h is header-only; without this flag,
@@ -78,6 +88,19 @@ endif ()
 set( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake" )
 include( Utils )
 
+# ---- Split DWARF (Linux only) ----
+# Moves debug info into .dwo files, dramatically reducing .o file sizes
+# and link time. Requires GCC 4.8+ or Clang 3.7+.
+if (LINUX AND NOT USE_ASAN STREQUAL "ON")
+    check_cxx_compiler_flag("-gsplit-dwarf" HAS_SPLIT_DWARF)
+    if (HAS_SPLIT_DWARF)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -gsplit-dwarf")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -gsplit-dwarf")
+        message(STATUS "Using -gsplit-dwarf for faster linking")
+    endif ()
+endif ()
+
+
 # **************************** Build time, type and code version ****************************
 get_current_time( BUILD_TIME )
 message( STATUS "Build time = ${BUILD_TIME}" )
@@ -95,6 +118,15 @@ set( CMAKE_EXPORT_COMPILE_COMMANDS ON )
 
 # **************************** Project ****************************
 project( milvus VERSION "${MILVUS_VERSION}" )
+
+# Unity (jumbo) build: merge multiple .cpp files per target into fewer
+# translation units, dramatically reducing redundant header parsing.
+if ( MILVUS_UNITY_BUILD )
+    set( CMAKE_UNITY_BUILD ON )
+    # ~8 sources per unity chunk is a good balance between speed and memory.
+    set( CMAKE_UNITY_BUILD_BATCH_SIZE 8 )
+    message( STATUS "Unity build enabled (batch size ${CMAKE_UNITY_BUILD_BATCH_SIZE})" )
+endif ()
 
 set( CMAKE_CXX_STANDARD 17 )
 set( CMAKE_CXX_STANDARD_REQUIRED on )

--- a/internal/core/cmake/DefineOptions.cmake
+++ b/internal/core/cmake/DefineOptions.cmake
@@ -59,6 +59,10 @@ define_option_string(MILVUS_DEPENDENCY_SOURCE
 
 define_option(MILVUS_USE_CCACHE "Use ccache when compiling (if available)" ON)
 
+define_option(MILVUS_USE_PCH "Use precompiled headers to speed up compilation" ON)
+
+define_option(MILVUS_UNITY_BUILD "Use CMake unity (jumbo) build to speed up compilation" OFF)
+
 define_option(MILVUS_VERBOSE_THIRDPARTY_BUILD
         "Show output from ExternalProjects rather than just logging to files" ON)
 

--- a/internal/core/cmake/milvus_pch.hxx
+++ b/internal/core/cmake/milvus_pch.hxx
@@ -1,0 +1,50 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Milvus precompiled header - STL + commonly-used third-party headers.
+// This file is auto-included via CMake's target_precompile_headers().
+// Adding a header here speeds up compilation for ALL 350+ .cpp files.
+// NOTE: Avoid adding very large headers (protobuf .pb.h) here — the per-target
+// PCH compilation cost outweighs the benefit at low parallelism (j8).
+
+// ---- STL headers (included in 50+ .cpp files) ----
+#include <string>
+#include <vector>
+#include <memory>
+#include <cstdint>
+#include <utility>
+#include <algorithm>
+#include <map>
+#include <unordered_map>
+#include <optional>
+#include <functional>
+#include <chrono>
+#include <string_view>
+#include <type_traits>
+#include <exception>
+#include <cstddef>
+#include <limits>
+#include <tuple>
+#include <set>
+#include <numeric>
+#include <mutex>
+#include <atomic>
+#include <stdexcept>
+#include <variant>
+
+// ---- Third-party headers (included in 40+ .cpp files, small parse cost) ----
+#include "fmt/core.h"
+#include "glog/logging.h"

--- a/internal/core/src/CMakeLists.txt
+++ b/internal/core/src/CMakeLists.txt
@@ -57,6 +57,30 @@ add_subdirectory( minhash )
 
 milvus_add_pkg_config("milvus_core")
 
+# ---- Precompiled Headers (PCH) ----
+# Apply the same STL PCH to all OBJECT libraries. Each target generates its
+# own PCH binary (small per-target overhead) but avoids cross-directory
+# REUSE_FROM issues with CMake < 3.22.
+if (MILVUS_USE_PCH)
+    # Use generator expression to apply PCH only for C++ compilation.
+    # The project enables both C and CXX languages; without this guard
+    # CMake would also generate a C PCH containing C++ headers, which fails.
+    set(MILVUS_PCH_HEADERS
+        # STL headers included in 50+ .cpp files
+        $<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/../cmake/milvus_pch.hxx>
+    )
+    # NOTE: milvus_bitset and milvus_minhash are excluded because they contain
+    # source files compiled with special target flags (-mavx512f, -march=armv8-a+sve)
+    # which are incompatible with PCH compiled under default target features.
+    foreach(_target
+        milvus_common milvus_config milvus_monitor milvus_storage milvus_index
+        milvus_query milvus_segcore milvus_indexbuilder milvus_clustering
+        milvus_exec milvus_futures milvus_rescores
+        milvus_plan)
+        target_precompile_headers(${_target} PRIVATE ${MILVUS_PCH_HEADERS})
+    endforeach()
+endif()
+
 add_library(milvus_core SHARED
     $<TARGET_OBJECTS:milvus_pb>
     $<TARGET_OBJECTS:milvus_config>

--- a/internal/core/thirdparty/tantivy/tantivy-binding/Cargo.toml
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/Cargo.toml
@@ -18,7 +18,7 @@ opt-level = 3
 debug = 1
 lto = true
 debug-assertions = false
-codegen-units = 1
+codegen-units = 4
 panic = "unwind"
 overflow-checks = false
 

--- a/scripts/3rdparty_build.sh
+++ b/scripts/3rdparty_build.sh
@@ -117,6 +117,8 @@ unset DYLD_LIBRARY_PATH
 unset DYLD_INSERT_LIBRARIES
 
 export CONAN_REVISIONS_ENABLED=1
+# Enable parallel downloads for faster dependency resolution
+export CONAN_CPU_COUNT=${CONAN_CPU_COUNT:-$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 4)}
 export CXXFLAGS="-Wno-error=address -Wno-error=deprecated-declarations -include cstdint"
 export CFLAGS="-Wno-error=address -Wno-error=deprecated-declarations"
 # LLVM from Homebrew doesn't set TARGET_OS_OSX=1 (unlike Apple's clang), which causes

--- a/scripts/core_build.sh
+++ b/scripts/core_build.sh
@@ -104,6 +104,9 @@ TANTIVY_FEATURES=""
 INDEX_ENGINE="KNOWHERE"
 ENABLE_AZURE_FS="ON"
 : "${ENABLE_GCP_NATIVE:="OFF"}"
+# Build acceleration options (override via env vars)
+: "${USE_PCH:="ON"}"
+: "${USE_UNITY_BUILD:="OFF"}"
 
 while getopts "p:t:s:n:a:y:x:o:f:ulcgbZh" arg; do
   case $arg in
@@ -246,7 +249,9 @@ ${CMAKE_EXTRA_ARGS} \
 -DINDEX_ENGINE=${INDEX_ENGINE} \
 -DTANTIVY_FEATURES_LIST=${TANTIVY_FEATURES} \
 -DENABLE_GCP_NATIVE=${ENABLE_GCP_NATIVE} \
--DENABLE_AZURE_FS=${ENABLE_AZURE_FS} "
+-DENABLE_AZURE_FS=${ENABLE_AZURE_FS} \
+-DMILVUS_USE_PCH=${USE_PCH} \
+-DMILVUS_UNITY_BUILD=${USE_UNITY_BUILD} "
 # Azure build variables removed as we now use Arrow with Azure support directly
 CMAKE_CMD=${CMAKE_CMD}"${CPP_SRC_DIR}"
 


### PR DESCRIPTION
## Summary
Cherry-pick from master PR #48696 to 3.0 branch.

- Enable precompiled headers (PCH) for core C++ build
- Add unity build for tantivy-binding (Cargo)
- Split 3rdparty build parallelism from core build
- Optimize CMake configuration caching

pr: #48696