### PR TITLE
fix: V3 snapshot restore fails for segments with JSON key stats or text index

### DIFF
--- a/internal/datacoord/copy_segment_task.go
+++ b/internal/datacoord/copy_segment_task.go
@@ -589,6 +589,16 @@ func AssembleCopySegmentRequest(task CopySegmentTask, job CopySegmentJob) (*data
 				return nil, err
 			}
 		}
+		for _, textIndex := range sourceSegDesc.GetTextIndexFiles() {
+			if err := allocNewBuildID(textIndex.GetBuildID()); err != nil {
+				return nil, err
+			}
+		}
+		for _, jsonStats := range sourceSegDesc.GetJsonKeyIndexFiles() {
+			if err := allocNewBuildID(jsonStats.GetBuildID()); err != nil {
+				return nil, err
+			}
+		}
 		// Build target with IDs and buildID mappings
 		target := &datapb.CopySegmentTarget{
 			CollectionId: job.GetCollectionId(),

--- a/internal/datacoord/handler.go
+++ b/internal/datacoord/handler.go
@@ -828,7 +828,7 @@ func (h *ServerHandler) GenSnapshot(ctx context.Context, collectionID UniqueID) 
 func uncompressJsonStats(h *ServerHandler, segInfo *datapb.SegmentInfo, jsonStats *datapb.JsonKeyStats) *datapb.JsonKeyStats {
 	prefix := metautil.BuildJSONKeyStatsPrefix(h.s.meta.chunkManager.RootPath(), jsonStats.GetJsonKeyStatsDataFormat(),
 		jsonStats.GetBuildID(), jsonStats.GetVersion(), segInfo.GetCollectionID(), segInfo.GetPartitionID(), segInfo.GetID(), jsonStats.GetFieldID())
-	uncompressedFiles := make([]string, 0)
+	uncompressedFiles := make([]string, 0, len(jsonStats.GetFiles()))
 	for _, file := range jsonStats.GetFiles() {
 		uncompressedFiles = append(uncompressedFiles, path.Join(prefix, file))
 	}

--- a/internal/datanode/importv2/copy_segment_utils.go
+++ b/internal/datanode/importv2/copy_segment_utils.go
@@ -239,13 +239,19 @@ func collectSegmentFiles(
 			zap.Int64("storageVersion", source.GetStorageVersion()))
 	}
 
-	// Other types always from pb (not yet in manifest)
+	// Other types from pb
 	files.DeltaBinlogs = extractFromPb(source.GetDeltaBinlogs())
 	files.StatsBinlogs = extractFromPb(source.GetStatsBinlogs())
 	files.Bm25Binlogs = extractFromPb(source.GetBm25Binlogs())
 	files.VectorScalarIndex = extractIndexFiles(source.GetIndexFiles())
-	files.TextIndex = extractTextIndexFiles(source.GetTextIndexFiles())
-	files.JsonKeyIndex, files.JsonStats = extractJsonFiles(source.GetJsonKeyIndexFiles())
+
+	// For V3, text/json stats files live under basePath/_stats/ and are already
+	// included in InsertBinlogs via listAllFiles(). Skip pb extraction to avoid
+	// using potentially stale or wrong-format paths from etcd metadata.
+	if source.GetStorageVersion() < storage.StorageV3 {
+		files.TextIndex = extractTextIndexFiles(source.GetTextIndexFiles())
+		files.JsonKeyIndex, files.JsonStats = extractJsonFiles(source.GetJsonKeyIndexFiles())
+	}
 
 	return files, nil
 }
@@ -648,44 +654,69 @@ func buildIndexInfoFromSource(
 		}
 	}
 
-	// Process text indexes - transform file paths
+	// Process text indexes
+	// For V3, text files are already copied via manifest basePath/_stats/;
+	// pass metadata as placeholders (etcd paths may be stale or wrong format).
+	// For V2, transform file paths using mappings.
 	textIndexInfos := make(map[int64]*datapb.TextIndexStats)
-	for fieldID, srcText := range source.GetTextIndexFiles() {
-		// Transform text index file paths using mappings
-		targetFiles := make([]string, 0, len(srcText.GetFiles()))
-		for _, srcFile := range srcText.GetFiles() {
-			targetFile, ok := mappings[srcFile]
-			if !ok {
-				return nil, nil, nil, fmt.Errorf("no mapping found for text index file: %s", srcFile)
+	if source.GetStorageVersion() >= storage.StorageV3 {
+		for fieldID, srcText := range source.GetTextIndexFiles() {
+			dstText := proto.Clone(srcText).(*datapb.TextIndexStats)
+			if newID, ok := target.GetNewBuildIds()[dstText.GetBuildID()]; ok {
+				dstText.BuildID = newID
 			}
-			targetFiles = append(targetFiles, targetFile)
+			textIndexInfos[fieldID] = dstText
 		}
+	} else {
+		for fieldID, srcText := range source.GetTextIndexFiles() {
+			targetFiles := make([]string, 0, len(srcText.GetFiles()))
+			for _, srcFile := range srcText.GetFiles() {
+				targetFile, ok := mappings[srcFile]
+				if !ok {
+					return nil, nil, nil, fmt.Errorf("no mapping found for text index file: %s", srcFile)
+				}
+				targetFiles = append(targetFiles, targetFile)
+			}
 
-		dstText := proto.Clone(srcText).(*datapb.TextIndexStats)
-		dstText.Files = targetFiles
-		textIndexInfos[fieldID] = dstText
+			dstText := proto.Clone(srcText).(*datapb.TextIndexStats)
+			dstText.Files = targetFiles
+			if newID, ok := target.GetNewBuildIds()[dstText.GetBuildID()]; ok {
+				dstText.BuildID = newID
+			}
+			textIndexInfos[fieldID] = dstText
+		}
 	}
 
-	// Process JSON Key indexes - transform file paths
+	// Process JSON Key indexes
+	// For V3, json files are already copied via manifest basePath/_stats/;
+	// pass metadata as placeholders. For V2, transform file paths using mappings.
 	jsonKeyIndexInfos := make(map[int64]*datapb.JsonKeyStats)
-	for fieldID, srcJson := range source.GetJsonKeyIndexFiles() {
-		// Transform JSON index file paths using mappings
-		targetFiles := make([]string, 0, len(srcJson.GetFiles()))
-		for _, srcFile := range srcJson.GetFiles() {
-			targetFile, ok := mappings[srcFile]
-			if !ok {
-				return nil, nil, nil, fmt.Errorf("no mapping found for JSON index file: %s", srcFile)
+	if source.GetStorageVersion() >= storage.StorageV3 {
+		for fieldID, srcJson := range source.GetJsonKeyIndexFiles() {
+			dstJson := proto.Clone(srcJson).(*datapb.JsonKeyStats)
+			if newID, ok := target.GetNewBuildIds()[dstJson.GetBuildID()]; ok {
+				dstJson.BuildID = newID
 			}
-			targetFiles = append(targetFiles, targetFile)
+			jsonKeyIndexInfos[fieldID] = dstJson
 		}
+	} else {
+		for fieldID, srcJson := range source.GetJsonKeyIndexFiles() {
+			targetFiles := make([]string, 0, len(srcJson.GetFiles()))
+			for _, srcFile := range srcJson.GetFiles() {
+				targetFile, ok := mappings[srcFile]
+				if !ok {
+					return nil, nil, nil, fmt.Errorf("no mapping found for JSON index file: %s", srcFile)
+				}
+				targetFiles = append(targetFiles, targetFile)
+			}
 
-		dstJson := proto.Clone(srcJson).(*datapb.JsonKeyStats)
-		dstJson.Files = targetFiles
-		// Use new buildID if available
-		if newID, ok := target.GetNewBuildIds()[dstJson.GetBuildID()]; ok {
-			dstJson.BuildID = newID
+			dstJson := proto.Clone(srcJson).(*datapb.JsonKeyStats)
+			dstJson.Files = targetFiles
+			if newID, ok := target.GetNewBuildIds()[dstJson.GetBuildID()]; ok {
+				dstJson.BuildID = newID
+			}
+			jsonKeyIndexInfos[fieldID] = dstJson
 		}
-		jsonKeyIndexInfos[fieldID] = dstJson
 	}
 
 	return indexInfos, textIndexInfos, jsonKeyIndexInfos, nil

--- a/internal/datanode/importv2/copy_segment_utils_test.go
+++ b/internal/datanode/importv2/copy_segment_utils_test.go
@@ -1771,3 +1771,100 @@ func TestListAllFiles(t *testing.T) {
 		assert.Nil(t, files)
 	})
 }
+
+// TestCopySegmentAndIndexFiles_V3WithTextAndJsonStats verifies that V3 segments
+// with text index and JSON key stats succeed during copy. Before the fix, V3
+// segments had wrong-format paths in TextIndexFiles/JsonKeyIndexFiles (etcd
+// metadata), causing "no mapping found" errors during buildIndexInfoFromSource.
+// The fix skips pb path extraction for V3 (files already copied via manifest
+// basePath/_stats/) and passes metadata as placeholders.
+func TestCopySegmentAndIndexFiles_V3WithTextAndJsonStats(t *testing.T) {
+	manifestPath := packed.MarshalManifestPath("files/insert_log/111/222/333", 2)
+
+	source := &datapb.CopySegmentSource{
+		CollectionId:   111,
+		PartitionId:    222,
+		SegmentId:      333,
+		StorageVersion: storage.StorageV3,
+		ManifestPath:   manifestPath,
+		InsertBinlogs: []*datapb.FieldBinlog{
+			{
+				FieldID: 100,
+				Binlogs: []*datapb.Binlog{
+					{EntriesNum: 500, LogPath: "files/insert_log/111/222/333/100/10001", LogSize: 1024},
+				},
+			},
+		},
+		// Text index with relative paths (as stored in etcd after dual-write fix)
+		TextIndexFiles: map[int64]*datapb.TextIndexStats{
+			101: {
+				FieldID: 101,
+				BuildID: 7000,
+				Version: 1,
+				Files:   []string{"tokenizer.json", "index.data"},
+			},
+		},
+		// JSON key stats with relative paths (as stored in etcd after dual-write fix)
+		JsonKeyIndexFiles: map[int64]*datapb.JsonKeyStats{
+			102: {
+				FieldID:                102,
+				BuildID:                8000,
+				Version:                1,
+				Files:                  []string{"shared_key_index/.managed.json_0", "shared_key_index/.managed.json_1"},
+				JsonKeyStatsDataFormat: 3,
+			},
+		},
+	}
+
+	target := &datapb.CopySegmentTarget{
+		CollectionId: 444,
+		PartitionId:  555,
+		SegmentId:    666,
+		NewBuildIds:  map[int64]int64{7000: 7777, 8000: 9000},
+	}
+
+	mList := mockey.Mock(listAllFiles).To(func(_ context.Context, _ storage.ChunkManager, basePath string) ([]string, error) {
+		// Simulate listing all files under basePath including _stats/
+		return []string{
+			"files/insert_log/111/222/333/_data/0",
+			"files/insert_log/111/222/333/_metadata/manifest.json",
+			"files/insert_log/111/222/333/_stats/text_index.101/tokenizer.json",
+			"files/insert_log/111/222/333/_stats/text_index.101/index.data",
+			"files/insert_log/111/222/333/_stats/json_key_index.102/shared_key_index/.managed.json_0",
+			"files/insert_log/111/222/333/_stats/json_key_index.102/shared_key_index/.managed.json_1",
+		}, nil
+	}).Build()
+	defer mList.UnPatch()
+
+	mCopy := mockey.Mock(copyFile).Return(nil).Build()
+	defer mCopy.UnPatch()
+
+	cm := &struct{ storage.ChunkManager }{}
+	result, copiedFiles, err := CopySegmentAndIndexFiles(context.Background(), cm, source, target, nil)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, int64(666), result.SegmentId)
+
+	// Verify text index metadata is passed through as placeholder
+	assert.Len(t, result.TextIndexInfos, 1)
+	assert.Contains(t, result.TextIndexInfos, int64(101))
+	// Files are passed through as-is (placeholder, not mapped)
+	assert.Equal(t, []string{"tokenizer.json", "index.data"}, result.TextIndexInfos[101].GetFiles())
+	assert.Equal(t, int64(7777), result.TextIndexInfos[101].GetBuildID(), "text index buildID should be remapped")
+
+	// Verify JSON key stats metadata is passed through as placeholder with new buildID
+	assert.Len(t, result.JsonKeyIndexInfos, 1)
+	assert.Contains(t, result.JsonKeyIndexInfos, int64(102))
+	assert.Equal(t, int64(9000), result.JsonKeyIndexInfos[102].GetBuildID(), "buildID should be remapped")
+	// Files are passed through as-is (placeholder, not mapped)
+	assert.Equal(t, []string{"shared_key_index/.managed.json_0", "shared_key_index/.managed.json_1"},
+		result.JsonKeyIndexInfos[102].GetFiles())
+
+	// Verify manifest path is transformed
+	expectedManifestPath := packed.MarshalManifestPath("files/insert_log/444/555/666", 2)
+	assert.Equal(t, expectedManifestPath, result.ManifestPath)
+
+	// Verify _stats files are included in the copy (from listAllFiles, part of InsertBinlogs)
+	assert.True(t, len(copiedFiles) >= 6, "should copy all files including _stats/")
+}

--- a/internal/datanode/index/task_stats.go
+++ b/internal/datanode/index/task_stats.go
@@ -610,17 +610,22 @@ func (st *statsTask) createTextIndex(ctx context.Context,
 	// When manifest_path is set, register text index stats in manifest.
 	// C++ Upload() returns relative paths; convert to absolute by prepending basePath
 	// before registering with manifest (loon library expects absolute paths).
+	// Use a separate copy for manifest so the original stats retain relative paths
+	// for dual-write to etcd (etcd stores relative paths, reconstructed on read).
 	if st.manifestPath != "" && len(textIndexLogs) > 0 {
-		for _, stats := range textIndexLogs {
+		manifestStats := make(map[int64]*datapb.TextIndexStats, len(textIndexLogs))
+		for fieldID, stats := range textIndexLogs {
+			cloned := proto.Clone(stats).(*datapb.TextIndexStats)
 			basePath, err := computeStatsBasePath(st.req, st.manifestPath, "text_index", stats.GetFieldID())
 			if err != nil {
 				return err
 			}
-			for i, f := range stats.GetFiles() {
-				stats.Files[i] = basePath + "/" + f
+			for i, f := range cloned.GetFiles() {
+				cloned.Files[i] = basePath + "/" + f
 			}
+			manifestStats[fieldID] = cloned
 		}
-		statEntries := packed.TextIndexStatEntries(textIndexLogs, st.req.GetCurrentScalarIndexVersion())
+		statEntries := packed.TextIndexStatEntries(manifestStats, st.req.GetCurrentScalarIndexVersion())
 		newManifest, err := packed.AddStatsToManifest(
 			st.manifestPath, st.req.GetStorageConfig(), statEntries)
 		if err != nil {
@@ -783,17 +788,22 @@ func (st *statsTask) createJSONKeyStats(ctx context.Context,
 	// When manifest_path is set, register JSON key stats in manifest.
 	// C++ Upload() returns relative paths; convert to absolute by prepending basePath
 	// before registering with manifest (loon library expects absolute paths).
+	// Use a separate copy for manifest so the original stats retain relative paths
+	// for dual-write to etcd (etcd stores relative paths, reconstructed on read).
 	if st.manifestPath != "" && len(jsonKeyIndexStats) > 0 {
-		for _, stats := range jsonKeyIndexStats {
+		manifestStats := make(map[int64]*datapb.JsonKeyStats, len(jsonKeyIndexStats))
+		for fieldID, stats := range jsonKeyIndexStats {
+			cloned := proto.Clone(stats).(*datapb.JsonKeyStats)
 			basePath, err := computeStatsBasePath(st.req, st.manifestPath, "json_key_index", stats.GetFieldID())
 			if err != nil {
 				return err
 			}
-			for i, f := range stats.GetFiles() {
-				stats.Files[i] = basePath + "/" + f
+			for i, f := range cloned.GetFiles() {
+				cloned.Files[i] = basePath + "/" + f
 			}
+			manifestStats[fieldID] = cloned
 		}
-		statEntries := packed.JSONKeyStatEntries(jsonKeyIndexStats)
+		statEntries := packed.JSONKeyStatEntries(manifestStats)
 		newManifest, err := packed.AddStatsToManifest(
 			st.manifestPath, st.req.GetStorageConfig(), statEntries)
 		if err != nil {


### PR DESCRIPTION
## Summary

- Fix dual-write path pollution: clone stats before manifest path mutation so etcd retains relative paths
- Fix V3 copy segment: skip text/json stats pb path extraction for V3 (files already copied via manifest `listAllFiles`), pass metadata as placeholders
- Add test for V3 copy segment with text index and JSON key stats

## Root Cause

Two bugs combined:
1. `task_stats.go` mutated `stats.Files` in-place when prepending basePath for manifest, polluting the same object dual-written to etcd
2. `copy_segment_utils.go` extracted text/json paths from pb for V3 segments, but these paths were wrong format (full V3 paths instead of relative), causing "no mapping found" during restore

## Test plan

- [ ] `TestCopySegmentAndIndexFiles_V3WithTextAndJsonStats` — verifies V3 copy segment with text/json stats succeeds, metadata passed as placeholders, buildID remapped
- [ ] Existing `TestCopySegmentAndIndexFiles_WithManifest` — verifies V3 copy still works without text/json
- [ ] CI e2e snapshot restore tests

issue: #48752

🤖 Generated with [Claude Code](https://claude.com/claude-code)