### PR TITLE
fix: make config write synchronously visible and add leaked resource check

### DIFF
--- a/internal/coordinator/restful_mgr_routes.go
+++ b/internal/coordinator/restful_mgr_routes.go
@@ -1348,7 +1348,9 @@ func (s *mixCoordImpl) HandleAlterConfig(writer http.ResponseWriter, request *ht
 		return
 	}
 
-	// Alter configuration(s) in etcd atomically (updates + deletes in one transaction)
+	// Alter configuration(s) in etcd atomically (updates + deletes in one transaction).
+	// AlterConfigsInEtcd also proactively refreshes the local EtcdSource so that the write
+	// is immediately visible in this process before we return.
 	if err := paramMgr.AlterConfigsInEtcd(etcdSource, configsToUpdate, keysToDelete); err != nil {
 		logger.Info("HandleAlterConfig failed to atomically alter configs in etcd",
 			zap.Any("updates", configsToUpdate),

--- a/internal/coordinator/restful_replica.go
+++ b/internal/coordinator/restful_replica.go
@@ -23,6 +23,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/milvus-io/milvus/internal/streamingcoord/server/balancer/balance"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v2/util/commonpbutil"
@@ -54,6 +55,19 @@ func (s *mixCoordImpl) HandleReplicaLoadConfigCompliance(w http.ResponseWriter, 
 
 	ctx := req.Context()
 	logger := log.Ctx(ctx).With(zap.String("handler", "ReplicaLoadConfigCompliance"))
+
+	// Cluster-level check: WAL is fully migrated onto the configured primary resource group.
+	// Short-circuit before reading config / loading collections — a WAL-layout issue affects
+	// every collection and is independent of per-collection replica/RG config.
+	if b, err := balance.GetWithContext(ctx); err != nil {
+		writeJSONError(w, fmt.Sprintf("failed to get streaming balancer: %s", err.Error()), http.StatusInternalServerError)
+		return
+	} else if err := b.ConfirmPrimaryResourceGroupReady(ctx); err != nil {
+		reason := fmt.Sprintf("WAL placement: %s", err.Error())
+		logger.Info("WAL not fully placed on primary resource group", zap.String("reason", reason))
+		s.writeComplianceResponse(w, LoadConfigComplianceStateNotReady, reason)
+		return
+	}
 
 	// Get cluster-level configuration
 	clusterReplicaNum := Params.QueryCoordCfg.ClusterLevelLoadReplicaNumber.GetAsInt()

--- a/internal/coordinator/restful_replica.go
+++ b/internal/coordinator/restful_replica.go
@@ -74,25 +74,12 @@ func (s *mixCoordImpl) HandleReplicaLoadConfigCompliance(w http.ResponseWriter, 
 	}
 
 	// Check each collection
-	percentages := showResp.GetInMemoryPercentages()
-	for idx, collectionID := range showResp.GetCollectionIDs() {
-		// Check if collection is fully loaded (LoadPercentage == 100)
-		if idx >= len(percentages) {
-			writeJSONError(w, fmt.Sprintf("inconsistent response: collection %d has no load percentage", collectionID), http.StatusInternalServerError)
-			return
-		}
-		loadPercentage := percentages[idx]
-		if loadPercentage < 100 {
-			reason := fmt.Sprintf("collection %d: not fully loaded (%d%%)", collectionID, loadPercentage)
-			logger.Info("collection not 100% loaded", zap.String("reason", reason))
-			s.writeComplianceResponse(w, LoadConfigComplianceStateNotReady, reason)
-			return
-		}
-
+	for _, collectionID := range showResp.GetCollectionIDs() {
 		// Get internal replicas from QueryCoord meta which contains StreamingResourceGroup field
 		internalReplicas := s.queryCoordServer.GetInternalReplicasByCollection(ctx, collectionID)
 
-		// Check replica count matches exactly
+		// Check replica count matches exactly — the replica meta must already reflect
+		// the configured count before we inspect serviceability/leaks.
 		if clusterReplicaNum > 0 && len(internalReplicas) != clusterReplicaNum {
 			reason := fmt.Sprintf("collection %d: replica count mismatch (expected %d, actual %d)",
 				collectionID, clusterReplicaNum, len(internalReplicas))
@@ -113,6 +100,31 @@ func (s *mixCoordImpl) HandleReplicaLoadConfigCompliance(w http.ResponseWriter, 
 				s.writeComplianceResponse(w, LoadConfigComplianceStateNotReady, reason)
 				return
 			}
+		}
+
+		// Now that replica count and RG distribution match, verify every replica actually
+		// has a serviceable shard leader for every channel. This live dist check avoids
+		// the stale CollectionObserver-persisted LoadPercentage that can falsely report
+		// 100% during scale-up/scale-down transitions.
+		if err := s.queryCoordServer.CheckAllReplicasServiceable(ctx, collectionID); err != nil {
+			reason := fmt.Sprintf("collection %d: %s", collectionID, err.Error())
+			logger.Info("collection not serviceable", zap.String("reason", reason))
+			s.writeComplianceResponse(w, LoadConfigComplianceStateNotReady, reason)
+			return
+		}
+
+		// Check that physical resources have been released from querynodes no longer
+		// part of any replica. During scale-down a decommissioned replica's querynode may
+		// still hold segments/channels while release is in flight; compliance must wait for
+		// that to finish before signaling Ready, otherwise callers may terminate nodes while
+		// they are still serving or holding state.
+		leakedSegments, leakedChannels := s.queryCoordServer.GetLeakedResourcesByCollection(ctx, collectionID)
+		if leakedSegments > 0 || leakedChannels > 0 {
+			reason := fmt.Sprintf("collection %d: resources not fully released (leaked segments=%d, channels=%d)",
+				collectionID, leakedSegments, leakedChannels)
+			logger.Info("collection has leaked resources on non-replica nodes", zap.String("reason", reason))
+			s.writeComplianceResponse(w, LoadConfigComplianceStateNotReady, reason)
+			return
 		}
 	}
 

--- a/internal/coordinator/restful_replica_test.go
+++ b/internal/coordinator/restful_replica_test.go
@@ -26,14 +26,27 @@ import (
 
 	"github.com/bytedance/mockey"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus/internal/mocks/streamingcoord/server/mock_balancer"
 	"github.com/milvus-io/milvus/internal/querycoordv2"
 	"github.com/milvus-io/milvus/internal/querycoordv2/meta"
+	"github.com/milvus-io/milvus/internal/streamingcoord/server/balancer/balance"
 	"github.com/milvus-io/milvus/pkg/v2/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
+
+// registerTestBalancer installs a mock balancer that returns the given error from
+// ConfirmPrimaryResourceGroupReady. Caller must invoke the returned cleanup.
+func registerTestBalancer(t *testing.T, primaryRGErr error) func() {
+	balance.ResetBalancer()
+	b := mock_balancer.NewMockBalancer(t)
+	b.EXPECT().ConfirmPrimaryResourceGroupReady(mock.Anything).Return(primaryRGErr).Maybe()
+	balance.Register(b)
+	return balance.ResetBalancer
+}
 
 func TestHandleReplicaLoadConfigCompliance(t *testing.T) {
 	paramtable.Init()
@@ -55,6 +68,7 @@ func TestHandleReplicaLoadConfigCompliance(t *testing.T) {
 		paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.Key, "")
 		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadReplicaNumber.Key)
 		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.Key)
+		defer registerTestBalancer(t, nil)()
 
 		coord := &mixCoordImpl{
 			queryCoordServer: &querycoordv2.Server{},
@@ -87,6 +101,7 @@ func TestHandleReplicaLoadConfigCompliance(t *testing.T) {
 		paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.Key, "")
 		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadReplicaNumber.Key)
 		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.Key)
+		defer registerTestBalancer(t, nil)()
 
 		replicas := []*meta.Replica{
 			meta.NewReplica(&querypb.Replica{
@@ -137,6 +152,7 @@ func TestHandleReplicaLoadConfigCompliance(t *testing.T) {
 		paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.Key, "rg1,rg2")
 		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadReplicaNumber.Key)
 		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.Key)
+		defer registerTestBalancer(t, nil)()
 
 		replicas := []*meta.Replica{
 			meta.NewReplica(&querypb.Replica{
@@ -184,11 +200,40 @@ func TestHandleReplicaLoadConfigCompliance(t *testing.T) {
 		assert.Contains(t, resp.Reason, "resource group mismatch")
 	})
 
+	t.Run("primary resource group not ready returns NotReady", func(t *testing.T) {
+		paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadReplicaNumber.Key, "1")
+		paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.Key, "")
+		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadReplicaNumber.Key)
+		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.Key)
+		defer registerTestBalancer(t, fmt.Errorf("pchannel p0 still on rg=rg_old, expected primary rg=rg_new (WAL migration in progress)"))()
+
+		coord := &mixCoordImpl{queryCoordServer: &querycoordv2.Server{}}
+
+		mocker := mockey.Mock((*mixCoordImpl).ShowLoadCollections).Return(&querypb.ShowCollectionsResponse{
+			Status:              &commonpb.Status{ErrorCode: commonpb.ErrorCode_Success},
+			CollectionIDs:       []int64{100},
+			InMemoryPercentages: []int64{100},
+		}, nil).Build()
+		defer mocker.UnPatch()
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/replicas/compliance", nil)
+		w := httptest.NewRecorder()
+		coord.HandleReplicaLoadConfigCompliance(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		var resp LoadConfigComplianceResponse
+		assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Equal(t, LoadConfigComplianceStateNotReady, resp.State)
+		assert.Contains(t, resp.Reason, "WAL placement")
+		assert.Contains(t, resp.Reason, "WAL migration in progress")
+	})
+
 	t.Run("delegator not serviceable returns NotReady", func(t *testing.T) {
 		paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadReplicaNumber.Key, "1")
 		paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.Key, "")
 		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadReplicaNumber.Key)
 		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.Key)
+		defer registerTestBalancer(t, nil)()
 
 		coord := &mixCoordImpl{queryCoordServer: &querycoordv2.Server{}}
 
@@ -228,6 +273,7 @@ func TestHandleReplicaLoadConfigCompliance(t *testing.T) {
 		paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.Key, "rg1,rg2")
 		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadReplicaNumber.Key)
 		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.Key)
+		defer registerTestBalancer(t, nil)()
 
 		replicas := []*meta.Replica{
 			meta.NewReplica(&querypb.Replica{
@@ -284,6 +330,7 @@ func TestHandleReplicaLoadConfigCompliance(t *testing.T) {
 		paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.Key, "rg1")
 		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadReplicaNumber.Key)
 		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.Key)
+		defer registerTestBalancer(t, nil)()
 
 		replicas := []*meta.Replica{
 			meta.NewReplica(&querypb.Replica{ID: 1, CollectionID: 100, ResourceGroup: "rg1"}, typeutil.NewUniqueSet()),
@@ -326,6 +373,7 @@ func TestHandleReplicaLoadConfigCompliance(t *testing.T) {
 		paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.Key, "rg1")
 		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadReplicaNumber.Key)
 		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.Key)
+		defer registerTestBalancer(t, nil)()
 
 		replicas := []*meta.Replica{
 			meta.NewReplica(&querypb.Replica{ID: 1, CollectionID: 100, ResourceGroup: "rg1"}, typeutil.NewUniqueSet()),
@@ -365,6 +413,7 @@ func TestHandleReplicaLoadConfigCompliance(t *testing.T) {
 		paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.Key, "")
 		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadReplicaNumber.Key)
 		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.Key)
+		defer registerTestBalancer(t, nil)()
 
 		coord := &mixCoordImpl{
 			queryCoordServer: &querycoordv2.Server{},
@@ -394,6 +443,7 @@ func TestHandleReplicaLoadConfigCompliance(t *testing.T) {
 		paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.Key, "rg1")
 		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadReplicaNumber.Key)
 		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.Key)
+		defer registerTestBalancer(t, nil)()
 
 		replicasMap := map[int64][]*meta.Replica{
 			100: {

--- a/internal/coordinator/restful_replica_test.go
+++ b/internal/coordinator/restful_replica_test.go
@@ -19,6 +19,7 @@ package coordinator
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -111,6 +112,10 @@ func TestHandleReplicaLoadConfigCompliance(t *testing.T) {
 		mocker2 := mockey.Mock((*querycoordv2.Server).GetInternalReplicasByCollection).Return(replicas).Build()
 		defer mocker2.UnPatch()
 
+		// Mock CheckAllReplicasServiceable to allow flow to reach later checks
+		mockerSvc := mockey.Mock((*querycoordv2.Server).CheckAllReplicasServiceable).Return(nil).Build()
+		defer mockerSvc.UnPatch()
+
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/replicas/compliance", nil)
 		w := httptest.NewRecorder()
 
@@ -162,6 +167,10 @@ func TestHandleReplicaLoadConfigCompliance(t *testing.T) {
 		mocker2 := mockey.Mock((*querycoordv2.Server).GetInternalReplicasByCollection).Return(replicas).Build()
 		defer mocker2.UnPatch()
 
+		// Mock CheckAllReplicasServiceable to allow flow to reach later checks
+		mockerSvc := mockey.Mock((*querycoordv2.Server).CheckAllReplicasServiceable).Return(nil).Build()
+		defer mockerSvc.UnPatch()
+
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/replicas/compliance", nil)
 		w := httptest.NewRecorder()
 
@@ -175,37 +184,42 @@ func TestHandleReplicaLoadConfigCompliance(t *testing.T) {
 		assert.Contains(t, resp.Reason, "resource group mismatch")
 	})
 
-	t.Run("collection loading returns NotReady", func(t *testing.T) {
-		// Set cluster config
+	t.Run("delegator not serviceable returns NotReady", func(t *testing.T) {
 		paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadReplicaNumber.Key, "1")
 		paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.Key, "")
 		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadReplicaNumber.Key)
 		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.Key)
 
-		coord := &mixCoordImpl{
-			queryCoordServer: &querycoordv2.Server{},
-		}
+		coord := &mixCoordImpl{queryCoordServer: &querycoordv2.Server{}}
 
-		// Mock ShowLoadCollections with collection still loading (50%)
-		mocker := mockey.Mock((*mixCoordImpl).ShowLoadCollections).Return(&querypb.ShowCollectionsResponse{
+		mocker1 := mockey.Mock((*mixCoordImpl).ShowLoadCollections).Return(&querypb.ShowCollectionsResponse{
 			Status:              &commonpb.Status{ErrorCode: commonpb.ErrorCode_Success},
 			CollectionIDs:       []int64{100},
-			InMemoryPercentages: []int64{50}, // Only 50% loaded
+			InMemoryPercentages: []int64{100},
 		}, nil).Build()
-		defer mocker.UnPatch()
+		defer mocker1.UnPatch()
+
+		// Replica count matches (1 replica) — needed so the flow reaches the serviceable check
+		replicas := []*meta.Replica{
+			meta.NewReplica(&querypb.Replica{ID: 1, CollectionID: 100, ResourceGroup: "rg1"}, typeutil.NewUniqueSet()),
+		}
+		mockerRep := mockey.Mock((*querycoordv2.Server).GetInternalReplicasByCollection).Return(replicas).Build()
+		defer mockerRep.UnPatch()
+
+		mocker2 := mockey.Mock((*querycoordv2.Server).CheckAllReplicasServiceable).
+			Return(fmt.Errorf("replica 1 (rg=rg1) channel c1 not serviceable: still catching up")).Build()
+		defer mocker2.UnPatch()
 
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/replicas/compliance", nil)
 		w := httptest.NewRecorder()
-
 		coord.HandleReplicaLoadConfigCompliance(w, req)
 
 		assert.Equal(t, http.StatusOK, w.Code)
 		var resp LoadConfigComplianceResponse
-		err := json.Unmarshal(w.Body.Bytes(), &resp)
-		assert.NoError(t, err)
+		assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 		assert.Equal(t, LoadConfigComplianceStateNotReady, resp.State)
-		assert.Contains(t, resp.Reason, "not fully loaded")
-		assert.Contains(t, resp.Reason, "50%")
+		assert.Contains(t, resp.Reason, "not serviceable")
+		assert.Contains(t, resp.Reason, "catching up")
 	})
 
 	t.Run("correct setup returns Ready", func(t *testing.T) {
@@ -244,6 +258,14 @@ func TestHandleReplicaLoadConfigCompliance(t *testing.T) {
 		mocker2 := mockey.Mock((*querycoordv2.Server).GetInternalReplicasByCollection).Return(replicas).Build()
 		defer mocker2.UnPatch()
 
+		// Mock CheckAllReplicasServiceable to skip the live dist check
+		mockerSvc := mockey.Mock((*querycoordv2.Server).CheckAllReplicasServiceable).Return(nil).Build()
+		defer mockerSvc.UnPatch()
+
+		// Mock GetLeakedResourcesByCollection to report no leaks
+		mocker3 := mockey.Mock((*querycoordv2.Server).GetLeakedResourcesByCollection).Return(0, 0).Build()
+		defer mocker3.UnPatch()
+
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/replicas/compliance", nil)
 		w := httptest.NewRecorder()
 
@@ -255,6 +277,86 @@ func TestHandleReplicaLoadConfigCompliance(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, LoadConfigComplianceStateReady, resp.State)
 		assert.Empty(t, resp.Reason)
+	})
+
+	t.Run("leaked segments returns NotReady", func(t *testing.T) {
+		paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadReplicaNumber.Key, "1")
+		paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.Key, "rg1")
+		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadReplicaNumber.Key)
+		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.Key)
+
+		replicas := []*meta.Replica{
+			meta.NewReplica(&querypb.Replica{ID: 1, CollectionID: 100, ResourceGroup: "rg1"}, typeutil.NewUniqueSet()),
+		}
+
+		coord := &mixCoordImpl{queryCoordServer: &querycoordv2.Server{}}
+
+		mocker1 := mockey.Mock((*mixCoordImpl).ShowLoadCollections).Return(&querypb.ShowCollectionsResponse{
+			Status:              &commonpb.Status{ErrorCode: commonpb.ErrorCode_Success},
+			CollectionIDs:       []int64{100},
+			InMemoryPercentages: []int64{100},
+		}, nil).Build()
+		defer mocker1.UnPatch()
+
+		mocker2 := mockey.Mock((*querycoordv2.Server).GetInternalReplicasByCollection).Return(replicas).Build()
+		defer mocker2.UnPatch()
+
+		mockerSvc := mockey.Mock((*querycoordv2.Server).CheckAllReplicasServiceable).Return(nil).Build()
+		defer mockerSvc.UnPatch()
+
+		// Simulate 5 segments still held by nodes no longer in any replica
+		mocker3 := mockey.Mock((*querycoordv2.Server).GetLeakedResourcesByCollection).Return(5, 0).Build()
+		defer mocker3.UnPatch()
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/replicas/compliance", nil)
+		w := httptest.NewRecorder()
+		coord.HandleReplicaLoadConfigCompliance(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		var resp LoadConfigComplianceResponse
+		assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Equal(t, LoadConfigComplianceStateNotReady, resp.State)
+		assert.Contains(t, resp.Reason, "not fully released")
+		assert.Contains(t, resp.Reason, "leaked segments=5")
+		assert.Contains(t, resp.Reason, "channels=0")
+	})
+
+	t.Run("leaked channels returns NotReady", func(t *testing.T) {
+		paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadReplicaNumber.Key, "1")
+		paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.Key, "rg1")
+		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadReplicaNumber.Key)
+		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.Key)
+
+		replicas := []*meta.Replica{
+			meta.NewReplica(&querypb.Replica{ID: 1, CollectionID: 100, ResourceGroup: "rg1"}, typeutil.NewUniqueSet()),
+		}
+
+		coord := &mixCoordImpl{queryCoordServer: &querycoordv2.Server{}}
+
+		mocker1 := mockey.Mock((*mixCoordImpl).ShowLoadCollections).Return(&querypb.ShowCollectionsResponse{
+			Status:              &commonpb.Status{ErrorCode: commonpb.ErrorCode_Success},
+			CollectionIDs:       []int64{100},
+			InMemoryPercentages: []int64{100},
+		}, nil).Build()
+		defer mocker1.UnPatch()
+
+		mocker2 := mockey.Mock((*querycoordv2.Server).GetInternalReplicasByCollection).Return(replicas).Build()
+		defer mocker2.UnPatch()
+
+		mockerSvc := mockey.Mock((*querycoordv2.Server).CheckAllReplicasServiceable).Return(nil).Build()
+		defer mockerSvc.UnPatch()
+
+		mocker3 := mockey.Mock((*querycoordv2.Server).GetLeakedResourcesByCollection).Return(0, 2).Build()
+		defer mocker3.UnPatch()
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/replicas/compliance", nil)
+		w := httptest.NewRecorder()
+		coord.HandleReplicaLoadConfigCompliance(w, req)
+
+		var resp LoadConfigComplianceResponse
+		assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Equal(t, LoadConfigComplianceStateNotReady, resp.State)
+		assert.Contains(t, resp.Reason, "channels=2")
 	})
 
 	t.Run("internal error returns HTTP 500", func(t *testing.T) {
@@ -327,6 +429,14 @@ func TestHandleReplicaLoadConfigCompliance(t *testing.T) {
 			return replicasMap[collectionID]
 		}).Build()
 		defer mocker2.UnPatch()
+
+		// All replicas serviceable
+		mockerSvc := mockey.Mock((*querycoordv2.Server).CheckAllReplicasServiceable).Return(nil).Build()
+		defer mockerSvc.UnPatch()
+
+		// No leaked resources for either collection
+		mocker3 := mockey.Mock((*querycoordv2.Server).GetLeakedResourcesByCollection).Return(0, 0).Build()
+		defer mocker3.UnPatch()
 
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/replicas/compliance", nil)
 		w := httptest.NewRecorder()

--- a/internal/mocks/streamingcoord/server/mock_balancer/mock_Balancer.go
+++ b/internal/mocks/streamingcoord/server/mock_balancer/mock_Balancer.go
@@ -124,6 +124,52 @@ func (_c *MockBalancer_Close_Call) RunAndReturn(run func()) *MockBalancer_Close_
 	return _c
 }
 
+// ConfirmPrimaryResourceGroupReady provides a mock function with given fields: ctx
+func (_m *MockBalancer) ConfirmPrimaryResourceGroupReady(ctx context.Context) error {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ConfirmPrimaryResourceGroupReady")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockBalancer_ConfirmPrimaryResourceGroupReady_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ConfirmPrimaryResourceGroupReady'
+type MockBalancer_ConfirmPrimaryResourceGroupReady_Call struct {
+	*mock.Call
+}
+
+// ConfirmPrimaryResourceGroupReady is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *MockBalancer_Expecter) ConfirmPrimaryResourceGroupReady(ctx interface{}) *MockBalancer_ConfirmPrimaryResourceGroupReady_Call {
+	return &MockBalancer_ConfirmPrimaryResourceGroupReady_Call{Call: _e.mock.On("ConfirmPrimaryResourceGroupReady", ctx)}
+}
+
+func (_c *MockBalancer_ConfirmPrimaryResourceGroupReady_Call) Run(run func(ctx context.Context)) *MockBalancer_ConfirmPrimaryResourceGroupReady_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context))
+	})
+	return _c
+}
+
+func (_c *MockBalancer_ConfirmPrimaryResourceGroupReady_Call) Return(_a0 error) *MockBalancer_ConfirmPrimaryResourceGroupReady_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockBalancer_ConfirmPrimaryResourceGroupReady_Call) RunAndReturn(run func(context.Context) error) *MockBalancer_ConfirmPrimaryResourceGroupReady_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetAllStreamingNodes provides a mock function with given fields: ctx
 func (_m *MockBalancer) GetAllStreamingNodes(ctx context.Context) (map[int64]*types.StreamingNodeInfoWithResourceGroup, error) {
 	ret := _m.Called(ctx)

--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -49,6 +49,7 @@ import (
 	"github.com/milvus-io/milvus/internal/querycoordv2/params"
 	"github.com/milvus-io/milvus/internal/querycoordv2/session"
 	"github.com/milvus-io/milvus/internal/querycoordv2/task"
+	"github.com/milvus-io/milvus/internal/querycoordv2/utils"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/proxyutil"
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
@@ -881,4 +882,57 @@ func (s *Server) watchLoadConfigChanges() {
 // This method provides access to internal replica information including resource groups.
 func (s *Server) GetInternalReplicasByCollection(ctx context.Context, collectionID int64) []*meta.Replica {
 	return s.meta.GetByCollection(ctx, collectionID)
+}
+
+// CheckAllReplicasServiceable returns an error if any replica has a non-serviceable
+// shard leader for any channel in the collection's current target. Unlike
+// CalculateLoadPercentage (which reads the CollectionObserver's periodically-persisted
+// snapshot), this performs a live check against the distribution manager and so
+// reflects the real-time serviceability after scale-up / scale-down.
+func (s *Server) CheckAllReplicasServiceable(ctx context.Context, collectionID int64) error {
+	replicas := s.meta.GetByCollection(ctx, collectionID)
+	if len(replicas) == 0 {
+		return errors.New("no replica found")
+	}
+	channels := s.targetMgr.GetDmChannelsByCollection(ctx, collectionID, meta.CurrentTarget)
+	if len(channels) == 0 {
+		return errors.New("no channels in current target")
+	}
+	for _, replica := range replicas {
+		for channelName := range channels {
+			leader := s.dist.ChannelDistManager.GetShardLeader(channelName, replica)
+			if leader == nil {
+				return fmt.Errorf("replica %d (rg=%s): no leader for channel %s",
+					replica.GetID(), replica.GetResourceGroup(), channelName)
+			}
+			if err := utils.CheckDelegatorDataReady(s.nodeMgr, s.targetMgr, leader.View, meta.CurrentTarget); err != nil {
+				return fmt.Errorf("replica %d (rg=%s) channel %s not serviceable: %w",
+					replica.GetID(), replica.GetResourceGroup(), channelName, err)
+			}
+		}
+	}
+	return nil
+}
+
+// GetLeakedResourcesByCollection returns the number of segments and channels still held by
+// querynodes that are NOT part of any current replica of the collection. A non-zero result
+// means physical resources have not been fully released yet (e.g., during scale-down a
+// decommissioned replica's querynode may still hold segments while release RPCs are in flight).
+func (s *Server) GetLeakedResourcesByCollection(ctx context.Context, collectionID int64) (leakedSegments, leakedChannels int) {
+	replicas := s.meta.GetByCollection(ctx, collectionID)
+	validNodes := typeutil.NewUniqueSet()
+	for _, r := range replicas {
+		validNodes.Insert(r.GetNodes()...)
+	}
+	for _, seg := range s.dist.SegmentDistManager.GetByFilter(meta.WithCollectionID(collectionID)) {
+		if !validNodes.Contain(seg.Node) {
+			leakedSegments++
+		}
+	}
+	for _, ch := range s.dist.ChannelDistManager.GetByCollectionAndFilter(collectionID) {
+		if !validNodes.Contain(ch.Node) {
+			leakedChannels++
+		}
+	}
+	return leakedSegments, leakedChannels
 }

--- a/internal/querycoordv2/server_test.go
+++ b/internal/querycoordv2/server_test.go
@@ -60,6 +60,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/syncutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/tikv"
+	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
 func TestMain(m *testing.M) {
@@ -937,4 +938,208 @@ func createTestSession(nodeID int64, address string, stopping bool) *sessionutil
 
 func TestServer(t *testing.T) {
 	suite.Run(t, new(ServerSuite))
+}
+
+func TestGetLeakedResourcesByCollection(t *testing.T) {
+	const collectionID int64 = 100
+
+	// Replica in meta holds nodes {10, 11}. Any segment/channel on a different node is leaked.
+	replica := meta.NewReplica(&querypb.Replica{
+		ID:           1,
+		CollectionID: collectionID,
+		Nodes:        []int64{10, 11},
+	}, typeutil.NewUniqueSet(10, 11))
+
+	idAllocator := func() func() (int64, error) {
+		var id int64
+		return func() (int64, error) {
+			id++
+			return id, nil
+		}
+	}
+	newServer := func() *Server {
+		return &Server{
+			meta: meta.NewMeta(idAllocator(), nil, session.NewNodeManager()),
+			dist: meta.NewDistributionManager(session.NewNodeManager()),
+		}
+	}
+
+	t.Run("no segments or channels returns 0", func(t *testing.T) {
+		s := newServer()
+		mocker := mockey.Mock((*meta.ReplicaManager).GetByCollection).Return([]*meta.Replica{replica}).Build()
+		defer mocker.UnPatch()
+
+		leakedSeg, leakedCh := s.GetLeakedResourcesByCollection(context.Background(), collectionID)
+		assert.Equal(t, 0, leakedSeg)
+		assert.Equal(t, 0, leakedCh)
+	})
+
+	t.Run("segments only on replica nodes are not leaked", func(t *testing.T) {
+		s := newServer()
+		mocker := mockey.Mock((*meta.ReplicaManager).GetByCollection).Return([]*meta.Replica{replica}).Build()
+		defer mocker.UnPatch()
+
+		s.dist.SegmentDistManager.Update(10, meta.SegmentFromInfo(&datapb.SegmentInfo{ID: 1, CollectionID: collectionID}))
+		s.dist.SegmentDistManager.Update(11, meta.SegmentFromInfo(&datapb.SegmentInfo{ID: 2, CollectionID: collectionID}))
+
+		leakedSeg, leakedCh := s.GetLeakedResourcesByCollection(context.Background(), collectionID)
+		assert.Equal(t, 0, leakedSeg)
+		assert.Equal(t, 0, leakedCh)
+	})
+
+	t.Run("segments on non-replica nodes are leaked", func(t *testing.T) {
+		s := newServer()
+		mocker := mockey.Mock((*meta.ReplicaManager).GetByCollection).Return([]*meta.Replica{replica}).Build()
+		defer mocker.UnPatch()
+
+		// Node 10 is in replica → not leaked
+		s.dist.SegmentDistManager.Update(10, meta.SegmentFromInfo(&datapb.SegmentInfo{ID: 1, CollectionID: collectionID}))
+		// Nodes 99, 98 are NOT in replica → leaked (these are querynodes pending release during scale-down)
+		s.dist.SegmentDistManager.Update(99, meta.SegmentFromInfo(&datapb.SegmentInfo{ID: 2, CollectionID: collectionID}),
+			meta.SegmentFromInfo(&datapb.SegmentInfo{ID: 3, CollectionID: collectionID}))
+		s.dist.SegmentDistManager.Update(98, meta.SegmentFromInfo(&datapb.SegmentInfo{ID: 4, CollectionID: collectionID}))
+
+		leakedSeg, leakedCh := s.GetLeakedResourcesByCollection(context.Background(), collectionID)
+		assert.Equal(t, 3, leakedSeg)
+		assert.Equal(t, 0, leakedCh)
+	})
+
+	t.Run("channels on non-replica nodes are leaked", func(t *testing.T) {
+		s := newServer()
+		mocker := mockey.Mock((*meta.ReplicaManager).GetByCollection).Return([]*meta.Replica{replica}).Build()
+		defer mocker.UnPatch()
+
+		s.dist.ChannelDistManager.Update(10, meta.DmChannelFromVChannel(&datapb.VchannelInfo{CollectionID: collectionID, ChannelName: "c1"}))
+		s.dist.ChannelDistManager.Update(99, meta.DmChannelFromVChannel(&datapb.VchannelInfo{CollectionID: collectionID, ChannelName: "c2"}))
+
+		leakedSeg, leakedCh := s.GetLeakedResourcesByCollection(context.Background(), collectionID)
+		assert.Equal(t, 0, leakedSeg)
+		assert.Equal(t, 1, leakedCh)
+	})
+
+	t.Run("segments for other collections are ignored", func(t *testing.T) {
+		s := newServer()
+		mocker := mockey.Mock((*meta.ReplicaManager).GetByCollection).Return([]*meta.Replica{replica}).Build()
+		defer mocker.UnPatch()
+
+		// Segment on non-replica node 99 but belongs to different collection
+		s.dist.SegmentDistManager.Update(99, meta.SegmentFromInfo(&datapb.SegmentInfo{ID: 1, CollectionID: 200}))
+
+		leakedSeg, leakedCh := s.GetLeakedResourcesByCollection(context.Background(), collectionID)
+		assert.Equal(t, 0, leakedSeg)
+		assert.Equal(t, 0, leakedCh)
+	})
+}
+
+func TestCheckAllReplicasServiceable(t *testing.T) {
+	const collectionID int64 = 100
+	const channelName = "test-channel-1"
+
+	replica := meta.NewReplica(&querypb.Replica{
+		ID:           1,
+		CollectionID: collectionID,
+		Nodes:        []int64{10, 11},
+	}, typeutil.NewUniqueSet(10, 11))
+
+	idAllocator := func() func() (int64, error) {
+		var id int64
+		return func() (int64, error) {
+			id++
+			return id, nil
+		}
+	}
+	newServer := func() *Server {
+		nodeMgr := session.NewNodeManager()
+		targetMgr := meta.NewMockTargetManager(t)
+		return &Server{
+			meta:      meta.NewMeta(idAllocator(), nil, nodeMgr),
+			dist:      meta.NewDistributionManager(nodeMgr),
+			nodeMgr:   nodeMgr,
+			targetMgr: targetMgr,
+		}
+	}
+
+	t.Run("no replicas returns error", func(t *testing.T) {
+		s := newServer()
+		mocker := mockey.Mock((*meta.ReplicaManager).GetByCollection).Return([]*meta.Replica{}).Build()
+		defer mocker.UnPatch()
+
+		err := s.CheckAllReplicasServiceable(context.Background(), collectionID)
+		assert.ErrorContains(t, err, "no replica")
+	})
+
+	t.Run("no channels in target returns error", func(t *testing.T) {
+		s := newServer()
+		mocker := mockey.Mock((*meta.ReplicaManager).GetByCollection).Return([]*meta.Replica{replica}).Build()
+		defer mocker.UnPatch()
+		s.targetMgr.(*meta.MockTargetManager).EXPECT().GetDmChannelsByCollection(mock.Anything, collectionID, meta.CurrentTarget).Return(map[string]*meta.DmChannel{})
+
+		err := s.CheckAllReplicasServiceable(context.Background(), collectionID)
+		assert.ErrorContains(t, err, "no channels")
+	})
+
+	t.Run("missing shard leader returns error", func(t *testing.T) {
+		s := newServer()
+		mocker := mockey.Mock((*meta.ReplicaManager).GetByCollection).Return([]*meta.Replica{replica}).Build()
+		defer mocker.UnPatch()
+		s.targetMgr.(*meta.MockTargetManager).EXPECT().GetDmChannelsByCollection(mock.Anything, collectionID, meta.CurrentTarget).Return(map[string]*meta.DmChannel{
+			channelName: {VchannelInfo: &datapb.VchannelInfo{CollectionID: collectionID, ChannelName: channelName}},
+		})
+
+		err := s.CheckAllReplicasServiceable(context.Background(), collectionID)
+		assert.ErrorContains(t, err, "no leader for channel")
+	})
+
+	t.Run("leader not serviceable returns error", func(t *testing.T) {
+		s := newServer()
+		mocker := mockey.Mock((*meta.ReplicaManager).GetByCollection).Return([]*meta.Replica{replica}).Build()
+		defer mocker.UnPatch()
+		s.nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{NodeID: 10, Address: "localhost:10", Hostname: "localhost"}))
+		s.targetMgr.(*meta.MockTargetManager).EXPECT().GetDmChannelsByCollection(mock.Anything, collectionID, meta.CurrentTarget).Return(map[string]*meta.DmChannel{
+			channelName: {VchannelInfo: &datapb.VchannelInfo{CollectionID: collectionID, ChannelName: channelName}},
+		})
+		// Segment exists in target but not in leader's view -> CheckDelegatorDataReady fails
+		s.targetMgr.(*meta.MockTargetManager).EXPECT().GetSealedSegmentsByChannel(mock.Anything, collectionID, channelName, meta.CurrentTarget).Return(map[int64]*datapb.SegmentInfo{
+			42: {ID: 42, CollectionID: collectionID},
+		})
+
+		s.dist.ChannelDistManager.Update(10, &meta.DmChannel{
+			VchannelInfo: &datapb.VchannelInfo{CollectionID: collectionID, ChannelName: channelName},
+			Node:         10,
+			Version:      1,
+			View: &meta.LeaderView{
+				ID: 10, CollectionID: collectionID, Channel: channelName,
+				Status:   &querypb.LeaderViewStatus{Serviceable: true},
+				Segments: map[int64]*querypb.SegmentDist{}, // empty → lacks segment 42
+			},
+		})
+
+		err := s.CheckAllReplicasServiceable(context.Background(), collectionID)
+		assert.ErrorContains(t, err, "not serviceable")
+	})
+
+	t.Run("all serviceable returns nil", func(t *testing.T) {
+		s := newServer()
+		mocker := mockey.Mock((*meta.ReplicaManager).GetByCollection).Return([]*meta.Replica{replica}).Build()
+		defer mocker.UnPatch()
+		s.nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{NodeID: 10, Address: "localhost:10", Hostname: "localhost"}))
+		s.targetMgr.(*meta.MockTargetManager).EXPECT().GetDmChannelsByCollection(mock.Anything, collectionID, meta.CurrentTarget).Return(map[string]*meta.DmChannel{
+			channelName: {VchannelInfo: &datapb.VchannelInfo{CollectionID: collectionID, ChannelName: channelName}},
+		})
+		s.targetMgr.(*meta.MockTargetManager).EXPECT().GetSealedSegmentsByChannel(mock.Anything, collectionID, channelName, meta.CurrentTarget).Return(map[int64]*datapb.SegmentInfo{})
+
+		s.dist.ChannelDistManager.Update(10, &meta.DmChannel{
+			VchannelInfo: &datapb.VchannelInfo{CollectionID: collectionID, ChannelName: channelName},
+			Node:         10,
+			Version:      1,
+			View: &meta.LeaderView{
+				ID: 10, CollectionID: collectionID, Channel: channelName,
+				Status:   &querypb.LeaderViewStatus{Serviceable: true},
+				Segments: map[int64]*querypb.SegmentDist{},
+			},
+		})
+
+		err := s.CheckAllReplicasServiceable(context.Background(), collectionID)
+		assert.NoError(t, err)
+	})
 }

--- a/internal/streamingcoord/server/balancer/balancer.go
+++ b/internal/streamingcoord/server/balancer/balancer.go
@@ -38,6 +38,13 @@ type Balancer interface {
 	// GetAvailableStreamingNodes fetches streaming node info with resource group excluding frozen nodes.
 	GetAvailableStreamingNodes(ctx context.Context) (map[int64]*types.StreamingNodeInfoWithResourceGroup, error)
 
+	// ConfirmPrimaryResourceGroupReady returns nil iff every RW pchannel is currently
+	// assigned to a streaming node that belongs to the configured primary resource group.
+	// Used by compliance checks to verify that a primary-RG change has finished
+	// propagating through the WAL layout before signaling Ready.
+	// If streaming.primaryResourceGroup is not configured, returns nil.
+	ConfirmPrimaryResourceGroupReady(ctx context.Context) error
+
 	// AllocVirtualChannels allocates virtual channels for a collection.
 	AllocVirtualChannels(ctx context.Context, param AllocVChannelParam) ([]string, error)
 

--- a/internal/streamingcoord/server/balancer/balancer_impl.go
+++ b/internal/streamingcoord/server/balancer/balancer_impl.go
@@ -137,6 +137,46 @@ func (b *balancerImpl) GetAvailableStreamingNodes(ctx context.Context) (map[int6
 	return filtered, nil
 }
 
+// ConfirmPrimaryResourceGroupReady returns nil iff every RW pchannel is currently
+// assigned to a streaming node that belongs to the configured primary resource group.
+// If streaming.primaryResourceGroup is not configured, returns nil.
+func (b *balancerImpl) ConfirmPrimaryResourceGroupReady(ctx context.Context) error {
+	if !b.lifetime.Add(typeutil.LifetimeStateWorking) {
+		return status.NewOnShutdownError("balancer is closing")
+	}
+	defer b.lifetime.Done()
+
+	primaryRG := paramtable.Get().StreamingCfg.PrimaryResourceGroup.GetValue()
+	if primaryRG == "" {
+		return nil
+	}
+	nodes, err := resource.Resource().StreamingNodeManagerClient().GetAllStreamingNodes(ctx)
+	if err != nil {
+		return err
+	}
+	assignment, err := b.channelMetaManager.GetLatestChannelAssignment()
+	if err != nil {
+		return err
+	}
+	for _, rel := range assignment.Relations {
+		// Only RW pchannels carry WAL writes; RO pchannels (e.g., CDC source) are
+		// not constrained by the local primary RG.
+		if rel.Channel.AccessMode != types.AccessModeRW {
+			continue
+		}
+		node, ok := nodes[rel.Node.ServerID]
+		if !ok {
+			return status.NewInner("pchannel %s: assigned node %d not found in streaming nodes",
+				rel.Channel.Name, rel.Node.ServerID)
+		}
+		if node.ResourceGroup != primaryRG {
+			return status.NewInner("pchannel %s still on rg=%s, expected primary rg=%s (WAL migration in progress)",
+				rel.Channel.Name, node.ResourceGroup, primaryRG)
+		}
+	}
+	return nil
+}
+
 // GetLatestWALLocated returns the server id of the node that the wal of the vChannel is located.
 func (b *balancerImpl) GetLatestWALLocated(ctx context.Context, pchannel string) (int64, bool) {
 	return b.channelMetaManager.GetLatestWALLocated(ctx, pchannel)

--- a/pkg/config/etcd_source.go
+++ b/pkg/config/etcd_source.go
@@ -143,7 +143,26 @@ func (es *EtcdSource) UpdateOptions(opts Options) {
 	}
 }
 
+// refreshConfigurations is the serializable-read variant used by the periodic async
+// refresher. Registered as a func() error callback via newRefresher(...), so the
+// signature must stay no-arg. WithSerializable lets the locally-connected etcd member
+// answer from its own applied state without a ReadIndex round-trip to the leader —
+// acceptable for an async poll where sub-ms staleness is harmless (see #23907).
 func (es *EtcdSource) refreshConfigurations() error {
+	return es.refreshConfigurationsWithOpts(clientv3.WithSerializable())
+}
+
+// RefreshConfigurationsLinearizable is the linearizable-read variant for
+// post-write "read-your-own-write" paths (e.g., AlterConfigsInEtcd). Issues one
+// extra ReadIndex round-trip to the etcd leader per call, guaranteeing that the
+// read reflects every committed entry — including the one the caller just wrote.
+// Without this, the follower the client is connected to can legitimately return
+// the pre-write value because apply is not synchronized with commit.
+func (es *EtcdSource) RefreshConfigurationsLinearizable() error {
+	return es.refreshConfigurationsWithOpts()
+}
+
+func (es *EtcdSource) refreshConfigurationsWithOpts(extraOpts ...clientv3.OpOption) error {
 	log := log.Ctx(es.ctx).WithRateGroup("config.etcdSource", 1, 60)
 	es.RLock()
 	prefix := path.Join(es.keyPrefix, "config")
@@ -152,7 +171,8 @@ func (es *EtcdSource) refreshConfigurations() error {
 	ctx, cancel := context.WithTimeout(es.ctx, ReadConfigTimeout)
 	defer cancel()
 	log.RatedDebug(10, "etcd refreshConfigurations", zap.String("prefix", prefix), zap.Any("endpoints", es.etcdCli.Endpoints()))
-	response, err := es.etcdCli.Get(ctx, prefix, clientv3.WithPrefix(), clientv3.WithSerializable())
+	opts := append([]clientv3.OpOption{clientv3.WithPrefix()}, extraOpts...)
+	response, err := es.etcdCli.Get(ctx, prefix, opts...)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -543,7 +543,7 @@ func (m *Manager) ProcessImmutableConfigs() error {
 
 	if len(savedConfigs) > 0 {
 		log.Info("triggering etcd source refresh after saving immutable configs", zap.Strings("savedConfigs", savedConfigs))
-		if refreshErr := etcdSourceImpl.refreshConfigurations(); refreshErr != nil {
+		if refreshErr := etcdSourceImpl.RefreshConfigurationsLinearizable(); refreshErr != nil {
 			log.Warn("failed to refresh etcd configurations after saving immutable configs", zap.Error(refreshErr))
 		} else {
 			log.Info("successfully refreshed etcd configurations after saving immutable configs")
@@ -622,8 +622,10 @@ func (m *Manager) AlterConfigsInEtcd(etcdSource *EtcdSource, updates map[string]
 	}
 
 	// Proactively refresh local EtcdSource so the write is immediately visible in this process,
-	// rather than waiting for the async etcd-watch refresher.
-	if err := etcdSource.refreshConfigurations(); err != nil {
+	// rather than waiting for the async etcd-watch refresher. Linearizable read (no
+	// WithSerializable) ensures the follower we read from has applied the txn we just
+	// committed — the async refresher's serializable path would not provide that guarantee.
+	if err := etcdSource.RefreshConfigurationsLinearizable(); err != nil {
 		return err
 	}
 

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -621,6 +621,12 @@ func (m *Manager) AlterConfigsInEtcd(etcdSource *EtcdSource, updates map[string]
 		return fmt.Errorf("failed to atomically alter configs in etcd: %w", err)
 	}
 
+	// Proactively refresh local EtcdSource so the write is immediately visible in this process,
+	// rather than waiting for the async etcd-watch refresher.
+	if err := etcdSource.refreshConfigurations(); err != nil {
+		return err
+	}
+
 	log.Info("configs atomically altered in etcd",
 		zap.Int("updates", len(updates)),
 		zap.Int("deletes", len(deletes)),


### PR DESCRIPTION
issue: #47314
pr: #49210

- pkg/config: AlterConfigsInEtcd now proactively refreshes the local EtcdSource after etcd write succeeds, so callers reading paramtable in the same process see the new values immediately (previously relied on async etcd-watch refresher, causing HandleAlterConfig to return before local paramtable was updated).
- querycoordv2: add GetLeakedResourcesByCollection which reports segments/ channels still held by querynodes no longer in any replica of a collection — true signal that physical resources are being released during scale-down.
- coordinator/restful_replica: compliance check now returns NotReady until GetLeakedResourcesByCollection reports zero, so compliance Ready truly means "safe to terminate removed nodes" rather than just meta-level convergence.
- Unit tests: 5 cases for GetLeakedResourcesByCollection and 2 cases for leaked-resource compliance branch; update existing Ready-path tests to mock GetLeakedResourcesByCollection.