### PR TITLE
fix: prevent ChunkManagerWrapper destructor crash on parallel test teardown

### DIFF
--- a/internal/core/src/index/InvertedIndexTest.cpp
+++ b/internal/core/src/index/InvertedIndexTest.cpp
@@ -85,7 +85,8 @@ struct ChunkManagerWrapper {
             cm_->Remove(file);
         }
 
-        boost::filesystem::remove_all(cm_->GetRootPath());
+        boost::system::error_code ec;
+        boost::filesystem::remove_all(cm_->GetRootPath(), ec);
     }
 
     void

--- a/internal/core/src/index/JsonFlatIndexTest.cpp
+++ b/internal/core/src/index/JsonFlatIndexTest.cpp
@@ -82,7 +82,8 @@ struct ChunkManagerWrapper {
             cm_->Remove(file);
         }
 
-        boost::filesystem::remove_all(cm_->GetRootPath());
+        boost::system::error_code ec;
+        boost::filesystem::remove_all(cm_->GetRootPath(), ec);
     }
 
     void

--- a/internal/core/unittest/test_utils/storage_test_utils.h
+++ b/internal/core/unittest/test_utils/storage_test_utils.h
@@ -306,7 +306,8 @@ struct ChunkManagerWrapper {
             cm_->Remove(file);
         }
 
-        boost::filesystem::remove_all(cm_->GetRootPath());
+        boost::system::error_code ec;
+        boost::filesystem::remove_all(cm_->GetRootPath(), ec);
     }
 
     void


### PR DESCRIPTION
pr: #48834

## Summary
- Use `boost::system::error_code` overload of `remove_all()` in `ChunkManagerWrapper` destructor to prevent SIGABRT crash
- Fix applied to all 3 copies: `storage_test_utils.h`, `InvertedIndexTest.cpp`, `JsonFlatIndexTest.cpp`

## Problem
When running C++ unit tests in parallel shards, `ChunkManagerWrapper::~ChunkManagerWrapper()` can crash with:
```
boost::filesystem::remove: Directory not empty [system:39]: "4000_4000_3_100"
*** Signal 6 (SIGABRT)
```

## Fix
Use the `error_code` overload: `boost::filesystem::remove_all(path, ec)` which silently ignores errors instead of throwing. This is the standard pattern for RAII cleanup in destructors.

Related: #48368 (same pattern fixed for JsonKeyStats destructor)