### PR TITLE
fix: [3.0] preserve wildcard privilege in RBAC backup/restore

### DIFF
--- a/internal/metastore/kv/rootcoord/kv_catalog.go
+++ b/internal/metastore/kv/rootcoord/kv_catalog.go
@@ -1755,9 +1755,11 @@ func (kc *Catalog) RestoreRBAC(ctx context.Context, tenant string, meta *milvusp
 
 	for _, grant := range meta.GetGrants() {
 		privName := grant.GetGrantor().GetPrivilege().GetName()
-		if util.IsPrivilegeNameDefined(privName) {
+		switch {
+		case util.IsAnyWord(privName):
+		case util.IsPrivilegeNameDefined(privName):
 			grant.Grantor.Privilege.Name = util.PrivilegeNameForMetastore(privName)
-		} else {
+		default:
 			grant.Grantor.Privilege.Name = util.PrivilegeGroupNameForMetastore(privName)
 		}
 		if err := kc.AlterGrant(ctx, tenant, grant, milvuspb.OperatePrivilegeType_Grant); err != nil {

--- a/internal/metastore/kv/rootcoord/kv_catalog_test.go
+++ b/internal/metastore/kv/rootcoord/kv_catalog_test.go
@@ -2972,6 +2972,59 @@ func TestRBAC_Restore(t *testing.T) {
 	assert.Len(t, privGroups, 2)
 }
 
+func TestRBAC_Restore_Wildcard(t *testing.T) {
+	etcdCli, _ := etcd.GetEtcdClient(
+		Params.EtcdCfg.UseEmbedEtcd.GetAsBool(),
+		Params.EtcdCfg.EtcdUseSSL.GetAsBool(),
+		Params.EtcdCfg.Endpoints.GetAsStrings(),
+		Params.EtcdCfg.EtcdTLSCert.GetValue(),
+		Params.EtcdCfg.EtcdTLSKey.GetValue(),
+		Params.EtcdCfg.EtcdTLSCACert.GetValue(),
+		Params.EtcdCfg.EtcdTLSMinVersion.GetValue())
+	rootPath := "/test/rbac/wildcard"
+	metaKV := etcdkv.NewEtcdKV(etcdCli, rootPath)
+	defer metaKV.RemoveWithPrefix(context.TODO(), "")
+	defer metaKV.Close()
+	c := NewCatalog(metaKV, nil)
+
+	ctx := context.Background()
+
+	wildcardGrant := &milvuspb.GrantEntity{
+		Role:       &milvuspb.RoleEntity{Name: "wildcard_role"},
+		Object:     &milvuspb.ObjectEntity{Name: commonpb.ObjectType_Global.String()},
+		ObjectName: util.AnyWord,
+		DbName:     util.AnyWord,
+		Grantor: &milvuspb.GrantorEntity{
+			User:      &milvuspb.UserEntity{Name: util.UserRoot},
+			Privilege: &milvuspb.PrivilegeEntity{Name: util.AnyWord},
+		},
+	}
+
+	require.NoError(t, c.CreateRole(ctx, util.DefaultTenant, &milvuspb.RoleEntity{Name: "wildcard_role"}))
+	require.NoError(t, c.AlterGrant(ctx, util.DefaultTenant, wildcardGrant, milvuspb.OperatePrivilegeType_Grant))
+	expectedIDKeys, _, err := metaKV.LoadWithPrefix(ctx, GranteeIDPrefix)
+	require.NoError(t, err)
+	require.Len(t, expectedIDKeys, 1)
+	require.True(t, strings.HasSuffix(expectedIDKeys[0], "/"+util.AnyWord),
+		"OperatePrivilege baseline should store wildcard as '/*', got %q", expectedIDKeys[0])
+
+	require.NoError(t, metaKV.RemoveWithPrefix(ctx, ""))
+
+	rbacMeta := &milvuspb.RBACMeta{
+		Roles:  []*milvuspb.RoleEntity{{Name: "wildcard_role"}},
+		Grants: []*milvuspb.GrantEntity{wildcardGrant},
+	}
+	require.NoError(t, c.RestoreRBAC(ctx, util.DefaultTenant, rbacMeta))
+
+	restoredIDKeys, _, err := metaKV.LoadWithPrefix(ctx, GranteeIDPrefix)
+	require.NoError(t, err)
+	require.Len(t, restoredIDKeys, 1)
+	assert.True(t, strings.HasSuffix(restoredIDKeys[0], "/"+util.AnyWord),
+		"RestoreRBAC must persist wildcard as '/*', got %q", restoredIDKeys[0])
+	assert.False(t, strings.Contains(restoredIDKeys[0], util.PrivilegeGroupWord+util.AnyWord),
+		"RestoreRBAC must not encode wildcard as 'PrivilegeGroup*', got %q", restoredIDKeys[0])
+}
+
 func TestRBAC_PrivilegeGroup(t *testing.T) {
 	ctx := context.TODO()
 	group1 := "group1"

--- a/internal/rootcoord/meta_table.go
+++ b/internal/rootcoord/meta_table.go
@@ -2014,6 +2014,9 @@ func (mt *MetaTable) CheckIfRBACRestorable(ctx context.Context, req *milvuspb.Re
 	// check if grant can be restored
 	for _, grant := range meta.GetGrants() {
 		privName := grant.GetGrantor().GetPrivilege().GetName()
+		if util.IsAnyWord(privName) {
+			continue
+		}
 		if _, ok := existPrivGroupAfterRestoreMap[privName]; !ok && !util.IsPrivilegeNameDefined(privName) {
 			return errors.Newf("privilege [%s] does not exist", privName)
 		}

--- a/internal/rootcoord/meta_table_test.go
+++ b/internal/rootcoord/meta_table_test.go
@@ -2456,6 +2456,44 @@ func TestMetaTable_RestoreRBAC(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestMetaTable_CheckIfRBACRestorable_Wildcard(t *testing.T) {
+	catalog := mocks.NewRootCoordCatalog(t)
+	catalog.EXPECT().ListRole(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
+	catalog.EXPECT().ListPrivilegeGroups(mock.Anything).
+		Return(nil, nil)
+	catalog.EXPECT().ListUser(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
+
+	mt := &MetaTable{
+		dbName2Meta: map[string]*model.Database{
+			"not_commit": model.NewDatabase(1, "not_commit", pb.DatabaseState_DatabaseCreated, nil),
+		},
+		names:   newNameDb(),
+		aliases: newNameDb(),
+		catalog: catalog,
+	}
+
+	req := &milvuspb.RestoreRBACMetaRequest{
+		RBACMeta: &milvuspb.RBACMeta{
+			Roles: []*milvuspb.RoleEntity{{Name: "wildcard_role"}},
+			Grants: []*milvuspb.GrantEntity{
+				{
+					Role:       &milvuspb.RoleEntity{Name: "wildcard_role"},
+					Object:     &milvuspb.ObjectEntity{Name: commonpb.ObjectType_Global.String()},
+					ObjectName: util.AnyWord,
+					DbName:     util.AnyWord,
+					Grantor: &milvuspb.GrantorEntity{
+						User:      &milvuspb.UserEntity{Name: util.UserRoot},
+						Privilege: &milvuspb.PrivilegeEntity{Name: util.AnyWord},
+					},
+				},
+			},
+		},
+	}
+	assert.NoError(t, mt.CheckIfRBACRestorable(context.TODO(), req))
+}
+
 func TestMetaTable_PrivilegeGroup(t *testing.T) {
 	catalog := mocks.NewRootCoordCatalog(t)
 	catalog.EXPECT().ListPrivilegeGroups(mock.Anything).Return([]*milvuspb.PrivilegeGroupInfo{


### PR DESCRIPTION
- Catalog.RestoreRBAC routed IsAnyWord through the IsPrivilegeNameDefined /else branches and ended up calling PrivilegeGroupNameForMetastore("*"), writing 'grantee-id/<id>/PrivilegeGroup*'.
- MetaTable.CheckIfRBACRestorable rejected wildcard grants with 'privilege [*] does not exist' before broadcastRestoreRBACV2 ever reached the catalog, so the catalog fix alone was unreachable on the in-process restore path.

issue: https://github.com/milvus-io/milvus/issues/48963
pr: https://github.com/milvus-io/milvus/pull/48978