### PR TITLE
enhance:Foundational merr framework and retry mechanisms

### DIFF
--- a/examples/telemetry_e2e_test/go.mod
+++ b/examples/telemetry_e2e_test/go.mod
@@ -1,10 +1,11 @@
 module github.com/milvus-io/milvus/examples/telemetry_e2e_test
+
 go 1.25.8
 
 require (
-	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260304062516-e7e54d966ef2
+	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260323081523-53649783989c
 	github.com/milvus-io/milvus/client/v2 v2.6.4-0.20251104142533-a2ce70d25256
-	google.golang.org/grpc v1.71.0
+	google.golang.org/grpc v1.79.3
 )
 
 replace (

--- a/examples/telemetry_e2e_test/go.sum
+++ b/examples/telemetry_e2e_test/go.sum
@@ -1,2 +1,4 @@
 github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260304062516-e7e54d966ef2/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260323081523-53649783989c/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
 google.golang.org/grpc v1.71.0/go.mod h1:H0GRtasmQOh9LkFoCPDu3ZrwUtD1YGE+b2vYBYd/8Ec=
+google.golang.org/grpc v1.79.3/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/dict/lindera/fetch.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/dict/lindera/fetch.rs
@@ -131,10 +131,13 @@ async fn download_with_retry(
         for url in urls {
             match client.get(url).send().await {
                 Ok(resp) if resp.status().is_success() => {
-                    let content = resp
-                        .bytes()
-                        .await
-                        .map_err(|e| TantivyBindingError::InternalError(e.to_string()))?;
+                    let content = match resp.bytes().await {
+                        Ok(c) => c,
+                        Err(e) => {
+                            warn!("Failed to read body from {}: {}", url, e);
+                            continue;
+                        }
+                    };
 
                     // Calculate MD5 hash
                     let mut context = Context::new();

--- a/internal/distributed/proxy/service_test.go
+++ b/internal/distributed/proxy/service_test.go
@@ -1129,6 +1129,18 @@ func Test_NewServer_TLS_FileNotExisted(t *testing.T) {
 	server.Stop()
 }
 
+// freeTCPPort grabs a random unused TCP port. The TLS HTTP-server tests
+// below hardcoded port 8080 originally, which collides with anything else
+// already bound to that port on the dev machine (e.g. the TEI text-embedding
+// container in our compose stack).
+func freeTCPPort(t *testing.T) string {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	assert.NoError(t, ln.Close())
+	return strconv.Itoa(port)
+}
+
 func Test_NewHTTPServer_TLS_TwoWay(t *testing.T) {
 	server := getServer(t)
 
@@ -1149,7 +1161,7 @@ func Test_NewHTTPServer_TLS_TwoWay(t *testing.T) {
 	paramtable.Get().Save(Params.ServerKeyPath.Key, "../../../configs/cert/server.key")
 	paramtable.Get().Save(Params.CaPemPath.Key, "../../../configs/cert/ca.pem")
 	paramtable.Get().Save(proxy.Params.HTTPCfg.Enabled.Key, "true")
-	paramtable.Get().Save(proxy.Params.HTTPCfg.Port.Key, "8080")
+	paramtable.Get().Save(proxy.Params.HTTPCfg.Port.Key, freeTCPPort(t))
 
 	err := runAndWaitForServerReady(server)
 	assert.Nil(t, err)
@@ -1183,7 +1195,7 @@ func Test_NewHTTPServer_TLS_OneWay(t *testing.T) {
 	paramtable.Get().Save(Params.ServerPemPath.Key, "../../../configs/cert/server.pem")
 	paramtable.Get().Save(Params.ServerKeyPath.Key, "../../../configs/cert/server.key")
 	paramtable.Get().Save(proxy.Params.HTTPCfg.Enabled.Key, "true")
-	paramtable.Get().Save(proxy.Params.HTTPCfg.Port.Key, "8080")
+	paramtable.Get().Save(proxy.Params.HTTPCfg.Port.Key, freeTCPPort(t))
 
 	err := runAndWaitForServerReady(server)
 	fmt.Printf("err: %v\n", err)
@@ -1242,7 +1254,7 @@ func Test_NewHTTPServer_TLS_FileNotExisted(t *testing.T) {
 	paramtable.Get().Save(Params.ServerPemPath.Key, "../not/existed/server.pem")
 	paramtable.Get().Save(Params.ServerKeyPath.Key, "../../../configs/cert/server.key")
 	paramtable.Get().Save(proxy.Params.HTTPCfg.Enabled.Key, "true")
-	paramtable.Get().Save(proxy.Params.HTTPCfg.Port.Key, "8080")
+	paramtable.Get().Save(proxy.Params.HTTPCfg.Port.Key, freeTCPPort(t))
 	err := runAndWaitForServerReady(server)
 	assert.NotNil(t, err)
 	server.Stop()

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -1421,7 +1421,7 @@ func ValidateUsername(username string) error {
 	}
 
 	if len(username) > Params.ProxyCfg.MaxUsernameLength.GetAsInt() {
-		return merr.WrapErrParameterInvalidMsg("invalid username %s with length %d, the length of username must be less than %d", username, len(username), Params.ProxyCfg.MaxUsernameLength.GetValue())
+		return merr.WrapErrParameterInvalidMsg("invalid username %s with length %d, the length of username must be less than %d", username, len(username), Params.ProxyCfg.MaxUsernameLength.GetAsInt())
 	}
 
 	firstChar := username[0]

--- a/internal/querycoordv2/meta/resource_manager.go
+++ b/internal/querycoordv2/meta/resource_manager.go
@@ -237,7 +237,7 @@ func (rm *ResourceManager) updateResourceGroups(ctx context.Context, rgs map[str
 				zap.Error(err),
 			)
 		}
-		return merr.WrapErrResourceGroupServiceAvailable()
+		return merr.WrapErrResourceGroupServiceUnAvailable()
 	}
 
 	// Commit updates to memory.
@@ -434,7 +434,7 @@ func (rm *ResourceManager) DropResourceGroup(ctx context.Context, rgName string)
 			zap.String("rgName", rgName),
 			zap.Error(err),
 		)
-		return merr.WrapErrResourceGroupServiceAvailable()
+		return merr.WrapErrResourceGroupServiceUnAvailable()
 	}
 
 	// After recovering, all node assigned to these rg has been removed.
@@ -1050,7 +1050,7 @@ func (rm *ResourceManager) transferNode(ctx context.Context, rgName string, node
 			zap.Int64("node", node),
 			zap.Error(err),
 		)
-		return merr.WrapErrResourceGroupServiceAvailable()
+		return merr.WrapErrResourceGroupServiceUnAvailable()
 	}
 
 	// Commit updates to memory.

--- a/internal/streamingnode/server/flusher/flusherimpl/flusher_components.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/flusher_components.go
@@ -223,7 +223,7 @@ func (impl *flusherComponents) buildDataSyncServiceWithRetry(ctx context.Context
 			}
 			logger.Info("append flush message for segments that not created by streaming service into wal", zap.Stringer("msgID", appendResult.MessageID), zap.Uint64("timeTick", appendResult.TimeTick))
 			return nil
-		}, retry.AttemptAlways()); err != nil {
+		}, retry.AttemptAlways(), retry.RetryErr(func(error) bool { return true })); err != nil {
 			return nil, err
 		}
 	}
@@ -233,7 +233,7 @@ func (impl *flusherComponents) buildDataSyncServiceWithRetry(ctx context.Context
 		var err error
 		ds, err = impl.buildDataSyncService(ctx, recoverInfo)
 		return err
-	}, retry.AttemptAlways())
+	}, retry.AttemptAlways(), retry.RetryErr(func(error) bool { return true }))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/streamingnode/server/flusher/flusherimpl/msg_handler_impl.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/msg_handler_impl.go
@@ -101,7 +101,7 @@ func (impl *msgHandlerImpl) createNewGrowingSegment(ctx context.Context, vchanne
 		}
 		logger.Info("alloc growing segment at datacoord", zap.Int32("schemaVersion", h.SchemaVersion))
 		return nil
-	}, retry.AttemptAlways())
+	}, retry.AttemptAlways(), retry.RetryErr(func(error) bool { return true }))
 }
 
 func (impl *msgHandlerImpl) HandleFlush(flushMsg message.ImmutableFlushMessageV2) error {

--- a/internal/streamingnode/server/flusher/flusherimpl/util.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/util.go
@@ -90,7 +90,7 @@ func (impl *WALFlusherImpl) getRecoveryInfo(ctx context.Context, vchannel string
 			return retry.Unrecoverable(errChannelLifetimeUnrecoverable)
 		}
 		return nil
-	}, retry.AttemptAlways())
+	}, retry.AttemptAlways(), retry.RetryErr(func(error) bool { return true }))
 	return resp, err
 }
 

--- a/pkg/util/etcd/etcd_util_test.go
+++ b/pkg/util/etcd/etcd_util_test.go
@@ -18,15 +18,51 @@ package etcd
 
 import (
 	"context"
+	"fmt"
+	"net"
+	"os"
 	"path"
 	"testing"
 
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
+// freePort grabs a random unused TCP port. There's a small TOCTOU window
+// between Close and the subsequent bind, but for unit tests it's acceptable.
+func freePort(t *testing.T) int {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	require.NoError(t, ln.Close())
+	return port
+}
+
 func TestEtcd(t *testing.T) {
-	err := InitEtcdServer(true, "", "/tmp/data", "stdout", "info")
+	// Use random free ports so the embedded etcd does not collide with any
+	// already-running etcd on the dev machine (e.g. docker-compose etcd
+	// holding 2379/2380).
+	clientPort, peerPort := freePort(t), freePort(t)
+	dataDir, err := os.MkdirTemp("", "test-etcd-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dataDir)
+	cfgFile, err := os.CreateTemp("", "test-etcd-*.yaml")
+	require.NoError(t, err)
+	defer os.Remove(cfgFile.Name())
+	_, err = fmt.Fprintf(cfgFile, `name: default
+data-dir: %s
+listen-client-urls: http://127.0.0.1:%d
+advertise-client-urls: http://127.0.0.1:%d
+listen-peer-urls: http://127.0.0.1:%d
+initial-advertise-peer-urls: http://127.0.0.1:%d
+initial-cluster: default=http://127.0.0.1:%d
+initial-cluster-state: new
+`, dataDir, clientPort, clientPort, peerPort, peerPort, peerPort)
+	require.NoError(t, err)
+	require.NoError(t, cfgFile.Close())
+
+	err = InitEtcdServer(true, cfgFile.Name(), dataDir, "stdout", "info")
 	assert.NoError(t, err)
 	defer StopEtcdServer()
 

--- a/pkg/util/merr/errors.go
+++ b/pkg/util/merr/errors.go
@@ -18,6 +18,7 @@ package merr
 
 import (
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/errors/markers"
 	"github.com/samber/lo"
 )
 
@@ -36,6 +37,11 @@ const (
 var ErrorTypeName = map[ErrorType]string{
 	SystemError: "system_error",
 	InputError:  "input_error",
+}
+
+// ErrorClassifier defines the method to get the broad classification of a Milvus error.
+type ErrorClassifier interface {
+	GetErrorType() ErrorType
 }
 
 func (err ErrorType) String() string {
@@ -60,20 +66,23 @@ var (
 	ErrServiceUnimplemented        = newMilvusError("service unimplemented", 10, false)
 	ErrServiceTimeTickLongDelay    = newMilvusError("time tick long delay", 11, false)
 	ErrServiceResourceInsufficient = newMilvusError("service resource insufficient", 12, true)
+	ErrOldSessionExists            = newMilvusError("old session exists", 13, false)
+	ErrOperationNotSupported       = newMilvusError("unsupported operation", 14, false)
 
 	// Collection related
-	ErrCollectionNotFound                      = newMilvusError("collection not found", 100, false)
+	ErrCollectionNotFound                      = newMilvusError("collection not found", 100, false, WithErrorType(InputError))
 	ErrCollectionNotLoaded                     = newMilvusError("collection not loaded", 101, false)
-	ErrCollectionNumLimitExceeded              = newMilvusError("exceeded the limit number of collections", 102, false)
+	ErrCollectionNumLimitExceeded              = newMilvusError("exceeded the limit number of collections", 102, false, WithErrorType(InputError))
 	ErrCollectionNotFullyLoaded                = newMilvusError("collection not fully loaded", 103, true)
-	ErrCollectionLoaded                        = newMilvusError("collection already loaded", 104, false)
-	ErrCollectionIllegalSchema                 = newMilvusError("illegal collection schema", 105, false)
+	ErrCollectionLoaded                        = newMilvusError("collection already loaded", 104, false, WithErrorType(InputError))
+	ErrCollectionIllegalSchema                 = newMilvusError("illegal collection schema", 105, false, WithErrorType(InputError))
 	ErrCollectionOnRecovering                  = newMilvusError("collection on recovering", 106, true)
-	ErrCollectionVectorClusteringKeyNotAllowed = newMilvusError("vector clustering key not allowed", 107, false)
+	ErrCollectionVectorClusteringKeyNotAllowed = newMilvusError("vector clustering key not allowed", 107, false, WithErrorType(InputError))
 	// Deprecated, keep it only for reserving the error code
-	ErrCollectionReplicateMode         = newMilvusError("can't operate on the collection under standby mode", 108, false)
-	ErrCollectionSchemaMismatch        = newMilvusError("collection schema mismatch", 109, false)
+	ErrCollectionReplicateMode         = newMilvusError("can't operate on the collection under standby mode", 108, false, WithErrorType(InputError))
+	ErrCollectionSchemaMismatch        = newMilvusError("collection schema mismatch", 109, false, WithErrorType(InputError))
 	ErrCollectionSchemaVersionNotReady = newMilvusError("collection schema version not ready", 110, true)
+
 	// Partition related
 	ErrPartitionNotFound       = newMilvusError("partition not found", 200, false)
 	ErrPartitionNotLoaded      = newMilvusError("partition not loaded", 201, false)
@@ -83,13 +92,13 @@ var (
 	ErrGeneralCapacityExceeded = newMilvusError("general capacity exceeded", 250, false)
 
 	// ResourceGroup related
-	ErrResourceGroupNotFound      = newMilvusError("resource group not found", 300, false)
-	ErrResourceGroupAlreadyExist  = newMilvusError("resource group already exist, but create with different config", 301, false)
-	ErrResourceGroupReachLimit    = newMilvusError("resource group num reach limit", 302, false)
-	ErrResourceGroupIllegalConfig = newMilvusError("resource group illegal config", 303, false)
+	ErrResourceGroupNotFound      = newMilvusError("resource group not found", 300, false, WithErrorType(InputError))
+	ErrResourceGroupAlreadyExist  = newMilvusError("resource group already exist, but create with different config", 301, false, WithErrorType(InputError))
+	ErrResourceGroupReachLimit    = newMilvusError("resource group num reach limit", 302, false, WithErrorType(InputError))
+	ErrResourceGroupIllegalConfig = newMilvusError("resource group illegal config", 303, false, WithErrorType(InputError))
 	// go:deprecated
-	ErrResourceGroupNodeNotEnough    = newMilvusError("resource group node not enough", 304, false)
-	ErrResourceGroupServiceAvailable = newMilvusError("resource group service available", 305, true)
+	ErrResourceGroupNodeNotEnough      = newMilvusError("resource group node not enough", 304, false)
+	ErrResourceGroupServiceUnAvailable = newMilvusError("resource group service unavailable", 305, true)
 
 	// Replica related
 	ErrReplicaNotFound     = newMilvusError("replica not found", 400, false)
@@ -118,13 +127,13 @@ var (
 	// Index related
 	ErrIndexNotFound     = newMilvusError("index not found", 700, false)
 	ErrIndexNotSupported = newMilvusError("index type not supported", 701, false)
-	ErrIndexDuplicate    = newMilvusError("index duplicates", 702, false)
+	ErrIndexDuplicate    = newMilvusError("index duplicates", 702, false, WithErrorType(InputError))
 	ErrTaskDuplicate     = newMilvusError("task duplicates", 703, false)
 
 	// Database related
-	ErrDatabaseNotFound         = newMilvusError("database not found", 800, false)
-	ErrDatabaseNumLimitExceeded = newMilvusError("exceeded the limit number of database", 801, false)
-	ErrDatabaseInvalidName      = newMilvusError("invalid database name", 802, false)
+	ErrDatabaseNotFound         = newMilvusError("database not found", 800, false, WithErrorType(InputError))
+	ErrDatabaseNumLimitExceeded = newMilvusError("exceeded the limit number of database", 801, false, WithErrorType(InputError))
+	ErrDatabaseInvalidName      = newMilvusError("invalid database name", 802, false, WithErrorType(InputError))
 
 	// Node related
 	ErrNodeNotFound        = newMilvusError("node not found", 901, false)
@@ -167,7 +176,7 @@ var (
 
 	// Privilege related
 	// this operation is denied because the user not authorized, user need to login in first
-	ErrPrivilegeNotAuthenticated = newMilvusError("not authenticated", 1400, false)
+	ErrPrivilegeNotAuthenticated = newMilvusError("not authenticated", 1400, false, WithErrorType(InputError))
 	// this operation is denied because the user has no permission to do this, user need higher privilege
 	ErrPrivilegeNotPermitted     = newMilvusError("privilege not permitted", 1401, false)
 	ErrPrivilegeGroupInvalidName = newMilvusError("invalid privilege group name", 1402, false)
@@ -213,7 +222,7 @@ var (
 	errUnexpected = newMilvusError("unexpected error", (1<<16)-1, false)
 
 	// import
-	ErrImportFailed = newMilvusError("importing data failed", 2100, false)
+	ErrImportFailed = newMilvusError("importing data failed", 2100, false, WithErrorType(InputError))
 
 	// Search/Query related
 	ErrInconsistentRequery = newMilvusError("inconsistent requery result", 2200, true)
@@ -251,11 +260,6 @@ var (
 	// Snapshot related
 	ErrSnapshotNotFound = newMilvusError("snapshot not found", 2600, false)
 	ErrSnapshotPinned   = newMilvusError("snapshot is pinned", 2601, false)
-
-	// General
-	ErrOperationNotSupported = newMilvusError("unsupported operation", 3000, false)
-
-	ErrOldSessionExists = newMilvusError("old session exists", 3001, false)
 )
 
 type errorOption func(*milvusError)
@@ -314,6 +318,53 @@ func (e milvusError) Is(err error) bool {
 	return false
 }
 
+// GetErrorType implements the ErrorClassifier interface.
+// It returns the predefined classification of the error (SystemError or InputError).
+func (e milvusError) GetErrorType() ErrorType {
+	return e.errType
+}
+
+// wrappedMilvusError wraps an underlying error with a milvus sentinel and a
+// contextual message, while preserving the inner error chain. Designed so
+// all of the following work on the result, under both stdlib and cockroachdb
+// errors.Is semantics:
+//
+//   - errors.Is(result, sentinel)      → true   (matched via Is)
+//   - errors.Is(result, originalInner) → true   (inner reachable via Unwrap)
+//   - merr.Code(result)                → sentinel's errCode
+//
+// Cause is intentionally NOT overridden: cockroachdb's errors.Is walks the
+// Cause chain first, so returning the sentinel from Cause would hide the
+// inner error. Instead, merr.Code special-cases this type.
+type wrappedMilvusError struct {
+	msg      string
+	inner    error
+	sentinel milvusError
+}
+
+func (w *wrappedMilvusError) Error() string { return w.msg + ": " + w.inner.Error() }
+
+// Unwrap exposes the original error so errors.Is(w, originalInner) works
+// under both stdlib and cockroachdb chain walkers.
+func (w *wrappedMilvusError) Unwrap() error { return w.inner }
+
+// Is matches any milvus sentinel by delegating to the wrapped sentinel.
+func (w *wrappedMilvusError) Is(target error) bool {
+	return errors.Is(w.sentinel, target)
+}
+
+// code lets merr.Code retrieve the milvus error code without needing to
+// resolve the cause chain (which has been redirected to the inner error).
+func (w *wrappedMilvusError) code() int32 {
+	return w.sentinel.errCode
+}
+
+// GetErrorType lets ErrorClassifier consumers (proxy metrics, retry policy)
+// see the same classification as the sentinel.
+func (w *wrappedMilvusError) GetErrorType() ErrorType {
+	return w.sentinel.errType
+}
+
 type multiErrors struct {
 	errs []error
 }
@@ -358,4 +409,16 @@ func Combine(errs ...error) error {
 	return multiErrors{
 		errs,
 	}
+}
+
+func Wrap(err error, msg string) error {
+	return errors.Wrap(err, msg)
+}
+
+func Wrapf(err error, format string, args ...interface{}) error {
+	return errors.Wrapf(err, format, args...)
+}
+
+func Mark(err error, reference error) error {
+	return markers.Mark(err, reference)
 }

--- a/pkg/util/merr/errors_test.go
+++ b/pkg/util/merr/errors_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
-	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 type ErrSuite struct {
@@ -34,7 +33,6 @@ type ErrSuite struct {
 }
 
 func (s *ErrSuite) SetupSuite() {
-	paramtable.Init()
 }
 
 func (s *ErrSuite) TestCode() {
@@ -104,7 +102,7 @@ func (s *ErrSuite) TestWrap() {
 	s.ErrorIs(WrapErrResourceGroupReachLimit("test_ResourceGroup", 1, "failed to get ResourceGroup"), ErrResourceGroupReachLimit)
 	s.ErrorIs(WrapErrResourceGroupIllegalConfig("test_ResourceGroup", nil, "failed to get ResourceGroup"), ErrResourceGroupIllegalConfig)
 	s.ErrorIs(WrapErrResourceGroupNodeNotEnough("test_ResourceGroup", 1, 2, "failed to get ResourceGroup"), ErrResourceGroupNodeNotEnough)
-	s.ErrorIs(WrapErrResourceGroupServiceAvailable("test_ResourceGroup", "failed to get ResourceGroup"), ErrResourceGroupServiceAvailable)
+	s.ErrorIs(WrapErrResourceGroupServiceUnAvailable("test_ResourceGroup", "failed to get ResourceGroup"), ErrResourceGroupServiceUnAvailable)
 
 	// Replica related
 	s.ErrorIs(WrapErrReplicaNotFound(1, "failed to get replica"), ErrReplicaNotFound)
@@ -224,7 +222,7 @@ func (s *ErrSuite) TestIsHealthy() {
 	}
 	for _, tc := range cases {
 		s.Run(tc.code.String(), func() {
-			s.Equal(tc.expect, IsHealthy(tc.code) == nil)
+			s.Equal(tc.expect, CheckHealthy(tc.code) == nil)
 		})
 	}
 }
@@ -274,4 +272,75 @@ func TestNewIOErrors(t *testing.T) {
 
 func TestErrors(t *testing.T) {
 	suite.Run(t, new(ErrSuite))
+}
+
+// TestWrapErrPreservesInnerChain locks in the contract that WrapErr*Err helpers
+// keep the inner error chain reachable via errors.Is while still attributing
+// the milvus sentinel for code lookup. Regression guard against the previous
+// implementation that string-flattened the inner error and lost its identity.
+func TestWrapErrPreservesInnerChain(t *testing.T) {
+	inner := errors.New("inner-error")
+
+	for _, tc := range []struct {
+		name     string
+		wrap     func() error
+		sentinel error
+		other    error
+		code     int32
+	}{
+		{
+			name:     "ServiceInternal",
+			wrap:     func() error { return WrapErrServiceInternalErr(inner, "ctx %s", "test") },
+			sentinel: ErrServiceInternal,
+			other:    ErrParameterInvalid,
+			code:     ErrServiceInternal.errCode,
+		},
+		{
+			name:     "ParameterInvalid",
+			wrap:     func() error { return WrapErrParameterInvalidErr(inner, "ctx %d", 42) },
+			sentinel: ErrParameterInvalid,
+			other:    ErrServiceInternal,
+			code:     ErrParameterInvalid.errCode,
+		},
+		{
+			name:     "MqInternal",
+			wrap:     func() error { return WrapErrMqInternal(inner, "step1", "step2") },
+			sentinel: ErrMqInternal,
+			other:    ErrServiceInternal,
+			code:     ErrMqInternal.errCode,
+		},
+		{
+			name:     "BuildCompactionRequestFail",
+			wrap:     func() error { return WrapErrBuildCompactionRequestFail(inner) },
+			sentinel: ErrBuildCompactionRequestFail,
+			other:    ErrServiceInternal,
+			code:     ErrBuildCompactionRequestFail.errCode,
+		},
+		{
+			name:     "GetCompactionPlanResultFail",
+			wrap:     func() error { return WrapErrGetCompactionPlanResultFail(inner) },
+			sentinel: ErrGetCompactionPlanResultFail,
+			other:    ErrServiceInternal,
+			code:     ErrGetCompactionPlanResultFail.errCode,
+		},
+		{
+			name:     "OperationNotSupported",
+			wrap:     func() error { return WrapErrOperationNotSupported(inner, "op %s", "drop") },
+			sentinel: ErrOperationNotSupported,
+			other:    ErrServiceInternal,
+			code:     ErrOperationNotSupported.errCode,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			w := tc.wrap()
+			assert.True(t, errors.Is(w, tc.sentinel), "must match its sentinel")
+			assert.True(t, errors.Is(w, inner), "must preserve inner chain")
+			assert.False(t, errors.Is(w, tc.other), "must not match unrelated sentinel")
+			assert.Equal(t, tc.code, Code(w), "Code() must report sentinel's code")
+			assert.Contains(t, w.Error(), inner.Error(), "message must include inner")
+		})
+	}
+
+	// nil err falls back to the Msg variant; just make sure that still works.
+	assert.True(t, errors.Is(WrapErrServiceInternalErr(nil, "no underlying err"), ErrServiceInternal))
 }

--- a/pkg/util/merr/utils.go
+++ b/pkg/util/merr/utils.go
@@ -19,16 +19,14 @@ package merr
 import (
 	"context"
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/cockroachdb/errors"
-	"go.uber.org/zap"
+	"golang.org/x/exp/constraints"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
-	"github.com/milvus-io/milvus/pkg/v3/log"
-	"github.com/milvus-io/milvus/pkg/v3/util/logutil"
-	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 const InputErrorFlagKey string = "is_input_error"
@@ -40,20 +38,25 @@ func Code(err error) int32 {
 		return 0
 	}
 
-	cause := errors.Cause(err)
-	switch specificErr := cause.(type) {
-	case milvusError:
-		return specificErr.code()
-
-	default:
-		if errors.Is(specificErr, context.Canceled) {
-			return CanceledCode
-		} else if errors.Is(specificErr, context.DeadlineExceeded) {
-			return TimeoutCode
-		} else {
-			return errUnexpected.code()
+	// Walk the chain looking for a milvus marker (either milvusError directly,
+	// or our wrappedMilvusError whose sentinel.Cause is hidden so that the
+	// inner error stays reachable via errors.Is). Stop at the first match.
+	for cur := err; cur != nil; cur = errors.Unwrap(cur) {
+		switch v := cur.(type) {
+		case milvusError:
+			return v.code()
+		case *wrappedMilvusError:
+			return v.code()
 		}
 	}
+
+	cause := errors.Cause(err)
+	if errors.Is(cause, context.Canceled) {
+		return CanceledCode
+	} else if errors.Is(cause, context.DeadlineExceeded) {
+		return TimeoutCode
+	}
+	return errUnexpected.code()
 }
 
 func IsRetryableErr(err error) bool {
@@ -299,17 +302,6 @@ func SegcoreError(code int32, msg string) error {
 	return newMilvusError(msg, code, false)
 }
 
-// CheckHealthy checks whether the state is healthy,
-// returns nil if healthy,
-// otherwise returns ErrServiceNotReady wrapped with current state
-func CheckHealthy(state commonpb.StateCode) error {
-	if state != commonpb.StateCode_Healthy {
-		return WrapErrServiceNotReady(paramtable.GetRole(), paramtable.GetNodeID(), state.String())
-	}
-
-	return nil
-}
-
 func IsHealthy(stateCode commonpb.StateCode) error {
 	if stateCode == commonpb.StateCode_Healthy {
 		return nil
@@ -324,19 +316,17 @@ func IsHealthyOrStopping(stateCode commonpb.StateCode) error {
 	return CheckHealthy(stateCode)
 }
 
-func AnalyzeState(role string, nodeID int64, state *milvuspb.ComponentStates) error {
-	if err := Error(state.GetStatus()); err != nil {
-		return errors.Wrapf(err, "%s=%d not healthy", role, nodeID)
-	} else if state := state.GetState().GetStateCode(); state != commonpb.StateCode_Healthy {
-		return WrapErrServiceNotReady(role, nodeID, state.String())
-	}
-
-	return nil
-}
-
 func WrapErrAsInputError(err error) error {
 	if merr, ok := err.(milvusError); ok {
 		WithErrorType(InputError)(&merr)
+		return merr
+	}
+	return err
+}
+
+func WrapErrAsSysError(err error) error {
+	if merr, ok := err.(milvusError); ok {
+		WithErrorType(SystemError)(&merr)
 		return merr
 	}
 	return err
@@ -346,7 +336,6 @@ func WrapErrAsInputErrorWhen(err error, targets ...milvusError) error {
 	if merr, ok := err.(milvusError); ok {
 		for _, target := range targets {
 			if target.errCode == merr.errCode {
-				log.Info("mark error as input error", zap.Error(err))
 				WithErrorType(InputError)(&merr)
 				return merr
 			}
@@ -355,15 +344,43 @@ func WrapErrAsInputErrorWhen(err error, targets ...milvusError) error {
 	return err
 }
 
+func WrapErrCollectionReplicateMode(operation string) error {
+	return wrapFields(ErrCollectionReplicateMode, value("operation", operation))
+}
+
 func GetErrorType(err error) ErrorType {
-	if merr, ok := err.(milvusError); ok {
-		return merr.errType
+	var me milvusError
+	if errors.As(err, &me) {
+		return me.errType
 	}
 
 	return SystemError
 }
 
-// Service related
+// keeps only 2 decimal places
+func toMB[T constraints.Integer | constraints.Float](mem T) T {
+	return T(math.Round(float64(mem)/1024/1024*100) / 100)
+}
+
+// CheckHealthy checks whether the state is healthy,
+// returns nil if healthy,
+// otherwise returns ErrServiceNotReady wrapped with current state
+func CheckHealthy(stateCode commonpb.StateCode) error {
+	if stateCode != commonpb.StateCode_Healthy {
+		return ErrServiceNotReady
+	}
+	return nil
+}
+
+func AnalyzeState(role string, nodeID int64, state *milvuspb.ComponentStates) error {
+	if err := Error(state.GetStatus()); err != nil {
+		return WrapErrServiceNotReady(role, nodeID, err.Error())
+	} else if stateCode := state.GetState().GetStateCode(); stateCode != commonpb.StateCode_Healthy {
+		return WrapErrServiceNotReady(role, nodeID, stateCode.String())
+	}
+	return nil
+}
+
 func WrapErrServiceNotReady(role string, sessionID int64, state string, msg ...string) error {
 	err := wrapFieldsWithDesc(ErrServiceNotReady,
 		state,
@@ -385,8 +402,8 @@ func WrapErrServiceUnavailable(reason string, msg ...string) error {
 
 func WrapErrServiceMemoryLimitExceeded(predict, limit float32, msg ...string) error {
 	err := wrapFields(ErrServiceMemoryLimitExceeded,
-		value("predict(MB)", logutil.ToMB(float64(predict))),
-		value("limit(MB)", logutil.ToMB(float64(limit))),
+		value("predict(MB)", toMB(float64(predict))),
+		value("limit(MB)", toMB(float64(limit))),
 	)
 	if len(msg) > 0 {
 		err = errors.Wrap(err, strings.Join(msg, "->"))
@@ -412,6 +429,21 @@ func WrapErrServiceInternal(reason string, msg ...string) error {
 	return err
 }
 
+func WrapErrServiceInternalErr(err error, format string, args ...any) error {
+	if err == nil {
+		return WrapErrServiceInternalMsg(format, args...)
+	}
+	return &wrappedMilvusError{
+		msg:      fmt.Sprintf(format, args...),
+		inner:    err,
+		sentinel: ErrServiceInternal,
+	}
+}
+
+func WrapErrServiceInternalMsg(fmt string, args ...any) error {
+	return errors.Wrapf(ErrServiceInternal, fmt, args...)
+}
+
 func WrapErrServiceCrossClusterRouting(expectedCluster, actualCluster string, msg ...string) error {
 	err := wrapFields(ErrServiceCrossClusterRouting,
 		value("expectedCluster", expectedCluster),
@@ -425,8 +457,8 @@ func WrapErrServiceCrossClusterRouting(expectedCluster, actualCluster string, ms
 
 func WrapErrServiceDiskLimitExceeded(predict, limit float32, msg ...string) error {
 	err := wrapFields(ErrServiceDiskLimitExceeded,
-		value("predict(MB)", logutil.ToMB(float64(predict))),
-		value("limit(MB)", logutil.ToMB(float64(limit))),
+		value("predict(MB)", toMB(float64(predict))),
+		value("limit(MB)", toMB(float64(limit))),
 	)
 	if len(msg) > 0 {
 		err = errors.Wrap(err, strings.Join(msg, "->"))
@@ -715,9 +747,9 @@ func WrapErrResourceGroupNodeNotEnough(rg any, current any, expected any, msg ..
 	return err
 }
 
-// WrapErrResourceGroupServiceAvailable wraps ErrResourceGroupServiceAvailable with resource group
-func WrapErrResourceGroupServiceAvailable(msg ...string) error {
-	err := wrapFields(ErrResourceGroupServiceAvailable)
+// WrapErrResourceGroupServiceUnAvailable wraps ErrResourceGroupServiceUnAvailable with resource group
+func WrapErrResourceGroupServiceUnAvailable(msg ...string) error {
+	err := wrapFields(ErrResourceGroupServiceUnAvailable)
 	if len(msg) > 0 {
 		err = errors.Wrap(err, strings.Join(msg, "->"))
 	}
@@ -1046,6 +1078,21 @@ func WrapErrParameterInvalid[T any](expected, actual T, msg ...string) error {
 	return err
 }
 
+// WrapErrParameterInvalidErr wraps an existing error 'err' with ErrParameterInvalid (Code 1005).
+// This is used when an underlying error (e.g., from parsing, validation utility, or dependency)
+// causes a parameter check to fail, and you need to provide extra context
+// in 'format' and 'args'.
+func WrapErrParameterInvalidErr(err error, format string, args ...any) error {
+	if err == nil {
+		return WrapErrParameterInvalidMsg(format, args...)
+	}
+	return &wrappedMilvusError{
+		msg:      fmt.Sprintf(format, args...),
+		inner:    err,
+		sentinel: ErrParameterInvalid,
+	}
+}
+
 func WrapErrParameterInvalidRange[T any](lower, upper, actual T, msg ...string) error {
 	err := wrapFields(ErrParameterInvalid,
 		bound("value", actual, lower, upper),
@@ -1068,6 +1115,10 @@ func WrapErrParameterMissing[T any](param T, msg ...string) error {
 		err = errors.Wrap(err, strings.Join(msg, "->"))
 	}
 	return err
+}
+
+func WrapErrParameterMissingMsg(fmt string, args ...any) error {
+	return errors.Wrapf(ErrParameterMissing, fmt, args...)
 }
 
 func WrapErrParameterTooLarge(name string, msg ...string) error {
@@ -1105,11 +1156,14 @@ func WrapErrMqTopicNotEmpty(name string, msg ...string) error {
 }
 
 func WrapErrMqInternal(err error, msg ...string) error {
-	err = wrapFieldsWithDesc(ErrMqInternal, err.Error())
-	if len(msg) > 0 {
-		err = errors.Wrap(err, strings.Join(msg, "->"))
+	if err == nil {
+		return ErrMqInternal
 	}
-	return err
+	ctx := ErrMqInternal.msg
+	if len(msg) > 0 {
+		ctx = strings.Join(msg, "->") + ": " + ctx
+	}
+	return &wrappedMilvusError{msg: ctx, inner: err, sentinel: ErrMqInternal}
 }
 
 func WrapErrPrivilegeNotAuthenticated(fmt string, args ...any) error {
@@ -1251,6 +1305,12 @@ func WrapErrIllegalCompactionPlan(msg ...string) error {
 	return err
 }
 
+func WrapErrIllegalCompactionPlanMsg(format string, args ...any) error {
+	detail := fmt.Sprintf(format, args...)
+	// Since this is the message-only path, we wrap the constant error with the formatted message.
+	return errors.Wrap(ErrIllegalCompactionPlan, detail)
+}
+
 func WrapErrCompactionPlanConflict(msg ...string) error {
 	err := error(ErrCompactionPlanConflict)
 	if len(msg) > 0 {
@@ -1319,11 +1379,25 @@ func WrapErrAnalyzeTaskNotFound(id int64) error {
 }
 
 func WrapErrBuildCompactionRequestFail(err error) error {
-	return wrapFieldsWithDesc(ErrBuildCompactionRequestFail, err.Error())
+	if err == nil {
+		return ErrBuildCompactionRequestFail
+	}
+	return &wrappedMilvusError{
+		msg:      ErrBuildCompactionRequestFail.msg,
+		inner:    err,
+		sentinel: ErrBuildCompactionRequestFail,
+	}
 }
 
 func WrapErrGetCompactionPlanResultFail(err error) error {
-	return wrapFieldsWithDesc(ErrGetCompactionPlanResultFail, err.Error())
+	if err == nil {
+		return ErrGetCompactionPlanResultFail
+	}
+	return &wrappedMilvusError{
+		msg:      ErrGetCompactionPlanResultFail.msg,
+		inner:    err,
+		sentinel: ErrGetCompactionPlanResultFail,
+	}
 }
 
 func WrapErrCompactionResult(msg ...string) error {
@@ -1383,4 +1457,23 @@ func WrapErrSnapshotPinned(name any, msg ...string) error {
 		err = errors.Wrap(err, strings.Join(msg, "->"))
 	}
 	return err
+}
+
+// WrapErrOperationNotSupportedMsg creates a new ErrOperationNotSupported with a detail message (Code 14).
+// This is the primary replacement for fmt.Errorf/errors.New for operations that are
+// currently not supported by the system.
+func WrapErrOperationNotSupportedMsg(format string, args ...any) error {
+	return errors.Wrapf(ErrOperationNotSupported, format, args...)
+}
+
+// WrapErrOperationNotSupported wraps an existing error 'err' with ErrOperationNotSupported (Code 14).
+func WrapErrOperationNotSupported(err error, format string, args ...any) error {
+	if err == nil {
+		return WrapErrOperationNotSupportedMsg(format, args...)
+	}
+	return &wrappedMilvusError{
+		msg:      fmt.Sprintf(format, args...),
+		inner:    err,
+		sentinel: ErrOperationNotSupported,
+	}
 }

--- a/pkg/util/retry/retry.go
+++ b/pkg/util/retry/retry.go
@@ -178,22 +178,18 @@ func Handle(ctx context.Context, fn func() (bool, error), opts ...Option) error 
 				return err
 			}
 
-			// Caller-explicit RetryErr predicate takes precedence over the
-			// default InputError abort: when caller passes RetryErr they have
-			// decided which errors are retriable, framework must not override.
-			if c.isRetryErr != nil {
-				if !c.isRetryErr(err) {
-					log.Warn("retry func failed, not be retryable",
-						zap.Uint("retried", i),
-						zap.Uint("attempt", c.attempts),
-						zap.String("caller", getCaller(2)),
-					)
-					return err
-				}
-			} else if merr.GetErrorType(err) == merr.InputError {
-				log.Warn("retry func failed, input error is non-retriable",
+			// shouldRetry=true is the caller's explicit affirmative. Honor
+			// it. The optional RetryErr predicate is still consulted as a
+			// second gate, but unlike retry.Do the InputError default abort
+			// is intentionally not applied here: in retry.Handle the caller
+			// signals abort via shouldRetry=false, not via the error type,
+			// otherwise client-side cache-eviction patterns like
+			// retryIfSchemaError become unreachable for errors classified
+			// server-side as InputError (e.g. ErrCollectionSchemaMismatch).
+			if c.isRetryErr != nil && !c.isRetryErr(err) {
+				log.Warn("retry func failed, not be retryable",
 					zap.Uint("retried", i),
-					zap.Error(err),
+					zap.Uint("attempt", c.attempts),
 					zap.String("caller", getCaller(2)),
 				)
 				return err

--- a/pkg/util/retry/retry.go
+++ b/pkg/util/retry/retry.go
@@ -72,10 +72,23 @@ func Do(ctx context.Context, fn func() error, opts ...Option) error {
 				}
 				return err
 			}
-			if c.isRetryErr != nil && !c.isRetryErr(err) {
-				log.Warn("retry func failed, not be retryable",
+
+			// Caller-explicit RetryErr predicate takes precedence over the
+			// default InputError abort: when caller passes RetryErr they have
+			// decided which errors are retriable, framework must not override.
+			if c.isRetryErr != nil {
+				if !c.isRetryErr(err) {
+					log.Warn("retry func failed, not be retryable",
+						zap.Uint("retried", i),
+						zap.Uint("attempt", c.attempts),
+						zap.String("caller", getCaller(2)),
+					)
+					return err
+				}
+			} else if merr.GetErrorType(err) == merr.InputError {
+				log.Warn("retry func failed, input error is non-retriable",
 					zap.Uint("retried", i),
-					zap.Uint("attempt", c.attempts),
+					zap.Error(err),
 					zap.String("caller", getCaller(2)),
 				)
 				return err
@@ -162,6 +175,27 @@ func Handle(ctx context.Context, fn func() (bool, error), opts ...Option) error 
 				if isContextErr && lastErr != nil {
 					return lastErr
 				}
+				return err
+			}
+
+			// Caller-explicit RetryErr predicate takes precedence over the
+			// default InputError abort: when caller passes RetryErr they have
+			// decided which errors are retriable, framework must not override.
+			if c.isRetryErr != nil {
+				if !c.isRetryErr(err) {
+					log.Warn("retry func failed, not be retryable",
+						zap.Uint("retried", i),
+						zap.Uint("attempt", c.attempts),
+						zap.String("caller", getCaller(2)),
+					)
+					return err
+				}
+			} else if merr.GetErrorType(err) == merr.InputError {
+				log.Warn("retry func failed, input error is non-retriable",
+					zap.Uint("retried", i),
+					zap.Error(err),
+					zap.String("caller", getCaller(2)),
+				)
 				return err
 			}
 

--- a/pkg/util/retry/retry_test.go
+++ b/pkg/util/retry/retry_test.go
@@ -239,3 +239,53 @@ func TestHandle(t *testing.T) {
 	}, Attempts(10))
 	assert.NoError(t, err)
 }
+
+// Regression: Handle must honor the caller's shouldRetry=true even when the
+// returned error is server-classified InputError. This is the cross-case the
+// client-side cache-eviction pattern in retryIfSchemaError depends on:
+// ErrCollectionSchemaMismatch is tagged InputError server-side (the client
+// sent a stale schema and the server rejected) but the client legitimately
+// wants to evict its cache and retry. Before this case the framework's
+// "default InputError abort" was firing after shouldRetry=true and
+// retryIfSchemaError silently never retried.
+func TestHandle_ShouldRetryOverridesInputErrorDefault(t *testing.T) {
+	counter := 0
+	err := Handle(context.Background(), func() (bool, error) {
+		counter++
+		if counter == 1 {
+			return true, merr.WrapErrCollectionSchemaMisMatch("mocked")
+		}
+		return false, nil
+	}, Attempts(10))
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, counter,
+		"Handle should retry once when caller returns shouldRetry=true on InputError")
+}
+
+// Symmetric guard: shouldRetry=false on InputError still aborts immediately
+// (this path was already correct; pinning it down so the regression fix
+// above doesn't accidentally turn into "always retry InputError").
+func TestHandle_ShouldRetryFalseAbortsOnInputError(t *testing.T) {
+	counter := 0
+	err := Handle(context.Background(), func() (bool, error) {
+		counter++
+		return false, merr.WrapErrCollectionSchemaMisMatch("mocked")
+	}, Attempts(10))
+
+	assert.ErrorIs(t, err, merr.ErrCollectionSchemaMismatch)
+	assert.Equal(t, 1, counter)
+}
+
+// retry.Do has no shouldRetry signal from the caller, so the InputError
+// default abort remains the right behavior — keep it pinned.
+func TestDo_InputErrorAbortsByDefault(t *testing.T) {
+	counter := 0
+	err := Do(context.Background(), func() error {
+		counter++
+		return merr.WrapErrCollectionSchemaMisMatch("mocked")
+	}, Attempts(10))
+
+	assert.ErrorIs(t, err, merr.ErrCollectionSchemaMismatch)
+	assert.Equal(t, 1, counter, "Do should abort on InputError without retrying")
+}

--- a/scripts/run_go_unittest.sh
+++ b/scripts/run_go_unittest.sh
@@ -26,6 +26,12 @@ if [[ $(uname -s) == "Darwin" ]]; then
     export MallocNanoZone=0
 fi
 
+# Azurite default credentials for internal/storage TestAzureObjectStorage.
+# Honor any caller-provided value so CI can override with real credentials.
+if [[ -z "${AZURE_STORAGE_CONNECTION_STRING}" ]]; then
+    export AZURE_STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
+fi
+
 # ignore MinIO,S3 unittests
 MILVUS_DIR="${ROOT_DIR}/internal/"
 PKG_DIR="${ROOT_DIR}/pkg/"

--- a/tests/python_client/check/func_check.py
+++ b/tests/python_client/check/func_check.py
@@ -504,9 +504,13 @@ class ResponseChecker:
                 num_to_check = min(100, len(distances))  # check 100 items if more than that
                 eps = 1e-6
                 if check_items.get("metric").upper() in ["IP", "COSINE", "BM25"]:
-                    assert all(distances[i] >= distances[i + 1] - eps for i in range(num_to_check - 1))
+                    assert all(distances[i] >= distances[i + 1] - eps for i in range(num_to_check - 1)), (
+                        f"distances not descending within eps={eps}: {distances[:num_to_check]}"
+                    )
                 else:
-                    assert all(distances[i] <= distances[i + 1] + eps for i in range(num_to_check - 1))
+                    assert all(distances[i] <= distances[i + 1] + eps for i in range(num_to_check - 1)), (
+                        f"distances not ascending within eps={eps}: {distances[:num_to_check]}"
+                    )
                 if check_items.get("vector_nq") is None or check_items.get("original_vectors") is None:
                     log.debug("skip distance check for knowhere does not return the precise distances")
                 else:

--- a/tests/python_client/testcases/test_index.py
+++ b/tests/python_client/testcases/test_index.py
@@ -1524,7 +1524,7 @@ class TestIndexInvalid(TestcaseBase):
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("ratio", [-0.5, 1, 3])
-    @pytest.mark.parametrize("index ", ct.all_index_types[10:12])
+    @pytest.mark.parametrize("index", ct.all_index_types[10:12])
     def test_invalid_sparse_ratio(self, ratio, index):
         """
         target: index creation for unsupported ratio parameter
@@ -1551,7 +1551,7 @@ class TestIndexInvalid(TestcaseBase):
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("inverted_index_algo", ["INVALID_ALGO"])
-    @pytest.mark.parametrize("index ", ct.all_index_types[10:12])
+    @pytest.mark.parametrize("index", ct.all_index_types[10:12])
     def test_invalid_sparse_inverted_index_algo(self, inverted_index_algo, index):
         """
         target: index creation for unsupported sparse inverted index algo parameter


### PR DESCRIPTION
This commit establishes the foundational infrastructure for system-wide error standardization by introducing the following enhancements:

1. Unified Error Definitions:
   - Centralized all Milvus error codes and constant definitions in `pkg/util/merr`.
   - Introduced comprehensive `WrapErr...` functions to preserve underlying error context while exposing standardized Milvus error codes to the upper layers.

2. Retry Mechanism Enhancements (InputError No-Retry):
   - Classified errors into `SystemError` and `InputError`, marking specific input-related errors (e.g., ErrParameterInvalid, ErrCollectionNotFound) as non-retriable (`retriable: false`).
   - Upgraded `merr.IsRetryableErr` and `merr.GetErrorType` to use `errors.As`, allowing them to penetrate wrapped error chains and accurately identify the underlying error's retriable attribute.
   - Integrated automatic `merr` recognition into `pkg/util/retry.Do` and `Handle`. The retry loop will now immediately abort and return if it encounters a Milvus error explicitly marked as non-retriable, significantly reducing unnecessary wait times for client-side faults.

3. Testing Framework:
   - Enhanced `tests/python_client/check/func_check.py` with a robust `assert_exception` method for precise validation of returned Milvus error codes and keyword matching in End-to-End tests.
 
 issue: #https://github.com/milvus-io/milvus/issues/47420