### PR TITLE
test: fix SnapshotRestoreChecker row count mismatch in chaos test

### DIFF
--- a/tests/python_client/chaos/checker.py
+++ b/tests/python_client/chaos/checker.py
@@ -2758,19 +2758,23 @@ class SnapshotRestoreChecker(Checker):
                 self._do_dml_operations()
                 time.sleep(0.1)
 
-            # 2. Flush and capture state (no lock needed - this is our own collection)
+            # 2. Flush and create snapshot (no lock needed - this is our own collection)
             self.milvus_client.flush(collection_name=self.c_name)
             log.debug(f"Flushed collection {self.c_name}")
             time.sleep(1)
 
-            self._capture_snapshot_state()
-            row_count_before = self.snapshot_row_count
-            log.info(f"State before snapshot: row_count={row_count_before}, sample_pks={len(self.snapshot_sample_pks)}")
-
-            # 3. Create snapshot
+            # 3. Create snapshot first, then capture state.
+            # Capturing state AFTER snapshot creation ensures the count query's
+            # guarantee timestamp >= snapshot's timestamp, so the count reflects
+            # at least all data the snapshot contains. Since no DML happens between
+            # snapshot creation and the count, they will match exactly.
             self.snapshot_name = cf.gen_unique_str("snapshot_")
             self.milvus_client.create_snapshot(self.c_name, self.snapshot_name)
             log.info(f"Created snapshot {self.snapshot_name} for collection {self.c_name}")
+
+            self._capture_snapshot_state()
+            row_count_before = self.snapshot_row_count
+            log.info(f"State after snapshot: row_count={row_count_before}, sample_pks={len(self.snapshot_sample_pks)}")
 
             # 4. Restore to new collection
             self.restored_collection = cf.gen_unique_str("restored_")


### PR DESCRIPTION
## Summary

Fix false `Row count mismatch` failures in `SnapshotRestoreChecker` by reordering the state capture to happen **after** snapshot creation instead of before.

**Root cause**: The checker captured `count(*)` at timestamp T1, then created the snapshot at T2 > T1. Under Milvus's streaming architecture, data that was flushed but not yet visible at T1's guarantee timestamp could be captured by the snapshot at T2, causing `actual > expected` mismatches (typically +3 to +16 rows).

**Fix**: Move `_capture_snapshot_state()` to after `create_snapshot()`. Since:
1. The checker uses an independent collection with no concurrent DML after flush
2. The count query's guarantee timestamp T2 >= snapshot's timestamp T1
3. No new writes happen between snapshot and count

The count will exactly match the snapshot's data.

**Evidence from chaos-test-cron #24383**: 10 mismatch instances occurred both before and after chaos injection, confirming this is a checker timing issue, not a server bug:
```
04:44:54  expected=2960  actual=2970  diff=+10
04:48:08  expected=2990  actual=3001  diff=+11
05:19:02  expected=2991  actual=2998  diff=+7
05:22:30  expected=2976  actual=2992  diff=+16
...
```

## Test plan

- [ ] Run chaos test with `pod-failure` chaos type and verify no `Row count mismatch` errors from `SnapshotRestoreChecker`
- [ ] Verify `SnapshotRestoreChecker` still correctly detects real data corruption (e.g., by manually injecting a mismatch)