### PR TITLE
fix: [2.5] implement PatternMatch for StringIndexMarisa to fix LIKE prefix performance regression

### DIFF
--- a/internal/core/src/bitset/common.h
+++ b/internal/core/src/bitset/common.h
@@ -164,11 +164,14 @@ struct ArithCompareOperator {
 template <CompareOpType CmpOp>
 struct CompareOpDivFlip {
     static constexpr CompareOpType op =
-        (CmpOp == CompareOpType::LE)   ? CompareOpType::GE
-        : (CmpOp == CompareOpType::LT) ? CompareOpType::GT
-        : (CmpOp == CompareOpType::GE) ? CompareOpType::LE
-        : (CmpOp == CompareOpType::GT) ? CompareOpType::LT
-                                       : CmpOp;
+        (CmpOp == CompareOpType::LE)
+            ? CompareOpType::GE
+            : (CmpOp == CompareOpType::LT)
+                  ? CompareOpType::GT
+                  : (CmpOp == CompareOpType::GE)
+                        ? CompareOpType::LE
+                        : (CmpOp == CompareOpType::GT) ? CompareOpType::LT
+                                                       : CmpOp;
 };
 
 }  // namespace bitset

--- a/internal/core/src/common/Array.h
+++ b/internal/core/src/common/Array.h
@@ -297,7 +297,8 @@ class Array {
     output_data(ScalarArray& data_array) const {
         switch (element_type_) {
             case DataType::BOOL: {
-                data_array.mutable_bool_data()->mutable_data()->Reserve(length_);
+                data_array.mutable_bool_data()->mutable_data()->Reserve(
+                    length_);
                 for (int j = 0; j < length_; ++j) {
                     auto element = get_data<bool>(j);
                     data_array.mutable_bool_data()->add_data(element);
@@ -315,7 +316,8 @@ class Array {
                 break;
             }
             case DataType::INT64: {
-                data_array.mutable_long_data()->mutable_data()->Reserve(length_);
+                data_array.mutable_long_data()->mutable_data()->Reserve(
+                    length_);
                 for (int j = 0; j < length_; ++j) {
                     auto element = get_data<int64_t>(j);
                     data_array.mutable_long_data()->add_data(element);
@@ -324,15 +326,18 @@ class Array {
             }
             case DataType::STRING:
             case DataType::VARCHAR: {
-                data_array.mutable_string_data()->mutable_data()->Reserve(length_);
+                data_array.mutable_string_data()->mutable_data()->Reserve(
+                    length_);
                 for (int j = 0; j < length_; ++j) {
                     auto element = get_data<std::string_view>(j);
-                    data_array.mutable_string_data()->add_data(element.data(), element.size());
+                    data_array.mutable_string_data()->add_data(element.data(),
+                                                               element.size());
                 }
                 break;
             }
             case DataType::FLOAT: {
-                data_array.mutable_float_data()->mutable_data()->Reserve(length_);
+                data_array.mutable_float_data()->mutable_data()->Reserve(
+                    length_);
                 for (int j = 0; j < length_; ++j) {
                     auto element = get_data<float>(j);
                     data_array.mutable_float_data()->add_data(element);
@@ -340,7 +345,8 @@ class Array {
                 break;
             }
             case DataType::DOUBLE: {
-                data_array.mutable_double_data()->mutable_data()->Reserve(length_);
+                data_array.mutable_double_data()->mutable_data()->Reserve(
+                    length_);
                 for (int j = 0; j < length_; ++j) {
                     auto element = get_data<double>(j);
                     data_array.mutable_double_data()->add_data(element);
@@ -348,10 +354,12 @@ class Array {
                 break;
             }
             case DataType::GEOMETRY: {
-                data_array.mutable_geometry_data()->mutable_data()->Reserve(length_);
+                data_array.mutable_geometry_data()->mutable_data()->Reserve(
+                    length_);
                 for (int j = 0; j < length_; ++j) {
                     auto element = get_data<std::string_view>(j);
-                    data_array.mutable_geometry_data()->add_data(element.data(), element.size());
+                    data_array.mutable_geometry_data()->add_data(
+                        element.data(), element.size());
                 }
                 break;
             }
@@ -554,7 +562,8 @@ class ArrayView {
     output_data(ScalarArray& data_array) const {
         switch (element_type_) {
             case DataType::BOOL: {
-                data_array.mutable_bool_data()->mutable_data()->Reserve(length_);
+                data_array.mutable_bool_data()->mutable_data()->Reserve(
+                    length_);
                 for (int j = 0; j < length_; ++j) {
                     auto element = get_data<bool>(j);
                     data_array.mutable_bool_data()->add_data(element);
@@ -572,7 +581,8 @@ class ArrayView {
                 break;
             }
             case DataType::INT64: {
-                data_array.mutable_long_data()->mutable_data()->Reserve(length_);
+                data_array.mutable_long_data()->mutable_data()->Reserve(
+                    length_);
                 for (int j = 0; j < length_; ++j) {
                     auto element = get_data<int64_t>(j);
                     data_array.mutable_long_data()->add_data(element);
@@ -581,15 +591,18 @@ class ArrayView {
             }
             case DataType::STRING:
             case DataType::VARCHAR: {
-                data_array.mutable_string_data()->mutable_data()->Reserve(length_);
+                data_array.mutable_string_data()->mutable_data()->Reserve(
+                    length_);
                 for (int j = 0; j < length_; ++j) {
                     auto element = get_data<std::string_view>(j);
-                    data_array.mutable_string_data()->add_data(element.data(), element.size());
+                    data_array.mutable_string_data()->add_data(element.data(),
+                                                               element.size());
                 }
                 break;
             }
             case DataType::FLOAT: {
-                data_array.mutable_float_data()->mutable_data()->Reserve(length_);
+                data_array.mutable_float_data()->mutable_data()->Reserve(
+                    length_);
                 for (int j = 0; j < length_; ++j) {
                     auto element = get_data<float>(j);
                     data_array.mutable_float_data()->add_data(element);
@@ -597,7 +610,8 @@ class ArrayView {
                 break;
             }
             case DataType::DOUBLE: {
-                data_array.mutable_double_data()->mutable_data()->Reserve(length_);
+                data_array.mutable_double_data()->mutable_data()->Reserve(
+                    length_);
                 for (int j = 0; j < length_; ++j) {
                     auto element = get_data<double>(j);
                     data_array.mutable_double_data()->add_data(element);
@@ -605,10 +619,12 @@ class ArrayView {
                 break;
             }
             case DataType::GEOMETRY: {
-                data_array.mutable_geometry_data()->mutable_data()->Reserve(length_);
+                data_array.mutable_geometry_data()->mutable_data()->Reserve(
+                    length_);
                 for (int j = 0; j < length_; ++j) {
                     auto element = get_data<std::string_view>(j);
-                    data_array.mutable_geometry_data()->add_data(element.data(), element.size());
+                    data_array.mutable_geometry_data()->add_data(
+                        element.data(), element.size());
                 }
                 break;
             }

--- a/internal/core/src/index/StringIndexMarisa.cpp
+++ b/internal/core/src/index/StringIndexMarisa.cpp
@@ -503,7 +503,7 @@ StringIndexMarisa::PatternMatch(const std::string& pattern,
     if (op != proto::plan::OpType::Match &&
         op != proto::plan::OpType::PostfixMatch &&
         op != proto::plan::OpType::InnerMatch) {
-        ThrowInfo(Unsupported,
+        PanicInfo(Unsupported,
                   "StringIndexMarisa::PatternMatch only supports Match, "
                   "PrefixMatch, PostfixMatch, InnerMatch, got op: {}",
                   static_cast<int>(op));

--- a/internal/core/src/index/StringIndexMarisa.cpp
+++ b/internal/core/src/index/StringIndexMarisa.cpp
@@ -28,6 +28,7 @@
 #include <unistd.h>
 
 #include "common/File.h"
+#include "common/RegexQuery.h"
 #include "common/Types.h"
 #include "common/EasyAssert.h"
 #include "common/Exception.h"
@@ -487,6 +488,62 @@ StringIndexMarisa::PrefixMatch(std::string_view prefix) {
         auto offsets = str_ids_to_offsets_[str_id];
         for (auto offset : offsets) {
             bitset[offset] = true;
+        }
+    }
+    return bitset;
+}
+
+const TargetBitmap
+StringIndexMarisa::PatternMatch(const std::string& pattern,
+                                proto::plan::OpType op) {
+    if (op == proto::plan::OpType::PrefixMatch) {
+        return PrefixMatch(pattern);
+    }
+
+    if (op != proto::plan::OpType::Match &&
+        op != proto::plan::OpType::PostfixMatch &&
+        op != proto::plan::OpType::InnerMatch) {
+        ThrowInfo(Unsupported,
+                  "StringIndexMarisa::PatternMatch only supports Match, "
+                  "PrefixMatch, PostfixMatch, InnerMatch, got op: {}",
+                  static_cast<int>(op));
+    }
+
+    // For Match/PostfixMatch/InnerMatch, iterate over unique trie keys
+    // instead of all rows to avoid redundant matching on duplicate values.
+    TargetBitmap bitset(str_ids_.size());
+
+    auto match_fn = [&](const std::string& val) -> bool {
+        switch (op) {
+            case proto::plan::OpType::PostfixMatch:
+                return PostfixMatch(val, pattern);
+            case proto::plan::OpType::InnerMatch:
+                return InnerMatch(val, pattern);
+            default:
+                return false;
+        }
+    };
+
+    if (op == proto::plan::OpType::Match) {
+        PatternMatchTranslator translator;
+        auto regex_pattern = translator(pattern);
+        RegexMatcher matcher(regex_pattern);
+        for (const auto& [str_id, offsets] : str_ids_to_offsets_) {
+            auto val = Reverse_Lookup(offsets[0]);
+            if (val.has_value() && matcher(val.value())) {
+                for (auto offset : offsets) {
+                    bitset[offset] = true;
+                }
+            }
+        }
+    } else {
+        for (const auto& [str_id, offsets] : str_ids_to_offsets_) {
+            auto val = Reverse_Lookup(offsets[0]);
+            if (val.has_value() && match_fn(val.value())) {
+                for (auto offset : offsets) {
+                    bitset[offset] = true;
+                }
+            }
         }
     }
     return bitset;

--- a/internal/core/src/index/StringIndexMarisa.h
+++ b/internal/core/src/index/StringIndexMarisa.h
@@ -89,6 +89,14 @@ class StringIndexMarisa : public StringIndex {
     const TargetBitmap
     PrefixMatch(const std::string_view prefix) override;
 
+    bool
+    SupportPatternMatch() const override {
+        return true;
+    }
+
+    const TargetBitmap
+    PatternMatch(const std::string& pattern, proto::plan::OpType op) override;
+
     std::optional<std::string>
     Reverse_Lookup(size_t offset) const override;
 

--- a/internal/core/src/storage/DiskFileManagerImpl.cpp
+++ b/internal/core/src/storage/DiskFileManagerImpl.cpp
@@ -354,9 +354,10 @@ DiskFileManagerImpl::CacheRawDataToDisk(std::vector<std::string> remote_files) {
             if (data_type == milvus::DataType::VECTOR_SPARSE_FLOAT) {
                 dim = std::max(
                     dim,
-                    (uint32_t)(std::dynamic_pointer_cast<
-                                   FieldData<SparseFloatVector>>(field_data)
-                                   ->Dim()));
+                    (uint32_t)(
+                        std::dynamic_pointer_cast<FieldData<SparseFloatVector>>(
+                            field_data)
+                            ->Dim()));
                 auto sparse_rows =
                     static_cast<const knowhere::sparse::SparseRow<float>*>(
                         field_data->Data());


### PR DESCRIPTION
StringIndexMarisa (Trie index) was missing SupportPatternMatch() and PatternMatch() overrides, causing the expression evaluation framework to bypass the trie's efficient predictive_search-based PrefixMatch and fall back to O(n) brute-force scan via Reverse_Lookup for every row.

This regression was introduced when the expression framework was refactored to use UnaryIndexFunc/UnaryIndexFuncForMatch instead of the old StringIndex::Query(dataset) path. Other index types (StringIndexSort, InvertedIndexTantivy, BitmapIndex) were updated to implement these interfaces, but StringIndexMarisa was missed.

Cherry-pick of #48688 to 2.5 branch.

issue: https://github.com/milvus-io/milvus/issues/48685
pr: #48688