### PR TITLE
test: add struct array filter correctness tests for query and search (index access, array_contains, array_length)

### DIFF
--- a/tests/python_client/check/func_check.py
+++ b/tests/python_client/check/func_check.py
@@ -11,6 +11,30 @@ from pymilvus import Collection, DataType, Partition, ResourceGroupInfo, Role
 from pymilvus.client.types import CompactionPlans
 from utils.util_log import test_log as log
 
+_CONSISTENCY_LEVEL_NAMES = {
+    0: "Strong",
+    1: "Session",
+    2: "Bounded",
+    3: "Eventually",
+    4: "Customized",
+}
+_CONSISTENCY_LEVEL_NAME_BY_LOWER = {v.lower(): v for v in _CONSISTENCY_LEVEL_NAMES.values()}
+
+
+def _normalize_consistency_level(level):
+    if isinstance(level, str):
+        level = level.strip()
+        if level.isdigit():
+            return _CONSISTENCY_LEVEL_NAMES.get(int(level), level)
+        name = level.rsplit("_", 1)[-1]
+        if name.startswith("Cl"):
+            name = name[2:]
+        return _CONSISTENCY_LEVEL_NAME_BY_LOWER.get(name.lower(), level)
+    try:
+        return _CONSISTENCY_LEVEL_NAMES.get(int(level), level)
+    except (TypeError, ValueError):
+        return level
+
 
 class Error:
     def __init__(self, error):
@@ -251,7 +275,9 @@ class ResponseChecker:
             assert res["collection_name"] == check_items.get("collection_name")
         assert res["auto_id"] == check_items.get("auto_id", False)
         assert res["num_shards"] == check_items.get("num_shards", 1)
-        assert res["consistency_level"] == check_items.get("consistency_level", 0)
+        assert _normalize_consistency_level(res["consistency_level"]) == _normalize_consistency_level(
+            check_items.get("consistency_level", 0)
+        )
         assert res["enable_dynamic_field"] == check_items.get("enable_dynamic_field", True)
         assert res["num_partitions"] == check_items.get("num_partitions", 1)
         if check_items.get("id_name", None):

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array.py
@@ -118,6 +118,54 @@ BINARY_METRIC = "MAX_SIM_HAMMING"
 FLOAT_METRIC = "MAX_SIM_COSINE"
 INT8_METRIC = "MAX_SIM_COSINE"
 
+EMB_LIST_STRATEGY_CONFIGS = {
+    "tokenann": {
+        "strategy_params": {
+            "emb_list_strategy": "tokenann",
+        },
+    },
+    "muvera": {
+        "strategy_params": {
+            "emb_list_strategy": "muvera",
+            "muvera_num_projections": 3,
+            "muvera_num_repeats": 5,
+            "muvera_seed": 42,
+        },
+    },
+    "lemur": {
+        "strategy_params": {
+            "emb_list_strategy": "lemur",
+            "lemur_hidden_dim": 32,
+            "lemur_num_train_samples": 1000,
+            "lemur_num_epochs": 2,
+            "lemur_batch_size": 16,
+            "lemur_learning_rate": 0.001,
+            "lemur_seed": 42,
+            "lemur_num_layers": 1,
+        },
+    },
+}
+
+EMB_LIST_STRATEGY_INDEX_CONFIGS = {
+    "HNSW": {
+        "build_params": {
+            "M": 16,
+            "efConstruction": 96,
+        },
+        "search_params": {"ef": 64, "retrieval_ann_ratio": 3.0, "emb_list_rerank": True},
+    },
+    "DISKANN": {
+        "build_params": {},
+        "search_params": {"search_list": 30, "retrieval_ann_ratio": 3.0, "emb_list_rerank": True},
+    },
+}
+EMB_LIST_STRATEGY_INDEX_CASES = [
+    ("tokenann", "HNSW"),
+    ("muvera", "HNSW"),
+    ("lemur", "HNSW"),
+    ("tokenann", "DISKANN"),
+]
+
 
 class TestMilvusClientStructArrayBasic(TestMilvusClientV2Base):
     """Test case of struct array basic functionality"""
@@ -2479,6 +2527,105 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
         assert len(results[0]) > 0
         for hit in results[0]:
             assert hit["id"] not in delete_ids
+
+    @pytest.mark.tags(CaseLabel.L1)
+    @pytest.mark.parametrize("emb_list_strategy,index_type", EMB_LIST_STRATEGY_INDEX_CASES)
+    def test_search_emb_list_with_explicit_strategy(self, emb_list_strategy, index_type):
+        """
+        target: test emb list search with explicitly specified strategies
+        method: create HNSW and DISKANN indexes with supported emb_list_strategy values, load, and search
+        expected: index creation and search work correctly
+        """
+        collection_name = cf.gen_unique_str(f"{prefix}_search_{emb_list_strategy}_{index_type.lower()}")
+        client = self._client()
+        strategy_config = EMB_LIST_STRATEGY_CONFIGS[emb_list_strategy]
+        index_config = EMB_LIST_STRATEGY_INDEX_CONFIGS[index_type]
+
+        schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
+        schema.add_field(field_name="id", datatype=DataType.INT64, is_primary=True)
+        schema.add_field(field_name="normal_vector", datatype=DataType.FLOAT_VECTOR, dim=EMB_LIST_DIM)
+
+        struct_schema = client.create_struct_field_schema()
+        struct_schema.add_field("clip_embedding1", DataType.FLOAT_VECTOR, dim=EMB_LIST_DIM)
+        struct_schema.add_field("scalar_field", DataType.INT64)
+        schema.add_field(
+            "clips",
+            datatype=DataType.ARRAY,
+            element_type=DataType.STRUCT,
+            struct_schema=struct_schema,
+            max_capacity=10,
+        )
+
+        res, check = self.create_collection(client, collection_name, schema=schema)
+        assert check
+
+        nb = 3000
+        data = []
+        for i in range(nb):
+            clips = []
+            for j in range(2):
+                clips.append(
+                    {
+                        "clip_embedding1": [random.random() for _ in range(EMB_LIST_DIM)],
+                        "scalar_field": i * 10 + j,
+                    }
+                )
+            data.append(
+                {
+                    "id": i,
+                    "normal_vector": [random.random() for _ in range(EMB_LIST_DIM)],
+                    "clips": clips,
+                }
+            )
+
+        res, check = self.insert(client, collection_name, data)
+        assert check
+        assert res["insert_count"] == nb
+
+        res, check = self.flush(client, collection_name)
+        assert check
+
+        index_params = client.prepare_index_params()
+        index_params.add_index(
+            field_name="normal_vector",
+            index_type="IVF_FLAT",
+            metric_type="L2",
+            params={"nlist": 128},
+        )
+        index_params.add_index(
+            field_name="clips[clip_embedding1]",
+            index_name=f"struct_vector_index_{emb_list_strategy}_{index_type.lower()}",
+            index_type=index_type,
+            metric_type="MAX_SIM_COSINE",
+            params={
+                **index_config["build_params"],
+                **strategy_config["strategy_params"],
+            },
+        )
+
+        res, check = self.create_index(client, collection_name, index_params)
+        assert check
+
+        res, check = self.load_collection(client, collection_name)
+        assert check
+
+        embedding_list = self.create_embedding_list(EMB_LIST_DIM, 3)
+        results, check = self.search(
+            client,
+            collection_name,
+            data=[embedding_list],
+            anns_field="clips[clip_embedding1]",
+            search_params={
+                "metric_type": "MAX_SIM_COSINE",
+                "params": index_config["search_params"],
+            },
+            limit=10,
+            output_fields=["id"],
+        )
+        assert check
+        assert len(results[0]) > 0
+        for hit in results[0]:
+            assert 0 <= hit["id"] < nb
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize(

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array.py
@@ -164,16 +164,12 @@ EMB_LIST_STRATEGY_INDEX_CASES = [
     pytest.param(
         "muvera",
         "HNSW",
-        marks=pytest.mark.skip(
-            reason="milvus-io/milvus#49748: muvera+HNSW can fail to load emb-list index"
-        ),
+        marks=pytest.mark.skip(reason="milvus-io/milvus#49748: muvera+HNSW can fail to load emb-list index"),
     ),
     pytest.param(
         "lemur",
         "HNSW",
-        marks=pytest.mark.skip(
-            reason="milvus-io/milvus#49748: lemur+HNSW can fail to load emb-list index"
-        ),
+        marks=pytest.mark.skip(reason="milvus-io/milvus#49748: lemur+HNSW can fail to load emb-list index"),
     ),
     ("tokenann", "DISKANN"),
 ]

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array.py
@@ -4745,7 +4745,6 @@ class TestMilvusClientStructArrayImport(TestMilvusClientV2Base):
     @pytest.mark.parametrize("dim", [128])
     @pytest.mark.parametrize("entities", [1000])
     @pytest.mark.parametrize("array_capacity", [100])
-    @pytest.mark.xfail(reason="issue")
     def test_import_struct_array_with_parquet(self, dim, entities, array_capacity):
         """
         Test bulk import of struct array data from parquet file

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array.py
@@ -161,8 +161,20 @@ EMB_LIST_STRATEGY_INDEX_CONFIGS = {
 }
 EMB_LIST_STRATEGY_INDEX_CASES = [
     ("tokenann", "HNSW"),
-    ("muvera", "HNSW"),
-    ("lemur", "HNSW"),
+    pytest.param(
+        "muvera",
+        "HNSW",
+        marks=pytest.mark.skip(
+            reason="milvus-io/milvus#49748: muvera+HNSW can fail to load emb-list index"
+        ),
+    ),
+    pytest.param(
+        "lemur",
+        "HNSW",
+        marks=pytest.mark.skip(
+            reason="milvus-io/milvus#49748: lemur+HNSW can fail to load emb-list index"
+        ),
+    ),
     ("tokenann", "DISKANN"),
 ]
 

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_element_query.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_element_query.py
@@ -3385,3 +3385,986 @@ class TestMilvusClientStructArrayElementMatchQuery(TestMilvusClientV2Base):
         assert has_sealed and has_growing, "Should have results from both segments"
 
 
+# ==================== Test Case 9: StructArray Index Access (PR #48987) ====================
+
+
+@pytest.mark.xdist_group("TestMilvusClientStructArrayIndexAccess")
+class TestMilvusClientStructArrayIndexAccess(TestMilvusClientV2Base):
+    """Test struct_arr[index][sub_field] index-access syntax (PR #48987).
+
+    The new syntax accesses a fixed positional element of a struct array's
+    sub-field, e.g. ``structA[0][int_val] > 100`` selects rows whose 1st
+    struct element has int_val > 100.
+
+    Coverage:
+    - Comparison operators (==, !=, >, >=, <, <=)
+    - IN / NOT IN
+    - Forward range ``a < expr < b`` and reverse range ``b > expr > a``
+    - String sub-field access
+    - Cross-index conditions (structA[0]... AND structA[1]...)
+    - Combination with doc-level filter
+    - Out-of-bounds index (rows shorter than the requested index do not match)
+    - Negative cases for invalid sub-field / parent field / unsupported swapped form
+    - Use inside search() filter
+    - array_length(structA[sub_field]) and rejection of array_length on indexed form
+
+    Data layout per case (>= 3500 rows total, sealed + growing both populated):
+    - Sealed segment:  3000 inert background rows (id 100000..102999)
+                       + first half of controlled rows -> flushed
+    - Growing segment: 500 inert background rows (id 103000..103499)
+                       + remaining controlled rows -> not flushed
+    Inert rows have struct array length 1 with int_val=0 / color="Inert" so
+    they never match controlled predicates; assertions are scoped to id < 100.
+    """
+
+    def _create_schema(self, client, dim=default_dim):
+        schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
+        schema.add_field(field_name="id", datatype=DataType.INT64, is_primary=True)
+        schema.add_field(field_name="doc_int", datatype=DataType.INT64)
+        schema.add_field(field_name="normal_vector", datatype=DataType.FLOAT_VECTOR, dim=dim)
+
+        struct_schema = client.create_struct_field_schema()
+        struct_schema.add_field("embedding", DataType.FLOAT_VECTOR, dim=dim)
+        struct_schema.add_field("int_val", DataType.INT64)
+        struct_schema.add_field("str_val", DataType.VARCHAR, max_length=65535)
+        struct_schema.add_field("color", DataType.VARCHAR, max_length=128)
+
+        schema.add_field(
+            "structA", datatype=DataType.ARRAY,
+            element_type=DataType.STRUCT,
+            struct_schema=struct_schema,
+            max_capacity=default_capacity,
+        )
+        return schema
+
+    def _make_row(self, row_id, struct_elements):
+        """Build a row with explicit struct elements (in order)."""
+        return {
+            "id": row_id,
+            "doc_int": row_id,
+            "normal_vector": _seed_vector(row_id + 999999),
+            "structA": [
+                {
+                    "embedding": _seed_vector(row_id * 1000 + j),
+                    "int_val": elem["int_val"],
+                    "str_val": elem.get("str_val", f"r{row_id}_e{j}"),
+                    "color": elem.get("color", "Red"),
+                }
+                for j, elem in enumerate(struct_elements)
+            ],
+        }
+
+    def _make_inert_row(self, row_id):
+        """Background row that does not match any controlled filter.
+        Single-element struct array with int_val=0, str_val=inert_X, color=Inert."""
+        return {
+            "id": row_id,
+            "doc_int": row_id,
+            "normal_vector": _seed_vector(row_id + 999999),
+            "structA": [{
+                "embedding": _seed_vector(row_id * 1000),
+                "int_val": 0,
+                "str_val": f"inert_{row_id}",
+                "color": "Inert",
+            }],
+        }
+
+    def _setup_collection_split(self, client, collection_name,
+                                 sealed_rows, growing_rows):
+        """Setup with explicit sealed/growing controlled row groups.
+
+        Layout (>= 3500 rows total):
+        - Sealed: 3000 inert background + sealed_rows -> flushed
+        - Growing: 500 inert background + growing_rows -> not flushed
+        """
+        schema = self._create_schema(client)
+        index_params = client.prepare_index_params()
+        index_params.add_index(
+            field_name="normal_vector", index_type="HNSW",
+            metric_type="COSINE", params=INDEX_PARAMS,
+        )
+        index_params.add_index(
+            field_name="structA[embedding]", index_type="HNSW",
+            metric_type="COSINE", params=INDEX_PARAMS,
+        )
+        self.create_collection(client, collection_name, schema=schema,
+                               index_params=index_params)
+
+        bg_start = 100000
+        for start in range(0, default_nb, insert_batch_size):
+            batch = [self._make_inert_row(bg_start + start + k)
+                     for k in range(insert_batch_size)]
+            self.insert(client, collection_name, batch)
+        if sealed_rows:
+            self.insert(client, collection_name, sealed_rows)
+        self.flush(client, collection_name)
+
+        growing_bg = [self._make_inert_row(bg_start + default_nb + k)
+                      for k in range(default_growing_nb)]
+        self.insert(client, collection_name, growing_bg)
+        if growing_rows:
+            self.insert(client, collection_name, growing_rows)
+
+        self.load_collection(client, collection_name)
+
+    def _setup_collection(self, client, collection_name, controlled_rows):
+        """Setup with sealed + growing background data + controlled rows split
+        across both segments.
+
+        Layout (>= 3500 rows total):
+        - Sealed: 3000 inert background (id 100000..102999)
+                  + first half of controlled_rows -> flushed
+        - Growing: 500 inert background (id 103000..103499)
+                   + second half of controlled_rows -> not flushed
+        """
+        schema = self._create_schema(client)
+        index_params = client.prepare_index_params()
+        index_params.add_index(
+            field_name="normal_vector", index_type="HNSW",
+            metric_type="COSINE", params=INDEX_PARAMS,
+        )
+        index_params.add_index(
+            field_name="structA[embedding]", index_type="HNSW",
+            metric_type="COSINE", params=INDEX_PARAMS,
+        )
+        self.create_collection(client, collection_name, schema=schema,
+                               index_params=index_params)
+
+        # 1) Sealed inert background: 3000 rows
+        bg_start = 100000
+        for start in range(0, default_nb, insert_batch_size):
+            batch = [self._make_inert_row(bg_start + start + k)
+                     for k in range(insert_batch_size)]
+            self.insert(client, collection_name, batch)
+
+        # 2) Half of controlled rows -> sealed
+        half = len(controlled_rows) // 2
+        sealed_part = controlled_rows[:half]
+        growing_part = controlled_rows[half:]
+        if sealed_part:
+            self.insert(client, collection_name, sealed_part)
+        self.flush(client, collection_name)
+
+        # 3) Growing inert background: 500 rows
+        growing_bg = [self._make_inert_row(bg_start + default_nb + k)
+                      for k in range(default_growing_nb)]
+        self.insert(client, collection_name, growing_bg)
+
+        # 4) Remaining controlled rows -> growing
+        if growing_part:
+            self.insert(client, collection_name, growing_part)
+
+        self.load_collection(client, collection_name)
+
+    # ---- 9.1 Equality on indexed sub-field ----
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_index_access_query_eq(self):
+        """
+        target: structA[0][int_val] == X selects rows whose 1st element matches
+        method: build 5 rows with distinct first-element int_val
+        expected: only the row with matching first element returned
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_idx_eq")
+
+        rows = [
+            self._make_row(0, [{"int_val": 10}, {"int_val": 20}]),
+            self._make_row(1, [{"int_val": 100}, {"int_val": 200}]),
+            self._make_row(2, [{"int_val": 100}]),                   # first elem also 100
+            self._make_row(3, [{"int_val": 50}, {"int_val": 100}]),  # 100 at index 1, not 0
+            self._make_row(4, [{"int_val": 999}]),
+        ]
+        self._setup_collection(client, collection_name, rows)
+
+        results, check = self.query(
+            client, collection_name,
+            filter='id < 100 && structA[0][int_val] == 100',
+            output_fields=["id"], limit=100,
+        )
+        assert check
+        ids = sorted({r["id"] for r in results})
+        assert ids == [1, 2], f"Expected [1, 2], got {ids}"
+
+    # ---- 9.2 Inequality + greater/less than ----
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_index_access_query_comparison_operators(self):
+        """
+        target: !=, >, >=, <, <= all work on structA[i][int_val]
+        method: same dataset, different operators
+        expected: each operator returns the exact expected ID set
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_idx_cmp")
+
+        rows = [
+            self._make_row(i, [{"int_val": v}])
+            for i, v in enumerate([10, 20, 30, 40, 50])
+        ]
+        self._setup_collection(client, collection_name, rows)
+
+        cases = [
+            ('id < 100 && structA[0][int_val] != 30', [0, 1, 3, 4]),
+            ('id < 100 && structA[0][int_val] > 30', [3, 4]),
+            ('id < 100 && structA[0][int_val] >= 30', [2, 3, 4]),
+            ('id < 100 && structA[0][int_val] < 30', [0, 1]),
+            ('id < 100 && structA[0][int_val] <= 30', [0, 1, 2]),
+        ]
+        for expr, expected in cases:
+            results, check = self.query(
+                client, collection_name,
+                filter=expr, output_fields=["id"], limit=100,
+            )
+            assert check, expr
+            ids = sorted({r["id"] for r in results})
+            assert ids == expected, f"{expr}: expected {expected}, got {ids}"
+
+    # ---- 9.3 IN / NOT IN ----
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_index_access_query_in_not_in(self):
+        """
+        target: IN / NOT IN on structA[i][int_val]
+        method: filter against a literal list
+        expected: exact ID set returned for each
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_idx_in")
+
+        rows = [
+            self._make_row(i, [{"int_val": v}])
+            for i, v in enumerate([10, 20, 30, 40, 50])
+        ]
+        self._setup_collection(client, collection_name, rows)
+
+        results, check = self.query(
+            client, collection_name,
+            filter='id < 100 && structA[0][int_val] in [10, 30, 50, 999]',
+            output_fields=["id"], limit=100,
+        )
+        assert check
+        assert sorted({r["id"] for r in results}) == [0, 2, 4]
+
+        results, check = self.query(
+            client, collection_name,
+            filter='id < 100 && structA[0][int_val] not in [10, 30, 50]',
+            output_fields=["id"], limit=100,
+        )
+        assert check
+        assert sorted({r["id"] for r in results}) == [1, 3]
+
+    # ---- 9.4 Forward range a < expr < b ----
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_index_access_query_range_forward(self):
+        """
+        target: range syntax 'lo < structA[0][int_val] < hi'
+        method: open and closed bounds
+        expected: only rows in the range returned
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_idx_range_fwd")
+
+        rows = [
+            self._make_row(i, [{"int_val": v}])
+            for i, v in enumerate([10, 20, 30, 40, 50])
+        ]
+        self._setup_collection(client, collection_name, rows)
+
+        # Open: 20 < x < 40 -> only 30 (inert int_val=0 excluded)
+        results, check = self.query(
+            client, collection_name,
+            filter='id < 100 && 20 < structA[0][int_val] < 40',
+            output_fields=["id"], limit=100,
+        )
+        assert check
+        assert sorted({r["id"] for r in results}) == [2]
+
+        # Closed: 20 <= x <= 40 -> 20, 30, 40
+        results, check = self.query(
+            client, collection_name,
+            filter='id < 100 && 20 <= structA[0][int_val] <= 40',
+            output_fields=["id"], limit=100,
+        )
+        assert check
+        assert sorted({r["id"] for r in results}) == [1, 2, 3]
+
+    # ---- 9.5 Reverse range b > expr > a ----
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_index_access_query_range_reverse(self):
+        """
+        target: reverse range syntax 'hi > structA[0][int_val] > lo'
+        method: open and closed bounds
+        expected: only rows in the range returned
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_idx_range_rev")
+
+        rows = [
+            self._make_row(i, [{"int_val": v}])
+            for i, v in enumerate([10, 20, 30, 40, 50])
+        ]
+        self._setup_collection(client, collection_name, rows)
+
+        # Open: 40 > x > 20 -> only 30
+        results, check = self.query(
+            client, collection_name,
+            filter='id < 100 && 40 > structA[0][int_val] > 20',
+            output_fields=["id"], limit=100,
+        )
+        assert check
+        assert sorted({r["id"] for r in results}) == [2]
+
+        # Closed: 40 >= x >= 20 -> 20, 30, 40
+        results, check = self.query(
+            client, collection_name,
+            filter='id < 100 && 40 >= structA[0][int_val] >= 20',
+            output_fields=["id"], limit=100,
+        )
+        assert check
+        assert sorted({r["id"] for r in results}) == [1, 2, 3]
+
+    # ---- 9.6 String sub-field ----
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_index_access_query_string_subfield(self):
+        """
+        target: index-access on VARCHAR sub-field (==, !=, IN)
+        method: build rows with distinct str_val per first element
+        expected: exact ID set returned
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_idx_str")
+
+        rows = [
+            self._make_row(0, [{"int_val": 1, "str_val": "apple"}]),
+            self._make_row(1, [{"int_val": 2, "str_val": "banana"}]),
+            self._make_row(2, [{"int_val": 3, "str_val": "apple"}]),
+            self._make_row(3, [{"int_val": 4, "str_val": "cherry"}]),
+        ]
+        self._setup_collection(client, collection_name, rows)
+
+        results, check = self.query(
+            client, collection_name,
+            filter='id < 100 && structA[0][str_val] == "apple"',
+            output_fields=["id"], limit=100,
+        )
+        assert check
+        assert sorted({r["id"] for r in results}) == [0, 2]
+
+        results, check = self.query(
+            client, collection_name,
+            filter='id < 100 && structA[0][str_val] in ["banana", "cherry"]',
+            output_fields=["id"], limit=100,
+        )
+        assert check
+        assert sorted({r["id"] for r in results}) == [1, 3]
+
+        results, check = self.query(
+            client, collection_name,
+            filter='id < 100 && structA[0][str_val] != "apple"',
+            output_fields=["id"], limit=100,
+        )
+        assert check
+        assert sorted({r["id"] for r in results}) == [1, 3]
+
+    # ---- 9.7 Compound conditions across indices ----
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_index_access_query_compound_indices(self):
+        """
+        target: combine two index-access predicates with AND/OR
+        method: structA[0][int_val] > X && structA[1][int_val] < Y
+        expected: both element positions evaluated independently
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_idx_compound")
+
+        # int_val pairs:           [a, b]
+        rows = [
+            self._make_row(0, [{"int_val": 100}, {"int_val": 1}]),    # a>50, b<10  -> match
+            self._make_row(1, [{"int_val": 100}, {"int_val": 50}]),   # a>50, b>=10 -> no
+            self._make_row(2, [{"int_val": 10}, {"int_val": 1}]),     # a<=50       -> no
+            self._make_row(3, [{"int_val": 200}, {"int_val": 5}]),    # match
+            self._make_row(4, [{"int_val": 60}, {"int_val": 9}]),     # match
+        ]
+        self._setup_collection(client, collection_name, rows)
+
+        results, check = self.query(
+            client, collection_name,
+            filter='id < 100 && structA[0][int_val] > 50 && structA[1][int_val] < 10',
+            output_fields=["id"], limit=100,
+        )
+        assert check
+        assert sorted({r["id"] for r in results}) == [0, 3, 4]
+
+        # OR variant — wrap with id-bound to keep inert rows out
+        results, check = self.query(
+            client, collection_name,
+            filter='id < 100 && (structA[0][int_val] > 150 || structA[1][int_val] == 50)',
+            output_fields=["id"], limit=100,
+        )
+        assert check
+        assert sorted({r["id"] for r in results}) == [1, 3]
+
+    # ---- 9.8 Combined with doc-level filter ----
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_index_access_query_with_doc_filter(self):
+        """
+        target: doc-level scalar filter combined with index-access predicate
+        method: 'id >= 2 && structA[0][int_val] >= 30'
+        expected: both predicates applied
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_idx_doc")
+
+        rows = [
+            self._make_row(i, [{"int_val": v}])
+            for i, v in enumerate([10, 20, 30, 40, 50])
+        ]
+        self._setup_collection(client, collection_name, rows)
+
+        results, check = self.query(
+            client, collection_name,
+            filter='id >= 2 && structA[0][int_val] >= 30',
+            output_fields=["id"], limit=100,
+        )
+        assert check
+        assert sorted({r["id"] for r in results}) == [2, 3, 4]
+
+    # ---- 9.9 Index out of bounds ----
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_index_access_query_out_of_range(self):
+        """
+        target: requesting an index larger than the row's struct array length
+        method: query structA[3][int_val] across rows of varying length
+        expected: rows with fewer elements do not match; query does not error
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_idx_oob")
+
+        rows = [
+            self._make_row(0, [{"int_val": 10}]),                            # length 1
+            self._make_row(1, [{"int_val": 10}, {"int_val": 20}]),           # length 2
+            self._make_row(2, [{"int_val": 1}, {"int_val": 2},
+                               {"int_val": 3}, {"int_val": 99}]),            # length 4 -> index 3 = 99
+            self._make_row(3, [{"int_val": 1}, {"int_val": 2},
+                               {"int_val": 3}, {"int_val": 100}]),           # length 4 -> index 3 = 100
+        ]
+        self._setup_collection(client, collection_name, rows)
+
+        results, check = self.query(
+            client, collection_name,
+            filter='id < 100 && structA[3][int_val] >= 99',
+            output_fields=["id"], limit=100,
+        )
+        assert check
+        ids = sorted({r["id"] for r in results})
+        assert ids == [2, 3], (
+            f"Only rows with >=4 elements at index 3 should match, got {ids}"
+        )
+
+    # ---- 9.10 Negative cases ----
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_index_access_query_invalid_expressions(self):
+        """
+        target: invalid index-access expressions are rejected
+        method: non-existent parent field, non-existent sub-field, swapped form
+        expected: server returns parameter-invalid error (does not crash)
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_idx_invalid")
+
+        rows = [self._make_row(0, [{"int_val": 10}])]
+        self._setup_collection(client, collection_name, rows)
+
+        # parent field does not exist -> server reports "struct field not found"
+        self.query(
+            client, collection_name,
+            filter='non_existent[0][int_val] > 0',
+            output_fields=["id"],
+            check_task=CheckTasks.err_res,
+            check_items={ct.err_code: 1100,
+                         ct.err_msg: "struct field not found"},
+        )
+
+        # sub-field does not exist on structA
+        self.query(
+            client, collection_name,
+            filter='structA[0][not_a_field] > 0',
+            output_fields=["id"],
+            check_task=CheckTasks.err_res,
+            check_items={ct.err_code: 1100,
+                         ct.err_msg: "struct field not found"},
+        )
+
+        # swapped form: sub-field name first, then numeric index — grammar
+        # rejects it as an invalid expression, not as a missing field.
+        self.query(
+            client, collection_name,
+            filter='structA[int_val][0] > 0',
+            output_fields=["id"],
+            check_task=CheckTasks.err_res,
+            check_items={ct.err_code: 1100,
+                         ct.err_msg: "invalid expression"},
+        )
+
+    # ---- 9.11 Use inside search() filter ----
+
+    # ---- 9.12 array_length on struct sub-field (companion path of PR #48987) ----
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_array_length_on_struct_subfield(self):
+        """
+        target: array_length(structA[sub_field]) returns the per-row element count
+        method: build rows with distinct struct array lengths
+        expected: equality / range filters on array_length match the exact rows
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_idx_arrlen")
+
+        # Row i has (i+1) struct elements (lengths: 1, 2, 3, 4, 5)
+        rows = [
+            self._make_row(i, [{"int_val": j} for j in range(i + 1)])
+            for i in range(5)
+        ]
+        self._setup_collection(client, collection_name, rows)
+
+        # inert background rows have struct length=1, so combine with id<100
+        # to keep assertions on the controlled set exact.
+        cases = [
+            ('id < 100 && array_length(structA[int_val]) == 3', [2]),
+            ('id < 100 && array_length(structA[int_val]) >= 4', [3, 4]),
+            ('id < 100 && array_length(structA[int_val]) < 3', [0, 1]),
+        ]
+        for expr, expected in cases:
+            results, check = self.query(
+                client, collection_name,
+                filter=expr, output_fields=["id"], limit=100,
+            )
+            assert check, expr
+            ids = sorted({r["id"] for r in results})
+            assert ids == expected, f"{expr}: expected {expected}, got {ids}"
+
+    # ---- 9.13 array_length(structA[i][sub_field]) is NOT supported by grammar ----
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_array_length_on_struct_index_field_rejected(self):
+        """
+        target: array_length only accepts Identifier | JSONIdentifier |
+                StructFieldIdentifier — the indexed form structA[0][sub_field]
+                refers to a single element, not an array, so it must be rejected.
+        method: send array_length(structA[0][int_val]) and expect a parser/param
+                error (not a crash)
+        expected: server returns parameter-invalid / parser error
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_idx_arrlen_neg")
+
+        rows = [self._make_row(0, [{"int_val": 10}])]
+        self._setup_collection(client, collection_name, rows)
+
+        # Grammar lists allowed forms in the parser error message; assert the
+        # indexed form is rejected as a parse mismatch.
+        self.query(
+            client, collection_name,
+            filter='array_length(structA[0][int_val]) == 1',
+            output_fields=["id"],
+            check_task=CheckTasks.err_res,
+            check_items={ct.err_code: 1100,
+                         ct.err_msg: "mismatched input"},
+        )
+
+    # ---- 9.14 Per-segment consistency: same predicate on sealed-only / growing-only ----
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_index_access_query_sealed_growing_consistency(self):
+        """
+        target: index-access predicate must yield equivalent results regardless
+                of whether matching rows live in a sealed or growing segment.
+        method: build two mirrored controlled groups with identical first-element
+                int_val pattern, place group A in sealed (flushed) and group B
+                in growing (not flushed). After querying:
+                  - the sealed-side IDs must equal the predicted sealed expectation
+                  - the growing-side IDs must equal the predicted growing expectation
+                  - both halves must mirror each other
+        expected: per-segment subsets are exact and isomorphic.
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_idx_segments")
+
+        # Identical int_val pattern; sealed ids 0..4 / growing ids 5..9
+        pattern = [10, 20, 30, 40, 50]
+        sealed_rows = [
+            self._make_row(i, [{"int_val": v}]) for i, v in enumerate(pattern)
+        ]
+        growing_rows = [
+            self._make_row(i + 5, [{"int_val": v}]) for i, v in enumerate(pattern)
+        ]
+        self._setup_collection_split(client, collection_name, sealed_rows, growing_rows)
+
+        cases = [
+            ('id < 100 && structA[0][int_val] == 30', [2], [7]),
+            ('id < 100 && structA[0][int_val] >= 30', [2, 3, 4], [7, 8, 9]),
+            ('id < 100 && structA[0][int_val] in [10, 50]', [0, 4], [5, 9]),
+            ('id < 100 && 20 < structA[0][int_val] < 50', [2, 3], [7, 8]),
+        ]
+        for expr, exp_sealed, exp_growing in cases:
+            results, check = self.query(
+                client, collection_name,
+                filter=expr, output_fields=["id"], limit=200,
+            )
+            assert check, expr
+            ids = sorted({r["id"] for r in results})
+            sealed_part = [i for i in ids if i < 5]
+            growing_part = [i for i in ids if 5 <= i < 100]
+            assert sealed_part == exp_sealed, (
+                f"{expr}: sealed expected {exp_sealed}, got {sealed_part}"
+            )
+            assert growing_part == exp_growing, (
+                f"{expr}: growing expected {exp_growing}, got {growing_part}"
+            )
+            # Mirroring: each sealed id i has growing counterpart i+5
+            assert [i + 5 for i in sealed_part] == growing_part, (
+                f"{expr}: sealed/growing pattern is not mirrored: "
+                f"sealed={sealed_part} growing={growing_part}"
+            )
+
+    # ---- 9.15 After delete: deleted matching rows disappear ----
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_index_access_query_after_delete(self):
+        """
+        target: index-access predicate reflects deletions correctly
+        method: baseline query -> delete a matching row and a non-matching row
+                -> requery, both sealed and growing controlled rows are exercised
+        expected: deleted matching IDs are absent; non-matching deletes do not
+                  affect the result; surviving matches are unchanged.
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_idx_delete")
+
+        # Spread across sealed (0..4) and growing (5..9) using split helper
+        sealed_rows = [
+            self._make_row(i, [{"int_val": v}])
+            for i, v in enumerate([10, 20, 30, 40, 50])
+        ]
+        growing_rows = [
+            self._make_row(i + 5, [{"int_val": v}])
+            for i, v in enumerate([10, 20, 30, 40, 50])
+        ]
+        self._setup_collection_split(client, collection_name, sealed_rows, growing_rows)
+
+        # Baseline: structA[0][int_val] >= 30 -> [2,3,4,7,8,9]
+        results, _ = self.query(
+            client, collection_name,
+            filter='id < 100 && structA[0][int_val] >= 30',
+            output_fields=["id"], limit=200,
+        )
+        assert sorted({r["id"] for r in results}) == [2, 3, 4, 7, 8, 9]
+
+        # Delete matching id 4 (sealed) and 7 (growing); also delete id 0 (non-matching)
+        self.delete(client, collection_name, ids=[4, 7, 0])
+        import time
+        time.sleep(1)  # give delete time to propagate
+
+        results, _ = self.query(
+            client, collection_name,
+            filter='id < 100 && structA[0][int_val] >= 30',
+            output_fields=["id"], limit=200,
+        )
+        ids = sorted({r["id"] for r in results})
+        assert ids == [2, 3, 8, 9], (
+            f"After deleting [4,7,0], expected [2,3,8,9], got {ids}"
+        )
+
+        # Sanity: id 0 (non-matching) really gone from any-id query as well
+        results, _ = self.query(
+            client, collection_name,
+            filter='id < 100',
+            output_fields=["id"], limit=200,
+        )
+        all_ids = sorted({r["id"] for r in results})
+        assert 0 not in all_ids and 4 not in all_ids and 7 not in all_ids, (
+            f"Deleted IDs leaked: {all_ids}"
+        )
+
+    # ---- 9.16 After upsert: indexed sub-field changes are reflected ----
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_index_access_query_after_upsert(self):
+        """
+        target: upserting a row's struct array updates the indexed sub-field
+                value seen by structA[i][sub_field] predicates.
+        method: baseline query -> upsert two rows (one sealed, one growing) so
+                that the first-element int_val crosses the predicate threshold
+                in both directions -> requery.
+        expected:
+          - row 1 (sealed, was 20 -> now 100) becomes a new match
+          - row 9 (growing, was 50 -> now 5) drops out
+          - all unchanged rows keep their match status
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_idx_upsert")
+
+        sealed_rows = [
+            self._make_row(i, [{"int_val": v}])
+            for i, v in enumerate([10, 20, 30, 40, 50])
+        ]
+        growing_rows = [
+            self._make_row(i + 5, [{"int_val": v}])
+            for i, v in enumerate([10, 20, 30, 40, 50])
+        ]
+        self._setup_collection_split(client, collection_name, sealed_rows, growing_rows)
+
+        # Baseline: structA[0][int_val] >= 30 -> [2,3,4,7,8,9]
+        results, _ = self.query(
+            client, collection_name,
+            filter='id < 100 && structA[0][int_val] >= 30',
+            output_fields=["id"], limit=200,
+        )
+        assert sorted({r["id"] for r in results}) == [2, 3, 4, 7, 8, 9]
+
+        # Upsert: id 1 sealed (20 -> 100, becomes match)
+        #         id 9 growing (50 -> 5, drops out)
+        upserts = [
+            self._make_row(1, [{"int_val": 100}]),
+            self._make_row(9, [{"int_val": 5}]),
+        ]
+        self.upsert(client, collection_name, upserts)
+        import time
+        time.sleep(1)
+
+        results, _ = self.query(
+            client, collection_name,
+            filter='id < 100 && structA[0][int_val] >= 30',
+            output_fields=["id"], limit=200,
+        )
+        ids = sorted({r["id"] for r in results})
+        assert ids == [1, 2, 3, 4, 7, 8], (
+            f"After upserting id1->100, id9->5, expected [1,2,3,4,7,8], got {ids}"
+        )
+
+    # NOTE: search() filter coverage for index-access / array_contains /
+    # array_length lives in test_milvus_client_struct_array_element_search.py
+    # (TestMilvusClientStructArrayIndexAccessSearch).
+
+    # ====================================================================
+    # Companion correctness tests for array_contains / array_contains_all /
+    # array_contains_any / array_length on struct sub-fields. The earlier
+    # cases (Test Case 1) only verify "no false positives" by walking through
+    # returned hits; the cases below add exact `==` ground-truth assertions
+    # so any false negative also fails the test.
+    # ====================================================================
+
+    # ---- 9.17 array_contains exact correctness ----
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_array_contains_exact_correctness(self):
+        """
+        target: array_contains(structA[sub_field], v) returns the EXACT row set
+                that has v among the sub-field values (no false positives AND
+                no false negatives).
+        method: build controlled rows where the target value appears in some
+                rows multiple times, in some rows not at all, and at varying
+                element positions; assert ids == expected.
+        expected: precise ID set match for int + varchar sub-fields.
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_idx_ac_exact")
+
+        # int_val coverage:
+        #   row 0: [100]                            -> contains 100
+        #   row 1: [200, 201]                       -> contains 200
+        #   row 2: [301, 302, 303]                  -> contains none of {100,200,999}
+        #   row 3: [200, 999]                       -> contains 200 AND 999
+        #   row 4: [700, 100]                       -> contains 100 (at index 1)
+        rows = [
+            self._make_row(0, [{"int_val": 100}]),
+            self._make_row(1, [{"int_val": 200}, {"int_val": 201}]),
+            self._make_row(2, [{"int_val": 301}, {"int_val": 302}, {"int_val": 303}]),
+            self._make_row(3, [{"int_val": 200}, {"int_val": 999}]),
+            self._make_row(4, [{"int_val": 700}, {"int_val": 100}]),
+        ]
+        self._setup_collection(client, collection_name, rows)
+
+        cases = [
+            ('id < 100 && array_contains(structA[int_val], 100)', [0, 4]),
+            ('id < 100 && array_contains(structA[int_val], 200)', [1, 3]),
+            ('id < 100 && array_contains(structA[int_val], 999)', [3]),
+            ('id < 100 && array_contains(structA[int_val], 12345)', []),
+        ]
+        for expr, expected in cases:
+            results, check = self.query(
+                client, collection_name,
+                filter=expr, output_fields=["id"], limit=200,
+            )
+            assert check, expr
+            ids = sorted({r["id"] for r in results})
+            assert ids == expected, f"{expr}: expected {expected}, got {ids}"
+
+    # ---- 9.18 array_contains_all exact correctness ----
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_array_contains_all_exact_correctness(self):
+        """
+        target: array_contains_all(structA[sub_field], [v1, v2, ...]) returns
+                exactly the rows whose sub-field values contain ALL of vi.
+        method: controlled rows with overlapping subsets of {Red, Blue, Green};
+                assert exact ID set per query.
+        expected: precise ID set match.
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_idx_acall_exact")
+
+        # str_val coverage (int_val filler is irrelevant):
+        #   row 0: [Red]                       -> {Red}
+        #   row 1: [Red, Blue]                 -> {Red, Blue}
+        #   row 2: [Blue, Green]               -> {Blue, Green}
+        #   row 3: [Red, Blue, Green]          -> {Red, Blue, Green}
+        #   row 4: [Red, Green]                -> {Red, Green}
+        def _e(s):
+            return {"int_val": 0, "str_val": s}
+
+        rows = [
+            self._make_row(0, [_e("Red")]),
+            self._make_row(1, [_e("Red"), _e("Blue")]),
+            self._make_row(2, [_e("Blue"), _e("Green")]),
+            self._make_row(3, [_e("Red"), _e("Blue"), _e("Green")]),
+            self._make_row(4, [_e("Red"), _e("Green")]),
+        ]
+        self._setup_collection(client, collection_name, rows)
+
+        cases = [
+            ('id < 100 && array_contains_all(structA[str_val], ["Red"])',
+             [0, 1, 3, 4]),
+            ('id < 100 && array_contains_all(structA[str_val], ["Red", "Blue"])',
+             [1, 3]),
+            ('id < 100 && array_contains_all(structA[str_val], ["Red", "Blue", "Green"])',
+             [3]),
+            ('id < 100 && array_contains_all(structA[str_val], ["Yellow"])',
+             []),
+        ]
+        for expr, expected in cases:
+            results, check = self.query(
+                client, collection_name,
+                filter=expr, output_fields=["id"], limit=200,
+            )
+            assert check, expr
+            ids = sorted({r["id"] for r in results})
+            assert ids == expected, f"{expr}: expected {expected}, got {ids}"
+
+    # ---- 9.19 array_contains_any exact correctness ----
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_array_contains_any_exact_correctness(self):
+        """
+        target: array_contains_any(structA[sub_field], [v1, v2, ...]) returns
+                exactly the rows whose sub-field values intersect with the list.
+        method: same controlled dataset as 9.18; query with various lists.
+        expected: precise ID set match.
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_idx_acany_exact")
+
+        def _e(s):
+            return {"int_val": 0, "str_val": s}
+
+        rows = [
+            self._make_row(0, [_e("Red")]),
+            self._make_row(1, [_e("Red"), _e("Blue")]),
+            self._make_row(2, [_e("Blue"), _e("Green")]),
+            self._make_row(3, [_e("Red"), _e("Blue"), _e("Green")]),
+            self._make_row(4, [_e("Red"), _e("Green")]),
+        ]
+        self._setup_collection(client, collection_name, rows)
+
+        cases = [
+            # Red OR Yellow -> rows containing Red
+            ('id < 100 && array_contains_any(structA[str_val], ["Red", "Yellow"])',
+             [0, 1, 3, 4]),
+            # Blue OR Green -> rows containing either
+            ('id < 100 && array_contains_any(structA[str_val], ["Blue", "Green"])',
+             [1, 2, 3, 4]),
+            # only colors absent from controlled data
+            ('id < 100 && array_contains_any(structA[str_val], ["Yellow", "Magenta"])',
+             []),
+        ]
+        for expr, expected in cases:
+            results, check = self.query(
+                client, collection_name,
+                filter=expr, output_fields=["id"], limit=200,
+            )
+            assert check, expr
+            ids = sorted({r["id"] for r in results})
+            assert ids == expected, f"{expr}: expected {expected}, got {ids}"
+
+    # ---- 9.20 array_length after delete & upsert ----
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_array_length_after_delete_and_upsert(self):
+        """
+        target: array_length predicate stays correct after delete and upsert
+                (length-changing) on rows in both sealed and growing segments.
+        method: baseline query -> delete one matching row in each segment ->
+                requery -> upsert two rows (one growing in, one growing out
+                of the predicate by changing struct array length) -> requery.
+        expected: per-step exact ID set match.
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_idx_arrlen_du")
+
+        # length: sealed [1,2,3,4,5] (ids 0..4), growing [1,2,3,4,5] (ids 5..9)
+        sealed_rows = [
+            self._make_row(i, [{"int_val": j} for j in range(i + 1)])
+            for i in range(5)
+        ]
+        growing_rows = [
+            self._make_row(i + 5, [{"int_val": j} for j in range(i + 1)])
+            for i in range(5)
+        ]
+        self._setup_collection_split(client, collection_name, sealed_rows, growing_rows)
+
+        # Baseline: length>=3 -> [2,3,4,7,8,9]
+        results, _ = self.query(
+            client, collection_name,
+            filter='id < 100 && array_length(structA[int_val]) >= 3',
+            output_fields=["id"], limit=200,
+        )
+        assert sorted({r["id"] for r in results}) == [2, 3, 4, 7, 8, 9]
+
+        # Delete one matching row in each segment: 4 (sealed), 8 (growing)
+        self.delete(client, collection_name, ids=[4, 8])
+        import time
+        time.sleep(1)
+
+        results, _ = self.query(
+            client, collection_name,
+            filter='id < 100 && array_length(structA[int_val]) >= 3',
+            output_fields=["id"], limit=200,
+        )
+        assert sorted({r["id"] for r in results}) == [2, 3, 7, 9]
+
+        # Upsert: id 0 (length 1 -> 5, becomes match)
+        #         id 9 (length 5 -> 1, drops out)
+        upserts = [
+            self._make_row(0, [{"int_val": j} for j in range(5)]),  # length 5
+            self._make_row(9, [{"int_val": 0}]),                    # length 1
+        ]
+        self.upsert(client, collection_name, upserts)
+        time.sleep(1)
+
+        results, _ = self.query(
+            client, collection_name,
+            filter='id < 100 && array_length(structA[int_val]) >= 3',
+            output_fields=["id"], limit=200,
+        )
+        ids = sorted({r["id"] for r in results})
+        assert ids == [0, 2, 3, 7], (
+            f"After upserting id0->len5, id9->len1, expected [0,2,3,7], got {ids}"
+        )

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_element_query.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_element_query.py
@@ -3388,7 +3388,6 @@ class TestMilvusClientStructArrayElementMatchQuery(TestMilvusClientV2Base):
 # ==================== Test Case 9: StructArray Index Access (PR #48987) ====================
 
 
-@pytest.mark.xdist_group("TestMilvusClientStructArrayIndexAccess")
 class TestMilvusClientStructArrayIndexAccess(TestMilvusClientV2Base):
     """Test struct_arr[index][sub_field] index-access syntax (PR #48987).
 

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_element_query.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_element_query.py
@@ -7,18 +7,17 @@ Tests for struct array element-level query features:
 - MATCH family operators in pure query context
 """
 
-import pytest
-import numpy as np
 import random
 
+import numpy as np
+import pytest
 from base.client_v2_base import TestMilvusClientV2Base
-from utils.util_log import test_log as log
 from common import common_func as cf
 from common import common_type as ct
 from common.common_type import CaseLabel, CheckTasks
-from utils.util_pymilvus import *
 from common.constants import *  # noqa
 from pymilvus import DataType
+from utils.util_log import test_log as log
 
 prefix = "struct_elem_query"
 epsilon = 0.001
@@ -54,8 +53,7 @@ def gt_element_filter_query(data, elem_filter_fn, doc_filter_fn=None):
     return ids
 
 
-def gt_match_query(data, match_type, elem_filter_fn, threshold=None,
-                   doc_filter_fn=None):
+def gt_match_query(data, match_type, elem_filter_fn, threshold=None, doc_filter_fn=None):
     """Ground truth for MATCH family query."""
     matching = []
     for row in data:
@@ -65,21 +63,22 @@ def gt_match_query(data, match_type, elem_filter_fn, threshold=None,
         total = len(row["structA"])
         matched = False
         if match_type == "MATCH_ALL":
-            matched = (count == total)
+            matched = count == total
         elif match_type == "MATCH_ANY":
-            matched = (count >= 1)
+            matched = count >= 1
         elif match_type == "MATCH_LEAST":
-            matched = (count >= threshold)
+            matched = count >= threshold
         elif match_type == "MATCH_MOST":
-            matched = (count <= threshold)
+            matched = count <= threshold
         elif match_type == "MATCH_EXACT":
-            matched = (count == threshold)
+            matched = count == threshold
         if matched:
             matching.append(row["id"])
     return set(matching)
 
 
 # ==================== Test Case 1: ARRAY_CONTAINS* in Struct Array ====================
+
 
 @pytest.mark.xdist_group("TestMilvusClientStructArrayElementContains")
 class TestMilvusClientStructArrayElementContains(TestMilvusClientV2Base):
@@ -110,7 +109,8 @@ class TestMilvusClientStructArrayElementContains(TestMilvusClientV2Base):
         struct_schema.add_field("category", DataType.VARCHAR, max_length=128)
 
         schema.add_field(
-            "structA", datatype=DataType.ARRAY,
+            "structA",
+            datatype=DataType.ARRAY,
             element_type=DataType.STRUCT,
             struct_schema=struct_schema,
             max_capacity=default_capacity,
@@ -118,16 +118,19 @@ class TestMilvusClientStructArrayElementContains(TestMilvusClientV2Base):
 
         index_params = client.prepare_index_params()
         index_params.add_index(
-            field_name="normal_vector", index_type="HNSW",
-            metric_type="COSINE", params=INDEX_PARAMS,
+            field_name="normal_vector",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
         )
         index_params.add_index(
-            field_name="structA[embedding]", index_type="HNSW",
-            metric_type="COSINE", params=INDEX_PARAMS,
+            field_name="structA[embedding]",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
         )
         # force_teardown=False: don't let teardown_method drop this collection
-        self.create_collection(client, collection_name, schema=schema,
-                               index_params=index_params, force_teardown=False)
+        self.create_collection(client, collection_name, schema=schema, index_params=index_params, force_teardown=False)
 
         def _make_row(i):
             rng = random.Random(i)
@@ -136,14 +139,17 @@ class TestMilvusClientStructArrayElementContains(TestMilvusClientV2Base):
                 "id": i,
                 "doc_int": i,
                 "normal_vector": _seed_vector(i + 999999, default_dim),
-                "structA": [{
-                    "embedding": _seed_vector(i * 1000 + j, default_dim),
-                    "int_val": i * 100 + j,
-                    "str_val": f"row_{i}_elem_{j}",
-                    "float_val": float(i + j * 0.1),
-                    "color": COLORS[j % 3],
-                    "category": CATEGORIES[(i + j) % 4],
-                } for j in range(num_elems)],
+                "structA": [
+                    {
+                        "embedding": _seed_vector(i * 1000 + j, default_dim),
+                        "int_val": i * 100 + j,
+                        "str_val": f"row_{i}_elem_{j}",
+                        "float_val": float(i + j * 0.1),
+                        "color": COLORS[j % 3],
+                        "category": CATEGORIES[(i + j) % 4],
+                    }
+                    for j in range(num_elems)
+                ],
             }
 
         # Sealed: 3000 rows, inserted in batches
@@ -183,8 +189,9 @@ class TestMilvusClientStructArrayElementContains(TestMilvusClientV2Base):
 
         target_val = 100  # row 1 elem 0
         results, check = self.query(
-            client, collection_name,
-            filter=f'array_contains(structA[int_val], {target_val})',
+            client,
+            collection_name,
+            filter=f"array_contains(structA[int_val], {target_val})",
             output_fields=["id", "structA"],
             limit=50,
         )
@@ -192,8 +199,7 @@ class TestMilvusClientStructArrayElementContains(TestMilvusClientV2Base):
         assert len(results) > 0
         for hit in results:
             int_vals = [e["int_val"] for e in hit["structA"]]
-            assert target_val in int_vals, \
-                f"Row {hit['id']}: {target_val} not in int_vals {int_vals}"
+            assert target_val in int_vals, f"Row {hit['id']}: {target_val} not in int_vals {int_vals}"
 
     @pytest.mark.tags(CaseLabel.L0)
     def test_array_contains_varchar_subfield(self):
@@ -206,7 +212,8 @@ class TestMilvusClientStructArrayElementContains(TestMilvusClientV2Base):
         collection_name = self.shared_collection
 
         results, check = self.query(
-            client, collection_name,
+            client,
+            collection_name,
             filter='array_contains(structA[color], "Red")',
             output_fields=["id", "structA"],
             limit=50,
@@ -215,8 +222,7 @@ class TestMilvusClientStructArrayElementContains(TestMilvusClientV2Base):
         assert len(results) > 0
         for hit in results:
             colors = [e["color"] for e in hit["structA"]]
-            assert "Red" in colors, \
-                f"Row {hit['id']}: 'Red' not in colors {colors}"
+            assert "Red" in colors, f"Row {hit['id']}: 'Red' not in colors {colors}"
 
     # ---- 1.2 array_contains_all on struct sub-field ----
 
@@ -232,7 +238,8 @@ class TestMilvusClientStructArrayElementContains(TestMilvusClientV2Base):
         data = self.shared_data
 
         results, check = self.query(
-            client, collection_name,
+            client,
+            collection_name,
             filter='array_contains_all(structA[color], ["Red", "Blue"])',
             output_fields=["id", "structA"],
             limit=50,
@@ -241,8 +248,7 @@ class TestMilvusClientStructArrayElementContains(TestMilvusClientV2Base):
         assert len(results) > 0
         for hit in results:
             colors = set(e["color"] for e in hit["structA"])
-            assert "Red" in colors and "Blue" in colors, \
-                f"Row {hit['id']}: colors {colors} missing Red or Blue"
+            assert "Red" in colors and "Blue" in colors, f"Row {hit['id']}: colors {colors} missing Red or Blue"
 
         gt_ids = set()
         for row in data:
@@ -265,7 +271,8 @@ class TestMilvusClientStructArrayElementContains(TestMilvusClientV2Base):
         collection_name = self.shared_collection
 
         results, check = self.query(
-            client, collection_name,
+            client,
+            collection_name,
             filter='array_contains_any(structA[category], ["A", "B"])',
             output_fields=["id", "structA"],
             limit=50,
@@ -274,8 +281,7 @@ class TestMilvusClientStructArrayElementContains(TestMilvusClientV2Base):
         assert len(results) > 0
         for hit in results:
             categories = set(e["category"] for e in hit["structA"])
-            assert categories & {"A", "B"}, \
-                f"Row {hit['id']}: categories {categories} has no A or B"
+            assert categories & {"A", "B"}, f"Row {hit['id']}: categories {categories} has no A or B"
 
     # ---- 1.4 array_contains with search ----
 
@@ -293,11 +299,12 @@ class TestMilvusClientStructArrayElementContains(TestMilvusClientV2Base):
         query_vector = data[1]["normal_vector"]
         target_val = 100  # row 1 elem 0
         results, check = self.search(
-            client, collection_name,
+            client,
+            collection_name,
             data=[query_vector],
             anns_field="normal_vector",
             search_params={"metric_type": "COSINE"},
-            filter=f'array_contains(structA[int_val], {target_val})',
+            filter=f"array_contains(structA[int_val], {target_val})",
             limit=10,
             output_fields=["id", "structA"],
         )
@@ -305,8 +312,7 @@ class TestMilvusClientStructArrayElementContains(TestMilvusClientV2Base):
         assert len(results) > 0
         for hit in results[0]:
             int_vals = [e["int_val"] for e in hit["structA"]]
-            assert target_val in int_vals, \
-                f"Row {hit['id']}: {target_val} not in int_vals"
+            assert target_val in int_vals, f"Row {hit['id']}: {target_val} not in int_vals"
 
     # ---- 1.5 array_contains combined with compound filter ----
 
@@ -321,7 +327,8 @@ class TestMilvusClientStructArrayElementContains(TestMilvusClientV2Base):
         collection_name = self.shared_collection
 
         results, check = self.query(
-            client, collection_name,
+            client,
+            collection_name,
             filter='doc_int > 100 && array_contains(structA[color], "Red")',
             output_fields=["id", "doc_int", "structA"],
             limit=50,
@@ -345,8 +352,9 @@ class TestMilvusClientStructArrayElementContains(TestMilvusClientV2Base):
         collection_name = self.shared_collection
 
         results, check = self.query(
-            client, collection_name,
-            filter='array_contains_all(structA[int_val], [100, 101])',
+            client,
+            collection_name,
+            filter="array_contains_all(structA[int_val], [100, 101])",
             output_fields=["id", "structA"],
             limit=50,
         )
@@ -354,8 +362,7 @@ class TestMilvusClientStructArrayElementContains(TestMilvusClientV2Base):
         assert len(results) > 0
         for hit in results:
             int_vals = set(e["int_val"] for e in hit["structA"])
-            assert 100 in int_vals and 101 in int_vals, \
-                f"Row {hit['id']}: int_vals {int_vals} missing 100 or 101"
+            assert 100 in int_vals and 101 in int_vals, f"Row {hit['id']}: int_vals {int_vals} missing 100 or 101"
 
     # ---- 1.7 array_contains with inverted index ----
 
@@ -372,8 +379,9 @@ class TestMilvusClientStructArrayElementContains(TestMilvusClientV2Base):
 
         target_val = 200  # row 2 elem 0
         results, check = self.query(
-            client, collection_name,
-            filter=f'array_contains(structA[int_val], {target_val})',
+            client,
+            collection_name,
+            filter=f"array_contains(structA[int_val], {target_val})",
             output_fields=["id", "structA"],
             limit=50,
         )
@@ -384,6 +392,7 @@ class TestMilvusClientStructArrayElementContains(TestMilvusClientV2Base):
 
 
 # ==================== Test Case 2: Element-level Query ====================
+
 
 @pytest.mark.xdist_group("TestMilvusClientStructArrayElementQuery")
 class TestMilvusClientStructArrayElementQuery(TestMilvusClientV2Base):
@@ -406,7 +415,8 @@ class TestMilvusClientStructArrayElementQuery(TestMilvusClientV2Base):
         struct_schema.add_field("category", DataType.VARCHAR, max_length=128)
 
         schema.add_field(
-            "structA", datatype=DataType.ARRAY,
+            "structA",
+            datatype=DataType.ARRAY,
             element_type=DataType.STRUCT,
             struct_schema=struct_schema,
             max_capacity=default_capacity,
@@ -421,21 +431,25 @@ class TestMilvusClientStructArrayElementQuery(TestMilvusClientV2Base):
             num_elems = rng.randint(3, 8)
             struct_array = []
             for j in range(num_elems):
-                struct_array.append({
-                    "embedding": _seed_vector(i * 1000 + j, dim),
-                    "int_val": i * 100 + j,
-                    "str_val": f"row_{i}_elem_{j}",
-                    "float_val": float(i + j * 0.1),
-                    "color": COLORS[j % 3],
-                    "category": CATEGORIES[(i + j) % 4],
-                })
-            data.append({
-                "id": i,
-                "doc_int": i,
-                "doc_varchar": f"cat_{i % 10}",
-                "normal_vector": _seed_vector(i + 999999, dim),
-                "structA": struct_array,
-            })
+                struct_array.append(
+                    {
+                        "embedding": _seed_vector(i * 1000 + j, dim),
+                        "int_val": i * 100 + j,
+                        "str_val": f"row_{i}_elem_{j}",
+                        "float_val": float(i + j * 0.1),
+                        "color": COLORS[j % 3],
+                        "category": CATEGORIES[(i + j) % 4],
+                    }
+                )
+            data.append(
+                {
+                    "id": i,
+                    "doc_int": i,
+                    "doc_varchar": f"cat_{i % 10}",
+                    "normal_vector": _seed_vector(i + 999999, dim),
+                    "structA": struct_array,
+                }
+            )
         return data
 
     @pytest.fixture(scope="class", autouse=True)
@@ -447,16 +461,19 @@ class TestMilvusClientStructArrayElementQuery(TestMilvusClientV2Base):
         schema = self._create_schema(client)
         index_params = client.prepare_index_params()
         index_params.add_index(
-            field_name="normal_vector", index_type="HNSW",
-            metric_type="COSINE", params=INDEX_PARAMS,
+            field_name="normal_vector",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
         )
         index_params.add_index(
-            field_name="structA[embedding]", index_type="HNSW",
-            metric_type="COSINE", params=INDEX_PARAMS,
+            field_name="structA[embedding]",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
         )
         # force_teardown=False to prevent teardown_method from dropping it
-        self.create_collection(client, collection_name, schema=schema,
-                               index_params=index_params, force_teardown=False)
+        self.create_collection(client, collection_name, schema=schema, index_params=index_params, force_teardown=False)
 
         # Sealed: 3000 rows in batches
         data = []
@@ -495,16 +512,16 @@ class TestMilvusClientStructArrayElementQuery(TestMilvusClientV2Base):
         data = self.shared_data
 
         results, check = self.query(
-            client, collection_name,
-            filter='element_filter(structA, $[int_val] > 200)',
+            client,
+            collection_name,
+            filter="element_filter(structA, $[int_val] > 200)",
             output_fields=["id", "structA"],
             limit=50,
         )
         assert check
         assert len(results) > 0
         for hit in results:
-            assert any(e["int_val"] > 200 for e in hit["structA"]), \
-                f"Row {hit['id']} has no element with int_val > 200"
+            assert any(e["int_val"] > 200 for e in hit["structA"]), f"Row {hit['id']} has no element with int_val > 200"
 
         gt_ids = gt_element_filter_query(data, lambda e: e["int_val"] > 200)
         milvus_ids = {r["id"] for r in results}
@@ -524,7 +541,8 @@ class TestMilvusClientStructArrayElementQuery(TestMilvusClientV2Base):
         data = self.shared_data
 
         results, check = self.query(
-            client, collection_name,
+            client,
+            collection_name,
             filter='element_filter(structA, $[color] == "Red" && $[int_val] > 100)',
             output_fields=["id", "structA"],
             limit=50,
@@ -532,13 +550,13 @@ class TestMilvusClientStructArrayElementQuery(TestMilvusClientV2Base):
         assert check
         assert len(results) > 0
         for hit in results:
-            assert any(
-                e["color"] == "Red" and e["int_val"] > 100
-                for e in hit["structA"]
-            ), f"Row {hit['id']}: no element matches compound condition"
+            assert any(e["color"] == "Red" and e["int_val"] > 100 for e in hit["structA"]), (
+                f"Row {hit['id']}: no element matches compound condition"
+            )
 
         gt_ids = gt_element_filter_query(
-            data, lambda e: e["color"] == "Red" and e["int_val"] > 100,
+            data,
+            lambda e: e["color"] == "Red" and e["int_val"] > 100,
         )
         milvus_ids = {r["id"] for r in results}
         assert milvus_ids.issubset(gt_ids)
@@ -557,8 +575,9 @@ class TestMilvusClientStructArrayElementQuery(TestMilvusClientV2Base):
         data = self.shared_data
 
         results, check = self.query(
-            client, collection_name,
-            filter='id > 100 && element_filter(structA, $[int_val] > 200)',
+            client,
+            collection_name,
+            filter="id > 100 && element_filter(structA, $[int_val] > 200)",
             output_fields=["id", "structA"],
             limit=50,
         )
@@ -568,7 +587,8 @@ class TestMilvusClientStructArrayElementQuery(TestMilvusClientV2Base):
             assert any(e["int_val"] > 200 for e in hit["structA"])
 
         gt_ids = gt_element_filter_query(
-            data, lambda e: e["int_val"] > 200,
+            data,
+            lambda e: e["int_val"] > 200,
             doc_filter_fn=lambda row: row["id"] > 100,
         )
         milvus_ids = {r["id"] for r in results}
@@ -587,7 +607,8 @@ class TestMilvusClientStructArrayElementQuery(TestMilvusClientV2Base):
         collection_name = self.shared_collection
 
         results, check = self.query(
-            client, collection_name,
+            client,
+            collection_name,
             filter='element_filter(structA, $[color] == "Blue")',
             output_fields=["id", "structA[int_val]", "structA[color]"],
             limit=20,
@@ -609,8 +630,9 @@ class TestMilvusClientStructArrayElementQuery(TestMilvusClientV2Base):
         data = self.shared_data
 
         results, check = self.query(
-            client, collection_name,
-            filter='MATCH_ALL(structA, $[int_val] > 0)',
+            client,
+            collection_name,
+            filter="MATCH_ALL(structA, $[int_val] > 0)",
             output_fields=["id", "structA"],
             limit=100,
         )
@@ -636,7 +658,8 @@ class TestMilvusClientStructArrayElementQuery(TestMilvusClientV2Base):
         data = self.shared_data
 
         results, check = self.query(
-            client, collection_name,
+            client,
+            collection_name,
             filter='MATCH_ANY(structA, $[color] == "Green")',
             output_fields=["id", "structA"],
             limit=100,
@@ -663,8 +686,9 @@ class TestMilvusClientStructArrayElementQuery(TestMilvusClientV2Base):
         data = self.shared_data
 
         results, check = self.query(
-            client, collection_name,
-            filter='MATCH_LEAST(structA, $[int_val] > 5, threshold=2)',
+            client,
+            collection_name,
+            filter="MATCH_LEAST(structA, $[int_val] > 5, threshold=2)",
             output_fields=["id", "structA"],
             limit=100,
         )
@@ -692,14 +716,20 @@ class TestMilvusClientStructArrayElementQuery(TestMilvusClientV2Base):
         collection_name = self.shared_collection
 
         results_p1, _ = self.query(
-            client, collection_name,
-            filter='element_filter(structA, $[int_val] > 100)',
-            output_fields=["id"], limit=10, offset=0,
+            client,
+            collection_name,
+            filter="element_filter(structA, $[int_val] > 100)",
+            output_fields=["id"],
+            limit=10,
+            offset=0,
         )
         results_p2, _ = self.query(
-            client, collection_name,
-            filter='element_filter(structA, $[int_val] > 100)',
-            output_fields=["id"], limit=10, offset=10,
+            client,
+            collection_name,
+            filter="element_filter(structA, $[int_val] > 100)",
+            output_fields=["id"],
+            limit=10,
+            offset=10,
         )
         ids_p1 = {r["id"] for r in results_p1}
         ids_p2 = {r["id"] for r in results_p2}
@@ -718,8 +748,9 @@ class TestMilvusClientStructArrayElementQuery(TestMilvusClientV2Base):
         collection_name = self.shared_collection
 
         results, check = self.query(
-            client, collection_name,
-            filter='element_filter(structA, $[int_val] > 200)',
+            client,
+            collection_name,
+            filter="element_filter(structA, $[int_val] > 200)",
             output_fields=["count(*)"],
         )
         assert check
@@ -741,12 +772,16 @@ class TestMilvusClientStructArrayElementQuery(TestMilvusClientV2Base):
         schema = self._create_schema(client)
         index_params = client.prepare_index_params()
         index_params.add_index(
-            field_name="normal_vector", index_type="HNSW",
-            metric_type="COSINE", params=INDEX_PARAMS,
+            field_name="normal_vector",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
         )
         index_params.add_index(
-            field_name="structA[embedding]", index_type="HNSW",
-            metric_type="COSINE", params=INDEX_PARAMS,
+            field_name="structA[embedding]",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
         )
         self.create_collection(client, collection_name, schema=schema, index_params=index_params)
 
@@ -766,23 +801,23 @@ class TestMilvusClientStructArrayElementQuery(TestMilvusClientV2Base):
         # Query both segments — filter targets rows from both sealed and growing
         threshold = (default_nb - 100) * 100  # ensures hits in both segments
         results, check = self.query(
-            client, collection_name,
-            filter=f'element_filter(structA, $[int_val] > {threshold})',
+            client,
+            collection_name,
+            filter=f"element_filter(structA, $[int_val] > {threshold})",
             output_fields=["id"],
             limit=16384,
         )
         assert check
         milvus_ids = {r["id"] for r in results}
-        assert any(rid >= default_nb for rid in milvus_ids), \
-            "No results from growing segment"
-        assert any(rid < default_nb for rid in milvus_ids), \
-            "No results from sealed segment"
+        assert any(rid >= default_nb for rid in milvus_ids), "No results from growing segment"
+        assert any(rid < default_nb for rid in milvus_ids), "No results from sealed segment"
         all_data = data_sealed + data_growing
         gt_ids = gt_element_filter_query(all_data, lambda e: e["int_val"] > threshold)
         assert milvus_ids.issubset(gt_ids)
 
 
 # ==================== Test Case 4: STL_SORT Index on Struct Fields ====================
+
 
 @pytest.mark.xdist_group("TestMilvusClientStructArrayElementSTLSortIndex")
 class TestMilvusClientStructArrayElementSTLSortIndex(TestMilvusClientV2Base):
@@ -803,7 +838,8 @@ class TestMilvusClientStructArrayElementSTLSortIndex(TestMilvusClientV2Base):
         struct_schema.add_field("color", DataType.VARCHAR, max_length=128)
 
         schema.add_field(
-            "structA", datatype=DataType.ARRAY,
+            "structA",
+            datatype=DataType.ARRAY,
             element_type=DataType.STRUCT,
             struct_schema=struct_schema,
             max_capacity=default_capacity,
@@ -818,19 +854,23 @@ class TestMilvusClientStructArrayElementSTLSortIndex(TestMilvusClientV2Base):
             num_elems = rng.randint(3, 8)
             struct_array = []
             for j in range(num_elems):
-                struct_array.append({
-                    "embedding": _seed_vector(i * 1000 + j, dim),
-                    "int_val": i * 100 + j,
-                    "str_val": f"row_{i}_elem_{j}",
-                    "float_val": float(i + j * 0.1),
-                    "color": COLORS[j % 3],
-                })
-            data.append({
-                "id": i,
-                "doc_int": i,
-                "normal_vector": _seed_vector(i + 999999, dim),
-                "structA": struct_array,
-            })
+                struct_array.append(
+                    {
+                        "embedding": _seed_vector(i * 1000 + j, dim),
+                        "int_val": i * 100 + j,
+                        "str_val": f"row_{i}_elem_{j}",
+                        "float_val": float(i + j * 0.1),
+                        "color": COLORS[j % 3],
+                    }
+                )
+            data.append(
+                {
+                    "id": i,
+                    "doc_int": i,
+                    "normal_vector": _seed_vector(i + 999999, dim),
+                    "structA": struct_array,
+                }
+            )
         return data
 
     def _insert_sealed_and_growing(self, client, collection_name):
@@ -862,27 +902,36 @@ class TestMilvusClientStructArrayElementSTLSortIndex(TestMilvusClientV2Base):
         schema = self._create_schema(client)
         index_params = client.prepare_index_params()
         index_params.add_index(
-            field_name="normal_vector", index_type="HNSW",
-            metric_type="COSINE", params=INDEX_PARAMS,
+            field_name="normal_vector",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
         )
         index_params.add_index(
-            field_name="structA[embedding]", index_type="HNSW",
-            metric_type="COSINE", params=INDEX_PARAMS,
+            field_name="structA[embedding]",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
         )
         index_params.add_index(
-            field_name="structA[int_val]", index_type="STL_SORT",
+            field_name="structA[int_val]",
+            index_type="STL_SORT",
         )
         res, check = self.create_collection(
-            client, collection_name, schema=schema, index_params=index_params,
+            client,
+            collection_name,
+            schema=schema,
+            index_params=index_params,
         )
         assert check
 
-        data = self._insert_sealed_and_growing(client, collection_name)
+        self._insert_sealed_and_growing(client, collection_name)
 
         # Verify collection is loaded and queryable
         results, check = self.query(
-            client, collection_name,
-            filter='id < 10',
+            client,
+            collection_name,
+            filter="id < 10",
             output_fields=["id"],
             limit=10,
         )
@@ -902,26 +951,35 @@ class TestMilvusClientStructArrayElementSTLSortIndex(TestMilvusClientV2Base):
         schema = self._create_schema(client)
         index_params = client.prepare_index_params()
         index_params.add_index(
-            field_name="normal_vector", index_type="HNSW",
-            metric_type="COSINE", params=INDEX_PARAMS,
+            field_name="normal_vector",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
         )
         index_params.add_index(
-            field_name="structA[embedding]", index_type="HNSW",
-            metric_type="COSINE", params=INDEX_PARAMS,
+            field_name="structA[embedding]",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
         )
         index_params.add_index(
-            field_name="structA[str_val]", index_type="STL_SORT",
+            field_name="structA[str_val]",
+            index_type="STL_SORT",
         )
         res, check = self.create_collection(
-            client, collection_name, schema=schema, index_params=index_params,
+            client,
+            collection_name,
+            schema=schema,
+            index_params=index_params,
         )
         assert check
 
-        data = self._insert_sealed_and_growing(client, collection_name)
+        self._insert_sealed_and_growing(client, collection_name)
 
         results, check = self.query(
-            client, collection_name,
-            filter='id < 10',
+            client,
+            collection_name,
+            filter="id < 10",
             output_fields=["id"],
             limit=10,
         )
@@ -943,18 +1001,26 @@ class TestMilvusClientStructArrayElementSTLSortIndex(TestMilvusClientV2Base):
         schema = self._create_schema(client)
         index_params = client.prepare_index_params()
         index_params.add_index(
-            field_name="normal_vector", index_type="HNSW",
-            metric_type="COSINE", params=INDEX_PARAMS,
+            field_name="normal_vector",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
         )
         index_params.add_index(
-            field_name="structA[embedding]", index_type="HNSW",
-            metric_type="COSINE", params=INDEX_PARAMS,
+            field_name="structA[embedding]",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
         )
         index_params.add_index(
-            field_name="structA[int_val]", index_type="STL_SORT",
+            field_name="structA[int_val]",
+            index_type="STL_SORT",
         )
         res, check = self.create_collection(
-            client, collection_name, schema=schema, index_params=index_params,
+            client,
+            collection_name,
+            schema=schema,
+            index_params=index_params,
         )
         assert check
 
@@ -962,26 +1028,21 @@ class TestMilvusClientStructArrayElementSTLSortIndex(TestMilvusClientV2Base):
 
         query_vector = data[0]["structA"][0]["embedding"]
         results, check = self.search(
-            client, collection_name,
+            client,
+            collection_name,
             data=[query_vector],
             anns_field="structA[embedding]",
             search_params={"metric_type": "COSINE"},
-            filter='element_filter(structA, $[int_val] > 200)',
+            filter="element_filter(structA, $[int_val] > 200)",
             limit=10,
             output_fields=["id", "structA"],
         )
         assert check
         assert len(results) > 0
 
-        # Verify filter condition
-        for hit in results[0]:
-            assert any(e["int_val"] > 200 for e in hit["structA"])
-
         # Verify all results satisfy the filter (correctness, not recall)
-        milvus_ids = {hit["id"] for hit in results[0]}
         for hit in results[0]:
-            assert any(e["int_val"] > 200 for e in hit["structA"]), \
-                f"Row {hit['id']}: no element with int_val > 200"
+            assert any(e["int_val"] > 200 for e in hit["structA"]), f"Row {hit['id']}: no element with int_val > 200"
 
     # ---- 4.3 STL_SORT + INVERTED index coexistence ----
 
@@ -998,21 +1059,30 @@ class TestMilvusClientStructArrayElementSTLSortIndex(TestMilvusClientV2Base):
         schema = self._create_schema(client)
         index_params = client.prepare_index_params()
         index_params.add_index(
-            field_name="normal_vector", index_type="HNSW",
-            metric_type="COSINE", params=INDEX_PARAMS,
+            field_name="normal_vector",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
         )
         index_params.add_index(
-            field_name="structA[embedding]", index_type="HNSW",
-            metric_type="COSINE", params=INDEX_PARAMS,
+            field_name="structA[embedding]",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
         )
         index_params.add_index(
-            field_name="structA[int_val]", index_type="STL_SORT",
+            field_name="structA[int_val]",
+            index_type="STL_SORT",
         )
         index_params.add_index(
-            field_name="structA[color]", index_type="INVERTED",
+            field_name="structA[color]",
+            index_type="INVERTED",
         )
         res, check = self.create_collection(
-            client, collection_name, schema=schema, index_params=index_params,
+            client,
+            collection_name,
+            schema=schema,
+            index_params=index_params,
         )
         assert check
 
@@ -1021,11 +1091,12 @@ class TestMilvusClientStructArrayElementSTLSortIndex(TestMilvusClientV2Base):
         # Search using filter on int_val (STL_SORT indexed)
         query_vector = data[0]["structA"][0]["embedding"]
         results1, check1 = self.search(
-            client, collection_name,
+            client,
+            collection_name,
             data=[query_vector],
             anns_field="structA[embedding]",
             search_params={"metric_type": "COSINE"},
-            filter='element_filter(structA, $[int_val] > 100)',
+            filter="element_filter(structA, $[int_val] > 100)",
             limit=10,
             output_fields=["id"],
         )
@@ -1034,7 +1105,8 @@ class TestMilvusClientStructArrayElementSTLSortIndex(TestMilvusClientV2Base):
 
         # Search using filter on color (INVERTED indexed)
         results2, check2 = self.search(
-            client, collection_name,
+            client,
+            collection_name,
             data=[query_vector],
             anns_field="structA[embedding]",
             search_params={"metric_type": "COSINE"},
@@ -1060,26 +1132,35 @@ class TestMilvusClientStructArrayElementSTLSortIndex(TestMilvusClientV2Base):
         schema = self._create_schema(client)
         index_params = client.prepare_index_params()
         index_params.add_index(
-            field_name="normal_vector", index_type="HNSW",
-            metric_type="COSINE", params=INDEX_PARAMS,
+            field_name="normal_vector",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
         )
         index_params.add_index(
-            field_name="structA[embedding]", index_type="HNSW",
-            metric_type="COSINE", params=INDEX_PARAMS,
+            field_name="structA[embedding]",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
         )
         index_params.add_index(
-            field_name="structA[int_val]", index_type="STL_SORT",
+            field_name="structA[int_val]",
+            index_type="STL_SORT",
         )
         res, check = self.create_collection(
-            client, collection_name, schema=schema, index_params=index_params,
+            client,
+            collection_name,
+            schema=schema,
+            index_params=index_params,
         )
         assert check
 
         data = self._insert_sealed_and_growing(client, collection_name)
 
         results, check = self.query(
-            client, collection_name,
-            filter='MATCH_ALL(structA, $[int_val] > 0)',
+            client,
+            collection_name,
+            filter="MATCH_ALL(structA, $[int_val] > 0)",
             output_fields=["id", "structA"],
             limit=100,
         )
@@ -1095,6 +1176,7 @@ class TestMilvusClientStructArrayElementSTLSortIndex(TestMilvusClientV2Base):
 
 
 # ==================== Test Case 5: Index Type Regression (#48183) ====================
+
 
 @pytest.mark.xdist_group("TestMilvusClientStructArrayElementIndexRegression")
 class TestMilvusClientStructArrayElementIndexRegression(TestMilvusClientV2Base):
@@ -1114,7 +1196,8 @@ class TestMilvusClientStructArrayElementIndexRegression(TestMilvusClientV2Base):
         struct_schema.add_field("color", DataType.VARCHAR, max_length=128)
 
         schema.add_field(
-            "structA", datatype=DataType.ARRAY,
+            "structA",
+            datatype=DataType.ARRAY,
             element_type=DataType.STRUCT,
             struct_schema=struct_schema,
             max_capacity=default_capacity,
@@ -1129,18 +1212,22 @@ class TestMilvusClientStructArrayElementIndexRegression(TestMilvusClientV2Base):
             num_elems = rng.randint(3, 8)
             struct_array = []
             for j in range(num_elems):
-                struct_array.append({
-                    "embedding": _seed_vector(i * 1000 + j, dim),
-                    "int_val": i * 100 + j,
-                    "str_val": f"row_{i}_elem_{j}",
-                    "float_val": float(i + j * 0.1),
-                    "color": COLORS[j % 3],
-                })
-            data.append({
-                "id": i,
-                "normal_vector": _seed_vector(i + 999999, dim),
-                "structA": struct_array,
-            })
+                struct_array.append(
+                    {
+                        "embedding": _seed_vector(i * 1000 + j, dim),
+                        "int_val": i * 100 + j,
+                        "str_val": f"row_{i}_elem_{j}",
+                        "float_val": float(i + j * 0.1),
+                        "color": COLORS[j % 3],
+                    }
+                )
+            data.append(
+                {
+                    "id": i,
+                    "normal_vector": _seed_vector(i + 999999, dim),
+                    "structA": struct_array,
+                }
+            )
         return data
 
     def _insert_sealed_and_growing(self, client, collection_name):
@@ -1172,18 +1259,26 @@ class TestMilvusClientStructArrayElementIndexRegression(TestMilvusClientV2Base):
         schema = self._create_schema(client)
         index_params = client.prepare_index_params()
         index_params.add_index(
-            field_name="normal_vector", index_type="HNSW",
-            metric_type="COSINE", params=INDEX_PARAMS,
+            field_name="normal_vector",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
         )
         index_params.add_index(
-            field_name="structA[embedding]", index_type="HNSW",
-            metric_type="COSINE", params=INDEX_PARAMS,
+            field_name="structA[embedding]",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
         )
         index_params.add_index(
-            field_name="structA[color]", index_type="INVERTED",
+            field_name="structA[color]",
+            index_type="INVERTED",
         )
         res, check = self.create_collection(
-            client, collection_name, schema=schema, index_params=index_params,
+            client,
+            collection_name,
+            schema=schema,
+            index_params=index_params,
         )
         assert check
 
@@ -1191,7 +1286,8 @@ class TestMilvusClientStructArrayElementIndexRegression(TestMilvusClientV2Base):
 
         # Verify index works by querying
         results, check = self.search(
-            client, collection_name,
+            client,
+            collection_name,
             data=[data[0]["structA"][0]["embedding"]],
             anns_field="structA[embedding]",
             search_params={"metric_type": "COSINE"},
@@ -1217,18 +1313,26 @@ class TestMilvusClientStructArrayElementIndexRegression(TestMilvusClientV2Base):
         schema = self._create_schema(client)
         index_params = client.prepare_index_params()
         index_params.add_index(
-            field_name="normal_vector", index_type="HNSW",
-            metric_type="COSINE", params=INDEX_PARAMS,
+            field_name="normal_vector",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
         )
         index_params.add_index(
-            field_name="structA[embedding]", index_type="HNSW",
-            metric_type="COSINE", params=INDEX_PARAMS,
+            field_name="structA[embedding]",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
         )
         index_params.add_index(
-            field_name="structA[int_val]", index_type="INVERTED",
+            field_name="structA[int_val]",
+            index_type="INVERTED",
         )
         res, check = self.create_collection(
-            client, collection_name, schema=schema, index_params=index_params,
+            client,
+            collection_name,
+            schema=schema,
+            index_params=index_params,
         )
         assert check
 
@@ -1238,11 +1342,12 @@ class TestMilvusClientStructArrayElementIndexRegression(TestMilvusClientV2Base):
         self.load_collection(client, collection_name)
 
         results, check = self.search(
-            client, collection_name,
+            client,
+            collection_name,
             data=[data[0]["structA"][0]["embedding"]],
             anns_field="structA[embedding]",
             search_params={"metric_type": "COSINE"},
-            filter='element_filter(structA, $[int_val] > 100)',
+            filter="element_filter(structA, $[int_val] > 100)",
             limit=10,
             output_fields=["id", "structA"],
         )
@@ -1266,29 +1371,37 @@ class TestMilvusClientStructArrayElementIndexRegression(TestMilvusClientV2Base):
         schema = self._create_schema(client)
         index_params = client.prepare_index_params()
         index_params.add_index(
-            field_name="normal_vector", index_type="HNSW",
-            metric_type="COSINE", params=INDEX_PARAMS,
+            field_name="normal_vector",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
         )
         index_params.add_index(
-            field_name="structA[embedding]", index_type="HNSW",
-            metric_type="COSINE", params=INDEX_PARAMS,
+            field_name="structA[embedding]",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
         )
         index_params.add_index(
-            field_name="structA[int_val]", index_type="STL_SORT",
+            field_name="structA[int_val]",
+            index_type="STL_SORT",
         )
         res, check = self.create_collection(
-            client, collection_name, schema=schema, index_params=index_params,
+            client,
+            collection_name,
+            schema=schema,
+            index_params=index_params,
         )
         assert check
 
-        data = self._insert_sealed_and_growing(client, collection_name)
+        self._insert_sealed_and_growing(client, collection_name)
 
         # Describe indexes and verify type
         indexes = client.list_indexes(collection_name)
         log.info(f"Indexes: {indexes}")
-        assert "structA[int_val]" in indexes or any(
-            "int_val" in idx for idx in indexes
-        ), f"STL_SORT index not found in indexes: {indexes}"
+        assert "structA[int_val]" in indexes or any("int_val" in idx for idx in indexes), (
+            f"STL_SORT index not found in indexes: {indexes}"
+        )
 
     # ---- 5.3 Mixed index types on same struct ----
 
@@ -1305,24 +1418,34 @@ class TestMilvusClientStructArrayElementIndexRegression(TestMilvusClientV2Base):
         schema = self._create_schema(client)
         index_params = client.prepare_index_params()
         index_params.add_index(
-            field_name="normal_vector", index_type="HNSW",
-            metric_type="COSINE", params=INDEX_PARAMS,
+            field_name="normal_vector",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
         )
         index_params.add_index(
-            field_name="structA[embedding]", index_type="HNSW",
-            metric_type="COSINE", params=INDEX_PARAMS,
+            field_name="structA[embedding]",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
         )
         index_params.add_index(
-            field_name="structA[int_val]", index_type="STL_SORT",
+            field_name="structA[int_val]",
+            index_type="STL_SORT",
         )
         index_params.add_index(
-            field_name="structA[color]", index_type="INVERTED",
+            field_name="structA[color]",
+            index_type="INVERTED",
         )
         index_params.add_index(
-            field_name="structA[str_val]", index_type="INVERTED",
+            field_name="structA[str_val]",
+            index_type="INVERTED",
         )
         res, check = self.create_collection(
-            client, collection_name, schema=schema, index_params=index_params,
+            client,
+            collection_name,
+            schema=schema,
+            index_params=index_params,
         )
         assert check
 
@@ -1333,11 +1456,12 @@ class TestMilvusClientStructArrayElementIndexRegression(TestMilvusClientV2Base):
 
         # Use STL_SORT indexed field
         r1, c1 = self.search(
-            client, collection_name,
+            client,
+            collection_name,
             data=[query_vector],
             anns_field="structA[embedding]",
             search_params={"metric_type": "COSINE"},
-            filter='element_filter(structA, $[int_val] > 100)',
+            filter="element_filter(structA, $[int_val] > 100)",
             limit=5,
             output_fields=["id"],
         )
@@ -1345,7 +1469,8 @@ class TestMilvusClientStructArrayElementIndexRegression(TestMilvusClientV2Base):
 
         # Use INVERTED indexed field
         r2, c2 = self.search(
-            client, collection_name,
+            client,
+            collection_name,
             data=[query_vector],
             anns_field="structA[embedding]",
             search_params={"metric_type": "COSINE"},
@@ -1357,7 +1482,8 @@ class TestMilvusClientStructArrayElementIndexRegression(TestMilvusClientV2Base):
 
         # Use both indexed fields in compound filter
         r3, c3 = self.search(
-            client, collection_name,
+            client,
+            collection_name,
             data=[query_vector],
             anns_field="structA[embedding]",
             search_params={"metric_type": "COSINE"},
@@ -1369,6 +1495,7 @@ class TestMilvusClientStructArrayElementIndexRegression(TestMilvusClientV2Base):
 
 
 # ==================== Aggressive Correctness Tests ====================
+
 
 @pytest.mark.xdist_group("TestMilvusClientStructArrayElementQueryCorrectness")
 class TestMilvusClientStructArrayElementQueryCorrectness(TestMilvusClientV2Base):
@@ -1396,7 +1523,8 @@ class TestMilvusClientStructArrayElementQueryCorrectness(TestMilvusClientV2Base)
         struct_schema.add_field("color", DataType.VARCHAR, max_length=128)
 
         schema.add_field(
-            "structA", datatype=DataType.ARRAY,
+            "structA",
+            datatype=DataType.ARRAY,
             element_type=DataType.STRUCT,
             struct_schema=struct_schema,
             max_capacity=default_capacity,
@@ -1410,18 +1538,23 @@ class TestMilvusClientStructArrayElementQueryCorrectness(TestMilvusClientV2Base)
         for i in range(start_id, start_id + nb):
             rng = random.Random(i + 100000)
             num_elems = rng.randint(3, 8)
-            struct_array = [{
-                "embedding": _seed_vector(i * 1000 + j),
-                "int_val": 9000000 + i * 10 + j,  # high range to avoid filter collision
-                "str_val": f"bg_row_{i}_elem_{j}",
-                "color": f"BgColor{j}",  # unique colors to avoid filter collision
-            } for j in range(num_elems)]
-            data.append({
-                "id": i,
-                "doc_int": 9000000 + i,  # high range to avoid filter collision
-                "normal_vector": _seed_vector(i + 999999),
-                "structA": struct_array,
-            })
+            struct_array = [
+                {
+                    "embedding": _seed_vector(i * 1000 + j),
+                    "int_val": 9000000 + i * 10 + j,  # high range to avoid filter collision
+                    "str_val": f"bg_row_{i}_elem_{j}",
+                    "color": f"BgColor{j}",  # unique colors to avoid filter collision
+                }
+                for j in range(num_elems)
+            ]
+            data.append(
+                {
+                    "id": i,
+                    "doc_int": 9000000 + i,  # high range to avoid filter collision
+                    "normal_vector": _seed_vector(i + 999999),
+                    "structA": struct_array,
+                }
+            )
         return data
 
     def _make_inert_row(self, row_id):
@@ -1431,12 +1564,14 @@ class TestMilvusClientStructArrayElementQueryCorrectness(TestMilvusClientV2Base)
             "id": row_id,
             "doc_int": row_id,
             "normal_vector": _seed_vector(row_id + 999999),
-            "structA": [{
-                "embedding": _seed_vector(row_id * 1000),
-                "int_val": 0,
-                "str_val": f"inert_{row_id}",
-                "color": "Inert",
-            }],
+            "structA": [
+                {
+                    "embedding": _seed_vector(row_id * 1000),
+                    "int_val": 0,
+                    "str_val": f"inert_{row_id}",
+                    "color": "Inert",
+                }
+            ],
         }
 
     def _setup_with_controlled_data(self, client, collection_name, data, flush=True):
@@ -1444,29 +1579,34 @@ class TestMilvusClientStructArrayElementQueryCorrectness(TestMilvusClientV2Base)
         schema = self._create_schema(client)
         index_params = client.prepare_index_params()
         index_params.add_index(
-            field_name="normal_vector", index_type="HNSW",
-            metric_type="COSINE", params=INDEX_PARAMS,
+            field_name="normal_vector",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
         )
         index_params.add_index(
-            field_name="structA[embedding]", index_type="HNSW",
-            metric_type="COSINE", params=INDEX_PARAMS,
+            field_name="structA[embedding]",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
         )
         res, check = self.create_collection(
-            client, collection_name, schema=schema, index_params=index_params,
+            client,
+            collection_name,
+            schema=schema,
+            index_params=index_params,
         )
         assert check
 
         # Background sealed data: 3000 inert rows (IDs 100000+)
         bg_start = 100000
         for start in range(0, default_nb, insert_batch_size):
-            batch = [self._make_inert_row(bg_start + start + k)
-                     for k in range(insert_batch_size)]
+            batch = [self._make_inert_row(bg_start + start + k) for k in range(insert_batch_size)]
             self.insert(client, collection_name, batch)
         self.flush(client, collection_name)
 
         # Background growing data: 500 inert rows (IDs 103000+)
-        growing = [self._make_inert_row(bg_start + default_nb + k)
-                   for k in range(default_growing_nb)]
+        growing = [self._make_inert_row(bg_start + default_nb + k) for k in range(default_growing_nb)]
         self.insert(client, collection_name, growing)
 
         # Controlled data (the test-specific rows)
@@ -1521,16 +1661,16 @@ class TestMilvusClientStructArrayElementQueryCorrectness(TestMilvusClientV2Base)
         self._setup_with_controlled_data(client, collection_name, data)
 
         results, check = self.query(
-            client, collection_name,
-            filter='element_filter(structA, $[int_val] > 5)',
+            client,
+            collection_name,
+            filter="element_filter(structA, $[int_val] > 5)",
             output_fields=["id"],
             limit=100,
         )
         assert check
         milvus_ids = sorted(set(r["id"] for r in results))
         expected_ids = [0, 2, 3]  # rows with at least one element > 5
-        assert milvus_ids == expected_ids, \
-            f"Expected IDs {expected_ids}, got {milvus_ids}"
+        assert milvus_ids == expected_ids, f"Expected IDs {expected_ids}, got {milvus_ids}"
 
     @pytest.mark.tags(CaseLabel.L0)
     def test_element_filter_query_no_match(self):
@@ -1549,8 +1689,9 @@ class TestMilvusClientStructArrayElementQueryCorrectness(TestMilvusClientV2Base)
         self._setup_with_controlled_data(client, collection_name, data)
 
         results, check = self.query(
-            client, collection_name,
-            filter='element_filter(structA, $[int_val] > 9999)',
+            client,
+            collection_name,
+            filter="element_filter(structA, $[int_val] > 9999)",
             output_fields=["id"],
             limit=100,
         )
@@ -1570,38 +1711,46 @@ class TestMilvusClientStructArrayElementQueryCorrectness(TestMilvusClientV2Base)
         collection_name = cf.gen_unique_str(f"{prefix}_offset_exact")
 
         # 20 rows, all with one element int_val == row_id * 10
-        data = [
-            self._make_row(i, [{"int_val": i * 10}])
-            for i in range(20)
-        ]
+        data = [self._make_row(i, [{"int_val": i * 10}]) for i in range(20)]
         self._setup_with_controlled_data(client, collection_name, data)
 
         # All rows with int_val > 50 → rows 6..19 (14 rows)
         # Get all results first
         all_results, _ = self.query(
-            client, collection_name,
-            filter='element_filter(structA, $[int_val] > 50)',
-            output_fields=["id"], limit=100,
+            client,
+            collection_name,
+            filter="element_filter(structA, $[int_val] > 50)",
+            output_fields=["id"],
+            limit=100,
         )
         all_ids = sorted([r["id"] for r in all_results])
 
         # Now paginate: page 1 (limit=5, offset=0)
         p1, _ = self.query(
-            client, collection_name,
-            filter='element_filter(structA, $[int_val] > 50)',
-            output_fields=["id"], limit=5, offset=0,
+            client,
+            collection_name,
+            filter="element_filter(structA, $[int_val] > 50)",
+            output_fields=["id"],
+            limit=5,
+            offset=0,
         )
         # Page 2 (limit=5, offset=5)
         p2, _ = self.query(
-            client, collection_name,
-            filter='element_filter(structA, $[int_val] > 50)',
-            output_fields=["id"], limit=5, offset=5,
+            client,
+            collection_name,
+            filter="element_filter(structA, $[int_val] > 50)",
+            output_fields=["id"],
+            limit=5,
+            offset=5,
         )
         # Page 3 (limit=5, offset=10)
         p3, _ = self.query(
-            client, collection_name,
-            filter='element_filter(structA, $[int_val] > 50)',
-            output_fields=["id"], limit=5, offset=10,
+            client,
+            collection_name,
+            filter="element_filter(structA, $[int_val] > 50)",
+            output_fields=["id"],
+            limit=5,
+            offset=10,
         )
 
         p1_ids = set(r["id"] for r in p1)
@@ -1615,8 +1764,9 @@ class TestMilvusClientStructArrayElementQueryCorrectness(TestMilvusClientV2Base)
 
         # Union of all pages should equal all results
         union_ids = sorted(p1_ids | p2_ids | p3_ids)
-        assert union_ids == all_ids[:15] or set(union_ids).issubset(set(all_ids)), \
+        assert union_ids == all_ids[:15] or set(union_ids).issubset(set(all_ids)), (
             f"Pages union {union_ids} != all results {all_ids}"
+        )
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_element_filter_query_offset_beyond_results(self):
@@ -1628,17 +1778,17 @@ class TestMilvusClientStructArrayElementQueryCorrectness(TestMilvusClientV2Base)
         client = self._client()
         collection_name = cf.gen_unique_str(f"{prefix}_offset_beyond")
 
-        data = [
-            self._make_row(i, [{"int_val": i * 10}])
-            for i in range(5)
-        ]
+        data = [self._make_row(i, [{"int_val": i * 10}]) for i in range(5)]
         self._setup_with_controlled_data(client, collection_name, data)
 
         # Only rows 3,4 match (int_val > 20), offset=10 is beyond
         results, check = self.query(
-            client, collection_name,
-            filter='element_filter(structA, $[int_val] > 20)',
-            output_fields=["id"], limit=10, offset=10,
+            client,
+            collection_name,
+            filter="element_filter(structA, $[int_val] > 20)",
+            output_fields=["id"],
+            limit=10,
+            offset=10,
         )
         assert check
         assert len(results) == 0, f"Expected 0 results with large offset, got {len(results)}"
@@ -1656,20 +1806,27 @@ class TestMilvusClientStructArrayElementQueryCorrectness(TestMilvusClientV2Base)
         collection_name = cf.gen_unique_str(f"{prefix}_elem_correct")
 
         data = [
-            self._make_row(0, [
-                {"int_val": 10, "color": "Red"},
-                {"int_val": 20, "color": "Blue"},
-                {"int_val": 30, "color": "Green"},
-            ]),
-            self._make_row(1, [
-                {"int_val": 5, "color": "Red"},
-            ]),
+            self._make_row(
+                0,
+                [
+                    {"int_val": 10, "color": "Red"},
+                    {"int_val": 20, "color": "Blue"},
+                    {"int_val": 30, "color": "Green"},
+                ],
+            ),
+            self._make_row(
+                1,
+                [
+                    {"int_val": 5, "color": "Red"},
+                ],
+            ),
         ]
         self._setup_with_controlled_data(client, collection_name, data)
 
         results, check = self.query(
-            client, collection_name,
-            filter='element_filter(structA, $[int_val] > 15)',
+            client,
+            collection_name,
+            filter="element_filter(structA, $[int_val] > 15)",
             output_fields=["id", "structA"],
             limit=100,
         )
@@ -1712,23 +1869,23 @@ class TestMilvusClientStructArrayElementQueryCorrectness(TestMilvusClientV2Base)
 
         # Count rows with int_val > 50 → should be exactly 5
         results, check = self.query(
-            client, collection_name,
-            filter='element_filter(structA, $[int_val] > 50)',
+            client,
+            collection_name,
+            filter="element_filter(structA, $[int_val] > 50)",
             output_fields=["count(*)"],
         )
         assert check
-        assert results[0]["count(*)"] == 5, \
-            f"Expected count=5, got {results[0]['count(*)']}"
+        assert results[0]["count(*)"] == 5, f"Expected count=5, got {results[0]['count(*)']}"
 
         # Count all rows with int_val > 0 → should be exactly 10
         results2, check2 = self.query(
-            client, collection_name,
-            filter='element_filter(structA, $[int_val] > 0)',
+            client,
+            collection_name,
+            filter="element_filter(structA, $[int_val] > 0)",
             output_fields=["count(*)"],
         )
         assert check2
-        assert results2[0]["count(*)"] == 10, \
-            f"Expected count=10, got {results2[0]['count(*)']}"
+        assert results2[0]["count(*)"] == 10, f"Expected count=10, got {results2[0]['count(*)']}"
 
     # ---- Compound same-element semantic in query ----
 
@@ -1746,29 +1903,38 @@ class TestMilvusClientStructArrayElementQueryCorrectness(TestMilvusClientV2Base)
         collection_name = cf.gen_unique_str(f"{prefix}_same_elem_q")
 
         data = [
-            self._make_row(0, [
-                {"int_val": 10, "color": "Red"},
-                {"int_val": 20, "color": "Blue"},
-            ]),
-            self._make_row(1, [
-                {"int_val": 20, "color": "Red"},
-            ]),
-            self._make_row(2, [
-                {"int_val": 5, "color": "Green"},
-            ]),
+            self._make_row(
+                0,
+                [
+                    {"int_val": 10, "color": "Red"},
+                    {"int_val": 20, "color": "Blue"},
+                ],
+            ),
+            self._make_row(
+                1,
+                [
+                    {"int_val": 20, "color": "Red"},
+                ],
+            ),
+            self._make_row(
+                2,
+                [
+                    {"int_val": 5, "color": "Green"},
+                ],
+            ),
         ]
         self._setup_with_controlled_data(client, collection_name, data)
 
         results, check = self.query(
-            client, collection_name,
+            client,
+            collection_name,
             filter='element_filter(structA, $[color] == "Red" && $[int_val] > 15)',
             output_fields=["id"],
             limit=100,
         )
         assert check
         milvus_ids = [r["id"] for r in results]
-        assert milvus_ids == [1], \
-            f"Expected only row 1 (same-element semantic), got {milvus_ids}"
+        assert milvus_ids == [1], f"Expected only row 1 (same-element semantic), got {milvus_ids}"
 
     # ---- MATCH_ALL/ANY exact verification in query ----
 
@@ -1797,16 +1963,16 @@ class TestMilvusClientStructArrayElementQueryCorrectness(TestMilvusClientV2Base)
         self._setup_with_controlled_data(client, collection_name, data)
 
         results, check = self.query(
-            client, collection_name,
-            filter='MATCH_ALL(structA, $[int_val] > 10)',
+            client,
+            collection_name,
+            filter="MATCH_ALL(structA, $[int_val] > 10)",
             output_fields=["id"],
             limit=100,
         )
         assert check
         milvus_ids = sorted([r["id"] for r in results])
         expected = [0, 2]
-        assert milvus_ids == expected, \
-            f"MATCH_ALL expected {expected}, got {milvus_ids}"
+        assert milvus_ids == expected, f"MATCH_ALL expected {expected}, got {milvus_ids}"
 
     @pytest.mark.tags(CaseLabel.L0)
     def test_match_exact_query_verification(self):
@@ -1820,36 +1986,52 @@ class TestMilvusClientStructArrayElementQueryCorrectness(TestMilvusClientV2Base)
 
         data = [
             # Row 0: 3 Red elements → ✗ (not exactly 2)
-            self._make_row(0, [
-                {"int_val": 1, "color": "Red"},
-                {"int_val": 2, "color": "Red"},
-                {"int_val": 3, "color": "Red"},
-            ]),
+            self._make_row(
+                0,
+                [
+                    {"int_val": 1, "color": "Red"},
+                    {"int_val": 2, "color": "Red"},
+                    {"int_val": 3, "color": "Red"},
+                ],
+            ),
             # Row 1: 2 Red elements → ✓
-            self._make_row(1, [
-                {"int_val": 1, "color": "Red"},
-                {"int_val": 2, "color": "Blue"},
-                {"int_val": 3, "color": "Red"},
-            ]),
+            self._make_row(
+                1,
+                [
+                    {"int_val": 1, "color": "Red"},
+                    {"int_val": 2, "color": "Blue"},
+                    {"int_val": 3, "color": "Red"},
+                ],
+            ),
             # Row 2: 1 Red element → ✗
-            self._make_row(2, [
-                {"int_val": 1, "color": "Red"},
-                {"int_val": 2, "color": "Blue"},
-            ]),
+            self._make_row(
+                2,
+                [
+                    {"int_val": 1, "color": "Red"},
+                    {"int_val": 2, "color": "Blue"},
+                ],
+            ),
             # Row 3: 0 Red elements → ✗
-            self._make_row(3, [
-                {"int_val": 1, "color": "Blue"},
-            ]),
+            self._make_row(
+                3,
+                [
+                    {"int_val": 1, "color": "Blue"},
+                ],
+            ),
             # Row 4: 2 Red elements → ✓
-            self._make_row(4, [
-                {"int_val": 1, "color": "Red"},
-                {"int_val": 2, "color": "Red"},
-            ]),
+            self._make_row(
+                4,
+                [
+                    {"int_val": 1, "color": "Red"},
+                    {"int_val": 2, "color": "Red"},
+                ],
+            ),
         ]
         self._setup_with_controlled_data(client, collection_name, data)
 
         results, check = self.query(
-            client, collection_name,
+            client,
+            collection_name,
             filter='MATCH_EXACT(structA, $[color] == "Red", threshold=2)',
             output_fields=["id"],
             limit=100,
@@ -1857,8 +2039,7 @@ class TestMilvusClientStructArrayElementQueryCorrectness(TestMilvusClientV2Base)
         assert check
         milvus_ids = sorted([r["id"] for r in results])
         expected = [1, 4]
-        assert milvus_ids == expected, \
-            f"MATCH_EXACT(threshold=2) expected {expected}, got {milvus_ids}"
+        assert milvus_ids == expected, f"MATCH_EXACT(threshold=2) expected {expected}, got {milvus_ids}"
 
     # ---- Growing vs sealed consistency ----
 
@@ -1881,12 +2062,16 @@ class TestMilvusClientStructArrayElementQueryCorrectness(TestMilvusClientV2Base)
         schema = self._create_schema(client)
         index_params = client.prepare_index_params()
         index_params.add_index(
-            field_name="normal_vector", index_type="HNSW",
-            metric_type="COSINE", params=INDEX_PARAMS,
+            field_name="normal_vector",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
         )
         index_params.add_index(
-            field_name="structA[embedding]", index_type="HNSW",
-            metric_type="COSINE", params=INDEX_PARAMS,
+            field_name="structA[embedding]",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
         )
         self.create_collection(client, collection_name, schema=schema, index_params=index_params)
         self.insert(client, collection_name, data)
@@ -1894,29 +2079,33 @@ class TestMilvusClientStructArrayElementQueryCorrectness(TestMilvusClientV2Base)
         self.load_collection(client, collection_name)
 
         growing_results, _ = self.query(
-            client, collection_name,
-            filter='element_filter(structA, $[int_val] > 100)',
-            output_fields=["id"], limit=100,
+            client,
+            collection_name,
+            filter="element_filter(structA, $[int_val] > 100)",
+            output_fields=["id"],
+            limit=100,
         )
         growing_ids = sorted([r["id"] for r in growing_results])
 
         # Flush to create sealed segment
         self.flush(client, collection_name)
         import time
+
         time.sleep(2)
 
         sealed_results, _ = self.query(
-            client, collection_name,
-            filter='element_filter(structA, $[int_val] > 100)',
-            output_fields=["id"], limit=100,
+            client,
+            collection_name,
+            filter="element_filter(structA, $[int_val] > 100)",
+            output_fields=["id"],
+            limit=100,
         )
         sealed_ids = sorted([r["id"] for r in sealed_results])
 
         expected = [0, 2]  # row 0 has 200, row 2 has 150
         assert growing_ids == expected, f"Growing: expected {expected}, got {growing_ids}"
         assert sealed_ids == expected, f"Sealed: expected {expected}, got {sealed_ids}"
-        assert growing_ids == sealed_ids, \
-            f"Growing vs sealed mismatch: growing={growing_ids}, sealed={sealed_ids}"
+        assert growing_ids == sealed_ids, f"Growing vs sealed mismatch: growing={growing_ids}, sealed={sealed_ids}"
 
     # ---- Single element struct array ----
 
@@ -1939,9 +2128,11 @@ class TestMilvusClientStructArrayElementQueryCorrectness(TestMilvusClientV2Base)
         self._setup_with_controlled_data(client, collection_name, data)
 
         results, check = self.query(
-            client, collection_name,
-            filter='element_filter(structA, $[int_val] >= 20)',
-            output_fields=["id"], limit=100,
+            client,
+            collection_name,
+            filter="element_filter(structA, $[int_val] >= 20)",
+            output_fields=["id"],
+            limit=100,
         )
         assert check
         milvus_ids = sorted([r["id"] for r in results])
@@ -1949,9 +2140,11 @@ class TestMilvusClientStructArrayElementQueryCorrectness(TestMilvusClientV2Base)
 
         # MATCH_ALL with single element == element_filter
         match_results, _ = self.query(
-            client, collection_name,
-            filter='MATCH_ALL(structA, $[int_val] >= 20)',
-            output_fields=["id"], limit=100,
+            client,
+            collection_name,
+            filter="MATCH_ALL(structA, $[int_val] >= 20)",
+            output_fields=["id"],
+            limit=100,
         )
         match_ids = sorted([r["id"] for r in match_results])
         assert match_ids == [1, 2], f"MATCH_ALL with single elem: expected [1, 2], got {match_ids}"
@@ -1978,9 +2171,11 @@ class TestMilvusClientStructArrayElementQueryCorrectness(TestMilvusClientV2Base)
 
         # array_contains(structA[color], "Red") → rows 0, 2
         results, check = self.query(
-            client, collection_name,
+            client,
+            collection_name,
             filter='array_contains(structA[color], "Red")',
-            output_fields=["id"], limit=100,
+            output_fields=["id"],
+            limit=100,
         )
         assert check
         milvus_ids = sorted([r["id"] for r in results])
@@ -1988,9 +2183,11 @@ class TestMilvusClientStructArrayElementQueryCorrectness(TestMilvusClientV2Base)
 
         # array_contains_all(structA[color], ["Red", "Blue"]) → only row 2
         results2, check2 = self.query(
-            client, collection_name,
+            client,
+            collection_name,
             filter='array_contains_all(structA[color], ["Red", "Blue"])',
-            output_fields=["id"], limit=100,
+            output_fields=["id"],
+            limit=100,
         )
         assert check2
         milvus_ids2 = sorted([r["id"] for r in results2])
@@ -2019,12 +2216,15 @@ class TestMilvusClientStructArrayElementQueryCorrectness(TestMilvusClientV2Base)
         # Delete row 1
         self.delete(client, collection_name, ids=[1])
         import time
+
         time.sleep(1)
 
         results, check = self.query(
-            client, collection_name,
-            filter='element_filter(structA, $[int_val] > 50)',
-            output_fields=["id"], limit=100,
+            client,
+            collection_name,
+            filter="element_filter(structA, $[int_val] > 50)",
+            output_fields=["id"],
+            limit=100,
         )
         assert check
         milvus_ids = sorted([r["id"] for r in results])
@@ -2054,9 +2254,11 @@ class TestMilvusClientStructArrayElementQueryCorrectness(TestMilvusClientV2Base)
         # element_filter returns element-level results keyed by (id, offset)
         # Get all matching elements
         all_res, _ = self.query(
-            client, collection_name,
-            filter='element_filter(structA, $[int_val] > 500)',
-            output_fields=["id"], limit=500,
+            client,
+            collection_name,
+            filter="element_filter(structA, $[int_val] > 500)",
+            output_fields=["id"],
+            limit=500,
         )
         total = len(all_res)
         log.info(f"Total matching elements: {total}")
@@ -2068,14 +2270,16 @@ class TestMilvusClientStructArrayElementQueryCorrectness(TestMilvusClientV2Base)
         pages = 0
         while offset < total + page_size:  # go a bit beyond to check
             page, _ = self.query(
-                client, collection_name,
-                filter='element_filter(structA, $[int_val] > 500)',
-                output_fields=["id"], limit=page_size, offset=offset,
+                client,
+                collection_name,
+                filter="element_filter(structA, $[int_val] > 500)",
+                output_fields=["id"],
+                limit=page_size,
+                offset=offset,
             )
             page_keys = set((r["id"], r.get("offset", 0)) for r in page)
             overlap = collected_keys & page_keys
-            assert len(overlap) == 0, \
-                f"Page at offset={offset} overlaps with previous: {overlap}"
+            assert len(overlap) == 0, f"Page at offset={offset} overlaps with previous: {overlap}"
             collected_keys |= page_keys
             offset += page_size
             pages += 1
@@ -2083,8 +2287,9 @@ class TestMilvusClientStructArrayElementQueryCorrectness(TestMilvusClientV2Base)
                 break
 
         all_keys = set((r["id"], r.get("offset", 0)) for r in all_res)
-        assert collected_keys == all_keys, \
+        assert collected_keys == all_keys, (
             f"Paginated keys count {len(collected_keys)} != all keys count {len(all_keys)}"
+        )
 
     # ---- element_filter + doc-level filter interaction ----
 
@@ -2102,24 +2307,26 @@ class TestMilvusClientStructArrayElementQueryCorrectness(TestMilvusClientV2Base)
             self._make_row(0, [{"int_val": 100}]),  # doc_int=0, int_val>50 ✓
             self._make_row(1, [{"int_val": 100}]),  # doc_int=1, int_val>50 ✓
             self._make_row(2, [{"int_val": 100}]),  # doc_int=2 > 1, int_val>50 ✓ → MATCH
-            self._make_row(3, [{"int_val": 1}]),    # doc_int=3 > 1, int_val>50 ✗
+            self._make_row(3, [{"int_val": 1}]),  # doc_int=3 > 1, int_val>50 ✗
             self._make_row(4, [{"int_val": 200}]),  # doc_int=4 > 1, int_val>50 ✓ → MATCH
         ]
         self._setup_with_controlled_data(client, collection_name, data)
 
         results, check = self.query(
-            client, collection_name,
-            filter='doc_int > 1 && element_filter(structA, $[int_val] > 50)',
-            output_fields=["id"], limit=100,
+            client,
+            collection_name,
+            filter="doc_int > 1 && element_filter(structA, $[int_val] > 50)",
+            output_fields=["id"],
+            limit=100,
         )
         assert check
         milvus_ids = sorted(set(r["id"] for r in results))
         expected = [2, 4]
-        assert milvus_ids == expected, \
-            f"Intersection expected {expected}, got {milvus_ids}"
+        assert milvus_ids == expected, f"Intersection expected {expected}, got {milvus_ids}"
 
 
 # ==================== Query Aggressive Correctness Tests ====================
+
 
 @pytest.mark.xdist_group("TestMilvusClientStructArrayElementQueryAggressive")
 class TestMilvusClientStructArrayElementQueryAggressive(TestMilvusClientV2Base):
@@ -2141,7 +2348,8 @@ class TestMilvusClientStructArrayElementQueryAggressive(TestMilvusClientV2Base):
         struct_schema.add_field("color", DataType.VARCHAR, max_length=128)
 
         schema.add_field(
-            "structA", datatype=DataType.ARRAY,
+            "structA",
+            datatype=DataType.ARRAY,
             element_type=DataType.STRUCT,
             struct_schema=struct_schema,
             max_capacity=default_capacity,
@@ -2156,11 +2364,13 @@ class TestMilvusClientStructArrayElementQueryAggressive(TestMilvusClientV2Base):
             "id": row_id,
             "doc_int": 9000000 + row_id,
             "normal_vector": _seed_vector(row_id + 999999),
-            "structA": [{
-                "embedding": _seed_vector(row_id * 1000),
-                "int_val": 0,
-                "color": "Inert",
-            }],
+            "structA": [
+                {
+                    "embedding": _seed_vector(row_id * 1000),
+                    "int_val": 0,
+                    "color": "Inert",
+                }
+            ],
         }
 
     def _setup_with_controlled_data(self, client, collection_name, data, flush=True):
@@ -2168,29 +2378,34 @@ class TestMilvusClientStructArrayElementQueryAggressive(TestMilvusClientV2Base):
         schema = self._create_schema(client)
         index_params = client.prepare_index_params()
         index_params.add_index(
-            field_name="normal_vector", index_type="HNSW",
-            metric_type="COSINE", params=INDEX_PARAMS,
+            field_name="normal_vector",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
         )
         index_params.add_index(
-            field_name="structA[embedding]", index_type="HNSW",
-            metric_type="COSINE", params=INDEX_PARAMS,
+            field_name="structA[embedding]",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
         )
         res, check = self.create_collection(
-            client, collection_name, schema=schema, index_params=index_params,
+            client,
+            collection_name,
+            schema=schema,
+            index_params=index_params,
         )
         assert check
 
         # Background sealed data: 3000 inert rows (IDs 200000+)
         bg_start = 200000
         for start in range(0, default_nb, insert_batch_size):
-            batch = [self._make_inert_row(bg_start + start + k)
-                     for k in range(insert_batch_size)]
+            batch = [self._make_inert_row(bg_start + start + k) for k in range(insert_batch_size)]
             self.insert(client, collection_name, batch)
         self.flush(client, collection_name)
 
         # Background growing data: 500 inert rows (IDs 203000+)
-        growing = [self._make_inert_row(bg_start + default_nb + k)
-                   for k in range(default_growing_nb)]
+        growing = [self._make_inert_row(bg_start + default_nb + k) for k in range(default_growing_nb)]
         self.insert(client, collection_name, growing)
 
         # Controlled data
@@ -2228,24 +2443,35 @@ class TestMilvusClientStructArrayElementQueryAggressive(TestMilvusClientV2Base):
         collection_name = cf.gen_unique_str(f"{prefix}_ef_or")
 
         data = [
-            self._make_row(0, [
-                {"int_val": 1, "color": "Red"},      # matches (Red)
-                {"int_val": 300, "color": "Blue"},    # matches (> 200)
-            ]),
-            self._make_row(1, [
-                {"int_val": 5, "color": "Blue"},      # doesn't match
-                {"int_val": 10, "color": "Green"},     # doesn't match
-            ]),
-            self._make_row(2, [
-                {"int_val": 500, "color": "Green"},    # matches (> 200)
-            ]),
+            self._make_row(
+                0,
+                [
+                    {"int_val": 1, "color": "Red"},  # matches (Red)
+                    {"int_val": 300, "color": "Blue"},  # matches (> 200)
+                ],
+            ),
+            self._make_row(
+                1,
+                [
+                    {"int_val": 5, "color": "Blue"},  # doesn't match
+                    {"int_val": 10, "color": "Green"},  # doesn't match
+                ],
+            ),
+            self._make_row(
+                2,
+                [
+                    {"int_val": 500, "color": "Green"},  # matches (> 200)
+                ],
+            ),
         ]
         self._setup_with_controlled_data(client, collection_name, data)
 
         results, check = self.query(
-            client, collection_name,
+            client,
+            collection_name,
             filter='element_filter(structA, $[color] == "Red" || $[int_val] > 200)',
-            output_fields=["id"], limit=100,
+            output_fields=["id"],
+            limit=100,
         )
         assert check
         milvus_ids = sorted(set(r["id"] for r in results))
@@ -2271,9 +2497,11 @@ class TestMilvusClientStructArrayElementQueryAggressive(TestMilvusClientV2Base):
         self._setup_with_controlled_data(client, collection_name, data)
 
         results, check = self.query(
-            client, collection_name,
-            filter='element_filter(structA, $[int_val] < 0)',
-            output_fields=["id"], limit=100,
+            client,
+            collection_name,
+            filter="element_filter(structA, $[int_val] < 0)",
+            output_fields=["id"],
+            limit=100,
         )
         assert check
         milvus_ids = sorted(set(r["id"] for r in results))
@@ -2302,9 +2530,11 @@ class TestMilvusClientStructArrayElementQueryAggressive(TestMilvusClientV2Base):
         self._setup_with_controlled_data(client, collection_name, data)
 
         results, check = self.query(
-            client, collection_name,
-            filter='MATCH_LEAST(structA, $[int_val] > 10, threshold=3)',
-            output_fields=["id"], limit=100,
+            client,
+            collection_name,
+            filter="MATCH_LEAST(structA, $[int_val] > 10, threshold=3)",
+            output_fields=["id"],
+            limit=100,
         )
         assert check
         milvus_ids = sorted([r["id"] for r in results])
@@ -2333,9 +2563,11 @@ class TestMilvusClientStructArrayElementQueryAggressive(TestMilvusClientV2Base):
         self._setup_with_controlled_data(client, collection_name, data)
 
         results, check = self.query(
-            client, collection_name,
-            filter='doc_int < 100 && MATCH_MOST(structA, $[int_val] > 10, threshold=2)',
-            output_fields=["id"], limit=100,
+            client,
+            collection_name,
+            filter="doc_int < 100 && MATCH_MOST(structA, $[int_val] > 10, threshold=2)",
+            output_fields=["id"],
+            limit=100,
         )
         assert check
         milvus_ids = sorted([r["id"] for r in results])
@@ -2357,13 +2589,13 @@ class TestMilvusClientStructArrayElementQueryAggressive(TestMilvusClientV2Base):
         for i in range(50):
             rng = random.Random(i)
             num_elems = rng.randint(2, 6)
-            elems = [{"int_val": i * 100 + j, "color": COLORS[j % 3]}
-                     for j in range(num_elems)]
+            elems = [{"int_val": i * 100 + j, "color": COLORS[j % 3]} for j in range(num_elems)]
             data.append(self._make_row(i, elems))
         self._setup_with_controlled_data(client, collection_name, data)
 
         results, check = self.query(
-            client, collection_name,
+            client,
+            collection_name,
             filter='element_filter(structA, $[color] == "Blue" && $[int_val] > 2000)',
             output_fields=["id", "structA"],
             limit=100,
@@ -2372,13 +2604,11 @@ class TestMilvusClientStructArrayElementQueryAggressive(TestMilvusClientV2Base):
 
         # Verify every result: at least one element must satisfy BOTH conditions
         for hit in results:
-            has_match = any(
-                e["color"] == "Blue" and e["int_val"] > 2000
-                for e in hit["structA"]
-            )
-            assert has_match, \
-                f"False positive! Row {hit['id']}: no element with color=Blue AND int_val>2000. " \
+            has_match = any(e["color"] == "Blue" and e["int_val"] > 2000 for e in hit["structA"])
+            assert has_match, (
+                f"False positive! Row {hit['id']}: no element with color=Blue AND int_val>2000. "
                 f"Elements: {[(e['color'], e['int_val']) for e in hit['structA']]}"
+            )
 
         # Verify against ground truth
         gt_ids = set()
@@ -2386,8 +2616,7 @@ class TestMilvusClientStructArrayElementQueryAggressive(TestMilvusClientV2Base):
             if any(e["color"] == "Blue" and e["int_val"] > 2000 for e in row["structA"]):
                 gt_ids.add(row["id"])
         milvus_ids = {r["id"] for r in results}
-        assert milvus_ids == gt_ids, \
-            f"Result mismatch: got {sorted(milvus_ids)}, expected {sorted(gt_ids)}"
+        assert milvus_ids == gt_ids, f"Result mismatch: got {sorted(milvus_ids)}, expected {sorted(gt_ids)}"
 
     # ---- array_contains_all with non-existent combination ----
 
@@ -2408,15 +2637,18 @@ class TestMilvusClientStructArrayElementQueryAggressive(TestMilvusClientV2Base):
         self._setup_with_controlled_data(client, collection_name, data)
 
         results, check = self.query(
-            client, collection_name,
+            client,
+            collection_name,
             filter='array_contains_all(structA[color], ["Red", "Blue", "Purple"])',
-            output_fields=["id"], limit=100,
+            output_fields=["id"],
+            limit=100,
         )
         assert check
         assert len(results) == 0, f"Expected 0 results (no Purple), got {[r['id'] for r in results]}"
 
 
 # ==================== Large-scale Stress Tests ====================
+
 
 @pytest.mark.xdist_group("TestMilvusClientStructArrayElementQueryLargeScale")
 class TestMilvusClientStructArrayElementQueryLargeScale(TestMilvusClientV2Base):
@@ -2440,15 +2672,15 @@ class TestMilvusClientStructArrayElementQueryLargeScale(TestMilvusClientV2Base):
         struct_schema.add_field("color", DataType.VARCHAR, max_length=128)
 
         schema.add_field(
-            "structA", datatype=DataType.ARRAY,
+            "structA",
+            datatype=DataType.ARRAY,
             element_type=DataType.STRUCT,
             struct_schema=struct_schema,
             max_capacity=100,
         )
         return schema
 
-    def _generate_large_data(self, nb=5000, dim=default_dim,
-                              min_elems=20, max_elems=50):
+    def _generate_large_data(self, nb=5000, dim=default_dim, min_elems=20, max_elems=50):
         """Generate large dataset with many elements per row."""
         data = []
         for i in range(nb):
@@ -2456,53 +2688,68 @@ class TestMilvusClientStructArrayElementQueryLargeScale(TestMilvusClientV2Base):
             num_elems = rng.randint(min_elems, max_elems)
             struct_array = []
             for j in range(num_elems):
-                struct_array.append({
-                    "embedding": _seed_vector(i * 1000 + j, dim),
-                    "int_val": i * 100 + j,
-                    "str_val": f"row_{i}_elem_{j}",
-                    "color": COLORS[j % 3],
-                })
-            data.append({
-                "id": i,
-                "doc_int": i,
-                "doc_category": CATEGORIES[i % 4],
-                "normal_vector": _seed_vector(i + 999999, dim),
-                "structA": struct_array,
-            })
+                struct_array.append(
+                    {
+                        "embedding": _seed_vector(i * 1000 + j, dim),
+                        "int_val": i * 100 + j,
+                        "str_val": f"row_{i}_elem_{j}",
+                        "color": COLORS[j % 3],
+                    }
+                )
+            data.append(
+                {
+                    "id": i,
+                    "doc_int": i,
+                    "doc_category": CATEGORIES[i % 4],
+                    "normal_vector": _seed_vector(i + 999999, dim),
+                    "structA": struct_array,
+                }
+            )
         return data
 
-    def _setup_large_collection(self, client, collection_name, nb=5000,
-                                 flush=True, nested_index=False,
-                                 min_elems=20, max_elems=50):
+    def _setup_large_collection(
+        self, client, collection_name, nb=5000, flush=True, nested_index=False, min_elems=20, max_elems=50
+    ):
         schema = self._create_schema(client)
         index_params = client.prepare_index_params()
         index_params.add_index(
-            field_name="normal_vector", index_type="HNSW",
-            metric_type="COSINE", params=INDEX_PARAMS,
+            field_name="normal_vector",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
         )
         index_params.add_index(
-            field_name="structA[embedding]", index_type="HNSW",
-            metric_type="COSINE", params=INDEX_PARAMS,
+            field_name="structA[embedding]",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
         )
         if nested_index:
             index_params.add_index(
-                field_name="structA[int_val]", index_type="STL_SORT",
+                field_name="structA[int_val]",
+                index_type="STL_SORT",
             )
             index_params.add_index(
-                field_name="structA[color]", index_type="INVERTED",
+                field_name="structA[color]",
+                index_type="INVERTED",
             )
         res, check = self.create_collection(
-            client, collection_name, schema=schema, index_params=index_params,
+            client,
+            collection_name,
+            schema=schema,
+            index_params=index_params,
         )
         assert check
 
         data = self._generate_large_data(
-            nb=nb, min_elems=min_elems, max_elems=max_elems,
+            nb=nb,
+            min_elems=min_elems,
+            max_elems=max_elems,
         )
         # Insert in batches to create multiple segments
         batch_size = 1000
         for start in range(0, nb, batch_size):
-            batch = data[start:start + batch_size]
+            batch = data[start : start + batch_size]
             res, check = self.insert(client, collection_name, batch)
             assert check
             assert res["insert_count"] == len(batch)
@@ -2521,22 +2768,25 @@ class TestMilvusClientStructArrayElementQueryLargeScale(TestMilvusClientV2Base):
         schema = self._create_schema(client)
         index_params = client.prepare_index_params()
         index_params.add_index(
-            field_name="normal_vector", index_type="HNSW",
-            metric_type="COSINE", params=INDEX_PARAMS,
+            field_name="normal_vector",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
         )
         index_params.add_index(
-            field_name="structA[embedding]", index_type="HNSW",
-            metric_type="COSINE", params=INDEX_PARAMS,
+            field_name="structA[embedding]",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
         )
         # force_teardown=False to prevent teardown_method from dropping it
-        self.create_collection(client, collection_name, schema=schema,
-                               index_params=index_params, force_teardown=False)
+        self.create_collection(client, collection_name, schema=schema, index_params=index_params, force_teardown=False)
 
         sealed_data = self._generate_large_data(nb=5000, min_elems=20, max_elems=50)
         # Insert in batches to create multiple sealed segments
         batch_size = 1000
         for start in range(0, 5000, batch_size):
-            batch = sealed_data[start:start + batch_size]
+            batch = sealed_data[start : start + batch_size]
             res, check = self.insert(client, collection_name, batch)
             assert check
             assert res["insert_count"] == len(batch)
@@ -2577,8 +2827,9 @@ class TestMilvusClientStructArrayElementQueryLargeScale(TestMilvusClientV2Base):
         # Filter: int_val > 300000 — matches elements from rows 3001+
         # element_filter returns element-level results, so limit needs to be large enough
         results, check = self.query(
-            client, collection_name,
-            filter='element_filter(structA, $[int_val] > 300000)',
+            client,
+            collection_name,
+            filter="element_filter(structA, $[int_val] > 300000)",
             output_fields=["id"],
             limit=16384,
         )
@@ -2598,16 +2849,16 @@ class TestMilvusClientStructArrayElementQueryLargeScale(TestMilvusClientV2Base):
 
         # Verify no false positives at row level
         false_positives = milvus_row_ids - gt_row_ids
-        assert len(false_positives) == 0, \
-            f"{len(false_positives)} false positive rows: {sorted(false_positives)[:20]}"
+        assert len(false_positives) == 0, f"{len(false_positives)} false positive rows: {sorted(false_positives)[:20]}"
 
         # Verify row coverage: check returned rows cover all matching rows
         # Note: limit may truncate element-level results, so check covered row ratio
         coverage = len(milvus_row_ids & gt_row_ids) / len(gt_row_ids) if gt_row_ids else 1.0
-        log.info(f"Row coverage: {len(milvus_row_ids)}/{len(gt_row_ids)} = {coverage:.2%}, "
-                 f"total elements returned: {len(results)}, gt elements: {len(gt_elements)}")
-        assert coverage > 0.2, \
-            f"Row coverage too low: {coverage:.2%} ({len(milvus_row_ids)}/{len(gt_row_ids)})"
+        log.info(
+            f"Row coverage: {len(milvus_row_ids)}/{len(gt_row_ids)} = {coverage:.2%}, "
+            f"total elements returned: {len(results)}, gt elements: {len(gt_elements)}"
+        )
+        assert coverage > 0.2, f"Row coverage too low: {coverage:.2%} ({len(milvus_row_ids)}/{len(gt_row_ids)})"
 
     # ---- MATCH_ALL at scale ----
 
@@ -2628,16 +2879,16 @@ class TestMilvusClientStructArrayElementQueryLargeScale(TestMilvusClientV2Base):
         # Use a looser condition: int_val > doc_id * 100 - 1 (always true)
         # Actually, let's use: int_val >= 0 (all match)
         results, check = self.query(
-            client, collection_name,
-            filter='MATCH_ALL(structA, $[int_val] >= 0)',
+            client,
+            collection_name,
+            filter="MATCH_ALL(structA, $[int_val] >= 0)",
             output_fields=["id"],
             limit=16384,
         )
         assert check
         # All rows (5000 sealed + 500 growing) should match since all int_vals >= 0
         total_rows = 5000 + default_growing_nb
-        assert len(results) == total_rows, \
-            f"MATCH_ALL(int_val >= 0) expected {total_rows} rows, got {len(results)}"
+        assert len(results) == total_rows, f"MATCH_ALL(int_val >= 0) expected {total_rows} rows, got {len(results)}"
 
     # ---- MATCH_ANY at scale with ground truth ----
 
@@ -2654,7 +2905,8 @@ class TestMilvusClientStructArrayElementQueryLargeScale(TestMilvusClientV2Base):
 
         # MATCH_ANY: at least one element has color == "Red" AND int_val > 200000
         results, check = self.query(
-            client, collection_name,
+            client,
+            collection_name,
             filter='MATCH_ANY(structA, $[color] == "Red" && $[int_val] > 200000)',
             output_fields=["id"],
             limit=16384,
@@ -2663,14 +2915,14 @@ class TestMilvusClientStructArrayElementQueryLargeScale(TestMilvusClientV2Base):
 
         gt_ids = set()
         for row in data:
-            if any(e["color"] == "Red" and e["int_val"] > 200000
-                   for e in row["structA"]):
+            if any(e["color"] == "Red" and e["int_val"] > 200000 for e in row["structA"]):
                 gt_ids.add(row["id"])
 
         milvus_ids = set(r["id"] for r in results)
-        assert milvus_ids == gt_ids, \
-            f"Mismatch: {len(milvus_ids)} results vs {len(gt_ids)} expected. " \
+        assert milvus_ids == gt_ids, (
+            f"Mismatch: {len(milvus_ids)} results vs {len(gt_ids)} expected. "
             f"FP={len(milvus_ids - gt_ids)}, FN={len(gt_ids - milvus_ids)}"
+        )
 
     # ---- array_contains at scale ----
 
@@ -2686,7 +2938,8 @@ class TestMilvusClientStructArrayElementQueryLargeScale(TestMilvusClientV2Base):
         data = self.shared_data
 
         results, check = self.query(
-            client, collection_name,
+            client,
+            collection_name,
             filter='array_contains(structA[color], "Green")',
             output_fields=["id"],
             limit=16384,
@@ -2699,9 +2952,10 @@ class TestMilvusClientStructArrayElementQueryLargeScale(TestMilvusClientV2Base):
                 gt_ids.add(row["id"])
 
         milvus_ids = set(r["id"] for r in results)
-        assert milvus_ids == gt_ids, \
-            f"Mismatch: {len(milvus_ids)} vs {len(gt_ids)} expected. " \
+        assert milvus_ids == gt_ids, (
+            f"Mismatch: {len(milvus_ids)} vs {len(gt_ids)} expected. "
             f"FP={len(milvus_ids - gt_ids)}, FN={len(gt_ids - milvus_ids)}"
+        )
 
     # ---- Index vs no-index at scale ----
 
@@ -2722,21 +2976,20 @@ class TestMilvusClientStructArrayElementQueryLargeScale(TestMilvusClientV2Base):
 
         # Without index
         self._setup_large_collection.__func__(
-            self, client, col_no, nb=0,  # skip generation
+            self,
+            client,
+            col_no,
+            nb=0,  # skip generation
         )
         # Manual setup since we have data already
         schema = self._create_schema(client)
         idx_no = client.prepare_index_params()
-        idx_no.add_index(field_name="normal_vector", index_type="HNSW",
-                         metric_type="COSINE", params=INDEX_PARAMS)
-        idx_no.add_index(field_name="structA[embedding]", index_type="HNSW",
-                         metric_type="COSINE", params=INDEX_PARAMS)
+        idx_no.add_index(field_name="normal_vector", index_type="HNSW", metric_type="COSINE", params=INDEX_PARAMS)
+        idx_no.add_index(field_name="structA[embedding]", index_type="HNSW", metric_type="COSINE", params=INDEX_PARAMS)
 
         idx_yes = client.prepare_index_params()
-        idx_yes.add_index(field_name="normal_vector", index_type="HNSW",
-                          metric_type="COSINE", params=INDEX_PARAMS)
-        idx_yes.add_index(field_name="structA[embedding]", index_type="HNSW",
-                          metric_type="COSINE", params=INDEX_PARAMS)
+        idx_yes.add_index(field_name="normal_vector", index_type="HNSW", metric_type="COSINE", params=INDEX_PARAMS)
+        idx_yes.add_index(field_name="structA[embedding]", index_type="HNSW", metric_type="COSINE", params=INDEX_PARAMS)
         idx_yes.add_index(field_name="structA[int_val]", index_type="STL_SORT")
         idx_yes.add_index(field_name="structA[color]", index_type="INVERTED")
 
@@ -2750,7 +3003,7 @@ class TestMilvusClientStructArrayElementQueryLargeScale(TestMilvusClientV2Base):
         # Insert same data into both (small batch to avoid gRPC message size limit)
         batch_size = 200
         for start in range(0, len(data), batch_size):
-            batch = data[start:start + batch_size]
+            batch = data[start : start + batch_size]
             self.insert(client, col_no, batch)
             self.insert(client, col_yes, batch)
         self.flush(client, col_no)
@@ -2761,29 +3014,25 @@ class TestMilvusClientStructArrayElementQueryLargeScale(TestMilvusClientV2Base):
 
         # Compare element_filter query results
         filt = 'element_filter(structA, $[int_val] > 150000 && $[color] == "Blue")'
-        r_no, _ = self.query(client, col_no, filter=filt,
-                             output_fields=["id"], limit=16384)
-        r_yes, _ = self.query(client, col_yes, filter=filt,
-                              output_fields=["id"], limit=16384)
+        r_no, _ = self.query(client, col_no, filter=filt, output_fields=["id"], limit=16384)
+        r_yes, _ = self.query(client, col_yes, filter=filt, output_fields=["id"], limit=16384)
 
         ids_no = set(r["id"] for r in r_no)
         ids_yes = set(r["id"] for r in r_yes)
-        assert ids_no == ids_yes, \
-            f"Index inconsistency: no_idx={len(ids_no)} rows, with_idx={len(ids_yes)} rows. " \
-            f"Only in no_idx: {sorted(ids_no - ids_yes)[:10]}, " \
+        assert ids_no == ids_yes, (
+            f"Index inconsistency: no_idx={len(ids_no)} rows, with_idx={len(ids_yes)} rows. "
+            f"Only in no_idx: {sorted(ids_no - ids_yes)[:10]}, "
             f"Only in with_idx: {sorted(ids_yes - ids_no)[:10]}"
+        )
 
         # Also compare MATCH_ANY
         filt2 = 'MATCH_ANY(structA, $[int_val] > 150000 && $[color] == "Blue")'
-        r2_no, _ = self.query(client, col_no, filter=filt2,
-                              output_fields=["id"], limit=16384)
-        r2_yes, _ = self.query(client, col_yes, filter=filt2,
-                               output_fields=["id"], limit=16384)
+        r2_no, _ = self.query(client, col_no, filter=filt2, output_fields=["id"], limit=16384)
+        r2_yes, _ = self.query(client, col_yes, filter=filt2, output_fields=["id"], limit=16384)
 
         ids2_no = set(r["id"] for r in r2_no)
         ids2_yes = set(r["id"] for r in r2_yes)
-        assert ids2_no == ids2_yes, \
-            f"MATCH_ANY index inconsistency: {len(ids2_no)} vs {len(ids2_yes)}"
+        assert ids2_no == ids2_yes, f"MATCH_ANY index inconsistency: {len(ids2_no)} vs {len(ids2_yes)}"
 
     # ---- Multi-segment consistency ----
 
@@ -2801,15 +3050,18 @@ class TestMilvusClientStructArrayElementQueryLargeScale(TestMilvusClientV2Base):
         schema = self._create_schema(client)
         index_params = client.prepare_index_params()
         index_params.add_index(
-            field_name="normal_vector", index_type="HNSW",
-            metric_type="COSINE", params=INDEX_PARAMS,
+            field_name="normal_vector",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
         )
         index_params.add_index(
-            field_name="structA[embedding]", index_type="HNSW",
-            metric_type="COSINE", params=INDEX_PARAMS,
+            field_name="structA[embedding]",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
         )
-        self.create_collection(client, collection_name, schema=schema,
-                               index_params=index_params)
+        self.create_collection(client, collection_name, schema=schema, index_params=index_params)
 
         all_data = []
         # 5 sealed segments, 1000 rows each
@@ -2819,19 +3071,24 @@ class TestMilvusClientStructArrayElementQueryLargeScale(TestMilvusClientV2Base):
                 row_id = seg * 1000 + i
                 rng = random.Random(row_id)
                 num_elems = rng.randint(10, 30)
-                elems = [{
-                    "embedding": _seed_vector(row_id * 100 + j),
-                    "int_val": row_id * 10 + j,
-                    "str_val": f"r{row_id}_e{j}",
-                    "color": COLORS[j % 3],
-                } for j in range(num_elems)]
-                batch.append({
-                    "id": row_id,
-                    "doc_int": row_id,
-                    "doc_category": CATEGORIES[row_id % 4],
-                    "normal_vector": _seed_vector(row_id + 999999),
-                    "structA": elems,
-                })
+                elems = [
+                    {
+                        "embedding": _seed_vector(row_id * 100 + j),
+                        "int_val": row_id * 10 + j,
+                        "str_val": f"r{row_id}_e{j}",
+                        "color": COLORS[j % 3],
+                    }
+                    for j in range(num_elems)
+                ]
+                batch.append(
+                    {
+                        "id": row_id,
+                        "doc_int": row_id,
+                        "doc_category": CATEGORIES[row_id % 4],
+                        "normal_vector": _seed_vector(row_id + 999999),
+                        "structA": elems,
+                    }
+                )
             self.insert(client, collection_name, batch)
             self.flush(client, collection_name)
             all_data.extend(batch)
@@ -2844,19 +3101,24 @@ class TestMilvusClientStructArrayElementQueryLargeScale(TestMilvusClientV2Base):
             row_id = 5000 + i
             rng = random.Random(row_id)
             num_elems = rng.randint(10, 30)
-            elems = [{
-                "embedding": _seed_vector(row_id * 100 + j),
-                "int_val": row_id * 10 + j,
-                "str_val": f"r{row_id}_e{j}",
-                "color": COLORS[j % 3],
-            } for j in range(num_elems)]
-            growing_batch.append({
-                "id": row_id,
-                "doc_int": row_id,
-                "doc_category": CATEGORIES[row_id % 4],
-                "normal_vector": _seed_vector(row_id + 999999),
-                "structA": elems,
-            })
+            elems = [
+                {
+                    "embedding": _seed_vector(row_id * 100 + j),
+                    "int_val": row_id * 10 + j,
+                    "str_val": f"r{row_id}_e{j}",
+                    "color": COLORS[j % 3],
+                }
+                for j in range(num_elems)
+            ]
+            growing_batch.append(
+                {
+                    "id": row_id,
+                    "doc_int": row_id,
+                    "doc_category": CATEGORIES[row_id % 4],
+                    "normal_vector": _seed_vector(row_id + 999999),
+                    "structA": elems,
+                }
+            )
         self.insert(client, collection_name, growing_batch)
         all_data.extend(growing_batch)
 
@@ -2864,10 +3126,13 @@ class TestMilvusClientStructArrayElementQueryLargeScale(TestMilvusClientV2Base):
         # element_filter returns element-level results keyed by (id, offset)
         # Use a selective filter so total matching elements fit within limit,
         # ensuring both sealed and growing segments are represented
-        filt = 'element_filter(structA, $[int_val] > 49000)'
+        filt = "element_filter(structA, $[int_val] > 49000)"
         results, check = self.query(
-            client, collection_name,
-            filter=filt, output_fields=["id"], limit=16384,
+            client,
+            collection_name,
+            filter=filt,
+            output_fields=["id"],
+            limit=16384,
         )
         assert check
 
@@ -2881,15 +3146,16 @@ class TestMilvusClientStructArrayElementQueryLargeScale(TestMilvusClientV2Base):
         # Check coverage: results should include rows from all segments
         sealed_hits = [rid for rid in milvus_row_ids if rid < 5000]
         growing_hits = [rid for rid in milvus_row_ids if rid >= 5000]
-        log.info(f"Sealed hits: {len(sealed_hits)}, Growing hits: {len(growing_hits)}, "
-                 f"Total elements: {len(results)}, GT rows: {len(gt_row_ids)}")
+        log.info(
+            f"Sealed hits: {len(sealed_hits)}, Growing hits: {len(growing_hits)}, "
+            f"Total elements: {len(results)}, GT rows: {len(gt_row_ids)}"
+        )
         assert len(sealed_hits) > 0, "No results from sealed segments"
         assert len(growing_hits) > 0, "No results from growing segment"
 
         # Check no false positives at row level
         false_positives = milvus_row_ids - gt_row_ids
-        assert len(false_positives) == 0, \
-            f"{len(false_positives)} false positive rows"
+        assert len(false_positives) == 0, f"{len(false_positives)} false positive rows"
 
     # ---- MATCH_LEAST at scale ----
 
@@ -2906,7 +3172,8 @@ class TestMilvusClientStructArrayElementQueryLargeScale(TestMilvusClientV2Base):
 
         # MATCH_LEAST: at least 5 elements have color == "Red"
         results, check = self.query(
-            client, collection_name,
+            client,
+            collection_name,
             filter='MATCH_LEAST(structA, $[color] == "Red", threshold=5)',
             output_fields=["id"],
             limit=16384,
@@ -2920,9 +3187,10 @@ class TestMilvusClientStructArrayElementQueryLargeScale(TestMilvusClientV2Base):
                 gt_ids.add(row["id"])
 
         milvus_ids = set(r["id"] for r in results)
-        assert milvus_ids == gt_ids, \
-            f"MATCH_LEAST(5) mismatch: {len(milvus_ids)} vs {len(gt_ids)}. " \
+        assert milvus_ids == gt_ids, (
+            f"MATCH_LEAST(5) mismatch: {len(milvus_ids)} vs {len(gt_ids)}. "
             f"FP={len(milvus_ids - gt_ids)}, FN={len(gt_ids - milvus_ids)}"
+        )
 
     # ---- Multi-segment consistency using MATCH_ANY (doc-level, no limit issue) ----
 
@@ -2940,15 +3208,18 @@ class TestMilvusClientStructArrayElementQueryLargeScale(TestMilvusClientV2Base):
         schema = self._create_schema(client)
         index_params = client.prepare_index_params()
         index_params.add_index(
-            field_name="normal_vector", index_type="HNSW",
-            metric_type="COSINE", params=INDEX_PARAMS,
+            field_name="normal_vector",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
         )
         index_params.add_index(
-            field_name="structA[embedding]", index_type="HNSW",
-            metric_type="COSINE", params=INDEX_PARAMS,
+            field_name="structA[embedding]",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
         )
-        self.create_collection(client, collection_name, schema=schema,
-                               index_params=index_params)
+        self.create_collection(client, collection_name, schema=schema, index_params=index_params)
 
         all_data = []
         # 5 sealed segments, 1000 rows each
@@ -2958,19 +3229,24 @@ class TestMilvusClientStructArrayElementQueryLargeScale(TestMilvusClientV2Base):
                 row_id = seg * 1000 + i
                 rng = random.Random(row_id)
                 num_elems = rng.randint(10, 30)
-                elems = [{
-                    "embedding": _seed_vector(row_id * 100 + j),
-                    "int_val": row_id * 10 + j,
-                    "str_val": f"r{row_id}_e{j}",
-                    "color": COLORS[j % 3],
-                } for j in range(num_elems)]
-                batch.append({
-                    "id": row_id,
-                    "doc_int": row_id,
-                    "doc_category": CATEGORIES[row_id % 4],
-                    "normal_vector": _seed_vector(row_id + 999999),
-                    "structA": elems,
-                })
+                elems = [
+                    {
+                        "embedding": _seed_vector(row_id * 100 + j),
+                        "int_val": row_id * 10 + j,
+                        "str_val": f"r{row_id}_e{j}",
+                        "color": COLORS[j % 3],
+                    }
+                    for j in range(num_elems)
+                ]
+                batch.append(
+                    {
+                        "id": row_id,
+                        "doc_int": row_id,
+                        "doc_category": CATEGORIES[row_id % 4],
+                        "normal_vector": _seed_vector(row_id + 999999),
+                        "structA": elems,
+                    }
+                )
             self.insert(client, collection_name, batch)
             self.flush(client, collection_name)
             all_data.extend(batch)
@@ -2983,27 +3259,35 @@ class TestMilvusClientStructArrayElementQueryLargeScale(TestMilvusClientV2Base):
             row_id = 5000 + i
             rng = random.Random(row_id)
             num_elems = rng.randint(10, 30)
-            elems = [{
-                "embedding": _seed_vector(row_id * 100 + j),
-                "int_val": row_id * 10 + j,
-                "str_val": f"r{row_id}_e{j}",
-                "color": COLORS[j % 3],
-            } for j in range(num_elems)]
-            growing_batch.append({
-                "id": row_id,
-                "doc_int": row_id,
-                "doc_category": CATEGORIES[row_id % 4],
-                "normal_vector": _seed_vector(row_id + 999999),
-                "structA": elems,
-            })
+            elems = [
+                {
+                    "embedding": _seed_vector(row_id * 100 + j),
+                    "int_val": row_id * 10 + j,
+                    "str_val": f"r{row_id}_e{j}",
+                    "color": COLORS[j % 3],
+                }
+                for j in range(num_elems)
+            ]
+            growing_batch.append(
+                {
+                    "id": row_id,
+                    "doc_int": row_id,
+                    "doc_category": CATEGORIES[row_id % 4],
+                    "normal_vector": _seed_vector(row_id + 999999),
+                    "structA": elems,
+                }
+            )
         self.insert(client, collection_name, growing_batch)
         all_data.extend(growing_batch)
 
         # MATCH_ANY query (doc-level limit, not affected by #3325)
-        filt = 'MATCH_ANY(structA, $[int_val] > 40000)'
+        filt = "MATCH_ANY(structA, $[int_val] > 40000)"
         results, check = self.query(
-            client, collection_name,
-            filter=filt, output_fields=["id"], limit=16384,
+            client,
+            collection_name,
+            filter=filt,
+            output_fields=["id"],
+            limit=16384,
         )
         assert check
 
@@ -3023,11 +3307,8 @@ class TestMilvusClientStructArrayElementQueryLargeScale(TestMilvusClientV2Base):
         # Exact match
         false_positives = milvus_ids - gt_ids
         false_negatives = gt_ids - milvus_ids
-        assert len(false_positives) == 0, \
-            f"{len(false_positives)} false positives"
-        assert len(false_negatives) == 0, \
-            f"{len(false_negatives)} false negatives out of {len(gt_ids)}"
-
+        assert len(false_positives) == 0, f"{len(false_positives)} false positives"
+        assert len(false_negatives) == 0, f"{len(false_negatives)} false negatives out of {len(gt_ids)}"
 
 
 class TestMilvusClientStructArrayElementMatchQuery(TestMilvusClientV2Base):
@@ -3047,7 +3328,8 @@ class TestMilvusClientStructArrayElementMatchQuery(TestMilvusClientV2Base):
         struct_schema.add_field("color", DataType.VARCHAR, max_length=128)
 
         schema.add_field(
-            "structA", datatype=DataType.ARRAY,
+            "structA",
+            datatype=DataType.ARRAY,
             element_type=DataType.STRUCT,
             struct_schema=struct_schema,
             max_capacity=default_capacity,
@@ -3066,27 +3348,32 @@ class TestMilvusClientStructArrayElementMatchQuery(TestMilvusClientV2Base):
                     emb = [1.0] + [0.0] * (dim - 1)
                 else:
                     emb = _seed_vector(i * 1000 + j, dim)
-                struct_array.append({
-                    "embedding": emb,
-                    "int_val": i * 100 + j,
-                    "str_val": f"row_{i}_elem_{j}",
-                    "color": COLORS[j % 3],
-                })
-            data.append({
-                "id": i, "doc_int": i,
-                "normal_vector": _seed_vector(i + 999999, dim),
-                "structA": struct_array,
-            })
+                struct_array.append(
+                    {
+                        "embedding": emb,
+                        "int_val": i * 100 + j,
+                        "str_val": f"row_{i}_elem_{j}",
+                        "color": COLORS[j % 3],
+                    }
+                )
+            data.append(
+                {
+                    "id": i,
+                    "doc_int": i,
+                    "normal_vector": _seed_vector(i + 999999, dim),
+                    "structA": struct_array,
+                }
+            )
         return data
 
     def _setup_collection(self, client, collection_name, nb=500, flush=True):
         """Helper: create, insert, index, load."""
         schema = self._create_schema(client)
         index_params = client.prepare_index_params()
-        index_params.add_index(field_name="normal_vector", index_type="HNSW",
-                               metric_type="COSINE", params=INDEX_PARAMS)
-        index_params.add_index(field_name="structA[embedding]", index_type="HNSW",
-                               metric_type="MAX_SIM_COSINE", params=INDEX_PARAMS)
+        index_params.add_index(field_name="normal_vector", index_type="HNSW", metric_type="COSINE", params=INDEX_PARAMS)
+        index_params.add_index(
+            field_name="structA[embedding]", index_type="HNSW", metric_type="MAX_SIM_COSINE", params=INDEX_PARAMS
+        )
         self.create_collection(client, collection_name, schema=schema, index_params=index_params)
 
         data = self._generate_data(nb=nb)
@@ -3110,8 +3397,9 @@ class TestMilvusClientStructArrayElementMatchQuery(TestMilvusClientV2Base):
         data = self._setup_collection(client, collection_name)
 
         results, check = self.query(
-            client, collection_name,
-            filter='MATCH_ALL(structA, $[int_val] > 0)',
+            client,
+            collection_name,
+            filter="MATCH_ALL(structA, $[int_val] > 0)",
             output_fields=["id", "structA"],
             limit=100,
         )
@@ -3136,7 +3424,8 @@ class TestMilvusClientStructArrayElementMatchQuery(TestMilvusClientV2Base):
         data = self._setup_collection(client, collection_name)
 
         results, check = self.query(
-            client, collection_name,
+            client,
+            collection_name,
             filter='MATCH_ANY(structA, $[str_val] == "row_10_elem_0")',
             output_fields=["id", "structA"],
             limit=100,
@@ -3163,8 +3452,9 @@ class TestMilvusClientStructArrayElementMatchQuery(TestMilvusClientV2Base):
         data = self._setup_collection(client, collection_name)
 
         results, check = self.query(
-            client, collection_name,
-            filter='MATCH_LEAST(structA, $[int_val] > 5, threshold=2)',
+            client,
+            collection_name,
+            filter="MATCH_LEAST(structA, $[int_val] > 5, threshold=2)",
             output_fields=["id", "structA"],
             limit=100,
         )
@@ -3190,8 +3480,9 @@ class TestMilvusClientStructArrayElementMatchQuery(TestMilvusClientV2Base):
         data = self._setup_collection(client, collection_name)
 
         results, check = self.query(
-            client, collection_name,
-            filter='MATCH_MOST(structA, $[int_val] > 5, threshold=3)',
+            client,
+            collection_name,
+            filter="MATCH_MOST(structA, $[int_val] > 5, threshold=3)",
             output_fields=["id", "structA"],
             limit=100,
         )
@@ -3217,7 +3508,8 @@ class TestMilvusClientStructArrayElementMatchQuery(TestMilvusClientV2Base):
         data = self._setup_collection(client, collection_name)
 
         results, check = self.query(
-            client, collection_name,
+            client,
+            collection_name,
             filter='MATCH_EXACT(structA, $[color] == "Red", threshold=1)',
             output_fields=["id", "structA"],
             limit=100,
@@ -3244,7 +3536,8 @@ class TestMilvusClientStructArrayElementMatchQuery(TestMilvusClientV2Base):
         data = self._setup_collection(client, collection_name)
 
         results, check = self.query(
-            client, collection_name,
+            client,
+            collection_name,
             filter='id > 100 && MATCH_ANY(structA, $[color] == "Red")',
             output_fields=["id", "structA"],
             limit=100,
@@ -3254,7 +3547,9 @@ class TestMilvusClientStructArrayElementMatchQuery(TestMilvusClientV2Base):
             assert hit["id"] > 100
             assert any(e["color"] == "Red" for e in hit["structA"])
         gt_ids = gt_match_query(
-            data, "MATCH_ANY", lambda e: e["color"] == "Red",
+            data,
+            "MATCH_ANY",
+            lambda e: e["color"] == "Red",
             doc_filter_fn=lambda row: row["id"] > 100,
         )
         milvus_ids = {r["id"] for r in results}
@@ -3274,7 +3569,8 @@ class TestMilvusClientStructArrayElementMatchQuery(TestMilvusClientV2Base):
         self._setup_collection(client, collection_name)
 
         results, check = self.query(
-            client, collection_name,
+            client,
+            collection_name,
             filter='MATCH_ANY(structA, $[color] == "Blue")',
             output_fields=["id", "structA[color]", "structA[int_val]"],
             limit=50,
@@ -3296,7 +3592,8 @@ class TestMilvusClientStructArrayElementMatchQuery(TestMilvusClientV2Base):
         self._setup_collection(client, collection_name)
 
         results, check = self.query(
-            client, collection_name,
+            client,
+            collection_name,
             filter='MATCH_ANY(structA, $[color] == "Red")',
             output_fields=["count(*)"],
         )
@@ -3316,14 +3613,20 @@ class TestMilvusClientStructArrayElementMatchQuery(TestMilvusClientV2Base):
         self._setup_collection(client, collection_name)
 
         results_p1, _ = self.query(
-            client, collection_name,
+            client,
+            collection_name,
             filter='MATCH_ANY(structA, $[color] == "Red")',
-            output_fields=["id"], limit=10, offset=0,
+            output_fields=["id"],
+            limit=10,
+            offset=0,
         )
         results_p2, _ = self.query(
-            client, collection_name,
+            client,
+            collection_name,
             filter='MATCH_ANY(structA, $[color] == "Red")',
-            output_fields=["id"], limit=10, offset=10,
+            output_fields=["id"],
+            limit=10,
+            offset=10,
         )
         ids_p1 = {r["id"] for r in results_p1}
         ids_p2 = {r["id"] for r in results_p2}
@@ -3341,10 +3644,10 @@ class TestMilvusClientStructArrayElementMatchQuery(TestMilvusClientV2Base):
 
         schema = self._create_schema(client)
         index_params = client.prepare_index_params()
-        index_params.add_index(field_name="normal_vector", index_type="HNSW",
-                               metric_type="COSINE", params=INDEX_PARAMS)
-        index_params.add_index(field_name="structA[embedding]", index_type="HNSW",
-                               metric_type="MAX_SIM_COSINE", params=INDEX_PARAMS)
+        index_params.add_index(field_name="normal_vector", index_type="HNSW", metric_type="COSINE", params=INDEX_PARAMS)
+        index_params.add_index(
+            field_name="structA[embedding]", index_type="HNSW", metric_type="MAX_SIM_COSINE", params=INDEX_PARAMS
+        )
         self.create_collection(client, collection_name, schema=schema, index_params=index_params)
 
         # Sealed data
@@ -3359,24 +3662,31 @@ class TestMilvusClientStructArrayElementMatchQuery(TestMilvusClientV2Base):
             num_elems = rng.randint(3, 10)
             struct_array = []
             for j in range(num_elems):
-                struct_array.append({
-                    "embedding": _seed_vector(i * 1000 + j),
-                    "int_val": i * 100 + j,
-                    "str_val": f"row_{i}_elem_{j}",
-                    "color": COLORS[j % 3],
-                })
-            growing_data.append({
-                "id": i, "doc_int": i,
-                "normal_vector": _seed_vector(i + 999999),
-                "structA": struct_array,
-            })
+                struct_array.append(
+                    {
+                        "embedding": _seed_vector(i * 1000 + j),
+                        "int_val": i * 100 + j,
+                        "str_val": f"row_{i}_elem_{j}",
+                        "color": COLORS[j % 3],
+                    }
+                )
+            growing_data.append(
+                {
+                    "id": i,
+                    "doc_int": i,
+                    "normal_vector": _seed_vector(i + 999999),
+                    "structA": struct_array,
+                }
+            )
         self.insert(client, collection_name, growing_data)
         self.load_collection(client, collection_name)
 
         results, check = self.query(
-            client, collection_name,
+            client,
+            collection_name,
             filter='MATCH_ANY(structA, $[color] == "Blue")',
-            output_fields=["id"], limit=500,
+            output_fields=["id"],
+            limit=500,
         )
         assert check
         ids = [r["id"] for r in results]
@@ -3429,7 +3739,8 @@ class TestMilvusClientStructArrayIndexAccess(TestMilvusClientV2Base):
         struct_schema.add_field("color", DataType.VARCHAR, max_length=128)
 
         schema.add_field(
-            "structA", datatype=DataType.ARRAY,
+            "structA",
+            datatype=DataType.ARRAY,
             element_type=DataType.STRUCT,
             struct_schema=struct_schema,
             max_capacity=default_capacity,
@@ -3460,16 +3771,17 @@ class TestMilvusClientStructArrayIndexAccess(TestMilvusClientV2Base):
             "id": row_id,
             "doc_int": row_id,
             "normal_vector": _seed_vector(row_id + 999999),
-            "structA": [{
-                "embedding": _seed_vector(row_id * 1000),
-                "int_val": 0,
-                "str_val": f"inert_{row_id}",
-                "color": "Inert",
-            }],
+            "structA": [
+                {
+                    "embedding": _seed_vector(row_id * 1000),
+                    "int_val": 0,
+                    "str_val": f"inert_{row_id}",
+                    "color": "Inert",
+                }
+            ],
         }
 
-    def _setup_collection_split(self, client, collection_name,
-                                 sealed_rows, growing_rows):
+    def _setup_collection_split(self, client, collection_name, sealed_rows, growing_rows):
         """Setup with explicit sealed/growing controlled row groups.
 
         Layout (>= 3500 rows total):
@@ -3479,27 +3791,28 @@ class TestMilvusClientStructArrayIndexAccess(TestMilvusClientV2Base):
         schema = self._create_schema(client)
         index_params = client.prepare_index_params()
         index_params.add_index(
-            field_name="normal_vector", index_type="HNSW",
-            metric_type="COSINE", params=INDEX_PARAMS,
+            field_name="normal_vector",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
         )
         index_params.add_index(
-            field_name="structA[embedding]", index_type="HNSW",
-            metric_type="COSINE", params=INDEX_PARAMS,
+            field_name="structA[embedding]",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
         )
-        self.create_collection(client, collection_name, schema=schema,
-                               index_params=index_params)
+        self.create_collection(client, collection_name, schema=schema, index_params=index_params)
 
         bg_start = 100000
         for start in range(0, default_nb, insert_batch_size):
-            batch = [self._make_inert_row(bg_start + start + k)
-                     for k in range(insert_batch_size)]
+            batch = [self._make_inert_row(bg_start + start + k) for k in range(insert_batch_size)]
             self.insert(client, collection_name, batch)
         if sealed_rows:
             self.insert(client, collection_name, sealed_rows)
         self.flush(client, collection_name)
 
-        growing_bg = [self._make_inert_row(bg_start + default_nb + k)
-                      for k in range(default_growing_nb)]
+        growing_bg = [self._make_inert_row(bg_start + default_nb + k) for k in range(default_growing_nb)]
         self.insert(client, collection_name, growing_bg)
         if growing_rows:
             self.insert(client, collection_name, growing_rows)
@@ -3519,21 +3832,23 @@ class TestMilvusClientStructArrayIndexAccess(TestMilvusClientV2Base):
         schema = self._create_schema(client)
         index_params = client.prepare_index_params()
         index_params.add_index(
-            field_name="normal_vector", index_type="HNSW",
-            metric_type="COSINE", params=INDEX_PARAMS,
+            field_name="normal_vector",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
         )
         index_params.add_index(
-            field_name="structA[embedding]", index_type="HNSW",
-            metric_type="COSINE", params=INDEX_PARAMS,
+            field_name="structA[embedding]",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
         )
-        self.create_collection(client, collection_name, schema=schema,
-                               index_params=index_params)
+        self.create_collection(client, collection_name, schema=schema, index_params=index_params)
 
         # 1) Sealed inert background: 3000 rows
         bg_start = 100000
         for start in range(0, default_nb, insert_batch_size):
-            batch = [self._make_inert_row(bg_start + start + k)
-                     for k in range(insert_batch_size)]
+            batch = [self._make_inert_row(bg_start + start + k) for k in range(insert_batch_size)]
             self.insert(client, collection_name, batch)
 
         # 2) Half of controlled rows -> sealed
@@ -3545,8 +3860,7 @@ class TestMilvusClientStructArrayIndexAccess(TestMilvusClientV2Base):
         self.flush(client, collection_name)
 
         # 3) Growing inert background: 500 rows
-        growing_bg = [self._make_inert_row(bg_start + default_nb + k)
-                      for k in range(default_growing_nb)]
+        growing_bg = [self._make_inert_row(bg_start + default_nb + k) for k in range(default_growing_nb)]
         self.insert(client, collection_name, growing_bg)
 
         # 4) Remaining controlled rows -> growing
@@ -3570,16 +3884,18 @@ class TestMilvusClientStructArrayIndexAccess(TestMilvusClientV2Base):
         rows = [
             self._make_row(0, [{"int_val": 10}, {"int_val": 20}]),
             self._make_row(1, [{"int_val": 100}, {"int_val": 200}]),
-            self._make_row(2, [{"int_val": 100}]),                   # first elem also 100
+            self._make_row(2, [{"int_val": 100}]),  # first elem also 100
             self._make_row(3, [{"int_val": 50}, {"int_val": 100}]),  # 100 at index 1, not 0
             self._make_row(4, [{"int_val": 999}]),
         ]
         self._setup_collection(client, collection_name, rows)
 
         results, check = self.query(
-            client, collection_name,
-            filter='id < 100 && structA[0][int_val] == 100',
-            output_fields=["id"], limit=100,
+            client,
+            collection_name,
+            filter="id < 100 && structA[0][int_val] == 100",
+            output_fields=["id"],
+            limit=100,
         )
         assert check
         ids = sorted({r["id"] for r in results})
@@ -3597,23 +3913,23 @@ class TestMilvusClientStructArrayIndexAccess(TestMilvusClientV2Base):
         client = self._client()
         collection_name = cf.gen_unique_str(f"{prefix}_idx_cmp")
 
-        rows = [
-            self._make_row(i, [{"int_val": v}])
-            for i, v in enumerate([10, 20, 30, 40, 50])
-        ]
+        rows = [self._make_row(i, [{"int_val": v}]) for i, v in enumerate([10, 20, 30, 40, 50])]
         self._setup_collection(client, collection_name, rows)
 
         cases = [
-            ('id < 100 && structA[0][int_val] != 30', [0, 1, 3, 4]),
-            ('id < 100 && structA[0][int_val] > 30', [3, 4]),
-            ('id < 100 && structA[0][int_val] >= 30', [2, 3, 4]),
-            ('id < 100 && structA[0][int_val] < 30', [0, 1]),
-            ('id < 100 && structA[0][int_val] <= 30', [0, 1, 2]),
+            ("id < 100 && structA[0][int_val] != 30", [0, 1, 3, 4]),
+            ("id < 100 && structA[0][int_val] > 30", [3, 4]),
+            ("id < 100 && structA[0][int_val] >= 30", [2, 3, 4]),
+            ("id < 100 && structA[0][int_val] < 30", [0, 1]),
+            ("id < 100 && structA[0][int_val] <= 30", [0, 1, 2]),
         ]
         for expr, expected in cases:
             results, check = self.query(
-                client, collection_name,
-                filter=expr, output_fields=["id"], limit=100,
+                client,
+                collection_name,
+                filter=expr,
+                output_fields=["id"],
+                limit=100,
             )
             assert check, expr
             ids = sorted({r["id"] for r in results})
@@ -3631,24 +3947,25 @@ class TestMilvusClientStructArrayIndexAccess(TestMilvusClientV2Base):
         client = self._client()
         collection_name = cf.gen_unique_str(f"{prefix}_idx_in")
 
-        rows = [
-            self._make_row(i, [{"int_val": v}])
-            for i, v in enumerate([10, 20, 30, 40, 50])
-        ]
+        rows = [self._make_row(i, [{"int_val": v}]) for i, v in enumerate([10, 20, 30, 40, 50])]
         self._setup_collection(client, collection_name, rows)
 
         results, check = self.query(
-            client, collection_name,
-            filter='id < 100 && structA[0][int_val] in [10, 30, 50, 999]',
-            output_fields=["id"], limit=100,
+            client,
+            collection_name,
+            filter="id < 100 && structA[0][int_val] in [10, 30, 50, 999]",
+            output_fields=["id"],
+            limit=100,
         )
         assert check
         assert sorted({r["id"] for r in results}) == [0, 2, 4]
 
         results, check = self.query(
-            client, collection_name,
-            filter='id < 100 && structA[0][int_val] not in [10, 30, 50]',
-            output_fields=["id"], limit=100,
+            client,
+            collection_name,
+            filter="id < 100 && structA[0][int_val] not in [10, 30, 50]",
+            output_fields=["id"],
+            limit=100,
         )
         assert check
         assert sorted({r["id"] for r in results}) == [1, 3]
@@ -3665,26 +3982,27 @@ class TestMilvusClientStructArrayIndexAccess(TestMilvusClientV2Base):
         client = self._client()
         collection_name = cf.gen_unique_str(f"{prefix}_idx_range_fwd")
 
-        rows = [
-            self._make_row(i, [{"int_val": v}])
-            for i, v in enumerate([10, 20, 30, 40, 50])
-        ]
+        rows = [self._make_row(i, [{"int_val": v}]) for i, v in enumerate([10, 20, 30, 40, 50])]
         self._setup_collection(client, collection_name, rows)
 
         # Open: 20 < x < 40 -> only 30 (inert int_val=0 excluded)
         results, check = self.query(
-            client, collection_name,
-            filter='id < 100 && 20 < structA[0][int_val] < 40',
-            output_fields=["id"], limit=100,
+            client,
+            collection_name,
+            filter="id < 100 && 20 < structA[0][int_val] < 40",
+            output_fields=["id"],
+            limit=100,
         )
         assert check
         assert sorted({r["id"] for r in results}) == [2]
 
         # Closed: 20 <= x <= 40 -> 20, 30, 40
         results, check = self.query(
-            client, collection_name,
-            filter='id < 100 && 20 <= structA[0][int_val] <= 40',
-            output_fields=["id"], limit=100,
+            client,
+            collection_name,
+            filter="id < 100 && 20 <= structA[0][int_val] <= 40",
+            output_fields=["id"],
+            limit=100,
         )
         assert check
         assert sorted({r["id"] for r in results}) == [1, 2, 3]
@@ -3701,26 +4019,27 @@ class TestMilvusClientStructArrayIndexAccess(TestMilvusClientV2Base):
         client = self._client()
         collection_name = cf.gen_unique_str(f"{prefix}_idx_range_rev")
 
-        rows = [
-            self._make_row(i, [{"int_val": v}])
-            for i, v in enumerate([10, 20, 30, 40, 50])
-        ]
+        rows = [self._make_row(i, [{"int_val": v}]) for i, v in enumerate([10, 20, 30, 40, 50])]
         self._setup_collection(client, collection_name, rows)
 
         # Open: 40 > x > 20 -> only 30
         results, check = self.query(
-            client, collection_name,
-            filter='id < 100 && 40 > structA[0][int_val] > 20',
-            output_fields=["id"], limit=100,
+            client,
+            collection_name,
+            filter="id < 100 && 40 > structA[0][int_val] > 20",
+            output_fields=["id"],
+            limit=100,
         )
         assert check
         assert sorted({r["id"] for r in results}) == [2]
 
         # Closed: 40 >= x >= 20 -> 20, 30, 40
         results, check = self.query(
-            client, collection_name,
-            filter='id < 100 && 40 >= structA[0][int_val] >= 20',
-            output_fields=["id"], limit=100,
+            client,
+            collection_name,
+            filter="id < 100 && 40 >= structA[0][int_val] >= 20",
+            output_fields=["id"],
+            limit=100,
         )
         assert check
         assert sorted({r["id"] for r in results}) == [1, 2, 3]
@@ -3746,25 +4065,31 @@ class TestMilvusClientStructArrayIndexAccess(TestMilvusClientV2Base):
         self._setup_collection(client, collection_name, rows)
 
         results, check = self.query(
-            client, collection_name,
+            client,
+            collection_name,
             filter='id < 100 && structA[0][str_val] == "apple"',
-            output_fields=["id"], limit=100,
+            output_fields=["id"],
+            limit=100,
         )
         assert check
         assert sorted({r["id"] for r in results}) == [0, 2]
 
         results, check = self.query(
-            client, collection_name,
+            client,
+            collection_name,
             filter='id < 100 && structA[0][str_val] in ["banana", "cherry"]',
-            output_fields=["id"], limit=100,
+            output_fields=["id"],
+            limit=100,
         )
         assert check
         assert sorted({r["id"] for r in results}) == [1, 3]
 
         results, check = self.query(
-            client, collection_name,
+            client,
+            collection_name,
             filter='id < 100 && structA[0][str_val] != "apple"',
-            output_fields=["id"], limit=100,
+            output_fields=["id"],
+            limit=100,
         )
         assert check
         assert sorted({r["id"] for r in results}) == [1, 3]
@@ -3783,27 +4108,31 @@ class TestMilvusClientStructArrayIndexAccess(TestMilvusClientV2Base):
 
         # int_val pairs:           [a, b]
         rows = [
-            self._make_row(0, [{"int_val": 100}, {"int_val": 1}]),    # a>50, b<10  -> match
-            self._make_row(1, [{"int_val": 100}, {"int_val": 50}]),   # a>50, b>=10 -> no
-            self._make_row(2, [{"int_val": 10}, {"int_val": 1}]),     # a<=50       -> no
-            self._make_row(3, [{"int_val": 200}, {"int_val": 5}]),    # match
-            self._make_row(4, [{"int_val": 60}, {"int_val": 9}]),     # match
+            self._make_row(0, [{"int_val": 100}, {"int_val": 1}]),  # a>50, b<10  -> match
+            self._make_row(1, [{"int_val": 100}, {"int_val": 50}]),  # a>50, b>=10 -> no
+            self._make_row(2, [{"int_val": 10}, {"int_val": 1}]),  # a<=50       -> no
+            self._make_row(3, [{"int_val": 200}, {"int_val": 5}]),  # match
+            self._make_row(4, [{"int_val": 60}, {"int_val": 9}]),  # match
         ]
         self._setup_collection(client, collection_name, rows)
 
         results, check = self.query(
-            client, collection_name,
-            filter='id < 100 && structA[0][int_val] > 50 && structA[1][int_val] < 10',
-            output_fields=["id"], limit=100,
+            client,
+            collection_name,
+            filter="id < 100 && structA[0][int_val] > 50 && structA[1][int_val] < 10",
+            output_fields=["id"],
+            limit=100,
         )
         assert check
         assert sorted({r["id"] for r in results}) == [0, 3, 4]
 
         # OR variant — wrap with id-bound to keep inert rows out
         results, check = self.query(
-            client, collection_name,
-            filter='id < 100 && (structA[0][int_val] > 150 || structA[1][int_val] == 50)',
-            output_fields=["id"], limit=100,
+            client,
+            collection_name,
+            filter="id < 100 && (structA[0][int_val] > 150 || structA[1][int_val] == 50)",
+            output_fields=["id"],
+            limit=100,
         )
         assert check
         assert sorted({r["id"] for r in results}) == [1, 3]
@@ -3820,16 +4149,15 @@ class TestMilvusClientStructArrayIndexAccess(TestMilvusClientV2Base):
         client = self._client()
         collection_name = cf.gen_unique_str(f"{prefix}_idx_doc")
 
-        rows = [
-            self._make_row(i, [{"int_val": v}])
-            for i, v in enumerate([10, 20, 30, 40, 50])
-        ]
+        rows = [self._make_row(i, [{"int_val": v}]) for i, v in enumerate([10, 20, 30, 40, 50])]
         self._setup_collection(client, collection_name, rows)
 
         results, check = self.query(
-            client, collection_name,
-            filter='id >= 2 && structA[0][int_val] >= 30',
-            output_fields=["id"], limit=100,
+            client,
+            collection_name,
+            filter="id >= 2 && structA[0][int_val] >= 30",
+            output_fields=["id"],
+            limit=100,
         )
         assert check
         assert sorted({r["id"] for r in results}) == [2, 3, 4]
@@ -3847,25 +4175,27 @@ class TestMilvusClientStructArrayIndexAccess(TestMilvusClientV2Base):
         collection_name = cf.gen_unique_str(f"{prefix}_idx_oob")
 
         rows = [
-            self._make_row(0, [{"int_val": 10}]),                            # length 1
-            self._make_row(1, [{"int_val": 10}, {"int_val": 20}]),           # length 2
-            self._make_row(2, [{"int_val": 1}, {"int_val": 2},
-                               {"int_val": 3}, {"int_val": 99}]),            # length 4 -> index 3 = 99
-            self._make_row(3, [{"int_val": 1}, {"int_val": 2},
-                               {"int_val": 3}, {"int_val": 100}]),           # length 4 -> index 3 = 100
+            self._make_row(0, [{"int_val": 10}]),  # length 1
+            self._make_row(1, [{"int_val": 10}, {"int_val": 20}]),  # length 2
+            self._make_row(
+                2, [{"int_val": 1}, {"int_val": 2}, {"int_val": 3}, {"int_val": 99}]
+            ),  # length 4 -> index 3 = 99
+            self._make_row(
+                3, [{"int_val": 1}, {"int_val": 2}, {"int_val": 3}, {"int_val": 100}]
+            ),  # length 4 -> index 3 = 100
         ]
         self._setup_collection(client, collection_name, rows)
 
         results, check = self.query(
-            client, collection_name,
-            filter='id < 100 && structA[3][int_val] >= 99',
-            output_fields=["id"], limit=100,
+            client,
+            collection_name,
+            filter="id < 100 && structA[3][int_val] >= 99",
+            output_fields=["id"],
+            limit=100,
         )
         assert check
         ids = sorted({r["id"] for r in results})
-        assert ids == [2, 3], (
-            f"Only rows with >=4 elements at index 3 should match, got {ids}"
-        )
+        assert ids == [2, 3], f"Only rows with >=4 elements at index 3 should match, got {ids}"
 
     # ---- 9.10 Negative cases ----
 
@@ -3884,33 +4214,33 @@ class TestMilvusClientStructArrayIndexAccess(TestMilvusClientV2Base):
 
         # parent field does not exist -> server reports "struct field not found"
         self.query(
-            client, collection_name,
-            filter='non_existent[0][int_val] > 0',
+            client,
+            collection_name,
+            filter="non_existent[0][int_val] > 0",
             output_fields=["id"],
             check_task=CheckTasks.err_res,
-            check_items={ct.err_code: 1100,
-                         ct.err_msg: "struct field not found"},
+            check_items={ct.err_code: 1100, ct.err_msg: "struct field not found"},
         )
 
         # sub-field does not exist on structA
         self.query(
-            client, collection_name,
-            filter='structA[0][not_a_field] > 0',
+            client,
+            collection_name,
+            filter="structA[0][not_a_field] > 0",
             output_fields=["id"],
             check_task=CheckTasks.err_res,
-            check_items={ct.err_code: 1100,
-                         ct.err_msg: "struct field not found"},
+            check_items={ct.err_code: 1100, ct.err_msg: "struct field not found"},
         )
 
         # swapped form: sub-field name first, then numeric index — grammar
         # rejects it as an invalid expression, not as a missing field.
         self.query(
-            client, collection_name,
-            filter='structA[int_val][0] > 0',
+            client,
+            collection_name,
+            filter="structA[int_val][0] > 0",
             output_fields=["id"],
             check_task=CheckTasks.err_res,
-            check_items={ct.err_code: 1100,
-                         ct.err_msg: "invalid expression"},
+            check_items={ct.err_code: 1100, ct.err_msg: "invalid expression"},
         )
 
     # ---- 9.11 Use inside search() filter ----
@@ -3928,23 +4258,23 @@ class TestMilvusClientStructArrayIndexAccess(TestMilvusClientV2Base):
         collection_name = cf.gen_unique_str(f"{prefix}_idx_arrlen")
 
         # Row i has (i+1) struct elements (lengths: 1, 2, 3, 4, 5)
-        rows = [
-            self._make_row(i, [{"int_val": j} for j in range(i + 1)])
-            for i in range(5)
-        ]
+        rows = [self._make_row(i, [{"int_val": j} for j in range(i + 1)]) for i in range(5)]
         self._setup_collection(client, collection_name, rows)
 
         # inert background rows have struct length=1, so combine with id<100
         # to keep assertions on the controlled set exact.
         cases = [
-            ('id < 100 && array_length(structA[int_val]) == 3', [2]),
-            ('id < 100 && array_length(structA[int_val]) >= 4', [3, 4]),
-            ('id < 100 && array_length(structA[int_val]) < 3', [0, 1]),
+            ("id < 100 && array_length(structA[int_val]) == 3", [2]),
+            ("id < 100 && array_length(structA[int_val]) >= 4", [3, 4]),
+            ("id < 100 && array_length(structA[int_val]) < 3", [0, 1]),
         ]
         for expr, expected in cases:
             results, check = self.query(
-                client, collection_name,
-                filter=expr, output_fields=["id"], limit=100,
+                client,
+                collection_name,
+                filter=expr,
+                output_fields=["id"],
+                limit=100,
             )
             assert check, expr
             ids = sorted({r["id"] for r in results})
@@ -3971,12 +4301,12 @@ class TestMilvusClientStructArrayIndexAccess(TestMilvusClientV2Base):
         # Grammar lists allowed forms in the parser error message; assert the
         # indexed form is rejected as a parse mismatch.
         self.query(
-            client, collection_name,
-            filter='array_length(structA[0][int_val]) == 1',
+            client,
+            collection_name,
+            filter="array_length(structA[0][int_val]) == 1",
             output_fields=["id"],
             check_task=CheckTasks.err_res,
-            check_items={ct.err_code: 1100,
-                         ct.err_msg: "mismatched input"},
+            check_items={ct.err_code: 1100, ct.err_msg: "mismatched input"},
         )
 
     # ---- 9.14 Per-segment consistency: same predicate on sealed-only / growing-only ----
@@ -3999,39 +4329,33 @@ class TestMilvusClientStructArrayIndexAccess(TestMilvusClientV2Base):
 
         # Identical int_val pattern; sealed ids 0..4 / growing ids 5..9
         pattern = [10, 20, 30, 40, 50]
-        sealed_rows = [
-            self._make_row(i, [{"int_val": v}]) for i, v in enumerate(pattern)
-        ]
-        growing_rows = [
-            self._make_row(i + 5, [{"int_val": v}]) for i, v in enumerate(pattern)
-        ]
+        sealed_rows = [self._make_row(i, [{"int_val": v}]) for i, v in enumerate(pattern)]
+        growing_rows = [self._make_row(i + 5, [{"int_val": v}]) for i, v in enumerate(pattern)]
         self._setup_collection_split(client, collection_name, sealed_rows, growing_rows)
 
         cases = [
-            ('id < 100 && structA[0][int_val] == 30', [2], [7]),
-            ('id < 100 && structA[0][int_val] >= 30', [2, 3, 4], [7, 8, 9]),
-            ('id < 100 && structA[0][int_val] in [10, 50]', [0, 4], [5, 9]),
-            ('id < 100 && 20 < structA[0][int_val] < 50', [2, 3], [7, 8]),
+            ("id < 100 && structA[0][int_val] == 30", [2], [7]),
+            ("id < 100 && structA[0][int_val] >= 30", [2, 3, 4], [7, 8, 9]),
+            ("id < 100 && structA[0][int_val] in [10, 50]", [0, 4], [5, 9]),
+            ("id < 100 && 20 < structA[0][int_val] < 50", [2, 3], [7, 8]),
         ]
         for expr, exp_sealed, exp_growing in cases:
             results, check = self.query(
-                client, collection_name,
-                filter=expr, output_fields=["id"], limit=200,
+                client,
+                collection_name,
+                filter=expr,
+                output_fields=["id"],
+                limit=200,
             )
             assert check, expr
             ids = sorted({r["id"] for r in results})
             sealed_part = [i for i in ids if i < 5]
             growing_part = [i for i in ids if 5 <= i < 100]
-            assert sealed_part == exp_sealed, (
-                f"{expr}: sealed expected {exp_sealed}, got {sealed_part}"
-            )
-            assert growing_part == exp_growing, (
-                f"{expr}: growing expected {exp_growing}, got {growing_part}"
-            )
+            assert sealed_part == exp_sealed, f"{expr}: sealed expected {exp_sealed}, got {sealed_part}"
+            assert growing_part == exp_growing, f"{expr}: growing expected {exp_growing}, got {growing_part}"
             # Mirroring: each sealed id i has growing counterpart i+5
             assert [i + 5 for i in sealed_part] == growing_part, (
-                f"{expr}: sealed/growing pattern is not mirrored: "
-                f"sealed={sealed_part} growing={growing_part}"
+                f"{expr}: sealed/growing pattern is not mirrored: sealed={sealed_part} growing={growing_part}"
             )
 
     # ---- 9.15 After delete: deleted matching rows disappear ----
@@ -4049,49 +4373,46 @@ class TestMilvusClientStructArrayIndexAccess(TestMilvusClientV2Base):
         collection_name = cf.gen_unique_str(f"{prefix}_idx_delete")
 
         # Spread across sealed (0..4) and growing (5..9) using split helper
-        sealed_rows = [
-            self._make_row(i, [{"int_val": v}])
-            for i, v in enumerate([10, 20, 30, 40, 50])
-        ]
-        growing_rows = [
-            self._make_row(i + 5, [{"int_val": v}])
-            for i, v in enumerate([10, 20, 30, 40, 50])
-        ]
+        sealed_rows = [self._make_row(i, [{"int_val": v}]) for i, v in enumerate([10, 20, 30, 40, 50])]
+        growing_rows = [self._make_row(i + 5, [{"int_val": v}]) for i, v in enumerate([10, 20, 30, 40, 50])]
         self._setup_collection_split(client, collection_name, sealed_rows, growing_rows)
 
         # Baseline: structA[0][int_val] >= 30 -> [2,3,4,7,8,9]
         results, _ = self.query(
-            client, collection_name,
-            filter='id < 100 && structA[0][int_val] >= 30',
-            output_fields=["id"], limit=200,
+            client,
+            collection_name,
+            filter="id < 100 && structA[0][int_val] >= 30",
+            output_fields=["id"],
+            limit=200,
         )
         assert sorted({r["id"] for r in results}) == [2, 3, 4, 7, 8, 9]
 
         # Delete matching id 4 (sealed) and 7 (growing); also delete id 0 (non-matching)
         self.delete(client, collection_name, ids=[4, 7, 0])
         import time
+
         time.sleep(1)  # give delete time to propagate
 
         results, _ = self.query(
-            client, collection_name,
-            filter='id < 100 && structA[0][int_val] >= 30',
-            output_fields=["id"], limit=200,
+            client,
+            collection_name,
+            filter="id < 100 && structA[0][int_val] >= 30",
+            output_fields=["id"],
+            limit=200,
         )
         ids = sorted({r["id"] for r in results})
-        assert ids == [2, 3, 8, 9], (
-            f"After deleting [4,7,0], expected [2,3,8,9], got {ids}"
-        )
+        assert ids == [2, 3, 8, 9], f"After deleting [4,7,0], expected [2,3,8,9], got {ids}"
 
         # Sanity: id 0 (non-matching) really gone from any-id query as well
         results, _ = self.query(
-            client, collection_name,
-            filter='id < 100',
-            output_fields=["id"], limit=200,
+            client,
+            collection_name,
+            filter="id < 100",
+            output_fields=["id"],
+            limit=200,
         )
         all_ids = sorted({r["id"] for r in results})
-        assert 0 not in all_ids and 4 not in all_ids and 7 not in all_ids, (
-            f"Deleted IDs leaked: {all_ids}"
-        )
+        assert 0 not in all_ids and 4 not in all_ids and 7 not in all_ids, f"Deleted IDs leaked: {all_ids}"
 
     # ---- 9.16 After upsert: indexed sub-field changes are reflected ----
 
@@ -4111,21 +4432,17 @@ class TestMilvusClientStructArrayIndexAccess(TestMilvusClientV2Base):
         client = self._client()
         collection_name = cf.gen_unique_str(f"{prefix}_idx_upsert")
 
-        sealed_rows = [
-            self._make_row(i, [{"int_val": v}])
-            for i, v in enumerate([10, 20, 30, 40, 50])
-        ]
-        growing_rows = [
-            self._make_row(i + 5, [{"int_val": v}])
-            for i, v in enumerate([10, 20, 30, 40, 50])
-        ]
+        sealed_rows = [self._make_row(i, [{"int_val": v}]) for i, v in enumerate([10, 20, 30, 40, 50])]
+        growing_rows = [self._make_row(i + 5, [{"int_val": v}]) for i, v in enumerate([10, 20, 30, 40, 50])]
         self._setup_collection_split(client, collection_name, sealed_rows, growing_rows)
 
         # Baseline: structA[0][int_val] >= 30 -> [2,3,4,7,8,9]
         results, _ = self.query(
-            client, collection_name,
-            filter='id < 100 && structA[0][int_val] >= 30',
-            output_fields=["id"], limit=200,
+            client,
+            collection_name,
+            filter="id < 100 && structA[0][int_val] >= 30",
+            output_fields=["id"],
+            limit=200,
         )
         assert sorted({r["id"] for r in results}) == [2, 3, 4, 7, 8, 9]
 
@@ -4137,17 +4454,18 @@ class TestMilvusClientStructArrayIndexAccess(TestMilvusClientV2Base):
         ]
         self.upsert(client, collection_name, upserts)
         import time
+
         time.sleep(1)
 
         results, _ = self.query(
-            client, collection_name,
-            filter='id < 100 && structA[0][int_val] >= 30',
-            output_fields=["id"], limit=200,
+            client,
+            collection_name,
+            filter="id < 100 && structA[0][int_val] >= 30",
+            output_fields=["id"],
+            limit=200,
         )
         ids = sorted({r["id"] for r in results})
-        assert ids == [1, 2, 3, 4, 7, 8], (
-            f"After upserting id1->100, id9->5, expected [1,2,3,4,7,8], got {ids}"
-        )
+        assert ids == [1, 2, 3, 4, 7, 8], f"After upserting id1->100, id9->5, expected [1,2,3,4,7,8], got {ids}"
 
     # NOTE: search() filter coverage for index-access / array_contains /
     # array_length lives in test_milvus_client_struct_array_element_search.py
@@ -4193,15 +4511,18 @@ class TestMilvusClientStructArrayIndexAccess(TestMilvusClientV2Base):
         self._setup_collection(client, collection_name, rows)
 
         cases = [
-            ('id < 100 && array_contains(structA[int_val], 100)', [0, 4]),
-            ('id < 100 && array_contains(structA[int_val], 200)', [1, 3]),
-            ('id < 100 && array_contains(structA[int_val], 999)', [3]),
-            ('id < 100 && array_contains(structA[int_val], 12345)', []),
+            ("id < 100 && array_contains(structA[int_val], 100)", [0, 4]),
+            ("id < 100 && array_contains(structA[int_val], 200)", [1, 3]),
+            ("id < 100 && array_contains(structA[int_val], 999)", [3]),
+            ("id < 100 && array_contains(structA[int_val], 12345)", []),
         ]
         for expr, expected in cases:
             results, check = self.query(
-                client, collection_name,
-                filter=expr, output_fields=["id"], limit=200,
+                client,
+                collection_name,
+                filter=expr,
+                output_fields=["id"],
+                limit=200,
             )
             assert check, expr
             ids = sorted({r["id"] for r in results})
@@ -4240,19 +4561,18 @@ class TestMilvusClientStructArrayIndexAccess(TestMilvusClientV2Base):
         self._setup_collection(client, collection_name, rows)
 
         cases = [
-            ('id < 100 && array_contains_all(structA[str_val], ["Red"])',
-             [0, 1, 3, 4]),
-            ('id < 100 && array_contains_all(structA[str_val], ["Red", "Blue"])',
-             [1, 3]),
-            ('id < 100 && array_contains_all(structA[str_val], ["Red", "Blue", "Green"])',
-             [3]),
-            ('id < 100 && array_contains_all(structA[str_val], ["Yellow"])',
-             []),
+            ('id < 100 && array_contains_all(structA[str_val], ["Red"])', [0, 1, 3, 4]),
+            ('id < 100 && array_contains_all(structA[str_val], ["Red", "Blue"])', [1, 3]),
+            ('id < 100 && array_contains_all(structA[str_val], ["Red", "Blue", "Green"])', [3]),
+            ('id < 100 && array_contains_all(structA[str_val], ["Yellow"])', []),
         ]
         for expr, expected in cases:
             results, check = self.query(
-                client, collection_name,
-                filter=expr, output_fields=["id"], limit=200,
+                client,
+                collection_name,
+                filter=expr,
+                output_fields=["id"],
+                limit=200,
             )
             assert check, expr
             ids = sorted({r["id"] for r in results})
@@ -4285,19 +4605,19 @@ class TestMilvusClientStructArrayIndexAccess(TestMilvusClientV2Base):
 
         cases = [
             # Red OR Yellow -> rows containing Red
-            ('id < 100 && array_contains_any(structA[str_val], ["Red", "Yellow"])',
-             [0, 1, 3, 4]),
+            ('id < 100 && array_contains_any(structA[str_val], ["Red", "Yellow"])', [0, 1, 3, 4]),
             # Blue OR Green -> rows containing either
-            ('id < 100 && array_contains_any(structA[str_val], ["Blue", "Green"])',
-             [1, 2, 3, 4]),
+            ('id < 100 && array_contains_any(structA[str_val], ["Blue", "Green"])', [1, 2, 3, 4]),
             # only colors absent from controlled data
-            ('id < 100 && array_contains_any(structA[str_val], ["Yellow", "Magenta"])',
-             []),
+            ('id < 100 && array_contains_any(structA[str_val], ["Yellow", "Magenta"])', []),
         ]
         for expr, expected in cases:
             results, check = self.query(
-                client, collection_name,
-                filter=expr, output_fields=["id"], limit=200,
+                client,
+                collection_name,
+                filter=expr,
+                output_fields=["id"],
+                limit=200,
             )
             assert check, expr
             ids = sorted({r["id"] for r in results})
@@ -4319,33 +4639,32 @@ class TestMilvusClientStructArrayIndexAccess(TestMilvusClientV2Base):
         collection_name = cf.gen_unique_str(f"{prefix}_idx_arrlen_du")
 
         # length: sealed [1,2,3,4,5] (ids 0..4), growing [1,2,3,4,5] (ids 5..9)
-        sealed_rows = [
-            self._make_row(i, [{"int_val": j} for j in range(i + 1)])
-            for i in range(5)
-        ]
-        growing_rows = [
-            self._make_row(i + 5, [{"int_val": j} for j in range(i + 1)])
-            for i in range(5)
-        ]
+        sealed_rows = [self._make_row(i, [{"int_val": j} for j in range(i + 1)]) for i in range(5)]
+        growing_rows = [self._make_row(i + 5, [{"int_val": j} for j in range(i + 1)]) for i in range(5)]
         self._setup_collection_split(client, collection_name, sealed_rows, growing_rows)
 
         # Baseline: length>=3 -> [2,3,4,7,8,9]
         results, _ = self.query(
-            client, collection_name,
-            filter='id < 100 && array_length(structA[int_val]) >= 3',
-            output_fields=["id"], limit=200,
+            client,
+            collection_name,
+            filter="id < 100 && array_length(structA[int_val]) >= 3",
+            output_fields=["id"],
+            limit=200,
         )
         assert sorted({r["id"] for r in results}) == [2, 3, 4, 7, 8, 9]
 
         # Delete one matching row in each segment: 4 (sealed), 8 (growing)
         self.delete(client, collection_name, ids=[4, 8])
         import time
+
         time.sleep(1)
 
         results, _ = self.query(
-            client, collection_name,
-            filter='id < 100 && array_length(structA[int_val]) >= 3',
-            output_fields=["id"], limit=200,
+            client,
+            collection_name,
+            filter="id < 100 && array_length(structA[int_val]) >= 3",
+            output_fields=["id"],
+            limit=200,
         )
         assert sorted({r["id"] for r in results}) == [2, 3, 7, 9]
 
@@ -4353,17 +4672,17 @@ class TestMilvusClientStructArrayIndexAccess(TestMilvusClientV2Base):
         #         id 9 (length 5 -> 1, drops out)
         upserts = [
             self._make_row(0, [{"int_val": j} for j in range(5)]),  # length 5
-            self._make_row(9, [{"int_val": 0}]),                    # length 1
+            self._make_row(9, [{"int_val": 0}]),  # length 1
         ]
         self.upsert(client, collection_name, upserts)
         time.sleep(1)
 
         results, _ = self.query(
-            client, collection_name,
-            filter='id < 100 && array_length(structA[int_val]) >= 3',
-            output_fields=["id"], limit=200,
+            client,
+            collection_name,
+            filter="id < 100 && array_length(structA[int_val]) >= 3",
+            output_fields=["id"],
+            limit=200,
         )
         ids = sorted({r["id"] for r in results})
-        assert ids == [0, 2, 3, 7], (
-            f"After upserting id0->len5, id9->len1, expected [0,2,3,7], got {ids}"
-        )
+        assert ids == [0, 2, 3, 7], f"After upserting id0->len5, id9->len1, expected [0,2,3,7], got {ids}"

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_element_search.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_element_search.py
@@ -375,7 +375,6 @@ class TestMilvusClientStructArrayElementFilterSearch(TestMilvusClientV2Base):
 
     # ---- L0 tests ----
 
-    @pytest.mark.xfail(reason="flaky: element-level search on growing segment returns wrong element-to-row mapping")
     @pytest.mark.tags(CaseLabel.L0)
     def test_element_filter_search_basic_cosine(self):
         """
@@ -409,7 +408,6 @@ class TestMilvusClientStructArrayElementFilterSearch(TestMilvusClientV2Base):
         # Distance ordering
         _assert_distance_order(results, "COSINE")
 
-    @pytest.mark.xfail(reason="flaky: element-level search on growing segment returns wrong element-to-row mapping")
     @pytest.mark.tags(CaseLabel.L0)
     def test_element_filter_search_basic_l2(self):
         """
@@ -593,18 +591,17 @@ class TestMilvusClientStructArrayElementFilterSearch(TestMilvusClientV2Base):
         assert_result_ids_match(results, gt, recall_threshold=1.0)
 
     @pytest.mark.tags(CaseLabel.L0)
-    @pytest.mark.xfail(reason="pymilvus element_indices not yet re-exposed after PR #3240 refactoring")
     def test_element_filter_search_verify_in_struct_offset(self):
         """
-        target: verify element_indices corresponds to correct array subscript
-        method: insert known data, search with element_filter matching specific element
-        expected: element_indices matches the known position
+        target: verify the hit's `offset` maps to the correct element subscript inside structA
+        method: insert known data, search for a specific element via a unique str_val filter
+        expected: top-1 hit.id == target_row AND hit["offset"] == target_elem
+        note: `offset` is accessible via dict-style hit["offset"] (not attribute access).
         """
         client = self._client()
         collection_name = cf.gen_unique_str(f"{prefix}_ef_offset")
         data = self._create_collection_and_insert(client, collection_name, nb=1000, metric_type="COSINE")
 
-        # Search for elem_2 of row 50 specifically
         target_row = 50
         target_elem = 2
         query_vector = data[target_row]["structA"][target_elem]["embedding"]
@@ -620,12 +617,11 @@ class TestMilvusClientStructArrayElementFilterSearch(TestMilvusClientV2Base):
             output_fields=["id", "structA"],
         )
         assert check
-        assert len(results) > 0
-        # Check element_indices (offset) if exposed
-        top_hit = results[0]
-        assert top_hit["id"] == target_row
-        # Verify offset field exists
-        assert "offset" in top_hit or hasattr(top_hit, "offset"), "element_indices (offset) not exposed in pymilvus"
+        assert len(results[0]) > 0, "no hits returned for unique element filter"
+        top_hit = results[0][0]
+        assert top_hit["id"] == target_row, f"expected row {target_row}, got {top_hit['id']}"
+        assert "offset" in top_hit, "element offset not exposed on hit"
+        assert top_hit["offset"] == target_elem, f"expected element offset={target_elem}, got {top_hit['offset']}"
 
     # ---- L1 tests ----
 
@@ -889,7 +885,6 @@ class TestMilvusClientStructArrayElementFilterSearch(TestMilvusClientV2Base):
         assert results[0][0]["id"] == 0, f"Top-1 should be row 0 (self-vector), got {results[0][0]['id']}"
         _assert_distance_order(results, "COSINE")
 
-    @pytest.mark.xfail(reason="flaky: element-level search on sealed segment returns wrong element-to-row mapping")
     @pytest.mark.tags(CaseLabel.L1)
     def test_element_filter_search_sealed_segment(self):
         """
@@ -953,7 +948,6 @@ class TestMilvusClientStructArrayElementFilterSearch(TestMilvusClientV2Base):
             assert hit["structA"] is not None
         _assert_distance_order(results, "COSINE")
 
-    @pytest.mark.xfail(reason="FLAT index on struct array vector not supported for element_filter search")
     @pytest.mark.tags(CaseLabel.L1)
     def test_element_filter_search_brute_force(self):
         """
@@ -3633,54 +3627,6 @@ class TestMilvusClientStructArrayElementHybridSearch(TestMilvusClientV2Base):
 
     # ---- L2 tests ----
 
-    @pytest.mark.xfail(
-        reason="element_filter(COSINE) + EmbeddingList(MAX_SIM) require different index metrics on same field"
-    )
-    @pytest.mark.tags(CaseLabel.L2)
-    def test_hybrid_element_filter_and_max_sim(self):
-        """
-        target: element_filter search + MAX_SIM search hybrid
-        method: combine element-level search with MAX_SIM search
-        expected: hybrid results (requires server metric adaptation)
-        """
-        client = self._client()
-        collection_name = cf.gen_unique_str(f"{prefix}_hyb_maxsim")
-        data = self._setup_collection(client, collection_name, nb=500, struct_metric_type="MAX_SIM_COSINE")
-
-        # element_filter search (single vector)
-        req1 = AnnSearchRequest(
-            **{
-                "data": [data[0]["structA"][0]["embedding"]],
-                "anns_field": "structA[embedding]",
-                "param": {"metric_type": "COSINE"},
-                "limit": 10,
-                "expr": 'element_filter(structA, $[color] == "Red")',
-            }
-        )
-
-        # MAX_SIM search (EmbeddingList)
-        search_tensor = EmbeddingList()
-        search_tensor.add(_seed_vector(42))
-        req2 = AnnSearchRequest(
-            **{
-                "data": [search_tensor],
-                "anns_field": "structA[embedding]",
-                "param": {"metric_type": "MAX_SIM_COSINE"},
-                "limit": 10,
-            }
-        )
-
-        results, check = self.hybrid_search(
-            client,
-            collection_name,
-            [req1, req2],
-            ranker=RRFRanker(),
-            limit=10,
-            output_fields=["id"],
-        )
-        assert check
-        assert len(results) > 0
-
     @pytest.mark.tags(CaseLabel.L2)
     def test_hybrid_with_match_as_filter(self):
         """
@@ -4321,6 +4267,123 @@ class TestMilvusClientStructArrayElementSearchInvalid(TestMilvusClientV2Base):
             check_items=error,
         )
 
+    def _create_embedding_list_collection(self, client, collection_name, sealed_nb=3000, growing_nb=500):
+        """Build a collection whose struct vector field uses an embedding-list metric
+        (MAX_SIM_COSINE) so the anns_field behaves as embedding-list-level and the
+        proxy rejection paths for range search / iterator can be exercised.
+
+        Default: 3000 sealed + 500 growing = 3500 rows.
+        """
+        schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
+        schema.add_field("id", DataType.INT64, is_primary=True)
+        schema.add_field("doc_int", DataType.INT64)
+        schema.add_field("normal_vector", DataType.FLOAT_VECTOR, dim=default_dim)
+        ss = client.create_struct_field_schema()
+        ss.add_field("embedding", DataType.FLOAT_VECTOR, dim=default_dim)
+        ss.add_field("int_val", DataType.INT64)
+        schema.add_field(
+            "structA", DataType.ARRAY, element_type=DataType.STRUCT, struct_schema=ss, max_capacity=default_capacity
+        )
+
+        ip = client.prepare_index_params()
+        ip.add_index("normal_vector", index_type="HNSW", metric_type="COSINE", params=INDEX_PARAMS)
+        ip.add_index("structA[embedding]", index_type="HNSW", metric_type="MAX_SIM_COSINE", params=INDEX_PARAMS)
+        self.create_collection(client, collection_name, schema=schema, index_params=ip)
+
+        def _gen_row(i):
+            rng = random.Random(i)
+            num = rng.randint(3, 6)
+            return {
+                "id": i,
+                "doc_int": i,
+                "normal_vector": _seed_vector(i + 999999),
+                "structA": [{"embedding": _seed_vector(i * 100 + k), "int_val": i * 10 + k} for k in range(num)],
+            }
+
+        all_data = []
+        if sealed_nb > 0:
+            sealed = [_gen_row(i) for i in range(sealed_nb)]
+            for start in range(0, sealed_nb, insert_batch_size):
+                self.insert(client, collection_name, sealed[start : start + insert_batch_size])
+            self.flush(client, collection_name)
+            all_data.extend(sealed)
+        if growing_nb > 0:
+            growing = [_gen_row(sealed_nb + i) for i in range(growing_nb)]
+            for start in range(0, growing_nb, insert_batch_size):
+                self.insert(client, collection_name, growing[start : start + insert_batch_size])
+            all_data.extend(growing)
+        self.load_collection(client, collection_name)
+        return all_data
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_element_search_invalid_embedding_list_with_radius(self):
+        """
+        target: range search (radius) is rejected on embedding-list-level struct vector search
+        method: build MAX_SIM_COSINE index, search with EmbeddingList + radius
+        expected: server rejects with an error (proxy task_search.go:810-819 path)
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_inv_emblist_radius")
+        self._create_embedding_list_collection(client, collection_name)
+
+        tensor = EmbeddingList()
+        tensor.add(_seed_vector(7))
+        tensor.add(_seed_vector(8))
+        error = {ct.err_code: 65535, ct.err_msg: ""}
+        self.search(
+            client,
+            collection_name,
+            data=[tensor],
+            anns_field="structA[embedding]",
+            search_params={"metric_type": "MAX_SIM_COSINE", "params": {"radius": 0.1}},
+            limit=10,
+            output_fields=["id"],
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_element_search_invalid_embedding_list_with_search_iterator(self):
+        """
+        target: search_iterator is rejected on embedding-list-level struct vector search
+        method: build MAX_SIM_COSINE index, open search_iterator with EmbeddingList
+        expected: server rejects (proxy task_search.go:815-818 path)
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_inv_emblist_iter")
+        self._create_embedding_list_collection(client, collection_name)
+
+        tensor = EmbeddingList()
+        tensor.add(_seed_vector(3))
+        tensor.add(_seed_vector(4))
+        # iterator construction or first next() should surface the server-side rejection
+        try:
+            iterator, _ = self.search_iterator(
+                client,
+                collection_name,
+                data=[tensor],
+                batch_size=20,
+                anns_field="structA[embedding]",
+                search_params={"metric_type": "MAX_SIM_COSINE"},
+                limit=50,
+                output_fields=["id"],
+            )
+            if iterator is not None:
+                try:
+                    iterator.next()
+                except Exception as e:
+                    log.info(f"expected rejection at iterator.next(): {e}")
+                    return
+                finally:
+                    try:
+                        iterator.close()
+                    except Exception:
+                        pass
+            # if iterator creation silently returned None or didn't raise, fail loud
+            pytest.fail("expected server to reject search_iterator on embedding-list-level search")
+        except Exception as e:
+            log.info(f"expected rejection at iterator creation: {e}")
+
 
 class TestMilvusClientStructArrayElementSearchCRUD(TestMilvusClientV2Base):
     """Test CRUD operations with element-level features (5 cases)"""
@@ -4590,11 +4653,20 @@ class TestMilvusClientStructArrayElementSearchCRUD(TestMilvusClientV2Base):
             assert r["id"] >= 10000
 
 
-class TestMilvusClientStructArrayElementSearchIterator(TestMilvusClientV2Base):
-    """Test search iterator + element_filter (3 cases)"""
+class TestMilvusClientStructArrayElementRangeSearch(TestMilvusClientV2Base):
+    """
+    Range search on struct array element-level search (radius / range_filter).
+    Covered by PR #49182 on master (element-level only; embedding-list-level is rejected).
+    """
 
-    def _setup_collection(self, client, collection_name, nb=500):
-        """Helper to setup collection for iterator tests."""
+    def _setup_collection(
+        self, client, collection_name, sealed_nb=3000, growing_nb=500, metric_type="COSINE", elems_per_row=None
+    ):
+        """Create collection + insert `sealed_nb` rows (flushed → sealed) then `growing_nb`
+        rows (no flush → growing). Default totals 3500 rows (3000 sealed + 500 growing).
+
+        elems_per_row: if int, every row has exactly that many struct elements; None → random 3..8.
+        """
         schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
         schema.add_field(field_name="id", datatype=DataType.INT64, is_primary=True)
         schema.add_field(field_name="doc_int", datatype=DataType.INT64)
@@ -4623,86 +4695,505 @@ class TestMilvusClientStructArrayElementSearchIterator(TestMilvusClientV2Base):
         index_params.add_index(
             field_name="structA[embedding]",
             index_type="HNSW",
-            metric_type="COSINE",
+            metric_type=metric_type,
             params=INDEX_PARAMS,
         )
         self.create_collection(client, collection_name, schema=schema, index_params=index_params)
 
-        data = []
-        for i in range(nb):
+        def _gen_row(i):
             rng = random.Random(i)
-            num_elems = rng.randint(3, 8)
-            struct_array = []
-            for j in range(num_elems):
-                struct_array.append(
-                    {
-                        "embedding": _seed_vector(i * 1000 + j),
-                        "int_val": i * 100 + j,
-                        "color": COLORS[j % 3],
-                    }
-                )
-            data.append(
+            num_elems = elems_per_row if elems_per_row else rng.randint(3, 8)
+            struct_array = [
                 {
-                    "id": i,
-                    "doc_int": i,
-                    "normal_vector": _seed_vector(i + 999999),
-                    "structA": struct_array,
+                    "embedding": _seed_vector(i * 1000 + j),
+                    "int_val": i * 100 + j,
+                    "color": COLORS[j % 3],
                 }
-            )
-        self.insert(client, collection_name, data)
-        self.flush(client, collection_name)
+                for j in range(num_elems)
+            ]
+            return {
+                "id": i,
+                "doc_int": i,
+                "normal_vector": _seed_vector(i + 999999),
+                "structA": struct_array,
+            }
+
+        all_data = []
+        if sealed_nb > 0:
+            sealed = [_gen_row(i) for i in range(sealed_nb)]
+            for start in range(0, sealed_nb, insert_batch_size):
+                self.insert(client, collection_name, sealed[start : start + insert_batch_size])
+            self.flush(client, collection_name)
+            all_data.extend(sealed)
+        if growing_nb > 0:
+            growing = [_gen_row(sealed_nb + i) for i in range(growing_nb)]
+            for start in range(0, growing_nb, insert_batch_size):
+                self.insert(client, collection_name, growing[start : start + insert_batch_size])
+            all_data.extend(growing)
         self.load_collection(client, collection_name)
-        return data
+        return all_data
 
-    @pytest.mark.xfail(reason="search iterator not supported for vector array (embedding list) fields")
-    @pytest.mark.tags(CaseLabel.L1)
-    def test_search_iterator_with_element_filter(self):
+    def _pick_range(self, client, collection_name, query_vector, metric_type, filter_expr):
         """
-        target: search_iterator with element_filter
-        method: iterate through all results using search_iterator + element_filter
-        expected: all results collected across batches
+        Pick a [low, high] distance window by running a wider one-shot search
+        and taking the 30%/70% quantiles of the observed distances.
         """
-        client = self._client()
-        collection_name = cf.gen_unique_str(f"{prefix}_iter_ef")
-        data = self._setup_collection(client, collection_name, nb=500)
-
-        query_vector = data[0]["structA"][0]["embedding"]
-        iterator, _ = self.search_iterator(
+        res, check = self.search(
             client,
             collection_name,
             data=[query_vector],
-            batch_size=50,
+            anns_field="structA[embedding]",
+            search_params={"metric_type": metric_type},
+            filter=filter_expr,
+            limit=200,
+            output_fields=["id"],
+        )
+        assert check
+        distances = sorted(hit["distance"] for hit in res[0])
+        assert len(distances) >= 20, f"not enough hits ({len(distances)}) to pick a range window"
+        low = distances[int(len(distances) * 0.3)]
+        high = distances[int(len(distances) * 0.7)]
+        # For L2 (ascending), radius is upper bound (=high), range_filter is lower (=low).
+        # For COSINE/IP (descending), radius is lower bound (=low), range_filter is upper (=high).
+        if metric_type == "L2":
+            return low, high  # (range_filter, radius)
+        return low, high  # caller composes params based on metric
+
+    def _assert_range(self, results, metric_type, low, high):
+        """Assert every returned distance sits within [low, high] (with tolerance)."""
+        for hit in results[0]:
+            d = hit["distance"]
+            assert low - epsilon <= d <= high + epsilon, f"{metric_type} distance {d} not in window [{low}, {high}]"
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_range_search_cosine_radius_only(self):
+        """
+        target: COSINE range search with radius only (lower bound)
+        method: radius=low, no range_filter → expect all distances >= low
+        expected: every returned hit has distance >= radius
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_range_cos_radius")
+        data = self._setup_collection(client, collection_name, metric_type="COSINE")
+        query_vector = data[0]["structA"][0]["embedding"]
+        filter_expr = "element_filter(structA, $[int_val] >= 0)"
+        low, high = self._pick_range(client, collection_name, query_vector, "COSINE", filter_expr)
+
+        results, check = self.search(
+            client,
+            collection_name,
+            data=[query_vector],
+            anns_field="structA[embedding]",
+            search_params={"metric_type": "COSINE", "params": {"radius": low}},
+            filter=filter_expr,
+            limit=100,
+            output_fields=["id"],
+        )
+        assert check
+        assert len(results[0]) > 0, "COSINE radius-only range search returned 0 rows"
+        for hit in results[0]:
+            assert hit["distance"] >= low - epsilon, f"COSINE distance {hit['distance']} < radius {low}"
+        _assert_distance_order(results, "COSINE")
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_range_search_l2_radius_only(self):
+        """
+        target: L2 range search with radius only (upper bound)
+        method: radius=high, no range_filter → expect all distances <= high
+        expected: every returned hit has distance <= radius
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_range_l2_radius")
+        data = self._setup_collection(client, collection_name, metric_type="L2")
+        query_vector = data[0]["structA"][0]["embedding"]
+        filter_expr = "element_filter(structA, $[int_val] >= 0)"
+        low, high = self._pick_range(client, collection_name, query_vector, "L2", filter_expr)
+
+        results, check = self.search(
+            client,
+            collection_name,
+            data=[query_vector],
+            anns_field="structA[embedding]",
+            search_params={"metric_type": "L2", "params": {"radius": high}},
+            filter=filter_expr,
+            limit=100,
+            output_fields=["id"],
+        )
+        assert check
+        assert len(results[0]) > 0
+        for hit in results[0]:
+            assert hit["distance"] <= high + epsilon, f"L2 distance {hit['distance']} > radius {high}"
+        _assert_distance_order(results, "L2")
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_range_search_ip_radius_only(self):
+        """
+        target: IP range search with radius only (lower bound)
+        method: radius=low → all distances >= low
+        expected: every hit has distance >= radius
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_range_ip_radius")
+        data = self._setup_collection(client, collection_name, metric_type="IP")
+        query_vector = data[0]["structA"][0]["embedding"]
+        filter_expr = "element_filter(structA, $[int_val] >= 0)"
+        low, high = self._pick_range(client, collection_name, query_vector, "IP", filter_expr)
+
+        results, check = self.search(
+            client,
+            collection_name,
+            data=[query_vector],
+            anns_field="structA[embedding]",
+            search_params={"metric_type": "IP", "params": {"radius": low}},
+            filter=filter_expr,
+            limit=100,
+            output_fields=["id"],
+        )
+        assert check
+        assert len(results[0]) > 0
+        for hit in results[0]:
+            assert hit["distance"] >= low - epsilon, f"IP distance {hit['distance']} < radius {low}"
+        _assert_distance_order(results, "IP")
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_range_search_l2_radius_and_range_filter(self):
+        """
+        target: L2 range search with both radius (upper) and range_filter (lower)
+        method: radius > range_filter; expect range_filter <= d <= radius
+        expected: every hit is inside [range_filter, radius]; result count < topK
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_range_l2_both")
+        data = self._setup_collection(client, collection_name, metric_type="L2")
+        query_vector = data[0]["structA"][0]["embedding"]
+        filter_expr = "element_filter(structA, $[int_val] >= 0)"
+        low, high = self._pick_range(client, collection_name, query_vector, "L2", filter_expr)
+
+        limit = 200
+        results, check = self.search(
+            client,
+            collection_name,
+            data=[query_vector],
+            anns_field="structA[embedding]",
+            search_params={"metric_type": "L2", "params": {"radius": high, "range_filter": low}},
+            filter=filter_expr,
+            limit=limit,
+            output_fields=["id"],
+        )
+        assert check
+        assert 0 < len(results[0]) < limit, f"expect a bounded non-empty result set, got {len(results[0])}"
+        for hit in results[0]:
+            assert low - epsilon <= hit["distance"] <= high + epsilon, (
+                f"L2 distance {hit['distance']} outside [{low}, {high}]"
+            )
+        _assert_distance_order(results, "L2")
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_range_search_cosine_radius_and_range_filter(self):
+        """
+        target: COSINE range search with both radius (lower) and range_filter (upper)
+        method: range_filter > radius; expect radius <= d <= range_filter
+        expected: every hit is inside [radius, range_filter]; result count < topK
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_range_cos_both")
+        data = self._setup_collection(client, collection_name, metric_type="COSINE")
+        query_vector = data[0]["structA"][0]["embedding"]
+        filter_expr = "element_filter(structA, $[int_val] >= 0)"
+        low, high = self._pick_range(client, collection_name, query_vector, "COSINE", filter_expr)
+
+        limit = 200
+        results, check = self.search(
+            client,
+            collection_name,
+            data=[query_vector],
+            anns_field="structA[embedding]",
+            search_params={"metric_type": "COSINE", "params": {"radius": low, "range_filter": high}},
+            filter=filter_expr,
+            limit=limit,
+            output_fields=["id"],
+        )
+        assert check
+        assert 0 < len(results[0]) < limit
+        for hit in results[0]:
+            assert low - epsilon <= hit["distance"] <= high + epsilon, (
+                f"COSINE distance {hit['distance']} outside [{low}, {high}]"
+            )
+        _assert_distance_order(results, "COSINE")
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_range_search_with_element_filter(self):
+        """
+        target: range search combined with a tighter element_filter scalar condition
+        method: radius window + element_filter(structA, $[int_val] > 1000)
+        expected: every hit has distance inside window AND some element matching the scalar filter
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_range_with_ef")
+        data = self._setup_collection(client, collection_name, metric_type="COSINE")
+        query_vector = data[0]["structA"][0]["embedding"]
+
+        # broader window (10%/90%) since tighter scalar filter shrinks the candidate pool
+        res, _ = self.search(
+            client,
+            collection_name,
+            data=[query_vector],
             anns_field="structA[embedding]",
             search_params={"metric_type": "COSINE"},
             filter="element_filter(structA, $[int_val] >= 0)",
             limit=200,
             output_fields=["id"],
         )
-        all_results = []
-        if iterator:
-            while True:
-                batch = iterator.next()
-                if not batch:
-                    break
-                all_results.extend(batch)
-            iterator.close()
-        assert len(all_results) > 0
-        log.info(f"Iterator collected {len(all_results)} results")
+        distances = sorted(hit["distance"] for hit in res[0])
+        low = distances[int(len(distances) * 0.1)]
+        high = distances[int(len(distances) * 0.9)]
 
-    @pytest.mark.xfail(reason="search iterator not supported for vector array (embedding list) fields")
-    @pytest.mark.tags(CaseLabel.L2)
-    @pytest.mark.parametrize("batch_size", [10, 50, 100])
-    def test_search_iterator_element_filter_batch_size(self, batch_size):
+        tight_filter = "element_filter(structA, $[int_val] > 1000 && $[int_val] < 40000)"
+        results, check = self.search(
+            client,
+            collection_name,
+            data=[query_vector],
+            anns_field="structA[embedding]",
+            search_params={"metric_type": "COSINE", "params": {"radius": low, "range_filter": high}},
+            filter=tight_filter,
+            limit=100,
+            output_fields=["id", "structA"],
+        )
+        assert check
+        for hit in results[0]:
+            assert low - epsilon <= hit["distance"] <= high + epsilon, (
+                f"COSINE distance {hit['distance']} outside [{low}, {high}]"
+            )
+            assert any(1000 < e["int_val"] < 40000 for e in hit["structA"]), (
+                f"row {hit['id']} has no element matching scalar filter"
+            )
+        _assert_distance_order(results, "COSINE")
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_range_search_growing_segment(self):
         """
-        target: search_iterator with different batch sizes
-        method: parametrize batch_size=10,50,100
-        expected: all batch sizes work correctly
+        target: range search on growing-only segments (no flush)
+        method: insert 3500 rows without flush; run COSINE range search
+        expected: all returned distances inside the window
         """
         client = self._client()
-        collection_name = cf.gen_unique_str(f"{prefix}_iter_bs_{batch_size}")
-        data = self._setup_collection(client, collection_name, nb=500)
+        collection_name = cf.gen_unique_str(f"{prefix}_range_growing")
+        data = self._setup_collection(client, collection_name, sealed_nb=0, growing_nb=3500, metric_type="COSINE")
+
+        qv = data[0]["structA"][0]["embedding"]
+        filter_expr = "element_filter(structA, $[int_val] >= 0)"
+        low, high = self._pick_range(client, collection_name, qv, "COSINE", filter_expr)
+        results, check = self.search(
+            client,
+            collection_name,
+            data=[qv],
+            anns_field="structA[embedding]",
+            search_params={"metric_type": "COSINE", "params": {"radius": low, "range_filter": high}},
+            filter=filter_expr,
+            limit=200,
+            output_fields=["id"],
+        )
+        assert check
+        for hit in results[0]:
+            assert low - epsilon <= hit["distance"] <= high + epsilon
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_range_search_mixed_segments(self):
+        """
+        target: range search on mixed sealed + growing segments with baseline data size
+        method: 3000 sealed + 500 growing = 3500 rows; pick range window, run search
+        expected: hits from both segments, all inside the distance window
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_range_mixed")
+        data = self._setup_collection(client, collection_name, metric_type="COSINE")
+
+        qv = data[0]["structA"][0]["embedding"]
+        filter_expr = "element_filter(structA, $[int_val] >= 0)"
+        low, high = self._pick_range(client, collection_name, qv, "COSINE", filter_expr)
+        results, check = self.search(
+            client,
+            collection_name,
+            data=[qv],
+            anns_field="structA[embedding]",
+            search_params={"metric_type": "COSINE", "params": {"radius": low, "range_filter": high}},
+            filter=filter_expr,
+            limit=400,
+            output_fields=["id"],
+        )
+        assert check
+        ids = [h["id"] for h in results[0]]
+        for hit in results[0]:
+            assert low - epsilon <= hit["distance"] <= high + epsilon
+        # recall hits from both segments (may be weaker for growing due to serial scan)
+        has_sealed = any(i < 3000 for i in ids)
+        has_growing = any(i >= 3000 for i in ids)
+        assert has_sealed or has_growing, "no hits from either segment"
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_range_search_nq_multiple(self):
+        """
+        target: range search with multiple query vectors (nq=3)
+        method: 3 queries, each should return its own distance window
+        expected: every result list respects the window
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_range_nq")
+        data = self._setup_collection(client, collection_name, metric_type="COSINE")
+
+        query_vectors = [
+            data[0]["structA"][0]["embedding"],
+            data[1500]["structA"][0]["embedding"],
+            data[3200]["structA"][0]["embedding"],  # in the growing segment (>= 3000)
+        ]
+        filter_expr = "element_filter(structA, $[int_val] >= 0)"
+        low, high = self._pick_range(client, collection_name, query_vectors[0], "COSINE", filter_expr)
+
+        results, check = self.search(
+            client,
+            collection_name,
+            data=query_vectors,
+            anns_field="structA[embedding]",
+            search_params={"metric_type": "COSINE", "params": {"radius": low, "range_filter": high}},
+            filter=filter_expr,
+            limit=100,
+            output_fields=["id"],
+        )
+        assert check
+        assert len(results) == 3, f"expect 3 result lists for nq=3, got {len(results)}"
+        for q_idx, hits in enumerate(results):
+            for hit in hits:
+                assert low - epsilon <= hit["distance"] <= high + epsilon, (
+                    f"query {q_idx}: distance {hit['distance']} outside [{low}, {high}]"
+                )
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_range_search_l2_invalid_radius_less_than_range_filter(self):
+        """
+        target: for L2, radius must be > range_filter (radius is upper bound)
+        method: set radius < range_filter
+        expected: server rejects with an error
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_range_l2_invalid")
+        data = self._setup_collection(client, collection_name, metric_type="L2")
+        qv = data[0]["structA"][0]["embedding"]
+        error = {ct.err_code: 65535, ct.err_msg: ""}
+        self.search(
+            client,
+            collection_name,
+            data=[qv],
+            anns_field="structA[embedding]",
+            search_params={"metric_type": "L2", "params": {"radius": 10, "range_filter": 20}},
+            filter="element_filter(structA, $[int_val] >= 0)",
+            limit=10,
+            output_fields=["id"],
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
+
+
+class TestMilvusClientStructArrayElementSearchIterator(TestMilvusClientV2Base):
+    """Test search iterator + element_filter (3 cases)"""
+
+    def _setup_collection(
+        self, client, collection_name, sealed_nb=3000, growing_nb=500, metric_type="COSINE", elems_per_row=None
+    ):
+        """Helper to setup collection for iterator tests.
+
+        Inserts `sealed_nb` rows then flushes (sealed segments) and `growing_nb` more rows
+        without flushing (growing segments). Default totals 3500 rows (3000 sealed + 500 growing).
+
+        elems_per_row: if int, every row has exactly that many struct elements;
+                       if None, each row has random 3..8 elements (default).
+        """
+        schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
+        schema.add_field(field_name="id", datatype=DataType.INT64, is_primary=True)
+        schema.add_field(field_name="doc_int", datatype=DataType.INT64)
+        schema.add_field(field_name="normal_vector", datatype=DataType.FLOAT_VECTOR, dim=default_dim)
+
+        struct_schema = client.create_struct_field_schema()
+        struct_schema.add_field("embedding", DataType.FLOAT_VECTOR, dim=default_dim)
+        struct_schema.add_field("int_val", DataType.INT64)
+        struct_schema.add_field("color", DataType.VARCHAR, max_length=128)
+
+        schema.add_field(
+            "structA",
+            datatype=DataType.ARRAY,
+            element_type=DataType.STRUCT,
+            struct_schema=struct_schema,
+            max_capacity=default_capacity,
+        )
+
+        index_params = client.prepare_index_params()
+        index_params.add_index(
+            field_name="normal_vector",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
+        )
+        index_params.add_index(
+            field_name="structA[embedding]",
+            index_type="HNSW",
+            metric_type=metric_type,
+            params=INDEX_PARAMS,
+        )
+        self.create_collection(client, collection_name, schema=schema, index_params=index_params)
+
+        def _gen_row(i):
+            rng = random.Random(i)
+            num_elems = elems_per_row if elems_per_row else rng.randint(3, 8)
+            sa = [
+                {
+                    "embedding": _seed_vector(i * 1000 + j),
+                    "int_val": i * 100 + j,
+                    "color": COLORS[j % 3],
+                }
+                for j in range(num_elems)
+            ]
+            return {
+                "id": i,
+                "doc_int": i,
+                "normal_vector": _seed_vector(i + 999999),
+                "structA": sa,
+            }
+
+        all_data = []
+        if sealed_nb > 0:
+            sealed = [_gen_row(i) for i in range(sealed_nb)]
+            for start in range(0, sealed_nb, insert_batch_size):
+                self.insert(client, collection_name, sealed[start : start + insert_batch_size])
+            self.flush(client, collection_name)
+            all_data.extend(sealed)
+        if growing_nb > 0:
+            growing = [_gen_row(sealed_nb + i) for i in range(growing_nb)]
+            for start in range(0, growing_nb, insert_batch_size):
+                self.insert(client, collection_name, growing[start : start + insert_batch_size])
+            all_data.extend(growing)
+        self.load_collection(client, collection_name)
+        return all_data
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_search_iterator_with_element_filter(self):
+        """
+        target: search_iterator with element_filter on struct array element-level search (PR #49182)
+        method: iterate through all results using search_iterator + element_filter
+        expected:
+          - iterator returns exactly `limit` results across batches
+          - (row_id, element_offset) pairs are unique — the iterator's natural unit is a single
+            matched element, so the same row_id may repeat with different offsets, but never
+            the same (row_id, offset) twice
+          - distances are monotonic (COSINE: descending)
+          - every hit satisfies the element_filter predicate
+          - iterator's unique row ids overlap substantially with one-shot search ids
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_iter_ef")
+        data = self._setup_collection(client, collection_name)  # 2500 sealed + 500 growing
 
         query_vector = data[0]["structA"][0]["embedding"]
+        limit = 200
+        batch_size = 50
         iterator, _ = self.search_iterator(
             client,
             collection_name,
@@ -4711,137 +5202,661 @@ class TestMilvusClientStructArrayElementSearchIterator(TestMilvusClientV2Base):
             anns_field="structA[embedding]",
             search_params={"metric_type": "COSINE"},
             filter="element_filter(structA, $[int_val] >= 0)",
-            limit=200,
+            limit=limit,
+            output_fields=["id", "structA"],
+        )
+        assert iterator is not None, "search_iterator should return a valid iterator for element-level search"
+
+        all_results = []
+        batch_count = 0
+        while True:
+            batch = iterator.next()
+            if not batch:
+                break
+            all_results.extend(batch)
+            batch_count += 1
+        iterator.close()
+
+        # 1. total count == limit
+        assert len(all_results) == limit, f"expect {limit} results across batches, got {len(all_results)}"
+        # 2. (id, offset) pairs are unique — element-level iterator emits one hit per matched element
+        pairs = [(h["id"], h["offset"]) for h in all_results]
+        assert len(pairs) == len(set(pairs)), (
+            f"duplicated (id, offset) pairs across batches: "
+            f"{len(pairs) - len(set(pairs))} duplicates out of {len(pairs)}"
+        )
+        # 3. distance monotonic (COSINE descending)
+        distances = [hit["distance"] for hit in all_results]
+        for k in range(len(distances) - 1):
+            assert distances[k] >= distances[k + 1] - epsilon, (
+                f"COSINE distances not descending at {k}: {distances[k]} < {distances[k + 1]}"
+            )
+        # 4. element_filter correctness
+        for hit in all_results:
+            assert any(e["int_val"] >= 0 for e in hit["structA"]), f"row {hit['id']} has no element with int_val >= 0"
+        # 5. iterator's unique row ids vs one-shot search (wider one-shot to account for HNSW recall)
+        oneshot, check = self.search(
+            client,
+            collection_name,
+            data=[query_vector],
+            anns_field="structA[embedding]",
+            search_params={"metric_type": "COSINE"},
+            filter="element_filter(structA, $[int_val] >= 0)",
+            limit=500,
             output_fields=["id"],
         )
-        all_results = []
-        if iterator:
-            while True:
-                batch = iterator.next()
-                if not batch:
-                    break
-                all_results.extend(batch)
-            iterator.close()
-        assert len(all_results) > 0
+        assert check
+        oneshot_ids = {hit["id"] for hit in oneshot[0]}
+        iter_unique_ids = {h["id"] for h in all_results}
+        overlap = len(iter_unique_ids & oneshot_ids) / max(len(iter_unique_ids), 1)
+        assert overlap >= 0.9, (
+            f"iterator unique ids diverge from one-shot search: overlap={overlap:.2f} "
+            f"iter_unique={len(iter_unique_ids)}, oneshot={len(oneshot_ids)}"
+        )
+        log.info(
+            f"iterator collected {len(all_results)} hits in {batch_count} batches, "
+            f"unique ids={len(iter_unique_ids)} (duplicates reflect element-level semantics)"
+        )
 
-    @pytest.mark.xfail(reason="search iterator not supported for vector array (embedding list) fields")
     @pytest.mark.tags(CaseLabel.L2)
-    def test_search_iterator_mixed_segments(self):
+    @pytest.mark.parametrize("batch_size", [10, 50, 100])
+    def test_search_iterator_element_filter_batch_size(self, batch_size):
         """
-        target: search_iterator on mixed sealed + growing segments
-        method: insert + flush + insert more, then iterate with element_filter
-        expected: results from both segments
+        target: search_iterator with different batch sizes on element-level search
+        method: parametrize batch_size=10,50,100
+        expected:
+          - total count exactly == limit
+          - each batch size <= batch_size (SearchIteratorV2 may return fewer due to internal
+            dedup / fetch rounds)
+          - distances monotonic (COSINE descending)
+        note: element-level iterator may duplicate row ids; this is element-level semantics.
         """
         client = self._client()
-        collection_name = cf.gen_unique_str(f"{prefix}_iter_mixed")
+        collection_name = cf.gen_unique_str(f"{prefix}_iter_bs_{batch_size}")
+        data = self._setup_collection(client, collection_name)  # 2500 sealed + 500 growing
 
-        schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
-        schema.add_field(field_name="id", datatype=DataType.INT64, is_primary=True)
-        schema.add_field(field_name="doc_int", datatype=DataType.INT64)
-        schema.add_field(field_name="normal_vector", datatype=DataType.FLOAT_VECTOR, dim=default_dim)
-
-        struct_schema = client.create_struct_field_schema()
-        struct_schema.add_field("embedding", DataType.FLOAT_VECTOR, dim=default_dim)
-        struct_schema.add_field("int_val", DataType.INT64)
-        struct_schema.add_field("color", DataType.VARCHAR, max_length=128)
-
-        schema.add_field(
-            "structA",
-            datatype=DataType.ARRAY,
-            element_type=DataType.STRUCT,
-            struct_schema=struct_schema,
-            max_capacity=default_capacity,
-        )
-
-        index_params = client.prepare_index_params()
-        index_params.add_index(
-            field_name="normal_vector",
-            index_type="HNSW",
-            metric_type="COSINE",
-            params=INDEX_PARAMS,
-        )
-        index_params.add_index(
-            field_name="structA[embedding]",
-            index_type="HNSW",
-            metric_type="COSINE",
-            params=INDEX_PARAMS,
-        )
-        self.create_collection(client, collection_name, schema=schema, index_params=index_params)
-
-        # Sealed segment
-        sealed_data = []
-        for i in range(300):
-            random.Random(i)
-            struct_array = [
-                {
-                    "embedding": _seed_vector(i * 1000),
-                    "int_val": i * 100,
-                    "color": "Red",
-                }
-            ]
-            sealed_data.append(
-                {
-                    "id": i,
-                    "doc_int": i,
-                    "normal_vector": _seed_vector(i + 999999),
-                    "structA": struct_array,
-                }
-            )
-        self.insert(client, collection_name, sealed_data)
-        self.flush(client, collection_name)
-
-        # Growing segment
-        growing_data = []
-        for i in range(300, 500):
-            struct_array = [
-                {
-                    "embedding": _seed_vector(i * 1000),
-                    "int_val": i * 100,
-                    "color": "Blue",
-                }
-            ]
-            growing_data.append(
-                {
-                    "id": i,
-                    "doc_int": i,
-                    "normal_vector": _seed_vector(i + 999999),
-                    "structA": struct_array,
-                }
-            )
-        self.insert(client, collection_name, growing_data)
-        self.load_collection(client, collection_name)
-
-        query_vector = sealed_data[0]["structA"][0]["embedding"]
+        query_vector = data[0]["structA"][0]["embedding"]
+        limit = 200
         iterator, _ = self.search_iterator(
             client,
             collection_name,
             data=[query_vector],
-            batch_size=50,
+            batch_size=batch_size,
             anns_field="structA[embedding]",
             search_params={"metric_type": "COSINE"},
             filter="element_filter(structA, $[int_val] >= 0)",
-            limit=400,
+            limit=limit,
             output_fields=["id"],
         )
-        all_ids = set()
-        if iterator:
-            while True:
-                batch = iterator.next()
-                if not batch:
-                    break
-                for r in batch:
-                    all_ids.add(r["id"])
-            iterator.close()
-        has_sealed = any(i < 300 for i in all_ids)
-        has_growing = any(i >= 300 for i in all_ids)
-        assert has_sealed and has_growing, "Should have results from both segments"
+        assert iterator is not None
+
+        batches = []
+        while True:
+            batch = iterator.next()
+            if not batch:
+                break
+            batches.append(batch)
+        iterator.close()
+
+        all_results = [hit for batch in batches for hit in batch]
+        # 1. total count == limit
+        assert len(all_results) == limit, f"expect total={limit}, got {len(all_results)}"
+        # 2. every batch <= batch_size (V2 may return fewer after internal dedup)
+        for k, batch in enumerate(batches):
+            assert len(batch) <= batch_size, f"batch {k}: size={len(batch)} exceeds batch_size={batch_size}"
+        # 3. distance monotonic across concatenated batches (COSINE descending)
+        distances = [hit["distance"] for hit in all_results]
+        for k in range(len(distances) - 1):
+            assert distances[k] >= distances[k + 1] - epsilon, (
+                f"distances not descending at {k}: {distances[k]} vs {distances[k + 1]}"
+            )
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_search_iterator_mixed_segments(self):
+        """
+        target: search_iterator on mixed sealed + growing segments (element-level search)
+        method: insert 3000 rows + flush (sealed), insert another 500 (growing, no flush),
+                every row has exactly 1 struct element so row ids are unique;
+                iterate with element_filter covering all rows
+        expected:
+          - iterator returns rows from BOTH segments
+          - ids unique across batches
+          - every hit satisfies element_filter
+          - distances monotonic (COSINE descending)
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_iter_mixed")
+        data = self._setup_collection(client, collection_name, elems_per_row=1)  # 3000+500
+
+        query_vector = data[0]["structA"][0]["embedding"]
+        limit = 1000
+        iterator, _ = self.search_iterator(
+            client,
+            collection_name,
+            data=[query_vector],
+            batch_size=100,
+            anns_field="structA[embedding]",
+            search_params={"metric_type": "COSINE"},
+            filter="element_filter(structA, $[int_val] >= 0)",
+            limit=limit,
+            output_fields=["id", "structA"],
+        )
+        assert iterator is not None
+        all_hits = []
+        while True:
+            batch = iterator.next()
+            if not batch:
+                break
+            all_hits.extend(batch)
+        iterator.close()
+
+        all_ids = [h["id"] for h in all_hits]
+        # 1. total count == limit (3500 rows > limit, every row has 1 element)
+        assert len(all_hits) == limit, f"expect {limit} results, got {len(all_hits)}"
+        # 2. ids unique (every row has exactly 1 struct element, no element-level duplication)
+        assert len(all_ids) == len(set(all_ids)), "duplicated ids despite single-element rows"
+        # 3. hits come from BOTH segments
+        has_sealed = any(i < 3000 for i in all_ids)
+        has_growing = any(i >= 3000 for i in all_ids)
+        assert has_sealed and has_growing, "iterator should return results from both sealed and growing segments"
+        # 4. distance monotonic (COSINE descending)
+        distances = [h["distance"] for h in all_hits]
+        for k in range(len(distances) - 1):
+            assert distances[k] >= distances[k + 1] - epsilon, (
+                f"distances not descending at {k}: {distances[k]} vs {distances[k + 1]}"
+            )
+        # 5. element_filter correctness
+        for hit in all_hits:
+            assert any(e["int_val"] >= 0 for e in hit["structA"]), f"row {hit['id']} violates element_filter"
+
+    @pytest.mark.tags(CaseLabel.L1)
+    @pytest.mark.parametrize("metric_type", ["L2", "IP"])
+    def test_search_iterator_element_filter_non_cosine(self, metric_type):
+        """
+        target: search_iterator on element-level with L2/IP metrics
+        method: build index with metric, iterate with element_filter
+        expected: iterator works, distances monotonic in the metric's direction
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_iter_{metric_type.lower()}")
+        data = self._setup_collection(client, collection_name, metric_type=metric_type)
+
+        qv = data[0]["structA"][0]["embedding"]
+        limit = 100
+        iterator, _ = self.search_iterator(
+            client,
+            collection_name,
+            data=[qv],
+            batch_size=30,
+            anns_field="structA[embedding]",
+            search_params={"metric_type": metric_type},
+            filter="element_filter(structA, $[int_val] >= 0)",
+            limit=limit,
+            output_fields=["id", "structA"],
+        )
+        assert iterator is not None
+        all_hits = []
+        while True:
+            batch = iterator.next()
+            if not batch:
+                break
+            all_hits.extend(batch)
+        iterator.close()
+        assert len(all_hits) == limit
+        distances = [h["distance"] for h in all_hits]
+        if metric_type == "L2":
+            for k in range(len(distances) - 1):
+                assert distances[k] <= distances[k + 1] + epsilon, (
+                    f"L2 distances not ascending at {k}: {distances[k]} vs {distances[k + 1]}"
+                )
+        else:  # IP descending
+            for k in range(len(distances) - 1):
+                assert distances[k] >= distances[k + 1] - epsilon, (
+                    f"IP distances not descending at {k}: {distances[k]} vs {distances[k + 1]}"
+                )
+        for hit in all_hits:
+            assert any(e["int_val"] >= 0 for e in hit["structA"])
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_search_iterator_empty_result(self):
+        """
+        target: search_iterator with an element_filter that matches nothing
+        method: filter `int_val > 10_000_000` never holds in generated data
+        expected: iterator returns 0 hits across 0 batches and closes cleanly
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_iter_empty")
+        data = self._setup_collection(client, collection_name)  # 2500 sealed + 500 growing
+        qv = data[0]["structA"][0]["embedding"]
+        iterator, _ = self.search_iterator(
+            client,
+            collection_name,
+            data=[qv],
+            batch_size=50,
+            anns_field="structA[embedding]",
+            search_params={"metric_type": "COSINE"},
+            filter="element_filter(structA, $[int_val] > 10000000)",
+            limit=100,
+            output_fields=["id"],
+        )
+        assert iterator is not None
+        all_hits = []
+        while True:
+            batch = iterator.next()
+            if not batch:
+                break
+            all_hits.extend(batch)
+        iterator.close()
+        assert len(all_hits) == 0, f"expected 0 hits for impossible filter, got {len(all_hits)}"
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_search_iterator_no_duplicate_ids_single_element(self):
+        """
+        target: confirm no row-id duplication when every row has exactly 1 struct element
+        method: each row has a single struct element → element-level ≡ row-level
+        expected: iterator returns unique ids across batches
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_iter_unique_1elem")
+        # 3500 rows (3000 sealed + 500 growing), 1 element each
+        data = self._setup_collection(client, collection_name, elems_per_row=1)
+        qv = data[0]["structA"][0]["embedding"]
+        limit = 1000
+        iterator, _ = self.search_iterator(
+            client,
+            collection_name,
+            data=[qv],
+            batch_size=100,
+            anns_field="structA[embedding]",
+            search_params={"metric_type": "COSINE"},
+            filter="element_filter(structA, $[int_val] >= 0)",
+            limit=limit,
+            output_fields=["id"],
+        )
+        assert iterator is not None
+        ids = []
+        while True:
+            batch = iterator.next()
+            if not batch:
+                break
+            for hit in batch:
+                ids.append(hit["id"])
+        iterator.close()
+        assert len(ids) == min(limit, 3500)
+        assert len(ids) == len(set(ids)), "duplicated row ids despite single-element rows"
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_search_iterator_limit_larger_than_available(self):
+        """
+        target: iterator with limit greater than the number of matching rows
+        method: collection has 3500 rows × 1 element each; request limit=10000 (> total);
+                iterator should emit at most 3500 unique rows then terminate
+        expected: iterator stops cleanly; unique id count <= 3500
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_iter_overlimit")
+        data = self._setup_collection(client, collection_name, elems_per_row=1)  # 3500 rows
+        qv = data[0]["structA"][0]["embedding"]
+        iterator, _ = self.search_iterator(
+            client,
+            collection_name,
+            data=[qv],
+            batch_size=200,
+            anns_field="structA[embedding]",
+            search_params={"metric_type": "COSINE"},
+            filter="element_filter(structA, $[int_val] >= 0)",
+            limit=10000,
+            output_fields=["id"],
+        )
+        assert iterator is not None
+        hits = []
+        while True:
+            batch = iterator.next()
+            if not batch:
+                break
+            hits.extend(batch)
+        iterator.close()
+        ids = {h["id"] for h in hits}
+        assert len(ids) <= 3500, f"unique rows {len(ids)} exceeds actual data size 3500"
+        assert len(ids) > 0
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_search_iterator_with_range_search(self):
+        """
+        target: search_iterator combined with range search (radius/range_filter)
+        method: build COSINE index; pick a distance window from a wider one-shot search;
+                iterate with radius+range_filter set
+        expected: every hit across batches sits within the distance window;
+                  iterator terminates when no more candidates qualify
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_iter_range")
+        data = self._setup_collection(client, collection_name)  # 2500 sealed + 500 growing
+        qv = data[0]["structA"][0]["embedding"]
+        filter_expr = "element_filter(structA, $[int_val] >= 0)"
+
+        # pick [low, high] from a one-shot sample
+        res, check = self.search(
+            client,
+            collection_name,
+            data=[qv],
+            anns_field="structA[embedding]",
+            search_params={"metric_type": "COSINE"},
+            filter=filter_expr,
+            limit=200,
+            output_fields=["id"],
+        )
+        assert check
+        distances = sorted(h["distance"] for h in res[0])
+        low = distances[int(len(distances) * 0.3)]
+        high = distances[int(len(distances) * 0.7)]
+
+        iterator, _ = self.search_iterator(
+            client,
+            collection_name,
+            data=[qv],
+            batch_size=30,
+            anns_field="structA[embedding]",
+            search_params={"metric_type": "COSINE", "params": {"radius": low, "range_filter": high}},
+            filter=filter_expr,
+            limit=200,
+            output_fields=["id"],
+        )
+        assert iterator is not None
+        all_hits = []
+        while True:
+            batch = iterator.next()
+            if not batch:
+                break
+            all_hits.extend(batch)
+        iterator.close()
+        assert len(all_hits) > 0, "iterator+range should return at least some hits within the window"
+        for hit in all_hits:
+            assert low - epsilon <= hit["distance"] <= high + epsilon, (
+                f"iterator+range hit distance {hit['distance']} outside [{low}, {high}]"
+            )
+        dists = [h["distance"] for h in all_hits]
+        for k in range(len(dists) - 1):
+            assert dists[k] >= dists[k + 1] - epsilon, f"iterator distances not descending at {k}"
+
+
+class TestMilvusClientStructArrayElementQueryIterator(TestMilvusClientV2Base):
+    """
+    Query iterator + element_filter / MATCH family on struct array sub-fields.
+    Unlike search_iterator, query iterates over filtered rows without a vector anchor,
+    so row ids are expected to be unique.
+    """
+
+    def _setup_collection(self, client, collection_name, sealed_nb=3000, growing_nb=500):
+        """Insert `sealed_nb` rows (flushed → sealed) then `growing_nb` rows (no flush → growing).
+        Default totals 3500 rows (3000 sealed + 500 growing).
+        """
+        schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
+        schema.add_field("id", DataType.INT64, is_primary=True)
+        schema.add_field("doc_int", DataType.INT64)
+        schema.add_field("normal_vector", DataType.FLOAT_VECTOR, dim=default_dim)
+        ss = client.create_struct_field_schema()
+        ss.add_field("embedding", DataType.FLOAT_VECTOR, dim=default_dim)
+        ss.add_field("int_val", DataType.INT64)
+        ss.add_field("color", DataType.VARCHAR, max_length=128)
+        schema.add_field(
+            "structA", DataType.ARRAY, element_type=DataType.STRUCT, struct_schema=ss, max_capacity=default_capacity
+        )
+
+        ip = client.prepare_index_params()
+        ip.add_index("normal_vector", index_type="HNSW", metric_type="COSINE", params=INDEX_PARAMS)
+        ip.add_index("structA[embedding]", index_type="HNSW", metric_type="COSINE", params=INDEX_PARAMS)
+        self.create_collection(client, collection_name, schema=schema, index_params=ip)
+
+        def _gen_row(i):
+            rng = random.Random(i)
+            num_elems = rng.randint(3, 6)
+            sa = [
+                {
+                    "embedding": _seed_vector(i * 1000 + j),
+                    "int_val": i * 100 + j,
+                    "color": COLORS[j % 3],
+                }
+                for j in range(num_elems)
+            ]
+            return {
+                "id": i,
+                "doc_int": i,
+                "normal_vector": _seed_vector(i + 999999),
+                "structA": sa,
+            }
+
+        all_data = []
+        if sealed_nb > 0:
+            sealed = [_gen_row(i) for i in range(sealed_nb)]
+            for start in range(0, sealed_nb, insert_batch_size):
+                self.insert(client, collection_name, sealed[start : start + insert_batch_size])
+            self.flush(client, collection_name)
+            all_data.extend(sealed)
+        if growing_nb > 0:
+            growing = [_gen_row(sealed_nb + i) for i in range(growing_nb)]
+            for start in range(0, growing_nb, insert_batch_size):
+                self.insert(client, collection_name, growing[start : start + insert_batch_size])
+            all_data.extend(growing)
+        self.load_collection(client, collection_name)
+        return all_data
+
+    def _drain(self, iterator):
+        """Collect all results from a query iterator until exhaustion."""
+        assert iterator is not None
+        all_rows = []
+        while True:
+            batch = iterator.next()
+            if not batch:
+                break
+            all_rows.extend(batch)
+        iterator.close()
+        return all_rows
+
+    @pytest.mark.xfail(
+        reason="milvus-io/milvus#49355: query_iterator over element_filter drops "
+        "trailing offsets of any row whose matched offsets span a page boundary "
+        "(server's element-level limit truncates mid-row; iterator advances pk > "
+        "last_pk, so the row's remaining offsets are never re-fetched)."
+    )
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_query_iterator_with_element_filter(self):
+        """
+        target: query_iterator with element_filter on struct array
+        method: iterate with `element_filter(structA, $[int_val] >= 20000)`
+        expected: element_filter is element-level; each hit carries a row `id` plus an
+                  `offset` (the index inside structA) and the (id, offset) pairs are unique
+                  across batches. Pair set must equal the one-shot query's pair set.
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_qiter_ef")
+        self._setup_collection(client, collection_name)  # 3000 sealed + 500 growing
+
+        filter_expr = "element_filter(structA, $[int_val] >= 20000)"
+        batch_size = 50
+        iterator, _ = self.query_iterator(
+            client,
+            collection_name,
+            batch_size=batch_size,
+            filter=filter_expr,
+            output_fields=["id", "structA"],
+            consistency_level="Strong",
+        )
+        rows = self._drain(iterator)
+        pairs = [(r["id"], r["offset"]) for r in rows]
+        assert len(pairs) == len(set(pairs)), (
+            f"duplicated (id, offset) pairs across batches: "
+            f"{len(pairs) - len(set(pairs))} duplicates out of {len(pairs)}"
+        )
+        for row in rows:
+            assert row["structA"][row["offset"]]["int_val"] >= 20000, (
+                f"row {row['id']} offset {row['offset']} violates element_filter"
+            )
+
+        # cross-check against one-shot query (also element-level)
+        oneshot, _ = self.query(
+            client,
+            collection_name,
+            filter=filter_expr,
+            output_fields=["id"],
+            limit=16384,
+        )
+        oneshot_pairs = {(r["id"], r["offset"]) for r in oneshot}
+        assert set(pairs) == oneshot_pairs, (
+            f"query_iterator pairs diverge from one-shot: "
+            f"only_iter={set(pairs) - oneshot_pairs}, only_oneshot={oneshot_pairs - set(pairs)}"
+        )
+
+    @pytest.mark.tags(CaseLabel.L1)
+    @pytest.mark.parametrize(
+        "match_type,match_expr,predicate",
+        [
+            ("ANY", 'match_any(structA, $[color] == "Red")', lambda sa: any(e["color"] == "Red" for e in sa)),
+            ("ALL", "match_all(structA, $[int_val] >= 0)", lambda sa: all(e["int_val"] >= 0 for e in sa)),
+        ],
+    )
+    def test_query_iterator_with_match_family(self, match_type, match_expr, predicate):
+        """
+        target: query_iterator combined with MATCH_ANY / MATCH_ALL predicates on struct array
+        method: iterate with match expr, predicate applied row-level
+        expected: every returned row satisfies the predicate; ids unique; count matches one-shot
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_qiter_match_{match_type.lower()}")
+        self._setup_collection(client, collection_name)  # 3000 sealed + 500 growing
+
+        iterator, _ = self.query_iterator(
+            client,
+            collection_name,
+            batch_size=40,
+            filter=match_expr,
+            output_fields=["id", "structA"],
+        )
+        rows = self._drain(iterator)
+        ids = {r["id"] for r in rows}
+        assert len(ids) == len(rows), "duplicated row ids"
+        for row in rows:
+            assert predicate(row["structA"]), f"row {row['id']} does not satisfy {match_type}"
+
+        oneshot, _ = self.query(
+            client,
+            collection_name,
+            filter=match_expr,
+            output_fields=["id"],
+            limit=16384,
+        )
+        assert ids == {r["id"] for r in oneshot}
+
+    @pytest.mark.xfail(
+        reason="milvus-io/milvus#49355: same root cause as "
+        "test_query_iterator_with_element_filter — server truncates within a row at "
+        "the element-level limit boundary; client cursor (pk > last_pk) cannot "
+        "recover the row's remaining offsets."
+    )
+    @pytest.mark.tags(CaseLabel.L2)
+    @pytest.mark.parametrize("batch_size", [10, 50, 100])
+    def test_query_iterator_element_filter_batch_size(self, batch_size):
+        """
+        target: query_iterator with element_filter across different batch sizes
+        method: parametrize batch_size; expect element-level (id, offset) pair set stable
+                across sizes and equal to the one-shot query pair set.
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_qiter_bs_{batch_size}")
+        self._setup_collection(client, collection_name)  # 3000 sealed + 500 growing
+
+        filter_expr = "element_filter(structA, $[int_val] >= 10000)"
+        iterator, _ = self.query_iterator(
+            client,
+            collection_name,
+            batch_size=batch_size,
+            filter=filter_expr,
+            output_fields=["id"],
+            consistency_level="Strong",
+        )
+        rows = self._drain(iterator)
+        pairs = [(r["id"], r["offset"]) for r in rows]
+        assert len(pairs) == len(set(pairs)), (
+            f"batch_size={batch_size}: duplicated (id, offset) pairs: "
+            f"{len(pairs) - len(set(pairs))} dups out of {len(pairs)}"
+        )
+
+        oneshot, _ = self.query(
+            client,
+            collection_name,
+            filter=filter_expr,
+            output_fields=["id"],
+            limit=16384,
+        )
+        oneshot_pairs = {(r["id"], r["offset"]) for r in oneshot}
+        assert set(pairs) == oneshot_pairs, (
+            f"batch_size={batch_size}: iterator pairs={len(pairs)} vs one-shot={len(oneshot)}"
+        )
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_query_iterator_empty_result(self):
+        """
+        target: query_iterator with an unsatisfiable element_filter
+        method: `int_val > 10_000_000` never holds → 0 rows → pagination never triggers
+        expected: iterator yields 0 rows and terminates cleanly without composing an invalid
+                  AND expression (element_filter alone is not blocked).
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_qiter_empty")
+        self._setup_collection(client, collection_name)  # 3000 sealed + 500 growing
+        iterator, _ = self.query_iterator(
+            client,
+            collection_name,
+            batch_size=50,
+            filter="element_filter(structA, $[int_val] > 10000000)",
+            output_fields=["id"],
+        )
+        rows = self._drain(iterator)
+        assert len(rows) == 0, f"expected 0 rows for impossible filter, got {len(rows)}"
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_query_iterator_doc_scalar_filter_on_struct_array_collection(self):
+        """
+        target: on a collection that contains a struct array, query_iterator over a plain
+                doc-level scalar predicate works normally (sanity check that iterator itself
+                is not blocked by struct array schema; only element_filter composition is).
+        method: 3500 rows (3000 sealed + 500 growing); filter covers sealed+growing
+        expected: iterator returns exactly the one-shot set; ids unique; count > 2000
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_qiter_doc_scalar")
+        self._setup_collection(client, collection_name)  # 3000 sealed + 500 growing
+
+        # Covers both sealed (1000..2999) and growing (3000..3199) rows
+        filter_expr = "doc_int >= 1000 and doc_int < 3200"
+        iterator, _ = self.query_iterator(
+            client,
+            collection_name,
+            batch_size=100,
+            filter=filter_expr,
+            output_fields=["id"],
+        )
+        rows = self._drain(iterator)
+        ids = [r["id"] for r in rows]
+        assert len(ids) == len(set(ids))
+        assert len(ids) == 2200, f"expect 2200 rows matching [1000, 3200), got {len(ids)}"
+        # Span both segments
+        assert any(i < 3000 for i in ids) and any(i >= 3000 for i in ids), "must span sealed+growing"
+
+        oneshot, _ = self.query(
+            client,
+            collection_name,
+            filter=filter_expr,
+            output_fields=["id"],
+            limit=16384,
+        )
+        assert set(ids) == {r["id"] for r in oneshot}
 
 
 class TestMilvusClientStructArrayElementContainsSearch(TestMilvusClientV2Base):
     """Test ARRAY_CONTAINS on struct sub-fields (6 cases, all skip - depends on PR #47172)"""
 
     @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.skip(reason="Depends on PR #47172 - ARRAY_CONTAINS support for struct arrays")
     def test_array_contains_struct_int_subfield(self):
         """
         target: array_contains on struct array int sub-field
@@ -4851,7 +5866,6 @@ class TestMilvusClientStructArrayElementContainsSearch(TestMilvusClientV2Base):
         pass
 
     @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.skip(reason="Depends on PR #47172 - ARRAY_CONTAINS support for struct arrays")
     def test_array_contains_all_struct_varchar_subfield(self):
         """
         target: array_contains_all on struct varchar sub-field
@@ -4861,7 +5875,6 @@ class TestMilvusClientStructArrayElementContainsSearch(TestMilvusClientV2Base):
         pass
 
     @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.skip(reason="Depends on PR #47172 - ARRAY_CONTAINS support for struct arrays")
     def test_array_contains_any_struct_int_subfield(self):
         """
         target: array_contains_any on struct int sub-field
@@ -4871,7 +5884,6 @@ class TestMilvusClientStructArrayElementContainsSearch(TestMilvusClientV2Base):
         pass
 
     @pytest.mark.tags(CaseLabel.L2)
-    @pytest.mark.skip(reason="Depends on PR #47172 - ARRAY_CONTAINS support for struct arrays")
     def test_array_contains_combined_with_match(self):
         """
         target: array_contains combined with MATCH operator
@@ -4881,7 +5893,6 @@ class TestMilvusClientStructArrayElementContainsSearch(TestMilvusClientV2Base):
         pass
 
     @pytest.mark.tags(CaseLabel.L2)
-    @pytest.mark.skip(reason="Depends on PR #47172 - ARRAY_CONTAINS support for struct arrays")
     def test_array_contains_combined_with_element_filter(self):
         """
         target: array_contains combined with element_filter
@@ -4891,7 +5902,6 @@ class TestMilvusClientStructArrayElementContainsSearch(TestMilvusClientV2Base):
         pass
 
     @pytest.mark.tags(CaseLabel.L2)
-    @pytest.mark.skip(reason="Depends on PR #47172 - ARRAY_CONTAINS support for struct arrays")
     def test_array_contains_empty_array(self):
         """
         target: array_contains on empty array sub-field

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_element_search.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_element_search.py
@@ -20,6 +20,7 @@ default_growing_nb = 500
 insert_batch_size = 500
 default_capacity = 100
 INDEX_PARAMS = {"M": 16, "efConstruction": 200}
+HNSW_SEARCH_PARAMS = {"ef": 1000}
 COLORS = ["Red", "Blue", "Green"]
 SIZES = ["S", "M", "L", "XL"]
 CATEGORIES = ["A", "B", "C", "D"]
@@ -286,6 +287,65 @@ def _assert_element_range_hits_ground_truth(
                 )
 
 
+def _expected_element_range_hits(data, query_vector, metric_type, elem_filter_fn, low=None, high=None):
+    """Compute exact element-level range-search candidates from inserted data."""
+    expected = []
+    for row in data:
+        for offset, elem in enumerate(row["structA"]):
+            if not elem_filter_fn(elem):
+                continue
+            distance = _compute_similarity(query_vector, elem["embedding"], metric_type)
+            if low is not None and distance < low:
+                continue
+            if high is not None and distance > high:
+                continue
+            expected.append((row["id"], offset, distance))
+    expected.sort(key=lambda x: x[2], reverse=_is_descending(metric_type))
+    return expected
+
+
+def _assert_no_missing_range_hits(results, expected_hits):
+    """Assert returned element hits exactly match the expected element candidates."""
+    actual_pairs = {(hit["id"], hit["offset"]) for hit in results[0]}
+    expected_pairs = {(row_id, offset) for row_id, offset, _ in expected_hits}
+    missing = expected_pairs - actual_pairs
+    extra = actual_pairs - expected_pairs
+    assert not missing and not extra, (
+        f"range search result mismatch: missing={sorted(missing)[:20]}, "
+        f"extra={sorted(extra)[:20]}, expected={len(expected_pairs)}, actual={len(actual_pairs)}"
+    )
+
+
+def _assert_range_recall(hits, expected_hits, limit, recall_threshold=0.8, context="range search"):
+    """Assert ANN range-search results recall enough exact top candidates."""
+    expected_top = expected_hits[: min(limit, len(expected_hits))]
+    assert expected_top, f"{context}: exact expected range candidates should not be empty"
+
+    actual_pairs = {(hit["id"], hit["offset"]) for hit in hits}
+    expected_pairs = {(row_id, offset) for row_id, offset, _ in expected_top}
+    overlap = actual_pairs & expected_pairs
+    recall = len(overlap) / len(expected_pairs)
+    assert recall >= recall_threshold, (
+        f"{context}: recall {recall:.2f} < {recall_threshold}; "
+        f"overlap={len(overlap)}, expected={len(expected_pairs)}, actual={len(actual_pairs)}, "
+        f"missing={sorted(expected_pairs - actual_pairs)[:20]}"
+    )
+
+
+def _hnsw_search_params(**params):
+    """Compose HNSW search params with a recall-oriented ef value."""
+    merged = dict(HNSW_SEARCH_PARAMS)
+    merged.update(params)
+    return merged
+
+
+def _diskann_search_params(**params):
+    """Compose DISKANN search params with a recall-oriented search_list value."""
+    merged = {"search_list": 1000}
+    merged.update(params)
+    return merged
+
+
 def _generate_float16_vector(dim, seed=None):
     """Generate Float16 vector as np.ndarray(dtype=float16)."""
     rng = np.random.RandomState(seed)
@@ -442,7 +502,7 @@ class TestMilvusClientStructArrayElementFilterSearch(TestMilvusClientV2Base):
             collection_name,
             data=[query_vector],
             anns_field="structA[embedding]",
-            search_params={"metric_type": "COSINE"},
+            search_params={"metric_type": "COSINE", "params": HNSW_SEARCH_PARAMS},
             filter="element_filter(structA, $[int_val] >= 0)",
             limit=10,
             output_fields=["id", "structA"],
@@ -4709,7 +4769,14 @@ class TestMilvusClientStructArrayElementRangeSearch(TestMilvusClientV2Base):
     """
 
     def _setup_collection(
-        self, client, collection_name, sealed_nb=3000, growing_nb=500, metric_type="COSINE", elems_per_row=None
+        self,
+        client,
+        collection_name,
+        sealed_nb=3000,
+        growing_nb=500,
+        metric_type="COSINE",
+        elems_per_row=None,
+        index_type="HNSW",
     ):
         """Create collection + insert `sealed_nb` rows (flushed → sealed) then `growing_nb`
         rows (no flush → growing). Default totals 3500 rows (3000 sealed + 500 growing).
@@ -4743,9 +4810,9 @@ class TestMilvusClientStructArrayElementRangeSearch(TestMilvusClientV2Base):
         )
         index_params.add_index(
             field_name="structA[embedding]",
-            index_type="HNSW",
+            index_type=index_type,
             metric_type=metric_type,
-            params=INDEX_PARAMS,
+            params=INDEX_PARAMS if index_type == "HNSW" else {},
         )
         self.create_collection(client, collection_name, schema=schema, index_params=index_params)
 
@@ -4792,7 +4859,7 @@ class TestMilvusClientStructArrayElementRangeSearch(TestMilvusClientV2Base):
             collection_name,
             data=[query_vector],
             anns_field="structA[embedding]",
-            search_params={"metric_type": metric_type},
+            search_params={"metric_type": metric_type, "params": HNSW_SEARCH_PARAMS},
             filter=filter_expr,
             limit=200,
             output_fields=["id"],
@@ -4815,6 +4882,141 @@ class TestMilvusClientStructArrayElementRangeSearch(TestMilvusClientV2Base):
             assert low - epsilon <= d <= high + epsilon, f"{metric_type} distance {d} not in window [{low}, {high}]"
 
     @pytest.mark.tags(CaseLabel.L0)
+    def test_range_search_flat_no_missing_results(self):
+        """
+        target: FLAT range search returns every exact element candidate in the range window
+        method: use one struct element per row, compute exact ground truth from inserted data,
+                then compare returned (id, offset) pairs with the full expected set
+        expected: no missing or extra element hits
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_range_flat_exact")
+        data = self._setup_collection(
+            client,
+            collection_name,
+            sealed_nb=300,
+            growing_nb=0,
+            metric_type="COSINE",
+            elems_per_row=1,
+            index_type="FLAT",
+        )
+        query_vector = data[0]["structA"][0]["embedding"]
+        filter_expr = "element_filter(structA, $[int_val] >= 0)"
+
+        all_hits = _expected_element_range_hits(
+            data,
+            query_vector,
+            "COSINE",
+            elem_filter_fn=lambda e: e["int_val"] >= 0,
+        )
+        start = 30
+        end = 80
+        upper_bound = (all_hits[start - 1][2] + all_hits[start][2]) / 2
+        lower_bound = (all_hits[end - 1][2] + all_hits[end][2]) / 2
+        expected_hits = _expected_element_range_hits(
+            data,
+            query_vector,
+            "COSINE",
+            elem_filter_fn=lambda e: e["int_val"] >= 0,
+            low=lower_bound,
+            high=upper_bound,
+        )
+        assert 0 < len(expected_hits) < 100, f"unexpected exact candidate count: {len(expected_hits)}"
+
+        results, check = self.search(
+            client,
+            collection_name,
+            data=[query_vector],
+            anns_field="structA[embedding]",
+            search_params={"metric_type": "COSINE", "params": {"radius": lower_bound, "range_filter": upper_bound}},
+            filter=filter_expr,
+            limit=len(expected_hits) + 10,
+            output_fields=["id"],
+        )
+        assert check
+        _assert_element_range_hits_ground_truth(
+            results,
+            data,
+            [query_vector],
+            "COSINE",
+            elem_filter_fn=lambda e: e["int_val"] >= 0,
+            low=lower_bound,
+            high=upper_bound,
+        )
+        _assert_no_missing_range_hits(results, expected_hits)
+        _assert_distance_order(results, "COSINE")
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_range_search_diskann_recall(self):
+        """
+        target: DISKANN range search on struct array element-level vectors has acceptable recall
+        method: build DISKANN on structA[embedding], compute exact range candidates from inserted data,
+                then require at least 70% overlap with the expected top candidates
+        expected: returned hits are valid range hits and recall is not too low
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_range_diskann")
+        data = self._setup_collection(
+            client,
+            collection_name,
+            sealed_nb=1000,
+            growing_nb=0,
+            metric_type="COSINE",
+            elems_per_row=1,
+            index_type="DISKANN",
+        )
+        query_vector = data[0]["structA"][0]["embedding"]
+        filter_expr = "element_filter(structA, $[int_val] >= 0)"
+
+        all_hits = _expected_element_range_hits(
+            data,
+            query_vector,
+            "COSINE",
+            elem_filter_fn=lambda e: e["int_val"] >= 0,
+        )
+        start = 50
+        end = 150
+        upper_bound = (all_hits[start - 1][2] + all_hits[start][2]) / 2
+        lower_bound = (all_hits[end - 1][2] + all_hits[end][2]) / 2
+        expected_hits = _expected_element_range_hits(
+            data,
+            query_vector,
+            "COSINE",
+            elem_filter_fn=lambda e: e["int_val"] >= 0,
+            low=lower_bound,
+            high=upper_bound,
+        )
+        assert expected_hits, "DISKANN range exact candidates should not be empty"
+
+        limit = 100
+        results, check = self.search(
+            client,
+            collection_name,
+            data=[query_vector],
+            anns_field="structA[embedding]",
+            search_params={
+                "metric_type": "COSINE",
+                "params": _diskann_search_params(radius=lower_bound, range_filter=upper_bound),
+            },
+            filter=filter_expr,
+            limit=limit,
+            output_fields=["id"],
+        )
+        assert check
+        assert len(results[0]) > 0, "DISKANN range search returned 0 rows"
+        _assert_element_range_hits_ground_truth(
+            results,
+            data,
+            [query_vector],
+            "COSINE",
+            elem_filter_fn=lambda e: e["int_val"] >= 0,
+            low=lower_bound,
+            high=upper_bound,
+        )
+        _assert_range_recall(results[0], expected_hits, limit=limit, context="DISKANN COSINE range search")
+        _assert_distance_order(results, "COSINE")
+
+    @pytest.mark.tags(CaseLabel.L0)
     def test_range_search_cosine_radius_only(self):
         """
         target: COSINE range search with radius only (lower bound)
@@ -4833,7 +5035,7 @@ class TestMilvusClientStructArrayElementRangeSearch(TestMilvusClientV2Base):
             collection_name,
             data=[query_vector],
             anns_field="structA[embedding]",
-            search_params={"metric_type": "COSINE", "params": {"radius": low}},
+            search_params={"metric_type": "COSINE", "params": _hnsw_search_params(radius=low)},
             filter=filter_expr,
             limit=100,
             output_fields=["id"],
@@ -4850,6 +5052,14 @@ class TestMilvusClientStructArrayElementRangeSearch(TestMilvusClientV2Base):
             elem_filter_fn=lambda e: e["int_val"] >= 0,
             low=low,
         )
+        expected_hits = _expected_element_range_hits(
+            data,
+            query_vector,
+            "COSINE",
+            elem_filter_fn=lambda e: e["int_val"] >= 0,
+            low=low,
+        )
+        _assert_range_recall(results[0], expected_hits, limit=100, context="COSINE radius-only range search")
         _assert_distance_order(results, "COSINE")
 
     @pytest.mark.tags(CaseLabel.L0)
@@ -4871,7 +5081,7 @@ class TestMilvusClientStructArrayElementRangeSearch(TestMilvusClientV2Base):
             collection_name,
             data=[query_vector],
             anns_field="structA[embedding]",
-            search_params={"metric_type": "L2", "params": {"radius": high}},
+            search_params={"metric_type": "L2", "params": _hnsw_search_params(radius=high)},
             filter=filter_expr,
             limit=100,
             output_fields=["id"],
@@ -4888,6 +5098,14 @@ class TestMilvusClientStructArrayElementRangeSearch(TestMilvusClientV2Base):
             elem_filter_fn=lambda e: e["int_val"] >= 0,
             high=high,
         )
+        expected_hits = _expected_element_range_hits(
+            data,
+            query_vector,
+            "L2",
+            elem_filter_fn=lambda e: e["int_val"] >= 0,
+            high=high,
+        )
+        _assert_range_recall(results[0], expected_hits, limit=100, context="L2 radius-only range search")
         _assert_distance_order(results, "L2")
 
     @pytest.mark.tags(CaseLabel.L1)
@@ -4909,7 +5127,7 @@ class TestMilvusClientStructArrayElementRangeSearch(TestMilvusClientV2Base):
             collection_name,
             data=[query_vector],
             anns_field="structA[embedding]",
-            search_params={"metric_type": "IP", "params": {"radius": low}},
+            search_params={"metric_type": "IP", "params": _hnsw_search_params(radius=low)},
             filter=filter_expr,
             limit=100,
             output_fields=["id"],
@@ -4926,6 +5144,14 @@ class TestMilvusClientStructArrayElementRangeSearch(TestMilvusClientV2Base):
             elem_filter_fn=lambda e: e["int_val"] >= 0,
             low=low,
         )
+        expected_hits = _expected_element_range_hits(
+            data,
+            query_vector,
+            "IP",
+            elem_filter_fn=lambda e: e["int_val"] >= 0,
+            low=low,
+        )
+        _assert_range_recall(results[0], expected_hits, limit=100, context="IP radius-only range search")
         _assert_distance_order(results, "IP")
 
     @pytest.mark.tags(CaseLabel.L0)
@@ -4948,7 +5174,7 @@ class TestMilvusClientStructArrayElementRangeSearch(TestMilvusClientV2Base):
             collection_name,
             data=[query_vector],
             anns_field="structA[embedding]",
-            search_params={"metric_type": "L2", "params": {"radius": high, "range_filter": low}},
+            search_params={"metric_type": "L2", "params": _hnsw_search_params(radius=high, range_filter=low)},
             filter=filter_expr,
             limit=limit,
             output_fields=["id"],
@@ -4968,6 +5194,15 @@ class TestMilvusClientStructArrayElementRangeSearch(TestMilvusClientV2Base):
             low=low,
             high=high,
         )
+        expected_hits = _expected_element_range_hits(
+            data,
+            query_vector,
+            "L2",
+            elem_filter_fn=lambda e: e["int_val"] >= 0,
+            low=low,
+            high=high,
+        )
+        _assert_range_recall(results[0], expected_hits, limit=limit, context="L2 bounded range search")
         _assert_distance_order(results, "L2")
 
     @pytest.mark.tags(CaseLabel.L0)
@@ -4990,7 +5225,7 @@ class TestMilvusClientStructArrayElementRangeSearch(TestMilvusClientV2Base):
             collection_name,
             data=[query_vector],
             anns_field="structA[embedding]",
-            search_params={"metric_type": "COSINE", "params": {"radius": low, "range_filter": high}},
+            search_params={"metric_type": "COSINE", "params": _hnsw_search_params(radius=low, range_filter=high)},
             filter=filter_expr,
             limit=limit,
             output_fields=["id"],
@@ -5010,6 +5245,15 @@ class TestMilvusClientStructArrayElementRangeSearch(TestMilvusClientV2Base):
             low=low,
             high=high,
         )
+        expected_hits = _expected_element_range_hits(
+            data,
+            query_vector,
+            "COSINE",
+            elem_filter_fn=lambda e: e["int_val"] >= 0,
+            low=low,
+            high=high,
+        )
+        _assert_range_recall(results[0], expected_hits, limit=limit, context="COSINE bounded range search")
         _assert_distance_order(results, "COSINE")
 
     @pytest.mark.tags(CaseLabel.L1)
@@ -5030,7 +5274,7 @@ class TestMilvusClientStructArrayElementRangeSearch(TestMilvusClientV2Base):
             collection_name,
             data=[query_vector],
             anns_field="structA[embedding]",
-            search_params={"metric_type": "COSINE"},
+            search_params={"metric_type": "COSINE", "params": HNSW_SEARCH_PARAMS},
             filter="element_filter(structA, $[int_val] >= 0)",
             limit=200,
             output_fields=["id"],
@@ -5045,7 +5289,7 @@ class TestMilvusClientStructArrayElementRangeSearch(TestMilvusClientV2Base):
             collection_name,
             data=[query_vector],
             anns_field="structA[embedding]",
-            search_params={"metric_type": "COSINE", "params": {"radius": low, "range_filter": high}},
+            search_params={"metric_type": "COSINE", "params": _hnsw_search_params(radius=low, range_filter=high)},
             filter=tight_filter,
             limit=100,
             output_fields=["id", "structA"],
@@ -5068,6 +5312,15 @@ class TestMilvusClientStructArrayElementRangeSearch(TestMilvusClientV2Base):
             low=low,
             high=high,
         )
+        expected_hits = _expected_element_range_hits(
+            data,
+            query_vector,
+            "COSINE",
+            elem_filter_fn=lambda e: 1000 < e["int_val"] < 40000,
+            low=low,
+            high=high,
+        )
+        _assert_range_recall(results[0], expected_hits, limit=100, context="COSINE range search with element_filter")
         _assert_distance_order(results, "COSINE")
 
     @pytest.mark.tags(CaseLabel.L1)
@@ -5089,7 +5342,7 @@ class TestMilvusClientStructArrayElementRangeSearch(TestMilvusClientV2Base):
             collection_name,
             data=[qv],
             anns_field="structA[embedding]",
-            search_params={"metric_type": "COSINE", "params": {"radius": low, "range_filter": high}},
+            search_params={"metric_type": "COSINE", "params": _hnsw_search_params(radius=low, range_filter=high)},
             filter=filter_expr,
             limit=200,
             output_fields=["id"],
@@ -5107,6 +5360,15 @@ class TestMilvusClientStructArrayElementRangeSearch(TestMilvusClientV2Base):
             low=low,
             high=high,
         )
+        expected_hits = _expected_element_range_hits(
+            data,
+            qv,
+            "COSINE",
+            elem_filter_fn=lambda e: e["int_val"] >= 0,
+            low=low,
+            high=high,
+        )
+        _assert_range_recall(results[0], expected_hits, limit=200, context="COSINE growing range search")
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_range_search_mixed_segments(self):
@@ -5127,7 +5389,7 @@ class TestMilvusClientStructArrayElementRangeSearch(TestMilvusClientV2Base):
             collection_name,
             data=[qv],
             anns_field="structA[embedding]",
-            search_params={"metric_type": "COSINE", "params": {"radius": low, "range_filter": high}},
+            search_params={"metric_type": "COSINE", "params": _hnsw_search_params(radius=low, range_filter=high)},
             filter=filter_expr,
             limit=400,
             output_fields=["id"],
@@ -5145,6 +5407,15 @@ class TestMilvusClientStructArrayElementRangeSearch(TestMilvusClientV2Base):
             low=low,
             high=high,
         )
+        expected_hits = _expected_element_range_hits(
+            data,
+            qv,
+            "COSINE",
+            elem_filter_fn=lambda e: e["int_val"] >= 0,
+            low=low,
+            high=high,
+        )
+        _assert_range_recall(results[0], expected_hits, limit=400, context="COSINE mixed-segment range search")
         # recall hits from both segments (may be weaker for growing due to serial scan)
         has_sealed = any(i < 3000 for i in ids)
         has_growing = any(i >= 3000 for i in ids)
@@ -5174,7 +5445,7 @@ class TestMilvusClientStructArrayElementRangeSearch(TestMilvusClientV2Base):
             collection_name,
             data=query_vectors,
             anns_field="structA[embedding]",
-            search_params={"metric_type": "COSINE", "params": {"radius": low, "range_filter": high}},
+            search_params={"metric_type": "COSINE", "params": _hnsw_search_params(radius=low, range_filter=high)},
             filter=filter_expr,
             limit=100,
             output_fields=["id"],
@@ -5196,6 +5467,21 @@ class TestMilvusClientStructArrayElementRangeSearch(TestMilvusClientV2Base):
             low=low,
             high=high,
         )
+        for q_idx, query_vector in enumerate(query_vectors):
+            expected_hits = _expected_element_range_hits(
+                data,
+                query_vector,
+                "COSINE",
+                elem_filter_fn=lambda e: e["int_val"] >= 0,
+                low=low,
+                high=high,
+            )
+            _assert_range_recall(
+                results[q_idx],
+                expected_hits,
+                limit=100,
+                context=f"COSINE nq={q_idx} range search",
+            )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_range_search_l2_invalid_radius_less_than_range_filter(self):
@@ -5687,7 +5973,7 @@ class TestMilvusClientStructArrayElementSearchIterator(TestMilvusClientV2Base):
             data=[qv],
             batch_size=30,
             anns_field="structA[embedding]",
-            search_params={"metric_type": "COSINE", "params": {"radius": low, "range_filter": high}},
+            search_params={"metric_type": "COSINE", "params": _hnsw_search_params(radius=low, range_filter=high)},
             filter=filter_expr,
             limit=200,
             output_fields=["id"],
@@ -5714,6 +6000,15 @@ class TestMilvusClientStructArrayElementSearchIterator(TestMilvusClientV2Base):
             low=low,
             high=high,
         )
+        expected_hits = _expected_element_range_hits(
+            data,
+            qv,
+            "COSINE",
+            elem_filter_fn=lambda e: e["int_val"] >= 0,
+            low=low,
+            high=high,
+        )
+        _assert_range_recall(all_hits, expected_hits, limit=200, context="iterator COSINE range search")
         dists = [h["distance"] for h in all_hits]
         for k in range(len(dists) - 1):
             assert dists[k] >= dists[k + 1] - epsilon, f"iterator distances not descending at {k}"

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_element_search.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_element_search.py
@@ -237,6 +237,55 @@ def _assert_distance_order(results, metric_type):
             )
 
 
+def _assert_element_range_hits_ground_truth(
+    results,
+    data,
+    query_vectors,
+    metric_type,
+    elem_filter_fn,
+    low=None,
+    high=None,
+):
+    """
+    Verify every returned element-level range-search hit against inserted data.
+
+    This intentionally checks returned-hit correctness rather than exact recall:
+    HNSW search is approximate, but any returned (row id, element offset, distance)
+    must be independently valid.
+    """
+    assert len(results) == len(query_vectors), f"result nq={len(results)} != query nq={len(query_vectors)}"
+    data_by_id = {row["id"]: row for row in data}
+
+    for q_idx, (hits, query_vector) in enumerate(zip(results, query_vectors)):
+        for hit in hits:
+            row_id = hit["id"]
+            assert row_id in data_by_id, f"query {q_idx}: row id {row_id} not found in inserted data"
+            assert "offset" in hit, f"query {q_idx}: hit {row_id} has no element offset"
+
+            row = data_by_id[row_id]
+            offset = hit["offset"]
+            assert 0 <= offset < len(row["structA"]), (
+                f"query {q_idx}: row {row_id} offset {offset} out of range, structA length={len(row['structA'])}"
+            )
+
+            elem = row["structA"][offset]
+            assert elem_filter_fn(elem), f"query {q_idx}: row {row_id} offset {offset} violates element_filter"
+
+            expected_distance = _compute_similarity(query_vector, elem["embedding"], metric_type)
+            assert abs(hit["distance"] - expected_distance) <= epsilon, (
+                f"query {q_idx}: row {row_id} offset {offset} distance mismatch: "
+                f"milvus={hit['distance']}, expected={expected_distance}"
+            )
+            if low is not None:
+                assert hit["distance"] >= low - epsilon, (
+                    f"query {q_idx}: row {row_id} offset {offset} distance {hit['distance']} < low {low}"
+                )
+            if high is not None:
+                assert hit["distance"] <= high + epsilon, (
+                    f"query {q_idx}: row {row_id} offset {offset} distance {hit['distance']} > high {high}"
+                )
+
+
 def _generate_float16_vector(dim, seed=None):
     """Generate Float16 vector as np.ndarray(dtype=float16)."""
     rng = np.random.RandomState(seed)
@@ -4793,6 +4842,14 @@ class TestMilvusClientStructArrayElementRangeSearch(TestMilvusClientV2Base):
         assert len(results[0]) > 0, "COSINE radius-only range search returned 0 rows"
         for hit in results[0]:
             assert hit["distance"] >= low - epsilon, f"COSINE distance {hit['distance']} < radius {low}"
+        _assert_element_range_hits_ground_truth(
+            results,
+            data,
+            [query_vector],
+            "COSINE",
+            elem_filter_fn=lambda e: e["int_val"] >= 0,
+            low=low,
+        )
         _assert_distance_order(results, "COSINE")
 
     @pytest.mark.tags(CaseLabel.L0)
@@ -4823,6 +4880,14 @@ class TestMilvusClientStructArrayElementRangeSearch(TestMilvusClientV2Base):
         assert len(results[0]) > 0
         for hit in results[0]:
             assert hit["distance"] <= high + epsilon, f"L2 distance {hit['distance']} > radius {high}"
+        _assert_element_range_hits_ground_truth(
+            results,
+            data,
+            [query_vector],
+            "L2",
+            elem_filter_fn=lambda e: e["int_val"] >= 0,
+            high=high,
+        )
         _assert_distance_order(results, "L2")
 
     @pytest.mark.tags(CaseLabel.L1)
@@ -4853,6 +4918,14 @@ class TestMilvusClientStructArrayElementRangeSearch(TestMilvusClientV2Base):
         assert len(results[0]) > 0
         for hit in results[0]:
             assert hit["distance"] >= low - epsilon, f"IP distance {hit['distance']} < radius {low}"
+        _assert_element_range_hits_ground_truth(
+            results,
+            data,
+            [query_vector],
+            "IP",
+            elem_filter_fn=lambda e: e["int_val"] >= 0,
+            low=low,
+        )
         _assert_distance_order(results, "IP")
 
     @pytest.mark.tags(CaseLabel.L0)
@@ -4886,6 +4959,15 @@ class TestMilvusClientStructArrayElementRangeSearch(TestMilvusClientV2Base):
             assert low - epsilon <= hit["distance"] <= high + epsilon, (
                 f"L2 distance {hit['distance']} outside [{low}, {high}]"
             )
+        _assert_element_range_hits_ground_truth(
+            results,
+            data,
+            [query_vector],
+            "L2",
+            elem_filter_fn=lambda e: e["int_val"] >= 0,
+            low=low,
+            high=high,
+        )
         _assert_distance_order(results, "L2")
 
     @pytest.mark.tags(CaseLabel.L0)
@@ -4919,6 +5001,15 @@ class TestMilvusClientStructArrayElementRangeSearch(TestMilvusClientV2Base):
             assert low - epsilon <= hit["distance"] <= high + epsilon, (
                 f"COSINE distance {hit['distance']} outside [{low}, {high}]"
             )
+        _assert_element_range_hits_ground_truth(
+            results,
+            data,
+            [query_vector],
+            "COSINE",
+            elem_filter_fn=lambda e: e["int_val"] >= 0,
+            low=low,
+            high=high,
+        )
         _assert_distance_order(results, "COSINE")
 
     @pytest.mark.tags(CaseLabel.L1)
@@ -4960,6 +5051,7 @@ class TestMilvusClientStructArrayElementRangeSearch(TestMilvusClientV2Base):
             output_fields=["id", "structA"],
         )
         assert check
+        assert len(results[0]) > 0, "range search with element_filter returned 0 rows"
         for hit in results[0]:
             assert low - epsilon <= hit["distance"] <= high + epsilon, (
                 f"COSINE distance {hit['distance']} outside [{low}, {high}]"
@@ -4967,6 +5059,15 @@ class TestMilvusClientStructArrayElementRangeSearch(TestMilvusClientV2Base):
             assert any(1000 < e["int_val"] < 40000 for e in hit["structA"]), (
                 f"row {hit['id']} has no element matching scalar filter"
             )
+        _assert_element_range_hits_ground_truth(
+            results,
+            data,
+            [query_vector],
+            "COSINE",
+            elem_filter_fn=lambda e: 1000 < e["int_val"] < 40000,
+            low=low,
+            high=high,
+        )
         _assert_distance_order(results, "COSINE")
 
     @pytest.mark.tags(CaseLabel.L1)
@@ -4994,8 +5095,18 @@ class TestMilvusClientStructArrayElementRangeSearch(TestMilvusClientV2Base):
             output_fields=["id"],
         )
         assert check
+        assert len(results[0]) > 0, "range search on growing segment returned 0 rows"
         for hit in results[0]:
             assert low - epsilon <= hit["distance"] <= high + epsilon
+        _assert_element_range_hits_ground_truth(
+            results,
+            data,
+            [qv],
+            "COSINE",
+            elem_filter_fn=lambda e: e["int_val"] >= 0,
+            low=low,
+            high=high,
+        )
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_range_search_mixed_segments(self):
@@ -5025,6 +5136,15 @@ class TestMilvusClientStructArrayElementRangeSearch(TestMilvusClientV2Base):
         ids = [h["id"] for h in results[0]]
         for hit in results[0]:
             assert low - epsilon <= hit["distance"] <= high + epsilon
+        _assert_element_range_hits_ground_truth(
+            results,
+            data,
+            [qv],
+            "COSINE",
+            elem_filter_fn=lambda e: e["int_val"] >= 0,
+            low=low,
+            high=high,
+        )
         # recall hits from both segments (may be weaker for growing due to serial scan)
         has_sealed = any(i < 3000 for i in ids)
         has_growing = any(i >= 3000 for i in ids)
@@ -5062,10 +5182,20 @@ class TestMilvusClientStructArrayElementRangeSearch(TestMilvusClientV2Base):
         assert check
         assert len(results) == 3, f"expect 3 result lists for nq=3, got {len(results)}"
         for q_idx, hits in enumerate(results):
+            assert len(hits) > 0, f"query {q_idx}: range search returned 0 rows"
             for hit in hits:
                 assert low - epsilon <= hit["distance"] <= high + epsilon, (
                     f"query {q_idx}: distance {hit['distance']} outside [{low}, {high}]"
                 )
+        _assert_element_range_hits_ground_truth(
+            results,
+            data,
+            query_vectors,
+            "COSINE",
+            elem_filter_fn=lambda e: e["int_val"] >= 0,
+            low=low,
+            high=high,
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_range_search_l2_invalid_radius_less_than_range_filter(self):
@@ -5575,6 +5705,15 @@ class TestMilvusClientStructArrayElementSearchIterator(TestMilvusClientV2Base):
             assert low - epsilon <= hit["distance"] <= high + epsilon, (
                 f"iterator+range hit distance {hit['distance']} outside [{low}, {high}]"
             )
+        _assert_element_range_hits_ground_truth(
+            [all_hits],
+            data,
+            [qv],
+            "COSINE",
+            elem_filter_fn=lambda e: e["int_val"] >= 0,
+            low=low,
+            high=high,
+        )
         dists = [h["distance"] for h in all_hits]
         for k in range(len(dists) - 1):
             assert dists[k] >= dists[k + 1] - epsilon, f"iterator distances not descending at {k}"

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_element_search.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_element_search.py
@@ -6287,62 +6287,196 @@ class TestMilvusClientStructArrayElementQueryIterator(TestMilvusClientV2Base):
         assert set(ids) == {r["id"] for r in oneshot}
 
 
+@pytest.mark.xdist_group("TestMilvusClientStructArrayElementContainsSearch")
 class TestMilvusClientStructArrayElementContainsSearch(TestMilvusClientV2Base):
-    """Test ARRAY_CONTAINS on struct sub-fields (6 cases, all skip - depends on PR #47172)"""
+    """Test ARRAY_CONTAINS on struct sub-fields in search filters."""
+
+    SEARCH_VEC_SEED = 616161
+    SEARCH_LIMIT = 50
+
+    def _query_vec(self):
+        return _seed_vector(self.SEARCH_VEC_SEED)
+
+    def _create_schema(self, client):
+        schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
+        schema.add_field(field_name="id", datatype=DataType.INT64, is_primary=True)
+        schema.add_field(field_name="doc_int", datatype=DataType.INT64)
+        schema.add_field(field_name="normal_vector", datatype=DataType.FLOAT_VECTOR, dim=default_dim)
+
+        struct_schema = client.create_struct_field_schema()
+        struct_schema.add_field("embedding", DataType.FLOAT_VECTOR, dim=default_dim)
+        struct_schema.add_field("int_val", DataType.INT64)
+        struct_schema.add_field("color", DataType.VARCHAR, max_length=128)
+
+        schema.add_field(
+            "structA",
+            datatype=DataType.ARRAY,
+            element_type=DataType.STRUCT,
+            struct_schema=struct_schema,
+            max_capacity=default_capacity,
+        )
+        return schema
+
+    def _make_row(self, row_id, struct_elements):
+        return {
+            "id": row_id,
+            "doc_int": row_id,
+            "normal_vector": self._query_vec(),
+            "structA": [
+                {
+                    "embedding": _seed_vector(row_id * 1000 + offset),
+                    "int_val": elem["int_val"],
+                    "color": elem["color"],
+                }
+                for offset, elem in enumerate(struct_elements)
+            ],
+        }
+
+    @pytest.fixture(scope="class", autouse=True)
+    def setup_shared_collection(self, request):
+        """Create a deterministic FLAT-indexed collection with sealed and growing rows."""
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_ac_search")
+
+        schema = self._create_schema(client)
+        index_params = client.prepare_index_params()
+        index_params.add_index(
+            field_name="normal_vector",
+            index_type="FLAT",
+            metric_type="COSINE",
+        )
+        index_params.add_index(
+            field_name="structA[embedding]",
+            index_type="FLAT",
+            metric_type="COSINE",
+        )
+        self.create_collection(client, collection_name, schema=schema, index_params=index_params, force_teardown=False)
+
+        controlled_rows = [
+            self._make_row(0, [{"int_val": 5, "color": "Red"}]),
+            self._make_row(1, [{"int_val": 5, "color": "Blue"}, {"int_val": 11, "color": "Green"}]),
+            self._make_row(2, [{"int_val": 7, "color": "Red"}, {"int_val": 13, "color": "Blue"}]),
+            self._make_row(3, [{"int_val": 5, "color": "Red"}, {"int_val": 13, "color": "Blue"}]),
+            self._make_row(
+                4,
+                [{"int_val": 11, "color": "Blue"}, {"int_val": 17, "color": "Green"}],
+            ),
+            self._make_row(
+                5,
+                [
+                    {"int_val": 5, "color": "Red"},
+                    {"int_val": 11, "color": "Green"},
+                    {"int_val": 17, "color": "Blue"},
+                ],
+            ),
+            self._make_row(6, []),
+            self._make_row(7, [{"int_val": 23, "color": "Yellow"}]),
+        ]
+
+        self.insert(client, collection_name, controlled_rows[:4])
+        self.flush(client, collection_name)
+        self.insert(client, collection_name, controlled_rows[4:])
+        self.load_collection(client, collection_name)
+
+        request.cls.shared_client = client
+        request.cls.shared_collection = collection_name
+
+        yield
+
+        client.drop_collection(collection_name)
+
+    def _search_ids(self, expr):
+        results, check = self.search(
+            self.shared_client,
+            self.shared_collection,
+            data=[self._query_vec()],
+            anns_field="normal_vector",
+            search_params={"metric_type": "COSINE"},
+            filter=expr,
+            limit=self.SEARCH_LIMIT,
+            output_fields=["id"],
+            consistency_level="Strong",
+        )
+        assert check, expr
+        return sorted({hit["id"] for hit in results[0] if hit["id"] < 100})
+
+    def _element_search_ids(self, expr):
+        results, check = self.search(
+            self.shared_client,
+            self.shared_collection,
+            data=[_seed_vector(0)],
+            anns_field="structA[embedding]",
+            search_params={"metric_type": "COSINE"},
+            filter=expr,
+            limit=self.SEARCH_LIMIT,
+            output_fields=["id"],
+            consistency_level="Strong",
+        )
+        assert check, expr
+        return sorted({hit["id"] for hit in results[0] if hit["id"] < 100})
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_array_contains_struct_int_subfield(self):
         """
         target: array_contains on struct array int sub-field
-        method: array_contains query on struct sub-field of array type
-        expected: matching rows returned
+        method: search with array_contains(structA[int_val], 5)
+        expected: exact matching row ids returned
         """
-        pass
+        ids = self._search_ids("id < 100 && array_contains(structA[int_val], 5)")
+        assert ids == [0, 1, 3, 5]
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_array_contains_all_struct_varchar_subfield(self):
         """
         target: array_contains_all on struct varchar sub-field
-        method: array_contains_all query
-        expected: matching rows returned
+        method: search with array_contains_all(structA[color], ["Red", "Blue"])
+        expected: exact matching row ids returned
         """
-        pass
+        ids = self._search_ids('id < 100 && array_contains_all(structA[color], ["Red", "Blue"])')
+        assert ids == [2, 3, 5]
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_array_contains_any_struct_int_subfield(self):
         """
         target: array_contains_any on struct int sub-field
-        method: array_contains_any query
-        expected: matching rows returned
+        method: search with array_contains_any(structA[int_val], [13, 99])
+        expected: exact matching row ids returned
         """
-        pass
+        ids = self._search_ids("id < 100 && array_contains_any(structA[int_val], [13, 99])")
+        assert ids == [2, 3]
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_array_contains_combined_with_match(self):
         """
         target: array_contains combined with MATCH operator
-        method: MATCH_ANY(structA, array_contains($[tags], 5) && $[int_val] > 10)
-        expected: matching rows returned
+        method: array_contains(structA[int_val], 5) && MATCH_ANY(structA, $[int_val] > 10)
+        expected: exact matching row ids returned
         """
-        pass
+        ids = self._search_ids("id < 100 && array_contains(structA[int_val], 5) && MATCH_ANY(structA, $[int_val] > 10)")
+        assert ids == [1, 3, 5]
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_array_contains_combined_with_element_filter(self):
         """
         target: array_contains combined with element_filter
-        method: element_filter(structA, array_contains($[tags], 5))
-        expected: matching rows returned
+        method: element-level search with array_contains(structA[int_val], 5)
+                and element_filter(structA, $[color] == "Red")
+        expected: exact matching row ids returned
         """
-        pass
+        ids = self._element_search_ids(
+            'id < 100 && array_contains(structA[int_val], 5) && element_filter(structA, $[color] == "Red")'
+        )
+        assert ids == [0, 3, 5]
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_array_contains_empty_array(self):
         """
         target: array_contains on empty array sub-field
-        method: query where sub-field array is empty
+        method: search with row whose structA is empty
         expected: no match
         """
-        pass
+        ids = self._search_ids("id == 6 && array_contains(structA[int_val], 5)")
+        assert ids == []
 
 
 class TestMilvusClientStructArrayElementSearchMmap(TestMilvusClientV2Base):

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_element_search.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_element_search.py
@@ -6087,12 +6087,35 @@ class TestMilvusClientStructArrayElementQueryIterator(TestMilvusClientV2Base):
         iterator.close()
         return all_rows
 
-    @pytest.mark.xfail(
-        reason="milvus-io/milvus#49355: query_iterator over element_filter drops "
-        "trailing offsets of any row whose matched offsets span a page boundary "
-        "(server's element-level limit truncates mid-row; iterator advances pk > "
-        "last_pk, so the row's remaining offsets are never re-fetched)."
-    )
+    def _assert_match_query_and_iterator(self, client, collection_name, match_expr, predicate):
+        query_rows, _ = self.query(
+            client,
+            collection_name,
+            filter=match_expr,
+            output_fields=["id", "structA"],
+            limit=16384,
+            consistency_level="Strong",
+        )
+        query_ids = {r["id"] for r in query_rows}
+        assert len(query_ids) == len(query_rows), "one-shot query returned duplicated row ids"
+        for row in query_rows:
+            assert predicate(row["structA"]), f"row {row['id']} does not satisfy match predicate"
+
+        iterator, _ = self.query_iterator(
+            client,
+            collection_name,
+            batch_size=40,
+            filter=match_expr,
+            output_fields=["id", "structA"],
+            consistency_level="Strong",
+        )
+        iterator_rows = self._drain(iterator)
+        iterator_ids = {r["id"] for r in iterator_rows}
+        assert len(iterator_ids) == len(iterator_rows), "query_iterator returned duplicated row ids"
+        for row in iterator_rows:
+            assert predicate(row["structA"]), f"row {row['id']} does not satisfy match predicate"
+        assert iterator_ids == query_ids
+
     @pytest.mark.tags(CaseLabel.L1)
     def test_query_iterator_with_element_filter(self):
         """
@@ -6159,34 +6182,32 @@ class TestMilvusClientStructArrayElementQueryIterator(TestMilvusClientV2Base):
         collection_name = cf.gen_unique_str(f"{prefix}_qiter_match_{match_type.lower()}")
         self._setup_collection(client, collection_name)  # 3000 sealed + 500 growing
 
-        iterator, _ = self.query_iterator(
-            client,
-            collection_name,
-            batch_size=40,
-            filter=match_expr,
-            output_fields=["id", "structA"],
-        )
-        rows = self._drain(iterator)
-        ids = {r["id"] for r in rows}
-        assert len(ids) == len(rows), "duplicated row ids"
-        for row in rows:
-            assert predicate(row["structA"]), f"row {row['id']} does not satisfy {match_type}"
-
-        oneshot, _ = self.query(
-            client,
-            collection_name,
-            filter=match_expr,
-            output_fields=["id"],
-            limit=16384,
-        )
-        assert ids == {r["id"] for r in oneshot}
+        self._assert_match_query_and_iterator(client, collection_name, match_expr, predicate)
 
     @pytest.mark.xfail(
-        reason="milvus-io/milvus#49355: same root cause as "
-        "test_query_iterator_with_element_filter — server truncates within a row at "
-        "the element-level limit boundary; client cursor (pk > last_pk) cannot "
-        "recover the row's remaining offsets."
+        reason="milvus-io/milvus#49693: full StructArray output fails after release/load "
+        "when ArrayOfVector uses HNSW+COSINE index raw-data retrieve path"
     )
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_query_iterator_full_struct_output_after_reload(self):
+        """
+        target: query/query_iterator return full struct array output after release/load
+        method: query with output_fields=["id", "structA"], then release_collection +
+                load_collection and query with the same output fields again
+        expected: reload does not change full struct array output behavior
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_qiter_reload")
+        self._setup_collection(client, collection_name)  # 3000 sealed + 500 growing
+
+        match_expr = "match_all(structA, $[int_val] >= 0)"
+        predicate = lambda sa: all(e["int_val"] >= 0 for e in sa)
+        self._assert_match_query_and_iterator(client, collection_name, match_expr, predicate)
+
+        self.release_collection(client, collection_name)
+        self.load_collection(client, collection_name)
+        self._assert_match_query_and_iterator(client, collection_name, match_expr, predicate)
+
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("batch_size", [10, 50, 100])
     def test_query_iterator_element_filter_batch_size(self, batch_size):

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_element_search.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_element_search.py
@@ -6201,7 +6201,10 @@ class TestMilvusClientStructArrayElementQueryIterator(TestMilvusClientV2Base):
         self._setup_collection(client, collection_name)  # 3000 sealed + 500 growing
 
         match_expr = "match_all(structA, $[int_val] >= 0)"
-        predicate = lambda sa: all(e["int_val"] >= 0 for e in sa)
+
+        def predicate(sa):
+            return all(e["int_val"] >= 0 for e in sa)
+
         self._assert_match_query_and_iterator(client, collection_name, match_expr, predicate)
 
         self.release_collection(client, collection_name)

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_element_search.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_element_search.py
@@ -6165,6 +6165,10 @@ class TestMilvusClientStructArrayElementQueryIterator(TestMilvusClientV2Base):
         )
 
     @pytest.mark.tags(CaseLabel.L1)
+    @pytest.mark.xfail(
+        reason="milvus-io/milvus#49693: query_iterator full StructArray output can fail "
+        "when ArrayOfVector uses HNSW+COSINE index raw-data retrieve path"
+    )
     @pytest.mark.parametrize(
         "match_type,match_expr,predicate",
         [

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_element_search.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_element_search.py
@@ -6084,3 +6084,538 @@ class TestMilvusClientStructArrayElementSearchNoFilter(TestMilvusClientV2Base):
                 "err_msg": "only group by primary key is supported for element-level search",
             },
         )
+
+
+# ==================== Test Case 10: StructArray Index-Access in search() (PR #48987) ====================
+
+
+@pytest.mark.xdist_group("TestMilvusClientStructArrayIndexAccessSearch")
+class TestMilvusClientStructArrayIndexAccessSearch(TestMilvusClientV2Base):
+    """search() filter coverage for the same predicates verified by query in
+    TestMilvusClientStructArrayIndexAccess (PR #48987 + companion array ops).
+
+    Verification strategy:
+    - normal_vector uses FLAT index -> brute-force, recall=1.0 (exact ID set
+      assertions are independent of ANN behavior).
+    - Controlled rows share the same normal_vector as the query vector so they
+      sit at COSINE=1.0 (top of the result list); inert background rows use
+      diverse seeds -> always lower similarity.
+    - limit is set well above the controlled row count, so all controlled
+      rows that pass the filter are guaranteed to be returned.
+    - Each case still has >= 3500 rows total: 3000 sealed + 500 growing inert
+      background, controlled rows split across both segments.
+    """
+
+    SEARCH_VEC_SEED = 424242
+    SEARCH_LIMIT = 200
+
+    def _create_schema(self, client, dim=default_dim):
+        schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
+        schema.add_field(field_name="id", datatype=DataType.INT64, is_primary=True)
+        schema.add_field(field_name="doc_int", datatype=DataType.INT64)
+        schema.add_field(field_name="normal_vector", datatype=DataType.FLOAT_VECTOR, dim=dim)
+
+        struct_schema = client.create_struct_field_schema()
+        struct_schema.add_field("embedding", DataType.FLOAT_VECTOR, dim=dim)
+        struct_schema.add_field("int_val", DataType.INT64)
+        struct_schema.add_field("str_val", DataType.VARCHAR, max_length=65535)
+        struct_schema.add_field("color", DataType.VARCHAR, max_length=128)
+
+        schema.add_field(
+            "structA", datatype=DataType.ARRAY,
+            element_type=DataType.STRUCT,
+            struct_schema=struct_schema,
+            max_capacity=10,
+        )
+        return schema
+
+    def _query_vec(self):
+        return _seed_vector(self.SEARCH_VEC_SEED)
+
+    def _make_row(self, row_id, struct_elements):
+        """Controlled row: normal_vector == query vec so it sits at COSINE=1.0."""
+        return {
+            "id": row_id,
+            "doc_int": row_id,
+            "normal_vector": self._query_vec(),
+            "structA": [
+                {
+                    "embedding": _seed_vector(row_id * 1000 + j),
+                    "int_val": elem["int_val"],
+                    "str_val": elem.get("str_val", f"r{row_id}_e{j}"),
+                    "color": elem.get("color", "Red"),
+                }
+                for j, elem in enumerate(struct_elements)
+            ],
+        }
+
+    def _make_inert_row(self, row_id):
+        """Background row with diverse vector (low similarity to query vec)
+        and a single struct element that never matches controlled predicates."""
+        return {
+            "id": row_id,
+            "doc_int": row_id,
+            "normal_vector": _seed_vector(row_id + 999999),
+            "structA": [{
+                "embedding": _seed_vector(row_id * 1000),
+                "int_val": 0,
+                "str_val": f"inert_{row_id}",
+                "color": "Inert",
+            }],
+        }
+
+    def _setup_collection(self, client, collection_name, controlled_rows):
+        """3000 sealed inert + first half of controlled (sealed) +
+        500 growing inert + second half of controlled (growing).
+        normal_vector uses FLAT for recall=1.0."""
+        schema = self._create_schema(client)
+        index_params = client.prepare_index_params()
+        index_params.add_index(
+            field_name="normal_vector", index_type="FLAT", metric_type="COSINE",
+        )
+        index_params.add_index(
+            field_name="structA[embedding]", index_type="FLAT", metric_type="COSINE",
+        )
+        self.create_collection(client, collection_name, schema=schema,
+                               index_params=index_params)
+
+        bg_start = 100000
+        for start in range(0, default_nb, insert_batch_size):
+            batch = [self._make_inert_row(bg_start + start + k)
+                     for k in range(insert_batch_size)]
+            self.insert(client, collection_name, batch)
+
+        half = len(controlled_rows) // 2
+        sealed_part = controlled_rows[:half]
+        growing_part = controlled_rows[half:]
+        if sealed_part:
+            self.insert(client, collection_name, sealed_part)
+        self.flush(client, collection_name)
+
+        growing_bg = [self._make_inert_row(bg_start + default_nb + k)
+                      for k in range(default_growing_nb)]
+        self.insert(client, collection_name, growing_bg)
+        if growing_part:
+            self.insert(client, collection_name, growing_part)
+
+        self.load_collection(client, collection_name)
+
+    def _setup_collection_split(self, client, collection_name,
+                                 sealed_rows, growing_rows):
+        """Same as _setup_collection but with explicit sealed/growing row groups."""
+        schema = self._create_schema(client)
+        index_params = client.prepare_index_params()
+        index_params.add_index(
+            field_name="normal_vector", index_type="FLAT", metric_type="COSINE",
+        )
+        index_params.add_index(
+            field_name="structA[embedding]", index_type="FLAT", metric_type="COSINE",
+        )
+        self.create_collection(client, collection_name, schema=schema,
+                               index_params=index_params)
+
+        bg_start = 100000
+        for start in range(0, default_nb, insert_batch_size):
+            batch = [self._make_inert_row(bg_start + start + k)
+                     for k in range(insert_batch_size)]
+            self.insert(client, collection_name, batch)
+        if sealed_rows:
+            self.insert(client, collection_name, sealed_rows)
+        self.flush(client, collection_name)
+
+        growing_bg = [self._make_inert_row(bg_start + default_nb + k)
+                      for k in range(default_growing_nb)]
+        self.insert(client, collection_name, growing_bg)
+        if growing_rows:
+            self.insert(client, collection_name, growing_rows)
+
+        self.load_collection(client, collection_name)
+
+    def _search_ids(self, client, collection_name, expr, limit=None):
+        """Run search() with given filter, return sorted unique controlled IDs."""
+        results, check = self.search(
+            client, collection_name,
+            data=[self._query_vec()],
+            anns_field="normal_vector",
+            search_params={"metric_type": "COSINE"},
+            filter=expr,
+            limit=limit or self.SEARCH_LIMIT,
+            output_fields=["id"],
+        )
+        assert check, expr
+        return sorted({hit["id"] for hit in results[0] if hit["id"] < 100})
+
+    # ---- 10.1 search filter: structA[i][sub_field] == ----
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_search_index_access_eq(self):
+        """
+        target: structA[i][sub_field] == X usable as search() filter, exact recall
+        expected: hits exactly == predicted ID set (FLAT recall=1.0)
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_idx_search_eq")
+
+        rows = [
+            self._make_row(0, [{"int_val": 10}, {"int_val": 20}]),
+            self._make_row(1, [{"int_val": 100}, {"int_val": 200}]),
+            self._make_row(2, [{"int_val": 100}]),
+            self._make_row(3, [{"int_val": 50}, {"int_val": 100}]),
+            self._make_row(4, [{"int_val": 999}]),
+        ]
+        self._setup_collection(client, collection_name, rows)
+
+        ids = self._search_ids(
+            client, collection_name,
+            'id < 100 && structA[0][int_val] == 100',
+        )
+        assert ids == [1, 2], f"Expected [1, 2], got {ids}"
+
+    # ---- 10.2 search filter: comparison operators ----
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_search_index_access_comparison_operators(self):
+        """target: !=, >, >=, <, <= as search() filter, all exact."""
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_idx_search_cmp")
+
+        rows = [
+            self._make_row(i, [{"int_val": v}])
+            for i, v in enumerate([10, 20, 30, 40, 50])
+        ]
+        self._setup_collection(client, collection_name, rows)
+
+        cases = [
+            ('id < 100 && structA[0][int_val] != 30', [0, 1, 3, 4]),
+            ('id < 100 && structA[0][int_val] > 30', [3, 4]),
+            ('id < 100 && structA[0][int_val] >= 30', [2, 3, 4]),
+            ('id < 100 && structA[0][int_val] < 30', [0, 1]),
+            ('id < 100 && structA[0][int_val] <= 30', [0, 1, 2]),
+        ]
+        for expr, expected in cases:
+            ids = self._search_ids(client, collection_name, expr)
+            assert ids == expected, f"{expr}: expected {expected}, got {ids}"
+
+    # ---- 10.3 search filter: IN / NOT IN ----
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_search_index_access_in_not_in(self):
+        """target: IN / NOT IN as search() filter."""
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_idx_search_in")
+
+        rows = [
+            self._make_row(i, [{"int_val": v}])
+            for i, v in enumerate([10, 20, 30, 40, 50])
+        ]
+        self._setup_collection(client, collection_name, rows)
+
+        ids = self._search_ids(
+            client, collection_name,
+            'id < 100 && structA[0][int_val] in [10, 30, 50, 999]',
+        )
+        assert ids == [0, 2, 4], f"IN expected [0,2,4], got {ids}"
+
+        ids = self._search_ids(
+            client, collection_name,
+            'id < 100 && structA[0][int_val] not in [10, 30, 50]',
+        )
+        assert ids == [1, 3], f"NOT IN expected [1,3], got {ids}"
+
+    # ---- 10.4 search filter: range (forward + reverse) ----
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_search_index_access_range(self):
+        """target: forward and reverse range syntax as search() filter."""
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_idx_search_range")
+
+        rows = [
+            self._make_row(i, [{"int_val": v}])
+            for i, v in enumerate([10, 20, 30, 40, 50])
+        ]
+        self._setup_collection(client, collection_name, rows)
+
+        cases = [
+            ('id < 100 && 20 < structA[0][int_val] < 40', [2]),
+            ('id < 100 && 20 <= structA[0][int_val] <= 40', [1, 2, 3]),
+            ('id < 100 && 40 > structA[0][int_val] > 20', [2]),
+            ('id < 100 && 40 >= structA[0][int_val] >= 20', [1, 2, 3]),
+        ]
+        for expr, expected in cases:
+            ids = self._search_ids(client, collection_name, expr)
+            assert ids == expected, f"{expr}: expected {expected}, got {ids}"
+
+    # ---- 10.5 search filter: string sub-field ----
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_search_index_access_string_subfield(self):
+        """target: VARCHAR sub-field index access in search()."""
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_idx_search_str")
+
+        rows = [
+            self._make_row(0, [{"int_val": 1, "str_val": "apple"}]),
+            self._make_row(1, [{"int_val": 2, "str_val": "banana"}]),
+            self._make_row(2, [{"int_val": 3, "str_val": "apple"}]),
+            self._make_row(3, [{"int_val": 4, "str_val": "cherry"}]),
+        ]
+        self._setup_collection(client, collection_name, rows)
+
+        ids = self._search_ids(
+            client, collection_name,
+            'id < 100 && structA[0][str_val] == "apple"',
+        )
+        assert ids == [0, 2]
+
+        ids = self._search_ids(
+            client, collection_name,
+            'id < 100 && structA[0][str_val] in ["banana", "cherry"]',
+        )
+        assert ids == [1, 3]
+
+    # ---- 10.6 search filter: compound across indices ----
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_search_index_access_compound_indices(self):
+        """target: structA[0]... && structA[1]... compound predicate in search()."""
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_idx_search_compound")
+
+        rows = [
+            self._make_row(0, [{"int_val": 100}, {"int_val": 1}]),
+            self._make_row(1, [{"int_val": 100}, {"int_val": 50}]),
+            self._make_row(2, [{"int_val": 10}, {"int_val": 1}]),
+            self._make_row(3, [{"int_val": 200}, {"int_val": 5}]),
+            self._make_row(4, [{"int_val": 60}, {"int_val": 9}]),
+        ]
+        self._setup_collection(client, collection_name, rows)
+
+        ids = self._search_ids(
+            client, collection_name,
+            'id < 100 && structA[0][int_val] > 50 && structA[1][int_val] < 10',
+        )
+        assert ids == [0, 3, 4]
+
+        ids = self._search_ids(
+            client, collection_name,
+            'id < 100 && (structA[0][int_val] > 150 || structA[1][int_val] == 50)',
+        )
+        assert ids == [1, 3]
+
+    # ---- 10.7 search filter: array_contains exact ----
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_search_array_contains_exact(self):
+        """target: array_contains(structA[sub_field], v) in search() filter."""
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_idx_search_ac")
+
+        rows = [
+            self._make_row(0, [{"int_val": 100}]),
+            self._make_row(1, [{"int_val": 200}, {"int_val": 201}]),
+            self._make_row(2, [{"int_val": 301}, {"int_val": 302}]),
+            self._make_row(3, [{"int_val": 200}, {"int_val": 999}]),
+            self._make_row(4, [{"int_val": 700}, {"int_val": 100}]),
+        ]
+        self._setup_collection(client, collection_name, rows)
+
+        cases = [
+            ('id < 100 && array_contains(structA[int_val], 100)', [0, 4]),
+            ('id < 100 && array_contains(structA[int_val], 200)', [1, 3]),
+            ('id < 100 && array_contains(structA[int_val], 999)', [3]),
+            ('id < 100 && array_contains(structA[int_val], 12345)', []),
+        ]
+        for expr, expected in cases:
+            ids = self._search_ids(client, collection_name, expr)
+            assert ids == expected, f"{expr}: expected {expected}, got {ids}"
+
+    # ---- 10.8 search filter: array_contains_all / _any ----
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_search_array_contains_all_any(self):
+        """target: array_contains_all and array_contains_any in search()."""
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_idx_search_acall")
+
+        def _e(s):
+            return {"int_val": 0, "str_val": s}
+
+        rows = [
+            self._make_row(0, [_e("Red")]),
+            self._make_row(1, [_e("Red"), _e("Blue")]),
+            self._make_row(2, [_e("Blue"), _e("Green")]),
+            self._make_row(3, [_e("Red"), _e("Blue"), _e("Green")]),
+            self._make_row(4, [_e("Red"), _e("Green")]),
+        ]
+        self._setup_collection(client, collection_name, rows)
+
+        # ALL
+        cases_all = [
+            ('id < 100 && array_contains_all(structA[str_val], ["Red", "Blue"])',
+             [1, 3]),
+            ('id < 100 && array_contains_all(structA[str_val], ["Red", "Blue", "Green"])',
+             [3]),
+            ('id < 100 && array_contains_all(structA[str_val], ["Yellow"])', []),
+        ]
+        for expr, expected in cases_all:
+            ids = self._search_ids(client, collection_name, expr)
+            assert ids == expected, f"{expr}: expected {expected}, got {ids}"
+
+        # ANY
+        cases_any = [
+            ('id < 100 && array_contains_any(structA[str_val], ["Red", "Yellow"])',
+             [0, 1, 3, 4]),
+            ('id < 100 && array_contains_any(structA[str_val], ["Blue", "Green"])',
+             [1, 2, 3, 4]),
+            ('id < 100 && array_contains_any(structA[str_val], ["Yellow", "Magenta"])',
+             []),
+        ]
+        for expr, expected in cases_any:
+            ids = self._search_ids(client, collection_name, expr)
+            assert ids == expected, f"{expr}: expected {expected}, got {ids}"
+
+    # ---- 10.9 search filter: array_length exact ----
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_search_array_length_exact(self):
+        """target: array_length(structA[sub_field]) ==/>=/< in search() filter."""
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_idx_search_arrlen")
+
+        rows = [
+            self._make_row(i, [{"int_val": j} for j in range(i + 1)])
+            for i in range(5)
+        ]
+        self._setup_collection(client, collection_name, rows)
+
+        cases = [
+            ('id < 100 && array_length(structA[int_val]) == 3', [2]),
+            ('id < 100 && array_length(structA[int_val]) >= 4', [3, 4]),
+            ('id < 100 && array_length(structA[int_val]) < 3', [0, 1]),
+        ]
+        for expr, expected in cases:
+            ids = self._search_ids(client, collection_name, expr)
+            assert ids == expected, f"{expr}: expected {expected}, got {ids}"
+
+    # ---- 10.10 search per-segment consistency ----
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_search_index_access_sealed_growing_consistency(self):
+        """
+        target: search() filter produces equivalent per-segment results when
+                matching rows live in sealed vs growing.
+        method: mirrored controlled groups (sealed ids 0..4, growing ids 5..9
+                with identical first-element int_val pattern).
+        expected: per-segment subsets are exact and isomorphic.
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_idx_search_segments")
+
+        pattern = [10, 20, 30, 40, 50]
+        sealed_rows = [
+            self._make_row(i, [{"int_val": v}]) for i, v in enumerate(pattern)
+        ]
+        growing_rows = [
+            self._make_row(i + 5, [{"int_val": v}]) for i, v in enumerate(pattern)
+        ]
+        self._setup_collection_split(client, collection_name, sealed_rows, growing_rows)
+
+        cases = [
+            ('id < 100 && structA[0][int_val] == 30', [2], [7]),
+            ('id < 100 && structA[0][int_val] >= 30', [2, 3, 4], [7, 8, 9]),
+            ('id < 100 && structA[0][int_val] in [10, 50]', [0, 4], [5, 9]),
+        ]
+        for expr, exp_sealed, exp_growing in cases:
+            ids = self._search_ids(client, collection_name, expr)
+            sealed_part = [i for i in ids if i < 5]
+            growing_part = [i for i in ids if 5 <= i < 100]
+            assert sealed_part == exp_sealed, (
+                f"{expr}: sealed expected {exp_sealed}, got {sealed_part}"
+            )
+            assert growing_part == exp_growing, (
+                f"{expr}: growing expected {exp_growing}, got {growing_part}"
+            )
+            assert [i + 5 for i in sealed_part] == growing_part, (
+                f"{expr}: sealed/growing not mirrored: "
+                f"sealed={sealed_part} growing={growing_part}"
+            )
+
+    # ---- 10.11 search after delete ----
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_search_index_access_after_delete(self):
+        """target: search filter reflects deletions across both segments."""
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_idx_search_delete")
+
+        sealed_rows = [
+            self._make_row(i, [{"int_val": v}])
+            for i, v in enumerate([10, 20, 30, 40, 50])
+        ]
+        growing_rows = [
+            self._make_row(i + 5, [{"int_val": v}])
+            for i, v in enumerate([10, 20, 30, 40, 50])
+        ]
+        self._setup_collection_split(client, collection_name, sealed_rows, growing_rows)
+
+        # Baseline
+        ids = self._search_ids(
+            client, collection_name,
+            'id < 100 && structA[0][int_val] >= 30',
+        )
+        assert ids == [2, 3, 4, 7, 8, 9]
+
+        # Delete 4 (sealed match), 7 (growing match), 0 (non-matching)
+        self.delete(client, collection_name, ids=[4, 7, 0])
+        import time
+        time.sleep(1)
+
+        ids = self._search_ids(
+            client, collection_name,
+            'id < 100 && structA[0][int_val] >= 30',
+        )
+        assert ids == [2, 3, 8, 9], f"After delete expected [2,3,8,9], got {ids}"
+
+    # ---- 10.12 search after upsert ----
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_search_index_access_after_upsert(self):
+        """target: search filter reflects upsert that changes the indexed value."""
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_idx_search_upsert")
+
+        sealed_rows = [
+            self._make_row(i, [{"int_val": v}])
+            for i, v in enumerate([10, 20, 30, 40, 50])
+        ]
+        growing_rows = [
+            self._make_row(i + 5, [{"int_val": v}])
+            for i, v in enumerate([10, 20, 30, 40, 50])
+        ]
+        self._setup_collection_split(client, collection_name, sealed_rows, growing_rows)
+
+        # Baseline
+        ids = self._search_ids(
+            client, collection_name,
+            'id < 100 && structA[0][int_val] >= 30',
+        )
+        assert ids == [2, 3, 4, 7, 8, 9]
+
+        # id 1 sealed (20 -> 100, becomes match)
+        # id 9 growing (50 -> 5, drops out)
+        upserts = [
+            self._make_row(1, [{"int_val": 100}]),
+            self._make_row(9, [{"int_val": 5}]),
+        ]
+        self.upsert(client, collection_name, upserts)
+        import time
+        time.sleep(1)
+
+        ids = self._search_ids(
+            client, collection_name,
+            'id < 100 && structA[0][int_val] >= 30',
+        )
+        assert ids == [1, 2, 3, 4, 7, 8], (
+            f"After upsert expected [1,2,3,4,7,8], got {ids}"
+        )

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_element_search.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_element_search.py
@@ -10,7 +10,6 @@ from common.constants import *  # noqa
 from pymilvus import AnnSearchRequest, DataType, RRFRanker, WeightedRanker
 from pymilvus.client.embedding_list import EmbeddingList
 from utils.util_log import test_log as log
-from utils.util_pymilvus import *  # noqa: F403
 
 prefix = "struct_elem_search"
 epsilon = 0.001
@@ -6121,7 +6120,8 @@ class TestMilvusClientStructArrayIndexAccessSearch(TestMilvusClientV2Base):
         struct_schema.add_field("color", DataType.VARCHAR, max_length=128)
 
         schema.add_field(
-            "structA", datatype=DataType.ARRAY,
+            "structA",
+            datatype=DataType.ARRAY,
             element_type=DataType.STRUCT,
             struct_schema=struct_schema,
             max_capacity=10,
@@ -6155,12 +6155,14 @@ class TestMilvusClientStructArrayIndexAccessSearch(TestMilvusClientV2Base):
             "id": row_id,
             "doc_int": row_id,
             "normal_vector": _seed_vector(row_id + 999999),
-            "structA": [{
-                "embedding": _seed_vector(row_id * 1000),
-                "int_val": 0,
-                "str_val": f"inert_{row_id}",
-                "color": "Inert",
-            }],
+            "structA": [
+                {
+                    "embedding": _seed_vector(row_id * 1000),
+                    "int_val": 0,
+                    "str_val": f"inert_{row_id}",
+                    "color": "Inert",
+                }
+            ],
         }
 
     def _setup_collection(self, client, collection_name, controlled_rows):
@@ -6170,18 +6172,20 @@ class TestMilvusClientStructArrayIndexAccessSearch(TestMilvusClientV2Base):
         schema = self._create_schema(client)
         index_params = client.prepare_index_params()
         index_params.add_index(
-            field_name="normal_vector", index_type="FLAT", metric_type="COSINE",
+            field_name="normal_vector",
+            index_type="FLAT",
+            metric_type="COSINE",
         )
         index_params.add_index(
-            field_name="structA[embedding]", index_type="FLAT", metric_type="COSINE",
+            field_name="structA[embedding]",
+            index_type="FLAT",
+            metric_type="COSINE",
         )
-        self.create_collection(client, collection_name, schema=schema,
-                               index_params=index_params)
+        self.create_collection(client, collection_name, schema=schema, index_params=index_params)
 
         bg_start = 100000
         for start in range(0, default_nb, insert_batch_size):
-            batch = [self._make_inert_row(bg_start + start + k)
-                     for k in range(insert_batch_size)]
+            batch = [self._make_inert_row(bg_start + start + k) for k in range(insert_batch_size)]
             self.insert(client, collection_name, batch)
 
         half = len(controlled_rows) // 2
@@ -6191,39 +6195,38 @@ class TestMilvusClientStructArrayIndexAccessSearch(TestMilvusClientV2Base):
             self.insert(client, collection_name, sealed_part)
         self.flush(client, collection_name)
 
-        growing_bg = [self._make_inert_row(bg_start + default_nb + k)
-                      for k in range(default_growing_nb)]
+        growing_bg = [self._make_inert_row(bg_start + default_nb + k) for k in range(default_growing_nb)]
         self.insert(client, collection_name, growing_bg)
         if growing_part:
             self.insert(client, collection_name, growing_part)
 
         self.load_collection(client, collection_name)
 
-    def _setup_collection_split(self, client, collection_name,
-                                 sealed_rows, growing_rows):
+    def _setup_collection_split(self, client, collection_name, sealed_rows, growing_rows):
         """Same as _setup_collection but with explicit sealed/growing row groups."""
         schema = self._create_schema(client)
         index_params = client.prepare_index_params()
         index_params.add_index(
-            field_name="normal_vector", index_type="FLAT", metric_type="COSINE",
+            field_name="normal_vector",
+            index_type="FLAT",
+            metric_type="COSINE",
         )
         index_params.add_index(
-            field_name="structA[embedding]", index_type="FLAT", metric_type="COSINE",
+            field_name="structA[embedding]",
+            index_type="FLAT",
+            metric_type="COSINE",
         )
-        self.create_collection(client, collection_name, schema=schema,
-                               index_params=index_params)
+        self.create_collection(client, collection_name, schema=schema, index_params=index_params)
 
         bg_start = 100000
         for start in range(0, default_nb, insert_batch_size):
-            batch = [self._make_inert_row(bg_start + start + k)
-                     for k in range(insert_batch_size)]
+            batch = [self._make_inert_row(bg_start + start + k) for k in range(insert_batch_size)]
             self.insert(client, collection_name, batch)
         if sealed_rows:
             self.insert(client, collection_name, sealed_rows)
         self.flush(client, collection_name)
 
-        growing_bg = [self._make_inert_row(bg_start + default_nb + k)
-                      for k in range(default_growing_nb)]
+        growing_bg = [self._make_inert_row(bg_start + default_nb + k) for k in range(default_growing_nb)]
         self.insert(client, collection_name, growing_bg)
         if growing_rows:
             self.insert(client, collection_name, growing_rows)
@@ -6233,7 +6236,8 @@ class TestMilvusClientStructArrayIndexAccessSearch(TestMilvusClientV2Base):
     def _search_ids(self, client, collection_name, expr, limit=None):
         """Run search() with given filter, return sorted unique controlled IDs."""
         results, check = self.search(
-            client, collection_name,
+            client,
+            collection_name,
             data=[self._query_vec()],
             anns_field="normal_vector",
             search_params={"metric_type": "COSINE"},
@@ -6265,8 +6269,9 @@ class TestMilvusClientStructArrayIndexAccessSearch(TestMilvusClientV2Base):
         self._setup_collection(client, collection_name, rows)
 
         ids = self._search_ids(
-            client, collection_name,
-            'id < 100 && structA[0][int_val] == 100',
+            client,
+            collection_name,
+            "id < 100 && structA[0][int_val] == 100",
         )
         assert ids == [1, 2], f"Expected [1, 2], got {ids}"
 
@@ -6278,18 +6283,15 @@ class TestMilvusClientStructArrayIndexAccessSearch(TestMilvusClientV2Base):
         client = self._client()
         collection_name = cf.gen_unique_str(f"{prefix}_idx_search_cmp")
 
-        rows = [
-            self._make_row(i, [{"int_val": v}])
-            for i, v in enumerate([10, 20, 30, 40, 50])
-        ]
+        rows = [self._make_row(i, [{"int_val": v}]) for i, v in enumerate([10, 20, 30, 40, 50])]
         self._setup_collection(client, collection_name, rows)
 
         cases = [
-            ('id < 100 && structA[0][int_val] != 30', [0, 1, 3, 4]),
-            ('id < 100 && structA[0][int_val] > 30', [3, 4]),
-            ('id < 100 && structA[0][int_val] >= 30', [2, 3, 4]),
-            ('id < 100 && structA[0][int_val] < 30', [0, 1]),
-            ('id < 100 && structA[0][int_val] <= 30', [0, 1, 2]),
+            ("id < 100 && structA[0][int_val] != 30", [0, 1, 3, 4]),
+            ("id < 100 && structA[0][int_val] > 30", [3, 4]),
+            ("id < 100 && structA[0][int_val] >= 30", [2, 3, 4]),
+            ("id < 100 && structA[0][int_val] < 30", [0, 1]),
+            ("id < 100 && structA[0][int_val] <= 30", [0, 1, 2]),
         ]
         for expr, expected in cases:
             ids = self._search_ids(client, collection_name, expr)
@@ -6303,21 +6305,20 @@ class TestMilvusClientStructArrayIndexAccessSearch(TestMilvusClientV2Base):
         client = self._client()
         collection_name = cf.gen_unique_str(f"{prefix}_idx_search_in")
 
-        rows = [
-            self._make_row(i, [{"int_val": v}])
-            for i, v in enumerate([10, 20, 30, 40, 50])
-        ]
+        rows = [self._make_row(i, [{"int_val": v}]) for i, v in enumerate([10, 20, 30, 40, 50])]
         self._setup_collection(client, collection_name, rows)
 
         ids = self._search_ids(
-            client, collection_name,
-            'id < 100 && structA[0][int_val] in [10, 30, 50, 999]',
+            client,
+            collection_name,
+            "id < 100 && structA[0][int_val] in [10, 30, 50, 999]",
         )
         assert ids == [0, 2, 4], f"IN expected [0,2,4], got {ids}"
 
         ids = self._search_ids(
-            client, collection_name,
-            'id < 100 && structA[0][int_val] not in [10, 30, 50]',
+            client,
+            collection_name,
+            "id < 100 && structA[0][int_val] not in [10, 30, 50]",
         )
         assert ids == [1, 3], f"NOT IN expected [1,3], got {ids}"
 
@@ -6329,17 +6330,14 @@ class TestMilvusClientStructArrayIndexAccessSearch(TestMilvusClientV2Base):
         client = self._client()
         collection_name = cf.gen_unique_str(f"{prefix}_idx_search_range")
 
-        rows = [
-            self._make_row(i, [{"int_val": v}])
-            for i, v in enumerate([10, 20, 30, 40, 50])
-        ]
+        rows = [self._make_row(i, [{"int_val": v}]) for i, v in enumerate([10, 20, 30, 40, 50])]
         self._setup_collection(client, collection_name, rows)
 
         cases = [
-            ('id < 100 && 20 < structA[0][int_val] < 40', [2]),
-            ('id < 100 && 20 <= structA[0][int_val] <= 40', [1, 2, 3]),
-            ('id < 100 && 40 > structA[0][int_val] > 20', [2]),
-            ('id < 100 && 40 >= structA[0][int_val] >= 20', [1, 2, 3]),
+            ("id < 100 && 20 < structA[0][int_val] < 40", [2]),
+            ("id < 100 && 20 <= structA[0][int_val] <= 40", [1, 2, 3]),
+            ("id < 100 && 40 > structA[0][int_val] > 20", [2]),
+            ("id < 100 && 40 >= structA[0][int_val] >= 20", [1, 2, 3]),
         ]
         for expr, expected in cases:
             ids = self._search_ids(client, collection_name, expr)
@@ -6362,13 +6360,15 @@ class TestMilvusClientStructArrayIndexAccessSearch(TestMilvusClientV2Base):
         self._setup_collection(client, collection_name, rows)
 
         ids = self._search_ids(
-            client, collection_name,
+            client,
+            collection_name,
             'id < 100 && structA[0][str_val] == "apple"',
         )
         assert ids == [0, 2]
 
         ids = self._search_ids(
-            client, collection_name,
+            client,
+            collection_name,
             'id < 100 && structA[0][str_val] in ["banana", "cherry"]',
         )
         assert ids == [1, 3]
@@ -6391,14 +6391,16 @@ class TestMilvusClientStructArrayIndexAccessSearch(TestMilvusClientV2Base):
         self._setup_collection(client, collection_name, rows)
 
         ids = self._search_ids(
-            client, collection_name,
-            'id < 100 && structA[0][int_val] > 50 && structA[1][int_val] < 10',
+            client,
+            collection_name,
+            "id < 100 && structA[0][int_val] > 50 && structA[1][int_val] < 10",
         )
         assert ids == [0, 3, 4]
 
         ids = self._search_ids(
-            client, collection_name,
-            'id < 100 && (structA[0][int_val] > 150 || structA[1][int_val] == 50)',
+            client,
+            collection_name,
+            "id < 100 && (structA[0][int_val] > 150 || structA[1][int_val] == 50)",
         )
         assert ids == [1, 3]
 
@@ -6420,10 +6422,10 @@ class TestMilvusClientStructArrayIndexAccessSearch(TestMilvusClientV2Base):
         self._setup_collection(client, collection_name, rows)
 
         cases = [
-            ('id < 100 && array_contains(structA[int_val], 100)', [0, 4]),
-            ('id < 100 && array_contains(structA[int_val], 200)', [1, 3]),
-            ('id < 100 && array_contains(structA[int_val], 999)', [3]),
-            ('id < 100 && array_contains(structA[int_val], 12345)', []),
+            ("id < 100 && array_contains(structA[int_val], 100)", [0, 4]),
+            ("id < 100 && array_contains(structA[int_val], 200)", [1, 3]),
+            ("id < 100 && array_contains(structA[int_val], 999)", [3]),
+            ("id < 100 && array_contains(structA[int_val], 12345)", []),
         ]
         for expr, expected in cases:
             ids = self._search_ids(client, collection_name, expr)
@@ -6451,10 +6453,8 @@ class TestMilvusClientStructArrayIndexAccessSearch(TestMilvusClientV2Base):
 
         # ALL
         cases_all = [
-            ('id < 100 && array_contains_all(structA[str_val], ["Red", "Blue"])',
-             [1, 3]),
-            ('id < 100 && array_contains_all(structA[str_val], ["Red", "Blue", "Green"])',
-             [3]),
+            ('id < 100 && array_contains_all(structA[str_val], ["Red", "Blue"])', [1, 3]),
+            ('id < 100 && array_contains_all(structA[str_val], ["Red", "Blue", "Green"])', [3]),
             ('id < 100 && array_contains_all(structA[str_val], ["Yellow"])', []),
         ]
         for expr, expected in cases_all:
@@ -6463,12 +6463,9 @@ class TestMilvusClientStructArrayIndexAccessSearch(TestMilvusClientV2Base):
 
         # ANY
         cases_any = [
-            ('id < 100 && array_contains_any(structA[str_val], ["Red", "Yellow"])',
-             [0, 1, 3, 4]),
-            ('id < 100 && array_contains_any(structA[str_val], ["Blue", "Green"])',
-             [1, 2, 3, 4]),
-            ('id < 100 && array_contains_any(structA[str_val], ["Yellow", "Magenta"])',
-             []),
+            ('id < 100 && array_contains_any(structA[str_val], ["Red", "Yellow"])', [0, 1, 3, 4]),
+            ('id < 100 && array_contains_any(structA[str_val], ["Blue", "Green"])', [1, 2, 3, 4]),
+            ('id < 100 && array_contains_any(structA[str_val], ["Yellow", "Magenta"])', []),
         ]
         for expr, expected in cases_any:
             ids = self._search_ids(client, collection_name, expr)
@@ -6482,16 +6479,13 @@ class TestMilvusClientStructArrayIndexAccessSearch(TestMilvusClientV2Base):
         client = self._client()
         collection_name = cf.gen_unique_str(f"{prefix}_idx_search_arrlen")
 
-        rows = [
-            self._make_row(i, [{"int_val": j} for j in range(i + 1)])
-            for i in range(5)
-        ]
+        rows = [self._make_row(i, [{"int_val": j} for j in range(i + 1)]) for i in range(5)]
         self._setup_collection(client, collection_name, rows)
 
         cases = [
-            ('id < 100 && array_length(structA[int_val]) == 3', [2]),
-            ('id < 100 && array_length(structA[int_val]) >= 4', [3, 4]),
-            ('id < 100 && array_length(structA[int_val]) < 3', [0, 1]),
+            ("id < 100 && array_length(structA[int_val]) == 3", [2]),
+            ("id < 100 && array_length(structA[int_val]) >= 4", [3, 4]),
+            ("id < 100 && array_length(structA[int_val]) < 3", [0, 1]),
         ]
         for expr, expected in cases:
             ids = self._search_ids(client, collection_name, expr)
@@ -6512,32 +6506,23 @@ class TestMilvusClientStructArrayIndexAccessSearch(TestMilvusClientV2Base):
         collection_name = cf.gen_unique_str(f"{prefix}_idx_search_segments")
 
         pattern = [10, 20, 30, 40, 50]
-        sealed_rows = [
-            self._make_row(i, [{"int_val": v}]) for i, v in enumerate(pattern)
-        ]
-        growing_rows = [
-            self._make_row(i + 5, [{"int_val": v}]) for i, v in enumerate(pattern)
-        ]
+        sealed_rows = [self._make_row(i, [{"int_val": v}]) for i, v in enumerate(pattern)]
+        growing_rows = [self._make_row(i + 5, [{"int_val": v}]) for i, v in enumerate(pattern)]
         self._setup_collection_split(client, collection_name, sealed_rows, growing_rows)
 
         cases = [
-            ('id < 100 && structA[0][int_val] == 30', [2], [7]),
-            ('id < 100 && structA[0][int_val] >= 30', [2, 3, 4], [7, 8, 9]),
-            ('id < 100 && structA[0][int_val] in [10, 50]', [0, 4], [5, 9]),
+            ("id < 100 && structA[0][int_val] == 30", [2], [7]),
+            ("id < 100 && structA[0][int_val] >= 30", [2, 3, 4], [7, 8, 9]),
+            ("id < 100 && structA[0][int_val] in [10, 50]", [0, 4], [5, 9]),
         ]
         for expr, exp_sealed, exp_growing in cases:
             ids = self._search_ids(client, collection_name, expr)
             sealed_part = [i for i in ids if i < 5]
             growing_part = [i for i in ids if 5 <= i < 100]
-            assert sealed_part == exp_sealed, (
-                f"{expr}: sealed expected {exp_sealed}, got {sealed_part}"
-            )
-            assert growing_part == exp_growing, (
-                f"{expr}: growing expected {exp_growing}, got {growing_part}"
-            )
+            assert sealed_part == exp_sealed, f"{expr}: sealed expected {exp_sealed}, got {sealed_part}"
+            assert growing_part == exp_growing, f"{expr}: growing expected {exp_growing}, got {growing_part}"
             assert [i + 5 for i in sealed_part] == growing_part, (
-                f"{expr}: sealed/growing not mirrored: "
-                f"sealed={sealed_part} growing={growing_part}"
+                f"{expr}: sealed/growing not mirrored: sealed={sealed_part} growing={growing_part}"
             )
 
     # ---- 10.11 search after delete ----
@@ -6548,31 +6533,28 @@ class TestMilvusClientStructArrayIndexAccessSearch(TestMilvusClientV2Base):
         client = self._client()
         collection_name = cf.gen_unique_str(f"{prefix}_idx_search_delete")
 
-        sealed_rows = [
-            self._make_row(i, [{"int_val": v}])
-            for i, v in enumerate([10, 20, 30, 40, 50])
-        ]
-        growing_rows = [
-            self._make_row(i + 5, [{"int_val": v}])
-            for i, v in enumerate([10, 20, 30, 40, 50])
-        ]
+        sealed_rows = [self._make_row(i, [{"int_val": v}]) for i, v in enumerate([10, 20, 30, 40, 50])]
+        growing_rows = [self._make_row(i + 5, [{"int_val": v}]) for i, v in enumerate([10, 20, 30, 40, 50])]
         self._setup_collection_split(client, collection_name, sealed_rows, growing_rows)
 
         # Baseline
         ids = self._search_ids(
-            client, collection_name,
-            'id < 100 && structA[0][int_val] >= 30',
+            client,
+            collection_name,
+            "id < 100 && structA[0][int_val] >= 30",
         )
         assert ids == [2, 3, 4, 7, 8, 9]
 
         # Delete 4 (sealed match), 7 (growing match), 0 (non-matching)
         self.delete(client, collection_name, ids=[4, 7, 0])
         import time
+
         time.sleep(1)
 
         ids = self._search_ids(
-            client, collection_name,
-            'id < 100 && structA[0][int_val] >= 30',
+            client,
+            collection_name,
+            "id < 100 && structA[0][int_val] >= 30",
         )
         assert ids == [2, 3, 8, 9], f"After delete expected [2,3,8,9], got {ids}"
 
@@ -6584,20 +6566,15 @@ class TestMilvusClientStructArrayIndexAccessSearch(TestMilvusClientV2Base):
         client = self._client()
         collection_name = cf.gen_unique_str(f"{prefix}_idx_search_upsert")
 
-        sealed_rows = [
-            self._make_row(i, [{"int_val": v}])
-            for i, v in enumerate([10, 20, 30, 40, 50])
-        ]
-        growing_rows = [
-            self._make_row(i + 5, [{"int_val": v}])
-            for i, v in enumerate([10, 20, 30, 40, 50])
-        ]
+        sealed_rows = [self._make_row(i, [{"int_val": v}]) for i, v in enumerate([10, 20, 30, 40, 50])]
+        growing_rows = [self._make_row(i + 5, [{"int_val": v}]) for i, v in enumerate([10, 20, 30, 40, 50])]
         self._setup_collection_split(client, collection_name, sealed_rows, growing_rows)
 
         # Baseline
         ids = self._search_ids(
-            client, collection_name,
-            'id < 100 && structA[0][int_val] >= 30',
+            client,
+            collection_name,
+            "id < 100 && structA[0][int_val] >= 30",
         )
         assert ids == [2, 3, 4, 7, 8, 9]
 
@@ -6609,12 +6586,12 @@ class TestMilvusClientStructArrayIndexAccessSearch(TestMilvusClientV2Base):
         ]
         self.upsert(client, collection_name, upserts)
         import time
+
         time.sleep(1)
 
         ids = self._search_ids(
-            client, collection_name,
-            'id < 100 && structA[0][int_val] >= 30',
+            client,
+            collection_name,
+            "id < 100 && structA[0][int_val] >= 30",
         )
-        assert ids == [1, 2, 3, 4, 7, 8], (
-            f"After upsert expected [1,2,3,4,7,8], got {ids}"
-        )
+        assert ids == [1, 2, 3, 4, 7, 8], f"After upsert expected [1,2,3,4,7,8], got {ids}"

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_element_search.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_element_search.py
@@ -6089,7 +6089,6 @@ class TestMilvusClientStructArrayElementSearchNoFilter(TestMilvusClientV2Base):
 # ==================== Test Case 10: StructArray Index-Access in search() (PR #48987) ====================
 
 
-@pytest.mark.xdist_group("TestMilvusClientStructArrayIndexAccessSearch")
 class TestMilvusClientStructArrayIndexAccessSearch(TestMilvusClientV2Base):
     """search() filter coverage for the same predicates verified by query in
     TestMilvusClientStructArrayIndexAccess (PR #48987 + companion array ops).

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_element_search.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_element_search.py
@@ -6165,15 +6165,25 @@ class TestMilvusClientStructArrayElementQueryIterator(TestMilvusClientV2Base):
         )
 
     @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.xfail(
-        reason="milvus-io/milvus#49693: query_iterator full StructArray output can fail "
-        "when ArrayOfVector uses HNSW+COSINE index raw-data retrieve path"
-    )
     @pytest.mark.parametrize(
         "match_type,match_expr,predicate",
         [
-            ("ANY", 'match_any(structA, $[color] == "Red")', lambda sa: any(e["color"] == "Red" for e in sa)),
-            ("ALL", "match_all(structA, $[int_val] >= 0)", lambda sa: all(e["int_val"] >= 0 for e in sa)),
+            pytest.param(
+                "ANY",
+                'match_any(structA, $[color] == "Red")',
+                lambda sa: any(e["color"] == "Red" for e in sa),
+                marks=pytest.mark.skip(
+                    reason="milvus-io/milvus#49755: query_iterator + match_any can trigger ASan abort"
+                ),
+            ),
+            pytest.param(
+                "ALL",
+                "match_all(structA, $[int_val] >= 0)",
+                lambda sa: all(e["int_val"] >= 0 for e in sa),
+                marks=pytest.mark.skip(
+                    reason="milvus-io/milvus#49693: query_iterator full StructArray output can fail"
+                ),
+            ),
         ],
     )
     def test_query_iterator_with_match_family(self, match_type, match_expr, predicate):
@@ -6188,7 +6198,7 @@ class TestMilvusClientStructArrayElementQueryIterator(TestMilvusClientV2Base):
 
         self._assert_match_query_and_iterator(client, collection_name, match_expr, predicate)
 
-    @pytest.mark.xfail(
+    @pytest.mark.skip(
         reason="milvus-io/milvus#49693: full StructArray output fails after release/load "
         "when ArrayOfVector uses HNSW+COSINE index raw-data retrieve path"
     )


### PR DESCRIPTION
## Summary

End-to-end correctness tests for struct array filter expressions in both
`query()` and `search()`, covering:

- **Index access** `structA[i][sub_field]` — newly introduced by PR #48987
- **`array_contains` / `array_contains_all` / `array_contains_any`** — exact
  ground-truth `==` assertions to detect false negatives (the existing
  Test Case 1 only checks no-false-positives via per-hit walking)
- **`array_length(structA[sub_field])`** — positive cases plus rejection
  of `array_length(structA[i][sub_field])` (grammar disallowed)

## Why

Every case asserts **exact ID sets** (no false negatives AND no false
positives) instead of subset / per-hit checks, so any drop in recall or
spurious match fails the test. Coverage spans:

- All comparison operators (`==`, `!=`, `>`, `>=`, `<`, `<=`)
- `IN` / `NOT IN`
- Forward / reverse range syntax (`a < x < b` and `b > x > a`)
- String sub-field
- Compound predicates across positions (`structA[0]... && structA[1]...`)
- Doc-level filter combination
- Out-of-bounds index (rows shorter than the requested index)
- Parser-error negative cases (missing field, swapped form, indexed-form
  passed to `array_length`)
- **Per-segment consistency**: mirrored controlled rows in sealed vs
  growing produce mirrored result sets
- **After `delete`** and **after `upsert`** (both matching and
  non-matching rows, cross-segment)

## Layout

- query: `TestMilvusClientStructArrayIndexAccess` (19 cases) in
  `test_milvus_client_struct_array_element_query.py`
- search: `TestMilvusClientStructArrayIndexAccessSearch` (12 cases) in
  `test_milvus_client_struct_array_element_search.py`
  - uses FLAT index + controlled vector layout (controlled rows share
    the query vector at COSINE=1.0) so search recall is 1.0 and exact
    ID set assertions are valid

Each case uses **>= 3500 rows** (3000 sealed + 500 growing inert
background plus controlled rows split across both segments).

## Test plan

- [x] verified locally on a Milvus standalone instance built from PR
  #48987 (commit `0c5a964ea0`): **31 / 31 passed in 387.54s**
- [x] each case scoped to `id < 100` so inert background rows cannot
  contaminate strict-equality assertions

issue: #42148