### PR TITLE
fix: Write delta log summary to SegmentInfo for V3 manifest segments

### DIFF
--- a/internal/datacoord/compaction_task_l0.go
+++ b/internal/datacoord/compaction_task_l0.go
@@ -448,10 +448,9 @@ func (t *l0CompactionTask) saveSegmentMeta(outputSegs []*datapb.CompactionSegmen
 	var operators []UpdateOperator
 	for _, seg := range outputSegs {
 		if seg.GetManifest() != "" {
-			// V2: Update manifest path (deltalog is inside manifest)
 			operators = append(operators, UpdateManifest(seg.GetSegmentID(), seg.GetManifest()))
-		} else {
-			// V1: Add deltalogs directly
+		}
+		if len(seg.GetDeltalogs()) > 0 {
 			operators = append(operators, AddBinlogsOperator(seg.GetSegmentID(), nil, nil, seg.GetDeltalogs(), nil))
 		}
 	}

--- a/internal/datanode/compactor/l0_compactor.go
+++ b/internal/datanode/compactor/l0_compactor.go
@@ -324,6 +324,14 @@ func (t *LevelZeroCompactionTask) splitAndWrite(
 					Channel:   t.plan.GetChannel(),
 					Manifest:  newManifest,
 					NumOfRows: int64(len(deletes.pks)),
+					// Delta summary for compaction trigger decisions (no path, only stats)
+					Deltalogs: []*datapb.FieldBinlog{{
+						Binlogs: []*datapb.Binlog{{
+							LogID:      logID,
+							EntriesNum: int64(len(deletes.pks)),
+							MemorySize: int64(writer.GetWrittenUncompressed()),
+						}},
+					}},
 				}, nil
 			}
 			// V1: Return deltalog in FieldBinlog format

--- a/internal/flushcommon/syncmgr/pack_writer_v3.go
+++ b/internal/flushcommon/syncmgr/pack_writer_v3.go
@@ -116,6 +116,7 @@ func (bw *BulkPackWriterV3) Write(ctx context.Context, pack *SyncPack) (
 		)
 	}()
 
+	var deltaSummary *datapb.FieldBinlog
 	err = retry.Do(ctx, func() error {
 		bw.resetForRetry()
 
@@ -132,8 +133,8 @@ func (bw *BulkPackWriterV3) Write(ctx context.Context, pack *SyncPack) (
 			log.Warn("failed to process stats blob", zap.Error(innerErr))
 			return classifyLoonErr(innerErr)
 		}
-		// writeDelta for V3 updates manifest and returns nil FieldBinlog
-		if manifest, innerErr = bw.writeDelta(ctx, pack); innerErr != nil {
+		// writeDelta for V3 updates manifest and returns delta summary
+		if manifest, deltaSummary, innerErr = bw.writeDelta(ctx, pack); innerErr != nil {
 			log.Warn("failed to process delta blob", zap.Error(innerErr))
 			return classifyLoonErr(innerErr)
 		}
@@ -148,8 +149,8 @@ func (bw *BulkPackWriterV3) Write(ctx context.Context, pack *SyncPack) (
 		return
 	}
 
-	// For V3, deltas and stats are in manifest
-	deltas = nil
+	// For V3, stats are in manifest; delta summary is returned for compaction trigger
+	deltas = deltaSummary
 	manifest = bw.manifestPath
 	size = bw.sizeWritten
 	return
@@ -281,27 +282,28 @@ func (bw *BulkPackWriterV3) writeInsertsIntoStorage(ctx context.Context,
 }
 
 // writeDelta writes deltalog to storage and updates the manifest.
-// For V3, deltalogs are stored in the manifest, not returned as FieldBinlog.
-func (bw *BulkPackWriterV3) writeDelta(ctx context.Context, pack *SyncPack) (string, error) {
+// Returns the updated manifest path and a pathless delta summary FieldBinlog
+// containing only EntriesNum and MemorySize for compaction trigger decisions.
+func (bw *BulkPackWriterV3) writeDelta(ctx context.Context, pack *SyncPack) (string, *datapb.FieldBinlog, error) {
 	if pack.deltaData == nil || pack.deltaData.RowCount == 0 {
-		return bw.manifestPath, nil
+		return bw.manifestPath, nil, nil
 	}
 
 	pkField, err := typeutil.GetPrimaryFieldSchema(bw.schema)
 	if err != nil {
-		return "", fmt.Errorf("primary key field not found: %w", err)
+		return "", nil, fmt.Errorf("primary key field not found: %w", err)
 	}
 
 	// Allocate log ID for deltalog
 	logID, err := bw.allocator.AllocOne()
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 
 	// Build deltalog path under basePath/_delta/
 	basePath, _, err := packed.UnmarshalManifestPath(bw.manifestPath)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse manifest path: %w", err)
+		return "", nil, fmt.Errorf("failed to parse manifest path: %w", err)
 	}
 	deltaPath := metautil.BuildDeltaLogPathV3(basePath, logID)
 
@@ -312,22 +314,22 @@ func (bw *BulkPackWriterV3) writeDelta(ctx context.Context, pack *SyncPack) (str
 		storage.WithStorageConfig(bw.storageConfig),
 	)
 	if err != nil {
-		return "", fmt.Errorf("failed to create deltalog writer: %w", err)
+		return "", nil, fmt.Errorf("failed to create deltalog writer: %w", err)
 	}
 
 	// Build Arrow record from delete data using existing utility
 	record, _, _, err := storage.BuildDeleteRecord(pack.deltaData.Pks, pack.deltaData.Tss)
 	if err != nil {
-		return "", fmt.Errorf("failed to build delete record: %w", err)
+		return "", nil, fmt.Errorf("failed to build delete record: %w", err)
 	}
 	defer record.Release()
 
 	// Write and close
 	if err := writer.Write(record); err != nil {
-		return "", fmt.Errorf("failed to write delta record: %w", err)
+		return "", nil, fmt.Errorf("failed to write delta record: %w", err)
 	}
 	if err := writer.Close(); err != nil {
-		return "", fmt.Errorf("failed to close delta writer: %w", err)
+		return "", nil, fmt.Errorf("failed to close delta writer: %w", err)
 	}
 
 	// Update manifest with the new deltalog
@@ -337,13 +339,21 @@ func (bw *BulkPackWriterV3) writeDelta(ctx context.Context, pack *SyncPack) (str
 		[]packed.DeltaLogEntry{{Path: deltaPath, NumEntries: pack.deltaData.RowCount}},
 	)
 	if err != nil {
-		return "", fmt.Errorf("failed to add deltalog to manifest: %w", err)
+		return "", nil, fmt.Errorf("failed to add deltalog to manifest: %w", err)
 	}
 
 	bw.manifestPath = newManifest
 	bw.sizeWritten += pack.deltaData.Size()
 
-	return newManifest, nil
+	// Return delta summary for compaction trigger decisions (no path, only stats)
+	summary := &datapb.FieldBinlog{
+		Binlogs: []*datapb.Binlog{{
+			LogID:      logID,
+			EntriesNum: pack.deltaData.RowCount,
+			MemorySize: int64(writer.GetWrittenUncompressed()),
+		}},
+	}
+	return newManifest, summary, nil
 }
 
 // writeStats overrides the base class to write bloom filter stats into the

--- a/internal/flushcommon/syncmgr/pack_writer_v3_test.go
+++ b/internal/flushcommon/syncmgr/pack_writer_v3_test.go
@@ -320,8 +320,12 @@ func (s *PackWriterV3Suite) TestWriteWithDeleteData() {
 	gotInserts, gotDeletes, _, _, writtenManifestPath, _, err := bw.Write(context.Background(), pack)
 	s.NoError(err)
 	s.Equal(0, len(gotInserts)) // No insert binlogs when only deletes
-	// For V3, deltas are nil since deltalogs are stored in manifest
-	s.Nil(gotDeletes)
+	// For V3, delta summary is returned for compaction trigger (no path, only stats)
+	s.NotNil(gotDeletes)
+	s.Equal(1, len(gotDeletes.GetBinlogs()))
+	s.EqualValues(int64(rows), gotDeletes.GetBinlogs()[0].GetEntriesNum())
+	s.NotZero(gotDeletes.GetBinlogs()[0].GetLogID())
+	s.Empty(gotDeletes.GetBinlogs()[0].GetLogPath())
 	// Verify manifest was updated (version should be > -1)
 	_, revision, err := packed.UnmarshalManifestPath(writtenManifestPath)
 	s.NoError(err)

--- a/tests/integration/compaction/l0_compaction_test.go
+++ b/tests/integration/compaction/l0_compaction_test.go
@@ -241,3 +241,174 @@ func (s *CompactionSuite) TestL0Compaction() {
 
 	log.Info("Test compaction succeed")
 }
+
+// TestL0CompactionDeltaLogOnV3Segment verifies that after L0 compaction,
+// V3 (manifest) L1 target segments have their Deltalogs populated in etcd.
+// Without the fix, V3 segments would have empty Deltalogs because the
+// compaction result only updated the manifest path, not the deltalog prefix.
+func (s *CompactionSuite) TestL0CompactionDeltaLogOnV3Segment() {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*10)
+	defer cancel()
+	c := s.Cluster
+
+	const (
+		dim       = 128
+		dbName    = ""
+		rowNum    = 50000
+		deleteCnt = 10000
+
+		indexType  = integration.IndexFaissIvfFlat
+		metricType = metric.L2
+		vecType    = schemapb.DataType_FloatVector
+	)
+
+	// Enable L0 compaction with low trigger, disable single compaction
+	// so we can observe the post-L0-compaction state.
+	revertGuard := s.Cluster.MustModifyMilvusConfig(map[string]string{
+		paramtable.Get().DataCoordCfg.LevelZeroCompactionTriggerDeltalogMinNum.Key: "1",
+		paramtable.Get().DataCoordCfg.SingleCompactionRatioThreshold.Key:           "1.0",
+		paramtable.Get().DataCoordCfg.SingleCompactionDeltalogMaxNum.Key:           "99999",
+		paramtable.Get().DataCoordCfg.SingleCompactionDeltaLogMaxSize.Key:          "999999999999",
+	})
+	defer revertGuard()
+
+	collectionName := "TestL0V3DeltaLog_" + funcutil.GenRandomStr()
+
+	schema := integration.ConstructSchemaOfVecDataType(collectionName, dim, false, vecType)
+	marshaledSchema, err := proto.Marshal(schema)
+	s.NoError(err)
+
+	createCollectionStatus, err := c.MilvusClient.CreateCollection(ctx, &milvuspb.CreateCollectionRequest{
+		DbName:           dbName,
+		CollectionName:   collectionName,
+		Schema:           marshaledSchema,
+		ShardsNum:        common.DefaultShardsNum,
+		ConsistencyLevel: commonpb.ConsistencyLevel_Strong,
+	})
+	err = merr.CheckRPCCall(createCollectionStatus, err)
+	s.NoError(err)
+
+	// insert
+	pkColumn := integration.NewInt64FieldData(integration.Int64Field, rowNum)
+	fVecColumn := integration.NewFloatVectorFieldData(integration.FloatVecField, rowNum, dim)
+	hashKeys := integration.GenerateHashKeys(rowNum)
+	insertResult, err := c.MilvusClient.Insert(ctx, &milvuspb.InsertRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		FieldsData:     []*schemapb.FieldData{pkColumn, fVecColumn},
+		HashKeys:       hashKeys,
+		NumRows:        uint32(rowNum),
+	})
+	err = merr.CheckRPCCall(insertResult, err)
+	s.NoError(err)
+
+	// flush to create L1 segment
+	flushResp, err := c.MilvusClient.Flush(ctx, &milvuspb.FlushRequest{
+		DbName:          dbName,
+		CollectionNames: []string{collectionName},
+	})
+	err = merr.CheckRPCCall(flushResp, err)
+	s.NoError(err)
+	segmentIDs, has := flushResp.GetCollSegIDs()[collectionName]
+	ids := segmentIDs.GetData()
+	s.Require().NotEmpty(segmentIDs)
+	s.Require().True(has)
+	flushTs, has := flushResp.GetCollFlushTs()[collectionName]
+	s.True(has)
+	s.WaitForFlush(ctx, ids, flushTs, dbName, collectionName)
+
+	// create index
+	createIndexStatus, err := c.MilvusClient.CreateIndex(ctx, &milvuspb.CreateIndexRequest{
+		CollectionName: collectionName,
+		FieldName:      integration.FloatVecField,
+		IndexName:      "_default",
+		ExtraParams:    integration.ConstructIndexParam(dim, indexType, metricType),
+	})
+	err = merr.CheckRPCCall(createIndexStatus, err)
+	s.NoError(err)
+	s.WaitForIndexBuilt(ctx, collectionName, integration.FloatVecField)
+
+	// load
+	loadStatus, err := c.MilvusClient.LoadCollection(ctx, &milvuspb.LoadCollectionRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+	})
+	err = merr.CheckRPCCall(loadStatus, err)
+	s.NoError(err)
+	s.WaitForLoad(ctx, collectionName)
+
+	// delete
+	deleteResult, err := c.MilvusClient.Delete(ctx, &milvuspb.DeleteRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		Expr:           fmt.Sprintf("%s < %d", integration.Int64Field, deleteCnt),
+	})
+	err = merr.CheckRPCCall(deleteResult, err)
+	s.NoError(err)
+
+	// flush L0
+	flushResp, err = c.MilvusClient.Flush(ctx, &milvuspb.FlushRequest{
+		DbName:          dbName,
+		CollectionNames: []string{collectionName},
+	})
+	err = merr.CheckRPCCall(flushResp, err)
+	s.NoError(err)
+	flushTs, has = flushResp.GetCollFlushTs()[collectionName]
+	s.True(has)
+	s.WaitForFlush(ctx, ids, flushTs, dbName, collectionName)
+
+	// Wait for L0 compaction: L0 segment should be dropped, L1 should remain
+	// with NumOfRows unchanged (single compaction is disabled).
+	var segments []*datapb.SegmentInfo
+	l0CompactionDone := func() bool {
+		segments, err = c.ShowSegments(collectionName)
+		s.NoError(err)
+		flushed := lo.Filter(segments, func(segment *datapb.SegmentInfo, _ int) bool {
+			return segment.GetState() == commonpb.SegmentState_Flushed
+		})
+		// After L0 compaction: only L1 segment(s) should remain flushed,
+		// and no L0 segments should be flushed.
+		hasL0 := lo.SomeBy(flushed, func(seg *datapb.SegmentInfo) bool {
+			return seg.GetLevel() == datapb.SegmentLevel_L0
+		})
+		hasL1 := lo.SomeBy(flushed, func(seg *datapb.SegmentInfo) bool {
+			return seg.GetLevel() == datapb.SegmentLevel_L1
+		})
+		return !hasL0 && hasL1
+	}
+	for !l0CompactionDone() {
+		select {
+		case <-ctx.Done():
+			s.Fail("waiting for L0 compaction timeout")
+			return
+		case <-time.After(1 * time.Second):
+		}
+	}
+
+	// Verify: L1 segment should have Deltalogs populated with correct entry count
+	flushed := lo.Filter(segments, func(segment *datapb.SegmentInfo, _ int) bool {
+		return segment.GetState() == commonpb.SegmentState_Flushed && segment.GetLevel() == datapb.SegmentLevel_L1
+	})
+	s.Require().NotEmpty(flushed, "expected at least one flushed L1 segment")
+
+	for _, seg := range flushed {
+		log.Info("checking L1 segment after L0 compaction",
+			zap.Int64("segmentID", seg.GetID()),
+			zap.Int64("numOfRows", seg.GetNumOfRows()),
+			zap.Int64("storageVersion", seg.GetStorageVersion()),
+			zap.Int("deltalogFieldCount", len(seg.GetDeltalogs())),
+		)
+		s.NotEmpty(seg.GetDeltalogs(), "L1 segment should have Deltalogs after L0 compaction")
+
+		totalDeletedRows := int64(0)
+		for _, dl := range seg.GetDeltalogs() {
+			for _, b := range dl.GetBinlogs() {
+				totalDeletedRows += b.GetEntriesNum()
+			}
+		}
+		s.EqualValues(deleteCnt, totalDeletedRows,
+			"Deltalogs EntriesNum should match deletion count")
+	}
+
+	log.Info("TestL0CompactionDeltaLogOnV3Segment succeed")
+}


### PR DESCRIPTION
See #48914 

After delta logs migrated from SegmentInfo to manifests (V3), the
Deltalogs field in SegmentInfo is always empty for V3 segments. All
compaction trigger logic reads from `segment.GetDeltalogs()`, so
compaction triggers never fire for V3 segments.

Fix: when V3 delta data is produced (flush or L0 compaction), also
write a delta summary entry (`LogID` + `EntriesNum` + `MemorySize`,
no path) to `SegmentInfo.Deltalogs`. All existing consumer code
works unchanged.

- `pack_writer_v3.go`: `writeDelta()` returns delta summary
- `l0_compactor.go`: V3 `CompactionSegment` includes delta summary
- `compaction_task_l0.go`: always write deltalogs via `AddBinlogsOperator`
- `l0_compaction_test.go`: IT verifying Deltalogs on V3 L1 segment
  after L0 compaction