### PR TITLE
feat: add function field backfill - Part 6: segcore cpp part (#48809)

### DIFF
--- a/internal/core/src/common/QueryResult.h
+++ b/internal/core/src/common/QueryResult.h
@@ -353,6 +353,10 @@ struct SearchResult {
 using SearchResultPtr = std::shared_ptr<SearchResult>;
 using SearchResultOpt = std::optional<SearchResult>;
 
+[[nodiscard]] inline SearchResult
+make_empty_search_result(int64_t num_queries) {
+    return SearchResult{num_queries, 0, 0};
+}
 struct RetrieveResult {
     RetrieveResult() = default;
 

--- a/internal/core/src/common/Schema.cpp
+++ b/internal/core/src/common/Schema.cpp
@@ -122,13 +122,12 @@ Schema::ParseFrom(const milvus::proto::schema::CollectionSchema& schema_proto) {
 
     AssertInfo(schema->get_primary_field_id().has_value(),
                "primary key should be specified");
-
     // Parse external collection properties
     if (!schema_proto.external_source().empty()) {
         schema->set_external_source(schema_proto.external_source());
         schema->set_external_spec(schema_proto.external_spec());
     }
-
+    schema->set_do_physical_backfill(schema_proto.do_physical_backfill());
     return schema;
 }
 

--- a/internal/core/src/common/Schema.h
+++ b/internal/core/src/common/Schema.h
@@ -282,6 +282,11 @@ class Schema {
         this->schema_version_ = version;
     }
 
+    void
+    set_do_physical_backfill(bool do_physical_backfill) {
+        this->do_physical_backfill_ = do_physical_backfill;
+    }
+
     std::optional<FieldId>
     get_namespace_field_id() const {
         return this->namespace_field_id_opt_;
@@ -290,6 +295,11 @@ class Schema {
     uint64_t
     get_schema_version() const {
         return this->schema_version_;
+    }
+
+    bool
+    get_do_physical_backfill() const {
+        return this->do_physical_backfill_;
     }
 
     auto
@@ -314,6 +324,11 @@ class Schema {
                    "Cannot find field with field_id: " +
                        std::to_string(field_id.get()));
         return fields_.at(field_id);
+    }
+
+    bool
+    is_field_exist(FieldId field_id) const {
+        return fields_.find(field_id) != fields_.end();
     }
 
     FieldId
@@ -564,7 +579,6 @@ class Schema {
 
     // schema_version_, currently marked with update timestamp
     uint64_t schema_version_;
-
     // mmap settings
     bool has_mmap_setting_ = false;
     bool mmap_enabled_ = false;
@@ -572,6 +586,7 @@ class Schema {
 
     // Cache for struct_name -> first array field mapping (built during AddField)
     std::unordered_map<std::string, FieldId> struct_array_field_cache_;
+    bool do_physical_backfill_ = false;
 
     // warmup policy settings
     // Valid values: "disable", "sync", "async" (empty string means no setting)

--- a/internal/core/src/exec/operator/VectorSearchNode.cpp
+++ b/internal/core/src/exec/operator/VectorSearchNode.cpp
@@ -43,15 +43,6 @@
 namespace milvus {
 namespace exec {
 
-static milvus::SearchResult
-empty_search_result(int64_t num_queries) {
-    milvus::SearchResult final_result;
-    final_result.total_nq_ = num_queries;
-    final_result.unity_topK_ = 0;  // no result
-    final_result.total_data_cnt_ = 0;
-    return final_result;
-}
-
 PhyVectorSearchNode::PhyVectorSearchNode(
     int32_t operator_id,
     DriverContext* driverctx,

--- a/internal/core/src/exec/operator/VectorSearchNode.cpp
+++ b/internal/core/src/exec/operator/VectorSearchNode.cpp
@@ -139,7 +139,8 @@ PhyVectorSearchNode::GetOutput() {
         TargetBitmapView view(col_input->GetRawData(), col_input->size());
 
         if (view.all()) {
-            query_context_->set_search_result(empty_search_result(num_queries));
+            query_context_->set_search_result(
+                milvus::make_empty_search_result(num_queries));
             return input_;
         }
 

--- a/internal/core/src/query/ExecPlanNodeVisitor.cpp
+++ b/internal/core/src/query/ExecPlanNodeVisitor.cpp
@@ -34,15 +34,6 @@
 
 namespace milvus::query {
 
-static SearchResult
-empty_search_result(int64_t num_queries) {
-    SearchResult final_result;
-    final_result.total_nq_ = num_queries;
-    final_result.unity_topK_ = 0;  // no result
-    final_result.total_data_cnt_ = 0;
-    return final_result;
-}
-
 RowVectorPtr
 ExecPlanNodeVisitor::ExecuteTask(
     plan::PlanFragment& plan,
@@ -466,8 +457,8 @@ ExecPlanNodeVisitor::visit(VectorPlanNode& node) {
 
     // PreExecute: skip all calculation
     if (active_count == 0) {
-        search_result_opt_ =
-            empty_search_result(placeholder_group_->at(0).num_of_queries_);
+        search_result_opt_ = std::move(make_empty_search_result(
+            placeholder_group_->at(0).num_of_queries_));
         return;
     }
 

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -1254,11 +1254,6 @@ ChunkedSegmentSealedImpl::get_deleted_count() const {
     return deleted_record_.size();
 }
 
-const Schema&
-ChunkedSegmentSealedImpl::get_schema() const {
-    return *schema_;
-}
-
 void
 ChunkedSegmentSealedImpl::mask_with_delete(BitsetTypeView& bitset,
                                            int64_t ins_barrier,
@@ -1986,7 +1981,6 @@ ChunkedSegmentSealedImpl::ChunkedSegmentSealedImpl(
                            ->Register()),
       insert_record_(*schema, MAX_ROW_COUNT),
       segment_load_info_(milvus::proto::segcore::SegmentLoadInfo(), schema),
-      schema_(schema),
       id_(segment_id),
       col_index_meta_(index_meta),
       is_sorted_by_pk_(is_sorted_by_pk),
@@ -2003,6 +1997,7 @@ ChunkedSegmentSealedImpl::ChunkedSegmentSealedImpl(
                   callback);
           },
           segment_id) {
+    schema_ = std::move(schema);
 }
 
 ChunkedSegmentSealedImpl::~ChunkedSegmentSealedImpl() {
@@ -3370,7 +3365,8 @@ ChunkedSegmentSealedImpl::RemoveFieldFile(const FieldId field_id) {
 
 void
 ChunkedSegmentSealedImpl::LazyCheckSchema(SchemaPtr sch) {
-    if (sch->get_schema_version() > schema_->get_schema_version()) {
+    if (sch->get_schema_version() > schema_->get_schema_version() &&
+        !sch->get_do_physical_backfill()) {
         LOG_INFO(
             "lazy check schema segment {} found newer schema version, "
             "current "

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -273,9 +273,6 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         return insert_record_.timestamp_index_.get_max_timestamp();
     }
 
-    const Schema&
-    get_schema() const override;
-
     void
     pk_range(milvus::OpContext* op_ctx,
              proto::plan::OpType op,
@@ -1322,7 +1319,6 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
 
     SegmentLoadInfo segment_load_info_;
 
-    SchemaPtr schema_;
     int64_t id_;
     mutable folly::Synchronized<
         std::unordered_map<FieldId, std::shared_ptr<ChunkedColumnInterface>>>

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -1890,7 +1890,8 @@ SegmentGrowingImpl::BulkGetJsonData(
 
 void
 SegmentGrowingImpl::LazyCheckSchema(SchemaPtr sch) {
-    if (sch->get_schema_version() > schema_->get_schema_version()) {
+    if (sch->get_schema_version() > schema_->get_schema_version() &&
+        !sch->get_do_physical_backfill()) {
         LOG_INFO(
             "lazy check schema segment {} found newer schema version, "
             "current "

--- a/internal/core/src/segcore/SegmentGrowingImpl.h
+++ b/internal/core/src/segcore/SegmentGrowingImpl.h
@@ -188,11 +188,6 @@ class SegmentGrowingImpl : public SegmentGrowing {
         return chunk_mutex_;
     }
 
-    const Schema&
-    get_schema() const override {
-        return *schema_;
-    }
-
     // return count of index that has index, i.e., [0, num_chunk_index) have built index
     int64_t
     num_chunk_index(FieldId field_id) const {
@@ -382,12 +377,11 @@ class SegmentGrowingImpl : public SegmentGrowing {
                                .GetMmapChunkManager()
                                ->Register()),
           segcore_config_(segcore_config),
-          schema_(std::move(schema)),
           index_meta_(indexMeta),
           insert_record_(
-              *schema_, segcore_config.get_chunk_rows(), mmap_descriptor_),
+              *schema, segcore_config.get_chunk_rows(), mmap_descriptor_),
           indexing_record_(
-              *schema_, index_meta_, segcore_config_, &insert_record_),
+              *schema, index_meta_, segcore_config_, &insert_record_),
           id_(segment_id),
           deleted_record_(
               &insert_record_,
@@ -398,6 +392,7 @@ class SegmentGrowingImpl : public SegmentGrowing {
                   this->search_batch_pks(pks, timestamps, false, callback);
               },
               segment_id) {
+        schema_ = std::move(schema);
         this->CreateTextIndexes();
         this->InitializeArrayOffsets();
         this->UpdateResourceTracking();
@@ -459,14 +454,13 @@ class SegmentGrowingImpl : public SegmentGrowing {
 
     bool
     HasIndex(FieldId field_id) const override {
-        auto& field_meta = schema_->operator[](field_id);
-        if ((IsVectorDataType(field_meta.get_data_type()) ||
-             IsGeometryType(field_meta.get_data_type())) &&
-            indexing_record_.SyncDataWithIndex(field_id)) {
-            return true;
+        if (!schema_->is_field_exist(field_id)) {
+            return false;
         }
-
-        return false;
+        const auto& field_meta = schema_->operator[](field_id);
+        return (IsVectorDataType(field_meta.get_data_type()) ||
+                IsGeometryType(field_meta.get_data_type())) &&
+               indexing_record_.SyncDataWithIndex(field_id);
     }
 
     std::vector<PinWrapper<const index::IndexBase*>>
@@ -503,7 +497,7 @@ class SegmentGrowingImpl : public SegmentGrowing {
 
     bool
     HasFieldData(FieldId field_id) const override {
-        return true;
+        return insert_record_.is_data_exist(field_id);
     }
 
     bool
@@ -710,7 +704,6 @@ class SegmentGrowingImpl : public SegmentGrowing {
  private:
     storage::MmapChunkDescriptorPtr mmap_descriptor_ = nullptr;
     SegcoreConfig segcore_config_;
-    SchemaPtr schema_;
     IndexMetaPtr index_meta_;
 
     // inserted fields data and row_ids, timestamps

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -197,6 +197,14 @@ class SegmentInterface {
     HasFieldData(FieldId field_id) const = 0;
 
     virtual bool
+    HasIndex(FieldId field_id) const = 0;
+
+    bool
+    FieldAccessable(FieldId field_id) const {
+        return HasFieldData(field_id) || HasIndex(field_id);
+    }
+
+    virtual bool
     is_nullable(FieldId field_id) const = 0;
 
     virtual void
@@ -415,9 +423,6 @@ class SegmentInternalInterface : public SegmentInterface {
              const int64_t* offsets,
              int64_t size) const override;
 
-    virtual bool
-    HasIndex(FieldId field_id) const = 0;
-
     int64_t
     get_real_count() const override;
 
@@ -473,6 +478,12 @@ class SegmentInternalInterface : public SegmentInterface {
 
     virtual std::shared_ptr<index::JsonKeyStats>
     GetJsonStats(milvus::OpContext* op_ctx, FieldId field_id) const override;
+
+    const Schema&
+    get_schema() const override {
+        std::shared_lock lck(sch_mutex_);
+        return *schema_;
+    }
 
  public:
     // `query_offsets` is not null only for vector array (embedding list) search
@@ -712,7 +723,8 @@ class SegmentInternalInterface : public SegmentInterface {
 
  protected:
     // mutex protecting rw options on schema_
-    std::shared_mutex sch_mutex_;
+    mutable std::shared_mutex sch_mutex_;
+    SchemaPtr schema_;
 
     milvus::proto::segcore::SegmentLoadInfo load_info_;
 

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -325,28 +325,37 @@ AsyncSearch(CTraceContext c_trace,
 
             auto span = milvus::tracer::StartSpan("SegCoreSearch", &trace_ctx);
             milvus::tracer::SetRootSpan(span);
+            AssertInfo(phg_ptr != nullptr && !phg_ptr->empty(),
+                       "search requires non-empty placeholder group");
+            const int64_t num_queries = milvus::query::GetNumOfQueries(phg_ptr);
+            auto target_vector_field_id =
+                plan->plan_node_->search_info_.field_id_;
 
             segment->LazyCheckSchema(plan->schema_);
-
-            auto search_result = segment->Search(plan,
-                                                 phg_ptr,
-                                                 timestamp,
-                                                 cancel_token,
-                                                 consistency_level,
-                                                 collection_ttl,
-                                                 entity_ttl_physical_time_us,
-                                                 filter_only);
+            std::unique_ptr<milvus::SearchResult> ret;
+            if (!segment->FieldAccessable(target_vector_field_id)) {
+                ret = std::make_unique<milvus::SearchResult>(
+                    milvus::make_empty_search_result(num_queries));
+            } else {
+                ret = segment->Search(plan,
+                                      phg_ptr,
+                                      timestamp,
+                                      cancel_token,
+                                      consistency_level,
+                                      collection_ttl,
+                                      entity_ttl_physical_time_us,
+                                      filter_only);
+            }
             if (!filter_only &&
                 !milvus::PositivelyRelated(
                     plan->plan_node_->search_info_.metric_type_)) {
-                for (auto& dis : search_result->distances_) {
+                for (auto& dis : ret->distances_) {
                     dis *= -1;
                 }
             }
             span->End();
             milvus::tracer::CloseRootSpan();
-
-            return search_result.release();
+            return ret.release();
         });
 
     return static_cast<CFuture*>(static_cast<void*>(


### PR DESCRIPTION
## What this PR does

Adds C++ segcore changes required for function field physical backfill support. This is a split of #48139 (streaming node backfill) — C++ layer only.

### Changes
- Add `do_physical_backfill` flag to `Schema` parsed from proto, used to suppress `LazyCheckSchema` updates during backfill
- Add `is_field_exist()` helper to `Schema` for safe field existence check
- Move `schema_` member up to `SegmentInternalInterface` base class (shared mutex protection)
- Add `HasIndex()` / `FieldAccessable()` to `SegmentInterface` base
- `AsyncSearch` in `segment_c.cpp`: skip search and return empty result if target vector field not yet accessible (e.g. during backfill)
- Consolidate duplicate `empty_search_result` helpers → single `make_empty_search_result` in `QueryResult.h`

## Related

issue: #44444
pr: #48808

🤖 Generated with [Claude Code](https://claude.ai/code)