### PR TITLE
enhance: [3.0] add preferFieldDataWhenIndexHasRawData toggle for sealed retrieve

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -538,7 +538,6 @@ queryNode:
     fixedFileSizeForMmapAlloc: 1 # tmp file size for mmap chunk manager
     maxDiskUsagePercentageForMmapAlloc: 50 # disk percentage used in mmap chunk manager
   indexOffsetCacheEnabled: false # enable index offset cache for some scalar indexes, now is just for bitmap index, enable this param can improve performance for retrieving raw data from index
-  preferFieldDataWhenIndexHasRawData: false # when true, sealed retrieve prefers field data in columns over index raw data when both are available. Note: enabling this keeps both the raw field data and the index resident in memory, roughly doubling the memory footprint for fields whose index normally supplies raw data.
   scheduler:
     receiveChanSize: 10240
     unsolvedQueueSize: 10240

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -538,6 +538,10 @@ queryNode:
     fixedFileSizeForMmapAlloc: 1 # tmp file size for mmap chunk manager
     maxDiskUsagePercentageForMmapAlloc: 50 # disk percentage used in mmap chunk manager
   indexOffsetCacheEnabled: false # enable index offset cache for some scalar indexes, now is just for bitmap index, enable this param can improve performance for retrieving raw data from index
+  # when enabled, sealed retrieve prefers field data over index raw data when both are available.
+  # Note: enabling this keeps both the raw field data and the index resident in memory,
+  # roughly doubling the memory footprint for fields whose index normally supplies raw data.
+  preferFieldDataWhenIndexHasRawData: false
   scheduler:
     receiveChanSize: 10240
     unsolvedQueueSize: 10240

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -538,10 +538,7 @@ queryNode:
     fixedFileSizeForMmapAlloc: 1 # tmp file size for mmap chunk manager
     maxDiskUsagePercentageForMmapAlloc: 50 # disk percentage used in mmap chunk manager
   indexOffsetCacheEnabled: false # enable index offset cache for some scalar indexes, now is just for bitmap index, enable this param can improve performance for retrieving raw data from index
-  # when enabled, sealed retrieve prefers field data over index raw data when both are available.
-  # Note: enabling this keeps both the raw field data and the index resident in memory,
-  # roughly doubling the memory footprint for fields whose index normally supplies raw data.
-  preferFieldDataWhenIndexHasRawData: false
+  preferFieldDataWhenIndexHasRawData: false # when true, sealed retrieve prefers field data in columns over index raw data when both are available. Note: enabling this keeps both the raw field data and the index resident in memory, roughly doubling the memory footprint for fields whose index normally supplies raw data.
   scheduler:
     receiveChanSize: 10240
     unsolvedQueueSize: 10240

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -3067,20 +3067,31 @@ ChunkedSegmentSealedImpl::bulk_subscript(milvus::OpContext* op_ctx,
         return ret;
     }
 
+    // Decide once whether to serve this retrieve from column data instead of
+    // the index-backed raw data. The flag is off by default, so short-circuit
+    // before touching HasFieldData — that call takes a shared_lock and would
+    // otherwise be paid on every retrieve regardless of the flag.
+    bool use_field_data =
+        SegcoreConfig::default_config()
+            .get_prefer_field_data_when_index_has_raw_data() &&
+        HasFieldData(field_id);
+
     if (!IsVectorDataType(field_meta.get_data_type())) {
         // === Scalar field ===
-        // Try index first: if scalar index exists and has raw data, read from index
-        PinWrapper<const index::IndexBase*> pin_scalar_index_ptr;
-        auto scalar_indexes = PinIndex(op_ctx, field_id);
-        if (!scalar_indexes.empty()) {
-            pin_scalar_index_ptr = std::move(scalar_indexes[0]);
-            if (IndexHasRawData(field_id)) {
-                return ReverseDataFromIndex(
-                    pin_scalar_index_ptr.get(), seg_offsets, count, field_meta);
+        if (!use_field_data) {
+            // Try index first: if scalar index exists and has raw data, read from index
+            PinWrapper<const index::IndexBase*> pin_scalar_index_ptr;
+            auto scalar_indexes = PinIndex(op_ctx, field_id);
+            if (!scalar_indexes.empty()) {
+                pin_scalar_index_ptr = std::move(scalar_indexes[0]);
+                if (IndexHasRawData(field_id)) {
+                    return ReverseDataFromIndex(pin_scalar_index_ptr.get(),
+                                                seg_offsets,
+                                                count,
+                                                field_meta);
+                }
             }
         }
-        // Fallback to field data
-        auto [field, exist] = GetFieldDataIfExist(field_id);
         return get_raw_data(op_ctx, field_id, field_meta, seg_offsets, count);
     }
 
@@ -3090,11 +3101,9 @@ ChunkedSegmentSealedImpl::bulk_subscript(milvus::OpContext* op_ctx,
 
     std::unique_ptr<DataArray> vector{nullptr};
     // Try index first: if vector index exists and has raw data, read from index
-    if (IndexHasRawData(field_id)) {
+    if (!use_field_data && IndexHasRawData(field_id)) {
         vector = get_vector(op_ctx, field_id, seg_offsets, count);
     } else {
-        // Fallback to field data
-        auto [field, exist] = GetFieldDataIfExist(field_id);
         vector = get_raw_data(op_ctx, field_id, field_meta, seg_offsets, count);
     }
 

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -4447,6 +4447,12 @@ ChunkedSegmentSealedImpl::LoadBatchFieldData(
              field_binlog_to_load.size(),
              id_);
 
+    // When the flag is on, the loader must keep the column resident alongside
+    // the index so bulk_subscript can serve retrieve from field data.
+    auto prefer_field_data =
+        SegcoreConfig::default_config()
+            .get_prefer_field_data_when_index_has_raw_data();
+
     std::map<FieldId, LoadFieldDataInfo> field_data_to_load;
     for (auto& [field_ids, field_binlog] : field_binlog_to_load) {
         LoadFieldDataInfo load_field_data_info;
@@ -4507,8 +4513,10 @@ ChunkedSegmentSealedImpl::LoadBatchFieldData(
         }
 
         auto group_id = field_binlog.fieldid();
-        // Skip if this field has an index with raw data
-        if (index_has_raw_data) {
+        // Normally we skip loading field data when the index already carries
+        // raw data, but prefer_field_data_when_index_has_raw_data opts into
+        // keeping both resident so retrieve can read the column directly.
+        if (index_has_raw_data && !prefer_field_data) {
             LOG_INFO(
                 "Skip loading fielddata for segment {} group {} because "
                 "index "

--- a/internal/core/src/segcore/SegcoreConfig.h
+++ b/internal/core/src/segcore/SegcoreConfig.h
@@ -166,6 +166,16 @@ class SegcoreConfig {
         return visibility_filter_enabled_;
     }
 
+    void
+    set_prefer_field_data_when_index_has_raw_data(bool value) {
+        prefer_field_data_when_index_has_raw_data_ = value;
+    }
+
+    bool
+    get_prefer_field_data_when_index_has_raw_data() const {
+        return prefer_field_data_when_index_has_raw_data_;
+    }
+
     static constexpr int64_t kDefaultMaxGroupByGroups = 100000;
 
     int64_t
@@ -208,6 +218,7 @@ class SegcoreConfig {
     inline static bool refine_with_quant_flag_ = false;
     inline static bool enable_geometry_cache_ = false;
     inline static bool visibility_filter_enabled_ = true;
+    inline static bool prefer_field_data_when_index_has_raw_data_ = false;
     inline static float interim_index_mem_expansion_rate_ = 1.15f;
     inline static int64_t max_group_by_groups_ = kDefaultMaxGroupByGroups;
 };

--- a/internal/core/src/segcore/SegmentLoadInfo.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfo.cpp
@@ -23,6 +23,7 @@
 #include "milvus-storage/column_groups.h"
 #include "milvus-storage/manifest.h"
 #include "pb/schema.pb.h"
+#include "segcore/SegcoreConfig.h"
 #include "segcore/SegmentLoadInfo.h"
 #include "storage/LocalChunkManager.h"
 #include "storage/LocalChunkManagerSingleton.h"
@@ -240,6 +241,10 @@ SegmentLoadInfo::ComputeDiffIndexes(LoadDiff& diff, SegmentLoadInfo& new_info) {
 
 void
 SegmentLoadInfo::ComputeDiffBinlogs(LoadDiff& diff, SegmentLoadInfo& new_info) {
+    auto prefer_field_data =
+        SegcoreConfig::default_config()
+            .get_prefer_field_data_when_index_has_raw_data();
+
     // field id -> binlog group id
     std::map<int64_t, int64_t> current_fields;
     for (int i = 0; i < GetBinlogPathCount(); i++) {
@@ -331,6 +336,10 @@ SegmentLoadInfo::ComputeDiffBinlogs(LoadDiff& diff, SegmentLoadInfo& new_info) {
     // Find field data to drop: fields in current but not in new_info
     for (const auto& [field_id, group_id] : current_fields) {
         if (new_binlog_fields.find(field_id) == new_binlog_fields.end()) {
+            if (prefer_field_data && new_info.field_index_has_raw_data_.count(
+                                         FieldId(field_id)) > 0) {
+                continue;
+            }
             diff.field_data_to_drop.emplace(field_id);
         }
     }
@@ -339,6 +348,9 @@ SegmentLoadInfo::ComputeDiffBinlogs(LoadDiff& diff, SegmentLoadInfo& new_info) {
 void
 SegmentLoadInfo::ComputeDiffColumnGroups(LoadDiff& diff,
                                          SegmentLoadInfo& new_info) {
+    auto prefer_field_data =
+        SegcoreConfig::default_config()
+            .get_prefer_field_data_when_index_has_raw_data();
     auto cur_column_group = GetColumnGroups();
     auto new_column_group = new_info.GetColumnGroups();
 
@@ -410,24 +422,24 @@ SegmentLoadInfo::ComputeDiffColumnGroups(LoadDiff& diff,
             bool files_changed = cur_iter != cur_field_to_files.end() &&
                                  !same_files(*cur_iter->second, cg->files);
             bool is_replace_field = was_default_filled || files_changed;
+            bool index_has_raw_data =
+                new_info.field_index_has_raw_data_.count(FieldId(field_id)) > 0;
+            // Eager-load when: system field, OR schema says load AND
+            // (we want to keep field data alongside index, OR index can't serve raw).
+            bool should_eager_load =
+                field_id < START_USER_FIELDID ||
+                (schema_->ShouldLoadField(FieldId(field_id)) &&
+                 (prefer_field_data || !index_has_raw_data));
             if (is_new_field) {
                 // Field not in current and not default-filled → new load
-                if (field_id < START_USER_FIELDID ||
-                    (schema_->ShouldLoadField(FieldId(field_id)) &&
-                     new_info.field_index_has_raw_data_.find(
-                         FieldId(field_id)) ==
-                         new_info.field_index_has_raw_data_.end())) {
+                if (should_eager_load) {
                     fields.emplace_back(field_id);
                 } else {
                     lazy_fields.emplace_back(field_id);
                 }
             } else if (is_replace_field) {
                 // Field was default-filled or moved between groups → replace
-                if (field_id < START_USER_FIELDID ||
-                    (schema_->ShouldLoadField(FieldId(field_id)) &&
-                     new_info.field_index_has_raw_data_.find(
-                         FieldId(field_id)) ==
-                         new_info.field_index_has_raw_data_.end())) {
+                if (should_eager_load) {
                     replace_fields.emplace_back(field_id);
                 } else {
                     lazy_replace_fields.emplace_back(field_id);
@@ -435,7 +447,8 @@ SegmentLoadInfo::ComputeDiffColumnGroups(LoadDiff& diff,
             } else {
                 // Field at same position — check if needs lazification
                 // (transitioning from no-raw-data-index to raw-data-index)
-                if (new_info.field_index_has_raw_data_.count(
+                if (!prefer_field_data &&
+                    new_info.field_index_has_raw_data_.count(
                         FieldId(field_id)) > 0 &&
                     field_index_has_raw_data_.count(FieldId(field_id)) == 0) {
                     lazy_replace_fields.emplace_back(field_id);
@@ -467,6 +480,10 @@ SegmentLoadInfo::ComputeDiffColumnGroups(LoadDiff& diff,
     // Find field data to drop: fields in current but not in new
     for (const auto& [field_id, files_ptr] : cur_field_to_files) {
         if (new_seen_field_ids.find(field_id) == new_seen_field_ids.end()) {
+            if (prefer_field_data && new_info.field_index_has_raw_data_.count(
+                                         FieldId(field_id)) > 0) {
+                continue;
+            }
             diff.field_data_to_drop.emplace(field_id);
         }
     }

--- a/internal/core/src/segcore/segcore_init_c.cpp
+++ b/internal/core/src/segcore/segcore_init_c.cpp
@@ -64,6 +64,13 @@ SegcoreSetVisibilityFilterEnabled(const bool value) {
 }
 
 extern "C" void
+SegcoreSetPreferFieldDataWhenIndexHasRawData(const bool value) {
+    milvus::segcore::SegcoreConfig& config =
+        milvus::segcore::SegcoreConfig::default_config();
+    config.set_prefer_field_data_when_index_has_raw_data(value);
+}
+
+extern "C" void
 SegcoreSetNlist(const int64_t value) {
     milvus::segcore::SegcoreConfig& config =
         milvus::segcore::SegcoreConfig::default_config();

--- a/internal/core/src/segcore/segcore_init_c.h
+++ b/internal/core/src/segcore/segcore_init_c.h
@@ -89,6 +89,9 @@ void
 SegcoreSetVisibilityFilterEnabled(const bool value);
 
 void
+SegcoreSetPreferFieldDataWhenIndexHasRawData(const bool value);
+
+void
 SegcoreCloseGlog();
 
 int32_t

--- a/internal/core/src/segcore/segment_c_test.cpp
+++ b/internal/core/src/segcore/segment_c_test.cpp
@@ -1769,6 +1769,86 @@ TEST(CApiTest, RetrieveScalarFieldFromSealedSegmentWithIndex) {
     DeleteSegment(segment);
 }
 
+TEST(
+    CApiTest,
+    RetrieveScalarFieldFromColumnWhenIndexHasRawDataAndPreferFieldDataEnabled) {
+    auto schema = std::make_shared<Schema>();
+    auto i32_fid = schema->AddDebugField("age32", DataType::INT32);
+    auto i64_fid = schema->AddDebugField("age64", DataType::INT64);
+    schema->set_primary_field_id(i64_fid);
+
+    auto segment = CreateSealedSegment(schema).release();
+
+    int N = ROW_COUNT;
+    auto raw_data = DataGen(schema, N);
+
+    auto cm = milvus::storage::RemoteChunkManagerSingleton::GetInstance()
+                  .GetRemoteChunkManager();
+    auto load_info = PrepareInsertBinlog(
+        kCollectionID, kPartitionID, kSegmentID, raw_data, cm);
+    auto status = LoadFieldData(segment, &load_info);
+    ASSERT_EQ(status.error_code, Success);
+
+    auto age32_col = raw_data.get_col<int32_t>(i32_fid);
+    std::vector<int32_t> age32_index_col(age32_col.begin(), age32_col.end());
+    for (auto& value : age32_index_col) {
+        value += 1;
+    }
+
+    GenScalarIndexing(N, age32_index_col.data());
+    auto age32_index = milvus::index::CreateScalarIndexSort<int32_t>();
+    age32_index->Build(N, age32_index_col.data());
+
+    LoadIndexInfo load_index_info;
+    load_index_info.field_id = i32_fid.get();
+    load_index_info.field_type = DataType::INT32;
+    load_index_info.index_params = GenIndexParams(age32_index.get());
+    load_index_info.cache_index =
+        CreateTestCacheIndex("test", std::move(age32_index));
+    segment->LoadIndex(load_index_info);
+
+    auto age64_col = raw_data.get_col<int64_t>(i64_fid);
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
+    plan->plan_node_ = std::make_unique<query::RetrievePlanNode>();
+    std::vector<proto::plan::GenericValue> retrieve_row_ids;
+    proto::plan::GenericValue val;
+    val.set_int64_val(age64_col[0]);
+    retrieve_row_ids.push_back(val);
+    auto term_expr = std::make_shared<milvus::expr::TermFilterExpr>(
+        milvus::expr::ColumnInfo(
+            i64_fid, DataType::INT64, std::vector<std::string>()),
+        retrieve_row_ids);
+    plan->plan_node_->plannodes_ = CreateRetrievePlanByExpr(term_expr);
+    plan->field_ids_ = {i32_fid};
+
+    auto& segcore_config = milvus::segcore::SegcoreConfig::default_config();
+    auto previous_prefer_field_data =
+        segcore_config.get_prefer_field_data_when_index_has_raw_data();
+    segcore_config.set_prefer_field_data_when_index_has_raw_data(true);
+    auto reset_prefer_field_data = [&]() {
+        segcore_config.set_prefer_field_data_when_index_has_raw_data(
+            previous_prefer_field_data);
+    };
+
+    CRetrieveResult* retrieve_result = nullptr;
+    auto res = CRetrieve(
+        segment, plan.get(), raw_data.timestamps_[N - 1], &retrieve_result);
+    reset_prefer_field_data();
+    ASSERT_EQ(res.error_code, Success);
+
+    auto query_result = std::make_unique<proto::segcore::RetrieveResults>();
+    auto suc = query_result->ParseFromArray(retrieve_result->proto_blob,
+                                            retrieve_result->proto_size);
+    ASSERT_TRUE(suc);
+    ASSERT_EQ(query_result->fields_data().size(), 1);
+    ASSERT_EQ(query_result->fields_data(0).scalars().int_data().data(0),
+              age32_col[0]);
+
+    DeleteRetrievePlan(plan.release());
+    DeleteRetrieveResult(retrieve_result);
+    DeleteSegment(segment);
+}
+
 template <class TraitType>
 void
 Test_Range_Search_With_Radius_And_Range_Filter() {

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -1827,7 +1827,8 @@ func estimateLogicalResourceUsageOfSegment(schema *schemapb.CollectionSchema, lo
 
 			// could skip binlog or
 			// could be missing for new field or storage v2 group 0
-			if estimateResult.HasRawData {
+			if estimateResult.HasRawData &&
+				!paramtable.Get().QueryNodeCfg.PreferFieldDataWhenIndexHasRawData.GetAsBool() {
 				delete(id2Binlogs, fieldID)
 				continue
 			}
@@ -2032,7 +2033,8 @@ func estimateLoadingResourceUsageOfSegment(schema *schemapb.CollectionSchema, lo
 
 			// could skip binlog or
 			// could be missing for new field or storage v2 group 0
-			if estimateResult.HasRawData {
+			if estimateResult.HasRawData &&
+				!paramtable.Get().QueryNodeCfg.PreferFieldDataWhenIndexHasRawData.GetAsBool() {
 				delete(id2Binlogs, fieldID)
 				continue
 			}

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -815,6 +815,8 @@ func separateIndexAndBinlog(loadInfo *querypb.SegmentLoadInfo) (map[int64]*Index
 		}
 	}
 
+	preferFieldData := paramtable.Get().QueryNodeCfg.PreferFieldDataWhenIndexHasRawData.GetAsBool()
+
 	indexedFieldInfos := make(map[int64]*IndexedFieldInfo)
 	fieldBinlogs := make([]*datapb.FieldBinlog, 0, len(loadInfo.BinlogPaths))
 
@@ -828,6 +830,9 @@ func separateIndexAndBinlog(loadInfo *querypb.SegmentLoadInfo) (map[int64]*Index
 					IndexInfo:   index,
 				}
 				indexedFieldInfos[index.IndexID] = fieldInfo
+			}
+			if preferFieldData {
+				fieldBinlogs = append(fieldBinlogs, fieldBinlog)
 			}
 		} else {
 			fieldBinlogs = append(fieldBinlogs, fieldBinlog)
@@ -883,6 +888,8 @@ func separateLoadInfoV2(loadInfo *querypb.SegmentLoadInfo, schema *schemapb.Coll
 		}
 	}
 
+	preferFieldData := paramtable.Get().QueryNodeCfg.PreferFieldDataWhenIndexHasRawData.GetAsBool()
+
 	indexedFieldInfos := make(map[int64]*IndexedFieldInfo)
 	fieldBinlogs := make([]*datapb.FieldBinlog, 0, len(loadInfo.BinlogPaths))
 
@@ -924,6 +931,9 @@ func separateLoadInfoV2(loadInfo *querypb.SegmentLoadInfo, schema *schemapb.Coll
 						}
 						indexedFieldInfos[indexInfo.IndexID] = fieldInfo
 					}
+					if preferFieldData {
+						fieldBinlogs = append(fieldBinlogs, fieldBinlog)
+					}
 				} else {
 					fieldBinlogs = append(fieldBinlogs, fieldBinlog)
 				}
@@ -945,6 +955,9 @@ func separateLoadInfoV2(loadInfo *querypb.SegmentLoadInfo, schema *schemapb.Coll
 						IndexInfo:   indexInfo,
 					}
 					indexedFieldInfos[indexInfo.IndexID] = fieldInfo
+				}
+				if preferFieldData {
+					fieldBinlogs = append(fieldBinlogs, fieldBinlog)
 				}
 			} else {
 				fieldBinlogs = append(fieldBinlogs, fieldBinlog)

--- a/internal/querynodev2/segments/segment_loader_test.go
+++ b/internal/querynodev2/segments/segment_loader_test.go
@@ -335,7 +335,11 @@ func (suite *SegmentLoaderSuite) TestLoadWithIndexPreferFieldDataWhenIndexHasRaw
 
 	msgLength := 100
 	oldPreferFieldData := paramtable.Get().QueryNodeCfg.PreferFieldDataWhenIndexHasRawData.SwapTempValue("true")
-	defer paramtable.Get().QueryNodeCfg.PreferFieldDataWhenIndexHasRawData.SwapTempValue(oldPreferFieldData)
+	initcore.SyncPreferFieldDataWhenIndexHasRawData(ctx, paramtable.Get())
+	defer func() {
+		paramtable.Get().QueryNodeCfg.PreferFieldDataWhenIndexHasRawData.SwapTempValue(oldPreferFieldData)
+		initcore.SyncPreferFieldDataWhenIndexHasRawData(ctx, paramtable.Get())
+	}()
 
 	for i := 0; i < suite.segmentNum; i++ {
 		segmentID := suite.segmentID + int64(i)
@@ -396,7 +400,11 @@ func (suite *SegmentLoaderSuite) TestLoadWithIndexSkipsFieldDataByDefault() {
 
 	msgLength := 100
 	oldPreferFieldData := paramtable.Get().QueryNodeCfg.PreferFieldDataWhenIndexHasRawData.SwapTempValue("false")
-	defer paramtable.Get().QueryNodeCfg.PreferFieldDataWhenIndexHasRawData.SwapTempValue(oldPreferFieldData)
+	initcore.SyncPreferFieldDataWhenIndexHasRawData(ctx, paramtable.Get())
+	defer func() {
+		paramtable.Get().QueryNodeCfg.PreferFieldDataWhenIndexHasRawData.SwapTempValue(oldPreferFieldData)
+		initcore.SyncPreferFieldDataWhenIndexHasRawData(ctx, paramtable.Get())
+	}()
 
 	for i := 0; i < suite.segmentNum; i++ {
 		segmentID := suite.segmentID + int64(i)

--- a/internal/querynodev2/segments/segment_loader_test.go
+++ b/internal/querynodev2/segments/segment_loader_test.go
@@ -329,6 +329,125 @@ func (suite *SegmentLoaderSuite) TestLoadWithIndex() {
 	}
 }
 
+func (suite *SegmentLoaderSuite) TestLoadWithIndexPreferFieldDataWhenIndexHasRawData() {
+	ctx := context.Background()
+	loadInfos := make([]*querypb.SegmentLoadInfo, 0, suite.segmentNum)
+
+	msgLength := 100
+	oldPreferFieldData := paramtable.Get().QueryNodeCfg.PreferFieldDataWhenIndexHasRawData.SwapTempValue("true")
+	defer paramtable.Get().QueryNodeCfg.PreferFieldDataWhenIndexHasRawData.SwapTempValue(oldPreferFieldData)
+
+	for i := 0; i < suite.segmentNum; i++ {
+		segmentID := suite.segmentID + int64(i)
+		binlogs, statsLogs, err := mock_segcore.SaveBinLog(ctx,
+			suite.collectionID,
+			suite.partitionID,
+			segmentID,
+			msgLength,
+			suite.schema,
+			suite.chunkManager,
+		)
+		suite.NoError(err)
+
+		vecFields := funcutil.GetVecFieldIDs(suite.schema)
+		indexInfo, err := mock_segcore.GenAndSaveIndex(
+			suite.collectionID,
+			suite.partitionID,
+			segmentID,
+			vecFields[0],
+			msgLength,
+			mock_segcore.IndexFaissIVFFlat,
+			metric.L2,
+			suite.chunkManager,
+		)
+		suite.NoError(err)
+		loadInfos = append(loadInfos, &querypb.SegmentLoadInfo{
+			SegmentID:     segmentID,
+			PartitionID:   suite.partitionID,
+			CollectionID:  suite.collectionID,
+			BinlogPaths:   binlogs,
+			Statslogs:     statsLogs,
+			IndexInfos:    []*querypb.FieldIndexInfo{indexInfo},
+			NumOfRows:     int64(msgLength),
+			InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", suite.collectionID),
+		})
+	}
+
+	segments, err := suite.loader.Load(ctx, suite.collectionID, SegmentTypeSealed, 0, loadInfos...)
+	suite.NoError(err)
+
+	vecFields := funcutil.GetVecFieldIDs(suite.schema)
+	for _, segment := range segments {
+		suite.True(segment.ExistIndex(vecFields[0]))
+		suite.True(segment.HasRawData(vecFields[0]))
+
+		localSegment, ok := segment.(*LocalSegment)
+		suite.True(ok)
+		suite.True(localSegment.HasFieldData(vecFields[0]))
+	}
+}
+
+// Negative counterpart: with the flag off (default) and the index already
+// holding raw data, the loader must skip loading the field data — otherwise
+// the memory-saving behavior relied on by existing deployments is broken.
+func (suite *SegmentLoaderSuite) TestLoadWithIndexSkipsFieldDataByDefault() {
+	ctx := context.Background()
+	loadInfos := make([]*querypb.SegmentLoadInfo, 0, suite.segmentNum)
+
+	msgLength := 100
+	oldPreferFieldData := paramtable.Get().QueryNodeCfg.PreferFieldDataWhenIndexHasRawData.SwapTempValue("false")
+	defer paramtable.Get().QueryNodeCfg.PreferFieldDataWhenIndexHasRawData.SwapTempValue(oldPreferFieldData)
+
+	for i := 0; i < suite.segmentNum; i++ {
+		segmentID := suite.segmentID + int64(i)
+		binlogs, statsLogs, err := mock_segcore.SaveBinLog(ctx,
+			suite.collectionID,
+			suite.partitionID,
+			segmentID,
+			msgLength,
+			suite.schema,
+			suite.chunkManager,
+		)
+		suite.NoError(err)
+
+		vecFields := funcutil.GetVecFieldIDs(suite.schema)
+		indexInfo, err := mock_segcore.GenAndSaveIndex(
+			suite.collectionID,
+			suite.partitionID,
+			segmentID,
+			vecFields[0],
+			msgLength,
+			mock_segcore.IndexFaissIVFFlat,
+			metric.L2,
+			suite.chunkManager,
+		)
+		suite.NoError(err)
+		loadInfos = append(loadInfos, &querypb.SegmentLoadInfo{
+			SegmentID:     segmentID,
+			PartitionID:   suite.partitionID,
+			CollectionID:  suite.collectionID,
+			BinlogPaths:   binlogs,
+			Statslogs:     statsLogs,
+			IndexInfos:    []*querypb.FieldIndexInfo{indexInfo},
+			NumOfRows:     int64(msgLength),
+			InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", suite.collectionID),
+		})
+	}
+
+	segments, err := suite.loader.Load(ctx, suite.collectionID, SegmentTypeSealed, 0, loadInfos...)
+	suite.NoError(err)
+
+	vecFields := funcutil.GetVecFieldIDs(suite.schema)
+	for _, segment := range segments {
+		suite.True(segment.ExistIndex(vecFields[0]))
+		suite.True(segment.HasRawData(vecFields[0]))
+
+		localSegment, ok := segment.(*LocalSegment)
+		suite.True(ok)
+		suite.False(localSegment.HasFieldData(vecFields[0]))
+	}
+}
+
 func (suite *SegmentLoaderSuite) TestLoadBloomFilter() {
 	ctx := context.Background()
 	loadInfos := make([]*querypb.SegmentLoadInfo, 0, suite.segmentNum)

--- a/internal/util/initcore/query_node.go
+++ b/internal/util/initcore/query_node.go
@@ -84,6 +84,13 @@ func doInitQueryNodeOnce(ctx context.Context) error {
 		log.Warn("visibilityFilterEnabled=false with bloomFilterEnabled=true: deletes are forwarded via bloom filter but never applied — consider disabling bloom filter to save memory")
 	}
 
+	preferFieldDataWhenIndexHasRawData := paramtable.Get().QueryNodeCfg.PreferFieldDataWhenIndexHasRawData.GetAsBool()
+	C.SegcoreSetPreferFieldDataWhenIndexHasRawData(C.bool(preferFieldDataWhenIndexHasRawData))
+	if preferFieldDataWhenIndexHasRawData {
+		log.Ctx(ctx).Info("preferFieldDataWhenIndexHasRawData=true: sealed retrieve will read field data instead of index raw data; " +
+			"both will stay resident in memory, increasing the memory footprint for fields whose index also holds raw data")
+	}
+
 	cKnowhereThreadPoolSize := C.uint32_t(paramtable.Get().QueryNodeCfg.KnowhereThreadPoolSize.GetAsUint32())
 	C.SegcoreSetKnowhereSearchThreadPoolNum(cKnowhereThreadPoolSize)
 

--- a/internal/util/initcore/query_node.go
+++ b/internal/util/initcore/query_node.go
@@ -84,12 +84,7 @@ func doInitQueryNodeOnce(ctx context.Context) error {
 		log.Warn("visibilityFilterEnabled=false with bloomFilterEnabled=true: deletes are forwarded via bloom filter but never applied — consider disabling bloom filter to save memory")
 	}
 
-	preferFieldDataWhenIndexHasRawData := paramtable.Get().QueryNodeCfg.PreferFieldDataWhenIndexHasRawData.GetAsBool()
-	C.SegcoreSetPreferFieldDataWhenIndexHasRawData(C.bool(preferFieldDataWhenIndexHasRawData))
-	if preferFieldDataWhenIndexHasRawData {
-		log.Ctx(ctx).Info("preferFieldDataWhenIndexHasRawData=true: sealed retrieve will read field data instead of index raw data; " +
-			"both will stay resident in memory, increasing the memory footprint for fields whose index also holds raw data")
-	}
+	SyncPreferFieldDataWhenIndexHasRawData(ctx, paramtable.Get())
 
 	cKnowhereThreadPoolSize := C.uint32_t(paramtable.Get().QueryNodeCfg.KnowhereThreadPoolSize.GetAsUint32())
 	C.SegcoreSetKnowhereSearchThreadPoolNum(cKnowhereThreadPoolSize)
@@ -214,4 +209,17 @@ func doInitQueryNodeOnce(ctx context.Context) error {
 	// init paramtable change callback for core related config
 	SetupCoreConfigChangelCallback()
 	return InitPluginLoader()
+}
+
+// SyncPreferFieldDataWhenIndexHasRawData pushes the current paramtable value
+// of queryNode.preferFieldDataWhenIndexHasRawData into the segcore C++
+// singleton. Safe to call repeatedly; tests invoke it after mutating the
+// paramtable so the Go and C++ views of the flag stay in sync.
+func SyncPreferFieldDataWhenIndexHasRawData(ctx context.Context, params *paramtable.ComponentParam) {
+	v := params.QueryNodeCfg.PreferFieldDataWhenIndexHasRawData.GetAsBool()
+	C.SegcoreSetPreferFieldDataWhenIndexHasRawData(C.bool(v))
+	if v {
+		log.Ctx(ctx).Info("preferFieldDataWhenIndexHasRawData=true: sealed retrieve will read field data instead of index raw data; " +
+			"both will stay resident in memory, increasing the memory footprint for fields whose index also holds raw data")
+	}
 }

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -4377,12 +4377,12 @@ Max read concurrency must greater than or equal to 1, and less than or equal to 
 
 	p.PreferFieldDataWhenIndexHasRawData = ParamItem{
 		Key:          "queryNode.preferFieldDataWhenIndexHasRawData",
-		Version:      "3.0",
+		Version:      "3.0.0",
 		DefaultValue: "false",
 		Doc: "when true, sealed retrieve prefers field data in columns over index raw data when both are available. " +
 			"Note: enabling this keeps both the raw field data and the index resident in memory, " +
 			"roughly doubling the memory footprint for fields whose index normally supplies raw data.",
-		Export: true,
+		Export: false,
 	}
 	p.PreferFieldDataWhenIndexHasRawData.Init(base.mgr)
 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3461,7 +3461,8 @@ type queryNodeConfig struct {
 	FixedFileSizeForMmapManager         ParamItem `refreshable:"false"`
 	MaxMmapDiskPercentageForMmapManager ParamItem `refreshable:"false"`
 
-	IndexOffsetCacheEnabled ParamItem `refreshable:"true"`
+	IndexOffsetCacheEnabled            ParamItem `refreshable:"true"`
+	PreferFieldDataWhenIndexHasRawData ParamItem `refreshable:"false"`
 
 	ReadAheadPolicy     ParamItem `refreshable:"false"`
 	ChunkCacheWarmingUp ParamItem `refreshable:"true"`
@@ -4373,6 +4374,17 @@ Max read concurrency must greater than or equal to 1, and less than or equal to 
 		Export: true,
 	}
 	p.IndexOffsetCacheEnabled.Init(base.mgr)
+
+	p.PreferFieldDataWhenIndexHasRawData = ParamItem{
+		Key:          "queryNode.preferFieldDataWhenIndexHasRawData",
+		Version:      "3.0",
+		DefaultValue: "false",
+		Doc: "when true, sealed retrieve prefers field data in columns over index raw data when both are available. " +
+			"Note: enabling this keeps both the raw field data and the index resident in memory, " +
+			"roughly doubling the memory footprint for fields whose index normally supplies raw data.",
+		Export: true,
+	}
+	p.PreferFieldDataWhenIndexHasRawData.Init(base.mgr)
 
 	p.DiskCapacityLimit = ParamItem{
 		Key:     "LOCAL_STORAGE_SIZE",


### PR DESCRIPTION
Backport of #49127 to 3.0.

## Summary

- New QueryNode toggle `queryNode.preferFieldDataWhenIndexHasRawData` (default `false`) makes sealed retrieve serve scalar and vector fields from resident column data instead of index-backed raw data, and the loader keeps the column resident alongside the index on load/reload.
- Hot-path short-circuit: when the toggle is off, retrieve does not call `HasFieldData` or take the segment's `shared_lock`, so the default retrieve path is unchanged in cost.
- Observability: log at `InitQueryNode` when the toggle is on, calling out the memory trade-off.

## Test plan

- [x] C++ unit: `RetrieveScalarFieldFromColumnWhenIndexHasRawDataAndPreferFieldDataEnabled` — seeds the scalar index with values deliberately desynchronized from the column, then asserts the retrieved value equals the column value under toggle=true.
- [x] Go unit (positive): `TestLoadWithIndexPreferFieldDataWhenIndexHasRawData` — toggle=on, asserts `HasFieldData=true`.
- [x] Go unit (negative): `TestLoadWithIndexSkipsFieldDataByDefault` — toggle=off default, asserts `HasFieldData=false`.
- [ ] Integration smoke on local standalone.

## Trade-off

Enabling the toggle keeps both the raw field data and the index resident in memory, roughly doubling the memory footprint for fields whose index normally supplies raw data. The toggle is off by default, so no existing deployment is affected.

issue: #49126
pr: #49127