### PR TITLE
fix: correct nullable vector field merge to prevent panic on empty lidData (#48700)

### DIFF
--- a/internal/proxy/query_pipeline.go
+++ b/internal/proxy/query_pipeline.go
@@ -119,7 +119,7 @@ func buildPlainQueryPipeline(
 	reduceType reduce.IReduceType,
 ) *queryutil.Pipeline {
 	b := queryutil.NewPipelineBuilder("proxy-query-plain")
-	b.Add(queryutil.OpReduceByPK, in(), ch(chanReduced), queryutil.NewSortAndCheckPKOperator(reduceType))
+	b.Add(queryutil.OpReduceByPK, in(), ch(chanReduced), queryutil.NewSortAndCheckPKOperator(reduceType, schema))
 	b.Add(queryutil.OpSlice, ch(chanReduced), ch(chanSliced), queryutil.NewSliceOperator(limit, offset))
 	b.Add("complement_fields", ch(chanSliced), out(), newComplementFieldOperator(schema))
 	return b.Build()
@@ -133,7 +133,7 @@ func buildOrderByPipeline(
 	outputFieldIDs []int64,
 ) *queryutil.Pipeline {
 	b := queryutil.NewPipelineBuilder("proxy-query-orderby")
-	b.Add(queryutil.OpConcatAndCheckPK, in(), ch(chanReduced), queryutil.NewConcatAndCheckPKOperator())
+	b.Add(queryutil.OpConcatAndCheckPK, in(), ch(chanReduced), queryutil.NewConcatAndCheckPKOperator(schema))
 	b.Add(queryutil.OpOrderByLimit, ch(chanReduced), ch(chanSorted), queryutil.NewOrderByLimitOperator(orderByFields, offset+limit))
 	b.Add(queryutil.OpSlice, ch(chanSorted), ch(chanSliced), queryutil.NewSliceOperator(limit, offset))
 

--- a/internal/util/queryutil/dedup_pk_op.go
+++ b/internal/util/queryutil/dedup_pk_op.go
@@ -23,6 +23,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
@@ -44,10 +45,11 @@ import (
 // Output[0]: *internalpb.RetrieveResults (concatenated + deduplicated)
 type DeduplicatePKOperator struct {
 	maxOutputSize int64
+	schema        *schemapb.CollectionSchema
 }
 
-func NewDeduplicatePKOperator(maxOutputSize int64) *DeduplicatePKOperator {
-	return &DeduplicatePKOperator{maxOutputSize: maxOutputSize}
+func NewDeduplicatePKOperator(maxOutputSize int64, schema *schemapb.CollectionSchema) *DeduplicatePKOperator {
+	return &DeduplicatePKOperator{maxOutputSize: maxOutputSize, schema: schema}
 }
 
 func (op *DeduplicatePKOperator) Name() string {
@@ -130,7 +132,7 @@ func (op *DeduplicatePKOperator) Run(ctx context.Context, span trace.Span, input
 		return []any{&internalpb.RetrieveResults{HasMoreResult: hasMoreResult}}, nil
 	}
 
-	merged, err := buildMergedRetrieveResults(origResults, selectedRows)
+	merged, err := buildMergedRetrieveResults(origResults, selectedRows, op.schema)
 	if err != nil {
 		return nil, err
 	}
@@ -160,10 +162,12 @@ func extractTimestamps(r *internalpb.RetrieveResults) []int64 {
 //
 // Input[0]: []*internalpb.RetrieveResults
 // Output[0]: *internalpb.RetrieveResults (concatenated)
-type ConcatAndCheckPKOperator struct{}
+type ConcatAndCheckPKOperator struct {
+	schema *schemapb.CollectionSchema
+}
 
-func NewConcatAndCheckPKOperator() *ConcatAndCheckPKOperator {
-	return &ConcatAndCheckPKOperator{}
+func NewConcatAndCheckPKOperator(schema *schemapb.CollectionSchema) *ConcatAndCheckPKOperator {
+	return &ConcatAndCheckPKOperator{schema: schema}
 }
 
 func (op *ConcatAndCheckPKOperator) Name() string {
@@ -217,7 +221,7 @@ func (op *ConcatAndCheckPKOperator) Run(ctx context.Context, span trace.Span, in
 		}
 	}
 
-	merged, err := buildMergedRetrieveResults(validResults, selectedRows)
+	merged, err := buildMergedRetrieveResults(validResults, selectedRows, op.schema)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/util/queryutil/dedup_pk_op_test.go
+++ b/internal/util/queryutil/dedup_pk_op_test.go
@@ -62,12 +62,12 @@ func makeDedupInt64Field(fieldID int64, name string, vals []int64) *schemapb.Fie
 }
 
 func TestDeduplicatePKOperator_Name(t *testing.T) {
-	op := NewDeduplicatePKOperator(0)
+	op := NewDeduplicatePKOperator(0, nil)
 	assert.Equal(t, OpDeduplicatePK, op.Name())
 }
 
 func TestDeduplicatePKOperator_EmptyInput(t *testing.T) {
-	op := NewDeduplicatePKOperator(0)
+	op := NewDeduplicatePKOperator(0, nil)
 	ctx := context.Background()
 
 	outputs, err := op.Run(ctx, nil, []*internalpb.RetrieveResults{})
@@ -77,7 +77,7 @@ func TestDeduplicatePKOperator_EmptyInput(t *testing.T) {
 }
 
 func TestDeduplicatePKOperator_NilResults(t *testing.T) {
-	op := NewDeduplicatePKOperator(0)
+	op := NewDeduplicatePKOperator(0, nil)
 	ctx := context.Background()
 
 	outputs, err := op.Run(ctx, nil, []*internalpb.RetrieveResults{nil, nil})
@@ -87,7 +87,7 @@ func TestDeduplicatePKOperator_NilResults(t *testing.T) {
 }
 
 func TestDeduplicatePKOperator_SingleResult(t *testing.T) {
-	op := NewDeduplicatePKOperator(0)
+	op := NewDeduplicatePKOperator(0, nil)
 	ctx := context.Background()
 
 	r := &internalpb.RetrieveResults{
@@ -102,7 +102,7 @@ func TestDeduplicatePKOperator_SingleResult(t *testing.T) {
 }
 
 func TestDeduplicatePKOperator_MultipleResults_NoDuplicates(t *testing.T) {
-	op := NewDeduplicatePKOperator(0)
+	op := NewDeduplicatePKOperator(0, nil)
 	ctx := context.Background()
 
 	r1 := &internalpb.RetrieveResults{
@@ -120,7 +120,7 @@ func TestDeduplicatePKOperator_MultipleResults_NoDuplicates(t *testing.T) {
 }
 
 func TestDeduplicatePKOperator_DuplicatePK_HigherTimestampWins(t *testing.T) {
-	op := NewDeduplicatePKOperator(0)
+	op := NewDeduplicatePKOperator(0, nil)
 	ctx := context.Background()
 
 	// r1: PK=1 with ts=100, val=10
@@ -147,7 +147,7 @@ func TestDeduplicatePKOperator_DuplicatePK_HigherTimestampWins(t *testing.T) {
 }
 
 func TestDeduplicatePKOperator_DuplicatePK_LowerTimestampLoses(t *testing.T) {
-	op := NewDeduplicatePKOperator(0)
+	op := NewDeduplicatePKOperator(0, nil)
 	ctx := context.Background()
 
 	// r1: PK=1 with ts=200, val=10 (should win)
@@ -174,7 +174,7 @@ func TestDeduplicatePKOperator_DuplicatePK_LowerTimestampLoses(t *testing.T) {
 }
 
 func TestDeduplicatePKOperator_DuplicateWithinSingleResult(t *testing.T) {
-	op := NewDeduplicatePKOperator(0)
+	op := NewDeduplicatePKOperator(0, nil)
 	ctx := context.Background()
 
 	// Single result with duplicate PK=1 (ts=100 then ts=200)
@@ -194,7 +194,7 @@ func TestDeduplicatePKOperator_DuplicateWithinSingleResult(t *testing.T) {
 
 func TestDeduplicatePKOperator_MaxOutputSize(t *testing.T) {
 	// Very small maxOutputSize should trigger error
-	op := NewDeduplicatePKOperator(1) // 1 byte limit
+	op := NewDeduplicatePKOperator(1, nil) // 1 byte limit
 	ctx := context.Background()
 
 	r := &internalpb.RetrieveResults{
@@ -207,7 +207,7 @@ func TestDeduplicatePKOperator_MaxOutputSize(t *testing.T) {
 }
 
 func TestDeduplicatePKOperator_HasMoreResult(t *testing.T) {
-	op := NewDeduplicatePKOperator(0)
+	op := NewDeduplicatePKOperator(0, nil)
 	ctx := context.Background()
 
 	r1 := &internalpb.RetrieveResults{
@@ -227,7 +227,7 @@ func TestDeduplicatePKOperator_HasMoreResult(t *testing.T) {
 }
 
 func TestDeduplicatePKOperator_StringPK(t *testing.T) {
-	op := NewDeduplicatePKOperator(0)
+	op := NewDeduplicatePKOperator(0, nil)
 	ctx := context.Background()
 
 	r1 := &internalpb.RetrieveResults{
@@ -250,7 +250,7 @@ func TestDeduplicatePKOperator_StringPK(t *testing.T) {
 // =========================================================================
 
 func TestConcatAndCheckPKOperator_DuplicatePK_ReturnsError(t *testing.T) {
-	op := NewConcatAndCheckPKOperator()
+	op := NewConcatAndCheckPKOperator(nil)
 	ctx := context.Background()
 
 	r1 := &internalpb.RetrieveResults{
@@ -267,7 +267,7 @@ func TestConcatAndCheckPKOperator_DuplicatePK_ReturnsError(t *testing.T) {
 }
 
 func TestConcatAndCheckPKOperator_SingleResult(t *testing.T) {
-	op := NewConcatAndCheckPKOperator()
+	op := NewConcatAndCheckPKOperator(nil)
 	ctx := context.Background()
 
 	r := &internalpb.RetrieveResults{
@@ -283,7 +283,7 @@ func TestConcatAndCheckPKOperator_SingleResult(t *testing.T) {
 // TestConcatAndCheckPKOperator_HasMoreResult_MultiResult verifies HasMoreResult is propagated
 // when multiple non-empty results are concatenated.
 func TestConcatAndCheckPKOperator_HasMoreResult_MultiResult(t *testing.T) {
-	op := NewConcatAndCheckPKOperator()
+	op := NewConcatAndCheckPKOperator(nil)
 	ctx := context.Background()
 
 	r1 := &internalpb.RetrieveResults{
@@ -305,7 +305,7 @@ func TestConcatAndCheckPKOperator_HasMoreResult_MultiResult(t *testing.T) {
 // TestConcatAndCheckPKOperator_HasMoreResult_EmptyResultPropagates verifies that HasMoreResult
 // from an empty (filtered-out) result is still propagated to the merged output.
 func TestConcatAndCheckPKOperator_HasMoreResult_EmptyResultPropagates(t *testing.T) {
-	op := NewConcatAndCheckPKOperator()
+	op := NewConcatAndCheckPKOperator(nil)
 	ctx := context.Background()
 
 	// r1 is empty (no rows) but has HasMoreResult=true
@@ -328,7 +328,7 @@ func TestConcatAndCheckPKOperator_HasMoreResult_EmptyResultPropagates(t *testing
 // TestConcatAndCheckPKOperator_HasMoreResult_AllEmpty verifies HasMoreResult is set on
 // the empty output when all inputs are empty.
 func TestConcatAndCheckPKOperator_HasMoreResult_AllEmpty(t *testing.T) {
-	op := NewConcatAndCheckPKOperator()
+	op := NewConcatAndCheckPKOperator(nil)
 	ctx := context.Background()
 
 	r1 := &internalpb.RetrieveResults{HasMoreResult: true}
@@ -347,7 +347,7 @@ func TestDeduplicatePKOperator_MaxOutputSize_ExactlyAtLimit(t *testing.T) {
 	const rowCount = 3
 	const exactLimit = rowSize * rowCount // 24 bytes
 
-	op := NewDeduplicatePKOperator(exactLimit)
+	op := NewDeduplicatePKOperator(exactLimit, nil)
 	ctx := context.Background()
 
 	r := &internalpb.RetrieveResults{
@@ -367,7 +367,7 @@ func TestDeduplicatePKOperator_MaxOutputSize_OneBelowLimit(t *testing.T) {
 	const rowCount = 3
 	const limitOneByte = rowSize*rowCount - 1 // 23 bytes — one below total
 
-	op := NewDeduplicatePKOperator(limitOneByte)
+	op := NewDeduplicatePKOperator(limitOneByte, nil)
 	ctx := context.Background()
 
 	r := &internalpb.RetrieveResults{

--- a/internal/util/queryutil/helpers.go
+++ b/internal/util/queryutil/helpers.go
@@ -57,12 +57,15 @@ func comparePK(a, b any) int {
 }
 
 // buildMergedRetrieveResults builds merged result from selected rows.
-func buildMergedRetrieveResults(results []*internalpb.RetrieveResults, selectedRows []rowRef) (*internalpb.RetrieveResults, error) {
+// schema provides field metadata (DataType, dim, nullable) used to drive
+// the merge logic. Pass nil to fall back to template-based inference
+// (backward compatible for tests and callers without schema).
+func buildMergedRetrieveResults(results []*internalpb.RetrieveResults, selectedRows []rowRef, schema *schemapb.CollectionSchema) (*internalpb.RetrieveResults, error) {
 	if len(selectedRows) == 0 || len(results) == 0 {
 		return &internalpb.RetrieveResults{}, nil
 	}
 
-	// Use first result as template
+	// Use first result as template for field count / metadata
 	template := results[selectedRows[0].resultIdx]
 	numFields := len(template.GetFieldsData())
 
@@ -77,12 +80,17 @@ func buildMergedRetrieveResults(results []*internalpb.RetrieveResults, selectedR
 	}
 
 	// Validate element-level consistency across all results referenced by selectedRows.
-	// For element-level queries (StructArray element_filter), all results must agree on
-	// the ElementLevel flag and each result's ElementIndices length must match its IDs length.
-	// This is a defensive check — the same query should produce consistent flags across
-	// all segments/shards, but mismatches indicate a data integrity issue.
 	if err := validateElementLevelConsistency(results, selectedRows); err != nil {
 		return nil, err
+	}
+
+	// Build field schema lookup map (fieldID → *FieldSchema).
+	var fieldSchemaMap map[int64]*schemapb.FieldSchema
+	if schema != nil {
+		fieldSchemaMap = make(map[int64]*schemapb.FieldSchema, len(schema.GetFields()))
+		for _, f := range schema.GetFields() {
+			fieldSchemaMap[f.GetFieldID()] = f
+		}
 	}
 
 	merged := &internalpb.RetrieveResults{
@@ -94,7 +102,16 @@ func buildMergedRetrieveResults(results []*internalpb.RetrieveResults, selectedR
 
 	// Build merged field data
 	for fieldIdx := 0; fieldIdx < numFields; fieldIdx++ {
-		merged.FieldsData[fieldIdx] = buildMergedFieldData(results, selectedRows, fieldIdx)
+		fieldID := template.GetFieldsData()[fieldIdx].GetFieldId()
+		var fs *schemapb.FieldSchema
+		if fieldSchemaMap != nil {
+			fs = fieldSchemaMap[fieldID] // nil for system fields (RowID=0, Timestamp=1)
+		}
+		fd, err := buildMergedFieldData(results, selectedRows, fieldIdx, fs)
+		if err != nil {
+			return nil, err
+		}
+		merged.FieldsData[fieldIdx] = fd
 	}
 
 	// Propagate element-level metadata
@@ -177,8 +194,12 @@ func buildMergedIDs(results []*internalpb.RetrieveResults, selectedRows []rowRef
 }
 
 // buildMergedFieldData builds merged field data from selected rows.
-func buildMergedFieldData(results []*internalpb.RetrieveResults, selectedRows []rowRef, fieldIdx int) *schemapb.FieldData {
+// fieldSchema provides DataType, dim, and nullable from the collection schema.
+// It may be nil for system fields (RowID, Timestamp) or in tests; in that case
+// the function falls back to template-based inference for backward compatibility.
+func buildMergedFieldData(results []*internalpb.RetrieveResults, selectedRows []rowRef, fieldIdx int, fieldSchema *schemapb.FieldSchema) (*schemapb.FieldData, error) {
 	template := results[selectedRows[0].resultIdx].GetFieldsData()[fieldIdx]
+	isNullable := fieldSchema != nil && fieldSchema.GetNullable()
 
 	newFd := &schemapb.FieldData{
 		Type:      template.GetType(),
@@ -187,118 +208,48 @@ func buildMergedFieldData(results []*internalpb.RetrieveResults, selectedRows []
 		IsDynamic: template.GetIsDynamic(),
 	}
 
-	switch template.GetField().(type) {
-	case *schemapb.FieldData_Scalars:
+	// Determine whether this field is a vector using schema (preferred) or template (fallback).
+	isVector := false
+	if fieldSchema != nil {
+		isVector = typeutil.IsVectorType(fieldSchema.GetDataType())
+	} else {
+		_, isVector = template.GetField().(*schemapb.FieldData_Vectors)
+	}
+
+	if isVector {
+		vecField, err := buildMergedVectorField(results, selectedRows, fieldIdx, fieldSchema)
+		if err != nil {
+			return nil, err
+		}
+		newFd.Field = &schemapb.FieldData_Vectors{
+			Vectors: vecField,
+		}
+	} else {
 		newFd.Field = &schemapb.FieldData_Scalars{
 			Scalars: buildMergedScalarField(results, selectedRows, fieldIdx),
 		}
-	case *schemapb.FieldData_Vectors:
-		newFd.Field = &schemapb.FieldData_Vectors{
-			Vectors: buildMergedVectorField(results, selectedRows, fieldIdx),
-		}
-		// Note: FieldData_StructArrays is intentionally not handled here.
-		// Segcore returns struct sub-fields as flat, independent FieldData entries.
-		// reconstructStructFieldDataForQuery assembles them into StructArrays AFTER
-		// merge/slice, so this switch only sees Scalars and Vectors.
 	}
 
 	// Preserve ValidData (nullable bitmap) for nullable fields.
-	// Each source result may have its own ValidData; merge them by selectedRows.
-	if hasValidData(results, selectedRows, fieldIdx) {
+	if isNullable {
 		validData := make([]bool, len(selectedRows))
 		for i, ref := range selectedRows {
 			vd := results[ref.resultIdx].GetFieldsData()[fieldIdx].GetValidData()
-			if len(vd) > int(ref.rowIdx) {
+			if len(vd) > 0 && int(ref.rowIdx) < len(vd) {
 				validData[i] = vd[ref.rowIdx]
-			} else {
-				// No ValidData means all values are valid (non-nullable field
-				// or source result that doesn't carry the bitmap).
-				validData[i] = true
 			}
+			// ValidData absent or rowIdx out of bounds: keep false (null semantics)
 		}
 		newFd.ValidData = validData
 	}
 
-	return newFd
-}
-
-// hasValidData checks if any source result has ValidData for the given field.
-func hasValidData(results []*internalpb.RetrieveResults, selectedRows []rowRef, fieldIdx int) bool {
-	for _, ref := range selectedRows {
-		fd := results[ref.resultIdx].GetFieldsData()[fieldIdx]
-		if len(fd.GetValidData()) > 0 {
-			return true
-		}
-	}
-	return false
-}
-
-// buildMergedStructArrayField builds merged struct array field from selected rows.
-// Each sub-field in the StructArrayField is merged independently using the same selectedRows.
-func buildMergedStructArrayField(results []*internalpb.RetrieveResults, selectedRows []rowRef, fieldIdx int) *schemapb.StructArrayField {
-	template := results[selectedRows[0].resultIdx].GetFieldsData()[fieldIdx].GetStructArrays()
-	numSubFields := len(template.GetFields())
-
-	// Build a "virtual" result set for each sub-field, then reuse existing merge logic.
-	// Each sub-field i across all results forms its own set of FieldData arrays.
-	mergedSubFields := make([]*schemapb.FieldData, numSubFields)
-	for subIdx := 0; subIdx < numSubFields; subIdx++ {
-		subTemplate := template.GetFields()[subIdx]
-		newSubFd := &schemapb.FieldData{
-			Type:      subTemplate.GetType(),
-			FieldName: subTemplate.GetFieldName(),
-			FieldId:   subTemplate.GetFieldId(),
-			IsDynamic: subTemplate.GetIsDynamic(),
-		}
-
-		// Build virtual results where each result's sub-field is at position 0.
-		virtualResults := make([]*internalpb.RetrieveResults, len(results))
-		for ri, r := range results {
-			subFields := r.GetFieldsData()[fieldIdx].GetStructArrays().GetFields()
-			if subIdx < len(subFields) {
-				virtualResults[ri] = &internalpb.RetrieveResults{
-					FieldsData: []*schemapb.FieldData{subFields[subIdx]},
-				}
-			}
-		}
-
-		switch subTemplate.GetField().(type) {
-		case *schemapb.FieldData_Scalars:
-			newSubFd.Field = &schemapb.FieldData_Scalars{
-				Scalars: buildMergedScalarField(virtualResults, selectedRows, 0),
-			}
-		case *schemapb.FieldData_Vectors:
-			newSubFd.Field = &schemapb.FieldData_Vectors{
-				Vectors: buildMergedVectorField(virtualResults, selectedRows, 0),
-			}
-		}
-
-		// Preserve ValidData for sub-fields.
-		// Check the sub-field's own ValidData (not the parent StructArray's),
-		// since segcore returns sub-fields as flat FieldData with independent validity bitmaps.
-		if hasValidData(virtualResults, selectedRows, 0) {
-			validData := make([]bool, len(selectedRows))
-			for i, ref := range selectedRows {
-				subFields := results[ref.resultIdx].GetFieldsData()[fieldIdx].GetStructArrays().GetFields()
-				if subIdx < len(subFields) {
-					vd := subFields[subIdx].GetValidData()
-					if len(vd) > int(ref.rowIdx) {
-						validData[i] = vd[ref.rowIdx]
-					} else {
-						validData[i] = true
-					}
-				}
-			}
-			newSubFd.ValidData = validData
-		}
-
-		mergedSubFields[subIdx] = newSubFd
-	}
-
-	return &schemapb.StructArrayField{Fields: mergedSubFields}
+	return newFd, nil
 }
 
 // buildMergedScalarField builds merged scalar field from selected rows.
+// Bounds-checks each row access: nullable fields with all-null results may have an empty
+// Data array (segcore omits the storage); out-of-bounds rows keep the Go zero value.
+// The corresponding ValidData entry will be false, so users never see zero-filled nulls.
 func buildMergedScalarField(results []*internalpb.RetrieveResults, selectedRows []rowRef, fieldIdx int) *schemapb.ScalarField {
 	template := results[selectedRows[0].resultIdx].GetFieldsData()[fieldIdx].GetScalars()
 	newSf := &schemapb.ScalarField{}
@@ -307,63 +258,81 @@ func buildMergedScalarField(results []*internalpb.RetrieveResults, selectedRows 
 	case *schemapb.ScalarField_BoolData:
 		data := make([]bool, len(selectedRows))
 		for i, ref := range selectedRows {
-			data[i] = results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetBoolData().GetData()[ref.rowIdx]
+			if src := results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetBoolData().GetData(); int(ref.rowIdx) < len(src) {
+				data[i] = src[ref.rowIdx]
+			}
 		}
 		newSf.Data = &schemapb.ScalarField_BoolData{BoolData: &schemapb.BoolArray{Data: data}}
 
 	case *schemapb.ScalarField_IntData:
 		data := make([]int32, len(selectedRows))
 		for i, ref := range selectedRows {
-			data[i] = results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetIntData().GetData()[ref.rowIdx]
+			if src := results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetIntData().GetData(); int(ref.rowIdx) < len(src) {
+				data[i] = src[ref.rowIdx]
+			}
 		}
 		newSf.Data = &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: data}}
 
 	case *schemapb.ScalarField_LongData:
 		data := make([]int64, len(selectedRows))
 		for i, ref := range selectedRows {
-			data[i] = results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetLongData().GetData()[ref.rowIdx]
+			if src := results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetLongData().GetData(); int(ref.rowIdx) < len(src) {
+				data[i] = src[ref.rowIdx]
+			}
 		}
 		newSf.Data = &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: data}}
 
 	case *schemapb.ScalarField_FloatData:
 		data := make([]float32, len(selectedRows))
 		for i, ref := range selectedRows {
-			data[i] = results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetFloatData().GetData()[ref.rowIdx]
+			if src := results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetFloatData().GetData(); int(ref.rowIdx) < len(src) {
+				data[i] = src[ref.rowIdx]
+			}
 		}
 		newSf.Data = &schemapb.ScalarField_FloatData{FloatData: &schemapb.FloatArray{Data: data}}
 
 	case *schemapb.ScalarField_DoubleData:
 		data := make([]float64, len(selectedRows))
 		for i, ref := range selectedRows {
-			data[i] = results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetDoubleData().GetData()[ref.rowIdx]
+			if src := results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetDoubleData().GetData(); int(ref.rowIdx) < len(src) {
+				data[i] = src[ref.rowIdx]
+			}
 		}
 		newSf.Data = &schemapb.ScalarField_DoubleData{DoubleData: &schemapb.DoubleArray{Data: data}}
 
 	case *schemapb.ScalarField_StringData:
 		data := make([]string, len(selectedRows))
 		for i, ref := range selectedRows {
-			data[i] = results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetStringData().GetData()[ref.rowIdx]
+			if src := results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetStringData().GetData(); int(ref.rowIdx) < len(src) {
+				data[i] = src[ref.rowIdx]
+			}
 		}
 		newSf.Data = &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: data}}
 
 	case *schemapb.ScalarField_BytesData:
 		data := make([][]byte, len(selectedRows))
 		for i, ref := range selectedRows {
-			data[i] = results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetBytesData().GetData()[ref.rowIdx]
+			if src := results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetBytesData().GetData(); int(ref.rowIdx) < len(src) {
+				data[i] = src[ref.rowIdx]
+			}
 		}
 		newSf.Data = &schemapb.ScalarField_BytesData{BytesData: &schemapb.BytesArray{Data: data}}
 
 	case *schemapb.ScalarField_JsonData:
 		data := make([][]byte, len(selectedRows))
 		for i, ref := range selectedRows {
-			data[i] = results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetJsonData().GetData()[ref.rowIdx]
+			if src := results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetJsonData().GetData(); int(ref.rowIdx) < len(src) {
+				data[i] = src[ref.rowIdx]
+			}
 		}
 		newSf.Data = &schemapb.ScalarField_JsonData{JsonData: &schemapb.JSONArray{Data: data}}
 
 	case *schemapb.ScalarField_ArrayData:
 		data := make([]*schemapb.ScalarField, len(selectedRows))
 		for i, ref := range selectedRows {
-			data[i] = results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetArrayData().GetData()[ref.rowIdx]
+			if src := results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetArrayData().GetData(); int(ref.rowIdx) < len(src) {
+				data[i] = src[ref.rowIdx]
+			}
 		}
 		newSf.Data = &schemapb.ScalarField_ArrayData{ArrayData: &schemapb.ArrayArray{
 			Data:        data,
@@ -373,28 +342,36 @@ func buildMergedScalarField(results []*internalpb.RetrieveResults, selectedRows 
 	case *schemapb.ScalarField_GeometryData:
 		data := make([][]byte, len(selectedRows))
 		for i, ref := range selectedRows {
-			data[i] = results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetGeometryData().GetData()[ref.rowIdx]
+			if src := results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetGeometryData().GetData(); int(ref.rowIdx) < len(src) {
+				data[i] = src[ref.rowIdx]
+			}
 		}
 		newSf.Data = &schemapb.ScalarField_GeometryData{GeometryData: &schemapb.GeometryArray{Data: data}}
 
 	case *schemapb.ScalarField_GeometryWktData:
 		data := make([]string, len(selectedRows))
 		for i, ref := range selectedRows {
-			data[i] = results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetGeometryWktData().GetData()[ref.rowIdx]
+			if src := results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetGeometryWktData().GetData(); int(ref.rowIdx) < len(src) {
+				data[i] = src[ref.rowIdx]
+			}
 		}
 		newSf.Data = &schemapb.ScalarField_GeometryWktData{GeometryWktData: &schemapb.GeometryWktArray{Data: data}}
 
 	case *schemapb.ScalarField_TimestamptzData:
 		data := make([]int64, len(selectedRows))
 		for i, ref := range selectedRows {
-			data[i] = results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetTimestamptzData().GetData()[ref.rowIdx]
+			if src := results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetTimestamptzData().GetData(); int(ref.rowIdx) < len(src) {
+				data[i] = src[ref.rowIdx]
+			}
 		}
 		newSf.Data = &schemapb.ScalarField_TimestamptzData{TimestamptzData: &schemapb.TimestamptzArray{Data: data}}
 
 	case *schemapb.ScalarField_MolData:
 		data := make([][]byte, len(selectedRows))
 		for i, ref := range selectedRows {
-			data[i] = results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetMolData().GetData()[ref.rowIdx]
+			if src := results[ref.resultIdx].GetFieldsData()[fieldIdx].GetScalars().GetMolData().GetData(); int(ref.rowIdx) < len(src) {
+				data[i] = src[ref.rowIdx]
+			}
 		}
 		newSf.Data = &schemapb.ScalarField_MolData{MolData: &schemapb.MolArray{Data: data}}
 	}
@@ -405,29 +382,68 @@ func buildMergedScalarField(results []*internalpb.RetrieveResults, selectedRows 
 // buildCompactIndices pre-computes the compact data index for each result's vector field.
 // In compact mode (nullable vectors), the data array only contains entries for valid rows.
 // compactIdx[resultIdx][logicalRowIdx] = data array index, or -1 if null.
-// Returns nil for non-nullable fields (data index = row index).
-func buildCompactIndices(results []*internalpb.RetrieveResults, fieldIdx int) [][]int {
-	hasAny := false
-	for _, r := range results {
-		if len(r.GetFieldsData()[fieldIdx].GetValidData()) > 0 {
-			hasAny = true
-			break
-		}
-	}
-	if !hasAny {
-		return nil // non-nullable field, no compact mapping needed
+// Returns (nil, nil) for non-nullable fields (data index = row index).
+//
+// Returns error when the segcore contract is violated:
+//   - nullable field with numRows > 0 but empty ValidData
+//   - len(ValidData) != numRows
+//
+// These conditions indicate a segcore bug and must fail the request loudly
+// rather than silently treating rows as null (which corrupts the downstream
+// Contents/ValidData contract and causes index-out-of-range panics).
+//
+// Why hard-error instead of graceful fallback:
+// All segcore paths that produce vector FieldData for nullable fields
+// (SegmentGrowingImpl::bulk_subscript, ChunkedSegmentSealedImpl::get_raw_data,
+// ChunkedSegmentSealedImpl::get_vector) call FilterVectorValidOffsets and write
+// a full-length ValidData bitmap. The only path that omits ValidData is
+// fill_with_empty(field_id, count) (2-arg overload, used when index is not ready),
+// but that early-returns with numRows=count and no selected rows can reference it.
+// Therefore, "empty ValidData + numRows > 0" in a merge input is never a legitimate
+// state — it always indicates a segcore bug that must be surfaced, not masked.
+func buildCompactIndices(results []*internalpb.RetrieveResults, fieldIdx int, isNullable bool) ([][]int, error) {
+	if !isNullable {
+		return nil, nil
 	}
 
 	indices := make([][]int, len(results))
 	for ri, r := range results {
-		vd := r.GetFieldsData()[fieldIdx].GetValidData()
-		if len(vd) == 0 {
-			continue // this result is non-nullable, use rowIdx directly
+		numRows := typeutil.GetSizeOfIDs(r.GetIds())
+		fd := r.GetFieldsData()[fieldIdx]
+		vd := fd.GetValidData()
+
+		if numRows == 0 {
+			indices[ri] = nil
+			continue
 		}
-		idx := make([]int, len(vd))
+
+		// Hard-error, not graceful fallback. All segcore vector output paths for
+		// nullable fields populate ValidData:
+		//   - get_raw_data:  FilterVectorValidOffsets → fill_with_empty(4-arg) → ValidData set
+		//   - get_vector:    FilterVectorValidOffsets → CreateVectorDataArrayFrom → ValidData set
+		//   - bulk_subscript (growing): FilterVectorValidOffsets → CreateEmptyVectorDataArray(4-arg) → ValidData set
+		//   - bulk_subscript_not_exist_field: CreateEmptyVectorDataArray(0) + manual Add(false) × count → ValidData set
+		// The only path that omits ValidData is fill_with_empty(2-arg) when index is not ready,
+		// but that path is unreachable for merge inputs (HasRawData gate + empty IDs filtering).
+		// Therefore empty ValidData here is always a segcore bug, not a legitimate state.
+		if len(vd) == 0 {
+			return nil, fmt.Errorf(
+				"buildCompactIndices: nullable vector field fid=%d name=%q has empty ValidData but numRows=%d in result[%d]; "+
+					"segcore must always provide ValidData for nullable fields with rows",
+				fd.GetFieldId(), fd.GetFieldName(), numRows, ri)
+		}
+
+		if len(vd) != numRows {
+			return nil, fmt.Errorf(
+				"buildCompactIndices: nullable vector field fid=%d name=%q has len(ValidData)=%d but numRows=%d in result[%d]; "+
+					"segcore violated the nullable contract (len(ValidData) must equal numRows)",
+				fd.GetFieldId(), fd.GetFieldName(), len(vd), numRows, ri)
+		}
+
+		idx := make([]int, numRows)
 		dataIdx := 0
-		for i, valid := range vd {
-			if valid {
+		for i := 0; i < numRows; i++ {
+			if vd[i] {
 				idx[i] = dataIdx
 				dataIdx++
 			} else {
@@ -436,21 +452,22 @@ func buildCompactIndices(results []*internalpb.RetrieveResults, fieldIdx int) []
 		}
 		indices[ri] = idx
 	}
-	return indices
+	return indices, nil
 }
 
 // getVecDataIdx returns the compact data index for a vector row.
 // Returns -1 if the row is null. If compactIndices is nil, returns rowIdx directly.
+// Callers must call buildCompactIndices first, which validates len(vd) == numRows;
+// after that validation passes, out-of-range access here is impossible for correctly
+// constructed selectedRows. If it somehow happens, the Go runtime panics with a
+// clear stack trace — no silent fallback.
 func getVecDataIdx(compactIndices [][]int, ref rowRef) int {
 	if compactIndices == nil {
-		return int(ref.rowIdx) // non-nullable field
+		return int(ref.rowIdx)
 	}
 	ci := compactIndices[ref.resultIdx]
 	if ci == nil {
-		return int(ref.rowIdx) // this result is non-nullable
-	}
-	if int(ref.rowIdx) >= len(ci) {
-		return -1 // out of range → null
+		return int(ref.rowIdx)
 	}
 	return ci[ref.rowIdx]
 }
@@ -460,31 +477,93 @@ func getVecDataIdx(compactIndices [][]int, ref rowRef) int {
 // contains entries for valid (non-null) rows, and ValidData bitmap marks which
 // logical rows are null. Null rows don't occupy space in the data array.
 // buildCompactIndices/getVecDataIdx handle the logical→data index mapping.
-func buildMergedVectorField(results []*internalpb.RetrieveResults, selectedRows []rowRef, fieldIdx int) *schemapb.VectorField {
-	template := results[selectedRows[0].resultIdx].GetFieldsData()[fieldIdx].GetVectors()
-	dim := int(template.GetDim())
+//
+// fieldSchema drives the type switch (DataType) and dim, avoiding the previous
+// bug where template.GetData().(type) was used: when the template result had
+// nil Data oneof (e.g., sparse field not yet in a segment via AlterCollection),
+// the type switch missed all cases, producing nil Data in the merged output.
+//
+// fieldSchema may be nil for system fields or tests; in that case we fall back
+// to scanning results for the first non-nil Data to infer the type.
+func buildMergedVectorField(results []*internalpb.RetrieveResults, selectedRows []rowRef, fieldIdx int, fieldSchema *schemapb.FieldSchema) (*schemapb.VectorField, error) {
+	isNullable := fieldSchema != nil && fieldSchema.GetNullable()
 
-	newVf := &schemapb.VectorField{Dim: template.GetDim()}
+	// Determine DataType and dim from schema (preferred) or from result data (fallback).
+	dataType := schemapb.DataType_None
+	var dim int64
+	if fieldSchema != nil {
+		dataType = fieldSchema.GetDataType()
+		if !typeutil.IsSparseFloatVectorType(dataType) {
+			h := typeutil.CreateFieldSchemaHelper(fieldSchema)
+			dim, _ = h.GetDim()
+		}
+	}
 
-	// Pre-compute compact index mapping for nullable vector fields (O(N) once).
-	compactIdx := buildCompactIndices(results, fieldIdx)
+	// Fallback: if no schema, scan results for the first non-nil VectorField.Data
+	// to infer type and dim. This keeps backward compatibility with tests that pass
+	// nil schema.
+	if dataType == schemapb.DataType_None {
+		for _, ref := range selectedRows {
+			vec := results[ref.resultIdx].GetFieldsData()[fieldIdx].GetVectors()
+			if vec != nil && vec.GetData() != nil {
+				dim = vec.GetDim()
+				switch vec.GetData().(type) {
+				case *schemapb.VectorField_FloatVector:
+					dataType = schemapb.DataType_FloatVector
+				case *schemapb.VectorField_BinaryVector:
+					dataType = schemapb.DataType_BinaryVector
+				case *schemapb.VectorField_Float16Vector:
+					dataType = schemapb.DataType_Float16Vector
+				case *schemapb.VectorField_Bfloat16Vector:
+					dataType = schemapb.DataType_BFloat16Vector
+				case *schemapb.VectorField_Int8Vector:
+					dataType = schemapb.DataType_Int8Vector
+				case *schemapb.VectorField_SparseFloatVector:
+					dataType = schemapb.DataType_SparseFloatVector
+				case *schemapb.VectorField_VectorArray:
+					dataType = schemapb.DataType_Array
+				}
+				break
+			}
+		}
+	}
 
-	switch template.GetData().(type) {
-	case *schemapb.VectorField_FloatVector:
-		data := make([]float32, 0, len(selectedRows)*dim)
+	newVf := &schemapb.VectorField{Dim: dim}
+	compactIdx, err := buildCompactIndices(results, fieldIdx, isNullable)
+	if err != nil {
+		return nil, err
+	}
+
+	// vecDataOOB builds a descriptive error for vector data out-of-bounds access.
+	// This indicates segcore returned truncated/malformed vector data.
+	vecDataOOB := func(ref rowRef, di int, dataLen int) error {
+		fd := results[ref.resultIdx].GetFieldsData()[fieldIdx]
+		return fmt.Errorf(
+			"buildMergedVectorField: vector data too short for %s field fid=%d name=%q in result[%d]: "+
+				"dataIdx=%d requires offset beyond data length %d (dim=%d, numRows=%d); segcore returned truncated data",
+			dataType, fd.GetFieldId(), fd.GetFieldName(), ref.resultIdx,
+			di, dataLen, dim, typeutil.GetSizeOfIDs(results[ref.resultIdx].GetIds()))
+	}
+
+	switch dataType {
+	case schemapb.DataType_FloatVector:
+		data := make([]float32, 0, len(selectedRows)*int(dim))
 		for _, ref := range selectedRows {
 			di := getVecDataIdx(compactIdx, ref)
 			if di < 0 {
-				continue // null row — compact mode skips
+				continue
 			}
 			vec := results[ref.resultIdx].GetFieldsData()[fieldIdx].GetVectors().GetFloatVector().GetData()
-			start := di * dim
-			data = append(data, vec[start:start+dim]...)
+			start := di * int(dim)
+			if start+int(dim) > len(vec) {
+				return nil, vecDataOOB(ref, di, len(vec))
+			}
+			data = append(data, vec[start:start+int(dim)]...)
 		}
 		newVf.Data = &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: data}}
 
-	case *schemapb.VectorField_BinaryVector:
-		bytesPerRow := dim / 8
+	case schemapb.DataType_BinaryVector:
+		bytesPerRow := int(dim) / 8
 		data := make([]byte, 0, len(selectedRows)*bytesPerRow)
 		for _, ref := range selectedRows {
 			di := getVecDataIdx(compactIdx, ref)
@@ -493,12 +572,15 @@ func buildMergedVectorField(results []*internalpb.RetrieveResults, selectedRows 
 			}
 			vec := results[ref.resultIdx].GetFieldsData()[fieldIdx].GetVectors().GetBinaryVector()
 			start := di * bytesPerRow
+			if start+bytesPerRow > len(vec) {
+				return nil, vecDataOOB(ref, di, len(vec))
+			}
 			data = append(data, vec[start:start+bytesPerRow]...)
 		}
 		newVf.Data = &schemapb.VectorField_BinaryVector{BinaryVector: data}
 
-	case *schemapb.VectorField_Float16Vector:
-		bytesPerRow := dim * 2
+	case schemapb.DataType_Float16Vector:
+		bytesPerRow := int(dim) * 2
 		data := make([]byte, 0, len(selectedRows)*bytesPerRow)
 		for _, ref := range selectedRows {
 			di := getVecDataIdx(compactIdx, ref)
@@ -507,12 +589,15 @@ func buildMergedVectorField(results []*internalpb.RetrieveResults, selectedRows 
 			}
 			vec := results[ref.resultIdx].GetFieldsData()[fieldIdx].GetVectors().GetFloat16Vector()
 			start := di * bytesPerRow
+			if start+bytesPerRow > len(vec) {
+				return nil, vecDataOOB(ref, di, len(vec))
+			}
 			data = append(data, vec[start:start+bytesPerRow]...)
 		}
 		newVf.Data = &schemapb.VectorField_Float16Vector{Float16Vector: data}
 
-	case *schemapb.VectorField_Bfloat16Vector:
-		bytesPerRow := dim * 2
+	case schemapb.DataType_BFloat16Vector:
+		bytesPerRow := int(dim) * 2
 		data := make([]byte, 0, len(selectedRows)*bytesPerRow)
 		for _, ref := range selectedRows {
 			di := getVecDataIdx(compactIdx, ref)
@@ -521,12 +606,15 @@ func buildMergedVectorField(results []*internalpb.RetrieveResults, selectedRows 
 			}
 			vec := results[ref.resultIdx].GetFieldsData()[fieldIdx].GetVectors().GetBfloat16Vector()
 			start := di * bytesPerRow
+			if start+bytesPerRow > len(vec) {
+				return nil, vecDataOOB(ref, di, len(vec))
+			}
 			data = append(data, vec[start:start+bytesPerRow]...)
 		}
 		newVf.Data = &schemapb.VectorField_Bfloat16Vector{Bfloat16Vector: data}
 
-	case *schemapb.VectorField_Int8Vector:
-		bytesPerRow := dim // 1 byte per element
+	case schemapb.DataType_Int8Vector:
+		bytesPerRow := int(dim)
 		data := make([]byte, 0, len(selectedRows)*bytesPerRow)
 		for _, ref := range selectedRows {
 			di := getVecDataIdx(compactIdx, ref)
@@ -535,46 +623,78 @@ func buildMergedVectorField(results []*internalpb.RetrieveResults, selectedRows 
 			}
 			vec := results[ref.resultIdx].GetFieldsData()[fieldIdx].GetVectors().GetInt8Vector()
 			start := di * bytesPerRow
+			if start+bytesPerRow > len(vec) {
+				return nil, vecDataOOB(ref, di, len(vec))
+			}
 			data = append(data, vec[start:start+bytesPerRow]...)
 		}
 		newVf.Data = &schemapb.VectorField_Int8Vector{Int8Vector: data}
 
-	case *schemapb.VectorField_SparseFloatVector:
+	case schemapb.DataType_SparseFloatVector:
 		contents := make([][]byte, 0, len(selectedRows))
+		var maxDim int64
 		for _, ref := range selectedRows {
 			di := getVecDataIdx(compactIdx, ref)
 			if di < 0 {
 				continue
 			}
-			contents = append(contents, results[ref.resultIdx].GetFieldsData()[fieldIdx].GetVectors().GetSparseFloatVector().GetContents()[di])
+			sparse := results[ref.resultIdx].GetFieldsData()[fieldIdx].GetVectors().GetSparseFloatVector()
+			if sparse == nil || di >= len(sparse.GetContents()) {
+				fd := results[ref.resultIdx].GetFieldsData()[fieldIdx]
+				return nil, fmt.Errorf(
+					"buildMergedVectorField: sparse vector data missing for field fid=%d name=%q in result[%d]: "+
+						"dataIdx=%d but SparseFloatArray is nil or has only %d contents (numRows=%d); segcore returned truncated data",
+					fd.GetFieldId(), fd.GetFieldName(), ref.resultIdx,
+					di, len(sparse.GetContents()), typeutil.GetSizeOfIDs(results[ref.resultIdx].GetIds()))
+			}
+			contents = append(contents, sparse.GetContents()[di])
+			if sparse.GetDim() > maxDim {
+				maxDim = sparse.GetDim()
+			}
 		}
 		newVf.Data = &schemapb.VectorField_SparseFloatVector{
 			SparseFloatVector: &schemapb.SparseFloatArray{
 				Contents: contents,
-				Dim:      template.GetSparseFloatVector().GetDim(),
+				Dim:      maxDim,
 			},
 		}
+		newVf.Dim = maxDim
 
-	case *schemapb.VectorField_VectorArray:
-		// VectorArray: each row is a VectorField (used in StructArray vector sub-fields)
-		data := make([]*schemapb.VectorField, 0, len(selectedRows))
+	default:
+		// VectorArray or unknown — scan for first non-nil VectorArray to get metadata.
 		for _, ref := range selectedRows {
-			di := getVecDataIdx(compactIdx, ref)
-			if di < 0 {
-				continue
+			va := results[ref.resultIdx].GetFieldsData()[fieldIdx].GetVectors().GetVectorArray()
+			if va != nil {
+				data := make([]*schemapb.VectorField, 0, len(selectedRows))
+				for _, ref2 := range selectedRows {
+					di := getVecDataIdx(compactIdx, ref2)
+					if di < 0 {
+						continue
+					}
+					va2 := results[ref2.resultIdx].GetFieldsData()[fieldIdx].GetVectors().GetVectorArray()
+					if va2 == nil || di >= len(va2.GetData()) {
+						fd := results[ref2.resultIdx].GetFieldsData()[fieldIdx]
+						return nil, fmt.Errorf(
+							"buildMergedVectorField: VectorArray data missing for field fid=%d name=%q in result[%d]: "+
+								"dataIdx=%d but VectorArray is nil or has only %d entries (numRows=%d); segcore returned truncated data",
+							fd.GetFieldId(), fd.GetFieldName(), ref2.resultIdx,
+							di, len(va2.GetData()), typeutil.GetSizeOfIDs(results[ref2.resultIdx].GetIds()))
+					}
+					data = append(data, va2.GetData()[di])
+				}
+				newVf.Data = &schemapb.VectorField_VectorArray{
+					VectorArray: &schemapb.VectorArray{
+						Dim:         va.GetDim(),
+						Data:        data,
+						ElementType: va.GetElementType(),
+					},
+				}
+				break
 			}
-			data = append(data, results[ref.resultIdx].GetFieldsData()[fieldIdx].GetVectors().GetVectorArray().GetData()[di])
-		}
-		newVf.Data = &schemapb.VectorField_VectorArray{
-			VectorArray: &schemapb.VectorArray{
-				Dim:         template.GetVectorArray().GetDim(),
-				Data:        data,
-				ElementType: template.GetVectorArray().GetElementType(),
-			},
 		}
 	}
 
-	return newVf
+	return newVf, nil
 }
 
 // rangeSliceRetrieveResults extracts a contiguous range [start, end) from a RetrieveResult.

--- a/internal/util/queryutil/helpers_test.go
+++ b/internal/util/queryutil/helpers_test.go
@@ -18,14 +18,35 @@ package queryutil
 
 import (
 	"context"
+	"encoding/binary"
+	"fmt"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/internalpb"
 )
+
+// makeNullableSchema builds a minimal CollectionSchema marking the given
+// fieldID as nullable with the specified DataType. For dense vectors, pass
+// dim > 0; for sparse or scalars, pass dim = 0.
+func makeNullableSchema(fieldID int64, dataType schemapb.DataType, dim int64) *schemapb.CollectionSchema {
+	fs := &schemapb.FieldSchema{
+		FieldID:  fieldID,
+		DataType: dataType,
+		Nullable: true,
+	}
+	if dim > 0 {
+		fs.TypeParams = []*commonpb.KeyValuePair{
+			{Key: "dim", Value: fmt.Sprintf("%d", dim)},
+		}
+	}
+	return &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{fs}}
+}
 
 // =========================================================================
 // buildMergedFieldData: ValidData preservation
@@ -65,7 +86,7 @@ func TestBuildMergedFieldData_ValidData(t *testing.T) {
 		{resultIdx: 1, rowIdx: 0}, // r2 row 0 (valid)
 	}
 
-	merged, err := buildMergedRetrieveResults(results, selectedRows)
+	merged, err := buildMergedRetrieveResults(results, selectedRows, makeNullableSchema(100, schemapb.DataType_Int64, 0))
 	require.NoError(t, err)
 	require.Len(t, merged.FieldsData, 1)
 
@@ -75,7 +96,8 @@ func TestBuildMergedFieldData_ValidData(t *testing.T) {
 }
 
 func TestBuildMergedFieldData_ValidData_MixedNullable(t *testing.T) {
-	// r1 has ValidData (nullable), r2 does not (non-nullable)
+	// r1 has ValidData (nullable), r2 has explicit ValidData=[true] (all valid)
+	// This tests that explicit all-valid ValidData is preserved correctly.
 	r1 := &internalpb.RetrieveResults{
 		Ids: &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{1}}}},
 		FieldsData: []*schemapb.FieldData{
@@ -96,7 +118,7 @@ func TestBuildMergedFieldData_ValidData_MixedNullable(t *testing.T) {
 				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{
 					Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{20}}},
 				}},
-				// No ValidData — non-nullable
+				ValidData: []bool{true}, // explicit valid (segcore always includes ValidData for nullable fields)
 			},
 		},
 	}
@@ -104,14 +126,13 @@ func TestBuildMergedFieldData_ValidData_MixedNullable(t *testing.T) {
 	results := []*internalpb.RetrieveResults{r1, r2}
 	selectedRows := []rowRef{
 		{resultIdx: 0, rowIdx: 0}, // r1 (null)
-		{resultIdx: 1, rowIdx: 0}, // r2 (no ValidData → valid=true)
+		{resultIdx: 1, rowIdx: 0}, // r2 (valid=true)
 	}
 
-	merged, err := buildMergedRetrieveResults(results, selectedRows)
+	merged, err := buildMergedRetrieveResults(results, selectedRows, makeNullableSchema(100, schemapb.DataType_Int64, 0))
 	require.NoError(t, err)
 
 	fd := merged.FieldsData[0]
-	// r1 row is null, r2 row has no ValidData so defaults to true
 	assert.Equal(t, []bool{false, true}, fd.ValidData)
 }
 
@@ -141,7 +162,7 @@ func TestBuildMergedScalarField_ArrayElementType(t *testing.T) {
 	results := []*internalpb.RetrieveResults{r1}
 	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 0}, {resultIdx: 0, rowIdx: 1}}
 
-	merged, err := buildMergedRetrieveResults(results, selectedRows)
+	merged, err := buildMergedRetrieveResults(results, selectedRows, nil)
 	require.NoError(t, err)
 
 	arrayField := merged.FieldsData[0].GetScalars().GetArrayData()
@@ -171,7 +192,7 @@ func TestBuildMergedScalarField_GeometryWktData(t *testing.T) {
 	results := []*internalpb.RetrieveResults{r1}
 	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 1}}
 
-	merged, err := buildMergedRetrieveResults(results, selectedRows)
+	merged, err := buildMergedRetrieveResults(results, selectedRows, nil)
 	require.NoError(t, err)
 
 	wktData := merged.FieldsData[0].GetScalars().GetGeometryWktData().GetData()
@@ -196,7 +217,7 @@ func TestBuildMergedScalarField_GeometryData(t *testing.T) {
 	results := []*internalpb.RetrieveResults{r1}
 	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 0}}
 
-	merged, err := buildMergedRetrieveResults(results, selectedRows)
+	merged, err := buildMergedRetrieveResults(results, selectedRows, nil)
 	require.NoError(t, err)
 
 	geoData := merged.FieldsData[0].GetScalars().GetGeometryData().GetData()
@@ -225,7 +246,7 @@ func TestBuildMergedScalarField_TimestamptzData(t *testing.T) {
 	results := []*internalpb.RetrieveResults{r1}
 	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 0}, {resultIdx: 0, rowIdx: 1}}
 
-	merged, err := buildMergedRetrieveResults(results, selectedRows)
+	merged, err := buildMergedRetrieveResults(results, selectedRows, nil)
 	require.NoError(t, err)
 
 	tsData := merged.FieldsData[0].GetScalars().GetTimestamptzData().GetData()
@@ -250,7 +271,7 @@ func TestBuildMergedScalarField_MolData(t *testing.T) {
 	results := []*internalpb.RetrieveResults{r1}
 	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 0}}
 
-	merged, err := buildMergedRetrieveResults(results, selectedRows)
+	merged, err := buildMergedRetrieveResults(results, selectedRows, nil)
 	require.NoError(t, err)
 
 	molData := merged.FieldsData[0].GetScalars().GetMolData().GetData()
@@ -279,7 +300,7 @@ func TestBuildMergedVectorField_Int8Vector(t *testing.T) {
 	results := []*internalpb.RetrieveResults{r1}
 	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 1}} // select row 1 only
 
-	merged, err := buildMergedRetrieveResults(results, selectedRows)
+	merged, err := buildMergedRetrieveResults(results, selectedRows, nil)
 	require.NoError(t, err)
 
 	vecData := merged.FieldsData[0].GetVectors().GetInt8Vector()
@@ -439,7 +460,7 @@ func TestBuildMergedRetrieveResults_ElementIndices(t *testing.T) {
 	results := []*internalpb.RetrieveResults{r1}
 	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 1}, {resultIdx: 0, rowIdx: 0}}
 
-	merged, err := buildMergedRetrieveResults(results, selectedRows)
+	merged, err := buildMergedRetrieveResults(results, selectedRows, nil)
 	require.NoError(t, err)
 
 	assert.True(t, merged.GetElementLevel())
@@ -484,7 +505,7 @@ func TestRangeSliceRetrieveResults_ElementIndices(t *testing.T) {
 // =========================================================================
 
 func TestConcatAndCheckPKOperator_NoDuplicate(t *testing.T) {
-	op := NewConcatAndCheckPKOperator()
+	op := NewConcatAndCheckPKOperator(nil)
 	ctx := context.Background()
 
 	r1 := &internalpb.RetrieveResults{
@@ -520,7 +541,7 @@ func TestConcatAndCheckPKOperator_NoDuplicate(t *testing.T) {
 }
 
 func TestConcatAndCheckPKOperator_DuplicateFails(t *testing.T) {
-	op := NewConcatAndCheckPKOperator()
+	op := NewConcatAndCheckPKOperator(nil)
 	ctx := context.Background()
 
 	r1 := &internalpb.RetrieveResults{
@@ -596,7 +617,7 @@ func TestBuildMergedFieldData_CommonScalarTypes(t *testing.T) {
 	}
 
 	selectedRows := []rowRef{{0, 0}, {1, 0}, {0, 1}} // r1[0], r2[0], r1[1]
-	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1, r2}, selectedRows)
+	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1, r2}, selectedRows, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, []int64{1, 3, 2}, merged.GetIds().GetIntId().GetData())
@@ -635,7 +656,7 @@ func TestBuildMergedFieldData_FloatVector(t *testing.T) {
 	}
 
 	selectedRows := []rowRef{{1, 0}, {0, 1}} // r2[0], r1[1]
-	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1, r2}, selectedRows)
+	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1, r2}, selectedRows, nil)
 	require.NoError(t, err)
 
 	vecData := merged.GetFieldsData()[0].GetVectors().GetFloatVector().GetData()
@@ -752,11 +773,8 @@ func TestValidateElementLevelConsistency_Consistent(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-// =========================================================================
-// buildMergedStructArrayField
-// =========================================================================
-
 // makeStructArrayFieldData creates a FieldData wrapping a StructArrayField with scalar sub-fields.
+// Used by TestGetRowCount and slice/reconstruct tests below.
 func makeStructArrayFieldData(fieldID int64, name string, subFields []*schemapb.FieldData) *schemapb.FieldData {
 	return &schemapb.FieldData{
 		Type:      schemapb.DataType_Array,
@@ -768,79 +786,6 @@ func makeStructArrayFieldData(fieldID int64, name string, subFields []*schemapb.
 			},
 		},
 	}
-}
-
-func TestBuildMergedStructArrayField_ScalarSubFields(t *testing.T) {
-	// Two results, each with a struct array field containing two scalar sub-fields:
-	// sub-field 0: int64 "age", sub-field 1: string "name"
-	r1 := &internalpb.RetrieveResults{
-		Ids: &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{1, 2}}}},
-		FieldsData: []*schemapb.FieldData{
-			makeStructArrayFieldData(100, "info", []*schemapb.FieldData{
-				makeInt64Field(101, "age", []int64{25, 30}),
-				makeStringField(102, "name", []string{"alice", "bob"}),
-			}),
-		},
-	}
-	r2 := &internalpb.RetrieveResults{
-		Ids: &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{3}}}},
-		FieldsData: []*schemapb.FieldData{
-			makeStructArrayFieldData(100, "info", []*schemapb.FieldData{
-				makeInt64Field(101, "age", []int64{35}),
-				makeStringField(102, "name", []string{"charlie"}),
-			}),
-		},
-	}
-
-	results := []*internalpb.RetrieveResults{r1, r2}
-	// Select: r1 row1, r2 row0, r1 row0
-	selectedRows := []rowRef{
-		{resultIdx: 0, rowIdx: 1},
-		{resultIdx: 1, rowIdx: 0},
-		{resultIdx: 0, rowIdx: 0},
-	}
-
-	merged := buildMergedStructArrayField(results, selectedRows, 0)
-	require.Len(t, merged.GetFields(), 2)
-
-	// Sub-field 0: age
-	ages := merged.GetFields()[0].GetScalars().GetLongData().GetData()
-	assert.Equal(t, []int64{30, 35, 25}, ages)
-
-	// Sub-field 1: name
-	names := merged.GetFields()[1].GetScalars().GetStringData().GetData()
-	assert.Equal(t, []string{"bob", "charlie", "alice"}, names)
-}
-
-func TestBuildMergedStructArrayField_WithValidData(t *testing.T) {
-	// Struct array sub-field with ValidData (nullable sub-field)
-	r1 := &internalpb.RetrieveResults{
-		Ids: &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{1, 2}}}},
-		FieldsData: []*schemapb.FieldData{
-			makeStructArrayFieldData(100, "info", []*schemapb.FieldData{
-				{
-					Type: schemapb.DataType_Int64, FieldId: 101, FieldName: "age",
-					Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{
-						Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{25, 30}}},
-					}},
-					ValidData: []bool{true, false}, // row 1 is null
-				},
-			}),
-		},
-	}
-
-	results := []*internalpb.RetrieveResults{r1}
-	selectedRows := []rowRef{
-		{resultIdx: 0, rowIdx: 0},
-		{resultIdx: 0, rowIdx: 1},
-	}
-
-	merged := buildMergedStructArrayField(results, selectedRows, 0)
-	require.Len(t, merged.GetFields(), 1)
-
-	subFd := merged.GetFields()[0]
-	assert.Equal(t, []int64{25, 30}, subFd.GetScalars().GetLongData().GetData())
-	assert.Equal(t, []bool{true, false}, subFd.GetValidData())
 }
 
 // =========================================================================
@@ -954,7 +899,7 @@ func TestBuildMergedVectorField_VectorArray(t *testing.T) {
 	results := []*internalpb.RetrieveResults{r1, r2}
 	selectedRows := []rowRef{{resultIdx: 1, rowIdx: 0}, {resultIdx: 0, rowIdx: 0}}
 
-	merged, err := buildMergedRetrieveResults(results, selectedRows)
+	merged, err := buildMergedRetrieveResults(results, selectedRows, nil)
 	require.NoError(t, err)
 
 	va := merged.FieldsData[0].GetVectors().GetVectorArray()
@@ -1013,42 +958,6 @@ func TestRangeSliceVectorField_VectorArray(t *testing.T) {
 }
 
 // =========================================================================
-// buildMergedStructArrayField with vector sub-field
-// =========================================================================
-
-func TestBuildMergedStructArrayField_VectorSubField(t *testing.T) {
-	dim := int64(2)
-	r1 := &internalpb.RetrieveResults{
-		Ids: &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{1, 2}}}},
-		FieldsData: []*schemapb.FieldData{
-			makeStructArrayFieldData(100, "info", []*schemapb.FieldData{
-				makeInt64Field(101, "id", []int64{10, 20}),
-				{
-					Type: schemapb.DataType_FloatVector, FieldId: 102, FieldName: "vec",
-					Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
-						Dim:  dim,
-						Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: []float32{1, 2, 3, 4}}},
-					}},
-				},
-			}),
-		},
-	}
-
-	results := []*internalpb.RetrieveResults{r1}
-	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 1}} // select row 1 only
-
-	merged := buildMergedStructArrayField(results, selectedRows, 0)
-	require.Len(t, merged.GetFields(), 2)
-
-	// Sub-field 0: scalar id
-	assert.Equal(t, []int64{20}, merged.GetFields()[0].GetScalars().GetLongData().GetData())
-
-	// Sub-field 1: vector
-	vecData := merged.GetFields()[1].GetVectors().GetFloatVector().GetData()
-	assert.Equal(t, []float32{3, 4}, vecData)
-}
-
-// =========================================================================
 // comparePK: string PK
 // =========================================================================
 
@@ -1076,7 +985,7 @@ func TestBuildMergedScalarField_BoolData(t *testing.T) {
 		}},
 	})
 	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 1}, {resultIdx: 0, rowIdx: 0}}
-	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows)
+	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows, nil)
 	require.NoError(t, err)
 	assert.Equal(t, []bool{false, true}, merged.FieldsData[0].GetScalars().GetBoolData().GetData())
 }
@@ -1089,7 +998,7 @@ func TestBuildMergedScalarField_IntData(t *testing.T) {
 		}},
 	})
 	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 1}}
-	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows)
+	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows, nil)
 	require.NoError(t, err)
 	assert.Equal(t, []int32{20}, merged.FieldsData[0].GetScalars().GetIntData().GetData())
 }
@@ -1102,7 +1011,7 @@ func TestBuildMergedScalarField_FloatData(t *testing.T) {
 		}},
 	})
 	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 0}}
-	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows)
+	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows, nil)
 	require.NoError(t, err)
 	assert.Equal(t, []float32{1.5}, merged.FieldsData[0].GetScalars().GetFloatData().GetData())
 }
@@ -1115,7 +1024,7 @@ func TestBuildMergedScalarField_DoubleData(t *testing.T) {
 		}},
 	})
 	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 1}}
-	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows)
+	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows, nil)
 	require.NoError(t, err)
 	assert.Equal(t, []float64{2.71}, merged.FieldsData[0].GetScalars().GetDoubleData().GetData())
 }
@@ -1128,7 +1037,7 @@ func TestBuildMergedScalarField_BytesData(t *testing.T) {
 		}},
 	})
 	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 0}, {resultIdx: 0, rowIdx: 1}}
-	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows)
+	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows, nil)
 	require.NoError(t, err)
 	assert.Equal(t, [][]byte{{0x01}, {0x02}}, merged.FieldsData[0].GetScalars().GetBytesData().GetData())
 }
@@ -1141,7 +1050,7 @@ func TestBuildMergedScalarField_JsonData(t *testing.T) {
 		}},
 	})
 	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 1}}
-	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows)
+	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows, nil)
 	require.NoError(t, err)
 	assert.Equal(t, [][]byte{[]byte(`{"b":2}`)}, merged.FieldsData[0].GetScalars().GetJsonData().GetData())
 }
@@ -1158,7 +1067,7 @@ func TestBuildMergedIDs_StringPK(t *testing.T) {
 		},
 	}
 	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 1}, {resultIdx: 0, rowIdx: 0}}
-	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows)
+	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows, nil)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"b", "a"}, merged.GetIds().GetStrId().GetData())
 }
@@ -1177,7 +1086,7 @@ func TestBuildMergedVectorField_BinaryVector(t *testing.T) {
 		}},
 	})
 	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 1}}
-	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows)
+	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows, nil)
 	require.NoError(t, err)
 	assert.Equal(t, []byte{0xCC, 0xDD}, merged.FieldsData[0].GetVectors().GetBinaryVector())
 }
@@ -1192,7 +1101,7 @@ func TestBuildMergedVectorField_Float16Vector(t *testing.T) {
 		}},
 	})
 	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 1}}
-	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows)
+	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows, nil)
 	require.NoError(t, err)
 	assert.Equal(t, []byte{5, 6, 7, 8}, merged.FieldsData[0].GetVectors().GetFloat16Vector())
 }
@@ -1207,7 +1116,7 @@ func TestBuildMergedVectorField_BFloat16Vector(t *testing.T) {
 		}},
 	})
 	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 0}}
-	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows)
+	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows, nil)
 	require.NoError(t, err)
 	assert.Equal(t, []byte{10, 20, 30, 40}, merged.FieldsData[0].GetVectors().GetBfloat16Vector())
 }
@@ -1224,7 +1133,7 @@ func TestBuildMergedVectorField_SparseFloatVector(t *testing.T) {
 		}},
 	})
 	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 1}}
-	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows)
+	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows, nil)
 	require.NoError(t, err)
 	assert.Equal(t, [][]byte{{0x03, 0x04}}, merged.FieldsData[0].GetVectors().GetSparseFloatVector().GetContents())
 }
@@ -1235,6 +1144,7 @@ func TestBuildMergedVectorField_SparseFloatVector(t *testing.T) {
 
 func TestBuildCompactIndices_NullableVector(t *testing.T) {
 	r1 := &internalpb.RetrieveResults{
+		Ids: &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{1, 2, 3}}}},
 		FieldsData: []*schemapb.FieldData{
 			{
 				Type: schemapb.DataType_FloatVector, FieldId: 100,
@@ -1246,7 +1156,8 @@ func TestBuildCompactIndices_NullableVector(t *testing.T) {
 			},
 		},
 	}
-	indices := buildCompactIndices([]*internalpb.RetrieveResults{r1}, 0)
+	indices, err := buildCompactIndices([]*internalpb.RetrieveResults{r1}, 0, true)
+	require.NoError(t, err)
 	require.NotNil(t, indices)
 	assert.Equal(t, []int{0, -1, 1}, indices[0])
 }
@@ -1264,8 +1175,41 @@ func TestBuildCompactIndices_NonNullable(t *testing.T) {
 			},
 		},
 	}
-	indices := buildCompactIndices([]*internalpb.RetrieveResults{r1}, 0)
+	indices, err := buildCompactIndices([]*internalpb.RetrieveResults{r1}, 0, false)
+	require.NoError(t, err)
 	assert.Nil(t, indices) // non-nullable → nil
+}
+
+func TestBuildCompactIndices_FailFast_EmptyValidData(t *testing.T) {
+	// nullable field with numRows > 0 but empty ValidData → must error
+	r1 := &internalpb.RetrieveResults{
+		Ids: &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{1, 2}}}},
+		FieldsData: []*schemapb.FieldData{
+			{
+				Type: schemapb.DataType_SparseFloatVector, FieldId: 100,
+				// ValidData intentionally empty — segcore contract violation
+			},
+		},
+	}
+	_, err := buildCompactIndices([]*internalpb.RetrieveResults{r1}, 0, true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty ValidData")
+}
+
+func TestBuildCompactIndices_FailFast_LengthMismatch(t *testing.T) {
+	// nullable field with len(ValidData) != numRows → must error
+	r1 := &internalpb.RetrieveResults{
+		Ids: &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{1, 2, 3}}}},
+		FieldsData: []*schemapb.FieldData{
+			{
+				Type: schemapb.DataType_FloatVector, FieldId: 100,
+				ValidData: []bool{true, false}, // 2 entries but 3 rows → mismatch
+			},
+		},
+	}
+	_, err := buildCompactIndices([]*internalpb.RetrieveResults{r1}, 0, true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "len(ValidData)")
 }
 
 func TestGetVecDataIdx(t *testing.T) {
@@ -1281,6 +1225,282 @@ func TestGetVecDataIdx(t *testing.T) {
 	assert.Equal(t, -1, getVecDataIdx(compactIdx, rowRef{resultIdx: 0, rowIdx: 1}))
 	assert.Equal(t, 1, getVecDataIdx(compactIdx, rowRef{resultIdx: 0, rowIdx: 2}))
 	assert.Equal(t, 5, getVecDataIdx(compactIdx, rowRef{resultIdx: 1, rowIdx: 5})) // nil slice → rowIdx
+
+	// Out of range → panics (validated upstream by buildCompactIndices)
+	assert.Panics(t, func() { getVecDataIdx(compactIdx, rowRef{resultIdx: 0, rowIdx: 10}) })
+}
+
+// =========================================================================
+// buildMergedVectorField: truncated data error paths
+// =========================================================================
+
+func TestBuildMergedVectorField_FloatVector_TruncatedData(t *testing.T) {
+	// FloatVector with dim=2 but only 2 floats (enough for 1 row, not 2)
+	r1 := &internalpb.RetrieveResults{
+		Ids: &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{1, 2}}}},
+		FieldsData: []*schemapb.FieldData{{
+			FieldId: 100, Type: schemapb.DataType_FloatVector,
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Dim:  2,
+				Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: []float32{1, 2}}}, // only 1 row
+			}},
+		}},
+	}
+	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 0}, {resultIdx: 0, rowIdx: 1}}
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: 100, DataType: schemapb.DataType_FloatVector, TypeParams: []*commonpb.KeyValuePair{{Key: "dim", Value: "2"}}},
+	}}
+
+	_, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows, schema)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "truncated data")
+}
+
+func TestBuildMergedVectorField_BinaryVector_TruncatedData(t *testing.T) {
+	// BinaryVector with dim=16 (2 bytes/row) but only 2 bytes (1 row, not 2)
+	r1 := &internalpb.RetrieveResults{
+		Ids: &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{1, 2}}}},
+		FieldsData: []*schemapb.FieldData{{
+			FieldId: 100, Type: schemapb.DataType_BinaryVector,
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Dim:  16,
+				Data: &schemapb.VectorField_BinaryVector{BinaryVector: []byte{0xFF, 0x00}}, // 1 row
+			}},
+		}},
+	}
+	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 0}, {resultIdx: 0, rowIdx: 1}}
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: 100, DataType: schemapb.DataType_BinaryVector, TypeParams: []*commonpb.KeyValuePair{{Key: "dim", Value: "16"}}},
+	}}
+
+	_, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows, schema)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "truncated data")
+}
+
+func TestBuildMergedVectorField_SparseVector_TruncatedContents(t *testing.T) {
+	// Sparse with ValidData=[true, true] but Contents has only 1 entry
+	r1 := &internalpb.RetrieveResults{
+		Ids: &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{1, 2}}}},
+		FieldsData: []*schemapb.FieldData{{
+			FieldId: 100, Type: schemapb.DataType_SparseFloatVector,
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Data: &schemapb.VectorField_SparseFloatVector{SparseFloatVector: &schemapb.SparseFloatArray{
+					Contents: [][]byte{makeTestSparseVec(1, 0.5)}, // only 1 content
+				}},
+			}},
+			ValidData: []bool{true, true}, // claims 2 valid rows
+		}},
+	}
+	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 0}, {resultIdx: 0, rowIdx: 1}}
+
+	_, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows,
+		makeNullableSchema(100, schemapb.DataType_SparseFloatVector, 0))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "truncated data")
+}
+
+func TestBuildMergedVectorField_NullableCompact_BinaryVector(t *testing.T) {
+	// BinaryVector dim=8 (1 byte/row), nullable: row0=valid, row1=null, row2=valid
+	// Compact data: 2 bytes (only valid rows)
+	r1 := &internalpb.RetrieveResults{
+		Ids: &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{1, 2, 3}}}},
+		FieldsData: []*schemapb.FieldData{{
+			FieldId: 100, Type: schemapb.DataType_BinaryVector,
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Dim:  8,
+				Data: &schemapb.VectorField_BinaryVector{BinaryVector: []byte{0xAA, 0xBB}}, // 2 compact rows
+			}},
+			ValidData: []bool{true, false, true},
+		}},
+	}
+	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 2}, {resultIdx: 0, rowIdx: 0}, {resultIdx: 0, rowIdx: 1}}
+
+	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows,
+		makeNullableSchema(100, schemapb.DataType_BinaryVector, 8))
+	require.NoError(t, err)
+
+	// row2 → compact idx 1 → 0xBB, row0 → compact idx 0 → 0xAA, row1 → null (skipped)
+	assert.Equal(t, []byte{0xBB, 0xAA}, merged.FieldsData[0].GetVectors().GetBinaryVector())
+	assert.Equal(t, []bool{true, true, false}, merged.FieldsData[0].ValidData)
+}
+
+func TestBuildMergedVectorField_NullableCompact_Float16Vector(t *testing.T) {
+	// Float16 dim=1 (2 bytes/row), nullable: row0=null, row1=valid
+	// Compact data: 2 bytes (1 valid row)
+	r1 := &internalpb.RetrieveResults{
+		Ids: &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{1, 2}}}},
+		FieldsData: []*schemapb.FieldData{{
+			FieldId: 100, Type: schemapb.DataType_Float16Vector,
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Dim:  1,
+				Data: &schemapb.VectorField_Float16Vector{Float16Vector: []byte{0x01, 0x02}}, // 1 compact row
+			}},
+			ValidData: []bool{false, true},
+		}},
+	}
+	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 1}, {resultIdx: 0, rowIdx: 0}}
+
+	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows,
+		makeNullableSchema(100, schemapb.DataType_Float16Vector, 1))
+	require.NoError(t, err)
+
+	// row1 → compact idx 0 → [0x01, 0x02], row0 → null (skipped)
+	assert.Equal(t, []byte{0x01, 0x02}, merged.FieldsData[0].GetVectors().GetFloat16Vector())
+	assert.Equal(t, []bool{true, false}, merged.FieldsData[0].ValidData)
+}
+
+func TestBuildMergedVectorField_Float16Vector_TruncatedData(t *testing.T) {
+	// Float16 dim=2 (4 bytes/row) but only 4 bytes provided (1 row, not 2)
+	r1 := &internalpb.RetrieveResults{
+		Ids: &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{1, 2}}}},
+		FieldsData: []*schemapb.FieldData{{
+			FieldId: 100, Type: schemapb.DataType_Float16Vector,
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Dim:  2,
+				Data: &schemapb.VectorField_Float16Vector{Float16Vector: []byte{0x01, 0x02, 0x03, 0x04}}, // 1 row
+			}},
+		}},
+	}
+	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 0}, {resultIdx: 0, rowIdx: 1}}
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: 100, DataType: schemapb.DataType_Float16Vector, TypeParams: []*commonpb.KeyValuePair{{Key: "dim", Value: "2"}}},
+	}}
+
+	_, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows, schema)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "truncated data")
+}
+
+func TestBuildMergedVectorField_NullableCompact_BFloat16Vector(t *testing.T) {
+	// BFloat16 dim=1 (2 bytes/row), nullable: row0=valid, row1=null, row2=valid
+	// Compact data: 4 bytes (2 valid rows)
+	r1 := &internalpb.RetrieveResults{
+		Ids: &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{1, 2, 3}}}},
+		FieldsData: []*schemapb.FieldData{{
+			FieldId: 100, Type: schemapb.DataType_BFloat16Vector,
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Dim:  1,
+				Data: &schemapb.VectorField_Bfloat16Vector{Bfloat16Vector: []byte{0xAA, 0xBB, 0xCC, 0xDD}},
+			}},
+			ValidData: []bool{true, false, true},
+		}},
+	}
+	// Select row1(null), row2(valid), row0(valid)
+	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 1}, {resultIdx: 0, rowIdx: 2}, {resultIdx: 0, rowIdx: 0}}
+
+	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows,
+		makeNullableSchema(100, schemapb.DataType_BFloat16Vector, 1))
+	require.NoError(t, err)
+
+	// row1 → null (skipped), row2 → compact idx 1 → [0xCC,0xDD], row0 → compact idx 0 → [0xAA,0xBB]
+	assert.Equal(t, []byte{0xCC, 0xDD, 0xAA, 0xBB}, merged.FieldsData[0].GetVectors().GetBfloat16Vector())
+	assert.Equal(t, []bool{false, true, true}, merged.FieldsData[0].ValidData)
+}
+
+func TestBuildMergedVectorField_BFloat16Vector_TruncatedData(t *testing.T) {
+	// BFloat16 dim=2 (4 bytes/row) but only 4 bytes (1 row, not 2)
+	r1 := &internalpb.RetrieveResults{
+		Ids: &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{1, 2}}}},
+		FieldsData: []*schemapb.FieldData{{
+			FieldId: 100, Type: schemapb.DataType_BFloat16Vector,
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Dim:  2,
+				Data: &schemapb.VectorField_Bfloat16Vector{Bfloat16Vector: []byte{0x01, 0x02, 0x03, 0x04}},
+			}},
+		}},
+	}
+	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 0}, {resultIdx: 0, rowIdx: 1}}
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: 100, DataType: schemapb.DataType_BFloat16Vector, TypeParams: []*commonpb.KeyValuePair{{Key: "dim", Value: "2"}}},
+	}}
+
+	_, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows, schema)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "truncated data")
+}
+
+func TestBuildMergedVectorField_NullableCompact_Int8Vector(t *testing.T) {
+	// Int8Vector dim=2 (2 bytes/row), nullable: row0=null, row1=valid
+	// Compact data: 2 bytes (1 valid row)
+	r1 := &internalpb.RetrieveResults{
+		Ids: &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{1, 2}}}},
+		FieldsData: []*schemapb.FieldData{{
+			FieldId: 100, Type: schemapb.DataType_Int8Vector,
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Dim:  2,
+				Data: &schemapb.VectorField_Int8Vector{Int8Vector: []byte{0x11, 0x22}},
+			}},
+			ValidData: []bool{false, true},
+		}},
+	}
+	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 0}, {resultIdx: 0, rowIdx: 1}}
+
+	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows,
+		makeNullableSchema(100, schemapb.DataType_Int8Vector, 2))
+	require.NoError(t, err)
+
+	// row0 → null (skipped), row1 → compact idx 0 → [0x11,0x22]
+	assert.Equal(t, []byte{0x11, 0x22}, merged.FieldsData[0].GetVectors().GetInt8Vector())
+	assert.Equal(t, []bool{false, true}, merged.FieldsData[0].ValidData)
+}
+
+func TestBuildMergedVectorField_Int8Vector_TruncatedData(t *testing.T) {
+	// Int8Vector dim=3 (3 bytes/row) but only 3 bytes (1 row, not 2)
+	r1 := &internalpb.RetrieveResults{
+		Ids: &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{1, 2}}}},
+		FieldsData: []*schemapb.FieldData{{
+			FieldId: 100, Type: schemapb.DataType_Int8Vector,
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Dim:  3,
+				Data: &schemapb.VectorField_Int8Vector{Int8Vector: []byte{0x01, 0x02, 0x03}},
+			}},
+		}},
+	}
+	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 0}, {resultIdx: 0, rowIdx: 1}}
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: 100, DataType: schemapb.DataType_Int8Vector, TypeParams: []*commonpb.KeyValuePair{{Key: "dim", Value: "3"}}},
+	}}
+
+	_, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows, schema)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "truncated data")
+}
+
+// Note: VectorArray `di < 0` branch (default case with compact mode) is architecturally
+// unreachable. To get compact mode, fieldSchema must be non-nil (nullable=true). But non-nil
+// fieldSchema provides a concrete DataType that matches one of the explicit switch cases
+// (FloatVector, BinaryVector, etc.), so the default/VectorArray branch is only entered via
+// nil-schema fallback where isNullable=false and compact indices are nil.
+// This leaves 1 line (VectorArray di<0) permanently uncovered — accepted as dead code.
+
+func TestBuildMergedVectorField_VectorArray_TruncatedData(t *testing.T) {
+	dim := int64(2)
+	v1 := &schemapb.VectorField{Dim: dim, Data: &schemapb.VectorField_FloatVector{
+		FloatVector: &schemapb.FloatArray{Data: []float32{1.0, 2.0}},
+	}}
+
+	// Result has 2 IDs but VectorArray has only 1 entry
+	r1 := &internalpb.RetrieveResults{
+		Ids: &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{1, 2}}}},
+		FieldsData: []*schemapb.FieldData{{
+			FieldId: 100, Type: schemapb.DataType_FloatVector,
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Dim: dim,
+				Data: &schemapb.VectorField_VectorArray{VectorArray: &schemapb.VectorArray{
+					Dim:         dim,
+					Data:        []*schemapb.VectorField{v1}, // only 1 entry
+					ElementType: schemapb.DataType_FloatVector,
+				}},
+			}},
+		}},
+	}
+	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 0}, {resultIdx: 0, rowIdx: 1}}
+
+	// nil schema → fallback infers VectorArray from data
+	_, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "truncated data")
 }
 
 // =========================================================================
@@ -2349,6 +2569,8 @@ func TestRangeSliceVectorField_NullableCompact_VectorArray(t *testing.T) {
 // =========================================================================
 
 func TestBuildMergedVectorField_NullableCompact_FloatVector(t *testing.T) {
+	// FloatVector dim=2, nullable: row0=valid(compact idx 0), row1=null, row2=valid(compact idx 1)
+	// Compact data: [1,2, 3,4] — 2 valid rows only
 	r1 := &internalpb.RetrieveResults{
 		Ids: &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{1, 2, 3}}}},
 		FieldsData: []*schemapb.FieldData{
@@ -2362,10 +2584,13 @@ func TestBuildMergedVectorField_NullableCompact_FloatVector(t *testing.T) {
 			},
 		},
 	}
-	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 2}, {resultIdx: 0, rowIdx: 0}}
-	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows)
+	// Include the null row (row1) in selectedRows to exercise the di < 0 skip path
+	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 2}, {resultIdx: 0, rowIdx: 1}, {resultIdx: 0, rowIdx: 0}}
+	merged, err := buildMergedRetrieveResults([]*internalpb.RetrieveResults{r1}, selectedRows, makeNullableSchema(100, schemapb.DataType_FloatVector, 2))
 	require.NoError(t, err)
+	// row2 → compact idx 1 → [3,4], row1 → null (skipped), row0 → compact idx 0 → [1,2]
 	assert.Equal(t, []float32{3, 4, 1, 2}, merged.FieldsData[0].GetVectors().GetFloatVector().GetData())
+	assert.Equal(t, []bool{true, false, true}, merged.FieldsData[0].ValidData)
 }
 
 // =========================================================================
@@ -2444,4 +2669,214 @@ func TestValidateElementLevelConsistency_LengthMismatch(t *testing.T) {
 	err := validateElementLevelConsistency([]*internalpb.RetrieveResults{r}, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "element_indices length")
+}
+
+// =========================================================================
+// Nullable vector / scalar merge correctness tests
+// =========================================================================
+
+// makeTestIntIDs is a helper to build IDs for test results.
+func makeTestIntIDs(ids ...int64) *schemapb.IDs {
+	return &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: ids}}}
+}
+
+// makeTestSparseVec builds a knowhere sparse vector binary: [dim uint32][val float32], little-endian.
+func makeTestSparseVec(dim uint32, val float32) []byte {
+	b := make([]byte, 8)
+	binary.LittleEndian.PutUint32(b[0:4], dim)
+	binary.LittleEndian.PutUint32(b[4:8], math.Float32bits(val))
+	return b
+}
+
+// TestBuildMergedVectorField_NullableSparseVector_AllNull_EmptyValidData validates Bug 1 fix:
+// when a nullable sparse vector field has empty ValidData + empty Contents, merge must not panic,
+// and the merged output must correctly mark those rows as null (ValidData=false).
+func TestBuildMergedVectorField_NullableSparse_RejectsEmptyValidData(t *testing.T) {
+	sparseSchema := makeNullableSchema(100, schemapb.DataType_SparseFloatVector, 0)
+
+	// rA: 1 row, has valid data
+	rA := &internalpb.RetrieveResults{
+		Ids: makeTestIntIDs(1),
+		FieldsData: []*schemapb.FieldData{{
+			FieldId: 100,
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Data: &schemapb.VectorField_SparseFloatVector{
+					SparseFloatVector: &schemapb.SparseFloatArray{
+						Contents: [][]byte{makeTestSparseVec(1, 0.5)},
+					},
+				},
+			}},
+			ValidData: []bool{true},
+		}},
+	}
+
+	// rB: 1 row, ValidData absent, Contents absent (segcore get_vector early return).
+	// This is now a contract violation: nullable field with numRows > 0 must have ValidData.
+	// The old code silently treated this as "all null"; the new code fails fast.
+	rB := &internalpb.RetrieveResults{
+		Ids: makeTestIntIDs(2),
+		FieldsData: []*schemapb.FieldData{{
+			FieldId: 100,
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Data: &schemapb.VectorField_SparseFloatVector{
+					SparseFloatVector: &schemapb.SparseFloatArray{Contents: nil},
+				},
+			}},
+			ValidData: nil,
+		}},
+	}
+
+	results := []*internalpb.RetrieveResults{rA, rB}
+	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 0}, {resultIdx: 1, rowIdx: 0}}
+
+	_, err := buildMergedRetrieveResults(results, selectedRows, sparseSchema)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty ValidData")
+}
+
+// TestBuildMergedVectorField_NullableSparse_RejectsMultipleRowsWithEmptyValidData validates that
+// multiple rows from a result with absent ValidData trigger fail-fast error.
+func TestBuildMergedVectorField_NullableSparse_RejectsMultipleRowsWithEmptyValidData(t *testing.T) {
+	sparseSchema := makeNullableSchema(100, schemapb.DataType_SparseFloatVector, 0)
+
+	rA := &internalpb.RetrieveResults{
+		Ids: makeTestIntIDs(1),
+		FieldsData: []*schemapb.FieldData{{
+			FieldId: 100,
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Data: &schemapb.VectorField_SparseFloatVector{
+					SparseFloatVector: &schemapb.SparseFloatArray{
+						Contents: [][]byte{makeTestSparseVec(1, 0.1)},
+					},
+				},
+			}},
+			ValidData: []bool{true},
+		}},
+	}
+
+	rB := &internalpb.RetrieveResults{
+		Ids: makeTestIntIDs(2, 3),
+		FieldsData: []*schemapb.FieldData{{
+			FieldId: 100,
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Data: &schemapb.VectorField_SparseFloatVector{
+					SparseFloatVector: &schemapb.SparseFloatArray{Contents: nil},
+				},
+			}},
+			ValidData: nil,
+		}},
+	}
+
+	results := []*internalpb.RetrieveResults{rA, rB}
+	selectedRows := []rowRef{
+		{resultIdx: 0, rowIdx: 0},
+		{resultIdx: 1, rowIdx: 0},
+		{resultIdx: 1, rowIdx: 1},
+	}
+
+	// rB has 2 rows but no ValidData → contract violation, must error
+	_, err := buildMergedRetrieveResults(results, selectedRows, sparseSchema)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty ValidData")
+}
+
+// TestBuildMergedVectorField_NullableSparseVector_AllNullWithValidData validates compact path
+// when ValidData is present and all false (explicit all-null).
+func TestBuildMergedVectorField_NullableSparseVector_AllNullWithValidData(t *testing.T) {
+	sparseSchema := makeNullableSchema(100, schemapb.DataType_SparseFloatVector, 0)
+	r := &internalpb.RetrieveResults{
+		Ids: makeTestIntIDs(1, 2),
+		FieldsData: []*schemapb.FieldData{{
+			FieldId: 100,
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Data: &schemapb.VectorField_SparseFloatVector{
+					SparseFloatVector: &schemapb.SparseFloatArray{Contents: nil},
+				},
+			}},
+			ValidData: []bool{false, false},
+		}},
+	}
+	results := []*internalpb.RetrieveResults{r}
+	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 0}, {resultIdx: 0, rowIdx: 1}}
+
+	merged, err := buildMergedRetrieveResults(results, selectedRows, sparseSchema)
+	require.NoError(t, err)
+	assert.Equal(t, []bool{false, false}, merged.FieldsData[0].ValidData)
+	assert.Empty(t, merged.FieldsData[0].GetVectors().GetSparseFloatVector().GetContents())
+}
+
+// TestBuildMergedVectorField_NullableSparseVector_Mixed validates compact index mapping when
+// some rows are valid and some are null within the same result.
+func TestBuildMergedVectorField_NullableSparseVector_Mixed(t *testing.T) {
+	sparseSchema := makeNullableSchema(100, schemapb.DataType_SparseFloatVector, 0)
+	// 3 rows: ValidData=[true,false,true], Contents=[vec0, vec2] (compact)
+	r := &internalpb.RetrieveResults{
+		Ids: makeTestIntIDs(1, 2, 3),
+		FieldsData: []*schemapb.FieldData{{
+			FieldId: 100,
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Data: &schemapb.VectorField_SparseFloatVector{
+					SparseFloatVector: &schemapb.SparseFloatArray{
+						Contents: [][]byte{makeTestSparseVec(1, 0.1), makeTestSparseVec(3, 0.3)},
+					},
+				},
+			}},
+			ValidData: []bool{true, false, true},
+		}},
+	}
+	results := []*internalpb.RetrieveResults{r}
+	// Select row 0 (valid) and row 1 (null)
+	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 0}, {resultIdx: 0, rowIdx: 1}}
+
+	merged, err := buildMergedRetrieveResults(results, selectedRows, sparseSchema)
+	require.NoError(t, err)
+	assert.Equal(t, []bool{true, false}, merged.FieldsData[0].ValidData)
+	// Only 1 non-null row in output
+	assert.Len(t, merged.FieldsData[0].GetVectors().GetSparseFloatVector().GetContents(), 1)
+}
+
+// TestBuildMergedFieldData_NullableScalar_EmptyValidData_FailFast validates that
+// a nullable field with rows but absent ValidData triggers a fail-fast error,
+// not a silent fallback to all-null. This catches segcore contract violations
+// early instead of letting them propagate to downstream panics.
+func TestBuildMergedVectorField_NullableVector_RejectsEmptyValidData(t *testing.T) {
+	// Note: buildCompactIndices only validates vector fields. For scalar fields,
+	// the ValidData check is still lenient (scalar fields are not compacted).
+	// This test uses a vector schema to trigger the vector-path validation.
+	sparseSchema := makeNullableSchema(100, schemapb.DataType_SparseFloatVector, 0)
+
+	rA := &internalpb.RetrieveResults{
+		Ids: makeTestIntIDs(1),
+		FieldsData: []*schemapb.FieldData{{
+			FieldId: 100,
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Data: &schemapb.VectorField_SparseFloatVector{
+					SparseFloatVector: &schemapb.SparseFloatArray{
+						Contents: [][]byte{makeTestSparseVec(1, 0.5)},
+					},
+				},
+			}},
+			ValidData: []bool{true},
+		}},
+	}
+	// rB: ValidData absent → contract violation for nullable vector
+	rB := &internalpb.RetrieveResults{
+		Ids: makeTestIntIDs(2),
+		FieldsData: []*schemapb.FieldData{{
+			FieldId: 100,
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Data: &schemapb.VectorField_SparseFloatVector{
+					SparseFloatVector: &schemapb.SparseFloatArray{Contents: nil},
+				},
+			}},
+			ValidData: nil,
+		}},
+	}
+
+	results := []*internalpb.RetrieveResults{rA, rB}
+	selectedRows := []rowRef{{resultIdx: 0, rowIdx: 0}, {resultIdx: 1, rowIdx: 0}}
+
+	_, err := buildMergedRetrieveResults(results, selectedRows, sparseSchema)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty ValidData")
 }

--- a/internal/util/queryutil/pipeline_builders.go
+++ b/internal/util/queryutil/pipeline_builders.go
@@ -54,22 +54,22 @@ func BuildQueryReducePipeline(
 	} else if hasGroupBy {
 		return buildGroupByReducePipeline(name, schema, topK, groupByFieldIDs, aggregates), nil
 	} else if hasOrderBy {
-		return buildOrderByReducePipeline(name, topK, orderByFields, maxOutputSize), nil
+		return buildOrderByReducePipeline(name, schema, topK, orderByFields, maxOutputSize), nil
 	}
-	return buildPlainReducePipeline(name, topK, reduceType, maxOutputSize), nil
+	return buildPlainReducePipeline(name, schema, topK, reduceType, maxOutputSize), nil
 }
 
 // buildPlainReducePipeline: [ReduceByPKTS(topK)] → output
-func buildPlainReducePipeline(name string, topK int64, reduceType reduce.IReduceType, maxOutputSize int64) *Pipeline {
+func buildPlainReducePipeline(name string, schema *schemapb.CollectionSchema, topK int64, reduceType reduce.IReduceType, maxOutputSize int64) *Pipeline {
 	b := NewPipelineBuilder(name)
-	b.Add(OpReduceByPKTS, pin(), pout(), NewReduceByPKWithTimestampOperator(reduceType, maxOutputSize, topK))
+	b.Add(OpReduceByPKTS, pin(), pout(), NewReduceByPKWithTimestampOperator(reduceType, maxOutputSize, topK, schema))
 	return b.Build()
 }
 
 // buildOrderByReducePipeline: [DeduplicatePK] → [OrderByLimit(topK)] → output
-func buildOrderByReducePipeline(name string, topK int64, orderByFields []*orderby.OrderByField, maxOutputSize int64) *Pipeline {
+func buildOrderByReducePipeline(name string, schema *schemapb.CollectionSchema, topK int64, orderByFields []*orderby.OrderByField, maxOutputSize int64) *Pipeline {
 	b := NewPipelineBuilder(name)
-	b.Add(OpDeduplicatePK, pin(), pch(ChannelDeduped), NewDeduplicatePKOperator(maxOutputSize))
+	b.Add(OpDeduplicatePK, pin(), pch(ChannelDeduped), NewDeduplicatePKOperator(maxOutputSize, schema))
 	b.Add(OpOrderByLimit, pch(ChannelDeduped), pout(), NewOrderByLimitOperator(orderByFields, topK))
 	return b.Build()
 }

--- a/internal/util/queryutil/reduce_by_pk_op.go
+++ b/internal/util/queryutil/reduce_by_pk_op.go
@@ -41,13 +41,16 @@ import (
 // (IReduceInOrder/IReduceInOrderForBest) stop early to maintain page boundaries.
 type ReduceByPKOperator struct {
 	reduceType reduce.IReduceType
+	schema     *schemapb.CollectionSchema
 }
 
 // NewSortAndCheckPKOperator creates a reduce-by-PK operator for proxy level.
 // It sorts by PK ASC and returns an error if duplicate PKs are detected
 // across shards (indicating a data integrity issue).
-func NewSortAndCheckPKOperator(reduceType reduce.IReduceType) *ReduceByPKOperator {
-	return &ReduceByPKOperator{reduceType: reduceType}
+// schema is used to determine per-field nullable flags for correct merge semantics.
+// Pass nil to treat all fields as non-nullable (QN-side / schema-unaware callers).
+func NewSortAndCheckPKOperator(reduceType reduce.IReduceType, schema *schemapb.CollectionSchema) *ReduceByPKOperator {
+	return &ReduceByPKOperator{reduceType: reduceType, schema: schema}
 }
 
 func (op *ReduceByPKOperator) Name() string {
@@ -130,7 +133,7 @@ func (op *ReduceByPKOperator) mergeByPK(results []*internalpb.RetrieveResults, h
 	}
 
 	// Build merged result
-	merged, err := buildMergedRetrieveResults(results, selectedRows)
+	merged, err := buildMergedRetrieveResults(results, selectedRows, op.schema)
 	if err != nil {
 		return nil, err
 	}
@@ -156,16 +159,19 @@ type ReduceByPKWithTimestampOperator struct {
 	reduceType    reduce.IReduceType
 	maxOutputSize int64
 	limit         int64
+	schema        *schemapb.CollectionSchema
 }
 
 // NewReduceByPKWithTimestampOperator creates an operator with timestamp-based deduplication.
 // maxOutputSize: maximum allowed output size in bytes; <= 0 disables the check.
 // limit: maximum rows/elements to keep; <= 0 means unlimited.
-func NewReduceByPKWithTimestampOperator(reduceType reduce.IReduceType, maxOutputSize int64, limit int64) *ReduceByPKWithTimestampOperator {
+// schema is used to determine per-field nullable flags. Pass nil for QN-side callers.
+func NewReduceByPKWithTimestampOperator(reduceType reduce.IReduceType, maxOutputSize int64, limit int64, schema *schemapb.CollectionSchema) *ReduceByPKWithTimestampOperator {
 	return &ReduceByPKWithTimestampOperator{
 		reduceType:    reduceType,
 		maxOutputSize: maxOutputSize,
 		limit:         limit,
+		schema:        schema,
 	}
 }
 
@@ -305,7 +311,7 @@ func (op *ReduceByPKWithTimestampOperator) mergeByPKWithTimestamp(results []*tim
 		origResults[i] = tr.result
 	}
 
-	merged, err := buildMergedRetrieveResults(origResults, selectedRows)
+	merged, err := buildMergedRetrieveResults(origResults, selectedRows, op.schema)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/util/queryutil/reduce_by_pk_op_test.go
+++ b/internal/util/queryutil/reduce_by_pk_op_test.go
@@ -29,12 +29,12 @@ import (
 )
 
 func TestReduceByPKOperator_Name(t *testing.T) {
-	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder)
+	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder, nil)
 	assert.Equal(t, OpReduceByPK, op.Name())
 }
 
 func TestReduceByPKOperator_EmptyInput(t *testing.T) {
-	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder)
+	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder, nil)
 	ctx := context.Background()
 
 	// Test with nil input
@@ -45,7 +45,7 @@ func TestReduceByPKOperator_EmptyInput(t *testing.T) {
 }
 
 func TestReduceByPKOperator_SingleResult(t *testing.T) {
-	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder)
+	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder, nil)
 	ctx := context.Background()
 
 	result := &internalpb.RetrieveResults{
@@ -82,7 +82,7 @@ func TestReduceByPKOperator_SingleResult(t *testing.T) {
 }
 
 func TestReduceByPKOperator_MultipleResults(t *testing.T) {
-	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder)
+	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder, nil)
 	ctx := context.Background()
 
 	result1 := &internalpb.RetrieveResults{
@@ -147,7 +147,7 @@ func TestReduceByPKOperator_MultipleResults(t *testing.T) {
 }
 
 func TestReduceByPKOperator_StringPK(t *testing.T) {
-	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder)
+	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder, nil)
 	ctx := context.Background()
 
 	result1 := &internalpb.RetrieveResults{
@@ -209,7 +209,7 @@ func TestReduceByPKOperator_StringPK(t *testing.T) {
 }
 
 func TestReduceByPKOperator_DuplicatePK(t *testing.T) {
-	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder)
+	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder, nil)
 	ctx := context.Background()
 
 	// Two results with overlapping PKs (2, 3 are duplicated)
@@ -265,7 +265,7 @@ func TestReduceByPKOperator_DuplicatePK(t *testing.T) {
 }
 
 func TestReduceByPKOperator_HasMoreResult(t *testing.T) {
-	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder)
+	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder, nil)
 	ctx := context.Background()
 
 	result1 := &internalpb.RetrieveResults{
@@ -322,7 +322,7 @@ func TestReduceByPKOperator_HasMoreResult(t *testing.T) {
 }
 
 func TestSortAndCheckPKOperator_NoDuplicate(t *testing.T) {
-	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder)
+	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder, nil)
 	ctx := context.Background()
 
 	result1 := &internalpb.RetrieveResults{
@@ -377,7 +377,7 @@ func TestSortAndCheckPKOperator_NoDuplicate(t *testing.T) {
 }
 
 func TestSortAndCheckPKOperator_FailOnDuplicate(t *testing.T) {
-	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder)
+	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder, nil)
 	ctx := context.Background()
 
 	result1 := &internalpb.RetrieveResults{
@@ -431,7 +431,7 @@ func TestSortAndCheckPKOperator_FailOnDuplicate(t *testing.T) {
 
 func TestReduceByPKOperator_DrainResultWithInOrder(t *testing.T) {
 	// IReduceInOrder should stop when one result is drained but has HasMoreResult=true
-	op := NewSortAndCheckPKOperator(reduce.IReduceInOrder)
+	op := NewSortAndCheckPKOperator(reduce.IReduceInOrder, nil)
 	ctx := context.Background()
 
 	result1 := &internalpb.RetrieveResults{
@@ -491,7 +491,7 @@ func TestReduceByPKOperator_DrainResultWithInOrder(t *testing.T) {
 
 func TestReduceByPKOperator_DrainResultWithNoOrder(t *testing.T) {
 	// Use IReduceNoOrder which should NOT stop when one result is drained
-	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder) // Default is IReduceNoOrder
+	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder, nil) // Default is IReduceNoOrder
 	ctx := context.Background()
 
 	result1 := &internalpb.RetrieveResults{
@@ -549,12 +549,12 @@ func TestReduceByPKOperator_DrainResultWithNoOrder(t *testing.T) {
 }
 
 func TestReduceByPKWithTimestampOperator_Name(t *testing.T) {
-	op := NewReduceByPKWithTimestampOperator(reduce.IReduceNoOrder, 0, 0)
+	op := NewReduceByPKWithTimestampOperator(reduce.IReduceNoOrder, 0, 0, nil)
 	assert.Equal(t, OpReduceByPKTS, op.Name())
 }
 
 func TestReduceByPKWithTimestampOperator_DuplicatePKWithHigherTimestamp(t *testing.T) {
-	op := NewReduceByPKWithTimestampOperator(reduce.IReduceNoOrder, 0, 0)
+	op := NewReduceByPKWithTimestampOperator(reduce.IReduceNoOrder, 0, 0, nil)
 	ctx := context.Background()
 
 	const timestampFieldID int64 = 1 // common.TimeStampField
@@ -646,7 +646,7 @@ func TestReduceByPKWithTimestampOperator_DuplicatePKWithHigherTimestamp(t *testi
 }
 
 func TestReduceByPKWithTimestampOperator_NoTimestampField(t *testing.T) {
-	op := NewReduceByPKWithTimestampOperator(reduce.IReduceNoOrder, 0, 0)
+	op := NewReduceByPKWithTimestampOperator(reduce.IReduceNoOrder, 0, 0, nil)
 	ctx := context.Background()
 
 	// Results without timestamp field - should still work (fallback to first seen)
@@ -743,7 +743,7 @@ func makeElementLevelResult(pks []int64, timestamps []int64, elemIndices [][]int
 }
 
 func TestReduceByPKWithTimestamp_ElementLevel_MergeAndDedup(t *testing.T) {
-	op := NewReduceByPKWithTimestampOperator(reduce.IReduceNoOrder, 0, 0)
+	op := NewReduceByPKWithTimestampOperator(reduce.IReduceNoOrder, 0, 0, nil)
 	ctx := context.Background()
 
 	// r1: pk=1 (ts=100, elements [0,1]), pk=3 (ts=100, elements [2])
@@ -777,7 +777,7 @@ func TestReduceByPKWithTimestamp_ElementLevel_MergeAndDedup(t *testing.T) {
 }
 
 func TestReduceByPKOperator_ElementLevel_Propagation(t *testing.T) {
-	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder)
+	op := NewSortAndCheckPKOperator(reduce.IReduceNoOrder, nil)
 	ctx := context.Background()
 
 	// Two element-level results with no overlapping PKs
@@ -859,7 +859,7 @@ func TestReduceByPKWithTimestampOperator_MaxOutputSize_ExactlyAtLimit(t *testing
 	const rowCount = 3
 	const exactLimit int64 = rowSize * rowCount // 24 bytes
 
-	op := NewReduceByPKWithTimestampOperator(reduce.IReduceNoOrder, exactLimit, 0)
+	op := NewReduceByPKWithTimestampOperator(reduce.IReduceNoOrder, exactLimit, 0, nil)
 	ctx := context.Background()
 
 	r := &internalpb.RetrieveResults{
@@ -891,7 +891,7 @@ func TestReduceByPKWithTimestampOperator_MaxOutputSize_Exceeded(t *testing.T) {
 	const rowCount = 3
 	const limitOneByte int64 = rowSize*rowCount - 1 // 23 bytes
 
-	op := NewReduceByPKWithTimestampOperator(reduce.IReduceNoOrder, limitOneByte, 0)
+	op := NewReduceByPKWithTimestampOperator(reduce.IReduceNoOrder, limitOneByte, 0, nil)
 	ctx := context.Background()
 
 	r := &internalpb.RetrieveResults{


### PR DESCRIPTION
Two bugs in the Go-layer query reduce pipeline caused panics and wrong ValidData output for nullable vector fields:

Bug 1: buildCompactIndices inferred nullable from ValidData presence. When segcore returns empty ValidData + empty Contents (e.g. index not ready via fill_with_empty), the compact mapping was not built, causing getVecDataIdx to return rowIdx directly and Contents[rowIdx] to panic.

Bug 2: buildMergedFieldData set validData[i]=true when ValidData was absent for a nullable field, incorrectly marking null rows as valid.

Fix: use schema (map[fieldID]bool) as the source of truth for nullability. Empty ValidData for a nullable field now means "all rows are null" rather than "non-nullable". All QN-side and proxy-side operators (ReduceByPKTS, DeduplicatePK, ReduceByPK, ConcatAndCheckPK) receive the nullable map built from schema at construction time.

Also add bounds checks to buildMergedScalarField for all scalar types to guard against nullable fields with empty Data arrays.

related: #48700