### PR TITLE
enhance: [2.6] cherry-pick c++ optimizations from master (#48859, #48891, #48906)

### DIFF
--- a/internal/core/src/clustering/KmeansClustering.cpp
+++ b/internal/core/src/clustering/KmeansClustering.cpp
@@ -188,7 +188,7 @@ KmeansClustering::CentroidIdMappingToPB(
             stats.add_num_in_centroid(num_vectors[j]);
         }
         cur_offset += num_offset;
-        stats_arr.emplace_back(stats);
+        stats_arr.emplace_back(std::move(stats));
     }
     return stats_arr;
 }
@@ -247,14 +247,14 @@ KmeansClustering::StreamingAssignandUpload(
     centroid_stats.SerializeToArray(data.get(), byte_size);
     std::unordered_map<std::string, int64_t> remote_paths_to_size;
     LOG_INFO(msg_header_ + "start upload cluster centroids file");
-    AddClusteringResultFiles(
-        file_manager_->GetChunkManager().get(),
-        data.get(),
-        byte_size,
-        GetRemoteCentroidsObjectPrefix() + "/" + std::string(CENTROIDS_NAME),
-        remote_paths_to_size);
-    cluster_result_.centroid_path =
+    auto centroid_remote_path =
         GetRemoteCentroidsObjectPrefix() + "/" + std::string(CENTROIDS_NAME);
+    AddClusteringResultFiles(file_manager_->GetChunkManager().get(),
+                             data.get(),
+                             byte_size,
+                             centroid_remote_path,
+                             remote_paths_to_size);
+    cluster_result_.centroid_path = std::move(centroid_remote_path);
     cluster_result_.centroid_file_size =
         remote_paths_to_size.at(cluster_result_.centroid_path);
     remote_paths_to_size.clear();
@@ -345,7 +345,7 @@ KmeansClustering::Run(const milvus::proto::clustering::AnalyzeInfo& config) {
         std::vector<std::string> segment_files(
             pair.second.insert_files().begin(),
             pair.second.insert_files().end());
-        insert_files[pair.first] = segment_files;
+        insert_files[pair.first] = std::move(segment_files);
     }
 
     std::map<int64_t, int64_t> num_rows(config.num_rows().begin(),

--- a/internal/core/src/clustering/analyze_c.cpp
+++ b/internal/core/src/clustering/analyze_c.cpp
@@ -32,25 +32,23 @@ using namespace milvus;
 milvus::storage::StorageConfig
 get_storage_config(const milvus::proto::clustering::StorageConfig& config) {
     auto storage_config = milvus::storage::StorageConfig();
-    storage_config.address = std::string(config.address());
-    storage_config.bucket_name = std::string(config.bucket_name());
-    storage_config.access_key_id = std::string(config.access_keyid());
-    storage_config.access_key_value = std::string(config.secret_access_key());
-    storage_config.root_path = std::string(config.root_path());
-    storage_config.storage_type = std::string(config.storage_type());
-    storage_config.cloud_provider = std::string(config.cloud_provider());
-    storage_config.iam_endpoint = std::string(config.iamendpoint());
-    storage_config.cloud_provider = std::string(config.cloud_provider());
+    storage_config.address = config.address();
+    storage_config.bucket_name = config.bucket_name();
+    storage_config.access_key_id = config.access_keyid();
+    storage_config.access_key_value = config.secret_access_key();
+    storage_config.root_path = config.root_path();
+    storage_config.storage_type = config.storage_type();
+    storage_config.cloud_provider = config.cloud_provider();
+    storage_config.iam_endpoint = config.iamendpoint();
     storage_config.useSSL = config.usessl();
     storage_config.sslCACert = config.sslcacert();
     storage_config.useIAM = config.useiam();
     storage_config.region = config.region();
     storage_config.useVirtualHost = config.use_virtual_host();
     storage_config.requestTimeoutMs = config.request_timeout_ms();
-    storage_config.gcp_credential_json =
-        std::string(config.gcpcredentialjson());
+    storage_config.gcp_credential_json = config.gcpcredentialjson();
     storage_config.max_connections = config.max_connections();
-    storage_config.tls_min_version = std::string(config.ssl_tls_min_version());
+    storage_config.tls_min_version = config.ssl_tls_min_version();
     storage_config.use_crc32c_checksum = config.use_crc32c_checksum();
 
     return storage_config;
@@ -114,7 +112,7 @@ Analyze(CAnalyze* res_analyze,
             throw SegcoreError(
                 DataTypeInvalid,
                 fmt::format("invalid data type for clustering is {}",
-                            std::to_string(int(field_type))));
+                            int(field_type)));
         }
         auto clusteringJob =
             std::make_unique<milvus::clustering::KmeansClustering>(

--- a/internal/core/src/common/Chunk.cpp
+++ b/internal/core/src/common/Chunk.cpp
@@ -62,9 +62,10 @@ StringChunk::ViewsByOffsets(const FixedVector<int32_t>& offsets) {
     ret.reserve(size);
     valid_res.reserve(size);
     for (auto i = 0; i < size; ++i) {
-        ret.emplace_back(data_ + offsets_[offsets[i]],
-                         offsets_[offsets[i] + 1] - offsets_[offsets[i]]);
-        valid_res.emplace_back(isValid(offsets[i]));
+        auto idx = offsets[i];
+        auto start = offsets_[idx];
+        ret.emplace_back(data_ + start, offsets_[idx + 1] - start);
+        valid_res.emplace_back(isValid(idx));
     }
     return {ret, valid_res};
 }

--- a/internal/core/src/common/ChunkTarget.cpp
+++ b/internal/core/src/common/ChunkTarget.cpp
@@ -10,12 +10,13 @@
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
 #include <common/ChunkTarget.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <unistd.h>
 #include <algorithm>
 #include <cstdint>
 #include <cstring>
 #include "common/EasyAssert.h"
-#include <sys/mman.h>
-#include <unistd.h>
 #include "File.h"
 
 const uint32_t SYS_PAGE_SIZE = sysconf(_SC_PAGE_SIZE);
@@ -40,8 +41,14 @@ MemChunkTarget::tell() {
 void
 MmapChunkTarget::flush() {
     if (cap_ > size_) {
-        std::string padding(cap_ - size_, 0);
-        file_writer_->Write(padding.data(), cap_ - size_);
+        static constexpr size_t kBufSize = 4096;
+        char zeros[kBufSize] = {};
+        auto remaining = cap_ - size_;
+        while (remaining > 0) {
+            auto to_write = std::min(remaining, kBufSize);
+            file_writer_->Write(zeros, to_write);
+            remaining -= to_write;
+        }
         size_ = cap_;
     }
     file_writer_->Finish();

--- a/internal/core/src/common/ChunkWriter.cpp
+++ b/internal/core/src/common/ChunkWriter.cpp
@@ -279,7 +279,7 @@ ArrayChunkWriter::write_to_target(const arrow::ArrayVector& array_vec,
             auto str = array->GetView(i);
             ScalarFieldProto scalar_array;
             scalar_array.ParseFromArray(str.data(), str.size());
-            arrays.emplace_back(Array(scalar_array));
+            arrays.emplace_back(scalar_array);
         }
         if (nullable_) {
             null_bitmaps.emplace_back(
@@ -458,7 +458,7 @@ void
 SparseFloatVectorChunkWriter::write_to_target(
     const arrow::ArrayVector& array_vec,
     const std::shared_ptr<ChunkTarget>& target) {
-    std::vector<std::string> strs;
+    std::vector<std::string_view> strs;
     strs.reserve(row_nums_);
     std::vector<std::tuple<const uint8_t*, int64_t, int64_t>> null_bitmaps;
 
@@ -844,8 +844,11 @@ create_group_chunk(const std::vector<FieldId>& field_ids,
                             ~(ChunkTarget::ALIGNED_SIZE - 1);
         auto padding_size = aligned_size - written;
         if (padding_size > 0) {
-            std::string padding(padding_size, 0);
-            target->write(padding.data(), padding_size);
+            // Use a stack buffer to avoid heap allocation for padding zeros.
+            // ChunkTarget::ALIGNED_SIZE is typically small (e.g. 64/512),
+            // so padding_size is always < ALIGNED_SIZE.
+            char padding[ChunkTarget::ALIGNED_SIZE] = {};
+            target->write(padding, padding_size);
         }
     }
 

--- a/internal/core/src/common/FieldData.cpp
+++ b/internal/core/src/common/FieldData.cpp
@@ -276,13 +276,13 @@ FieldDataImpl<Type, is_type_entire_row>::FillFieldData(
             std::vector<Array> values(element_count);
             int null_number = 0;
             for (size_t index = 0; index < element_count; ++index) {
-                ScalarFieldProto field_data;
-                if (array_array->GetString(index) == "") {
+                auto str = array_array->GetString(index);
+                if (str.empty()) {
                     null_number++;
                     continue;
                 }
-                auto success =
-                    field_data.ParseFromString(array_array->GetString(index));
+                ScalarFieldProto field_data;
+                auto success = field_data.ParseFromString(str);
                 AssertInfo(success, "parse from string failed");
                 values[index] = Array(field_data);
             }
@@ -404,9 +404,9 @@ FieldDataImpl<Type, is_type_entire_row>::FillFieldData(
         }
         default: {
             ThrowInfo(DataTypeInvalid,
-                      GetName() + "::FillFieldData" +
-                          " not support data type " +
-                          GetDataTypeName(data_type_));
+                      "{}::FillFieldData not support data type {}",
+                      GetName(),
+                      GetDataTypeName(data_type_));
         }
     }
 }
@@ -547,9 +547,9 @@ FieldDataImpl<Type, is_type_entire_row>::FillFieldData(
         }
         default: {
             ThrowInfo(DataTypeInvalid,
-                      GetName() + "::FillFieldData" +
-                          " not support data type " +
-                          GetDataTypeName(data_type_));
+                      "{}::FillFieldData not support data type {}",
+                      GetName(),
+                      GetDataTypeName(data_type_));
         }
     }
 }
@@ -614,8 +614,8 @@ InitScalarFieldData(const DataType& type, bool nullable, int64_t cap_rows) {
                 type, nullable, cap_rows);
         default:
             ThrowInfo(DataTypeInvalid,
-                      "InitScalarFieldData not support data type " +
-                          GetDataTypeName(type));
+                      "InitScalarFieldData not support data type {}",
+                      GetDataTypeName(type));
     }
 }
 

--- a/internal/core/src/common/FieldMeta.cpp
+++ b/internal/core/src/common/FieldMeta.cpp
@@ -137,8 +137,9 @@ FieldMeta::ParseFrom(const milvus::proto::schema::FieldSchema& schema_proto) {
         auto is_system =
             SystemProperty::Instance().SystemFieldVerify(name, field_id);
         AssertInfo(is_system,
-                   "invalid system type: name(" + name.get() + "), id(" +
-                       std::to_string(field_id.get()) + ")");
+                   "invalid system type: name({}), id({})",
+                   name.get(),
+                   field_id.get());
     }
 
     auto data_type = DataType(schema_proto.data_type());

--- a/internal/core/src/common/IndexMeta.cpp
+++ b/internal/core/src/common/IndexMeta.cpp
@@ -67,8 +67,9 @@ CollectionIndexMeta::HasField(FieldId fieldId) const {
 
 const FieldIndexMeta&
 CollectionIndexMeta::GetFieldIndexMeta(FieldId fieldId) const {
-    assert(fieldMetas_.find(fieldId) != fieldMetas_.end());
-    return fieldMetas_.at(fieldId);
+    auto it = fieldMetas_.find(fieldId);
+    assert(it != fieldMetas_.end());
+    return it->second;
 }
 
 std::string

--- a/internal/core/src/common/Json.h
+++ b/internal/core/src/common/Json.h
@@ -55,9 +55,9 @@ isDocEmpty(simdjson::ondemand::document document);
 // rapidjson is suitable for extract and reconstruct serialization
 // instead of simdjson which not suitable for serialization
 inline std::string
-ExtractSubJson(const std::string& json, const std::vector<std::string>& keys) {
+ExtractSubJson(std::string_view json, const std::vector<std::string>& keys) {
     rapidjson::Document doc;
-    doc.Parse(json.c_str());
+    doc.Parse(json.data(), json.size());
     if (doc.HasParseError()) {
         ThrowInfo(ErrorCode::UnexpectedError,
                   "json parse failed, error:{}",

--- a/internal/core/src/common/JsonCastType.cpp
+++ b/internal/core/src/common/JsonCastType.cpp
@@ -33,7 +33,7 @@ JsonCastType
 JsonCastType::FromString(const std::string& str) {
     auto it = json_cast_type_map_.find(str);
     if (it == json_cast_type_map_.end()) {
-        ThrowInfo(Unsupported, "Invalid json cast type: " + str);
+        ThrowInfo(Unsupported, "Invalid json cast type: {}", str);
     }
     return it->second;
 }

--- a/internal/core/src/common/JsonUtils.cpp
+++ b/internal/core/src/common/JsonUtils.cpp
@@ -1,5 +1,12 @@
 #include "common/JsonUtils.h"
 
+#include <simdjson.h>
+#include <stdlib.h>
+#include <algorithm>
+#include <utility>
+#include <cstddef>
+#include <stdexcept>
+
 namespace milvus {
 
 // Parse a JSON Pointer into unescaped path segments
@@ -29,7 +36,7 @@ parse_json_pointer(const std::string& pointer) {
             token.replace(pos, 2, "~");
             pos += 1;
         }
-        tokens.push_back(token);
+        tokens.push_back(std::move(token));
         start = end + 1;
     }
     return tokens;

--- a/internal/core/src/common/Schema.cpp
+++ b/internal/core/src/common/Schema.cpp
@@ -71,7 +71,7 @@ Schema::ParseFrom(const milvus::proto::schema::CollectionSchema& schema_proto) {
         auto warmup_policy =
             GetStringFromRepeatedKVs(child.type_params(), WARMUP_KEY);
         if (warmup_policy.has_value()) {
-            schema->warmup_fields_[field_id] = warmup_policy.value();
+            schema->warmup_fields_[field_id] = std::move(warmup_policy).value();
         }
     };
 

--- a/internal/core/src/common/Slice.cpp
+++ b/internal/core/src/common/Slice.cpp
@@ -88,20 +88,17 @@ Disassemble(BinarySet& binarySet) {
         }
     }
 
+    const auto slice_size = FILE_SLICE_SIZE.load();
     std::vector<std::string> slice_key_list;
     slice_key_list.reserve(binarySet.binary_map_.size());
     for (auto& kv : binarySet.binary_map_) {
-        if (kv.second->size > FILE_SLICE_SIZE.load()) {
+        if (kv.second->size > slice_size) {
             slice_key_list.push_back(kv.first);
         }
     }
     for (auto& key : slice_key_list) {
         Config slice_i;
-        Slice(key,
-              binarySet.Erase(key),
-              FILE_SLICE_SIZE.load(),
-              binarySet,
-              slice_i);
+        Slice(key, binarySet.Erase(key), slice_size, binarySet, slice_i);
         meta_info[META].emplace_back(slice_i);
     }
     if (!slice_key_list.empty()) {

--- a/internal/core/src/common/Utils.h
+++ b/internal/core/src/common/Utils.h
@@ -221,13 +221,17 @@ IsInteger(const std::string& str) {
     if (str.empty())
         return false;
 
-    try {
-        size_t pos;
-        std::stoi(str, &pos);
-        return pos == str.length();
-    } catch (...) {
-        return false;
+    size_t start = 0;
+    if (str[0] == '+' || str[0] == '-') {
+        start = 1;
+        if (str.size() == 1)
+            return false;
     }
+    for (size_t i = start; i < str.size(); ++i) {
+        if (str[i] < '0' || str[i] > '9')
+            return false;
+    }
+    return true;
 }
 
 inline std::string

--- a/internal/core/src/common/VectorTrait.h
+++ b/internal/core/src/common/VectorTrait.h
@@ -269,4 +269,9 @@ struct TagDispatchTrait<std::string> {
     using Tag = StringTag;
 };
 
+template <>
+struct TagDispatchTrait<std::string_view> {
+    using Tag = StringTag;
+};
+
 }  // namespace milvus

--- a/internal/core/src/config/ConfigKnowhere.cpp
+++ b/internal/core/src/config/ConfigKnowhere.cpp
@@ -61,7 +61,7 @@ KnowhereSetSimdType(const char* value) {
     } else if (strcmp(value, "avx") == 0 || strcmp(value, "sse4_2") == 0) {
         simd_type = knowhere::KnowhereConfig::SimdType::SSE4_2;
     } else {
-        ThrowInfo(ConfigInvalid, "invalid SIMD type: " + std::string(value));
+        ThrowInfo(ConfigInvalid, "invalid SIMD type: {}", value);
     }
     try {
         return knowhere::KnowhereConfig::SetSimdType(simd_type);
@@ -86,8 +86,8 @@ KnowhereInitSearchThreadPool(const uint32_t num_threads) {
     knowhere::KnowhereConfig::SetSearchThreadPoolSize(num_threads);
     if (!knowhere::KnowhereConfig::SetAioContextPool(num_threads)) {
         ThrowInfo(ConfigInvalid,
-                  "Failed to set aio context pool with num_threads " +
-                      std::to_string(num_threads));
+                  "Failed to set aio context pool with num_threads {}",
+                  num_threads);
     }
 }
 

--- a/internal/core/src/exec/Driver.cpp
+++ b/internal/core/src/exec/Driver.cpp
@@ -55,7 +55,7 @@ DriverFactory::CreateDriver(std::unique_ptr<DriverContext> ctx,
 
     for (size_t i = 0; i < plannodes_.size(); ++i) {
         auto id = operators.size();
-        auto plannode = plannodes_[i];
+        const auto& plannode = plannodes_[i];
         if (auto filterbitsnode =
                 std::dynamic_pointer_cast<const plan::FilterBitsNode>(
                     plannode)) {

--- a/internal/core/src/exec/Task.cpp
+++ b/internal/core/src/exec/Task.cpp
@@ -51,7 +51,7 @@ Task::Create(const std::string& task_id,
 
 std::shared_ptr<Task>
 Task::Create(const std::string& task_id,
-             const plan::PlanFragment& plan_fragment,
+             plan::PlanFragment plan_fragment,
              int destination,
              std::shared_ptr<QueryContext> query_ctx,
              ConsumerSupplier supplier,

--- a/internal/core/src/exec/Task.h
+++ b/internal/core/src/exec/Task.h
@@ -44,7 +44,7 @@ class Task : public std::enable_shared_from_this<Task> {
 
     static std::shared_ptr<Task>
     Create(const std::string& task_id,
-           const plan::PlanFragment& plan_fragment,
+           plan::PlanFragment plan_fragment,
            int destination,
            std::shared_ptr<QueryContext> query_ctx,
            ConsumerSupplier supplier,

--- a/internal/core/src/exec/expression/BinaryRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.cpp
@@ -282,13 +282,13 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForIndex() {
         return nullptr;
     }
 
-    auto execute_sub_batch =
-        [lower_inclusive, upper_inclusive](
-            Index* index_ptr, HighPrecisionType val1, HighPrecisionType val2) {
-            BinaryRangeIndexFunc<T> func;
-            return std::move(
-                func(index_ptr, val1, val2, lower_inclusive, upper_inclusive));
-        };
+    auto execute_sub_batch = [lower_inclusive, upper_inclusive](
+                                 Index* index_ptr,
+                                 HighPrecisionType val1,
+                                 HighPrecisionType val2) {
+        BinaryRangeIndexFunc<T> func;
+        return func(index_ptr, val1, val2, lower_inclusive, upper_inclusive);
+    };
     auto res = ProcessIndexChunks<T>(execute_sub_batch, val1, val2);
     AssertInfo(res->size() == real_batch_size,
                "internal error: expr processed rows {} not equal "

--- a/internal/core/src/exec/expression/ColumnExpr.cpp
+++ b/internal/core/src/exec/expression/ColumnExpr.cpp
@@ -116,7 +116,7 @@ PhyColumnExpr::DoEval(OffsetVector* input) {
                 valid_res[processed_rows] = false;
             } else {
                 res_value[processed_rows] =
-                    boost::get<T>(chunk_data_by_offset.value());
+                    segcore::get_from_variant<T>(chunk_data_by_offset);
             }
             processed_rows++;
         }
@@ -147,7 +147,7 @@ PhyColumnExpr::DoEval(OffsetVector* input) {
                 valid_res[i] = false;
                 continue;
             }
-            res_value[i] = boost::get<T>(data.value());
+            res_value[i] = segcore::get_from_variant<T>(data);
         }
         return res_vec;
     } else {
@@ -183,10 +183,12 @@ PhyColumnExpr::DoEval(OffsetVector* input) {
             for (int i = chunk_id == current_chunk_id_ ? current_chunk_pos_ : 0;
                  i < chunk_size;
                  ++i) {
-                if (!cda(i).has_value()) {
+                auto val = cda(i);
+                if (!val.has_value()) {
                     valid_res[processed_rows] = false;
                 } else {
-                    res_value[processed_rows] = boost::get<T>(cda(i).value());
+                    res_value[processed_rows] =
+                        segcore::get_from_variant<T>(val);
                 }
                 processed_rows++;
 

--- a/internal/core/src/exec/expression/CompareExpr.cpp
+++ b/internal/core/src/exec/expression/CompareExpr.cpp
@@ -191,14 +191,16 @@ PhyCompareFilterExpr::ExecCompareExprDispatcher(OpType op, EvalCtx& context) {
             for (int i = chunk_id == current_chunk_id_ ? current_chunk_pos_ : 0;
                  i < chunk_size;
                  ++i) {
-                if (!left(i).has_value() || !right(i).has_value()) {
+                auto left_opt = left(i);
+                auto right_opt = right(i);
+                if (!left_opt.has_value() || !right_opt.has_value()) {
                     res[processed_rows] = false;
                     valid_res[processed_rows] = false;
                 } else {
                     res[processed_rows] = boost::apply_visitor(
                         milvus::query::Relational<decltype(op)>{},
-                        left(i).value(),
-                        right(i).value());
+                        left_opt.value(),
+                        right_opt.value());
                 }
                 processed_rows++;
 

--- a/internal/core/src/exec/expression/ExistsExpr.cpp
+++ b/internal/core/src/exec/expression/ExistsExpr.cpp
@@ -61,8 +61,8 @@ PhyExistsFilterExpr::EvalJsonExistsForIndex() {
         cached_index_chunk_id_ = 0;
         auto pointer = milvus::Json::pointer(expr_->column_.nested_path_);
         auto* index = pinned_index_[cached_index_chunk_id_].get();
-        AssertInfo(index != nullptr,
-                   "Cannot find json index with path: " + pointer);
+        AssertInfo(
+            index != nullptr, "Cannot find json index with path: {}", pointer);
         switch (index->GetCastType().data_type()) {
             case JsonCastType::DataType::DOUBLE: {
                 auto* json_index =

--- a/internal/core/src/exec/expression/Expr.cpp
+++ b/internal/core/src/exec/expression/Expr.cpp
@@ -366,7 +366,7 @@ ReorderConjunctExpr(std::shared_ptr<milvus::exec::PhyConjunctFilterExpr>& expr,
 
     const auto& inputs = expr->GetInputsRef();
     for (int i = 0; i < inputs.size(); i++) {
-        auto input = inputs[i];
+        const auto& input = inputs[i];
 
         if (input->IsSource() && input->GetColumnInfo().has_value()) {
             auto column = input->GetColumnInfo().value();

--- a/internal/core/src/exec/expression/GISFunctionFilterExpr.cpp
+++ b/internal/core/src/exec/expression/GISFunctionFilterExpr.cpp
@@ -385,8 +385,7 @@ PhyGISFunctionFilterExpr::EvalForIndexSegment() {
             // Note: Distance is not used for bounding box intersection query
         } else {
             // For other operations, use original geometry
-            ds->Set(milvus::index::MATCH_VALUE,
-                    Geometry(ctx, expr_->geometry_wkt_.c_str()));
+            ds->Set(milvus::index::MATCH_VALUE, query_geometry);
         }
 
         // Query segment-level R-Tree index **once** since each chunk shares the same index

--- a/internal/core/src/exec/expression/JsonContainsExpr.cpp
+++ b/internal/core/src/exec/expression/JsonContainsExpr.cpp
@@ -107,10 +107,9 @@ PhyJsonContainsFilterExpr::EvalJsonContainsForDataSegment(EvalCtx& context) {
                         return ExecArrayContains<std::string>(context);
                     }
                     default:
-                        ThrowInfo(
-                            DataTypeInvalid,
-                            fmt::format("unsupported array sub element type {}",
-                                        val_type));
+                        ThrowInfo(DataTypeInvalid,
+                                  "unsupported array sub element type {}",
+                                  val_type);
                 }
             } else {
                 if (expr_->same_type_) {
@@ -163,10 +162,9 @@ PhyJsonContainsFilterExpr::EvalJsonContainsForDataSegment(EvalCtx& context) {
                         return ExecArrayContainsAll<std::string>(context);
                     }
                     default:
-                        ThrowInfo(
-                            DataTypeInvalid,
-                            fmt::format("unsupported array sub element type {}",
-                                        val_type));
+                        ThrowInfo(DataTypeInvalid,
+                                  "unsupported array sub element type {}",
+                                  val_type);
                 }
             } else {
                 if (expr_->same_type_) {
@@ -1166,7 +1164,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllWithDiffType(EvalCtx& context) {
 
     auto pointer = milvus::Json::pointer(expr_->column_.nested_path_);
 
-    auto elements = expr_->vals_;
+    const auto& elements = expr_->vals_;
     std::unordered_set<int> elements_index;
     int i = 0;
     for (auto& element : elements) {
@@ -1263,8 +1261,8 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllWithDiffType(EvalCtx& context) {
                         }
                         default:
                             ThrowInfo(DataTypeInvalid,
-                                      fmt::format("unsupported data type {}",
-                                                  element.val_case()));
+                                      "unsupported data type {}",
+                                      element.val_case());
                     }
                     if (tmp_elements_index.size() == 0) {
                         return true;
@@ -1329,7 +1327,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllWithDiffTypeByStats() {
         return nullptr;
     }
     auto pointer = milvus::Json::pointer(expr_->column_.nested_path_);
-    auto elements = expr_->vals_;
+    const auto& elements = expr_->vals_;
     std::set<int> elements_index;
     int i = 0;
     for (auto& element : elements) {
@@ -1455,8 +1453,8 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllWithDiffTypeByStats() {
                         }
                         default:
                             ThrowInfo(DataTypeInvalid,
-                                      fmt::format("unsupported data type {}",
-                                                  element.val_case()));
+                                      "unsupported data type {}",
+                                      element.val_case());
                     }
                     if (tmp_elements_index.size() == 0) {
                         res_view[row_offset] = true;
@@ -1749,13 +1747,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsWithDiffType(EvalCtx& context) {
 
     auto pointer = milvus::Json::pointer(expr_->column_.nested_path_);
 
-    auto elements = expr_->vals_;
-    std::unordered_set<int> elements_index;
-    int i = 0;
-    for (auto& element : elements) {
-        elements_index.insert(i);
-        i++;
-    }
+    const auto& elements = expr_->vals_;
 
     size_t processed_cursor = 0;
     auto execute_sub_batch =
@@ -1843,8 +1835,8 @@ PhyJsonContainsFilterExpr::ExecJsonContainsWithDiffType(EvalCtx& context) {
                         }
                         default:
                             ThrowInfo(DataTypeInvalid,
-                                      fmt::format("unsupported data type {}",
-                                                  element.val_case()));
+                                      "unsupported data type {}",
+                                      element.val_case());
                     }
                 }
             }
@@ -1901,7 +1893,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsWithDiffTypeByStats() {
         return nullptr;
     }
     auto pointer = milvus::Json::pointer(expr_->column_.nested_path_);
-    auto elements = expr_->vals_;
+    const auto& elements = expr_->vals_;
     if (elements.empty()) {
         MoveCursor();
         return std::make_shared<ColumnVector>(
@@ -2021,8 +2013,8 @@ PhyJsonContainsFilterExpr::ExecJsonContainsWithDiffTypeByStats() {
                         }
                         default:
                             ThrowInfo(DataTypeInvalid,
-                                      fmt::format("unsupported data type {}",
-                                                  element.val_case()));
+                                      "unsupported data type {}",
+                                      element.val_case());
                     }
                 }
             }

--- a/internal/core/src/exec/expression/TermExpr.cpp
+++ b/internal/core/src/exec/expression/TermExpr.cpp
@@ -486,7 +486,7 @@ PhyTermFilterExpr::ExecTermJsonVariableInField(EvalCtx& context) {
             const int size,
             TargetBitmapView res,
             TargetBitmapView valid_res,
-            const std::string pointer,
+            const std::string& pointer,
             const ValueType& target_val) {
         // If data is nullptr, this chunk was skipped by SkipIndex.
         // We only need to update processed_cursor for bitmap_input indexing.
@@ -585,7 +585,6 @@ PhyTermFilterExpr::ExecJsonInVariableByStats() {
         segment_->type() == SegmentType::Sealed) {
         auto segment = dynamic_cast<const segcore::SegmentSealed*>(segment_);
         auto field_id = expr_->column_.field_id_;
-        auto vals = expr_->vals_;
         pinned_json_stats_ = segment->GetJsonStats(op_ctx_, field_id);
         auto* index = pinned_json_stats_.get();
         Assert(index != nullptr);
@@ -786,7 +785,7 @@ PhyTermFilterExpr::ExecTermJsonFieldInVariable(EvalCtx& context) {
             const int size,
             TargetBitmapView res,
             TargetBitmapView valid_res,
-            const std::string pointer,
+            const std::string& pointer,
             const std::shared_ptr<MultiElement>& terms) {
         // If data is nullptr, this chunk was skipped by SkipIndex.
         // We only need to update processed_cursor for bitmap_input indexing.

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -1394,52 +1394,52 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplForIndex() {
         switch (op_type) {
             case proto::plan::GreaterThan: {
                 UnaryIndexFunc<T, proto::plan::GreaterThan> func;
-                res = std::move(func(index_ptr, val));
+                res = func(index_ptr, val);
                 break;
             }
             case proto::plan::GreaterEqual: {
                 UnaryIndexFunc<T, proto::plan::GreaterEqual> func;
-                res = std::move(func(index_ptr, val));
+                res = func(index_ptr, val);
                 break;
             }
             case proto::plan::LessThan: {
                 UnaryIndexFunc<T, proto::plan::LessThan> func;
-                res = std::move(func(index_ptr, val));
+                res = func(index_ptr, val);
                 break;
             }
             case proto::plan::LessEqual: {
                 UnaryIndexFunc<T, proto::plan::LessEqual> func;
-                res = std::move(func(index_ptr, val));
+                res = func(index_ptr, val);
                 break;
             }
             case proto::plan::Equal: {
                 UnaryIndexFunc<T, proto::plan::Equal> func;
-                res = std::move(func(index_ptr, val));
+                res = func(index_ptr, val);
                 break;
             }
             case proto::plan::NotEqual: {
                 UnaryIndexFunc<T, proto::plan::NotEqual> func;
-                res = std::move(func(index_ptr, val));
+                res = func(index_ptr, val);
                 break;
             }
             case proto::plan::PrefixMatch: {
                 UnaryIndexFunc<T, proto::plan::PrefixMatch> func;
-                res = std::move(func(index_ptr, val));
+                res = func(index_ptr, val);
                 break;
             }
             case proto::plan::PostfixMatch: {
                 UnaryIndexFunc<T, proto::plan::PostfixMatch> func;
-                res = std::move(func(index_ptr, val));
+                res = func(index_ptr, val);
                 break;
             }
             case proto::plan::InnerMatch: {
                 UnaryIndexFunc<T, proto::plan::InnerMatch> func;
-                res = std::move(func(index_ptr, val));
+                res = func(index_ptr, val);
                 break;
             }
             case proto::plan::Match: {
                 UnaryIndexFunc<T, proto::plan::Match> func;
-                res = std::move(func(index_ptr, val));
+                res = func(index_ptr, val);
                 break;
             }
             default:

--- a/internal/core/src/exec/expression/function/impl/Empty.cpp
+++ b/internal/core/src/exec/expression/function/impl/Empty.cpp
@@ -34,7 +34,7 @@ EmptyVarchar(const RowVector& args, FilterFunctionReturn& result) {
                   "invalid argument count, expect 1, actual {}",
                   args.childrens().size());
     }
-    auto arg = args.child(0);
+    const auto& arg = args.childrens()[0];
     auto vec = std::dynamic_pointer_cast<SimpleVector>(arg);
     Assert(vec != nullptr);
     CheckVarcharOrStringType(vec);

--- a/internal/core/src/exec/expression/function/impl/StartsWith.cpp
+++ b/internal/core/src/exec/expression/function/impl/StartsWith.cpp
@@ -49,7 +49,10 @@ StartsWithVarchar(const RowVector& args, FilterFunctionReturn& result) {
                 strs->RawValueAt(i, sizeof(std::string)));
             auto* prefix_ptr = reinterpret_cast<std::string*>(
                 prefixes->RawValueAt(i, sizeof(std::string)));
-            bitmap.set(i, str_ptr->find(*prefix_ptr) == 0);
+            bitmap.set(
+                i,
+                str_ptr->size() >= prefix_ptr->size() &&
+                    str_ptr->compare(0, prefix_ptr->size(), *prefix_ptr) == 0);
         } else {
             valid_bitmap[i] = false;
         }

--- a/internal/core/src/exec/operator/IterativeFilterNode.cpp
+++ b/internal/core/src/exec/operator/IterativeFilterNode.cpp
@@ -182,13 +182,18 @@ PhyIterativeFilterNode::GetOutput() {
 
         search_result.seg_offsets_.resize(nq * unity_topk, INVALID_SEG_OFFSET);
         search_result.distances_.resize(nq * unity_topk);
+
+        // Reuse memory allocation across batches and nqs
+        FixedVector<int32_t> offsets;
+        FixedVector<float> distances;
+
         for (auto& iterator : search_result.vector_iterators_.value()) {
             EvalCtx eval_ctx(operator_context_->get_exec_context(),
                              exprs_.get());
             int topk = 0;
             while (iterator->HasNext() && topk < unity_topk) {
-                FixedVector<int32_t> offsets;
-                FixedVector<float> distances;
+                offsets.clear();
+                distances.clear();
                 // remain unfilled size as iterator batch size
                 int64_t batch_size = unity_topk - topk;
                 offsets.reserve(batch_size);

--- a/internal/core/src/exec/operator/RandomSampleNode.cpp
+++ b/internal/core/src/exec/operator/RandomSampleNode.cpp
@@ -53,7 +53,7 @@ PhyRandomSampleNode::HashsetSample(const uint32_t N,
                                    std::mt19937& gen) {
     std::uniform_int_distribution<> dis(0, N - 1);
     std::unordered_set<uint32_t> sampled;
-    sampled.reserve(N);
+    sampled.reserve(M);
     while (sampled.size() < M) {
         sampled.insert(dis(gen));
     }
@@ -142,7 +142,8 @@ PhyRandomSampleNode::GetOutput() {
             }
         }
 
-        result = std::make_shared<RowVector>(std::vector<VectorPtr>{input_col});
+        result = std::make_shared<RowVector>(
+            std::vector<VectorPtr>{std::move(input_col)});
     } else {
         auto sample_output = std::make_shared<ColumnVector>(
             TargetBitmap(active_count_), TargetBitmap(active_count_));
@@ -167,8 +168,8 @@ PhyRandomSampleNode::GetOutput() {
             data.flip();
         }
 
-        result =
-            std::make_shared<RowVector>(std::vector<VectorPtr>{sample_output});
+        result = std::make_shared<RowVector>(
+            std::vector<VectorPtr>{std::move(sample_output)});
     }
 
     std::chrono::high_resolution_clock::time_point end =

--- a/internal/core/src/exec/operator/groupby/SearchGroupByOperator.cpp
+++ b/internal/core/src/exec/operator/groupby/SearchGroupByOperator.cpp
@@ -384,7 +384,7 @@ GroupIteratorResult(const std::shared_ptr<VectorIterator>& iterator,
     std::sort(res.begin(), res.end(), customComparator);
 
     //4. save groupBy results
-    for (auto iter = res.cbegin(); iter != res.cend(); iter++) {
+    for (auto iter = res.begin(); iter != res.end(); ++iter) {
         offsets.emplace_back(std::get<0>(*iter));
         distances.emplace_back(std::get<1>(*iter));
         group_by_values.emplace_back(std::move(std::get<2>(*iter)));

--- a/internal/core/src/index/BitmapIndex.cpp
+++ b/internal/core/src/index/BitmapIndex.cpp
@@ -626,9 +626,10 @@ BitmapIndex<T>::In(const size_t n, const T* values) {
         }
     } else {
         for (size_t i = 0; i < n; ++i) {
-            auto val = values[i];
-            if (bitsets_.find(val) != bitsets_.end()) {
-                res |= bitsets_.at(val);
+            const auto& val = values[i];
+            auto it = bitsets_.find(val);
+            if (it != bitsets_.end()) {
+                res |= it->second;
             }
         }
     }
@@ -674,9 +675,10 @@ BitmapIndex<T>::NotIn(const size_t n, const T* values) {
     } else {
         TargetBitmap res(total_num_rows_, false);
         for (size_t i = 0; i < n; ++i) {
-            auto val = values[i];
-            if (bitsets_.find(val) != bitsets_.end()) {
-                res |= bitsets_.at(val);
+            const auto& val = values[i];
+            auto it = bitsets_.find(val);
+            if (it != bitsets_.end()) {
+                res |= it->second;
             }
         }
         res.flip();

--- a/internal/core/src/index/HybridScalarIndex.cpp
+++ b/internal/core/src/index/HybridScalarIndex.cpp
@@ -176,7 +176,6 @@ template <typename T>
 ScalarIndexType
 HybridScalarIndex<T>::SelectIndexBuildType(
     const std::vector<FieldDataPtr>& field_datas) {
-    std::set<T> distinct_vals;
     if (IsPrimitiveType(field_type_)) {
         return SelectBuildTypeForPrimitiveType(field_datas);
     } else if (IsArrayType(field_type_)) {
@@ -334,6 +333,7 @@ HybridScalarIndex<T>::GetRemoteIndexTypeFile(
         auto file_name = file.substr(file.find_last_of('/') + 1);
         if (file_name == index::INDEX_TYPE) {
             ret = file;
+            break;
         }
     }
     AssertInfo(!ret.empty(), "index type file not found for hybrid index");

--- a/internal/core/src/index/IndexFactory.cpp
+++ b/internal/core/src/index/IndexFactory.cpp
@@ -141,9 +141,9 @@ IndexFactory::VecIndexLoadResource(
     int64_t dim) {
     auto config = milvus::index::ParseConfigFromIndexParams(index_params);
 
-    AssertInfo(index_params.find("index_type") != index_params.end(),
-               "index type is empty");
-    std::string index_type = index_params.at("index_type");
+    auto index_type_it = index_params.find("index_type");
+    AssertInfo(index_type_it != index_params.end(), "index type is empty");
+    const std::string& index_type = index_type_it->second;
 
     bool mmaped = false;
     if (mmap_enable &&
@@ -297,17 +297,18 @@ IndexFactory::VecIndexLoadResource(
     }
 
     LoadResourceRequest request{};
+    const auto& res = resource.value();
 
     request.has_raw_data = has_raw_data;
-    request.final_disk_cost = resource.value().diskCost;
-    request.final_memory_cost = resource.value().memoryCost;
+    request.final_disk_cost = res.diskCost;
+    request.final_memory_cost = res.memoryCost;
     if (knowhere::UseDiskLoad(index_type, index_version) || mmaped) {
-        request.max_disk_cost = resource.value().diskCost;
-        request.max_memory_cost = std::max(resource.value().memoryCost,
-                                           download_buffer_size_in_bytes);
+        request.max_disk_cost = res.diskCost;
+        request.max_memory_cost =
+            std::max(res.memoryCost, download_buffer_size_in_bytes);
     } else {
         request.max_disk_cost = 0;
-        request.max_memory_cost = 2 * resource.value().memoryCost;
+        request.max_memory_cost = 2 * res.memoryCost;
     }
     return request;
 }
@@ -321,9 +322,9 @@ IndexFactory::ScalarIndexLoadResource(
     bool mmap_enable) {
     auto config = milvus::index::ParseConfigFromIndexParams(index_params);
 
-    AssertInfo(index_params.find("index_type") != index_params.end(),
-               "index type is empty");
-    std::string index_type = index_params.at("index_type");
+    auto index_type_it = index_params.find("index_type");
+    AssertInfo(index_type_it != index_params.end(), "index type is empty");
+    const std::string& index_type = index_type_it->second;
 
     knowhere::expected<knowhere::Resource> resource;
 

--- a/internal/core/src/index/IndexStats.cpp
+++ b/internal/core/src/index/IndexStats.cpp
@@ -74,7 +74,7 @@ IndexStats::GetMemSize() const {
 int64_t
 IndexStats::GetSerializedSize() const {
     int64_t size = 0;
-    for (auto& info : serialized_index_infos_) {
+    for (const auto& info : serialized_index_infos_) {
         size += info.file_size;
     }
     return size;

--- a/internal/core/src/index/InvertedIndexTantivy.cpp
+++ b/internal/core/src/index/InvertedIndexTantivy.cpp
@@ -137,11 +137,12 @@ InvertedIndexTantivy<T>::Upload(const Config& config) {
         if (boost::filesystem::is_directory(*iter)) {
             LOG_WARN("{} is a directory", iter->path().string());
         } else {
-            LOG_INFO("trying to add index file: {}", iter->path().string());
-            AssertInfo(disk_file_manager_->AddFile(iter->path().string()),
+            auto file_path_str = iter->path().string();
+            LOG_INFO("trying to add index file: {}", file_path_str);
+            AssertInfo(disk_file_manager_->AddFile(file_path_str),
                        "failed to add index file: {}",
-                       iter->path().string());
-            LOG_INFO("index file: {} added", iter->path().string());
+                       file_path_str);
+            LOG_INFO("index file: {} added", file_path_str);
         }
     }
 
@@ -688,6 +689,7 @@ void
 InvertedIndexTantivy<std::string>::build_index_for_array(
     const std::vector<std::shared_ptr<FieldDataBase>>& field_datas) {
     int64_t offset = 0;
+    std::vector<std::string> output;
     for (const auto& data : field_datas) {
         auto n = data->get_num_rows();
         auto array_column = static_cast<const Array*>(data->Data());
@@ -699,7 +701,7 @@ InvertedIndexTantivy<std::string>::build_index_for_array(
                 Assert(IsStringDataType(
                     static_cast<DataType>(schema_.element_type())));
             }
-            std::vector<std::string> output;
+            output.clear();
             for (int64_t j = 0; j < array_column[i].length(); j++) {
                 output.push_back(
                     array_column[i].template get_data<std::string>(j));

--- a/internal/core/src/index/JsonIndexBuilder.cpp
+++ b/internal/core/src/index/JsonIndexBuilder.cpp
@@ -37,6 +37,7 @@ ProcessJsonFieldData(
 
     bool is_array = cast_type.data_type() == JsonCastType::DataType::ARRAY;
 
+    folly::fbvector<T> values;
     for (const auto& data : field_datas) {
         auto n = data->get_num_rows();
         for (int64_t i = 0; i < n; i++) {
@@ -57,7 +58,7 @@ ProcessJsonFieldData(
                 continue;
             }
 
-            folly::fbvector<T> values;
+            values.clear();
             if (is_array) {
                 auto doc = json_column->dom_doc();
                 auto array_res = doc.at_pointer(nested_path).get_array();

--- a/internal/core/src/index/NgramInvertedIndex.cpp
+++ b/internal/core/src/index/NgramInvertedIndex.cpp
@@ -133,7 +133,7 @@ NgramInvertedIndex::Load(milvus::tracer::TraceContext ctx,
         GetValueFromConfig<milvus::proto::common::LoadPriority>(
             config, milvus::LOAD_PRIORITY)
             .value_or(milvus::proto::common::LoadPriority::HIGH);
-    auto files_value = index_files.value();
+    auto files_value = std::move(*index_files);
     auto it = std::find_if(
         files_value.begin(), files_value.end(), [](const std::string& file) {
             constexpr std::string_view suffix{"/index_null_offset"};
@@ -362,7 +362,7 @@ split_by_wildcard(const std::string& literal) {
                 escape_mode = true;
             } else if (c == '%' || c == '_') {
                 if (r.length() > 0) {
-                    result.push_back(r);
+                    result.push_back(std::move(r));
                     r.clear();
                 }
             } else {
@@ -371,7 +371,7 @@ split_by_wildcard(const std::string& literal) {
         }
     }
     if (r.length() > 0) {
-        result.push_back(r);
+        result.push_back(std::move(r));
     }
     return result;
 }

--- a/internal/core/src/index/RTreeIndex.cpp
+++ b/internal/core/src/index/RTreeIndex.cpp
@@ -10,6 +10,7 @@
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
 #include <boost/filesystem.hpp>
+#include <string_view>
 #include "common/Slice.h"  // for INDEX_FILE_SLICE_META and Disassemble
 #include "common/EasyAssert.h"
 #include "log/Log.h"
@@ -19,6 +20,8 @@
 #include "index/RTreeIndex.h"
 
 namespace milvus::index {
+
+static constexpr size_t kMetaJsonSuffixLen = sizeof(".meta.json") - 1;
 
 static std::string
 GetRTreeTempPrefix() {
@@ -103,7 +106,7 @@ RTreeIndex<T>::Load(milvus::tracer::TraceContext ctx, const Config& config) {
     AssertInfo(index_files_opt.has_value(),
                "index file paths are empty when loading R-Tree index");
 
-    auto files = index_files_opt.value();
+    auto files = std::move(*index_files_opt);
 
     // 1. Extract and load null_offset file(s) if present
     {
@@ -131,9 +134,10 @@ RTreeIndex<T>::Load(milvus::tracer::TraceContext ctx, const Config& config) {
             null_offset_files.push_back(*it);
             for (auto& f : files) {
                 auto filename = GetFileName(f);
-                static const std::string kName = "index_null_offset";
+                static constexpr std::string_view kName = "index_null_offset";
                 if (filename.size() >= kName.size() &&
-                    filename.substr(0, kName.size()) == kName) {
+                    filename.compare(
+                        0, kName.size(), kName.data(), kName.size()) == 0) {
                     null_offset_files.push_back(f);
                 }
             }
@@ -205,8 +209,7 @@ RTreeIndex<T>::Load(milvus::tracer::TraceContext ctx, const Config& config) {
     if (base_path.empty()) {
         for (const auto& p : local_paths) {
             if (ends_with(p, ".meta.json")) {
-                base_path =
-                    p.substr(0, p.size() - std::string(".meta.json").size());
+                base_path = p.substr(0, p.size() - kMetaJsonSuffixLen);
                 break;
             }
         }

--- a/internal/core/src/index/RTreeIndexWrapper.cpp
+++ b/internal/core/src/index/RTreeIndexWrapper.cpp
@@ -114,8 +114,8 @@ RTreeIndexWrapper::bulk_load_from_field_data(
     int64_t absolute_offset = 0;
     for (const auto& fd : field_datas) {
         const auto n = fd->get_num_rows();
+        const bool is_nullable_effective = nullable || fd->IsNullable();
         for (int64_t i = 0; i < n; ++i, ++absolute_offset) {
-            const bool is_nullable_effective = nullable || fd->IsNullable();
             if (is_nullable_effective && !fd->is_valid(i)) {
                 continue;
             }

--- a/internal/core/src/index/ScalarIndex.cpp
+++ b/internal/core/src/index/ScalarIndex.cpp
@@ -79,8 +79,9 @@ ScalarIndex<std::string>::BuildWithRawDataForUT(size_t n,
     auto ok = arr.ParseFromArray(values, n);
     Assert(ok);
 
-    // TODO :: optimize here. avoid memory copy.
-    std::vector<std::string> vecs{arr.data().begin(), arr.data().end()};
+    std::vector<std::string> vecs{
+        std::make_move_iterator(arr.mutable_data()->begin()),
+        std::make_move_iterator(arr.mutable_data()->end())};
     Build(arr.data_size(), vecs.data());
 }
 

--- a/internal/core/src/index/ScalarIndexSort.cpp
+++ b/internal/core/src/index/ScalarIndexSort.cpp
@@ -324,15 +324,16 @@ ScalarIndexSort<T>::In(const size_t n, const T* values) {
     AssertInfo(is_built_, "index has not been built");
     TargetBitmap bitset(Count());
     for (size_t i = 0; i < n; ++i) {
-        auto lb =
-            std::lower_bound(begin(), end(), IndexStructure<T>(*(values + i)));
-        auto ub =
-            std::upper_bound(begin(), end(), IndexStructure<T>(*(values + i)));
+        const auto target = IndexStructure<T>(*(values + i));
+        auto lb = std::lower_bound(begin(), end(), target);
+        auto ub = std::upper_bound(lb, end(), target);
         for (; lb < ub; ++lb) {
-            if (lb->a_ != *(values + i)) {
-                std::cout << "error happens in ScalarIndexSort<T>::In, "
-                             "experted value is: "
-                          << *(values + i) << ", but real value is: " << lb->a_;
+            if (lb->a_ != target.a_) {
+                LOG_ERROR(
+                    "error happens in ScalarIndexSort<T>::In, "
+                    "expected value is: {}, but real value is: {}",
+                    target.a_,
+                    lb->a_);
             }
             bitset[lb->idx_] = true;
         }
@@ -346,15 +347,16 @@ ScalarIndexSort<T>::NotIn(const size_t n, const T* values) {
     AssertInfo(is_built_, "index has not been built");
     TargetBitmap bitset(Count(), true);
     for (size_t i = 0; i < n; ++i) {
-        auto lb =
-            std::lower_bound(begin(), end(), IndexStructure<T>(*(values + i)));
-        auto ub =
-            std::upper_bound(begin(), end(), IndexStructure<T>(*(values + i)));
+        const auto target = IndexStructure<T>(*(values + i));
+        auto lb = std::lower_bound(begin(), end(), target);
+        auto ub = std::upper_bound(lb, end(), target);
         for (; lb < ub; ++lb) {
-            if (lb->a_ != *(values + i)) {
-                std::cout << "error happens in ScalarIndexSort<T>::NotIn, "
-                             "experted value is: "
-                          << *(values + i) << ", but real value is: " << lb->a_;
+            if (lb->a_ != target.a_) {
+                LOG_ERROR(
+                    "error happens in ScalarIndexSort<T>::NotIn, "
+                    "expected value is: {}, but real value is: {}",
+                    target.a_,
+                    lb->a_);
             }
             bitset[lb->idx_] = false;
         }

--- a/internal/core/src/index/StringIndexMarisa.cpp
+++ b/internal/core/src/index/StringIndexMarisa.cpp
@@ -392,8 +392,8 @@ StringIndexMarisa::Range(std::string value, OpType op) {
         case OpType::GreaterThan: {
             if (in_lexico_order) {
                 while (trie_.predictive_search(agent)) {
-                    auto key =
-                        std::string(agent.key().ptr(), agent.key().length());
+                    std::string_view key(agent.key().ptr(),
+                                         agent.key().length());
                     if (key > value) {
                         ids.push_back(agent.key().id());
                         break;
@@ -406,8 +406,8 @@ StringIndexMarisa::Range(std::string value, OpType op) {
             } else {
                 // lexicographic order is not guaranteed, check all values
                 while (trie_.predictive_search(agent)) {
-                    auto key =
-                        std::string(agent.key().ptr(), agent.key().length());
+                    std::string_view key(agent.key().ptr(),
+                                         agent.key().length());
                     if (key > value) {
                         ids.push_back(agent.key().id());
                     }
@@ -418,8 +418,8 @@ StringIndexMarisa::Range(std::string value, OpType op) {
         case OpType::GreaterEqual: {
             if (in_lexico_order) {
                 while (trie_.predictive_search(agent)) {
-                    auto key =
-                        std::string(agent.key().ptr(), agent.key().length());
+                    std::string_view key(agent.key().ptr(),
+                                         agent.key().length());
                     if (key >= value) {
                         ids.push_back(agent.key().id());
                         break;
@@ -432,8 +432,8 @@ StringIndexMarisa::Range(std::string value, OpType op) {
             } else {
                 // lexicographic order is not guaranteed, check all values
                 while (trie_.predictive_search(agent)) {
-                    auto key =
-                        std::string(agent.key().ptr(), agent.key().length());
+                    std::string_view key(agent.key().ptr(),
+                                         agent.key().length());
                     if (key >= value) {
                         ids.push_back(agent.key().id());
                     }
@@ -444,8 +444,8 @@ StringIndexMarisa::Range(std::string value, OpType op) {
         case OpType::LessThan: {
             if (in_lexico_order) {
                 while (trie_.predictive_search(agent)) {
-                    auto key =
-                        std::string(agent.key().ptr(), agent.key().length());
+                    std::string_view key(agent.key().ptr(),
+                                         agent.key().length());
                     if (key >= value) {
                         break;
                     }
@@ -454,8 +454,8 @@ StringIndexMarisa::Range(std::string value, OpType op) {
             } else {
                 // lexicographic order is not guaranteed, check all values
                 while (trie_.predictive_search(agent)) {
-                    auto key =
-                        std::string(agent.key().ptr(), agent.key().length());
+                    std::string_view key(agent.key().ptr(),
+                                         agent.key().length());
                     if (key < value) {
                         ids.push_back(agent.key().id());
                     }
@@ -466,8 +466,8 @@ StringIndexMarisa::Range(std::string value, OpType op) {
         case OpType::LessEqual: {
             if (in_lexico_order) {
                 while (trie_.predictive_search(agent)) {
-                    auto key =
-                        std::string(agent.key().ptr(), agent.key().length());
+                    std::string_view key(agent.key().ptr(),
+                                         agent.key().length());
                     if (key > value) {
                         break;
                     }
@@ -476,8 +476,8 @@ StringIndexMarisa::Range(std::string value, OpType op) {
             } else {
                 // lexicographic order is not guaranteed, check all values
                 while (trie_.predictive_search(agent)) {
-                    auto key =
-                        std::string(agent.key().ptr(), agent.key().length());
+                    std::string_view key(agent.key().ptr(),
+                                         agent.key().length());
                     if (key <= value) {
                         ids.push_back(agent.key().id());
                     }
@@ -646,9 +646,6 @@ void
 StringIndexMarisa::fill_offsets() {
     for (size_t offset = 0; offset < str_ids_.size(); offset++) {
         auto str_id = str_ids_[offset];
-        if (str_ids_to_offsets_.find(str_id) == str_ids_to_offsets_.end()) {
-            str_ids_to_offsets_[str_id] = std::vector<size_t>{};
-        }
         str_ids_to_offsets_[str_id].push_back(offset);
     }
 }

--- a/internal/core/src/index/TextMatchIndex.cpp
+++ b/internal/core/src/index/TextMatchIndex.cpp
@@ -100,14 +100,15 @@ TextMatchIndex::Upload(const Config& config) {
 
     for (boost::filesystem::directory_iterator iter(p); iter != end_iter;
          iter++) {
+        auto path_str = iter->path().string();
         if (boost::filesystem::is_directory(*iter)) {
-            LOG_WARN("{} is a directory", iter->path().string());
+            LOG_WARN("{} is a directory", path_str);
         } else {
-            LOG_INFO("trying to add text log: {}", iter->path().string());
-            AssertInfo(disk_file_manager_->AddTextLog(iter->path().string()),
+            LOG_INFO("trying to add text log: {}", path_str);
+            AssertInfo(disk_file_manager_->AddTextLog(path_str),
                        "failed to add text log: {}",
-                       iter->path().string());
-            LOG_INFO("text log: {} added", iter->path().string());
+                       path_str);
+            LOG_INFO("text log: {} added", path_str);
         }
     }
 
@@ -198,7 +199,7 @@ void
 TextMatchIndex::AddNullSealed(int64_t offset) {
     null_offset_.push_back(offset);
     // still need to add null to make offset is correct
-    std::string empty = "";
+    static const std::string empty;
     wrapper_->add_array_data(&empty, 0, offset);
 }
 
@@ -245,7 +246,7 @@ TextMatchIndex::BuildIndexFromFieldData(
                     null_offset_.push_back(offset);
                     // add empty array doc to register offset in tantivy,
                     // same as AddNullSealed
-                    std::string empty = "";
+                    static const std::string empty;
                     wrapper_->add_array_data(&empty, 0, offset);
                 } else {
                     wrapper_->add_data(

--- a/internal/core/src/index/Utils.cpp
+++ b/internal/core/src/index/Utils.cpp
@@ -395,8 +395,8 @@ ReadDataFromFD(int fd, void* buf, size_t size, size_t chunk_size) {
         const ssize_t size_read = read(fd, buf, count);
         if (size_read != count) {
             ThrowInfo(ErrorCode::UnistdError,
-                      "read data from fd error, returned read size is " +
-                          std::to_string(size_read));
+                      "read data from fd error, returned read size is {}",
+                      size_read);
         }
 
         buf = static_cast<char*>(buf) + size_read;

--- a/internal/core/src/index/VectorDiskIndex.cpp
+++ b/internal/core/src/index/VectorDiskIndex.cpp
@@ -117,7 +117,8 @@ VectorDiskAnnIndex<T>::Load(milvus::tracer::TraceContext ctx,
     auto stat = index_.Deserialize(knowhere::BinarySet(), load_config);
     if (stat != knowhere::Status::success)
         ThrowInfo(ErrorCode::UnexpectedError,
-                  "failed to Deserialize index, " + KnowhereStatusString(stat));
+                  "failed to Deserialize index, {}",
+                  KnowhereStatusString(stat));
     span_load_engine->End();
 
     SetDim(index_.Dim());
@@ -130,7 +131,8 @@ VectorDiskAnnIndex<T>::Upload(const Config& config) {
     auto stat = index_.Serialize(ret);
     if (stat != knowhere::Status::success) {
         ThrowInfo(ErrorCode::UnexpectedError,
-                  "failed to serialize index, " + KnowhereStatusString(stat));
+                  "failed to serialize index, {}",
+                  KnowhereStatusString(stat));
     }
     auto remote_paths_to_size = file_manager_->GetRemotePathsToFileSize();
     return IndexStats::NewFromSizeMap(file_manager_->GetAddedTotalFileSize(),
@@ -181,9 +183,9 @@ VectorDiskAnnIndex<T>::Build(const Config& config) {
     if (GetIndexType() == knowhere::IndexEnum::INDEX_DISKANN) {
         auto num_threads = GetValueFromConfig<std::string>(
             build_config, DISK_ANN_BUILD_THREAD_NUM);
-        AssertInfo(
-            num_threads.has_value(),
-            "param " + std::string(DISK_ANN_BUILD_THREAD_NUM) + "is empty");
+        AssertInfo(num_threads.has_value(),
+                   "param {} is empty",
+                   DISK_ANN_BUILD_THREAD_NUM);
         build_config[DISK_ANN_THREADS_NUM] =
             std::atoi(num_threads.value().c_str());
     }
@@ -205,7 +207,8 @@ VectorDiskAnnIndex<T>::Build(const Config& config) {
     auto stat = index_.Build({}, build_config);
     if (stat != knowhere::Status::success)
         ThrowInfo(ErrorCode::IndexBuildError,
-                  "failed to build disk index, " + KnowhereStatusString(stat));
+                  "failed to build disk index, {}",
+                  KnowhereStatusString(stat));
 
     local_chunk_manager->RemoveDir(storage::GenFieldRawDataPathPrefix(
         local_chunk_manager, segment_id, field_id));
@@ -237,9 +240,9 @@ VectorDiskAnnIndex<T>::BuildWithDataset(const DatasetPtr& dataset,
     if (GetIndexType() == knowhere::IndexEnum::INDEX_DISKANN) {
         auto num_threads = GetValueFromConfig<std::string>(
             build_config, DISK_ANN_BUILD_THREAD_NUM);
-        AssertInfo(
-            num_threads.has_value(),
-            "param " + std::string(DISK_ANN_BUILD_THREAD_NUM) + "is empty");
+        AssertInfo(num_threads.has_value(),
+                   "param {} is empty",
+                   DISK_ANN_BUILD_THREAD_NUM);
         build_config[DISK_ANN_THREADS_NUM] =
             std::atoi(num_threads.value().c_str());
     }
@@ -306,7 +309,8 @@ VectorDiskAnnIndex<T>::BuildWithDataset(const DatasetPtr& dataset,
     auto stat = index_.Build({}, build_config);
     if (stat != knowhere::Status::success)
         ThrowInfo(ErrorCode::IndexBuildError,
-                  "failed to build index, " + KnowhereStatusString(stat));
+                  "failed to build index, {}",
+                  KnowhereStatusString(stat));
     local_chunk_manager->RemoveDir(storage::GenFieldRawDataPathPrefix(
         local_chunk_manager, segment_id, field_id));
 
@@ -466,9 +470,9 @@ VectorDiskAnnIndex<T>::update_load_json(const Config& config) {
         // set threads number
         auto num_threads = GetValueFromConfig<std::string>(
             load_config, DISK_ANN_LOAD_THREAD_NUM);
-        AssertInfo(
-            num_threads.has_value(),
-            "param " + std::string(DISK_ANN_LOAD_THREAD_NUM) + "is empty");
+        AssertInfo(num_threads.has_value(),
+                   "param {} is empty",
+                   DISK_ANN_LOAD_THREAD_NUM);
         load_config[DISK_ANN_THREADS_NUM] =
             std::atoi(num_threads.value().c_str());
 

--- a/internal/core/src/index/VectorMemIndex.cpp
+++ b/internal/core/src/index/VectorMemIndex.cpp
@@ -70,7 +70,9 @@ VectorMemIndex<T>::VectorMemIndex(
       use_knowhere_build_pool_(use_knowhere_build_pool) {
     CheckMetricTypeSupport<T>(metric_type);
     AssertInfo(!is_unsupported(index_type, metric_type),
-               index_type + " doesn't support metric: " + metric_type);
+               "{} doesn't support metric: {}",
+               index_type,
+               metric_type);
     if (file_manager_context.Valid()) {
         file_manager_ =
             std::make_shared<storage::MemFileManagerImpl>(file_manager_context);
@@ -102,7 +104,9 @@ VectorMemIndex<T>::VectorMemIndex(DataType elem_type,
       use_knowhere_build_pool_(use_knowhere_build_pool) {
     CheckMetricTypeSupport<T>(metric_type);
     AssertInfo(!is_unsupported(index_type, metric_type),
-               index_type + " doesn't support metric: " + metric_type);
+               "{} doesn't support metric: {}",
+               index_type,
+               metric_type);
 
     auto view_data_pack = knowhere::Pack(view_data);
     auto get_index_obj = knowhere::IndexFactory::Instance().Create<T>(
@@ -266,7 +270,7 @@ VectorMemIndex<T>::Load(milvus::tracer::TraceContext ctx,
                                          pending_index_files.end()),
                 load_priority);
             for (auto&& index_data : result) {
-                auto prefix = index_data.first;
+                const auto& prefix = index_data.first;
                 index_data_codecs.insert({prefix, IndexDataCodec{}});
                 auto& index_data_codec = index_data_codecs.at(prefix);
                 index_data_codec.size_ = index_data.second->PayloadSize();
@@ -310,7 +314,8 @@ VectorMemIndex<T>::BuildWithDataset(const DatasetPtr& dataset,
     auto stat = index_.Build(dataset, index_config, use_knowhere_build_pool_);
     if (stat != knowhere::Status::success)
         ThrowInfo(ErrorCode::IndexBuildError,
-                  "failed to build index, " + KnowhereStatusString(stat));
+                  "failed to build index, {}",
+                  KnowhereStatusString(stat));
     LOG_INFO("build memory index with KNOWHERE done, build_id: {}",
              config.value("build_id", "unknown"));
     rc.ElapseFromBegin("Done");
@@ -459,7 +464,8 @@ VectorMemIndex<T>::AddWithDataset(const DatasetPtr& dataset,
     auto stat = index_.Add(dataset, index_config, use_knowhere_build_pool_);
     if (stat != knowhere::Status::success)
         ThrowInfo(ErrorCode::IndexBuildError,
-                  "failed to append index, " + KnowhereStatusString(stat));
+                  "failed to append index, {}",
+                  KnowhereStatusString(stat));
     rc.ElapseFromBegin("Done");
 }
 
@@ -557,7 +563,8 @@ VectorMemIndex<T>::GetVector(const DatasetPtr dataset) const {
     auto res = index_.GetVectorByIds(dataset);
     if (!res.has_value()) {
         ThrowInfo(ErrorCode::UnexpectedError,
-                  "failed to get vector, " + KnowhereStatusString(res.error()));
+                  "failed to get vector, {}",
+                  KnowhereStatusString(res.error()));
     }
     auto tensor = res.value()->GetTensor();
     auto row_num = res.value()->GetRows();
@@ -575,7 +582,8 @@ VectorMemIndex<T>::GetSparseVector(const DatasetPtr dataset) const {
     auto res = index_.GetVectorByIds(dataset);
     if (!res.has_value()) {
         ThrowInfo(ErrorCode::UnexpectedError,
-                  "failed to get vector, " + KnowhereStatusString(res.error()));
+                  "failed to get vector, {}",
+                  KnowhereStatusString(res.error()));
     }
     // release and transfer ownership to the result unique ptr.
     res.value()->SetIsOwner(false);

--- a/internal/core/src/index/json_stats/JsonKeyStats.cpp
+++ b/internal/core/src/index/json_stats/JsonKeyStats.cpp
@@ -116,7 +116,7 @@ JsonKeyStats::AddKeyStatsInfo(const std::vector<std::string>& paths,
                               JSONType type,
                               uint8_t* value,
                               std::map<JsonKey, KeyStatsInfo>& infos) {
-    std::string key = "";
+    std::string key;
     if (!paths.empty()) {
         key = JsonPointer(paths);
     }
@@ -766,7 +766,7 @@ JsonKeyStats::BuildWithFieldData(const std::vector<FieldDataPtr>& field_datas,
 
     auto writer_context =
         ParquetWriterFactory::CreateContext(key_types_, remote_prefix);
-    parquet_writer_->Init(writer_context);
+    parquet_writer_->Init(std::move(writer_context));
     BuildKeyStats(field_datas, nullable);
     parquet_writer_->Close();
     bson_inverted_index_->BuildIndex();
@@ -782,8 +782,8 @@ JsonKeyStats::GetColumnSchemaFromParquet(int64_t column_group_id,
                   .GetArrowFileSystem();
     auto result = milvus_storage::FileRowGroupReader::Make(fs, file);
     AssertInfo(result.ok(),
-               "[StorageV2] Failed to create file row group reader: " +
-                   result.status().ToString());
+               "[StorageV2] Failed to create file row group reader: {}",
+               result.status().ToString());
     auto file_reader = result.ValueOrDie();
     std::shared_ptr<arrow::Schema> file_schema = file_reader->schema();
     LOG_DEBUG("get column schema: [{}] for segment {}",
@@ -846,8 +846,8 @@ JsonKeyStats::GetCommonMetaFromParquet(const std::string& file) {
                   .GetArrowFileSystem();
     auto result = milvus_storage::FileRowGroupReader::Make(fs, file);
     AssertInfo(result.ok(),
-               "[StorageV2] Failed to create file row group reader: " +
-                   result.status().ToString());
+               "[StorageV2] Failed to create file row group reader: {}",
+               result.status().ToString());
     auto file_reader = result.ValueOrDie();
     // get key value metadata from parquet file
     std::shared_ptr<milvus_storage::PackedFileMetadata> metadata =
@@ -952,8 +952,8 @@ JsonKeyStats::LoadColumnGroup(int64_t column_group_id,
                   .GetArrowFileSystem();
     auto result = milvus_storage::FileRowGroupReader::Make(fs, files[0]);
     AssertInfo(result.ok(),
-               "[StorageV2] Failed to create file row group reader: " +
-                   result.status().ToString());
+               "[StorageV2] Failed to create file row group reader: {}",
+               result.status().ToString());
     auto file_reader = result.ValueOrDie();
     std::shared_ptr<milvus_storage::PackedFileMetadata> metadata =
         file_reader->file_metadata();

--- a/internal/core/src/index/json_stats/bson_inverted.cpp
+++ b/internal/core/src/index/json_stats/bson_inverted.cpp
@@ -65,12 +65,8 @@ void
 BsonInvertedIndex::AddRecord(const std::string& key,
                              uint32_t row_id,
                              uint32_t offset) {
-    if (inverted_index_map_.find(key) == inverted_index_map_.end()) {
-        inverted_index_map_[key] = {EncodeInvertedIndexValue(row_id, offset)};
-    } else {
-        inverted_index_map_[key].push_back(
-            EncodeInvertedIndexValue(row_id, offset));
-    }
+    inverted_index_map_[key].push_back(
+        EncodeInvertedIndexValue(row_id, offset));
 }
 
 void
@@ -152,17 +148,15 @@ BsonInvertedIndex::UploadIndex() {
 
     for (boost::filesystem::directory_iterator iter(p); iter != end_iter;
          iter++) {
+        auto file_path = iter->path().string();
         if (boost::filesystem::is_directory(*iter)) {
-            LOG_WARN("{} is a directory", iter->path().string());
+            LOG_WARN("{} is a directory", file_path);
         } else {
-            LOG_INFO("trying to add bson inverted index file: {}",
-                     iter->path().string());
-            AssertInfo(disk_file_manager_->AddJsonSharedIndexLog(
-                           iter->path().string()),
+            LOG_INFO("trying to add bson inverted index file: {}", file_path);
+            AssertInfo(disk_file_manager_->AddJsonSharedIndexLog(file_path),
                        "failed to add bson inverted index file: {}",
-                       iter->path().string());
-            LOG_INFO("bson inverted index file: {} added",
-                     iter->path().string());
+                       file_path);
+            LOG_INFO("bson inverted index file: {} added", file_path);
         }
     }
 
@@ -170,7 +164,7 @@ BsonInvertedIndex::UploadIndex() {
 
     std::vector<SerializedIndexFileInfo> index_files;
     index_files.reserve(remote_paths_to_size.size());
-    for (auto& file : remote_paths_to_size) {
+    for (const auto& file : remote_paths_to_size) {
         index_files.emplace_back(file.first, file.second);
     }
     return IndexStats::New(disk_file_manager_->GetAddedTotalFileSize(),

--- a/internal/core/src/index/json_stats/parquet_writer.cpp
+++ b/internal/core/src/index/json_stats/parquet_writer.cpp
@@ -64,7 +64,7 @@ JsonStatsParquetWriter::UpdatePathSizeMap(
     const std::vector<std::shared_ptr<arrow::Array>>& arrays) {
     auto index = 0;
     for (const auto& group : column_groups_) {
-        auto path = file_paths_[index];
+        const auto& path = file_paths_[index];
         for (const auto& column_index : group) {
             size_t size = GetArrowArrayMemorySize(arrays[column_index]);
             path_size_map_[path] += size;
@@ -93,8 +93,8 @@ JsonStatsParquetWriter::WriteCurrentBatch() {
 
     UpdatePathSizeMap(arrays);
 
-    auto batch =
-        arrow::RecordBatch::Make(schema_, unflushed_row_count_, arrays);
+    auto batch = arrow::RecordBatch::Make(
+        schema_, unflushed_row_count_, std::move(arrays));
     auto status = packed_writer_->Write(batch);
     AssertInfo(
         status.ok(), "failed to write batch, error: {}", status.ToString());
@@ -105,13 +105,13 @@ JsonStatsParquetWriter::WriteCurrentBatch() {
 }
 
 void
-JsonStatsParquetWriter::Init(const ParquetWriteContext& context) {
-    schema_ = context.schema;
-    builders_ = context.builders;
-    builders_map_ = context.builders_map;
-    kv_metadata_ = context.kv_metadata;
-    column_groups_ = context.column_groups;
-    file_paths_ = context.file_paths;
+JsonStatsParquetWriter::Init(ParquetWriteContext context) {
+    schema_ = std::move(context.schema);
+    builders_ = std::move(context.builders);
+    builders_map_ = std::move(context.builders_map);
+    kv_metadata_ = std::move(context.kv_metadata);
+    column_groups_ = std::move(context.column_groups);
+    file_paths_ = std::move(context.file_paths);
     auto result = milvus_storage::PackedRecordBatchWriter::Make(fs_,
                                                                 file_paths_,
                                                                 schema_,
@@ -119,8 +119,8 @@ JsonStatsParquetWriter::Init(const ParquetWriteContext& context) {
                                                                 column_groups_,
                                                                 buffer_size_);
     AssertInfo(result.ok(),
-               "[StorageV2] Failed to create packed writer: " +
-                   result.status().ToString());
+               "[StorageV2] Failed to create packed writer: {}",
+               result.status().ToString());
     packed_writer_ = result.ValueOrDie();
     for (const auto& [key, value] : kv_metadata_) {
         packed_writer_->AddUserMetadata(key, value);
@@ -187,7 +187,8 @@ JsonStatsParquetWriter::AppendRow(
 
 arrow::Status
 JsonStatsParquetWriter::AppendDataToBuilder(
-    const std::string& value, std::shared_ptr<arrow::ArrayBuilder> builder) {
+    const std::string& value,
+    const std::shared_ptr<arrow::ArrayBuilder>& builder) {
     auto type_id = builder->type()->id();
 
     if (value.empty()) {

--- a/internal/core/src/index/json_stats/parquet_writer.h
+++ b/internal/core/src/index/json_stats/parquet_writer.h
@@ -178,7 +178,7 @@ class JsonStatsParquetWriter {
     ~JsonStatsParquetWriter();
 
     void
-    Init(const ParquetWriteContext& context);
+    Init(ParquetWriteContext context);
 
     void
     AppendValue(const std::string& key, const std::string& value);
@@ -217,7 +217,7 @@ class JsonStatsParquetWriter {
  private:
     arrow::Status
     AppendDataToBuilder(const std::string& value,
-                        std::shared_ptr<arrow::ArrayBuilder> builder);
+                        const std::shared_ptr<arrow::ArrayBuilder>& builder);
 
     // init info
     std::shared_ptr<arrow::Schema> schema_{nullptr};

--- a/internal/core/src/index/json_stats/utils.cpp
+++ b/internal/core/src/index/json_stats/utils.cpp
@@ -160,7 +160,7 @@ CreateArrowBuilders(const std::map<JsonKey, JsonKeyLayoutType>& column_map) {
         }
     }
     builders.push_back(shared_builder);
-    return std::make_pair(builders, builders_map);
+    return {std::move(builders), std::move(builders_map)};
 }
 
 std::shared_ptr<arrow::Schema>
@@ -262,7 +262,7 @@ JsonStatsMeta::Deserialize(const std::string& json_str) {
                         JsonKeyLayoutTypeFromString(layout_type_str);
                     layout_map[json_key] = layout_type;
                 }
-                meta.SetLayoutTypeMap(layout_map);
+                meta.SetLayoutTypeMap(std::move(layout_map));
             } else if (it.value().is_string()) {
                 meta.SetString(key, it.value().get<std::string>());
             } else if (it.value().is_number_integer()) {

--- a/internal/core/src/index/json_stats/utils.h
+++ b/internal/core/src/index/json_stats/utils.h
@@ -546,6 +546,11 @@ class JsonStatsMeta {
         layout_type_map_ = layout_map;
     }
 
+    void
+    SetLayoutTypeMap(std::map<JsonKey, JsonKeyLayoutType>&& layout_map) {
+        layout_type_map_ = std::move(layout_map);
+    }
+
     const std::map<JsonKey, JsonKeyLayoutType>&
     GetLayoutTypeMap() const {
         return layout_type_map_;

--- a/internal/core/src/indexbuilder/index_c.cpp
+++ b/internal/core/src/indexbuilder/index_c.cpp
@@ -104,7 +104,6 @@ get_storage_config(const milvus::proto::indexcgo::StorageConfig& config) {
     storage_config.storage_type = std::string(config.storage_type());
     storage_config.cloud_provider = std::string(config.cloud_provider());
     storage_config.iam_endpoint = std::string(config.iamendpoint());
-    storage_config.cloud_provider = std::string(config.cloud_provider());
     storage_config.useSSL = config.usessl();
     storage_config.sslCACert = config.sslcacert();
     storage_config.useIAM = config.useiam();
@@ -125,15 +124,20 @@ get_opt_field(const ::google::protobuf::RepeatedPtrField<
     milvus::OptFieldT opt_fields_map;
     for (const auto& field_info : field_infos) {
         auto field_id = field_info.fieldid();
-        if (opt_fields_map.find(field_id) == opt_fields_map.end()) {
-            opt_fields_map[field_id] = {
-                field_info.field_name(),
-                static_cast<milvus::DataType>(field_info.field_type()),
-                static_cast<milvus::DataType>(field_info.element_type()),
-                {}};
+        auto it = opt_fields_map.find(field_id);
+        if (it == opt_fields_map.end()) {
+            it = opt_fields_map
+                     .emplace(field_id,
+                              std::make_tuple(field_info.field_name(),
+                                              static_cast<milvus::DataType>(
+                                                  field_info.field_type()),
+                                              static_cast<milvus::DataType>(
+                                                  field_info.element_type()),
+                                              std::vector<std::string>{}))
+                     .first;
         }
         for (const auto& str : field_info.data_paths()) {
-            std::get<3>(opt_fields_map[field_id]).emplace_back(str);
+            std::get<3>(it->second).emplace_back(str);
         }
     }
 

--- a/internal/core/src/monitor/scope_metric.cpp
+++ b/internal/core/src/monitor/scope_metric.cpp
@@ -34,7 +34,7 @@ GetHistogram(std::string&& func) {
             .Register(getPrometheusClient().GetRegistry());
 
     // default buckets: [0.005, 0.01, ..., 1.0]
-    return hist_family.Add({{"func", func}}, cgoCallDurationbuckets);
+    return hist_family.Add({{"func", std::move(func)}}, cgoCallDurationbuckets);
 }
 
 FuncScopeMetric::FuncScopeMetric(const char* f)

--- a/internal/core/src/query/CachedSearchIterator.cpp
+++ b/internal/core/src/query/CachedSearchIterator.cpp
@@ -187,7 +187,7 @@ CachedSearchIterator::ValidateSearchInfo(const SearchInfo& search_info) {
                   "Iterator v2 SearchInfo is not set");
     }
 
-    auto iterator_v2_info = search_info.iterator_v2_info_.value();
+    const auto& iterator_v2_info = search_info.iterator_v2_info_.value();
     if (iterator_v2_info.batch_size != batch_size_) {
         ThrowInfo(ErrorCode::UnexpectedError,
                   "Batch size mismatch, expect %d, but got %d",
@@ -320,7 +320,7 @@ CachedSearchIterator::Init(const SearchInfo& search_info) {
                   "Iterator v2 info is not set, cannot initialize iterator");
     }
 
-    auto iterator_v2_info = search_info.iterator_v2_info_.value();
+    const auto& iterator_v2_info = search_info.iterator_v2_info_.value();
     if (iterator_v2_info.batch_size == 0) {
         ThrowInfo(ErrorCode::UnexpectedError,
                   "Batch size is 0, cannot initialize iterator");

--- a/internal/core/src/query/ExecPlanNodeVisitor.cpp
+++ b/internal/core/src/query/ExecPlanNodeVisitor.cpp
@@ -59,7 +59,7 @@ ExecPlanNodeVisitor::ExecuteTask(
             Assert(processed_num == query_context->get_active_count());
             break;
         }
-        auto childrens = result->childrens();
+        const auto& childrens = result->childrens();
         AssertInfo(childrens.size() == 1,
                    "plannode result vector's children size not equal one");
         LOG_DEBUG("output result length:{}", childrens[0]->size());

--- a/internal/core/src/query/PlanProto.cpp
+++ b/internal/core/src/query/PlanProto.cpp
@@ -436,8 +436,7 @@ ProtoParser::ParseCallExprs(const proto::plan::CallExpr& expr_pb) {
 
     auto function = factory.GetFilterFunction(func_sig);
     if (function == nullptr) {
-        ThrowInfo(ExprInvalid,
-                  "function " + func_sig.ToString() + " not found. ");
+        ThrowInfo(ExprInvalid, "function {} not found.", func_sig.ToString());
     }
     return std::make_shared<expr::CallExpr>(
         expr_pb.function_name(), parameters, function);
@@ -643,8 +642,7 @@ ProtoParser::ParseExprs(const proto::plan::Expr& expr_pb,
         default: {
             std::string s;
             google::protobuf::TextFormat::PrintToString(expr_pb, &s);
-            ThrowInfo(ExprInvalid,
-                      std::string("unsupported expr proto node: ") + s);
+            ThrowInfo(ExprInvalid, "unsupported expr proto node: {}", s);
         }
     }
     if (type_check(result->type())) {

--- a/internal/core/src/query/SearchBruteForce.cpp
+++ b/internal/core/src/query/SearchBruteForce.cpp
@@ -264,7 +264,8 @@ BruteForceSearch(const dataset::SearchDataset& query_ds,
         milvus::tracer::AddEvent("knowhere_finish_BruteForce_SearchWithBuf");
         if (stat != knowhere::Status::success) {
             ThrowInfo(KnowhereError,
-                      "Brute force search fail: " + KnowhereStatusString(stat));
+                      "Brute force search fail: {}",
+                      KnowhereStatusString(stat));
         }
     }
     sub_result.round_values();
@@ -335,17 +336,18 @@ PackBruteForceSearchIteratorsIntoSubResult(
     auto iterators_val = GetBruteForceSearchIterators(
         query_ds, raw_ds, search_info, index_info, bitset, data_type);
     if (iterators_val.has_value()) {
+        auto& iterators = iterators_val.value();
         AssertInfo(
-            iterators_val.value().size() == nq,
+            iterators.size() == nq,
             "Wrong state, initialized knowhere_iterators count:{} is not "
             "equal to nq:{} for single chunk",
-            iterators_val.value().size(),
+            iterators.size(),
             nq);
         return SubSearchResult(query_ds.num_queries,
                                query_ds.topk,
                                query_ds.metric_type,
                                query_ds.round_decimal,
-                               iterators_val.value());
+                               iterators);
     } else {
         LOG_ERROR(
             "Failed to get valid knowhere brute-force-iterators from chunk, "

--- a/internal/core/src/query/SearchOnGrowing.cpp
+++ b/internal/core/src/query/SearchOnGrowing.cpp
@@ -175,6 +175,7 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
         auto vec_size_per_chunk = vec_ptr->get_size_per_chunk();
         auto max_chunk = upper_div(active_count, vec_size_per_chunk);
 
+        std::vector<size_t> offsets;
         for (int chunk_id = current_chunk_id; chunk_id < max_chunk;
              ++chunk_id) {
             auto chunk_data = vec_ptr->get_chunk_data(chunk_id);
@@ -186,7 +187,6 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
 
             query::dataset::RawDataset sub_data;
             std::unique_ptr<uint8_t[]> buf = nullptr;
-            std::vector<size_t> offsets;
             if (data_type != DataType::VECTOR_ARRAY) {
                 sub_data = query::dataset::RawDataset{
                     element_begin, dim, size_per_chunk, chunk_data};
@@ -202,6 +202,7 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
                 }
 
                 buf = std::make_unique<uint8_t[]>(size);
+                offsets.clear();
                 offsets.reserve(size_per_chunk + 1);
                 offsets.push_back(0);
 

--- a/internal/core/src/query/Utils.h
+++ b/internal/core/src/query/Utils.h
@@ -56,6 +56,37 @@ Match<std::string_view>(const std::string_view& str,
     }
 }
 
+// Overloads for string_view combinations used when CompareExpr operands
+// hold string_view in the data_access_type variant (chunk access), or a
+// mix of string (index access) and string_view (chunk access).
+inline bool
+Match(const std::string_view& str, const std::string_view& val, OpType op) {
+    switch (op) {
+        case OpType::PrefixMatch:
+            return PrefixMatch(str, val);
+        case OpType::PostfixMatch:
+            return PostfixMatch(str, val);
+        case OpType::InnerMatch:
+            return InnerMatch(str, val);
+        default:
+            ThrowInfo(OpTypeInvalid, "not supported");
+    }
+}
+
+inline bool
+Match(const std::string& str, const std::string_view& val, OpType op) {
+    switch (op) {
+        case OpType::PrefixMatch:
+            return PrefixMatch(str, val);
+        case OpType::PostfixMatch:
+            return PostfixMatch(str, val);
+        case OpType::InnerMatch:
+            return InnerMatch(str, val);
+        default:
+            ThrowInfo(OpTypeInvalid, "not supported");
+    }
+}
+
 template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
 inline bool
 gt_ub(int64_t t) {

--- a/internal/core/src/rescores/Scorer.cpp
+++ b/internal/core/src/rescores/Scorer.cpp
@@ -163,9 +163,9 @@ RandomScorer::random_score(milvus::OpContext* op_ctx,
                    "now only support int64 field as seed");
         // TODO: Support varchar and int32 field as random field.
 
-        auto datas = array->scalars().long_data();
-        for (int i = 0; i < datas.data_size(); i++) {
-            auto a = datas.data()[i];
+        const auto& data = array->scalars().long_data();
+        for (int i = 0; i < data.data_size(); i++) {
+            auto a = data.data()[i];
             auto random_score =
                 hash_to_double(MurmurHash3_x64_64_Special(a, seed_));
             if (idx == nullptr) {
@@ -176,9 +176,10 @@ RandomScorer::random_score(milvus::OpContext* op_ctx,
         }
     } else {
         // if not set field, use offset and seed to hash.
+        const auto segment_id = segment->get_segment_id();
         for (int i = 0; i < target_offsets.size(); i++) {
             double random_score = hash_to_double(MurmurHash3_x64_64_Special(
-                target_offsets[i] + segment->get_segment_id(), seed_));
+                target_offsets[i] + segment_id, seed_));
             if (idx == nullptr) {
                 set_score(random_score, boost_scores[i], mode);
             } else {

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -2163,8 +2163,7 @@ ChunkedSegmentSealedImpl::bulk_subscript(
     column->BulkRawJsonAt(
         op_ctx,
         [&](Json json, size_t offset, bool is_valid) {
-            dst->at(offset) =
-                ExtractSubJson(std::string(json.data()), dynamic_field_names);
+            dst->at(offset) = ExtractSubJson(json.data(), dynamic_field_names);
         },
         seg_offsets,
         count);
@@ -2871,9 +2870,9 @@ ChunkedSegmentSealedImpl::LoadGeometryCache(
 
 void
 ChunkedSegmentSealedImpl::SetLoadInfo(
-    const proto::segcore::SegmentLoadInfo& load_info) {
+    proto::segcore::SegmentLoadInfo load_info) {
     std::unique_lock lck(mutex_);
-    segment_load_info_ = SegmentLoadInfo(load_info, schema_);
+    segment_load_info_ = SegmentLoadInfo(std::move(load_info), schema_);
     LOG_INFO(
         "SetLoadInfo for segment {}, num_rows: {}, index count: {}, "
         "storage_version: {}",

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -195,8 +195,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     FinishLoad() override;
 
     void
-    SetLoadInfo(
-        const milvus::proto::segcore::SegmentLoadInfo& load_info) override;
+    SetLoadInfo(milvus::proto::segcore::SegmentLoadInfo load_info) override;
 
     void
     Load(milvus::tracer::TraceContext& trace_ctx,

--- a/internal/core/src/segcore/Collection.cpp
+++ b/internal/core/src/segcore/Collection.cpp
@@ -32,8 +32,8 @@ Collection::Collection(const std::string_view schema_proto) {
     if (!suc) {
         LOG_WARN("unmarshal schema string failed");
     }
-    collection_name_ = collection_schema.name();
     schema_ = Schema::ParseFrom(collection_schema);
+    collection_name_ = std::move(*collection_schema.mutable_name());
 }
 
 Collection::Collection(const void* schema_proto, const int64_t length) {
@@ -44,8 +44,8 @@ Collection::Collection(const void* schema_proto, const int64_t length) {
         LOG_WARN("unmarshal schema string failed");
     }
 
-    collection_name_ = collection_schema.name();
     schema_ = Schema::ParseFrom(collection_schema);
+    collection_name_ = std::move(*collection_schema.mutable_name());
 }
 
 void

--- a/internal/core/src/segcore/ReduceUtils.cpp
+++ b/internal/core/src/segcore/ReduceUtils.cpp
@@ -298,10 +298,10 @@ AssembleGroupByValues(
             }
         }
 
-        mutable_group_by_field_value->mutable_valid_data()->MergeFrom(
-            *valid_data);
-        mutable_group_by_field_value->mutable_scalars()->MergeFrom(
-            *group_by_res_values.get());
+        mutable_group_by_field_value->mutable_valid_data()->Swap(
+            valid_data.get());
+        mutable_group_by_field_value->mutable_scalars()->Swap(
+            group_by_res_values.get());
     }
 }
 

--- a/internal/core/src/segcore/SegcoreConfig.cpp
+++ b/internal/core/src/segcore/SegcoreConfig.cpp
@@ -18,9 +18,9 @@ namespace milvus::segcore {
 
 static YAML::Node
 subnode(const YAML::Node& parent, const std::string& key) {
-    AssertInfo(parent.IsMap(), "wrong type node when getting key[" + key + "]");
+    AssertInfo(parent.IsMap(), "wrong type node when getting key[{}]", key);
     auto& node = parent[key];
-    AssertInfo(node.IsDefined(), "key[" + key + "] not found in sub-node");
+    AssertInfo(node.IsDefined(), "key[{}] not found in sub-node", key);
     return node;
 }
 

--- a/internal/core/src/segcore/SegmentChunkReader.cpp
+++ b/internal/core/src/segcore/SegmentChunkReader.cpp
@@ -139,7 +139,8 @@ SegmentChunkReader::GetMultipleChunkDataAccessor<std::string>(
                 current_chunk_pos++;
                 return std::nullopt;
             }
-            return chunk_data[current_chunk_pos++];
+            return data_access_type(
+                std::string_view(chunk_data[current_chunk_pos++]));
         };
     } else {
         auto pw = segment_->chunk_view<std::string_view>(
@@ -165,7 +166,7 @@ SegmentChunkReader::GetMultipleChunkDataAccessor<std::string>(
                 current_chunk_pos++;
                 return std::nullopt;
             }
-            return std::string(chunk_data[current_chunk_pos++]);
+            return data_access_type(chunk_data[current_chunk_pos++]);
         };
     }
 }
@@ -279,18 +280,18 @@ SegmentChunkReader::GetChunkDataAccessor<std::string>(
             if (chunk_valid_data && !chunk_valid_data[i]) {
                 return std::nullopt;
             }
-            return chunk_data[i];
+            return data_access_type(std::string_view(chunk_data[i]));
         };
     } else {
         auto pw =
             segment_->chunk_view<std::string_view>(op_ctx_, field_id, chunk_id);
         return [pw = std::move(pw)](int i) mutable -> const data_access_type {
-            auto chunk_data = pw.get().first;
-            auto chunk_valid_data = pw.get().second;
+            auto& chunk_data = pw.get().first;
+            auto& chunk_valid_data = pw.get().second;
             if (i < chunk_valid_data.size() && !chunk_valid_data[i]) {
                 return std::nullopt;
             }
-            return std::string(chunk_data[i]);
+            return data_access_type(chunk_data[i]);
         };
     }
 }

--- a/internal/core/src/segcore/SegmentChunkReader.h
+++ b/internal/core/src/segcore/SegmentChunkReader.h
@@ -31,10 +31,53 @@ using data_access_type = std::optional<boost::variant<bool,
                                                       int64_t,
                                                       float,
                                                       double,
-                                                      std::string>>;
+                                                      std::string,
+                                                      std::string_view>>;
 
 using ChunkDataAccessor = std::function<const data_access_type(int)>;
 using MultipleChunkDataAccessor = std::function<const data_access_type()>;
+
+// Helper to extract a value of type T from data_access_type.
+// For std::string, handles both std::string and std::string_view in the variant.
+// Uses boost::apply_visitor to avoid ADL conflicts between boost::variant::get
+// and boost::array::get.
+namespace detail {
+template <typename T>
+struct ValueExtractor : public boost::static_visitor<T> {
+    T
+    operator()(const T& val) const {
+        return val;
+    }
+    template <typename U>
+    T
+    operator()(const U&) const {
+        ThrowInfo(DataTypeInvalid, "unexpected type in data_access_type");
+    }
+};
+
+template <>
+struct ValueExtractor<std::string> : public boost::static_visitor<std::string> {
+    std::string
+    operator()(const std::string& s) const {
+        return s;
+    }
+    std::string
+    operator()(std::string_view sv) const {
+        return std::string(sv);
+    }
+    template <typename U>
+    std::string
+    operator()(const U&) const {
+        ThrowInfo(DataTypeInvalid, "unexpected type in data_access_type");
+    }
+};
+}  // namespace detail
+
+template <typename T>
+T
+get_from_variant(const data_access_type& opt) {
+    return boost::apply_visitor(detail::ValueExtractor<T>{}, opt.value());
+}
 
 class SegmentChunkReader {
  public:

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -436,8 +436,9 @@ SegmentGrowingImpl::Insert(int64_t reserved_offset,
     auto field_id = schema_->get_primary_field_id().value_or(FieldId(-1));
     AssertInfo(field_id.get() != INVALID_FIELD_ID, "Primary key is -1");
     std::vector<PkType> pks(num_rows);
-    ParsePksFromFieldData(
-        pks, insert_record_proto->fields_data(field_id_to_offset[field_id]));
+    ParsePksFromFieldData(pks,
+                          *insert_record_proto->mutable_fields_data(
+                              field_id_to_offset[field_id]));
     for (int i = 0; i < num_rows; ++i) {
         insert_record_.insert_pk(pks[i], reserved_offset + i);
     }
@@ -945,7 +946,7 @@ SegmentGrowingImpl::bulk_subscript(
     for (int64_t i = 0; i < count; ++i) {
         auto offset = seg_offsets[i];
         dst->at(i) =
-            ExtractSubJson(std::string(src[offset]), dynamic_field_names);
+            ExtractSubJson(std::string_view(src[offset]), dynamic_field_names);
     }
     return result;
 }

--- a/internal/core/src/segcore/SegmentInterface.cpp
+++ b/internal/core/src/segcore/SegmentInterface.cpp
@@ -47,7 +47,7 @@ SegmentInternalInterface::FillPrimaryKeys(const query::Plan* plan,
         bulk_subscript(&op_ctx, pk_field_id, results.seg_offsets_.data(), size);
     results.pk_type_ = DataType(field_data->type());
 
-    ParsePksFromFieldData(results.primary_keys_, *field_data.get());
+    ParsePksFromFieldData(results.primary_keys_, *field_data);
     results.search_storage_cost_.scanned_remote_bytes +=
         op_ctx.storage_usage.scanned_cold_bytes.load();
     results.search_storage_cost_.scanned_total_bytes +=

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -246,7 +246,7 @@ class SegmentInterface {
     FinishLoad() = 0;
 
     virtual void
-    SetLoadInfo(const milvus::proto::segcore::SegmentLoadInfo& load_info) = 0;
+    SetLoadInfo(milvus::proto::segcore::SegmentLoadInfo load_info) = 0;
 
     virtual void
     Load(milvus::tracer::TraceContext& trace_ctx,
@@ -439,9 +439,8 @@ class SegmentInternalInterface : public SegmentInterface {
                          const std::string& nested_path) const override;
 
     virtual void
-    SetLoadInfo(
-        const milvus::proto::segcore::SegmentLoadInfo& load_info) override {
-        load_info_ = load_info;
+    SetLoadInfo(milvus::proto::segcore::SegmentLoadInfo load_info) override {
+        load_info_ = std::move(load_info);
     }
 
  public:

--- a/internal/core/src/segcore/Utils.cpp
+++ b/internal/core/src/segcore/Utils.cpp
@@ -37,7 +37,10 @@
 namespace milvus::segcore {
 
 void
-ParsePksFromFieldData(std::vector<PkType>& pks, const DataArray& data) {
+// Takes a non-const DataArray& because VARCHAR strings are moved (not copied)
+// into the PkType variant vector. Callers must ensure the DataArray is
+// discarded after this call — the VARCHAR fields will be in a moved-from state.
+ParsePksFromFieldData(std::vector<PkType>& pks, DataArray& data) {
     auto data_type = static_cast<DataType>(data.type());
     switch (data_type) {
         case DataType::INT64: {
@@ -47,8 +50,11 @@ ParsePksFromFieldData(std::vector<PkType>& pks, const DataArray& data) {
             break;
         }
         case DataType::VARCHAR: {
-            auto& src_data = data.scalars().string_data().data();
-            std::copy(src_data.begin(), src_data.end(), pks.begin());
+            auto* src_data =
+                data.mutable_scalars()->mutable_string_data()->mutable_data();
+            for (size_t i = 0; i < pks.size(); i++) {
+                pks[i] = std::move(*src_data->Mutable(i));
+            }
             break;
         }
         default: {
@@ -675,6 +681,15 @@ CreateDataArrayFrom(const void* data_raw,
 }
 
 // TODO remove merge dataArray, instead fill target entity when get data slice
+//
+// IMPORTANT: This function uses std::move to transfer string/bytes data from
+// the per-segment output_fields_data_ (accessed via MergeBase) into the merged
+// DataArray. This is safe because each per-segment DataArray is discarded after
+// MergeDataArray completes — the caller (GetSearchResultDataSlice) never reads
+// the per-segment output_fields_data_ again after this point. Each offset
+// within a segment is referenced at most once in merge_bases (guaranteed by the
+// deduplication in ReduceSearchResultForOneNQ), so no element is moved twice.
+// If this invariant changes, the std::move calls below must be revisited.
 std::unique_ptr<DataArray>
 MergeDataArray(std::vector<MergeBase>& merge_bases,
                const FieldMeta& field_meta) {
@@ -721,13 +736,15 @@ MergeDataArray(std::vector<MergeBase>& merge_bases,
                 obj->assign(data + src_offset * num_bytes, num_bytes);
             } else if (field_meta.get_data_type() ==
                        DataType::VECTOR_SPARSE_U32_F32) {
-                auto src = src_field_data->vectors().sparse_float_vector();
+                auto* mutable_src_vec = src_field_data->mutable_vectors()
+                                            ->mutable_sparse_float_vector();
                 auto dst = vector_array->mutable_sparse_float_vector();
-                if (src.dim() > dst->dim()) {
-                    dst->set_dim(src.dim());
+                if (mutable_src_vec->dim() > dst->dim()) {
+                    dst->set_dim(mutable_src_vec->dim());
                 }
                 vector_array->set_dim(dst->dim());
-                *dst->mutable_contents() = src.contents();
+                *dst->mutable_contents() =
+                    std::move(*mutable_src_vec->mutable_contents());
             } else if (field_meta.get_data_type() == DataType::VECTOR_INT8) {
                 auto data = VEC_FIELD_DATA(src_field_data, int8);
                 auto obj = vector_array->mutable_int8_vector();
@@ -794,30 +811,41 @@ MergeDataArray(std::vector<MergeBase>& merge_bases,
             }
             case DataType::VARCHAR:
             case DataType::TEXT: {
-                auto& data = FIELD_DATA(src_field_data, string);
+                auto* mutable_src = src_field_data->mutable_scalars()
+                                        ->mutable_string_data()
+                                        ->mutable_data();
                 auto obj = scalar_array->mutable_string_data();
-                *(obj->mutable_data()->Add()) = data[src_offset];
+                *(obj->mutable_data()->Add()) =
+                    std::move(*mutable_src->Mutable(src_offset));
                 break;
             }
             case DataType::JSON: {
-                auto& data = FIELD_DATA(src_field_data, json);
+                auto* mutable_src = src_field_data->mutable_scalars()
+                                        ->mutable_json_data()
+                                        ->mutable_data();
                 auto obj = scalar_array->mutable_json_data();
-                *(obj->mutable_data()->Add()) = data[src_offset];
+                *(obj->mutable_data()->Add()) =
+                    std::move(*mutable_src->Mutable(src_offset));
                 break;
             }
             case DataType::GEOMETRY: {
-                auto& data = FIELD_DATA(src_field_data, geometry);
+                auto* mutable_src = src_field_data->mutable_scalars()
+                                        ->mutable_geometry_data()
+                                        ->mutable_data();
                 auto obj = scalar_array->mutable_geometry_data();
-                *(obj->mutable_data()->Add()) = std::string(
-                    data[src_offset].data(), data[src_offset].size());
+                *(obj->mutable_data()->Add()) =
+                    std::move(*mutable_src->Mutable(src_offset));
                 break;
             }
             case DataType::ARRAY: {
-                auto& data = FIELD_DATA(src_field_data, array);
                 auto obj = scalar_array->mutable_array_data();
                 obj->set_element_type(
                     proto::schema::DataType(field_meta.get_element_type()));
-                *(obj->mutable_data()->Add()) = data[src_offset];
+                auto* mutable_src = src_field_data->mutable_scalars()
+                                        ->mutable_array_data()
+                                        ->mutable_data();
+                *(obj->mutable_data()->Add()) =
+                    std::move(*mutable_src->Mutable(src_offset));
                 break;
             }
             default: {

--- a/internal/core/src/segcore/Utils.h
+++ b/internal/core/src/segcore/Utils.h
@@ -27,7 +27,7 @@
 namespace milvus::segcore {
 
 void
-ParsePksFromFieldData(std::vector<PkType>& pks, const DataArray& data);
+ParsePksFromFieldData(std::vector<PkType>& pks, DataArray& data);
 
 void
 ParsePksFromFieldData(DataType data_type,

--- a/internal/core/src/segcore/load_field_data_c.cpp
+++ b/internal/core/src/segcore/load_field_data_c.cpp
@@ -82,9 +82,8 @@ SetLoadFieldInfoChildFields(CLoadFieldDataInfo c_load_field_data_info,
             ThrowInfo(milvus::ErrorCode::FieldIDInvalid,
                       "please append field info first");
         }
-        load_field_data_info->field_infos[field_id].child_field_ids =
-            std::vector<int64_t>(child_field_ids,
-                                 child_field_ids + child_field_num);
+        iter->second.child_field_ids = std::vector<int64_t>(
+            child_field_ids, child_field_ids + child_field_num);
         return milvus::SuccessCStatus();
     } catch (std::exception& e) {
         return milvus::FailureCStatus(&e);
@@ -107,13 +106,10 @@ AppendLoadFieldDataPath(CLoadFieldDataInfo c_load_field_data_info,
             ThrowInfo(milvus::ErrorCode::FieldIDInvalid,
                       "please append field info first");
         }
-        std::string file_path(c_file_path);
-        load_field_data_info->field_infos[field_id].insert_files.emplace_back(
-            file_path);
-        load_field_data_info->field_infos[field_id].entries_nums.emplace_back(
-            entries_num);
-        load_field_data_info->field_infos[field_id].memory_sizes.emplace_back(
-            memory_size);
+        auto& field_info = iter->second;
+        field_info.insert_files.emplace_back(c_file_path);
+        field_info.entries_nums.emplace_back(entries_num);
+        field_info.memory_sizes.emplace_back(memory_size);
         return milvus::SuccessCStatus();
     } catch (std::exception& e) {
         return milvus::FailureCStatus(&e);

--- a/internal/core/src/segcore/memory_planner.cpp
+++ b/internal/core/src/segcore/memory_planner.cpp
@@ -199,8 +199,8 @@ LoadWithStrategy(const std::vector<std::string>& remote_files,
                             milvus::storage::GetReaderProperties());
                         AssertInfo(
                             result.ok(),
-                            "[StorageV2] Failed to create row group reader: " +
-                                result.status().ToString());
+                            "[StorageV2] Failed to create row group reader: {}",
+                            result.status().ToString());
                         auto row_group_reader = result.ValueOrDie();
                         auto close_guard =
                             folly::makeGuard([&row_group_reader]() {
@@ -211,20 +211,21 @@ LoadWithStrategy(const std::vector<std::string>& remote_files,
                                 block.offset, block.count);
                         AssertInfo(status.ok(),
                                    "[StorageV2] Failed to set row group offset "
-                                   "and count " +
-                                       std::to_string(block.offset) + " and " +
-                                       std::to_string(block.count) +
-                                       " with error " + status.ToString());
+                                   "and count {} and {} with error {}",
+                                   block.offset,
+                                   block.count,
+                                   status.ToString());
                         auto ret = std::make_shared<ArrowDataWrapper>();
                         for (int64_t i = 0; i < block.count; ++i) {
                             std::shared_ptr<arrow::Table> table;
                             auto status =
                                 row_group_reader->ReadNextRowGroup(&table);
                             AssertInfo(status.ok(),
-                                       "[StorageV2] Failed to read row group " +
-                                           std::to_string(block.offset + i) +
-                                           " from file " + file +
-                                           " with error " + status.ToString());
+                                       "[StorageV2] Failed to read row group "
+                                       "{} from file {} with error {}",
+                                       block.offset + i,
+                                       file,
+                                       status.ToString());
                             ret->arrow_tables.push_back(
                                 {file_idx,
                                  static_cast<size_t>(block.offset + i),

--- a/internal/core/src/segcore/packed_writer_c.cpp
+++ b/internal/core/src/segcore/packed_writer_c.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "common/common_type_c.h"
+#include "fmt/core.h"
 #include "parquet/encryption/encryption.h"
 #include "parquet/properties.h"
 #include "parquet/types.h"
@@ -237,8 +238,9 @@ WriteRecordBatch(CPackedWriter c_packed_writer,
             if (!array.ok()) {
                 return milvus::FailureCStatus(
                     milvus::ErrorCode::FileWriteFailed,
-                    "Failed to import array " + std::to_string(i) + ": " +
-                        array.status().ToString());
+                    fmt::format("Failed to import array {}: {}",
+                                i,
+                                array.status().ToString()));
             }
             all_arrays.push_back(array.ValueOrDie());
         }

--- a/internal/core/src/segcore/pkVisitor.h
+++ b/internal/core/src/segcore/pkVisitor.h
@@ -31,15 +31,15 @@ Int64PKVisitor::operator()<int64_t>(int64_t t) const {
 
 struct StrPKVisitor {
     template <typename T>
-    std::string
-    operator()(T t) const {
+    const std::string&
+    operator()(const T& t) const {
         ThrowInfo(Unsupported, "invalid string pk value");
     }
 };
 
 template <>
-inline std::string
-StrPKVisitor::operator()<std::string>(std::string t) const {
+inline const std::string&
+StrPKVisitor::operator()<std::string>(const std::string& t) const {
     return t;
 }
 

--- a/internal/core/src/segcore/reduce/GroupReduce.cpp
+++ b/internal/core/src/segcore/reduce/GroupReduce.cpp
@@ -71,11 +71,12 @@ GroupReduceHelper::RefreshSingleSearchResult(SearchResult* search_result,
     uint32_t index = 0;
     for (int j = 0; j < total_nq_; j++) {
         for (auto offset : final_search_records_[seg_res_idx][j]) {
-            primary_keys[index] = search_result->primary_keys_[offset];
+            primary_keys[index] =
+                std::move(search_result->primary_keys_[offset]);
             distances[index] = search_result->distances_[offset];
             seg_offsets[index] = search_result->seg_offsets_[offset];
             group_by_values[index] =
-                search_result->group_by_values_.value()[offset];
+                std::move(search_result->group_by_values_.value()[offset]);
             index++;
             real_topks[j]++;
         }

--- a/internal/core/src/segcore/reduce/Reduce.cpp
+++ b/internal/core/src/segcore/reduce/Reduce.cpp
@@ -42,10 +42,11 @@ ReduceHelper::Initialize() {
     std::partial_sum(slice_nqs_.begin(),
                      slice_nqs_.end(),
                      slice_nqs_prefix_sum_.begin() + 1);
-    AssertInfo(slice_nqs_prefix_sum_[num_slices_] == total_nq_,
-               "illegal req sizes, slice_nqs_prefix_sum_[last] = " +
-                   std::to_string(slice_nqs_prefix_sum_[num_slices_]) +
-                   ", total_nq = " + std::to_string(total_nq_));
+    AssertInfo(
+        slice_nqs_prefix_sum_[num_slices_] == total_nq_,
+        "illegal req sizes, slice_nqs_prefix_sum_[last] = {}, total_nq = {}",
+        slice_nqs_prefix_sum_[num_slices_],
+        total_nq_);
 
     // init final_search_records and final_read_topKs
     final_search_records_.resize(num_segments_);
@@ -85,13 +86,13 @@ ReduceHelper::FilterInvalidSearchResult(SearchResult* search_result) {
     auto nq = search_result->total_nq_;
     auto topK = search_result->unity_topK_;
     AssertInfo(search_result->seg_offsets_.size() == nq * topK,
-               "wrong seg offsets size, size = " +
-                   std::to_string(search_result->seg_offsets_.size()) +
-                   ", expected size = " + std::to_string(nq * topK));
+               "wrong seg offsets size, size = {}, expected size = {}",
+               search_result->seg_offsets_.size(),
+               nq * topK);
     AssertInfo(search_result->distances_.size() == nq * topK,
-               "wrong distances size, size = " +
-                   std::to_string(search_result->distances_.size()) +
-                   ", expected size = " + std::to_string(nq * topK));
+               "wrong distances size, size = {}, expected size = {}",
+               search_result->distances_.size(),
+               nq * topK);
     std::vector<int64_t> real_topks(nq, 0);
     uint32_t valid_index = 0;
     auto segment = static_cast<SegmentInterface*>(search_result->segment_);
@@ -172,6 +173,7 @@ ReduceHelper::SortEqualScoresOneNQ(size_t nq_begin,
     if (nq_end - nq_begin <= 1)
         return;
 
+    std::vector<size_t> indices;
     size_t start = nq_begin;
     while (start < nq_end) {
         // find scope with same scores
@@ -183,8 +185,8 @@ ReduceHelper::SortEqualScoresOneNQ(size_t nq_begin,
         }
 
         if (end - start > 1) {
-            // Create lightweight index array for sorting
-            std::vector<size_t> indices(end - start);
+            // Reuse indices vector to avoid repeated heap allocation
+            indices.resize(end - start);
             std::iota(indices.begin(), indices.end(), 0);
 
             // Sort indices by comparing primary keys
@@ -433,9 +435,10 @@ ReduceHelper::GetSearchResultDataSlice(const int slice_index,
         }
         case milvus::DataType::VARCHAR: {
             auto ids = std::make_unique<milvus::proto::schema::StringArray>();
-            std::vector<std::string> string_pks(result_count);
-            // TODO: prevent mem copy
-            *ids->mutable_data() = {string_pks.begin(), string_pks.end()};
+            ids->mutable_data()->Reserve(result_count);
+            for (int i = 0; i < result_count; i++) {
+                ids->mutable_data()->Add();
+            }
             search_result_data->mutable_ids()->set_allocated_str_id(
                 ids.release());
             break;
@@ -466,9 +469,10 @@ ReduceHelper::GetSearchResultDataSlice(const int slice_index,
             for (auto ki = topk_start; ki < topk_end; ki++) {
                 auto loc = search_result->result_offsets_[ki];
                 AssertInfo(loc < result_count && loc >= 0,
-                           "invalid loc when GetSearchResultDataSlice, loc = " +
-                               std::to_string(loc) + ", result_count = " +
-                               std::to_string(result_count));
+                           "invalid loc when GetSearchResultDataSlice, loc = "
+                           "{}, result_count = {}",
+                           loc,
+                           result_count);
                 // set result pks
                 switch (pk_type) {
                     case milvus::DataType::INT64: {
@@ -507,9 +511,9 @@ ReduceHelper::GetSearchResultDataSlice(const int slice_index,
     }
 
     AssertInfo(search_result_data->scores_size() == result_count,
-               "wrong scores size, size = " +
-                   std::to_string(search_result_data->scores_size()) +
-                   ", expected size = " + std::to_string(result_count));
+               "wrong scores size, size = {}, expected size = {}",
+               search_result_data->scores_size(),
+               result_count);
     // fill other wanted data
     FillOtherData(result_count, nq_begin, nq_end, search_result_data);
 

--- a/internal/core/src/segcore/segcore_init_c.cpp
+++ b/internal/core/src/segcore/segcore_init_c.cpp
@@ -242,7 +242,7 @@ ConfigureTieredStorage(const CacheWarmupPolicy scalarFieldCacheWarmupPolicy,
          cache_cell_unaccessed_survival_time,
          overloaded_memory_threshold_percentage,
          max_disk_usage_percentage,
-         disk_path_str,
+         std::move(disk_path_str),
          loading_resource_factor},
         std::chrono::milliseconds(loading_timeout_ms),
         std::chrono::milliseconds(warmup_loading_timeout_ms));

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -132,7 +132,7 @@ NewSegmentWithLoadInfo(CCollection collection,
 
         auto segment =
             CreateSegment(col, seg_type, segment_id, is_sorted_by_pk);
-        segment->SetLoadInfo(load_info);
+        segment->SetLoadInfo(std::move(load_info));
         *newSegment = segment.release();
         return milvus::SuccessCStatus();
     } catch (std::exception& e) {

--- a/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
@@ -123,19 +123,14 @@ SealedIndexTranslator::get_cells(milvus::OpContext* ctx,
     if (index_load_info_.enable_mmap && index->IsMmapSupported()) {
         AssertInfo(!index_load_info_.mmap_dir_path.empty(),
                    "mmap directory path is empty");
-        auto filepath = std::filesystem::path(index_load_info_.mmap_dir_path) /
-                        "index_files" / index_load_info_.index_id /
-                        index_load_info_.segment_id /
-                        index_load_info_.field_id / "index";
-        auto embedding_list_meta_path =
-            std::filesystem::path(index_load_info_.mmap_dir_path) /
-            "index_files" / index_load_info_.index_id /
-            index_load_info_.segment_id / index_load_info_.field_id /
-            index::EMB_LIST_META_FILE_NAME;
+        auto base_path = std::filesystem::path(index_load_info_.mmap_dir_path) /
+                         "index_files" / index_load_info_.index_id /
+                         index_load_info_.segment_id /
+                         index_load_info_.field_id;
         config_[milvus::index::ENABLE_MMAP] = "true";
-        config_[milvus::index::MMAP_FILE_PATH] = filepath.string();
+        config_[milvus::index::MMAP_FILE_PATH] = (base_path / "index").string();
         config_[milvus::index::EMB_LIST_META_PATH] =
-            embedding_list_meta_path.string();
+            (base_path / index::EMB_LIST_META_FILE_NAME).string();
     } else {
         config_[milvus::index::ENABLE_MMAP] = "false";
     }

--- a/internal/core/src/segcore/vector_index_c.cpp
+++ b/internal/core/src/segcore/vector_index_c.cpp
@@ -45,50 +45,39 @@ ValidateIndexParams(const char* index_type,
 
         knowhere::Status status;
         std::string error_msg;
-        auto check_leaf_type = [&index_type, &json, &error_msg, &status](
-                                   milvus::DataType dataType) {
+        auto version_number =
+            knowhere::Version::GetCurrentVersion().VersionNumber();
+        auto check_leaf_type = [&index_type,
+                                &json,
+                                &error_msg,
+                                &status,
+                                version_number](milvus::DataType dataType) {
             if (dataType == milvus::DataType::VECTOR_BINARY) {
                 status =
                     knowhere::IndexStaticFaced<knowhere::bin1>::ConfigCheck(
-                        index_type,
-                        knowhere::Version::GetCurrentVersion().VersionNumber(),
-                        json,
-                        error_msg);
+                        index_type, version_number, json, error_msg);
             } else if (dataType == milvus::DataType::VECTOR_FLOAT) {
                 status =
                     knowhere::IndexStaticFaced<knowhere::fp32>::ConfigCheck(
-                        index_type,
-                        knowhere::Version::GetCurrentVersion().VersionNumber(),
-                        json,
-                        error_msg);
+                        index_type, version_number, json, error_msg);
             } else if (dataType == milvus::DataType::VECTOR_BFLOAT16) {
                 status =
                     knowhere::IndexStaticFaced<knowhere::bf16>::ConfigCheck(
-                        index_type,
-                        knowhere::Version::GetCurrentVersion().VersionNumber(),
-                        json,
-                        error_msg);
+                        index_type, version_number, json, error_msg);
             } else if (dataType == milvus::DataType::VECTOR_FLOAT16) {
                 status =
                     knowhere::IndexStaticFaced<knowhere::fp16>::ConfigCheck(
-                        index_type,
-                        knowhere::Version::GetCurrentVersion().VersionNumber(),
-                        json,
-                        error_msg);
+                        index_type, version_number, json, error_msg);
             } else if (dataType == milvus::DataType::VECTOR_SPARSE_U32_F32) {
-                status = knowhere::IndexStaticFaced<knowhere::sparse_u32_f32>::
-                    ConfigCheck(
-                        index_type,
-                        knowhere::Version::GetCurrentVersion().VersionNumber(),
-                        json,
-                        error_msg);
+                status = knowhere::IndexStaticFaced<
+                    knowhere::sparse_u32_f32>::ConfigCheck(index_type,
+                                                           version_number,
+                                                           json,
+                                                           error_msg);
             } else if (dataType == milvus::DataType::VECTOR_INT8) {
                 status =
                     knowhere::IndexStaticFaced<knowhere::int8>::ConfigCheck(
-                        index_type,
-                        knowhere::Version::GetCurrentVersion().VersionNumber(),
-                        json,
-                        error_msg);
+                        index_type, version_number, json, error_msg);
             } else {
                 status = knowhere::Status::invalid_args;
             }

--- a/internal/core/src/storage/AliyunCredentialsProvider.cpp
+++ b/internal/core/src/storage/AliyunCredentialsProvider.cpp
@@ -152,7 +152,7 @@ AliyunSTSAssumeRoleWebIdentityCredentialsProvider::Reload() {
     if (tokenFile) {
         Aws::String token((std::istreambuf_iterator<char>(tokenFile)),
                           std::istreambuf_iterator<char>());
-        m_token = token;
+        m_token = std::move(token);
     } else {
         AWS_LOGSTREAM_ERROR(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
                             "Can't open token file: " << m_tokenFile);

--- a/internal/core/src/storage/Event.cpp
+++ b/internal/core/src/storage/Event.cpp
@@ -189,7 +189,7 @@ std::vector<uint8_t>
 DescriptorEventData::Serialize() {
     auto fix_part_data = fix_part.Serialize();
     nlohmann::json extras_json;
-    for (auto v : extras) {
+    for (const auto& v : extras) {
         if (v.first == NULLABLE) {
             extras_json.emplace(v.first, std::any_cast<bool>(v.second));
         } else if (v.first == EZID) {
@@ -313,8 +313,7 @@ BaseEventData::Serialize() {
                     auto size =
                         field_data->is_valid(offset) ? string_view.size() : -1;
                     payload_writer->add_one_binary_payload(
-                        reinterpret_cast<const uint8_t*>(
-                            std::string(string_view).c_str()),
+                        reinterpret_cast<const uint8_t*>(string_view.data()),
                         size);
                 }
                 break;

--- a/internal/core/src/storage/HuaweiCloudCredentialsProvider.cpp
+++ b/internal/core/src/storage/HuaweiCloudCredentialsProvider.cpp
@@ -178,7 +178,7 @@ HuaweiCloudSTSAssumeRoleWebIdentityCredentialsProvider::Reload() {
         if (!token.empty() && token.back() == '\n') {
             token.pop_back();
         }
-        m_token = token;
+        m_token = std::move(token);
     } else {
         m_stsFailureCount++;
         LOG_WARN(

--- a/internal/core/src/storage/KeyRetriever.cpp
+++ b/internal/core/src/storage/KeyRetriever.cpp
@@ -1,5 +1,6 @@
 #include "storage/KeyRetriever.h"
 #include "common/EasyAssert.h"
+#include "fmt/format.h"
 #include "log/Log.h"
 #include "parquet/properties.h"
 #include "storage/PluginLoader.h"
@@ -33,12 +34,11 @@ GetReaderProperties() {
 
 std::string
 EncodeKeyMetadata(int64_t ez_id, int64_t collection_id, std::string key) {
-    return std::to_string(ez_id) + "_" + std::to_string(collection_id) + "_" +
-           key;
+    return fmt::format("{}_{}_{}", ez_id, collection_id, key);
 }
 
 std::shared_ptr<CPluginContext>
-DecodeKeyMetadata(std::string key_metadata) {
+DecodeKeyMetadata(const std::string& key_metadata) {
     auto context = std::make_shared<CPluginContext>();
     try {
         auto first_pos = key_metadata.find("_");

--- a/internal/core/src/storage/KeyRetriever.h
+++ b/internal/core/src/storage/KeyRetriever.h
@@ -27,6 +27,6 @@ std::string
 EncodeKeyMetadata(int64_t ez_id, int64_t collection_id, std::string key);
 
 std::shared_ptr<CPluginContext>
-DecodeKeyMetadata(std::string key_metadata);
+DecodeKeyMetadata(const std::string& key_metadata);
 
 }  // namespace milvus::storage

--- a/internal/core/src/storage/LocalChunkManager.cpp
+++ b/internal/core/src/storage/LocalChunkManager.cpp
@@ -47,7 +47,16 @@ uint64_t
 LocalChunkManager::Size(const std::string& filepath) {
     boost::filesystem::path absPath(filepath);
 
-    if (!Exist(filepath)) {
+    boost::system::error_code exist_err;
+    bool isExist = boost::filesystem::exists(absPath, exist_err);
+    if (exist_err &&
+        exist_err.value() != boost::system::errc::no_such_file_or_directory) {
+        ThrowInfo(FileReadFailed,
+                  fmt::format("local file {} exist interface failed, error: {}",
+                              filepath,
+                              exist_err.message()));
+    }
+    if (!isExist) {
         ThrowInfo(PathNotExist, "invalid local path:" + absPath.string());
     }
     boost::system::error_code err;

--- a/internal/core/src/storage/MmapChunkManager.cpp
+++ b/internal/core/src/storage/MmapChunkManager.cpp
@@ -261,12 +261,13 @@ void
 MmapChunkManager::UnRegister(
     const MmapChunkDescriptor::ID descriptor_inner_id) {
     std::unique_lock<std::shared_mutex> lck(mtx_);
-    if (blocks_table_.find(descriptor_inner_id) != blocks_table_.end()) {
-        auto& blocks = blocks_table_[descriptor_inner_id];
+    auto it = blocks_table_.find(descriptor_inner_id);
+    if (it != blocks_table_.end()) {
+        auto& blocks = it->second;
         for (auto i = 0; i < blocks.size(); i++) {
             blocks_handler_->Deallocate(std::move(blocks[i]));
         }
-        blocks_table_.erase(descriptor_inner_id);
+        blocks_table_.erase(it);
     }
 }
 

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -675,9 +675,8 @@ GenIndexPathIdentifier(int64_t build_id,
                        int64_t index_version,
                        int64_t segment_id,
                        int64_t field_id) {
-    return std::to_string(build_id) + "_" + std::to_string(index_version) +
-           "_" + std::to_string(segment_id) + "_" + std::to_string(field_id) +
-           "/";
+    return fmt::format(
+        "{}_{}_{}_{}/", build_id, index_version, segment_id, field_id);
 }
 
 std::string
@@ -809,8 +808,7 @@ GenFieldRawDataPathPrefix(ChunkManagerPtr cm,
                           int64_t field_id) {
     boost::filesystem::path prefix = cm->GetRootPath();
     boost::filesystem::path path = std::string(RAWDATA_ROOT_PATH);
-    boost::filesystem::path path1 =
-        std::to_string(segment_id) + "_" + std::to_string(field_id) + "/";
+    boost::filesystem::path path1 = fmt::format("{}_{}/", segment_id, field_id);
     return NormalizePath(prefix / path / path1);
 }
 

--- a/internal/core/src/storage/gcp-native-storage/GcpNativeClientManager.cpp
+++ b/internal/core/src/storage/gcp-native-storage/GcpNativeClientManager.cpp
@@ -162,9 +162,8 @@ GcpNativeClientManager::PutObjectBuffer(const std::string& bucket_name,
                                         const std::string& object_name,
                                         void* buf,
                                         uint64_t size) {
-    std::string buffer(reinterpret_cast<char*>(buf), size);
     auto stream = client_->WriteObject(bucket_name, object_name);
-    stream << buffer;
+    stream.write(reinterpret_cast<const char*>(buf), size);
     stream.Close();
     if (stream.bad()) {
         throw std::runtime_error(GetGcpNativeError(stream.metadata().status()));

--- a/internal/core/src/storage/loon_ffi/util.cpp
+++ b/internal/core/src/storage/loon_ffi/util.cpp
@@ -107,11 +107,12 @@ MakePropertiesFromStorageConfig(CStorageConfig c_storage_config) {
     keys.emplace_back(PROPERTY_FS_MAX_CONNECTIONS);
     values.emplace_back(max_connections_str.c_str());
 
-    if (c_storage_config.tls_min_version != nullptr &&
-        std::string(c_storage_config.tls_min_version).length() > 0 &&
-        std::string(c_storage_config.tls_min_version) != "default") {
-        keys.emplace_back(PROPERTY_FS_TLS_MIN_VERSION);
-        values.emplace_back(c_storage_config.tls_min_version);
+    if (c_storage_config.tls_min_version != nullptr) {
+        std::string tls_ver(c_storage_config.tls_min_version);
+        if (!tls_ver.empty() && tls_ver != "default") {
+            keys.emplace_back(PROPERTY_FS_TLS_MIN_VERSION);
+            values.emplace_back(c_storage_config.tls_min_version);
+        }
     }
 
     keys.emplace_back(PROPERTY_FS_USE_CRC32C_CHECKSUM);
@@ -223,12 +224,13 @@ MakeInternalPropertiesFromStorageConfig(CStorageConfig c_storage_config) {
         PROPERTY_FS_MAX_CONNECTIONS,
         std::to_string(c_storage_config.max_connections).c_str());
 
-    if (c_storage_config.tls_min_version != nullptr &&
-        std::string(c_storage_config.tls_min_version).length() > 0 &&
-        std::string(c_storage_config.tls_min_version) != "default") {
-        milvus_storage::api::SetValue(*properties_map,
-                                      PROPERTY_FS_TLS_MIN_VERSION,
-                                      c_storage_config.tls_min_version);
+    if (c_storage_config.tls_min_version != nullptr) {
+        std::string tls_ver(c_storage_config.tls_min_version);
+        if (!tls_ver.empty() && tls_ver != "default") {
+            milvus_storage::api::SetValue(*properties_map,
+                                          PROPERTY_FS_TLS_MIN_VERSION,
+                                          c_storage_config.tls_min_version);
+        }
     }
 
     milvus_storage::api::SetValue(


### PR DESCRIPTION
Cherry-pick the following C++ performance optimization PRs from master to 2.6:

- #48859 enhance: reduce unnecessary copies in search/query path
- #48891 enhance: replace exception-based integer validation with character iteration
- #48906 enhance: general c++ optimizations

issue: #44452
pr: #48859
pr: #48891
pr: #48906

Because 2.6 diverges substantially from master in many of the touched files (e.g. different `SearchResult` members, different `InvertedIndexTantivy`/`RTreeIndex` write/load code paths, `ExtractSubJson` still on rapidjson, no `build_index_for_array_nested`, no `element_level_`/`array_offsets_` machinery), several conflicts were resolved by applying only the parts of the upstream optimizations that match 2.6's code shape:

- `ExtractSubJson` signature changed to `std::string_view` while keeping the rapidjson-based implementation in 2.6.
- `SetLoadInfo` switched to by-value parameter with `std::move` across the interface, `ChunkedSegmentSealedImpl`, and `SegmentInterface`.
- `Utils.cpp` sparse-vector merge uses `std::move` for contents; 2.6-specific bulk-copy semantics preserved.
- Dropped master-only additions that don't exist on 2.6 (e.g. `ResizeScalarFieldData`, `InvertedIndexTantivy`/`RTreeIndex` `WriteEntries`/`LoadEntries`, `HasValidData`, `element_level_` branches in `IterativeFilterNode`/`GroupReduce`/`QueryResult`, embedding-search branches in `SearchOnGrowing`, namespace/aggregate code in `PlanProto`, and files missing on 2.6 like `OffsetMapping.cpp`, `HashTable.cpp`, `ElementFilterNode.cpp`, `ProjectNode.cpp`, `QueryOrderByNode.cpp`, `SkipIndexStats.h`).
- Kept the applicable micro-optimizations (e.g. `std::move` for strings, `const auto&` captures, fmt::format-style `ThrowInfo`, `LOG_ERROR` over `std::cout`, `kMetaJsonSuffixLen`, hoisted `offsets`/`distances` in `IterativeFilterNode` and `SearchOnGrowing`, `fmt/format.h` include in `KeyRetriever.cpp`).