### PR TITLE
fix: clear only file paths in V3 stats metadata to prevent redundant tasks and stale references

### DIFF
--- a/internal/datanode/compactor/sort_compaction.go
+++ b/internal/datanode/compactor/sort_compaction.go
@@ -480,9 +480,12 @@ func (t *sortCompactionTask) Compact() (*datapb.CompactionPlanResult, error) {
 				}, nil
 			}
 			resultSegment.Manifest = newManifest
-			// Dual-write: V3 segments store text index stats in both manifest and segment metadata.
-			// Manifest is the source of truth at load time; metadata acts as a placeholder so that
-			// needDoTextIndex() in stats_inspector.go won't trigger a redundant TextIndexJob.
+			// V3 segments store text index stats in the manifest (source of truth at load time).
+			// Clear file paths from metadata to avoid stale references, but keep the map entries
+			// as placeholders so needDoTextIndex() in stats_inspector.go won't trigger redundant jobs.
+			for _, stats := range textStatsLogs {
+				stats.Files = nil
+			}
 		}
 		resultSegment.TextStatsLogs = textStatsLogs
 	}

--- a/internal/datanode/index/task_stats.go
+++ b/internal/datanode/index/task_stats.go
@@ -627,9 +627,12 @@ func (st *statsTask) createTextIndex(ctx context.Context,
 			return fmt.Errorf("failed to add text index stats to manifest: %w", err)
 		}
 		st.manifestPath = newManifest
-		// Dual-write: keep textIndexLogs populated so it is stored in segment metadata as a
-		// placeholder. This prevents stats_inspector from re-triggering TextIndexJob for V3
-		// segments that already have text index stats in the manifest.
+		// V3 segments store text index stats in the manifest (source of truth at load time).
+		// Clear file paths from metadata to avoid stale references, but keep the map entries
+		// as placeholders so needDoTextIndex() in stats_inspector.go won't trigger redundant jobs.
+		for _, stats := range textIndexLogs {
+			stats.Files = nil
+		}
 	}
 
 	st.manager.StoreStatsTextIndexResult(st.req.GetClusterID(),
@@ -800,9 +803,12 @@ func (st *statsTask) createJSONKeyStats(ctx context.Context,
 			return fmt.Errorf("failed to add JSON key stats to manifest: %w", err)
 		}
 		st.manifestPath = newManifest
-		// Dual-write: keep jsonKeyIndexStats populated so it is stored in segment metadata as a
-		// placeholder. This prevents stats_inspector from re-triggering JsonKeyIndexJob for V3
-		// segments that already have JSON key stats in the manifest.
+		// V3 segments store JSON key stats in the manifest (source of truth at load time).
+		// Clear file paths from metadata to avoid stale references, but keep the map entries
+		// as placeholders so needDoJsonKeyIndex() in stats_inspector.go won't trigger redundant jobs.
+		for _, stats := range jsonKeyIndexStats {
+			stats.Files = nil
+		}
 	}
 
 	totalElapse := st.tr.RecordSpan()


### PR DESCRIPTION
For V3 segments, sort compaction and stats tasks previously cleared the entire TextStatsLogs/JsonKeyStats entries (or kept full file paths via dual-write) from segment metadata after writing them to the manifest.

- Clearing entirely caused needDoTextIndex()/needDoJsonKeyIndex() in stats_inspector to see nil entries and repeatedly trigger redundant TextIndexJob/JsonKeyIndexJob tasks.
- Dual-write (keeping full absolute file paths) left stale references in metadata that could confuse downstream consumers like copy segment's file mapping lookup.

Now clear only the Files list while preserving the map entries and other metadata fields (FieldID, Version, BuildID, JsonKeyStatsDataFormat, etc.) as placeholders. This ensures:

1. stats_inspector sees non-nil entries and skips redundant job creation
2. No stale file paths in metadata that could cause "no mapping found" errors during copy segment operations
3. GC can still use Version/BuildID to clean up old version files
4. QueryNode loading is unaffected — V3 loadInfo does not populate TextStatsLogs/JsonKeyStatsLogs (reads from manifest instead)

issue: #48713 #48752