### PR TITLE
test: add positive case for decay reranker on add_collection_field nullable input

### DIFF
--- a/tests/python_client/milvus_client/test_add_field_feature.py
+++ b/tests/python_client/milvus_client/test_add_field_feature.py
@@ -793,6 +793,67 @@ class TestMilvusClientAddFieldFeature(TestMilvusClientV2Base):
         self.release_collection(client, collection_name)
         self.drop_collection(client, collection_name)
 
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_milvus_client_add_field_used_as_decay_reranker_input(self):
+        """
+        target: verify a nullable field added via add_collection_field can be used
+                as the input field of a decay reranker in search
+        method: create collection without reranker field, add nullable INT64 field
+                via add_collection_field, then search with decay reranker referencing it
+        expected: search succeeds
+        note: PR #47919 removed the "Function input field cannot be nullable" Go-side
+              validation, but segcore still hits an assertion (offset out of range)
+              when the reranker reads the newly added nullable field. Tracked as a
+              separate kernel bug; this test guards the intended behavior.
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        dim = 8
+
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=dim)
+        schema.add_field(default_string_field_name, DataType.VARCHAR, max_length=64, is_partition_key=True)
+
+        index_params = self.prepare_index_params(client)[0]
+        index_params.add_index(default_vector_field_name, metric_type="COSINE")
+        self.create_collection(client, collection_name, dimension=dim, schema=schema, index_params=index_params)
+
+        vectors = cf.gen_vectors(default_nb, dim, vector_data_type=DataType.FLOAT_VECTOR)
+        rows = [{default_primary_key_field_name: i, default_vector_field_name: vectors[i],
+                 default_string_field_name: str(i)} for i in range(default_nb)]
+        self.insert(client, collection_name, rows)
+
+        self.add_collection_field(client, collection_name, field_name=ct.default_reranker_field_name,
+                                  data_type=DataType.INT64, nullable=True, default_value=0)
+
+        vectors_batch2 = cf.gen_vectors(default_nb, dim, vector_data_type=DataType.FLOAT_VECTOR)
+        rows_with_reranker = [
+            {default_primary_key_field_name: i, default_vector_field_name: vectors_batch2[i - default_nb],
+             default_string_field_name: str(i), ct.default_reranker_field_name: i}
+            for i in range(default_nb, default_nb * 2)]
+        self.insert(client, collection_name, rows_with_reranker)
+
+        from pymilvus import Function, FunctionType
+        my_rerank_fn = Function(
+            name="my_reranker",
+            input_field_names=[ct.default_reranker_field_name],
+            function_type=FunctionType.RERANK,
+            params={
+                "reranker": "decay",
+                "function": "gauss",
+                "origin": 0,
+                "offset": 0,
+                "decay": 0.5,
+                "scale": 100
+            }
+        )
+
+        self.search(client, collection_name, [vectors[0]], ranker=my_rerank_fn,
+                    check_task=CheckTasks.check_search_results,
+                    check_items={"nq": 1, "limit": ct.default_limit,
+                                 "pk_name": default_primary_key_field_name})
+
 
 class TestMilvusClientAddFieldFeatureInvalid(TestMilvusClientV2Base):
     """Test invalid cases for add field feature"""
@@ -1021,70 +1082,3 @@ class TestMilvusClientAddFieldFeatureInvalid(TestMilvusClientV2Base):
                                   nullable=True,
                                   check_task=CheckTasks.err_res, check_items=error)
 
-    @pytest.mark.tags(CaseLabel.L2)
-    def test_milvus_client_add_field_with_reranker_unsupported(self):
-        """
-        target: test that add_collection_field and decay ranker combination is not supported
-        method: create collection without reranker field, add nullable reranker field via add_collection_field,
-                then try to use it with decay ranker
-        expected: raise exception because decay ranker requires non-nullable fields but add_collection_field
-                 only supports nullable fields, creating a technical limitation
-        """
-        client = self._client()
-        collection_name = cf.gen_collection_name_by_testcase_name()
-        dim = 8
-
-        # 1. create collection WITHOUT reranker field initially
-        schema = self.create_schema(client, enable_dynamic_field=False)[0]
-        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
-        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=dim)
-        schema.add_field(default_string_field_name, DataType.VARCHAR, max_length=64, is_partition_key=True)
-        # Note: NO reranker field here - we'll try to add it later via add_collection_field
-
-        index_params = self.prepare_index_params(client)[0]
-        index_params.add_index(default_vector_field_name, metric_type="COSINE")
-        self.create_collection(client, collection_name, dimension=dim, schema=schema, index_params=index_params)
-
-        # 2. insert initial data WITHOUT reranker field
-        vectors = cf.gen_vectors(default_nb, dim, vector_data_type=DataType.FLOAT_VECTOR)
-        rows = [{default_primary_key_field_name: i, default_vector_field_name: vectors[i],
-                 default_string_field_name: str(i)} for i in range(default_nb)]
-        results = self.insert(client, collection_name, rows)[0]
-        assert results['insert_count'] == default_nb
-
-        # 3. Try to add nullable reranker field via add_collection_field (nullable must be True)
-        # This will succeed in adding the field, but then we'll test if it can work with decay reranker
-        # The conflict: add_collection_field only supports nullable fields, but decay reranker needs non-nullable fields
-        self.add_collection_field(client, collection_name, field_name=ct.default_reranker_field_name,
-                                  data_type=DataType.INT64, nullable=True, default_value=0)
-
-        # 4. Insert data with the newly added reranker field
-        # Generate new vectors for the second batch of data
-        vectors_batch2 = cf.gen_vectors(default_nb, dim, vector_data_type=DataType.FLOAT_VECTOR)
-        rows_with_reranker = [
-            {default_primary_key_field_name: i, default_vector_field_name: vectors_batch2[i - default_nb],
-             default_string_field_name: str(i), ct.default_reranker_field_name: i}
-            for i in range(default_nb, default_nb * 2)]
-        results = self.insert(client, collection_name, rows_with_reranker)[0]
-        assert results['insert_count'] == default_nb
-
-        # 5. Try to use the nullable reranker field with decay reranker
-        # This should fail because decay reranker requires non-nullable fields for proper functionality
-        from pymilvus import Function, FunctionType
-        my_rerank_fn = Function(
-            name="my_reranker",
-            input_field_names=[ct.default_reranker_field_name],
-            function_type=FunctionType.RERANK,
-            params={
-                "reranker": "decay",
-                "function": "gauss",
-                "origin": 0,
-                "offset": 0,
-                "decay": 0.5,
-                "scale": 100
-            }
-        )
-
-        error = {ct.err_code: 65535, ct.err_msg: "Function input field cannot be nullable: field reranker_field"}
-        self.search(client, collection_name, [vectors[0]], ranker=my_rerank_fn,
-                    check_task=CheckTasks.err_res, check_items=error)


### PR DESCRIPTION
## Summary

PR #47919 (Arrow-based function chain pipeline) removed the Go-side `Function input field cannot be nullable` validation in `internal/util/function/rerank/rerank_base.go`. As a result, a nullable field added via `add_collection_field` is now an accepted input for a decay reranker.

This PR replaces the previous negative case `test_milvus_client_add_field_with_reranker_unsupported` (which expected the now-removed validation error) with a positive case `test_milvus_client_add_field_used_as_decay_reranker_input`, covering the combination `add_collection_field(nullable=True) + decay reranker on the new field` and asserting that search succeeds.