### PR TITLE
enhance: downgrade CDC replicate stream idle timeout log from WARN to INFO

### DIFF
--- a/internal/cdc/replication/replicatestream/replicate_stream_client_impl.go
+++ b/internal/cdc/replication/replicatestream/replicate_stream_client_impl.go
@@ -19,11 +19,14 @@ package replicatestream
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
@@ -155,6 +158,12 @@ func (r *replicateStreamClient) startReplicating(backoff backoff.BackOff) (needR
 	} else if errors.Is(chErr, ErrReplicationRemoved) {
 		logger.Info("close replicate stream client due to replication removed")
 		return false
+	} else if isStreamIdleTimeout(chErr) {
+		// Stream idle timeout is expected when no data is being replicated on the source channel.
+		// See isStreamIdleTimeout for details.
+		logger.Info("replicate stream closed due to stream idle timeout, will reconnect", zap.Error(chErr))
+		r.metrics.OnDisconnect()
+		return true
 	} else {
 		logger.Warn("restart replicate stream client due to unexpected error", zap.Error(chErr))
 		r.metrics.OnDisconnect()
@@ -284,7 +293,11 @@ func (r *replicateStreamClient) recvLoop(ctx context.Context) (err error) {
 	logger := log.With(zap.String("key", r.channel.Key), zap.Int64("revision", r.channel.ModRevision))
 	defer func() {
 		if err != nil && !errors.Is(err, ErrReplicationRemoved) {
-			logger.Warn("recv loop closed by unexpected error", zap.Error(err))
+			if isStreamIdleTimeout(err) {
+				logger.Info("replicate stream closed due to stream idle timeout, will reconnect", zap.Error(err))
+			} else {
+				logger.Warn("recv loop closed by unexpected error", zap.Error(err))
+			}
 		} else {
 			logger.Info("recv loop closed", zap.Error(err))
 		}
@@ -296,7 +309,11 @@ func (r *replicateStreamClient) recvLoop(ctx context.Context) (err error) {
 		default:
 			resp, err := r.client.Recv()
 			if err != nil {
-				logger.Warn("replicate stream recv failed", zap.Error(err))
+				if isStreamIdleTimeout(err) {
+					logger.Info("replicate stream closed due to stream idle timeout, will reconnect", zap.Error(err))
+				} else {
+					logger.Warn("replicate stream recv failed", zap.Error(err))
+				}
 				return err
 			}
 			lastConfirmedMessageInfo := resp.GetReplicateConfirmedMessageInfo()
@@ -364,4 +381,18 @@ func (r *replicateStreamClient) BlockUntilFinish() {
 func (r *replicateStreamClient) Close() {
 	r.cancel()
 	<-r.finishedCh
+}
+
+// isStreamIdleTimeout checks if the error is a gRPC "stream timeout" error.
+// This is typically caused by envoy sidecar's stream_idle_timeout (default 5m):
+// when no application-level DATA frames flow on a gRPC bidirectional stream,
+// envoy considers the stream idle and terminates it, even though gRPC transport-level
+// keepalive pings are still active (PING frames don't reset stream_idle_timeout).
+// This is expected when no data is being replicated on the source channel.
+func isStreamIdleTimeout(err error) bool {
+	if err == nil {
+		return false
+	}
+	s, ok := status.FromError(err)
+	return ok && s.Code() == codes.Unknown && strings.Contains(s.Message(), "stream timeout")
 }

--- a/internal/cdc/replication/replicatestream/replicate_stream_client_impl_test.go
+++ b/internal/cdc/replication/replicatestream/replicate_stream_client_impl_test.go
@@ -26,7 +26,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	milvuspb "github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
@@ -331,4 +333,20 @@ func (m *mockReplicateStreamClient) Close() {
 	m.closeOnce.Do(func() {
 		close(m.closeCh)
 	})
+}
+
+func TestIsStreamIdleTimeout(t *testing.T) {
+	// nil error
+	assert.False(t, isStreamIdleTimeout(nil))
+
+	// Exact error from envoy sidecar stream_idle_timeout
+	assert.True(t, isStreamIdleTimeout(status.Error(codes.Unknown, "stream timeout")))
+
+	// Other gRPC errors should not match
+	assert.False(t, isStreamIdleTimeout(status.Error(codes.Unavailable, "connection refused")))
+	assert.False(t, isStreamIdleTimeout(status.Error(codes.Unknown, "some other error")))
+	assert.False(t, isStreamIdleTimeout(status.Error(codes.DeadlineExceeded, "stream timeout")))
+
+	// Non-gRPC errors should not match
+	assert.False(t, isStreamIdleTimeout(assert.AnError))
 }


### PR DESCRIPTION
## Summary
- Distinguish envoy sidecar `stream_idle_timeout` errors from real unexpected errors in CDC replicate stream client
- Log at INFO level for stream idle timeout (expected when no data is being replicated), keep WARN for other errors
- Add `isStreamIdleTimeout` helper that checks gRPC status code (`Unknown`) and message (`stream timeout`)
- Add unit test for `isStreamIdleTimeout`

issue: #48933

## Test plan
- [ ] Verify `TestIsStreamIdleTimeout` passes in CI
- [ ] Verify existing `TestReplicateStreamClient_*` tests still pass
- [ ] Deploy to env with envoy sidecar, confirm idle timeout logs are INFO not WARN

🤖 Generated with [Claude Code](https://claude.com/claude-code)