### PR TITLE
fix: add StorageV3 manifest support for CacheOptFieldToDisk to prevent assert failure

### DIFF
--- a/internal/core/src/storage/DiskFileManagerImpl.cpp
+++ b/internal/core/src/storage/DiskFileManagerImpl.cpp
@@ -54,6 +54,7 @@
 #include "log/Log.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "nlohmann/json.hpp"
+#include "pb/schema.pb.h"
 #include "storage/ChunkManager.h"
 #include "storage/DataCodec.h"
 #include "storage/DiskFileManagerImpl.h"
@@ -1032,24 +1033,96 @@ DiskFileManagerImpl::CacheOptFieldToDisk(const Config& config) {
     auto storage_version =
         index::GetValueFromConfig<int64_t>(config, STORAGE_VERSION_KEY)
             .value_or(0);
+    if (storage_version == STORAGE_V3) {
+        return cache_opt_field_to_disk_v3(config);
+    }
+    if (storage_version == STORAGE_V2) {
+        return cache_opt_field_to_disk_v2(config);
+    }
+
+    // legacy path
+    auto opt_fields =
+        index::GetValueFromConfig<OptFieldT>(config, VEC_OPT_FIELDS);
+    if (!opt_fields.has_value()) {
+        return "";
+    }
+    auto fields_map = opt_fields.value();
+    const uint32_t num_of_fields = fields_map.size();
+    if (0 == num_of_fields) {
+        return "";
+    } else if (num_of_fields > 1) {
+        ThrowInfo(
+            ErrorCode::NotImplemented,
+            "vector index build with multiple fields is not supported yet");
+    }
+
+    auto segment_id = GetFieldDataMeta().segment_id;
+    auto vec_field_id = GetFieldDataMeta().field_id;
+    auto local_chunk_manager =
+        LocalChunkManagerSingleton::GetInstance().GetChunkManager();
+    auto local_data_path = storage::GenFieldRawDataPathPrefix(
+                               local_chunk_manager, segment_id, vec_field_id) +
+                           std::string(VEC_OPT_FIELDS);
+    local_chunk_manager->CreateFile(local_data_path);
+    uint64_t write_offset = 0;
+    WriteOptFieldsIvfMeta(
+        local_chunk_manager, local_data_path, num_of_fields, write_offset);
+
+    std::unordered_set<int64_t> actual_field_ids;
+    for (auto& [field_id, tup] : fields_map) {
+        const auto& field_type = std::get<1>(tup);
+
+        auto& field_paths = std::get<3>(tup);
+        if (0 == field_paths.size()) {
+            LOG_WARN("optional field {} has no data", field_id);
+            return "";
+        }
+
+        SortByPath(field_paths);
+        std::vector<FieldDataPtr> field_datas =
+            FetchFieldData(rcm_.get(), field_paths);
+
+        if (WriteOptFieldIvfData(field_type,
+                                 field_id,
+                                 local_chunk_manager,
+                                 local_data_path,
+                                 field_datas,
+                                 write_offset)) {
+            actual_field_ids.insert(field_id);
+        }
+    }
+
+    if (actual_field_ids.size() != num_of_fields) {
+        write_offset = 0;
+        WriteOptFieldsIvfMeta(local_chunk_manager,
+                              local_data_path,
+                              actual_field_ids.size(),
+                              write_offset);
+        if (actual_field_ids.empty()) {
+            return "";
+        }
+    }
+
+    return local_data_path;
+}
+
+std::string
+DiskFileManagerImpl::cache_opt_field_to_disk_v2(const Config& config) {
     auto opt_fields =
         index::GetValueFromConfig<OptFieldT>(config, VEC_OPT_FIELDS);
     if (!opt_fields.has_value()) {
         return "";
     }
 
-    std::vector<std::vector<std::string>> remote_files_storage_v2;
-    if (storage_version == STORAGE_V2 || storage_version == STORAGE_V3) {
-        auto segment_insert_files =
-            index::GetValueFromConfig<std::vector<std::vector<std::string>>>(
-                config, SEGMENT_INSERT_FILES_KEY);
-        AssertInfo(segment_insert_files.has_value(),
-                   "segment insert files is empty when build index while "
-                   "caching opt fields");
-        remote_files_storage_v2 = segment_insert_files.value();
-        for (auto& remote_files : remote_files_storage_v2) {
-            SortByPath(remote_files);
-        }
+    auto segment_insert_files =
+        index::GetValueFromConfig<std::vector<std::vector<std::string>>>(
+            config, SEGMENT_INSERT_FILES_KEY);
+    AssertInfo(segment_insert_files.has_value(),
+               "segment insert files is empty when build index while "
+               "caching opt fields");
+    auto remote_files_storage_v2 = segment_insert_files.value();
+    for (auto& remote_files : remote_files_storage_v2) {
+        SortByPath(remote_files);
     }
 
     auto fields_map = opt_fields.value();
@@ -1079,25 +1152,95 @@ DiskFileManagerImpl::CacheOptFieldToDisk(const Config& config) {
         const auto& field_type = std::get<1>(tup);
         const auto& element_type = std::get<2>(tup);
 
-        std::vector<FieldDataPtr> field_datas;
-        // fetch scalar data from storage v2
-        if (storage_version == STORAGE_V2 || storage_version == STORAGE_V3) {
-            field_datas = GetFieldDatasFromStorageV2(remote_files_storage_v2,
-                                                     field_id,
-                                                     field_type,
-                                                     element_type,
-                                                     1,
-                                                     fs_);
-        } else {  // original way
-            auto& field_paths = std::get<3>(tup);
-            if (0 == field_paths.size()) {
-                LOG_WARN("optional field {} has no data", field_id);
-                return "";
-            }
+        auto field_datas = GetFieldDatasFromStorageV2(remote_files_storage_v2,
+                                                      field_id,
+                                                      field_type,
+                                                      element_type,
+                                                      1,
+                                                      fs_);
 
-            SortByPath(field_paths);
-            field_datas = FetchFieldData(rcm_.get(), field_paths);
+        if (WriteOptFieldIvfData(field_type,
+                                 field_id,
+                                 local_chunk_manager,
+                                 local_data_path,
+                                 field_datas,
+                                 write_offset)) {
+            actual_field_ids.insert(field_id);
         }
+    }
+
+    if (actual_field_ids.size() != num_of_fields) {
+        write_offset = 0;
+        WriteOptFieldsIvfMeta(local_chunk_manager,
+                              local_data_path,
+                              actual_field_ids.size(),
+                              write_offset);
+        if (actual_field_ids.empty()) {
+            return "";
+        }
+    }
+
+    return local_data_path;
+}
+
+std::string
+DiskFileManagerImpl::cache_opt_field_to_disk_v3(const Config& config) {
+    auto opt_fields =
+        index::GetValueFromConfig<OptFieldT>(config, VEC_OPT_FIELDS);
+    if (!opt_fields.has_value()) {
+        return "";
+    }
+    auto fields_map = opt_fields.value();
+    const uint32_t num_of_fields = fields_map.size();
+    if (0 == num_of_fields) {
+        return "";
+    } else if (num_of_fields > 1) {
+        ThrowInfo(
+            ErrorCode::NotImplemented,
+            "vector index build with multiple fields is not supported yet");
+    }
+
+    auto manifest =
+        index::GetValueFromConfig<std::string>(config, SEGMENT_MANIFEST_KEY);
+    AssertInfo(manifest.has_value() && manifest.value() != "",
+               "[StorageV3] manifest path is empty when build index");
+    auto manifest_path_str = manifest.value();
+    AssertInfo(loon_ffi_properties_ != nullptr,
+               "[StorageV3] loon ffi properties is null when build index "
+               "with manifest");
+
+    auto segment_id = GetFieldDataMeta().segment_id;
+    auto vec_field_id = GetFieldDataMeta().field_id;
+    auto local_chunk_manager =
+        LocalChunkManagerSingleton::GetInstance().GetChunkManager();
+    auto local_data_path = storage::GenFieldRawDataPathPrefix(
+                               local_chunk_manager, segment_id, vec_field_id) +
+                           std::string(VEC_OPT_FIELDS);
+    local_chunk_manager->CreateFile(local_data_path);
+    uint64_t write_offset = 0;
+    WriteOptFieldsIvfMeta(
+        local_chunk_manager, local_data_path, num_of_fields, write_offset);
+
+    std::unordered_set<int64_t> actual_field_ids;
+    for (auto& [field_id, tup] : fields_map) {
+        const auto& field_type = std::get<1>(tup);
+        const auto& element_type = std::get<2>(tup);
+
+        // compose field schema for optional field
+        proto::schema::FieldSchema field_schema;
+        field_schema.set_fieldid(field_id);
+        field_schema.set_nullable(true);  // use always nullable
+        milvus::storage::FieldDataMeta field_meta{field_meta_.collection_id,
+                                                  field_meta_.partition_id,
+                                                  field_meta_.segment_id,
+                                                  field_id,
+                                                  field_schema};
+        auto field_datas = GetFieldDatasFromManifest(manifest_path_str,
+                                                     loon_ffi_properties_,
+                                                     field_meta,
+                                                     field_type,
+                                                     1,  // scalar field
+                                                     element_type);
 
         if (WriteOptFieldIvfData(field_type,
                                  field_id,

--- a/internal/core/src/storage/DiskFileManagerImpl.h
+++ b/internal/core/src/storage/DiskFileManagerImpl.h
@@ -240,6 +240,12 @@ class DiskFileManagerImpl : public FileManagerImpl {
     std::string
     cache_raw_data_to_disk_storage_v2(const Config& config);
 
+    std::string
+    cache_opt_field_to_disk_v2(const Config& config);
+
+    std::string
+    cache_opt_field_to_disk_v3(const Config& config);
+
     template <typename DataType>
     void
     cache_raw_data_to_disk_common(

--- a/internal/core/src/storage/MemFileManagerImpl.cpp
+++ b/internal/core/src/storage/MemFileManagerImpl.cpp
@@ -325,7 +325,10 @@ MemFileManagerImpl::CacheOptFieldToMemory(const Config& config) {
     auto storage_version =
         index::GetValueFromConfig<int64_t>(config, STORAGE_VERSION_KEY)
             .value_or(0);
-    if (storage_version == STORAGE_V2 || storage_version == STORAGE_V3) {
+    if (storage_version == STORAGE_V3) {
+        return cache_opt_field_memory_v3(config);
+    }
+    if (storage_version == STORAGE_V2) {
         return cache_opt_field_memory_v2(config);
     }
     return cache_opt_field_memory(config);
@@ -382,39 +385,6 @@ MemFileManagerImpl::cache_opt_field_memory_v2(const Config& config) {
             "vector index build with multiple fields is not supported yet");
     }
 
-    auto manifest =
-        index::GetValueFromConfig<std::string>(config, SEGMENT_MANIFEST_KEY);
-    // use manifest file for storage v2
-    auto manifest_path_str = manifest.value_or("");
-    if (manifest_path_str != "") {
-        AssertInfo(loon_ffi_properties_ != nullptr,
-                   "[StorageV2] loon ffi properties is null when build index "
-                   "with manifest");
-        std::unordered_map<int64_t, std::vector<std::vector<uint32_t>>> res;
-        for (auto& [field_id, tup] : fields_map) {
-            const auto& field_type = std::get<1>(tup);
-            const auto& element_type = std::get<2>(tup);
-
-            // compose field schema for optional field
-            proto::schema::FieldSchema field_schema;
-            field_schema.set_fieldid(field_id);
-            field_schema.set_nullable(true);  // use always nullable
-            milvus::storage::FieldDataMeta field_meta{field_meta_.collection_id,
-                                                      field_meta_.partition_id,
-                                                      field_meta_.segment_id,
-                                                      field_id,
-                                                      field_schema};
-            auto field_datas = GetFieldDatasFromManifest(manifest_path_str,
-                                                         loon_ffi_properties_,
-                                                         field_meta_,
-                                                         field_type,
-                                                         1,  // scalar field
-                                                         element_type);
-
-            res[field_id] = GetOptFieldIvfData(field_type, field_datas);
-        }
-        return res;
-    }
     auto segment_insert_files =
         index::GetValueFromConfig<std::vector<std::vector<std::string>>>(
             config, SEGMENT_INSERT_FILES_KEY);
@@ -432,6 +402,58 @@ MemFileManagerImpl::cache_opt_field_memory_v2(const Config& config) {
 
         auto field_datas = GetFieldDatasFromStorageV2(
             remote_files, field_id, field_type, element_type, 1, fs_);
+
+        res[field_id] = GetOptFieldIvfData(field_type, field_datas);
+    }
+    return res;
+}
+
+std::unordered_map<int64_t, std::vector<std::vector<uint32_t>>>
+MemFileManagerImpl::cache_opt_field_memory_v3(const Config& config) {
+    auto opt_fields =
+        index::GetValueFromConfig<OptFieldT>(config, VEC_OPT_FIELDS);
+    if (!opt_fields.has_value()) {
+        return {};
+    }
+    auto fields_map = opt_fields.value();
+    auto num_of_fields = fields_map.size();
+    if (0 == num_of_fields) {
+        return {};
+    } else if (num_of_fields > 1) {
+        ThrowInfo(
+            ErrorCode::NotImplemented,
+            "vector index build with multiple fields is not supported yet");
+    }
+
+    auto manifest =
+        index::GetValueFromConfig<std::string>(config, SEGMENT_MANIFEST_KEY);
+    AssertInfo(manifest.has_value() && manifest.value() != "",
+               "[StorageV3] manifest path is empty when build index");
+    auto manifest_path_str = manifest.value();
+    AssertInfo(loon_ffi_properties_ != nullptr,
+               "[StorageV3] loon ffi properties is null when build index "
+               "with manifest");
+
+    std::unordered_map<int64_t, std::vector<std::vector<uint32_t>>> res;
+    for (auto& [field_id, tup] : fields_map) {
+        const auto& field_type = std::get<1>(tup);
+        const auto& element_type = std::get<2>(tup);
+
+        // compose field schema for optional field
+        proto::schema::FieldSchema field_schema;
+        field_schema.set_fieldid(field_id);
+        field_schema.set_nullable(true);  // use always nullable
+        milvus::storage::FieldDataMeta field_meta{field_meta_.collection_id,
+                                                  field_meta_.partition_id,
+                                                  field_meta_.segment_id,
+                                                  field_id,
+                                                  field_schema};
+        auto field_datas = GetFieldDatasFromManifest(manifest_path_str,
+                                                     loon_ffi_properties_,
+                                                     field_meta,
+                                                     field_type,
+                                                     1,  // scalar field
+                                                     element_type);
 
         res[field_id] = GetOptFieldIvfData(field_type, field_datas);
     }

--- a/internal/core/src/storage/MemFileManagerImpl.h
+++ b/internal/core/src/storage/MemFileManagerImpl.h
@@ -98,6 +98,9 @@ class MemFileManagerImpl : public FileManagerImpl {
     std::unordered_map<int64_t, std::vector<std::vector<uint32_t>>>
     cache_opt_field_memory_v2(const Config& config);
 
+    std::unordered_map<int64_t, std::vector<std::vector<uint32_t>>>
+    cache_opt_field_memory_v3(const Config& config);
+
  private:
     // remote file path
     std::map<std::string, int64_t> remote_paths_to_size_;


### PR DESCRIPTION
Related to #48749

DiskFileManagerImpl::CacheOptFieldToDisk had no manifest handling for StorageV3, unconditionally reading segment_insert_files which would file not found error.

Also fix MemFileManagerImpl::cache_opt_field_memory_v2 passing the vector field's member field_meta_ instead of the locally constructed scalar field_meta to GetFieldDatasFromManifest.

Refactor CacheOptField dispatch in both MemFileManagerImpl and DiskFileManagerImpl to use explicit 3-way branching (V3/V2/legacy) with dedicated _v2 and _v3 methods.