### PR TITLE
fix: prevent nil pointer panic in go_client teardown when Milvus is unreachable

### DIFF
--- a/tests/go_client/base/milvus_client.go
+++ b/tests/go_client/base/milvus_client.go
@@ -80,6 +80,9 @@ func NewMilvusClient(ctx context.Context, cfg *client.ClientConfig) (*MilvusClie
 }
 
 func (mc *MilvusClient) Close(ctx context.Context) error {
+	if mc.Client == nil {
+		return nil
+	}
 	err := mc.Client.Close(ctx)
 	return err
 }

--- a/tests/go_client/testcases/helper/test_setup.go
+++ b/tests/go_client/testcases/helper/test_setup.go
@@ -97,6 +97,7 @@ func teardown() {
 	mc, err := base.NewMilvusClient(ctx, &client.ClientConfig{Address: GetAddr(), Username: GetUser(), Password: GetPassword()})
 	if err != nil {
 		log.Error("teardown failed to connect milvus with error", zap.Error(err))
+		return
 	}
 	defer mc.Close(ctx)
 


### PR DESCRIPTION
## Summary

- `teardown()` in `tests/go_client/testcases/helper/test_setup.go` did not return early on connection error, causing a SIGSEGV when subsequent calls hit a nil `Client`
- `MilvusClient.Close()` in `tests/go_client/base/milvus_client.go` now has a nil guard as a defensive measure

issue: #49111

## Changes

- `test_setup.go`: add `return` after logging connection error in `teardown()`
- `milvus_client.go`: add nil check in `MilvusClient.Close()` before calling inner client

## Test plan

- [ ] CI go-sdk pipeline passes without SIGSEGV when Milvus pod is slow to start
- [ ] No regression in normal teardown flow when Milvus is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)