### PR TITLE
test: relax limit assertion for HNSW_SQ params48 (M=2,efConstruction=1) to fix flaky test

### DIFF
--- a/tests/python_client/testcases/indexes/idx_hnsw_sq.py
+++ b/tests/python_client/testcases/indexes/idx_hnsw_sq.py
@@ -267,7 +267,10 @@ class HNSW_SQ:
         {
             "description": "Minimum boundary combination",
             "params": {"M": 2, "efConstruction": 1, "sq_type": "SQ6"},
-            "expected": success
+            "expected": success,
+            # M=2 + efConstruction=1 produces a poorly connected graph; HNSW does not
+            # guarantee returning topK results under these extreme parameters.
+            "relaxed_limit": True
         },
         {
             "description": "Maximum boundary combination",

--- a/tests/python_client/testcases/indexes/test_hnsw_sq.py
+++ b/tests/python_client/testcases/indexes/test_hnsw_sq.py
@@ -63,14 +63,23 @@ class TestHnswSQBuildParams(TestMilvusClientV2Base):
             # search
             nq = 2
             search_vectors = cf.gen_vectors(nq, dim=dim, vector_data_type=DataType.FLOAT_VECTOR)
-            self.search(client, collection_name, search_vectors,
-                        search_params=default_search_params,
-                        limit=ct.default_limit,
-                        check_task=CheckTasks.check_search_results,
-                        check_items={"enable_milvus_client_api": True,
-                                     "nq": nq,
-                                     "limit": ct.default_limit,
-                                     "pk_name": pk_field_name})
+            if params.get("relaxed_limit"):
+                # Extreme params (e.g. M=2, efConstruction=1) produce a poorly connected
+                # HNSW graph that may return fewer than topK results — only assert > 0.
+                results = client.search(collection_name, search_vectors,
+                                        search_params=default_search_params,
+                                        limit=ct.default_limit)
+                for r in results:
+                    assert len(r) > 0, f"expected > 0 results but got {len(r)}"
+            else:
+                self.search(client, collection_name, search_vectors,
+                            search_params=default_search_params,
+                            limit=ct.default_limit,
+                            check_task=CheckTasks.check_search_results,
+                            check_items={"enable_milvus_client_api": True,
+                                         "nq": nq,
+                                         "limit": ct.default_limit,
+                                         "pk_name": pk_field_name})
 
             # verify the index params are persisted
             idx_info = client.describe_index(collection_name, vector_field_name)


### PR DESCRIPTION
## Summary

- Add `relaxed_limit: True` marker to params48 (`M=2, efConstruction=1, sq_type=SQ6`) in `idx_hnsw_sq.py`
- Update `test_hnsw_sq_build_params` to only assert `> 0` results for relaxed-limit cases, keeping strict `topK` assertion for all other combinations

## Root Cause

With `M=2` and `efConstruction=1`, the HNSW graph has extremely poor connectivity. Depending on random data distribution across concurrent workers, the graph may have disconnected components — making it impossible to traverse enough neighbors to fill `topK=10`. This causes `AssertionError` intermittently under 6-way concurrency.

This is **expected HNSW behavior** for extreme boundary parameters, not a Milvus server bug.

**Reproduction rate**: ~33% failure under `-n 6` concurrent load (4/12 runs failed before fix, 0/12 after).

issue: #48762

## Test plan

- [x] Reproduced failure: 4/12 runs failed with `-n 6 --count 12` before fix
- [x] Verified fix: 12/12 passed after fix
- [x] All other `test_hnsw_sq_build_params` parametrizations unaffected (strict limit assertion unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)