### PR TITLE
fix: [2.6.14] make $meta ValidData population conditional for 2.5 compat

### DIFF
--- a/internal/proxy/task_upsert.go
+++ b/internal/proxy/task_upsert.go
@@ -306,10 +306,13 @@ func (it *upsertTask) queryPreExecute(ctx context.Context) error {
 		fieldData.FieldId = fieldSchema.GetFieldID()
 		fieldData.FieldName = fieldName
 
-		// Ensure dynamic field has ValidData before merge logic.
-		// SDK doesn't set ValidData on $meta; without it, AppendFieldDataByColumn
-		// won't propagate ValidData for insert rows, causing length mismatch.
-		if fieldData.GetIsDynamic() && len(fieldData.GetValidData()) == 0 {
+		// Ensure dynamic field has ValidData before merge logic, but only when
+		// the field schema actually requires it (nullable or has default value).
+		// For 2.5 collections where $meta is non-nullable with no default,
+		// ValidData must remain empty — CheckValidData expects len==0 for
+		// non-nullable fields.
+		if fieldData.GetIsDynamic() && len(fieldData.GetValidData()) == 0 &&
+			(fieldSchema.GetNullable() || fieldSchema.GetDefaultValue() != nil) {
 			nRows := int(it.upsertMsg.InsertMsg.NRows())
 			validData := make([]bool, nRows)
 			for i := range validData {

--- a/internal/proxy/task_upsert_test.go
+++ b/internal/proxy/task_upsert_test.go
@@ -2281,4 +2281,108 @@ func TestUpsertTask_queryPreExecute_DynamicFieldValidData(t *testing.T) {
 		assert.Equal(t, 3, len(validData),
 			"queryPreExecute auto-fills ValidData, merge produces correct length 3")
 	})
+
+	t.Run("v25 schema (non-nullable $meta) upsert should not fail", func(t *testing.T) {
+		// 2.5-style schema: $meta is NOT nullable and has NO default value.
+		// After upgrading to 2.6, existing collections retain this schema.
+		// queryPreExecute must NOT unconditionally fill ValidData for $meta,
+		// because CheckValidData expects len(ValidData)==0 for non-nullable fields.
+		v25Schema := newSchemaInfo(&schemapb.CollectionSchema{
+			Name:               "test_v25_compat",
+			EnableDynamicField: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "id", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+				{FieldID: 101, Name: "value", DataType: schemapb.DataType_Int32},
+				{
+					FieldID: 102, Name: common.MetaFieldName, DataType: schemapb.DataType_JSON,
+					IsDynamic: true,
+					Nullable:  false, // 2.5 style: NOT nullable
+					// No DefaultValue — 2.5 style
+				},
+			},
+		})
+
+		meta1, _ := json.Marshal(map[string]interface{}{"color": "gold"})
+		meta2, _ := json.Marshal(map[string]interface{}{"color": "silver"})
+		meta3, _ := json.Marshal(map[string]interface{}{"color": "bronze"})
+
+		upsertData := []*schemapb.FieldData{
+			{
+				FieldName: "id", FieldId: 100, Type: schemapb.DataType_Int64,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{1, 2, 3}}}}},
+			},
+			{
+				FieldName: "value", FieldId: 101, Type: schemapb.DataType_Int32,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: []int32{100, 200, 300}}}}},
+			},
+			{
+				FieldName: common.MetaFieldName, FieldId: 102, Type: schemapb.DataType_JSON, IsDynamic: true,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_JsonData{
+					JsonData: &schemapb.JSONArray{Data: [][]byte{meta1, meta2, meta3}},
+				}}},
+				// No ValidData — SDK behavior
+			},
+		}
+
+		existMeta1, _ := json.Marshal(map[string]interface{}{"color": "red"})
+		existMeta2, _ := json.Marshal(map[string]interface{}{"color": "blue"})
+		mockQueryResult := &milvuspb.QueryResults{
+			Status: merr.Success(),
+			FieldsData: []*schemapb.FieldData{
+				{
+					FieldName: "id", FieldId: 100, Type: schemapb.DataType_Int64,
+					Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{1, 2}}}}},
+				},
+				{
+					FieldName: "value", FieldId: 101, Type: schemapb.DataType_Int32,
+					Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: []int32{10, 20}}}}},
+				},
+				{
+					FieldName: common.MetaFieldName, FieldId: 102, Type: schemapb.DataType_JSON, IsDynamic: true,
+					Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_JsonData{
+						JsonData: &schemapb.JSONArray{Data: [][]byte{existMeta1, existMeta2}},
+					}}},
+				},
+			},
+		}
+
+		task := &upsertTask{
+			ctx:    context.Background(),
+			schema: v25Schema,
+			req: &milvuspb.UpsertRequest{
+				FieldsData: upsertData,
+				NumRows:    3,
+			},
+			upsertMsg: &msgstream.UpsertMsg{
+				InsertMsg: &msgstream.InsertMsg{
+					InsertRequest: &msgpb.InsertRequest{
+						FieldsData: upsertData,
+						NumRows:    3,
+						Version:    msgpb.InsertDataVersion_ColumnBased,
+					},
+				},
+			},
+			node: &Proxy{},
+		}
+
+		mockRetrieve := mockey.Mock(retrieveByPKs).Return(mockQueryResult, segcore.StorageCost{}, nil).Build()
+		defer mockRetrieve.UnPatch()
+
+		err := task.queryPreExecute(context.Background())
+		assert.NoError(t, err, "queryPreExecute should not fail for 2.5-style non-nullable $meta")
+
+		var metaField *schemapb.FieldData
+		for _, f := range task.insertFieldData {
+			if f.GetFieldName() == common.MetaFieldName {
+				metaField = f
+				break
+			}
+		}
+		assert.NotNil(t, metaField)
+		metaData := metaField.GetScalars().GetJsonData().GetData()
+		assert.Equal(t, 3, len(metaData), "merged $meta should have 3 rows")
+		// For non-nullable $meta, ValidData should remain empty (not auto-filled)
+		assert.Empty(t, metaField.GetValidData(),
+			"non-nullable $meta should NOT have ValidData auto-filled")
+	})
 }

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -1173,12 +1173,8 @@ func autoGenPrimaryFieldData(fieldSchema *schemapb.FieldSchema, data interface{}
 	return &fieldData, nil
 }
 
-func autoGenDynamicFieldData(data [][]byte) *schemapb.FieldData {
-	validData := make([]bool, len(data))
-	for i := range validData {
-		validData[i] = true
-	}
-	return &schemapb.FieldData{
+func autoGenDynamicFieldData(schema *schemapb.CollectionSchema, data [][]byte) *schemapb.FieldData {
+	fd := &schemapb.FieldData{
 		FieldName: common.MetaFieldName,
 		Type:      schemapb.DataType_JSON,
 		Field: &schemapb.FieldData_Scalars{
@@ -1191,8 +1187,23 @@ func autoGenDynamicFieldData(data [][]byte) *schemapb.FieldData {
 			},
 		},
 		IsDynamic: true,
-		ValidData: validData,
 	}
+
+	// Only set ValidData when the $meta field is nullable or has a default value.
+	// For 2.5 collections (non-nullable, no default), CheckValidData expects
+	// len(ValidData)==0, so we must NOT set it.
+	for _, f := range schema.Fields {
+		if f.GetIsDynamic() && (f.GetNullable() || f.GetDefaultValue() != nil) {
+			validData := make([]bool, len(data))
+			for i := range validData {
+				validData[i] = true
+			}
+			fd.ValidData = validData
+			break
+		}
+	}
+
+	return fd
 }
 
 // validateFieldDataColumns validates that all required fields are present and no unknown fields exist.
@@ -2406,7 +2417,7 @@ func checkDynamicFieldData(schema *schemapb.CollectionSchema, insertMsg *msgstre
 	for i := range defaultData {
 		defaultData[i] = []byte("{}")
 	}
-	dynamicData := autoGenDynamicFieldData(defaultData)
+	dynamicData := autoGenDynamicFieldData(schema, defaultData)
 	insertMsg.FieldsData = append(insertMsg.FieldsData, dynamicData)
 	return nil
 }

--- a/internal/proxy/util_test.go
+++ b/internal/proxy/util_test.go
@@ -2189,8 +2189,8 @@ func Test_CheckDynamicFieldData(t *testing.T) {
 		jsonBytes, err := json.MarshalIndent(data, "", "  ")
 		assert.NoError(t, err)
 		jsonData = append(jsonData, jsonBytes)
-		jsonFieldData := autoGenDynamicFieldData(jsonData)
 		schema := newTestSchema()
+		jsonFieldData := autoGenDynamicFieldData(schema, jsonData)
 		insertMsg := &msgstream.InsertMsg{
 			InsertRequest: &msgpb.InsertRequest{
 				CollectionName: "collectionName",
@@ -2218,8 +2218,8 @@ func Test_CheckDynamicFieldData(t *testing.T) {
 		jsonBytes, err := json.MarshalIndent(data, "", "  ")
 		assert.NoError(t, err)
 		jsonData = append(jsonData, jsonBytes)
-		jsonFieldData := autoGenDynamicFieldData(jsonData)
 		schema := newTestSchema()
+		jsonFieldData := autoGenDynamicFieldData(schema, jsonData)
 		insertMsg := &msgstream.InsertMsg{
 			InsertRequest: &msgpb.InsertRequest{
 				CollectionName: "collectionName",
@@ -2247,8 +2247,8 @@ func Test_CheckDynamicFieldData(t *testing.T) {
 		jsonBytes, err := json.MarshalIndent(data, "", "  ")
 		assert.NoError(t, err)
 		jsonData = append(jsonData, jsonBytes)
-		jsonFieldData := autoGenDynamicFieldData(jsonData)
 		schema := newTestSchema()
+		jsonFieldData := autoGenDynamicFieldData(schema, jsonData)
 		insertMsg := &msgstream.InsertMsg{
 			InsertRequest: &msgpb.InsertRequest{
 				CollectionName: "collectionName",
@@ -2275,8 +2275,8 @@ func Test_CheckDynamicFieldData(t *testing.T) {
 		jsonBytes, err := json.MarshalIndent(data, "", "  ")
 		assert.NoError(t, err)
 		jsonData = append(jsonData, jsonBytes)
-		jsonFieldData := autoGenDynamicFieldData(jsonData)
 		schema := newTestSchema()
+		jsonFieldData := autoGenDynamicFieldData(schema, jsonData)
 		insertMsg := &msgstream.InsertMsg{
 			InsertRequest: &msgpb.InsertRequest{
 				CollectionName: "collectionName",
@@ -2291,8 +2291,8 @@ func Test_CheckDynamicFieldData(t *testing.T) {
 	})
 	t.Run("json data is string", func(t *testing.T) {
 		data := "abcdefg"
-		jsonFieldData := autoGenDynamicFieldData([][]byte{[]byte(data)})
 		schema := newTestSchema()
+		jsonFieldData := autoGenDynamicFieldData(schema, [][]byte{[]byte(data)})
 		insertMsg := &msgstream.InsertMsg{
 			InsertRequest: &msgpb.InsertRequest{
 				CollectionName: "collectionName",

--- a/internal/proxy/validate_util_test.go
+++ b/internal/proxy/validate_util_test.go
@@ -7398,3 +7398,174 @@ func TestFillWithNullValue_Geometry(t *testing.T) {
 		assert.Nil(t, field.GetScalars().GetGeometryData().GetData()[3])
 	})
 }
+
+// Test_MetaNullableCompat_v25_vs_v26 verifies that insert and upsert Validate
+// (specifically fillWithValue) works correctly for both 2.5-style $meta
+// (Nullable=false, no DefaultValue) and 2.6-style $meta (Nullable=true,
+// DefaultValue="{}").
+//
+// Scenario: after upgrading from 2.5 to 2.6, old collections retain their
+// original $meta schema. The proxy code must handle both formats.
+func Test_MetaNullableCompat_v25_vs_v26(t *testing.T) {
+	numRows := 3
+
+	// Build a minimal schema with PK + vector + $meta (dynamic field).
+	// metaNullable/metaDefault control whether the $meta matches 2.5 or 2.6.
+	buildSchema := func(metaNullable bool, metaDefault []byte) *schemapb.CollectionSchema {
+		metaField := &schemapb.FieldSchema{
+			FieldID:   101,
+			Name:      common.MetaFieldName,
+			DataType:  schemapb.DataType_JSON,
+			IsDynamic: true,
+			Nullable:  metaNullable,
+		}
+		if metaDefault != nil {
+			metaField.DefaultValue = &schemapb.ValueField{
+				Data: &schemapb.ValueField_BytesData{BytesData: metaDefault},
+			}
+		}
+		return &schemapb.CollectionSchema{
+			Name:               "compat_test",
+			EnableDynamicField: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 1, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+				metaField,
+			},
+		}
+	}
+
+	// Simulate SDK-provided $meta data WITHOUT ValidData (the common SDK behavior).
+	sdkMetaFieldData := func() *schemapb.FieldData {
+		jsonRows := make([][]byte, numRows)
+		for i := range jsonRows {
+			jsonRows[i] = []byte(`{"dyn_key":"value"}`)
+		}
+		return &schemapb.FieldData{
+			FieldName: common.MetaFieldName,
+			Type:      schemapb.DataType_JSON,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_JsonData{
+						JsonData: &schemapb.JSONArray{Data: jsonRows},
+					},
+				},
+			},
+			IsDynamic: true,
+			// NOTE: no ValidData — this is what the SDK sends
+		}
+	}
+
+	// Auto-generated $meta (when SDK sends no dynamic data) — mirrors autoGenDynamicFieldData.
+	autoGenMetaFieldData := func(schema *schemapb.CollectionSchema) *schemapb.FieldData {
+		defaultData := make([][]byte, numRows)
+		for i := range defaultData {
+			defaultData[i] = []byte("{}")
+		}
+		return autoGenDynamicFieldData(schema, defaultData)
+	}
+
+	t.Run("INSERT_v26_schema_sdk_provided_meta", func(t *testing.T) {
+		schema := buildSchema(true, []byte("{}"))
+		h, err := typeutil.CreateSchemaHelper(schema)
+		require.NoError(t, err)
+
+		data := []*schemapb.FieldData{sdkMetaFieldData()}
+		err = newValidateUtil().fillWithValue(data, h, numRows)
+		assert.NoError(t, err, "2.6 schema + SDK-provided $meta should pass fillWithValue")
+	})
+
+	t.Run("INSERT_v25_schema_sdk_provided_meta", func(t *testing.T) {
+		schema := buildSchema(false, nil) // 2.5 style
+		h, err := typeutil.CreateSchemaHelper(schema)
+		require.NoError(t, err)
+
+		data := []*schemapb.FieldData{sdkMetaFieldData()}
+		err = newValidateUtil().fillWithValue(data, h, numRows)
+		assert.NoError(t, err, "2.5 schema + SDK-provided $meta (no ValidData) should pass fillWithValue")
+	})
+
+	t.Run("INSERT_v26_schema_autogen_meta", func(t *testing.T) {
+		schema := buildSchema(true, []byte("{}"))
+		h, err := typeutil.CreateSchemaHelper(schema)
+		require.NoError(t, err)
+
+		data := []*schemapb.FieldData{autoGenMetaFieldData(schema)}
+		err = newValidateUtil().fillWithValue(data, h, numRows)
+		assert.NoError(t, err, "2.6 schema + auto-generated $meta should pass fillWithValue")
+	})
+
+	t.Run("INSERT_v25_schema_autogen_meta", func(t *testing.T) {
+		// autoGenDynamicFieldData checks schema: for 2.5 (non-nullable, no default),
+		// it does NOT set ValidData. CheckValidData expects len(ValidData)==0.
+		schema := buildSchema(false, nil) // 2.5 style
+		h, err := typeutil.CreateSchemaHelper(schema)
+		require.NoError(t, err)
+
+		data := []*schemapb.FieldData{autoGenMetaFieldData(schema)}
+		err = newValidateUtil().fillWithValue(data, h, numRows)
+		assert.NoError(t, err, "2.5 schema + auto-generated $meta should pass fillWithValue")
+		// ValidData should remain empty for non-nullable field
+		assert.Empty(t, data[0].GetValidData(), "non-nullable $meta should not have ValidData")
+	})
+
+	t.Run("UPSERT_queryPreExecute_v25_schema", func(t *testing.T) {
+		// Simulates the fixed upsert queryPreExecute path where ValidData is
+		// conditionally auto-filled only for nullable/default-value fields.
+		schema := buildSchema(false, nil) // 2.5 style
+		h, err := typeutil.CreateSchemaHelper(schema)
+		require.NoError(t, err)
+
+		fieldData := sdkMetaFieldData()
+		fieldSchema, _ := h.GetFieldFromName(common.MetaFieldName)
+
+		// Simulate FIXED queryPreExecute auto-fill (with schema condition)
+		if fieldData.GetIsDynamic() && len(fieldData.GetValidData()) == 0 &&
+			(fieldSchema.GetNullable() || fieldSchema.GetDefaultValue() != nil) {
+			validData := make([]bool, numRows)
+			for i := range validData {
+				validData[i] = true
+			}
+			fieldData.ValidData = validData
+		}
+
+		// For 2.5 schema: ValidData is NOT set, so this branch is skipped
+		if len(fieldData.GetValidData()) != 0 {
+			if fieldSchema.GetDefaultValue() != nil {
+				err = FillWithDefaultValue(fieldData, fieldSchema, numRows)
+			} else {
+				err = FillWithNullValue(fieldData, fieldSchema, numRows)
+			}
+		}
+		assert.NoError(t, err, "2.5 schema upsert queryPreExecute should not fail")
+		assert.Empty(t, fieldData.GetValidData(), "non-nullable $meta should not have ValidData")
+	})
+
+	t.Run("UPSERT_queryPreExecute_v26_schema", func(t *testing.T) {
+		schema := buildSchema(true, []byte("{}"))
+		h, err := typeutil.CreateSchemaHelper(schema)
+		require.NoError(t, err)
+
+		fieldData := sdkMetaFieldData()
+		fieldSchema, _ := h.GetFieldFromName(common.MetaFieldName)
+
+		// Simulate FIXED queryPreExecute auto-fill (with schema condition)
+		if fieldData.GetIsDynamic() && len(fieldData.GetValidData()) == 0 &&
+			(fieldSchema.GetNullable() || fieldSchema.GetDefaultValue() != nil) {
+			validData := make([]bool, numRows)
+			for i := range validData {
+				validData[i] = true
+			}
+			fieldData.ValidData = validData
+		}
+
+		if len(fieldData.GetValidData()) != 0 {
+			if fieldSchema.GetDefaultValue() != nil {
+				err = FillWithDefaultValue(fieldData, fieldSchema, numRows)
+			} else {
+				err = FillWithNullValue(fieldData, fieldSchema, numRows)
+			}
+		}
+		assert.NoError(t, err, "2.6 schema upsert queryPreExecute should pass")
+		assert.Equal(t, numRows, len(fieldData.GetValidData()), "nullable $meta should have ValidData")
+	})
+}


### PR DESCRIPTION
issue: #48930
pr: #48969

cherry-pick from master

After upgrading from 2.5 to 2.6, insert/upsert on collections created in 2.5 with `enable_dynamic_field=true` fails because the `$meta` field schema differs between versions:

- 2.5: `Nullable=false`, `DefaultValue=nil`
- 2.6: `Nullable=true`,  `DefaultValue="{}"`

`nullutil.CheckValidData` requires `len(ValidData)==0` for non-nullable fields, but two proxy code paths unconditionally populated ValidData on `$meta`:

- `autoGenDynamicFieldData` (internal/proxy/util.go): used when SDK doesn't provide dynamic fields
- `queryPreExecute` (internal/proxy/task_upsert.go): auto-fills ValidData before upsert merge logic

This change gates ValidData population on the field schema's Nullable / DefaultValue attributes so that 2.5 collections (where `$meta` remains non-nullable) pass CheckValidData, while 2.6 collections continue to work.