### PR TITLE
fix: add standalone migrate data timeout to prevent shutdown hang

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -569,6 +569,7 @@ queryNode:
   levelZeroForwardPolicy: FilterByBF # delegator level zero deletion forward policy, possible option["FilterByBF", "RemoteLoad"]
   streamingDeltaForwardPolicy: FilterByBF # delegator streaming deletion forward policy, possible option["FilterByBF", "Direct"]
   forwardBatchSize: 4194304 # the batch size delegator uses for forwarding stream delete in loading procedure
+  standaloneMigrateDataTimeout: 3m # Duration string (e.g. 3m, 180s). In standalone mode, if no other active query node is available to accept migrated data within this duration during graceful stop, the node will stop waiting and proceed with shutdown.
   exprCache:
     enabled: false # enable expression result cache
     capacityBytes: 268435456 # max capacity in bytes for expression result cache

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -641,6 +641,7 @@ queryNode:
   streamingDeltaForwardPolicy: FilterByBF # delegator streaming deletion forward policy, possible option["FilterByBF", "Direct"]
   forwardBatchSize: 4194304 # the batch size delegator uses for forwarding stream delete in loading procedure
   delegatorPostLoadConcurrencyFactor: 1 # delegator post-load concurrency factor after worker LoadSegments returns. Concurrency is hardware.GetCPUNum * factor
+  standaloneMigrateDataTimeout: 3m # Duration string (e.g. 3m, 180s). In standalone mode, if no other active query node is available to accept migrated data within this duration during graceful stop, the node will stop waiting and proceed with shutdown.
   exprCache:
     enabled: false # enable expression result cache
     mode: disk # cache mode: 'disk' (sealed segments only, pread/pwrite + fixed slots) or 'memory' (sealed and growing segments, malloc + Clock + compression)

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -635,13 +635,13 @@ queryNode:
     nqMergeRatio: 16 # Maximum ratio between merged total NQ and the smaller task NQ when grouping query node read tasks.
     maxDeadlineMergeGap: 50ms # Maximum allowed gap between task context deadlines when grouping query node read tasks. Tasks with only one deadline cannot be grouped. Set a negative duration to disable this check.
     topKMergeRatio: 20
+  standaloneMigrateDataTimeout: 10s # Duration string (e.g. 10s, 3m). In standalone mode, after this duration, the node stops waiting for data migration if no other active query node is available.
   search:
     enableResultZeroCopy: false # When true, delegator passes reduced SearchResultData directly instead of re-marshaling to SlicedBlob. Toggle at runtime for instant fallback.
   levelZeroForwardPolicy: FilterByBF # delegator level zero deletion forward policy, possible option["FilterByBF", "RemoteLoad"]
   streamingDeltaForwardPolicy: FilterByBF # delegator streaming deletion forward policy, possible option["FilterByBF", "Direct"]
   forwardBatchSize: 4194304 # the batch size delegator uses for forwarding stream delete in loading procedure
   delegatorPostLoadConcurrencyFactor: 1 # delegator post-load concurrency factor after worker LoadSegments returns. Concurrency is hardware.GetCPUNum * factor
-  standaloneMigrateDataTimeout: 3m # Duration string (e.g. 3m, 180s). In standalone mode, if no other active query node is available to accept migrated data within this duration during graceful stop, the node will stop waiting and proceed with shutdown.
   exprCache:
     enabled: false # enable expression result cache
     mode: disk # cache mode: 'disk' (sealed segments only, pread/pwrite + fixed slots) or 'memory' (sealed and growing segments, malloc + Clock + compression)

--- a/internal/querynodev2/server.go
+++ b/internal/querynodev2/server.go
@@ -447,6 +447,21 @@ func (node *QueryNode) Start() error {
 	return nil
 }
 
+// hasOtherActiveQueryNode checks via session whether there is any other
+// non-stopping query node that can accept migrated data.
+func (node *QueryNode) hasOtherActiveQueryNode() bool {
+	sessions, _, err := node.session.GetSessions(node.ctx, typeutil.QueryNodeRole)
+	if err != nil {
+		return false
+	}
+	for _, sess := range sessions {
+		if sess.ServerID != node.GetNodeID() && !sess.Stopping {
+			return true
+		}
+	}
+	return false
+}
+
 // Stop mainly stop QueryNode's query service, historical loop and streaming loop.
 func (node *QueryNode) Stop() error {
 	log := log.Ctx(node.ctx)
@@ -460,6 +475,9 @@ func (node *QueryNode) Stop() error {
 			// TODO: Redundant timeout control, graceful stop timeout is controlled by outside by `component`.
 			// Integration test is still using it, Remove it in future.
 			timeoutCh := time.After(paramtable.Get().QueryNodeCfg.GracefulStopTimeout.GetAsDuration(time.Second))
+			isStandalone := paramtable.GetRole() == typeutil.StandaloneRole
+			standaloneMigrateTimeout := paramtable.Get().QueryNodeCfg.StandaloneMigrateDataTimeout.GetAsDurationByParse()
+			standaloneMigrateDeadline := time.Now().Add(standaloneMigrateTimeout)
 
 		outer:
 			for (node.manager != nil && !node.manager.Segment.Empty()) ||
@@ -477,6 +495,24 @@ func (node *QueryNode) Stop() error {
 					channelNum = node.pipelineManager.Num()
 				}
 				if len(sealedSegments) == 0 && len(growingSegments) == 0 && channelNum == 0 {
+					break outer
+				}
+
+				// In standalone mode, after the migrate timeout, check if there is any other
+				// active query node (e.g. a new standalone starting up for rolling upgrade).
+				// If not, no migration will happen, so give up and proceed with shutdown.
+				if isStandalone && time.Now().After(standaloneMigrateDeadline) && !node.hasOtherActiveQueryNode() {
+					log.Warn("standalone migrate data stopped due to no active query node available to accept data",
+						zap.Int64("ServerID", node.GetNodeID()),
+						zap.Duration("standaloneMigrateTimeout", standaloneMigrateTimeout),
+						zap.Int64s("sealedSegments", lo.Map(sealedSegments, func(s segments.Segment, i int) int64 {
+							return s.ID()
+						})),
+						zap.Int64s("growingSegments", lo.Map(growingSegments, func(t segments.Segment, i int) int64 {
+							return t.ID()
+						})),
+						zap.Int("channelNum", channelNum),
+					)
 					break outer
 				}
 

--- a/internal/querynodev2/server.go
+++ b/internal/querynodev2/server.go
@@ -470,6 +470,21 @@ func (node *QueryNode) Start() error {
 	return nil
 }
 
+// hasOtherActiveQueryNode checks via session whether there is any other
+// non-stopping query node that can accept migrated data.
+func (node *QueryNode) hasOtherActiveQueryNode() bool {
+	sessions, _, err := node.session.GetSessions(node.ctx, typeutil.QueryNodeRole)
+	if err != nil {
+		return false
+	}
+	for _, sess := range sessions {
+		if sess.ServerID != node.GetNodeID() && !sess.Stopping {
+			return true
+		}
+	}
+	return false
+}
+
 // Stop mainly stop QueryNode's query service, historical loop and streaming loop.
 func (node *QueryNode) Stop() error {
 	node.stopOnce.Do(func() {
@@ -482,6 +497,9 @@ func (node *QueryNode) Stop() error {
 			// TODO: Redundant timeout control, graceful stop timeout is controlled by outside by `component`.
 			// Integration test is still using it, Remove it in future.
 			timeoutCh := time.After(paramtable.Get().QueryNodeCfg.GracefulStopTimeout.GetAsDuration(time.Second))
+			isStandalone := paramtable.GetRole() == typeutil.StandaloneRole
+			standaloneMigrateTimeout := paramtable.Get().QueryNodeCfg.StandaloneMigrateDataTimeout.GetAsDurationByParse()
+			standaloneMigrateDeadline := time.Now().Add(standaloneMigrateTimeout)
 
 		outer:
 			for (node.manager != nil && !node.manager.Segment.Empty()) ||
@@ -499,6 +517,24 @@ func (node *QueryNode) Stop() error {
 					channelNum = node.pipelineManager.Num()
 				}
 				if len(sealedSegments) == 0 && len(growingSegments) == 0 && channelNum == 0 {
+					break outer
+				}
+
+				// In standalone mode, after the migrate timeout, check if there is any other
+				// active query node (e.g. a new standalone starting up for rolling upgrade).
+				// If not, no migration will happen, so give up and proceed with shutdown.
+				if isStandalone && time.Now().After(standaloneMigrateDeadline) && !node.hasOtherActiveQueryNode() {
+					log.Warn("standalone migrate data stopped due to no active query node available to accept data",
+						zap.Int64("ServerID", node.GetNodeID()),
+						zap.Duration("standaloneMigrateTimeout", standaloneMigrateTimeout),
+						zap.Int64s("sealedSegments", lo.Map(sealedSegments, func(s segments.Segment, i int) int64 {
+							return s.ID()
+						})),
+						zap.Int64s("growingSegments", lo.Map(growingSegments, func(t segments.Segment, i int) int64 {
+							return t.ID()
+						})),
+						zap.Int("channelNum", channelNum),
+					)
 					break outer
 				}
 

--- a/internal/querynodev2/server.go
+++ b/internal/querynodev2/server.go
@@ -78,6 +78,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/metricsinfo"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v3/util/retry"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -472,17 +473,27 @@ func (node *QueryNode) Start() error {
 
 // hasOtherActiveQueryNode checks via session whether there is any other
 // non-stopping query node that can accept migrated data.
-func (node *QueryNode) hasOtherActiveQueryNode() bool {
-	sessions, _, err := node.session.GetSessions(node.ctx, typeutil.QueryNodeRole)
+func (node *QueryNode) hasOtherActiveQueryNode() (bool, error) {
+	var sessions map[string]*sessionutil.Session
+	err := retry.Do(node.ctx, func() error {
+		var err error
+		sessions, _, err = node.session.GetSessions(node.ctx, typeutil.QueryNodeRole)
+		return err
+	},
+		retry.AttemptAlways(),
+		retry.Sleep(time.Second),
+		retry.RetryErr(func(error) bool { return true }),
+	)
 	if err != nil {
-		return false
+		return false, err
 	}
+
 	for _, sess := range sessions {
 		if sess.ServerID != node.GetNodeID() && !sess.Stopping {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 // Stop mainly stop QueryNode's query service, historical loop and streaming loop.
@@ -522,20 +533,25 @@ func (node *QueryNode) Stop() error {
 
 				// In standalone mode, after the migrate timeout, check if there is any other
 				// active query node (e.g. a new standalone starting up for rolling upgrade).
-				// If not, no migration will happen, so give up and proceed with shutdown.
-				if isStandalone && time.Now().After(standaloneMigrateDeadline) && !node.hasOtherActiveQueryNode() {
-					log.Warn("standalone migrate data stopped due to no active query node available to accept data",
-						zap.Int64("ServerID", node.GetNodeID()),
-						zap.Duration("standaloneMigrateTimeout", standaloneMigrateTimeout),
-						zap.Int64s("sealedSegments", lo.Map(sealedSegments, func(s segments.Segment, i int) int64 {
-							return s.ID()
-						})),
-						zap.Int64s("growingSegments", lo.Map(growingSegments, func(t segments.Segment, i int) int64 {
-							return t.ID()
-						})),
-						zap.Int("channelNum", channelNum),
-					)
-					break outer
+				if isStandalone && time.Now().After(standaloneMigrateDeadline) {
+					hasOther, err := node.hasOtherActiveQueryNode()
+					if err != nil {
+						break outer
+					}
+					if !hasOther {
+						mlog.Warn(node.ctx, "standalone migrate data stopped due to no active query node available to accept data",
+							mlog.FieldNodeID(node.GetNodeID()),
+							mlog.Duration("standaloneMigrateTimeout", standaloneMigrateTimeout),
+							mlog.Int64s("sealedSegments", lo.Map(sealedSegments, func(s segments.Segment, i int) int64 {
+								return s.ID()
+							})),
+							mlog.Int64s("growingSegments", lo.Map(growingSegments, func(t segments.Segment, i int) int64 {
+								return t.ID()
+							})),
+							mlog.Int("channelNum", channelNum),
+						)
+						break outer
+					}
 				}
 
 				select {

--- a/internal/querynodev2/server_test.go
+++ b/internal/querynodev2/server_test.go
@@ -39,12 +39,15 @@ import (
 	"github.com/milvus-io/milvus/internal/querynodev2/segments"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/util/dependency"
+	"github.com/milvus-io/milvus/internal/util/initcore"
+	"github.com/milvus-io/milvus/internal/util/sessionutil"
 	"github.com/milvus-io/milvus/pkg/v2/config"
 	"github.com/milvus-io/milvus/pkg/v2/objectstorage"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v2/util/etcd"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
 type QueryNodeSuite struct {
@@ -251,6 +254,99 @@ func (suite *QueryNodeSuite) TestStop() {
 	err = suite.node.Stop()
 	suite.NoError(err)
 	suite.True(suite.node.manager.Segment.Empty())
+}
+
+func (suite *QueryNodeSuite) TestHasOtherActiveQueryNode() {
+	metaRoot := fmt.Sprintf("milvus-ut/test-has-other-active-qn/%d", time.Now().UnixNano())
+
+	// Create and register the current node's session.
+	sess := sessionutil.NewSessionWithEtcd(suite.node.ctx, metaRoot, suite.etcd)
+	sess.Init(typeutil.QueryNodeRole, "addr1", false)
+	sess.Register()
+	defer sess.Stop()
+
+	node := &QueryNode{
+		ctx:      suite.node.ctx,
+		session:  sess,
+		serverID: sess.ServerID,
+	}
+
+	// No other node registered — should return false.
+	suite.False(node.hasOtherActiveQueryNode())
+
+	// Simulate a second active query node by writing session data directly to etcd.
+	otherSessionKey := fmt.Sprintf("%s/session/%s-%d", metaRoot, typeutil.QueryNodeRole, 99999)
+	activeSessionJSON := `{"ServerID":99999,"ServerName":"querynode","Address":"addr2","Stopping":false}`
+	_, err := suite.etcd.Put(context.Background(), otherSessionKey, activeSessionJSON)
+	suite.Require().NoError(err)
+	defer suite.etcd.Delete(context.Background(), otherSessionKey)
+
+	// Another active node exists — should return true.
+	suite.True(node.hasOtherActiveQueryNode())
+
+	// Update the other session to stopping state.
+	stoppingSessionJSON := `{"ServerID":99999,"ServerName":"querynode","Address":"addr2","Stopping":true}`
+	_, err = suite.etcd.Put(context.Background(), otherSessionKey, stoppingSessionJSON)
+	suite.Require().NoError(err)
+
+	// Only stopping node exists — should return false.
+	suite.False(node.hasOtherActiveQueryNode())
+}
+
+func (suite *QueryNodeSuite) TestStopStandaloneMigrateTimeout() {
+	// Set standalone role and a very short migrate timeout so test finishes quickly.
+	paramtable.SetRole(typeutil.StandaloneRole)
+	defer paramtable.SetRole("")
+	paramtable.Get().Save(paramtable.Get().QueryNodeCfg.GracefulStopTimeout.Key, "10")
+	paramtable.Get().Save(paramtable.Get().QueryNodeCfg.StandaloneMigrateDataTimeout.Key, "1s")
+	// Use a non-rocksmq WAL so the migrate data loop is entered.
+	paramtable.Get().Save("mq.type", "pulsar")
+
+	metaRoot := fmt.Sprintf("milvus-ut/test-standalone-migrate/%d", time.Now().UnixNano())
+
+	// Set up a registered session on suite.node so GoingStop succeeds and the migrate loop runs.
+	sess := sessionutil.NewSessionWithEtcd(suite.node.ctx, metaRoot, suite.etcd)
+	sess.Init(typeutil.QueryNodeRole, "addr-standalone", false)
+	sess.Register()
+	suite.node.session = sess
+	suite.node.serverID = sess.ServerID
+	suite.node.manager = segments.NewManager()
+
+	// Ensure segcore is initialized (needed by NewSegment).
+	initcore.InitLocalChunkManager(suite.T().TempDir())
+	err := initcore.InitMmapManager(paramtable.Get(), 1)
+	suite.Require().NoError(err)
+
+	// Put a sealed segment so the migrate data loop has something to wait for.
+	schema := mock_segcore.GenTestCollectionSchema("test_standalone_stop", schemapb.DataType_Int64, true)
+	collection, err := segments.NewCollection(1, schema, nil, &querypb.LoadMetaInfo{
+		LoadType: querypb.LoadType_LoadCollection,
+	})
+	suite.Require().NoError(err)
+	segment, err := segments.NewSegment(
+		context.Background(),
+		collection,
+		suite.node.manager.Segment,
+		segments.SegmentTypeSealed,
+		1,
+		&querypb.SegmentLoadInfo{
+			SegmentID:     200,
+			PartitionID:   20,
+			CollectionID:  1,
+			Level:         datapb.SegmentLevel_Legacy,
+			InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", 1),
+		},
+	)
+	suite.Require().NoError(err)
+	suite.node.manager.Segment.Put(context.Background(), segments.SegmentTypeSealed, segment)
+
+	// Stop should return within a few seconds (standalone migrate timeout = 1s),
+	// NOT block for the full GracefulStopTimeout (10s).
+	start := time.Now()
+	err = suite.node.Stop()
+	elapsed := time.Since(start)
+	suite.NoError(err)
+	suite.Less(elapsed, 5*time.Second, "standalone stop should exit early when no other active query node exists")
 }
 
 func TestResizeThreadPools(t *testing.T) {

--- a/internal/querynodev2/server_test.go
+++ b/internal/querynodev2/server_test.go
@@ -39,12 +39,15 @@ import (
 	"github.com/milvus-io/milvus/internal/querynodev2/segments"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/util/dependency"
+	"github.com/milvus-io/milvus/internal/util/initcore"
+	"github.com/milvus-io/milvus/internal/util/sessionutil"
 	"github.com/milvus-io/milvus/pkg/v3/config"
 	"github.com/milvus-io/milvus/pkg/v3/objectstorage"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v3/util/etcd"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
 type QueryNodeSuite struct {
@@ -251,6 +254,99 @@ func (suite *QueryNodeSuite) TestStop() {
 	err = suite.node.Stop()
 	suite.NoError(err)
 	suite.True(suite.node.manager.Segment.Empty())
+}
+
+func (suite *QueryNodeSuite) TestHasOtherActiveQueryNode() {
+	metaRoot := fmt.Sprintf("milvus-ut/test-has-other-active-qn/%d", time.Now().UnixNano())
+
+	// Create and register the current node's session.
+	sess := sessionutil.NewSessionWithEtcd(suite.node.ctx, metaRoot, suite.etcd)
+	sess.Init(typeutil.QueryNodeRole, "addr1", false)
+	sess.Register()
+	defer sess.Stop()
+
+	node := &QueryNode{
+		ctx:      suite.node.ctx,
+		session:  sess,
+		serverID: sess.ServerID,
+	}
+
+	// No other node registered — should return false.
+	suite.False(node.hasOtherActiveQueryNode())
+
+	// Simulate a second active query node by writing session data directly to etcd.
+	otherSessionKey := fmt.Sprintf("%s/session/%s-%d", metaRoot, typeutil.QueryNodeRole, 99999)
+	activeSessionJSON := `{"ServerID":99999,"ServerName":"querynode","Address":"addr2","Stopping":false}`
+	_, err := suite.etcd.Put(context.Background(), otherSessionKey, activeSessionJSON)
+	suite.Require().NoError(err)
+	defer suite.etcd.Delete(context.Background(), otherSessionKey)
+
+	// Another active node exists — should return true.
+	suite.True(node.hasOtherActiveQueryNode())
+
+	// Update the other session to stopping state.
+	stoppingSessionJSON := `{"ServerID":99999,"ServerName":"querynode","Address":"addr2","Stopping":true}`
+	_, err = suite.etcd.Put(context.Background(), otherSessionKey, stoppingSessionJSON)
+	suite.Require().NoError(err)
+
+	// Only stopping node exists — should return false.
+	suite.False(node.hasOtherActiveQueryNode())
+}
+
+func (suite *QueryNodeSuite) TestStopStandaloneMigrateTimeout() {
+	// Set standalone role and a very short migrate timeout so test finishes quickly.
+	paramtable.SetRole(typeutil.StandaloneRole)
+	defer paramtable.SetRole("")
+	paramtable.Get().Save(paramtable.Get().QueryNodeCfg.GracefulStopTimeout.Key, "10")
+	paramtable.Get().Save(paramtable.Get().QueryNodeCfg.StandaloneMigrateDataTimeout.Key, "1s")
+	// Use a non-rocksmq WAL so the migrate data loop is entered.
+	paramtable.Get().Save("mq.type", "pulsar")
+
+	metaRoot := fmt.Sprintf("milvus-ut/test-standalone-migrate/%d", time.Now().UnixNano())
+
+	// Set up a registered session on suite.node so GoingStop succeeds and the migrate loop runs.
+	sess := sessionutil.NewSessionWithEtcd(suite.node.ctx, metaRoot, suite.etcd)
+	sess.Init(typeutil.QueryNodeRole, "addr-standalone", false)
+	sess.Register()
+	suite.node.session = sess
+	suite.node.serverID = sess.ServerID
+	suite.node.manager = segments.NewManager()
+
+	// Ensure segcore is initialized (needed by NewSegment).
+	initcore.InitLocalChunkManager(suite.T().TempDir())
+	err := initcore.InitMmapManager(paramtable.Get(), 1)
+	suite.Require().NoError(err)
+
+	// Put a sealed segment so the migrate data loop has something to wait for.
+	schema := mock_segcore.GenTestCollectionSchema("test_standalone_stop", schemapb.DataType_Int64, true)
+	collection, err := segments.NewCollection(1, schema, nil, &querypb.LoadMetaInfo{
+		LoadType: querypb.LoadType_LoadCollection,
+	})
+	suite.Require().NoError(err)
+	segment, err := segments.NewSegment(
+		context.Background(),
+		collection,
+		suite.node.manager.Segment,
+		segments.SegmentTypeSealed,
+		1,
+		&querypb.SegmentLoadInfo{
+			SegmentID:     200,
+			PartitionID:   20,
+			CollectionID:  1,
+			Level:         datapb.SegmentLevel_Legacy,
+			InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", 1),
+		},
+	)
+	suite.Require().NoError(err)
+	suite.node.manager.Segment.Put(context.Background(), segments.SegmentTypeSealed, segment)
+
+	// Stop should return within a few seconds (standalone migrate timeout = 1s),
+	// NOT block for the full GracefulStopTimeout (10s).
+	start := time.Now()
+	err = suite.node.Stop()
+	elapsed := time.Since(start)
+	suite.NoError(err)
+	suite.Less(elapsed, 5*time.Second, "standalone stop should exit early when no other active query node exists")
 }
 
 func TestResizeThreadPools(t *testing.T) {

--- a/internal/querynodev2/server_test.go
+++ b/internal/querynodev2/server_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bytedance/mockey"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -272,17 +273,21 @@ func (suite *QueryNodeSuite) TestHasOtherActiveQueryNode() {
 	}
 
 	// No other node registered — should return false.
-	suite.False(node.hasOtherActiveQueryNode())
+	hasOther, err := node.hasOtherActiveQueryNode()
+	suite.NoError(err)
+	suite.False(hasOther)
 
 	// Simulate a second active query node by writing session data directly to etcd.
 	otherSessionKey := fmt.Sprintf("%s/session/%s-%d", metaRoot, typeutil.QueryNodeRole, 99999)
 	activeSessionJSON := `{"ServerID":99999,"ServerName":"querynode","Address":"addr2","Stopping":false}`
-	_, err := suite.etcd.Put(context.Background(), otherSessionKey, activeSessionJSON)
+	_, err = suite.etcd.Put(context.Background(), otherSessionKey, activeSessionJSON)
 	suite.Require().NoError(err)
 	defer suite.etcd.Delete(context.Background(), otherSessionKey)
 
 	// Another active node exists — should return true.
-	suite.True(node.hasOtherActiveQueryNode())
+	hasOther, err = node.hasOtherActiveQueryNode()
+	suite.NoError(err)
+	suite.True(hasOther)
 
 	// Update the other session to stopping state.
 	stoppingSessionJSON := `{"ServerID":99999,"ServerName":"querynode","Address":"addr2","Stopping":true}`
@@ -290,7 +295,35 @@ func (suite *QueryNodeSuite) TestHasOtherActiveQueryNode() {
 	suite.Require().NoError(err)
 
 	// Only stopping node exists — should return false.
-	suite.False(node.hasOtherActiveQueryNode())
+	hasOther, err = node.hasOtherActiveQueryNode()
+	suite.NoError(err)
+	suite.False(hasOther)
+
+	// Context cancellation stops the retry loop instead of being treated as no active node.
+	canceledCtx, cancel := context.WithCancel(node.ctx)
+	cancel()
+	node.ctx = canceledCtx
+	hasOther, err = node.hasOtherActiveQueryNode()
+	suite.Error(err)
+	suite.False(hasOther)
+
+	// Transient lookup errors should be retried inside the helper until a session
+	// result is available.
+	node.ctx = context.Background()
+	attempts := 0
+	patch := mockey.Mock((*sessionutil.Session).GetSessions).To(func(_ *sessionutil.Session, _ context.Context, _ string) (map[string]*sessionutil.Session, int64, error) {
+		attempts++
+		if attempts == 1 {
+			return nil, 0, errors.New("transient session lookup failure")
+		}
+		return map[string]*sessionutil.Session{}, 0, nil
+	}).Build()
+	defer patch.UnPatch()
+
+	hasOther, err = node.hasOtherActiveQueryNode()
+	suite.NoError(err)
+	suite.False(hasOther)
+	suite.Equal(2, attempts)
 }
 
 func (suite *QueryNodeSuite) TestStopStandaloneMigrateTimeout() {
@@ -298,7 +331,7 @@ func (suite *QueryNodeSuite) TestStopStandaloneMigrateTimeout() {
 	paramtable.SetRole(typeutil.StandaloneRole)
 	defer paramtable.SetRole("")
 	paramtable.Get().Save(paramtable.Get().QueryNodeCfg.GracefulStopTimeout.Key, "10")
-	paramtable.Get().Save(paramtable.Get().QueryNodeCfg.StandaloneMigrateDataTimeout.Key, "1s")
+	paramtable.Get().Save(paramtable.Get().QueryNodeCfg.StandaloneMigrateDataTimeout.Key, "0s")
 	// Use a non-rocksmq WAL so the migrate data loop is entered.
 	paramtable.Get().Save("mq.type", "pulsar")
 
@@ -340,13 +373,13 @@ func (suite *QueryNodeSuite) TestStopStandaloneMigrateTimeout() {
 	suite.Require().NoError(err)
 	suite.node.manager.Segment.Put(context.Background(), segments.SegmentTypeSealed, segment)
 
-	// Stop should return within a few seconds (standalone migrate timeout = 1s),
-	// NOT block for the full GracefulStopTimeout (10s).
+	// Stop should exit as soon as the first successful session lookup confirms
+	// there is no other active query node.
 	start := time.Now()
 	err = suite.node.Stop()
 	elapsed := time.Since(start)
 	suite.NoError(err)
-	suite.Less(elapsed, 5*time.Second, "standalone stop should exit early when no other active query node exists")
+	suite.Less(elapsed, time.Second, "standalone stop should exit after the first successful empty session result")
 }
 
 func TestResizeThreadPools(t *testing.T) {

--- a/internal/streamingnode/server/resource/resource.go
+++ b/internal/streamingnode/server/resource/resource.go
@@ -89,6 +89,7 @@ func Init(opts ...optResourceInit) {
 
 // Release releases the singleton of resources.
 func Release() {
+	r.timeTickInspector.Close()
 	r.wbMgr.Stop()
 	r.syncMgr.Close()
 }

--- a/internal/streamingnode/server/resource/resource_test.go
+++ b/internal/streamingnode/server/resource/resource_test.go
@@ -2,7 +2,10 @@ package resource
 
 import (
 	"os"
+	"runtime"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -37,6 +40,38 @@ func TestInit(t *testing.T) {
 	Release()
 }
 
+func TestReleaseClosesTimeTickInspector(t *testing.T) {
+	backgrounds := countTimeTickInspectorBackgrounds()
+	Init(
+		OptChunkManager(mock_storage.NewMockChunkManager(t)),
+		OptETCD(&clientv3.Client{}),
+		OptMixCoordClient(syncutil.NewFuture[types.MixCoordClient]()),
+		OptStreamingNodeCatalog(mock_metastore.NewMockStreamingNodeCataLog(t)),
+	)
+	inspector := Resource().TimeTickInspector()
+	t.Cleanup(inspector.Close)
+
+	assert.Eventually(t, func() bool {
+		return countTimeTickInspectorBackgrounds() == backgrounds+1
+	}, time.Second, 10*time.Millisecond)
+
+	Release()
+	assert.Eventually(t, func() bool {
+		return countTimeTickInspectorBackgrounds() == backgrounds
+	}, time.Second, 10*time.Millisecond)
+}
+
 func TestInitForTest(t *testing.T) {
 	InitForTest(t)
+}
+
+func countTimeTickInspectorBackgrounds() int {
+	buffer := make([]byte, 64*1024)
+	for {
+		n := runtime.Stack(buffer, true)
+		if n < len(buffer) {
+			return strings.Count(string(buffer[:n]), "timeTickSyncInspectorImpl).background")
+		}
+		buffer = make([]byte, len(buffer)*2)
+	}
 }

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3432,14 +3432,15 @@ type queryNodeConfig struct {
 	ReadAheadPolicy     ParamItem `refreshable:"false"`
 	ChunkCacheWarmingUp ParamItem `refreshable:"true"`
 
-	MaxReceiveChanSize    ParamItem `refreshable:"false"`
-	MaxUnsolvedQueueSize  ParamItem `refreshable:"true"`
-	MaxReadConcurrency    ParamItem `refreshable:"true"`
-	MaxGpuReadConcurrency ParamItem `refreshable:"false"`
-	MaxGroupNQ            ParamItem `refreshable:"true"`
-	TopKMergeRatio        ParamItem `refreshable:"true"`
-	CPURatio              ParamItem `refreshable:"true"`
-	GracefulStopTimeout   ParamItem `refreshable:"false"`
+	MaxReceiveChanSize           ParamItem `refreshable:"false"`
+	MaxUnsolvedQueueSize         ParamItem `refreshable:"true"`
+	MaxReadConcurrency           ParamItem `refreshable:"true"`
+	MaxGpuReadConcurrency        ParamItem `refreshable:"false"`
+	MaxGroupNQ                   ParamItem `refreshable:"true"`
+	TopKMergeRatio               ParamItem `refreshable:"true"`
+	CPURatio                     ParamItem `refreshable:"true"`
+	GracefulStopTimeout          ParamItem `refreshable:"false"`
+	StandaloneMigrateDataTimeout ParamItem `refreshable:"false"`
 
 	EnableResultZeroCopy ParamItem `refreshable:"true"`
 
@@ -4413,6 +4414,14 @@ Max read concurrency must greater than or equal to 1, and less than or equal to 
 		FallbackKeys: []string{"common.gracefulStopTimeout"},
 	}
 	p.GracefulStopTimeout.Init(base.mgr)
+
+	p.StandaloneMigrateDataTimeout = ParamItem{
+		Key:          "queryNode.standaloneMigrateDataTimeout",
+		Version:      "2.6.0",
+		DefaultValue: "3m",
+		Doc:          "Duration string (e.g. 3m, 180s). In standalone mode, if no other active query node is available to accept migrated data within this duration during graceful stop, the node will stop waiting and proceed with shutdown.",
+	}
+	p.StandaloneMigrateDataTimeout.Init(base.mgr)
 
 	p.MaxSegmentDeleteBuffer = ParamItem{
 		Key:          "queryNode.maxSegmentDeleteBuffer",

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -4417,9 +4417,10 @@ Max read concurrency must greater than or equal to 1, and less than or equal to 
 
 	p.StandaloneMigrateDataTimeout = ParamItem{
 		Key:          "queryNode.standaloneMigrateDataTimeout",
-		Version:      "2.6.0",
+		Version:      "2.6.16",
 		DefaultValue: "3m",
 		Doc:          "Duration string (e.g. 3m, 180s). In standalone mode, if no other active query node is available to accept migrated data within this duration during graceful stop, the node will stop waiting and proceed with shutdown.",
+		Export:       true,
 	}
 	p.StandaloneMigrateDataTimeout.Init(base.mgr)
 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -4784,8 +4784,8 @@ Max read concurrency must greater than or equal to 1, and less than or equal to 
 	p.StandaloneMigrateDataTimeout = ParamItem{
 		Key:          "queryNode.standaloneMigrateDataTimeout",
 		Version:      "2.6.16",
-		DefaultValue: "3m",
-		Doc:          "Duration string (e.g. 3m, 180s). In standalone mode, if no other active query node is available to accept migrated data within this duration during graceful stop, the node will stop waiting and proceed with shutdown.",
+		DefaultValue: "10s",
+		Doc:          "Duration string (e.g. 10s, 3m). In standalone mode, after this duration, the node stops waiting for data migration if no other active query node is available.",
 		Export:       true,
 	}
 	p.StandaloneMigrateDataTimeout.Init(base.mgr)

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -4783,9 +4783,10 @@ Max read concurrency must greater than or equal to 1, and less than or equal to 
 
 	p.StandaloneMigrateDataTimeout = ParamItem{
 		Key:          "queryNode.standaloneMigrateDataTimeout",
-		Version:      "2.6.0",
+		Version:      "2.6.16",
 		DefaultValue: "3m",
 		Doc:          "Duration string (e.g. 3m, 180s). In standalone mode, if no other active query node is available to accept migrated data within this duration during graceful stop, the node will stop waiting and proceed with shutdown.",
+		Export:       true,
 	}
 	p.StandaloneMigrateDataTimeout.Init(base.mgr)
 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3679,15 +3679,16 @@ type queryNodeConfig struct {
 	ReadAheadPolicy     ParamItem `refreshable:"false"`
 	ChunkCacheWarmingUp ParamItem `refreshable:"true"`
 
-	MaxUnsolvedQueueSize  ParamItem `refreshable:"true"`
-	MaxReadConcurrency    ParamItem `refreshable:"true"`
-	MaxGpuReadConcurrency ParamItem `refreshable:"false"`
-	MaxGroupNQ            ParamItem `refreshable:"true"`
-	NQMergeRatio          ParamItem `refreshable:"true"`
-	MaxDeadlineMergeGap   ParamItem `refreshable:"true"`
-	TopKMergeRatio        ParamItem `refreshable:"true"`
-	CPURatio              ParamItem `refreshable:"true"`
-	GracefulStopTimeout   ParamItem `refreshable:"false"`
+	MaxUnsolvedQueueSize         ParamItem `refreshable:"true"`
+	MaxReadConcurrency           ParamItem `refreshable:"true"`
+	MaxGpuReadConcurrency        ParamItem `refreshable:"false"`
+	MaxGroupNQ                   ParamItem `refreshable:"true"`
+	NQMergeRatio                 ParamItem `refreshable:"true"`
+	MaxDeadlineMergeGap          ParamItem `refreshable:"true"`
+	TopKMergeRatio               ParamItem `refreshable:"true"`
+	CPURatio                     ParamItem `refreshable:"true"`
+	GracefulStopTimeout          ParamItem `refreshable:"false"`
+	StandaloneMigrateDataTimeout ParamItem `refreshable:"false"`
 
 	EnableResultZeroCopy ParamItem `refreshable:"true"`
 
@@ -4779,6 +4780,14 @@ Max read concurrency must greater than or equal to 1, and less than or equal to 
 		FallbackKeys: []string{"common.gracefulStopTimeout"},
 	}
 	p.GracefulStopTimeout.Init(base.mgr)
+
+	p.StandaloneMigrateDataTimeout = ParamItem{
+		Key:          "queryNode.standaloneMigrateDataTimeout",
+		Version:      "2.6.0",
+		DefaultValue: "3m",
+		Doc:          "Duration string (e.g. 3m, 180s). In standalone mode, if no other active query node is available to accept migrated data within this duration during graceful stop, the node will stop waiting and proceed with shutdown.",
+	}
+	p.StandaloneMigrateDataTimeout.Init(base.mgr)
 
 	p.MaxSegmentDeleteBuffer = ParamItem{
 		Key:          "queryNode.maxSegmentDeleteBuffer",

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -537,6 +537,7 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, 100*time.Millisecond, Params.SchedulePolicyTaskDeadlineAdvance.GetAsDurationByParse())
 		assert.Equal(t, 10.0, Params.CPURatio.GetAsFloat())
 		assert.Equal(t, uint32(hardware.GetCPUNum()), Params.KnowhereThreadPoolSize.GetAsUint32())
+		assert.Equal(t, "10s", Params.StandaloneMigrateDataTimeout.DefaultValue)
 
 		// chunk cache
 		assert.Equal(t, "willneed", Params.ReadAheadPolicy.GetValue())


### PR DESCRIPTION
issue: #48777

- standalone shutdown: wait 10 seconds before checking for another active QueryNode, then skip migration when none is available
- session discovery: retry etcd session lookups until a snapshot is available so transient failures do not bypass rolling-upgrade migration
- streaming shutdown: close the TimeTickSyncInspector during resource release so its background and async sync goroutines cannot outlive the StreamingNode
- configuration: export queryNode.standaloneMigrateDataTimeout with a 10s default