### PR TITLE
enhance: expose index building progress metrics via Prometheus

### DIFF
--- a/internal/datacoord/index_meta.go
+++ b/internal/datacoord/index_meta.go
@@ -321,6 +321,61 @@ func (m *indexMeta) updateIndexTasksMetrics() {
 	log.Ctx(m.ctx).Info("update index metric", zap.Int("collectionNum", len(taskMetrics)))
 }
 
+// indexRowsKey uniquely identifies an index within a collection for metric aggregation.
+type indexRowsKey struct {
+	collectionID int64
+	indexID      int64
+}
+
+// indexRowsAccum accumulates row counts for a single index.
+type indexRowsAccum struct {
+	indexName   string
+	totalRows   int64
+	indexedRows int64
+	pendingRows int64
+}
+
+// updateIndexRowsProgressMetrics aggregates per-segment index state into
+// per-collection/index Prometheus gauges that expose total_rows, indexed_rows
+// and pending_index_rows. This gives operators dashboards-level visibility
+// into index building progress without requiring SDK calls (issue #47411).
+func (m *indexMeta) updateIndexRowsProgressMetrics() {
+	// Reset the gauge so stale index entries disappear after deletion.
+	metrics.IndexRowsProgress.Reset()
+
+	accum := make(map[indexRowsKey]*indexRowsAccum)
+
+	for _, segIdx := range m.segmentBuildInfo.List() {
+		if segIdx.IsDeleted || !m.IsIndexExist(segIdx.CollectionID, segIdx.IndexID) {
+			continue
+		}
+		key := indexRowsKey{collectionID: segIdx.CollectionID, indexID: segIdx.IndexID}
+		a, ok := accum[key]
+		if !ok {
+			a = &indexRowsAccum{
+				indexName: m.GetIndexNameByID(segIdx.CollectionID, segIdx.IndexID),
+			}
+			accum[key] = a
+		}
+		a.totalRows += segIdx.NumRows
+		switch segIdx.IndexState {
+		case commonpb.IndexState_Finished:
+			a.indexedRows += segIdx.NumRows
+		default:
+			// Unissued, InProgress, Failed, Retry, None — all count as pending
+			a.pendingRows += segIdx.NumRows
+		}
+	}
+
+	for key, a := range accum {
+		collID := fmt.Sprint(key.collectionID)
+		iName := a.indexName
+		metrics.IndexRowsProgress.WithLabelValues(collID, iName, "total_rows").Set(float64(a.totalRows))
+		metrics.IndexRowsProgress.WithLabelValues(collID, iName, "indexed_rows").Set(float64(a.indexedRows))
+		metrics.IndexRowsProgress.WithLabelValues(collID, iName, "pending_index_rows").Set(float64(a.pendingRows))
+	}
+}
+
 func checkIdenticalJSON(index *model.Index, req *indexpb.CreateIndexRequest) bool {
 	// Skip error handling since json path existence is guaranteed in CreateIndex
 	jsonPath1, _ := getIndexParam(index.IndexParams, common.JSONPathKey)

--- a/internal/datacoord/index_meta_test.go
+++ b/internal/datacoord/index_meta_test.go
@@ -2401,3 +2401,99 @@ func TestStoredIndexFilesSizeMetric(t *testing.T) {
 			"FinishTask after index drop must not re-add bytes to gauge")
 	})
 }
+
+func TestIndexMeta_UpdateIndexRowsProgressMetrics(t *testing.T) {
+	catalog := catalogmocks.NewDataCoordCatalog(t)
+	m := newSegmentIndexMeta(catalog)
+
+	const (
+		testCollID  = int64(200)
+		testIndexID = int64(10)
+	)
+	const testIndexName = "vector_idx"
+
+	// Register a live index so IsIndexExist returns true.
+	m.indexes[testCollID] = map[UniqueID]*model.Index{
+		testIndexID: {
+			CollectionID: testCollID,
+			IndexID:      testIndexID,
+			IndexName:    testIndexName,
+		},
+	}
+
+	t.Run("empty build info emits no metrics", func(t *testing.T) {
+		metrics.IndexRowsProgress.Reset()
+		m.updateIndexRowsProgressMetrics()
+		assert.Equal(t, 0, testutil.CollectAndCount(metrics.IndexRowsProgress))
+	})
+
+	t.Run("finished and pending segments are counted correctly", func(t *testing.T) {
+		metrics.IndexRowsProgress.Reset()
+
+		m.segmentBuildInfo.Add(&model.SegmentIndex{
+			BuildID:      1,
+			CollectionID: testCollID,
+			IndexID:      testIndexID,
+			NumRows:      1000,
+			IndexState:   commonpb.IndexState_Finished,
+		})
+		m.segmentBuildInfo.Add(&model.SegmentIndex{
+			BuildID:      2,
+			CollectionID: testCollID,
+			IndexID:      testIndexID,
+			NumRows:      400,
+			IndexState:   commonpb.IndexState_InProgress,
+		})
+		m.segmentBuildInfo.Add(&model.SegmentIndex{
+			BuildID:      3,
+			CollectionID: testCollID,
+			IndexID:      testIndexID,
+			NumRows:      100,
+			IndexState:   commonpb.IndexState_Unissued,
+		})
+
+		m.updateIndexRowsProgressMetrics()
+
+		collIDStr := fmt.Sprint(testCollID)
+		assert.Equal(t, float64(1500), testutil.ToFloat64(metrics.IndexRowsProgress.WithLabelValues(collIDStr, testIndexName, "total_rows")))
+		assert.Equal(t, float64(1000), testutil.ToFloat64(metrics.IndexRowsProgress.WithLabelValues(collIDStr, testIndexName, "indexed_rows")))
+		assert.Equal(t, float64(500), testutil.ToFloat64(metrics.IndexRowsProgress.WithLabelValues(collIDStr, testIndexName, "pending_index_rows")))
+
+		metrics.IndexRowsProgress.Reset()
+	})
+
+	t.Run("deleted segment indexes are skipped", func(t *testing.T) {
+		metrics.IndexRowsProgress.Reset()
+		m2 := newSegmentIndexMeta(catalog)
+		m2.indexes[testCollID] = map[UniqueID]*model.Index{
+			testIndexID: {CollectionID: testCollID, IndexID: testIndexID, IndexName: testIndexName},
+		}
+		m2.segmentBuildInfo.Add(&model.SegmentIndex{
+			BuildID:      4,
+			CollectionID: testCollID,
+			IndexID:      testIndexID,
+			NumRows:      999,
+			IndexState:   commonpb.IndexState_Finished,
+			IsDeleted:    true,
+		})
+		m2.updateIndexRowsProgressMetrics()
+		assert.Equal(t, 0, testutil.CollectAndCount(metrics.IndexRowsProgress))
+		metrics.IndexRowsProgress.Reset()
+	})
+
+	t.Run("segment for unknown index is skipped", func(t *testing.T) {
+		metrics.IndexRowsProgress.Reset()
+		m3 := newSegmentIndexMeta(catalog)
+		// no indexes registered — IsIndexExist will return false
+		m3.segmentBuildInfo.Add(&model.SegmentIndex{
+			BuildID:      5,
+			CollectionID: testCollID,
+			IndexID:      testIndexID,
+			NumRows:      500,
+			IndexState:   commonpb.IndexState_Finished,
+		})
+		m3.updateIndexRowsProgressMetrics()
+		assert.Equal(t, 0, testutil.CollectAndCount(metrics.IndexRowsProgress))
+		metrics.IndexRowsProgress.Reset()
+	})
+}

--- a/internal/datacoord/server.go
+++ b/internal/datacoord/server.go
@@ -741,6 +741,7 @@ func (s *Server) collectMetaMetrics(ctx context.Context) {
 		case <-ticker.C:
 			s.meta.statsTaskMeta.updateMetrics()
 			s.meta.indexMeta.updateIndexTasksMetrics()
+			s.meta.indexMeta.updateIndexRowsProgressMetrics()
 		}
 	}
 }

--- a/pkg/metrics/datacoord_metrics.go
+++ b/pkg/metrics/datacoord_metrics.go
@@ -301,6 +301,16 @@ var (
 
 	*/
 
+	// IndexRowsProgress tracks index building progress by row count per collection/index.
+	// The "progress_type" label distinguishes total_rows, indexed_rows, and pending_index_rows.
+	IndexRowsProgress = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.DataCoordRole,
+			Name:      "index_rows_progress",
+			Help:      "index building progress in rows, grouped by collection and index",
+		}, []string{collectionIDLabelName, indexName, "progress_type"})
+
 	// IndexRequestCounter records the number of the index requests.
 	IndexRequestCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -456,6 +466,7 @@ func RegisterDataCoord(registry *prometheus.Registry) {
 	registry.MustRegister(DataCoordSizeStoredL0Segment)
 	registry.MustRegister(DataCoordL0DeleteEntriesNum)
 	registry.MustRegister(FlushedSegmentFileNum)
+	registry.MustRegister(IndexRowsProgress)
 	registry.MustRegister(IndexRequestCounter)
 	registry.MustRegister(IndexTaskNum)
 	registry.MustRegister(IndexNodeNum)
@@ -476,6 +487,9 @@ func RegisterDataCoord(registry *prometheus.Registry) {
 }
 
 func CleanupDataCoordWithCollectionID(collectionID int64) {
+	IndexRowsProgress.DeletePartialMatch(prometheus.Labels{
+		collectionIDLabelName: fmt.Sprint(collectionID),
+	})
 	IndexTaskNum.DeletePartialMatch(prometheus.Labels{
 		collectionIDLabelName: fmt.Sprint(collectionID),
 	})

--- a/pkg/metrics/datacoord_metrics_test.go
+++ b/pkg/metrics/datacoord_metrics_test.go
@@ -111,3 +111,53 @@ func TestDataCoordNumSegmentsLabelNames(t *testing.T) {
 	// Clean up
 	DataCoordNumSegments.Reset()
 }
+
+func TestIndexRowsProgress(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	RegisterDataCoord(registry)
+
+	// Test that IndexRowsProgress can be used with all three progress types
+	IndexRowsProgress.WithLabelValues("1", "test_index", "total_rows").Set(1000)
+	IndexRowsProgress.WithLabelValues("1", "test_index", "indexed_rows").Set(500)
+	IndexRowsProgress.WithLabelValues("1", "test_index", "pending_index_rows").Set(500)
+
+	// Verify values
+	total := testutil.ToFloat64(IndexRowsProgress.WithLabelValues("1", "test_index", "total_rows"))
+	assert.Equal(t, float64(1000), total)
+
+	indexed := testutil.ToFloat64(IndexRowsProgress.WithLabelValues("1", "test_index", "indexed_rows"))
+	assert.Equal(t, float64(500), indexed)
+
+	pending := testutil.ToFloat64(IndexRowsProgress.WithLabelValues("1", "test_index", "pending_index_rows"))
+	assert.Equal(t, float64(500), pending)
+
+	// Clean up
+	IndexRowsProgress.Reset()
+}
+
+func TestCleanupDataCoordWithCollectionID_IndexRowsProgress(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	RegisterDataCoord(registry)
+
+	// Set up metrics for two collections
+	IndexRowsProgress.WithLabelValues("100", "idx1", "total_rows").Set(1000)
+	IndexRowsProgress.WithLabelValues("100", "idx1", "indexed_rows").Set(500)
+	IndexRowsProgress.WithLabelValues("200", "idx2", "total_rows").Set(2000)
+	IndexRowsProgress.WithLabelValues("200", "idx2", "indexed_rows").Set(1500)
+
+	// Verify both collections have metrics
+	assert.Equal(t, float64(1000), testutil.ToFloat64(IndexRowsProgress.WithLabelValues("100", "idx1", "total_rows")))
+	assert.Equal(t, float64(2000), testutil.ToFloat64(IndexRowsProgress.WithLabelValues("200", "idx2", "total_rows")))
+
+	// Cleanup collection 100
+	CleanupDataCoordWithCollectionID(100)
+
+	// Verify collection 100 metrics are deleted
+	assert.Equal(t, 0.0, testutil.ToFloat64(IndexRowsProgress.WithLabelValues("100", "idx1", "total_rows")))
+
+	// Verify collection 200 metrics still exist
+	assert.Equal(t, float64(2000), testutil.ToFloat64(IndexRowsProgress.WithLabelValues("200", "idx2", "total_rows")))
+
+	// Clean up
+	IndexRowsProgress.Reset()
+}


### PR DESCRIPTION
## Purpose

Expose index building progress as Prometheus metrics so operators can monitor index state via dashboards and alerts without requiring SDK calls to `DescribeIndex()`.

Currently, the only way to check index building progress is through the SDK (`describe_index()`), which is not practical for production monitoring setups that rely on Prometheus/Grafana.

issue: #47411

## Modifications

### New metric: `milvus_datacoord_index_rows_progress`

A `GaugeVec` with labels `collection_id`, `index_name`, and `progress_type`, where `progress_type` is one of:
- `total_rows` — total number of rows across all segments for this index
- `indexed_rows` — rows in segments with `Finished` index state
- `pending_index_rows` — rows in segments still building (Unissued, InProgress, Failed, Retry)

### Files changed

| File | Change |
|------|--------|
| `pkg/metrics/datacoord_metrics.go` | Define `IndexRowsProgress` gauge, register it, add cleanup on collection deletion |
| `internal/datacoord/index_meta.go` | Add `updateIndexRowsProgressMetrics()` that aggregates per-segment index state into per-collection/index row counts |
| `internal/datacoord/server.go` | Call the new update function in the periodic metrics collection loop |

### Design decisions

- **Follows existing pattern**: Same structure as `IndexStatsTaskNum` — periodic aggregation in `startCollectMetaMetrics()` ticker loop
- **Reset-then-set**: Gauge is reset each cycle to ensure deleted indexes don't leave stale metrics
- **Cleanup on drop**: Added to `CleanupDataCoordWithCollectionID()` for immediate cleanup when collections are dropped
- **Labels**: `collection_id` + `index_name` enables per-index dashboarding; `progress_type` keeps the metric count bounded

## Test

- Verified Go compilation (`go vet` passes for both `pkg/metrics/` and `internal/datacoord/`)
- Metric follows the same lifecycle as existing `IndexStatsTaskNum`: periodic update in server ticker, cleanup on collection drop
- No behavioral changes to existing code paths — purely additive