### PR TITLE
fix: [3.0] upgrade knowhere to enable fused L2 distance kernel for PQ training

### DIFF
--- a/internal/core/thirdparty/knowhere/CMakeLists.txt
+++ b/internal/core/thirdparty/knowhere/CMakeLists.txt
@@ -14,7 +14,7 @@
 # Update KNOWHERE_VERSION for the first occurrence
 milvus_add_pkg_config("knowhere")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( KNOWHERE_VERSION 3b330dd0 )
+set( KNOWHERE_VERSION 902ea36c )
 set( GIT_REPOSITORY  "https://github.com/zilliztech/knowhere.git")
 
 message(STATUS "Knowhere repo: ${GIT_REPOSITORY}")


### PR DESCRIPTION
## Summary

Cherry-pick of knowhere upgrade from master to 3.0 branch.

Upgrade Knowhere from `3b330dd0` to `902ea36c` to include [knowhere#1558](https://github.com/zilliztech/knowhere/pull/1558), which fixes the fused L2 distance kernel being dead code under dynamic SIMD builds. PQ k-means training was ~25x slower than it should be, causing HNSW_PQ index build timeout in CI.

issue: https://github.com/milvus-io/milvus/issues/48959
pr: #48981