### PR TITLE
enhance: load each lazy field with its own projected reader

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -3651,6 +3651,11 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
                                      : mmap_config.GetScalarFieldEnableMmap();
     auto use_mmap = has_mmap_setting ? mmap_enabled : global_use_mmap;
 
+    // The set of columns this entry projects is exactly the field_ids the
+    // diff handed us. For lazy entries, SegmentLoadInfo::ComputeDiffColumnGroups
+    // emits one entry per field, so each lazy entry produces a single-column
+    // projected ChunkReader — touching one lazy field will not co-load chunks
+    // for sibling lazy fields in the same column group.
     auto needed_columns = std::make_shared<std::vector<std::string>>();
     needed_columns->reserve(milvus_field_ids.size());
     for (const auto& fid : milvus_field_ids) {
@@ -3671,9 +3676,13 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
 
     auto chunk_reader = std::move(chunk_reader_result).ValueOrDie();
 
-    LOG_INFO("[StorageV2] segment {} loads manifest cg index {}",
-             this->get_segment_id(),
-             index);
+    LOG_INFO(
+        "[StorageV2] segment {} loads manifest cg index {} ({} field(s), "
+        "eager={})",
+        this->get_segment_id(),
+        index,
+        milvus_field_ids.size(),
+        eager_load);
     auto mmap_dir_path =
         milvus::storage::LocalChunkManagerSingleton::GetInstance()
             .GetChunkManager()
@@ -3683,6 +3692,15 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
     // otherwise pass empty string to fall back to global config
     std::string warmup_policy =
         has_warmup_setting ? aggregated_warmup_policy : "";
+
+    // Multiple lazy entries can share the same column-group index (one per
+    // field), so the translator cache key must be disambiguated by the
+    // field-id of this entry. Eager entries are still one-per-cg, so they
+    // keep the unsuffixed key.
+    std::string cache_key_suffix;
+    if (!eager_load) {
+        cache_key_suffix = std::to_string(milvus_field_ids.front().get());
+    }
 
     auto translator =
         std::make_unique<storagev2translator::ManifestGroupTranslator>(
@@ -3694,10 +3712,11 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
             use_mmap,
             mmap_config.GetMmapPopulate(),
             mmap_dir_path,
-            column_group->columns.size(),
+            milvus_field_ids.size(),
             segment_load_info_.GetPriority(),
             eager_load,
-            warmup_policy);
+            warmup_policy,
+            cache_key_suffix);
     auto chunked_column_group =
         std::make_shared<ChunkedColumnGroup>(std::move(translator));
 
@@ -3707,7 +3726,6 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
         auto column = std::make_shared<ProxyChunkColumn>(
             chunked_column_group, field_id, field_meta);
         auto data_type = field_meta.get_data_type();
-        std::optional<ParquetStatistics> statistics_opt;
         load_field_data_common(
             field_id,
             column,

--- a/internal/core/src/segcore/SegmentLoadInfo.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfo.cpp
@@ -378,12 +378,19 @@ SegmentLoadInfo::ComputeDiffColumnGroups(LoadDiff& diff,
         if (!replace_fields.empty()) {
             diff.column_groups_to_replace.emplace_back(i, replace_fields);
         }
-        if (!lazy_fields.empty()) {
-            diff.column_groups_to_lazyload.emplace_back(i, lazy_fields);
+        // Lazy entries are emitted one-per-field on purpose: each entry maps
+        // to a separate single-column projected ChunkReader in
+        // LoadColumnGroup, so touching one lazy field never co-loads chunks
+        // for sibling lazy fields in the same column group. Reader-sharing
+        // policy is therefore encoded in the diff entry shape itself rather
+        // than re-derived inside the loader.
+        for (const auto& fid : lazy_fields) {
+            diff.column_groups_to_lazyload.emplace_back(
+                i, std::vector<FieldId>{fid});
         }
-        if (!lazy_replace_fields.empty()) {
-            diff.column_groups_to_lazyreplace.emplace_back(i,
-                                                           lazy_replace_fields);
+        for (const auto& fid : lazy_replace_fields) {
+            diff.column_groups_to_lazyreplace.emplace_back(
+                i, std::vector<FieldId>{fid});
         }
     }
 

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
@@ -70,12 +70,18 @@ ManifestGroupTranslator::ManifestGroupTranslator(
     int64_t num_fields,
     milvus::proto::common::LoadPriority load_priority,
     bool eager_load,
-    const std::string& warmup_policy)
+    const std::string& warmup_policy,
+    const std::string& cache_key_suffix)
     : segment_id_(segment_id),
       group_chunk_type_(group_chunk_type),
       column_group_index_(column_group_index),
       chunk_reader_(std::move(chunk_reader)),
-      key_(fmt::format("seg_{}_cg_{}", segment_id, column_group_index)),
+      key_(cache_key_suffix.empty()
+               ? fmt::format("seg_{}_cg_{}", segment_id, column_group_index)
+               : fmt::format("seg_{}_cg_{}_{}",
+                             segment_id,
+                             column_group_index,
+                             cache_key_suffix)),
       field_metas_(field_metas),
       mmap_dir_path_(mmap_dir_path),
       meta_(num_fields,

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.h
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.h
@@ -77,7 +77,8 @@ class ManifestGroupTranslator
         int64_t num_fields,
         milvus::proto::common::LoadPriority load_priority,
         bool eager_load,
-        const std::string& warmup_policy);
+        const std::string& warmup_policy,
+        const std::string& cache_key_suffix = "");
     ~ManifestGroupTranslator() = default;
 
     /**


### PR DESCRIPTION
Previously all lazy fields sharing a column group were loaded through a single ChunkReader projecting the full lazy subset. Touching any one of them forced the underlying reader to materialize chunks for every other lazy field in the group, inflating resident memory even though lazy fields (index-has-raw-data) only need raw data as a fallback.

Encode reader-sharing policy directly in the LoadDiff entries: ComputeDiffColumnGroups now emits column_groups_to_lazyload and column_groups_to_lazyreplace as one entry per field. LoadColumnGroup keeps a single uniform code path that projects exactly the field set the entry contains, so lazy entries naturally produce single-column projected ChunkReaders.

Multiple lazy entries can share the same column group index, so ManifestGroupTranslator gains an optional cache_key_suffix parameter (defaulted, backward compatible) to disambiguate per-field translator cache keys as seg_{id}_cg_{idx}_{fid}. Eager entries keep the unsuffixed key.

issue: #45060