### PR TITLE
fix: [3.0] fix buildID handling for text/JSON indexes in snapshot restore

### DIFF
--- a/internal/datacoord/copy_segment_task.go
+++ b/internal/datacoord/copy_segment_task.go
@@ -547,10 +547,8 @@ func AssembleCopySegmentRequest(task CopySegmentTask, job CopySegmentJob) (*data
 		// Get source segment description from snapshot
 		sourceSegDesc, ok := sourceSegmentMap[sourceSegID]
 		if !ok {
-			log.Warn("source segment not found in snapshot",
-				zap.Int64("sourceSegmentID", sourceSegID),
-				zap.String("snapshotName", job.GetSnapshotName()))
-			continue
+			return nil, merr.WrapErrServiceInternal(
+				fmt.Sprintf("source segment %d not found in snapshot %s", sourceSegID, job.GetSnapshotName()))
 		}
 
 		// Build source with full binlog information
@@ -590,13 +588,17 @@ func AssembleCopySegmentRequest(task CopySegmentTask, job CopySegmentJob) (*data
 			}
 		}
 		for _, textIndex := range sourceSegDesc.GetTextIndexFiles() {
-			if err := allocNewBuildID(textIndex.GetBuildID()); err != nil {
-				return nil, err
+			if textIndex.GetBuildID() != 0 {
+				if err := allocNewBuildID(textIndex.GetBuildID()); err != nil {
+					return nil, err
+				}
 			}
 		}
-		for _, jsonStats := range sourceSegDesc.GetJsonKeyIndexFiles() {
-			if err := allocNewBuildID(jsonStats.GetBuildID()); err != nil {
-				return nil, err
+		for _, jsonKeyIndex := range sourceSegDesc.GetJsonKeyIndexFiles() {
+			if jsonKeyIndex.GetBuildID() != 0 {
+				if err := allocNewBuildID(jsonKeyIndex.GetBuildID()); err != nil {
+					return nil, err
+				}
 			}
 		}
 		// Build target with IDs and buildID mappings

--- a/internal/datacoord/copy_segment_task_test.go
+++ b/internal/datacoord/copy_segment_task_test.go
@@ -22,15 +22,19 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bytedance/mockey"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/metastore"
 	catalogmocks "github.com/milvus-io/milvus/internal/metastore/mocks"
 	"github.com/milvus-io/milvus/internal/metastore/model"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v2/taskcommon"
 	"github.com/milvus-io/milvus/pkg/v2/util/lock"
 	"github.com/milvus-io/milvus/pkg/v2/util/timerecord"
@@ -673,4 +677,145 @@ func (s *CopySegmentTaskSuite) TestSyncVectorScalarIndexes_AddSegmentIndexError(
 	syncErr := syncVectorScalarIndexes(context.Background(), result, task, m, copyMeta)
 	s.Error(syncErr)
 	s.Contains(syncErr.Error(), "catalog error")
+}
+
+func TestAssembleCopySegmentRequest_SourceSegmentNotFound(t *testing.T) {
+	// Arrange: snapshot data has segment 1, but task maps from segment 999 which doesn't exist
+	snapshotData := &SnapshotData{
+		SnapshotInfo: &datapb.SnapshotInfo{
+			Id:           1,
+			CollectionId: 100,
+			Name:         "test_snapshot",
+		},
+		Segments: []*datapb.SegmentDescription{
+			{SegmentId: 1, PartitionId: 10},
+		},
+	}
+
+	sm := &snapshotMeta{}
+	// Mock ReadSnapshotData to return our test data
+	mock1 := mockey.Mock((*snapshotMeta).ReadSnapshotData).Return(snapshotData, nil).Build()
+	defer mock1.UnPatch()
+
+	task := &copySegmentTask{
+		snapshotMeta: sm,
+		tr:           timerecord.NewTimeRecorder("test"),
+		times:        taskcommon.NewTimes(),
+	}
+	task.task.Store(&datapb.CopySegmentTask{
+		TaskId:       1001,
+		JobId:        100,
+		CollectionId: 100,
+		IdMappings: []*datapb.CopySegmentIDMapping{
+			{SourceSegmentId: 999, TargetSegmentId: 2001, PartitionId: 10}, // 999 not in snapshot
+		},
+	})
+
+	job := &copySegmentJob{
+		CopySegmentJob: &datapb.CopySegmentJob{
+			JobId:        100,
+			CollectionId: 100,
+			SnapshotName: "test_snapshot",
+		},
+		tr: timerecord.NewTimeRecorder("test_job"),
+	}
+
+	// Act
+	req, err := AssembleCopySegmentRequest(task, job)
+
+	// Assert
+	assert.Nil(t, req)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "source segment 999 not found")
+}
+
+func TestAssembleCopySegmentRequest_AllocatesTextAndJsonBuildIDs(t *testing.T) {
+	// Arrange: snapshot data with segment that has vector, text, and JSON key indexes
+	snapshotData := &SnapshotData{
+		SnapshotInfo: &datapb.SnapshotInfo{
+			Id:           1,
+			CollectionId: 100,
+			Name:         "test_snapshot",
+		},
+		Segments: []*datapb.SegmentDescription{
+			{
+				SegmentId:   1,
+				PartitionId: 10,
+				IndexFiles: []*indexpb.IndexFilePathInfo{
+					{BuildID: 3001, FieldID: 100, IndexID: 1001},
+				},
+				TextIndexFiles: map[int64]*datapb.TextIndexStats{
+					200: {FieldID: 200, BuildID: 4001},
+				},
+				JsonKeyIndexFiles: map[int64]*datapb.JsonKeyStats{
+					300: {FieldID: 300, BuildID: 5001},
+				},
+			},
+		},
+	}
+
+	sm := &snapshotMeta{}
+	mock1 := mockey.Mock((*snapshotMeta).ReadSnapshotData).Return(snapshotData, nil).Build()
+	defer mock1.UnPatch()
+
+	// Mock allocator to return sequential IDs starting from 9001
+	nextID := int64(9001)
+	alloc := &struct{ allocator.Allocator }{}
+	mock2 := mockey.Mock((*struct{ allocator.Allocator }).AllocID).To(func(ctx context.Context) (typeutil.UniqueID, error) {
+		id := nextID
+		nextID++
+		return id, nil
+	}).Build()
+	defer mock2.UnPatch()
+
+	// Mock Params access
+	mock3 := mockey.Mock(createStorageConfig).Return(nil).Build()
+	defer mock3.UnPatch()
+
+	task := &copySegmentTask{
+		snapshotMeta: sm,
+		alloc:        alloc,
+		tr:           timerecord.NewTimeRecorder("test"),
+		times:        taskcommon.NewTimes(),
+	}
+	task.task.Store(&datapb.CopySegmentTask{
+		TaskId:       1001,
+		JobId:        100,
+		CollectionId: 100,
+		IdMappings: []*datapb.CopySegmentIDMapping{
+			{SourceSegmentId: 1, TargetSegmentId: 2001, PartitionId: 10},
+		},
+	})
+
+	job := &copySegmentJob{
+		CopySegmentJob: &datapb.CopySegmentJob{
+			JobId:        100,
+			CollectionId: 100,
+			SnapshotName: "test_snapshot",
+		},
+		tr: timerecord.NewTimeRecorder("test_job"),
+	}
+
+	// Act
+	req, err := AssembleCopySegmentRequest(task, job)
+
+	// Assert
+	assert.NoError(t, err)
+	assert.NotNil(t, req)
+	assert.Len(t, req.Targets, 1)
+
+	newBuildIDs := req.Targets[0].GetNewBuildIds()
+	// Should have 3 entries: one for vector index (3001), one for text (4001), one for JSON (5001)
+	assert.Len(t, newBuildIDs, 3)
+	assert.Contains(t, newBuildIDs, int64(3001))
+	assert.Contains(t, newBuildIDs, int64(4001))
+	assert.Contains(t, newBuildIDs, int64(5001))
+
+	// All new IDs should be distinct and >= 9001
+	seenIDs := make(map[int64]bool)
+	for _, newID := range newBuildIDs {
+		assert.True(t, newID >= 9001, "new build ID should be allocated by allocator")
+		assert.False(t, seenIDs[newID], "new build IDs should be unique")
+		seenIDs[newID] = true
+	}
 }

--- a/internal/datacoord/snapshot_meta.go
+++ b/internal/datacoord/snapshot_meta.go
@@ -393,6 +393,16 @@ func (sm *snapshotMeta) SaveSnapshot(ctx context.Context, snapshot *SnapshotData
 		for _, indexFile := range segment.GetIndexFiles() {
 			buildIDs = append(buildIDs, indexFile.GetBuildID())
 		}
+		for _, textIndex := range segment.GetTextIndexFiles() {
+			if textIndex.GetBuildID() != 0 {
+				buildIDs = append(buildIDs, textIndex.GetBuildID())
+			}
+		}
+		for _, jsonKeyIndex := range segment.GetJsonKeyIndexFiles() {
+			if jsonKeyIndex.GetBuildID() != 0 {
+				buildIDs = append(buildIDs, jsonKeyIndex.GetBuildID())
+			}
+		}
 	}
 	snapshot.SegmentIDs = segmentIDs
 	snapshot.BuildIDs = buildIDs

--- a/internal/datacoord/snapshot_meta_test.go
+++ b/internal/datacoord/snapshot_meta_test.go
@@ -1976,3 +1976,130 @@ func TestSnapshotMeta_IsAllRefIndexLoaded(t *testing.T) {
 	sm.snapshotID2RefIndex.Insert(info2.GetId(), NewSnapshotRefIndex())
 	assert.False(t, sm.IsAllRefIndexLoaded())
 }
+
+func TestSnapshotMeta_SaveSnapshot_CollectsBuildIDs_AllIndexTypes(t *testing.T) {
+	// Arrange
+	ctx := context.Background()
+	sm := createTestSnapshotMetaLoaded(t)
+	metadataFilePath := "s3://bucket/snapshots/1/metadata/test-uuid.json"
+
+	snapshotData := &SnapshotData{
+		SnapshotInfo: createTestSnapshotInfoForMeta(),
+		Collection: &datapb.CollectionDescription{
+			Schema: &schemapb.CollectionSchema{Name: "test_collection"},
+		},
+		Segments: []*datapb.SegmentDescription{
+			{
+				SegmentId:   1001,
+				PartitionId: 1,
+				IndexFiles: []*indexpb.IndexFilePathInfo{
+					{BuildID: 3001},
+					{BuildID: 3002},
+				},
+				TextIndexFiles: map[int64]*datapb.TextIndexStats{
+					100: {FieldID: 100, BuildID: 4001},
+					101: {FieldID: 101, BuildID: 4002},
+				},
+				JsonKeyIndexFiles: map[int64]*datapb.JsonKeyStats{
+					200: {FieldID: 200, BuildID: 5001},
+				},
+			},
+		},
+	}
+
+	// Mock SnapshotWriter.Save
+	mock1 := mockey.Mock((*SnapshotWriter).Save).To(func(ctx context.Context, snapshot *SnapshotData) (string, error) {
+		return metadataFilePath, nil
+	}).Build()
+	defer mock1.UnPatch()
+
+	// Mock catalog.SaveSnapshot
+	mock2 := mockey.Mock((*kv_datacoord.Catalog).SaveSnapshot).To(func(ctx context.Context, snapshotInfo *datapb.SnapshotInfo) error {
+		return nil
+	}).Build()
+	defer mock2.UnPatch()
+
+	// Act
+	err := sm.SaveSnapshot(ctx, snapshotData)
+
+	// Assert
+	assert.NoError(t, err)
+	refIndex, exists := sm.snapshotID2RefIndex.Get(snapshotData.SnapshotInfo.GetId())
+	assert.True(t, exists)
+
+	// Vector/scalar index build IDs
+	assert.True(t, refIndex.ContainsBuildID(3001))
+	assert.True(t, refIndex.ContainsBuildID(3002))
+	// Text index build IDs
+	assert.True(t, refIndex.ContainsBuildID(4001))
+	assert.True(t, refIndex.ContainsBuildID(4002))
+	// JSON key index build IDs
+	assert.True(t, refIndex.ContainsBuildID(5001))
+	// Non-existent build IDs
+	assert.False(t, refIndex.ContainsBuildID(9999))
+}
+
+func TestSnapshotMeta_SaveSnapshot_SkipsZeroBuildIDs(t *testing.T) {
+	// Arrange
+	ctx := context.Background()
+	sm := createTestSnapshotMetaLoaded(t)
+	metadataFilePath := "s3://bucket/snapshots/1/metadata/test-uuid.json"
+
+	snapshotData := &SnapshotData{
+		SnapshotInfo: createTestSnapshotInfoForMeta(),
+		Collection: &datapb.CollectionDescription{
+			Schema: &schemapb.CollectionSchema{Name: "test_collection"},
+		},
+		Segments: []*datapb.SegmentDescription{
+			{
+				SegmentId:   1001,
+				PartitionId: 1,
+				IndexFiles: []*indexpb.IndexFilePathInfo{
+					{BuildID: 3001},
+				},
+				TextIndexFiles: map[int64]*datapb.TextIndexStats{
+					100: {FieldID: 100, BuildID: 0}, // zero build ID, should be skipped
+					101: {FieldID: 101, BuildID: 4001},
+				},
+				JsonKeyIndexFiles: map[int64]*datapb.JsonKeyStats{
+					200: {FieldID: 200, BuildID: 0}, // zero build ID, should be skipped
+					201: {FieldID: 201, BuildID: 5001},
+				},
+			},
+		},
+	}
+
+	// Mock SnapshotWriter.Save
+	mock1 := mockey.Mock((*SnapshotWriter).Save).To(func(ctx context.Context, snapshot *SnapshotData) (string, error) {
+		return metadataFilePath, nil
+	}).Build()
+	defer mock1.UnPatch()
+
+	// Mock catalog.SaveSnapshot
+	mock2 := mockey.Mock((*kv_datacoord.Catalog).SaveSnapshot).To(func(ctx context.Context, snapshotInfo *datapb.SnapshotInfo) error {
+		return nil
+	}).Build()
+	defer mock2.UnPatch()
+
+	// Act
+	err := sm.SaveSnapshot(ctx, snapshotData)
+
+	// Assert
+	assert.NoError(t, err)
+	refIndex, exists := sm.snapshotID2RefIndex.Get(snapshotData.SnapshotInfo.GetId())
+	assert.True(t, exists)
+
+	// Vector/scalar build IDs are always collected (no zero check)
+	assert.True(t, refIndex.ContainsBuildID(3001))
+	// Non-zero text/JSON build IDs should be collected
+	assert.True(t, refIndex.ContainsBuildID(4001))
+	assert.True(t, refIndex.ContainsBuildID(5001))
+	// Zero build IDs should NOT be in the refIndex
+	assert.False(t, refIndex.ContainsBuildID(0))
+
+	// Verify BuildIDs slice on SnapshotData: should have 3001, 4001, 5001 only (3 items)
+	assert.Len(t, snapshotData.BuildIDs, 3)
+	assert.Contains(t, snapshotData.BuildIDs, int64(3001))
+	assert.Contains(t, snapshotData.BuildIDs, int64(4001))
+	assert.Contains(t, snapshotData.BuildIDs, int64(5001))
+}

--- a/tests/go_client/testcases/snapshot_test.go
+++ b/tests/go_client/testcases/snapshot_test.go
@@ -23,6 +23,28 @@ import (
 
 var snapshotPrefix = "snapshot"
 
+// flushWithRetry retries Flush if it hits the collection-level rate limiter (default: 0.1 rps),
+// and awaits flush completion before returning.
+func flushWithRetry(ctx context.Context, mc *base.MilvusClient, collName string) error {
+	maxRetries := 5
+	for i := 0; i < maxRetries; i++ {
+		flushTask, err := mc.Flush(ctx, client.NewFlushOption(collName))
+		if err == nil {
+			return flushTask.Await(ctx)
+		}
+		if i < maxRetries-1 {
+			log.Info("flush rate limited, retrying",
+				zap.String("collection", collName),
+				zap.Int("attempt", i+1),
+				zap.Error(err))
+			time.Sleep(5 * time.Second)
+			continue
+		}
+		return err
+	}
+	return nil
+}
+
 // waitForRestoreComplete polls GetRestoreSnapshotState until the restore job completes or fails.
 // Returns the final RestoreSnapshotInfo and any error.
 func waitForRestoreComplete(ctx context.Context, mc *base.MilvusClient, jobID int64, timeout time.Duration) (*milvuspb.RestoreSnapshotInfo, error) {
@@ -55,6 +77,52 @@ func waitForRestoreComplete(ctx context.Context, mc *base.MilvusClient, jobID in
 	}
 
 	return nil, fmt.Errorf("timeout waiting for restore to complete: jobID=%d", jobID)
+}
+
+// waitForAllIndexesBuilt polls DescribeIndex for each index in the collection until all indexes
+// have finished building (PendingIndexRows == 0 and TotalRows == IndexedRows).
+// If the collection has no indexes, the function returns immediately.
+func waitForAllIndexesBuilt(ctx context.Context, mc *base.MilvusClient, collName string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	pollInterval := 2 * time.Second
+
+	// List indexes once — the set of indexes doesn't change during building.
+	indexes, err := mc.ListIndexes(ctx, client.NewListIndexOption(collName))
+	if err != nil {
+		return fmt.Errorf("failed to list indexes for collection %s: %w", collName, err)
+	}
+	if len(indexes) == 0 {
+		return nil
+	}
+
+	for time.Now().Before(deadline) {
+		allFinished := true
+		for _, idxName := range indexes {
+			descIdx, err := mc.DescribeIndex(ctx, client.NewDescribeIndexOption(collName, idxName))
+			if err != nil {
+				return fmt.Errorf("failed to describe index %s on collection %s: %w", idxName, collName, err)
+			}
+			if descIdx.PendingIndexRows != 0 || descIdx.TotalRows != descIdx.IndexedRows {
+				log.Info("index not yet finished",
+					zap.String("collection", collName),
+					zap.String("index", idxName),
+					zap.Int64("pendingRows", descIdx.PendingIndexRows),
+					zap.Int64("totalRows", descIdx.TotalRows),
+					zap.Int64("indexedRows", descIdx.IndexedRows))
+				allFinished = false
+				break
+			}
+		}
+		if allFinished {
+			log.Info("all indexes built", zap.String("collection", collName), zap.Int("numIndexes", len(indexes)))
+			// Allow extra time for segment state settling (compaction, delta merge)
+			// after indexes are built but before snapshot can see all segments.
+			time.Sleep(5 * time.Second)
+			return nil
+		}
+		time.Sleep(pollInterval)
+	}
+	return fmt.Errorf("timeout waiting for indexes to be built on collection %s", collName)
 }
 
 // TestCreateSnapshot tests creating a snapshot for a collection
@@ -140,12 +208,11 @@ func TestSnapshotRestoreWithMultiSegment(t *testing.T) {
 		require.Equal(t, insertBatchSize, insertRes.IDs.Len())
 	}
 	// Flush to ensure data is persisted
-	flushTask, err := mc.Flush(ctx, client.NewFlushOption(collName))
+	err = flushWithRetry(ctx, mc, collName)
 	common.CheckErr(t, err, true)
-	err = flushTask.Await(ctx)
+	// Wait for all indexes to be built after flush
+	err = waitForAllIndexesBuilt(ctx, mc, collName, 2*time.Minute)
 	common.CheckErr(t, err, true)
-	// wait for rate limiter reset before next flush (rate=0.1 means 1 flush per 10s)
-	time.Sleep(10 * time.Second)
 
 	// Verify initial data count
 	queryRes, err := mc.Query(ctx, client.NewQueryOption(collName).WithOutputFields(common.QueryCountFieldName).WithConsistencyLevel(entity.ClStrong))
@@ -162,9 +229,7 @@ func TestSnapshotRestoreWithMultiSegment(t *testing.T) {
 	}
 
 	// Flush to ensure deletion is persisted
-	flushTask2, err := mc.Flush(ctx, client.NewFlushOption(collName))
-	common.CheckErr(t, err, true)
-	err = flushTask2.Await(ctx)
+	err = flushWithRetry(ctx, mc, collName)
 	common.CheckErr(t, err, true)
 
 	// Verify data count after deletion
@@ -305,10 +370,12 @@ func TestSnapshotRestoreWithMultiShardMultiPartition(t *testing.T) {
 	}
 
 	// Flush to ensure deletion is persisted
-	_, err = mc.Flush(ctx, client.NewFlushOption(collName))
+	err = flushWithRetry(ctx, mc, collName)
 	common.CheckErr(t, err, true)
 
-	time.Sleep(10 * time.Second)
+	// Wait for all indexes to be built after flush
+	err = waitForAllIndexesBuilt(ctx, mc, collName, 2*time.Minute)
+	common.CheckErr(t, err, true)
 
 	// Verify data count after deletion
 	queryRes2, err := mc.Query(ctx, client.NewQueryOption(collName).WithOutputFields(common.QueryCountFieldName).WithConsistencyLevel(entity.ClStrong))
@@ -498,11 +565,12 @@ func TestSnapshotRestoreWithMultiFields(t *testing.T) {
 	}
 
 	// Flush to ensure data is persisted
-	_, err = mc.Flush(ctx, client.NewFlushOption(collName))
+	err = flushWithRetry(ctx, mc, collName)
 	common.CheckErr(t, err, true)
 
-	// Wait for flush to complete
-	time.Sleep(10 * time.Second)
+	// Wait for all indexes to be built after flush
+	err = waitForAllIndexesBuilt(ctx, mc, collName, 2*time.Minute)
+	common.CheckErr(t, err, true)
 
 	// Step 3: Delete some records (3,000 from each batch)
 	for i := 0; i < numOfBatch; i++ {
@@ -513,11 +581,12 @@ func TestSnapshotRestoreWithMultiFields(t *testing.T) {
 	}
 
 	// Flush to ensure deletion is persisted
-	_, err = mc.Flush(ctx, client.NewFlushOption(collName))
+	err = flushWithRetry(ctx, mc, collName)
 	common.CheckErr(t, err, true)
 
-	// Wait for flush to complete
-	time.Sleep(10 * time.Second)
+	// Wait for all indexes to be built after flush
+	err = waitForAllIndexesBuilt(ctx, mc, collName, 2*time.Minute)
+	common.CheckErr(t, err, true)
 
 	// Step 4: Create snapshot
 	snapshotName := fmt.Sprintf("multi_fields_snapshot_%s", common.GenRandomString(snapshotPrefix, 6))
@@ -956,9 +1025,12 @@ func TestSnapshotRestoreWithJSONStats(t *testing.T) {
 	}
 
 	// Flush to ensure data is persisted and JSON stats are generated
-	_, err = mc.Flush(ctx, client.NewFlushOption(collName))
+	err = flushWithRetry(ctx, mc, collName)
 	common.CheckErr(t, err, true)
-	time.Sleep(10 * time.Second)
+
+	// Wait for all indexes to be built after flush
+	err = waitForAllIndexesBuilt(ctx, mc, collName, 2*time.Minute)
+	common.CheckErr(t, err, true)
 
 	// Verify initial data count
 	queryRes, err := mc.Query(ctx,
@@ -979,9 +1051,12 @@ func TestSnapshotRestoreWithJSONStats(t *testing.T) {
 	}
 
 	// Flush to ensure deletion is persisted
-	_, err = mc.Flush(ctx, client.NewFlushOption(collName))
+	err = flushWithRetry(ctx, mc, collName)
 	common.CheckErr(t, err, true)
-	time.Sleep(30 * time.Second)
+
+	// Wait for all indexes to be built after flush
+	err = waitForAllIndexesBuilt(ctx, mc, collName, 2*time.Minute)
+	common.CheckErr(t, err, true)
 
 	// Verify count after deletion
 	queryRes2, err := mc.Query(ctx,
@@ -1108,9 +1183,12 @@ func TestSnapshotRestoreAfterDropPartitionAndCollection(t *testing.T) {
 	}
 
 	// Flush to ensure data is persisted
-	_, err = mc.Flush(ctx, client.NewFlushOption(collName))
+	err = flushWithRetry(ctx, mc, collName)
 	common.CheckErr(t, err, true)
-	time.Sleep(10 * time.Second)
+
+	// Wait for all indexes to be built after flush
+	err = waitForAllIndexesBuilt(ctx, mc, collName, 2*time.Minute)
+	common.CheckErr(t, err, true)
 
 	// Verify initial data count (3 partitions * 3000 = 9000)
 	queryRes, err := mc.Query(ctx, client.NewQueryOption(collName).WithOutputFields(common.QueryCountFieldName).WithConsistencyLevel(entity.ClStrong))
@@ -1315,9 +1393,12 @@ func TestSnapshotRestoreDropAndRestoreAgain(t *testing.T) {
 	_, insertRes := hp.CollPrepare.InsertData(ctx, t, mc, hp.NewInsertParams(coll.Schema), insertOpt)
 	require.Equal(t, insertBatchSize, insertRes.IDs.Len())
 
-	_, err = mc.Flush(ctx, client.NewFlushOption(collNameA))
+	err = flushWithRetry(ctx, mc, collNameA)
 	common.CheckErr(t, err, true)
-	time.Sleep(10 * time.Second)
+
+	// Wait for all indexes to be built after flush
+	err = waitForAllIndexesBuilt(ctx, mc, collNameA, 2*time.Minute)
+	common.CheckErr(t, err, true)
 
 	// Verify data count in A
 	queryRes, err := mc.Query(ctx, client.NewQueryOption(collNameA).WithOutputFields(common.QueryCountFieldName).WithConsistencyLevel(entity.ClStrong))
@@ -1528,9 +1609,12 @@ func TestSnapshotRestoreWithMultipleJSONPathIndexes(t *testing.T) {
 	_, err = mc.Insert(ctx, client.NewColumnBasedInsertOption(collName, idColumn, jsonColumn, vecColumn))
 	common.CheckErr(t, err, true)
 
-	_, err = mc.Flush(ctx, client.NewFlushOption(collName))
+	err = flushWithRetry(ctx, mc, collName)
 	common.CheckErr(t, err, true)
-	time.Sleep(10 * time.Second)
+
+	// Wait for all indexes to be built after flush
+	err = waitForAllIndexesBuilt(ctx, mc, collName, 2*time.Minute)
+	common.CheckErr(t, err, true)
 
 	// Step 4: Verify indexes exist on source
 	originalIndexes, err := mc.ListIndexes(ctx, client.NewListIndexOption(collName))


### PR DESCRIPTION
## Summary

Cherry-pick of [#48796](https://github.com/milvus-io/milvus/pull/48796) to the 3.0 branch.

- Skip `allocNewBuildID` when textIndex/jsonKeyIndex `buildID` is 0 (no real index exists)
- Collect textIndex/jsonKeyIndex buildIDs in `SaveSnapshot` to prevent GC from deleting referenced index files
- Return error instead of silently skipping when source segment is not found in snapshot
- Replace fragile `time.Sleep` in E2E snapshot tests with condition-based polling

issue: #48742
pr: #48796

## Test plan

- [x] Unit tests for `AssembleCopySegmentRequest` (source not found, buildID allocation)
- [x] Unit tests for `SaveSnapshot` (all index types, zero buildID skipping)
- [x] Unit tests for `buildIndexInfoFromSource` (buildID replacement, no-replacement path)
- [x] E2E snapshot tests with `flushWithRetry` and `waitForAllIndexesBuilt`
