### PR TITLE
fix: [hotfix-2.6.14] fix NewCatalog call in TestRBAC_Restore_Wildcard

### DIFF
--- a/internal/metastore/kv/rootcoord/kv_catalog_test.go
+++ b/internal/metastore/kv/rootcoord/kv_catalog_test.go
@@ -2985,7 +2985,7 @@ func TestRBAC_Restore_Wildcard(t *testing.T) {
 	metaKV := etcdkv.NewEtcdKV(etcdCli, rootPath)
 	defer metaKV.RemoveWithPrefix(context.TODO(), "")
 	defer metaKV.Close()
-	c := NewCatalog(metaKV)
+	c := NewCatalog(metaKV, nil)
 
 	ctx := context.Background()
 


### PR DESCRIPTION
The cherry-pick in #49011 carried over the master signature NewCatalog(metaKV) but hotfix-2.6.14 still has the two-parameter NewCatalog(metaKV, ss). Passing nil as the SnapShotKV argument aligns with the existing TestRBAC_Backup/TestRBAC_Restore tests.

issue: #48963
pr: #49011