### PR TITLE
fix: insert/upsert fails on 2.5 collections due to $meta nullable mismatch

### DIFF
--- a/internal/proxy/task_upsert.go
+++ b/internal/proxy/task_upsert.go
@@ -309,10 +309,13 @@ func (it *upsertTask) queryPreExecute(ctx context.Context) error {
 		fieldData.FieldId = fieldSchema.GetFieldID()
 		fieldData.FieldName = fieldName
 
-		// Ensure dynamic field has ValidData before merge logic.
-		// SDK doesn't set ValidData on $meta; without it, AppendFieldDataByColumn
-		// won't propagate ValidData for insert rows, causing length mismatch.
-		if fieldData.GetIsDynamic() && len(fieldData.GetValidData()) == 0 {
+		// Ensure dynamic field has ValidData before merge logic, but only when
+		// the field schema actually requires it (nullable or has default value).
+		// For 2.5 collections where $meta is non-nullable with no default,
+		// ValidData must remain empty — CheckValidData expects len==0 for
+		// non-nullable fields.
+		if fieldData.GetIsDynamic() && len(fieldData.GetValidData()) == 0 &&
+			(fieldSchema.GetNullable() || fieldSchema.GetDefaultValue() != nil) {
 			nRows := int(it.upsertMsg.InsertMsg.NRows())
 			validData := make([]bool, nRows)
 			for i := range validData {

--- a/internal/proxy/task_upsert_test.go
+++ b/internal/proxy/task_upsert_test.go
@@ -3066,4 +3066,108 @@ func TestUpsertTask_queryPreExecute_DynamicFieldValidData(t *testing.T) {
 		assert.Equal(t, 3, len(validData),
 			"queryPreExecute auto-fills ValidData, merge produces correct length 3")
 	})
+
+	t.Run("v25 schema (non-nullable $meta) upsert should not fail", func(t *testing.T) {
+		// 2.5-style schema: $meta is NOT nullable and has NO default value.
+		// After upgrading to 2.6, existing collections retain this schema.
+		// queryPreExecute must NOT unconditionally fill ValidData for $meta,
+		// because CheckValidData expects len(ValidData)==0 for non-nullable fields.
+		v25Schema := newSchemaInfo(&schemapb.CollectionSchema{
+			Name:               "test_v25_compat",
+			EnableDynamicField: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "id", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+				{FieldID: 101, Name: "value", DataType: schemapb.DataType_Int32},
+				{
+					FieldID: 102, Name: common.MetaFieldName, DataType: schemapb.DataType_JSON,
+					IsDynamic: true,
+					Nullable:  false, // 2.5 style: NOT nullable
+					// No DefaultValue — 2.5 style
+				},
+			},
+		})
+
+		meta1, _ := json.Marshal(map[string]interface{}{"color": "gold"})
+		meta2, _ := json.Marshal(map[string]interface{}{"color": "silver"})
+		meta3, _ := json.Marshal(map[string]interface{}{"color": "bronze"})
+
+		upsertData := []*schemapb.FieldData{
+			{
+				FieldName: "id", FieldId: 100, Type: schemapb.DataType_Int64,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{1, 2, 3}}}}},
+			},
+			{
+				FieldName: "value", FieldId: 101, Type: schemapb.DataType_Int32,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: []int32{100, 200, 300}}}}},
+			},
+			{
+				FieldName: common.MetaFieldName, FieldId: 102, Type: schemapb.DataType_JSON, IsDynamic: true,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_JsonData{
+					JsonData: &schemapb.JSONArray{Data: [][]byte{meta1, meta2, meta3}},
+				}}},
+				// No ValidData — SDK behavior
+			},
+		}
+
+		existMeta1, _ := json.Marshal(map[string]interface{}{"color": "red"})
+		existMeta2, _ := json.Marshal(map[string]interface{}{"color": "blue"})
+		mockQueryResult := &milvuspb.QueryResults{
+			Status: merr.Success(),
+			FieldsData: []*schemapb.FieldData{
+				{
+					FieldName: "id", FieldId: 100, Type: schemapb.DataType_Int64,
+					Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{1, 2}}}}},
+				},
+				{
+					FieldName: "value", FieldId: 101, Type: schemapb.DataType_Int32,
+					Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: []int32{10, 20}}}}},
+				},
+				{
+					FieldName: common.MetaFieldName, FieldId: 102, Type: schemapb.DataType_JSON, IsDynamic: true,
+					Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_JsonData{
+						JsonData: &schemapb.JSONArray{Data: [][]byte{existMeta1, existMeta2}},
+					}}},
+				},
+			},
+		}
+
+		task := &upsertTask{
+			ctx:    context.Background(),
+			schema: v25Schema,
+			req: &milvuspb.UpsertRequest{
+				FieldsData: upsertData,
+				NumRows:    3,
+			},
+			upsertMsg: &msgstream.UpsertMsg{
+				InsertMsg: &msgstream.InsertMsg{
+					InsertRequest: &msgpb.InsertRequest{
+						FieldsData: upsertData,
+						NumRows:    3,
+						Version:    msgpb.InsertDataVersion_ColumnBased,
+					},
+				},
+			},
+			node: &Proxy{},
+		}
+
+		mockRetrieve := mockey.Mock(retrieveByPKs).Return(mockQueryResult, segcore.StorageCost{}, nil).Build()
+		defer mockRetrieve.UnPatch()
+
+		err := task.queryPreExecute(context.Background())
+		assert.NoError(t, err, "queryPreExecute should not fail for 2.5-style non-nullable $meta")
+
+		var metaField *schemapb.FieldData
+		for _, f := range task.insertFieldData {
+			if f.GetFieldName() == common.MetaFieldName {
+				metaField = f
+				break
+			}
+		}
+		assert.NotNil(t, metaField)
+		metaData := metaField.GetScalars().GetJsonData().GetData()
+		assert.Equal(t, 3, len(metaData), "merged $meta should have 3 rows")
+		// For non-nullable $meta, ValidData should remain empty (not auto-filled)
+		assert.Empty(t, metaField.GetValidData(),
+			"non-nullable $meta should NOT have ValidData auto-filled")
+	})
 }

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -1217,12 +1217,8 @@ func autoGenPrimaryFieldData(fieldSchema *schemapb.FieldSchema, data interface{}
 	return &fieldData, nil
 }
 
-func autoGenDynamicFieldData(data [][]byte) *schemapb.FieldData {
-	validData := make([]bool, len(data))
-	for i := range validData {
-		validData[i] = true
-	}
-	return &schemapb.FieldData{
+func autoGenDynamicFieldData(schema *schemapb.CollectionSchema, data [][]byte) *schemapb.FieldData {
+	fd := &schemapb.FieldData{
 		FieldName: common.MetaFieldName,
 		Type:      schemapb.DataType_JSON,
 		Field: &schemapb.FieldData_Scalars{
@@ -1235,8 +1231,23 @@ func autoGenDynamicFieldData(data [][]byte) *schemapb.FieldData {
 			},
 		},
 		IsDynamic: true,
-		ValidData: validData,
 	}
+
+	// Only set ValidData when the $meta field is nullable or has a default value.
+	// For 2.5 collections (non-nullable, no default), CheckValidData expects
+	// len(ValidData)==0, so we must NOT set it.
+	for _, f := range schema.Fields {
+		if f.GetIsDynamic() && (f.GetNullable() || f.GetDefaultValue() != nil) {
+			validData := make([]bool, len(data))
+			for i := range validData {
+				validData[i] = true
+			}
+			fd.ValidData = validData
+			break
+		}
+	}
+
+	return fd
 }
 
 // validateFieldDataColumns validates that all required fields are present and no unknown fields exist.
@@ -2509,7 +2520,7 @@ func doCheckDynamicFieldData(schema *schemapb.CollectionSchema, insertMsg *msgst
 	for i := range defaultData {
 		defaultData[i] = []byte("{}")
 	}
-	dynamicData := autoGenDynamicFieldData(defaultData)
+	dynamicData := autoGenDynamicFieldData(schema, defaultData)
 	insertMsg.FieldsData = append(insertMsg.FieldsData, dynamicData)
 	return nil
 }

--- a/internal/proxy/util_test.go
+++ b/internal/proxy/util_test.go
@@ -2189,8 +2189,8 @@ func Test_CheckDynamicFieldData(t *testing.T) {
 		jsonBytes, err := json.MarshalIndent(data, "", "  ")
 		assert.NoError(t, err)
 		jsonData = append(jsonData, jsonBytes)
-		jsonFieldData := autoGenDynamicFieldData(jsonData)
 		schema := newTestSchema()
+		jsonFieldData := autoGenDynamicFieldData(schema, jsonData)
 		insertMsg := &msgstream.InsertMsg{
 			InsertRequest: &msgpb.InsertRequest{
 				CollectionName: "collectionName",
@@ -2218,8 +2218,8 @@ func Test_CheckDynamicFieldData(t *testing.T) {
 		jsonBytes, err := json.MarshalIndent(data, "", "  ")
 		assert.NoError(t, err)
 		jsonData = append(jsonData, jsonBytes)
-		jsonFieldData := autoGenDynamicFieldData(jsonData)
 		schema := newTestSchema()
+		jsonFieldData := autoGenDynamicFieldData(schema, jsonData)
 		insertMsg := &msgstream.InsertMsg{
 			InsertRequest: &msgpb.InsertRequest{
 				CollectionName: "collectionName",
@@ -2247,8 +2247,8 @@ func Test_CheckDynamicFieldData(t *testing.T) {
 		jsonBytes, err := json.MarshalIndent(data, "", "  ")
 		assert.NoError(t, err)
 		jsonData = append(jsonData, jsonBytes)
-		jsonFieldData := autoGenDynamicFieldData(jsonData)
 		schema := newTestSchema()
+		jsonFieldData := autoGenDynamicFieldData(schema, jsonData)
 		insertMsg := &msgstream.InsertMsg{
 			InsertRequest: &msgpb.InsertRequest{
 				CollectionName: "collectionName",
@@ -2275,8 +2275,8 @@ func Test_CheckDynamicFieldData(t *testing.T) {
 		jsonBytes, err := json.MarshalIndent(data, "", "  ")
 		assert.NoError(t, err)
 		jsonData = append(jsonData, jsonBytes)
-		jsonFieldData := autoGenDynamicFieldData(jsonData)
 		schema := newTestSchema()
+		jsonFieldData := autoGenDynamicFieldData(schema, jsonData)
 		insertMsg := &msgstream.InsertMsg{
 			InsertRequest: &msgpb.InsertRequest{
 				CollectionName: "collectionName",
@@ -2291,8 +2291,8 @@ func Test_CheckDynamicFieldData(t *testing.T) {
 	})
 	t.Run("json data is string", func(t *testing.T) {
 		data := "abcdefg"
-		jsonFieldData := autoGenDynamicFieldData([][]byte{[]byte(data)})
 		schema := newTestSchema()
+		jsonFieldData := autoGenDynamicFieldData(schema, [][]byte{[]byte(data)})
 		insertMsg := &msgstream.InsertMsg{
 			InsertRequest: &msgpb.InsertRequest{
 				CollectionName: "collectionName",

--- a/internal/proxy/validate_util_test.go
+++ b/internal/proxy/validate_util_test.go
@@ -8020,3 +8020,174 @@ func TestFillWithNullValue_Geometry(t *testing.T) {
 		assert.Nil(t, field.GetScalars().GetGeometryData().GetData()[3])
 	})
 }
+
+// Test_MetaNullableCompat_v25_vs_v26 verifies that insert and upsert Validate
+// (specifically fillWithValue) works correctly for both 2.5-style $meta
+// (Nullable=false, no DefaultValue) and 2.6-style $meta (Nullable=true,
+// DefaultValue="{}").
+//
+// Scenario: after upgrading from 2.5 to 2.6, old collections retain their
+// original $meta schema. The proxy code must handle both formats.
+func Test_MetaNullableCompat_v25_vs_v26(t *testing.T) {
+	numRows := 3
+
+	// Build a minimal schema with PK + vector + $meta (dynamic field).
+	// metaNullable/metaDefault control whether the $meta matches 2.5 or 2.6.
+	buildSchema := func(metaNullable bool, metaDefault []byte) *schemapb.CollectionSchema {
+		metaField := &schemapb.FieldSchema{
+			FieldID:   101,
+			Name:      common.MetaFieldName,
+			DataType:  schemapb.DataType_JSON,
+			IsDynamic: true,
+			Nullable:  metaNullable,
+		}
+		if metaDefault != nil {
+			metaField.DefaultValue = &schemapb.ValueField{
+				Data: &schemapb.ValueField_BytesData{BytesData: metaDefault},
+			}
+		}
+		return &schemapb.CollectionSchema{
+			Name:               "compat_test",
+			EnableDynamicField: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 1, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+				metaField,
+			},
+		}
+	}
+
+	// Simulate SDK-provided $meta data WITHOUT ValidData (the common SDK behavior).
+	sdkMetaFieldData := func() *schemapb.FieldData {
+		jsonRows := make([][]byte, numRows)
+		for i := range jsonRows {
+			jsonRows[i] = []byte(`{"dyn_key":"value"}`)
+		}
+		return &schemapb.FieldData{
+			FieldName: common.MetaFieldName,
+			Type:      schemapb.DataType_JSON,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_JsonData{
+						JsonData: &schemapb.JSONArray{Data: jsonRows},
+					},
+				},
+			},
+			IsDynamic: true,
+			// NOTE: no ValidData — this is what the SDK sends
+		}
+	}
+
+	// Auto-generated $meta (when SDK sends no dynamic data) — mirrors autoGenDynamicFieldData.
+	autoGenMetaFieldData := func(schema *schemapb.CollectionSchema) *schemapb.FieldData {
+		defaultData := make([][]byte, numRows)
+		for i := range defaultData {
+			defaultData[i] = []byte("{}")
+		}
+		return autoGenDynamicFieldData(schema, defaultData)
+	}
+
+	t.Run("INSERT_v26_schema_sdk_provided_meta", func(t *testing.T) {
+		schema := buildSchema(true, []byte("{}"))
+		h, err := typeutil.CreateSchemaHelper(schema)
+		require.NoError(t, err)
+
+		data := []*schemapb.FieldData{sdkMetaFieldData()}
+		err = newValidateUtil().fillWithValue(data, h, numRows)
+		assert.NoError(t, err, "2.6 schema + SDK-provided $meta should pass fillWithValue")
+	})
+
+	t.Run("INSERT_v25_schema_sdk_provided_meta", func(t *testing.T) {
+		schema := buildSchema(false, nil) // 2.5 style
+		h, err := typeutil.CreateSchemaHelper(schema)
+		require.NoError(t, err)
+
+		data := []*schemapb.FieldData{sdkMetaFieldData()}
+		err = newValidateUtil().fillWithValue(data, h, numRows)
+		assert.NoError(t, err, "2.5 schema + SDK-provided $meta (no ValidData) should pass fillWithValue")
+	})
+
+	t.Run("INSERT_v26_schema_autogen_meta", func(t *testing.T) {
+		schema := buildSchema(true, []byte("{}"))
+		h, err := typeutil.CreateSchemaHelper(schema)
+		require.NoError(t, err)
+
+		data := []*schemapb.FieldData{autoGenMetaFieldData(schema)}
+		err = newValidateUtil().fillWithValue(data, h, numRows)
+		assert.NoError(t, err, "2.6 schema + auto-generated $meta should pass fillWithValue")
+	})
+
+	t.Run("INSERT_v25_schema_autogen_meta", func(t *testing.T) {
+		// autoGenDynamicFieldData checks schema: for 2.5 (non-nullable, no default),
+		// it does NOT set ValidData. CheckValidData expects len(ValidData)==0.
+		schema := buildSchema(false, nil) // 2.5 style
+		h, err := typeutil.CreateSchemaHelper(schema)
+		require.NoError(t, err)
+
+		data := []*schemapb.FieldData{autoGenMetaFieldData(schema)}
+		err = newValidateUtil().fillWithValue(data, h, numRows)
+		assert.NoError(t, err, "2.5 schema + auto-generated $meta should pass fillWithValue")
+		// ValidData should remain empty for non-nullable field
+		assert.Empty(t, data[0].GetValidData(), "non-nullable $meta should not have ValidData")
+	})
+
+	t.Run("UPSERT_queryPreExecute_v25_schema", func(t *testing.T) {
+		// Simulates the fixed upsert queryPreExecute path where ValidData is
+		// conditionally auto-filled only for nullable/default-value fields.
+		schema := buildSchema(false, nil) // 2.5 style
+		h, err := typeutil.CreateSchemaHelper(schema)
+		require.NoError(t, err)
+
+		fieldData := sdkMetaFieldData()
+		fieldSchema, _ := h.GetFieldFromName(common.MetaFieldName)
+
+		// Simulate FIXED queryPreExecute auto-fill (with schema condition)
+		if fieldData.GetIsDynamic() && len(fieldData.GetValidData()) == 0 &&
+			(fieldSchema.GetNullable() || fieldSchema.GetDefaultValue() != nil) {
+			validData := make([]bool, numRows)
+			for i := range validData {
+				validData[i] = true
+			}
+			fieldData.ValidData = validData
+		}
+
+		// For 2.5 schema: ValidData is NOT set, so this branch is skipped
+		if len(fieldData.GetValidData()) != 0 {
+			if fieldSchema.GetDefaultValue() != nil {
+				err = FillWithDefaultValue(fieldData, fieldSchema, numRows)
+			} else {
+				err = FillWithNullValue(fieldData, fieldSchema, numRows)
+			}
+		}
+		assert.NoError(t, err, "2.5 schema upsert queryPreExecute should not fail")
+		assert.Empty(t, fieldData.GetValidData(), "non-nullable $meta should not have ValidData")
+	})
+
+	t.Run("UPSERT_queryPreExecute_v26_schema", func(t *testing.T) {
+		schema := buildSchema(true, []byte("{}"))
+		h, err := typeutil.CreateSchemaHelper(schema)
+		require.NoError(t, err)
+
+		fieldData := sdkMetaFieldData()
+		fieldSchema, _ := h.GetFieldFromName(common.MetaFieldName)
+
+		// Simulate FIXED queryPreExecute auto-fill (with schema condition)
+		if fieldData.GetIsDynamic() && len(fieldData.GetValidData()) == 0 &&
+			(fieldSchema.GetNullable() || fieldSchema.GetDefaultValue() != nil) {
+			validData := make([]bool, numRows)
+			for i := range validData {
+				validData[i] = true
+			}
+			fieldData.ValidData = validData
+		}
+
+		if len(fieldData.GetValidData()) != 0 {
+			if fieldSchema.GetDefaultValue() != nil {
+				err = FillWithDefaultValue(fieldData, fieldSchema, numRows)
+			} else {
+				err = FillWithNullValue(fieldData, fieldSchema, numRows)
+			}
+		}
+		assert.NoError(t, err, "2.6 schema upsert queryPreExecute should pass")
+		assert.Equal(t, numRows, len(fieldData.GetValidData()), "nullable $meta should have ValidData")
+	})
+}

--- a/internal/rootcoord/meta_table.go
+++ b/internal/rootcoord/meta_table.go
@@ -28,6 +28,7 @@ import (
 	"golang.org/x/exp/maps"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/metastore"
 	"github.com/milvus-io/milvus/internal/metastore/model"
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/balancer/channel"
@@ -152,6 +153,9 @@ type IMetaTable interface {
 	AddFileResource(ctx context.Context, resource *internalpb.FileResourceInfo) error
 	RemoveFileResource(ctx context.Context, name string) (error, bool)
 	ListFileResource(ctx context.Context) ([]*internalpb.FileResourceInfo, uint64)
+
+	// MigrateDynamicFieldNullable upgrades a 2.5-style $meta field to nullable with default "{}".
+	MigrateDynamicFieldNullable(ctx context.Context, coll *model.Collection) (bool, error)
 }
 
 // MetaTable is a persistent meta set of all databases, collections and partitions.
@@ -2322,4 +2326,64 @@ func (mt *MetaTable) ListFileResource(ctx context.Context) ([]*internalpb.FileRe
 	defer mt.ddLock.RUnlock()
 
 	return lo.Values(mt.fileResourceID2Meta), mt.fileResourceVersion
+}
+
+// MigrateDynamicFieldNullable upgrades a 2.5-style $meta field (non-nullable, no
+// default) to the 2.6 format (nullable=true, default="{}"). Returns true if the
+// schema was modified and persisted.
+//
+// TODO: remove after 3.0 — all collections will have been migrated by then.
+func (mt *MetaTable) MigrateDynamicFieldNullable(ctx context.Context, coll *model.Collection) (bool, error) {
+	if !coll.EnableDynamicField {
+		return false, nil
+	}
+
+	// Find the dynamic field.
+	var hasDynamic bool
+	for _, f := range coll.Fields {
+		if f.IsDynamic {
+			hasDynamic = true
+			// Already migrated — idempotent.
+			if f.Nullable && f.DefaultValue != nil {
+				return false, nil
+			}
+			break
+		}
+	}
+	if !hasDynamic {
+		return false, nil
+	}
+
+	mt.ddLock.Lock()
+	defer mt.ddLock.Unlock()
+
+	// Clone-mutate-swap: never modify the live object before persistence succeeds.
+	oldColl := coll.Clone()
+	newColl := coll.Clone()
+
+	for _, f := range newColl.Fields {
+		if f.IsDynamic {
+			f.Nullable = true
+			f.DefaultValue = &schemapb.ValueField{
+				Data: &schemapb.ValueField_BytesData{BytesData: []byte("{}")},
+			}
+			break
+		}
+	}
+
+	ts, err := mt.tsoAllocator.GenerateTSO(1)
+	if err != nil {
+		return false, err
+	}
+	newColl.UpdateTimestamp = ts
+
+	ctx1 := contextutil.WithTenantID(ctx, Params.CommonCfg.ClusterName.GetValue())
+	if err := mt.catalog.AlterCollection(ctx1, oldColl, newColl, metastore.MODIFY, ts, true); err != nil {
+		return false, err
+	}
+
+	// Persistence succeeded — swap into live cache.
+	mt.collID2Meta[coll.CollectionID] = newColl
+
+	return true, nil
 }

--- a/internal/rootcoord/meta_table_test.go
+++ b/internal/rootcoord/meta_table_test.go
@@ -28,7 +28,9 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	etcdkv "github.com/milvus-io/milvus/internal/kv/etcd"
+	"github.com/milvus-io/milvus/internal/metastore"
 	"github.com/milvus-io/milvus/internal/metastore/kv/rootcoord"
 	"github.com/milvus-io/milvus/internal/metastore/mocks"
 	"github.com/milvus-io/milvus/internal/metastore/model"
@@ -2691,4 +2693,174 @@ func TestMetaTable_TruncateCollection(t *testing.T) {
 	require.False(t, ok)
 	require.Equal(t, 1, len(coll.ShardInfos))
 	require.Equal(t, uint64(1000), coll.ShardInfos["vchannel1"].LastTruncateTimeTick)
+}
+
+func TestMetaTable_MigrateDynamicFieldNullable(t *testing.T) {
+	paramtable.Init()
+
+	t.Run("migrates non-nullable $meta to nullable with default", func(t *testing.T) {
+		catalog := mocks.NewRootCoordCatalog(t)
+		catalog.EXPECT().AlterCollection(
+			mock.Anything, // ctx
+			mock.Anything, // oldColl
+			mock.Anything, // newColl
+			metastore.MODIFY,
+			mock.AnythingOfType("uint64"), // ts
+			true,                          // fieldModify
+		).Return(nil)
+
+		tso := mocktso.NewAllocator(t)
+		tso.On("GenerateTSO", mock.Anything).Return(uint64(100), nil)
+
+		dynField := &model.Field{
+			FieldID:   101,
+			Name:      common.MetaFieldName,
+			IsDynamic: true,
+			Nullable:  false,
+		}
+		coll := &model.Collection{
+			CollectionID:       1,
+			Name:               "test_coll",
+			EnableDynamicField: true,
+			Fields:             []*model.Field{dynField},
+		}
+
+		mt := &MetaTable{
+			catalog:      catalog,
+			tsoAllocator: tso,
+			collID2Meta: map[typeutil.UniqueID]*model.Collection{
+				1: coll,
+			},
+		}
+
+		changed, err := mt.MigrateDynamicFieldNullable(context.Background(), coll)
+		assert.NoError(t, err)
+		assert.True(t, changed)
+
+		// Clone-mutate-swap: the original dynField should NOT be mutated.
+		// The cache should contain a new cloned collection.
+		assert.False(t, dynField.Nullable, "original field pointer must not be mutated")
+		assert.Nil(t, dynField.DefaultValue, "original field pointer must not be mutated")
+
+		// The swapped collection in cache should be migrated.
+		newColl := mt.collID2Meta[1]
+		assert.NotSame(t, coll, newColl, "cache should hold a new clone, not the original")
+		var newDynField *model.Field
+		for _, f := range newColl.Fields {
+			if f.IsDynamic {
+				newDynField = f
+				break
+			}
+		}
+		assert.NotNil(t, newDynField)
+		assert.True(t, newDynField.Nullable)
+		assert.Equal(t, []byte("{}"), newDynField.DefaultValue.GetBytesData())
+		assert.Equal(t, uint64(100), newColl.UpdateTimestamp)
+	})
+
+	t.Run("skips already-migrated collection", func(t *testing.T) {
+		catalog := mocks.NewRootCoordCatalog(t)
+		// AlterCollection should NOT be called.
+
+		tso := mocktso.NewAllocator(t)
+
+		coll := &model.Collection{
+			CollectionID:       2,
+			Name:               "migrated_coll",
+			EnableDynamicField: true,
+			Fields: []*model.Field{
+				{
+					FieldID:   101,
+					Name:      common.MetaFieldName,
+					IsDynamic: true,
+					Nullable:  true,
+					DefaultValue: &schemapb.ValueField{
+						Data: &schemapb.ValueField_BytesData{BytesData: []byte("{}")},
+					},
+				},
+			},
+		}
+
+		mt := &MetaTable{
+			catalog:      catalog,
+			tsoAllocator: tso,
+			collID2Meta: map[typeutil.UniqueID]*model.Collection{
+				2: coll,
+			},
+		}
+
+		changed, err := mt.MigrateDynamicFieldNullable(context.Background(), coll)
+		assert.NoError(t, err)
+		assert.False(t, changed)
+	})
+
+	t.Run("skips collection without dynamic field", func(t *testing.T) {
+		catalog := mocks.NewRootCoordCatalog(t)
+		tso := mocktso.NewAllocator(t)
+
+		coll := &model.Collection{
+			CollectionID:       3,
+			Name:               "no_dynamic",
+			EnableDynamicField: false,
+		}
+
+		mt := &MetaTable{
+			catalog:      catalog,
+			tsoAllocator: tso,
+			collID2Meta: map[typeutil.UniqueID]*model.Collection{
+				3: coll,
+			},
+		}
+
+		changed, err := mt.MigrateDynamicFieldNullable(context.Background(), coll)
+		assert.NoError(t, err)
+		assert.False(t, changed)
+	})
+
+	t.Run("catalog error is propagated", func(t *testing.T) {
+		catalog := mocks.NewRootCoordCatalog(t)
+		catalog.EXPECT().AlterCollection(
+			mock.Anything,
+			mock.Anything,
+			mock.Anything,
+			metastore.MODIFY,
+			mock.AnythingOfType("uint64"),
+			true,
+		).Return(errors.New("catalog failure"))
+
+		tso := mocktso.NewAllocator(t)
+		tso.On("GenerateTSO", mock.Anything).Return(uint64(200), nil)
+
+		coll := &model.Collection{
+			CollectionID:       4,
+			Name:               "error_coll",
+			EnableDynamicField: true,
+			Fields: []*model.Field{
+				{
+					FieldID:   101,
+					Name:      common.MetaFieldName,
+					IsDynamic: true,
+					Nullable:  false,
+				},
+			},
+		}
+
+		mt := &MetaTable{
+			catalog:      catalog,
+			tsoAllocator: tso,
+			collID2Meta: map[typeutil.UniqueID]*model.Collection{
+				4: coll,
+			},
+		}
+
+		changed, err := mt.MigrateDynamicFieldNullable(context.Background(), coll)
+		assert.Error(t, err)
+		assert.False(t, changed)
+		assert.Contains(t, err.Error(), "catalog failure")
+
+		// Clone-mutate-swap: original coll must NOT be modified on failure.
+		dynField := coll.Fields[0]
+		assert.False(t, dynField.Nullable, "original field must not be mutated on catalog failure")
+		assert.Nil(t, dynField.DefaultValue, "original field must not be mutated on catalog failure")
+	})
 }

--- a/internal/rootcoord/mocks/meta_table.go
+++ b/internal/rootcoord/mocks/meta_table.go
@@ -3833,3 +3833,50 @@ func NewIMetaTable(t interface {
 
 	return mock
 }
+
+// MigrateDynamicFieldNullable provides a mock function with given fields: ctx, coll
+func (_m *IMetaTable) MigrateDynamicFieldNullable(ctx context.Context, coll *model.Collection) (bool, error) {
+	ret := _m.Called(ctx, coll)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(context.Context, *model.Collection) bool); ok {
+		r0 = rf(ctx, coll)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *model.Collection) error); ok {
+		r1 = rf(ctx, coll)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// IMetaTable_MigrateDynamicFieldNullable_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MigrateDynamicFieldNullable'
+type IMetaTable_MigrateDynamicFieldNullable_Call struct {
+	*mock.Call
+}
+
+func (_e *IMetaTable_Expecter) MigrateDynamicFieldNullable(ctx interface{}, coll interface{}) *IMetaTable_MigrateDynamicFieldNullable_Call {
+	return &IMetaTable_MigrateDynamicFieldNullable_Call{Call: _e.mock.On("MigrateDynamicFieldNullable", ctx, coll)}
+}
+
+func (_c *IMetaTable_MigrateDynamicFieldNullable_Call) Run(run func(ctx context.Context, coll *model.Collection)) *IMetaTable_MigrateDynamicFieldNullable_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*model.Collection))
+	})
+	return _c
+}
+
+func (_c *IMetaTable_MigrateDynamicFieldNullable_Call) Return(_a0 bool, _a1 error) *IMetaTable_MigrateDynamicFieldNullable_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *IMetaTable_MigrateDynamicFieldNullable_Call) RunAndReturn(run func(context.Context, *model.Collection) (bool, error)) *IMetaTable_MigrateDynamicFieldNullable_Call {
+	_c.Call.Return(run)
+	return _c
+}

--- a/internal/rootcoord/root_coord.go
+++ b/internal/rootcoord/root_coord.go
@@ -695,6 +695,19 @@ func (c *Core) restore(ctx context.Context) error {
 					c.tombstoneSweeper.AddTombstone(newPartitionTombstone(c.meta, c.broker, coll.CollectionID, part.PartitionID))
 				}
 			}
+
+			// Migrate 2.5-style $meta to nullable with default value.
+			// TODO: remove after 3.0 — all collections will have been migrated by then.
+			if changed, err := c.meta.MigrateDynamicFieldNullable(ctx, coll); err != nil {
+				log.Ctx(ctx).Warn("failed to migrate dynamic field schema, will retry on next restart",
+					zap.Int64("collectionID", coll.CollectionID),
+					zap.String("collection", coll.Name),
+					zap.Error(err))
+			} else if changed {
+				log.Ctx(ctx).Info("migrated dynamic field to nullable",
+					zap.Int64("collectionID", coll.CollectionID),
+					zap.String("collection", coll.Name))
+			}
 		}
 	}
 	return nil

--- a/internal/rootcoord/root_coord_test.go
+++ b/internal/rootcoord/root_coord_test.go
@@ -1858,6 +1858,10 @@ func (s *RootCoordSuite) TestRestore() {
 			},
 		}, nil)
 
+	// MigrateDynamicFieldNullable is called for CollectionCreated collections.
+	// These test collections have EnableDynamicField=false, so the method returns (false, nil).
+	meta.EXPECT().MigrateDynamicFieldNullable(mock.Anything, mock.Anything).Return(false, nil).Maybe()
+
 	// ticker := newTickerWithMockNormalStream()
 	tsoAllocator := newMockTsoAllocator()
 	tsoAllocator.GenerateTSOF = func(count uint32) (uint64, error) {


### PR DESCRIPTION
## Summary

- Fix insert/upsert/partial-update failures on 2.5 collections after upgrading to 2.6, caused by `$meta` field nullable format mismatch
- Proxy defensive fix: make ValidData population schema-aware in `autoGenDynamicFieldData` and `queryPreExecute`
- RootCoord startup migration: normalize all `$meta` fields to `Nullable=true, DefaultValue="{}"` during `restore()`

issue: https://github.com/milvus-io/milvus/issues/48930

## Root Cause

In 2.6, `$meta` was changed to `Nullable=true, DefaultValue="{}"`. But 2.5 collections retain `Nullable=false, DefaultValue=nil` (no migration). Two code paths unconditionally set `ValidData` on `$meta`, which fails `CheckValidData` for non-nullable fields (`expectedLen=0` but got `numRows`).

## Changes

### Proxy Layer (defensive, immediate)
| File | Change |
|------|--------|
| `internal/proxy/util.go` | `autoGenDynamicFieldData`: accept schema param, only set ValidData when `$meta` is nullable or has default |
| `internal/proxy/task_upsert.go` | `queryPreExecute`: add `(nullable \|\| defaultValue)` condition to ValidData auto-fill |

### RootCoord Layer (migration, root fix)
| File | Change |
|------|--------|
| `internal/rootcoord/meta_table.go` | Add `MigrateDynamicFieldNullable` method + `IMetaTable` interface |
| `internal/rootcoord/root_coord.go` | Call migration in `restore()` before Healthy |

### Safety Design
- **Clone-mutate-swap**: `MigrateDynamicFieldNullable` never modifies live objects before persistence succeeds
- **Failure-tolerant**: migration failure logs Warn, does not block startup; proxy fix provides fallback
- **Idempotent**: skips already-migrated collections
- **Storage-safe**: old binlogs self-describe nullable via descriptor event; read path unaffected

## Test plan

- [x] `Test_MetaNullableCompat_v25_vs_v26` — 6 sub-tests: INSERT/UPSERT x v25/v26 x SDK/auto-gen
- [x] `TestUpsertTask_queryPreExecute_DynamicFieldValidData` — 3 sub-tests including v25 schema
- [x] `TestMetaTable_MigrateDynamicFieldNullable` — 4 sub-tests: success, idempotent, skip, error
- [x] `TestRootCoordSuite/TestRestore` — mock expectation updated
- [x] `Test_CheckDynamicFieldData` — 6 existing tests, zero regression
- [x] `Test_validateUtil_fillWithValue` — 87 existing tests, zero regression
- [x] `make milvus` build passed
- [x] `make lint-fix` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)