### PR TITLE
test: revert mergify format upgrade, restore misc section with 3.0 rules

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -7,22 +7,75 @@
 # GLOBAL CONFIGURATIONS AND ALIASES
 # Define reusable conditions and patterns for better maintainability
 # ==============================================================================
-pull_request_rules:
-  # ==========================================================================
-  # DCO (Developer Certificate of Origin) MANAGEMENT
-  # Handles DCO compliance for all contributions
-  # ==========================================================================
-  - name: Add needs-dco label when DCO check failed
-    conditions:
-      - or: &BRANCHES
-          - &MASTER_BRANCH base=master
-          - &2X_BRANCH base~=^2(\.\d+){1,2}$
-          - &3X_BRANCH base=3.0
+misc:
+  # File pattern matchers
+  - &source_code_files files~=^(?=.*((\.(rs|go|h|cpp)|go.sum|go.mod|CMakeLists.txt|conanfile\.*))).*$
+  - &no_source_code_files -files~=^(?=.*((\.(rs|go|h|cpp)|go.sum|go.mod|CMakeLists.txt|conanfile\.*))).*$
+  - &only_go_unittest_files -files~=^(?!(client|internal|pkg|tests)\/.*_test\.go).*$
+  - &morethan_go_unittest_files files~=^(?!(client|internal|pkg|tests)\/.*_test\.go).*$
+  
+  # Build and test status conditions
+  - when_build_and_test_status_successs: &Build_AND_TEST_STATUS_SUCESS_ON_UBUNTU_20_OR_UBUNTU_22
+      - 'status-success=Build and test AMD64 Ubuntu 20.04'
+      - 'status-success=Build and test AMD64 Ubuntu 22.04'
+  - when_build_and_test_status_failed: &Build_AND_TEST_STATUS_FAILED_ON_UBUNTU_20_OR_UBUNTU_22
+      - &failed_on_ubuntu_20 'check-failure=Build and test AMD64 Ubuntu 20.04'
+      - &failed_on_ubuntu_22 'check-failure=Build and test AMD64 Ubuntu 22.04'
+  - when_go_sdk_status_success: &WHEN_GO_SDK_STATUS_SUCCESS
+      - 'status-success=go-sdk'
+      - 'status-success=milvus-sdk-go'
+      - 'status-success=ci-v2/go-sdk'
+  - when_cpp_unit_test_success: &WHEN_CPP_UNIT_TEST_SUCCESS
+      - 'status-success=cpp-unit-test'
+      - 'status-success=UT for Cpp'
+      - 'status-success=ci-v2/ut-cpp'
+  - when_go_unit_test_success: &WHEN_GO_UNIT_TEST_SUCCESS
+      - 'status-success=go-unit-test'
+      - 'status-success=UT for Go'
+      - 'status-success=ci-v2/ut-go'
+  - when_integration_unit_test_success: &WHEN_INTEGRATION_UNIT_TEST_SUCCESS
+      - 'status-success=integration-test'
+      - 'status-success=Integration Test'
+      - 'status-success=ci-v2/integration-test'
+  - when_e2e_test_success: &WHEN_E2E_TEST_SUCCESS
+      - 'status-success=cpu-e2e'
+      - 'status-success=ci-v2/e2e-default'
+  - when_build_success: &WHEN_BUILD_SUCCESS
+      - 'status-success=Build and test AMD64 Ubuntu 22.04'
+      - 'status-success=ci-v2/build'
+  - when_code_check_ubuntu_success: &WHEN_CODE_CHECK_UBUNTU_SUCCESS
+      - 'status-success=Code Checker AMD64 Ubuntu 22.04'
+      - 'status-success=ci-v2/code-check'
+  - when_code_check_macos_success: &WHEN_CODE_CHECK_MACOS_SUCCESS
+      - 'status-success=Code Checker MacOS 13'
+      - 'status-success=Code Checker MacOS'
+
+  # CI-v2 checker conditions (3.0 branch)
+  - when_build_ut_cov_success: &WHEN_BUILD_UT_COV_SUCCESS
+      - 'status-success=ci-v2/build-ut-cov'
+  - when_e2e_amd_success: &WHEN_E2E_AMD_SUCCESS
+      - 'status-success=ci-v2/e2e-amd'
+
+  # Branch configurations
+  - branch: &BRANCHES
+      - &MASTER_BRANCH base=master
+      - &2X_BRANCH base~=^2(\.\d+){1,2}$
+      - &3X_BRANCH base=3.0
 
 # ==============================================================================
 # PULL REQUEST RULES
 # Organized by functionality for better maintenance and understanding
 # ==============================================================================
+pull_request_rules:
+  
+  # ==========================================================================
+  # DCO (Developer Certificate of Origin) MANAGEMENT
+  # Handles DCO compliance for all contributions
+  # ==========================================================================
+  
+  - name: Add needs-dco label when DCO check failed
+    conditions:
+      - or: *BRANCHES
       - -status-success=DCO
     actions:
       label:
@@ -49,46 +102,25 @@ pull_request_rules:
   # CONTINUOUS INTEGRATION (CI) STATUS MANAGEMENT
   # Rules for managing CI test results and labeling PRs accordingly
   # ==========================================================================
-  - name: Test passed for code changed on master
+  
+  - name: Test passed for code changed on master 
     conditions:
       - *MASTER_BRANCH
-      - or: &WHEN_BUILD_SUCCESS
-          - 'status-success=Build and test AMD64 Ubuntu 22.04'
-          - 'status-success=ci-v2/build'
-      - or:
-          - 'status-success=go-sdk'
-          - 'status-success=milvus-sdk-go'
-          - 'status-success=ci-v2/go-sdk'
-      - or: &WHEN_CPP_UNIT_TEST_SUCCESS
-          - 'status-success=cpp-unit-test'
-          - 'status-success=UT for Cpp'
-          - 'status-success=ci-v2/ut-cpp'
-      - or: &WHEN_GO_UNIT_TEST_SUCCESS
-          - 'status-success=go-unit-test'
-          - 'status-success=UT for Go'
-          - 'status-success=ci-v2/ut-go'
-      - or: &WHEN_INTEGRATION_UNIT_TEST_SUCCESS
-          - 'status-success=integration-test'
-          - 'status-success=Integration Test'
-          - 'status-success=ci-v2/integration-test'
-      - or: &WHEN_E2E_TEST_SUCCESS
-          - 'status-success=cpu-e2e'
-          - 'status-success=ci-v2/e2e-default'
-      - or: &WHEN_CODE_CHECK_UBUNTU_SUCCESS
-          - 'status-success=Code Checker AMD64 Ubuntu 22.04'
-          - 'status-success=ci-v2/code-check'
-      - or: &WHEN_CODE_CHECK_MACOS_SUCCESS
-          - 'status-success=Code Checker MacOS 13'
-          - 'status-success=Code Checker MacOS'
-
-  # Branch configurations
+      - or: *WHEN_BUILD_SUCCESS
+      - or: *WHEN_GO_SDK_STATUS_SUCCESS
+      - or: *WHEN_CPP_UNIT_TEST_SUCCESS
+      - or: *WHEN_GO_UNIT_TEST_SUCCESS
+      - or: *WHEN_INTEGRATION_UNIT_TEST_SUCCESS
+      - or: *WHEN_E2E_TEST_SUCCESS
+      - or: *WHEN_CODE_CHECK_UBUNTU_SUCCESS
+      - or: *WHEN_CODE_CHECK_MACOS_SUCCESS
       # - 'status-success=codecov/patch'
       # - 'status-success=codecov/project'
     actions:
       label:
         add:
           - ci-passed
-
+          
   - name: Test passed for code changed on 2.* branch
     conditions:
       - *2X_BRANCH
@@ -110,12 +142,9 @@ pull_request_rules:
   - name: Test passed for code changed on 3.0 branch
     conditions:
       - *3X_BRANCH
-      - or:
-          - 'status-success=ci-v2/build-ut-cov'
-      - or:
-          - 'status-success=ci-v2/e2e-amd'
-      - or:
-          - 'status-success=ci-v2/go-sdk'
+      - or: *WHEN_BUILD_UT_COV_SUCCESS
+      - or: *WHEN_E2E_AMD_SUCCESS
+      - or: *WHEN_GO_SDK_STATUS_SUCCESS
       - or: *WHEN_CODE_CHECK_MACOS_SUCCESS
     actions:
       label:
@@ -126,8 +155,8 @@ pull_request_rules:
   - name: Test passed for tests changed
     conditions:
       - or:
-          - *MASTER_BRANCH
-          - *2X_BRANCH
+        - *MASTER_BRANCH
+        - *2X_BRANCH
       - -files~=^(?!tests\/python_client).+
       - or: *WHEN_E2E_TEST_SUCCESS
     actions:
@@ -139,7 +168,7 @@ pull_request_rules:
     conditions:
       - *3X_BRANCH
       - -files~=^(?!tests\/python_client).+
-      - 'status-success=ci-v2/e2e-amd'
+      - or: *WHEN_E2E_AMD_SUCCESS
     actions:
       label:
         add:
@@ -157,10 +186,10 @@ pull_request_rules:
   - name: Test passed for non rust go or c++ code changed
     conditions:
       - or:
-          - *MASTER_BRANCH
-          - *2X_BRANCH
+        - *MASTER_BRANCH
+        - *2X_BRANCH
       - or: *WHEN_E2E_TEST_SUCCESS
-      - &no_source_code_files -files~=^(?=.*((\.(rs|go|h|cpp)|go.sum|go.mod|CMakeLists.txt|conanfile\.*))).*$
+      - *no_source_code_files
     actions:
       label:
         add:
@@ -169,7 +198,7 @@ pull_request_rules:
   - name: Test passed for non source code changed on 3.0
     conditions:
       - *3X_BRANCH
-      - 'status-success=ci-v2/e2e-amd'
+      - or: *WHEN_E2E_AMD_SUCCESS
       - *no_source_code_files
     actions:
       label:
@@ -179,9 +208,9 @@ pull_request_rules:
   - name: Test passed for go unittest code changed-master
     conditions:
       - or:
-          - *MASTER_BRANCH
-          - *2X_BRANCH
-      - &only_go_unittest_files -files~=^(?!(client|internal|pkg|tests)\/.*_test\.go).*$
+        - *MASTER_BRANCH
+        - *2X_BRANCH
+      - *only_go_unittest_files
       - or: *WHEN_BUILD_SUCCESS
       - or: *WHEN_CODE_CHECK_UBUNTU_SUCCESS
       - or: *WHEN_CODE_CHECK_MACOS_SUCCESS
@@ -195,7 +224,7 @@ pull_request_rules:
     conditions:
       - *3X_BRANCH
       - *only_go_unittest_files
-      - 'status-success=ci-v2/build-ut-cov'
+      - or: *WHEN_BUILD_UT_COV_SUCCESS
       - or: *WHEN_CODE_CHECK_MACOS_SUCCESS
     actions:
       label:
@@ -226,8 +255,8 @@ pull_request_rules:
   - name: Test passed for skip e2e when source code changed
     conditions:
       - or:
-          - *MASTER_BRANCH
-          - *2X_BRANCH
+        - *MASTER_BRANCH
+        - *2X_BRANCH
       - or: *WHEN_BUILD_SUCCESS
       - title~=\[skip e2e\]
       - or: *WHEN_CPP_UNIT_TEST_SUCCESS
@@ -235,7 +264,7 @@ pull_request_rules:
       - or: *WHEN_INTEGRATION_UNIT_TEST_SUCCESS
       - or: *WHEN_CODE_CHECK_UBUNTU_SUCCESS
       - or: *WHEN_CODE_CHECK_MACOS_SUCCESS
-      - &source_code_files files~=^(?=.*((\.(rs|go|h|cpp)|go.sum|go.mod|CMakeLists.txt|conanfile\.*))).*$
+      - *source_code_files
     actions:
       label:
         add:
@@ -245,7 +274,7 @@ pull_request_rules:
     conditions:
       - *3X_BRANCH
       - title~=\[skip e2e\]
-      - 'status-success=ci-v2/build-ut-cov'
+      - or: *WHEN_BUILD_UT_COV_SUCCESS
       - or: *WHEN_CODE_CHECK_MACOS_SUCCESS
       - *source_code_files
     actions:
@@ -261,8 +290,8 @@ pull_request_rules:
   - name: Remove ci-passed when E2E test not success for tests changed
     conditions:
       - or:
-          - *MASTER_BRANCH
-          - *2X_BRANCH
+        - *MASTER_BRANCH
+        - *2X_BRANCH
       - -files~=^(?!tests\/python_client).+
       - label!=manual-pass
       - label=ci-passed
@@ -295,87 +324,87 @@ pull_request_rules:
   - name: Remove ci-passed when any CI system fails during migration
     conditions:
       - or:
-          - *MASTER_BRANCH
-          - *2X_BRANCH
+        - *MASTER_BRANCH
+        - *2X_BRANCH
       - label!=manual-pass
       - *source_code_files
       # Comprehensive failure logic: remove ci-passed when any required system fails
       - or:
         # Build systems: remove if no success AND has failure
-          - and:
-              - not:
-                  or:
-                    - status-success = Build and test AMD64 Ubuntu 22.04
-                    - status-success = ci-v2/build
-              - or:
-                  - status-failure = Build and test AMD64 Ubuntu 22.04
-                  - status-failure = ci-v2/build
+        - and:
+            - not:
+                or:
+                  - status-success = Build and test AMD64 Ubuntu 22.04
+                  - status-success = ci-v2/build
+            - or:
+                - status-failure = Build and test AMD64 Ubuntu 22.04
+                - status-failure = ci-v2/build
         # Go unit tests: remove if no success AND has failure
-          - and:
-              - not:
-                  or:
-                    - status-success = UT for Go
-                    - status-success = ci-v2/ut-go
-              - or:
-                  - status-failure = UT for Go
-                  - status-failure = ci-v2/ut-go
+        - and:
+            - not:
+                or:
+                  - status-success = UT for Go
+                  - status-success = ci-v2/ut-go
+            - or:
+                - status-failure = UT for Go
+                - status-failure = ci-v2/ut-go
         # Integration tests: remove if no success AND has failure
-          - and:
-              - not:
-                  or:
-                    - status-success = Integration Test
-                    - status-success = ci-v2/integration-test
-              - or:
-                  - status-failure = Integration Test
-                  - status-failure = ci-v2/integration-test
+        - and:
+            - not:
+                or:
+                  - status-success = Integration Test
+                  - status-success = ci-v2/integration-test
+            - or:
+                - status-failure = Integration Test
+                - status-failure = ci-v2/integration-test
         # Cpp unit tests: remove if no success AND has failure (only when cpp files changed)
-          - and:
-              - &morethan_go_unittest_files files~=^(?!(client|internal|pkg|tests)\/.*_test\.go).*$
-              - not:
-                  or:
-                    - status-success = cpp-unit-test
-                    - status-success = ci-v2/ut-cpp
-              - or:
-                  - status-failure = cpp-unit-test
-                  - status-failure = ci-v2/ut-cpp
+        - and:
+          - *morethan_go_unittest_files
+          - not:
+              or:
+                - status-success = cpp-unit-test
+                - status-success = ci-v2/ut-cpp
+          - or:
+              - status-failure = cpp-unit-test
+              - status-failure = ci-v2/ut-cpp
         # Code checker Ubuntu: remove if no success AND has failure
-          - and:
-              - not:
-                  or:
-                    - status-success = Code Checker AMD64 Ubuntu 22.04
-                    - status-success = ci-v2/code-check
-              - or:
-                  - status-failure = Code Checker AMD64 Ubuntu 22.04
-                  - status-failure = ci-v2/code-check
+        - and:
+            - not:
+                or:
+                  - status-success = Code Checker AMD64 Ubuntu 22.04
+                  - status-success = ci-v2/code-check
+            - or:
+                - status-failure = Code Checker AMD64 Ubuntu 22.04
+                - status-failure = ci-v2/code-check
         # Code checker MacOS: remove if no success AND has failure
-          - and:
-              - not:
-                  or:
-                    - status-success = Code Checker MacOS 13
-                    - status-success = Code Checker MacOS
-              - or:
-                  - status-failure = Code Checker MacOS 13
-                  - status-failure = Code Checker MacOS
+        - and:
+            - not:
+                or:
+                  - status-success = Code Checker MacOS 13
+                  - status-success = Code Checker MacOS
+            - or:
+                - status-failure = Code Checker MacOS 13
+                - status-failure = Code Checker MacOS
         # E2E tests: regular case - remove if no success AND has failure
-          - and:
-              - not:
-                  or:
-                    - status-success = cpu-e2e
-                    - status-success = ci-v2/e2e-default
-              - or:
-                  - status-failure = cpu-e2e
-                  - status-failure = ci-v2/e2e-default
+        - and:
+            - not:
+                or:
+                  - status-success = cpu-e2e
+                  - status-success = ci-v2/e2e-default
+            - or:
+                - status-failure = cpu-e2e
+                - status-failure = ci-v2/e2e-default
         # E2E tests: required case - remove if no success AND has failure (when not skipped)
-          - and:
-              - -title~=\[skip e2e\]
-              - files~=^(?!(.*_test\.go|.*\.md|\.github\/mergify\.yml)).*$
-              - not:
-                  or:
-                    - status-success = cpu-e2e
-                    - status-success = ci-v2/e2e-default
-              - or:
-                  - status-failure = cpu-e2e
-                  - status-failure = ci-v2/e2e-default
+        - and:
+          - -title~=\[skip e2e\]
+          - files~=^(?!(.*_test\.go|.*\.md|\.github\/mergify\.yml)).*$
+          - not:
+              or:
+                - status-success = cpu-e2e
+                - status-success = ci-v2/e2e-default
+          - or:
+              - status-failure = cpu-e2e
+              - status-failure = ci-v2/e2e-default
     actions:
       label:
         remove:
@@ -421,14 +450,14 @@ pull_request_rules:
           - -body~=\#[0-9]{1,6}(\s+|$)
           - -body~=https://github.com/milvus-io/milvus/issues/[0-9]{1,6}(\s+|$)
       - or:
-          - and:
-              - label=kind/enhancement
-              - or:
-                  - label=size/L
-                  - label=size/XL
-                  - label=size/XXL
-          - label=kind/bug
-          - label=kind/feature
+        - and:
+          - label=kind/enhancement
+          - or:
+            - label=size/L
+            - label=size/XL
+            - label=size/XXL
+        - label=kind/bug
+        - label=kind/feature
       - -label=kind/doc
       - -label=kind/test
       - -title~=\[automated\]
@@ -455,8 +484,8 @@ pull_request_rules:
   - name: Blocking PR if missing a related master PR or doesn't have kind/branch-feature label
     conditions:
       - or:
-          - *2X_BRANCH
-          - *3X_BRANCH
+        - *2X_BRANCH
+        - *3X_BRANCH
       - and:
           - -body~=pr\:\ \#[0-9]{1,6}(\s+|$)
           - -body~=https://github.com/milvus-io/milvus/pull/[0-9]{1,6}(\s+|$)
@@ -473,8 +502,8 @@ pull_request_rules:
   - name: Dismiss block label if related pr be added into PR
     conditions:
       - or:
-          - *2X_BRANCH
-          - *3X_BRANCH
+        - *2X_BRANCH
+        - *3X_BRANCH
       - or:
           - body~=pr\:\ \#[0-9]{1,6}(\s+|$)
           - body~=https://github.com/milvus-io/milvus/pull/[0-9]{1,6}(\s+|$)
@@ -539,8 +568,8 @@ pull_request_rules:
     conditions:
       - or: *BRANCHES
       - or:
-          - '-title~=^(feat:|enhance:|fix:|test:|doc:|auto:|build\(deps\):|\[automated\])'
-          - body=^$
+        - '-title~=^(feat:|enhance:|fix:|test:|doc:|auto:|build\(deps\):|\[automated\])'
+        - body=^$
     actions:
       label:
         add:
@@ -730,4 +759,4 @@ pull_request_rules:
           - lgtm
           - approved
 
-
+        


### PR DESCRIPTION
## Summary
Revert `ci(mergify): upgrade configuration to current format (#46385)` which removed the `misc:` section and broke mergify rule evaluation — all PRs stuck on "Your rules are under evaluation".

Restore the `misc:` section with YAML anchors (the working format) and include 3.0 branch CI rules.

**Root cause**: The format upgrade removed `misc:` and inlined anchors into `pull_request_rules:`. This caused mergify to get stuck evaluating rules indefinitely.

## Test plan
- [ ] After merge, verify mergify processes PRs again (ci-passed labels appear)
- [ ] Verify 3.0 branch PRs get ci-passed with 4 checkers