### PR TITLE
fix: [2.6.12-backfill] bump milvus-proto to hotfix-2.6.12-backfill pseudo-version

### DIFF
--- a/client/go.mod
+++ b/client/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/cockroachdb/errors v1.9.1
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
-	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.12
+	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.14-0.20260415095946-e6ff15c3f0ab
 	github.com/milvus-io/milvus/pkg/v2 v2.6.7-0.20251201120310-af64f2acba38
 	github.com/quasilyte/go-ruleguard/dsl v0.3.23
 	github.com/samber/lo v1.27.0
@@ -119,5 +119,3 @@ require (
 	k8s.io/apimachinery v0.32.3 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
-
-replace github.com/milvus-io/milvus-proto/go-api/v2 => /Users/wei.liu/Code/snapshot-cp-2.6/milvus-proto/go-api

--- a/client/go.sum
+++ b/client/go.sum
@@ -331,8 +331,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/mediocregopher/radix/v3 v3.4.2/go.mod h1:8FL3F6UQRXHXIBSPUs5h0RybMF8i4n7wVopoX3x7Bv8=
 github.com/microcosm-cc/bluemonday v1.0.2/go.mod h1:iVP4YcDBq+n/5fb23BhYFvIMq/leAFZyRl6bYmGDlGc=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
-github.com/milvus-io/milvus-proto/go-api/v2 v2.6.12 h1:IaKkwnC8df59wT1bUz7e3zhTqoY3WiT67NHEeFfdRzI=
-github.com/milvus-io/milvus-proto/go-api/v2 v2.6.12/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.14-0.20260415095946-e6ff15c3f0ab h1:+GPMUpTrPg/ydpSV3NL6fH8cnreyNcQ4zf8C143UnA8=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.14-0.20260415095946-e6ff15c3f0ab/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
 github.com/milvus-io/milvus/pkg/v2 v2.6.7-0.20251201120310-af64f2acba38 h1:75pdNz8Ln9jdBxlkUQRJu+P8tz4q+G48XAybS3O30FQ=
 github.com/milvus-io/milvus/pkg/v2 v2.6.7-0.20251201120310-af64f2acba38/go.mod h1:ak5nlCCbtImG4/WWcI/csU5ht6EyF/9QQ/tmivMzF4c=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/klauspost/compress v1.18.0
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
-	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.12
+	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.14-0.20260415095946-e6ff15c3f0ab
 	github.com/minio/minio-go/v7 v7.0.73
 	github.com/panjf2000/ants/v2 v2.11.3 // indirect
 	github.com/pingcap/log v1.1.1-0.20221015072633-39906604fb81 // indirect
@@ -324,5 +324,3 @@ replace (
 	github.com/streamnative/pulsarctl => github.com/xiaofan-luan/pulsarctl v0.5.1
 	github.com/tecbot/gorocksdb => github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b // indirect
 )
-
-replace github.com/milvus-io/milvus-proto/go-api/v2 => /Users/wei.liu/Code/snapshot-cp-2.6/milvus-proto/go-api

--- a/go.sum
+++ b/go.sum
@@ -799,8 +799,8 @@ github.com/milvus-io/cgosymbolizer v0.0.0-20250318084424-114f4050c3a6 h1:YHMFI6L
 github.com/milvus-io/cgosymbolizer v0.0.0-20250318084424-114f4050c3a6/go.mod h1:DvXTE/K/RtHehxU8/GtDs4vFtfw64jJ3PaCnFri8CRg=
 github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b h1:TfeY0NxYxZzUfIfYe5qYDBzt4ZYRqzUjTR6CvUzjat8=
 github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b/go.mod h1:iwW+9cWfIzzDseEBCCeDSN5SD16Tidvy8cwQ7ZY8Qj4=
-github.com/milvus-io/milvus-proto/go-api/v2 v2.6.12 h1:IaKkwnC8df59wT1bUz7e3zhTqoY3WiT67NHEeFfdRzI=
-github.com/milvus-io/milvus-proto/go-api/v2 v2.6.12/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.14-0.20260415095946-e6ff15c3f0ab h1:+GPMUpTrPg/ydpSV3NL6fH8cnreyNcQ4zf8C143UnA8=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.14-0.20260415095946-e6ff15c3f0ab/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 h1:AMFGa4R4MiIpspGNG7Z948v4n35fFGB3RR3G/ry4FWs=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8/go.mod h1:mC1jAcsrzbxHt8iiaC+zU4b1ylILSosueou12R++wfY=
 github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 h1:+n/aFZefKZp7spd8DFdX7uMikMLXX4oubIzJF4kv/wI=
@@ -1276,6 +1276,7 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191227163750-53104e6ec876/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -1283,6 +1284,7 @@ golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201012173705-84dcc777aaee/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
+golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/jolestar/go-commons-pool/v2 v2.1.2
 	github.com/json-iterator/go v1.1.13-0.20220915233716-71ac16282d12
 	github.com/klauspost/compress v1.18.0
-	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.12
+	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.14-0.20260415095946-e6ff15c3f0ab
 	github.com/minio/minio-go/v7 v7.0.73
 	github.com/panjf2000/ants/v2 v2.11.3
 	github.com/prometheus/client_golang v1.20.5
@@ -242,5 +242,3 @@ replace (
 )
 
 exclude github.com/apache/pulsar-client-go/oauth2 v0.0.0-20211108044248-fe3b7c4e445b
-
-replace github.com/milvus-io/milvus-proto/go-api/v2 => /Users/wei.liu/Code/snapshot-cp-2.6/milvus-proto/go-api

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -482,8 +482,8 @@ github.com/milvus-io/cgosymbolizer v0.0.0-20250318084424-114f4050c3a6 h1:YHMFI6L
 github.com/milvus-io/cgosymbolizer v0.0.0-20250318084424-114f4050c3a6/go.mod h1:DvXTE/K/RtHehxU8/GtDs4vFtfw64jJ3PaCnFri8CRg=
 github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b h1:TfeY0NxYxZzUfIfYe5qYDBzt4ZYRqzUjTR6CvUzjat8=
 github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b/go.mod h1:iwW+9cWfIzzDseEBCCeDSN5SD16Tidvy8cwQ7ZY8Qj4=
-github.com/milvus-io/milvus-proto/go-api/v2 v2.6.12 h1:IaKkwnC8df59wT1bUz7e3zhTqoY3WiT67NHEeFfdRzI=
-github.com/milvus-io/milvus-proto/go-api/v2 v2.6.12/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.14-0.20260415095946-e6ff15c3f0ab h1:+GPMUpTrPg/ydpSV3NL6fH8cnreyNcQ4zf8C143UnA8=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.14-0.20260415095946-e6ff15c3f0ab/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=
 github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEpN+20RM=
 github.com/minio/minio-go/v7 v7.0.73 h1:qr2vi96Qm7kZ4v7LLebjte+MQh621fFWnv93p12htEo=

--- a/tests/go_client/go.mod
+++ b/tests/go_client/go.mod
@@ -3,7 +3,7 @@ module github.com/milvus-io/milvus/tests/go_client
 go 1.24.12
 
 require (
-	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.14
+	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.14-0.20260415095946-e6ff15c3f0ab
 	github.com/milvus-io/milvus/client/v2 v2.0.0-20241125024034-0b9edb62a92d
 	github.com/milvus-io/milvus/pkg/v2 v2.6.7-0.20251202033909-b71a123d25ad
 	github.com/peterstace/simplefeatures v0.54.0
@@ -122,5 +122,3 @@ require (
 	k8s.io/apimachinery v0.32.3 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
-
-replace github.com/milvus-io/milvus-proto/go-api/v2 => /Users/wei.liu/Code/snapshot-cp-2.6/milvus-proto/go-api

--- a/tests/go_client/go.sum
+++ b/tests/go_client/go.sum
@@ -333,8 +333,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/mediocregopher/radix/v3 v3.4.2/go.mod h1:8FL3F6UQRXHXIBSPUs5h0RybMF8i4n7wVopoX3x7Bv8=
 github.com/microcosm-cc/bluemonday v1.0.2/go.mod h1:iVP4YcDBq+n/5fb23BhYFvIMq/leAFZyRl6bYmGDlGc=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
-github.com/milvus-io/milvus-proto/go-api/v2 v2.6.14 h1:nqtOeeyinDyfJQwux514eUwFCj9fPhmR0komkXegtW0=
-github.com/milvus-io/milvus-proto/go-api/v2 v2.6.14/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.14-0.20260415095946-e6ff15c3f0ab h1:+GPMUpTrPg/ydpSV3NL6fH8cnreyNcQ4zf8C143UnA8=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.14-0.20260415095946-e6ff15c3f0ab/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
 github.com/milvus-io/milvus/pkg/v2 v2.6.7-0.20251202033909-b71a123d25ad h1:pjSurtVnX3VLLdjUg3HKMpILDv/ZEfSI1rZLsTd+h1U=
 github.com/milvus-io/milvus/pkg/v2 v2.6.7-0.20251202033909-b71a123d25ad/go.mod h1:ak5nlCCbtImG4/WWcI/csU5ht6EyF/9QQ/tmivMzF4c=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=


### PR DESCRIPTION
## Summary

Drop the local-path replace directive and bump \`milvus-proto/go-api/v2\` to the pseudo-version corresponding to the milvus-proto \`hotfix-2.6.12-backfill\` HEAD.

## Background

[#49058](https://github.com/milvus-io/milvus/pull/49058) accidentally merged with a hardcoded \`replace\` pointing to a local path:

\`\`\`
replace github.com/milvus-io/milvus-proto/go-api/v2 => /Users/wei.liu/Code/snapshot-cp-2.6/milvus-proto/go-api
\`\`\`

This makes the build non-reproducible for anyone else. It also left the \`milvus-proto/go-api/v2\` require at \`v2.6.12\`, which does not contain the snapshot API definitions.

## Changes

- Remove the local-path \`replace\` directive from \`go.mod\`, \`pkg/go.mod\`, \`client/go.mod\`, and \`tests/go_client/go.mod\`.
- Bump \`github.com/milvus-io/milvus-proto/go-api/v2\` to \`v2.6.14-0.20260415095946-e6ff15c3f0ab\`, which is the pseudo-version for commit \`e6ff15c\` on milvus-proto \`hotfix-2.6.12-backfill\` (merged via [milvus-io/milvus-proto#584](https://github.com/milvus-io/milvus-proto/pull/584)).
- Regenerate \`go.sum\` for all four modules via \`go mod tidy\`.

issue: none (follow-up fix for [#49058](https://github.com/milvus-io/milvus/pull/49058))