### PR TITLE
fix: sync RBAC built-in privilege groups with Go constants

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -1003,13 +1003,15 @@ common:
     rbac:
       overrideBuiltInPrivilegeGroups:
         enabled: false # Whether to override build-in privilege groups
+      # NOTE: keep these privilege lists in sync with pkg/util/constant.go (ClusterReadOnlyPrivileges etc.).
+      # TestRbacConfig_BuiltinPrivilegesMatchGoConstants enforces drift detection in CI.
       cluster:
         readonly:
-          privileges: ListDatabases,SelectOwnership,SelectUser,DescribeResourceGroup,ListResourceGroups,ListPrivilegeGroups # Cluster level readonly privileges
+          privileges: ListDatabases,SelectOwnership,SelectUser,DescribeResourceGroup,ListResourceGroups,ListPrivilegeGroups,GetReplicateConfiguration,ListFileResources # Cluster level readonly privileges
         readwrite:
-          privileges: ListDatabases,SelectOwnership,SelectUser,DescribeResourceGroup,ListResourceGroups,ListPrivilegeGroups,FlushAll,TransferNode,TransferReplica,UpdateResourceGroups # Cluster level readwrite privileges
+          privileges: ListDatabases,SelectOwnership,SelectUser,DescribeResourceGroup,ListResourceGroups,ListPrivilegeGroups,GetReplicateConfiguration,ListFileResources,FlushAll,TransferNode,TransferReplica,UpdateResourceGroups,AddFileResource,RemoveFileResource,PinSnapshotData,UnpinSnapshotData # Cluster level readwrite privileges
         admin:
-          privileges: ListDatabases,SelectOwnership,SelectUser,DescribeResourceGroup,ListResourceGroups,ListPrivilegeGroups,FlushAll,TransferNode,TransferReplica,UpdateResourceGroups,BackupRBAC,RestoreRBAC,CreateDatabase,DropDatabase,CreateOwnership,DropOwnership,ManageOwnership,CreateResourceGroup,DropResourceGroup,UpdateUser,RenameCollection,CreatePrivilegeGroup,DropPrivilegeGroup,OperatePrivilegeGroup,UpdateReplicateConfiguration # Cluster level admin privileges
+          privileges: ListDatabases,SelectOwnership,SelectUser,DescribeResourceGroup,ListResourceGroups,ListPrivilegeGroups,GetReplicateConfiguration,ListFileResources,FlushAll,TransferNode,TransferReplica,UpdateResourceGroups,AddFileResource,RemoveFileResource,PinSnapshotData,UnpinSnapshotData,BackupRBAC,RestoreRBAC,CreateDatabase,DropDatabase,CreateOwnership,DropOwnership,ManageOwnership,CreateResourceGroup,DropResourceGroup,UpdateUser,RenameCollection,CreatePrivilegeGroup,DropPrivilegeGroup,OperatePrivilegeGroup,UpdateReplicateConfiguration # Cluster level admin privileges
       database:
         readonly:
           privileges: ShowCollections,DescribeDatabase # Database level readonly privileges
@@ -1019,11 +1021,11 @@ common:
           privileges: ShowCollections,DescribeDatabase,AlterDatabase,CreateCollection,DropCollection # Database level admin privileges
       collection:
         readonly:
-          privileges: Query,Search,IndexDetail,GetFlushState,GetLoadState,GetLoadingProgress,HasPartition,ShowPartitions,DescribeCollection,DescribeAlias,GetStatistics,ListAliases,GetImportProgress,ListImport # Collection level readonly privileges
+          privileges: Query,Search,IndexDetail,GetFlushState,GetLoadState,GetLoadingProgress,HasPartition,ShowPartitions,DescribeCollection,DescribeAlias,GetStatistics,ListAliases,GetImportProgress,ListImport,DescribeSnapshot,ListSnapshots # Collection level readonly privileges
         readwrite:
-          privileges: Query,Search,IndexDetail,GetFlushState,GetLoadState,GetLoadingProgress,HasPartition,ShowPartitions,DescribeCollection,DescribeAlias,GetStatistics,ListAliases,GetImportProgress,ListImport,Load,Release,Insert,Delete,Upsert,Import,Flush,Compaction,LoadBalance,CreateIndex,DropIndex,CreatePartition,DropPartition,AddCollectionField # Collection level readwrite privileges
+          privileges: Query,Search,IndexDetail,GetFlushState,GetLoadState,GetLoadingProgress,HasPartition,ShowPartitions,DescribeCollection,DescribeAlias,GetStatistics,ListAliases,GetImportProgress,ListImport,DescribeSnapshot,ListSnapshots,Load,Release,Insert,Delete,Upsert,Import,Flush,Compaction,LoadBalance,CreateIndex,DropIndex,CreatePartition,DropPartition,AddCollectionField,AlterCollectionSchema,RefreshExternalCollection,CreateSnapshot,DropSnapshot # Collection level readwrite privileges
         admin:
-          privileges: Query,Search,IndexDetail,GetFlushState,GetLoadState,GetLoadingProgress,HasPartition,ShowPartitions,DescribeCollection,DescribeAlias,GetStatistics,ListAliases,GetImportProgress,ListImport,Load,Release,Insert,Delete,Upsert,Import,Flush,Compaction,LoadBalance,CreateIndex,DropIndex,CreatePartition,DropPartition,AddCollectionField,CreateAlias,DropAlias # Collection level admin privileges
+          privileges: Query,Search,IndexDetail,GetFlushState,GetLoadState,GetLoadingProgress,HasPartition,ShowPartitions,DescribeCollection,DescribeAlias,GetStatistics,ListAliases,GetImportProgress,ListImport,DescribeSnapshot,ListSnapshots,Load,Release,Insert,Delete,Upsert,Import,Flush,Compaction,LoadBalance,CreateIndex,DropIndex,CreatePartition,DropPartition,AddCollectionField,AlterCollectionSchema,RefreshExternalCollection,CreateSnapshot,DropSnapshot,CreateAlias,DropAlias,RestoreSnapshot # Collection level admin privileges
     internaltlsEnabled: false
     tlsMode: 0
   session:

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -312,7 +312,13 @@ var (
 	}
 )
 
-// rbac v2 uses privilege level to group privileges rather than object type
+// rbac v2 uses privilege level to group privileges rather than object type.
+//
+// WARNING: these lists must stay in sync with the `common.security.rbac.*.privileges`
+// entries in configs/milvus.yaml. The yaml values override the DefaultValue set in
+// pkg/util/paramtable/rbac_param.go because ParamItem resolves in the order
+// etcd override -> yaml file -> DefaultValue. TestRbacConfig_BuiltinPrivilegesMatchGoConstants
+// enforces drift detection in CI.
 var (
 	CollectionReadOnlyPrivileges = ConvertPrivileges([]string{
 		commonpb.ObjectPrivilege_PrivilegeQuery.String(),

--- a/pkg/util/paramtable/rbac_config_test.go
+++ b/pkg/util/paramtable/rbac_config_test.go
@@ -20,23 +20,45 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/pkg/v2/util"
 )
 
-func TestRbacConfig_DefaultPrivileges(t *testing.T) {
+// TestRbacConfig_BuiltinPrivilegesMatchGoConstants guards against drift between
+// configs/milvus.yaml and the authoritative Go constants in pkg/util/constant.go.
+// When a new privilege is added to util.XxxPrivileges, the matching yaml list
+// must be updated in the same PR or this test fails.
+//
+// Comparing GetAsStrings() against util.XxxPrivileges (not against another
+// ParamItem-derived value) is what makes the drift detectable: the assertion
+// walks the full resolution chain (etcd override -> yaml file -> DefaultValue)
+// and compares the runtime value with the compile-time truth.
+func TestRbacConfig_BuiltinPrivilegesMatchGoConstants(t *testing.T) {
 	params := ComponentParam{}
 	params.Init(NewBaseTable(SkipRemote(true)))
 	cfg := &params.RbacConfig
-	assert.Equal(t, len(cfg.GetDefaultPrivilegeGroupNames()), 9)
-	assert.Equal(t, cfg.Enabled.GetAsBool(), false)
-	assert.Equal(t, cfg.ClusterReadOnlyPrivileges.GetAsStrings(), cfg.GetDefaultPrivilegeGroupPrivileges("ClusterReadOnly"))
-	assert.Equal(t, cfg.ClusterReadWritePrivileges.GetAsStrings(), cfg.GetDefaultPrivilegeGroupPrivileges("ClusterReadWrite"))
-	assert.Equal(t, cfg.ClusterAdminPrivileges.GetAsStrings(), cfg.GetDefaultPrivilegeGroupPrivileges("ClusterAdmin"))
-	assert.Equal(t, cfg.DBReadOnlyPrivileges.GetAsStrings(), cfg.GetDefaultPrivilegeGroupPrivileges("DatabaseReadOnly"))
-	assert.Equal(t, cfg.DBReadWritePrivileges.GetAsStrings(), cfg.GetDefaultPrivilegeGroupPrivileges("DatabaseReadWrite"))
-	assert.Equal(t, cfg.DBAdminPrivileges.GetAsStrings(), cfg.GetDefaultPrivilegeGroupPrivileges("DatabaseAdmin"))
-	assert.Equal(t, cfg.CollectionReadOnlyPrivileges.GetAsStrings(), cfg.GetDefaultPrivilegeGroupPrivileges("CollectionReadOnly"))
-	assert.Equal(t, cfg.CollectionReadWritePrivileges.GetAsStrings(), cfg.GetDefaultPrivilegeGroupPrivileges("CollectionReadWrite"))
-	assert.Equal(t, cfg.CollectionAdminPrivileges.GetAsStrings(), cfg.GetDefaultPrivilegeGroupPrivileges("CollectionAdmin"))
+
+	cases := []struct {
+		name     string
+		got      []string
+		expected []string
+	}{
+		{"ClusterReadOnly", cfg.ClusterReadOnlyPrivileges.GetAsStrings(), util.ClusterReadOnlyPrivileges},
+		{"ClusterReadWrite", cfg.ClusterReadWritePrivileges.GetAsStrings(), util.ClusterReadWritePrivileges},
+		{"ClusterAdmin", cfg.ClusterAdminPrivileges.GetAsStrings(), util.ClusterAdminPrivileges},
+		{"DatabaseReadOnly", cfg.DBReadOnlyPrivileges.GetAsStrings(), util.DatabaseReadOnlyPrivileges},
+		{"DatabaseReadWrite", cfg.DBReadWritePrivileges.GetAsStrings(), util.DatabaseReadWritePrivileges},
+		{"DatabaseAdmin", cfg.DBAdminPrivileges.GetAsStrings(), util.DatabaseAdminPrivileges},
+		{"CollectionReadOnly", cfg.CollectionReadOnlyPrivileges.GetAsStrings(), util.CollectionReadOnlyPrivileges},
+		{"CollectionReadWrite", cfg.CollectionReadWritePrivileges.GetAsStrings(), util.CollectionReadWritePrivileges},
+		{"CollectionAdmin", cfg.CollectionAdminPrivileges.GetAsStrings(), util.CollectionAdminPrivileges},
+	}
+	for _, c := range cases {
+		assert.ElementsMatchf(t, c.expected, c.got,
+			"privilege group %q out of sync: configs/milvus.yaml `common.security.rbac.*.privileges` "+
+				"drifted from util.%sPrivileges in pkg/util/constant.go. "+
+				"Update the yaml list to match the Go constant.", c.name, c.name)
+	}
 }
 
 func TestRbacConfig_OverridePrivileges(t *testing.T) {


### PR DESCRIPTION
issue: #49167

## Summary

RBAC v2 built-in privilege groups (`Cluster*`/`Database*`/`Collection*`) were missing recently added privileges on fresh deployments, so e.g. granting `CollectionReadOnly` to a role did not include `DescribeSnapshot`/`ListSnapshots`. Root cause: `configs/milvus.yaml` hard-codes the privilege lists and drifted from `pkg/util/constant.go`. `ParamItem` resolves in the order etcd > yaml > DefaultValue, so the stale yaml always wins.



## Changes

- Sync `configs/milvus.yaml` with the current Go constants, restoring the missing privileges from [#47393](https://github.com/milvus-io/milvus/pull/47393) (`GetReplicateConfiguration`), [#48126](https://github.com/milvus-io/milvus/pull/48126) (`*FileResource`), and [#48143](https://github.com/milvus-io/milvus/pull/48143) (`*Snapshot*`).
- Add `TestRbacConfig_BuiltinPrivilegesMatchGoConstants` that compares `ParamItem.GetAsStrings()` against `util.*Privileges` directly. Unlike the previous test (which compared two ParamItem-derived values and was trivially satisfied), this walks the full etcd→yaml→DefaultValue resolution chain and fails loudly on drift.
- Drop the old `TestRbacConfig_DefaultPrivileges` — both sides of its assertions read the same `ParamItem`, so it could never detect drift.
- Add a WARNING comment in `pkg/util/constant.go` pointing to the yaml file and the new regression test so future privilege additions are less likely to miss the yaml sync.

## Scope

- [x] No change to the `overrideBuiltInPrivilegeGroups.enabled` flag (dead code; separate cleanup).
- [x] No change to `pkg/util/paramtable/rbac_param.go` resolution logic.
- [x] `refreshable:"false"` preserved — existing deployments must restart to pick up the fix.

## Test plan

- [x] `go test -tags dynamic,test -count=1 -run TestRbacConfig_ ./pkg/v2/util/paramtable/...` passes locally.
- [x] Drift verification: temporarily removed `DescribeSnapshot,ListSnapshots` from the yaml `collection.readwrite.privileges` entry — the new test failed with a clear message pointing at the drifted group and the two files to reconcile.
- [ ] Integration test: deploy fresh master, `client.list_privilege_groups()` shows the expected counts (CollectionReadOnly=16, ClusterReadOnly=8, etc.), grant `CollectionReadOnly` to a role → `describe_snapshot` works.