### PR TITLE
[WIP] fix: mark db-level rate limiters as updated in quota center

### DIFF
--- a/internal/rootcoord/quota_center.go
+++ b/internal/rootcoord/quota_center.go
@@ -1413,10 +1413,8 @@ func (q *QuotaCenter) resetAllCurrentRates() error {
 					updateLimiterHasUpdated(partitionLimiter)
 				}
 			}
-			if len(collections) == 0 {
-				dbLimiter := q.rateLimiter.GetOrCreateDatabaseLimiters(dbID, newParamLimiterFunc(internalpb.RateScope_Database, allOps))
-				updateLimiterHasUpdated(dbLimiter)
-			}
+			dbLimiter := q.rateLimiter.GetOrCreateDatabaseLimiters(dbID, newParamLimiterFunc(internalpb.RateScope_Database, allOps))
+			updateLimiterHasUpdated(dbLimiter)
 		}
 	}
 	partitions := q.meta.ListAllAvailPartitions(q.ctx)


### PR DESCRIPTION
## Summary

- In `resetAllCurrentRates`, `updateLimiterHasUpdated` was only called on db-level limiter nodes when `len(collections) == 0`. For databases with collections (the normal case), db-level limiters retained `hasUpdated=false`, causing `toRequestLimiter` to skip them entirely.
- This meant db-level DQL/DML rates (e.g. `quotaAndLimits.dql.searchRate.db.max`) were never included in the `SetRatesRequest` sent to proxies, so the `rate/proxyNum` division at `toRequestLimiter` never executed for db-level rates.
- Each proxy fell back to enforcing the full configured rate from local config via `initLimiter`, resulting in an effective cluster-wide rate of `configuredRate * proxyCount` instead of `configuredRate`.

issue: https://github.com/milvus-io/milvus/issues/

## Test plan

- [ ] Deploy a multi-proxy cluster (2+ proxies) with `quotaAndLimits.dql.searchRate.db.max = 100`
- [ ] Verify aggregate search QPS is capped at 100, not 100 * proxyCount
- [ ] Check `milvus_proxy_limiter_rate` Prometheus metric includes `db.*` entries for `DQLSearch`
- [ ] Verify single-proxy standalone mode still works correctly
- [ ] Verify databases with zero collections still work correctly