### PR TITLE
test: refactor snapshot test cases for collection-scoped snapshot API

### DIFF
--- a/tests/python_client/base/client_v2_base.py
+++ b/tests/python_client/base/client_v2_base.py
@@ -1149,13 +1149,16 @@ class TestMilvusClientV2Base(Base):
                         timeout=None, check_task=None, check_items=None, **kwargs):
         """Create a snapshot for a collection.
 
-        Note: Parameter order follows SDK convention - collection_name first, then snapshot_name.
+        Note: wrapper keeps ``collection_name`` before ``snapshot_name`` for test
+        readability, but the SDK signature is ``create_snapshot(snapshot_name,
+        collection_name, ...)`` so we forward positionals in SDK order.
         """
         timeout = TIMEOUT if timeout is None else timeout
         kwargs.update({"timeout": timeout})
 
         func_name = sys._getframe().f_code.co_name
-        res, check = api_request([client.create_snapshot, collection_name, snapshot_name, description], **kwargs)
+        res, check = api_request([client.create_snapshot, snapshot_name, collection_name],
+                                 description=description, **kwargs)
         check_result = ResponseChecker(res, func_name, check_task, check_items, check,
                                        snapshot_name=snapshot_name, collection_name=collection_name,
                                        **kwargs).run()
@@ -1202,12 +1205,17 @@ class TestMilvusClientV2Base(Base):
     def restore_snapshot(self, client, snapshot_name, target_collection_name,
                          source_collection_name="",
                          timeout=None, check_task=None, check_items=None, **kwargs):
+        """Restore a snapshot into a new collection.
+
+        SDK positional order is ``(snapshot_name, source_collection_name,
+        target_collection_name)`` and ``source_collection_name`` is now required.
+        """
         timeout = TIMEOUT if timeout is None else timeout
         kwargs.update({"timeout": timeout})
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.restore_snapshot, snapshot_name,
-                                  target_collection_name, source_collection_name], **kwargs)
+                                  source_collection_name, target_collection_name], **kwargs)
         check_result = ResponseChecker(res, func_name, check_task, check_items, check,
                                        snapshot_name=snapshot_name,
                                        target_collection_name=target_collection_name,

--- a/tests/python_client/base/client_v2_base.py
+++ b/tests/python_client/base/client_v2_base.py
@@ -1162,14 +1162,16 @@ class TestMilvusClientV2Base(Base):
         return res, check_result
 
     @trace()
-    def drop_snapshot(self, client, snapshot_name, timeout=None, check_task=None, check_items=None, **kwargs):
+    def drop_snapshot(self, client, snapshot_name, collection_name,
+                      timeout=None, check_task=None, check_items=None, **kwargs):
         timeout = TIMEOUT if timeout is None else timeout
         kwargs.update({"timeout": timeout})
 
         func_name = sys._getframe().f_code.co_name
-        res, check = api_request([client.drop_snapshot, snapshot_name], **kwargs)
+        res, check = api_request([client.drop_snapshot, snapshot_name, collection_name], **kwargs)
         check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       snapshot_name=snapshot_name, **kwargs).run()
+                                       snapshot_name=snapshot_name, collection_name=collection_name,
+                                       **kwargs).run()
         return res, check_result
 
     @trace()
@@ -1184,26 +1186,32 @@ class TestMilvusClientV2Base(Base):
         return res, check_result
 
     @trace()
-    def describe_snapshot(self, client, snapshot_name, timeout=None, check_task=None, check_items=None, **kwargs):
+    def describe_snapshot(self, client, snapshot_name, collection_name,
+                          timeout=None, check_task=None, check_items=None, **kwargs):
         timeout = TIMEOUT if timeout is None else timeout
         kwargs.update({"timeout": timeout})
 
         func_name = sys._getframe().f_code.co_name
-        res, check = api_request([client.describe_snapshot, snapshot_name], **kwargs)
+        res, check = api_request([client.describe_snapshot, snapshot_name, collection_name], **kwargs)
         check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       snapshot_name=snapshot_name, **kwargs).run()
+                                       snapshot_name=snapshot_name, collection_name=collection_name,
+                                       **kwargs).run()
         return res, check_result
 
     @trace()
-    def restore_snapshot(self, client, snapshot_name, collection_name,
+    def restore_snapshot(self, client, snapshot_name, target_collection_name,
+                         source_collection_name="",
                          timeout=None, check_task=None, check_items=None, **kwargs):
         timeout = TIMEOUT if timeout is None else timeout
         kwargs.update({"timeout": timeout})
 
         func_name = sys._getframe().f_code.co_name
-        res, check = api_request([client.restore_snapshot, snapshot_name, collection_name], **kwargs)
+        res, check = api_request([client.restore_snapshot, snapshot_name,
+                                  target_collection_name, source_collection_name], **kwargs)
         check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       snapshot_name=snapshot_name, collection_name=collection_name,
+                                       snapshot_name=snapshot_name,
+                                       target_collection_name=target_collection_name,
+                                       source_collection_name=source_collection_name,
                                        **kwargs).run()
         return res, check_result
 

--- a/tests/python_client/chaos/checker.py
+++ b/tests/python_client/chaos/checker.py
@@ -2536,14 +2536,13 @@ class SnapshotChecker(Checker):
         try:
             # 1. Create snapshot
             self.snapshot_name = cf.gen_unique_str("snapshot_")
-            self.milvus_client.create_snapshot(self.c_name, self.snapshot_name)
+            self.milvus_client.create_snapshot(self.snapshot_name, self.c_name)
             log.info(f"[SnapshotChecker] Created snapshot {self.snapshot_name} for {self.c_name}")
 
             # 2. Restore to new collection
             self.restored_collection = cf.gen_unique_str("restored_")
             job_id = self.milvus_client.restore_snapshot(
-                self.snapshot_name, self.restored_collection,
-                source_collection_name=self.c_name
+                self.snapshot_name, self.c_name, self.restored_collection
             )
             log.info(f"[SnapshotChecker] Started restore job {job_id}")
 
@@ -2770,14 +2769,13 @@ class SnapshotRestoreChecker(Checker):
 
             # 3. Create snapshot
             self.snapshot_name = cf.gen_unique_str("snapshot_")
-            self.milvus_client.create_snapshot(self.c_name, self.snapshot_name)
+            self.milvus_client.create_snapshot(self.snapshot_name, self.c_name)
             log.info(f"Created snapshot {self.snapshot_name} for collection {self.c_name}")
 
             # 4. Restore to new collection
             self.restored_collection = cf.gen_unique_str("restored_")
             job_id = self.milvus_client.restore_snapshot(
-                self.snapshot_name, self.restored_collection,
-                source_collection_name=self.c_name
+                self.snapshot_name, self.c_name, self.restored_collection
             )
             log.info(f"Started restore job {job_id} to collection {self.restored_collection}")
 

--- a/tests/python_client/chaos/checker.py
+++ b/tests/python_client/chaos/checker.py
@@ -2542,7 +2542,8 @@ class SnapshotChecker(Checker):
             # 2. Restore to new collection
             self.restored_collection = cf.gen_unique_str("restored_")
             job_id = self.milvus_client.restore_snapshot(
-                self.snapshot_name, self.restored_collection
+                self.snapshot_name, self.restored_collection,
+                source_collection_name=self.c_name
             )
             log.info(f"[SnapshotChecker] Started restore job {job_id}")
 
@@ -2577,7 +2578,7 @@ class SnapshotChecker(Checker):
             log.warning(f"[SnapshotChecker] Failed to drop restored collection: {e}")
         try:
             if self.snapshot_name:
-                self.milvus_client.drop_snapshot(self.snapshot_name)
+                self.milvus_client.drop_snapshot(self.snapshot_name, collection_name=self.c_name)
                 log.debug(f"[SnapshotChecker] Dropped snapshot {self.snapshot_name}")
                 self.snapshot_name = None
         except Exception as e:
@@ -2775,7 +2776,8 @@ class SnapshotRestoreChecker(Checker):
             # 4. Restore to new collection
             self.restored_collection = cf.gen_unique_str("restored_")
             job_id = self.milvus_client.restore_snapshot(
-                self.snapshot_name, self.restored_collection
+                self.snapshot_name, self.restored_collection,
+                source_collection_name=self.c_name
             )
             log.info(f"Started restore job {job_id} to collection {self.restored_collection}")
 
@@ -2820,7 +2822,7 @@ class SnapshotRestoreChecker(Checker):
 
         try:
             if self.snapshot_name:
-                self.milvus_client.drop_snapshot(self.snapshot_name)
+                self.milvus_client.drop_snapshot(self.snapshot_name, collection_name=self.c_name)
                 log.debug(f"Dropped snapshot {self.snapshot_name}")
                 self.snapshot_name = None
         except Exception as e:

--- a/tests/python_client/milvus_client/test_milvus_client_snapshot.py
+++ b/tests/python_client/milvus_client/test_milvus_client_snapshot.py
@@ -3127,7 +3127,7 @@ class TestMilvusClientSnapshotConcurrency(TestMilvusClientV2Base):
             try:
                 # Directly call client method to bypass ResponseChecker framework
                 # This allows us to capture the real MilvusException with original error message
-                client.create_snapshot(collection_name, snapshot_name)
+                client.create_snapshot(snapshot_name, collection_name)
                 results.append("success")
             except Exception as e:
                 errors.append(str(e))

--- a/tests/python_client/milvus_client/test_milvus_client_snapshot.py
+++ b/tests/python_client/milvus_client/test_milvus_client_snapshot.py
@@ -9,6 +9,7 @@ from common import common_func as cf
 from common import common_type as ct
 from common.common_type import CaseLabel, CheckTasks
 from pymilvus import DataType
+from ml_dtypes import bfloat16
 
 
 prefix = "snapshot"
@@ -36,7 +37,6 @@ default_float_field_name = ct.default_float_field_name
 default_string_field_name = ct.default_string_field_name
 
 
-@pytest.mark.skip(reason="pymilvus SDK does not yet support collection_name for snapshot APIs")
 class TestMilvusClientSnapshotDefault(TestMilvusClientV2Base):
     """Test snapshot basic operations - L0 smoke tests"""
 
@@ -72,13 +72,13 @@ class TestMilvusClientSnapshotDefault(TestMilvusClientV2Base):
         assert snapshot_name in snapshots, f"Snapshot {snapshot_name} not found in list"
 
         # 4. Describe snapshot
-        info, _ = self.describe_snapshot(client, snapshot_name)
+        info, _ = self.describe_snapshot(client, snapshot_name, collection_name)
         assert info.name == snapshot_name
         assert info.collection_name == collection_name
         assert info.create_ts > 0
 
         # 5. Drop snapshot
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
 
         # 6. Verify snapshot is dropped
         snapshots, _ = self.list_snapshots(client, collection_name=collection_name)
@@ -112,7 +112,8 @@ class TestMilvusClientSnapshotDefault(TestMilvusClientV2Base):
         self.create_snapshot(client, collection_name, snapshot_name)
 
         # 3. Restore snapshot to new collection
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         assert job_id > 0, "restore_snapshot should return a valid job_id"
 
         # 4. Wait for restore to complete
@@ -127,12 +128,11 @@ class TestMilvusClientSnapshotDefault(TestMilvusClientV2Base):
             f"Restored collection should have {default_nb} rows, got {restored_count}"
 
         # 6. Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
 
 
-@pytest.mark.skip(reason="pymilvus SDK does not yet support collection_name for snapshot APIs")
 class TestMilvusClientSnapshotCreateInvalid(TestMilvusClientV2Base):
     """Test create_snapshot with invalid parameters - L1"""
 
@@ -206,7 +206,7 @@ class TestMilvusClientSnapshotCreateInvalid(TestMilvusClientV2Base):
                              check_task=CheckTasks.err_res, check_items=error)
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_snapshot_create_empty_collection(self):
@@ -227,10 +227,9 @@ class TestMilvusClientSnapshotCreateInvalid(TestMilvusClientV2Base):
         assert snapshot_name in snapshots
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
 
 
-@pytest.mark.skip(reason="pymilvus SDK does not yet support collection_name for snapshot APIs")
 class TestMilvusClientSnapshotDropInvalid(TestMilvusClientV2Base):
     """Test drop_snapshot with invalid parameters - L1"""
 
@@ -244,9 +243,9 @@ class TestMilvusClientSnapshotDropInvalid(TestMilvusClientV2Base):
         """
         client = self._client()
 
-        # SDK validates snapshot_name and raises ParamError
+        # SDK validates snapshot_name and raises ParamError before checking collection_name
         error = {ct.err_code: 1, ct.err_msg: "snapshot_name must be a non-empty string"}
-        self.drop_snapshot(client, snapshot_name,
+        self.drop_snapshot(client, snapshot_name, "",
                            check_task=CheckTasks.err_res, check_items=error)
 
     @pytest.mark.tags(CaseLabel.L1)
@@ -259,10 +258,12 @@ class TestMilvusClientSnapshotDropInvalid(TestMilvusClientV2Base):
         Fixed in PR #47096: Server now validates snapshot names using standard naming rules.
         """
         client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        self.create_collection(client, collection_name, default_dim)
 
         # Server validates snapshot name and rejects whitespace-only names
         error = {ct.err_code: 1100, ct.err_msg: "snapshot name should be not empty"}
-        self.drop_snapshot(client, " ",
+        self.drop_snapshot(client, " ", collection_name,
                            check_task=CheckTasks.err_res, check_items=error)
 
     @pytest.mark.tags(CaseLabel.L1)
@@ -273,13 +274,14 @@ class TestMilvusClientSnapshotDropInvalid(TestMilvusClientV2Base):
         expected: should succeed (idempotent behavior)
         """
         client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        self.create_collection(client, collection_name, default_dim)
         snapshot_name = cf.gen_unique_str("non_existent")
 
         # Should not raise exception (idempotent)
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
 
 
-@pytest.mark.skip(reason="pymilvus SDK does not yet support collection_name for snapshot APIs")
 class TestMilvusClientSnapshotListDescribe(TestMilvusClientV2Base):
     """Test list_snapshots and describe_snapshot - L1"""
 
@@ -307,7 +309,7 @@ class TestMilvusClientSnapshotListDescribe(TestMilvusClientV2Base):
 
         # Cleanup
         for name in snapshot_names:
-            self.drop_snapshot(client, name)
+            self.drop_snapshot(client, name, collection_name)
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_snapshot_list_by_collection(self):
@@ -334,8 +336,8 @@ class TestMilvusClientSnapshotListDescribe(TestMilvusClientV2Base):
         assert snapshot_name2 not in snapshots
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name1)
-        self.drop_snapshot(client, snapshot_name2)
+        self.drop_snapshot(client, snapshot_name1, collection_name1)
+        self.drop_snapshot(client, snapshot_name2, collection_name2)
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_snapshot_list_empty(self):
@@ -359,10 +361,12 @@ class TestMilvusClientSnapshotListDescribe(TestMilvusClientV2Base):
         expected: raise exception
         """
         client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        self.create_collection(client, collection_name, default_dim)
         snapshot_name = cf.gen_unique_str("non_existent")
 
         error = {ct.err_code: 1, ct.err_msg: "not found"}
-        self.describe_snapshot(client, snapshot_name,
+        self.describe_snapshot(client, snapshot_name, collection_name,
                                check_task=CheckTasks.err_res, check_items=error)
 
     @pytest.mark.tags(CaseLabel.L1)
@@ -380,14 +384,13 @@ class TestMilvusClientSnapshotListDescribe(TestMilvusClientV2Base):
         self.create_collection(client, collection_name, default_dim)
         self.create_snapshot(client, collection_name, snapshot_name, description=description)
 
-        info, _ = self.describe_snapshot(client, snapshot_name)
+        info, _ = self.describe_snapshot(client, snapshot_name, collection_name)
         assert info.description == description
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
 
 
-@pytest.mark.skip(reason="pymilvus SDK does not yet support collection_name for snapshot APIs")
 class TestMilvusClientSnapshotRestoreInvalid(TestMilvusClientV2Base):
     """Test restore_snapshot with invalid parameters - L1"""
 
@@ -399,11 +402,14 @@ class TestMilvusClientSnapshotRestoreInvalid(TestMilvusClientV2Base):
         expected: raise exception
         """
         client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        self.create_collection(client, collection_name, default_dim)
         snapshot_name = cf.gen_unique_str("non_existent")
-        collection_name = cf.gen_unique_str(prefix)
+        target_collection_name = cf.gen_unique_str(prefix + "_target")
 
         error = {ct.err_code: 1, ct.err_msg: "not found"}
-        self.restore_snapshot(client, snapshot_name, collection_name,
+        self.restore_snapshot(client, snapshot_name, target_collection_name,
+                              source_collection_name=collection_name,
                               check_task=CheckTasks.err_res, check_items=error)
 
     @pytest.mark.tags(CaseLabel.L1)
@@ -427,13 +433,13 @@ class TestMilvusClientSnapshotRestoreInvalid(TestMilvusClientV2Base):
 
         error = {ct.err_code: 65535, ct.err_msg: "duplicate collection"}
         self.restore_snapshot(client, snapshot_name, target_collection_name,
+                              source_collection_name=collection_name,
                               check_task=CheckTasks.err_res, check_items=error)
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
 
 
-@pytest.mark.skip(reason="pymilvus SDK does not yet support collection_name for snapshot APIs")
 class TestMilvusClientSnapshotRestoreState(TestMilvusClientV2Base):
     """Test get_restore_snapshot_state and list_restore_snapshot_jobs - L1"""
 
@@ -464,7 +470,6 @@ class TestMilvusClientSnapshotRestoreState(TestMilvusClientV2Base):
         assert isinstance(jobs, list), "list_restore_snapshot_jobs should return a list"
 
 
-@pytest.mark.skip(reason="pymilvus SDK does not yet support collection_name for snapshot APIs")
 class TestMilvusClientSnapshotDataTypes(TestMilvusClientV2Base):
     """Test snapshot with various data types - L2"""
 
@@ -492,7 +497,8 @@ class TestMilvusClientSnapshotDataTypes(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify data
@@ -504,7 +510,7 @@ class TestMilvusClientSnapshotDataTypes(TestMilvusClientV2Base):
         assert ids == list(range(100))
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -540,7 +546,8 @@ class TestMilvusClientSnapshotDataTypes(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify data
@@ -550,7 +557,7 @@ class TestMilvusClientSnapshotDataTypes(TestMilvusClientV2Base):
         assert len(res) == 100
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -589,7 +596,8 @@ class TestMilvusClientSnapshotDataTypes(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify data count
@@ -599,7 +607,7 @@ class TestMilvusClientSnapshotDataTypes(TestMilvusClientV2Base):
         assert res[0]["count(*)"] == 100
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -637,7 +645,8 @@ class TestMilvusClientSnapshotDataTypes(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify JSON data
@@ -647,7 +656,7 @@ class TestMilvusClientSnapshotDataTypes(TestMilvusClientV2Base):
         assert res[0]["metadata"]["key"] == "value_0"
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -685,7 +694,8 @@ class TestMilvusClientSnapshotDataTypes(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify dynamic field data
@@ -696,12 +706,11 @@ class TestMilvusClientSnapshotDataTypes(TestMilvusClientV2Base):
         assert res[0]["dynamic_field_2"] == 0
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
 
 
-@pytest.mark.skip(reason="pymilvus SDK does not yet support collection_name for snapshot APIs")
 class TestMilvusClientSnapshotPartition(TestMilvusClientV2Base):
     """Test snapshot with partitions - L2"""
 
@@ -737,7 +746,8 @@ class TestMilvusClientSnapshotPartition(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify partitions are preserved
@@ -754,7 +764,7 @@ class TestMilvusClientSnapshotPartition(TestMilvusClientV2Base):
             assert res[0]["count(*)"] == 100, f"Partition {p_name} should have 100 rows"
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -790,7 +800,8 @@ class TestMilvusClientSnapshotPartition(TestMilvusClientV2Base):
         self.drop_partition(client, collection_name, partition_name)
 
         # Restore snapshot
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify partition is restored
@@ -805,12 +816,11 @@ class TestMilvusClientSnapshotPartition(TestMilvusClientV2Base):
         assert res[0]["count(*)"] == 100
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
 
 
-@pytest.mark.skip(reason="pymilvus SDK does not yet support collection_name for snapshot APIs")
 class TestMilvusClientSnapshotDataOperations(TestMilvusClientV2Base):
     """Test snapshot with data operations - L2"""
 
@@ -845,7 +855,8 @@ class TestMilvusClientSnapshotDataOperations(TestMilvusClientV2Base):
         self.create_snapshot(client, collection_name, snapshot_name)
 
         # Restore
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify only 50 rows remain
@@ -855,7 +866,7 @@ class TestMilvusClientSnapshotDataOperations(TestMilvusClientV2Base):
         assert res[0]["count(*)"] == 50
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -898,7 +909,8 @@ class TestMilvusClientSnapshotDataOperations(TestMilvusClientV2Base):
         assert res[0]["count(*)"] == 150
 
         # Restore snapshot
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Restored collection should only have 100 rows (point-in-time)
@@ -908,7 +920,7 @@ class TestMilvusClientSnapshotDataOperations(TestMilvusClientV2Base):
         assert res[0]["count(*)"] == 100
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -973,7 +985,8 @@ class TestMilvusClientSnapshotDataOperations(TestMilvusClientV2Base):
         log.info("Created snapshot (without triggering flush)")
 
         # Restore snapshot to new collection
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify restored collection data count
@@ -1001,12 +1014,11 @@ class TestMilvusClientSnapshotDataOperations(TestMilvusClientV2Base):
         log.info("Verified: Snapshot does NOT include growing segment data")
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
 
 
-@pytest.mark.skip(reason="pymilvus SDK does not yet support collection_name for snapshot APIs")
 class TestMilvusClientSnapshotIndex(TestMilvusClientV2Base):
     """Test snapshot with various index types - L2"""
 
@@ -1045,7 +1057,8 @@ class TestMilvusClientSnapshotIndex(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify index is preserved
@@ -1060,12 +1073,11 @@ class TestMilvusClientSnapshotIndex(TestMilvusClientV2Base):
         assert len(res[0]) == 10
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
 
 
-@pytest.mark.skip(reason="pymilvus SDK does not yet support collection_name for snapshot APIs")
 class TestMilvusClientSnapshotDataIntegrity(TestMilvusClientV2Base):
     """Test snapshot data integrity - verify actual data content, not just counts"""
 
@@ -1094,7 +1106,8 @@ class TestMilvusClientSnapshotDataIntegrity(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Query all vectors from restored collection
@@ -1112,7 +1125,7 @@ class TestMilvusClientSnapshotDataIntegrity(TestMilvusClientV2Base):
                     f"Vector mismatch at id={row['id']}, dim={j}"
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -1145,7 +1158,8 @@ class TestMilvusClientSnapshotDataIntegrity(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Search on restored collection with same queries
@@ -1161,7 +1175,7 @@ class TestMilvusClientSnapshotDataIntegrity(TestMilvusClientV2Base):
                 f"Search results mismatch for query {i}: original={original_ids}, restored={restored_ids}"
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -1206,7 +1220,8 @@ class TestMilvusClientSnapshotDataIntegrity(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Query and verify all scalar values
@@ -1223,12 +1238,11 @@ class TestMilvusClientSnapshotDataIntegrity(TestMilvusClientV2Base):
             assert row["varchar_field"] == f"string_value_{i}", f"varchar_field mismatch at id={i}"
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
 
 
-@pytest.mark.skip(reason="pymilvus SDK does not yet support collection_name for snapshot APIs")
 class TestMilvusClientSnapshotBoundary(TestMilvusClientV2Base):
     """Test snapshot boundary conditions and edge cases"""
 
@@ -1263,7 +1277,7 @@ class TestMilvusClientSnapshotBoundary(TestMilvusClientV2Base):
                 snapshots, _ = self.list_snapshots(client, collection_name=collection_name)
                 if name in snapshots:
                     results[name] = "accepted"
-                    self.drop_snapshot(client, name)
+                    self.drop_snapshot(client, name, collection_name)
                 else:
                     results[name] = "created but not listed"
             except Exception as e:
@@ -1290,7 +1304,7 @@ class TestMilvusClientSnapshotBoundary(TestMilvusClientV2Base):
             name = "s" * length
             try:
                 self.create_snapshot(client, collection_name, name)
-                self.drop_snapshot(client, name)
+                self.drop_snapshot(client, name, collection_name)
             except Exception as e:
                 found_limit = length
                 log.info(f"Snapshot name length limit is less than {length}: {e}")
@@ -1324,7 +1338,8 @@ class TestMilvusClientSnapshotBoundary(TestMilvusClientV2Base):
         self.flush(client, collection_name)
 
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
 
         # Track progress
         progress_values = []
@@ -1354,7 +1369,7 @@ class TestMilvusClientSnapshotBoundary(TestMilvusClientV2Base):
         assert final_state.time_cost > 0, "time_cost should be > 0 after completion"
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -1392,7 +1407,8 @@ class TestMilvusClientSnapshotBoundary(TestMilvusClientV2Base):
         # Restore each snapshot and verify correct count
         for i, snapshot_name in enumerate(snapshots):
             restored_name = cf.gen_unique_str(prefix + "_restored")
-            job_id, _ = self.restore_snapshot(client, snapshot_name, restored_name)
+            job_id, _ = self.restore_snapshot(client, snapshot_name, restored_name,
+                                                      source_collection_name=collection_name)
             wait_for_restore_complete(client, job_id)
 
             self.load_collection(client, restored_name)
@@ -1406,7 +1422,7 @@ class TestMilvusClientSnapshotBoundary(TestMilvusClientV2Base):
 
         # Cleanup
         for snapshot_name in snapshots:
-            self.drop_snapshot(client, snapshot_name)
+            self.drop_snapshot(client, snapshot_name, collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_snapshot_concurrent_restore(self):
@@ -1440,7 +1456,8 @@ class TestMilvusClientSnapshotBoundary(TestMilvusClientV2Base):
         for i in range(num_restores):
             restored_name = cf.gen_unique_str(prefix + f"_restored_{i}")
             restored_names.append(restored_name)
-            job_id, _ = self.restore_snapshot(client, snapshot_name, restored_name)
+            job_id, _ = self.restore_snapshot(client, snapshot_name, restored_name,
+                                                      source_collection_name=collection_name)
             restore_jobs.append(job_id)
 
         # Wait for all to complete
@@ -1455,11 +1472,10 @@ class TestMilvusClientSnapshotBoundary(TestMilvusClientV2Base):
             self.drop_collection(client, restored_name)
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
 
 
 
-@pytest.mark.skip(reason="pymilvus SDK does not yet support collection_name for snapshot APIs")
 class TestMilvusClientSnapshotNegative(TestMilvusClientV2Base):
     """Test snapshot negative scenarios and error handling"""
 
@@ -1487,21 +1503,23 @@ class TestMilvusClientSnapshotNegative(TestMilvusClientV2Base):
         self.create_snapshot(client, collection_name, snapshot_name)
 
         # Delete snapshot
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
 
         # Try to restore - should fail
         error = {ct.err_code: 1, ct.err_msg: "not found"}
         self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                              source_collection_name=collection_name,
                               check_task=CheckTasks.err_res, check_items=error)
 
     @pytest.mark.tags(CaseLabel.L2)
-    def test_snapshot_list_after_drop_collection(self):
+    def test_snapshot_cascade_delete_on_drop_collection(self):
         """
-        target: test listing snapshots after source collection is dropped
-        method: create snapshot, drop collection, list snapshots
-        expected: snapshot should still be listable (snapshot is independent)
+        target: test snapshots are cascade deleted when collection is dropped
+        method: create snapshot, drop collection, recreate collection, list snapshots
+        expected: snapshots should be automatically deleted with the collection
 
-        Fixed in PR #47096: Server now handles empty collection_name by listing all snapshots.
+        Changed in PR #48143: snapshot lifecycle is now bound to collection.
+        Dropping a collection cascades to delete all its snapshots.
         """
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
@@ -1518,25 +1536,20 @@ class TestMilvusClientSnapshotNegative(TestMilvusClientV2Base):
         self.flush(client, collection_name)
         self.create_snapshot(client, collection_name, snapshot_name)
 
-        # Drop original collection
+        # Verify snapshot exists before drop
+        snapshots, _ = self.list_snapshots(client, collection_name=collection_name)
+        assert snapshot_name in snapshots, "Snapshot should exist before collection drop"
+
+        # Drop collection - should cascade delete snapshots
         self.drop_collection(client, collection_name)
 
-        # Snapshot should still be listable
-        snapshots, _ = self.list_snapshots(client)
-        assert snapshot_name in snapshots, "Snapshot should exist after collection drop"
+        # Recreate collection with same name (this is a new collection)
+        self.create_collection(client, collection_name, default_dim)
 
-        # Should be able to restore to new collection
-        restored_collection_name = cf.gen_unique_str(prefix + "_restored")
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
-        wait_for_restore_complete(client, job_id)
-
-        self.load_collection(client, restored_collection_name)
-        res, _ = self.query(client, restored_collection_name, filter="id >= 0", output_fields=["count(*)"])
-        assert res[0]["count(*)"] == 100
-
-        # Cleanup
-        self.drop_snapshot(client, snapshot_name)
-        self.drop_collection(client, restored_collection_name)
+        # Snapshots should not exist for the new collection
+        snapshots, _ = self.list_snapshots(client, collection_name=collection_name)
+        assert len(snapshots) == 0, \
+            "Snapshots should be cascade deleted when collection is dropped"
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_snapshot_schema_consistency_autoID(self):
@@ -1569,7 +1582,8 @@ class TestMilvusClientSnapshotNegative(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify schema of restored collection
@@ -1583,12 +1597,11 @@ class TestMilvusClientSnapshotNegative(TestMilvusClientV2Base):
         self.insert(client, restored_collection_name, new_rows)
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
 
 
-@pytest.mark.skip(reason="pymilvus SDK does not yet support collection_name for snapshot APIs")
 class TestMilvusClientSnapshotAllDataTypes(TestMilvusClientV2Base):
     """
     L2 Test - Snapshot with all data types matrix testing
@@ -1643,7 +1656,8 @@ class TestMilvusClientSnapshotAllDataTypes(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify all scalar data
@@ -1666,7 +1680,7 @@ class TestMilvusClientSnapshotAllDataTypes(TestMilvusClientV2Base):
             assert row["varchar_field"] == f"string_{i}", f"varchar_field mismatch at id={i}"
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -1712,7 +1726,8 @@ class TestMilvusClientSnapshotAllDataTypes(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify array data
@@ -1727,7 +1742,7 @@ class TestMilvusClientSnapshotAllDataTypes(TestMilvusClientV2Base):
         assert row["bool_array"] == [j % 2 == 0 for j in range(5)]
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -1782,7 +1797,8 @@ class TestMilvusClientSnapshotAllDataTypes(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify data count
@@ -1798,7 +1814,7 @@ class TestMilvusClientSnapshotAllDataTypes(TestMilvusClientV2Base):
         assert len(search_res[0]) == 10
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -1844,7 +1860,8 @@ class TestMilvusClientSnapshotAllDataTypes(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify nullable fields
@@ -1869,12 +1886,235 @@ class TestMilvusClientSnapshotAllDataTypes(TestMilvusClientV2Base):
         assert abs(res[0]["nullable_float"] - 3.5) < 1e-5
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
+        self.drop_collection(client, restored_collection_name)
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_snapshot_with_comprehensive_schema(self):
+        """
+        target: test snapshot with comprehensive schema covering all data types
+        method: use gen_all_datatype_collection_schema (all scalars, arrays, vectors,
+                struct array, BM25 function, MinHash function, nullable fields, text match)
+                then snapshot and restore, verify data integrity
+        expected: all field data should be preserved correctly after restore
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        snapshot_name = cf.gen_unique_str(prefix)
+        restored_collection_name = cf.gen_unique_str(prefix + "_restored")
+
+        # Generate comprehensive schema with all data types
+        schema = cf.gen_all_datatype_collection_schema(
+            dim=default_dim,
+            enable_struct_array_field=True,
+            enable_dynamic_field=True,
+            nullable=True
+        )
+
+        # Create indexes for vector fields
+        index_params = client.prepare_index_params()
+        index_params.add_index("float_vector", metric_type="COSINE")
+        index_params.add_index("text_sparse_emb", metric_type="BM25",
+                               index_type="SPARSE_INVERTED_INDEX")
+        index_params.add_index("minhash_emb", metric_type="HAMMING")
+        # Struct array inner vector field also needs index
+        index_params.add_index("array_struct[float_vector]", metric_type="COSINE")
+
+        self.create_collection(client, collection_name, schema=schema,
+                               index_params=index_params)
+
+        # Generate row data using schema-based data generator
+        nb = 200
+        data = cf.gen_row_data_by_schema(nb=nb, schema=schema)
+        self.insert(client, collection_name, data)
+        self.flush(client, collection_name)
+
+        # Verify source collection
+        self.load_collection(client, collection_name)
+        res, _ = self.query(client, collection_name, filter="",
+                            output_fields=["count(*)"])
+        assert res[0]["count(*)"] == nb
+
+        # Create snapshot and restore
+        self.create_snapshot(client, collection_name, snapshot_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
+        wait_for_restore_complete(client, job_id)
+
+        # Verify restored data count
+        self.load_collection(client, restored_collection_name)
+        res, _ = self.query(client, restored_collection_name, filter="",
+                            output_fields=["count(*)"])
+        assert res[0]["count(*)"] == nb, \
+            f"Expected {nb} rows, got {res[0]['count(*)']}"
+
+        # Verify text match works (BM25 function preserved)
+        res, _ = self.query(client, restored_collection_name,
+                            filter='TEXT_MATCH(text, "the")',
+                            output_fields=["id", "text"])
+        log.info(f"Text match results: {len(res)} rows")
+
+        # Verify float vector search works
+        rng = np.random.default_rng(seed=19530)
+        search_vectors = [list(rng.random(default_dim))]
+        search_res, _ = self.search(client, restored_collection_name, search_vectors,
+                                    anns_field="float_vector", limit=10,
+                                    output_fields=["id"])
+        assert len(search_res[0]) > 0, "Float vector search should return results"
+
+        # Verify scalar fields are preserved (PK field name is "int64")
+        res, _ = self.query(client, restored_collection_name,
+                            filter="int64 >= 0",
+                            output_fields=["int64", "varchar", "json_field",
+                                           "array_int", "array_bool", "array_struct"],
+                            limit=10)
+        assert len(res) > 0
+        # Check at least one row has non-null array fields
+        has_array_data = False
+        has_struct_data = False
+        for row in res:
+            arr = row.get("array_int")
+            if arr is not None and len(arr) > 0:
+                has_array_data = True
+            struct_arr = row.get("array_struct")
+            if struct_arr is not None and len(struct_arr) > 0:
+                has_struct_data = True
+                assert "name" in struct_arr[0], "Struct element should have 'name'"
+                assert "age" in struct_arr[0], "Struct element should have 'age'"
+        assert has_array_data, "Should have rows with array_int data"
+        assert has_struct_data, "Should have rows with array_struct data"
+
+        # Cleanup
+        self.drop_snapshot(client, snapshot_name, collection_name)
+        self.drop_collection(client, restored_collection_name)
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_snapshot_with_bfloat16_vector(self):
+        """
+        target: test snapshot with BFloat16 vector type
+        method: create collection with BFloat16Vector field, snapshot and restore
+        expected: BFloat16 vector data should be preserved correctly
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        snapshot_name = cf.gen_unique_str(prefix)
+        restored_collection_name = cf.gen_unique_str(prefix + "_restored")
+
+        schema = client.create_schema(enable_dynamic_field=False, auto_id=False)
+        schema.add_field("id", DataType.INT64, is_primary=True)
+        schema.add_field("float_vector", DataType.FLOAT_VECTOR, dim=default_dim)
+        schema.add_field("bfloat16_vector", DataType.BFLOAT16_VECTOR, dim=default_dim)
+
+        index_params = client.prepare_index_params()
+        index_params.add_index("float_vector", metric_type="COSINE")
+        index_params.add_index("bfloat16_vector", metric_type="L2")
+
+        self.create_collection(client, collection_name, schema=schema,
+                               index_params=index_params)
+
+        rng = np.random.default_rng(seed=19530)
+        rows = [{
+            "id": i,
+            "float_vector": list(rng.random(default_dim)),
+            "bfloat16_vector": np.array(rng.random(default_dim), dtype=bfloat16),
+        } for i in range(100)]
+        self.insert(client, collection_name, rows)
+        self.flush(client, collection_name)
+
+        # Create snapshot and restore
+        self.create_snapshot(client, collection_name, snapshot_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
+        wait_for_restore_complete(client, job_id)
+
+        # Verify data count
+        self.load_collection(client, restored_collection_name)
+        res, _ = self.query(client, restored_collection_name,
+                            filter="id >= 0", output_fields=["count(*)"])
+        assert res[0]["count(*)"] == 100
+
+        # Verify search on bfloat16 vector works
+        search_vectors = [np.array(rng.random(default_dim), dtype=bfloat16)]
+        res, _ = self.search(client, restored_collection_name, search_vectors,
+                             anns_field="bfloat16_vector", limit=10,
+                             output_fields=["id"])
+        assert len(res[0]) == 10
+
+        # Cleanup
+        self.drop_snapshot(client, snapshot_name, collection_name)
+        self.drop_collection(client, restored_collection_name)
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_snapshot_with_all_array_element_types(self):
+        """
+        target: test snapshot with all array element types
+        method: create collection with Array[Int8/Int16/Int32/Int64/Float/Double/Bool/VarChar]
+        expected: all array data should be preserved correctly after restore
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        snapshot_name = cf.gen_unique_str(prefix)
+        restored_collection_name = cf.gen_unique_str(prefix + "_restored")
+
+        schema = client.create_schema(enable_dynamic_field=False, auto_id=False)
+        schema.add_field("id", DataType.INT64, is_primary=True)
+        schema.add_field("vector", DataType.FLOAT_VECTOR, dim=default_dim)
+        schema.add_field("arr_int8", DataType.ARRAY, element_type=DataType.INT8, max_capacity=20)
+        schema.add_field("arr_int16", DataType.ARRAY, element_type=DataType.INT16, max_capacity=20)
+        schema.add_field("arr_int32", DataType.ARRAY, element_type=DataType.INT32, max_capacity=20)
+        schema.add_field("arr_int64", DataType.ARRAY, element_type=DataType.INT64, max_capacity=20)
+        schema.add_field("arr_float", DataType.ARRAY, element_type=DataType.FLOAT, max_capacity=20)
+        schema.add_field("arr_double", DataType.ARRAY, element_type=DataType.DOUBLE, max_capacity=20)
+        schema.add_field("arr_bool", DataType.ARRAY, element_type=DataType.BOOL, max_capacity=20)
+        schema.add_field("arr_varchar", DataType.ARRAY, element_type=DataType.VARCHAR,
+                         max_length=100, max_capacity=20)
+
+        index_params = client.prepare_index_params()
+        index_params.add_index("vector", metric_type="COSINE")
+
+        self.create_collection(client, collection_name, schema=schema,
+                               index_params=index_params)
+
+        rng = np.random.default_rng(seed=19530)
+        rows = [{
+            "id": i,
+            "vector": list(rng.random(default_dim)),
+            "arr_int8": [int(np.int8(j)) for j in range(5)],
+            "arr_int16": [int(np.int16(i * 10 + j)) for j in range(5)],
+            "arr_int32": [i * 100 + j for j in range(5)],
+            "arr_int64": [i * 1000 + j for j in range(5)],
+            "arr_float": [float(i * 0.1 + j * 0.01) for j in range(5)],
+            "arr_double": [float(i * 1.1 + j * 0.11) for j in range(5)],
+            "arr_bool": [j % 2 == 0 for j in range(5)],
+            "arr_varchar": [f"s_{i}_{j}" for j in range(5)],
+        } for i in range(100)]
+        self.insert(client, collection_name, rows)
+        self.flush(client, collection_name)
+
+        # Create snapshot and restore
+        self.create_snapshot(client, collection_name, snapshot_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
+        wait_for_restore_complete(client, job_id)
+
+        # Verify data
+        self.load_collection(client, restored_collection_name)
+        res, _ = self.query(client, restored_collection_name,
+                            filter="id == 5",
+                            output_fields=["arr_int8", "arr_int16", "arr_int32", "arr_int64",
+                                           "arr_float", "arr_double", "arr_bool", "arr_varchar"])
+        assert len(res) == 1
+        row = res[0]
+        assert row["arr_int32"] == [500, 501, 502, 503, 504]
+        assert row["arr_int64"] == [5000, 5001, 5002, 5003, 5004]
+        assert row["arr_bool"] == [True, False, True, False, True]
+        assert row["arr_varchar"] == ["s_5_0", "s_5_1", "s_5_2", "s_5_3", "s_5_4"]
+
+        # Cleanup
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
 
-
-@pytest.mark.skip(reason="pymilvus SDK does not yet support collection_name for snapshot APIs")
 class TestMilvusClientSnapshotAllIndexTypes(TestMilvusClientV2Base):
     """
     L2 Test - Snapshot with all index types testing
@@ -1912,7 +2152,8 @@ class TestMilvusClientSnapshotAllIndexTypes(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify index and search
@@ -1923,7 +2164,7 @@ class TestMilvusClientSnapshotAllIndexTypes(TestMilvusClientV2Base):
         assert len(res[0]) == 10
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -1957,7 +2198,8 @@ class TestMilvusClientSnapshotAllIndexTypes(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify search works
@@ -1968,7 +2210,7 @@ class TestMilvusClientSnapshotAllIndexTypes(TestMilvusClientV2Base):
         assert len(res[0]) == 10
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -2002,7 +2244,8 @@ class TestMilvusClientSnapshotAllIndexTypes(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify search works
@@ -2013,7 +2256,7 @@ class TestMilvusClientSnapshotAllIndexTypes(TestMilvusClientV2Base):
         assert len(res[0]) == 10
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -2046,7 +2289,8 @@ class TestMilvusClientSnapshotAllIndexTypes(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify search works
@@ -2057,7 +2301,7 @@ class TestMilvusClientSnapshotAllIndexTypes(TestMilvusClientV2Base):
         assert len(res[0]) == 10
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -2091,7 +2335,8 @@ class TestMilvusClientSnapshotAllIndexTypes(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify search works
@@ -2102,7 +2347,7 @@ class TestMilvusClientSnapshotAllIndexTypes(TestMilvusClientV2Base):
         assert len(res[0]) == 10
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -2143,7 +2388,8 @@ class TestMilvusClientSnapshotAllIndexTypes(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify scalar index works with filter
@@ -2157,12 +2403,11 @@ class TestMilvusClientSnapshotAllIndexTypes(TestMilvusClientV2Base):
         assert res[0]["count(*)"] == 100  # 500/5 = 100 rows with tag='tag_3'
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
 
 
-@pytest.mark.skip(reason="pymilvus SDK does not yet support collection_name for snapshot APIs")
 class TestMilvusClientSnapshotCollectionProperties(TestMilvusClientV2Base):
     """
     L2 Test - Snapshot with collection properties testing
@@ -2201,7 +2446,8 @@ class TestMilvusClientSnapshotCollectionProperties(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify description is preserved
@@ -2210,7 +2456,7 @@ class TestMilvusClientSnapshotCollectionProperties(TestMilvusClientV2Base):
             f"Description should be preserved, got: {desc.get('description')}"
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -2249,7 +2495,8 @@ class TestMilvusClientSnapshotCollectionProperties(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify shard count is preserved
@@ -2260,7 +2507,7 @@ class TestMilvusClientSnapshotCollectionProperties(TestMilvusClientV2Base):
             f"Shard count should be {num_shards}, got: {restored_shards}"
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -2298,7 +2545,8 @@ class TestMilvusClientSnapshotCollectionProperties(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify consistency level is preserved
@@ -2309,7 +2557,7 @@ class TestMilvusClientSnapshotCollectionProperties(TestMilvusClientV2Base):
         assert restored_consistency is not None
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -2346,7 +2594,8 @@ class TestMilvusClientSnapshotCollectionProperties(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify partition key is preserved in schema
@@ -2364,12 +2613,11 @@ class TestMilvusClientSnapshotCollectionProperties(TestMilvusClientV2Base):
         assert res[0]["count(*)"] == 500
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
 
 
-@pytest.mark.skip(reason="pymilvus SDK does not yet support collection_name for snapshot APIs")
 class TestMilvusClientSnapshotDataOperationsExtended(TestMilvusClientV2Base):
     """
     L2 Test - Snapshot after various data operations
@@ -2415,7 +2663,8 @@ class TestMilvusClientSnapshotDataOperationsExtended(TestMilvusClientV2Base):
         self.create_snapshot(client, collection_name, snapshot_name)
 
         # Restore
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify
@@ -2448,7 +2697,7 @@ class TestMilvusClientSnapshotDataOperationsExtended(TestMilvusClientV2Base):
         assert res[0]["varchar"] == "updated_125"
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -2490,7 +2739,8 @@ class TestMilvusClientSnapshotDataOperationsExtended(TestMilvusClientV2Base):
         self.create_snapshot(client, collection_name, snapshot_name)
 
         # Restore
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify data count (should be 700: 1000 - 300 deleted)
@@ -2505,7 +2755,7 @@ class TestMilvusClientSnapshotDataOperationsExtended(TestMilvusClientV2Base):
         assert res[0]["count(*)"] == 0, "Deleted data should not be present"
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -2561,11 +2811,13 @@ class TestMilvusClientSnapshotDataOperationsExtended(TestMilvusClientV2Base):
         log.info("Created snapshot with IVF_FLAT index")
 
         # Restore snapshot 1 (HNSW)
-        job_id_1, _ = self.restore_snapshot(client, snapshot_name_1, restored_collection_name_1)
+        job_id_1, _ = self.restore_snapshot(client, snapshot_name_1, restored_collection_name_1,
+                                                  source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id_1)
 
         # Restore snapshot 2 (IVF_FLAT)
-        job_id_2, _ = self.restore_snapshot(client, snapshot_name_2, restored_collection_name_2)
+        job_id_2, _ = self.restore_snapshot(client, snapshot_name_2, restored_collection_name_2,
+                                                  source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id_2)
 
         # Verify both collections can search
@@ -2577,8 +2829,8 @@ class TestMilvusClientSnapshotDataOperationsExtended(TestMilvusClientV2Base):
             assert len(res[0]) == 10, f"Search should return 10 results for {restored_name}"
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name_1)
-        self.drop_snapshot(client, snapshot_name_2)
+        self.drop_snapshot(client, snapshot_name_1, collection_name)
+        self.drop_snapshot(client, snapshot_name_2, collection_name)
         self.drop_collection(client, restored_collection_name_1)
         self.drop_collection(client, restored_collection_name_2)
 
@@ -2613,7 +2865,8 @@ class TestMilvusClientSnapshotDataOperationsExtended(TestMilvusClientV2Base):
         self.create_snapshot(client, collection_name, snapshot_name)
 
         # Restore
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify all data
@@ -2630,7 +2883,7 @@ class TestMilvusClientSnapshotDataOperationsExtended(TestMilvusClientV2Base):
         assert ids == list(range(total_rows)), "All IDs should be present"
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -2678,7 +2931,8 @@ class TestMilvusClientSnapshotDataOperationsExtended(TestMilvusClientV2Base):
         self.create_snapshot(client, collection_name, snapshot_name)
 
         # Restore
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify final state
@@ -2710,7 +2964,7 @@ class TestMilvusClientSnapshotDataOperationsExtended(TestMilvusClientV2Base):
         assert res[0]["varchar"] == "upserted_225"
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -2759,7 +3013,8 @@ class TestMilvusClientSnapshotDataOperationsExtended(TestMilvusClientV2Base):
         self.create_snapshot(client, collection_name, snapshot_name)
 
         # Restore
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify data
@@ -2775,7 +3030,7 @@ class TestMilvusClientSnapshotDataOperationsExtended(TestMilvusClientV2Base):
             assert res[0]["count(*)"] == 100, f"Category {cat} should have 100 rows"
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -2816,7 +3071,8 @@ class TestMilvusClientSnapshotDataOperationsExtended(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify dynamic field data
@@ -2836,12 +3092,11 @@ class TestMilvusClientSnapshotDataOperationsExtended(TestMilvusClientV2Base):
         assert res[0]["count(*)"] == 100
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
 
 
-@pytest.mark.skip(reason="pymilvus SDK does not yet support collection_name for snapshot APIs")
 class TestMilvusClientSnapshotConcurrency(TestMilvusClientV2Base):
     """
     Test concurrent operations for snapshot feature.
@@ -2896,7 +3151,7 @@ class TestMilvusClientSnapshotConcurrency(TestMilvusClientV2Base):
                 f"Unexpected error: {err}"
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_snapshot_captures_consistent_point_in_time(self):
@@ -2953,13 +3208,14 @@ class TestMilvusClientSnapshotConcurrency(TestMilvusClientV2Base):
         inserter.join()
 
         # Get snapshot info
-        info, _ = self.describe_snapshot(client, snapshot_name)
+        info, _ = self.describe_snapshot(client, snapshot_name, collection_name)
         log.info(f"Snapshot created at ts: {info.create_ts}")
         log.info(f"Total inserted: {insert_count[0]}")
 
         # Restore and verify consistency
         restored_name = cf.gen_unique_str(prefix + "_restored")
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         self.load_collection(client, restored_name)
@@ -2977,7 +3233,7 @@ class TestMilvusClientSnapshotConcurrency(TestMilvusClientV2Base):
             f"Should not exceed total inserted: {restored_count} > {insert_count[0]}"
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -3010,7 +3266,8 @@ class TestMilvusClientSnapshotConcurrency(TestMilvusClientV2Base):
         def restore_thread(idx):
             restored_name = cf.gen_unique_str(prefix + f"_concurrent_{idx}")
             try:
-                job_id, _ = self.restore_snapshot(client, snapshot_name, restored_name)
+                job_id, _ = self.restore_snapshot(client, snapshot_name, restored_name,
+                                                      source_collection_name=collection_name)
                 with lock:
                     job_ids.append(job_id)
                     restored_names.append(restored_name)
@@ -3034,6 +3291,6 @@ class TestMilvusClientSnapshotConcurrency(TestMilvusClientV2Base):
             assert res[0]["count(*)"] == 500, f"{name} should have 500 rows"
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         for name in restored_names:
             self.drop_collection(client, name)

--- a/tests/python_client/requirements.txt
+++ b/tests/python_client/requirements.txt
@@ -23,8 +23,8 @@ pytest-sugar==0.9.5
 pytest-random-order
 
 # pymilvus
-pymilvus==2.7.0rc194
-pymilvus[bulk_writer]==2.7.0rc194
+pymilvus==2.7.0rc197
+pymilvus[bulk_writer]==2.7.0rc197
 # for protobuf
 protobuf>=5.29.5
 


### PR DESCRIPTION
## Summary
- Refactor snapshot test cases to align with PR #48143 (bind snapshot lifecycle to collection)
- Update base class helpers: add `collection_name` to `drop_snapshot`/`describe_snapshot`, add `source_collection_name` to `restore_snapshot`
- Remove 18 `@pytest.mark.skip` decorators since pymilvus SDK now supports collection_name
- Update all snapshot API calls (58 drop, 4 describe, 46 restore) to pass required collection_name
- Rewrite `test_snapshot_list_after_drop_collection` → `test_snapshot_cascade_delete_on_drop_collection` for new cascade delete semantics
- Add 3 comprehensive data type tests: struct array + BM25 text match + MinHash, BFloat16Vector, all 8 array element types

## Test plan
- [x] L0: 2 passed (basic lifecycle + restore)
- [x] L1: 19 passed (invalid params + list/describe + restore state)
- [x] L2: 49 passed (data types, indexes, partitions, concurrency, data ops, collection properties)
- [x] All 70 tests pass against master-20260416-e87cc36e (the commit that introduced collection-scoped snapshots)