### PR TITLE
enhance: [3.0] expose arrow IO thread pool capacity via paramtable

### DIFF
--- a/internal/core/src/common/init_c.cpp
+++ b/internal/core/src/common/init_c.cpp
@@ -17,12 +17,14 @@
 #include <cstddef>
 #include <mutex>
 
+#include <arrow/io/interfaces.h>
 #include <openssl/evp.h>
 #include "common/init_c.h"
 #include "common/Common.h"
 #include "common/Tracer.h"
 #include "common/init_c.h"
 #include "exec/expression/ExprCache.h"
+#include "log/Log.h"
 #include "storage/ThreadPool.h"
 
 std::once_flag traceFlag;
@@ -108,6 +110,21 @@ void
 SetExprResCacheCapacityBytes(int64_t bytes) {
     milvus::exec::ExprResCacheManager::Instance().SetCapacityBytes(
         static_cast<size_t>(bytes));
+}
+
+void
+SetArrowIOThreadPoolCapacity(int threads) {
+    if (threads <= 0) {
+        return;
+    }
+    auto status = arrow::io::SetIOThreadPoolCapacity(threads);
+    if (!status.ok()) {
+        LOG_WARN("failed to set arrow io thread pool capacity to {}: {}",
+                 threads,
+                 status.ToString());
+        return;
+    }
+    LOG_INFO("arrow io thread pool capacity set to {}", threads);
 }
 
 void

--- a/internal/core/src/common/init_c.h
+++ b/internal/core/src/common/init_c.h
@@ -85,6 +85,19 @@ SetExprResCacheEnable(bool val);
 void
 SetExprResCacheCapacityBytes(int64_t bytes);
 
+// Set the capacity of arrow's internal IO thread pool. This pool runs
+// async range reads (ReadRangeCache) that issue actual S3 GetObject
+// requests, so it's the true ceiling on parallel object-storage reads —
+// independent of the segcore HIGH/MIDDLE pools and aws-sdk-cpp's
+// ClientConfiguration::maxConnections. Arrow's built-in default is a
+// fixed constant (kDefaultNumIoThreads = 8 in arrow 17), which is almost
+// always the hidden bottleneck for retrieve/load workloads. The Go side
+// resolves common.arrow.ioThreadPoolCoefficient (× CPU cores, clamped by
+// common.arrow.ioThreadPoolMaxCapacity) into a final thread count and
+// passes it here. Values <= 0 are ignored (keep the current capacity).
+void
+SetArrowIOThreadPoolCapacity(int threads);
+
 #ifdef __cplusplus
 };
 #endif

--- a/internal/querynodev2/server.go
+++ b/internal/querynodev2/server.go
@@ -270,6 +270,24 @@ func (node *QueryNode) RegisterSegcoreConfigWatcher() {
 		config.NewHandler("common.diskWriteRateLimiter.middlePriorityRatio", node.ReconfigDiskFileWriterParams))
 	pt.Watch(pt.CommonCfg.DiskWriteRateLimiterLowPriorityRatio.Key,
 		config.NewHandler("common.diskWriteRateLimiter.lowPriorityRatio", node.ReconfigDiskFileWriterParams))
+	arrowIOThreadHandler := func(key string) func(evt *config.Event) {
+		return func(evt *config.Event) {
+			if !evt.HasUpdated {
+				return
+			}
+			newThreads := initcore.ResolveArrowIOThreadPoolCapacity()
+			initcore.UpdateArrowIOThreadPoolCapacity(newThreads)
+			log.Info("arrow io thread pool capacity updated",
+				zap.String("trigger", key),
+				zap.Int("threads", newThreads))
+		}
+	}
+	pt.Watch(pt.CommonCfg.ArrowIOThreadPoolCoefficient.Key,
+		config.NewHandler(pt.CommonCfg.ArrowIOThreadPoolCoefficient.Key,
+			arrowIOThreadHandler(pt.CommonCfg.ArrowIOThreadPoolCoefficient.Key)))
+	pt.Watch(pt.CommonCfg.ArrowIOThreadPoolMaxCapacity.Key,
+		config.NewHandler(pt.CommonCfg.ArrowIOThreadPoolMaxCapacity.Key,
+			arrowIOThreadHandler(pt.CommonCfg.ArrowIOThreadPoolMaxCapacity.Key)))
 }
 
 func getIndexEngineVersion() (minimal, current, maximum int32) {

--- a/internal/util/initcore/query_node.go
+++ b/internal/util/initcore/query_node.go
@@ -155,6 +155,8 @@ func doInitQueryNodeOnce(ctx context.Context) error {
 	cExprResCacheCapacityBytes := C.int64_t(paramtable.Get().QueryNodeCfg.ExprResCacheCapacityBytes.GetAsInt64())
 	C.SetExprResCacheCapacityBytes(cExprResCacheCapacityBytes)
 
+	C.SetArrowIOThreadPoolCapacity(C.int(ResolveArrowIOThreadPoolCapacity()))
+
 	enableParquetStatsSkipIndex := paramtable.Get().CommonCfg.ParquetStatsSkipIndex.GetAsBool()
 	C.SetDefaultEnableParquetStatsSkipIndex(C.bool(enableParquetStatsSkipIndex))
 

--- a/internal/util/initcore/util.go
+++ b/internal/util/initcore/util.go
@@ -29,6 +29,9 @@ import "C"
 import (
 	"strings"
 	"unsafe"
+
+	"github.com/milvus-io/milvus/pkg/v2/util/hardware"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
 func UpdateLogLevel(level string) error {
@@ -78,6 +81,30 @@ func UpdateExprResCacheEnable(enable bool) {
 
 func UpdateExprResCacheCapacityBytes(capacity int) {
 	C.SetExprResCacheCapacityBytes(C.int64_t(capacity))
+}
+
+func UpdateArrowIOThreadPoolCapacity(threads int) {
+	C.SetArrowIOThreadPoolCapacity(C.int(threads))
+}
+
+// ResolveArrowIOThreadPoolCapacity returns the effective arrow IO thread pool
+// size: coefficient × CPU cores, clamped by MaxCapacity when > 0. Returns 0
+// when the coefficient is unset, which signals the C++ side to keep arrow's
+// built-in default (8).
+func ResolveArrowIOThreadPoolCapacity() int {
+	cfg := paramtable.Get().CommonCfg
+	coef := cfg.ArrowIOThreadPoolCoefficient.GetAsFloat()
+	if coef <= 0 {
+		return 0
+	}
+	threads := int(coef * float64(hardware.GetCPUNum()))
+	if threads < 1 {
+		threads = 1
+	}
+	if maxCap := cfg.ArrowIOThreadPoolMaxCapacity.GetAsInt(); maxCap > 0 && threads > maxCap {
+		threads = maxCap
+	}
+	return threads
 }
 
 func UpdateDefaultGrowingJSONKeyStatsEnable(enable bool) {

--- a/internal/util/initcore/util.go
+++ b/internal/util/initcore/util.go
@@ -92,7 +92,7 @@ func UpdateArrowIOThreadPoolCapacity(threads int) {
 // when the coefficient is unset, which signals the C++ side to keep arrow's
 // built-in default (8).
 func ResolveArrowIOThreadPoolCapacity() int {
-	cfg := paramtable.Get().CommonCfg
+	cfg := &paramtable.Get().CommonCfg
 	coef := cfg.ArrowIOThreadPoolCoefficient.GetAsFloat()
 	if coef <= 0 {
 		return 0

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -719,7 +719,7 @@ This configuration is only used by querynode and indexnode, it selects CPU instr
 			`minio.maxConnections. Arrow's built-in default is a fixed constant ` +
 			`of 8, which is almost always undersized. Typical range 2–8. 0 keeps ` +
 			`arrow's default (and the cap is ignored).`,
-		Export: true,
+		Export: false,
 	}
 	p.ArrowIOThreadPoolCoefficient.Init(base.mgr)
 
@@ -734,7 +734,7 @@ This configuration is only used by querynode and indexnode, it selects CPU instr
 			`produce a pool larger than minio.maxConnections or the S3 gateway ` +
 			`can service. 0 disables the cap. Has no effect when coefficient ` +
 			`is 0.`,
-		Export: true,
+		Export: false,
 	}
 	p.ArrowIOThreadPoolMaxCapacity.Init(base.mgr)
 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -232,6 +232,8 @@ type commonConfig struct {
 	LowPriorityThreadCoreCoefficient    ParamItem `refreshable:"true"`
 	BM25LoadThreadCoreCoefficient       ParamItem `refreshable:"true"`
 	ThreadPoolMaxThreadsSize            ParamItem `refreshable:"true"`
+	ArrowIOThreadPoolCoefficient        ParamItem `refreshable:"true"`
+	ArrowIOThreadPoolMaxCapacity        ParamItem `refreshable:"true"`
 	EnableMaterializedView              ParamItem `refreshable:"false"`
 	BuildIndexThreadPoolRatio           ParamItem `refreshable:"false"`
 	MaxDegree                           ParamItem `refreshable:"true"`
@@ -703,6 +705,38 @@ This configuration is only used by querynode and indexnode, it selects CPU instr
 		Export:       true,
 	}
 	p.ThreadPoolMaxThreadsSize.Init(base.mgr)
+
+	p.ArrowIOThreadPoolCoefficient = ParamItem{
+		Key:          "common.arrow.ioThreadPoolCoefficient",
+		Version:      "3.0.0",
+		DefaultValue: "0",
+		Doc: `Coefficient for arrow's internal IO thread pool size ` +
+			`(threads = CPU cores × coefficient, then clamped by ` +
+			`common.arrow.ioThreadPoolMaxCapacity when > 0). Arrow runs async ` +
+			`range reads (ReadRangeCache) on this pool, which issue the actual ` +
+			`S3 GetObject requests — it is the real ceiling on parallel ` +
+			`object-storage reads, independent of segcore HIGH/MIDDLE pools and ` +
+			`minio.maxConnections. Arrow's built-in default is a fixed constant ` +
+			`of 8, which is almost always undersized. Typical range 2–8. 0 keeps ` +
+			`arrow's default (and the cap is ignored).`,
+		Export: true,
+	}
+	p.ArrowIOThreadPoolCoefficient.Init(base.mgr)
+
+	p.ArrowIOThreadPoolMaxCapacity = ParamItem{
+		Key:          "common.arrow.ioThreadPoolMaxCapacity",
+		Version:      "3.0.0",
+		DefaultValue: "0",
+		Doc: `Upper bound on arrow's IO thread pool size after applying ` +
+			`common.arrow.ioThreadPoolCoefficient. When > 0, the computed ` +
+			`threads = coefficient × CPU cores is clamped to this value — ` +
+			`useful on very large hosts where the coefficient would otherwise ` +
+			`produce a pool larger than minio.maxConnections or the S3 gateway ` +
+			`can service. 0 disables the cap. Has no effect when coefficient ` +
+			`is 0.`,
+		Export: true,
+	}
+	p.ArrowIOThreadPoolMaxCapacity.Init(base.mgr)
 
 	p.DiskWriteMode = ParamItem{
 		Key:          "common.diskWriteMode",


### PR DESCRIPTION
## Summary

Cherry-pick of master PR #49208 into the 3.0 branch.

Expose Arrow's internal IO thread pool capacity as a refreshable paramtable knob so operators can raise it beyond Arrow's fixed default of 8, independently of segcore `HIGH/MIDDLE` pools and `minio.maxConnections`.

- New keys (both refreshable, `common` scope):
  - `common.arrow.ioThreadPoolCoefficient` (default `0` → keep Arrow's built-in default)
  - `common.arrow.ioThreadPoolMaxCapacity` (default `0` → no cap)
- Effective size = `coefficient × CPU cores`, clamped by `maxCapacity` when `> 0`.
- Wired through `init_c.{h,cpp}` + `initcore` + QueryNode paramtable watcher; hot reloads apply without restart.

## Why

`GetIOThreadPool` runs the async range reads behind `ReadRangeCache`, which is what actually issues S3 `GetObject` for storage v2 reads. Milvus never calls `SetIOThreadPoolCapacity`, so this pool sticks at Arrow's fixed default (`kDefaultNumIoThreads = 8` in arrow 17). Off-CPU profiling on a QueryNode under heavy storage v2 load shows ~62% of `HIGH`-pool wait time sitting on `curl_easy_perform -> poll` — `HIGH`-pool threads blocked inside `ReadRangeCache::Wait` because Arrow's IO pool cannot dispatch their range reads fast enough.

## Test plan

- [ ] CI: `ci-v2/build-ut-cov`, `ci-v2/e2e-amd`
- [ ] Manual: set `common.arrow.ioThreadPoolCoefficient=4` on a QueryNode, confirm the `arrow io thread pool capacity set to N` log at startup and that the pool is resized on subsequent config edits.
- [ ] Manual: re-run the storage-v2-heavy workload that produced the off-CPU profile and confirm `curl_easy_perform -> poll` share drops from ~62%.

issue: #49207
pr: #49208