### PR TITLE
fix: [3.0] Clear unselected segment results in RefreshSearchResults to avoid unnecessary FillEntryData

### DIFF
--- a/internal/core/src/segcore/reduce/Reduce.cpp
+++ b/internal/core/src/segcore/reduce/Reduce.cpp
@@ -324,9 +324,7 @@ ReduceHelper::RefreshSearchResults() {
     for (int i = 0; i < num_segments_; i++) {
         std::vector<int64_t> real_topks(total_nq_, 0);
         auto search_result = search_results_[i];
-        if (search_result->result_offsets_.size() != 0) {
-            RefreshSingleSearchResult(search_result, i, real_topks);
-        }
+        RefreshSingleSearchResult(search_result, i, real_topks);
         std::partial_sum(real_topks.begin(),
                          real_topks.end(),
                          search_result->topk_per_nq_prefix_sum_.begin() + 1);

--- a/internal/core/src/segcore/reduce_c_test.cpp
+++ b/internal/core/src/segcore/reduce_c_test.cpp
@@ -410,6 +410,114 @@ TEST(CApiTest, ReduceSearchWithExpr) {
     testReduceSearchWithExpr<milvus::Int8Vector>(100, 10, 10);
 }
 
+// Test that after reduce with multiple segments, unselected segments
+// have their distances_/seg_offsets_ cleared (resized to 0).
+// This prevents unnecessary FillTargetEntry calls on unselected segments,
+// which is critical for external tables where each fill triggers S3 reads.
+TEST(CApiTest, ReduceRefreshClearsUnselectedSegments) {
+    int num_segments = 5;
+    int N = 100;
+    int num_queries = 1;
+    int topK = 1;
+
+    auto schema_config = get_default_schema_config();
+    auto collection = NewCollection(schema_config.c_str());
+    auto schema = ((milvus::segcore::Collection*)collection)->get_schema();
+
+    // Create multiple segments and search each
+    std::vector<CSegmentInterface> segments(num_segments);
+    std::vector<CSearchResult> results(num_segments);
+
+    milvus::segcore::ScopedSchemaHandle schema_handle(*schema);
+    auto binary_plan = schema_handle.ParseSearch(
+        "", "fakevec", topK, "L2", R"({"nprobe": 10})");
+
+    void* plan = nullptr;
+    auto status = CreateSearchPlanByExpr(
+        collection, binary_plan.data(), binary_plan.size(), &plan);
+    ASSERT_EQ(status.error_code, Success);
+
+    auto blob = generate_query_data<milvus::FloatVector>(num_queries);
+    void* placeholderGroup = nullptr;
+    status = ParsePlaceholderGroup(
+        plan, blob.data(), blob.length(), &placeholderGroup);
+    ASSERT_EQ(status.error_code, Success);
+
+    for (int i = 0; i < num_segments; i++) {
+        status = NewSegment(collection, Growing, -1, &segments[i], false);
+        ASSERT_EQ(status.error_code, Success);
+
+        // Use different seed per segment to get different data/distances
+        auto dataset = DataGen(schema, N, /*seed=*/42 + i);
+        int64_t offset;
+        PreInsert(segments[i], N, &offset);
+        auto insert_data = serialize(dataset.raw_);
+        status = Insert(segments[i],
+                        offset,
+                        N,
+                        dataset.row_ids_.data(),
+                        dataset.timestamps_.data(),
+                        insert_data.data(),
+                        insert_data.size());
+        ASSERT_EQ(status.error_code, Success);
+
+        status = CSearch(
+            segments[i], plan, placeholderGroup, MAX_TIMESTAMP, &results[i]);
+        ASSERT_EQ(status.error_code, Success);
+    }
+
+    // Reduce: global topk=1 across 5 segments
+    auto slice_nqs = std::vector<int64_t>{num_queries};
+    auto slice_topKs = std::vector<int64_t>{topK};
+    CSearchResultDataBlobs cSearchResultData;
+    status = ReduceSearchResultsAndFillData({},
+                                            &cSearchResultData,
+                                            plan,
+                                            results.data(),
+                                            results.size(),
+                                            slice_nqs.data(),
+                                            slice_topKs.data(),
+                                            slice_nqs.size());
+    ASSERT_EQ(status.error_code, Success);
+
+    // Verify: after reduce, only selected segments should have non-empty
+    // distances_. Unselected segments must have distances_.size() == 0
+    // so that FillEntryData skips them (avoiding unnecessary I/O).
+    int selected_count = 0;
+    int unselected_count = 0;
+    for (int i = 0; i < num_segments; i++) {
+        auto* sr = (SearchResult*)results[i];
+        if (sr->result_offsets_.size() > 0) {
+            // Selected segment: should have exactly topK results
+            EXPECT_EQ(sr->distances_.size(), topK)
+                << "Selected segment " << i << " should have topK distances";
+            selected_count++;
+        } else {
+            // Unselected segment: distances_ must be cleared to 0
+            EXPECT_EQ(sr->distances_.size(), 0)
+                << "Unselected segment " << i
+                << " should have empty distances after refresh";
+            EXPECT_EQ(sr->seg_offsets_.size(), 0)
+                << "Unselected segment " << i
+                << " should have empty seg_offsets after refresh";
+            unselected_count++;
+        }
+    }
+    // With topk=1 and nq=1, exactly 1 segment should be selected
+    EXPECT_EQ(selected_count, 1);
+    EXPECT_EQ(unselected_count, num_segments - 1);
+
+    // Cleanup
+    DeleteSearchResultDataBlobs(cSearchResultData);
+    DeleteSearchPlan(plan);
+    DeletePlaceholderGroup(placeholderGroup);
+    for (int i = 0; i < num_segments; i++) {
+        DeleteSearchResult(results[i]);
+        DeleteSegment(segments[i]);
+    }
+    DeleteCollection(collection);
+}
+
 TEST(CApiTest, ReduceSearchWithExprFilterAll) {
     // float32
     testReduceSearchWithExpr<milvus::FloatVector>(2, 1, 1, true);


### PR DESCRIPTION
issue: #48945
pr: #48946

Cherry-pick of #48946 to 3.0 branch.

## Summary
Clear unselected segment results in `RefreshSearchResults` to avoid unnecessary `FillEntryData` calls on segments whose results won't be used.

Signed-off-by: Wei Liu <wei.liu@zilliz.com>