### PR TITLE
fix: prevent V1 deltalog path reconstruction for V3 manifest segments

### DIFF
--- a/internal/compaction/common.go
+++ b/internal/compaction/common.go
@@ -21,11 +21,11 @@ import (
 	"io"
 
 	"github.com/apache/arrow/go/v17/arrow/array"
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
@@ -68,7 +68,16 @@ func readFromSegment(
 	option ...storage.RwOption,
 ) ([]storage.PrimaryKey, []typeutil.Timestamp, error) {
 	if segment.GetManifest() != "" {
-		return readDeltalogsV2(ctx, pkType, segment.GetManifest(), option...)
+		storageConfig := storage.GetStorageConfig(option...)
+		paths, err := packed.GetDeltaLogPathsFromManifest(segment.GetManifest(), storageConfig)
+		if err != nil {
+			return nil, nil, err
+		}
+		if len(paths) == 0 {
+			log.Ctx(ctx).Info("no delta log paths found in manifest")
+			return []storage.PrimaryKey{}, []typeutil.Timestamp{}, nil
+		}
+		return readDeltalogsV2(ctx, pkType, paths, option...)
 	}
 	return readDeltalogsV1(ctx, pkType, segment.GetDeltalogs(), option...)
 }
@@ -103,20 +112,16 @@ func readDeltalogsV1(
 	return allPks, allTss, nil
 }
 
-// readDeltalogsV2 reads deltalogs from V2 format (manifest-based).
+// readDeltalogsV2 reads deltalogs from V2 format (parquet files at given paths).
 func readDeltalogsV2(
 	ctx context.Context,
 	pkType schemapb.DataType,
-	manifestPath string,
+	paths []string,
 	option ...storage.RwOption,
 ) ([]storage.PrimaryKey, []typeutil.Timestamp, error) {
-	log := log.Ctx(ctx)
-	reader, err := storage.NewDeltalogReaderFromManifest(pkType, manifestPath, option...)
+	reader, err := storage.NewDeltalogReader(pkType, paths,
+		append(option, storage.WithVersion(storage.StorageV3))...)
 	if err != nil {
-		if errors.Is(err, io.EOF) {
-			log.Info("new detalog reader returns EOF, no deltalog found")
-			return []storage.PrimaryKey{}, []typeutil.Timestamp{}, nil
-		}
 		return nil, nil, err
 	}
 	defer reader.Close()
@@ -126,7 +131,7 @@ func readDeltalogsV2(
 		return nil, nil, err
 	}
 
-	log.Info("read V2 deltalogs from manifest", zap.Int("entries", len(pks)))
+	log.Ctx(ctx).Info("read V2 deltalogs", zap.Int("entries", len(pks)))
 	return pks, tss, nil
 }
 

--- a/internal/metastore/kv/binlog/binlog.go
+++ b/internal/metastore/kv/binlog/binlog.go
@@ -133,9 +133,14 @@ func DecompressBinLogs(s *datapb.SegmentInfo) error {
 	if err != nil {
 		return err
 	}
-	err = DecompressBinLog(storage.DeleteBinlog, collectionID, partitionID, segmentID, s.GetDeltalogs())
-	if err != nil {
-		return err
+	// V3 segments store delta data in the manifest; Deltalogs entries are
+	// pathless summary placeholders for compaction triggers — skip V1 path
+	// reconstruction which would generate wrong paths.
+	if s.GetManifestPath() == "" {
+		err = DecompressBinLog(storage.DeleteBinlog, collectionID, partitionID, segmentID, s.GetDeltalogs())
+		if err != nil {
+			return err
+		}
 	}
 	err = DecompressBinLog(storage.StatsBinlog, collectionID, partitionID, segmentID, s.GetStatslogs())
 	if err != nil {

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -1381,52 +1381,42 @@ func (loader *segmentLoader) loadDeltalogs(ctx context.Context, segment Segment,
 		return nil
 	}
 
-	// For V3 (manifest) segments, Deltalogs is a pathless placeholder used only
-	// for compaction-trigger decisions. The real delta data is referenced by
-	// the manifest and loaded below.
-	isV3 := loadInfo.GetManifestPath() != ""
-	if !isV3 {
+	// Collect delta paths and reader options based on storage version.
+	var paths []string
+	var opts []storage.RwOption
+	if manifestPath := loadInfo.GetManifestPath(); manifestPath != "" {
+		// V3: delta data lives in manifest
+		paths, err = packed.GetDeltaLogPathsFromManifest(manifestPath, createStorageConfig())
+		if err != nil {
+			return err
+		}
+		opts = []storage.RwOption{
+			storage.WithStorageConfig(createStorageConfig()),
+			storage.WithVersion(storage.StorageV3),
+		}
+	} else {
+		// V1: delta data referenced by Deltalogs entries
 		for _, deltalog := range deltaLogs {
-			err := func() error {
-				opts := []storage.RwOption{
-					storage.WithDownloader(
-						func(ctx context.Context, paths []string) ([][]byte, error) {
-							return loader.cm.MultiRead(ctx, paths)
-						},
-					),
+			for _, binlog := range lo.Filter(deltalog.Binlogs, valid) {
+				if p := binlog.GetLogPath(); p != "" {
+					paths = append(paths, p)
 				}
-				paths := lo.Map(lo.Filter(deltalog.Binlogs, valid), func(binlog *datapb.Binlog, _ int) string {
-					return binlog.GetLogPath()
-				})
-				reader, err := storage.NewDeltalogReader(pkField.DataType, paths, opts...)
-				if err != nil {
-					return err
-				}
-				return readDeltaRecords(reader)
-			}()
-			if err != nil {
-				return err
 			}
+		}
+		opts = []storage.RwOption{
+			storage.WithDownloader(func(ctx context.Context, paths []string) ([][]byte, error) {
+				return loader.cm.MultiRead(ctx, paths)
+			}),
 		}
 	}
 
-	// Read deltalogs from manifest for StorageV3 segments
-	if manifestPath := loadInfo.GetManifestPath(); manifestPath != "" {
-		reader, err := storage.NewDeltalogReaderFromManifest(
-			pkField.DataType,
-			manifestPath,
-			storage.WithStorageConfig(createStorageConfig()),
-			storage.WithVersion(storage.StorageV2),
-		)
+	if len(paths) > 0 {
+		reader, err := storage.NewDeltalogReader(pkField.DataType, paths, opts...)
 		if err != nil {
-			if !errors.Is(err, io.EOF) {
-				return err
-			}
-			// io.EOF means no deltalogs in manifest, not an error
-		} else {
-			if err := readDeltaRecords(reader); err != nil {
-				return err
-			}
+			return err
+		}
+		if err := readDeltaRecords(reader); err != nil {
+			return err
 		}
 	}
 

--- a/internal/querynodev2/segments/segment_loader_test.go
+++ b/internal/querynodev2/segments/segment_loader_test.go
@@ -35,10 +35,12 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/mocks/util/mock_segcore"
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/internal/util/indexparamcheck"
 	"github.com/milvus-io/milvus/internal/util/initcore"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
@@ -557,30 +559,26 @@ func (suite *SegmentLoaderSuite) TestLoadDeltaLogsV3PlaceholderSkipsPathRead() {
 	suite.Require().Len(segs, 1)
 	segment := segs[0]
 
-	// Patch readers to observe which branch is exercised.
-	legacyReaderCalled := atomic.NewInt32(0)
-	manifestReaderCalled := atomic.NewInt32(0)
+	readerCalled := atomic.NewInt32(0)
+	manifestCalled := atomic.NewInt32(0)
 
-	patchLegacy := mockey.Mock(storage.NewDeltalogReader).To(
-		func(pkType schemapb.DataType, paths []string, option ...storage.RwOption) (storage.RecordReader, error) {
-			legacyReaderCalled.Inc()
-			return nil, errors.Newf("V1 path-based delta reader should not be called for V3 segments; paths=%v", paths)
-		},
-	).Build()
-	defer patchLegacy.UnPatch()
-
-	patchManifest := mockey.Mock(storage.NewDeltalogReaderFromManifest).To(
-		func(pkType schemapb.DataType, manifestPath string, option ...storage.RwOption) (storage.RecordReader, error) {
-			manifestReaderCalled.Inc()
-			// io.EOF indicates "no deltalogs in manifest" and is handled gracefully by loadDeltalogs.
-			return nil, io.EOF
+	patchManifest := mockey.Mock(packed.GetDeltaLogPathsFromManifest).To(
+		func(manifestPath string, storageConfig *indexpb.StorageConfig) ([]string, error) {
+			manifestCalled.Inc()
+			// Return empty paths — no delta data in manifest.
+			return nil, nil
 		},
 	).Build()
 	defer patchManifest.UnPatch()
 
-	// Build V3 loadInfo: ManifestPath set, Deltalogs contains a pathless placeholder
-	// (LogID/EntriesNum/MemorySize only — no LogPath). Without the fix, the V1
-	// loop would try to MultiRead an empty path and fail.
+	patchReader := mockey.Mock(storage.NewDeltalogReader).To(
+		func(pkType schemapb.DataType, paths []string, option ...storage.RwOption) (storage.RecordReader, error) {
+			readerCalled.Inc()
+			return nil, errors.New("should not be called when manifest has no delta paths")
+		},
+	).Build()
+	defer patchReader.UnPatch()
+
 	v3LoadInfo := &querypb.SegmentLoadInfo{
 		SegmentID:    suite.segmentID,
 		PartitionID:  suite.partitionID,
@@ -600,10 +598,10 @@ func (suite *SegmentLoaderSuite) TestLoadDeltaLogsV3PlaceholderSkipsPathRead() {
 	loader := suite.loader.(*segmentLoader)
 	err = loader.loadDeltalogs(ctx, segment, v3LoadInfo)
 	suite.NoError(err)
-	suite.EqualValues(0, legacyReaderCalled.Load(),
-		"V1 path-based delta reader must be skipped for V3 segments")
-	suite.EqualValues(1, manifestReaderCalled.Load(),
-		"manifest-based delta reader must be invoked once for V3 segments")
+	suite.EqualValues(1, manifestCalled.Load(),
+		"GetDeltaLogPathsFromManifest must be called for V3 segments")
+	suite.EqualValues(0, readerCalled.Load(),
+		"NewDeltalogReader must not be called when manifest returns no paths")
 }
 
 // TestLoadDeltaLogsV1StillUsesPathRead ensures the skip logic does not break
@@ -643,25 +641,24 @@ func (suite *SegmentLoaderSuite) TestLoadDeltaLogsV1StillUsesPathRead() {
 	suite.Require().Len(segs, 1)
 	segment := segs[0]
 
-	legacyReaderCalled := atomic.NewInt32(0)
-	manifestReaderCalled := atomic.NewInt32(0)
+	readerCalled := atomic.NewInt32(0)
+	manifestCalled := atomic.NewInt32(0)
 
-	patchLegacy := mockey.Mock(storage.NewDeltalogReader).To(
-		func(pkType schemapb.DataType, paths []string, option ...storage.RwOption) (storage.RecordReader, error) {
-			legacyReaderCalled.Inc()
-			// Return an empty reader via EOF so the test finishes quickly; we only care that this was invoked.
-			return nil, io.EOF
-		},
-	).Build()
-	defer patchLegacy.UnPatch()
-
-	patchManifest := mockey.Mock(storage.NewDeltalogReaderFromManifest).To(
-		func(pkType schemapb.DataType, manifestPath string, option ...storage.RwOption) (storage.RecordReader, error) {
-			manifestReaderCalled.Inc()
-			return nil, io.EOF
+	patchManifest := mockey.Mock(packed.GetDeltaLogPathsFromManifest).To(
+		func(manifestPath string, storageConfig *indexpb.StorageConfig) ([]string, error) {
+			manifestCalled.Inc()
+			return nil, nil
 		},
 	).Build()
 	defer patchManifest.UnPatch()
+
+	patchReader := mockey.Mock(storage.NewDeltalogReader).To(
+		func(pkType schemapb.DataType, paths []string, option ...storage.RwOption) (storage.RecordReader, error) {
+			readerCalled.Inc()
+			return nil, io.EOF
+		},
+	).Build()
+	defer patchReader.UnPatch()
 
 	v1LoadInfo := &querypb.SegmentLoadInfo{
 		SegmentID:     suite.segmentID,
@@ -674,13 +671,11 @@ func (suite *SegmentLoaderSuite) TestLoadDeltaLogsV1StillUsesPathRead() {
 	}
 
 	loader := suite.loader.(*segmentLoader)
-	// NewDeltalogReader returns io.EOF which bubbles up as an error in the V1 branch;
-	// we only need to assert the branch was taken, not that the reader succeeded.
 	_ = loader.loadDeltalogs(ctx, segment, v1LoadInfo)
-	suite.Greater(legacyReaderCalled.Load(), int32(0),
-		"V1 path-based delta reader must be invoked for non-V3 segments")
-	suite.EqualValues(0, manifestReaderCalled.Load(),
-		"manifest-based delta reader must not be invoked when ManifestPath is empty")
+	suite.Greater(readerCalled.Load(), int32(0),
+		"NewDeltalogReader must be invoked for V1 segments")
+	suite.EqualValues(0, manifestCalled.Load(),
+		"GetDeltaLogPathsFromManifest must not be called when ManifestPath is empty")
 }
 
 func (suite *SegmentLoaderSuite) TestLoadIndex() {

--- a/internal/storage/rw.go
+++ b/internal/storage/rw.go
@@ -160,6 +160,15 @@ func WithStorageConfig(storageConfig *indexpb.StorageConfig) RwOption {
 	}
 }
 
+// GetStorageConfig extracts the storage config from the given options.
+func GetStorageConfig(option ...RwOption) *indexpb.StorageConfig {
+	opts := DefaultReaderOptions()
+	for _, opt := range option {
+		opt(opts)
+	}
+	return opts.storageConfig
+}
+
 func WithNeededFields(neededFields typeutil.Set[int64]) RwOption {
 	return func(options *rwOptions) {
 		options.neededFields = neededFields
@@ -478,7 +487,7 @@ func NewDeltalogReader(
 	switch rwOptions.version {
 	case StorageV1:
 		return NewLegacyDeltalogReader(pkField, rwOptions.downloader, paths)
-	case StorageV2:
+	case StorageV2, StorageV3:
 		pathPos := 0
 		schema := &schemapb.CollectionSchema{
 			Fields: []*schemapb.FieldSchema{
@@ -503,30 +512,4 @@ func NewDeltalogReader(
 	default:
 		return nil, merr.WrapErrServiceInternal(fmt.Sprintf("unsupported storage version %d", rwOptions.version))
 	}
-}
-
-// NewDeltalogReaderFromManifest creates a deltalog reader from segment manifest path.
-// It extracts delta log file paths from the manifest and reads them as V2 parquet files.
-func NewDeltalogReaderFromManifest(
-	pkType schemapb.DataType,
-	manifestPath string,
-	option ...RwOption,
-) (RecordReader, error) {
-	rwOptions := DefaultReaderOptions()
-	for _, opt := range option {
-		opt(rwOptions)
-	}
-	if err := rwOptions.validate(); err != nil {
-		return nil, err
-	}
-
-	paths, err := packed.GetDeltaLogPathsFromManifest(manifestPath, rwOptions.storageConfig)
-	if err != nil {
-		return nil, err
-	}
-	if len(paths) == 0 {
-		return nil, io.EOF
-	}
-
-	return NewDeltalogReader(pkType, paths, WithVersion(StorageV2), WithStorageConfig(rwOptions.storageConfig))
 }


### PR DESCRIPTION
See #48914

PR #48890 added pathless delta summary entries to
`SegmentInfo.Deltalogs` for V3 segments so compaction triggers
keep working. However, `DecompressBinLog` reconstructs V1-style
`LogPath` from `LogID` for entries with empty paths, causing
QueryNode to read from non-existent V1 paths (`file/delta_log/...`)
while real data lives under the V3 manifest
(`file/insert_log/.../_delta/...`).

Changes:
- `DecompressBinLogs`: skip V1 delta path reconstruction when
  `ManifestPath` is set
- `segment_loader.go`: unify V1 and V3 delta reading into a single
  code path — collect paths from either `Deltalogs` entries or the
  manifest, then call `NewDeltalogReader` once
- `rw.go`: remove `NewDeltalogReaderFromManifest` wrapper, add
  `StorageV3` support to `NewDeltalogReader`, export
  `GetStorageConfig` helper
- `compaction/common.go`: inline manifest path extraction via
  `packed.GetDeltaLogPathsFromManifest` + `NewDeltalogReader`

Test cases adapted from #49034 (credit: @congqixia).