### PR TITLE
fix: [2.5] self-heal compaction segment positions and add L0 force-select bypass

### DIFF
--- a/internal/datacoord/compaction_l0_view.go
+++ b/internal/datacoord/compaction_l0_view.go
@@ -2,12 +2,32 @@ package datacoord
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/samber/lo"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
+
+// resolveLatestDeletePos returns the position used as the L0 trigger Pos.
+// When dataCoord.compaction.levelzero.forceSelectAllSegments is enabled, it
+// returns a max-timestamp position so that all L1/L2 segments pass the
+// startPos < taskPos filter in selectSealedSegment — used during repair to
+// recover from wrong StartPosition metadata caused by the import position bug.
+func resolveLatestDeletePos(pos *msgpb.MsgPosition) *msgpb.MsgPosition {
+	if paramtable.Get().DataCoordCfg.LevelZeroCompactionForceSelectAll.GetAsBool() {
+		channel := ""
+		if pos != nil {
+			channel = pos.GetChannelName()
+		}
+		return &msgpb.MsgPosition{
+			ChannelName: channel,
+			Timestamp:   math.MaxUint64,
+		}
+	}
+	return pos
+}
 
 // The LevelZeroSegments keeps the min group
 type LevelZeroSegmentsView struct {
@@ -85,7 +105,7 @@ func (v *LevelZeroSegmentsView) ForceTrigger() (CompactionView, string) {
 		return &LevelZeroSegmentsView{
 			label:                     v.label,
 			segments:                  targetViews,
-			earliestGrowingSegmentPos: v.earliestGrowingSegmentPos,
+			earliestGrowingSegmentPos: resolveLatestDeletePos(v.earliestGrowingSegmentPos),
 		}, reason
 	}
 
@@ -104,7 +124,7 @@ func (v *LevelZeroSegmentsView) Trigger() (CompactionView, string) {
 		return &LevelZeroSegmentsView{
 			label:                     v.label,
 			segments:                  targetViews,
-			earliestGrowingSegmentPos: v.earliestGrowingSegmentPos,
+			earliestGrowingSegmentPos: resolveLatestDeletePos(v.earliestGrowingSegmentPos),
 		}, reason
 	}
 

--- a/internal/datacoord/compaction_l0_view_test.go
+++ b/internal/datacoord/compaction_l0_view_test.go
@@ -1,6 +1,7 @@
 package datacoord
 
 import (
+	"math"
 	"testing"
 
 	"github.com/samber/lo"
@@ -11,6 +12,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
 func TestLevelZeroSegmentsViewSuite(t *testing.T) {
@@ -254,4 +256,84 @@ func (s *LevelZeroSegmentsViewSuite) TestForceTrigger() {
 			log.Info("test forceTrigger", zap.Any("trigger reason", reason))
 		})
 	}
+}
+
+func (s *LevelZeroSegmentsViewSuite) TestResolveLatestDeletePos() {
+	paramtable.Init()
+	dmlPos := &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 12345}
+
+	s.Run("default_returns_dml_pos", func() {
+		paramtable.Get().Save("dataCoord.compaction.levelzero.forceSelectAllSegments", "false")
+		defer paramtable.Get().Reset("dataCoord.compaction.levelzero.forceSelectAllSegments")
+
+		got := resolveLatestDeletePos(dmlPos)
+		s.Equal(dmlPos, got)
+	})
+
+	s.Run("force_select_returns_max_timestamp", func() {
+		paramtable.Get().Save("dataCoord.compaction.levelzero.forceSelectAllSegments", "true")
+		defer paramtable.Get().Reset("dataCoord.compaction.levelzero.forceSelectAllSegments")
+
+		got := resolveLatestDeletePos(dmlPos)
+		s.Equal(uint64(math.MaxUint64), got.GetTimestamp())
+		s.Equal("ch-1", got.GetChannelName())
+	})
+
+	s.Run("force_select_with_nil_pos", func() {
+		paramtable.Get().Save("dataCoord.compaction.levelzero.forceSelectAllSegments", "true")
+		defer paramtable.Get().Reset("dataCoord.compaction.levelzero.forceSelectAllSegments")
+
+		got := resolveLatestDeletePos(nil)
+		s.Equal(uint64(math.MaxUint64), got.GetTimestamp())
+		s.Equal("", got.GetChannelName())
+	})
+
+	s.Run("trigger_uses_resolved_pos_when_force_select_enabled", func() {
+		paramtable.Get().Save("dataCoord.compaction.levelzero.forceSelectAllSegments", "true")
+		defer paramtable.Get().Reset("dataCoord.compaction.levelzero.forceSelectAllSegments")
+
+		label := s.v.GetGroupLabel()
+		views := []*SegmentView{
+			genTestL0SegmentView(100, label, 20000),
+			genTestL0SegmentView(101, label, 10000),
+			genTestL0SegmentView(102, label, 30000),
+		}
+		for _, v := range views {
+			v.DeltalogCount = 100
+			v.DeltaSize = 1
+			v.DeltaRowCount = 1
+		}
+		s.v.segments = views
+		s.v.earliestGrowingSegmentPos = &msgpb.MsgPosition{Timestamp: 100000}
+
+		gotView, _ := s.v.Trigger()
+		s.Require().NotNil(gotView)
+		levelZeroView, ok := gotView.(*LevelZeroSegmentsView)
+		s.Require().True(ok)
+		s.Equal(uint64(math.MaxUint64), levelZeroView.earliestGrowingSegmentPos.GetTimestamp())
+	})
+
+	s.Run("force_trigger_uses_resolved_pos_when_force_select_enabled", func() {
+		paramtable.Get().Save("dataCoord.compaction.levelzero.forceSelectAllSegments", "true")
+		defer paramtable.Get().Reset("dataCoord.compaction.levelzero.forceSelectAllSegments")
+
+		label := s.v.GetGroupLabel()
+		views := []*SegmentView{
+			genTestL0SegmentView(100, label, 20000),
+			genTestL0SegmentView(101, label, 10000),
+		}
+		for _, v := range views {
+			v.DeltalogCount = 1
+			v.DeltaSize = 1
+			v.DeltaRowCount = 1
+		}
+		s.v.segments = views
+		s.v.earliestGrowingSegmentPos = &msgpb.MsgPosition{Timestamp: 100000}
+
+		gotView, _ := s.v.ForceTrigger()
+		s.Require().NotNil(gotView)
+		levelZeroView, ok := gotView.(*LevelZeroSegmentsView)
+		s.Require().True(ok)
+		s.Equal(uint64(math.MaxUint64), levelZeroView.earliestGrowingSegmentPos.GetTimestamp())
+	})
 }

--- a/internal/datacoord/compaction_task_l0_test.go
+++ b/internal/datacoord/compaction_task_l0_test.go
@@ -27,10 +27,12 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/datacoord/session"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
 func TestL0CompactionTaskSuite(t *testing.T) {
@@ -566,5 +568,152 @@ func (s *L0CompactionTaskSuite) TestSetterGetter() {
 		s.mockMeta.EXPECT().SaveCompactionTask(mock.Anything, mock.Anything).Return(nil)
 		t.SetNodeID(1000)
 		s.EqualValues(1000, t.GetTaskProto().GetNodeID())
+	})
+}
+
+// TestSelectSealedSegment_ForceSelectAllFlag exercises the flag end-to-end:
+// build an L0 view, call Trigger() with the flag off / on, feed the resulting
+// earliestGrowingSegmentPos into an l0CompactionTask (the same wiring
+// compaction_trigger_v2.go uses), and verify selectSealedSegment's output
+// actually changes based on the flag. A high-StartPosition segment (the
+// shape silently dropped by the import-position bug) is excluded with the
+// flag off and included with the flag on.
+func (s *L0CompactionTaskSuite) TestSelectSealedSegment_ForceSelectAllFlag() {
+	paramtable.Init()
+	const flagKey = "dataCoord.compaction.levelzero.forceSelectAllSegments"
+
+	channel := "ch-1"
+	collectionID := int64(1)
+	partitionID := int64(10)
+	label := &CompactionGroupLabel{
+		CollectionID: collectionID,
+		PartitionID:  partitionID,
+		Channel:      channel,
+	}
+
+	// Flushed L1 segments visible to selectSealedSegment. The one with
+	// StartPosition > realL0DmlTs is the case we care about — it would
+	// normally be filtered out by `startPos < taskPos`.
+	const realL0DmlTs = uint64(5000)
+	lowPosSeg := &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{
+		ID:            200,
+		CollectionID:  collectionID,
+		PartitionID:   partitionID,
+		InsertChannel: channel,
+		Level:         datapb.SegmentLevel_L1,
+		State:         commonpb.SegmentState_Flushed,
+		StartPosition: &msgpb.MsgPosition{ChannelName: channel, Timestamp: 3000},
+	}}
+	highPosSeg := &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{
+		ID:            201,
+		CollectionID:  collectionID,
+		PartitionID:   partitionID,
+		InsertChannel: channel,
+		Level:         datapb.SegmentLevel_L1,
+		State:         commonpb.SegmentState_Flushed,
+		StartPosition: &msgpb.MsgPosition{ChannelName: channel, Timestamp: 20000},
+	}}
+
+	// Mockery's SelectSegments returns whatever we tell it without applying
+	// filters. We need the real filter logic to run so the `startPos <
+	// taskPos` predicate is actually exercised — install RunAndReturn that
+	// evaluates each SegmentFilter.Match against our fixed segment set.
+	installFilteringMock := func() {
+		s.mockMeta.EXPECT().SelectSegments(mock.Anything, mock.Anything, mock.Anything).
+			RunAndReturn(func(ctx context.Context, filters ...SegmentFilter) []*SegmentInfo {
+				all := []*SegmentInfo{lowPosSeg, highPosSeg}
+				result := make([]*SegmentInfo, 0, len(all))
+				for _, seg := range all {
+					matched := true
+					for _, f := range filters {
+						if !f.Match(seg) {
+							matched = false
+							break
+						}
+					}
+					if matched {
+						result = append(result, seg)
+					}
+				}
+				return result
+			})
+	}
+
+	// Build an L0 view with a couple of L0 segments whose dmlPos is
+	// `realL0DmlTs`. Trigger() runs resolveLatestDeletePos under the current
+	// flag value, so the returned view's earliestGrowingSegmentPos reflects
+	// the flag.
+	buildView := func() *LevelZeroSegmentsView {
+		l0Segs := []*SegmentView{
+			{
+				ID:            100,
+				label:         label,
+				dmlPos:        &msgpb.MsgPosition{ChannelName: channel, Timestamp: realL0DmlTs},
+				Level:         datapb.SegmentLevel_L0,
+				State:         commonpb.SegmentState_Flushed,
+				DeltalogCount: 100,
+				DeltaSize:     1,
+				DeltaRowCount: 1,
+			},
+			{
+				ID:            101,
+				label:         label,
+				dmlPos:        &msgpb.MsgPosition{ChannelName: channel, Timestamp: realL0DmlTs},
+				Level:         datapb.SegmentLevel_L0,
+				State:         commonpb.SegmentState_Flushed,
+				DeltalogCount: 100,
+				DeltaSize:     1,
+				DeltaRowCount: 1,
+			},
+		}
+		return &LevelZeroSegmentsView{
+			label:                     label,
+			segments:                  l0Segs,
+			earliestGrowingSegmentPos: &msgpb.MsgPosition{ChannelName: channel, Timestamp: realL0DmlTs},
+		}
+	}
+
+	// Mirrors compaction_trigger_v2.go — feed the triggered view's
+	// earliestGrowingSegmentPos into task.Pos and run selectSealedSegment.
+	runSelectWithTriggeredPos := func() []int64 {
+		installFilteringMock()
+		srcView := buildView()
+		triggered, reason := srcView.Trigger()
+		s.Require().NotNil(triggered, "Trigger returned nil: %s", reason)
+		triggeredView := triggered.(*LevelZeroSegmentsView)
+
+		task := newL0CompactionTask(&datapb.CompactionTask{
+			PlanID:        1,
+			TriggerID:     19530,
+			CollectionID:  collectionID,
+			PartitionID:   partitionID,
+			Channel:       channel,
+			Type:          datapb.CompactionType_Level0DeleteCompaction,
+			NodeID:        1,
+			State:         datapb.CompactionTaskState_executing,
+			InputSegments: []int64{100, 101},
+			Pos:           triggeredView.earliestGrowingSegmentPos,
+		}, s.mockAlloc, s.mockMeta, s.mockSessMgr)
+
+		sealed, _ := task.selectSealedSegment()
+		return lo.Map(sealed, func(seg *SegmentInfo, _ int) int64 { return seg.GetID() })
+	}
+
+	s.Run("flag_off_excludes_high_start_position_segment", func() {
+		paramtable.Get().Save(flagKey, "false")
+		defer paramtable.Get().Reset(flagKey)
+
+		gotIDs := runSelectWithTriggeredPos()
+		s.ElementsMatch([]int64{200}, gotIDs,
+			"with flag off, segment 201 (StartPosition=20000 > taskPos=%d) must be excluded", realL0DmlTs)
+	})
+
+	s.Run("flag_on_includes_high_start_position_segment", func() {
+		paramtable.Get().Save(flagKey, "true")
+		defer paramtable.Get().Reset(flagKey)
+
+		gotIDs := runSelectWithTriggeredPos()
+		s.ElementsMatch([]int64{200, 201}, gotIDs,
+			"with flag on, resolveLatestDeletePos must lift taskPos so segment 201 is included")
 	})
 }

--- a/internal/datacoord/compaction_task_l0_test.go
+++ b/internal/datacoord/compaction_task_l0_test.go
@@ -667,9 +667,14 @@ func (s *L0CompactionTaskSuite) TestSelectSealedSegment_ForceSelectAllFlag() {
 			},
 		}
 		return &LevelZeroSegmentsView{
-			label:                     label,
-			segments:                  l0Segs,
-			earliestGrowingSegmentPos: &msgpb.MsgPosition{ChannelName: channel, Timestamp: realL0DmlTs},
+			label:    label,
+			segments: l0Segs,
+			// Must be strictly greater than realL0DmlTs so L0 segments pass the
+			// dmlPos < earliestGrowingSegmentPos filter inside Trigger(), and
+			// strictly less than highPosSeg.StartPosition (20000) so that the
+			// flag-off case excludes highPosSeg while the flag-on case (MaxUint64)
+			// includes it.
+			earliestGrowingSegmentPos: &msgpb.MsgPosition{ChannelName: channel, Timestamp: 10000},
 		}
 	}
 

--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -1595,6 +1595,37 @@ func getMinPosition(positions []*msgpb.MsgPosition) *msgpb.MsgPosition {
 	return minPos
 }
 
+func getMaxPosition(positions []*msgpb.MsgPosition) *msgpb.MsgPosition {
+	var maxPos *msgpb.MsgPosition
+	for _, pos := range positions {
+		if maxPos == nil ||
+			pos != nil && pos.GetTimestamp() > maxPos.GetTimestamp() {
+			maxPos = pos
+		}
+	}
+	return maxPos
+}
+
+// recalculateSegmentPosition recalculates StartPosition and DmlPosition from
+// actual binlog timestamps on the compaction result segment. This makes compaction
+// self-healing: wrong positions from import or prior compaction are corrected.
+// Also fixes the DmlPosition bug where getMinPosition was used instead of max.
+// Falls back to the provided fallback positions if binlog timestamps are unavailable
+// (e.g., legacy segments without TimestampFrom/TimestampTo populated).
+func recalculateSegmentPosition(binlogs []*datapb.FieldBinlog, channel string, fallbackStart, fallbackDml *msgpb.MsgPosition) (startPos, dmlPos *msgpb.MsgPosition) {
+	minTs, maxTs := extractTimestampFromBinlogs(binlogs)
+	if minTs > 0 && minTs != math.MaxUint64 && maxTs > 0 {
+		return &msgpb.MsgPosition{
+				ChannelName: channel,
+				Timestamp:   minTs,
+			}, &msgpb.MsgPosition{
+				ChannelName: channel,
+				Timestamp:   maxTs,
+			}
+	}
+	return fallbackStart, fallbackDml
+}
+
 func (m *meta) completeClusterCompactionMutation(t *datapb.CompactionTask, result *datapb.CompactionPlanResult) ([]*SegmentInfo, *segMetricMutation, error) {
 	log := log.Ctx(context.TODO()).With(zap.Int64("planID", t.GetPlanID()),
 		zap.String("type", t.GetType().String()),
@@ -1620,7 +1651,16 @@ func (m *meta) completeClusterCompactionMutation(t *datapb.CompactionTask, resul
 		compactFromSegIDs = append(compactFromSegIDs, cloned.GetID())
 	}
 
+	// Compute fallback positions from source segments (used when binlog timestamps unavailable)
+	fallbackStart := getMinPosition(lo.Map(compactFromSegInfos, func(info *SegmentInfo, _ int) *msgpb.MsgPosition {
+		return info.GetStartPosition()
+	}))
+	fallbackDml := getMaxPosition(lo.Map(compactFromSegInfos, func(info *SegmentInfo, _ int) *msgpb.MsgPosition {
+		return info.GetDmlPosition()
+	}))
+
 	for _, seg := range result.GetSegments() {
+		startPos, dmlPos := recalculateSegmentPosition(seg.GetInsertLogs(), t.GetChannel(), fallbackStart, fallbackDml)
 		segmentInfo := &datapb.SegmentInfo{
 			ID:                  seg.GetSegmentID(),
 			CollectionID:        compactFromSegInfos[0].CollectionID,
@@ -1635,12 +1675,8 @@ func (m *meta) completeClusterCompactionMutation(t *datapb.CompactionTask, resul
 			CompactionFrom:      compactFromSegIDs,
 			LastExpireTime:      tsoutil.ComposeTSByTime(time.Unix(t.GetStartTime(), 0), 0),
 			Level:               datapb.SegmentLevel_L2,
-			StartPosition: getMinPosition(lo.Map(compactFromSegInfos, func(info *SegmentInfo, _ int) *msgpb.MsgPosition {
-				return info.GetStartPosition()
-			})),
-			DmlPosition: getMinPosition(lo.Map(compactFromSegInfos, func(info *SegmentInfo, _ int) *msgpb.MsgPosition {
-				return info.GetDmlPosition()
-			})),
+			StartPosition:       startPos,
+			DmlPosition:         dmlPos,
 			// visible after stats and index
 			IsInvisible: true,
 		}
@@ -1702,8 +1738,17 @@ func (m *meta) completeMixCompactionMutation(t *datapb.CompactionTask, result *d
 
 	log = log.With(zap.Int64s("compactFrom", compactFromSegIDs))
 
+	// Compute fallback positions from source segments (used when binlog timestamps unavailable)
+	fallbackStart := getMinPosition(lo.Map(compactFromSegInfos, func(info *SegmentInfo, _ int) *msgpb.MsgPosition {
+		return info.GetStartPosition()
+	}))
+	fallbackDml := getMaxPosition(lo.Map(compactFromSegInfos, func(info *SegmentInfo, _ int) *msgpb.MsgPosition {
+		return info.GetDmlPosition()
+	}))
+
 	compactToSegments := make([]*SegmentInfo, 0)
 	for _, compactToSegment := range result.GetSegments() {
+		startPos, dmlPos := recalculateSegmentPosition(compactToSegment.GetInsertLogs(), t.GetChannel(), fallbackStart, fallbackDml)
 		compactToSegmentInfo := NewSegmentInfo(
 			&datapb.SegmentInfo{
 				ID:            compactToSegment.GetSegmentID(),
@@ -1723,13 +1768,9 @@ func (m *meta) completeMixCompactionMutation(t *datapb.CompactionTask, result *d
 				LastExpireTime:      tsoutil.ComposeTSByTime(time.Unix(t.GetStartTime(), 0), 0),
 				Level:               datapb.SegmentLevel_L1,
 
-				StartPosition: getMinPosition(lo.Map(compactFromSegInfos, func(info *SegmentInfo, _ int) *msgpb.MsgPosition {
-					return info.GetStartPosition()
-				})),
-				DmlPosition: getMinPosition(lo.Map(compactFromSegInfos, func(info *SegmentInfo, _ int) *msgpb.MsgPosition {
-					return info.GetDmlPosition()
-				})),
-				IsSorted: compactToSegment.GetIsSorted(),
+				StartPosition: startPos,
+				DmlPosition:   dmlPos,
+				IsSorted:      compactToSegment.GetIsSorted(),
 			})
 
 		if compactToSegmentInfo.GetNumOfRows() == 0 {
@@ -2163,14 +2204,17 @@ func (m *meta) SaveStatsResultSegment(oldSegmentID int64, result *workerpb.Stats
 		resultInvisible = false
 	}
 
+	startPos, dmlPos := recalculateSegmentPosition(result.GetInsertLogs(), oldSegment.GetInsertChannel(),
+		oldSegment.GetStartPosition(), oldSegment.GetDmlPosition())
+
 	segmentInfo := &datapb.SegmentInfo{
 		CollectionID:   oldSegment.GetCollectionID(),
 		PartitionID:    oldSegment.GetPartitionID(),
 		InsertChannel:  oldSegment.GetInsertChannel(),
 		MaxRowNum:      oldSegment.GetMaxRowNum(),
 		LastExpireTime: oldSegment.GetLastExpireTime(),
-		StartPosition:  oldSegment.GetStartPosition(),
-		DmlPosition:    oldSegment.GetDmlPosition(),
+		StartPosition:  startPos,
+		DmlPosition:    dmlPos,
 		IsImporting:    oldSegment.GetIsImporting(),
 		StorageVersion: oldSegment.GetStorageVersion(),
 		// only flushed segment can do sort stats

--- a/internal/datacoord/meta_test.go
+++ b/internal/datacoord/meta_test.go
@@ -427,6 +427,344 @@ func (suite *MetaBasicSuite) TestCompleteCompactionMutation() {
 	})
 }
 
+func (suite *MetaBasicSuite) TestGetMaxPosition() {
+	suite.Run("nil_positions", func() {
+		pos := getMaxPosition(nil)
+		suite.Nil(pos)
+	})
+
+	suite.Run("single_position", func() {
+		p := &msgpb.MsgPosition{Timestamp: 100}
+		pos := getMaxPosition([]*msgpb.MsgPosition{p})
+		suite.Equal(uint64(100), pos.GetTimestamp())
+	})
+
+	suite.Run("multiple_positions", func() {
+		pos := getMaxPosition([]*msgpb.MsgPosition{
+			{Timestamp: 100},
+			{Timestamp: 300},
+			{Timestamp: 200},
+		})
+		suite.Equal(uint64(300), pos.GetTimestamp())
+	})
+
+	suite.Run("with_nil_entries", func() {
+		pos := getMaxPosition([]*msgpb.MsgPosition{
+			nil,
+			{Timestamp: 50},
+			nil,
+			{Timestamp: 200},
+		})
+		suite.Equal(uint64(200), pos.GetTimestamp())
+	})
+}
+
+func (suite *MetaBasicSuite) TestRecalculateSegmentPosition() {
+	channel := "ch-1"
+	fallbackStart := &msgpb.MsgPosition{ChannelName: channel, Timestamp: 10}
+	fallbackDml := &msgpb.MsgPosition{ChannelName: channel, Timestamp: 90}
+
+	suite.Run("recalculates_from_binlog_timestamps", func() {
+		binlogs := []*datapb.FieldBinlog{
+			{
+				FieldID: 0,
+				Binlogs: []*datapb.Binlog{
+					{LogID: 1, TimestampFrom: 100, TimestampTo: 200},
+					{LogID: 2, TimestampFrom: 150, TimestampTo: 300},
+				},
+			},
+			{
+				FieldID: 1,
+				Binlogs: []*datapb.Binlog{
+					{LogID: 3, TimestampFrom: 80, TimestampTo: 250},
+				},
+			},
+		}
+		startPos, dmlPos := recalculateSegmentPosition(binlogs, channel, fallbackStart, fallbackDml)
+		suite.Equal(uint64(80), startPos.GetTimestamp())
+		suite.Equal(uint64(300), dmlPos.GetTimestamp())
+		suite.Equal(channel, startPos.GetChannelName())
+		suite.Equal(channel, dmlPos.GetChannelName())
+	})
+
+	suite.Run("fallback_when_timestamps_zero", func() {
+		binlogs := []*datapb.FieldBinlog{
+			{
+				FieldID: 0,
+				Binlogs: []*datapb.Binlog{
+					{LogID: 1, TimestampFrom: 0, TimestampTo: 0},
+				},
+			},
+		}
+		startPos, dmlPos := recalculateSegmentPosition(binlogs, channel, fallbackStart, fallbackDml)
+		suite.Equal(fallbackStart, startPos)
+		suite.Equal(fallbackDml, dmlPos)
+	})
+
+	suite.Run("fallback_when_no_binlogs", func() {
+		startPos, dmlPos := recalculateSegmentPosition(nil, channel, fallbackStart, fallbackDml)
+		suite.Equal(fallbackStart, startPos)
+		suite.Equal(fallbackDml, dmlPos)
+	})
+
+	suite.Run("fallback_when_empty_binlogs", func() {
+		startPos, dmlPos := recalculateSegmentPosition([]*datapb.FieldBinlog{}, channel, fallbackStart, fallbackDml)
+		suite.Equal(fallbackStart, startPos)
+		suite.Equal(fallbackDml, dmlPos)
+	})
+}
+
+func (suite *MetaBasicSuite) TestCompleteCompactionMutation_RecalculatePositions() {
+	mockChMgr := mocks.NewChunkManager(suite.T())
+
+	// Helper to build FieldBinlog with timestamps
+	fieldBinlogWithTimestamps := func(fieldID int64, logID int64, tsFrom, tsTo uint64) *datapb.FieldBinlog {
+		return &datapb.FieldBinlog{
+			FieldID: fieldID,
+			Binlogs: []*datapb.Binlog{
+				{LogID: logID, TimestampFrom: tsFrom, TimestampTo: tsTo},
+			},
+		}
+	}
+
+	suite.Run("mix_compaction_recalculates_positions_from_binlogs", func() {
+		latestSegments := NewSegmentsInfo()
+		for segID, segment := range map[UniqueID]*SegmentInfo{
+			1: {SegmentInfo: &datapb.SegmentInfo{
+				ID:            1,
+				CollectionID:  100,
+				PartitionID:   10,
+				State:         commonpb.SegmentState_Flushed,
+				Level:         datapb.SegmentLevel_L1,
+				Binlogs:       []*datapb.FieldBinlog{getFieldBinlogIDs(0, 10000)},
+				Statslogs:     []*datapb.FieldBinlog{getFieldBinlogIDs(0, 20000)},
+				NumOfRows:     2,
+				StartPosition: &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 999},
+				DmlPosition:   &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 1},
+			}},
+			2: {SegmentInfo: &datapb.SegmentInfo{
+				ID:            2,
+				CollectionID:  100,
+				PartitionID:   10,
+				State:         commonpb.SegmentState_Flushed,
+				Level:         datapb.SegmentLevel_L1,
+				Binlogs:       []*datapb.FieldBinlog{getFieldBinlogIDs(0, 11000)},
+				Statslogs:     []*datapb.FieldBinlog{getFieldBinlogIDs(0, 21000)},
+				NumOfRows:     2,
+				StartPosition: &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 888},
+				DmlPosition:   &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 2},
+			}},
+		} {
+			latestSegments.SetSegment(segID, segment)
+		}
+
+		result := &datapb.CompactionPlanResult{
+			Segments: []*datapb.CompactionSegment{{
+				SegmentID:           3,
+				InsertLogs:          []*datapb.FieldBinlog{fieldBinlogWithTimestamps(0, 50000, 100, 500)},
+				Field2StatslogPaths: []*datapb.FieldBinlog{getFieldBinlogIDs(0, 50001)},
+				NumOfRows:           4,
+			}},
+		}
+		task := &datapb.CompactionTask{
+			InputSegments: []UniqueID{1, 2},
+			Type:          datapb.CompactionType_MixCompaction,
+			Channel:       "ch-1",
+		}
+		m := &meta{
+			catalog:      &datacoord.Catalog{MetaKv: NewMetaMemoryKV()},
+			segments:     latestSegments,
+			chunkManager: mockChMgr,
+		}
+
+		infos, _, err := m.CompleteCompactionMutation(context.TODO(), task, result)
+		suite.NoError(err)
+		suite.Require().Equal(1, len(infos))
+
+		// Should use binlog timestamps, NOT inherited positions
+		suite.Equal(uint64(100), infos[0].GetStartPosition().GetTimestamp())
+		suite.Equal(uint64(500), infos[0].GetDmlPosition().GetTimestamp())
+		suite.Equal("ch-1", infos[0].GetStartPosition().GetChannelName())
+	})
+
+	suite.Run("mix_compaction_fallback_when_no_timestamps", func() {
+		latestSegments := NewSegmentsInfo()
+		for segID, segment := range map[UniqueID]*SegmentInfo{
+			1: {SegmentInfo: &datapb.SegmentInfo{
+				ID:            1,
+				CollectionID:  100,
+				PartitionID:   10,
+				State:         commonpb.SegmentState_Flushed,
+				Level:         datapb.SegmentLevel_L1,
+				Binlogs:       []*datapb.FieldBinlog{getFieldBinlogIDs(0, 10000)},
+				Statslogs:     []*datapb.FieldBinlog{getFieldBinlogIDs(0, 20000)},
+				NumOfRows:     2,
+				StartPosition: &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 50},
+				DmlPosition:   &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 200},
+			}},
+			2: {SegmentInfo: &datapb.SegmentInfo{
+				ID:            2,
+				CollectionID:  100,
+				PartitionID:   10,
+				State:         commonpb.SegmentState_Flushed,
+				Level:         datapb.SegmentLevel_L1,
+				Binlogs:       []*datapb.FieldBinlog{getFieldBinlogIDs(0, 11000)},
+				Statslogs:     []*datapb.FieldBinlog{getFieldBinlogIDs(0, 21000)},
+				NumOfRows:     2,
+				StartPosition: &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 100},
+				DmlPosition:   &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 300},
+			}},
+		} {
+			latestSegments.SetSegment(segID, segment)
+		}
+
+		// Result binlogs have no timestamps (legacy)
+		result := &datapb.CompactionPlanResult{
+			Segments: []*datapb.CompactionSegment{{
+				SegmentID:           3,
+				InsertLogs:          []*datapb.FieldBinlog{getFieldBinlogIDs(0, 50000)},
+				Field2StatslogPaths: []*datapb.FieldBinlog{getFieldBinlogIDs(0, 50001)},
+				NumOfRows:           4,
+			}},
+		}
+		task := &datapb.CompactionTask{
+			InputSegments: []UniqueID{1, 2},
+			Type:          datapb.CompactionType_MixCompaction,
+			Channel:       "ch-1",
+		}
+		m := &meta{
+			catalog:      &datacoord.Catalog{MetaKv: NewMetaMemoryKV()},
+			segments:     latestSegments,
+			chunkManager: mockChMgr,
+		}
+
+		infos, _, err := m.CompleteCompactionMutation(context.TODO(), task, result)
+		suite.NoError(err)
+		suite.Require().Equal(1, len(infos))
+
+		// Fallback: StartPosition = min, DmlPosition = max of source segments
+		suite.Equal(uint64(50), infos[0].GetStartPosition().GetTimestamp())
+		suite.Equal(uint64(300), infos[0].GetDmlPosition().GetTimestamp())
+	})
+
+	suite.Run("cluster_compaction_recalculates_positions", func() {
+		latestSegments := NewSegmentsInfo()
+		for segID, segment := range map[UniqueID]*SegmentInfo{
+			1: {SegmentInfo: &datapb.SegmentInfo{
+				ID:            1,
+				CollectionID:  100,
+				PartitionID:   10,
+				State:         commonpb.SegmentState_Flushed,
+				Level:         datapb.SegmentLevel_L1,
+				Binlogs:       []*datapb.FieldBinlog{getFieldBinlogIDs(0, 10000)},
+				Statslogs:     []*datapb.FieldBinlog{getFieldBinlogIDs(0, 20000)},
+				NumOfRows:     2,
+				StartPosition: &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 999},
+				DmlPosition:   &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 1},
+			}},
+			2: {SegmentInfo: &datapb.SegmentInfo{
+				ID:            2,
+				CollectionID:  100,
+				PartitionID:   10,
+				State:         commonpb.SegmentState_Flushed,
+				Level:         datapb.SegmentLevel_L1,
+				Binlogs:       []*datapb.FieldBinlog{getFieldBinlogIDs(0, 11000)},
+				Statslogs:     []*datapb.FieldBinlog{getFieldBinlogIDs(0, 21000)},
+				NumOfRows:     2,
+				StartPosition: &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 888},
+				DmlPosition:   &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 2},
+			}},
+		} {
+			latestSegments.SetSegment(segID, segment)
+		}
+
+		result := &datapb.CompactionPlanResult{
+			Segments: []*datapb.CompactionSegment{{
+				SegmentID:           3,
+				InsertLogs:          []*datapb.FieldBinlog{fieldBinlogWithTimestamps(0, 50000, 150, 600)},
+				Field2StatslogPaths: []*datapb.FieldBinlog{getFieldBinlogIDs(0, 50001)},
+				NumOfRows:           4,
+			}},
+		}
+		task := &datapb.CompactionTask{
+			InputSegments: []UniqueID{1, 2},
+			Type:          datapb.CompactionType_ClusteringCompaction,
+			Channel:       "ch-1",
+		}
+		m := &meta{
+			catalog:      &datacoord.Catalog{MetaKv: NewMetaMemoryKV()},
+			segments:     latestSegments,
+			chunkManager: mockChMgr,
+		}
+
+		infos, _, err := m.CompleteCompactionMutation(context.TODO(), task, result)
+		suite.NoError(err)
+		suite.Require().Equal(1, len(infos))
+
+		suite.Equal(uint64(150), infos[0].GetStartPosition().GetTimestamp())
+		suite.Equal(uint64(600), infos[0].GetDmlPosition().GetTimestamp())
+		suite.Equal(datapb.SegmentLevel_L2, infos[0].GetLevel())
+	})
+
+	suite.Run("cluster_compaction_fallback_when_no_timestamps", func() {
+		latestSegments := NewSegmentsInfo()
+		for segID, segment := range map[UniqueID]*SegmentInfo{
+			1: {SegmentInfo: &datapb.SegmentInfo{
+				ID:            1,
+				CollectionID:  100,
+				PartitionID:   10,
+				State:         commonpb.SegmentState_Flushed,
+				Level:         datapb.SegmentLevel_L1,
+				Binlogs:       []*datapb.FieldBinlog{getFieldBinlogIDs(0, 10000)},
+				Statslogs:     []*datapb.FieldBinlog{getFieldBinlogIDs(0, 20000)},
+				NumOfRows:     2,
+				StartPosition: &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 50},
+				DmlPosition:   &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 400},
+			}},
+			2: {SegmentInfo: &datapb.SegmentInfo{
+				ID:            2,
+				CollectionID:  100,
+				PartitionID:   10,
+				State:         commonpb.SegmentState_Flushed,
+				Level:         datapb.SegmentLevel_L1,
+				Binlogs:       []*datapb.FieldBinlog{getFieldBinlogIDs(0, 11000)},
+				Statslogs:     []*datapb.FieldBinlog{getFieldBinlogIDs(0, 21000)},
+				NumOfRows:     2,
+				StartPosition: &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 80},
+				DmlPosition:   &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 500},
+			}},
+		} {
+			latestSegments.SetSegment(segID, segment)
+		}
+
+		result := &datapb.CompactionPlanResult{
+			Segments: []*datapb.CompactionSegment{{
+				SegmentID:           3,
+				InsertLogs:          []*datapb.FieldBinlog{getFieldBinlogIDs(0, 50000)},
+				Field2StatslogPaths: []*datapb.FieldBinlog{getFieldBinlogIDs(0, 50001)},
+				NumOfRows:           4,
+			}},
+		}
+		task := &datapb.CompactionTask{
+			InputSegments: []UniqueID{1, 2},
+			Type:          datapb.CompactionType_ClusteringCompaction,
+			Channel:       "ch-1",
+		}
+		m := &meta{
+			catalog:      &datacoord.Catalog{MetaKv: NewMetaMemoryKV()},
+			segments:     latestSegments,
+			chunkManager: mockChMgr,
+		}
+
+		infos, _, err := m.CompleteCompactionMutation(context.TODO(), task, result)
+		suite.NoError(err)
+		suite.Require().Equal(1, len(infos))
+
+		suite.Equal(uint64(50), infos[0].GetStartPosition().GetTimestamp())
+		suite.Equal(uint64(500), infos[0].GetDmlPosition().GetTimestamp())
+	})
+}
+
 func (suite *MetaBasicSuite) TestSetSegment() {
 	meta := suite.meta
 	catalog := mocks2.NewDataCoordCatalog(suite.T())

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3918,6 +3918,7 @@ type dataCoordConfig struct {
 	LevelZeroCompactionTriggerMaxSize        ParamItem `refreshable:"true"`
 	LevelZeroCompactionTriggerDeltalogMinNum ParamItem `refreshable:"true"`
 	LevelZeroCompactionTriggerDeltalogMaxNum ParamItem `refreshable:"true"`
+	LevelZeroCompactionForceSelectAll        ParamItem `refreshable:"true"`
 
 	// Garbage Collection
 	EnableGarbageCollection ParamItem `refreshable:"false"`
@@ -4445,6 +4446,16 @@ During compaction, the size of segment # of rows is able to exceed segment max #
 		Export:       true,
 	}
 	p.LevelZeroCompactionTriggerDeltalogMaxNum.Init(base.mgr)
+
+	p.LevelZeroCompactionForceSelectAll = ParamItem{
+		Key:          "dataCoord.compaction.levelzero.forceSelectAllSegments",
+		Version:      "2.5.28",
+		DefaultValue: "false",
+		Doc: "When enabled, L0 compaction selects all L1/L2 segments regardless of position filtering. " +
+			"Use during repair to bypass wrong StartPosition metadata from the import position bug.",
+		Export: false,
+	}
+	p.LevelZeroCompactionForceSelectAll.Init(base.mgr)
 
 	p.IndexMemSizeEstimateMultiplier = ParamItem{
 		Key:          "dataCoord.index.memSizeEstimateMultiplier",


### PR DESCRIPTION
Compaction inherits StartPosition/DmlPosition from source segments via getMinPosition without recalculating from actual data. The import position bug (PR #47276) wrote wrong timestamps on imported segments, and these wrong positions persist and propagate through compaction. L0 compaction then misses L1/L2 segments due to StartPosition mismatches, causing zombie L0 segments and silent delete loss.

There is also a latent bug: DmlPosition in mix/clustering compaction uses getMinPosition, but DmlPosition represents the latest entity timestamp and should use max.

See also: #46435
pr: #48907