### PR TITLE
test: Fix 20 nightly e2e cases broken by test code bugs

### DIFF
--- a/tests/python_client/common/common_func.py
+++ b/tests/python_client/common/common_func.py
@@ -1700,7 +1700,7 @@ def gen_default_rows_data_all_data_type(nb=ct.default_nb, dim=ct.default_dim, st
         dict = {ct.default_int64_field_name: i,
                 ct.default_int32_field_name: i,
                 ct.default_int16_field_name: i,
-                ct.default_int8_field_name: i,
+                ct.default_int8_field_name: int(np.int8(i)),
                 ct.default_bool_field_name: bool(i),
                 ct.default_float_field_name: i*1.0,
                 ct.default_double_field_name: i * 1.0,

--- a/tests/python_client/milvus_client_v2/test_milvus_client_range_search.py
+++ b/tests/python_client/milvus_client_v2/test_milvus_client_range_search.py
@@ -1248,8 +1248,9 @@ class TestRangeSearchIndependent(TestMilvusClientV2Base):
 
         # 3. range search
         search_vectors = cf.gen_vectors(ct.default_nq, dim)
-        search_params = cf.get_search_params_params(index)
-        search_params["params"].update({"radius": 2, "range_filter": 0.1})
+        params = cf.get_search_params_params(index)
+        params.update({"radius": 2, "range_filter": 0.1})
+        search_params = {"params": params}
         self.search(client, collection_name,
                     data=search_vectors,
                     anns_field=default_search_field,


### PR DESCRIPTION
## Summary

Two unrelated test code bugs caused 20 e2e cases to fail in master nightly #664, reproducing in **both** `distributed-pulsar-mmap` and `distributed-woodpecker` configurations. Both root causes are pure test-code issues — no Milvus server change required.

issue: #48841

## Root Causes & Fixes

### A1 — `test_range_search_after_different_index_with_params` (8 cases)

`cf.get_search_params_params(index)` returns the **inner** params dict (e.g. `{"nprobe": 32}`), not a wrapped `{"params": {...}}`. All other 16 callers in the repo wrap it themselves, but this call site at `test_milvus_client_range_search.py:1251-1252` wrongly accessed `search_params["params"]`, causing `KeyError: 'params'`.

The same file at line 672-678 already shows the **correct** pattern. Fix matches it:

```diff
-        search_params = cf.get_search_params_params(index)
-        search_params["params"].update({"radius": 2, "range_filter": 0.1})
+        params = cf.get_search_params_params(index)
+        params.update({"radius": 2, "range_filter": 0.1})
+        search_params = {"params": params}
```

### A2 — `test_search_after_{none,default}_data_all_field_datatype` (12 cases)

`gen_default_rows_data_all_data_type` at `common/common_func.py:1703` assigned the row index `i` directly to the int8 field. At `i=128` it overflowed `int8 [-128, 127]` and the server rejected insert with:

```
MilvusException(code=1100, message=the 128th element (128) out of range:
[-128, 127]: invalid parameter[expected=integer doesn't overflow][actual=out of range])
```

Wrap with `np.int8(i)` to keep the sequential property while staying in range. `i=128 → -128`, `i=255 → -1`, `i=256 → 0`. Existing assertions like `int8 == 8` for row 8 still hold (8 is unchanged).

```diff
-                ct.default_int8_field_name: i,
+                ct.default_int8_field_name: int(np.int8(i)),
```

Note: `gen_row_data_by_schema()` (a different helper) already uses `random.randint(-128, 127)` correctly. Only `gen_default_rows_data_all_data_type()` was buggy.

## Test Plan

Verified locally against `master-20260408-151dc63` on a real Milvus cluster:

| Group | Before | After | Duration |
|---|---|---|---|
| A1 (8 cases) | 0/8 PASS | **8/8 PASS** | 22s |
| A2 (12 cases) | 0/12 PASS | **12/12 PASS** | 39s |

- [x] A1: `pytest milvus_client_v2/test_milvus_client_range_search.py -k test_range_search_after_different_index_with_params -n 4` → 8 passed
- [x] A2: `pytest milvus_client_v2/test_milvus_client_search_none_default.py -k "test_search_after_none_data_all_field_datatype or test_search_after_default_data_all_field_datatype" -n 4` → 12 passed
- [x] Reproduced original failures before fix to confirm root cause
- [ ] Nightly CI green after merge

## Related

- Issue: milvus-io/milvus#48841
- Nightly build: https://jenkins.milvus.io:18080/job/Milvus%20Nightly%20CI(new)/job/master/664/