### PR TITLE
enhance: reduce unnecessary copies in search/query path

### DIFF
--- a/internal/core/src/common/Json.h
+++ b/internal/core/src/common/Json.h
@@ -54,8 +54,8 @@ isDocEmpty(simdjson::ondemand::document document);
 // This is safe because JSON objects are unordered per RFC 8259, and downstream
 // consumers (Go protobuf → map) do not depend on key ordering.
 inline std::string
-ExtractSubJson(const std::string& json, const std::vector<std::string>& keys) {
-    simdjson::padded_string padded(json);
+ExtractSubJson(std::string_view json, const std::vector<std::string>& keys) {
+    simdjson::padded_string padded(json.data(), json.size());
     thread_local simdjson::ondemand::parser parser;
     auto doc = parser.iterate(padded);
     if (doc.error()) {

--- a/internal/core/src/common/QueryResult.h
+++ b/internal/core/src/common/QueryResult.h
@@ -344,14 +344,6 @@ struct SearchResult {
                (!element_level_ && vector_iterators_.has_value());
     }
 
-    std::optional<std::vector<std::shared_ptr<VectorIterator>>>
-    GetIterators() {
-        if (element_level_) {
-            return element_iterators_;
-        } else {
-            return vector_iterators_;
-        }
-    }
     // For two-stage search: count of rows that pass the filter in this segment
     // Set to -1 when not applicable (normal search mode)
     // Each segment's SearchResult has its own valid_count, preserved separately

--- a/internal/core/src/common/VectorTrait.h
+++ b/internal/core/src/common/VectorTrait.h
@@ -269,4 +269,9 @@ struct TagDispatchTrait<std::string> {
     using Tag = StringTag;
 };
 
+template <>
+struct TagDispatchTrait<std::string_view> {
+    using Tag = StringTag;
+};
+
 }  // namespace milvus

--- a/internal/core/src/exec/expression/ColumnExpr.cpp
+++ b/internal/core/src/exec/expression/ColumnExpr.cpp
@@ -128,7 +128,7 @@ PhyColumnExpr::DoEval(OffsetVector* input) {
                 valid_res[processed_rows] = false;
             } else {
                 res_value[processed_rows] =
-                    boost::get<T>(chunk_data_by_offset.value());
+                    segcore::get_from_variant<T>(chunk_data_by_offset);
             }
             processed_rows++;
         }
@@ -159,7 +159,7 @@ PhyColumnExpr::DoEval(OffsetVector* input) {
                 valid_res[i] = false;
                 continue;
             }
-            res_value[i] = boost::get<T>(data.value());
+            res_value[i] = segcore::get_from_variant<T>(data);
         }
         return res_vec;
     } else {
@@ -198,7 +198,9 @@ PhyColumnExpr::DoEval(OffsetVector* input) {
                 if (!cda(i).has_value()) {
                     valid_res[processed_rows] = false;
                 } else {
-                    res_value[processed_rows] = boost::get<T>(cda(i).value());
+                    auto tmp = cda(i);
+                    res_value[processed_rows] =
+                        segcore::get_from_variant<T>(tmp);
                 }
                 processed_rows++;
 

--- a/internal/core/src/exec/expression/ColumnExpr.cpp
+++ b/internal/core/src/exec/expression/ColumnExpr.cpp
@@ -195,12 +195,12 @@ PhyColumnExpr::DoEval(OffsetVector* input) {
             for (int i = chunk_id == current_chunk_id_ ? current_chunk_pos_ : 0;
                  i < chunk_size;
                  ++i) {
-                if (!cda(i).has_value()) {
+                auto val = cda(i);
+                if (!val.has_value()) {
                     valid_res[processed_rows] = false;
                 } else {
-                    auto tmp = cda(i);
                     res_value[processed_rows] =
-                        segcore::get_from_variant<T>(tmp);
+                        segcore::get_from_variant<T>(val);
                 }
                 processed_rows++;
 

--- a/internal/core/src/query/Utils.h
+++ b/internal/core/src/query/Utils.h
@@ -84,6 +84,37 @@ Match<std::string_view>(const std::string_view& str,
     }
 }
 
+// Overloads for string_view combinations used when CompareExpr operands
+// hold string_view in the data_access_type variant (chunk access), or a
+// mix of string (index access) and string_view (chunk access).
+inline bool
+Match(const std::string_view& str, const std::string_view& val, OpType op) {
+    switch (op) {
+        case OpType::PrefixMatch:
+            return PrefixMatch(str, val);
+        case OpType::PostfixMatch:
+            return PostfixMatch(str, val);
+        case OpType::InnerMatch:
+            return InnerMatch(str, val);
+        default:
+            ThrowInfo(OpTypeInvalid, "not supported");
+    }
+}
+
+inline bool
+Match(const std::string& str, const std::string_view& val, OpType op) {
+    switch (op) {
+        case OpType::PrefixMatch:
+            return PrefixMatch(str, val);
+        case OpType::PostfixMatch:
+            return PostfixMatch(str, val);
+        case OpType::InnerMatch:
+            return InnerMatch(str, val);
+        default:
+            ThrowInfo(OpTypeInvalid, "not supported");
+    }
+}
+
 template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
 inline bool
 gt_ub(int64_t t) {

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -2642,8 +2642,7 @@ ChunkedSegmentSealedImpl::bulk_subscript(
     column->BulkRawJsonAt(
         op_ctx,
         [&](Json json, size_t offset, bool is_valid) {
-            dst->at(offset) =
-                ExtractSubJson(std::string(json.data()), dynamic_field_names);
+            dst->at(offset) = ExtractSubJson(json.data(), dynamic_field_names);
         },
         seg_offsets,
         count);
@@ -3548,9 +3547,9 @@ ChunkedSegmentSealedImpl::LoadGeometryCache(
 
 void
 ChunkedSegmentSealedImpl::SetLoadInfo(
-    const proto::segcore::SegmentLoadInfo& load_info) {
+    proto::segcore::SegmentLoadInfo load_info) {
     std::unique_lock lck(mutex_);
-    segment_load_info_ = SegmentLoadInfo(load_info, schema_);
+    segment_load_info_ = SegmentLoadInfo(std::move(load_info), schema_);
     LOG_INFO(
         "SetLoadInfo for segment {}, num_rows: {}, index count: {}, "
         "storage_version: {}",

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -242,8 +242,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     LazyCheckSchema(SchemaPtr sch) override;
 
     void
-    SetLoadInfo(
-        const milvus::proto::segcore::SegmentLoadInfo& load_info) override;
+    SetLoadInfo(milvus::proto::segcore::SegmentLoadInfo load_info) override;
 
     void
     Load(milvus::tracer::TraceContext& trace_ctx,

--- a/internal/core/src/segcore/SegmentChunkReader.cpp
+++ b/internal/core/src/segcore/SegmentChunkReader.cpp
@@ -154,7 +154,8 @@ SegmentChunkReader::GetMultipleChunkDataAccessor<std::string>(
                 current_chunk_pos++;
                 return std::nullopt;
             }
-            return chunk_data[current_chunk_pos++];
+            return data_access_type(
+                std::string_view(chunk_data[current_chunk_pos++]));
         };
     } else {
         auto pw = segment_->chunk_view<std::string_view>(
@@ -180,7 +181,7 @@ SegmentChunkReader::GetMultipleChunkDataAccessor<std::string>(
                 current_chunk_pos++;
                 return std::nullopt;
             }
-            return std::string(chunk_data[current_chunk_pos++]);
+            return data_access_type(chunk_data[current_chunk_pos++]);
         };
     }
 }
@@ -294,18 +295,18 @@ SegmentChunkReader::GetChunkDataAccessor<std::string>(
             if (chunk_valid_data && !chunk_valid_data[i]) {
                 return std::nullopt;
             }
-            return chunk_data[i];
+            return data_access_type(std::string_view(chunk_data[i]));
         };
     } else {
         auto pw =
             segment_->chunk_view<std::string_view>(op_ctx_, field_id, chunk_id);
         return [pw = std::move(pw)](int i) mutable -> const data_access_type {
-            auto chunk_data = pw.get().first;
-            auto chunk_valid_data = pw.get().second;
+            auto& chunk_data = pw.get().first;
+            auto& chunk_valid_data = pw.get().second;
             if (i < chunk_valid_data.size() && !chunk_valid_data[i]) {
                 return std::nullopt;
             }
-            return std::string(chunk_data[i]);
+            return data_access_type(chunk_data[i]);
         };
     }
 }

--- a/internal/core/src/segcore/SegmentChunkReader.h
+++ b/internal/core/src/segcore/SegmentChunkReader.h
@@ -38,10 +38,53 @@ using data_access_type = std::optional<boost::variant<bool,
                                                       int64_t,
                                                       float,
                                                       double,
-                                                      std::string>>;
+                                                      std::string,
+                                                      std::string_view>>;
 
 using ChunkDataAccessor = std::function<const data_access_type(int)>;
 using MultipleChunkDataAccessor = std::function<const data_access_type()>;
+
+// Helper to extract a value of type T from data_access_type.
+// For std::string, handles both std::string and std::string_view in the variant.
+// Uses boost::apply_visitor to avoid ADL conflicts between boost::variant::get
+// and boost::array::get.
+namespace detail {
+template <typename T>
+struct ValueExtractor : public boost::static_visitor<T> {
+    T
+    operator()(const T& val) const {
+        return val;
+    }
+    template <typename U>
+    T
+    operator()(const U&) const {
+        ThrowInfo(DataTypeInvalid, "unexpected type in data_access_type");
+    }
+};
+
+template <>
+struct ValueExtractor<std::string> : public boost::static_visitor<std::string> {
+    std::string
+    operator()(const std::string& s) const {
+        return s;
+    }
+    std::string
+    operator()(std::string_view sv) const {
+        return std::string(sv);
+    }
+    template <typename U>
+    std::string
+    operator()(const U&) const {
+        ThrowInfo(DataTypeInvalid, "unexpected type in data_access_type");
+    }
+};
+}  // namespace detail
+
+template <typename T>
+T
+get_from_variant(const data_access_type& opt) {
+    return boost::apply_visitor(detail::ValueExtractor<T>{}, opt.value());
+}
 
 class SegmentChunkReader {
  public:

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -641,8 +641,9 @@ SegmentGrowingImpl::Insert(int64_t reserved_offset,
     auto field_id = schema_->get_primary_field_id().value_or(FieldId(-1));
     AssertInfo(field_id.get() != INVALID_FIELD_ID, "Primary key is -1");
     std::vector<PkType> pks(num_rows);
-    ParsePksFromFieldData(
-        pks, insert_record_proto->fields_data(field_id_to_offset[field_id]));
+    ParsePksFromFieldData(pks,
+                          *insert_record_proto->mutable_fields_data(
+                              field_id_to_offset[field_id]));
     for (int i = 0; i < num_rows; ++i) {
         insert_record_.insert_pk(pks[i], reserved_offset + i);
     }
@@ -1168,7 +1169,7 @@ SegmentGrowingImpl::bulk_subscript(
     for (int64_t i = 0; i < count; ++i) {
         auto offset = seg_offsets[i];
         dst->at(i) =
-            ExtractSubJson(std::string(src[offset]), dynamic_field_names);
+            ExtractSubJson(std::string_view(src[offset]), dynamic_field_names);
     }
     return result;
 }

--- a/internal/core/src/segcore/SegmentInterface.cpp
+++ b/internal/core/src/segcore/SegmentInterface.cpp
@@ -71,7 +71,7 @@ SegmentInternalInterface::FillPrimaryKeys(const query::Plan* plan,
         bulk_subscript(&op_ctx, pk_field_id, results.seg_offsets_.data(), size);
     results.pk_type_ = DataType(field_data->type());
 
-    ParsePksFromFieldData(results.primary_keys_, *field_data.get());
+    ParsePksFromFieldData(results.primary_keys_, *field_data);
     results.search_storage_cost_.scanned_remote_bytes +=
         op_ctx.storage_usage.scanned_cold_bytes.load();
     results.search_storage_cost_.scanned_total_bytes +=

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -257,7 +257,7 @@ class SegmentInterface {
            const milvus::proto::segcore::SegmentLoadInfo& new_load_info) = 0;
 
     virtual void
-    SetLoadInfo(const milvus::proto::segcore::SegmentLoadInfo& load_info) = 0;
+    SetLoadInfo(milvus::proto::segcore::SegmentLoadInfo load_info) = 0;
 
     virtual void
     Load(milvus::tracer::TraceContext& trace_ctx,
@@ -467,9 +467,8 @@ class SegmentInternalInterface : public SegmentInterface {
                          const std::string& nested_path) const override;
 
     void
-    SetLoadInfo(
-        const milvus::proto::segcore::SegmentLoadInfo& load_info) override {
-        load_info_ = load_info;
+    SetLoadInfo(milvus::proto::segcore::SegmentLoadInfo load_info) override {
+        load_info_ = std::move(load_info);
     }
 
     virtual std::shared_ptr<index::JsonKeyStats>

--- a/internal/core/src/segcore/Utils.cpp
+++ b/internal/core/src/segcore/Utils.cpp
@@ -66,7 +66,10 @@
 namespace milvus::segcore {
 
 void
-ParsePksFromFieldData(std::vector<PkType>& pks, const DataArray& data) {
+// Takes a non-const DataArray& because VARCHAR strings are moved (not copied)
+// into the PkType variant vector. Callers must ensure the DataArray is
+// discarded after this call — the VARCHAR fields will be in a moved-from state.
+ParsePksFromFieldData(std::vector<PkType>& pks, DataArray& data) {
     auto data_type = static_cast<DataType>(data.type());
     switch (data_type) {
         case DataType::INT64: {
@@ -76,8 +79,11 @@ ParsePksFromFieldData(std::vector<PkType>& pks, const DataArray& data) {
             break;
         }
         case DataType::VARCHAR: {
-            auto& src_data = data.scalars().string_data().data();
-            std::copy(src_data.begin(), src_data.end(), pks.begin());
+            auto* src_data =
+                data.mutable_scalars()->mutable_string_data()->mutable_data();
+            for (size_t i = 0; i < pks.size(); i++) {
+                pks[i] = std::move(*src_data->Mutable(i));
+            }
             break;
         }
         default: {
@@ -789,6 +795,15 @@ CreateDataArrayFrom(const void* data_raw,
 }
 
 // TODO remove merge dataArray, instead fill target entity when get data slice
+//
+// IMPORTANT: This function uses std::move to transfer string/bytes data from
+// the per-segment output_fields_data_ (accessed via MergeBase) into the merged
+// DataArray. This is safe because each per-segment DataArray is discarded after
+// MergeDataArray completes — the caller (GetSearchResultDataSlice) never reads
+// the per-segment output_fields_data_ again after this point. Each offset
+// within a segment is referenced at most once in merge_bases (guaranteed by the
+// deduplication in ReduceSearchResultForOneNQ), so no element is moved twice.
+// If this invariant changes, the std::move calls below must be revisited.
 std::unique_ptr<DataArray>
 MergeDataArray(std::vector<MergeBase>& merge_bases,
                const FieldMeta& field_meta) {
@@ -852,14 +867,16 @@ MergeDataArray(std::vector<MergeBase>& merge_bases,
                 obj->assign(data + physical_offset * num_bytes, num_bytes);
             } else if (field_meta.get_data_type() ==
                        DataType::VECTOR_SPARSE_U32_F32) {
-                auto& src_vec = src_field_data->vectors().sparse_float_vector();
+                auto* mutable_src_vec = src_field_data->mutable_vectors()
+                                            ->mutable_sparse_float_vector();
                 auto dst = vector_array->mutable_sparse_float_vector();
-                if (src_vec.dim() > dst->dim()) {
-                    dst->set_dim(src_vec.dim());
+                if (mutable_src_vec->dim() > dst->dim()) {
+                    dst->set_dim(mutable_src_vec->dim());
                 }
                 vector_array->set_dim(dst->dim());
-                auto& src_contents = src_vec.contents(physical_offset);
-                *(dst->mutable_contents()->Add()) = src_contents;
+                *(dst->mutable_contents()->Add()) =
+                    std::move(*mutable_src_vec->mutable_contents()->Mutable(
+                        physical_offset));
             } else if (field_meta.get_data_type() == DataType::VECTOR_INT8) {
                 auto data = VEC_FIELD_DATA(src_field_data, int8);
                 auto obj = vector_array->mutable_int8_vector();
@@ -927,30 +944,41 @@ MergeDataArray(std::vector<MergeBase>& merge_bases,
             }
             case DataType::VARCHAR:
             case DataType::TEXT: {
-                auto& data = FIELD_DATA(src_field_data, string);
+                auto* mutable_src = src_field_data->mutable_scalars()
+                                        ->mutable_string_data()
+                                        ->mutable_data();
                 auto obj = scalar_array->mutable_string_data();
-                *(obj->mutable_data()->Add()) = data[src_offset];
+                *(obj->mutable_data()->Add()) =
+                    std::move(*mutable_src->Mutable(src_offset));
                 break;
             }
             case DataType::JSON: {
-                auto& data = FIELD_DATA(src_field_data, json);
+                auto* mutable_src = src_field_data->mutable_scalars()
+                                        ->mutable_json_data()
+                                        ->mutable_data();
                 auto obj = scalar_array->mutable_json_data();
-                *(obj->mutable_data()->Add()) = data[src_offset];
+                *(obj->mutable_data()->Add()) =
+                    std::move(*mutable_src->Mutable(src_offset));
                 break;
             }
             case DataType::GEOMETRY: {
-                auto& data = FIELD_DATA(src_field_data, geometry);
+                auto* mutable_src = src_field_data->mutable_scalars()
+                                        ->mutable_geometry_data()
+                                        ->mutable_data();
                 auto obj = scalar_array->mutable_geometry_data();
-                *(obj->mutable_data()->Add()) = std::string(
-                    data[src_offset].data(), data[src_offset].size());
+                *(obj->mutable_data()->Add()) =
+                    std::move(*mutable_src->Mutable(src_offset));
                 break;
             }
             case DataType::ARRAY: {
-                auto& data = FIELD_DATA(src_field_data, array);
                 auto obj = scalar_array->mutable_array_data();
                 obj->set_element_type(
                     proto::schema::DataType(field_meta.get_element_type()));
-                *(obj->mutable_data()->Add()) = data[src_offset];
+                auto* mutable_src = src_field_data->mutable_scalars()
+                                        ->mutable_array_data()
+                                        ->mutable_data();
+                *(obj->mutable_data()->Add()) =
+                    std::move(*mutable_src->Mutable(src_offset));
                 break;
             }
             default: {

--- a/internal/core/src/segcore/Utils.h
+++ b/internal/core/src/segcore/Utils.h
@@ -29,7 +29,7 @@
 namespace milvus::segcore {
 
 void
-ParsePksFromFieldData(std::vector<PkType>& pks, const DataArray& data);
+ParsePksFromFieldData(std::vector<PkType>& pks, DataArray& data);
 
 void
 ParsePksFromFieldData(DataType data_type,

--- a/internal/core/src/segcore/pkVisitor.h
+++ b/internal/core/src/segcore/pkVisitor.h
@@ -34,15 +34,15 @@ Int64PKVisitor::operator()<int64_t>(int64_t t) const {
 
 struct StrPKVisitor {
     template <typename T>
-    std::string
-    operator()(T t) const {
+    const std::string&
+    operator()(const T& t) const {
         ThrowInfo(Unsupported, "invalid string pk value");
     }
 };
 
 template <>
-inline std::string
-StrPKVisitor::operator()<std::string>(std::string t) const {
+inline const std::string&
+StrPKVisitor::operator()<std::string>(const std::string& t) const {
     return t;
 }
 

--- a/internal/core/src/segcore/reduce/GroupReduce.cpp
+++ b/internal/core/src/segcore/reduce/GroupReduce.cpp
@@ -85,11 +85,12 @@ GroupReduceHelper::RefreshSingleSearchResult(SearchResult* search_result,
     uint32_t index = 0;
     for (int j = 0; j < total_nq_; j++) {
         for (auto offset : final_search_records_[seg_res_idx][j]) {
-            primary_keys[index] = search_result->primary_keys_[offset];
+            primary_keys[index] =
+                std::move(search_result->primary_keys_[offset]);
             distances[index] = search_result->distances_[offset];
             seg_offsets[index] = search_result->seg_offsets_[offset];
             group_by_values[index] =
-                search_result->group_by_values_.value()[offset];
+                std::move(search_result->group_by_values_.value()[offset]);
             if (search_result->element_level_) {
                 element_indices[index] =
                     search_result->element_indices_[offset];

--- a/internal/core/src/segcore/reduce/Reduce.cpp
+++ b/internal/core/src/segcore/reduce/Reduce.cpp
@@ -61,10 +61,11 @@ ReduceHelper::Initialize() {
     std::partial_sum(slice_nqs_.begin(),
                      slice_nqs_.end(),
                      slice_nqs_prefix_sum_.begin() + 1);
-    AssertInfo(slice_nqs_prefix_sum_[num_slices_] == total_nq_,
-               "illegal req sizes, slice_nqs_prefix_sum_[last] = " +
-                   std::to_string(slice_nqs_prefix_sum_[num_slices_]) +
-                   ", total_nq = " + std::to_string(total_nq_));
+    AssertInfo(
+        slice_nqs_prefix_sum_[num_slices_] == total_nq_,
+        "illegal req sizes, slice_nqs_prefix_sum_[last] = {}, total_nq = {}",
+        slice_nqs_prefix_sum_[num_slices_],
+        total_nq_);
 
     // init final_search_records and final_read_topKs
     final_search_records_.resize(num_segments_);
@@ -104,13 +105,13 @@ ReduceHelper::FilterInvalidSearchResult(SearchResult* search_result) {
     auto nq = search_result->total_nq_;
     auto topK = search_result->unity_topK_;
     AssertInfo(search_result->seg_offsets_.size() == nq * topK,
-               "wrong seg offsets size, size = " +
-                   std::to_string(search_result->seg_offsets_.size()) +
-                   ", expected size = " + std::to_string(nq * topK));
+               "wrong seg offsets size, size = {}, expected size = {}",
+               search_result->seg_offsets_.size(),
+               nq * topK);
     AssertInfo(search_result->distances_.size() == nq * topK,
-               "wrong distances size, size = " +
-                   std::to_string(search_result->distances_.size()) +
-                   ", expected size = " + std::to_string(nq * topK));
+               "wrong distances size, size = {}, expected size = {}",
+               search_result->distances_.size(),
+               nq * topK);
     std::vector<int64_t> real_topks(nq, 0);
     uint32_t valid_index = 0;
     auto segment = static_cast<SegmentInterface*>(search_result->segment_);
@@ -196,6 +197,7 @@ ReduceHelper::SortEqualScoresOneNQ(size_t nq_begin,
     if (nq_end - nq_begin <= 1)
         return;
 
+    std::vector<size_t> indices;
     size_t start = nq_begin;
     while (start < nq_end) {
         // find scope with same scores
@@ -207,8 +209,8 @@ ReduceHelper::SortEqualScoresOneNQ(size_t nq_begin,
         }
 
         if (end - start > 1) {
-            // Create lightweight index array for sorting
-            std::vector<size_t> indices(end - start);
+            // Reuse indices vector to avoid repeated heap allocation
+            indices.resize(end - start);
             std::iota(indices.begin(), indices.end(), 0);
 
             // Sort indices by comparing primary keys
@@ -494,9 +496,10 @@ ReduceHelper::GetSearchResultDataSlice(const int slice_index,
         }
         case milvus::DataType::VARCHAR: {
             auto ids = std::make_unique<milvus::proto::schema::StringArray>();
-            std::vector<std::string> string_pks(result_count);
-            // TODO: prevent mem copy
-            *ids->mutable_data() = {string_pks.begin(), string_pks.end()};
+            ids->mutable_data()->Reserve(result_count);
+            for (int i = 0; i < result_count; i++) {
+                ids->mutable_data()->Add();
+            }
             search_result_data->mutable_ids()->set_allocated_str_id(
                 ids.release());
             break;
@@ -536,9 +539,10 @@ ReduceHelper::GetSearchResultDataSlice(const int slice_index,
             for (auto ki = topk_start; ki < topk_end; ki++) {
                 auto loc = search_result->result_offsets_[ki];
                 AssertInfo(loc < result_count && loc >= 0,
-                           "invalid loc when GetSearchResultDataSlice, loc = " +
-                               std::to_string(loc) + ", result_count = " +
-                               std::to_string(result_count));
+                           "invalid loc when GetSearchResultDataSlice, loc = "
+                           "{}, result_count = {}",
+                           loc,
+                           result_count);
                 // set result pks
                 switch (pk_type) {
                     case milvus::DataType::INT64: {
@@ -605,9 +609,9 @@ ReduceHelper::GetSearchResultDataSlice(const int slice_index,
     }
 
     AssertInfo(search_result_data->scores_size() == result_count,
-               "wrong scores size, size = " +
-                   std::to_string(search_result_data->scores_size()) +
-                   ", expected size = " + std::to_string(result_count));
+               "wrong scores size, size = {}, expected size = {}",
+               search_result_data->scores_size(),
+               result_count);
     // fill other wanted data
     FillOtherData(result_count, nq_begin, nq_end, search_result_data);
 

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -155,7 +155,7 @@ NewSegmentWithLoadInfo(CCollection collection,
 
         auto segment =
             CreateSegment(col, seg_type, segment_id, is_sorted_by_pk);
-        segment->SetLoadInfo(load_info);
+        segment->SetLoadInfo(std::move(load_info));
         *newSegment = segment.release();
         return milvus::SuccessCStatus();
     } catch (std::exception& e) {


### PR DESCRIPTION
Eliminate redundant string copies and memory allocations across the search/query execution pipeline from Go through CGO to C++ segcore:

- Add std::string_view to data_access_type variant, avoiding per-element std::string construction in expression evaluation hot paths
- Use std::move in MergeDataArray for VARCHAR/JSON/ARRAY/Sparse types
- Fix StrPKVisitor to take const ref instead of by-value parameter
- Replace intermediate vector<string> with direct protobuf Reserve
- Use std::move in GroupReduceHelper::RefreshSingleSearchResult
- Change ExtractSubJson to accept string_view parameter
- Support move semantics in SetLoadInfo across segment interface
- Convert AssertInfo string concatenation to fmt::format parameters
- Hoist indices vector outside loop in SortEqualScoresOneNQ
- Move strings in ParsePksFromFieldData instead of copying
- Fix auto -> auto& in SegmentChunkReader lambda
- Remove unused GetIterators() dead code

issue: https://github.com/milvus-io/milvus/issues/44452