### PR TITLE
fix: [3.0] bind file resource refCnt to collection lifecycle to prevent panic

### DIFF
--- a/internal/mocks/streamingcoord/server/mock_broadcaster/mock_Broadcaster.go
+++ b/internal/mocks/streamingcoord/server/mock_broadcaster/mock_Broadcaster.go
@@ -72,6 +72,26 @@ func (_c *MockBroadcaster_Ack_Call) RunAndReturn(run func(context.Context, messa
 	return _c
 }
 
+// GetPendingCreateCollectionResources provides a mock function with no fields
+func (_m *MockBroadcaster) GetPendingCreateCollectionResources() map[int64][]int64 {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetPendingCreateCollectionResources")
+	}
+
+	var r0 map[int64][]int64
+	if rf, ok := ret.Get(0).(func() map[int64][]int64); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[int64][]int64)
+		}
+	}
+
+	return r0
+}
+
 // Close provides a mock function with no fields
 func (_m *MockBroadcaster) Close() {
 	_m.Called()

--- a/internal/rootcoord/create_collection_task.go
+++ b/internal/rootcoord/create_collection_task.go
@@ -51,6 +51,19 @@ type createCollectionTask struct {
 	header          *message.CreateCollectionMessageHeader
 	body            *message.CreateCollectionRequest
 	preserveFieldID bool
+
+	// heldFileResourceIds tracks file resources whose refCnt was incremented
+	// during validation, to be released if the task fails before Broadcast.
+	heldFileResourceIds []int64
+}
+
+// releaseFileResources decrements refCnt for file resources that were
+// incremented during validation. Called when the task fails before Broadcast.
+func (t *createCollectionTask) releaseFileResources() {
+	if len(t.heldFileResourceIds) > 0 {
+		t.meta.DecFileResourceRefCnt(t.heldFileResourceIds)
+		t.heldFileResourceIds = nil
+	}
 }
 
 func (t *createCollectionTask) validate(ctx context.Context) error {
@@ -246,6 +259,15 @@ func (t *createCollectionTask) validateSchema(ctx context.Context, schema *schem
 			return err
 		}
 		schema.FileResourceIds = resp.GetResourceIds()
+
+		// Bind file resources to collection lifecycle: refCnt++ now, refCnt-- on
+		// drop. Under ddLock, atomic with RemoveFileResource. See #48612.
+		if len(schema.FileResourceIds) > 0 {
+			if err := t.meta.IncFileResourceRefCnt(schema.FileResourceIds); err != nil {
+				return err
+			}
+			t.heldFileResourceIds = schema.FileResourceIds
+		}
 	}
 
 	return validateFieldDataType(schema.GetFields())

--- a/internal/rootcoord/create_collection_task_test.go
+++ b/internal/rootcoord/create_collection_task_test.go
@@ -1468,6 +1468,9 @@ func Test_createCollectionTask_prepareSchema(t *testing.T) {
 			ResourceIds: []int64{1, 2, 3},
 		}, nil)
 
+		meta := mockrootcoord.NewIMetaTable(t)
+		meta.EXPECT().IncFileResourceRefCnt(mock.Anything).Return(nil)
+
 		collectionName := funcutil.GenRandomStr()
 		field1 := funcutil.GenRandomStr()
 		field2 := funcutil.GenRandomStr()
@@ -1498,7 +1501,7 @@ func Test_createCollectionTask_prepareSchema(t *testing.T) {
 		assert.NoError(t, err)
 
 		task := createCollectionTask{
-			Core: newTestCore(withMixCoord(mixcoord)),
+			Core: newTestCore(withMixCoord(mixcoord), withMeta(meta)),
 			Req: &milvuspb.CreateCollectionRequest{
 				Base:           &commonpb.MsgBase{MsgType: commonpb.MsgType_CreateCollection},
 				CollectionName: collectionName,
@@ -1522,6 +1525,9 @@ func Test_createCollectionTask_prepareSchema(t *testing.T) {
 			ResourceIds: []int64{1, 2, 3},
 		}, nil)
 
+		meta := mockrootcoord.NewIMetaTable(t)
+		meta.EXPECT().IncFileResourceRefCnt(mock.Anything).Return(nil)
+
 		collectionName := funcutil.GenRandomStr()
 		field1 := funcutil.GenRandomStr()
 		field2 := funcutil.GenRandomStr()
@@ -1552,7 +1558,7 @@ func Test_createCollectionTask_prepareSchema(t *testing.T) {
 		assert.NoError(t, err)
 
 		task := createCollectionTask{
-			Core: newTestCore(withMixCoord(mixcoord)),
+			Core: newTestCore(withMixCoord(mixcoord), withMeta(meta)),
 			Req: &milvuspb.CreateCollectionRequest{
 				Base:           &commonpb.MsgBase{MsgType: commonpb.MsgType_CreateCollection},
 				CollectionName: collectionName,

--- a/internal/rootcoord/ddl_callbacks_create_collection.go
+++ b/internal/rootcoord/ddl_callbacks_create_collection.go
@@ -80,6 +80,7 @@ func (c *Core) broadcastCreateCollectionV1(ctx context.Context, req *milvuspb.Cr
 		preserveFieldID: preserveFieldID == "true",
 	}
 	if err := createCollectionTask.Prepare(ctx); err != nil {
+		createCollectionTask.releaseFileResources()
 		return err
 	}
 
@@ -95,8 +96,11 @@ func (c *Core) broadcastCreateCollectionV1(ctx context.Context, req *milvuspb.Cr
 		WithBroadcast(broadcastChannel).
 		MustBuildBroadcast()
 	if _, err := broadcaster.Broadcast(ctx, msg); err != nil {
+		createCollectionTask.releaseFileResources()
 		return err
 	}
+	// Broadcast succeeded → task persisted in etcd → retries until AddCollection.
+	// refCnt stays until collection is dropped. No release here.
 	return nil
 }
 

--- a/internal/rootcoord/ddl_callbacks_create_collection.go
+++ b/internal/rootcoord/ddl_callbacks_create_collection.go
@@ -96,11 +96,11 @@ func (c *Core) broadcastCreateCollectionV1(ctx context.Context, req *milvuspb.Cr
 		WithBroadcast(broadcastChannel).
 		MustBuildBroadcast()
 	if _, err := broadcaster.Broadcast(ctx, msg); err != nil {
-		createCollectionTask.releaseFileResources()
+		// Do NOT release file resources here: the broadcast task is already in the
+		// scheduler and will retry until success. refCnt will be decremented when
+		// the collection is eventually dropped.
 		return err
 	}
-	// Broadcast succeeded → task persisted in etcd → retries until AddCollection.
-	// refCnt stays until collection is dropped. No release here.
 	return nil
 }
 

--- a/internal/rootcoord/meta_table.go
+++ b/internal/rootcoord/meta_table.go
@@ -598,7 +598,9 @@ func (mt *MetaTable) DropCollection(ctx context.Context, collectionID UniqueID, 
 	}
 	mt.collID2Meta[collectionID] = clone
 	for _, fileResourceID := range coll.FileResourceIds {
-		mt.fileResourceRefCnt[fileResourceID]--
+		if mt.fileResourceRefCnt[fileResourceID] > 0 {
+			mt.fileResourceRefCnt[fileResourceID]--
+		}
 	}
 
 	log.Ctx(ctx).Info("update coll state to dropping",
@@ -2340,7 +2342,9 @@ func (mt *MetaTable) DecFileResourceRefCnt(ids []int64) {
 	mt.ddLock.Lock()
 	defer mt.ddLock.Unlock()
 	for _, id := range ids {
-		mt.fileResourceRefCnt[id]--
+		if mt.fileResourceRefCnt[id] > 0 {
+			mt.fileResourceRefCnt[id]--
+		}
 	}
 }
 
@@ -2354,9 +2358,13 @@ func (mt *MetaTable) RecoverFileResourceRefCnt(pendingCollections map[int64][]in
 		if _, exists := mt.collID2Meta[collID]; exists {
 			continue // collection already persisted, reload already counted it
 		}
+		var missing []int64
 		for _, id := range resourceIds {
 			if _, ok := mt.fileResourceID2Meta[id]; ok {
 				mt.fileResourceRefCnt[id]++
+			} else {
+				log.Warn("RecoverFileResourceRefCnt: pending task references missing file resource",
+					zap.Int64("collectionID", collID), zap.Int64("resourceID", id))
 			}
 		}
 	}

--- a/internal/rootcoord/meta_table.go
+++ b/internal/rootcoord/meta_table.go
@@ -600,6 +600,9 @@ func (mt *MetaTable) DropCollection(ctx context.Context, collectionID UniqueID, 
 	for _, fileResourceID := range coll.FileResourceIds {
 		if mt.fileResourceRefCnt[fileResourceID] > 0 {
 			mt.fileResourceRefCnt[fileResourceID]--
+		} else {
+			log.Warn("DropCollection: file resource refCnt underflow",
+				zap.Int64("collectionID", collectionID), zap.Int64("fileResourceID", fileResourceID))
 		}
 	}
 
@@ -2344,6 +2347,8 @@ func (mt *MetaTable) DecFileResourceRefCnt(ids []int64) {
 	for _, id := range ids {
 		if mt.fileResourceRefCnt[id] > 0 {
 			mt.fileResourceRefCnt[id]--
+		} else {
+			log.Warn("DecFileResourceRefCnt underflow", zap.Int64("id", id))
 		}
 	}
 }

--- a/internal/rootcoord/meta_table.go
+++ b/internal/rootcoord/meta_table.go
@@ -152,6 +152,9 @@ type IMetaTable interface {
 	AddFileResource(ctx context.Context, resource *internalpb.FileResourceInfo) error
 	RemoveFileResource(ctx context.Context, name string) (error, bool)
 	ListFileResource(ctx context.Context) ([]*internalpb.FileResourceInfo, uint64)
+	IncFileResourceRefCnt(ids []int64) error
+	DecFileResourceRefCnt(ids []int64)
+	RecoverFileResourceRefCnt(pendingCollections map[int64][]int64)
 }
 
 // MetaTable is a persistent meta set of all databases, collections and partitions.
@@ -557,9 +560,6 @@ func (mt *MetaTable) AddCollection(ctx context.Context, coll *model.Collection) 
 
 	mt.collID2Meta[coll.CollectionID] = coll.Clone()
 	mt.names.insert(coll.DBName, coll.Name, coll.CollectionID)
-	for _, fileResourceID := range coll.FileResourceIds {
-		mt.fileResourceRefCnt[fileResourceID]++
-	}
 
 	pn := coll.GetPartitionNum(true)
 	mt.generalCnt += pn * int(coll.ShardsNum)
@@ -2315,4 +2315,49 @@ func (mt *MetaTable) ListFileResource(ctx context.Context) ([]*internalpb.FileRe
 	defer mt.ddLock.RUnlock()
 
 	return lo.Values(mt.fileResourceID2Meta), mt.fileResourceVersion
+}
+
+// IncFileResourceRefCnt increments refCnt for file resources, binding them to a
+// collection being created. Under ddLock, atomic with RemoveFileResource.
+// Returns error if any resource ID does not exist.
+func (mt *MetaTable) IncFileResourceRefCnt(ids []int64) error {
+	mt.ddLock.Lock()
+	defer mt.ddLock.Unlock()
+	for _, id := range ids {
+		if _, ok := mt.fileResourceID2Meta[id]; !ok {
+			return merr.WrapErrParameterInvalidMsg("file resource %d not found", id)
+		}
+	}
+	for _, id := range ids {
+		mt.fileResourceRefCnt[id]++
+	}
+	return nil
+}
+
+// DecFileResourceRefCnt decrements refCnt. Used for early release when
+// CreateCollection fails after validation.
+func (mt *MetaTable) DecFileResourceRefCnt(ids []int64) {
+	mt.ddLock.Lock()
+	defer mt.ddLock.Unlock()
+	for _, id := range ids {
+		mt.fileResourceRefCnt[id]--
+	}
+}
+
+// RecoverFileResourceRefCnt re-increments refCnt for file resources referenced by
+// pending CreateCollection broadcast tasks whose collections have not yet been
+// persisted. Called during startup before rootcoord becomes Healthy.
+func (mt *MetaTable) RecoverFileResourceRefCnt(pendingCollections map[int64][]int64) {
+	mt.ddLock.Lock()
+	defer mt.ddLock.Unlock()
+	for collID, resourceIds := range pendingCollections {
+		if _, exists := mt.collID2Meta[collID]; exists {
+			continue // collection already persisted, reload already counted it
+		}
+		for _, id := range resourceIds {
+			if _, ok := mt.fileResourceID2Meta[id]; ok {
+				mt.fileResourceRefCnt[id]++
+			}
+		}
+	}
 }

--- a/internal/rootcoord/meta_table.go
+++ b/internal/rootcoord/meta_table.go
@@ -2363,7 +2363,6 @@ func (mt *MetaTable) RecoverFileResourceRefCnt(pendingCollections map[int64][]in
 		if _, exists := mt.collID2Meta[collID]; exists {
 			continue // collection already persisted, reload already counted it
 		}
-		var missing []int64
 		for _, id := range resourceIds {
 			if _, ok := mt.fileResourceID2Meta[id]; ok {
 				mt.fileResourceRefCnt[id]++

--- a/internal/rootcoord/mocks/meta_table.go
+++ b/internal/rootcoord/mocks/meta_table.go
@@ -1371,6 +1371,39 @@ func (_c *IMetaTable_CreateRole_Call) RunAndReturn(run func(context.Context, str
 	return _c
 }
 
+// DecFileResourceRefCnt provides a mock function with given fields: ids
+func (_m *IMetaTable) DecFileResourceRefCnt(ids []int64) {
+	_m.Called(ids)
+}
+
+// IMetaTable_DecFileResourceRefCnt_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DecFileResourceRefCnt'
+type IMetaTable_DecFileResourceRefCnt_Call struct {
+	*mock.Call
+}
+
+// DecFileResourceRefCnt is a helper method to define mock.On call
+//   - ids []int64
+func (_e *IMetaTable_Expecter) DecFileResourceRefCnt(ids interface{}) *IMetaTable_DecFileResourceRefCnt_Call {
+	return &IMetaTable_DecFileResourceRefCnt_Call{Call: _e.mock.On("DecFileResourceRefCnt", ids)}
+}
+
+func (_c *IMetaTable_DecFileResourceRefCnt_Call) Run(run func(ids []int64)) *IMetaTable_DecFileResourceRefCnt_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].([]int64))
+	})
+	return _c
+}
+
+func (_c *IMetaTable_DecFileResourceRefCnt_Call) Return() *IMetaTable_DecFileResourceRefCnt_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *IMetaTable_DecFileResourceRefCnt_Call) RunAndReturn(run func([]int64)) *IMetaTable_DecFileResourceRefCnt_Call {
+	_c.Run(run)
+	return _c
+}
+
 // DeleteCredential provides a mock function with given fields: ctx, result
 func (_m *IMetaTable) DeleteCredential(ctx context.Context, result message.BroadcastResult[*messagespb.DropUserMessageHeader, *messagespb.DropUserMessageBody]) error {
 	ret := _m.Called(ctx, result)
@@ -2424,6 +2457,52 @@ func (_c *IMetaTable_GetPrivilegeGroupRoles_Call) RunAndReturn(run func(context.
 	return _c
 }
 
+// IncFileResourceRefCnt provides a mock function with given fields: ids
+func (_m *IMetaTable) IncFileResourceRefCnt(ids []int64) error {
+	ret := _m.Called(ids)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IncFileResourceRefCnt")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func([]int64) error); ok {
+		r0 = rf(ids)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// IMetaTable_IncFileResourceRefCnt_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IncFileResourceRefCnt'
+type IMetaTable_IncFileResourceRefCnt_Call struct {
+	*mock.Call
+}
+
+// IncFileResourceRefCnt is a helper method to define mock.On call
+//   - ids []int64
+func (_e *IMetaTable_Expecter) IncFileResourceRefCnt(ids interface{}) *IMetaTable_IncFileResourceRefCnt_Call {
+	return &IMetaTable_IncFileResourceRefCnt_Call{Call: _e.mock.On("IncFileResourceRefCnt", ids)}
+}
+
+func (_c *IMetaTable_IncFileResourceRefCnt_Call) Run(run func(ids []int64)) *IMetaTable_IncFileResourceRefCnt_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].([]int64))
+	})
+	return _c
+}
+
+func (_c *IMetaTable_IncFileResourceRefCnt_Call) Return(_a0 error) *IMetaTable_IncFileResourceRefCnt_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *IMetaTable_IncFileResourceRefCnt_Call) RunAndReturn(run func([]int64) error) *IMetaTable_IncFileResourceRefCnt_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // InitCredential provides a mock function with given fields: ctx
 func (_m *IMetaTable) InitCredential(ctx context.Context) error {
 	ret := _m.Called(ctx)
@@ -3386,6 +3465,39 @@ func (_c *IMetaTable_OperateUserRole_Call) Return(_a0 error) *IMetaTable_Operate
 
 func (_c *IMetaTable_OperateUserRole_Call) RunAndReturn(run func(context.Context, string, *milvuspb.UserEntity, *milvuspb.RoleEntity, milvuspb.OperateUserRoleType) error) *IMetaTable_OperateUserRole_Call {
 	_c.Call.Return(run)
+	return _c
+}
+
+// RecoverFileResourceRefCnt provides a mock function with given fields: pendingCollections
+func (_m *IMetaTable) RecoverFileResourceRefCnt(pendingCollections map[int64][]int64) {
+	_m.Called(pendingCollections)
+}
+
+// IMetaTable_RecoverFileResourceRefCnt_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RecoverFileResourceRefCnt'
+type IMetaTable_RecoverFileResourceRefCnt_Call struct {
+	*mock.Call
+}
+
+// RecoverFileResourceRefCnt is a helper method to define mock.On call
+//   - pendingCollections map[int64][]int64
+func (_e *IMetaTable_Expecter) RecoverFileResourceRefCnt(pendingCollections interface{}) *IMetaTable_RecoverFileResourceRefCnt_Call {
+	return &IMetaTable_RecoverFileResourceRefCnt_Call{Call: _e.mock.On("RecoverFileResourceRefCnt", pendingCollections)}
+}
+
+func (_c *IMetaTable_RecoverFileResourceRefCnt_Call) Run(run func(pendingCollections map[int64][]int64)) *IMetaTable_RecoverFileResourceRefCnt_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(map[int64][]int64))
+	})
+	return _c
+}
+
+func (_c *IMetaTable_RecoverFileResourceRefCnt_Call) Return() *IMetaTable_RecoverFileResourceRefCnt_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *IMetaTable_RecoverFileResourceRefCnt_Call) RunAndReturn(run func(map[int64][]int64)) *IMetaTable_RecoverFileResourceRefCnt_Call {
+	_c.Run(run)
 	return _c
 }
 

--- a/internal/rootcoord/root_coord.go
+++ b/internal/rootcoord/root_coord.go
@@ -524,6 +524,14 @@ func (c *Core) Init() error {
 
 	c.initOnce.Do(func() {
 		initError = c.initInternal()
+		// Recover file resource refCnt for pending CreateCollection broadcast tasks
+		// before registering DDL callbacks, so ack callbacks won't race with recovery.
+		// See #48612.
+		pending := broadcast.GetPendingCreateCollectionResources()
+		if len(pending) > 0 {
+			c.meta.RecoverFileResourceRefCnt(pending)
+			log.Info("recovered file resource refCnt from pending broadcast tasks", zap.Int("count", len(pending)))
+		}
 		RegisterDDLCallbacks(c)
 	})
 	log.Info("RootCoord init successfully")
@@ -664,14 +672,6 @@ func (c *Core) restore(ctx context.Context) error {
 			}
 		}
 	}
-	// Recover file resource refCnt for pending CreateCollection broadcast tasks
-	// whose collections haven't been persisted yet. See #48612.
-	pending := broadcast.GetPendingCreateCollectionResources()
-	if len(pending) > 0 {
-		c.meta.RecoverFileResourceRefCnt(pending)
-		log.Ctx(ctx).Info("recovered file resource refCnt from pending broadcast tasks", zap.Int("count", len(pending)))
-	}
-
 	return nil
 }
 

--- a/internal/rootcoord/root_coord.go
+++ b/internal/rootcoord/root_coord.go
@@ -47,6 +47,7 @@ import (
 	"github.com/milvus-io/milvus/internal/rootcoord/tombstone"
 	"github.com/milvus-io/milvus/internal/storage"
 	streamingcoord "github.com/milvus-io/milvus/internal/streamingcoord/server"
+	"github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster/broadcast"
 	tso2 "github.com/milvus-io/milvus/internal/tso"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/dependency"
@@ -663,6 +664,14 @@ func (c *Core) restore(ctx context.Context) error {
 			}
 		}
 	}
+	// Recover file resource refCnt for pending CreateCollection broadcast tasks
+	// whose collections haven't been persisted yet. See #48612.
+	pending := broadcast.GetPendingCreateCollectionResources()
+	if len(pending) > 0 {
+		c.meta.RecoverFileResourceRefCnt(pending)
+		log.Ctx(ctx).Info("recovered file resource refCnt from pending broadcast tasks", zap.Int("count", len(pending)))
+	}
+
 	return nil
 }
 

--- a/internal/streamingcoord/server/broadcaster/broadcast/singleton.go
+++ b/internal/streamingcoord/server/broadcaster/broadcast/singleton.go
@@ -62,6 +62,15 @@ func StartBroadcastWithSecondaryClusterResourceKey(ctx context.Context) (broadca
 	return broadcaster.WithSecondaryClusterResourceKey(ctx)
 }
 
+// GetPendingCreateCollectionResources returns pending CreateCollection file resource
+// IDs from the broadcaster. Must be called after Register.
+func GetPendingCreateCollectionResources() map[int64][]int64 {
+	if !singleton.Ready() {
+		return nil
+	}
+	return singleton.Get().GetPendingCreateCollectionResources()
+}
+
 // Release releases the broadcaster.
 func Release() {
 	if !singleton.Ready() {

--- a/internal/streamingcoord/server/broadcaster/broadcast_manager.go
+++ b/internal/streamingcoord/server/broadcaster/broadcast_manager.go
@@ -364,3 +364,31 @@ func (bm *broadcastTaskManager) getIncompleteBroadcastTasks() []*broadcastTask {
 	}
 	return result
 }
+
+// GetPendingCreateCollectionResources returns collection ID → file resource IDs
+// for all non-tombstone CreateCollection broadcast tasks. Used during recovery to
+// rebuild file resource refCnt for collections whose AddCollection hasn't run yet.
+func (bm *broadcastTaskManager) GetPendingCreateCollectionResources() map[int64][]int64 {
+	bm.mu.Lock()
+	defer bm.mu.Unlock()
+
+	result := make(map[int64][]int64)
+	for _, task := range bm.tasks {
+		if task.State() == streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_TOMBSTONE {
+			continue
+		}
+		if task.msg.MessageType() != message.MessageTypeCreateCollection {
+			continue
+		}
+		createMsg, err := message.AsMutableCreateCollectionMessageV1(task.msg)
+		if err != nil {
+			continue
+		}
+		body := createMsg.MustBody()
+		ids := body.CollectionSchema.GetFileResourceIds()
+		if len(ids) > 0 {
+			result[createMsg.Header().CollectionId] = ids
+		}
+	}
+	return result
+}

--- a/internal/streamingcoord/server/broadcaster/broadcaster.go
+++ b/internal/streamingcoord/server/broadcaster/broadcaster.go
@@ -32,6 +32,11 @@ type Broadcaster interface {
 	// Ack acknowledges the message at the specified vchannel.
 	Ack(ctx context.Context, msg message.ImmutableMessage) error
 
+	// GetPendingCreateCollectionResources returns collection ID → file resource IDs
+	// for all pending CreateCollection broadcast tasks that haven't completed
+	// their ack callback yet. Used during recovery to rebuild file resource refCnt.
+	GetPendingCreateCollectionResources() map[int64][]int64
+
 	// Close closes the broadcaster.
 	Close()
 }


### PR DESCRIPTION
## Summary
- Increment `fileResourceRefCnt` during `validateSchema` instead of in the async ack callback's `AddCollection`, closing the TOCTOU race where `RemoveFileResource` could delete a resource between validation and `AddCollection`
- On failure before `Broadcast`, refCnt is decremented immediately; on restart, refCnt for pending broadcast tasks is recovered from etcd before rootcoord becomes Healthy
- Remove refCnt++ from `addCollectionMeta` since it's now done at validation time (reload path unchanged)

## Test plan
- [ ] Existing file resource E2E tests pass (the race that caused #48612)
- [ ] CreateCollection with file resource → verify refCnt incremented
- [ ] RemoveFileResource blocked during in-flight CreateCollection
- [ ] Restart during CreateCollection → verify refCnt recovered from pending broadcast tasks

issue: #48612
pr: #48893

🤖 Generated with [Claude Code](https://claude.com/claude-code)