### PR TITLE
enhance: replace exception-based integer validation with character iteration

### DIFF
--- a/internal/core/src/common/Utils.h
+++ b/internal/core/src/common/Utils.h
@@ -222,13 +222,17 @@ IsInteger(const std::string& str) {
     if (str.empty())
         return false;
 
-    try {
-        size_t pos;
-        std::stoi(str, &pos);
-        return pos == str.length();
-    } catch (...) {
-        return false;
+    size_t start = 0;
+    if (str[0] == '+' || str[0] == '-') {
+        start = 1;
+        if (str.size() == 1)
+            return false;
     }
+    for (size_t i = start; i < str.size(); ++i) {
+        if (str[i] < '0' || str[i] > '9')
+            return false;
+    }
+    return true;
 }
 
 inline std::string


### PR DESCRIPTION
## Summary

Cherry-pick of #48891 to 3.0.

Avoid exception-driven control flow in `IsInteger()`. On non-integer strings (e.g. `"active"`), `std::stoi` throws `std::invalid_argument` which triggers libfolly's `throwCallback` and `_Unwind_Backtrace` stack collection on every call. Replace with simple character iteration.

pr: #48891
issue: #44452