### PR TITLE
fix: [3.0] Remove incorrect lastDeltaTimestamp skip losing L0 deltas

### DIFF
--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -525,6 +525,31 @@ func (s *LocalSegment) LastDeltaTimestamp() uint64 {
 	return s.lastDeltaTimestamp.Load()
 }
 
+// advanceLastDeltaTimestamp moves lastDeltaTimestamp forward to max(current, max(tss)).
+// Consumers (file-level skip in segment_loader.LoadDeltaLogs, dist_handler reporting to
+// QueryCoord) treat this field as a high-water-mark. Using tss[last] on unsorted batches
+// underestimates the watermark, so we scan for the true max.
+func (s *LocalSegment) advanceLastDeltaTimestamp(tss []typeutil.Timestamp) {
+	if len(tss) == 0 {
+		return
+	}
+	maxTs := tss[0]
+	for _, t := range tss[1:] {
+		if t > maxTs {
+			maxTs = t
+		}
+	}
+	for {
+		cur := s.lastDeltaTimestamp.Load()
+		if maxTs <= cur {
+			return
+		}
+		if s.lastDeltaTimestamp.CompareAndSwap(cur, maxTs) {
+			return
+		}
+	}
+}
+
 // UpdatePkCandidate updates the PK candidate with provided pks and charges resource.
 // Overrides baseSegment.UpdatePkCandidate to handle resource charging for growing segments.
 func (s *LocalSegment) UpdatePkCandidate(pks []storage.PrimaryKey) {
@@ -816,12 +841,11 @@ func (s *LocalSegment) Delete(ctx context.Context, primaryKeys storage.PrimaryKe
 	s.deltaMut.Lock()
 	defer s.deltaMut.Unlock()
 
-	if s.lastDeltaTimestamp.Load() >= timestamps[len(timestamps)-1] {
-		log.Info("skip delete due to delete record before lastDeltaTimestamp",
-			zap.Int64("segmentID", s.ID()),
-			zap.Uint64("lastDeltaTimestamp", s.lastDeltaTimestamp.Load()))
-		return nil
-	}
+	// segcore DeletedRecord::InternalPush is idempotent on (PK, ts):
+	// duplicate deletes against already-deleted rows are discarded internally.
+	// Do NOT add a ts-watermark skip here. In L0-forward + partial-L0-compaction
+	// scenarios, batches contain ts values below the watermark that have NOT yet
+	// been applied to this segment, and skipping them causes silent data loss.
 
 	var err error
 	GetDynamicPool().Submit(func() (any, error) {
@@ -845,7 +869,10 @@ func (s *LocalSegment) Delete(ctx context.Context, primaryKeys storage.PrimaryKe
 	}
 
 	s.rowNum.Store(-1)
-	s.lastDeltaTimestamp.Store(timestamps[len(timestamps)-1])
+	// Track max ts as a high-water-mark (consumed by file-level skip in
+	// LoadDeltaLogs and by dist_handler for QueryCoord reporting). Using
+	// tss[last] on unsorted batches underestimates the watermark.
+	s.advanceLastDeltaTimestamp(timestamps)
 	return nil
 }
 
@@ -931,11 +958,9 @@ func (s *LocalSegment) LoadDeltaData(ctx context.Context, deltaData *storage.Del
 	s.deltaMut.Lock()
 	defer s.deltaMut.Unlock()
 
-	if s.lastDeltaTimestamp.Load() >= tss[len(tss)-1] {
-		log.Info("skip load delta data due to delete record before lastDeltaTimestamp",
-			zap.Uint64("lastDeltaTimestamp", s.lastDeltaTimestamp.Load()))
-		return nil
-	}
+	// See comment in Delete(): segcore dedups at (PK, ts) level, and tss is
+	// NOT sorted across L0 segments (BufferForwarder appends in iteration
+	// order), so comparing against tss[last] is both unnecessary and incorrect.
 
 	ids, err := storage.ParsePrimaryKeysBatch2IDs(pks)
 	if err != nil {
@@ -979,7 +1004,7 @@ func (s *LocalSegment) LoadDeltaData(ctx context.Context, deltaData *storage.Del
 	}
 
 	s.rowNum.Store(-1)
-	s.lastDeltaTimestamp.Store(tss[len(tss)-1])
+	s.advanceLastDeltaTimestamp(tss)
 
 	log.Info("load deleted record done",
 		zap.Int64("rowNum", rowNum),

--- a/internal/querynodev2/segments/segment_test.go
+++ b/internal/querynodev2/segments/segment_test.go
@@ -263,6 +263,89 @@ func (suite *SegmentSuite) TestDeleteSameTimestampAcrossBatches() {
 	suite.Equal(int64(100), suite.sealed.InsertCount())
 }
 
+// TestLoadDeltaData_LowerTsNotSkipped guards against the bug where L0-forwarded
+// deletes with ts lower than the already-applied manifest-delta watermark
+// were silently dropped, causing snapshot restore to retain deleted rows.
+//
+// Reproduction: apply a delete at a high ts (simulating segment's own _delta/
+// loaded from manifest), then apply a delete for a DIFFERENT PK at a lower ts
+// (simulating L0 segment delete forwarded by delegator). Both must take effect.
+// Before the fix, the second call was skipped entirely via:
+//
+//	if s.lastDeltaTimestamp.Load() >= tss[len(tss)-1] { return nil }
+func (suite *SegmentSuite) TestLoadDeltaData_LowerTsNotSkipped() {
+	ctx := context.Background()
+
+	// Phase 1: apply delete for PK=80 at ts=2000 (simulates manifest _delta/).
+	pksHigh := storage.NewInt64PrimaryKeys(1)
+	pksHigh.AppendRaw(80)
+	ddHigh, err := storage.NewDeltaDataWithData(pksHigh, []uint64{2000})
+	suite.Require().NoError(err)
+	suite.Require().NoError(suite.sealed.(*LocalSegment).LoadDeltaData(ctx, ddHigh))
+	suite.EqualValues(2000, suite.sealed.(*LocalSegment).LastDeltaTimestamp())
+
+	// Phase 2: L0-forwarded delete for PK=10 at ts=1000 (LOWER than watermark).
+	// Must be applied — before the fix this was silently dropped.
+	pksLow := storage.NewInt64PrimaryKeys(1)
+	pksLow.AppendRaw(10)
+	ddLow, err := storage.NewDeltaDataWithData(pksLow, []uint64{1000})
+	suite.Require().NoError(err)
+	suite.Require().NoError(suite.sealed.(*LocalSegment).LoadDeltaData(ctx, ddLow))
+
+	// Both PKs deleted => RowNum = 100 - 2 = 98.
+	suite.EqualValues(98, suite.sealed.RowNum())
+	// Watermark stays at max, not regresses to 1000.
+	suite.EqualValues(2000, suite.sealed.(*LocalSegment).LastDeltaTimestamp())
+}
+
+// TestLoadDeltaData_UnsortedBatchAllApplied guards against the BufferForwarder
+// interaction: rangeHitL0Deletions iterates L0 segments in unsorted order, so
+// tss[last] is whichever L0 segment was visited last, NOT the batch max.
+// A batch like tss=[1500, 500] would previously be compared as tss[1]=500
+// against watermark and (if watermark >= 500) get entirely dropped, including
+// the PK at ts=1500 that was ABOVE the watermark.
+func (suite *SegmentSuite) TestLoadDeltaData_UnsortedBatchAllApplied() {
+	ctx := context.Background()
+
+	// Establish watermark at 1000.
+	pksInit := storage.NewInt64PrimaryKeys(1)
+	pksInit.AppendRaw(99)
+	ddInit, err := storage.NewDeltaDataWithData(pksInit, []uint64{1000})
+	suite.Require().NoError(err)
+	suite.Require().NoError(suite.sealed.(*LocalSegment).LoadDeltaData(ctx, ddInit))
+
+	// Unsorted batch: first ts=1500 (above watermark), last ts=500 (below).
+	// Must apply both. Before fix: tss[last]=500 <= 1000 => entire batch dropped.
+	pksMixed := storage.NewInt64PrimaryKeys(2)
+	pksMixed.AppendRaw(20, 30)
+	ddMixed, err := storage.NewDeltaDataWithData(pksMixed, []uint64{1500, 500})
+	suite.Require().NoError(err)
+	suite.Require().NoError(suite.sealed.(*LocalSegment).LoadDeltaData(ctx, ddMixed))
+
+	suite.EqualValues(97, suite.sealed.RowNum()) // 100 - 3 deletes
+	// Watermark advances to batch max, not last.
+	suite.EqualValues(1500, suite.sealed.(*LocalSegment).LastDeltaTimestamp())
+}
+
+// TestAdvanceLastDeltaTimestamp_NeverRegresses verifies the watermark is
+// monotonic: a lower-max batch after a higher-max batch must not regress it.
+func (suite *SegmentSuite) TestAdvanceLastDeltaTimestamp_NeverRegresses() {
+	ctx := context.Background()
+
+	pksA := storage.NewInt64PrimaryKeys(1)
+	pksA.AppendRaw(11)
+	ddA, _ := storage.NewDeltaDataWithData(pksA, []uint64{5000})
+	suite.Require().NoError(suite.sealed.(*LocalSegment).LoadDeltaData(ctx, ddA))
+	suite.EqualValues(5000, suite.sealed.(*LocalSegment).LastDeltaTimestamp())
+
+	pksB := storage.NewInt64PrimaryKeys(1)
+	pksB.AppendRaw(12)
+	ddB, _ := storage.NewDeltaDataWithData(pksB, []uint64{2000})
+	suite.Require().NoError(suite.sealed.(*LocalSegment).LoadDeltaData(ctx, ddB))
+	// Watermark stays at 5000, not regresses to 2000.
+	suite.EqualValues(5000, suite.sealed.(*LocalSegment).LastDeltaTimestamp())
+}
+
 func (suite *SegmentSuite) TestSegmentReleased() {
 	suite.sealed.Release(context.Background())
 


### PR DESCRIPTION
pr: #49015

Cherry-pick of #49015 to 3.0 branch.

Signed-off-by: Wei Liu <wei.liu@zilliz.com>