### PR TITLE
test: fix add_field error message assertions to match updated Milvus responses

### DIFF
--- a/tests/python_client/milvus_client/test_add_field_feature.py
+++ b/tests/python_client/milvus_client/test_add_field_feature.py
@@ -937,7 +937,7 @@ class TestMilvusClientAddFieldFeatureInvalid(TestMilvusClientV2Base):
         collection_name = cf.gen_collection_name_by_testcase_name()
         # 1. create collection
         field_name = default_new_field_name
-        error = {ct.err_code: 1100, ct.err_msg: f"already has another clutering key field, "
+        error = {ct.err_code: 1100, ct.err_msg: f"already has another clustering key field, "
                                                 f"field name: {field_name}: invalid parameter"}
         schema = self.create_schema(client)[0]
         schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
@@ -961,7 +961,7 @@ class TestMilvusClientAddFieldFeatureInvalid(TestMilvusClientV2Base):
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
         # 1. create collection
-        error = {ct.err_code: 1100, ct.err_msg: f"duplicate field name: {default_string_field_name}: invalid parameter"}
+        error = {ct.err_code: 1100, ct.err_msg: f"duplicated field name {default_string_field_name}: invalid parameter"}
         schema = self.create_schema(client)[0]
         schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
         schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/48914

## Summary

- Fix typo in error assertion: `clutering` → `clustering` (Milvus server fixed the spelling)
- Fix wording in error assertion: `duplicate field name:` → `duplicated field name` (Milvus server changed the message format)

Affected test cases:
- `test_milvus_client_collection_add_field_as_cluster_key`
- `test_milvus_client_collection_add_field_same_other_name`

Both verified passing locally against master-20260409-80db722.

🤖 Generated with [Claude Code](https://claude.com/claude-code)