### PR TITLE
fix(querycoordv2): enumerate delegators by replica channel in LeaderChecker

### DIFF
--- a/internal/querycoordv2/checkers/leader_checker.go
+++ b/internal/querycoordv2/checkers/leader_checker.go
@@ -26,7 +26,6 @@ import (
 	"github.com/milvus-io/milvus/internal/querycoordv2/session"
 	"github.com/milvus-io/milvus/internal/querycoordv2/task"
 	"github.com/milvus-io/milvus/internal/querycoordv2/utils"
-	"github.com/milvus-io/milvus/internal/util/streamingutil"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 )
@@ -92,18 +91,17 @@ func (c *LeaderChecker) Check(ctx context.Context) []task.Task {
 
 		replicas := c.meta.ReplicaManager.GetByCollection(ctx, collectionID)
 		for _, replica := range replicas {
-			nodes := replica.GetRWNodes()
-			if streamingutil.IsStreamingServiceEnabled() {
-				nodes = replica.GetRWSQNodes()
-			}
-			for _, node := range nodes {
-				delegatorList := c.dist.ChannelDistManager.GetByFilter(meta.WithCollectionID2Channel(replica.GetCollectionID()), meta.WithNodeID2Channel(node))
-				for _, d := range delegatorList {
-					dist := c.dist.SegmentDistManager.GetByFilter(meta.WithChannel(d.View.Channel), meta.WithReplica(replica))
-					tasks = append(tasks, c.findNeedLoadedSegments(ctx, replica, d.View, dist)...)
-					tasks = append(tasks, c.findNeedRemovedSegments(ctx, replica, d.View, dist)...)
-					tasks = append(tasks, c.findNeedSyncPartitionStats(ctx, replica, d.View, node)...)
-				}
+			// PATCH: Do not filter delegators via replica.GetRWSQNodes(), which can
+			// become stale after streaming node restart and cause LeaderChecker to
+			// silently skip active delegators. Instead enumerate all delegators
+			// that belong to this replica via WithReplica2Channel — this mirrors
+			// the logic used by observers/target_observer.go which works correctly.
+			delegatorList := c.dist.ChannelDistManager.GetByFilter(meta.WithReplica2Channel(replica))
+			for _, d := range delegatorList {
+				dist := c.dist.SegmentDistManager.GetByFilter(meta.WithChannel(d.View.Channel), meta.WithReplica(replica))
+				tasks = append(tasks, c.findNeedLoadedSegments(ctx, replica, d.View, dist)...)
+				tasks = append(tasks, c.findNeedRemovedSegments(ctx, replica, d.View, dist)...)
+				tasks = append(tasks, c.findNeedSyncPartitionStats(ctx, replica, d.View, d.Node)...)
 			}
 		}
 	}

--- a/internal/querycoordv2/checkers/leader_checker_test.go
+++ b/internal/querycoordv2/checkers/leader_checker_test.go
@@ -603,6 +603,95 @@ func (suite *LeaderCheckerTestSuite) TestUpdatePartitionStats() {
 	suite.Equal(tasks[0].Actions()[0].Node(), int64(2))
 }
 
+// TestSyncLoadedSegmentsWithReplicaChannelFilter verifies that the leader checker
+// enumerates delegators using WithReplica2Channel(replica) rather than iterating
+// the replica's RW-SQ node list.
+//
+// Context: the original implementation filtered delegators via
+// replica.GetRWSQNodes() when the streaming service is enabled.  After a
+// streaming-node restart, GetRWSQNodes() can return an empty or stale set,
+// causing the checker to silently skip every delegator in the replica.  This
+// leaves them stuck with isServiceable=false indefinitely and triggers an
+// infinite segment-load-task re-scheduling loop.
+//
+// The fix replaces the node-loop with a single
+// ChannelDistManager.GetByFilter(meta.WithReplica2Channel(replica)) call, which
+// uses replica.GetNodes() (all node categories: RW, RO, RW-SQ, RO-SQ) and is
+// therefore not affected by a stale RW-SQ set.
+func (suite *LeaderCheckerTestSuite) TestSyncLoadedSegmentsWithReplicaChannelFilter() {
+	ctx := context.Background()
+	observer := suite.checker
+	observer.meta.CollectionManager.PutCollection(ctx, utils.CreateTestCollection(1, 1))
+	observer.meta.CollectionManager.PutPartition(ctx, utils.CreateTestPartition(1, 1))
+
+	// Replica nodes are regular querynode IDs (stored in GetRWNodes / GetNodes).
+	// GetRWSQNodes() returns empty for this replica because no RwSqNodes are set.
+	// The patched code must still find the delegator on node 2.
+	observer.meta.ReplicaManager.Put(ctx, utils.CreateTestReplica(1, 1, []int64{1, 2}))
+
+	segments := []*datapb.SegmentInfo{
+		{
+			ID:            1,
+			PartitionID:   1,
+			InsertChannel: "test-insert-channel",
+		},
+	}
+	channels := []*datapb.VchannelInfo{
+		{
+			CollectionID: 1,
+			ChannelName:  "test-insert-channel",
+		},
+	}
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, int64(1)).Return(channels, segments, nil)
+
+	suite.nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{
+		NodeID:   1,
+		Address:  "localhost",
+		Hostname: "localhost",
+	}))
+	suite.nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{
+		NodeID:   2,
+		Address:  "localhost",
+		Hostname: "localhost",
+	}))
+
+	observer.target.UpdateCollectionNextTarget(ctx, int64(1))
+	observer.target.UpdateCollectionCurrentTarget(ctx, 1)
+
+	// Segment is loaded on node 1.
+	loadVersion := time.Now().UnixMilli()
+	observer.dist.SegmentDistManager.Update(1, utils.CreateTestSegment(1, 1, 1, 1, loadVersion, "test-insert-channel"))
+
+	// Delegator lives on node 2.  WithReplica2Channel uses GetNodes() = [1, 2]
+	// so this delegator is reachable even when GetRWSQNodes() is empty.
+	observer.dist.ChannelDistManager.Update(2, &meta.DmChannel{
+		VchannelInfo: &datapb.VchannelInfo{
+			CollectionID: 1,
+			ChannelName:  "test-insert-channel",
+		},
+		Node:    2,
+		Version: 1,
+		View: &meta.LeaderView{
+			ID:           2,
+			CollectionID: 1,
+			Channel:      "test-insert-channel",
+			TargetVersion: observer.target.GetCollectionTargetVersion(
+				ctx, 1, meta.CurrentTarget),
+		},
+	})
+
+	// The checker must generate a task to sync the loaded segment to the
+	// leader view, proving that the delegator on node 2 was not skipped.
+	tasks := observer.Check(context.TODO())
+	suite.Len(tasks, 1)
+	suite.Equal(tasks[0].Source(), utils.LeaderChecker)
+	suite.Equal(tasks[0].ReplicaID(), int64(1))
+	suite.Len(tasks[0].Actions(), 1)
+	suite.Equal(tasks[0].Actions()[0].Type(), task.ActionTypeGrow)
+	suite.Equal(tasks[0].Actions()[0].Node(), int64(2))
+	suite.Equal(tasks[0].Actions()[0].(*task.LeaderAction).SegmentID(), int64(1))
+}
+
 func TestLeaderCheckerSuite(t *testing.T) {
 	suite.Run(t, new(LeaderCheckerTestSuite))
 }


### PR DESCRIPTION
 ## What this PR does / Why we need it

  LeaderChecker previously found delegator candidates by iterating
  `replica.GetRWSQNodes()` (streaming mode) or `replica.GetRWNodes()` and
  calling `ChannelDistManager.GetByFilter(WithCollectionID2Channel + WithNodeID2Channel(node))`
  for each node.

  When the streaming service is enabled and a streaming node restarts,
  `GetRWSQNodes()` can return an **empty or stale** node list for a short
  (or indefinite) period. During that window LeaderChecker silently skips
  every delegator belonging to the affected replica, leaving them stuck with
  `isServiceable=false` indefinitely.

  **Observed symptoms (production, Milvus 2.6 + streaming service):**
  - Delegator `version` frozen; never advances across checker ticks
  - All `load segment` tasks for the affected collection loop forever: mixcoord re-schedules them every ~200ms,
  querynode accepts but results are never acknowledged back
  - `collection may be not loaded or in recovering` warns every 5s
  - Collection loading progress stalls at a fixed percentage

  ## How

  Replace the per-node loop with a single call:

  ```go
  delegatorList := c.dist.ChannelDistManager.GetByFilter(meta.WithReplica2Channel(replica))

  WithReplica2Channel relies on replica.GetNodes(), which returns the
  union of all node categories (RW, RO, RW-SQ, RO-SQ) and is therefore
  unaffected by a temporarily empty RW-SQ set.

  This mirrors the logic already used correctly in observers/target_observer.go.

  Test

  New test TestSyncLoadedSegmentsWithReplicaChannelFilter in
  internal/querycoordv2/checkers/leader_checker_test.go verifies that the
  checker generates segment-sync tasks even when GetRWSQNodes() is empty
  (the replica's nodes are only present in the regular RW set).

  go test ./internal/querycoordv2/checkers/... -run
  TestLeaderCheckerSuite/TestSyncLoadedSegmentsWithReplicaChannelFilter -v

  Checklist

  - Code changes reviewed
  - Unit test added
  - No breaking changes (same behaviour when node lists are non-empty)