### PR TITLE
enhance: add SHA-3 support for internal hashing operations

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -989,6 +989,10 @@ common:
     middlePriorityRatio: -1 # amplification ratio for middle priority tasks if disk rate limiter is enabled, value <= 0 means ratio limit is disabled
     lowPriorityRatio: -1 # amplification ratio for low priority tasks if disk rate limiter is enabled, value <= 0 means ratio limit is disabled
   security:
+    # Hash algorithm used for internal hashing (e.g. telemetry fingerprints, config digests).
+    # Supported values: sha256 (default), sha3 (SHA3-256, per NIST SP 800-185).
+    # Changing this value will invalidate any previously computed hashes.
+    hashAlgorithm: sha256
     authorizationEnabled: false
     # The superusers will ignore some system check processes,
     # like the old password verification when updating the credential

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -98,7 +98,7 @@ minio:
   # minio.address and minio.port together generate the valid access to MinIO or S3 service.
   # MinIO preferentially acquires the valid IP address from the environment variable MINIO_ADDRESS when Milvus is started.
   # Default value applies when MinIO or S3 is running on the same network with Milvus.
-  address: localhost:9000
+  address: localhost
   port: 9000 # Port of MinIO or S3 service.
   # Access key ID that MinIO or S3 issues to user for authorized access.
   # Environment variable: MINIO_ACCESS_KEY_ID or minio.accessKeyID
@@ -235,7 +235,7 @@ pulsar:
   # Default value applies when Pulsar is running on the same network with Milvus.
   address: localhost
   port: 6650 # Port of Pulsar service.
-  webport: 80 # Web port of of Pulsar service. If you connect direcly without proxy, should use 8080.
+  webport: 18080 # Web port of of Pulsar service. If you connect direcly without proxy, should use 8080.
   # The maximum size of each message in Pulsar. Unit: Byte.
   # By default, Pulsar can transmit at most 2MB of data in a single message. When the size of inserted data is greater than this value, proxy fragments the data into multiple messages to ensure that they can be transmitted correctly.
   # If the corresponding parameter in Pulsar remains unchanged, increasing this configuration will cause Milvus to fail, and reducing it produces no advantage.
@@ -989,10 +989,6 @@ common:
     middlePriorityRatio: -1 # amplification ratio for middle priority tasks if disk rate limiter is enabled, value <= 0 means ratio limit is disabled
     lowPriorityRatio: -1 # amplification ratio for low priority tasks if disk rate limiter is enabled, value <= 0 means ratio limit is disabled
   security:
-    # Hash algorithm used for internal hashing (e.g. telemetry fingerprints, config digests).
-    # Supported values: sha256 (default), sha3 (SHA3-256, per NIST SP 800-185).
-    # Changing this value will invalidate any previously computed hashes.
-    hashAlgorithm: sha256
     authorizationEnabled: false
     # The superusers will ignore some system check processes,
     # like the old password verification when updating the credential
@@ -1003,6 +999,7 @@ common:
     rootShouldBindRole: false # Whether the root user should bind a role when the authorization is enabled.
     enablePublicPrivilege: true # Whether to enable public privilege
     exprEnabled: false # Whether to enable the /expr endpoint for debugging. When enabled, only root user can access it via HTTP Basic Auth on Proxy nodes.
+    hashAlgorithm: sha256 # Hash algorithm for internal hashing (e.g. telemetry fingerprints, config digests). Supported values: sha256 (default), sha3 (SHA3-256). Changing this invalidates previously computed hashes.
     rbac:
       overrideBuiltInPrivilegeGroups:
         enabled: false # Whether to override build-in privilege groups

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -98,7 +98,7 @@ minio:
   # minio.address and minio.port together generate the valid access to MinIO or S3 service.
   # MinIO preferentially acquires the valid IP address from the environment variable MINIO_ADDRESS when Milvus is started.
   # Default value applies when MinIO or S3 is running on the same network with Milvus.
-  address: localhost
+  address: localhost:9000
   port: 9000 # Port of MinIO or S3 service.
   # Access key ID that MinIO or S3 issues to user for authorized access.
   # Environment variable: MINIO_ACCESS_KEY_ID or minio.accessKeyID
@@ -235,7 +235,7 @@ pulsar:
   # Default value applies when Pulsar is running on the same network with Milvus.
   address: localhost
   port: 6650 # Port of Pulsar service.
-  webport: 18080 # Web port of of Pulsar service. If you connect direcly without proxy, should use 8080.
+  webport: 80 # Web port of of Pulsar service. If you connect direcly without proxy, should use 8080.
   # The maximum size of each message in Pulsar. Unit: Byte.
   # By default, Pulsar can transmit at most 2MB of data in a single message. When the size of inserted data is greater than this value, proxy fragments the data into multiple messages to ensure that they can be transmitted correctly.
   # If the corresponding parameter in Pulsar remains unchanged, increasing this configuration will cause Milvus to fail, and reducing it produces no advantage.

--- a/internal/rootcoord/telemetry/command_store.go
+++ b/internal/rootcoord/telemetry/command_store.go
@@ -18,8 +18,6 @@ package telemetry
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -32,8 +30,10 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
+	"github.com/milvus-io/milvus/internal/util/crypto"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
 // PushClientConfigRequest is a request to push a persistent config
@@ -517,12 +517,13 @@ func computeConfigHashFromConfigs(configs map[string]*storedConfig) string {
 	}
 	sort.Strings(ids)
 
-	h := sha256.New()
+	var data []byte
 	for _, id := range ids {
 		cfg := configs[id]
-		h.Write([]byte(cfg.ConfigID))
-		h.Write([]byte(cfg.ConfigType))
-		h.Write(cfg.Payload)
+		data = append(data, []byte(cfg.ConfigID)...)
+		data = append(data, []byte(cfg.ConfigType)...)
+		data = append(data, cfg.Payload...)
 	}
-	return hex.EncodeToString(h.Sum(nil))[:16]
+	hashType := crypto.HashType(paramtable.Get().CommonCfg.HashAlgorithm.GetValue())
+	return crypto.ComputeHash(data, hashType)[:16]
 }

--- a/internal/rootcoord/telemetry/manager.go
+++ b/internal/rootcoord/telemetry/manager.go
@@ -18,8 +18,6 @@ package telemetry
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -34,8 +32,10 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
+	"github.com/milvus-io/milvus/internal/util/crypto"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
 // TelemetryConfig holds configurable time values for the telemetry manager
@@ -503,8 +503,9 @@ func (m *TelemetryManager) getOrCreateClientID(info *commonpb.ClientInfo) string
 		user = info.User
 	}
 	seed := fmt.Sprintf("%s|%s|%s|%s", sdkType, sdkVersion, host, user)
-	sum := sha256.Sum256([]byte(seed))
-	return fmt.Sprintf("legacy:%s:%s", host, hex.EncodeToString(sum[:8]))
+	hashType := crypto.HashType(paramtable.Get().CommonCfg.HashAlgorithm.GetValue())
+	hash := crypto.ComputeHash([]byte(seed), hashType)
+	return fmt.Sprintf("legacy:%s:%s", host, hash[:16])
 }
 
 func (m *TelemetryManager) getDatabaseFromClientInfo(info *commonpb.ClientInfo) string {
@@ -625,13 +626,14 @@ func computeClientConfigHash(configs []*ClientConfig) string {
 		return sorted[i].ConfigId < sorted[j].ConfigId
 	})
 
-	h := sha256.New()
+	var data []byte
 	for _, cfg := range sorted {
-		h.Write([]byte(cfg.ConfigId))
-		h.Write([]byte(cfg.ConfigType))
-		h.Write(cfg.Payload)
+		data = append(data, []byte(cfg.ConfigId)...)
+		data = append(data, []byte(cfg.ConfigType)...)
+		data = append(data, cfg.Payload...)
 	}
-	return hex.EncodeToString(h.Sum(nil))[:16]
+	hashType := crypto.HashType(paramtable.Get().CommonCfg.HashAlgorithm.GetValue())
+	return crypto.ComputeHash(data, hashType)[:16]
 }
 
 // ListClients returns all clients, optionally filtered by database

--- a/internal/rootcoord/telemetry/manager_test.go
+++ b/internal/rootcoord/telemetry/manager_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
 // mockCommandStore implements CommandStoreInterface for testing
@@ -3761,4 +3762,125 @@ func TestProcessCommandRepliesPayloadFormat(t *testing.T) {
 	jsonStr := string(data)
 	assert.Contains(t, jsonStr, `"payload":"{\"user_config\"`)
 	assert.NotContains(t, jsonStr, "eyJ1c2VyX2NvbmZpZyI") // base64 prefix
+}
+
+func TestGetOrCreateClientIDWithSHA3(t *testing.T) {
+	paramtable.Init()
+	params := paramtable.Get()
+
+	mgr := NewTelemetryManager(nil)
+
+	info := &commonpb.ClientInfo{
+		Host:       "10.0.0.1",
+		SdkType:    "python",
+		SdkVersion: "2.7.0",
+		User:       "root",
+	}
+
+	params.Save("common.security.hashAlgorithm", "sha256")
+	sha256ID := mgr.getOrCreateClientID(info)
+
+	params.Save("common.security.hashAlgorithm", "sha3")
+	sha3ID := mgr.getOrCreateClientID(info)
+
+	assert.Contains(t, sha256ID, "legacy:10.0.0.1:")
+	assert.Contains(t, sha3ID, "legacy:10.0.0.1:")
+	assert.NotEqual(t, sha256ID, sha3ID, "SHA-256 and SHA-3 should produce different legacy client IDs")
+	assert.Len(t, sha256ID, len("legacy:10.0.0.1:")+16)
+	assert.Len(t, sha3ID, len("legacy:10.0.0.1:")+16)
+
+	// Deterministic: same algorithm should produce same ID
+	sha3ID2 := mgr.getOrCreateClientID(info)
+	assert.Equal(t, sha3ID, sha3ID2)
+
+	params.Save("common.security.hashAlgorithm", "sha256")
+}
+
+func TestComputeClientConfigHashWithSHA3(t *testing.T) {
+	paramtable.Init()
+	params := paramtable.Get()
+
+	configs := []*ClientConfig{
+		{ConfigId: "cfg-1", ConfigType: "persistent", Payload: []byte(`{"key":"val1"}`)},
+		{ConfigId: "cfg-2", ConfigType: "one_time", Payload: []byte(`{"key":"val2"}`)},
+	}
+
+	params.Save("common.security.hashAlgorithm", "sha256")
+	sha256Hash := computeClientConfigHash(configs)
+
+	params.Save("common.security.hashAlgorithm", "sha3")
+	sha3Hash := computeClientConfigHash(configs)
+
+	assert.Len(t, sha256Hash, 16)
+	assert.Len(t, sha3Hash, 16)
+	assert.NotEqual(t, sha256Hash, sha3Hash, "SHA-256 and SHA-3 should produce different config hashes")
+
+	// Deterministic
+	sha3Hash2 := computeClientConfigHash(configs)
+	assert.Equal(t, sha3Hash, sha3Hash2)
+
+	// Empty configs should return empty regardless of algorithm
+	assert.Equal(t, "", computeClientConfigHash(nil))
+	assert.Equal(t, "", computeClientConfigHash([]*ClientConfig{}))
+
+	params.Save("common.security.hashAlgorithm", "sha256")
+}
+
+func TestComputeConfigHashFromConfigsWithSHA3(t *testing.T) {
+	paramtable.Init()
+	params := paramtable.Get()
+
+	configs := map[string]*storedConfig{
+		"id-1": {ConfigID: "id-1", ConfigType: "persistent", Payload: []byte(`{"a":"b"}`)},
+		"id-2": {ConfigID: "id-2", ConfigType: "one_time", Payload: []byte(`{"c":"d"}`)},
+	}
+
+	params.Save("common.security.hashAlgorithm", "sha256")
+	sha256Hash := computeConfigHashFromConfigs(configs)
+
+	params.Save("common.security.hashAlgorithm", "sha3")
+	sha3Hash := computeConfigHashFromConfigs(configs)
+
+	assert.Len(t, sha256Hash, 16)
+	assert.Len(t, sha3Hash, 16)
+	assert.NotEqual(t, sha256Hash, sha3Hash, "SHA-256 and SHA-3 should produce different hashes")
+
+	// Deterministic
+	sha3Hash2 := computeConfigHashFromConfigs(configs)
+	assert.Equal(t, sha3Hash, sha3Hash2)
+
+	// Empty
+	assert.Equal(t, "", computeConfigHashFromConfigs(nil))
+	assert.Equal(t, "", computeConfigHashFromConfigs(map[string]*storedConfig{}))
+
+	params.Save("common.security.hashAlgorithm", "sha256")
+}
+
+func TestHashAlgorithmSwitchDuringHeartbeat(t *testing.T) {
+	paramtable.Init()
+	params := paramtable.Get()
+	params.Save("common.security.hashAlgorithm", "sha256")
+
+	mgr := NewTelemetryManager(nil)
+
+	info := &commonpb.ClientInfo{
+		Host:       "10.0.0.5",
+		SdkType:    "go",
+		SdkVersion: "2.6.0",
+		User:       "admin",
+	}
+
+	// Heartbeat with SHA-256
+	resp1, err := mgr.HandleHeartbeat(&milvuspb.ClientHeartbeatRequest{ClientInfo: info})
+	assert.NoError(t, err)
+	assert.NotNil(t, resp1)
+
+	// Switch to SHA-3 mid-flight
+	params.Save("common.security.hashAlgorithm", "sha3")
+
+	resp2, err := mgr.HandleHeartbeat(&milvuspb.ClientHeartbeatRequest{ClientInfo: info})
+	assert.NoError(t, err)
+	assert.NotNil(t, resp2)
+
+	params.Save("common.security.hashAlgorithm", "sha256")
 }

--- a/internal/util/crypto/hash.go
+++ b/internal/util/crypto/hash.go
@@ -1,0 +1,41 @@
+// Package crypto provides configurable cryptographic hashing utilities.
+//
+// It centralizes hash algorithm selection so that Milvus components use
+// a single, consistent implementation. The algorithm is controlled at
+// runtime via the common.security.hashAlgorithm configuration parameter,
+// supporting SHA-256 (default) and SHA-3 (SHA3-256) per NIST recommendations.
+//
+// See: https://github.com/milvus-io/milvus/issues/25970
+package crypto
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+
+	"golang.org/x/crypto/sha3"
+)
+
+// HashType defines the supported hash algorithm identifiers.
+type HashType string
+
+const (
+	HashSHA256 HashType = "sha256"
+	HashSHA3   HashType = "sha3"
+)
+
+// ComputeHash returns the hex-encoded digest of data using the specified algorithm.
+// Unrecognized hashType values fall back to SHA-256.
+func ComputeHash(data []byte, hashType HashType) string {
+	switch hashType {
+	case HashSHA3:
+		h := sha3.New256()
+		h.Write(data)
+		return hex.EncodeToString(h.Sum(nil))
+
+	case HashSHA256:
+		fallthrough
+	default:
+		h := sha256.Sum256(data)
+		return hex.EncodeToString(h[:])
+	}
+}

--- a/internal/util/crypto/hash_test.go
+++ b/internal/util/crypto/hash_test.go
@@ -3,6 +3,8 @@ package crypto
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -67,4 +69,159 @@ func TestComputeHash_Deterministic(t *testing.T) {
 	result3 := ComputeHash(data, HashSHA3)
 	result4 := ComputeHash(data, HashSHA3)
 	assert.Equal(t, result3, result4)
+}
+
+func TestComputeHash_KnownVectors(t *testing.T) {
+	// NIST test vector: SHA-256 of empty string
+	assert.Equal(t,
+		"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		ComputeHash([]byte{}, HashSHA256),
+	)
+	// SHA3-256 of empty string (NIST FIPS 202)
+	assert.Equal(t,
+		"a7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a",
+		ComputeHash([]byte{}, HashSHA3),
+	)
+}
+
+func TestComputeHash_SHA3_KnownVector(t *testing.T) {
+	// "abc" SHA3-256 from NIST examples
+	assert.Equal(t,
+		"3a985da74fe225b2045c172d6bd390bd855f086e3e9d525b46bfe24511431532",
+		ComputeHash([]byte("abc"), HashSHA3),
+	)
+}
+
+func TestComputeHash_OutputIsValidHex(t *testing.T) {
+	for _, ht := range []HashType{HashSHA256, HashSHA3} {
+		result := ComputeHash([]byte("test"), ht)
+		_, err := hex.DecodeString(result)
+		assert.NoError(t, err, "output for %s should be valid hex", ht)
+	}
+}
+
+func TestComputeHash_OutputLength(t *testing.T) {
+	inputs := [][]byte{
+		{},
+		{0x00},
+		[]byte("short"),
+		[]byte(strings.Repeat("a", 10000)),
+	}
+	for _, input := range inputs {
+		for _, ht := range []HashType{HashSHA256, HashSHA3} {
+			result := ComputeHash(input, ht)
+			assert.Len(t, result, 64,
+				"256-bit hash should always produce 64 hex chars (algo=%s, inputLen=%d)", ht, len(input))
+		}
+	}
+}
+
+func TestComputeHash_DifferentInputsProduceDifferentHashes(t *testing.T) {
+	for _, ht := range []HashType{HashSHA256, HashSHA3} {
+		a := ComputeHash([]byte("input_a"), ht)
+		b := ComputeHash([]byte("input_b"), ht)
+		assert.NotEqual(t, a, b, "different inputs should hash differently for %s", ht)
+	}
+}
+
+func TestComputeHash_NilInput(t *testing.T) {
+	sha256Result := ComputeHash(nil, HashSHA256)
+	sha3Result := ComputeHash(nil, HashSHA3)
+
+	assert.Len(t, sha256Result, 64)
+	assert.Len(t, sha3Result, 64)
+
+	// nil and empty slice should produce the same hash
+	assert.Equal(t, ComputeHash([]byte{}, HashSHA256), sha256Result)
+	assert.Equal(t, ComputeHash([]byte{}, HashSHA3), sha3Result)
+}
+
+func TestComputeHash_BinaryData(t *testing.T) {
+	data := []byte{0x00, 0xFF, 0x01, 0xFE, 0x80}
+	for _, ht := range []HashType{HashSHA256, HashSHA3} {
+		result := ComputeHash(data, ht)
+		assert.Len(t, result, 64)
+		_, err := hex.DecodeString(result)
+		assert.NoError(t, err)
+	}
+}
+
+func TestComputeHash_LargeInput(t *testing.T) {
+	data := []byte(strings.Repeat("x", 1<<20)) // 1 MiB
+	for _, ht := range []HashType{HashSHA256, HashSHA3} {
+		result := ComputeHash(data, ht)
+		assert.Len(t, result, 64)
+	}
+}
+
+func TestComputeHash_FallbackVariants(t *testing.T) {
+	data := []byte("fallback test")
+	expected := ComputeHash(data, HashSHA256)
+
+	for _, invalid := range []HashType{"", "SHA256", "SHA-256", "md5", "sha512", "SHA3"} {
+		result := ComputeHash(data, invalid)
+		assert.Equal(t, expected, result,
+			"invalid HashType %q should fall back to SHA-256", invalid)
+	}
+}
+
+func TestComputeHash_TruncatedDigest(t *testing.T) {
+	// Mirrors how callers use ComputeHash: truncating to [:16] for fingerprints
+	data := []byte("config-id-1" + "persistent" + "payload-bytes")
+	for _, ht := range []HashType{HashSHA256, HashSHA3} {
+		full := ComputeHash(data, ht)
+		truncated := full[:16]
+		assert.Len(t, truncated, 16)
+		_, err := hex.DecodeString(truncated)
+		assert.NoError(t, err, "truncated digest should be valid hex for %s", ht)
+	}
+}
+
+func TestComputeHash_ConcatenatedFields(t *testing.T) {
+	// Mirrors telemetry usage: hashing concatenated config fields
+	configID := "cfg-001"
+	configType := "persistent"
+	payload := []byte(`{"key":"value"}`)
+
+	var data []byte
+	data = append(data, []byte(configID)...)
+	data = append(data, []byte(configType)...)
+	data = append(data, payload...)
+
+	for _, ht := range []HashType{HashSHA256, HashSHA3} {
+		result := ComputeHash(data, ht)
+		assert.Len(t, result, 64)
+		// Same concatenation should always produce same result
+		assert.Equal(t, result, ComputeHash(data, ht))
+	}
+}
+
+func TestComputeHash_LegacyClientID(t *testing.T) {
+	// Mirrors manager.go legacy client ID generation
+	sdkType := "python"
+	sdkVersion := "2.7.0"
+	host := "10.0.0.1"
+	user := "root"
+	seed := fmt.Sprintf("%s|%s|%s|%s", sdkType, sdkVersion, host, user)
+
+	for _, ht := range []HashType{HashSHA256, HashSHA3} {
+		hash := ComputeHash([]byte(seed), ht)
+		clientID := fmt.Sprintf("legacy:%s:%s", host, hash[:16])
+		assert.True(t, strings.HasPrefix(clientID, "legacy:10.0.0.1:"))
+		assert.Len(t, hash[:16], 16)
+	}
+}
+
+func TestComputeHash_OrderSensitivity(t *testing.T) {
+	// Verify that field order matters (callers sort before hashing)
+	for _, ht := range []HashType{HashSHA256, HashSHA3} {
+		ab := ComputeHash([]byte("AB"), ht)
+		ba := ComputeHash([]byte("BA"), ht)
+		assert.NotEqual(t, ab, ba, "hash should be order-sensitive for %s", ht)
+	}
+}
+
+func TestHashTypeConstants(t *testing.T) {
+	assert.Equal(t, HashType("sha256"), HashSHA256)
+	assert.Equal(t, HashType("sha3"), HashSHA3)
 }

--- a/internal/util/crypto/hash_test.go
+++ b/internal/util/crypto/hash_test.go
@@ -1,0 +1,70 @@
+package crypto
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/crypto/sha3"
+)
+
+func TestComputeHash_SHA256(t *testing.T) {
+	data := []byte("hello world")
+	expected := sha256.Sum256(data)
+	expectedHex := hex.EncodeToString(expected[:])
+
+	result := ComputeHash(data, HashSHA256)
+	assert.Equal(t, expectedHex, result)
+}
+
+func TestComputeHash_SHA3(t *testing.T) {
+	data := []byte("hello world")
+	h := sha3.New256()
+	h.Write(data)
+	expectedHex := hex.EncodeToString(h.Sum(nil))
+
+	result := ComputeHash(data, HashSHA3)
+	assert.Equal(t, expectedHex, result)
+}
+
+func TestComputeHash_DefaultFallback(t *testing.T) {
+	data := []byte("hello world")
+	expected := sha256.Sum256(data)
+	expectedHex := hex.EncodeToString(expected[:])
+
+	result := ComputeHash(data, "unknown")
+	assert.Equal(t, expectedHex, result)
+}
+
+func TestComputeHash_EmptyData(t *testing.T) {
+	sha256Result := ComputeHash([]byte{}, HashSHA256)
+	sha3Result := ComputeHash([]byte{}, HashSHA3)
+
+	assert.NotEmpty(t, sha256Result)
+	assert.NotEmpty(t, sha3Result)
+	assert.NotEqual(t, sha256Result, sha3Result)
+}
+
+func TestComputeHash_DifferentAlgorithmsProduceDifferentHashes(t *testing.T) {
+	data := []byte("test data for hashing")
+
+	sha256Result := ComputeHash(data, HashSHA256)
+	sha3Result := ComputeHash(data, HashSHA3)
+
+	assert.Len(t, sha256Result, 64)
+	assert.Len(t, sha3Result, 64)
+	assert.NotEqual(t, sha256Result, sha3Result)
+}
+
+func TestComputeHash_Deterministic(t *testing.T) {
+	data := []byte("deterministic test")
+
+	result1 := ComputeHash(data, HashSHA256)
+	result2 := ComputeHash(data, HashSHA256)
+	assert.Equal(t, result1, result2)
+
+	result3 := ComputeHash(data, HashSHA3)
+	result4 := ComputeHash(data, HashSHA3)
+	assert.Equal(t, result3, result4)
+}

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -351,6 +351,9 @@ type commonConfig struct {
 
 	// group by
 	GroupByMaxGroups ParamItem `refreshable:"false"`
+
+	// hash algorithm
+	HashAlgorithm ParamItem `refreshable:"false"`
 }
 
 func (p *commonConfig) init(base *BaseTable) {
@@ -1414,6 +1417,21 @@ If enabled, IPv6 ULA/global addresses will be prioritized ahead of IPv4.`,
 		},
 	}
 	p.GroupByMaxGroups.Init(base.mgr)
+
+	p.HashAlgorithm = ParamItem{
+		Key:          "common.security.hashAlgorithm",
+		Version:      "2.6.0",
+		DefaultValue: "sha256",
+		Doc:          "Hash algorithm for internal hashing (e.g. telemetry fingerprints, config digests). Supported values: sha256 (default), sha3 (SHA3-256). Changing this invalidates previously computed hashes.",
+		Export:       true,
+		Formatter: func(v string) string {
+			if v == "sha3" {
+				return v
+			}
+			return "sha256"
+		},
+	}
+	p.HashAlgorithm.Init(base.mgr)
 }
 
 type gpuConfig struct {

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -156,6 +156,24 @@ func TestComponentParam(t *testing.T) {
 			params.CommonCfg.ClusterID.GetAsInt()
 		})
 		params.Save("common.clusterID", "0")
+
+		// HashAlgorithm: default is sha256
+		assert.Equal(t, "sha256", params.CommonCfg.HashAlgorithm.GetValue())
+
+		// HashAlgorithm: setting sha3 should return sha3
+		params.Save("common.security.hashAlgorithm", "sha3")
+		assert.Equal(t, "sha3", params.CommonCfg.HashAlgorithm.GetValue())
+
+		// HashAlgorithm: invalid values should fall back to sha256
+		for _, invalid := range []string{"", "md5", "SHA256", "SHA3", "sha512", "unknown"} {
+			params.Save("common.security.hashAlgorithm", invalid)
+			assert.Equal(t, "sha256", params.CommonCfg.HashAlgorithm.GetValue(),
+				"invalid value %q should fall back to sha256", invalid)
+		}
+
+		// HashAlgorithm: restore to default
+		params.Save("common.security.hashAlgorithm", "sha256")
+		assert.Equal(t, "sha256", params.CommonCfg.HashAlgorithm.GetValue())
 	})
 
 	t.Run("test logConfig", func(t *testing.T) {


### PR DESCRIPTION
**Summary**

- Adds a centralized ComputeHash utility in internal/util/crypto supporting both SHA-256 and SHA-3 (SHA3-256), addressing NIST recommendations to adopt SHA-3 based algorithms.
- Introduces a new configurable parameter common.security.hashAlgorithm (values: sha256, sha3) so the hash algorithm can be toggled via milvus.yaml without code changes.
- Refactors all direct crypto/sha256 usage in telemetry (manager.go, command_store.go) to use the new ComputeHash function with config-driven algorithm selection.
- Includes unit tests covering both algorithms, default fallback behavior, empty input, determinism, and output divergence.

**Related Issue**

#25970 