### PR TITLE
enhance: optimize load performance for high concurrency

### DIFF
--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -577,8 +577,6 @@ func (m *meta) GetQuotaInfo() *metricsinfo.DataCoordQuotaMetrics {
 
 				storedBinlogSize[collIDStr][segment.GetState().String()] += segmentSize
 				binlogFileCount[collIDStr] += int64(getBinlogFileCount(segment.SegmentInfo))
-			} else {
-				log.Ctx(context.TODO()).Warn("not found database name", zap.Int64("collectionID", segment.GetCollectionID()))
 			}
 
 			if _, ok := collectionRowsNum[segment.GetCollectionID()]; !ok {

--- a/internal/querycoordv2/meta/collection_manager.go
+++ b/internal/querycoordv2/meta/collection_manager.go
@@ -185,6 +185,9 @@ func (m *CollectionManager) Recover(ctx context.Context, broker Broker) error {
 	}
 
 	for collection, partitions := range partitions {
+		var partitionsToSave []*Partition
+		var partitionsToCache []*Partition
+		released := false
 		for _, partition := range partitions {
 			// Partitions not loaded done should be deprecated
 			if partition.GetStatus() != querypb.LoadStatus_Loaded {
@@ -193,25 +196,35 @@ func (m *CollectionManager) Recover(ctx context.Context, broker Broker) error {
 					ctxLog.Info("recover loading partition times reach limit, release collection",
 						zap.Int64("collectionID", collection),
 						zap.Int32("recoverTimes", partition.RecoverTimes))
+					released = true
 					break
 				}
 
 				partition.RecoverTimes += 1
-				m.putPartition(ctx, []*Partition{
-					{
-						PartitionLoadInfo: partition,
-						CreatedAt:         time.Now(),
-					},
-				}, true)
+				partitionsToSave = append(partitionsToSave, &Partition{
+					PartitionLoadInfo: partition,
+					CreatedAt:         time.Now(),
+				})
 				continue
 			}
 
-			m.putPartition(ctx, []*Partition{
-				{
-					PartitionLoadInfo: partition,
-					CreatedAt:         time.Now(),
-				},
-			}, false)
+			partitionsToCache = append(partitionsToCache, &Partition{
+				PartitionLoadInfo: partition,
+				CreatedAt:         time.Now(),
+			})
+		}
+		if released {
+			continue
+		}
+		if len(partitionsToSave) > 0 {
+			if err := m.putPartition(ctx, partitionsToSave, true); err != nil {
+				return err
+			}
+		}
+		if len(partitionsToCache) > 0 {
+			if err := m.putPartition(ctx, partitionsToCache, false); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/internal/querycoordv2/meta/resource_manager.go
+++ b/internal/querycoordv2/meta/resource_manager.go
@@ -617,7 +617,7 @@ func (rm *ResourceManager) HandleNodeUp(ctx context.Context, node int64) {
 
 func (rm *ResourceManager) handleNodeUp(ctx context.Context, node int64) {
 	nodeInfo := rm.nodeMgr.Get(node)
-	if nodeInfo == nil || nodeInfo.IsEmbeddedQueryNodeInStreamingNode() {
+	if nodeInfo == nil {
 		return
 	}
 	if nodeInfo.IsStoppingState() {
@@ -1224,9 +1224,6 @@ func (rm *ResourceManager) CheckNodesInResourceGroup(ctx context.Context) {
 				rm.handleNodeDown(ctx, node)
 			} else if info.GetState() == session.NodeStateStopping {
 				log.Warn("node is stopping", zap.Int64("node", node))
-				rm.handleNodeStopping(ctx, node)
-			} else if info.IsEmbeddedQueryNodeInStreamingNode() {
-				log.Warn("unreachable code, but just for dirty meta clean up", zap.Int64("node", node))
 				rm.handleNodeStopping(ctx, node)
 			}
 		}

--- a/internal/querycoordv2/meta/resource_manager.go
+++ b/internal/querycoordv2/meta/resource_manager.go
@@ -617,7 +617,7 @@ func (rm *ResourceManager) HandleNodeUp(ctx context.Context, node int64) {
 
 func (rm *ResourceManager) handleNodeUp(ctx context.Context, node int64) {
 	nodeInfo := rm.nodeMgr.Get(node)
-	if nodeInfo == nil {
+	if nodeInfo == nil || nodeInfo.IsEmbeddedQueryNodeInStreamingNode() {
 		return
 	}
 	if nodeInfo.IsStoppingState() {
@@ -1224,6 +1224,9 @@ func (rm *ResourceManager) CheckNodesInResourceGroup(ctx context.Context) {
 				rm.handleNodeDown(ctx, node)
 			} else if info.GetState() == session.NodeStateStopping {
 				log.Warn("node is stopping", zap.Int64("node", node))
+				rm.handleNodeStopping(ctx, node)
+			} else if info.IsEmbeddedQueryNodeInStreamingNode() {
+				log.Warn("unreachable code, but just for dirty meta clean up", zap.Int64("node", node))
 				rm.handleNodeStopping(ctx, node)
 			}
 		}

--- a/internal/querycoordv2/session/cluster.go
+++ b/internal/querycoordv2/session/cluster.go
@@ -134,7 +134,7 @@ func (c *QueryCluster) LoadSegments(ctx context.Context, nodeID int64, req *quer
 	var status *commonpb.Status
 	var err error
 	err1 := c.send(ctx, nodeID, func(cli types.QueryNodeClient) {
-		req := proto.Clone(req).(*querypb.LoadSegmentsRequest)
+		req = proto.Clone(req).(*querypb.LoadSegmentsRequest)
 		req.Base.TargetID = nodeID
 		status, err = cli.LoadSegments(ctx, req)
 	})

--- a/internal/querycoordv2/task/executor.go
+++ b/internal/querycoordv2/task/executor.go
@@ -858,18 +858,12 @@ func (ex *Executor) getMetaInfo(ctx context.Context, task Task) (*milvuspb.Descr
 		return nil, nil, nil, err
 	}
 	loadFields := ex.meta.GetLoadFields(ctx, task.CollectionID())
-	partitions, err := utils.GetPartitions(ctx, ex.targetMgr, collectionID)
-	if err != nil {
-		log.Warn("failed to get partitions of collection", zap.Error(err))
-		return nil, nil, nil, err
-	}
 
 	loadMeta := packLoadMeta(
 		ex.meta.GetLoadType(ctx, task.CollectionID()),
 		collectionInfo,
 		task.ResourceGroup(),
 		loadFields,
-		partitions...,
 	)
 
 	// get channel first, in case of target updated after segment info fetched

--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -1234,6 +1234,9 @@ func (sd *shardDelegator) Close() {
 	sd.tsCond.Broadcast()
 	sd.lifetime.Wait()
 
+	// Stop background snapshot loop before refunding candidates
+	sd.distribution.Close()
+
 	// Refund all sealed segment candidates in distribution
 	sd.distribution.RefundAllCandidates()
 

--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -569,13 +569,14 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 		// automatically by SyncDistribution when the segment is not in target.
 		return err
 	}
+	log.Debug("load stream delete done")
 
 	return nil
 }
 
 func (sd *shardDelegator) addDistributionIfVersionOK(version uint64, entries ...SegmentEntry) error {
-	sd.schemaChangeMutex.Lock()
-	defer sd.schemaChangeMutex.Unlock()
+	sd.schemaChangeMutex.RLock()
+	defer sd.schemaChangeMutex.RUnlock()
 	if version < sd.schemaVersion {
 		return merr.WrapErrServiceInternal("schema version changed")
 	}

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -481,6 +481,7 @@ func (s *DelegatorDataSuite) TestProcessDelete() {
 		},
 	}, 10)
 
+	s.delegator.distribution.Flush()
 	s.False(s.delegator.distribution.Serviceable())
 
 	worker1.EXPECT().LoadSegments(mock.Anything, mock.AnythingOfType("*querypb.LoadSegmentsRequest")).
@@ -503,6 +504,7 @@ func (s *DelegatorDataSuite) TestProcessDelete() {
 		Version: time.Now().UnixNano(),
 	})
 	s.Require().NoError(err)
+	s.delegator.distribution.Flush()
 	s.True(s.delegator.distribution.Serviceable())
 	// Test normal errors with retry and fail
 	worker1.ExpectedCalls = nil
@@ -515,6 +517,7 @@ func (s *DelegatorDataSuite) TestProcessDelete() {
 			RowCount:    1,
 		},
 	}, 10)
+	s.delegator.distribution.Flush()
 	s.False(s.delegator.distribution.Serviceable(), "should retry and failed")
 
 	// refresh
@@ -538,6 +541,7 @@ func (s *DelegatorDataSuite) TestProcessDelete() {
 		Version: time.Now().UnixNano(),
 	})
 	s.Require().NoError(err)
+	s.delegator.distribution.Flush()
 	s.True(s.delegator.distribution.Serviceable())
 
 	s.delegator.Close()

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -620,6 +620,7 @@ func (s *DelegatorDataSuite) TestLoadSegmentsWithBm25() {
 		})
 
 		s.NoError(err)
+		s.delegator.distribution.Flush()
 		sealed, _ := s.delegator.GetSegmentInfo(false)
 		s.Require().Equal(1, len(sealed))
 		s.Equal(int64(1), sealed[0].NodeID)
@@ -680,6 +681,7 @@ func (s *DelegatorDataSuite) TestLoadSegments() {
 		})
 
 		s.NoError(err)
+		s.delegator.distribution.Flush()
 		sealed, _ := s.delegator.GetSegmentInfo(false)
 		s.Require().Equal(1, len(sealed))
 		s.Equal(int64(1), sealed[0].NodeID)
@@ -1263,6 +1265,7 @@ func (s *DelegatorDataSuite) TestReleaseSegment() {
 	})
 	s.Require().NoError(err)
 
+	s.delegator.distribution.Flush()
 	sealed, growing := s.delegator.GetSegmentInfo(false)
 	s.Require().Equal(1, len(sealed))
 	s.Equal(int64(1), sealed[0].NodeID)

--- a/internal/querynodev2/delegator/delegator_test.go
+++ b/internal/querynodev2/delegator/delegator_test.go
@@ -700,6 +700,7 @@ func (s *DelegatorSuite) TestSearch() {
 		sd, ok := s.delegator.(*shardDelegator)
 		s.Require().True(ok)
 		sd.distribution.MarkOfflineSegments(1001)
+		sd.distribution.Flush()
 
 		_, err := s.delegator.Search(ctx, &querypb.SearchRequest{
 			Req: &internalpb.SearchRequest{
@@ -888,6 +889,7 @@ func (s *DelegatorSuite) TestQuery() {
 		sd, ok := s.delegator.(*shardDelegator)
 		s.Require().True(ok)
 		sd.distribution.MarkOfflineSegments(1001)
+		sd.distribution.Flush()
 
 		_, err := s.delegator.Query(ctx, &querypb.QueryRequest{
 			Req:         &internalpb.RetrieveRequest{QueryLabel: "query", Base: commonpbutil.NewMsgBase()},
@@ -1169,6 +1171,7 @@ func (s *DelegatorSuite) TestQueryStream() {
 		sd, ok := s.delegator.(*shardDelegator)
 		s.Require().True(ok)
 		sd.distribution.MarkOfflineSegments(1001)
+		sd.distribution.Flush()
 
 		client := streamrpc.NewLocalQueryClient(ctx)
 		server := client.CreateServer()
@@ -1346,6 +1349,7 @@ func (s *DelegatorSuite) TestGetStats() {
 		sd, ok := s.delegator.(*shardDelegator)
 		s.Require().True(ok)
 		sd.distribution.MarkOfflineSegments(1001)
+		sd.distribution.Flush()
 
 		_, err := s.delegator.GetStatistics(ctx, &querypb.GetStatisticsRequest{
 			Req:         &internalpb.GetStatisticsRequest{Base: commonpbutil.NewMsgBase()},
@@ -1447,6 +1451,7 @@ func (s *DelegatorSuite) TestUpdateSchema() {
 		sd, ok := s.delegator.(*shardDelegator)
 		s.Require().True(ok)
 		sd.distribution.MarkOfflineSegments(1001)
+		sd.distribution.Flush()
 
 		err := s.delegator.UpdateSchema(ctx, &schemapb.CollectionSchema{}, 100)
 		s.Error(err)

--- a/internal/querynodev2/delegator/delegator_test.go
+++ b/internal/querynodev2/delegator/delegator_test.go
@@ -380,6 +380,7 @@ func (s *DelegatorSuite) TestGetSegmentInfo() {
 		Version:     2001,
 	})
 
+	s.delegator.(*shardDelegator).distribution.Flush()
 	sealed, growing = s.delegator.GetSegmentInfo(false)
 	s.EqualValues([]SnapshotItem{
 		{

--- a/internal/querynodev2/delegator/distribution.go
+++ b/internal/querynodev2/delegator/distribution.go
@@ -125,6 +125,7 @@ type distribution struct {
 	// async snapshot generation
 	snapshotNotifier chan struct{} // capacity 1, notify background goroutine to regenerate snapshot
 	snapshotDone     chan struct{} // closed when background goroutine exits
+	closeOnce        sync.Once
 
 	// distribution info
 	channelName string
@@ -729,7 +730,9 @@ func (d *distribution) Flush() {
 
 // Close stops the background snapshot loop and waits for it to exit.
 func (d *distribution) Close() {
-	close(d.snapshotNotifier)
+	d.closeOnce.Do(func() {
+		close(d.snapshotNotifier)
+	})
 	<-d.snapshotDone
 }
 

--- a/internal/querynodev2/delegator/distribution.go
+++ b/internal/querynodev2/delegator/distribution.go
@@ -407,14 +407,17 @@ func refundCandidates(candidates []pkoracle.Candidate) {
 }
 
 // AddGrowing adds growing segment distribution.
+// genSnapshot is called synchronously so that the growing segment is
+// immediately visible to searches. Growing segments are created
+// infrequently (only on the first insert for each segment), so this
+// does not regress the lock-contention optimization.
 func (d *distribution) AddGrowing(entries ...SegmentEntry) {
 	d.mut.Lock()
 	for _, entry := range entries {
 		d.growingSegments[entry.SegmentID] = entry
 	}
+	d.genSnapshot()
 	d.mut.Unlock()
-
-	d.notifySnapshotUpdate()
 }
 
 // AddOffline set segmentIDs to offlines.

--- a/internal/querynodev2/delegator/distribution.go
+++ b/internal/querynodev2/delegator/distribution.go
@@ -122,6 +122,10 @@ type distribution struct {
 	// protects current & segments
 	mut sync.RWMutex
 
+	// async snapshot generation
+	snapshotNotifier chan struct{} // capacity 1, notify background goroutine to regenerate snapshot
+	snapshotDone     chan struct{} // closed when background goroutine exits
+
 	// distribution info
 	channelName string
 	queryView   *channelQueryView
@@ -146,16 +150,40 @@ type SegmentEntry struct {
 
 func NewDistribution(channelName string, queryView *channelQueryView) *distribution {
 	dist := &distribution{
-		channelName:     channelName,
-		growingSegments: make(map[UniqueID]SegmentEntry),
-		sealedSegments:  make(map[UniqueID]SegmentEntry),
-		snapshots:       typeutil.NewConcurrentMap[int64, *snapshot](),
-		current:         atomic.NewPointer[snapshot](nil),
-		queryView:       queryView,
+		channelName:      channelName,
+		growingSegments:  make(map[UniqueID]SegmentEntry),
+		sealedSegments:   make(map[UniqueID]SegmentEntry),
+		snapshots:        typeutil.NewConcurrentMap[int64, *snapshot](),
+		current:          atomic.NewPointer[snapshot](nil),
+		queryView:        queryView,
+		snapshotNotifier: make(chan struct{}, 1),
+		snapshotDone:     make(chan struct{}),
 	}
+	// generate initial snapshot synchronously
 	dist.genSnapshot()
 	dist.updateServiceable("NewDistribution")
+	// start background snapshot loop
+	go dist.snapshotLoop()
 	return dist
+}
+
+// notifySnapshotUpdate sends a non-blocking notification to regenerate snapshot.
+func (d *distribution) notifySnapshotUpdate() {
+	select {
+	case d.snapshotNotifier <- struct{}{}:
+	default:
+	}
+}
+
+// snapshotLoop runs in a background goroutine, regenerating snapshot on notification.
+func (d *distribution) snapshotLoop() {
+	defer close(d.snapshotDone)
+	for range d.snapshotNotifier {
+		d.mut.Lock()
+		d.genSnapshot()
+		d.updateServiceable("snapshotLoop")
+		d.mut.Unlock()
+	}
 }
 
 func (d *distribution) SetIDFOracle(idfOracle IDFOracle) {
@@ -335,9 +363,9 @@ func (d *distribution) updateServiceable(triggerAction string) {
 
 // AddDistributions add multiple segment entries.
 func (d *distribution) AddDistributions(entries ...SegmentEntry) {
-	d.mut.Lock()
 	var toRefund []pkoracle.Candidate
 
+	d.mut.Lock()
 	for _, entry := range entries {
 		oldEntry, ok := d.sealedSegments[entry.SegmentID]
 		if ok && oldEntry.Version >= entry.Version {
@@ -348,7 +376,6 @@ func (d *distribution) AddDistributions(entries ...SegmentEntry) {
 				zap.Int64("newVersion", entry.Version),
 				zap.Int64("newNode", entry.NodeID),
 			)
-			// if new entry has candidate but we skip it, refund the new candidate
 			if entry.Candidate != nil {
 				toRefund = append(toRefund, entry.Candidate)
 			}
@@ -356,9 +383,7 @@ func (d *distribution) AddDistributions(entries ...SegmentEntry) {
 		}
 
 		if ok {
-			// remain the target version for already loaded segment to void skipping this segment when executing search
 			entry.TargetVersion = oldEntry.TargetVersion
-			// if old entry has candidate and we're replacing it, refund old candidate
 			if oldEntry.Candidate != nil {
 				toRefund = append(toRefund, oldEntry.Candidate)
 			}
@@ -367,12 +392,9 @@ func (d *distribution) AddDistributions(entries ...SegmentEntry) {
 		}
 		d.sealedSegments[entry.SegmentID] = entry
 	}
-
-	d.genSnapshot()
-	d.updateServiceable("AddDistributions")
 	d.mut.Unlock()
 
-	// refund old candidates after releasing lock (synchronous to avoid use-after-free)
+	d.notifySnapshotUpdate()
 	refundCandidates(toRefund)
 }
 
@@ -386,20 +408,17 @@ func refundCandidates(candidates []pkoracle.Candidate) {
 // AddGrowing adds growing segment distribution.
 func (d *distribution) AddGrowing(entries ...SegmentEntry) {
 	d.mut.Lock()
-	defer d.mut.Unlock()
-
 	for _, entry := range entries {
 		d.growingSegments[entry.SegmentID] = entry
 	}
+	d.mut.Unlock()
 
-	d.genSnapshot()
+	d.notifySnapshotUpdate()
 }
 
 // AddOffline set segmentIDs to offlines.
 func (d *distribution) MarkOfflineSegments(segmentIDs ...int64) {
 	d.mut.Lock()
-	defer d.mut.Unlock()
-
 	updated := false
 	for _, segmentID := range segmentIDs {
 		entry, ok := d.sealedSegments[segmentID]
@@ -412,13 +431,13 @@ func (d *distribution) MarkOfflineSegments(segmentIDs ...int64) {
 		entry.NodeID = -1
 		d.sealedSegments[segmentID] = entry
 	}
+	d.mut.Unlock()
 
 	if updated {
 		log.Info("mark sealed segment offline from distribution",
 			zap.String("channelName", d.channelName),
 			zap.Int64s("segmentIDs", segmentIDs))
-		d.genSnapshot()
-		d.updateServiceable("MarkOfflineSegments")
+		d.notifySnapshotUpdate()
 	}
 }
 
@@ -478,6 +497,8 @@ func (d *distribution) SyncTargetVersion(action *querypb.SyncAction, partitions 
 		d.sealedSegments[id] = entry
 	}
 
+	// SyncTargetVersion needs synchronous genSnapshot because idfOracle.SetNext
+	// depends on the snapshot just generated.
 	d.genSnapshot()
 	if d.idfOracle != nil {
 		d.idfOracle.SetNext(d.current.Load())
@@ -506,17 +527,18 @@ func (d *distribution) GetQueryView() *channelQueryView {
 }
 
 // RemoveDistributions remove segments distributions and returns the clear signal channel.
+// The returned channel is closed when the snapshot that still contains the removed segments
+// is expired (i.e., all in-flight reads using that snapshot have finished).
 func (d *distribution) RemoveDistributions(sealedSegments []SegmentEntry, growingSegments []SegmentEntry) chan struct{} {
-	d.mut.Lock()
 	var toRefund []pkoracle.Candidate
 
+	d.mut.Lock()
 	for _, sealed := range sealedSegments {
 		entry, ok := d.sealedSegments[sealed.SegmentID]
 		if !ok {
 			continue
 		}
 		if entry.NodeID == sealed.NodeID || sealed.NodeID == wildcardNodeID {
-			// collect candidate before deletion
 			if entry.Candidate != nil {
 				toRefund = append(toRefund, entry.Candidate)
 			}
@@ -529,11 +551,19 @@ func (d *distribution) RemoveDistributions(sealedSegments []SegmentEntry, growin
 		if !ok {
 			continue
 		}
-		// Note: growing segment's Candidate (LocalSegment) is NOT refunded here
-		// because the segment lifecycle is managed by segmentManager
-		// The BF inside LocalSegment will be cleaned when segment.Release() is called
 		delete(d.growingSegments, growing.SegmentID)
 	}
+
+	// Capture current snapshot's cleared channel. The next genSnapshot will
+	// create a new snapshot and expire this one, closing the channel.
+	var signal chan struct{}
+	if current := d.current.Load(); current != nil {
+		signal = current.cleared
+	} else {
+		signal = make(chan struct{})
+		close(signal)
+	}
+	d.mut.Unlock()
 
 	log.Info("remove segments from distribution",
 		zap.String("channelName", d.channelName),
@@ -542,13 +572,7 @@ func (d *distribution) RemoveDistributions(sealedSegments []SegmentEntry, growin
 		zap.Int("sealedCandidatesRefunded", len(toRefund)),
 	)
 
-	d.updateServiceable("RemoveDistributions")
-	// wait previous read even not distribution changed
-	// in case of segment balance caused segment lost track
-	signal := d.genSnapshot()
-	d.mut.Unlock()
-
-	// refund sealed segment candidates after releasing lock (synchronous to avoid use-after-free)
+	d.notifySnapshotUpdate()
 	refundCandidates(toRefund)
 
 	return signal
@@ -691,6 +715,12 @@ func BatchGetFromSegments(pks []storage.PrimaryKey, partitionID int64, sealed []
 	}
 
 	return result
+}
+
+// Close stops the background snapshot loop and waits for it to exit.
+func (d *distribution) Close() {
+	close(d.snapshotNotifier)
+	<-d.snapshotDone
 }
 
 // RefundAllCandidates refunds resources for all sealed segment candidates.

--- a/internal/querynodev2/delegator/distribution.go
+++ b/internal/querynodev2/delegator/distribution.go
@@ -717,6 +717,16 @@ func BatchGetFromSegments(pks []storage.PrimaryKey, partitionID int64, sealed []
 	return result
 }
 
+// Flush synchronously generates a snapshot so that subsequent reads
+// (e.g. PeekSegments) see the latest distribution state.
+// This is useful in tests and in scenarios that require immediate consistency.
+func (d *distribution) Flush() {
+	d.mut.Lock()
+	d.genSnapshot()
+	d.updateServiceable("Flush")
+	d.mut.Unlock()
+}
+
 // Close stops the background snapshot loop and waits for it to exit.
 func (d *distribution) Close() {
 	close(d.snapshotNotifier)

--- a/internal/querynodev2/delegator/distribution_test.go
+++ b/internal/querynodev2/delegator/distribution_test.go
@@ -43,6 +43,9 @@ func (s *DistributionSuite) SetupTest() {
 }
 
 func (s *DistributionSuite) TearDownTest() {
+	if s.dist != nil {
+		s.dist.Close()
+	}
 	s.dist = nil
 }
 
@@ -193,6 +196,7 @@ func (s *DistributionSuite) TestAddDistribution() {
 			_, _, _, version, err := s.dist.PinReadableSegments(1.0, 1)
 			s.Require().NoError(err)
 			s.dist.AddDistributions(tc.input...)
+			s.dist.Flush()
 			sealed, _ := s.dist.PeekSegments(false)
 			s.compareSnapshotItems(tc.expected, sealed)
 			s.dist.Unpin(version)
@@ -628,12 +632,10 @@ func (s *DistributionSuite) TestPeek() {
 			s.SetupTest()
 			defer s.TearDownTest()
 
-			// peek during lock
 			s.dist.AddDistributions(tc.input...)
-			s.dist.mut.Lock()
+			s.dist.Flush()
 			sealed, _ := s.dist.PeekSegments(tc.readable)
 			s.compareSnapshotItems(tc.expected, sealed)
-			s.dist.mut.Unlock()
 		})
 	}
 }
@@ -698,6 +700,7 @@ func (s *DistributionSuite) TestMarkOfflineSegments() {
 				DroppedInTarget:       nil,
 			}, nil)
 			s.dist.MarkOfflineSegments(tc.offlines...)
+			s.dist.Flush()
 			s.Equal(tc.serviceable, s.dist.Serviceable())
 
 			for _, offline := range tc.offlines {

--- a/internal/querynodev2/delegator/distribution_test.go
+++ b/internal/querynodev2/delegator/distribution_test.go
@@ -1444,6 +1444,10 @@ func TestPinReadableSegments(t *testing.T) {
 			SealedSegmentRowCount: map[int64]int64{1: 100, 2: 100},
 			GrowingInTarget:       []int64{},
 		}, []int64{1})
+		// Flush pending snapshot and stop background goroutine to avoid
+		// data race with mockey patches in sub-tests.
+		dist.Flush()
+		dist.Close()
 		return dist
 	}
 
@@ -1527,6 +1531,10 @@ func TestPinReadableSegments_ServiceableLogic(t *testing.T) {
 		GrowingInTarget:       []int64{},
 	}, []int64{1})
 
+	// Stop background goroutine to avoid data race with mockey patches.
+	dist.Flush()
+	dist.Close()
+
 	// Test case: requireFullResult=true, Serviceable=false, GetLoadedRatio=1.0
 	// This tests the case where load ratio is satisfied but serviceable is false
 	mockServiceable := mockey.Mock((*channelQueryView).Serviceable).Return(false).Build()
@@ -1559,6 +1567,10 @@ func TestPinReadableSegments_LoadRatioLogic(t *testing.T) {
 		GrowingInTarget:       []int64{},
 	}, []int64{1})
 
+	// Stop background goroutine to avoid data race with mockey patches.
+	dist.Flush()
+	dist.Close()
+
 	// Test case: requireFullResult=false, loadRatioSatisfy=false
 	// This tests the case where partial result is requested but load ratio is insufficient
 	mockGetLoadedRatio := mockey.Mock((*channelQueryView).GetLoadedRatio).Return(0.3).Build()
@@ -1588,6 +1600,10 @@ func TestPinReadableSegments_EdgeCases(t *testing.T) {
 		SealedSegmentRowCount: map[int64]int64{1: 100},
 		GrowingInTarget:       []int64{},
 	}, []int64{1})
+
+	// Stop background goroutine to avoid data race with mockey patches.
+	dist.Flush()
+	dist.Close()
 
 	// Test case 1: requiredLoadRatio = 0.0 (edge case)
 	mockGetLoadedRatio := mockey.Mock((*channelQueryView).GetLoadedRatio).Return(0.0).Build()
@@ -1648,6 +1664,10 @@ func TestPinReadableSegments_PartialResultNotEmpty(t *testing.T) {
 		SealedSegmentRowCount: map[int64]int64{1: 100, 2: 100},
 		GrowingInTarget:       []int64{},
 	}, []int64{1})
+
+	// Stop background goroutine to avoid data race with mockey patches.
+	dist.Flush()
+	dist.Close()
 
 	// Call PinReadableSegments with partial result enabled (requiredLoadRatio < 1.0)
 	sealed, growing, _, _, err := dist.PinReadableSegments(0.8, 1)

--- a/internal/querynodev2/services_test.go
+++ b/internal/querynodev2/services_test.go
@@ -2137,11 +2137,14 @@ func (suite *ServiceSuite) TestSyncDistribution_ReleaseResultCheck() {
 	suite.TestWatchDmChannelsInt64()
 	suite.TestLoadSegments_Int64()
 
-	delegator, ok := suite.node.delegators.Get(suite.vchannel)
+	dlg, ok := suite.node.delegators.Get(suite.vchannel)
 	suite.True(ok)
-	sealedSegments, _ := delegator.GetSegmentInfo(false)
-	// 1 level 0 + 3 sealed segments
-	suite.Len(sealedSegments[0].Segments, 3)
+	// snapshot generation is async, wait for it to reflect loaded segments
+	var sealedSegments []delegator.SnapshotItem
+	suite.Require().Eventually(func() bool {
+		sealedSegments, _ = dlg.GetSegmentInfo(false)
+		return len(sealedSegments) > 0 && len(sealedSegments[0].Segments) == 3
+	}, time.Second, 10*time.Millisecond)
 
 	// data
 	req := &querypb.SyncDistributionRequest{
@@ -2164,7 +2167,7 @@ func (suite *ServiceSuite) TestSyncDistribution_ReleaseResultCheck() {
 	status, err := suite.node.SyncDistribution(ctx, req)
 	suite.NoError(err)
 	suite.Equal(commonpb.ErrorCode_Success, status.ErrorCode)
-	sealedSegments, _ = delegator.GetSegmentInfo(false)
+	sealedSegments, _ = dlg.GetSegmentInfo(false)
 	suite.Len(sealedSegments[0].Segments, 2)
 
 	releaseAction = &querypb.SyncAction{
@@ -2178,7 +2181,7 @@ func (suite *ServiceSuite) TestSyncDistribution_ReleaseResultCheck() {
 	status, err = suite.node.SyncDistribution(ctx, req)
 	suite.NoError(err)
 	suite.Equal(commonpb.ErrorCode_Success, status.ErrorCode)
-	sealedSegments, _ = delegator.GetSegmentInfo(false)
+	sealedSegments, _ = dlg.GetSegmentInfo(false)
 	suite.Len(sealedSegments[0].Segments, 1)
 }
 


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/48823
1. Async snapshot generation in distribution: move genSnapshot to a background goroutine, reducing lock hold time in AddDistributions, AddGrowing, MarkOfflineSegments, and RemoveDistributions.
2. Batch partition recovery in CollectionManager.Recover to reduce meta store write calls.
3. Remove embedded StreamingNode check in resource_manager.
4. Skip partition lookup in executor.getMetaInfo for loadMeta.
5. Fix proto.Clone scope in cluster.LoadSegments.
6. Downgrade schemaChangeMutex to RLock in addDistributionIfVersionOK.
7. Fix delegator Close order: stop snapshot loop before refunding.