### PR TITLE
fix: [3.0] buffer cm.Reader in BM25 streamOneFile to reduce IO syscalls (#48845)

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -585,6 +585,7 @@ queryNode:
     size: 10 # the size for worker querynode client pool
   idfOracle:
     preload: true # Whether to parse and merge BM25 stats into current during load before first target. When false, stats are only written to disk and loaded on first SyncDistribution.
+    readBufferSize: 4194304 # Read buffer size in bytes for streaming BM25 stats from remote storage. Reduces per-read overhead through the storage SDK.
   ip:  # TCP/IP address of queryNode. If not specified, use the first unicastable address
   port: 21123 # TCP port of queryNode
   grpc:

--- a/internal/querynodev2/delegator/idf_oracle.go
+++ b/internal/querynodev2/delegator/idf_oracle.go
@@ -410,8 +410,9 @@ func streamOneFile(ctx context.Context, cm storage.ChunkManager, remotePath, loc
 	defer f.Close()
 
 	if parseInto != nil {
+		br := bufio.NewReaderSize(reader, paramtable.Get().QueryNodeCfg.IDFReadBufferSize.GetAsInt())
 		bw := bufio.NewWriter(f)
-		tee := io.TeeReader(reader, bw)
+		tee := io.TeeReader(br, bw)
 		err = parseInto.DeserializeFromReader(tee)
 		if err != nil {
 			return 0, err

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3479,7 +3479,8 @@ type queryNodeConfig struct {
 	EnabledGrowingSegmentJSONKeyStats ParamItem `refreshable:"false"`
 
 	// Idf Oracle
-	IDFPreload ParamItem `refreshable:"true"`
+	IDFPreload        ParamItem `refreshable:"true"`
+	IDFReadBufferSize ParamItem `refreshable:"true"`
 	// partial search
 	PartialResultRequiredDataRatio ParamItem `refreshable:"true"`
 }
@@ -3493,6 +3494,15 @@ func (p *queryNodeConfig) init(base *BaseTable) {
 		Doc:          "Whether to parse and merge BM25 stats into current during load before first target. When false, stats are only written to disk and loaded on first SyncDistribution.",
 	}
 	p.IDFPreload.Init(base.mgr)
+
+	p.IDFReadBufferSize = ParamItem{
+		Key:          "queryNode.idfOracle.readBufferSize",
+		Version:      "2.6.14",
+		Export:       true,
+		DefaultValue: "4194304",
+		Doc:          "Read buffer size in bytes for streaming BM25 stats from remote storage. Reduces per-read overhead through the storage SDK.",
+	}
+	p.IDFReadBufferSize.Init(base.mgr)
 
 	p.SoPath = ParamItem{
 		Key:          "queryNode.soPath",


### PR DESCRIPTION
## Summary
- Wraps `cm.Reader` (S3/MinIO HTTP body) with `bufio.NewReaderSize(reader, 4MB)` in `streamOneFile` before creating the TeeReader
- `DeserializeFromReader` calls `binary.Read` which reads 4/8 bytes at a time; without buffering, each small read goes through minio SDK's channel-based protocol, causing excessive overhead during preload parsing
- With 4MB buffer, minio Object.Read calls are reduced to ~1 per 4MB chunk

## Test plan
- [x] Existing `TestIDFOracle` tests pass
- [x] Verified via profiling that IO overhead drops significantly during BM25 preload

pr: #48845
issue: #46468

🤖 Generated with [Claude Code](https://claude.com/claude-code)