### PR TITLE
fix: use binlog memory size for ArrayOfVector field data size estimation in index build

### DIFF
--- a/internal/datanode/index/task_index.go
+++ b/internal/datanode/index/task_index.go
@@ -235,17 +235,22 @@ func (it *indexBuildTask) Execute(ctx context.Context) error {
 
 	indexType := it.newIndexParams[common.IndexTypeKey]
 	var fieldDataSize uint64
-	var err error
 
-	// Ignore the error here, this param will only be used for diskann and aisaq
-	if it.req.GetField().GetDataType() == schemapb.DataType_ArrayOfVector {
+	// Estimate field data size, only used for diskann and aisaq
+	dim := uint64(it.req.GetDim())
+	numRows := uint64(it.req.GetNumRows())
+	switch it.req.GetField().GetDataType() {
+	case schemapb.DataType_BinaryVector:
+		fieldDataSize = dim / 8 * numRows
+	case schemapb.DataType_FloatVector:
+		fieldDataSize = dim * numRows * 4
+	case schemapb.DataType_Float16Vector, schemapb.DataType_BFloat16Vector:
+		fieldDataSize = dim * numRows * 2
+	case schemapb.DataType_ArrayOfVector:
 		fieldDataSize = getFieldDataSizeFromBinlogs(it.req.GetInsertLogs(), it.req.GetField().GetFieldID())
-	} else {
-		fieldDataSize, _ = estimateFieldDataSize(it.req.GetDim(), it.req.GetNumRows(), it.req.GetField().GetDataType())
 	}
 	if vecindexmgr.GetVecIndexMgrInstance().IsDiskANN(indexType) {
-		err = indexparams.SetDiskIndexBuildParams(it.newIndexParams, int64(fieldDataSize))
-		if err != nil {
+		if err := indexparams.SetDiskIndexBuildParams(it.newIndexParams, int64(fieldDataSize)); err != nil {
 			log.Warn("failed to fill disk index params", zap.Error(err))
 			return err
 		}

--- a/internal/datanode/index/task_index.go
+++ b/internal/datanode/index/task_index.go
@@ -333,6 +333,7 @@ func (it *indexBuildTask) Execute(ctx context.Context) error {
 		buildIndexParams.StoragePluginContext = it.pluginContext
 	}
 
+	var err error
 	it.index, err = indexcgowrapper.CreateIndex(ctx, buildIndexParams)
 	if err != nil {
 		if it.index != nil && it.index.CleanLocalData() != nil {

--- a/internal/datanode/index/task_index.go
+++ b/internal/datanode/index/task_index.go
@@ -238,7 +238,11 @@ func (it *indexBuildTask) Execute(ctx context.Context) error {
 	var err error
 
 	// Ignore the error here, this param will only be used for diskann and aisaq
-	fieldDataSize, _ = estimateFieldDataSize(it.req.GetDim(), it.req.GetNumRows(), it.req.GetField().GetDataType())
+	if it.req.GetField().GetDataType() == schemapb.DataType_ArrayOfVector {
+		fieldDataSize = getFieldDataSizeFromBinlogs(it.req.GetInsertLogs(), it.req.GetField().GetFieldID())
+	} else {
+		fieldDataSize, _ = estimateFieldDataSize(it.req.GetDim(), it.req.GetNumRows(), it.req.GetField().GetDataType())
+	}
 	if vecindexmgr.GetVecIndexMgrInstance().IsDiskANN(indexType) {
 		err = indexparams.SetDiskIndexBuildParams(it.newIndexParams, int64(fieldDataSize))
 		if err != nil {

--- a/internal/datanode/index/util.go
+++ b/internal/datanode/index/util.go
@@ -33,6 +33,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/pkg/v2/common"
+	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/util/hardware"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
@@ -59,6 +60,19 @@ func estimateFieldDataSize(dim int64, numRows int64, dataType schemapb.DataType)
 	default:
 		return 0, nil
 	}
+}
+
+func getFieldDataSizeFromBinlogs(insertLogs []*datapb.FieldBinlog, fieldID int64) uint64 {
+	var totalSize uint64
+	for _, fieldBinlog := range insertLogs {
+		if fieldBinlog.GetFieldID() == fieldID {
+			for _, binlog := range fieldBinlog.GetBinlogs() {
+				totalSize += uint64(binlog.GetMemorySize())
+			}
+			break
+		}
+	}
+	return totalSize
 }
 
 func mapToKVPairs(m map[string]string) []*commonpb.KeyValuePair {

--- a/internal/datanode/index/util.go
+++ b/internal/datanode/index/util.go
@@ -28,10 +28,7 @@ package index
 import "C"
 
 import (
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
-	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/util/hardware"
@@ -45,21 +42,6 @@ func getCurrentIndexVersion(v int32) int32 {
 		return cMaximum
 	}
 	return v
-}
-
-func estimateFieldDataSize(dim int64, numRows int64, dataType schemapb.DataType) (uint64, error) {
-	switch dataType {
-	case schemapb.DataType_BinaryVector:
-		return uint64(dim) / 8 * uint64(numRows), nil
-	case schemapb.DataType_FloatVector:
-		return uint64(dim) * uint64(numRows) * 4, nil
-	case schemapb.DataType_Float16Vector, schemapb.DataType_BFloat16Vector:
-		return uint64(dim) * uint64(numRows) * 2, nil
-	case schemapb.DataType_SparseFloatVector:
-		return 0, errors.New("could not estimate field data size of SparseFloatVector")
-	default:
-		return 0, nil
-	}
 }
 
 func getFieldDataSizeFromBinlogs(insertLogs []*datapb.FieldBinlog, fieldID int64) uint64 {

--- a/internal/datanode/index/util_test.go
+++ b/internal/datanode/index/util_test.go
@@ -76,33 +76,42 @@ func (s *utilSuite) Test_estimateFieldDataSize() {
 }
 
 func (s *utilSuite) Test_getFieldDataSizeFromBinlogs() {
+	// Storage V2/V3 splits vector fields into their own column group,
+	// where GroupID (used as FieldBinlog.FieldID) equals the vector field's ID.
+	// Non-vector fields may be grouped together under a different GroupID.
+	vectorFieldID := int64(101)
 	insertLogs := []*datapb.FieldBinlog{
 		{
-			FieldID: 100,
+			// Non-vector column group: GroupID=100, contains scalar fields 100 and 102
+			FieldID:     100,
+			ChildFields: []int64{100, 102},
 			Binlogs: []*datapb.Binlog{
 				{MemorySize: 1024},
 				{MemorySize: 2048},
 			},
 		},
 		{
-			FieldID: 101,
+			// Vector field in its own column group: GroupID = FieldID = 101
+			FieldID:     vectorFieldID,
+			ChildFields: []int64{vectorFieldID},
 			Binlogs: []*datapb.Binlog{
 				{MemorySize: 4096},
+				{MemorySize: 8192},
 			},
 		},
 	}
 
-	// Match field 100
-	s.Equal(uint64(3072), getFieldDataSizeFromBinlogs(insertLogs, 100))
+	// Vector field matches by FieldID (== GroupID)
+	s.Equal(uint64(12288), getFieldDataSizeFromBinlogs(insertLogs, vectorFieldID))
 
-	// Match field 101
-	s.Equal(uint64(4096), getFieldDataSizeFromBinlogs(insertLogs, 101))
+	// Scalar field grouped under GroupID=100
+	s.Equal(uint64(3072), getFieldDataSizeFromBinlogs(insertLogs, 100))
 
 	// No match
 	s.Equal(uint64(0), getFieldDataSizeFromBinlogs(insertLogs, 999))
 
 	// Nil insert logs
-	s.Equal(uint64(0), getFieldDataSizeFromBinlogs(nil, 100))
+	s.Equal(uint64(0), getFieldDataSizeFromBinlogs(nil, vectorFieldID))
 }
 
 func Test_utilSuite(t *testing.T) {

--- a/internal/datanode/index/util_test.go
+++ b/internal/datanode/index/util_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
-	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 )
 
@@ -38,41 +37,6 @@ func (s *utilSuite) Test_mapToKVPairs() {
 	}
 
 	s.Equal(3, len(mapToKVPairs(indexParams)))
-}
-
-func (s *utilSuite) Test_estimateFieldDataSize() {
-	dim := int64(128)
-	numRows := int64(1000)
-
-	// BinaryVector: dim/8 * numRows
-	size, err := estimateFieldDataSize(dim, numRows, schemapb.DataType_BinaryVector)
-	s.NoError(err)
-	s.Equal(uint64(dim)/8*uint64(numRows), size)
-
-	// FloatVector: dim * numRows * 4
-	size, err = estimateFieldDataSize(dim, numRows, schemapb.DataType_FloatVector)
-	s.NoError(err)
-	s.Equal(uint64(dim)*uint64(numRows)*4, size)
-
-	// Float16Vector: dim * numRows * 2
-	size, err = estimateFieldDataSize(dim, numRows, schemapb.DataType_Float16Vector)
-	s.NoError(err)
-	s.Equal(uint64(dim)*uint64(numRows)*2, size)
-
-	// BFloat16Vector: dim * numRows * 2
-	size, err = estimateFieldDataSize(dim, numRows, schemapb.DataType_BFloat16Vector)
-	s.NoError(err)
-	s.Equal(uint64(dim)*uint64(numRows)*2, size)
-
-	// SparseFloatVector: error
-	size, err = estimateFieldDataSize(dim, numRows, schemapb.DataType_SparseFloatVector)
-	s.Error(err)
-	s.Equal(uint64(0), size)
-
-	// Unknown type: 0, no error
-	size, err = estimateFieldDataSize(dim, numRows, schemapb.DataType_Int64)
-	s.NoError(err)
-	s.Equal(uint64(0), size)
 }
 
 func (s *utilSuite) Test_getFieldDataSizeFromBinlogs() {

--- a/internal/datanode/index/util_test.go
+++ b/internal/datanode/index/util_test.go
@@ -21,6 +21,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 )
 
 type utilSuite struct {
@@ -35,6 +38,71 @@ func (s *utilSuite) Test_mapToKVPairs() {
 	}
 
 	s.Equal(3, len(mapToKVPairs(indexParams)))
+}
+
+func (s *utilSuite) Test_estimateFieldDataSize() {
+	dim := int64(128)
+	numRows := int64(1000)
+
+	// BinaryVector: dim/8 * numRows
+	size, err := estimateFieldDataSize(dim, numRows, schemapb.DataType_BinaryVector)
+	s.NoError(err)
+	s.Equal(uint64(dim)/8*uint64(numRows), size)
+
+	// FloatVector: dim * numRows * 4
+	size, err = estimateFieldDataSize(dim, numRows, schemapb.DataType_FloatVector)
+	s.NoError(err)
+	s.Equal(uint64(dim)*uint64(numRows)*4, size)
+
+	// Float16Vector: dim * numRows * 2
+	size, err = estimateFieldDataSize(dim, numRows, schemapb.DataType_Float16Vector)
+	s.NoError(err)
+	s.Equal(uint64(dim)*uint64(numRows)*2, size)
+
+	// BFloat16Vector: dim * numRows * 2
+	size, err = estimateFieldDataSize(dim, numRows, schemapb.DataType_BFloat16Vector)
+	s.NoError(err)
+	s.Equal(uint64(dim)*uint64(numRows)*2, size)
+
+	// SparseFloatVector: error
+	size, err = estimateFieldDataSize(dim, numRows, schemapb.DataType_SparseFloatVector)
+	s.Error(err)
+	s.Equal(uint64(0), size)
+
+	// Unknown type: 0, no error
+	size, err = estimateFieldDataSize(dim, numRows, schemapb.DataType_Int64)
+	s.NoError(err)
+	s.Equal(uint64(0), size)
+}
+
+func (s *utilSuite) Test_getFieldDataSizeFromBinlogs() {
+	insertLogs := []*datapb.FieldBinlog{
+		{
+			FieldID: 100,
+			Binlogs: []*datapb.Binlog{
+				{MemorySize: 1024},
+				{MemorySize: 2048},
+			},
+		},
+		{
+			FieldID: 101,
+			Binlogs: []*datapb.Binlog{
+				{MemorySize: 4096},
+			},
+		},
+	}
+
+	// Match field 100
+	s.Equal(uint64(3072), getFieldDataSizeFromBinlogs(insertLogs, 100))
+
+	// Match field 101
+	s.Equal(uint64(4096), getFieldDataSizeFromBinlogs(insertLogs, 101))
+
+	// No match
+	s.Equal(uint64(0), getFieldDataSizeFromBinlogs(insertLogs, 999))
+
+	// Nil insert logs
+	s.Equal(uint64(0), getFieldDataSizeFromBinlogs(nil, 100))
 }
 
 func Test_utilSuite(t *testing.T) {


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/48743, https://github.com/milvus-io/milvus/issues/49014