### PR TITLE
enhance: fix data race and nil-slice edge case in BloomFilterSet.PkCandidateExist

### DIFF
--- a/internal/querynodev2/pkoracle/bloom_filter_set.go
+++ b/internal/querynodev2/pkoracle/bloom_filter_set.go
@@ -107,7 +107,17 @@ func (s *BloomFilterSet) Stats() *storage.PkStatistics {
 
 // PkCandidateExist reports whether bloom filter data has been loaded (current or historical).
 func (s *BloomFilterSet) PkCandidateExist() bool {
-	return s.currentStat != nil || s.historyStats != nil
+	s.statsMutex.RLock()
+	defer s.statsMutex.RUnlock()
+	if s.currentStat != nil {
+		return true
+	}
+	for _, stat := range s.historyStats {
+		if stat != nil {
+			return true
+		}
+	}
+	return false
 }
 
 // UpdatePkCandidate updates currentStats with provided pks.

--- a/internal/querynodev2/pkoracle/bloom_filter_set_test.go
+++ b/internal/querynodev2/pkoracle/bloom_filter_set_test.go
@@ -101,6 +101,49 @@ func TestHistoricalStat(t *testing.T) {
 	}
 }
 
+func TestPkCandidateExist(t *testing.T) {
+	paramtable.Init()
+
+	t.Run("empty set returns false", func(t *testing.T) {
+		bfs := NewBloomFilterSet(1, 1, commonpb.SegmentState_Sealed)
+		assert.False(t, bfs.PkCandidateExist())
+	})
+
+	t.Run("with current stat returns true", func(t *testing.T) {
+		bfs := NewBloomFilterSet(1, 1, commonpb.SegmentState_Sealed)
+		pks := []storage.PrimaryKey{storage.NewInt64PrimaryKey(1)}
+		bfs.UpdatePkCandidate(pks)
+		assert.True(t, bfs.PkCandidateExist())
+	})
+
+	t.Run("nil-only historyStats returns false", func(t *testing.T) {
+		bfs := NewBloomFilterSet(1, 1, commonpb.SegmentState_Sealed)
+		bfs.historyStats = []*storage.PkStatistics{nil, nil}
+		assert.False(t, bfs.PkCandidateExist())
+	})
+
+	t.Run("empty historyStats slice returns false", func(t *testing.T) {
+		bfs := NewBloomFilterSet(1, 1, commonpb.SegmentState_Sealed)
+		bfs.historyStats = []*storage.PkStatistics{}
+		assert.False(t, bfs.PkCandidateExist())
+	})
+
+	t.Run("valid historical stat returns true", func(t *testing.T) {
+		batchSize := 10
+		pks := make([]storage.PrimaryKey, 0, batchSize)
+		for i := 0; i < batchSize; i++ {
+			pks = append(pks, storage.NewInt64PrimaryKey(int64(i)))
+		}
+
+		bfs := NewBloomFilterSet(1, 1, commonpb.SegmentState_Sealed)
+		bfs.UpdatePkCandidate(pks)
+		bfs.AddHistoricalStats(bfs.currentStat)
+		bfs.currentStat = nil
+
+		assert.True(t, bfs.PkCandidateExist())
+	})
+}
+
 func TestMemSize(t *testing.T) {
 	paramtable.Init()
 


### PR DESCRIPTION
## Summary

`BloomFilterSet.PkCandidateExist` read `s.currentStat` and `s.historyStats` **without holding `statsMutex`**, while every other read method in the same struct (`MayPkExist`, `BatchPkExist`, `GetMinPk`, `GetMaxPk`, `MemSize`) takes the lock. A concurrent `UpdatePkCandidate` or `AddHistoricalStats` call (both write under lock) produces a data race detectable by `-race`.

Two issues fixed:

1. **Data race** — add `s.statsMutex.RLock()` / `RUnlock()` to `PkCandidateExist`, consistent with all other read methods.
2. **Nil-slice false positive** — replace `s.historyStats != nil` with an element-wise non-nil scan, matching the pattern already used by `GetMinPk` / `GetMaxPk`. An empty slice or a slice of all-nil entries is now correctly reported as "not ready."

issue: #48992

## Test plan

- [ ] Added `TestPkCandidateExist` covering: empty set, current stat only, nil-only historyStats slice, empty historyStats slice, valid historical stat with nil current.
- [ ] Existing tests (`TestInt64Pk`, `TestVarCharPk`, `TestHistoricalStat`, `TestMemSize`) remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)