### PR TITLE
enhance: use StorageVersion to identify v3 segments and fix stats task atomicity

### DIFF
--- a/internal/core/src/segcore/SegmentLoadInfo.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfo.cpp
@@ -35,10 +35,14 @@ namespace milvus::segcore {
 
 std::shared_ptr<milvus_storage::api::ColumnGroups>
 SegmentLoadInfo::GetColumnGroups() {
-    auto manifest_path = GetManifestPath();
-    if (manifest_path.empty()) {
+    if (GetStorageVersion() < STORAGE_V3) {
         return nullptr;
     }
+    auto manifest_path = GetManifestPath();
+    AssertInfo(manifest_path != "",
+               "manifest path shall not be empty for storage v3 segment, "
+               "segment id: {}",
+               GetSegmentID());
     // return cached result if exists
     if (column_groups_ != nullptr) {
         return column_groups_;

--- a/internal/datacoord/handler.go
+++ b/internal/datacoord/handler.go
@@ -170,8 +170,8 @@ func (h *ServerHandler) GetQueryVChanPositions(channel RWChannel, partitionIDs .
 		if filterWithPartition && !validPartitionsMap[s.GetPartitionID()] {
 			continue
 		}
-		if s.GetStartPosition() == nil && s.GetDmlPosition() == nil && s.GetManifestPath() == "" {
-			// External collection segments may not have start/DML positions but have ManifestPath
+		if s.GetStartPosition() == nil && s.GetDmlPosition() == nil && s.GetStorageVersion() < storage.StorageV3 {
+			// External collection segments may not have start/DML positions for v3 segment
 			continue
 		}
 		if s.GetIsImporting() {

--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -1282,8 +1282,8 @@ func UpdateManifestVersion(segmentID int64, manifestVersion int64) UpdateOperato
 				zap.Int64("segmentID", segmentID))
 			return false
 		}
-		if segment.ManifestPath == "" {
-			log.Ctx(context.TODO()).Warn("meta update: update manifest version failed - no manifest path",
+		if segment.GetStorageVersion() < storage.StorageV3 {
+			log.Ctx(context.TODO()).Warn("meta update: update manifest version failed - not a v3 segment",
 				zap.Int64("segmentID", segmentID))
 			return false
 		}

--- a/internal/datacoord/meta_test.go
+++ b/internal/datacoord/meta_test.go
@@ -1198,8 +1198,9 @@ func TestUpdateSegmentsInfo(t *testing.T) {
 
 		segment1 := NewSegmentInfo(&datapb.SegmentInfo{
 			ID: 1, State: commonpb.SegmentState_Growing,
-			Binlogs:   []*datapb.FieldBinlog{},
-			Statslogs: []*datapb.FieldBinlog{},
+			Binlogs:        []*datapb.FieldBinlog{},
+			Statslogs:      []*datapb.FieldBinlog{},
+			StorageVersion: storage.StorageV3,
 		})
 		err = meta.AddSegment(context.TODO(), segment1)
 		assert.NoError(t, err)
@@ -1488,15 +1489,15 @@ func TestUpdateManifestVersion(t *testing.T) {
 		assert.False(t, operator(pack))
 	})
 
-	t.Run("empty manifest path", func(t *testing.T) {
+	t.Run("non-v3 segment", func(t *testing.T) {
 		meta, err := newMemoryMeta(t)
 		assert.NoError(t, err)
 
 		meta.AddSegment(context.Background(), &SegmentInfo{
 			SegmentInfo: &datapb.SegmentInfo{
-				ID:           1,
-				State:        commonpb.SegmentState_Flushed,
-				ManifestPath: "",
+				ID:             1,
+				State:          commonpb.SegmentState_Flushed,
+				StorageVersion: storage.StorageV2,
 			},
 		})
 
@@ -1535,9 +1536,10 @@ func TestUpdateManifestVersion(t *testing.T) {
 		manifestPath := packed.MarshalManifestPath("/data/segments/1", 10)
 		meta.AddSegment(context.Background(), &SegmentInfo{
 			SegmentInfo: &datapb.SegmentInfo{
-				ID:           1,
-				State:        commonpb.SegmentState_Flushed,
-				ManifestPath: manifestPath,
+				ID:             1,
+				State:          commonpb.SegmentState_Flushed,
+				ManifestPath:   manifestPath,
+				StorageVersion: storage.StorageV3,
 			},
 		})
 
@@ -1556,9 +1558,10 @@ func TestUpdateManifestVersion(t *testing.T) {
 		manifestPath := packed.MarshalManifestPath("/data/segments/1", 5)
 		meta.AddSegment(context.Background(), &SegmentInfo{
 			SegmentInfo: &datapb.SegmentInfo{
-				ID:           1,
-				State:        commonpb.SegmentState_Flushed,
-				ManifestPath: manifestPath,
+				ID:             1,
+				State:          commonpb.SegmentState_Flushed,
+				ManifestPath:   manifestPath,
+				StorageVersion: storage.StorageV3,
 			},
 		})
 
@@ -1585,9 +1588,10 @@ func TestUpdateManifestVersion(t *testing.T) {
 		manifestPath := packed.MarshalManifestPath("/data/segments/1", 1)
 		meta.AddSegment(context.Background(), &SegmentInfo{
 			SegmentInfo: &datapb.SegmentInfo{
-				ID:           1,
-				State:        commonpb.SegmentState_Flushed,
-				ManifestPath: manifestPath,
+				ID:             1,
+				State:          commonpb.SegmentState_Flushed,
+				ManifestPath:   manifestPath,
+				StorageVersion: storage.StorageV3,
 			},
 		})
 

--- a/internal/datacoord/segment_info.go
+++ b/internal/datacoord/segment_info.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
+	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
@@ -577,7 +578,7 @@ type SegmentInfoSelector func(*SegmentInfo) bool
 // legacy stats fields. Returns a descriptive message if validation fails,
 // or empty string if the segment is valid.
 func ValidateManifestSegment(info *SegmentInfo) string {
-	if info.GetManifestPath() == "" {
+	if info.GetStorageVersion() < storage.StorageV3 {
 		return ""
 	}
 

--- a/internal/datacoord/segment_info_test.go
+++ b/internal/datacoord/segment_info_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 )
 
@@ -196,20 +197,22 @@ func TestIsStatsLogExists(t *testing.T) {
 }
 
 func TestValidateManifestSegment(t *testing.T) {
-	t.Run("no manifest is always valid", func(t *testing.T) {
+	t.Run("non-v3 segment", func(t *testing.T) {
 		info := NewSegmentInfo(&datapb.SegmentInfo{
 			ID: 1,
 			Statslogs: []*datapb.FieldBinlog{
 				{FieldID: 100},
 			},
+			StorageVersion: storage.StorageV2,
 		})
 		assert.Empty(t, ValidateManifestSegment(info))
 	})
 
 	t.Run("manifest with empty legacy fields is valid", func(t *testing.T) {
 		info := NewSegmentInfo(&datapb.SegmentInfo{
-			ID:           2,
-			ManifestPath: "base/path@1",
+			ID:             2,
+			ManifestPath:   "base/path@1",
+			StorageVersion: storage.StorageV3,
 		})
 		assert.Empty(t, ValidateManifestSegment(info))
 	})
@@ -221,6 +224,7 @@ func TestValidateManifestSegment(t *testing.T) {
 			Statslogs: []*datapb.FieldBinlog{
 				{FieldID: 100},
 			},
+			StorageVersion: storage.StorageV3,
 		})
 		msg := ValidateManifestSegment(info)
 		assert.Contains(t, msg, "statslogs")
@@ -234,6 +238,7 @@ func TestValidateManifestSegment(t *testing.T) {
 			Bm25Statslogs: []*datapb.FieldBinlog{
 				{FieldID: 200},
 			},
+			StorageVersion: storage.StorageV3,
 		})
 		msg := ValidateManifestSegment(info)
 		assert.Contains(t, msg, "bm25statslogs")
@@ -246,6 +251,7 @@ func TestValidateManifestSegment(t *testing.T) {
 			TextStatsLogs: map[int64]*datapb.TextIndexStats{
 				10: {FieldID: 10},
 			},
+			StorageVersion: storage.StorageV3,
 		})
 		msg := ValidateManifestSegment(info)
 		assert.Contains(t, msg, "textStatsLogs")
@@ -258,6 +264,7 @@ func TestValidateManifestSegment(t *testing.T) {
 			JsonKeyStats: map[int64]*datapb.JsonKeyStats{
 				20: {FieldID: 20},
 			},
+			StorageVersion: storage.StorageV3,
 		})
 		msg := ValidateManifestSegment(info)
 		assert.Contains(t, msg, "jsonKeyStats")
@@ -271,6 +278,7 @@ func TestValidateManifestSegment(t *testing.T) {
 			TextStatsLogs: map[int64]*datapb.TextIndexStats{
 				10: {FieldID: 10},
 			},
+			StorageVersion: storage.StorageV3,
 		})
 		msg := ValidateManifestSegment(info)
 		assert.Contains(t, msg, "statslogs")

--- a/internal/datacoord/segment_operator.go
+++ b/internal/datacoord/segment_operator.go
@@ -69,6 +69,16 @@ func SetJsonKeyIndexLogs(jsonKeyIndexLogs map[int64]*datapb.JsonKeyStats) Segmen
 	}
 }
 
+func SetManifestPath(manifestPath string) SegmentOperator {
+	return func(segment *SegmentInfo) bool {
+		if segment.GetManifestPath() == manifestPath {
+			return false
+		}
+		segment.ManifestPath = manifestPath
+		return true
+	}
+}
+
 type segmentCriterion struct {
 	collectionID int64
 	channel      string

--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -982,7 +982,7 @@ func (s *Server) GetRecoveryInfoV2(ctx context.Context, req *datapb.GetRecoveryI
 		}
 
 		binlogs := segment.GetBinlogs()
-		if len(binlogs) == 0 && segment.GetLevel() != datapb.SegmentLevel_L0 && segment.GetManifestPath() == "" {
+		if len(binlogs) == 0 && segment.GetLevel() != datapb.SegmentLevel_L0 {
 			continue
 		}
 		rowCount := segmentutil.CalcRowCountFromBinLog(segment.SegmentInfo)

--- a/internal/datacoord/snapshot.go
+++ b/internal/datacoord/snapshot.go
@@ -503,7 +503,7 @@ func (w *SnapshotWriter) Save(ctx context.Context, snapshot *SnapshotData) (stri
 	// StorageV2 segments have an additional manifest file for Lance/Arrow format
 	storagev2Manifests := make([]*datapb.StorageV2SegmentManifest, 0)
 	for _, segment := range snapshot.Segments {
-		if segment.GetManifestPath() != "" {
+		if segment.GetStorageVersion() == storage.StorageV3 {
 			storagev2Manifests = append(storagev2Manifests, &datapb.StorageV2SegmentManifest{
 				SegmentId: segment.GetSegmentId(),
 				Manifest:  segment.GetManifestPath(),

--- a/internal/datacoord/snapshot_test.go
+++ b/internal/datacoord/snapshot_test.go
@@ -888,6 +888,7 @@ func TestSnapshotWriter_Save_WithStorageV2Manifest(t *testing.T) {
 	snapshotData := createTestSnapshotData()
 
 	// Add manifest_path to segment
+	snapshotData.Segments[0].StorageVersion = storage.StorageV3
 	snapshotData.Segments[0].ManifestPath = "s3://bucket/collection/partition/segment1/manifest.json"
 
 	metadataPath, err := writer.Save(context.Background(), snapshotData)
@@ -917,6 +918,7 @@ func TestSnapshotReader_ReadSnapshot_WithStorageV2Manifest(t *testing.T) {
 	// Write a snapshot with StorageV2 manifest
 	writer := NewSnapshotWriter(cm)
 	snapshotData := createTestSnapshotData()
+	snapshotData.Segments[0].StorageVersion = 3
 	snapshotData.Segments[0].ManifestPath = "s3://bucket/collection/partition/segment1/manifest.json"
 
 	metadataPath, err := writer.Save(context.Background(), snapshotData)

--- a/internal/datacoord/task_stats.go
+++ b/internal/datacoord/task_stats.go
@@ -351,42 +351,27 @@ func (st *statsTask) prepareJobRequest(ctx context.Context, segment *SegmentInfo
 }
 
 func (st *statsTask) SetJobInfo(ctx context.Context, result *workerpb.StatsResult) error {
-	var err error
+	var operators []SegmentOperator
+	var segmentID int64
+
+	if result.GetManifest() != "" {
+		operators = append(operators, SetManifestPath(result.GetManifest()))
+	}
+
 	switch st.GetSubJobType() {
 	case indexpb.StatsSubJob_TextIndexJob:
-		err = st.meta.UpdateSegment(st.GetSegmentID(), SetTextIndexLogs(result.GetTextStatsLogs()))
-		if err != nil {
-			log.Ctx(ctx).Warn("save text index stats result failed", zap.Int64("taskID", st.GetTaskID()),
-				zap.Int64("segmentID", st.GetSegmentID()), zap.Error(err))
-			break
-		}
+		segmentID = st.GetSegmentID()
+		operators = append(operators, SetTextIndexLogs(result.GetTextStatsLogs()))
 	case indexpb.StatsSubJob_JsonKeyIndexJob:
-		err = st.meta.UpdateSegment(st.GetSegmentID(), SetJsonKeyIndexLogs(result.GetJsonKeyStatsLogs()))
-		if err != nil {
-			log.Ctx(ctx).Warn("save json key index stats result failed", zap.Int64("taskId", st.GetTaskID()),
-				zap.Int64("segmentID", st.GetSegmentID()), zap.Error(err))
-			break
-		}
+		segmentID = st.GetSegmentID()
+		operators = append(operators, SetJsonKeyIndexLogs(result.GetJsonKeyStatsLogs()))
 	case indexpb.StatsSubJob_Sort:
-		// For V2 segments (no manifest), persist statsLogs and bm25Logs.
-		// For V3 segments (manifest set), stats are already in manifest.
-		segment := st.meta.GetHealthySegment(ctx, st.GetTargetSegmentID())
-		if segment != nil && segment.GetManifestPath() == "" {
-			var operators []SegmentOperator
-			if len(result.GetStatsLogs()) > 0 {
-				operators = append(operators, SetStatslogs(result.GetStatsLogs()))
-			}
-			if len(result.GetBm25Logs()) > 0 {
-				operators = append(operators, SetBm25Statslogs(result.GetBm25Logs()))
-			}
-			if len(operators) > 0 {
-				err = st.meta.UpdateSegment(st.GetTargetSegmentID(), operators...)
-				if err != nil {
-					log.Ctx(ctx).Warn("save sort stats result failed", zap.Int64("taskID", st.GetTaskID()),
-						zap.Int64("segmentID", st.GetTargetSegmentID()), zap.Error(err))
-					break
-				}
-			}
+		segmentID = st.GetTargetSegmentID()
+		if len(result.GetStatsLogs()) > 0 {
+			operators = append(operators, SetStatslogs(result.GetStatsLogs()))
+		}
+		if len(result.GetBm25Logs()) > 0 {
+			operators = append(operators, SetBm25Statslogs(result.GetBm25Logs()))
 		}
 	case indexpb.StatsSubJob_BM25Job:
 	// bm25 logs are generated during with segment flush.
@@ -394,27 +379,13 @@ func (st *statsTask) SetJobInfo(ctx context.Context, result *workerpb.StatsResul
 		log.Ctx(ctx).Warn("unexpected sub job type", zap.String("type", st.GetSubJobType().String()))
 	}
 
+	err := st.meta.UpdateSegment(segmentID, operators...)
 	// if segment is not found, it means the segment is already dropped,
 	// so we can ignore the error and mark task as finished.
 	if err != nil && !errors.Is(err, merr.ErrSegmentNotFound) {
+		log.Ctx(ctx).Warn("save stats result failed", zap.Int64("taskId", st.GetTaskID()),
+			zap.Int64("segmentID", st.GetSegmentID()), zap.String("taskType", st.GetSubJobType().String()), zap.Error(err))
 		return err
-	}
-
-	// Update segment manifest version so subsequent stats tasks use the latest version.
-	if manifest := result.GetManifest(); manifest != "" {
-		segID := st.GetSegmentID()
-		if st.GetSubJobType() == indexpb.StatsSubJob_Sort {
-			segID = st.GetTargetSegmentID()
-		}
-		if updateErr := st.meta.UpdateSegmentsInfo(ctx, UpdateManifest(segID, manifest)); updateErr != nil {
-			log.Ctx(ctx).Warn("failed to update manifest after stats task",
-				zap.Int64("taskID", st.GetTaskID()),
-				zap.Int64("segmentID", segID),
-				zap.Error(updateErr))
-			if !errors.Is(updateErr, merr.ErrSegmentNotFound) {
-				return updateErr
-			}
-		}
 	}
 
 	log.Ctx(ctx).Info("SetJobInfo for stats task success", zap.Int64("taskID", st.GetTaskID()),

--- a/internal/querycoordv2/utils/types.go
+++ b/internal/querycoordv2/utils/types.go
@@ -24,6 +24,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
 	"github.com/milvus-io/milvus/internal/querycoordv2/meta"
+	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/querypb"
@@ -91,9 +92,9 @@ func PackSegmentLoadInfo(segment *datapb.SegmentInfo, channelCheckpoint *msgpb.M
 	// Deltalogs are always populated (delta log loading has its own manifest path)
 	loadInfo.Deltalogs = segment.Deltalogs
 
-	// When manifest_path is set, stats are stored in the manifest.
+	// When using storage v3, stats are stored in the manifest.
 	// Skip populating legacy stats fields - the reader will load from manifest.
-	if segment.GetManifestPath() == "" {
+	if segment.GetStorageVersion() < storage.StorageV3 {
 		loadInfo.Statslogs = segment.Statslogs
 		loadInfo.Bm25Logs = segment.Bm25Statslogs
 		loadInfo.TextStatsLogs = segment.GetTextStatsLogs()

--- a/internal/querycoordv2/utils/types_test.go
+++ b/internal/querycoordv2/utils/types_test.go
@@ -93,8 +93,9 @@ func TestPackSegmentLoadInfo_ManifestPath(t *testing.T) {
 
 	t.Run("manifest set clears legacy stats fields", func(t *testing.T) {
 		seg := &datapb.SegmentInfo{
-			ID:           100,
-			ManifestPath: "base/path@5",
+			ID:             100,
+			StorageVersion: 3,
+			ManifestPath:   "base/path@5",
 			Statslogs: []*datapb.FieldBinlog{
 				{FieldID: 1},
 			},

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -1405,10 +1405,10 @@ func (loader *segmentLoader) loadDeltalogs(ctx context.Context, segment Segment,
 	}
 
 	// Read deltalogs from manifest for StorageV3 segments
-	if manifestPath := loadInfo.GetManifestPath(); manifestPath != "" {
+	if loadInfo.GetStorageVersion() == storage.StorageV3 {
 		reader, err := storage.NewDeltalogReaderFromManifest(
 			pkField.DataType,
-			manifestPath,
+			loadInfo.GetManifestPath(),
 			storage.WithStorageConfig(createStorageConfig()),
 			storage.WithVersion(storage.StorageV2),
 		)

--- a/internal/storagev2/packed/utils.go
+++ b/internal/storagev2/packed/utils.go
@@ -192,7 +192,9 @@ func BuildCurrentSegmentFragments(
 	result := make(SegmentFragments)
 	for _, seg := range segments {
 		// Try to read from manifest if available
-		if seg.GetManifestPath() != "" && storageConfig != nil {
+		// storageVersion >= StorageV3(3) means loon manifest format.
+		// Cannot reference storage.StorageV3 due to import cycle (storage <-> packed).
+		if seg.GetStorageVersion() == 3 && storageConfig != nil {
 			fragments, err := ReadFragmentsFromManifest(seg.GetManifestPath(), storageConfig)
 			if err != nil {
 				return nil, fmt.Errorf("failed to read manifest for segment %d at %s: %w",


### PR DESCRIPTION
Related to #48547

Replace ManifestPath != "" checks with StorageVersion-based checks across Go and C++ code to use the explicit version identifier instead of an indirect side-effect. This makes version gating clearer and decoupled from the manifest path value itself.

Fix statsTask.SetJobInfo to apply manifest path and stats/bm25/text/json operators in a single atomic UpdateSegment call, eliminating a race window where manifest could be updated without stats (or vice versa). The previous code used separate UpdateSegment and UpdateSegmentsInfo calls that could partially fail.

Also fix SetManifestPath SegmentOperator which had a self-comparison bug (segment.GetManifestPath() == segment.GetManifestPath()) causing it to always no-op.