### PR TITLE
enhance: lazy offset mapping for nullable vector columns

### DIFF
--- a/internal/core/src/common/OffsetMapping.cpp
+++ b/internal/core/src/common/OffsetMapping.cpp
@@ -6,10 +6,9 @@
 namespace milvus {
 
 void
-OffsetMapping::Build(const bool* valid_data,
-                     int64_t total_count,
-                     int64_t start_logical,
-                     int64_t start_physical) {
+OffsetMapping::Build(const bool* valid_data, int64_t total_count) {
+    constexpr int64_t start_logical = 0;
+    constexpr int64_t start_physical = 0;
     if (total_count == 0 || valid_data == nullptr) {
         return;
     }
@@ -17,6 +16,12 @@ OffsetMapping::Build(const bool* valid_data,
     std::unique_lock<std::shared_mutex> lck(mutex_);
     enabled_ = true;
     total_count_ = start_logical + total_count;
+    chunk_built_.clear();
+    valid_count_ = 0;
+    l2p_vec_.clear();
+    p2l_vec_.clear();
+    l2p_map_.clear();
+    p2l_map_.clear();
 
     // Count valid elements first
     int64_t valid_count = 0;
@@ -64,14 +69,14 @@ OffsetMapping::Build(const bool* valid_data,
         }
     }
 
-    valid_count_ += valid_count;
+    valid_count_ = valid_count;
 }
 
 void
-OffsetMapping::BuildIncremental(const bool* valid_data,
-                                int64_t count,
-                                int64_t start_logical,
-                                int64_t start_physical) {
+OffsetMapping::Append(const bool* valid_data,
+                      int64_t count,
+                      int64_t start_logical,
+                      int64_t start_physical) {
     if (count == 0 || valid_data == nullptr) {
         return;
     }
@@ -130,6 +135,76 @@ OffsetMapping::BuildIncremental(const bool* valid_data,
     }
 }
 
+void
+OffsetMapping::Reserve(int64_t total_count,
+                       int64_t valid_count,
+                       size_t num_chunks) {
+    std::unique_lock<std::shared_mutex> lck(mutex_);
+    enabled_ = true;
+    total_count_ = total_count;
+    valid_count_ = valid_count;
+    use_map_ = (valid_count * 10 < total_count);
+    chunk_built_.assign(num_chunks, 0);
+    l2p_map_.clear();
+    p2l_map_.clear();
+    if (use_map_) {
+        l2p_vec_.clear();
+        p2l_vec_.clear();
+    } else {
+        l2p_vec_.assign(total_count, -1);
+        p2l_vec_.assign(valid_count, -1);
+    }
+}
+
+void
+OffsetMapping::SetChunk(int64_t chunk_id,
+                        int64_t start_logical,
+                        int64_t start_physical,
+                        const bool* valid_data,
+                        int64_t count) {
+    if (count == 0 || valid_data == nullptr) {
+        return;
+    }
+    std::unique_lock<std::shared_mutex> lck(mutex_);
+    if (chunk_id >= 0 && chunk_id < static_cast<int64_t>(chunk_built_.size()) &&
+        chunk_built_[chunk_id]) {
+        return;
+    }
+    int64_t physical_idx = start_physical;
+    if (use_map_) {
+        for (int64_t i = 0; i < count; ++i) {
+            if (valid_data[i]) {
+                l2p_map_[static_cast<int32_t>(start_logical + i)] =
+                    static_cast<int32_t>(physical_idx);
+                p2l_map_[static_cast<int32_t>(physical_idx)] =
+                    static_cast<int32_t>(start_logical + i);
+                physical_idx++;
+            }
+        }
+    } else {
+        for (int64_t i = 0; i < count; ++i) {
+            if (valid_data[i]) {
+                l2p_vec_[start_logical + i] =
+                    static_cast<int32_t>(physical_idx);
+                p2l_vec_[physical_idx] =
+                    static_cast<int32_t>(start_logical + i);
+                physical_idx++;
+            }
+        }
+    }
+    if (chunk_id >= 0 && chunk_id < static_cast<int64_t>(chunk_built_.size())) {
+        chunk_built_[chunk_id] = 1;
+    }
+}
+
+bool
+OffsetMapping::IsChunkSet(int64_t chunk_id) const {
+    std::shared_lock<std::shared_mutex> lck(mutex_);
+    return chunk_id >= 0 &&
+           chunk_id < static_cast<int64_t>(chunk_built_.size()) &&
+           chunk_built_[chunk_id] != 0;
+}
+
 int64_t
 OffsetMapping::GetPhysicalOffset(int64_t logical_offset) const {
     std::shared_lock<std::shared_mutex> lck(mutex_);
@@ -183,12 +258,6 @@ bool
 OffsetMapping::IsEnabled() const {
     std::shared_lock<std::shared_mutex> lck(mutex_);
     return enabled_;
-}
-
-int64_t
-OffsetMapping::GetNextPhysicalOffset() const {
-    std::shared_lock<std::shared_mutex> lck(mutex_);
-    return valid_count_;
 }
 
 int64_t

--- a/internal/core/src/common/OffsetMapping.h
+++ b/internal/core/src/common/OffsetMapping.h
@@ -35,17 +35,29 @@ class OffsetMapping {
     // Build mapping from valid_data (bool array format)
     // If use_vec is not specified, auto-select based on valid ratio (< 10% uses map)
     void
-    Build(const bool* valid_data,
-          int64_t total_count,
-          int64_t start_logical = 0,
-          int64_t start_physical = 0);
+    Build(const bool* valid_data, int64_t total_count);
 
     // Build mapping incrementally (always uses vec mode for incremental builds)
     void
-    BuildIncremental(const bool* valid_data,
-                     int64_t count,
-                     int64_t start_logical,
-                     int64_t start_physical);
+    Append(const bool* valid_data,
+           int64_t count,
+           int64_t start_logical,
+           int64_t start_physical);
+
+    // Allocate shape and lock storage mode without filling per-row entries.
+    void
+    Reserve(int64_t total_count, int64_t valid_count, size_t num_chunks);
+
+    // Idempotent and safe for concurrent calls on distinct chunks.
+    void
+    SetChunk(int64_t chunk_id,
+             int64_t start_logical,
+             int64_t start_physical,
+             const bool* valid_data,
+             int64_t count);
+
+    bool
+    IsChunkSet(int64_t chunk_id) const;
 
     // Get physical offset from logical offset. Returns -1 if null.
     int64_t
@@ -67,10 +79,6 @@ class OffsetMapping {
     bool
     IsEnabled() const;
 
-    // Get next physical offset (for incremental builds)
-    int64_t
-    GetNextPhysicalOffset() const;
-
     // Get total logical count (including nulls)
     int64_t
     GetTotalCount() const;
@@ -86,6 +94,8 @@ class OffsetMapping {
     // Map mode storage (for sparse valid data)
     std::unordered_map<int32_t, int32_t> l2p_map_;  // logical -> physical
     std::unordered_map<int32_t, int32_t> p2l_map_;  // physical -> logical
+
+    std::vector<uint8_t> chunk_built_;
 
     int64_t valid_count_{0};
     int64_t total_count_{0};  // total logical count (including nulls)

--- a/internal/core/src/common/OffsetMappingTest.cpp
+++ b/internal/core/src/common/OffsetMappingTest.cpp
@@ -1,0 +1,418 @@
+// Copyright (C) 2019-2026 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <thread>
+#include <vector>
+
+#include "common/OffsetMapping.h"
+
+namespace milvus {
+
+namespace {
+std::vector<bool>
+MakeValid(std::initializer_list<int> bits) {
+    std::vector<bool> v;
+    v.reserve(bits.size());
+    for (int b : bits) {
+        v.push_back(b != 0);
+    }
+    return v;
+}
+
+std::vector<uint8_t>
+ToBoolBytes(const std::vector<bool>& valid) {
+    std::vector<uint8_t> bytes(valid.size());
+    for (size_t i = 0; i < valid.size(); ++i) {
+        bytes[i] = valid[i] ? 1 : 0;
+    }
+    return bytes;
+}
+}  // namespace
+
+// ---------- Default (disabled) state ----------
+
+TEST(OffsetMapping, DefaultIsDisabledAndPassThrough) {
+    OffsetMapping mapping;
+    EXPECT_FALSE(mapping.IsEnabled());
+    EXPECT_EQ(mapping.GetValidCount(), 0);
+    EXPECT_EQ(mapping.GetTotalCount(), 0);
+    // When disabled, offset queries must pass through unchanged.
+    EXPECT_EQ(mapping.GetPhysicalOffset(42), 42);
+    EXPECT_EQ(mapping.GetLogicalOffset(42), 42);
+}
+
+// ---------- Reserve ----------
+
+TEST(OffsetMapping, ReserveReflectsTotalCounts) {
+    OffsetMapping mapping;
+    mapping.Reserve(10, 8, 2);
+    EXPECT_TRUE(mapping.IsEnabled());
+    EXPECT_EQ(mapping.GetTotalCount(), 10);
+    EXPECT_EQ(mapping.GetValidCount(), 8);
+    EXPECT_FALSE(mapping.IsChunkSet(0));
+    EXPECT_FALSE(mapping.IsChunkSet(1));
+}
+
+TEST(OffsetMapping, ReserveAllValid) {
+    OffsetMapping mapping;
+    mapping.Reserve(5, 5, 1);
+    EXPECT_EQ(mapping.GetValidCount(), 5);
+    EXPECT_EQ(mapping.GetTotalCount(), 5);
+}
+
+TEST(OffsetMapping, ReserveAllNull) {
+    OffsetMapping mapping;
+    mapping.Reserve(5, 0, 1);
+    EXPECT_TRUE(mapping.IsEnabled());
+    EXPECT_EQ(mapping.GetValidCount(), 0);
+    EXPECT_EQ(mapping.GetTotalCount(), 5);
+}
+
+// ---------- Build (eager) ----------
+
+TEST(OffsetMapping, BuildBasicVecMode) {
+    OffsetMapping mapping;
+    auto valid = ToBoolBytes(MakeValid({1, 0, 1, 1, 0}));
+    mapping.Build(reinterpret_cast<const bool*>(valid.data()), 5);
+
+    EXPECT_TRUE(mapping.IsEnabled());
+    EXPECT_EQ(mapping.GetTotalCount(), 5);
+    EXPECT_EQ(mapping.GetValidCount(), 3);
+    EXPECT_EQ(mapping.GetPhysicalOffset(0), 0);
+    EXPECT_EQ(mapping.GetPhysicalOffset(1), -1);
+    EXPECT_EQ(mapping.GetPhysicalOffset(2), 1);
+    EXPECT_EQ(mapping.GetPhysicalOffset(3), 2);
+    EXPECT_EQ(mapping.GetPhysicalOffset(4), -1);
+    EXPECT_EQ(mapping.GetLogicalOffset(0), 0);
+    EXPECT_EQ(mapping.GetLogicalOffset(1), 2);
+    EXPECT_EQ(mapping.GetLogicalOffset(2), 3);
+}
+
+TEST(OffsetMapping, BuildMapModeOnSparse) {
+    OffsetMapping mapping;
+    std::vector<uint8_t> valid(100, 0);
+    valid[5] = 1;
+    valid[50] = 1;
+    mapping.Build(reinterpret_cast<const bool*>(valid.data()), 100);
+
+    EXPECT_EQ(mapping.GetTotalCount(), 100);
+    EXPECT_EQ(mapping.GetValidCount(), 2);
+    EXPECT_EQ(mapping.GetPhysicalOffset(5), 0);
+    EXPECT_EQ(mapping.GetPhysicalOffset(50), 1);
+    EXPECT_EQ(mapping.GetPhysicalOffset(0), -1);
+    EXPECT_EQ(mapping.GetLogicalOffset(0), 5);
+    EXPECT_EQ(mapping.GetLogicalOffset(1), 50);
+}
+
+TEST(OffsetMapping, BuildAllValid) {
+    OffsetMapping mapping;
+    std::vector<uint8_t> valid(4, 1);
+    mapping.Build(reinterpret_cast<const bool*>(valid.data()), 4);
+    EXPECT_EQ(mapping.GetValidCount(), 4);
+    for (int64_t i = 0; i < 4; ++i) {
+        EXPECT_EQ(mapping.GetPhysicalOffset(i), i);
+        EXPECT_EQ(mapping.GetLogicalOffset(i), i);
+    }
+}
+
+TEST(OffsetMapping, BuildAllNull) {
+    OffsetMapping mapping;
+    std::vector<uint8_t> valid(4, 0);
+    mapping.Build(reinterpret_cast<const bool*>(valid.data()), 4);
+    EXPECT_TRUE(mapping.IsEnabled());
+    EXPECT_EQ(mapping.GetValidCount(), 0);
+    EXPECT_EQ(mapping.GetTotalCount(), 4);
+    for (int64_t i = 0; i < 4; ++i) {
+        EXPECT_EQ(mapping.GetPhysicalOffset(i), -1);
+    }
+}
+
+TEST(OffsetMapping, BuildNoopOnNullOrZero) {
+    OffsetMapping mapping;
+    mapping.Build(nullptr, 100);
+    EXPECT_FALSE(mapping.IsEnabled());
+    std::vector<uint8_t> valid(1, 1);
+    mapping.Build(reinterpret_cast<const bool*>(valid.data()), 0);
+    EXPECT_FALSE(mapping.IsEnabled());
+}
+
+TEST(OffsetMapping, BuildTwiceResetsState) {
+    OffsetMapping mapping;
+    auto v1 = ToBoolBytes(MakeValid({1, 1, 0, 0, 1}));
+    mapping.Build(reinterpret_cast<const bool*>(v1.data()), 5);
+    EXPECT_EQ(mapping.GetValidCount(), 3);
+    EXPECT_EQ(mapping.GetTotalCount(), 5);
+
+    auto v2 = ToBoolBytes(MakeValid({1, 0, 0}));
+    mapping.Build(reinterpret_cast<const bool*>(v2.data()), 3);
+    EXPECT_EQ(mapping.GetValidCount(), 1);
+    EXPECT_EQ(mapping.GetTotalCount(), 3);
+    EXPECT_EQ(mapping.GetPhysicalOffset(0), 0);
+    EXPECT_EQ(mapping.GetPhysicalOffset(1), -1);
+    EXPECT_EQ(mapping.GetPhysicalOffset(2), -1);
+}
+
+// Regression: Reserve followed by Build must not double-count valid_count.
+TEST(OffsetMapping, ReserveThenBuildDoesNotDouble) {
+    OffsetMapping mapping;
+    mapping.Reserve(10, 6, 2);
+    EXPECT_EQ(mapping.GetValidCount(), 6);
+
+    auto valid = ToBoolBytes(MakeValid({1, 1, 0, 0, 1, 0, 1, 1, 0, 1}));
+    mapping.Build(reinterpret_cast<const bool*>(valid.data()), 10);
+
+    EXPECT_EQ(mapping.GetValidCount(), 6);
+    EXPECT_EQ(mapping.GetTotalCount(), 10);
+}
+
+// ---------- SetChunk ----------
+
+TEST(OffsetMapping, SetChunkVecModeSingleChunk) {
+    OffsetMapping mapping;
+    mapping.Reserve(5, 3, 1);
+    auto valid = ToBoolBytes(MakeValid({1, 0, 1, 0, 1}));
+    mapping.SetChunk(0, 0, 0, reinterpret_cast<const bool*>(valid.data()), 5);
+
+    EXPECT_TRUE(mapping.IsChunkSet(0));
+    EXPECT_EQ(mapping.GetValidCount(), 3);
+    EXPECT_EQ(mapping.GetPhysicalOffset(0), 0);
+    EXPECT_EQ(mapping.GetPhysicalOffset(1), -1);
+    EXPECT_EQ(mapping.GetPhysicalOffset(2), 1);
+    EXPECT_EQ(mapping.GetPhysicalOffset(3), -1);
+    EXPECT_EQ(mapping.GetPhysicalOffset(4), 2);
+    EXPECT_EQ(mapping.GetLogicalOffset(0), 0);
+    EXPECT_EQ(mapping.GetLogicalOffset(1), 2);
+    EXPECT_EQ(mapping.GetLogicalOffset(2), 4);
+}
+
+TEST(OffsetMapping, SetChunkVecModeMultipleChunksInOrder) {
+    OffsetMapping mapping;
+    mapping.Reserve(10, 6, 2);
+
+    auto c0 = ToBoolBytes(MakeValid({1, 1, 0, 0, 1}));
+    auto c1 = ToBoolBytes(MakeValid({0, 1, 1, 0, 1}));
+
+    mapping.SetChunk(0, 0, 0, reinterpret_cast<const bool*>(c0.data()), 5);
+    mapping.SetChunk(1, 5, 3, reinterpret_cast<const bool*>(c1.data()), 5);
+
+    EXPECT_TRUE(mapping.IsChunkSet(0));
+    EXPECT_TRUE(mapping.IsChunkSet(1));
+    EXPECT_EQ(mapping.GetValidCount(), 6);
+
+    EXPECT_EQ(mapping.GetPhysicalOffset(0), 0);
+    EXPECT_EQ(mapping.GetPhysicalOffset(1), 1);
+    EXPECT_EQ(mapping.GetPhysicalOffset(2), -1);
+    EXPECT_EQ(mapping.GetPhysicalOffset(4), 2);
+    EXPECT_EQ(mapping.GetPhysicalOffset(5), -1);
+    EXPECT_EQ(mapping.GetPhysicalOffset(6), 3);
+    EXPECT_EQ(mapping.GetPhysicalOffset(7), 4);
+    EXPECT_EQ(mapping.GetPhysicalOffset(9), 5);
+    for (int64_t p = 0; p < 6; ++p) {
+        auto l = mapping.GetLogicalOffset(p);
+        EXPECT_GE(l, 0);
+        EXPECT_EQ(mapping.GetPhysicalOffset(l), p);
+    }
+}
+
+TEST(OffsetMapping, SetChunkVecModeOutOfOrder) {
+    OffsetMapping mapping;
+    mapping.Reserve(10, 6, 2);
+
+    auto c0 = ToBoolBytes(MakeValid({1, 1, 0, 0, 1}));
+    auto c1 = ToBoolBytes(MakeValid({0, 1, 1, 0, 1}));
+
+    mapping.SetChunk(1, 5, 3, reinterpret_cast<const bool*>(c1.data()), 5);
+    EXPECT_FALSE(mapping.IsChunkSet(0));
+    EXPECT_EQ(mapping.GetPhysicalOffset(6), 3);
+    EXPECT_EQ(mapping.GetLogicalOffset(3), 6);
+
+    mapping.SetChunk(0, 0, 0, reinterpret_cast<const bool*>(c0.data()), 5);
+    EXPECT_TRUE(mapping.IsChunkSet(0));
+    EXPECT_EQ(mapping.GetPhysicalOffset(0), 0);
+    EXPECT_EQ(mapping.GetLogicalOffset(0), 0);
+    EXPECT_EQ(mapping.GetValidCount(), 6);
+}
+
+TEST(OffsetMapping, SetChunkMapMode) {
+    OffsetMapping mapping;
+    mapping.Reserve(100, 2, 2);
+
+    std::vector<uint8_t> c0(50, 0);
+    c0[10] = 1;
+    std::vector<uint8_t> c1(50, 0);
+    c1[20] = 1;
+
+    mapping.SetChunk(0, 0, 0, reinterpret_cast<const bool*>(c0.data()), 50);
+    mapping.SetChunk(1, 50, 1, reinterpret_cast<const bool*>(c1.data()), 50);
+
+    EXPECT_TRUE(mapping.IsChunkSet(0));
+    EXPECT_TRUE(mapping.IsChunkSet(1));
+    EXPECT_EQ(mapping.GetValidCount(), 2);
+    EXPECT_EQ(mapping.GetPhysicalOffset(10), 0);
+    EXPECT_EQ(mapping.GetPhysicalOffset(70), 1);
+    EXPECT_EQ(mapping.GetPhysicalOffset(0), -1);
+    EXPECT_EQ(mapping.GetLogicalOffset(0), 10);
+    EXPECT_EQ(mapping.GetLogicalOffset(1), 70);
+}
+
+TEST(OffsetMapping, SetChunkIdempotent) {
+    OffsetMapping mapping;
+    mapping.Reserve(5, 3, 1);
+    auto valid = ToBoolBytes(MakeValid({1, 0, 1, 0, 1}));
+    mapping.SetChunk(0, 0, 0, reinterpret_cast<const bool*>(valid.data()), 5);
+    auto before = mapping.GetValidCount();
+    mapping.SetChunk(0, 0, 0, reinterpret_cast<const bool*>(valid.data()), 5);
+    EXPECT_EQ(mapping.GetValidCount(), before);
+    EXPECT_EQ(mapping.GetPhysicalOffset(0), 0);
+    EXPECT_EQ(mapping.GetPhysicalOffset(2), 1);
+    EXPECT_EQ(mapping.GetPhysicalOffset(4), 2);
+}
+
+TEST(OffsetMapping, ConcurrentSetChunkDifferentChunks) {
+    OffsetMapping mapping;
+    constexpr int kChunks = 8;
+    constexpr int kRowsPerChunk = 32;
+    constexpr int kTotal = kChunks * kRowsPerChunk;
+    mapping.Reserve(kTotal, kTotal / 2, kChunks);
+
+    std::vector<std::vector<uint8_t>> valids(
+        kChunks, std::vector<uint8_t>(kRowsPerChunk));
+    for (int c = 0; c < kChunks; ++c) {
+        for (int r = 0; r < kRowsPerChunk; ++r) {
+            valids[c][r] = (r % 2 == 0) ? 1 : 0;
+        }
+    }
+
+    std::vector<std::thread> threads;
+    threads.reserve(kChunks);
+    for (int c = 0; c < kChunks; ++c) {
+        threads.emplace_back([&, c] {
+            int64_t start_logical = c * kRowsPerChunk;
+            int64_t start_physical = c * (kRowsPerChunk / 2);
+            mapping.SetChunk(c,
+                             start_logical,
+                             start_physical,
+                             reinterpret_cast<const bool*>(valids[c].data()),
+                             kRowsPerChunk);
+        });
+    }
+    for (auto& t : threads) t.join();
+
+    EXPECT_EQ(mapping.GetValidCount(), kTotal / 2);
+    for (int c = 0; c < kChunks; ++c) {
+        EXPECT_TRUE(mapping.IsChunkSet(c));
+    }
+    for (int logical = 0; logical < kTotal; ++logical) {
+        bool expect_valid = (logical % 2 == 0);
+        int64_t phys = mapping.GetPhysicalOffset(logical);
+        if (expect_valid) {
+            EXPECT_GE(phys, 0) << "logical=" << logical;
+            EXPECT_EQ(mapping.GetLogicalOffset(phys), logical);
+        } else {
+            EXPECT_EQ(phys, -1) << "logical=" << logical;
+        }
+    }
+}
+
+// ---------- Append ----------
+
+TEST(OffsetMapping, AppendBasic) {
+    OffsetMapping mapping;
+    auto v = ToBoolBytes(MakeValid({1, 0, 1, 1}));
+    mapping.Append(reinterpret_cast<const bool*>(v.data()), 4, 0, 0);
+
+    EXPECT_TRUE(mapping.IsEnabled());
+    EXPECT_EQ(mapping.GetValidCount(), 3);
+    EXPECT_EQ(mapping.GetTotalCount(), 4);
+    EXPECT_EQ(mapping.GetPhysicalOffset(0), 0);
+    EXPECT_EQ(mapping.GetPhysicalOffset(2), 1);
+    EXPECT_EQ(mapping.GetPhysicalOffset(3), 2);
+}
+
+TEST(OffsetMapping, AppendMultipleBatches) {
+    OffsetMapping mapping;
+    auto b1 = ToBoolBytes(MakeValid({1, 0, 1}));
+    mapping.Append(reinterpret_cast<const bool*>(b1.data()), 3, 0, 0);
+    EXPECT_EQ(mapping.GetValidCount(), 2);
+    EXPECT_EQ(mapping.GetTotalCount(), 3);
+
+    auto b2 = ToBoolBytes(MakeValid({0, 1, 1}));
+    mapping.Append(reinterpret_cast<const bool*>(b2.data()),
+                   3,
+                   mapping.GetTotalCount(),
+                   mapping.GetValidCount());
+    EXPECT_EQ(mapping.GetValidCount(), 4);
+    EXPECT_EQ(mapping.GetTotalCount(), 6);
+
+    EXPECT_EQ(mapping.GetPhysicalOffset(0), 0);
+    EXPECT_EQ(mapping.GetPhysicalOffset(2), 1);
+    EXPECT_EQ(mapping.GetPhysicalOffset(4), 2);
+    EXPECT_EQ(mapping.GetPhysicalOffset(5), 3);
+    EXPECT_EQ(mapping.GetLogicalOffset(3), 5);
+}
+
+TEST(OffsetMapping, AppendConvertsMapModeToVec) {
+    OffsetMapping mapping;
+    std::vector<uint8_t> sparse(100, 0);
+    sparse[7] = 1;
+    mapping.Build(reinterpret_cast<const bool*>(sparse.data()), 100);
+    EXPECT_EQ(mapping.GetValidCount(), 1);
+
+    auto b = ToBoolBytes(MakeValid({1, 1, 0}));
+    mapping.Append(reinterpret_cast<const bool*>(b.data()),
+                   3,
+                   mapping.GetTotalCount(),
+                   mapping.GetValidCount());
+
+    EXPECT_EQ(mapping.GetValidCount(), 3);
+    EXPECT_EQ(mapping.GetTotalCount(), 103);
+    EXPECT_EQ(mapping.GetPhysicalOffset(7), 0);
+    EXPECT_EQ(mapping.GetPhysicalOffset(100), 1);
+    EXPECT_EQ(mapping.GetPhysicalOffset(101), 2);
+    EXPECT_EQ(mapping.GetLogicalOffset(0), 7);
+    EXPECT_EQ(mapping.GetLogicalOffset(2), 101);
+}
+
+TEST(OffsetMapping, AppendNoopOnNullOrZero) {
+    OffsetMapping mapping;
+    mapping.Append(nullptr, 3, 0, 0);
+    EXPECT_FALSE(mapping.IsEnabled());
+    std::vector<uint8_t> v(1, 1);
+    mapping.Append(reinterpret_cast<const bool*>(v.data()), 0, 0, 0);
+    EXPECT_FALSE(mapping.IsEnabled());
+}
+
+// ---------- IsValid ----------
+
+TEST(OffsetMapping, IsValidMatchesPhysicalOffsetSign) {
+    OffsetMapping mapping;
+    auto v = ToBoolBytes(MakeValid({1, 0, 1, 0}));
+    mapping.Build(reinterpret_cast<const bool*>(v.data()), 4);
+    EXPECT_TRUE(mapping.IsValid(0));
+    EXPECT_FALSE(mapping.IsValid(1));
+    EXPECT_TRUE(mapping.IsValid(2));
+    EXPECT_FALSE(mapping.IsValid(3));
+}
+
+// ---------- Out-of-bounds queries ----------
+
+TEST(OffsetMapping, OutOfBoundsReturnsMinusOne) {
+    OffsetMapping mapping;
+    auto v = ToBoolBytes(MakeValid({1, 0, 1}));
+    mapping.Build(reinterpret_cast<const bool*>(v.data()), 3);
+    EXPECT_EQ(mapping.GetPhysicalOffset(99), -1);
+    EXPECT_EQ(mapping.GetLogicalOffset(99), -1);
+}
+
+}  // namespace milvus

--- a/internal/core/src/index/VectorIndex.h
+++ b/internal/core/src/index/VectorIndex.h
@@ -152,11 +152,10 @@ class VectorIndex : public IndexBase {
 
     void
     UpdateValidData(const bool* valid_data, int64_t count) {
-        offset_mapping_.BuildIncremental(
-            valid_data,
-            count,
-            offset_mapping_.GetTotalCount(),
-            offset_mapping_.GetNextPhysicalOffset());
+        offset_mapping_.Append(valid_data,
+                               count,
+                               offset_mapping_.GetTotalCount(),
+                               offset_mapping_.GetValidCount());
     }
 
     void

--- a/internal/core/src/mmap/ChunkedColumn.h
+++ b/internal/core/src/mmap/ChunkedColumn.h
@@ -376,50 +376,6 @@ class ChunkedColumnBase : public ChunkedColumnInterface {
         return meta->num_rows_until_chunk_;
     }
 
-    const std::vector<int64_t>&
-    GetNumValidRowsUntilChunk() const override {
-        if (!num_valid_rows_until_chunk_.empty()) {
-            return num_valid_rows_until_chunk_;
-        }
-        return GetNumRowsUntilChunk();
-    }
-
-    void
-    BuildValidRowIds(milvus::OpContext* op_ctx) override {
-        if (!nullable_) {
-            return;
-        }
-        auto ca = SemiInlineGet(slot_->PinAllCells(op_ctx));
-        int64_t logical_offset = 0;
-        valid_data_.resize(num_rows_);
-        valid_count_per_chunk_.resize(num_chunks_);
-        for (size_t i = 0; i < num_chunks_; i++) {
-            auto chunk = ca->get_cell_of(i);
-            auto rows = chunk_row_nums(i);
-            int64_t valid_count = 0;
-            for (int64_t j = 0; j < rows; j++) {
-                if (chunk->isValid(j)) {
-                    valid_data_[logical_offset + j] = true;
-                    valid_count++;
-                } else {
-                    valid_data_[logical_offset + j] = false;
-                }
-            }
-            valid_count_per_chunk_[i] = valid_count;
-            logical_offset += rows;
-        }
-
-        num_valid_rows_until_chunk_.clear();
-        num_valid_rows_until_chunk_.reserve(num_chunks_ + 1);
-        num_valid_rows_until_chunk_.push_back(0);
-        for (size_t i = 0; i < num_chunks_; i++) {
-            num_valid_rows_until_chunk_.push_back(
-                num_valid_rows_until_chunk_.back() + valid_count_per_chunk_[i]);
-        }
-
-        BuildOffsetMapping();
-    }
-
  protected:
     bool nullable_{false};
     DataType data_type_{DataType::NONE};

--- a/internal/core/src/mmap/ChunkedColumnGroup.h
+++ b/internal/core/src/mmap/ChunkedColumnGroup.h
@@ -440,16 +440,6 @@ class ProxyChunkColumn : public ChunkedColumnInterface {
         return group_->GetNumRowsUntilChunk();
     }
 
-    const std::vector<int64_t>&
-    GetNumValidRowsUntilChunk() const override {
-        // For nullable columns, return the cumulative valid row counts
-        // For non-nullable columns, this equals num_rows_until_chunk_
-        if (!num_valid_rows_until_chunk_.empty()) {
-            return num_valid_rows_until_chunk_;
-        }
-        return GetNumRowsUntilChunk();
-    }
-
     void
     BulkValueAt(milvus::OpContext* op_ctx,
                 std::function<void(const char*, size_t)> fn,
@@ -715,45 +705,6 @@ class ProxyChunkColumn : public ChunkedColumnInterface {
                              .output_data();
             fn(std::move(array), i);
         }
-    }
-
-    void
-    BuildValidRowIds(milvus::OpContext* op_ctx) override {
-        if (!field_meta_.is_nullable()) {
-            return;
-        }
-        auto total_rows = NumRows();
-        auto total_chunks = num_chunks();
-        valid_data_.resize(total_rows);
-        valid_count_per_chunk_.resize(total_chunks);
-
-        int64_t logical_offset = 0;
-        for (int64_t i = 0; i < total_chunks; i++) {
-            auto group_chunk = group_->GetGroupChunk(op_ctx, i);
-            auto chunk = group_chunk.get()->GetChunk(field_id_);
-            auto rows = chunk->RowNums();
-            int64_t valid_count = 0;
-            for (int64_t j = 0; j < rows; j++) {
-                if (chunk->isValid(j)) {
-                    valid_data_[logical_offset + j] = true;
-                    valid_count++;
-                } else {
-                    valid_data_[logical_offset + j] = false;
-                }
-            }
-            valid_count_per_chunk_[i] = valid_count;
-            logical_offset += rows;
-        }
-
-        num_valid_rows_until_chunk_.clear();
-        num_valid_rows_until_chunk_.reserve(total_chunks + 1);
-        num_valid_rows_until_chunk_.push_back(0);
-        for (int64_t i = 0; i < total_chunks; i++) {
-            num_valid_rows_until_chunk_.push_back(
-                num_valid_rows_until_chunk_.back() + valid_count_per_chunk_[i]);
-        }
-
-        BuildOffsetMapping();
     }
 
  private:

--- a/internal/core/src/mmap/ChunkedColumnInterface.h
+++ b/internal/core/src/mmap/ChunkedColumnInterface.h
@@ -15,6 +15,8 @@
 // limitations under the License.
 #pragma once
 
+#include <mutex>
+
 #include "cachinglayer/CacheSlot.h"
 #include "common/Chunk.h"
 #include "common/OffsetMapping.h"
@@ -148,8 +150,13 @@ class ChunkedColumnInterface {
     // Get vector of valid (non-null) row counts before each chunk
     // For nullable columns, this tracks cumulative physical offsets
     // For non-nullable columns, this equals GetNumRowsUntilChunk()
-    virtual const std::vector<int64_t>&
-    GetNumValidRowsUntilChunk() const = 0;
+    const std::vector<int64_t>&
+    GetNumValidRowsUntilChunk() const {
+        if (!num_valid_rows_until_chunk_.empty()) {
+            return num_valid_rows_until_chunk_;
+        }
+        return GetNumRowsUntilChunk();
+    }
 
     const FixedVector<bool>&
     GetValidData() const {
@@ -168,8 +175,138 @@ class ChunkedColumnInterface {
 
     virtual void
     BuildValidRowIds(milvus::OpContext* op_ctx) {
-        ThrowInfo(ErrorCode::Unsupported,
-                  "BuildValidRowIds not supported for this column type");
+        if (!IsNullable()) {
+            return;
+        }
+        const auto total_chunks = num_chunks();
+        const auto total_rows = NumRows();
+        auto chunk_pws = GetAllChunks(op_ctx);
+
+        valid_data_.resize(total_rows);
+        valid_count_per_chunk_.assign(total_chunks, 0);
+
+        int64_t logical_offset = 0;
+        for (int64_t i = 0; i < total_chunks; i++) {
+            auto chunk = chunk_pws[i].get();
+            const auto rows = chunk_row_nums(i);
+            int64_t valid_count = 0;
+            for (int64_t j = 0; j < rows; j++) {
+                const bool v = chunk->isValid(j);
+                valid_data_[logical_offset + j] = v;
+                valid_count += v ? 1 : 0;
+            }
+            valid_count_per_chunk_[i] = valid_count;
+            logical_offset += rows;
+        }
+
+        num_valid_rows_until_chunk_.clear();
+        num_valid_rows_until_chunk_.reserve(total_chunks + 1);
+        num_valid_rows_until_chunk_.push_back(0);
+        for (int64_t i = 0; i < total_chunks; i++) {
+            num_valid_rows_until_chunk_.push_back(
+                num_valid_rows_until_chunk_.back() + valid_count_per_chunk_[i]);
+        }
+        if (chunk_build_flags_.empty()) {
+            BuildOffsetMapping();
+        }
+    }
+
+    // Returns false if stats can't be aligned to chunks; caller falls back to eager.
+    template <typename GetRgRows, typename GetRgNulls>
+    bool
+    TryInitValidRowIdsFromRowGroups(size_t num_row_groups,
+                                    GetRgRows&& rg_rows,
+                                    GetRgNulls&& rg_nulls) {
+        const auto num_chunks = static_cast<int64_t>(this->num_chunks());
+        if (num_chunks == 0) {
+            return false;
+        }
+        const auto& chunk_bounds = GetNumRowsUntilChunk();
+        if (static_cast<int64_t>(chunk_bounds.size()) != num_chunks + 1) {
+            return false;
+        }
+        std::vector<int64_t> counts(num_chunks, 0);
+        int64_t chunk_idx = 0;
+        int64_t accumulated_rows = 0;
+        for (size_t i = 0; i < num_row_groups; ++i) {
+            const int64_t rows = rg_rows(i);
+            const int64_t nulls = rg_nulls(i);
+            if (rows < 0 || nulls < 0 || nulls > rows) {
+                return false;
+            }
+            if (chunk_idx >= num_chunks) {
+                return false;
+            }
+            counts[chunk_idx] += rows - nulls;
+            accumulated_rows += rows;
+            if (chunk_idx + 1 < num_chunks &&
+                accumulated_rows >= chunk_bounds[chunk_idx + 1]) {
+                if (accumulated_rows != chunk_bounds[chunk_idx + 1]) {
+                    return false;
+                }
+                chunk_idx++;
+            }
+        }
+        if (accumulated_rows != chunk_bounds[num_chunks]) {
+            return false;
+        }
+        InitValidRowIds(counts);
+        return true;
+    }
+
+    // Lazy counterpart of BuildValidRowIds: populates counts from metadata
+    // without pinning any chunk.
+    void
+    InitValidRowIds(const std::vector<int64_t>& valid_count_per_chunk) {
+        if (!IsNullable()) {
+            return;
+        }
+        valid_count_per_chunk_ = valid_count_per_chunk;
+        num_valid_rows_until_chunk_.clear();
+        num_valid_rows_until_chunk_.reserve(valid_count_per_chunk.size() + 1);
+        num_valid_rows_until_chunk_.push_back(0);
+        int64_t total_valid = 0;
+        for (auto c : valid_count_per_chunk) {
+            total_valid += c;
+            num_valid_rows_until_chunk_.push_back(total_valid);
+        }
+        offset_mapping_.Reserve(static_cast<int64_t>(NumRows()),
+                                total_valid,
+                                valid_count_per_chunk.size());
+        chunk_build_flags_ =
+            std::vector<std::once_flag>(valid_count_per_chunk.size());
+    }
+
+    void
+    EnsureChunkOffsetMapping(int64_t chunk_id, milvus::OpContext* op_ctx) {
+        if (!IsNullable() || chunk_build_flags_.empty()) {
+            return;
+        }
+        if (chunk_id < 0 ||
+            chunk_id >= static_cast<int64_t>(chunk_build_flags_.size())) {
+            return;
+        }
+        if (offset_mapping_.IsChunkSet(chunk_id)) {
+            return;
+        }
+        std::call_once(chunk_build_flags_[chunk_id], [&]() {
+            auto pw = GetChunk(op_ctx, chunk_id);
+            auto chunk = pw.get();
+            const int64_t rows = chunk_row_nums(chunk_id);
+            std::vector<uint8_t> valid_bytes(rows);
+            for (int64_t j = 0; j < rows; ++j) {
+                valid_bytes[j] = chunk->isValid(j) ? 1 : 0;
+            }
+            const int64_t start_logical = GetNumRowsUntilChunk()[chunk_id];
+            const int64_t start_physical =
+                num_valid_rows_until_chunk_[chunk_id];
+            offset_mapping_.SetChunk(
+                chunk_id,
+                start_logical,
+                start_physical,
+                reinterpret_cast<const bool*>(valid_bytes.data()),
+                rows);
+        });
     }
 
     // Build offset mapping from valid_data
@@ -291,6 +428,7 @@ class ChunkedColumnInterface {
     std::vector<int64_t> valid_count_per_chunk_;
     std::vector<int64_t> num_valid_rows_until_chunk_;
     OffsetMapping offset_mapping_;
+    std::vector<std::once_flag> chunk_build_flags_;
 
     std::pair<std::vector<milvus::cachinglayer::cid_t>, std::vector<int64_t>>
     ToChunkIdAndOffset(const int64_t* offsets, int64_t count) const {

--- a/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
+++ b/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
@@ -1,0 +1,312 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <set>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "common/Chunk.h"
+#include "common/GroupChunk.h"
+#include "mmap/ChunkedColumn.h"
+#include "mmap/ChunkedColumnGroup.h"
+#include "test_utils/cachinglayer_test_utils.h"
+
+namespace milvus {
+namespace {
+
+constexpr int32_t kElementSize = 4;
+constexpr int64_t kTestFieldId = 1;
+
+struct ColumnFixture {
+    std::shared_ptr<ChunkedColumnInterface> column;
+    std::shared_ptr<std::set<cachinglayer::cid_t>> fetched;
+    // Keeps chunk data buffers alive for the column's lifetime.
+    std::shared_ptr<void> buffer_holder;
+};
+
+struct ColumnSpec {
+    std::vector<int64_t> rows_per_chunk;
+    std::vector<std::vector<bool>> valid_patterns;  // empty => all valid
+    bool nullable{true};
+};
+
+std::vector<char>
+BuildChunkBuffer(int64_t row_num,
+                 const std::vector<bool>* pattern,
+                 bool nullable) {
+    const int32_t bitmap_bytes = nullable ? (row_num + 7) / 8 : 0;
+    std::vector<char> buf(bitmap_bytes + row_num * kElementSize, 0);
+    if (nullable) {
+        for (int64_t j = 0; j < row_num; ++j) {
+            const bool v = pattern ? (*pattern)[j] : true;
+            if (v) {
+                buf[j >> 3] |= (1 << (j & 0x07));
+            }
+        }
+    }
+    return buf;
+}
+
+std::unique_ptr<FixedWidthChunk>
+MakeFixedChunk(int64_t row_num, bool nullable, char* data, size_t size) {
+    auto guard = std::make_shared<ChunkMmapGuard>(nullptr, 0, "");
+    return std::make_unique<FixedWidthChunk>(
+        row_num, 1, data, size, kElementSize, nullable, guard);
+}
+
+class CountingChunkTranslator : public TestChunkTranslator {
+ public:
+    CountingChunkTranslator(
+        std::vector<int64_t> rows,
+        std::string key,
+        std::vector<std::unique_ptr<Chunk>>&& chunks,
+        std::shared_ptr<std::set<cachinglayer::cid_t>> fetched)
+        : TestChunkTranslator(
+              std::move(rows), std::move(key), std::move(chunks)),
+          fetched_(std::move(fetched)) {
+    }
+
+    std::vector<std::pair<cachinglayer::cid_t, std::unique_ptr<Chunk>>>
+    get_cells(milvus::OpContext* ctx,
+              const std::vector<cachinglayer::cid_t>& cids) override {
+        for (auto c : cids) {
+            fetched_->insert(c);
+        }
+        return TestChunkTranslator::get_cells(ctx, cids);
+    }
+
+ private:
+    std::shared_ptr<std::set<cachinglayer::cid_t>> fetched_;
+};
+
+class CountingGroupChunkTranslator : public TestGroupChunkTranslator {
+ public:
+    CountingGroupChunkTranslator(
+        size_t num_fields,
+        std::vector<int64_t> rows,
+        std::string key,
+        std::vector<std::unique_ptr<GroupChunk>>&& chunks,
+        std::shared_ptr<std::set<cachinglayer::cid_t>> fetched)
+        : TestGroupChunkTranslator(
+              num_fields, std::move(rows), std::move(key), std::move(chunks)),
+          fetched_(std::move(fetched)) {
+    }
+
+    std::vector<std::pair<cachinglayer::cid_t, std::unique_ptr<GroupChunk>>>
+    get_cells(milvus::OpContext* ctx,
+              const std::vector<cachinglayer::cid_t>& cids) override {
+        for (auto c : cids) {
+            fetched_->insert(c);
+        }
+        return TestGroupChunkTranslator::get_cells(ctx, cids);
+    }
+
+ private:
+    std::shared_ptr<std::set<cachinglayer::cid_t>> fetched_;
+};
+
+struct ChunkedColumnFactory {
+    static ColumnFixture
+    Create(const ColumnSpec& spec) {
+        const auto n = spec.rows_per_chunk.size();
+        auto buffers = std::make_shared<std::vector<std::vector<char>>>(n);
+        std::vector<std::unique_ptr<Chunk>> chunks;
+        chunks.reserve(n);
+        for (size_t i = 0; i < n; ++i) {
+            (*buffers)[i] = BuildChunkBuffer(
+                spec.rows_per_chunk[i],
+                spec.valid_patterns.empty() ? nullptr : &spec.valid_patterns[i],
+                spec.nullable);
+            chunks.push_back(MakeFixedChunk(spec.rows_per_chunk[i],
+                                            spec.nullable,
+                                            (*buffers)[i].data(),
+                                            (*buffers)[i].size()));
+        }
+        auto fetched = std::make_shared<std::set<cachinglayer::cid_t>>();
+        auto translator = std::make_unique<CountingChunkTranslator>(
+            spec.rows_per_chunk, "cc_iface", std::move(chunks), fetched);
+        FieldMeta fm(FieldName("t"),
+                     FieldId(kTestFieldId),
+                     DataType::INT32,
+                     spec.nullable,
+                     std::nullopt);
+        auto slot = cachinglayer::Manager::GetInstance().CreateCacheSlot<Chunk>(
+            std::move(translator), nullptr);
+        auto column = std::make_shared<ChunkedColumn>(std::move(slot), fm);
+        return {std::static_pointer_cast<ChunkedColumnInterface>(column),
+                std::move(fetched),
+                std::static_pointer_cast<void>(buffers)};
+    }
+};
+
+struct ProxyChunkColumnFactory {
+    static ColumnFixture
+    Create(const ColumnSpec& spec) {
+        const auto n = spec.rows_per_chunk.size();
+        auto buffers = std::make_shared<std::vector<std::vector<char>>>(n);
+        std::vector<std::unique_ptr<GroupChunk>> group_chunks;
+        group_chunks.reserve(n);
+        for (size_t i = 0; i < n; ++i) {
+            (*buffers)[i] = BuildChunkBuffer(
+                spec.rows_per_chunk[i],
+                spec.valid_patterns.empty() ? nullptr : &spec.valid_patterns[i],
+                spec.nullable);
+            std::shared_ptr<Chunk> chunk =
+                MakeFixedChunk(spec.rows_per_chunk[i],
+                               spec.nullable,
+                               (*buffers)[i].data(),
+                               (*buffers)[i].size());
+            std::unordered_map<FieldId, std::shared_ptr<Chunk>> fields;
+            fields[FieldId(kTestFieldId)] = std::move(chunk);
+            group_chunks.push_back(std::make_unique<GroupChunk>(fields));
+        }
+        auto fetched = std::make_shared<std::set<cachinglayer::cid_t>>();
+        auto translator = std::make_unique<CountingGroupChunkTranslator>(
+            /*num_fields=*/1,
+            spec.rows_per_chunk,
+            "pcc_iface",
+            std::move(group_chunks),
+            fetched);
+        auto group =
+            std::make_shared<ChunkedColumnGroup>(std::move(translator));
+        FieldMeta fm(FieldName("t"),
+                     FieldId(kTestFieldId),
+                     DataType::INT32,
+                     spec.nullable,
+                     std::nullopt);
+        auto column = std::make_shared<ProxyChunkColumn>(
+            group, FieldId(kTestFieldId), fm);
+        return {std::static_pointer_cast<ChunkedColumnInterface>(column),
+                std::move(fetched),
+                std::static_pointer_cast<void>(buffers)};
+    }
+};
+
+}  // namespace
+
+template <typename Factory>
+class ChunkedColumnInterfaceTest : public ::testing::Test {};
+
+using Factories =
+    ::testing::Types<ChunkedColumnFactory, ProxyChunkColumnFactory>;
+TYPED_TEST_SUITE(ChunkedColumnInterfaceTest, Factories);
+
+TYPED_TEST(ChunkedColumnInterfaceTest,
+           InitValidRowIdsPopulatesCountsWithoutPin) {
+    ColumnSpec spec{{5, 3, 4},
+                    {{true, false, true, true, false},
+                     {false, false, false},
+                     {true, true, true, true}},
+                    true};
+    auto fx = TypeParam::Create(spec);
+
+    fx.column->InitValidRowIds({3, 0, 4});
+
+    EXPECT_TRUE(fx.fetched->empty());
+
+    const auto& cum = fx.column->GetNumValidRowsUntilChunk();
+    ASSERT_EQ(cum.size(), 4u);
+    EXPECT_EQ(cum[0], 0);
+    EXPECT_EQ(cum[1], 3);
+    EXPECT_EQ(cum[2], 3);
+    EXPECT_EQ(cum[3], 7);
+
+    const auto& per_chunk = fx.column->GetValidCountPerChunk();
+    ASSERT_EQ(per_chunk.size(), 3u);
+    EXPECT_EQ(per_chunk[0], 3);
+    EXPECT_EQ(per_chunk[1], 0);
+    EXPECT_EQ(per_chunk[2], 4);
+
+    const auto& m = fx.column->GetOffsetMapping();
+    EXPECT_TRUE(m.IsEnabled());
+    EXPECT_EQ(m.GetTotalCount(), 12);
+    EXPECT_EQ(m.GetValidCount(), 7);
+    for (int64_t c = 0; c < 3; ++c) {
+        EXPECT_FALSE(m.IsChunkSet(c)) << "chunk " << c;
+    }
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest,
+           EnsureChunkOffsetMappingFillsOnlyTouched) {
+    ColumnSpec spec{{5, 3, 4},
+                    {{true, false, true, true, false},
+                     {false, false, false},
+                     {true, true, true, true}},
+                    true};
+    auto fx = TypeParam::Create(spec);
+
+    fx.column->InitValidRowIds({3, 0, 4});
+    const auto& m = fx.column->GetOffsetMapping();
+
+    fx.column->EnsureChunkOffsetMapping(2, nullptr);
+    EXPECT_FALSE(m.IsChunkSet(0));
+    EXPECT_FALSE(m.IsChunkSet(1));
+    EXPECT_TRUE(m.IsChunkSet(2));
+    EXPECT_EQ(fx.fetched->size(), 1u);
+    EXPECT_EQ(fx.fetched->count(2), 1u);
+
+    EXPECT_EQ(m.GetPhysicalOffset(8), 3);
+    EXPECT_EQ(m.GetPhysicalOffset(9), 4);
+    EXPECT_EQ(m.GetPhysicalOffset(10), 5);
+    EXPECT_EQ(m.GetPhysicalOffset(11), 6);
+    EXPECT_EQ(m.GetPhysicalOffset(0), -1);
+
+    fx.column->EnsureChunkOffsetMapping(0, nullptr);
+    EXPECT_TRUE(m.IsChunkSet(0));
+    EXPECT_EQ(m.GetPhysicalOffset(0), 0);
+    EXPECT_EQ(m.GetPhysicalOffset(2), 1);
+    EXPECT_EQ(m.GetPhysicalOffset(3), 2);
+    EXPECT_EQ(m.GetPhysicalOffset(1), -1);
+    EXPECT_EQ(m.GetPhysicalOffset(4), -1);
+    EXPECT_EQ(fx.fetched->size(), 2u);
+    EXPECT_EQ(fx.fetched->count(1), 0u);
+
+    // Idempotent.
+    fx.column->EnsureChunkOffsetMapping(0, nullptr);
+    EXPECT_EQ(fx.fetched->size(), 2u);
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest, EnsureChunkNoopOnEagerPath) {
+    ColumnSpec spec{{4}, {{true, false, true, false}}, true};
+    auto fx = TypeParam::Create(spec);
+
+    fx.column->BuildValidRowIds(nullptr);
+    const auto before = fx.column->GetOffsetMapping().GetValidCount();
+    const auto fetched_before = fx.fetched->size();
+
+    fx.column->EnsureChunkOffsetMapping(0, nullptr);
+
+    EXPECT_EQ(fx.column->GetOffsetMapping().GetValidCount(), before);
+    EXPECT_EQ(before, 2);
+    EXPECT_EQ(fx.fetched->size(), fetched_before);
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest, InitValidRowIdsNonNullableIsNoop) {
+    ColumnSpec spec{{5, 5}, {}, /*nullable=*/false};
+    auto fx = TypeParam::Create(spec);
+
+    fx.column->InitValidRowIds({5, 5});
+
+    EXPECT_FALSE(fx.column->GetOffsetMapping().IsEnabled());
+    EXPECT_TRUE(fx.column->GetValidCountPerChunk().empty());
+    EXPECT_TRUE(fx.fetched->empty());
+}
+
+}  // namespace milvus

--- a/internal/core/src/mmap/VirtualPKChunkedColumn.h
+++ b/internal/core/src/mmap/VirtualPKChunkedColumn.h
@@ -200,12 +200,6 @@ class VirtualPKChunkedColumn : public ChunkedColumnInterface {
         return num_rows_until_chunk_;
     }
 
-    const std::vector<int64_t>&
-    GetNumValidRowsUntilChunk() const override {
-        // Virtual PK is never nullable, so valid rows == total rows
-        return num_rows_until_chunk_;
-    }
-
     void
     BulkValueAt(milvus::OpContext* op_ctx,
                 std::function<void(const char*, size_t)> fn,

--- a/internal/core/src/query/SearchOnSealed.cpp
+++ b/internal/core/src/query/SearchOnSealed.cpp
@@ -202,6 +202,9 @@ SearchOnSealedColumn(const Schema& schema,
     TargetBitmap transformed_bitset;
     BitsetView search_bitview = bitview;
     if (offset_mapping.IsEnabled()) {
+        for (int64_t c = 0; c < column->num_chunks(); ++c) {
+            column->EnsureChunkOffsetMapping(c, op_context);
+        }
         transformed_bitset = TransformBitset(bitview, offset_mapping);
         search_bitview = BitsetView(transformed_bitset);
         if (offset_mapping.GetValidCount() == 0) {

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -893,10 +893,21 @@ ChunkedSegmentSealedImpl::load_column_group_data_internal(
             mmap_dir_path);
 
         auto field_metas = schema_->get_field_metas(milvus_field_ids);
+
+        std::vector<FieldId> fields_for_stats;
+        if (ENABLE_PARQUET_STATS_SKIP_INDEX) {
+            fields_for_stats = milvus_field_ids;
+        } else {
+            for (auto field_id : milvus_field_ids) {
+                const auto& fm = field_metas.at(field_id);
+                if (fm.is_nullable() && IsVectorDataType(fm.get_data_type())) {
+                    fields_for_stats.push_back(field_id);
+                }
+            }
+        }
         auto metadata = LoadGroupChunkMetadata(
             insert_files,
-            ENABLE_PARQUET_STATS_SKIP_INDEX ? milvus_field_ids
-                                            : std::vector<FieldId>{},
+            fields_for_stats,
             fmt::format(
                 "seg_{}_cg_{}", get_segment_id(), column_group_id.get()));
         auto parquet_stats_by_field =
@@ -925,24 +936,20 @@ ChunkedSegmentSealedImpl::load_column_group_data_internal(
                 chunked_column_group, field_id, field_meta);
             auto data_type = field_meta.get_data_type();
             std::optional<ParquetStatistics> statistics_opt;
-            if (ENABLE_PARQUET_STATS_SKIP_INDEX) {
-                auto it = parquet_stats_by_field.find(field_id.get());
-                AssertInfo(it != parquet_stats_by_field.end(),
-                           "parquet statistics for field {} not found",
-                           field_id.get());
+            auto it = parquet_stats_by_field.find(field_id.get());
+            if (it != parquet_stats_by_field.end()) {
                 statistics_opt = std::move(it->second);
             }
 
-            load_field_data_common(
-                field_id,
-                column,
-                num_rows,
-                data_type,
-                info.enable_mmap,
-                true,
-                ENABLE_PARQUET_STATS_SKIP_INDEX ? statistics_opt : std::nullopt,
-                op_ctx,
-                is_replace);
+            load_field_data_common(field_id,
+                                   column,
+                                   num_rows,
+                                   data_type,
+                                   info.enable_mmap,
+                                   true,
+                                   statistics_opt,
+                                   op_ctx,
+                                   is_replace);
             if (field_id == TimestampFieldID) {
                 init_storage_v2_timestamp_index(
                     column, num_rows, info.warmup_policy);
@@ -1487,6 +1494,15 @@ ChunkedSegmentSealedImpl::FilterVectorValidOffsets(milvus::OpContext* op_ctx,
         if (column != nullptr && column->IsNullable()) {
             result.valid_data = std::make_unique<bool[]>(count);
             result.valid_offsets.reserve(count);
+
+            std::unordered_set<int64_t> touched_chunks;
+            for (int64_t i = 0; i < count; ++i) {
+                auto [chunk_id, _] = column->GetChunkIDByOffset(seg_offsets[i]);
+                touched_chunks.insert(static_cast<int64_t>(chunk_id));
+            }
+            for (int64_t c : touched_chunks) {
+                column->EnsureChunkOffsetMapping(c, op_ctx);
+            }
 
             const auto& offset_mapping = column->GetOffsetMapping();
             for (int64_t i = 0; i < count; ++i) {
@@ -3533,7 +3549,28 @@ ChunkedSegmentSealedImpl::load_field_data_common(
     }
 
     if (column->IsNullable() && IsVectorDataType(data_type)) {
-        column->BuildValidRowIds(op_ctx);
+        bool lazy_inited = false;
+        if (statistics.has_value() && !statistics.value().empty()) {
+            const auto& stats = statistics.value();
+            bool any_null = false;
+            for (const auto& s : stats) {
+                if (s == nullptr) {
+                    any_null = true;
+                    break;
+                }
+            }
+            if (!any_null) {
+                lazy_inited = column->TryInitValidRowIdsFromRowGroups(
+                    stats.size(),
+                    [&](size_t i) {
+                        return stats[i]->num_values() + stats[i]->null_count();
+                    },
+                    [&](size_t i) { return stats[i]->null_count(); });
+            }
+        }
+        if (!lazy_inited) {
+            column->BuildValidRowIds(op_ctx);
+        }
     }
 
     if (!enable_mmap) {

--- a/internal/core/src/segcore/ConcurrentVector.h
+++ b/internal/core/src/segcore/ConcurrentVector.h
@@ -291,7 +291,7 @@ class ConcurrentVectorImpl : public VectorBase {
         ssize_t storage_offset = 0;
         if (use_mapping_storage_) {
             if constexpr (!std::is_same_v<Type, bool>) {
-                storage_offset = offset_mapping_.GetNextPhysicalOffset();
+                storage_offset = offset_mapping_.GetValidCount();
                 // Build valid_data array for offset mapping
                 std::unique_ptr<bool[]> valid_data(new bool[element_count]);
                 for (ssize_t i = 0; i < element_count; ++i) {
@@ -302,10 +302,10 @@ class ConcurrentVectorImpl : public VectorBase {
                         valid_count++;
                     }
                 }
-                offset_mapping_.BuildIncremental(valid_data.get(),
-                                                 element_count,
-                                                 element_offset,
-                                                 storage_offset);
+                offset_mapping_.Append(valid_data.get(),
+                                       element_count,
+                                       element_offset,
+                                       storage_offset);
             }
         } else {
             valid_count = element_count;

--- a/internal/core/src/segcore/storagev1translator/InterimSealedIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/InterimSealedIndexTranslator.cpp
@@ -171,6 +171,10 @@ InterimSealedIndexTranslator::get_cells(
     }
 
     auto num_chunk = vec_data_->num_chunks();
+    // Interim index is a scan-the-world consumer: needs full valid_data_.
+    if (vec_data_->IsNullable() && vec_data_->GetValidData().empty()) {
+        vec_data_->BuildValidRowIds(ctx);
+    }
     const auto& offset_mapping = vec_data_->GetOffsetMapping();
     bool nullable = offset_mapping.IsEnabled();
     const auto& valid_count_per_chunk =


### PR DESCRIPTION
## Summary

- `BuildValidRowIds` currently pins every chunk of a nullable vector column at segment load, which triggers a full-column S3 fetch for external tables and defeats `warmup=disable` for internal tables.
- Split `OffsetMapping` into `Init` (skeleton) + per-chunk `BuildChunk`, and route the load path through `InitValidRowIds` when per-row-group Parquet `null_count` metadata is available (storage v2 column groups). The skeleton populates per-chunk cumulative counts without pinning any chunk; l2p/p2l entries are filled lazily via `EnsureChunkOffsetMapping` on first touch.
- Decouple Parquet stats collection from `ENABLE_PARQUET_STATS_SKIP_INDEX`: stats for nullable vector fields are always collected (required for the lazy path), while the flag continues to gate skip-index usage and stats collection for other fields. v1 binlog path is unchanged and keeps the eager `BuildValidRowIds` fallback.
- Search-time consumers (`SearchOnSealedColumn`, `FilterVectorValidOffsets`, `InterimSealedIndexTranslator`) only ensure the chunks they actually touch; brute-force search pins all chunks as before.

## Test plan

- [x] New unit tests in `OffsetMappingTest.cpp` cover init + per-chunk build, vec/map mode, out-of-order fills, idempotency, concurrent builds on distinct chunks
- [x] New `ChunkedColumnInterfaceTest.cpp` uses `TYPED_TEST` to run the lazy-path invariants against both `ChunkedColumn` and `ProxyChunkColumn` (init without pin, ensure-only-touched, no-op on eager path, non-nullable no-op)
- [x] Full regression sweep on `OffsetMapping*`, `test_chunked_column*`, `ChunkedColumnInterfaceTest*`, `*Sealed*`, `*Interim*`, `*Filter*`, `*SkipIndex*` — 450+ tests, 0 failures
- [ ] CI integration suites

issue: #49110
related: https://github.com/milvus-io/milvus/issues/45993

🤖 Generated with [Claude Code](https://claude.com/claude-code)