### PR TITLE
enhance: add cluster-wide schema version consistency check at rootcoord

### DIFF
--- a/internal/rootcoord/ddl_callbacks_alter_collection_add_field.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_add_field.go
@@ -22,6 +22,11 @@ import (
 
 // broadcastAlterCollectionForAddField broadcasts the put collection message for add field.
 func (c *Core) broadcastAlterCollectionForAddField(ctx context.Context, req *milvuspb.AddCollectionFieldRequest) error {
+	// Cluster-wide serialization with broadcastAlterCollectionSchema is provided by
+	// the collection resource key lock acquired inside startBroadcastWithAliasOrCollectionLock.
+	// TODO: also run checkSchemaVersionConsistencyAtRootCoord here once the backfill
+	// compaction part (#48809 series) is merged. It is intentionally omitted for now
+	// because enabling the gate before backfill can complete would block E2E tests.
 	broadcaster, err := c.startBroadcastWithAliasOrCollectionLock(ctx, req.GetDbName(), req.GetCollectionName())
 	if err != nil {
 		return err

--- a/internal/rootcoord/ddl_callbacks_alter_collection_schema.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_schema.go
@@ -18,22 +18,33 @@ package rootcoord
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/cockroachdb/errors"
+	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/internal/metastore/model"
+	"github.com/milvus-io/milvus/pkg/v2/common"
+	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/messagespb"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v2/util/commonpbutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
 // broadcastAlterCollectionSchema broadcasts the alter collection schema message to all channels.
 func (c *Core) broadcastAlterCollectionSchema(ctx context.Context, req *milvuspb.AlterCollectionSchemaRequest) error {
+	// startBroadcastWithAliasOrCollectionLock acquires a cluster-wide exclusive
+	// resource-key lock on the collection (via StreamingCoord's broadcaster), which
+	// already serializes concurrent AlterCollectionSchema / AddCollectionField
+	// requests from different Proxy instances. The lock is alias-robust — the
+	// collection name is pre-resolved before the lock is taken.
 	broadcaster, err := c.startBroadcastWithAliasOrCollectionLock(ctx, req.GetDbName(), req.GetCollectionName())
 	if err != nil {
 		return err
@@ -63,6 +74,16 @@ func (c *Core) broadcastAlterCollectionSchema(ctx context.Context, req *milvuspb
 
 	if len(fieldInfos) == 0 {
 		return merr.WrapErrParameterInvalidMsg("fieldInfos is empty")
+	}
+
+	// Schema version consistency re-check: the broadcast resource lock serializes
+	// concurrent schema-change DDLs, but it does NOT guarantee that the previous
+	// one's backfill has finished. Verify against DataCoord's authoritative state
+	// that all segments have caught up to the current schema version before bumping
+	// it again. Run after cheap request-shape validation so malformed requests do
+	// not incur the DataCoord round-trip.
+	if err := c.checkSchemaVersionConsistencyAtRootCoord(ctx, coll); err != nil {
+		return err
 	}
 
 	// 2. check if the field schemas are illegal.
@@ -179,6 +200,97 @@ func (c *Core) broadcastAlterCollectionSchema(ctx context.Context, req *milvuspb
 		MustBuildBroadcast()
 	if _, err := broadcaster.Broadcast(ctx, msg); err != nil {
 		return err
+	}
+	return nil
+}
+
+// checkSchemaVersionConsistencyAtRootCoord is the authoritative, cluster-wide schema
+// version consistency check. It is called from schema-change DDL handlers after
+// acquiring the collection resource key lock and after cheap request-shape validation,
+// and before bumping the schema version.
+//
+// Rationale for running this at RootCoord rather than only at Proxy: in multi-Proxy
+// deployments, two concurrent requests routed to different Proxy instances each see
+// their own empty per-Proxy alterSchemaInFlight map and each call the Proxy-layer
+// consistency check independently. Both can pass before either has bumped the schema
+// version, producing two serial schema bumps that overlap backfill. RootCoord is a
+// single authoritative point, so its gate catches that race. The collection resource
+// key lock in startBroadcastWithAliasOrCollectionLock provides the mutual exclusion;
+// this function only adds the "wait for previous backfill to complete" semantics on
+// top of it.
+//
+// The check itself mirrors Proxy's checkSchemaVersionConsistency:
+//   - RPC DataCoord.GetCollectionStatistics
+//   - Look for SchemaVersionConsistentSegmentsKey and SchemaVersionTotalSegmentsKey
+//   - Absent keys → schema version 0 → trivially consistent → pass
+//   - Equal counts → pass
+//   - Otherwise → reject with ErrParameterInvalid
+//
+// Integer counts are used instead of a floating-point proportion to avoid the
+// rounding hazard where e.g. 99999/100000 = 99.999% would format as "100.00" and
+// falsely satisfy the gate.
+func (c *Core) checkSchemaVersionConsistencyAtRootCoord(ctx context.Context, coll *model.Collection) error {
+	// Defensive: callers should always pass a non-nil collection, but guard against
+	// a future caller forgetting the invariant — the field accesses below would panic.
+	if coll == nil {
+		return merr.WrapErrParameterInvalidMsg("nil collection in schema version consistency check")
+	}
+	log := log.Ctx(ctx).With(
+		zap.Int64("collectionID", coll.CollectionID),
+		zap.String("collection", coll.Name))
+
+	statsResp, err := c.mixCoord.GetCollectionStatistics(ctx, &datapb.GetCollectionStatisticsRequest{
+		Base:         commonpbutil.NewMsgBase(),
+		DbID:         coll.DBID,
+		CollectionID: coll.CollectionID,
+	})
+	if err := merr.CheckRPCCall(statsResp, err); err != nil {
+		log.Warn("failed to get collection statistics for schema version consistency check", zap.Error(err))
+		return err
+	}
+
+	// Find schema_version_consistent_segments and schema_version_total_segments from Stats.
+	// DataCoord emits these two integer keys only when the collection's schema version > 0.
+	// Absent keys mean the schema version is still 0 — no function field has ever been
+	// added — so there is no in-flight backfill and no DDL can be racing with one.
+	// -1 is the "absent" sentinel; parsed values are always >= 0.
+	consistent, total := -1, -1
+	for _, stat := range statsResp.GetStats() {
+		key := stat.GetKey()
+		if key != common.SchemaVersionConsistentSegmentsKey && key != common.SchemaVersionTotalSegmentsKey {
+			continue
+		}
+		v, err := strconv.Atoi(stat.GetValue())
+		if err != nil || v < 0 {
+			log.Warn("failed to parse schema version consistency stat",
+				zap.String("key", key), zap.String("value", stat.GetValue()), zap.Error(err))
+			return merr.WrapErrParameterInvalidMsg("invalid %s value: %s", key, stat.GetValue())
+		}
+		switch key {
+		case common.SchemaVersionConsistentSegmentsKey:
+			consistent = v
+		case common.SchemaVersionTotalSegmentsKey:
+			total = v
+		}
+	}
+
+	if consistent == -1 && total == -1 {
+		// Both keys absent: schema version is 0, no backfill has ever been triggered.
+		return nil
+	}
+	if consistent == -1 || total == -1 {
+		// Exactly one key present — should never happen since DataCoord emits both atomically.
+		// Treat as a data corruption signal and block the DDL rather than silently passing.
+		log.Warn("incomplete schema version consistency stats, blocking DDL",
+			zap.Int("consistent", consistent), zap.Int("total", total))
+		return merr.WrapErrParameterInvalidMsg("incomplete schema version consistency stats from DataCoord")
+	}
+	log.Info("checked schema version consistency",
+		zap.Int("consistent", consistent), zap.Int("total", total))
+	if consistent < total {
+		return merr.WrapErrParameterInvalidMsg(
+			"schema version consistency check failed: %d/%d segments have caught up; retry after backfill completes",
+			consistent, total)
 	}
 	return nil
 }

--- a/internal/rootcoord/ddl_callbacks_alter_collection_schema_test.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_schema_test.go
@@ -18,15 +18,19 @@ package rootcoord
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/mocks"
 	"github.com/milvus-io/milvus/pkg/v2/common"
+	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 )
@@ -245,3 +249,190 @@ func TestDDLCallbacksBroadcastAlterCollectionSchema(t *testing.T) {
 	})
 	require.Error(t, merr.CheckRPCCall(resp.GetAlterStatus(), err))
 }
+
+// addVarcharInputField adds a VARCHAR "text_input" field to the given collection so
+// that subsequent AlterCollectionSchema calls in consistency-gate tests can reference
+// it as a BM25 function input. Must be called BEFORE installMixCoordWithStats because
+// the AddCollectionField broadcast also uses the mixCoord.
+func addVarcharInputField(t *testing.T, ctx context.Context, core *Core, dbName, collectionName string) {
+	fieldBytes, err := proto.Marshal(&schemapb.FieldSchema{
+		Name:     "text_input",
+		DataType: schemapb.DataType_VarChar,
+		TypeParams: []*commonpb.KeyValuePair{
+			{Key: common.MaxLengthKey, Value: "256"},
+		},
+	})
+	require.NoError(t, err)
+	resp, err := core.AddCollectionField(ctx, &milvuspb.AddCollectionFieldRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		Schema:         fieldBytes,
+	})
+	require.NoError(t, merr.CheckRPCCall(resp, err))
+}
+
+// installMixCoordWithStats replaces the core's mixCoord with a valid mock that returns
+// the given consistency stats from GetCollectionStatistics. All other default
+// expectations are preserved so the broadcast path still works.
+func installMixCoordWithStats(core *Core, stats []*commonpb.KeyValuePair) {
+	mixc := &mocks.MixCoord{}
+	mixc.EXPECT().GetComponentStates(mock.Anything, mock.Anything).Return(
+		&milvuspb.ComponentStates{
+			State:  &milvuspb.ComponentInfo{StateCode: commonpb.StateCode_Healthy},
+			Status: merr.Success(),
+		}, nil).Maybe()
+	mixc.EXPECT().ReleaseCollection(mock.Anything, mock.Anything).Return(merr.Success(), nil).Maybe()
+	mixc.EXPECT().ReleasePartitions(mock.Anything, mock.Anything).Return(merr.Success(), nil).Maybe()
+	mixc.EXPECT().WatchChannels(mock.Anything, mock.Anything).Return(&datapb.WatchChannelsResponse{Status: merr.Success()}, nil).Maybe()
+	mixc.EXPECT().Flush(mock.Anything, mock.Anything).Return(&datapb.FlushResponse{Status: merr.Success()}, nil).Maybe()
+	mixc.EXPECT().BroadcastAlteredCollection(mock.Anything, mock.Anything).Return(merr.Success(), nil).Maybe()
+	mixc.EXPECT().GetCollectionStatistics(mock.Anything, mock.Anything).Return(
+		&datapb.GetCollectionStatisticsResponse{
+			Status: merr.Success(),
+			Stats:  stats,
+		}, nil).Maybe()
+	core.mixCoord = mixc
+}
+
+// TestDDLCallbacksBroadcastAlterCollectionSchemaConsistencyGate verifies the
+// schema-version consistency re-check added at RootCoord. Cluster-wide mutual
+// exclusion between schema-change DDLs is provided by the existing collection
+// resource key lock in startBroadcastWithAliasOrCollectionLock — this gate only
+// adds the "wait for previous backfill to complete" check on top of it.
+func TestDDLCallbacksBroadcastAlterCollectionSchemaConsistencyGate(t *testing.T) {
+	t.Run("rejects when consistent_count < total_count", func(t *testing.T) {
+		core := initStreamingSystemAndCore(t)
+
+		ctx := context.Background()
+		dbName := "testDB" + funcutil.RandomString(10)
+		collectionName := "testCollection" + funcutil.RandomString(10)
+		createCollectionForTest(t, ctx, core, dbName, collectionName)
+
+		installMixCoordWithStats(core, []*commonpb.KeyValuePair{
+			{Key: common.SchemaVersionConsistentSegmentsKey, Value: "5"},
+			{Key: common.SchemaVersionTotalSegmentsKey, Value: "10"},
+		})
+
+		resp, err := core.AlterCollectionSchema(ctx,
+			buildAlterSchemaReq(dbName, collectionName, "text_input", "sparse_inc", "bm25_inc", false))
+		require.Error(t, merr.CheckRPCCall(resp.GetAlterStatus(), err))
+		require.Contains(t, resp.GetAlterStatus().GetReason(), "schema version consistency check failed")
+		require.Contains(t, resp.GetAlterStatus().GetReason(), "retry after backfill completes")
+	})
+
+	t.Run("passes when consistent_count == total_count", func(t *testing.T) {
+		core := initStreamingSystemAndCore(t)
+
+		ctx := context.Background()
+		dbName := "testDB" + funcutil.RandomString(10)
+		collectionName := "testCollection" + funcutil.RandomString(10)
+		createCollectionForTest(t, ctx, core, dbName, collectionName)
+		addVarcharInputField(t, ctx, core, dbName, collectionName)
+
+		installMixCoordWithStats(core, []*commonpb.KeyValuePair{
+			{Key: common.SchemaVersionConsistentSegmentsKey, Value: "10"},
+			{Key: common.SchemaVersionTotalSegmentsKey, Value: "10"},
+		})
+
+		resp, err := core.AlterCollectionSchema(ctx,
+			buildAlterSchemaReq(dbName, collectionName, "text_input", "sparse_ok", "bm25_ok", false))
+		require.NoError(t, merr.CheckRPCCall(resp.GetAlterStatus(), err))
+	})
+
+	t.Run("absent keys treated as trivially consistent", func(t *testing.T) {
+		// Both keys absent → schema version has never been bumped, no backfill
+		// can be in progress, so the gate must pass.
+		core := initStreamingSystemAndCore(t)
+
+		ctx := context.Background()
+		dbName := "testDB" + funcutil.RandomString(10)
+		collectionName := "testCollection" + funcutil.RandomString(10)
+		createCollectionForTest(t, ctx, core, dbName, collectionName)
+		addVarcharInputField(t, ctx, core, dbName, collectionName)
+
+		installMixCoordWithStats(core, nil)
+
+		resp, err := core.AlterCollectionSchema(ctx,
+			buildAlterSchemaReq(dbName, collectionName, "text_input", "sparse_noop", "bm25_noop", false))
+		require.NoError(t, merr.CheckRPCCall(resp.GetAlterStatus(), err))
+	})
+
+	t.Run("invalid consistent_segments value is rejected", func(t *testing.T) {
+		core := initStreamingSystemAndCore(t)
+
+		ctx := context.Background()
+		dbName := "testDB" + funcutil.RandomString(10)
+		collectionName := "testCollection" + funcutil.RandomString(10)
+		createCollectionForTest(t, ctx, core, dbName, collectionName)
+
+		installMixCoordWithStats(core, []*commonpb.KeyValuePair{
+			{Key: common.SchemaVersionConsistentSegmentsKey, Value: "not-a-number"},
+			{Key: common.SchemaVersionTotalSegmentsKey, Value: "10"},
+		})
+
+		resp, err := core.AlterCollectionSchema(ctx,
+			buildAlterSchemaReq(dbName, collectionName, "text_input", "sparse_bad", "bm25_bad", false))
+		require.Error(t, merr.CheckRPCCall(resp.GetAlterStatus(), err))
+		require.Contains(t, resp.GetAlterStatus().GetReason(), "invalid schema_version_consistent_segments value")
+	})
+
+	t.Run("only one of two stat keys present is treated as corruption", func(t *testing.T) {
+		// Defensive branch: DataCoord is supposed to emit both keys atomically.
+		// If only one is present, treat as a data-corruption signal and block the DDL.
+		core := initStreamingSystemAndCore(t)
+
+		ctx := context.Background()
+		dbName := "testDB" + funcutil.RandomString(10)
+		collectionName := "testCollection" + funcutil.RandomString(10)
+		createCollectionForTest(t, ctx, core, dbName, collectionName)
+
+		installMixCoordWithStats(core, []*commonpb.KeyValuePair{
+			{Key: common.SchemaVersionConsistentSegmentsKey, Value: "5"},
+			// SchemaVersionTotalSegmentsKey intentionally omitted
+		})
+
+		resp, err := core.AlterCollectionSchema(ctx,
+			buildAlterSchemaReq(dbName, collectionName, "text_input", "sparse_half", "bm25_half", false))
+		require.Error(t, merr.CheckRPCCall(resp.GetAlterStatus(), err))
+		require.Contains(t, resp.GetAlterStatus().GetReason(), "incomplete schema version consistency stats")
+	})
+
+	t.Run("DataCoord RPC failure is surfaced", func(t *testing.T) {
+		core := initStreamingSystemAndCore(t)
+
+		ctx := context.Background()
+		dbName := "testDB" + funcutil.RandomString(10)
+		collectionName := "testCollection" + funcutil.RandomString(10)
+		createCollectionForTest(t, ctx, core, dbName, collectionName)
+
+		// Install a mock whose GetCollectionStatistics returns an error. Other
+		// methods need default expectations so the broadcast path still works
+		// up to the gate.
+		mixc := &mocks.MixCoord{}
+		mixc.EXPECT().GetComponentStates(mock.Anything, mock.Anything).Return(
+			&milvuspb.ComponentStates{
+				State:  &milvuspb.ComponentInfo{StateCode: commonpb.StateCode_Healthy},
+				Status: merr.Success(),
+			}, nil).Maybe()
+		mixc.EXPECT().ReleaseCollection(mock.Anything, mock.Anything).Return(merr.Success(), nil).Maybe()
+		mixc.EXPECT().ReleasePartitions(mock.Anything, mock.Anything).Return(merr.Success(), nil).Maybe()
+		mixc.EXPECT().WatchChannels(mock.Anything, mock.Anything).Return(&datapb.WatchChannelsResponse{Status: merr.Success()}, nil).Maybe()
+		mixc.EXPECT().Flush(mock.Anything, mock.Anything).Return(&datapb.FlushResponse{Status: merr.Success()}, nil).Maybe()
+		mixc.EXPECT().BroadcastAlteredCollection(mock.Anything, mock.Anything).Return(merr.Success(), nil).Maybe()
+		mixc.EXPECT().GetCollectionStatistics(mock.Anything, mock.Anything).Return(
+			nil, errors.New("mock datacoord error"),
+		).Maybe()
+		core.mixCoord = mixc
+
+		resp, err := core.AlterCollectionSchema(ctx,
+			buildAlterSchemaReq(dbName, collectionName, "text_input", "sparse_rpcerr", "bm25_rpcerr", false))
+		require.Error(t, merr.CheckRPCCall(resp.GetAlterStatus(), err))
+	})
+
+	// NOTE: AddCollectionField does NOT yet run the consistency gate (it's deferred
+	// until the backfill compaction series is merged — enabling the gate before
+	// backfill can complete would block E2E tests). See the TODO in
+	// broadcastAlterCollectionForAddField. A test for that path will be added
+	// together with the call itself in the follow-up PR.
+}
+

--- a/internal/rootcoord/mock_test.go
+++ b/internal/rootcoord/mock_test.go
@@ -736,6 +736,15 @@ func withValidMixCoord() Opt {
 		}, nil,
 	)
 
+	// Default: no schema-version consistency stats → trivially consistent (schema v0).
+	// Tests that need to exercise the consistency gate override this on a per-test basis.
+	mixc.EXPECT().GetCollectionStatistics(mock.Anything, mock.Anything).Return(
+		&datapb.GetCollectionStatisticsResponse{
+			Status: merr.Success(),
+			Stats:  []*commonpb.KeyValuePair{},
+		}, nil,
+	).Maybe()
+
 	mixc.EXPECT().BroadcastAlteredCollection(mock.Anything, mock.Anything).Return(
 		merr.Success(), nil,
 	)


### PR DESCRIPTION
## Summary

Adds a schema version consistency re-check at RootCoord inside the collection resource key lock, to catch a multi-Proxy race left by #48810.

### The race

Proxy's `alterSchemaInFlight sync.Map` (added in #48810) is a **per-Proxy instance** guard. In multi-Proxy deployments, two concurrent `AlterCollectionSchema` requests routed to different Proxy instances each see their own empty local map and both pass the Proxy-layer consistency check before either has bumped the schema version. Both then reach RootCoord, serialize through the DDL queue, and produce two back-to-back schema bumps that overlap backfill — leaving segments stuck below the collection version and blocking all subsequent schema-change DDLs via the consistency gate.

### The fix

Cluster-wide mutual exclusion is **already provided** by the collection resource key lock acquired inside `startBroadcastWithAliasOrCollectionLock` (via StreamingCoord's broadcaster), so no new lock is needed. This PR adds a consistency re-check at RootCoord inside that lock, to enforce \"wait for previous backfill to complete\" before accepting a new schema change:

- `checkSchemaVersionConsistencyAtRootCoord` helper in `ddl_callbacks_alter_collection_schema.go` — calls `DataCoord.GetCollectionStatistics` and compares `SchemaVersionConsistentSegmentsKey` / `SchemaVersionTotalSegmentsKey` integer counts (mirrors Proxy's check).
- Wired into `broadcastAlterCollectionSchema` after cheap request-shape validation (so malformed requests do not incur a DataCoord round-trip) and before schema version bump.
- Helper accepts the already-resolved `*model.Collection` from the caller to avoid a redundant meta lookup, and defensively guards against nil collection.

### Scope discipline: `AddCollectionField` intentionally deferred

The check is wired into `broadcastAlterCollectionSchema` only. Wiring it into `broadcastAlterCollectionForAddField` is **intentionally deferred** until the backfill compaction series (Part 3 of the function field backfill work) merges — enabling the gate there before backfill can complete would block E2E tests. A TODO is left in place so the follow-up is not lost.

issue: #48809
pr: #48810

## Test plan

- [x] Unit test: `rejects when consistent_count < total_count`
- [x] Unit test: `passes when consistent_count == total_count`
- [x] Unit test: `absent keys treated as trivially consistent` (schema v0 path)
- [x] Unit test: `invalid consistent_segments value is rejected` (parse error)
- [x] Unit test: `only one of two stat keys present is treated as corruption` (defensive branch)
- [x] Unit test: `DataCoord RPC failure is surfaced`
- [ ] Integration: multi-Proxy race can no longer produce overlapping schema bumps

🤖 Generated with [Claude Code](https://claude.com/claude-code)