### PR TITLE
fix: missing milvus_rootcoord_entity_num{status="total"}

### DIFF
--- a/internal/rootcoord/quota_center.go
+++ b/internal/rootcoord/quota_center.go
@@ -502,6 +502,20 @@ func (q *QuotaCenter) collectMetrics() error {
 			collectionMetrics = cm.Collections
 		}
 
+		// Because DataNode getQuotaMetrics only sets Effect.NodeID and does not populate
+		// Effect.CollectionIDs, DataNode quota metrics do not report collection IDs.
+		// Fall back to DataCoord-side collection metrics so we can still refresh writable
+		// collections and RootCoord entity_num(total).
+		if collections.Len() == 0 && collectionMetrics != nil {
+			for collectionID := range collectionMetrics {
+				collections.Insert(collectionID)
+			}
+		}
+
+		// Also include collections observed by DataCoord quota metrics (e.g. binlog size)
+		// to avoid missing collections when CollectionMetrics is absent.
+		collections.Insert(datacoordQuotaCollections...)
+
 		collections.Range(func(collectionID int64) bool {
 			coll, getErr := q.meta.GetCollectionByIDWithMaxTs(context.TODO(), collectionID)
 			if getErr != nil {
@@ -538,20 +552,6 @@ func (q *QuotaCenter) collectMetrics() error {
 			}
 			return true
 		})
-
-		for _, collectionID := range datacoordQuotaCollections {
-			_, ok := q.collectionIDToDBID.Get(collectionID)
-			if ok {
-				continue
-			}
-			coll, getErr := q.meta.GetCollectionByIDWithMaxTs(context.TODO(), collectionID)
-			if getErr != nil {
-				// skip limit check if the collection meta has been removed from rootcoord meta
-				continue
-			}
-			q.collectionIDToDBID.Insert(collectionID, coll.DBID)
-			q.collections.Insert(FormatCollectionKey(coll.DBID, coll.Name), collectionID)
-		}
 
 		return nil
 	})

--- a/internal/rootcoord/quota_center_test.go
+++ b/internal/rootcoord/quota_center_test.go
@@ -1180,6 +1180,81 @@ func (s *QuotaCenterSuite) TestSyncMetricsSuccess() {
 		nodes := lo.Keys(quotaCenter.dataNodeMetrics)
 		s.ElementsMatch([]int64{1, 2}, nodes)
 	})
+
+	s.Run("datacoord_cluster_with_empty_datanode_collectionIDs", func() {
+		pcm.EXPECT().GetProxyMetrics(mock.Anything).Return(nil, nil).Once()
+		qc.EXPECT().GetQueryCoordTopology(mock.Anything, mock.Anything).Return(s.getEmptyQCTopology(), nil).Once()
+
+		dcTopology := &metricsinfo.DataCoordTopology{
+			Cluster: metricsinfo.DataClusterTopology{
+				ConnectedDataNodes: []metricsinfo.DataNodeInfos{
+					{BaseComponentInfos: metricsinfo.BaseComponentInfos{ID: 1}, QuotaMetrics: &metricsinfo.DataNodeQuotaMetrics{Effect: metricsinfo.NodeEffect{NodeID: 1, CollectionIDs: []int64{}}}},
+					{BaseComponentInfos: metricsinfo.BaseComponentInfos{ID: 2}, QuotaMetrics: &metricsinfo.DataNodeQuotaMetrics{Effect: metricsinfo.NodeEffect{NodeID: 2, CollectionIDs: []int64{}}}},
+				},
+				Self: metricsinfo.DataCoordInfos{
+					CollectionMetrics: &metricsinfo.DataCoordCollectionMetrics{
+						Collections: map[int64]*metricsinfo.DataCoordCollectionInfo{
+							100: {NumEntitiesTotal: 1000},
+							200: {NumEntitiesTotal: 2000},
+							300: {NumEntitiesTotal: 3000},
+						},
+					},
+				},
+			},
+		}
+
+		qc.EXPECT().GetDataCoordTopology(mock.Anything, mock.Anything).Return(dcTopology, nil).Once()
+		meta.EXPECT().GetCollectionByIDWithMaxTs(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, i int64) (*model.Collection, error) {
+			return &model.Collection{CollectionID: i, DBID: 1}, nil
+		}).Times(3)
+
+		quotaCenter := NewQuotaCenter(pcm, qc, core.tsoAllocator, meta)
+
+		err := quotaCenter.collectMetrics()
+		s.Require().NoError(err)
+
+		s.ElementsMatch([]int64{100, 200, 300}, lo.Keys(quotaCenter.writableCollections[1]))
+		nodes := lo.Keys(quotaCenter.dataNodeMetrics)
+		s.ElementsMatch([]int64{1, 2}, nodes)
+	})
+
+	s.Run("datacoord_cluster_without_collection_metrics_but_quota_has_collections", func() {
+		pcm.EXPECT().GetProxyMetrics(mock.Anything).Return(nil, nil).Once()
+		qc.EXPECT().GetQueryCoordTopology(mock.Anything, mock.Anything).Return(s.getEmptyQCTopology(), nil).Once()
+
+		dcTopology := &metricsinfo.DataCoordTopology{
+			Cluster: metricsinfo.DataClusterTopology{
+				ConnectedDataNodes: []metricsinfo.DataNodeInfos{
+					{BaseComponentInfos: metricsinfo.BaseComponentInfos{ID: 1}, QuotaMetrics: &metricsinfo.DataNodeQuotaMetrics{Effect: metricsinfo.NodeEffect{NodeID: 1, CollectionIDs: []int64{}}}},
+					{BaseComponentInfos: metricsinfo.BaseComponentInfos{ID: 2}, QuotaMetrics: &metricsinfo.DataNodeQuotaMetrics{Effect: metricsinfo.NodeEffect{NodeID: 2, CollectionIDs: []int64{}}}},
+				},
+				Self: metricsinfo.DataCoordInfos{
+					QuotaMetrics: &metricsinfo.DataCoordQuotaMetrics{
+						PartitionsBinlogSize: map[int64]map[int64]int64{
+							100: {10: 1},
+							200: {20: 2},
+							300: {30: 3},
+						},
+					},
+					CollectionMetrics: nil,
+				},
+			},
+		}
+
+		qc.EXPECT().GetDataCoordTopology(mock.Anything, mock.Anything).Return(dcTopology, nil).Once()
+		meta.EXPECT().GetCollectionByIDWithMaxTs(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, i int64) (*model.Collection, error) {
+			return &model.Collection{CollectionID: i, DBID: 1}, nil
+		}).Times(3)
+
+		quotaCenter := NewQuotaCenter(pcm, qc, core.tsoAllocator, meta)
+
+		err := quotaCenter.collectMetrics()
+		s.Require().NoError(err)
+
+		s.ElementsMatch([]int64{100, 200, 300}, lo.Keys(quotaCenter.writableCollections[1]))
+		nodes := lo.Keys(quotaCenter.dataNodeMetrics)
+		s.ElementsMatch([]int64{1, 2}, nodes)
+	})
 }
 
 func (s *QuotaCenterSuite) TestSyncMetricsFailure() {


### PR DESCRIPTION
fix：https://github.com/milvus-io/milvus/issues/48144

This PR fixes missing milvus_rootcoord_entity_num{status="total"} updates in RootCoord when collecting DataCoord metrics.

Specifically:

- Adjusted QuotaCenter.collectMetrics() (DataCoord metrics branch) to not rely on DataNode quota metrics Effect.CollectionIDs for enumerating collections.
- When DataNode does not provide collection IDs, fall back to DataCoord CollectionMetrics.Collections keys to drive the collection iteration, so entity_num(total) can be refreshed.
- Also merge collections observed in DataCoord quota metrics ( PartitionsBinlogSize keys) into the same collection set to cover cases where CollectionMetrics is absent.
- Removed the extra loop that iterated datacoordQuotaCollections to only backfill collectionIDToDBID / collections , since those collections are now included in the unified collections.Range(...) flow (avoids duplicated meta lookups and keeps the logic in one place).
- Added unit tests to cover:
  - DataNode CollectionIDs empty but DataCoord CollectionMetrics present.
  - DataCoord CollectionMetrics absent but DataCoord quota metrics include collections.

Why is it needed?

Previously, RootCoord used DataNode quota metrics Effect.CollectionIDs as the collection enumeration source in the DataCoord metrics collection path. In the current implementation, DataNode quota metrics do not populate CollectionIDs , which caused RootCoord to skip iterating collections and therefore not update milvus_rootcoord_entity_num{status="total"} (missing series or stale values).

How was it tested?

- Added unit tests in quota_center_test.go to validate the two fallback scenarios above.
- Code compiles locally (note: running go test in this environment requires milvus_core pkg-config dependency).