### PR TITLE
fix: [cp2.6] skip running scalar index when segment was compacted

### DIFF
--- a/internal/datacoord/index_meta.go
+++ b/internal/datacoord/index_meta.go
@@ -920,6 +920,7 @@ func (m *indexMeta) UpdateIndexState(buildID UniqueID, state commonpb.IndexState
 
 	segIdx, ok := m.segmentBuildInfo.Get(buildID)
 	if !ok {
+		log.Ctx(m.ctx).Warn("there is no index with buildID", zap.Int64("buildID", buildID))
 		return fmt.Errorf("there is no index with buildID: %d", buildID)
 	}
 
@@ -930,6 +931,7 @@ func (m *indexMeta) UpdateIndexState(buildID UniqueID, state commonpb.IndexState
 	}
 
 	if err := m.updateSegIndexMeta(segIdx, updateFunc); err != nil {
+		log.Ctx(m.ctx).Warn("failed to update index meta", zap.Int64("buildID", buildID), zap.Error(err))
 		return err
 	}
 

--- a/internal/datacoord/task/global_scheduler.go
+++ b/internal/datacoord/task/global_scheduler.go
@@ -214,6 +214,8 @@ func (s *globalTaskScheduler) check() {
 			defer s.mu.RUnlock(task.GetTaskID())
 			task.QueryTaskOnWorker(s.cluster)
 			switch task.GetTaskState() {
+			case taskcommon.None:
+				s.runningTasks.Remove(task.GetTaskID())
 			case taskcommon.Init, taskcommon.Retry:
 				s.runningTasks.Remove(task.GetTaskID())
 				s.pendingTasks.Push(task)

--- a/internal/datacoord/task_index.go
+++ b/internal/datacoord/task_index.go
@@ -360,6 +360,17 @@ func (it *indexBuildTask) prepareOptionalFields(ctx context.Context, collectionI
 func (it *indexBuildTask) QueryTaskOnWorker(cluster session.Cluster) {
 	log := log.Ctx(context.TODO()).With(zap.Int64("taskID", it.BuildID), zap.Int64("segmentID", it.SegmentID), zap.Int64("nodeID", it.NodeID))
 
+	// Check if task exists in meta
+	segIndex, exist := it.meta.indexMeta.GetIndexJob(it.BuildID)
+	if !exist || segIndex == nil {
+		log.Info("index task has not exist in meta table, removing task")
+		if it.tryDropTaskOnWorker(cluster) != nil {
+			return
+		}
+		it.SetState(indexpb.JobState_JobStateNone, "index task has not exist in meta table")
+		return
+	}
+
 	results, err := cluster.QueryIndex(it.NodeID, &workerpb.QueryJobsRequest{
 		ClusterID: Params.CommonCfg.ClusterPrefix.GetValue(),
 		TaskIDs:   []UniqueID{it.BuildID},


### PR DESCRIPTION
## Summary
- Cherry-pick fix commit `222542794e6f201221d9f84664b469e012e07b40` for issue #48922.
- Skip running scalar index when segment was compacted/dropped to avoid meaningless repeated logs.
- Updated files: `internal/datacoord/index_meta.go`, `internal/datacoord/task/global_scheduler.go`, `internal/datacoord/task_index.go`.

## Test plan
- [x] Validate cherry-pick applies cleanly on latest `zilliz/2.6`.
- [ ] Run `go test -tags dynamic,test -gcflags=\"all=-N -l\" -count=1 ./internal/datacoord/...` in CI or a fully provisioned Milvus dev env.

issue: #48922
pr: #44690

🤖 Generated with [Claude Code](https://claude.ai/claude-code)