### PR TITLE
test: [cp3.0] Fix 20 nightly e2e cases broken by test code bugs (#48842)

### DIFF
--- a/tests/python_client/common/common_func.py
+++ b/tests/python_client/common/common_func.py
@@ -1700,7 +1700,7 @@ def gen_default_rows_data_all_data_type(nb=ct.default_nb, dim=ct.default_dim, st
         dict = {ct.default_int64_field_name: i,
                 ct.default_int32_field_name: i,
                 ct.default_int16_field_name: i,
-                ct.default_int8_field_name: i,
+                ct.default_int8_field_name: int(np.int8(i)),
                 ct.default_bool_field_name: bool(i),
                 ct.default_float_field_name: i*1.0,
                 ct.default_double_field_name: i * 1.0,

--- a/tests/python_client/milvus_client_v2/test_milvus_client_range_search.py
+++ b/tests/python_client/milvus_client_v2/test_milvus_client_range_search.py
@@ -1248,8 +1248,9 @@ class TestRangeSearchIndependent(TestMilvusClientV2Base):
 
         # 3. range search
         search_vectors = cf.gen_vectors(ct.default_nq, dim)
-        search_params = cf.get_search_params_params(index)
-        search_params["params"].update({"radius": 2, "range_filter": 0.1})
+        params = cf.get_search_params_params(index)
+        params.update({"radius": 2, "range_filter": 0.1})
+        search_params = {"params": params}
         self.search(client, collection_name,
                     data=search_vectors,
                     anns_field=default_search_field,


### PR DESCRIPTION
pr: #48842

Cherry-pick of #48842 to 3.0. Fixes 20 e2e cases reproducing across all 3 deploy modes (distributed-pulsar-mmap, distributed-woodpecker, distributed-woodpecker-service) in 3.0 nightly (daily-ci-trigger build 175, dispatcher 8867).

## Root Causes & Fixes

### A1 — `test_range_search_after_different_index_with_params` (8 cases)

`cf.get_search_params_params(index)` returns the inner params dict (e.g. `{"nprobe": 32}`), not a wrapped `{"params": {...}}`. The call site at `test_milvus_client_range_search.py:1251-1252` wrongly accessed `search_params["params"]`, causing `KeyError: 'params'`.

### A2 — `test_search_after_{none,default}_data_all_field_datatype` (12 cases)

`gen_default_rows_data_all_data_type` at `common/common_func.py:1703` assigned the row index `i` directly to the int8 field. At `i=128` it overflowed `int8 [-128, 127]` and the server rejected insert with `code=1100, message=the 128th element (128) out of range`. Wrapped with `np.int8(i)`.

## Test Plan

- [x] Cherry-pick from 8137ebcea13736d84e64fb31e7e02aa48cece515
- [x] Only test code changes; no Milvus server change
- [ ] 3.0 nightly CI green after merge