### PR TITLE
enhance: [v2backfill] replace stale columns when load-diff groups swap files

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -2727,8 +2727,11 @@ ChunkedSegmentSealedImpl::ApplyLoadDiff(SegmentLoadInfo& segment_load_info,
     }
 
     // load column groups
-    if (!diff.column_groups_to_load.empty() ||
-        !diff.column_groups_to_lazyload.empty()) {
+    bool has_cg_changes = !diff.column_groups_to_load.empty() ||
+                          !diff.column_groups_to_replace.empty() ||
+                          !diff.column_groups_to_lazyload.empty() ||
+                          !diff.column_groups_to_lazyreplace.empty();
+    if (has_cg_changes) {
         auto properties =
             milvus::storage::LoonFFIPropertiesSingleton::GetInstance()
                 .GetProperties();
@@ -2736,6 +2739,7 @@ ChunkedSegmentSealedImpl::ApplyLoadDiff(SegmentLoadInfo& segment_load_info,
         auto arrow_schema = schema_->ConvertToArrowSchema();
         reader_ = milvus_storage::api::Reader::create(
             column_groups, arrow_schema, nullptr, *properties);
+        // New column group fields
         if (!diff.column_groups_to_load.empty()) {
             LoadColumnGroups(
                 column_groups, properties, diff.column_groups_to_load, true);
@@ -2745,6 +2749,25 @@ ChunkedSegmentSealedImpl::ApplyLoadDiff(SegmentLoadInfo& segment_load_info,
                              properties,
                              diff.column_groups_to_lazyload,
                              false);
+        }
+        // Replace column group fields — used when the group shape stayed the
+        // same but files changed (e.g. compaction rewrote the parquet) so we
+        // must evict the stale column before installing the new one.
+        if (!diff.column_groups_to_replace.empty()) {
+            LoadColumnGroups(column_groups,
+                             properties,
+                             diff.column_groups_to_replace,
+                             true,
+                             /*op_ctx=*/nullptr,
+                             /*is_replace=*/true);
+        }
+        if (!diff.column_groups_to_lazyreplace.empty()) {
+            LoadColumnGroups(column_groups,
+                             properties,
+                             diff.column_groups_to_lazyreplace,
+                             false,
+                             /*op_ctx=*/nullptr,
+                             /*is_replace=*/true);
         }
     }
 
@@ -2944,7 +2967,8 @@ ChunkedSegmentSealedImpl::LoadColumnGroups(
     const std::shared_ptr<milvus_storage::api::Properties>& properties,
     std::vector<std::pair<int, std::vector<FieldId>>>& cg_field_ids,
     bool eager_load,
-    milvus::OpContext* op_ctx) {
+    milvus::OpContext* op_ctx,
+    bool is_replace) {
     auto& pool = ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::MIDDLE);
     std::vector<std::future<void>> load_group_futures;
     for (const auto& pair : cg_field_ids) {
@@ -2955,9 +2979,16 @@ ChunkedSegmentSealedImpl::LoadColumnGroups(
                                    properties,
                                    cg_index,
                                    field_ids,
-                                   eager_load]() {
-            LoadColumnGroup(
-                column_groups, properties, cg_index, field_ids, eager_load);
+                                   eager_load,
+                                   op_ctx,
+                                   is_replace]() {
+            LoadColumnGroup(column_groups,
+                            properties,
+                            cg_index,
+                            field_ids,
+                            eager_load,
+                            op_ctx,
+                            is_replace);
         });
         load_group_futures.emplace_back(std::move(future));
     }
@@ -2972,7 +3003,8 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
     int64_t index,
     const std::vector<FieldId>& milvus_field_ids,
     bool eager_load,
-    milvus::OpContext* op_ctx) {
+    milvus::OpContext* op_ctx,
+    bool is_replace) {
     AssertInfo(index < column_groups->size(),
                "load column group index out of range");
     auto column_group = column_groups->get_column_group(index);
@@ -3069,7 +3101,8 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
             data_type,
             use_mmap,
             true,
-            op_ctx);  // manifest cannot provide parquet skip index directly
+            op_ctx,
+            is_replace);  // manifest cannot provide parquet skip index directly
         if (field_id == TimestampFieldID) {
             auto timestamp_proxy_column = get_column(TimestampFieldID);
             AssertInfo(timestamp_proxy_column != nullptr,

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -981,7 +981,8 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         const std::shared_ptr<milvus_storage::api::Properties>& properties,
         std::vector<std::pair<int, std::vector<FieldId>>>& cg_field_ids,
         bool eager_load,
-        milvus::OpContext* op_ctx = nullptr);
+        milvus::OpContext* op_ctx = nullptr,
+        bool is_replace = false);
 
     /**
      * @brief Load a single column group at the specified index
@@ -1002,7 +1003,8 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         int64_t index,
         const std::vector<FieldId>& milvus_field_ids,
         bool eager_load,
-        milvus::OpContext* op_ctx = nullptr);
+        milvus::OpContext* op_ctx = nullptr,
+        bool is_replace = false);
 
     /**
      * @brief Reloads columns from the specified field IDs

--- a/internal/core/src/segcore/SegmentLoadInfo.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfo.cpp
@@ -183,6 +183,23 @@ SegmentLoadInfo::ComputeDiffBinlogs(LoadDiff& diff, SegmentLoadInfo& new_info) {
         }
     }
 
+    // Two FieldBinlogs at the same group id are equivalent only when their
+    // underlying log files (log_path sequence) match. Compaction/version
+    // bumps can swap files under the same fieldid, and without detecting
+    // that here the loader never evicts the stale column cache.
+    auto same_binlog_files = [](const proto::segcore::FieldBinlog& a,
+                                const proto::segcore::FieldBinlog& b) -> bool {
+        if (a.binlogs_size() != b.binlogs_size()) {
+            return false;
+        }
+        for (int j = 0; j < a.binlogs_size(); j++) {
+            if (a.binlogs(j).log_path() != b.binlogs(j).log_path()) {
+                return false;
+            }
+        }
+        return true;
+    };
+
     std::map<int64_t, int64_t> new_binlog_fields;
     for (int i = 0; i < new_info.GetBinlogPathCount(); i++) {
         auto& new_field_binlog = new_info.GetBinlogPath(i);
@@ -195,25 +212,37 @@ SegmentLoadInfo::ComputeDiffBinlogs(LoadDiff& diff, SegmentLoadInfo& new_info) {
         if (child_fields.empty()) {
             child_fields.emplace_back(new_field_binlog.fieldid());
         }
+
+        auto* cur_field_binlog =
+            GetFieldBinlog(FieldId(new_field_binlog.fieldid()));
+        bool group_files_changed =
+            cur_field_binlog != nullptr &&
+            !same_binlog_files(*cur_field_binlog, new_field_binlog);
+
         for (auto child_id : child_fields) {
             new_binlog_fields[child_id] = new_field_binlog.fieldid();
             // current_fields is keyed by child field id (see loop above);
             // look up by child_id, not by the new group id.
             auto iter = current_fields.find(child_id);
-            // Load/replace this child if it's absent from current or its
-            // group moved to a different binlog.
-            if (iter == current_fields.end() ||
-                iter->second != new_field_binlog.fieldid()) {
-                // Route through the replace path if the child already has a
-                // column installed — either a prior binlog load or a default
-                // value filled during schema evolution. Otherwise it's a
-                // fresh load.
-                if (iter != current_fields.end() ||
-                    IsFieldFilledWithDefault(FieldId(child_id))) {
-                    ids_to_replace.emplace_back(child_id);
-                } else {
-                    ids_to_load.emplace_back(child_id);
-                }
+            // A binlog entry needs (re)loading when either
+            //   (a) the group mapping differs between current and new, or
+            //   (b) the group maps the same way but the underlying log
+            //       files changed (e.g. compaction rewrote the segment).
+            bool group_mapping_differs =
+                iter == current_fields.end() ||
+                iter->second != new_field_binlog.fieldid();
+            if (!group_mapping_differs && !group_files_changed) {
+                continue;
+            }
+            // Route through the replace path if the child already has a
+            // column installed — either a prior binlog load or a default
+            // value filled during schema evolution. Otherwise it's a
+            // fresh load.
+            if (iter != current_fields.end() ||
+                IsFieldFilledWithDefault(FieldId(child_id))) {
+                ids_to_replace.emplace_back(child_id);
+            } else {
+                ids_to_load.emplace_back(child_id);
             }
         }
         if (!ids_to_load.empty()) {
@@ -242,50 +271,106 @@ SegmentLoadInfo::ComputeDiffColumnGroups(LoadDiff& diff,
     AssertInfo(cur_column_group, "current column groups shall not be null");
     AssertInfo(new_column_group, "new column groups shall not be null");
 
-    // Build a set of current FieldIds from current column groups
-    std::map<int64_t, int> cur_field_ids;
+    // The loon manifest gives no ordering guarantee on the column-groups
+    // vector, so we don't try to pair cur/new groups by position or by a
+    // synthesized leader. For each field we only ask: "is it present in
+    // current, and did its backing files change?" — field-level existence
+    // plus per-field file-list comparison is enough to classify
+    // new/replace/unchanged without any group-identity assumption.
+    std::map<int64_t, const std::vector<milvus_storage::api::ColumnGroupFile>*>
+        cur_field_to_files;
     for (int i = 0; i < cur_column_group->size(); i++) {
         auto cg = cur_column_group->get_column_group(i);
+        if (!cg) {
+            continue;
+        }
         for (const auto& column : cg->columns) {
             auto field_id = std::stoll(column);
-            cur_field_ids.emplace(field_id, i);
+            cur_field_to_files[field_id] = &cg->files;
         }
     }
 
-    // Build a set of new FieldIds and find column groups to load
-    std::map<int64_t, int> new_field_ids;
+    auto same_files =
+        [](const std::vector<milvus_storage::api::ColumnGroupFile>& a,
+           const std::vector<milvus_storage::api::ColumnGroupFile>& b) -> bool {
+        if (a.size() != b.size()) {
+            return false;
+        }
+        for (size_t j = 0; j < a.size(); j++) {
+            if (a[j].path != b[j].path) {
+                return false;
+            }
+        }
+        return true;
+    };
+
+    // Find column groups to load/replace on the new side
+    std::set<int64_t> new_seen_field_ids;
     for (int i = 0; i < new_column_group->size(); i++) {
         auto cg = new_column_group->get_column_group(i);
+        if (!cg) {
+            continue;
+        }
         std::vector<FieldId> fields;
+        std::vector<FieldId> replace_fields;
         std::vector<FieldId> lazy_fields;
+        std::vector<FieldId> lazy_replace_fields;
         for (const auto& column : cg->columns) {
             auto field_id = std::stoll(column);
-            new_field_ids.emplace(field_id, i);
+            new_seen_field_ids.emplace(field_id);
 
-            auto iter = cur_field_ids.find(field_id);
-            // If this field doesn't exist in current, mark the column group for loading
-            if (iter == cur_field_ids.end() || iter->second != i) {
+            auto cur_iter = cur_field_to_files.find(field_id);
+            bool was_default_filled =
+                IsFieldFilledWithDefault(FieldId(field_id));
+            bool is_new_field =
+                cur_iter == cur_field_to_files.end() && !was_default_filled;
+            // A field that was present in current must go to replace when
+            // its backing files changed — whether that's the same group
+            // rewriting its parquet (compaction) or the field landing in
+            // a different group with a different file set. Either way the
+            // cached chunks are stale.
+            bool files_changed = cur_iter != cur_field_to_files.end() &&
+                                 !same_files(*cur_iter->second, cg->files);
+            bool is_replace_field = was_default_filled || files_changed;
+
+            auto classify = [&](std::vector<FieldId>& eager,
+                                std::vector<FieldId>& lazy) {
                 if (schema_->ShouldLoadField(FieldId(field_id)) &&
                     field_index_has_raw_data_.find(FieldId(field_id)) ==
                         field_index_has_raw_data_.end()) {
-                    fields.emplace_back(field_id);
+                    eager.emplace_back(field_id);
                 } else {
-                    // put lazy load & index_has_raw_data field in lazy_fields
-                    lazy_fields.emplace_back(field_id);
+                    // lazy load & index_has_raw_data fields go to lazy bucket
+                    lazy.emplace_back(field_id);
                 }
+            };
+
+            if (is_new_field) {
+                classify(fields, lazy_fields);
+            } else if (is_replace_field) {
+                classify(replace_fields, lazy_replace_fields);
             }
+            // else: field in current at a group with identical files —
+            // nothing to emit.
         }
         if (!fields.empty()) {
             diff.column_groups_to_load.emplace_back(i, fields);
         }
+        if (!replace_fields.empty()) {
+            diff.column_groups_to_replace.emplace_back(i, replace_fields);
+        }
         if (!lazy_fields.empty()) {
             diff.column_groups_to_lazyload.emplace_back(i, lazy_fields);
+        }
+        if (!lazy_replace_fields.empty()) {
+            diff.column_groups_to_lazyreplace.emplace_back(i,
+                                                           lazy_replace_fields);
         }
     }
 
     // Find field data to drop: fields in current but not in new
-    for (const auto& [field_id, cg_index] : cur_field_ids) {
-        if (new_field_ids.find(field_id) == new_field_ids.end()) {
+    for (const auto& [field_id, files_ptr] : cur_field_to_files) {
+        if (new_seen_field_ids.find(field_id) == new_seen_field_ids.end()) {
             diff.field_data_to_drop.emplace(field_id);
         }
     }

--- a/internal/core/src/segcore/SegmentLoadInfo.h
+++ b/internal/core/src/segcore/SegmentLoadInfo.h
@@ -57,9 +57,19 @@ struct LoadDiff {
     // same index could appear multiple times if same group using different setups
     std::vector<std::pair<int, std::vector<FieldId>>> column_groups_to_load;
 
+    // list of column group indices and related field ids to replace. Used
+    // when the group shape (columns) stayed the same but the backing parquet
+    // files changed (e.g. compaction rewrote the segment) so the loader must
+    // evict the stale cached column before installing the new one.
+    std::vector<std::pair<int, std::vector<FieldId>>> column_groups_to_replace;
+
     // list of column group indices and related field ids to lazy load
     // used for lazy load fields or fields with index has raw data
     std::vector<std::pair<int, std::vector<FieldId>>> column_groups_to_lazyload;
+
+    // lazy-equivalent of column_groups_to_replace.
+    std::vector<std::pair<int, std::vector<FieldId>>>
+        column_groups_to_lazyreplace;
 
     std::vector<FieldId> fields_to_reload;
 
@@ -80,6 +90,9 @@ struct LoadDiff {
     HasChanges() const {
         return !indexes_to_load.empty() || !binlogs_to_load.empty() ||
                !binlogs_to_replace.empty() || !column_groups_to_load.empty() ||
+               !column_groups_to_replace.empty() ||
+               !column_groups_to_lazyload.empty() ||
+               !column_groups_to_lazyreplace.empty() ||
                !fields_to_reload.empty() || !indexes_to_drop.empty() ||
                !field_data_to_drop.empty() || manifest_updated;
     }
@@ -143,6 +156,58 @@ struct LoadDiff {
         oss << "column_groups_to_load=[";
         first = true;
         for (const auto& [group_idx, field_ids] : column_groups_to_load) {
+            if (!first)
+                oss << ", ";
+            first = false;
+            oss << "group" << group_idx << ":[";
+            for (size_t i = 0; i < field_ids.size(); ++i) {
+                if (i > 0)
+                    oss << ",";
+                oss << field_ids[i].get();
+            }
+            oss << "]";
+        }
+        oss << "], ";
+
+        // column_groups_to_replace
+        oss << "column_groups_to_replace=[";
+        first = true;
+        for (const auto& [group_idx, field_ids] : column_groups_to_replace) {
+            if (!first)
+                oss << ", ";
+            first = false;
+            oss << "group" << group_idx << ":[";
+            for (size_t i = 0; i < field_ids.size(); ++i) {
+                if (i > 0)
+                    oss << ",";
+                oss << field_ids[i].get();
+            }
+            oss << "]";
+        }
+        oss << "], ";
+
+        // column_groups_to_lazyload
+        oss << "column_groups_to_lazyload=[";
+        first = true;
+        for (const auto& [group_idx, field_ids] : column_groups_to_lazyload) {
+            if (!first)
+                oss << ", ";
+            first = false;
+            oss << "group" << group_idx << ":[";
+            for (size_t i = 0; i < field_ids.size(); ++i) {
+                if (i > 0)
+                    oss << ",";
+                oss << field_ids[i].get();
+            }
+            oss << "]";
+        }
+        oss << "], ";
+
+        // column_groups_to_lazyreplace
+        oss << "column_groups_to_lazyreplace=[";
+        first = true;
+        for (const auto& [group_idx, field_ids] :
+             column_groups_to_lazyreplace) {
             if (!first)
                 oss << ", ";
             first = false;
@@ -563,6 +628,17 @@ class SegmentLoadInfo {
      */
     [[nodiscard]] std::shared_ptr<milvus_storage::api::ColumnGroups>
     GetColumnGroups();
+
+    /**
+     * @brief Pre-populate the column group cache without parsing a manifest
+     * @note Test-only hook: lets unit tests exercise diff logic that depends
+     *       on ColumnGroup contents without constructing real manifest files.
+     */
+    void
+    SetColumnGroupsForTesting(
+        std::shared_ptr<milvus_storage::api::ColumnGroups> cg) {
+        column_groups_ = std::move(cg);
+    }
 
     // ==================== Stats & Delta Logs ====================
 

--- a/internal/core/src/segcore/SegmentLoadInfoTest.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfoTest.cpp
@@ -819,3 +819,306 @@ TEST_F(SegmentLoadInfoTest, ComputeDiffNoChangesLegacyFormat) {
     EXPECT_TRUE(diff.binlogs_to_load.empty());
     EXPECT_TRUE(diff.field_data_to_drop.empty());
 }
+
+// -----------------------------------------------------------------------------
+// Tests for same-group file-change detection in ComputeDiffBinlogs and
+// ComputeDiffColumnGroups.
+// When compaction rewrites the data under the same group id / column group
+// index, the files list changes but the field layout does not. These tests
+// verify that the diff emits replace entries so the loader can evict stale
+// cached columns.
+// -----------------------------------------------------------------------------
+
+TEST_F(SegmentLoadInfoTest,
+       ComputeDiffBinlogSameGroupDifferentFilesTriggersReplace) {
+    // Current: legacy field 105 pointing at binlog A
+    proto::segcore::SegmentLoadInfo current_proto;
+    current_proto.set_segmentid(100);
+    current_proto.set_num_of_rows(1000);
+    auto* cur_binlog = current_proto.add_binlog_paths();
+    cur_binlog->set_fieldid(105);
+    auto* cur_log = cur_binlog->add_binlogs();
+    cur_log->set_log_path("/path/to/binlog_A");
+    cur_log->set_entries_num(1000);
+
+    // New: same group id, same child field, but a different log_path
+    proto::segcore::SegmentLoadInfo new_proto = current_proto;
+    new_proto.mutable_binlog_paths(0)->mutable_binlogs(0)->set_log_path(
+        "/path/to/binlog_B");
+
+    SegmentLoadInfo current_info(current_proto, schema_);
+    SegmentLoadInfo new_info(new_proto, schema_);
+    auto diff = current_info.ComputeDiff(new_info);
+
+    EXPECT_TRUE(diff.HasChanges());
+    ASSERT_EQ(diff.binlogs_to_replace.size(), 1);
+    ASSERT_EQ(diff.binlogs_to_replace[0].first.size(), 1);
+    EXPECT_EQ(diff.binlogs_to_replace[0].first[0].get(), 105);
+    EXPECT_TRUE(diff.binlogs_to_load.empty());
+    EXPECT_TRUE(diff.field_data_to_drop.empty());
+}
+
+TEST_F(SegmentLoadInfoTest,
+       ComputeDiffBinlogSameGroupDifferentFileCountTriggersReplace) {
+    // Current: legacy field 105 with one binlog file
+    proto::segcore::SegmentLoadInfo current_proto;
+    current_proto.set_segmentid(100);
+    current_proto.set_num_of_rows(1000);
+    auto* cur_binlog = current_proto.add_binlog_paths();
+    cur_binlog->set_fieldid(105);
+    auto* cur_log = cur_binlog->add_binlogs();
+    cur_log->set_log_path("/path/to/binlog_A");
+    cur_log->set_entries_num(500);
+
+    // New: same group id, same child, but an additional binlog file (post
+    // compaction merging more files into the same group).
+    proto::segcore::SegmentLoadInfo new_proto = current_proto;
+    auto* extra_log = new_proto.mutable_binlog_paths(0)->add_binlogs();
+    extra_log->set_log_path("/path/to/binlog_B");
+    extra_log->set_entries_num(500);
+
+    SegmentLoadInfo current_info(current_proto, schema_);
+    SegmentLoadInfo new_info(new_proto, schema_);
+    auto diff = current_info.ComputeDiff(new_info);
+
+    ASSERT_EQ(diff.binlogs_to_replace.size(), 1);
+    ASSERT_EQ(diff.binlogs_to_replace[0].first.size(), 1);
+    EXPECT_EQ(diff.binlogs_to_replace[0].first[0].get(), 105);
+    EXPECT_TRUE(diff.binlogs_to_load.empty());
+}
+
+TEST_F(SegmentLoadInfoTest, ComputeDiffBinlogSameGroupIdenticalFilesNoDiff) {
+    // Current and new have identical binlog contents under group 105.
+    proto::segcore::SegmentLoadInfo proto;
+    proto.set_segmentid(100);
+    proto.set_num_of_rows(1000);
+    auto* binlog = proto.add_binlog_paths();
+    binlog->set_fieldid(105);
+    auto* log1 = binlog->add_binlogs();
+    log1->set_log_path("/path/to/binlog_A");
+    log1->set_entries_num(500);
+    auto* log2 = binlog->add_binlogs();
+    log2->set_log_path("/path/to/binlog_B");
+    log2->set_entries_num(500);
+
+    SegmentLoadInfo current_info(proto, schema_);
+    (void)current_info.GetLoadDiff();
+    SegmentLoadInfo new_info(proto, schema_);
+    auto diff = current_info.ComputeDiff(new_info);
+
+    EXPECT_TRUE(diff.binlogs_to_load.empty());
+    EXPECT_TRUE(diff.binlogs_to_replace.empty());
+}
+
+TEST_F(SegmentLoadInfoTest,
+       ComputeDiffBinlogSameGroupFilesChangedWithNewChildSplitsReplaceAndLoad) {
+    // Current: multi-field group 200 contains only child 105
+    proto::segcore::SegmentLoadInfo current_proto;
+    current_proto.set_segmentid(100);
+    current_proto.set_num_of_rows(1000);
+    auto* cur_binlog = current_proto.add_binlog_paths();
+    cur_binlog->set_fieldid(200);
+    cur_binlog->add_child_fields(105);
+    auto* cur_log = cur_binlog->add_binlogs();
+    cur_log->set_log_path("/path/to/group_binlog_A");
+    cur_log->set_entries_num(1000);
+
+    // New: same group id 200 but files changed AND child 106 is newly added.
+    // Expect: 105 -> replace (already loaded, cache stale), 106 -> load (new).
+    proto::segcore::SegmentLoadInfo new_proto;
+    new_proto.set_segmentid(100);
+    new_proto.set_num_of_rows(1000);
+    auto* new_binlog = new_proto.add_binlog_paths();
+    new_binlog->set_fieldid(200);
+    new_binlog->add_child_fields(105);
+    new_binlog->add_child_fields(106);
+    auto* new_log = new_binlog->add_binlogs();
+    new_log->set_log_path("/path/to/group_binlog_B");
+    new_log->set_entries_num(1000);
+
+    SegmentLoadInfo current_info(current_proto, schema_);
+    SegmentLoadInfo new_info(new_proto, schema_);
+    auto diff = current_info.ComputeDiff(new_info);
+
+    ASSERT_EQ(diff.binlogs_to_replace.size(), 1);
+    ASSERT_EQ(diff.binlogs_to_replace[0].first.size(), 1);
+    EXPECT_EQ(diff.binlogs_to_replace[0].first[0].get(), 105);
+
+    ASSERT_EQ(diff.binlogs_to_load.size(), 1);
+    ASSERT_EQ(diff.binlogs_to_load[0].first.size(), 1);
+    EXPECT_EQ(diff.binlogs_to_load[0].first[0].get(), 106);
+
+    EXPECT_TRUE(diff.field_data_to_drop.empty());
+}
+
+// ---- Column group same-index file-change detection ----
+
+namespace {
+
+// Build a ColumnGroups payload from a list of (fields, files) pairs so
+// tests can exercise ComputeDiffColumnGroups without a real manifest.
+std::shared_ptr<milvus_storage::api::ColumnGroups>
+MakeColumnGroups(
+    std::initializer_list<
+        std::pair<std::vector<int64_t>, std::vector<std::string>>> groups) {
+    auto cgs = std::make_shared<milvus_storage::api::ColumnGroups>();
+    for (const auto& [field_ids, paths] : groups) {
+        auto cg = std::make_shared<milvus_storage::api::ColumnGroup>();
+        cg->format = "parquet";
+        for (auto fid : field_ids) {
+            cg->columns.push_back(std::to_string(fid));
+        }
+        for (const auto& p : paths) {
+            milvus_storage::api::ColumnGroupFile f;
+            f.path = p;
+            f.start_index = 0;
+            f.end_index = 0;
+            cg->files.push_back(std::move(f));
+        }
+        auto st = cgs->add_column_group(std::move(cg));
+        EXPECT_TRUE(st.ok()) << st.ToString();
+    }
+    return cgs;
+}
+
+proto::segcore::SegmentLoadInfo
+MakeManifestProto(const std::string& manifest_path) {
+    proto::segcore::SegmentLoadInfo p;
+    p.set_segmentid(100);
+    p.set_num_of_rows(1000);
+    p.set_manifest_path(manifest_path);
+    return p;
+}
+
+}  // namespace
+
+TEST_F(SegmentLoadInfoTest,
+       ComputeDiffColumnGroupSameIndexDifferentFilesTriggersReplace) {
+    // Two column groups with identical shape {105,106} at index 1, but the
+    // new manifest points at different parquet files. The pk (100) is in
+    // its own group at index 0 so it stays untouched.
+    auto current_cgs =
+        MakeColumnGroups({{{100}, {"/pk/file_A.parquet"}},
+                          {{105, 106}, {"/user/file_A.parquet"}}});
+    auto new_cgs = MakeColumnGroups({{{100}, {"/pk/file_A.parquet"}},
+                                     {{105, 106}, {"/user/file_B.parquet"}}});
+
+    SegmentLoadInfo current_info(MakeManifestProto("/manifest/old"), schema_);
+    current_info.SetColumnGroupsForTesting(current_cgs);
+    SegmentLoadInfo new_info(MakeManifestProto("/manifest/new"), schema_);
+    new_info.SetColumnGroupsForTesting(new_cgs);
+
+    auto diff = current_info.ComputeDiff(new_info);
+
+    // User fields (105, 106) at the unchanged index 1 must be replaced
+    // since the underlying parquet file changed.
+    bool saw_user_group = false;
+    for (const auto& [idx, fields] : diff.column_groups_to_replace) {
+        if (idx == 1) {
+            saw_user_group = true;
+            std::set<int64_t> ids;
+            for (auto f : fields) {
+                ids.insert(f.get());
+            }
+            EXPECT_EQ(ids, (std::set<int64_t>{105, 106}));
+        }
+    }
+    EXPECT_TRUE(saw_user_group);
+    // PK group (index 0) had identical files; no replace entry for it.
+    for (const auto& [idx, fields] : diff.column_groups_to_replace) {
+        EXPECT_NE(idx, 0);
+    }
+    EXPECT_TRUE(diff.column_groups_to_load.empty());
+}
+
+TEST_F(SegmentLoadInfoTest,
+       ComputeDiffColumnGroupSameIndexIdenticalFilesNoReplace) {
+    auto cgs = MakeColumnGroups(
+        {{{100}, {"/pk/file.parquet"}}, {{105, 106}, {"/user/file.parquet"}}});
+
+    SegmentLoadInfo current_info(MakeManifestProto("/manifest/v1"), schema_);
+    current_info.SetColumnGroupsForTesting(cgs);
+    SegmentLoadInfo new_info(MakeManifestProto("/manifest/v1"), schema_);
+    new_info.SetColumnGroupsForTesting(cgs);
+
+    auto diff = current_info.ComputeDiff(new_info);
+
+    EXPECT_TRUE(diff.column_groups_to_load.empty());
+    EXPECT_TRUE(diff.column_groups_to_replace.empty());
+    EXPECT_TRUE(diff.column_groups_to_lazyload.empty());
+    EXPECT_TRUE(diff.column_groups_to_lazyreplace.empty());
+}
+
+TEST_F(SegmentLoadInfoTest,
+       ComputeDiffColumnGroupSameIndexDifferentFileCountTriggersReplace) {
+    auto current_cgs = MakeColumnGroups(
+        {{{100}, {"/pk/file.parquet"}}, {{105, 106}, {"/user/a.parquet"}}});
+    auto new_cgs = MakeColumnGroups(
+        {{{100}, {"/pk/file.parquet"}},
+         {{105, 106}, {"/user/a.parquet", "/user/b.parquet"}}});
+
+    SegmentLoadInfo current_info(MakeManifestProto("/manifest/old"), schema_);
+    current_info.SetColumnGroupsForTesting(current_cgs);
+    SegmentLoadInfo new_info(MakeManifestProto("/manifest/new"), schema_);
+    new_info.SetColumnGroupsForTesting(new_cgs);
+
+    auto diff = current_info.ComputeDiff(new_info);
+
+    bool saw_user_group = false;
+    for (const auto& [idx, fields] : diff.column_groups_to_replace) {
+        if (idx == 1) {
+            saw_user_group = true;
+            std::set<int64_t> ids;
+            for (auto f : fields) {
+                ids.insert(f.get());
+            }
+            EXPECT_EQ(ids, (std::set<int64_t>{105, 106}));
+        }
+    }
+    EXPECT_TRUE(saw_user_group);
+}
+
+TEST_F(SegmentLoadInfoTest,
+       ComputeDiffColumnGroupMovedFieldNotDoubleEmittedWithFilesChanged) {
+    // Current: field 106 lives at column-group index 1 (alongside 105).
+    // New: field 106 moves to a new column-group index 2, and the files
+    //      at index 1 also differ. 106 must appear exactly once in the
+    //      diff — as a "moved" entry under group 2, not also under 1.
+    auto current_cgs =
+        MakeColumnGroups({{{100}, {"/pk/file.parquet"}},
+                          {{105, 106}, {"/user/file_A.parquet"}}});
+    auto new_cgs = MakeColumnGroups({{{100}, {"/pk/file.parquet"}},
+                                     {{105}, {"/user/file_B.parquet"}},
+                                     {{106}, {"/moved/file.parquet"}}});
+
+    SegmentLoadInfo current_info(MakeManifestProto("/manifest/old"), schema_);
+    current_info.SetColumnGroupsForTesting(current_cgs);
+    SegmentLoadInfo new_info(MakeManifestProto("/manifest/new"), schema_);
+    new_info.SetColumnGroupsForTesting(new_cgs);
+
+    auto diff = current_info.ComputeDiff(new_info);
+
+    int emissions_for_106 = 0;
+    for (const auto& [idx, fields] : diff.column_groups_to_replace) {
+        for (auto f : fields) {
+            if (f.get() == 106) {
+                emissions_for_106++;
+            }
+        }
+    }
+    for (const auto& [idx, fields] : diff.column_groups_to_lazyreplace) {
+        for (auto f : fields) {
+            if (f.get() == 106) {
+                emissions_for_106++;
+            }
+        }
+    }
+    for (const auto& [idx, fields] : diff.column_groups_to_load) {
+        for (auto f : fields) {
+            if (f.get() == 106) {
+                emissions_for_106++;
+            }
+        }
+    }
+    EXPECT_EQ(emissions_for_106, 1);
+}


### PR DESCRIPTION
Cherry-pick of the same-group file-change detection introduced on master (#46358 follow-up) to the 2.6 load-diff pipeline.

ComputeDiffBinlogs and ComputeDiffColumnGroups in SegmentLoadInfo only compared field-level membership, so a field that stayed under the same group id / column-group index was treated as unchanged even when the underlying files were rewritten (e.g. post-compaction manifests that preserve the column-group layout but point at new parquet files). ApplyLoadDiff gates reader rebuild and column eviction on *_to_replace entries, so the loader silently kept serving stale cached chunks.

Compare the ordered file-path sequence per group and route pre-existing fields into binlogs_to_replace / column_groups_to_replace (respecting the existing eager-vs-lazy policy) when files differ; genuinely new children in a files-changed group still go to binlogs_to_load so the replace path isn't asked to evict a column that was never loaded.

Because 2.6 previously only had the binlog replace path, also add the column-group replace infra missing here: column_groups_to_replace / column_groups_to_lazyreplace fields on LoadDiff, an is_replace flag threaded through LoadColumnGroups / LoadColumnGroup into load_field_data_common, and the corresponding branches in ApplyLoadDiff so the reader is rebuilt and stale proxy columns are overwritten in place.

Add SetColumnGroupsForTesting as a narrow hook so unit tests can exercise ComputeDiffColumnGroups without constructing real manifest files, and cover both diff functions for: identical files, different file paths, different file counts, new child under changed files, and non-double-emission for moved fields whose old group's files also changed.