### PR TITLE
fix: enforce strict case sensitivity for query_mode property key and value

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -495,22 +495,26 @@ func IsQueryModeKeyExists(kvs ...*commonpb.KeyValuePair) bool {
 func GetQueryMode(kvs ...*commonpb.KeyValuePair) string {
 	for _, kv := range kvs {
 		if kv.Key == QueryModeKey {
-			return strings.ToLower(strings.TrimSpace(kv.Value))
+			return kv.Value
 		}
 	}
 	return ""
 }
 
 // ValidateQueryMode validates the query_mode value. Returns nil if the value
-// is valid or if query_mode is not set.
+// is valid or if query_mode is not set. Also rejects case-variant keys
+// (e.g. "QUERY_MODE", "Query_Mode") that would be silently ignored.
 func ValidateQueryMode(kvs ...*commonpb.KeyValuePair) error {
 	for _, kv := range kvs {
 		if kv.Key == QueryModeKey {
-			mode := strings.ToLower(strings.TrimSpace(kv.Value))
+			mode := kv.Value
 			if mode != QueryModeLargeTopK {
 				return fmt.Errorf("invalid query_mode value %q, valid values: [%s]", kv.Value, ValidQueryModes)
 			}
 			return nil
+		}
+		if strings.EqualFold(kv.Key, QueryModeKey) {
+			return fmt.Errorf("invalid property key %q, did you mean %q?", kv.Key, QueryModeKey)
 		}
 	}
 	return nil

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -403,11 +403,12 @@ func TestQueryMode(t *testing.T) {
 		assert.Equal(t, QueryModeLargeTopK, GetQueryMode(kvs...))
 	})
 
-	t.Run("GetQueryMode case insensitive", func(t *testing.T) {
+	t.Run("GetQueryMode is case sensitive", func(t *testing.T) {
 		kvs := []*commonpb.KeyValuePair{
 			{Key: QueryModeKey, Value: "Large_TopK"},
 		}
-		assert.Equal(t, QueryModeLargeTopK, GetQueryMode(kvs...))
+		assert.NotEqual(t, QueryModeLargeTopK, GetQueryMode(kvs...))
+		assert.Equal(t, "Large_TopK", GetQueryMode(kvs...))
 	})
 
 	t.Run("GetQueryMode returns empty when not present", func(t *testing.T) {
@@ -448,6 +449,28 @@ func TestQueryMode(t *testing.T) {
 			{Key: QueryModeKey, Value: "invalid"},
 		}
 		assert.Error(t, ValidateQueryMode(kvs...))
+	})
+
+	t.Run("ValidateQueryMode rejects wrong case value", func(t *testing.T) {
+		for _, val := range []string{"LARGE_TOPK", "Large_TopK", "Large_Topk"} {
+			kvs := []*commonpb.KeyValuePair{
+				{Key: QueryModeKey, Value: val},
+			}
+			err := ValidateQueryMode(kvs...)
+			assert.Error(t, err, "value %q should be rejected", val)
+			assert.Contains(t, err.Error(), "valid values")
+		}
+	})
+
+	t.Run("ValidateQueryMode rejects wrong case key", func(t *testing.T) {
+		for _, key := range []string{"QUERY_MODE", "Query_Mode", "Query_mode"} {
+			kvs := []*commonpb.KeyValuePair{
+				{Key: key, Value: "large_topk"},
+			}
+			err := ValidateQueryMode(kvs...)
+			assert.Error(t, err, "key %q should be rejected", key)
+			assert.Contains(t, err.Error(), "did you mean")
+		}
 	})
 }
 


### PR DESCRIPTION
## Summary
- **Value casing**: `LARGE_TOPK` / `Large_TopK` were silently accepted as valid `query_mode` values due to `strings.ToLower()`. Now only the exact lowercase `large_topk` is accepted, with a clear error for mismatches.
- **Key casing**: `QUERY_MODE` / `Query_Mode` were silently stored as unknown properties with no effect. Now a case-insensitive key match triggers an error: `invalid property key "QUERY_MODE", did you mean "query_mode"?`
- Removed unnecessary `strings.TrimSpace()` from value handling for strict exact matching.

issue: #48725

## Test plan
- [x] Updated existing unit test for case-sensitive value behavior
- [x] Added test for wrong-case values being rejected (`LARGE_TOPK`, `Large_TopK`, `Large_Topk`)
- [x] Added test for wrong-case keys being rejected with "did you mean" hint (`QUERY_MODE`, `Query_Mode`, `Query_mode`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)