### PR TITLE
fix: authentication issue for built-in Web UI at port 9091

### DIFF
--- a/internal/distributed/proxy/service.go
+++ b/internal/distributed/proxy/service.go
@@ -88,6 +88,12 @@ var (
 
 const apiPathPrefix = "/api/v1"
 
+// webUIRouterRegistrar is satisfied by the real proxy.Proxy and can also be
+// satisfied by lightweight test stubs, avoiding a dependency on the concrete type.
+type webUIRouterRegistrar interface {
+	RegisterRestRouter(router gin.IRouter)
+}
+
 // Server is the Proxy Server
 type Server struct {
 	grpc_health_v1.UnimplementedHealthServer
@@ -180,10 +186,8 @@ func (s *Server) registerHTTPServer() {
 	// built-in WebUI regardless of the authorizationEnabled setting; the WebUI
 	// frontend has no mechanism to supply user credentials.
 	// Telemetry routes (_telemetry/*) carry their own per-handler auth middleware.
-	if p, ok := s.proxy.(*proxy.Proxy); ok {
-		webuiGroup := metricsGinHandler.Group(apiPathPrefix)
-		webuiGroup.Use(httpserver.RequestHandlerFunc)
-		p.RegisterRestRouter(webuiGroup)
+	if r, ok := s.proxy.(webUIRouterRegistrar); ok {
+		registerWebUIRoutes(metricsGinHandler, r)
 	}
 
 	mhttp.Register(&mhttp.Handler{
@@ -191,6 +195,14 @@ func (s *Server) registerHTTPServer() {
 		HandlerFunc: nil,
 		Handler:     metricsGinHandler.Handler(),
 	})
+}
+
+// registerWebUIRoutes creates a gin group without the user-auth middleware and
+// delegates route registration to r. Extracted for testability.
+func registerWebUIRoutes(engine *gin.Engine, r webUIRouterRegistrar) {
+	webuiGroup := engine.Group(apiPathPrefix)
+	webuiGroup.Use(httpserver.RequestHandlerFunc)
+	r.RegisterRestRouter(webuiGroup)
 }
 
 func (s *Server) startHTTPServer(errChan chan error) {

--- a/internal/distributed/proxy/service.go
+++ b/internal/distributed/proxy/service.go
@@ -164,18 +164,28 @@ func (s *Server) registerHTTPServer() {
 		gin.SetMode(gin.ReleaseMode)
 	}
 	metricsGinHandler := gin.Default()
+
+	// SDK REST API routes: require user authentication when authorization is enabled.
 	apiv1 := metricsGinHandler.Group(apiPathPrefix)
 	apiv1.Use(httpserver.RequestHandlerFunc)
-	// Add authentication middleware if authorization is enabled
-	// This ensures the metrics port follows the same security policy as the main HTTP server
 	if proxy.Params.CommonCfg.AuthorizationEnabled.GetAsBool() {
 		apiv1.Use(authenticate)
 	}
 	handlers := httpserver.NewHandlers(s.proxy)
 	handlers.RegisterRoutesTo(apiv1)
+
+	// WebUI management routes (_cluster/*, _qc/*, _dc/*, etc.) are served on the
+	// internal management port (9091) which is not publicly exposed in standard
+	// deployments. These observability endpoints must remain accessible to the
+	// built-in WebUI regardless of the authorizationEnabled setting; the WebUI
+	// frontend has no mechanism to supply user credentials.
+	// Telemetry routes (_telemetry/*) carry their own per-handler auth middleware.
 	if p, ok := s.proxy.(*proxy.Proxy); ok {
-		p.RegisterRestRouter(apiv1)
+		webuiGroup := metricsGinHandler.Group(apiPathPrefix)
+		webuiGroup.Use(httpserver.RequestHandlerFunc)
+		p.RegisterRestRouter(webuiGroup)
 	}
+
 	mhttp.Register(&mhttp.Handler{
 		Path:        mhttp.RootPath,
 		HandlerFunc: nil,

--- a/internal/distributed/proxy/service_test.go
+++ b/internal/distributed/proxy/service_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	grpcproxyclient "github.com/milvus-io/milvus/internal/distributed/proxy/client"
 	"github.com/milvus-io/milvus/internal/distributed/proxy/httpserver"
+	mhttp "github.com/milvus-io/milvus/internal/http"
 	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/internal/mocks"
 	"github.com/milvus-io/milvus/internal/proxy"
@@ -1199,16 +1200,85 @@ func TestHttpAuthenticate(t *testing.T) {
 	}
 }
 
+// stubWebUIRegistrar is a minimal implementation of webUIRouterRegistrar for tests.
+type stubWebUIRegistrar struct {
+	called bool
+}
+
+func (s *stubWebUIRegistrar) RegisterRestRouter(router gin.IRouter) {
+	s.called = true
+	router.GET("/_cluster/info", func(c *gin.Context) { c.Status(http.StatusOK) })
+	router.GET("/_cluster/clients", func(c *gin.Context) { c.Status(http.StatusOK) })
+	router.GET("/_cluster/dependencies", func(c *gin.Context) { c.Status(http.StatusOK) })
+}
+
+// proxyWithWebUI wraps MockProxy and additionally implements webUIRouterRegistrar
+// so that the type assertion in registerHTTPServer succeeds during tests.
+type proxyWithWebUI struct {
+	*mocks.MockProxy
+	webuiCalled bool
+}
+
+func (p *proxyWithWebUI) RegisterRestRouter(router gin.IRouter) {
+	p.webuiCalled = true
+}
+
+// TestRegisterHTTPServer_WithWebUIRegistrar covers the true branch of the type
+// assertion `if r, ok := s.proxy.(webUIRouterRegistrar); ok` inside
+// registerHTTPServer (service.go line 189-191). Without this test that line is
+// never reached because getServer() installs a *mocks.MockProxy which does not
+// implement webUIRouterRegistrar.
+// Regression test for: https://github.com/milvus-io/milvus/issues/48926
+func TestRegisterHTTPServer_WithWebUIRegistrar(t *testing.T) {
+	mockey.PatchConvey("proxy implementing webUIRouterRegistrar causes RegisterRestRouter to be called", t, func() {
+		// mhttp.Register writes to a package-level http.ServeMux; repeated
+		// registrations for the same path panic. Stub it out so this test can
+		// call registerHTTPServer without touching global state.
+		mockey.Mock(mhttp.Register).To(func(_ *mhttp.Handler) {}).Build()
+
+		server := getServer(t)
+		base := server.proxy.(*mocks.MockProxy)
+		webUIProxy := &proxyWithWebUI{MockProxy: base}
+		server.proxy = webUIProxy
+
+		server.registerHTTPServer()
+
+		assert.True(t, webUIProxy.webuiCalled,
+			"RegisterRestRouter must be invoked on the WebUI group when the proxy satisfies webUIRouterRegistrar")
+	})
+}
+
+// TestRegisterWebUIRoutes directly tests the registerWebUIRoutes helper, covering
+// all new lines in service.go and verifying that the WebUI group is created without
+// the authenticate middleware.
+// Regression test for: https://github.com/milvus-io/milvus/issues/48926
+func TestRegisterWebUIRoutes(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	engine := gin.New()
+	stub := &stubWebUIRegistrar{}
+	registerWebUIRoutes(engine, stub)
+
+	assert.True(t, stub.called, "RegisterRestRouter should have been called")
+
+	for _, path := range []string{"/_cluster/info", "/_cluster/clients", "/_cluster/dependencies"} {
+		req := httptest.NewRequest(http.MethodGet, apiPathPrefix+path, nil)
+		w := httptest.NewRecorder()
+		engine.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code,
+			"WebUI route %s should be reachable without any auth middleware", path)
+	}
+}
+
 // TestWebUIRoutesSkipAuthentication verifies that the WebUI management routes
-// (/_cluster/*, /_qc/*, etc.) registered via RegisterRestRouter remain accessible
-// without credentials even when authorizationEnabled = true.  The SDK REST API
-// routes must still require authentication.
+// (/_cluster/*, etc.) remain accessible without credentials even when
+// authorizationEnabled = true, while SDK REST API routes still require auth.
 // Regression test for: https://github.com/milvus-io/milvus/issues/48926
 func TestWebUIRoutesSkipAuthentication(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	// Use the mock hook so that the authenticate function does not panic
-	// when it cannot find valid credentials; it will abort with 401 instead.
+	// Use the mock hook so that authenticate does not panic when no credentials
+	// are present; it aborts with 401 instead.
 	hookutil.SetMockAPIHook("", nil)
 	defer hookutil.SetMockAPIHook("", nil)
 
@@ -1222,31 +1292,19 @@ func TestWebUIRoutesSkipAuthentication(t *testing.T) {
 	if proxy.Params.CommonCfg.AuthorizationEnabled.GetAsBool() {
 		apiv1.Use(authenticate)
 	}
-	apiv1.GET("/sdk-test-route", func(c *gin.Context) {
-		c.Status(http.StatusOK)
-	})
+	apiv1.GET("/sdk-test-route", func(c *gin.Context) { c.Status(http.StatusOK) })
 
-	// WebUI management group — no authenticate middleware (mirrors registerHTTPServer fix).
-	webuiGroup := engine.Group(apiPathPrefix)
-	webuiGroup.GET("/_cluster/info", func(c *gin.Context) {
-		c.Status(http.StatusOK)
-	})
-	webuiGroup.GET("/_cluster/clients", func(c *gin.Context) {
-		c.Status(http.StatusOK)
-	})
-	webuiGroup.GET("/_cluster/dependencies", func(c *gin.Context) {
-		c.Status(http.StatusOK)
-	})
+	// WebUI management group — registerWebUIRoutes creates it without auth middleware.
+	stub := &stubWebUIRegistrar{}
+	registerWebUIRoutes(engine, stub)
 
 	t.Run("WebUI cluster routes accessible without credentials when auth enabled", func(t *testing.T) {
 		for _, path := range []string{"/_cluster/info", "/_cluster/clients", "/_cluster/dependencies"} {
 			req := httptest.NewRequest(http.MethodGet, apiPathPrefix+path, nil)
 			w := httptest.NewRecorder()
 			engine.ServeHTTP(w, req)
-			assert.NotEqual(t, http.StatusUnauthorized, w.Code,
-				"WebUI route %s should not require authentication", path)
 			assert.Equal(t, http.StatusOK, w.Code,
-				"WebUI route %s should return 200 without credentials", path)
+				"WebUI route %s should return 200 without credentials when auth is enabled", path)
 		}
 	})
 
@@ -1258,22 +1316,19 @@ func TestWebUIRoutesSkipAuthentication(t *testing.T) {
 			"SDK routes must still require authentication when auth is enabled")
 	})
 
-	t.Run("WebUI routes accessible without credentials when auth disabled", func(t *testing.T) {
+	t.Run("WebUI routes accessible when auth disabled", func(t *testing.T) {
 		paramtable.Get().Save(proxy.Params.CommonCfg.AuthorizationEnabled.Key, "false")
 		defer paramtable.Get().Reset(proxy.Params.CommonCfg.AuthorizationEnabled.Key)
 
 		engine2 := gin.New()
-		apiv2 := engine2.Group(apiPathPrefix)
-		// No authenticate middleware because auth is disabled.
-		apiv2.GET("/sdk-test-route", func(c *gin.Context) {
-			c.Status(http.StatusOK)
-		})
+		stub2 := &stubWebUIRegistrar{}
+		registerWebUIRoutes(engine2, stub2)
 
-		req := httptest.NewRequest(http.MethodGet, apiPathPrefix+"/sdk-test-route", nil)
+		req := httptest.NewRequest(http.MethodGet, apiPathPrefix+"/_cluster/info", nil)
 		w := httptest.NewRecorder()
 		engine2.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusOK, w.Code,
-			"All routes should be accessible when auth is disabled")
+			"WebUI routes should be accessible when auth is disabled")
 	})
 }
 

--- a/internal/distributed/proxy/service_test.go
+++ b/internal/distributed/proxy/service_test.go
@@ -21,6 +21,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"strconv"
@@ -1196,6 +1197,84 @@ func TestHttpAuthenticate(t *testing.T) {
 		ctxName, _ := ctx.Get(httpserver.ContextUsername)
 		assert.Equal(t, "foo", ctxName)
 	}
+}
+
+// TestWebUIRoutesSkipAuthentication verifies that the WebUI management routes
+// (/_cluster/*, /_qc/*, etc.) registered via RegisterRestRouter remain accessible
+// without credentials even when authorizationEnabled = true.  The SDK REST API
+// routes must still require authentication.
+// Regression test for: https://github.com/milvus-io/milvus/issues/48926
+func TestWebUIRoutesSkipAuthentication(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	// Use the mock hook so that the authenticate function does not panic
+	// when it cannot find valid credentials; it will abort with 401 instead.
+	hookutil.SetMockAPIHook("", nil)
+	defer hookutil.SetMockAPIHook("", nil)
+
+	paramtable.Get().Save(proxy.Params.CommonCfg.AuthorizationEnabled.Key, "true")
+	defer paramtable.Get().Reset(proxy.Params.CommonCfg.AuthorizationEnabled.Key)
+
+	engine := gin.New()
+
+	// SDK REST API group — authenticate middleware applied when auth is enabled.
+	apiv1 := engine.Group(apiPathPrefix)
+	if proxy.Params.CommonCfg.AuthorizationEnabled.GetAsBool() {
+		apiv1.Use(authenticate)
+	}
+	apiv1.GET("/sdk-test-route", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	// WebUI management group — no authenticate middleware (mirrors registerHTTPServer fix).
+	webuiGroup := engine.Group(apiPathPrefix)
+	webuiGroup.GET("/_cluster/info", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+	webuiGroup.GET("/_cluster/clients", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+	webuiGroup.GET("/_cluster/dependencies", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	t.Run("WebUI cluster routes accessible without credentials when auth enabled", func(t *testing.T) {
+		for _, path := range []string{"/_cluster/info", "/_cluster/clients", "/_cluster/dependencies"} {
+			req := httptest.NewRequest(http.MethodGet, apiPathPrefix+path, nil)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+			assert.NotEqual(t, http.StatusUnauthorized, w.Code,
+				"WebUI route %s should not require authentication", path)
+			assert.Equal(t, http.StatusOK, w.Code,
+				"WebUI route %s should return 200 without credentials", path)
+		}
+	})
+
+	t.Run("SDK routes require credentials when auth enabled", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, apiPathPrefix+"/sdk-test-route", nil)
+		w := httptest.NewRecorder()
+		engine.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusUnauthorized, w.Code,
+			"SDK routes must still require authentication when auth is enabled")
+	})
+
+	t.Run("WebUI routes accessible without credentials when auth disabled", func(t *testing.T) {
+		paramtable.Get().Save(proxy.Params.CommonCfg.AuthorizationEnabled.Key, "false")
+		defer paramtable.Get().Reset(proxy.Params.CommonCfg.AuthorizationEnabled.Key)
+
+		engine2 := gin.New()
+		apiv2 := engine2.Group(apiPathPrefix)
+		// No authenticate middleware because auth is disabled.
+		apiv2.GET("/sdk-test-route", func(c *gin.Context) {
+			c.Status(http.StatusOK)
+		})
+
+		req := httptest.NewRequest(http.MethodGet, apiPathPrefix+"/sdk-test-route", nil)
+		w := httptest.NewRecorder()
+		engine2.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code,
+			"All routes should be accessible when auth is disabled")
+	})
 }
 
 func Test_Service_GracefulStop(t *testing.T) {


### PR DESCRIPTION
## What

Fixes the built-in Web UI (port 9091) returning `401 Unauthorized` for all internal API calls (`/_cluster/info`, `/_cluster/clients`, `/_cluster/dependencies`, etc.) when `authorizationEnabled: true` is set in configuration.

Closes #48926 

## Root Cause

In `registerHTTPServer()`, the WebUI management routes were registered on the **same** authenticated router group (`apiv1`) as the SDK REST API routes. When `authorizationEnabled = true`, the `authenticate` middleware was applied to that group, blocking all requests that did not carry credentials — including WebUI frontend calls, which have no mechanism to supply them.

## Fix

Split the two route groups so they use separate middleware chains on the same path prefix:

- **SDK REST API routes** (`/api/v1/...`): Keep the `authenticate` middleware when auth is enabled.
- **WebUI management routes** (`/api/v1/_cluster/...`, `/_qc/...`, `/_dc/...`, etc.): Register on a new group **without** the auth middleware. Port 9091 is an internal management port and is not publicly exposed in standard Kubernetes/Docker Compose deployments, so removing auth from this group does not introduce a security regression.

A new `webUIRouterRegistrar` interface is introduced using duck typing, allowing both the real `proxy.Proxy` and lightweight test stubs to satisfy it — avoiding a concrete-type dependency that broke test coverage.

## Changes

| File | Change |
|---|---|
| `internal/distributed/proxy/service.go` | Add `webUIRouterRegistrar` interface; extract `registerWebUIRoutes` helper that creates an unauthenticated gin group; split WebUI routes from SDK routes |
| `internal/distributed/proxy/service_test.go` | Add `stubWebUIRegistrar`, `proxyWithWebUI`; add `TestRegisterHTTPServer_WithWebUIRegistrar` (covers the true branch of the type assertion in `registerHTTPServer`); add `TestRegisterWebUIRoutes` (covers the extracted helper); add `TestWebUIRoutesSkipAuthentication` (end-to-end: WebUI returns 200, SDK returns 401, both without credentials) |

## Test Coverage

All new executable statements in the diff are covered:

| Statement | Test |
|---|---|
| `if r, ok := s.proxy.(webUIRouterRegistrar); ok` — false branch | `Test_NewServer_HTTPServer_Enabled` |
| `registerWebUIRoutes(metricsGinHandler, r)` — true branch | `TestRegisterHTTPServer_WithWebUIRegistrar` |
| `registerWebUIRoutes` function body | `TestRegisterWebUIRoutes` |
| WebUI routes accessible without credentials when auth enabled | `TestWebUIRoutesSkipAuthentication` |
| SDK routes still blocked without credentials when auth enabled | `TestWebUIRoutesSkipAuthentication` |