### PR TITLE
enhance: log statslogs in L0 invalid segment validation warning

### DIFF
--- a/internal/metastore/kv/datacoord/util.go
+++ b/internal/metastore/kv/datacoord/util.go
@@ -44,7 +44,7 @@ func ValidateSegment(segment *datapb.SegmentInfo) error {
 		if len(segment.GetBinlogs()) > 0 || len(segment.GetStatslogs()) > 0 {
 			log.Warn("find invalid segment while L0 segment get more than delta logs",
 				zap.Any("binlogs", segment.GetBinlogs()),
-				zap.Any("stats", segment.GetBinlogs()),
+				zap.Any("stats", segment.GetStatslogs()),
 			)
 			return fmt.Errorf("segment can not be saved because of L0 segment get more than delta logs: collection %v, segment %v",
 				segment.GetCollectionID(), segment.GetID())


### PR DESCRIPTION
## Summary

Fix the L0 segment validation warning so the `stats` zap field logs `GetStatslogs()` instead of duplicating `GetBinlogs()`, improving accuracy when diagnosing invalid L0 segments that have non-delta logs.

## Change

- `internal/metastore/kv/datacoord/util.go`: correct the field passed to `zap.Any("stats", ...)` in `ValidateSegment` for L0 segments.