### PR TITLE
feat: add REST handler for AlterCollectionSchema API

### DIFF
--- a/internal/distributed/proxy/httpserver/constant.go
+++ b/internal/distributed/proxy/httpserver/constant.go
@@ -84,7 +84,8 @@ const (
 	RemovePrivilegesFromGroupAction = "remove_privileges_from_group"
 	TransferReplicaAction           = "transfer_replica"
 
-	RunAnalyzerAction = "run_analyzer"
+	RunAnalyzerAction    = "run_analyzer"
+	AlterSchemaAction    = "alter_schema"
 )
 
 const (

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -93,6 +93,7 @@ var routeToMethod = map[string]string{
 
 	"/v2/vectordb/collections/fields/alter_properties": "AlterCollectionField",
 	"/v2/vectordb/collections/fields/add":              "AddCollectionField",
+	"/v2/vectordb/collections/alter_schema":             "AlterCollectionSchema",
 
 	"/v2/vectordb/databases/create":           "CreateDatabase",
 	"/v2/vectordb/databases/drop":             "DropDatabase",
@@ -200,6 +201,9 @@ func (h *HandlersV2) RegisterRoutesToV2(router gin.IRouter) {
 
 	// /collections/fields/add
 	router.POST(CollectionFieldCategory+AddAction, timeoutMiddleware(wrapperPost(func() any { return &CollectionFieldReqWithSchema{} }, wrapperTraceLog(h.addCollectionField))))
+
+	// /collections/alter_schema
+	router.POST(CollectionCategory+AlterSchemaAction, timeoutMiddleware(wrapperPost(func() any { return &AlterCollectionSchemaReq{} }, wrapperTraceLog(h.alterCollectionSchema))))
 
 	router.POST(DataBaseCategory+CreateAction, timeoutMiddleware(wrapperPost(func() any { return &DatabaseReqWithProperties{} }, wrapperTraceLog(h.createDatabase))))
 	router.POST(DataBaseCategory+DropAction, timeoutMiddleware(wrapperPost(func() any { return &DatabaseReqRequiredName{} }, wrapperTraceLog(h.dropDatabase))))
@@ -1048,6 +1052,47 @@ func (h *HandlersV2) addCollectionField(ctx context.Context, c *gin.Context, any
 		return h.proxy.AddCollectionField(reqCtx, req.(*milvuspb.AddCollectionFieldRequest))
 	})
 
+	if err == nil {
+		HTTPReturn(c, http.StatusOK, wrapperReturnDefault())
+	}
+	return resp, err
+}
+
+func (h *HandlersV2) alterCollectionSchema(ctx context.Context, c *gin.Context, anyReq any, dbName string) (interface{}, error) {
+	httpReq := anyReq.(*AlterCollectionSchemaReq)
+
+	fieldProto, err := httpReq.FieldSchema.GetProto(ctx)
+	if err != nil {
+		HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+		return nil, err
+	}
+
+	funcProto, err := genFunctionSchema(ctx, &httpReq.Function)
+	if err != nil {
+		HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(merr.ErrParameterInvalid), HTTPReturnMessage: err.Error()})
+		return nil, err
+	}
+
+	req := &milvuspb.AlterCollectionSchemaRequest{
+		DbName:         dbName,
+		CollectionName: httpReq.CollectionName,
+		Action: &milvuspb.AlterCollectionSchemaRequest_Action{
+			Op: &milvuspb.AlterCollectionSchemaRequest_Action_AddRequest{
+				AddRequest: &milvuspb.AlterCollectionSchemaRequest_AddRequest{
+					FieldInfos: []*milvuspb.AlterCollectionSchemaRequest_FieldInfo{
+						{FieldSchema: fieldProto},
+					},
+					FuncSchema:         []*schemapb.FunctionSchema{funcProto},
+					DoPhysicalBackfill: httpReq.DoPhysicalBackfill,
+				},
+			},
+		},
+	}
+
+	c.Set(ContextRequest, req)
+	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AlterCollectionSchema", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+		return h.proxy.AlterCollectionSchema(reqCtx, req.(*milvuspb.AlterCollectionSchemaRequest))
+	})
 	if err == nil {
 		HTTPReturn(c, http.StatusOK, wrapperReturnDefault())
 	}

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -2954,6 +2954,121 @@ func TestAddCollectionFieldSuite(t *testing.T) {
 	suite.Run(t, new(AddCollectionFieldSuite))
 }
 
+type AlterCollectionSchemaSuite struct {
+	suite.Suite
+	testEngine *gin.Engine
+	mp         *mocks.MockProxy
+}
+
+func (s *AlterCollectionSchemaSuite) SetupSuite() {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+}
+
+func (s *AlterCollectionSchemaSuite) TearDownSuite() {
+	defer paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key)
+}
+
+func (s *AlterCollectionSchemaSuite) SetupTest() {
+	s.mp = mocks.NewMockProxy(s.T())
+	s.testEngine = initHTTPServerV2(s.mp, false)
+}
+
+func (s *AlterCollectionSchemaSuite) TestAlterCollectionSchemaNormal() {
+	testCases := []requestBodyTestCase{
+		{
+			path: versionalV2(CollectionCategory, AlterSchemaAction),
+			requestBody: []byte(`{
+				"collectionName": "book",
+				"fieldSchema": {"fieldName": "sparse_bm25", "dataType": "SparseFloatVector"},
+				"function": {"name": "bm25_func", "type": "BM25", "inputFieldNames": ["text"], "outputFieldNames": ["sparse_bm25"]}
+			}`),
+		},
+		{
+			path: versionalV2(CollectionCategory, AlterSchemaAction),
+			requestBody: []byte(`{
+				"collectionName": "book",
+				"fieldSchema": {"fieldName": "sparse_bm25", "dataType": "SparseFloatVector"},
+				"function": {"name": "bm25_func", "type": "BM25", "inputFieldNames": ["text"], "outputFieldNames": ["sparse_bm25"]},
+				"doPhysicalBackfill": true
+			}`),
+		},
+	}
+	s.mp.EXPECT().AlterCollectionSchema(mock.Anything, mock.Anything).Return(&milvuspb.AlterCollectionSchemaResponse{
+		AlterStatus: merr.Success(),
+	}, nil)
+	validateRequestBodyTestCases(s.T(), s.testEngine, testCases, false)
+}
+
+func (s *AlterCollectionSchemaSuite) TestAlterCollectionSchemaFail() {
+	s.Run("bad_request", func() {
+		testCases := []requestBodyTestCase{
+			{
+				path:        versionalV2(CollectionCategory, AlterSchemaAction),
+				requestBody: []byte(`{"collectionName": "book"}`),
+				errCode:     1802,
+				errMsg:      "missing required parameters",
+			},
+			{
+				path:        versionalV2(CollectionCategory, AlterSchemaAction),
+				requestBody: []byte(`{"collectionName": "book", "fieldSchema": {"fieldName": "f", "dataType": "SparseFloatVector"}}`),
+				errCode:     1802,
+				errMsg:      "missing required parameters",
+			},
+			{
+				path:        versionalV2(CollectionCategory, AlterSchemaAction),
+				requestBody: []byte(`{"collectionName": "book"`),
+				errCode:     1801,
+				errMsg:      "can only accept json format request",
+			},
+			{
+				path: versionalV2(CollectionCategory, AlterSchemaAction),
+				requestBody: []byte(`{
+					"collectionName": "book",
+					"fieldSchema": {"fieldName": "f", "dataType": "INVALIDTYPE"},
+					"function": {"name": "fn", "type": "BM25", "inputFieldNames": ["text"], "outputFieldNames": ["f"]}
+				}`),
+				errCode: 1100,
+				errMsg:  "data type INVALIDTYPE is invalid",
+			},
+			{
+				path: versionalV2(CollectionCategory, AlterSchemaAction),
+				requestBody: []byte(`{
+					"collectionName": "book",
+					"fieldSchema": {"fieldName": "f", "dataType": "SparseFloatVector"},
+					"function": {"name": "fn", "type": "INVALIDFUNC", "inputFieldNames": ["text"], "outputFieldNames": ["f"]}
+				}`),
+				errCode: 1100,
+				errMsg:  "Unsupported function type",
+			},
+		}
+		validateRequestBodyTestCases(s.T(), s.testEngine, testCases, false)
+	})
+
+	s.Run("server_error", func() {
+		testCases := []requestBodyTestCase{
+			{
+				path: versionalV2(CollectionCategory, AlterSchemaAction),
+				requestBody: []byte(`{
+					"collectionName": "book",
+					"fieldSchema": {"fieldName": "sparse_bm25", "dataType": "SparseFloatVector"},
+					"function": {"name": "bm25_func", "type": "BM25", "inputFieldNames": ["text"], "outputFieldNames": ["sparse_bm25"]}
+				}`),
+				errCode: 5,
+				errMsg:  "service internal error: mock error",
+			},
+		}
+		s.mp.EXPECT().AlterCollectionSchema(mock.Anything, mock.Anything).Return(&milvuspb.AlterCollectionSchemaResponse{
+			AlterStatus: merr.Status(merr.WrapErrServiceInternal("mock error")),
+		}, nil).Maybe()
+		validateRequestBodyTestCases(s.T(), s.testEngine, testCases, false)
+	})
+}
+
+func TestAlterCollectionSchemaSuite(t *testing.T) {
+	suite.Run(t, new(AlterCollectionSchemaSuite))
+}
+
 func TestCollectionFunctionSuite(t *testing.T) {
 	suite.Run(t, new(CollectionFunctionSuite))
 }

--- a/internal/distributed/proxy/httpserver/request_v2.go
+++ b/internal/distributed/proxy/httpserver/request_v2.go
@@ -240,6 +240,19 @@ func (req *CollectionFieldReqWithSchema) GetFieldName() string {
 	return req.Schema.FieldName
 }
 
+// AlterCollectionSchemaReq represents a request to alter collection schema
+// by adding a function field (e.g., BM25 sparse vector) with its output field.
+type AlterCollectionSchemaReq struct {
+	DbName             string         `json:"dbName"`
+	CollectionName     string         `json:"collectionName" binding:"required"`
+	FieldSchema        FieldSchema    `json:"fieldSchema" binding:"required"`
+	Function           FunctionSchema `json:"function" binding:"required"`
+	DoPhysicalBackfill bool           `json:"doPhysicalBackfill,omitempty"`
+}
+
+func (req *AlterCollectionSchemaReq) GetDbName() string         { return req.DbName }
+func (req *AlterCollectionSchemaReq) GetCollectionName() string { return req.CollectionName }
+
 type PartitionReq struct {
 	// CollectionNameReq
 	DbName         string `json:"dbName"`


### PR DESCRIPTION
## Summary
- Register `/v2/vectordb/collections/alter_schema` REST endpoint for the `AlterCollectionSchema` gRPC API
- Add `AlterCollectionSchemaReq` request struct with `fieldSchema`, `function`, and `doPhysicalBackfill` fields
- Add `alterCollectionSchema` handler following the same pattern as `addCollectionField` and `addCollectionFunction`
- Add route-to-method mapping entry for metrics/auth integration

## Motivation
PR #48810 introduced the `AlterCollectionSchema` gRPC API but did not register a REST handler for it. HTTP clients (e.g., RESTful SDK users) cannot invoke this endpoint without this change.

related: #48808

## Test plan
- [ ] Verify REST endpoint accepts valid AlterCollectionSchema request
- [ ] Verify error handling for invalid field schema / function schema
- [ ] Verify DbName is correctly populated from request body

🤖 Generated with [Claude Code](https://claude.com/claude-code)