### PR TITLE
test: [cp3.0]relax limit assertion for HNSW_SQ params48 (M=2,efConstruction=1) to fix flaky test

### DIFF
--- a/tests/python_client/testcases/indexes/idx_hnsw_sq.py
+++ b/tests/python_client/testcases/indexes/idx_hnsw_sq.py
@@ -267,7 +267,10 @@ class HNSW_SQ:
         {
             "description": "Minimum boundary combination",
             "params": {"M": 2, "efConstruction": 1, "sq_type": "SQ6"},
-            "expected": success
+            "expected": success,
+            # M=2 + efConstruction=1 produces a poorly connected graph; HNSW does not
+            # guarantee returning topK results under these extreme parameters.
+            "relaxed_limit": True
         },
         {
             "description": "Maximum boundary combination",

--- a/tests/python_client/testcases/indexes/test_hnsw_sq.py
+++ b/tests/python_client/testcases/indexes/test_hnsw_sq.py
@@ -63,14 +63,23 @@ class TestHnswSQBuildParams(TestMilvusClientV2Base):
             # search
             nq = 2
             search_vectors = cf.gen_vectors(nq, dim=dim, vector_data_type=DataType.FLOAT_VECTOR)
-            self.search(client, collection_name, search_vectors,
-                        search_params=default_search_params,
-                        limit=ct.default_limit,
-                        check_task=CheckTasks.check_search_results,
-                        check_items={"enable_milvus_client_api": True,
-                                     "nq": nq,
-                                     "limit": ct.default_limit,
-                                     "pk_name": pk_field_name})
+            if params.get("relaxed_limit"):
+                # Extreme params (e.g. M=2, efConstruction=1) produce a poorly connected
+                # HNSW graph that may return fewer than topK results — only assert > 0.
+                results = client.search(collection_name, search_vectors,
+                                        search_params=default_search_params,
+                                        limit=ct.default_limit)
+                for r in results:
+                    assert len(r) > 0, f"expected > 0 results but got {len(r)}"
+            else:
+                self.search(client, collection_name, search_vectors,
+                            search_params=default_search_params,
+                            limit=ct.default_limit,
+                            check_task=CheckTasks.check_search_results,
+                            check_items={"enable_milvus_client_api": True,
+                                         "nq": nq,
+                                         "limit": ct.default_limit,
+                                         "pk_name": pk_field_name})
 
             # verify the index params are persisted
             idx_info = client.describe_index(collection_name, vector_field_name)


### PR DESCRIPTION
Cherry-pick from master
pr: #48788

## Summary

Relax limit assertion for HNSW_SQ params48 (M=2, efConstruction=1) to fix flaky test.

With M=2 and efConstruction=1, the HNSW graph has extremely poor connectivity and may not traverse enough neighbors to fill topK=10 results. This is expected behavior for extreme boundary parameters.

issue: #48762

🤖 Generated with [Claude Code](https://claude.com/claude-code)