### PR TITLE
enhance: allow simultaneous pchannel increase and cluster/topology changes

### DIFF
--- a/pkg/util/replicateutil/config_validator.go
+++ b/pkg/util/replicateutil/config_validator.go
@@ -264,46 +264,6 @@ func (v *ReplicateConfigValidator) validateConfigComparison() error {
 		// If cluster doesn't exist in current config, it's a new cluster, which is allowed
 	}
 
-	// When pchannels are increasing, enforce stricter rules
-	if v.isPChannelIncreasing {
-		if err := v.validatePChannelIncreasingConstraints(currentClusterMap); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// validatePChannelIncreasingConstraints enforces that when pchannels grow,
-// only pchannel lists can change — cluster set and topology must remain identical.
-func (v *ReplicateConfigValidator) validatePChannelIncreasingConstraints(currentClusterMap map[string]*commonpb.MilvusCluster) error {
-	// Cluster set must be identical (no new or removed clusters)
-	if len(currentClusterMap) != len(v.clusterMap) {
-		return fmt.Errorf("when pchannels are increasing, cluster set must remain identical: current has %d clusters, incoming has %d",
-			len(currentClusterMap), len(v.clusterMap))
-	}
-	for clusterID := range currentClusterMap {
-		if _, ok := v.clusterMap[clusterID]; !ok {
-			return fmt.Errorf("when pchannels are increasing, cluster set must remain identical: cluster '%s' missing from incoming config", clusterID)
-		}
-	}
-
-	// Topology must be identical
-	currentTopos := v.currentConfig.GetCrossClusterTopology()
-	incomingTopos := v.incomingConfig.GetCrossClusterTopology()
-	if len(currentTopos) != len(incomingTopos) {
-		return fmt.Errorf("when pchannels are increasing, topology must remain identical: current has %d edges, incoming has %d",
-			len(currentTopos), len(incomingTopos))
-	}
-	currentEdges := make(map[string]struct{})
-	for _, topo := range currentTopos {
-		currentEdges[topo.GetSourceClusterId()+"->"+topo.GetTargetClusterId()] = struct{}{}
-	}
-	for _, topo := range incomingTopos {
-		edge := topo.GetSourceClusterId() + "->" + topo.GetTargetClusterId()
-		if _, ok := currentEdges[edge]; !ok {
-			return fmt.Errorf("when pchannels are increasing, topology must remain identical: edge '%s' not in current config", edge)
-		}
-	}
 	return nil
 }
 

--- a/pkg/util/replicateutil/config_validator_test.go
+++ b/pkg/util/replicateutil/config_validator_test.go
@@ -1079,7 +1079,7 @@ func TestReplicateConfigValidator_validateConfigComparison(t *testing.T) {
 	})
 }
 
-func TestReplicateConfigValidator_PChannelIncreasingConstraints(t *testing.T) {
+func TestReplicateConfigValidator_PChannelIncreasing(t *testing.T) {
 	makeCluster := func(id, uri string, pchannels []string) *commonpb.MilvusCluster {
 		return &commonpb.MilvusCluster{
 			ClusterId:       id,
@@ -1113,32 +1113,7 @@ func TestReplicateConfigValidator_PChannelIncreasingConstraints(t *testing.T) {
 		assert.True(t, validator.IsPChannelIncreasing())
 	})
 
-	t.Run("error - topology changed during pchannel increase", func(t *testing.T) {
-		currentConfig := &commonpb.ReplicateConfiguration{
-			Clusters: []*commonpb.MilvusCluster{
-				makeCluster("c1", "localhost:19530", []string{"ch-1"}),
-				makeCluster("c2", "localhost:19531", []string{"ch-1"}),
-			},
-			CrossClusterTopology: []*commonpb.CrossClusterTopology{
-				{SourceClusterId: "c1", TargetClusterId: "c2"},
-			},
-		}
-		incomingConfig := &commonpb.ReplicateConfiguration{
-			Clusters: []*commonpb.MilvusCluster{
-				makeCluster("c1", "localhost:19530", []string{"ch-1", "ch-2"}),
-				makeCluster("c2", "localhost:19531", []string{"ch-1", "ch-2"}),
-			},
-			CrossClusterTopology: []*commonpb.CrossClusterTopology{
-				{SourceClusterId: "c2", TargetClusterId: "c1"}, // flipped
-			},
-		}
-		validator := NewReplicateConfigValidator(incomingConfig, currentConfig, "c1", []string{"ch-1", "ch-2"})
-		err := validator.Validate()
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "topology must remain identical")
-	})
-
-	t.Run("error - new cluster added during pchannel increase", func(t *testing.T) {
+	t.Run("success - new cluster added during pchannel increase", func(t *testing.T) {
 		currentConfig := &commonpb.ReplicateConfiguration{
 			Clusters: []*commonpb.MilvusCluster{
 				makeCluster("c1", "localhost:19530", []string{"ch-1"}),
@@ -1161,47 +1136,16 @@ func TestReplicateConfigValidator_PChannelIncreasingConstraints(t *testing.T) {
 		}
 		validator := NewReplicateConfigValidator(incomingConfig, currentConfig, "c1", []string{"ch-1", "ch-2"})
 		err := validator.Validate()
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "cluster set must remain identical")
+		assert.NoError(t, err)
+		assert.True(t, validator.IsPChannelIncreasing())
 	})
 
-	t.Run("error - cluster replaced during pchannel increase (same count, different ID)", func(t *testing.T) {
+	t.Run("success - topology changed during pchannel increase", func(t *testing.T) {
 		currentConfig := &commonpb.ReplicateConfiguration{
 			Clusters: []*commonpb.MilvusCluster{
 				makeCluster("c1", "localhost:19530", []string{"ch-1"}),
 				makeCluster("c2", "localhost:19531", []string{"ch-1"}),
-			},
-			CrossClusterTopology: []*commonpb.CrossClusterTopology{
-				{SourceClusterId: "c1", TargetClusterId: "c2"},
-			},
-		}
-		incomingConfig := &commonpb.ReplicateConfiguration{
-			Clusters: []*commonpb.MilvusCluster{
-				makeCluster("c1", "localhost:19530", []string{"ch-1", "ch-2"}),
-				makeCluster("c3", "localhost:19531", []string{"ch-1", "ch-2"}), // c2 replaced by c3
-			},
-			CrossClusterTopology: []*commonpb.CrossClusterTopology{
-				{SourceClusterId: "c1", TargetClusterId: "c3"},
-			},
-		}
-		validator := NewReplicateConfigValidator(incomingConfig, currentConfig, "c1", []string{"ch-1", "ch-2"})
-		err := validator.Validate()
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "cluster set must remain identical")
-		assert.Contains(t, err.Error(), "missing from incoming config")
-	})
-
-	t.Run("error - topology edge replaced during pchannel increase (same count, different edge)", func(t *testing.T) {
-		// Use validatePChannelIncreasingConstraints directly to bypass the star topology check
-		// which runs earlier and would reject the config before we get to our check.
-		currentClusterMap := map[string]*commonpb.MilvusCluster{
-			"c1": makeCluster("c1", "localhost:19530", []string{"ch-1"}),
-			"c2": makeCluster("c2", "localhost:19531", []string{"ch-1"}),
-			"c3": makeCluster("c3", "localhost:19532", []string{"ch-1"}),
-		}
-		currentConfig := &commonpb.ReplicateConfiguration{
-			Clusters: []*commonpb.MilvusCluster{
-				currentClusterMap["c1"], currentClusterMap["c2"], currentClusterMap["c3"],
+				makeCluster("c3", "localhost:19532", []string{"ch-1"}),
 			},
 			CrossClusterTopology: []*commonpb.CrossClusterTopology{
 				{SourceClusterId: "c1", TargetClusterId: "c2"},
@@ -1212,27 +1156,15 @@ func TestReplicateConfigValidator_PChannelIncreasingConstraints(t *testing.T) {
 			Clusters: []*commonpb.MilvusCluster{
 				makeCluster("c1", "localhost:19530", []string{"ch-1", "ch-2"}),
 				makeCluster("c2", "localhost:19531", []string{"ch-1", "ch-2"}),
-				makeCluster("c3", "localhost:19532", []string{"ch-1", "ch-2"}),
 			},
 			CrossClusterTopology: []*commonpb.CrossClusterTopology{
 				{SourceClusterId: "c1", TargetClusterId: "c2"},
-				{SourceClusterId: "c1", TargetClusterId: "c4"}, // c4 doesn't exist but same count
 			},
 		}
-		validator := &ReplicateConfigValidator{
-			incomingConfig:       incomingConfig,
-			currentConfig:        currentConfig,
-			isPChannelIncreasing: true,
-			clusterMap: map[string]*commonpb.MilvusCluster{
-				"c1": incomingConfig.Clusters[0],
-				"c2": incomingConfig.Clusters[1],
-				"c3": incomingConfig.Clusters[2],
-			},
-		}
-		err := validator.validatePChannelIncreasingConstraints(currentClusterMap)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "topology must remain identical")
-		assert.Contains(t, err.Error(), "not in current config")
+		validator := NewReplicateConfigValidator(incomingConfig, currentConfig, "c1", []string{"ch-1", "ch-2"})
+		err := validator.Validate()
+		assert.NoError(t, err)
+		assert.True(t, validator.IsPChannelIncreasing())
 	})
 
 	t.Run("no pchannel increase - IsPChannelIncreasing is false", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Remove `validatePChannelIncreasingConstraints` which prevented changing cluster set or topology when pchannels were increasing
- The constraint was overly restrictive — downstream consumers already handle P+C combinations correctly through independent code paths
- Preserve `IsPChannelIncreasing` flag for downstream channel mapping use

issue: #48993

## Test plan
- [x] Unit tests updated: previously error-expecting P+C tests now expect success
- [x] Added new test: topology change (cluster removal) during pchannel increase
- [x] All existing validator tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)