### PR TITLE
feat: [WIP] add ArrowSegment for direct Arrow RecordBatch filtering

### DIFF
--- a/internal/core/src/segcore/ArrowSegment.cpp
+++ b/internal/core/src/segcore/ArrowSegment.cpp
@@ -1,0 +1,627 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "segcore/ArrowSegment.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "arrow/api.h"
+#include "common/EasyAssert.h"
+#include "common/FieldMeta.h"
+#include "common/Schema.h"
+#include "common/Span.h"
+#include "common/Types.h"
+#include "segcore/ArrowUtil.h"
+
+namespace milvus::segcore {
+
+// =================================================================
+// Constructor
+// =================================================================
+
+ArrowSegment::ArrowSegment(
+    std::shared_ptr<milvus_storage::api::ChunkReader> reader,
+    SchemaPtr schema,
+    int64_t segment_id,
+    int64_t chunks_per_cell)
+    : chunk_reader_(std::move(reader)),
+      schema_(std::move(schema)),
+      segment_id_(segment_id) {
+    auto chunk_rows = chunk_reader_->get_chunk_rows().ValueOrDie();
+    size_t total = chunk_rows.size();
+    size_t num_logical =
+        (total + chunks_per_cell - 1) / chunks_per_cell;
+
+    prefix_row_counts_.push_back(0);
+    for (size_t cid = 0; cid < num_logical; ++cid) {
+        size_t start = cid * chunks_per_cell;
+        size_t end =
+            std::min(start + static_cast<size_t>(chunks_per_cell), total);
+        int64_t cell_rows = 0;
+        for (size_t i = start; i < end; ++i) {
+            cell_rows += static_cast<int64_t>(chunk_rows[i]);
+        }
+        chunk_row_counts_.push_back(cell_rows);
+        num_rows_ += cell_rows;
+        prefix_row_counts_.push_back(num_rows_);
+        chunk_ranges_.push_back({start, end});
+    }
+    // field_to_col_ built lazily on first chunk load
+}
+
+// =================================================================
+// GetOrLoadChunk
+// =================================================================
+
+std::shared_ptr<arrow::RecordBatch>
+ArrowSegment::GetOrLoadChunk(int64_t chunk_id) const {
+    auto it = chunk_cache_.find(chunk_id);
+    if (it != chunk_cache_.end()) {
+        return it->second;
+    }
+
+    auto [start, end] = chunk_ranges_[chunk_id];
+    std::shared_ptr<arrow::RecordBatch> result;
+    if (end - start == 1) {
+        result =
+            chunk_reader_->get_chunk(static_cast<int64_t>(start))
+                .ValueOrDie();
+    } else {
+        std::vector<int64_t> indices;
+        for (size_t i = start; i < end; ++i) {
+            indices.push_back(static_cast<int64_t>(i));
+        }
+        auto batches =
+            chunk_reader_->get_chunks(indices).ValueOrDie();
+        auto table =
+            arrow::Table::FromRecordBatches(batches).ValueOrDie();
+        result = table->CombineChunksToBatch().ValueOrDie();
+    }
+
+    // Build field mapping from first loaded chunk
+    if (field_to_col_.empty()) {
+        auto arrow_schema = result->schema();
+        for (const auto& [fid, meta] : schema_->get_fields()) {
+            auto idx = arrow_schema->GetFieldIndex(
+                meta.get_name().get());
+            if (idx >= 0) {
+                field_to_col_[fid] = idx;
+            }
+        }
+    }
+
+    chunk_cache_[chunk_id] = result;
+    return result;
+}
+
+// =================================================================
+// GetOrExpandValidity
+// =================================================================
+
+const FixedVector<bool>&
+ArrowSegment::GetOrExpandValidity(FieldId field_id,
+                                  int64_t chunk_id) const {
+    auto key = std::make_pair(field_id, chunk_id);
+    auto it = validity_cache_.find(key);
+    if (it != validity_cache_.end()) {
+        return it->second;
+    }
+
+    auto batch = GetOrLoadChunk(chunk_id);
+    auto col = batch->column(field_to_col_.at(field_id));
+    auto null_bitmap = col->null_bitmap_data();
+    auto expanded = ExpandArrowValidity(
+        null_bitmap, col->offset(), col->length());
+
+    auto [inserted, _] = validity_cache_.emplace(key, std::move(expanded));
+    return inserted->second;
+}
+
+// =================================================================
+// Core data access: chunk_data_impl (scalars, zero-copy)
+// =================================================================
+
+PinWrapper<SpanBase>
+ArrowSegment::chunk_data_impl(milvus::OpContext*,
+                              FieldId field_id,
+                              int64_t chunk_id) const {
+    auto batch = GetOrLoadChunk(chunk_id);
+    auto col = batch->column(field_to_col_.at(field_id));
+    auto& validity = GetOrExpandValidity(field_id, chunk_id);
+    auto data_type = schema_->operator[](field_id).get_data_type();
+    auto elem_size = GetDataTypeSize(data_type);
+
+    return PinWrapper<SpanBase>(SpanBase(
+        col->data()->buffers[1]->data(),
+        validity.empty() ? nullptr : validity.data(),
+        chunk_row_counts_[chunk_id],
+        elem_size));
+}
+
+// =================================================================
+// Core data access: chunk_string_view_impl
+// =================================================================
+
+PinWrapper<std::pair<std::vector<std::string_view>, FixedVector<bool>>>
+ArrowSegment::chunk_string_view_impl(
+    milvus::OpContext*,
+    FieldId field_id,
+    int64_t chunk_id,
+    std::optional<std::pair<int64_t, int64_t>> offset_len) const {
+    auto batch = GetOrLoadChunk(chunk_id);
+    auto str = std::static_pointer_cast<arrow::StringArray>(
+        batch->column(field_to_col_.at(field_id)));
+    auto& validity = GetOrExpandValidity(field_id, chunk_id);
+    auto [start, len] = offset_len.value_or(
+        std::make_pair(int64_t{0}, chunk_row_counts_[chunk_id]));
+
+    std::vector<std::string_view> views;
+    views.reserve(len);
+    for (int64_t i = start; i < start + len; ++i) {
+        auto sv = str->GetView(i);
+        views.emplace_back(sv.data(), sv.size());
+    }
+    FixedVector<bool> valid;
+    if (!validity.empty()) {
+        valid.assign(
+            validity.begin() + start,
+            validity.begin() + start + len);
+    }
+    return PinWrapper(
+        std::make_pair(std::move(views), std::move(valid)));
+}
+
+// =================================================================
+// Core data access: chunk_string_views_by_offsets
+// =================================================================
+
+PinWrapper<std::pair<std::vector<std::string_view>, FixedVector<bool>>>
+ArrowSegment::chunk_string_views_by_offsets(
+    milvus::OpContext*,
+    FieldId field_id,
+    int64_t chunk_id,
+    const FixedVector<int32_t>& offsets) const {
+    auto batch = GetOrLoadChunk(chunk_id);
+    auto str = std::static_pointer_cast<arrow::StringArray>(
+        batch->column(field_to_col_.at(field_id)));
+    auto& validity = GetOrExpandValidity(field_id, chunk_id);
+
+    std::vector<std::string_view> views;
+    views.reserve(offsets.size());
+    FixedVector<bool> valid;
+    if (!validity.empty()) {
+        valid.reserve(offsets.size());
+    }
+    for (auto off : offsets) {
+        auto sv = str->GetView(off);
+        views.emplace_back(sv.data(), sv.size());
+        if (!validity.empty()) {
+            valid.push_back(validity[off]);
+        }
+    }
+    return PinWrapper(
+        std::make_pair(std::move(views), std::move(valid)));
+}
+
+// =================================================================
+// Field info methods
+// =================================================================
+
+bool
+ArrowSegment::HasFieldData(FieldId field_id) const {
+    // Ensure field mapping is available by loading chunk if needed
+    if (field_to_col_.empty() && !chunk_ranges_.empty()) {
+        GetOrLoadChunk(0);
+    }
+    return field_to_col_.count(field_id) > 0;
+}
+
+bool
+ArrowSegment::HasRawData(int64_t field_id) const {
+    return HasFieldData(FieldId(field_id));
+}
+
+bool
+ArrowSegment::is_nullable(FieldId field_id) const {
+    auto& field_meta = schema_->operator[](field_id);
+    return field_meta.is_nullable();
+}
+
+DataType
+ArrowSegment::GetFieldDataType(FieldId field_id) const {
+    auto& field_meta = schema_->operator[](field_id);
+    return field_meta.get_data_type();
+}
+
+// =================================================================
+// Chunk metadata methods
+// =================================================================
+
+int64_t
+ArrowSegment::num_chunk(FieldId) const {
+    return static_cast<int64_t>(chunk_row_counts_.size());
+}
+
+int64_t
+ArrowSegment::num_chunk_data(FieldId) const {
+    return static_cast<int64_t>(chunk_row_counts_.size());
+}
+
+int64_t
+ArrowSegment::chunk_size(FieldId, int64_t chunk_id) const {
+    return chunk_row_counts_[chunk_id];
+}
+
+int64_t
+ArrowSegment::num_rows_until_chunk(FieldId,
+                                   int64_t chunk_id) const {
+    return prefix_row_counts_[chunk_id];
+}
+
+std::pair<int64_t, int64_t>
+ArrowSegment::get_chunk_by_offset(FieldId, int64_t offset) const {
+    // Binary search: find the chunk containing this offset
+    auto it = std::upper_bound(prefix_row_counts_.begin(),
+                               prefix_row_counts_.end(),
+                               offset);
+    int64_t chunk_id = std::max(
+        int64_t{0},
+        static_cast<int64_t>(
+            std::distance(prefix_row_counts_.begin(), it)) -
+            1);
+    int64_t local_offset = offset - prefix_row_counts_[chunk_id];
+    return {chunk_id, local_offset};
+}
+
+// =================================================================
+// Phase 2 stubs (array/vector_array)
+// =================================================================
+
+PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>
+ArrowSegment::chunk_array_view_impl(
+    milvus::OpContext*,
+    FieldId,
+    int64_t,
+    std::optional<std::pair<int64_t, int64_t>>) const {
+    ThrowInfo(ErrorCode::NotImplemented,
+              "ArrowSegment::chunk_array_view_impl");
+}
+
+PinWrapper<std::pair<std::vector<VectorArrayView>, FixedVector<bool>>>
+ArrowSegment::chunk_vector_array_view_impl(
+    milvus::OpContext*,
+    FieldId,
+    int64_t,
+    std::optional<std::pair<int64_t, int64_t>>) const {
+    ThrowInfo(ErrorCode::NotImplemented,
+              "ArrowSegment::chunk_vector_array_view_impl");
+}
+
+PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>
+ArrowSegment::chunk_array_views_by_offsets(
+    milvus::OpContext*,
+    FieldId,
+    int64_t,
+    const FixedVector<int32_t>&) const {
+    ThrowInfo(ErrorCode::NotImplemented,
+              "ArrowSegment::chunk_array_views_by_offsets");
+}
+
+// =================================================================
+// Stubs: SegmentInterface methods
+// =================================================================
+
+bool
+ArrowSegment::Contain(const PkType&) const {
+    ThrowInfo(ErrorCode::NotImplemented,
+              "ArrowSegment::Contain");
+}
+
+SegcoreError
+ArrowSegment::Delete(int64_t, const IdArray*, const Timestamp*) {
+    ThrowInfo(ErrorCode::NotImplemented,
+              "ArrowSegment::Delete");
+}
+
+void
+ArrowSegment::LoadDeletedRecord(const LoadDeletedRecordInfo&) {
+    ThrowInfo(ErrorCode::NotImplemented,
+              "ArrowSegment::LoadDeletedRecord");
+}
+
+void
+ArrowSegment::LoadFieldData(const LoadFieldDataInfo&, milvus::OpContext*) {
+    ThrowInfo(ErrorCode::NotImplemented,
+              "ArrowSegment::LoadFieldData");
+}
+
+void
+ArrowSegment::CreateTextIndex(FieldId, milvus::OpContext*) {
+    ThrowInfo(ErrorCode::NotImplemented,
+              "ArrowSegment::CreateTextIndex");
+}
+
+void
+ArrowSegment::BulkGetJsonData(milvus::OpContext*,
+                              FieldId,
+                              const std::function<void(milvus::Json, size_t, bool)>&,
+                              const int64_t*,
+                              int64_t) const {
+    ThrowInfo(ErrorCode::NotImplemented,
+              "ArrowSegment::BulkGetJsonData");
+}
+
+void
+ArrowSegment::LazyCheckSchema(SchemaPtr) {
+    ThrowInfo(ErrorCode::NotImplemented,
+              "ArrowSegment::LazyCheckSchema");
+}
+
+void
+ArrowSegment::Reopen(SchemaPtr) {
+    ThrowInfo(ErrorCode::NotImplemented,
+              "ArrowSegment::Reopen");
+}
+
+void
+ArrowSegment::Reopen(milvus::OpContext*,
+                     const milvus::proto::segcore::SegmentLoadInfo&) {
+    ThrowInfo(ErrorCode::NotImplemented,
+              "ArrowSegment::Reopen(OpContext)");
+}
+
+void
+ArrowSegment::Load(milvus::tracer::TraceContext&, milvus::OpContext*) {
+    ThrowInfo(ErrorCode::NotImplemented,
+              "ArrowSegment::Load");
+}
+
+std::shared_ptr<const IArrayOffsets>
+ArrowSegment::GetArrayOffsets(FieldId) const {
+    return nullptr;
+}
+
+// =================================================================
+// Stubs: SegmentInternalInterface methods
+// =================================================================
+
+void
+ArrowSegment::vector_search(SearchInfo&,
+                            const void*,
+                            const size_t*,
+                            int64_t,
+                            Timestamp,
+                            const BitsetView&,
+                            milvus::OpContext*,
+                            SearchResult&) const {
+    ThrowInfo(ErrorCode::NotImplemented,
+              "ArrowSegment::vector_search");
+}
+
+void
+ArrowSegment::mask_with_delete(BitsetTypeView&,
+                               int64_t,
+                               Timestamp) const {
+    // No-op: ArrowSegment has no deletes
+}
+
+void
+ArrowSegment::mask_with_timestamps(BitsetTypeView&,
+                                   Timestamp,
+                                   Timestamp) const {
+    // No-op: ArrowSegment has no timestamps to filter
+}
+
+void
+ArrowSegment::check_search(const query::Plan*) const {
+    ThrowInfo(ErrorCode::NotImplemented,
+              "ArrowSegment::check_search");
+}
+
+const ConcurrentVector<Timestamp>&
+ArrowSegment::get_timestamps() const {
+    ThrowInfo(ErrorCode::NotImplemented,
+              "ArrowSegment::get_timestamps");
+}
+
+void
+ArrowSegment::search_ids(BitsetType&, const IdArray&) const {
+    ThrowInfo(ErrorCode::NotImplemented,
+              "ArrowSegment::search_ids");
+}
+
+std::pair<std::vector<OffsetMap::OffsetType>, bool>
+ArrowSegment::find_first_n(int64_t, const BitsetTypeView&) const {
+    ThrowInfo(ErrorCode::NotImplemented,
+              "ArrowSegment::find_first_n");
+}
+
+std::tuple<std::vector<int64_t>, std::vector<std::vector<int32_t>>, bool>
+ArrowSegment::find_first_n_element(int64_t,
+                                   const BitsetTypeView&,
+                                   const IArrayOffsets*) const {
+    ThrowInfo(ErrorCode::NotImplemented,
+              "ArrowSegment::find_first_n_element");
+}
+
+void
+ArrowSegment::pk_range(milvus::OpContext*,
+                       proto::plan::OpType,
+                       const PkType&,
+                       BitsetTypeView&) const {
+    ThrowInfo(ErrorCode::NotImplemented,
+              "ArrowSegment::pk_range");
+}
+
+void
+ArrowSegment::pk_binary_range(milvus::OpContext*,
+                              const PkType&,
+                              bool,
+                              const PkType&,
+                              bool,
+                              BitsetTypeView&) const {
+    ThrowInfo(ErrorCode::NotImplemented,
+              "ArrowSegment::pk_binary_range");
+}
+
+void
+ArrowSegment::bulk_subscript(milvus::OpContext*,
+                             SystemFieldType,
+                             const int64_t*,
+                             int64_t,
+                             void*) const {
+    ThrowInfo(ErrorCode::NotImplemented,
+              "ArrowSegment::bulk_subscript");
+}
+
+void
+ArrowSegment::bulk_subscript(milvus::OpContext*,
+                             FieldId,
+                             DataType,
+                             const int64_t*,
+                             int64_t,
+                             void*,
+                             TargetBitmap&,
+                             bool) const {
+    ThrowInfo(ErrorCode::NotImplemented,
+              "ArrowSegment::bulk_subscript");
+}
+
+std::unique_ptr<DataArray>
+ArrowSegment::bulk_subscript(milvus::OpContext*,
+                             FieldId,
+                             const int64_t*,
+                             int64_t) const {
+    ThrowInfo(ErrorCode::NotImplemented,
+              "ArrowSegment::bulk_subscript");
+}
+
+std::unique_ptr<DataArray>
+ArrowSegment::bulk_subscript(milvus::OpContext*,
+                             FieldId,
+                             const int64_t*,
+                             int64_t,
+                             const std::vector<std::string>&) const {
+    ThrowInfo(ErrorCode::NotImplemented,
+              "ArrowSegment::bulk_subscript");
+}
+
+// =================================================================
+// Stubs: SegmentSealed methods
+// =================================================================
+
+void
+ArrowSegment::LoadIndex(LoadIndexInfo&) {
+    ThrowInfo(ErrorCode::NotImplemented,
+              "ArrowSegment::LoadIndex");
+}
+
+void
+ArrowSegment::LoadSegmentMeta(
+    const milvus::proto::segcore::LoadSegmentMeta&) {
+    ThrowInfo(ErrorCode::NotImplemented,
+              "ArrowSegment::LoadSegmentMeta");
+}
+
+void
+ArrowSegment::DropIndex(const FieldId) {
+    ThrowInfo(ErrorCode::NotImplemented,
+              "ArrowSegment::DropIndex");
+}
+
+void
+ArrowSegment::DropJSONIndex(const FieldId, const std::string&) {
+    ThrowInfo(ErrorCode::NotImplemented,
+              "ArrowSegment::DropJSONIndex");
+}
+
+void
+ArrowSegment::DropFieldData(const FieldId) {
+    ThrowInfo(ErrorCode::NotImplemented,
+              "ArrowSegment::DropFieldData");
+}
+
+void
+ArrowSegment::AddFieldDataInfoForSealed(const LoadFieldDataInfo&) {
+    ThrowInfo(ErrorCode::NotImplemented,
+              "ArrowSegment::AddFieldDataInfoForSealed");
+}
+
+void
+ArrowSegment::RemoveFieldFile(const FieldId) {
+    ThrowInfo(ErrorCode::NotImplemented,
+              "ArrowSegment::RemoveFieldFile");
+}
+
+void
+ArrowSegment::ClearData() {
+    chunk_cache_.clear();
+    validity_cache_.clear();
+    field_to_col_.clear();
+}
+
+std::unique_ptr<DataArray>
+ArrowSegment::get_vector(milvus::OpContext*, FieldId, const int64_t*, int64_t) const {
+    ThrowInfo(ErrorCode::NotImplemented,
+              "ArrowSegment::get_vector");
+}
+
+void
+ArrowSegment::LoadTextIndex(
+    milvus::OpContext*,
+    std::shared_ptr<milvus::proto::indexcgo::LoadTextIndexInfo>) {
+    ThrowInfo(ErrorCode::NotImplemented,
+              "ArrowSegment::LoadTextIndex");
+}
+
+InsertRecord<true>&
+ArrowSegment::get_insert_record() {
+    ThrowInfo(ErrorCode::NotImplemented,
+              "ArrowSegment::get_insert_record");
+}
+
+PinWrapper<index::NgramInvertedIndex*>
+ArrowSegment::GetNgramIndex(milvus::OpContext*, FieldId) const {
+    return nullptr;
+}
+
+PinWrapper<index::NgramInvertedIndex*>
+ArrowSegment::GetNgramIndexForJson(milvus::OpContext*,
+                                   FieldId,
+                                   const std::string&) const {
+    return nullptr;
+}
+
+void
+ArrowSegment::LoadJsonStats(FieldId,
+                            std::shared_ptr<index::JsonKeyStats>) {
+    ThrowInfo(ErrorCode::NotImplemented,
+              "ArrowSegment::LoadJsonStats");
+}
+
+void
+ArrowSegment::RemoveJsonStats(FieldId) {
+    ThrowInfo(ErrorCode::NotImplemented,
+              "ArrowSegment::RemoveJsonStats");
+}
+
+}  // namespace milvus::segcore

--- a/internal/core/src/segcore/ArrowSegment.h
+++ b/internal/core/src/segcore/ArrowSegment.h
@@ -1,0 +1,369 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "arrow/record_batch.h"
+#include "common/Schema.h"
+#include "common/Span.h"
+#include "common/Types.h"
+#include "milvus-storage/reader.h"
+#include "segcore/SegmentSealed.h"
+
+namespace milvus::segcore {
+
+class ArrowSegment : public SegmentSealed {
+ public:
+    ArrowSegment(
+        std::shared_ptr<milvus_storage::api::ChunkReader> reader,
+        SchemaPtr schema,
+        int64_t segment_id = 0,
+        int64_t chunks_per_cell = 1);
+
+    ~ArrowSegment() override = default;
+
+    // ---------------------------------------------------------------
+    // Trivial metadata
+    // ---------------------------------------------------------------
+    bool
+    is_chunked() const override {
+        return true;
+    }
+    int64_t
+    get_row_count() const override {
+        return num_rows_;
+    }
+    int64_t
+    get_deleted_count() const override {
+        return 0;
+    }
+    const Schema&
+    get_schema() const override {
+        return *schema_;
+    }
+    int64_t
+    get_segment_id() const override {
+        return segment_id_;
+    }
+    int64_t
+    size_per_chunk() const override {
+        return chunk_row_counts_.empty() ? 0 : chunk_row_counts_[0];
+    }
+    int64_t
+    get_active_count(Timestamp) const override {
+        return num_rows_;
+    }
+    Timestamp
+    get_max_timestamp() const override {
+        return MAX_TIMESTAMP;
+    }
+
+    // ---------------------------------------------------------------
+    // Field info
+    // ---------------------------------------------------------------
+    bool
+    HasFieldData(FieldId field_id) const override;
+
+    bool
+    HasRawData(int64_t field_id) const override;
+
+    bool
+    HasIndex(FieldId field_id) const override {
+        return false;
+    }
+
+    bool
+    is_nullable(FieldId field_id) const override;
+
+    DataType
+    GetFieldDataType(FieldId field_id) const override;
+
+    // ---------------------------------------------------------------
+    // Chunk metadata
+    // ---------------------------------------------------------------
+    int64_t
+    num_chunk(FieldId field_id) const override;
+
+    int64_t
+    num_chunk_data(FieldId field_id) const override;
+
+    int64_t
+    chunk_size(FieldId field_id, int64_t chunk_id) const override;
+
+    int64_t
+    num_rows_until_chunk(FieldId field_id,
+                         int64_t chunk_id) const override;
+
+    std::pair<int64_t, int64_t>
+    get_chunk_by_offset(FieldId field_id,
+                        int64_t offset) const override;
+
+    // ---------------------------------------------------------------
+    // Misc metadata
+    // ---------------------------------------------------------------
+    bool
+    is_field_exist(FieldId field_id) const override {
+        return schema_->get_fields().find(field_id) !=
+               schema_->get_fields().end();
+    }
+
+    bool
+    is_mmap_field(FieldId field_id) const override {
+        return false;
+    }
+
+    size_t
+    GetMemoryUsageInBytes() const override {
+        return 0;
+    }
+
+    bool
+    Contain(const PkType& pk) const override;
+
+    // ---------------------------------------------------------------
+    // Stubs: SegmentInterface
+    // ---------------------------------------------------------------
+    SegcoreError
+    Delete(int64_t size,
+           const IdArray* pks,
+           const Timestamp* timestamps) override;
+    void
+    LoadDeletedRecord(const LoadDeletedRecordInfo& info) override;
+    void
+    LoadFieldData(const LoadFieldDataInfo& info,
+                  milvus::OpContext* op_ctx = nullptr) override;
+    void
+    CreateTextIndex(FieldId field_id,
+                    milvus::OpContext* op_ctx = nullptr) override;
+    void
+    BulkGetJsonData(
+        milvus::OpContext* op_ctx,
+        FieldId field_id,
+        const std::function<void(milvus::Json, size_t, bool)>& fn,
+        const int64_t* offsets,
+        int64_t count) const override;
+    void
+    LazyCheckSchema(SchemaPtr sch) override;
+    void
+    Reopen(SchemaPtr sch) override;
+    void
+    Reopen(milvus::OpContext* op_ctx,
+           const milvus::proto::segcore::SegmentLoadInfo& new_load_info) override;
+    void
+    Load(milvus::tracer::TraceContext& trace_ctx,
+         milvus::OpContext* op_ctx = nullptr) override;
+    std::shared_ptr<const IArrayOffsets>
+    GetArrayOffsets(FieldId field_id) const override;
+
+    // ---------------------------------------------------------------
+    // Stubs: SegmentInternalInterface
+    // ---------------------------------------------------------------
+    void
+    vector_search(SearchInfo& search_info,
+                  const void* query_data,
+                  const size_t* query_offsets,
+                  int64_t query_count,
+                  Timestamp timestamp,
+                  const BitsetView& bitset,
+                  milvus::OpContext* op_context,
+                  SearchResult& output) const override;
+    void
+    mask_with_delete(BitsetTypeView& bitset,
+                     int64_t ins_barrier,
+                     Timestamp timestamp) const override;
+    void
+    mask_with_timestamps(BitsetTypeView& bitset_chunk,
+                         Timestamp timestamp,
+                         Timestamp collection_ttl) const override;
+    void
+    check_search(const query::Plan* plan) const override;
+    const ConcurrentVector<Timestamp>&
+    get_timestamps() const override;
+    void
+    search_ids(BitsetType& bitset,
+               const IdArray& id_array) const override;
+    std::pair<std::vector<OffsetMap::OffsetType>, bool>
+    find_first_n(int64_t limit,
+                 const BitsetTypeView& bitset) const override;
+    std::tuple<std::vector<int64_t>, std::vector<std::vector<int32_t>>, bool>
+    find_first_n_element(int64_t limit,
+                         const BitsetTypeView& element_bitset,
+                         const IArrayOffsets* array_offsets) const override;
+    void
+    bulk_subscript(milvus::OpContext* op_ctx,
+                   SystemFieldType system_type,
+                   const int64_t* seg_offsets,
+                   int64_t count,
+                   void* output) const override;
+    void
+    bulk_subscript(milvus::OpContext* op_ctx,
+                   FieldId field_id,
+                   DataType data_type,
+                   const int64_t* seg_offsets,
+                   int64_t count,
+                   void* data,
+                   TargetBitmap& valid_map,
+                   bool small_int_raw_type = false) const override;
+    std::unique_ptr<DataArray>
+    bulk_subscript(milvus::OpContext* op_ctx,
+                   FieldId field_id,
+                   const int64_t* seg_offsets,
+                   int64_t count) const override;
+    std::unique_ptr<DataArray>
+    bulk_subscript(
+        milvus::OpContext* op_ctx,
+        FieldId field_id,
+        const int64_t* seg_offsets,
+        int64_t count,
+        const std::vector<std::string>& dynamic_field_names) const override;
+    void
+    pk_range(milvus::OpContext* op_ctx,
+             proto::plan::OpType op,
+             const PkType& pk,
+             BitsetTypeView& bitset) const override;
+    void
+    pk_binary_range(milvus::OpContext* op_ctx,
+                    const PkType& lower_pk,
+                    bool lower_inclusive,
+                    const PkType& upper_pk,
+                    bool upper_inclusive,
+                    BitsetTypeView& bitset) const override;
+
+    // ---------------------------------------------------------------
+    // Stubs: SegmentSealed
+    // ---------------------------------------------------------------
+    void
+    LoadIndex(LoadIndexInfo& info) override;
+    void
+    LoadSegmentMeta(
+        const milvus::proto::segcore::LoadSegmentMeta& meta) override;
+    void
+    DropIndex(const FieldId field_id) override;
+    void
+    DropJSONIndex(const FieldId field_id,
+                  const std::string& nested_path) override;
+    void
+    DropFieldData(const FieldId field_id) override;
+    void
+    AddFieldDataInfoForSealed(
+        const LoadFieldDataInfo& field_data_info) override;
+    void
+    RemoveFieldFile(const FieldId field_id) override;
+    void
+    ClearData() override;
+    std::unique_ptr<DataArray>
+    get_vector(milvus::OpContext* op_ctx,
+               FieldId field_id,
+               const int64_t* ids,
+               int64_t count) const override;
+    void
+    LoadTextIndex(milvus::OpContext* op_ctx,
+                  std::shared_ptr<milvus::proto::indexcgo::LoadTextIndexInfo>
+                      info_proto) override;
+    InsertRecord<true>&
+    get_insert_record() override;
+    PinWrapper<index::NgramInvertedIndex*>
+    GetNgramIndex(milvus::OpContext* op_ctx,
+                  FieldId field_id) const override;
+    PinWrapper<index::NgramInvertedIndex*>
+    GetNgramIndexForJson(
+        milvus::OpContext* op_ctx,
+        FieldId field_id,
+        const std::string& nested_path) const override;
+    void
+    LoadJsonStats(FieldId field_id,
+                  std::shared_ptr<index::JsonKeyStats> stats) override;
+    void
+    RemoveJsonStats(FieldId field_id) override;
+
+ protected:
+    // ---------------------------------------------------------------
+    // Core data access
+    // ---------------------------------------------------------------
+    PinWrapper<SpanBase>
+    chunk_data_impl(milvus::OpContext* op_ctx,
+                    FieldId field_id,
+                    int64_t chunk_id) const override;
+
+    PinWrapper<std::pair<std::vector<std::string_view>, FixedVector<bool>>>
+    chunk_string_view_impl(
+        milvus::OpContext* op_ctx,
+        FieldId field_id,
+        int64_t chunk_id,
+        std::optional<std::pair<int64_t, int64_t>> offset_len) const override;
+
+    PinWrapper<std::pair<std::vector<std::string_view>, FixedVector<bool>>>
+    chunk_string_views_by_offsets(
+        milvus::OpContext* op_ctx,
+        FieldId field_id,
+        int64_t chunk_id,
+        const FixedVector<int32_t>& offsets) const override;
+
+    PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>
+    chunk_array_view_impl(
+        milvus::OpContext* op_ctx,
+        FieldId field_id,
+        int64_t chunk_id,
+        std::optional<std::pair<int64_t, int64_t>> offset_len) const override;
+
+    PinWrapper<std::pair<std::vector<VectorArrayView>, FixedVector<bool>>>
+    chunk_vector_array_view_impl(
+        milvus::OpContext* op_ctx,
+        FieldId field_id,
+        int64_t chunk_id,
+        std::optional<std::pair<int64_t, int64_t>> offset_len) const override;
+
+    PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>
+    chunk_array_views_by_offsets(
+        milvus::OpContext* op_ctx,
+        FieldId field_id,
+        int64_t chunk_id,
+        const FixedVector<int32_t>& offsets) const override;
+
+ private:
+    std::shared_ptr<arrow::RecordBatch>
+    GetOrLoadChunk(int64_t chunk_id) const;
+
+    const FixedVector<bool>&
+    GetOrExpandValidity(FieldId field_id,
+                        int64_t chunk_id) const;
+
+    std::shared_ptr<milvus_storage::api::ChunkReader> chunk_reader_;
+    SchemaPtr schema_;
+    int64_t segment_id_{0};
+    int64_t num_rows_{0};
+    std::vector<int64_t> chunk_row_counts_;
+    std::vector<int64_t> prefix_row_counts_;
+    std::vector<std::pair<size_t, size_t>> chunk_ranges_;
+    mutable std::unordered_map<FieldId, int> field_to_col_;
+
+    mutable std::unordered_map<int64_t,
+                               std::shared_ptr<arrow::RecordBatch>>
+        chunk_cache_;
+    mutable std::map<std::pair<FieldId, int64_t>, FixedVector<bool>>
+        validity_cache_;
+};
+
+}  // namespace milvus::segcore

--- a/internal/core/src/segcore/ArrowUtil.h
+++ b/internal/core/src/segcore/ArrowUtil.h
@@ -1,0 +1,72 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+
+#include "arrow/type.h"
+#include "common/Types.h"
+
+namespace milvus::segcore {
+
+// Expand Arrow bitpacked validity bitmap to Milvus byte-per-bool format.
+// If bitmap is nullptr, returns an empty vector (all valid).
+inline FixedVector<bool>
+ExpandArrowValidity(const uint8_t* bitmap,
+                    int64_t offset,
+                    int64_t length) {
+    if (bitmap == nullptr) {
+        return {};
+    }
+    FixedVector<bool> result(length);
+    for (int64_t i = 0; i < length; ++i) {
+        int64_t bit_idx = offset + i;
+        result[i] =
+            (bitmap[bit_idx >> 3] & (1 << (bit_idx & 7))) != 0;
+    }
+    return result;
+}
+
+// Map Arrow data types to Milvus DataType enum.
+inline DataType
+ArrowTypeToMilvusType(
+    const std::shared_ptr<arrow::DataType>& type) {
+    switch (type->id()) {
+        case arrow::Type::BOOL:
+            return DataType::BOOL;
+        case arrow::Type::INT8:
+            return DataType::INT8;
+        case arrow::Type::INT16:
+            return DataType::INT16;
+        case arrow::Type::INT32:
+            return DataType::INT32;
+        case arrow::Type::INT64:
+            return DataType::INT64;
+        case arrow::Type::FLOAT:
+            return DataType::FLOAT;
+        case arrow::Type::DOUBLE:
+            return DataType::DOUBLE;
+        case arrow::Type::STRING:
+        case arrow::Type::LARGE_STRING:
+            return DataType::VARCHAR;
+        default:
+            return DataType::NONE;
+    }
+}
+
+}  // namespace milvus::segcore

--- a/internal/core/unittest/CMakeLists.txt
+++ b/internal/core/unittest/CMakeLists.txt
@@ -66,6 +66,8 @@ set(MILVUS_TEST_FILES
         test_virtual_pk.cpp
         test_mvcc_fast_path.cpp
         test_external_take.cpp
+        test_arrow_segment.cpp
+        test_arrow_segment_parquet.cpp
         )
 
 if ( NOT (INDEX_ENGINE STREQUAL "cardinal") )

--- a/internal/core/unittest/test_arrow_segment.cpp
+++ b/internal/core/unittest/test_arrow_segment.cpp
@@ -1,0 +1,570 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <cstdint>
+#include <memory>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "arrow/api.h"
+#include "arrow/builder.h"
+#include "common/BitsetView.h"
+#include "common/Consts.h"
+#include "common/Schema.h"
+#include "common/Types.h"
+#include "exec/QueryContext.h"
+#include "exec/expression/Expr.h"
+#include "expr/ITypeExpr.h"
+#include "milvus-storage/reader.h"
+#include "pb/plan.pb.h"
+#include "plan/PlanNode.h"
+#include "segcore/ArrowSegment.h"
+#include "test_utils/GenExprProto.h"
+
+using namespace milvus;
+using namespace milvus::segcore;
+
+// ================================================================
+// MockChunkReader: in-memory ChunkReader backed by RecordBatches
+// ================================================================
+
+class MockChunkReader : public milvus_storage::api::ChunkReader {
+ public:
+    explicit MockChunkReader(
+        std::vector<std::shared_ptr<arrow::RecordBatch>> batches)
+        : batches_(std::move(batches)) {
+    }
+
+    size_t
+    total_number_of_chunks() const override {
+        return batches_.size();
+    }
+
+    arrow::Result<std::vector<int64_t>>
+    get_chunk_indices(
+        const std::vector<int64_t>& row_indices) override {
+        return arrow::Status::NotImplemented(
+            "MockChunkReader::get_chunk_indices");
+    }
+
+    arrow::Result<std::shared_ptr<arrow::RecordBatch>>
+    get_chunk(int64_t chunk_index) override {
+        loaded_chunks_.insert(chunk_index);
+        return batches_.at(chunk_index);
+    }
+
+    arrow::Result<std::vector<std::shared_ptr<arrow::RecordBatch>>>
+    get_chunks(const std::vector<int64_t>& chunk_indices,
+               size_t parallelism = 1) override {
+        std::vector<std::shared_ptr<arrow::RecordBatch>> result;
+        for (auto idx : chunk_indices) {
+            loaded_chunks_.insert(idx);
+            result.push_back(batches_.at(idx));
+        }
+        return result;
+    }
+
+    arrow::Result<std::vector<uint64_t>>
+    get_chunk_size() override {
+        std::vector<uint64_t> sizes;
+        for (const auto& batch : batches_) {
+            uint64_t size = 0;
+            for (int i = 0; i < batch->num_columns(); ++i) {
+                for (const auto& buf :
+                     batch->column(i)->data()->buffers) {
+                    if (buf) {
+                        size += buf->size();
+                    }
+                }
+            }
+            sizes.push_back(size);
+        }
+        return sizes;
+    }
+
+    arrow::Result<std::vector<uint64_t>>
+    get_chunk_rows() override {
+        std::vector<uint64_t> rows;
+        for (const auto& batch : batches_) {
+            rows.push_back(
+                static_cast<uint64_t>(batch->num_rows()));
+        }
+        return rows;
+    }
+
+    const std::set<int64_t>&
+    loaded_chunks() const {
+        return loaded_chunks_;
+    }
+
+    void
+    clear_loaded() {
+        loaded_chunks_.clear();
+    }
+
+ private:
+    std::vector<std::shared_ptr<arrow::RecordBatch>> batches_;
+    std::set<int64_t> loaded_chunks_;
+};
+
+// ================================================================
+// Helpers
+// ================================================================
+
+// Build a RecordBatch with a single int64 column
+static std::shared_ptr<arrow::RecordBatch>
+MakeInt64Batch(const std::string& name,
+               const std::vector<int64_t>& values) {
+    arrow::Int64Builder builder;
+    EXPECT_TRUE(builder.AppendValues(values).ok());
+    auto array = builder.Finish().ValueOrDie();
+    auto schema =
+        arrow::schema({arrow::field(name, arrow::int64())});
+    return arrow::RecordBatch::Make(
+        schema, values.size(), {array});
+}
+
+// Build a RecordBatch with a single string column
+static std::shared_ptr<arrow::RecordBatch>
+MakeStringBatch(const std::string& name,
+                const std::vector<std::string>& values) {
+    arrow::StringBuilder builder;
+    EXPECT_TRUE(builder.AppendValues(values).ok());
+    auto array = builder.Finish().ValueOrDie();
+    auto schema =
+        arrow::schema({arrow::field(name, arrow::utf8())});
+    return arrow::RecordBatch::Make(
+        schema, values.size(), {array});
+}
+
+// Build a RecordBatch with int64 "age" + string "name" columns
+static std::shared_ptr<arrow::RecordBatch>
+MakeIntStringBatch(const std::vector<int64_t>& ages,
+                   const std::vector<std::string>& names) {
+    arrow::Int64Builder int_builder;
+    EXPECT_TRUE(int_builder.AppendValues(ages).ok());
+    auto int_array = int_builder.Finish().ValueOrDie();
+
+    arrow::StringBuilder str_builder;
+    EXPECT_TRUE(str_builder.AppendValues(names).ok());
+    auto str_array = str_builder.Finish().ValueOrDie();
+
+    auto schema =
+        arrow::schema({arrow::field("age", arrow::int64()),
+                       arrow::field("name", arrow::utf8())});
+    return arrow::RecordBatch::Make(
+        schema, ages.size(), {int_array, str_array});
+}
+
+// Build a RecordBatch with a nullable int64 column
+static std::shared_ptr<arrow::RecordBatch>
+MakeNullableInt64Batch(const std::string& name,
+                       const std::vector<int64_t>& values,
+                       const std::vector<bool>& valid) {
+    arrow::Int64Builder builder;
+    EXPECT_TRUE(builder.AppendValues(values, valid).ok());
+    auto array = builder.Finish().ValueOrDie();
+    auto schema = arrow::schema(
+        {arrow::field(name, arrow::int64(), /*nullable=*/true)});
+    return arrow::RecordBatch::Make(
+        schema, values.size(), {array});
+}
+
+// Evaluate a filter expression on a segment, return column vector.
+// The result is a bitmap ColumnVector (IsBitmap() == true).
+// Use BitsetTypeView(col_vec->GetRawData(), col_vec->size()) to read.
+static ColumnVectorPtr
+EvalFilter(const SegmentInternalInterface* segment,
+           const std::shared_ptr<milvus::expr::ITypeExpr>& typed_expr,
+           int64_t active_count) {
+    // gen_filter_res expects a FilterBitsNode directly.
+    auto filter_node = std::make_shared<milvus::plan::FilterBitsNode>(
+        DEFAULT_PLANNODE_ID, typed_expr);
+    return milvus::test::gen_filter_res(
+        filter_node.get(), segment, active_count, MAX_TIMESTAMP);
+}
+
+// ================================================================
+// Test 1: Metadata
+// ================================================================
+
+TEST(ArrowSegmentTest, Metadata) {
+    auto schema = std::make_shared<Schema>();
+    auto age_fid =
+        schema->AddDebugField("age", DataType::INT64);
+
+    std::vector<std::shared_ptr<arrow::RecordBatch>> batches;
+    batches.push_back(
+        MakeInt64Batch("age", std::vector<int64_t>(100, 1)));
+    batches.push_back(
+        MakeInt64Batch("age", std::vector<int64_t>(200, 2)));
+    batches.push_back(
+        MakeInt64Batch("age", std::vector<int64_t>(50, 3)));
+
+    auto reader = std::make_shared<MockChunkReader>(batches);
+    ArrowSegment seg(reader, schema);
+
+    EXPECT_EQ(seg.get_row_count(), 350);
+    EXPECT_EQ(seg.get_real_count(), 350);
+    EXPECT_EQ(seg.get_deleted_count(), 0);
+    EXPECT_EQ(seg.num_chunk(age_fid), 3);
+    EXPECT_EQ(seg.num_chunk_data(age_fid), 3);
+    EXPECT_EQ(seg.chunk_size(age_fid, 0), 100);
+    EXPECT_EQ(seg.chunk_size(age_fid, 1), 200);
+    EXPECT_EQ(seg.chunk_size(age_fid, 2), 50);
+    EXPECT_EQ(seg.num_rows_until_chunk(age_fid, 0), 0);
+    EXPECT_EQ(seg.num_rows_until_chunk(age_fid, 1), 100);
+    EXPECT_EQ(seg.num_rows_until_chunk(age_fid, 2), 300);
+
+    auto [chunk_id, local_off] =
+        seg.get_chunk_by_offset(age_fid, 150);
+    EXPECT_EQ(chunk_id, 1);
+    EXPECT_EQ(local_off, 50);
+
+    EXPECT_TRUE(seg.is_chunked());
+    EXPECT_EQ(seg.get_max_timestamp(), MAX_TIMESTAMP);
+    EXPECT_FALSE(seg.HasIndex(age_fid));
+
+    // No get_chunk() calls during construction
+    EXPECT_TRUE(reader->loaded_chunks().empty());
+}
+
+// ================================================================
+// Test 2: Metadata with n:1 merge
+// ================================================================
+
+TEST(ArrowSegmentTest, MetadataWithMerge) {
+    auto schema = std::make_shared<Schema>();
+    auto age_fid =
+        schema->AddDebugField("age", DataType::INT64);
+
+    std::vector<std::shared_ptr<arrow::RecordBatch>> batches;
+    for (int i = 0; i < 6; ++i) {
+        batches.push_back(
+            MakeInt64Batch("age", std::vector<int64_t>(50, i)));
+    }
+
+    auto reader = std::make_shared<MockChunkReader>(batches);
+    // chunks_per_cell = 3 => 6 physical chunks merge to 2 logical
+    ArrowSegment seg(reader, schema, /*segment_id=*/0,
+                     /*chunks_per_cell=*/3);
+
+    EXPECT_EQ(seg.get_row_count(), 300);
+    EXPECT_EQ(seg.num_chunk_data(age_fid), 2);
+    EXPECT_EQ(seg.chunk_size(age_fid, 0), 150);
+    EXPECT_EQ(seg.chunk_size(age_fid, 1), 150);
+    EXPECT_EQ(seg.num_rows_until_chunk(age_fid, 0), 0);
+    EXPECT_EQ(seg.num_rows_until_chunk(age_fid, 1), 150);
+
+    // No chunks loaded yet
+    EXPECT_TRUE(reader->loaded_chunks().empty());
+}
+
+// ================================================================
+// Test 3: Scalar filter (int64) -- age > 20
+// ================================================================
+
+TEST(ArrowSegmentTest, ScalarFilterInt64) {
+    auto schema = std::make_shared<Schema>();
+    auto age_fid =
+        schema->AddDebugField("age", DataType::INT64);
+
+    auto batch = MakeInt64Batch("age", {25, 30, 18, 40, 22});
+    auto reader = std::make_shared<MockChunkReader>(
+        std::vector<std::shared_ptr<arrow::RecordBatch>>{batch});
+    ArrowSegment seg(reader, schema);
+
+    // Build expression: age > 20
+    proto::plan::GenericValue val;
+    val.set_int64_val(20);
+    auto expr =
+        std::make_shared<milvus::expr::UnaryRangeFilterExpr>(
+            expr::ColumnInfo(age_fid, DataType::INT64),
+            proto::plan::OpType::GreaterThan, val);
+
+    auto col_vec = EvalFilter(&seg, expr, seg.get_row_count());
+    ASSERT_NE(col_vec, nullptr);
+    BitsetTypeView view(col_vec->GetRawData(), col_vec->size());
+    // rows: 25>20=T, 30>20=T, 18>20=F, 40>20=T, 22>20=T
+    EXPECT_TRUE(view[0]);
+    EXPECT_TRUE(view[1]);
+    EXPECT_FALSE(view[2]);
+    EXPECT_TRUE(view[3]);
+    EXPECT_TRUE(view[4]);
+}
+
+// ================================================================
+// Test 4: String filter (varchar) -- name == "alice"
+// ================================================================
+
+TEST(ArrowSegmentTest, StringFilterVarchar) {
+    auto schema = std::make_shared<Schema>();
+    auto name_fid =
+        schema->AddDebugField("name", DataType::VARCHAR);
+
+    auto batch = MakeStringBatch(
+        "name", {"alice", "bob", "charlie", "dave", "eve"});
+    auto reader = std::make_shared<MockChunkReader>(
+        std::vector<std::shared_ptr<arrow::RecordBatch>>{batch});
+    ArrowSegment seg(reader, schema);
+
+    // Build expression: name == "alice"
+    proto::plan::GenericValue val;
+    val.set_string_val("alice");
+    auto expr =
+        std::make_shared<milvus::expr::UnaryRangeFilterExpr>(
+            expr::ColumnInfo(name_fid, DataType::VARCHAR),
+            proto::plan::OpType::Equal, val);
+
+    auto col_vec = EvalFilter(&seg, expr, seg.get_row_count());
+    ASSERT_NE(col_vec, nullptr);
+    BitsetTypeView view(col_vec->GetRawData(), col_vec->size());
+    EXPECT_TRUE(view[0]);   // "alice" == "alice"
+    EXPECT_FALSE(view[1]);  // "bob"
+    EXPECT_FALSE(view[2]);  // "charlie"
+    EXPECT_FALSE(view[3]);  // "dave"
+    EXPECT_FALSE(view[4]);  // "eve"
+}
+
+// ================================================================
+// Test 5: Multi-chunk scalar filter -- age > 20
+// ================================================================
+
+TEST(ArrowSegmentTest, MultiChunkScalarFilter) {
+    auto schema = std::make_shared<Schema>();
+    auto age_fid =
+        schema->AddDebugField("age", DataType::INT64);
+
+    std::vector<std::shared_ptr<arrow::RecordBatch>> batches;
+    batches.push_back(MakeInt64Batch("age", {25, 30, 18}));
+    batches.push_back(MakeInt64Batch("age", {40, 22, 35}));
+    batches.push_back(MakeInt64Batch("age", {10, 50}));
+
+    auto reader = std::make_shared<MockChunkReader>(batches);
+    ArrowSegment seg(reader, schema);
+
+    EXPECT_EQ(seg.get_row_count(), 8);
+    EXPECT_EQ(seg.num_chunk_data(age_fid), 3);
+
+    // Build expression: age > 20
+    proto::plan::GenericValue val;
+    val.set_int64_val(20);
+    auto expr =
+        std::make_shared<milvus::expr::UnaryRangeFilterExpr>(
+            expr::ColumnInfo(age_fid, DataType::INT64),
+            proto::plan::OpType::GreaterThan, val);
+
+    auto col_vec = EvalFilter(&seg, expr, seg.get_row_count());
+    ASSERT_NE(col_vec, nullptr);
+    BitsetTypeView view(col_vec->GetRawData(), col_vec->size());
+    // chunk 0: 25>20=T, 30>20=T, 18>20=F
+    // chunk 1: 40>20=T, 22>20=T, 35>20=T
+    // chunk 2: 10>20=F, 50>20=T
+    EXPECT_TRUE(view[0]);
+    EXPECT_TRUE(view[1]);
+    EXPECT_FALSE(view[2]);
+    EXPECT_TRUE(view[3]);
+    EXPECT_TRUE(view[4]);
+    EXPECT_TRUE(view[5]);
+    EXPECT_FALSE(view[6]);
+    EXPECT_TRUE(view[7]);
+
+    // All 3 chunks were loaded
+    EXPECT_EQ(reader->loaded_chunks().size(), 3u);
+}
+
+// ================================================================
+// Test 6: Compound filter (AND) -- age > 20 AND name != "bob"
+// ================================================================
+
+TEST(ArrowSegmentTest, CompoundFilterAnd) {
+    auto schema = std::make_shared<Schema>();
+    auto age_fid =
+        schema->AddDebugField("age", DataType::INT64);
+    auto name_fid =
+        schema->AddDebugField("name", DataType::VARCHAR);
+
+    auto batch = MakeIntStringBatch(
+        {25, 30, 18, 40, 22}, {"a", "bob", "c", "bob", "e"});
+    auto reader = std::make_shared<MockChunkReader>(
+        std::vector<std::shared_ptr<arrow::RecordBatch>>{batch});
+    ArrowSegment seg(reader, schema);
+
+    // age > 20
+    proto::plan::GenericValue age_val;
+    age_val.set_int64_val(20);
+    auto age_expr =
+        std::make_shared<milvus::expr::UnaryRangeFilterExpr>(
+            expr::ColumnInfo(age_fid, DataType::INT64),
+            proto::plan::OpType::GreaterThan, age_val);
+
+    // name != "bob"
+    proto::plan::GenericValue name_val;
+    name_val.set_string_val("bob");
+    auto name_expr =
+        std::make_shared<milvus::expr::UnaryRangeFilterExpr>(
+            expr::ColumnInfo(name_fid, DataType::VARCHAR),
+            proto::plan::OpType::NotEqual, name_val);
+
+    // AND
+    auto and_expr =
+        std::make_shared<milvus::expr::LogicalBinaryExpr>(
+            milvus::expr::LogicalBinaryExpr::OpType::And,
+            age_expr, name_expr);
+
+    auto col_vec =
+        EvalFilter(&seg, and_expr, seg.get_row_count());
+    ASSERT_NE(col_vec, nullptr);
+    BitsetTypeView view(col_vec->GetRawData(), col_vec->size());
+    // row 0: 25>20=T && "a"!="bob"=T  => T
+    // row 1: 30>20=T && "bob"!="bob"=F => F
+    // row 2: 18>20=F && ...            => F
+    // row 3: 40>20=T && "bob"!="bob"=F => F
+    // row 4: 22>20=T && "e"!="bob"=T   => T
+    EXPECT_TRUE(view[0]);
+    EXPECT_FALSE(view[1]);
+    EXPECT_FALSE(view[2]);
+    EXPECT_FALSE(view[3]);
+    EXPECT_TRUE(view[4]);
+}
+
+// ================================================================
+// Test 7: Nullable field -- age > 20 with nulls
+// ================================================================
+
+TEST(ArrowSegmentTest, NullableField) {
+    auto schema = std::make_shared<Schema>();
+    auto age_fid = schema->AddDebugField(
+        "age", DataType::INT64, /*nullable=*/true);
+
+    // values=[25, 0, 18, 0, 22], valid=[T, F, T, F, T]
+    auto batch = MakeNullableInt64Batch(
+        "age", {25, 0, 18, 0, 22},
+        {true, false, true, false, true});
+    auto reader = std::make_shared<MockChunkReader>(
+        std::vector<std::shared_ptr<arrow::RecordBatch>>{batch});
+    ArrowSegment seg(reader, schema);
+
+    // Build expression: age > 20
+    proto::plan::GenericValue val;
+    val.set_int64_val(20);
+    auto expr =
+        std::make_shared<milvus::expr::UnaryRangeFilterExpr>(
+            expr::ColumnInfo(
+                age_fid, DataType::INT64, {}, /*nullable=*/true),
+            proto::plan::OpType::GreaterThan, val);
+
+    auto col_vec = EvalFilter(&seg, expr, seg.get_row_count());
+    ASSERT_NE(col_vec, nullptr);
+    BitsetTypeView result(col_vec->GetRawData(), col_vec->size());
+    // row 0: 25>20=T, valid
+    // row 1: null => invalid
+    // row 2: 18>20=F, valid
+    // row 3: null => invalid
+    // row 4: 22>20=T, valid
+    EXPECT_TRUE(result[0]);
+    EXPECT_FALSE(result[2]);
+    EXPECT_TRUE(result[4]);
+
+    // Check validity using TargetBitmapView
+    auto* valid_raw = col_vec->GetValidRawData();
+    ASSERT_NE(valid_raw, nullptr);
+    TargetBitmapView valid_view(valid_raw, col_vec->size());
+    EXPECT_TRUE(valid_view[0]);
+    EXPECT_FALSE(valid_view[1]);
+    EXPECT_TRUE(valid_view[2]);
+    EXPECT_FALSE(valid_view[3]);
+    EXPECT_TRUE(valid_view[4]);
+}
+
+// ================================================================
+// Test 8: On-demand loading verification
+// ================================================================
+
+TEST(ArrowSegmentTest, OnDemandLoading) {
+    auto schema = std::make_shared<Schema>();
+    auto age_fid =
+        schema->AddDebugField("age", DataType::INT64);
+
+    std::vector<std::shared_ptr<arrow::RecordBatch>> batches;
+    for (int i = 0; i < 10; ++i) {
+        batches.push_back(MakeInt64Batch(
+            "age", std::vector<int64_t>(100, i * 10)));
+    }
+
+    auto reader = std::make_shared<MockChunkReader>(batches);
+    ArrowSegment seg(reader, schema);
+
+    // No chunks loaded during construction
+    EXPECT_TRUE(reader->loaded_chunks().empty());
+    EXPECT_EQ(seg.get_row_count(), 1000);
+
+    // Build expression: age > 5 (match most rows)
+    proto::plan::GenericValue val;
+    val.set_int64_val(5);
+    auto expr =
+        std::make_shared<milvus::expr::UnaryRangeFilterExpr>(
+            expr::ColumnInfo(age_fid, DataType::INT64),
+            proto::plan::OpType::GreaterThan, val);
+
+    auto col_vec = EvalFilter(&seg, expr, seg.get_row_count());
+    ASSERT_NE(col_vec, nullptr);
+
+    // After evaluation, all 10 chunks should have been loaded
+    EXPECT_EQ(reader->loaded_chunks().size(), 10u);
+}
+
+// ================================================================
+// Test 9: Term-in filter -- id IN (2, 4)
+// ================================================================
+
+TEST(ArrowSegmentTest, TermInFilter) {
+    auto schema = std::make_shared<Schema>();
+    auto id_fid =
+        schema->AddDebugField("id", DataType::INT64);
+
+    auto batch = MakeInt64Batch("id", {1, 2, 3, 4, 5});
+    auto reader = std::make_shared<MockChunkReader>(
+        std::vector<std::shared_ptr<arrow::RecordBatch>>{batch});
+    ArrowSegment seg(reader, schema);
+
+    // Build expression: id IN (2, 4)
+    std::vector<proto::plan::GenericValue> vals;
+    {
+        proto::plan::GenericValue v;
+        v.set_int64_val(2);
+        vals.push_back(v);
+    }
+    {
+        proto::plan::GenericValue v;
+        v.set_int64_val(4);
+        vals.push_back(v);
+    }
+    auto expr = std::make_shared<milvus::expr::TermFilterExpr>(
+        expr::ColumnInfo(id_fid, DataType::INT64), vals);
+
+    auto col_vec = EvalFilter(&seg, expr, seg.get_row_count());
+    ASSERT_NE(col_vec, nullptr);
+    BitsetTypeView view(col_vec->GetRawData(), col_vec->size());
+    EXPECT_FALSE(view[0]);  // 1 not in {2,4}
+    EXPECT_TRUE(view[1]);   // 2 in {2,4}
+    EXPECT_FALSE(view[2]);  // 3 not in {2,4}
+    EXPECT_TRUE(view[3]);   // 4 in {2,4}
+    EXPECT_FALSE(view[4]);  // 5 not in {2,4}
+}

--- a/internal/core/unittest/test_arrow_segment_parquet.cpp
+++ b/internal/core/unittest/test_arrow_segment_parquet.cpp
@@ -1,0 +1,387 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Example: Write data to Parquet via milvus-storage Writer, then read
+// it back through Reader/ChunkReader and run Milvus expression
+// filtering via ArrowSegment.
+
+#include <gtest/gtest.h>
+#include <cstdint>
+#include <cstdio>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "arrow/api.h"
+#include "common/BitsetView.h"
+#include "common/Consts.h"
+#include "common/Schema.h"
+#include "common/Types.h"
+#include "exec/QueryContext.h"
+#include "exec/expression/Expr.h"
+#include "expr/ITypeExpr.h"
+#include "milvus-storage/column_groups.h"
+#include "milvus-storage/properties.h"
+#include "milvus-storage/reader.h"
+#include "milvus-storage/writer.h"
+#include "pb/plan.pb.h"
+#include "plan/PlanNode.h"
+#include "segcore/ArrowSegment.h"
+#include "test_utils/GenExprProto.h"
+
+using namespace milvus;
+using namespace milvus::segcore;
+
+// ================================================================
+// Helpers
+// ================================================================
+
+static milvus_storage::api::Properties
+MakeLocalProperties(const std::string& root) {
+    milvus_storage::api::Properties props;
+    milvus_storage::api::SetValue(props, "fs.root.path", root.c_str());
+    return props;
+}
+
+static std::unique_ptr<milvus_storage::api::ColumnGroupPolicy>
+MakeSinglePolicy(const std::shared_ptr<arrow::Schema>& schema) {
+    milvus_storage::api::Properties props;
+    milvus_storage::api::SetValue(props, "writer.policy", "single");
+    milvus_storage::api::SetValue(props, "format", "parquet");
+    auto result =
+        milvus_storage::api::ColumnGroupPolicy::create_column_group_policy(
+            props, schema);
+    EXPECT_TRUE(result.ok()) << result.status().ToString();
+    return std::move(result).ValueOrDie();
+}
+
+static ColumnVectorPtr
+EvalFilter(const SegmentInternalInterface* segment,
+           const std::shared_ptr<milvus::expr::ITypeExpr>& typed_expr,
+           int64_t active_count) {
+    auto filter_node = std::make_shared<milvus::plan::FilterBitsNode>(
+        DEFAULT_PLANNODE_ID, typed_expr);
+    return milvus::test::gen_filter_res(filter_node.get(), segment,
+                                        active_count, MAX_TIMESTAMP);
+}
+
+static void
+PrintFilterResults(const std::string& label,
+                   BitsetTypeView view,
+                   int64_t count) {
+    std::printf("  %s => [", label.c_str());
+    for (int64_t i = 0; i < count; ++i) {
+        std::printf("%s%d", i ? ", " : "", view[i] ? 1 : 0);
+    }
+    std::printf("]\n");
+}
+
+// ================================================================
+// Test
+// ================================================================
+
+TEST(ArrowSegmentParquetExample, ReadAndFilter) {
+    // --- Arrow schema ---
+    auto arrow_schema =
+        arrow::schema({arrow::field("user_id", arrow::int64()),
+                       arrow::field("age", arrow::int64()),
+                       arrow::field("city", arrow::utf8())});
+
+    // --- Build test data ---
+    //                                                                 // idx
+    // cities chosen to exercise LIKE patterns: "San%" matches 3 rows  // ---
+    std::vector<int64_t> user_ids = {1,  2,  3,  4,  5,  6,  7,  8,  9,  10};
+    std::vector<int64_t> ages     = {25, 30, 18, 40, 22, 35, 28, 19, 45, 33};
+    std::vector<std::string> cities = {
+        "San Francisco",  // 0
+        "New York",       // 1
+        "San Jose",       // 2
+        "Boston",         // 3
+        "New York",       // 4
+        "San Diego",      // 5
+        "Boston",         // 6
+        "New York",       // 7
+        "Portland",       // 8
+        "Austin",         // 9
+    };
+
+    arrow::Int64Builder id_builder, age_builder;
+    arrow::StringBuilder city_builder;
+    ASSERT_TRUE(id_builder.AppendValues(user_ids).ok());
+    ASSERT_TRUE(age_builder.AppendValues(ages).ok());
+    ASSERT_TRUE(city_builder.AppendValues(cities).ok());
+
+    auto batch = arrow::RecordBatch::Make(
+        arrow_schema, 10,
+        {id_builder.Finish().ValueOrDie(),
+         age_builder.Finish().ValueOrDie(),
+         city_builder.Finish().ValueOrDie()});
+
+    // --- Step 1: Write via milvus-storage Writer ---
+    std::string root = "/tmp/arrow_segment_parquet_test";
+    std::string base_path = "example_data";
+    auto properties = MakeLocalProperties(root);
+
+    auto writer = milvus_storage::api::Writer::create(
+        base_path, arrow_schema, MakeSinglePolicy(arrow_schema),
+        properties);
+    ASSERT_NE(writer, nullptr);
+    ASSERT_TRUE(writer->write(batch).ok());
+
+    auto cgs_result = writer->close();
+    ASSERT_TRUE(cgs_result.ok()) << cgs_result.status().ToString();
+    auto cgs = std::move(cgs_result).ValueOrDie();
+
+    // --- Step 2: Read back via milvus-storage Reader ---
+    auto reader = milvus_storage::api::Reader::create(
+        cgs, arrow_schema, /*needed_columns=*/nullptr, properties);
+    ASSERT_NE(reader, nullptr);
+
+    auto chunk_reader_result = reader->get_chunk_reader(0);
+    ASSERT_TRUE(chunk_reader_result.ok())
+        << chunk_reader_result.status().ToString();
+    auto chunk_reader = std::move(chunk_reader_result).ValueOrDie();
+
+    // --- Step 3: Build Milvus schema + ArrowSegment ---
+    auto schema = std::make_shared<Schema>();
+    auto user_id_fid =
+        schema->AddDebugField("user_id", DataType::INT64);
+    auto age_fid =
+        schema->AddDebugField("age", DataType::INT64);
+    auto city_fid =
+        schema->AddDebugField("city", DataType::VARCHAR);
+
+    ArrowSegment seg(std::move(chunk_reader), schema);
+    int64_t total = seg.get_row_count();
+    std::printf("Loaded: %lld rows, %lld chunks\n",
+                static_cast<long long>(total),
+                static_cast<long long>(seg.num_chunk_data(age_fid)));
+    EXPECT_EQ(total, 10);
+
+    // --- Filter 1: age > 30 ---
+    {
+        proto::plan::GenericValue val;
+        val.set_int64_val(30);
+        auto expr =
+            std::make_shared<milvus::expr::UnaryRangeFilterExpr>(
+                expr::ColumnInfo(age_fid, DataType::INT64),
+                proto::plan::OpType::GreaterThan, val);
+
+        auto col_vec = EvalFilter(&seg, expr, total);
+        ASSERT_NE(col_vec, nullptr);
+        BitsetTypeView view(col_vec->GetRawData(), col_vec->size());
+
+        // ages: [25, 30, 18, 40, 22, 35, 28, 19, 45, 33]
+        std::printf("\nFilter: age > 30\n");
+        PrintFilterResults("result", view, total);
+        EXPECT_FALSE(view[0]);
+        EXPECT_FALSE(view[1]);
+        EXPECT_FALSE(view[2]);
+        EXPECT_TRUE(view[3]);   // 40
+        EXPECT_FALSE(view[4]);
+        EXPECT_TRUE(view[5]);   // 35
+        EXPECT_FALSE(view[6]);
+        EXPECT_FALSE(view[7]);
+        EXPECT_TRUE(view[8]);   // 45
+        EXPECT_TRUE(view[9]);   // 33
+    }
+
+    // --- Filter 2: city == "New York" ---
+    {
+        proto::plan::GenericValue val;
+        val.set_string_val("New York");
+        auto expr =
+            std::make_shared<milvus::expr::UnaryRangeFilterExpr>(
+                expr::ColumnInfo(city_fid, DataType::VARCHAR),
+                proto::plan::OpType::Equal, val);
+
+        auto col_vec = EvalFilter(&seg, expr, total);
+        ASSERT_NE(col_vec, nullptr);
+        BitsetTypeView view(col_vec->GetRawData(), col_vec->size());
+
+        std::printf("\nFilter: city == 'New York'\n");
+        PrintFilterResults("result", view, total);
+        EXPECT_FALSE(view[0]);  // San Francisco
+        EXPECT_TRUE(view[1]);   // New York
+        EXPECT_FALSE(view[2]);  // San Jose
+        EXPECT_FALSE(view[3]);  // Boston
+        EXPECT_TRUE(view[4]);   // New York
+        EXPECT_FALSE(view[5]);  // San Diego
+        EXPECT_FALSE(view[6]);  // Boston
+        EXPECT_TRUE(view[7]);   // New York
+        EXPECT_FALSE(view[8]);  // Portland
+        EXPECT_FALSE(view[9]);  // Austin
+    }
+
+    // --- Filter 3: city LIKE "San%" (SQL LIKE via OpType::Match) ---
+    // Matches: San Francisco, San Jose, San Diego
+    {
+        proto::plan::GenericValue val;
+        val.set_string_val("San%");
+        auto expr =
+            std::make_shared<milvus::expr::UnaryRangeFilterExpr>(
+                expr::ColumnInfo(city_fid, DataType::VARCHAR),
+                proto::plan::OpType::Match, val);
+
+        auto col_vec = EvalFilter(&seg, expr, total);
+        ASSERT_NE(col_vec, nullptr);
+        BitsetTypeView view(col_vec->GetRawData(), col_vec->size());
+
+        std::printf("\nFilter: city LIKE 'San%%'\n");
+        PrintFilterResults("result", view, total);
+        EXPECT_TRUE(view[0]);   // San Francisco
+        EXPECT_FALSE(view[1]);  // New York
+        EXPECT_TRUE(view[2]);   // San Jose
+        EXPECT_FALSE(view[3]);  // Boston
+        EXPECT_FALSE(view[4]);  // New York
+        EXPECT_TRUE(view[5]);   // San Diego
+        EXPECT_FALSE(view[6]);  // Boston
+        EXPECT_FALSE(view[7]);  // New York
+        EXPECT_FALSE(view[8]);  // Portland
+        EXPECT_FALSE(view[9]);  // Austin
+    }
+
+    // --- Filter 4: city LIKE "%ork" (suffix match) ---
+    // Matches: New York (rows 1, 4, 7)
+    {
+        proto::plan::GenericValue val;
+        val.set_string_val("%ork");
+        auto expr =
+            std::make_shared<milvus::expr::UnaryRangeFilterExpr>(
+                expr::ColumnInfo(city_fid, DataType::VARCHAR),
+                proto::plan::OpType::Match, val);
+
+        auto col_vec = EvalFilter(&seg, expr, total);
+        ASSERT_NE(col_vec, nullptr);
+        BitsetTypeView view(col_vec->GetRawData(), col_vec->size());
+
+        std::printf("\nFilter: city LIKE '%%ork'\n");
+        PrintFilterResults("result", view, total);
+        EXPECT_FALSE(view[0]);
+        EXPECT_TRUE(view[1]);   // New York
+        EXPECT_FALSE(view[2]);
+        EXPECT_FALSE(view[3]);
+        EXPECT_TRUE(view[4]);   // New York
+        EXPECT_FALSE(view[5]);
+        EXPECT_FALSE(view[6]);
+        EXPECT_TRUE(view[7]);   // New York
+        EXPECT_FALSE(view[8]);
+        EXPECT_FALSE(view[9]);
+    }
+
+    // --- Filter 5: city LIKE "%sto%" (substring match) ---
+    // Matches: Boston (rows 3, 6) — "Bo*sto*n" contains "sto"
+    // Austin does NOT match — "Au*sti*n" has "sti", not "sto"
+    {
+        proto::plan::GenericValue val;
+        val.set_string_val("%sto%");
+        auto expr =
+            std::make_shared<milvus::expr::UnaryRangeFilterExpr>(
+                expr::ColumnInfo(city_fid, DataType::VARCHAR),
+                proto::plan::OpType::Match, val);
+
+        auto col_vec = EvalFilter(&seg, expr, total);
+        ASSERT_NE(col_vec, nullptr);
+        BitsetTypeView view(col_vec->GetRawData(), col_vec->size());
+
+        std::printf("\nFilter: city LIKE '%%sto%%'\n");
+        PrintFilterResults("result", view, total);
+        EXPECT_FALSE(view[0]);
+        EXPECT_FALSE(view[1]);
+        EXPECT_FALSE(view[2]);
+        EXPECT_TRUE(view[3]);   // Boston
+        EXPECT_FALSE(view[4]);
+        EXPECT_FALSE(view[5]);
+        EXPECT_TRUE(view[6]);   // Boston
+        EXPECT_FALSE(view[7]);
+        EXPECT_FALSE(view[8]);
+        EXPECT_FALSE(view[9]);  // Austin — no "sto"
+    }
+
+    // --- Filter 6: age > 25 AND city LIKE "San%" ---
+    // San Francisco(25), San Jose(18), San Diego(35)
+    // age>25: only San Francisco(25>25=F), San Diego(35>25=T)
+    {
+        proto::plan::GenericValue age_val;
+        age_val.set_int64_val(25);
+        auto age_expr =
+            std::make_shared<milvus::expr::UnaryRangeFilterExpr>(
+                expr::ColumnInfo(age_fid, DataType::INT64),
+                proto::plan::OpType::GreaterThan, age_val);
+
+        proto::plan::GenericValue city_val;
+        city_val.set_string_val("San%");
+        auto city_expr =
+            std::make_shared<milvus::expr::UnaryRangeFilterExpr>(
+                expr::ColumnInfo(city_fid, DataType::VARCHAR),
+                proto::plan::OpType::Match, city_val);
+
+        auto and_expr =
+            std::make_shared<milvus::expr::LogicalBinaryExpr>(
+                milvus::expr::LogicalBinaryExpr::OpType::And,
+                age_expr, city_expr);
+
+        auto col_vec = EvalFilter(&seg, and_expr, total);
+        ASSERT_NE(col_vec, nullptr);
+        BitsetTypeView view(col_vec->GetRawData(), col_vec->size());
+
+        std::printf("\nFilter: age > 25 AND city LIKE 'San%%'\n");
+        PrintFilterResults("result", view, total);
+        EXPECT_FALSE(view[0]);  // San Francisco, age=25, 25>25=F
+        EXPECT_FALSE(view[1]);
+        EXPECT_FALSE(view[2]);  // San Jose, age=18, F
+        EXPECT_FALSE(view[3]);
+        EXPECT_FALSE(view[4]);
+        EXPECT_TRUE(view[5]);   // San Diego, age=35, T
+        EXPECT_FALSE(view[6]);
+        EXPECT_FALSE(view[7]);
+        EXPECT_FALSE(view[8]);
+        EXPECT_FALSE(view[9]);
+    }
+
+    // --- Filter 7: user_id IN (3, 7, 10) ---
+    {
+        std::vector<proto::plan::GenericValue> vals;
+        for (int64_t v : {3, 7, 10}) {
+            proto::plan::GenericValue gv;
+            gv.set_int64_val(v);
+            vals.push_back(gv);
+        }
+        auto expr = std::make_shared<milvus::expr::TermFilterExpr>(
+            expr::ColumnInfo(user_id_fid, DataType::INT64), vals);
+
+        auto col_vec = EvalFilter(&seg, expr, total);
+        ASSERT_NE(col_vec, nullptr);
+        BitsetTypeView view(col_vec->GetRawData(), col_vec->size());
+
+        std::printf("\nFilter: user_id IN (3, 7, 10)\n");
+        PrintFilterResults("result", view, total);
+        EXPECT_FALSE(view[0]);
+        EXPECT_FALSE(view[1]);
+        EXPECT_TRUE(view[2]);   // 3
+        EXPECT_FALSE(view[3]);
+        EXPECT_FALSE(view[4]);
+        EXPECT_FALSE(view[5]);
+        EXPECT_TRUE(view[6]);   // 7
+        EXPECT_FALSE(view[7]);
+        EXPECT_FALSE(view[8]);
+        EXPECT_TRUE(view[9]);   // 10
+    }
+
+    // Cleanup
+    std::filesystem::remove_all(root);
+}


### PR DESCRIPTION
- Introduce `ArrowSegment`, a read-only `SegmentSealed` implementation
  that wraps a milvus-storage `ChunkReader` and enables Milvus
  expression evaluation directly over Arrow RecordBatch data
- Support on-demand chunk loading, N:1 chunk merging, nullable fields,
  and all scalar types (int, float, varchar)
- Include unit tests with MockChunkReader and an end-to-end Parquet
  example using milvus-storage Writer/Reader APIs demonstrating
  range, equality, LIKE pattern matching, term-in, and compound filters