### PR TITLE
fix: upgrade knowhere to enable fused L2 distance kernel for PQ training

### DIFF
--- a/internal/core/thirdparty/knowhere/CMakeLists.txt
+++ b/internal/core/thirdparty/knowhere/CMakeLists.txt
@@ -14,7 +14,7 @@
 # Update KNOWHERE_VERSION for the first occurrence
 milvus_add_pkg_config("knowhere")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( KNOWHERE_VERSION 3b330dd0 )
+set( KNOWHERE_VERSION 902ea36c )
 set( GIT_REPOSITORY  "https://github.com/zilliztech/knowhere.git")
 
 message(STATUS "Knowhere repo: ${GIT_REPOSITORY}")


### PR DESCRIPTION
## Summary

Upgrade Knowhere from `3b330dd0` to `902ea36c` to include [knowhere#1558](https://github.com/zilliztech/knowhere/pull/1558), which fixes the fused L2 distance kernel (`exhaustive_L2sqr_fused_cmax`) being dead code under dynamic SIMD builds.

**Root cause**: The fused kernel source files used compile-time guards (`#ifdef __AVX512F__` / `#ifdef __AVX2__`), but Knowhere's dynamic SIMD build passes `-mno-avx -mno-avx2`. The fused kernel compiled to `return false`, got inlined away, and PQ k-means training fell back to the generic `sgemm` path — ~25x slower for the small matrices involved (dim=1 subquantizers with 1024 centroids).

**Impact**: HNSW_PQ index build with extreme params (`M=2048, efConstruction=10000, m=128, nbits=10`) drops from ~13s to ~2s. Fixes CI timeout under resource contention.

**Verification** (local, `m=128, nbits=10, N=2000, dim=128`):

| Configuration | PQ train | Milvus e2e |
|---|---|---|
| Before (`3b330dd0`) | 7630ms | 13.5s |
| After (`902ea36c`) | 330ms | 2.0s |
| faiss-cpu reference | 282ms | — |

issue: https://github.com/milvus-io/milvus/issues/48959