### PR TITLE
enhance: inject zap logger and gin context into hook plugin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/google/btree v1.1.2
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/klauspost/compress v1.18.0
-	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260422100939-04b6d9ff4644
+	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260424083539-440b7668b9e3
 	github.com/minio/minio-go/v7 v7.0.73
 	github.com/panjf2000/ants/v2 v2.11.3 // indirect
 	github.com/pingcap/log v1.1.1-0.20221015072633-39906604fb81 // indirect

--- a/go.sum
+++ b/go.sum
@@ -812,8 +812,10 @@ github.com/milvus-io/cgosymbolizer v0.0.0-20250318084424-114f4050c3a6 h1:YHMFI6L
 github.com/milvus-io/cgosymbolizer v0.0.0-20250318084424-114f4050c3a6/go.mod h1:DvXTE/K/RtHehxU8/GtDs4vFtfw64jJ3PaCnFri8CRg=
 github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b h1:TfeY0NxYxZzUfIfYe5qYDBzt4ZYRqzUjTR6CvUzjat8=
 github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b/go.mod h1:iwW+9cWfIzzDseEBCCeDSN5SD16Tidvy8cwQ7ZY8Qj4=
-github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260422100939-04b6d9ff4644 h1:05J2iqn8h56nkuxnOocyuNEcPv1u+u+1Rt+HKb0w34U=
-github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260422100939-04b6d9ff4644/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260323081523-53649783989c h1:fleNZQdnHHP1jSYCX+l3TbQrWcUKjFBeRyBgD+v1QXQ=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260323081523-53649783989c/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260424083539-440b7668b9e3 h1:TP+WKCGAz6HDtj57IDuYLlrbUQ1wmSizwCmxYZs0jxw=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260424083539-440b7668b9e3/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 h1:AMFGa4R4MiIpspGNG7Z948v4n35fFGB3RR3G/ry4FWs=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8/go.mod h1:mC1jAcsrzbxHt8iiaC+zU4b1ylILSosueou12R++wfY=
 github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 h1:+n/aFZefKZp7spd8DFdX7uMikMLXX4oubIzJF4kv/wI=

--- a/internal/distributed/proxy/httpserver/constant.go
+++ b/internal/distributed/proxy/httpserver/constant.go
@@ -89,6 +89,7 @@ const (
 
 const (
 	ContextRequest                = "request"
+	ContextResponse               = "response"
 	ContextUsername               = "username"
 	ContextToken                  = "token"
 	VectorCollectionsPath         = "/vector/collections"

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -522,7 +522,7 @@ func wrapperProxyWithLimit(ctx context.Context, ginCtx *gin.Context, req any, ch
 			return handler(ctx, req)
 		})
 	}
-	response, err := proxy.HookInterceptor(context.WithValue(ctx, hook.GinParamsKey, ginCtx.Keys), req, username.(string), fullMethod, forwardHandler)
+	response, err := proxy.HookInterceptor(context.WithValue(ctx, hook.GinParamsKey, ginCtx), req, username.(string), fullMethod, forwardHandler)
 	if err == nil {
 		status, ok := requestutil.GetStatusFromResponse(response)
 		if ok {

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -453,7 +453,7 @@ func checkAuthorizationV2(ctx context.Context, c *gin.Context, ignoreErr bool, r
 		if !ignoreErr {
 			HTTPReturn(c, http.StatusUnauthorized, gin.H{HTTPReturnCode: merr.Code(merr.ErrNeedAuthenticate), HTTPReturnMessage: merr.ErrNeedAuthenticate.Error()})
 		}
-		hookutil.GetExtension().ReportRefused(ctx, req, WrapErrorToResponse(merr.ErrNeedAuthenticate), nil, c.FullPath())
+		hookutil.GetExtension().ReportAction(ctx, req, WrapErrorToResponse(merr.ErrNeedAuthenticate), nil, c.FullPath(), hookutil.ActionAuthorize)
 		return merr.ErrNeedAuthenticate
 	}
 	_, authErr := proxy.PrivilegeInterceptor(ctx, req)
@@ -461,7 +461,7 @@ func checkAuthorizationV2(ctx context.Context, c *gin.Context, ignoreErr bool, r
 		if !ignoreErr {
 			HTTPReturn(c, http.StatusForbidden, gin.H{HTTPReturnCode: merr.Code(authErr), HTTPReturnMessage: authErr.Error()})
 		}
-		hookutil.GetExtension().ReportRefused(ctx, req, WrapErrorToResponse(authErr), nil, c.FullPath())
+		hookutil.GetExtension().ReportAction(ctx, req, WrapErrorToResponse(authErr), nil, c.FullPath(), hookutil.ActionAuthorize)
 		return authErr
 	}
 
@@ -499,7 +499,7 @@ func wrapperProxyWithLimit(ctx context.Context, ginCtx *gin.Context, req any, ch
 		_, err := CheckLimiter(ctx, req, pxy)
 		if err != nil {
 			log.Warn("high level restful api, fail to check limiter", zap.Error(err), zap.String("method", fullMethod))
-			hookutil.GetExtension().ReportRefused(ctx, req, WrapErrorToResponse(merr.ErrHTTPRateLimit), nil, ginCtx.FullPath())
+			hookutil.GetExtension().ReportAction(ctx, req, WrapErrorToResponse(merr.ErrHTTPRateLimit), nil, ginCtx.FullPath(), hookutil.ActionAuthorize)
 			HTTPAbortReturn(ginCtx, http.StatusOK, gin.H{
 				HTTPReturnCode:    merr.Code(merr.ErrHTTPRateLimit),
 				HTTPReturnMessage: merr.ErrHTTPRateLimit.Error() + ", error: " + err.Error(),
@@ -523,6 +523,9 @@ func wrapperProxyWithLimit(ctx context.Context, ginCtx *gin.Context, req any, ch
 		})
 	}
 	response, err := proxy.HookInterceptor(context.WithValue(ctx, hook.GinParamsKey, ginCtx), req, username.(string), fullMethod, forwardHandler)
+	if response != nil {
+		ginCtx.Set(ContextResponse, response)
+	}
 	if err == nil {
 		status, ok := requestutil.GetStatusFromResponse(response)
 		if ok {

--- a/internal/distributed/proxy/service.go
+++ b/internal/distributed/proxy/service.go
@@ -145,9 +145,9 @@ func authenticate(c *gin.Context) {
 		log.Ctx(context.TODO()).Warn("fail to verify apikey", zap.Error(err))
 	}
 
-	hookutil.GetExtension().ReportRefused(context.Background(), nil, &milvuspb.BoolResponse{
+	hookutil.GetExtension().ReportAction(context.Background(), nil, &milvuspb.BoolResponse{
 		Status: merr.Status(merr.ErrNeedAuthenticate),
-	}, nil, c.FullPath())
+	}, nil, c.FullPath(), hookutil.ActionAuthorize)
 	c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{mhttp.HTTPReturnCode: merr.Code(merr.ErrNeedAuthenticate), mhttp.HTTPReturnMessage: merr.ErrNeedAuthenticate.Error()})
 }
 

--- a/internal/proxy/accesslog/info/restful_info.go
+++ b/internal/proxy/accesslog/info/restful_info.go
@@ -80,6 +80,13 @@ func (i *RestfulInfo) TimeStart() string {
 	return i.start.Format(timeFormat)
 }
 
+// Start returns the request-entry timestamp captured by the access middleware.
+// Exposed so downstream consumers (e.g. audit plugins) can measure end-to-end
+// request latency instead of their own instantiation time.
+func (i *RestfulInfo) Start() time.Time {
+	return i.start
+}
+
 func (i *RestfulInfo) TimeEnd() string {
 	return i.params.TimeStamp.Format(timeFormat)
 }

--- a/internal/proxy/accesslog/util.go
+++ b/internal/proxy/accesslog/util.go
@@ -26,7 +26,9 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/hook"
 	"github.com/milvus-io/milvus/internal/proxy/accesslog/info"
+	"github.com/milvus-io/milvus/internal/util/hookutil"
 )
 
 type AccessKey struct{}
@@ -54,6 +56,11 @@ func AccessLogMiddleware(ctx *gin.Context) {
 	ctx.Next()
 	accessInfo.InitReq()
 	_globalL.Write(accessInfo)
+
+	// Plugin pulls req / status / err / path from the gin context — the
+	// middleware only needs to surface it through the stdlib context.
+	reqCtx := context.WithValue(ctx.Request.Context(), hook.GinParamsKey, ctx)
+	hookutil.GetExtension().ReportAction(reqCtx, nil, nil, nil, "", hookutil.ActionRestfulReturn)
 }
 
 func SetHTTPParams(ctx *gin.Context, p *gin.LogFormatterParams) {

--- a/internal/proxy/authentication_interceptor.go
+++ b/internal/proxy/authentication_interceptor.go
@@ -43,9 +43,9 @@ func GrpcAuthInterceptor(authFunc grpc_auth.AuthFunc) grpc.UnaryServerIntercepto
 			newCtx, err = authFunc(ctx)
 		}
 		if err != nil {
-			hookutil.GetExtension().ReportRefused(context.Background(), req, &milvuspb.BoolResponse{
+			hookutil.GetExtension().ReportAction(context.Background(), req, &milvuspb.BoolResponse{
 				Status: merr.Status(err),
-			}, err, info.FullMethod)
+			}, err, info.FullMethod, hookutil.ActionAuthorize)
 			return nil, err
 		}
 		return handler(newCtx, req)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -141,6 +141,7 @@ func NewProxy(ctx context.Context, _ dependency.Factory) (*Proxy, error) {
 	}
 	node.UpdateStateCode(commonpb.StateCode_Abnormal)
 	expr.Register("proxy", node)
+	hookutil.SetHook(connection.GetManager())
 	hookutil.InitOnceHook()
 	logutil.Logger(ctx).Debug("create a new Proxy instance", zap.Any("state", node.stateCode.Load()))
 	return node, nil

--- a/internal/util/hookutil/constant.go
+++ b/internal/util/hookutil/constant.go
@@ -39,4 +39,7 @@ var (
 	OpTypeSearch       = "search"
 	OpTypeHybridSearch = "hybrid_search"
 	OpTypeNodeID       = "node_id"
+
+	ActionAuthorize     = "Authorize"
+	ActionRestfulReturn = "RestfulReturn"
 )

--- a/internal/util/hookutil/default.go
+++ b/internal/util/hookutil/default.go
@@ -60,6 +60,6 @@ func (d DefaultExtension) Report(info any) int {
 	return 0
 }
 
-func (d DefaultExtension) ReportRefused(ctx context.Context, req interface{}, resp interface{}, err error, fullMethod string) error {
+func (d DefaultExtension) ReportAction(ctx context.Context, req interface{}, resp interface{}, err error, fullMethod string, action string) error {
 	return nil
 }

--- a/internal/util/hookutil/hook.go
+++ b/internal/util/hookutil/hook.go
@@ -44,6 +44,11 @@ type hookContainer struct {
 	hook hook.Hook
 }
 
+type hookSetter interface {
+	SetZapLogger(*zap.Logger)
+	SetClientInfoProvider(any)
+}
+
 // extensionContainer is Container to wrap hook.Extension interface
 // this struct is used to be stored in atomic.Value
 // since different type stored in it will cause panicking.
@@ -74,6 +79,7 @@ func initHook() error {
 	if err != nil {
 		return err
 	}
+
 	if err = hookVal.Init(paramtable.GetHookParams().SoConfig.GetValue()); err != nil {
 		return fmt.Errorf("fail to init configs for the hook, error: %s", err.Error())
 	}
@@ -98,6 +104,15 @@ func initHook() error {
 	storeExtension(extVal)
 
 	return nil
+}
+
+func SetHook(connectionManager any) {
+	hookVal := GetHook()
+	if setter, ok := hookVal.(hookSetter); ok {
+		setter.SetZapLogger(log.L())
+		setter.SetClientInfoProvider(connectionManager)
+		log.Info("hook setter injected")
+	}
 }
 
 func InitOnceHook() {

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/jolestar/go-commons-pool/v2 v2.1.2
 	github.com/json-iterator/go v1.1.13-0.20220915233716-71ac16282d12
 	github.com/klauspost/compress v1.18.0
-	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260422100939-04b6d9ff4644
+	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260424083539-440b7668b9e3
 	github.com/minio/minio-go/v7 v7.0.73
 	github.com/panjf2000/ants/v2 v2.11.3
 	github.com/prometheus/client_golang v1.20.5

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -515,8 +515,8 @@ github.com/milvus-io/cgosymbolizer v0.0.0-20250318084424-114f4050c3a6 h1:YHMFI6L
 github.com/milvus-io/cgosymbolizer v0.0.0-20250318084424-114f4050c3a6/go.mod h1:DvXTE/K/RtHehxU8/GtDs4vFtfw64jJ3PaCnFri8CRg=
 github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b h1:TfeY0NxYxZzUfIfYe5qYDBzt4ZYRqzUjTR6CvUzjat8=
 github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b/go.mod h1:iwW+9cWfIzzDseEBCCeDSN5SD16Tidvy8cwQ7ZY8Qj4=
-github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260422100939-04b6d9ff4644 h1:05J2iqn8h56nkuxnOocyuNEcPv1u+u+1Rt+HKb0w34U=
-github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260422100939-04b6d9ff4644/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260424083539-440b7668b9e3 h1:TP+WKCGAz6HDtj57IDuYLlrbUQ1wmSizwCmxYZs0jxw=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260424083539-440b7668b9e3/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=
 github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEpN+20RM=
 github.com/minio/minio-go/v7 v7.0.73 h1:qr2vi96Qm7kZ4v7LLebjte+MQh621fFWnv93p12htEo=


### PR DESCRIPTION
relate: https://github.com/milvus-io/milvus/issues/49326
## Summary

- Inject Milvus zap logger into hook plugin via `SetZapLogger` type assertion after plugin load, enabling the plugin to use Milvus's centralized logging
- Inject connection manager into hook plugin via `SetClientInfoProvider` type assertion, allowing the plugin to look up SDK info (sdk_type, sdk_version, host) for non-Connect requests by connection identifier
- Pass `*gin.Context` directly via `GinParamsKey` instead of `ginCtx.Keys` map, enabling the hook plugin to access `ClientIP()`, `FullPath()`, `GetHeader()` and other gin context methods for RESTful requests