### PR TITLE
fix: [2.6] await background load futures during cancellation and fix loadingTimeoutMs default

### DIFF
--- a/internal/core/src/segcore/MemoryPlannerTest.cpp
+++ b/internal/core/src/segcore/MemoryPlannerTest.cpp
@@ -21,6 +21,8 @@
 #include <vector>
 
 #include "arrow/api.h"
+#include <folly/CancellationToken.h>
+#include "common/EasyAssert.h"
 #include "gtest/gtest.h"
 #include "milvus-storage/common/metadata.h"
 #include "segcore/memory_planner.h"
@@ -308,4 +310,46 @@ TEST(LoadCellBatchAsync, EmptyCells) {
     auto futures = LoadCellBatchAsync(
         nullptr, {}, MakeMockReaderFactory(), channel, 128 << 20);
     EXPECT_EQ(futures.size(), 0);
+}
+
+TEST(LoadCellBatchAsync, CancellationStopsMidBatchPush) {
+    constexpr int64_t MB = 1 << 20;
+    std::vector<CellSpec> specs = {
+        {0, 0, 0, 1, 8 * MB},
+        {1, 0, 1, 1, 8 * MB},
+        {2, 0, 2, 1, 8 * MB},
+        {3, 0, 3, 1, 8 * MB},
+    };
+
+    folly::CancellationSource source;
+    milvus::OpContext op_ctx(source.getToken());
+    auto channel = std::make_shared<CellReaderChannel>(1);
+    auto futures = LoadCellBatchAsync(&op_ctx,
+                                      specs,
+                                      MakeMockReaderFactory(),
+                                      channel,
+                                      128 * MB);
+
+    ASSERT_EQ(futures.size(), 1);
+
+    std::shared_ptr<CellLoadResult> cell_data;
+    ASSERT_TRUE(channel->pop(cell_data));
+    ASSERT_NE(cell_data, nullptr);
+    EXPECT_EQ(cell_data->cid, 0);
+
+    source.requestCancellation();
+
+    size_t received = 1;
+    while (channel->pop(cell_data)) {
+        ASSERT_NE(cell_data, nullptr);
+        ++received;
+    }
+
+    try {
+        futures[0].get();
+        FAIL() << "expected cancellation";
+    } catch (const milvus::SegcoreError& e) {
+        EXPECT_EQ(e.get_error_code(), milvus::ErrorCode::FollyCancel);
+    }
+    EXPECT_LT(received, specs.size());
 }

--- a/internal/core/src/segcore/MemoryPlannerTest.cpp
+++ b/internal/core/src/segcore/MemoryPlannerTest.cpp
@@ -324,11 +324,8 @@ TEST(LoadCellBatchAsync, CancellationStopsMidBatchPush) {
     folly::CancellationSource source;
     milvus::OpContext op_ctx(source.getToken());
     auto channel = std::make_shared<CellReaderChannel>(1);
-    auto futures = LoadCellBatchAsync(&op_ctx,
-                                      specs,
-                                      MakeMockReaderFactory(),
-                                      channel,
-                                      128 * MB);
+    auto futures = LoadCellBatchAsync(
+        &op_ctx, specs, MakeMockReaderFactory(), channel, 128 * MB);
 
     ASSERT_EQ(futures.size(), 1);
 

--- a/internal/core/src/segcore/memory_planner.cpp
+++ b/internal/core/src/segcore/memory_planner.cpp
@@ -369,9 +369,11 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
                        "count: {}, result size: {}",
                        batch.rg_count,
                        all_tables.size());
+            CheckCancellation(op_ctx, -1, "LoadCellBatchAsync");
 
             int64_t table_offset = 0;
             for (const auto& cell : batch.cells) {
+                CheckCancellation(op_ctx, -1, "LoadCellBatchAsync");
                 auto cell_result = std::make_shared<CellLoadResult>();
                 cell_result->cid = cell.cid;
                 cell_result->tables.reserve(cell.rg_count);

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
@@ -379,6 +379,20 @@ GroupChunkTranslator::get_cells(milvus::OpContext* ctx,
         } catch (...) {
             LOG_WARN("drain channel exception swallowed");
         }
+        try {
+            storage::WaitAllFutures(load_futures);
+        } catch (const std::exception& e) {
+            LOG_WARN(
+                "[StorageV2] translator {} cleanup ignored background load "
+                "exception after cancellation: {}",
+                key_,
+                e.what());
+        } catch (...) {
+            LOG_WARN(
+                "[StorageV2] translator {} cleanup ignored unknown background "
+                "load exception after cancellation",
+                key_);
+        }
         throw;
     }
 

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
@@ -272,6 +272,20 @@ ManifestGroupTranslator::get_cells(
         } catch (...) {
             LOG_WARN("drain channel exception swallowed");
         }
+        try {
+            storage::WaitAllFutures(load_futures);
+        } catch (const std::exception& e) {
+            LOG_WARN(
+                "[StorageV2] translator {} cleanup ignored background load "
+                "exception after cancellation: {}",
+                key_,
+                e.what());
+        } catch (...) {
+            LOG_WARN(
+                "[StorageV2] translator {} cleanup ignored unknown background "
+                "load exception after cancellation",
+                key_);
+        }
         throw;
     }
 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3763,7 +3763,7 @@ If set to 0, time based eviction is disabled.`,
 	p.TieredLoadingTimeoutMs = ParamItem{
 		Key:          "queryNode.segcore.tieredStorage.loadingTimeoutMs",
 		Version:      "2.6.10",
-		DefaultValue: "0",
+		DefaultValue: "-1",
 		Doc:          "Loading timeout in milliseconds for cache slot loading. -1 means no timeout, 0 means immediate failure if resource cannot be reserved, >0 means a specific timeout.",
 		Export:       false,
 	}


### PR DESCRIPTION
- Await background load futures in `GroupChunkTranslator` and `ManifestGroupTranslator` cancellation cleanup paths to prevent use-after-free / dangling futures
- Add `CheckCancellation` calls in `LoadCellBatchAsync` loop for prompt cancellation
- Fix `tieredStorage.loadingTimeoutMs` default from `0` (immediate failure) to `-1` (no timeout)

issue: #48854
pr: #48855

## Test plan
- [x] Added unit test `CancellationStopsMidBatchPush` verifying mid-batch cancellation stops loading and raises `FollyCancel`
- [ ] CI passes