### PR TITLE
enhance: make BM25 stats per-entry memory cost configurable, default 20

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -586,6 +586,7 @@ queryNode:
   idfOracle:
     preload: true # Whether to parse and merge BM25 stats into current during load before first target. When false, stats are only written to disk and loaded on first SyncDistribution.
     readBufferSize: 4194304 # Read buffer size in bytes for streaming BM25 stats from remote storage. Reduces per-read overhead through the storage SDK.
+    bm25StatsBytesPerEntry: 20 # Estimated memory cost (bytes) per entry in BM25 stats rowsWithToken map for memory accounting. Empirical measurement: 12-19.5 bytes/entry depending on map fill ratio. Increase if cache eviction is too lax; decrease to load more segments concurrently.
   ip:  # TCP/IP address of queryNode. If not specified, use the first unicastable address
   port: 21123 # TCP port of queryNode
   grpc:

--- a/internal/querynodev2/delegator/idf_oracle.go
+++ b/internal/querynodev2/delegator/idf_oracle.go
@@ -499,10 +499,20 @@ func (o *idfOracle) diskSize() int64 {
 	return o.sealedDiskSize.Load()
 }
 
+// resourceTrackingEnabled reports whether to charge/refund the C++ caching layer.
+// When tiered storage eviction is disabled, the caching layer's resource accounting is
+// inert (no eviction will be driven by it), so we skip the cgo calls entirely.
+func resourceTrackingEnabled() bool {
+	return paramtable.Get().QueryNodeCfg.TieredEvictionEnabled.GetAsBool()
+}
+
 // syncResource precisely syncs resource usage to the caching layer.
 // Used for segment lifecycle events (Register/Unregister/SyncDistribution).
 // Caller must NOT hold the RWMutex.
 func (o *idfOracle) syncResource() {
+	if !resourceTrackingEnabled() {
+		return
+	}
 	actualMem := o.MemorySize()
 	actualDisk := o.diskSize()
 
@@ -515,6 +525,9 @@ func (o *idfOracle) syncResource() {
 // Only charges (with headroom), never refunds. Used in Insert path (UpdateGrowing).
 // Caller must hold RWMutex.Lock (so memSize is safe to call without RLock).
 func (o *idfOracle) checkMemoryResource() {
+	if !resourceTrackingEnabled() {
+		return
+	}
 	actualMem := o.memSize()
 
 	o.resourceMu.Lock()

--- a/internal/storage/stats.go
+++ b/internal/storage/stats.go
@@ -514,15 +514,12 @@ func DeserializeBloomFilterStats(paths []string, blobs []*Blob) ([]*PrimaryKeySt
 	return DeserializeStats(blobs)
 }
 
-// bm25StatsPerEntryBytes is the estimated memory cost per entry in the rowsWithToken map.
-// Go map overhead per entry: key(4) + value(4) + bucket/pointer overhead (~72B) ≈ 80 bytes.
-const bm25StatsPerEntryBytes = 80
-
 // MemSize estimates the in-memory size of this BM25Stats in bytes.
-// len(map) is O(1) in Go (reads hmap.count directly).
+// len(map) is O(1) in Go (reads hmap.count directly). Per-entry cost is configurable
+// via queryNode.idfOracle.bm25StatsBytesPerEntry.
 func (m *BM25Stats) MemSize() int64 {
 	// Fixed overhead: numRow(8) + numToken(8) + map header (~100B)
-	return 120 + int64(len(m.rowsWithToken))*bm25StatsPerEntryBytes
+	return 120 + int64(len(m.rowsWithToken))*paramtable.Get().QueryNodeCfg.BM25StatsBytesPerEntry.GetAsInt64()
 }
 
 // DeserializeFromReader reads BM25 stats from an io.Reader and accumulates into self.

--- a/internal/storage/stats_test.go
+++ b/internal/storage/stats_test.go
@@ -275,7 +275,8 @@ func TestBM25Stats_MemSize(t *testing.T) {
 	for i := uint32(0); i < 100; i++ {
 		stats.Append(map[uint32]float32{i: 1})
 	}
-	assert.Equal(t, int64(120+100*bm25StatsPerEntryBytes), stats.MemSize())
+	bytesPerEntry := paramtable.Get().QueryNodeCfg.BM25StatsBytesPerEntry.GetAsInt64()
+	assert.Equal(t, int64(120)+100*bytesPerEntry, stats.MemSize())
 }
 
 func TestBM25Stats_DeserializeFromReader(t *testing.T) {

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3511,8 +3511,9 @@ type queryNodeConfig struct {
 	EnabledGrowingSegmentJSONKeyStats ParamItem `refreshable:"false"`
 
 	// Idf Oracle
-	IDFPreload        ParamItem `refreshable:"true"`
-	IDFReadBufferSize ParamItem `refreshable:"true"`
+	IDFPreload             ParamItem `refreshable:"true"`
+	IDFReadBufferSize      ParamItem `refreshable:"true"`
+	BM25StatsBytesPerEntry ParamItem `refreshable:"true"`
 	// partial search
 	PartialResultRequiredDataRatio ParamItem `refreshable:"true"`
 }
@@ -3535,6 +3536,15 @@ func (p *queryNodeConfig) init(base *BaseTable) {
 		Doc:          "Read buffer size in bytes for streaming BM25 stats from remote storage. Reduces per-read overhead through the storage SDK.",
 	}
 	p.IDFReadBufferSize.Init(base.mgr)
+
+	p.BM25StatsBytesPerEntry = ParamItem{
+		Key:          "queryNode.idfOracle.bm25StatsBytesPerEntry",
+		Version:      "2.6.15",
+		Export:       true,
+		DefaultValue: "20",
+		Doc:          "Estimated memory cost (bytes) per entry in BM25 stats rowsWithToken map for memory accounting. Empirical measurement: 12-19.5 bytes/entry depending on map fill ratio. Increase if cache eviction is too lax; decrease to load more segments concurrently.",
+	}
+	p.BM25StatsBytesPerEntry.Init(base.mgr)
 
 	p.SoPath = ParamItem{
 		Key:          "queryNode.soPath",


### PR DESCRIPTION
## Summary
Two improvements to BM25 stats memory accounting in idfOracle:

### 1. Per-entry estimate: 80 → 20 bytes/entry
The previous hardcoded `bm25StatsPerEntryBytes = 80` overestimates `map[uint32]int32` memory by 4-7x. Empirical measurement on Go 1.24 (median of 5 runs, n ≥ 10K to avoid GC noise):

| n | heap delta | bytes/entry | overestimate vs 80 |
|---|---|---|---|
| 10K | 152 KB | 15.22 | 5.2× |
| 100K | 1.22 MB | 12.18 | 6.6× |
| 1M | 19.4 MB | 19.43 | 4.1× |
| 5M | 77.9 MB | 15.58 | 5.1× |
| 10M | 156 MB | 15.58 | 5.1× |
| 50M | 623 MB | 12.47 | 6.4× |

Steady-state cost oscillates between **12 and 19.5 bytes/entry** depending on the swiss table fill ratio (peak ~19.5 right after a 2× capacity grow, trough ~12 when near load factor 7/8).

Root cause: the original comment claimed "bucket overhead ~72B per entry", but Go map buckets/groups hold 8 entries each, so amortized overhead is ~10 bytes/entry, not 72.

**Fix**: lower the default to 20 (covers measured upper bound 19.5 with small safety margin) and expose as `queryNode.idfOracle.bm25StatsBytesPerEntry` (refreshable) for runtime tuning.

### 2. Skip cgo Charge/Refund when tiered eviction is disabled
When `queryNode.segcore.tieredStorage.evictionEnabled = false` (the default), the C++ caching layer's resource accounting is inert — no eviction will be driven by it. The per-load `C.ChargeLoadedResource` / `C.RefundLoadedResource` cgo calls are pure overhead in this case.

**Fix**: gate `syncResource` and `checkMemoryResource` on the eviction flag. Skip entirely when eviction is off.

## Impact
- ~75% reduction in cache budget consumed by BM25 stats (when eviction enabled)
- Eliminates per-segment cgo overhead in default deployments (eviction off)
- Tunable per-entry estimate without redeploying

## Test plan
- [x] `TestIDFOracle` passes
- [x] `TestBM25Stats_MemSize` passes with the new configurable value
- [x] Verified memory measurement methodology with multiple sample sizes

issue: #46468

🤖 Generated with [Claude Code](https://claude.com/claude-code)