### PR TITLE
enhance: [skip e2e] [3.0] update Nightly2 cron to trigger on 3.0 branch at 23:00 CST

### DIFF
--- a/ci/jenkins/Nightly2.groovy
+++ b/ci/jenkins/Nightly2.groovy
@@ -3,7 +3,7 @@
 def pod = libraryResource 'io/milvus/pod/tekton-4am.yaml'
 
 String cron_timezone = 'TZ=Asia/Shanghai'
-String cron_string = BRANCH_NAME == 'master' ? '50 4 * * * ' : ''
+String cron_string = BRANCH_NAME == '3.0' ? '0 23 * * * ' : ''
 
 // Make timeout 4 hours so that we can run two nightly during the ci
 int total_timeout_minutes = 7 * 60


### PR DESCRIPTION
## Summary

- Change Nightly2 cron trigger from `master` branch at 4:50 to `3.0` branch at 23:00 (Asia/Shanghai)

### Changes

- `ci/jenkins/Nightly2.groovy`: Update `cron_string` to target `3.0` branch with `0 23 * * *` schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)