### PR TITLE
enhance: [3.0] async reduce with cancellation and per-segment OpContext scoping

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -4590,12 +4590,15 @@ ChunkedSegmentSealedImpl::Load(milvus::tracer::TraceContext& trace_ctx,
 
 void
 ChunkedSegmentSealedImpl::FillTargetEntry(const query::Plan* plan,
-                                          SearchResult& results) const {
+                                          SearchResult& results,
+                                          milvus::OpContext* op_ctx) const {
     std::shared_lock lck(mutex_);
     AssertInfo(plan, "empty plan");
     auto size = results.distances_.size();
     AssertInfo(results.seg_offsets_.size() == size,
                "Size of result distances is not equal to size of ids");
+
+    segcore::CheckCancellation(op_ctx, get_segment_id(), "FillTargetEntry");
 
     // Try take() for external fields; fills output_fields_data_ for
     // external fields only. Non-external fields still go through
@@ -4604,18 +4607,27 @@ ChunkedSegmentSealedImpl::FillTargetEntry(const query::Plan* plan,
         TryTakeForSearch(plan, results.seg_offsets_.data(), size, results);
 
     std::unique_ptr<DataArray> field_data;
-    milvus::OpContext op_ctx;
+    // Per-call OpContext keeps storage_usage scoped to this segment;
+    // sharing op_ctx across segments would double-count bytes. See
+    // SegmentInternalInterface::FillPrimaryKeys for the same pattern.
+    milvus::OpContext local_ctx;
+    if (op_ctx != nullptr) {
+        local_ctx.cancellation_token = op_ctx->cancellation_token;
+        local_ctx.runtime_load_priority = op_ctx->runtime_load_priority;
+    }
     for (auto field_id : plan->target_entries_) {
         // Skip fields already filled by take
         if (used_take && results.output_fields_data_.count(field_id) > 0) {
             continue;
         }
+        segcore::CheckCancellation(
+            op_ctx, get_segment_id(), field_id.get(), "FillTargetEntry");
         auto& field_meta = plan->schema_->operator[](field_id);
         if (plan->schema_->get_dynamic_field_id().has_value() &&
             plan->schema_->get_dynamic_field_id().value() == field_id &&
             !plan->target_dynamic_fields_.empty()) {
             auto& target_dynamic_fields = plan->target_dynamic_fields_;
-            field_data = bulk_subscript(&op_ctx,
+            field_data = bulk_subscript(&local_ctx,
                                         field_id,
                                         results.seg_offsets_.data(),
                                         size,
@@ -4624,14 +4636,14 @@ ChunkedSegmentSealedImpl::FillTargetEntry(const query::Plan* plan,
             field_data = bulk_subscript_not_exist_field(field_meta, size);
         } else {
             field_data = bulk_subscript(
-                &op_ctx, field_id, results.seg_offsets_.data(), size);
+                &local_ctx, field_id, results.seg_offsets_.data(), size);
         }
         results.output_fields_data_[field_id] = std::move(field_data);
     }
     results.search_storage_cost_.scanned_remote_bytes +=
-        op_ctx.storage_usage.scanned_cold_bytes.load();
+        local_ctx.storage_usage.scanned_cold_bytes.load();
     results.search_storage_cost_.scanned_total_bytes +=
-        op_ctx.storage_usage.scanned_total_bytes.load();
+        local_ctx.storage_usage.scanned_total_bytes.load();
 }
 
 // ---- Shared helpers for TryTakeForRetrieve / TryTakeForSearch ----

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -4603,8 +4603,8 @@ ChunkedSegmentSealedImpl::FillTargetEntry(const query::Plan* plan,
     // Try take() for external fields; fills output_fields_data_ for
     // external fields only. Non-external fields still go through
     // bulk_subscript below.
-    bool used_take =
-        TryTakeForSearch(plan, results.seg_offsets_.data(), size, results);
+    bool used_take = TryTakeForSearch(
+        plan, results.seg_offsets_.data(), size, results, op_ctx);
 
     std::unique_ptr<DataArray> field_data;
     // Per-call OpContext keeps storage_usage scoped to this segment;
@@ -4880,7 +4880,14 @@ ChunkedSegmentSealedImpl::ExecuteTake(
     const std::vector<int64_t>& unique_offsets,
     const std::shared_ptr<std::vector<std::string>>& needed_columns,
     const char* caller_tag,
-    double& elapsed_ms) const {
+    double& elapsed_ms,
+    milvus::OpContext* op_ctx) const {
+    // reader_->take() issues remote reads and can take seconds under slow
+    // object storage. Bail out if the upstream reduce has already been
+    // cancelled so we don't waste IO on a doomed request.
+    segcore::CheckCancellation(
+        op_ctx, id_, fmt::format("ExecuteTake({})", caller_tag));
+
     // reader_->take() is NOT thread-safe — concurrent retrieve and search
     // workers may hit the same segment simultaneously under load. Also,
     // Reopen/ApplyLoadDiff can reassign reader_ under reader_mutex_ while a
@@ -4916,7 +4923,8 @@ ChunkedSegmentSealedImpl::TryTakeForRetrieve(
     const int64_t* offsets,
     int64_t size,
     bool ignore_non_pk,
-    bool fill_ids) const {
+    bool fill_ids,
+    milvus::OpContext* op_ctx) const {
     if (!schema_->is_external_collection() || size == 0 ||
         !use_take_for_output_) {
         return false;
@@ -4953,11 +4961,20 @@ ChunkedSegmentSealedImpl::TryTakeForRetrieve(
     auto ctx = BuildTakeContext(offsets, size);
 
     double take_elapsed_ms = 0;
-    auto table = ExecuteTake(
-        ctx.unique_offsets, needed_columns, "retrieve", take_elapsed_ms);
+    auto table = ExecuteTake(ctx.unique_offsets,
+                             needed_columns,
+                             "retrieve",
+                             take_elapsed_ms,
+                             op_ctx);
     if (!table) {
         return false;
     }
+
+    // Cancellation can become observable between reader_->take() returning
+    // and the Arrow Concatenate/NormalizeExternalArrow pass below, which
+    // can itself be expensive on wide result sets.
+    segcore::CheckCancellation(
+        op_ctx, id_, "TryTakeForRetrieve(pre-arrow-convert)");
 
     // Convert Arrow Table columns to DataArray results
     auto fields_data = results->mutable_fields_data();
@@ -5090,7 +5107,8 @@ bool
 ChunkedSegmentSealedImpl::TryTakeForSearch(const query::Plan* plan,
                                            const int64_t* seg_offsets,
                                            int64_t size,
-                                           SearchResult& results) const {
+                                           SearchResult& results,
+                                           milvus::OpContext* op_ctx) const {
     if (!schema_->is_external_collection() || size == 0 ||
         !use_take_for_output_) {
         return false;
@@ -5117,10 +5135,16 @@ ChunkedSegmentSealedImpl::TryTakeForSearch(const query::Plan* plan,
 
     double take_elapsed_ms = 0;
     auto table = ExecuteTake(
-        ctx.unique_offsets, needed_columns, "search", take_elapsed_ms);
+        ctx.unique_offsets, needed_columns, "search", take_elapsed_ms, op_ctx);
     if (!table) {
         return false;
     }
+
+    // Cancellation can become observable between reader_->take() returning
+    // and the Arrow Concatenate/NormalizeExternalArrow pass below, which
+    // can itself be expensive on wide result sets.
+    segcore::CheckCancellation(
+        op_ctx, id_, "TryTakeForSearch(pre-arrow-convert)");
 
     // Convert Arrow Table columns to DataArray and store in SearchResult
     for (size_t fi = 0; fi < take_field_ids.size(); fi++) {

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -4884,9 +4884,10 @@ ChunkedSegmentSealedImpl::ExecuteTake(
     milvus::OpContext* op_ctx) const {
     // reader_->take() issues remote reads and can take seconds under slow
     // object storage. Bail out if the upstream reduce has already been
-    // cancelled so we don't waste IO on a doomed request.
-    segcore::CheckCancellation(
-        op_ctx, id_, fmt::format("ExecuteTake({})", caller_tag));
+    // cancelled so we don't waste IO on a doomed request. caller_tag is a
+    // short static string ("search" / "retrieve"); pass it directly to
+    // avoid an extra fmt::format allocation on every call.
+    segcore::CheckCancellation(op_ctx, id_, caller_tag);
 
     // reader_->take() is NOT thread-safe — concurrent retrieve and search
     // workers may hit the same segment simultaneously under load. Also,

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -350,7 +350,8 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         const int64_t* offsets,
         int64_t size,
         bool ignore_non_pk,
-        bool fill_ids) const;
+        bool fill_ids,
+        milvus::OpContext* op_ctx = nullptr) const;
 
     // count of chunk that has raw data
     int64_t
@@ -490,7 +491,8 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     TryTakeForSearch(const query::Plan* plan,
                      const int64_t* seg_offsets,
                      int64_t size,
-                     SearchResult& results) const;
+                     SearchResult& results,
+                     milvus::OpContext* op_ctx = nullptr) const;
 
     // Shared helpers for TryTakeForRetrieve / TryTakeForSearch
     struct TakeContext {
@@ -510,12 +512,14 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                      int64_t size);
 
     // Calls reader_->take() with timing. Returns the table on success,
-    // or nullptr on failure (logs a warning).
+    // or nullptr on failure (logs a warning). Checks op_ctx for cancellation
+    // before invoking reader_->take(), which can do remote reads.
     std::shared_ptr<arrow::Table>
     ExecuteTake(const std::vector<int64_t>& unique_offsets,
                 const std::shared_ptr<std::vector<std::string>>& needed_columns,
                 const char* caller_tag,
-                double& elapsed_ms) const;
+                double& elapsed_ms,
+                milvus::OpContext* op_ctx = nullptr) const;
 
     void
     check_search(const query::Plan* plan) const override;

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -483,7 +483,8 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     // Uses existing vtable slot — no layout change.
     void
     FillTargetEntry(const query::Plan* plan,
-                    SearchResult& results) const override;
+                    SearchResult& results,
+                    milvus::OpContext* op_ctx = nullptr) const override;
 
     bool
     TryTakeForSearch(const query::Plan* plan,

--- a/internal/core/src/segcore/SegmentInterface.cpp
+++ b/internal/core/src/segcore/SegmentInterface.cpp
@@ -250,6 +250,10 @@ SegmentInternalInterface::Retrieve(tracer::TraceContext* trace_ctx,
 
     std::chrono::high_resolution_clock::time_point get_target_entry_start =
         std::chrono::high_resolution_clock::now();
+    // Carry the upstream cancel_token down into FillTargetEntry so the
+    // take()/Arrow-convert path can short-circuit on abort.
+    milvus::OpContext fte_op_ctx;
+    fte_op_ctx.cancellation_token = cancel_token;
     if (retrieve_results.field_data_.empty()) {
         FillTargetEntry(trace_ctx,
                         plan,
@@ -257,7 +261,8 @@ SegmentInternalInterface::Retrieve(tracer::TraceContext* trace_ctx,
                         retrieve_results.result_offsets_.data(),
                         retrieve_results.result_offsets_.size(),
                         ignore_non_pk,
-                        true);
+                        true,
+                        &fte_op_ctx);
     } else if (!plan->plan_node_->pipeline_field_ids_.empty()) {
         // Non-aggregation ORDER BY (single-project or two-project mode):
         // Pipeline output contains [pk, sort_cols, ..., SegmentOffsetFieldID].
@@ -436,15 +441,21 @@ SegmentInternalInterface::FillTargetEntry(
     const int64_t* offsets,
     int64_t size,
     bool ignore_non_pk,
-    bool fill_ids) const {
+    bool fill_ids,
+    milvus::OpContext* op_ctx) const {
     tracer::AutoSpan span("FillTargetEntry", tracer::GetRootSpan());
 
     // Fast path: use take() API for external tables with small result sets.
     // Use dynamic_cast to avoid adding new virtual methods (vtable layout
     // change causes SIGSEGV in cgo boundary).
     if (auto* chunked = dynamic_cast<const ChunkedSegmentSealedImpl*>(this)) {
-        if (chunked->TryTakeForRetrieve(
-                plan, results, offsets, size, ignore_non_pk, fill_ids)) {
+        if (chunked->TryTakeForRetrieve(plan,
+                                        results,
+                                        offsets,
+                                        size,
+                                        ignore_non_pk,
+                                        fill_ids,
+                                        op_ctx)) {
             return;
         }
     }
@@ -457,14 +468,23 @@ SegmentInternalInterface::FillTargetEntry(
         return pk_field_id.has_value() && pk_field_id.value() == field_id;
     };
 
-    milvus::OpContext op_ctx;
+    // Per-call OpContext keeps storage_usage scoped to this segment;
+    // sharing the caller's op_ctx across segments would double-count
+    // bytes. Inherit the caller's cancellation_token and load priority so
+    // in-loop cancellation still propagates.
+    milvus::OpContext local_ctx;
+    if (op_ctx != nullptr) {
+        local_ctx.cancellation_token = op_ctx->cancellation_token;
+        local_ctx.runtime_load_priority = op_ctx->runtime_load_priority;
+    }
     for (auto field_id : plan->field_ids_) {
         if (SystemProperty::Instance().IsSystem(field_id)) {
             auto system_type =
                 SystemProperty::Instance().GetSystemFieldType(field_id);
 
             FixedVector<int64_t> output(size);
-            bulk_subscript(&op_ctx, system_type, offsets, size, output.data());
+            bulk_subscript(
+                &local_ctx, system_type, offsets, size, output.data());
 
             auto data_array = std::make_unique<DataArray>();
             data_array->set_field_id(field_id.get());
@@ -487,7 +507,7 @@ SegmentInternalInterface::FillTargetEntry(
             !plan->target_dynamic_fields_.empty()) {
             auto& target_dynamic_fields = plan->target_dynamic_fields_;
             auto col = bulk_subscript(
-                &op_ctx, field_id, offsets, size, target_dynamic_fields);
+                &local_ctx, field_id, offsets, size, target_dynamic_fields);
             fields_data->AddAllocated(col.release());
             continue;
         }
@@ -496,7 +516,7 @@ SegmentInternalInterface::FillTargetEntry(
         if (!is_field_exist(field_id)) {
             col = bulk_subscript_not_exist_field(field_meta, size);
         } else {
-            col = bulk_subscript(&op_ctx, field_id, offsets, size);
+            col = bulk_subscript(&local_ctx, field_id, offsets, size);
         }
         // todo(SpadeA): consider vector array?
         if (field_meta.get_data_type() == DataType::ARRAY) {
@@ -543,23 +563,30 @@ SegmentInternalInterface::FillTargetEntry(
     // Add retrieve_storage_cost to results
     results->set_scanned_remote_bytes(
         results->scanned_remote_bytes() +
-        op_ctx.storage_usage.scanned_cold_bytes.load());
+        local_ctx.storage_usage.scanned_cold_bytes.load());
     results->set_scanned_total_bytes(
         results->scanned_total_bytes() +
-        op_ctx.storage_usage.scanned_total_bytes.load());
+        local_ctx.storage_usage.scanned_total_bytes.load());
 }
 
 std::unique_ptr<proto::segcore::RetrieveResults>
-SegmentInternalInterface::Retrieve(tracer::TraceContext* trace_ctx,
-                                   const query::RetrievePlan* Plan,
-                                   const int64_t* offsets,
-                                   int64_t size) const {
+SegmentInternalInterface::Retrieve(
+    tracer::TraceContext* trace_ctx,
+    const query::RetrievePlan* Plan,
+    const int64_t* offsets,
+    int64_t size,
+    const folly::CancellationToken& cancel_token) const {
     std::shared_lock lck(mutex_);
     tracer::AutoSpan span("RetrieveByOffsets", tracer::GetRootSpan());
     auto results = std::make_unique<proto::segcore::RetrieveResults>();
     std::chrono::high_resolution_clock::time_point get_target_entry_start =
         std::chrono::high_resolution_clock::now();
-    FillTargetEntry(trace_ctx, Plan, results, offsets, size, false, false);
+    // Carry the upstream cancel_token down into the take() + Arrow-convert
+    // path so RetrieveByOffsets on external fields can short-circuit.
+    milvus::OpContext fte_op_ctx;
+    fte_op_ctx.cancellation_token = cancel_token;
+    FillTargetEntry(
+        trace_ctx, Plan, results, offsets, size, false, false, &fte_op_ctx);
     std::chrono::high_resolution_clock::time_point get_target_entry_end =
         std::chrono::high_resolution_clock::now();
     double get_entry_cost = std::chrono::duration<double, std::micro>(

--- a/internal/core/src/segcore/SegmentInterface.cpp
+++ b/internal/core/src/segcore/SegmentInterface.cpp
@@ -50,7 +50,8 @@ namespace milvus::segcore {
 
 void
 SegmentInternalInterface::FillPrimaryKeys(const query::Plan* plan,
-                                          SearchResult& results) const {
+                                          SearchResult& results,
+                                          milvus::OpContext* op_ctx) const {
     std::shared_lock lck(mutex_);
     AssertInfo(plan, "empty plan");
     auto size = results.distances_.size();
@@ -66,21 +67,30 @@ SegmentInternalInterface::FillPrimaryKeys(const query::Plan* plan,
     AssertInfo(IsPrimaryKeyDataType(get_schema()[pk_field_id].get_data_type()),
                "Primary key field is not INT64 or VARCHAR type");
 
-    milvus::OpContext op_ctx;
-    auto field_data =
-        bulk_subscript(&op_ctx, pk_field_id, results.seg_offsets_.data(), size);
+    segcore::CheckCancellation(op_ctx, get_segment_id(), "FillPrimaryKeys");
+    // Use a per-call OpContext for storage_usage; sharing op_ctx across
+    // segments would make each segment's search_storage_cost_ accumulate
+    // every prior segment's bytes, inflating GetTotalStorageCost().
+    milvus::OpContext local_ctx;
+    if (op_ctx != nullptr) {
+        local_ctx.cancellation_token = op_ctx->cancellation_token;
+        local_ctx.runtime_load_priority = op_ctx->runtime_load_priority;
+    }
+    auto field_data = bulk_subscript(
+        &local_ctx, pk_field_id, results.seg_offsets_.data(), size);
     results.pk_type_ = DataType(field_data->type());
 
     ParsePksFromFieldData(results.primary_keys_, *field_data);
     results.search_storage_cost_.scanned_remote_bytes +=
-        op_ctx.storage_usage.scanned_cold_bytes.load();
+        local_ctx.storage_usage.scanned_cold_bytes.load();
     results.search_storage_cost_.scanned_total_bytes +=
-        op_ctx.storage_usage.scanned_total_bytes.load();
+        local_ctx.storage_usage.scanned_total_bytes.load();
 }
 
 void
 SegmentInternalInterface::FillTargetEntry(const query::Plan* plan,
-                                          SearchResult& results) const {
+                                          SearchResult& results,
+                                          milvus::OpContext* op_ctx) const {
     std::shared_lock lck(mutex_);
     AssertInfo(plan, "empty plan");
     auto size = results.distances_.size();
@@ -88,15 +98,23 @@ SegmentInternalInterface::FillTargetEntry(const query::Plan* plan,
                "Size of result distances is not equal to size of ids");
 
     std::unique_ptr<DataArray> field_data;
-    milvus::OpContext op_ctx;
+    // See FillPrimaryKeys: per-call OpContext so storage_usage stays scoped
+    // to this segment's fills.
+    milvus::OpContext local_ctx;
+    if (op_ctx != nullptr) {
+        local_ctx.cancellation_token = op_ctx->cancellation_token;
+        local_ctx.runtime_load_priority = op_ctx->runtime_load_priority;
+    }
     // fill other entries except primary key by result_offset
     for (auto field_id : plan->target_entries_) {
+        segcore::CheckCancellation(
+            op_ctx, get_segment_id(), field_id.get(), "FillTargetEntry");
         auto& field_meta = plan->schema_->operator[](field_id);
         if (plan->schema_->get_dynamic_field_id().has_value() &&
             plan->schema_->get_dynamic_field_id().value() == field_id &&
             !plan->target_dynamic_fields_.empty()) {
             auto& target_dynamic_fields = plan->target_dynamic_fields_;
-            field_data = bulk_subscript(&op_ctx,
+            field_data = bulk_subscript(&local_ctx,
                                         field_id,
                                         results.seg_offsets_.data(),
                                         size,
@@ -105,14 +123,14 @@ SegmentInternalInterface::FillTargetEntry(const query::Plan* plan,
             field_data = bulk_subscript_not_exist_field(field_meta, size);
         } else {
             field_data = bulk_subscript(
-                &op_ctx, field_id, results.seg_offsets_.data(), size);
+                &local_ctx, field_id, results.seg_offsets_.data(), size);
         }
         results.output_fields_data_[field_id] = std::move(field_data);
     }
     results.search_storage_cost_.scanned_remote_bytes +=
-        op_ctx.storage_usage.scanned_cold_bytes.load();
+        local_ctx.storage_usage.scanned_cold_bytes.load();
     results.search_storage_cost_.scanned_total_bytes +=
-        op_ctx.storage_usage.scanned_total_bytes.load();
+        local_ctx.storage_usage.scanned_total_bytes.load();
 }
 
 std::unique_ptr<SearchResult>

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -83,10 +83,14 @@ class SegmentInterface {
     virtual ~SegmentInterface() = default;
 
     virtual void
-    FillPrimaryKeys(const query::Plan* plan, SearchResult& results) const = 0;
+    FillPrimaryKeys(const query::Plan* plan,
+                    SearchResult& results,
+                    milvus::OpContext* op_ctx = nullptr) const = 0;
 
     virtual void
-    FillTargetEntry(const query::Plan* plan, SearchResult& results) const = 0;
+    FillTargetEntry(const query::Plan* plan,
+                    SearchResult& results,
+                    milvus::OpContext* op_ctx = nullptr) const = 0;
 
     virtual bool
     Contain(const PkType& pk) const = 0;
@@ -418,11 +422,13 @@ class SegmentInternalInterface : public SegmentInterface {
 
     void
     FillPrimaryKeys(const query::Plan* plan,
-                    SearchResult& results) const override;
+                    SearchResult& results,
+                    milvus::OpContext* op_ctx = nullptr) const override;
 
     void
     FillTargetEntry(const query::Plan* plan,
-                    SearchResult& results) const override;
+                    SearchResult& results,
+                    milvus::OpContext* op_ctx = nullptr) const override;
 
     // Bring in base class Retrieve overloads to avoid name hiding
     using SegmentInterface::Retrieve;

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -153,7 +153,9 @@ class SegmentInterface {
     Retrieve(tracer::TraceContext* trace_ctx,
              const query::RetrievePlan* Plan,
              const int64_t* offsets,
-             int64_t size) const = 0;
+             int64_t size,
+             const folly::CancellationToken& cancel_token =
+                 folly::CancellationToken()) const = 0;
 
     virtual size_t
     GetMemoryUsageInBytes() const = 0;
@@ -448,7 +450,8 @@ class SegmentInternalInterface : public SegmentInterface {
     Retrieve(tracer::TraceContext* trace_ctx,
              const query::RetrievePlan* Plan,
              const int64_t* offsets,
-             int64_t size) const override;
+             int64_t size,
+             const folly::CancellationToken& cancel_token) const override;
 
     virtual bool
     HasIndex(FieldId field_id) const = 0;
@@ -638,7 +641,8 @@ class SegmentInternalInterface : public SegmentInterface {
         const int64_t* offsets,
         int64_t size,
         bool ignore_non_pk,
-        bool fill_ids) const;
+        bool fill_ids,
+        milvus::OpContext* op_ctx = nullptr) const;
 
     // return whether field mmap or not
     virtual bool

--- a/internal/core/src/segcore/reduce/GroupReduce.h
+++ b/internal/core/src/segcore/reduce/GroupReduce.h
@@ -33,14 +33,16 @@ class GroupReduceHelper : public ReduceHelper {
         int64_t* slice_nqs,
         int64_t* slice_topKs,
         int64_t slice_num,
-        tracer::TraceContext* trace_ctx)
+        tracer::TraceContext* trace_ctx,
+        milvus::OpContext* op_ctx = nullptr)
         : ReduceHelper(search_results,
                        plan,
                        placeholder_group,
                        slice_nqs,
                        slice_topKs,
                        slice_num,
-                       trace_ctx) {
+                       trace_ctx,
+                       op_ctx) {
     }
 
  protected:

--- a/internal/core/src/segcore/reduce/Reduce.cpp
+++ b/internal/core/src/segcore/reduce/Reduce.cpp
@@ -760,7 +760,12 @@ ReduceHelper::FillEntryData() {
                 if (f.valid()) {
                     try {
                         f.get();
+                    } catch (const std::exception& e) {
+                        LOG_WARN("FillEntryData drain swallowed exception: {}",
+                                 e.what());
                     } catch (...) {
+                        LOG_WARN(
+                            "FillEntryData drain swallowed unknown exception");
                     }
                 }
             }

--- a/internal/core/src/segcore/reduce/Reduce.cpp
+++ b/internal/core/src/segcore/reduce/Reduce.cpp
@@ -238,7 +238,7 @@ ReduceHelper::FillPrimaryKey() {
             auto future = pool.Submit([this, search_result] {
                 auto segment =
                     static_cast<SegmentInterface*>(search_result->segment_);
-                segment->FillPrimaryKeys(plan_, *search_result);
+                segment->FillPrimaryKeys(plan_, *search_result, op_ctx_);
             });
             futures.emplace_back(std::move(future));
         }
@@ -258,7 +258,7 @@ ReduceHelper::FillPrimaryKey() {
     } else if (num_segments_ == 1) {
         auto segment =
             static_cast<SegmentInterface*>(search_results_[0]->segment_);
-        segment->FillPrimaryKeys(plan_, *search_results_[0]);
+        segment->FillPrimaryKeys(plan_, *search_results_[0], op_ctx_);
     }
 }
 
@@ -731,20 +731,45 @@ ReduceHelper::RefreshSingleSearchResult(SearchResult* search_result,
 void
 ReduceHelper::FillEntryData() {
     tracer::AutoSpan span("ReduceHelper::FillEntryData", tracer::GetRootSpan());
-    for (auto search_result : search_results_) {
+    auto run_one = [](SearchResult* search_result,
+                      milvus::query::Plan* plan,
+                      milvus::OpContext* op_ctx) {
         auto segment = static_cast<milvus::segcore::SegmentInterface*>(
             search_result->segment_);
-        std::chrono::high_resolution_clock::time_point get_target_entry_start =
-            std::chrono::high_resolution_clock::now();
-        segment->FillTargetEntry(plan_, *search_result);
-        std::chrono::high_resolution_clock::time_point get_target_entry_end =
-            std::chrono::high_resolution_clock::now();
-        double get_entry_cost =
-            std::chrono::duration<double, std::micro>(get_target_entry_end -
-                                                      get_target_entry_start)
-                .count();
+        auto start = std::chrono::high_resolution_clock::now();
+        segment->FillTargetEntry(plan, *search_result, op_ctx);
+        auto end = std::chrono::high_resolution_clock::now();
+        double cost =
+            std::chrono::duration<double, std::micro>(end - start).count();
         milvus::monitor::internal_core_search_get_target_entry_latency.Observe(
-            get_entry_cost / 1000);
+            cost / 1000);
+    };
+
+    if (search_results_.size() > 1) {
+        auto& pool =
+            ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::MIDDLE);
+        std::vector<std::future<void>> futures;
+        futures.reserve(search_results_.size());
+        for (auto search_result : search_results_) {
+            futures.emplace_back(pool.Submit([run_one, search_result, this] {
+                run_one(search_result, plan_, op_ctx_);
+            }));
+        }
+        auto futures_guard = folly::makeGuard([&futures]() {
+            for (auto& f : futures) {
+                if (f.valid()) {
+                    try {
+                        f.get();
+                    } catch (...) {
+                    }
+                }
+            }
+        });
+        for (auto& f : futures) {
+            f.get();
+        }
+    } else if (search_results_.size() == 1) {
+        run_one(search_results_[0], plan_, op_ctx_);
     }
 }
 

--- a/internal/core/src/segcore/reduce/Reduce.h
+++ b/internal/core/src/segcore/reduce/Reduce.h
@@ -20,6 +20,7 @@
 #include <variant>
 #include <vector>
 
+#include "common/OpContext.h"
 #include "common/QueryResult.h"
 #include "common/Tracer.h"
 #include "common/TypeTraits.h"
@@ -46,13 +47,15 @@ class ReduceHelper {
         int64_t* slice_nqs,
         int64_t* slice_topKs,
         int64_t slice_num,
-        tracer::TraceContext* trace_ctx)
+        tracer::TraceContext* trace_ctx,
+        milvus::OpContext* op_ctx = nullptr)
         : search_results_(search_results),
           plan_(plan),
           placeholder_group_(placeholder_group),
           slice_nqs_(slice_nqs, slice_nqs + slice_num),
           slice_topKs_(slice_topKs, slice_topKs + slice_num),
-          trace_ctx_(trace_ctx) {
+          trace_ctx_(trace_ctx),
+          op_ctx_(op_ctx) {
         Initialize();
     }
 
@@ -175,6 +178,7 @@ class ReduceHelper {
     std::unique_ptr<SearchResultDataBlobs> search_result_data_blobs_;
     tracer::TraceContext* trace_ctx_;
     StorageCost total_search_storage_cost_;
+    milvus::OpContext* op_ctx_{nullptr};
 };
 
 }  // namespace milvus::segcore

--- a/internal/core/src/segcore/reduce_c.cpp
+++ b/internal/core/src/segcore/reduce_c.cpp
@@ -46,6 +46,7 @@ DoReduce(milvus::tracer::TraceContext trace_ctx,
     milvus::tracer::AutoSpan span(
         "ReduceSearchResultsAndFillData", &trace_ctx, true);
 
+    auto num_slices = static_cast<int64_t>(slice_nqs.size());
     std::shared_ptr<milvus::segcore::ReduceHelper> reduce_helper;
     if (plan->plan_node_->search_info_.group_by_field_id_.has_value()) {
         reduce_helper =
@@ -53,19 +54,21 @@ DoReduce(milvus::tracer::TraceContext trace_ctx,
                 search_results,
                 plan,
                 placeholder_group,
-                slice_nqs,
-                slice_topKs,
+                slice_nqs.data(),
+                slice_topKs.data(),
                 num_slices,
-                &trace_ctx);
+                &trace_ctx,
+                op_ctx);
     } else {
         reduce_helper = std::make_shared<milvus::segcore::ReduceHelper>(
             search_results,
             plan,
             placeholder_group,
-            slice_nqs,
-            slice_topKs,
+            slice_nqs.data(),
+            slice_topKs.data(),
             num_slices,
-            &trace_ctx);
+            &trace_ctx,
+            op_ctx);
     }
     reduce_helper->Reduce();
     reduce_helper->Marshal();

--- a/internal/core/src/segcore/reduce_c.cpp
+++ b/internal/core/src/segcore/reduce_c.cpp
@@ -49,18 +49,7 @@ DoReduce(milvus::tracer::TraceContext trace_ctx,
     auto num_slices = static_cast<int64_t>(slice_nqs.size());
     std::shared_ptr<milvus::segcore::ReduceHelper> reduce_helper;
     if (plan->plan_node_->search_info_.group_by_field_id_.has_value()) {
-        reduce_helper =
-            std::make_shared<milvus::segcore::GroupReduceHelper>(
-                search_results,
-                plan,
-                placeholder_group,
-                slice_nqs.data(),
-                slice_topKs.data(),
-                num_slices,
-                &trace_ctx,
-                op_ctx);
-    } else {
-        reduce_helper = std::make_shared<milvus::segcore::ReduceHelper>(
+        reduce_helper = std::make_shared<milvus::segcore::GroupReduceHelper>(
             search_results,
             plan,
             placeholder_group,
@@ -69,6 +58,16 @@ DoReduce(milvus::tracer::TraceContext trace_ctx,
             num_slices,
             &trace_ctx,
             op_ctx);
+    } else {
+        reduce_helper =
+            std::make_shared<milvus::segcore::ReduceHelper>(search_results,
+                                                            plan,
+                                                            placeholder_group,
+                                                            slice_nqs.data(),
+                                                            slice_topKs.data(),
+                                                            num_slices,
+                                                            &trace_ctx,
+                                                            op_ctx);
     }
     reduce_helper->Reduce();
     reduce_helper->Marshal();

--- a/internal/core/src/segcore/reduce_c.cpp
+++ b/internal/core/src/segcore/reduce_c.cpp
@@ -9,15 +9,20 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
+#include <folly/CancellationToken.h>
 #include <exception>
 #include <memory>
 #include <optional>
+#include <utility>
 #include <vector>
 
 #include "common/EasyAssert.h"
+#include "common/OpContext.h"
 #include "common/QueryInfo.h"
 #include "common/QueryResult.h"
 #include "common/Tracer.h"
+#include "futures/Executor.h"
+#include "futures/Future.h"
 #include "monitor/scope_metric.h"
 #include "query/PlanImpl.h"
 #include "query/PlanNode.h"
@@ -27,6 +32,48 @@
 #include "segcore/reduce_c.h"
 
 using SearchResult = milvus::SearchResult;
+
+namespace {
+
+milvus::segcore::SearchResultDataBlobs*
+DoReduce(milvus::tracer::TraceContext trace_ctx,
+         milvus::query::Plan* plan,
+         const milvus::query::PlaceholderGroup* placeholder_group,
+         std::vector<SearchResult*> search_results,
+         std::vector<int64_t> slice_nqs,
+         std::vector<int64_t> slice_topKs,
+         milvus::OpContext* op_ctx) {
+    milvus::tracer::AutoSpan span(
+        "ReduceSearchResultsAndFillData", &trace_ctx, true);
+
+    std::shared_ptr<milvus::segcore::ReduceHelper> reduce_helper;
+    if (plan->plan_node_->search_info_.group_by_field_id_.has_value()) {
+        reduce_helper =
+            std::make_shared<milvus::segcore::GroupReduceHelper>(
+                search_results,
+                plan,
+                placeholder_group,
+                slice_nqs,
+                slice_topKs,
+                num_slices,
+                &trace_ctx);
+    } else {
+        reduce_helper = std::make_shared<milvus::segcore::ReduceHelper>(
+            search_results,
+            plan,
+            placeholder_group,
+            slice_nqs,
+            slice_topKs,
+            num_slices,
+            &trace_ctx);
+    }
+    reduce_helper->Reduce();
+    reduce_helper->Marshal();
+    return static_cast<milvus::segcore::SearchResultDataBlobs*>(
+        reduce_helper->GetSearchResultDataBlobs());
+}
+
+}  // namespace
 
 CStatus
 ReduceSearchResultsAndFillData(CTraceContext c_trace,
@@ -41,7 +88,6 @@ ReduceSearchResultsAndFillData(CTraceContext c_trace,
     SCOPE_CGO_CALL_METRIC();
 
     try {
-        // get SearchResult and SearchPlan
         auto plan = static_cast<milvus::query::Plan*>(c_plan);
         auto placeholder_group =
             static_cast<const milvus::query::PlaceholderGroup*>(
@@ -49,43 +95,83 @@ ReduceSearchResultsAndFillData(CTraceContext c_trace,
         AssertInfo(num_segments > 0, "num_segments must be greater than 0");
         auto trace_ctx = milvus::tracer::TraceContext{
             c_trace.traceID, c_trace.spanID, c_trace.traceFlags};
-        milvus::tracer::AutoSpan span(
-            "ReduceSearchResultsAndFillData", &trace_ctx, true);
         std::vector<SearchResult*> search_results(num_segments);
         for (int i = 0; i < num_segments; ++i) {
             search_results[i] = static_cast<SearchResult*>(c_search_results[i]);
         }
+        std::vector<int64_t> slice_nqs_vec(slice_nqs, slice_nqs + num_slices);
+        std::vector<int64_t> slice_topKs_vec(slice_topKs,
+                                             slice_topKs + num_slices);
 
-        std::shared_ptr<milvus::segcore::ReduceHelper> reduce_helper;
-        if (plan->plan_node_->search_info_.group_by_field_id_.has_value()) {
-            reduce_helper =
-                std::make_shared<milvus::segcore::GroupReduceHelper>(
-                    search_results,
-                    plan,
-                    placeholder_group,
-                    slice_nqs,
-                    slice_topKs,
-                    num_slices,
-                    &trace_ctx);
-        } else {
-            reduce_helper = std::make_shared<milvus::segcore::ReduceHelper>(
-                search_results,
-                plan,
-                placeholder_group,
-                slice_nqs,
-                slice_topKs,
-                num_slices,
-                &trace_ctx);
-        }
-        reduce_helper->Reduce();
-        reduce_helper->Marshal();
-
-        // set final result ptr
-        *cSearchResultDataBlobs = reduce_helper->GetSearchResultDataBlobs();
+        *cSearchResultDataBlobs = DoReduce(trace_ctx,
+                                           plan,
+                                           placeholder_group,
+                                           std::move(search_results),
+                                           std::move(slice_nqs_vec),
+                                           std::move(slice_topKs_vec),
+                                           nullptr);
         return milvus::SuccessCStatus();
     } catch (std::exception& e) {
         return milvus::FailureCStatus(&e);
     }
+}
+
+CFuture*
+AsyncReduceSearchResultsAndFillData(CTraceContext c_trace,
+                                    CSearchPlan c_plan,
+                                    CPlaceholderGroup c_placeholder_group,
+                                    CSearchResult* c_search_results,
+                                    int64_t num_segments,
+                                    int64_t* slice_nqs,
+                                    int64_t* slice_topKs,
+                                    int64_t num_slices) {
+    SCOPE_CGO_CALL_METRIC();
+
+    // Preflight (AssertInfo, vector allocations) runs inside the lambda so
+    // any exception becomes a failed CFuture instead of escaping across the
+    // C ABI. Input arrays are kept alive by the Go caller via
+    // runtime.KeepAlive until BlockAndLeakyGet returns.
+    auto future =
+        milvus::futures::Future<milvus::segcore::SearchResultDataBlobs>::async(
+            milvus::futures::getSearchCPUExecutor(),
+            milvus::futures::ExecutePriority::HIGH,
+            [c_trace,
+             c_plan,
+             c_placeholder_group,
+             c_search_results,
+             num_segments,
+             slice_nqs,
+             slice_topKs,
+             num_slices](folly::CancellationToken cancel_token) {
+                auto plan = static_cast<milvus::query::Plan*>(c_plan);
+                auto placeholder_group =
+                    static_cast<const milvus::query::PlaceholderGroup*>(
+                        c_placeholder_group);
+                AssertInfo(num_segments > 0,
+                           "num_segments must be greater than 0");
+                auto trace_ctx = milvus::tracer::TraceContext{
+                    c_trace.traceID, c_trace.spanID, c_trace.traceFlags};
+                std::vector<SearchResult*> search_results(num_segments);
+                for (int i = 0; i < num_segments; ++i) {
+                    search_results[i] =
+                        static_cast<SearchResult*>(c_search_results[i]);
+                }
+                std::vector<int64_t> slice_nqs_vec(slice_nqs,
+                                                   slice_nqs + num_slices);
+                std::vector<int64_t> slice_topKs_vec(slice_topKs,
+                                                     slice_topKs + num_slices);
+                milvus::OpContext op_ctx(cancel_token);
+                return DoReduce(trace_ctx,
+                                plan,
+                                placeholder_group,
+                                std::move(search_results),
+                                std::move(slice_nqs_vec),
+                                std::move(slice_topKs_vec),
+                                &op_ctx);
+            });
+
+    return static_cast<CFuture*>(static_cast<void*>(
+        static_cast<milvus::futures::IFuture*>(future.release())));
 }
 
 CStatus

--- a/internal/core/src/segcore/reduce_c.h
+++ b/internal/core/src/segcore/reduce_c.h
@@ -17,6 +17,7 @@ extern "C" {
 
 #include "common/common_type_c.h"
 #include "common/type_c.h"
+#include "futures/future_c_types.h"
 #include "segcore/plan_c.h"
 #include "segcore/segment_c.h"
 
@@ -32,6 +33,19 @@ ReduceSearchResultsAndFillData(CTraceContext c_trace,
                                int64_t* slice_nqs,
                                int64_t* slice_topKs,
                                int64_t num_slices);
+
+// Async variant of ReduceSearchResultsAndFillData. The returned CFuture
+// resolves to a CSearchResultDataBlobs pointer; cancellation propagates
+// to per-segment FillTargetEntry / FillPrimaryKeys via OpContext.
+CFuture*  // Future<CSearchResultDataBlobs>
+AsyncReduceSearchResultsAndFillData(CTraceContext c_trace,
+                                    CSearchPlan c_plan,
+                                    CPlaceholderGroup c_placeholder_group,
+                                    CSearchResult* search_results,
+                                    int64_t num_segments,
+                                    int64_t* slice_nqs,
+                                    int64_t* slice_topKs,
+                                    int64_t num_slices);
 
 CStatus
 GetSearchResultDataBlob(CProto* searchResultDataBlob,

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -448,7 +448,7 @@ AsyncRetrieveByOffsets(CTraceContext c_trace,
                 "SegCoreRetrieveByOffsets", &trace_ctx, true);
 
             auto retrieve_result =
-                segment->Retrieve(&trace_ctx, plan, offsets, len);
+                segment->Retrieve(&trace_ctx, plan, offsets, len, cancel_token);
 
             return CreateLeakedCRetrieveResultFromProto(
                 std::move(retrieve_result));

--- a/internal/util/segcore/reduce.go
+++ b/internal/util/segcore/reduce.go
@@ -78,7 +78,7 @@ func ReduceSearchResultsAndFillData(ctx context.Context, plan *SearchPlan, place
 	// cgo.Async starts the C call synchronously and only then registers the
 	// future for ctx-driven cancellation. For a small reduce the C side can
 	// finish in microseconds, well before the future manager propagates
-	// cancellation, so a pre-cancelled ctx otherwise leaks through as a
+	// cancellation, so a pre-canceled ctx otherwise leaks through as a
 	// successful reduce. Honor ctx early -- the standard Go idiom.
 	if err := ctx.Err(); err != nil {
 		return nil, err

--- a/internal/util/segcore/reduce.go
+++ b/internal/util/segcore/reduce.go
@@ -112,6 +112,7 @@ func ReduceSearchResultsAndFillData(ctx context.Context, plan *SearchPlan, place
 	defer runtime.KeepAlive(traceCtx)
 	defer runtime.KeepAlive(plan)
 	defer runtime.KeepAlive(searchResults)
+	defer runtime.KeepAlive(cSearchResults)
 	defer runtime.KeepAlive(sliceNQs)
 	defer runtime.KeepAlive(sliceTopKs)
 

--- a/internal/util/segcore/reduce.go
+++ b/internal/util/segcore/reduce.go
@@ -27,9 +27,12 @@ import "C"
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"unsafe"
 
 	"github.com/cockroachdb/errors"
+
+	"github.com/milvus-io/milvus/internal/util/cgo"
 )
 
 type SliceInfo struct {
@@ -72,6 +75,15 @@ func ParseSliceInfo(originNQs []int64, originTopKs []int64, nqPerSlice int64) *S
 func ReduceSearchResultsAndFillData(ctx context.Context, plan *SearchPlan, placeholderGroup unsafe.Pointer, searchResults []*SearchResult,
 	numSegments int64, sliceNQs []int64, sliceTopKs []int64,
 ) (SearchResultDataBlobs, error) {
+	// cgo.Async starts the C call synchronously and only then registers the
+	// future for ctx-driven cancellation. For a small reduce the C side can
+	// finish in microseconds, well before the future manager propagates
+	// cancellation, so a pre-cancelled ctx otherwise leaks through as a
+	// successful reduce. Honor ctx early -- the standard Go idiom.
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	if plan.cSearchPlan == nil {
 		return nil, errors.New("nil search plan")
 	}
@@ -96,14 +108,34 @@ func ReduceSearchResultsAndFillData(ctx context.Context, plan *SearchPlan, place
 	cSliceNQSPtr := (*C.int64_t)(&sliceNQs[0])
 	cSliceTopKSPtr := (*C.int64_t)(&sliceTopKs[0])
 	cNumSlices := C.int64_t(len(sliceNQs))
-	var cSearchResultDataBlobs SearchResultDataBlobs
 	traceCtx := ParseCTraceContext(ctx)
-	status := C.ReduceSearchResultsAndFillData(traceCtx.ctx, &cSearchResultDataBlobs, plan.cSearchPlan, C.CPlaceholderGroup(placeholderGroup), cSearchResultPtr,
-		cNumSegments, cSliceNQSPtr, cSliceTopKSPtr, cNumSlices)
-	if err := ConsumeCStatusIntoError(&status); err != nil {
+	defer runtime.KeepAlive(traceCtx)
+	defer runtime.KeepAlive(plan)
+	defer runtime.KeepAlive(searchResults)
+	defer runtime.KeepAlive(sliceNQs)
+	defer runtime.KeepAlive(sliceTopKs)
+
+	future := cgo.Async(ctx,
+		func() cgo.CFuturePtr {
+			return (cgo.CFuturePtr)(C.AsyncReduceSearchResultsAndFillData(
+				traceCtx.ctx,
+				plan.cSearchPlan,
+				C.CPlaceholderGroup(placeholderGroup),
+				cSearchResultPtr,
+				cNumSegments,
+				cSliceNQSPtr,
+				cSliceTopKSPtr,
+				cNumSlices,
+			))
+		},
+		cgo.WithName("reduce-search-results"),
+	)
+	defer future.Release()
+	result, err := future.BlockAndLeakyGet()
+	if err != nil {
 		return nil, errors.Wrap(err, "ReduceSearchResultsAndFillData failed")
 	}
-	return cSearchResultDataBlobs, nil
+	return SearchResultDataBlobs(result), nil
 }
 
 func GetSearchResultDataBlob(ctx context.Context, cSearchResultDataBlobs SearchResultDataBlobs, blobIndex int) ([]byte, StorageCost, error) {

--- a/internal/util/segcore/reduce_test.go
+++ b/internal/util/segcore/reduce_test.go
@@ -318,14 +318,14 @@ func (suite *ReduceSuite) TestReduceAsyncSuccess() {
 	segcore.DeleteSearchResultDataBlobs(blobs)
 }
 
-func (suite *ReduceSuite) TestReduceAsyncCancelled() {
+func (suite *ReduceSuite) TestReduceAsyncPreCancelled() {
 	nq := int64(10)
 	searchReq, searchResult := suite.buildSearchResult(nq)
 	defer searchReq.Delete()
 
-	// Pre-cancel the context; cgo.Async's future manager should request
-	// cancellation on the folly token before the reduce runner commits,
-	// surfacing a context.Canceled-marked error from BlockAndLeakyGet.
+	// Context is already canceled when ReduceSearchResultsAndFillData is
+	// entered, so the early ctx.Err() check returns without dispatching to
+	// cgo.Async. This exercises the pre-dispatch bail-out path.
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 

--- a/internal/util/segcore/reduce_test.go
+++ b/internal/util/segcore/reduce_test.go
@@ -248,6 +248,101 @@ func (suite *ReduceSuite) TestReduceInvalid() {
 	suite.Error(err)
 }
 
+// buildSearchResult runs a small search against suite.segment and returns the
+// request and its result, used by reduce-related tests.
+func (suite *ReduceSuite) buildSearchResult(nq int64) (*segcore.SearchRequest, *segcore.SearchResult) {
+	vec := testutils.GenerateFloatVectors(1, mock_segcore.DefaultDim)
+	var searchRawData []byte
+	for i, ele := range vec {
+		buf := make([]byte, 4)
+		common.Endian.PutUint32(buf, math.Float32bits(ele+float32(i*2)))
+		searchRawData = append(searchRawData, buf...)
+	}
+	placeholderValue := commonpb.PlaceholderValue{
+		Tag:    "$0",
+		Type:   commonpb.PlaceholderType_FloatVector,
+		Values: [][]byte{},
+	}
+	for i := 0; i < int(nq); i++ {
+		placeholderValue.Values = append(placeholderValue.Values, searchRawData)
+	}
+	placeholderGroup := commonpb.PlaceholderGroup{
+		Placeholders: []*commonpb.PlaceholderValue{&placeholderValue},
+	}
+	placeGroupByte, err := proto.Marshal(&placeholderGroup)
+	suite.Require().NoError(err)
+
+	planStr := `vector_anns: <
+                 field_id: 107
+                 query_info: <
+                   topk: 10
+                   round_decimal: 6
+                   metric_type: "L2"
+                   search_params: "{\"nprobe\": 10}"
+                 >
+                 placeholder_tag: "$0"
+               >`
+	var planNode planpb.PlanNode
+	suite.Require().NoError(prototext.Unmarshal([]byte(planStr), &planNode))
+	serializedPlan, err := proto.Marshal(&planNode)
+	suite.Require().NoError(err)
+	searchReq, err := segcore.NewSearchRequest(suite.collection, &querypb.SearchRequest{
+		Req: &internalpb.SearchRequest{
+			SerializedExprPlan: serializedPlan,
+			MvccTimestamp:      typeutil.MaxTimestamp,
+		},
+	}, placeGroupByte)
+	suite.Require().NoError(err)
+
+	searchResult, err := suite.segment.Search(context.Background(), searchReq)
+	suite.Require().NoError(err)
+	return searchReq, searchResult
+}
+
+func (suite *ReduceSuite) TestReduceAsyncSuccess() {
+	nq := int64(10)
+	searchReq, searchResult := suite.buildSearchResult(nq)
+	defer searchReq.Delete()
+
+	blobs, err := segcore.ReduceSearchResultsAndFillData(
+		context.Background(),
+		searchReq.Plan(),
+		searchReq.PlaceholderGroup(),
+		[]*segcore.SearchResult{searchResult},
+		1,
+		[]int64{nq},
+		[]int64{searchReq.Plan().GetTopK()},
+	)
+	suite.NoError(err)
+	suite.NotNil(blobs)
+	segcore.DeleteSearchResultDataBlobs(blobs)
+}
+
+func (suite *ReduceSuite) TestReduceAsyncCancelled() {
+	nq := int64(10)
+	searchReq, searchResult := suite.buildSearchResult(nq)
+	defer searchReq.Delete()
+
+	// Pre-cancel the context; cgo.Async's future manager should request
+	// cancellation on the folly token before the reduce runner commits,
+	// surfacing a context.Canceled-marked error from BlockAndLeakyGet.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	blobs, err := segcore.ReduceSearchResultsAndFillData(
+		ctx,
+		searchReq.Plan(),
+		searchReq.PlaceholderGroup(),
+		[]*segcore.SearchResult{searchResult},
+		1,
+		[]int64{nq},
+		[]int64{searchReq.Plan().GetTopK()},
+	)
+	suite.Error(err)
+	suite.ErrorIs(err, context.Canceled)
+	suite.Nil(blobs)
+}
+
 func TestReduce(t *testing.T) {
 	suite.Run(t, new(ReduceSuite))
 }


### PR DESCRIPTION
## Summary
- Parallelize per-segment `FillTargetEntry` on the MIDDLE thread pool (matching `FillPrimaryKeys`) and plumb `OpContext*` through the reduce path for cancellation support.
- Add `AsyncReduceSearchResultsAndFillData` returning `CFuture`, propagating the folly cancellation token into a per-call `OpContext`. Switch the Go wrapper to `cgo.Async` so a cancelled query context aborts the in-flight reduce instead of blocking until completion.
- Use a per-call `OpContext` for `storage_usage` in `FillPrimaryKeys` / `FillTargetEntry` — sharing `op_ctx` across segments made each segment's `search_storage_cost_` accumulate every prior segment's bytes, inflating `GetTotalStorageCost()`.
- Move preflight logic (AssertInfo, input copying) inside the async lambda so exceptions become failed `CFuture` results rather than escaping across the C ABI.

issue: #49116
pr: #49117

## Test plan
- [x] Add `TestReduceAsyncSuccess` — end-to-end async reduce with valid results
- [x] Add `TestReduceAsyncCancelled` — pre-cancelled context surfaces `context.Canceled`
- [ ] Existing reduce tests pass (`go test -tags dynamic,test ./internal/util/segcore/...`)
- [ ] C++ unit tests pass (synchronous C entry point preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)