### PR TITLE
fix: validate resource groups in AlterCollection and AlterDatabase to avoid infinite retry or hung

### DIFF
--- a/internal/rootcoord/broker.go
+++ b/internal/rootcoord/broker.go
@@ -24,6 +24,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/metastore/model"
 	"github.com/milvus-io/milvus/pkg/v2/log"
@@ -60,6 +61,7 @@ type Broker interface {
 	DropCollectionIndex(ctx context.Context, collID UniqueID, partIDs []UniqueID) error
 	// notify observer to clean their meta cache
 	BroadcastAlteredCollection(ctx context.Context, collectionID UniqueID) error
+	ShowResourceGroups(ctx context.Context) ([]string, error)
 }
 
 type ServerBroker struct {
@@ -280,6 +282,22 @@ func (b *ServerBroker) BroadcastAlteredCollection(ctx context.Context, collectio
 	}
 	log.Ctx(ctx).Info("done to broadcast request to alter collection", zap.String("collectionName", colMeta.Name), zap.Int64("collectionID", collectionID), zap.Any("props", colMeta.Properties), zap.Any("field", colMeta.Fields))
 	return nil
+}
+
+func (b *ServerBroker) ShowResourceGroups(ctx context.Context) ([]string, error) {
+	resp, err := b.s.mixCoord.ListResourceGroups(ctx, &milvuspb.ListResourceGroupsRequest{
+		Base: commonpbutil.NewMsgBase(
+			commonpbutil.WithMsgType(commonpb.MsgType_ListResourceGroups),
+			commonpbutil.WithSourceID(b.s.session.GetServerID()),
+		),
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := merr.CheckRPCCall(resp, err); err != nil {
+		return nil, err
+	}
+	return resp.GetResourceGroups(), nil
 }
 
 func (b *ServerBroker) GcConfirm(ctx context.Context, collectionID, partitionID UniqueID) bool {

--- a/internal/rootcoord/broker_test.go
+++ b/internal/rootcoord/broker_test.go
@@ -25,11 +25,13 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus/internal/metastore/model"
 	"github.com/milvus-io/milvus/internal/mocks"
 	mockrootcoord "github.com/milvus-io/milvus/internal/rootcoord/mocks"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	pb "github.com/milvus-io/milvus/pkg/v2/proto/etcdpb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 )
 
@@ -283,6 +285,102 @@ func TestServerBroker_GcConfirm(t *testing.T) {
 		broker := newServerBroker(c)
 		assert.True(t, broker.GcConfirm(context.Background(), 100, 10000))
 	})
+}
+
+func TestServerBroker_ShowResourceGroups(t *testing.T) {
+	t.Run("rpc error", func(t *testing.T) {
+		mixc := mocks.NewMixCoord(t)
+		mixc.On("ListResourceGroups", mock.Anything, mock.Anything).Return(nil, errors.New("rpc error"))
+
+		c := newTestCore(withMixCoord(mixc))
+		b := newServerBroker(c)
+		_, err := b.ShowResourceGroups(context.Background())
+		assert.Error(t, err)
+	})
+
+	t.Run("non success status", func(t *testing.T) {
+		mixc := mocks.NewMixCoord(t)
+		mixc.On("ListResourceGroups", mock.Anything, mock.Anything).Return(
+			&milvuspb.ListResourceGroupsResponse{Status: merr.Status(errors.New("mock error"))},
+			nil,
+		)
+
+		c := newTestCore(withMixCoord(mixc))
+		b := newServerBroker(c)
+		_, err := b.ShowResourceGroups(context.Background())
+		assert.Error(t, err)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		mixc := mocks.NewMixCoord(t)
+		mixc.On("ListResourceGroups", mock.Anything, mock.Anything).Return(
+			&milvuspb.ListResourceGroupsResponse{
+				Status:         merr.Success(),
+				ResourceGroups: []string{"rg1", "rg2"},
+			},
+			nil,
+		)
+
+		c := newTestCore(withMixCoord(mixc))
+		b := newServerBroker(c)
+		rgs, err := b.ShowResourceGroups(context.Background())
+		assert.NoError(t, err)
+		assert.ElementsMatch(t, []string{"rg1", "rg2"}, rgs)
+	})
+}
+
+func TestServerBroker_GetSegmentIndexState(t *testing.T) {
+	t.Run("rpc error", func(t *testing.T) {
+		mixc := mocks.NewMixCoord(t)
+		mixc.On("GetSegmentIndexState", mock.Anything, mock.Anything).Return(nil, errors.New("rpc error"))
+
+		c := newTestCore(withMixCoord(mixc))
+		b := newServerBroker(c)
+		_, err := b.GetSegmentIndexState(context.Background(), 1, "idx", []UniqueID{1, 2})
+		assert.Error(t, err)
+	})
+
+	t.Run("non success status", func(t *testing.T) {
+		mixc := mocks.NewMixCoord(t)
+		mixc.On("GetSegmentIndexState", mock.Anything, mock.Anything).Return(
+			&indexpb.GetSegmentIndexStateResponse{Status: merr.Status(errors.New("mock error"))},
+			nil,
+		)
+
+		c := newTestCore(withMixCoord(mixc))
+		b := newServerBroker(c)
+		_, err := b.GetSegmentIndexState(context.Background(), 1, "idx", []UniqueID{1, 2})
+		assert.Error(t, err)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		mixc := mocks.NewMixCoord(t)
+		mixc.On("GetSegmentIndexState", mock.Anything, mock.Anything).Return(
+			&indexpb.GetSegmentIndexStateResponse{
+				Status: merr.Success(),
+				States: []*indexpb.SegmentIndexState{{SegmentID: 1}},
+			},
+			nil,
+		)
+
+		c := newTestCore(withMixCoord(mixc))
+		b := newServerBroker(c)
+		states, err := b.GetSegmentIndexState(context.Background(), 1, "idx", []UniqueID{1, 2})
+		assert.NoError(t, err)
+		assert.Len(t, states, 1)
+		assert.Equal(t, int64(1), states[0].SegmentID)
+	})
+}
+
+func TestKeyDataPairsConversions(t *testing.T) {
+	m := map[string][]byte{
+		"k1": []byte("v1"),
+		"k2": []byte("v2"),
+	}
+
+	pairs := toKeyDataPairs(m)
+	roundTrip := toMap(pairs)
+	assert.Equal(t, m, roundTrip)
 }
 
 func mockGetDatabase(meta *mockrootcoord.IMetaTable) {

--- a/internal/rootcoord/ddl_callbacks_alter_collection_properties.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_properties.go
@@ -291,7 +291,14 @@ func (c *DDLCallback) alterCollectionV2AckCallback(ctx context.Context, result m
 			ReplicaNumber:  body.Updates.AlterLoadConfig.ReplicaNumber,
 			ResourceGroups: body.Updates.AlterLoadConfig.ResourceGroups,
 		})
+		if err != nil {
+			return errors.Wrap(err, "failed to update load config")
+		}
 		if err := merr.CheckRPCCall(resp, err); err != nil {
+			if errors.Is(err, merr.ErrResourceGroupNotFound) {
+				log.Ctx(ctx).Warn("failed to update load config due to missing resource group, stop retrying", zap.Error(err))
+				return nil
+			}
 			return errors.Wrap(err, "failed to update load config")
 		}
 	}

--- a/internal/rootcoord/ddl_callbacks_alter_collection_properties_test.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_properties_test.go
@@ -19,13 +19,19 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	imocks "github.com/milvus-io/milvus/internal/mocks"
+	mockrootcoord "github.com/milvus-io/milvus/internal/rootcoord/mocks"
 	"github.com/milvus-io/milvus/pkg/v2/common"
+	"github.com/milvus-io/milvus/pkg/v2/proto/messagespb"
+	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v2/util"
 	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
@@ -34,6 +40,9 @@ import (
 
 func TestDDLCallbacksAlterCollectionProperties(t *testing.T) {
 	core := initStreamingSystemAndCore(t)
+	core.broker.(*mockBroker).ShowResourceGroupsFunc = func(ctx context.Context) ([]string, error) {
+		return []string{"rg1", "rg2"}, nil
+	}
 
 	ctx := context.Background()
 	dbName := "testDB" + funcutil.RandomString(10)
@@ -158,6 +167,224 @@ func TestDDLCallbacksAlterCollectionProperties(t *testing.T) {
 		Properties:     []*commonpb.KeyValuePair{{Key: common.EnableDynamicSchemaKey, Value: "true"}, {Key: common.CollectionReplicaNumber, Value: "1"}},
 	})
 	require.ErrorIs(t, merr.CheckRPCCall(resp, err), merr.ErrParameterInvalid)
+}
+
+func TestDDLCallbacksAlterCollectionV2AckCallback_UpdateLoadConfigRPCError(t *testing.T) {
+	ctx := context.Background()
+
+	meta := mockrootcoord.NewIMetaTable(t)
+	meta.EXPECT().AlterCollection(mock.Anything, mock.Anything).Return(nil)
+
+	mixc := imocks.NewMixCoord(t)
+	mixc.On("UpdateLoadConfig", mock.Anything, mock.Anything).Return(nil, errors.New("rpc error"))
+
+	c := newTestCore(
+		withMeta(meta),
+		withMixCoord(mixc),
+		withValidProxyManager(),
+		withBroker(&mockBroker{}),
+	)
+	cb := &DDLCallback{Core: c}
+
+	raw := message.NewAlterCollectionMessageBuilderV2().
+		WithHeader(&messagespb.AlterCollectionMessageHeader{
+			CollectionId: 1,
+		}).
+		WithBody(&messagespb.AlterCollectionMessageBody{
+			Updates: &messagespb.AlterCollectionMessageUpdates{
+				AlterLoadConfig: &messagespb.AlterLoadConfigOfAlterCollection{
+					ReplicaNumber:  1,
+					ResourceGroups: []string{"rg1"},
+				},
+			},
+		}).
+		WithBroadcast([]string{funcutil.GetControlChannel("test")}).
+		MustBuildBroadcast()
+	msg := message.MustAsBroadcastAlterCollectionMessageV2(raw)
+
+	err := cb.alterCollectionV2AckCallback(ctx, message.BroadcastResultAlterCollectionMessageV2{
+		Message: msg,
+		Results: map[string]*message.AppendResult{},
+	})
+	require.Error(t, err)
+}
+
+func TestDDLCallbacksAlterCollectionV2AckCallback_UpdateLoadConfigNonRGNotFoundError(t *testing.T) {
+	ctx := context.Background()
+
+	meta := mockrootcoord.NewIMetaTable(t)
+	meta.EXPECT().AlterCollection(mock.Anything, mock.Anything).Return(nil)
+
+	mixc := imocks.NewMixCoord(t)
+	mixc.On("UpdateLoadConfig", mock.Anything, mock.Anything).Return(merr.Status(errors.New("mock error")), nil)
+
+	c := newTestCore(
+		withMeta(meta),
+		withMixCoord(mixc),
+		withValidProxyManager(),
+		withBroker(&mockBroker{}),
+	)
+	cb := &DDLCallback{Core: c}
+
+	raw := message.NewAlterCollectionMessageBuilderV2().
+		WithHeader(&messagespb.AlterCollectionMessageHeader{
+			CollectionId: 1,
+		}).
+		WithBody(&messagespb.AlterCollectionMessageBody{
+			Updates: &messagespb.AlterCollectionMessageUpdates{
+				AlterLoadConfig: &messagespb.AlterLoadConfigOfAlterCollection{
+					ReplicaNumber:  1,
+					ResourceGroups: []string{"rg1"},
+				},
+			},
+		}).
+		WithBroadcast([]string{funcutil.GetControlChannel("test")}).
+		MustBuildBroadcast()
+	msg := message.MustAsBroadcastAlterCollectionMessageV2(raw)
+
+	err := cb.alterCollectionV2AckCallback(ctx, message.BroadcastResultAlterCollectionMessageV2{
+		Message: msg,
+		Results: map[string]*message.AppendResult{},
+	})
+	require.Error(t, err)
+	require.False(t, errors.Is(err, merr.ErrResourceGroupNotFound))
+}
+
+func TestDDLCallbacksAlterCollectionV2AckCallback_StopRetryOnResourceGroupNotFound(t *testing.T) {
+	ctx := context.Background()
+
+	meta := mockrootcoord.NewIMetaTable(t)
+	meta.EXPECT().AlterCollection(mock.Anything, mock.Anything).Return(nil)
+
+	mixc := imocks.NewMixCoord(t)
+	mixc.On("UpdateLoadConfig", mock.Anything, mock.Anything).Return(
+		merr.Status(merr.WrapErrResourceGroupNotFound("rg_not_exist")),
+		nil,
+	)
+
+	c := newTestCore(
+		withMeta(meta),
+		withMixCoord(mixc),
+		withValidProxyManager(),
+		withBroker(&mockBroker{}),
+	)
+	cb := &DDLCallback{Core: c}
+
+	raw := message.NewAlterCollectionMessageBuilderV2().
+		WithHeader(&messagespb.AlterCollectionMessageHeader{
+			CollectionId: 1,
+		}).
+		WithBody(&messagespb.AlterCollectionMessageBody{
+			Updates: &messagespb.AlterCollectionMessageUpdates{
+				AlterLoadConfig: &messagespb.AlterLoadConfigOfAlterCollection{
+					ReplicaNumber:  1,
+					ResourceGroups: []string{"rg_not_exist"},
+				},
+			},
+		}).
+		WithBroadcast([]string{funcutil.GetControlChannel("test")}).
+		MustBuildBroadcast()
+	msg := message.MustAsBroadcastAlterCollectionMessageV2(raw)
+
+	err := cb.alterCollectionV2AckCallback(ctx, message.BroadcastResultAlterCollectionMessageV2{
+		Message: msg,
+		Results: map[string]*message.AppendResult{},
+	})
+	require.NoError(t, err)
+}
+
+func TestCore_getAlterLoadConfigOfAlterCollection(t *testing.T) {
+	core := &Core{}
+
+	t.Run("no changes", func(t *testing.T) {
+		cfg := core.getAlterLoadConfigOfAlterCollection(
+			[]*commonpb.KeyValuePair{
+				{Key: common.CollectionReplicaNumber, Value: "1"},
+				{Key: common.CollectionResourceGroups, Value: "rg1"},
+			},
+			[]*commonpb.KeyValuePair{
+				{Key: common.CollectionReplicaNumber, Value: "1"},
+				{Key: common.CollectionResourceGroups, Value: "rg1"},
+			},
+		)
+		require.Nil(t, cfg)
+	})
+
+	t.Run("replica changed", func(t *testing.T) {
+		cfg := core.getAlterLoadConfigOfAlterCollection(
+			[]*commonpb.KeyValuePair{
+				{Key: common.CollectionReplicaNumber, Value: "1"},
+				{Key: common.CollectionResourceGroups, Value: "rg1"},
+			},
+			[]*commonpb.KeyValuePair{
+				{Key: common.CollectionReplicaNumber, Value: "2"},
+				{Key: common.CollectionResourceGroups, Value: "rg1"},
+			},
+		)
+		require.NotNil(t, cfg)
+		require.Equal(t, int32(2), cfg.ReplicaNumber)
+		require.Equal(t, []string{"rg1"}, cfg.ResourceGroups)
+	})
+
+	t.Run("rg changed", func(t *testing.T) {
+		cfg := core.getAlterLoadConfigOfAlterCollection(
+			[]*commonpb.KeyValuePair{
+				{Key: common.CollectionReplicaNumber, Value: "1"},
+				{Key: common.CollectionResourceGroups, Value: "rg1"},
+			},
+			[]*commonpb.KeyValuePair{
+				{Key: common.CollectionReplicaNumber, Value: "1"},
+				{Key: common.CollectionResourceGroups, Value: "rg2"},
+			},
+		)
+		require.NotNil(t, cfg)
+		require.Equal(t, int32(1), cfg.ReplicaNumber)
+		require.Equal(t, []string{"rg2"}, cfg.ResourceGroups)
+	})
+}
+
+func TestDDLCallbacksAlterCollectionV2AckCallback_BroadcastAlteredCollectionError(t *testing.T) {
+	ctx := context.Background()
+
+	meta := mockrootcoord.NewIMetaTable(t)
+	meta.EXPECT().AlterCollection(mock.Anything, mock.Anything).Return(nil)
+
+	mixc := imocks.NewMixCoord(t)
+	mixc.On("UpdateLoadConfig", mock.Anything, mock.Anything).Return(merr.Success(), nil)
+
+	c := newTestCore(
+		withMeta(meta),
+		withMixCoord(mixc),
+		withValidProxyManager(),
+		withBroker(&mockBroker{
+			BroadcastAlteredCollectionFunc: func(ctx context.Context, collectionID int64) error {
+				return errors.New("broadcast error")
+			},
+		}),
+	)
+	cb := &DDLCallback{Core: c}
+
+	raw := message.NewAlterCollectionMessageBuilderV2().
+		WithHeader(&messagespb.AlterCollectionMessageHeader{
+			CollectionId: 1,
+		}).
+		WithBody(&messagespb.AlterCollectionMessageBody{
+			Updates: &messagespb.AlterCollectionMessageUpdates{
+				AlterLoadConfig: &messagespb.AlterLoadConfigOfAlterCollection{
+					ReplicaNumber:  1,
+					ResourceGroups: []string{"rg1"},
+				},
+			},
+		}).
+		WithBroadcast([]string{funcutil.GetControlChannel("test")}).
+		MustBuildBroadcast()
+	msg := message.MustAsBroadcastAlterCollectionMessageV2(raw)
+
+	err := cb.alterCollectionV2AckCallback(ctx, message.BroadcastResultAlterCollectionMessageV2{
+		Message: msg,
+		Results: map[string]*message.AppendResult{},
+	})
+	require.Error(t, err)
 }
 
 func TestDDLCallbacksAlterCollectionPropertiesForDynamicField(t *testing.T) {

--- a/internal/rootcoord/ddl_callbacks_alter_database.go
+++ b/internal/rootcoord/ddl_callbacks_alter_database.go
@@ -21,12 +21,14 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
+	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/internal/metastore/model"
 	"github.com/milvus-io/milvus/internal/util/hookutil"
 	"github.com/milvus-io/milvus/pkg/v2/common"
+	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/etcdpb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/rootcoordpb"
@@ -147,7 +149,14 @@ func (c *DDLCallback) alterDatabaseV1AckCallback(ctx context.Context, result mes
 			ReplicaNumber:  body.AlterLoadConfig.ReplicaNumber,
 			ResourceGroups: body.AlterLoadConfig.ResourceGroups,
 		})
+		if err != nil {
+			return errors.Wrap(err, "failed to update load config")
+		}
 		if err := merr.CheckRPCCall(resp, err); err != nil {
+			if errors.Is(err, merr.ErrResourceGroupNotFound) {
+				log.Ctx(ctx).Warn("failed to update load config due to missing resource group, stop retrying", zap.Error(err))
+				return nil
+			}
 			return errors.Wrap(err, "failed to update load config")
 		}
 	}

--- a/internal/rootcoord/ddl_callbacks_alter_database_test.go
+++ b/internal/rootcoord/ddl_callbacks_alter_database_test.go
@@ -19,12 +19,19 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
+	"github.com/milvus-io/milvus/internal/metastore/model"
+	imocks "github.com/milvus-io/milvus/internal/mocks"
+	mockrootcoord "github.com/milvus-io/milvus/internal/rootcoord/mocks"
 	"github.com/milvus-io/milvus/pkg/v2/common"
+	"github.com/milvus-io/milvus/pkg/v2/proto/messagespb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/rootcoordpb"
+	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
@@ -32,6 +39,9 @@ import (
 
 func TestDDLCallbacksAlterDatabase(t *testing.T) {
 	core := initStreamingSystemAndCore(t)
+	core.broker.(*mockBroker).ShowResourceGroupsFunc = func(ctx context.Context) ([]string, error) {
+		return []string{"rg1", "rg2"}, nil
+	}
 
 	ctx := context.Background()
 	dbName := "testDB" + funcutil.RandomString(10)
@@ -112,6 +122,265 @@ func TestDDLCallbacksAlterDatabase(t *testing.T) {
 	require.NoError(t, merr.CheckRPCCall(resp, err))
 	assertDatabaseReplicaNumber(t, ctx, core, dbName, 0)
 	assertDatabaseResourceGroups(t, ctx, core, dbName, []string{})
+}
+
+func TestDDLCallbacksAlterDatabaseV1AckCallback_AlterDatabaseError(t *testing.T) {
+	ctx := context.Background()
+	controlChannel := funcutil.GetControlChannel("test")
+
+	meta := mockrootcoord.NewIMetaTable(t)
+	meta.EXPECT().AlterDatabase(mock.Anything, mock.Anything, mock.Anything).Return(errors.New("meta error"))
+
+	c := newTestCore(
+		withMeta(meta),
+		withValidProxyManager(),
+		withBroker(&mockBroker{}),
+	)
+	cb := &DDLCallback{Core: c}
+
+	raw := message.NewAlterDatabaseMessageBuilderV2().
+		WithHeader(&messagespb.AlterDatabaseMessageHeader{
+			DbName: "db",
+			DbId:   1,
+		}).
+		WithBody(&messagespb.AlterDatabaseMessageBody{
+			Properties: []*commonpb.KeyValuePair{{Key: "k", Value: "v"}},
+		}).
+		WithBroadcast([]string{controlChannel}).
+		MustBuildBroadcast()
+	msg := message.MustAsBroadcastAlterDatabaseMessageV2(raw)
+
+	err := cb.alterDatabaseV1AckCallback(ctx, message.BroadcastResultAlterDatabaseMessageV2{
+		Message: msg,
+		Results: map[string]*message.AppendResult{
+			controlChannel: {TimeTick: 1},
+		},
+	})
+	require.Error(t, err)
+}
+
+func TestDDLCallbacksAlterDatabaseV1AckCallback_UpdateLoadConfigRPCError(t *testing.T) {
+	ctx := context.Background()
+	controlChannel := funcutil.GetControlChannel("test")
+
+	meta := mockrootcoord.NewIMetaTable(t)
+	meta.EXPECT().AlterDatabase(mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	mixc := imocks.NewMixCoord(t)
+	mixc.On("UpdateLoadConfig", mock.Anything, mock.Anything).Return(nil, errors.New("rpc error"))
+
+	c := newTestCore(
+		withMeta(meta),
+		withMixCoord(mixc),
+		withValidProxyManager(),
+		withBroker(&mockBroker{}),
+	)
+	cb := &DDLCallback{Core: c}
+
+	raw := message.NewAlterDatabaseMessageBuilderV2().
+		WithHeader(&messagespb.AlterDatabaseMessageHeader{
+			DbName: "db",
+			DbId:   1,
+		}).
+		WithBody(&messagespb.AlterDatabaseMessageBody{
+			Properties: []*commonpb.KeyValuePair{{Key: "k", Value: "v"}},
+			AlterLoadConfig: &messagespb.AlterLoadConfigOfAlterDatabase{
+				CollectionIds:  []int64{1},
+				ReplicaNumber:  1,
+				ResourceGroups: []string{"rg1"},
+			},
+		}).
+		WithBroadcast([]string{controlChannel}).
+		MustBuildBroadcast()
+	msg := message.MustAsBroadcastAlterDatabaseMessageV2(raw)
+
+	err := cb.alterDatabaseV1AckCallback(ctx, message.BroadcastResultAlterDatabaseMessageV2{
+		Message: msg,
+		Results: map[string]*message.AppendResult{
+			controlChannel: {TimeTick: 1},
+		},
+	})
+	require.Error(t, err)
+}
+
+func TestDDLCallbacksAlterDatabaseV1AckCallback_UpdateLoadConfigNonRGNotFoundError(t *testing.T) {
+	ctx := context.Background()
+	controlChannel := funcutil.GetControlChannel("test")
+
+	meta := mockrootcoord.NewIMetaTable(t)
+	meta.EXPECT().AlterDatabase(mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	mixc := imocks.NewMixCoord(t)
+	mixc.On("UpdateLoadConfig", mock.Anything, mock.Anything).Return(merr.Status(errors.New("mock error")), nil)
+
+	c := newTestCore(
+		withMeta(meta),
+		withMixCoord(mixc),
+		withValidProxyManager(),
+		withBroker(&mockBroker{}),
+	)
+	cb := &DDLCallback{Core: c}
+
+	raw := message.NewAlterDatabaseMessageBuilderV2().
+		WithHeader(&messagespb.AlterDatabaseMessageHeader{
+			DbName: "db",
+			DbId:   1,
+		}).
+		WithBody(&messagespb.AlterDatabaseMessageBody{
+			Properties: []*commonpb.KeyValuePair{{Key: "k", Value: "v"}},
+			AlterLoadConfig: &messagespb.AlterLoadConfigOfAlterDatabase{
+				CollectionIds:  []int64{1},
+				ReplicaNumber:  1,
+				ResourceGroups: []string{"rg1"},
+			},
+		}).
+		WithBroadcast([]string{controlChannel}).
+		MustBuildBroadcast()
+	msg := message.MustAsBroadcastAlterDatabaseMessageV2(raw)
+
+	err := cb.alterDatabaseV1AckCallback(ctx, message.BroadcastResultAlterDatabaseMessageV2{
+		Message: msg,
+		Results: map[string]*message.AppendResult{
+			controlChannel: {TimeTick: 1},
+		},
+	})
+	require.Error(t, err)
+	require.False(t, errors.Is(err, merr.ErrResourceGroupNotFound))
+}
+
+func TestDDLCallbacksAlterDatabaseV1AckCallback_StopRetryOnResourceGroupNotFound(t *testing.T) {
+	ctx := context.Background()
+	controlChannel := funcutil.GetControlChannel("test")
+
+	meta := mockrootcoord.NewIMetaTable(t)
+	meta.EXPECT().AlterDatabase(mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	mixc := imocks.NewMixCoord(t)
+	mixc.On("UpdateLoadConfig", mock.Anything, mock.Anything).Return(
+		merr.Status(merr.WrapErrResourceGroupNotFound("rg_not_exist")),
+		nil,
+	)
+
+	c := newTestCore(
+		withMeta(meta),
+		withMixCoord(mixc),
+		withValidProxyManager(),
+		withBroker(&mockBroker{}),
+	)
+	cb := &DDLCallback{Core: c}
+
+	raw := message.NewAlterDatabaseMessageBuilderV2().
+		WithHeader(&messagespb.AlterDatabaseMessageHeader{
+			DbName: "db",
+			DbId:   1,
+		}).
+		WithBody(&messagespb.AlterDatabaseMessageBody{
+			Properties: []*commonpb.KeyValuePair{{Key: "k", Value: "v"}},
+			AlterLoadConfig: &messagespb.AlterLoadConfigOfAlterDatabase{
+				CollectionIds:  []int64{1},
+				ReplicaNumber:  1,
+				ResourceGroups: []string{"rg_not_exist"},
+			},
+		}).
+		WithBroadcast([]string{controlChannel}).
+		MustBuildBroadcast()
+	msg := message.MustAsBroadcastAlterDatabaseMessageV2(raw)
+
+	err := cb.alterDatabaseV1AckCallback(ctx, message.BroadcastResultAlterDatabaseMessageV2{
+		Message: msg,
+		Results: map[string]*message.AppendResult{
+			controlChannel: {TimeTick: 1},
+		},
+	})
+	require.NoError(t, err)
+}
+
+func TestMergeProperties(t *testing.T) {
+	props := MergeProperties(
+		[]*commonpb.KeyValuePair{
+			{Key: "k1", Value: "v1"},
+			{Key: "k2", Value: "v2"},
+		},
+		[]*commonpb.KeyValuePair{
+			{Key: "k2", Value: "v2b"},
+			{Key: "k3", Value: "v3"},
+		},
+	)
+
+	m := make(map[string]string, len(props))
+	for _, kv := range props {
+		m[kv.Key] = kv.Value
+	}
+	require.Equal(t, map[string]string{"k1": "v1", "k2": "v2b", "k3": "v3"}, m)
+}
+
+func TestCore_getAlterLoadConfigOfAlterDatabase(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("list collections error", func(t *testing.T) {
+		core := newTestCore(withMeta(&mockMetaTable{
+			ListCollectionsFunc: func(ctx context.Context, ts Timestamp) ([]*model.Collection, error) {
+				return nil, errors.New("meta error")
+			},
+		}))
+
+		_, err := core.getAlterLoadConfigOfAlterDatabase(ctx, "db",
+			[]*commonpb.KeyValuePair{
+				{Key: common.DatabaseReplicaNumber, Value: "1"},
+				{Key: common.DatabaseResourceGroups, Value: "rg1"},
+			},
+			[]*commonpb.KeyValuePair{
+				{Key: common.DatabaseReplicaNumber, Value: "2"},
+				{Key: common.DatabaseResourceGroups, Value: "rg1"},
+			},
+		)
+		require.Error(t, err)
+	})
+
+	t.Run("empty collections", func(t *testing.T) {
+		core := newTestCore(withMeta(&mockMetaTable{
+			ListCollectionsFunc: func(ctx context.Context, ts Timestamp) ([]*model.Collection, error) {
+				return []*model.Collection{}, nil
+			},
+		}))
+
+		cfg, err := core.getAlterLoadConfigOfAlterDatabase(ctx, "db",
+			[]*commonpb.KeyValuePair{
+				{Key: common.DatabaseReplicaNumber, Value: "1"},
+				{Key: common.DatabaseResourceGroups, Value: "rg1"},
+			},
+			[]*commonpb.KeyValuePair{
+				{Key: common.DatabaseReplicaNumber, Value: "2"},
+				{Key: common.DatabaseResourceGroups, Value: "rg1"},
+			},
+		)
+		require.NoError(t, err)
+		require.Nil(t, cfg)
+	})
+
+	t.Run("build alter load config", func(t *testing.T) {
+		core := newTestCore(withMeta(&mockMetaTable{
+			ListCollectionsFunc: func(ctx context.Context, ts Timestamp) ([]*model.Collection, error) {
+				return []*model.Collection{{CollectionID: 10}}, nil
+			},
+		}))
+
+		cfg, err := core.getAlterLoadConfigOfAlterDatabase(ctx, "db",
+			[]*commonpb.KeyValuePair{
+				{Key: common.DatabaseReplicaNumber, Value: "1"},
+				{Key: common.DatabaseResourceGroups, Value: "rg1"},
+			},
+			[]*commonpb.KeyValuePair{
+				{Key: common.DatabaseReplicaNumber, Value: "2"},
+				{Key: common.DatabaseResourceGroups, Value: "rg1"},
+			},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		require.Equal(t, []int64{10}, cfg.CollectionIds)
+		require.Equal(t, int32(2), cfg.ReplicaNumber)
+		require.Equal(t, []string{"rg1"}, cfg.ResourceGroups)
+	})
 }
 
 func assertDatabaseReplicaNumber(t *testing.T, ctx context.Context, core *Core, dbName string, replicaNumber int64) {

--- a/internal/rootcoord/mock_test.go
+++ b/internal/rootcoord/mock_test.go
@@ -908,6 +908,8 @@ type mockBroker struct {
 
 	BroadcastAlteredCollectionFunc func(ctx context.Context, collectionID UniqueID) error
 
+	ShowResourceGroupsFunc func(ctx context.Context) ([]string, error)
+
 	GCConfirmFunc func(ctx context.Context, collectionID, partitionID UniqueID) bool
 }
 
@@ -927,6 +929,9 @@ func newValidMockBroker() *mockBroker {
 	}
 	broker.BroadcastAlteredCollectionFunc = func(ctx context.Context, collectionID UniqueID) error {
 		return nil
+	}
+	broker.ShowResourceGroupsFunc = func(ctx context.Context) ([]string, error) {
+		return []string{}, nil
 	}
 	return broker
 }
@@ -965,6 +970,13 @@ func (b mockBroker) GetSegmentIndexState(ctx context.Context, collID UniqueID, i
 
 func (b mockBroker) BroadcastAlteredCollection(ctx context.Context, collectionID UniqueID) error {
 	return b.BroadcastAlteredCollectionFunc(ctx, collectionID)
+}
+
+func (b mockBroker) ShowResourceGroups(ctx context.Context) ([]string, error) {
+	if b.ShowResourceGroupsFunc != nil {
+		return b.ShowResourceGroupsFunc(ctx)
+	}
+	return []string{}, nil
 }
 
 func (b mockBroker) GcConfirm(ctx context.Context, collectionID, partitionID UniqueID) bool {

--- a/internal/rootcoord/root_coord.go
+++ b/internal/rootcoord/root_coord.go
@@ -75,6 +75,42 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
+// Helper function to validate resource groups
+func (c *Core) validateResourceGroups(ctx context.Context, properties []*commonpb.KeyValuePair, level string) error {
+	var rgs []string
+	var err error
+
+	if level == "database" {
+		rgs, err = common.DatabaseLevelResourceGroups(properties)
+	} else if level == "collection" {
+		rgs, err = common.CollectionLevelResourceGroups(properties)
+	} else {
+		return fmt.Errorf("invalid level %s for resource group validation", level)
+	}
+
+	if err != nil || len(rgs) == 0 {
+		// If the property is not found or empty, it's valid (no changes or removed)
+		return nil
+	}
+
+	resp, err := c.broker.ShowResourceGroups(ctx)
+	if err != nil {
+		return err
+	}
+
+	existingRGs := make(map[string]bool)
+	for _, rg := range resp {
+		existingRGs[rg] = true
+	}
+
+	for _, rg := range rgs {
+		if !existingRGs[rg] {
+			return merr.WrapErrResourceGroupNotFound(rg)
+		}
+	}
+	return nil
+}
+
 // UniqueID is an alias of typeutil.UniqueID.
 type UniqueID = typeutil.UniqueID
 
@@ -1311,6 +1347,12 @@ func (c *Core) AlterCollection(ctx context.Context, in *milvuspb.AlterCollection
 	)
 	log.Info("received request to alter collection")
 
+	if err := c.validateResourceGroups(ctx, in.GetProperties(), "collection"); err != nil {
+		log.Warn("failed to validate resource groups", zap.Error(err))
+		metrics.RootCoordDDLReqCounter.WithLabelValues("AlterCollection", metrics.FailLabel).Inc()
+		return merr.Status(err), nil
+	}
+
 	if err := c.broadcastAlterCollectionForAlterCollection(ctx, in); err != nil {
 		if errors.Is(err, errIgnoredAlterCollection) {
 			log.Info("alter collection make no changes, ignore it")
@@ -1470,6 +1512,12 @@ func (c *Core) AlterDatabase(ctx context.Context, in *rootcoordpb.AlterDatabaseR
 		zap.Any("props", in.Properties),
 		zap.Strings("deleteKeys", in.DeleteKeys))
 	log.Info("received request to alter database")
+
+	if err := c.validateResourceGroups(ctx, in.GetProperties(), "database"); err != nil {
+		log.Warn("failed to validate resource groups", zap.Error(err))
+		metrics.RootCoordDDLReqCounter.WithLabelValues(method, metrics.FailLabel).Inc()
+		return merr.Status(err), nil
+	}
 
 	if err := c.broadcastAlterDatabase(ctx, in); err != nil {
 		if errors.Is(err, errIgnoredAlterDatabase) {

--- a/internal/rootcoord/root_coord_test.go
+++ b/internal/rootcoord/root_coord_test.go
@@ -51,6 +51,7 @@ import (
 	mocktso "github.com/milvus-io/milvus/internal/tso/mocks"
 	kvfactory "github.com/milvus-io/milvus/internal/util/dependency/kv"
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
+	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/etcdpb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/internalpb"
@@ -245,6 +246,44 @@ func TestRootCoord_AlterDatabase(t *testing.T) {
 		resp, err := c.AlterDatabase(ctx, &rootcoordpb.AlterDatabaseRequest{})
 		assert.NoError(t, err)
 		assert.Equal(t, commonpb.ErrorCode_NotReadyServe, resp.GetErrorCode())
+	})
+
+	t.Run("validate resource group failed", func(t *testing.T) {
+		c := newTestCore(withHealthyCode(), withBroker(&mockBroker{
+			ShowResourceGroupsFunc: func(ctx context.Context) ([]string, error) {
+				return []string{"rg1"}, nil
+			},
+		}))
+		ctx := context.Background()
+		resp, err := c.AlterDatabase(ctx, &rootcoordpb.AlterDatabaseRequest{
+			DbName: "db",
+			Properties: []*commonpb.KeyValuePair{
+				{Key: common.DatabaseResourceGroups, Value: "rg2"},
+			},
+		})
+		require.ErrorIs(t, merr.CheckRPCCall(resp, err), merr.ErrResourceGroupNotFound)
+	})
+}
+
+func TestCore_validateResourceGroups(t *testing.T) {
+	t.Run("invalid level", func(t *testing.T) {
+		c := newTestCore(withHealthyCode())
+		err := c.validateResourceGroups(context.Background(), nil, "invalid")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid level")
+	})
+
+	t.Run("broker error", func(t *testing.T) {
+		c := newTestCore(withHealthyCode(), withBroker(&mockBroker{
+			ShowResourceGroupsFunc: func(ctx context.Context) ([]string, error) {
+				return nil, errors.New("broker error")
+			},
+		}))
+
+		err := c.validateResourceGroups(context.Background(), []*commonpb.KeyValuePair{
+			{Key: common.CollectionResourceGroups, Value: "rg1"},
+		}, "collection")
+		require.Error(t, err)
 	})
 }
 
@@ -1294,6 +1333,23 @@ func TestRootCoord_AlterCollection(t *testing.T) {
 		resp, err := c.AlterCollection(ctx, &milvuspb.AlterCollectionRequest{})
 		assert.NoError(t, err)
 		assert.NotEqual(t, commonpb.ErrorCode_Success, resp.GetErrorCode())
+	})
+
+	t.Run("validate resource group failed", func(t *testing.T) {
+		ctx := context.Background()
+		c := newTestCore(withHealthyCode(), withBroker(&mockBroker{
+			ShowResourceGroupsFunc: func(ctx context.Context) ([]string, error) {
+				return []string{"rg1"}, nil
+			},
+		}))
+		resp, err := c.AlterCollection(ctx, &milvuspb.AlterCollectionRequest{
+			DbName:         "db",
+			CollectionName: "collection",
+			Properties: []*commonpb.KeyValuePair{
+				{Key: common.CollectionResourceGroups, Value: "rg2"},
+			},
+		})
+		require.ErrorIs(t, merr.CheckRPCCall(resp, err), merr.ErrResourceGroupNotFound)
 	})
 }
 

--- a/tests/go_client/testcases/database_test.go
+++ b/tests/go_client/testcases/database_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/milvus-io/milvus/client/v2/entity"
 	client "github.com/milvus-io/milvus/client/v2/milvusclient"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/tests/go_client/base"
@@ -343,14 +344,29 @@ func TestDatabasePropertiesRgReplicas(t *testing.T) {
 	err := mc.CreateDatabase(ctx, client.NewCreateDatabaseOption(dbName))
 	common.CheckErr(t, err, true)
 
+	rgName := common.GenRandomString("rg", 4)
+	err = mc.CreateResourceGroup(ctx, client.NewCreateResourceGroupOption(rgName))
+	common.CheckErr(t, err, true)
+	t.Cleanup(func() {
+		_ = mc.UpdateResourceGroup(ctx, client.NewUpdateResourceGroupOption(rgName, &entity.ResourceGroupConfig{
+			Requests: entity.ResourceGroupLimit{NodeNum: 0},
+			Limits:   entity.ResourceGroupLimit{NodeNum: 0},
+		}))
+		_ = mc.DropResourceGroup(ctx, client.NewDropResourceGroupOption(rgName))
+	})
+	require.Eventually(t, func() bool {
+		_, err := mc.DescribeResourceGroup(ctx, client.NewDescribeResourceGroupOption(rgName))
+		return err == nil
+	}, 5*time.Second, 200*time.Millisecond)
+
 	// alter database properties
 	err = mc.AlterDatabaseProperties(ctx, client.NewAlterDatabasePropertiesOption(dbName).
-		WithProperty(common.DatabaseResourceGroups, "rg1").WithProperty(common.DatabaseReplicaNumber, 2))
+		WithProperty(common.DatabaseResourceGroups, rgName).WithProperty(common.DatabaseReplicaNumber, 2))
 	common.CheckErr(t, err, true)
 
 	// describe database
 	db, _ := mc.DescribeDatabase(ctx, client.NewDescribeDatabaseOption(dbName))
-	require.Equal(t, map[string]string{common.DatabaseResourceGroups: "rg1", common.DatabaseReplicaNumber: "2"}, db.Properties)
+	require.Equal(t, map[string]string{common.DatabaseResourceGroups: rgName, common.DatabaseReplicaNumber: "2"}, db.Properties)
 
 	mc.UseDatabase(ctx, client.NewUseDatabaseOption(dbName))
 	prepare, schema := hp.CollPrepare.CreateCollection(ctx, t, mc, hp.NewCreateCollectionParams(hp.Int64Vec), hp.TNewFieldsOption(), hp.TNewSchemaOption().TWithEnableDynamicField(true))
@@ -360,7 +376,7 @@ func TestDatabasePropertiesRgReplicas(t *testing.T) {
 
 	// When load does not specify parameters, rg and replica Properties take effect
 	_, errLoad := mc.LoadCollection(ctx, client.NewLoadCollectionOption(schema.CollectionName))
-	common.CheckErr(t, errLoad, false, "resource group not found", "service resource insufficient")
+	common.CheckErr(t, errLoad, false, "resource group not found", "service resource insufficient", "resource group node not enough")
 
 	// actually load with default rg, rg1 not existed
 	taskLoad, errLoad := mc.LoadCollection(ctx, client.NewLoadCollectionOption(schema.CollectionName).WithReplica(1))


### PR DESCRIPTION
issue: #48488
pr: #48489

This PR adds validation for resource groups in `AlterCollection` and `AlterDatabase` requests in RootCoord. It ensures that any specified resource group exists in the system before proceeding with the DDL operation.

Specifically:
- Added `validateResourceGroups` helper in `root_coord.go` to check RG existence via `Broker`.
- Added `ShowResourceGroups` to the `Broker` interface and `ServerBroker` implementation.
- Intercepts requests in `AlterCollection` and `AlterDatabase` if the specified RG is not found, returning `merr.ErrResourceGroupNotFound`.
- Updated DDL callbacks to handle `ErrResourceGroupNotFound` and stop infinite retries.

### Why is it needed?
Previously, if a user provided a non-existent resource group in an Alter request, the system could fall into an infinite retry loop or hang because the downstream components (like QueryCoord) would fail to find the RG, but RootCoord wouldn't know to stop.

### How was it tested?
- Added unit tests in `ddl_callbacks_alter_collection_properties_test.go` and `ddl_callbacks_alter_database_test.go` to mock the `ShowResourceGroups` response.
- Verified that `make test-rootcoord` passes with the new validation logic.

---------