### PR TITLE
fix: reject ARRAY element access with IS NULL / IS NOT NULL at parse time (2.6)

### DIFF
--- a/internal/parser/planparserv2/parser_visitor.go
+++ b/internal/parser/planparserv2/parser_visitor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	parser "github.com/milvus-io/milvus/internal/parser/planparserv2/generated"
 	"github.com/milvus-io/milvus/pkg/v2/proto/planpb"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/timestamptz"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
@@ -1431,6 +1432,9 @@ func (v *ParserVisitor) VisitIsNotNull(ctx *parser.IsNotNullContext) interface{}
 	}
 
 	if len(column.NestedPath) != 0 {
+		if typeutil.IsArrayType(column.GetDataType()) {
+			return merr.WrapErrParameterInvalidMsg("IsNull/IsNotNull operations are not supported on array element access, got: %s", ctx.GetText())
+		}
 		// convert json not null expr to exists expr, eg: json['a'] is not null -> exists json['a']
 		expr := &planpb.Expr{
 			Expr: &planpb.Expr_ExistsExpr{
@@ -1471,6 +1475,9 @@ func (v *ParserVisitor) VisitIsNull(ctx *parser.IsNullContext) interface{} {
 	}
 
 	if len(column.NestedPath) != 0 {
+		if typeutil.IsArrayType(column.GetDataType()) {
+			return merr.WrapErrParameterInvalidMsg("IsNull/IsNotNull operations are not supported on array element access, got: %s", ctx.GetText())
+		}
 		// convert json is null expr to not exists expr, eg: json['a'] is null -> not exists json['a']
 		expr := &planpb.Expr{
 			Expr: &planpb.Expr_ExistsExpr{

--- a/internal/parser/planparserv2/plan_parser_v2_test.go
+++ b/internal/parser/planparserv2/plan_parser_v2_test.go
@@ -625,6 +625,8 @@ func TestExpr_IsNull(t *testing.T) {
 	exprStrs := []string{
 		`VarCharField is null`,
 		`VarCharField IS NULL`,
+		`ArrayField is null`,
+		`StringArrayField IS NULL`,
 	}
 	for _, exprStr := range exprStrs {
 		assertValidExpr(t, helper, exprStr)
@@ -632,6 +634,12 @@ func TestExpr_IsNull(t *testing.T) {
 
 	unsupported := []string{
 		`not_exist is null`,
+		// issue #48904: array element access with IS NULL should be
+		// rejected at parse time rather than raising an internal error
+		// at execution time.
+		`ArrayField[0] is null`,
+		`ArrayField[1] IS NULL`,
+		`StringArrayField[0] is null`,
 	}
 	for _, exprStr := range unsupported {
 		assertInvalidExpr(t, helper, exprStr)
@@ -646,6 +654,8 @@ func TestExpr_IsNotNull(t *testing.T) {
 	exprStrs := []string{
 		`VarCharField is not null`,
 		`VarCharField IS NOT NULL`,
+		`ArrayField is not null`,
+		`StringArrayField IS NOT NULL`,
 	}
 	for _, exprStr := range exprStrs {
 		assertValidExpr(t, helper, exprStr)
@@ -653,6 +663,12 @@ func TestExpr_IsNotNull(t *testing.T) {
 
 	unsupported := []string{
 		`not_exist is not null`,
+		// issue #48904: array element access with IS NOT NULL should be
+		// rejected at parse time rather than raising an internal error
+		// at execution time.
+		`ArrayField[0] is not null`,
+		`ArrayField[1] IS NOT NULL`,
+		`StringArrayField[0] is not null`,
 	}
 	for _, exprStr := range unsupported {
 		assertInvalidExpr(t, helper, exprStr)

--- a/tests/python_client/milvus_client/test_milvus_client_search.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search.py
@@ -532,8 +532,10 @@ class TestMilvusClientSearchInvalid(TestMilvusClientV2Base):
         self.insert(client, collection_name, rows)
         # 3. search
         null_expr = nullable_field_name + "[0]" + " " + null_expr_op
-        error = {ct.err_code: 65535,
-                 ct.err_msg: "unsupported data type: ARRAY"}
+        error = {
+            ct.err_code: 1100,
+            ct.err_msg: "IsNull/IsNotNull operations are not supported on array element access",
+        }
         self.search(client, collection_name, [vectors[0]],
                     filter=null_expr,
                     check_task=CheckTasks.err_res, check_items=error)


### PR DESCRIPTION
## Summary

Cherry-pick of #49240 into the 2.6 branch.

When a nullable ARRAY field is queried with a subscript and `IS NULL` / `IS NOT NULL` (e.g. `arr_int[0] is null`), the plan parser blindly translated the expression into an `ExistsExpr` carrying a `DataType::ARRAY` column. The C++ `PhyExistsFilterExpr` only supports `DataType::JSON` and therefore surfaced an internal `unsupported data type: ARRAY` error from `ExistsExpr.cpp:79` instead of a clear validation failure.

Milvus ARRAY elements are not individually nullable, so there is no well-defined semantics for `arr[i] IS NULL`. Reject the expression in `VisitIsNull` / `VisitIsNotNull` with a user-facing parameter error.

The 2.6 branch did not yet carry the later master-only vector-field IsNull guard, so the test additions on this cherry-pick are narrowed to the array-subscript cases that are actually introduced by this fix.

## Test plan

- [x] `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/parser/planparserv2/` passes.

issue: #48904
pr: #49575