### PR TITLE
test: [cp3.0]parallelize go_client testcases via t.Parallel()

### DIFF
--- a/tests/go_client/testcases/add_field_test.go
+++ b/tests/go_client/testcases/add_field_test.go
@@ -17,6 +17,8 @@ import (
 
 // create -> add field -> index -> load -> insert -> query/search
 func TestAddCollectionField(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 	// Test cases for different defaultValue and filter
@@ -76,6 +78,8 @@ func TestAddCollectionField(t *testing.T) {
 
 // parameterized test for add field invalid cases
 func TestAddCollectionFieldInvalid(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -207,6 +211,8 @@ func TestAddCollectionFieldInvalid(t *testing.T) {
 
 // test add field when max field number exceeded
 func TestCollectionAddFieldExceedMaxFieldNumber(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -229,6 +235,8 @@ func TestCollectionAddFieldExceedMaxFieldNumber(t *testing.T) {
 
 // create Inverted index for added field and drop index
 func TestIndexAddedField(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -300,6 +308,8 @@ func TestIndexAddedField(t *testing.T) {
 }
 
 func TestInsertWithAddedField(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 	for _, autoID := range [2]bool{false, true} {
@@ -345,6 +355,8 @@ func TestInsertWithAddedField(t *testing.T) {
 }
 
 func TestUpsertDynamicAddField(t *testing.T) {
+	t.Parallel()
+
 	// enable dynamic field/add field and insert dynamic/added column
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -397,6 +409,8 @@ func TestUpsertDynamicAddField(t *testing.T) {
 
 // query with dynamic field same as added field
 func TestQueryWithDynamicAddedField(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -447,6 +461,8 @@ func TestQueryWithDynamicAddedField(t *testing.T) {
 
 // search with dynamic field same as added field
 func TestSearchWithDynamicAddedField(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -501,6 +517,8 @@ func TestSearchWithDynamicAddedField(t *testing.T) {
 
 // test delete with added field
 func TestDeleteWithAddedField(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 

--- a/tests/go_client/testcases/client_test.go
+++ b/tests/go_client/testcases/client_test.go
@@ -13,6 +13,8 @@ import (
 
 // test connect and close, connect again
 func TestConnectClose(t *testing.T) {
+	t.Parallel()
+
 	// connect
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc, errConnect := base.NewMilvusClient(ctx, hp.GetDefaultClientConfig())
@@ -50,6 +52,8 @@ func genInvalidClientConfig() []client.ClientConfig {
 
 // test connect with timeout and invalid addr
 func TestConnectInvalidAddr(t *testing.T) {
+	t.Parallel()
+
 	// connect
 	ctx := hp.CreateContext(t, time.Second*5)
 	for _, invalidCfg := range genInvalidClientConfig() {
@@ -61,6 +65,8 @@ func TestConnectInvalidAddr(t *testing.T) {
 
 // test connect repeatedly
 func TestConnectRepeat(t *testing.T) {
+	t.Parallel()
+
 	// connect
 	ctx := hp.CreateContext(t, time.Second*10)
 
@@ -77,6 +83,8 @@ func TestConnectRepeat(t *testing.T) {
 
 // test close repeatedly
 func TestCloseRepeat(t *testing.T) {
+	t.Parallel()
+
 	// connect
 	ctx := hp.CreateContext(t, time.Second*10)
 	mc, errConnect2 := base.NewMilvusClient(ctx, hp.GetDefaultClientConfig())

--- a/tests/go_client/testcases/collection_test.go
+++ b/tests/go_client/testcases/collection_test.go
@@ -48,6 +48,8 @@ func TestCreateCollection(t *testing.T) {
 
 // fast: create -> index -> load
 func TestCreateCollectionFast(t *testing.T) {
+	t.Parallel()
+
 	// test collection property mmap
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -80,6 +82,8 @@ func TestCreateCollectionFast(t *testing.T) {
 }
 
 func TestCreateCollectionFastOption(t *testing.T) {
+	t.Parallel()
+
 	// test create collection fast with option: ConsistencyLevel, varcharPk, indexOption
 	// Collection AutoID not works !!!, please set it on the field side~
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
@@ -121,6 +125,8 @@ func TestCreateCollectionFastOption(t *testing.T) {
 }
 
 func TestCreateAutoIdCollectionField(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -152,6 +158,8 @@ func TestCreateAutoIdCollectionField(t *testing.T) {
 
 // create collection and specify shard num
 func TestCreateCollectionShards(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -179,6 +187,8 @@ func TestCreateCollectionShards(t *testing.T) {
 
 // test create auto collection with schema
 func TestCreateAutoIdCollectionSchema(t *testing.T) {
+	t.Parallel()
+
 	t.Skip("waiting for valid AutoId from schema params")
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -211,6 +221,8 @@ func TestCreateAutoIdCollectionSchema(t *testing.T) {
 
 // test create auto collection with collection option
 func TestCreateAutoIdCollection(t *testing.T) {
+	t.Parallel()
+
 	t.Skip("https://github.com/milvus-io/milvus/issues/39523")
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -242,6 +254,8 @@ func TestCreateAutoIdCollection(t *testing.T) {
 }
 
 func TestCreateJsonCollection(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -265,6 +279,8 @@ func TestCreateJsonCollection(t *testing.T) {
 }
 
 func TestCreateArrayCollections(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -297,6 +313,8 @@ func TestCreateArrayCollections(t *testing.T) {
 
 // test create collection with partition key not supported field type
 func TestCreateCollectionPartitionKey(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout*2)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -359,6 +377,8 @@ func TestCreateCollectionPartitionKeyNumPartition(t *testing.T) {
 }
 
 func TestCreateCollectionDynamicSchema(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -393,6 +413,8 @@ func TestCreateCollectionDynamicSchema(t *testing.T) {
 }
 
 func TestCreateCollectionDynamic(t *testing.T) {
+	t.Parallel()
+
 	t.Skip("waiting for dynamicField alignment")
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -429,6 +451,8 @@ func TestCreateCollectionDynamic(t *testing.T) {
 }
 
 func TestCreateCollectionAllFields(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -455,6 +479,8 @@ func TestCreateCollectionAllFields(t *testing.T) {
 }
 
 func TestCreateCollectionSparseVector(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -584,6 +610,8 @@ func TestCreateCollectionWithInvalidCollectionName(t *testing.T) {
 
 // create collection missing pk field or vector field
 func TestCreateCollectionInvalidFields(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -620,6 +648,8 @@ func TestCreateCollectionInvalidFields(t *testing.T) {
 
 // create autoID or not collection with non-int64 and non-varchar field
 func TestCreateCollectionInvalidAutoPkField(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout*2)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -640,6 +670,8 @@ func TestCreateCollectionInvalidAutoPkField(t *testing.T) {
 
 // test create collection with duplicate field name
 func TestCreateCollectionDuplicateField(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -662,6 +694,8 @@ func TestCreateCollectionDuplicateField(t *testing.T) {
 
 // test create collection with partition key not supported field type
 func TestCreateCollectionInvalidPartitionKeyType(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout*2)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -683,6 +717,8 @@ func TestCreateCollectionInvalidPartitionKeyType(t *testing.T) {
 
 // partition key field cannot be primary field, d can only be one partition key field
 func TestCreateCollectionPartitionKeyPk(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -697,6 +733,8 @@ func TestCreateCollectionPartitionKeyPk(t *testing.T) {
 
 // can only be one partition key field
 func TestCreateCollectionPartitionKeyNum(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -713,6 +751,8 @@ func TestCreateCollectionPartitionKeyNum(t *testing.T) {
 }
 
 func TestPartitionKeyInvalidNumPartition(t *testing.T) {
+	t.Parallel()
+
 	t.Skip("Waiting for num partition")
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -741,6 +781,8 @@ func TestPartitionKeyInvalidNumPartition(t *testing.T) {
 
 // test create collection with multi auto id
 func TestCreateCollectionMultiAutoId(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -756,6 +798,8 @@ func TestCreateCollectionMultiAutoId(t *testing.T) {
 
 // test create collection with different autoId between pk field and schema
 func TestCreateCollectionInconsistentAutoId(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -789,6 +833,8 @@ func TestCreateCollectionInconsistentAutoId(t *testing.T) {
 
 // create collection with field or schema description
 func TestCreateCollectionDescription(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -891,6 +937,8 @@ func TestCreateFloatCollectionInvalidDim(t *testing.T) {
 }
 
 func TestCreateVectorWithoutDim(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 	collName := common.GenRandomString(prefix, 6)
@@ -907,6 +955,8 @@ func TestCreateVectorWithoutDim(t *testing.T) {
 
 // specify dim for sparse vector -> error
 func TestCreateCollectionSparseVectorWithDim(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 	collName := common.GenRandomString(prefix, 6)
@@ -922,6 +972,8 @@ func TestCreateCollectionSparseVectorWithDim(t *testing.T) {
 }
 
 func TestCreateArrayFieldInvalidCapacity(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -946,6 +998,8 @@ func TestCreateArrayFieldInvalidCapacity(t *testing.T) {
 
 // test create collection varchar array with invalid max length
 func TestCreateVarcharArrayInvalidLength(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -969,6 +1023,8 @@ func TestCreateVarcharArrayInvalidLength(t *testing.T) {
 
 // test create collection varchar array with invalid max length
 func TestCreateVarcharInvalidLength(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -990,6 +1046,8 @@ func TestCreateVarcharInvalidLength(t *testing.T) {
 }
 
 func TestCreateArrayNotSupportedFieldType(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -1007,6 +1065,8 @@ func TestCreateArrayNotSupportedFieldType(t *testing.T) {
 
 // the num of vector fields > default limit=4
 func TestCreateMultiVectorExceed(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -1023,6 +1083,8 @@ func TestCreateMultiVectorExceed(t *testing.T) {
 
 // func TestCreateCollection(t *testing.T) {}
 func TestCreateCollectionInvalidShards(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -1038,6 +1100,8 @@ func TestCreateCollectionInvalidShards(t *testing.T) {
 }
 
 func TestCreateCollectionInvalid(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -1062,6 +1126,8 @@ func TestCreateCollectionInvalid(t *testing.T) {
 
 // test rename collection
 func TestRenameCollection(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -1098,6 +1164,8 @@ func TestRenameCollection(t *testing.T) {
 
 // There are collections with the same name in different db. Rename one of them.
 func TestRenameCollectionDb(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -1136,6 +1204,8 @@ func TestRenameCollectionDb(t *testing.T) {
 }
 
 func TestRenameCollectionInvalidName(t *testing.T) {
+	t.Parallel()
+
 	// connect
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout*2)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -1160,6 +1230,8 @@ func TestRenameCollectionInvalidName(t *testing.T) {
 }
 
 func TestRenameCollectionAdvanced(t *testing.T) {
+	t.Parallel()
+
 	// connect
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout*2)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -1191,6 +1263,8 @@ func TestRenameCollectionAdvanced(t *testing.T) {
 
 // alter collection ttl property
 func TestCollectionPropertyTtl(t *testing.T) {
+	t.Parallel()
+
 	// test collection property ttl
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -1224,6 +1298,8 @@ func TestCollectionPropertyTtl(t *testing.T) {
 
 // create collection with property -> alter property -> writing and reading
 func TestCollectionWithPropertyAlterMmap(t *testing.T) {
+	t.Parallel()
+
 	// test collection property mmap
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -1253,6 +1329,8 @@ func TestCollectionWithPropertyAlterMmap(t *testing.T) {
 }
 
 func TestCollectionPropertyMmap(t *testing.T) {
+	t.Parallel()
+
 	// test collection property mmap
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -1288,6 +1366,8 @@ func TestCollectionPropertyMmap(t *testing.T) {
 }
 
 func TestCollectionFakeProperties(t *testing.T) {
+	t.Parallel()
+
 	// test collection property mmap
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)

--- a/tests/go_client/testcases/delete_test.go
+++ b/tests/go_client/testcases/delete_test.go
@@ -17,6 +17,8 @@ import (
 )
 
 func TestDelete(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -53,6 +55,8 @@ func TestDelete(t *testing.T) {
 
 // test delete with string pks
 func TestDeleteVarcharPks(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -88,6 +92,8 @@ func TestDeleteVarcharPks(t *testing.T) {
 
 // test delete from empty collection
 func TestDeleteEmptyCollection(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -113,6 +119,8 @@ func TestDeleteEmptyCollection(t *testing.T) {
 
 // test delete from an not exist collection or partition
 func TestDeleteNotExistName(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -131,6 +139,8 @@ func TestDeleteNotExistName(t *testing.T) {
 // test delete with complex expr without loading
 // delete without loading support: pk ids
 func TestDeleteComplexExprWithoutLoad(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -167,6 +177,8 @@ func TestDeleteComplexExprWithoutLoad(t *testing.T) {
 
 // test delete with nil ids
 func TestDeleteEmptyIds(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -194,6 +206,8 @@ func TestDeleteEmptyIds(t *testing.T) {
 
 // test delete with string pks
 func TestDeleteVarcharEmptyIds(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -230,6 +244,8 @@ func TestDeleteVarcharEmptyIds(t *testing.T) {
 
 // test delete with invalid ids
 func TestDeleteInvalidIds(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -249,6 +265,8 @@ func TestDeleteInvalidIds(t *testing.T) {
 
 // test delete with non-pk ids
 func TestDeleteWithIds(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -295,6 +313,8 @@ func TestDeleteWithIds(t *testing.T) {
 
 // test delete with default partition name params
 func TestDeleteDefaultPartitionName(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -333,6 +353,8 @@ func TestDeleteDefaultPartitionName(t *testing.T) {
 
 // test delete with empty partition "": actually delete from all partitions
 func TestDeleteEmptyPartitionName(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -371,6 +393,8 @@ func TestDeleteEmptyPartitionName(t *testing.T) {
 
 // test delete with partition name
 func TestDeletePartitionName(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -435,6 +459,8 @@ func TestDeletePartitionName(t *testing.T) {
 
 // test delete ids field not pk int64
 func TestDeleteComplexExpr(t *testing.T) {
+	t.Parallel()
+
 	type exprCount struct {
 		expr  string
 		count int
@@ -507,6 +533,8 @@ func TestDeleteComplexExpr(t *testing.T) {
 
 // test delete json expr
 func TestDeleteComplexExprJson(t *testing.T) {
+	t.Parallel()
+
 	type exprCount struct {
 		expr  string
 		count int
@@ -569,6 +597,8 @@ func TestDeleteComplexExprJson(t *testing.T) {
 }
 
 func TestDeleteInvalidExpr(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout*2)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 

--- a/tests/go_client/testcases/external_table_benchmark_test.go
+++ b/tests/go_client/testcases/external_table_benchmark_test.go
@@ -672,6 +672,8 @@ func (env *benchEnv) makeRandomQueryVec() []float32 {
 // ============================================================================
 
 func TestBenchmarkExternalCreateCollection(t *testing.T) {
+	t.Parallel()
+
 	forEachScaleConfig(t, func(t *testing.T, cfg benchConfig) {
 		ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 		mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -720,6 +722,8 @@ func TestBenchmarkExternalCreateCollection(t *testing.T) {
 // ============================================================================
 
 func TestBenchmarkExternalRefresh(t *testing.T) {
+	t.Parallel()
+
 	forEachScale(t, func(t *testing.T, env *benchEnv) {
 		testBenchmarkExternalRefresh(t, env)
 	})
@@ -775,6 +779,8 @@ func testBenchmarkExternalRefresh(t *testing.T, env *benchEnv) {
 // ============================================================================
 
 func TestBenchmarkExternalIncrementalRefresh(t *testing.T) {
+	t.Parallel()
+
 	forEachScale(t, benchIncrementalRefresh)
 }
 
@@ -849,6 +855,8 @@ func benchIncrementalRefresh(t *testing.T, env *benchEnv) {
 // ============================================================================
 
 func TestBenchmarkExternalIndexBuilding(t *testing.T) {
+	t.Parallel()
+
 	forEachScale(t, benchIndexBuilding)
 }
 
@@ -925,6 +933,8 @@ func benchIndexBuilding(t *testing.T, env *benchEnv) {
 // ============================================================================
 
 func TestBenchmarkExternalLoadCollection(t *testing.T) {
+	t.Parallel()
+
 	forEachScale(t, benchLoadCollection)
 }
 
@@ -987,6 +997,8 @@ func benchLoadCollection(t *testing.T, env *benchEnv) {
 // ============================================================================
 
 func TestBenchmarkExternalCountQuery(t *testing.T) {
+	t.Parallel()
+
 	forEachScale(t, benchCountQuery)
 }
 
@@ -1008,6 +1020,8 @@ func benchCountQuery(t *testing.T, env *benchEnv) {
 // ============================================================================
 
 func TestBenchmarkExternalScalarFilter(t *testing.T) {
+	t.Parallel()
+
 	forEachScale(t, benchScalarFilter)
 }
 
@@ -1068,6 +1082,8 @@ func benchScalarFilter(t *testing.T, env *benchEnv) {
 // ============================================================================
 
 func TestBenchmarkExternalVectorSearch(t *testing.T) {
+	t.Parallel()
+
 	forEachScale(t, benchVectorSearch)
 }
 
@@ -1096,6 +1112,8 @@ func benchVectorSearch(t *testing.T, env *benchEnv) {
 // ============================================================================
 
 func TestBenchmarkExternalHybridSearch(t *testing.T) {
+	t.Parallel()
+
 	forEachScale(t, benchHybridSearch)
 }
 
@@ -1141,6 +1159,8 @@ func benchHybridSearch(t *testing.T, env *benchEnv) {
 // ============================================================================
 
 func TestBenchmarkExternalMultiVectorSearch(t *testing.T) {
+	t.Parallel()
+
 	forEachScale(t, benchMultiVectorSearch)
 }
 
@@ -1173,6 +1193,8 @@ func benchMultiVectorSearch(t *testing.T, env *benchEnv) {
 // ============================================================================
 
 func TestBenchmarkExternalPagination(t *testing.T) {
+	t.Parallel()
+
 	forEachScale(t, benchPagination)
 }
 
@@ -1205,6 +1227,8 @@ func benchPagination(t *testing.T, env *benchEnv) {
 // ============================================================================
 
 func TestBenchmarkExternalOutputFields(t *testing.T) {
+	t.Parallel()
+
 	forEachScale(t, benchOutputFields)
 }
 
@@ -1255,6 +1279,8 @@ func benchOutputFields(t *testing.T, env *benchEnv) {
 // ============================================================================
 
 func TestBenchmarkExternalVsRegularQuery(t *testing.T) {
+	t.Parallel()
+
 	forEachScale(t, benchVsRegularQuery)
 }
 
@@ -1402,6 +1428,8 @@ func benchVsRegularQuery(t *testing.T, env *benchEnv) {
 // ============================================================================
 
 func TestBenchmarkExternalManyFiles(t *testing.T) {
+	t.Parallel()
+
 	forEachScale(t, benchManyFiles)
 }
 
@@ -1460,6 +1488,8 @@ func benchManyFiles(t *testing.T, env *benchEnv) {
 // ============================================================================
 
 func TestBenchmarkExternalLargeSingleFile(t *testing.T) {
+	t.Parallel()
+
 	forEachScale(t, benchLargeSingleFile)
 }
 
@@ -1520,6 +1550,8 @@ func benchLargeSingleFile(t *testing.T, env *benchEnv) {
 // ============================================================================
 
 func TestBenchmarkExternalConcurrentQuery(t *testing.T) {
+	t.Parallel()
+
 	forEachScale(t, benchConcurrentQuery)
 }
 
@@ -1593,6 +1625,8 @@ func benchConcurrentQuery(t *testing.T, env *benchEnv) {
 // ============================================================================
 
 func TestBenchmarkExternalIdempotentRefresh(t *testing.T) {
+	t.Parallel()
+
 	forEachScale(t, benchIdempotentRefresh)
 }
 
@@ -1667,6 +1701,8 @@ func benchIdempotentRefresh(t *testing.T, env *benchEnv) {
 // ============================================================================
 
 func TestBenchmarkExternalMultiDataTypes(t *testing.T) {
+	t.Parallel()
+
 	forEachScale(t, benchMultiDataTypes)
 }
 
@@ -1796,5 +1832,7 @@ func benchMultiDataTypes(t *testing.T, env *benchEnv) {
 // ============================================================================
 
 func TestBenchmarkExternalZZReport(t *testing.T) {
+	t.Parallel()
+
 	globalReport.writeMarkdownReport(t)
 }

--- a/tests/go_client/testcases/external_table_refresh_test.go
+++ b/tests/go_client/testcases/external_table_refresh_test.go
@@ -334,6 +334,8 @@ func indexAndLoadCollectionWithScalarAndVector(ctx context.Context, t *testing.T
 //  4. Wait for refresh to complete
 //  5. Verify the generated segment count and total row count
 func TestRefreshExternalCollectionAndVerifySegments(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -503,6 +505,8 @@ verify:
 //  7. Query with filter and output fields
 //  8. Search with vector
 func TestExternalCollectionLoadAndQuery(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -752,6 +756,8 @@ indexAndLoad:
 //  2. Remove data1, add data2 (ids 2000-2299) → 800 rows
 //  3. Verify: data0 intact, data1 gone, data2 present
 func TestExternalCollectionIncrementalRefresh(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*600) // 10 min for two refresh+load cycles
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -912,6 +918,8 @@ func TestExternalCollectionIncrementalRefresh(t *testing.T) {
 // TestExternalCollectionMultipleDataTypes tests external collections with various data types:
 // Bool, Int8, Int16, Int32, Int64, Float, Double, VarChar, FloatVector
 func TestExternalCollectionMultipleDataTypes(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -1225,6 +1233,8 @@ func findPython3ForVortex() (string, error) {
 //  6. Query with filter
 //  7. Search with vector
 func TestExternalCollectionLanceFormat(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*600) // 10 min for lance operations
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -1461,6 +1471,8 @@ func generateVortexDataOnMinIO(t *testing.T, pythonBin, outputPath string, numRo
 //  6. Query with filter
 //  7. Search with vector
 func TestExternalCollectionVortexFormat(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*600)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -1676,6 +1688,8 @@ func TestExternalCollectionVortexFormat(t *testing.T) {
 // types regardless of the output schema.  Vortex and Lance require schema-level
 // changes to support float32 list vectors (tracked separately).
 func TestExternalCollectionFloat32ListVector(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*600)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 

--- a/tests/go_client/testcases/external_table_test.go
+++ b/tests/go_client/testcases/external_table_test.go
@@ -14,6 +14,8 @@ import (
 
 // TestCreateExternalCollection tests creating an external collection
 func TestCreateExternalCollection(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -86,6 +88,8 @@ func TestCreateExternalCollection(t *testing.T) {
 // TestCreateExternalCollectionMissingExternalField tests that creating external collection
 // without external_field mapping fails
 func TestCreateExternalCollectionMissingExternalField(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -119,6 +123,8 @@ func TestCreateExternalCollectionMissingExternalField(t *testing.T) {
 // TestCreateExternalCollectionWithPrimaryKey tests that creating external collection
 // with primary key field fails
 func TestCreateExternalCollectionWithPrimaryKey(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -152,6 +158,8 @@ func TestCreateExternalCollectionWithPrimaryKey(t *testing.T) {
 // TestCreateExternalCollectionWithDynamicField tests that creating external collection
 // with dynamic field enabled fails
 func TestCreateExternalCollectionWithDynamicField(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -186,6 +194,8 @@ func TestCreateExternalCollectionWithDynamicField(t *testing.T) {
 // TestCreateExternalCollectionWithAutoID tests that creating external collection
 // with auto ID field fails
 func TestCreateExternalCollectionWithAutoID(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -219,6 +229,8 @@ func TestCreateExternalCollectionWithAutoID(t *testing.T) {
 // TestCreateExternalCollectionWithPartitionKey tests that creating external collection
 // with partition key field fails
 func TestCreateExternalCollectionWithPartitionKey(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -253,6 +265,8 @@ func TestCreateExternalCollectionWithPartitionKey(t *testing.T) {
 // TestCreateExternalCollectionMultipleVectorFields tests creating external collection
 // with multiple vector fields
 func TestCreateExternalCollectionMultipleVectorFields(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 

--- a/tests/go_client/testcases/full_text_search_test.go
+++ b/tests/go_client/testcases/full_text_search_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestFullTextSearchDefault(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -45,6 +47,8 @@ func TestFullTextSearchDefault(t *testing.T) {
 
 // TestSearchFullTextBase tests basic full text search functionality with different languages
 func TestSearchFullTextWithDiffLang(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -105,6 +109,8 @@ func TestSearchFullTextWithDiffLang(t *testing.T) {
 
 // TestSearchFullTextWithDynamicField tests full text search with dynamic field enabled
 func TestSearchFullTextWithDynamicField(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 	// Test cases for different languages and analyzers
@@ -164,6 +170,8 @@ func TestSearchFullTextWithDynamicField(t *testing.T) {
 
 // TestSearchFullTextWithPartitionKey tests full text search with partition key
 func TestSearchFullTextWithPartitionKey(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -235,6 +243,8 @@ func TestSearchFullTextWithPartitionKey(t *testing.T) {
 
 // TestSearchFullTextWithEmptyData tests full text search with empty data
 func TestSearchFullTextWithEmptyData(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -298,6 +308,8 @@ func TestSearchFullTextWithEmptyData(t *testing.T) {
 
 // test full-text-search with default text, output text
 func TestFullTextSearchDefaultValue(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -343,6 +355,8 @@ func TestFullTextSearchDefaultValue(t *testing.T) {
 
 // TestTextMatchMinimumShouldMatch verifies text_match(..., minimum_should_match=N)
 func TestTextMatchMinimumShouldMatch(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 

--- a/tests/go_client/testcases/geometry_test.go
+++ b/tests/go_client/testcases/geometry_test.go
@@ -373,6 +373,8 @@ func validateSpatialResults(t *testing.T, actualIDs []int64, expectedIDs []int64
 
 // 1. Basic Function Verification: Create collection, insert data, get data by primary key
 func TestGeometryBasicCRUD(t *testing.T) {
+	t.Parallel()
+
 	// Use unified test setup function
 	setup := setupGeometryTest(t, true, false, nil)
 	defer func() {}()
@@ -395,6 +397,8 @@ func TestGeometryBasicCRUD(t *testing.T) {
 
 // 2. Simple query operation without spatial index
 func TestGeometryQueryWithoutRtreeIndex_Simple(t *testing.T) {
+	t.Parallel()
+
 	// Use unified setup, without creating spatial index
 	setup := setupGeometryTest(t, true, false, nil)
 
@@ -425,6 +429,8 @@ func TestGeometryQueryWithoutRtreeIndex_Simple(t *testing.T) {
 
 // 3. Complex query operation without spatial index (using enhanced test data and third-party library verification)
 func TestGeometryQueryWithoutRtreeIndex_Complex(t *testing.T) {
+	t.Parallel()
+
 	// Use enhanced test data
 	testData := createEnhancedSpatialTestData()
 	setup := setupGeometryTest(t, true, false, testData)
@@ -526,6 +532,8 @@ func TestGeometryQueryWithoutRtreeIndex_Complex(t *testing.T) {
 
 // 4. Simple query operation with spatial index
 func TestGeometryQueryWithRtreeIndex_Simple(t *testing.T) {
+	t.Parallel()
+
 	// Use unified setup, create spatial index
 	setup := setupGeometryTest(t, true, true, nil)
 
@@ -547,6 +555,8 @@ func TestGeometryQueryWithRtreeIndex_Simple(t *testing.T) {
 
 // 5. Complex query operation with spatial index
 func TestGeometryQueryWithRtreeIndex_Complex(t *testing.T) {
+	t.Parallel()
+
 	// Use enhanced test data and spatial index
 	testData := createEnhancedSpatialTestData()
 	setup := setupGeometryTest(t, true, true, testData)
@@ -603,6 +613,8 @@ func TestGeometryQueryWithRtreeIndex_Complex(t *testing.T) {
 
 // 6. Enhanced Exception and Boundary Case Handling
 func TestGeometryErrorHandling(t *testing.T) {
+	t.Parallel()
+
 	// Use enhanced test data
 	testData := createEnhancedSpatialTestData()
 	setup := setupGeometryTest(t, true, false, testData)
@@ -766,6 +778,8 @@ func TestGeometryErrorHandling(t *testing.T) {
 
 // Comprehensive Test: Verify complete Geometry workflow
 func TestGeometryCompleteWorkflow(t *testing.T) {
+	t.Parallel()
+
 	// Use enhanced test data and full index configuration
 	testData := createEnhancedSpatialTestData()
 	setup := setupGeometryTest(t, true, true, testData)

--- a/tests/go_client/testcases/groupby_search_test.go
+++ b/tests/go_client/testcases/groupby_search_test.go
@@ -465,6 +465,8 @@ func TestSearchGroupByUnsupportedIndex(t *testing.T) {
 
 // FLOAT, DOUBLE, JSON, ARRAY
 func TestSearchGroupByUnsupportedDataType(t *testing.T) {
+	t.Parallel()
+
 	idxHnsw := index.NewHNSWIndex(entity.L2, 8, 96)
 	mc, ctx, collName := prepareDataForGroupBySearch(t, 1, 1000, idxHnsw, true)
 
@@ -481,11 +483,15 @@ func TestSearchGroupByUnsupportedDataType(t *testing.T) {
 
 // groupBy + iterator -> not supported
 func TestSearchGroupByIterator(t *testing.T) {
+	t.Parallel()
+
 	// TODO: sdk support
 }
 
 // groupBy + range search -> not supported
 func TestSearchGroupByRangeSearch(t *testing.T) {
+	t.Parallel()
+
 	t.Skipf("https://github.com/milvus-io/milvus/issues/38846")
 	idxHnsw := index.NewHNSWIndex(entity.COSINE, 8, 96)
 	mc, ctx, collName := prepareDataForGroupBySearch(t, 1, 1000, idxHnsw, true)
@@ -501,5 +507,7 @@ func TestSearchGroupByRangeSearch(t *testing.T) {
 
 // groupBy + advanced search
 func TestSearchGroupByHybridSearch(t *testing.T) {
+	t.Parallel()
+
 	t.Skipf("Waiting for HybridSearch implemention")
 }

--- a/tests/go_client/testcases/hybrid_search_test.go
+++ b/tests/go_client/testcases/hybrid_search_test.go
@@ -98,6 +98,8 @@ func TestHybridSearchTemplateParam(t *testing.T) {
 
 // hybrid search default -> verify success
 func TestHybridSearchMultiVectorsDefault(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -240,6 +242,8 @@ func TestHybridSearchInvalidParams(t *testing.T) {
 // vector type mismatch: vectors: float32, queryVec: binary
 // vector dim mismatch
 func TestHybridSearchInvalidVectors(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -262,6 +266,8 @@ func TestHybridSearchInvalidVectors(t *testing.T) {
 
 // hybrid search Pagination -> verify success
 func TestHybridSearchMultiVectorsPagination(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -397,6 +403,8 @@ func TestHybridSearchSparseVector(t *testing.T) {
 }
 
 func TestHybridSearchGroupBy(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 

--- a/tests/go_client/testcases/index_test.go
+++ b/tests/go_client/testcases/index_test.go
@@ -28,6 +28,8 @@ ScalarAutoIndex: {"int_*": "HYBRID","varchar": "HYBRID","bool": "BITMAP", "float
 */
 
 func TestIndexVectorDefault(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout*2)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -60,6 +62,8 @@ func TestIndexVectorDefault(t *testing.T) {
 }
 
 func TestIndexVectorIP(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout*2)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -93,6 +97,8 @@ func TestIndexVectorIP(t *testing.T) {
 }
 
 func TestIndexVectorCosine(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout*2)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -126,6 +132,8 @@ func TestIndexVectorCosine(t *testing.T) {
 }
 
 func TestIndexAutoFloatVector(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -162,6 +170,8 @@ func TestIndexAutoFloatVector(t *testing.T) {
 }
 
 func TestIndexAutoBinaryVector(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -202,6 +212,8 @@ func TestIndexAutoBinaryVector(t *testing.T) {
 }
 
 func TestIndexAutoSparseVector(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -239,6 +251,8 @@ func TestIndexAutoSparseVector(t *testing.T) {
 
 // test create auto index on all vector and scalar index
 func TestCreateAutoIndexAllFields(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -288,6 +302,8 @@ func TestCreateAutoIndexAllFields(t *testing.T) {
 }
 
 func TestIndexBinaryFlat(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -319,6 +335,8 @@ func TestIndexBinaryFlat(t *testing.T) {
 }
 
 func TestIndexBinaryIvfFlat(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -351,6 +369,8 @@ func TestIndexBinaryIvfFlat(t *testing.T) {
 
 // test create binary index with unsupported metrics type
 func TestCreateBinaryIndexNotSupportedMetricType(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -395,6 +415,8 @@ func TestCreateBinaryIndexNotSupportedMetricType(t *testing.T) {
 }
 
 func TestIndexInvalidMetricType(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -416,6 +438,8 @@ func TestIndexInvalidMetricType(t *testing.T) {
 
 // Trie scalar Trie index only supported on varchar
 func TestCreateTrieScalarIndex(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -452,6 +476,8 @@ func TestCreateTrieScalarIndex(t *testing.T) {
 
 // Sort scalar index only supported on numeric field
 func TestCreateSortedScalarIndex(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -502,6 +528,8 @@ func TestCreateSortedScalarIndex(t *testing.T) {
 
 // create Inverted index for all scalar fields
 func TestCreateInvertedScalarIndex(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -545,6 +573,8 @@ func TestCreateInvertedScalarIndex(t *testing.T) {
 
 // test create index on vector field -> error
 func TestCreateScalarIndexVectorField(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -569,6 +599,8 @@ func TestCreateScalarIndexVectorField(t *testing.T) {
 
 // test create scalar index with vector field name
 func TestCreateIndexWithOtherFieldName(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -601,6 +633,8 @@ func TestCreateIndexWithOtherFieldName(t *testing.T) {
 
 // create all scalar index on json field -> error
 func TestCreateIndexJsonField(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -634,6 +668,8 @@ func TestCreateIndexJsonField(t *testing.T) {
 
 // array field on supported array field
 func TestCreateUnsupportedIndexArrayField(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -672,6 +708,8 @@ func TestCreateUnsupportedIndexArrayField(t *testing.T) {
 
 // create inverted index on array field
 func TestCreateInvertedIndexArrayField(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -710,6 +748,8 @@ func TestCreateInvertedIndexArrayField(t *testing.T) {
 
 // test create index without specify index name: default index name is field name
 func TestCreateIndexWithoutName(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -737,6 +777,8 @@ func TestCreateIndexWithoutName(t *testing.T) {
 
 // test create index on same field twice
 func TestCreateIndexDup(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -765,6 +807,8 @@ func TestCreateIndexDup(t *testing.T) {
 }
 
 func TestCreateIndexSparseVectorGeneric(t *testing.T) {
+	t.Parallel()
+
 	idxInverted := index.NewGenericIndex(common.DefaultSparseVecFieldName, map[string]string{"drop_ratio_build": "0.2", index.MetricTypeKey: "IP", index.IndexTypeKey: "SPARSE_INVERTED_INDEX"})
 	idxWand := index.NewGenericIndex(common.DefaultSparseVecFieldName, map[string]string{"drop_ratio_build": "0.3", index.MetricTypeKey: "IP", index.IndexTypeKey: "SPARSE_WAND"})
 
@@ -793,6 +837,8 @@ func TestCreateIndexSparseVectorGeneric(t *testing.T) {
 }
 
 func TestCreateIndexSparseVector(t *testing.T) {
+	t.Parallel()
+
 	idxInverted1 := index.NewSparseInvertedIndex(entity.IP, 0.2)
 	idxWand1 := index.NewSparseWANDIndex(entity.IP, 0.3)
 	for _, idx := range []index.Index{idxInverted1, idxWand1} {
@@ -819,6 +865,8 @@ func TestCreateIndexSparseVector(t *testing.T) {
 }
 
 func TestCreateSparseIndexInvalidParams(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -855,6 +903,8 @@ func TestCreateSparseIndexInvalidParams(t *testing.T) {
 
 // create sparse unsupported index: other vector index and scalar index and auto index
 func TestCreateSparseUnsupportedIndex(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -885,6 +935,8 @@ func TestCreateSparseUnsupportedIndex(t *testing.T) {
 
 // test new index by Generic index
 func TestCreateIndexGeneric(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -912,6 +964,8 @@ func TestCreateIndexGeneric(t *testing.T) {
 
 // test create index with not exist index name and not exist field name
 func TestIndexNotExistName(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -937,6 +991,8 @@ func TestIndexNotExistName(t *testing.T) {
 
 // test create float / binary / sparse vector index on non-vector field
 func TestCreateVectorIndexScalarField(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -972,6 +1028,8 @@ func TestCreateVectorIndexScalarField(t *testing.T) {
 
 // test create index with invalid params
 func TestCreateIndexInvalidParams(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -1028,6 +1086,8 @@ func TestCreateIndexInvalidParams(t *testing.T) {
 
 // test create index with nil index
 func TestCreateIndexNil(t *testing.T) {
+	t.Parallel()
+
 	t.Skip("Issue: https://github.com/milvus-io/milvus-sdk-go/issues/358")
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -1041,6 +1101,8 @@ func TestCreateIndexNil(t *testing.T) {
 
 // test create index async true
 func TestCreateIndexAsync(t *testing.T) {
+	t.Parallel()
+
 	t.Log("wait GetIndexState")
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -1064,6 +1126,8 @@ func TestCreateIndexAsync(t *testing.T) {
 
 // create same index name on different vector field
 func TestIndexMultiVectorDupName(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -1092,6 +1156,8 @@ func TestIndexMultiVectorDupName(t *testing.T) {
 }
 
 func TestDropIndex(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -1136,6 +1202,8 @@ func TestDropIndex(t *testing.T) {
 }
 
 func TestDropIndexCreateIndexWithIndexName(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 

--- a/tests/go_client/testcases/insert_test.go
+++ b/tests/go_client/testcases/insert_test.go
@@ -20,6 +20,8 @@ import (
 )
 
 func TestInsertDefault(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 	for _, autoID := range [2]bool{false, true} {
@@ -44,6 +46,8 @@ func TestInsertDefault(t *testing.T) {
 }
 
 func TestInsertDefaultPartition(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 	for _, autoID := range [2]bool{false, true} {
@@ -73,6 +77,8 @@ func TestInsertDefaultPartition(t *testing.T) {
 }
 
 func TestInsertVarcharPkDefault(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 	for _, autoID := range [2]bool{false, true} {
@@ -138,6 +144,8 @@ func TestInsertAllFieldsData(t *testing.T) {
 
 // test insert dynamic data with column
 func TestInsertDynamicExtraColumn(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -191,6 +199,8 @@ func TestInsertDynamicExtraColumn(t *testing.T) {
 }
 
 func TestInsertFp16OrBf16VectorsWithFp32Vector(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -214,6 +224,8 @@ func TestInsertFp16OrBf16VectorsWithFp32Vector(t *testing.T) {
 
 // test insert array column with empty data
 func TestInsertEmptyArray(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -294,6 +306,8 @@ func TestInsertArrayDataCapacityExceed(t *testing.T) {
 
 // test insert not exist collection or not exist partition
 func TestInsertNotExist(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -313,6 +327,8 @@ func TestInsertNotExist(t *testing.T) {
 
 // test insert data columns len, order mismatch fields
 func TestInsertColumnsMismatchFields(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -347,6 +363,8 @@ func TestInsertColumnsMismatchFields(t *testing.T) {
 
 // test insert with columns which has different len
 func TestInsertColumnsDifferentLen(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -364,6 +382,8 @@ func TestInsertColumnsDifferentLen(t *testing.T) {
 }
 
 func TestInsertAutoIdPkData(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -383,6 +403,8 @@ func TestInsertAutoIdPkData(t *testing.T) {
 
 // test insert invalid column: empty column or dim not match
 func TestInsertInvalidColumn(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 	// create collection
@@ -409,6 +431,8 @@ func TestInsertInvalidColumn(t *testing.T) {
 
 // test insert invalid column: empty column or dim not match
 func TestInsertColumnVarcharExceedLen(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 	// create collection
@@ -431,6 +455,8 @@ func TestInsertColumnVarcharExceedLen(t *testing.T) {
 
 // test insert sparse vector
 func TestInsertSparseData(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -451,6 +477,8 @@ func TestInsertSparseData(t *testing.T) {
 }
 
 func TestInsertSparseDataMaxDim(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -476,6 +504,8 @@ func TestInsertSparseDataMaxDim(t *testing.T) {
 
 // empty spare vector can't be searched, but can be queried
 func TestInsertReadSparseEmptyVector(t *testing.T) {
+	t.Parallel()
+
 	// invalid sparse vector: positions >= uint32
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -509,6 +539,8 @@ func TestInsertReadSparseEmptyVector(t *testing.T) {
 }
 
 func TestInsertSparseInvalidVector(t *testing.T) {
+	t.Parallel()
+
 	// invalid sparse vector: len(positions) != len(values)
 	positions := []uint32{1, 10}
 	values := []float32{0.4, 5.0, 0.34}
@@ -539,6 +571,8 @@ func TestInsertSparseInvalidVector(t *testing.T) {
 }
 
 func TestInsertSparseVectorSamePosition(t *testing.T) {
+	t.Parallel()
+
 	// invalid sparse vector: positions >= uint32
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -702,6 +736,8 @@ func TestInsertVarcharRows(t *testing.T) {
 }
 
 func TestInsertSparseRows(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -743,6 +779,8 @@ func TestInsertSparseRows(t *testing.T) {
 
 // test field name: pk, row json name: int64
 func TestInsertRowFieldNameNotMatch(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -762,6 +800,8 @@ func TestInsertRowFieldNameNotMatch(t *testing.T) {
 
 // test field name: pk, row json name: int64
 func TestInsertRowMismatchFields(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -885,6 +925,8 @@ func TestInsertEnableAutoIDRow(t *testing.T) {
 }
 
 func TestFlushRate(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 	// create collection

--- a/tests/go_client/testcases/load_release_test.go
+++ b/tests/go_client/testcases/load_release_test.go
@@ -19,6 +19,8 @@ import (
 
 // test load collection
 func TestLoadCollection(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -48,6 +50,8 @@ func TestLoadCollection(t *testing.T) {
 
 // test load not existed collection
 func TestLoadCollectionNotExist(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	// connect
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -59,6 +63,8 @@ func TestLoadCollectionNotExist(t *testing.T) {
 
 // test load collection async
 func TestLoadCollectionAsync(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -81,6 +87,8 @@ func TestLoadCollectionAsync(t *testing.T) {
 
 // load collection without index
 func TestLoadCollectionWithoutIndex(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -99,6 +107,8 @@ func TestLoadCollectionWithoutIndex(t *testing.T) {
 
 // load collection with multi partitions
 func TestLoadCollectionMultiPartitions(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -157,6 +167,8 @@ func TestLoadCollectionMultiPartitions(t *testing.T) {
 
 // test load repeated partition names
 func TestLoadPartitionsRepeatedly(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -191,6 +203,8 @@ func TestLoadPartitionsRepeatedly(t *testing.T) {
 }
 
 func TestLoadMultiVectorsIndex(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -210,6 +224,8 @@ func TestLoadMultiVectorsIndex(t *testing.T) {
 }
 
 func TestLoadCollectionAllFields(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -233,6 +249,8 @@ func TestLoadCollectionAllFields(t *testing.T) {
 }
 
 func TestLoadCollectionSparse(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -256,6 +274,8 @@ func TestLoadCollectionSparse(t *testing.T) {
 }
 
 func TestLoadPartialFields(t *testing.T) {
+	t.Parallel()
+
 	/*
 		1.  verify the collection loaded successfully
 		2.  verify the loaded fields can be searched in expr and output_fields
@@ -322,6 +342,8 @@ func TestLoadPartialFields(t *testing.T) {
 }
 
 func TestLoadPartialFieldsExpr(t *testing.T) {
+	t.Parallel()
+
 	/*
 		1.  verify the collection loaded successfully
 		2.  verify the loaded / not-loaded fields can be searched in expr
@@ -371,6 +393,8 @@ func TestLoadPartialFieldsExpr(t *testing.T) {
 }
 
 func TestLoadSkipDynamicField(t *testing.T) {
+	t.Parallel()
+
 	/*
 		1. load -> search output dynamic field
 		2. reload and skip dynamic field
@@ -411,6 +435,8 @@ func TestLoadSkipDynamicField(t *testing.T) {
 }
 
 func TestLoadPartialHybridSearch(t *testing.T) {
+	t.Parallel()
+
 	/*
 		1.  load partial vector fields
 		2.  hybrid search with loaded and not-loaded fields
@@ -448,6 +474,8 @@ func TestLoadPartialHybridSearch(t *testing.T) {
 }
 
 func TestLoadPartialFieldsPartitions(t *testing.T) {
+	t.Parallel()
+
 	/*
 		1. insert data into default partition and parName partition
 		2. load default partition with partial fields -> succ & query
@@ -507,6 +535,8 @@ func TestLoadPartialFieldsPartitions(t *testing.T) {
 }
 
 func TestLoadPartialFieldsWithoutPartitionKey(t *testing.T) {
+	t.Parallel()
+
 	/*
 		code fields: pk, clustering key, partition key, part dynamic fields, non-vector fields -> error
 		not index: error
@@ -545,6 +575,8 @@ func TestLoadPartialFieldsWithoutPartitionKey(t *testing.T) {
 }
 
 func TestLoadPartialFieldsRepeated(t *testing.T) {
+	t.Parallel()
+
 	/*
 		1. repeated Load with different LoadFields -> hint loaded
 	*/
@@ -577,6 +609,8 @@ func TestLoadPartialFieldsRepeated(t *testing.T) {
 }
 
 func TestLoadPartialFieldsRelease(t *testing.T) {
+	t.Parallel()
+
 	/*
 		1. release collection after loading partial fields -> ok
 	*/
@@ -604,6 +638,8 @@ func TestLoadPartialFieldsRelease(t *testing.T) {
 }
 
 func TestReleaseCollection(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -624,6 +660,8 @@ func TestReleaseCollection(t *testing.T) {
 }
 
 func TestReleaseCollectionNotExist(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	// connect
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -634,6 +672,8 @@ func TestReleaseCollectionNotExist(t *testing.T) {
 }
 
 func TestReleasePartitions(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -664,6 +704,8 @@ func TestReleasePartitions(t *testing.T) {
 }
 
 func TestReleasePartitionsNotExist(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	// connect
 	mc := hp.CreateDefaultMilvusClient(ctx, t)

--- a/tests/go_client/testcases/nullable_default_value_test.go
+++ b/tests/go_client/testcases/nullable_default_value_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -372,6 +373,8 @@ func VerifyNullableVectorDataWithFieldName(t *testing.T, vt NullableVectorType, 
 
 // create collection with nullable fields and insert with column / nullableColumn
 func TestNullableDefault(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -446,6 +449,8 @@ func TestNullableDefault(t *testing.T) {
 
 // create collection with default value and insert with column / nullableColumn
 func TestDefaultValueDefault(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -542,6 +547,8 @@ func TestDefaultValueDefault(t *testing.T) {
 }
 
 func TestNullableInvalid(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -574,6 +581,8 @@ func TestNullableInvalid(t *testing.T) {
 }
 
 func TestDefaultValueInvalid(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -608,6 +617,8 @@ func TestDefaultValueInvalid(t *testing.T) {
 }
 
 func TestDefaultValueInvalidValue(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -704,6 +715,8 @@ func TestDefaultValueInvalidValue(t *testing.T) {
 }
 
 func TestDefaultValueOutOfRange(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 	pkField := entity.NewField().WithName(common.GenRandomString("pk", 3)).WithDataType(entity.FieldTypeInt64).WithIsPrimaryKey(true)
@@ -749,6 +762,8 @@ func TestDefaultValueOutOfRange(t *testing.T) {
 
 // test default value "" and insert ""
 func TestDefaultValueVarcharEmpty(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -790,6 +805,8 @@ func TestDefaultValueVarcharEmpty(t *testing.T) {
 
 // test insert with nullableColumn into normal collection
 func TestNullableDefaultInsertInvalid(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -810,6 +827,8 @@ func TestNullableDefaultInsertInvalid(t *testing.T) {
 
 // test insert with part/all/not null -> query check
 func TestNullableQuery(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -862,6 +881,8 @@ func TestNullableQuery(t *testing.T) {
 
 // test insert with part/all/not default value -> query check
 func TestDefaultValueQuery(t *testing.T) {
+	t.Parallel()
+
 	for _, nullable := range [2]bool{false, true} {
 		ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 		mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -919,6 +940,8 @@ func TestDefaultValueQuery(t *testing.T) {
 
 // clustering-key nullable
 func TestNullableClusteringKey(t *testing.T) {
+	t.Parallel()
+
 	// test clustering key nullable
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -950,6 +973,8 @@ func TestNullableClusteringKey(t *testing.T) {
 
 // partition-key nullable
 func TestDefaultValuePartitionKey(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -980,6 +1005,8 @@ func TestDefaultValuePartitionKey(t *testing.T) {
 }
 
 func TestNullableGroubBy(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -1012,6 +1039,8 @@ func TestNullableGroubBy(t *testing.T) {
 }
 
 func TestNullableSearch(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 	fieldsOpt := hp.TNewFieldOptions().WithFieldOption(common.DefaultVarcharFieldName, hp.TNewFieldsOption().TWithNullable(true))
@@ -1049,6 +1078,8 @@ func TestNullableSearch(t *testing.T) {
 }
 
 func TestDefaultValueSearch(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 	fieldsOpt := hp.TNewFieldOptions().WithFieldOption(common.DefaultVarcharFieldName, hp.TNewFieldsOption().TWithDefaultValue("test").TWithNullable(true))
@@ -1086,6 +1117,8 @@ func TestDefaultValueSearch(t *testing.T) {
 
 // test nullable fields in all scalar index
 func TestNullableAutoScalarIndex(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -1153,6 +1186,8 @@ func TestNullableAutoScalarIndex(t *testing.T) {
 }
 
 func TestNullableUpsert(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -1205,6 +1240,8 @@ func TestNullableUpsert(t *testing.T) {
 }
 
 func TestNullableDelete(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 	fieldsOpt := hp.TNewFieldOptions().WithFieldOption(common.DefaultVarcharFieldName, hp.TNewFieldsOption().TWithNullable(true))
@@ -1234,6 +1271,8 @@ func TestNullableDelete(t *testing.T) {
 
 // TestNullableRows tests row-based insert with nullable varchar using pointer fields.
 func TestNullableRows(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 	fieldsOpt := hp.TNewFieldOptions().WithFieldOption(common.DefaultVarcharFieldName, hp.TNewFieldsOption().TWithNullable(true))
@@ -1260,6 +1299,8 @@ func TestNullableRows(t *testing.T) {
 
 // TestNullableRowsAllScalarTypes tests row-based insert with all nullable scalar types using pointer fields.
 func TestNullableRowsAllScalarTypes(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -1322,6 +1363,8 @@ func TestNullableRowsAllScalarTypes(t *testing.T) {
 
 // TestNullableRowsAllNullAndAllValid tests edge cases: all null and all valid rows.
 func TestNullableRowsAllNullAndAllValid(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 	fieldsOpt := hp.TNewFieldOptions().WithFieldOption(common.DefaultVarcharFieldName, hp.TNewFieldsOption().TWithNullable(true))
@@ -1367,6 +1410,8 @@ func TestNullableRowsAllNullAndAllValid(t *testing.T) {
 
 // TestNullableRowsUpsert tests upserting with nullable pointer rows.
 func TestNullableRowsUpsert(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 	fieldsOpt := hp.TNewFieldOptions().WithFieldOption(common.DefaultVarcharFieldName, hp.TNewFieldsOption().TWithNullable(true))
@@ -1405,6 +1450,8 @@ func TestNullableRowsUpsert(t *testing.T) {
 }
 
 func TestNullableVectorAllTypes(t *testing.T) {
+	t.Parallel()
+
 	vectorTypes := GetVectorTypes()
 	nullPercents := GetNullPercents()
 
@@ -1705,6 +1752,8 @@ func TestNullableVectorAllTypes(t *testing.T) {
 }
 
 func TestNullableVectorWithScalarFilter(t *testing.T) {
+	t.Parallel()
+
 	vectorTypes := GetVectorTypes()
 	nullPercents := GetNullPercents()
 
@@ -1792,6 +1841,8 @@ func TestNullableVectorWithScalarFilter(t *testing.T) {
 }
 
 func TestNullableVectorDelete(t *testing.T) {
+	t.Parallel()
+
 	vectorTypes := GetVectorTypes()
 	nullPercents := GetNullPercents()
 
@@ -1891,6 +1942,8 @@ func TestNullableVectorDelete(t *testing.T) {
 }
 
 func TestNullableVectorUpsert(t *testing.T) {
+	t.Parallel()
+
 	autoIDOptions := []bool{false, true}
 
 	for _, autoID := range autoIDOptions {
@@ -2202,6 +2255,8 @@ func TestNullableVectorUpsert(t *testing.T) {
 }
 
 func TestNullableVectorAllNull(t *testing.T) {
+	t.Parallel()
+
 	vectorTypes := GetVectorTypes()
 
 	for _, vt := range vectorTypes {
@@ -2323,6 +2378,8 @@ func TestNullableVectorAllNull(t *testing.T) {
 }
 
 func TestNullableVectorMultiFields(t *testing.T) {
+	t.Parallel()
+
 	vectorTypes := GetVectorTypes()
 
 	for _, vt := range vectorTypes {
@@ -2439,6 +2496,8 @@ func TestNullableVectorMultiFields(t *testing.T) {
 }
 
 func TestNullableVectorPaginatedQuery(t *testing.T) {
+	t.Parallel()
+
 	vectorTypes := GetVectorTypes()
 	nullPercents := GetNullPercents()
 
@@ -2531,6 +2590,8 @@ func TestNullableVectorPaginatedQuery(t *testing.T) {
 }
 
 func TestNullableVectorMultiPartitions(t *testing.T) {
+	t.Parallel()
+
 	vectorTypes := GetVectorTypes()
 
 	for _, vt := range vectorTypes {
@@ -2730,6 +2791,8 @@ func TestNullableVectorMultiPartitions(t *testing.T) {
 }
 
 func TestNullableVectorCompaction(t *testing.T) {
+	t.Parallel()
+
 	vectorTypes := GetVectorTypes()
 
 	for _, vt := range vectorTypes {
@@ -2919,6 +2982,8 @@ func TestNullableVectorCompaction(t *testing.T) {
 }
 
 func TestNullableVectorAddField(t *testing.T) {
+	t.Parallel()
+
 	vectorTypes := GetVectorTypes()
 
 	for _, vt := range vectorTypes {
@@ -3080,6 +3145,8 @@ func TestNullableVectorAddField(t *testing.T) {
 }
 
 func TestNullableVectorRangeSearch(t *testing.T) {
+	t.Parallel()
+
 	vectorTypes := GetVectorTypes()
 
 	for _, vt := range vectorTypes {
@@ -3224,10 +3291,206 @@ func TestNullableVectorRangeSearch(t *testing.T) {
 
 // index building on both SegmentGrowingImpl and ChunkedSegmentSealedImpl
 func TestNullableVectorDifferentIndexTypes(t *testing.T) {
+	t.Parallel()
+
 	vectorTypes := GetVectorTypes()
 	nullPercents := GetNullPercents()
-
 	segmentTypes := []string{"growing", "sealed"}
+
+	concurrency := 10
+	ch := make(chan struct{}, concurrency)
+	wg := sync.WaitGroup{}
+
+	testFunc := func(vt NullableVectorType, nullPercent int, segmentType string, idxCfg IndexConfig, testName string) {
+		defer func() {
+			wg.Done()
+			<-ch
+		}()
+		t.Run(testName, func(t *testing.T) {
+			ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout*10)
+			mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+			// Create collection with nullable vector
+			collName := common.GenRandomString("nullable_vec_large", 5)
+			pkField := entity.NewField().WithName(common.DefaultInt64FieldName).WithDataType(entity.FieldTypeInt64).WithIsPrimaryKey(true)
+			vecField := entity.NewField().WithName("vector").WithDataType(vt.FieldType).WithNullable(true)
+			if vt.FieldType != entity.FieldTypeSparseVector {
+				vecField = vecField.WithDim(common.DefaultDim)
+			}
+			schema := entity.NewSchema().WithName(collName).WithField(pkField).WithField(vecField)
+
+			err := mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema).WithConsistencyLevel(entity.ClStrong))
+			common.CheckErr(t, err, true)
+			t.Cleanup(func() {
+				_ = mc.DropCollection(context.Background(), client.NewDropCollectionOption(collName))
+			})
+
+			nb := 5000
+			validData := make([]bool, nb)
+			validCount := 0
+			for i := range nb {
+				validData[i] = (i % 100) >= nullPercent
+				if validData[i] {
+					validCount++
+				}
+			}
+
+			pkToVecIdx := make(map[int64]int)
+			vecIdx := 0
+			for i := range nb {
+				if validData[i] {
+					pkToVecIdx[int64(i)] = vecIdx
+					vecIdx++
+				}
+			}
+
+			// Generate pk column
+			pkData := make([]int64, nb)
+			for i := range nb {
+				pkData[i] = int64(i)
+			}
+			pkColumn := column.NewColumnInt64(common.DefaultInt64FieldName, pkData)
+
+			// Generate vector column based on type
+			var vecColumn column.Column
+			var searchVec entity.Vector
+			var originalVectors interface{}
+
+			switch vt.FieldType {
+			case entity.FieldTypeFloatVector:
+				vectors := make([][]float32, validCount)
+				for i := range validCount {
+					vec := make([]float32, common.DefaultDim)
+					for j := range common.DefaultDim {
+						vec[j] = float32(i*common.DefaultDim+j) / float32(validCount*common.DefaultDim)
+					}
+					vectors[i] = vec
+				}
+				vecColumn, err = column.NewNullableColumnFloatVector("vector", common.DefaultDim, vectors, validData)
+				searchVec = entity.FloatVector(vectors[0])
+				originalVectors = vectors
+
+			case entity.FieldTypeBinaryVector:
+				vectors := make([][]byte, validCount)
+				byteDim := common.DefaultDim / 8
+				for i := range validCount {
+					vec := make([]byte, byteDim)
+					for j := range byteDim {
+						vec[j] = byte((i + j) % 256)
+					}
+					vectors[i] = vec
+				}
+				vecColumn, err = column.NewNullableColumnBinaryVector("vector", common.DefaultDim, vectors, validData)
+				searchVec = entity.BinaryVector(vectors[0])
+				originalVectors = vectors
+
+			case entity.FieldTypeFloat16Vector:
+				vectors := make([][]byte, validCount)
+				for i := range validCount {
+					vectors[i] = common.GenFloat16Vector(common.DefaultDim)
+				}
+				vecColumn, err = column.NewNullableColumnFloat16Vector("vector", common.DefaultDim, vectors, validData)
+				searchVec = entity.Float16Vector(vectors[0])
+				originalVectors = vectors
+
+			case entity.FieldTypeBFloat16Vector:
+				vectors := make([][]byte, validCount)
+				for i := range validCount {
+					vectors[i] = common.GenBFloat16Vector(common.DefaultDim)
+				}
+				vecColumn, err = column.NewNullableColumnBFloat16Vector("vector", common.DefaultDim, vectors, validData)
+				searchVec = entity.BFloat16Vector(vectors[0])
+				originalVectors = vectors
+
+			case entity.FieldTypeInt8Vector:
+				vectors := make([][]int8, validCount)
+				for i := range validCount {
+					vec := make([]int8, common.DefaultDim)
+					for j := range common.DefaultDim {
+						vec[j] = int8((i + j) % 127)
+					}
+					vectors[i] = vec
+				}
+				vecColumn, err = column.NewNullableColumnInt8Vector("vector", common.DefaultDim, vectors, validData)
+				searchVec = entity.Int8Vector(vectors[0])
+				originalVectors = vectors
+
+			case entity.FieldTypeSparseVector:
+				vectors := make([]entity.SparseEmbedding, validCount)
+				for i := range validCount {
+					positions := []uint32{0, uint32(i%1000 + 1), uint32(i%10000 + 1000)}
+					values := []float32{1.0, float32(i+1) / 1000.0, 0.1}
+					vectors[i], err = entity.NewSliceSparseEmbedding(positions, values)
+					common.CheckErr(t, err, true)
+				}
+				vecColumn, err = column.NewNullableColumnSparseFloatVector("vector", vectors, validData)
+				searchVec = vectors[0]
+				originalVectors = vectors
+			}
+			common.CheckErr(t, err, true)
+
+			// Insert data
+			insertRes, err := mc.Insert(ctx, client.NewColumnBasedInsertOption(collName, pkColumn, vecColumn))
+			common.CheckErr(t, err, true)
+			require.EqualValues(t, nb, insertRes.InsertCount)
+
+			// For sealed segment, flush before creating index to convert growing to sealed
+			if segmentType == "sealed" {
+				flushTask, err := mc.Flush(ctx, client.NewFlushOption(collName))
+				common.CheckErr(t, err, true)
+				err = flushTask.Await(ctx)
+				common.CheckErr(t, err, true)
+			}
+
+			// Create index using the config for this test iteration
+			vecIndex := CreateIndexFromConfig("vector", idxCfg)
+			indexTask, err := mc.CreateIndex(ctx, client.NewCreateIndexOption(collName, "vector", vecIndex))
+			common.CheckErr(t, err, true)
+			err = indexTask.Await(ctx)
+			common.CheckErr(t, err, true)
+
+			// Load collection - specify load fields to potentially skip loading vector raw data
+			// When vector has index and is specified in LoadFields, system may use index instead of field data
+			loadTask, err := mc.LoadCollection(ctx, client.NewLoadCollectionOption(collName).
+				WithLoadFields(common.DefaultInt64FieldName, "vector")) // Load pk and vector (via index)
+			common.CheckErr(t, err, true)
+			err = loadTask.Await(ctx)
+			common.CheckErr(t, err, true)
+
+			// Search
+			searchRes, err := mc.Search(ctx, client.NewSearchOption(collName, 10, []entity.Vector{searchVec}).
+				WithOutputFields("*").
+				WithConsistencyLevel(entity.ClStrong))
+			common.CheckErr(t, err, true)
+			require.EqualValues(t, 1, len(searchRes))
+			require.GreaterOrEqual(t, searchRes[0].ResultCount, 1)
+
+			// Verify search results
+			VerifyNullableVectorData(t, vt, searchRes[0], pkToVecIdx, originalVectors, "search")
+
+			// Query to count rows
+			queryRes, err := mc.Query(ctx, client.NewQueryOption(collName).
+				WithFilter(fmt.Sprintf("%s >= 0", common.DefaultInt64FieldName)).
+				WithOutputFields("count(*)"))
+			common.CheckErr(t, err, true)
+			countCol := queryRes.GetColumn("count(*)")
+			count, _ := countCol.GetAsInt64(0)
+			require.EqualValues(t, nb, count)
+
+			// Query with vector output to verify data
+			queryVecRes, err := mc.Query(ctx, client.NewQueryOption(collName).
+				WithFilter(fmt.Sprintf("%s < 100", common.DefaultInt64FieldName)).
+				WithOutputFields("*"))
+			common.CheckErr(t, err, true)
+
+			// Verify query results
+			VerifyNullableVectorData(t, vt, queryVecRes, pkToVecIdx, originalVectors, "query")
+
+			// Clean up
+			err = mc.DropCollection(ctx, client.NewDropCollectionOption(collName))
+			common.CheckErr(t, err, true)
+		})
+	}
 
 	for _, vt := range vectorTypes {
 		indexConfigs := GetIndexesForVectorType(vt.FieldType)
@@ -3246,198 +3509,19 @@ func TestNullableVectorDifferentIndexTypes(t *testing.T) {
 
 				for _, idxCfg := range testIndexConfigs {
 					testName := fmt.Sprintf("%s_%s_%d%%null_%s", vt.Name, idxCfg.Name, nullPercent, segmentType)
-					idxCfgCopy := idxCfg // capture loop variable
-					t.Run(testName, func(t *testing.T) {
-						ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout*10)
-						mc := hp.CreateDefaultMilvusClient(ctx, t)
-
-						// Create collection with nullable vector
-						collName := common.GenRandomString("nullable_vec_large", 5)
-						pkField := entity.NewField().WithName(common.DefaultInt64FieldName).WithDataType(entity.FieldTypeInt64).WithIsPrimaryKey(true)
-						vecField := entity.NewField().WithName("vector").WithDataType(vt.FieldType).WithNullable(true)
-						if vt.FieldType != entity.FieldTypeSparseVector {
-							vecField = vecField.WithDim(common.DefaultDim)
-						}
-						schema := entity.NewSchema().WithName(collName).WithField(pkField).WithField(vecField)
-
-						err := mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema).WithConsistencyLevel(entity.ClStrong))
-						common.CheckErr(t, err, true)
-						t.Cleanup(func() {
-							_ = mc.DropCollection(context.Background(), client.NewDropCollectionOption(collName))
-						})
-
-						nb := 10000
-						validData := make([]bool, nb)
-						validCount := 0
-						for i := range nb {
-							validData[i] = (i % 100) >= nullPercent
-							if validData[i] {
-								validCount++
-							}
-						}
-
-						pkToVecIdx := make(map[int64]int)
-						vecIdx := 0
-						for i := range nb {
-							if validData[i] {
-								pkToVecIdx[int64(i)] = vecIdx
-								vecIdx++
-							}
-						}
-
-						// Generate pk column
-						pkData := make([]int64, nb)
-						for i := range nb {
-							pkData[i] = int64(i)
-						}
-						pkColumn := column.NewColumnInt64(common.DefaultInt64FieldName, pkData)
-
-						// Generate vector column based on type
-						var vecColumn column.Column
-						var searchVec entity.Vector
-						var originalVectors interface{}
-
-						switch vt.FieldType {
-						case entity.FieldTypeFloatVector:
-							vectors := make([][]float32, validCount)
-							for i := range validCount {
-								vec := make([]float32, common.DefaultDim)
-								for j := range common.DefaultDim {
-									vec[j] = float32(i*common.DefaultDim+j) / float32(validCount*common.DefaultDim)
-								}
-								vectors[i] = vec
-							}
-							vecColumn, err = column.NewNullableColumnFloatVector("vector", common.DefaultDim, vectors, validData)
-							searchVec = entity.FloatVector(vectors[0])
-							originalVectors = vectors
-
-						case entity.FieldTypeBinaryVector:
-							vectors := make([][]byte, validCount)
-							byteDim := common.DefaultDim / 8
-							for i := range validCount {
-								vec := make([]byte, byteDim)
-								for j := range byteDim {
-									vec[j] = byte((i + j) % 256)
-								}
-								vectors[i] = vec
-							}
-							vecColumn, err = column.NewNullableColumnBinaryVector("vector", common.DefaultDim, vectors, validData)
-							searchVec = entity.BinaryVector(vectors[0])
-							originalVectors = vectors
-
-						case entity.FieldTypeFloat16Vector:
-							vectors := make([][]byte, validCount)
-							for i := range validCount {
-								vectors[i] = common.GenFloat16Vector(common.DefaultDim)
-							}
-							vecColumn, err = column.NewNullableColumnFloat16Vector("vector", common.DefaultDim, vectors, validData)
-							searchVec = entity.Float16Vector(vectors[0])
-							originalVectors = vectors
-
-						case entity.FieldTypeBFloat16Vector:
-							vectors := make([][]byte, validCount)
-							for i := range validCount {
-								vectors[i] = common.GenBFloat16Vector(common.DefaultDim)
-							}
-							vecColumn, err = column.NewNullableColumnBFloat16Vector("vector", common.DefaultDim, vectors, validData)
-							searchVec = entity.BFloat16Vector(vectors[0])
-							originalVectors = vectors
-
-						case entity.FieldTypeInt8Vector:
-							vectors := make([][]int8, validCount)
-							for i := range validCount {
-								vec := make([]int8, common.DefaultDim)
-								for j := range common.DefaultDim {
-									vec[j] = int8((i + j) % 127)
-								}
-								vectors[i] = vec
-							}
-							vecColumn, err = column.NewNullableColumnInt8Vector("vector", common.DefaultDim, vectors, validData)
-							searchVec = entity.Int8Vector(vectors[0])
-							originalVectors = vectors
-
-						case entity.FieldTypeSparseVector:
-							vectors := make([]entity.SparseEmbedding, validCount)
-							for i := range validCount {
-								positions := []uint32{0, uint32(i%1000 + 1), uint32(i%10000 + 1000)}
-								values := []float32{1.0, float32(i+1) / 1000.0, 0.1}
-								vectors[i], err = entity.NewSliceSparseEmbedding(positions, values)
-								common.CheckErr(t, err, true)
-							}
-							vecColumn, err = column.NewNullableColumnSparseFloatVector("vector", vectors, validData)
-							searchVec = vectors[0]
-							originalVectors = vectors
-						}
-						common.CheckErr(t, err, true)
-
-						// Insert data
-						insertRes, err := mc.Insert(ctx, client.NewColumnBasedInsertOption(collName, pkColumn, vecColumn))
-						common.CheckErr(t, err, true)
-						require.EqualValues(t, nb, insertRes.InsertCount)
-
-						// For sealed segment, flush before creating index to convert growing to sealed
-						if segmentType == "sealed" {
-							flushTask, err := mc.Flush(ctx, client.NewFlushOption(collName))
-							common.CheckErr(t, err, true)
-							err = flushTask.Await(ctx)
-							common.CheckErr(t, err, true)
-						}
-
-						// Create index using the config for this test iteration
-						vecIndex := CreateIndexFromConfig("vector", idxCfgCopy)
-						indexTask, err := mc.CreateIndex(ctx, client.NewCreateIndexOption(collName, "vector", vecIndex))
-						common.CheckErr(t, err, true)
-						err = indexTask.Await(ctx)
-						common.CheckErr(t, err, true)
-
-						// Load collection - specify load fields to potentially skip loading vector raw data
-						// When vector has index and is specified in LoadFields, system may use index instead of field data
-						loadTask, err := mc.LoadCollection(ctx, client.NewLoadCollectionOption(collName).
-							WithLoadFields(common.DefaultInt64FieldName, "vector")) // Load pk and vector (via index)
-						common.CheckErr(t, err, true)
-						err = loadTask.Await(ctx)
-						common.CheckErr(t, err, true)
-
-						// Search
-						searchRes, err := mc.Search(ctx, client.NewSearchOption(collName, 10, []entity.Vector{searchVec}).
-							WithOutputFields("*").
-							WithConsistencyLevel(entity.ClStrong))
-						common.CheckErr(t, err, true)
-						require.EqualValues(t, 1, len(searchRes))
-						require.GreaterOrEqual(t, searchRes[0].ResultCount, 1)
-
-						// Verify search results
-						VerifyNullableVectorData(t, vt, searchRes[0], pkToVecIdx, originalVectors, "search")
-
-						// Query to count rows
-						queryRes, err := mc.Query(ctx, client.NewQueryOption(collName).
-							WithFilter(fmt.Sprintf("%s >= 0", common.DefaultInt64FieldName)).
-							WithOutputFields("count(*)"))
-						common.CheckErr(t, err, true)
-						countCol := queryRes.GetColumn("count(*)")
-						count, _ := countCol.GetAsInt64(0)
-						require.EqualValues(t, nb, count)
-
-						// Query with vector output to verify data
-						queryVecRes, err := mc.Query(ctx, client.NewQueryOption(collName).
-							WithFilter(fmt.Sprintf("%s < 100", common.DefaultInt64FieldName)).
-							WithOutputFields("*"))
-						common.CheckErr(t, err, true)
-
-						// Verify query results
-						VerifyNullableVectorData(t, vt, queryVecRes, pkToVecIdx, originalVectors, "query")
-
-						// Clean up
-						err = mc.DropCollection(ctx, client.NewDropCollectionOption(collName))
-						common.CheckErr(t, err, true)
-					})
+					ch <- struct{}{}
+					wg.Add(1)
+					go testFunc(vt, nullPercent, segmentType, idxCfg, testName)
 				}
 			}
 		}
 	}
+	wg.Wait()
 }
 
 func TestNullableVectorGroupBy(t *testing.T) {
+	t.Parallel()
+
 	groupByVectorTypes := []NullableVectorType{
 		{"FloatVector", entity.FieldTypeFloatVector},
 		{"Float16Vector", entity.FieldTypeFloat16Vector},

--- a/tests/go_client/testcases/partition_test.go
+++ b/tests/go_client/testcases/partition_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func TestPartitionsDefault(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -61,6 +63,8 @@ func TestPartitionsDefault(t *testing.T) {
 }
 
 func TestCreatePartitionInvalid(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -106,7 +110,8 @@ func TestCreatePartitionInvalid(t *testing.T) {
 }
 
 func TestPartitionsNumExceedsMax(t *testing.T) {
-	// 120 seconds may timeout for 1024 partitions
+	// 1023 sequential CreatePartition calls serialize on a per-collection lock in rootcoord;
+	// keep this test serial so it isn't starved by other parallel tests' DDL load.
 	ctx := hp.CreateContext(t, time.Second*300)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -131,6 +136,8 @@ func TestPartitionsNumExceedsMax(t *testing.T) {
 }
 
 func TestDropPartitionInvalid(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 	_, schema := hp.CollPrepare.CreateCollection(ctx, t, mc, hp.NewCreateCollectionParams(hp.Int64Vec), hp.TNewFieldsOption(), hp.TNewSchemaOption())
@@ -151,6 +158,8 @@ func TestDropPartitionInvalid(t *testing.T) {
 }
 
 func TestListHasPartitionInvalid(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -164,6 +173,8 @@ func TestListHasPartitionInvalid(t *testing.T) {
 }
 
 func TestDropPartitionData(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 

--- a/tests/go_client/testcases/phrase_match_test.go
+++ b/tests/go_client/testcases/phrase_match_test.go
@@ -17,6 +17,8 @@ import (
 
 // TestPhraseMatchDefault tests basic phrase match functionality with slop=0
 func TestPhraseMatchDefault(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -46,6 +48,8 @@ func TestPhraseMatchDefault(t *testing.T) {
 
 // TestPhraseMatchWithSlop tests phrase match with different slop values
 func TestPhraseMatchWithSlop(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -90,6 +94,8 @@ func TestPhraseMatchWithSlop(t *testing.T) {
 
 // TestPhraseMatchWithDiffLang tests phrase match with different languages
 func TestPhraseMatchWithDiffLang(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -140,6 +146,8 @@ func TestPhraseMatchWithDiffLang(t *testing.T) {
 
 // TestPhraseMatchWithEmptyData tests phrase match with empty data
 func TestPhraseMatchWithEmptyData(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -168,6 +176,8 @@ func TestPhraseMatchWithEmptyData(t *testing.T) {
 
 // TestPhraseMatchDefault tests basic phrase match functionality with slop=0
 func TestPhraseMatchNullable(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -203,6 +213,8 @@ func TestPhraseMatchNullable(t *testing.T) {
 
 // TestPhraseMatchDefault tests basic phrase match functionality with slop=0
 func TestPhraseMatchDefaultValue(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 

--- a/tests/go_client/testcases/query_iterator_test.go
+++ b/tests/go_client/testcases/query_iterator_test.go
@@ -18,6 +18,8 @@ import (
 
 // TestQueryIteratorDefault tests query iterator with default parameters
 func TestQueryIteratorDefault(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -38,6 +40,8 @@ func TestQueryIteratorDefault(t *testing.T) {
 
 // TestQueryIteratorHitEmpty tests query iterator on empty collection
 func TestQueryIteratorHitEmpty(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -58,6 +62,8 @@ func TestQueryIteratorHitEmpty(t *testing.T) {
 
 // TestQueryIteratorBatchSize tests query iterator with different batch sizes
 func TestQueryIteratorBatchSize(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -149,6 +155,8 @@ func TestQueryIteratorSparseVecFields(t *testing.T) {
 
 // TestQueryIteratorInvalid tests query iterator with invalid parameters
 func TestQueryIteratorInvalid(t *testing.T) {
+	t.Parallel()
+
 	nb := 201
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -188,6 +196,8 @@ func TestQueryIteratorInvalid(t *testing.T) {
 
 // TestQueryIteratorInvalidExpr tests query iterator with invalid expressions
 func TestQueryIteratorInvalidExpr(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -208,6 +218,8 @@ func TestQueryIteratorInvalidExpr(t *testing.T) {
 
 // TestQueryIteratorOutputFieldDynamic tests query iterator with non-existed field when dynamic enabled or not
 func TestQueryIteratorOutputFieldDynamic(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 	nb := 201
@@ -235,6 +247,8 @@ func TestQueryIteratorOutputFieldDynamic(t *testing.T) {
 
 // TestQueryIteratorExpr tests query iterator with various expressions
 func TestQueryIteratorExpr(t *testing.T) {
+	t.Parallel()
+
 	type exprCount struct {
 		expr  string
 		count int
@@ -317,6 +331,8 @@ func TestQueryIteratorExpr(t *testing.T) {
 
 // TestQueryIteratorPartitions tests query iterator with partition filtering
 func TestQueryIteratorPartitions(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -355,6 +371,8 @@ func TestQueryIteratorPartitions(t *testing.T) {
 
 // TestQueryIteratorWithLimit tests query iterator with limit
 func TestQueryIteratorWithLimit(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -376,6 +394,8 @@ func TestQueryIteratorWithLimit(t *testing.T) {
 
 // TestQueryIteratorGrowing tests query iterator on growing segments
 func TestQueryIteratorGrowing(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -395,6 +415,8 @@ func TestQueryIteratorGrowing(t *testing.T) {
 
 // TestQueryIteratorConsistencyLevel tests query iterator with different consistency levels
 func TestQueryIteratorConsistencyLevel(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 

--- a/tests/go_client/testcases/query_test.go
+++ b/tests/go_client/testcases/query_test.go
@@ -19,6 +19,8 @@ import (
 
 // test query from default partition
 func TestQueryDefault(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -52,6 +54,8 @@ func TestQueryDefault(t *testing.T) {
 
 // test query with varchar field filter
 func TestQueryVarcharPkDefault(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -79,6 +83,8 @@ func TestQueryVarcharPkDefault(t *testing.T) {
 
 // test get with invalid ids
 func TestGetInvalid(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -112,6 +118,8 @@ func TestGetInvalid(t *testing.T) {
 
 // query from not existed collection name and partition name
 func TestQueryNotExistName(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -132,6 +140,8 @@ func TestQueryNotExistName(t *testing.T) {
 
 // test query with invalid partition name
 func TestQueryInvalidPartitionName(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -147,6 +157,8 @@ func TestQueryInvalidPartitionName(t *testing.T) {
 
 // test query with empty partition name
 func TestQueryPartition(t *testing.T) {
+	t.Parallel()
+
 	parName := "p1"
 
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
@@ -197,6 +209,8 @@ func TestQueryPartition(t *testing.T) {
 
 // test query with invalid partition name
 func TestQueryWithoutExpr(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -291,6 +305,8 @@ func TestQueryOutputFields(t *testing.T) {
 
 // test query output all fields and verify data
 func TestQueryOutputAllFieldsColumn(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -346,6 +362,8 @@ func TestQueryOutputAllFieldsColumn(t *testing.T) {
 
 // test query output all fields
 func TestQueryOutputAllFieldsRows(t *testing.T) {
+	t.Parallel()
+
 	t.Skip("https://github.com/milvus-io/milvus/issues/33459")
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -377,6 +395,8 @@ func TestQueryOutputAllFieldsRows(t *testing.T) {
 
 // test query output varchar and binaryVector fields
 func TestQueryOutputBinaryAndVarchar(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -448,6 +468,8 @@ func TestQueryOutputSparse(t *testing.T) {
 
 // test query different array rows has different element length
 func TestQueryArrayDifferentLenBetweenRows(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -495,6 +517,8 @@ func TestQueryArrayDifferentLenBetweenRows(t *testing.T) {
 
 // test query with expr and verify output dynamic field data
 func TestQueryJsonDynamicExpr(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -527,6 +551,8 @@ func TestQueryJsonDynamicExpr(t *testing.T) {
 
 // test query with invalid expr
 func TestQueryInvalidExpr(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -544,6 +570,8 @@ func TestQueryInvalidExpr(t *testing.T) {
 
 // Test query json and dynamic collection with string expr
 func TestQueryCountJsonDynamicExpr(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -621,6 +649,8 @@ func TestQueryCountJsonDynamicExpr(t *testing.T) {
 }
 
 func TestQueryNestedJsonExpr(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 	prepare, schema := hp.CollPrepare.CreateCollection(ctx, t, mc, hp.NewCreateCollectionParams(hp.Int64VecJSON), hp.TNewFieldsOption(), hp.TNewSchemaOption())
@@ -665,6 +695,8 @@ func TestQueryNestedJsonExpr(t *testing.T) {
 }
 
 func TestQueryNumberJsonExpr(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 	prepare, schema := hp.CollPrepare.CreateCollection(ctx, t, mc, hp.NewCreateCollectionParams(hp.Int64VecJSON), hp.TNewFieldsOption(), hp.TNewSchemaOption())
@@ -785,6 +817,8 @@ func TestQueryNumberJsonExpr(t *testing.T) {
 }
 
 func TestQueryObjectJsonExpr(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 	prepare, schema := hp.CollPrepare.CreateCollection(ctx, t, mc, hp.NewCreateCollectionParams(hp.Int64VecJSON), hp.TNewFieldsOption(), hp.TNewSchemaOption())
@@ -923,6 +957,8 @@ func TestQueryObjectJsonExpr(t *testing.T) {
 }
 
 func TestQueryNullJsonExpr(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -1003,6 +1039,8 @@ func TestQueryNullJsonExpr(t *testing.T) {
 
 // test query with all kinds of array expr
 func TestQueryArrayFieldExpr(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -1046,6 +1084,8 @@ func TestQueryArrayFieldExpr(t *testing.T) {
 
 // test query output invalid count(*) fields
 func TestQueryOutputInvalidOutputFieldCount(t *testing.T) {
+	t.Parallel()
+
 	type invalidCountStruct struct {
 		countField string
 		errMsg     string
@@ -1076,6 +1116,8 @@ func TestQueryOutputInvalidOutputFieldCount(t *testing.T) {
 }
 
 func TestQueryWithTemplateParam(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -1147,6 +1189,8 @@ func TestQueryWithTemplateParam(t *testing.T) {
 }
 
 func TestQueryWithTemplateParamInvalid(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -1206,6 +1250,8 @@ func TestQueryWithTemplateParamInvalid(t *testing.T) {
 }
 
 func TestRunAnalyzer(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 

--- a/tests/go_client/testcases/reranker_function_test.go
+++ b/tests/go_client/testcases/reranker_function_test.go
@@ -156,6 +156,8 @@ func TestRerankFunctionDecay(t *testing.T) {
 }
 
 func TestRerankFunctionModel(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout*3)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -421,6 +423,8 @@ func TestRerankFunctionDecaySingleVector(t *testing.T) {
 }
 
 func TestRerankFunctionModelSingleVector(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout*3)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 

--- a/tests/go_client/testcases/search_by_pk_test.go
+++ b/tests/go_client/testcases/search_by_pk_test.go
@@ -24,6 +24,8 @@ import (
 //
 // Expected: search successfully and results are correct
 func TestSearchByPKFloatVectors(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -70,6 +72,8 @@ func TestSearchByPKFloatVectors(t *testing.T) {
 //
 // Expected: null vectors are filtered out, result count = non-null vector count
 func TestSearchByPKNullableVectorField(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -205,6 +209,8 @@ func TestSearchByPKNullableVectorField(t *testing.T) {
 //
 // Expected: search successfully and results are correct
 func TestSearchByPKBinaryVectors(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -251,6 +257,8 @@ func TestSearchByPKBinaryVectors(t *testing.T) {
 //
 // Expected: search should return error for empty IDs
 func TestSearchByPKWithEmptyIDs(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -283,6 +291,8 @@ func TestSearchByPKWithEmptyIDs(t *testing.T) {
 //
 // Expected: search should handle duplicate IDs (may deduplicate or error)
 func TestSearchByPKWithDuplicateIDs(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -321,6 +331,8 @@ func TestSearchByPKWithDuplicateIDs(t *testing.T) {
 //
 // Expected: search successfully and results satisfy both conditions
 func TestSearchByPKWithExpression(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -370,6 +382,8 @@ func TestSearchByPKWithExpression(t *testing.T) {
 //
 // Expected: search successfully with grouped results
 func TestSearchByPKWithGroupBy(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -413,6 +427,8 @@ func TestSearchByPKWithGroupBy(t *testing.T) {
 //
 // Expected: search successfully with sparse vectors
 func TestSearchByPKSparseVectors(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -499,6 +515,8 @@ func TestSearchByPKSparseVectors(t *testing.T) {
 //
 // Expected: search successfully and returns specified fields
 func TestSearchByPKWithOutputFields(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -553,6 +571,8 @@ func TestSearchByPKWithOutputFields(t *testing.T) {
 //
 // Expected: search should handle gracefully (empty results or error)
 func TestSearchByPKWithInvalidIDs(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -586,6 +606,8 @@ func TestSearchByPKWithInvalidIDs(t *testing.T) {
 //
 // Expected: search successfully and all distances are within [radius, range_filter]
 func TestSearchByPKWithRangeSearch(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -649,6 +671,8 @@ func TestSearchByPKWithRangeSearch(t *testing.T) {
 //
 // Expected: hybrid search should fail with error indicating IDs not supported
 func TestSearchByPKWithHybridSearch(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -746,6 +770,8 @@ func TestSearchByPKWithHybridSearch(t *testing.T) {
 // search by IDs is not supported for iterators at the API level.
 // This is consistent with Python SDK behavior where search_iterator does not support ids parameter.
 func TestSearchByPKWithSearchIterator(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 

--- a/tests/go_client/testcases/search_iterator_test.go
+++ b/tests/go_client/testcases/search_iterator_test.go
@@ -18,6 +18,8 @@ import (
 )
 
 func TestSearchIteratorDefault(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -57,6 +59,8 @@ func TestSearchIteratorDefault(t *testing.T) {
 }
 
 func TestSearchIteratorGrowing(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -77,6 +81,8 @@ func TestSearchIteratorGrowing(t *testing.T) {
 }
 
 func TestSearchIteratorHitEmpty(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -94,6 +100,8 @@ func TestSearchIteratorHitEmpty(t *testing.T) {
 }
 
 func TestSearchIteratorBatchSize(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -206,6 +214,8 @@ func TestQueryIteratorOutputSparseFieldsRows(t *testing.T) {
 }
 
 func TestSearchIteratorInvalid(t *testing.T) {
+	t.Parallel()
+
 	nb := 201
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -256,6 +266,8 @@ func TestSearchIteratorInvalid(t *testing.T) {
 }
 
 func TestSearchIteratorWithInvalidExpr(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -276,6 +288,8 @@ func TestSearchIteratorWithInvalidExpr(t *testing.T) {
 }
 
 func TestSearchIteratorTemplateKey(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -316,6 +330,8 @@ func TestSearchIteratorTemplateKey(t *testing.T) {
 }
 
 func TestSearchIteratorGroupBy(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -334,6 +350,8 @@ func TestSearchIteratorGroupBy(t *testing.T) {
 }
 
 func TestSearchIteratorIgnoreGrowing(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -371,6 +389,8 @@ func TestSearchIteratorIgnoreGrowing(t *testing.T) {
 }
 
 func TestSearchIteratorNull(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -437,6 +457,8 @@ func TestSearchIteratorNull(t *testing.T) {
 }
 
 func TestSearchIteratorDefaultValue(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 

--- a/tests/go_client/testcases/search_test.go
+++ b/tests/go_client/testcases/search_test.go
@@ -21,6 +21,8 @@ import (
 )
 
 func TestSearchDefault(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -39,6 +41,8 @@ func TestSearchDefault(t *testing.T) {
 }
 
 func TestSearchDefaultGrowing(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -57,6 +61,8 @@ func TestSearchDefaultGrowing(t *testing.T) {
 
 // test search collection and partition name not exist
 func TestSearchInvalidCollectionPartitionName(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -112,6 +118,8 @@ func TestSearchEmptyCollection(t *testing.T) {
 }
 
 func TestSearchEmptySparseCollection(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -130,6 +138,8 @@ func TestSearchEmptySparseCollection(t *testing.T) {
 
 // test search with partition names []string{}, specify partitions
 func TestSearchPartitions(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -338,6 +348,8 @@ func TestSearchOutputSparse(t *testing.T) {
 
 // test search with invalid vector field name: not exist; non-vector field, empty fiend name, json and dynamic field -> error
 func TestSearchInvalidVectorField(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -455,6 +467,8 @@ func TestSearchEmptyInvalidVectors(t *testing.T) {
 
 // test search metric type isn't the same with index metric type
 func TestSearchNotMatchMetricType(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -472,6 +486,8 @@ func TestSearchNotMatchMetricType(t *testing.T) {
 
 // test search with invalid topK -> error
 func TestSearchInvalidTopK(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -490,6 +506,8 @@ func TestSearchInvalidTopK(t *testing.T) {
 
 // test search with invalid topK -> error
 func TestSearchInvalidOffset(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -508,6 +526,8 @@ func TestSearchInvalidOffset(t *testing.T) {
 
 // test search with invalid search params
 func TestSearchInvalidSearchParams(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -542,6 +562,8 @@ func TestSearchInvalidSearchParams(t *testing.T) {
 
 // search with index scann search param ef < topK -> error
 func TestSearchInvalidScannReorderK(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -613,6 +635,8 @@ func TestSearchScannAllMetricsWithRawData(t *testing.T) {
 
 // test search with valid expression
 func TestSearchExpr(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -725,6 +749,8 @@ func TestSearchJsonFieldExpr(t *testing.T) {
 }
 
 func TestSearchDynamicFieldExpr(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 	// create collection
@@ -786,6 +812,8 @@ func TestSearchDynamicFieldExpr(t *testing.T) {
 }
 
 func TestSearchArrayFieldExpr(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -864,6 +892,8 @@ func TestSearchNotExistedExpr(t *testing.T) {
 
 // test search with fp16/ bf16 /binary vector
 func TestSearchMultiVectors(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout*2)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -1021,6 +1051,8 @@ func TestSearchWithEmptySparseVector(t *testing.T) {
 
 // test search from empty sparse vectors collection
 func TestSearchFromEmptySparseVector(t *testing.T) {
+	t.Parallel()
+
 	idxInverted := index.NewSparseInvertedIndex(entity.IP, 0.1)
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout*2)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -1100,10 +1132,14 @@ func TestSearchSparseVectorPagination(t *testing.T) {
 
 // test sparse vector unsupported search: TODO iterator search
 func TestSearchSparseVectorNotSupported(t *testing.T) {
+	t.Parallel()
+
 	t.Skip("Go-sdk support iterator search in progress")
 }
 
 func TestRangeSearchSparseVector(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout*2)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 

--- a/tests/go_client/testcases/snapshot_test.go
+++ b/tests/go_client/testcases/snapshot_test.go
@@ -127,6 +127,8 @@ func waitForAllIndexesBuilt(ctx context.Context, mc *base.MilvusClient, collName
 
 // TestCreateSnapshot tests creating a snapshot for a collection
 func TestCreateSnapshot(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -175,6 +177,8 @@ func TestCreateSnapshot(t *testing.T) {
 
 // TestSnapshotRestoreWithMultiSegment tests the complete snapshot restore workflow with data operations
 func TestSnapshotRestoreWithMultiSegment(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -312,6 +316,8 @@ func TestSnapshotRestoreWithMultiSegment(t *testing.T) {
 
 // TestSnapshotRestoreWithMultiShardMultiPartition tests the complete snapshot restore workflow with data operations
 func TestSnapshotRestoreWithMultiShardMultiPartition(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -460,6 +466,8 @@ func TestSnapshotRestoreWithMultiShardMultiPartition(t *testing.T) {
 
 // TestSnapshotRestoreWithMultiFields tests snapshot restore with all supported field types
 func TestSnapshotRestoreWithMultiFields(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -665,6 +673,8 @@ func TestSnapshotRestoreWithMultiFields(t *testing.T) {
 // TestSnapshotRestoreEmptyCollection tests snapshot and restore of an empty collection
 // Verifies that schema and indexes are preserved correctly without any data
 func TestSnapshotRestoreEmptyCollection(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -931,6 +941,8 @@ func TestSnapshotRestoreEmptyCollection(t *testing.T) {
 // This test verifies that JSON stats (both legacy json_key_index_log and new json_stats formats)
 // are correctly preserved and restored during snapshot operations
 func TestSnapshotRestoreWithJSONStats(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -1142,6 +1154,8 @@ func TestSnapshotRestoreWithJSONStats(t *testing.T) {
 // TestSnapshotRestoreAfterDropPartitionAndCollection tests snapshot restore functionality
 // after dropping partitions and the entire collection
 func TestSnapshotRestoreAfterDropPartitionAndCollection(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -1332,6 +1346,8 @@ func TestSnapshotRestoreAfterDropPartitionAndCollection(t *testing.T) {
 // Verifies that ListSnapshots with db-level filtering returns only snapshots
 // belonging to collections in the specified database.
 func TestSnapshotCrossDatabase(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -1404,6 +1420,8 @@ func TestSnapshotCrossDatabase(t *testing.T) {
 // 3. Drop collection B, restore A1 again to collection C
 // 4. Verify both A and C can load and query/search
 func TestSnapshotRestoreDropAndRestoreAgain(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -1559,6 +1577,8 @@ func TestSnapshotRestoreDropAndRestoreAgain(t *testing.T) {
 // This covers the bug where CopySegmentResult.index_infos used fieldID as map key,
 // causing only the last index per field to survive (overwriting earlier ones).
 func TestSnapshotRestoreWithMultipleJSONPathIndexes(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 

--- a/tests/go_client/testcases/text_embedding_test.go
+++ b/tests/go_client/testcases/text_embedding_test.go
@@ -27,6 +27,8 @@ func newTextEmbeddingFieldsOption(autoId bool) hp.FieldOptions {
 
 // TestCreateCollectionWithTextEmbedding tests basic collection creation with text embedding function
 func TestCreateCollectionWithTextEmbedding(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -49,6 +51,8 @@ func TestCreateCollectionWithTextEmbedding(t *testing.T) {
 
 // TestCreateCollectionWithTextEmbeddingTwice tests creating collection twice with same schema
 func TestCreateCollectionWithTextEmbeddingTwice(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -89,6 +93,8 @@ func TestCreateCollectionWithTextEmbeddingTwice(t *testing.T) {
 
 // TestCreateCollectionUnsupportedEndpoint tests creation with unsupported endpoint
 func TestCreateCollectionUnsupportedEndpoint(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -115,6 +121,8 @@ func TestCreateCollectionUnsupportedEndpoint(t *testing.T) {
 
 // TestCreateCollectionUnmatchedDim tests creation with mismatched dimension
 func TestCreateCollectionUnmatchedDim(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -145,6 +153,8 @@ func TestCreateCollectionUnmatchedDim(t *testing.T) {
 
 // TestInsertWithTextEmbedding tests basic data insertion with text embedding
 func TestInsertWithTextEmbedding(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -183,6 +193,8 @@ func TestInsertWithTextEmbedding(t *testing.T) {
 
 // TestInsertWithTruncateParams tests insertion with different truncate parameters
 func TestInsertWithTruncateParams(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name                string
 		truncate            bool
@@ -317,6 +329,8 @@ func TestInsertWithTruncateParams(t *testing.T) {
 
 // TestVerifyEmbeddingConsistency verifies that Milvus text embedding function produces same results as direct TEI calls
 func TestVerifyEmbeddingConsistency(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -411,6 +425,8 @@ func TestVerifyEmbeddingConsistency(t *testing.T) {
 
 // TestUpsertTextFieldUpdatesEmbedding tests that upserting text field updates embedding
 func TestUpsertTextFieldUpdatesEmbedding(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -508,6 +524,8 @@ func TestUpsertTextFieldUpdatesEmbedding(t *testing.T) {
 
 // TestDeleteAndSearch tests that deleted text cannot be searched
 func TestDeleteAndSearch(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -569,6 +587,8 @@ func TestDeleteAndSearch(t *testing.T) {
 
 // TestSearchWithTextEmbedding tests search functionality with text embedding
 func TestSearchWithTextEmbedding(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -613,6 +633,8 @@ func TestSearchWithTextEmbedding(t *testing.T) {
 
 // TestSearchWithEmptyQuery tests search with empty query (should fail)
 func TestSearchWithEmptyQuery(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -641,6 +663,8 @@ func TestSearchWithEmptyQuery(t *testing.T) {
 
 // TestHybridSearchTextEmbeddingBM25 tests hybrid search combining TEI text embedding and BM25
 func TestHybridSearchTextEmbeddingBM25(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -774,6 +798,8 @@ func TestHybridSearchTextEmbeddingBM25(t *testing.T) {
 
 // TestInsertEmptyDocument tests insertion with empty document
 func TestInsertEmptyDocument(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -791,6 +817,8 @@ func TestInsertEmptyDocument(t *testing.T) {
 
 // TestInsertLongDocument tests insertion with very long document
 func TestInsertLongDocument(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -824,6 +852,8 @@ func TestInsertLongDocument(t *testing.T) {
 
 // TestInvalidEndpointHandling tests various invalid endpoint scenarios
 func TestInvalidEndpointHandling(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name     string
 		endpoint string
@@ -866,6 +896,8 @@ func TestInvalidEndpointHandling(t *testing.T) {
 
 // TestMissingRequiredParameters tests creation with missing required parameters
 func TestMissingRequiredParameters(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -909,6 +941,8 @@ func TestMissingRequiredParameters(t *testing.T) {
 
 // TestConcurrentOperations tests concurrent text embedding operations
 func TestConcurrentOperations(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout*2) // longer timeout for concurrent ops
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 

--- a/tests/go_client/testcases/update_test.go
+++ b/tests/go_client/testcases/update_test.go
@@ -17,6 +17,8 @@ import (
 )
 
 func TestUpdatePartialFields(t *testing.T) {
+	t.Parallel()
+
 	/*
 		1. prepare create -> insert -> index -> load -> query
 		2. partial update existing entities -> data updated -> query and verify
@@ -65,6 +67,8 @@ func TestUpdatePartialFields(t *testing.T) {
 }
 
 func TestPartialUpdateDynamicField(t *testing.T) {
+	t.Parallel()
+
 	// enable dynamic field and perform partial update operations on dynamic columns
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -126,6 +130,8 @@ func TestPartialUpdateDynamicField(t *testing.T) {
 }
 
 func TestPartialUpdateDynamicSchemaStaticOnly(t *testing.T) {
+	t.Parallel()
+
 	/*
 		Test partial upsert with dynamic schema enabled but data contains ONLY static fields:
 		1. Create collection with enable_dynamic_field=true, schema has id + vector + name(nullable)
@@ -230,6 +236,8 @@ func TestPartialUpdateDynamicSchemaStaticOnly(t *testing.T) {
 }
 
 func TestPartialUpdateDynamicSchemaWithDynamicFields(t *testing.T) {
+	t.Parallel()
+
 	/*
 		Test partial upsert with dynamic schema enabled AND user-provided dynamic fields:
 		1. Create collection with enable_dynamic_field=true, schema has id + vector + name(nullable)
@@ -355,6 +363,8 @@ func TestPartialUpdateDynamicSchemaWithDynamicFields(t *testing.T) {
 }
 
 func TestUpdateNullableFieldBehavior(t *testing.T) {
+	t.Parallel()
+
 	/*
 		Test nullable field behavior for Update operation:
 		1. Insert data with nullable field having a value
@@ -435,6 +445,8 @@ func TestUpdateNullableFieldBehavior(t *testing.T) {
 }
 
 func TestUpdateDefaultValueFieldBehavior(t *testing.T) {
+	t.Parallel()
+
 	/*
 		Test default value field behavior for Update operation:
 		1. Insert data with a non-nullable default-value field having explicit values
@@ -511,6 +523,8 @@ func TestUpdateDefaultValueFieldBehavior(t *testing.T) {
 }
 
 func TestPartialUpdateEmptyStringDefaultValue(t *testing.T) {
+	t.Parallel()
+
 	/*
 		Test partial update on a non-nullable field with empty string as default value:
 		1. Create collection with non-nullable varchar field, defaultValue=""
@@ -609,6 +623,8 @@ func TestPartialUpdateEmptyStringDefaultValue(t *testing.T) {
 }
 
 func TestUpsertDefaultValueWithCompressedValidData(t *testing.T) {
+	t.Parallel()
+
 	/*
 		Test upsert with compressed ValidData for a field with defaultValue.
 		This covers the upsert path (task_upsert.go queryPreExecute) where

--- a/tests/go_client/testcases/upsert_test.go
+++ b/tests/go_client/testcases/upsert_test.go
@@ -254,6 +254,8 @@ func TestUpsertSparse(t *testing.T) {
 }
 
 func TestUpsertVarcharPk(t *testing.T) {
+	t.Parallel()
+
 	/*
 		test upsert varchar pks
 		upsert after query
@@ -308,6 +310,8 @@ func TestUpsertVarcharPk(t *testing.T) {
 
 // test upsert with partition
 func TestUpsertMultiPartitions(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 	prepare, schema := hp.CollPrepare.CreateCollection(ctx, t, mc, hp.NewCreateCollectionParams(hp.AllFields), hp.TNewFieldsOption(), hp.TNewSchemaOption().TWithEnableDynamicField(true))
@@ -344,6 +348,8 @@ func TestUpsertMultiPartitions(t *testing.T) {
 }
 
 func TestUpsertSamePksManyTimes(t *testing.T) {
+	t.Parallel()
+
 	// upsert pks [0, 1000) many times with different vector
 	// query -> gets last upsert entities
 
@@ -385,6 +391,8 @@ func TestUpsertSamePksManyTimes(t *testing.T) {
 
 // test upsert autoId collection
 func TestUpsertAutoID(t *testing.T) {
+	t.Parallel()
+
 	/*
 		prepare autoID collection
 		upsert not exist pk -> error
@@ -441,6 +449,8 @@ func TestUpsertAutoID(t *testing.T) {
 
 // test upsert autoId collection
 func TestUpsertAutoIDRows(t *testing.T) {
+	t.Parallel()
+
 	t.Skip("https://github.com/milvus-io/milvus/issues/40816")
 	/*
 		prepare autoID collection
@@ -512,6 +522,8 @@ func TestUpsertAutoIDRows(t *testing.T) {
 
 // test upsert with invalid collection / partition name
 func TestUpsertNotExistCollectionPartition(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -534,6 +546,8 @@ func TestUpsertNotExistCollectionPartition(t *testing.T) {
 
 // test upsert with invalid column data
 func TestUpsertInvalidColumnData(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -584,6 +598,8 @@ func TestUpsertInvalidColumnData(t *testing.T) {
 }
 
 func TestUpsertDynamicField(t *testing.T) {
+	t.Parallel()
+
 	// enable dynamic field and insert dynamic column
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -626,6 +642,8 @@ func TestUpsertDynamicField(t *testing.T) {
 }
 
 func TestUpsertWithoutLoading(t *testing.T) {
+	t.Parallel()
+
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
@@ -652,10 +670,14 @@ func TestUpsertWithoutLoading(t *testing.T) {
 }
 
 func TestUpsertPartitionKeyCollection(t *testing.T) {
+	t.Parallel()
+
 	t.Skip("waiting gen partition key field")
 }
 
 func TestUpsertNullableFieldBehavior(t *testing.T) {
+	t.Parallel()
+
 	/*
 		Test nullable field behavior for Upsert operation:
 		1. Insert data with nullable field having a value


### PR DESCRIPTION
Cherry-pick from master
pr: #49138
issue: #49135

## Summary

Cherry-pick of #49138 to branch 3.0.

- Add `t.Parallel()` to top-level tests in `tests/go_client/testcases/` that weren't already parallel. The batch add is function-body aware — it scans each test's body first and skips any test that already has a `t.Parallel()` call (e.g. after a leading comment block), so we don't hit `t.Parallel called multiple times` panics.
- Refactor `TestNullableVectorDifferentIndexTypes` to fan out its 52 sub-cases via a goroutine + semaphore pattern (concurrency=10), matching the existing idiom in `groupby_search_test.go`.
- `advcases/` tests are intentionally **not** parallelized — per the go_client README, the `rg`-tagged tests require `-p=1` due to resource-group global state.

## Test plan

- [ ] Full `go_client` CI suite runs green on this branch
- [ ] No `t.Parallel called multiple times` panics
- [ ] No race-condition failures from shared state between tests
- [ ] Suite wall-clock time in CI drops meaningfully vs prior baseline