### PR TITLE
fix: [v2backfill] make StorageV2 reopen handle schema-evolved fields

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -283,20 +283,29 @@ ChunkedSegmentSealedImpl::LoadScalarIndex(const LoadIndexInfo& info) {
 void
 ChunkedSegmentSealedImpl::LoadFieldData(const LoadFieldDataInfo& load_info,
                                         milvus::OpContext* op_ctx) {
+    LoadFieldData(load_info, op_ctx, /*is_replace=*/false);
+}
+
+void
+ChunkedSegmentSealedImpl::LoadFieldData(const LoadFieldDataInfo& load_info,
+                                        milvus::OpContext* op_ctx,
+                                        bool is_replace) {
     switch (load_info.storage_version) {
         case 2: {
-            load_column_group_data_internal(load_info, op_ctx);
+            load_column_group_data_internal(load_info, op_ctx, is_replace);
             break;
         }
         default:
-            load_field_data_internal(load_info, op_ctx);
+            load_field_data_internal(load_info, op_ctx, is_replace);
             break;
     }
 }
 
 void
 ChunkedSegmentSealedImpl::load_column_group_data_internal(
-    const LoadFieldDataInfo& load_info, milvus::OpContext* op_ctx) {
+    const LoadFieldDataInfo& load_info,
+    milvus::OpContext* op_ctx,
+    bool is_replace) {
     size_t num_rows = storage::GetNumRowsForLoadInfo(load_info);
     ArrowSchemaPtr arrow_schema = schema_->ConvertToArrowSchema();
     auto& mmap_config = storage::MmapManager::GetInstance().GetMmapConfig();
@@ -383,7 +392,8 @@ ChunkedSegmentSealedImpl::load_column_group_data_internal(
                                    data_type,
                                    info.enable_mmap,
                                    true,
-                                   op_ctx);
+                                   op_ctx,
+                                   is_replace);
             if (field_id == TimestampFieldID) {
                 auto timestamp_proxy_column = get_column(TimestampFieldID);
                 AssertInfo(timestamp_proxy_column != nullptr,
@@ -426,7 +436,9 @@ ChunkedSegmentSealedImpl::load_column_group_data_internal(
 
 void
 ChunkedSegmentSealedImpl::load_field_data_internal(
-    const LoadFieldDataInfo& load_info, milvus::OpContext* op_ctx) {
+    const LoadFieldDataInfo& load_info,
+    milvus::OpContext* op_ctx,
+    bool is_replace) {
     SCOPE_CGO_CALL_METRIC();
 
     auto& mmap_config = storage::MmapManager::GetInstance().GetMmapConfig();
@@ -512,7 +524,8 @@ ChunkedSegmentSealedImpl::load_field_data_internal(
                                    data_type,
                                    info.enable_mmap,
                                    false,
-                                   op_ctx);
+                                   op_ctx,
+                                   is_replace);
         }
     }
 }
@@ -2532,20 +2545,39 @@ ChunkedSegmentSealedImpl::load_field_data_common(
     DataType data_type,
     bool enable_mmap,
     bool is_proxy_column,
-    milvus::OpContext* op_ctx) {
+    milvus::OpContext* op_ctx,
+    bool is_replace) {
     {
         std::unique_lock lck(mutex_);
-        AssertInfo(SystemProperty::Instance().IsSystem(field_id) ||
-                       !get_bit(field_data_ready_bitset_, field_id),
-                   "non system field {} data already loaded",
-                   field_id.get());
-        bool already_exists = false;
-        fields_.withRLock([&](auto& fields) {
-            already_exists = fields.find(field_id) != fields.end();
-        });
-        AssertInfo(
-            !already_exists, "field {} column already exists", field_id.get());
-        fields_.wlock()->emplace(field_id, column);
+        if (is_replace) {
+            // Replace path: an earlier load (real binlog or default-filled
+            // empty column from schema evolution) already installed a column
+            // for this field; overwrite it in place instead of asserting.
+            auto old_column = get_column(field_id);
+            if (old_column && !enable_mmap) {
+                if (!is_proxy_column ||
+                    (is_proxy_column &&
+                     field_id.get() != DEFAULT_SHORT_COLUMN_GROUP_ID)) {
+                    stats_.mem_size -= old_column->DataByteSize();
+                }
+            }
+            fields_.wlock()->insert_or_assign(field_id, column);
+            LOG_INFO(
+                "Replacing field {} data in segment {}", field_id.get(), id_);
+        } else {
+            AssertInfo(SystemProperty::Instance().IsSystem(field_id) ||
+                           !get_bit(field_data_ready_bitset_, field_id),
+                       "non system field {} data already loaded",
+                       field_id.get());
+            bool already_exists = false;
+            fields_.withRLock([&](auto& fields) {
+                already_exists = fields.find(field_id) != fields.end();
+            });
+            AssertInfo(!already_exists,
+                       "field {} column already exists",
+                       field_id.get());
+            fields_.wlock()->emplace(field_id, column);
+        }
         if (enable_mmap) {
             mmap_field_ids_.insert(field_id);
         }
@@ -2570,7 +2602,8 @@ ChunkedSegmentSealedImpl::load_field_data_common(
     LoadSkipIndex(field_id, data_type, column);
 
     // set pks to offset
-    if (schema_->get_primary_field_id() == field_id && !is_sorted_by_pk_) {
+    if (schema_->get_primary_field_id() == field_id && !is_sorted_by_pk_ &&
+        !is_replace) {
         AssertInfo(field_id.get() != -1, "Primary key is -1");
         AssertInfo(insert_record_.empty_pks(),
                    "primary key records already exists, current field id {}",
@@ -2582,9 +2615,11 @@ ChunkedSegmentSealedImpl::load_field_data_common(
     bool generated_interim_index = generate_interim_index(field_id, num_rows);
 
     std::unique_lock lck(mutex_);
-    AssertInfo(!get_bit(field_data_ready_bitset_, field_id),
-               "field {} data already loaded",
-               field_id.get());
+    if (!is_replace) {
+        AssertInfo(!get_bit(field_data_ready_bitset_, field_id),
+                   "field {} data already loaded",
+                   field_id.get());
+    }
     set_bit(field_data_ready_bitset_, field_id, true);
     update_row_count(num_rows);
     // Only drop field data when the interim index has raw data.
@@ -2652,6 +2687,13 @@ ChunkedSegmentSealedImpl::Reopen(
     {
         std::unique_lock lck(mutex_);
         current = segment_load_info_;
+        // Carry default-fill tracking forward: fields that were previously
+        // installed as empty placeholder columns (or already loaded via a
+        // prior binlog) must still route through the replace path on future
+        // reopens, even if this reopen doesn't touch them.
+        for (auto fid : current.GetFieldsFilledWithDefault()) {
+            new_seg_load_info.MarkFieldFilledWithDefault(fid);
+        }
         segment_load_info_ = new_seg_load_info;
     }
 
@@ -2709,6 +2751,16 @@ ChunkedSegmentSealedImpl::ApplyLoadDiff(SegmentLoadInfo& segment_load_info,
     // load field binlog
     if (!diff.binlogs_to_load.empty()) {
         LoadBatchFieldData(trace_ctx, diff.binlogs_to_load, op_ctx);
+    }
+
+    // replace field binlog: used when a field already has a column installed
+    // (e.g. filled with default values during schema evolution) and a fresh
+    // binlog arrives that should overwrite it.
+    if (!diff.binlogs_to_replace.empty()) {
+        LoadBatchFieldData(trace_ctx,
+                           diff.binlogs_to_replace,
+                           op_ctx,
+                           /*is_replace=*/true);
     }
 
     // drop field
@@ -2814,6 +2866,10 @@ ChunkedSegmentSealedImpl::fill_empty_field(const FieldMeta& field_meta) {
 
     fields_.wlock()->emplace(field_id, column);
     set_bit(field_data_ready_bitset_, field_id, true);
+    // Record the field as default-filled so that if a real binlog for it
+    // arrives later (via Reopen), ComputeDiffBinlogs routes the load through
+    // the replace path instead of asserting "data already loaded".
+    segment_load_info_.MarkFieldFilledWithDefault(field_id);
     LOG_INFO(
         "fill empty field {} (data type {}) for growing segment {} "
         "done",
@@ -3115,10 +3171,12 @@ ChunkedSegmentSealedImpl::LoadBatchFieldData(
     milvus::tracer::TraceContext& trace_ctx,
     std::vector<std::pair<std::vector<FieldId>, proto::segcore::FieldBinlog>>&
         field_binlog_to_load,
-    milvus::OpContext* op_ctx) {
-    LOG_INFO("Loading field binlog for {} fields in segment {}",
+    milvus::OpContext* op_ctx,
+    bool is_replace) {
+    LOG_INFO("Loading field binlog for {} fields in segment {}{}",
              field_binlog_to_load.size(),
-             id_);
+             id_,
+             is_replace ? " (replace)" : "");
 
     std::map<FieldId, LoadFieldDataInfo> field_data_to_load;
     for (auto& [field_ids, field_binlog] : field_binlog_to_load) {
@@ -3189,6 +3247,16 @@ ChunkedSegmentSealedImpl::LoadBatchFieldData(
         // Build FieldBinlogInfo
         FieldBinlogInfo field_binlog_info;
         field_binlog_info.field_id = group_id;
+        // Trust binlog proto's child_fields as the authoritative field list.
+        // Leaving it empty makes load_column_group_data_internal fall back to
+        // parsing the parquet schema, which may carry stale columns from a
+        // previous column-group layout and double-load fields that now live
+        // in their own groups.
+        if (field_binlog.child_fields_size() > 0) {
+            field_binlog_info.child_field_ids.assign(
+                field_binlog.child_fields().begin(),
+                field_binlog.child_fields().end());
+        }
 
         // Calculate total row count and collect binlog paths
         int64_t total_entries = 0;
@@ -3231,13 +3299,14 @@ ChunkedSegmentSealedImpl::LoadBatchFieldData(
         const auto field_data = load_field_data_info;
         const auto captured_field_id = field_id;
         auto future = pool.Submit(
-            [this, field_data, captured_field_id, op_ctx]() -> void {
+            [this, field_data, captured_field_id, op_ctx, is_replace]()
+                -> void {
                 // Early exit if cancelled while queued
                 CheckCancellation(op_ctx,
                                   id_,
                                   captured_field_id.get(),
                                   "ChunkedSegmentSealedImpl::LoadFieldData()");
-                LoadFieldData(field_data, op_ctx);
+                LoadFieldData(field_data, op_ctx, is_replace);
             });
 
         load_field_futures.push_back(std::move(future));

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -944,13 +944,22 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     init_timestamp_index(const std::vector<Timestamp>& timestamps,
                          size_t num_rows);
 
+    // Private overload: dispatched by the public LoadFieldData override and
+    // also called from ApplyLoadDiff's replace path.
+    void
+    LoadFieldData(const LoadFieldDataInfo& load_info,
+                  milvus::OpContext* op_ctx,
+                  bool is_replace);
+
     void
     load_field_data_internal(const LoadFieldDataInfo& load_info,
-                             milvus::OpContext* op_ctx = nullptr);
+                             milvus::OpContext* op_ctx = nullptr,
+                             bool is_replace = false);
 
     void
     load_column_group_data_internal(const LoadFieldDataInfo& load_info,
-                                    milvus::OpContext* op_ctx = nullptr);
+                                    milvus::OpContext* op_ctx = nullptr,
+                                    bool is_replace = false);
 
     void
     LoadBatchIndexes(milvus::tracer::TraceContext& trace_ctx,
@@ -963,7 +972,8 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                        std::vector<std::pair<std::vector<FieldId>,
                                              proto::segcore::FieldBinlog>>&
                            field_binlog_to_load,
-                       milvus::OpContext* op_ctx = nullptr);
+                       milvus::OpContext* op_ctx = nullptr,
+                       bool is_replace = false);
 
     void
     LoadColumnGroups(
@@ -1028,7 +1038,8 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         DataType data_type,
         bool enable_mmap,
         bool is_proxy_column,
-        milvus::OpContext* op_ctx = nullptr);
+        milvus::OpContext* op_ctx = nullptr,
+        bool is_replace = false);
 
     std::shared_ptr<ChunkedColumnInterface>
     get_column(FieldId field_id) const {

--- a/internal/core/src/segcore/SegmentLoadInfo.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfo.cpp
@@ -187,6 +187,7 @@ SegmentLoadInfo::ComputeDiffBinlogs(LoadDiff& diff, SegmentLoadInfo& new_info) {
     for (int i = 0; i < new_info.GetBinlogPathCount(); i++) {
         auto& new_field_binlog = new_info.GetBinlogPath(i);
         std::vector<FieldId> ids_to_load;
+        std::vector<FieldId> ids_to_replace;
         std::vector<int64_t> child_fields(
             new_field_binlog.child_fields().begin(),
             new_field_binlog.child_fields().end());
@@ -199,14 +200,28 @@ SegmentLoadInfo::ComputeDiffBinlogs(LoadDiff& diff, SegmentLoadInfo& new_info) {
             // current_fields is keyed by child field id (see loop above);
             // look up by child_id, not by the new group id.
             auto iter = current_fields.find(child_id);
-            // Load this child if it's absent from current, or its group moved.
+            // Load/replace this child if it's absent from current or its
+            // group moved to a different binlog.
             if (iter == current_fields.end() ||
                 iter->second != new_field_binlog.fieldid()) {
-                ids_to_load.emplace_back(child_id);
+                // Route through the replace path if the child already has a
+                // column installed — either a prior binlog load or a default
+                // value filled during schema evolution. Otherwise it's a
+                // fresh load.
+                if (iter != current_fields.end() ||
+                    IsFieldFilledWithDefault(FieldId(child_id))) {
+                    ids_to_replace.emplace_back(child_id);
+                } else {
+                    ids_to_load.emplace_back(child_id);
+                }
             }
         }
         if (!ids_to_load.empty()) {
             diff.binlogs_to_load.emplace_back(ids_to_load, new_field_binlog);
+        }
+        if (!ids_to_replace.empty()) {
+            diff.binlogs_to_replace.emplace_back(ids_to_replace,
+                                                 new_field_binlog);
         }
     }
 

--- a/internal/core/src/segcore/SegmentLoadInfo.h
+++ b/internal/core/src/segcore/SegmentLoadInfo.h
@@ -46,6 +46,13 @@ struct LoadDiff {
     std::vector<std::pair<std::vector<FieldId>, proto::segcore::FieldBinlog>>
         binlogs_to_load;
 
+    // Field binlog paths that need to replace existing (already-loaded or
+    // default-filled) field data. Same layout as binlogs_to_load but applied
+    // with is_replace=true so the load path uses insert_or_assign instead of
+    // emplace and skips the "already loaded" assertion.
+    std::vector<std::pair<std::vector<FieldId>, proto::segcore::FieldBinlog>>
+        binlogs_to_replace;
+
     // list of column group indices and related field ids to load
     // same index could appear multiple times if same group using different setups
     std::vector<std::pair<int, std::vector<FieldId>>> column_groups_to_load;
@@ -72,9 +79,9 @@ struct LoadDiff {
     [[nodiscard]] bool
     HasChanges() const {
         return !indexes_to_load.empty() || !binlogs_to_load.empty() ||
-               !column_groups_to_load.empty() || !fields_to_reload.empty() ||
-               !indexes_to_drop.empty() || !field_data_to_drop.empty() ||
-               manifest_updated;
+               !binlogs_to_replace.empty() || !column_groups_to_load.empty() ||
+               !fields_to_reload.empty() || !indexes_to_drop.empty() ||
+               !field_data_to_drop.empty() || manifest_updated;
     }
 
     [[nodiscard]] bool
@@ -102,6 +109,23 @@ struct LoadDiff {
         oss << "binlogs_to_load=[";
         first = true;
         for (const auto& [field_ids, binlog] : binlogs_to_load) {
+            if (!first)
+                oss << ", ";
+            first = false;
+            oss << "[";
+            for (size_t i = 0; i < field_ids.size(); ++i) {
+                if (i > 0)
+                    oss << ",";
+                oss << field_ids[i].get();
+            }
+            oss << "]";
+        }
+        oss << "], ";
+
+        // binlogs_to_replace
+        oss << "binlogs_to_replace=[";
+        first = true;
+        for (const auto& [field_ids, binlog] : binlogs_to_replace) {
             if (!first)
                 oss << ", ";
             first = false;
@@ -207,6 +231,7 @@ class SegmentLoadInfo {
     SegmentLoadInfo(const SegmentLoadInfo& other)
         : info_(other.info_),
           schema_(other.schema_),
+          fields_filled_with_default_(other.fields_filled_with_default_),
           column_groups_(other.column_groups_) {
         BuildCache();
     }
@@ -220,6 +245,8 @@ class SegmentLoadInfo {
           converted_index_infos_(std::move(other.converted_index_infos_)),
           converted_field_index_cache_(
               std::move(other.converted_field_index_cache_)),
+          fields_filled_with_default_(
+              std::move(other.fields_filled_with_default_)),
           field_binlog_cache_(std::move(other.field_binlog_cache_)),
           column_groups_(std::move(other.column_groups_)) {
     }
@@ -233,6 +260,7 @@ class SegmentLoadInfo {
         if (this != &other) {
             info_ = other.info_;
             schema_ = other.schema_;
+            fields_filled_with_default_ = other.fields_filled_with_default_;
             column_groups_ = other.column_groups_;
             BuildCache();
         }
@@ -250,6 +278,8 @@ class SegmentLoadInfo {
             converted_index_infos_ = std::move(other.converted_index_infos_);
             converted_field_index_cache_ =
                 std::move(other.converted_field_index_cache_);
+            fields_filled_with_default_ =
+                std::move(other.fields_filled_with_default_);
             field_binlog_cache_ = std::move(other.field_binlog_cache_);
             column_groups_ = std::move(other.column_groups_);
         }
@@ -714,6 +744,27 @@ class SegmentLoadInfo {
         return info_.segmentid() == 0 && info_.num_of_rows() == 0;
     }
 
+    /**
+     * @brief Record a field as currently populated with a default (empty)
+     *        value — e.g. after fill_empty_field runs for a schema-evolved
+     *        column. Consulted by ComputeDiffBinlogs to route subsequent real
+     *        binlog loads through the replace path instead of the load path.
+     */
+    void
+    MarkFieldFilledWithDefault(FieldId field_id) {
+        fields_filled_with_default_.insert(field_id);
+    }
+
+    [[nodiscard]] bool
+    IsFieldFilledWithDefault(FieldId field_id) const {
+        return fields_filled_with_default_.count(field_id) > 0;
+    }
+
+    [[nodiscard]] const std::set<FieldId>&
+    GetFieldsFilledWithDefault() const {
+        return fields_filled_with_default_;
+    }
+
     // ==================== LoadIndexInfo Conversion ====================
 
     /**
@@ -800,6 +851,12 @@ class SegmentLoadInfo {
 
     // set of field ids that corresponding index has raw data
     std::set<FieldId> field_index_has_raw_data_;
+
+    // set of field ids that have been filled with default values
+    // (e.g. via fill_empty_field during schema evolution).
+    // Consulted by ComputeDiffBinlogs: when a new binlog targets such a field
+    // the load goes into binlogs_to_replace instead of binlogs_to_load.
+    std::set<FieldId> fields_filled_with_default_;
 
     // Cache for quick field -> binlog lookup
     std::map<FieldId, const proto::segcore::FieldBinlog*> field_binlog_cache_;

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -143,19 +143,27 @@ NewSegmentWithLoadInfo(CCollection collection,
 CStatus
 ReopenSegment(CTraceContext c_trace,
               CSegmentInterface c_segment,
+              CCollection c_collection,
               const uint8_t* load_info_blob,
               const int64_t load_info_length) {
     SCOPE_CGO_CALL_METRIC();
 
     try {
         AssertInfo(load_info_blob, "load info is null");
+        AssertInfo(c_collection, "collection handle is null");
         milvus::proto::segcore::SegmentLoadInfo load_info;
         auto suc = load_info.ParseFromArray(load_info_blob, load_info_length);
         AssertInfo(suc, "unmarshal load info failed");
 
         auto segment =
             static_cast<milvus::segcore::SegmentInterface*>(c_segment);
+        auto collection =
+            static_cast<milvus::segcore::Collection*>(c_collection);
 
+        // Sync segment schema to the collection's latest before applying the
+        // load diff; without this, binlogs for fields added by schema
+        // evolution would fail the field_metas lookup in LoadBatchFieldData.
+        segment->LazyCheckSchema(collection->get_schema());
         segment->Reopen(load_info);
         return milvus::SuccessCStatus();
     } catch (std::exception& e) {

--- a/internal/core/src/segcore/segment_c.h
+++ b/internal/core/src/segcore/segment_c.h
@@ -112,8 +112,15 @@ SegmentLoad(CTraceContext c_trace,
  * load parameters. The segment will be reinitialized with the provided load info
  * while preserving its identity (segment_id).
  *
+ * The collection handle is used to sync the segment's schema to the latest
+ * version before applying the load diff — required when the new load info
+ * carries binlogs for fields added by schema evolution that the segment's
+ * cached schema doesn't yet know about.
+ *
  * @param c_trace Tracing context for distributed tracing and debugging
  * @param c_segment The segment handle to be reopened
+ * @param c_collection The collection handle whose schema should be synced into
+ *                     the segment before the diff is applied
  * @param load_info_blob Serialized SegmentLoadInfo protobuf message containing
  *                       the new load configuration (field data info, index info, etc.)
  * @param load_info_length Length of the load_info_blob in bytes
@@ -122,6 +129,7 @@ SegmentLoad(CTraceContext c_trace,
 CStatus
 ReopenSegment(CTraceContext c_trace,
               CSegmentInterface c_segment,
+              CCollection c_collection,
               const uint8_t* load_info_blob,
               const int64_t load_info_length);
 

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -1403,7 +1403,8 @@ func (s *LocalSegment) Reopen(ctx context.Context, newLoadInfo *querypb.SegmentL
 	defer s.ptrLock.Unpin()
 
 	err := s.csegment.Reopen(ctx, &segcore.ReopenRequest{
-		LoadInfo: newLoadInfo,
+		Collection: s.GetCollection().GetCCollection(),
+		LoadInfo:   newLoadInfo,
 	})
 	if err != nil {
 		return err

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -2278,6 +2278,14 @@ func (loader *segmentLoader) LoadIndex(ctx context.Context,
 func (loader *segmentLoader) ReopenSegments(ctx context.Context,
 	loadInfos []*querypb.SegmentLoadInfo,
 ) error {
+	// Prepend the configured bucket name to StorageV2 binlog paths, matching
+	// the initial Load path. Without this, reopen-time paths stay as bare
+	// "files/..." and the remote file reader fails with "path does not
+	// exist" when opening new field binlogs.
+	for _, loadInfo := range loadInfos {
+		addBucketNameStorageV2(loadInfo)
+	}
+
 	// Filter out LOADING segments only
 	// use None to avoid loaded check
 	infos := loader.prepare(ctx, commonpb.SegmentState_SegmentStateNone, loadInfos...)

--- a/internal/util/segcore/requests.go
+++ b/internal/util/segcore/requests.go
@@ -122,5 +122,10 @@ type AddFieldDataInfoRequest = LoadFieldDataRequest
 type AddFieldDataInfoResult struct{}
 
 type ReopenRequest struct {
-	LoadInfo *querypb.SegmentLoadInfo
+	// Collection is required so that the segment's cached schema can be
+	// synced to the collection's latest version before the load diff is
+	// applied; otherwise, binlogs for fields added via schema evolution
+	// would fail field_metas lookups in segcore.
+	Collection *CCollection
+	LoadInfo   *querypb.SegmentLoadInfo
 }

--- a/internal/util/segcore/segment.go
+++ b/internal/util/segcore/segment.go
@@ -331,13 +331,17 @@ func (s *cSegmentImpl) Reopen(ctx context.Context, req *ReopenRequest) error {
 	defer runtime.KeepAlive(traceCtx)
 	defer runtime.KeepAlive(req)
 
+	if req.Collection == nil {
+		return merr.WrapErrServiceInternal("reopen segment without collection handle")
+	}
+
 	segLoadInfo := ConvertToSegcoreSegmentLoadInfo(req.LoadInfo)
 	loadInfoBlob, err := proto.Marshal(segLoadInfo)
 	if err != nil {
 		return err
 	}
 
-	status := C.ReopenSegment(traceCtx.ctx, s.ptr, (*C.uint8_t)(unsafe.Pointer(&loadInfoBlob[0])), C.int64_t(len(loadInfoBlob)))
+	status := C.ReopenSegment(traceCtx.ctx, s.ptr, req.Collection.rawPointer(), (*C.uint8_t)(unsafe.Pointer(&loadInfoBlob[0])), C.int64_t(len(loadInfoBlob)))
 	return ConsumeCStatusIntoError(&status)
 }
 

--- a/tests/go_client/testcases/snapshot_test.go
+++ b/tests/go_client/testcases/snapshot_test.go
@@ -1718,6 +1718,6 @@ func TestCreateSnapshotCompactionProtectionInvalid(t *testing.T) {
 	// Value exceeding 7 days should be rejected (7*24*3600 = 604800)
 	snapshotName2 := fmt.Sprintf("snapshot_%s", common.GenRandomString(snapshotPrefix, 6))
 	err = mc.CreateSnapshot(ctx, client.NewCreateSnapshotOption(snapshotName2, collName).
-		WithCompactionProtectionSeconds(7*24*3600 + 1))
+		WithCompactionProtectionSeconds(7*24*3600+1))
 	common.CheckErr(t, err, false, "compaction_protection_seconds")
 }


### PR DESCRIPTION
Reopening a sealed segment to pick up binlogs for fields added by schema evolution failed across several layers. Bring the fix set inline with master's replace flow and address a few adjacent bugs on the reopen path:

- ReopenSegment C API now takes the collection handle and syncs the segment's cached schema via LazyCheckSchema before computing the diff, so newly-added fields are registered and filled as empty placeholder columns first.
- Port LoadDiff.binlogs_to_replace and the is_replace plumbing down through LoadBatchFieldData / LoadFieldData /
load_column_group_data_internal / load_field_data_common. A real binlog arriving for a default-filled field now overwrites the placeholder via insert_or_assign instead of tripping the "data already loaded" assertion.
- Track default-filled fields in SegmentLoadInfo and carry the set forward across reopens so subsequent diffs still route such fields through the replace path.
- ComputeDiffBinlogs: look up current_fields by child_id instead of the new group id when deciding what needs loading.
- LoadBatchFieldData: populate FieldBinlogInfo.child_field_ids from the binlog proto so load_column_group_data_internal trusts the authoritative field list and doesn't fall back to parsing the parquet schema (which may carry stale columns from a prior column-group layout).
- GroupChunkTranslator: skip parquet columns not in field_metas_ instead of asserting, tolerating stale extra columns.
- segmentLoader.ReopenSegments: call addBucketNameStorageV2 on the incoming load infos, mirroring the initial Load path, so binlog paths keep the bucket prefix and remote reads don't fail with "path does not exist".