### PR TITLE
enhance: [3.0] PK compressed storage and lazy system index for segment loading optimization

### DIFF
--- a/internal/core/src/index/json_stats/JsonKeyStats.cpp
+++ b/internal/core/src/index/json_stats/JsonKeyStats.cpp
@@ -65,6 +65,7 @@
 #include "storage/LocalChunkManagerSingleton.h"
 #include "storage/MemFileManagerImpl.h"
 #include "storage/MmapManager.h"
+#include "folly/ScopeGuard.h"
 #include "storage/ThreadPools.h"
 #include "storage/Types.h"
 #include "storage/Util.h"
@@ -1016,6 +1017,18 @@ JsonKeyStats::LoadColumnGroup(int64_t column_group_id,
             return static_cast<int64_t>(row_group_meta_vector.row_num());
         }));
     }
+    // Ensure all futures are awaited even if one throws, to prevent
+    // use-after-free on captured references (&fs) in background tasks.
+    auto futures_guard = folly::makeGuard([&futures]() {
+        for (auto& f : futures) {
+            if (f.valid()) {
+                try {
+                    f.get();
+                } catch (...) {
+                }
+            }
+        }
+    });
     for (auto& f : futures) {
         num_rows += f.get();
     }

--- a/internal/core/src/index/json_stats/JsonKeyStats.cpp
+++ b/internal/core/src/index/json_stats/JsonKeyStats.cpp
@@ -58,6 +58,7 @@
 #include "parquet/metadata.h"
 #include "segcore/storagev1translator/BsonInvertedIndexTranslator.h"
 #include "segcore/storagev2translator/GroupChunkTranslator.h"
+#include "segcore/Utils.h"
 #include "storage/DiskFileManagerImpl.h"
 #include "storage/FileManager.h"
 #include "storage/LocalChunkManager.h"
@@ -998,15 +999,28 @@ JsonKeyStats::LoadColumnGroup(int64_t column_group_id,
         milvus_field_ids.push_back(FieldId(field_id_list.Get(i)));
     }
 
+    // Fetch row group metadata from all files in parallel using HIGH POOL
+    // to avoid blocking the caller thread with serial S3 I/O
+    auto& pool =
+        ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::HIGH);
+    std::vector<std::future<int64_t>> futures;
+    futures.reserve(files.size());
     for (const auto& file : files) {
-        auto result = milvus_storage::FileRowGroupReader::Make(fs, file);
-        AssertInfo(result.ok(),
-                   "[StorageV2] Failed to create file row group reader: " +
-                       result.status().ToString());
-        auto reader = result.ValueOrDie();
-        auto row_group_meta_vector =
-            reader->file_metadata()->GetRowGroupMetadataVector();
-        num_rows += row_group_meta_vector.row_num();
+        futures.push_back(pool.Submit([&fs, &file]() {
+            auto result =
+                milvus_storage::FileRowGroupReader::Make(fs, file);
+            AssertInfo(
+                result.ok(),
+                "[StorageV2] Failed to create file row group reader: " +
+                    result.status().ToString());
+            auto reader = result.ValueOrDie();
+            auto row_group_meta_vector =
+                reader->file_metadata()->GetRowGroupMetadataVector();
+            return static_cast<int64_t>(row_group_meta_vector.row_num());
+        }));
+    }
+    for (auto& f : futures) {
+        num_rows += f.get();
     }
 
     if (num_rows_ == 0) {

--- a/internal/core/src/index/json_stats/JsonKeyStats.cpp
+++ b/internal/core/src/index/json_stats/JsonKeyStats.cpp
@@ -1001,18 +1001,15 @@ JsonKeyStats::LoadColumnGroup(int64_t column_group_id,
 
     // Fetch row group metadata from all files in parallel using HIGH POOL
     // to avoid blocking the caller thread with serial S3 I/O
-    auto& pool =
-        ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::HIGH);
+    auto& pool = ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::HIGH);
     std::vector<std::future<int64_t>> futures;
     futures.reserve(files.size());
     for (const auto& file : files) {
-        futures.push_back(pool.Submit([&fs, &file]() {
-            auto result =
-                milvus_storage::FileRowGroupReader::Make(fs, file);
-            AssertInfo(
-                result.ok(),
-                "[StorageV2] Failed to create file row group reader: " +
-                    result.status().ToString());
+        futures.push_back(pool.Submit([&fs, file]() {
+            auto result = milvus_storage::FileRowGroupReader::Make(fs, file);
+            AssertInfo(result.ok(),
+                       "[StorageV2] Failed to create file row group reader: " +
+                           result.status().ToString());
             auto reader = result.ValueOrDie();
             auto row_group_meta_vector =
                 reader->file_metadata()->GetRowGroupMetadataVector();

--- a/internal/core/src/segcore/CMakeLists.txt
+++ b/internal/core/src/segcore/CMakeLists.txt
@@ -11,6 +11,7 @@
 
 
 add_source_at_current_directory_recursively()
+list(APPEND SOURCE_FILES storagev2translator/SystemIndexTranslator.cpp)
 add_library(milvus_segcore OBJECT ${SOURCE_FILES})
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/internal/core/src/segcore/CMakeLists.txt
+++ b/internal/core/src/segcore/CMakeLists.txt
@@ -11,7 +11,6 @@
 
 
 add_source_at_current_directory_recursively()
-list(APPEND SOURCE_FILES storagev2translator/SystemIndexTranslator.cpp)
 add_library(milvus_segcore OBJECT ${SOURCE_FILES})
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -120,6 +120,7 @@
 #include "segcore/TimestampIndex.h"
 #include "segcore/storagev1translator/ChunkTranslator.h"
 #include "segcore/storagev1translator/DefaultValueChunkTranslator.h"
+#include "segcore/storagev2translator/SystemIndexTranslator.h"
 #include "segcore/storagev1translator/InterimSealedIndexTranslator.h"
 #include "segcore/storagev1translator/TextMatchIndexTranslator.h"
 #include "segcore/storagev2translator/GroupChunkTranslator.h"
@@ -243,6 +244,116 @@ cancel_and_clear_json_indices(std::vector<JsonIndexT>& json_indices) {
         cancel_warmup(index.index);
     }
     json_indices.clear();
+}
+
+PinWrapper<const storagev2translator::TimestampIndexCell*>
+ChunkedSegmentSealedImpl::PinTimestampIndex(milvus::OpContext* op_ctx) const {
+    auto slot = *timestamp_index_slot_.rlock();
+    if (!slot) {
+        return PinWrapper<const storagev2translator::TimestampIndexCell*>(
+            nullptr);
+    }
+    auto ca = SemiInlineGet(slot->PinCells(op_ctx, {0}));
+    auto* cell = ca->get_cell_of(0);
+    AssertInfo(
+        cell != nullptr, "timestamp index cache is corrupted, segment {}", id_);
+    return PinWrapper<const storagev2translator::TimestampIndexCell*>(ca, cell);
+}
+
+PinWrapper<const storagev2translator::PkIndexCell*>
+ChunkedSegmentSealedImpl::PinPkIndex(milvus::OpContext* op_ctx) const {
+    auto slot = *pk_index_slot_.rlock();
+    if (!slot) {
+        return PinWrapper<const storagev2translator::PkIndexCell*>(nullptr);
+    }
+    auto ca = SemiInlineGet(slot->PinCells(op_ctx, {0}));
+    auto* cell = ca->get_cell_of(0);
+    AssertInfo(cell != nullptr, "pk index cache is corrupted, segment {}", id_);
+    return PinWrapper<const storagev2translator::PkIndexCell*>(ca, cell);
+}
+
+bool
+ChunkedSegmentSealedImpl::Contain(const PkType& pk) const {
+    auto pk_index = PinPkIndex(nullptr);
+    if (pk_index.get() != nullptr && pk_index.get()->has_pk2offset()) {
+        return pk_index.get()->contain(pk);
+    }
+    // Sorted-by-pk segment: binary search on pk column directly.
+    if (is_sorted_by_pk_) {
+        auto pk_field_id =
+            schema_->get_primary_field_id().value_or(FieldId(-1));
+        AssertInfo(pk_field_id.get() != -1, "Primary key is -1");
+        auto pk_column = get_column(pk_field_id);
+        if (pk_column != nullptr) {
+            auto num_chunks = pk_column->num_chunks();
+            auto all_chunks = pk_column->GetAllChunks(nullptr);
+            switch (schema_->get_fields().at(pk_field_id).get_data_type()) {
+                case DataType::INT64: {
+                    auto target = std::get<int64_t>(pk);
+                    for (int64_t i = 0; i < num_chunks; ++i) {
+                        auto* src = reinterpret_cast<const int64_t*>(
+                            all_chunks[i].get()->RawData());
+                        auto rows = pk_column->chunk_row_nums(i);
+                        auto it = std::lower_bound(src, src + rows, target);
+                        if (it != src + rows && *it == target) {
+                            return true;
+                        }
+                    }
+                    return false;
+                }
+                case DataType::VARCHAR: {
+                    auto& target = std::get<std::string>(pk);
+                    for (int64_t i = 0; i < num_chunks; ++i) {
+                        auto* chunk =
+                            static_cast<StringChunk*>(all_chunks[i].get());
+                        auto offset = chunk->binary_search_string(target);
+                        if (offset != -1 && offset < chunk->RowNums() &&
+                            chunk->operator[](offset) == target) {
+                            return true;
+                        }
+                    }
+                    return false;
+                }
+                default:
+                    break;
+            }
+        }
+    }
+    return insert_record_.contain(pk);
+}
+
+bool
+ChunkedSegmentSealedImpl::is_system_field_ready() const {
+    if (!insert_record_.timestamps_.empty()) {
+        return true;
+    }
+    return get_column(TimestampFieldID) != nullptr;
+}
+
+void
+ChunkedSegmentSealedImpl::init_storage_v2_timestamp_index(
+    const std::shared_ptr<ChunkedColumnInterface>& column, size_t num_rows) {
+    std::unique_ptr<Translator<storagev2translator::TimestampIndexCell>>
+        translator =
+            std::make_unique<storagev2translator::TimestampIndexTranslator>(
+                id_, column, num_rows);
+    *timestamp_index_slot_.wlock() =
+        Manager::GetInstance().CreateCacheSlot(std::move(translator));
+}
+
+void
+ChunkedSegmentSealedImpl::init_storage_v2_pk_index(
+    FieldId field_id,
+    const std::shared_ptr<ChunkedColumnInterface>& column,
+    DataType data_type) {
+    if (schema_->get_primary_field_id() != field_id) {
+        return;
+    }
+    std::unique_ptr<Translator<storagev2translator::PkIndexCell>> translator =
+        std::make_unique<storagev2translator::PkIndexTranslator>(
+            id_, column, data_type, is_sorted_by_pk_);
+    *pk_index_slot_.wlock() =
+        Manager::GetInstance().CreateCacheSlot(std::move(translator));
 }
 
 void
@@ -683,17 +794,7 @@ ChunkedSegmentSealedImpl::load_column_group_data_internal(
                 op_ctx,
                 is_replace);
             if (field_id == TimestampFieldID) {
-                auto timestamp_proxy_column = get_column(TimestampFieldID);
-                AssertInfo(timestamp_proxy_column != nullptr,
-                           "timestamp proxy column is nullptr");
-                // TODO check timestamp_index ready instead of check system_ready_count_
-                int64_t num_rows;
-                for (auto& [_, info] : load_info.field_infos) {
-                    num_rows = info.row_count;
-                }
-                init_timestamp_index_from_column(timestamp_proxy_column,
-                                                 num_rows);
-                system_ready_count_++;
+                init_storage_v2_timestamp_index(column, num_rows);
             }
         }
 
@@ -829,7 +930,6 @@ ChunkedSegmentSealedImpl::load_system_field_internal(
         }
 
         init_timestamp_index_owned(std::move(timestamps), num_rows);
-        ++system_ready_count_;
     } else {
         AssertInfo(system_field_type == SystemFieldType::RowId,
                    "System field type of id column is not RowId");
@@ -1422,9 +1522,21 @@ ChunkedSegmentSealedImpl::search_pks(BitsetType& bitset,
     }
     BitsetTypeView bitset_view(bitset);
     if (!is_sorted_by_pk_) {
+        auto pk_index = PinPkIndex(nullptr);
+        auto* pk_cell = pk_index.get();
+        AssertInfo(pk_cell != nullptr || !insert_record_.empty_pks(),
+                   "primary key index is not ready");
         for (auto& pk : pks) {
-            insert_record_.search_pk_range(
-                pk, proto::plan::OpType::Equal, bitset_view);
+            if (pk_cell != nullptr) {
+                pk_cell->pk2offset().find_range(
+                    pk,
+                    proto::plan::OpType::Equal,
+                    bitset_view,
+                    [](int64_t offset) { return true; });
+            } else {
+                insert_record_.search_pk_range(
+                    pk, proto::plan::OpType::Equal, bitset_view);
+            }
         }
         return;
     }
@@ -1459,14 +1571,56 @@ ChunkedSegmentSealedImpl::search_batch_pks(
     bool include_same_ts,
     const std::function<void(const SegOffset offset, const Timestamp ts)>&
         callback) const {
+    // Helper to read a single timestamp by segment offset.
+    // For StorageV2: pins the timestamp column and indexes into chunks.
+    // For StorageV1: reads from insert_record_ directly.
+    auto ts_column = get_column(TimestampFieldID);
+    std::vector<cachinglayer::PinWrapper<Chunk*>> ts_chunk_pins;
+    std::vector<int64_t> ts_chunk_offsets;
+    if (ts_column) {
+        ts_chunk_pins = ts_column->GetAllChunks(nullptr);
+        auto num_ts_chunks = ts_column->num_chunks();
+        ts_chunk_offsets.resize(num_ts_chunks + 1, 0);
+        for (int64_t c = 0; c < num_ts_chunks; c++) {
+            ts_chunk_offsets[c + 1] =
+                ts_chunk_offsets[c] + ts_column->chunk_row_nums(c);
+        }
+    } else {
+        AssertInfo(!insert_record_.timestamps_.empty(),
+                   "timestamp data is not ready");
+    }
+    auto read_ts = [&](int64_t offset) -> Timestamp {
+        if (!ts_column) {
+            return insert_record_.timestamps_[offset];
+        }
+        auto num_ts_chunks = static_cast<int64_t>(ts_chunk_pins.size());
+        int64_t c = 0;
+        while (c < num_ts_chunks - 1 && offset >= ts_chunk_offsets[c + 1]) {
+            ++c;
+        }
+        auto* data = reinterpret_cast<const Timestamp*>(
+            ts_chunk_pins[c].get()->RawData());
+        return data[offset - ts_chunk_offsets[c]];
+    };
+
     // handle unsorted case
     if (!is_sorted_by_pk_) {
+        auto pk_index = PinPkIndex(nullptr);
+        auto* pk_cell = pk_index.get();
+        auto timestamp_hit =
+            include_same_ts
+                ? [](Timestamp lhs, Timestamp rhs) { return lhs <= rhs; }
+                : [](Timestamp lhs, Timestamp rhs) { return lhs < rhs; };
         for (size_t i = 0; i < pks.size(); i++) {
             auto timestamp = get_timestamp(i);
-            auto offsets =
-                insert_record_.search_pk(pks[i], timestamp, include_same_ts);
+            auto offsets = pk_cell != nullptr
+                               ? pk_cell->pk2offset().find(pks[i])
+                               : insert_record_.pk2offset_->find(pks[i]);
             for (auto offset : offsets) {
-                callback(offset, timestamp);
+                auto insert_ts = read_ts(offset);
+                if (timestamp_hit(insert_ts, timestamp)) {
+                    callback(SegOffset(offset), timestamp);
+                }
             }
         }
         return;
@@ -1509,8 +1663,8 @@ ChunkedSegmentSealedImpl::search_batch_pks(
                         pk_column->GetNumRowsUntilChunk(i);
                     for (; it != src + chunk_row_num && *it == target; ++it) {
                         auto offset = it - src + num_rows_until_chunk;
-                        if (timestamp_hit(insert_record_.timestamps_[offset],
-                                          timestamp)) {
+                        auto insert_ts = read_ts(offset);
+                        if (timestamp_hit(insert_ts, timestamp)) {
                             callback(SegOffset(offset), timestamp);
                         }
                     }
@@ -1535,9 +1689,8 @@ ChunkedSegmentSealedImpl::search_batch_pks(
                            string_chunk->operator[](offset) == target;
                          ++offset) {
                         auto segment_offset = offset + num_rows_until_chunk;
-                        if (timestamp_hit(
-                                insert_record_.timestamps_[segment_offset],
-                                timestamp)) {
+                        auto insert_ts = read_ts(segment_offset);
+                        if (timestamp_hit(insert_ts, timestamp)) {
                             callback(SegOffset(segment_offset), timestamp);
                         }
                     }
@@ -1561,7 +1714,16 @@ ChunkedSegmentSealedImpl::pk_range(milvus::OpContext* op_ctx,
                                    const PkType& pk,
                                    BitsetTypeView& bitset) const {
     if (!is_sorted_by_pk_) {
-        insert_record_.search_pk_range(pk, op, bitset);
+        auto pk_index = PinPkIndex(op_ctx);
+        auto* pk_cell = pk_index.get();
+        AssertInfo(pk_cell != nullptr || !insert_record_.empty_pks(),
+                   "primary key index is not ready");
+        if (pk_cell != nullptr) {
+            pk_cell->pk2offset().find_range(
+                pk, op, bitset, [](int64_t offset) { return true; });
+        } else {
+            insert_record_.search_pk_range(pk, op, bitset);
+        }
         return;
     }
 
@@ -1604,9 +1766,30 @@ ChunkedSegmentSealedImpl::pk_binary_range(milvus::OpContext* op_ctx,
                                           bool upper_inclusive,
                                           BitsetTypeView& bitset) const {
     if (!is_sorted_by_pk_) {
-        // For unsorted segments, use the InsertRecord's binary range search
-        insert_record_.search_pk_binary_range(
-            lower_pk, lower_inclusive, upper_pk, upper_inclusive, bitset);
+        auto pk_index = PinPkIndex(op_ctx);
+        auto* pk_cell = pk_index.get();
+        AssertInfo(pk_cell != nullptr || !insert_record_.empty_pks(),
+                   "primary key index is not ready");
+        if (pk_cell != nullptr) {
+            auto lower_op = lower_inclusive ? proto::plan::OpType::GreaterEqual
+                                            : proto::plan::OpType::GreaterThan;
+            auto upper_op = upper_inclusive ? proto::plan::OpType::LessEqual
+                                            : proto::plan::OpType::LessThan;
+            BitsetType upper_result(bitset.size());
+            auto upper_view = upper_result.view();
+            pk_cell->pk2offset().find_range(
+                lower_pk, lower_op, bitset, [](int64_t offset) {
+                    return true;
+                });
+            pk_cell->pk2offset().find_range(
+                upper_pk, upper_op, upper_view, [](int64_t offset) {
+                    return true;
+                });
+            bitset &= upper_result;
+        } else {
+            insert_record_.search_pk_binary_range(
+                lower_pk, lower_inclusive, upper_pk, upper_inclusive, bitset);
+        }
         return;
     }
 
@@ -1648,6 +1831,13 @@ std::pair<std::vector<OffsetMap::OffsetType>, bool>
 ChunkedSegmentSealedImpl::find_first_n(int64_t limit,
                                        const BitsetTypeView& bitset) const {
     if (!is_sorted_by_pk_) {
+        auto pk_index = PinPkIndex(nullptr);
+        auto* pk_cell = pk_index.get();
+        AssertInfo(pk_cell != nullptr || !insert_record_.empty_pks(),
+                   "primary key index is not ready");
+        if (pk_cell != nullptr) {
+            return pk_cell->pk2offset().find_first_n(limit, bitset);
+        }
         return insert_record_.pk2offset_->find_first_n(limit, bitset);
     }
     if (limit == Unlimited || limit == NoLimit) {
@@ -1793,13 +1983,34 @@ ChunkedSegmentSealedImpl::bulk_subscript(milvus::OpContext* op_ctx,
     switch (system_type) {
         case SystemFieldType::Timestamp: {
             auto* dst = static_cast<Timestamp*>(output);
-            auto& ts = insert_record_.timestamps_;
-            if (ts.num_chunks() == 1) {
-                auto* src = ts.chunk_data(0);
+            auto ts_column = get_column(TimestampFieldID);
+            if (ts_column) {
+                // StorageV2: read from timestamp column directly
+                auto all_chunks = ts_column->GetAllChunks(op_ctx);
+                // Build prefix-sum for chunk offset lookup
+                auto num_chunks = ts_column->num_chunks();
+                std::vector<int64_t> chunk_offsets(num_chunks + 1, 0);
+                for (int64_t c = 0; c < num_chunks; c++) {
+                    chunk_offsets[c + 1] =
+                        chunk_offsets[c] + ts_column->chunk_row_nums(c);
+                }
                 for (int64_t i = 0; i < count; ++i) {
-                    dst[i] = src[seg_offsets[i]];
+                    auto offset = seg_offsets[i];
+                    // Find chunk via linear scan (chunks are typically few)
+                    int64_t c = 0;
+                    while (c < num_chunks - 1 &&
+                           offset >= chunk_offsets[c + 1]) {
+                        ++c;
+                    }
+                    auto* chunk_data = reinterpret_cast<const Timestamp*>(
+                        all_chunks[c].get()->RawData());
+                    dst[i] = chunk_data[offset - chunk_offsets[c]];
                 }
             } else {
+                // StorageV1 fallback
+                AssertInfo(!insert_record_.timestamps_.empty(),
+                           "timestamp data is not ready");
+                auto& ts = insert_record_.timestamps_;
                 for (int64_t i = 0; i < count; ++i) {
                     dst[i] = ts[seg_offsets[i]];
                 }
@@ -2096,7 +2307,6 @@ ChunkedSegmentSealedImpl::ClearData() {
         index_ready_bitset_.reset();
         binlog_index_bitset_.reset();
         index_has_raw_data_.clear();
-        system_ready_count_ = 0;
         num_rows_ = std::nullopt;
         ngram_fields_.wlock()->clear();
         scalar_indexings_.withWLock([&](auto& scalar_indexings) {
@@ -2110,6 +2320,8 @@ ChunkedSegmentSealedImpl::ClearData() {
             cancel_and_clear_json_indices(json_indexings);
         });
         insert_record_.clear();
+        timestamp_index_slot_.wlock()->reset();
+        pk_index_slot_.wlock()->reset();
         fields_.wlock()->clear();
         variable_fields_avg_size_.clear();
         stats_.mem_size = 0;
@@ -2573,16 +2785,23 @@ ChunkedSegmentSealedImpl::bulk_subscript(milvus::OpContext* op_ctx,
 
     // Fast path for int64 PK field: use compressed offset2pk index
     auto pk_field_id = schema_->get_primary_field_id();
+    auto pk_index = PinPkIndex(op_ctx);
     if (pk_field_id.has_value() && pk_field_id.value() == field_id &&
         field_meta.get_data_type() == DataType::INT64 &&
-        insert_record_.has_int64_pk_index()) {
+        (pk_index.get() != nullptr ? pk_index.get()->has_int64_pk_index()
+                                   : insert_record_.has_int64_pk_index())) {
         auto ret = fill_with_empty(field_id, count);
         auto* output = ret->mutable_scalars()
                            ->mutable_long_data()
                            ->mutable_data()
                            ->mutable_data();
-        insert_record_.bulk_get_int64_pks_by_offsets(
-            seg_offsets, count, output);
+        if (pk_index.get() != nullptr) {
+            pk_index.get()->bulk_get_int64_pks_by_offsets(
+                seg_offsets, count, output);
+        } else {
+            insert_record_.bulk_get_int64_pks_by_offsets(
+                seg_offsets, count, output);
+        }
         return ret;
     }
 
@@ -2789,11 +3008,17 @@ ChunkedSegmentSealedImpl::Delete(int64_t size,
     }
     // if insert record is empty (may be only-load meta but not data for lru-cache at go side),
     // filtering may cause the deletion lost, skip the filtering to avoid it.
-    if (!insert_record_.empty_pks()) {
+    auto pk_index = PinPkIndex(nullptr);
+    auto has_pk_index = pk_index.get() != nullptr ? !pk_index.get()->empty_pks()
+                                                  : !insert_record_.empty_pks();
+    if (has_pk_index) {
         auto end = std::remove_if(
             ordering.begin(),
             ordering.end(),
             [&](const std::tuple<Timestamp, PkType>& record) {
+                if (pk_index.get() != nullptr) {
+                    return !pk_index.get()->contain(std::get<1>(record));
+                }
                 return !insert_record_.contain(std::get<1>(record));
             });
         size = end - ordering.begin();
@@ -2836,8 +3061,9 @@ ChunkedSegmentSealedImpl::get_active_count(Timestamp ts) const {
     return this->get_row_count();
 }
 
-// Helper: apply a per-element timestamp scan over a range [beg, end) on
-// segmented TimestampData, calling `pred(global_offset, ts_value)` for each.
+// Helper: apply a per-element timestamp scan over a range [beg, end),
+// calling `pred(global_offset, ts_value)` for each row.
+// Overload for TimestampData (StorageV1 / growing segment path).
 template <typename Pred>
 static void
 scan_timestamp_range(const TimestampData& ts,
@@ -2860,6 +3086,35 @@ scan_timestamp_range(const TimestampData& ts,
     }
 }
 
+// Overload for ChunkedColumnInterface (StorageV2 sealed segment path).
+// Pins each chunk on demand and releases after scanning.
+template <typename Pred>
+static void
+scan_timestamp_range(const ChunkedColumnInterface& column,
+                     int64_t beg,
+                     int64_t end,
+                     Pred pred) {
+    auto num_chunks = column.num_chunks();
+    int64_t chunk_start = 0;
+    for (int64_t c = 0; c < num_chunks; c++) {
+        auto chunk_rows = column.chunk_row_nums(c);
+        auto chunk_end = chunk_start + chunk_rows;
+        auto overlap_beg = std::max(beg, chunk_start);
+        auto overlap_end = std::min(end, chunk_end);
+        if (overlap_beg >= overlap_end) {
+            chunk_start = chunk_end;
+            continue;
+        }
+        auto pw = column.DataOfChunk(nullptr, c);
+        auto* data = reinterpret_cast<const Timestamp*>(pw.get());
+        auto local = overlap_beg - chunk_start;
+        for (int64_t i = overlap_beg; i < overlap_end; ++i, ++local) {
+            pred(i, data[local]);
+        }
+        chunk_start = chunk_end;
+    }
+}
+
 void
 ChunkedSegmentSealedImpl::mask_with_timestamps(BitsetTypeView& bitset_chunk,
                                                Timestamp timestamp,
@@ -2868,11 +3123,27 @@ ChunkedSegmentSealedImpl::mask_with_timestamps(BitsetTypeView& bitset_chunk,
     if (schema_->is_external_collection()) {
         return;
     }
-    auto& ts = insert_record_.timestamps_;
-    auto total_size = static_cast<int64_t>(ts.size());
+    auto ts_index = PinTimestampIndex(nullptr);
+    auto* ts_cell = ts_index.get();
+    AssertInfo(ts_cell != nullptr || !insert_record_.timestamps_.empty(),
+               "timestamp index is not ready");
+    auto& ts_index_data = ts_cell != nullptr ? ts_cell->timestamp_index()
+                                             : insert_record_.timestamp_index_;
+    auto ts_column =
+        ts_cell != nullptr ? get_column(TimestampFieldID) : nullptr;
+    auto total_size = static_cast<int64_t>(get_row_count());
+
+    // Lambda to dispatch scan_timestamp_range to the right overload
+    auto do_scan = [&](int64_t beg, int64_t end, auto pred) {
+        if (ts_column) {
+            scan_timestamp_range(*ts_column, beg, end, pred);
+        } else {
+            scan_timestamp_range(insert_record_.timestamps_, beg, end, pred);
+        }
+    };
+
     if (collection_ttl > 0) {
-        auto range =
-            insert_record_.timestamp_index_.get_active_range(collection_ttl);
+        auto range = ts_index_data.get_active_range(collection_ttl);
         if (range.first == range.second && range.first == total_size) {
             bitset_chunk.set();
             return;
@@ -2882,10 +3153,9 @@ ChunkedSegmentSealedImpl::mask_with_timestamps(BitsetTypeView& bitset_chunk,
             ttl_mask.reserve(total_size);
             ttl_mask.resize(range.first, true);
             ttl_mask.resize(total_size, false);
-            scan_timestamp_range(
-                ts, range.first, range.second, [&](int64_t i, Timestamp val) {
-                    ttl_mask[i] = val <= collection_ttl;
-                });
+            do_scan(range.first, range.second, [&](int64_t i, Timestamp val) {
+                ttl_mask[i] = val <= collection_ttl;
+            });
             bitset_chunk |= ttl_mask;
         }
     }
@@ -2894,7 +3164,7 @@ ChunkedSegmentSealedImpl::mask_with_timestamps(BitsetTypeView& bitset_chunk,
                fmt::format("Timestamp size not equal to row count: {}, {}",
                            total_size,
                            get_row_count()));
-    auto range = insert_record_.timestamp_index_.get_active_range(timestamp);
+    auto range = ts_index_data.get_active_range(timestamp);
 
     // range == (size_, size_): all data is useful, no filtering needed.
     if (range.first == range.second && range.first == total_size) {
@@ -2910,10 +3180,9 @@ ChunkedSegmentSealedImpl::mask_with_timestamps(BitsetTypeView& bitset_chunk,
     mask.reserve(total_size);
     mask.resize(range.first, false);
     mask.resize(total_size, true);
-    scan_timestamp_range(
-        ts, range.first, range.second, [&](int64_t i, Timestamp val) {
-            mask[i] = val > timestamp;
-        });
+    do_scan(range.first, range.second, [&](int64_t i, Timestamp val) {
+        mask[i] = val > timestamp;
+    });
     bitset_chunk |= mask;
 }
 
@@ -3140,18 +3409,22 @@ ChunkedSegmentSealedImpl::load_field_data_common(
 
     // set pks to offset
     if (schema_->get_primary_field_id() == field_id) {
-        // Always build compressed offset->pk for FillPrimaryKeys fast path
-        insert_record_.build_offset2pk(data_type, column.get());
+        if (is_proxy_column) {
+            init_storage_v2_pk_index(field_id, column, data_type);
+        } else {
+            // Always build compressed offset->pk for FillPrimaryKeys fast path
+            insert_record_.build_offset2pk(data_type, column.get());
 
-        if (!is_sorted_by_pk_) {
-            AssertInfo(field_id.get() != -1, "Primary key is -1");
-            if (!is_replace) {
-                AssertInfo(
-                    insert_record_.empty_pks(),
-                    "primary key records already exists, current field id {}",
-                    field_id.get());
-                insert_record_.insert_pks(data_type, column.get());
-                insert_record_.seal_pks();
+            if (!is_sorted_by_pk_) {
+                AssertInfo(field_id.get() != -1, "Primary key is -1");
+                if (!is_replace) {
+                    AssertInfo(insert_record_.empty_pks(),
+                               "primary key records already exists, current "
+                               "field id {}",
+                               field_id.get());
+                    insert_record_.insert_pks(data_type, column.get());
+                    insert_record_.seal_pks();
+                }
             }
         }
     }
@@ -3764,12 +4037,8 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
             op_ctx,
             is_replace);
         if (field_id == TimestampFieldID) {
-            auto timestamp_proxy_column = get_column(TimestampFieldID);
-            AssertInfo(timestamp_proxy_column != nullptr,
-                       "timestamp proxy column is nullptr");
-            int64_t num_rows = segment_load_info_.GetNumOfRows();
-            init_timestamp_index_from_column(timestamp_proxy_column, num_rows);
-            system_ready_count_++;
+            init_storage_v2_timestamp_index(column,
+                                            segment_load_info_.GetNumOfRows());
         }
     }
 }

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -341,6 +341,28 @@ ChunkedSegmentSealedImpl::init_storage_v2_timestamp_index(
                 id_, column, num_rows, warmup_policy);
     *timestamp_index_slot_.wlock() =
         Manager::GetInstance().CreateCacheSlot(std::move(translator));
+
+    // Provide a callback so DeletedRecord can read insert timestamps
+    // from the column even when insert_record_.timestamps_ is empty
+    // (StorageV2 lazy-init path). This preserves the same-timestamp
+    // correctness check in DeletedRecord::InternalPush.
+    auto ts_col = column;
+    deleted_record_.set_get_insert_timestamp_func(
+        [ts_col](int64_t row_id) -> Timestamp {
+            auto num_chunks = ts_col->num_chunks();
+            int64_t offset = 0;
+            for (int64_t c = 0; c < num_chunks; ++c) {
+                auto chunk_rows = ts_col->chunk_row_nums(c);
+                if (row_id < offset + chunk_rows) {
+                    auto pin = ts_col->GetChunk(nullptr, c);
+                    auto* chunk_data = reinterpret_cast<const Timestamp*>(
+                        pin.get()->RawData());
+                    return chunk_data[row_id - offset];
+                }
+                offset += chunk_rows;
+            }
+            return 0;
+        });
 }
 
 void

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -2571,6 +2571,21 @@ ChunkedSegmentSealedImpl::bulk_subscript(milvus::OpContext* op_ctx,
         return fill_with_empty(field_id, count);
     }
 
+    // Fast path for int64 PK field: use compressed offset2pk index
+    auto pk_field_id = schema_->get_primary_field_id();
+    if (pk_field_id.has_value() && pk_field_id.value() == field_id &&
+        field_meta.get_data_type() == DataType::INT64 &&
+        insert_record_.has_int64_pk_index()) {
+        auto ret = fill_with_empty(field_id, count);
+        auto* output = ret->mutable_scalars()
+                           ->mutable_long_data()
+                           ->mutable_data()
+                           ->mutable_data();
+        insert_record_.bulk_get_int64_pks_by_offsets(
+            seg_offsets, count, output);
+        return ret;
+    }
+
     if (!IsVectorDataType(field_meta.get_data_type())) {
         // === Scalar field ===
         // Try index first: if scalar index exists and has raw data, read from index
@@ -3124,17 +3139,21 @@ ChunkedSegmentSealedImpl::load_field_data_common(
     }
 
     // set pks to offset
-    if (schema_->get_primary_field_id() == field_id && !is_sorted_by_pk_) {
-        AssertInfo(field_id.get() != -1, "Primary key is -1");
-        if (!is_replace) {
-            AssertInfo(
-                insert_record_.empty_pks(),
-                "primary key records already exists, current field id {}",
-                field_id.get());
-            insert_record_.insert_pks(data_type, column.get());
-            insert_record_.seal_pks();
+    if (schema_->get_primary_field_id() == field_id) {
+        // Always build compressed offset->pk for FillPrimaryKeys fast path
+        insert_record_.build_offset2pk(data_type, column.get());
+
+        if (!is_sorted_by_pk_) {
+            AssertInfo(field_id.get() != -1, "Primary key is -1");
+            if (!is_replace) {
+                AssertInfo(
+                    insert_record_.empty_pks(),
+                    "primary key records already exists, current field id {}",
+                    field_id.get());
+                insert_record_.insert_pks(data_type, column.get());
+                insert_record_.seal_pks();
+            }
         }
-        // TODO: handle PK replacement for insert_record_ in future
     }
 
     // now interim index does not touch column warmup

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -332,11 +332,13 @@ ChunkedSegmentSealedImpl::is_system_field_ready() const {
 
 void
 ChunkedSegmentSealedImpl::init_storage_v2_timestamp_index(
-    const std::shared_ptr<ChunkedColumnInterface>& column, size_t num_rows) {
+    const std::shared_ptr<ChunkedColumnInterface>& column,
+    size_t num_rows,
+    const std::string& warmup_policy) {
     std::unique_ptr<Translator<storagev2translator::TimestampIndexCell>>
         translator =
             std::make_unique<storagev2translator::TimestampIndexTranslator>(
-                id_, column, num_rows);
+                id_, column, num_rows, warmup_policy);
     *timestamp_index_slot_.wlock() =
         Manager::GetInstance().CreateCacheSlot(std::move(translator));
 }
@@ -819,7 +821,8 @@ ChunkedSegmentSealedImpl::load_column_group_data_internal(
                 op_ctx,
                 is_replace);
             if (field_id == TimestampFieldID) {
-                init_storage_v2_timestamp_index(column, num_rows);
+                init_storage_v2_timestamp_index(
+                    column, num_rows, info.warmup_policy);
             }
         }
 

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -624,7 +624,8 @@ ChunkedSegmentSealedImpl::SynthesizeExternalSystemFields() {
     if (num_rows == 0) {
         std::unique_lock lck(mutex_);
         update_row_count(0);
-        system_ready_count_++;
+        // Initialize empty timestamps so is_system_field_ready() returns true
+        insert_record_.init_timestamps_from_owned({}, TimestampIndex());
         return;
     }
 
@@ -654,7 +655,6 @@ ChunkedSegmentSealedImpl::SynthesizeExternalSystemFields() {
         std::unique_lock lck(mutex_);
         update_row_count(num_rows);
     }
-    system_ready_count_++;
 }
 
 std::optional<ChunkedSegmentSealedImpl::ParquetStatistics>

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -342,6 +342,31 @@ ChunkedSegmentSealedImpl::init_storage_v2_timestamp_index(
 }
 
 void
+ChunkedSegmentSealedImpl::init_storage_v1_pk_index(
+    FieldId field_id,
+    const std::shared_ptr<ChunkedColumnInterface>& column,
+    DataType data_type,
+    bool is_replace) {
+    if (schema_->get_primary_field_id() != field_id) {
+        return;
+    }
+    // Build compressed offset->pk for FillPrimaryKeys fast path
+    insert_record_.build_offset2pk(data_type, column.get());
+
+    if (!is_sorted_by_pk_) {
+        AssertInfo(field_id.get() != -1, "Primary key is -1");
+        if (!is_replace) {
+            AssertInfo(insert_record_.empty_pks(),
+                       "primary key records already exists, current "
+                       "field id {}",
+                       field_id.get());
+            insert_record_.insert_pks(data_type, column.get());
+            insert_record_.seal_pks();
+        }
+    }
+}
+
+void
 ChunkedSegmentSealedImpl::init_storage_v2_pk_index(
     FieldId field_id,
     const std::shared_ptr<ChunkedColumnInterface>& column,
@@ -929,7 +954,7 @@ ChunkedSegmentSealedImpl::load_system_field_internal(
             offset += chunk_ptr->Span().row_count();
         }
 
-        init_timestamp_index_owned(std::move(timestamps), num_rows);
+        init_storage_v1_timestamp_index(std::move(timestamps), num_rows);
     } else {
         AssertInfo(system_field_type == SystemFieldType::RowId,
                    "System field type of id column is not RowId");
@@ -3409,23 +3434,10 @@ ChunkedSegmentSealedImpl::load_field_data_common(
 
     // set pks to offset
     if (schema_->get_primary_field_id() == field_id) {
-        if (is_proxy_column) {
+        if (segment_load_info_.GetStorageVersion() >= STORAGE_V2) {
             init_storage_v2_pk_index(field_id, column, data_type);
         } else {
-            // Always build compressed offset->pk for FillPrimaryKeys fast path
-            insert_record_.build_offset2pk(data_type, column.get());
-
-            if (!is_sorted_by_pk_) {
-                AssertInfo(field_id.get() != -1, "Primary key is -1");
-                if (!is_replace) {
-                    AssertInfo(insert_record_.empty_pks(),
-                               "primary key records already exists, current "
-                               "field id {}",
-                               field_id.get());
-                    insert_record_.insert_pks(data_type, column.get());
-                    insert_record_.seal_pks();
-                }
-            }
+            init_storage_v1_pk_index(field_id, column, data_type, is_replace);
         }
     }
 
@@ -3499,53 +3511,7 @@ build_timestamp_index(const Timestamp* data, size_t num_rows) {
 }
 
 void
-ChunkedSegmentSealedImpl::init_timestamp_index_from_column(
-    std::shared_ptr<ChunkedColumnInterface> column, size_t num_rows) {
-    auto all_chunks = column->GetAllChunks(nullptr);
-
-    // Build timestamp index — needs contiguous data
-    TimestampIndex index;
-    if (all_chunks.size() == 1) {
-        // Single chunk: build index directly from chunk data
-        auto* fixed_chunk = static_cast<FixedWidthChunk*>(all_chunks[0].get());
-        auto span = fixed_chunk->Span();
-        auto* ts_ptr = static_cast<const Timestamp*>(span.data());
-        AssertInfo(static_cast<size_t>(span.row_count()) == num_rows,
-                   "timestamp chunk row count {} != expected {}",
-                   span.row_count(),
-                   num_rows);
-        index = build_timestamp_index(ts_ptr, num_rows);
-    } else {
-        // Multi-chunk: temp contiguous copy for index building only
-        std::vector<Timestamp> temp(num_rows);
-        size_t offset = 0;
-        for (auto& pin : all_chunks) {
-            auto* fixed_chunk = static_cast<FixedWidthChunk*>(pin.get());
-            auto span = fixed_chunk->Span();
-            auto n = std::min(static_cast<size_t>(span.row_count()),
-                              num_rows - offset);
-            std::copy_n(static_cast<const Timestamp*>(span.data()),
-                        n,
-                        temp.data() + offset);
-            offset += n;
-        }
-        AssertInfo(offset == num_rows,
-                   "timestamp total row count {} != expected {}",
-                   offset,
-                   num_rows);
-        index = build_timestamp_index(temp.data(), num_rows);
-        // temp is freed here — runtime access uses pinned chunks directly
-    }
-
-    // Always pin mode: zero-copy segmented access
-    std::unique_lock lck(mutex_);
-    AssertInfo(insert_record_.timestamps_.empty(), "already exists");
-    insert_record_.init_timestamps_from_column(
-        std::move(column), std::move(all_chunks), std::move(index));
-}
-
-void
-ChunkedSegmentSealedImpl::init_timestamp_index_owned(
+ChunkedSegmentSealedImpl::init_storage_v1_timestamp_index(
     std::vector<Timestamp> timestamps, size_t num_rows) {
     auto index = build_timestamp_index(timestamps.data(), num_rows);
     std::unique_lock lck(mutex_);

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -527,15 +527,9 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         FieldDataInfo& data,
         milvus::proto::common::LoadPriority load_priority);
 
-    // Initialize timestamp index from a column (zero-copy pin mode for single
-    // chunk, owned copy for multi-chunk)
-    void
-    init_timestamp_index_from_column(
-        std::shared_ptr<ChunkedColumnInterface> column, size_t num_rows);
-
     // Initialize timestamp index with owned data (StorageV1 path)
     void
-    init_timestamp_index_owned(std::vector<Timestamp> timestamps,
+    init_storage_v1_timestamp_index(std::vector<Timestamp> timestamps,
                                size_t num_rows);
 
     template <typename PK>
@@ -1241,6 +1235,13 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     void
     init_storage_v2_timestamp_index(
         const std::shared_ptr<ChunkedColumnInterface>& column, size_t num_rows);
+
+    void
+    init_storage_v1_pk_index(
+        FieldId field_id,
+        const std::shared_ptr<ChunkedColumnInterface>& column,
+        DataType data_type,
+        bool is_replace);
 
     void
     init_storage_v2_pk_index(

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -86,6 +86,11 @@ namespace storagev1translator {
 class InsertRecordTranslator;
 }
 
+namespace storagev2translator {
+class TimestampIndexCell;
+class PkIndexCell;
+}
+
 using namespace milvus::cachinglayer;
 
 class ChunkedSegmentSealedImpl : public SegmentSealed {
@@ -144,9 +149,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     }
 
     bool
-    Contain(const PkType& pk) const override {
-        return insert_record_.contain(pk);
-    }
+    Contain(const PkType& pk) const override;
 
     void
     AddFieldDataInfoForSealed(
@@ -1062,9 +1065,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                      Timestamp timestamp) const override;
 
     bool
-    is_system_field_ready() const {
-        return system_ready_count_ == 1;
-    }
+    is_system_field_ready() const;
 
     void
     search_ids(BitsetType& bitset, const IdArray& id_array) const override;
@@ -1231,6 +1232,23 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         return res;
     }
 
+    PinWrapper<const storagev2translator::TimestampIndexCell*>
+    PinTimestampIndex(milvus::OpContext* op_ctx) const;
+
+    PinWrapper<const storagev2translator::PkIndexCell*>
+    PinPkIndex(milvus::OpContext* op_ctx) const;
+
+    void
+    init_storage_v2_timestamp_index(
+        const std::shared_ptr<ChunkedColumnInterface>& column,
+        size_t num_rows);
+
+    void
+    init_storage_v2_pk_index(
+        FieldId field_id,
+        const std::shared_ptr<ChunkedColumnInterface>& column,
+        DataType data_type);
+
 #ifdef MILVUS_UNIT_TEST
  public:
     // Test-only: inject a mock Reader for unit testing take() paths.
@@ -1264,7 +1282,6 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     BitsetType field_data_ready_bitset_;
     BitsetType index_ready_bitset_;
     BitsetType binlog_index_bitset_;
-    std::atomic<int> system_ready_count_ = 0;
 
     // when index is ready (index_ready_bitset_/binlog_index_bitset_ is set to true), must also set index_has_raw_data_
     // to indicate whether the loaded index has raw data.
@@ -1290,6 +1307,12 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
 
     // inserted fields data and row_ids, timestamps
     InsertRecord<true> insert_record_;
+    folly::Synchronized<
+        std::shared_ptr<CacheSlot<storagev2translator::TimestampIndexCell>>>
+        timestamp_index_slot_;
+    folly::Synchronized<
+        std::shared_ptr<CacheSlot<storagev2translator::PkIndexCell>>>
+        pk_index_slot_;
 
     // deleted pks
     mutable DeletedRecord<true> deleted_record_;

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -89,7 +89,7 @@ class InsertRecordTranslator;
 namespace storagev2translator {
 class TimestampIndexCell;
 class PkIndexCell;
-}
+}  // namespace storagev2translator
 
 using namespace milvus::cachinglayer;
 
@@ -1240,8 +1240,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
 
     void
     init_storage_v2_timestamp_index(
-        const std::shared_ptr<ChunkedColumnInterface>& column,
-        size_t num_rows);
+        const std::shared_ptr<ChunkedColumnInterface>& column, size_t num_rows);
 
     void
     init_storage_v2_pk_index(

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -530,7 +530,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     // Initialize timestamp index with owned data (StorageV1 path)
     void
     init_storage_v1_timestamp_index(std::vector<Timestamp> timestamps,
-                               size_t num_rows);
+                                    size_t num_rows);
 
     template <typename PK>
     void
@@ -1234,7 +1234,9 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
 
     void
     init_storage_v2_timestamp_index(
-        const std::shared_ptr<ChunkedColumnInterface>& column, size_t num_rows);
+        const std::shared_ptr<ChunkedColumnInterface>& column,
+        size_t num_rows,
+        const std::string& warmup_policy = "");
 
     void
     init_storage_v1_pk_index(

--- a/internal/core/src/segcore/ChunkedSegmentSealedStorageV2Test.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedStorageV2Test.cpp
@@ -73,16 +73,28 @@ using namespace milvus::segcore::storagev1translator;
 
 class TestChunkSegmentStorageV2 : public testing::TestWithParam<bool> {
  protected:
-    void
-    SetUp() override {
-        bool pk_is_string = GetParam();
-        auto schema = segcore::GenChunkedSegmentTestSchema(pk_is_string);
-        segment = segcore::CreateSealedSegment(
-            schema,
+    segcore::SegmentSealedUPtr
+    CreateSegment(bool is_sorted_by_pk) {
+        auto seg = segcore::CreateSealedSegment(
+            schema_,
             nullptr,
             -1,
             segcore::SegcoreConfig::default_config(),
-            true);
+            is_sorted_by_pk);
+        seg->AddFieldDataInfoForSealed(load_info_);
+        for (auto& [id, info] : load_info_.field_infos) {
+            LoadFieldDataInfo load_field_info;
+            load_field_info.storage_version = 2;
+            load_field_info.field_infos.emplace(id, info);
+            seg->LoadFieldData(load_field_info);
+        }
+        return seg;
+    }
+
+    void
+    SetUp() override {
+        bool pk_is_string = GetParam();
+        schema_ = segcore::GenChunkedSegmentTestSchema(pk_is_string);
 
         // Use globally initialized ArrowFileSystem
         auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
@@ -110,7 +122,7 @@ class TestChunkSegmentStorageV2 : public testing::TestWithParam<bool> {
         auto result = milvus_storage::PackedRecordBatchWriter::Make(
             fs,
             paths,
-            schema->ConvertToArrowSchema(),
+            schema_->ConvertToArrowSchema(),
             storage_config,
             column_groups,
             writer_memory,
@@ -128,13 +140,13 @@ class TestChunkSegmentStorageV2 : public testing::TestWithParam<bool> {
         }
         std::sort(str_data.begin(), str_data.end());
 
-        fields = {{"int64", schema->get_field_id(FieldName("int64"))},
-                  {"pk", schema->get_field_id(FieldName("pk"))},
+        fields = {{"int64", schema_->get_field_id(FieldName("int64"))},
+                  {"pk", schema_->get_field_id(FieldName("pk"))},
                   {"ts", TimestampFieldID},
-                  {"string1", schema->get_field_id(FieldName("string1"))},
-                  {"string2", schema->get_field_id(FieldName("string2"))}};
+                  {"string1", schema_->get_field_id(FieldName("string1"))},
+                  {"string2", schema_->get_field_id(FieldName("string2"))}};
 
-        auto arrow_schema = schema->ConvertToArrowSchema();
+        auto arrow_schema = schema_->ConvertToArrowSchema();
         for (int chunk_id = 0; chunk_id < chunk_num;
              chunk_id++, start_id += test_data_count) {
             std::vector<int64_t> test_data(test_data_count);
@@ -170,14 +182,13 @@ class TestChunkSegmentStorageV2 : public testing::TestWithParam<bool> {
 
             // Create record batch
             auto record_batch = arrow::RecordBatch::Make(
-                schema->ConvertToArrowSchema(), test_data_count, arrays);
+                schema_->ConvertToArrowSchema(), test_data_count, arrays);
             row_count += test_data_count;
             EXPECT_TRUE(writer->Write(record_batch).ok());
         }
         EXPECT_TRUE(writer->Close().ok());
 
-        LoadFieldDataInfo load_info;
-        load_info.field_infos.emplace(
+        load_info_.field_infos.emplace(
             int64_t(0),
             FieldBinlogInfo{
                 int64_t(0),
@@ -187,7 +198,7 @@ class TestChunkSegmentStorageV2 : public testing::TestWithParam<bool> {
                 false,
                 "",
                 std::vector<std::string>({paths[0]})});
-        load_info.field_infos.emplace(
+        load_info_.field_infos.emplace(
             int64_t(102),
             FieldBinlogInfo{
                 int64_t(102),
@@ -197,7 +208,7 @@ class TestChunkSegmentStorageV2 : public testing::TestWithParam<bool> {
                 false,
                 "",
                 std::vector<std::string>({paths[1]})});
-        load_info.field_infos.emplace(
+        load_info_.field_infos.emplace(
             int64_t(103),
             FieldBinlogInfo{
                 int64_t(103),
@@ -207,14 +218,8 @@ class TestChunkSegmentStorageV2 : public testing::TestWithParam<bool> {
                 false,
                 "",
                 std::vector<std::string>({paths[2]})});
-        load_info.storage_version = 2;
-        segment->AddFieldDataInfoForSealed(load_info);
-        for (auto& [id, info] : load_info.field_infos) {
-            LoadFieldDataInfo load_field_info;
-            load_field_info.storage_version = 2;
-            load_field_info.field_infos.emplace(id, info);
-            segment->LoadFieldData(load_field_info);
-        }
+        load_info_.storage_version = 2;
+        segment = CreateSegment(true);
     }
 
     void
@@ -227,6 +232,8 @@ class TestChunkSegmentStorageV2 : public testing::TestWithParam<bool> {
     }
 
     segcore::SegmentSealedUPtr segment;
+    SchemaPtr schema_;
+    LoadFieldDataInfo load_info_;
     int chunk_num = 2;
     int test_data_count = 10000;
     std::unordered_map<std::string, FieldId> fields;
@@ -363,4 +370,161 @@ TEST_P(TestChunkSegmentStorageV2, TestCompareExpr) {
     final = query::ExecuteQueryExpr(
         plan, segment.get(), chunk_num * test_data_count, MAX_TIMESTAMP);
     ASSERT_EQ(chunk_num * test_data_count, final.count());
+}
+
+// Test DropFieldData behavior based on parquet file structure.
+// In this test setup, the parquet files are organized as:
+//   - paths[0] contains columns {0, 4, 3} = int64, ts, string2 (multi-field column group)
+//   - paths[1] contains column {2} = string1 (single-field group)
+//   - paths[2] contains column {1} = pk (single-field group)
+// When storage_version=2 reads a parquet file with multiple columns, they become
+// a multi-field column group, so DropFieldData should be skipped for those fields.
+TEST_P(TestChunkSegmentStorageV2, TestDropFieldDataWithColumnGroups) {
+    auto segment_impl = dynamic_cast<ChunkedSegmentSealedImpl*>(segment.get());
+    ASSERT_NE(segment_impl, nullptr);
+
+    // Verify fields have data initially
+    auto int64_fid = fields.at("int64");
+    auto string1_fid = fields.at("string1");
+    auto string2_fid = fields.at("string2");
+
+    EXPECT_TRUE(segment_impl->HasFieldData(int64_fid))
+        << "int64 field data should be ready";
+    EXPECT_TRUE(segment_impl->HasFieldData(string1_fid))
+        << "string1 field data should be ready";
+    EXPECT_TRUE(segment_impl->HasFieldData(string2_fid))
+        << "string2 field data should be ready";
+
+    // int64 and string2 are in the same parquet file (multi-field column group)
+    // DropFieldData should be SKIPPED for these fields
+    segment_impl->DropFieldData(int64_fid);
+
+    // int64 should still have data because it's in a multi-field column group
+    EXPECT_TRUE(segment_impl->HasFieldData(int64_fid))
+        << "int64 field data should still be ready (multi-field column group)";
+
+    // string2 is in the same group, should also still have data
+    EXPECT_TRUE(segment_impl->HasFieldData(string2_fid))
+        << "string2 field data should still be ready (same column group as "
+           "int64)";
+
+    // string1 is in its own parquet file (single-field group)
+    // DropFieldData SHOULD work for this field
+    segment_impl->DropFieldData(string1_fid);
+    EXPECT_FALSE(segment_impl->HasFieldData(string1_fid))
+        << "string1 field data should be dropped (single-field column group)";
+
+    // int64 and string2 should still have data
+    EXPECT_TRUE(segment_impl->HasFieldData(int64_fid))
+        << "int64 field data should still be ready";
+    EXPECT_TRUE(segment_impl->HasFieldData(string2_fid))
+        << "string2 field data should still be ready";
+}
+
+TEST_P(TestChunkSegmentStorageV2, TestLazySystemIndexesOnUnsortedSegment) {
+    auto unsorted_segment = CreateSegment(false);
+    auto* segment_internal =
+        dynamic_cast<SegmentInternalInterface*>(unsorted_segment.get());
+    auto* segment_impl =
+        dynamic_cast<ChunkedSegmentSealedImpl*>(unsorted_segment.get());
+    ASSERT_NE(segment_internal, nullptr);
+    ASSERT_NE(segment_impl, nullptr);
+
+    PkType existing_pk;
+    PkType missing_pk;
+    std::unique_ptr<IdArray> delete_ids = std::make_unique<IdArray>();
+    if (GetParam()) {
+        existing_pk = std::string("test42");
+        missing_pk = std::string("test_missing");
+        delete_ids->mutable_str_id()->mutable_data()->Add("test42");
+    } else {
+        existing_pk = int64_t(42);
+        missing_pk = int64_t(-1);
+        delete_ids->mutable_int_id()->mutable_data()->Add(42);
+    }
+
+    EXPECT_TRUE(segment_impl->Contain(existing_pk));
+    EXPECT_FALSE(segment_impl->Contain(missing_pk));
+
+    Timestamp delete_ts = MAX_TIMESTAMP;
+    auto status = unsorted_segment->Delete(1, delete_ids.get(), &delete_ts);
+    ASSERT_TRUE(status.ok());
+
+    BitsetType timestamp_mask(chunk_num * test_data_count);
+    BitsetTypeView timestamp_mask_view(timestamp_mask);
+    segment_internal->mask_with_timestamps(timestamp_mask_view, 41, 0);
+    ASSERT_FALSE(timestamp_mask[41]);
+    ASSERT_TRUE(timestamp_mask[42]);
+
+    timestamp_mask.reset();
+    segment_internal->mask_with_timestamps(timestamp_mask_view, 42, 0);
+    ASSERT_FALSE(timestamp_mask[42]);
+    ASSERT_TRUE(timestamp_mask[43]);
+
+    BitsetType delete_mask(chunk_num * test_data_count);
+    BitsetTypeView delete_mask_view(delete_mask);
+    segment_internal->mask_with_delete(
+        delete_mask_view, chunk_num * test_data_count, MAX_TIMESTAMP);
+    ASSERT_EQ(1, delete_mask.count());
+    ASSERT_EQ(1, unsorted_segment->get_deleted_count());
+    ASSERT_EQ(chunk_num * test_data_count - 1,
+              unsorted_segment->get_real_count());
+}
+
+TEST_P(TestChunkSegmentStorageV2, TestLazySystemIndexesOnSortedSegment) {
+    auto sorted_segment = CreateSegment(true);
+    auto* segment_internal =
+        dynamic_cast<SegmentInternalInterface*>(sorted_segment.get());
+    auto* segment_impl =
+        dynamic_cast<ChunkedSegmentSealedImpl*>(sorted_segment.get());
+    ASSERT_NE(segment_internal, nullptr);
+    ASSERT_NE(segment_impl, nullptr);
+
+    PkType existing_pk;
+    PkType missing_pk;
+    std::unique_ptr<IdArray> delete_ids = std::make_unique<IdArray>();
+    if (GetParam()) {
+        existing_pk = std::string("test42");
+        missing_pk = std::string("test_missing");
+        delete_ids->mutable_str_id()->mutable_data()->Add("test42");
+    } else {
+        existing_pk = int64_t(42);
+        missing_pk = int64_t(-1);
+        delete_ids->mutable_int_id()->mutable_data()->Add(42);
+    }
+
+    EXPECT_TRUE(segment_impl->Contain(existing_pk));
+    EXPECT_FALSE(segment_impl->Contain(missing_pk));
+
+    Timestamp delete_ts = MAX_TIMESTAMP;
+    auto status = sorted_segment->Delete(1, delete_ids.get(), &delete_ts);
+    ASSERT_TRUE(status.ok());
+
+    BitsetType timestamp_mask(chunk_num * test_data_count);
+    BitsetTypeView timestamp_mask_view(timestamp_mask);
+    segment_internal->mask_with_timestamps(timestamp_mask_view, 41, 0);
+    ASSERT_FALSE(timestamp_mask[41]);
+    ASSERT_TRUE(timestamp_mask[42]);
+
+    timestamp_mask.reset();
+    segment_internal->mask_with_timestamps(timestamp_mask_view, 42, 0);
+    ASSERT_FALSE(timestamp_mask[42]);
+    ASSERT_TRUE(timestamp_mask[43]);
+
+    BitsetType delete_mask(chunk_num * test_data_count);
+    BitsetTypeView delete_mask_view(delete_mask);
+    segment_internal->mask_with_delete(
+        delete_mask_view, chunk_num * test_data_count, MAX_TIMESTAMP);
+    ASSERT_EQ(1, delete_mask.count());
+    ASSERT_EQ(1, sorted_segment->get_deleted_count());
+    ASSERT_EQ(chunk_num * test_data_count - 1,
+              sorted_segment->get_real_count());
+
+    if (!GetParam()) {
+        int64_t seg_offsets[] = {0, 42};
+        auto pk_result = sorted_segment->bulk_subscript(
+            nullptr, fields.at("pk"), seg_offsets, 2);
+        ASSERT_EQ(pk_result->scalars().long_data().data(0), 0);
+        ASSERT_EQ(pk_result->scalars().long_data().data(1), 42);
+    }
 }

--- a/internal/core/src/segcore/ChunkedSegmentSealedStorageV2Test.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedStorageV2Test.cpp
@@ -379,47 +379,6 @@ TEST_P(TestChunkSegmentStorageV2, TestCompareExpr) {
 //   - paths[2] contains column {1} = pk (single-field group)
 // When storage_version=2 reads a parquet file with multiple columns, they become
 // a multi-field column group, so DropFieldData should be skipped for those fields.
-TEST_P(TestChunkSegmentStorageV2, TestDropFieldDataWithColumnGroups) {
-    auto segment_impl = dynamic_cast<ChunkedSegmentSealedImpl*>(segment.get());
-    ASSERT_NE(segment_impl, nullptr);
-
-    // Verify fields have data initially
-    auto int64_fid = fields.at("int64");
-    auto string1_fid = fields.at("string1");
-    auto string2_fid = fields.at("string2");
-
-    EXPECT_TRUE(segment_impl->HasFieldData(int64_fid))
-        << "int64 field data should be ready";
-    EXPECT_TRUE(segment_impl->HasFieldData(string1_fid))
-        << "string1 field data should be ready";
-    EXPECT_TRUE(segment_impl->HasFieldData(string2_fid))
-        << "string2 field data should be ready";
-
-    // int64 and string2 are in the same parquet file (multi-field column group)
-    // DropFieldData should be SKIPPED for these fields
-    segment_impl->DropFieldData(int64_fid);
-
-    // int64 should still have data because it's in a multi-field column group
-    EXPECT_TRUE(segment_impl->HasFieldData(int64_fid))
-        << "int64 field data should still be ready (multi-field column group)";
-
-    // string2 is in the same group, should also still have data
-    EXPECT_TRUE(segment_impl->HasFieldData(string2_fid))
-        << "string2 field data should still be ready (same column group as "
-           "int64)";
-
-    // string1 is in its own parquet file (single-field group)
-    // DropFieldData SHOULD work for this field
-    segment_impl->DropFieldData(string1_fid);
-    EXPECT_FALSE(segment_impl->HasFieldData(string1_fid))
-        << "string1 field data should be dropped (single-field column group)";
-
-    // int64 and string2 should still have data
-    EXPECT_TRUE(segment_impl->HasFieldData(int64_fid))
-        << "int64 field data should still be ready";
-    EXPECT_TRUE(segment_impl->HasFieldData(string2_fid))
-        << "string2 field data should still be ready";
-}
 
 TEST_P(TestChunkSegmentStorageV2, TestLazySystemIndexesOnUnsortedSegment) {
     auto unsorted_segment = CreateSegment(false);

--- a/internal/core/src/segcore/ChunkedSegmentSealedStorageV2Test.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedStorageV2Test.cpp
@@ -430,6 +430,30 @@ TEST_P(TestChunkSegmentStorageV2, TestLazySystemIndexesOnUnsortedSegment) {
               unsorted_segment->get_real_count());
 }
 
+// Verify that when delete_ts == insert_ts, the delete does NOT take effect.
+// This tests the same-timestamp correctness check in DeletedRecord when
+// insert_record_.timestamps_ is empty (StorageV2 lazy-init path).
+TEST_P(TestChunkSegmentStorageV2, TestSameTimestampDeleteNotEffective) {
+    auto unsorted_segment = CreateSegment(false);
+
+    // Row 42 has insert timestamp = 42 (from sequential int64 data).
+    // Deleting with the same timestamp should have no effect.
+    std::unique_ptr<IdArray> delete_ids = std::make_unique<IdArray>();
+    if (GetParam()) {
+        delete_ids->mutable_str_id()->mutable_data()->Add("test42");
+    } else {
+        delete_ids->mutable_int_id()->mutable_data()->Add(42);
+    }
+
+    Timestamp delete_ts = 42;  // same as insert timestamp of row 42
+    auto status = unsorted_segment->Delete(1, delete_ids.get(), &delete_ts);
+    ASSERT_TRUE(status.ok());
+
+    // The delete should not have taken effect because delete_ts == insert_ts
+    ASSERT_EQ(0, unsorted_segment->get_deleted_count());
+    ASSERT_EQ(chunk_num * test_data_count, unsorted_segment->get_real_count());
+}
+
 TEST_P(TestChunkSegmentStorageV2, TestLazySystemIndexesOnSortedSegment) {
     auto sorted_segment = CreateSegment(true);
     auto* segment_internal =

--- a/internal/core/src/segcore/CompressedInt64PkArray_test.cpp
+++ b/internal/core/src/segcore/CompressedInt64PkArray_test.cpp
@@ -1,0 +1,285 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <numeric>
+#include <random>
+#include <vector>
+
+#include "segcore/InsertRecord.h"
+
+using namespace milvus::segcore;
+
+TEST(CompressedInt64PkArrayTest, Empty) {
+    CompressedInt64PkArray arr;
+    EXPECT_TRUE(arr.empty());
+    EXPECT_EQ(arr.num_rows(), 0);
+}
+
+TEST(CompressedInt64PkArrayTest, SingleElement) {
+    CompressedInt64PkArray arr;
+    int64_t pk = 42;
+    arr.build(&pk, 1);
+
+    EXPECT_FALSE(arr.empty());
+    EXPECT_EQ(arr.num_rows(), 1);
+    EXPECT_EQ(arr.at(0), 42);
+}
+
+TEST(CompressedInt64PkArrayTest, AllIdentical) {
+    // bit_width = 0, no data stored
+    constexpr int64_t N = 200;
+    std::vector<int64_t> pks(N, 12345);
+
+    CompressedInt64PkArray arr;
+    arr.build(pks.data(), N);
+
+    EXPECT_EQ(arr.num_rows(), N);
+    for (int64_t i = 0; i < N; ++i) {
+        EXPECT_EQ(arr.at(i), 12345) << "mismatch at offset " << i;
+    }
+}
+
+TEST(CompressedInt64PkArrayTest, Sequential) {
+    constexpr int64_t N = 500;
+    std::vector<int64_t> pks(N);
+    std::iota(pks.begin(), pks.end(), 1000);  // 1000..1499
+
+    CompressedInt64PkArray arr;
+    arr.build(pks.data(), N);
+
+    EXPECT_EQ(arr.num_rows(), N);
+    for (int64_t i = 0; i < N; ++i) {
+        EXPECT_EQ(arr.at(i), 1000 + i) << "mismatch at offset " << i;
+    }
+}
+
+TEST(CompressedInt64PkArrayTest, NegativeValues) {
+    std::vector<int64_t> pks = {-100, -50, 0, 50, 100, -200, 200};
+
+    CompressedInt64PkArray arr;
+    arr.build(pks.data(), pks.size());
+
+    EXPECT_EQ(arr.num_rows(), static_cast<int64_t>(pks.size()));
+    for (int64_t i = 0; i < static_cast<int64_t>(pks.size()); ++i) {
+        EXPECT_EQ(arr.at(i), pks[i]) << "mismatch at offset " << i;
+    }
+}
+
+TEST(CompressedInt64PkArrayTest, LargeRange) {
+    // Large deltas requiring many bits
+    std::vector<int64_t> pks = {0,
+                                1,
+                                INT64_MAX / 2,
+                                INT64_MAX / 2 + 1,
+                                INT64_MAX - 1};
+
+    CompressedInt64PkArray arr;
+    arr.build(pks.data(), pks.size());
+
+    for (int64_t i = 0; i < static_cast<int64_t>(pks.size()); ++i) {
+        EXPECT_EQ(arr.at(i), pks[i]) << "mismatch at offset " << i;
+    }
+}
+
+TEST(CompressedInt64PkArrayTest, RandomAccess) {
+    // Random values spanning multiple blocks
+    constexpr int64_t N = 1000;
+    std::mt19937_64 rng(42);
+    std::uniform_int_distribution<int64_t> dist(0, 1'000'000);
+
+    std::vector<int64_t> pks(N);
+    for (auto& pk : pks) {
+        pk = dist(rng);
+    }
+
+    CompressedInt64PkArray arr;
+    arr.build(pks.data(), N);
+
+    // Verify all values
+    for (int64_t i = 0; i < N; ++i) {
+        EXPECT_EQ(arr.at(i), pks[i]) << "mismatch at offset " << i;
+    }
+}
+
+TEST(CompressedInt64PkArrayTest, BulkAt) {
+    constexpr int64_t N = 300;
+    std::mt19937_64 rng(123);
+    std::uniform_int_distribution<int64_t> dist(0, 100'000);
+
+    std::vector<int64_t> pks(N);
+    for (auto& pk : pks) {
+        pk = dist(rng);
+    }
+
+    CompressedInt64PkArray arr;
+    arr.build(pks.data(), N);
+
+    // Query a subset of offsets in random order
+    std::vector<int64_t> offsets = {0, 1, 127, 128, 129, 255, 256, 299};
+    std::vector<int64_t> output(offsets.size());
+    arr.bulk_at(offsets.data(), offsets.size(), output.data());
+
+    for (size_t i = 0; i < offsets.size(); ++i) {
+        EXPECT_EQ(output[i], pks[offsets[i]])
+            << "bulk_at mismatch at query index " << i
+            << " (offset " << offsets[i] << ")";
+    }
+}
+
+TEST(CompressedInt64PkArrayTest, ExactlyOneBlock) {
+    constexpr int64_t N = 128;  // kBlockSize
+    std::vector<int64_t> pks(N);
+    std::iota(pks.begin(), pks.end(), 500);
+
+    CompressedInt64PkArray arr;
+    arr.build(pks.data(), N);
+
+    EXPECT_EQ(arr.num_rows(), N);
+    for (int64_t i = 0; i < N; ++i) {
+        EXPECT_EQ(arr.at(i), 500 + i);
+    }
+}
+
+TEST(CompressedInt64PkArrayTest, BlockBoundary) {
+    // 129 elements = 2 blocks (128 + 1)
+    constexpr int64_t N = 129;
+    std::vector<int64_t> pks(N);
+    std::iota(pks.begin(), pks.end(), 0);
+
+    CompressedInt64PkArray arr;
+    arr.build(pks.data(), N);
+
+    // Verify boundary elements
+    EXPECT_EQ(arr.at(0), 0);       // first of block 0
+    EXPECT_EQ(arr.at(127), 127);   // last of block 0
+    EXPECT_EQ(arr.at(128), 128);   // first of block 1
+}
+
+TEST(CompressedInt64PkArrayTest, MemorySize) {
+    constexpr int64_t N = 1000;
+    std::vector<int64_t> pks(N);
+    std::iota(pks.begin(), pks.end(), 0);
+
+    CompressedInt64PkArray arr;
+    arr.build(pks.data(), N);
+
+    size_t mem = arr.memory_size();
+    size_t uncompressed = N * sizeof(int64_t);
+    // Compressed should be smaller than uncompressed for sequential data
+    EXPECT_LT(mem, uncompressed)
+        << "compressed=" << mem << " uncompressed=" << uncompressed;
+}
+
+TEST(CompressedInt64PkArrayTest, PowerOfTwoBitWidths) {
+    // Test bit widths 1, 2, 4, 8, 16 by controlling max delta
+    auto test_max_delta = [](uint64_t max_delta) {
+        constexpr int64_t N = 128;
+        std::vector<int64_t> pks(N, 0);
+        pks[0] = 0;
+        pks[1] = static_cast<int64_t>(max_delta);
+        // Fill rest with values in range
+        std::mt19937_64 rng(max_delta);
+        std::uniform_int_distribution<int64_t> dist(
+            0, static_cast<int64_t>(max_delta));
+        for (int64_t i = 2; i < N; ++i) {
+            pks[i] = dist(rng);
+        }
+
+        CompressedInt64PkArray arr;
+        arr.build(pks.data(), N);
+
+        for (int64_t i = 0; i < N; ++i) {
+            EXPECT_EQ(arr.at(i), pks[i])
+                << "mismatch at offset " << i
+                << " with max_delta=" << max_delta;
+        }
+    };
+
+    test_max_delta(1);          // 1 bit
+    test_max_delta(3);          // 2 bits
+    test_max_delta(15);         // 4 bits
+    test_max_delta(255);        // 8 bits
+    test_max_delta(65535);      // 16 bits
+    test_max_delta(0xFFFFFFFF); // 32 bits
+}
+
+// Simulate what build_offset2pk does: build from unsorted PK data
+// (as would happen in a non-sorted segment)
+TEST(CompressedInt64PkArrayTest, UnsortedPks) {
+    // Typical auto-id pattern: IDs assigned out of order due to concurrent inserts
+    std::vector<int64_t> pks = {
+        449595445547098119, 449595445547098120, 449595445547098121,
+        449595445547098115, 449595445547098116, 449595445547098117,
+        449595445547098112, 449595445547098113, 449595445547098114,
+        449595445547098118};
+
+    CompressedInt64PkArray arr;
+    arr.build(pks.data(), pks.size());
+
+    for (int64_t i = 0; i < static_cast<int64_t>(pks.size()); ++i) {
+        EXPECT_EQ(arr.at(i), pks[i]) << "mismatch at offset " << i;
+    }
+}
+
+// Simulate sorted segment: PKs are in ascending order
+TEST(CompressedInt64PkArrayTest, SortedPks) {
+    constexpr int64_t N = 500;
+    std::mt19937_64 rng(99);
+    std::uniform_int_distribution<int64_t> dist(1, 1'000'000'000LL);
+
+    std::vector<int64_t> pks(N);
+    for (auto& pk : pks) {
+        pk = dist(rng);
+    }
+    std::sort(pks.begin(), pks.end());
+
+    CompressedInt64PkArray arr;
+    arr.build(pks.data(), N);
+
+    EXPECT_EQ(arr.num_rows(), N);
+    for (int64_t i = 0; i < N; ++i) {
+        EXPECT_EQ(arr.at(i), pks[i]) << "mismatch at offset " << i;
+    }
+
+    // Verify bulk_at with random offsets
+    std::vector<int64_t> offsets(50);
+    std::uniform_int_distribution<int64_t> offset_dist(0, N - 1);
+    for (auto& o : offsets) {
+        o = offset_dist(rng);
+    }
+    std::vector<int64_t> output(50);
+    arr.bulk_at(offsets.data(), offsets.size(), output.data());
+    for (size_t i = 0; i < offsets.size(); ++i) {
+        EXPECT_EQ(output[i], pks[offsets[i]]);
+    }
+}
+
+// Simulate sorted segment with duplicates (possible with non-unique PK)
+TEST(CompressedInt64PkArrayTest, SortedWithDuplicates) {
+    std::vector<int64_t> pks;
+    for (int64_t v = 100; v < 200; ++v) {
+        // Each value appears 3 times
+        pks.push_back(v);
+        pks.push_back(v);
+        pks.push_back(v);
+    }
+
+    CompressedInt64PkArray arr;
+    arr.build(pks.data(), pks.size());
+
+    for (int64_t i = 0; i < static_cast<int64_t>(pks.size()); ++i) {
+        EXPECT_EQ(arr.at(i), pks[i]) << "mismatch at offset " << i;
+    }
+}

--- a/internal/core/src/segcore/CompressedInt64PkArray_test.cpp
+++ b/internal/core/src/segcore/CompressedInt64PkArray_test.cpp
@@ -79,11 +79,8 @@ TEST(CompressedInt64PkArrayTest, NegativeValues) {
 
 TEST(CompressedInt64PkArrayTest, LargeRange) {
     // Large deltas requiring many bits
-    std::vector<int64_t> pks = {0,
-                                1,
-                                INT64_MAX / 2,
-                                INT64_MAX / 2 + 1,
-                                INT64_MAX - 1};
+    std::vector<int64_t> pks = {
+        0, 1, INT64_MAX / 2, INT64_MAX / 2 + 1, INT64_MAX - 1};
 
     CompressedInt64PkArray arr;
     arr.build(pks.data(), pks.size());
@@ -133,8 +130,8 @@ TEST(CompressedInt64PkArrayTest, BulkAt) {
 
     for (size_t i = 0; i < offsets.size(); ++i) {
         EXPECT_EQ(output[i], pks[offsets[i]])
-            << "bulk_at mismatch at query index " << i
-            << " (offset " << offsets[i] << ")";
+            << "bulk_at mismatch at query index " << i << " (offset "
+            << offsets[i] << ")";
     }
 }
 
@@ -162,9 +159,9 @@ TEST(CompressedInt64PkArrayTest, BlockBoundary) {
     arr.build(pks.data(), N);
 
     // Verify boundary elements
-    EXPECT_EQ(arr.at(0), 0);       // first of block 0
-    EXPECT_EQ(arr.at(127), 127);   // last of block 0
-    EXPECT_EQ(arr.at(128), 128);   // first of block 1
+    EXPECT_EQ(arr.at(0), 0);      // first of block 0
+    EXPECT_EQ(arr.at(127), 127);  // last of block 0
+    EXPECT_EQ(arr.at(128), 128);  // first of block 1
 }
 
 TEST(CompressedInt64PkArrayTest, MemorySize) {
@@ -201,29 +198,33 @@ TEST(CompressedInt64PkArrayTest, PowerOfTwoBitWidths) {
         arr.build(pks.data(), N);
 
         for (int64_t i = 0; i < N; ++i) {
-            EXPECT_EQ(arr.at(i), pks[i])
-                << "mismatch at offset " << i
-                << " with max_delta=" << max_delta;
+            EXPECT_EQ(arr.at(i), pks[i]) << "mismatch at offset " << i
+                                         << " with max_delta=" << max_delta;
         }
     };
 
-    test_max_delta(1);          // 1 bit
-    test_max_delta(3);          // 2 bits
-    test_max_delta(15);         // 4 bits
-    test_max_delta(255);        // 8 bits
-    test_max_delta(65535);      // 16 bits
-    test_max_delta(0xFFFFFFFF); // 32 bits
+    test_max_delta(1);           // 1 bit
+    test_max_delta(3);           // 2 bits
+    test_max_delta(15);          // 4 bits
+    test_max_delta(255);         // 8 bits
+    test_max_delta(65535);       // 16 bits
+    test_max_delta(0xFFFFFFFF);  // 32 bits
 }
 
 // Simulate what build_offset2pk does: build from unsorted PK data
 // (as would happen in a non-sorted segment)
 TEST(CompressedInt64PkArrayTest, UnsortedPks) {
     // Typical auto-id pattern: IDs assigned out of order due to concurrent inserts
-    std::vector<int64_t> pks = {
-        449595445547098119, 449595445547098120, 449595445547098121,
-        449595445547098115, 449595445547098116, 449595445547098117,
-        449595445547098112, 449595445547098113, 449595445547098114,
-        449595445547098118};
+    std::vector<int64_t> pks = {449595445547098119,
+                                449595445547098120,
+                                449595445547098121,
+                                449595445547098115,
+                                449595445547098116,
+                                449595445547098117,
+                                449595445547098112,
+                                449595445547098113,
+                                449595445547098114,
+                                449595445547098118};
 
     CompressedInt64PkArray arr;
     arr.build(pks.data(), pks.size());

--- a/internal/core/src/segcore/DeletedRecord.h
+++ b/internal/core/src/segcore/DeletedRecord.h
@@ -153,11 +153,6 @@ class DeletedRecord {
                 if (deleted_mask_.size() > row_id && deleted_mask_[row_id]) {
                     return;
                 }
-                // if insert record and delete record is same timestamp,
-                // delete not take effect on this record.
-                if (delete_ts == insert_record_->timestamps_[row_id]) {
-                    return;
-                }
                 accessor.insert(std::make_pair(delete_ts, row_id));
                 if constexpr (is_sealed) {
                     Assert(deleted_mask_.size() > 0);

--- a/internal/core/src/segcore/DeletedRecord.h
+++ b/internal/core/src/segcore/DeletedRecord.h
@@ -155,10 +155,13 @@ class DeletedRecord {
                 }
                 // if insert and delete have the same timestamp,
                 // delete should not take effect on this record.
-                // Skip this check when timestamps_ is empty (StorageV2
-                // lazy-init path where timestamps are not yet loaded).
-                if (!insert_record_->timestamps_.empty() &&
-                    delete_ts == insert_record_->timestamps_[row_id]) {
+                Timestamp insert_ts = 0;
+                if (!insert_record_->timestamps_.empty()) {
+                    insert_ts = insert_record_->timestamps_[row_id];
+                } else if (get_insert_timestamp_func_) {
+                    insert_ts = get_insert_timestamp_func_(row_id);
+                }
+                if (insert_ts != 0 && delete_ts == insert_ts) {
                     return;
                 }
                 accessor.insert(std::make_pair(delete_ts, row_id));
@@ -400,6 +403,15 @@ class DeletedRecord {
         deleted_mask_.resize(row_count);
     }
 
+    // Set a callback to read insert timestamp for a given row_id.
+    // Used by StorageV2 lazy-init path where insert_record_.timestamps_
+    // may be empty but timestamp data is available in the column.
+    void
+    set_get_insert_timestamp_func(
+        std::function<Timestamp(int64_t row_id)> func) {
+        get_insert_timestamp_func_ = std::move(func);
+    }
+
     std::vector<std::pair<Timestamp, BitsetType>>
     get_snapshots() const {
         std::shared_lock<std::shared_mutex> lock(snap_lock_);
@@ -437,6 +449,10 @@ class DeletedRecord {
     std::atomic<int64_t> dumped_entry_count_{0};
     // estimated memory size of DeletedRecord, only used for sealed segment
     int64_t estimated_memory_size_{0};
+
+    // Callback to read insert timestamp from column (StorageV2 lazy path).
+    // Used when insert_record_->timestamps_ is empty.
+    std::function<Timestamp(int64_t row_id)> get_insert_timestamp_func_;
 
     // atomic snapshot for fast path query optimization
     // when query_timestamp >= snapshot.max_ts, we can directly use the bitset

--- a/internal/core/src/segcore/DeletedRecord.h
+++ b/internal/core/src/segcore/DeletedRecord.h
@@ -153,6 +153,14 @@ class DeletedRecord {
                 if (deleted_mask_.size() > row_id && deleted_mask_[row_id]) {
                     return;
                 }
+                // if insert and delete have the same timestamp,
+                // delete should not take effect on this record.
+                // Skip this check when timestamps_ is empty (StorageV2
+                // lazy-init path where timestamps are not yet loaded).
+                if (!insert_record_->timestamps_.empty() &&
+                    delete_ts == insert_record_->timestamps_[row_id]) {
+                    return;
+                }
                 accessor.insert(std::make_pair(delete_ts, row_id));
                 if constexpr (is_sealed) {
                     Assert(deleted_mask_.size() > 0);

--- a/internal/core/src/segcore/InsertRecord.h
+++ b/internal/core/src/segcore/InsertRecord.h
@@ -44,6 +44,225 @@ constexpr int64_t BruteForceSelectivity = 10;
 
 using Condition = std::function<bool(int64_t)>;
 
+// Compressed storage for offset -> int64 PK reverse lookup.
+// Uses global base + per-block base + bitpacked deltas.
+// Block size = 128, O(1) random access within each block.
+// Each block stores deltas with a uniform bit width (max bits needed in that block).
+class CompressedInt64PkArray {
+ public:
+    static constexpr int64_t kBlockSize = 128;
+
+    CompressedInt64PkArray() = default;
+
+    void
+    build(const int64_t* pks, int64_t num_rows) {
+        if (num_rows == 0) {
+            return;
+        }
+        num_rows_ = num_rows;
+
+        // Find global minimum as base
+        base_ = pks[0];
+        for (int64_t i = 1; i < num_rows; ++i) {
+            if (pks[i] < base_) {
+                base_ = pks[i];
+            }
+        }
+
+        // Calculate number of blocks
+        int64_t num_blocks = (num_rows + kBlockSize - 1) / kBlockSize;
+        block_bit_widths_.reserve(num_blocks);
+        block_offsets_.reserve(num_blocks);
+        block_bases_.reserve(num_blocks);
+
+        for (int64_t block_id = 0; block_id < num_blocks; ++block_id) {
+            int64_t block_start = block_id * kBlockSize;
+            int64_t block_end =
+                std::min(block_start + kBlockSize, num_rows);
+            int64_t block_count = block_end - block_start;
+
+            // Find block minimum
+            int64_t block_min = pks[block_start];
+            for (int64_t i = block_start + 1; i < block_end; ++i) {
+                if (pks[i] < block_min) {
+                    block_min = pks[i];
+                }
+            }
+
+            // Find max delta to determine bit width
+            uint64_t max_delta = 0;
+            for (int64_t i = block_start; i < block_end; ++i) {
+                uint64_t delta =
+                    static_cast<uint64_t>(pks[i] - block_min);
+                if (delta > max_delta) {
+                    max_delta = delta;
+                }
+            }
+
+            uint8_t bits = bit_width(max_delta);
+            block_bases_.push_back(
+                static_cast<uint64_t>(block_min - base_));
+            block_bit_widths_.push_back(bits);
+            block_offsets_.push_back(
+                static_cast<uint32_t>(data_.size()));
+
+            // Pack deltas with uniform bit width
+            if (bits == 0) {
+                // All values identical in this block, no data needed
+            } else {
+                // Number of bytes needed: ceil(block_count * bits / 8)
+                size_t num_bytes =
+                    (static_cast<size_t>(block_count) * bits + 7) / 8;
+                size_t data_start = data_.size();
+                data_.resize(data_start + num_bytes, 0);
+
+                for (int64_t i = 0; i < block_count; ++i) {
+                    uint64_t delta = static_cast<uint64_t>(
+                        pks[block_start + i] - block_min);
+                    pack_value(data_start, i, bits, delta);
+                }
+            }
+        }
+
+        // Shrink to fit
+        data_.shrink_to_fit();
+        block_offsets_.shrink_to_fit();
+        block_bases_.shrink_to_fit();
+        block_bit_widths_.shrink_to_fit();
+    }
+
+    int64_t
+    at(int64_t offset) const {
+        AssertInfo(offset >= 0 && offset < num_rows_,
+                   "offset out of range: {} not in [0, {})",
+                   offset,
+                   num_rows_);
+
+        int64_t block_id = offset / kBlockSize;
+        int64_t idx_in_block = offset % kBlockSize;
+        uint8_t bits = block_bit_widths_[block_id];
+
+        uint64_t delta = 0;
+        if (bits > 0) {
+            delta = unpack_value(block_offsets_[block_id],
+                                 idx_in_block,
+                                 bits);
+        }
+
+        return base_ + static_cast<int64_t>(block_bases_[block_id]) +
+               static_cast<int64_t>(delta);
+    }
+
+    void
+    bulk_at(const int64_t* offsets,
+            int64_t count,
+            int64_t* output) const {
+        for (int64_t i = 0; i < count; ++i) {
+            output[i] = at(offsets[i]);
+        }
+    }
+
+    size_t
+    memory_size() const {
+        return sizeof(*this) + data_.capacity() +
+               block_offsets_.capacity() * sizeof(uint32_t) +
+               block_bases_.capacity() * sizeof(uint64_t) +
+               block_bit_widths_.capacity() * sizeof(uint8_t);
+    }
+
+    int64_t
+    num_rows() const {
+        return num_rows_;
+    }
+
+    bool
+    empty() const {
+        return num_rows_ == 0;
+    }
+
+ private:
+    static uint8_t
+    bit_width(uint64_t max_val) {
+        if (max_val == 0) {
+            return 0;
+        }
+        return static_cast<uint8_t>(64 - __builtin_clzll(max_val));
+    }
+
+    void
+    pack_value(size_t data_start,
+               int64_t idx,
+               uint8_t bits,
+               uint64_t value) {
+        uint64_t bit_offset =
+            static_cast<uint64_t>(idx) * bits;
+        size_t byte_offset = data_start + bit_offset / 8;
+        unsigned bit_shift = bit_offset % 8;
+
+        // Low 64 bits of (value << bit_shift)
+        uint64_t lo = value << bit_shift;
+        for (unsigned b = 0; b < 8 && byte_offset + b < data_.size();
+             ++b) {
+            data_[byte_offset + b] |=
+                static_cast<uint8_t>(lo >> (b * 8));
+        }
+        // High bits that overflowed past 64-bit boundary
+        if (bit_shift > 0 && bit_shift + bits > 64) {
+            uint64_t hi = value >> (64 - bit_shift);
+            for (unsigned b = 0;
+                 byte_offset + 8 + b < data_.size() && b < 8;
+                 ++b) {
+                data_[byte_offset + 8 + b] |=
+                    static_cast<uint8_t>(hi >> (b * 8));
+            }
+        }
+    }
+
+    uint64_t
+    unpack_value(uint32_t block_data_offset,
+                 int64_t idx,
+                 uint8_t bits) const {
+        uint64_t bit_offset =
+            static_cast<uint64_t>(idx) * bits;
+        size_t byte_offset = block_data_offset + bit_offset / 8;
+        unsigned bit_shift = bit_offset % 8;
+
+        // Read low 8 bytes
+        uint64_t lo = 0;
+        for (unsigned b = 0; b < 8 && byte_offset + b < data_.size();
+             ++b) {
+            lo |= static_cast<uint64_t>(data_[byte_offset + b])
+                  << (b * 8);
+        }
+        uint64_t result = lo >> bit_shift;
+
+        // Read high bytes if crossing 64-bit boundary
+        if (bit_shift > 0 && bit_shift + bits > 64) {
+            uint64_t hi = 0;
+            for (unsigned b = 0;
+                 byte_offset + 8 + b < data_.size() && b < 8;
+                 ++b) {
+                hi |= static_cast<uint64_t>(
+                          data_[byte_offset + 8 + b])
+                      << (b * 8);
+            }
+            result |= hi << (64 - bit_shift);
+        }
+
+        uint64_t mask = (bits == 64) ? ~uint64_t(0)
+                                     : (uint64_t(1) << bits) - 1;
+        return result & mask;
+    }
+
+ private:
+    int64_t base_ = 0;      // Global minimum PK
+    int64_t num_rows_ = 0;
+    std::vector<uint32_t> block_offsets_;   // Byte offset of each block in data_
+    std::vector<uint64_t> block_bases_;     // Block base relative to global base
+    std::vector<uint8_t> block_bit_widths_; // Bit width per block
+    std::vector<uint8_t> data_;             // Bitpacked deltas
+};
+
 class OffsetMap {
  public:
     virtual ~OffsetMap() = default;
@@ -596,11 +815,13 @@ class InsertRecordSealed {
                     case DataType::INT64: {
                         pk2offset_ =
                             std::make_unique<OffsetOrderedArray<int64_t>>();
+                        is_int64_pk_ = true;
                         break;
                     }
                     case DataType::VARCHAR: {
                         pk2offset_ =
                             std::make_unique<OffsetOrderedArray<std::string>>();
+                        is_int64_pk_ = false;
                         break;
                     }
                     default: {
@@ -732,6 +953,37 @@ class InsertRecordSealed {
         }
     }
 
+    // Build only the compressed offset->pk mapping (no pk2offset_ index).
+    // Used by sorted segments where pk2offset_ is not needed.
+    void
+    build_offset2pk(milvus::DataType data_type, ChunkedColumnInterface* data) {
+        if (data_type != DataType::INT64 || !is_int64_pk_) {
+            return;
+        }
+        std::lock_guard lck(shared_mutex_);
+        int64_t total_rows = data->NumRows();
+        std::vector<int64_t> all_pks;
+        all_pks.reserve(total_rows);
+
+        auto num_chunk = data->num_chunks();
+        for (int i = 0; i < num_chunk; ++i) {
+            auto pw = data->DataOfChunk(nullptr, i);
+            auto pks = reinterpret_cast<const int64_t*>(pw.get());
+            auto chunk_num_rows = data->chunk_row_nums(i);
+            for (int j = 0; j < chunk_num_rows; ++j) {
+                all_pks.push_back(pks[j]);
+            }
+        }
+
+        offset2pk_ = std::make_unique<CompressedInt64PkArray>();
+        offset2pk_->build(all_pks.data(), all_pks.size());
+
+        size_t mem = offset2pk_->memory_size();
+        cachinglayer::Manager::GetInstance().ChargeLoadedResource(
+            {static_cast<int64_t>(mem), 0});
+        estimated_memory_size_ += mem;
+    }
+
     bool
     empty_pks() const {
         std::shared_lock lck(shared_mutex_);
@@ -743,9 +995,11 @@ class InsertRecordSealed {
         std::lock_guard lck(shared_mutex_);
         pk2offset_->seal();
         // update estimated memory size to caching layer
+        // offset2pk_ memory is charged separately in build_offset2pk()
+        size_t total_size = pk2offset_->memory_size();
         cachinglayer::Manager::GetInstance().ChargeLoadedResource(
-            {static_cast<int64_t>(pk2offset_->memory_size()), 0});
-        estimated_memory_size_ += pk2offset_->memory_size();
+            {static_cast<int64_t>(total_size), 0});
+        estimated_memory_size_ += total_size;
     }
 
     // Pin mode: zero-copy from column chunks (StorageV2, single or multi-chunk)
@@ -792,6 +1046,7 @@ class InsertRecordSealed {
         if (pk2offset_) {
             pk2offset_->clear();
         }
+        offset2pk_.reset();
 
         reserved = 0;
         if (estimated_memory_size_ > 0) {
@@ -801,6 +1056,30 @@ class InsertRecordSealed {
         }
     }
 
+    // Returns true if PK type is int64 and offset2pk is available
+    bool
+    has_int64_pk_index() const {
+        return is_int64_pk_ && offset2pk_ != nullptr;
+    }
+
+    // Get PK by offset. Only valid when has_int64_pk_index() returns true.
+    int64_t
+    get_int64_pk_by_offset(int64_t offset) const {
+        AssertInfo(has_int64_pk_index(),
+                   "get_int64_pk_by_offset requires int64 PK with offset2pk index");
+        return offset2pk_->at(offset);
+    }
+
+    // Bulk get PKs by offsets. Only valid when has_int64_pk_index() returns true.
+    void
+    bulk_get_int64_pks_by_offsets(const int64_t* offsets,
+                                  int64_t count,
+                                  int64_t* output) const {
+        AssertInfo(has_int64_pk_index(),
+                   "bulk_get_int64_pks_by_offsets requires int64 PK with offset2pk index");
+        offset2pk_->bulk_at(offsets, count, output);
+    }
+
  public:
     TimestampData timestamps_;
     std::atomic<int64_t> reserved = 0;
@@ -808,6 +1087,10 @@ class InsertRecordSealed {
     TimestampIndex timestamp_index_;
     // pks to row offset
     std::unique_ptr<OffsetMap> pk2offset_;
+    // offset to pk (compressed), only available for int64 PK
+    std::unique_ptr<CompressedInt64PkArray> offset2pk_;
+    // whether PK type is int64
+    bool is_int64_pk_ = false;
     // estimated memory size of InsertRecord, only used for sealed segment
     int64_t estimated_memory_size_{0};
 

--- a/internal/core/src/segcore/InsertRecord.h
+++ b/internal/core/src/segcore/InsertRecord.h
@@ -78,8 +78,7 @@ class CompressedInt64PkArray {
 
         for (int64_t block_id = 0; block_id < num_blocks; ++block_id) {
             int64_t block_start = block_id * kBlockSize;
-            int64_t block_end =
-                std::min(block_start + kBlockSize, num_rows);
+            int64_t block_end = std::min(block_start + kBlockSize, num_rows);
             int64_t block_count = block_end - block_start;
 
             // Find block minimum
@@ -93,19 +92,16 @@ class CompressedInt64PkArray {
             // Find max delta to determine bit width
             uint64_t max_delta = 0;
             for (int64_t i = block_start; i < block_end; ++i) {
-                uint64_t delta =
-                    static_cast<uint64_t>(pks[i] - block_min);
+                uint64_t delta = static_cast<uint64_t>(pks[i] - block_min);
                 if (delta > max_delta) {
                     max_delta = delta;
                 }
             }
 
             uint8_t bits = bit_width(max_delta);
-            block_bases_.push_back(
-                static_cast<uint64_t>(block_min - base_));
+            block_bases_.push_back(static_cast<uint64_t>(block_min - base_));
             block_bit_widths_.push_back(bits);
-            block_offsets_.push_back(
-                static_cast<uint32_t>(data_.size()));
+            block_offsets_.push_back(static_cast<uint32_t>(data_.size()));
 
             // Pack deltas with uniform bit width
             if (bits == 0) {
@@ -118,8 +114,8 @@ class CompressedInt64PkArray {
                 data_.resize(data_start + num_bytes, 0);
 
                 for (int64_t i = 0; i < block_count; ++i) {
-                    uint64_t delta = static_cast<uint64_t>(
-                        pks[block_start + i] - block_min);
+                    uint64_t delta =
+                        static_cast<uint64_t>(pks[block_start + i] - block_min);
                     pack_value(data_start, i, bits, delta);
                 }
             }
@@ -145,9 +141,7 @@ class CompressedInt64PkArray {
 
         uint64_t delta = 0;
         if (bits > 0) {
-            delta = unpack_value(block_offsets_[block_id],
-                                 idx_in_block,
-                                 bits);
+            delta = unpack_value(block_offsets_[block_id], idx_in_block, bits);
         }
 
         return base_ + static_cast<int64_t>(block_bases_[block_id]) +
@@ -155,9 +149,7 @@ class CompressedInt64PkArray {
     }
 
     void
-    bulk_at(const int64_t* offsets,
-            int64_t count,
-            int64_t* output) const {
+    bulk_at(const int64_t* offsets, int64_t count, int64_t* output) const {
         for (int64_t i = 0; i < count; ++i) {
             output[i] = at(offsets[i]);
         }
@@ -191,27 +183,20 @@ class CompressedInt64PkArray {
     }
 
     void
-    pack_value(size_t data_start,
-               int64_t idx,
-               uint8_t bits,
-               uint64_t value) {
-        uint64_t bit_offset =
-            static_cast<uint64_t>(idx) * bits;
+    pack_value(size_t data_start, int64_t idx, uint8_t bits, uint64_t value) {
+        uint64_t bit_offset = static_cast<uint64_t>(idx) * bits;
         size_t byte_offset = data_start + bit_offset / 8;
         unsigned bit_shift = bit_offset % 8;
 
         // Low 64 bits of (value << bit_shift)
         uint64_t lo = value << bit_shift;
-        for (unsigned b = 0; b < 8 && byte_offset + b < data_.size();
-             ++b) {
-            data_[byte_offset + b] |=
-                static_cast<uint8_t>(lo >> (b * 8));
+        for (unsigned b = 0; b < 8 && byte_offset + b < data_.size(); ++b) {
+            data_[byte_offset + b] |= static_cast<uint8_t>(lo >> (b * 8));
         }
         // High bits that overflowed past 64-bit boundary
         if (bit_shift > 0 && bit_shift + bits > 64) {
             uint64_t hi = value >> (64 - bit_shift);
-            for (unsigned b = 0;
-                 byte_offset + 8 + b < data_.size() && b < 8;
+            for (unsigned b = 0; byte_offset + 8 + b < data_.size() && b < 8;
                  ++b) {
                 data_[byte_offset + 8 + b] |=
                     static_cast<uint8_t>(hi >> (b * 8));
@@ -220,48 +205,40 @@ class CompressedInt64PkArray {
     }
 
     uint64_t
-    unpack_value(uint32_t block_data_offset,
-                 int64_t idx,
-                 uint8_t bits) const {
-        uint64_t bit_offset =
-            static_cast<uint64_t>(idx) * bits;
+    unpack_value(uint32_t block_data_offset, int64_t idx, uint8_t bits) const {
+        uint64_t bit_offset = static_cast<uint64_t>(idx) * bits;
         size_t byte_offset = block_data_offset + bit_offset / 8;
         unsigned bit_shift = bit_offset % 8;
 
         // Read low 8 bytes
         uint64_t lo = 0;
-        for (unsigned b = 0; b < 8 && byte_offset + b < data_.size();
-             ++b) {
-            lo |= static_cast<uint64_t>(data_[byte_offset + b])
-                  << (b * 8);
+        for (unsigned b = 0; b < 8 && byte_offset + b < data_.size(); ++b) {
+            lo |= static_cast<uint64_t>(data_[byte_offset + b]) << (b * 8);
         }
         uint64_t result = lo >> bit_shift;
 
         // Read high bytes if crossing 64-bit boundary
         if (bit_shift > 0 && bit_shift + bits > 64) {
             uint64_t hi = 0;
-            for (unsigned b = 0;
-                 byte_offset + 8 + b < data_.size() && b < 8;
+            for (unsigned b = 0; byte_offset + 8 + b < data_.size() && b < 8;
                  ++b) {
-                hi |= static_cast<uint64_t>(
-                          data_[byte_offset + 8 + b])
+                hi |= static_cast<uint64_t>(data_[byte_offset + 8 + b])
                       << (b * 8);
             }
             result |= hi << (64 - bit_shift);
         }
 
-        uint64_t mask = (bits == 64) ? ~uint64_t(0)
-                                     : (uint64_t(1) << bits) - 1;
+        uint64_t mask = (bits == 64) ? ~uint64_t(0) : (uint64_t(1) << bits) - 1;
         return result & mask;
     }
 
  private:
-    int64_t base_ = 0;      // Global minimum PK
+    int64_t base_ = 0;  // Global minimum PK
     int64_t num_rows_ = 0;
-    std::vector<uint32_t> block_offsets_;   // Byte offset of each block in data_
-    std::vector<uint64_t> block_bases_;     // Block base relative to global base
-    std::vector<uint8_t> block_bit_widths_; // Bit width per block
-    std::vector<uint8_t> data_;             // Bitpacked deltas
+    std::vector<uint32_t> block_offsets_;  // Byte offset of each block in data_
+    std::vector<uint64_t> block_bases_;    // Block base relative to global base
+    std::vector<uint8_t> block_bit_widths_;  // Bit width per block
+    std::vector<uint8_t> data_;              // Bitpacked deltas
 };
 
 class OffsetMap {
@@ -1076,8 +1053,9 @@ class InsertRecordSealed {
     // Get PK by offset. Only valid when has_int64_pk_index() returns true.
     int64_t
     get_int64_pk_by_offset(int64_t offset) const {
-        AssertInfo(has_int64_pk_index(),
-                   "get_int64_pk_by_offset requires int64 PK with offset2pk index");
+        AssertInfo(
+            has_int64_pk_index(),
+            "get_int64_pk_by_offset requires int64 PK with offset2pk index");
         return offset2pk_->at(offset);
     }
 
@@ -1087,7 +1065,8 @@ class InsertRecordSealed {
                                   int64_t count,
                                   int64_t* output) const {
         AssertInfo(has_int64_pk_index(),
-                   "bulk_get_int64_pks_by_offsets requires int64 PK with offset2pk index");
+                   "bulk_get_int64_pks_by_offsets requires int64 PK with "
+                   "offset2pk index");
         offset2pk_->bulk_at(offsets, count, output);
     }
 

--- a/internal/core/src/segcore/InsertRecord.h
+++ b/internal/core/src/segcore/InsertRecord.h
@@ -990,23 +990,6 @@ class InsertRecordSealed {
         estimated_memory_size_ += total_size;
     }
 
-    // Pin mode: zero-copy from column chunks (StorageV2, single or multi-chunk)
-    void
-    init_timestamps_from_column(
-        std::shared_ptr<ChunkedColumnInterface> column,
-        std::vector<cachinglayer::PinWrapper<Chunk*>> pins,
-        TimestampIndex timestamp_index) {
-        std::lock_guard lck(shared_mutex_);
-        timestamps_.InitFromPinnedChunks(std::move(column), std::move(pins));
-        timestamp_index_ = std::move(timestamp_index);
-        // Pin mode: timestamp data is managed by the column group,
-        // only charge the index metadata memory.
-        size_t ts_index_size = timestamp_index_.memory_size();
-        cachinglayer::Manager::GetInstance().ChargeLoadedResource(
-            {static_cast<int64_t>(ts_index_size), 0});
-        estimated_memory_size_ += ts_index_size;
-    }
-
     // Own mode: takes ownership of timestamp data (StorageV1 / multi-chunk)
     void
     init_timestamps_from_owned(std::vector<Timestamp> data,

--- a/internal/core/src/segcore/InsertRecord.h
+++ b/internal/core/src/segcore/InsertRecord.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <algorithm>
+#include <numeric>
 #include <cstddef>
 #include <memory>
 #include <mutex>
@@ -921,6 +922,9 @@ class InsertRecordSealed {
         switch (data_type) {
             case DataType::INT64: {
                 auto num_chunk = data->num_chunks();
+                std::vector<int64_t> chunk_ids(num_chunk);
+                std::iota(chunk_ids.begin(), chunk_ids.end(), 0);
+                data->PrefetchChunks(nullptr, chunk_ids);
                 for (int i = 0; i < num_chunk; ++i) {
                     auto pw = data->DataOfChunk(nullptr, i);
                     auto pks = reinterpret_cast<const int64_t*>(pw.get());
@@ -966,6 +970,13 @@ class InsertRecordSealed {
         all_pks.reserve(total_rows);
 
         auto num_chunk = data->num_chunks();
+        // Prefetch all chunks so that subsequent sequential
+        // DataOfChunk() calls hit the cache instead of blocking
+        // on HIGH pool downloads one at a time.
+        std::vector<int64_t> chunk_ids(num_chunk);
+        std::iota(chunk_ids.begin(), chunk_ids.end(), 0);
+        data->PrefetchChunks(nullptr, chunk_ids);
+
         for (int i = 0; i < num_chunk; ++i) {
             auto pw = data->DataOfChunk(nullptr, i);
             auto pks = reinterpret_cast<const int64_t*>(pw.get());

--- a/internal/core/src/segcore/reduce/Reduce.cpp
+++ b/internal/core/src/segcore/reduce/Reduce.cpp
@@ -32,6 +32,7 @@
 #include "common/Tracer.h"
 #include "common/protobuf_utils.h"
 #include "fmt/core.h"
+#include "folly/ScopeGuard.h"
 #include "glog/logging.h"
 #include "log/Log.h"
 #include "monitor/Monitor.h"
@@ -191,6 +192,16 @@ ReduceHelper::FillPrimaryKey() {
             });
             futures.emplace_back(std::move(future));
         }
+        auto futures_guard = folly::makeGuard([&futures]() {
+            for (auto& f : futures) {
+                if (f.valid()) {
+                    try {
+                        f.get();
+                    } catch (...) {
+                    }
+                }
+            }
+        });
         for (auto& future : futures) {
             future.get();
         }

--- a/internal/core/src/segcore/reduce/Reduce.cpp
+++ b/internal/core/src/segcore/reduce/Reduce.cpp
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cstdint>
+#include <future>
 #include <map>
 #include <numeric>
 #include <optional>
@@ -40,6 +41,8 @@
 #include "segcore/SegmentInterface.h"
 #include "segcore/Utils.h"
 #include "segcore/pkVisitor.h"
+#include "segcore/ReduceUtils.h"
+#include "storage/ThreadPools.h"
 
 namespace milvus::segcore {
 
@@ -157,23 +160,45 @@ ReduceHelper::FillPrimaryKey() {
     tracer::AutoSpan span("ReduceHelper::FillPrimaryKey",
                           tracer::GetRootSpan());
     // get primary keys for duplicates removal
+    // First pass: filter invalid results and compact the array sequentially
     uint32_t valid_index = 0;
     for (auto& search_result : search_results_) {
-        // skip when results num is 0
         if (search_result->unity_topK_ == 0) {
             continue;
         }
         FilterInvalidSearchResult(search_result);
         LOG_DEBUG("the size of search result: {}",
                   search_result->seg_offsets_.size());
-        auto segment = static_cast<SegmentInterface*>(search_result->segment_);
         if (search_result->get_total_result_count() > 0) {
-            segment->FillPrimaryKeys(plan_, *search_result);
             search_results_[valid_index++] = search_result;
         }
     }
     search_results_.resize(valid_index);
     num_segments_ = search_results_.size();
+
+    // Second pass: fill primary keys
+    if (num_segments_ > 1) {
+        // Parallel execution using MIDDLE thread pool for multiple segments
+        auto& pool =
+            ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::MIDDLE);
+        std::vector<std::future<void>> futures;
+        futures.reserve(num_segments_);
+        for (auto& search_result : search_results_) {
+            auto future = pool.Submit([this, search_result] {
+                auto segment =
+                    static_cast<SegmentInterface*>(search_result->segment_);
+                segment->FillPrimaryKeys(plan_, *search_result);
+            });
+            futures.emplace_back(std::move(future));
+        }
+        for (auto& future : futures) {
+            future.get();
+        }
+    } else if (num_segments_ == 1) {
+        auto segment =
+            static_cast<SegmentInterface*>(search_results_[0]->segment_);
+        segment->FillPrimaryKeys(plan_, *search_results_[0]);
+    }
 }
 
 void

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
@@ -140,16 +140,15 @@ GroupChunkTranslator::GroupChunkTranslator(
     std::vector<std::future<FileMetaResult>> futures;
     futures.reserve(insert_files_.size());
     for (const auto& file : insert_files_) {
-        futures.push_back(pool.Submit([&fs, &file, this]() {
+        futures.push_back(pool.Submit([&fs, file, this]() {
             auto result = milvus_storage::FileRowGroupReader::Make(
                 fs,
                 file,
                 milvus_storage::DEFAULT_READ_BUFFER_SIZE,
                 storage::GetReaderProperties());
-            AssertInfo(
-                result.ok(),
-                "[StorageV2] Failed to create file row group reader: " +
-                    result.status().ToString());
+            AssertInfo(result.ok(),
+                       "[StorageV2] Failed to create file row group reader: " +
+                           result.status().ToString());
             auto reader = result.ValueOrDie();
             FileMetaResult meta_result;
             meta_result.parquet_metadata =

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
@@ -50,6 +50,7 @@
 #include "segcore/memory_planner.h"
 #include "segcore/storagev2translator/GroupCTMeta.h"
 #include "storage/KeyRetriever.h"
+#include "folly/ScopeGuard.h"
 #include "storage/ThreadPools.h"
 #include "storage/Util.h"
 
@@ -168,6 +169,18 @@ GroupChunkTranslator::GroupChunkTranslator(
             return meta_result;
         }));
     }
+    // Ensure all futures are awaited even if one throws, to prevent
+    // use-after-free on captured references (&fs, this) in background tasks.
+    auto futures_guard = folly::makeGuard([&futures]() {
+        for (auto& f : futures) {
+            if (f.valid()) {
+                try {
+                    f.get();
+                } catch (...) {
+                }
+            }
+        }
+    });
     parquet_file_metadata_.reserve(insert_files_.size());
     row_group_meta_list_.reserve(insert_files_.size());
     for (auto& f : futures) {
@@ -175,7 +188,9 @@ GroupChunkTranslator::GroupChunkTranslator(
         parquet_file_metadata_.push_back(
             std::move(meta_result.parquet_metadata));
         row_group_meta_list_.push_back(std::move(meta_result.row_group_meta));
-        field_id_mapping_ = std::move(meta_result.field_id_mapping);
+        if (field_id_mapping_.empty()) {
+            field_id_mapping_ = std::move(meta_result.field_id_mapping);
+        }
     }
 
     // Build prefix sum for O(1) lookup in get_cid_from_file_and_row_group_index

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
@@ -129,32 +129,54 @@ GroupChunkTranslator::GroupChunkTranslator(
     auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
                   .GetArrowFileSystem();
 
-    // Get row group metadata from files
+    // Get row group metadata from files in parallel using HIGH POOL
+    // to avoid blocking the MIDDLE POOL thread with serial S3 I/O
+    struct FileMetaResult {
+        std::shared_ptr<parquet::FileMetaData> parquet_metadata;
+        milvus_storage::RowGroupMetadataVector row_group_meta;
+        std::map<int64_t, milvus_storage::ColumnOffset> field_id_mapping;
+    };
+    auto& pool = ThreadPools::GetThreadPool(ThreadPoolPriority::HIGH);
+    std::vector<std::future<FileMetaResult>> futures;
+    futures.reserve(insert_files_.size());
+    for (const auto& file : insert_files_) {
+        futures.push_back(pool.Submit([&fs, &file, this]() {
+            auto result = milvus_storage::FileRowGroupReader::Make(
+                fs,
+                file,
+                milvus_storage::DEFAULT_READ_BUFFER_SIZE,
+                storage::GetReaderProperties());
+            AssertInfo(
+                result.ok(),
+                "[StorageV2] Failed to create file row group reader: " +
+                    result.status().ToString());
+            auto reader = result.ValueOrDie();
+            FileMetaResult meta_result;
+            meta_result.parquet_metadata =
+                reader->file_metadata()->GetParquetMetadata();
+            meta_result.row_group_meta =
+                reader->file_metadata()->GetRowGroupMetadataVector();
+            meta_result.field_id_mapping =
+                reader->file_metadata()->GetFieldIDMapping();
+            auto status = reader->Close();
+            AssertInfo(
+                status.ok(),
+                "[StorageV2] translator {} failed to close file reader when "
+                "get row group "
+                "metadata from file {} with error {}",
+                key_,
+                file + " with error: " + status.ToString());
+            return meta_result;
+        }));
+    }
     parquet_file_metadata_.reserve(insert_files_.size());
     row_group_meta_list_.reserve(insert_files_.size());
-    for (const auto& file : insert_files_) {
-        auto result = milvus_storage::FileRowGroupReader::Make(
-            fs,
-            file,
-            milvus_storage::DEFAULT_READ_BUFFER_SIZE,
-            storage::GetReaderProperties());
-        AssertInfo(result.ok(),
-                   "[StorageV2] Failed to create file row group reader: " +
-                       result.status().ToString());
-        auto reader = result.ValueOrDie();
+    for (auto& f : futures) {
+        auto meta_result = f.get();
         parquet_file_metadata_.push_back(
-            reader->file_metadata()->GetParquetMetadata());
-
-        field_id_mapping_ = reader->file_metadata()->GetFieldIDMapping();
-        row_group_meta_list_.push_back(
-            reader->file_metadata()->GetRowGroupMetadataVector());
-        auto status = reader->Close();
-        AssertInfo(status.ok(),
-                   "[StorageV2] translator {} failed to close file reader when "
-                   "get row group "
-                   "metadata from file {} with error {}",
-                   key_,
-                   file + " with error: " + status.ToString());
+            std::move(meta_result.parquet_metadata));
+        row_group_meta_list_.push_back(std::move(meta_result.row_group_meta));
+        field_id_mapping_ = std::move(meta_result.field_id_mapping);
     }
 
     // Build prefix sum for O(1) lookup in get_cid_from_file_and_row_group_index

--- a/internal/core/src/segcore/storagev2translator/SystemIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/SystemIndexTranslator.cpp
@@ -33,10 +33,10 @@ int64_t
 estimate_timestamp_index_bytes(int64_t num_rows, int64_t num_chunks) {
     auto num_slices = std::max<int64_t>(1, (num_rows + 4095) / 4096);
     return sizeof(TimestampIndex) +
-           num_slices * static_cast<int64_t>(sizeof(int64_t) * 2 +
-                                             sizeof(Timestamp)) +
-           num_chunks * static_cast<int64_t>(sizeof(const Timestamp*) +
-                                             sizeof(int64_t));
+           num_slices *
+               static_cast<int64_t>(sizeof(int64_t) * 2 + sizeof(Timestamp)) +
+           num_chunks *
+               static_cast<int64_t>(sizeof(const Timestamp*) + sizeof(int64_t));
 }
 
 TimestampIndex
@@ -58,7 +58,8 @@ create_offset_map(DataType data_type) {
             return std::make_unique<OffsetOrderedArray<std::string>>();
         default:
             ThrowInfo(DataTypeInvalid,
-                      "unsupported primary key data type {}", data_type);
+                      "unsupported primary key data type {}",
+                      data_type);
     }
     return nullptr;
 }
@@ -82,12 +83,14 @@ estimate_pk_index_bytes(DataType data_type,
             if (is_sorted_by_pk) {
                 base = 0;  // sorted varchar: no index built
             } else {
-                base = num_rows * static_cast<int64_t>(sizeof(std::string) + 16);
+                base =
+                    num_rows * static_cast<int64_t>(sizeof(std::string) + 16);
             }
             break;
         default:
             ThrowInfo(DataTypeInvalid,
-                      "unsupported primary key data type {}", data_type);
+                      "unsupported primary key data type {}",
+                      data_type);
     }
     return std::max<int64_t>(base, 1024);
 }
@@ -106,10 +109,10 @@ PkIndexCell::PkIndexCell(std::unique_ptr<OffsetMap> pk2offset,
     : pk2offset_(std::move(pk2offset)),
       offset2pk_(std::move(offset2pk)),
       is_int64_pk_(is_int64_pk),
-      byte_size_{static_cast<int64_t>(
-                     (pk2offset_ ? pk2offset_->memory_size() : 0) +
-                     (offset2pk_ ? offset2pk_->memory_size() : 0)),
-                 0} {
+      byte_size_{
+          static_cast<int64_t>((pk2offset_ ? pk2offset_->memory_size() : 0) +
+                               (offset2pk_ ? offset2pk_->memory_size() : 0)),
+          0} {
 }
 
 void
@@ -150,9 +153,9 @@ std::pair<milvus::cachinglayer::ResourceUsage,
           milvus::cachinglayer::ResourceUsage>
 TimestampIndexTranslator::estimated_byte_size_of_cell(
     milvus::cachinglayer::cid_t) const {
-    return {{estimate_timestamp_index_bytes(num_rows_, column_->num_chunks()),
-             0},
-            {0, 0}};
+    return {
+        {estimate_timestamp_index_bytes(num_rows_, column_->num_chunks()), 0},
+        {0, 0}};
 }
 
 const std::string&
@@ -160,11 +163,10 @@ TimestampIndexTranslator::key() const {
     return key_;
 }
 
-std::vector<std::pair<milvus::cachinglayer::cid_t,
-                      std::unique_ptr<TimestampIndexCell>>>
+std::vector<
+    std::pair<milvus::cachinglayer::cid_t, std::unique_ptr<TimestampIndexCell>>>
 TimestampIndexTranslator::get_cells(
-    milvus::OpContext* ctx,
-    const std::vector<milvus::cachinglayer::cid_t>&) {
+    milvus::OpContext* ctx, const std::vector<milvus::cachinglayer::cid_t>&) {
     CheckCancellation(
         ctx, segment_id_, "TimestampIndexTranslator::get_cells()");
 
@@ -215,10 +217,11 @@ TimestampIndexTranslator::meta() {
     return &meta_;
 }
 
-PkIndexTranslator::PkIndexTranslator(int64_t segment_id,
-                                     std::shared_ptr<ChunkedColumnInterface> column,
-                                     DataType data_type,
-                                     bool is_sorted_by_pk)
+PkIndexTranslator::PkIndexTranslator(
+    int64_t segment_id,
+    std::shared_ptr<ChunkedColumnInterface> column,
+    DataType data_type,
+    bool is_sorted_by_pk)
     : segment_id_(segment_id),
       column_(std::move(column)),
       data_type_(data_type),
@@ -245,7 +248,8 @@ std::pair<milvus::cachinglayer::ResourceUsage,
           milvus::cachinglayer::ResourceUsage>
 PkIndexTranslator::estimated_byte_size_of_cell(
     milvus::cachinglayer::cid_t) const {
-    return {{estimate_pk_index_bytes(data_type_, column_->NumRows(), is_sorted_by_pk_),
+    return {{estimate_pk_index_bytes(
+                 data_type_, column_->NumRows(), is_sorted_by_pk_),
              0},
             {0, 0}};
 }
@@ -255,7 +259,8 @@ PkIndexTranslator::key() const {
     return key_;
 }
 
-std::vector<std::pair<milvus::cachinglayer::cid_t, std::unique_ptr<PkIndexCell>>>
+std::vector<
+    std::pair<milvus::cachinglayer::cid_t, std::unique_ptr<PkIndexCell>>>
 PkIndexTranslator::get_cells(milvus::OpContext* ctx,
                              const std::vector<milvus::cachinglayer::cid_t>&) {
     CheckCancellation(ctx, segment_id_, "PkIndexTranslator::get_cells()");
@@ -311,19 +316,22 @@ PkIndexTranslator::get_cells(milvus::OpContext* ctx,
         }
         default:
             ThrowInfo(DataTypeInvalid,
-                      "unsupported primary key data type {}", data_type_);
+                      "unsupported primary key data type {}",
+                      data_type_);
     }
 
     if (pk2offset) {
         pk2offset->seal();
     }
 
-    std::vector<std::pair<milvus::cachinglayer::cid_t, std::unique_ptr<PkIndexCell>>>
+    std::vector<
+        std::pair<milvus::cachinglayer::cid_t, std::unique_ptr<PkIndexCell>>>
         result;
     result.emplace_back(
         0,
-        std::make_unique<PkIndexCell>(
-            std::move(pk2offset), std::move(offset2pk), data_type_ == DataType::INT64));
+        std::make_unique<PkIndexCell>(std::move(pk2offset),
+                                      std::move(offset2pk),
+                                      data_type_ == DataType::INT64));
     return result;
 }
 

--- a/internal/core/src/segcore/storagev2translator/SystemIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/SystemIndexTranslator.cpp
@@ -127,15 +127,18 @@ PkIndexCell::bulk_get_int64_pks_by_offsets(const int64_t* offsets,
 TimestampIndexTranslator::TimestampIndexTranslator(
     int64_t segment_id,
     std::shared_ptr<ChunkedColumnInterface> column,
-    int64_t num_rows)
+    int64_t num_rows,
+    const std::string& warmup_policy)
     : segment_id_(segment_id),
       column_(std::move(column)),
       num_rows_(num_rows),
       key_(fmt::format("seg_{}_ts_index", segment_id)),
       meta_(milvus::cachinglayer::StorageType::MEMORY,
             milvus::cachinglayer::CellIdMappingMode::ALWAYS_ZERO,
-            milvus::cachinglayer::CellDataType::OTHER,
-            CacheWarmupPolicy::CacheWarmupPolicy_Disable,
+            milvus::cachinglayer::CellDataType::SCALAR_INDEX,
+            milvus::segcore::getCacheWarmupPolicy(warmup_policy,
+                                                  /* is_vector */ false,
+                                                  /* is_index */ false),
             /* support_eviction */ true) {
 }
 

--- a/internal/core/src/segcore/storagev2translator/SystemIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/SystemIndexTranslator.cpp
@@ -230,7 +230,7 @@ PkIndexTranslator::PkIndexTranslator(
       meta_(milvus::cachinglayer::StorageType::MEMORY,
             milvus::cachinglayer::CellIdMappingMode::ALWAYS_ZERO,
             milvus::cachinglayer::CellDataType::OTHER,
-            CacheWarmupPolicy::CacheWarmupPolicy_Disable,
+            CacheWarmupPolicy::CacheWarmupPolicy_Sync,
             /* support_eviction */ true) {
 }
 

--- a/internal/core/src/segcore/storagev2translator/SystemIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/SystemIndexTranslator.cpp
@@ -1,0 +1,335 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "segcore/storagev2translator/SystemIndexTranslator.h"
+
+#include <algorithm>
+#include <fmt/core.h>
+#include <numeric>
+#include <utility>
+
+#include "common/Chunk.h"
+#include "common/EasyAssert.h"
+#include "segcore/Utils.h"
+
+namespace milvus::segcore::storagev2translator {
+
+namespace {
+
+int64_t
+estimate_timestamp_index_bytes(int64_t num_rows, int64_t num_chunks) {
+    auto num_slices = std::max<int64_t>(1, (num_rows + 4095) / 4096);
+    return sizeof(TimestampIndex) +
+           num_slices * static_cast<int64_t>(sizeof(int64_t) * 2 +
+                                             sizeof(Timestamp)) +
+           num_chunks * static_cast<int64_t>(sizeof(const Timestamp*) +
+                                             sizeof(int64_t));
+}
+
+TimestampIndex
+build_timestamp_index(const Timestamp* data, size_t num_rows) {
+    TimestampIndex index;
+    auto min_slice_length = num_rows < 4096 ? 1 : 4096;
+    auto meta = GenerateFakeSlices(data, num_rows, min_slice_length);
+    index.set_length_meta(std::move(meta));
+    index.build_with(data, num_rows);
+    return index;
+}
+
+std::unique_ptr<OffsetMap>
+create_offset_map(DataType data_type) {
+    switch (data_type) {
+        case DataType::INT64:
+            return std::make_unique<OffsetOrderedArray<int64_t>>();
+        case DataType::VARCHAR:
+            return std::make_unique<OffsetOrderedArray<std::string>>();
+        default:
+            ThrowInfo(DataTypeInvalid,
+                      "unsupported primary key data type {}", data_type);
+    }
+    return nullptr;
+}
+
+int64_t
+estimate_pk_index_bytes(DataType data_type,
+                        int64_t num_rows,
+                        bool is_sorted_by_pk) {
+    int64_t base = 0;
+    switch (data_type) {
+        case DataType::INT64:
+            if (is_sorted_by_pk) {
+                // sorted: only compressed offset->pk, no pk->offset
+                base = num_rows * static_cast<int64_t>(sizeof(int64_t));
+            } else {
+                // unsorted: both pk->offset and compressed offset->pk
+                base = num_rows * static_cast<int64_t>(sizeof(int64_t) * 2);
+            }
+            break;
+        case DataType::VARCHAR:
+            if (is_sorted_by_pk) {
+                base = 0;  // sorted varchar: no index built
+            } else {
+                base = num_rows * static_cast<int64_t>(sizeof(std::string) + 16);
+            }
+            break;
+        default:
+            ThrowInfo(DataTypeInvalid,
+                      "unsupported primary key data type {}", data_type);
+    }
+    return std::max<int64_t>(base, 1024);
+}
+
+}  // namespace
+
+TimestampIndexCell::TimestampIndexCell(TimestampIndex timestamp_index,
+                                       int64_t num_rows)
+    : timestamp_index_(std::move(timestamp_index)),
+      byte_size_{estimate_timestamp_index_bytes(num_rows, 1), 0} {
+}
+
+PkIndexCell::PkIndexCell(std::unique_ptr<OffsetMap> pk2offset,
+                         std::unique_ptr<CompressedInt64PkArray> offset2pk,
+                         bool is_int64_pk)
+    : pk2offset_(std::move(pk2offset)),
+      offset2pk_(std::move(offset2pk)),
+      is_int64_pk_(is_int64_pk),
+      byte_size_{static_cast<int64_t>(
+                     (pk2offset_ ? pk2offset_->memory_size() : 0) +
+                     (offset2pk_ ? offset2pk_->memory_size() : 0)),
+                 0} {
+}
+
+void
+PkIndexCell::bulk_get_int64_pks_by_offsets(const int64_t* offsets,
+                                           int64_t count,
+                                           int64_t* output) const {
+    AssertInfo(has_int64_pk_index(),
+               "bulk_get_int64_pks_by_offsets requires int64 PK index");
+    offset2pk_->bulk_at(offsets, count, output);
+}
+
+TimestampIndexTranslator::TimestampIndexTranslator(
+    int64_t segment_id,
+    std::shared_ptr<ChunkedColumnInterface> column,
+    int64_t num_rows)
+    : segment_id_(segment_id),
+      column_(std::move(column)),
+      num_rows_(num_rows),
+      key_(fmt::format("seg_{}_ts_index", segment_id)),
+      meta_(milvus::cachinglayer::StorageType::MEMORY,
+            milvus::cachinglayer::CellIdMappingMode::ALWAYS_ZERO,
+            milvus::cachinglayer::CellDataType::OTHER,
+            CacheWarmupPolicy::CacheWarmupPolicy_Disable,
+            /* support_eviction */ true) {
+}
+
+size_t
+TimestampIndexTranslator::num_cells() const {
+    return 1;
+}
+
+milvus::cachinglayer::cid_t
+TimestampIndexTranslator::cell_id_of(milvus::cachinglayer::uid_t) const {
+    return 0;
+}
+
+std::pair<milvus::cachinglayer::ResourceUsage,
+          milvus::cachinglayer::ResourceUsage>
+TimestampIndexTranslator::estimated_byte_size_of_cell(
+    milvus::cachinglayer::cid_t) const {
+    return {{estimate_timestamp_index_bytes(num_rows_, column_->num_chunks()),
+             0},
+            {0, 0}};
+}
+
+const std::string&
+TimestampIndexTranslator::key() const {
+    return key_;
+}
+
+std::vector<std::pair<milvus::cachinglayer::cid_t,
+                      std::unique_ptr<TimestampIndexCell>>>
+TimestampIndexTranslator::get_cells(
+    milvus::OpContext* ctx,
+    const std::vector<milvus::cachinglayer::cid_t>&) {
+    CheckCancellation(
+        ctx, segment_id_, "TimestampIndexTranslator::get_cells()");
+
+    // Pin column chunks temporarily to build the TimestampIndex, then release.
+    // TimestampIndexCell intentionally does NOT hold raw timestamp data or
+    // pins to GroupChunk cells — callers read raw timestamps by pinning the
+    // timestamp column directly. This avoids a DList deadlock where evicting
+    // this cell would unpin GroupChunk cells under the same list_mtx_.
+    auto all_chunks = column_->GetAllChunks(ctx);
+    TimestampIndex index;
+    if (all_chunks.size() == 1) {
+        auto* fixed_chunk = static_cast<FixedWidthChunk*>(all_chunks[0].get());
+        auto span = fixed_chunk->Span();
+        auto* ts_ptr = static_cast<const Timestamp*>(span.data());
+        AssertInfo(static_cast<int64_t>(span.row_count()) == num_rows_,
+                   "timestamp chunk row count {} != expected {}",
+                   span.row_count(),
+                   num_rows_);
+        index = build_timestamp_index(ts_ptr, num_rows_);
+    } else {
+        std::vector<Timestamp> temp(num_rows_);
+        size_t offset = 0;
+        for (auto& pin : all_chunks) {
+            auto* fixed_chunk = static_cast<FixedWidthChunk*>(pin.get());
+            auto span = fixed_chunk->Span();
+            std::copy_n(static_cast<const Timestamp*>(span.data()),
+                        span.row_count(),
+                        temp.data() + offset);
+            offset += span.row_count();
+        }
+        AssertInfo(static_cast<int64_t>(offset) == num_rows_,
+                   "timestamp total row count {} != expected {}",
+                   offset,
+                   num_rows_);
+        index = build_timestamp_index(temp.data(), num_rows_);
+    }
+
+    std::vector<std::pair<milvus::cachinglayer::cid_t,
+                          std::unique_ptr<TimestampIndexCell>>>
+        result;
+    result.emplace_back(
+        0, std::make_unique<TimestampIndexCell>(std::move(index), num_rows_));
+    return result;
+}
+
+Meta*
+TimestampIndexTranslator::meta() {
+    return &meta_;
+}
+
+PkIndexTranslator::PkIndexTranslator(int64_t segment_id,
+                                     std::shared_ptr<ChunkedColumnInterface> column,
+                                     DataType data_type,
+                                     bool is_sorted_by_pk)
+    : segment_id_(segment_id),
+      column_(std::move(column)),
+      data_type_(data_type),
+      is_sorted_by_pk_(is_sorted_by_pk),
+      key_(fmt::format("seg_{}_pk_index", segment_id)),
+      meta_(milvus::cachinglayer::StorageType::MEMORY,
+            milvus::cachinglayer::CellIdMappingMode::ALWAYS_ZERO,
+            milvus::cachinglayer::CellDataType::OTHER,
+            CacheWarmupPolicy::CacheWarmupPolicy_Disable,
+            /* support_eviction */ true) {
+}
+
+size_t
+PkIndexTranslator::num_cells() const {
+    return 1;
+}
+
+milvus::cachinglayer::cid_t
+PkIndexTranslator::cell_id_of(milvus::cachinglayer::uid_t) const {
+    return 0;
+}
+
+std::pair<milvus::cachinglayer::ResourceUsage,
+          milvus::cachinglayer::ResourceUsage>
+PkIndexTranslator::estimated_byte_size_of_cell(
+    milvus::cachinglayer::cid_t) const {
+    return {{estimate_pk_index_bytes(data_type_, column_->NumRows(), is_sorted_by_pk_),
+             0},
+            {0, 0}};
+}
+
+const std::string&
+PkIndexTranslator::key() const {
+    return key_;
+}
+
+std::vector<std::pair<milvus::cachinglayer::cid_t, std::unique_ptr<PkIndexCell>>>
+PkIndexTranslator::get_cells(milvus::OpContext* ctx,
+                             const std::vector<milvus::cachinglayer::cid_t>&) {
+    CheckCancellation(ctx, segment_id_, "PkIndexTranslator::get_cells()");
+
+    std::unique_ptr<OffsetMap> pk2offset;
+    std::unique_ptr<CompressedInt64PkArray> offset2pk;
+
+    auto num_chunks = column_->num_chunks();
+    std::vector<int64_t> chunk_ids(num_chunks);
+    std::iota(chunk_ids.begin(), chunk_ids.end(), 0);
+    column_->PrefetchChunks(ctx, chunk_ids);
+
+    int64_t offset = 0;
+    switch (data_type_) {
+        case DataType::INT64: {
+            std::vector<int64_t> all_pks;
+            all_pks.reserve(column_->NumRows());
+            if (!is_sorted_by_pk_) {
+                pk2offset = create_offset_map(data_type_);
+            }
+            for (int64_t i = 0; i < num_chunks; ++i) {
+                auto pw = column_->DataOfChunk(ctx, i);
+                auto pks = reinterpret_cast<const int64_t*>(pw.get());
+                auto chunk_num_rows = column_->chunk_row_nums(i);
+                for (int64_t j = 0; j < chunk_num_rows; ++j) {
+                    auto pk = pks[j];
+                    all_pks.push_back(pk);
+                    if (pk2offset) {
+                        pk2offset->insert(pk, offset);
+                    }
+                    ++offset;
+                }
+            }
+            offset2pk = std::make_unique<CompressedInt64PkArray>();
+            offset2pk->build(all_pks.data(), all_pks.size());
+            break;
+        }
+        case DataType::VARCHAR: {
+            if (!is_sorted_by_pk_) {
+                pk2offset = create_offset_map(data_type_);
+            }
+            for (int64_t i = 0; i < num_chunks; ++i) {
+                auto pw = column_->StringViews(ctx, i);
+                auto& pks = pw.get().first;
+                for (auto pk : pks) {
+                    if (pk2offset) {
+                        pk2offset->insert(std::string(pk), offset);
+                    }
+                    ++offset;
+                }
+            }
+            break;
+        }
+        default:
+            ThrowInfo(DataTypeInvalid,
+                      "unsupported primary key data type {}", data_type_);
+    }
+
+    if (pk2offset) {
+        pk2offset->seal();
+    }
+
+    std::vector<std::pair<milvus::cachinglayer::cid_t, std::unique_ptr<PkIndexCell>>>
+        result;
+    result.emplace_back(
+        0,
+        std::make_unique<PkIndexCell>(
+            std::move(pk2offset), std::move(offset2pk), data_type_ == DataType::INT64));
+    return result;
+}
+
+Meta*
+PkIndexTranslator::meta() {
+    return &meta_;
+}
+
+}  // namespace milvus::segcore::storagev2translator

--- a/internal/core/src/segcore/storagev2translator/SystemIndexTranslator.h
+++ b/internal/core/src/segcore/storagev2translator/SystemIndexTranslator.h
@@ -1,0 +1,192 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "cachinglayer/Translator.h"
+#include "common/Types.h"
+#include "mmap/ChunkedColumnInterface.h"
+#include "segcore/InsertRecord.h"
+#include "segcore/TimestampIndex.h"
+
+namespace milvus::segcore::storagev2translator {
+
+class TimestampIndexCell {
+ public:
+    explicit TimestampIndexCell(TimestampIndex timestamp_index, int64_t num_rows);
+
+    const TimestampIndex&
+    timestamp_index() const {
+        return timestamp_index_;
+    }
+
+    cachinglayer::ResourceUsage
+    CellByteSize() const {
+        return byte_size_;
+    }
+
+ private:
+    TimestampIndex timestamp_index_;
+    cachinglayer::ResourceUsage byte_size_;
+};
+
+class PkIndexCell {
+ public:
+    PkIndexCell(std::unique_ptr<OffsetMap> pk2offset,
+                std::unique_ptr<CompressedInt64PkArray> offset2pk,
+                bool is_int64_pk);
+
+    bool
+    has_pk2offset() const {
+        return pk2offset_ != nullptr;
+    }
+
+    bool
+    empty_pks() const {
+        return pk2offset_ == nullptr || pk2offset_->empty();
+    }
+
+    bool
+    contain(const PkType& pk) const {
+        if (pk2offset_ == nullptr) {
+            return false;
+        }
+        return pk2offset_->contain(pk);
+    }
+
+    const OffsetMap&
+    pk2offset() const {
+        AssertInfo(pk2offset_ != nullptr,
+                   "pk2offset not built (sorted-by-pk segment)");
+        return *pk2offset_;
+    }
+
+    bool
+    has_int64_pk_index() const {
+        return is_int64_pk_ && offset2pk_ != nullptr;
+    }
+
+    void
+    bulk_get_int64_pks_by_offsets(const int64_t* offsets,
+                                  int64_t count,
+                                  int64_t* output) const;
+
+    cachinglayer::ResourceUsage
+    CellByteSize() const {
+        return byte_size_;
+    }
+
+ private:
+    std::unique_ptr<OffsetMap> pk2offset_;
+    std::unique_ptr<CompressedInt64PkArray> offset2pk_;
+    bool is_int64_pk_{false};
+    cachinglayer::ResourceUsage byte_size_;
+};
+
+class TimestampIndexTranslator
+    : public milvus::cachinglayer::Translator<TimestampIndexCell> {
+ public:
+    TimestampIndexTranslator(int64_t segment_id,
+                             std::shared_ptr<ChunkedColumnInterface> column,
+                             int64_t num_rows);
+
+    ~TimestampIndexTranslator() override = default;
+
+    size_t
+    num_cells() const override;
+
+    milvus::cachinglayer::cid_t
+    cell_id_of(milvus::cachinglayer::uid_t uid) const override;
+
+    std::pair<milvus::cachinglayer::ResourceUsage,
+              milvus::cachinglayer::ResourceUsage>
+    estimated_byte_size_of_cell(milvus::cachinglayer::cid_t cid) const override;
+
+    const std::string&
+    key() const override;
+
+    std::vector<std::pair<milvus::cachinglayer::cid_t,
+                          std::unique_ptr<TimestampIndexCell>>>
+    get_cells(milvus::OpContext* ctx,
+              const std::vector<milvus::cachinglayer::cid_t>& cids) override;
+
+    Meta*
+    meta() override;
+
+    int64_t
+    cells_storage_bytes(
+        const std::vector<milvus::cachinglayer::cid_t>& cids) const override {
+        return 0;
+    }
+
+ private:
+    int64_t segment_id_;
+    std::shared_ptr<ChunkedColumnInterface> column_;
+    int64_t num_rows_;
+    std::string key_;
+    milvus::cachinglayer::Meta meta_;
+};
+
+class PkIndexTranslator
+    : public milvus::cachinglayer::Translator<PkIndexCell> {
+ public:
+    PkIndexTranslator(int64_t segment_id,
+                      std::shared_ptr<ChunkedColumnInterface> column,
+                      DataType data_type,
+                      bool is_sorted_by_pk);
+
+    ~PkIndexTranslator() override = default;
+
+    size_t
+    num_cells() const override;
+
+    milvus::cachinglayer::cid_t
+    cell_id_of(milvus::cachinglayer::uid_t uid) const override;
+
+    std::pair<milvus::cachinglayer::ResourceUsage,
+              milvus::cachinglayer::ResourceUsage>
+    estimated_byte_size_of_cell(milvus::cachinglayer::cid_t cid) const override;
+
+    const std::string&
+    key() const override;
+
+    std::vector<std::pair<milvus::cachinglayer::cid_t,
+                          std::unique_ptr<PkIndexCell>>>
+    get_cells(milvus::OpContext* ctx,
+              const std::vector<milvus::cachinglayer::cid_t>& cids) override;
+
+    Meta*
+    meta() override;
+
+    int64_t
+    cells_storage_bytes(
+        const std::vector<milvus::cachinglayer::cid_t>& cids) const override {
+        return 0;
+    }
+
+ private:
+    int64_t segment_id_;
+    std::shared_ptr<ChunkedColumnInterface> column_;
+    DataType data_type_;
+    bool is_sorted_by_pk_;
+    std::string key_;
+    milvus::cachinglayer::Meta meta_;
+};
+
+}  // namespace milvus::segcore::storagev2translator

--- a/internal/core/src/segcore/storagev2translator/SystemIndexTranslator.h
+++ b/internal/core/src/segcore/storagev2translator/SystemIndexTranslator.h
@@ -29,7 +29,8 @@ namespace milvus::segcore::storagev2translator {
 
 class TimestampIndexCell {
  public:
-    explicit TimestampIndexCell(TimestampIndex timestamp_index, int64_t num_rows);
+    explicit TimestampIndexCell(TimestampIndex timestamp_index,
+                                int64_t num_rows);
 
     const TimestampIndex&
     timestamp_index() const {
@@ -143,8 +144,7 @@ class TimestampIndexTranslator
     milvus::cachinglayer::Meta meta_;
 };
 
-class PkIndexTranslator
-    : public milvus::cachinglayer::Translator<PkIndexCell> {
+class PkIndexTranslator : public milvus::cachinglayer::Translator<PkIndexCell> {
  public:
     PkIndexTranslator(int64_t segment_id,
                       std::shared_ptr<ChunkedColumnInterface> column,
@@ -166,8 +166,8 @@ class PkIndexTranslator
     const std::string&
     key() const override;
 
-    std::vector<std::pair<milvus::cachinglayer::cid_t,
-                          std::unique_ptr<PkIndexCell>>>
+    std::vector<
+        std::pair<milvus::cachinglayer::cid_t, std::unique_ptr<PkIndexCell>>>
     get_cells(milvus::OpContext* ctx,
               const std::vector<milvus::cachinglayer::cid_t>& cids) override;
 

--- a/internal/core/src/segcore/storagev2translator/SystemIndexTranslator.h
+++ b/internal/core/src/segcore/storagev2translator/SystemIndexTranslator.h
@@ -105,7 +105,8 @@ class TimestampIndexTranslator
  public:
     TimestampIndexTranslator(int64_t segment_id,
                              std::shared_ptr<ChunkedColumnInterface> column,
-                             int64_t num_rows);
+                             int64_t num_rows,
+                             const std::string& warmup_policy = "");
 
     ~TimestampIndexTranslator() override = default;
 


### PR DESCRIPTION
## Summary

- Port of #48771 to `3.0` branch
- Add bitpacking-based CompressedInt64PkArray for int64 PK compression (50-75% memory reduction)
- Defer timestamp/PK index construction to first access via lazy SystemIndexTranslator (zero S3 I/O on load path)
- Parallelize StorageV2 row group metadata fetching across files
- Skip OffsetOrderedArray for sorted-by-pk segments (save ~12 bytes/row)

issue: #48770
pr: #48771

## Changes

### PK Compressed Storage (4 commits)
- `CompressedInt64PkArray`: block-based encoding with per-block min + variable-width bitpacked deltas, O(1) random access via block index
- `build_offset2pk()` on `InsertRecord`: builds compressed offset→pk for both sorted and unsorted segments, enabling fast `FillPrimaryKeys` path
- Unit tests covering edge cases: empty, single element, large ranges, INT64_MAX boundaries

### Segment Loading Optimization (2 commits)
- Prefetch pk and timestamp column chunks before sequential access
- Parallelize row group metadata fetching using HIGH thread pool (fix: capture loop variable by value to avoid dangling reference)

### Lazy System Index - SystemIndexTranslator (2 commits)
- `TimestampIndexTranslator`: builds timestamp index lazily on first `mask_with_timestamps` / `bulk_subscript` call
- `PkIndexTranslator`: builds pk2offset / offset2pk lazily on first `Contain` / `search` call
- V1 compatibility: fallback to `insert_record_` when translator slot is empty
- Sorted-by-pk: skip OffsetOrderedArray (pk2offset) construction, only build offset2pk

### Bug Fixes (3 commits)
- Fix `Contain()` returning false for sorted-by-pk segments (missing binary search path)
- Remove `TimestampData` from `TimestampIndexCell` to prevent DList deadlock (read timestamp from column directly)
- Remove stale `system_ready_count_++` references; init empty timestamps for zero-row segments so `is_system_field_ready()` returns true
- Fix dangling reference in parallel metadata fetch lambda (GroupChunkTranslator + JsonKeyStats)

## Test plan

- [ ] CompressedInt64PkArray unit tests pass
- [ ] StorageV2 lazy system index tests pass (TestLazySystemIndexesOnUnsortedSegment, TestLazySystemIndexesOnSortedSegment)
- [ ] Load collection with int64 PK fields, verify reduced RSS
- [ ] Load sorted-by-pk segments, verify Contain() and delete work correctly
- [ ] Concurrent segment loading does not deadlock on TimestampIndex access

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>