### PR TITLE
enhance: clarify scalar index version semantics

### DIFF
--- a/internal/core/src/exec/expression/LikeConjunctExprTest.cpp
+++ b/internal/core/src/exec/expression/LikeConjunctExprTest.cpp
@@ -227,7 +227,7 @@ TEST(LikeConjunctExpr, TestMultiFieldMultiLikeWithRetrieve) {
             auto index =
                 std::make_shared<index::NgramInvertedIndex>(ctx, ngram_params);
             index->Build(config);
-            auto create_index_result = index->UploadV3({});
+            auto create_index_result = index->UploadUnified({});
             auto index_files = create_index_result->GetIndexFiles();
 
             std::map<std::string, std::string> index_params{

--- a/internal/core/src/index/BitmapIndexArrayTest.cpp
+++ b/internal/core/src/index/BitmapIndexArrayTest.cpp
@@ -260,7 +260,7 @@ class ArrayBitmapIndexTest : public testing::Test {
         ctx.set_for_loading_index(true);
         index_ =
             index::IndexFactory::GetInstance().CreateIndex(index_info, ctx);
-        index_->LoadV3(config);
+        index_->LoadUnified(config);
     }
 
     virtual void

--- a/internal/core/src/index/BitmapIndexTest.cpp
+++ b/internal/core/src/index/BitmapIndexTest.cpp
@@ -213,7 +213,7 @@ class BitmapIndexTest : public testing::Test {
             milvus::proto::common::LoadPriority::HIGH;
         index_ =
             index::IndexFactory::GetInstance().CreateIndex(index_info, ctx);
-        index_->LoadV3(config);
+        index_->LoadUnified(config);
     }
 
     virtual void

--- a/internal/core/src/index/BoolIndexTest.cpp
+++ b/internal/core/src/index/BoolIndexTest.cpp
@@ -201,13 +201,13 @@ TEST_F(BoolIndexTest, Codec) {
         index->Build(all_true.data_size(), all_true.data().data());
 
         auto copy_index = milvus::index::CreateBoolIndex(file_manager_ctx);
-        auto create_index_result = index->UploadV3({});
+        auto create_index_result = index->UploadUnified({});
         auto index_files = create_index_result->GetIndexFiles();
         milvus::Config load_config;
         load_config["index_files"] = index_files;
         load_config[milvus::LOAD_PRIORITY] =
             milvus::proto::common::LoadPriority::HIGH;
-        copy_index->LoadV3(load_config);
+        copy_index->LoadUnified(load_config);
 
         auto bitset1 = copy_index->NotIn(1, true_test.get());
         ASSERT_TRUE(bitset1.none());
@@ -222,13 +222,13 @@ TEST_F(BoolIndexTest, Codec) {
         index->Build(all_false.data_size(), all_false.data().data());
 
         auto copy_index = milvus::index::CreateBoolIndex(file_manager_ctx);
-        auto create_index_result = index->UploadV3({});
+        auto create_index_result = index->UploadUnified({});
         auto index_files = create_index_result->GetIndexFiles();
         milvus::Config load_config;
         load_config["index_files"] = index_files;
         load_config[milvus::LOAD_PRIORITY] =
             milvus::proto::common::LoadPriority::HIGH;
-        copy_index->LoadV3(load_config);
+        copy_index->LoadUnified(load_config);
 
         auto bitset1 = copy_index->NotIn(1, true_test.get());
         ASSERT_TRUE(bitset1.any());
@@ -243,13 +243,13 @@ TEST_F(BoolIndexTest, Codec) {
         index->Build(half.data_size(), half.data().data());
 
         auto copy_index = milvus::index::CreateBoolIndex(file_manager_ctx);
-        auto create_index_result = index->UploadV3({});
+        auto create_index_result = index->UploadUnified({});
         auto index_files = create_index_result->GetIndexFiles();
         milvus::Config load_config;
         load_config["index_files"] = index_files;
         load_config[milvus::LOAD_PRIORITY] =
             milvus::proto::common::LoadPriority::HIGH;
-        copy_index->LoadV3(load_config);
+        copy_index->LoadUnified(load_config);
 
         auto bitset1 = copy_index->NotIn(1, true_test.get());
         for (size_t i = 0; i < n; i++) {

--- a/internal/core/src/index/HybridScalarIndexTest.cpp
+++ b/internal/core/src/index/HybridScalarIndexTest.cpp
@@ -207,7 +207,7 @@ class HybridIndexTestV1 : public testing::Test {
         ctx.set_for_loading_index(true);
         index_ =
             index::IndexFactory::GetInstance().CreateIndex(index_info, ctx);
-        index_->LoadV3(config);
+        index_->LoadUnified(config);
     }
 
     virtual void

--- a/internal/core/src/index/Index.h
+++ b/internal/core/src/index/Index.h
@@ -65,13 +65,15 @@ class IndexBase {
     Upload(const Config& config = {}) = 0;
 
     virtual void
-    LoadV3(const Config& config) {
-        ThrowInfo(Unsupported, "LoadV3 is not supported for this index type");
+    LoadUnified(const Config& config) {
+        ThrowInfo(Unsupported,
+                  "LoadUnified is not supported for this index type");
     }
 
     virtual IndexStatsPtr
-    UploadV3(const Config& config) {
-        ThrowInfo(Unsupported, "UploadV3 is not supported for this index type");
+    UploadUnified(const Config& config) {
+        ThrowInfo(Unsupported,
+                  "UploadUnified is not supported for this index type");
     }
 
     virtual const bool

--- a/internal/core/src/index/InvertedIndexTest.cpp
+++ b/internal/core/src/index/InvertedIndexTest.cpp
@@ -246,7 +246,7 @@ test_run() {
         ctx.set_for_loading_index(true);
         auto index =
             index::IndexFactory::GetInstance().CreateIndex(index_info, ctx);
-        index->LoadV3(config);
+        index->LoadUnified(config);
 
         auto cnt = index->Count();
         if (has_lack_binlog_row_) {
@@ -642,7 +642,7 @@ test_string() {
         ctx.set_for_loading_index(true);
         auto index =
             index::IndexFactory::GetInstance().CreateIndex(index_info, ctx);
-        index->LoadV3(config);
+        index->LoadUnified(config);
 
         auto cnt = index->Count();
         if (has_lack_binlog_row_) {

--- a/internal/core/src/index/JsonFlatIndexTest.cpp
+++ b/internal/core/src/index/JsonFlatIndexTest.cpp
@@ -166,7 +166,7 @@ class JsonFlatIndexTest : public ::testing::Test {
             auto index = std::make_shared<index::JsonFlatIndex>(*ctx_, "");
             index->Build(config);
 
-            auto create_index_result = index->UploadV3({});
+            auto create_index_result = index->UploadUnified({});
             auto memSize = create_index_result->GetMemSize();
             auto serializedSize = create_index_result->GetSerializedSize();
             ASSERT_GT(memSize, 0);
@@ -186,7 +186,7 @@ class JsonFlatIndexTest : public ::testing::Test {
 
         ctx_->set_for_loading_index(true);
         json_index_ = std::make_shared<index::JsonFlatIndex>(*ctx_, "");
-        json_index_->LoadV3(load_config);
+        json_index_->LoadUnified(load_config);
 
         auto cnt = json_index_->Count();
         ASSERT_EQ(cnt, json_data_.size());

--- a/internal/core/src/index/NgramInvertedIndexTest.cpp
+++ b/internal/core/src/index/NgramInvertedIndexTest.cpp
@@ -177,7 +177,7 @@ test_ngram_with_data(const boost::container::vector<std::string>& data,
             std::make_shared<index::NgramInvertedIndex>(ctx, ngram_params);
         index->Build(config);
 
-        auto create_index_result = index->UploadV3({});
+        auto create_index_result = index->UploadUnified({});
         auto memSize = create_index_result->GetMemSize();
         index_size = create_index_result->GetSerializedSize();
         ASSERT_GT(memSize, 0);
@@ -194,7 +194,7 @@ test_ngram_with_data(const boost::container::vector<std::string>& data,
         auto ngram_params = index::NgramParams{true, 2, 4};
         auto index =
             std::make_unique<index::NgramInvertedIndex>(ctx, ngram_params);
-        index->LoadV3(config);
+        index->LoadUnified(config);
 
         auto cnt = index->Count();
         ASSERT_EQ(cnt, nb);
@@ -501,7 +501,7 @@ TEST(NgramIndex, TestNonLikeExpressionsWithNgram) {
             std::make_shared<index::NgramInvertedIndex>(ctx, ngram_params);
         index->Build(config);
 
-        auto create_index_result = index->UploadV3({});
+        auto create_index_result = index->UploadUnified({});
         index_files = create_index_result->GetIndexFiles();
     }
 
@@ -1654,7 +1654,7 @@ TEST(NgramBenchmark, NgramVsTantivyVsBruteForce) {
         auto index =
             std::make_shared<index::NgramInvertedIndex>(ctx, ngram_params);
         index->Build(config);
-        auto result = index->UploadV3({});
+        auto result = index->UploadUnified({});
         index_files = result->GetIndexFiles();
     }
 
@@ -1667,7 +1667,7 @@ TEST(NgramBenchmark, NgramVsTantivyVsBruteForce) {
         index::NgramParams{.loading_index = true, .min_gram = 2, .max_gram = 4};
     auto ngram_index =
         std::make_unique<index::NgramInvertedIndex>(ctx, load_ngram_params);
-    ngram_index->LoadV3(load_config);
+    ngram_index->LoadUnified(load_config);
 
     // Build Tantivy index for comparison
     std::vector<std::string> data_vec(data.begin(), data.end());
@@ -1935,7 +1935,7 @@ TEST(NgramBenchmark, NgramFilteringEffectiveness) {
         auto index =
             std::make_shared<index::NgramInvertedIndex>(ctx, ngram_params);
         index->Build(config);
-        auto result = index->UploadV3({});
+        auto result = index->UploadUnified({});
         index_files = result->GetIndexFiles();
     }
 
@@ -1947,7 +1947,7 @@ TEST(NgramBenchmark, NgramFilteringEffectiveness) {
         index::NgramParams{.loading_index = true, .min_gram = 2, .max_gram = 4};
     auto ngram_index =
         std::make_unique<index::NgramInvertedIndex>(ctx, load_ngram_params);
-    ngram_index->LoadV3(load_config);
+    ngram_index->LoadUnified(load_config);
 
     std::vector<std::string> data_vec(data.begin(), data.end());
 

--- a/internal/core/src/index/RTreeIndexTest.cpp
+++ b/internal/core/src/index/RTreeIndexTest.cpp
@@ -223,7 +223,7 @@ TEST_F(RTreeIndexTest, Build_Upload_Load) {
     ASSERT_EQ(rtree_build.Count(), 2);
 
     // ---------- Upload ----------
-    auto stats = rtree_build.UploadV3({});
+    auto stats = rtree_build.UploadUnified({});
     ASSERT_NE(stats, nullptr);
     ASSERT_GT(stats->GetIndexFiles().size(), 0);
 
@@ -237,7 +237,7 @@ TEST_F(RTreeIndexTest, Build_Upload_Load) {
     cfg["index_files"] = stats->GetIndexFiles();
 
     milvus::tracer::TraceContext trace_ctx;  // empty context
-    rtree_load.LoadV3(cfg);
+    rtree_load.LoadUnified(cfg);
 
     ASSERT_EQ(rtree_load.Count(), 2);
 }
@@ -252,7 +252,7 @@ TEST_F(RTreeIndexTest, Load_WithFileNamesOnly) {
                                       CreatePointWKB(20.0, 20.0)};
     rtree_build.BuildWithRawDataForUT(wkbs2.size(), wkbs2.data());
 
-    auto stats = rtree_build.UploadV3({});
+    auto stats = rtree_build.UploadUnified({});
 
     // gather only filenames (strip parent path)
     std::vector<std::string> filenames;
@@ -273,7 +273,7 @@ TEST_F(RTreeIndexTest, Load_WithFileNamesOnly) {
     cfg["index_files"] = filenames;  // no directory info
 
     milvus::tracer::TraceContext trace_ctx;
-    rtree_load.LoadV3(cfg);
+    rtree_load.LoadUnified(cfg);
 
     ASSERT_EQ(rtree_load.Count(), 2);
 }
@@ -301,7 +301,7 @@ TEST_F(RTreeIndexTest, Build_WithInvalidWKB_Upload_Load) {
     rtree.BuildWithRawDataForUT(wkbs.size(), wkbs.data());
 
     // Upload and then load back to let loader compute count from wrapper
-    auto stats = rtree.UploadV3({});
+    auto stats = rtree.UploadUnified({});
 
     milvus::storage::FileManagerContext ctx_load(
         field_meta_, index_meta_, chunk_manager_, fs_);
@@ -311,7 +311,7 @@ TEST_F(RTreeIndexTest, Build_WithInvalidWKB_Upload_Load) {
     nlohmann::json cfg;
     cfg["index_files"] = stats->GetIndexFiles();
     milvus::tracer::TraceContext trace_ctx;
-    rtree_load.LoadV3(cfg);
+    rtree_load.LoadUnified(cfg);
 
     // Only 2 valid points should be present
     ASSERT_EQ(rtree_load.Count(), 2);
@@ -332,7 +332,7 @@ TEST_F(RTreeIndexTest, Build_VariousGeometries) {
     rtree.BuildWithRawDataForUT(wkbs.size(), wkbs.data());
     ASSERT_EQ(rtree.Count(), wkbs.size());
 
-    auto stats = rtree.UploadV3({});
+    auto stats = rtree.UploadUnified({});
     ASSERT_FALSE(stats->GetIndexFiles().empty());
 
     milvus::storage::FileManagerContext ctx_load(
@@ -343,7 +343,7 @@ TEST_F(RTreeIndexTest, Build_VariousGeometries) {
     nlohmann::json cfg;
     cfg["index_files"] = stats->GetIndexFiles();
     milvus::tracer::TraceContext trace_ctx;
-    rtree_load.LoadV3(cfg);
+    rtree_load.LoadUnified(cfg);
     ASSERT_EQ(rtree_load.Count(), wkbs.size());
 }
 
@@ -361,7 +361,7 @@ TEST_F(RTreeIndexTest, Build_ConfigAndMetaJson) {
     build_cfg["insert_files"] = std::vector<std::string>{remote_file};
 
     rtree.Build(build_cfg);
-    auto stats = rtree.UploadV3({});
+    auto stats = rtree.UploadUnified({});
 
     // V3 mode: verify upload produced a single packed file and can be loaded
     auto index_files = stats->GetIndexFiles();
@@ -375,7 +375,7 @@ TEST_F(RTreeIndexTest, Build_ConfigAndMetaJson) {
     nlohmann::json cfg;
     cfg["index_files"] = index_files;
     milvus::tracer::TraceContext trace_ctx;
-    rtree_load.LoadV3(cfg);
+    rtree_load.LoadUnified(cfg);
     ASSERT_EQ(rtree_load.Count(), 2);
 }
 
@@ -387,7 +387,7 @@ TEST_F(RTreeIndexTest, Load_MixedFileNamesAndPaths) {
     std::vector<std::string> wkbs = {CreatePointWKB(6.0, 6.0),
                                      CreatePointWKB(7.0, 7.0)};
     rtree.BuildWithRawDataForUT(wkbs.size(), wkbs.data());
-    auto stats = rtree.UploadV3({});
+    auto stats = rtree.UploadUnified({});
 
     // Use full list, but replace one with filename-only
     auto mixed = stats->GetIndexFiles();
@@ -402,7 +402,7 @@ TEST_F(RTreeIndexTest, Load_MixedFileNamesAndPaths) {
     nlohmann::json cfg;
     cfg["index_files"] = mixed;
     milvus::tracer::TraceContext trace_ctx;
-    rtree_load.LoadV3(cfg);
+    rtree_load.LoadUnified(cfg);
     ASSERT_EQ(rtree_load.Count(), wkbs.size());
 }
 
@@ -417,7 +417,7 @@ TEST_F(RTreeIndexTest, Load_NonexistentRemote_ShouldThrow) {
     cfg["index_files"] = std::vector<std::string>{
         (temp_path_.get() / "does_not_exist.bgi_0").string()};
     milvus::tracer::TraceContext trace_ctx;
-    EXPECT_THROW(rtree_load.LoadV3(cfg), milvus::SegcoreError);
+    EXPECT_THROW(rtree_load.LoadUnified(cfg), milvus::SegcoreError);
 }
 
 TEST_F(RTreeIndexTest, Build_EndToEnd_FromInsertFiles) {
@@ -437,7 +437,7 @@ TEST_F(RTreeIndexTest, Build_EndToEnd_FromInsertFiles) {
     rtree.Build(build_cfg);
     ASSERT_EQ(rtree.Count(), wkbs.size());
 
-    auto stats = rtree.UploadV3({});
+    auto stats = rtree.UploadUnified({});
 
     milvus::storage::FileManagerContext ctx_load(
         field_meta_, index_meta_, chunk_manager_, fs_);
@@ -446,7 +446,7 @@ TEST_F(RTreeIndexTest, Build_EndToEnd_FromInsertFiles) {
     nlohmann::json cfg;
     cfg["index_files"] = stats->GetIndexFiles();
     milvus::tracer::TraceContext trace_ctx;
-    rtree_load.LoadV3(cfg);
+    rtree_load.LoadUnified(cfg);
     ASSERT_EQ(rtree_load.Count(), wkbs.size());
 }
 
@@ -478,7 +478,7 @@ TEST_F(RTreeIndexTest, Build_Upload_Load_LargeDataset) {
     ASSERT_EQ(rtree.Count(), static_cast<int64_t>(N));
 
     // Upload index
-    auto stats = rtree.UploadV3({});
+    auto stats = rtree.UploadUnified({});
     ASSERT_GT(stats->GetIndexFiles().size(), 0);
 
     // Load index back and verify
@@ -490,7 +490,7 @@ TEST_F(RTreeIndexTest, Build_Upload_Load_LargeDataset) {
     nlohmann::json cfg_load;
     cfg_load["index_files"] = stats->GetIndexFiles();
     milvus::tracer::TraceContext trace_ctx;
-    rtree_load.LoadV3(cfg_load);
+    rtree_load.LoadUnified(cfg_load);
 
     ASSERT_EQ(rtree_load.Count(), static_cast<int64_t>(N));
 
@@ -533,7 +533,7 @@ TEST_F(RTreeIndexTest, Build_BulkLoad_Nulls_And_BadWKB) {
     ASSERT_EQ(rtree.Count(), 4);
 
     // upload -> load back and verify consistency
-    auto stats = rtree.UploadV3({});
+    auto stats = rtree.UploadUnified({});
     ASSERT_GT(stats->GetIndexFiles().size(), 0);
 
     milvus::storage::FileManagerContext ctx_load(
@@ -545,7 +545,7 @@ TEST_F(RTreeIndexTest, Build_BulkLoad_Nulls_And_BadWKB) {
     cfg["index_files"] = stats->GetIndexFiles();
 
     milvus::tracer::TraceContext trace_ctx;
-    rtree_load.LoadV3(cfg);
+    rtree_load.LoadUnified(cfg);
     ASSERT_EQ(rtree_load.Count(), 4);
 }
 
@@ -568,7 +568,7 @@ TEST_F(RTreeIndexTest, Query_CoarseAndExact_Equals_Intersects_Within) {
     ASSERT_EQ(rtree.Count(), 3);
 
     // Upload and then load into a new index instance for querying
-    auto stats = rtree.UploadV3({});
+    auto stats = rtree.UploadUnified({});
     milvus::storage::FileManagerContext ctx_load(
         field_meta_, index_meta_, chunk_manager_, fs_);
     ctx_load.set_for_loading_index(true);
@@ -576,7 +576,7 @@ TEST_F(RTreeIndexTest, Query_CoarseAndExact_Equals_Intersects_Within) {
     nlohmann::json cfg;
     cfg["index_files"] = stats->GetIndexFiles();
     milvus::tracer::TraceContext trace_ctx;
-    rtree_load.LoadV3(cfg);
+    rtree_load.LoadUnified(cfg);
 
     // Helper to run Query
     auto run_query = [&](::milvus::proto::plan::GISFunctionFilterExpr_GISOp op,
@@ -644,7 +644,7 @@ TEST_F(RTreeIndexTest, Query_Touches_Contains_Crosses_Overlaps) {
     ASSERT_EQ(rtree.Count(), 3);
 
     // Upload and load a new instance for querying
-    auto stats = rtree.UploadV3({});
+    auto stats = rtree.UploadUnified({});
     milvus::storage::FileManagerContext ctx_load(
         field_meta_, index_meta_, chunk_manager_, fs_);
     ctx_load.set_for_loading_index(true);
@@ -652,7 +652,7 @@ TEST_F(RTreeIndexTest, Query_Touches_Contains_Crosses_Overlaps) {
     nlohmann::json cfg;
     cfg["index_files"] = stats->GetIndexFiles();
     milvus::tracer::TraceContext trace_ctx;
-    rtree_load.LoadV3(cfg);
+    rtree_load.LoadUnified(cfg);
 
     auto run_query = [&](::milvus::proto::plan::GISFunctionFilterExpr_GISOp op,
                          const std::string& wkt) {
@@ -776,7 +776,7 @@ TEST_F(RTreeIndexTest, GIS_Index_Exact_Filtering) {
     build_cfg["index_type"] = milvus::index::RTREE_INDEX_TYPE;
 
     rtree_index->Build(build_cfg);
-    auto stats = rtree_index->UploadV3({});
+    auto stats = rtree_index->UploadUnified({});
 
     // load geometry index into sealed segment
     milvus::segcore::LoadIndexInfo info{};
@@ -795,7 +795,7 @@ TEST_F(RTreeIndexTest, GIS_Index_Exact_Filtering) {
     nlohmann::json cfg_load;
     cfg_load["index_files"] = stats->GetIndexFiles();
     milvus::tracer::TraceContext trace_ctx_load;
-    rtree_index->LoadV3(cfg_load);
+    rtree_index->LoadUnified(cfg_load);
 
     info.cache_index =
         CreateTestCacheIndex("rtree_index_key", std::move(rtree_index));

--- a/internal/core/src/index/ScalarIndex.cpp
+++ b/internal/core/src/index/ScalarIndex.cpp
@@ -164,11 +164,15 @@ ScalarIndex<double>::BuildWithRawDataForUT(size_t n,
 
 template <typename T>
 IndexStatsPtr
-ScalarIndex<T>::UploadV3(const Config& config) {
-    AssertInfo(file_manager_ != nullptr,
-               "file_manager_ is null, UploadV3 requires a valid file manager");
+ScalarIndex<T>::UploadUnified(const Config& config) {
+    AssertInfo(
+        file_manager_ != nullptr,
+        "file_manager_ is null, UploadUnified requires a valid file manager");
 
     // Build filename: milvus_packed_<type>_index.v3
+    // The ".v3" suffix encodes the on-disk file format version (matches
+    // MILVUS_V3_FORMAT_VERSION in IndexEntryWriter.h), not the scalar index
+    // engine version. See pkg/common/common.go for the distinction.
     auto type_str = ToString(GetIndexType());
     std::transform(
         type_str.begin(), type_str.end(), type_str.begin(), ::tolower);
@@ -176,7 +180,7 @@ ScalarIndex<T>::UploadV3(const Config& config) {
 
     // Create the IndexEntryWriter
     auto writer =
-        file_manager_->CreateIndexEntryWriterV3(filename, is_index_file_);
+        file_manager_->CreateIndexEntryWriterUnified(filename, is_index_file_);
     AssertInfo(writer != nullptr,
                "failed to create IndexEntryWriter for V3 format");
 
@@ -190,7 +194,7 @@ ScalarIndex<T>::UploadV3(const Config& config) {
     // Get actual file size from writer
     auto file_size = writer->GetTotalBytesWritten();
 
-    LOG_INFO("UploadV3 completed for index type: {}, file size: {}",
+    LOG_INFO("UploadUnified completed for index type: {}, file size: {}",
              index_type_,
              file_size);
 
@@ -207,23 +211,24 @@ ScalarIndex<T>::UploadV3(const Config& config) {
 
 template <typename T>
 void
-ScalarIndex<T>::LoadV3(const Config& config) {
-    AssertInfo(file_manager_ != nullptr,
-               "file_manager_ is null, LoadV3 requires a valid file manager");
+ScalarIndex<T>::LoadUnified(const Config& config) {
+    AssertInfo(
+        file_manager_ != nullptr,
+        "file_manager_ is null, LoadUnified requires a valid file manager");
 
     // Get the packed index file path from config
     auto index_files =
         GetValueFromConfig<std::vector<std::string>>(config, INDEX_FILES);
     AssertInfo(index_files.has_value() && !index_files.value().empty(),
-               "index_files is required for LoadV3");
+               "index_files is required for LoadUnified");
 
     // For V3 format, there should be exactly one packed file
     AssertInfo(index_files.value().size() == 1,
-               "LoadV3 expects exactly one packed index file, got: {}",
+               "LoadUnified expects exactly one packed index file, got: {}",
                index_files.value().size());
     const auto& packed_file = index_files.value()[0];
 
-    LOG_INFO("LoadV3: loading packed index file: {}", packed_file);
+    LOG_INFO("LoadUnified: loading packed index file: {}", packed_file);
 
     // Open the file using the file manager
     auto input = file_manager_->OpenInputStream(packed_file, is_index_file_);
@@ -242,7 +247,7 @@ ScalarIndex<T>::LoadV3(const Config& config) {
 
     LoadEntries(*reader, config);
 
-    LOG_INFO("LoadV3 completed for index type: {}", index_type_);
+    LOG_INFO("LoadUnified completed for index type: {}", index_type_);
 }
 
 template class ScalarIndex<bool>;

--- a/internal/core/src/index/ScalarIndex.h
+++ b/internal/core/src/index/ScalarIndex.h
@@ -231,14 +231,20 @@ class ScalarIndex : public IndexBase {
         ThrowInfo(Unsupported, "LoadWithoutAssemble is not supported");
     }
 
-    // V3 streaming upload - subclasses must implement WriteEntries() instead
+    // Packed single-file streaming upload — subclasses must implement
+    // WriteEntries() instead. The current on-disk file format is V3
+    // (see MILVUS_V3_FORMAT_VERSION in IndexEntryWriter.h, and the ".v3"
+    // filename suffix produced by the implementation); the method name is
+    // kept format-agnostic so future format versions can reuse this entry
+    // point and dispatch by reading the file header.
     IndexStatsPtr
-    UploadV3(const Config& config) override;
+    UploadUnified(const Config& config) override;
 
-    // V3 streaming load - loads index from a packed V3 format file
-    // Opens the file and calls LoadEntries() for subclass-specific loading
+    // Packed single-file streaming load — opens the file and calls
+    // LoadEntries() for subclass-specific loading. Currently handles the V3
+    // file format (see UploadUnified above for naming rationale).
     void
-    LoadV3(const Config& config) override;
+    LoadUnified(const Config& config) override;
 
     virtual void
     WriteEntries(storage::IndexEntryWriter* writer) {

--- a/internal/core/src/index/ScalarIndexSortTest.cpp
+++ b/internal/core/src/index/ScalarIndexSortTest.cpp
@@ -60,7 +60,7 @@ test_stlsort_for_range(
             CreateScalarSortTestFileManagerContext());
         index->Build(nb, data.data());
 
-        auto create_index_result = index->UploadV3({});
+        auto create_index_result = index->UploadUnified({});
         index_files = create_index_result->GetIndexFiles();
     }
     {
@@ -72,7 +72,7 @@ test_stlsort_for_range(
 
         auto index = std::make_shared<index::ScalarIndexSort<int64_t>>(
             CreateScalarSortTestFileManagerContext());
-        index->LoadV3(config);
+        index->LoadUnified(config);
 
         auto cnt = index->Count();
         ASSERT_EQ(cnt, nb);

--- a/internal/core/src/index/ScalarIndexTest.cpp
+++ b/internal/core/src/index/ScalarIndexTest.cpp
@@ -241,7 +241,7 @@ TYPED_TEST_P(TypedScalarIndexTest, Codec) {
         auto arr = GenSortedArr<T>(nb);
         scalar_index->Build(nb, arr.data());
 
-        auto create_index_result = index->UploadV3({});
+        auto create_index_result = index->UploadUnified({});
         auto index_files = create_index_result->GetIndexFiles();
         auto copy_index =
             milvus::index::IndexFactory::GetInstance().CreateScalarIndex(
@@ -250,7 +250,7 @@ TYPED_TEST_P(TypedScalarIndexTest, Codec) {
         load_config["index_files"] = index_files;
         load_config[milvus::LOAD_PRIORITY] =
             milvus::proto::common::LoadPriority::HIGH;
-        copy_index->LoadV3(load_config);
+        copy_index->LoadUnified(load_config);
 
         auto copy_scalar_index =
             dynamic_cast<milvus::index::ScalarIndex<T>*>(copy_index.get());

--- a/internal/core/src/index/StringIndexTest.cpp
+++ b/internal/core/src/index/StringIndexTest.cpp
@@ -356,13 +356,13 @@ TEST_F(StringIndexMarisaTest, Codec) {
     auto copy_index = milvus::index::CreateStringIndexMarisa(file_manager_ctx);
 
     {
-        auto create_index_result = index->UploadV3({});
+        auto create_index_result = index->UploadUnified({});
         auto index_files = create_index_result->GetIndexFiles();
         Config load_config;
         load_config["index_files"] = index_files;
         load_config[milvus::LOAD_PRIORITY] =
             milvus::proto::common::LoadPriority::HIGH;
-        copy_index->LoadV3(load_config);
+        copy_index->LoadUnified(load_config);
     }
 
     {
@@ -440,13 +440,13 @@ TEST_F(StringIndexMarisaTest, BaseIndexCodec) {
     auto copy_index = milvus::index::CreateStringIndexMarisa(file_manager_ctx);
 
     {
-        auto create_index_result = index->UploadV3({});
+        auto create_index_result = index->UploadUnified({});
         auto index_files = create_index_result->GetIndexFiles();
         Config load_config;
         load_config["index_files"] = index_files;
         load_config[milvus::LOAD_PRIORITY] =
             milvus::proto::common::LoadPriority::HIGH;
-        copy_index->LoadV3(load_config);
+        copy_index->LoadUnified(load_config);
     }
 
     {

--- a/internal/core/src/index/TextMatchIndex.cpp
+++ b/internal/core/src/index/TextMatchIndex.cpp
@@ -164,7 +164,7 @@ TextMatchIndex::Load(const Config& config) {
         if (filename.size() > 3 &&
             filename.substr(filename.size() - 3) == ".v3") {
             LOG_INFO("TextMatchIndex::Load V3 format detected: {}", file);
-            InvertedIndexTantivy<std::string>::LoadV3(config);
+            InvertedIndexTantivy<std::string>::LoadUnified(config);
             return;
         }
     }

--- a/internal/core/src/indexbuilder/ScalarIndexCreator.cpp
+++ b/internal/core/src/indexbuilder/ScalarIndexCreator.cpp
@@ -136,7 +136,7 @@ ScalarIndexCreator::Upload() {
                        config_, index::SCALAR_INDEX_ENGINE_VERSION)
                        .value_or(1);
     if (version >= 3) {
-        return index_->UploadV3(config_);
+        return index_->UploadUnified(config_);
     }
     return index_->Upload(config_);
 }

--- a/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
@@ -158,7 +158,7 @@ SealedIndexTranslator::get_cells(milvus::OpContext* ctx,
         config_[milvus::index::COLLECTION_ID] =
             file_manager_context_.fieldDataMeta.collection_id;
         LOG_INFO("load V3 scalar index with configs: {}", config_.dump());
-        index->LoadV3(config_);
+        index->LoadUnified(config_);
     } else {
         LOG_INFO("load index with configs: {}", config_.dump());
         index->Load(ctx_, config_);

--- a/internal/core/src/storage/DiskFileManagerTest.cpp
+++ b/internal/core/src/storage/DiskFileManagerTest.cpp
@@ -281,7 +281,7 @@ TEST_F(DiskAnnFileManagerTest, V3PackedIndexPathMismatch) {
     std::vector<int64_t> values = {1, 2, 3};
     index.Build(values.size(), values.data());
 
-    auto stats = index.UploadV3({});
+    auto stats = index.UploadUnified({});
     auto files = stats->GetIndexFiles();
     ASSERT_EQ(files.size(), 1);
 
@@ -1062,7 +1062,7 @@ TEST_F(DiskAnnFileManagerTest, ScalarIndexSortV3Roundtrip) {
     build_index.Build(N, values.data());
     ASSERT_EQ(build_index.Count(), static_cast<int64_t>(N));
 
-    auto stats = build_index.UploadV3({});
+    auto stats = build_index.UploadUnified({});
     ASSERT_NE(stats, nullptr);
     auto files = stats->GetIndexFiles();
     ASSERT_EQ(files.size(), 1);
@@ -1072,7 +1072,7 @@ TEST_F(DiskAnnFileManagerTest, ScalarIndexSortV3Roundtrip) {
     load_config[milvus::index::INDEX_FILES] =
         std::vector<std::string>{files[0]};
     load_config[milvus::index::ENABLE_MMAP] = false;
-    load_index.LoadV3(load_config);
+    load_index.LoadUnified(load_config);
 
     EXPECT_EQ(load_index.Count(), static_cast<int64_t>(N));
 
@@ -1124,7 +1124,7 @@ TEST_F(DiskAnnFileManagerTest, BitmapIndexV3Roundtrip) {
     build_index.Build(N, values.data());
     ASSERT_EQ(build_index.Count(), static_cast<int64_t>(N));
 
-    auto stats = build_index.UploadV3({});
+    auto stats = build_index.UploadUnified({});
     ASSERT_NE(stats, nullptr);
     auto files = stats->GetIndexFiles();
     ASSERT_EQ(files.size(), 1);
@@ -1134,7 +1134,7 @@ TEST_F(DiskAnnFileManagerTest, BitmapIndexV3Roundtrip) {
     load_config[milvus::index::INDEX_FILES] =
         std::vector<std::string>{files[0]};
     load_config[milvus::index::ENABLE_MMAP] = false;
-    load_index.LoadV3(load_config);
+    load_index.LoadUnified(load_config);
 
     EXPECT_EQ(load_index.Count(), static_cast<int64_t>(N));
 
@@ -1168,7 +1168,7 @@ TEST_F(DiskAnnFileManagerTest, StringIndexMarisaV3Roundtrip) {
     build_index.Build(N, values.data());
     ASSERT_EQ(build_index.Count(), static_cast<int64_t>(N));
 
-    auto stats = build_index.UploadV3({});
+    auto stats = build_index.UploadUnified({});
     ASSERT_NE(stats, nullptr);
     auto files = stats->GetIndexFiles();
     ASSERT_EQ(files.size(), 1);
@@ -1178,7 +1178,7 @@ TEST_F(DiskAnnFileManagerTest, StringIndexMarisaV3Roundtrip) {
     load_config[milvus::index::INDEX_FILES] =
         std::vector<std::string>{files[0]};
     load_config[milvus::index::ENABLE_MMAP] = false;
-    load_index.LoadV3(load_config);
+    load_index.LoadUnified(load_config);
 
     EXPECT_EQ(load_index.Count(), static_cast<int64_t>(N));
 
@@ -1210,7 +1210,7 @@ TEST_F(DiskAnnFileManagerTest, StringIndexSortV3Roundtrip) {
     build_index.Build(N, values.data());
     ASSERT_EQ(build_index.Count(), static_cast<int64_t>(N));
 
-    auto stats = build_index.UploadV3({});
+    auto stats = build_index.UploadUnified({});
     ASSERT_NE(stats, nullptr);
     auto files = stats->GetIndexFiles();
     ASSERT_EQ(files.size(), 1);
@@ -1220,7 +1220,7 @@ TEST_F(DiskAnnFileManagerTest, StringIndexSortV3Roundtrip) {
     load_config[milvus::index::INDEX_FILES] =
         std::vector<std::string>{files[0]};
     load_config[milvus::index::ENABLE_MMAP] = false;
-    load_index.LoadV3(load_config);
+    load_index.LoadUnified(load_config);
 
     EXPECT_EQ(load_index.Count(), static_cast<int64_t>(N));
 

--- a/internal/core/src/storage/FileManager.h
+++ b/internal/core/src/storage/FileManager.h
@@ -234,8 +234,8 @@ class FileManagerImpl : public milvus::FileManager {
     }
 
     std::unique_ptr<IndexEntryWriter>
-    CreateIndexEntryWriterV3(const std::string& filename,
-                             bool is_index_file = true) {
+    CreateIndexEntryWriterUnified(const std::string& filename,
+                                  bool is_index_file = true) {
         if (plugin_context_) {
             auto cipher_plugin = PluginLoader::GetInstance().getCipherPlugin();
             if (cipher_plugin) {

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -100,6 +100,21 @@ const (
 )
 
 const (
+	// Scalar index engine version tracks the *capability* of a Milvus node
+	// (which index types / features it supports). It is reported by QueryNodes
+	// in their session and aggregated by datacoord so that newly built indexes
+	// are clamped to a version every node in the cluster can load — this is
+	// what makes rolling upgrades safe.
+	//
+	// Engine version is distinct from the on-disk file format version
+	// (see MILVUS_V3_FORMAT_VERSION in IndexEntryWriter.h). Multiple engine
+	// versions can share the same file format; bumping the engine version
+	// does not necessarily imply a format change.
+	//
+	// Scalar index engine version 3:
+	// - Packed single-file index layout (file format v3) becomes the default
+	// - HYBRID/AUTOINDEX high-cardinality scalar indexes switched from
+	//   INVERTED to STL_SORT
 	MinimalScalarIndexEngineVersion = int32(0)
 	CurrentScalarIndexEngineVersion = int32(3)
 	MaximumScalarIndexEngineVersion = int32(3)


### PR DESCRIPTION
rename LoadV3/UploadV3 to LoadUnified/UploadUnified

Engine version (CurrentScalarIndexEngineVersion) tracks a node's feature capability and is what gets aggregated across the cluster for rolling- upgrade safety. File format version (MILVUS_V3_FORMAT_VERSION in IndexEntryWriter.h, matched by the on-disk ".v3" filename suffix) tracks the on-disk layout. These are deliberately independent concepts: an engine version bump does not necessarily imply a format change.

- pkg/common/common.go: add a comment block above the engine version constants explaining the distinction and the specific meaning of engine version 3.
- Rename LoadV3 / UploadV3 / CreateIndexEntryWriterV3 to LoadUnified / UploadUnified / CreateIndexEntryWriterUnified. These methods are the format-agnostic packed-file entry points; keeping "V3" in the name would wrongly suggest they are tied to the V3 on-disk format only. Future file format versions can dispatch from the same entry point by reading the file header.

issue: https://github.com/milvus-io/milvus/issues/47417