### PR TITLE
enhance: [v2backfill] Handle legacy v2 parquet column replaced by backfill

### DIFF
--- a/internal/core/src/segcore/SegmentLoadInfo.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfo.cpp
@@ -196,8 +196,10 @@ SegmentLoadInfo::ComputeDiffBinlogs(LoadDiff& diff, SegmentLoadInfo& new_info) {
         }
         for (auto child_id : child_fields) {
             new_binlog_fields[child_id] = new_field_binlog.fieldid();
-            auto iter = current_fields.find(new_field_binlog.fieldid());
-            // Find binlogs to load: fields in new_info match current
+            // current_fields is keyed by child field id (see loop above);
+            // look up by child_id, not by the new group id.
+            auto iter = current_fields.find(child_id);
+            // Load this child if it's absent from current, or its group moved.
             if (iter == current_fields.end() ||
                 iter->second != new_field_binlog.fieldid()) {
                 ids_to_load.emplace_back(child_id);

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
@@ -445,11 +445,14 @@ GroupChunkTranslator::load_group_chunk(
             continue;
         }
         auto it = field_metas_.find(fid);
-        AssertInfo(
-            it != field_metas_.end(),
-            "[StorageV2] translator {} field id {} not found in field_metas",
-            key_,
-            fid.get());
+        if (it == field_metas_.end()) {
+            // Parquet file may carry extra columns from a previous
+            // column-group layout (e.g. nullable fields later split into
+            // their own groups but physically still present here). Drop
+            // them — the real data will come from the dedicated group's
+            // binlog entry.
+            continue;
+        }
         const auto& field_meta = it->second;
 
         // Merge array vectors from all tables for this field

--- a/internal/querycoordv2/task/executor.go
+++ b/internal/querycoordv2/task/executor.go
@@ -231,7 +231,7 @@ func (ex *Executor) removeTask(task Task, step int) {
 
 func (ex *Executor) executeSegmentAction(task *SegmentTask, step int) {
 	switch task.Actions()[step].Type() {
-	case ActionTypeGrow, ActionTypeUpdate, ActionTypeStatsUpdate:
+	case ActionTypeGrow, ActionTypeUpdate, ActionTypeStatsUpdate, ActionTypeReopen:
 		ex.loadSegment(task, step)
 
 	case ActionTypeReduce:


### PR DESCRIPTION
This PR:

- Discard parquet column from legacy data replaced by backfill
- Handle reopen task type in querycoord
- Use correct child field id computing diff binlogs