### PR TITLE
fix: remove unused queryNode.ioPoolSize parameter

### DIFF
--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -168,22 +168,6 @@ func NewLoader(
 	manager *Manager,
 	cm storage.ChunkManager,
 ) *segmentLoader {
-	cpuNum := hardware.GetCPUNum()
-	ioPoolSize := cpuNum * 8
-	// make sure small machines could load faster
-	if ioPoolSize < 32 {
-		ioPoolSize = 32
-	}
-	// limit the number of concurrency
-	if ioPoolSize > 256 {
-		ioPoolSize = 256
-	}
-
-	if configPoolSize := paramtable.Get().QueryNodeCfg.IoPoolSize.GetAsInt(); configPoolSize > 0 {
-		ioPoolSize = configPoolSize
-	}
-
-	log.Info("SegmentLoader created", zap.Int("ioPoolSize", ioPoolSize))
 	duf := NewDiskUsageFetcher(ctx)
 	go duf.Start()
 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3428,7 +3428,6 @@ type queryNodeConfig struct {
 	ForwardBatchSize            ParamItem `refreshable:"true"`
 
 	// loader
-	IoPoolSize                  ParamItem `refreshable:"false"`
 	DeltaDataExpansionRate      ParamItem `refreshable:"true"`
 	JSONKeyStatsExpansionFactor ParamItem `refreshable:"true"`
 	TextIndexExpansionFactor    ParamItem `refreshable:"true"`
@@ -4415,14 +4414,6 @@ Max read concurrency must greater than or equal to 1, and less than or equal to 
 		Export:       true,
 	}
 	p.ForwardBatchSize.Init(base.mgr)
-
-	p.IoPoolSize = ParamItem{
-		Key:          "queryNode.ioPoolSize",
-		Version:      "2.3.0",
-		DefaultValue: "0",
-		Doc:          "Control how many goroutines will the loader use to pull files, if the given value is non-positive, the value will be set to CpuNum * 8, at least 32, and at most 256",
-	}
-	p.IoPoolSize.Init(base.mgr)
 
 	p.DeltaDataExpansionRate = ParamItem{
 		Key:          "querynode.deltaDataExpansionRate",


### PR DESCRIPTION
## Summary

- Remove the unused `queryNode.ioPoolSize` config parameter and its dead code
- The parameter was computed and read but never stored or used — only logged

## Details

The `ioPoolSize` was calculated in `NewLoader()` and the config `queryNode.ioPoolSize` was read to override it, but the resulting value was never assigned to any struct field. The actual loading concurrency is controlled by:
- **ConcurrencyLevel**: `min(CPUNum, segmentCount)` — hardcoded in `segment_loader.go`
- **LoadPool**: `CPUNum * middlePriority` — controlled by `common.threadCoreCoefficient.middlePriority`

## Changes

| File | Change |
|------|--------|
| `pkg/util/paramtable/component_param.go` | Remove `IoPoolSize` field definition and init |
| `internal/querynodev2/segments/segment_loader.go` | Remove dead `ioPoolSize` computation in `NewLoader()` |

issue: #48900

🤖 Generated with [Claude Code](https://claude.com/claude-code)