### PR TITLE
feat: add function field backfill - Part 2 (#48808)

### DIFF
--- a/internal/metastore/model/collection.go
+++ b/internal/metastore/model/collection.go
@@ -58,6 +58,7 @@ type Collection struct {
 	FileResourceIds      []int64
 	ExternalSource       string
 	ExternalSpec         string
+	DoPhysicalBackfill   bool
 }
 
 type ShardInfo struct {
@@ -100,6 +101,7 @@ func (c *Collection) ShallowClone() *Collection {
 		FileResourceIds:      c.FileResourceIds,
 		ExternalSource:       c.ExternalSource,
 		ExternalSpec:         c.ExternalSpec,
+		DoPhysicalBackfill:   c.DoPhysicalBackfill,
 	}
 }
 
@@ -141,6 +143,7 @@ func (c *Collection) Clone() *Collection {
 		FileResourceIds:      slices.Clone(c.FileResourceIds),
 		ExternalSource:       c.ExternalSource,
 		ExternalSpec:         c.ExternalSpec,
+		DoPhysicalBackfill:   c.DoPhysicalBackfill,
 	}
 }
 
@@ -193,6 +196,7 @@ func (c *Collection) ApplyUpdates(header *message.AlterCollectionMessageHeader, 
 			c.SchemaVersion = updates.Schema.Version
 			c.ExternalSource = updates.Schema.ExternalSource
 			c.ExternalSpec = updates.Schema.ExternalSpec
+			c.DoPhysicalBackfill = updates.Schema.DoPhysicalBackfill
 		}
 	}
 }
@@ -254,6 +258,7 @@ func UnmarshalCollectionModel(coll *pb.CollectionInfo) *Collection {
 		FileResourceIds:      coll.Schema.GetFileResourceIds(),
 		ExternalSource:       coll.Schema.ExternalSource,
 		ExternalSpec:         coll.Schema.ExternalSpec,
+		DoPhysicalBackfill:   coll.Schema.DoPhysicalBackfill,
 	}
 }
 
@@ -309,6 +314,7 @@ func marshalCollectionModelWithConfig(coll *Collection, c *config) *pb.Collectio
 		FileResourceIds:    coll.FileResourceIds,
 		ExternalSource:     coll.ExternalSource,
 		ExternalSpec:       coll.ExternalSpec,
+		DoPhysicalBackfill: coll.DoPhysicalBackfill,
 	}
 
 	if c.withFields {

--- a/internal/metastore/model/index.go
+++ b/internal/metastore/model/index.go
@@ -8,17 +8,18 @@ import (
 )
 
 type Index struct {
-	TenantID        string
-	CollectionID    int64
-	FieldID         int64
-	IndexID         int64
-	IndexName       string
-	IsDeleted       bool
-	CreateTime      uint64
-	TypeParams      []*commonpb.KeyValuePair
-	IndexParams     []*commonpb.KeyValuePair
-	IsAutoIndex     bool
-	UserIndexParams []*commonpb.KeyValuePair
+	TenantID         string
+	CollectionID     int64
+	FieldID          int64
+	IndexID          int64
+	IndexName        string
+	IsDeleted        bool
+	CreateTime       uint64
+	TypeParams       []*commonpb.KeyValuePair
+	IndexParams      []*commonpb.KeyValuePair
+	IsAutoIndex      bool
+	UserIndexParams  []*commonpb.KeyValuePair
+	MinSchemaVersion int32
 }
 
 func UnmarshalIndexModel(indexInfo *indexpb.FieldIndex) *Index {
@@ -27,16 +28,17 @@ func UnmarshalIndexModel(indexInfo *indexpb.FieldIndex) *Index {
 	}
 
 	return &Index{
-		CollectionID:    indexInfo.IndexInfo.GetCollectionID(),
-		FieldID:         indexInfo.IndexInfo.GetFieldID(),
-		IndexID:         indexInfo.IndexInfo.GetIndexID(),
-		IndexName:       indexInfo.IndexInfo.GetIndexName(),
-		IsDeleted:       indexInfo.GetDeleted(),
-		CreateTime:      indexInfo.CreateTime,
-		TypeParams:      indexInfo.IndexInfo.GetTypeParams(),
-		IndexParams:     indexInfo.IndexInfo.GetIndexParams(),
-		IsAutoIndex:     indexInfo.IndexInfo.GetIsAutoIndex(),
-		UserIndexParams: indexInfo.IndexInfo.GetUserIndexParams(),
+		CollectionID:     indexInfo.IndexInfo.GetCollectionID(),
+		FieldID:          indexInfo.IndexInfo.GetFieldID(),
+		IndexID:          indexInfo.IndexInfo.GetIndexID(),
+		IndexName:        indexInfo.IndexInfo.GetIndexName(),
+		IsDeleted:        indexInfo.GetDeleted(),
+		CreateTime:       indexInfo.CreateTime,
+		TypeParams:       indexInfo.IndexInfo.GetTypeParams(),
+		IndexParams:      indexInfo.IndexInfo.GetIndexParams(),
+		IsAutoIndex:      indexInfo.IndexInfo.GetIsAutoIndex(),
+		UserIndexParams:  indexInfo.IndexInfo.GetUserIndexParams(),
+		MinSchemaVersion: indexInfo.GetMinSchemaVersion(),
 	}
 }
 
@@ -56,8 +58,9 @@ func MarshalIndexModel(index *Index) *indexpb.FieldIndex {
 			IsAutoIndex:     index.IsAutoIndex,
 			UserIndexParams: index.UserIndexParams,
 		},
-		Deleted:    index.IsDeleted,
-		CreateTime: index.CreateTime,
+		Deleted:          index.IsDeleted,
+		CreateTime:       index.CreateTime,
+		MinSchemaVersion: index.MinSchemaVersion,
 	}
 }
 
@@ -113,17 +116,18 @@ func MarshalIndexModel(index *Index) *indexpb.FieldIndex {
 
 func CloneIndex(index *Index) *Index {
 	clonedIndex := &Index{
-		TenantID:        index.TenantID,
-		CollectionID:    index.CollectionID,
-		FieldID:         index.FieldID,
-		IndexID:         index.IndexID,
-		IndexName:       index.IndexName,
-		IsDeleted:       index.IsDeleted,
-		CreateTime:      index.CreateTime,
-		TypeParams:      make([]*commonpb.KeyValuePair, len(index.TypeParams)),
-		IndexParams:     make([]*commonpb.KeyValuePair, len(index.IndexParams)),
-		IsAutoIndex:     index.IsAutoIndex,
-		UserIndexParams: make([]*commonpb.KeyValuePair, len(index.UserIndexParams)),
+		TenantID:         index.TenantID,
+		CollectionID:     index.CollectionID,
+		FieldID:          index.FieldID,
+		IndexID:          index.IndexID,
+		IndexName:        index.IndexName,
+		IsDeleted:        index.IsDeleted,
+		CreateTime:       index.CreateTime,
+		TypeParams:       make([]*commonpb.KeyValuePair, len(index.TypeParams)),
+		IndexParams:      make([]*commonpb.KeyValuePair, len(index.IndexParams)),
+		IsAutoIndex:      index.IsAutoIndex,
+		UserIndexParams:  make([]*commonpb.KeyValuePair, len(index.UserIndexParams)),
+		MinSchemaVersion: index.MinSchemaVersion,
 	}
 	for i, param := range index.TypeParams {
 		clonedIndex.TypeParams[i] = proto.Clone(param).(*commonpb.KeyValuePair)

--- a/internal/proxy/database_interceptor.go
+++ b/internal/proxy/database_interceptor.go
@@ -306,6 +306,11 @@ func fillDatabase(ctx context.Context, req interface{}) (context.Context, interf
 			r.DbName = GetCurDBNameFromContextOrDefault(ctx)
 		}
 		return ctx, r
+	case *milvuspb.AlterCollectionSchemaRequest:
+		if r.DbName == "" {
+			r.DbName = GetCurDBNameFromContextOrDefault(ctx)
+		}
+		return ctx, r
 
 	case *milvuspb.RunAnalyzerRequest:
 		if r.DbName == "" {

--- a/internal/proxy/database_interceptor_test.go
+++ b/internal/proxy/database_interceptor_test.go
@@ -101,6 +101,8 @@ func TestDatabaseInterceptor(t *testing.T) {
 			&milvuspb.OperatePrivilegeRequest{Entity: &milvuspb.GrantEntity{}},
 			&milvuspb.SelectGrantRequest{Entity: &milvuspb.GrantEntity{}},
 			&milvuspb.ManualCompactionRequest{},
+			&milvuspb.AddCollectionFieldRequest{},
+			&milvuspb.AlterCollectionSchemaRequest{},
 			&milvuspb.RunAnalyzerRequest{},
 			&milvuspb.RefreshExternalCollectionRequest{},
 			&milvuspb.ListRefreshExternalCollectionJobsRequest{},

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -968,6 +968,11 @@ func (node *Proxy) AddCollectionField(ctx context.Context, request *milvuspb.Add
 			"add field operation is not supported for external collection %s", request.GetCollectionName())), nil
 	}
 
+	// TODO(#48808): gate AddCollectionField against in-progress backfill once segment schema-version
+	// propagation for DoPhysicalBackfill=false DDLs is synchronous.  Currently the backfill
+	// policy updates segment schema versions on a tick, so a rapid second AddCollectionField
+	// can arrive before the tick fires and be incorrectly rejected by the gate.
+
 	task := &addCollectionFieldTask{
 		ctx:                       ctx,
 		Condition:                 NewTaskCondition(ctx),
@@ -1016,6 +1021,181 @@ func (node *Proxy) AddCollectionField(ctx context.Context, request *milvuspb.Add
 
 	metrics.ProxyReqLatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), method).Observe(float64(tr.ElapseSpan().Milliseconds()))
 	return task.result, nil
+}
+
+func (node *Proxy) AlterCollectionSchema(ctx context.Context, request *milvuspb.AlterCollectionSchemaRequest) (*milvuspb.AlterCollectionSchemaResponse, error) {
+	if err := merr.CheckHealthy(node.GetStateCode()); err != nil {
+		return &milvuspb.AlterCollectionSchemaResponse{
+			AlterStatus: merr.Status(err),
+		}, nil
+	}
+	ctx, sp := otel.Tracer(typeutil.ProxyRole).Start(ctx, "Proxy-AlterCollectionSchema")
+	defer sp.End()
+
+	dresp, err := node.DescribeCollection(ctx, &milvuspb.DescribeCollectionRequest{DbName: request.DbName, CollectionName: request.CollectionName})
+	if err := merr.CheckRPCCall(dresp, err); err != nil {
+		return &milvuspb.AlterCollectionSchemaResponse{
+			AlterStatus: merr.Status(err),
+		}, nil
+	}
+
+	// Check for external collection - alter collection schema is not supported
+	if typeutil.IsExternalCollection(dresp.GetSchema()) {
+		return &milvuspb.AlterCollectionSchemaResponse{
+			AlterStatus: merr.Status(merr.WrapErrParameterInvalidMsg(
+				"alter collection schema operation is not supported for external collection %s", request.GetCollectionName())),
+		}, nil
+	}
+
+	// Prevent concurrent AlterCollectionSchema requests on the same collection from
+	// racing past the schema version consistency gate. Only one request per collection
+	// is allowed to proceed at a time; others are rejected immediately.
+	collKey := request.GetDbName() + "/" + request.GetCollectionName()
+	if _, loaded := node.alterSchemaInFlight.LoadOrStore(collKey, struct{}{}); loaded {
+		return &milvuspb.AlterCollectionSchemaResponse{
+			AlterStatus: merr.Status(merr.WrapErrParameterInvalidMsg(
+				"another AlterCollectionSchema request is already in progress for collection %s", request.GetCollectionName())),
+		}, nil
+	}
+	defer node.alterSchemaInFlight.Delete(collKey)
+
+	// Check schema version consistency before proceeding with alter collection schema
+	if err := node.checkSchemaVersionConsistency(ctx, request.DbName, request.CollectionName); err != nil {
+		return &milvuspb.AlterCollectionSchemaResponse{
+			AlterStatus: merr.Status(err),
+		}, nil
+	}
+
+	task := &alterCollectionSchemaTask{
+		ctx:                          ctx,
+		Condition:                    NewTaskCondition(ctx),
+		AlterCollectionSchemaRequest: request,
+		mixCoord:                     node.mixCoord,
+		oldSchema:                    dresp.GetSchema(),
+	}
+	method := "AlterCollectionSchema"
+	tr := timerecord.NewTimeRecorder(method)
+
+	log := log.Ctx(ctx).With(
+		zap.String("role", typeutil.ProxyRole),
+		zap.String("db", request.DbName),
+		zap.String("collection", request.CollectionName))
+
+	log.Info(rpcReceived(method))
+
+	if err := node.sched.ddQueue.Enqueue(task); err != nil {
+		log.Warn(
+			rpcFailedToEnqueue(method),
+			zap.Error(err))
+		return &milvuspb.AlterCollectionSchemaResponse{
+			AlterStatus: merr.Status(err),
+		}, nil
+	}
+
+	log.Info(
+		rpcEnqueued(method),
+		zap.Uint64("BeginTs", task.BeginTs()),
+		zap.Uint64("EndTs", task.EndTs()))
+
+	if err := task.WaitToFinish(); err != nil {
+		log.Warn(
+			rpcFailedToWaitToFinish(method),
+			zap.Error(err),
+			zap.Uint64("BeginTs", task.BeginTs()),
+			zap.Uint64("EndTs", task.EndTs()))
+		return &milvuspb.AlterCollectionSchemaResponse{
+			AlterStatus: merr.Status(err),
+		}, nil
+	}
+	log.Info(
+		rpcDone(method),
+		zap.Uint64("BeginTs", task.BeginTs()),
+		zap.Uint64("EndTs", task.EndTs()))
+
+	metrics.ProxyReqLatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), method).Observe(float64(tr.ElapseSpan().Milliseconds()))
+
+	return task.AlterCollectionSchemaResponse, nil
+}
+
+// checkSchemaVersionConsistency checks if all segments have consistent schema version
+// Returns error if schema version consistency proportion is less than 100%
+func (node *Proxy) checkSchemaVersionConsistency(ctx context.Context, dbName, collectionName string) error {
+	log := log.Ctx(ctx).With(
+		zap.String("role", typeutil.ProxyRole),
+		zap.String("db", dbName),
+		zap.String("collection", collectionName))
+
+	// Get collection statistics to check schema version consistency
+	statsResp, err := node.GetCollectionStatistics(ctx, &milvuspb.GetCollectionStatisticsRequest{
+		Base:           commonpbutil.NewMsgBase(),
+		DbName:         dbName,
+		CollectionName: collectionName,
+	})
+	if err := merr.CheckRPCCall(statsResp, err); err != nil {
+		log.Warn("failed to get collection statistics for schema version consistency check", zap.Error(err))
+		return err
+	}
+
+	// Find schema_version_consistent_segments and schema_version_total_segments from Stats.
+	// DataCoord emits these two integer keys only when the collection's schema version > 0
+	// (i.e. AlterCollectionSchema has been called at least once).  Absent keys mean the
+	// schema version is still 0 — no function field has ever been added — so there is no
+	// in-flight backfill and no DDL can be racing with one.  This does NOT open a window
+	// for concurrent DDL to slip through: RootCoord serializes all schema-change DDLs through
+	// a single DDL queue, so a second AlterCollectionSchema call can only enter this check
+	// after the first has already bumped the schema version and DataCoord has started reporting
+	// the count keys.
+	//
+	// Integer counts are used instead of a floating-point proportion to avoid the rounding
+	// hazard where e.g. 99999/100000 = 99.999% would format as "100.00" with "%.2f" and
+	// falsely satisfy the 100% gate check.
+	consistentSegments := -1
+	totalSegments := -1
+	for _, stat := range statsResp.GetStats() {
+		switch stat.GetKey() {
+		case common.SchemaVersionConsistentSegmentsKey:
+			v, err := strconv.Atoi(stat.GetValue())
+			if err != nil || v < 0 {
+				log.Warn("failed to parse schema_version_consistent_segments",
+					zap.String("value", stat.GetValue()), zap.Error(err))
+				return merr.WrapErrParameterInvalidMsg(
+					"invalid schema_version_consistent_segments value: %s", stat.GetValue())
+			}
+			consistentSegments = v
+		case common.SchemaVersionTotalSegmentsKey:
+			v, err := strconv.Atoi(stat.GetValue())
+			if err != nil || v < 0 {
+				log.Warn("failed to parse schema_version_total_segments",
+					zap.String("value", stat.GetValue()), zap.Error(err))
+				return merr.WrapErrParameterInvalidMsg(
+					"invalid schema_version_total_segments value: %s", stat.GetValue())
+			}
+			totalSegments = v
+		}
+	}
+
+	log.Info("checked schema version consistency",
+		zap.Int("consistentSegments", consistentSegments),
+		zap.Int("totalSegments", totalSegments))
+
+	if consistentSegments < 0 && totalSegments < 0 {
+		// Both keys absent: schema version is 0, no backfill has ever been triggered.
+		return nil
+	}
+	if consistentSegments < 0 || totalSegments < 0 {
+		// Exactly one key present — should never happen since DataCoord emits both atomically.
+		// Treat as a data corruption signal and block the DDL rather than silently passing.
+		log.Warn("incomplete schema version consistency stats, blocking DDL",
+			zap.Int("consistentSegments", consistentSegments),
+			zap.Int("totalSegments", totalSegments))
+		return merr.WrapErrParameterInvalidMsg("incomplete schema version consistency stats from DataCoord")
+	}
+	if consistentSegments < totalSegments {
+		return merr.WrapErrParameterInvalidMsg(
+			"schema version consistency check failed: %d/%d segments are consistent, required 100%%",
+			consistentSegments, totalSegments)
+	}
+	return nil
 }
 
 // GetStatistics get the statistics, such as `num_rows`.
@@ -1447,6 +1627,10 @@ func (node *Proxy) AlterCollectionField(ctx context.Context, request *milvuspb.A
 	if err := checkExternalCollectionBlockedForWrite(ctx, request.GetDbName(), request.GetCollectionName(), "alter field"); err != nil {
 		return merr.Status(err), nil
 	}
+
+	// TODO(#48808): gate AlterCollectionField against in-progress backfill once segment schema-version
+	// propagation for DoPhysicalBackfill=false DDLs is synchronous.  Same timing issue as
+	// AddCollectionField — backfill tick may not have fired before the next DDL arrives.
 
 	act := &alterCollectionFieldTask{
 		ctx:                         ctx,

--- a/internal/proxy/impl_test.go
+++ b/internal/proxy/impl_test.go
@@ -2606,3 +2606,335 @@ func TestProxy_BatchUpdateManifest(t *testing.T) {
 		})
 	})
 }
+
+func TestProxy_AlterCollectionSchema(t *testing.T) {
+	t.Run("unhealthy node", func(t *testing.T) {
+		proxy := &Proxy{}
+		proxy.UpdateStateCode(commonpb.StateCode_Abnormal)
+		resp, err := proxy.AlterCollectionSchema(context.Background(), &milvuspb.AlterCollectionSchemaRequest{})
+		assert.NoError(t, err)
+		assert.Error(t, merr.Error(resp.GetAlterStatus()))
+	})
+
+	t.Run("DescribeCollection fails", func(t *testing.T) {
+		mockey.PatchConvey("DescribeCollection fails", t, func() {
+			node := createTestProxy()
+			defer node.sched.Close()
+
+			mockey.Mock((*Proxy).DescribeCollection).Return(&milvuspb.DescribeCollectionResponse{
+				Status: merr.Status(merr.ErrCollectionNotFound),
+			}, nil).Build()
+
+			resp, err := node.AlterCollectionSchema(context.Background(), &milvuspb.AlterCollectionSchemaRequest{
+				CollectionName: "test_coll",
+			})
+			assert.NoError(t, err)
+			assert.Error(t, merr.Error(resp.GetAlterStatus()))
+		})
+	})
+
+	t.Run("external collection rejected", func(t *testing.T) {
+		mockey.PatchConvey("external collection", t, func() {
+			node := createTestProxy()
+			defer node.sched.Close()
+
+			mockey.Mock((*Proxy).DescribeCollection).Return(&milvuspb.DescribeCollectionResponse{
+				Status: merr.Success(),
+				Schema: &schemapb.CollectionSchema{
+					Name: "ext_col",
+					Fields: []*schemapb.FieldSchema{
+						{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true, ExternalField: "ext_id"},
+					},
+				},
+			}, nil).Build()
+
+			resp, err := node.AlterCollectionSchema(context.Background(), &milvuspb.AlterCollectionSchemaRequest{
+				CollectionName: "ext_col",
+			})
+			assert.NoError(t, err)
+			assert.Error(t, merr.Error(resp.GetAlterStatus()))
+			assert.Contains(t, resp.GetAlterStatus().GetReason(), "external collection")
+		})
+	})
+
+	t.Run("schema version consistency check fails", func(t *testing.T) {
+		mockey.PatchConvey("consistency check fails", t, func() {
+			node := createTestProxy()
+			defer node.sched.Close()
+
+			mockey.Mock((*Proxy).DescribeCollection).Return(&milvuspb.DescribeCollectionResponse{
+				Status: merr.Success(),
+				Schema: &schemapb.CollectionSchema{Name: "test_coll"},
+			}, nil).Build()
+
+			mockey.Mock((*Proxy).checkSchemaVersionConsistency).Return(
+				merr.WrapErrParameterInvalidMsg("consistency check failed"),
+			).Build()
+
+			resp, err := node.AlterCollectionSchema(context.Background(), &milvuspb.AlterCollectionSchemaRequest{
+				CollectionName: "test_coll",
+			})
+			assert.NoError(t, err)
+			assert.Error(t, merr.Error(resp.GetAlterStatus()))
+		})
+	})
+
+	t.Run("enqueue fails", func(t *testing.T) {
+		mockey.PatchConvey("enqueue fails", t, func() {
+			node := createTestProxy()
+			defer node.sched.Close()
+
+			mockey.Mock((*Proxy).DescribeCollection).Return(&milvuspb.DescribeCollectionResponse{
+				Status: merr.Success(),
+				Schema: &schemapb.CollectionSchema{Name: "test_coll"},
+			}, nil).Build()
+
+			mockey.Mock((*Proxy).checkSchemaVersionConsistency).Return(nil).Build()
+
+			mockey.Mock((*ddTaskQueue).Enqueue).To(func(_ *ddTaskQueue, _ task) error {
+				return errors.New("queue full")
+			}).Build()
+
+			resp, err := node.AlterCollectionSchema(context.Background(), &milvuspb.AlterCollectionSchemaRequest{
+				CollectionName: "test_coll",
+			})
+			assert.NoError(t, err)
+			assert.Error(t, merr.Error(resp.GetAlterStatus()))
+		})
+	})
+
+	t.Run("WaitToFinish fails", func(t *testing.T) {
+		mockey.PatchConvey("WaitToFinish fails", t, func() {
+			node := createTestProxy()
+			defer node.sched.Close()
+
+			mockey.Mock((*Proxy).DescribeCollection).Return(&milvuspb.DescribeCollectionResponse{
+				Status: merr.Success(),
+				Schema: &schemapb.CollectionSchema{Name: "test_coll"},
+			}, nil).Build()
+
+			mockey.Mock((*Proxy).checkSchemaVersionConsistency).Return(nil).Build()
+
+			// Call OnEnqueue so task.Base is initialized (BeginTs/EndTs are logged after Enqueue).
+			mockey.Mock((*ddTaskQueue).Enqueue).To(func(_ *ddTaskQueue, t task) error {
+				_ = t.OnEnqueue()
+				return nil
+			}).Build()
+
+			mockey.Mock((*TaskCondition).WaitToFinish).Return(errors.New("timeout")).Build()
+
+			resp, err := node.AlterCollectionSchema(context.Background(), &milvuspb.AlterCollectionSchemaRequest{
+				CollectionName: "test_coll",
+			})
+			assert.NoError(t, err)
+			assert.Error(t, merr.Error(resp.GetAlterStatus()))
+		})
+	})
+
+	t.Run("happy path", func(t *testing.T) {
+		mockey.PatchConvey("happy path", t, func() {
+			node := createTestProxy()
+			defer node.sched.Close()
+
+			mockey.Mock((*Proxy).DescribeCollection).Return(&milvuspb.DescribeCollectionResponse{
+				Status: merr.Success(),
+				Schema: &schemapb.CollectionSchema{Name: "test_coll"},
+			}, nil).Build()
+
+			mockey.Mock((*Proxy).checkSchemaVersionConsistency).Return(nil).Build()
+
+			// Call OnEnqueue so task.Base is initialized (BeginTs/EndTs are logged after Enqueue).
+			mockey.Mock((*ddTaskQueue).Enqueue).To(func(_ *ddTaskQueue, t task) error {
+				_ = t.OnEnqueue()
+				return nil
+			}).Build()
+
+			mockey.Mock((*TaskCondition).WaitToFinish).Return(nil).Build()
+
+			_, err := node.AlterCollectionSchema(context.Background(), &milvuspb.AlterCollectionSchemaRequest{
+				CollectionName: "test_coll",
+			})
+			assert.NoError(t, err)
+		})
+	})
+}
+
+func TestCheckSchemaVersionConsistency(t *testing.T) {
+	t.Run("GetCollectionStatistics returns error", func(t *testing.T) {
+		mockey.PatchConvey("error from GetCollectionStatistics", t, func() {
+			node := createTestProxy()
+			defer node.sched.Close()
+
+			mockey.Mock((*Proxy).GetCollectionStatistics).To(
+				func(_ *Proxy, ctx context.Context, req *milvuspb.GetCollectionStatisticsRequest) (*milvuspb.GetCollectionStatisticsResponse, error) {
+					return nil, errors.New("rpc error")
+				}).Build()
+
+			err := node.checkSchemaVersionConsistency(context.Background(), "db", "coll")
+			assert.Error(t, err)
+		})
+	})
+
+	t.Run("GetCollectionStatistics returns RPC error status", func(t *testing.T) {
+		mockey.PatchConvey("rpc status error", t, func() {
+			node := createTestProxy()
+			defer node.sched.Close()
+
+			mockey.Mock((*Proxy).GetCollectionStatistics).To(
+				func(_ *Proxy, ctx context.Context, req *milvuspb.GetCollectionStatisticsRequest) (*milvuspb.GetCollectionStatisticsResponse, error) {
+					return &milvuspb.GetCollectionStatisticsResponse{
+						Status: merr.Status(merr.ErrCollectionNotFound),
+					}, nil
+				}).Build()
+
+			err := node.checkSchemaVersionConsistency(context.Background(), "db", "coll")
+			assert.Error(t, err)
+		})
+	})
+
+	t.Run("both keys absent returns nil", func(t *testing.T) {
+		mockey.PatchConvey("no keys present", t, func() {
+			node := createTestProxy()
+			defer node.sched.Close()
+
+			mockey.Mock((*Proxy).GetCollectionStatistics).To(
+				func(_ *Proxy, ctx context.Context, req *milvuspb.GetCollectionStatisticsRequest) (*milvuspb.GetCollectionStatisticsResponse, error) {
+					return &milvuspb.GetCollectionStatisticsResponse{
+						Status: merr.Success(),
+						Stats:  []*commonpb.KeyValuePair{},
+					}, nil
+				}).Build()
+
+			err := node.checkSchemaVersionConsistency(context.Background(), "db", "coll")
+			assert.NoError(t, err)
+		})
+	})
+
+	t.Run("only consistent key present total absent returns error", func(t *testing.T) {
+		mockey.PatchConvey("consistent only", t, func() {
+			node := createTestProxy()
+			defer node.sched.Close()
+
+			mockey.Mock((*Proxy).GetCollectionStatistics).To(
+				func(_ *Proxy, ctx context.Context, req *milvuspb.GetCollectionStatisticsRequest) (*milvuspb.GetCollectionStatisticsResponse, error) {
+					return &milvuspb.GetCollectionStatisticsResponse{
+						Status: merr.Success(),
+						Stats: []*commonpb.KeyValuePair{
+							{Key: common.SchemaVersionConsistentSegmentsKey, Value: "5"},
+						},
+					}, nil
+				}).Build()
+
+			err := node.checkSchemaVersionConsistency(context.Background(), "db", "coll")
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "incomplete schema version consistency stats")
+		})
+	})
+
+	t.Run("only total key present consistent absent returns error", func(t *testing.T) {
+		mockey.PatchConvey("total only", t, func() {
+			node := createTestProxy()
+			defer node.sched.Close()
+
+			mockey.Mock((*Proxy).GetCollectionStatistics).To(
+				func(_ *Proxy, ctx context.Context, req *milvuspb.GetCollectionStatisticsRequest) (*milvuspb.GetCollectionStatisticsResponse, error) {
+					return &milvuspb.GetCollectionStatisticsResponse{
+						Status: merr.Success(),
+						Stats: []*commonpb.KeyValuePair{
+							{Key: common.SchemaVersionTotalSegmentsKey, Value: "10"},
+						},
+					}, nil
+				}).Build()
+
+			err := node.checkSchemaVersionConsistency(context.Background(), "db", "coll")
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "incomplete schema version consistency stats")
+		})
+	})
+
+	t.Run("consistent less than total returns error with counts", func(t *testing.T) {
+		mockey.PatchConvey("consistent < total", t, func() {
+			node := createTestProxy()
+			defer node.sched.Close()
+
+			mockey.Mock((*Proxy).GetCollectionStatistics).To(
+				func(_ *Proxy, ctx context.Context, req *milvuspb.GetCollectionStatisticsRequest) (*milvuspb.GetCollectionStatisticsResponse, error) {
+					return &milvuspb.GetCollectionStatisticsResponse{
+						Status: merr.Success(),
+						Stats: []*commonpb.KeyValuePair{
+							{Key: common.SchemaVersionConsistentSegmentsKey, Value: "5"},
+							{Key: common.SchemaVersionTotalSegmentsKey, Value: "10"},
+						},
+					}, nil
+				}).Build()
+
+			err := node.checkSchemaVersionConsistency(context.Background(), "db", "coll")
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "5")
+			assert.Contains(t, err.Error(), "10")
+		})
+	})
+
+	t.Run("consistent equals total returns nil", func(t *testing.T) {
+		mockey.PatchConvey("consistent == total", t, func() {
+			node := createTestProxy()
+			defer node.sched.Close()
+
+			mockey.Mock((*Proxy).GetCollectionStatistics).To(
+				func(_ *Proxy, ctx context.Context, req *milvuspb.GetCollectionStatisticsRequest) (*milvuspb.GetCollectionStatisticsResponse, error) {
+					return &milvuspb.GetCollectionStatisticsResponse{
+						Status: merr.Success(),
+						Stats: []*commonpb.KeyValuePair{
+							{Key: common.SchemaVersionConsistentSegmentsKey, Value: "10"},
+							{Key: common.SchemaVersionTotalSegmentsKey, Value: "10"},
+						},
+					}, nil
+				}).Build()
+
+			err := node.checkSchemaVersionConsistency(context.Background(), "db", "coll")
+			assert.NoError(t, err)
+		})
+	})
+
+	t.Run("malformed consistent value returns parse error", func(t *testing.T) {
+		mockey.PatchConvey("bad consistent value", t, func() {
+			node := createTestProxy()
+			defer node.sched.Close()
+
+			mockey.Mock((*Proxy).GetCollectionStatistics).To(
+				func(_ *Proxy, ctx context.Context, req *milvuspb.GetCollectionStatisticsRequest) (*milvuspb.GetCollectionStatisticsResponse, error) {
+					return &milvuspb.GetCollectionStatisticsResponse{
+						Status: merr.Success(),
+						Stats: []*commonpb.KeyValuePair{
+							{Key: common.SchemaVersionConsistentSegmentsKey, Value: "not-a-number"},
+							{Key: common.SchemaVersionTotalSegmentsKey, Value: "10"},
+						},
+					}, nil
+				}).Build()
+
+			err := node.checkSchemaVersionConsistency(context.Background(), "db", "coll")
+			assert.Error(t, err)
+		})
+	})
+
+	t.Run("malformed total value returns parse error", func(t *testing.T) {
+		mockey.PatchConvey("bad total value", t, func() {
+			node := createTestProxy()
+			defer node.sched.Close()
+
+			mockey.Mock((*Proxy).GetCollectionStatistics).To(
+				func(_ *Proxy, ctx context.Context, req *milvuspb.GetCollectionStatisticsRequest) (*milvuspb.GetCollectionStatisticsResponse, error) {
+					return &milvuspb.GetCollectionStatisticsResponse{
+						Status: merr.Success(),
+						Stats: []*commonpb.KeyValuePair{
+							{Key: common.SchemaVersionConsistentSegmentsKey, Value: "5"},
+							{Key: common.SchemaVersionTotalSegmentsKey, Value: "bad-value"},
+						},
+					}, nil
+				}).Build()
+
+			err := node.checkSchemaVersionConsistency(context.Background(), "db", "coll")
+			assert.Error(t, err)
+		})
+	})
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -116,6 +116,11 @@ type Proxy struct {
 	enableComplexDeleteLimit bool
 
 	slowQueries *expirable.LRU[Timestamp, *metricsinfo.SlowQuery]
+
+	// alterSchemaInFlight tracks collections that have an AlterCollectionSchema
+	// request in progress, keyed by "dbName/collectionName". Prevents concurrent
+	// requests from racing past the schema version consistency gate.
+	alterSchemaInFlight sync.Map
 }
 
 // NewProxy returns a Proxy struct.

--- a/internal/proxy/service_provider.go
+++ b/internal/proxy/service_provider.go
@@ -213,6 +213,8 @@ func (node *CachedProxyServiceProvider) DescribeCollection(ctx context.Context,
 		DbName:             c.schema.CollectionSchema.DbName,
 		ExternalSource:     c.schema.CollectionSchema.ExternalSource,
 		ExternalSpec:       c.schema.CollectionSchema.ExternalSpec,
+		Version:            c.schema.CollectionSchema.Version,
+		DoPhysicalBackfill: c.schema.CollectionSchema.DoPhysicalBackfill,
 	}
 
 	// Restore struct field names from internal format (structName[fieldName]) to original format
@@ -239,12 +241,10 @@ func (node *CachedProxyServiceProvider) DescribeCollection(ctx context.Context,
 	resp.ShardsNum = c.shardsNum
 	resp.Aliases = c.aliases
 	resp.Properties = c.properties
-
 	log.Debug("DescribeCollection done",
 		zap.Int64("collectionID", resp.GetCollectionID()),
 		zap.Any("schema", resp.GetSchema()),
 	)
-
 	return resp, nil
 }
 

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -129,7 +129,8 @@ const (
 	AlterDatabaseTaskName    = "AlterDatabaseTaskName"
 	DescribeDatabaseTaskName = "DescribeDatabaseTaskName"
 
-	AddFieldTaskName = "AddFieldTaskName"
+	AddFieldTaskName              = "AddFieldTaskName"
+	AlterCollectionSchemaTaskName = "AlterCollectionSchemaTaskName"
 
 	// minFloat32 minimum float.
 	minFloat32 = -1 * float32(math.MaxFloat32)
@@ -650,76 +651,20 @@ func (t *addCollectionFieldTask) PreExecute(ctx context.Context) error {
 	}
 
 	t.fieldSchema = &schemapb.FieldSchema{}
-	err := proto.Unmarshal(t.GetSchema(), t.fieldSchema)
-	if err != nil {
+	if err := proto.Unmarshal(t.GetSchema(), t.fieldSchema); err != nil {
 		return err
 	}
-	fieldList := typeutil.NewSet[string]()
-	for _, schema := range t.oldSchema.Fields {
-		fieldList.Insert(schema.Name)
+	if err := validateAddFieldRequest(t.oldSchema, t.fieldSchema); err != nil {
+		return err
 	}
-
-	if len(fieldList) >= Params.ProxyCfg.MaxFieldNum.GetAsInt() {
-		msg := fmt.Sprintf("The number of fields has reached the maximum value %d", Params.ProxyCfg.MaxFieldNum.GetAsInt())
-		return merr.WrapErrParameterInvalidMsg(msg)
-	}
-
-	if typeutil.IsVectorType(t.fieldSchema.DataType) {
-		vectorFields := len(typeutil.GetVectorFieldSchemas(t.oldSchema))
-		if vectorFields >= Params.ProxyCfg.MaxVectorFieldNum.GetAsInt() {
-			return fmt.Errorf("maximum vector field's number should be limited to %d", Params.ProxyCfg.MaxVectorFieldNum.GetAsInt())
-		}
-	}
-
-	if _, ok := schemapb.DataType_name[int32(t.fieldSchema.DataType)]; !ok || t.fieldSchema.GetDataType() == schemapb.DataType_None {
-		return merr.WrapErrParameterInvalid("valid field", fmt.Sprintf("field data type: %s is not supported", t.fieldSchema.GetDataType()))
-	}
-
-	if funcutil.SliceContain([]string{common.RowIDFieldName, common.TimeStampFieldName, common.MetaFieldName, common.NamespaceFieldName}, t.fieldSchema.GetName()) {
-		return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("not support to add system field, field name = %s", t.fieldSchema.Name))
-	}
-	if t.fieldSchema.IsPrimaryKey {
-		return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("not support to add pk field, field name = %s", t.fieldSchema.Name))
-	}
-	if !t.fieldSchema.Nullable {
-		return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("added field must be nullable, please check it, field name = %s", t.fieldSchema.Name))
-	}
-	if typeutil.IsVectorType(t.fieldSchema.DataType) && t.fieldSchema.Nullable {
-		if t.fieldSchema.DataType == schemapb.DataType_FloatVector ||
-			t.fieldSchema.DataType == schemapb.DataType_Float16Vector ||
-			t.fieldSchema.DataType == schemapb.DataType_BFloat16Vector ||
-			t.fieldSchema.DataType == schemapb.DataType_BinaryVector ||
-			t.fieldSchema.DataType == schemapb.DataType_Int8Vector {
-			if len(t.fieldSchema.TypeParams) == 0 {
-				return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("vector field must have dimension specified, field name = %s", t.fieldSchema.Name))
-			}
-		}
-	}
-	if t.fieldSchema.AutoID {
-		return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("only primary field can speficy AutoID with true, field name = %s", t.fieldSchema.Name))
-	}
-	if t.fieldSchema.IsPartitionKey {
-		return merr.WrapErrParameterInvalidMsg("not support to add partition key field, field name  = %s", t.fieldSchema.Name)
-	}
-	if t.fieldSchema.GetIsClusteringKey() {
-		if !typeutil.IsClusteringKeyType(t.fieldSchema.GetDataType()) {
-			return merr.WrapErrParameterInvalidMsg(
-				fmt.Sprintf("clustering key field %s has unsupported data type %s",
-					t.fieldSchema.GetName(), t.fieldSchema.GetDataType().String()))
-		}
-		for _, f := range t.oldSchema.Fields {
-			if f.GetIsClusteringKey() {
-				return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("already has another clutering key field, field name: %s", t.fieldSchema.GetName()))
-			}
-		}
+	// User-added fields must be nullable so that old segments without this field can return
+	// NULL rather than causing a schema inconsistency at query time.
+	if !t.fieldSchema.GetNullable() {
+		return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("added field must be nullable, please check it, field name = %s", t.fieldSchema.GetName()))
 	}
 	if err := ValidateField(t.fieldSchema, t.oldSchema); err != nil {
 		return err
 	}
-	if fieldList.Contain(t.fieldSchema.Name) {
-		return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("duplicate field name: %s", t.fieldSchema.GetName()))
-	}
-
 	log.Info("PreExecute addField task done", zap.Any("field schema", t.fieldSchema))
 	return nil
 }
@@ -731,6 +676,229 @@ func (t *addCollectionFieldTask) Execute(ctx context.Context) error {
 }
 
 func (t *addCollectionFieldTask) PostExecute(ctx context.Context) error {
+	return nil
+}
+
+// validateAddFieldRequest validates both the old schema constraints and the new field properties
+// for an AddCollectionField request. It is the single source of truth for add-field validation.
+func validateAddFieldRequest(schema *schemapb.CollectionSchema, newFieldSchema *schemapb.FieldSchema) error {
+	// --- old schema constraints ---
+	fieldList := typeutil.NewSet[string]()
+	for _, f := range schema.Fields {
+		fieldList.Insert(f.Name)
+	}
+	if len(fieldList) >= Params.ProxyCfg.MaxFieldNum.GetAsInt() {
+		msg := fmt.Sprintf("The number of fields has reached the maximum value %d", Params.ProxyCfg.MaxFieldNum.GetAsInt())
+		return merr.WrapErrParameterInvalidMsg(msg)
+	}
+	if fieldList.Contain(newFieldSchema.GetName()) {
+		return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("duplicated field name %s", newFieldSchema.GetName()))
+	}
+
+	// --- new field property constraints ---
+	if _, ok := schemapb.DataType_name[int32(newFieldSchema.GetDataType())]; !ok || newFieldSchema.GetDataType() == schemapb.DataType_None {
+		return merr.WrapErrParameterInvalid("valid field", fmt.Sprintf("field data type: %s is not supported", newFieldSchema.GetDataType()))
+	}
+	if funcutil.SliceContain([]string{common.RowIDFieldName, common.TimeStampFieldName, common.MetaFieldName, common.NamespaceFieldName}, newFieldSchema.GetName()) {
+		return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("not support to add system field, field name = %s", newFieldSchema.GetName()))
+	}
+	if newFieldSchema.GetIsPrimaryKey() {
+		return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("not support to add pk field, field name = %s", newFieldSchema.GetName()))
+	}
+	if newFieldSchema.GetAutoID() {
+		return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("only primary field can speficy AutoID with true, field name = %s", newFieldSchema.GetName()))
+	}
+	if newFieldSchema.GetIsPartitionKey() {
+		return merr.WrapErrParameterInvalidMsg("not support to add partition key field, field name  = %s", newFieldSchema.GetName())
+	}
+	if newFieldSchema.GetIsClusteringKey() {
+		if !typeutil.IsClusteringKeyType(newFieldSchema.GetDataType()) {
+			return merr.WrapErrParameterInvalidMsg(
+				fmt.Sprintf("clustering key field %s has unsupported data type %s",
+					newFieldSchema.GetName(), newFieldSchema.GetDataType().String()))
+		}
+		for _, f := range schema.GetFields() {
+			if f.GetIsClusteringKey() {
+				return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("already has another clustering key field, field name: %s", newFieldSchema.GetName()))
+			}
+		}
+	}
+	if typeutil.IsVectorType(newFieldSchema.DataType) {
+		vectorFields := len(typeutil.GetVectorFieldSchemas(schema))
+		if vectorFields >= Params.ProxyCfg.MaxVectorFieldNum.GetAsInt() {
+			return fmt.Errorf("maximum vector field's number should be limited to %d", Params.ProxyCfg.MaxVectorFieldNum.GetAsInt())
+		}
+	}
+
+	// NOTE: The nullable requirement for added fields is enforced by callers that deal with
+	// user-defined fields (e.g. addCollectionFieldTask). Function output fields managed by
+	// alterCollectionSchemaTask are explicitly prohibited from being nullable by validateFunction,
+	// so the check is intentionally left to callers rather than enforced here universally.
+	//
+	// Dense vector types require a dimension TypeParam. This check applies unconditionally
+	// (regardless of nullable) because a vector field without dimension is always invalid.
+	// SparseFloatVector is excluded because it does not have a fixed dimension by design.
+	if typeutil.IsVectorType(newFieldSchema.DataType) {
+		if newFieldSchema.DataType == schemapb.DataType_FloatVector ||
+			newFieldSchema.DataType == schemapb.DataType_Float16Vector ||
+			newFieldSchema.DataType == schemapb.DataType_BFloat16Vector ||
+			newFieldSchema.DataType == schemapb.DataType_BinaryVector ||
+			newFieldSchema.DataType == schemapb.DataType_Int8Vector {
+			if len(newFieldSchema.TypeParams) == 0 {
+				return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("vector field must have dimension specified, field name = %s", newFieldSchema.GetName()))
+			}
+		}
+	}
+	return nil
+}
+
+type alterCollectionSchemaTask struct {
+	baseTask
+	Condition
+	*milvuspb.AlterCollectionSchemaRequest
+	*milvuspb.AlterCollectionSchemaResponse
+	ctx       context.Context
+	mixCoord  types.MixCoordClient
+	oldSchema *schemapb.CollectionSchema
+}
+
+func (t *alterCollectionSchemaTask) TraceCtx() context.Context {
+	return t.ctx
+}
+
+func (t *alterCollectionSchemaTask) ID() UniqueID {
+	return t.Base.MsgID
+}
+
+func (t *alterCollectionSchemaTask) SetID(uid UniqueID) {
+	t.Base.MsgID = uid
+}
+
+func (t *alterCollectionSchemaTask) Name() string {
+	return AlterCollectionSchemaTaskName
+}
+
+func (t *alterCollectionSchemaTask) Type() commonpb.MsgType {
+	return t.Base.MsgType
+}
+
+func (t *alterCollectionSchemaTask) BeginTs() Timestamp {
+	return t.Base.Timestamp
+}
+
+func (t *alterCollectionSchemaTask) EndTs() Timestamp {
+	return t.Base.Timestamp
+}
+
+func (t *alterCollectionSchemaTask) SetTs(ts Timestamp) {
+	t.Base.Timestamp = ts
+}
+
+func (t *alterCollectionSchemaTask) OnEnqueue() error {
+	if t.Base == nil {
+		t.Base = commonpbutil.NewMsgBase()
+	}
+	t.Base.MsgType = commonpb.MsgType_AlterCollectionSchema
+	t.Base.SourceID = paramtable.GetNodeID()
+	return nil
+}
+
+func (t *alterCollectionSchemaTask) PreExecute(ctx context.Context) error {
+	if t.oldSchema == nil {
+		return merr.WrapErrParameterInvalidMsg("empty old schema in alter collection schema task")
+	}
+
+	action := t.AlterCollectionSchemaRequest.GetAction()
+	if action == nil {
+		return merr.WrapErrParameterInvalidMsg("action is nil in alter schema task")
+	}
+	addRequest := action.GetAddRequest()
+	if addRequest == nil {
+		return merr.WrapErrParameterInvalidMsg("add_request is nil, only add operation is supported for now")
+	}
+
+	fieldInfos := addRequest.GetFieldInfos()
+	funcSchemas := addRequest.GetFuncSchema()
+
+	// AlterCollectionSchema currently only supports adding exactly one function with its output fields.
+	// RootCoord enforces the same constraint (ddl_callbacks_alter_collection_schema.go);
+	// validate early at Proxy to give clearer error messages.
+	if len(funcSchemas) != 1 || funcSchemas[0] == nil {
+		return merr.WrapErrParameterInvalidMsg("For now, exactly one function schema is required in alter schema task")
+	}
+	if len(fieldInfos) == 0 {
+		return merr.WrapErrParameterInvalidMsg("fieldInfos is empty, function output fields are required")
+	}
+
+	if len(fieldInfos) != 1 {
+		return merr.WrapErrParameterInvalidMsg("For now, only one field info is supported in alter schema task")
+	}
+	newFieldSchema := fieldInfos[0].GetFieldSchema()
+	if newFieldSchema == nil {
+		return merr.WrapErrParameterInvalidMsg("empty new field schema in alter schema task")
+	}
+	if err := validateAddFieldRequest(t.oldSchema, newFieldSchema); err != nil {
+		return err
+	}
+	if err := ValidateField(newFieldSchema, t.oldSchema); err != nil {
+		return err
+	}
+
+	// Verify that every OutputFieldName of the function refers to one of the newly-added
+	// fields (from fieldInfos), not to a field that already exists in the old schema.
+	// This prevents a caller from wiring function output to an existing field, which
+	// would corrupt that field's data silently.
+	newFieldNames := make(map[string]struct{}, len(fieldInfos))
+	for _, fi := range fieldInfos {
+		if fi.GetFieldSchema() != nil {
+			newFieldNames[fi.GetFieldSchema().GetName()] = struct{}{}
+		}
+	}
+	for _, outName := range funcSchemas[0].GetOutputFieldNames() {
+		if _, isNew := newFieldNames[outName]; !isNew {
+			return merr.WrapErrParameterInvalidMsg(
+				"function output field %q must be one of the newly-added fields, not an existing field",
+				outName,
+			)
+		}
+	}
+
+	// Validate function-field type compatibility (e.g., BM25 requires varchar input,
+	// SparseFloatVector output). Construct a merged schema with old fields + new fields
+	// + new function, then validate only the new function to avoid re-checking existing
+	// functions' runtime providers.
+	// Deep-copy each new field schema so validateFunction's mutations (e.g. clearing
+	// IsFunctionOutput) do not affect the original request objects.
+	mergedSchema := proto.Clone(t.oldSchema).(*schemapb.CollectionSchema)
+	for _, fieldInfo := range fieldInfos {
+		mergedSchema.Fields = append(mergedSchema.Fields, proto.Clone(fieldInfo.GetFieldSchema()).(*schemapb.FieldSchema))
+	}
+	mergedSchema.Functions = append(mergedSchema.Functions, funcSchemas[0])
+	if err := validateFunction(mergedSchema, funcSchemas[0].GetName(), false); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (t *alterCollectionSchemaTask) Execute(ctx context.Context) error {
+	action := t.AlterCollectionSchemaRequest.GetAction()
+	if action != nil {
+		addRequest := action.GetAddRequest()
+		if addRequest != nil {
+			for _, fieldInfo := range addRequest.GetFieldInfos() {
+				if fieldInfo != nil && fieldInfo.GetFieldSchema() != nil {
+					fieldInfo.GetFieldSchema().IsFunctionOutput = true
+				}
+			}
+		}
+	}
+	var err error
+	t.AlterCollectionSchemaResponse, err = t.mixCoord.AlterCollectionSchema(ctx, t.AlterCollectionSchemaRequest)
+	return merr.CheckRPCCall(t.AlterCollectionSchemaResponse.GetAlterStatus(), err)
+}
+
+func (t *alterCollectionSchemaTask) PostExecute(ctx context.Context) error {
 	return nil
 }
 

--- a/internal/proxy/task_insert_streaming.go
+++ b/internal/proxy/task_insert_streaming.go
@@ -20,6 +20,11 @@ import (
 )
 
 // we only overwrite the Execute function
+// TODO: InsertMessageHeader does not carry SchemaVersion, which means the consistency gate
+// in StreamingNode cannot tell whether an insert was produced before or after a schema change.
+// This can cause a deadlock when the gate waits for inserts at the new schema version that
+// will never arrive. The companion PR https://github.com/milvus-io/milvus/pull/48139
+// resolves this by propagating SchemaVersion through the insert path.
 func (it *insertTask) Execute(ctx context.Context) error {
 	ctx, sp := otel.Tracer(typeutil.ProxyRole).Start(ctx, "Proxy-Insert-Execute")
 	defer sp.End()

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -6674,3 +6674,491 @@ func TestHasPropInDeletekeys(t *testing.T) {
 		assert.Equal(t, "", hasPropInDeletekeys([]string{}))
 	})
 }
+
+func TestValidateAddFieldRequest(t *testing.T) {
+	// Build a base schema with one int64 PK and one float vector field.
+	baseSchema := func() *schemapb.CollectionSchema {
+		return &schemapb.CollectionSchema{
+			Name: "test_coll",
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+				{
+					FieldID: 101, Name: "vec", DataType: schemapb.DataType_FloatVector,
+					TypeParams: []*commonpb.KeyValuePair{{Key: "dim", Value: "128"}},
+				},
+			},
+		}
+	}
+
+	t.Run("happy path", func(t *testing.T) {
+		schema := baseSchema()
+		newField := &schemapb.FieldSchema{
+			Name:     "new_field",
+			DataType: schemapb.DataType_Int64,
+			Nullable: true,
+		}
+		err := validateAddFieldRequest(schema, newField)
+		assert.NoError(t, err)
+	})
+
+	t.Run("field count exceeds MaxFieldNum", func(t *testing.T) {
+		schema := baseSchema()
+		// Build exactly MaxFieldNum fields so that the check triggers.
+		maxFieldNum := Params.ProxyCfg.MaxFieldNum.GetAsInt()
+		for i := len(schema.Fields); i < maxFieldNum; i++ {
+			schema.Fields = append(schema.Fields, &schemapb.FieldSchema{
+				FieldID:  int64(200 + i),
+				Name:     fmt.Sprintf("field_%d", i),
+				DataType: schemapb.DataType_Int64,
+			})
+		}
+		newField := &schemapb.FieldSchema{
+			Name:     "overflow_field",
+			DataType: schemapb.DataType_Int64,
+		}
+		err := validateAddFieldRequest(schema, newField)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("duplicate field name", func(t *testing.T) {
+		schema := baseSchema()
+		newField := &schemapb.FieldSchema{
+			Name:     "vec", // already exists
+			DataType: schemapb.DataType_Int64,
+		}
+		err := validateAddFieldRequest(schema, newField)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("invalid DataType_None", func(t *testing.T) {
+		schema := baseSchema()
+		newField := &schemapb.FieldSchema{
+			Name:     "invalid_type_field",
+			DataType: schemapb.DataType_None,
+		}
+		err := validateAddFieldRequest(schema, newField)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("system field name RowID", func(t *testing.T) {
+		schema := baseSchema()
+		newField := &schemapb.FieldSchema{
+			Name:     "RowID",
+			DataType: schemapb.DataType_Int64,
+		}
+		err := validateAddFieldRequest(schema, newField)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("is_primary_key = true", func(t *testing.T) {
+		schema := baseSchema()
+		newField := &schemapb.FieldSchema{
+			Name:         "new_pk",
+			DataType:     schemapb.DataType_Int64,
+			IsPrimaryKey: true,
+		}
+		err := validateAddFieldRequest(schema, newField)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("auto_id = true", func(t *testing.T) {
+		schema := baseSchema()
+		newField := &schemapb.FieldSchema{
+			Name:     "auto_field",
+			DataType: schemapb.DataType_Int64,
+			AutoID:   true,
+		}
+		err := validateAddFieldRequest(schema, newField)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("is_partition_key = true", func(t *testing.T) {
+		schema := baseSchema()
+		newField := &schemapb.FieldSchema{
+			Name:           "part_key",
+			DataType:       schemapb.DataType_Int64,
+			IsPartitionKey: true,
+		}
+		err := validateAddFieldRequest(schema, newField)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("clustering key when schema already has one", func(t *testing.T) {
+		schema := baseSchema()
+		// Mark an existing field as clustering key.
+		schema.Fields[0].IsClusteringKey = true
+		newField := &schemapb.FieldSchema{
+			Name:            "new_cluster",
+			DataType:        schemapb.DataType_Int64,
+			IsClusteringKey: true,
+		}
+		err := validateAddFieldRequest(schema, newField)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("vector type with max vector fields exceeded", func(t *testing.T) {
+		schema := baseSchema()
+		// Fill up vector fields to MaxVectorFieldNum.
+		maxVecFieldNum := Params.ProxyCfg.MaxVectorFieldNum.GetAsInt()
+		// schema already has one FloatVector; add more to reach the limit.
+		for i := 1; i < maxVecFieldNum; i++ {
+			schema.Fields = append(schema.Fields, &schemapb.FieldSchema{
+				FieldID:  int64(300 + i),
+				Name:     fmt.Sprintf("vec_%d", i),
+				DataType: schemapb.DataType_FloatVector,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: "dim", Value: "128"},
+				},
+			})
+		}
+		newVecField := &schemapb.FieldSchema{
+			Name:     "extra_vec",
+			DataType: schemapb.DataType_FloatVector,
+			TypeParams: []*commonpb.KeyValuePair{
+				{Key: "dim", Value: "128"},
+			},
+		}
+		err := validateAddFieldRequest(schema, newVecField)
+		assert.Error(t, err)
+	})
+}
+
+func TestAlterCollectionSchemaTask(t *testing.T) {
+	rc := NewMixCoordMock()
+	ctx := context.Background()
+	prefix := "TestAlterCollectionSchemaTask"
+	dbName := ""
+	collectionName := prefix + funcutil.GenRandomStr()
+	collectionID := int64(1)
+
+	rc.collName2ID[collectionName] = collectionID
+	rc.collID2Meta[collectionID] = collectionMeta{
+		name: collectionName,
+		id:   collectionID,
+		schema: &schemapb.CollectionSchema{
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, DataType: schemapb.DataType_Int64, AutoID: true, Name: "ID", IsPrimaryKey: true},
+				{
+					FieldID: 101, DataType: schemapb.DataType_VarChar, Name: "text",
+					TypeParams: []*commonpb.KeyValuePair{
+						{Key: "max_length", Value: "65535"},
+					},
+				},
+			},
+		},
+	}
+
+	// oldSchema matches the collection: has a varchar field "text" used as BM25 input.
+	oldSchema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, DataType: schemapb.DataType_Int64, AutoID: true, Name: "ID", IsPrimaryKey: true},
+			{
+				FieldID: 101, DataType: schemapb.DataType_VarChar, Name: "text",
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: "max_length", Value: "65535"},
+					{Key: "enable_analyzer", Value: "true"},
+				},
+			},
+		},
+	}
+
+	// sparseOutputField is the output field for the BM25 function.
+	sparseOutputField := &schemapb.FieldSchema{
+		Name:     "sparse_bm25",
+		DataType: schemapb.DataType_SparseFloatVector,
+	}
+
+	// BM25 function schema: input "text", output "sparse_bm25".
+	functionSchema := &schemapb.FunctionSchema{
+		Name:             "bm25_func",
+		Type:             schemapb.FunctionType_BM25,
+		InputFieldNames:  []string{"text"},
+		OutputFieldNames: []string{"sparse_bm25"},
+	}
+
+	buildValidRequest := func() *milvuspb.AlterCollectionSchemaRequest {
+		return &milvuspb.AlterCollectionSchemaRequest{
+			DbName:         dbName,
+			CollectionName: collectionName,
+			Action: &milvuspb.AlterCollectionSchemaRequest_Action{
+				Op: &milvuspb.AlterCollectionSchemaRequest_Action_AddRequest{
+					AddRequest: &milvuspb.AlterCollectionSchemaRequest_AddRequest{
+						FieldInfos: []*milvuspb.AlterCollectionSchemaRequest_FieldInfo{
+							{FieldSchema: sparseOutputField},
+						},
+						FuncSchema: []*schemapb.FunctionSchema{functionSchema},
+					},
+				},
+			},
+		}
+	}
+
+	buildTask := func(req *milvuspb.AlterCollectionSchemaRequest, schema *schemapb.CollectionSchema) *alterCollectionSchemaTask {
+		return &alterCollectionSchemaTask{
+			Condition:                     NewTaskCondition(ctx),
+			AlterCollectionSchemaRequest:  req,
+			AlterCollectionSchemaResponse: nil,
+			ctx:                           ctx,
+			mixCoord:                      rc,
+			oldSchema:                     schema,
+		}
+	}
+
+	t.Run("OnEnqueue", func(t *testing.T) {
+		task := buildTask(buildValidRequest(), oldSchema)
+		err := task.OnEnqueue()
+		assert.NoError(t, err)
+		assert.Equal(t, commonpb.MsgType_AlterCollectionSchema, task.Type())
+	})
+
+	t.Run("ctx", func(t *testing.T) {
+		task := buildTask(buildValidRequest(), oldSchema)
+		assert.NotNil(t, task.TraceCtx())
+	})
+
+	t.Run("id", func(t *testing.T) {
+		task := buildTask(buildValidRequest(), oldSchema)
+		_ = task.OnEnqueue()
+		id := UniqueID(uniquegenerator.GetUniqueIntGeneratorIns().GetInt())
+		task.SetID(id)
+		assert.Equal(t, id, task.ID())
+	})
+
+	t.Run("name", func(t *testing.T) {
+		task := buildTask(buildValidRequest(), oldSchema)
+		assert.Equal(t, AlterCollectionSchemaTaskName, task.Name())
+	})
+
+	t.Run("ts", func(t *testing.T) {
+		task := buildTask(buildValidRequest(), oldSchema)
+		_ = task.OnEnqueue()
+		ts := Timestamp(time.Now().UnixNano())
+		task.SetTs(ts)
+		assert.Equal(t, ts, task.BeginTs())
+		assert.Equal(t, ts, task.EndTs())
+	})
+
+	t.Run("PostExecute", func(t *testing.T) {
+		task := buildTask(buildValidRequest(), oldSchema)
+		assert.NoError(t, task.PostExecute(ctx))
+	})
+
+	t.Run("PreExecute nil oldSchema", func(t *testing.T) {
+		task := buildTask(buildValidRequest(), nil)
+		err := task.PreExecute(ctx)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("PreExecute nil action", func(t *testing.T) {
+		req := &milvuspb.AlterCollectionSchemaRequest{
+			DbName:         dbName,
+			CollectionName: collectionName,
+			Action:         nil,
+		}
+		task := buildTask(req, oldSchema)
+		err := task.PreExecute(ctx)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("PreExecute nil addRequest", func(t *testing.T) {
+		// Action is set but Op is not AddRequest (use nil oneof).
+		req := &milvuspb.AlterCollectionSchemaRequest{
+			DbName:         dbName,
+			CollectionName: collectionName,
+			Action:         &milvuspb.AlterCollectionSchemaRequest_Action{
+				// Op is nil — GetAddRequest() returns nil.
+			},
+		}
+		task := buildTask(req, oldSchema)
+		err := task.PreExecute(ctx)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("PreExecute zero funcSchemas", func(t *testing.T) {
+		req := &milvuspb.AlterCollectionSchemaRequest{
+			DbName:         dbName,
+			CollectionName: collectionName,
+			Action: &milvuspb.AlterCollectionSchemaRequest_Action{
+				Op: &milvuspb.AlterCollectionSchemaRequest_Action_AddRequest{
+					AddRequest: &milvuspb.AlterCollectionSchemaRequest_AddRequest{
+						FieldInfos: []*milvuspb.AlterCollectionSchemaRequest_FieldInfo{
+							{FieldSchema: sparseOutputField},
+						},
+						FuncSchema: nil, // no functions
+					},
+				},
+			},
+		}
+		task := buildTask(req, oldSchema)
+		err := task.PreExecute(ctx)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("PreExecute multiple funcSchemas", func(t *testing.T) {
+		req := &milvuspb.AlterCollectionSchemaRequest{
+			DbName:         dbName,
+			CollectionName: collectionName,
+			Action: &milvuspb.AlterCollectionSchemaRequest_Action{
+				Op: &milvuspb.AlterCollectionSchemaRequest_Action_AddRequest{
+					AddRequest: &milvuspb.AlterCollectionSchemaRequest_AddRequest{
+						FieldInfos: []*milvuspb.AlterCollectionSchemaRequest_FieldInfo{
+							{FieldSchema: sparseOutputField},
+						},
+						FuncSchema: []*schemapb.FunctionSchema{functionSchema, functionSchema}, // two functions
+					},
+				},
+			},
+		}
+		task := buildTask(req, oldSchema)
+		err := task.PreExecute(ctx)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("PreExecute empty fieldInfos", func(t *testing.T) {
+		req := &milvuspb.AlterCollectionSchemaRequest{
+			DbName:         dbName,
+			CollectionName: collectionName,
+			Action: &milvuspb.AlterCollectionSchemaRequest_Action{
+				Op: &milvuspb.AlterCollectionSchemaRequest_Action_AddRequest{
+					AddRequest: &milvuspb.AlterCollectionSchemaRequest_AddRequest{
+						FieldInfos: nil, // empty
+						FuncSchema: []*schemapb.FunctionSchema{functionSchema},
+					},
+				},
+			},
+		}
+		task := buildTask(req, oldSchema)
+		err := task.PreExecute(ctx)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("PreExecute multiple fieldInfos", func(t *testing.T) {
+		req := &milvuspb.AlterCollectionSchemaRequest{
+			DbName:         dbName,
+			CollectionName: collectionName,
+			Action: &milvuspb.AlterCollectionSchemaRequest_Action{
+				Op: &milvuspb.AlterCollectionSchemaRequest_Action_AddRequest{
+					AddRequest: &milvuspb.AlterCollectionSchemaRequest_AddRequest{
+						FieldInfos: []*milvuspb.AlterCollectionSchemaRequest_FieldInfo{
+							{FieldSchema: sparseOutputField},
+							{FieldSchema: &schemapb.FieldSchema{Name: "extra", DataType: schemapb.DataType_Int64}},
+						},
+						FuncSchema: []*schemapb.FunctionSchema{functionSchema},
+					},
+				},
+			},
+		}
+		task := buildTask(req, oldSchema)
+		err := task.PreExecute(ctx)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("PreExecute nil fieldSchema in fieldInfo", func(t *testing.T) {
+		req := &milvuspb.AlterCollectionSchemaRequest{
+			DbName:         dbName,
+			CollectionName: collectionName,
+			Action: &milvuspb.AlterCollectionSchemaRequest_Action{
+				Op: &milvuspb.AlterCollectionSchemaRequest_Action_AddRequest{
+					AddRequest: &milvuspb.AlterCollectionSchemaRequest_AddRequest{
+						FieldInfos: []*milvuspb.AlterCollectionSchemaRequest_FieldInfo{
+							{FieldSchema: nil}, // nil inner schema
+						},
+						FuncSchema: []*schemapb.FunctionSchema{functionSchema},
+					},
+				},
+			},
+		}
+		task := buildTask(req, oldSchema)
+		err := task.PreExecute(ctx)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("PreExecute output field points to existing field", func(t *testing.T) {
+		// OutputFieldNames must only reference newly-added fields, not pre-existing ones.
+		// "text" is already in oldSchema; pointing function output to it must be rejected.
+		req := &milvuspb.AlterCollectionSchemaRequest{
+			DbName:         dbName,
+			CollectionName: collectionName,
+			Action: &milvuspb.AlterCollectionSchemaRequest_Action{
+				Op: &milvuspb.AlterCollectionSchemaRequest_Action_AddRequest{
+					AddRequest: &milvuspb.AlterCollectionSchemaRequest_AddRequest{
+						FieldInfos: []*milvuspb.AlterCollectionSchemaRequest_FieldInfo{
+							{FieldSchema: sparseOutputField},
+						},
+						FuncSchema: []*schemapb.FunctionSchema{
+							{
+								Name:             "bm25_func",
+								Type:             schemapb.FunctionType_BM25,
+								InputFieldNames:  []string{"text"},
+								OutputFieldNames: []string{"text"}, // "text" exists in oldSchema — must be rejected
+							},
+						},
+					},
+				},
+			},
+		}
+		task := buildTask(req, oldSchema)
+		err := task.PreExecute(ctx)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("PreExecute happy path", func(t *testing.T) {
+		task := buildTask(buildValidRequest(), oldSchema)
+		err := task.PreExecute(ctx)
+		assert.NoError(t, err)
+	})
+
+	t.Run("Execute sets IsFunctionOutput and calls AlterCollectionSchema", func(t *testing.T) {
+		req := buildValidRequest()
+		task := buildTask(req, oldSchema)
+
+		// Ensure PreExecute passes first.
+		err := task.PreExecute(ctx)
+		assert.NoError(t, err)
+
+		err = task.Execute(ctx)
+		assert.NoError(t, err)
+
+		// After Execute, the output field should have IsFunctionOutput = true.
+		addReq := req.GetAction().GetAddRequest()
+		assert.NotNil(t, addReq)
+		for _, fi := range addReq.GetFieldInfos() {
+			assert.True(t, fi.GetFieldSchema().GetIsFunctionOutput())
+		}
+	})
+
+	t.Run("Execute returns error when mixCoord AlterCollectionSchema fails", func(t *testing.T) {
+		mockey.PatchConvey("mixCoord returns error status", t, func() {
+			mockey.Mock((*MixCoordMock).AlterCollectionSchema).Return(
+				&milvuspb.AlterCollectionSchemaResponse{
+					AlterStatus: merr.Status(merr.ErrServiceUnavailable),
+				}, nil,
+			).Build()
+
+			req := buildValidRequest()
+			task := buildTask(req, oldSchema)
+			err := task.PreExecute(ctx)
+			assert.NoError(t, err)
+
+			err = task.Execute(ctx)
+			assert.Error(t, err)
+		})
+	})
+}

--- a/internal/rootcoord/broker.go
+++ b/internal/rootcoord/broker.go
@@ -257,13 +257,15 @@ func (b *ServerBroker) BroadcastAlteredCollection(ctx context.Context, collectio
 	dcReq := &datapb.AlterCollectionRequest{
 		CollectionID: collectionID,
 		Schema: &schemapb.CollectionSchema{
-			Name:              colMeta.Name,
-			Description:       colMeta.Description,
-			AutoID:            colMeta.AutoID,
-			Fields:            model.MarshalFieldModels(colMeta.Fields),
-			StructArrayFields: model.MarshalStructArrayFieldModels(colMeta.StructArrayFields),
-			Functions:         model.MarshalFunctionModels(colMeta.Functions),
-			Properties:        colMeta.Properties,
+			Name:               colMeta.Name,
+			Description:        colMeta.Description,
+			AutoID:             colMeta.AutoID,
+			Fields:             model.MarshalFieldModels(colMeta.Fields),
+			StructArrayFields:  model.MarshalStructArrayFieldModels(colMeta.StructArrayFields),
+			Functions:          model.MarshalFunctionModels(colMeta.Functions),
+			Properties:         colMeta.Properties,
+			Version:            colMeta.SchemaVersion,
+			DoPhysicalBackfill: colMeta.DoPhysicalBackfill,
 		},
 		PartitionIDs:   partitionIDs,
 		StartPositions: colMeta.StartPositions,
@@ -271,7 +273,6 @@ func (b *ServerBroker) BroadcastAlteredCollection(ctx context.Context, collectio
 		DbID:           db.ID,
 		VChannels:      colMeta.VirtualChannelNames,
 	}
-
 	resp, err := b.s.mixCoord.BroadcastAlteredCollection(ctx, dcReq)
 	if err != nil {
 		return err
@@ -280,7 +281,10 @@ func (b *ServerBroker) BroadcastAlteredCollection(ctx context.Context, collectio
 	if resp.ErrorCode != commonpb.ErrorCode_Success {
 		return errors.New(resp.Reason)
 	}
-	log.Ctx(ctx).Info("done to broadcast request to alter collection", zap.String("collectionName", colMeta.Name), zap.Int64("collectionID", collectionID), zap.Any("props", colMeta.Properties), zap.Any("field", colMeta.Fields))
+	log.Ctx(ctx).Info("done to broadcast request to alter collection",
+		zap.String("collectionName", colMeta.Name), zap.Int64("collectionID", dcReq.GetCollectionID()),
+		zap.Any("props", colMeta.Properties), zap.Any("fields", colMeta.Fields),
+		zap.Int32("schemaVersion", colMeta.SchemaVersion), zap.Bool("doPhysicalBackfill", colMeta.DoPhysicalBackfill))
 	return nil
 }
 

--- a/internal/rootcoord/ddl_callbacks_alter_collection_schema.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_schema.go
@@ -1,0 +1,184 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rootcoord
+
+import (
+	"context"
+
+	"github.com/cockroachdb/errors"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/distributed/streaming"
+	"github.com/milvus-io/milvus/internal/metastore/model"
+	"github.com/milvus-io/milvus/pkg/v2/proto/messagespb"
+	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
+)
+
+// broadcastAlterCollectionSchema broadcasts the alter collection schema message to all channels.
+func (c *Core) broadcastAlterCollectionSchema(ctx context.Context, req *milvuspb.AlterCollectionSchemaRequest) error {
+	broadcaster, err := c.startBroadcastWithAliasOrCollectionLock(ctx, req.GetDbName(), req.GetCollectionName())
+	if err != nil {
+		return err
+	}
+	defer broadcaster.Close()
+	coll, err := c.meta.GetCollectionByName(ctx, req.GetDbName(), req.GetCollectionName(), typeutil.MaxTimestamp)
+	if err != nil {
+		return err
+	}
+
+	// 1. check if the request is valid.
+	action := req.GetAction()
+	if action == nil {
+		return merr.WrapErrParameterInvalidMsg("action is nil")
+	}
+	addRequest := action.GetAddRequest()
+	if addRequest == nil {
+		return merr.WrapErrParameterInvalidMsg("add_request is nil, only add operation is supported for now")
+	}
+
+	fieldInfos := addRequest.GetFieldInfos()
+	funcSchemas := addRequest.GetFuncSchema()
+	if len(funcSchemas) != 1 || funcSchemas[0] == nil {
+		return merr.WrapErrParameterInvalidMsg("For now, exactly one function schema is supported in alter schema task")
+	}
+	functionSchema := funcSchemas[0]
+
+	if len(fieldInfos) == 0 {
+		return merr.WrapErrParameterInvalidMsg("fieldInfos is empty")
+	}
+
+	// 2. check if the field schemas are illegal.
+	fieldSchemas := make([]*schemapb.FieldSchema, 0, len(fieldInfos))
+	for _, fieldInfo := range fieldInfos {
+		fieldSchema := fieldInfo.GetFieldSchema()
+		if fieldSchema == nil {
+			return merr.WrapErrParameterInvalidMsg("fieldSchema is nil in fieldInfos")
+		}
+		fieldSchemas = append(fieldSchemas, fieldSchema)
+	}
+	if err := checkFieldSchema(fieldSchemas); err != nil {
+		return errors.Wrap(err, "failed to check field schema")
+	}
+
+	// 3. check if the fields already exist
+	fieldNameSet := make(map[string]struct{})
+	for _, field := range coll.Fields {
+		fieldNameSet[field.Name] = struct{}{}
+	}
+	for _, fieldSchema := range fieldSchemas {
+		if _, ok := fieldNameSet[fieldSchema.GetName()]; ok {
+			return merr.WrapErrParameterInvalidMsg("field already exists, name: %s", fieldSchema.GetName())
+		}
+		fieldNameSet[fieldSchema.Name] = struct{}{}
+	}
+
+	// 4. check if the function already exists
+	for _, function := range coll.Functions {
+		if function.Name == functionSchema.GetName() {
+			return merr.WrapErrParameterInvalidMsg("function already exists, name: %s", functionSchema.GetName())
+		}
+	}
+
+	// 5. assign new field and function ids.
+	fieldIDStart := nextFieldID(coll)
+	for i, fieldSchema := range fieldSchemas {
+		fieldSchema.FieldID = fieldIDStart + int64(i)
+	}
+	functionSchema.Id = nextFunctionID(coll)
+	name2id := make(map[string]int64)
+	for _, field := range coll.Fields {
+		name2id[field.Name] = field.FieldID
+	}
+	for _, fieldSchema := range fieldSchemas {
+		name2id[fieldSchema.Name] = fieldSchema.FieldID
+	}
+
+	functionSchema.InputFieldIds = make([]int64, len(functionSchema.InputFieldNames))
+	for idx, name := range functionSchema.InputFieldNames {
+		fieldID, ok := name2id[name]
+		if !ok {
+			return merr.WrapErrParameterInvalidMsg("input field %s of function %s not found", name, functionSchema.GetName())
+		}
+		functionSchema.InputFieldIds[idx] = fieldID
+	}
+
+	functionSchema.OutputFieldIds = make([]int64, len(functionSchema.OutputFieldNames))
+	for idx, name := range functionSchema.OutputFieldNames {
+		fieldID, ok := name2id[name]
+		if !ok {
+			return merr.WrapErrParameterInvalidMsg("output field %s of function %s not found", name, functionSchema.GetName())
+		}
+		functionSchema.OutputFieldIds[idx] = fieldID
+	}
+
+	// 6. build new collection schema.
+	schema := &schemapb.CollectionSchema{
+		Name:               coll.Name,
+		Description:        coll.Description,
+		AutoID:             coll.AutoID,
+		Fields:             model.MarshalFieldModels(coll.Fields),
+		StructArrayFields:  model.MarshalStructArrayFieldModels(coll.StructArrayFields),
+		Functions:          model.MarshalFunctionModels(coll.Functions),
+		EnableDynamicField: coll.EnableDynamicField,
+		Properties:         coll.Properties,
+		DbName:             coll.DBName,
+		FileResourceIds:    coll.FileResourceIds,
+		// Version is incremented by 1. No CAS is needed here because Proxy's
+		// checkSchemaVersionConsistency gate blocks new AlterCollectionSchema calls
+		// until the previous backfill reaches 100% consistency, and DDL requests
+		// are serialized through a single DDL queue — so concurrent schema changes
+		// that could produce duplicate version numbers are impossible.
+		Version:            coll.SchemaVersion + 1,
+		DoPhysicalBackfill: addRequest.GetDoPhysicalBackfill(),
+	}
+	schema.Fields = append(schema.Fields, fieldSchemas...)
+	schema.Functions = append(schema.Functions, functionSchema)
+
+	// 7. get cache expirations.
+	cacheExpirations, err := c.getCacheExpireForCollection(ctx, req.GetDbName(), req.GetCollectionName())
+	if err != nil {
+		return err
+	}
+
+	channels := make([]string, 0, len(coll.VirtualChannelNames)+1)
+	channels = append(channels, streaming.WAL().ControlChannel())
+	channels = append(channels, coll.VirtualChannelNames...)
+	msg := message.NewAlterCollectionMessageBuilderV2().
+		WithHeader(&messagespb.AlterCollectionMessageHeader{
+			DbId:         coll.DBID,
+			CollectionId: coll.CollectionID,
+			UpdateMask: &fieldmaskpb.FieldMask{
+				Paths: []string{message.FieldMaskCollectionSchema},
+			},
+			CacheExpirations: cacheExpirations,
+		}).
+		WithBody(&messagespb.AlterCollectionMessageBody{
+			Updates: &messagespb.AlterCollectionMessageUpdates{
+				Schema: schema,
+			},
+		}).
+		WithBroadcast(channels).
+		MustBuildBroadcast()
+	if _, err := broadcaster.Broadcast(ctx, msg); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/rootcoord/ddl_callbacks_alter_collection_schema_test.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_schema_test.go
@@ -1,0 +1,247 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rootcoord
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/pkg/v2/common"
+	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+)
+
+// buildAlterSchemaReq constructs a valid AlterCollectionSchemaRequest with an add operation.
+func buildAlterSchemaReq(dbName, collName, inputField, outputField, funcName string, doBackfill bool) *milvuspb.AlterCollectionSchemaRequest {
+	outputFieldSchema := &schemapb.FieldSchema{
+		Name:             outputField,
+		DataType:         schemapb.DataType_SparseFloatVector,
+		IsFunctionOutput: true,
+	}
+	functionSchema := &schemapb.FunctionSchema{
+		Name:             funcName,
+		Type:             schemapb.FunctionType_BM25,
+		InputFieldNames:  []string{inputField},
+		OutputFieldNames: []string{outputField},
+	}
+	return &milvuspb.AlterCollectionSchemaRequest{
+		DbName:         dbName,
+		CollectionName: collName,
+		Action: &milvuspb.AlterCollectionSchemaRequest_Action{
+			Op: &milvuspb.AlterCollectionSchemaRequest_Action_AddRequest{
+				AddRequest: &milvuspb.AlterCollectionSchemaRequest_AddRequest{
+					FieldInfos: []*milvuspb.AlterCollectionSchemaRequest_FieldInfo{
+						{FieldSchema: outputFieldSchema},
+					},
+					FuncSchema:         []*schemapb.FunctionSchema{functionSchema},
+					DoPhysicalBackfill: doBackfill,
+				},
+			},
+		},
+	}
+}
+
+func TestDDLCallbacksBroadcastAlterCollectionSchema(t *testing.T) {
+	core := initStreamingSystemAndCore(t)
+
+	ctx := context.Background()
+	dbName := "testDB" + funcutil.RandomString(10)
+	collectionName := "testCollection" + funcutil.RandomString(10)
+
+	createCollectionForTest(t, ctx, core, dbName, collectionName)
+	assertSchemaVersion(t, ctx, core, dbName, collectionName, 0)
+
+	// case 1: action == nil
+	resp, err := core.AlterCollectionSchema(ctx, &milvuspb.AlterCollectionSchemaRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		Action:         nil,
+	})
+	require.ErrorIs(t, merr.CheckRPCCall(resp.GetAlterStatus(), err), merr.ErrParameterInvalid)
+
+	// case 2: add_request == nil (action present but no Op set)
+	resp, err = core.AlterCollectionSchema(ctx, &milvuspb.AlterCollectionSchemaRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		Action:         &milvuspb.AlterCollectionSchemaRequest_Action{},
+	})
+	require.ErrorIs(t, merr.CheckRPCCall(resp.GetAlterStatus(), err), merr.ErrParameterInvalid)
+
+	// case 3: funcSchemas empty (len != 1)
+	resp, err = core.AlterCollectionSchema(ctx, &milvuspb.AlterCollectionSchemaRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		Action: &milvuspb.AlterCollectionSchemaRequest_Action{
+			Op: &milvuspb.AlterCollectionSchemaRequest_Action_AddRequest{
+				AddRequest: &milvuspb.AlterCollectionSchemaRequest_AddRequest{
+					FuncSchema: []*schemapb.FunctionSchema{},
+					FieldInfos: []*milvuspb.AlterCollectionSchemaRequest_FieldInfo{
+						{FieldSchema: &schemapb.FieldSchema{Name: "sparse1", DataType: schemapb.DataType_SparseFloatVector}},
+					},
+				},
+			},
+		},
+	})
+	require.ErrorIs(t, merr.CheckRPCCall(resp.GetAlterStatus(), err), merr.ErrParameterInvalid)
+
+	// case 4: fieldInfos empty
+	resp, err = core.AlterCollectionSchema(ctx, &milvuspb.AlterCollectionSchemaRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		Action: &milvuspb.AlterCollectionSchemaRequest_Action{
+			Op: &milvuspb.AlterCollectionSchemaRequest_Action_AddRequest{
+				AddRequest: &milvuspb.AlterCollectionSchemaRequest_AddRequest{
+					FuncSchema: []*schemapb.FunctionSchema{
+						{Name: "fn1", Type: schemapb.FunctionType_BM25},
+					},
+					FieldInfos: []*milvuspb.AlterCollectionSchemaRequest_FieldInfo{},
+				},
+			},
+		},
+	})
+	require.ErrorIs(t, merr.CheckRPCCall(resp.GetAlterStatus(), err), merr.ErrParameterInvalid)
+
+	// case 5: fieldSchema nil in fieldInfos
+	resp, err = core.AlterCollectionSchema(ctx, &milvuspb.AlterCollectionSchemaRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		Action: &milvuspb.AlterCollectionSchemaRequest_Action{
+			Op: &milvuspb.AlterCollectionSchemaRequest_Action_AddRequest{
+				AddRequest: &milvuspb.AlterCollectionSchemaRequest_AddRequest{
+					FuncSchema: []*schemapb.FunctionSchema{
+						{Name: "fn1", Type: schemapb.FunctionType_BM25},
+					},
+					FieldInfos: []*milvuspb.AlterCollectionSchemaRequest_FieldInfo{
+						{FieldSchema: nil},
+					},
+				},
+			},
+		},
+	})
+	require.ErrorIs(t, merr.CheckRPCCall(resp.GetAlterStatus(), err), merr.ErrParameterInvalid)
+
+	// case 6: output field already exists (field1 created by createCollectionForTest)
+	resp, err = core.AlterCollectionSchema(ctx, &milvuspb.AlterCollectionSchemaRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		Action: &milvuspb.AlterCollectionSchemaRequest_Action{
+			Op: &milvuspb.AlterCollectionSchemaRequest_Action_AddRequest{
+				AddRequest: &milvuspb.AlterCollectionSchemaRequest_AddRequest{
+					FuncSchema: []*schemapb.FunctionSchema{
+						{Name: "fn_dup_field", Type: schemapb.FunctionType_BM25, InputFieldNames: []string{"field1"}, OutputFieldNames: []string{"field1"}},
+					},
+					FieldInfos: []*milvuspb.AlterCollectionSchemaRequest_FieldInfo{
+						{FieldSchema: &schemapb.FieldSchema{Name: "field1", DataType: schemapb.DataType_SparseFloatVector}},
+					},
+				},
+			},
+		},
+	})
+	require.ErrorIs(t, merr.CheckRPCCall(resp.GetAlterStatus(), err), merr.ErrParameterInvalid)
+
+	// Add a VARCHAR input field so that the happy-path call below can succeed.
+	varcharFieldSchema := &schemapb.FieldSchema{
+		Name:     "text_input",
+		DataType: schemapb.DataType_VarChar,
+		TypeParams: []*commonpb.KeyValuePair{
+			{Key: common.MaxLengthKey, Value: "256"},
+		},
+	}
+	varcharBytes, err := proto.Marshal(varcharFieldSchema)
+	require.NoError(t, err)
+	addFieldResp, err := core.AddCollectionField(ctx, &milvuspb.AddCollectionFieldRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		Schema:         varcharBytes,
+	})
+	require.NoError(t, merr.CheckRPCCall(addFieldResp, err))
+
+	// happy path: add sparse vector output field + BM25 function → schema version bumps (AddCollectionField already bumped to 1, so now 2)
+	firstAlterReq := buildAlterSchemaReq(dbName, collectionName, "text_input", "sparse_output", "bm25_fn", false)
+	resp, err = core.AlterCollectionSchema(ctx, firstAlterReq)
+	require.NoError(t, merr.CheckRPCCall(resp.GetAlterStatus(), err))
+	assertSchemaVersion(t, ctx, core, dbName, collectionName, 2)
+
+	// happy path with DoPhysicalBackfill=true: flag propagates through broadcast, schema version bumps to 3
+	secondAlterReq := buildAlterSchemaReq(dbName, collectionName, "text_input", "sparse_output2", "bm25_fn2", true)
+	resp, err = core.AlterCollectionSchema(ctx, secondAlterReq)
+	require.NoError(t, merr.CheckRPCCall(resp.GetAlterStatus(), err))
+	assertSchemaVersion(t, ctx, core, dbName, collectionName, 3)
+
+	// case 7: function already exists (same name "bm25_fn")
+	resp, err = core.AlterCollectionSchema(ctx, &milvuspb.AlterCollectionSchemaRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		Action: &milvuspb.AlterCollectionSchemaRequest_Action{
+			Op: &milvuspb.AlterCollectionSchemaRequest_Action_AddRequest{
+				AddRequest: &milvuspb.AlterCollectionSchemaRequest_AddRequest{
+					FuncSchema: []*schemapb.FunctionSchema{
+						{Name: "bm25_fn", Type: schemapb.FunctionType_BM25, InputFieldNames: []string{"text_input"}, OutputFieldNames: []string{"sparse_output2"}},
+					},
+					FieldInfos: []*milvuspb.AlterCollectionSchemaRequest_FieldInfo{
+						{FieldSchema: &schemapb.FieldSchema{Name: "sparse_output2", DataType: schemapb.DataType_SparseFloatVector, IsFunctionOutput: true}},
+					},
+				},
+			},
+		},
+	})
+	require.ErrorIs(t, merr.CheckRPCCall(resp.GetAlterStatus(), err), merr.ErrParameterInvalid)
+
+	// case 8: input field not found
+	resp, err = core.AlterCollectionSchema(ctx, &milvuspb.AlterCollectionSchemaRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		Action: &milvuspb.AlterCollectionSchemaRequest_Action{
+			Op: &milvuspb.AlterCollectionSchemaRequest_Action_AddRequest{
+				AddRequest: &milvuspb.AlterCollectionSchemaRequest_AddRequest{
+					FuncSchema: []*schemapb.FunctionSchema{
+						{Name: "fn_missing_input", Type: schemapb.FunctionType_BM25, InputFieldNames: []string{"nonexistent_input"}, OutputFieldNames: []string{"sparse_output3"}},
+					},
+					FieldInfos: []*milvuspb.AlterCollectionSchemaRequest_FieldInfo{
+						{FieldSchema: &schemapb.FieldSchema{Name: "sparse_output3", DataType: schemapb.DataType_SparseFloatVector, IsFunctionOutput: true}},
+					},
+				},
+			},
+		},
+	})
+	require.Error(t, merr.CheckRPCCall(resp.GetAlterStatus(), err))
+
+	// case 9: output field not found (function references "ghost_output" but FieldInfos has "sparse_output4")
+	resp, err = core.AlterCollectionSchema(ctx, &milvuspb.AlterCollectionSchemaRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		Action: &milvuspb.AlterCollectionSchemaRequest_Action{
+			Op: &milvuspb.AlterCollectionSchemaRequest_Action_AddRequest{
+				AddRequest: &milvuspb.AlterCollectionSchemaRequest_AddRequest{
+					FuncSchema: []*schemapb.FunctionSchema{
+						{Name: "fn_missing_output", Type: schemapb.FunctionType_BM25, InputFieldNames: []string{"text_input"}, OutputFieldNames: []string{"ghost_output"}},
+					},
+					FieldInfos: []*milvuspb.AlterCollectionSchemaRequest_FieldInfo{
+						{FieldSchema: &schemapb.FieldSchema{Name: "sparse_output4", DataType: schemapb.DataType_SparseFloatVector, IsFunctionOutput: true}},
+					},
+				},
+			},
+		},
+	})
+	require.Error(t, merr.CheckRPCCall(resp.GetAlterStatus(), err))
+}

--- a/internal/rootcoord/meta_table.go
+++ b/internal/rootcoord/meta_table.go
@@ -729,7 +729,7 @@ func (mt *MetaTable) RemoveCollection(ctx context.Context, collectionID UniqueID
 
 // Note: The returned model.Collection is read-only. Do NOT modify it directly,
 // as it may cause unexpected behavior or inconsistencies.
-func filterUnavailable(coll *model.Collection) *model.Collection {
+func filterUnavailablePartition(coll *model.Collection) *model.Collection {
 	clone := coll.ShallowClone()
 	// pick available partitions.
 	clone.Partitions = make([]*model.Partition, 0, len(coll.Partitions))
@@ -756,7 +756,7 @@ func (mt *MetaTable) getLatestCollectionByIDInternal(ctx context.Context, collec
 	if !coll.Available() {
 		return nil, merr.WrapErrCollectionNotFound(collectionID)
 	}
-	return filterUnavailable(coll), nil
+	return filterUnavailablePartition(coll), nil
 }
 
 // getCollectionByIDInternal get collection by collection id without lock.
@@ -769,7 +769,16 @@ func (mt *MetaTable) getCollectionByIDInternal(ctx context.Context, dbName strin
 
 	var coll *model.Collection
 	coll, ok := mt.collID2Meta[collectionID]
-	if !ok || coll == nil || !coll.Available() || coll.CreateTime > ts {
+	// Use UpdateTimestamp (not CreateTime) for cache invalidation.
+	// This is a bug fix for time-travel correctness, not merely an enhancement for backfill:
+	// collID2Meta always holds the *latest* collection state.  After a schema alteration (e.g.
+	// AlterCollectionSchema), the in-memory entry has a schema that didn't exist at timestamps
+	// before the alteration.  The old code compared against CreateTime, so a time-travel query
+	// at T where CreateTime < T < AlterTime would incorrectly serve the altered schema from the
+	// in-memory cache instead of falling back to the catalog for the historical version.
+	// Comparing against UpdateTimestamp ensures the cache is bypassed for any ts that predates
+	// the last schema modification, fixing time-travel semantics for all schema-altering DDLs.
+	if !ok || coll == nil || !coll.Available() || coll.UpdateTimestamp > ts {
 		// travel meta information from catalog.
 		ctx1 := contextutil.WithTenantID(ctx, Params.CommonCfg.ClusterName.GetValue())
 		db, err := mt.getDatabaseByNameInternal(ctx, dbName, typeutil.MaxTimestamp)
@@ -796,7 +805,7 @@ func (mt *MetaTable) getCollectionByIDInternal(ctx context.Context, dbName strin
 		return nil, merr.WrapErrCollectionNotFound(dbName, coll.Name)
 	}
 
-	return filterUnavailable(coll), nil
+	return filterUnavailablePartition(coll), nil
 }
 
 func (mt *MetaTable) GetCollectionByName(ctx context.Context, dbName string, collectionName string, ts Timestamp) (*model.Collection, error) {
@@ -873,7 +882,7 @@ func (mt *MetaTable) getCollectionByNameInternal(ctx context.Context, dbName str
 	if coll == nil || !coll.Available() {
 		return nil, merr.WrapErrCollectionNotFoundWithDB(dbName, collectionName)
 	}
-	return filterUnavailable(coll), nil
+	return filterUnavailablePartition(coll), nil
 }
 
 func (mt *MetaTable) GetCollectionByID(ctx context.Context, dbName string, collectionID UniqueID, ts Timestamp, allowUnavailable bool) (*model.Collection, error) {
@@ -1019,7 +1028,6 @@ func (mt *MetaTable) AlterCollection(ctx context.Context, result message.Broadca
 		// collection not exists, return directly.
 		return errAlterCollectionNotFound
 	}
-
 	oldColl := coll.Clone()
 	newColl := coll.Clone()
 	newColl.ApplyUpdates(header, body)
@@ -1067,6 +1075,8 @@ func (mt *MetaTable) AlterCollection(ctx context.Context, result message.Broadca
 		zap.Int64("oldCollectionID", oldColl.CollectionID),
 		zap.Bool("dbChanged", dbChanged),
 		zap.Uint64("ts", newColl.UpdateTimestamp),
+		zap.Bool("doPhysicalBackfill", newColl.DoPhysicalBackfill),
+		zap.Int32("schemaVersion", newColl.SchemaVersion),
 	)
 	return nil
 }

--- a/internal/rootcoord/meta_table_test.go
+++ b/internal/rootcoord/meta_table_test.go
@@ -621,6 +621,79 @@ func TestMetaTable_getCollectionByIDInternal(t *testing.T) {
 		assert.Equal(t, UniqueID(11), coll.Partitions[0].PartitionID)
 		assert.Equal(t, Params.CommonCfg.DefaultPartitionName.GetValue(), coll.Partitions[0].PartitionName)
 	})
+
+	t.Run("UpdateTimestamp > ts triggers catalog fallback (time-travel correctness)", func(t *testing.T) {
+		// Regression test for the bug fix in getCollectionByIDInternal:
+		// cache invalidation was changed from CreateTime to UpdateTimestamp.
+		// Scenario: collection created at T=50, schema altered at T=100.
+		// A time-travel query at ts=80 (50 < 80 < 100) must NOT use the in-memory
+		// cache (which holds the post-alteration schema) — it must fall back to catalog.
+		catalog := mocks.NewRootCoordCatalog(t)
+		catalog.On("GetCollectionByID",
+			mock.Anything,
+			mock.Anything,
+			uint64(80),
+			int64(100),
+		).Return(&model.Collection{
+			State:           pb.CollectionState_CollectionCreated,
+			CreateTime:      50,
+			UpdateTimestamp: 100,
+			Partitions: []*model.Partition{
+				{PartitionID: 11, PartitionName: Params.CommonCfg.DefaultPartitionName.GetValue(), State: pb.PartitionState_PartitionCreated},
+			},
+		}, nil)
+
+		meta := &MetaTable{
+			catalog: catalog,
+			dbName2Meta: map[string]*model.Database{
+				util.DefaultDBName: model.NewDefaultDatabase(nil),
+			},
+			collID2Meta: map[typeutil.UniqueID]*model.Collection{
+				100: {
+					State:           pb.CollectionState_CollectionCreated,
+					CreateTime:      50,
+					UpdateTimestamp: 100, // schema was altered at T=100
+					Partitions: []*model.Partition{
+						{PartitionID: 11, PartitionName: Params.CommonCfg.DefaultPartitionName.GetValue(), State: pb.PartitionState_PartitionCreated},
+					},
+				},
+			},
+		}
+		ctx := context.Background()
+
+		// ts=80 is between CreateTime(50) and UpdateTimestamp(100):
+		// UpdateTimestamp(100) > ts(80) → cache bypass → catalog must be called.
+		coll, err := meta.getCollectionByIDInternal(ctx, util.DefaultDBName, 100, 80, false)
+		assert.NoError(t, err)
+		assert.NotNil(t, coll)
+		catalog.AssertCalled(t, "GetCollectionByID", mock.Anything, mock.Anything, uint64(80), int64(100))
+	})
+
+	t.Run("UpdateTimestamp <= ts uses in-memory cache (no catalog call)", func(t *testing.T) {
+		// ts=150 >= UpdateTimestamp(100) → the in-memory cache is fresh enough → no catalog call.
+		catalog := mocks.NewRootCoordCatalog(t)
+		// No expectations set — testify mock will fail if GetCollectionByID is called.
+
+		meta := &MetaTable{
+			catalog: catalog,
+			collID2Meta: map[typeutil.UniqueID]*model.Collection{
+				100: {
+					State:           pb.CollectionState_CollectionCreated,
+					CreateTime:      50,
+					UpdateTimestamp: 100,
+					Partitions: []*model.Partition{
+						{PartitionID: 11, PartitionName: Params.CommonCfg.DefaultPartitionName.GetValue(), State: pb.PartitionState_PartitionCreated},
+					},
+				},
+			},
+		}
+		ctx := context.Background()
+
+		coll, err := meta.getCollectionByIDInternal(ctx, "", 100, 150, false)
+		assert.NoError(t, err)
+		assert.NotNil(t, coll)
+		catalog.AssertNotCalled(t, "GetCollectionByID")
+	})
 }
 
 func TestMetaTable_GetCollectionByName(t *testing.T) {
@@ -1101,7 +1174,7 @@ func Test_filterUnavailable(t *testing.T) {
 		}
 		coll.Partitions = append(coll.Partitions, partition)
 	}
-	clone := filterUnavailable(coll)
+	clone := filterUnavailablePartition(coll)
 	assert.Equal(t, nAvailablePartition, len(clone.Partitions))
 	for _, p := range clone.Partitions {
 		assert.True(t, p.Available())

--- a/internal/rootcoord/root_coord.go
+++ b/internal/rootcoord/root_coord.go
@@ -1024,6 +1024,37 @@ func (c *Core) AddCollectionField(ctx context.Context, in *milvuspb.AddCollectio
 	return merr.Success(), nil
 }
 
+func (c *Core) AlterCollectionSchema(ctx context.Context, in *milvuspb.AlterCollectionSchemaRequest) (*milvuspb.AlterCollectionSchemaResponse, error) {
+	if err := merr.CheckHealthy(c.GetStateCode()); err != nil {
+		return &milvuspb.AlterCollectionSchemaResponse{
+			AlterStatus: merr.Status(err),
+		}, nil
+	}
+
+	metrics.RootCoordDDLReqCounter.WithLabelValues("AlterCollectionSchema", metrics.TotalLabel).Inc()
+	tr := timerecord.NewTimeRecorder("AlterCollectionSchema")
+
+	log := log.Ctx(ctx).With(zap.String("role", typeutil.RootCoordRole),
+		zap.String("dbName", in.GetDbName()),
+		zap.String("collectionName", in.GetCollectionName()))
+	log.Info("received request to add function field")
+
+	if err := c.broadcastAlterCollectionSchema(ctx, in); err != nil {
+		log.Info("failed to add function field", zap.Error(err))
+		metrics.RootCoordDDLReqCounter.WithLabelValues("AlterCollectionSchema", metrics.FailLabel).Inc()
+		return &milvuspb.AlterCollectionSchemaResponse{
+			AlterStatus: merr.Status(err),
+		}, nil
+	}
+
+	metrics.RootCoordDDLReqCounter.WithLabelValues("AlterCollectionSchema", metrics.SuccessLabel).Inc()
+	metrics.RootCoordDDLReqLatency.WithLabelValues("AlterCollectionSchema").Observe(float64(tr.ElapseSpan().Milliseconds()))
+	log.Info("done to alter collection schema")
+	return &milvuspb.AlterCollectionSchemaResponse{
+		AlterStatus: merr.Success(),
+	}, nil
+}
+
 // DropCollection drop collection
 func (c *Core) DropCollection(ctx context.Context, in *milvuspb.DropCollectionRequest) (*commonpb.Status, error) {
 	if err := merr.CheckHealthy(c.GetStateCode()); err != nil {
@@ -1172,6 +1203,8 @@ func convertModelToDesc(collInfo *model.Collection, aliases []string, dbName str
 		ExternalSource:     collInfo.ExternalSource,
 		ExternalSpec:       collInfo.ExternalSpec,
 		DbName:             dbName, // Use dbName parameter for consistency with resp.DbName
+		Version:            collInfo.SchemaVersion,
+		DoPhysicalBackfill: collInfo.DoPhysicalBackfill,
 	}
 	resp.CollectionID = collInfo.CollectionID
 	resp.VirtualChannelNames = collInfo.VirtualChannelNames
@@ -1538,29 +1571,6 @@ func (c *Core) AlterCollectionField(ctx context.Context, in *milvuspb.AlterColle
 	metrics.RootCoordDDLReqLatency.WithLabelValues("AlterCollectionField").Observe(float64(tr.ElapseSpan().Milliseconds()))
 	log.Info("done to alter collection field")
 	return merr.Success(), nil
-}
-
-func (c *Core) AlterCollectionSchema(ctx context.Context, in *milvuspb.AlterCollectionSchemaRequest) (*milvuspb.AlterCollectionSchemaResponse, error) {
-	if err := merr.CheckHealthy(c.GetStateCode()); err != nil {
-		return &milvuspb.AlterCollectionSchemaResponse{}, nil
-	}
-
-	metrics.RootCoordDDLReqCounter.WithLabelValues("AlterCollectionSchema", metrics.TotalLabel).Inc()
-	tr := timerecord.NewTimeRecorder("AlterCollectionSchema")
-
-	log := log.Ctx(ctx).With(zap.String("role", typeutil.RootCoordRole),
-		zap.String("dbName", in.GetDbName()),
-		zap.String("collectionName", in.GetCollectionName()),
-	)
-	log.Info("received request to alter collection schema")
-
-	// AlterCollectionSchema is currently a placeholder implementation
-	// The actual logic should handle schema alterations similar to AlterCollection
-	// For now, return success to satisfy the interface
-	metrics.RootCoordDDLReqCounter.WithLabelValues("AlterCollectionSchema", metrics.SuccessLabel).Inc()
-	metrics.RootCoordDDLReqLatency.WithLabelValues("AlterCollectionSchema").Observe(float64(tr.ElapseSpan().Milliseconds()))
-	log.Info("done to alter collection schema")
-	return &milvuspb.AlterCollectionSchemaResponse{}, nil
 }
 
 func (c *Core) AlterDatabase(ctx context.Context, in *rootcoordpb.AlterDatabaseRequest) (*commonpb.Status, error) {

--- a/internal/rootcoord/root_coord_test.go
+++ b/internal/rootcoord/root_coord_test.go
@@ -1447,6 +1447,38 @@ func TestRootCoord_AlterCollectionFunction(t *testing.T) {
 	})
 }
 
+func TestRootCoord_AlterCollectionSchema(t *testing.T) {
+	t.Run("not healthy", func(t *testing.T) {
+		ctx := context.Background()
+		c := newTestCore(withAbnormalCode())
+		resp, err := c.AlterCollectionSchema(ctx, &milvuspb.AlterCollectionSchemaRequest{})
+		assert.NoError(t, err)
+		assert.NotEqual(t, commonpb.ErrorCode_Success, resp.GetAlterStatus().GetErrorCode())
+	})
+
+	t.Run("run ok", func(t *testing.T) {
+		ctx := context.Background()
+		c := initStreamingSystemAndCore(t)
+		defer c.Stop()
+		mocker := mockey.Mock((*Core).broadcastAlterCollectionSchema).Return(nil).Build()
+		defer mocker.UnPatch()
+		resp, err := c.AlterCollectionSchema(ctx, &milvuspb.AlterCollectionSchemaRequest{})
+		assert.NoError(t, err)
+		assert.Equal(t, commonpb.ErrorCode_Success, resp.GetAlterStatus().GetErrorCode())
+	})
+
+	t.Run("run failed", func(t *testing.T) {
+		ctx := context.Background()
+		c := initStreamingSystemAndCore(t)
+		defer c.Stop()
+		mocker := mockey.Mock((*Core).broadcastAlterCollectionSchema).Return(fmt.Errorf("mock broadcast error")).Build()
+		defer mocker.UnPatch()
+		resp, err := c.AlterCollectionSchema(ctx, &milvuspb.AlterCollectionSchemaRequest{})
+		assert.NoError(t, err)
+		assert.NotEqual(t, commonpb.ErrorCode_Success, resp.GetAlterStatus().GetErrorCode())
+	})
+}
+
 func TestRootCoord_CheckHealth(t *testing.T) {
 	// getQueryCoordMetricsFunc := func(tt typeutil.Timestamp) (*milvuspb.GetMetricsResponse, error) {
 	// 	clusterTopology := metricsinfo.QueryClusterTopology{

--- a/internal/rootcoord/util.go
+++ b/internal/rootcoord/util.go
@@ -551,3 +551,13 @@ func nextFieldID(coll *model.Collection) int64 {
 
 	return maxFieldID + 1
 }
+
+func nextFunctionID(coll *model.Collection) int64 {
+	maxFunctionID := int64(common.StartOfUserFunctionID)
+	for _, function := range coll.Functions {
+		if function.ID > maxFunctionID {
+			maxFunctionID = function.ID
+		}
+	}
+	return maxFunctionID + 1
+}

--- a/internal/rootcoord/util_test.go
+++ b/internal/rootcoord/util_test.go
@@ -518,3 +518,54 @@ func Test_nextFieldID(t *testing.T) {
 		})
 	}
 }
+
+func Test_nextFunctionID(t *testing.T) {
+	type args struct {
+		coll *model.Collection
+	}
+	tests := []struct {
+		name string
+		args args
+		want int64
+	}{
+		{
+			name: "empty functions list returns StartOfUserFunctionID+1",
+			args: args{
+				coll: &model.Collection{
+					Functions: nil,
+				},
+			},
+			want: common.StartOfUserFunctionID + 1,
+		},
+		{
+			name: "single function returns its ID+1",
+			args: args{
+				coll: &model.Collection{
+					Functions: []*model.Function{
+						{ID: common.StartOfUserFunctionID + 5},
+					},
+				},
+			},
+			want: common.StartOfUserFunctionID + 6,
+		},
+		{
+			name: "multiple functions returns max ID+1",
+			args: args{
+				coll: &model.Collection{
+					Functions: []*model.Function{
+						{ID: common.StartOfUserFunctionID + 3},
+						{ID: common.StartOfUserFunctionID + 10},
+						{ID: common.StartOfUserFunctionID + 7},
+					},
+				},
+			},
+			want: common.StartOfUserFunctionID + 11,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := nextFunctionID(tt.args.coll)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -195,6 +195,10 @@ const (
 	JSONCastFunctionKey = "json_cast_function"
 
 	SchemaVersionConsistencyProportionKey = "schema_version_consistency_proportion"
+	// SchemaVersionConsistentSegmentsKey and SchemaVersionTotalSegmentsKey are emitted by DataCoord
+	// GetCollectionStatistics to surface per-segment schema-version consistency progress.
+	SchemaVersionConsistentSegmentsKey = "schema_version_consistent_segments"
+	SchemaVersionTotalSegmentsKey      = "schema_version_total_segments"
 )
 
 // expr query params

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -111,6 +111,7 @@ var (
 			MetaStore2API(commonpb.ObjectPrivilege_PrivilegeGetImportProgress.String()),
 			MetaStore2API(commonpb.ObjectPrivilege_PrivilegeListImport.String()),
 			MetaStore2API(commonpb.ObjectPrivilege_PrivilegeAddCollectionField.String()),
+			MetaStore2API(commonpb.ObjectPrivilege_PrivilegeAlterCollectionSchema.String()),
 			MetaStore2API(commonpb.ObjectPrivilege_PrivilegeRefreshExternalCollection.String()),
 		},
 		commonpb.ObjectType_Global.String(): {
@@ -343,6 +344,7 @@ var (
 			commonpb.ObjectPrivilege_PrivilegeCreatePartition.String(),
 			commonpb.ObjectPrivilege_PrivilegeDropPartition.String(),
 			commonpb.ObjectPrivilege_PrivilegeAddCollectionField.String(),
+			commonpb.ObjectPrivilege_PrivilegeAlterCollectionSchema.String(),
 			commonpb.ObjectPrivilege_PrivilegeRefreshExternalCollection.String(),
 		})...,
 	)

--- a/tests/go_client/testcases/add_field_test.go
+++ b/tests/go_client/testcases/add_field_test.go
@@ -169,7 +169,7 @@ func TestAddCollectionFieldInvalid(t *testing.T) {
 			fieldBuilder: func() *entity.Field {
 				return entity.NewField().WithName(common.DefaultNewField).WithDataType(entity.FieldTypeInt64).WithNullable(true).WithIsClusteringKey(true)
 			},
-			expectedError: "already has another clutering key field, field name: " + common.DefaultNewField + ": invalid parameter",
+			expectedError: "already has another clustering key field, field name: " + common.DefaultNewField + ": invalid parameter",
 		},
 		{
 			name: "addFieldSameOtherName",
@@ -185,7 +185,7 @@ func TestAddCollectionFieldInvalid(t *testing.T) {
 			fieldBuilder: func() *entity.Field {
 				return entity.NewField().WithName(common.DefaultVarcharFieldName).WithDataType(entity.FieldTypeVarChar).WithNullable(true).WithMaxLength(64)
 			},
-			expectedError: "duplicate field name: varchar: invalid parameter",
+			expectedError: "duplicated field name varchar: invalid parameter",
 		},
 	}
 


### PR DESCRIPTION
Proxy/RootCoord/Schema layer for AlterCollectionSchema API.

- Proxy: AlterCollectionSchema handler (alterCollectionSchemaTask, validateAddFieldRequest), schema version consistency gate (checkSchemaVersionConsistency), external collection guard
- RootCoord: broadcastAlterCollectionSchema DDL callback with schema version increment
- metastore/model: DoPhysicalBackfill field in Collection, MinSchemaVersion field in Index
- pkg/common: SchemaVersionConsistentSegmentsKey/TotalSegmentsKey

related: #48808
design doc: https://github.com/milvus-io/milvus-design-docs/blob/main/design_docs/20260129-add-function-field-design.md