### PR TITLE
feat: add function field backfill - Part 3 (#48809)

### DIFF
--- a/internal/datacoord/compaction_inspector.go
+++ b/internal/datacoord/compaction_inspector.go
@@ -45,6 +45,7 @@ var maxCompactionTaskExecutionDuration = map[datapb.CompactionType]time.Duration
 	datapb.CompactionType_Level0DeleteCompaction: 30 * time.Minute,
 	datapb.CompactionType_ClusteringCompaction:   60 * time.Minute,
 	datapb.CompactionType_SortCompaction:         20 * time.Minute,
+	datapb.CompactionType_BackfillCompaction:     30 * time.Minute,
 }
 
 type CompactionInspector interface {
@@ -221,7 +222,7 @@ func (c *compactionInspector) schedule() []CompactionTask {
 		switch t.GetTaskProto().GetType() {
 		case datapb.CompactionType_Level0DeleteCompaction:
 			l0ChannelExcludes.Insert(t.GetTaskProto().GetChannel())
-		case datapb.CompactionType_MixCompaction, datapb.CompactionType_SortCompaction:
+		case datapb.CompactionType_MixCompaction, datapb.CompactionType_SortCompaction, datapb.CompactionType_BackfillCompaction:
 			mixChannelExcludes.Insert(t.GetTaskProto().GetChannel())
 			mixLabelExcludes.Insert(t.GetLabel())
 		case datapb.CompactionType_ClusteringCompaction:
@@ -262,7 +263,10 @@ func (c *compactionInspector) schedule() []CompactionTask {
 			}
 			l0ChannelExcludes.Insert(t.GetTaskProto().GetChannel())
 			selected = append(selected, t)
-		case datapb.CompactionType_MixCompaction, datapb.CompactionType_SortCompaction:
+		case datapb.CompactionType_MixCompaction, datapb.CompactionType_SortCompaction, datapb.CompactionType_BackfillCompaction:
+			// BackfillCompaction shares the same exclusion rules as Mix/Sort:
+			// - Channel-level mutual exclusion with L0 (L0 may write delta logs to any segment on the channel)
+			// - Label-level exclusion registered for Clustering awareness
 			if l0ChannelExcludes.Contain(t.GetTaskProto().GetChannel()) {
 				excluded = append(excluded, t)
 				continue
@@ -587,6 +591,8 @@ func (c *compactionInspector) createCompactTask(t *datapb.CompactionTask) (Compa
 		task = newL0CompactionTask(t, c.allocator, c.meta)
 	case datapb.CompactionType_ClusteringCompaction:
 		task = newClusteringCompactionTask(t, c.allocator, c.meta, c.handler, c.analyzeScheduler)
+	case datapb.CompactionType_BackfillCompaction:
+		task = newBackfillCompactionTask(t, c.allocator, c.meta, c.ievm, t.GetDiffFunctions())
 	default:
 		return nil, merr.WrapErrIllegalCompactionPlan("illegal compaction type")
 	}

--- a/internal/datacoord/compaction_inspector_test.go
+++ b/internal/datacoord/compaction_inspector_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/milvus-io/milvus/internal/metastore/kv/datacoord"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	taskcommon "github.com/milvus-io/milvus/pkg/v2/taskcommon"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/metautil"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
@@ -1078,4 +1079,44 @@ func TestGetCompactionTasksNum(t *testing.T) {
 		i := handler.getCompactionTasksNum(CollectionIDCompactionTaskFilter(1), L0CompactionCompactionTaskFilter())
 		assert.Equal(t, 1, i)
 	})
+}
+
+func (s *CompactionPlanHandlerSuite) TestCreateCompactTask_BackfillCompaction() {
+	s.SetupTest()
+	s.mockMeta.EXPECT().CheckAndSetSegmentsCompacting(mock.Anything, mock.Anything).Return(true, true).Maybe()
+
+	mockScheduler := task.NewMockGlobalScheduler(s.T())
+	mockScheduler.EXPECT().Enqueue(mock.Anything).Maybe()
+	handler := newCompactionInspector(s.mockMeta, s.mockAlloc, nil, mockScheduler, mockScheduler, newMockVersionManager())
+
+	t := &datapb.CompactionTask{
+		TriggerID: 1,
+		PlanID:    10,
+		Channel:   "ch-1",
+		Type:      datapb.CompactionType_BackfillCompaction,
+	}
+
+	compactTask, err := handler.createCompactTask(t)
+	s.NoError(err)
+	s.NotNil(compactTask)
+	s.Equal(datapb.CompactionType_BackfillCompaction, compactTask.GetTaskProto().GetType())
+}
+
+func (s *CompactionPlanHandlerSuite) TestCreateCompactTask_UnknownType() {
+	s.SetupTest()
+
+	mockScheduler := task.NewMockGlobalScheduler(s.T())
+	handler := newCompactionInspector(s.mockMeta, s.mockAlloc, nil, mockScheduler, mockScheduler, newMockVersionManager())
+
+	t := &datapb.CompactionTask{
+		TriggerID: 2,
+		PlanID:    20,
+		Channel:   "ch-1",
+		Type:      datapb.CompactionType(9999),
+	}
+
+	compactTask, err := handler.createCompactTask(t)
+	s.Nil(compactTask)
+	s.Error(err)
+	s.True(errors.Is(err, merr.ErrIllegalCompactionPlan))
 }

--- a/internal/datacoord/compaction_l0_view.go
+++ b/internal/datacoord/compaction_l0_view.go
@@ -25,6 +25,10 @@ type LevelZeroCompactionView struct {
 
 var _ CompactionView = (*LevelZeroCompactionView)(nil)
 
+// IsInlineExecutable returns false: L0 compaction is real compaction work that must
+// be dispatched to the inspector.
+func (v *LevelZeroCompactionView) IsInlineExecutable() bool { return false }
+
 func (v *LevelZeroCompactionView) String() string {
 	l0strings := lo.Map(v.l0Segments, func(v *SegmentView, _ int) string {
 		return v.LevelZeroString()

--- a/internal/datacoord/compaction_policy_backfill.go
+++ b/internal/datacoord/compaction_policy_backfill.go
@@ -1,0 +1,319 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datacoord
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/datacoord/allocator"
+	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+)
+
+// FuncDiff represents the differences in functions between two schemas.
+type FuncDiff struct {
+	Added []*schemapb.FunctionSchema
+}
+
+type backfillCompactionPolicy struct {
+	meta      *meta
+	handler   Handler
+	allocator allocator.Allocator
+}
+
+// Ensure backfillCompactionPolicy implements CompactionPolicy interface
+var _ CompactionPolicy = (*backfillCompactionPolicy)(nil)
+
+func newBackfillCompactionPolicy(meta *meta, allocator allocator.Allocator, handler Handler) *backfillCompactionPolicy {
+	return &backfillCompactionPolicy{meta: meta, allocator: allocator, handler: handler}
+}
+
+func (policy *backfillCompactionPolicy) Enable() bool {
+	// Always enabled: both metadata-only and physical backfill are correctness requirements.
+	// Without backfill, segments can never reconcile missing function output fields and
+	// schema version consistency will never be reached, blocking GetCollectionStatistics.
+	return true
+}
+
+func (policy *backfillCompactionPolicy) Name() string {
+	return "BackfillCompaction"
+}
+
+// getMissingFunctions checks which functions in the collection schema have output fields
+// missing from the segment's binlogs. Returns the list of functions that need backfill.
+func (policy *backfillCompactionPolicy) getMissingFunctions(segment *SegmentInfo, schema *schemapb.CollectionSchema) []*schemapb.FunctionSchema {
+	existingFields := getSegmentBinlogFields(segment)
+	var missing []*schemapb.FunctionSchema
+	for _, fn := range schema.GetFunctions() {
+		for _, outputFieldID := range fn.GetOutputFieldIds() {
+			if _, ok := existingFields[outputFieldID]; !ok {
+				missing = append(missing, fn)
+				break // one missing output field is enough to mark this function
+			}
+		}
+	}
+	return missing
+}
+
+// staleFlushedSegments returns the flushed segments for collectionID whose SchemaVersion
+// lags behind collectionSchemaVersion. L0 segments are excluded (deletes only, no data).
+func (policy *backfillCompactionPolicy) staleFlushedSegments(collectionID int64, collectionSchemaVersion int32) []*chanPartSegments {
+	return GetSegmentsChanPart(policy.meta, collectionID, SegmentFilterFunc(func(segment *SegmentInfo) bool {
+		return isSegmentHealthy(segment) &&
+			isFlushed(segment) &&
+			!segment.isCompacting &&
+			!segment.GetIsImporting() &&
+			!segment.GetIsInvisible() &&
+			segment.GetLevel() != datapb.SegmentLevel_L0 &&
+			segment.GetSchemaVersion() < collectionSchemaVersion
+	}))
+}
+
+// TriggerInline returns metadata-only backfill views that can be applied without
+// consuming inspector slots. Two cases qualify:
+//  1. DoPhysicalBackfill=false: schema-only change, no function output to compute.
+//  2. DoPhysicalBackfill=true but all function outputs already present in binlogs:
+//     stale SchemaVersion anomaly — self-heal by bumping the version in-place.
+//
+// TriggerInline is called before the inspector isFull() check so these lightweight
+// updates always proceed regardless of compaction queue capacity.
+func (policy *backfillCompactionPolicy) TriggerInline(ctx context.Context) (map[CompactionTriggerType][]CompactionView, error) {
+	collections := policy.meta.GetCollections()
+	events := make(map[CompactionTriggerType][]CompactionView)
+
+	for _, collection := range collections {
+		collectionID := collection.ID
+		collectionSchemaVersion := collection.Schema.GetVersion()
+		doPhysicalBackfill := collection.Schema.GetDoPhysicalBackfill()
+		partSegments := policy.staleFlushedSegments(collectionID, collectionSchemaVersion)
+
+		var views []CompactionView
+		for _, group := range partSegments {
+			for _, segment := range group.segments {
+				segmentID := segment.GetID()
+				segmentViews := GetViewsByInfo(segment)
+				if len(segmentViews) == 0 {
+					log.Ctx(ctx).Warn("GetViewsByInfo returned empty views, skip segment",
+						zap.Int64("segmentID", segmentID))
+					continue
+				}
+				if len(segmentViews) != 1 {
+					log.Ctx(ctx).Warn("GetViewsByInfo returned unexpected view count, using first view only",
+						zap.Int64("segmentID", segmentID),
+						zap.Int("viewCount", len(segmentViews)))
+				}
+
+				// Case 1: no physical data to rewrite — bump SchemaVersion only.
+				if !doPhysicalBackfill {
+					views = append(views, &BackfillSegmentsView{
+						label:               segmentViews[0].label,
+						segments:            segmentViews,
+						inlineMetaOnly:      true,
+						targetSchemaVersion: collectionSchemaVersion,
+					})
+					continue
+				}
+
+				// Case 2: physical mode but all function outputs already present — self-heal.
+				missingFunctions := policy.getMissingFunctions(segment, collection.Schema)
+				if len(missingFunctions) == 0 {
+					log.Ctx(ctx).Error("backfill: segment has all function output fields but schema_version is stale, self-healing via inline meta update",
+						zap.Int64("segmentID", segmentID),
+						zap.Int64("collectionID", collectionID),
+						zap.Int32("segmentSchemaVersion", segment.GetSchemaVersion()),
+						zap.Int32("collectionSchemaVersion", collectionSchemaVersion))
+					views = append(views, &BackfillSegmentsView{
+						label:               segmentViews[0].label,
+						segments:            segmentViews,
+						inlineMetaOnly:      true,
+						targetSchemaVersion: collectionSchemaVersion,
+					})
+				}
+				// Segments with missing functions are handled by Trigger() (physical backfill).
+			}
+		}
+		if len(views) > 0 {
+			events[TriggerTypeBackfill] = append(events[TriggerTypeBackfill], views...)
+		}
+	}
+	return events, nil
+}
+
+// Trigger returns physical backfill views for segments that are missing function output
+// fields. It is only called when the inspector has available capacity (after TriggerInline
+// and the isFull() gate in handleTicker).
+func (policy *backfillCompactionPolicy) Trigger(ctx context.Context) (map[CompactionTriggerType][]CompactionView, error) {
+	collections := policy.meta.GetCollections()
+	events := make(map[CompactionTriggerType][]CompactionView)
+
+	for _, collection := range collections {
+		if !collection.Schema.GetDoPhysicalBackfill() {
+			// Metadata-only collections are handled entirely by TriggerInline.
+			continue
+		}
+		collectionID := collection.ID
+		collectionSchemaVersion := collection.Schema.GetVersion()
+		partSegments := policy.staleFlushedSegments(collectionID, collectionSchemaVersion)
+
+		var views []CompactionView
+		// triggerID is allocated per collection so tasks belonging to the same collection
+		// can be grouped and queried independently. Lazy-allocated on the first segment
+		// that actually needs a physical backfill task.
+		var collectionTriggerID int64
+		for _, group := range partSegments {
+			for _, segment := range group.segments {
+				segmentID := segment.GetID()
+				missingFunctions := policy.getMissingFunctions(segment, collection.Schema)
+				if len(missingFunctions) == 0 {
+					// Self-heal case — already handled by TriggerInline, skip here.
+					continue
+				}
+				// checkSchemaVersionConsistencyAtRootCoord guarantees the cluster-wide
+				// schema version increments by exactly 1 per DDL, and a single DDL adds
+				// at most one function. More than one missing function is therefore an
+				// invariant violation — skip the segment rather than silently backfilling
+				// only part of the missing state.
+				if len(missingFunctions) > 1 {
+					log.Ctx(ctx).Error("backfill: segment is missing more than one function output field — invariant violation, skipping",
+						zap.Int64("segmentID", segmentID),
+						zap.Int64("collectionID", collectionID),
+						zap.Int32("segmentSchemaVersion", segment.GetSchemaVersion()),
+						zap.Int32("collectionSchemaVersion", collectionSchemaVersion),
+						zap.Int("missingFunctionCount", len(missingFunctions)))
+					continue
+				}
+
+				segmentViews := GetViewsByInfo(segment)
+				if len(segmentViews) == 0 {
+					log.Ctx(ctx).Warn("GetViewsByInfo returned empty views, skip segment",
+						zap.Int64("segmentID", segmentID))
+					continue
+				}
+				if len(segmentViews) != 1 {
+					log.Ctx(ctx).Warn("GetViewsByInfo returned unexpected view count, using first view only",
+						zap.Int64("segmentID", segmentID),
+						zap.Int("viewCount", len(segmentViews)))
+				}
+
+				if collectionTriggerID == 0 {
+					id, err := policy.allocator.AllocID(ctx)
+					if err != nil {
+						log.Ctx(ctx).Warn("Failed to allocate triggerID for backfill, skip remaining segments in current group",
+							zap.Int64("collectionID", collectionID),
+							zap.Error(err))
+						break
+					}
+					collectionTriggerID = id
+				}
+				backfillFunc := missingFunctions[0]
+				log.Ctx(ctx).Info("Found segment missing function output fields, do physical backfill",
+					zap.Int64("segmentID", segmentID),
+					zap.Int64("collectionID", collectionID),
+					zap.Int32("segmentSchemaVersion", segment.GetSchemaVersion()),
+					zap.Int32("collectionSchemaVersion", collectionSchemaVersion),
+					zap.String("backfillFunction", backfillFunc.GetName()))
+				views = append(views, &BackfillSegmentsView{
+					label:     segmentViews[0].label,
+					segments:  segmentViews,
+					triggerID: collectionTriggerID,
+					funcDiff:  &FuncDiff{Added: []*schemapb.FunctionSchema{backfillFunc}},
+					schema:    collection.Schema,
+				})
+			}
+		}
+		if len(views) > 0 {
+			events[TriggerTypeBackfill] = append(events[TriggerTypeBackfill], views...)
+		}
+	}
+	return events, nil
+}
+
+type BackfillSegmentsView struct {
+	label     *CompactionGroupLabel
+	segments  []*SegmentView
+	triggerID int64
+	funcDiff  *FuncDiff
+
+	// inlineMetaOnly marks this view as inline-executable: the trigger manager
+	// applies targetSchemaVersion to each segment via meta.UpdateSegment without
+	// dispatching any compaction task. funcDiff is unused on this path. Set when
+	// the segment needs no physical backfill (DoPhysicalBackfill=false on the
+	// collection, or all required function output fields are already present in
+	// the segment's binlogs).
+	inlineMetaOnly      bool
+	targetSchemaVersion int32
+
+	// schema is the collection schema captured at policy-scan time. Used as
+	// task.Schema in SubmitBackfillViewToScheduler so that completeBackfillCompactionMutation
+	// advances the segment's SchemaVersion only to the version that was actually
+	// backfilled — not to a newer version if the live collection raced ahead between
+	// scan and submission (possible before the cluster-wide gate in PR #48989 lands).
+	schema *schemapb.CollectionSchema
+}
+
+var _ CompactionView = (*BackfillSegmentsView)(nil)
+
+func (v *BackfillSegmentsView) GetGroupLabel() *CompactionGroupLabel {
+	return v.label
+}
+
+func (v *BackfillSegmentsView) GetSegmentsView() []*SegmentView {
+	return v.segments
+}
+
+func (v *BackfillSegmentsView) Append(segments ...*SegmentView) {
+	v.segments = append(v.segments, segments...)
+}
+
+func (v *BackfillSegmentsView) String() string {
+	if v.inlineMetaOnly {
+		return fmt.Sprintf("BackfillSegmentsView(meta-only): label=%s, segments=%d, targetSchemaVersion=%d",
+			v.label.Key(), len(v.segments), v.targetSchemaVersion)
+	}
+	return fmt.Sprintf("BackfillSegmentsView: label=%s, segments=%d, triggerID=%d",
+		v.label.Key(), len(v.segments), v.triggerID)
+}
+
+func (v *BackfillSegmentsView) Trigger() (CompactionView, string) {
+	return v, "backfill schema version mismatch"
+}
+
+func (v *BackfillSegmentsView) ForceTrigger() (CompactionView, string) {
+	return v.Trigger()
+}
+
+// ForceTriggerAll returns a single-element slice intentionally: the backfill policy
+// creates one BackfillSegmentsView per segment, so each view already represents the
+// smallest unit of work. Unlike LevelZeroCompactionView or ForceMergeSegmentView
+// which aggregate many segments and need multi-round splitting, there is nothing to
+// split further here.
+func (v *BackfillSegmentsView) ForceTriggerAll() ([]CompactionView, string) {
+	view, reason := v.Trigger()
+	return []CompactionView{view}, reason
+}
+
+func (v *BackfillSegmentsView) GetTriggerID() int64 {
+	return v.triggerID
+}
+
+func (v *BackfillSegmentsView) IsInlineExecutable() bool {
+	return v.inlineMetaOnly
+}

--- a/internal/datacoord/compaction_policy_backfill_test.go
+++ b/internal/datacoord/compaction_policy_backfill_test.go
@@ -1,0 +1,1004 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datacoord
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/datacoord/allocator"
+	"github.com/milvus-io/milvus/internal/metastore/mocks"
+	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
+)
+
+func TestBackfillCompactionPolicySuite(t *testing.T) {
+	suite.Run(t, new(BackfillCompactionPolicySuite))
+}
+
+type BackfillCompactionPolicySuite struct {
+	suite.Suite
+
+	mockAlloc      *allocator.MockAllocator
+	handler        *NMockHandler
+	testLabel      *CompactionGroupLabel
+	backfillPolicy *backfillCompactionPolicy
+}
+
+func (s *BackfillCompactionPolicySuite) SetupTest() {
+	s.testLabel = &CompactionGroupLabel{
+		CollectionID: 1,
+		PartitionID:  10,
+		Channel:      "ch-1",
+	}
+
+	segments := genSegmentsForMeta(s.testLabel)
+	mockCatalog := mocks.NewDataCoordCatalog(s.T())
+	meta := &meta{
+		segments:    NewSegmentsInfo(),
+		collections: typeutil.NewConcurrentMap[UniqueID, *collectionInfo](),
+		catalog:     mockCatalog,
+	}
+	for id, segment := range segments {
+		meta.segments.SetSegment(id, segment)
+	}
+
+	s.mockAlloc = newMockAllocator(s.T())
+	mockHandler := NewNMockHandler(s.T())
+	s.handler = mockHandler
+	s.backfillPolicy = newBackfillCompactionPolicy(meta, s.mockAlloc, mockHandler)
+}
+
+func (s *BackfillCompactionPolicySuite) TestTrigger() {
+	// Test basic trigger with no collections
+	events, err := s.backfillPolicy.Trigger(context.Background())
+	s.NoError(err)
+	gotViews, ok := events[TriggerTypeBackfill]
+	s.False(ok)
+	s.Nil(gotViews)
+	s.Equal(0, len(gotViews))
+}
+
+func (s *BackfillCompactionPolicySuite) TestBackfillSegmentsViewBasic() {
+	view := &BackfillSegmentsView{
+		label: &CompactionGroupLabel{
+			CollectionID: 1,
+			PartitionID:  10,
+			Channel:      "ch-1",
+		},
+		segments:  []*SegmentView{},
+		triggerID: 100,
+	}
+
+	// Test GetGroupLabel
+	label := view.GetGroupLabel()
+	s.NotNil(label)
+	s.Equal(int64(1), label.CollectionID)
+
+	// Test GetSegmentsView
+	segments := view.GetSegmentsView()
+	s.NotNil(segments)
+	s.Equal(0, len(segments))
+
+	// Test Append
+	segmentView := &SegmentView{
+		ID:    101,
+		label: label,
+		State: commonpb.SegmentState_Flushed,
+		Level: datapb.SegmentLevel_L1,
+	}
+	view.Append(segmentView)
+	s.Equal(1, len(view.GetSegmentsView()))
+
+	// Test String
+	str := view.String()
+	s.Contains(str, "BackfillSegmentsView")
+	s.Contains(str, "segments=1")
+	s.Contains(str, "triggerID=100")
+
+	// Test Trigger
+	triggeredView, reason := view.Trigger()
+	s.NotNil(triggeredView)
+	s.Equal("backfill schema version mismatch", reason)
+
+	// Test ForceTrigger
+	forceView, reason := view.ForceTrigger()
+	s.NotNil(forceView)
+	s.Equal("backfill schema version mismatch", reason)
+
+	// Test ForceTriggerAll
+	forceViews, reason := view.ForceTriggerAll()
+	s.Equal(1, len(forceViews))
+	s.Equal("backfill schema version mismatch", reason)
+
+	// Test GetTriggerID
+	triggerID := view.GetTriggerID()
+	s.Equal(int64(100), triggerID)
+}
+
+func (s *BackfillCompactionPolicySuite) TestEnable() {
+	// Backfill policy is always enabled regardless of EnableAutoCompaction toggle.
+	// Metadata-only schema version updates are a correctness requirement.
+	// Physical backfill is guarded by EnableAutoCompaction inside Trigger() instead.
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key, "true")
+	defer paramtable.Get().Reset(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key)
+	s.True(s.backfillPolicy.Enable())
+
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key, "false")
+	s.True(s.backfillPolicy.Enable())
+	paramtable.Get().Reset(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key)
+}
+
+func (s *BackfillCompactionPolicySuite) TestName() {
+	// Test Name method
+	s.Equal("BackfillCompaction", s.backfillPolicy.Name())
+}
+
+func (s *BackfillCompactionPolicySuite) TestTriggerWithCollectionNoBackfill() {
+	ctx := context.Background()
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key, "true")
+	defer paramtable.Get().Reset(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key)
+
+	collID := int64(100)
+	// Create collection with schema version 1
+	coll := &collectionInfo{
+		ID: collID,
+		Schema: &schemapb.CollectionSchema{
+			Name:               "test_collection",
+			Description:        "test collection",
+			Version:            1,
+			DoPhysicalBackfill: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+				{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar},
+			},
+		},
+	}
+	s.backfillPolicy.meta.collections.Insert(collID, coll)
+
+	// Create segment with same schema version (no backfill needed)
+	segmentID := int64(101)
+	segment := &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:            segmentID,
+			CollectionID:  collID,
+			PartitionID:   10,
+			InsertChannel: "ch-1",
+			Level:         datapb.SegmentLevel_L1,
+			State:         commonpb.SegmentState_Flushed,
+			NumOfRows:     1000,
+			SchemaVersion: 1, // Same as collection schema version
+			StartPosition: &msgpb.MsgPosition{
+				Timestamp: 10000,
+			},
+			Binlogs: []*datapb.FieldBinlog{
+				{
+					FieldID: 101,
+					Binlogs: []*datapb.Binlog{
+						{LogPath: "test_path", EntriesNum: 1000},
+					},
+				},
+			},
+		},
+	}
+	s.backfillPolicy.meta.segments.SetSegment(segmentID, segment)
+
+	events, err := s.backfillPolicy.Trigger(ctx)
+	s.NoError(err)
+	gotViews, ok := events[TriggerTypeBackfill]
+	s.False(ok)
+	s.Nil(gotViews)
+}
+
+func (s *BackfillCompactionPolicySuite) TestTriggerWithCompactingSegment() {
+	ctx := context.Background()
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key, "true")
+	defer paramtable.Get().Reset(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key)
+
+	collID := int64(100)
+	coll := &collectionInfo{
+		ID: collID,
+		Schema: &schemapb.CollectionSchema{
+			Name:               "test_collection",
+			Description:        "test collection",
+			Version:            2,
+			DoPhysicalBackfill: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+				{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar},
+			},
+		},
+	}
+	s.backfillPolicy.meta.collections.Insert(collID, coll)
+
+	// Create segment that is compacting (should be filtered out)
+	segmentID := int64(101)
+	segment := &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:            segmentID,
+			CollectionID:  collID,
+			PartitionID:   10,
+			InsertChannel: "ch-1",
+			Level:         datapb.SegmentLevel_L1,
+			State:         commonpb.SegmentState_Flushed,
+			NumOfRows:     1000,
+			SchemaVersion: 1, // Outdated schema version
+			StartPosition: &msgpb.MsgPosition{
+				Timestamp: 10000,
+			},
+			Binlogs: []*datapb.FieldBinlog{
+				{
+					FieldID: 101,
+					Binlogs: []*datapb.Binlog{
+						{LogPath: "test_path", EntriesNum: 1000},
+					},
+				},
+			},
+		},
+	}
+	segment.isCompacting = true // Mark as compacting
+	s.backfillPolicy.meta.segments.SetSegment(segmentID, segment)
+
+	events, err := s.backfillPolicy.Trigger(ctx)
+	s.NoError(err)
+	gotViews, ok := events[TriggerTypeBackfill]
+	s.False(ok)
+	s.Nil(gotViews)
+}
+
+func (s *BackfillCompactionPolicySuite) TestTriggerWithImportingSegment() {
+	ctx := context.Background()
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key, "true")
+	defer paramtable.Get().Reset(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key)
+
+	collID := int64(100)
+	coll := &collectionInfo{
+		ID: collID,
+		Schema: &schemapb.CollectionSchema{
+			Name:               "test_collection",
+			Description:        "test collection",
+			Version:            2,
+			DoPhysicalBackfill: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+				{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar},
+			},
+		},
+	}
+	s.backfillPolicy.meta.collections.Insert(collID, coll)
+
+	// Create segment that is importing (should be filtered out)
+	segmentID := int64(101)
+	segment := &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:            segmentID,
+			CollectionID:  collID,
+			PartitionID:   10,
+			InsertChannel: "ch-1",
+			Level:         datapb.SegmentLevel_L1,
+			State:         commonpb.SegmentState_Flushed,
+			NumOfRows:     1000,
+			SchemaVersion: 1,    // Outdated schema version
+			IsImporting:   true, // Mark as importing
+			StartPosition: &msgpb.MsgPosition{
+				Timestamp: 10000,
+			},
+			Binlogs: []*datapb.FieldBinlog{
+				{
+					FieldID: 101,
+					Binlogs: []*datapb.Binlog{
+						{LogPath: "test_path", EntriesNum: 1000},
+					},
+				},
+			},
+		},
+	}
+	s.backfillPolicy.meta.segments.SetSegment(segmentID, segment)
+
+	events, err := s.backfillPolicy.Trigger(ctx)
+	s.NoError(err)
+	gotViews, ok := events[TriggerTypeBackfill]
+	s.False(ok)
+	s.Nil(gotViews)
+}
+
+func (s *BackfillCompactionPolicySuite) TestTriggerWithInvisibleSegment() {
+	ctx := context.Background()
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key, "true")
+	defer paramtable.Get().Reset(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key)
+
+	collID := int64(100)
+	coll := &collectionInfo{
+		ID: collID,
+		Schema: &schemapb.CollectionSchema{
+			Name:               "test_collection",
+			Description:        "test collection",
+			Version:            2,
+			DoPhysicalBackfill: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+				{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar},
+			},
+		},
+	}
+	s.backfillPolicy.meta.collections.Insert(collID, coll)
+
+	// Create segment that is invisible (should be filtered out)
+	segmentID := int64(101)
+	segment := &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:            segmentID,
+			CollectionID:  collID,
+			PartitionID:   10,
+			InsertChannel: "ch-1",
+			Level:         datapb.SegmentLevel_L1,
+			State:         commonpb.SegmentState_Flushed,
+			NumOfRows:     1000,
+			SchemaVersion: 1,    // Outdated schema version
+			IsInvisible:   true, // Mark as invisible
+			StartPosition: &msgpb.MsgPosition{
+				Timestamp: 10000,
+			},
+			Binlogs: []*datapb.FieldBinlog{
+				{
+					FieldID: 101,
+					Binlogs: []*datapb.Binlog{
+						{LogPath: "test_path", EntriesNum: 1000},
+					},
+				},
+			},
+		},
+	}
+	s.backfillPolicy.meta.segments.SetSegment(segmentID, segment)
+
+	events, err := s.backfillPolicy.Trigger(ctx)
+	s.NoError(err)
+	gotViews, ok := events[TriggerTypeBackfill]
+	s.False(ok)
+	s.Nil(gotViews)
+}
+
+func (s *BackfillCompactionPolicySuite) TestTriggerWithUnhealthySegment() {
+	ctx := context.Background()
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key, "true")
+	defer paramtable.Get().Reset(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key)
+
+	collID := int64(100)
+	coll := &collectionInfo{
+		ID: collID,
+		Schema: &schemapb.CollectionSchema{
+			Name:               "test_collection",
+			Description:        "test collection",
+			Version:            2,
+			DoPhysicalBackfill: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+				{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar},
+			},
+		},
+	}
+	s.backfillPolicy.meta.collections.Insert(collID, coll)
+
+	// Create segment that is not healthy (should be filtered out)
+	segmentID := int64(101)
+	segment := &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:            segmentID,
+			CollectionID:  collID,
+			PartitionID:   10,
+			InsertChannel: "ch-1",
+			Level:         datapb.SegmentLevel_L1,
+			State:         commonpb.SegmentState_Dropped, // Not healthy
+			NumOfRows:     1000,
+			SchemaVersion: 1, // Outdated schema version
+			StartPosition: &msgpb.MsgPosition{
+				Timestamp: 10000,
+			},
+			Binlogs: []*datapb.FieldBinlog{
+				{
+					FieldID: 101,
+					Binlogs: []*datapb.Binlog{
+						{LogPath: "test_path", EntriesNum: 1000},
+					},
+				},
+			},
+		},
+	}
+	s.backfillPolicy.meta.segments.SetSegment(segmentID, segment)
+
+	// AllocID should NOT be called: unhealthy segment is filtered before physical backfill.
+	events, err := s.backfillPolicy.Trigger(ctx)
+	s.NoError(err)
+	gotViews, ok := events[TriggerTypeBackfill]
+	s.False(ok)
+	s.Nil(gotViews)
+}
+
+func (s *BackfillCompactionPolicySuite) TestTriggerWithNonFlushedSegment() {
+	ctx := context.Background()
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key, "true")
+	defer paramtable.Get().Reset(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key)
+
+	collID := int64(100)
+	coll := &collectionInfo{
+		ID: collID,
+		Schema: &schemapb.CollectionSchema{
+			Name:               "test_collection",
+			Description:        "test collection",
+			Version:            2,
+			DoPhysicalBackfill: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+				{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar},
+			},
+		},
+	}
+	s.backfillPolicy.meta.collections.Insert(collID, coll)
+
+	// Create segment that is not flushed (should be filtered out)
+	segmentID := int64(101)
+	segment := &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:            segmentID,
+			CollectionID:  collID,
+			PartitionID:   10,
+			InsertChannel: "ch-1",
+			Level:         datapb.SegmentLevel_L1,
+			State:         commonpb.SegmentState_Growing, // Not flushed
+			NumOfRows:     1000,
+			SchemaVersion: 1, // Outdated schema version
+			StartPosition: &msgpb.MsgPosition{
+				Timestamp: 10000,
+			},
+			Binlogs: []*datapb.FieldBinlog{
+				{
+					FieldID: 101,
+					Binlogs: []*datapb.Binlog{
+						{LogPath: "test_path", EntriesNum: 1000},
+					},
+				},
+			},
+		},
+	}
+	s.backfillPolicy.meta.segments.SetSegment(segmentID, segment)
+
+	// AllocID should NOT be called: non-flushed segment is filtered before physical backfill.
+	events, err := s.backfillPolicy.Trigger(ctx)
+	s.NoError(err)
+	gotViews, ok := events[TriggerTypeBackfill]
+	s.False(ok)
+	s.Nil(gotViews)
+}
+
+func (s *BackfillCompactionPolicySuite) TestGetMissingFunctionsWithChildFields() {
+	// getMissingFunctions must use ChildFields (real field IDs) not FieldID (columnGroupID).
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "pk"},
+			{FieldID: 101, Name: "text"},
+			{FieldID: 102, Name: "sparse"},
+		},
+		Functions: []*schemapb.FunctionSchema{
+			{Name: "bm25_func", OutputFieldIds: []int64{102}},
+		},
+	}
+
+	// Segment with ChildFields containing field 102 → no missing functions
+	segPresent := &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			Binlogs: []*datapb.FieldBinlog{
+				{
+					FieldID:     0, // columnGroupID, not a real field ID
+					ChildFields: []int64{100, 101, 102},
+					Binlogs:     []*datapb.Binlog{{LogPath: "p1"}},
+				},
+			},
+		},
+	}
+	s.Empty(s.backfillPolicy.getMissingFunctions(segPresent, schema))
+
+	// Segment with ChildFields NOT containing field 102 → missing bm25_func
+	segMissing := &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			Binlogs: []*datapb.FieldBinlog{
+				{
+					FieldID:     0,
+					ChildFields: []int64{100, 101},
+					Binlogs:     []*datapb.Binlog{{LogPath: "p1"}},
+				},
+			},
+		},
+	}
+	missing := s.backfillPolicy.getMissingFunctions(segMissing, schema)
+	s.Equal(1, len(missing))
+	s.Equal("bm25_func", missing[0].GetName())
+
+	// Segment where FieldID happens to equal 102 (columnGroupID collision) but
+	// ChildFields does NOT contain 102 → must still report as missing
+	segFalsePositive := &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			Binlogs: []*datapb.FieldBinlog{
+				{
+					FieldID:     102, // columnGroupID, NOT real field 102
+					ChildFields: []int64{100, 101},
+					Binlogs:     []*datapb.Binlog{{LogPath: "p1"}},
+				},
+			},
+		},
+	}
+	missing = s.backfillPolicy.getMissingFunctions(segFalsePositive, schema)
+	s.Equal(1, len(missing))
+	s.Equal("bm25_func", missing[0].GetName())
+}
+
+func (s *BackfillCompactionPolicySuite) TestTriggerWithOutdatedSchemaVersion() {
+	ctx := context.Background()
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key, "true")
+	defer paramtable.Get().Reset(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key)
+
+	collID := int64(100)
+
+	// Create collection with schema version 2, with a BM25 function whose output field 102 is missing from segment
+	coll := &collectionInfo{
+		ID: collID,
+		Schema: &schemapb.CollectionSchema{
+			Name:               "test_collection",
+			Description:        "test collection",
+			Version:            2,
+			DoPhysicalBackfill: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+				{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar},
+				{FieldID: 102, Name: "sparse_vector", DataType: schemapb.DataType_SparseFloatVector},
+			},
+			Functions: []*schemapb.FunctionSchema{
+				{
+					Name:           "bm25_func",
+					OutputFieldIds: []int64{102},
+				},
+			},
+		},
+	}
+	s.backfillPolicy.meta.collections.Insert(collID, coll)
+
+	// Create segment with outdated schema version 1, binlogs only have field 101 (missing 102)
+	segmentID := int64(101)
+	segment := &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:            segmentID,
+			CollectionID:  collID,
+			PartitionID:   10,
+			InsertChannel: "ch-1",
+			Level:         datapb.SegmentLevel_L1,
+			State:         commonpb.SegmentState_Flushed,
+			NumOfRows:     1000,
+			SchemaVersion: 1,
+			StartPosition: &msgpb.MsgPosition{
+				Timestamp: 10000,
+			},
+			Binlogs: []*datapb.FieldBinlog{
+				{
+					FieldID:     0,
+					ChildFields: []int64{101},
+					Binlogs: []*datapb.Binlog{
+						{LogPath: "test_path", EntriesNum: 1000},
+					},
+				},
+			},
+		},
+	}
+	s.backfillPolicy.meta.segments.SetSegment(segmentID, segment)
+
+	// Setup allocator mock
+	s.mockAlloc.EXPECT().AllocID(mock.Anything).Return(int64(1), nil)
+
+	events, err := s.backfillPolicy.Trigger(ctx)
+	s.NoError(err)
+	gotViews, ok := events[TriggerTypeBackfill]
+	s.True(ok)
+	s.NotNil(gotViews)
+	s.Equal(1, len(gotViews))
+
+	// Verify the view
+	view, ok := gotViews[0].(*BackfillSegmentsView)
+	s.True(ok)
+	s.NotNil(view)
+	s.Equal(int64(1), view.GetTriggerID())
+	s.Equal(1, len(view.GetSegmentsView()))
+	s.Equal(segmentID, view.GetSegmentsView()[0].ID)
+	// Verify funcDiff contains the missing function
+	s.Equal(1, len(view.funcDiff.Added))
+	s.Equal("bm25_func", view.funcDiff.Added[0].GetName())
+}
+
+func (s *BackfillCompactionPolicySuite) TestTriggerInlineNoPhysicalBackfill() {
+	// TriggerInline must emit an inline-executable view when DoPhysicalBackfill=false.
+	// Trigger() skips this collection entirely; only TriggerInline handles it.
+	ctx := context.Background()
+
+	collID := int64(100)
+
+	// Create collection with schema version 2, but DoPhysicalBackfill = false
+	coll := &collectionInfo{
+		ID: collID,
+		Schema: &schemapb.CollectionSchema{
+			Name:               "test_collection",
+			Description:        "test collection",
+			Version:            2,
+			DoPhysicalBackfill: false, // No physical backfill
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+				{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar},
+			},
+		},
+	}
+	s.backfillPolicy.meta.collections.Insert(collID, coll)
+
+	// Create segment with outdated schema version 1
+	segmentID := int64(101)
+	segment := &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:            segmentID,
+			CollectionID:  collID,
+			PartitionID:   10,
+			InsertChannel: "ch-1",
+			Level:         datapb.SegmentLevel_L1,
+			State:         commonpb.SegmentState_Flushed,
+			NumOfRows:     1000,
+			SchemaVersion: 1, // Outdated schema version
+			StartPosition: &msgpb.MsgPosition{
+				Timestamp: 10000,
+			},
+			Binlogs: []*datapb.FieldBinlog{
+				{
+					FieldID: 101,
+					Binlogs: []*datapb.Binlog{
+						{LogPath: "test_path", EntriesNum: 1000},
+					},
+				},
+			},
+		},
+	}
+	s.backfillPolicy.meta.segments.SetSegment(segmentID, segment)
+
+	// AllocID must NOT be called: DoPhysicalBackfill=false produces only an
+	// inline-executable view (meta-only). TriggerInline handles it; Trigger() skips it.
+	events, err := s.backfillPolicy.TriggerInline(ctx)
+	s.NoError(err)
+
+	views, ok := events[TriggerTypeBackfill]
+	s.Require().True(ok)
+	s.Require().Len(views, 1)
+	bv, ok := views[0].(*BackfillSegmentsView)
+	s.Require().True(ok)
+	s.True(bv.IsInlineExecutable(), "meta-only path must be inline-executable")
+	s.Equal(int32(2), bv.targetSchemaVersion)
+	s.Require().Len(bv.GetSegmentsView(), 1)
+	s.Equal(segmentID, bv.GetSegmentsView()[0].ID)
+
+	// Trigger() must return nothing for this collection (DoPhysicalBackfill=false).
+	triggerEvents, err := s.backfillPolicy.Trigger(ctx)
+	s.NoError(err)
+	s.Empty(triggerEvents[TriggerTypeBackfill])
+}
+
+func (s *BackfillCompactionPolicySuite) TestTriggerInlineMetadataOnlyWithAutoCompactionDisabled() {
+	// Metadata-only backfill (DoPhysicalBackfill=false) must proceed via TriggerInline
+	// even when EnableAutoCompaction is disabled. Otherwise GetCollectionStatistics
+	// deadlocks waiting for schema version consistency that can never be achieved.
+	ctx := context.Background()
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key, "false")
+	defer paramtable.Get().Reset(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key)
+
+	collID := int64(100)
+	coll := &collectionInfo{
+		ID: collID,
+		Schema: &schemapb.CollectionSchema{
+			Name:               "test_collection",
+			Version:            2,
+			DoPhysicalBackfill: false,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+				{FieldID: 101, Name: "new_field", DataType: schemapb.DataType_VarChar},
+			},
+		},
+	}
+	s.backfillPolicy.meta.collections.Insert(collID, coll)
+
+	segmentID := int64(101)
+	segment := &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:            segmentID,
+			CollectionID:  collID,
+			PartitionID:   10,
+			InsertChannel: "ch-1",
+			Level:         datapb.SegmentLevel_L1,
+			State:         commonpb.SegmentState_Flushed,
+			NumOfRows:     1000,
+			SchemaVersion: 1,
+			StartPosition: &msgpb.MsgPosition{
+				Timestamp: 10000,
+			},
+			Binlogs: []*datapb.FieldBinlog{
+				{
+					FieldID: 101,
+					Binlogs: []*datapb.Binlog{
+						{LogPath: "test_path", EntriesNum: 1000},
+					},
+				},
+			},
+		},
+	}
+	s.backfillPolicy.meta.segments.SetSegment(segmentID, segment)
+
+	events, err := s.backfillPolicy.TriggerInline(ctx)
+	s.NoError(err)
+	// TriggerInline must emit inline-executable view regardless of EnableAutoCompaction.
+	views, ok := events[TriggerTypeBackfill]
+	s.Require().True(ok)
+	s.Require().Len(views, 1)
+	bv, ok := views[0].(*BackfillSegmentsView)
+	s.Require().True(ok)
+	s.True(bv.IsInlineExecutable(), "meta-only path must be inline-executable")
+	s.Equal(int32(2), bv.targetSchemaVersion)
+	s.Require().Len(bv.GetSegmentsView(), 1)
+	s.Equal(segmentID, bv.GetSegmentsView()[0].ID)
+}
+
+func (s *BackfillCompactionPolicySuite) TestTriggerPhysicalBackfillWithAutoCompactionDisabled() {
+	// Physical backfill must also proceed when EnableAutoCompaction is disabled.
+	// Backfill is a correctness requirement: without it, segments can never reconcile
+	// missing function output fields and schema version consistency will never be reached.
+	ctx := context.Background()
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key, "false")
+	defer paramtable.Get().Reset(paramtable.Get().DataCoordCfg.EnableAutoCompaction.Key)
+
+	collID := int64(100)
+	coll := &collectionInfo{
+		ID: collID,
+		Schema: &schemapb.CollectionSchema{
+			Name:               "test_collection",
+			Version:            2,
+			DoPhysicalBackfill: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+				{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar},
+				{FieldID: 102, Name: "sparse", DataType: schemapb.DataType_SparseFloatVector},
+			},
+			Functions: []*schemapb.FunctionSchema{
+				{
+					Name:           "bm25_func",
+					OutputFieldIds: []int64{102},
+				},
+			},
+		},
+	}
+	s.backfillPolicy.meta.collections.Insert(collID, coll)
+
+	segmentID := int64(101)
+	segment := &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:            segmentID,
+			CollectionID:  collID,
+			PartitionID:   10,
+			InsertChannel: "ch-1",
+			Level:         datapb.SegmentLevel_L1,
+			State:         commonpb.SegmentState_Flushed,
+			NumOfRows:     1000,
+			SchemaVersion: 1,
+			StartPosition: &msgpb.MsgPosition{
+				Timestamp: 10000,
+			},
+			Binlogs: []*datapb.FieldBinlog{
+				{
+					FieldID: 101,
+					Binlogs: []*datapb.Binlog{
+						{LogPath: "test_path", EntriesNum: 1000},
+					},
+				},
+			},
+		},
+	}
+	s.backfillPolicy.meta.segments.SetSegment(segmentID, segment)
+
+	// AllocID should be called: physical backfill proceeds even with auto compaction disabled
+	s.mockAlloc.EXPECT().AllocID(mock.Anything).Return(int64(1), nil)
+
+	events, err := s.backfillPolicy.Trigger(ctx)
+	s.NoError(err)
+	gotViews, ok := events[TriggerTypeBackfill]
+	s.True(ok)
+	s.NotNil(gotViews)
+	s.Equal(1, len(gotViews))
+
+	view, ok := gotViews[0].(*BackfillSegmentsView)
+	s.True(ok)
+	s.Equal(int64(1), view.GetTriggerID())
+	s.Equal(1, len(view.GetSegmentsView()))
+	s.Equal(segmentID, view.GetSegmentsView()[0].ID)
+	s.Equal("bm25_func", view.funcDiff.Added[0].GetName())
+}
+
+// TestSchemaFrozenAtScanTime verifies that physical-backfill views capture the
+// collection schema at scan time. SubmitBackfillViewToScheduler uses this frozen
+// schema for task.Schema, preventing premature schema-version advancement when the
+// live collection races ahead between scan and submission.
+func (s *BackfillCompactionPolicySuite) TestSchemaFrozenAtScanTime() {
+	ctx := context.Background()
+	collID := int64(200)
+	schemaV1 := &schemapb.CollectionSchema{
+		Version:            1,
+		DoPhysicalBackfill: true,
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+			{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar},
+			{FieldID: 102, Name: "sparse", DataType: schemapb.DataType_SparseFloatVector},
+		},
+		Functions: []*schemapb.FunctionSchema{
+			{Name: "bm25_v1", OutputFieldIds: []int64{102}},
+		},
+	}
+	s.backfillPolicy.meta.collections.Insert(collID, &collectionInfo{ID: collID, Schema: schemaV1})
+	segment := &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID: int64(201), CollectionID: collID, PartitionID: 10,
+			InsertChannel: "ch-1", Level: datapb.SegmentLevel_L1,
+			State: commonpb.SegmentState_Flushed, NumOfRows: 100,
+			SchemaVersion: 0,
+			StartPosition: &msgpb.MsgPosition{Timestamp: 1},
+			Binlogs: []*datapb.FieldBinlog{
+				{FieldID: 101, Binlogs: []*datapb.Binlog{{LogPath: "p", EntriesNum: 100}}},
+			},
+		},
+	}
+	s.backfillPolicy.meta.segments.SetSegment(int64(201), segment)
+	s.mockAlloc.EXPECT().AllocID(mock.Anything).Return(int64(1), nil)
+
+	events, err := s.backfillPolicy.Trigger(ctx)
+	s.NoError(err)
+	views, ok := events[TriggerTypeBackfill]
+	s.True(ok)
+	s.Len(views, 1)
+
+	bv, ok := views[0].(*BackfillSegmentsView)
+	s.True(ok)
+	// The frozen schema must match the collection state at scan time (v1), not any
+	// live version the collection might race to before SubmitBackfillViewToScheduler.
+	s.NotNil(bv.schema)
+	s.Equal(int32(1), bv.schema.GetVersion())
+}
+
+// TestMultipleMissingFunctionsSkipped verifies that a segment missing more than one
+// function output field is skipped entirely. checkSchemaVersionConsistencyAtRootCoord
+// guarantees schema version increments by exactly 1 per DDL and a single DDL adds at
+// most one function, so len(missingFunctions)>1 is an invariant violation that must not
+// be silently patched.
+func (s *BackfillCompactionPolicySuite) TestMultipleMissingFunctionsSkipped() {
+	ctx := context.Background()
+	collID := int64(300)
+
+	coll := &collectionInfo{
+		ID: collID,
+		Schema: &schemapb.CollectionSchema{
+			Name:               "test_multi_func",
+			Version:            2,
+			DoPhysicalBackfill: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+				{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar},
+				{FieldID: 102, Name: "sparse1", DataType: schemapb.DataType_SparseFloatVector},
+				{FieldID: 103, Name: "sparse2", DataType: schemapb.DataType_SparseFloatVector},
+			},
+			Functions: []*schemapb.FunctionSchema{
+				{Name: "func1", OutputFieldIds: []int64{102}},
+				{Name: "func2", OutputFieldIds: []int64{103}},
+			},
+		},
+	}
+	s.backfillPolicy.meta.collections.Insert(collID, coll)
+
+	// Segment at version=0, missing both function output fields (102 and 103).
+	segmentID := int64(301)
+	segment := &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID: segmentID, CollectionID: collID, PartitionID: 10,
+			InsertChannel: "ch-1", Level: datapb.SegmentLevel_L1,
+			State: commonpb.SegmentState_Flushed, NumOfRows: 100,
+			SchemaVersion: 0,
+			StartPosition: &msgpb.MsgPosition{Timestamp: 1},
+			Binlogs: []*datapb.FieldBinlog{
+				{FieldID: 101, Binlogs: []*datapb.Binlog{{LogPath: "p", EntriesNum: 100}}},
+			},
+		},
+	}
+	s.backfillPolicy.meta.segments.SetSegment(segmentID, segment)
+
+	events, err := s.backfillPolicy.Trigger(ctx)
+	s.NoError(err)
+	// Invariant violation: segment must be skipped, no view emitted.
+	s.Empty(events[TriggerTypeBackfill])
+}
+
+// TestTriggerInlineSelfHeal verifies the self-heal path: DoPhysicalBackfill=true but
+// segment already has all function output fields → stale SchemaVersion anomaly, fixed
+// via TriggerInline without dispatching a compaction task.
+func (s *BackfillCompactionPolicySuite) TestTriggerInlineSelfHeal() {
+	ctx := context.Background()
+	collID := int64(400)
+	coll := &collectionInfo{
+		ID: collID,
+		Schema: &schemapb.CollectionSchema{
+			Name:               "test_self_heal",
+			Version:            2,
+			DoPhysicalBackfill: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+				{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar},
+				{FieldID: 102, Name: "sparse", DataType: schemapb.DataType_SparseFloatVector},
+			},
+			Functions: []*schemapb.FunctionSchema{
+				{Name: "bm25_func", OutputFieldIds: []int64{102}},
+			},
+		},
+	}
+	s.backfillPolicy.meta.collections.Insert(collID, coll)
+
+	// Segment at version=1 (stale) but already has field 102 present in binlogs.
+	segmentID := int64(401)
+	segment := &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID: segmentID, CollectionID: collID, PartitionID: 10,
+			InsertChannel: "ch-1", Level: datapb.SegmentLevel_L1,
+			State: commonpb.SegmentState_Flushed, NumOfRows: 100,
+			SchemaVersion: 1, // stale
+			StartPosition: &msgpb.MsgPosition{Timestamp: 1},
+			Binlogs: []*datapb.FieldBinlog{
+				{
+					FieldID:     0,
+					ChildFields: []int64{101, 102}, // 102 already present
+					Binlogs:     []*datapb.Binlog{{LogPath: "p", EntriesNum: 100}},
+				},
+			},
+		},
+	}
+	s.backfillPolicy.meta.segments.SetSegment(segmentID, segment)
+
+	// TriggerInline must emit an inline-executable self-heal view (no AllocID call).
+	events, err := s.backfillPolicy.TriggerInline(ctx)
+	s.NoError(err)
+	views, ok := events[TriggerTypeBackfill]
+	s.Require().True(ok)
+	s.Require().Len(views, 1)
+	bv, ok := views[0].(*BackfillSegmentsView)
+	s.Require().True(ok)
+	s.True(bv.IsInlineExecutable(), "self-heal path must be inline-executable")
+	s.Equal(int32(2), bv.targetSchemaVersion)
+	s.Require().Len(bv.GetSegmentsView(), 1)
+	s.Equal(segmentID, bv.GetSegmentsView()[0].ID)
+
+	// Trigger() must return nothing for this segment (self-heal is TriggerInline only).
+	triggerEvents, err := s.backfillPolicy.Trigger(ctx)
+	s.NoError(err)
+	s.Empty(triggerEvents[TriggerTypeBackfill])
+}

--- a/internal/datacoord/compaction_policy_clustering.go
+++ b/internal/datacoord/compaction_policy_clustering.go
@@ -40,6 +40,9 @@ type clusteringCompactionPolicy struct {
 	handler   Handler
 }
 
+// Ensure clusteringCompactionPolicy implements CompactionPolicy interface
+var _ CompactionPolicy = (*clusteringCompactionPolicy)(nil)
+
 func newClusteringCompactionPolicy(meta *meta, allocator allocator.Allocator, handler Handler) *clusteringCompactionPolicy {
 	return &clusteringCompactionPolicy{meta: meta, allocator: allocator, handler: handler}
 }
@@ -48,6 +51,14 @@ func (policy *clusteringCompactionPolicy) Enable() bool {
 	return Params.DataCoordCfg.EnableAutoCompaction.GetAsBool() &&
 		Params.DataCoordCfg.ClusteringCompactionEnable.GetAsBool() &&
 		Params.DataCoordCfg.ClusteringCompactionAutoEnable.GetAsBool()
+}
+
+func (policy *clusteringCompactionPolicy) TriggerInline(_ context.Context) (map[CompactionTriggerType][]CompactionView, error) {
+	return nil, nil
+}
+
+func (policy *clusteringCompactionPolicy) Name() string {
+	return "ClusteringCompactionPolicy"
 }
 
 func (policy *clusteringCompactionPolicy) Trigger(ctx context.Context) (map[CompactionTriggerType][]CompactionView, error) {
@@ -180,6 +191,18 @@ func (policy *clusteringCompactionPolicy) triggerOneCollection(ctx context.Conte
 			}
 		}
 
+		// Intentionally check internal consistency (all segments share the same schema version)
+		// rather than requiring segments to match the collection schema version.
+		// Clustering before backfill is more efficient: merging N segments first reduces
+		// N separate backfill tasks to 1 backfill task on the merged result.
+		if !policy.checkGroupSchemaVersionInternallyConsistent(group) {
+			log.Debug("segments in group have inconsistent schema versions, skip clustering compaction for this group",
+				zap.Int64("collectionID", group.collectionID),
+				zap.Int64("partitionID", group.partitionID),
+				zap.String("channel", group.channelName))
+			continue
+		}
+
 		segmentViews := GetViewsByInfo(group.segments...)
 		view := &ClusteringSegmentsView{
 			label:              segmentViews[0].label,
@@ -193,6 +216,19 @@ func (policy *clusteringCompactionPolicy) triggerOneCollection(ctx context.Conte
 
 	log.Info("finish trigger collection clustering compaction", zap.Int("viewNum", len(views)))
 	return views, newTriggerID, nil
+}
+
+func (policy *clusteringCompactionPolicy) checkGroupSchemaVersionInternallyConsistent(group *chanPartSegments) bool {
+	if len(group.segments) == 0 {
+		return true
+	}
+	firstSchemaVersion := group.segments[0].GetSchemaVersion()
+	for _, segment := range group.segments {
+		if segment.GetSchemaVersion() != firstSchemaVersion {
+			return false
+		}
+	}
+	return true
 }
 
 func (policy *clusteringCompactionPolicy) collectionIsClusteringCompacting(collectionID UniqueID) (bool, int64) {
@@ -319,6 +355,9 @@ func triggerClusteringCompactionPolicy(ctx context.Context, meta *meta, collecti
 }
 
 var _ CompactionView = (*ClusteringSegmentsView)(nil)
+
+// IsInlineExecutable returns false: clustering compaction is real compaction work.
+func (v *ClusteringSegmentsView) IsInlineExecutable() bool { return false }
 
 type ClusteringSegmentsView struct {
 	label              *CompactionGroupLabel

--- a/internal/datacoord/compaction_policy_clustering_test.go
+++ b/internal/datacoord/compaction_policy_clustering_test.go
@@ -361,6 +361,78 @@ func (s *ClusteringCompactionPolicySuite) TestTriggerOneCollectionNormal() {
 	s.Equal(testLabel, view[0].GetGroupLabel())
 }
 
+func (s *ClusteringCompactionPolicySuite) TestCheckGroupSchemaVersionInternallyConsistent() {
+	// empty group is trivially consistent
+	s.True(s.clusteringCompactionPolicy.checkGroupSchemaVersionInternallyConsistent(
+		&chanPartSegments{segments: nil},
+	))
+
+	// single segment is trivially consistent
+	s.True(s.clusteringCompactionPolicy.checkGroupSchemaVersionInternallyConsistent(
+		&chanPartSegments{segments: []*SegmentInfo{
+			{SegmentInfo: &datapb.SegmentInfo{SchemaVersion: 3}},
+		}},
+	))
+
+	// all segments with the same schema version → consistent
+	s.True(s.clusteringCompactionPolicy.checkGroupSchemaVersionInternallyConsistent(
+		&chanPartSegments{segments: []*SegmentInfo{
+			{SegmentInfo: &datapb.SegmentInfo{SchemaVersion: 5}},
+			{SegmentInfo: &datapb.SegmentInfo{SchemaVersion: 5}},
+			{SegmentInfo: &datapb.SegmentInfo{SchemaVersion: 5}},
+		}},
+	))
+
+	// segments with different schema versions → inconsistent
+	s.False(s.clusteringCompactionPolicy.checkGroupSchemaVersionInternallyConsistent(
+		&chanPartSegments{segments: []*SegmentInfo{
+			{SegmentInfo: &datapb.SegmentInfo{SchemaVersion: 5}},
+			{SegmentInfo: &datapb.SegmentInfo{SchemaVersion: 6}},
+		}},
+	))
+}
+
+func (s *ClusteringCompactionPolicySuite) TestTriggerOneCollectionSkipsInconsistentSchemaGroup() {
+	paramtable.Get().Save(Params.DataCoordCfg.ClusteringCompactionNewDataSizeThreshold.Key, "0")
+	defer paramtable.Get().Reset(Params.DataCoordCfg.ClusteringCompactionNewDataSizeThreshold.Key)
+
+	testLabel := &CompactionGroupLabel{
+		CollectionID: 1,
+		PartitionID:  10,
+		Channel:      "ch-1",
+	}
+
+	s.meta.collections.Insert(testLabel.CollectionID, &collectionInfo{
+		ID:     testLabel.CollectionID,
+		Schema: newTestScalarClusteringKeySchema(),
+	})
+
+	segments := genSegmentsForMeta(testLabel)
+	// Force all segments to have mixed schema versions so the group is internally inconsistent
+	versionCounter := int32(0)
+	for id, segment := range segments {
+		versionCounter++
+		segment.SchemaVersion = versionCounter
+		segments[id] = segment
+	}
+	for id, segment := range segments {
+		s.meta.segments.SetSegment(id, segment)
+	}
+
+	s.handler.EXPECT().GetCollection(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, collectionID int64) (*collectionInfo, error) {
+		coll, exist := s.meta.collections.Get(collectionID)
+		if exist {
+			return coll, nil
+		}
+		return nil, nil
+	})
+
+	// Because the group has mixed schema versions, triggerOneCollection should skip it
+	view, _, err := s.clusteringCompactionPolicy.triggerOneCollection(context.TODO(), 1, false)
+	s.NoError(err)
+	s.Equal(0, len(view))
+}
+
 func (s *ClusteringCompactionPolicySuite) TestGetExpectedSegmentSize() {
 }
 

--- a/internal/datacoord/compaction_policy_l0.go
+++ b/internal/datacoord/compaction_policy_l0.go
@@ -25,6 +25,9 @@ type l0CompactionPolicy struct {
 	allocator         allocator.Allocator
 }
 
+// Ensure l0CompactionPolicy implements CompactionPolicy interface
+var _ CompactionPolicy = (*l0CompactionPolicy)(nil)
+
 func newL0CompactionPolicy(meta *meta, allocator allocator.Allocator) *l0CompactionPolicy {
 	return &l0CompactionPolicy{
 		meta:              meta,
@@ -35,6 +38,14 @@ func newL0CompactionPolicy(meta *meta, allocator allocator.Allocator) *l0Compact
 
 func (policy *l0CompactionPolicy) Enable() bool {
 	return Params.DataCoordCfg.EnableAutoCompaction.GetAsBool()
+}
+
+func (policy *l0CompactionPolicy) TriggerInline(_ context.Context) (map[CompactionTriggerType][]CompactionView, error) {
+	return nil, nil
+}
+
+func (policy *l0CompactionPolicy) Name() string {
+	return "L0Compaction"
 }
 
 // Notify policy to record the active updated(when adding a new L0 segment) collections.

--- a/internal/datacoord/compaction_policy_single.go
+++ b/internal/datacoord/compaction_policy_single.go
@@ -40,12 +40,23 @@ type singleCompactionPolicy struct {
 	handler   Handler
 }
 
+// Ensure singleCompactionPolicy implements CompactionPolicy interface
+var _ CompactionPolicy = (*singleCompactionPolicy)(nil)
+
 func newSingleCompactionPolicy(meta *meta, allocator allocator.Allocator, handler Handler) *singleCompactionPolicy {
 	return &singleCompactionPolicy{meta: meta, allocator: allocator, handler: handler}
 }
 
 func (policy *singleCompactionPolicy) Enable() bool {
 	return Params.DataCoordCfg.EnableAutoCompaction.GetAsBool()
+}
+
+func (policy *singleCompactionPolicy) TriggerInline(_ context.Context) (map[CompactionTriggerType][]CompactionView, error) {
+	return nil, nil
+}
+
+func (policy *singleCompactionPolicy) Name() string {
+	return "SingleCompactionPolicy"
 }
 
 func (policy *singleCompactionPolicy) Trigger(ctx context.Context) (map[CompactionTriggerType][]CompactionView, error) {
@@ -306,6 +317,9 @@ func (policy *singleCompactionPolicy) triggerOneCollection(ctx context.Context, 
 }
 
 var _ CompactionView = (*MixSegmentView)(nil)
+
+// IsInlineExecutable returns false: mix compaction is real compaction work.
+func (v *MixSegmentView) IsInlineExecutable() bool { return false }
 
 type MixSegmentView struct {
 	label         *CompactionGroupLabel

--- a/internal/datacoord/compaction_policy_storage_version.go
+++ b/internal/datacoord/compaction_policy_storage_version.go
@@ -51,8 +51,16 @@ func newStorageVersionUpgradePolicy(meta *meta, allocator allocator.Allocator, h
 	}
 }
 
+func (policy *storageVersionUpgradePolicy) Name() string {
+	return "storageVersionUpgrade"
+}
+
 func (policy *storageVersionUpgradePolicy) Enable() bool {
 	return paramtable.Get().DataCoordCfg.StorageVersionCompactionEnabled.GetAsBool()
+}
+
+func (policy *storageVersionUpgradePolicy) TriggerInline(_ context.Context) (map[CompactionTriggerType][]CompactionView, error) {
+	return nil, nil
 }
 
 func (policy *storageVersionUpgradePolicy) targetVersion() int64 {

--- a/internal/datacoord/compaction_queue.go
+++ b/internal/datacoord/compaction_queue.go
@@ -166,6 +166,8 @@ var (
 			return 1
 		case datapb.CompactionType_MixCompaction:
 			return 10
+		case datapb.CompactionType_BackfillCompaction:
+			return 10
 		case datapb.CompactionType_ClusteringCompaction:
 			return 100
 		default:
@@ -178,6 +180,8 @@ var (
 		case datapb.CompactionType_Level0DeleteCompaction:
 			return 10
 		case datapb.CompactionType_MixCompaction:
+			return 1
+		case datapb.CompactionType_BackfillCompaction:
 			return 1
 		case datapb.CompactionType_ClusteringCompaction:
 			return 100

--- a/internal/datacoord/compaction_task_backfill.go
+++ b/internal/datacoord/compaction_task_backfill.go
@@ -1,0 +1,422 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datacoord
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/samber/lo"
+	"go.uber.org/atomic"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/compaction"
+	"github.com/milvus-io/milvus/internal/datacoord/allocator"
+	"github.com/milvus-io/milvus/internal/datacoord/session"
+	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v2/taskcommon"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+)
+
+var _ CompactionTask = (*backfillCompactionTask)(nil)
+
+type backfillCompactionTask struct {
+	taskProto atomic.Value // *datapb.CompactionTask
+	allocator allocator.Allocator
+	meta      CompactionMeta
+	ievm      IndexEngineVersionManager
+	functions []*schemapb.FunctionSchema
+	times     *taskcommon.Times
+}
+
+func newBackfillCompactionTask(t *datapb.CompactionTask, allocator allocator.Allocator, meta CompactionMeta, ievm IndexEngineVersionManager, functions []*schemapb.FunctionSchema) *backfillCompactionTask {
+	task := &backfillCompactionTask{
+		allocator: allocator,
+		meta:      meta,
+		ievm:      ievm,
+		functions: functions,
+		times:     taskcommon.NewTimes(),
+	}
+	task.taskProto.Store(t)
+	return task
+}
+
+func (t *backfillCompactionTask) GetTaskID() int64 {
+	return t.GetTaskProto().GetPlanID()
+}
+
+func (t *backfillCompactionTask) GetTaskType() taskcommon.Type {
+	return taskcommon.Compaction
+}
+
+func (t *backfillCompactionTask) GetTaskState() taskcommon.State {
+	return taskcommon.FromCompactionState(t.GetTaskProto().GetState())
+}
+
+func (t *backfillCompactionTask) GetTaskProto() *datapb.CompactionTask {
+	return t.taskProto.Load().(*datapb.CompactionTask)
+}
+
+func (t *backfillCompactionTask) GetTaskSlot() int64 {
+	return paramtable.Get().DataCoordCfg.BackfillCompactionSlotUsage.GetAsInt64()
+}
+
+func (t *backfillCompactionTask) SetTaskTime(timeType taskcommon.TimeType, time time.Time) {
+	t.times.SetTaskTime(timeType, time)
+}
+
+func (t *backfillCompactionTask) GetTaskTime(timeType taskcommon.TimeType) time.Time {
+	return timeType.GetTaskTime(t.times)
+}
+
+func (t *backfillCompactionTask) GetTaskVersion() int64 {
+	return int64(t.GetTaskProto().GetRetryTimes())
+}
+
+func (t *backfillCompactionTask) BuildCompactionRequest() (*datapb.CompactionPlan, error) {
+	compactionParams, err := compaction.GenerateJSONParams()
+	if err != nil {
+		return nil, err
+	}
+	taskProto := t.GetTaskProto()
+	log := log.With(zap.Int64("triggerID", taskProto.GetTriggerID()), zap.Int64("PlanID", taskProto.GetPlanID()), zap.Int64("collectionID", taskProto.GetCollectionID()))
+	plan := &datapb.CompactionPlan{
+		PlanID:                    taskProto.GetPlanID(),
+		StartTime:                 taskProto.GetStartTime(),
+		Type:                      taskProto.GetType(),
+		Channel:                   taskProto.GetChannel(),
+		CollectionTtl:             taskProto.GetCollectionTtl(),
+		TotalRows:                 taskProto.GetTotalRows(),
+		Schema:                    taskProto.GetSchema(),
+		PreAllocatedSegmentIDs:    taskProto.GetPreAllocatedSegmentIDs(),
+		SlotUsage:                 t.GetSlotUsage(),
+		MaxSize:                   taskProto.GetMaxSize(),
+		JsonParams:                compactionParams,
+		CurrentScalarIndexVersion: t.ievm.GetCurrentScalarIndexEngineVersion(),
+		Functions:                 t.functions,
+	}
+	segments := make([]*SegmentInfo, 0, len(taskProto.GetInputSegments()))
+	for _, segID := range taskProto.GetInputSegments() {
+		segInfo := t.meta.GetHealthySegment(context.TODO(), segID)
+		if segInfo == nil {
+			return nil, merr.WrapErrSegmentNotFound(segID)
+		}
+		plan.SegmentBinlogs = append(plan.SegmentBinlogs, &datapb.CompactionSegmentBinlogs{
+			SegmentID:           segID,
+			CollectionID:        segInfo.GetCollectionID(),
+			PartitionID:         segInfo.GetPartitionID(),
+			Level:               segInfo.GetLevel(),
+			InsertChannel:       segInfo.GetInsertChannel(),
+			FieldBinlogs:        segInfo.GetBinlogs(),
+			Field2StatslogPaths: segInfo.GetStatslogs(),
+			Deltalogs:           segInfo.GetDeltalogs(),
+			IsSorted:            segInfo.GetIsSorted(),
+			IsSortedByNamespace: segInfo.GetIsSortedByNamespace(),
+			StorageVersion:      segInfo.GetStorageVersion(),
+			Manifest:            segInfo.GetManifestPath(),
+		})
+		segments = append(segments, segInfo)
+	}
+
+	logIDRange, err := PreAllocateBinlogIDs(t.allocator, segments)
+	if err != nil {
+		return nil, err
+	}
+	plan.PreAllocatedLogIDs = logIDRange
+	plan.BeginLogID = logIDRange.Begin
+	WrapPluginContext(taskProto.GetCollectionID(), taskProto.GetSchema().GetProperties(), plan)
+	log.Info("Compaction handler refreshed backfill compaction plan", zap.Int64("maxSize", plan.GetMaxSize()),
+		zap.Any("PreAllocatedLogIDs", logIDRange), zap.Int64s("inputSegments", taskProto.GetInputSegments()))
+	return plan, nil
+}
+
+func (t *backfillCompactionTask) GetSlotUsage() int64 {
+	return t.GetTaskSlot()
+}
+
+func (t *backfillCompactionTask) GetLabel() string {
+	return fmt.Sprintf("%d-%s", t.GetTaskProto().GetPartitionID(), t.GetTaskProto().GetChannel())
+}
+
+func (t *backfillCompactionTask) SetTask(task *datapb.CompactionTask) {
+	t.taskProto.Store(task)
+}
+
+func (t *backfillCompactionTask) ShadowClone(opts ...compactionTaskOpt) *datapb.CompactionTask {
+	cloned := proto.Clone(t.GetTaskProto()).(*datapb.CompactionTask)
+	for _, opt := range opts {
+		opt(cloned)
+	}
+	return cloned
+}
+
+func (t *backfillCompactionTask) SetNodeID(nodeID int64) error {
+	return t.updateAndSaveTaskMeta(setNodeID(nodeID))
+}
+
+func (t *backfillCompactionTask) NeedReAssignNodeID() bool {
+	return t.GetTaskProto().GetState() == datapb.CompactionTaskState_pipelining && (t.GetTaskProto().GetNodeID() == 0 || t.GetTaskProto().GetNodeID() == NullNodeID)
+}
+
+func (t *backfillCompactionTask) saveTaskMeta(task *datapb.CompactionTask) error {
+	return t.meta.SaveCompactionTask(context.TODO(), task)
+}
+
+func (t *backfillCompactionTask) SaveTaskMeta() error {
+	return t.saveTaskMeta(t.GetTaskProto())
+}
+
+func (t *backfillCompactionTask) Clean() bool {
+	return t.doClean() == nil
+}
+
+func (t *backfillCompactionTask) doClean() error {
+	log := log.With(zap.Int64("triggerID", t.GetTaskProto().GetTriggerID()),
+		zap.Int64("PlanID", t.GetTaskProto().GetPlanID()),
+		zap.Int64("collectionID", t.GetTaskProto().GetCollectionID()))
+	err := t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_cleaned))
+	if err != nil {
+		log.Warn("backfillCompactionTask fail to updateAndSaveTaskMeta", zap.Error(err))
+		return err
+	}
+	// resetSegmentCompacting must be the last step of Clean, to make sure resetSegmentCompacting only called once
+	// otherwise, it may unlock segments locked by other compaction tasks
+	t.resetSegmentCompacting()
+	log.Info("backfillCompactionTask clean done")
+	return nil
+}
+
+func (t *backfillCompactionTask) resetSegmentCompacting() {
+	t.meta.SetSegmentsCompacting(context.TODO(), t.GetTaskProto().GetInputSegments(), false)
+}
+
+func (t *backfillCompactionTask) processFailed() bool {
+	return true
+}
+
+func (t *backfillCompactionTask) CreateTaskOnWorker(nodeID int64, cluster session.Cluster) {
+	log := log.With(zap.Int64("triggerID", t.GetTaskProto().GetTriggerID()),
+		zap.Int64("PlanID", t.GetTaskProto().GetPlanID()),
+		zap.Int64("collectionID", t.GetTaskProto().GetCollectionID()),
+		zap.Int64("nodeID", nodeID))
+
+	plan, err := t.BuildCompactionRequest()
+	if err != nil {
+		log.Warn("backfillCompactionTask failed to build compaction request", zap.Error(err))
+		err = t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_failed), setFailReason(err.Error()))
+		if err != nil {
+			log.Warn("backfillCompactionTask failed to updateAndSaveTaskMeta", zap.Error(err))
+		}
+		return
+	}
+
+	err = cluster.CreateCompaction(nodeID, plan)
+	if err != nil {
+		log.Warn("backfillCompactionTask failed to notify compaction tasks to DataNode",
+			zap.Int64("planID", t.GetTaskProto().GetPlanID()),
+			zap.Int64("nodeID", nodeID),
+			zap.Error(err))
+		err = t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_pipelining), setNodeID(NullNodeID))
+		if err != nil {
+			log.Warn("backfillCompactionTask failed to updateAndSaveTaskMeta", zap.Error(err))
+		}
+		return
+	}
+
+	log.Info("backfillCompactionTask created task on worker", zap.Int64("planID", t.GetTaskProto().GetPlanID()),
+		zap.Int64("nodeID", nodeID))
+
+	err = t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_executing), setNodeID(nodeID))
+	if err != nil {
+		log.Warn("backfillCompactionTask failed to updateAndSaveTaskMeta", zap.Error(err))
+	}
+}
+
+func (t *backfillCompactionTask) QueryTaskOnWorker(cluster session.Cluster) {
+	log := log.With(zap.Int64("triggerID", t.GetTaskProto().GetTriggerID()),
+		zap.Int64("PlanID", t.GetTaskProto().GetPlanID()),
+		zap.Int64("collectionID", t.GetTaskProto().GetCollectionID()))
+	result, err := cluster.QueryCompaction(t.GetTaskProto().GetNodeID(), &datapb.CompactionStateRequest{
+		PlanID: t.GetTaskProto().GetPlanID(),
+	})
+	if err != nil || result == nil {
+		if errors.Is(err, merr.ErrNodeNotFound) {
+			if err := t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_pipelining), setNodeID(NullNodeID)); err != nil {
+				log.Warn("backfillCompactionTask failed to updateAndSaveTaskMeta", zap.Error(err))
+			}
+		}
+		log.Warn("backfillCompactionTask failed to get compaction result", zap.Error(err))
+		return
+	}
+	switch result.GetState() {
+	case datapb.CompactionTaskState_completed:
+		if len(result.GetSegments()) == 0 {
+			log.Warn("backfillCompactionTask illegal compaction results: no segments returned")
+			if err := t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_failed),
+				setFailReason("illegal compaction results: no segments returned")); err != nil {
+				log.Warn("backfillCompactionTask failed to setState failed", zap.Error(err))
+			}
+			return
+		}
+		err = t.meta.ValidateSegmentStateBeforeCompleteCompactionMutation(t.GetTaskProto())
+		if err != nil {
+			if saveErr := t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_failed), setFailReason(err.Error())); saveErr != nil {
+				log.Warn("backfillCompactionTask failed to setState failed", zap.Error(saveErr))
+			}
+			return
+		}
+		if err := t.saveSegmentMeta(result); err != nil {
+			log.Warn("backfillCompactionTask failed to save segment meta", zap.Error(err))
+			if errors.Is(err, merr.ErrIllegalCompactionPlan) {
+				if saveErr := t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_failed),
+					setFailReason(err.Error())); saveErr != nil {
+					log.Warn("backfillCompactionTask failed to setState failed", zap.Error(saveErr))
+				}
+			}
+			return
+		}
+		UpdateCompactionSegmentSizeMetrics(result.GetSegments())
+		t.processMetaSaved()
+	case datapb.CompactionTaskState_pipelining, datapb.CompactionTaskState_executing:
+		return
+	case datapb.CompactionTaskState_timeout:
+		err = t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_timeout))
+		if err != nil {
+			log.Warn("backfillCompactionTask failed to updateAndSaveTaskMeta", zap.Error(err))
+			return
+		}
+	case datapb.CompactionTaskState_failed:
+		log.Warn("backfillCompactionTask fail in datanode")
+		if err := t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_failed),
+			setFailReason("compaction failed in datanode")); err != nil {
+			log.Warn("backfillCompactionTask failed to updateAndSaveTaskMeta", zap.Error(err))
+		}
+	default:
+		log.Error("not support compaction task state", zap.String("state", result.GetState().String()))
+		reason := fmt.Sprintf("unsupported compaction state: %s", result.GetState().String())
+		if err = t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_failed),
+			setFailReason(reason)); err != nil {
+			log.Warn("backfillCompactionTask failed to updateAndSaveTaskMeta", zap.Error(err))
+			return
+		}
+	}
+}
+
+func (t *backfillCompactionTask) DropTaskOnWorker(cluster session.Cluster) {
+	log := log.With(zap.Int64("triggerID", t.GetTaskProto().GetTriggerID()),
+		zap.Int64("PlanID", t.GetTaskProto().GetPlanID()),
+		zap.Int64("collectionID", t.GetTaskProto().GetCollectionID()))
+	if err := cluster.DropCompaction(t.GetTaskProto().GetNodeID(), t.GetTaskProto().GetPlanID()); err != nil {
+		log.Warn("backfillCompactionTask unable to drop compaction plan", zap.Error(err))
+	}
+}
+
+// Process performs the task's state machine
+// Note: return True means exit this state machine.
+// ONLY return True for Completed, Failed, Timeout
+func (t *backfillCompactionTask) Process() bool {
+	log := log.With(zap.Int64("triggerID", t.GetTaskProto().GetTriggerID()),
+		zap.Int64("PlanID", t.GetTaskProto().GetPlanID()),
+		zap.Int64("collectionID", t.GetTaskProto().GetCollectionID()))
+	lastState := t.GetTaskProto().GetState().String()
+	processResult := false
+	switch t.GetTaskProto().GetState() {
+	case datapb.CompactionTaskState_meta_saved:
+		processResult = t.processMetaSaved()
+	case datapb.CompactionTaskState_completed:
+		processResult = t.processCompleted()
+	case datapb.CompactionTaskState_failed:
+		processResult = t.processFailed()
+	case datapb.CompactionTaskState_timeout:
+		processResult = true
+	}
+	currentState := t.GetTaskProto().GetState().String()
+	if currentState != lastState {
+		log.Info("backfill compaction task state changed", zap.String("lastState", lastState), zap.String("currentState", currentState))
+	}
+	return processResult
+}
+
+func (t *backfillCompactionTask) saveSegmentMeta(result *datapb.CompactionPlanResult) error {
+	log := log.With(zap.Int64("triggerID", t.GetTaskProto().GetTriggerID()),
+		zap.Int64("PlanID", t.GetTaskProto().GetPlanID()),
+		zap.Int64("collectionID", t.GetTaskProto().GetCollectionID()))
+	newSegments, metricMutation, err := t.meta.CompleteCompactionMutation(context.TODO(), t.GetTaskProto(), result)
+	if err != nil {
+		return err
+	}
+	newSegmentIDs := lo.Map(newSegments, func(s *SegmentInfo, _ int) UniqueID { return s.GetID() })
+	metricMutation.commit()
+	for _, newSegID := range newSegmentIDs {
+		select {
+		case getBuildIndexChSingleton() <- newSegID:
+		default:
+		}
+	}
+
+	err = t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_meta_saved), setResultSegments(newSegmentIDs))
+	if err != nil {
+		log.Warn("backfillCompactionTask failed to setState meta saved", zap.Error(err))
+		return err
+	}
+	log.Info("backfillCompactionTask success to save segment meta")
+	return nil
+}
+
+func (t *backfillCompactionTask) processMetaSaved() bool {
+	err := t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_completed))
+	if err != nil {
+		log.Warn("backfillCompactionTask unable to processMetaSaved",
+			zap.Int64("planID", t.GetTaskProto().GetPlanID()),
+			zap.Error(err))
+		return false
+	}
+	return t.processCompleted()
+}
+
+func (t *backfillCompactionTask) processCompleted() bool {
+	log := log.With(zap.Int64("triggerID", t.GetTaskProto().GetTriggerID()),
+		zap.Int64("PlanID", t.GetTaskProto().GetPlanID()),
+		zap.Int64("collectionID", t.GetTaskProto().GetCollectionID()))
+	log.Info("backfillCompactionTask processCompleted done")
+	return true
+}
+
+func (t *backfillCompactionTask) updateAndSaveTaskMeta(opts ...compactionTaskOpt) error {
+	// if task state is completed, cleaned, failed, timeout, then do append end time and save
+	if t.GetTaskProto().State == datapb.CompactionTaskState_completed ||
+		t.GetTaskProto().State == datapb.CompactionTaskState_cleaned ||
+		t.GetTaskProto().State == datapb.CompactionTaskState_failed ||
+		t.GetTaskProto().State == datapb.CompactionTaskState_timeout {
+		ts := time.Now().Unix()
+		opts = append(opts, setEndTime(ts))
+	}
+
+	task := t.ShadowClone(opts...)
+	err := t.saveTaskMeta(task)
+	if err != nil {
+		return err
+	}
+	t.SetTask(task)
+	return nil
+}

--- a/internal/datacoord/compaction_task_backfill_test.go
+++ b/internal/datacoord/compaction_task_backfill_test.go
@@ -1,0 +1,782 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datacoord
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/atomic"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/datacoord/allocator"
+	"github.com/milvus-io/milvus/internal/datacoord/broker"
+	"github.com/milvus-io/milvus/internal/datacoord/session"
+	"github.com/milvus-io/milvus/internal/metastore/kv/datacoord"
+	"github.com/milvus-io/milvus/internal/metastore/mocks"
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/pkg/v2/objectstorage"
+	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+	taskcommon "github.com/milvus-io/milvus/pkg/v2/taskcommon"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+)
+
+func TestBackfillCompactionTaskSuite(t *testing.T) {
+	suite.Run(t, new(BackfillCompactionTaskSuite))
+}
+
+type BackfillCompactionTaskSuite struct {
+	suite.Suite
+
+	mockID    atomic.Int64
+	mockAlloc *allocator.MockAllocator
+	meta      *meta
+	handler   *NMockHandler
+	ievm      IndexEngineVersionManager
+}
+
+func (s *BackfillCompactionTaskSuite) SetupTest() {
+	ctx := context.Background()
+	cm := storage.NewLocalChunkManager(objectstorage.RootPath(""))
+	catalog := datacoord.NewCatalog(NewMetaMemoryKV(), "", "")
+	broker := broker.NewMockBroker(s.T())
+	broker.EXPECT().ShowCollectionIDs(mock.Anything).Return(nil, nil)
+	meta, err := newMeta(ctx, catalog, cm, broker)
+	s.NoError(err)
+	s.meta = meta
+
+	s.mockID.Store(time.Now().UnixMilli())
+	s.mockAlloc = allocator.NewMockAllocator(s.T())
+	s.mockAlloc.EXPECT().AllocN(mock.Anything).RunAndReturn(func(x int64) (int64, int64, error) {
+		start := s.mockID.Load()
+		end := s.mockID.Add(x)
+		return start, end, nil
+	}).Maybe()
+	s.mockAlloc.EXPECT().AllocID(mock.Anything).RunAndReturn(func(ctx context.Context) (int64, error) {
+		end := s.mockID.Add(1)
+		return end, nil
+	}).Maybe()
+
+	s.handler = NewNMockHandler(s.T())
+	s.handler.EXPECT().GetCollection(mock.Anything, mock.Anything).Return(&collectionInfo{}, nil).Maybe()
+	s.ievm = newIndexEngineVersionManager()
+}
+
+func (s *BackfillCompactionTaskSuite) SetupSubTest() {
+	s.SetupTest()
+}
+
+func (s *BackfillCompactionTaskSuite) generateBasicTask() *backfillCompactionTask {
+	schema := &schemapb.CollectionSchema{
+		Name:        "test_backfill_collection",
+		Description: "test collection for backfill compaction",
+		Version:     2,
+		Fields: []*schemapb.FieldSchema{
+			{
+				FieldID:      100,
+				Name:         "pk",
+				IsPrimaryKey: true,
+				DataType:     schemapb.DataType_Int64,
+				AutoID:       true,
+			},
+			{
+				FieldID:  101,
+				Name:     "text",
+				DataType: schemapb.DataType_VarChar,
+			},
+			{
+				FieldID:  102,
+				Name:     "sparse_vector",
+				DataType: schemapb.DataType_SparseFloatVector,
+			},
+		},
+	}
+
+	// Create BM25 function schema
+	// Note: FunctionSchema structure needs to be verified from actual proto definition
+	// For now, we create an empty functions slice
+	functions := []*schemapb.FunctionSchema{}
+
+	compactionTask := &datapb.CompactionTask{
+		PlanID:         1,
+		TriggerID:      19530,
+		CollectionID:   1,
+		PartitionID:    10,
+		Type:           datapb.CompactionType_BackfillCompaction,
+		NodeID:         1,
+		State:          datapb.CompactionTaskState_pipelining,
+		Schema:         schema,
+		InputSegments:  []int64{101},
+		ResultSegments: []int64{1000},
+		PreAllocatedSegmentIDs: &datapb.IDRange{
+			Begin: 1000,
+			End:   2000,
+		},
+		Channel: "ch-1",
+	}
+
+	task := newBackfillCompactionTask(compactionTask, s.mockAlloc, s.meta, s.ievm, functions)
+	return task
+}
+
+func (s *BackfillCompactionTaskSuite) TestBackfillCompactionTaskBasic() {
+	task := s.generateBasicTask()
+
+	// Test basic getters
+	s.Equal(int64(1), task.GetTaskID())
+	s.Equal(taskcommon.Compaction, task.GetTaskType())
+	s.Equal(int64(1), task.GetSlotUsage())
+	s.Equal("10-ch-1", task.GetLabel())
+	s.Equal(int64(0), task.GetTaskVersion())
+
+	// Test task proto
+	taskProto := task.GetTaskProto()
+	s.NotNil(taskProto)
+	s.Equal(int64(1), taskProto.GetPlanID())
+	s.Equal(int64(19530), taskProto.GetTriggerID())
+	s.Equal(int64(1), taskProto.GetCollectionID())
+	s.Equal(int64(10), taskProto.GetPartitionID())
+	s.Equal(datapb.CompactionType_BackfillCompaction, taskProto.GetType())
+	s.Equal(datapb.CompactionTaskState_pipelining, taskProto.GetState())
+	s.Equal([]int64{101}, taskProto.GetInputSegments())
+	s.Equal([]int64{1000}, taskProto.GetResultSegments())
+}
+
+func (s *BackfillCompactionTaskSuite) TestBuildCompactionRequest() {
+	// Add a segment to meta
+	segmentID := int64(101)
+	err := s.meta.AddSegment(context.TODO(), &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:            segmentID,
+			CollectionID:  1,
+			PartitionID:   10,
+			InsertChannel: "ch-1",
+			Level:         datapb.SegmentLevel_L1,
+			State:         commonpb.SegmentState_Flushed,
+			NumOfRows:     1000,
+			Binlogs: []*datapb.FieldBinlog{
+				{
+					FieldID: 101,
+					Binlogs: []*datapb.Binlog{
+						{LogID: 1000, EntriesNum: 1000},
+					},
+				},
+			},
+		},
+	})
+	s.NoError(err)
+
+	task := s.generateBasicTask()
+
+	// Build compaction request
+	plan, err := task.BuildCompactionRequest()
+	s.NoError(err)
+	s.NotNil(plan)
+
+	// Verify plan
+	s.Equal(int64(1), plan.GetPlanID())
+	s.Equal(datapb.CompactionType_BackfillCompaction, plan.GetType())
+	s.Equal("ch-1", plan.GetChannel())
+	s.Equal(1, len(plan.GetSegmentBinlogs()))
+	s.Equal(segmentID, plan.GetSegmentBinlogs()[0].GetSegmentID())
+	s.Equal(int64(1), plan.GetSegmentBinlogs()[0].GetCollectionID())
+	s.Equal(int64(10), plan.GetSegmentBinlogs()[0].GetPartitionID())
+	s.NotNil(plan.GetFunctions())
+}
+
+func (s *BackfillCompactionTaskSuite) TestBuildCompactionRequestSegmentNotFound() {
+	task := s.generateBasicTask()
+
+	// Try to build compaction request without adding segment to meta
+	plan, err := task.BuildCompactionRequest()
+	s.Error(err)
+	s.Nil(plan)
+	s.Contains(err.Error(), "segment not found")
+}
+
+func (s *BackfillCompactionTaskSuite) TestCreateTaskOnWorker() {
+	s.Run("CreateTaskOnWorker fail, segment not found", func() {
+		task := s.generateBasicTask()
+		cluster := session.NewMockCluster(s.T())
+		task.CreateTaskOnWorker(1, cluster)
+		s.Equal(datapb.CompactionTaskState_failed, task.GetTaskProto().GetState())
+	})
+
+	s.Run("CreateTaskOnWorker fail, CreateCompaction error", func() {
+		// Add segment to meta
+		segmentID := int64(101)
+		err := s.meta.AddSegment(context.TODO(), &SegmentInfo{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:            segmentID,
+				CollectionID:  1,
+				PartitionID:   10,
+				InsertChannel: "ch-1",
+				Level:         datapb.SegmentLevel_L1,
+				State:         commonpb.SegmentState_Flushed,
+				NumOfRows:     1000,
+				Binlogs: []*datapb.FieldBinlog{
+					{
+						FieldID: 101,
+						Binlogs: []*datapb.Binlog{
+							{LogID: 1000, EntriesNum: 1000},
+						},
+					},
+				},
+			},
+		})
+		s.NoError(err)
+
+		task := s.generateBasicTask()
+		cluster := session.NewMockCluster(s.T())
+		cluster.EXPECT().CreateCompaction(mock.Anything, mock.Anything).Return(merr.WrapErrNodeNotFound(1))
+		task.CreateTaskOnWorker(1, cluster)
+		// Should remain in pipelining state when CreateCompaction fails
+		s.Equal(datapb.CompactionTaskState_pipelining, task.GetTaskProto().GetState())
+		// NodeID should be set to NullNodeID (-1) when CreateCompaction fails
+		s.Equal(int64(-1), task.GetTaskProto().GetNodeID())
+	})
+
+	s.Run("CreateTaskOnWorker succeed", func() {
+		// Add segment to meta
+		segmentID := int64(101)
+		err := s.meta.AddSegment(context.TODO(), &SegmentInfo{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:            segmentID,
+				CollectionID:  1,
+				PartitionID:   10,
+				InsertChannel: "ch-1",
+				Level:         datapb.SegmentLevel_L1,
+				State:         commonpb.SegmentState_Flushed,
+				NumOfRows:     1000,
+				Binlogs: []*datapb.FieldBinlog{
+					{
+						FieldID: 101,
+						Binlogs: []*datapb.Binlog{
+							{LogID: 1000, EntriesNum: 1000},
+						},
+					},
+				},
+			},
+		})
+		s.NoError(err)
+
+		task := s.generateBasicTask()
+		cluster := session.NewMockCluster(s.T())
+		cluster.EXPECT().CreateCompaction(mock.Anything, mock.Anything).Return(nil)
+		task.CreateTaskOnWorker(1, cluster)
+		s.Equal(datapb.CompactionTaskState_executing, task.GetTaskProto().GetState())
+		s.Equal(int64(1), task.GetTaskProto().GetNodeID())
+	})
+}
+
+func (s *BackfillCompactionTaskSuite) TestQueryTaskOnWorker() {
+	s.Run("QueryTaskOnWorker, node not found", func() {
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_executing), setNodeID(1)))
+		cluster := session.NewMockCluster(s.T())
+		cluster.EXPECT().QueryCompaction(mock.Anything, mock.Anything).Return(nil, merr.WrapErrNodeNotFound(1)).Once()
+		task.QueryTaskOnWorker(cluster)
+		s.Equal(datapb.CompactionTaskState_pipelining, task.GetTaskProto().GetState())
+		s.Equal(int64(-1), task.GetTaskProto().GetNodeID())
+	})
+
+	s.Run("QueryTaskOnWorker, result is nil", func() {
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_executing), setNodeID(1)))
+		cluster := session.NewMockCluster(s.T())
+		cluster.EXPECT().QueryCompaction(mock.Anything, mock.Anything).Return(nil, nil).Once()
+		task.QueryTaskOnWorker(cluster)
+		// State should remain unchanged when result is nil
+		s.Equal(datapb.CompactionTaskState_executing, task.GetTaskProto().GetState())
+	})
+
+	s.Run("QueryTaskOnWorker, completed with empty segments", func() {
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_executing), setNodeID(1)))
+		cluster := session.NewMockCluster(s.T())
+		cluster.EXPECT().QueryCompaction(mock.Anything, mock.Anything).Return(&datapb.CompactionPlanResult{
+			State:    datapb.CompactionTaskState_completed,
+			Segments: []*datapb.CompactionSegment{},
+		}, nil).Once()
+		task.QueryTaskOnWorker(cluster)
+		s.Equal(datapb.CompactionTaskState_failed, task.GetTaskProto().GetState())
+	})
+
+	s.Run("QueryTaskOnWorker, pipelining state", func() {
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_executing), setNodeID(1)))
+		cluster := session.NewMockCluster(s.T())
+		cluster.EXPECT().QueryCompaction(mock.Anything, mock.Anything).Return(&datapb.CompactionPlanResult{
+			State: datapb.CompactionTaskState_pipelining,
+		}, nil).Once()
+		task.QueryTaskOnWorker(cluster)
+		// State should remain unchanged
+		s.Equal(datapb.CompactionTaskState_executing, task.GetTaskProto().GetState())
+	})
+
+	s.Run("QueryTaskOnWorker, executing state", func() {
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_executing), setNodeID(1)))
+		cluster := session.NewMockCluster(s.T())
+		cluster.EXPECT().QueryCompaction(mock.Anything, mock.Anything).Return(&datapb.CompactionPlanResult{
+			State: datapb.CompactionTaskState_executing,
+		}, nil).Once()
+		task.QueryTaskOnWorker(cluster)
+		// State should remain unchanged
+		s.Equal(datapb.CompactionTaskState_executing, task.GetTaskProto().GetState())
+	})
+
+	s.Run("QueryTaskOnWorker, timeout state", func() {
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_executing), setNodeID(1)))
+		cluster := session.NewMockCluster(s.T())
+		cluster.EXPECT().QueryCompaction(mock.Anything, mock.Anything).Return(&datapb.CompactionPlanResult{
+			State: datapb.CompactionTaskState_timeout,
+		}, nil).Once()
+		task.QueryTaskOnWorker(cluster)
+		s.Equal(datapb.CompactionTaskState_timeout, task.GetTaskProto().GetState())
+	})
+
+	s.Run("QueryTaskOnWorker, failed state", func() {
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_executing), setNodeID(1)))
+		cluster := session.NewMockCluster(s.T())
+		cluster.EXPECT().QueryCompaction(mock.Anything, mock.Anything).Return(&datapb.CompactionPlanResult{
+			State: datapb.CompactionTaskState_failed,
+		}, nil).Once()
+		task.QueryTaskOnWorker(cluster)
+		s.Equal(datapb.CompactionTaskState_failed, task.GetTaskProto().GetState())
+	})
+
+	s.Run("QueryTaskOnWorker, completed with ValidateSegmentState error (segment not in meta)", func() {
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_executing), setNodeID(1)))
+		cluster := session.NewMockCluster(s.T())
+		// segment 101 is NOT in meta → ValidateSegmentStateBeforeCompleteCompactionMutation returns error
+		cluster.EXPECT().QueryCompaction(mock.Anything, mock.Anything).Return(&datapb.CompactionPlanResult{
+			State:    datapb.CompactionTaskState_completed,
+			Segments: []*datapb.CompactionSegment{{SegmentID: 101}},
+		}, nil).Once()
+		task.QueryTaskOnWorker(cluster)
+		s.Equal(datapb.CompactionTaskState_failed, task.GetTaskProto().GetState())
+	})
+
+	s.Run("QueryTaskOnWorker, completed with ErrIllegalCompactionPlan from saveSegmentMeta", func() {
+		// Add segment 101 so ValidateSegmentState passes, but result segmentID mismatches → ErrIllegalCompactionPlan
+		segmentID := int64(101)
+		err := s.meta.AddSegment(context.TODO(), &SegmentInfo{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:            segmentID,
+				CollectionID:  1,
+				PartitionID:   10,
+				InsertChannel: "ch-1",
+				Level:         datapb.SegmentLevel_L1,
+				State:         commonpb.SegmentState_Flushed,
+				NumOfRows:     1000,
+			},
+			isCompacting: true,
+		})
+		s.NoError(err)
+
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_executing), setNodeID(1)))
+		cluster := session.NewMockCluster(s.T())
+		cluster.EXPECT().QueryCompaction(mock.Anything, mock.Anything).Return(&datapb.CompactionPlanResult{
+			State:    datapb.CompactionTaskState_completed,
+			Segments: []*datapb.CompactionSegment{{SegmentID: 999}}, // mismatched → ErrIllegalCompactionPlan
+		}, nil).Once()
+		task.QueryTaskOnWorker(cluster)
+		s.Equal(datapb.CompactionTaskState_failed, task.GetTaskProto().GetState())
+	})
+
+	s.Run("QueryTaskOnWorker, completed success path", func() {
+		segmentID := int64(101)
+		err := s.meta.AddSegment(context.TODO(), &SegmentInfo{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:            segmentID,
+				CollectionID:  1,
+				PartitionID:   10,
+				InsertChannel: "ch-1",
+				Level:         datapb.SegmentLevel_L1,
+				State:         commonpb.SegmentState_Flushed,
+				NumOfRows:     1000,
+			},
+			isCompacting: true,
+		})
+		s.NoError(err)
+
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_executing), setNodeID(1)))
+		cluster := session.NewMockCluster(s.T())
+		cluster.EXPECT().QueryCompaction(mock.Anything, mock.Anything).Return(&datapb.CompactionPlanResult{
+			State: datapb.CompactionTaskState_completed,
+			Segments: []*datapb.CompactionSegment{{
+				SegmentID:  segmentID,
+				InsertLogs: []*datapb.FieldBinlog{},
+			}},
+		}, nil).Once()
+		task.QueryTaskOnWorker(cluster)
+		// saveSegmentMeta succeeds → processMetaSaved → completed
+		s.Equal(datapb.CompactionTaskState_completed, task.GetTaskProto().GetState())
+	})
+
+	s.Run("QueryTaskOnWorker, default unknown state", func() {
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_executing), setNodeID(1)))
+		cluster := session.NewMockCluster(s.T())
+		cluster.EXPECT().QueryCompaction(mock.Anything, mock.Anything).Return(&datapb.CompactionPlanResult{
+			State: datapb.CompactionTaskState_unknown,
+		}, nil).Once()
+		task.QueryTaskOnWorker(cluster)
+		s.Equal(datapb.CompactionTaskState_failed, task.GetTaskProto().GetState())
+	})
+}
+
+func (s *BackfillCompactionTaskSuite) TestProcess() {
+	s.Run("Process meta_saved state", func() {
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_meta_saved)))
+		result := task.Process()
+		// processMetaSaved should transition to completed and return true
+		s.True(result)
+		s.Equal(datapb.CompactionTaskState_completed, task.GetTaskProto().GetState())
+	})
+
+	s.Run("Process completed state", func() {
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_completed)))
+		result := task.Process()
+		s.True(result)
+		s.Equal(datapb.CompactionTaskState_completed, task.GetTaskProto().GetState())
+	})
+
+	s.Run("Process failed state", func() {
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_failed)))
+		result := task.Process()
+		s.True(result)
+		s.Equal(datapb.CompactionTaskState_failed, task.GetTaskProto().GetState())
+	})
+
+	s.Run("Process timeout state", func() {
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_timeout)))
+		result := task.Process()
+		s.True(result)
+		s.Equal(datapb.CompactionTaskState_timeout, task.GetTaskProto().GetState())
+	})
+
+	s.Run("Process other states return false", func() {
+		testStates := []datapb.CompactionTaskState{
+			datapb.CompactionTaskState_pipelining,
+			datapb.CompactionTaskState_executing,
+			datapb.CompactionTaskState_unknown,
+		}
+		for _, state := range testStates {
+			task := s.generateBasicTask()
+			task.SetTask(task.ShadowClone(setState(state)))
+			result := task.Process()
+			s.False(result, "state %s should return false", state.String())
+		}
+	})
+}
+
+func (s *BackfillCompactionTaskSuite) TestClean() {
+	task := s.generateBasicTask()
+	// Mark segment as compacting
+	s.meta.SetSegmentsCompacting(context.TODO(), []int64{101}, true)
+
+	// Add segment to meta
+	segmentID := int64(101)
+	err := s.meta.AddSegment(context.TODO(), &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:            segmentID,
+			CollectionID:  1,
+			PartitionID:   10,
+			InsertChannel: "ch-1",
+			Level:         datapb.SegmentLevel_L1,
+			State:         commonpb.SegmentState_Flushed,
+			NumOfRows:     1000,
+		},
+	})
+	s.NoError(err)
+
+	result := task.Clean()
+	s.True(result)
+	s.Equal(datapb.CompactionTaskState_cleaned, task.GetTaskProto().GetState())
+
+	// Verify segment compacting flag is reset
+	seg := s.meta.GetSegment(context.TODO(), segmentID)
+	s.NotNil(seg)
+	s.False(seg.isCompacting)
+}
+
+func (s *BackfillCompactionTaskSuite) TestNeedReAssignNodeID() {
+	s.Run("NeedReAssignNodeID, pipelining with nodeID 0", func() {
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_pipelining), setNodeID(0)))
+		s.True(task.NeedReAssignNodeID())
+	})
+
+	s.Run("NeedReAssignNodeID, pipelining with NullNodeID", func() {
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_pipelining), setNodeID(-1)))
+		s.True(task.NeedReAssignNodeID())
+	})
+
+	s.Run("NeedReAssignNodeID, pipelining with valid nodeID", func() {
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_pipelining), setNodeID(1)))
+		s.False(task.NeedReAssignNodeID())
+	})
+
+	s.Run("NeedReAssignNodeID, non-pipelining state", func() {
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_executing), setNodeID(0)))
+		s.False(task.NeedReAssignNodeID())
+	})
+}
+
+func (s *BackfillCompactionTaskSuite) TestDropTaskOnWorker() {
+	task := s.generateBasicTask()
+	task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_executing), setNodeID(1)))
+	cluster := session.NewMockCluster(s.T())
+	cluster.EXPECT().DropCompaction(mock.Anything, mock.Anything).Return(nil).Once()
+	task.DropTaskOnWorker(cluster)
+}
+
+func (s *BackfillCompactionTaskSuite) TestSetNodeID() {
+	task := s.generateBasicTask()
+	err := task.SetNodeID(100)
+	s.NoError(err)
+	s.Equal(int64(100), task.GetTaskProto().GetNodeID())
+}
+
+func (s *BackfillCompactionTaskSuite) TestSaveSegmentMeta() {
+	s.Run("success", func() {
+		segmentID := int64(101)
+		err := s.meta.AddSegment(context.TODO(), &SegmentInfo{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:            segmentID,
+				CollectionID:  1,
+				PartitionID:   10,
+				InsertChannel: "ch-1",
+				Level:         datapb.SegmentLevel_L1,
+				State:         commonpb.SegmentState_Flushed,
+				NumOfRows:     1000,
+				Binlogs: []*datapb.FieldBinlog{
+					{FieldID: 101, Binlogs: []*datapb.Binlog{{LogID: 1000, EntriesNum: 1000}}},
+				},
+			},
+			isCompacting: true,
+		})
+		s.NoError(err)
+
+		task := s.generateBasicTask()
+		result := &datapb.CompactionPlanResult{
+			PlanID: 1,
+			State:  datapb.CompactionTaskState_completed,
+			Type:   datapb.CompactionType_BackfillCompaction,
+			Segments: []*datapb.CompactionSegment{
+				{
+					SegmentID: segmentID,
+					InsertLogs: []*datapb.FieldBinlog{
+						{FieldID: 101, Binlogs: []*datapb.Binlog{{LogID: 1000, EntriesNum: 1000}}},
+						{FieldID: 102, Binlogs: []*datapb.Binlog{{LogID: 2000, EntriesNum: 1000}}},
+					},
+				},
+			},
+		}
+		err = task.saveSegmentMeta(result)
+		s.NoError(err)
+		s.Equal(datapb.CompactionTaskState_meta_saved, task.GetTaskProto().GetState())
+	})
+
+	s.Run("CompleteCompactionMutation error", func() {
+		// Without adding a segment to meta, CompleteCompactionMutation should fail
+		task := s.generateBasicTask()
+		result := &datapb.CompactionPlanResult{
+			PlanID: 1,
+			State:  datapb.CompactionTaskState_completed,
+			Type:   datapb.CompactionType_BackfillCompaction,
+			Segments: []*datapb.CompactionSegment{
+				{SegmentID: 101},
+			},
+		}
+		err := task.saveSegmentMeta(result)
+		s.Error(err)
+	})
+}
+
+func (s *BackfillCompactionTaskSuite) TestProcessCompleted() {
+	segmentID := int64(101)
+	err := s.meta.AddSegment(context.TODO(), &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:            segmentID,
+			CollectionID:  1,
+			PartitionID:   10,
+			InsertChannel: "ch-1",
+			Level:         datapb.SegmentLevel_L1,
+			State:         commonpb.SegmentState_Flushed,
+		},
+		isCompacting: true,
+	})
+	s.NoError(err)
+
+	task := s.generateBasicTask()
+	task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_completed)))
+
+	result := task.processCompleted()
+	s.True(result)
+	// processCompleted() does NOT reset the compacting flag — that is done by Clean().
+}
+
+func (s *BackfillCompactionTaskSuite) TestUpdateAndSaveTaskMeta() {
+	s.Run("normal state update", func() {
+		task := s.generateBasicTask()
+		err := task.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_executing))
+		s.NoError(err)
+		s.Equal(datapb.CompactionTaskState_executing, task.GetTaskProto().GetState())
+		// EndTime should not be set for non-terminal states
+		s.Equal(int64(0), task.GetTaskProto().GetEndTime())
+	})
+
+	s.Run("terminal state sets end time", func() {
+		task := s.generateBasicTask()
+		// First set to completed state
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_completed)))
+		// Then call updateAndSaveTaskMeta which checks current state
+		err := task.updateAndSaveTaskMeta()
+		s.NoError(err)
+		s.Equal(datapb.CompactionTaskState_completed, task.GetTaskProto().GetState())
+		s.NotZero(task.GetTaskProto().GetEndTime())
+	})
+
+	s.Run("failed state sets end time", func() {
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_failed)))
+		err := task.updateAndSaveTaskMeta()
+		s.NoError(err)
+		s.Equal(datapb.CompactionTaskState_failed, task.GetTaskProto().GetState())
+		s.NotZero(task.GetTaskProto().GetEndTime())
+	})
+}
+
+func (s *BackfillCompactionTaskSuite) TestProcessFailed() {
+	task := s.generateBasicTask()
+	task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_failed)))
+	s.True(task.processFailed())
+}
+
+func (s *BackfillCompactionTaskSuite) TestGetSlotUsage() {
+	task := s.generateBasicTask()
+	s.Equal(int64(1), task.GetSlotUsage())
+}
+
+func (s *BackfillCompactionTaskSuite) TestSetTaskTime() {
+	task := s.generateBasicTask()
+	now := time.Now()
+	task.SetTaskTime(taskcommon.TimeQueue, now)
+	s.False(task.GetTaskTime(taskcommon.TimeQueue).IsZero())
+}
+
+func (s *BackfillCompactionTaskSuite) TestGetTaskState() {
+	s.Run("pipelining state", func() {
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_pipelining)))
+		state := task.GetTaskState()
+		s.Equal(taskcommon.Init, state)
+	})
+
+	s.Run("executing state", func() {
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_executing)))
+		state := task.GetTaskState()
+		s.Equal(taskcommon.InProgress, state)
+	})
+
+	s.Run("completed state", func() {
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_completed)))
+		state := task.GetTaskState()
+		s.Equal(taskcommon.Finished, state)
+	})
+
+	s.Run("failed state", func() {
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_failed)))
+		state := task.GetTaskState()
+		s.Equal(taskcommon.Failed, state)
+	})
+}
+
+func (s *BackfillCompactionTaskSuite) TestGetTaskSlot() {
+	task := s.generateBasicTask()
+	slot := task.GetTaskSlot()
+	// GetTaskSlot reads from paramtable; default is 1
+	s.GreaterOrEqual(slot, int64(1))
+}
+
+func (s *BackfillCompactionTaskSuite) TestCleanError() {
+	// Make the compactionTaskMeta catalog fail on SaveCompactionTask so that doClean returns an error.
+	// meta.compactionTaskMeta.catalog is the catalog used by SaveCompactionTask,
+	// separate from meta.catalog which is used by segment operations.
+	mockCatalog := mocks.NewDataCoordCatalog(s.T())
+	mockCatalog.EXPECT().SaveCompactionTask(mock.Anything, mock.Anything).Return(errors.New("catalog write error"))
+	s.meta.compactionTaskMeta.catalog = mockCatalog
+
+	task := s.generateBasicTask()
+	result := task.Clean()
+	s.False(result, "Clean() must return false when doClean fails")
+}
+
+func (s *BackfillCompactionTaskSuite) TestResetSegmentCompacting() {
+	// Add two segments and mark them as compacting.
+	for _, segID := range []int64{101, 102} {
+		err := s.meta.AddSegment(context.TODO(), &SegmentInfo{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:            segID,
+				CollectionID:  1,
+				PartitionID:   10,
+				InsertChannel: "ch-1",
+				Level:         datapb.SegmentLevel_L1,
+				State:         commonpb.SegmentState_Flushed,
+			},
+		})
+		s.NoError(err)
+	}
+	s.meta.SetSegmentsCompacting(context.TODO(), []int64{101, 102}, true)
+
+	task := s.generateBasicTask()
+	// Override input segments to include both IDs.
+	task.SetTask(task.ShadowClone(func(t *datapb.CompactionTask) {
+		t.InputSegments = []int64{101, 102}
+	}))
+
+	task.resetSegmentCompacting()
+
+	for _, segID := range []int64{101, 102} {
+		seg := s.meta.GetSegment(context.TODO(), segID)
+		s.Require().NotNil(seg)
+		s.False(seg.isCompacting, "segment %d should no longer be compacting after reset", segID)
+	}
+}

--- a/internal/datacoord/compaction_task_meta.go
+++ b/internal/datacoord/compaction_task_meta.go
@@ -96,9 +96,13 @@ func (csm *compactionTaskMeta) reloadFromKV() error {
 		// - Level0DeleteCompaction tasks never use PreAllocatedSegmentIDs and must be ignored here,
 		//   otherwise unfinished L0 delete compaction tasks created before upgrade will be
 		//   incorrectly marked as failed on reload.
+		// - BackfillCompaction is an in-place update of the original segment — no new segment
+		//   ID is allocated. Without this exception, an in-progress backfill task would be killed
+		//   on every datacoord restart, preventing backfill from ever completing under restart loops.
 		if !isCompactionTaskFinished(task) &&
 			task.PreAllocatedSegmentIDs == nil &&
-			task.GetType() != datapb.CompactionType_Level0DeleteCompaction {
+			task.GetType() != datapb.CompactionType_Level0DeleteCompaction &&
+			task.GetType() != datapb.CompactionType_BackfillCompaction {
 			log.Warn("PreAllocatedSegmentIDs is nil, mark the task as failed",
 				zap.Int64("taskID", task.GetPlanID()),
 				zap.String("type", task.GetType().String()),

--- a/internal/datacoord/compaction_task_meta_test.go
+++ b/internal/datacoord/compaction_task_meta_test.go
@@ -165,3 +165,28 @@ func (suite *CompactionTaskMetaSuite) TestReloadFromKV_PreAllocatedSegmentIDsCom
 	suite.Equal(1, len(clusteringTasks))
 	suite.Equal(datapb.CompactionTaskState_failed, clusteringTasks[0].State)
 }
+
+// TestReloadFromKV_BackfillTaskSurvives verifies that an in-progress backfill compaction
+// task is NOT marked failed on reload, even though it has no PreAllocatedSegmentIDs —
+// backfill is in-place and never allocates new segment IDs. Without this guard, every
+// datacoord restart would kill any running backfill task.
+func (suite *CompactionTaskMetaSuite) TestReloadFromKV_BackfillTaskSurvives() {
+	backfillTask := &datapb.CompactionTask{
+		PlanID:    10,
+		TriggerID: 10,
+		Type:      datapb.CompactionType_BackfillCompaction,
+		State:     datapb.CompactionTaskState_executing,
+		// PreAllocatedSegmentIDs intentionally nil — backfill never allocates new segment IDs
+	}
+
+	catalog := mocks.NewDataCoordCatalog(suite.T())
+	catalog.EXPECT().ListCompactionTask(mock.Anything).Return([]*datapb.CompactionTask{backfillTask}, nil).Once()
+
+	meta, err := newCompactionTaskMeta(context.TODO(), catalog)
+	suite.NoError(err)
+
+	tasks := meta.GetCompactionTasksByTriggerID(10)
+	suite.Equal(1, len(tasks))
+	suite.Equal(datapb.CompactionTaskState_executing, tasks[0].State,
+		"backfill task must survive reload even with nil PreAllocatedSegmentIDs")
+}

--- a/internal/datacoord/compaction_trigger.go
+++ b/internal/datacoord/compaction_trigger.go
@@ -230,6 +230,20 @@ func (t *compactionTrigger) getCollection(collectionID UniqueID) (*collectionInf
 	return coll, nil
 }
 
+// filterSegmentsWithMatchingSchemaVersion removes segments whose schema version does not match the
+// collection's current schema version. This allows mix compaction to proceed on the matching subset
+// rather than blocking the entire group (collection + partition + channel) during backfill.
+func filterSegmentsWithMatchingSchemaVersion(segments []*SegmentInfo, coll *collectionInfo) []*SegmentInfo {
+	collectionSchemaVersion := coll.Schema.GetVersion()
+	result := make([]*SegmentInfo, 0, len(segments))
+	for _, segment := range segments {
+		if segment.GetSchemaVersion() == collectionSchemaVersion {
+			result = append(result, segment)
+		}
+	}
+	return result
+}
+
 func isCollectionAutoCompactionEnabled(coll *collectionInfo) bool {
 	if coll == nil {
 		return false
@@ -371,6 +385,15 @@ func (t *compactionTrigger) handleSignal(signal *compactionSignal) error {
 			if signal.collectionID != 0 {
 				return err
 			}
+			continue
+		}
+
+		group.segments = filterSegmentsWithMatchingSchemaVersion(group.segments, coll)
+		if len(group.segments) == 0 {
+			log.Debug("no segments with matching schema version in group, skip mix compaction",
+				zap.Int64("collectionID", group.collectionID),
+				zap.Int64("partitionID", group.partitionID),
+				zap.String("channel", group.channelName))
 			continue
 		}
 

--- a/internal/datacoord/compaction_trigger_test.go
+++ b/internal/datacoord/compaction_trigger_test.go
@@ -2003,6 +2003,41 @@ func Test_compactionTrigger_new(t *testing.T) {
 	}
 }
 
+func TestFilterSegmentsWithMatchingSchemaVersion(t *testing.T) {
+	coll := &collectionInfo{
+		ID:     1,
+		Schema: &schemapb.CollectionSchema{Version: 5},
+	}
+
+	// empty input → empty output
+	result := filterSegmentsWithMatchingSchemaVersion(nil, coll)
+	assert.Empty(t, result)
+
+	// all segments match → all returned
+	result = filterSegmentsWithMatchingSchemaVersion([]*SegmentInfo{
+		{SegmentInfo: &datapb.SegmentInfo{SchemaVersion: 5}},
+		{SegmentInfo: &datapb.SegmentInfo{SchemaVersion: 5}},
+	}, coll)
+	assert.Equal(t, 2, len(result))
+
+	// mixed versions → only matching segments returned
+	result = filterSegmentsWithMatchingSchemaVersion([]*SegmentInfo{
+		{SegmentInfo: &datapb.SegmentInfo{ID: 1, SchemaVersion: 5}},
+		{SegmentInfo: &datapb.SegmentInfo{ID: 2, SchemaVersion: 4}},
+		{SegmentInfo: &datapb.SegmentInfo{ID: 3, SchemaVersion: 5}},
+	}, coll)
+	assert.Equal(t, 2, len(result))
+	assert.Equal(t, int64(1), result[0].GetID())
+	assert.Equal(t, int64(3), result[1].GetID())
+
+	// all segments outdated → empty output
+	result = filterSegmentsWithMatchingSchemaVersion([]*SegmentInfo{
+		{SegmentInfo: &datapb.SegmentInfo{SchemaVersion: 0}},
+		{SegmentInfo: &datapb.SegmentInfo{SchemaVersion: 4}},
+	}, coll)
+	assert.Empty(t, result)
+}
+
 func Test_compactionTrigger_getCompactTime(t *testing.T) {
 	coll := &collectionInfo{
 		ID:         1,

--- a/internal/datacoord/compaction_trigger_v2.go
+++ b/internal/datacoord/compaction_trigger_v2.go
@@ -18,6 +18,7 @@ package datacoord
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -48,6 +49,17 @@ const (
 	TriggerTypeSort
 	TriggerTypeForceMerge
 	TriggerTypeStorageVersionUpgrade
+	TriggerTypeBackfill
+)
+
+type TickerType int8
+
+const (
+	L0Ticker TickerType = iota + 1
+	ClusteringTicker
+	SingleTicker
+	BackfillTicker
+	StorageVersionTicker
 )
 
 func (t CompactionTriggerType) GetCompactionType() datapb.CompactionType {
@@ -62,6 +74,8 @@ func (t CompactionTriggerType) GetCompactionType() datapb.CompactionType {
 		return datapb.CompactionType_SortCompaction
 	case TriggerTypeStorageVersionUpgrade:
 		return datapb.CompactionType_MixCompaction
+	case TriggerTypeBackfill:
+		return datapb.CompactionType_BackfillCompaction
 	default:
 		return datapb.CompactionType_MixCompaction
 	}
@@ -87,9 +101,26 @@ func (t CompactionTriggerType) String() string {
 		return "ForceMerge"
 	case TriggerTypeStorageVersionUpgrade:
 		return "StorageVersionUpgrade"
+	case TriggerTypeBackfill:
+		return "Backfill"
 	default:
 		return ""
 	}
+}
+
+// CompactionPolicy defines the interface for different compaction policies
+type CompactionPolicy interface {
+	// Enable returns whether this compaction policy is enabled
+	Enable() bool
+	// TriggerInline returns views that can be applied inline (without inspector slots).
+	// Called unconditionally before the isFull() check so metadata-only updates always
+	// proceed regardless of inspector capacity. Non-backfill policies return an empty map.
+	TriggerInline(ctx context.Context) (map[CompactionTriggerType][]CompactionView, error)
+	// Trigger returns views that require inspector slots (actual compaction tasks).
+	// Only called when the inspector is not full.
+	Trigger(ctx context.Context) (map[CompactionTriggerType][]CompactionView, error)
+	// Name returns the name of this compaction policy
+	Name() string
 }
 
 type TriggerManager interface {
@@ -110,29 +141,46 @@ type CompactionTriggerManager struct {
 	handler   Handler
 	allocator allocator.Allocator
 
-	meta                        *meta
+	meta     *meta
+	policies map[TickerType]CompactionPolicy
+
 	l0Policy                    *l0CompactionPolicy
 	clusteringPolicy            *clusteringCompactionPolicy
 	singlePolicy                *singleCompactionPolicy
 	forceMergePolicy            *forceMergeCompactionPolicy
 	upgradeStorageVersionPolicy *storageVersionUpgradePolicy
+	backfillPolicy              *backfillCompactionPolicy
 
 	cancel  context.CancelFunc
 	closeWg sync.WaitGroup
 }
 
-func NewCompactionTriggerManager(alloc allocator.Allocator, handler Handler, inspector CompactionInspector, meta *meta, versionManager IndexEngineVersionManager) *CompactionTriggerManager {
+func NewCompactionTriggerManager(alloc allocator.Allocator, handler Handler, inspector CompactionInspector, meta *meta,
+	versionManager IndexEngineVersionManager,
+) *CompactionTriggerManager {
 	m := &CompactionTriggerManager{
 		allocator: alloc,
 		handler:   handler,
 		inspector: inspector,
 		meta:      meta,
+		policies:  make(map[TickerType]CompactionPolicy),
 	}
+	// Initialize policies and keep separate pointers for frequently accessed ones
+
 	m.l0Policy = newL0CompactionPolicy(meta, alloc)
 	m.clusteringPolicy = newClusteringCompactionPolicy(meta, m.allocator, m.handler)
 	m.singlePolicy = newSingleCompactionPolicy(meta, m.allocator, m.handler)
+
 	m.forceMergePolicy = newForceMergeCompactionPolicy(meta, m.allocator, m.handler)
 	m.upgradeStorageVersionPolicy = newStorageVersionUpgradePolicy(meta, m.allocator, m.handler, versionManager)
+	m.backfillPolicy = newBackfillCompactionPolicy(meta, m.allocator, m.handler)
+
+	// Initialize policies map for ticker handling
+	m.policies[L0Ticker] = m.l0Policy
+	m.policies[ClusteringTicker] = m.clusteringPolicy
+	m.policies[SingleTicker] = m.singlePolicy
+	m.policies[BackfillTicker] = m.backfillPolicy
+	m.policies[StorageVersionTicker] = m.upgradeStorageVersionPolicy
 	return m
 }
 
@@ -179,6 +227,8 @@ func (m *CompactionTriggerManager) loop(ctx context.Context) {
 	defer singleTicker.Stop()
 	storageVersionTicker := time.NewTicker(Params.DataCoordCfg.MixCompactionTriggerInterval.GetAsDuration(time.Second))
 	defer storageVersionTicker.Stop()
+	backfillTicker := time.NewTicker(Params.DataCoordCfg.BackfillCompactionTriggerInterval.GetAsDuration(time.Second))
+	defer backfillTicker.Stop()
 	log.Info("Compaction trigger manager start")
 	for {
 		select {
@@ -186,77 +236,15 @@ func (m *CompactionTriggerManager) loop(ctx context.Context) {
 			log.Info("Compaction trigger manager checkLoop quit")
 			return
 		case <-l0Ticker.C:
-			if !m.l0Policy.Enable() {
-				continue
-			}
-			if m.inspector.isFull() {
-				log.RatedInfo(10, "Skip trigger l0 compaction since inspector is full")
-				continue
-			}
-			events, err := m.l0Policy.Trigger(ctx)
-			if err != nil {
-				log.Warn("Fail to trigger L0 policy", zap.Error(err))
-				continue
-			}
-			if len(events) > 0 {
-				for triggerType, views := range events {
-					m.notify(ctx, triggerType, views)
-				}
-			}
+			m.handleTicker(ctx, L0Ticker)
 		case <-clusteringTicker.C:
-			if !m.clusteringPolicy.Enable() {
-				continue
-			}
-			if m.inspector.isFull() {
-				log.RatedInfo(10, "Skip trigger clustering compaction since inspector is full")
-				continue
-			}
-			events, err := m.clusteringPolicy.Trigger(ctx)
-			if err != nil {
-				log.Warn("Fail to trigger clustering policy", zap.Error(err))
-				continue
-			}
-			if len(events) > 0 {
-				for triggerType, views := range events {
-					m.notify(ctx, triggerType, views)
-				}
-			}
+			m.handleTicker(ctx, ClusteringTicker)
 		case <-singleTicker.C:
-			if !m.singlePolicy.Enable() {
-				continue
-			}
-			if m.inspector.isFull() {
-				log.RatedInfo(10, "Skip trigger single compaction since inspector is full")
-				continue
-			}
-			events, err := m.singlePolicy.Trigger(ctx)
-			if err != nil {
-				log.Warn("Fail to trigger single policy", zap.Error(err))
-				continue
-			}
-			if len(events) > 0 {
-				for triggerType, views := range events {
-					m.notify(ctx, triggerType, views)
-				}
-			}
+			m.handleTicker(ctx, SingleTicker)
 		case <-storageVersionTicker.C:
-			if !m.upgradeStorageVersionPolicy.Enable() {
-				continue
-			}
-			if m.inspector.isFull() {
-				log.RatedInfo(10, "Skip trigger storage version compaction since inspector is full")
-				continue
-			}
-			events, err := m.upgradeStorageVersionPolicy.Trigger(ctx)
-			if err != nil {
-				log.Warn("Fail to trigger storage version policy", zap.Error(err))
-				continue
-			}
-			if len(events) > 0 {
-				for triggerType, views := range events {
-					m.notify(ctx, triggerType, views)
-				}
-			}
+			m.handleTicker(ctx, StorageVersionTicker)
+		case <-backfillTicker.C:
+			m.handleTicker(ctx, BackfillTicker)
 		case segID := <-getStatsTaskChSingleton():
 			log.Info("receive new segment to trigger sort compaction", zap.Int64("segmentID", segID))
 			view := m.singlePolicy.triggerSegmentSortCompaction(ctx, segID)
@@ -270,6 +258,83 @@ func (m *CompactionTriggerManager) loop(ctx context.Context) {
 			}
 			m.notify(ctx, TriggerTypeSort, []CompactionView{view})
 		}
+	}
+}
+
+func (m *CompactionTriggerManager) handleTicker(ctx context.Context, tickerType TickerType) {
+	policy, exists := m.policies[tickerType]
+	if !exists {
+		log.Warn("Policy not found for ticker type", zap.Any("tickerType", tickerType))
+		return
+	}
+
+	if !policy.Enable() {
+		return
+	}
+
+	// Step 1: apply inline views unconditionally — these never need inspector slots
+	// (e.g. backfill metadata-only schema-version bumps) and must proceed even when
+	// the inspector queue is full.
+	inlineEvents, err := policy.TriggerInline(ctx)
+	if err != nil {
+		log.Warn("Fail to trigger inline policy", zap.String("policy", policy.Name()), zap.Error(err))
+		return
+	}
+	m.executeInline(ctx, inlineEvents)
+
+	// Step 2: gate normal compaction dispatch on inspector capacity.
+	if m.inspector.isFull() {
+		log.RatedInfo(10, "Skip dispatching compaction events since inspector is full",
+			zap.String("policy", policy.Name()))
+		return
+	}
+
+	// Step 3: trigger and dispatch views that require inspector slots.
+	events, err := policy.Trigger(ctx)
+	if err != nil {
+		log.Warn("Fail to trigger policy", zap.String("policy", policy.Name()), zap.Error(err))
+		return
+	}
+	for triggerType, views := range events {
+		if len(views) == 0 {
+			continue
+		}
+		m.notify(ctx, triggerType, views)
+	}
+}
+
+// executeInline applies all views returned by TriggerInline directly inside datacoord
+// without consuming inspector slots or notifying the scheduler.
+func (m *CompactionTriggerManager) executeInline(ctx context.Context, events map[CompactionTriggerType][]CompactionView) {
+	for _, views := range events {
+		for _, view := range views {
+			m.applyInlineView(ctx, view)
+		}
+	}
+}
+
+// applyInlineView applies a CompactionView whose IsInlineExecutable() == true
+// directly inside datacoord. Today this is only used by backfillCompactionPolicy
+// for the metadata-only path: bump segment SchemaVersion via meta.UpdateSegment
+// without producing any compaction task.
+func (m *CompactionTriggerManager) applyInlineView(ctx context.Context, view CompactionView) {
+	bv, ok := view.(*BackfillSegmentsView)
+	if !ok {
+		log.Ctx(ctx).Warn("unexpected inline-executable view type, skip",
+			zap.String("actualType", fmt.Sprintf("%T", view)))
+		return
+	}
+	for _, sv := range bv.GetSegmentsView() {
+		if err := m.meta.UpdateSegment(sv.ID, SetSchemaVersion(bv.targetSchemaVersion)); err != nil {
+			log.Ctx(ctx).Error("failed to apply inline backfill schema version update",
+				zap.Int64("segmentID", sv.ID),
+				zap.Int32("newSchemaVersion", bv.targetSchemaVersion),
+				zap.Error(err))
+			continue
+		}
+		log.Ctx(ctx).Info("applied inline backfill schema version update",
+			zap.Int64("segmentID", sv.ID),
+			zap.Int32("newSchemaVersion", bv.targetSchemaVersion))
 	}
 }
 
@@ -356,6 +421,8 @@ func (m *CompactionTriggerManager) notify(ctx context.Context, eventType Compact
 					m.SubmitSingleViewToScheduler(ctx, outView, eventType)
 				case TriggerTypeForceMerge:
 					m.SubmitForceMergeViewToScheduler(ctx, outView)
+				case TriggerTypeBackfill:
+					m.SubmitBackfillViewToScheduler(ctx, outView)
 				}
 			}
 		}
@@ -626,6 +693,84 @@ func (m *CompactionTriggerManager) SubmitForceMergeViewToScheduler(ctx context.C
 		zap.Int64("triggerID", task.GetTriggerID()),
 		zap.Int64("collectionID", task.GetCollectionID()),
 		zap.Int64("targetSize", task.GetMaxSize()),
+	)
+}
+
+func (m *CompactionTriggerManager) SubmitBackfillViewToScheduler(ctx context.Context, view CompactionView) {
+	log := log.Ctx(ctx).With(zap.String("view", view.String()))
+	planID, _, err := m.allocator.AllocN(1)
+	if err != nil {
+		log.Warn("Failed to submit compaction view to scheduler because allocate id fail", zap.Error(err))
+		return
+	}
+	collection, err := m.handler.GetCollection(ctx, view.GetGroupLabel().CollectionID)
+	if err != nil {
+		log.Warn("Failed to submit compaction view to scheduler because get collection fail", zap.Error(err))
+		return
+	}
+	if collection == nil {
+		log.Warn("Failed to submit compaction view to scheduler because collection is nil")
+		return
+	}
+	if collection.IsExternal() {
+		log.Info("skip submitting backfill compaction for external collection", zap.Int64("collectionID", collection.ID))
+		return
+	}
+	var totalRows int64 = 0
+	for _, s := range view.GetSegmentsView() {
+		totalRows += s.NumOfRows
+	}
+	expectedSize := getExpectedSegmentSize(m.meta, collection.ID, collection.Schema)
+	bfView, ok := view.(*BackfillSegmentsView)
+	if !ok {
+		log.Warn("unexpected view type for backfill trigger, expected *BackfillSegmentsView",
+			zap.String("actualType", fmt.Sprintf("%T", view)))
+		return
+	}
+	if bfView.funcDiff == nil || len(bfView.funcDiff.Added) != 1 {
+		funcCount := 0
+		if bfView.funcDiff != nil {
+			funcCount = len(bfView.funcDiff.Added)
+		}
+		log.Warn("backfill view must have exactly one function to backfill",
+			zap.Int("funcCount", funcCount))
+		return
+	}
+	task := &datapb.CompactionTask{
+		PlanID:       planID,
+		TriggerID:    bfView.triggerID,
+		State:        datapb.CompactionTaskState_pipelining,
+		StartTime:    time.Now().Unix(),
+		Type:         datapb.CompactionType_BackfillCompaction,
+		CollectionID: view.GetGroupLabel().CollectionID,
+		PartitionID:  view.GetGroupLabel().PartitionID,
+		Channel:      view.GetGroupLabel().Channel,
+		// Use the schema frozen at scan time so completeBackfillCompactionMutation
+		// only advances the segment to the version that was actually backfilled.
+		// Re-using the live collection.Schema here risks advancing the segment's
+		// SchemaVersion beyond what this task backfills if the collection raced
+		// ahead between scan and submission (prevented in practice by PR #48989).
+		Schema:             bfView.schema,
+		InputSegments:      lo.Map(view.GetSegmentsView(), func(segmentView *SegmentView, _ int) int64 { return segmentView.ID }),
+		ResultSegments:     []int64{},
+		TotalRows:          totalRows,
+		LastStateStartTime: time.Now().Unix(),
+		MaxSize:            expectedSize,
+		DiffFunctions:      bfView.funcDiff.Added,
+	}
+	err = m.inspector.enqueueCompaction(task)
+	if err != nil {
+		log.Warn("Failed to execute compaction task",
+			zap.Int64("triggerID", task.GetTriggerID()),
+			zap.Int64("planID", task.GetPlanID()),
+			zap.Int64s("segmentIDs", task.GetInputSegments()),
+			zap.Error(err))
+		return
+	}
+	log.Info("Finish to submit a backfill compaction task",
+		zap.Int64("triggerID", task.GetTriggerID()),
+		zap.Int64("planID", task.GetPlanID()),
+		zap.String("type", task.GetType().String()),
 	)
 }
 

--- a/internal/datacoord/compaction_trigger_v2_test.go
+++ b/internal/datacoord/compaction_trigger_v2_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/blang/semver/v4"
+	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
@@ -14,6 +15,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
+	"github.com/milvus-io/milvus/internal/metastore/mocks"
 	"github.com/milvus-io/milvus/internal/metastore/model"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/log"
@@ -25,6 +27,44 @@ import (
 func TestCompactionTriggerManagerSuite(t *testing.T) {
 	suite.Run(t, new(CompactionTriggerManagerSuite))
 }
+
+// testCompactionPolicy is a minimal CompactionPolicy stub for handleTicker tests.
+type testCompactionPolicy struct {
+	enabled             bool
+	triggerResult       map[CompactionTriggerType][]CompactionView
+	triggerErr          error
+	inlineTriggerResult map[CompactionTriggerType][]CompactionView
+	policyName          string
+}
+
+func (p *testCompactionPolicy) Enable() bool { return p.enabled }
+func (p *testCompactionPolicy) TriggerInline(_ context.Context) (map[CompactionTriggerType][]CompactionView, error) {
+	return p.inlineTriggerResult, nil
+}
+
+func (p *testCompactionPolicy) Trigger(_ context.Context) (map[CompactionTriggerType][]CompactionView, error) {
+	return p.triggerResult, p.triggerErr
+}
+func (p *testCompactionPolicy) Name() string { return p.policyName }
+
+// stubDispatchableView is a CompactionView stub for handleTicker tests that need a
+// non-inline-executable view to reach the dispatch / isFull branch. All methods
+// return zero values; the only method used by handleTicker is IsInlineExecutable.
+type stubDispatchableView struct{}
+
+func (stubDispatchableView) GetGroupLabel() *CompactionGroupLabel { return &CompactionGroupLabel{} }
+func (stubDispatchableView) GetSegmentsView() []*SegmentView      { return nil }
+func (stubDispatchableView) Append(_ ...*SegmentView)             {}
+func (stubDispatchableView) String() string                       { return "stubDispatchableView" }
+
+// Trigger returns (nil, "") so that notify()'s `if outView != nil` short-circuits
+// before invoking the real Submit*ViewToScheduler path. Tests using this stub care
+// only about the dispatch decision (isFull check), not the downstream submit.
+func (stubDispatchableView) Trigger() (CompactionView, string)           { return nil, "" }
+func (stubDispatchableView) ForceTrigger() (CompactionView, string)      { return nil, "" }
+func (stubDispatchableView) ForceTriggerAll() ([]CompactionView, string) { return nil, "" }
+func (stubDispatchableView) GetTriggerID() int64                         { return 0 }
+func (stubDispatchableView) IsInlineExecutable() bool                    { return false }
 
 type CompactionTriggerManagerSuite struct {
 	suite.Suite
@@ -390,4 +430,387 @@ func (s *CompactionTriggerManagerSuite) TestManualTriggerInvalidParams() {
 	triggerID, err := s.triggerManager.ManualTrigger(context.Background(), s.testLabel.CollectionID, false, false, 0)
 	s.NoError(err)
 	s.Equal(int64(0), triggerID)
+}
+
+func (s *CompactionTriggerManagerSuite) TestSubmitBackfillViewToScheduler() {
+	collectionSchema := &schemapb.CollectionSchema{
+		Name: "test_coll",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 1, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+		},
+		Functions: []*schemapb.FunctionSchema{
+			{Name: "bm25_fn", Type: schemapb.FunctionType_BM25, OutputFieldIds: []int64{100}},
+		},
+	}
+	backfillFunc := collectionSchema.Functions[0]
+
+	makeBackfillView := func(triggerID int64) *BackfillSegmentsView {
+		segView := &SegmentView{
+			ID:        200,
+			label:     s.testLabel,
+			NumOfRows: 1000,
+		}
+		return &BackfillSegmentsView{
+			label:     s.testLabel,
+			segments:  []*SegmentView{segView},
+			triggerID: triggerID,
+			funcDiff:  &FuncDiff{Added: []*schemapb.FunctionSchema{backfillFunc}},
+			schema:    collectionSchema, // frozen at scan time
+		}
+	}
+
+	s.Run("AllocN fails", func() {
+		s.SetupTest()
+		s.mockAlloc.EXPECT().AllocN(int64(1)).Return(int64(0), int64(0), errors.New("alloc error")).Once()
+		view := makeBackfillView(111)
+		// Should return early with no panic — no other mock calls expected.
+		s.triggerManager.SubmitBackfillViewToScheduler(context.Background(), view)
+	})
+
+	s.Run("GetCollection fails", func() {
+		s.SetupTest()
+		const planID = int64(500)
+		s.mockAlloc.EXPECT().AllocN(int64(1)).Return(planID, planID, nil).Once()
+		handler := NewNMockHandler(s.T())
+		handler.EXPECT().GetCollection(mock.Anything, s.testLabel.CollectionID).
+			Return(nil, errors.New("get collection error")).Once()
+		s.triggerManager.handler = handler
+
+		view := makeBackfillView(111)
+		s.triggerManager.SubmitBackfillViewToScheduler(context.Background(), view)
+	})
+
+	s.Run("collection is nil", func() {
+		s.SetupTest()
+		const planID = int64(501)
+		s.mockAlloc.EXPECT().AllocN(int64(1)).Return(planID, planID, nil).Once()
+		handler := NewNMockHandler(s.T())
+		handler.EXPECT().GetCollection(mock.Anything, s.testLabel.CollectionID).
+			Return(nil, nil).Once()
+		s.triggerManager.handler = handler
+
+		view := makeBackfillView(111)
+		s.triggerManager.SubmitBackfillViewToScheduler(context.Background(), view)
+	})
+
+	s.Run("collection is external", func() {
+		s.SetupTest()
+		const planID = int64(502)
+		s.mockAlloc.EXPECT().AllocN(int64(1)).Return(planID, planID, nil).Once()
+		handler := NewNMockHandler(s.T())
+		handler.EXPECT().GetCollection(mock.Anything, s.testLabel.CollectionID).
+			Return(&collectionInfo{
+				ID: s.testLabel.CollectionID,
+				// IsExternal() checks for fields with ExternalField set, not Schema.ExternalSource.
+				Schema: &schemapb.CollectionSchema{
+					Fields: []*schemapb.FieldSchema{
+						{FieldID: 1, Name: "ext_field", ExternalField: "s3://bucket/external"},
+					},
+				},
+			}, nil).Once()
+		s.triggerManager.handler = handler
+
+		view := makeBackfillView(111)
+		s.triggerManager.SubmitBackfillViewToScheduler(context.Background(), view)
+	})
+
+	s.Run("funcDiff is nil", func() {
+		s.SetupTest()
+		s.meta.indexMeta = &indexMeta{indexes: make(map[UniqueID]map[UniqueID]*model.Index)}
+		const planID = int64(504)
+		s.mockAlloc.EXPECT().AllocN(int64(1)).Return(planID, planID, nil).Once()
+		handler := NewNMockHandler(s.T())
+		handler.EXPECT().GetCollection(mock.Anything, s.testLabel.CollectionID).
+			Return(&collectionInfo{
+				ID:     s.testLabel.CollectionID,
+				Schema: collectionSchema,
+			}, nil).Once()
+		s.triggerManager.handler = handler
+
+		// Create a BackfillSegmentsView with funcDiff=nil — should log warning and return, not panic.
+		view := &BackfillSegmentsView{
+			label:     s.testLabel,
+			segments:  []*SegmentView{{ID: 200, label: s.testLabel, NumOfRows: 1000}},
+			triggerID: 111,
+			funcDiff:  nil,
+		}
+		s.triggerManager.SubmitBackfillViewToScheduler(context.Background(), view)
+	})
+
+	s.Run("view is not BackfillSegmentsView", func() {
+		s.SetupTest()
+		s.meta.indexMeta = &indexMeta{indexes: make(map[UniqueID]map[UniqueID]*model.Index)}
+		const planID = int64(503)
+		s.mockAlloc.EXPECT().AllocN(int64(1)).Return(planID, planID, nil).Once()
+		handler := NewNMockHandler(s.T())
+		handler.EXPECT().GetCollection(mock.Anything, s.testLabel.CollectionID).
+			Return(&collectionInfo{
+				ID:     s.testLabel.CollectionID,
+				Schema: collectionSchema,
+			}, nil).Once()
+		s.triggerManager.handler = handler
+
+		// Use LevelZeroCompactionView which is NOT a *BackfillSegmentsView.
+		nonBackfillView := &LevelZeroCompactionView{
+			label:      s.testLabel,
+			l0Segments: []*SegmentView{},
+		}
+		s.triggerManager.SubmitBackfillViewToScheduler(context.Background(), nonBackfillView)
+	})
+
+	s.Run("enqueueCompaction fails", func() {
+		s.SetupTest()
+		s.meta.indexMeta = &indexMeta{indexes: make(map[UniqueID]map[UniqueID]*model.Index)}
+		const (
+			planID    = int64(504)
+			triggerID = int64(999)
+		)
+		s.mockAlloc.EXPECT().AllocN(int64(1)).Return(planID, planID, nil).Once()
+		handler := NewNMockHandler(s.T())
+		handler.EXPECT().GetCollection(mock.Anything, s.testLabel.CollectionID).
+			Return(&collectionInfo{
+				ID:     s.testLabel.CollectionID,
+				Schema: collectionSchema,
+			}, nil).Once()
+		s.triggerManager.handler = handler
+		s.inspector.EXPECT().enqueueCompaction(mock.Anything).Return(errors.New("enqueue error")).Once()
+
+		view := makeBackfillView(triggerID)
+		s.triggerManager.SubmitBackfillViewToScheduler(context.Background(), view)
+	})
+
+	s.Run("success", func() {
+		s.SetupTest()
+		s.meta.indexMeta = &indexMeta{indexes: make(map[UniqueID]map[UniqueID]*model.Index)}
+		const (
+			planID    = int64(600)
+			triggerID = int64(1001)
+		)
+		s.mockAlloc.EXPECT().AllocN(int64(1)).Return(planID, planID, nil).Once()
+		handler := NewNMockHandler(s.T())
+		handler.EXPECT().GetCollection(mock.Anything, s.testLabel.CollectionID).
+			Return(&collectionInfo{
+				ID:     s.testLabel.CollectionID,
+				Schema: collectionSchema,
+			}, nil).Once()
+		s.triggerManager.handler = handler
+		s.inspector.EXPECT().enqueueCompaction(mock.Anything).
+			RunAndReturn(func(task *datapb.CompactionTask) error {
+				s.EqualValues(planID, task.GetPlanID())
+				s.EqualValues(triggerID, task.GetTriggerID())
+				s.Equal(datapb.CompactionType_BackfillCompaction, task.GetType())
+				s.Equal(s.testLabel.CollectionID, task.GetCollectionID())
+				s.Equal(s.testLabel.PartitionID, task.GetPartitionID())
+				s.Equal(s.testLabel.Channel, task.GetChannel())
+				s.Equal(collectionSchema, task.GetSchema())
+				s.Require().Len(task.GetDiffFunctions(), 1)
+				s.Equal(backfillFunc.GetName(), task.GetDiffFunctions()[0].GetName())
+				s.ElementsMatch([]int64{200}, task.GetInputSegments())
+				return nil
+			}).Once()
+
+		view := makeBackfillView(triggerID)
+		s.triggerManager.SubmitBackfillViewToScheduler(context.Background(), view)
+	})
+}
+
+func (s *CompactionTriggerManagerSuite) TestHandleTicker() {
+	s.Run("policy not found for ticker type", func() {
+		s.SetupTest()
+		// TickerType 99 is not registered in policies map
+		s.triggerManager.handleTicker(context.Background(), TickerType(99))
+		// Should return without panic
+	})
+
+	s.Run("policy disabled", func() {
+		s.SetupTest()
+		mockPolicy := &testCompactionPolicy{enabled: false, policyName: "test-disabled"}
+		s.triggerManager.policies[BackfillTicker] = mockPolicy
+		s.triggerManager.handleTicker(context.Background(), BackfillTicker)
+		// Returns early — no inspector or trigger calls
+	})
+
+	s.Run("inspector full skips Trigger dispatch", func() {
+		// When isFull() returns true, Trigger() is not called. TriggerInline() runs
+		// unconditionally before the isFull() gate, so metadata-only updates always
+		// proceed; only physical compaction tasks are gated by inspector capacity.
+		s.SetupTest()
+		mockPolicy := &testCompactionPolicy{
+			enabled:    true,
+			policyName: "test-full",
+			// Views in Trigger() result are NOT dispatched because isFull() returns true.
+			triggerResult: map[CompactionTriggerType][]CompactionView{
+				TriggerTypeBackfill: {stubDispatchableView{}},
+			},
+		}
+		s.triggerManager.policies[BackfillTicker] = mockPolicy
+		s.inspector.EXPECT().isFull().Return(true).Once()
+		s.triggerManager.handleTicker(context.Background(), BackfillTicker)
+	})
+
+	s.Run("policy trigger error returns before isFull check", func() {
+		s.SetupTest()
+		mockPolicy := &testCompactionPolicy{
+			enabled:    true,
+			policyName: "test-err",
+			triggerErr: errors.New("trigger error"),
+		}
+		s.triggerManager.policies[BackfillTicker] = mockPolicy
+		// isFull() IS called now (step 2, before Trigger). Trigger() errors → no notify().
+		s.inspector.EXPECT().isFull().Return(false).Once()
+		s.triggerManager.handleTicker(context.Background(), BackfillTicker)
+	})
+
+	s.Run("policy trigger returns no events skips isFull check", func() {
+		s.SetupTest()
+		mockPolicy := &testCompactionPolicy{
+			enabled:    true,
+			policyName: "test-empty",
+			// Nil result — Trigger() returns nothing, notify() is never called.
+			triggerResult: nil,
+		}
+		s.triggerManager.policies[BackfillTicker] = mockPolicy
+		// isFull() IS called now (step 2 gate before Trigger). Trigger returns nil → no notify.
+		s.inspector.EXPECT().isFull().Return(false).Once()
+		s.triggerManager.handleTicker(context.Background(), BackfillTicker)
+	})
+
+	s.Run("policy trigger returns events dispatched when inspector not full", func() {
+		s.SetupTest()
+		mockPolicy := &testCompactionPolicy{
+			enabled:    true,
+			policyName: "test-events",
+			triggerResult: map[CompactionTriggerType][]CompactionView{
+				TriggerTypeBackfill: {stubDispatchableView{}},
+			},
+		}
+		s.triggerManager.policies[BackfillTicker] = mockPolicy
+		s.inspector.EXPECT().isFull().Return(false).Once()
+		// stubDispatchableView.Trigger() returns nil, so notify() short-circuits
+		// before reaching SubmitBackfillViewToScheduler. We only care here that
+		// isFull was consulted and the dispatch path was entered.
+		s.triggerManager.handleTicker(context.Background(), BackfillTicker)
+	})
+
+	s.Run("inline-executable backfill view applied regardless of inspector full", func() {
+		// Regression for backfillCompactionPolicy: pure column additions emit an
+		// inline-executable BackfillSegmentsView (inlineMetaOnly=true). The trigger
+		// manager must apply it via meta.UpdateSegment without consulting isFull —
+		// otherwise schema versions never converge under inspector pressure.
+		s.SetupTest()
+
+		// Wire a mock catalog so meta.UpdateSegment can call catalog.AlterSegments.
+		mockCatalog := mocks.NewDataCoordCatalog(s.T())
+		mockCatalog.EXPECT().AlterSegments(mock.Anything, mock.Anything, mock.Anything).
+			Return(nil).Once()
+		s.triggerManager.meta.catalog = mockCatalog
+
+		segmentID := int64(424242)
+		s.triggerManager.meta.segments.SetSegment(segmentID, &SegmentInfo{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:            segmentID,
+				CollectionID:  s.testLabel.CollectionID,
+				State:         commonpb.SegmentState_Flushed,
+				SchemaVersion: 1,
+			},
+		})
+
+		// Inline views come from TriggerInline(), not Trigger(). Trigger() returns nothing.
+		// The inline view is applied before isFull() is even consulted, so schema version
+		// convergence is guaranteed regardless of inspector pressure.
+		mockPolicy := &testCompactionPolicy{
+			enabled:    true,
+			policyName: "test-meta-update",
+			inlineTriggerResult: map[CompactionTriggerType][]CompactionView{
+				TriggerTypeBackfill: {
+					&BackfillSegmentsView{
+						label:               s.testLabel,
+						segments:            []*SegmentView{{ID: segmentID, label: s.testLabel}},
+						inlineMetaOnly:      true,
+						targetSchemaVersion: 5,
+					},
+				},
+			},
+			// triggerResult is nil: no compaction tasks to dispatch
+		}
+		s.triggerManager.policies[BackfillTicker] = mockPolicy
+		// isFull() is consulted for the Trigger() gate — simulate a full inspector to
+		// prove inline views are unaffected by inspector pressure.
+		s.inspector.EXPECT().isFull().Return(true).Once()
+		s.triggerManager.handleTicker(context.Background(), BackfillTicker)
+
+		updated := s.triggerManager.meta.segments.GetSegment(segmentID)
+		s.Require().NotNil(updated)
+		s.Equal(int32(5), updated.GetSchemaVersion(),
+			"inline view must be applied to bump segment schema version")
+	})
+
+	s.Run("applyInlineView with wrong view type logs warning and returns", func() {
+		// When TriggerInline() returns a non-BackfillSegmentsView in the inline events,
+		// applyInlineView must log a warning and return without panic.
+		s.SetupTest()
+		mockPolicy := &testCompactionPolicy{
+			enabled:    true,
+			policyName: "test-wrong-inline-type",
+			inlineTriggerResult: map[CompactionTriggerType][]CompactionView{
+				TriggerTypeBackfill: {
+					// stubDispatchableView is NOT *BackfillSegmentsView — triggers the wrong-type branch.
+					stubDispatchableView{},
+				},
+			},
+			// No compaction tasks to dispatch.
+		}
+		s.triggerManager.policies[BackfillTicker] = mockPolicy
+		// isFull() is consulted for the Trigger() gate.
+		s.inspector.EXPECT().isFull().Return(true).Once()
+		// Should complete without panic.
+		s.triggerManager.handleTicker(context.Background(), BackfillTicker)
+	})
+
+	s.Run("applyInlineView UpdateSegment fails logs error and continues", func() {
+		// When meta.UpdateSegment fails (catalog error), applyInlineView logs the error
+		// and continues rather than aborting the whole inline pass.
+		s.SetupTest()
+
+		// Wire a catalog that rejects AlterSegments.
+		mockCatalog := mocks.NewDataCoordCatalog(s.T())
+		mockCatalog.EXPECT().AlterSegments(mock.Anything, mock.Anything, mock.Anything).
+			Return(errors.New("catalog error")).Once()
+		s.triggerManager.meta.catalog = mockCatalog
+
+		segmentID := int64(424243)
+		s.triggerManager.meta.segments.SetSegment(segmentID, &SegmentInfo{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:            segmentID,
+				CollectionID:  s.testLabel.CollectionID,
+				State:         commonpb.SegmentState_Flushed,
+				SchemaVersion: 1,
+			},
+		})
+
+		mockPolicy := &testCompactionPolicy{
+			enabled:    true,
+			policyName: "test-update-segment-fail",
+			inlineTriggerResult: map[CompactionTriggerType][]CompactionView{
+				TriggerTypeBackfill: {
+					&BackfillSegmentsView{
+						label:               s.testLabel,
+						segments:            []*SegmentView{{ID: segmentID, label: s.testLabel}},
+						inlineMetaOnly:      true,
+						targetSchemaVersion: 9,
+					},
+				},
+			},
+		}
+		s.triggerManager.policies[BackfillTicker] = mockPolicy
+		s.inspector.EXPECT().isFull().Return(true).Once()
+		// Should not panic despite the catalog error.
+		s.triggerManager.handleTicker(context.Background(), BackfillTicker)
+
+		// Schema version must remain unchanged because UpdateSegment failed.
+		updated := s.triggerManager.meta.segments.GetSegment(segmentID)
+		s.Require().NotNil(updated)
+		s.Equal(int32(1), updated.GetSchemaVersion(),
+			"schema version must stay 1 when UpdateSegment fails")
+	})
 }

--- a/internal/datacoord/compaction_view.go
+++ b/internal/datacoord/compaction_view.go
@@ -36,6 +36,12 @@ type CompactionView interface {
 	ForceTrigger() (CompactionView, string)
 	ForceTriggerAll() ([]CompactionView, string)
 	GetTriggerID() int64
+	// IsInlineExecutable reports whether this view should be applied directly inside
+	// datacoord by CompactionTriggerManager rather than dispatched as a compaction
+	// task to the inspector. Inline views consume no inspector slot and do not depend
+	// on a free queue, so they must not be gated by inspector pressure.
+	// Default: false (most views are real compaction work).
+	IsInlineExecutable() bool
 }
 
 type FullViews struct {

--- a/internal/datacoord/compaction_view_forcemerge.go
+++ b/internal/datacoord/compaction_view_forcemerge.go
@@ -32,6 +32,9 @@ const (
 	defaultToleranceMB = 0.05
 )
 
+// IsInlineExecutable returns false: force merge is real compaction work.
+func (v *ForceMergeSegmentView) IsInlineExecutable() bool { return false }
+
 // static segment view, only algothrims here, no IO
 type ForceMergeSegmentView struct {
 	label         *CompactionGroupLabel

--- a/internal/datacoord/index_inspector.go
+++ b/internal/datacoord/index_inspector.go
@@ -18,6 +18,7 @@ package datacoord
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -31,6 +32,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/vecindexmgr"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
@@ -156,16 +158,71 @@ func (i *indexInspector) createIndexesForSegment(ctx context.Context, segment *S
 
 	indexes := i.meta.indexMeta.GetIndexesForCollection(segment.CollectionID, "")
 	indexIDToSegIndexes := i.meta.indexMeta.GetSegmentIndexes(segment.CollectionID, segment.ID)
+
+	// MinSchemaVersion enforcement is only applied while the collection has an in-flight
+	// physical backfill (e.g. AlterCollectionSchema adding a BM25 function): until backfill
+	// writes the new field's data, an index built on the empty binlog would silently return
+	// wrong results. For metadata-only schema changes (e.g. nullable AddCollectionField),
+	// the index builder handles null/default values, so no delay is needed.
+	// Within the physical-backfill branch we still double-check segment binlogs because a
+	// function output field that was backfilled in a previous schema version is already
+	// present in this segment.
+	coll := i.meta.GetCollection(segment.CollectionID)
+	collectionInPhysicalBackfill := coll != nil && coll.Schema != nil && coll.Schema.GetDoPhysicalBackfill()
+	var segmentBinlogFields map[int64]struct{}
 	for _, index := range indexes {
-		if _, ok := indexIDToSegIndexes[index.IndexID]; !ok {
-			if err := i.createIndexForSegment(ctx, segment, index.IndexID); err != nil {
-				log.Ctx(ctx).Warn("create index for segment fail", zap.Int64("segmentID", segment.ID),
-					zap.Int64("indexID", index.IndexID))
-				return err
+		if _, ok := indexIDToSegIndexes[index.IndexID]; ok {
+			continue
+		}
+		if collectionInPhysicalBackfill && index.MinSchemaVersion > segment.GetSchemaVersion() {
+			if segmentBinlogFields == nil {
+				segmentBinlogFields = getSegmentBinlogFields(segment)
 			}
+			if _, hasField := segmentBinlogFields[index.FieldID]; !hasField {
+				log.Ctx(ctx).Info("skip index creation: field data not yet present in segment, waiting for physical backfill",
+					zap.Int64("segmentID", segment.ID),
+					zap.Int64("indexID", index.IndexID),
+					zap.Int64("fieldID", index.FieldID),
+					zap.Int32("segSchemaVersion", segment.GetSchemaVersion()),
+					zap.Int32("indexMinSchemaVersion", index.MinSchemaVersion))
+				continue
+			}
+			// Transient inconsistency window: backfill has already written the field's
+			// binlog data to this segment, but the metadata tick has not yet bumped
+			// segment.SchemaVersion to match. The window should close within one backfill
+			// tick. Bail out with an error so the inspector retries on the next tick by
+			// which time the metadata is expected to have caught up. Sustained occurrences
+			// indicate the metadata-update path is stuck and warrant investigation.
+			log.Ctx(ctx).Warn("inconsistent state: field binlogs present but segment schema version still behind, will retry",
+				zap.Int64("segmentID", segment.ID),
+				zap.Int64("indexID", index.IndexID),
+				zap.Int64("fieldID", index.FieldID),
+				zap.Int32("segSchemaVersion", segment.GetSchemaVersion()),
+				zap.Int32("indexMinSchemaVersion", index.MinSchemaVersion))
+			return merr.WrapErrServiceInternal(
+				fmt.Sprintf("segment schema version %d behind index min schema version %d while field %d binlogs already present, retry next tick",
+					segment.GetSchemaVersion(), index.MinSchemaVersion, index.FieldID))
+		}
+		if err := i.createIndexForSegment(ctx, segment, index.IndexID); err != nil {
+			log.Ctx(ctx).Warn("create index for segment fail", zap.Int64("segmentID", segment.ID),
+				zap.Int64("indexID", index.IndexID))
+			return err
 		}
 	}
 	return nil
+}
+
+// getSegmentBinlogFields returns the set of field IDs that have binlog data in the segment.
+// binlog.GetFieldID() is a columnGroupID, not a real field ID; the actual field IDs
+// are always in binlog.GetChildFields().
+func getSegmentBinlogFields(segment *SegmentInfo) map[int64]struct{} {
+	result := make(map[int64]struct{})
+	for _, binlog := range segment.GetBinlogs() {
+		for _, childFieldID := range binlog.GetChildFields() {
+			result[childFieldID] = struct{}{}
+		}
+	}
+	return result
 }
 
 func (i *indexInspector) createIndexForSegment(ctx context.Context, segment *SegmentInfo, indexID UniqueID) error {

--- a/internal/datacoord/index_inspector_test.go
+++ b/internal/datacoord/index_inspector_test.go
@@ -378,3 +378,174 @@ func TestIndexInspector_CreateIndexForSegment_OverrideIndexType(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, "DISKANN", segIdx.IndexType)
 }
+
+func TestGetSegmentBinlogFields(t *testing.T) {
+	t.Run("uses ChildFields not FieldID", func(t *testing.T) {
+		segment := &SegmentInfo{
+			SegmentInfo: &datapb.SegmentInfo{
+				Binlogs: []*datapb.FieldBinlog{
+					{
+						FieldID:     0, // columnGroupID
+						ChildFields: []int64{100, 101, 102},
+					},
+					{
+						FieldID:     1, // another columnGroupID
+						ChildFields: []int64{200},
+					},
+				},
+			},
+		}
+		fields := getSegmentBinlogFields(segment)
+		assert.Contains(t, fields, int64(100))
+		assert.Contains(t, fields, int64(101))
+		assert.Contains(t, fields, int64(102))
+		assert.Contains(t, fields, int64(200))
+		// columnGroupIDs should NOT be in the result
+		assert.NotContains(t, fields, int64(0))
+		assert.NotContains(t, fields, int64(1))
+	})
+
+	t.Run("empty binlogs", func(t *testing.T) {
+		segment := &SegmentInfo{
+			SegmentInfo: &datapb.SegmentInfo{Binlogs: nil},
+		}
+		fields := getSegmentBinlogFields(segment)
+		assert.Empty(t, fields)
+	})
+}
+
+func TestIndexInspector_MinSchemaVersionEnforcement(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.EnableSortCompaction.Key, "false")
+	defer paramtable.Get().Reset(paramtable.Get().DataCoordCfg.EnableSortCompaction.Key)
+
+	ctx := context.Background()
+	notifyChan := make(chan int64, 1)
+	scheduler := task.NewMockGlobalScheduler(t)
+	alloc := allocator.NewMockAllocator(t)
+	handler := NewNMockHandler(t)
+	storageCli := mocks.NewChunkManager(t)
+	versionManager := newIndexEngineVersionManager()
+	catalog := mocks2.NewDataCoordCatalog(t)
+
+	m := &meta{
+		segments:    NewSegmentsInfo(),
+		collections: typeutil.NewConcurrentMap[UniqueID, *collectionInfo](),
+		indexMeta: &indexMeta{
+			keyLock:          lock.NewKeyLock[UniqueID](),
+			catalog:          catalog,
+			segmentBuildInfo: newSegmentIndexBuildInfo(),
+			indexes:          make(map[UniqueID]map[UniqueID]*model.Index),
+			segmentIndexes:   typeutil.NewConcurrentMap[UniqueID, *typeutil.ConcurrentMap[UniqueID, *model.SegmentIndex]](),
+		},
+	}
+
+	inspector := newIndexInspector(ctx, notifyChan, m, scheduler, alloc, handler, storageCli, versionManager)
+
+	collID := int64(10)
+
+	// Index on field 102 (function output) with MinSchemaVersion=2
+	m.indexMeta.indexes[collID] = map[UniqueID]*model.Index{
+		5: {
+			CollectionID:     collID,
+			FieldID:          102,
+			IndexID:          5,
+			IndexName:        "bm25_idx",
+			MinSchemaVersion: 2,
+		},
+	}
+
+	m.collections.Insert(collID, &collectionInfo{
+		ID: collID,
+		Schema: &schemapb.CollectionSchema{
+			// DoPhysicalBackfill=true is required for the MinSchemaVersion gate to engage.
+			// Without it the gate is bypassed and indexes are built immediately (the
+			// metadata-only schema-change path).
+			DoPhysicalBackfill: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64},
+				{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar},
+				{FieldID: 102, Name: "sparse", DataType: schemapb.DataType_SparseFloatVector},
+			},
+			Functions: []*schemapb.FunctionSchema{
+				{Name: "bm25_fn", OutputFieldIds: []int64{102}},
+			},
+		},
+	})
+
+	t.Run("skip index when field data missing from segment", func(t *testing.T) {
+		// Segment with SchemaVersion=1, binlogs have fields 100+101 but NOT 102.
+		// In physical backfill mode, the gate skips index creation until the field's
+		// binlog data is written by backfill.
+		segment := &SegmentInfo{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:            1,
+				CollectionID:  collID,
+				State:         commonpb.SegmentState_Flushed,
+				IsSorted:      true,
+				SchemaVersion: 1,
+				Binlogs: []*datapb.FieldBinlog{
+					{FieldID: 0, ChildFields: []int64{100, 101}},
+				},
+			},
+		}
+		m.segments.SetSegment(segment.GetID(), segment)
+
+		err := inspector.createIndexesForSegment(ctx, segment)
+		assert.NoError(t, err)
+		// Index should NOT have been created — field 102 data is missing
+		assert.True(t, m.indexMeta.IsUnIndexedSegment(collID, segment.GetID()))
+	})
+
+	t.Run("return error when field binlogs present but segment schema version still behind", func(t *testing.T) {
+		// Segment with SchemaVersion=1 (behind index.MinSchemaVersion=2) BUT field 102
+		// already exists in binlogs. This is a transient inconsistency window: backfill
+		// has written the field data but the metadata-update tick has not yet bumped
+		// segment.SchemaVersion. The inspector must NOT proceed to build the index in
+		// this window — it returns an error and retries on the next tick by which time
+		// the metadata is expected to have caught up.
+		segment := &SegmentInfo{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:            2,
+				CollectionID:  collID,
+				State:         commonpb.SegmentState_Flushed,
+				IsSorted:      true,
+				SchemaVersion: 1,
+				Binlogs: []*datapb.FieldBinlog{
+					{FieldID: 0, ChildFields: []int64{100, 101, 102}},
+				},
+			},
+		}
+		m.segments.SetSegment(segment.GetID(), segment)
+
+		err := inspector.createIndexesForSegment(ctx, segment)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "segment schema version")
+		// Index should NOT have been created
+		assert.True(t, m.indexMeta.IsUnIndexedSegment(collID, segment.GetID()))
+	})
+
+	t.Run("create index normally when MinSchemaVersion matches", func(t *testing.T) {
+		// Segment with SchemaVersion=2, matches MinSchemaVersion — should proceed normally
+		segment := &SegmentInfo{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:            3,
+				CollectionID:  collID,
+				State:         commonpb.SegmentState_Flushed,
+				IsSorted:      true,
+				SchemaVersion: 2,
+				Binlogs: []*datapb.FieldBinlog{
+					{FieldID: 0, ChildFields: []int64{100, 101, 102}},
+				},
+			},
+		}
+		m.segments.SetSegment(segment.GetID(), segment)
+
+		alloc.EXPECT().AllocID(mock.Anything).Return(int64(12346), nil).Once()
+		catalog.EXPECT().CreateSegmentIndex(mock.Anything, mock.Anything).Return(nil).Once()
+		scheduler.EXPECT().Enqueue(mock.Anything).Return().Once()
+
+		err := inspector.createIndexesForSegment(ctx, segment)
+		assert.NoError(t, err)
+	})
+}

--- a/internal/datacoord/index_service.go
+++ b/internal/datacoord/index_service.go
@@ -269,12 +269,19 @@ func (s *Server) CreateIndex(ctx context.Context, req *indexpb.CreateIndexReques
 		CreateTime:      req.GetTimestamp(),
 		IsAutoIndex:     req.GetIsAutoIndex(),
 		UserIndexParams: req.GetUserIndexParams(),
+		// MinSchemaVersion prevents building an index on a function-output column (e.g. BM25 sparse
+		// vector) before backfill has written that column into old segments.  The inspector skips any
+		// segment whose SchemaVersion is still below this value.
+		MinSchemaVersion: schema.GetVersion(),
 	}
 	// Validate the index params.
 	if err := ValidateIndexParams(index); err != nil {
 		return nil, err
 	}
 
+	channels := make([]string, 0, len(coll.GetVirtualChannelNames())+1)
+	channels = append(channels, streaming.WAL().ControlChannel())
+	channels = append(channels, coll.GetVirtualChannelNames()...)
 	if _, err = broadcaster.Broadcast(ctx, message.NewCreateIndexMessageBuilderV2().
 		WithHeader(&message.CreateIndexMessageHeader{
 			DbId:         coll.GetDbId(),
@@ -286,7 +293,7 @@ func (s *Server) CreateIndex(ctx context.Context, req *indexpb.CreateIndexReques
 		WithBody(&message.CreateIndexMessageBody{
 			FieldIndex: model.MarshalIndexModel(index),
 		}).
-		WithBroadcast([]string{streaming.WAL().ControlChannel()}).
+		WithBroadcast(channels).
 		MustBuildBroadcast(),
 	); err != nil {
 		log.Error("CreateIndex fail", zap.Error(err))
@@ -295,7 +302,8 @@ func (s *Server) CreateIndex(ctx context.Context, req *indexpb.CreateIndexReques
 	}
 	log.Info("CreateIndex successfully",
 		zap.String("IndexName", index.IndexName), zap.Int64("fieldID", index.FieldID),
-		zap.Int64("IndexID", index.IndexID))
+		zap.Int64("IndexID", index.IndexID), zap.Int32("MinSchemaVersion", index.MinSchemaVersion),
+		zap.Strings("channels", channels))
 	metrics.IndexRequestCounter.WithLabelValues(metrics.SuccessLabel).Inc()
 	return merr.Success(), nil
 }

--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -1857,6 +1857,7 @@ func (m *meta) completeClusterCompactionMutation(t *datapb.CompactionTask, resul
 			StorageVersion: seg.GetStorageVersion(),
 			ManifestPath:   seg.GetManifest(),
 			ExpirQuantiles: seg.GetExpirQuantiles(),
+			SchemaVersion:  compactFromSegInfos[0].GetSchemaVersion(),
 		}
 		segment := NewSegmentInfo(segmentInfo)
 		compactToSegInfos = append(compactToSegInfos, segment)
@@ -1969,6 +1970,7 @@ func (m *meta) completeMixCompactionMutation(
 				ManifestPath:        compactToSegment.GetManifest(),
 				IsSortedByNamespace: compactToSegment.GetIsSortedByNamespace(),
 				ExpirQuantiles:      compactToSegment.GetExpirQuantiles(),
+				SchemaVersion:       compactFromSegInfos[0].GetSchemaVersion(),
 			})
 
 		if compactToSegmentInfo.GetNumOfRows() == 0 {
@@ -2094,6 +2096,8 @@ func (m *meta) CompleteCompactionMutation(ctx context.Context, t *datapb.Compact
 		return m.completeClusterCompactionMutation(t, result)
 	case datapb.CompactionType_SortCompaction:
 		return m.completeSortCompactionMutation(t, result)
+	case datapb.CompactionType_BackfillCompaction:
+		return m.completeBackfillCompactionMutation(t, result)
 	}
 	return nil, nil, merr.WrapErrIllegalCompactionPlan("illegal compaction type")
 }
@@ -2532,6 +2536,7 @@ func (m *meta) completeSortCompactionMutation(
 		ManifestPath:              resultSegment.GetManifest(),
 		ExpirQuantiles:            resultSegment.GetExpirQuantiles(),
 		IsSortedByNamespace:       resultSegment.GetIsSortedByNamespace(),
+		SchemaVersion:             oldSegment.GetSchemaVersion(),
 	}
 
 	segment := NewSegmentInfo(segmentInfo)
@@ -2564,6 +2569,125 @@ func (m *meta) completeSortCompactionMutation(
 	m.segments.SetSegment(segment.GetID(), segment)
 	log.Info("meta update: alter in memory meta after compaction - complete")
 	return []*SegmentInfo{segment}, metricMutation, nil
+}
+
+func (m *meta) completeBackfillCompactionMutation(
+	t *datapb.CompactionTask,
+	result *datapb.CompactionPlanResult,
+) ([]*SegmentInfo, *segMetricMutation, error) {
+	log := log.Ctx(context.TODO()).With(zap.Int64("planID", t.GetPlanID()),
+		zap.String("type", t.GetType().String()),
+		zap.Int64("collectionID", t.CollectionID),
+		zap.Int64("partitionID", t.PartitionID),
+		zap.String("channel", t.GetChannel()))
+
+	metricMutation := &segMetricMutation{stateChange: make(map[string]map[string]map[string]map[string]int)}
+
+	// Backfill compaction updates the existing segment, not creating a new one
+	if len(t.GetInputSegments()) != 1 {
+		return nil, nil, merr.WrapErrIllegalCompactionPlan("backfill compaction should have exactly one input segment")
+	}
+	if len(result.GetSegments()) != 1 {
+		return nil, nil, merr.WrapErrIllegalCompactionPlan("backfill compaction result should have exactly one segment")
+	}
+
+	segmentID := t.GetInputSegments()[0]
+	oldSegment := m.segments.GetSegment(segmentID)
+	if oldSegment == nil {
+		return nil, nil, merr.WrapErrSegmentNotFound(segmentID)
+	}
+
+	// Re-validate segment health to prevent race condition with drop collection
+	// between ValidateSegmentStateBeforeCompleteCompactionMutation and here
+	if !isSegmentHealthy(oldSegment) {
+		log.Warn("input segment was dropped during compaction mutation",
+			zap.Int64("planID", t.GetPlanID()),
+			zap.Int64("segmentID", segmentID),
+			zap.String("state", oldSegment.GetState().String()))
+		return nil, nil, merr.WrapErrSegmentNotFound(segmentID, "input segment was dropped")
+	}
+
+	resultSegment := result.GetSegments()[0]
+	if resultSegment.GetSegmentID() != segmentID {
+		return nil, nil, merr.WrapErrIllegalCompactionPlan(fmt.Sprintf("backfill compaction result segment ID %d does not match input segment ID %d", resultSegment.GetSegmentID(), segmentID))
+	}
+
+	// Clone the segment for update
+	cloned := oldSegment.Clone()
+
+	// Replace binlogs with the merged result (original fields + new function output field).
+	// For V3 segments, buildMergedLogsV3 assigns LogID!=0 so buildBinlogKvs validation passes
+	// and getSegmentBinlogFields can detect the new field via ChildFields.
+	cloned.Binlogs = resultSegment.GetInsertLogs()
+
+	// Update BM25 stats logs: for V2 segments, stats are separate files tracked in Bm25Statslogs.
+	// Merge so that stats for previously backfilled BM25 fields are preserved when a second
+	// AlterCollectionSchema adds another BM25 function. Before merging, filter out entries
+	// whose (fieldID, logID) already exist so that crash-replay — where the same result is
+	// applied twice because datacoord crashed between the etcd write and the task state
+	// transition — does not produce duplicate stats entries.
+	// For V3 segments (manifest-based), BM25 stats are embedded in the manifest and
+	// Bm25Logs in the result is nil — skip updating Bm25Statslogs to avoid clearing existing stats.
+	if resultSegment.GetManifest() == "" {
+		dedupedBm25Logs := filterDuplicateFieldBinlogs(cloned.GetBm25Statslogs(), resultSegment.GetBm25Logs())
+		cloned.Bm25Statslogs = mergeFieldBinlogs(cloned.GetBm25Statslogs(), dedupedBm25Logs)
+	}
+
+	// Update SchemaVersion from task schema.
+	// t.Schema is set from collection.Schema at task creation time and should never be nil.
+	// A nil schema here indicates data corruption (e.g. etcd serialization loss); we warn
+	// and skip the update so the segment's schemaVersion remains stale, causing the next
+	// backfill trigger to re-evaluate and re-submit the task.
+	if t.GetSchema() == nil {
+		log.Warn("backfill compaction task has nil schema, skipping schemaVersion update — segment will be re-evaluated on next trigger",
+			zap.Int64("segmentID", segmentID),
+			zap.Int64("planID", t.GetPlanID()))
+	} else {
+		newSchemaVersion := t.GetSchema().GetVersion()
+		if newSchemaVersion > cloned.GetSchemaVersion() {
+			cloned.SchemaVersion = newSchemaVersion
+			log.Info("meta update: update schema version for backfill compaction",
+				zap.Int64("segmentID", segmentID),
+				zap.Int32("oldSchemaVersion", oldSegment.GetSchemaVersion()),
+				zap.Int32("newSchemaVersion", newSchemaVersion))
+		}
+	}
+
+	// Update StorageVersion only when result has manifest (true V3 segment).
+	// V2 segments on V3 clusters stay V2 — backfill forces V2 path to avoid
+	// creating partial manifests that would corrupt segment loading.
+	// Update ManifestPath for V3 segments — the merged manifest contains both
+	// original columns and new function output columns + BM25 stats.
+	if resultSegment.GetManifest() != "" {
+		cloned.StorageVersion = resultSegment.GetStorageVersion()
+		cloned.ManifestPath = resultSegment.GetManifest()
+	}
+
+	// Prepare binlogs increment for catalog update
+	binlogsIncrement := metastore.BinlogsIncrement{
+		Segment: cloned.SegmentInfo,
+	}
+
+	log = log.With(zap.Int64("segmentID", segmentID),
+		zap.Int32("oldSchemaVersion", oldSegment.GetSchemaVersion()),
+		zap.Int32("newSchemaVersion", cloned.GetSchemaVersion()),
+		zap.Int("newInsertLogsCount", len(resultSegment.GetInsertLogs())),
+		zap.Int("newBm25LogsCount", len(resultSegment.GetBm25Logs())))
+
+	log.Info("meta update: prepare for complete backfill compaction mutation - complete",
+		zap.Int64("num rows", cloned.GetNumOfRows()))
+
+	// Save to catalog
+	if err := m.catalog.AlterSegments(m.ctx, []*datapb.SegmentInfo{cloned.SegmentInfo}, binlogsIncrement); err != nil {
+		log.Warn("fail to alter segment for backfill compaction", zap.Error(err))
+		return nil, nil, err
+	}
+
+	// Update in-memory meta
+	m.segments.SetSegment(segmentID, cloned)
+	log.Info("meta update: alter in memory meta after backfill compaction - complete")
+
+	return []*SegmentInfo{cloned}, metricMutation, nil
 }
 
 func (m *meta) getSegmentsMetrics(collectionID int64) []*metricsinfo.Segment {

--- a/internal/datacoord/meta_test.go
+++ b/internal/datacoord/meta_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/datacoord/broker"
 	mockkv "github.com/milvus-io/milvus/internal/kv/mocks"
 	"github.com/milvus-io/milvus/internal/metastore/kv/datacoord"
@@ -955,6 +956,336 @@ func (suite *MetaBasicSuite) TestSetSegment() {
 	})
 }
 
+func (suite *MetaBasicSuite) TestCompleteBackfillCompactionMutation() {
+	// Helper to build a SegmentsInfo containing a single healthy Flushed segment with the given ID.
+	makeSegments := func(segID int64, state commonpb.SegmentState) *SegmentsInfo {
+		segs := NewSegmentsInfo()
+		segs.SetSegment(segID, &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{
+			ID:            segID,
+			CollectionID:  100,
+			PartitionID:   10,
+			State:         state,
+			Level:         datapb.SegmentLevel_L1,
+			Binlogs:       []*datapb.FieldBinlog{getFieldBinlogIDs(0, 10000)},
+			Statslogs:     []*datapb.FieldBinlog{getFieldBinlogIDs(0, 20000)},
+			NumOfRows:     5,
+			SchemaVersion: 1,
+		}})
+		return segs
+	}
+
+	suite.Run("too many input segments", func() {
+		m := &meta{
+			catalog:  &datacoord.Catalog{MetaKv: NewMetaMemoryKV()},
+			segments: makeSegments(1, commonpb.SegmentState_Flushed),
+		}
+		task := &datapb.CompactionTask{
+			InputSegments: []int64{1, 2}, // two inputs — should error
+			Type:          datapb.CompactionType_BackfillCompaction,
+		}
+		result := &datapb.CompactionPlanResult{
+			Segments: []*datapb.CompactionSegment{
+				{SegmentID: 1},
+			},
+		}
+		infos, mutation, err := m.completeBackfillCompactionMutation(task, result)
+		suite.Error(err)
+		suite.Nil(infos)
+		suite.Nil(mutation)
+	})
+
+	suite.Run("too many result segments", func() {
+		m := &meta{
+			catalog:  &datacoord.Catalog{MetaKv: NewMetaMemoryKV()},
+			segments: makeSegments(1, commonpb.SegmentState_Flushed),
+		}
+		task := &datapb.CompactionTask{
+			InputSegments: []int64{1},
+			Type:          datapb.CompactionType_BackfillCompaction,
+		}
+		result := &datapb.CompactionPlanResult{
+			Segments: []*datapb.CompactionSegment{
+				{SegmentID: 1},
+				{SegmentID: 2}, // two results — should error
+			},
+		}
+		infos, mutation, err := m.completeBackfillCompactionMutation(task, result)
+		suite.Error(err)
+		suite.Nil(infos)
+		suite.Nil(mutation)
+	})
+
+	suite.Run("segment not found", func() {
+		// Segment 99 is not in meta.
+		m := &meta{
+			catalog:  &datacoord.Catalog{MetaKv: NewMetaMemoryKV()},
+			segments: NewSegmentsInfo(),
+		}
+		task := &datapb.CompactionTask{
+			InputSegments: []int64{99},
+			Type:          datapb.CompactionType_BackfillCompaction,
+		}
+		result := &datapb.CompactionPlanResult{
+			Segments: []*datapb.CompactionSegment{
+				{SegmentID: 99},
+			},
+		}
+		infos, mutation, err := m.completeBackfillCompactionMutation(task, result)
+		suite.Error(err)
+		suite.ErrorIs(err, merr.ErrSegmentNotFound)
+		suite.Nil(infos)
+		suite.Nil(mutation)
+	})
+
+	suite.Run("segment dropped", func() {
+		m := &meta{
+			catalog:  &datacoord.Catalog{MetaKv: NewMetaMemoryKV()},
+			segments: makeSegments(1, commonpb.SegmentState_Dropped),
+		}
+		task := &datapb.CompactionTask{
+			InputSegments: []int64{1},
+			Type:          datapb.CompactionType_BackfillCompaction,
+		}
+		result := &datapb.CompactionPlanResult{
+			Segments: []*datapb.CompactionSegment{
+				{SegmentID: 1},
+			},
+		}
+		infos, mutation, err := m.completeBackfillCompactionMutation(task, result)
+		suite.Error(err)
+		suite.ErrorIs(err, merr.ErrSegmentNotFound)
+		suite.Nil(infos)
+		suite.Nil(mutation)
+	})
+
+	suite.Run("segment ID mismatch", func() {
+		m := &meta{
+			catalog:  &datacoord.Catalog{MetaKv: NewMetaMemoryKV()},
+			segments: makeSegments(1, commonpb.SegmentState_Flushed),
+		}
+		task := &datapb.CompactionTask{
+			InputSegments: []int64{1},
+			Type:          datapb.CompactionType_BackfillCompaction,
+		}
+		result := &datapb.CompactionPlanResult{
+			Segments: []*datapb.CompactionSegment{
+				{SegmentID: 999}, // ID mismatch
+			},
+		}
+		infos, mutation, err := m.completeBackfillCompactionMutation(task, result)
+		suite.Error(err)
+		suite.Nil(infos)
+		suite.Nil(mutation)
+	})
+
+	suite.Run("v2 success - schema version updated", func() {
+		// Task schema version (3) > old segment schema version (1) → cloned.SchemaVersion should become 3.
+		segs := NewSegmentsInfo()
+		segs.SetSegment(1, &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{
+			ID:            1,
+			CollectionID:  100,
+			PartitionID:   10,
+			State:         commonpb.SegmentState_Flushed,
+			Level:         datapb.SegmentLevel_L1,
+			Binlogs:       []*datapb.FieldBinlog{getFieldBinlogIDs(0, 10000)},
+			NumOfRows:     5,
+			SchemaVersion: 1,
+		}})
+		m := &meta{
+			catalog:  &datacoord.Catalog{MetaKv: NewMetaMemoryKV()},
+			segments: segs,
+		}
+		task := &datapb.CompactionTask{
+			InputSegments: []int64{1},
+			Type:          datapb.CompactionType_BackfillCompaction,
+			Schema: &schemapb.CollectionSchema{
+				Version: 3,
+			},
+		}
+		result := &datapb.CompactionPlanResult{
+			Segments: []*datapb.CompactionSegment{
+				{
+					SegmentID:  1,
+					InsertLogs: []*datapb.FieldBinlog{getFieldBinlogIDs(0, 10001)},
+					// No manifest → V2 path
+				},
+			},
+		}
+		infos, mutation, err := m.completeBackfillCompactionMutation(task, result)
+		suite.NoError(err)
+		suite.NotNil(mutation)
+		suite.Require().Len(infos, 1)
+		suite.EqualValues(3, infos[0].GetSchemaVersion())
+		// In-memory segment should also be updated.
+		updated := m.segments.GetSegment(1)
+		suite.EqualValues(3, updated.GetSchemaVersion())
+	})
+
+	suite.Run("v2 success - bm25 stats merged", func() {
+		// Old segment already has BM25 stats for field 101.
+		// Result adds BM25 stats for field 102.
+		// Both should be present after mutation.
+		segs := NewSegmentsInfo()
+		segs.SetSegment(1, &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{
+			ID:            1,
+			CollectionID:  100,
+			PartitionID:   10,
+			State:         commonpb.SegmentState_Flushed,
+			Level:         datapb.SegmentLevel_L1,
+			Binlogs:       []*datapb.FieldBinlog{getFieldBinlogIDs(0, 10000)},
+			Bm25Statslogs: []*datapb.FieldBinlog{getFieldBinlogIDs(101, 50001)},
+			NumOfRows:     5,
+			SchemaVersion: 1,
+		}})
+		m := &meta{
+			catalog:  &datacoord.Catalog{MetaKv: NewMetaMemoryKV()},
+			segments: segs,
+		}
+		task := &datapb.CompactionTask{
+			InputSegments: []int64{1},
+			Type:          datapb.CompactionType_BackfillCompaction,
+		}
+		result := &datapb.CompactionPlanResult{
+			Segments: []*datapb.CompactionSegment{
+				{
+					SegmentID:  1,
+					InsertLogs: []*datapb.FieldBinlog{getFieldBinlogIDs(0, 10001)},
+					Bm25Logs:   []*datapb.FieldBinlog{getFieldBinlogIDs(102, 50002)},
+					// No manifest → V2 path, BM25 stats should be merged
+				},
+			},
+		}
+		infos, mutation, err := m.completeBackfillCompactionMutation(task, result)
+		suite.NoError(err)
+		suite.NotNil(mutation)
+		suite.Require().Len(infos, 1)
+
+		// Collect all field IDs present in Bm25Statslogs of the result.
+		fieldIDs := make(map[int64]bool)
+		for _, fl := range infos[0].GetBm25Statslogs() {
+			fieldIDs[fl.GetFieldID()] = true
+		}
+		suite.True(fieldIDs[101], "field 101 bm25 stats should be preserved")
+		suite.True(fieldIDs[102], "field 102 bm25 stats should be added from result")
+	})
+
+	suite.Run("v2 crash-replay idempotent - no duplicate bm25 stats", func() {
+		// Simulate crash-replay: datacoord applies the same backfill result twice
+		// (crash between etcd write and task state transition). Without the dedup
+		// filter, the second application would append duplicate logID entries to
+		// Bm25Statslogs. Verify that applying the same result twice is a no-op.
+		segs := NewSegmentsInfo()
+		segs.SetSegment(1, &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{
+			ID:            1,
+			CollectionID:  100,
+			PartitionID:   10,
+			State:         commonpb.SegmentState_Flushed,
+			Level:         datapb.SegmentLevel_L1,
+			Binlogs:       []*datapb.FieldBinlog{getFieldBinlogIDs(0, 10000)},
+			NumOfRows:     5,
+			SchemaVersion: 1,
+		}})
+		m := &meta{
+			catalog:  &datacoord.Catalog{MetaKv: NewMetaMemoryKV()},
+			segments: segs,
+		}
+		task := &datapb.CompactionTask{
+			InputSegments: []int64{1},
+			Type:          datapb.CompactionType_BackfillCompaction,
+		}
+		result := &datapb.CompactionPlanResult{
+			Segments: []*datapb.CompactionSegment{
+				{
+					SegmentID:  1,
+					InsertLogs: []*datapb.FieldBinlog{getFieldBinlogIDs(0, 10001)},
+					Bm25Logs:   []*datapb.FieldBinlog{getFieldBinlogIDs(102, 50002)},
+				},
+			},
+		}
+
+		// First application
+		infos, _, err := m.completeBackfillCompactionMutation(task, result)
+		suite.NoError(err)
+		suite.Require().Len(infos, 1)
+		suite.Require().Len(infos[0].GetBm25Statslogs(), 1)
+		firstFieldBinlog := infos[0].GetBm25Statslogs()[0]
+		suite.Equal(int64(102), firstFieldBinlog.GetFieldID())
+		suite.Require().Len(firstFieldBinlog.GetBinlogs(), 1)
+		firstLogID := firstFieldBinlog.GetBinlogs()[0].GetLogID()
+
+		// Second application (crash-replay) — same result, must be idempotent
+		infos2, _, err := m.completeBackfillCompactionMutation(task, result)
+		suite.NoError(err)
+		suite.Require().Len(infos2, 1)
+		suite.Require().Len(infos2[0].GetBm25Statslogs(), 1,
+			"replay must not add a second FieldBinlog entry")
+		secondFieldBinlog := infos2[0].GetBm25Statslogs()[0]
+		suite.Equal(int64(102), secondFieldBinlog.GetFieldID())
+		suite.Require().Len(secondFieldBinlog.GetBinlogs(), 1,
+			"replay must not append a duplicate logID entry")
+		suite.Equal(firstLogID, secondFieldBinlog.GetBinlogs()[0].GetLogID())
+
+		// Third application — still idempotent
+		infos3, _, err := m.completeBackfillCompactionMutation(task, result)
+		suite.NoError(err)
+		suite.Require().Len(infos3[0].GetBm25Statslogs(), 1)
+		suite.Require().Len(infos3[0].GetBm25Statslogs()[0].GetBinlogs(), 1)
+	})
+
+	suite.Run("v3 success - manifest and storage version updated", func() {
+		// Result segment has a non-empty manifest → V3 path.
+		// ManifestPath and StorageVersion should be set; Bm25Statslogs should NOT change.
+		segs := NewSegmentsInfo()
+		segs.SetSegment(1, &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{
+			ID:            1,
+			CollectionID:  100,
+			PartitionID:   10,
+			State:         commonpb.SegmentState_Flushed,
+			Level:         datapb.SegmentLevel_L1,
+			Binlogs:       []*datapb.FieldBinlog{getFieldBinlogIDs(0, 10000)},
+			Bm25Statslogs: []*datapb.FieldBinlog{getFieldBinlogIDs(101, 50001)},
+			NumOfRows:     5,
+			SchemaVersion: 1,
+		}})
+		m := &meta{
+			catalog:  &datacoord.Catalog{MetaKv: NewMetaMemoryKV()},
+			segments: segs,
+		}
+		task := &datapb.CompactionTask{
+			InputSegments: []int64{1},
+			Type:          datapb.CompactionType_BackfillCompaction,
+		}
+		const manifestPath = "collection/100/partition/10/segment/1/v3_manifest.json"
+		result := &datapb.CompactionPlanResult{
+			Segments: []*datapb.CompactionSegment{
+				{
+					SegmentID:      1,
+					InsertLogs:     []*datapb.FieldBinlog{getFieldBinlogIDs(0, 10001)},
+					Bm25Logs:       []*datapb.FieldBinlog{getFieldBinlogIDs(102, 50002)},
+					Manifest:       manifestPath,
+					StorageVersion: 3,
+				},
+			},
+		}
+		infos, mutation, err := m.completeBackfillCompactionMutation(task, result)
+		suite.NoError(err)
+		suite.NotNil(mutation)
+		suite.Require().Len(infos, 1)
+
+		// ManifestPath and StorageVersion should reflect the V3 result.
+		suite.Equal(manifestPath, infos[0].GetManifestPath())
+		suite.EqualValues(3, infos[0].GetStorageVersion())
+
+		// BM25 stats should NOT be updated for V3 path — still only field 101.
+		fieldIDs := make(map[int64]bool)
+		for _, fl := range infos[0].GetBm25Statslogs() {
+			fieldIDs[fl.GetFieldID()] = true
+		}
+		suite.True(fieldIDs[101], "field 101 bm25 stats should be preserved")
+		suite.False(fieldIDs[102], "field 102 bm25 stats should NOT be added for V3 path")
+	})
+}
+
 func TestMeta(t *testing.T) {
 	suite.Run(t, new(MetaBasicSuite))
 	suite.Run(t, new(MetaReloadSuite))
@@ -1809,18 +2140,17 @@ func Test_meta_SetSegmentsCompacting(t *testing.T) {
 			"test set segment compacting",
 			fields{
 				NewMetaMemoryKV(),
-				&SegmentsInfo{
-					segments: map[int64]*SegmentInfo{
-						1: {
-							SegmentInfo: &datapb.SegmentInfo{
-								ID:    1,
-								State: commonpb.SegmentState_Flushed,
-							},
-							isCompacting: false,
+				func() *SegmentsInfo {
+					s := NewSegmentsInfo()
+					s.SetSegment(1, &SegmentInfo{
+						SegmentInfo: &datapb.SegmentInfo{
+							ID:    1,
+							State: commonpb.SegmentState_Flushed,
 						},
-					},
-					compactionTo: make(map[int64][]UniqueID),
-				},
+						isCompacting: false,
+					})
+					return s
+				}(),
 			},
 			args{
 				segmentID:  1,

--- a/internal/datacoord/segment_info.go
+++ b/internal/datacoord/segment_info.go
@@ -304,12 +304,23 @@ func (s *SegmentsInfo) SetFlushTime(segmentID UniqueID, t time.Time) {
 	}
 }
 
-// SetIsCompacting sets compaction status for segment
+// SetIsCompacting sets compaction status for segment.
+// NOTE: This method manually updates secondary indexes after ShadowClone.
+// Other Set methods (SetRowCount, SetLevel, SetFlushTime, etc.) have the same
+// stale-index problem but are not yet fixed. See #48593 for the tracking issue
+// to extract a common updateSegment helper for all Set methods.
 func (s *SegmentsInfo) SetIsCompacting(segmentID UniqueID, isCompacting bool) {
 	st := string(debug.Stack())
 	log.Info("set compacting", zap.Int64("segmentID", segmentID), zap.Bool("isCompacting", isCompacting), zap.Any("stacktrace", st))
 	if segment, ok := s.segments[segmentID]; ok {
-		s.segments[segmentID] = segment.ShadowClone(SetIsCompacting(isCompacting))
+		newSegment := segment.ShadowClone(SetIsCompacting(isCompacting))
+		s.segments[segmentID] = newSegment
+		if collSegs, ok := s.secondaryIndexes.coll2Segments[segment.GetCollectionID()]; ok {
+			collSegs[segmentID] = newSegment
+		}
+		if chSegs, ok := s.secondaryIndexes.channel2Segments[segment.GetInsertChannel()]; ok {
+			chSegs[segmentID] = newSegment
+		}
 	}
 }
 

--- a/internal/datacoord/segment_manager.go
+++ b/internal/datacoord/segment_manager.go
@@ -80,6 +80,7 @@ type AllocNewGrowingSegmentRequest struct {
 	ChannelName          string
 	StorageVersion       int64
 	IsCreatedByStreaming bool
+	SchemaVersion        int32
 }
 
 // Manager manages segment related operations.
@@ -441,6 +442,7 @@ func (s *SegmentManager) openNewSegmentWithGivenSegmentID(ctx context.Context, r
 		StorageVersion:       req.StorageVersion,
 		IsCreatedByStreaming: req.IsCreatedByStreaming,
 		ManifestPath:         manifestPath,
+		SchemaVersion:        req.SchemaVersion,
 	}
 	segment := NewSegmentInfo(segmentInfo)
 	if err := s.meta.AddSegment(ctx, segment); err != nil {
@@ -454,6 +456,7 @@ func (s *SegmentManager) openNewSegmentWithGivenSegmentID(ctx context.Context, r
 		zap.Int64("SegmentID", segmentInfo.ID),
 		zap.String("Channel", segmentInfo.InsertChannel),
 		zap.Bool("IsCreatedByStreaming", segmentInfo.IsCreatedByStreaming),
+		zap.Int32("SchemaVersion", segmentInfo.SchemaVersion),
 	)
 
 	return segment, s.helper.afterCreateSegment(segmentInfo)

--- a/internal/datacoord/segment_operator.go
+++ b/internal/datacoord/segment_operator.go
@@ -69,6 +69,16 @@ func SetJSONKeyIndexLogs(jsonKeyIndexLogs map[int64]*datapb.JsonKeyStats) Segmen
 	}
 }
 
+func SetSchemaVersion(schemaVersion int32) SegmentOperator {
+	return func(segment *SegmentInfo) bool {
+		if segment.GetSchemaVersion() == schemaVersion {
+			return false
+		}
+		segment.SchemaVersion = schemaVersion
+		return true
+	}
+}
+
 type segmentCriterion struct {
 	collectionID int64
 	channel      string

--- a/internal/datacoord/server_test.go
+++ b/internal/datacoord/server_test.go
@@ -256,6 +256,176 @@ func TestGetCollectionStatistics(t *testing.T) {
 	})
 }
 
+func TestGetCollectionStatisticsSchemaVersionConsistency(t *testing.T) {
+	// All subtests share one server to avoid spawning 6 etcd connections.
+	// Each subtest uses a unique collectionID and segmentID range to stay isolated.
+	svr := newTestServer(t)
+	defer closeTestServer(t, svr)
+
+	statsMap := func(resp *datapb.GetCollectionStatisticsResponse) map[string]string {
+		m := map[string]string{}
+		for _, kv := range resp.GetStats() {
+			m[kv.Key] = kv.Value
+		}
+		return m
+	}
+
+	// schema version == 0: no consistency stats emitted
+	t.Run("schema version 0 emits no consistency stats", func(t *testing.T) {
+		collectionID := int64(9001)
+		svr.meta.AddCollection(&collectionInfo{
+			ID:     collectionID,
+			Schema: &schemapb.CollectionSchema{Version: 0},
+		})
+		assert.NoError(t, svr.meta.AddSegment(context.TODO(), NewSegmentInfo(&datapb.SegmentInfo{
+			ID: 9100, CollectionID: collectionID, State: commonpb.SegmentState_Flushed,
+		})))
+
+		resp, err := svr.GetCollectionStatistics(svr.ctx, &datapb.GetCollectionStatisticsRequest{CollectionID: collectionID})
+		assert.NoError(t, err)
+		m := statsMap(resp)
+		assert.NotContains(t, m, common.SchemaVersionConsistentSegmentsKey)
+		assert.NotContains(t, m, common.SchemaVersionTotalSegmentsKey)
+	})
+
+	// schema version > 0 but no healthy segments: no consistency stats emitted
+	t.Run("no healthy segments emits no consistency stats", func(t *testing.T) {
+		collectionID := int64(9002)
+		svr.meta.AddCollection(&collectionInfo{
+			ID:     collectionID,
+			Schema: &schemapb.CollectionSchema{Version: 1},
+		})
+		// Dropped segment is not healthy — should be excluded
+		assert.NoError(t, svr.meta.AddSegment(context.TODO(), NewSegmentInfo(&datapb.SegmentInfo{
+			ID: 9101, CollectionID: collectionID, State: commonpb.SegmentState_Dropped,
+		})))
+
+		resp, err := svr.GetCollectionStatistics(svr.ctx, &datapb.GetCollectionStatisticsRequest{CollectionID: collectionID})
+		assert.NoError(t, err)
+		m := statsMap(resp)
+		assert.NotContains(t, m, common.SchemaVersionConsistentSegmentsKey)
+		assert.NotContains(t, m, common.SchemaVersionTotalSegmentsKey)
+	})
+
+	// L0 segment must not be counted in the consistency gate
+	t.Run("L0 segment excluded from consistency gate", func(t *testing.T) {
+		collectionID := int64(9003)
+		svr.meta.AddCollection(&collectionInfo{
+			ID:     collectionID,
+			Schema: &schemapb.CollectionSchema{Version: 2},
+		})
+		// L0 segment with outdated schema version — must not contribute to total
+		assert.NoError(t, svr.meta.AddSegment(context.TODO(), NewSegmentInfo(&datapb.SegmentInfo{
+			ID: 9102, CollectionID: collectionID, State: commonpb.SegmentState_Flushed,
+			Level: datapb.SegmentLevel_L0, SchemaVersion: 1,
+		})))
+		// Normal L1 flushed segment that IS consistent
+		assert.NoError(t, svr.meta.AddSegment(context.TODO(), NewSegmentInfo(&datapb.SegmentInfo{
+			ID: 9103, CollectionID: collectionID, State: commonpb.SegmentState_Flushed,
+			Level: datapb.SegmentLevel_L1, SchemaVersion: 2,
+		})))
+
+		resp, err := svr.GetCollectionStatistics(svr.ctx, &datapb.GetCollectionStatisticsRequest{CollectionID: collectionID})
+		assert.NoError(t, err)
+		m := statsMap(resp)
+		assert.Equal(t, "1", m[common.SchemaVersionConsistentSegmentsKey])
+		assert.Equal(t, "1", m[common.SchemaVersionTotalSegmentsKey])
+	})
+
+	// importing segment must not affect the consistency gate
+	t.Run("importing segment excluded from consistency gate", func(t *testing.T) {
+		collectionID := int64(9004)
+		svr.meta.AddCollection(&collectionInfo{
+			ID:     collectionID,
+			Schema: &schemapb.CollectionSchema{Version: 3},
+		})
+		assert.NoError(t, svr.meta.AddSegment(context.TODO(), NewSegmentInfo(&datapb.SegmentInfo{
+			ID: 9104, CollectionID: collectionID, State: commonpb.SegmentState_Flushed,
+			IsImporting: true, SchemaVersion: 1,
+		})))
+		assert.NoError(t, svr.meta.AddSegment(context.TODO(), NewSegmentInfo(&datapb.SegmentInfo{
+			ID: 9105, CollectionID: collectionID, State: commonpb.SegmentState_Flushed,
+			SchemaVersion: 3,
+		})))
+
+		resp, err := svr.GetCollectionStatistics(svr.ctx, &datapb.GetCollectionStatisticsRequest{CollectionID: collectionID})
+		assert.NoError(t, err)
+		m := statsMap(resp)
+		assert.Equal(t, "1", m[common.SchemaVersionConsistentSegmentsKey])
+		assert.Equal(t, "1", m[common.SchemaVersionTotalSegmentsKey])
+	})
+
+	// all segments consistent: consistent == total
+	t.Run("all segments consistent", func(t *testing.T) {
+		collectionID := int64(9005)
+		svr.meta.AddCollection(&collectionInfo{
+			ID:     collectionID,
+			Schema: &schemapb.CollectionSchema{Version: 5},
+		})
+		for _, id := range []int64{9200, 9201, 9202} {
+			assert.NoError(t, svr.meta.AddSegment(context.TODO(), NewSegmentInfo(&datapb.SegmentInfo{
+				ID: id, CollectionID: collectionID, State: commonpb.SegmentState_Flushed, SchemaVersion: 5,
+			})))
+		}
+
+		resp, err := svr.GetCollectionStatistics(svr.ctx, &datapb.GetCollectionStatisticsRequest{CollectionID: collectionID})
+		assert.NoError(t, err)
+		m := statsMap(resp)
+		assert.Equal(t, "3", m[common.SchemaVersionConsistentSegmentsKey])
+		assert.Equal(t, "3", m[common.SchemaVersionTotalSegmentsKey])
+	})
+
+	// partial segments consistent: consistent < total
+	t.Run("partial segments consistent", func(t *testing.T) {
+		collectionID := int64(9006)
+		svr.meta.AddCollection(&collectionInfo{
+			ID:     collectionID,
+			Schema: &schemapb.CollectionSchema{Version: 7},
+		})
+		for _, id := range []int64{9300, 9301} {
+			assert.NoError(t, svr.meta.AddSegment(context.TODO(), NewSegmentInfo(&datapb.SegmentInfo{
+				ID: id, CollectionID: collectionID, State: commonpb.SegmentState_Flushed, SchemaVersion: 7,
+			})))
+		}
+		// 1 stale segment (not yet backfilled)
+		assert.NoError(t, svr.meta.AddSegment(context.TODO(), NewSegmentInfo(&datapb.SegmentInfo{
+			ID: 9302, CollectionID: collectionID, State: commonpb.SegmentState_Flushed, SchemaVersion: 6,
+		})))
+
+		resp, err := svr.GetCollectionStatistics(svr.ctx, &datapb.GetCollectionStatisticsRequest{CollectionID: collectionID})
+		assert.NoError(t, err)
+		m := statsMap(resp)
+		assert.Equal(t, "2", m[common.SchemaVersionConsistentSegmentsKey])
+		assert.Equal(t, "3", m[common.SchemaVersionTotalSegmentsKey])
+	})
+
+	// Growing segments must be excluded from the consistency gate (workaround for #48865).
+	// Streaming-created growing segments carry SchemaVersion=0 — including them would
+	// permanently block schema-change DDLs under any write traffic.
+	t.Run("growing segments excluded from consistency gate", func(t *testing.T) {
+		collectionID := int64(9007)
+		svr.meta.AddCollection(&collectionInfo{
+			ID:     collectionID,
+			Schema: &schemapb.CollectionSchema{Version: 9},
+		})
+		// One flushed segment matching the current schema version
+		assert.NoError(t, svr.meta.AddSegment(context.TODO(), NewSegmentInfo(&datapb.SegmentInfo{
+			ID: 9400, CollectionID: collectionID, State: commonpb.SegmentState_Flushed, SchemaVersion: 9,
+		})))
+		// Growing segment with SchemaVersion=0 (streaming-created post-alter) — must NOT
+		// count toward total; otherwise the gate would report 1/2 and block DDL forever.
+		assert.NoError(t, svr.meta.AddSegment(context.TODO(), NewSegmentInfo(&datapb.SegmentInfo{
+			ID: 9401, CollectionID: collectionID, State: commonpb.SegmentState_Growing, SchemaVersion: 0,
+		})))
+
+		resp, err := svr.GetCollectionStatistics(svr.ctx, &datapb.GetCollectionStatisticsRequest{CollectionID: collectionID})
+		assert.NoError(t, err)
+		m := statsMap(resp)
+		assert.Equal(t, "1", m[common.SchemaVersionConsistentSegmentsKey])
+		assert.Equal(t, "1", m[common.SchemaVersionTotalSegmentsKey])
+	})
+}
+
 func TestGetPartitionStatistics(t *testing.T) {
 	t.Run("normal cases", func(t *testing.T) {
 		svr := newTestServer(t)

--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -302,7 +302,6 @@ func (s *Server) AllocSegment(ctx context.Context, req *datapb.AllocSegmentReque
 	if req.GetCollectionId() == 0 || req.GetPartitionId() == 0 || req.GetVchannel() == "" || req.GetSegmentId() == 0 {
 		return &datapb.AllocSegmentResponse{Status: merr.Status(merr.ErrParameterInvalid)}, nil
 	}
-
 	// Alloc new growing segment and return the segment info.
 	segmentInfo, err := s.segmentManager.AllocNewGrowingSegment(
 		ctx,
@@ -313,6 +312,7 @@ func (s *Server) AllocSegment(ctx context.Context, req *datapb.AllocSegmentReque
 			ChannelName:          req.GetVchannel(),
 			StorageVersion:       req.GetStorageVersion(),
 			IsCreatedByStreaming: req.GetIsCreatedByStreaming(),
+			SchemaVersion:        req.GetSchemaVersion(),
 		},
 	)
 	if err != nil {
@@ -414,6 +414,66 @@ func (s *Server) GetCollectionStatistics(ctx context.Context, req *datapb.GetCol
 	}
 	nums := s.meta.GetNumRowsOfCollection(ctx, req.CollectionID)
 	resp.Stats = append(resp.Stats, &commonpb.KeyValuePair{Key: "row_count", Value: strconv.FormatInt(nums, 10)})
+
+	// Calculate schema version consistency proportion
+	// Only report when schema version > 0 (i.e., AlterCollectionSchema has been called)
+	collection := s.meta.GetCollection(req.CollectionID)
+	if collection != nil && collection.Schema != nil && collection.Schema.GetVersion() > 0 {
+		collectionSchemaVersion := collection.Schema.GetVersion()
+		// Growing segments are excluded from the consistency gate as a workaround until
+		// companion PR #48865 lands. Streaming-created growing segments currently carry
+		// SchemaVersion=0 because the propagation chain in segment_alloc_worker.go and
+		// msg_handler_impl.go does not yet pass SchemaVersion through. Including them
+		// would cause the gate to never reach 100% under any write traffic, permanently
+		// blocking subsequent schema-change DDLs.
+		//
+		// This is safe: growing segments will eventually be sealed/flushed, at which
+		// point the backfill policy picks them up and updates their SchemaVersion. The
+		// consistency gate only needs to prove that all data eligible for backfill has
+		// been backfilled — growing segments are not yet eligible.
+		//
+		// L0 segments are also excluded: they only contain delete logs, so there is no
+		// user data to backfill and no schema version consistency to track.
+		//
+		// TODO: remove the Growing exclusion once #48865 lands and streaming-created
+		// segments carry the correct SchemaVersion from creation.
+		segments := s.meta.SelectSegments(ctx, WithCollection(req.CollectionID), SegmentFilterFunc(func(si *SegmentInfo) bool {
+			return isSegmentHealthy(si) &&
+				!si.GetIsImporting() &&
+				!si.GetIsInvisible() &&
+				si.GetLevel() != datapb.SegmentLevel_L0 &&
+				si.GetState() != commonpb.SegmentState_Growing
+		}))
+
+		// When there are no segments the collection is trivially consistent; emit nothing so the
+		// proxy treats the absent keys as "no backfill in progress" and allows the DDL through.
+		if len(segments) > 0 {
+			consistentCount := 0
+			for _, segment := range segments {
+				if segment.GetSchemaVersion() == collectionSchemaVersion {
+					consistentCount++
+				}
+			}
+			log.Info("calculated schema version consistency",
+				zap.Int32("collectionSchemaVersion", collectionSchemaVersion),
+				zap.Int("totalSegments", len(segments)),
+				zap.Int("consistentSegments", consistentCount))
+			// Emit raw integer counts instead of a floating-point proportion to avoid the rounding
+			// hazard where e.g. 99999/100000 = 99.999% formats as "100.00" with "%.2f" and would
+			// falsely satisfy a 100% gate check.  Proxy compares these as exact integers.
+			resp.Stats = append(resp.Stats,
+				&commonpb.KeyValuePair{
+					Key:   common.SchemaVersionConsistentSegmentsKey,
+					Value: strconv.Itoa(consistentCount),
+				},
+				&commonpb.KeyValuePair{
+					Key:   common.SchemaVersionTotalSegmentsKey,
+					Value: strconv.Itoa(len(segments)),
+				},
+			)
+		}
+	}
+
 	log.Info("success to get collection statistics", zap.Any("response", resp))
 	return resp, nil
 }

--- a/internal/datacoord/util.go
+++ b/internal/datacoord/util.go
@@ -248,6 +248,48 @@ func mergeFieldBinlogs(currentBinlogs []*datapb.FieldBinlog, newBinlogs []*datap
 	return currentBinlogs
 }
 
+// filterDuplicateFieldBinlogs removes FieldBinlog entries from newLogs whose (fieldID, logID)
+// pairs already exist in existingLogs. Used to make crash-replay idempotent when the same
+// set of binlog results may be applied twice (e.g. backfill task completion after a datacoord
+// restart between the etcd write and the task state transition).
+func filterDuplicateFieldBinlogs(existingLogs, newLogs []*datapb.FieldBinlog) []*datapb.FieldBinlog {
+	if len(existingLogs) == 0 || len(newLogs) == 0 {
+		return newLogs
+	}
+	existing := make(map[int64]map[int64]struct{}, len(existingLogs))
+	for _, fb := range existingLogs {
+		logIDs, ok := existing[fb.GetFieldID()]
+		if !ok {
+			logIDs = make(map[int64]struct{})
+			existing[fb.GetFieldID()] = logIDs
+		}
+		for _, b := range fb.GetBinlogs() {
+			logIDs[b.GetLogID()] = struct{}{}
+		}
+	}
+	result := make([]*datapb.FieldBinlog, 0, len(newLogs))
+	for _, fb := range newLogs {
+		existingSet, hasField := existing[fb.GetFieldID()]
+		if !hasField {
+			result = append(result, fb)
+			continue
+		}
+		filteredBinlogs := make([]*datapb.Binlog, 0, len(fb.GetBinlogs()))
+		for _, b := range fb.GetBinlogs() {
+			if _, dup := existingSet[b.GetLogID()]; !dup {
+				filteredBinlogs = append(filteredBinlogs, b)
+			}
+		}
+		if len(filteredBinlogs) > 0 {
+			result = append(result, &datapb.FieldBinlog{
+				FieldID: fb.GetFieldID(),
+				Binlogs: filteredBinlogs,
+			})
+		}
+	}
+	return result
+}
+
 func calculateL0SegmentSize(fields []*datapb.FieldBinlog) float64 {
 	size := int64(0)
 	for _, field := range fields {

--- a/internal/datacoord/util_test.go
+++ b/internal/datacoord/util_test.go
@@ -176,3 +176,95 @@ func (suite *UtilSuite) TestCalculateL0SegmentSize() {
 
 	suite.Equal(calculateL0SegmentSize(fields), float64(logsize))
 }
+
+func (suite *UtilSuite) TestFilterDuplicateFieldBinlogs() {
+	suite.Run("empty existing returns new unchanged", func() {
+		newLogs := []*datapb.FieldBinlog{{
+			FieldID: 102,
+			Binlogs: []*datapb.Binlog{{LogID: 1}, {LogID: 2}},
+		}}
+		result := filterDuplicateFieldBinlogs(nil, newLogs)
+		suite.Equal(newLogs, result)
+	})
+
+	suite.Run("empty new returns empty", func() {
+		existing := []*datapb.FieldBinlog{{
+			FieldID: 102,
+			Binlogs: []*datapb.Binlog{{LogID: 1}},
+		}}
+		result := filterDuplicateFieldBinlogs(existing, nil)
+		suite.Empty(result)
+	})
+
+	suite.Run("partial overlap same field", func() {
+		existing := []*datapb.FieldBinlog{{
+			FieldID: 102,
+			Binlogs: []*datapb.Binlog{{LogID: 1}, {LogID: 2}},
+		}}
+		newLogs := []*datapb.FieldBinlog{{
+			FieldID: 102,
+			Binlogs: []*datapb.Binlog{{LogID: 2}, {LogID: 3}}, // 2 dup, 3 new
+		}}
+		result := filterDuplicateFieldBinlogs(existing, newLogs)
+		suite.Equal(1, len(result))
+		suite.Equal(int64(102), result[0].FieldID)
+		suite.Equal(1, len(result[0].Binlogs))
+		suite.Equal(int64(3), result[0].Binlogs[0].LogID)
+	})
+
+	suite.Run("full overlap returns empty", func() {
+		existing := []*datapb.FieldBinlog{{
+			FieldID: 102,
+			Binlogs: []*datapb.Binlog{{LogID: 1}, {LogID: 2}},
+		}}
+		newLogs := []*datapb.FieldBinlog{{
+			FieldID: 102,
+			Binlogs: []*datapb.Binlog{{LogID: 1}, {LogID: 2}},
+		}}
+		result := filterDuplicateFieldBinlogs(existing, newLogs)
+		suite.Empty(result)
+	})
+
+	suite.Run("different fieldIDs no filtering", func() {
+		existing := []*datapb.FieldBinlog{{
+			FieldID: 102,
+			Binlogs: []*datapb.Binlog{{LogID: 1}},
+		}}
+		newLogs := []*datapb.FieldBinlog{{
+			FieldID: 103,
+			Binlogs: []*datapb.Binlog{{LogID: 1}}, // same logID but different field
+		}}
+		result := filterDuplicateFieldBinlogs(existing, newLogs)
+		suite.Equal(1, len(result))
+		suite.Equal(int64(103), result[0].FieldID)
+		suite.Equal(1, len(result[0].Binlogs))
+	})
+
+	suite.Run("mixed fields partial overlap", func() {
+		existing := []*datapb.FieldBinlog{
+			{FieldID: 102, Binlogs: []*datapb.Binlog{{LogID: 1}}},
+			{FieldID: 103, Binlogs: []*datapb.Binlog{{LogID: 5}}},
+		}
+		newLogs := []*datapb.FieldBinlog{
+			{FieldID: 102, Binlogs: []*datapb.Binlog{{LogID: 1}, {LogID: 2}}}, // 1 dup, 2 new
+			{FieldID: 104, Binlogs: []*datapb.Binlog{{LogID: 10}}},            // completely new field
+		}
+		result := filterDuplicateFieldBinlogs(existing, newLogs)
+		suite.Equal(2, len(result))
+		// find fieldID 102 in result
+		var fb102, fb104 *datapb.FieldBinlog
+		for _, fb := range result {
+			if fb.FieldID == 102 {
+				fb102 = fb
+			}
+			if fb.FieldID == 104 {
+				fb104 = fb
+			}
+		}
+		suite.NotNil(fb102)
+		suite.Equal(1, len(fb102.Binlogs))
+		suite.Equal(int64(2), fb102.Binlogs[0].LogID)
+		suite.NotNil(fb104)
+		suite.Equal(1, len(fb104.Binlogs))
+	})
+}

--- a/internal/datanode/compactor/backfill_compactor.go
+++ b/internal/datanode/compactor/backfill_compactor.go
@@ -1,0 +1,911 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compactor
+
+import (
+	"context"
+	"fmt"
+	sio "io"
+	"path"
+	"strconv"
+	"time"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/memory"
+	"github.com/cockroachdb/errors"
+	"github.com/samber/lo"
+	"go.opentelemetry.io/otel"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/allocator"
+	"github.com/milvus-io/milvus/internal/compaction"
+	"github.com/milvus-io/milvus/internal/metastore/kv/binlog"
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/storagecommon"
+	"github.com/milvus-io/milvus/internal/storagev2/packed"
+	"github.com/milvus-io/milvus/internal/util/function"
+	"github.com/milvus-io/milvus/internal/util/hookutil"
+	"github.com/milvus-io/milvus/pkg/v2/common"
+	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexcgopb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+	"github.com/milvus-io/milvus/pkg/v2/util/metautil"
+	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
+)
+
+// backfillWriter abstracts the packed writer interface for V2/V3 compatibility.
+// Both packed.PackedWriter (V2) and packed.FFIPackedWriter (V3) implement WriteRecordBatch,
+// but their Close signatures differ, so we use wrappers for both.
+// Manifest() returns the V3 manifest path after Close(); V2 always returns "".
+type backfillWriter interface {
+	WriteRecordBatch(arrow.Record) error
+	Close() error
+	Manifest() string
+}
+
+// ffiWriterWrapper wraps packed.FFIPackedWriter to implement backfillWriter,
+// capturing the manifest string returned by Close.
+type ffiWriterWrapper struct {
+	writer   *packed.FFIPackedWriter
+	manifest string
+}
+
+func (w *ffiWriterWrapper) WriteRecordBatch(r arrow.Record) error {
+	return w.writer.WriteRecordBatch(r)
+}
+
+func (w *ffiWriterWrapper) Close() error {
+	manifest, err := w.writer.Close()
+	if err != nil {
+		return err
+	}
+	w.manifest = manifest
+	return nil
+}
+
+func (w *ffiWriterWrapper) Manifest() string {
+	return w.manifest
+}
+
+// v2WriterWrapper wraps packed.PackedWriter to implement backfillWriter.
+// Manifest() always returns "" for V2 segments (no manifest concept).
+// fileSizes is populated by Close() via CloseAndTell, indexed by column group order.
+type v2WriterWrapper struct {
+	writer    *packed.PackedWriter
+	numGroups int
+	fileSizes []int64
+}
+
+func (w *v2WriterWrapper) WriteRecordBatch(r arrow.Record) error {
+	return w.writer.WriteRecordBatch(r)
+}
+
+func (w *v2WriterWrapper) Close() error {
+	sizes, err := w.writer.CloseAndTell(w.numGroups)
+	if err != nil {
+		return err
+	}
+	w.fileSizes = sizes
+	return nil
+}
+
+func (w *v2WriterWrapper) Manifest() string {
+	return ""
+}
+
+type backfillCompactionTask struct {
+	ctx              context.Context
+	cancel           context.CancelFunc
+	plan             *datapb.CompactionPlan
+	compactionParams compaction.Params
+	done             chan struct{}
+	logIDAlloc       allocator.Interface
+	functionRunner   function.FunctionRunner
+	chunkManager     storage.ChunkManager
+}
+
+func (t *backfillCompactionTask) Compact() (*datapb.CompactionPlanResult, error) {
+	if !funcutil.CheckCtxValid(t.ctx) {
+		return nil, t.ctx.Err()
+	}
+	ctx, span := otel.Tracer(typeutil.DataNodeRole).Start(t.ctx, fmt.Sprintf("BackfillCompact-%d", t.GetPlanID()))
+	defer span.End()
+
+	if err := t.preCompact(); err != nil {
+		log.Ctx(ctx).Warn("failed to preCompact", zap.Error(err))
+		return nil, err
+	}
+	defer t.functionRunner.Close()
+
+	compactStart := time.Now()
+	log := log.Ctx(ctx).With(
+		zap.Int64("planID", t.GetPlanID()),
+		zap.Int64("collectionID", t.GetCollection()),
+	)
+
+	log.Info("backfill compact start",
+		zap.Int64("segmentID", t.plan.GetSegmentBinlogs()[0].GetSegmentID()),
+		zap.Int32("collectionSchemaVersion", t.plan.GetSchema().GetVersion()),
+		zap.Int("numFunctions", len(t.plan.GetFunctions())),
+	)
+
+	result, err := t.runBackfillFunction(ctx, t.functionRunner)
+	if err != nil {
+		log.Warn("backfill compact failed", zap.Error(err), zap.Duration("compact cost", time.Since(compactStart)))
+		return nil, err
+	}
+
+	log.Info("backfill compact done", zap.Duration("compact cost", time.Since(compactStart)))
+	return result, nil
+}
+
+// preCompact validates the compaction plan, checks context, and sets up the function runner.
+func (t *backfillCompactionTask) preCompact() error {
+	if ok := funcutil.CheckCtxValid(t.ctx); !ok {
+		return t.ctx.Err()
+	}
+
+	// Check segment binlogs: must have exactly one segment
+	if len(t.plan.GetSegmentBinlogs()) != 1 {
+		return errors.Newf("backfill compaction plan is illegal, must have exactly one segment, but got %d segments, planID = %d", len(t.plan.GetSegmentBinlogs()), t.GetPlanID())
+	}
+
+	segment := t.plan.GetSegmentBinlogs()[0]
+	if segment.GetManifest() == "" && len(segment.GetFieldBinlogs()) == 0 {
+		return errors.Newf("compaction plan is illegal, segment's field binlogs are empty, planID = %d, segmentID = %d", t.GetPlanID(), segment.GetSegmentID())
+	}
+
+	backfillFunctions := t.plan.GetFunctions()
+	if len(backfillFunctions) != 1 {
+		return errors.New("backfill functions should be exactly one")
+	}
+	backfillFunction := backfillFunctions[0]
+
+	functionRunner, err := function.NewFunctionRunner(t.plan.GetSchema(), backfillFunction)
+	if err != nil {
+		return err
+	}
+	if functionRunner == nil {
+		return errors.New("failed to set up backfill function runner")
+	}
+
+	// Validate function runner
+	if err := t.checkFunctionRunner(functionRunner); err != nil {
+		functionRunner.Close()
+		return err
+	}
+
+	t.functionRunner = functionRunner
+	return nil
+}
+
+func (t *backfillCompactionTask) checkFunctionRunner(functionRunner function.FunctionRunner) error {
+	switch functionRunner.GetSchema().GetType() {
+	case schemapb.FunctionType_BM25:
+		functionSchema := functionRunner.GetSchema()
+
+		// 1. Check inputFieldIDs: must have exactly one, and type must be varchar
+		inputFieldIDs := functionSchema.GetInputFieldIds()
+		if len(inputFieldIDs) != 1 {
+			return errors.New("bm25 function should have exactly one input field")
+		}
+		inputFieldID := inputFieldIDs[0]
+		inputField := typeutil.GetField(t.plan.GetSchema(), inputFieldID)
+		if inputField == nil {
+			return errors.New("input field not found in schema")
+		}
+		if inputField.GetDataType() != schemapb.DataType_VarChar && inputField.GetDataType() != schemapb.DataType_Text {
+			return errors.New("input field data type must be varchar or text for bm25 function backfill")
+		}
+
+		// 2. Check outputFieldIDs: must have exactly one, and type must be SparseFloatVector
+		outputFieldIDs := functionSchema.GetOutputFieldIds()
+		if len(outputFieldIDs) != 1 {
+			return errors.New("bm25 function should have exactly one output field")
+		}
+		outputFieldID := outputFieldIDs[0]
+		outputField := typeutil.GetField(t.plan.GetSchema(), outputFieldID)
+		if outputField == nil {
+			return errors.New("output field not found in schema")
+		}
+		if outputField.GetDataType() != schemapb.DataType_SparseFloatVector {
+			return errors.New("output field data type must be sparse float vector for bm25 function backfill")
+		}
+
+		return nil
+	default:
+		return errors.New("unsupported function type")
+	}
+}
+
+func (t *backfillCompactionTask) runBackfillFunction(ctx context.Context, functionRunner function.FunctionRunner) (*datapb.CompactionPlanResult, error) {
+	switch functionRunner.GetSchema().GetType() {
+	case schemapb.FunctionType_BM25:
+		return t.runBm25Function(ctx, functionRunner)
+	default:
+		return nil, errors.New("unsupported function type")
+	}
+}
+
+func (t *backfillCompactionTask) openBinlogReader(inputFieldID int64) (storage.RecordReader, error) {
+	inputField := typeutil.GetField(t.plan.GetSchema(), inputFieldID)
+
+	segment := t.plan.GetSegmentBinlogs()[0]
+	collectionID := segment.GetCollectionID()
+	partitionID := segment.GetPartitionID()
+	segmentID := segment.GetSegmentID()
+
+	inputSchema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		inputField,
+	}}
+
+	if segment.GetManifest() != "" {
+		return storage.NewManifestRecordReader(t.ctx,
+			segment.GetManifest(),
+			inputSchema,
+			storage.WithCollectionID(collectionID),
+			storage.WithVersion(segment.GetStorageVersion()),
+			storage.WithDownloader(t.chunkManager.MultiRead),
+			storage.WithStorageConfig(t.compactionParams.StorageConfig),
+		)
+	}
+
+	if err := binlog.DecompressBinLogWithRootPath(t.compactionParams.StorageConfig.GetRootPath(),
+		storage.InsertBinlog, collectionID, partitionID,
+		segmentID, segment.GetFieldBinlogs()); err != nil {
+		log.Ctx(t.ctx).Warn("Decompress insert binlog error", zap.Error(err))
+		return nil, err
+	}
+	return storage.NewBinlogRecordReader(t.ctx, segment.GetFieldBinlogs(), inputSchema,
+		storage.WithCollectionID(collectionID),
+		storage.WithVersion(segment.GetStorageVersion()),
+		storage.WithDownloader(t.chunkManager.MultiRead),
+		storage.WithStorageConfig(t.compactionParams.StorageConfig),
+	)
+}
+
+func (t *backfillCompactionTask) processBatch(functionRunner function.FunctionRunner, inputStrs []string, outputFieldID int64) (*storage.InsertData, int, error) {
+	// run function on this batch
+	output, err := functionRunner.BatchRun(inputStrs)
+	if err != nil {
+		return nil, 0, err
+	}
+	if len(output) != 1 {
+		return nil, 0, errors.New("bm25 function backfill should return exactly one output")
+	}
+	outputSparseArray, ok := output[0].(*schemapb.SparseFloatArray)
+	if !ok {
+		return nil, 0, errors.New("unexpected output type from BM25 function runner, expected SparseFloatArray")
+	}
+
+	// build output field data
+	outputFieldData := &storage.SparseFloatVectorFieldData{
+		SparseFloatArray: schemapb.SparseFloatArray{
+			Contents: outputSparseArray.GetContents(),
+			Dim:      outputSparseArray.GetDim(),
+		},
+	}
+
+	// build insert data
+	insertData := &storage.InsertData{
+		Data: make(map[int64]storage.FieldData),
+	}
+	insertData.Data[outputFieldID] = outputFieldData
+	sparseFieldMemorySize := proto.Size(&outputFieldData.SparseFloatArray)
+
+	return insertData, sparseFieldMemorySize, nil
+}
+
+// backfillWriterResult holds the writer and associated metadata needed after writing.
+type backfillWriterResult struct {
+	writer         backfillWriter
+	arrowSchema    *arrow.Schema
+	outputSchema   *schemapb.CollectionSchema
+	columnGroups   []storagecommon.ColumnGroup
+	paths          []string // V2 only: log paths for buildMergedLogs
+	truePaths      []string // V2 only: true paths for log path resolution
+	logIDs         []int64  // V2 only: log IDs corresponding to each column group path, for LogID in FieldBinlog
+	fileSizes      []int64  // V2 only: on-disk compressed sizes from CloseAndTell, indexed by column group order
+	storageVersion int64
+	basePath       string             // V3 only: parsed from existing manifest in setupWriter
+	v3Stats        []packed.StatEntry // V3 only: stats to commit atomically with column groups
+}
+
+func (t *backfillCompactionTask) setupWriter(outputField *schemapb.FieldSchema, outputFieldID int64, segment *datapb.CompactionSegmentBinlogs, collectionID, partitionID, segmentID int64) (*backfillWriterResult, error) {
+	outputSchema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		outputField,
+	}}
+	arrowSchema, err := storage.ConvertToArrowSchema(outputSchema, true)
+	if err != nil {
+		return nil, err
+	}
+	if segment.GetManifest() == "" && len(segment.GetFieldBinlogs()) == 0 {
+		return nil, errors.New("segment field binlogs is empty, wrong state for compaction segments")
+	}
+	newColumnGroups := []storagecommon.ColumnGroup{
+		{
+			GroupID: outputFieldID,
+			Columns: []int{0},
+			Fields:  []int64{outputFieldID},
+		},
+	}
+
+	var pluginContext *indexcgopb.StoragePluginContext
+	if hookutil.IsClusterEncryptionEnabled() {
+		ez := hookutil.GetEzByCollProperties(t.plan.GetSchema().GetProperties(), collectionID)
+		if ez != nil {
+			unsafe := hookutil.GetCipher().GetUnsafeKey(ez.EzID, ez.CollectionID)
+			if len(unsafe) > 0 {
+				pluginContext = &indexcgopb.StoragePluginContext{
+					EncryptionZoneId: ez.EzID,
+					CollectionId:     ez.CollectionID,
+					EncryptionKey:    string(unsafe),
+				}
+			}
+		}
+	}
+
+	// Determine effective storage version: V3 only if segment already has a manifest.
+	// V2 segments on V3 clusters must stay V2 — a partial manifest (only new columns)
+	// would cause segcore to ignore original binlog data, corrupting the segment.
+	storageVersion := t.compactionParams.StorageVersion
+	existingManifest := segment.GetManifest()
+	if storageVersion == storage.StorageV3 && existingManifest == "" {
+		storageVersion = storage.StorageV2 // force V2 path for V2 segment on V3 cluster
+	}
+
+	result := &backfillWriterResult{
+		arrowSchema:    arrowSchema,
+		outputSchema:   outputSchema,
+		columnGroups:   newColumnGroups,
+		storageVersion: storageVersion,
+	}
+
+	if storageVersion == storage.StorageV3 {
+		// V3: extend existing manifest by appending new column groups.
+		// Parse basePath and version from the segment's current manifest,
+		// so the transaction reads the existing manifest and merges new columns in.
+		basePath, existingVersion, err := packed.UnmarshalManifestPath(existingManifest)
+		if err != nil {
+			return nil, merr.WrapErrServiceInternal("failed to parse existing manifest for V3 backfill", err.Error())
+		}
+		ffiWriter, err := packed.NewFFIPackedWriter(basePath, existingVersion, arrowSchema, newColumnGroups, t.compactionParams.StorageConfig, pluginContext)
+		if err != nil {
+			return nil, err
+		}
+		// The output field is a new addition to the existing manifest (backfill).
+		// Use AddColumnGroup semantics so Loon does not require the count to match
+		// the existing groups in the manifest.
+		ffiWriter.AsNewColumnGroups()
+		result.writer = &ffiWriterWrapper{writer: ffiWriter}
+		result.basePath = basePath
+	} else {
+		// V2: use PackedWriter with explicit file paths.
+		// TODO(backfill): no file-size rotation — all rows land in one Parquet file per
+		// column group regardless of segment size. Fix by splitting at BinLogMaxSize (64MB)
+		// and allocating a new LogID+path per chunk, like MultiSegmentWriter.rotateWriter.
+		logIdStart, _, err := t.logIDAlloc.Alloc(uint32(len(newColumnGroups)))
+		if err != nil {
+			return nil, err
+		}
+		paths := []string{}
+		logIDs := []int64{}
+		for _, columnGroup := range newColumnGroups {
+			p := metautil.BuildInsertLogPath(t.compactionParams.StorageConfig.GetRootPath(), collectionID, partitionID, segmentID, columnGroup.GroupID, logIdStart)
+			paths = append(paths, p)
+			logIDs = append(logIDs, logIdStart)
+			logIdStart++
+		}
+		truePaths := lo.Map(paths, func(p string, _ int) string {
+			if t.compactionParams.StorageConfig.GetStorageType() == "local" {
+				return p
+			}
+			return path.Join(t.compactionParams.StorageConfig.GetBucketName(), p)
+		})
+		writer, err := packed.NewPackedWriter(truePaths, arrowSchema, packed.DefaultWriteBufferSize, packed.DefaultMultiPartUploadSize, newColumnGroups, t.compactionParams.StorageConfig, pluginContext)
+		if err != nil {
+			return nil, err
+		}
+		result.writer = &v2WriterWrapper{writer: writer, numGroups: len(newColumnGroups)}
+		result.paths = paths
+		result.truePaths = truePaths
+		result.logIDs = logIDs
+	}
+
+	return result, nil
+}
+
+func (t *backfillCompactionTask) writeBatch(writer backfillWriter, arrowSchema *arrow.Schema, insertData *storage.InsertData, outputSchema *schemapb.CollectionSchema) error {
+	builder := array.NewRecordBuilder(memory.DefaultAllocator, arrowSchema)
+	defer builder.Release()
+	err := storage.BuildRecord(builder, insertData, outputSchema)
+	if err != nil {
+		return err
+	}
+	arrowRecord := builder.NewRecord()
+	defer arrowRecord.Release()
+	return writer.WriteRecordBatch(arrowRecord)
+}
+
+func (t *backfillCompactionTask) updateStats(stats *storage.BM25Stats, collectionID, partitionID, segmentID, outputFieldID int64, writerResult *backfillWriterResult) ([]byte, string, int64, error) {
+	cli := t.chunkManager
+	statsID, _, err := t.logIDAlloc.Alloc(uint32(1))
+	if err != nil {
+		return nil, "", 0, err
+	}
+
+	bytes, err := stats.Serialize()
+	if err != nil {
+		return nil, "", 0, err
+	}
+
+	if writerResult.storageVersion == storage.StorageV3 {
+		// V3: write stats file under manifest basePath/_stats/ directory.
+		// Stats will be registered in manifest via AddStatsToManifest after Close().
+		// basePath was already parsed from the manifest in setupWriter — reuse it here.
+		basePath := writerResult.basePath
+		statsRelPath := fmt.Sprintf("_stats/bm25.%d/%d", outputFieldID, statsID)
+		absStatsPath := path.Join(basePath, statsRelPath)
+		if err := cli.Write(t.ctx, absStatsPath, bytes); err != nil {
+			return nil, "", 0, merr.WrapErrServiceInternal("failed to write V3 BM25 stats", err.Error())
+		}
+		writerResult.v3Stats = append(writerResult.v3Stats, packed.StatEntry{
+			Key:   fmt.Sprintf("bm25.%d", outputFieldID),
+			Files: []string{absStatsPath}, // C++ converts absolute to relative at commit
+			Metadata: map[string]string{
+				"memory_size": strconv.FormatInt(int64(len(bytes)), 10),
+			},
+		})
+		return bytes, "", 0, nil // no separate bm25LogPathForResult for V3; statsID unused
+	}
+
+	// V2: write stats file to bm25_stats path, return path and ID for result metadata
+	statsPath := metautil.JoinIDPath(collectionID, partitionID, segmentID, outputFieldID, statsID)
+	bm25LogPath := path.Join(cli.RootPath(), common.SegmentBm25LogPath, statsPath)
+	if err := cli.Write(t.ctx, bm25LogPath, bytes); err != nil {
+		return nil, "", 0, err
+	}
+
+	bm25LogPathForResult := metautil.BuildBm25LogPath(
+		t.compactionParams.StorageConfig.GetRootPath(),
+		collectionID, partitionID, segmentID, outputFieldID, statsID)
+	if t.compactionParams.StorageConfig.GetStorageType() != "local" {
+		bm25LogPathForResult = path.Join(t.compactionParams.StorageConfig.GetBucketName(), bm25LogPathForResult)
+	}
+
+	return bytes, bm25LogPathForResult, statsID, nil
+}
+
+func (t *backfillCompactionTask) buildMergedLogsV2(segment *datapb.CompactionSegmentBinlogs, writerResult *backfillWriterResult, sparseFieldMemorySize int, totalRows int64, bytes []byte, bm25LogPathForResult string, bm25LogID int64, outputFieldID int64) ([]*datapb.FieldBinlog, []*datapb.FieldBinlog, error) {
+	newInsertLogs := make(map[int64]*datapb.FieldBinlog)
+	for i, columnGroup := range writerResult.columnGroups {
+		fileSize := writerResult.fileSizes[i]
+		logPath := writerResult.paths[i]
+		truePath := writerResult.truePaths[i]
+		if t.compactionParams.StorageConfig.GetStorageType() != "local" {
+			logPath = truePath
+		}
+		fieldBinlog := &datapb.FieldBinlog{
+			FieldID:     columnGroup.GroupID,
+			ChildFields: columnGroup.Fields,
+			Binlogs: []*datapb.Binlog{
+				{
+					LogSize:    fileSize,
+					MemorySize: int64(sparseFieldMemorySize),
+					LogPath:    logPath,
+					LogID:      writerResult.logIDs[i],
+					EntriesNum: totalRows,
+				},
+			},
+		}
+		newInsertLogs[columnGroup.GroupID] = fieldBinlog
+	}
+
+	return t.finalizeMergedLogs(segment, newInsertLogs, totalRows, bytes, bm25LogPathForResult, bm25LogID, outputFieldID)
+}
+
+func (t *backfillCompactionTask) buildMergedLogsV3(segment *datapb.CompactionSegmentBinlogs, writerResult *backfillWriterResult, sparseFieldMemorySize int, totalRows int64, bytes []byte, bm25LogPathForResult string, bm25LogID int64, outputFieldID int64) ([]*datapb.FieldBinlog, []*datapb.FieldBinlog, error) {
+	// V3: data is tracked by the manifest. Binlog entries in etcd serve as field-presence
+	// markers used by getSegmentBinlogFields (backfill detection). Each entry must have
+	// LogID!=0 and LogPath=="" to pass buildBinlogKvs validation — allocate a real ID from
+	// logIDAlloc (same allocator used for V2 LogIDs) so the entry is properly persisted.
+	logIDStart, _, err := t.logIDAlloc.Alloc(uint32(len(writerResult.columnGroups)))
+	if err != nil {
+		return nil, nil, err
+	}
+	newInsertLogs := make(map[int64]*datapb.FieldBinlog)
+	for i, columnGroup := range writerResult.columnGroups {
+		fieldBinlog := &datapb.FieldBinlog{
+			FieldID:     columnGroup.GroupID,
+			ChildFields: columnGroup.Fields,
+			Binlogs: []*datapb.Binlog{
+				{
+					MemorySize: int64(sparseFieldMemorySize),
+					EntriesNum: totalRows,
+					LogID:      logIDStart + int64(i),
+				},
+			},
+		}
+		newInsertLogs[columnGroup.GroupID] = fieldBinlog
+	}
+
+	return t.finalizeMergedLogs(segment, newInsertLogs, totalRows, bytes, bm25LogPathForResult, bm25LogID, outputFieldID)
+}
+
+func (t *backfillCompactionTask) finalizeMergedLogs(segment *datapb.CompactionSegmentBinlogs, newInsertLogs map[int64]*datapb.FieldBinlog, totalRows int64, bytes []byte, bm25LogPathForResult string, bm25LogID int64, outputFieldID int64) ([]*datapb.FieldBinlog, []*datapb.FieldBinlog, error) {
+	// build new Bm25Logs
+	bm25FileSize := int64(len(bytes))
+	newBm25Logs := []*datapb.FieldBinlog{
+		{
+			FieldID: outputFieldID,
+			Binlogs: []*datapb.Binlog{
+				{
+					LogSize:    bm25FileSize,
+					MemorySize: bm25FileSize,
+					LogPath:    bm25LogPathForResult,
+					LogID:      bm25LogID,
+					EntriesNum: totalRows,
+				},
+			},
+		},
+	}
+
+	// Crash-replay guard: if DC crashed after AlterSegments but before the task-state
+	// transition, the output field is already in etcd — skip it to stay idempotent.
+	originalInsertLogs := segment.GetFieldBinlogs()
+	existingFields := make(map[int64]struct{}, len(originalInsertLogs)*2)
+	for _, fb := range originalInsertLogs {
+		existingFields[fb.GetFieldID()] = struct{}{}
+		for _, childID := range fb.GetChildFields() {
+			existingFields[childID] = struct{}{}
+		}
+	}
+	newInsertLogsList := storage.SortFieldBinlogs(newInsertLogs)
+	dedupedNew := newInsertLogsList[:0]
+	for _, fb := range newInsertLogsList {
+		if _, ok := existingFields[fb.GetFieldID()]; ok {
+			log.Warn("backfill crash-replay: output field already in segment binlogs, skipping duplicate",
+				zap.Int64("fieldID", fb.GetFieldID()),
+				zap.Int64("segmentID", segment.GetSegmentID()))
+			continue
+		}
+		childDup := false
+		for _, childID := range fb.GetChildFields() {
+			if _, ok := existingFields[childID]; ok {
+				childDup = true
+				break
+			}
+		}
+		if childDup {
+			log.Warn("backfill crash-replay: output field already in segment binlogs, skipping duplicate",
+				zap.Int64("fieldID", fb.GetFieldID()),
+				zap.Int64("segmentID", segment.GetSegmentID()))
+			continue
+		}
+		dedupedNew = append(dedupedNew, fb)
+	}
+	mergedInsertLogs := make([]*datapb.FieldBinlog, 0, len(originalInsertLogs)+len(dedupedNew))
+	mergedInsertLogs = append(mergedInsertLogs, originalInsertLogs...)
+	mergedInsertLogs = append(mergedInsertLogs, dedupedNew...)
+
+	return mergedInsertLogs, newBm25Logs, nil
+}
+
+func (t *backfillCompactionTask) runBm25Function(ctx context.Context, functionRunner function.FunctionRunner) (*datapb.CompactionPlanResult, error) {
+	// 1. set up function schema — duplicate checks from checkFunctionRunner so this path cannot panic
+	//    if schema/runner state diverges or call sites change.
+	functionSchema := functionRunner.GetSchema()
+	inputFieldIDs := functionSchema.GetInputFieldIds()
+	if len(inputFieldIDs) != 1 {
+		return nil, errors.Newf("bm25 backfill: expected exactly one input field, got %d (planID=%d)", len(inputFieldIDs), t.plan.GetPlanID())
+	}
+	inputFieldID := inputFieldIDs[0]
+	outputFieldIDs := functionSchema.GetOutputFieldIds()
+	if len(outputFieldIDs) != 1 {
+		return nil, errors.Newf("bm25 backfill: expected exactly one output field, got %d (planID=%d)", len(outputFieldIDs), t.plan.GetPlanID())
+	}
+	outputFieldID := outputFieldIDs[0]
+	outputField := typeutil.GetField(t.plan.GetSchema(), outputFieldID)
+
+	// 2. get segment info
+	segment := t.plan.GetSegmentBinlogs()[0]
+	collectionID := segment.GetCollectionID()
+	partitionID := segment.GetPartitionID()
+	segmentID := segment.GetSegmentID()
+
+	log := log.Ctx(ctx).With(
+		zap.Int64("planID", t.plan.GetPlanID()),
+		zap.Int64("collectionID", collectionID),
+		zap.Int64("partitionID", partitionID),
+		zap.Int64("segmentID", segmentID),
+		zap.Int64("inputFieldID", inputFieldID),
+		zap.Int64("outputFieldID", outputFieldID),
+	)
+
+	// Track durations for each heavy operation
+	var readDuration, computeDuration, writeDuration, updateStatsDuration time.Duration
+
+	// 3. open binlog reader
+	reader, err := t.openBinlogReader(inputFieldID)
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+
+	// 4. set up writer
+	writerResult, err := t.setupWriter(outputField, outputFieldID, segment, collectionID, partitionID, segmentID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Log effective storage version (may differ from cluster version for V2-origin segments).
+	log.Info("backfill writer setup",
+		zap.Int64("effectiveStorageVersion", writerResult.storageVersion),
+		zap.Int64("clusterStorageVersion", t.compactionParams.StorageVersion),
+		zap.Bool("segmentHasManifest", segment.GetManifest() != ""),
+		zap.Int("inputFieldBinlogCount", len(segment.GetFieldBinlogs())),
+		zap.Strings("v2WritePaths", writerResult.paths),
+	)
+	writerClosed := false
+	defer func() {
+		if !writerClosed {
+			writerResult.writer.Close()
+		}
+	}()
+
+	// 5. batch loop: read → compute → write → accumulate stats
+	_, span := otel.Tracer(typeutil.DataNodeRole).Start(ctx, "BackfillCompact.batchProcess")
+	stats := storage.NewBM25Stats()
+	var totalRows int64
+	var totalSparseMemorySize int
+
+	for {
+		// read one batch
+		readStart := time.Now()
+		record, err := reader.Next()
+		if err != nil {
+			if err == sio.EOF {
+				readDuration += time.Since(readStart)
+				break
+			}
+			span.End()
+			return nil, err
+		}
+		readDuration += time.Since(readStart)
+
+		// extract input strings from this batch
+		col := record.Column(inputFieldID)
+		if col == nil {
+			record.Release()
+			span.End()
+			return nil, merr.WrapErrServiceInternal(fmt.Sprintf("input field %d not found in record", inputFieldID))
+		}
+		recordStr, ok := col.(*array.String)
+		if !ok {
+			record.Release()
+			span.End()
+			return nil, merr.WrapErrServiceInternal(fmt.Sprintf("input field %d data type must be varchar or text for bm25 function backfill, got %T", inputFieldID, col))
+		}
+		batchStrs := make([]string, record.Len())
+		for i := 0; i < record.Len(); i++ {
+			batchStrs[i] = recordStr.Value(i)
+		}
+		record.Release()
+
+		// compute BM25 for this batch
+		computeStart := time.Now()
+		insertData, batchMemSize, err := t.processBatch(functionRunner, batchStrs, outputFieldID)
+		computeDuration += time.Since(computeStart)
+		if err != nil {
+			span.End()
+			return nil, err
+		}
+
+		// accumulate stats from this batch
+		outputFieldData := insertData.Data[outputFieldID].(*storage.SparseFloatVectorFieldData)
+		stats.AppendBytes(outputFieldData.GetContents()...)
+
+		// write this batch
+		writeStart := time.Now()
+		if err := t.writeBatch(writerResult.writer, writerResult.arrowSchema, insertData, writerResult.outputSchema); err != nil {
+			span.End()
+			return nil, err
+		}
+		writeDuration += time.Since(writeStart)
+
+		totalRows += int64(len(batchStrs))
+		totalSparseMemorySize += batchMemSize
+	}
+	span.End()
+
+	// 6. write stats file (must happen before Close for V3 — stats are committed atomically)
+	_, span2 := otel.Tracer(typeutil.DataNodeRole).Start(ctx, "BackfillCompact.updateStats")
+	startTime := time.Now()
+	bytes, bm25LogPathForResult, bm25LogID, err := t.updateStats(stats, collectionID, partitionID, segmentID, outputFieldID, writerResult)
+	updateStatsDuration = time.Since(startTime)
+	span2.End()
+	if err != nil {
+		return nil, err
+	}
+
+	log.Info("backfill bm25 stats written",
+		zap.String("bm25LogPath", bm25LogPathForResult),
+		zap.Int64("bm25LogID", bm25LogID),
+		zap.Int("bm25StatsBytes", len(bytes)),
+		zap.Int64("storageVersion", writerResult.storageVersion),
+		zap.Int("v3StatsCount", len(writerResult.v3Stats)),
+	)
+
+	// Close writer — for V3, this commits new column groups to the existing manifest
+	// (version N → N+1). BM25 stats are added separately via AddStatsToManifest.
+	if err := writerResult.writer.Close(); err != nil {
+		return nil, err
+	}
+	writerClosed = true
+	// For V2: capture on-disk compressed file sizes written by CloseAndTell.
+	if v2w, ok := writerResult.writer.(*v2WriterWrapper); ok {
+		writerResult.fileSizes = v2w.fileSizes
+		log.Info("backfill V2 insert binlogs written",
+			zap.Strings("logPaths", writerResult.paths),
+			zap.Int64s("logIDs", writerResult.logIDs),
+			zap.Int64s("fileSizeBytes", v2w.fileSizes),
+			zap.Int64("totalRows", totalRows),
+		)
+	}
+	// Read the manifest produced by Close(); "" for V2, real path for V3.
+	manifestPath := writerResult.writer.Manifest()
+	if manifestPath != "" {
+		log.Info("backfill V3 writer closed, manifest produced", zap.String("manifestPath", manifestPath))
+	}
+
+	// For V3: register BM25 stats in manifest (version N+1 → N+2).
+	// Channel-level scheduler exclusion guarantees no concurrent manifest modification.
+	if writerResult.storageVersion == storage.StorageV3 && len(writerResult.v3Stats) > 0 {
+		newManifest, err := packed.AddStatsToManifest(
+			manifestPath, t.compactionParams.StorageConfig, writerResult.v3Stats)
+		if err != nil {
+			return nil, merr.WrapErrServiceInternal("failed to add BM25 stats to V3 manifest", err.Error())
+		}
+		log.Info("backfill V3 bm25 stats added to manifest",
+			zap.String("oldManifest", manifestPath),
+			zap.String("newManifest", newManifest),
+		)
+		manifestPath = newManifest
+	}
+
+	// 7. build merged logs
+	var mergedInsertLogs, mergedBm25Logs []*datapb.FieldBinlog
+	if writerResult.storageVersion == storage.StorageV3 {
+		mergedInsertLogs, mergedBm25Logs, err = t.buildMergedLogsV3(segment, writerResult, totalSparseMemorySize, totalRows, bytes, bm25LogPathForResult, bm25LogID, outputFieldID)
+	} else {
+		mergedInsertLogs, mergedBm25Logs, err = t.buildMergedLogsV2(segment, writerResult, totalSparseMemorySize, totalRows, bytes, bm25LogPathForResult, bm25LogID, outputFieldID)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// 8. manifest path is already set from Close() and optionally updated by AddStatsToManifest above.
+
+	// 9. return compaction result
+	// For V3: BM25 stats are embedded in the manifest (committed atomically with
+	// column groups), so Bm25Logs should be nil — PackSegmentLoadInfo skips
+	// Bm25Logs when ManifestPath is set, relying on StatsResolver to read from manifest.
+	resultBm25Logs := mergedBm25Logs
+	if writerResult.storageVersion == storage.StorageV3 {
+		resultBm25Logs = nil
+	}
+
+	ret := &datapb.CompactionPlanResult{
+		PlanID: t.plan.GetPlanID(),
+		State:  datapb.CompactionTaskState_completed,
+		Segments: []*datapb.CompactionSegment{
+			{
+				SegmentID:           segmentID,
+				NumOfRows:           totalRows,
+				InsertLogs:          mergedInsertLogs,
+				Bm25Logs:            resultBm25Logs,
+				Field2StatslogPaths: segment.GetField2StatslogPaths(),
+				Deltalogs:           segment.GetDeltalogs(),
+				Channel:             segment.GetInsertChannel(),
+				StorageVersion:      writerResult.storageVersion,
+				Manifest:            manifestPath,
+			},
+		},
+		Type: t.plan.GetType(),
+	}
+	log.Info("backfill compaction completed",
+		zap.Int64("numOfRows", totalRows),
+		zap.Int("mergedInsertLogsCount", len(mergedInsertLogs)),
+		zap.Int("mergedBm25LogsCount", len(mergedBm25Logs)),
+		zap.Int("resultBm25LogsCount", len(resultBm25Logs)),
+		zap.String("manifestPath", manifestPath),
+		zap.Int64("effectiveStorageVersion", writerResult.storageVersion),
+		zap.Int32("collectionSchemaVersion", t.plan.GetSchema().GetVersion()),
+		zap.Duration("readDuration", readDuration),
+		zap.Duration("computeDuration", computeDuration),
+		zap.Duration("writeDuration", writeDuration),
+		zap.Duration("updateStatsDuration", updateStatsDuration),
+	)
+	return ret, nil
+}
+
+func (t *backfillCompactionTask) Complete() {
+	if t.done != nil {
+		select {
+		case t.done <- struct{}{}:
+		default:
+		}
+	}
+}
+
+func (t *backfillCompactionTask) Stop() {
+	if t.cancel != nil {
+		t.cancel()
+	}
+	if t.done != nil {
+		<-t.done
+	}
+}
+
+func (t *backfillCompactionTask) GetPlanID() typeutil.UniqueID {
+	return t.plan.GetPlanID()
+}
+
+func (t *backfillCompactionTask) GetCollection() typeutil.UniqueID {
+	// Get collection ID from the first segment binlog
+	if len(t.plan.GetSegmentBinlogs()) > 0 {
+		return t.plan.GetSegmentBinlogs()[0].GetCollectionID()
+	}
+	return 0
+}
+
+func (t *backfillCompactionTask) GetChannelName() string {
+	return t.plan.GetChannel()
+}
+
+func (t *backfillCompactionTask) GetCompactionType() datapb.CompactionType {
+	return t.plan.GetType()
+}
+
+func (t *backfillCompactionTask) GetSlotUsage() int64 {
+	return t.plan.GetSlotUsage()
+}
+
+func (t *backfillCompactionTask) GetStorageConfig() *indexpb.StorageConfig {
+	return t.compactionParams.StorageConfig
+}
+
+var _ Compactor = (*backfillCompactionTask)(nil)
+
+func NewBackfillCompactionTask(ctx context.Context, cm storage.ChunkManager, plan *datapb.CompactionPlan, compactionParams compaction.Params) *backfillCompactionTask {
+	ctx, cancel := context.WithCancel(ctx)
+	return &backfillCompactionTask{
+		ctx:              ctx,
+		cancel:           cancel,
+		plan:             plan,
+		compactionParams: compactionParams,
+		done:             make(chan struct{}, 1),
+		logIDAlloc:       allocator.NewLocalAllocator(plan.GetPreAllocatedLogIDs().GetBegin(), plan.GetPreAllocatedLogIDs().GetEnd()),
+		chunkManager:     cm,
+	}
+}

--- a/internal/datanode/compactor/backfill_compactor_test.go
+++ b/internal/datanode/compactor/backfill_compactor_test.go
@@ -1,0 +1,784 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compactor
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/allocator"
+	"github.com/milvus-io/milvus/internal/compaction"
+	"github.com/milvus-io/milvus/internal/mocks/flushcommon/mock_util"
+	mock_storage "github.com/milvus-io/milvus/internal/mocks/mock_storage"
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/storagecommon"
+	"github.com/milvus-io/milvus/internal/util/function"
+	"github.com/milvus-io/milvus/internal/util/initcore"
+	"github.com/milvus-io/milvus/pkg/v2/common"
+	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/etcdpb"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v2/util/tsoutil"
+)
+
+func TestBackfillCompactionTaskSuite(t *testing.T) {
+	suite.Run(t, new(BackfillCompactionTaskSuite))
+}
+
+type BackfillCompactionTaskSuite struct {
+	suite.Suite
+
+	mockBinlogIO *mock_util.MockBinlogIO
+
+	meta           *etcdpb.CollectionMeta
+	multiSegWriter *MultiSegmentWriter
+
+	task *backfillCompactionTask
+}
+
+func (s *BackfillCompactionTaskSuite) SetupSuite() {
+	paramtable.Get().Init(paramtable.NewBaseTable())
+}
+
+func (s *BackfillCompactionTaskSuite) setupTest() {
+	s.mockBinlogIO = mock_util.NewMockBinlogIO(s.T())
+
+	s.meta = genTestCollectionMetaWithBM25()
+
+	params, err := compaction.GenerateJSONParams()
+	if err != nil {
+		panic(err)
+	}
+
+	plan := &datapb.CompactionPlan{
+		PlanID: 999,
+		SegmentBinlogs: []*datapb.CompactionSegmentBinlogs{{
+			CollectionID:        1,
+			PartitionID:         1,
+			SegmentID:           100,
+			FieldBinlogs:        nil,
+			Field2StatslogPaths: nil,
+			Deltalogs:           nil,
+			InsertChannel:       "test_channel",
+			StorageVersion:      storage.StorageV2,
+		}},
+		Type:                   datapb.CompactionType_BackfillCompaction,
+		Schema:                 s.meta.GetSchema(),
+		PreAllocatedSegmentIDs: &datapb.IDRange{Begin: 19531, End: math.MaxInt64},
+		PreAllocatedLogIDs:     &datapb.IDRange{Begin: 9530, End: 19530},
+		MaxSize:                64 * 1024 * 1024,
+		JsonParams:             params,
+		Functions: []*schemapb.FunctionSchema{{
+			Name:             "BM25",
+			Id:               100,
+			Type:             schemapb.FunctionType_BM25,
+			InputFieldNames:  []string{"text"},
+			InputFieldIds:    []int64{101},
+			OutputFieldNames: []string{"sparse"},
+			OutputFieldIds:   []int64{102},
+		}},
+		TotalRows: 3,
+	}
+
+	cm, err := storage.NewChunkManagerFactoryWithParam(paramtable.Get()).NewPersistentStorageChunkManager(context.Background())
+	if err != nil {
+		panic(err)
+	}
+	s.task = NewBackfillCompactionTask(context.Background(), cm, plan, compaction.GenParams())
+}
+
+func (s *BackfillCompactionTaskSuite) SetupTest() {
+	// Align with sort_compaction_test fixture: use a per-test temp dir as the local
+	// storage root and disable Loon FFI. Without UseLoonFFI=false, the loon local
+	// filesystem double-prepends the configured root_path onto already-absolute log
+	// paths produced by MultiSegmentWriter, causing the reader to look for files at
+	// /rootPath/rootPath/insert_log/... and fail to open them.
+	paramtable.Get().Save("common.storage.enablev2", "true")
+	paramtable.Get().Save(paramtable.Get().CommonCfg.StorageType.Key, "local")
+	paramtable.Get().Save(paramtable.Get().CommonCfg.UseLoonFFI.Key, "false")
+	paramtable.Get().Save(paramtable.Get().LocalStorageCfg.Path.Key, s.T().TempDir())
+	initcore.InitStorageV2FileSystem(paramtable.Get())
+	s.setupTest()
+}
+
+func (s *BackfillCompactionTaskSuite) TearDownTest() {
+	paramtable.Get().Reset(paramtable.Get().CommonCfg.StorageType.Key)
+	paramtable.Get().Reset(paramtable.Get().CommonCfg.UseLoonFFI.Key)
+	paramtable.Get().Reset(paramtable.Get().LocalStorageCfg.Path.Key)
+	paramtable.Get().Reset("common.storage.enablev2")
+	initcore.CleanArrowFileSystemSingleton()
+}
+
+func (s *BackfillCompactionTaskSuite) prepareBackfillCompaction() {
+	segID := int64(100)
+	s.mockBinlogIO.EXPECT().Upload(mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	// Create multi segment writer with varchar field (input) but without sparse vector field (output)
+	// This simulates a segment that needs backfill
+	s.initSegBufferForBackfill(segID)
+
+	// Close the writer to finalize segments
+	err := s.multiSegWriter.Close()
+	s.Require().NoError(err)
+
+	// Get compaction segments
+	segments := s.multiSegWriter.GetCompactionSegments()
+	s.Require().Equal(1, len(segments), "should create exactly one segment")
+
+	segment := segments[0]
+	// Use the actual segmentID allocated by MultiSegmentWriter
+	actualSegID := segment.GetSegmentID()
+	s.task.plan.SegmentBinlogs = []*datapb.CompactionSegmentBinlogs{
+		{
+			CollectionID:   1,
+			PartitionID:    1,
+			SegmentID:      actualSegID,
+			FieldBinlogs:   segment.GetInsertLogs(),
+			InsertChannel:  "test_channel",
+			StorageVersion: segment.GetStorageVersion(),
+			Manifest:       segment.GetManifest(),
+		},
+	}
+
+	// Write blobs to disk from the uploaded blobs
+	// Note: MultiSegmentWriter handles upload internally, but we can still write to disk for testing
+	log.Info("created segment with MultiSegmentWriter",
+		zap.Int64("segmentID", segID),
+		zap.Int("numRows", int(segment.GetNumOfRows())),
+		zap.Int("insertLogsCount", len(segment.GetInsertLogs())))
+}
+
+func (s *BackfillCompactionTaskSuite) initSegBufferForBackfill(segID int64) {
+	// Create schema without sparse vector field (output field)
+	// Only include input field (varchar)
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{
+				FieldID:  common.RowIDField,
+				Name:     "row_id",
+				DataType: schemapb.DataType_Int64,
+			},
+			{
+				FieldID:  common.TimeStampField,
+				Name:     "Timestamp",
+				DataType: schemapb.DataType_Int64,
+			},
+			{
+				FieldID:      100,
+				Name:         "pk",
+				DataType:     schemapb.DataType_Int64,
+				IsPrimaryKey: true,
+			},
+			{
+				FieldID:  101,
+				Name:     "text",
+				DataType: schemapb.DataType_VarChar,
+				TypeParams: []*commonpb.KeyValuePair{
+					{
+						Key:   common.MaxLengthKey,
+						Value: "128",
+					},
+				},
+			},
+		},
+	}
+
+	// Create allocator for MultiSegmentWriter
+	// Use segID as the starting point for segmentID allocation to ensure consistent paths
+	segIDAlloc := allocator.NewLocalAllocator(segID, math.MaxInt64)
+	logIDAlloc := allocator.NewLocalAllocator(9530, 19530)
+	compAlloc := NewCompactionAllocator(segIDAlloc, logIDAlloc)
+
+	// Create MultiSegmentWriter with StorageV2
+	multiSegWriter, err := NewMultiSegmentWriter(
+		context.Background(),
+		s.mockBinlogIO,
+		compAlloc,
+		64*1024*1024, // 64MB segment size
+		schema,
+		s.task.compactionParams,
+		1000, // maxRows
+		PartitionID,
+		CollectionID,
+		"test_channel",
+		compactionBatchSize,
+		storage.WithStorageConfig(s.task.compactionParams.StorageConfig),
+		storage.WithVersion(storage.StorageV2),
+	)
+	s.Require().NoError(err)
+
+	// Write test data with varchar field
+	for i := 0; i < 3; i++ {
+		v := storage.Value{
+			PK:        storage.NewInt64PrimaryKey(segID + int64(i)),
+			Timestamp: int64(tsoutil.ComposeTSByTime(getMilvusBirthday(), 0)),
+			Value: map[int64]interface{}{
+				common.RowIDField:     segID + int64(i),
+				common.TimeStampField: int64(tsoutil.ComposeTSByTime(getMilvusBirthday(), 0)),
+				100:                   segID + int64(i),
+				101:                   "test string " + string(rune('0'+i)),
+			},
+		}
+		err = multiSegWriter.WriteValue(&v)
+		s.Require().NoError(err)
+	}
+
+	s.multiSegWriter = multiSegWriter
+}
+
+func (s *BackfillCompactionTaskSuite) TestBackfillCompactionSuccess() {
+	s.prepareBackfillCompaction()
+
+	result, err := s.task.Compact()
+	s.NoError(err)
+	s.NotNil(result)
+
+	s.Equal(s.task.plan.GetPlanID(), result.GetPlanID())
+	s.Equal(datapb.CompactionTaskState_completed, result.GetState())
+	s.Equal(1, len(result.GetSegments()))
+
+	segment := result.GetSegments()[0]
+	// SegmentID should match the one allocated by MultiSegmentWriter
+	s.NotZero(segment.GetSegmentID())
+	s.EqualValues(3, segment.GetNumOfRows())
+	s.NotEmpty(segment.GetInsertLogs())
+	// For V3 segments (with manifest), BM25 stats are embedded in the manifest
+	// atomically with the column groups. PackSegmentLoadInfo relies on StatsResolver
+	// to read them from the manifest instead of Bm25Logs.
+	// For V2 segments (no manifest), BM25 stats are returned in Bm25Logs as usual.
+	if segment.GetManifest() != "" {
+		s.Empty(segment.GetBm25Logs())
+		s.NotEmpty(segment.GetManifest())
+	} else {
+		s.NotEmpty(segment.GetBm25Logs())
+		s.Equal(1, len(segment.GetBm25Logs()))
+		// V2 BM25 stats binlog must have non-zero LogID so buildBinlogKvs does not reject it.
+		s.NotZero(segment.GetBm25Logs()[0].GetBinlogs()[0].GetLogID(),
+			"V2 BM25 stats binlog must have non-zero LogID")
+	}
+
+	// The backfilled output field (ID=102) must carry a non-zero LogID in its insert binlog.
+	// buildBinlogKvs requires LogID!=0 or LogPath!="" for V2; this guards against regression
+	// where LogID is accidentally left at zero (pre-existing fields are exempt — they were
+	// written by the test setup without LogID allocation).
+	const backfillOutputFieldID = int64(102)
+	for _, fl := range segment.GetInsertLogs() {
+		if fl.GetFieldID() == backfillOutputFieldID {
+			s.Require().NotEmpty(fl.GetBinlogs(), "backfilled output field must have at least one binlog entry")
+			s.NotZero(fl.GetBinlogs()[0].GetLogID(),
+				"V2 backfill insert binlog (fieldID=%d) must have non-zero LogID", backfillOutputFieldID)
+		}
+	}
+}
+
+func (s *BackfillCompactionTaskSuite) TestBackfillCompactionInvalidFunctionCount() {
+	s.prepareBackfillCompaction()
+
+	// Test with zero functions
+	s.task.plan.Functions = []*schemapb.FunctionSchema{}
+	_, err := s.task.Compact()
+	s.Error(err)
+	s.Contains(err.Error(), "backfill functions should be exactly one")
+
+	// Test with multiple functions
+	s.task.plan.Functions = []*schemapb.FunctionSchema{
+		{Type: schemapb.FunctionType_BM25},
+		{Type: schemapb.FunctionType_BM25},
+	}
+	_, err = s.task.Compact()
+	s.Error(err)
+	s.Contains(err.Error(), "backfill functions should be exactly one")
+}
+
+func (s *BackfillCompactionTaskSuite) TestBackfillCompactionInvalidInputField() {
+	s.prepareBackfillCompaction()
+
+	// Test with wrong input field type (Int64 instead of VarChar)
+	s.task.plan.Functions = []*schemapb.FunctionSchema{{
+		Name:           "BM25",
+		Type:           schemapb.FunctionType_BM25,
+		InputFieldIds:  []int64{100}, // Int64 field instead of VarChar
+		OutputFieldIds: []int64{102},
+	}}
+
+	_, err := s.task.Compact()
+	s.Error(err)
+	s.Contains(err.Error(), "input field data type must be varchar")
+}
+
+func (s *BackfillCompactionTaskSuite) TestBackfillCompactionInvalidOutputField() {
+	s.prepareBackfillCompaction()
+
+	// Test with wrong output field type (VarChar instead of SparseFloatVector)
+	s.task.plan.Functions = []*schemapb.FunctionSchema{{
+		Name:           "BM25",
+		Type:           schemapb.FunctionType_BM25,
+		InputFieldIds:  []int64{101},
+		OutputFieldIds: []int64{101}, // VarChar field instead of SparseFloatVector
+	}}
+
+	_, err := s.task.Compact()
+	s.Error(err)
+	s.Contains(err.Error(), "output field data type must be sparse float vector")
+}
+
+func (s *BackfillCompactionTaskSuite) TestBackfillCompactionMultipleInputFields() {
+	s.prepareBackfillCompaction()
+
+	// Test with multiple input fields
+	s.task.plan.Functions = []*schemapb.FunctionSchema{{
+		Name:           "BM25",
+		Type:           schemapb.FunctionType_BM25,
+		InputFieldIds:  []int64{101, 115}, // Multiple input fields
+		OutputFieldIds: []int64{102},
+	}}
+
+	_, err := s.task.Compact()
+	s.Error(err)
+	s.Contains(err.Error(), "bm25 function should have exactly one input field")
+}
+
+func (s *BackfillCompactionTaskSuite) TestBackfillCompactionMultipleOutputFields() {
+	s.prepareBackfillCompaction()
+
+	// Test with multiple output fields
+	s.task.plan.Functions = []*schemapb.FunctionSchema{{
+		Name:           "BM25",
+		Type:           schemapb.FunctionType_BM25,
+		InputFieldIds:  []int64{101},
+		OutputFieldIds: []int64{102, 114}, // Multiple output fields
+	}}
+
+	_, err := s.task.Compact()
+	s.Error(err)
+	s.Contains(err.Error(), "bm25 function should only have one output field")
+}
+
+func (s *BackfillCompactionTaskSuite) TestBackfillCompactionInputFieldNotFound() {
+	s.prepareBackfillCompaction()
+
+	// Test with non-existent input field ID
+	s.task.plan.Functions = []*schemapb.FunctionSchema{{
+		Name:           "BM25",
+		Type:           schemapb.FunctionType_BM25,
+		InputFieldIds:  []int64{999}, // Non-existent field ID
+		OutputFieldIds: []int64{102},
+	}}
+
+	_, err := s.task.Compact()
+	s.Error(err)
+	s.Contains(err.Error(), "input field not found in schema")
+}
+
+func (s *BackfillCompactionTaskSuite) TestBackfillCompactionOutputFieldNotFound() {
+	s.prepareBackfillCompaction()
+
+	// Test with non-existent output field ID
+	s.task.plan.Functions = []*schemapb.FunctionSchema{{
+		Name:           "BM25",
+		Type:           schemapb.FunctionType_BM25,
+		InputFieldIds:  []int64{101},
+		OutputFieldIds: []int64{999}, // Non-existent field ID
+	}}
+
+	_, err := s.task.Compact()
+	s.Error(err)
+	s.Contains(err.Error(), "no output field")
+}
+
+func (s *BackfillCompactionTaskSuite) TestBackfillCompactionUnsupportedFunctionType() {
+	s.prepareBackfillCompaction()
+
+	// Test with unsupported function type
+	s.task.plan.Functions = []*schemapb.FunctionSchema{{
+		Name:           "Unknown",
+		Type:           schemapb.FunctionType_Unknown,
+		InputFieldIds:  []int64{101},
+		OutputFieldIds: []int64{102},
+	}}
+
+	_, err := s.task.Compact()
+	s.Error(err)
+	s.Contains(err.Error(), "unknown functionRunner type")
+}
+
+func (s *BackfillCompactionTaskSuite) TestBackfillCompactionEmptySegmentBinlogs() {
+	// Test with empty segment binlogs
+	s.task.plan.SegmentBinlogs = nil
+
+	_, err := s.task.Compact()
+	s.Error(err)
+}
+
+func (s *BackfillCompactionTaskSuite) TestBackfillCompactionEmptyColumnGroups() {
+	s.prepareBackfillCompaction()
+
+	// Create segment binlogs with empty field binlogs to trigger empty field binlogs error
+	s.task.plan.SegmentBinlogs = []*datapb.CompactionSegmentBinlogs{
+		{
+			CollectionID:   1,
+			PartitionID:    1,
+			SegmentID:      100,
+			FieldBinlogs:   []*datapb.FieldBinlog{}, // Empty field binlogs
+			InsertChannel:  "test_channel",
+			StorageVersion: storage.StorageV2,
+		},
+	}
+
+	_, err := s.task.Compact()
+	s.Error(err)
+	s.Contains(err.Error(), "segment's field binlogs are empty")
+}
+
+func (s *BackfillCompactionTaskSuite) TestBackfillCompactionMultipleSegments() {
+	s.prepareBackfillCompaction()
+
+	// Test with multiple segments (should fail, must have exactly one)
+	s.task.plan.SegmentBinlogs = []*datapb.CompactionSegmentBinlogs{
+		{
+			CollectionID:   1,
+			PartitionID:    1,
+			SegmentID:      100,
+			FieldBinlogs:   []*datapb.FieldBinlog{{FieldID: 101}},
+			InsertChannel:  "test_channel",
+			StorageVersion: storage.StorageV2,
+		},
+		{
+			CollectionID:   1,
+			PartitionID:    1,
+			SegmentID:      200,
+			FieldBinlogs:   []*datapb.FieldBinlog{{FieldID: 101}},
+			InsertChannel:  "test_channel",
+			StorageVersion: storage.StorageV2,
+		},
+	}
+
+	_, err := s.task.Compact()
+	s.Error(err)
+	s.Contains(err.Error(), "must have exactly one segment")
+	s.Contains(err.Error(), "but got 2 segments")
+}
+
+func (s *BackfillCompactionTaskSuite) TestBackfillCompactionContextCanceled() {
+	// Cancel context before compact (before prepareBackfillCompaction)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	s.task.ctx = ctx
+	s.task.cancel = cancel
+
+	// Compact should detect context cancel at the beginning
+	_, err := s.task.Compact()
+	s.Error(err)
+	s.ErrorIs(err, context.Canceled)
+}
+
+func TestBackfillCompactionTaskBasic(t *testing.T) {
+	ctx := context.Background()
+
+	meta := genTestCollectionMetaWithBM25()
+	params, err := compaction.GenerateJSONParams()
+	assert.NoError(t, err)
+
+	plan := &datapb.CompactionPlan{
+		PlanID: 1000,
+		SegmentBinlogs: []*datapb.CompactionSegmentBinlogs{{
+			CollectionID:   1,
+			PartitionID:    1,
+			SegmentID:      200,
+			InsertChannel:  "test_channel",
+			StorageVersion: storage.StorageV2,
+		}},
+		Type:                   datapb.CompactionType_BackfillCompaction,
+		Schema:                 meta.GetSchema(),
+		PreAllocatedSegmentIDs: &datapb.IDRange{Begin: 19531, End: math.MaxInt64},
+		PreAllocatedLogIDs:     &datapb.IDRange{Begin: 9530, End: 19530},
+		MaxSize:                64 * 1024 * 1024,
+		JsonParams:             params,
+		Functions: []*schemapb.FunctionSchema{{
+			Name:           "BM25",
+			Type:           schemapb.FunctionType_BM25,
+			InputFieldIds:  []int64{101},
+			OutputFieldIds: []int64{102},
+		}},
+		TotalRows: 0,
+		Channel:   "test_channel",
+		SlotUsage: 1,
+	}
+
+	mockCM := mock_storage.NewMockChunkManager(t)
+	task := NewBackfillCompactionTask(ctx, mockCM, plan, compaction.GenParams())
+	assert.NotNil(t, task)
+	assert.Equal(t, int64(1000), task.GetPlanID())
+	assert.Equal(t, int64(1), task.GetCollection())
+	assert.Equal(t, "test_channel", task.GetChannelName())
+	assert.Equal(t, datapb.CompactionType_BackfillCompaction, task.GetCompactionType())
+	assert.Equal(t, int64(1), task.GetSlotUsage())
+}
+
+func (s *BackfillCompactionTaskSuite) TestProcessBatch() {
+	s.Run("success", func() {
+		s.setupTest()
+		mockRunner := function.NewMockFunctionRunner(s.T())
+		sparseArray := &schemapb.SparseFloatArray{
+			Contents: [][]byte{{1, 2, 3, 4}},
+			Dim:      100,
+		}
+		mockRunner.EXPECT().BatchRun([]string{"hello world"}).Return([]interface{}{sparseArray}, nil)
+
+		insertData, memSize, err := s.task.processBatch(mockRunner, []string{"hello world"}, 102)
+		s.NoError(err)
+		s.Greater(memSize, 0)
+		s.NotNil(insertData)
+		s.NotNil(insertData.Data[102])
+	})
+
+	s.Run("BatchRun error", func() {
+		s.setupTest()
+		mockRunner := function.NewMockFunctionRunner(s.T())
+		mockRunner.EXPECT().BatchRun([]string{"test"}).Return(nil, errors.New("batch run failed"))
+
+		_, _, err := s.task.processBatch(mockRunner, []string{"test"}, 102)
+		s.Error(err)
+		s.Contains(err.Error(), "batch run failed")
+	})
+
+	s.Run("wrong output count", func() {
+		s.setupTest()
+		mockRunner := function.NewMockFunctionRunner(s.T())
+		mockRunner.EXPECT().BatchRun([]string{"test"}).Return([]interface{}{nil, nil}, nil)
+
+		_, _, err := s.task.processBatch(mockRunner, []string{"test"}, 102)
+		s.Error(err)
+		s.Contains(err.Error(), "exactly one output")
+	})
+
+	s.Run("wrong output type", func() {
+		s.setupTest()
+		mockRunner := function.NewMockFunctionRunner(s.T())
+		mockRunner.EXPECT().BatchRun([]string{"test"}).Return([]interface{}{"not_sparse"}, nil)
+
+		_, _, err := s.task.processBatch(mockRunner, []string{"test"}, 102)
+		s.Error(err)
+		s.Contains(err.Error(), "unexpected output type")
+	})
+}
+
+func (s *BackfillCompactionTaskSuite) TestFinalizeMergedLogs() {
+	s.setupTest()
+
+	segment := &datapb.CompactionSegmentBinlogs{
+		SegmentID: 1,
+		FieldBinlogs: []*datapb.FieldBinlog{
+			{
+				FieldID: 100,
+				Binlogs: []*datapb.Binlog{
+					{LogPath: "original/100", EntriesNum: 1000},
+				},
+			},
+		},
+	}
+	newInsertLogs := map[int64]*datapb.FieldBinlog{
+		102: {
+			FieldID: 102,
+			Binlogs: []*datapb.Binlog{
+				{LogPath: "new/102", EntriesNum: 1000, MemorySize: 500},
+			},
+		},
+	}
+	bm25Bytes := []byte{1, 2, 3, 4, 5}
+
+	mergedInsert, mergedBm25, err := s.task.finalizeMergedLogs(segment, newInsertLogs, 1000, bm25Bytes, "bm25/stats/path", 77, 102)
+	s.NoError(err)
+
+	// Check merged insert logs contain both original and new
+	s.Equal(2, len(mergedInsert))
+	s.Equal(int64(100), mergedInsert[0].GetFieldID())
+	s.Equal(int64(102), mergedInsert[1].GetFieldID())
+
+	// Check BM25 logs
+	s.Equal(1, len(mergedBm25))
+	s.Equal(int64(102), mergedBm25[0].GetFieldID())
+	s.Equal(int64(5), mergedBm25[0].GetBinlogs()[0].GetLogSize())
+	s.Equal("bm25/stats/path", mergedBm25[0].GetBinlogs()[0].GetLogPath())
+	s.Equal(int64(1000), mergedBm25[0].GetBinlogs()[0].GetEntriesNum())
+	// LogID must be populated so buildBinlogKvs does not reject it with "invalid log id"
+	s.Equal(int64(77), mergedBm25[0].GetBinlogs()[0].GetLogID())
+}
+
+// TestFinalizeMergedLogsCrashReplay verifies that re-running finalizeMergedLogs
+// when the segment already contains the output field (DC crashed after AlterSegments
+// but before task-state transition) does not produce duplicate InsertLog entries.
+func (s *BackfillCompactionTaskSuite) TestFinalizeMergedLogsCrashReplay() {
+	s.setupTest()
+
+	// Segment state after first successful run: field 102 already present in etcd.
+	segment := &datapb.CompactionSegmentBinlogs{
+		SegmentID: 1,
+		FieldBinlogs: []*datapb.FieldBinlog{
+			{FieldID: 100, Binlogs: []*datapb.Binlog{{LogPath: "original/100", EntriesNum: 1000}}},
+			{FieldID: 102, Binlogs: []*datapb.Binlog{{LogPath: "first-run/102", EntriesNum: 1000, LogID: 99}}},
+		},
+	}
+	// Second run allocates a new logID for the same output field.
+	newInsertLogs := map[int64]*datapb.FieldBinlog{
+		102: {FieldID: 102, Binlogs: []*datapb.Binlog{{LogPath: "second-run/102", EntriesNum: 1000, LogID: 100}}},
+	}
+
+	mergedInsert, _, err := s.task.finalizeMergedLogs(segment, newInsertLogs, 1000, []byte{1}, "bm25/path", 77, 102)
+	s.NoError(err)
+
+	// Must have exactly 2 entries (field 100 + field 102), not 3.
+	s.Require().Equal(2, len(mergedInsert))
+	var fieldIDs []int64
+	for _, fb := range mergedInsert {
+		fieldIDs = append(fieldIDs, fb.GetFieldID())
+	}
+	s.ElementsMatch([]int64{100, 102}, fieldIDs)
+	// Retained entry must be the first-run binlog, not the replay copy.
+	for _, fb := range mergedInsert {
+		if fb.GetFieldID() == 102 {
+			s.Equal("first-run/102", fb.GetBinlogs()[0].GetLogPath())
+		}
+	}
+}
+
+// TestFinalizeMergedLogsV3CrashReplay verifies crash-replay dedup for V3 column groups
+// where the output field is identified via ChildFields rather than FieldID directly.
+func (s *BackfillCompactionTaskSuite) TestFinalizeMergedLogsV3CrashReplay() {
+	s.setupTest()
+
+	// V3: column group 102 already present in segment after first run.
+	segment := &datapb.CompactionSegmentBinlogs{
+		SegmentID: 1,
+		FieldBinlogs: []*datapb.FieldBinlog{
+			{FieldID: 100, Binlogs: []*datapb.Binlog{{LogPath: "original/100"}}},
+			{FieldID: 102, ChildFields: []int64{102}, Binlogs: []*datapb.Binlog{{LogPath: "first-run/cg102"}}},
+		},
+	}
+	newInsertLogs := map[int64]*datapb.FieldBinlog{
+		102: {FieldID: 102, ChildFields: []int64{102}, Binlogs: []*datapb.Binlog{{LogPath: "second-run/cg102"}}},
+	}
+
+	mergedInsert, _, err := s.task.finalizeMergedLogs(segment, newInsertLogs, 0, []byte{1}, "bm25/path", 0, 102)
+	s.NoError(err)
+
+	s.Require().Equal(2, len(mergedInsert))
+	for _, fb := range mergedInsert {
+		if fb.GetFieldID() == 102 {
+			s.Equal("first-run/cg102", fb.GetBinlogs()[0].GetLogPath())
+		}
+	}
+}
+
+func (s *BackfillCompactionTaskSuite) TestBuildMergedLogsV2() {
+	s.setupTest()
+
+	segment := &datapb.CompactionSegmentBinlogs{
+		SegmentID: 1,
+		FieldBinlogs: []*datapb.FieldBinlog{
+			{FieldID: 100, Binlogs: []*datapb.Binlog{{LogPath: "original/100", EntriesNum: 1000}}},
+		},
+	}
+	// Simulate a V2 writer result: one column group with explicit paths, logIDs, and file sizes.
+	writerResult := &backfillWriterResult{
+		columnGroups: []storagecommon.ColumnGroup{
+			{GroupID: 102, Fields: []int64{102}},
+		},
+		paths:          []string{"/local/insert_log/1/1/1/102/77"},
+		truePaths:      []string{"/local/insert_log/1/1/1/102/77"},
+		logIDs:         []int64{77},
+		fileSizes:      []int64{2048},
+		storageVersion: storage.StorageV2,
+	}
+
+	mergedInsert, mergedBm25, err := s.task.buildMergedLogsV2(segment, writerResult, 512, 1000, []byte{1, 2, 3}, "bm25/path/55", 55, 102)
+	s.NoError(err)
+
+	// Expect original field 100 + new field 102.
+	s.Require().Equal(2, len(mergedInsert))
+	s.Equal(int64(100), mergedInsert[0].GetFieldID())
+	s.Equal(int64(102), mergedInsert[1].GetFieldID())
+
+	newBinlog := mergedInsert[1].GetBinlogs()[0]
+	s.Equal(int64(2048), newBinlog.GetLogSize(), "LogSize should match file size from CloseAndTell")
+	s.Equal(int64(512), newBinlog.GetMemorySize(), "MemorySize should match sparse field memory size")
+	s.Equal(int64(1000), newBinlog.GetEntriesNum())
+	s.Equal(int64(77), newBinlog.GetLogID(), "LogID must match allocated log ID")
+	s.Equal("/local/insert_log/1/1/1/102/77", newBinlog.GetLogPath())
+
+	// BM25 stats log.
+	s.Require().Equal(1, len(mergedBm25))
+	s.Equal(int64(102), mergedBm25[0].GetFieldID())
+	s.Equal("bm25/path/55", mergedBm25[0].GetBinlogs()[0].GetLogPath())
+	s.Equal(int64(55), mergedBm25[0].GetBinlogs()[0].GetLogID())
+	s.Equal(int64(3), mergedBm25[0].GetBinlogs()[0].GetLogSize(), "BM25 log size should equal len(bytes)")
+}
+
+func (s *BackfillCompactionTaskSuite) TestBuildMergedLogsV3() {
+	s.setupTest()
+
+	segment := &datapb.CompactionSegmentBinlogs{
+		SegmentID: 1,
+		FieldBinlogs: []*datapb.FieldBinlog{
+			{FieldID: 100, Binlogs: []*datapb.Binlog{{LogPath: "original/100", EntriesNum: 1000}}},
+		},
+	}
+	writerResult := &backfillWriterResult{
+		columnGroups: []storagecommon.ColumnGroup{
+			{GroupID: 102, Fields: []int64{102}},
+		},
+	}
+
+	mergedInsert, mergedBm25, err := s.task.buildMergedLogsV3(segment, writerResult, 512, 1000, []byte{1, 2, 3}, "bm25/path", 0, 102)
+	s.NoError(err)
+
+	// Original + new
+	s.Equal(2, len(mergedInsert))
+	s.Equal(int64(100), mergedInsert[0].GetFieldID())
+	s.Equal(int64(102), mergedInsert[1].GetFieldID())
+	s.Equal(int64(512), mergedInsert[1].GetBinlogs()[0].GetMemorySize())
+	s.Equal(int64(1000), mergedInsert[1].GetBinlogs()[0].GetEntriesNum())
+	// V3 binlog presence marker must carry a non-zero LogID so buildBinlogKvs validation
+	// passes (requires LogID!=0 AND LogPath=="" for V3 segments).
+	s.NotZero(mergedInsert[1].GetBinlogs()[0].GetLogID(),
+		"V3 backfill binlog presence marker must have non-zero LogID")
+
+	s.Equal(1, len(mergedBm25))
+	s.Equal(int64(102), mergedBm25[0].GetFieldID())
+}
+
+func (s *BackfillCompactionTaskSuite) TestCompleteAndStop() {
+	s.setupTest()
+	s.task.Complete()
+	s.task.Stop()
+}
+
+func (s *BackfillCompactionTaskSuite) TestGetStorageConfig() {
+	s.setupTest()
+	s.NotNil(s.task.GetStorageConfig())
+}

--- a/internal/datanode/compactor/backfill_compactor_test.go
+++ b/internal/datanode/compactor/backfill_compactor_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/errors"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"

--- a/internal/datanode/compactor/executor.go
+++ b/internal/datanode/compactor/executor.go
@@ -91,6 +91,8 @@ func getTaskSlotUsage(task Compactor) int64 {
 			taskSlotUsage = paramtable.Get().DataCoordCfg.MixCompactionSlotUsage.GetAsInt64()
 		case datapb.CompactionType_Level0DeleteCompaction:
 			taskSlotUsage = paramtable.Get().DataCoordCfg.L0DeleteCompactionSlotUsage.GetAsInt64()
+		case datapb.CompactionType_BackfillCompaction:
+			taskSlotUsage = paramtable.Get().DataCoordCfg.BackfillCompactionSlotUsage.GetAsInt64()
 		}
 		log.Warn("illegal task slot usage, change it to a default value",
 			zap.Int64("illegalSlotUsage", task.GetSlotUsage()),

--- a/internal/datanode/services.go
+++ b/internal/datanode/services.go
@@ -302,6 +302,8 @@ func (node *DataNode) CompactionV2(ctx context.Context, req *datapb.CompactionPl
 			compactionParams,
 			sortFields,
 		)
+	case datapb.CompactionType_BackfillCompaction:
+		task = compactor.NewBackfillCompactionTask(taskCtx, cm, req, compactionParams)
 	default:
 		log.Warn("Unknown compaction type", zap.String("type", req.GetType().String()))
 		return merr.Status(merr.WrapErrParameterInvalidMsg("Unknown compaction type: %v", req.GetType().String())), nil

--- a/internal/distributed/proxy/service.go
+++ b/internal/distributed/proxy/service.go
@@ -685,6 +685,10 @@ func (s *Server) AlterCollectionField(ctx context.Context, request *milvuspb.Alt
 	return s.proxy.AlterCollectionField(ctx, request)
 }
 
+func (s *Server) AlterCollectionSchema(ctx context.Context, request *milvuspb.AlterCollectionSchemaRequest) (*milvuspb.AlterCollectionSchemaResponse, error) {
+	return s.proxy.AlterCollectionSchema(ctx, request)
+}
+
 func (s *Server) AddCollectionFunction(ctx context.Context, request *milvuspb.AddCollectionFunctionRequest) (*commonpb.Status, error) {
 	return s.proxy.AddCollectionFunction(ctx, request)
 }

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -969,10 +969,20 @@ func (node *Proxy) AddCollectionField(ctx context.Context, request *milvuspb.Add
 			"add field operation is not supported for external collection %s", request.GetCollectionName())), nil
 	}
 
-	// TODO(#48808): gate AddCollectionField against in-progress backfill once segment schema-version
-	// propagation for DoPhysicalBackfill=false DDLs is synchronous.  Currently the backfill
-	// policy updates segment schema versions on a tick, so a rapid second AddCollectionField
-	// can arrive before the tick fires and be incorrectly rejected by the gate.
+	// Prevent concurrent schema-change requests (AddCollectionField / AlterCollectionSchema)
+	// on the same collection from racing past the schema version consistency gate.
+	collKey := request.GetDbName() + "/" + request.GetCollectionName()
+	if _, loaded := node.alterSchemaInFlight.LoadOrStore(collKey, struct{}{}); loaded {
+		return merr.Status(merr.WrapErrParameterInvalidMsg(
+			"another schema-change request is already in progress for collection %s", request.GetCollectionName())), nil
+	}
+	defer node.alterSchemaInFlight.Delete(collKey)
+
+	// Block until all segments have caught up to the current schema version,
+	// preventing a new field addition while a previous backfill is still in progress.
+	if err := node.checkSchemaVersionConsistency(ctx, request.DbName, request.CollectionName); err != nil {
+		return merr.Status(err), nil
+	}
 
 	task := &addCollectionFieldTask{
 		ctx:                       ctx,
@@ -1119,7 +1129,17 @@ func (node *Proxy) AlterCollectionSchema(ctx context.Context, request *milvuspb.
 }
 
 // checkSchemaVersionConsistency checks if all segments have consistent schema version
-// Returns error if schema version consistency proportion is less than 100%
+// Returns error if schema version consistency proportion is less than 100%.
+//
+// NOTE: this is a Proxy-local fast-path check only. The `alterSchemaInFlight` map
+// on the Proxy is per-instance, so in a multi-Proxy deployment two concurrent
+// schema-change requests routed to different Proxy instances each see their own
+// empty local map and both pass this check before either has bumped the schema
+// version, allowing the race through. The authoritative cluster-wide consistency
+// gate lives at RootCoord and is enforced after acquiring the collection resource
+// key lock — see checkSchemaVersionConsistencyAtRootCoord in rootcoord, added by
+// companion PR #48989. This Proxy-side check remains as a cheap early reject to
+// avoid unnecessary RootCoord round-trips on the common single-Proxy path.
 func (node *Proxy) checkSchemaVersionConsistency(ctx context.Context, dbName, collectionName string) error {
 	log := log.Ctx(ctx).With(
 		zap.String("role", typeutil.ProxyRole),

--- a/internal/proxy/impl_test.go
+++ b/internal/proxy/impl_test.go
@@ -2392,6 +2392,58 @@ func TestProxy_AddCollectionField_ExternalCollection(t *testing.T) {
 	assert.Contains(t, resp.GetReason(), "add field operation is not supported for external collection")
 }
 
+func TestProxy_AddCollectionField_SchemaVersionGate(t *testing.T) {
+	t.Run("consistency check fails", func(t *testing.T) {
+		mockey.PatchConvey("consistency check blocks AddCollectionField", t, func() {
+			node := createTestProxy()
+			defer node.sched.Close()
+
+			mockey.Mock((*Proxy).DescribeCollection).Return(&milvuspb.DescribeCollectionResponse{
+				Status: merr.Success(),
+				Schema: &schemapb.CollectionSchema{Name: "test_coll"},
+			}, nil).Build()
+
+			mockey.Mock((*Proxy).checkSchemaVersionConsistency).Return(
+				merr.WrapErrParameterInvalidMsg("consistency check failed"),
+			).Build()
+
+			resp, err := node.AddCollectionField(context.Background(), &milvuspb.AddCollectionFieldRequest{
+				DbName:         "default",
+				CollectionName: "test_coll",
+			})
+			assert.NoError(t, err)
+			assert.Error(t, merr.Error(resp))
+			assert.Contains(t, resp.GetReason(), "consistency check failed")
+		})
+	})
+
+	t.Run("concurrent request rejected", func(t *testing.T) {
+		mockey.PatchConvey("in-flight gate blocks concurrent AddCollectionField", t, func() {
+			node := createTestProxy()
+			defer node.sched.Close()
+
+			mockey.Mock((*Proxy).DescribeCollection).Return(&milvuspb.DescribeCollectionResponse{
+				Status: merr.Success(),
+				Schema: &schemapb.CollectionSchema{Name: "test_coll"},
+			}, nil).Build()
+
+			// Simulate an in-flight schema change on the same collection
+			collKey := "default/test_coll"
+			node.alterSchemaInFlight.Store(collKey, struct{}{})
+
+			resp, err := node.AddCollectionField(context.Background(), &milvuspb.AddCollectionFieldRequest{
+				DbName:         "default",
+				CollectionName: "test_coll",
+			})
+			assert.NoError(t, err)
+			assert.Error(t, merr.Error(resp))
+			assert.Contains(t, resp.GetReason(), "another schema-change request is already in progress")
+
+			node.alterSchemaInFlight.Delete(collKey)
+		})
+	})
+}
+
 func TestProxy_AlterCollectionField_ExternalCollection(t *testing.T) {
 	cache := globalMetaCache
 	defer func() { globalMetaCache = cache }()

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -863,6 +863,15 @@ func (t *alterCollectionSchemaTask) PreExecute(ctx context.Context) error {
 		}
 	}
 
+	// Physical backfill is currently only implemented for BM25 in the datanode backfill
+	// compactor. Reject unsupported types early so the request never reaches RootCoord
+	// and no segment is left in an unrecoverable stale-schema state.
+	if addRequest.GetDoPhysicalBackfill() && funcSchemas[0].GetType() != schemapb.FunctionType_BM25 {
+		return merr.WrapErrParameterInvalidMsg(
+			"physical backfill is currently only supported for BM25 functions, got %s",
+			funcSchemas[0].GetType().String())
+	}
+
 	// Validate function-field type compatibility (e.g., BM25 requires varchar input,
 	// SparseFloatVector output). Construct a merged schema with old fields + new fields
 	// + new function, then validate only the new function to avoid re-checking existing

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -7119,6 +7119,35 @@ func TestAlterCollectionSchemaTask(t *testing.T) {
 		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
 	})
 
+	t.Run("PreExecute rejects non-BM25 function with DoPhysicalBackfill", func(t *testing.T) {
+		req := &milvuspb.AlterCollectionSchemaRequest{
+			DbName:         dbName,
+			CollectionName: collectionName,
+			Action: &milvuspb.AlterCollectionSchemaRequest_Action{
+				Op: &milvuspb.AlterCollectionSchemaRequest_Action_AddRequest{
+					AddRequest: &milvuspb.AlterCollectionSchemaRequest_AddRequest{
+						DoPhysicalBackfill: true,
+						FieldInfos: []*milvuspb.AlterCollectionSchemaRequest_FieldInfo{
+							{FieldSchema: sparseOutputField},
+						},
+						FuncSchema: []*schemapb.FunctionSchema{
+							{
+								Name:             "text_embedding_func",
+								Type:             schemapb.FunctionType_TextEmbedding,
+								InputFieldNames:  []string{"text"},
+								OutputFieldNames: []string{"sparse_bm25"},
+							},
+						},
+					},
+				},
+			},
+		}
+		task := buildTask(req, oldSchema)
+		err := task.PreExecute(ctx)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
 	t.Run("PreExecute happy path", func(t *testing.T) {
 		task := buildTask(buildValidRequest(), oldSchema)
 		err := task.PreExecute(ctx)

--- a/internal/rootcoord/ddl_callbacks_alter_collection_schema.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_schema.go
@@ -61,6 +61,15 @@ func (c *Core) broadcastAlterCollectionSchema(ctx context.Context, req *milvuspb
 	}
 	functionSchema := funcSchemas[0]
 
+	// Physical backfill is currently only implemented for BM25 functions in the datanode
+	// backfill_compactor. Proxy performs the same check; this is a defense-in-depth guard
+	// for requests that bypass the Proxy (e.g. direct gRPC to RootCoord).
+	if addRequest.GetDoPhysicalBackfill() && functionSchema.GetType() != schemapb.FunctionType_BM25 {
+		return merr.WrapErrParameterInvalidMsg(
+			"physical backfill is currently only supported for BM25 functions, got %s",
+			functionSchema.GetType().String())
+	}
+
 	if len(fieldInfos) == 0 {
 		return merr.WrapErrParameterInvalidMsg("fieldInfos is empty")
 	}

--- a/internal/rootcoord/ddl_callbacks_alter_collection_schema_test.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_schema_test.go
@@ -121,6 +121,77 @@ func TestDDLCallbacksBroadcastAlterCollectionSchema(t *testing.T) {
 	})
 	require.ErrorIs(t, merr.CheckRPCCall(resp.GetAlterStatus(), err), merr.ErrParameterInvalid)
 
+	// case 4.1: physical backfill with non-BM25 function must be rejected.
+	// Otherwise the backfill task would fail at datanode with "unsupported function type"
+	// and permanently block subsequent schema-change DDLs via the consistency gate.
+	resp, err = core.AlterCollectionSchema(ctx, &milvuspb.AlterCollectionSchemaRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		Action: &milvuspb.AlterCollectionSchemaRequest_Action{
+			Op: &milvuspb.AlterCollectionSchemaRequest_Action_AddRequest{
+				AddRequest: &milvuspb.AlterCollectionSchemaRequest_AddRequest{
+					FuncSchema: []*schemapb.FunctionSchema{
+						{
+							Name:             "minhash_fn",
+							Type:             schemapb.FunctionType_MinHash,
+							InputFieldNames:  []string{"text_input"},
+							OutputFieldNames: []string{"sparse_minhash"},
+						},
+					},
+					FieldInfos: []*milvuspb.AlterCollectionSchemaRequest_FieldInfo{
+						{FieldSchema: &schemapb.FieldSchema{
+							Name:             "sparse_minhash",
+							DataType:         schemapb.DataType_SparseFloatVector,
+							IsFunctionOutput: true,
+						}},
+					},
+					DoPhysicalBackfill: true,
+				},
+			},
+		},
+	})
+	require.ErrorIs(t, merr.CheckRPCCall(resp.GetAlterStatus(), err), merr.ErrParameterInvalid)
+	require.Contains(t, resp.GetAlterStatus().GetReason(), "physical backfill is currently only supported for BM25 functions")
+
+	// case 4.2: non-BM25 function with DoPhysicalBackfill=false should NOT be rejected by
+	// the type check (it may still fail later for other reasons, but the type check must pass).
+	// This path never invokes the backfill_compactor, so "unsupported type" cannot be triggered.
+	// We don't assert success here because downstream validation may reject for unrelated
+	// reasons in this minimal test setup — we only assert that the error, if any, is not the
+	// physical-backfill type rejection.
+	resp, err = core.AlterCollectionSchema(ctx, &milvuspb.AlterCollectionSchemaRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		Action: &milvuspb.AlterCollectionSchemaRequest_Action{
+			Op: &milvuspb.AlterCollectionSchemaRequest_Action_AddRequest{
+				AddRequest: &milvuspb.AlterCollectionSchemaRequest_AddRequest{
+					FuncSchema: []*schemapb.FunctionSchema{
+						{
+							Name:             "minhash_fn_nophys",
+							Type:             schemapb.FunctionType_MinHash,
+							InputFieldNames:  []string{"text_input"},
+							OutputFieldNames: []string{"sparse_minhash2"},
+						},
+					},
+					FieldInfos: []*milvuspb.AlterCollectionSchemaRequest_FieldInfo{
+						{FieldSchema: &schemapb.FieldSchema{
+							Name:             "sparse_minhash2",
+							DataType:         schemapb.DataType_SparseFloatVector,
+							IsFunctionOutput: true,
+						}},
+					},
+					DoPhysicalBackfill: false,
+				},
+			},
+		},
+	})
+	// Whatever happens, it must not be the BM25-only rejection.
+	if err := merr.CheckRPCCall(resp.GetAlterStatus(), err); err != nil {
+		require.NotContains(t, resp.GetAlterStatus().GetReason(),
+			"physical backfill is currently only supported for BM25 functions",
+			"non-BM25 with DoPhysicalBackfill=false must not be rejected by the BM25-only type check")
+	}
+
 	// case 5: fieldSchema nil in fieldInfos
 	resp, err = core.AlterCollectionSchema(ctx, &milvuspb.AlterCollectionSchemaRequest{
 		DbName:         dbName,

--- a/internal/storagev2/packed/packed_writer_ffi.go
+++ b/internal/storagev2/packed/packed_writer_ffi.go
@@ -151,6 +151,15 @@ func NewFFIPackedWriter(basePath string, baseVersion int64, schema *arrow.Schema
 	}, nil
 }
 
+// AsNewColumnGroups marks this writer so that Close() calls loon_transaction_add_column_group
+// for each written column group instead of loon_transaction_append_files.
+// Call this when the written columns are brand-new additions to an existing manifest
+// (e.g. function-field backfill), not when appending more files to the same column structure.
+func (pw *FFIPackedWriter) AsNewColumnGroups() *FFIPackedWriter {
+	pw.addNewColumnGroups = true
+	return pw
+}
+
 func (pw *FFIPackedWriter) WriteRecordBatch(recordBatch arrow.Record) error {
 	var caa cdata.CArrowArray
 	var cas cdata.CArrowSchema
@@ -185,9 +194,24 @@ func (pw *FFIPackedWriter) Close() (string, error) {
 	}
 	defer C.loon_transaction_destroy(transationHandle)
 
-	result = C.loon_transaction_append_files(transationHandle, cColumnGroups)
-	if err := HandleLoonFFIResult(result); err != nil {
-		return "", err
+	if pw.addNewColumnGroups {
+		// Each written group is a brand-new column group: add them one-by-one.
+		// loon_transaction_append_files requires the count to match existing groups,
+		// which would fail when extending the schema (e.g. backfill adds sparse vector
+		// to a manifest that already has 2 groups of different columns).
+		numGroups := int(cColumnGroups.num_of_column_groups)
+		colGroupSlice := (*[1 << 20]C.LoonColumnGroup)(unsafe.Pointer(cColumnGroups.column_group_array))[:numGroups:numGroups]
+		for i := range colGroupSlice {
+			result = C.loon_transaction_add_column_group(transationHandle, &colGroupSlice[i])
+			if err := HandleLoonFFIResult(result); err != nil {
+				return "", err
+			}
+		}
+	} else {
+		result = C.loon_transaction_append_files(transationHandle, cColumnGroups)
+		if err := HandleLoonFFIResult(result); err != nil {
+			return "", err
+		}
 	}
 
 	var cCommitVersion C.int64_t

--- a/internal/storagev2/packed/type.go
+++ b/internal/storagev2/packed/type.go
@@ -39,6 +39,12 @@ type FFIPackedWriter struct {
 	baseVersion   int64
 	cWriterHandle C.LoonWriterHandle
 	cProperties   *C.LoonProperties
+	// addNewColumnGroups controls whether Close() uses loon_transaction_add_column_group
+	// (true) or loon_transaction_append_files (false).
+	//
+	// Use true when adding columns that do not yet exist in the manifest (e.g. backfill).
+	// Use false (default) when writing more files into the same column structure (e.g. multi-batch write).
+	addNewColumnGroups bool
 }
 
 type PackedReader struct {

--- a/internal/streamingnode/server/flusher/flusherimpl/msg_handler_impl.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/msg_handler_impl.go
@@ -72,6 +72,10 @@ func (impl *msgHandlerImpl) createNewGrowingSegment(ctx context.Context, vchanne
 	}
 	logger := log.With(zap.Int64("collectionID", h.CollectionId), zap.Int64("partitionID", h.PartitionId), zap.Int64("segmentID", h.SegmentId))
 	return retry.Do(ctx, func() (err error) {
+		// TODO: propagate SchemaVersion from CreateSegmentMessageHeader into AllocSegmentRequest
+		// so that DataCoord records the correct schema version for streaming-created segments.
+		// Without this, new segments get SchemaVersion=0 and will be falsely flagged for backfill.
+		// Tracked in companion PR: https://github.com/milvus-io/milvus/pull/48865
 		resp, err := mix.AllocSegment(ctx, &datapb.AllocSegmentRequest{
 			CollectionId:         h.CollectionId,
 			PartitionId:          h.PartitionId,

--- a/internal/streamingnode/server/wal/interceptors/shard/shards/segment_alloc_worker.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shards/segment_alloc_worker.go
@@ -97,6 +97,10 @@ func (w *segmentAllocWorker) doOnce() error {
 	// Build a fresh message each time to avoid reusing a contaminated message.
 	// After a failed WAL append, the message may have internal state set (e.g., WAL term)
 	// that would cause a panic if reused.
+	// TODO: include SchemaVersion in CreateSegmentMessageHeader so that the flusher
+	// can propagate it to DataCoord's AllocSegment RPC. Currently streaming-created
+	// segments get SchemaVersion=0, causing unnecessary backfill triggers.
+	// Tracked in companion PR: https://github.com/milvus-io/milvus/pull/48865
 	msg := message.NewCreateSegmentMessageBuilderV2().
 		WithVChannel(w.vchannel).
 		WithHeader(&message.CreateSegmentMessageHeader{

--- a/tests/python_client/base/client_v2_base.py
+++ b/tests/python_client/base/client_v2_base.py
@@ -1143,6 +1143,76 @@ class TestMilvusClientV2Base(Base):
                                        **kwargs).run()
         return res, check_result
 
+    def wait_schema_version_consistent(self, client, collection_name, timeout=30, poll_interval=0.01):
+        """
+        Poll get_collection_stats until the schema version consistency gate would pass.
+
+        Background: After a previous schema-change DDL (AlterCollectionSchema or
+        AddCollectionField), DataCoord's backfill segment-version propagation runs on
+        a periodic tick. Until the tick fires, a back-to-back schema-change call is
+        rejected by the consistency gate at the Proxy / RootCoord with an error like
+        "schema version consistency check failed: N/M segments have caught up".
+        E2E tests that issue successive schema changes need to wait until the gate
+        would pass; this helper polls the same stats keys the gate reads.
+
+        Pass condition (mirrors checkSchemaVersionConsistency):
+          - both keys absent → schema version is 0, no backfill in progress → pass
+          - schema_version_consistent_segments == schema_version_total_segments → pass
+
+        Note: pymilvus MilvusClient.get_collection_stats returns a dict[str, str]
+        (with row_count converted to int), so we read the keys directly from the dict.
+
+        Args:
+            client: pymilvus MilvusClient
+            collection_name: target collection
+            timeout: max seconds to wait before giving up (default 30s)
+            poll_interval: sleep between polls in seconds (default 10ms)
+
+        Raises:
+            AssertionError on timeout, with the last observed counts for debugging.
+        """
+        consistent_key = "schema_version_consistent_segments"
+        total_key = "schema_version_total_segments"
+        deadline = time.time() + timeout
+        last_consistent, last_total = None, None
+        while time.time() < deadline:
+            stats, _ = self.get_collection_stats(client, collection_name)
+            if not stats:
+                time.sleep(poll_interval)
+                continue
+            consistent = stats.get(consistent_key)
+            total = stats.get(total_key)
+            # Both absent → schema v0 path, gate passes trivially.
+            if consistent is None and total is None:
+                return
+            # Both present and equal → backfill caught up.
+            if consistent is not None and total is not None and int(consistent) == int(total):
+                return
+            last_consistent, last_total = consistent, total
+            time.sleep(poll_interval)
+        raise AssertionError(
+            f"wait_schema_version_consistent timed out after {timeout}s for collection "
+            f"{collection_name}: consistent={last_consistent}, total={last_total}"
+        )
+
+    def add_collection_field_wait_schema_version_consistency(self, client, collection_name, field_name, data_type,
+                                                              desc="", timeout=None, check_task=None, check_items=None,
+                                                              wait_timeout=30, poll_interval=0.01, **kwargs):
+        """
+        Wrapper around add_collection_field that first waits for the schema-version
+        consistency gate to pass. Use this in E2E tests that issue successive
+        schema-change DDLs back-to-back, where the previous call's backfill
+        segment-version propagation tick may not have fired yet.
+
+        See wait_schema_version_consistent for the polling logic and pass conditions.
+        All add_collection_field arguments are forwarded unchanged.
+        """
+        self.wait_schema_version_consistent(client, collection_name,
+                                            timeout=wait_timeout, poll_interval=poll_interval)
+        return self.add_collection_field(client, collection_name, field_name, data_type, desc=desc,
+                                         timeout=timeout, check_task=check_task, check_items=check_items,
+                                         **kwargs)
+
     # ====================== Snapshot ======================
     @trace()
     def create_snapshot(self, client, collection_name, snapshot_name, description="",

--- a/tests/python_client/milvus_client/test_add_field_feature.py
+++ b/tests/python_client/milvus_client/test_add_field_feature.py
@@ -62,8 +62,10 @@ class TestMilvusClientAddFieldFeature(TestMilvusClientV2Base):
                        "vector_name": "embeddings"}
         self.add_collection_field(client, collection_name, field_name="field_new_int64", data_type=DataType.INT64,
                                   nullable=True, is_clustering_key=True, mmap_enabled=True)
-        self.add_collection_field(client, collection_name, field_name="field_new_var", data_type=DataType.VARCHAR,
-                                  nullable=True, default_vaule="field_new_var", max_length=64, mmap_enabled=True)
+        # Wait for previous schema bump's backfill segment-version propagation tick to fire.
+        self.add_collection_field_wait_schema_version_consistency(
+            client, collection_name, field_name="field_new_var", data_type=DataType.VARCHAR,
+            nullable=True, default_vaule="field_new_var", max_length=64, mmap_enabled=True)
         check_items["add_fields"] = ["field_new_int64", "field_new_var"]
         self.describe_collection(client, collection_name,
                                  check_task=CheckTasks.check_describe_collection_property,
@@ -271,10 +273,14 @@ class TestMilvusClientAddFieldFeature(TestMilvusClientV2Base):
         rows = cf.gen_row_data_by_schema(nb=ct.default_nb, schema=new_collection_info, start=ct.default_nb)
         self.insert(client, collection_name, rows)
         # 4. add one more vector field and index data
+        # Wait for the previous add_collection_field's backfill segment-version
+        # propagation tick to fire before the second schema change — otherwise
+        # the consistency gate at Proxy / RootCoord rejects this call.
         new_vec_field_name_2 = "embeddings_2"
-        self.add_collection_field(client, collection_name, field_name=new_vec_field_name_2,
-                                  data_type=DataType.FLOAT_VECTOR, dim=dim,
-                                  nullable=True)
+        self.add_collection_field_wait_schema_version_consistency(
+            client, collection_name, field_name=new_vec_field_name_2,
+            data_type=DataType.FLOAT_VECTOR, dim=dim,
+            nullable=True)
         # 5. build index for new added vector field
         index_params = self.prepare_index_params(client)[0]
         index_params.add_index(new_vec_field_name_2, index_type=index_type, metric_type="COSINE")
@@ -990,11 +996,17 @@ class TestMilvusClientAddFieldFeatureInvalid(TestMilvusClientV2Base):
         self.create_collection(client, collection_name, dim)
         collections = self.list_collections(client)[0]
         assert collection_name in collections
+        # Each loop iteration bumps the schema version; wait for the previous bump's
+        # backfill segment-version propagation tick to fire before the next call.
         for i in range(62):
-            self.add_collection_field(client, collection_name, field_name=f"{field_name}_{i}",
-                                      data_type=DataType.VARCHAR, nullable=True, max_length=64)
-        self.add_collection_field(client, collection_name, field_name=field_name, data_type=DataType.VARCHAR,
-                                  nullable=True, max_length=64, check_task=CheckTasks.err_res, check_items=error)
+            self.add_collection_field_wait_schema_version_consistency(
+                client, collection_name, field_name=f"{field_name}_{i}",
+                data_type=DataType.VARCHAR, nullable=True, max_length=64)
+        # Final err_res call: the gate must be passed BEFORE this call so the error
+        # returned is the intended "max fields exceeded" error, not a consistency error.
+        self.add_collection_field_wait_schema_version_consistency(
+            client, collection_name, field_name=field_name, data_type=DataType.VARCHAR,
+            nullable=True, max_length=64, check_task=CheckTasks.err_res, check_items=error)
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_milvus_client_collection_add_vector_field_exceed_max_vector_field_number(self):
@@ -1012,14 +1024,20 @@ class TestMilvusClientAddFieldFeatureInvalid(TestMilvusClientV2Base):
         self.create_collection(client, collection_name, dim)
         collections = self.list_collections(client)[0]
         assert collection_name in collections
+        # Each loop iteration bumps the schema version; wait for the previous bump's
+        # backfill segment-version propagation tick to fire before the next call.
         for i in range(ct.max_vector_field_num - 1):
-            self.add_collection_field(client, collection_name, field_name=f"{field_name}_{i}",
-                                      data_type=DataType.FLOAT_VECTOR, dim=dim,
-                                      nullable=True)
-        self.add_collection_field(client, collection_name, field_name=field_name,
-                                  data_type=DataType.FLOAT_VECTOR, dim=dim,
-                                  nullable=True,
-                                  check_task=CheckTasks.err_res, check_items=error)
+            self.add_collection_field_wait_schema_version_consistency(
+                client, collection_name, field_name=f"{field_name}_{i}",
+                data_type=DataType.FLOAT_VECTOR, dim=dim,
+                nullable=True)
+        # Final err_res call: wait for consistency so the error we assert is the
+        # real "max vector fields exceeded" error, not a spurious consistency error.
+        self.add_collection_field_wait_schema_version_consistency(
+            client, collection_name, field_name=field_name,
+            data_type=DataType.FLOAT_VECTOR, dim=dim,
+            nullable=True,
+            check_task=CheckTasks.err_res, check_items=error)
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_milvus_client_add_field_with_reranker_unsupported(self):

--- a/tests/python_client/milvus_client/test_milvus_client_alter.py
+++ b/tests/python_client/milvus_client/test_milvus_client_alter.py
@@ -355,8 +355,10 @@ class TestMilvusClientAlterCollection(TestMilvusClientV2Base):
                                  "pk_name": default_primary_key_field_name,
                                  "limit": default_limit})
         # 9. add new field same as dynamic field name
-        self.add_collection_field(client, collection_name, field_name=default_dynamic_field_name,
-                                  data_type=DataType.INT64, nullable=True, default_value=default_value)
+        # Wait for step-3 add_collection_field's backfill segment-version propagation tick.
+        self.add_collection_field_wait_schema_version_consistency(
+            client, collection_name, field_name=default_dynamic_field_name,
+            data_type=DataType.INT64, nullable=True, default_value=default_value)
         # 10. query using filter with dynamic field and new field
         res = self.query(client, collection_name,
                          filter='$meta["{}"]["a"]["b"] >= 0 and {} == {}'.format(default_dynamic_field_name,
@@ -694,15 +696,17 @@ class TestMilvusClientAlterCollectionField(TestMilvusClientV2Base):
                                     check_task=CheckTasks.err_res, check_items=error)
 
         # add a nullable vector field to the collection
-        self.add_collection_field(client, collection_name, field_name="embeddings_3", 
+        self.add_collection_field(client, collection_name, field_name="embeddings_3",
                                   data_type=DataType.FLOAT_VECTOR, dim=dim, nullable=True)
         # try to alert the new added nullable vector field to non-nullable field
         self.alter_collection_field(client, collection_name, field_name="embeddings_3",
                                     field_params={"nullable": False},
                                     check_task=CheckTasks.err_res, check_items=error)
         # add a nullable varchar field to the collection
-        self.add_collection_field(client, collection_name, field_name="varchar_3", 
-                                  data_type=DataType.VARCHAR, max_length=64, nullable=True)
+        # Wait for previous add_collection_field's backfill segment-version propagation tick.
+        self.add_collection_field_wait_schema_version_consistency(
+            client, collection_name, field_name="varchar_3",
+            data_type=DataType.VARCHAR, max_length=64, nullable=True)
         # try to alert the new added nullable varchar field to non-nullable varchar field
         self.alter_collection_field(client, collection_name, field_name="varchar_3",
                                     field_params={"nullable": False},

--- a/tests/python_client/milvus_client/test_milvus_client_alter_warmup.py
+++ b/tests/python_client/milvus_client/test_milvus_client_alter_warmup.py
@@ -3012,8 +3012,12 @@ class TestMilvusClientWarmupAsync(TestMilvusClientV2Base):
                                   DataType.VARCHAR, max_length=1024,
                                   nullable=True, warmup="async",
                                   enable_analyzer=True, enable_match=True)
-        self.add_collection_field(client, collection_name, "json_1",
-                                  DataType.JSON, nullable=True, warmup="async")
+        # Wait for the previous AddCollectionField's backfill segment-version propagation
+        # tick to fire before issuing the next one — otherwise the consistency gate at
+        # the Proxy / RootCoord rejects this call with "schema version consistency check failed".
+        self.add_collection_field_wait_schema_version_consistency(
+            client, collection_name, "json_1",
+            DataType.JSON, nullable=True, warmup="async")
 
         res = self.describe_collection(client, collection_name)[0]
         assert cf.get_field_warmup(res, "varchar_1") == "async"

--- a/tests/python_client/milvus_client/test_milvus_client_collection.py
+++ b/tests/python_client/milvus_client/test_milvus_client_collection.py
@@ -772,8 +772,10 @@ class TestMilvusClientCollectionValid(TestMilvusClientV2Base):
         if add_field:
             self.add_collection_field(client, collection_name, field_name="field_new_int64", data_type=DataType.INT64,
                                       nullable=True, is_cluster_key=True)
-            self.add_collection_field(client, collection_name, field_name="field_new_var", data_type=DataType.VARCHAR,
-                                      nullable=True, default_vaule="field_new_var", max_length=64)
+            # Wait for previous schema bump's backfill segment-version propagation tick.
+            self.add_collection_field_wait_schema_version_consistency(
+                client, collection_name, field_name="field_new_var", data_type=DataType.VARCHAR,
+                nullable=True, default_vaule="field_new_var", max_length=64)
             check_items["add_fields"] = ["field_new_int64", "field_new_var"]
         self.describe_collection(client, collection_name,
                                  check_task=CheckTasks.check_describe_collection_property,

--- a/tests/python_client/milvus_client/test_milvus_client_index.py
+++ b/tests/python_client/milvus_client/test_milvus_client_index.py
@@ -409,8 +409,10 @@ class TestMilvusClientIndexValid(TestMilvusClientV2Base):
         if add_field:
             self.add_collection_field(client, collection_name, field_name="field_int", data_type=DataType.INT32,
                                       nullable=True)
-            self.add_collection_field(client, collection_name, field_name="field_varchar", data_type=DataType.VARCHAR,
-                                      nullable=True, max_length=64)
+            # Wait for previous schema bump's backfill segment-version propagation tick.
+            self.add_collection_field_wait_schema_version_consistency(
+                client, collection_name, field_name="field_varchar", data_type=DataType.VARCHAR,
+                nullable=True, max_length=64)
         self.release_collection(client, collection_name)
         self.drop_index(client, collection_name, "vector")
         res = self.list_indexes(client, collection_name)[0]


### PR DESCRIPTION
DataCoord/DataNode compaction execution layer for function field backfill.

- DataCoord: BackfillCompactionPolicy (trigger when schema version inconsistent), BackfillCompactionTask (coord-side state machine), schema version consistency gating in GetCollectionStatistics, clustering compaction guard
- DataNode: BackfillCompactionTask (executor-side), backfillCompactor for physical data transformation of function output fields
- storagev2: AsNewColumnGroups() API for packed writer transactions

related: https://github.com/milvus-io/milvus/issues/48808
design doc: https://github.com/milvus-io/milvus-design-docs/blob/main/design_docs/20260129-add-function-field-design.md