### PR TITLE
fix: always apply DefaultGrpcOpts before user DialOptions

### DIFF
--- a/client/milvusclient/client.go
+++ b/client/milvusclient/client.go
@@ -108,12 +108,9 @@ func (c *Client) dialOptions() []grpc.DialOption {
 		options = append(options, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	}
 
-	if c.config.DialOptions == nil {
-		// Add default connection options.
-		options = append(options, DefaultGrpcOpts...)
-	} else {
-		options = append(options, c.config.DialOptions...)
-	}
+	// Always apply default connection options first, then let caller override/extend.
+	options = append(options, DefaultGrpcOpts...)
+	options = append(options, c.config.DialOptions...)
 
 	options = append(options,
 		grpc.WithChainUnaryInterceptor(grpc_retry.UnaryClientInterceptor(

--- a/client/milvusclient/client_config.go
+++ b/client/milvusclient/client_config.go
@@ -162,8 +162,8 @@ func (c *ClientConfig) WithTLSConfig(tlsConfig *tls.Config) *ClientConfig {
 }
 
 // WithGrpcAuthority sets the gRPC :authority header, used for proxy-based routing.
-// Preserves all DefaultGrpcOpts.
+// DefaultGrpcOpts are always applied by dialOptions(), so only the authority option is needed here.
 func (c *ClientConfig) WithGrpcAuthority(authority string) *ClientConfig {
-	c.DialOptions = append(append([]grpc.DialOption{}, DefaultGrpcOpts...), grpc.WithAuthority(authority))
+	c.DialOptions = []grpc.DialOption{grpc.WithAuthority(authority)}
 	return c
 }

--- a/client/milvusclient/client_config_test.go
+++ b/client/milvusclient/client_config_test.go
@@ -4,7 +4,23 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
 )
+
+func TestDialOptionsAlwaysIncludesDefaults(t *testing.T) {
+	c := &Client{config: &ClientConfig{
+		DialOptions: []grpc.DialOption{grpc.WithAuthority("test")},
+	}}
+	opts := c.dialOptions()
+	// TLS/insecure (1) + DefaultGrpcOpts (len) + user option (1) + interceptors (2)
+	assert.True(t, len(opts) >= len(DefaultGrpcOpts)+1, "dialOptions should include DefaultGrpcOpts plus user options")
+}
+
+func TestDialOptionsWithNilDialOptions(t *testing.T) {
+	c := &Client{config: &ClientConfig{}}
+	opts := c.dialOptions()
+	assert.True(t, len(opts) >= len(DefaultGrpcOpts), "dialOptions should include DefaultGrpcOpts even when DialOptions is nil")
+}
 
 func TestWithGrpcAuthority(t *testing.T) {
 	t.Run("sets authority option only", func(t *testing.T) {

--- a/client/milvusclient/client_config_test.go
+++ b/client/milvusclient/client_config_test.go
@@ -7,13 +7,13 @@ import (
 )
 
 func TestWithGrpcAuthority(t *testing.T) {
-	t.Run("sets authority and preserves default opts", func(t *testing.T) {
+	t.Run("sets authority option only", func(t *testing.T) {
 		config := &ClientConfig{}
 		result := config.WithGrpcAuthority("proxy.example.com")
 
 		assert.Same(t, config, result)
-		// DefaultGrpcOpts + grpc.WithAuthority = len(DefaultGrpcOpts) + 1
-		assert.Equal(t, len(DefaultGrpcOpts)+1, len(config.DialOptions))
+		// Only grpc.WithAuthority; DefaultGrpcOpts are applied by dialOptions()
+		assert.Equal(t, 1, len(config.DialOptions))
 	})
 
 	t.Run("does not mutate DefaultGrpcOpts", func(t *testing.T) {
@@ -29,6 +29,6 @@ func TestWithGrpcAuthority(t *testing.T) {
 		config.WithGrpcAuthority("first.example.com")
 		config.WithGrpcAuthority("second.example.com")
 
-		assert.Equal(t, len(DefaultGrpcOpts)+1, len(config.DialOptions))
+		assert.Equal(t, 1, len(config.DialOptions))
 	})
 }


### PR DESCRIPTION
## Summary
- When `ClientConfig.DialOptions` is set to any non-nil value, `dialOptions()` silently drops all `DefaultGrpcOpts` (keepalive, backoff, MaxRecvMsgSize), causing connection stability and message size issues
- Fix `dialOptions()` to always apply `DefaultGrpcOpts` as baseline before appending user's custom `DialOptions`
- Simplify `WithGrpcAuthority()` — it previously copied `DefaultGrpcOpts` as a workaround for this bug, now only sets the authority option

issue: #48828

## Test plan
- [x] Existing `TestClient` and `TestWithGrpcAuthority` tests pass
- [x] Added `TestDialOptionsAlwaysIncludesDefaults` and `TestDialOptionsWithNilDialOptions` to verify defaults are always present
- [x] Full `client/milvusclient` test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)