### PR TITLE
fix: avoid doubling base_path prefix for text/json index file paths

### DIFF
--- a/internal/core/src/index/TextMatchIndex.cpp
+++ b/internal/core/src/index/TextMatchIndex.cpp
@@ -175,15 +175,22 @@ TextMatchIndex::Load(const Config& config) {
             .value_or(milvus::proto::common::LoadPriority::HIGH);
     // V2: existing multi-file load path
     auto prefix = disk_file_manager_->GetLocalTextIndexPrefix();
-    // Files are relative paths; prepend base_path to construct absolute remote paths.
+    // Prepend base_path to construct absolute remote paths.
     // This must happen before extracting index_null_offset so all files have full paths.
+    //
+    // NOTE: files may already be absolute paths when loaded from etcd via
+    // BuildTextLogPaths(), which expands filenames to full paths for backward
+    // compatibility. Skip prepending if the path already starts with base_path
+    // to avoid doubling the prefix (which causes S3 404 errors).
     auto base_path =
         GetValueFromConfig<std::string>(config, STATS_BASE_PATH_KEY)
             .value_or("");
     AssertInfo(!base_path.empty(),
                "stats_base_path is required for loading text index");
     for (auto& f : files_value) {
-        f = base_path + "/" + f;
+        if (f.compare(0, base_path.size(), base_path) != 0) {
+            f = base_path + "/" + f;
+        }
     }
 
     auto it = std::find_if(

--- a/internal/core/src/index/json_stats/JsonKeyStats.cpp
+++ b/internal/core/src/index/json_stats/JsonKeyStats.cpp
@@ -1193,14 +1193,18 @@ JsonKeyStats::Load(milvus::tracer::TraceContext ctx, const Config& config) {
                segment_id_);
 
     // Split index_files into meta, shared_key_index, and shredding_data.
-    // Files are relative paths; prepend base_path to get absolute remote paths.
+    // Prepend base_path to get absolute remote paths.
+    // NOTE: files may already be absolute when loaded from etcd (same reason
+    // as TextMatchIndex::Load — see comment there). Skip if already prefixed.
     // Note: Check directory paths (shared_key_index, shredding_data) BEFORE meta.json,
     // because shared_key_index/meta.json_0 contains "meta.json" but is not the meta file.
     std::vector<std::string> meta_files;
     std::vector<std::string> shared_key_index_files;
     std::vector<std::string> shredding_data_files;
     for (const auto& file : index_files.value()) {
-        auto abs_path = base_path + "/" + file;
+        auto abs_path = file.compare(0, base_path.size(), base_path) != 0
+                            ? base_path + "/" + file
+                            : file;
         if (file.find(JSON_STATS_SHARED_INDEX_PATH) != std::string::npos) {
             shared_key_index_files.emplace_back(abs_path);
         } else if (file.find(JSON_STATS_SHREDDING_DATA_PATH) !=


### PR DESCRIPTION
## Summary

`BuildTextLogPaths()` expands filenames to absolute paths when loading from etcd for backward compatibility. `TextMatchIndex::Load()` and `JsonKeyStats::Load()` then unconditionally prepend `base_path` again, producing doubled S3 object paths (e.g. `prefix/prefix/file`) that return 404 and break all TEXT_MATCH searches.

Fix: skip prepending `base_path` when the file path already starts with it.

## Test plan

- [ ] Reproduce on an affected cluster (loading a collection with an existing text/json index from etcd), confirm paths are no longer doubled and TEXT_MATCH search returns results.

issue: #48547