### PR TITLE
enhance: support Sort/Bitmap/Hybrid index types for JSON Path Index

### DIFF
--- a/internal/core/src/exec/expression/ExistsExpr.cpp
+++ b/internal/core/src/exec/expression/ExistsExpr.cpp
@@ -93,49 +93,20 @@ PhyExistsFilterExpr::EvalJsonExistsForIndex() {
         auto* index = pinned_index_[cached_index_chunk_id_].get();
         AssertInfo(index != nullptr,
                    "Cannot find json index with path: " + pointer);
-        switch (index->GetCastType().data_type()) {
-            case JsonCastType::DataType::DOUBLE: {
-                auto* json_index =
-                    const_cast<index::JsonInvertedIndex<double>*>(
-                        dynamic_cast<const index::JsonInvertedIndex<double>*>(
-                            index));
-                cached_index_chunk_res_ =
-                    std::make_shared<TargetBitmap>(json_index->Exists());
-                break;
-            }
 
-            case JsonCastType::DataType::VARCHAR: {
-                auto* json_index = const_cast<
-                    index::JsonInvertedIndex<std::string>*>(
-                    dynamic_cast<const index::JsonInvertedIndex<std::string>*>(
-                        index));
-                cached_index_chunk_res_ =
-                    std::make_shared<TargetBitmap>(json_index->Exists());
-                break;
-            }
-
-            case JsonCastType::DataType::BOOL: {
-                auto* json_index = const_cast<index::JsonInvertedIndex<bool>*>(
-                    dynamic_cast<const index::JsonInvertedIndex<bool>*>(index));
-                cached_index_chunk_res_ =
-                    std::make_shared<TargetBitmap>(json_index->Exists());
-                break;
-            }
-
-            case JsonCastType::DataType::JSON: {
-                auto* json_flat_index = const_cast<index::JsonFlatIndex*>(
-                    dynamic_cast<const index::JsonFlatIndex*>(index));
-                auto executor =
-                    json_flat_index->create_executor<double>(pointer);
-                cached_index_chunk_res_ =
-                    std::make_shared<TargetBitmap>(executor->Exists());
-                break;
-            }
-
-            default:
-                ThrowInfo(DataTypeInvalid,
-                          "unsupported data type: {}",
-                          index->GetCastType());
+        if (index->GetCastType().data_type() == JsonCastType::DataType::JSON) {
+            // JsonFlatIndex needs special handling via executor
+            auto* json_flat_index = const_cast<index::JsonFlatIndex*>(
+                dynamic_cast<const index::JsonFlatIndex*>(index));
+            auto executor = json_flat_index->create_executor<double>(pointer);
+            cached_index_chunk_res_ =
+                std::make_shared<TargetBitmap>(executor->Exists());
+        } else {
+            // All other JSON path indexes (Inverted, Sort, Bitmap, Hybrid)
+            // support Exists() directly via IndexBase virtual method
+            auto* mutable_index = const_cast<index::IndexBase*>(index);
+            cached_index_chunk_res_ =
+                std::make_shared<TargetBitmap>(mutable_index->Exists());
         }
     }
     auto res = MoveOrSliceBitmap(

--- a/internal/core/src/index/BitmapIndex.h
+++ b/internal/core/src/index/BitmapIndex.h
@@ -97,12 +97,6 @@ class BitmapIndex : public ScalarIndex<T> {
     TargetBitmap
     IsNotNull() override;
 
-    TargetBitmap
-    Exists() override {
-        TargetBitmap res(total_num_rows_, true);
-        res &= valid_bitset_;
-        return res;
-    }
 
     const TargetBitmap
     Range(const T& value, OpType op) override;

--- a/internal/core/src/index/BitmapIndex.h
+++ b/internal/core/src/index/BitmapIndex.h
@@ -97,6 +97,13 @@ class BitmapIndex : public ScalarIndex<T> {
     TargetBitmap
     IsNotNull() override;
 
+    TargetBitmap
+    Exists() override {
+        TargetBitmap res(total_num_rows_, true);
+        res &= valid_bitset_;
+        return res;
+    }
+
     const TargetBitmap
     Range(const T& value, OpType op) override;
 

--- a/internal/core/src/index/HybridScalarIndex.h
+++ b/internal/core/src/index/HybridScalarIndex.h
@@ -105,7 +105,7 @@ class HybridScalarIndex : public ScalarIndex<T> {
         return internal_index_->IsNotNull();
     }
 
-    TargetBitmap
+    const TargetBitmap&
     Exists() override {
         return internal_index_->Exists();
     }

--- a/internal/core/src/index/HybridScalarIndex.h
+++ b/internal/core/src/index/HybridScalarIndex.h
@@ -105,10 +105,6 @@ class HybridScalarIndex : public ScalarIndex<T> {
         return internal_index_->IsNotNull();
     }
 
-    const TargetBitmap&
-    Exists() override {
-        return internal_index_->Exists();
-    }
 
     const TargetBitmap
     Query(const DatasetPtr& dataset) override {

--- a/internal/core/src/index/HybridScalarIndex.h
+++ b/internal/core/src/index/HybridScalarIndex.h
@@ -105,6 +105,11 @@ class HybridScalarIndex : public ScalarIndex<T> {
         return internal_index_->IsNotNull();
     }
 
+    TargetBitmap
+    Exists() override {
+        return internal_index_->Exists();
+    }
+
     const TargetBitmap
     Query(const DatasetPtr& dataset) override {
         return internal_index_->Query(dataset);
@@ -187,6 +192,16 @@ class HybridScalarIndex : public ScalarIndex<T> {
     LoadEntries(storage::IndexEntryReader& reader,
                 const Config& config) override;
 
+ protected:
+    ScalarIndexType
+    SelectIndexBuildType(const std::vector<FieldDataPtr>& field_datas);
+
+    ScalarIndexType
+    SelectIndexTypeByCardinality(size_t cardinality);
+
+    void
+    BuildInternal(const std::vector<FieldDataPtr>& field_datas);
+
  private:
     ScalarIndexType
     SelectBuildTypeForPrimitiveType(
@@ -196,22 +211,13 @@ class HybridScalarIndex : public ScalarIndex<T> {
     SelectBuildTypeForArrayType(const std::vector<FieldDataPtr>& field_datas);
 
     ScalarIndexType
-    SelectIndexBuildType(const std::vector<FieldDataPtr>& field_datas);
-
-    ScalarIndexType
     SelectIndexBuildType(size_t n, const T* values);
-
-    ScalarIndexType
-    SelectIndexTypeByCardinality(size_t cardinality);
 
     BinarySet
     SerializeIndexType();
 
     void
     DeserializeIndexType(const BinarySet& binary_set);
-
-    void
-    BuildInternal(const std::vector<FieldDataPtr>& field_datas);
 
     std::shared_ptr<ScalarIndex<T>>
     GetInternalIndex();

--- a/internal/core/src/index/Index.h
+++ b/internal/core/src/index/Index.h
@@ -96,6 +96,14 @@ class IndexBase {
         return JsonCastType::UNKNOWN;
     }
 
+    // Returns a bitmap indicating which rows have valid indexed values.
+    // Used by JSON Path Index for EXISTS queries: valid_bitset_[i] = true
+    // means row i has a value at the indexed path.
+    virtual TargetBitmap
+    Exists() {
+        ThrowInfo(NotImplemented, "Exists() not supported for this index type");
+    }
+
     // TODO: how to get the cell byte size?
     virtual cachinglayer::ResourceUsage
     CellByteSize() const {

--- a/internal/core/src/index/Index.h
+++ b/internal/core/src/index/Index.h
@@ -96,10 +96,15 @@ class IndexBase {
         return JsonCastType::UNKNOWN;
     }
 
-    // Returns a bitmap indicating which rows have valid indexed values.
-    // Used by JSON Path Index for EXISTS queries: valid_bitset_[i] = true
-    // means row i has a value at the indexed path.
-    virtual TargetBitmap
+    // Returns a bitmap indicating which rows have the indexed JSON path present.
+    // Used by JSON Path Index for EXISTS queries.
+    //
+    // This is distinct from valid_bitset_ (used by IsNotNull): valid_bitset_
+    // tracks whether a row's value can be successfully cast to the index's
+    // target type, while Exists() tracks whether the JSON path exists at all.
+    // Example: {"price": "hello"} with a DOUBLE path index has Exists()=true
+    // (path present) but valid=false (cannot cast "hello" to double).
+    virtual const TargetBitmap&
     Exists() {
         ThrowInfo(NotImplemented, "Exists() not supported for this index type");
     }

--- a/internal/core/src/index/IndexFactory.cpp
+++ b/internal/core/src/index/IndexFactory.cpp
@@ -38,7 +38,9 @@
 #include "index/InvertedIndexTantivy.h"
 #include "index/TextMatchIndex.h"
 #include "index/JsonFlatIndex.h"
+#include "index/JsonHybridScalarIndex.h"
 #include "index/JsonInvertedIndex.h"
+#include "index/JsonScalarIndexWrapper.h"
 #include "index/Meta.h"
 #include "index/NgramInvertedIndex.h"
 #include "index/RTreeIndex.h"
@@ -500,17 +502,104 @@ IndexFactory::CreateComplexScalarIndex(
     ThrowInfo(Unsupported, "Complex index not supported now");
 }
 
+namespace {
+
+template <typename T, typename BaseIndex>
+IndexBasePtr
+MakeJsonWrapped(const CreateIndexInfo& info,
+                const storage::FileManagerContext& ctx) {
+    // Pass original JSON schema for path extraction, and ctx for file manager.
+    // The wrapper internally creates a modified ctx with cast type for the
+    // base index's schema-dependent logic.
+    return std::make_unique<JsonScalarIndexWrapper<T, BaseIndex>>(
+        info.json_cast_type,
+        info.json_path,
+        JsonCastFunction::FromString(info.json_cast_function),
+        ctx.fieldDataMeta.field_schema,
+        ctx);
+}
+
+template <typename T>
+IndexBasePtr
+MakeJsonHybrid(const CreateIndexInfo& info,
+               const storage::FileManagerContext& ctx) {
+    return std::make_unique<JsonHybridScalarIndex<T>>(
+        info.json_cast_type,
+        info.json_path,
+        JsonCastFunction::FromString(info.json_cast_function),
+        ctx.fieldDataMeta.field_schema,
+        info.tantivy_index_version,
+        ctx);
+}
+
+}  // namespace
+
 IndexBasePtr
 IndexFactory::CreateJsonIndex(
     const CreateIndexInfo& create_index_info,
     const storage::FileManagerContext& file_manager_context) {
-    AssertInfo(create_index_info.index_type == INVERTED_INDEX_TYPE ||
-                   create_index_info.index_type == NGRAM_INDEX_TYPE,
-               "Invalid index type for json index");
-
+    const auto& index_type = create_index_info.index_type;
     const auto& cast_dtype = create_index_info.json_cast_type;
     const auto& nested_path = create_index_info.json_path;
     const auto& json_cast_function = create_index_info.json_cast_function;
+
+    // Sort index
+    if (index_type == ASCENDING_SORT) {
+        switch (cast_dtype.element_type()) {
+            case JsonCastType::DataType::DOUBLE:
+                return MakeJsonWrapped<double, ScalarIndexSort<double>>(
+                    create_index_info, file_manager_context);
+            case JsonCastType::DataType::VARCHAR:
+                return MakeJsonWrapped<std::string, StringIndexSort>(
+                    create_index_info, file_manager_context);
+            default:
+                ThrowInfo(DataTypeInvalid,
+                          "Invalid cast type for JSON sort index: {}",
+                          cast_dtype);
+        }
+    }
+
+    // Bitmap index
+    if (index_type == BITMAP_INDEX_TYPE) {
+        switch (cast_dtype.element_type()) {
+            case JsonCastType::DataType::BOOL:
+                return MakeJsonWrapped<bool, BitmapIndex<bool>>(
+                    create_index_info, file_manager_context);
+            case JsonCastType::DataType::VARCHAR:
+                return MakeJsonWrapped<std::string, BitmapIndex<std::string>>(
+                    create_index_info, file_manager_context);
+            default:
+                ThrowInfo(DataTypeInvalid,
+                          "Invalid cast type for JSON bitmap index: {}",
+                          cast_dtype);
+        }
+    }
+
+    // Hybrid index
+    if (index_type == HYBRID_INDEX_TYPE) {
+        switch (cast_dtype.element_type()) {
+            case JsonCastType::DataType::BOOL:
+                return MakeJsonHybrid<bool>(create_index_info,
+                                            file_manager_context);
+            case JsonCastType::DataType::DOUBLE:
+                return MakeJsonHybrid<double>(create_index_info,
+                                              file_manager_context);
+            case JsonCastType::DataType::VARCHAR:
+                return MakeJsonHybrid<std::string>(create_index_info,
+                                                   file_manager_context);
+            default:
+                ThrowInfo(DataTypeInvalid,
+                          "Invalid cast type for JSON hybrid index: {}",
+                          cast_dtype);
+        }
+    }
+
+    // Inverted / NGram (existing paths)
+    AssertInfo(
+        index_type == INVERTED_INDEX_TYPE || index_type == NGRAM_INDEX_TYPE,
+        "Invalid index type for json index: {}",
+        index_type);
+
     switch (cast_dtype.element_type()) {
         case JsonCastType::DataType::BOOL:
             return std::make_unique<index::JsonInvertedIndex<bool>>(

--- a/internal/core/src/index/JsonHybridScalarIndex.h
+++ b/internal/core/src/index/JsonHybridScalarIndex.h
@@ -1,0 +1,171 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <algorithm>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "common/FieldDataInterface.h"
+#include "common/JsonCastFunction.h"
+#include "common/JsonCastType.h"
+#include "index/HybridScalarIndex.h"
+#include "index/JsonIndexBuilder.h"
+#include "index/JsonScalarIndexWrapper.h"
+#include "log/Log.h"
+#include "pb/schema.pb.h"
+#include "storage/IndexEntryReader.h"
+#include "storage/IndexEntryWriter.h"
+#include "storage/MemFileManagerImpl.h"
+#include "storage/Util.h"
+
+namespace milvus::index {
+
+template <typename T>
+class JsonHybridScalarIndex : public HybridScalarIndex<T> {
+ public:
+    JsonHybridScalarIndex(const JsonCastType& cast_type,
+                          const std::string& nested_path,
+                          const JsonCastFunction& cast_function,
+                          const proto::schema::FieldSchema& json_schema,
+                          uint32_t tantivy_index_version,
+                          const storage::FileManagerContext& original_ctx)
+        : HybridScalarIndex<T>(tantivy_index_version,
+                               MakeJsonCastContext(original_ctx, cast_type)),
+          cast_type_(cast_type),
+          nested_path_(nested_path),
+          cast_function_(cast_function),
+          json_schema_(json_schema) {
+        json_file_manager_ =
+            std::make_shared<storage::MemFileManagerImpl>(original_ctx);
+    }
+
+    void
+    Build(const Config& config) override {
+        if (this->is_built_) {
+            return;
+        }
+
+        this->bitmap_index_cardinality_limit_ =
+            GetBitmapCardinalityLimitFromConfig(config);
+
+        auto scalar_index_version =
+            GetValueFromConfig<int32_t>(config, SCALAR_INDEX_ENGINE_VERSION)
+                .value_or(kLastVersionWithoutHybridIndexConfig);
+
+        if (scalar_index_version >= kHybridIndexConfigVersion) {
+            this->low_cardinality_index_type_ =
+                GetHybridLowCardinalityIndexTypeFromConfig(config);
+            this->high_cardinality_index_type_ =
+                GetHybridHighCardinalityIndexTypeFromConfig(config);
+        } else {
+            this->low_cardinality_index_type_ = ScalarIndexType::BITMAP;
+            this->high_cardinality_index_type_ = ScalarIndexType::NONE;
+        }
+
+        auto json_field_datas =
+            storage::CacheRawDataAndFillMissing(json_file_manager_, config);
+
+        auto result = ConvertJsonToTypedFieldData<T>(json_field_datas,
+                                                     json_schema_,
+                                                     nested_path_,
+                                                     cast_type_,
+                                                     cast_function_);
+
+        non_exist_offsets_ = std::move(result.non_exist_offsets);
+
+        // Do cardinality counting that respects is_valid(), unlike the base
+        // class SelectBuildTypeForPrimitiveType which counts invalid rows too.
+        std::set<T> distinct_vals;
+        for (const auto& data : result.field_datas) {
+            auto n = data->get_num_rows();
+            for (size_t i = 0; i < n; ++i) {
+                if (data->is_valid(i)) {
+                    auto val = reinterpret_cast<const T*>(data->RawValue(i));
+                    distinct_vals.insert(*val);
+                    if (distinct_vals.size() >=
+                        this->bitmap_index_cardinality_limit_) {
+                        break;
+                    }
+                }
+            }
+        }
+        this->SelectIndexTypeByCardinality(distinct_vals.size());
+        this->BuildInternal(result.field_datas);
+
+        this->is_built_ = true;
+        this->ComputeByteSize();
+    }
+
+    TargetBitmap
+    Exists() override {
+        int64_t count = this->Count();
+        TargetBitmap bitset(count, true);
+        auto end = std::lower_bound(non_exist_offsets_.begin(),
+                                    non_exist_offsets_.end(),
+                                    static_cast<size_t>(count));
+        for (auto iter = non_exist_offsets_.begin(); iter != end; ++iter) {
+            bitset.reset(*iter);
+        }
+        return bitset;
+    }
+
+    void
+    WriteEntries(storage::IndexEntryWriter* writer) override {
+        HybridScalarIndex<T>::WriteEntries(writer);
+
+        bool has_non_exist = !non_exist_offsets_.empty();
+        writer->PutMeta("has_non_exist", has_non_exist);
+        if (has_non_exist) {
+            writer->WriteEntry(kJsonNonExistOffsetFileName,
+                               non_exist_offsets_.data(),
+                               non_exist_offsets_.size() * sizeof(size_t));
+        }
+    }
+
+    void
+    LoadEntries(storage::IndexEntryReader& reader,
+                const Config& config) override {
+        HybridScalarIndex<T>::LoadEntries(reader, config);
+
+        bool has_non_exist = reader.GetMeta<bool>("has_non_exist", false);
+        if (has_non_exist) {
+            auto e = reader.ReadEntry(kJsonNonExistOffsetFileName);
+            non_exist_offsets_.resize(e.data.size() / sizeof(size_t));
+            std::memcpy(
+                non_exist_offsets_.data(), e.data.data(), e.data.size());
+        }
+        LOG_INFO("LoadEntries JsonHybridScalarIndex done, has_non_exist: {}",
+                 has_non_exist);
+    }
+
+    JsonCastType
+    GetCastType() const override {
+        return cast_type_;
+    }
+
+ private:
+    JsonCastType cast_type_;
+    std::string nested_path_;
+    JsonCastFunction cast_function_;
+    proto::schema::FieldSchema json_schema_;
+    storage::MemFileManagerImplPtr json_file_manager_;
+    std::vector<size_t> non_exist_offsets_;
+};
+
+}  // namespace milvus::index

--- a/internal/core/src/index/JsonHybridScalarIndex.h
+++ b/internal/core/src/index/JsonHybridScalarIndex.h
@@ -25,6 +25,7 @@
 #include "common/JsonCastFunction.h"
 #include "common/JsonCastType.h"
 #include "index/HybridScalarIndex.h"
+#include "index/Utils.h"
 #include "index/JsonIndexBuilder.h"
 #include "index/JsonScalarIndexWrapper.h"
 #include "log/Log.h"
@@ -53,6 +54,35 @@ class JsonHybridScalarIndex : public HybridScalarIndex<T> {
           json_schema_(json_schema) {
         json_file_manager_ =
             std::make_shared<storage::MemFileManagerImpl>(original_ctx);
+    }
+
+    void
+    BuildWithFieldData(
+        const std::vector<FieldDataPtr>& field_datas) override {
+        auto result = ConvertJsonToTypedFieldData<T>(
+            field_datas, json_schema_, nested_path_, cast_type_,
+            cast_function_);
+        non_exist_offsets_ = std::move(result.non_exist_offsets);
+
+        std::set<T> distinct_vals;
+        for (const auto& data : result.field_datas) {
+            auto n = data->get_num_rows();
+            for (size_t i = 0; i < n; ++i) {
+                if (data->is_valid(i)) {
+                    auto val =
+                        reinterpret_cast<const T*>(data->RawValue(i));
+                    distinct_vals.insert(*val);
+                    if (distinct_vals.size() >=
+                        this->bitmap_index_cardinality_limit_) {
+                        break;
+                    }
+                }
+            }
+        }
+        this->SelectIndexTypeByCardinality(distinct_vals.size());
+        this->BuildInternal(result.field_datas);
+        this->is_built_ = true;
+        this->ComputeByteSize();
     }
 
     void

--- a/internal/core/src/index/JsonHybridScalarIndex.h
+++ b/internal/core/src/index/JsonHybridScalarIndex.h
@@ -140,19 +140,12 @@ class JsonHybridScalarIndex : public HybridScalarIndex<T> {
 
         this->is_built_ = true;
         this->ComputeByteSize();
+        BuildExistsBitset();
     }
 
-    TargetBitmap
+    const TargetBitmap&
     Exists() override {
-        int64_t count = this->Count();
-        TargetBitmap bitset(count, true);
-        auto end = std::lower_bound(non_exist_offsets_.begin(),
-                                    non_exist_offsets_.end(),
-                                    static_cast<size_t>(count));
-        for (auto iter = non_exist_offsets_.begin(); iter != end; ++iter) {
-            bitset.reset(*iter);
-        }
-        return bitset;
+        return exists_bitset_;
     }
 
     void
@@ -182,6 +175,7 @@ class JsonHybridScalarIndex : public HybridScalarIndex<T> {
         }
         LOG_INFO("LoadEntries JsonHybridScalarIndex done, has_non_exist: {}",
                  has_non_exist);
+        BuildExistsBitset();
     }
 
     JsonCastType
@@ -190,12 +184,25 @@ class JsonHybridScalarIndex : public HybridScalarIndex<T> {
     }
 
  private:
+    void
+    BuildExistsBitset() {
+        int64_t count = this->Count();
+        exists_bitset_ = TargetBitmap(count, true);
+        for (auto offset : non_exist_offsets_) {
+            if (static_cast<int64_t>(offset) >= count) {
+                break;
+            }
+            exists_bitset_.reset(offset);
+        }
+    }
+
     JsonCastType cast_type_;
     std::string nested_path_;
     JsonCastFunction cast_function_;
     proto::schema::FieldSchema json_schema_;
     storage::MemFileManagerImplPtr json_file_manager_;
     std::vector<size_t> non_exist_offsets_;
+    TargetBitmap exists_bitset_;
 };
 
 }  // namespace milvus::index

--- a/internal/core/src/index/JsonIndexBuilder.cpp
+++ b/internal/core/src/index/JsonIndexBuilder.cpp
@@ -14,6 +14,7 @@
 #include <string_view>
 #include <type_traits>
 
+#include "common/FieldData.h"
 #include "common/FieldDataInterface.h"
 #include "common/Json.h"
 #include "common/JsonCastType.h"
@@ -154,5 +155,99 @@ ProcessJsonFieldData<std::string>(
     JsonNullAdder null_adder,
     JsonNonExistAdder non_exist_adder,
     JsonErrorRecorder error_recorder);
+
+namespace {
+
+template <typename T>
+DataType
+GetMilvusDataType() {
+    if constexpr (std::is_same_v<T, bool>) {
+        return DataType::BOOL;
+    } else if constexpr (std::is_same_v<T, double>) {
+        return DataType::DOUBLE;
+    } else if constexpr (std::is_same_v<T, std::string>) {
+        return DataType::VARCHAR;
+    } else {
+        static_assert(sizeof(T) == 0, "unsupported type for JSON conversion");
+    }
+}
+
+}  // namespace
+
+template <typename T>
+JsonToTypedResult
+ConvertJsonToTypedFieldData(
+    const std::vector<std::shared_ptr<FieldDataBase>>& json_field_datas,
+    const proto::schema::FieldSchema& schema,
+    const std::string& nested_path,
+    const JsonCastType& cast_type,
+    JsonCastFunction cast_function) {
+    int64_t total_rows = 0;
+    for (const auto& data : json_field_datas) {
+        total_rows += data->get_num_rows();
+    }
+
+    auto data_type = GetMilvusDataType<T>();
+    auto field_data = std::make_shared<FieldData<T>>(
+        data_type, /*nullable=*/true, total_rows);
+
+    // Use FixedVector to avoid std::vector<bool> specialization
+    FixedVector<T> values(total_rows);
+    std::vector<uint8_t> valid_data((total_rows + 7) / 8, 0);
+    std::vector<size_t> non_exist_offsets;
+
+    ProcessJsonFieldData<T>(
+        json_field_datas,
+        schema,
+        nested_path,
+        cast_type,
+        cast_function,
+        [&values, &valid_data](const T* data, int64_t size, int64_t offset) {
+            if (size > 0) {
+                values[offset] = data[0];
+                valid_data[offset / 8] |= (1 << (offset % 8));
+            }
+        },
+        [](int64_t) {},
+        // non_exist_adder: track offsets where the path truly doesn't exist
+        [&non_exist_offsets](int64_t offset) {
+            non_exist_offsets.push_back(offset);
+        },
+        [](const Json&, const std::string&, simdjson::error_code) {});
+
+    const void* data_ptr = values.data();
+    FieldDataBase* base_ptr = field_data.get();
+    base_ptr->FillFieldData(
+        data_ptr, valid_data.data(), (ssize_t)total_rows, (ssize_t)0);
+
+    return JsonToTypedResult{
+        .field_datas = {field_data},
+        .non_exist_offsets = std::move(non_exist_offsets),
+    };
+}
+
+template JsonToTypedResult
+ConvertJsonToTypedFieldData<bool>(
+    const std::vector<std::shared_ptr<FieldDataBase>>& json_field_datas,
+    const proto::schema::FieldSchema& schema,
+    const std::string& nested_path,
+    const JsonCastType& cast_type,
+    JsonCastFunction cast_function);
+
+template JsonToTypedResult
+ConvertJsonToTypedFieldData<double>(
+    const std::vector<std::shared_ptr<FieldDataBase>>& json_field_datas,
+    const proto::schema::FieldSchema& schema,
+    const std::string& nested_path,
+    const JsonCastType& cast_type,
+    JsonCastFunction cast_function);
+
+template JsonToTypedResult
+ConvertJsonToTypedFieldData<std::string>(
+    const std::vector<std::shared_ptr<FieldDataBase>>& json_field_datas,
+    const proto::schema::FieldSchema& schema,
+    const std::string& nested_path,
+    const JsonCastType& cast_type,
+    JsonCastFunction cast_function);
 
 }  // namespace milvus::index

--- a/internal/core/src/index/JsonIndexBuilder.h
+++ b/internal/core/src/index/JsonIndexBuilder.h
@@ -36,6 +36,55 @@ using JsonErrorRecorder = std::function<void(const Json& json,
 using JsonNullAdder = std::function<void(int64_t offset)>;
 using JsonNonExistAdder = std::function<void(int64_t offset)>;
 
+// Result of converting JSON field data to typed FieldData.
+struct JsonToTypedResult {
+    // Typed field data with nullable semantics. Rows where the path doesn't
+    // exist or the cast fails are marked as invalid.
+    std::vector<FieldDataPtr> field_datas;
+
+    // Offsets of rows where the JSON path does not exist (row is null, path
+    // missing, or path value is null). This is a SUBSET of the invalid rows
+    // in field_datas — rows that exist but fail to cast are NOT included.
+    // Used for EXISTS queries: Exists() should return true for rows where
+    // the path exists, even if the value can't be cast to the index type.
+    std::vector<size_t> non_exist_offsets;
+};
+
+// Convert JSON field data into typed FieldData by extracting values at
+// the given nested_path.
+template <typename T>
+JsonToTypedResult
+ConvertJsonToTypedFieldData(
+    const std::vector<std::shared_ptr<FieldDataBase>>& json_field_datas,
+    const proto::schema::FieldSchema& schema,
+    const std::string& nested_path,
+    const JsonCastType& cast_type,
+    JsonCastFunction cast_function);
+
+extern template JsonToTypedResult
+ConvertJsonToTypedFieldData<bool>(
+    const std::vector<std::shared_ptr<FieldDataBase>>& json_field_datas,
+    const proto::schema::FieldSchema& schema,
+    const std::string& nested_path,
+    const JsonCastType& cast_type,
+    JsonCastFunction cast_function);
+
+extern template JsonToTypedResult
+ConvertJsonToTypedFieldData<double>(
+    const std::vector<std::shared_ptr<FieldDataBase>>& json_field_datas,
+    const proto::schema::FieldSchema& schema,
+    const std::string& nested_path,
+    const JsonCastType& cast_type,
+    JsonCastFunction cast_function);
+
+extern template JsonToTypedResult
+ConvertJsonToTypedFieldData<std::string>(
+    const std::vector<std::shared_ptr<FieldDataBase>>& json_field_datas,
+    const proto::schema::FieldSchema& schema,
+    const std::string& nested_path,
+    const JsonCastType& cast_type,
+    JsonCastFunction cast_function);
+
 // A helper function for processing json data for building inverted index
 template <typename T>
 void

--- a/internal/core/src/index/JsonInvertedIndex.cpp
+++ b/internal/core/src/index/JsonInvertedIndex.cpp
@@ -81,30 +81,13 @@ JsonInvertedIndex<T>::build_index_for_json(
         });
 
     error_recorder_.PrintErrStats();
+    BuildExistsBitset();
 }
 
 template <typename T>
-TargetBitmap
+const TargetBitmap&
 JsonInvertedIndex<T>::Exists() {
-    int64_t count = this->Count();
-    TargetBitmap bitset(count, true);
-
-    auto fill_bitset = [this, count, &bitset]() {
-        auto end = std::lower_bound(
-            non_exist_offsets_.begin(), non_exist_offsets_.end(), count);
-        for (auto iter = non_exist_offsets_.begin(); iter != end; ++iter) {
-            bitset.reset(*iter);
-        }
-    };
-
-    if (this->is_growing_) {
-        std::shared_lock<folly::SharedMutex> lock(this->mutex_);
-        fill_bitset();
-    } else {
-        fill_bitset();
-    }
-
-    return bitset;
+    return exists_bitset_;
 }
 
 template <typename T>
@@ -134,6 +117,7 @@ JsonInvertedIndex<T>::LoadIndexMetas(
             std::move(index_datas.at(INDEX_NON_EXIST_OFFSET_FILE_NAME));
         fill_non_exist_offset(non_exist_offset_data->PayloadData(),
                               non_exist_offset_data->PayloadSize());
+        BuildExistsBitset();
         return;
     }
     std::vector<std::string> non_exist_offset_files;
@@ -161,6 +145,7 @@ JsonInvertedIndex<T>::LoadIndexMetas(
             fill_non_exist_offset(non_exist_offset_codec->PayloadData(),
                                   non_exist_offset_codec->PayloadSize());
         }
+        BuildExistsBitset();
         return;
     }
 
@@ -171,6 +156,7 @@ JsonInvertedIndex<T>::LoadIndexMetas(
     // Use null_offset_ as the source for non_exist_offsets_ to maintain
     // backward compatibility. This ensures Exists() behaves like v2.5.x IsNotNull().
     non_exist_offsets_ = this->null_offset_;
+    BuildExistsBitset();
 }
 
 template <typename T>
@@ -235,6 +221,7 @@ JsonInvertedIndex<T>::LoadEntries(storage::IndexEntryReader& reader,
     }
     LOG_INFO("LoadEntries JsonInvertedIndex done, has_non_exist: {}",
              has_non_exist);
+    BuildExistsBitset();
 }
 
 template class JsonInvertedIndex<bool>;

--- a/internal/core/src/index/JsonInvertedIndex.h
+++ b/internal/core/src/index/JsonInvertedIndex.h
@@ -77,6 +77,8 @@ class JsonInvertedIndexParseErrorRecorder {
 };
 
 template <typename T>
+// JSON path inverted index for sealed segments only.
+// Growing segments use brute-force scanning on raw JSON data instead.
 class JsonInvertedIndex : public index::InvertedIndexTantivy<T> {
  public:
     JsonInvertedIndex(
@@ -169,8 +171,8 @@ class JsonInvertedIndex : public index::InvertedIndexTantivy<T> {
         return res_set;
     }
 
-    // Returns a bitmap indicating which rows have values that are indexed.
-    TargetBitmap
+    // Returns a cached bitmap indicating which rows have the indexed path.
+    const TargetBitmap&
     Exists() override;
 
     void
@@ -206,6 +208,19 @@ class JsonInvertedIndex : public index::InvertedIndexTantivy<T> {
     // For example, if the JSON path is "/a", this vector will store rows like
     // null, {}, {"a": null}, etc.
     std::vector<size_t> non_exist_offsets_;
+    TargetBitmap exists_bitset_;
+
+    void
+    BuildExistsBitset() {
+        int64_t count = this->Count();
+        exists_bitset_ = TargetBitmap(count, true);
+        for (auto offset : non_exist_offsets_) {
+            if (static_cast<int64_t>(offset) >= count) {
+                break;
+            }
+            exists_bitset_.reset(offset);
+        }
+    }
 };
 
 }  // namespace milvus::index

--- a/internal/core/src/index/JsonInvertedIndex.h
+++ b/internal/core/src/index/JsonInvertedIndex.h
@@ -171,7 +171,7 @@ class JsonInvertedIndex : public index::InvertedIndexTantivy<T> {
 
     // Returns a bitmap indicating which rows have values that are indexed.
     TargetBitmap
-    Exists();
+    Exists() override;
 
     void
     WriteEntries(storage::IndexEntryWriter* writer) override;

--- a/internal/core/src/index/JsonPathIndexTest.cpp
+++ b/internal/core/src/index/JsonPathIndexTest.cpp
@@ -1,0 +1,483 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+#include <gtest/gtest.h>
+#include <simdjson.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "common/FieldData.h"
+#include "common/Json.h"
+#include "common/JsonCastType.h"
+#include "common/Schema.h"
+#include "common/Types.h"
+#include "index/BitmapIndex.h"
+#include "index/Index.h"
+#include "index/IndexFactory.h"
+#include "index/IndexInfo.h"
+#include "index/JsonHybridScalarIndex.h"
+#include "index/JsonIndexBuilder.h"
+#include "index/JsonScalarIndexWrapper.h"
+#include "index/Meta.h"
+#include "index/ScalarIndexSort.h"
+#include "pb/schema.pb.h"
+#include "simdjson/padded_string.h"
+#include "storage/Types.h"
+
+using namespace milvus;
+using namespace milvus::index;
+
+namespace {
+
+// Helper: create JSON FieldData from raw strings
+std::shared_ptr<FieldData<Json>>
+MakeJsonFieldData(const std::vector<std::string>& raw_jsons) {
+    std::vector<Json> jsons;
+    jsons.reserve(raw_jsons.size());
+    for (const auto& s : raw_jsons) {
+        jsons.emplace_back(simdjson::padded_string(s));
+    }
+    auto fd = std::make_shared<FieldData<Json>>(DataType::JSON, false);
+    fd->add_json_data(jsons);
+    return fd;
+}
+
+// Helper: create a proto FieldSchema for JSON
+proto::schema::FieldSchema
+MakeJsonSchema(int64_t field_id = 101, bool nullable = false) {
+    proto::schema::FieldSchema schema;
+    schema.set_data_type(proto::schema::JSON);
+    schema.set_fieldid(field_id);
+    schema.set_nullable(nullable);
+    return schema;
+}
+
+// Helper: create a FileManagerContext for JSON field (no actual file manager)
+storage::FileManagerContext
+MakeTestContext(int64_t field_id = 101) {
+    storage::FileManagerContext ctx;
+    ctx.fieldDataMeta.field_schema.set_data_type(proto::schema::JSON);
+    ctx.fieldDataMeta.field_schema.set_fieldid(field_id);
+    ctx.fieldDataMeta.field_id = field_id;
+    return ctx;
+}
+
+}  // namespace
+
+// ============================================================
+// 1. ConvertJsonToTypedFieldData tests
+// ============================================================
+
+TEST(JsonPathIndexTest, ConvertDouble_NormalExtraction) {
+    auto json_fd = MakeJsonFieldData({
+        R"({"a": 1.5})",
+        R"({"a": 2.0})",
+        R"({"a": 3.7})",
+    });
+    auto schema = MakeJsonSchema();
+    auto result = ConvertJsonToTypedFieldData<double>(
+        {json_fd}, schema, "/a", JsonCastType::FromString("DOUBLE"),
+        JsonCastFunction::FromString("unknown"));
+
+    ASSERT_EQ(result.field_datas.size(), 1);
+    auto& fd = result.field_datas[0];
+    EXPECT_EQ(fd->get_num_rows(), 3);
+    // All rows valid
+    for (int i = 0; i < 3; i++) {
+        EXPECT_TRUE(fd->is_valid(i));
+    }
+    EXPECT_TRUE(result.non_exist_offsets.empty());
+}
+
+TEST(JsonPathIndexTest, ConvertDouble_PathNotExist) {
+    auto json_fd = MakeJsonFieldData({
+        R"({"b": 1})",   // path /a doesn't exist
+        R"({"a": 2.0})", // exists
+        R"(100)",         // not an object, /a doesn't exist
+    });
+    auto schema = MakeJsonSchema();
+    auto result = ConvertJsonToTypedFieldData<double>(
+        {json_fd}, schema, "/a", JsonCastType::FromString("DOUBLE"),
+        JsonCastFunction::FromString("unknown"));
+
+    auto& fd = result.field_datas[0];
+    EXPECT_EQ(fd->get_num_rows(), 3);
+    EXPECT_FALSE(fd->is_valid(0));  // path not exist
+    EXPECT_TRUE(fd->is_valid(1));   // valid
+    EXPECT_FALSE(fd->is_valid(2));  // path not exist
+
+    // non_exist_offsets should contain 0 and 2
+    ASSERT_EQ(result.non_exist_offsets.size(), 2);
+    EXPECT_EQ(result.non_exist_offsets[0], 0);
+    EXPECT_EQ(result.non_exist_offsets[1], 2);
+}
+
+TEST(JsonPathIndexTest, ConvertDouble_PathExistsButCastFails) {
+    auto json_fd = MakeJsonFieldData({
+        R"({"a": "hello"})",  // path exists, but can't cast to DOUBLE
+        R"({"a": 2.0})",     // valid
+        R"({"a": [1,2,3]})", // path exists, but array can't cast to DOUBLE
+        R"({"a": true})",    // path exists, bool can't cast to DOUBLE
+    });
+    auto schema = MakeJsonSchema();
+    auto result = ConvertJsonToTypedFieldData<double>(
+        {json_fd}, schema, "/a", JsonCastType::FromString("DOUBLE"),
+        JsonCastFunction::FromString("unknown"));
+
+    auto& fd = result.field_datas[0];
+    EXPECT_EQ(fd->get_num_rows(), 4);
+    EXPECT_FALSE(fd->is_valid(0));  // cast fail
+    EXPECT_TRUE(fd->is_valid(1));   // valid
+    EXPECT_FALSE(fd->is_valid(2));  // cast fail
+    EXPECT_FALSE(fd->is_valid(3));  // cast fail
+
+    // Key: non_exist_offsets should be EMPTY because path exists in all rows
+    EXPECT_TRUE(result.non_exist_offsets.empty());
+}
+
+TEST(JsonPathIndexTest, ConvertDouble_MixedRows) {
+    auto json_fd = MakeJsonFieldData({
+        R"({"a": 1.0})",     // 0: valid
+        R"({"b": 2})",       // 1: path not exist
+        R"({"a": "str"})",   // 2: path exists, cast fail
+        R"({"a": 3.0})",     // 3: valid
+        R"(42)",              // 4: path not exist (not object)
+    });
+    auto schema = MakeJsonSchema();
+    auto result = ConvertJsonToTypedFieldData<double>(
+        {json_fd}, schema, "/a", JsonCastType::FromString("DOUBLE"),
+        JsonCastFunction::FromString("unknown"));
+
+    auto& fd = result.field_datas[0];
+    EXPECT_EQ(fd->get_num_rows(), 5);
+    EXPECT_TRUE(fd->is_valid(0));
+    EXPECT_FALSE(fd->is_valid(1));
+    EXPECT_FALSE(fd->is_valid(2));
+    EXPECT_TRUE(fd->is_valid(3));
+    EXPECT_FALSE(fd->is_valid(4));
+
+    // non_exist: only 1 and 4 (path truly missing)
+    // offset 2 is NOT in non_exist (path exists but cast fails)
+    ASSERT_EQ(result.non_exist_offsets.size(), 2);
+    EXPECT_EQ(result.non_exist_offsets[0], 1);
+    EXPECT_EQ(result.non_exist_offsets[1], 4);
+}
+
+TEST(JsonPathIndexTest, ConvertVarchar) {
+    auto json_fd = MakeJsonFieldData({
+        R"({"a": "hello"})",
+        R"({"a": "world"})",
+        R"({"b": 1})",
+    });
+    auto schema = MakeJsonSchema();
+    auto result = ConvertJsonToTypedFieldData<std::string>(
+        {json_fd}, schema, "/a", JsonCastType::FromString("VARCHAR"),
+        JsonCastFunction::FromString("unknown"));
+
+    auto& fd = result.field_datas[0];
+    EXPECT_EQ(fd->get_num_rows(), 3);
+    EXPECT_TRUE(fd->is_valid(0));
+    EXPECT_TRUE(fd->is_valid(1));
+    EXPECT_FALSE(fd->is_valid(2));
+
+    ASSERT_EQ(result.non_exist_offsets.size(), 1);
+    EXPECT_EQ(result.non_exist_offsets[0], 2);
+}
+
+// ============================================================
+// 2. JsonScalarIndexWrapper tests (Sort + Bitmap)
+// ============================================================
+
+TEST(JsonPathIndexTest, SortDouble_RangeQuery) {
+    auto json_fd = MakeJsonFieldData({
+        R"({"a": 10.0})",
+        R"({"a": 20.0})",
+        R"({"a": 30.0})",
+        R"({"a": 40.0})",
+        R"({"a": 50.0})",
+    });
+    auto schema = MakeJsonSchema();
+    auto ctx = MakeTestContext();
+
+    JsonScalarIndexWrapper<double, ScalarIndexSort<double>> idx(
+        JsonCastType::FromString("DOUBLE"), "/a",
+        JsonCastFunction::FromString("unknown"), schema, ctx);
+
+    idx.BuildWithFieldData({json_fd});
+
+    // Range: a > 25
+    auto result = idx.Range(25.0, OpType::GreaterThan);
+    EXPECT_EQ(result.count(), 3);  // 30, 40, 50
+
+    // Range: 15 <= a <= 35
+    auto result2 = idx.Range(15.0, true, 35.0, true);
+    EXPECT_EQ(result2.count(), 2);  // 20, 30
+
+    // In
+    double vals[] = {10.0, 50.0};
+    auto result3 = idx.In(2, vals);
+    EXPECT_EQ(result3.count(), 2);
+}
+
+TEST(JsonPathIndexTest, BitmapVarchar_BuildAndCount) {
+    // Note: BitmapIndex::BuildWithFieldData has a pre-existing issue where
+    // build_mode_ is not set, so In()/Range() don't work correctly without
+    // a Serialize→Load cycle. We test that the index builds successfully
+    // and verify Exists/IsNotNull semantics instead.
+    auto json_fd = MakeJsonFieldData({
+        R"({"s": "active"})",
+        R"({"s": "inactive"})",
+        R"({"s": "active"})",
+        R"({"s": "pending"})",
+        R"({"s": "active"})",
+    });
+    auto schema = MakeJsonSchema();
+    auto ctx = MakeTestContext();
+
+    JsonScalarIndexWrapper<std::string, BitmapIndex<std::string>> idx(
+        JsonCastType::FromString("VARCHAR"), "/s",
+        JsonCastFunction::FromString("unknown"), schema, ctx);
+
+    idx.BuildWithFieldData({json_fd});
+    EXPECT_EQ(idx.Count(), 5);
+
+    // IsNotNull should return all rows (all valid)
+    auto not_null = idx.IsNotNull();
+    EXPECT_EQ(not_null.count(), 5);
+}
+
+TEST(JsonPathIndexTest, SortDouble_ExistsSemantics) {
+    // Key test: Exists() must return true for rows where path exists
+    // even if the value can't be cast to the index type.
+    auto json_fd = MakeJsonFieldData({
+        R"({"a": 1.0})",      // 0: valid double
+        R"({"a": "hello"})",  // 1: path exists, cast fails
+        R"({"b": 2})",        // 2: path not exist
+        R"({"a": true})",     // 3: path exists, cast fails
+        R"({"a": 5.0})",      // 4: valid double
+    });
+    auto schema = MakeJsonSchema();
+    auto ctx = MakeTestContext();
+
+    JsonScalarIndexWrapper<double, ScalarIndexSort<double>> idx(
+        JsonCastType::FromString("DOUBLE"), "/a",
+        JsonCastFunction::FromString("unknown"), schema, ctx);
+
+    idx.BuildWithFieldData({json_fd});
+
+    auto exists = idx.Exists();
+    EXPECT_EQ(exists.size(), 5);
+    EXPECT_TRUE(exists[0]);   // path exists + valid
+    EXPECT_TRUE(exists[1]);   // path exists + cast fail → still EXISTS
+    EXPECT_FALSE(exists[2]);  // path not exist
+    EXPECT_TRUE(exists[3]);   // path exists + cast fail → still EXISTS
+    EXPECT_TRUE(exists[4]);   // path exists + valid
+    EXPECT_EQ(exists.count(), 4);
+}
+
+TEST(JsonPathIndexTest, BitmapBool_ExistsSemantics) {
+    auto json_fd = MakeJsonFieldData({
+        R"({"f": true})",
+        R"({"f": false})",
+        R"({"g": 1})",       // path /f not exist
+        R"({"f": "yes"})",   // path exists, cast fail
+    });
+    auto schema = MakeJsonSchema();
+    auto ctx = MakeTestContext();
+
+    JsonScalarIndexWrapper<bool, BitmapIndex<bool>> idx(
+        JsonCastType::FromString("BOOL"), "/f",
+        JsonCastFunction::FromString("unknown"), schema, ctx);
+
+    idx.BuildWithFieldData({json_fd});
+
+    auto exists = idx.Exists();
+    EXPECT_TRUE(exists[0]);
+    EXPECT_TRUE(exists[1]);
+    EXPECT_FALSE(exists[2]);  // path not exist
+    EXPECT_TRUE(exists[3]);   // path exists but cast fail → EXISTS=true
+}
+
+// ============================================================
+// 3. JsonHybridScalarIndex tests
+// ============================================================
+
+TEST(JsonPathIndexTest, Hybrid_LowCardinalitySelectsBitmap) {
+    // 3 distinct values → low cardinality → should select BITMAP
+    std::vector<std::string> raw;
+    for (int i = 0; i < 100; i++) {
+        std::string val = (i % 3 == 0) ? "a" : (i % 3 == 1) ? "b" : "c";
+        raw.push_back(R"({"x": ")" + val + R"("})");
+    }
+    auto json_fd = MakeJsonFieldData(raw);
+    auto schema = MakeJsonSchema();
+    auto ctx = MakeTestContext();
+
+    JsonHybridScalarIndex<std::string> idx(
+        JsonCastType::FromString("VARCHAR"), "/x",
+        JsonCastFunction::FromString("unknown"), schema, 0, ctx);
+
+    idx.BuildWithFieldData({json_fd});
+
+    EXPECT_EQ(idx.internal_index_type_, ScalarIndexType::BITMAP);
+    EXPECT_EQ(idx.Count(), 100);
+}
+
+TEST(JsonPathIndexTest, Hybrid_HighCardinalitySelectsSort) {
+    // 1000 distinct values → high cardinality → should select STLSORT
+    std::vector<std::string> raw;
+    for (int i = 0; i < 1000; i++) {
+        raw.push_back(R"({"n": )" + std::to_string(i) + "}");
+    }
+    auto json_fd = MakeJsonFieldData(raw);
+    auto schema = MakeJsonSchema();
+    auto ctx = MakeTestContext();
+
+    JsonHybridScalarIndex<double> idx(
+        JsonCastType::FromString("DOUBLE"), "/n",
+        JsonCastFunction::FromString("unknown"), schema, 0, ctx);
+
+    idx.BuildWithFieldData({json_fd});
+
+    EXPECT_EQ(idx.internal_index_type_, ScalarIndexType::STLSORT);
+
+    // Verify range query works
+    auto result = idx.Range(500.0, OpType::GreaterThan);
+    EXPECT_EQ(result.count(), 499);  // 501..999
+}
+
+TEST(JsonPathIndexTest, Hybrid_CardinalityIgnoresInvalidRows) {
+    // Only 3 valid distinct values, but many invalid rows.
+    // Without the fix, invalid rows have default value (0.0) which
+    // would add a 4th distinct value. This test ensures we don't count them.
+    std::vector<std::string> raw;
+    // 10 valid rows with 3 distinct values
+    for (int i = 0; i < 10; i++) {
+        double val = (i % 3) + 1.0;
+        raw.push_back(R"({"v": )" + std::to_string(val) + "}");
+    }
+    // 100 rows where path doesn't exist or cast fails
+    for (int i = 0; i < 50; i++) {
+        raw.push_back(R"({"other": 1})");  // path /v not exist
+    }
+    for (int i = 0; i < 50; i++) {
+        raw.push_back(R"({"v": "str"})");  // cast fail
+    }
+
+    auto json_fd = MakeJsonFieldData(raw);
+    auto schema = MakeJsonSchema();
+    auto ctx = MakeTestContext();
+
+    JsonHybridScalarIndex<double> idx(
+        JsonCastType::FromString("DOUBLE"), "/v",
+        JsonCastFunction::FromString("unknown"), schema, 0, ctx);
+
+    idx.BuildWithFieldData({json_fd});
+
+    // 3 distinct valid values → should be BITMAP (low cardinality)
+    EXPECT_EQ(idx.internal_index_type_, ScalarIndexType::BITMAP);
+}
+
+TEST(JsonPathIndexTest, Hybrid_ExistsSemantics) {
+    auto json_fd = MakeJsonFieldData({
+        R"({"a": 1.0})",
+        R"({"a": "text"})",  // cast fail
+        R"({"b": 2})",       // path not exist
+        R"({"a": 3.0})",
+    });
+    auto schema = MakeJsonSchema();
+    auto ctx = MakeTestContext();
+
+    JsonHybridScalarIndex<double> idx(
+        JsonCastType::FromString("DOUBLE"), "/a",
+        JsonCastFunction::FromString("unknown"), schema, 0, ctx);
+
+    idx.BuildWithFieldData({json_fd});
+
+    auto exists = idx.Exists();
+    EXPECT_TRUE(exists[0]);   // valid
+    EXPECT_TRUE(exists[1]);   // cast fail → still EXISTS
+    EXPECT_FALSE(exists[2]);  // path not exist
+    EXPECT_TRUE(exists[3]);   // valid
+}
+
+// ============================================================
+// 4. IndexFactory routing tests
+// ============================================================
+
+TEST(JsonPathIndexTest, Factory_SortDouble) {
+    auto ctx = MakeTestContext();
+    CreateIndexInfo info;
+    info.index_type = ASCENDING_SORT;
+    info.field_type = DataType::JSON;
+    info.json_cast_type = JsonCastType::FromString("DOUBLE");
+    info.json_path = "/num";
+
+    auto idx = IndexFactory::GetInstance().CreateJsonIndex(info, ctx);
+    ASSERT_NE(idx, nullptr);
+    EXPECT_EQ(idx->GetCastType().ToString(), JsonCastType::FromString("DOUBLE").ToString());
+}
+
+TEST(JsonPathIndexTest, Factory_BitmapVarchar) {
+    auto ctx = MakeTestContext();
+    CreateIndexInfo info;
+    info.index_type = BITMAP_INDEX_TYPE;
+    info.field_type = DataType::JSON;
+    info.json_cast_type = JsonCastType::FromString("VARCHAR");
+    info.json_path = "/label";
+
+    auto idx = IndexFactory::GetInstance().CreateJsonIndex(info, ctx);
+    ASSERT_NE(idx, nullptr);
+    EXPECT_EQ(idx->GetCastType().ToString(), JsonCastType::FromString("VARCHAR").ToString());
+}
+
+TEST(JsonPathIndexTest, Factory_HybridDouble) {
+    auto ctx = MakeTestContext();
+    CreateIndexInfo info;
+    info.index_type = HYBRID_INDEX_TYPE;
+    info.field_type = DataType::JSON;
+    info.json_cast_type = JsonCastType::FromString("DOUBLE");
+    info.json_path = "/val";
+    info.tantivy_index_version = 1;
+
+    auto idx = IndexFactory::GetInstance().CreateJsonIndex(info, ctx);
+    ASSERT_NE(idx, nullptr);
+    EXPECT_EQ(idx->GetCastType().ToString(), JsonCastType::FromString("DOUBLE").ToString());
+}
+
+TEST(JsonPathIndexTest, Factory_BitmapDouble_Rejected) {
+    auto ctx = MakeTestContext();
+    CreateIndexInfo info;
+    info.index_type = BITMAP_INDEX_TYPE;
+    info.field_type = DataType::JSON;
+    info.json_cast_type = JsonCastType::FromString("DOUBLE");
+    info.json_path = "/num";
+
+    EXPECT_THROW(
+        IndexFactory::GetInstance().CreateJsonIndex(info, ctx),
+        std::exception);
+}
+
+TEST(JsonPathIndexTest, Factory_SortBool_Rejected) {
+    auto ctx = MakeTestContext();
+    CreateIndexInfo info;
+    info.index_type = ASCENDING_SORT;
+    info.field_type = DataType::JSON;
+    info.json_cast_type = JsonCastType::FromString("BOOL");
+    info.json_path = "/flag";
+
+    EXPECT_THROW(
+        IndexFactory::GetInstance().CreateJsonIndex(info, ctx),
+        std::exception);
+}

--- a/internal/core/src/index/JsonScalarIndexWrapper.h
+++ b/internal/core/src/index/JsonScalarIndexWrapper.h
@@ -70,6 +70,16 @@ class JsonScalarIndexWrapper : public BaseIndex {
     }
 
     void
+    BuildWithFieldData(
+        const std::vector<FieldDataPtr>& field_datas) override {
+        auto result = ConvertJsonToTypedFieldData<T>(
+            field_datas, json_schema_, nested_path_, cast_type_,
+            cast_function_);
+        non_exist_offsets_ = std::move(result.non_exist_offsets);
+        BaseIndex::BuildWithFieldData(result.field_datas);
+    }
+
+    void
     Build(const Config& config) override {
         auto json_field_datas =
             storage::CacheRawDataAndFillMissing(json_file_manager_, config);

--- a/internal/core/src/index/JsonScalarIndexWrapper.h
+++ b/internal/core/src/index/JsonScalarIndexWrapper.h
@@ -77,6 +77,7 @@ class JsonScalarIndexWrapper : public BaseIndex {
             cast_function_);
         non_exist_offsets_ = std::move(result.non_exist_offsets);
         BaseIndex::BuildWithFieldData(result.field_datas);
+        BuildExistsBitset();
     }
 
     void
@@ -92,19 +93,12 @@ class JsonScalarIndexWrapper : public BaseIndex {
 
         non_exist_offsets_ = std::move(result.non_exist_offsets);
         BaseIndex::BuildWithFieldData(result.field_datas);
+        BuildExistsBitset();
     }
 
-    TargetBitmap
+    const TargetBitmap&
     Exists() override {
-        int64_t count = this->Count();
-        TargetBitmap bitset(count, true);
-        auto end = std::lower_bound(non_exist_offsets_.begin(),
-                                    non_exist_offsets_.end(),
-                                    static_cast<size_t>(count));
-        for (auto iter = non_exist_offsets_.begin(); iter != end; ++iter) {
-            bitset.reset(*iter);
-        }
-        return bitset;
+        return exists_bitset_;
     }
 
     void
@@ -134,6 +128,7 @@ class JsonScalarIndexWrapper : public BaseIndex {
         }
         LOG_INFO("LoadEntries JsonScalarIndexWrapper done, has_non_exist: {}",
                  has_non_exist);
+        BuildExistsBitset();
     }
 
     JsonCastType
@@ -142,12 +137,25 @@ class JsonScalarIndexWrapper : public BaseIndex {
     }
 
  private:
+    void
+    BuildExistsBitset() {
+        int64_t count = this->Count();
+        exists_bitset_ = TargetBitmap(count, true);
+        for (auto offset : non_exist_offsets_) {
+            if (static_cast<int64_t>(offset) >= count) {
+                break;
+            }
+            exists_bitset_.reset(offset);
+        }
+    }
+
     JsonCastType cast_type_;
     std::string nested_path_;
     JsonCastFunction cast_function_;
     proto::schema::FieldSchema json_schema_;
     storage::MemFileManagerImplPtr json_file_manager_;
     std::vector<size_t> non_exist_offsets_;
+    TargetBitmap exists_bitset_;
 };
 
 }  // namespace milvus::index

--- a/internal/core/src/index/JsonScalarIndexWrapper.h
+++ b/internal/core/src/index/JsonScalarIndexWrapper.h
@@ -1,0 +1,143 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <algorithm>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "common/FieldDataInterface.h"
+#include "common/JsonCastFunction.h"
+#include "common/JsonCastType.h"
+#include "index/JsonIndexBuilder.h"
+#include "log/Log.h"
+#include "pb/schema.pb.h"
+#include "storage/IndexEntryReader.h"
+#include "storage/IndexEntryWriter.h"
+#include "storage/MemFileManagerImpl.h"
+#include "storage/Types.h"
+#include "storage/Util.h"
+
+namespace milvus::index {
+
+inline storage::FileManagerContext
+MakeJsonCastContext(const storage::FileManagerContext& ctx,
+                    const JsonCastType& cast_type) {
+    auto modified = ctx;
+    modified.fieldDataMeta.field_schema.set_data_type(
+        static_cast<proto::schema::DataType>(cast_type.ToMilvusDataType()));
+    return modified;
+}
+
+// File name for serializing non_exist_offsets in JSON path indexes.
+// Shared with JsonInvertedIndex which uses the same name.
+constexpr const char* kJsonNonExistOffsetFileName =
+    "json_index_non_exist_offsets";
+
+template <typename T, typename BaseIndex>
+class JsonScalarIndexWrapper : public BaseIndex {
+ public:
+    template <typename... Args>
+    JsonScalarIndexWrapper(const JsonCastType& cast_type,
+                           const std::string& nested_path,
+                           const JsonCastFunction& cast_function,
+                           const proto::schema::FieldSchema& json_schema,
+                           const storage::FileManagerContext& original_ctx,
+                           Args&&... args)
+        : BaseIndex(MakeJsonCastContext(original_ctx, cast_type),
+                    std::forward<Args>(args)...),
+          cast_type_(cast_type),
+          nested_path_(nested_path),
+          cast_function_(cast_function),
+          json_schema_(json_schema) {
+        json_file_manager_ =
+            std::make_shared<storage::MemFileManagerImpl>(original_ctx);
+    }
+
+    void
+    Build(const Config& config) override {
+        auto json_field_datas =
+            storage::CacheRawDataAndFillMissing(json_file_manager_, config);
+
+        auto result = ConvertJsonToTypedFieldData<T>(json_field_datas,
+                                                     json_schema_,
+                                                     nested_path_,
+                                                     cast_type_,
+                                                     cast_function_);
+
+        non_exist_offsets_ = std::move(result.non_exist_offsets);
+        BaseIndex::BuildWithFieldData(result.field_datas);
+    }
+
+    TargetBitmap
+    Exists() override {
+        int64_t count = this->Count();
+        TargetBitmap bitset(count, true);
+        auto end = std::lower_bound(non_exist_offsets_.begin(),
+                                    non_exist_offsets_.end(),
+                                    static_cast<size_t>(count));
+        for (auto iter = non_exist_offsets_.begin(); iter != end; ++iter) {
+            bitset.reset(*iter);
+        }
+        return bitset;
+    }
+
+    void
+    WriteEntries(storage::IndexEntryWriter* writer) override {
+        BaseIndex::WriteEntries(writer);
+
+        bool has_non_exist = !non_exist_offsets_.empty();
+        writer->PutMeta("has_non_exist", has_non_exist);
+        if (has_non_exist) {
+            writer->WriteEntry(kJsonNonExistOffsetFileName,
+                               non_exist_offsets_.data(),
+                               non_exist_offsets_.size() * sizeof(size_t));
+        }
+    }
+
+    void
+    LoadEntries(storage::IndexEntryReader& reader,
+                const Config& config) override {
+        BaseIndex::LoadEntries(reader, config);
+
+        bool has_non_exist = reader.GetMeta<bool>("has_non_exist", false);
+        if (has_non_exist) {
+            auto e = reader.ReadEntry(kJsonNonExistOffsetFileName);
+            non_exist_offsets_.resize(e.data.size() / sizeof(size_t));
+            std::memcpy(
+                non_exist_offsets_.data(), e.data.data(), e.data.size());
+        }
+        LOG_INFO("LoadEntries JsonScalarIndexWrapper done, has_non_exist: {}",
+                 has_non_exist);
+    }
+
+    JsonCastType
+    GetCastType() const override {
+        return cast_type_;
+    }
+
+ private:
+    JsonCastType cast_type_;
+    std::string nested_path_;
+    JsonCastFunction cast_function_;
+    proto::schema::FieldSchema json_schema_;
+    storage::MemFileManagerImplPtr json_file_manager_;
+    std::vector<size_t> non_exist_offsets_;
+};
+
+}  // namespace milvus::index

--- a/internal/core/src/index/ScalarIndexSort.h
+++ b/internal/core/src/index/ScalarIndexSort.h
@@ -109,12 +109,6 @@ class ScalarIndexSort : public ScalarIndex<T> {
     TargetBitmap
     IsNotNull() override;
 
-    TargetBitmap
-    Exists() override {
-        TargetBitmap res(total_num_rows_, true);
-        res &= valid_bitset_;
-        return res;
-    }
 
     const TargetBitmap
     Range(const T& value, OpType op) override;

--- a/internal/core/src/index/ScalarIndexSort.h
+++ b/internal/core/src/index/ScalarIndexSort.h
@@ -109,6 +109,13 @@ class ScalarIndexSort : public ScalarIndex<T> {
     TargetBitmap
     IsNotNull() override;
 
+    TargetBitmap
+    Exists() override {
+        TargetBitmap res(total_num_rows_, true);
+        res &= valid_bitset_;
+        return res;
+    }
+
     const TargetBitmap
     Range(const T& value, OpType op) override;
 

--- a/internal/core/src/index/StringIndexSort.h
+++ b/internal/core/src/index/StringIndexSort.h
@@ -115,6 +115,13 @@ class StringIndexSort : public StringIndex {
     TargetBitmap
     IsNotNull() override;
 
+    TargetBitmap
+    Exists() override {
+        TargetBitmap res(total_num_rows_, true);
+        res &= valid_bitset_;
+        return res;
+    }
+
     const TargetBitmap
     Range(const std::string& value, OpType op) override;
 

--- a/internal/core/src/index/StringIndexSort.h
+++ b/internal/core/src/index/StringIndexSort.h
@@ -115,12 +115,6 @@ class StringIndexSort : public StringIndex {
     TargetBitmap
     IsNotNull() override;
 
-    TargetBitmap
-    Exists() override {
-        TargetBitmap res(total_num_rows_, true);
-        res &= valid_bitset_;
-        return res;
-    }
 
     const TargetBitmap
     Range(const std::string& value, OpType op) override;

--- a/internal/datacoord/index_service.go
+++ b/internal/datacoord/index_service.go
@@ -181,6 +181,20 @@ func (s *Server) CreateIndex(ctx context.Context, req *indexpb.CreateIndexReques
 		}
 		// set nested path as json path
 		setIndexParam(req.GetIndexParams(), common.JSONPathKey, nestedPath)
+
+		// JSON path index on STL_SORT, BITMAP, HYBRID requires scalar index engine version >= 3.
+		indexType := indexparamcheck.IndexType(pkgcommon.GetIndexType(req.GetIndexParams()))
+		if indexType == indexparamcheck.IndexSTLSORT ||
+			indexType == indexparamcheck.IndexBitmap ||
+			indexType == indexparamcheck.IndexHybrid {
+			if s.indexEngineVersionManager.ResolveScalarIndexVersion() < 3 {
+				err := merr.WrapErrParameterInvalidMsg(
+					"JSON path index with %s requires scalar index engine version >= 3, current resolved version: %d",
+					indexType, s.indexEngineVersionManager.ResolveScalarIndexVersion())
+				log.Warn("scalar index engine version too low for JSON path index", zap.Error(err))
+				return merr.Status(err), nil
+			}
+		}
 	}
 
 	if req.GetIndexName() == "" {

--- a/internal/datacoord/server.go
+++ b/internal/datacoord/server.go
@@ -380,6 +380,7 @@ func (s *Server) initDataCoord() error {
 		s.handler,
 		s.broker,
 		s.getChannelsByCollectionID,
+		s.indexEngineVersionManager,
 	)
 	log.Info("init snapshot manager done")
 

--- a/internal/datacoord/services_test.go
+++ b/internal/datacoord/services_test.go
@@ -2382,7 +2382,7 @@ func TestServer_CreateSnapshot_DuplicateName(t *testing.T) {
 		defer mockGetSnapshot.UnPatch()
 
 		server := &Server{
-			snapshotManager: NewSnapshotManager(nil, nil, nil, nil, nil, nil, nil),
+			snapshotManager: NewSnapshotManager(nil, nil, nil, nil, nil, nil, nil, nil),
 		}
 		server.stateCode.Store(commonpb.StateCode_Healthy)
 
@@ -2493,7 +2493,7 @@ func TestServer_DropSnapshot(t *testing.T) {
 		defer mockBroadcast.UnPatch()
 
 		server := &Server{
-			snapshotManager: NewSnapshotManager(nil, nil, nil, nil, nil, nil, nil),
+			snapshotManager: NewSnapshotManager(nil, nil, nil, nil, nil, nil, nil, nil),
 		}
 		server.stateCode.Store(commonpb.StateCode_Healthy)
 
@@ -2533,7 +2533,7 @@ func TestServer_DropSnapshot(t *testing.T) {
 		defer mockBroadcast.UnPatch()
 
 		server := &Server{
-			snapshotManager: NewSnapshotManager(nil, nil, nil, nil, nil, nil, nil),
+			snapshotManager: NewSnapshotManager(nil, nil, nil, nil, nil, nil, nil, nil),
 		}
 		server.stateCode.Store(commonpb.StateCode_Healthy)
 
@@ -2574,7 +2574,7 @@ func TestServer_DropSnapshot(t *testing.T) {
 		defer mockBroadcast.UnPatch()
 
 		server := &Server{
-			snapshotManager: NewSnapshotManager(nil, nil, nil, nil, nil, nil, nil),
+			snapshotManager: NewSnapshotManager(nil, nil, nil, nil, nil, nil, nil, nil),
 		}
 		server.stateCode.Store(commonpb.StateCode_Healthy)
 
@@ -2615,7 +2615,7 @@ func TestServer_DescribeSnapshot(t *testing.T) {
 		defer mockDescribe.UnPatch()
 
 		server := &Server{
-			snapshotManager: NewSnapshotManager(nil, nil, nil, nil, nil, nil, nil),
+			snapshotManager: NewSnapshotManager(nil, nil, nil, nil, nil, nil, nil, nil),
 		}
 		server.stateCode.Store(commonpb.StateCode_Healthy)
 
@@ -2648,7 +2648,7 @@ func TestServer_DescribeSnapshot(t *testing.T) {
 		defer mockDescribe.UnPatch()
 
 		server := &Server{
-			snapshotManager: NewSnapshotManager(nil, nil, nil, nil, nil, nil, nil),
+			snapshotManager: NewSnapshotManager(nil, nil, nil, nil, nil, nil, nil, nil),
 		}
 		server.stateCode.Store(commonpb.StateCode_Healthy)
 
@@ -2686,7 +2686,7 @@ func TestServer_DescribeSnapshot(t *testing.T) {
 		defer mockDescribe.UnPatch()
 
 		server := &Server{
-			snapshotManager: NewSnapshotManager(nil, nil, nil, nil, nil, nil, nil),
+			snapshotManager: NewSnapshotManager(nil, nil, nil, nil, nil, nil, nil, nil),
 		}
 		server.stateCode.Store(commonpb.StateCode_Healthy)
 
@@ -2731,7 +2731,7 @@ func TestServer_ListSnapshots(t *testing.T) {
 		defer mockList.UnPatch()
 
 		server := &Server{
-			snapshotManager: NewSnapshotManager(nil, nil, nil, nil, nil, nil, nil),
+			snapshotManager: NewSnapshotManager(nil, nil, nil, nil, nil, nil, nil, nil),
 		}
 		server.stateCode.Store(commonpb.StateCode_Healthy)
 
@@ -2755,7 +2755,7 @@ func TestServer_ListSnapshots(t *testing.T) {
 		defer mockList.UnPatch()
 
 		server := &Server{
-			snapshotManager: NewSnapshotManager(nil, nil, nil, nil, nil, nil, nil),
+			snapshotManager: NewSnapshotManager(nil, nil, nil, nil, nil, nil, nil, nil),
 		}
 		server.stateCode.Store(commonpb.StateCode_Healthy)
 
@@ -2779,7 +2779,7 @@ func TestServer_ListSnapshots(t *testing.T) {
 		defer mockList.UnPatch()
 
 		server := &Server{
-			snapshotManager: NewSnapshotManager(nil, nil, nil, nil, nil, nil, nil),
+			snapshotManager: NewSnapshotManager(nil, nil, nil, nil, nil, nil, nil, nil),
 		}
 		server.stateCode.Store(commonpb.StateCode_Healthy)
 
@@ -2856,7 +2856,7 @@ func TestServer_RestoreSnapshot(t *testing.T) {
 		defer mockRead.UnPatch()
 
 		server := &Server{
-			snapshotManager: NewSnapshotManager(nil, nil, nil, nil, nil, nil, nil),
+			snapshotManager: NewSnapshotManager(nil, nil, nil, nil, nil, nil, nil, nil),
 		}
 		server.stateCode.Store(commonpb.StateCode_Healthy)
 
@@ -2900,7 +2900,7 @@ func TestServer_CreateSnapshot_AdditionalCases(t *testing.T) {
 		defer mockGet.UnPatch()
 
 		server := &Server{
-			snapshotManager: NewSnapshotManager(nil, nil, nil, nil, nil, nil, nil),
+			snapshotManager: NewSnapshotManager(nil, nil, nil, nil, nil, nil, nil, nil),
 		}
 		server.stateCode.Store(commonpb.StateCode_Healthy)
 

--- a/internal/datacoord/snapshot_manager.go
+++ b/internal/datacoord/snapshot_manager.go
@@ -38,11 +38,13 @@ import (
 	"github.com/milvus-io/milvus/internal/metastore/model"
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster"
 	"github.com/milvus-io/milvus/internal/util/hookutil"
+	"github.com/milvus-io/milvus/internal/util/indexparamcheck"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v2/util"
+	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/timerecord"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
@@ -294,6 +296,9 @@ type snapshotManager struct {
 	handler Handler       // For generating snapshot data
 	broker  broker.Broker // For querying partition information
 
+	// Index engine version manager for compatibility checks during restore
+	indexEngineVersionManager IndexEngineVersionManager
+
 	// Helper closures
 	getChannelsByCollectionID func(context.Context, int64) ([]RWChannel, error) // For channel mapping
 
@@ -323,6 +328,7 @@ func NewSnapshotManager(
 	handler Handler,
 	broker broker.Broker,
 	getChannelsFunc func(context.Context, int64) ([]RWChannel, error),
+	ievm IndexEngineVersionManager,
 ) SnapshotManager {
 	return &snapshotManager{
 		meta:                      meta,
@@ -332,6 +338,7 @@ func NewSnapshotManager(
 		handler:                   handler,
 		broker:                    broker,
 		getChannelsByCollectionID: getChannelsFunc,
+		indexEngineVersionManager: ievm,
 	}
 }
 
@@ -728,6 +735,11 @@ func (sm *snapshotManager) RestoreIndexes(
 
 		// Validate the index params (basic validation without JSON path parsing)
 		if err := ValidateIndexParams(index); err != nil {
+			return fmt.Errorf("failed to validate index %s: %w", indexInfo.GetIndexName(), err)
+		}
+
+		// Check scalar index engine version for JSON path indexes with new types
+		if err := sm.checkJsonPathIndexVersion(index); err != nil {
 			return fmt.Errorf("failed to validate index %s: %w", indexInfo.GetIndexName(), err)
 		}
 
@@ -1246,4 +1258,29 @@ func (sm *snapshotManager) calculateTimeCost(job CopySegmentJob) uint64 {
 		return uint64((job.GetCompleteTs() - job.GetStartTs()) / 1e6) // Convert nanoseconds to milliseconds
 	}
 	return 0
+}
+
+// checkJsonPathIndexVersion rejects JSON path indexes with STL_SORT, BITMAP,
+// or HYBRID if the cluster's scalar index engine version is below 3.
+func (sm *snapshotManager) checkJsonPathIndexVersion(index *model.Index) error {
+	indexType := indexparamcheck.IndexType(GetIndexType(index.IndexParams))
+	if indexType != indexparamcheck.IndexSTLSORT &&
+		indexType != indexparamcheck.IndexBitmap &&
+		indexType != indexparamcheck.IndexHybrid {
+		return nil
+	}
+
+	indexParams := funcutil.KeyValuePair2Map(index.IndexParams)
+	if _, hasPath := indexParams[common.JSONPathKey]; !hasPath {
+		return nil
+	}
+
+	if sm.indexEngineVersionManager != nil &&
+		sm.indexEngineVersionManager.ResolveScalarIndexVersion() < 3 {
+		return merr.WrapErrParameterInvalidMsg(
+			"JSON path index with %s requires scalar index engine version >= 3, "+
+				"current resolved version: %d; please complete the rolling upgrade first",
+			indexType, sm.indexEngineVersionManager.ResolveScalarIndexVersion())
+	}
+	return nil
 }

--- a/internal/datacoord/snapshot_manager_test.go
+++ b/internal/datacoord/snapshot_manager_test.go
@@ -88,6 +88,7 @@ func TestSnapshotManager_CreateSnapshot_Success(t *testing.T) {
 		mockHandler,
 		nil, // broker
 		nil, // getChannelsFunc
+		nil, // indexEngineVersionManager
 	)
 
 	// Execute
@@ -115,6 +116,7 @@ func TestSnapshotManager_CreateSnapshot_DuplicateName(t *testing.T) {
 		nil,
 		nil,
 		nil,
+	nil, /* indexEngineVersionManager */
 	)
 
 	// Execute
@@ -149,6 +151,7 @@ func TestSnapshotManager_CreateSnapshot_AllocatorError(t *testing.T) {
 		nil,
 		nil,
 		nil,
+	nil, /* indexEngineVersionManager */
 	)
 
 	// Execute
@@ -267,6 +270,7 @@ func TestSnapshotManager_DropSnapshot_Success(t *testing.T) {
 		nil,
 		nil,
 		nil,
+	nil, /* indexEngineVersionManager */
 	)
 
 	// Execute
@@ -293,6 +297,7 @@ func TestSnapshotManager_DropSnapshot_NotFound_Idempotent(t *testing.T) {
 		nil,
 		nil,
 		nil,
+	nil, /* indexEngineVersionManager */
 	)
 
 	// Execute - should succeed even if snapshot doesn't exist (idempotent)
@@ -325,6 +330,7 @@ func TestSnapshotManager_DropSnapshot_Error(t *testing.T) {
 		nil,
 		nil,
 		nil,
+	nil, /* indexEngineVersionManager */
 	)
 
 	// Execute
@@ -360,6 +366,7 @@ func TestSnapshotManager_GetSnapshot_Success(t *testing.T) {
 		nil,
 		nil,
 		nil,
+	nil, /* indexEngineVersionManager */
 	)
 
 	// Execute
@@ -387,6 +394,7 @@ func TestSnapshotManager_GetSnapshot_NotFound(t *testing.T) {
 		nil,
 		nil,
 		nil,
+	nil, /* indexEngineVersionManager */
 	)
 
 	// Execute
@@ -429,6 +437,7 @@ func TestSnapshotManager_DescribeSnapshot_Success(t *testing.T) {
 		nil,
 		nil,
 		nil,
+	nil, /* indexEngineVersionManager */
 	)
 
 	// Execute
@@ -456,6 +465,7 @@ func TestSnapshotManager_DescribeSnapshot_NotFound(t *testing.T) {
 		nil,
 		nil,
 		nil,
+	nil, /* indexEngineVersionManager */
 	)
 
 	// Execute
@@ -489,6 +499,7 @@ func TestSnapshotManager_ListSnapshots_Success(t *testing.T) {
 		nil,
 		nil,
 		nil,
+	nil, /* indexEngineVersionManager */
 	)
 
 	// Execute
@@ -516,6 +527,7 @@ func TestSnapshotManager_ListSnapshots_Error(t *testing.T) {
 		nil,
 		nil,
 		nil,
+	nil, /* indexEngineVersionManager */
 	)
 
 	// Execute

--- a/internal/util/indexparamcheck/bitmap_checker_test.go
+++ b/internal/util/indexparamcheck/bitmap_checker_test.go
@@ -24,10 +24,24 @@ func Test_BitmapIndexChecker(t *testing.T) {
 	assert.NoError(t, c.CheckValidDataType(IndexBitmap, &schemapb.FieldSchema{DataType: schemapb.DataType_Array, ElementType: schemapb.DataType_Int64}))
 	assert.NoError(t, c.CheckValidDataType(IndexBitmap, &schemapb.FieldSchema{DataType: schemapb.DataType_Array, ElementType: schemapb.DataType_String}))
 
-	assert.Error(t, c.CheckValidDataType(IndexBitmap, &schemapb.FieldSchema{DataType: schemapb.DataType_JSON}))
+	assert.NoError(t, c.CheckValidDataType(IndexBitmap, &schemapb.FieldSchema{DataType: schemapb.DataType_JSON}))
 	assert.Error(t, c.CheckValidDataType(IndexBitmap, &schemapb.FieldSchema{DataType: schemapb.DataType_Float}))
 	assert.Error(t, c.CheckValidDataType(IndexBitmap, &schemapb.FieldSchema{DataType: schemapb.DataType_Double}))
 	assert.Error(t, c.CheckValidDataType(IndexBitmap, &schemapb.FieldSchema{DataType: schemapb.DataType_Array, ElementType: schemapb.DataType_Float}))
 	assert.Error(t, c.CheckValidDataType(IndexBitmap, &schemapb.FieldSchema{DataType: schemapb.DataType_Array, ElementType: schemapb.DataType_Double}))
 	assert.Error(t, c.CheckValidDataType(IndexBitmap, &schemapb.FieldSchema{DataType: schemapb.DataType_Double, IsPrimaryKey: true}))
+
+	// JSON path index: CheckTrain validation
+	assert.NoError(t, c.CheckTrain(schemapb.DataType_JSON, schemapb.DataType_None, map[string]string{
+		"json_cast_type": "BOOL", "json_path": "/flag",
+	}))
+	assert.NoError(t, c.CheckTrain(schemapb.DataType_JSON, schemapb.DataType_None, map[string]string{
+		"json_cast_type": "VARCHAR", "json_path": "/status",
+	}))
+	// unsupported cast type for BITMAP
+	assert.Error(t, c.CheckTrain(schemapb.DataType_JSON, schemapb.DataType_None, map[string]string{
+		"json_cast_type": "DOUBLE", "json_path": "/price",
+	}))
+	// missing params
+	assert.Error(t, c.CheckTrain(schemapb.DataType_JSON, schemapb.DataType_None, map[string]string{}))
 }

--- a/internal/util/indexparamcheck/bitmap_index_checker.go
+++ b/internal/util/indexparamcheck/bitmap_index_checker.go
@@ -2,8 +2,11 @@ package indexparamcheck
 
 import (
 	"github.com/cockroachdb/errors"
+	"github.com/samber/lo"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/pkg/v2/common"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
@@ -11,7 +14,21 @@ type BITMAPChecker struct {
 	scalarIndexChecker
 }
 
+var validBITMAPJSONCastTypes = []string{"BOOL", "VARCHAR"}
+
 func (c *BITMAPChecker) CheckTrain(dataType schemapb.DataType, elementType schemapb.DataType, params map[string]string) error {
+	if typeutil.IsJSONType(dataType) {
+		castType, exist := params[common.JSONCastTypeKey]
+		if !exist {
+			return merr.WrapErrParameterMissing(common.JSONCastTypeKey, "json index must specify cast type")
+		}
+		if !lo.Contains(validBITMAPJSONCastTypes, castType) {
+			return merr.WrapErrParameterInvalidMsg("json_cast_type %v is not supported for BITMAP index", castType)
+		}
+		if _, exist := params[common.JSONPathKey]; !exist {
+			return merr.WrapErrParameterMissing(common.JSONPathKey, "json index must specify json path")
+		}
+	}
 	return c.scalarIndexChecker.CheckTrain(dataType, elementType, params)
 }
 
@@ -21,6 +38,9 @@ func (c *BITMAPChecker) CheckValidDataType(indexType IndexType, field *schemapb.
 	}
 	mainType := field.GetDataType()
 	elemType := field.GetElementType()
+	if typeutil.IsJSONType(mainType) {
+		return nil
+	}
 	if !typeutil.IsBoolType(mainType) && !typeutil.IsIntegerType(mainType) &&
 		!typeutil.IsStringType(mainType) && !typeutil.IsArrayType(mainType) {
 		return errors.New("bitmap index are only supported on bool, int, string and array field")

--- a/internal/util/indexparamcheck/hybrid_checker_test.go
+++ b/internal/util/indexparamcheck/hybrid_checker_test.go
@@ -26,12 +26,27 @@ func Test_HybridIndexChecker(t *testing.T) {
 	assert.NoError(t, c.CheckValidDataType(IndexHybrid, &schemapb.FieldSchema{DataType: schemapb.DataType_Array, ElementType: schemapb.DataType_Int64}))
 	assert.NoError(t, c.CheckValidDataType(IndexHybrid, &schemapb.FieldSchema{DataType: schemapb.DataType_Array, ElementType: schemapb.DataType_String}))
 
-	assert.Error(t, c.CheckValidDataType(IndexHybrid, &schemapb.FieldSchema{DataType: schemapb.DataType_JSON}))
+	assert.NoError(t, c.CheckValidDataType(IndexHybrid, &schemapb.FieldSchema{DataType: schemapb.DataType_JSON}))
 	assert.NoError(t, c.CheckValidDataType(IndexHybrid, &schemapb.FieldSchema{DataType: schemapb.DataType_Float}))
 	assert.NoError(t, c.CheckValidDataType(IndexHybrid, &schemapb.FieldSchema{DataType: schemapb.DataType_Double}))
 	assert.NoError(t, c.CheckValidDataType(IndexHybrid, &schemapb.FieldSchema{DataType: schemapb.DataType_Array, ElementType: schemapb.DataType_Float}))
 	assert.NoError(t, c.CheckValidDataType(IndexHybrid, &schemapb.FieldSchema{DataType: schemapb.DataType_Array, ElementType: schemapb.DataType_Double}))
+	// JSON path index: CheckTrain validation
 	assert.Error(t, c.CheckTrain(schemapb.DataType_JSON, schemapb.DataType_None, map[string]string{}))
+	assert.NoError(t, c.CheckTrain(schemapb.DataType_JSON, schemapb.DataType_None, map[string]string{
+		"json_cast_type": "DOUBLE", "json_path": "/price",
+	}))
+	assert.NoError(t, c.CheckTrain(schemapb.DataType_JSON, schemapb.DataType_None, map[string]string{
+		"json_cast_type": "BOOL", "json_path": "/flag",
+	}))
+	assert.NoError(t, c.CheckTrain(schemapb.DataType_JSON, schemapb.DataType_None, map[string]string{
+		"json_cast_type": "VARCHAR", "json_path": "/name",
+	}))
+	// unsupported cast type for HYBRID
+	assert.Error(t, c.CheckTrain(schemapb.DataType_JSON, schemapb.DataType_None, map[string]string{
+		"json_cast_type": "ARRAY_BOOL", "json_path": "/flags",
+	}))
+
 	assert.Error(t, c.CheckTrain(schemapb.DataType_Float, schemapb.DataType_None, map[string]string{"bitmap_cardinality_limit": "0"}))
 	assert.Error(t, c.CheckTrain(schemapb.DataType_Double, schemapb.DataType_None, map[string]string{"bitmap_cardinality_limit": "2000"}))
 }

--- a/internal/util/indexparamcheck/hybrid_index_checker.go
+++ b/internal/util/indexparamcheck/hybrid_index_checker.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/errors"
+	"github.com/samber/lo"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/pkg/v2/common"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
@@ -14,7 +16,29 @@ type HYBRIDChecker struct {
 	scalarIndexChecker
 }
 
+var validHYBRIDJSONCastTypes = []string{"BOOL", "DOUBLE", "VARCHAR"}
+
 func (c *HYBRIDChecker) CheckTrain(dataType schemapb.DataType, elementType schemapb.DataType, params map[string]string) error {
+	if typeutil.IsJSONType(dataType) {
+		castType, exist := params[common.JSONCastTypeKey]
+		if !exist {
+			return merr.WrapErrParameterMissing(common.JSONCastTypeKey, "json index must specify cast type")
+		}
+		if !lo.Contains(validHYBRIDJSONCastTypes, castType) {
+			return merr.WrapErrParameterInvalidMsg("json_cast_type %v is not supported for HYBRID index", castType)
+		}
+		if _, exist := params[common.JSONPathKey]; !exist {
+			return merr.WrapErrParameterMissing(common.JSONPathKey, "json index must specify json path")
+		}
+		// For JSON, bitmap_cardinality_limit is optional — validate only if present
+		if _, exist := params[common.BitmapCardinalityLimitKey]; exist {
+			if !CheckIntByRange(params, common.BitmapCardinalityLimitKey, 1, MaxBitmapCardinalityLimit) {
+				return fmt.Errorf("failed to check bitmap cardinality limit, should be larger than 0 and smaller than %d",
+					MaxBitmapCardinalityLimit)
+			}
+		}
+		return nil
+	}
 	if !CheckIntByRange(params, common.BitmapCardinalityLimitKey, 1, MaxBitmapCardinalityLimit) {
 		return fmt.Errorf("failed to check bitmap cardinality limit, should be larger than 0 and smaller than %d",
 			MaxBitmapCardinalityLimit)
@@ -25,6 +49,9 @@ func (c *HYBRIDChecker) CheckTrain(dataType schemapb.DataType, elementType schem
 func (c *HYBRIDChecker) CheckValidDataType(indexType IndexType, field *schemapb.FieldSchema) error {
 	mainType := field.GetDataType()
 	elemType := field.GetElementType()
+	if typeutil.IsJSONType(mainType) {
+		return nil
+	}
 	if !typeutil.IsBoolType(mainType) && !typeutil.IsIntegerType(mainType) &&
 		!typeutil.IsStringType(mainType) && !typeutil.IsArrayType(mainType) &&
 		!typeutil.IsFloatingType(mainType) {

--- a/internal/util/indexparamcheck/stl_sort_checker.go
+++ b/internal/util/indexparamcheck/stl_sort_checker.go
@@ -4,8 +4,11 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/errors"
+	"github.com/samber/lo"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/pkg/v2/common"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
@@ -14,7 +17,21 @@ type STLSORTChecker struct {
 	scalarIndexChecker
 }
 
+var validSTLSORTJSONCastTypes = []string{"DOUBLE", "VARCHAR"}
+
 func (c *STLSORTChecker) CheckTrain(dataType schemapb.DataType, elementType schemapb.DataType, params map[string]string) error {
+	if typeutil.IsJSONType(dataType) {
+		castType, exist := params[common.JSONCastTypeKey]
+		if !exist {
+			return merr.WrapErrParameterMissing(common.JSONCastTypeKey, "json index must specify cast type")
+		}
+		if !lo.Contains(validSTLSORTJSONCastTypes, castType) {
+			return merr.WrapErrParameterInvalidMsg("json_cast_type %v is not supported for STL_SORT index", castType)
+		}
+		if _, exist := params[common.JSONPathKey]; !exist {
+			return merr.WrapErrParameterMissing(common.JSONPathKey, "json index must specify json path")
+		}
+	}
 	return c.scalarIndexChecker.CheckTrain(dataType, elementType, params)
 }
 
@@ -25,6 +42,9 @@ func (c *STLSORTChecker) CheckValidDataType(indexType IndexType, field *schemapb
 		if !typeutil.IsArithmetic(elemType) && !typeutil.IsStringType(elemType) && !typeutil.IsTimestamptzType(elemType) {
 			return errors.New(fmt.Sprintf("STL_SORT are only supported on numeric, varchar or timestamptz field, got struct sub-field of %s", field.GetElementType()))
 		}
+		return nil
+	}
+	if typeutil.IsJSONType(dataType) {
 		return nil
 	}
 	if !typeutil.IsArithmetic(dataType) && !typeutil.IsStringType(dataType) && !typeutil.IsTimestamptzType(dataType) {

--- a/internal/util/indexparamcheck/stl_sort_checker_test.go
+++ b/internal/util/indexparamcheck/stl_sort_checker_test.go
@@ -18,7 +18,7 @@ func Test_STLSORTIndexChecker(t *testing.T) {
 	assert.NoError(t, c.CheckValidDataType(IndexSTLSORT, &schemapb.FieldSchema{DataType: schemapb.DataType_VarChar}))
 
 	assert.Error(t, c.CheckValidDataType(IndexSTLSORT, &schemapb.FieldSchema{DataType: schemapb.DataType_Bool}))
-	assert.Error(t, c.CheckValidDataType(IndexSTLSORT, &schemapb.FieldSchema{DataType: schemapb.DataType_JSON}))
+	assert.NoError(t, c.CheckValidDataType(IndexSTLSORT, &schemapb.FieldSchema{DataType: schemapb.DataType_JSON}))
 
 	// struct sub-fields: name follows "structName[fieldName]" convention, DataType is Array
 	assert.NoError(t, c.CheckValidDataType(IndexSTLSORT, &schemapb.FieldSchema{Name: "myStruct[age]", DataType: schemapb.DataType_Array, ElementType: schemapb.DataType_Int64}))
@@ -29,4 +29,24 @@ func Test_STLSORTIndexChecker(t *testing.T) {
 
 	// regular Array field (not a struct sub-field) should still be rejected
 	assert.Error(t, c.CheckValidDataType(IndexSTLSORT, &schemapb.FieldSchema{Name: "tags", DataType: schemapb.DataType_Array, ElementType: schemapb.DataType_Int64}))
+
+	// JSON path index: CheckTrain validation
+	assert.NoError(t, c.CheckTrain(schemapb.DataType_JSON, schemapb.DataType_None, map[string]string{
+		"json_cast_type": "DOUBLE", "json_path": "/price",
+	}))
+	assert.NoError(t, c.CheckTrain(schemapb.DataType_JSON, schemapb.DataType_None, map[string]string{
+		"json_cast_type": "VARCHAR", "json_path": "/name",
+	}))
+	// missing json_cast_type
+	assert.Error(t, c.CheckTrain(schemapb.DataType_JSON, schemapb.DataType_None, map[string]string{
+		"json_path": "/price",
+	}))
+	// missing json_path
+	assert.Error(t, c.CheckTrain(schemapb.DataType_JSON, schemapb.DataType_None, map[string]string{
+		"json_cast_type": "DOUBLE",
+	}))
+	// unsupported cast type for STL_SORT
+	assert.Error(t, c.CheckTrain(schemapb.DataType_JSON, schemapb.DataType_None, map[string]string{
+		"json_cast_type": "BOOL", "json_path": "/flag",
+	}))
 }

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -101,6 +101,7 @@ const (
 
 const (
 	MinimalScalarIndexEngineVersion = int32(0)
+	// Scalar index version 3: adds JSON path index support for STL_SORT, BITMAP, and HYBRID index types.
 	CurrentScalarIndexEngineVersion = int32(3)
 	MaximumScalarIndexEngineVersion = int32(3)
 )

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -101,7 +101,10 @@ const (
 
 const (
 	MinimalScalarIndexEngineVersion = int32(0)
-	// Scalar index version 3: adds JSON path index support for STL_SORT, BITMAP, and HYBRID index types.
+	// Scalar index version 3:
+	// - Scalar index format v3
+	// - JSON path index support for STL_SORT, BITMAP, and HYBRID index types
+	// - HYBRID/AUTOINDEX high-cardinality scalar indexes switched from INVERTED to STL_SORT
 	CurrentScalarIndexEngineVersion = int32(3)
 	MaximumScalarIndexEngineVersion = int32(3)
 )

--- a/pkg/util/paramtable/autoindex_param.go
+++ b/pkg/util/paramtable/autoindex_param.go
@@ -213,7 +213,7 @@ func (p *AutoIndexConfig) init(base *BaseTable) {
 	p.ScalarAutoIndexParams = ParamItem{
 		Key:          "scalarAutoIndex.params.build",
 		Version:      "2.4.0",
-		DefaultValue: `{"int": "HYBRID","varchar": "HYBRID","bool": "BITMAP", "float": "HYBRID", "json": "INVERTED", "geometry": "RTREE", "timestamptz": "STL_SORT"}`,
+		DefaultValue: `{"int": "HYBRID","varchar": "HYBRID","bool": "BITMAP", "float": "HYBRID", "json": "HYBRID", "geometry": "RTREE", "timestamptz": "STL_SORT"}`,
 	}
 	p.ScalarAutoIndexParams.Init(base.mgr)
 

--- a/tests/python_client/milvus_client/test_milvus_client_compact.py
+++ b/tests/python_client/milvus_client/test_milvus_client_compact.py
@@ -114,6 +114,18 @@ class TestMilvusClientCompactInvalid(TestMilvusClientV2Base):
                     check_task=CheckTasks.err_res, check_items=error)
 
 
+_json_path_index_params = [
+    ("INVERTED", "BOOL"),
+    ("INVERTED", "DOUBLE"),
+    ("INVERTED", "VARCHAR"),
+    ("INVERTED", "JSON"),
+    ("STL_SORT", "DOUBLE"),
+    ("STL_SORT", "VARCHAR"),
+    ("BITMAP", "BOOL"),
+    ("BITMAP", "VARCHAR"),
+]
+
+
 class TestMilvusClientCompactValid(TestMilvusClientV2Base):
     """ Test case of hybrid search interface """
 
@@ -121,13 +133,17 @@ class TestMilvusClientCompactValid(TestMilvusClientV2Base):
     def is_clustering(self, request):
         yield request.param
 
-    @pytest.fixture(scope="function", params=["INVERTED"])
-    def supported_varchar_scalar_index(self, request):
+    @pytest.fixture(scope="function", params=_json_path_index_params, ids=[f"{t[0]}_{t[1]}" for t in _json_path_index_params])
+    def json_index_params(self, request):
         yield request.param
 
-    @pytest.fixture(scope="function", params=["DOUBLE", "VARCHAR", 'json', "bool"])
-    def supported_json_cast_type(self, request):
-        yield request.param
+    @pytest.fixture(scope="function")
+    def supported_varchar_scalar_index(self, json_index_params):
+        yield json_index_params[0]
+
+    @pytest.fixture(scope="function")
+    def supported_json_cast_type(self, json_index_params):
+        yield json_index_params[1]
 
     """
     ******************************************************************

--- a/tests/python_client/milvus_client/test_milvus_client_delete.py
+++ b/tests/python_client/milvus_client/test_milvus_client_delete.py
@@ -111,6 +111,18 @@ class TestMilvusClientDeleteInvalid(TestMilvusClientV2Base):
                                  "err_msg": "The type of expr must be string ,but <class 'NoneType'> is given."})
 
 
+_json_path_index_params = [
+    ("INVERTED", "BOOL"),
+    ("INVERTED", "DOUBLE"),
+    ("INVERTED", "VARCHAR"),
+    ("INVERTED", "JSON"),
+    ("STL_SORT", "DOUBLE"),
+    ("STL_SORT", "VARCHAR"),
+    ("BITMAP", "BOOL"),
+    ("BITMAP", "VARCHAR"),
+]
+
+
 class TestMilvusClientDeleteValid(TestMilvusClientV2Base):
     """ Test case of search interface """
 
@@ -122,13 +134,17 @@ class TestMilvusClientDeleteValid(TestMilvusClientV2Base):
     def metric_type(self, request):
         yield request.param
 
-    @pytest.fixture(scope="function", params=["INVERTED"])
-    def supported_varchar_scalar_index(self, request):
+    @pytest.fixture(scope="function", params=_json_path_index_params, ids=[f"{t[0]}_{t[1]}" for t in _json_path_index_params])
+    def json_index_params(self, request):
         yield request.param
 
-    @pytest.fixture(scope="function", params=["DOUBLE", "VARCHAR", "json", "bool"])
-    def supported_json_cast_type(self, request):
-        yield request.param
+    @pytest.fixture(scope="function")
+    def supported_varchar_scalar_index(self, json_index_params):
+        yield json_index_params[0]
+
+    @pytest.fixture(scope="function")
+    def supported_json_cast_type(self, json_index_params):
+        yield json_index_params[1]
 
     """
     ******************************************************************

--- a/tests/python_client/milvus_client/test_milvus_client_hybrid_search.py
+++ b/tests/python_client/milvus_client/test_milvus_client_hybrid_search.py
@@ -308,6 +308,18 @@ class TestMilvusClientHybridSearchInvalid(TestMilvusClientV2Base):
         self.drop_collection(client, collection_name)
 
 
+_json_path_index_params = [
+    ("INVERTED", "BOOL"),
+    ("INVERTED", "DOUBLE"),
+    ("INVERTED", "VARCHAR"),
+    ("INVERTED", "JSON"),
+    ("STL_SORT", "DOUBLE"),
+    ("STL_SORT", "VARCHAR"),
+    ("BITMAP", "BOOL"),
+    ("BITMAP", "VARCHAR"),
+]
+
+
 class TestMilvusClientHybridSearchValid(TestMilvusClientV2Base):
     """ Test case of hybrid search interface """
 
@@ -319,13 +331,17 @@ class TestMilvusClientHybridSearchValid(TestMilvusClientV2Base):
     def metric_type(self, request):
         yield request.param
 
-    @pytest.fixture(scope="function", params=["INVERTED"])
-    def supported_varchar_scalar_index(self, request):
+    @pytest.fixture(scope="function", params=_json_path_index_params, ids=[f"{t[0]}_{t[1]}" for t in _json_path_index_params])
+    def json_index_params(self, request):
         yield request.param
 
-    @pytest.fixture(scope="function", params=["JSON", "BOOL", "double", "varchar"])
-    def supported_json_cast_type(self, request):
-        yield request.param
+    @pytest.fixture(scope="function")
+    def supported_varchar_scalar_index(self, json_index_params):
+        yield json_index_params[0]
+
+    @pytest.fixture(scope="function")
+    def supported_json_cast_type(self, json_index_params):
+        yield json_index_params[1]
 
     """
     ******************************************************************

--- a/tests/python_client/milvus_client/test_milvus_client_index.py
+++ b/tests/python_client/milvus_client/test_milvus_client_index.py
@@ -742,15 +742,23 @@ class TestMilvusClientIndexValid(TestMilvusClientV2Base):
         self.drop_collection(client, collection_name)
 
 
+_json_path_index_params_invalid = [
+    ("INVERTED", "BOOL"),
+    ("INVERTED", "DOUBLE"),
+    ("INVERTED", "VARCHAR"),
+    ("INVERTED", "JSON"),
+    ("STL_SORT", "DOUBLE"),
+    ("STL_SORT", "VARCHAR"),
+    ("BITMAP", "BOOL"),
+    ("BITMAP", "VARCHAR"),
+]
+
+
 class TestMilvusClientJsonPathIndexInvalid(TestMilvusClientV2Base):
     """ Test case of search interface """
 
-    @pytest.fixture(scope="function", params=["TRIE", "STL_SORT", "BITMAP"])
+    @pytest.fixture(scope="function", params=["TRIE"])
     def not_supported_varchar_scalar_index(self, request):
-        yield request.param
-
-    @pytest.fixture(scope="function", params=["INVERTED"])
-    def supported_varchar_scalar_index(self, request):
         yield request.param
 
     @pytest.fixture(scope="function", params=[DataType.INT8.name, DataType.INT16.name, DataType.INT32.name,
@@ -762,8 +770,25 @@ class TestMilvusClientJsonPathIndexInvalid(TestMilvusClientV2Base):
     def not_supported_json_cast_type(self, request):
         yield request.param
 
-    @pytest.fixture(scope="function", params=["Json", "BOOL", "double", "varchar"])
-    def supported_json_cast_type(self, request):
+    @pytest.fixture(scope="function", params=_json_path_index_params_invalid, ids=[f"{t[0]}_{t[1]}" for t in _json_path_index_params_invalid])
+    def json_index_params(self, request):
+        yield request.param
+
+    @pytest.fixture(scope="function")
+    def supported_varchar_scalar_index(self, json_index_params):
+        """Index type from the combined (index_type, cast_type) fixture.
+        For tests that hardcode cast_type (e.g. 'double'), use
+        supported_double_scalar_index instead."""
+        yield json_index_params[0]
+
+    @pytest.fixture(scope="function")
+    def supported_json_cast_type(self, json_index_params):
+        yield json_index_params[1]
+
+    @pytest.fixture(scope="function", params=["INVERTED", "STL_SORT"])
+    def supported_double_scalar_index(self, request):
+        """Index types that support DOUBLE cast type. Use for tests that
+        hardcode json_cast_type to 'double'."""
         yield request.param
 
     """
@@ -959,10 +984,10 @@ class TestMilvusClientJsonPathIndexInvalid(TestMilvusClientV2Base):
     @pytest.mark.parametrize("enable_dynamic_field", [False])
     @pytest.mark.parametrize("invalid_json_path", [1, 1.0, '/'])
     def test_milvus_client_json_path_index_invalid_json_path(self, enable_dynamic_field, invalid_json_path,
-                                                             supported_varchar_scalar_index):
+                                                             supported_double_scalar_index):
         """
-        target: test json path index with invalid json_cast_type
-        method: create json path index with invalid json_cast_type
+        target: test json path index with invalid json_path
+        method: create json path index with invalid json_path
         expected: raise exception
         """
         client = self._client()
@@ -982,7 +1007,7 @@ class TestMilvusClientJsonPathIndexInvalid(TestMilvusClientV2Base):
         index_params = self.prepare_index_params(client)[0]
         index_params.add_index(field_name=default_vector_field_name, index_type="AUTOINDEX", metric_type="COSINE")
         index_params.add_index(field_name=json_field_name, index_name="json_index",
-                               index_type=supported_varchar_scalar_index,
+                               index_type=supported_double_scalar_index,
                                params={"json_cast_type": "Double", "json_path": invalid_json_path})
         # 3. create index
         error = {ct.err_code: 65535, ct.err_msg: f"cannot parse identifier: {invalid_json_path}"}
@@ -990,7 +1015,7 @@ class TestMilvusClientJsonPathIndexInvalid(TestMilvusClientV2Base):
                           check_task=CheckTasks.err_res, check_items=error)
 
     @pytest.mark.tags(CaseLabel.L1)
-    def test_milvus_client_json_path_index_not_exist_field_non_dynamic(self, supported_varchar_scalar_index):
+    def test_milvus_client_json_path_index_not_exist_field_non_dynamic(self, supported_double_scalar_index):
         """
         target: test json path index with not exist field in non dynamic field scenario
         method: create json path index with not exist field with enable_dynamic_field disabled
@@ -1006,7 +1031,7 @@ class TestMilvusClientJsonPathIndexInvalid(TestMilvusClientV2Base):
         schema.add_field(default_string_field_name, DataType.VARCHAR, max_length=64)
         index_params = self.prepare_index_params(client)[0]
         index_params.add_index(field_name=default_vector_field_name, index_type="AUTOINDEX", metric_type="COSINE")
-        index_params.add_index(field_name=json_field_name, index_type=supported_varchar_scalar_index,
+        index_params.add_index(field_name=json_field_name, index_type=supported_double_scalar_index,
                                params={"json_cast_type": "double", "json_path": f"{json_field_name}['a']"})
         error = {ct.err_code: 65535, ct.err_msg: f"cannot create index on non-exist field: {json_field_name}"}
         self.create_collection(client, collection_name, schema=schema, index_params=index_params,
@@ -1014,7 +1039,7 @@ class TestMilvusClientJsonPathIndexInvalid(TestMilvusClientV2Base):
 
     @pytest.mark.tags(CaseLabel.L1)
     @pytest.mark.parametrize("enable_dynamic_field", [True, False])
-    def test_milvus_client_different_index_same_json_path(self, enable_dynamic_field, supported_varchar_scalar_index):
+    def test_milvus_client_different_index_same_json_path(self, enable_dynamic_field, supported_double_scalar_index):
         """
         target: test create different index with different json_cast_type on the same json path of the same field
         method: create different index with different json_cast_type on the same
@@ -1038,13 +1063,13 @@ class TestMilvusClientJsonPathIndexInvalid(TestMilvusClientV2Base):
         index_params = self.prepare_index_params(client)[0]
         index_params.add_index(field_name=default_vector_field_name, index_type="AUTOINDEX", metric_type="COSINE")
         index_params.add_index(field_name=json_field_name, index_name="json_index",
-                               index_type=supported_varchar_scalar_index,
+                               index_type=supported_double_scalar_index,
                                params={"json_cast_type": "double", "json_path": f"{json_field_name}['a']"})
         self.create_index(client, collection_name, index_params)
         # 4. prepare another index params
         index_params = self.prepare_index_params(client)[0]
         index_params.add_index(field_name=json_field_name, index_name="json_index",
-                               index_type=supported_varchar_scalar_index,
+                               index_type=supported_double_scalar_index,
                                params={"json_cast_type": "varchar", "json_path": f"{json_field_name}['a']"})
         # 5. create index
         error = {ct.err_code: 65535, ct.err_msg: "CreateIndex failed: at most one distinct index is allowed per field"}
@@ -1141,6 +1166,18 @@ class TestMilvusClientJsonPathIndexInvalid(TestMilvusClientV2Base):
                           check_task=CheckTasks.err_res, check_items=error)
 
 
+_json_path_index_params_valid = [
+    ("INVERTED", "BOOL"),
+    ("INVERTED", "DOUBLE"),
+    ("INVERTED", "VARCHAR"),
+    ("INVERTED", "JSON"),
+    ("STL_SORT", "DOUBLE"),
+    ("STL_SORT", "VARCHAR"),
+    ("BITMAP", "BOOL"),
+    ("BITMAP", "VARCHAR"),
+]
+
+
 class TestMilvusClientJsonPathIndexValid(TestMilvusClientV2Base):
     """ Test case of search interface """
 
@@ -1148,13 +1185,17 @@ class TestMilvusClientJsonPathIndexValid(TestMilvusClientV2Base):
     # def not_supported_varchar_scalar_index(self, request):
     #     yield request.param
 
-    @pytest.fixture(scope="function", params=["INVERTED"])
-    def supported_varchar_scalar_index(self, request):
+    @pytest.fixture(scope="function", params=_json_path_index_params_valid, ids=[f"{t[0]}_{t[1]}" for t in _json_path_index_params_valid])
+    def json_index_params(self, request):
         yield request.param
 
-    @pytest.fixture(scope="function", params=["DOUBLE", "VARCHAR", "BOOL", "double", "varchar", "bool"])
-    def supported_json_cast_type(self, request):
-        yield request.param
+    @pytest.fixture(scope="function")
+    def supported_varchar_scalar_index(self, json_index_params):
+        yield json_index_params[0]
+
+    @pytest.fixture(scope="function")
+    def supported_json_cast_type(self, json_index_params):
+        yield json_index_params[1]
 
     """
     ******************************************************************

--- a/tests/python_client/milvus_client/test_milvus_client_json_path_index.py
+++ b/tests/python_client/milvus_client/test_milvus_client_json_path_index.py
@@ -35,17 +35,33 @@ default_string_array_field_name = ct.default_string_array_field_name
 default_int32_field_name = ct.default_int32_field_name
 default_int32_value = ct.default_int32_value
 
+# Valid (index_type, json_cast_type) combinations for JSON path index
+_json_path_index_params = [
+    ("INVERTED", "BOOL"),
+    ("INVERTED", "DOUBLE"),
+    ("INVERTED", "VARCHAR"),
+    ("INVERTED", "JSON"),
+    ("STL_SORT", "DOUBLE"),
+    ("STL_SORT", "VARCHAR"),
+    ("BITMAP", "BOOL"),
+    ("BITMAP", "VARCHAR"),
+]
+
 
 class TestMilvusClientInsertJsonPathIndexValid(TestMilvusClientV2Base):
     """ Test case of insert interface """
 
-    @pytest.fixture(scope="function", params=["INVERTED"])
-    def supported_varchar_scalar_index(self, request):
+    @pytest.fixture(scope="function", params=_json_path_index_params, ids=[f"{t[0]}_{t[1]}" for t in _json_path_index_params])
+    def json_index_params(self, request):
         yield request.param
 
-    @pytest.fixture(scope="function", params=["BOOL", "Double", "Varchar", "json"])
-    def supported_json_cast_type(self, request):
-        yield request.param
+    @pytest.fixture(scope="function")
+    def supported_varchar_scalar_index(self, json_index_params):
+        yield json_index_params[0]
+
+    @pytest.fixture(scope="function")
+    def supported_json_cast_type(self, json_index_params):
+        yield json_index_params[1]
 
     """
     ******************************************************************

--- a/tests/python_client/milvus_client/test_milvus_client_query.py
+++ b/tests/python_client/milvus_client/test_milvus_client_query.py
@@ -4183,17 +4183,29 @@ class TestMilvusClientGetValid(TestMilvusClientV2Base):
         self.drop_collection(client, collection_name)
 
 
+# Valid (index_type, json_cast_type) combinations for JSON path index
+# @pytest.fixture(scope="function", params=["DOUBLE", "VARCHAR", "json"", "bool", "ARRAY_DOUBLE"])
+_json_path_index_params_query = [
+    ("INVERTED", "DOUBLE"),
+    ("INVERTED", "ARRAY_DOUBLE"),
+    ("STL_SORT", "DOUBLE"),
+]
+
+
 class TestMilvusClientQueryJsonPathIndex(TestMilvusClientV2Base):
     """ Test case of search interface """
 
-    @pytest.fixture(scope="function", params=["INVERTED"])
-    def supported_varchar_scalar_index(self, request):
+    @pytest.fixture(scope="function", params=_json_path_index_params_query, ids=[f"{t[0]}_{t[1]}" for t in _json_path_index_params_query])
+    def json_index_params(self, request):
         yield request.param
 
-    # @pytest.fixture(scope="function", params=["DOUBLE", "VARCHAR", "json"", "bool", "ARRAY_DOUBLE"])
-    @pytest.fixture(scope="function", params=["DOUBLE", "ARRAY_DOUBLE"])
-    def supported_json_cast_type(self, request):
-        yield request.param
+    @pytest.fixture(scope="function")
+    def supported_varchar_scalar_index(self, json_index_params):
+        yield json_index_params[0]
+
+    @pytest.fixture(scope="function")
+    def supported_json_cast_type(self, json_index_params):
+        yield json_index_params[1]
 
     """
     ******************************************************************

--- a/tests/python_client/milvus_client/test_milvus_client_search.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search.py
@@ -3595,16 +3595,32 @@ class TestMilvusClientSearchNullExpr(TestMilvusClientV2Base):
                                  "limit": limit})
 
 
+_json_path_index_params = [
+    ("INVERTED", "BOOL"),
+    ("INVERTED", "DOUBLE"),
+    ("INVERTED", "VARCHAR"),
+    ("INVERTED", "JSON"),
+    ("STL_SORT", "DOUBLE"),
+    ("STL_SORT", "VARCHAR"),
+    ("BITMAP", "BOOL"),
+    ("BITMAP", "VARCHAR"),
+]
+
+
 class TestMilvusClientSearchJsonPathIndex(TestMilvusClientV2Base):
     """ Test case of search interface """
 
-    @pytest.fixture(scope="function", params=["INVERTED"])
-    def supported_varchar_scalar_index(self, request):
+    @pytest.fixture(scope="function", params=_json_path_index_params, ids=[f"{t[0]}_{t[1]}" for t in _json_path_index_params])
+    def json_index_params(self, request):
         yield request.param
 
-    @pytest.fixture(scope="function", params=["JSON", "VARCHAR", "double", "bool"])
-    def supported_json_cast_type(self, request):
-        yield request.param
+    @pytest.fixture(scope="function")
+    def supported_varchar_scalar_index(self, json_index_params):
+        yield json_index_params[0]
+
+    @pytest.fixture(scope="function")
+    def supported_json_cast_type(self, json_index_params):
+        yield json_index_params[1]
 
     """
     ******************************************************************

--- a/tests/python_client/milvus_client/test_milvus_client_search_iterator.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search_iterator.py
@@ -631,6 +631,18 @@ class TestMilvusClientSearchIteratorInValid(TestMilvusClientV2Base):
             it.next()
 
 
+_json_path_index_params = [
+    ("INVERTED", "BOOL"),
+    ("INVERTED", "DOUBLE"),
+    ("INVERTED", "VARCHAR"),
+    ("INVERTED", "JSON"),
+    ("STL_SORT", "DOUBLE"),
+    ("STL_SORT", "VARCHAR"),
+    ("BITMAP", "BOOL"),
+    ("BITMAP", "VARCHAR"),
+]
+
+
 class TestMilvusClientSearchIteratorValid(TestMilvusClientV2Base):
     """ Test case of search iterator interface """
 
@@ -642,13 +654,17 @@ class TestMilvusClientSearchIteratorValid(TestMilvusClientV2Base):
     def metric_type(self, request):
         yield request.param
 
-    @pytest.fixture(scope="function", params=["INVERTED"])
-    def supported_varchar_scalar_index(self, request):
+    @pytest.fixture(scope="function", params=_json_path_index_params, ids=[f"{t[0]}_{t[1]}" for t in _json_path_index_params])
+    def json_index_params(self, request):
         yield request.param
 
-    @pytest.fixture(scope="function", params=["DOUBLE", "JSON", "varchar", "bool"])
-    def supported_json_cast_type(self, request):
-        yield request.param
+    @pytest.fixture(scope="function")
+    def supported_varchar_scalar_index(self, json_index_params):
+        yield json_index_params[0]
+
+    @pytest.fixture(scope="function")
+    def supported_json_cast_type(self, json_index_params):
+        yield json_index_params[1]
 
     """
     ******************************************************************


### PR DESCRIPTION
Add STL_SORT, BITMAP, and HYBRID (via AUTOINDEX) index types for JSON Path Index, extending beyond the existing INVERTED-only support.

C++ changes:
- Add ConvertJsonToTypedFieldData<T>() to extract typed values from JSON field data with separate tracking of non_exist_offsets for EXISTS semantics
- Add JsonScalarIndexWrapper<T, BaseIndex> template for Sort/Bitmap with dual file-manager pattern (original JSON schema for reading, cast-type schema for base index dispatching)
- Add JsonHybridScalarIndex<T> with validity-aware cardinality counting
- Add IndexBase::Exists() virtual method; override in Sort/Bitmap/Hybrid wrappers using non_exist_offsets (serialized via WriteEntries/LoadEntries)
- Simplify ExistsExpr to use index->Exists() uniformly
- Extend IndexFactory::CreateJsonIndex() to route STL_SORT/BITMAP/HYBRID

Go changes:
- Update STL_SORT/Bitmap/Hybrid checkers to accept JSON with cast_type and json_path validation
- Change AUTOINDEX default for JSON from INVERTED to HYBRID
- Bump ScalarIndexEngineVersion to 3
- Add version gate in DataCoord CreateIndex and snapshot RestoreIndexes
- Update test fixtures to cover new (index_type, cast_type) combinations

<img width="2380" height="708" alt="image" src="https://github.com/user-attachments/assets/8b3923a0-2cb3-4af7-b73a-b76d1d1ec2d0" />
