### PR TITLE
fix: add MOL field type support

### DIFF
--- a/client/column/columns.go
+++ b/client/column/columns.go
@@ -232,6 +232,9 @@ func FieldDataColumn(fd *schemapb.FieldData, begin, end int) (Column, error) {
 	case schemapb.DataType_Geometry:
 		return parseScalarData(fd.GetFieldName(), fd.GetScalars().GetGeometryWktData().GetData(), begin, end, validData, NewColumnGeometryWKT, NewNullableColumnGeometryWKT)
 
+	case schemapb.DataType_Mol:
+		return parseScalarData(fd.GetFieldName(), fd.GetScalars().GetMolSmilesData().GetData(), begin, end, validData, NewColumnMolSmiles, NewNullableColumnMolSmiles)
+
 	case schemapb.DataType_FloatVector:
 		vectors := fd.GetVectors()
 		x, ok := vectors.GetData().(*schemapb.VectorField_FloatVector)

--- a/client/column/columns.go
+++ b/client/column/columns.go
@@ -233,7 +233,13 @@ func FieldDataColumn(fd *schemapb.FieldData, begin, end int) (Column, error) {
 		return parseScalarData(fd.GetFieldName(), fd.GetScalars().GetGeometryWktData().GetData(), begin, end, validData, NewColumnGeometryWKT, NewNullableColumnGeometryWKT)
 
 	case schemapb.DataType_Mol:
-		return parseScalarData(fd.GetFieldName(), fd.GetScalars().GetMolSmilesData().GetData(), begin, end, validData, NewColumnMolSmiles, NewNullableColumnMolSmiles)
+		if data := fd.GetScalars().GetMolSmilesData().GetData(); data != nil {
+			return parseScalarData(fd.GetFieldName(), data, begin, end, validData, NewColumnMolSmiles, NewNullableColumnMolSmiles)
+		}
+		data := lo.Map(fd.GetScalars().GetMolData().GetData(), func(item []byte, _ int) string {
+			return string(item)
+		})
+		return parseScalarData(fd.GetFieldName(), data, begin, end, validData, NewColumnMolSmiles, NewNullableColumnMolSmiles)
 
 	case schemapb.DataType_FloatVector:
 		vectors := fd.GetVectors()

--- a/client/column/conversion.go
+++ b/client/column/conversion.go
@@ -119,6 +119,7 @@ func values2FieldData[T any](values []T, fieldType entity.FieldType, dim int) *s
 		entity.FieldTypeString,
 		entity.FieldTypeJSON,
 		entity.FieldTypeGeometry,
+		entity.FieldTypeMol,
 		entity.FieldTypeTimestamptz:
 		fd.Field = &schemapb.FieldData_Scalars{
 			Scalars: values2Scalars(values, fieldType), // scalars,
@@ -206,6 +207,12 @@ func values2Scalars[T any](values []T, fieldType entity.FieldType) *schemapb.Sca
 		strVals, ok = any(values).([]string)
 		scalars.Data = &schemapb.ScalarField_GeometryWktData{
 			GeometryWktData: &schemapb.GeometryWktArray{Data: strVals},
+		}
+	case entity.FieldTypeMol:
+		var strVals []string
+		strVals, ok = any(values).([]string)
+		scalars.Data = &schemapb.ScalarField_MolSmilesData{
+			MolSmilesData: &schemapb.MolSmilesArray{Data: strVals},
 		}
 	}
 	// shall not be accessed

--- a/client/column/mol.go
+++ b/client/column/mol.go
@@ -19,17 +19,13 @@ package column
 import (
 	"github.com/cockroachdb/errors"
 
-	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/client/v2/entity"
 )
 
+var _ Column = (*ColumnMolSmiles)(nil)
+
 type ColumnMolSmiles struct {
 	*genericColumnBase[string]
-}
-
-// Name returns column name.
-func (c *ColumnMolSmiles) Name() string {
-	return c.name
 }
 
 // Type returns column entity.FieldType.
@@ -37,13 +33,8 @@ func (c *ColumnMolSmiles) Type() entity.FieldType {
 	return entity.FieldTypeMol
 }
 
-// Len returns column values length.
-func (c *ColumnMolSmiles) Len() int {
-	return len(c.values)
-}
-
 func (c *ColumnMolSmiles) Slice(start, end int) Column {
-	l := c.Len()
+	l := c.genericColumnBase.Len()
 	if start > l {
 		start = l
 	}
@@ -55,30 +46,9 @@ func (c *ColumnMolSmiles) Slice(start, end int) Column {
 	}
 }
 
-// Get returns value at index as interface{}.
-func (c *ColumnMolSmiles) Get(idx int) (interface{}, error) {
-	if idx < 0 || idx >= c.Len() {
-		return nil, errors.New("index out of range")
-	}
-	return c.values[idx], nil
-}
-
-func (c *ColumnMolSmiles) GetAsString(idx int) (string, error) {
-	return c.ValueByIdx(idx)
-}
-
-// FieldData return column data mapped to schemapb.FieldData.
-func (c *ColumnMolSmiles) FieldData() *schemapb.FieldData {
-	fd := c.genericColumnBase.FieldData()
-	return fd
-}
-
 // ValueByIdx returns value of the provided index.
 func (c *ColumnMolSmiles) ValueByIdx(idx int) (string, error) {
-	if idx < 0 || idx >= c.Len() {
-		return "", errors.New("index out of range")
-	}
-	return c.values[idx], nil
+	return c.Value(idx)
 }
 
 // AppendValue append value into column.
@@ -87,13 +57,7 @@ func (c *ColumnMolSmiles) AppendValue(i interface{}) error {
 	if !ok {
 		return errors.New("expect mol SMILES type(string)")
 	}
-	c.values = append(c.values, s)
-	return nil
-}
-
-// Data returns column data.
-func (c *ColumnMolSmiles) Data() []string {
-	return c.values
+	return c.genericColumnBase.AppendValue(s)
 }
 
 func NewColumnMolSmiles(name string, values []string) *ColumnMolSmiles {

--- a/client/column/mol.go
+++ b/client/column/mol.go
@@ -1,0 +1,107 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package column
+
+import (
+	"github.com/cockroachdb/errors"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/client/v2/entity"
+)
+
+type ColumnMolSmiles struct {
+	*genericColumnBase[string]
+}
+
+// Name returns column name.
+func (c *ColumnMolSmiles) Name() string {
+	return c.name
+}
+
+// Type returns column entity.FieldType.
+func (c *ColumnMolSmiles) Type() entity.FieldType {
+	return entity.FieldTypeMol
+}
+
+// Len returns column values length.
+func (c *ColumnMolSmiles) Len() int {
+	return len(c.values)
+}
+
+func (c *ColumnMolSmiles) Slice(start, end int) Column {
+	l := c.Len()
+	if start > l {
+		start = l
+	}
+	if end == -1 || end > l {
+		end = l
+	}
+	return &ColumnMolSmiles{
+		genericColumnBase: c.genericColumnBase.slice(start, end),
+	}
+}
+
+// Get returns value at index as interface{}.
+func (c *ColumnMolSmiles) Get(idx int) (interface{}, error) {
+	if idx < 0 || idx >= c.Len() {
+		return nil, errors.New("index out of range")
+	}
+	return c.values[idx], nil
+}
+
+func (c *ColumnMolSmiles) GetAsString(idx int) (string, error) {
+	return c.ValueByIdx(idx)
+}
+
+// FieldData return column data mapped to schemapb.FieldData.
+func (c *ColumnMolSmiles) FieldData() *schemapb.FieldData {
+	fd := c.genericColumnBase.FieldData()
+	return fd
+}
+
+// ValueByIdx returns value of the provided index.
+func (c *ColumnMolSmiles) ValueByIdx(idx int) (string, error) {
+	if idx < 0 || idx >= c.Len() {
+		return "", errors.New("index out of range")
+	}
+	return c.values[idx], nil
+}
+
+// AppendValue append value into column.
+func (c *ColumnMolSmiles) AppendValue(i interface{}) error {
+	s, ok := i.(string)
+	if !ok {
+		return errors.New("expect mol SMILES type(string)")
+	}
+	c.values = append(c.values, s)
+	return nil
+}
+
+// Data returns column data.
+func (c *ColumnMolSmiles) Data() []string {
+	return c.values
+}
+
+func NewColumnMolSmiles(name string, values []string) *ColumnMolSmiles {
+	return &ColumnMolSmiles{
+		genericColumnBase: &genericColumnBase[string]{
+			name:      name,
+			fieldType: entity.FieldTypeMol,
+			values:    values,
+		},
+	}
+}

--- a/client/column/mol_test.go
+++ b/client/column/mol_test.go
@@ -1,0 +1,137 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package column
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/client/v2/entity"
+)
+
+func TestColumnMolSmilesMethods(t *testing.T) {
+	column := NewColumnMolSmiles("mol", []string{"CCO", "c1ccccc1"})
+
+	assert.Equal(t, "mol", column.Name())
+	assert.Equal(t, entity.FieldTypeMol, column.Type())
+	assert.Equal(t, 2, column.Len())
+	assert.Equal(t, []string{"CCO", "c1ccccc1"}, column.Data())
+	assert.Equal(t, []string{"CCO", "c1ccccc1"}, column.FieldData().GetScalars().GetMolSmilesData().GetData())
+
+	value, err := column.Get(0)
+	require.NoError(t, err)
+	assert.Equal(t, "CCO", value)
+
+	stringValue, err := column.GetAsString(1)
+	require.NoError(t, err)
+	assert.Equal(t, "c1ccccc1", stringValue)
+
+	valueByIdx, err := column.ValueByIdx(0)
+	require.NoError(t, err)
+	assert.Equal(t, "CCO", valueByIdx)
+
+	_, err = column.Get(-1)
+	assert.Error(t, err)
+	_, err = column.Get(2)
+	assert.Error(t, err)
+	_, err = column.GetAsString(2)
+	assert.Error(t, err)
+	_, err = column.ValueByIdx(-1)
+	assert.Error(t, err)
+
+	sliced, ok := column.Slice(1, -1).(*ColumnMolSmiles)
+	require.True(t, ok)
+	assert.Equal(t, 1, sliced.Len())
+	assert.Equal(t, []string{"c1ccccc1"}, sliced.Data())
+
+	emptySlice, ok := column.Slice(10, 10).(*ColumnMolSmiles)
+	require.True(t, ok)
+	assert.Equal(t, 0, emptySlice.Len())
+
+	err = column.AppendValue("N#N")
+	require.NoError(t, err)
+	assert.Equal(t, 3, column.Len())
+	assert.Equal(t, []string{"CCO", "c1ccccc1", "N#N"}, column.Data())
+
+	err = column.AppendValue([]byte("invalid"))
+	assert.Error(t, err)
+}
+
+func TestNullableColumnMolSmilesCompactAccess(t *testing.T) {
+	column, err := NewNullableColumnMolSmiles("mol", []string{"CCO", "N#N"}, []bool{true, false, true})
+	require.NoError(t, err)
+
+	assert.True(t, column.Nullable())
+	assert.Equal(t, entity.FieldTypeMol, column.Type())
+	assert.Equal(t, 3, column.Len())
+	assert.Equal(t, []string{"CCO", "N#N"}, column.Data())
+
+	value, err := column.GetAsString(0)
+	require.NoError(t, err)
+	assert.Equal(t, "CCO", value)
+
+	_, err = column.GetAsString(1)
+	assert.Error(t, err)
+
+	value, err = column.GetAsString(2)
+	require.NoError(t, err)
+	assert.Equal(t, "N#N", value)
+
+	err = column.AppendValue("CO")
+	require.NoError(t, err)
+	assert.Equal(t, 4, column.Len())
+
+	value, err = column.GetAsString(3)
+	require.NoError(t, err)
+	assert.Equal(t, "CO", value)
+}
+
+func TestFieldDataColumnMolDataNullableSlice(t *testing.T) {
+	fd := &schemapb.FieldData{
+		Type:      schemapb.DataType_Mol,
+		FieldName: "mol",
+		ValidData: []bool{true, false, true},
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_MolData{
+					MolData: &schemapb.MolArray{
+						Data: [][]byte{[]byte("CCO"), []byte(""), []byte("N#N")},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := FieldDataColumn(fd, 1, 3)
+	require.NoError(t, err)
+
+	column, ok := result.(*ColumnMolSmiles)
+	require.True(t, ok)
+	assert.Equal(t, 2, column.Len())
+	assert.Equal(t, []string{"", "N#N"}, column.Data())
+
+	isNull, err := column.IsNull(0)
+	require.NoError(t, err)
+	assert.True(t, isNull)
+
+	value, err := column.GetAsString(1)
+	require.NoError(t, err)
+	assert.Equal(t, "N#N", value)
+}

--- a/client/column/nullable.go
+++ b/client/column/nullable.go
@@ -38,6 +38,7 @@ var (
 	NewNullableColumnTimestamptzIsoString NullableColumnCreateFunc[string, *ColumnTimestampTzIsoString] = NewNullableColumnCreator(NewColumnTimestamptzIsoString).New
 	NewNullableColumnJSONBytes            NullableColumnCreateFunc[[]byte, *ColumnJSONBytes]            = NewNullableColumnCreator(NewColumnJSONBytes).New
 	NewNullableColumnGeometryWKT          NullableColumnCreateFunc[string, *ColumnGeometryWKT]          = NewNullableColumnCreator(NewColumnGeometryWKT).New
+	NewNullableColumnMolSmiles            NullableColumnCreateFunc[string, *ColumnMolSmiles]            = NewNullableColumnCreator(NewColumnMolSmiles).New
 	// array
 	NewNullableColumnBoolArray    NullableColumnCreateFunc[[]bool, *ColumnBoolArray]      = NewNullableColumnCreator(NewColumnBoolArray).New
 	NewNullableColumnInt8Array    NullableColumnCreateFunc[[]int8, *ColumnInt8Array]      = NewNullableColumnCreator(NewColumnInt8Array).New

--- a/client/column/nullable_test.go
+++ b/client/column/nullable_test.go
@@ -334,6 +334,40 @@ func (s *NullableScalarSuite) TestBasic() {
 		s.Error(err)
 	})
 
+	s.Run("nullable_mol", func() {
+		name := fmt.Sprintf("field_%d", rand.Intn(1000))
+		compactData := []string{"CCO", "c1ccccc1"}
+		sparseData := []string{"CCO", "", "c1ccccc1"}
+		validData := []bool{true, false, true}
+		column, err := NewNullableColumnMolSmiles(name, compactData, validData)
+		s.NoError(err)
+		s.Equal(entity.FieldTypeMol, column.Type())
+		s.Equal(name, column.Name())
+		s.Equal(compactData, column.Data())
+		for i := 0; i < len(validData); i++ {
+			r, err := column.IsNull(i)
+			s.NoError(err)
+			s.Equal(validData[i], !r)
+		}
+
+		column, err = NewNullableColumnMolSmiles(name, sparseData, validData, WithSparseNullableMode[string](true))
+		s.NoError(err)
+
+		fd := column.FieldData()
+		s.Equal(validData, fd.GetValidData())
+		result, err := FieldDataColumn(fd, 0, -1)
+		s.NoError(err)
+		parsed, ok := result.(*ColumnMolSmiles)
+		if s.True(ok) {
+			s.Equal(name, parsed.Name())
+			s.Equal(sparseData, parsed.Data())
+			s.Equal(entity.FieldTypeMol, parsed.Type())
+		}
+
+		_, err = NewNullableColumnMolSmiles(name, compactData, []bool{false, false})
+		s.Error(err)
+	})
+
 	s.Run("nullable_timestamptz_iso_string", func() {
 		name := fmt.Sprintf("field_%d", rand.Intn(1000))
 		compactData := []string{"2024-01-01T00:00:00Z", "2024-06-15T12:30:45Z"}

--- a/client/column/scalar_test.go
+++ b/client/column/scalar_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/client/v2/entity"
 )
 
@@ -212,6 +213,42 @@ func (s *ScalarSuite) TestBasic() {
 			s.Equal(name, parsed.Name())
 			s.Equal(data, parsed.Data())
 			s.Equal(entity.FieldTypeVarChar, column.Type())
+		}
+	})
+
+	s.Run("column_mol", func() {
+		name := fmt.Sprintf("field_%d", rand.Intn(1000))
+		data := []string{"CCO", "c1ccccc1"}
+		column := NewColumnMolSmiles(name, data)
+		s.Equal(entity.FieldTypeMol, column.Type())
+		s.Equal(name, column.Name())
+		s.Equal(data, column.Data())
+
+		fd := column.FieldData()
+		s.Equal(name, fd.GetFieldName())
+		s.Equal(data, fd.GetScalars().GetMolSmilesData().GetData())
+
+		result, err := FieldDataColumn(fd, 0, -1)
+		s.NoError(err)
+		parsed, ok := result.(*ColumnMolSmiles)
+		if s.True(ok) {
+			s.Equal(name, parsed.Name())
+			s.Equal(data, parsed.Data())
+			s.Equal(entity.FieldTypeMol, parsed.Type())
+		}
+
+		fd = &schemapb.FieldData{
+			Type:      schemapb.DataType_Mol,
+			FieldName: name,
+			Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_MolData{MolData: &schemapb.MolArray{Data: [][]byte{[]byte("CCO"), []byte("c1ccccc1")}}},
+			}},
+		}
+		result, err = FieldDataColumn(fd, 0, -1)
+		s.NoError(err)
+		parsed, ok = result.(*ColumnMolSmiles)
+		if s.True(ok) {
+			s.Equal(data, parsed.Data())
 		}
 	})
 

--- a/client/entity/field.go
+++ b/client/entity/field.go
@@ -58,6 +58,8 @@ func (t FieldType) Name() string {
 		return "JSON"
 	case FieldTypeGeometry:
 		return "Geometry"
+	case FieldTypeMol:
+		return "Mol"
 	case FieldTypeBinaryVector:
 		return "BinaryVector"
 	case FieldTypeFloatVector:
@@ -102,6 +104,8 @@ func (t FieldType) String() string {
 		return "JSON"
 	case FieldTypeGeometry:
 		return "Geometry"
+	case FieldTypeMol:
+		return "Mol"
 	case FieldTypeBinaryVector:
 		return "[]byte"
 	case FieldTypeFloatVector:
@@ -144,6 +148,8 @@ func (t FieldType) PbFieldType() (string, string) {
 		return "JSON", "JSON"
 	case FieldTypeGeometry:
 		return "Geometry", "Geometry"
+	case FieldTypeMol:
+		return "Mol", "string"
 	case FieldTypeBinaryVector:
 		return "[]byte", ""
 	case FieldTypeFloatVector:
@@ -187,6 +193,8 @@ const (
 	FieldTypeJSON FieldType = 23
 	// FieldTypeGeometry field type Geometry
 	FieldTypeGeometry FieldType = 24
+	// FieldTypeMol field type Mol
+	FieldTypeMol FieldType = 27
 	// FieldTypeTimestamptz field type timestamptz
 	FieldTypeTimestamptz FieldType = 26
 	// FieldTypeBinaryVector field type binary vector

--- a/client/entity/field_test.go
+++ b/client/entity/field_test.go
@@ -73,6 +73,14 @@ func TestFieldSchema(t *testing.T) {
 	})
 }
 
+func TestFieldTypeMolMeta(t *testing.T) {
+	assert.Equal(t, "Mol", FieldTypeMol.Name())
+	assert.Equal(t, "Mol", FieldTypeMol.String())
+	pbName, pbType := FieldTypeMol.PbFieldType()
+	assert.Equal(t, "Mol", pbName)
+	assert.Equal(t, "string", pbType)
+}
+
 func TestStructSchema(t *testing.T) {
 	// Test NewStructSchema
 	schema := NewStructSchema()

--- a/client/entity/function.go
+++ b/client/entity/function.go
@@ -30,9 +30,10 @@ type FunctionType = schemapb.FunctionType
 const (
 	FunctionTypeUnknown       = schemapb.FunctionType_Unknown
 	FunctionTypeBM25          = schemapb.FunctionType_BM25
-	FunctionTypeMinHash       = schemapb.FunctionType_MinHash
-	FunctionTypeTextEmbedding = schemapb.FunctionType_TextEmbedding
-	FunctionTypeRerank        = schemapb.FunctionType_Rerank
+	FunctionTypeMinHash        = schemapb.FunctionType_MinHash
+	FunctionTypeTextEmbedding  = schemapb.FunctionType_TextEmbedding
+	FunctionTypeRerank         = schemapb.FunctionType_Rerank
+	FunctionTypeMolFingerprint = schemapb.FunctionType_MolFingerprint
 )
 
 type Function struct {

--- a/client/entity/function.go
+++ b/client/entity/function.go
@@ -28,8 +28,8 @@ type FunctionType = schemapb.FunctionType
 
 // provide package alias
 const (
-	FunctionTypeUnknown       = schemapb.FunctionType_Unknown
-	FunctionTypeBM25          = schemapb.FunctionType_BM25
+	FunctionTypeUnknown        = schemapb.FunctionType_Unknown
+	FunctionTypeBM25           = schemapb.FunctionType_BM25
 	FunctionTypeMinHash        = schemapb.FunctionType_MinHash
 	FunctionTypeTextEmbedding  = schemapb.FunctionType_TextEmbedding
 	FunctionTypeRerank         = schemapb.FunctionType_Rerank

--- a/client/entity/function_test.go
+++ b/client/entity/function_test.go
@@ -26,6 +26,7 @@ func TestFunctionSchema(t *testing.T) {
 	functions := []*Function{
 		NewFunction().WithName("text_bm25_emb").WithType(FunctionTypeBM25).WithInputFields("a", "b").WithOutputFields("c").WithParam("key", "value"),
 		NewFunction().WithName("other_emb").WithType(FunctionTypeTextEmbedding).WithInputFields("c").WithOutputFields("b", "a"),
+		NewFunction().WithName("mol_fp").WithType(FunctionTypeMolFingerprint).WithInputFields("mol").WithOutputFields("fp"),
 	}
 
 	for _, function := range functions {

--- a/client/index/common.go
+++ b/client/index/common.go
@@ -68,4 +68,5 @@ const (
 	Inverted IndexType = "INVERTED"
 	BITMAP   IndexType = "BITMAP"
 	RTREE    IndexType = "RTREE"
+	PATTERN  IndexType = "PATTERN"
 )

--- a/client/index/scalar_test.go
+++ b/client/index/scalar_test.go
@@ -39,6 +39,7 @@ func (s *ScalarIndexSuite) TestConstructors() {
 		{tag: "Sorted", input: NewSortedIndex(), expectIndexType: Sorted},
 		{tag: "Inverted", input: NewInvertedIndex(), expectIndexType: Inverted},
 		{tag: "Bitmap", input: NewBitmapIndex(), expectIndexType: BITMAP},
+		{tag: "Pattern", input: scalarIndex{indexType: PATTERN}, expectIndexType: PATTERN},
 	}
 
 	for _, tc := range testcases {

--- a/client/row/data.go
+++ b/client/row/data.go
@@ -226,6 +226,9 @@ func getColumnCreators(sch *entity.Schema) map[string]columnCreator {
 			case entity.FieldTypeJSON:
 				data := make([][]byte, 0, rowsLen)
 				col = column.NewColumnJSONBytes(field.Name, data)
+			case entity.FieldTypeMol:
+				data := make([]string, 0, rowsLen)
+				col = column.NewColumnMolSmiles(field.Name, data)
 			case entity.FieldTypeArray:
 				col = NewArrayColumn(field)
 				if col == nil {

--- a/client/row/data_test.go
+++ b/client/row/data_test.go
@@ -50,6 +50,27 @@ func (s *RowsSuite) TestRowsToColumns() {
 		s.Equal(3, len(columns))
 	})
 
+	s.Run("mol", func() {
+		type MolStruct struct {
+			ID  int64  `milvus:"primary_key"`
+			Mol string
+		}
+		schema := entity.NewSchema().
+			WithField(entity.NewField().WithName("ID").WithDataType(entity.FieldTypeInt64).WithIsPrimaryKey(true)).
+			WithField(entity.NewField().WithName("Mol").WithDataType(entity.FieldTypeMol))
+		columns, err := AnyToColumns([]any{&MolStruct{ID: 1, Mol: "CCO"}}, false, schema)
+		s.NoError(err)
+		s.Require().Len(columns, 2)
+		for _, col := range columns {
+			if col.Name() == "Mol" {
+				s.Equal(entity.FieldTypeMol, col.Type())
+				val, err := col.Get(0)
+				s.NoError(err)
+				s.Equal("CCO", val)
+			}
+		}
+	})
+
 	s.Run("auto_id_pk", func() {
 		type AutoPK struct {
 			ID     int64     `milvus:"primary_key;auto_id"`

--- a/client/row/data_test.go
+++ b/client/row/data_test.go
@@ -52,7 +52,7 @@ func (s *RowsSuite) TestRowsToColumns() {
 
 	s.Run("mol", func() {
 		type MolStruct struct {
-			ID  int64  `milvus:"primary_key"`
+			ID  int64 `milvus:"primary_key"`
 			Mol string
 		}
 		schema := entity.NewSchema().


### PR DESCRIPTION
## Summary
- add `FieldTypeMol` mapping and MOL column support in Go client
- support MOL insert encoding and query/result decoding compatibility
- add `PATTERN` index enum and `FunctionTypeMolFingerprint` alias
- add client tests covering MOL type, nullable MOL, PATTERN index, and function alias

### Changes
- `client/entity/field.go`: add `FieldTypeMol` mapping
- `client/column/mol.go`: add MOL column type
- `client/column/conversion.go`: encode insert values into `mol_smiles_data`
- `client/column/columns.go`: decode MOL columns from both `mol_smiles_data` and `mol_data`
- `client/index/common.go`: add `PATTERN`
- `client/entity/function.go`: add Mol fingerprint function alias

## Test plan
- [x] `cd client && go test ./column ./entity ./index ./row`

issue: #47229
