### PR TITLE
enhance: propagate collection_id in datacoord task properties

### DIFF
--- a/internal/datacoord/compaction_task_backfill.go
+++ b/internal/datacoord/compaction_task_backfill.go
@@ -231,7 +231,7 @@ func (t *backfillCompactionTask) CreateTaskOnWorker(nodeID int64, cluster sessio
 		return
 	}
 
-	err = cluster.CreateCompaction(nodeID, plan)
+	err = cluster.CreateCompaction(nodeID, plan, t.GetTaskProto().GetCollectionID())
 	if err != nil {
 		log.Warn("backfillCompactionTask failed to notify compaction tasks to DataNode",
 			zap.Int64("planID", t.GetTaskProto().GetPlanID()),

--- a/internal/datacoord/compaction_task_backfill_test.go
+++ b/internal/datacoord/compaction_task_backfill_test.go
@@ -247,7 +247,7 @@ func (s *BackfillCompactionTaskSuite) TestCreateTaskOnWorker() {
 
 		task := s.generateBasicTask()
 		cluster := session.NewMockCluster(s.T())
-		cluster.EXPECT().CreateCompaction(mock.Anything, mock.Anything).Return(merr.WrapErrNodeNotFound(1))
+		cluster.EXPECT().CreateCompaction(mock.Anything, mock.Anything, mock.Anything).Return(merr.WrapErrNodeNotFound(1))
 		task.CreateTaskOnWorker(1, cluster)
 		// Should remain in pipelining state when CreateCompaction fails
 		s.Equal(datapb.CompactionTaskState_pipelining, task.GetTaskProto().GetState())
@@ -281,7 +281,7 @@ func (s *BackfillCompactionTaskSuite) TestCreateTaskOnWorker() {
 
 		task := s.generateBasicTask()
 		cluster := session.NewMockCluster(s.T())
-		cluster.EXPECT().CreateCompaction(mock.Anything, mock.Anything).Return(nil)
+		cluster.EXPECT().CreateCompaction(mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		task.CreateTaskOnWorker(1, cluster)
 		s.Equal(datapb.CompactionTaskState_executing, task.GetTaskProto().GetState())
 		s.Equal(int64(1), task.GetTaskProto().GetNodeID())

--- a/internal/datacoord/compaction_task_clustering.go
+++ b/internal/datacoord/compaction_task_clustering.go
@@ -767,7 +767,7 @@ func (t *clusteringCompactionTask) doCompact(nodeID int64, cluster session.Clust
 		log.Warn("Failed to BuildCompactionRequest", zap.Error(err))
 		return err
 	}
-	err = cluster.CreateCompaction(nodeID, t.GetPlan())
+	err = cluster.CreateCompaction(nodeID, t.GetPlan(), t.GetTaskProto().GetCollectionID())
 	if err != nil {
 		originNodeID := t.GetTaskProto().GetNodeID()
 		log.Warn("Failed to notify compaction tasks to DataNode",

--- a/internal/datacoord/compaction_task_clustering.go
+++ b/internal/datacoord/compaction_task_clustering.go
@@ -773,7 +773,7 @@ func (t *clusteringCompactionTask) doCompact(nodeID int64, cluster session.Clust
 		log.Warn("Failed to BuildCompactionRequest", zap.Error(err))
 		return err
 	}
-	err = cluster.CreateCompaction(nodeID, t.GetPlan())
+	err = cluster.CreateCompaction(nodeID, t.GetPlan(), t.GetTaskProto().GetCollectionID())
 	if err != nil {
 		originNodeID := t.GetTaskProto().GetNodeID()
 		log.Warn("Failed to notify compaction tasks to DataNode",

--- a/internal/datacoord/compaction_task_clustering_test.go
+++ b/internal/datacoord/compaction_task_clustering_test.go
@@ -114,7 +114,7 @@ func (s *ClusteringCompactionTaskSuite) TestClusteringCompactionSegmentMetaChang
 	task := s.generateBasicTask(false)
 
 	cluster := session.NewMockCluster(s.T())
-	cluster.EXPECT().CreateCompaction(mock.Anything, mock.Anything).Return(nil)
+	cluster.EXPECT().CreateCompaction(mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	task.CreateTaskOnWorker(1, cluster)
 
 	seg11 := s.meta.GetSegment(context.TODO(), 101)
@@ -397,7 +397,7 @@ func (s *ClusteringCompactionTaskSuite) TestCreateTaskOnWorker() {
 		})
 		task.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_pipelining))
 		cluster := session.NewMockCluster(s.T())
-		cluster.EXPECT().CreateCompaction(mock.Anything, mock.Anything).Return(nil)
+		cluster.EXPECT().CreateCompaction(mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		task.CreateTaskOnWorker(1, cluster)
 		s.Equal(datapb.CompactionTaskState_executing, task.GetTaskProto().GetState())
 	})

--- a/internal/datacoord/compaction_task_l0.go
+++ b/internal/datacoord/compaction_task_l0.go
@@ -121,7 +121,7 @@ func (t *l0CompactionTask) CreateTaskOnWorker(nodeID int64, cluster session.Clus
 		return
 	}
 
-	err = cluster.CreateCompaction(nodeID, plan)
+	err = cluster.CreateCompaction(nodeID, plan, t.GetTaskProto().GetCollectionID())
 	if err != nil {
 		originNodeID := t.GetTaskProto().GetNodeID()
 		log.Warn("l0CompactionTask failed to notify compaction tasks to DataNode",

--- a/internal/datacoord/compaction_task_l0.go
+++ b/internal/datacoord/compaction_task_l0.go
@@ -124,7 +124,7 @@ func (t *l0CompactionTask) CreateTaskOnWorker(nodeID int64, cluster session.Clus
 		return
 	}
 
-	err = cluster.CreateCompaction(nodeID, plan)
+	err = cluster.CreateCompaction(nodeID, plan, t.GetTaskProto().GetCollectionID())
 	if err != nil {
 		originNodeID := t.GetTaskProto().GetNodeID()
 		log.Warn("l0CompactionTask failed to notify compaction tasks to DataNode",

--- a/internal/datacoord/compaction_task_l0_test.go
+++ b/internal/datacoord/compaction_task_l0_test.go
@@ -266,8 +266,9 @@ func (s *L0CompactionTaskSuite) TestPorcessStateTrans() {
 		s.mockMeta.EXPECT().SaveCompactionTask(mock.Anything, mock.Anything).Return(nil)
 
 		cluster := session.NewMockCluster(s.T())
-		cluster.EXPECT().CreateCompaction(mock.Anything, mock.Anything).RunAndReturn(func(nodeID int64, plan *datapb.CompactionPlan) error {
+		cluster.EXPECT().CreateCompaction(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(nodeID int64, plan *datapb.CompactionPlan, collectionID int64) error {
 			s.Require().EqualValues(t.GetTaskProto().NodeID, nodeID)
+			s.Require().EqualValues(t.GetTaskProto().GetCollectionID(), collectionID)
 			return errors.New("mock error")
 		})
 
@@ -305,8 +306,9 @@ func (s *L0CompactionTaskSuite) TestPorcessStateTrans() {
 		}).Twice()
 
 		cluster := session.NewMockCluster(s.T())
-		cluster.EXPECT().CreateCompaction(mock.Anything, mock.Anything).RunAndReturn(func(nodeID int64, plan *datapb.CompactionPlan) error {
+		cluster.EXPECT().CreateCompaction(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(nodeID int64, plan *datapb.CompactionPlan, collectionID int64) error {
 			s.Require().EqualValues(t.GetTaskProto().NodeID, nodeID)
+			s.Require().EqualValues(t.GetTaskProto().GetCollectionID(), collectionID)
 			return nil
 		})
 

--- a/internal/datacoord/compaction_task_l0_test.go
+++ b/internal/datacoord/compaction_task_l0_test.go
@@ -408,8 +408,9 @@ func (s *L0CompactionTaskSuite) TestPorcessStateTrans() {
 		s.mockMeta.EXPECT().SaveCompactionTask(mock.Anything, mock.Anything).Return(nil)
 
 		cluster := session.NewMockCluster(s.T())
-		cluster.EXPECT().CreateCompaction(mock.Anything, mock.Anything).RunAndReturn(func(nodeID int64, plan *datapb.CompactionPlan) error {
+		cluster.EXPECT().CreateCompaction(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(nodeID int64, plan *datapb.CompactionPlan, collectionID int64) error {
 			s.Require().EqualValues(t.GetTaskProto().NodeID, nodeID)
+			s.Require().EqualValues(t.GetTaskProto().GetCollectionID(), collectionID)
 			return errors.New("mock error")
 		})
 
@@ -447,8 +448,9 @@ func (s *L0CompactionTaskSuite) TestPorcessStateTrans() {
 		}).Twice()
 
 		cluster := session.NewMockCluster(s.T())
-		cluster.EXPECT().CreateCompaction(mock.Anything, mock.Anything).RunAndReturn(func(nodeID int64, plan *datapb.CompactionPlan) error {
+		cluster.EXPECT().CreateCompaction(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(nodeID int64, plan *datapb.CompactionPlan, collectionID int64) error {
 			s.Require().EqualValues(t.GetTaskProto().NodeID, nodeID)
+			s.Require().EqualValues(t.GetTaskProto().GetCollectionID(), collectionID)
 			return nil
 		})
 

--- a/internal/datacoord/compaction_task_mix.go
+++ b/internal/datacoord/compaction_task_mix.go
@@ -96,7 +96,7 @@ func (t *mixCompactionTask) CreateTaskOnWorker(nodeID int64, cluster session.Clu
 		return
 	}
 
-	err = cluster.CreateCompaction(nodeID, plan)
+	err = cluster.CreateCompaction(nodeID, plan, t.GetTaskProto().GetCollectionID())
 	if err != nil {
 		// Compaction tasks may be refused by DataNode because of slot limit. In this case, the node id is reset
 		//  to enable a retry in compaction.checkCompaction().

--- a/internal/datacoord/compaction_task_mix.go
+++ b/internal/datacoord/compaction_task_mix.go
@@ -97,7 +97,7 @@ func (t *mixCompactionTask) CreateTaskOnWorker(nodeID int64, cluster session.Clu
 		return
 	}
 
-	err = cluster.CreateCompaction(nodeID, plan)
+	err = cluster.CreateCompaction(nodeID, plan, t.GetTaskProto().GetCollectionID())
 	if err != nil {
 		// Compaction tasks may be refused by DataNode because of slot limit. In this case, the node id is reset
 		//  to enable a retry in compaction.checkCompaction().

--- a/internal/datacoord/copy_segment_task.go
+++ b/internal/datacoord/copy_segment_task.go
@@ -315,7 +315,7 @@ func (t *copySegmentTask) CreateTaskOnWorker(nodeID int64, cluster session.Clust
 			WrapCopySegmentTaskLog(t, zap.Int64("nodeID", nodeID), zap.Error(err))...)
 		return
 	}
-	err = cluster.CreateCopySegment(nodeID, req)
+	err = cluster.CreateCopySegment(nodeID, req, t.GetCollectionId())
 	if err != nil {
 		log.Warn("failed to create copy segment task on datanode",
 			WrapCopySegmentTaskLog(t, zap.Int64("nodeID", nodeID), zap.Error(err))...)

--- a/internal/datacoord/copy_segment_task.go
+++ b/internal/datacoord/copy_segment_task.go
@@ -317,7 +317,7 @@ func (t *copySegmentTask) CreateTaskOnWorker(nodeID int64, cluster session.Clust
 			WrapCopySegmentTaskLog(t, zap.Int64("nodeID", nodeID), zap.Error(err))...)
 		return
 	}
-	err = cluster.CreateCopySegment(nodeID, req)
+	err = cluster.CreateCopySegment(nodeID, req, t.GetCollectionId())
 	if err != nil {
 		log.Warn("failed to create copy segment task on datanode",
 			WrapCopySegmentTaskLog(t, zap.Int64("nodeID", nodeID), zap.Error(err))...)

--- a/internal/datacoord/session/cluster.go
+++ b/internal/datacoord/session/cluster.go
@@ -46,7 +46,7 @@ type Cluster interface {
 	QuerySlot() map[int64]*WorkerSlots
 
 	// CreateCompaction creates a new compaction task on the specified node
-	CreateCompaction(nodeID int64, in *datapb.CompactionPlan) error
+	CreateCompaction(nodeID int64, in *datapb.CompactionPlan, collectionID int64) error
 	// QueryCompaction queries the status of a compaction task
 	QueryCompaction(nodeID int64, in *datapb.CompactionStateRequest) (*datapb.CompactionPlanResult, error)
 	// DropCompaction drops a compaction task
@@ -92,7 +92,7 @@ type Cluster interface {
 	DropExternalCollectionTask(nodeID int64, taskID int64) error
 
 	// CreateCopySegment creates a copy segment task
-	CreateCopySegment(nodeID int64, in *datapb.CopySegmentRequest) error
+	CreateCopySegment(nodeID int64, in *datapb.CopySegmentRequest, collectionID int64) error
 	// QueryCopySegment queries the status of a copy segment task
 	QueryCopySegment(nodeID int64, in *datapb.QueryCopySegmentRequest) (*datapb.QueryCopySegmentResponse, error)
 	// DropCopySegment drops a copy segment task
@@ -209,12 +209,13 @@ func (c *cluster) QuerySlot() map[int64]*WorkerSlots {
 	return availableNodeSlots
 }
 
-func (c *cluster) CreateCompaction(nodeID int64, in *datapb.CompactionPlan) error {
+func (c *cluster) CreateCompaction(nodeID int64, in *datapb.CompactionPlan, collectionID int64) error {
 	properties := taskcommon.NewProperties(nil)
 	properties.AppendClusterID(paramtable.Get().CommonCfg.ClusterPrefix.GetValue())
 	properties.AppendTaskID(in.GetPlanID())
 	properties.AppendType(taskcommon.Compaction)
 	properties.AppendTaskSlot(in.GetSlotUsage())
+	properties.AppendCollectionID(collectionID)
 	return c.createTask(nodeID, in, properties)
 }
 
@@ -289,6 +290,7 @@ func (c *cluster) CreatePreImport(nodeID int64, in *datapb.PreImportRequest, tas
 	properties.AppendTaskID(in.GetTaskID())
 	properties.AppendType(taskcommon.PreImport)
 	properties.AppendTaskSlot(taskSlot)
+	properties.AppendCollectionID(in.GetCollectionID())
 	return c.createTask(nodeID, in, properties)
 }
 
@@ -298,6 +300,7 @@ func (c *cluster) CreateImport(nodeID int64, in *datapb.ImportRequest, taskSlot 
 	properties.AppendTaskID(in.GetTaskID())
 	properties.AppendType(taskcommon.Import)
 	properties.AppendTaskSlot(taskSlot)
+	properties.AppendCollectionID(in.GetCollectionID())
 	return c.createTask(nodeID, in, properties)
 }
 
@@ -411,6 +414,7 @@ func (c *cluster) CreateIndex(nodeID int64, in *workerpb.CreateJobRequest) error
 	properties.AppendTaskSlot(in.GetTaskSlot())
 	properties.AppendNumRows(in.GetNumRows())
 	properties.AppendTaskVersion(in.GetIndexVersion())
+	properties.AppendCollectionID(in.GetCollectionID())
 	return c.createTask(nodeID, in, properties)
 }
 
@@ -487,6 +491,7 @@ func (c *cluster) CreateStats(nodeID int64, in *workerpb.CreateStatsRequest) err
 	properties.AppendTaskSlot(in.GetTaskSlot())
 	properties.AppendNumRows(in.GetNumRows())
 	properties.AppendTaskVersion(in.GetTaskVersion())
+	properties.AppendCollectionID(in.GetCollectionID())
 	return c.createTask(nodeID, in, properties)
 }
 
@@ -561,6 +566,7 @@ func (c *cluster) CreateAnalyze(nodeID int64, in *workerpb.AnalyzeRequest) error
 	properties.AppendType(taskcommon.Analyze)
 	properties.AppendTaskSlot(in.GetTaskSlot())
 	properties.AppendTaskVersion(in.GetVersion())
+	properties.AppendCollectionID(in.GetCollectionID())
 	return c.createTask(nodeID, in, properties)
 }
 
@@ -642,6 +648,7 @@ func (c *cluster) CreateExternalCollectionTask(nodeID int64, req *datapb.UpdateE
 	properties.AppendClusterID(paramtable.Get().CommonCfg.ClusterPrefix.GetValue())
 	properties.AppendTaskID(req.GetTaskID())
 	properties.AppendType(taskcommon.ExternalCollection)
+	properties.AppendCollectionID(req.GetCollectionID())
 
 	payload, err := proto.Marshal(req)
 	if err != nil {
@@ -695,12 +702,13 @@ func (c *cluster) DropExternalCollectionTask(nodeID int64, taskID int64) error {
 	return c.dropTask(nodeID, properties)
 }
 
-func (c *cluster) CreateCopySegment(nodeID int64, in *datapb.CopySegmentRequest) error {
+func (c *cluster) CreateCopySegment(nodeID int64, in *datapb.CopySegmentRequest, collectionID int64) error {
 	properties := taskcommon.NewProperties(nil)
 	properties.AppendClusterID(paramtable.Get().CommonCfg.ClusterPrefix.GetValue())
 	properties.AppendTaskID(in.GetTaskID())
 	properties.AppendType(taskcommon.CopySegment)
 	properties.AppendTaskSlot(in.GetTaskSlot())
+	properties.AppendCollectionID(collectionID)
 	return c.createTask(nodeID, in, properties)
 }
 

--- a/internal/datacoord/session/cluster.go
+++ b/internal/datacoord/session/cluster.go
@@ -45,7 +45,7 @@ type Cluster interface {
 	QuerySlot() map[int64]*WorkerSlots
 
 	// CreateCompaction creates a new compaction task on the specified node
-	CreateCompaction(nodeID int64, in *datapb.CompactionPlan) error
+	CreateCompaction(nodeID int64, in *datapb.CompactionPlan, collectionID int64) error
 	// QueryCompaction queries the status of a compaction task
 	QueryCompaction(nodeID int64, in *datapb.CompactionStateRequest) (*datapb.CompactionPlanResult, error)
 	// DropCompaction drops a compaction task
@@ -91,7 +91,7 @@ type Cluster interface {
 	DropRefreshExternalCollectionTask(nodeID int64, taskID int64) error
 
 	// CreateCopySegment creates a copy segment task
-	CreateCopySegment(nodeID int64, in *datapb.CopySegmentRequest) error
+	CreateCopySegment(nodeID int64, in *datapb.CopySegmentRequest, collectionID int64) error
 	// QueryCopySegment queries the status of a copy segment task
 	QueryCopySegment(nodeID int64, in *datapb.QueryCopySegmentRequest) (*datapb.QueryCopySegmentResponse, error)
 	// DropCopySegment drops a copy segment task
@@ -208,12 +208,13 @@ func (c *cluster) QuerySlot() map[int64]*WorkerSlots {
 	return availableNodeSlots
 }
 
-func (c *cluster) CreateCompaction(nodeID int64, in *datapb.CompactionPlan) error {
+func (c *cluster) CreateCompaction(nodeID int64, in *datapb.CompactionPlan, collectionID int64) error {
 	properties := taskcommon.NewProperties(nil)
 	properties.AppendClusterID(paramtable.Get().CommonCfg.ClusterPrefix.GetValue())
 	properties.AppendTaskID(in.GetPlanID())
 	properties.AppendType(taskcommon.Compaction)
 	properties.AppendTaskSlot(in.GetSlotUsage())
+	properties.AppendCollectionID(collectionID)
 	return c.createTask(nodeID, in, properties)
 }
 
@@ -284,6 +285,7 @@ func (c *cluster) CreatePreImport(nodeID int64, in *datapb.PreImportRequest, tas
 	properties.AppendTaskID(in.GetTaskID())
 	properties.AppendType(taskcommon.PreImport)
 	properties.AppendTaskSlot(taskSlot)
+	properties.AppendCollectionID(in.GetCollectionID())
 	return c.createTask(nodeID, in, properties)
 }
 
@@ -293,6 +295,7 @@ func (c *cluster) CreateImport(nodeID int64, in *datapb.ImportRequest, taskSlot 
 	properties.AppendTaskID(in.GetTaskID())
 	properties.AppendType(taskcommon.Import)
 	properties.AppendTaskSlot(taskSlot)
+	properties.AppendCollectionID(in.GetCollectionID())
 	return c.createTask(nodeID, in, properties)
 }
 
@@ -406,6 +409,7 @@ func (c *cluster) CreateIndex(nodeID int64, in *workerpb.CreateJobRequest) error
 	properties.AppendTaskSlot(in.GetTaskSlot())
 	properties.AppendNumRows(in.GetNumRows())
 	properties.AppendTaskVersion(in.GetIndexVersion())
+	properties.AppendCollectionID(in.GetCollectionID())
 	return c.createTask(nodeID, in, properties)
 }
 
@@ -482,6 +486,7 @@ func (c *cluster) CreateStats(nodeID int64, in *workerpb.CreateStatsRequest) err
 	properties.AppendTaskSlot(in.GetTaskSlot())
 	properties.AppendNumRows(in.GetNumRows())
 	properties.AppendTaskVersion(in.GetTaskVersion())
+	properties.AppendCollectionID(in.GetCollectionID())
 	return c.createTask(nodeID, in, properties)
 }
 
@@ -556,6 +561,7 @@ func (c *cluster) CreateAnalyze(nodeID int64, in *workerpb.AnalyzeRequest) error
 	properties.AppendType(taskcommon.Analyze)
 	properties.AppendTaskSlot(in.GetTaskSlot())
 	properties.AppendTaskVersion(in.GetVersion())
+	properties.AppendCollectionID(in.GetCollectionID())
 	return c.createTask(nodeID, in, properties)
 }
 
@@ -638,6 +644,7 @@ func (c *cluster) CreateRefreshExternalCollectionTask(nodeID int64, req *datapb.
 	properties.AppendTaskID(req.GetTaskID())
 	properties.AppendType(taskcommon.RefreshExternalCollection)
 	properties.AppendTaskSlot(1)
+	properties.AppendCollectionID(req.GetCollectionID())
 
 	payload, err := proto.Marshal(req)
 	if err != nil {
@@ -691,12 +698,13 @@ func (c *cluster) DropRefreshExternalCollectionTask(nodeID int64, taskID int64) 
 	return c.dropTask(nodeID, properties)
 }
 
-func (c *cluster) CreateCopySegment(nodeID int64, in *datapb.CopySegmentRequest) error {
+func (c *cluster) CreateCopySegment(nodeID int64, in *datapb.CopySegmentRequest, collectionID int64) error {
 	properties := taskcommon.NewProperties(nil)
 	properties.AppendClusterID(paramtable.Get().CommonCfg.ClusterPrefix.GetValue())
 	properties.AppendTaskID(in.GetTaskID())
 	properties.AppendType(taskcommon.CopySegment)
 	properties.AppendTaskSlot(in.GetTaskSlot())
+	properties.AppendCollectionID(collectionID)
 	return c.createTask(nodeID, in, properties)
 }
 

--- a/internal/datacoord/session/cluster.go
+++ b/internal/datacoord/session/cluster.go
@@ -279,7 +279,6 @@ func (c *cluster) DropCompaction(nodeID int64, planID int64) error {
 }
 
 func (c *cluster) CreatePreImport(nodeID int64, in *datapb.PreImportRequest, taskSlot int64) error {
-	// TODO: sheep, use taskSlot in request
 	properties := taskcommon.NewProperties(nil)
 	properties.AppendClusterID(paramtable.Get().CommonCfg.ClusterPrefix.GetValue())
 	properties.AppendTaskID(in.GetTaskID())

--- a/internal/datacoord/session/cluster_test.go
+++ b/internal/datacoord/session/cluster_test.go
@@ -198,7 +198,7 @@ func TestCluster_Compaction(t *testing.T) {
 		mockClient.EXPECT().CreateTask(mock.Anything, mock.Anything).Return(merr.Success(), nil)
 
 		// Test
-		err := cluster.CreateCompaction(1, &datapb.CompactionPlan{})
+		err := cluster.CreateCompaction(1, &datapb.CompactionPlan{}, 100)
 		assert.NoError(t, err)
 	})
 
@@ -703,7 +703,7 @@ func TestCluster_CreateProperties(t *testing.T) {
 			PlanID:    1,
 			SlotUsage: 1,
 		}
-		err := cluster.CreateCompaction(1, req)
+		err := cluster.CreateCompaction(1, req, 100)
 		assert.NoError(t, err)
 	})
 
@@ -753,6 +753,92 @@ func TestCluster_CreateProperties(t *testing.T) {
 			Version:  1,
 		}
 		err := cluster.CreateAnalyze(1, req)
+		assert.NoError(t, err)
+	})
+}
+
+func TestCluster_CreateProperties_CollectionID(t *testing.T) {
+	const expectedCollectionID int64 = 778899
+
+	mockNodeManager := NewMockNodeManager(t)
+	cluster := NewCluster(mockNodeManager)
+	mockClient := mocks.NewMockDataNodeClient(t)
+	mockNodeManager.EXPECT().GetClient(mock.Anything).Return(mockClient, nil)
+
+	mockClient.EXPECT().CreateTask(mock.Anything, mock.MatchedBy(func(req *workerpb.CreateTaskRequest) bool {
+		props := taskcommon.NewProperties(req.GetProperties())
+		assert.Equal(t, expectedCollectionID, props.GetCollectionID(),
+			"collection_id must be propagated into task properties")
+		return true
+	})).Return(merr.Success(), nil)
+
+	t.Run("CreateCompaction", func(t *testing.T) {
+		err := cluster.CreateCompaction(1, &datapb.CompactionPlan{PlanID: 1, SlotUsage: 1}, expectedCollectionID)
+		assert.NoError(t, err)
+	})
+
+	t.Run("CreatePreImport", func(t *testing.T) {
+		err := cluster.CreatePreImport(1, &datapb.PreImportRequest{
+			TaskID:       1,
+			CollectionID: expectedCollectionID,
+		}, 1)
+		assert.NoError(t, err)
+	})
+
+	t.Run("CreateImport", func(t *testing.T) {
+		err := cluster.CreateImport(1, &datapb.ImportRequest{
+			TaskID:       1,
+			CollectionID: expectedCollectionID,
+		}, 1)
+		assert.NoError(t, err)
+	})
+
+	t.Run("CreateIndex", func(t *testing.T) {
+		err := cluster.CreateIndex(1, &workerpb.CreateJobRequest{
+			BuildID:      1,
+			TaskSlot:     1,
+			NumRows:      1000,
+			IndexVersion: 1,
+			CollectionID: expectedCollectionID,
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("CreateStats", func(t *testing.T) {
+		err := cluster.CreateStats(1, &workerpb.CreateStatsRequest{
+			TaskID:       1,
+			TaskSlot:     1,
+			NumRows:      1000,
+			TaskVersion:  1,
+			SubJobType:   indexpb.StatsSubJob_Sort,
+			CollectionID: expectedCollectionID,
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("CreateAnalyze", func(t *testing.T) {
+		err := cluster.CreateAnalyze(1, &workerpb.AnalyzeRequest{
+			TaskID:       1,
+			TaskSlot:     1,
+			Version:      1,
+			CollectionID: expectedCollectionID,
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("CreateCopySegment", func(t *testing.T) {
+		err := cluster.CreateCopySegment(1, &datapb.CopySegmentRequest{
+			TaskID:   1,
+			TaskSlot: 1,
+		}, expectedCollectionID)
+		assert.NoError(t, err)
+	})
+
+	t.Run("CreateExternalCollectionTask", func(t *testing.T) {
+		err := cluster.CreateExternalCollectionTask(1, &datapb.UpdateExternalCollectionRequest{
+			TaskID:       1,
+			CollectionID: expectedCollectionID,
+		})
 		assert.NoError(t, err)
 	})
 }
@@ -934,7 +1020,7 @@ func TestCluster_CopySegment(t *testing.T) {
 			TaskID:   123,
 			TaskSlot: 1,
 		}
-		err := cluster.CreateCopySegment(1, req)
+		err := cluster.CreateCopySegment(1, req, 100)
 		assert.NoError(t, err)
 	})
 
@@ -950,7 +1036,7 @@ func TestCluster_CopySegment(t *testing.T) {
 			TaskID:   123,
 			TaskSlot: 1,
 		}
-		err := cluster.CreateCopySegment(1, req)
+		err := cluster.CreateCopySegment(1, req, 100)
 		assert.Error(t, err)
 	})
 

--- a/internal/datacoord/session/cluster_test.go
+++ b/internal/datacoord/session/cluster_test.go
@@ -769,11 +769,13 @@ func TestCluster_CreateProperties_CollectionID(t *testing.T) {
 	mockClient := mocks.NewMockDataNodeClient(t)
 	mockNodeManager.EXPECT().GetClient(mock.Anything).Return(mockClient, nil)
 
+	// The expectation is intentionally shared by all sub-tests; testify/mock
+	// allows unlimited calls unless Once/Times is specified.
 	mockClient.EXPECT().CreateTask(mock.Anything, mock.MatchedBy(func(req *workerpb.CreateTaskRequest) bool {
 		props := taskcommon.NewProperties(req.GetProperties())
-		assert.Equal(t, expectedCollectionID, props.GetCollectionID(),
+		collectionID, err := props.GetCollectionID()
+		return assert.NoError(t, err) && assert.Equal(t, expectedCollectionID, collectionID,
 			"collection_id must be propagated into task properties")
-		return true
 	})).Return(merr.Success(), nil)
 
 	t.Run("CreateCompaction", func(t *testing.T) {

--- a/internal/datacoord/session/cluster_test.go
+++ b/internal/datacoord/session/cluster_test.go
@@ -198,7 +198,7 @@ func TestCluster_Compaction(t *testing.T) {
 		mockClient.EXPECT().CreateTask(mock.Anything, mock.Anything).Return(merr.Success(), nil)
 
 		// Test
-		err := cluster.CreateCompaction(1, &datapb.CompactionPlan{})
+		err := cluster.CreateCompaction(1, &datapb.CompactionPlan{}, 100)
 		assert.NoError(t, err)
 	})
 
@@ -707,7 +707,7 @@ func TestCluster_CreateProperties(t *testing.T) {
 			PlanID:    1,
 			SlotUsage: 1,
 		}
-		err := cluster.CreateCompaction(1, req)
+		err := cluster.CreateCompaction(1, req, 100)
 		assert.NoError(t, err)
 	})
 
@@ -757,6 +757,92 @@ func TestCluster_CreateProperties(t *testing.T) {
 			Version:  1,
 		}
 		err := cluster.CreateAnalyze(1, req)
+		assert.NoError(t, err)
+	})
+}
+
+func TestCluster_CreateProperties_CollectionID(t *testing.T) {
+	const expectedCollectionID int64 = 778899
+
+	mockNodeManager := NewMockNodeManager(t)
+	cluster := NewCluster(mockNodeManager)
+	mockClient := mocks.NewMockDataNodeClient(t)
+	mockNodeManager.EXPECT().GetClient(mock.Anything).Return(mockClient, nil)
+
+	mockClient.EXPECT().CreateTask(mock.Anything, mock.MatchedBy(func(req *workerpb.CreateTaskRequest) bool {
+		props := taskcommon.NewProperties(req.GetProperties())
+		assert.Equal(t, expectedCollectionID, props.GetCollectionID(),
+			"collection_id must be propagated into task properties")
+		return true
+	})).Return(merr.Success(), nil)
+
+	t.Run("CreateCompaction", func(t *testing.T) {
+		err := cluster.CreateCompaction(1, &datapb.CompactionPlan{PlanID: 1, SlotUsage: 1}, expectedCollectionID)
+		assert.NoError(t, err)
+	})
+
+	t.Run("CreatePreImport", func(t *testing.T) {
+		err := cluster.CreatePreImport(1, &datapb.PreImportRequest{
+			TaskID:       1,
+			CollectionID: expectedCollectionID,
+		}, 1)
+		assert.NoError(t, err)
+	})
+
+	t.Run("CreateImport", func(t *testing.T) {
+		err := cluster.CreateImport(1, &datapb.ImportRequest{
+			TaskID:       1,
+			CollectionID: expectedCollectionID,
+		}, 1)
+		assert.NoError(t, err)
+	})
+
+	t.Run("CreateIndex", func(t *testing.T) {
+		err := cluster.CreateIndex(1, &workerpb.CreateJobRequest{
+			BuildID:      1,
+			TaskSlot:     1,
+			NumRows:      1000,
+			IndexVersion: 1,
+			CollectionID: expectedCollectionID,
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("CreateStats", func(t *testing.T) {
+		err := cluster.CreateStats(1, &workerpb.CreateStatsRequest{
+			TaskID:       1,
+			TaskSlot:     1,
+			NumRows:      1000,
+			TaskVersion:  1,
+			SubJobType:   indexpb.StatsSubJob_Sort,
+			CollectionID: expectedCollectionID,
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("CreateAnalyze", func(t *testing.T) {
+		err := cluster.CreateAnalyze(1, &workerpb.AnalyzeRequest{
+			TaskID:       1,
+			TaskSlot:     1,
+			Version:      1,
+			CollectionID: expectedCollectionID,
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("CreateCopySegment", func(t *testing.T) {
+		err := cluster.CreateCopySegment(1, &datapb.CopySegmentRequest{
+			TaskID:   1,
+			TaskSlot: 1,
+		}, expectedCollectionID)
+		assert.NoError(t, err)
+	})
+
+	t.Run("CreateRefreshExternalCollectionTask", func(t *testing.T) {
+		err := cluster.CreateRefreshExternalCollectionTask(1, &datapb.RefreshExternalCollectionTaskRequest{
+			TaskID:       1,
+			CollectionID: expectedCollectionID,
+		})
 		assert.NoError(t, err)
 	})
 }
@@ -938,7 +1024,7 @@ func TestCluster_CopySegment(t *testing.T) {
 			TaskID:   123,
 			TaskSlot: 1,
 		}
-		err := cluster.CreateCopySegment(1, req)
+		err := cluster.CreateCopySegment(1, req, 100)
 		assert.NoError(t, err)
 	})
 
@@ -954,7 +1040,7 @@ func TestCluster_CopySegment(t *testing.T) {
 			TaskID:   123,
 			TaskSlot: 1,
 		}
-		err := cluster.CreateCopySegment(1, req)
+		err := cluster.CreateCopySegment(1, req, 100)
 		assert.Error(t, err)
 	})
 

--- a/internal/datacoord/session/mock_cluster.go
+++ b/internal/datacoord/session/mock_cluster.go
@@ -69,17 +69,17 @@ func (_c *MockCluster_CreateAnalyze_Call) RunAndReturn(run func(int64, *workerpb
 	return _c
 }
 
-// CreateCompaction provides a mock function with given fields: nodeID, in
-func (_m *MockCluster) CreateCompaction(nodeID int64, in *datapb.CompactionPlan) error {
-	ret := _m.Called(nodeID, in)
+// CreateCompaction provides a mock function with given fields: nodeID, in, collectionID
+func (_m *MockCluster) CreateCompaction(nodeID int64, in *datapb.CompactionPlan, collectionID int64) error {
+	ret := _m.Called(nodeID, in, collectionID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateCompaction")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(int64, *datapb.CompactionPlan) error); ok {
-		r0 = rf(nodeID, in)
+	if rf, ok := ret.Get(0).(func(int64, *datapb.CompactionPlan, int64) error); ok {
+		r0 = rf(nodeID, in, collectionID)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -95,13 +95,14 @@ type MockCluster_CreateCompaction_Call struct {
 // CreateCompaction is a helper method to define mock.On call
 //   - nodeID int64
 //   - in *datapb.CompactionPlan
-func (_e *MockCluster_Expecter) CreateCompaction(nodeID interface{}, in interface{}) *MockCluster_CreateCompaction_Call {
-	return &MockCluster_CreateCompaction_Call{Call: _e.mock.On("CreateCompaction", nodeID, in)}
+//   - collectionID int64
+func (_e *MockCluster_Expecter) CreateCompaction(nodeID interface{}, in interface{}, collectionID interface{}) *MockCluster_CreateCompaction_Call {
+	return &MockCluster_CreateCompaction_Call{Call: _e.mock.On("CreateCompaction", nodeID, in, collectionID)}
 }
 
-func (_c *MockCluster_CreateCompaction_Call) Run(run func(nodeID int64, in *datapb.CompactionPlan)) *MockCluster_CreateCompaction_Call {
+func (_c *MockCluster_CreateCompaction_Call) Run(run func(nodeID int64, in *datapb.CompactionPlan, collectionID int64)) *MockCluster_CreateCompaction_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(int64), args[1].(*datapb.CompactionPlan))
+		run(args[0].(int64), args[1].(*datapb.CompactionPlan), args[2].(int64))
 	})
 	return _c
 }
@@ -111,22 +112,22 @@ func (_c *MockCluster_CreateCompaction_Call) Return(_a0 error) *MockCluster_Crea
 	return _c
 }
 
-func (_c *MockCluster_CreateCompaction_Call) RunAndReturn(run func(int64, *datapb.CompactionPlan) error) *MockCluster_CreateCompaction_Call {
+func (_c *MockCluster_CreateCompaction_Call) RunAndReturn(run func(int64, *datapb.CompactionPlan, int64) error) *MockCluster_CreateCompaction_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// CreateCopySegment provides a mock function with given fields: nodeID, in
-func (_m *MockCluster) CreateCopySegment(nodeID int64, in *datapb.CopySegmentRequest) error {
-	ret := _m.Called(nodeID, in)
+// CreateCopySegment provides a mock function with given fields: nodeID, in, collectionID
+func (_m *MockCluster) CreateCopySegment(nodeID int64, in *datapb.CopySegmentRequest, collectionID int64) error {
+	ret := _m.Called(nodeID, in, collectionID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateCopySegment")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(int64, *datapb.CopySegmentRequest) error); ok {
-		r0 = rf(nodeID, in)
+	if rf, ok := ret.Get(0).(func(int64, *datapb.CopySegmentRequest, int64) error); ok {
+		r0 = rf(nodeID, in, collectionID)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -142,13 +143,14 @@ type MockCluster_CreateCopySegment_Call struct {
 // CreateCopySegment is a helper method to define mock.On call
 //   - nodeID int64
 //   - in *datapb.CopySegmentRequest
-func (_e *MockCluster_Expecter) CreateCopySegment(nodeID interface{}, in interface{}) *MockCluster_CreateCopySegment_Call {
-	return &MockCluster_CreateCopySegment_Call{Call: _e.mock.On("CreateCopySegment", nodeID, in)}
+//   - collectionID int64
+func (_e *MockCluster_Expecter) CreateCopySegment(nodeID interface{}, in interface{}, collectionID interface{}) *MockCluster_CreateCopySegment_Call {
+	return &MockCluster_CreateCopySegment_Call{Call: _e.mock.On("CreateCopySegment", nodeID, in, collectionID)}
 }
 
-func (_c *MockCluster_CreateCopySegment_Call) Run(run func(nodeID int64, in *datapb.CopySegmentRequest)) *MockCluster_CreateCopySegment_Call {
+func (_c *MockCluster_CreateCopySegment_Call) Run(run func(nodeID int64, in *datapb.CopySegmentRequest, collectionID int64)) *MockCluster_CreateCopySegment_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(int64), args[1].(*datapb.CopySegmentRequest))
+		run(args[0].(int64), args[1].(*datapb.CopySegmentRequest), args[2].(int64))
 	})
 	return _c
 }
@@ -158,7 +160,7 @@ func (_c *MockCluster_CreateCopySegment_Call) Return(_a0 error) *MockCluster_Cre
 	return _c
 }
 
-func (_c *MockCluster_CreateCopySegment_Call) RunAndReturn(run func(int64, *datapb.CopySegmentRequest) error) *MockCluster_CreateCopySegment_Call {
+func (_c *MockCluster_CreateCopySegment_Call) RunAndReturn(run func(int64, *datapb.CopySegmentRequest, int64) error) *MockCluster_CreateCopySegment_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/taskcommon/properties.go
+++ b/pkg/taskcommon/properties.go
@@ -26,13 +26,14 @@ import (
 // properties keys
 const (
 	// request
-	ClusterIDKey   = "cluster_id"
-	TaskIDKey      = "task_id"
-	TypeKey        = "task_type"
-	SubTypeKey     = "task_sub_type" // optional, only for Stats
-	SlotKey        = "task_slot"
-	NumRowsKey     = "num_row"      // optional, only for Index, Stats
-	TaskVersionKey = "task_version" // optional, only for Index, Stats and Analyze
+	ClusterIDKey    = "cluster_id"
+	TaskIDKey       = "task_id"
+	TypeKey         = "task_type"
+	SubTypeKey      = "task_sub_type" // optional, only for Stats
+	SlotKey         = "task_slot"
+	NumRowsKey      = "num_row"      // optional, only for Index, Stats
+	TaskVersionKey  = "task_version" // optional, only for Index, Stats and Analyze
+	CollectionIDKey = "collection_id"
 
 	// result
 	StateKey  = "task_state"
@@ -83,6 +84,10 @@ func (p Properties) AppendNumRows(rows int64) {
 
 func (p Properties) AppendTaskVersion(version int64) {
 	p[TaskVersionKey] = fmt.Sprintf("%d", version)
+}
+
+func (p Properties) AppendCollectionID(collectionID int64) {
+	p[CollectionIDKey] = fmt.Sprintf("%d", collectionID)
 }
 
 func (p Properties) AppendReason(reason string) {
@@ -182,4 +187,15 @@ func (p Properties) GetTaskVersion() int64 {
 		return 0
 	}
 	return version
+}
+
+func (p Properties) GetCollectionID() int64 {
+	if _, ok := p[CollectionIDKey]; !ok {
+		return 0
+	}
+	collectionID, err := strconv.ParseInt(p[CollectionIDKey], 10, 64)
+	if err != nil {
+		return 0
+	}
+	return collectionID
 }

--- a/pkg/taskcommon/properties.go
+++ b/pkg/taskcommon/properties.go
@@ -189,13 +189,13 @@ func (p Properties) GetTaskVersion() int64 {
 	return version
 }
 
-func (p Properties) GetCollectionID() int64 {
+func (p Properties) GetCollectionID() (int64, error) {
 	if _, ok := p[CollectionIDKey]; !ok {
-		return 0
+		return 0, WrapErrTaskPropertyLack(CollectionIDKey, p[TaskIDKey])
 	}
 	collectionID, err := strconv.ParseInt(p[CollectionIDKey], 10, 64)
 	if err != nil {
-		return 0
+		return 0, err
 	}
-	return collectionID
+	return collectionID, nil
 }

--- a/pkg/taskcommon/properties_test.go
+++ b/pkg/taskcommon/properties_test.go
@@ -58,3 +58,37 @@ func TestProperties_GetTaskType_Unrecognized(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "UnknownType", taskType)
 }
+
+func TestProperties_CollectionID(t *testing.T) {
+	t.Run("append and get", func(t *testing.T) {
+		props := NewProperties(nil)
+		props.AppendCollectionID(123456789)
+		assert.Equal(t, "123456789", props[CollectionIDKey])
+		assert.Equal(t, int64(123456789), props.GetCollectionID())
+	})
+
+	t.Run("get missing returns zero", func(t *testing.T) {
+		props := NewProperties(nil)
+		assert.Equal(t, int64(0), props.GetCollectionID())
+	})
+
+	t.Run("get invalid returns zero", func(t *testing.T) {
+		props := NewProperties(map[string]string{
+			CollectionIDKey: "not_a_number",
+		})
+		assert.Equal(t, int64(0), props.GetCollectionID())
+	})
+
+	t.Run("zero value round-trip", func(t *testing.T) {
+		props := NewProperties(nil)
+		props.AppendCollectionID(0)
+		assert.Equal(t, "0", props[CollectionIDKey])
+		assert.Equal(t, int64(0), props.GetCollectionID())
+	})
+
+	t.Run("negative value round-trip", func(t *testing.T) {
+		props := NewProperties(nil)
+		props.AppendCollectionID(-1)
+		assert.Equal(t, int64(-1), props.GetCollectionID())
+	})
+}

--- a/pkg/taskcommon/properties_test.go
+++ b/pkg/taskcommon/properties_test.go
@@ -64,31 +64,39 @@ func TestProperties_CollectionID(t *testing.T) {
 		props := NewProperties(nil)
 		props.AppendCollectionID(123456789)
 		assert.Equal(t, "123456789", props[CollectionIDKey])
-		assert.Equal(t, int64(123456789), props.GetCollectionID())
+		collectionID, err := props.GetCollectionID()
+		assert.NoError(t, err)
+		assert.Equal(t, int64(123456789), collectionID)
 	})
 
-	t.Run("get missing returns zero", func(t *testing.T) {
+	t.Run("get missing returns error", func(t *testing.T) {
 		props := NewProperties(nil)
-		assert.Equal(t, int64(0), props.GetCollectionID())
+		_, err := props.GetCollectionID()
+		assert.Error(t, err)
 	})
 
-	t.Run("get invalid returns zero", func(t *testing.T) {
+	t.Run("get invalid returns error", func(t *testing.T) {
 		props := NewProperties(map[string]string{
 			CollectionIDKey: "not_a_number",
 		})
-		assert.Equal(t, int64(0), props.GetCollectionID())
+		_, err := props.GetCollectionID()
+		assert.Error(t, err)
 	})
 
 	t.Run("zero value round-trip", func(t *testing.T) {
 		props := NewProperties(nil)
 		props.AppendCollectionID(0)
 		assert.Equal(t, "0", props[CollectionIDKey])
-		assert.Equal(t, int64(0), props.GetCollectionID())
+		collectionID, err := props.GetCollectionID()
+		assert.NoError(t, err)
+		assert.Equal(t, int64(0), collectionID)
 	})
 
 	t.Run("negative value round-trip", func(t *testing.T) {
 		props := NewProperties(nil)
 		props.AppendCollectionID(-1)
-		assert.Equal(t, int64(-1), props.GetCollectionID())
+		collectionID, err := props.GetCollectionID()
+		assert.NoError(t, err)
+		assert.Equal(t, int64(-1), collectionID)
 	})
 }


### PR DESCRIPTION
issue: #49136

## Summary

Add `collection_id` to the `Properties` map of every task that datacoord's `Cluster.createTask` dispatches to datanode (Compaction, PreImport, Import, Index, Stats, Analyze, ExternalCollection, CopySegment). This is groundwork for worker-side attribution and telemetry without decoding every task payload; this PR only propagates the wire field and does not add the datanode-side consumer yet.

## What changed

- Add `CollectionIDKey`, `AppendCollectionID`, `GetCollectionID` helpers in `pkg/taskcommon.Properties`.
- `GetCollectionID` returns `(int64, error)` so future consumers can distinguish a missing / invalid property from an explicit `0` value.
- For requests whose proto already exposes `CollectionID` — `PreImportRequest`, `ImportRequest`, `CreateJobRequest`, `CreateStatsRequest`, `AnalyzeRequest`, `UpdateExternalCollectionRequest` — read it directly from the request.
- `CompactionPlan` and `CopySegmentRequest` have no top-level `CollectionID` field, so `CreateCompaction` / `CreateCopySegment` now take an explicit `collectionID int64` argument (consistent with the existing `taskSlot` parameter of `CreatePreImport` / `CreateImport`). Callers pass `t.GetTaskProto().GetCollectionID()` / `t.GetCollectionId()`, which are already tracked in task metadata.
- Update `MockCluster`, existing callers and existing tests accordingly.
- Add a dedicated unit test `TestCluster_CreateProperties_CollectionID` asserting that `collection_id` is carried in the `CreateTaskRequest.Properties` for all eight task types, plus round-trip tests for the new properties helpers.

## Follow-up

- Add the datanode-side consumer for `collection_id` once the worker-side attribution / telemetry path lands.
- Consider adding top-level `collection_id` fields to `CompactionPlan` and `CopySegmentRequest` so all `Create*` paths can read collection IDs directly from their request protos.

## Test plan

- [x] `go test ./taskcommon/...` from `pkg/` — `TestProperties_CollectionID` and pre-existing tests pass.
- [x] `go test -tags=test ./internal/datacoord/session/...` — previously passed for `TestCluster_CreateProperties`, `TestCluster_CreateProperties_CollectionID`, `TestCluster_{Compaction,Import,Index,Stats,Analyze,CopySegment}`.
- [x] `go test -tags=test -run "TestL0CompactionTask|TestClusteringCompactionTask|TestMixCompactionTask|TestCopySegment" ./internal/datacoord/` — affected compaction / copy-segment suites pass.
- [x] `go build ./internal/datacoord/...` — clean build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
