### PR TITLE
enhance: [3.0] add bloomFilterEnabled and visibilityFilterEnabled toggles for querynode optimization

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -1039,6 +1039,8 @@ common:
       warn: 1000 # minimum milliseconds for printing durations in warn level
     maxWLockConditionalWaitTime: 600 # maximum seconds for waiting wlock conditional
   traceLogMode: 0 # trace request info
+  visibilityFilterEnabled: true # whether to apply row visibility filtering (timestamp, delete, and TTL) on querynode. When disabled, all rows are returned regardless of insert/delete timestamps.
+  bloomFilterEnabled: true # whether to load and apply bloom filter/pk stats on querynode
   bloomFilterSize: 100000 # bloom filter initial size
   bloomFilterType: BlockedBloomFilter # bloom filter type, support BasicBloomFilter and BlockedBloomFilter
   maxBloomFalsePositive: 0.001 # max false positive rate for bloom filter

--- a/internal/core/src/exec/operator/MvccNode.cpp
+++ b/internal/core/src/exec/operator/MvccNode.cpp
@@ -24,6 +24,7 @@
 #include "exec/expression/Utils.h"
 #include "fmt/core.h"
 #include "plan/PlanNode.h"
+#include "segcore/SegcoreConfig.h"
 #include "segcore/SegmentInterface.h"
 
 namespace milvus {
@@ -74,6 +75,18 @@ PhyMvccNode::GetOutput() {
 
     tracer::AddEvent(fmt::format("input_rows: {}", active_count_));
 
+    // Visibility filtering disabled globally: skip all filtering.
+    if (!segcore::SegcoreConfig::default_config()
+             .get_visibility_filter_enabled()) {
+        auto col_input = is_source_node_ ? std::make_shared<ColumnVector>(
+                                               TargetBitmap(active_count_),
+                                               TargetBitmap(active_count_))
+                                         : GetColumnVector(input_);
+        query_context->set_all_rows_visible(true);
+        is_finished_ = true;
+        return std::make_shared<RowVector>(std::vector<VectorPtr>{col_input});
+    }
+
     // ── Sealed-segment fast path (skip timestamp mask) ──
     // On a sealed segment without TTL, when query_ts covers all inserts,
     // mask_with_timestamps is redundant (all rows pass).  Only apply the
@@ -105,7 +118,6 @@ PhyMvccNode::GetOutput() {
                                      : GetColumnVector(input_);
 
     TargetBitmapView data(col_input->GetRawData(), col_input->size());
-    // need to expose null?
     segment_->mask_with_timestamps(
         data, query_timestamp_, collection_ttl_timestamp_);
     segment_->mask_with_delete(data, active_count_, query_timestamp_);

--- a/internal/core/src/segcore/SegcoreConfig.h
+++ b/internal/core/src/segcore/SegcoreConfig.h
@@ -156,6 +156,16 @@ class SegcoreConfig {
         return enable_geometry_cache_;
     }
 
+    void
+    set_visibility_filter_enabled(bool value) {
+        visibility_filter_enabled_ = value;
+    }
+
+    bool
+    get_visibility_filter_enabled() const {
+        return visibility_filter_enabled_;
+    }
+
     static constexpr int64_t kDefaultMaxGroupByGroups = 100000;
 
     int64_t
@@ -197,6 +207,7 @@ class SegcoreConfig {
         knowhere::RefineType::DATA_VIEW;
     inline static bool refine_with_quant_flag_ = false;
     inline static bool enable_geometry_cache_ = false;
+    inline static bool visibility_filter_enabled_ = true;
     inline static float interim_index_mem_expansion_rate_ = 1.15f;
     inline static int64_t max_group_by_groups_ = kDefaultMaxGroupByGroups;
 };

--- a/internal/core/src/segcore/segcore_init_c.cpp
+++ b/internal/core/src/segcore/segcore_init_c.cpp
@@ -57,6 +57,13 @@ SegcoreSetEnableGeometryCache(const bool value) {
 }
 
 extern "C" void
+SegcoreSetVisibilityFilterEnabled(const bool value) {
+    milvus::segcore::SegcoreConfig& config =
+        milvus::segcore::SegcoreConfig::default_config();
+    config.set_visibility_filter_enabled(value);
+}
+
+extern "C" void
 SegcoreSetNlist(const int64_t value) {
     milvus::segcore::SegcoreConfig& config =
         milvus::segcore::SegcoreConfig::default_config();

--- a/internal/core/src/segcore/segcore_init_c.h
+++ b/internal/core/src/segcore/segcore_init_c.h
@@ -86,6 +86,9 @@ SegcoreSetKnowhereGpuMemoryPoolSize(const uint32_t init_size,
                                     const uint32_t max_size);
 
 void
+SegcoreSetVisibilityFilterEnabled(const bool value);
+
+void
 SegcoreCloseGlog();
 
 int32_t

--- a/internal/core/unittest/test_mvcc_fast_path.cpp
+++ b/internal/core/unittest/test_mvcc_fast_path.cpp
@@ -18,6 +18,7 @@
 #include "exec/QueryContext.h"
 #include "exec/Task.h"
 #include "plan/PlanNode.h"
+#include "segcore/SegcoreConfig.h"
 #include "segcore/SegmentSealed.h"
 #include "segcore/SegmentGrowingImpl.h"
 #include "segcore/Types.h"
@@ -27,6 +28,23 @@
 using namespace milvus;
 using namespace milvus::exec;
 using namespace milvus::segcore;
+
+// RAII guard to set/restore visibility_filter_enabled
+class VisibilityFilterGuard {
+ public:
+    explicit VisibilityFilterGuard(bool value)
+        : original_(SegcoreConfig::default_config()
+                        .get_visibility_filter_enabled()) {
+        SegcoreConfig::default_config().set_visibility_filter_enabled(value);
+    }
+    ~VisibilityFilterGuard() {
+        SegcoreConfig::default_config().set_visibility_filter_enabled(
+            original_);
+    }
+
+ private:
+    bool original_;
+};
 
 class MvccFastPathTest : public ::testing::Test {
  protected:
@@ -306,4 +324,89 @@ TEST_F(MvccFastPathTest, Level1_NoCachePollution_SequentialQueries) {
     TargetBitmapView view2(col2->GetRawData(), col2->size());
     EXPECT_EQ(view2.count(), 0)
         << "Second query must return clean bitmap, not polluted cache";
+}
+
+// ---------------------------------------------------------------------------
+// visibilityFilterEnabled=false: all MVCC filtering skipped, all rows visible
+// ---------------------------------------------------------------------------
+TEST_F(MvccFastPathTest, VisibilityFilterDisabled_AllRowsVisible) {
+    VisibilityFilterGuard guard(false);
+    auto segment = CreateSealedSegment();
+    auto result = RunMvccPlan(segment.get());
+
+    EXPECT_EQ(result.num_rows, N_);
+    EXPECT_TRUE(result.all_rows_visible)
+        << "visibilityFilterEnabled=false should set all_rows_visible=true";
+
+    // Verify output bitmap is all zeros (no rows filtered out)
+    ASSERT_NE(result.output, nullptr);
+    auto col = std::dynamic_pointer_cast<ColumnVector>(result.output->child(0));
+    ASSERT_NE(col, nullptr);
+    TargetBitmapView view(col->GetRawData(), col->size());
+    EXPECT_EQ(view.count(), 0)
+        << "visibilityFilterEnabled=false should produce all-zero bitmap";
+}
+
+// ---------------------------------------------------------------------------
+// visibilityFilterEnabled=false: deletes are ignored even when present
+// ---------------------------------------------------------------------------
+TEST_F(MvccFastPathTest, VisibilityFilterDisabled_DeletesIgnored) {
+    VisibilityFilterGuard guard(false);
+    int64_t num_deletes = 5;
+    auto segment = CreateSealedSegmentWithDeletes(num_deletes);
+    auto result = RunMvccPlan(segment.get());
+
+    EXPECT_EQ(result.num_rows, N_);
+    EXPECT_TRUE(result.all_rows_visible)
+        << "visibilityFilterEnabled=false should ignore deletes";
+
+    ASSERT_NE(result.output, nullptr);
+    auto col = std::dynamic_pointer_cast<ColumnVector>(result.output->child(0));
+    ASSERT_NE(col, nullptr);
+    TargetBitmapView view(col->GetRawData(), col->size());
+    EXPECT_EQ(view.count(), 0)
+        << "visibilityFilterEnabled=false should not mask deleted rows";
+}
+
+// ---------------------------------------------------------------------------
+// visibilityFilterEnabled=false on growing segment: still skips all filtering
+// ---------------------------------------------------------------------------
+TEST_F(MvccFastPathTest, VisibilityFilterDisabled_GrowingSegment) {
+    VisibilityFilterGuard guard(false);
+    auto raw_data = DataGen(schema_, N_);
+    auto segment = CreateGrowingSegment(schema_, empty_index_meta);
+    segment->PreInsert(N_);
+    segment->Insert(0,
+                    N_,
+                    raw_data.row_ids_.data(),
+                    raw_data.timestamps_.data(),
+                    raw_data.raw_);
+
+    auto mvcc_node = std::make_shared<plan::MvccNode>("mvcc_1");
+    auto plan = plan::PlanFragment(mvcc_node);
+
+    auto query_context = std::make_shared<QueryContext>(
+        "test_vis_disabled_growing",
+        segment.get(),
+        N_,
+        MAX_TIMESTAMP,
+        0,
+        0,
+        query::PlanOptions{false},
+        std::make_shared<QueryConfig>(
+            std::unordered_map<std::string, std::string>{}));
+
+    auto task = Task::Create("task_vis_growing", plan, 0, query_context);
+    int64_t num_rows = 0;
+    for (;;) {
+        auto output = task->Next();
+        if (!output) {
+            break;
+        }
+        num_rows += output->size();
+    }
+    EXPECT_EQ(num_rows, N_);
+    EXPECT_TRUE(query_context->get_all_rows_visible())
+        << "visibilityFilterEnabled=false should skip filtering on growing "
+           "segments too";
 }

--- a/internal/core/unittest/test_mvcc_fast_path.cpp
+++ b/internal/core/unittest/test_mvcc_fast_path.cpp
@@ -33,8 +33,8 @@ using namespace milvus::segcore;
 class VisibilityFilterGuard {
  public:
     explicit VisibilityFilterGuard(bool value)
-        : original_(SegcoreConfig::default_config()
-                        .get_visibility_filter_enabled()) {
+        : original_(
+              SegcoreConfig::default_config().get_visibility_filter_enabled()) {
         SegcoreConfig::default_config().set_visibility_filter_enabled(value);
     }
     ~VisibilityFilterGuard() {

--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -629,7 +629,7 @@ func (sd *shardDelegator) rangeHitL0Deletions(partitionID int64, candidate pkora
 	log := sd.getLogger(context.Background())
 	start := time.Now()
 	totalL0Rows := 0
-	totalBfHitRows := int64(0)
+	totalForwardRows := int64(0)
 	processedL0Count := 0
 
 	for _, segment := range level0Segments {
@@ -646,14 +646,25 @@ func (sd *shardDelegator) rangeHitL0Deletions(partitionID int64, candidate pkora
 					endIdx = len(segmentPks)
 				}
 
+				if !candidate.PkCandidateExist() {
+					for i := idx; i < endIdx; i++ {
+						totalForwardRows += 1
+						if err := fn(segmentPks[i], segmentTss[i]); err != nil {
+							return err
+						}
+					}
+					continue
+				}
+
 				lc := storage.NewBatchLocationsCache(segmentPks[idx:endIdx])
 				hits := candidate.BatchPkExist(lc)
 				for i, hit := range hits {
-					if hit {
-						totalBfHitRows += 1
-						if err := fn(segmentPks[idx+i], segmentTss[idx+i]); err != nil {
-							return err
-						}
+					if !hit {
+						continue
+					}
+					totalForwardRows += 1
+					if err := fn(segmentPks[idx+i], segmentTss[idx+i]); err != nil {
+						return err
 					}
 				}
 			}
@@ -663,9 +674,10 @@ func (sd *shardDelegator) rangeHitL0Deletions(partitionID int64, candidate pkora
 	log.Info("forward delete from L0 segments to worker",
 		zap.Int64("targetSegmentID", candidate.ID()),
 		zap.String("channel", sd.vchannelName),
+		zap.Bool("broadcast", !candidate.PkCandidateExist()),
 		zap.Int("l0SegmentCount", processedL0Count),
 		zap.Int("totalDeleteRowsInL0", totalL0Rows),
-		zap.Int64("totalBfHitRows", totalBfHitRows),
+		zap.Int64("totalForwardRows", totalForwardRows),
 		zap.Int64("totalCost", time.Since(start).Milliseconds()),
 	)
 
@@ -718,6 +730,7 @@ func (sd *shardDelegator) RefreshLevel0DeletionStats() {
 
 // processDeleteRecords performs BF checks on delete buffer records and forwards matching deletes
 // via the buffered forwarder. Does NOT require any lock to be held.
+// When candidate has no stats (PkCandidateExist() == false), all deletes are forwarded (broadcast mode).
 // Returns the number of timestamp-hit and bloom-filter-hit rows.
 func (sd *shardDelegator) processDeleteRecords(
 	candidate *pkoracle.BloomFilterSet,
@@ -736,6 +749,17 @@ func (sd *shardDelegator) processDeleteRecords(
 				endIdx := idx + batchSize
 				if endIdx > len(pks) {
 					endIdx = len(pks)
+				}
+
+				// When BF not initialized (bloom filter disabled), forward all deletes
+				if !candidate.PkCandidateExist() {
+					for i := idx; i < endIdx; i++ {
+						bfHit++
+						if err = forwarder.Buffer(pks[i], record.DeleteData.Tss[i]); err != nil {
+							return tsHit, bfHit, err
+						}
+					}
+					continue
 				}
 
 				lc := storage.NewBatchLocationsCache(pks[idx:endIdx])

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -928,6 +928,66 @@ func (s *DelegatorDataSuite) TestLoadSegments() {
 	})
 }
 
+func (s *DelegatorDataSuite) TestLoadSegmentsWithoutBloomFilter() {
+	paramtable.Get().Save(paramtable.Get().CommonCfg.BloomFilterEnabled.Key, "false")
+	defer paramtable.Get().Reset(paramtable.Get().CommonCfg.BloomFilterEnabled.Key)
+
+	workers := make(map[int64]*cluster.MockWorker)
+	worker1 := &cluster.MockWorker{}
+	workers[1] = worker1
+
+	worker1.EXPECT().LoadSegments(mock.Anything, mock.AnythingOfType("*querypb.LoadSegmentsRequest")).
+		Return(nil)
+	worker1.EXPECT().Delete(mock.Anything, mock.AnythingOfType("*querypb.DeleteRequest")).
+		RunAndReturn(func(ctx context.Context, req *querypb.DeleteRequest) error {
+			s.Equal(int64(100), req.GetSegmentId())
+			s.Equal(querypb.DataScope_Historical, req.GetScope())
+			s.ElementsMatch([]int64{1, 10}, req.GetPrimaryKeys().GetIntId().GetData())
+			s.ElementsMatch([]uint64{10, 10}, req.GetTimestamps())
+			return nil
+		}).Once()
+	s.workerManager.EXPECT().GetWorker(mock.Anything, mock.AnythingOfType("int64")).Call.Return(func(_ context.Context, nodeID int64) cluster.Worker {
+		return workers[nodeID]
+	}, nil)
+
+	s.delegator.ProcessDelete([]*DeleteData{
+		{
+			PartitionID: 500,
+			PrimaryKeys: []storage.PrimaryKey{
+				storage.NewInt64PrimaryKey(1),
+				storage.NewInt64PrimaryKey(10),
+			},
+			Timestamps: []uint64{10, 10},
+			RowCount:   2,
+		},
+	}, 10)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := s.delegator.LoadSegments(ctx, &querypb.LoadSegmentsRequest{
+		Base:         commonpbutil.NewMsgBase(),
+		DstNodeID:    1,
+		CollectionID: s.collectionID,
+		Infos: []*querypb.SegmentLoadInfo{
+			{
+				SegmentID:     100,
+				PartitionID:   500,
+				StartPosition: &msgpb.MsgPosition{Timestamp: 20000},
+				DeltaPosition: &msgpb.MsgPosition{Timestamp: 20000},
+				Level:         datapb.SegmentLevel_L1,
+				InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", s.collectionID),
+			},
+		},
+	})
+
+	s.NoError(err)
+	sealed, _ := s.delegator.GetSegmentInfo(false)
+	s.Require().Equal(1, len(sealed))
+	s.Require().Equal(1, len(sealed[0].Segments))
+	s.Nil(sealed[0].Segments[0].Candidate)
+}
+
 func (s *DelegatorDataSuite) waitTargetVersion(targetVersion int64) {
 	for {
 		if s.delegator.idfOracle.TargetVersion() >= targetVersion {
@@ -1484,6 +1544,14 @@ func (s *DelegatorDataSuite) TestLevel0Deletions() {
 	delegator.deleteBuffer.RegisterL0(l0Global)
 	pks, _ = delegator.GetLevel0Deletions(partitionID, pkoracle.NewCandidateKey(l0.ID(), l0.Partition(), segments.SegmentTypeGrowing))
 	rawPks := make([]storage.PrimaryKey, 0, pks.Len())
+	for i := 0; i < pks.Len(); i++ {
+		rawPks = append(rawPks, pks.Get(i))
+	}
+	s.ElementsMatch(rawPks, []storage.PrimaryKey{partitionDeleteData.DeletePks().Get(0), allPartitionDeleteData.DeletePks().Get(0)})
+
+	stubCandidate := pkoracle.NewBloomFilterSet(3, l0.Partition(), commonpb.SegmentState_Sealed)
+	pks, _ = delegator.GetLevel0Deletions(partitionID, stubCandidate)
+	rawPks = rawPks[:0]
 	for i := 0; i < pks.Len(); i++ {
 		rawPks = append(rawPks, pks.Get(i))
 	}

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -950,6 +950,11 @@ func (s *DelegatorDataSuite) TestLoadSegmentsWithoutBloomFilter() {
 		return workers[nodeID]
 	}, nil)
 
+	// Mock LoadBloomFilterSet to return metadata-only stubs (BF disabled path)
+	stubCandidate := pkoracle.NewBloomFilterSet(100, 500, commonpb.SegmentState_Sealed)
+	s.loader.EXPECT().LoadBloomFilterSet(mock.Anything, mock.AnythingOfType("int64"), mock.Anything).
+		Return([]*pkoracle.BloomFilterSet{stubCandidate}, nil)
+
 	s.delegator.ProcessDelete([]*DeleteData{
 		{
 			PartitionID: 500,
@@ -985,7 +990,8 @@ func (s *DelegatorDataSuite) TestLoadSegmentsWithoutBloomFilter() {
 	sealed, _ := s.delegator.GetSegmentInfo(false)
 	s.Require().Equal(1, len(sealed))
 	s.Require().Equal(1, len(sealed[0].Segments))
-	s.Nil(sealed[0].Segments[0].Candidate)
+	s.NotNil(sealed[0].Segments[0].Candidate)
+	s.False(sealed[0].Segments[0].Candidate.PkCandidateExist())
 }
 
 func (s *DelegatorDataSuite) waitTargetVersion(targetVersion int64) {

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -337,6 +337,7 @@ func (s *DelegatorDataSuite) TestProcessDelete() {
 			ms.EXPECT().MayPkExist(mock.Anything).RunAndReturn(func(lc *storage.LocationsCache) bool {
 				return lc.GetPk().EQ(storage.NewInt64PrimaryKey(10))
 			})
+			ms.EXPECT().PkCandidateExist().Return(true)
 			ms.EXPECT().BatchPkExist(mock.Anything).RunAndReturn(func(lc *storage.BatchLocationsCache) []bool {
 				hits := make([]bool, lc.Size())
 				for i, pk := range lc.PKs() {

--- a/internal/querynodev2/delegator/delta_forward.go
+++ b/internal/querynodev2/delegator/delta_forward.go
@@ -134,7 +134,7 @@ func (sd *shardDelegator) forwardL0ByBF(ctx context.Context,
 	worker cluster.Worker,
 ) error {
 	// after L0 segment feature
-	// growing segemnts should have load stream delete as well
+	// growing segments should have load stream delete as well
 	deleteScope := querypb.DataScope_All
 	switch candidate.Type() {
 	case commonpb.SegmentState_Sealed:

--- a/internal/querynodev2/delegator/delta_forward_test.go
+++ b/internal/querynodev2/delegator/delta_forward_test.go
@@ -419,6 +419,7 @@ func (s *GrowingMergeL0Suite) TestAddL0ForGrowingBF() {
 
 	seg.EXPECT().ID().Return(1)
 	seg.EXPECT().Partition().Return(100)
+	seg.EXPECT().PkCandidateExist().Return(true)
 	seg.EXPECT().BatchPkExist(mock.Anything).Return(lo.RepeatBy(n, func(i int) bool { return true }))
 	seg.EXPECT().LoadDeltaData(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, dd *storage.DeltaData) error {
 		s.Equal(deltaData.DeletePks(), dd.DeletePks())

--- a/internal/querynodev2/delegator/distribution.go
+++ b/internal/querynodev2/delegator/distribution.go
@@ -30,6 +30,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
@@ -672,6 +673,31 @@ func BatchGetFromSegments(pks []storage.PrimaryKey, partitionID int64, sealed []
 			hits[i] = true
 		}
 		return hits
+	}
+
+	// When bloom filter is disabled, skip BF checks entirely and broadcast all deletes.
+	if !paramtable.Get().CommonCfg.BloomFilterEnabled.GetAsBool() {
+		for _, item := range sealed {
+			for _, entry := range item.Segments {
+				if entry.Offline || entry.Candidate == nil {
+					continue
+				}
+				if partitionID != common.AllPartitionsID && entry.Candidate.Partition() != partitionID {
+					continue
+				}
+				result[entry.SegmentID] = allTrue()
+			}
+		}
+		for _, entry := range growing {
+			if entry.Offline || entry.Candidate == nil {
+				continue
+			}
+			if partitionID != common.AllPartitionsID && entry.PartitionID != partitionID {
+				continue
+			}
+			result[entry.SegmentID] = allTrue()
+		}
+		return result
 	}
 
 	// Check sealed segments from pinned snapshot

--- a/internal/querynodev2/delegator/distribution.go
+++ b/internal/querynodev2/delegator/distribution.go
@@ -666,6 +666,14 @@ func BatchGetFromSegments(pks []storage.PrimaryKey, partitionID int64, sealed []
 	result := make(map[int64][]bool)
 	lc := storage.NewBatchLocationsCache(pks)
 
+	allTrue := func() []bool {
+		hits := make([]bool, lc.Size())
+		for i := range hits {
+			hits[i] = true
+		}
+		return hits
+	}
+
 	// Check sealed segments from pinned snapshot
 	for _, item := range sealed {
 		for _, entry := range item.Segments {
@@ -675,16 +683,24 @@ func BatchGetFromSegments(pks []storage.PrimaryKey, partitionID int64, sealed []
 			if partitionID != common.AllPartitionsID && entry.Candidate.Partition() != partitionID {
 				continue
 			}
+			if !entry.Candidate.PkCandidateExist() {
+				result[entry.SegmentID] = allTrue()
+				continue
+			}
 			result[entry.SegmentID] = entry.Candidate.BatchPkExist(lc)
 		}
 	}
 
 	// Check growing segments from pinned snapshot
 	for _, entry := range growing {
-		if entry.Candidate == nil {
+		if entry.Offline || entry.Candidate == nil {
 			continue
 		}
 		if partitionID != common.AllPartitionsID && entry.Candidate.Partition() != partitionID {
+			continue
+		}
+		if !entry.Candidate.PkCandidateExist() {
+			result[entry.SegmentID] = allTrue()
 			continue
 		}
 		result[entry.SegmentID] = entry.Candidate.BatchPkExist(lc)

--- a/internal/querynodev2/delegator/distribution_test.go
+++ b/internal/querynodev2/delegator/distribution_test.go
@@ -1760,20 +1760,49 @@ func TestBatchGetFromSegments(t *testing.T) {
 				NodeID: 1,
 				Segments: []SegmentEntry{
 					{SegmentID: 1, PartitionID: 1, Candidate: candidate1, Offline: true}, // offline
-					{SegmentID: 2, PartitionID: 1, Candidate: nil},                       // nil candidate
+					{SegmentID: 2, PartitionID: 1, Candidate: nil},                       // nil candidate — skipped
 				},
 			},
 		}
 		growing := []SegmentEntry{
-			{SegmentID: 10, PartitionID: 1, Candidate: nil}, // nil candidate in growing
+			{SegmentID: 10, PartitionID: 1, Candidate: nil}, // nil candidate — skipped
 		}
 
 		pks := []storage.PrimaryKey{storage.NewInt64PrimaryKey(100)}
 
 		result := BatchGetFromSegments(pks, common.AllPartitionsID, sealed, growing)
 
-		// All should be skipped
-		assert.Empty(t, result)
+		// nil candidates are skipped (not broadcast) in streaming forward path
+		assert.Len(t, result, 0)
+		assert.NotContains(t, result, int64(1))
+		assert.NotContains(t, result, int64(2))
+		assert.NotContains(t, result, int64(10))
+	})
+
+	t.Run("nil_candidates_are_skipped", func(t *testing.T) {
+		sealed := []SnapshotItem{
+			{
+				NodeID: 1,
+				Segments: []SegmentEntry{
+					{SegmentID: 1, PartitionID: 1, Candidate: nil},
+					{SegmentID: 2, PartitionID: 2, Candidate: nil},
+				},
+			},
+		}
+		growing := []SegmentEntry{
+			{SegmentID: 10, PartitionID: 1, Candidate: nil},
+			{SegmentID: 11, PartitionID: 2, Candidate: nil},
+		}
+
+		pks := []storage.PrimaryKey{
+			storage.NewInt64PrimaryKey(100),
+			storage.NewInt64PrimaryKey(200),
+		}
+
+		result := BatchGetFromSegments(pks, 1, sealed, growing)
+
+		// nil candidates are skipped entirely
+		assert.Len(t, result, 0)
 	})
 
 	t.Run("growing_segments", func(t *testing.T) {

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -396,7 +396,7 @@ func (loader *segmentLoader) Load(ctx context.Context,
 						zap.Int64("segmentID2", collidingID),
 						zap.Int64("truncatedID", loadInfo.GetSegmentID()&0xFFFFFFFF))
 				}
-			} else {
+			} else if paramtable.Get().CommonCfg.BloomFilterEnabled.GetAsBool() {
 				bfs, err := loader.loadSingleBloomFilterSet(ctx, loadInfo.GetCollectionID(), loadInfo, segment.Type())
 				if err != nil {
 					return errors.Wrap(err, "At LoadBloomFilter")
@@ -643,6 +643,15 @@ func (loader *segmentLoader) loadSingleBloomFilterSet(ctx context.Context, colle
 		zap.Int64("collectionID", collectionID),
 		zap.Int64("segmentIDs", loadInfo.GetSegmentID()))
 
+	partitionID := loadInfo.PartitionID
+	segmentID := loadInfo.SegmentID
+	bfs := pkoracle.NewBloomFilterSet(segmentID, partitionID, segtype)
+
+	if !paramtable.Get().CommonCfg.BloomFilterEnabled.GetAsBool() {
+		log.Info("skip loading bloom filter for remote segment because bloom filter is disabled")
+		return bfs, nil
+	}
+
 	collection := loader.manager.Collection.Get(collectionID)
 	if collection == nil {
 		err := merr.WrapErrCollectionNotFound(collectionID)
@@ -652,10 +661,6 @@ func (loader *segmentLoader) loadSingleBloomFilterSet(ctx context.Context, colle
 	pkField := GetPkField(collection.Schema())
 
 	log.Info("start loading remote...", zap.Int("segmentNum", 1))
-
-	partitionID := loadInfo.PartitionID
-	segmentID := loadInfo.SegmentID
-	bfs := pkoracle.NewBloomFilterSet(segmentID, partitionID, segtype)
 
 	// For external collections, return empty bloom filter set.
 	// External collections use ExternalSegmentCandidate for PK checking (set on segment)
@@ -699,6 +704,20 @@ func (loader *segmentLoader) LoadBloomFilterSet(ctx context.Context, collectionI
 		return nil, nil
 	}
 
+	// Phase 1: always create metadata-only stubs (segmentID / partitionID / type).
+	// This gives callers valid candidates even when BF data is not loaded,
+	// so partition filtering and type-based delete-scope logic never need nil guards.
+	bfSets := make([]*pkoracle.BloomFilterSet, segmentNum)
+	for i, info := range infos {
+		bfSets[i] = pkoracle.NewBloomFilterSet(info.GetSegmentID(), info.GetPartitionID(), commonpb.SegmentState_Sealed)
+	}
+
+	// Phase 2: load BF stats into the stubs (skip when disabled or external collection).
+	if !paramtable.Get().CommonCfg.BloomFilterEnabled.GetAsBool() {
+		log.Info("bloom filter disabled: returning metadata-only stubs")
+		return bfSets, nil
+	}
+
 	collection := loader.manager.Collection.Get(collectionID)
 	if collection == nil {
 		err := merr.WrapErrCollectionNotFound(collectionID)
@@ -707,6 +726,11 @@ func (loader *segmentLoader) LoadBloomFilterSet(ctx context.Context, collectionI
 	}
 	pkField := GetPkField(collection.Schema())
 	pkFieldID := pkField.GetFieldID()
+
+	// External collections use ExternalSegmentCandidate for PK checking and have no stats logs.
+	if typeutil.IsExternalCollection(collection.Schema()) {
+		return bfSets, nil
+	}
 
 	// Calculate total memory size needed for bloom filters (PK stats)
 	var totalMemorySize int64
@@ -740,37 +764,24 @@ func (loader *segmentLoader) LoadBloomFilterSet(ctx context.Context, collectionI
 
 	log.Info("start loading remote...", zap.Int("segmentNum", segmentNum))
 
-	loadedBfs := typeutil.NewConcurrentSet[*pkoracle.BloomFilterSet]()
-	isExternal := typeutil.IsExternalCollection(collection.Schema())
 	loadRemoteFunc := func(idx int) error {
 		loadInfo := infos[idx]
-		partitionID := loadInfo.PartitionID
-		segmentID := loadInfo.SegmentID
-		bfs := pkoracle.NewBloomFilterSet(segmentID, partitionID, commonpb.SegmentState_Sealed)
-
-		// For external collections, return empty bloom filter set
-		// External collections don't have stats logs and use ExternalSegmentCandidate for PK checking
-		if isExternal {
-			loadedBfs.Insert(bfs)
-			return nil
-		}
+		bfs := bfSets[idx]
 
 		log.Info("loading bloom filter for remote...")
 		pkStatsBinlogs, err := packed.NewStatsResolverFromLoadInfo(loadInfo).BloomFilterPaths(pkFieldID)
 		if err != nil {
 			return err
 		}
-		err = loader.loadBloomFilter(ctx, segmentID, bfs, pkStatsBinlogs)
+		err = loader.loadBloomFilter(ctx, bfs.ID(), bfs, pkStatsBinlogs)
 		if err != nil {
 			log.Warn("load remote segment bloom filter failed",
-				zap.Int64("partitionID", partitionID),
-				zap.Int64("segmentID", segmentID),
+				zap.Int64("partitionID", bfs.Partition()),
+				zap.Int64("segmentID", bfs.ID()),
 				zap.Error(err),
 			)
 			return err
 		}
-		loadedBfs.Insert(bfs)
-
 		return nil
 	}
 
@@ -781,14 +792,12 @@ func (loader *segmentLoader) LoadBloomFilterSet(ctx context.Context, collectionI
 		return nil, err
 	}
 
-	result := loadedBfs.Collect()
-
 	// Charge loaded resource for bloom filters
-	for _, bfs := range result {
+	for _, bfs := range bfSets {
 		bfs.Charge()
 	}
 
-	return result, nil
+	return bfSets, nil
 }
 
 func separateIndexAndBinlog(loadInfo *querypb.SegmentLoadInfo) (map[int64]*IndexedFieldInfo, []*datapb.FieldBinlog) {

--- a/internal/querynodev2/segments/segment_loader_test.go
+++ b/internal/querynodev2/segments/segment_loader_test.go
@@ -367,6 +367,45 @@ func (suite *SegmentLoaderSuite) TestLoadBloomFilter() {
 	}
 }
 
+func (suite *SegmentLoaderSuite) TestLoadWithoutBloomFilter() {
+	paramtable.Get().Save(paramtable.Get().CommonCfg.BloomFilterEnabled.Key, "false")
+	defer paramtable.Get().Reset(paramtable.Get().CommonCfg.BloomFilterEnabled.Key)
+
+	ctx := context.Background()
+	msgLength := 100
+
+	binlogs, statsLogs, err := mock_segcore.SaveBinLog(ctx,
+		suite.collectionID,
+		suite.partitionID,
+		suite.segmentID,
+		msgLength,
+		suite.schema,
+		suite.chunkManager,
+	)
+	suite.NoError(err)
+
+	loadInfo := &querypb.SegmentLoadInfo{
+		SegmentID:     suite.segmentID,
+		PartitionID:   suite.partitionID,
+		CollectionID:  suite.collectionID,
+		BinlogPaths:   binlogs,
+		Statslogs:     statsLogs,
+		NumOfRows:     int64(msgLength),
+		InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", suite.collectionID),
+	}
+
+	segments, err := suite.loader.Load(ctx, suite.collectionID, SegmentTypeSealed, 0, loadInfo)
+	suite.NoError(err)
+	suite.Len(segments, 1)
+	suite.False(segments[0].PkCandidateExist())
+
+	bfs, err := suite.loader.LoadBloomFilterSet(ctx, suite.collectionID, loadInfo)
+	suite.NoError(err)
+	suite.NotNil(bfs)
+	suite.Len(bfs, 1)
+	suite.False(bfs[0].PkCandidateExist()) // metadata-only stub when BF disabled
+}
+
 func (suite *SegmentLoaderSuite) TestLoadDeltaLogs() {
 	ctx := context.Background()
 	loadInfos := make([]*querypb.SegmentLoadInfo, 0, suite.segmentNum)

--- a/internal/util/initcore/query_node.go
+++ b/internal/util/initcore/query_node.go
@@ -77,7 +77,12 @@ func doInitQueryNodeOnce(ctx context.Context) error {
 	cMaxGroupByGroups := C.int64_t(paramtable.Get().CommonCfg.GroupByMaxGroups.GetAsInt64())
 	C.SegcoreSetMaxGroupByGroups(cMaxGroupByGroups)
 
-	C.SegcoreSetVisibilityFilterEnabled(C.bool(paramtable.Get().CommonCfg.VisibilityFilterEnabled.GetAsBool()))
+	visibilityEnabled := paramtable.Get().CommonCfg.VisibilityFilterEnabled.GetAsBool()
+	bloomEnabled := paramtable.Get().CommonCfg.BloomFilterEnabled.GetAsBool()
+	C.SegcoreSetVisibilityFilterEnabled(C.bool(visibilityEnabled))
+	if !visibilityEnabled && bloomEnabled {
+		log.Warn("visibilityFilterEnabled=false with bloomFilterEnabled=true: deletes are forwarded via bloom filter but never applied — consider disabling bloom filter to save memory")
+	}
 
 	cKnowhereThreadPoolSize := C.uint32_t(paramtable.Get().QueryNodeCfg.KnowhereThreadPoolSize.GetAsUint32())
 	C.SegcoreSetKnowhereSearchThreadPoolNum(cKnowhereThreadPoolSize)

--- a/internal/util/initcore/query_node.go
+++ b/internal/util/initcore/query_node.go
@@ -77,6 +77,8 @@ func doInitQueryNodeOnce(ctx context.Context) error {
 	cMaxGroupByGroups := C.int64_t(paramtable.Get().CommonCfg.GroupByMaxGroups.GetAsInt64())
 	C.SegcoreSetMaxGroupByGroups(cMaxGroupByGroups)
 
+	C.SegcoreSetVisibilityFilterEnabled(C.bool(paramtable.Get().CommonCfg.VisibilityFilterEnabled.GetAsBool()))
+
 	cKnowhereThreadPoolSize := C.uint32_t(paramtable.Get().QueryNodeCfg.KnowhereThreadPoolSize.GetAsUint32())
 	C.SegcoreSetKnowhereSearchThreadPoolNum(cKnowhereThreadPoolSize)
 

--- a/internal/util/segcore/plan.go
+++ b/internal/util/segcore/plan.go
@@ -120,13 +120,15 @@ func NewSearchRequest(collection *CCollection, req *querypb.SearchRequest, place
 		return nil, errors.Wrap(err, "get fieldID from plan failed")
 	}
 
+	cl := req.GetReq().GetConsistencyLevel()
+
 	return &SearchRequest{
 		plan:                  plan,
 		cPlaceholderGroup:     cPlaceholderGroup,
 		msgID:                 req.GetReq().GetBase().GetMsgID(),
 		searchFieldID:         int64(fieldID),
 		mvccTimestamp:         req.GetReq().GetMvccTimestamp(),
-		consistencyLevel:      req.GetReq().GetConsistencyLevel(),
+		consistencyLevel:      cl,
 		collectionTTL:         req.GetReq().GetCollectionTtlTimestamps(),
 		entityTTLPhysicalTime: req.GetReq().GetEntityTtlPhysicalTime(),
 	}, nil

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -303,6 +303,8 @@ type commonConfig struct {
 	StorageReadRetryAttempts ParamItem `refreshable:"true"`
 
 	TraceLogMode              ParamItem `refreshable:"true"`
+	VisibilityFilterEnabled   ParamItem `refreshable:"false"`
+	BloomFilterEnabled        ParamItem `refreshable:"false"`
 	BloomFilterSize           ParamItem `refreshable:"true"`
 	BloomFilterType           ParamItem `refreshable:"true"`
 	MaxBloomFalsePositive     ParamItem `refreshable:"true"`
@@ -1094,6 +1096,24 @@ The default value is 1, which is enough for most cases.`,
 		Export:       true,
 	}
 	p.TraceLogMode.Init(base.mgr)
+
+	p.VisibilityFilterEnabled = ParamItem{
+		Key:          "common.visibilityFilterEnabled",
+		Version:      "3.0.0",
+		DefaultValue: "true",
+		Doc:          "whether to apply row visibility filtering (timestamp, delete, and TTL) on querynode. When disabled, all rows are returned regardless of insert/delete timestamps.",
+		Export:       true,
+	}
+	p.VisibilityFilterEnabled.Init(base.mgr)
+
+	p.BloomFilterEnabled = ParamItem{
+		Key:          "common.bloomFilterEnabled",
+		Version:      "3.0.0",
+		DefaultValue: "true",
+		Doc:          "whether to load and apply bloom filter/pk stats on querynode",
+		Export:       true,
+	}
+	p.BloomFilterEnabled.Init(base.mgr)
 
 	p.BloomFilterSize = ParamItem{
 		Key:          "common.bloomFilterSize",

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -111,6 +111,12 @@ func TestComponentParam(t *testing.T) {
 		params.Save("common.preCreatedTopic.timeticker", "timeticker")
 		assert.Equal(t, []string{"timeticker"}, Params.TimeTicker.GetAsStrings())
 
+		assert.True(t, params.CommonCfg.BloomFilterEnabled.GetAsBool())
+		params.Save("common.bloomFilterEnabled", "false")
+		assert.False(t, params.CommonCfg.BloomFilterEnabled.GetAsBool())
+		params.Reset("common.bloomFilterEnabled")
+		assert.True(t, params.CommonCfg.BloomFilterEnabled.GetAsBool())
+
 		assert.Equal(t, 1000, params.CommonCfg.BloomFilterApplyBatchSize.GetAsInt())
 
 		params.Save("common.gcenabled", "false")
@@ -869,6 +875,7 @@ func TestCachedParam(t *testing.T) {
 
 	assert.Equal(t, uint(100000), params.CommonCfg.BloomFilterSize.GetAsUint())
 	assert.Equal(t, uint(100000), params.CommonCfg.BloomFilterSize.GetAsUint())
+	assert.True(t, params.CommonCfg.BloomFilterEnabled.GetAsBool())
 	assert.Equal(t, "BlockedBloomFilter", params.CommonCfg.BloomFilterType.GetValue())
 
 	assert.Equal(t, uint64(8388608), params.ServiceParam.MQCfg.PursuitBufferSize.GetAsUint64())


### PR DESCRIPTION
## Summary
- Port of #48701 to `3.0` branch
- Add `common.bloomFilterEnabled` toggle to skip bloom filter/PK stats loading on querynode, reducing memory for workloads without delete or search-by-id. Delete forwarding falls back to broadcast mode when disabled.
- Add `common.visibilityFilterEnabled` toggle to bypass MVCC filtering in C++ search/retrieve, improving performance for workloads that don't need timestamp consistency.

issue: #48703
pr: #48701

## Test plan
- [ ] Unit tests for bloom filter disabled path (`TestLoadSegmentsWithoutBloomFilter`, `TestLoadWithoutBloomFilter`)
- [ ] Unit tests for nil candidate broadcast in delete forwarding
- [ ] Unit tests for MVCC bypass with visibility filter disabled
- [ ] Verify no nil pointer panics when bloom filter is disabled
- [ ] Integration test with `bloomFilterEnabled=false` and `visibilityFilterEnabled=false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)