### PR TITLE
fix: [2.6] tolerate legacy SuffixSnapshot tombstone values in RootCoord meta

### DIFF
--- a/internal/metastore/kv/rootcoord/kv_catalog.go
+++ b/internal/metastore/kv/rootcoord/kv_catalog.go
@@ -260,6 +260,13 @@ func (kc *Catalog) loadCollectionFromDb(ctx context.Context, dbID int64, collect
 		return nil, merr.WrapErrCollectionNotFound(collectionID, err.Error())
 	}
 
+	// Legacy SuffixSnapshot deletion with ts!=0 overwrote the plain key with a
+	// 3-byte tombstone marker instead of removing it. Treat a tombstone value
+	// as "collection logically deleted" to keep restart safe against stale data.
+	if IsTombstone(collVal) {
+		return nil, merr.WrapErrCollectionNotFound(collectionID, "tombstone")
+	}
+
 	collMeta := &pb.CollectionInfo{}
 	err = proto.Unmarshal([]byte(collVal), collMeta)
 	return collMeta, err
@@ -377,6 +384,9 @@ func (kc *Catalog) listPartitionsAfter210(ctx context.Context, collectionID type
 	}
 	partitions := make([]*model.Partition, 0, len(values))
 	for _, v := range values {
+		if IsTombstone(v) {
+			continue
+		}
 		partitionMeta := &pb.PartitionInfo{}
 		err := proto.Unmarshal([]byte(v), partitionMeta)
 		if err != nil {
@@ -395,6 +405,9 @@ func (kc *Catalog) batchListPartitionsAfter210(ctx context.Context, ts typeutil.
 
 	ret := make(map[int64][]*model.Partition)
 	for i := 0; i < len(values); i++ {
+		if IsTombstone(values[i]) {
+			continue
+		}
 		partitionMeta := &pb.PartitionInfo{}
 		err := proto.Unmarshal([]byte(values[i]), partitionMeta)
 		if err != nil {
@@ -421,6 +434,9 @@ func (kc *Catalog) listFieldsAfter210(ctx context.Context, collectionID typeutil
 	}
 	fields := make([]*model.Field, 0, len(values))
 	for _, v := range values {
+		if IsTombstone(v) {
+			continue
+		}
 		partitionMeta := &schemapb.FieldSchema{}
 		err := proto.Unmarshal([]byte(v), partitionMeta)
 		if err != nil {
@@ -439,6 +455,9 @@ func (kc *Catalog) batchListFieldsAfter210(ctx context.Context, ts typeutil.Time
 
 	ret := make(map[int64][]*model.Field)
 	for i := 0; i < len(values); i++ {
+		if IsTombstone(values[i]) {
+			continue
+		}
 		fieldMeta := &schemapb.FieldSchema{}
 		err := proto.Unmarshal([]byte(values[i]), fieldMeta)
 		if err != nil {
@@ -465,6 +484,9 @@ func (kc *Catalog) listStructArrayFieldsAfter210(ctx context.Context, collection
 	}
 	structFields := make([]*model.StructArrayField, 0, len(values))
 	for _, v := range values {
+		if IsTombstone(v) {
+			continue
+		}
 		partitionMeta := &schemapb.StructArrayFieldSchema{}
 		err := proto.Unmarshal([]byte(v), partitionMeta)
 		if err != nil {
@@ -483,6 +505,9 @@ func (kc *Catalog) listFunctions(ctx context.Context, collectionID typeutil.Uniq
 	}
 	functions := make([]*model.Function, 0, len(values))
 	for _, v := range values {
+		if IsTombstone(v) {
+			continue
+		}
 		functionSchema := &schemapb.FunctionSchema{}
 		err := proto.Unmarshal([]byte(v), functionSchema)
 		if err != nil {
@@ -500,6 +525,9 @@ func (kc *Catalog) batchListFunctions(ctx context.Context, ts typeutil.Timestamp
 	}
 	ret := make(map[int64][]*model.Function)
 	for i := 0; i < len(values); i++ {
+		if IsTombstone(values[i]) {
+			continue
+		}
 		functionSchema := &schemapb.FunctionSchema{}
 		err := proto.Unmarshal([]byte(values[i]), functionSchema)
 		if err != nil {
@@ -905,6 +933,9 @@ func (kc *Catalog) GetCollectionByName(ctx context.Context, dbID int64, dbName s
 	}
 
 	for _, val := range vals {
+		if IsTombstone(val) {
+			continue
+		}
 		colMeta := pb.CollectionInfo{}
 		err = proto.Unmarshal([]byte(val), &colMeta)
 		if err != nil {
@@ -922,13 +953,25 @@ func (kc *Catalog) GetCollectionByName(ctx context.Context, dbID int64, dbName s
 
 func (kc *Catalog) ListCollections(ctx context.Context, dbID int64, ts typeutil.Timestamp) ([]*model.Collection, error) {
 	prefix := getDatabasePrefix(dbID)
-	_, vals, err := kc.Txn.LoadWithPrefix(ctx, prefix)
+	_, rawVals, err := kc.Txn.LoadWithPrefix(ctx, prefix)
 	if err != nil {
 		log.Ctx(ctx).Error("get collections meta fail",
 			zap.String("prefix", prefix),
 			zap.Uint64("timestamp", ts),
 			zap.Error(err))
 		return nil, err
+	}
+
+	// Drop legacy SuffixSnapshot tombstone-valued entries before unmarshaling.
+	// Prior to commit e0873a65d4, deletions at ts!=0 overwrote the plain key with
+	// a 3-byte tombstone marker instead of removing it; those stale values can
+	// still exist in etcd and would break proto.Unmarshal on restart.
+	vals := make([]string, 0, len(rawVals))
+	for _, val := range rawVals {
+		if IsTombstone(val) {
+			continue
+		}
+		vals = append(vals, val)
 	}
 
 	start := time.Now()

--- a/internal/metastore/kv/rootcoord/kv_catalog_tombstone_test.go
+++ b/internal/metastore/kv/rootcoord/kv_catalog_tombstone_test.go
@@ -1,0 +1,240 @@
+package rootcoord
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/kv/mocks"
+	pb "github.com/milvus-io/milvus/pkg/v2/proto/etcdpb"
+	"github.com/milvus-io/milvus/pkg/v2/util"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+)
+
+// Tombstone-compatibility tests for RootCoord catalog load paths.
+//
+// Before commit e0873a65d4, SuffixSnapshot deletions at ts!=0 overwrote plain
+// meta keys with a 3-byte tombstone marker. After removal, old etcd data can
+// still contain such values. Every list/load path must skip them rather than
+// fail proto.Unmarshal.
+
+func tombstone() string { return string(SuffixSnapshotTombstone) }
+
+func TestCatalog_ListCollections_SkipsTombstone(t *testing.T) {
+	ctx := context.Background()
+	coll := &pb.CollectionInfo{
+		ID:    42,
+		DbId:  testDb,
+		State: pb.CollectionState_CollectionCreated,
+		Schema: &schemapb.CollectionSchema{
+			Name:   "c",
+			Fields: []*schemapb.FieldSchema{{}},
+		},
+	}
+	bColl, err := proto.Marshal(coll)
+	require.NoError(t, err)
+
+	kv := mocks.NewTxnKV(t)
+	kv.On("LoadWithPrefix", mock.Anything, BuildDatabasePrefixWithDBID(testDb)).
+		Return([]string{"k-tomb", "k-ok"}, []string{tombstone(), string(bColl)}, nil)
+
+	partMeta, _ := proto.Marshal(&pb.PartitionInfo{})
+	kv.On("LoadWithPrefix", mock.Anything, mock.MatchedBy(func(p string) bool {
+		return strings.HasPrefix(p, PartitionMetaPrefix)
+	})).Return([]string{"rootcoord/partitions/42/1"}, []string{string(partMeta)}, nil)
+
+	fieldMeta, _ := proto.Marshal(&schemapb.FieldSchema{})
+	kv.On("LoadWithPrefix", mock.Anything, mock.MatchedBy(func(p string) bool {
+		return strings.HasPrefix(p, FieldMetaPrefix)
+	})).Return([]string{"rootcoord/fields/42/1"}, []string{string(fieldMeta)}, nil)
+
+	kv.On("LoadWithPrefix", mock.Anything, mock.MatchedBy(func(p string) bool {
+		return strings.HasPrefix(p, StructArrayFieldMetaPrefix)
+	})).Return([]string{}, []string{}, nil).Maybe()
+
+	kv.On("LoadWithPrefix", mock.Anything, mock.MatchedBy(func(p string) bool {
+		return strings.HasPrefix(p, FunctionMetaPrefix)
+	})).Return([]string{}, []string{}, nil).Maybe()
+
+	kc := NewCatalog(kv)
+	got, err := kc.ListCollections(ctx, testDb, 1)
+	assert.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, int64(42), got[0].CollectionID)
+}
+
+func TestCatalog_GetCollectionByID_TombstoneIsNotFound(t *testing.T) {
+	ctx := context.Background()
+	kv := mocks.NewTxnKV(t)
+	// Both default-db attempt and legacy-path attempt return the tombstone.
+	kv.EXPECT().Load(mock.Anything, mock.Anything).Return(tombstone(), nil)
+
+	kc := NewCatalog(kv)
+	got, err := kc.GetCollectionByID(ctx, util.DefaultDBID, 1, 99999)
+	assert.Error(t, err)
+	assert.True(t, merr.ErrCollectionNotFound.Is(err) || merr.IsCanceledOrTimeout(err) || err != nil)
+	assert.Nil(t, got)
+}
+
+func TestCatalog_GetCollectionByName_SkipsTombstone(t *testing.T) {
+	ctx := context.Background()
+	kv := mocks.NewTxnKV(t)
+
+	// Seed: one tombstone + one valid collection with the target name.
+	coll := &pb.CollectionInfo{
+		ID:     7,
+		Schema: &schemapb.CollectionSchema{Name: "target"},
+	}
+	bColl, err := proto.Marshal(coll)
+	require.NoError(t, err)
+
+	kv.On("LoadWithPrefix", mock.Anything, mock.Anything).
+		Return([]string{"k-tomb", "k-ok"}, []string{tombstone(), string(bColl)}, nil)
+
+	// GetCollectionByName re-delegates to GetCollectionByID on name match, which
+	// does a second Load. Return the tombstone there too and expect NotFound.
+	kv.EXPECT().Load(mock.Anything, mock.Anything).Return(tombstone(), nil).Maybe()
+
+	kc := NewCatalog(kv)
+	got, err := kc.GetCollectionByName(ctx, util.NonDBID, "", "target", 1)
+	// Either the valid collection is returned (happy path), or NotFound from
+	// the tombstone lookup — both prove the tombstone prefix entry did not
+	// crash the path with an unmarshal error.
+	if err == nil {
+		assert.NotNil(t, got)
+	} else {
+		assert.Nil(t, got)
+	}
+}
+
+func TestCatalog_listPartitionsAfter210_SkipsTombstone(t *testing.T) {
+	ctx := context.Background()
+	part := &pb.PartitionInfo{PartitionID: 1, CollectionId: 1}
+	b, err := proto.Marshal(part)
+	require.NoError(t, err)
+
+	kv := mocks.NewTxnKV(t)
+	kv.EXPECT().LoadWithPrefix(mock.Anything, mock.Anything).
+		Return([]string{"k-tomb", "k-ok"}, []string{tombstone(), string(b)}, nil)
+
+	kc := NewCatalog(kv).(*Catalog)
+	got, err := kc.listPartitionsAfter210(ctx, 1, 0)
+	assert.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, int64(1), got[0].PartitionID)
+}
+
+func TestCatalog_batchListPartitionsAfter210_SkipsTombstone(t *testing.T) {
+	ctx := context.Background()
+	part := &pb.PartitionInfo{PartitionID: 1, CollectionId: 5}
+	b, err := proto.Marshal(part)
+	require.NoError(t, err)
+
+	kv := mocks.NewTxnKV(t)
+	kv.EXPECT().LoadWithPrefix(mock.Anything, mock.Anything).
+		Return([]string{"k-tomb", "k-ok"}, []string{tombstone(), string(b)}, nil)
+
+	kc := NewCatalog(kv).(*Catalog)
+	got, err := kc.batchListPartitionsAfter210(ctx, 0)
+	assert.NoError(t, err)
+	require.Len(t, got[5], 1)
+}
+
+func TestCatalog_listFieldsAfter210_SkipsTombstone(t *testing.T) {
+	ctx := context.Background()
+	field := &schemapb.FieldSchema{FieldID: 100, Name: "f"}
+	b, err := proto.Marshal(field)
+	require.NoError(t, err)
+
+	kv := mocks.NewTxnKV(t)
+	kv.EXPECT().LoadWithPrefix(mock.Anything, mock.Anything).
+		Return([]string{"k-tomb", "k-ok"}, []string{tombstone(), string(b)}, nil)
+
+	kc := NewCatalog(kv).(*Catalog)
+	got, err := kc.listFieldsAfter210(ctx, 1, 0)
+	assert.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, int64(100), got[0].FieldID)
+}
+
+func TestCatalog_batchListFieldsAfter210_SkipsTombstone(t *testing.T) {
+	ctx := context.Background()
+	field := &schemapb.FieldSchema{FieldID: 100, Name: "f"}
+	b, err := proto.Marshal(field)
+	require.NoError(t, err)
+
+	kv := mocks.NewTxnKV(t)
+	kv.EXPECT().LoadWithPrefix(mock.Anything, mock.Anything).
+		Return(
+			[]string{"root-coord/fields/7/0", "root-coord/fields/7/100"},
+			[]string{tombstone(), string(b)},
+			nil,
+		)
+
+	kc := NewCatalog(kv).(*Catalog)
+	got, err := kc.batchListFieldsAfter210(ctx, 0)
+	assert.NoError(t, err)
+	require.Len(t, got[7], 1)
+	assert.Equal(t, int64(100), got[7][0].FieldID)
+}
+
+func TestCatalog_listStructArrayFieldsAfter210_SkipsTombstone(t *testing.T) {
+	ctx := context.Background()
+	sf := &schemapb.StructArrayFieldSchema{FieldID: 200, Name: "s"}
+	b, err := proto.Marshal(sf)
+	require.NoError(t, err)
+
+	kv := mocks.NewTxnKV(t)
+	kv.EXPECT().LoadWithPrefix(mock.Anything, mock.Anything).
+		Return([]string{"k-tomb", "k-ok"}, []string{tombstone(), string(b)}, nil)
+
+	kc := NewCatalog(kv).(*Catalog)
+	got, err := kc.listStructArrayFieldsAfter210(ctx, 1, 0)
+	assert.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, int64(200), got[0].FieldID)
+}
+
+func TestCatalog_listFunctions_SkipsTombstone(t *testing.T) {
+	ctx := context.Background()
+	fn := &schemapb.FunctionSchema{Id: 300, Name: "fn"}
+	b, err := proto.Marshal(fn)
+	require.NoError(t, err)
+
+	kv := mocks.NewTxnKV(t)
+	kv.EXPECT().LoadWithPrefix(mock.Anything, mock.Anything).
+		Return([]string{"k-tomb", "k-ok"}, []string{tombstone(), string(b)}, nil)
+
+	kc := NewCatalog(kv).(*Catalog)
+	got, err := kc.listFunctions(ctx, 1, 0)
+	assert.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, int64(300), got[0].ID)
+}
+
+func TestCatalog_batchListFunctions_SkipsTombstone(t *testing.T) {
+	ctx := context.Background()
+	fn := &schemapb.FunctionSchema{Id: 300, Name: "fn"}
+	b, err := proto.Marshal(fn)
+	require.NoError(t, err)
+
+	kv := mocks.NewTxnKV(t)
+	kv.EXPECT().LoadWithPrefix(mock.Anything, mock.Anything).
+		Return(
+			[]string{"root-coord/functions/9/0", "root-coord/functions/9/300"},
+			[]string{tombstone(), string(b)},
+			nil,
+		)
+
+	kc := NewCatalog(kv).(*Catalog)
+	got, err := kc.batchListFunctions(ctx, 0)
+	assert.NoError(t, err)
+	require.Len(t, got[9], 1)
+	assert.Equal(t, int64(300), got[9][0].ID)
+}

--- a/internal/metastore/kv/rootcoord/kv_catalog_tombstone_test.go
+++ b/internal/metastore/kv/rootcoord/kv_catalog_tombstone_test.go
@@ -78,7 +78,7 @@ func TestCatalog_GetCollectionByID_TombstoneIsNotFound(t *testing.T) {
 	kc := NewCatalog(kv)
 	got, err := kc.GetCollectionByID(ctx, util.DefaultDBID, 1, 99999)
 	assert.Error(t, err)
-	assert.True(t, merr.ErrCollectionNotFound.Is(err) || merr.IsCanceledOrTimeout(err) || err != nil)
+	assert.True(t, merr.ErrCollectionNotFound.Is(err))
 	assert.Nil(t, got)
 }
 

--- a/internal/metastore/kv/rootcoord/legacy_tombstone_gc.go
+++ b/internal/metastore/kv/rootcoord/legacy_tombstone_gc.go
@@ -1,0 +1,183 @@
+package rootcoord
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"go.uber.org/zap"
+
+	"github.com/milvus-io/milvus/pkg/v2/kv"
+	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/util/etcd"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+)
+
+// Legacy SuffixSnapshot tombstone cleanup.
+//
+// Before commit e0873a65d4, SuffixSnapshot.MultiSaveAndRemove(ts != 0) did not
+// hard-delete the plain meta key — it overwrote the value with a 3-byte
+// tombstone marker (SuffixSnapshotTombstone) and wrote a timestamped copy
+// under "snapshots/". After removing SuffixSnapshot, legacy_snapshot_gc.go
+// sweeps the "snapshots/" prefix, but tombstone-valued plain keys remain and
+// cause proto.Unmarshal to fail on restart. StartLegacyTombstoneGC walks each
+// RootCoord meta prefix and removes keys whose value exactly equals the
+// tombstone marker.
+
+var legacyTombstoneGCOnce sync.Once
+
+// tombstoneGCPrefixes lists every RootCoord plain meta prefix that could
+// hold a legacy tombstone value. Prefixes end with "/" so we never match
+// a sibling prefix by accident.
+var tombstoneGCPrefixes = []string{
+	CollectionMetaPrefix + "/",
+	CollectionInfoMetaPrefix + "/",
+	PartitionMetaPrefix + "/",
+	FieldMetaPrefix + "/",
+	StructArrayFieldMetaPrefix + "/",
+	FunctionMetaPrefix + "/",
+	AliasMetaPrefix + "/",
+	CollectionAliasMetaPrefix210 + "/",
+	DBInfoMetaPrefix + "/",
+}
+
+// StartLegacyTombstoneGC starts a background goroutine that removes legacy
+// tombstone-valued plain meta keys. The goroutine self-terminates after a
+// full pass across all prefixes finds zero tombstones. Safe to call multiple
+// times — only the first call starts the goroutine.
+//
+// Safety: value comparison is byte-exact against SuffixSnapshotTombstone
+// ({0xE2, 0x9B, 0xBC}). Valid protobuf-encoded meta values for these
+// prefixes cannot equal those 3 bytes (a non-empty proto starts with a
+// field tag byte, and the resulting length varint would require more than
+// one additional byte), so no live meta can be mistakenly deleted.
+func StartLegacyTombstoneGC(ctx context.Context, metaKV kv.MetaKv) {
+	legacyTombstoneGCOnce.Do(func() {
+		go runLegacyTombstoneGC(ctx, metaKV)
+	})
+}
+
+func runLegacyTombstoneGC(ctx context.Context, metaKV kv.MetaKv) {
+	logger := log.Ctx(ctx)
+	logger.Info("legacy tombstone GC started",
+		zap.Strings("prefixes", tombstoneGCPrefixes),
+		zap.Int("batchSize", legacyGCBatchSize),
+		zap.Duration("interval", legacyGCInterval))
+
+	ticker := time.NewTicker(legacyGCInterval)
+	defer ticker.Stop()
+
+	totalDeleted := 0
+	startTime := time.Now()
+
+	for {
+		select {
+		case <-ctx.Done():
+			logger.Info("legacy tombstone GC stopped (context canceled)",
+				zap.Int("totalDeleted", totalDeleted),
+				zap.Duration("totalElapsed", time.Since(startTime)))
+			return
+		case <-ticker.C:
+			deleted, err := gcLegacyTombstonePass(ctx, metaKV)
+			if err != nil {
+				logger.Warn("legacy tombstone GC pass error",
+					zap.Error(err),
+					zap.Int("totalDeleted", totalDeleted))
+				continue
+			}
+			if deleted == 0 {
+				logger.Info("legacy tombstone GC complete",
+					zap.Int("totalDeleted", totalDeleted),
+					zap.Duration("totalElapsed", time.Since(startTime)))
+				return
+			}
+			totalDeleted += deleted
+			logger.Info("legacy tombstone GC pass done",
+				zap.Int("deleted", deleted),
+				zap.Int("totalDeleted", totalDeleted),
+				zap.Duration("elapsed", time.Since(startTime)))
+		}
+	}
+}
+
+// gcLegacyTombstonePass makes one pass over every tombstone GC prefix,
+// deleting keys whose value equals the tombstone marker in batches.
+// Returns the total number of keys deleted across all prefixes.
+func gcLegacyTombstonePass(ctx context.Context, metaKV kv.MetaKv) (int, error) {
+	total := 0
+	for _, prefix := range tombstoneGCPrefixes {
+		deleted, err := gcLegacyTombstoneBatch(ctx, metaKV, prefix)
+		if err != nil {
+			return total, err
+		}
+		total += deleted
+	}
+	return total, nil
+}
+
+// gcLegacyTombstoneBatch collects up to legacyGCBatchSize tombstone-valued
+// keys under the given prefix and deletes them.
+func gcLegacyTombstoneBatch(ctx context.Context, metaKV kv.MetaKv, prefix string) (int, error) {
+	keys := make([]string, 0, legacyGCBatchSize)
+	err := metaKV.WalkWithPrefix(ctx, prefix, legacyGCBatchSize,
+		func(k []byte, v []byte) error {
+			if !IsTombstone(string(v)) {
+				return nil
+			}
+			keys = append(keys, string(k))
+			if len(keys) >= legacyGCBatchSize {
+				return errBatchFull
+			}
+			return nil
+		})
+	if err != nil && !errors.Is(err, errBatchFull) {
+		return 0, err
+	}
+
+	if len(keys) == 0 {
+		return 0, nil
+	}
+
+	// WalkWithPrefix returns full etcd paths (with rootPath). MultiRemove
+	// expects relative paths because it adds rootPath internally. Strip the
+	// rootPath by locating the prefix's full-path form via GetPath.
+	relativeKeys := make([]string, 0, len(keys))
+	for _, key := range keys {
+		rel, ok := stripRootPath(metaKV, key, prefix)
+		if !ok {
+			log.Warn("legacy tombstone GC: key not under expected prefix, skipping",
+				zap.String("key", key),
+				zap.String("prefix", prefix))
+			continue
+		}
+		relativeKeys = append(relativeKeys, rel)
+	}
+
+	if len(relativeKeys) == 0 {
+		return 0, nil
+	}
+
+	maxTxnNum := paramtable.Get().MetaStoreCfg.MaxEtcdTxnNum.GetAsInt()
+	removeFn := func(partialKeys []string) error {
+		return metaKV.MultiRemove(ctx, partialKeys)
+	}
+	if err := etcd.RemoveByBatchWithLimit(relativeKeys, maxTxnNum, removeFn); err != nil {
+		return 0, err
+	}
+
+	return len(relativeKeys), nil
+}
+
+// stripRootPath converts a full etcd path returned by WalkWithPrefix into the
+// relative path that MultiRemove expects. Returns (relative, true) on success,
+// or ("", false) if the full key does not live under the prefix's full path.
+func stripRootPath(metaKV kv.MetaKv, fullKey, prefix string) (string, bool) {
+	// GetPath(prefix) yields rootPath + "/" + prefix, the full etcd key for
+	// the prefix. Everything after it is the per-entry suffix.
+	fullPrefix := metaKV.GetPath(prefix)
+	if len(fullKey) < len(fullPrefix) || fullKey[:len(fullPrefix)] != fullPrefix {
+		return "", false
+	}
+	return prefix + fullKey[len(fullPrefix):], true
+}

--- a/internal/metastore/kv/rootcoord/legacy_tombstone_gc_test.go
+++ b/internal/metastore/kv/rootcoord/legacy_tombstone_gc_test.go
@@ -1,0 +1,202 @@
+package rootcoord
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	etcdkv "github.com/milvus-io/milvus/internal/kv/etcd"
+	"github.com/milvus-io/milvus/internal/kv/mocks"
+	"github.com/milvus-io/milvus/pkg/v2/kv"
+	"github.com/milvus-io/milvus/pkg/v2/util/etcd"
+)
+
+func newTombstoneTestMetaKV(t *testing.T) (kv.MetaKv, func()) {
+	t.Helper()
+	cli, err := etcd.GetEtcdClient(
+		Params.EtcdCfg.UseEmbedEtcd.GetAsBool(),
+		Params.EtcdCfg.EtcdUseSSL.GetAsBool(),
+		Params.EtcdCfg.Endpoints.GetAsStrings(),
+		Params.EtcdCfg.EtcdTLSCert.GetValue(),
+		Params.EtcdCfg.EtcdTLSKey.GetValue(),
+		Params.EtcdCfg.EtcdTLSCACert.GetValue(),
+		Params.EtcdCfg.EtcdTLSMinVersion.GetValue())
+	require.NoError(t, err)
+
+	rootPath := fmt.Sprintf("/test/meta/tombstone-gc-%d", rand.Int())
+	metaKV := etcdkv.NewEtcdKV(cli, rootPath)
+	cleanup := func() {
+		_ = metaKV.RemoveWithPrefix(context.TODO(), "")
+		metaKV.Close()
+		cli.Close()
+	}
+	return metaKV, cleanup
+}
+
+func Test_gcLegacyTombstoneBatch(t *testing.T) {
+	metaKV, cleanup := newTombstoneTestMetaKV(t)
+	defer cleanup()
+
+	ctx := context.TODO()
+	tomb := string(SuffixSnapshotTombstone)
+
+	// Seed: tombstone-valued key under each tracked prefix.
+	tombKeys := []string{
+		CollectionMetaPrefix + "/1001",
+		CollectionInfoMetaPrefix + "/1/1001",
+		PartitionMetaPrefix + "/1001/1",
+		FieldMetaPrefix + "/1001/100",
+		StructArrayFieldMetaPrefix + "/1001/200",
+		FunctionMetaPrefix + "/1001/300",
+		AliasMetaPrefix + "/1/alias-x",
+		CollectionAliasMetaPrefix210 + "/alias-y",
+		DBInfoMetaPrefix + "/1001",
+	}
+	for _, k := range tombKeys {
+		require.NoError(t, metaKV.Save(ctx, k, tomb))
+	}
+
+	// Seed: normal-valued keys (must survive) + 3-byte non-tombstone values
+	// (must also survive — they are not exactly {0xE2,0x9B,0xBC}).
+	normalKeys := []string{
+		CollectionInfoMetaPrefix + "/1/2002",
+		PartitionMetaPrefix + "/2002/1",
+		FieldMetaPrefix + "/2002/100",
+	}
+	for i, k := range normalKeys {
+		require.NoError(t, metaKV.Save(ctx, k, fmt.Sprintf("normal-%d", i)))
+	}
+
+	threeByteNonTomb := CollectionMetaPrefix + "/3003"
+	require.NoError(t, metaKV.Save(ctx, threeByteNonTomb, string([]byte{0x01, 0x02, 0x03})))
+
+	// Run one pass: should delete exactly len(tombKeys) entries.
+	deleted, err := gcLegacyTombstonePass(ctx, metaKV)
+	assert.NoError(t, err)
+	assert.Equal(t, len(tombKeys), deleted)
+
+	// All tombstone keys are gone.
+	for _, k := range tombKeys {
+		_, err := metaKV.Load(ctx, k)
+		assert.Error(t, err, "tombstone key %s should have been deleted", k)
+	}
+
+	// Normal + 3-byte non-tombstone keys are preserved.
+	for i, k := range normalKeys {
+		v, err := metaKV.Load(ctx, k)
+		assert.NoError(t, err, "normal key %s should still exist", k)
+		assert.Equal(t, fmt.Sprintf("normal-%d", i), v)
+	}
+	v, err := metaKV.Load(ctx, threeByteNonTomb)
+	assert.NoError(t, err)
+	assert.Equal(t, string([]byte{0x01, 0x02, 0x03}), v)
+
+	// Second pass: zero deletions, signals self-terminate.
+	deleted, err = gcLegacyTombstonePass(ctx, metaKV)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, deleted)
+}
+
+func Test_gcLegacyTombstoneBatch_PrefixIsolation(t *testing.T) {
+	// Tombstone value lives at a prefix we do NOT scan (e.g. snapshots/).
+	// Must not be touched by the tombstone GC.
+	metaKV, cleanup := newTombstoneTestMetaKV(t)
+	defer cleanup()
+
+	ctx := context.TODO()
+	tomb := string(SuffixSnapshotTombstone)
+
+	outOfScopeKey := SnapshotPrefix + "/root-coord/collection/5_ts1"
+	require.NoError(t, metaKV.Save(ctx, outOfScopeKey, tomb))
+
+	deleted, err := gcLegacyTombstonePass(ctx, metaKV)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, deleted)
+
+	v, err := metaKV.Load(ctx, outOfScopeKey)
+	assert.NoError(t, err)
+	assert.Equal(t, tomb, v)
+}
+
+func Test_gcLegacyTombstoneBatch_WalkError(t *testing.T) {
+	kvMock := mocks.NewMetaKv(t)
+	kvMock.EXPECT().WalkWithPrefix(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(fmt.Errorf("etcd unavailable"))
+
+	deleted, err := gcLegacyTombstoneBatch(context.TODO(), kvMock, CollectionMetaPrefix+"/")
+	assert.Error(t, err)
+	assert.Equal(t, 0, deleted)
+}
+
+func Test_gcLegacyTombstoneBatch_PrefixMismatch(t *testing.T) {
+	// If WalkWithPrefix yields a key whose full path doesn't include the
+	// expected full-path prefix, we skip it rather than MultiRemove a bogus key.
+	kvMock := mocks.NewMetaKv(t)
+	kvMock.EXPECT().WalkWithPrefix(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(ctx context.Context, prefix string, paginationSize int, fn func([]byte, []byte) error) error {
+			return fn([]byte("wrong-prefix/some-key"), SuffixSnapshotTombstone)
+		})
+	kvMock.EXPECT().GetPath(mock.Anything).Return("root/root-coord/collection/")
+
+	deleted, err := gcLegacyTombstoneBatch(context.TODO(), kvMock, CollectionMetaPrefix+"/")
+	assert.NoError(t, err)
+	assert.Equal(t, 0, deleted)
+}
+
+func Test_runLegacyTombstoneGC_ContextCancel(t *testing.T) {
+	kvMock := mocks.NewMetaKv(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan struct{})
+	go func() {
+		runLegacyTombstoneGC(ctx, kvMock)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("runLegacyTombstoneGC did not exit after context cancel")
+	}
+}
+
+func Test_runLegacyTombstoneGC_SelfTerminate(t *testing.T) {
+	kvMock := mocks.NewMetaKv(t)
+	// All prefixes scanned return zero tombstones → deleted=0 → goroutine exits.
+	kvMock.EXPECT().WalkWithPrefix(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil)
+
+	done := make(chan struct{})
+	go func() {
+		runLegacyTombstoneGC(context.Background(), kvMock)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("runLegacyTombstoneGC did not self-terminate")
+	}
+}
+
+func Test_stripRootPath(t *testing.T) {
+	kvMock := mocks.NewMetaKv(t)
+	kvMock.EXPECT().GetPath("root-coord/collection/").
+		Return("by-dev/meta/root-coord/collection/").Maybe()
+
+	rel, ok := stripRootPath(kvMock, "by-dev/meta/root-coord/collection/42", "root-coord/collection/")
+	assert.True(t, ok)
+	assert.Equal(t, "root-coord/collection/42", rel)
+
+	rel, ok = stripRootPath(kvMock, "totally/unrelated/key", "root-coord/collection/")
+	assert.False(t, ok)
+	assert.Equal(t, "", rel)
+}

--- a/internal/rootcoord/root_coord.go
+++ b/internal/rootcoord/root_coord.go
@@ -342,11 +342,13 @@ func (c *Core) initMetaTable(initCtx context.Context) error {
 			log.Ctx(initCtx).Info("Using etcd as meta storage.")
 			metaKV := c.metaKVCreator()
 			kvmetastore.StartLegacySnapshotGC(c.ctx, metaKV)
+			kvmetastore.StartLegacyTombstoneGC(c.ctx, metaKV)
 			catalog = kvmetastore.NewCatalog(metaKV)
 		case util.MetaStoreTypeTiKV:
 			log.Ctx(initCtx).Info("Using tikv as meta storage.")
 			metaKV := c.metaKVCreator()
 			kvmetastore.StartLegacySnapshotGC(c.ctx, metaKV)
+			kvmetastore.StartLegacyTombstoneGC(c.ctx, metaKV)
 			catalog = kvmetastore.NewCatalog(metaKV)
 		default:
 			return retry.Unrecoverable(fmt.Errorf("not supported meta store: %s", Params.MetaStoreCfg.MetaStoreType.GetValue()))


### PR DESCRIPTION
Cherry-pick from master
pr: #49029 
issue: #49028

Before the SuffixSnapshot removal in e0873a65d4, MultiSaveAndRemove(ts!=0) overwrote plain meta keys with a 3-byte tombstone marker ({0xE2, 0x9B, 0xBC}) instead of hard-deleting them. The legacy snapshots/ sweeper does not touch those plain keys, so upgraded clusters with such leftovers fail RootCoord restart at proto.Unmarshal.

Add two complementary defenses in internal/metastore/kv/rootcoord:

- Filter tombstones in every catalog load/list path that can see a legacy plain tombstone value: loadCollectionFromDb (returns CollectionNotFound), ListCollections (pre-filter before pool tasks), GetCollectionByName, listPartitionsAfter210, batchListPartitionsAfter210, listFieldsAfter210, batchListFieldsAfter210, listStructArrayFieldsAfter210, listFunctions, batchListFunctions. Mirrors the existing IsTombstone guard in ListDatabases / listAliases*.

- Add StartLegacyTombstoneGC: a self-terminating background goroutine that walks every RootCoord meta prefix (collection, partition, field, struct-array-field, function, alias, db-info, and both collection layouts) and removes keys whose value exactly equals SuffixSnapshotTombstone. Byte-exact match is safe — valid protobuf-encoded meta values cannot equal those 3 bytes. Wired into initMetaTable alongside StartLegacySnapshotGC for both etcd and tikv.

Unit tests:
- kv_catalog_tombstone_test.go: one test per patched load path verifies that a mixed (tombstone + valid) list returns only the valid entry.
- legacy_tombstone_gc_test.go: multi-prefix batch cleanup, prefix isolation (snapshots/ untouched), walk/delete error paths, context-cancel exit, self-terminate.