### PR TITLE
enhance: rewrite keyLockDispatcher with per-key queues and semaphore backpressure

### DIFF
--- a/internal/flushcommon/syncmgr/key_lock_dispatcher.go
+++ b/internal/flushcommon/syncmgr/key_lock_dispatcher.go
@@ -80,7 +80,7 @@ func (d *keyLockDispatcher[K]) Submit(ctx context.Context, key K, t Task, callba
 	}
 
 	metrics.WALFlusherSyncDispatcherTaskTotal.WithLabelValues(nodeID).Inc()
-	metrics.WALFlusherSyncDispatcherPending.WithLabelValues(nodeID).Inc()
+	metrics.WALFlusherSyncDispatcherPendingTasks.WithLabelValues(nodeID).Inc()
 
 	pt := &pendingTask{
 		ctx:       ctx,
@@ -152,7 +152,7 @@ func (d *keyLockDispatcher[K]) dispatchLocked(key K, pt *pendingTask) {
 			close(pt.resultCh)
 
 			d.semaphore.Release()
-			metrics.WALFlusherSyncDispatcherPending.WithLabelValues(paramtable.GetStringNodeID()).Dec()
+			metrics.WALFlusherSyncDispatcherPendingTasks.WithLabelValues(paramtable.GetStringNodeID()).Dec()
 
 			d.mu.Lock()
 			d.inFlight[key] = false
@@ -213,7 +213,7 @@ func (d *keyLockDispatcher[K]) Close() {
 			pt.resultCh <- err
 			close(pt.resultCh)
 			d.semaphore.Release()
-			metrics.WALFlusherSyncDispatcherPending.WithLabelValues(nodeID).Dec()
+			metrics.WALFlusherSyncDispatcherPendingTasks.WithLabelValues(nodeID).Dec()
 		}
 		delete(d.queues, key)
 	}

--- a/internal/flushcommon/syncmgr/key_lock_dispatcher.go
+++ b/internal/flushcommon/syncmgr/key_lock_dispatcher.go
@@ -4,9 +4,12 @@ import (
 	"container/list"
 	"context"
 	"sync"
+	"time"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
+	"github.com/milvus-io/milvus/pkg/v2/metrics"
 	"github.com/milvus-io/milvus/pkg/v2/util/conc"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/syncutil"
 )
 
@@ -26,6 +29,7 @@ type pendingTask struct {
 	task      Task
 	callbacks []func(error) error
 	resultCh  chan error // buffered(1); result sent then channel closed on completion
+	enqueueAt time.Time  // for queue duration metric
 }
 
 // keyLockDispatcher provides per-key serial execution with cross-key concurrency.
@@ -65,6 +69,8 @@ func newKeyLockDispatcher[K comparable](maxParallel int) *keyLockDispatcher[K] {
 // sync throughput cannot keep up with the write rate. The caller can cancel via
 // ctx to unblock during shutdown.
 func (d *keyLockDispatcher[K]) Submit(ctx context.Context, key K, t Task, callbacks ...func(error) error) *conc.Future[struct{}] {
+	nodeID := paramtable.GetStringNodeID()
+
 	// Backpressure: acquire a semaphore slot. Blocks if all slots are taken.
 	// Returns early if ctx is canceled (e.g. during shutdown).
 	if err := d.semaphore.Acquire(ctx); err != nil {
@@ -73,11 +79,15 @@ func (d *keyLockDispatcher[K]) Submit(ctx context.Context, key K, t Task, callba
 		})
 	}
 
+	metrics.WALFlusherSyncDispatcherTaskTotal.WithLabelValues(nodeID).Inc()
+	metrics.WALFlusherSyncDispatcherPending.WithLabelValues(nodeID).Inc()
+
 	pt := &pendingTask{
 		ctx:       ctx,
 		task:      t,
 		callbacks: callbacks,
 		resultCh:  make(chan error, 1),
+		enqueueAt: time.Now(),
 	}
 
 	// Create a Future that resolves when the task completes.
@@ -142,6 +152,7 @@ func (d *keyLockDispatcher[K]) dispatchLocked(key K, pt *pendingTask) {
 			close(pt.resultCh)
 
 			d.semaphore.Release()
+			metrics.WALFlusherSyncDispatcherPending.WithLabelValues(paramtable.GetStringNodeID()).Dec()
 
 			d.mu.Lock()
 			d.inFlight[key] = false
@@ -159,10 +170,15 @@ func (d *keyLockDispatcher[K]) dispatchLocked(key K, pt *pendingTask) {
 	// release its slot, allowing the goroutine's Submit to proceed.
 	go func() {
 		f := d.workerPool.Submit(func() (struct{}, error) {
+			nodeID := paramtable.GetStringNodeID()
+			metrics.WALFlusherSyncDispatcherQueueDuration.WithLabelValues(nodeID).Observe(time.Since(pt.enqueueAt).Seconds())
+
+			startTime := time.Now()
 			err := pt.task.Run(pt.ctx)
 			for _, cb := range pt.callbacks {
 				err = cb(err)
 			}
+			metrics.WALFlusherSyncDispatcherExecuteDuration.WithLabelValues(nodeID).Observe(time.Since(startTime).Seconds())
 			onComplete(err)
 			return struct{}{}, err
 		})
@@ -185,6 +201,7 @@ func (d *keyLockDispatcher[K]) dispatchLocked(key K, pt *pendingTask) {
 // pending Future with context.Canceled. Should be called after the worker pool
 // has been released to clean up tasks that were never dispatched.
 func (d *keyLockDispatcher[K]) Close() {
+	nodeID := paramtable.GetStringNodeID()
 	err := context.Canceled
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -196,6 +213,7 @@ func (d *keyLockDispatcher[K]) Close() {
 			pt.resultCh <- err
 			close(pt.resultCh)
 			d.semaphore.Release()
+			metrics.WALFlusherSyncDispatcherPending.WithLabelValues(nodeID).Dec()
 		}
 		delete(d.queues, key)
 	}

--- a/internal/flushcommon/syncmgr/key_lock_dispatcher.go
+++ b/internal/flushcommon/syncmgr/key_lock_dispatcher.go
@@ -1,11 +1,13 @@
 package syncmgr
 
 import (
+	"container/list"
 	"context"
+	"sync"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/conc"
-	"github.com/milvus-io/milvus/pkg/v2/util/lock"
+	"github.com/milvus-io/milvus/pkg/v2/util/syncutil"
 )
 
 type Task interface {
@@ -18,30 +20,188 @@ type Task interface {
 	IsFlush() bool
 }
 
+// pendingTask wraps a task queued for execution.
+type pendingTask struct {
+	ctx       context.Context
+	task      Task
+	callbacks []func(error) error
+	resultCh  chan error // buffered(1); result sent then channel closed on completion
+}
+
+// keyLockDispatcher provides per-key serial execution with cross-key concurrency.
+//
+// For each key, tasks are queued in FIFO order and executed one at a time.
+// Different keys execute concurrently up to the worker pool capacity.
+// A semaphore limits total pending (queued + in-flight) tasks to provide backpressure.
 type keyLockDispatcher[K comparable] struct {
-	keyLock    *lock.KeyLock[K]
+	mu         sync.Mutex
+	queues     map[K]*list.List // per-key FIFO queue of *pendingTask
+	inFlight   map[K]bool       // true if a task for this key is currently running
 	workerPool *conc.Pool[struct{}]
+	semaphore  *syncutil.Semaphore
 }
 
 func newKeyLockDispatcher[K comparable](maxParallel int) *keyLockDispatcher[K] {
-	dispatcher := &keyLockDispatcher[K]{
-		workerPool: conc.NewPool[struct{}](maxParallel, conc.WithPreAlloc(false)),
-		keyLock:    lock.NewKeyLock[K](),
+	semCap := maxParallel * 2
+	if semCap < 4 {
+		semCap = 4
 	}
-	return dispatcher
+	return &keyLockDispatcher[K]{
+		queues:     make(map[K]*list.List),
+		inFlight:   make(map[K]bool),
+		workerPool: conc.NewPool[struct{}](maxParallel, conc.WithPreAlloc(false)),
+		semaphore:  syncutil.NewSemaphore(semCap),
+	}
 }
 
+// Submit enqueues a task for the given key and returns a Future.
+//
+// If no task for this key is currently in-flight, the task is dispatched to the
+// worker pool immediately. Otherwise it is queued and will be dispatched when
+// the current in-flight task for this key completes.
+//
+// Backpressure: blocks the caller when total pending tasks reach the semaphore
+// capacity. This is the mechanism that slows down the pipeline goroutine when
+// sync throughput cannot keep up with the write rate. The caller can cancel via
+// ctx to unblock during shutdown.
 func (d *keyLockDispatcher[K]) Submit(ctx context.Context, key K, t Task, callbacks ...func(error) error) *conc.Future[struct{}] {
-	d.keyLock.Lock(key)
+	// Backpressure: acquire a semaphore slot. Blocks if all slots are taken.
+	// Returns early if ctx is canceled (e.g. during shutdown).
+	if err := d.semaphore.Acquire(ctx); err != nil {
+		return conc.Go(func() (struct{}, error) {
+			return struct{}{}, err
+		})
+	}
 
-	return d.workerPool.Submit(func() (struct{}, error) {
-		defer d.keyLock.Unlock(key)
-		err := t.Run(ctx)
+	pt := &pendingTask{
+		ctx:       ctx,
+		task:      t,
+		callbacks: callbacks,
+		resultCh:  make(chan error, 1),
+	}
 
-		for _, callback := range callbacks {
-			err = callback(err)
-		}
-
+	// Create a Future that resolves when the task completes.
+	// The goroutine spawned by conc.Go is parked on resultCh until the task
+	// finishes. The number of such goroutines is bounded by the semaphore capacity.
+	future := conc.Go(func() (struct{}, error) {
+		err := <-pt.resultCh
 		return struct{}{}, err
 	})
+
+	d.mu.Lock()
+	q, ok := d.queues[key]
+	if !ok {
+		q = list.New()
+		d.queues[key] = q
+	}
+	q.PushBack(pt)
+	d.tryDrainLocked(key)
+	d.mu.Unlock()
+
+	return future
+}
+
+// tryDrainLocked dispatches the next queued task for key if no task is in-flight.
+// Must be called with d.mu held.
+func (d *keyLockDispatcher[K]) tryDrainLocked(key K) {
+	if d.inFlight[key] {
+		return
+	}
+	q, ok := d.queues[key]
+	if !ok || q.Len() == 0 {
+		delete(d.queues, key)
+		delete(d.inFlight, key)
+		return
+	}
+
+	elem := q.Front()
+	q.Remove(elem)
+	if q.Len() == 0 {
+		delete(d.queues, key)
+	}
+
+	pt := elem.Value.(*pendingTask)
+	d.inFlight[key] = true
+
+	d.dispatchLocked(key, pt)
+}
+
+// dispatchLocked submits a task to the worker pool.
+// Must be called with d.mu held. Uses a goroutine to avoid deadlock when called
+// from within a worker's completion path (the current worker hasn't returned to
+// the pool yet, so a direct workerPool.Submit would block waiting for a free slot).
+//
+// The cleanup logic (notify resultCh, release semaphore, reset inFlight, drain queue)
+// is guarded by sync.Once to handle the race between normal task completion and pool
+// rejection (e.g., during shutdown). Both paths call onComplete; only the first wins.
+func (d *keyLockDispatcher[K]) dispatchLocked(key K, pt *pendingTask) {
+	var once sync.Once
+	onComplete := func(err error) {
+		once.Do(func() {
+			pt.resultCh <- err
+			close(pt.resultCh)
+
+			d.semaphore.Release()
+
+			d.mu.Lock()
+			d.inFlight[key] = false
+			d.tryDrainLocked(key)
+			d.mu.Unlock()
+		})
+	}
+
+	// Must use a goroutine for workerPool.Submit to avoid deadlock.
+	// tryDrainLocked → dispatchLocked is called from within a pool worker's
+	// onComplete callback, so the current worker has not yet returned its slot.
+	// A direct workerPool.Submit here would block waiting for a free slot,
+	// but that slot cannot be freed until this function returns — deadlock.
+	// By spawning a goroutine, the current worker function can return and
+	// release its slot, allowing the goroutine's Submit to proceed.
+	go func() {
+		f := d.workerPool.Submit(func() (struct{}, error) {
+			err := pt.task.Run(pt.ctx)
+			for _, cb := range pt.callbacks {
+				err = cb(err)
+			}
+			onComplete(err)
+			return struct{}{}, err
+		})
+
+		// Detect pool rejection (e.g., pool closed during shutdown).
+		// When the pool rejects a submission, it closes f's channel synchronously
+		// before Submit returns, so a non-blocking receive succeeds immediately.
+		// When the pool accepts, f's channel is still open (closed only after the
+		// task function completes), so the default branch is taken and this
+		// goroutine exits without blocking.
+		select {
+		case <-f.Inner():
+			onComplete(f.Err())
+		default:
+		}
+	}()
+}
+
+// Close drains all remaining queued tasks across all keys, notifying each
+// pending Future with context.Canceled. Should be called after the worker pool
+// has been released to clean up tasks that were never dispatched.
+func (d *keyLockDispatcher[K]) Close() {
+	err := context.Canceled
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for key, q := range d.queues {
+		for q.Len() > 0 {
+			elem := q.Front()
+			q.Remove(elem)
+			pt := elem.Value.(*pendingTask)
+			pt.resultCh <- err
+			close(pt.resultCh)
+			d.semaphore.Release()
+		}
+		delete(d.queues, key)
+	}
+}
+
+// Pending returns the total number of pending tasks (queued + in-flight).
+func (d *keyLockDispatcher[K]) Pending() int {
+	return d.semaphore.Current()
 }

--- a/internal/flushcommon/syncmgr/key_lock_dispatcher_test.go
+++ b/internal/flushcommon/syncmgr/key_lock_dispatcher_test.go
@@ -2,9 +2,11 @@ package syncmgr
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/atomic"
 )
@@ -13,65 +15,189 @@ type KeyLockDispatcherSuite struct {
 	suite.Suite
 }
 
-func (s *KeyLockDispatcherSuite) TestKeyLock() {
+// TestSameKeySerial verifies that tasks with the same key execute serially.
+func (s *KeyLockDispatcherSuite) TestSameKeySerial() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	d := newKeyLockDispatcher[int64](2)
 
-	done := make(chan struct{})
+	blocker := make(chan struct{})
 	t1 := NewMockTask(s.T())
 	t1.EXPECT().Run(ctx).Run(func(_ context.Context) {
-		<-done
+		<-blocker
 	}).Return(nil)
+
+	t2Started := atomic.NewBool(false)
 	t2 := NewMockTask(s.T())
-	t2.EXPECT().Run(ctx).Return(nil)
+	t2.EXPECT().Run(ctx).Run(func(_ context.Context) {
+		t2Started.Store(true)
+	}).Return(nil)
 
-	sig := atomic.NewBool(false)
+	// Submit both tasks for key=1. Submit returns immediately (non-blocking).
+	f1 := d.Submit(ctx, 1, t1)
+	f2 := d.Submit(ctx, 1, t2)
 
-	d.Submit(ctx, 1, t1)
+	// t2 must not start while t1 is still running (same key).
+	time.Sleep(50 * time.Millisecond)
+	s.False(t2Started.Load(), "task 2 must not start before task 1 completes")
 
-	go func() {
-		future := d.Submit(ctx, 1, t2)
-		future.Await()
-		sig.Store(true)
-	}()
+	// Complete t1.
+	close(blocker)
+	_, err := f1.Await()
+	s.NoError(err)
 
-	s.False(sig.Load(), "task 2 will never be submit before task 1 done")
-
-	close(done)
-
-	s.Eventually(sig.Load, time.Second, time.Millisecond*100)
+	// t2 should now complete.
+	_, err = f2.Await()
+	s.NoError(err)
+	s.True(t2Started.Load())
 }
 
-func (s *KeyLockDispatcherSuite) TestCap() {
+// TestCrossKeyConcurrent verifies that tasks with different keys run concurrently.
+func (s *KeyLockDispatcherSuite) TestCrossKeyConcurrent() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	d := newKeyLockDispatcher[int64](1)
+	d := newKeyLockDispatcher[int64](4)
+
+	blocker1 := make(chan struct{})
+	blocker2 := make(chan struct{})
+
+	t1Started := atomic.NewBool(false)
+	t2Started := atomic.NewBool(false)
 
 	t1 := NewMockTask(s.T())
-	t2 := NewMockTask(s.T())
-
-	done := make(chan struct{})
 	t1.EXPECT().Run(ctx).Run(func(_ context.Context) {
-		<-done
+		t1Started.Store(true)
+		<-blocker1
 	}).Return(nil)
-	t2.EXPECT().Run(ctx).Return(nil)
-	sig := atomic.NewBool(false)
+
+	t2 := NewMockTask(s.T())
+	t2.EXPECT().Run(ctx).Run(func(_ context.Context) {
+		t2Started.Store(true)
+		<-blocker2
+	}).Return(nil)
 
 	d.Submit(ctx, 1, t1)
+	d.Submit(ctx, 2, t2)
 
+	// Both tasks should be running concurrently.
+	s.Eventually(func() bool { return t1Started.Load() && t2Started.Load() },
+		time.Second, 10*time.Millisecond,
+		"tasks with different keys must run concurrently")
+
+	close(blocker1)
+	close(blocker2)
+}
+
+// TestSemaphoreBackpressure verifies that Submit blocks when pending tasks reach the limit.
+func (s *KeyLockDispatcherSuite) TestSemaphoreBackpressure() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Pool size 1, semaphore capacity = max(1*2, 4) = 4.
+	// Use same key so tasks queue internally (only 1 pool worker needed at a time).
+	d := newKeyLockDispatcher[int64](1)
+	semCap := d.semaphore.Cap()
+
+	blocker := make(chan struct{})
+
+	// Submit semCap tasks for the same key. First runs, rest queue internally.
+	for i := 0; i < semCap; i++ {
+		t := NewMockTask(s.T())
+		t.EXPECT().Run(mock.Anything).Run(func(_ context.Context) {
+			<-blocker
+		}).Return(nil).Maybe()
+		d.Submit(ctx, 1, t)
+	}
+
+	// Next Submit must block (semaphore full).
+	extraTask := NewMockTask(s.T())
+	extraTask.EXPECT().Run(mock.Anything).Run(func(_ context.Context) {
+		<-blocker
+	}).Return(nil).Maybe()
+
+	submitted := atomic.NewBool(false)
 	go func() {
-		future := d.Submit(ctx, 2, t2)
-		future.Await()
-
-		sig.Store(true)
+		d.Submit(ctx, 1, extraTask)
+		submitted.Store(true)
 	}()
 
-	s.False(sig.Load(), "task 2 will never be submit before task 1 done")
+	time.Sleep(100 * time.Millisecond)
+	s.False(submitted.Load(), "submit must block when semaphore is full")
 
-	close(done)
+	// Release tasks to free semaphore slots.
+	close(blocker)
 
-	s.Eventually(sig.Load, time.Second, time.Millisecond*100)
+	s.Eventually(submitted.Load, 5*time.Second, 10*time.Millisecond,
+		"submit must unblock after tasks complete")
+}
+
+// TestCallbackPropagation verifies callbacks are called and errors propagated.
+func (s *KeyLockDispatcherSuite) TestCallbackPropagation() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	d := newKeyLockDispatcher[int64](2)
+
+	t := NewMockTask(s.T())
+	t.EXPECT().Run(ctx).Return(nil)
+
+	callbackCalled := atomic.NewBool(false)
+	f := d.Submit(ctx, 1, t, func(err error) error {
+		callbackCalled.Store(true)
+		return err
+	})
+
+	_, err := f.Await()
+	s.NoError(err)
+	s.True(callbackCalled.Load())
+}
+
+// TestMixedKeysConcurrency verifies a realistic scenario: multiple segments
+// syncing concurrently while same-segment syncs remain serial.
+func (s *KeyLockDispatcherSuite) TestMixedKeysConcurrency() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	d := newKeyLockDispatcher[int64](4)
+
+	var mu sync.Mutex
+	executionOrder := make([]int64, 0)
+
+	makeTask := func(key int64, delay time.Duration) *MockTask {
+		t := NewMockTask(s.T())
+		t.EXPECT().Run(ctx).Run(func(_ context.Context) {
+			time.Sleep(delay)
+			mu.Lock()
+			executionOrder = append(executionOrder, key)
+			mu.Unlock()
+		}).Return(nil)
+		return t
+	}
+
+	// Key 1: two serial tasks (slow, 100ms each)
+	f1a := d.Submit(ctx, 1, makeTask(1, 100*time.Millisecond))
+	f1b := d.Submit(ctx, 1, makeTask(1, 100*time.Millisecond))
+
+	// Key 2: one fast task (10ms)
+	f2 := d.Submit(ctx, 2, makeTask(2, 10*time.Millisecond))
+
+	// Wait for all to complete.
+	_, _ = f2.Await()
+	_, _ = f1a.Await()
+	_, _ = f1b.Await()
+
+	// Key 2 (10ms) should finish before key 1's second task (starts after 100ms).
+	mu.Lock()
+	defer mu.Unlock()
+	s.Len(executionOrder, 3)
+	key1Count := 0
+	for _, k := range executionOrder {
+		if k == 2 {
+			s.Less(key1Count, 2, "key 2 should finish before both key 1 tasks complete")
+			break
+		}
+		if k == 1 {
+			key1Count++
+		}
+	}
 }
 
 func TestKeyLockDispatcher(t *testing.T) {

--- a/internal/flushcommon/syncmgr/sync_manager.go
+++ b/internal/flushcommon/syncmgr/sync_manager.go
@@ -98,12 +98,18 @@ func (mgr *syncManager) resizeHandler(evt *config.Event) {
 			log.Warn("failed to parse new datanode syncmgr pool size", zap.Error(err))
 			return
 		}
-		err = mgr.workerPool.Resize(cpuNum * int(size))
+		newPoolSize := cpuNum * int(size)
+		err = mgr.workerPool.Resize(newPoolSize)
 		if err != nil {
 			log.Warn("failed to resize datanode syncmgr pool size", zap.String("key", evt.Key), zap.String("value", evt.Value), zap.Error(err))
 			return
 		}
-		log.Info("sync mgr pool size updated", zap.Int64("newSize", size))
+		semCap := newPoolSize * 2
+		if semCap < 4 {
+			semCap = 4
+		}
+		mgr.semaphore.SetCapacity(semCap)
+		log.Info("sync mgr pool size updated", zap.Int64("newSize", size), zap.Int("semaphoreCapacity", semCap))
 	}
 }
 
@@ -178,5 +184,8 @@ func (mgr *syncManager) TaskStatsJSON() string {
 func (mgr *syncManager) Close() error {
 	paramtable.Get().Unwatch(paramtable.Get().DataNodeCfg.MaxParallelSyncMgrTasksPerCPUCore.Key, mgr.handler)
 	timeout := paramtable.Get().CommonCfg.SyncTaskPoolReleaseTimeoutSeconds.GetAsDuration(time.Second)
-	return mgr.workerPool.ReleaseTimeout(timeout)
+	err := mgr.workerPool.ReleaseTimeout(timeout)
+	// Drain all remaining queued tasks that were never dispatched.
+	mgr.keyLockDispatcher.Close()
+	return err
 }

--- a/pkg/metrics/streaming_service_metrics.go
+++ b/pkg/metrics/streaming_service_metrics.go
@@ -484,8 +484,8 @@ var (
 
 	// Flusher sync dispatcher metrics.
 
-	WALFlusherSyncDispatcherPending = newWALGaugeVec(prometheus.GaugeOpts{
-		Name: "flusher_sync_dispatcher_pending_total",
+	WALFlusherSyncDispatcherPendingTasks = newWALGaugeVec(prometheus.GaugeOpts{
+		Name: "flusher_sync_dispatcher_pending_tasks",
 		Help: "Number of pending sync tasks (queued + in-flight) in the dispatcher",
 	})
 
@@ -610,7 +610,7 @@ func registerWAL(registry *prometheus.Registry) {
 	registry.MustRegister(WALDelegatorEmptyTimeTickFilteredTotal)
 	registry.MustRegister(WALDelegatorTsafeTimeTickUnfilteredTotal)
 	registry.MustRegister(WALFlusherEmptyTimeTickFilteredTotal)
-	registry.MustRegister(WALFlusherSyncDispatcherPending)
+	registry.MustRegister(WALFlusherSyncDispatcherPendingTasks)
 	registry.MustRegister(WALFlusherSyncDispatcherTaskTotal)
 	registry.MustRegister(WALFlusherSyncDispatcherQueueDuration)
 	registry.MustRegister(WALFlusherSyncDispatcherExecuteDuration)

--- a/pkg/metrics/streaming_service_metrics.go
+++ b/pkg/metrics/streaming_service_metrics.go
@@ -481,6 +481,30 @@ var (
 		Name: "flusher_empty_time_tick_filtered_total",
 		Help: "Total of empty time tick filtered",
 	}, WALChannelLabelName)
+
+	// Flusher sync dispatcher metrics.
+
+	WALFlusherSyncDispatcherPending = newWALGaugeVec(prometheus.GaugeOpts{
+		Name: "flusher_sync_dispatcher_pending_total",
+		Help: "Number of pending sync tasks (queued + in-flight) in the dispatcher",
+	})
+
+	WALFlusherSyncDispatcherTaskTotal = newWALCounterVec(prometheus.CounterOpts{
+		Name: "flusher_sync_dispatcher_task_total",
+		Help: "Total number of sync tasks submitted to the dispatcher",
+	})
+
+	WALFlusherSyncDispatcherQueueDuration = newWALHistogramVec(prometheus.HistogramOpts{
+		Name:    "flusher_sync_dispatcher_queue_duration_seconds",
+		Help:    "Time a sync task spends waiting in the per-key queue before execution starts",
+		Buckets: prometheus.ExponentialBucketsRange(0.001, 60, 15),
+	})
+
+	WALFlusherSyncDispatcherExecuteDuration = newWALHistogramVec(prometheus.HistogramOpts{
+		Name:    "flusher_sync_dispatcher_execute_duration_seconds",
+		Help:    "Time a sync task spends executing (including S3 upload and callbacks)",
+		Buckets: prometheus.ExponentialBucketsRange(0.001, 60, 15),
+	})
 )
 
 // RegisterStreamingServiceClient registers streaming service client metrics
@@ -586,6 +610,10 @@ func registerWAL(registry *prometheus.Registry) {
 	registry.MustRegister(WALDelegatorEmptyTimeTickFilteredTotal)
 	registry.MustRegister(WALDelegatorTsafeTimeTickUnfilteredTotal)
 	registry.MustRegister(WALFlusherEmptyTimeTickFilteredTotal)
+	registry.MustRegister(WALFlusherSyncDispatcherPending)
+	registry.MustRegister(WALFlusherSyncDispatcherTaskTotal)
+	registry.MustRegister(WALFlusherSyncDispatcherQueueDuration)
+	registry.MustRegister(WALFlusherSyncDispatcherExecuteDuration)
 }
 
 func newStreamingCoordGaugeVec(opts prometheus.GaugeOpts, extra ...string) *prometheus.GaugeVec {

--- a/pkg/util/syncutil/semaphore.go
+++ b/pkg/util/syncutil/semaphore.go
@@ -1,0 +1,98 @@
+package syncutil
+
+import (
+	"context"
+	"sync"
+)
+
+// Semaphore is a counting semaphore with dynamically adjustable capacity.
+//
+// It supports context-aware Acquire (can be canceled/timed out) and non-blocking
+// TryAcquire. The capacity can be changed at runtime via SetCapacity; waiters are
+// woken up when capacity increases.
+type Semaphore struct {
+	mu   sync.Mutex
+	cond *ContextCond
+
+	capacity int // maximum number of concurrent holders
+	current  int // number of currently held tokens
+}
+
+// NewSemaphore creates a semaphore with the given initial capacity.
+// Panics if capacity <= 0.
+func NewSemaphore(capacity int) *Semaphore {
+	if capacity <= 0 {
+		panic("syncutil: semaphore capacity must be positive")
+	}
+	s := &Semaphore{
+		capacity: capacity,
+	}
+	s.cond = NewContextCond(&s.mu)
+	return s
+}
+
+// Acquire blocks until a token is available or ctx is canceled.
+// Returns nil on success, or the context error on cancellation/timeout.
+func (s *Semaphore) Acquire(ctx context.Context) error {
+	s.mu.Lock()
+	for s.current >= s.capacity {
+		if err := s.cond.Wait(ctx); err != nil {
+			// cond.Wait does NOT re-acquire the lock on error.
+			return err
+		}
+	}
+	s.current++
+	s.mu.Unlock()
+	return nil
+}
+
+// TryAcquire attempts to acquire a token without blocking.
+// Returns true if a token was acquired, false if the semaphore is full.
+func (s *Semaphore) TryAcquire() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.current >= s.capacity {
+		return false
+	}
+	s.current++
+	return true
+}
+
+// Release returns a token to the semaphore, waking one waiter if any.
+func (s *Semaphore) Release() {
+	s.cond.LockAndBroadcast()
+	if s.current <= 0 {
+		s.mu.Unlock()
+		panic("syncutil: semaphore release without acquire")
+	}
+	s.current--
+	s.mu.Unlock()
+}
+
+// SetCapacity dynamically adjusts the semaphore capacity.
+// If the new capacity is larger, blocked Acquire calls may proceed.
+// If smaller, no tokens are revoked — the semaphore simply won't grant new
+// tokens until current holders release enough to drop below the new capacity.
+// Panics if capacity <= 0.
+func (s *Semaphore) SetCapacity(capacity int) {
+	if capacity <= 0 {
+		panic("syncutil: semaphore capacity must be positive")
+	}
+	s.cond.LockAndBroadcast()
+	s.capacity = capacity
+	s.mu.Unlock()
+}
+
+// Cap returns the current capacity.
+func (s *Semaphore) Cap() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.capacity
+}
+
+// Current returns the number of currently held tokens.
+func (s *Semaphore) Current() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.current
+}

--- a/pkg/util/syncutil/semaphore_test.go
+++ b/pkg/util/syncutil/semaphore_test.go
@@ -1,0 +1,159 @@
+package syncutil
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/atomic"
+)
+
+func TestSemaphoreAcquireRelease(t *testing.T) {
+	s := NewSemaphore(2)
+	assert.Equal(t, 2, s.Cap())
+	assert.Equal(t, 0, s.Current())
+
+	assert.NoError(t, s.Acquire(context.Background()))
+	assert.Equal(t, 1, s.Current())
+
+	assert.NoError(t, s.Acquire(context.Background()))
+	assert.Equal(t, 2, s.Current())
+
+	s.Release()
+	assert.Equal(t, 1, s.Current())
+
+	s.Release()
+	assert.Equal(t, 0, s.Current())
+}
+
+func TestSemaphoreTryAcquire(t *testing.T) {
+	s := NewSemaphore(1)
+
+	assert.True(t, s.TryAcquire())
+	assert.False(t, s.TryAcquire())
+
+	s.Release()
+	assert.True(t, s.TryAcquire())
+}
+
+func TestSemaphoreBlocksWhenFull(t *testing.T) {
+	s := NewSemaphore(1)
+	assert.NoError(t, s.Acquire(context.Background()))
+
+	acquired := atomic.NewBool(false)
+	go func() {
+		assert.NoError(t, s.Acquire(context.Background()))
+		acquired.Store(true)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	assert.False(t, acquired.Load(), "acquire must block when semaphore is full")
+
+	s.Release()
+	assert.Eventually(t, acquired.Load, time.Second, 10*time.Millisecond)
+}
+
+func TestSemaphoreContextCancellation(t *testing.T) {
+	s := NewSemaphore(1)
+	assert.NoError(t, s.Acquire(context.Background()))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	err := s.Acquire(ctx)
+	assert.Error(t, err)
+	assert.Equal(t, 1, s.Current(), "failed acquire must not change current count")
+
+	s.Release()
+}
+
+func TestSemaphoreSetCapacityIncrease(t *testing.T) {
+	s := NewSemaphore(1)
+	assert.NoError(t, s.Acquire(context.Background()))
+
+	// Semaphore is full. Start a goroutine that will block on Acquire.
+	acquired := atomic.NewBool(false)
+	go func() {
+		assert.NoError(t, s.Acquire(context.Background()))
+		acquired.Store(true)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	assert.False(t, acquired.Load())
+
+	// Increase capacity — blocked goroutine should proceed.
+	s.SetCapacity(2)
+	assert.Eventually(t, acquired.Load, time.Second, 10*time.Millisecond)
+	assert.Equal(t, 2, s.Current())
+}
+
+func TestSemaphoreSetCapacityDecrease(t *testing.T) {
+	s := NewSemaphore(3)
+	assert.NoError(t, s.Acquire(context.Background()))
+	assert.NoError(t, s.Acquire(context.Background()))
+
+	// Decrease capacity below current holders — no tokens revoked.
+	s.SetCapacity(1)
+	assert.Equal(t, 2, s.Current())
+	assert.Equal(t, 1, s.Cap())
+
+	// New acquires should block until current drops below new capacity.
+	acquired := atomic.NewBool(false)
+	go func() {
+		assert.NoError(t, s.Acquire(context.Background()))
+		acquired.Store(true)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	assert.False(t, acquired.Load())
+
+	// Release two tokens — now current=0 < capacity=1, goroutine should proceed.
+	s.Release()
+	s.Release()
+	assert.Eventually(t, acquired.Load, time.Second, 10*time.Millisecond)
+}
+
+func TestSemaphorePanicOnInvalidCapacity(t *testing.T) {
+	assert.Panics(t, func() { NewSemaphore(0) })
+	assert.Panics(t, func() { NewSemaphore(-1) })
+
+	s := NewSemaphore(1)
+	assert.Panics(t, func() { s.SetCapacity(0) })
+}
+
+func TestSemaphorePanicOnReleaseWithoutAcquire(t *testing.T) {
+	s := NewSemaphore(1)
+	assert.Panics(t, func() { s.Release() })
+}
+
+func TestSemaphoreConcurrent(t *testing.T) {
+	s := NewSemaphore(3)
+	maxConcurrent := atomic.NewInt32(0)
+	current := atomic.NewInt32(0)
+
+	done := make(chan struct{})
+	for i := 0; i < 20; i++ {
+		go func() {
+			assert.NoError(t, s.Acquire(context.Background()))
+			c := current.Add(1)
+			for {
+				old := maxConcurrent.Load()
+				if c <= old || maxConcurrent.CompareAndSwap(old, c) {
+					break
+				}
+			}
+			time.Sleep(5 * time.Millisecond)
+			current.Add(-1)
+			s.Release()
+			done <- struct{}{}
+		}()
+	}
+
+	for i := 0; i < 20; i++ {
+		<-done
+	}
+
+	assert.LessOrEqual(t, maxConcurrent.Load(), int32(3))
+	assert.Equal(t, 0, s.Current())
+}


### PR DESCRIPTION
Replace keyLock-based blocking with per-key FIFO queues so that Submit() is non-blocking to the caller. Different keys execute concurrently; same key tasks run serially via queue.

Key changes:
- Add syncutil.Semaphore with dynamic SetCapacity and context-aware Acquire for backpressure and graceful shutdown.
- Use goroutine in dispatchLocked to avoid deadlock when chaining tasks from within a worker's completion path.
- Guard cleanup with sync.Once to handle the race between normal task completion and pool rejection during shutdown.
- Explicit Close() drains all remaining queued tasks.
- resizeHandler adjusts both pool size and semaphore capacity.

issue: #49077
pr: #49098