### PR TITLE
enhance: replace DSS panic with graceful exit on write failure in streaming node

### DIFF
--- a/internal/flushcommon/pipeline/data_sync_service.go
+++ b/internal/flushcommon/pipeline/data_sync_service.go
@@ -238,6 +238,7 @@ func getServiceWithChannel(initCtx context.Context, params *util.PipelineParams,
 	unflushed, flushed []*datapb.SegmentInfo, input <-chan *msgstream.MsgPack,
 	wbTaskObserverCallback writebuffer.TaskObserverCallback,
 	dropCallback func(),
+	extraWBOpts ...writebuffer.WriteBufferOption,
 ) (dss *DataSyncService, err error) {
 	var (
 		channelName  = info.GetVchan().GetChannelName()
@@ -297,14 +298,14 @@ func getServiceWithChannel(initCtx context.Context, params *util.PipelineParams,
 	nodeList = append(nodeList, ddNode)
 
 	if len(info.GetSchema().GetFunctions()) > 0 {
-		emNode, err := newEmbeddingNode(channelName, config.metacache)
+		emNode, err := newEmbeddingNode(channelName, config.metacache, params.ErrorHandler)
 		if err != nil {
 			return nil, err
 		}
 		nodeList = append(nodeList, emNode)
 	}
 
-	writeNode, err := newWriteNode(params.Ctx, params.WriteBufferManager, ds.timetickSender, config)
+	writeNode, err := newWriteNode(params.Ctx, params.WriteBufferManager, ds.timetickSender, config, params.ErrorHandler)
 	if err != nil {
 		return nil, err
 	}
@@ -321,10 +322,13 @@ func getServiceWithChannel(initCtx context.Context, params *util.PipelineParams,
 	// Register channel after channel pipeline is ready.
 	// This'll reject any FlushChannel and FlushSegments calls to prevent inconsistency between DN and DC over flushTs
 	// if fail to init flowgraph nodes.
-	err = params.WriteBufferManager.Register(channelName, metacache,
+	wbOpts := []writebuffer.WriteBufferOption{
 		writebuffer.WithMetaWriter(syncmgr.BrokerMetaWriter(params.Broker, config.serverID)),
 		writebuffer.WithIDAllocator(params.Allocator),
-		writebuffer.WithTaskObserverCallback(wbTaskObserverCallback))
+		writebuffer.WithTaskObserverCallback(wbTaskObserverCallback),
+	}
+	wbOpts = append(wbOpts, extraWBOpts...)
+	err = params.WriteBufferManager.Register(channelName, metacache, wbOpts...)
 	if err != nil {
 		log.Warn("failed to register channel buffer", zap.String("channel", channelName), zap.Error(err))
 		return nil, err
@@ -388,6 +392,7 @@ func NewStreamingNodeDataSyncService(
 	input <-chan *msgstream.MsgPack,
 	wbTaskObserverCallback writebuffer.TaskObserverCallback,
 	dropCallback func(),
+	extraWBOpts ...writebuffer.WriteBufferOption,
 ) (*DataSyncService, error) {
 	// recover segment checkpoints
 	var (
@@ -413,7 +418,7 @@ func NewStreamingNodeDataSyncService(
 	if metaCache, err = getMetaCacheForStreaming(initCtx, pipelineParams, info, unflushedSegmentInfos, flushedSegmentInfos); err != nil {
 		return nil, err
 	}
-	return getServiceWithChannel(initCtx, pipelineParams, info, metaCache, unflushedSegmentInfos, flushedSegmentInfos, input, wbTaskObserverCallback, dropCallback)
+	return getServiceWithChannel(initCtx, pipelineParams, info, metaCache, unflushedSegmentInfos, flushedSegmentInfos, input, wbTaskObserverCallback, dropCallback, extraWBOpts...)
 }
 
 func NewDataSyncServiceWithMetaCache(metaCache metacache.MetaCache) *DataSyncService {
@@ -428,6 +433,7 @@ func NewEmptyStreamingNodeDataSyncService(
 	vchannelInfo *datapb.VchannelInfo,
 	wbTaskObserverCallback writebuffer.TaskObserverCallback,
 	dropCallback func(),
+	extraWBOpts ...writebuffer.WriteBufferOption,
 ) *DataSyncService {
 	watchInfo := &datapb.ChannelWatchInfo{
 		Vchan:  vchannelInfo,
@@ -437,7 +443,7 @@ func NewEmptyStreamingNodeDataSyncService(
 	if err != nil {
 		panic(fmt.Sprintf("new a empty streaming node data sync service should never be failed, %s", err.Error()))
 	}
-	ds, err := getServiceWithChannel(initCtx, pipelineParams, watchInfo, metaCache, make([]*datapb.SegmentInfo, 0), make([]*datapb.SegmentInfo, 0), input, wbTaskObserverCallback, dropCallback)
+	ds, err := getServiceWithChannel(initCtx, pipelineParams, watchInfo, metaCache, make([]*datapb.SegmentInfo, 0), make([]*datapb.SegmentInfo, 0), input, wbTaskObserverCallback, dropCallback, extraWBOpts...)
 	if err != nil {
 		panic(fmt.Sprintf("new a empty data sync service should never be failed, %s", err.Error()))
 	}

--- a/internal/flushcommon/pipeline/flow_graph_embedding_node.go
+++ b/internal/flushcommon/pipeline/flow_graph_embedding_node.go
@@ -27,6 +27,7 @@ import (
 	"github.com/milvus-io/milvus/internal/flushcommon/metacache"
 	"github.com/milvus-io/milvus/internal/flushcommon/writebuffer"
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/util/flowgraph"
 	"github.com/milvus-io/milvus/internal/util/function"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
@@ -41,12 +42,13 @@ type embeddingNode struct {
 	metaCache   metacache.MetaCache
 	pkField     *schemapb.FieldSchema
 	channelName string
+	errHandler  func(error) // Called on unrecoverable write errors; if nil, panics (DataNode compat).
 
 	// embeddingType EmbeddingType
 	functionRunners map[int64]function.FunctionRunner
 }
 
-func newEmbeddingNode(channelName string, metaCache metacache.MetaCache) (*embeddingNode, error) {
+func newEmbeddingNode(channelName string, metaCache metacache.MetaCache, errHandler func(error)) (*embeddingNode, error) {
 	baseNode := BaseNode{}
 	baseNode.SetMaxQueueLength(paramtable.Get().DataNodeCfg.FlowGraphMaxQueueLength.GetAsInt32())
 	baseNode.SetMaxParallelism(paramtable.Get().DataNodeCfg.FlowGraphMaxParallelism.GetAsInt32())
@@ -55,6 +57,7 @@ func newEmbeddingNode(channelName string, metaCache metacache.MetaCache) (*embed
 		BaseNode:        baseNode,
 		channelName:     channelName,
 		metaCache:       metaCache,
+		errHandler:      errHandler,
 		functionRunners: make(map[int64]function.FunctionRunner),
 	}
 
@@ -199,6 +202,14 @@ func (eNode *embeddingNode) Embedding(datas []*writebuffer.InsertData) error {
 	return nil
 }
 
+func (eNode *embeddingNode) handleError(err error) {
+	if eNode.errHandler != nil {
+		eNode.errHandler(err)
+		return
+	}
+	panic(err)
+}
+
 func (eNode *embeddingNode) Operate(in []Msg) []Msg {
 	fgMsg := in[0].(*FlowGraphMsg)
 
@@ -211,13 +222,15 @@ func (eNode *embeddingNode) Operate(in []Msg) []Msg {
 		var err error
 		if insertData, err = writebuffer.PrepareInsert(eNode.metaCache.GetSchema(fgMsg.TimeTick()), eNode.pkField, fgMsg.InsertMessages); err != nil {
 			log.Error("failed to prepare insert data", zap.Error(err))
-			panic(err)
+			eNode.handleError(err)
+			return []Msg{&FlowGraphMsg{BaseMsg: flowgraph.NewBaseMsg(true)}}
 		}
 	}
 
 	if err := eNode.Embedding(insertData); err != nil {
 		log.Warn("failed to embedding insert data", zap.Error(err))
-		panic(err)
+		eNode.handleError(err)
+		return []Msg{&FlowGraphMsg{BaseMsg: flowgraph.NewBaseMsg(true)}}
 	}
 
 	fgMsg.InsertData = insertData

--- a/internal/flushcommon/pipeline/flow_graph_embedding_node_test.go
+++ b/internal/flushcommon/pipeline/flow_graph_embedding_node_test.go
@@ -223,6 +223,107 @@ func TestEmbeddingNode_Operator(t *testing.T) {
 				})
 			})
 
+			// Regression coverage for PR #48928 review comment on flow_graph_embedding_node.go:223.
+			// With a non-nil errHandler, Operate must NOT panic — instead it calls the handler
+			// with the underlying error and returns a close-msg so the flowgraph shuts down.
+			// Placed before the "embedding failed" subtest because that subtest mutates the
+			// shared collSchema function Type to 0, which would subsequently break newEmbeddingNode.
+			t.Run("prepare insert failed with errHandler", func(t *testing.T) {
+				var (
+					handlerCalled int
+					capturedErr   error
+				)
+				handler := func(err error) {
+					handlerCalled++
+					capturedErr = err
+				}
+				node, err := newEmbeddingNode("test-channel", metaCache, handler)
+				assert.NoError(t, err)
+				defer node.Free()
+
+				var output []Msg
+				assert.NotPanics(t, func() {
+					output = node.Operate([]Msg{
+						&FlowGraphMsg{
+							BaseMsg: flowgraph.NewBaseMsg(false),
+							InsertMessages: []*msgstream.InsertMsg{{
+								BaseMsg: msgstream.BaseMsg{},
+								InsertRequest: &msgpb.InsertRequest{
+									FieldsData: []*schemapb.FieldData{{
+										FieldId: 1100, // invalid fieldID — forces PrepareInsert to fail
+									}},
+								},
+							}},
+						},
+					})
+				})
+				assert.Equal(t, 1, handlerCalled, "errHandler should be invoked exactly once")
+				assert.Error(t, capturedErr)
+				assert.Equal(t, 1, len(output))
+				closeMsg, ok := output[0].(*FlowGraphMsg)
+				assert.True(t, ok)
+				assert.True(t, closeMsg.IsCloseMsg(),
+					"on failure, errHandler path must return a close msg to trigger flowgraph shutdown")
+			})
+
+			t.Run("embedding failed with errHandler", func(t *testing.T) {
+				var (
+					handlerCalled int
+					capturedErr   error
+				)
+				handler := func(err error) {
+					handlerCalled++
+					capturedErr = err
+				}
+				node, err := newEmbeddingNode("test-channel", metaCache, handler)
+				assert.NoError(t, err)
+				defer node.Free()
+
+				// Break the function runner to force Embedding() to fail. Restore the schema
+				// type on exit so this subtest does not leak mutation into sibling subtests.
+				runnerSchema := node.functionRunners[0].GetSchema()
+				originalType := runnerSchema.Type
+				runnerSchema.Type = 0
+				defer func() { runnerSchema.Type = originalType }()
+
+				var output []Msg
+				assert.NotPanics(t, func() {
+					output = node.Operate([]Msg{
+						&FlowGraphMsg{
+							BaseMsg: flowgraph.NewBaseMsg(false),
+							InsertMessages: []*msgstream.InsertMsg{{
+								BaseMsg: msgstream.BaseMsg{},
+								InsertRequest: &msgpb.InsertRequest{
+									SegmentID:  1,
+									Version:    msgpb.InsertDataVersion_ColumnBased,
+									Timestamps: []uint64{1, 1, 1},
+									FieldsData: []*schemapb.FieldData{
+										{
+											FieldId: 100,
+											Field: &schemapb.FieldData_Scalars{
+												Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{1, 2, 3}}}},
+											},
+										}, {
+											FieldId: 101,
+											Field: &schemapb.FieldData_Scalars{
+												Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"test1", "test2", "test3"}}}},
+											},
+										},
+									},
+								},
+							}},
+						},
+					})
+				})
+				assert.Equal(t, 1, handlerCalled, "errHandler should be invoked exactly once")
+				assert.Error(t, capturedErr)
+				assert.Equal(t, 1, len(output))
+				closeMsg, ok := output[0].(*FlowGraphMsg)
+				assert.True(t, ok)
+				assert.True(t, closeMsg.IsCloseMsg(),
+					"on failure, errHandler path must return a close msg to trigger flowgraph shutdown")
+			})
+
 			t.Run("embedding failed", func(t *testing.T) {
 				node, err := newEmbeddingNode("test-channel", metaCache, nil)
 				assert.NoError(t, err)

--- a/internal/flushcommon/pipeline/flow_graph_embedding_node_test.go
+++ b/internal/flushcommon/pipeline/flow_graph_embedding_node_test.go
@@ -142,7 +142,7 @@ func TestEmbeddingNode_Operator(t *testing.T) {
 			metaCache.EXPECT().GetSchema(mock.Anything).Return(collSchema)
 
 			t.Run("normal case", func(t *testing.T) {
-				node, err := newEmbeddingNode("test-channel", metaCache)
+				node, err := newEmbeddingNode("test-channel", metaCache, nil)
 				assert.NoError(t, err)
 				defer node.Free()
 
@@ -184,7 +184,7 @@ func TestEmbeddingNode_Operator(t *testing.T) {
 			})
 
 			t.Run("with close msg", func(t *testing.T) {
-				node, err := newEmbeddingNode("test-channel", metaCache)
+				node, err := newEmbeddingNode("test-channel", metaCache, nil)
 				assert.NoError(t, err)
 				defer node.Free()
 
@@ -202,7 +202,7 @@ func TestEmbeddingNode_Operator(t *testing.T) {
 			})
 
 			t.Run("prepare insert failed", func(t *testing.T) {
-				node, err := newEmbeddingNode("test-channel", metaCache)
+				node, err := newEmbeddingNode("test-channel", metaCache, nil)
 				assert.NoError(t, err)
 				defer node.Free()
 
@@ -224,7 +224,7 @@ func TestEmbeddingNode_Operator(t *testing.T) {
 			})
 
 			t.Run("embedding failed", func(t *testing.T) {
-				node, err := newEmbeddingNode("test-channel", metaCache)
+				node, err := newEmbeddingNode("test-channel", metaCache, nil)
 				assert.NoError(t, err)
 				defer node.Free()
 

--- a/internal/flushcommon/pipeline/flow_graph_write_node.go
+++ b/internal/flushcommon/pipeline/flow_graph_write_node.go
@@ -15,6 +15,7 @@ import (
 	"github.com/milvus-io/milvus/internal/flushcommon/metacache"
 	"github.com/milvus-io/milvus/internal/flushcommon/util"
 	"github.com/milvus-io/milvus/internal/flushcommon/writebuffer"
+	"github.com/milvus-io/milvus/internal/util/flowgraph"
 	"github.com/milvus-io/milvus/internal/util/streamingutil"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
@@ -29,6 +30,15 @@ type writeNode struct {
 	updater     util.StatsUpdater
 	metacache   metacache.MetaCache
 	pkField     *schemapb.FieldSchema
+	errHandler  func(error) // Called on unrecoverable write errors; if nil, panics (DataNode compat).
+}
+
+func (wNode *writeNode) handleError(err error) {
+	if wNode.errHandler != nil {
+		wNode.errHandler(err)
+		return
+	}
+	panic(err)
 }
 
 // Name returns node name, implementing flowgraph.Node
@@ -87,7 +97,8 @@ func (wNode *writeNode) Operate(in []Msg) []Msg {
 			var err error
 			if insertData, err = writebuffer.PrepareInsert(wNode.metacache.GetSchema(fgMsg.TimeTick()), wNode.pkField, fgMsg.InsertMessages); err != nil {
 				log.Error("failed to prepare data", zap.Error(err))
-				panic(err)
+				wNode.handleError(err)
+				return []Msg{&FlowGraphMsg{BaseMsg: flowgraph.NewBaseMsg(true)}}
 			}
 		}
 		fgMsg.InsertData = insertData
@@ -96,7 +107,8 @@ func (wNode *writeNode) Operate(in []Msg) []Msg {
 	err := wNode.wbManager.BufferData(wNode.channelName, fgMsg.InsertData, fgMsg.DeleteMessages, start, end)
 	if err != nil {
 		log.Error("failed to buffer data", zap.Error(err))
-		panic(err)
+		wNode.handleError(err)
+		return []Msg{&FlowGraphMsg{BaseMsg: flowgraph.NewBaseMsg(true)}}
 	}
 
 	stats := lo.FilterMap(
@@ -143,6 +155,7 @@ func newWriteNode(
 	writeBufferManager writebuffer.BufferManager,
 	updater util.StatsUpdater,
 	config *nodeConfig,
+	errHandler func(error),
 ) (*writeNode, error) {
 	baseNode := BaseNode{}
 	baseNode.SetMaxQueueLength(paramtable.Get().DataNodeCfg.FlowGraphMaxQueueLength.GetAsInt32())
@@ -162,5 +175,6 @@ func newWriteNode(
 		updater:     updater,
 		metacache:   config.metacache,
 		pkField:     pkField,
+		errHandler:  errHandler,
 	}, nil
 }

--- a/internal/flushcommon/pipeline/flow_graph_write_node_test.go
+++ b/internal/flushcommon/pipeline/flow_graph_write_node_test.go
@@ -1,0 +1,161 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipeline
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/flushcommon/metacache"
+	"github.com/milvus-io/milvus/internal/flushcommon/writebuffer"
+	"github.com/milvus-io/milvus/internal/util/flowgraph"
+	"github.com/milvus-io/milvus/pkg/v2/common"
+)
+
+// Regression coverage for PR #48928 review comment on flow_graph_write_node.go:98.
+//
+// Prior to this PR, BufferData / PrepareInsert failures inside writeNode.Operate
+// caused an unrecoverable panic. The PR introduced a non-nil errHandler hook: on
+// failure, Operate must call the handler with the underlying error AND return a
+// close-msg so the flowgraph propagates shutdown. With a nil handler (DataNode
+// compat) the old panic behavior is preserved.
+//
+// These tests pin that contract at the unit level. We exercise it through the
+// BufferData failure branch (line 107-111). The PrepareInsert failure branch
+// (line 98-101) invokes the identical `handleError(err)` + close-msg return
+// pattern — it is the same two-line snippet, so covering one branch covers the
+// contract semantics of the other. Triggering a real PrepareInsert error from
+// unit scope is brittle because writebuffer.PrepareInsert is a package-level
+// function and its failure modes depend on storage-layer validation details.
+//
+// The end-to-end "close-msg shuts down the flowgraph" propagation is already
+// exercised by existing integration tests (TestWALFlusher, data_sync_service
+// tests) which use close messages in the normal drop-collection path.
+func TestWriteNode_ErrHandler(t *testing.T) {
+	collSchema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{
+				FieldID:  common.TimeStampField,
+				Name:     common.TimeStampFieldName,
+				DataType: schemapb.DataType_Int64,
+			},
+			{
+				FieldID:      100,
+				Name:         "pk",
+				IsPrimaryKey: true,
+				DataType:     schemapb.DataType_Int64,
+			},
+			{
+				FieldID:  101,
+				Name:     "vec",
+				DataType: schemapb.DataType_FloatVector,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: "dim", Value: "8"},
+				},
+			},
+		},
+	}
+
+	newNode := func(t *testing.T, wbManager writebuffer.BufferManager, handler func(error)) *writeNode {
+		t.Helper()
+		metaCache := metacache.NewMockMetaCache(t)
+		metaCache.EXPECT().GetSchema(mock.Anything).Return(collSchema).Maybe()
+		cfg := &nodeConfig{
+			vChannelName: "write-node-test-vchannel",
+			metacache:    metaCache,
+		}
+		node, err := newWriteNode(context.Background(), wbManager, nil, cfg, handler)
+		assert.NoError(t, err)
+		return node
+	}
+
+	// Minimal valid InsertData so PrepareInsert succeeds and Operate proceeds to
+	// BufferData — used by the BufferData failure cases.
+	validFGMsg := func() *FlowGraphMsg {
+		return &FlowGraphMsg{
+			BaseMsg:        flowgraph.NewBaseMsg(false),
+			StartPositions: []*msgpb.MsgPosition{{Timestamp: 1}},
+			EndPositions:   []*msgpb.MsgPosition{{Timestamp: 2}},
+			InsertData:     []*writebuffer.InsertData{
+				// Non-nil slice short-circuits the PrepareInsert path (see line 94-105).
+			},
+		}
+	}
+
+	t.Run("close msg is passed through unchanged", func(t *testing.T) {
+		wbManager := writebuffer.NewMockBufferManager(t)
+		node := newNode(t, wbManager, nil)
+
+		out := node.Operate([]Msg{&FlowGraphMsg{BaseMsg: flowgraph.NewBaseMsg(true)}})
+		assert.Equal(t, 1, len(out))
+		fg, ok := out[0].(*FlowGraphMsg)
+		assert.True(t, ok)
+		assert.True(t, fg.IsCloseMsg())
+	})
+
+	t.Run("BufferData failure with errHandler", func(t *testing.T) {
+		injected := errors.New("injected buffer data error")
+		wbManager := writebuffer.NewMockBufferManager(t)
+		wbManager.EXPECT().
+			BufferData(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(injected).
+			Once()
+
+		var (
+			handlerCalled int
+			capturedErr   error
+		)
+		handler := func(err error) {
+			handlerCalled++
+			capturedErr = err
+		}
+		node := newNode(t, wbManager, handler)
+
+		var out []Msg
+		assert.NotPanics(t, func() {
+			out = node.Operate([]Msg{validFGMsg()})
+		})
+		assert.Equal(t, 1, handlerCalled, "errHandler should be invoked exactly once")
+		assert.ErrorIs(t, capturedErr, injected,
+			"errHandler should receive the underlying BufferData error unwrapped")
+		assert.Equal(t, 1, len(out))
+		fg, ok := out[0].(*FlowGraphMsg)
+		assert.True(t, ok)
+		assert.True(t, fg.IsCloseMsg(),
+			"on BufferData failure, the errHandler path must return a close msg to trigger flowgraph shutdown")
+	})
+
+	t.Run("BufferData failure with nil handler panics (DataNode compat)", func(t *testing.T) {
+		wbManager := writebuffer.NewMockBufferManager(t)
+		wbManager.EXPECT().
+			BufferData(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(errors.New("boom")).
+			Once()
+
+		node := newNode(t, wbManager, nil)
+		assert.Panics(t, func() {
+			node.Operate([]Msg{validFGMsg()})
+		}, "nil errHandler must preserve the legacy DataNode panic-on-failure contract")
+	})
+}

--- a/internal/flushcommon/util/util.go
+++ b/internal/flushcommon/util/util.go
@@ -49,6 +49,7 @@ type PipelineParams struct {
 	Allocator          allocator.Interface
 	MsgHandler         MsgHandler
 	SchemaManager      metacache.SchemaManager
+	ErrorHandler       func(error) // Called on unrecoverable write errors; if nil, the caller should panic.
 }
 
 // TimeRange is a range of timestamp contains the min-timestamp and max-timestamp

--- a/internal/flushcommon/writebuffer/l0_write_buffer.go
+++ b/internal/flushcommon/writebuffer/l0_write_buffer.go
@@ -48,15 +48,21 @@ func NewL0WriteBuffer(channel string, metacache metacache.MetaCache, syncMgr syn
 	}, nil
 }
 
-func (wb *l0WriteBuffer) dispatchDeleteMsgsWithoutFilter(deleteMsgs []*msgstream.DeleteMsg, startPos, endPos *msgpb.MsgPosition) {
+func (wb *l0WriteBuffer) dispatchDeleteMsgsWithoutFilter(deleteMsgs []*msgstream.DeleteMsg, startPos, endPos *msgpb.MsgPosition) error {
 	for _, msg := range deleteMsgs {
-		l0SegmentID := wb.getL0SegmentID(msg.GetPartitionID(), startPos)
+		l0SegmentID, err := wb.getL0SegmentID(msg.GetPartitionID(), startPos)
+		if err != nil {
+			return err
+		}
 		pks := storage.ParseIDs2PrimaryKeys(msg.GetPrimaryKeys())
 		pkTss := msg.GetTimestamps()
 		if len(pks) > 0 {
-			wb.bufferDelete(l0SegmentID, pks, pkTss, startPos, endPos)
+			if err := wb.bufferDelete(l0SegmentID, pks, pkTss, startPos, endPos); err != nil {
+				return err
+			}
 		}
 	}
+	return nil
 }
 
 func (wb *l0WriteBuffer) BufferData(insertData []*InsertData, deleteMsgs []*msgstream.DeleteMsg, startPos, endPos *msgpb.MsgPosition) error {
@@ -74,7 +80,9 @@ func (wb *l0WriteBuffer) BufferData(insertData []*InsertData, deleteMsgs []*msgs
 	// In streaming service mode, flushed segments no longer maintain a bloom filter.
 	// So, here we skip generating BF (growing segment's BF will be regenerated during the sync phase)
 	// and also skip filtering delete entries by bf.
-	wb.dispatchDeleteMsgsWithoutFilter(deleteMsgs, startPos, endPos)
+	if err := wb.dispatchDeleteMsgsWithoutFilter(deleteMsgs, startPos, endPos); err != nil {
+		return err
+	}
 	// update buffer last checkpoint
 	wb.checkpoint = endPos
 
@@ -93,7 +101,10 @@ func (wb *l0WriteBuffer) BufferData(insertData []*InsertData, deleteMsgs []*msgs
 // bufferInsert function InsertMsg into bufferred InsertData and returns primary key field data for future usage.
 func (wb *l0WriteBuffer) bufferInsert(inData *InsertData, startPos, endPos *msgpb.MsgPosition) error {
 	wb.CreateNewGrowingSegment(inData.partitionID, inData.segmentID, startPos)
-	segBuf := wb.getOrCreateBuffer(inData.segmentID, startPos.GetTimestamp())
+	segBuf, err := wb.getOrCreateBuffer(inData.segmentID, startPos.GetTimestamp())
+	if err != nil {
+		return err
+	}
 
 	totalMemSize := segBuf.insertBuffer.Buffer(inData, startPos, endPos)
 	wb.metaCache.UpdateSegments(metacache.SegmentActions(
@@ -106,7 +117,7 @@ func (wb *l0WriteBuffer) bufferInsert(inData *InsertData, startPos, endPos *msgp
 	return nil
 }
 
-func (wb *l0WriteBuffer) getL0SegmentID(partitionID int64, startPos *msgpb.MsgPosition) int64 {
+func (wb *l0WriteBuffer) getL0SegmentID(partitionID int64, startPos *msgpb.MsgPosition) (int64, error) {
 	log := wb.logger
 	segmentID, ok := wb.l0Segments[partitionID]
 	if !ok {
@@ -117,7 +128,7 @@ func (wb *l0WriteBuffer) getL0SegmentID(partitionID int64, startPos *msgpb.MsgPo
 		})
 		if err != nil {
 			log.Error("failed to allocate l0 segment ID", zap.Error(err))
-			panic(err)
+			return 0, err
 		}
 		wb.l0Segments[partitionID] = segmentID
 		wb.l0partition[segmentID] = partitionID
@@ -136,5 +147,5 @@ func (wb *l0WriteBuffer) getL0SegmentID(partitionID int64, startPos *msgpb.MsgPo
 			zap.Any("start position", startPos),
 		)
 	}
-	return segmentID
+	return segmentID, nil
 }

--- a/internal/flushcommon/writebuffer/write_buffer.go
+++ b/internal/flushcommon/writebuffer/write_buffer.go
@@ -379,19 +379,18 @@ func (wb *writeBufferBase) getSegmentsToSync(ts typeutil.Timestamp, policies ...
 	return segments.Collect()
 }
 
-func (wb *writeBufferBase) getOrCreateBuffer(segmentID int64, timetick uint64) *segmentBuffer {
+func (wb *writeBufferBase) getOrCreateBuffer(segmentID int64, timetick uint64) (*segmentBuffer, error) {
 	buffer, ok := wb.buffers[segmentID]
 	if !ok {
 		var err error
 		buffer, err = newSegmentBuffer(segmentID, wb.metaCache.GetSchema(timetick))
 		if err != nil {
-			// TODO avoid panic here
-			panic(err)
+			return nil, err
 		}
 		wb.buffers[segmentID] = buffer
 	}
 
-	return buffer
+	return buffer, nil
 }
 
 func (wb *writeBufferBase) yieldBuffer(segmentID int64) ([]*storage.InsertData, map[int64]*storage.BM25Stats, *storage.DeleteData, *schemapb.CollectionSchema, *TimeRange, *msgpb.MsgPosition) {
@@ -554,10 +553,14 @@ func (wb *writeBufferBase) CreateNewGrowingSegment(partitionID int64, segmentID 
 }
 
 // bufferDelete buffers DeleteMsg into DeleteData.
-func (wb *writeBufferBase) bufferDelete(segmentID int64, pks []storage.PrimaryKey, tss []typeutil.Timestamp, startPos, endPos *msgpb.MsgPosition) {
-	segBuf := wb.getOrCreateBuffer(segmentID, tss[0])
+func (wb *writeBufferBase) bufferDelete(segmentID int64, pks []storage.PrimaryKey, tss []typeutil.Timestamp, startPos, endPos *msgpb.MsgPosition) error {
+	segBuf, err := wb.getOrCreateBuffer(segmentID, tss[0])
+	if err != nil {
+		return err
+	}
 	bufSize := segBuf.deltaBuffer.Buffer(pks, tss, startPos, endPos)
 	metrics.DataNodeFlowGraphBufferDataSize.WithLabelValues(paramtable.GetStringNodeID(), fmt.Sprint(wb.collectionID)).Add(float64(bufSize))
+	return nil
 }
 
 func (wb *writeBufferBase) getSyncTask(ctx context.Context, segmentID int64) (syncmgr.Task, error) {
@@ -686,14 +689,14 @@ func (wb *writeBufferBase) Close(ctx context.Context, drop bool) {
 	err := conc.AwaitAll(futures...)
 	if err != nil {
 		log.Error("failed to sink write buffer data", zap.Error(err))
-		// TODO change to remove channel in the future
-		panic(err)
+		wb.errHandler(err)
+		return
 	}
 	err = wb.metaWriter.DropChannel(ctx, wb.channelName)
 	if err != nil {
 		log.Error("failed to drop channel", zap.Error(err))
-		// TODO change to remove channel in the future
-		panic(err)
+		wb.errHandler(err)
+		return
 	}
 }
 

--- a/internal/flushcommon/writebuffer/write_buffer_test.go
+++ b/internal/flushcommon/writebuffer/write_buffer_test.go
@@ -66,7 +66,8 @@ func (s *WriteBufferSuite) TestHasSegment() {
 
 	s.False(s.wb.HasSegment(segmentID))
 
-	s.wb.getOrCreateBuffer(segmentID, 0)
+	_, err := s.wb.getOrCreateBuffer(segmentID, 0)
+	s.Require().NoError(err)
 
 	s.True(s.wb.HasSegment(segmentID))
 }

--- a/internal/streamingnode/server/flusher/flusherimpl/flusher_components.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/flusher_components.go
@@ -130,6 +130,11 @@ func (impl *flusherComponents) WhenDropCollection(vchannel string) {
 }
 
 // HandleMessage handles the plain message.
+//
+// Contract: ctx MUST be a stable context that is not cancelled by the DSS failure
+// handler (i.e. not failCtx from WALFlusherImpl.Execute). Per-message delivery needs
+// to be atomic across all vchannels; a mid-call cancel leaves partial state that
+// diverges from the recovery-storage checkpoint. See wal_flusher.go dispatch() doc.
 func (impl *flusherComponents) HandleMessage(ctx context.Context, msg message.ImmutableMessage) error {
 	// AlterReplicateConfig is a coordinator-only message, skip it in flusher.
 	if msg.MessageType() == message.MessageTypeAlterReplicateConfig {
@@ -146,6 +151,11 @@ func (impl *flusherComponents) HandleMessage(ctx context.Context, msg message.Im
 }
 
 // broadcastToAllDataSyncService broadcasts the message to all data sync services.
+//
+// Contract: callers MUST pass a stable context — not one cancelled by the DSS failure
+// handler — because a mid-loop cancel leaves earlier vchannels written and later ones
+// skipped, while ObserveMessage (deferred in the caller) still advances the recovery
+// checkpoint, causing data loss on flusher restart. See wal_flusher.go dispatch() doc.
 func (impl *flusherComponents) broadcastToAllDataSyncService(ctx context.Context, msg message.ImmutableMessage) error {
 	for _, ds := range impl.dataServices {
 		if err := ds.HandleMessage(ctx, msg); err != nil {

--- a/internal/streamingnode/server/flusher/flusherimpl/flusher_components.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/flusher_components.go
@@ -131,7 +131,7 @@ func (impl *flusherComponents) WhenDropCollection(vchannel string) {
 
 // HandleMessage handles the plain message.
 //
-// Contract: ctx MUST be a stable context that is not cancelled by the DSS failure
+// Contract: ctx MUST be a stable context that is not canceled by the DSS failure
 // handler (i.e. not failCtx from WALFlusherImpl.Execute). Per-message delivery needs
 // to be atomic across all vchannels; a mid-call cancel leaves partial state that
 // diverges from the recovery-storage checkpoint. See wal_flusher.go dispatch() doc.
@@ -152,7 +152,7 @@ func (impl *flusherComponents) HandleMessage(ctx context.Context, msg message.Im
 
 // broadcastToAllDataSyncService broadcasts the message to all data sync services.
 //
-// Contract: callers MUST pass a stable context — not one cancelled by the DSS failure
+// Contract: callers MUST pass a stable context — not one canceled by the DSS failure
 // handler — because a mid-loop cancel leaves earlier vchannels written and later ones
 // skipped, while ObserveMessage (deferred in the caller) still advances the recovery
 // checkpoint, causing data loss on flusher restart. See wal_flusher.go dispatch() doc.

--- a/internal/streamingnode/server/flusher/flusherimpl/flusher_components.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/flusher_components.go
@@ -3,6 +3,7 @@ package flusherimpl
 import (
 	"context"
 
+	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
@@ -11,6 +12,7 @@ import (
 	"github.com/milvus-io/milvus/internal/flushcommon/pipeline"
 	"github.com/milvus-io/milvus/internal/flushcommon/syncmgr"
 	"github.com/milvus-io/milvus/internal/flushcommon/util"
+	"github.com/milvus-io/milvus/internal/flushcommon/writebuffer"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/resource"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal"
@@ -37,6 +39,17 @@ type flusherComponents struct {
 	logger                     *log.MLogger
 	recoveryCheckPointTimeTick uint64 // The time tick of the recovery storage.
 	rs                         recovery.RecoveryStorage
+	failCancel                 context.CancelCauseFunc // Cancels the flusher context on DSS write failure.
+}
+
+// makeWriteFailureHandler creates an error handler for a specific vchannel's DSS.
+// When invoked, it cancels the flusher's context to trigger flusher shutdown and WAL re-consumption.
+func (impl *flusherComponents) makeWriteFailureHandler(vchannel string) func(error) {
+	return func(err error) {
+		impl.logger.Warn("DSS write failure, triggering flusher restart",
+			zap.String("vchannel", vchannel), zap.Error(err))
+		impl.failCancel(errors.Wrapf(err, "DSS write failure on vchannel %s", vchannel))
+	}
 }
 
 // WhenCreateCollection handles the create collection message.
@@ -60,6 +73,7 @@ func (impl *flusherComponents) WhenCreateCollection(createCollectionMsg message.
 	}
 
 	msgChan := make(chan *msgstream.MsgPack, 10)
+	failureHandler := impl.makeWriteFailureHandler(createCollectionMsg.VChannel())
 	ds := pipeline.NewEmptyStreamingNodeDataSyncService(
 		context.Background(), // There's no any rpc in this function, so the context is not used here.
 		&util.PipelineParams{
@@ -72,6 +86,7 @@ func (impl *flusherComponents) WhenCreateCollection(createCollectionMsg message.
 			Allocator:          idalloc.NewMAllocator(resource.Resource().IDAllocator()),
 			MsgHandler:         newMsgHandler(resource.Resource().WriteBufferManager()),
 			SchemaManager:      newVersionedSchemaManager(createCollectionMsg.VChannel(), impl.rs),
+			ErrorHandler:       failureHandler,
 		},
 		msgChan,
 		&datapb.VchannelInfo{
@@ -99,6 +114,7 @@ func (impl *flusherComponents) WhenCreateCollection(createCollectionMsg message.
 			}
 		},
 		nil,
+		writebuffer.WithErrorHandler(failureHandler),
 	)
 	impl.addNewDataSyncService(createCollectionMsg, msgChan, ds)
 }
@@ -246,6 +262,8 @@ func (impl *flusherComponents) buildDataSyncService(ctx context.Context, recover
 	input := make(chan *msgstream.MsgPack, 10)
 	schemaManager := newVersionedSchemaManager(recoverInfo.GetInfo().GetChannelName(), impl.rs)
 	schema := schemaManager.GetSchema(0)
+	vchannel := recoverInfo.GetInfo().GetChannelName()
+	failureHandler := impl.makeWriteFailureHandler(vchannel)
 	ds, err := pipeline.NewStreamingNodeDataSyncService(ctx,
 		&util.PipelineParams{
 			Ctx:                context.Background(),
@@ -256,7 +274,8 @@ func (impl *flusherComponents) buildDataSyncService(ctx context.Context, recover
 			CheckpointUpdater:  impl.cpUpdater,
 			Allocator:          idalloc.NewMAllocator(resource.Resource().IDAllocator()),
 			MsgHandler:         newMsgHandler(resource.Resource().WriteBufferManager()),
-			SchemaManager:      newVersionedSchemaManager(recoverInfo.GetInfo().GetChannelName(), impl.rs),
+			SchemaManager:      newVersionedSchemaManager(vchannel, impl.rs),
+			ErrorHandler:       failureHandler,
 		},
 		&datapb.ChannelWatchInfo{Vchan: recoverInfo.GetInfo(), Schema: schema},
 		input,
@@ -273,6 +292,7 @@ func (impl *flusherComponents) buildDataSyncService(ctx context.Context, recover
 			}
 		},
 		nil,
+		writebuffer.WithErrorHandler(failureHandler),
 	)
 	if err != nil {
 		return nil, err

--- a/internal/streamingnode/server/flusher/flusherimpl/wal_flusher.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/wal_flusher.go
@@ -243,7 +243,7 @@ func (impl *WALFlusherImpl) generateScanner(ctx context.Context, l wal.WAL, chec
 
 // dispatch dispatches the message to the related handler for flusher components.
 //
-// The caller MUST pass a stable context that is not cancelled by the DSS failure handler
+// The caller MUST pass a stable context that is not canceled by the DSS failure handler
 // (typically impl.notifier.Context()). Dispatch of a single WAL message must be atomic:
 // either every target vchannel receives every MsgPack AND ObserveMessage advances the
 // recovery checkpoint, or none of it happens. Passing a cancellable failCtx here would

--- a/internal/streamingnode/server/flusher/flusherimpl/wal_flusher.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/wal_flusher.go
@@ -83,6 +83,10 @@ func (impl *WALFlusherImpl) Execute(recoverSnapshot *recovery.RecoverySnapshot) 
 		impl.logger.Warn("wal flusher is canceled before executing", zap.Error(err))
 	}()
 
+	// Create a derived context with cancel-cause so that DSS write failures can trigger flusher shutdown.
+	failCtx, failCancel := context.WithCancelCause(impl.notifier.Context())
+	defer failCancel(nil)
+
 	// because current flusher is build asynchronously,
 	// so we need to enter slowdown mode to protect the wal from being overloaded before the recovery-storage scanner is started.
 	// recovery-storage scanner will protect the wal from being overloaded after the recovery-storage is started.
@@ -96,7 +100,7 @@ func (impl *WALFlusherImpl) Execute(recoverSnapshot *recovery.RecoverySnapshot) 
 	impl.logger.Info("wal ready for flusher recovery")
 
 	var checkpoint message.MessageID
-	impl.flusherComponents, checkpoint, err = impl.buildFlusherComponents(impl.notifier.Context(), l, recoverSnapshot)
+	impl.flusherComponents, checkpoint, err = impl.buildFlusherComponents(impl.notifier.Context(), l, recoverSnapshot, failCancel)
 	if err != nil {
 		return errors.Wrap(err, "when build flusher components")
 	}
@@ -115,7 +119,11 @@ func (impl *WALFlusherImpl) Execute(recoverSnapshot *recovery.RecoverySnapshot) 
 
 	for {
 		select {
-		case <-impl.notifier.Context().Done():
+		case <-failCtx.Done():
+			// Check if the flusher was stopped due to a DSS write failure.
+			if cause := context.Cause(failCtx); cause != nil && !errors.Is(cause, context.Canceled) {
+				impl.logger.Warn("wal flusher stopped due to DSS write failure, will trigger re-consumption", zap.Error(cause))
+			}
 			return nil
 		case msg, ok := <-scanner.Chan():
 			if !ok {
@@ -123,8 +131,7 @@ func (impl *WALFlusherImpl) Execute(recoverSnapshot *recovery.RecoverySnapshot) 
 				return nil
 			}
 			impl.metrics.ObserveMetrics(msg.TimeTick())
-			if err := impl.dispatch(msg); err != nil {
-				// The error is always context canceled.
+			if err := impl.dispatch(failCtx, msg); err != nil {
 				return nil
 			}
 		}
@@ -144,7 +151,7 @@ func (impl *WALFlusherImpl) Close() {
 }
 
 // buildFlusherComponents builds the components of the flusher.
-func (impl *WALFlusherImpl) buildFlusherComponents(ctx context.Context, l wal.WAL, snapshot *recovery.RecoverySnapshot) (*flusherComponents, message.MessageID, error) {
+func (impl *WALFlusherImpl) buildFlusherComponents(ctx context.Context, l wal.WAL, snapshot *recovery.RecoverySnapshot, failCancel context.CancelCauseFunc) (*flusherComponents, message.MessageID, error) {
 	// Get all existed vchannels of the pchannel.
 	vchannels := lo.Keys(snapshot.VChannels)
 	impl.logger.Info("fetch vchannel done", zap.Int("vchannelNum", len(vchannels)))
@@ -191,6 +198,7 @@ func (impl *WALFlusherImpl) buildFlusherComponents(ctx context.Context, l wal.WA
 		logger:                     impl.logger,
 		recoveryCheckPointTimeTick: snapshot.Checkpoint.TimeTick,
 		rs:                         impl.RecoveryStorage,
+		failCancel:                 failCancel,
 	}
 	impl.logger.Info("flusher components intiailizing done")
 	if err := fc.recover(ctx, recoverInfos); err != nil {
@@ -222,7 +230,7 @@ func (impl *WALFlusherImpl) generateScanner(ctx context.Context, l wal.WAL, chec
 }
 
 // dispatch dispatches the message to the related handler for flusher components.
-func (impl *WALFlusherImpl) dispatch(msg message.ImmutableMessage) (err error) {
+func (impl *WALFlusherImpl) dispatch(ctx context.Context, msg message.ImmutableMessage) (err error) {
 	if msg.MessageType() == message.MessageTypeTimeTick && !msg.IsPersisted() {
 		// Currently, milvus use the timetick to synchronize the system periodically,
 		// so the wal will still produce empty timetick message after the last write operation is done.
@@ -244,7 +252,7 @@ func (impl *WALFlusherImpl) dispatch(msg message.ImmutableMessage) (err error) {
 	// TODO: should be removed at 3.0, after merge the flusher logic into recovery storage.
 	// only for truncate api now.
 	if bh := msg.BroadcastHeader(); bh != nil && bh.AckSyncUp {
-		if err := impl.RecoveryStorage.ObserveMessage(impl.notifier.Context(), msg); err != nil {
+		if err := impl.RecoveryStorage.ObserveMessage(ctx, msg); err != nil {
 			impl.logger.Warn("failed to observe message", zap.Error(err))
 			return err
 		}
@@ -252,7 +260,7 @@ func (impl *WALFlusherImpl) dispatch(msg message.ImmutableMessage) (err error) {
 		// TODO: We will merge the flusher into recovery storage in future.
 		// Currently, flusher works as a separate component.
 		defer func() {
-			if err = impl.RecoveryStorage.ObserveMessage(impl.notifier.Context(), msg); err != nil {
+			if err = impl.RecoveryStorage.ObserveMessage(ctx, msg); err != nil {
 				impl.logger.Warn("failed to observe message", zap.Error(err))
 			}
 		}()
@@ -279,5 +287,5 @@ func (impl *WALFlusherImpl) dispatch(msg message.ImmutableMessage) (err error) {
 			impl.flusherComponents.WhenDropCollection(msg.VChannel())
 		}()
 	}
-	return impl.flusherComponents.HandleMessage(impl.notifier.Context(), msg)
+	return impl.flusherComponents.HandleMessage(ctx, msg)
 }

--- a/internal/streamingnode/server/flusher/flusherimpl/wal_flusher.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/wal_flusher.go
@@ -84,6 +84,15 @@ func (impl *WALFlusherImpl) Execute(recoverSnapshot *recovery.RecoverySnapshot) 
 	}()
 
 	// Create a derived context with cancel-cause so that DSS write failures can trigger flusher shutdown.
+	//
+	// Context split:
+	//   - failCtx: gates the OUTER scanner loop only (the select below). When a DSS async
+	//     failure fires failCancel, we stop pulling new messages from the scanner and exit.
+	//   - impl.notifier.Context(): governs every INNER per-message operation (dispatch,
+	//     HandleMessage, broadcast, ObserveMessage). Once a message is pulled from the scanner
+	//     we MUST complete its delivery atomically — otherwise partial MsgPack delivery races
+	//     with ObserveMessage advancing the recovery-storage checkpoint, which would cause the
+	//     re-opened flusher to skip partially-flushed data. See PR #48928 review discussion.
 	failCtx, failCancel := context.WithCancelCause(impl.notifier.Context())
 	defer failCancel(nil)
 
@@ -131,7 +140,10 @@ func (impl *WALFlusherImpl) Execute(recoverSnapshot *recovery.RecoverySnapshot) 
 				return nil
 			}
 			impl.metrics.ObserveMetrics(msg.TimeTick())
-			if err := impl.dispatch(failCtx, msg); err != nil {
+			// Pass the stable notifier context (NOT failCtx) into dispatch, so that a concurrent
+			// DSS failure firing failCancel mid-dispatch cannot interrupt in-flight per-message
+			// delivery. An async DSS failure only affects the next scanner iteration via failCtx.Done().
+			if err := impl.dispatch(impl.notifier.Context(), msg); err != nil {
 				return nil
 			}
 		}
@@ -230,6 +242,14 @@ func (impl *WALFlusherImpl) generateScanner(ctx context.Context, l wal.WAL, chec
 }
 
 // dispatch dispatches the message to the related handler for flusher components.
+//
+// The caller MUST pass a stable context that is not cancelled by the DSS failure handler
+// (typically impl.notifier.Context()). Dispatch of a single WAL message must be atomic:
+// either every target vchannel receives every MsgPack AND ObserveMessage advances the
+// recovery checkpoint, or none of it happens. Passing a cancellable failCtx here would
+// allow a mid-dispatch cancel to leave some vchannels written and some not, while
+// ObserveMessage still unconditionally advances the recovery-storage checkpoint, causing
+// the re-opened flusher to skip data that was never actually flushed.
 func (impl *WALFlusherImpl) dispatch(ctx context.Context, msg message.ImmutableMessage) (err error) {
 	if msg.MessageType() == message.MessageTypeTimeTick && !msg.IsPersisted() {
 		// Currently, milvus use the timetick to synchronize the system periodically,

--- a/internal/streamingnode/server/flusher/flusherimpl/wal_flusher_test.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/wal_flusher_test.go
@@ -6,10 +6,15 @@ package flusherimpl
 import (
 	"context"
 	"os"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
@@ -112,6 +117,152 @@ func TestWALFlusher(t *testing.T) {
 	flusher := RecoverWALFlusher(param)
 	time.Sleep(5 * time.Second)
 	flusher.Close()
+}
+
+// TestWALFlusherGracefulExitOnDSSFailure asserts that when a DSS failure handler is
+// invoked mid-flight (as would happen when an async write-buffer / flowgraph node
+// fails), the flusher:
+//  1. exits the main loop cleanly (graceful shutdown, no panic)
+//  2. does not leave recovery state diverged relative to dispatched messages —
+//     i.e. for every ObserveMessage call that started under the in-flight dispatch
+//     path, the call completes.
+//
+// Regression coverage for PR #48928 review comments on wal_flusher.go:134 and
+// flusher_components.go:42: failCtx must NOT be passed into the in-flight
+// dispatch/HandleMessage/ObserveMessage path, otherwise a mid-call cancel would
+// leave partial MsgPack delivery while ObserveMessage advances the recovery
+// checkpoint. This test pins the "dispatch is atomic relative to DSS failure" invariant.
+func TestWALFlusherGracefulExitOnDSSFailure(t *testing.T) {
+	streamingutil.SetStreamingServiceEnabled()
+	defer streamingutil.UnsetStreamingServiceEnabled()
+
+	// Build mixcoord inline with all expectations as .Maybe(), since this test
+	// tears the flusher down early on DSS failure and may not drive every lifecycle call.
+	mixcoord := mocks.NewMockMixCoordClient(t)
+	mixcoord.EXPECT().DropVirtualChannel(mock.Anything, mock.Anything).Return(&datapb.DropVirtualChannelResponse{
+		Status: &commonpb.Status{ErrorCode: commonpb.ErrorCode_Success},
+	}, nil).Maybe()
+	mixcoord.EXPECT().GetChannelRecoveryInfo(mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, request *datapb.GetChannelRecoveryInfoRequest, option ...grpc.CallOption,
+		) (*datapb.GetChannelRecoveryInfoResponse, error) {
+			messageID := 1
+			b := make([]byte, 8)
+			common.Endian.PutUint64(b, uint64(messageID))
+			return &datapb.GetChannelRecoveryInfoResponse{
+				Info: &datapb.VchannelInfo{
+					ChannelName:  request.GetVchannel(),
+					SeekPosition: &msgpb.MsgPosition{MsgID: b},
+				},
+				Schema: &schemapb.CollectionSchema{
+					Fields: []*schemapb.FieldSchema{
+						{FieldID: 100, Name: "ID", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+						{FieldID: 101, Name: "Vector", DataType: schemapb.DataType_FloatVector},
+					},
+				},
+			}, nil
+		}).Maybe()
+	mixcoord.EXPECT().AllocSegment(mock.Anything, mock.Anything).Return(&datapb.AllocSegmentResponse{
+		Status: merr.Status(nil),
+	}, nil).Maybe()
+	fMixcoord := syncutil.NewFuture[internaltypes.MixCoordClient]()
+	fMixcoord.Set(mixcoord)
+
+	rs := mock_recovery.NewMockRecoveryStorage(t)
+	rs.EXPECT().GetSchema(mock.Anything, mock.Anything, mock.Anything).Return(&schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "ID", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+			{FieldID: 101, Name: "Vector", DataType: schemapb.DataType_FloatVector},
+		},
+	}, nil).Maybe()
+
+	// Count ObserveMessage calls; for the first call, block briefly so the test can
+	// concurrently fire the failure handler while dispatch is in-flight. The fix
+	// guarantees this first call runs to completion (stable ctx), not cancelled.
+	var (
+		observed     atomic.Int64
+		firstStarted = make(chan struct{})
+		firstProceed = make(chan struct{})
+		once         sync.Once
+	)
+	rs.EXPECT().ObserveMessage(mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, msg message.ImmutableMessage) error {
+			if observed.Add(1) == 1 {
+				once.Do(func() { close(firstStarted) })
+				// Wait for the test to fire the failure handler, then continue.
+				// Importantly, we do NOT consult ctx here — this mirrors production
+				// ObserveMessage (recovery_storage_impl.go) which ignores ctx.
+				<-firstProceed
+			}
+			return nil
+		}).Maybe()
+	rs.EXPECT().Close().Return().Maybe()
+
+	resource.InitForTest(
+		t,
+		resource.OptMixCoordClient(fMixcoord),
+		resource.OptChunkManager(mock_storage.NewMockChunkManager(t)),
+	)
+
+	l := newMockWAL(t, true)
+	rateLimitComponent := rate.NewWALRateLimitComponent(l.Channel())
+	defer rateLimitComponent.Close()
+
+	param := &RecoverWALFlusherParam{
+		ChannelInfo: l.Channel(),
+		WAL:         syncutil.NewFuture[wal.WAL](),
+		RecoverySnapshot: &recovery.RecoverySnapshot{
+			VChannels: map[string]*streamingpb.VChannelMeta{
+				"vchannel-1": {
+					CollectionInfo: &streamingpb.CollectionInfoOfVChannel{CollectionId: 100},
+				},
+			},
+			Checkpoint: &recovery.WALCheckpoint{TimeTick: 0},
+		},
+		RecoveryStorage:    rs,
+		RateLimitComponent: rateLimitComponent,
+	}
+	param.WAL.Set(l)
+	flusher := RecoverWALFlusher(param)
+
+	// Wait until the first ObserveMessage is running (i.e. dispatch is in-flight),
+	// then fire the DSS failure handler. With the fix this maps to failCancel, but
+	// the dispatch call for the first message must still complete atomically.
+	select {
+	case <-firstStarted:
+	case <-time.After(10 * time.Second):
+		close(firstProceed)
+		flusher.Close()
+		t.Fatal("timed out waiting for first ObserveMessage to start")
+	}
+
+	// Fire the failure handler while dispatch is in-flight. This is exactly the
+	// scenario that, prior to the fix, would cancel the dispatch's ctx and let
+	// ObserveMessage/HandleMessage see ctx.Err() mid-call.
+	require.NotNil(t, flusher.flusherComponents, "flusherComponents must be built before the first dispatch")
+	flusher.flusherComponents.makeWriteFailureHandler("vchannel-1")(errors.New("simulated DSS write failure"))
+
+	// Let the in-flight ObserveMessage return. The dispatch of the first message
+	// must still complete successfully.
+	close(firstProceed)
+
+	// Now the Execute main loop should exit via failCtx.Done(). Close should return
+	// promptly; if the loop was wedged or dispatch was partially aborted, Close would
+	// hang or we'd have observed a panic.
+	done := make(chan struct{})
+	go func() {
+		flusher.Close()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("flusher.Close did not return; graceful exit path is blocked")
+	}
+
+	// At least the first message's ObserveMessage was invoked and returned nil —
+	// dispatch was atomic with respect to the mid-flight failure.
+	assert.GreaterOrEqual(t, observed.Load(), int64(1),
+		"dispatch should have completed ObserveMessage for at least the in-flight message")
 }
 
 func newMockMixcoord(t *testing.T, maybe bool) *mocks.MockMixCoordClient {

--- a/internal/streamingnode/server/flusher/flusherimpl/wal_flusher_test.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/wal_flusher_test.go
@@ -177,7 +177,7 @@ func TestWALFlusherGracefulExitOnDSSFailure(t *testing.T) {
 
 	// Count ObserveMessage calls; for the first call, block briefly so the test can
 	// concurrently fire the failure handler while dispatch is in-flight. The fix
-	// guarantees this first call runs to completion (stable ctx), not cancelled.
+	// guarantees this first call runs to completion (stable ctx), not canceled.
 	var (
 		observed     atomic.Int64
 		firstStarted = make(chan struct{})


### PR DESCRIPTION
When the Data Sync Service (DSS) encounters a write failure (e.g., buffer creation error, sync task failure, L0 segment ID allocation failure), it previously called panic(), crashing the entire process.

This change replaces those panics with a graceful exit mechanism:
- Add context.WithCancelCause to the WAL flusher so DSS write failures cancel the flusher context instead of panicking
- Wire the failure handler through WriteBuffer's existing WithErrorHandler option and a new PipelineParams.ErrorHandler field
- Replace panic() in WriteNode, EmbeddingNode, and WriteBuffer with error handler calls that return close messages to shut down the flowgraph
- Convert getOrCreateBuffer and getL0SegmentID to return errors instead of panicking, propagating through the existing BufferData error path

When a DSS write failure occurs, the flusher detects the context cancellation, exits gracefully, and the WAL lifetime manager re-opens the WAL with a new flusher that re-consumes from checkpoint. This is safe because WAL replay is idempotent.

The DataNode (non-streaming) path retains the default panic behavior for backward compatibility.

issue: #48927
related to #48885