### PR TITLE
test: update search iterator mul-db test to reflect SearchIteratorV2 behavior

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_search_iterator.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search_iterator.py
@@ -58,7 +58,9 @@ class TestMilvusClientSearchIteratorInValid(TestMilvusClientV2Base):
         """
         target: test search iterator(high level api) case about mul db
         method: create connection, collection, insert and search iterator
-        expected: search iterator error after switch to another db
+        expected: SearchIteratorV2 captures db_name at creation time, so switching db after
+                  iterator creation does NOT affect the iterator — it continues to return results
+                  from the original db without error.
         """
         batch_size = 20
         client = self._client()
@@ -66,31 +68,32 @@ class TestMilvusClientSearchIteratorInValid(TestMilvusClientV2Base):
         my_db = cf.gen_unique_str(prefix)
         self.create_database(client, my_db)
         self.using_database(client, my_db)
-        # 1. create collection
+        # 1. create collection in my_db
         self.create_collection(client, collection_name, default_dim, consistency_level="Bounded")
         collections = self.list_collections(client)[0]
         assert collection_name in collections
-        # 2. insert
+        # 2. insert into my_db collection
         rows = [{default_primary_key_field_name: i, default_vector_field_name: list(cf.gen_vectors(1, default_dim)[0]),
                  default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(default_nb)]
         self.insert(client, collection_name, rows)
         self.flush(client, collection_name)
         self.using_database(client, "default")
-        # 3. create collection
+        # 3. create same-named collection in default db
         self.create_collection(client, collection_name, default_dim, consistency_level="Bounded")
         collections = self.list_collections(client)[0]
         assert collection_name in collections
-        # 4. insert
+        # 4. insert into default db collection
         self.insert(client, collection_name, rows)
         self.flush(client, collection_name)
-        # 5. search_iterator
+        # 5. search_iterator: created on default db; switch to my_db after creation.
+        #    With SearchIteratorV2, db_name is captured at creation — the switch has no effect
+        #    and the iterator continues to return results from the default db collection.
         vectors_to_search = cf.gen_vectors(1, default_dim)
         search_params = {"params": {}}
-        error_msg = "alias or database may have been changed"
         self.search_iterator(client, collection_name, vectors_to_search, batch_size, search_params=search_params,
                              use_mul_db=True, another_db=my_db,
                              check_task=CheckTasks.check_search_iterator,
-                             check_items={ct.err_code: 1, ct.err_msg: error_msg})
+                             check_items={"batch_size": batch_size})
         self.release_collection(client, collection_name)
         self.drop_collection(client, collection_name)
 

--- a/tests/python_client/milvus_client_v2/test_milvus_client_range_search.py
+++ b/tests/python_client/milvus_client_v2/test_milvus_client_range_search.py
@@ -131,44 +131,43 @@ class TestRangeSearchCosineShared(TestMilvusClientV2Base):
     @pytest.mark.tags(CaseLabel.L2)
     def test_range_search_only_range_filter(self):
         """
-        target: test range search with only range filter
-        method: create connection, collection, insert and search
-        expected: range search successfully as normal search
+        target: test range search with only range_filter (no radius) is rejected
+        method: search with range_filter but no radius for COSINE/IP/L2 metrics
+        expected: search fails with ErrParameterInvalid; range_filter requires radius
+
+        Background: before fix #48915, range_filter without radius was silently ignored
+        by the C++ core and fell back to regular top-K search, returning results that
+        violated the range_filter constraint (e.g. self-match with distance=1.0 despite
+        range_filter=0.5). The proxy now rejects such requests explicitly.
         """
         client = self._client(alias=self.shared_alias)
 
-        # 2. get vectors that inserted into collection
+        # get vectors that inserted into collection
         query_res, _ = self.query(client, self.collection_name, filter=default_search_exp,
                                   output_fields=[ct.default_float_vec_field_name])
         search_vectors = [row[ct.default_float_vec_field_name] for row in query_res[:default_nq]]
 
-        # 3. range search with COSINE (only range_filter, no radius)
-        # With [-1,1] vectors, cosine distances span full range. range_filter=0.5 filters out high-similarity results.
-        range_search_params = {"metric_type": "COSINE",
-                               "params": {"range_filter": 0.5}}
-        search_res, _ = self.search(client, self.collection_name,
-                    data=search_vectors[:default_nq],
-                    anns_field=default_search_field,
-                    search_params=range_search_params,
-                    limit=default_limit,
-                    filter=default_search_exp)
-        # verify range filter is effective: all distances should be <= 0.5
-        for hits in search_res:
-            for hit in hits:
-                assert hit["distance"] <= 0.5
-        # 4. range search with IP (should fail - metric mismatch)
-        range_search_params = {"metric_type": "IP",
-                               "params": {"range_filter": 1}}
+        # range_filter without radius must be rejected (COSINE)
         self.search(client, self.collection_name,
                     data=search_vectors[:default_nq],
                     anns_field=default_search_field,
-                    search_params=range_search_params,
+                    search_params={"metric_type": "COSINE", "params": {"range_filter": 0.5}},
                     limit=default_limit,
                     filter=default_search_exp,
                     check_task=CheckTasks.err_res,
-                    check_items={ct.err_code: 65535,
-                                 ct.err_msg: "metric type not match: "
-                                             "invalid parameter[expected=COSINE][actual=IP]"})
+                    check_items={ct.err_code: 1100,
+                                 ct.err_msg: "range_filter requires radius to be set"})
+
+        # range_filter without radius must be rejected (IP)
+        self.search(client, self.collection_name,
+                    data=search_vectors[:default_nq],
+                    anns_field=default_search_field,
+                    search_params={"metric_type": "IP", "params": {"range_filter": 0.5}},
+                    limit=default_limit,
+                    filter=default_search_exp,
+                    check_task=CheckTasks.err_res,
+                    check_items={ct.err_code: 1100,
+                                 ct.err_msg: "range_filter requires radius to be set"})
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_range_search_radius_range_filter_not_in_params(self):


### PR DESCRIPTION
## What

Update `test_milvus_client_search_iterator_using_mul_db` to reflect the behavior of `SearchIteratorV2`.

## Root Cause

The test was written for `SearchIteratorV1`, which reads `db_name` from the connection context on each `next()` call. This meant calling `using_database()` after iterator creation would redirect subsequent `next()` calls to the new db, causing a collection-ID mismatch and the error `"alias or database may have been changed"`.

`SearchIteratorV2` (default since pymilvus 2.7.0rc185) captures `db_name` at creation time via `_generate_call_context(db_name=self._config.db_name)`. The captured context is baked into the iterator — `using_database()` called after creation has no effect on it. The iterator continues to return results from the original db, so the expected error never triggers.

This caused a pre-existing CI flake observed in build [#25680](https://jenkins-milvus-ci.milvus.io/job/MILVUS-CI-V2-PR-PIPELINES/job/milvus-e2e-pipeline-gcp/25680/).

## Fix

- Update the expected outcome from error to success
- Update `check_items` to verify the iterator returns results in the correct batch size
- Update docstring and inline comments to describe V2 semantics