### PR TITLE
enhance: [3.0] replace stale columns when load-diff groups keep shape but swap files (#49066)

### DIFF
--- a/internal/core/src/segcore/SegmentLoadInfo.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfo.cpp
@@ -256,6 +256,23 @@ SegmentLoadInfo::ComputeDiffBinlogs(LoadDiff& diff, SegmentLoadInfo& new_info) {
         }
     }
 
+    // Two FieldBinlogs at the same group id are equivalent only when their
+    // underlying log files (log_path sequence) match. Compaction/version
+    // bumps can swap files under the same fieldid, and without detecting
+    // that here the loader never evicts the stale column cache.
+    auto same_binlog_files = [](const proto::segcore::FieldBinlog& a,
+                                const proto::segcore::FieldBinlog& b) -> bool {
+        if (a.binlogs_size() != b.binlogs_size()) {
+            return false;
+        }
+        for (int j = 0; j < a.binlogs_size(); j++) {
+            if (a.binlogs(j).log_path() != b.binlogs(j).log_path()) {
+                return false;
+            }
+        }
+        return true;
+    };
+
     std::map<int64_t, int64_t> new_binlog_fields;
     for (int i = 0; i < new_info.GetBinlogPathCount(); i++) {
         auto& new_field_binlog = new_info.GetBinlogPath(i);
@@ -268,20 +285,38 @@ SegmentLoadInfo::ComputeDiffBinlogs(LoadDiff& diff, SegmentLoadInfo& new_info) {
         if (child_fields.empty()) {
             child_fields.emplace_back(new_field_binlog.fieldid());
         }
+
+        auto* cur_field_binlog =
+            GetFieldBinlog(FieldId(new_field_binlog.fieldid()));
+        bool group_files_changed =
+            cur_field_binlog != nullptr &&
+            !same_binlog_files(*cur_field_binlog, new_field_binlog);
+
         for (auto child_id : child_fields) {
             new_binlog_fields[child_id] = new_field_binlog.fieldid();
-            auto iter = current_fields.find(new_field_binlog.fieldid());
-            // Find binlogs to load/replace: fields in new_info not matching current
-            if (iter == current_fields.end() ||
-                iter->second != new_field_binlog.fieldid()) {
-                // Check if this child field already exists in current
-                // (either from binlogs or from default value filling)
-                if (current_fields.find(child_id) != current_fields.end() ||
-                    fields_filled_with_default_.count(FieldId(child_id)) > 0) {
-                    ids_to_replace.emplace_back(child_id);
-                } else {
-                    ids_to_load.emplace_back(child_id);
-                }
+            // current_fields is keyed by child field id, so look up the
+            // child — keying by new_field_binlog.fieldid() misses multi-
+            // field groups (whose group id is not itself a map key) and
+            // spuriously classifies unchanged groups as moved.
+            auto iter = current_fields.find(child_id);
+            // A binlog entry needs (re)loading when either
+            //   (a) the group this child belongs to differs between
+            //       current and new, or
+            //   (b) the group maps the same way but the underlying log
+            //       files changed (e.g. compaction rewrote the segment).
+            bool group_mapping_differs =
+                iter == current_fields.end() ||
+                iter->second != new_field_binlog.fieldid();
+            if (!group_mapping_differs && !group_files_changed) {
+                continue;
+            }
+            // Pre-existing children go to replace (to evict stale cached
+            // columns); genuinely new children go to load.
+            if (current_fields.find(child_id) != current_fields.end() ||
+                fields_filled_with_default_.count(FieldId(child_id)) > 0) {
+                ids_to_replace.emplace_back(child_id);
+            } else {
+                ids_to_load.emplace_back(child_id);
             }
         }
         if (!ids_to_load.empty()) {
@@ -310,36 +345,71 @@ SegmentLoadInfo::ComputeDiffColumnGroups(LoadDiff& diff,
     AssertInfo(cur_column_group, "current column groups shall not be null");
     AssertInfo(new_column_group, "new column groups shall not be null");
 
-    // Build a set of current FieldIds from current column groups
-    std::map<int64_t, int> cur_field_ids;
-    for (int i = 0; i < cur_column_group->size(); i++) {
-        auto cg = cur_column_group->at(i);
+    // The loon manifest gives no ordering guarantee on the column-groups
+    // vector, so we don't try to pair cur/new groups by position or by a
+    // synthesized leader. For each field we only ask: "is it present in
+    // current, and did its backing files change?" — field-level existence
+    // plus per-field file-list comparison is enough to classify
+    // new/replace/unchanged without any group-identity assumption.
+    std::map<int64_t, const std::vector<milvus_storage::api::ColumnGroupFile>*>
+        cur_field_to_files;
+    for (const auto& cg : *cur_column_group) {
+        if (!cg) {
+            continue;
+        }
         for (const auto& column : cg->columns) {
             auto field_id = std::stoll(column);
-            cur_field_ids.emplace(field_id, i);
+            cur_field_to_files[field_id] = &cg->files;
         }
     }
 
-    // Build a set of new FieldIds and find column groups to load/replace
-    std::map<int64_t, int> new_field_ids;
+    // Compare path + row range: storage v2 packed files can share a path
+    // across compactions while the row window (start_index/end_index)
+    // changes, so path-only comparison would leave stale cache in place.
+    auto same_files =
+        [](const std::vector<milvus_storage::api::ColumnGroupFile>& a,
+           const std::vector<milvus_storage::api::ColumnGroupFile>& b) -> bool {
+        if (a.size() != b.size()) {
+            return false;
+        }
+        for (size_t j = 0; j < a.size(); j++) {
+            if (a[j].path != b[j].path ||
+                a[j].start_index != b[j].start_index ||
+                a[j].end_index != b[j].end_index) {
+                return false;
+            }
+        }
+        return true;
+    };
+
+    // Find column groups to load/replace on the new side
+    std::set<int64_t> new_seen_field_ids;
     for (int i = 0; i < new_column_group->size(); i++) {
         auto cg = new_column_group->at(i);
+        if (!cg) {
+            continue;
+        }
         std::vector<FieldId> fields;
         std::vector<FieldId> replace_fields;
         std::vector<FieldId> lazy_fields;
         std::vector<FieldId> lazy_replace_fields;
         for (const auto& column : cg->columns) {
             auto field_id = std::stoll(column);
-            new_field_ids.emplace(field_id, i);
+            new_seen_field_ids.emplace(field_id);
 
-            auto iter = cur_field_ids.find(field_id);
+            auto cur_iter = cur_field_to_files.find(field_id);
             bool was_default_filled =
                 fields_filled_with_default_.count(FieldId(field_id)) > 0;
             bool is_new_field =
-                iter == cur_field_ids.end() && !was_default_filled;
-            bool is_replace_field =
-                was_default_filled ||
-                (iter != cur_field_ids.end() && iter->second != i);
+                cur_iter == cur_field_to_files.end() && !was_default_filled;
+            // A field that was present in current must go to replace when
+            // its backing files changed — whether that's the same group
+            // rewriting its parquet (compaction) or the field landing in
+            // a different group with a different file set. Either way the
+            // cached chunks are stale.
+            bool files_changed = cur_iter != cur_field_to_files.end() &&
+                                 !same_files(*cur_iter->second, cg->files);
+            bool is_replace_field = was_default_filled || files_changed;
             if (is_new_field) {
                 // Field not in current and not default-filled → new load
                 if (field_id < START_USER_FIELDID ||
@@ -395,8 +465,8 @@ SegmentLoadInfo::ComputeDiffColumnGroups(LoadDiff& diff,
     }
 
     // Find field data to drop: fields in current but not in new
-    for (const auto& [field_id, cg_index] : cur_field_ids) {
-        if (new_field_ids.find(field_id) == new_field_ids.end()) {
+    for (const auto& [field_id, files_ptr] : cur_field_to_files) {
+        if (new_seen_field_ids.find(field_id) == new_seen_field_ids.end()) {
             diff.field_data_to_drop.emplace(field_id);
         }
     }

--- a/internal/core/src/segcore/SegmentLoadInfo.h
+++ b/internal/core/src/segcore/SegmentLoadInfo.h
@@ -703,6 +703,17 @@ class SegmentLoadInfo {
     [[nodiscard]] std::shared_ptr<milvus_storage::api::ColumnGroups>
     GetColumnGroups();
 
+    /**
+     * @brief Pre-populate the column group cache without parsing a manifest
+     * @note Test-only hook: lets unit tests exercise diff logic that depends
+     *       on ColumnGroup contents without constructing real manifest files.
+     */
+    void
+    SetColumnGroupsForTesting(
+        std::shared_ptr<milvus_storage::api::ColumnGroups> cg) {
+        column_groups_ = std::move(cg);
+    }
+
     // ==================== Stats & Delta Logs ====================
 
     [[nodiscard]] int

--- a/internal/core/src/segcore/SegmentLoadInfoTest.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfoTest.cpp
@@ -2220,3 +2220,422 @@ TEST_F(SegmentLoadInfoTest, ComputeDiffNoReloadWhenIndexStaysRaw) {
     EXPECT_TRUE(diff.fields_to_reload.empty());
     EXPECT_TRUE(diff.field_data_to_drop.empty());
 }
+
+// -----------------------------------------------------------------------------
+// Tests for same-group file-change detection in ComputeDiffBinlogs and
+// ComputeDiffColumnGroups.
+// When compaction rewrites the data under the same group id / column group
+// index, the files list changes but the field layout does not. These tests
+// verify that the diff emits replace entries so the loader can evict stale
+// cached columns.
+// -----------------------------------------------------------------------------
+
+TEST_F(SegmentLoadInfoTest,
+       ComputeDiffBinlogSameGroupDifferentFilesTriggersReplace) {
+    // Current: legacy field 105 pointing at binlog A
+    proto::segcore::SegmentLoadInfo current_proto;
+    current_proto.set_segmentid(100);
+    current_proto.set_num_of_rows(1000);
+    auto* cur_binlog = current_proto.add_binlog_paths();
+    cur_binlog->set_fieldid(105);
+    auto* cur_log = cur_binlog->add_binlogs();
+    cur_log->set_log_path("/path/to/binlog_A");
+    cur_log->set_entries_num(1000);
+
+    // New: same group id, same child field, but a different log_path
+    proto::segcore::SegmentLoadInfo new_proto = current_proto;
+    new_proto.mutable_binlog_paths(0)->mutable_binlogs(0)->set_log_path(
+        "/path/to/binlog_B");
+
+    SegmentLoadInfo current_info(current_proto, schema_);
+    SegmentLoadInfo new_info(new_proto, schema_);
+    auto diff = current_info.ComputeDiff(new_info);
+
+    EXPECT_TRUE(diff.HasChanges());
+    ASSERT_EQ(diff.binlogs_to_replace.size(), 1);
+    ASSERT_EQ(diff.binlogs_to_replace[0].first.size(), 1);
+    EXPECT_EQ(diff.binlogs_to_replace[0].first[0].get(), 105);
+    EXPECT_TRUE(diff.binlogs_to_load.empty());
+    EXPECT_TRUE(diff.field_data_to_drop.empty());
+}
+
+TEST_F(SegmentLoadInfoTest,
+       ComputeDiffBinlogSameGroupDifferentFileCountTriggersReplace) {
+    // Current: legacy field 105 with one binlog file
+    proto::segcore::SegmentLoadInfo current_proto;
+    current_proto.set_segmentid(100);
+    current_proto.set_num_of_rows(1000);
+    auto* cur_binlog = current_proto.add_binlog_paths();
+    cur_binlog->set_fieldid(105);
+    auto* cur_log = cur_binlog->add_binlogs();
+    cur_log->set_log_path("/path/to/binlog_A");
+    cur_log->set_entries_num(500);
+
+    // New: same group id, same child, but an additional binlog file (post
+    // compaction merging more files into the same group).
+    proto::segcore::SegmentLoadInfo new_proto = current_proto;
+    auto* extra_log = new_proto.mutable_binlog_paths(0)->add_binlogs();
+    extra_log->set_log_path("/path/to/binlog_B");
+    extra_log->set_entries_num(500);
+
+    SegmentLoadInfo current_info(current_proto, schema_);
+    SegmentLoadInfo new_info(new_proto, schema_);
+    auto diff = current_info.ComputeDiff(new_info);
+
+    ASSERT_EQ(diff.binlogs_to_replace.size(), 1);
+    ASSERT_EQ(diff.binlogs_to_replace[0].first.size(), 1);
+    EXPECT_EQ(diff.binlogs_to_replace[0].first[0].get(), 105);
+    EXPECT_TRUE(diff.binlogs_to_load.empty());
+}
+
+TEST_F(SegmentLoadInfoTest, ComputeDiffBinlogSameGroupIdenticalFilesNoDiff) {
+    // Current and new have identical binlog contents under group 105.
+    proto::segcore::SegmentLoadInfo proto;
+    proto.set_segmentid(100);
+    proto.set_num_of_rows(1000);
+    auto* binlog = proto.add_binlog_paths();
+    binlog->set_fieldid(105);
+    auto* log1 = binlog->add_binlogs();
+    log1->set_log_path("/path/to/binlog_A");
+    log1->set_entries_num(500);
+    auto* log2 = binlog->add_binlogs();
+    log2->set_log_path("/path/to/binlog_B");
+    log2->set_entries_num(500);
+
+    SegmentLoadInfo current_info(proto, schema_);
+    (void)current_info.GetLoadDiff();
+    SegmentLoadInfo new_info(proto, schema_);
+    auto diff = current_info.ComputeDiff(new_info);
+
+    EXPECT_TRUE(diff.binlogs_to_load.empty());
+    EXPECT_TRUE(diff.binlogs_to_replace.empty());
+}
+
+TEST_F(SegmentLoadInfoTest,
+       ComputeDiffBinlogMultiFieldGroupIdenticalFilesNoDiff) {
+    // Multi-field (storage v2) binlog group: group id 200 carries children
+    // 105 and 106 under the same log file. Cur and new are identical, so
+    // the diff must be empty. Regression for a bug where the mapping
+    // lookup used the group id (which is not a map key) and spuriously
+    // routed both children into binlogs_to_replace.
+    proto::segcore::SegmentLoadInfo proto;
+    proto.set_segmentid(100);
+    proto.set_num_of_rows(1000);
+    auto* binlog = proto.add_binlog_paths();
+    binlog->set_fieldid(200);
+    binlog->add_child_fields(105);
+    binlog->add_child_fields(106);
+    auto* log1 = binlog->add_binlogs();
+    log1->set_log_path("/path/to/group_binlog_A");
+    log1->set_entries_num(1000);
+
+    SegmentLoadInfo current_info(proto, schema_);
+    SegmentLoadInfo new_info(proto, schema_);
+    auto diff = current_info.ComputeDiff(new_info);
+
+    EXPECT_TRUE(diff.binlogs_to_load.empty());
+    EXPECT_TRUE(diff.binlogs_to_replace.empty());
+    EXPECT_TRUE(diff.field_data_to_drop.empty());
+}
+
+TEST_F(SegmentLoadInfoTest,
+       ComputeDiffBinlogMultiFieldGroupDifferentFilesReplacesAllChildren) {
+    // Same multi-field group shape on both sides but the underlying
+    // binlog file path changes — every child must land in
+    // binlogs_to_replace so the loader evicts the stale cached columns.
+    proto::segcore::SegmentLoadInfo current_proto;
+    current_proto.set_segmentid(100);
+    current_proto.set_num_of_rows(1000);
+    auto* cur_binlog = current_proto.add_binlog_paths();
+    cur_binlog->set_fieldid(200);
+    cur_binlog->add_child_fields(105);
+    cur_binlog->add_child_fields(106);
+    auto* cur_log = cur_binlog->add_binlogs();
+    cur_log->set_log_path("/path/to/group_binlog_A");
+    cur_log->set_entries_num(1000);
+
+    proto::segcore::SegmentLoadInfo new_proto = current_proto;
+    new_proto.mutable_binlog_paths(0)->mutable_binlogs(0)->set_log_path(
+        "/path/to/group_binlog_B");
+
+    SegmentLoadInfo current_info(current_proto, schema_);
+    SegmentLoadInfo new_info(new_proto, schema_);
+    auto diff = current_info.ComputeDiff(new_info);
+
+    ASSERT_EQ(diff.binlogs_to_replace.size(), 1);
+    std::set<int64_t> replaced;
+    for (const auto& fid : diff.binlogs_to_replace[0].first) {
+        replaced.insert(fid.get());
+    }
+    EXPECT_EQ(replaced, (std::set<int64_t>{105, 106}));
+    EXPECT_TRUE(diff.binlogs_to_load.empty());
+    EXPECT_TRUE(diff.field_data_to_drop.empty());
+}
+
+TEST_F(SegmentLoadInfoTest,
+       ComputeDiffBinlogSameGroupFilesChangedWithNewChildSplitsReplaceAndLoad) {
+    // Current: multi-field group 200 contains only child 105
+    proto::segcore::SegmentLoadInfo current_proto;
+    current_proto.set_segmentid(100);
+    current_proto.set_num_of_rows(1000);
+    auto* cur_binlog = current_proto.add_binlog_paths();
+    cur_binlog->set_fieldid(200);
+    cur_binlog->add_child_fields(105);
+    auto* cur_log = cur_binlog->add_binlogs();
+    cur_log->set_log_path("/path/to/group_binlog_A");
+    cur_log->set_entries_num(1000);
+
+    // New: same group id 200 but files changed AND child 106 is newly added.
+    // Expect: 105 -> replace (already loaded, cache stale), 106 -> load (new).
+    proto::segcore::SegmentLoadInfo new_proto;
+    new_proto.set_segmentid(100);
+    new_proto.set_num_of_rows(1000);
+    auto* new_binlog = new_proto.add_binlog_paths();
+    new_binlog->set_fieldid(200);
+    new_binlog->add_child_fields(105);
+    new_binlog->add_child_fields(106);
+    auto* new_log = new_binlog->add_binlogs();
+    new_log->set_log_path("/path/to/group_binlog_B");
+    new_log->set_entries_num(1000);
+
+    SegmentLoadInfo current_info(current_proto, schema_);
+    SegmentLoadInfo new_info(new_proto, schema_);
+    auto diff = current_info.ComputeDiff(new_info);
+
+    ASSERT_EQ(diff.binlogs_to_replace.size(), 1);
+    ASSERT_EQ(diff.binlogs_to_replace[0].first.size(), 1);
+    EXPECT_EQ(diff.binlogs_to_replace[0].first[0].get(), 105);
+
+    ASSERT_EQ(diff.binlogs_to_load.size(), 1);
+    ASSERT_EQ(diff.binlogs_to_load[0].first.size(), 1);
+    EXPECT_EQ(diff.binlogs_to_load[0].first[0].get(), 106);
+
+    EXPECT_TRUE(diff.field_data_to_drop.empty());
+}
+
+// ---- Column group same-index file-change detection ----
+
+namespace {
+
+// Build a ColumnGroups payload from a list of (fields, files) pairs so
+// tests can exercise ComputeDiffColumnGroups without a real manifest.
+std::shared_ptr<milvus_storage::api::ColumnGroups>
+MakeColumnGroups(
+    std::initializer_list<
+        std::pair<std::vector<int64_t>, std::vector<std::string>>> groups) {
+    auto cgs = std::make_shared<milvus_storage::api::ColumnGroups>();
+    for (const auto& [field_ids, paths] : groups) {
+        auto cg = std::make_shared<milvus_storage::api::ColumnGroup>();
+        cg->format = "parquet";
+        for (auto fid : field_ids) {
+            cg->columns.push_back(std::to_string(fid));
+        }
+        for (const auto& p : paths) {
+            milvus_storage::api::ColumnGroupFile f;
+            f.path = p;
+            f.start_index = 0;
+            f.end_index = 0;
+            cg->files.push_back(std::move(f));
+        }
+        cgs->push_back(std::move(cg));
+    }
+    return cgs;
+}
+
+proto::segcore::SegmentLoadInfo
+MakeManifestProto(const std::string& manifest_path) {
+    proto::segcore::SegmentLoadInfo p;
+    p.set_segmentid(100);
+    p.set_num_of_rows(1000);
+    p.set_manifest_path(manifest_path);
+    return p;
+}
+
+}  // namespace
+
+TEST_F(SegmentLoadInfoTest,
+       ComputeDiffColumnGroupSameIndexDifferentFilesTriggersReplace) {
+    // Two column groups with identical shape {105,106} at index 0, but the
+    // new manifest points at different parquet files. The pk (100) is in
+    // its own group at index 1 so it stays untouched.
+    auto current_cgs =
+        MakeColumnGroups({{{100}, {"/pk/file_A.parquet"}},
+                          {{105, 106}, {"/user/file_A.parquet"}}});
+    auto new_cgs = MakeColumnGroups({{{100}, {"/pk/file_A.parquet"}},
+                                     {{105, 106}, {"/user/file_B.parquet"}}});
+
+    SegmentLoadInfo current_info(MakeManifestProto("/manifest/old"), schema_);
+    current_info.SetColumnGroupsForTesting(current_cgs);
+    SegmentLoadInfo new_info(MakeManifestProto("/manifest/new"), schema_);
+    new_info.SetColumnGroupsForTesting(new_cgs);
+
+    auto diff = current_info.ComputeDiff(new_info);
+
+    EXPECT_TRUE(diff.manifest_updated);
+    // User fields (105, 106) at the unchanged index 1 must be replaced
+    // since the underlying parquet file changed.
+    bool saw_user_group = false;
+    for (const auto& [idx, fields] : diff.column_groups_to_replace) {
+        if (idx == 1) {
+            saw_user_group = true;
+            std::set<int64_t> ids;
+            for (auto f : fields) {
+                ids.insert(f.get());
+            }
+            EXPECT_EQ(ids, (std::set<int64_t>{105, 106}));
+        }
+    }
+    EXPECT_TRUE(saw_user_group);
+    // PK group (index 0) had identical files; no replace entry for it.
+    for (const auto& [idx, fields] : diff.column_groups_to_replace) {
+        EXPECT_NE(idx, 0);
+    }
+    EXPECT_TRUE(diff.column_groups_to_load.empty());
+}
+
+TEST_F(SegmentLoadInfoTest,
+       ComputeDiffColumnGroupSameIndexIdenticalFilesNoReplace) {
+    auto cgs = MakeColumnGroups(
+        {{{100}, {"/pk/file.parquet"}}, {{105, 106}, {"/user/file.parquet"}}});
+
+    SegmentLoadInfo current_info(MakeManifestProto("/manifest/v1"), schema_);
+    current_info.SetColumnGroupsForTesting(cgs);
+    SegmentLoadInfo new_info(MakeManifestProto("/manifest/v1"), schema_);
+    new_info.SetColumnGroupsForTesting(cgs);
+
+    auto diff = current_info.ComputeDiff(new_info);
+
+    EXPECT_FALSE(diff.manifest_updated);
+    EXPECT_TRUE(diff.column_groups_to_load.empty());
+    EXPECT_TRUE(diff.column_groups_to_replace.empty());
+    EXPECT_TRUE(diff.column_groups_to_lazyload.empty());
+    EXPECT_TRUE(diff.column_groups_to_lazyreplace.empty());
+}
+
+TEST_F(SegmentLoadInfoTest,
+       ComputeDiffColumnGroupSameIndexDifferentFileCountTriggersReplace) {
+    auto current_cgs = MakeColumnGroups(
+        {{{100}, {"/pk/file.parquet"}}, {{105, 106}, {"/user/a.parquet"}}});
+    auto new_cgs = MakeColumnGroups(
+        {{{100}, {"/pk/file.parquet"}},
+         {{105, 106}, {"/user/a.parquet", "/user/b.parquet"}}});
+
+    SegmentLoadInfo current_info(MakeManifestProto("/manifest/old"), schema_);
+    current_info.SetColumnGroupsForTesting(current_cgs);
+    SegmentLoadInfo new_info(MakeManifestProto("/manifest/new"), schema_);
+    new_info.SetColumnGroupsForTesting(new_cgs);
+
+    auto diff = current_info.ComputeDiff(new_info);
+
+    bool saw_user_group = false;
+    for (const auto& [idx, fields] : diff.column_groups_to_replace) {
+        if (idx == 1) {
+            saw_user_group = true;
+            std::set<int64_t> ids;
+            for (auto f : fields) {
+                ids.insert(f.get());
+            }
+            EXPECT_EQ(ids, (std::set<int64_t>{105, 106}));
+        }
+    }
+    EXPECT_TRUE(saw_user_group);
+}
+
+TEST_F(SegmentLoadInfoTest,
+       ComputeDiffColumnGroupMovedFieldNotDoubleEmittedWithFilesChanged) {
+    // Current: field 106 lives at column-group index 0 (alongside 105).
+    // New: field 106 moves to a new column-group index 2, and the files
+    //      at index 0 also differ. 106 must appear exactly once in the
+    //      diff — as a "moved" entry under group 2, not also under 0.
+    auto current_cgs =
+        MakeColumnGroups({{{100}, {"/pk/file.parquet"}},
+                          {{105, 106}, {"/user/file_A.parquet"}}});
+    auto new_cgs = MakeColumnGroups({{{100}, {"/pk/file.parquet"}},
+                                     {{105}, {"/user/file_B.parquet"}},
+                                     {{106}, {"/moved/file.parquet"}}});
+
+    SegmentLoadInfo current_info(MakeManifestProto("/manifest/old"), schema_);
+    current_info.SetColumnGroupsForTesting(current_cgs);
+    SegmentLoadInfo new_info(MakeManifestProto("/manifest/new"), schema_);
+    new_info.SetColumnGroupsForTesting(new_cgs);
+
+    auto diff = current_info.ComputeDiff(new_info);
+
+    int emissions_for_106 = 0;
+    for (const auto& [idx, fields] : diff.column_groups_to_replace) {
+        for (auto f : fields) {
+            if (f.get() == 106) {
+                emissions_for_106++;
+            }
+        }
+    }
+    for (const auto& [idx, fields] : diff.column_groups_to_lazyreplace) {
+        for (auto f : fields) {
+            if (f.get() == 106) {
+                emissions_for_106++;
+            }
+        }
+    }
+    for (const auto& [idx, fields] : diff.column_groups_to_load) {
+        for (auto f : fields) {
+            if (f.get() == 106) {
+                emissions_for_106++;
+            }
+        }
+    }
+    EXPECT_EQ(emissions_for_106, 1);
+}
+
+TEST_F(SegmentLoadInfoTest,
+       ComputeDiffColumnGroupSamePathDifferentRowRangeTriggersReplace) {
+    // Same file path on both sides, but the row range (start_index /
+    // end_index) differs — e.g. compaction re-slices a packed file.
+    // path-only comparison would miss this and leave stale cache.
+    auto make_cgs = [](int64_t start, int64_t end) {
+        auto cgs = std::make_shared<milvus_storage::api::ColumnGroups>();
+        auto pk_cg = std::make_shared<milvus_storage::api::ColumnGroup>();
+        pk_cg->format = "parquet";
+        pk_cg->columns.push_back("100");
+        milvus_storage::api::ColumnGroupFile pk_file;
+        pk_file.path = "/pk/file.parquet";
+        pk_file.start_index = 0;
+        pk_file.end_index = 0;
+        pk_cg->files.push_back(std::move(pk_file));
+        cgs->push_back(std::move(pk_cg));
+
+        auto user_cg = std::make_shared<milvus_storage::api::ColumnGroup>();
+        user_cg->format = "parquet";
+        user_cg->columns.push_back("105");
+        user_cg->columns.push_back("106");
+        milvus_storage::api::ColumnGroupFile user_file;
+        user_file.path = "/user/packed.parquet";
+        user_file.start_index = start;
+        user_file.end_index = end;
+        user_cg->files.push_back(std::move(user_file));
+        cgs->push_back(std::move(user_cg));
+        return cgs;
+    };
+
+    auto current_cgs = make_cgs(0, 500);
+    auto new_cgs = make_cgs(500, 1000);
+
+    SegmentLoadInfo current_info(MakeManifestProto("/manifest/old"), schema_);
+    current_info.SetColumnGroupsForTesting(current_cgs);
+    SegmentLoadInfo new_info(MakeManifestProto("/manifest/new"), schema_);
+    new_info.SetColumnGroupsForTesting(new_cgs);
+
+    auto diff = current_info.ComputeDiff(new_info);
+
+    bool saw_user_group = false;
+    for (const auto& [idx, fields] : diff.column_groups_to_replace) {
+        std::set<int64_t> ids;
+        for (auto f : fields) {
+            ids.insert(f.get());
+        }
+        if (ids == std::set<int64_t>{105, 106}) {
+            saw_user_group = true;
+        }
+    }
+    EXPECT_TRUE(saw_user_group);
+    EXPECT_TRUE(diff.column_groups_to_load.empty());
+}


### PR DESCRIPTION
Cherry-pick from master
pr: #49066
Related to #46358

ComputeDiffBinlogs and ComputeDiffColumnGroups in SegmentLoadInfo only compared field-level membership, so a field that stayed under the same group id / column-group index was treated as unchanged even when the underlying files were rewritten (e.g. post-compaction manifests that preserve the column-group layout but point at new parquet files). ApplyLoadDiff gates reader rebuild and column eviction on *_to_replace entries, so the loader silently kept serving stale cached chunks.

Compare the ordered file-path sequence per group and route pre-existing fields into binlogs_to_replace / column_groups_to_replace (respecting the existing eager-vs-lazy policy) when files differ; genuinely new children in a files-changed group still go to binlogs_to_load so the replace path isn't asked to evict a column that was never loaded.

Add SetColumnGroupsForTesting as a narrow hook so unit tests can exercise ComputeDiffColumnGroups without constructing real manifest files, and cover both diff functions for: identical files, different file paths, different file counts, new child under changed files, and non-double-emission for moved fields whose old group's files also changed.

---------