### PR TITLE
test: [cp3.0] cherry-pick test coverage improvements and bug fixes from master

### DIFF
--- a/internal/proxy/search_util.go
+++ b/internal/proxy/search_util.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/google/uuid"
+	"github.com/tidwall/gjson"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
@@ -112,7 +113,7 @@ type SearchInfo struct {
 // and whether a filter expression is present. The caller supplies hasFilter
 // because the DSL/expression is not available inside parseSearchInfo.
 func (s *SearchInfo) DetermineSearchType(hasFilter bool) internalpb.SearchType {
-	isRangeSearch := strings.Contains(s.planInfo.GetSearchParams(), radiusKey)
+	isRangeSearch := gjson.Get(s.planInfo.GetSearchParams(), radiusKey).Exists()
 	hasGroupBy := s.planInfo.GetGroupByFieldId() > 0
 	if isRangeSearch || hasGroupBy || s.isIterator || s.iterativeFilter {
 		return internalpb.SearchType_DEFAULT
@@ -543,8 +544,12 @@ func parseSearchInfo(searchParamsPair []*commonpb.KeyValuePair, schema *schemapb
 			"Not allowed to do groupBy when doing iteration")
 	}
 
-	isRangeSearch = strings.Contains(searchParamStr, radiusKey)
+	isRangeSearch = gjson.Get(searchParamStr, radiusKey).Exists()
 	isIterativeFilter = (hints == iterativeFilterKey) || strings.Contains(searchParamStr, iterativeFilterKey)
+	if !isRangeSearch && gjson.Get(searchParamStr, rangeFilterKey).Exists() {
+		return nil, merr.WrapErrParameterInvalid("range_filter", "",
+			"range_filter requires radius to be set; range_filter alone is not a valid range search parameter")
+	}
 	if isRangeSearch && groupByFieldId > 0 {
 		return nil, merr.WrapErrParameterInvalid("", "",
 			"Not allowed to do range-search when doing search-group-by")

--- a/internal/proxy/task_search_test.go
+++ b/internal/proxy/task_search_test.go
@@ -3292,6 +3292,37 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 				t.Logf("err=%s", err)
 			})
 		}
+
+		t.Run("range_filter_without_radius", func(t *testing.T) {
+			// range_filter without radius should be rejected: range_filter is a secondary
+			// bound that only makes sense when a primary radius boundary is also set.
+			// Without radius, the engine silently ignores range_filter and falls back to
+			// regular top-K search (issue #48915).
+			spRangeFilterOnly := make([]*commonpb.KeyValuePair, len(noRoundDecimal))
+			copy(spRangeFilterOnly, noRoundDecimal)
+			resetSearchParamsValue(spRangeFilterOnly, ParamsKey, `{"nprobe": 10, "range_filter": 0.5}`)
+			searchInfo, err := parseSearchInfo(spRangeFilterOnly, nil, nil, false)
+			assert.Error(t, err)
+			assert.Nil(t, searchInfo)
+			assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+			assert.Contains(t, err.Error(), "range_filter")
+			assert.Contains(t, err.Error(), "radius")
+		})
+
+		t.Run("range_filter_with_not_radius_key", func(t *testing.T) {
+			// "not_radius" contains "radius" as a substring; a naive strings.Contains
+			// check would falsely treat this as a range search and skip the validation.
+			// gjson.Get does an exact JSON key lookup so this must still be rejected.
+			spBadKey := make([]*commonpb.KeyValuePair, len(noRoundDecimal))
+			copy(spBadKey, noRoundDecimal)
+			resetSearchParamsValue(spBadKey, ParamsKey, `{"nprobe": 10, "not_radius": 1, "range_filter": 0.5}`)
+			searchInfo, err := parseSearchInfo(spBadKey, nil, nil, false)
+			assert.Error(t, err)
+			assert.Nil(t, searchInfo)
+			assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+			assert.Contains(t, err.Error(), "range_filter")
+			assert.Contains(t, err.Error(), "radius")
+		})
 	})
 	t.Run("check iterator and groupBy", func(t *testing.T) {
 		normalParam := getValidSearchParams()

--- a/tests/go_client/base/milvus_client.go
+++ b/tests/go_client/base/milvus_client.go
@@ -80,6 +80,9 @@ func NewMilvusClient(ctx context.Context, cfg *client.ClientConfig) (*MilvusClie
 }
 
 func (mc *MilvusClient) Close(ctx context.Context) error {
+	if mc.Client == nil {
+		return nil
+	}
 	err := mc.Client.Close(ctx)
 	return err
 }

--- a/tests/go_client/testcases/helper/test_setup.go
+++ b/tests/go_client/testcases/helper/test_setup.go
@@ -97,6 +97,7 @@ func teardown() {
 	mc, err := base.NewMilvusClient(ctx, &client.ClientConfig{Address: GetAddr(), Username: GetUser(), Password: GetPassword()})
 	if err != nil {
 		log.Error("teardown failed to connect milvus with error", zap.Error(err))
+		return
 	}
 	defer mc.Close(ctx)
 

--- a/tests/python_client/milvus_client/test_milvus_client_search_iterator.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search_iterator.py
@@ -58,7 +58,9 @@ class TestMilvusClientSearchIteratorInValid(TestMilvusClientV2Base):
         """
         target: test search iterator(high level api) case about mul db
         method: create connection, collection, insert and search iterator
-        expected: search iterator error after switch to another db
+        expected: SearchIteratorV2 captures db_name at creation time, so switching db after
+                  iterator creation does NOT affect the iterator — it continues to return results
+                  from the original db without error.
         """
         batch_size = 20
         client = self._client()
@@ -66,31 +68,32 @@ class TestMilvusClientSearchIteratorInValid(TestMilvusClientV2Base):
         my_db = cf.gen_unique_str(prefix)
         self.create_database(client, my_db)
         self.using_database(client, my_db)
-        # 1. create collection
+        # 1. create collection in my_db
         self.create_collection(client, collection_name, default_dim, consistency_level="Bounded")
         collections = self.list_collections(client)[0]
         assert collection_name in collections
-        # 2. insert
+        # 2. insert into my_db collection
         rows = [{default_primary_key_field_name: i, default_vector_field_name: list(cf.gen_vectors(1, default_dim)[0]),
                  default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(default_nb)]
         self.insert(client, collection_name, rows)
         self.flush(client, collection_name)
         self.using_database(client, "default")
-        # 3. create collection
+        # 3. create same-named collection in default db
         self.create_collection(client, collection_name, default_dim, consistency_level="Bounded")
         collections = self.list_collections(client)[0]
         assert collection_name in collections
-        # 4. insert
+        # 4. insert into default db collection
         self.insert(client, collection_name, rows)
         self.flush(client, collection_name)
-        # 5. search_iterator
+        # 5. search_iterator: created on default db; switch to my_db after creation.
+        #    With SearchIteratorV2, db_name is captured at creation — the switch has no effect
+        #    and the iterator continues to return results from the default db collection.
         vectors_to_search = cf.gen_vectors(1, default_dim)
         search_params = {"params": {}}
-        error_msg = "alias or database may have been changed"
         self.search_iterator(client, collection_name, vectors_to_search, batch_size, search_params=search_params,
                              use_mul_db=True, another_db=my_db,
                              check_task=CheckTasks.check_search_iterator,
-                             check_items={ct.err_code: 1, ct.err_msg: error_msg})
+                             check_items={"batch_size": batch_size})
         self.release_collection(client, collection_name)
         self.drop_collection(client, collection_name)
 

--- a/tests/python_client/milvus_client_v2/test_milvus_client_range_search.py
+++ b/tests/python_client/milvus_client_v2/test_milvus_client_range_search.py
@@ -131,44 +131,43 @@ class TestRangeSearchCosineShared(TestMilvusClientV2Base):
     @pytest.mark.tags(CaseLabel.L2)
     def test_range_search_only_range_filter(self):
         """
-        target: test range search with only range filter
-        method: create connection, collection, insert and search
-        expected: range search successfully as normal search
+        target: test range search with only range_filter (no radius) is rejected
+        method: search with range_filter but no radius for COSINE/IP/L2 metrics
+        expected: search fails with ErrParameterInvalid; range_filter requires radius
+
+        Background: before fix #48915, range_filter without radius was silently ignored
+        by the C++ core and fell back to regular top-K search, returning results that
+        violated the range_filter constraint (e.g. self-match with distance=1.0 despite
+        range_filter=0.5). The proxy now rejects such requests explicitly.
         """
         client = self._client(alias=self.shared_alias)
 
-        # 2. get vectors that inserted into collection
+        # get vectors that inserted into collection
         query_res, _ = self.query(client, self.collection_name, filter=default_search_exp,
                                   output_fields=[ct.default_float_vec_field_name])
         search_vectors = [row[ct.default_float_vec_field_name] for row in query_res[:default_nq]]
 
-        # 3. range search with COSINE (only range_filter, no radius)
-        # Known limitation (milvus-io/milvus#48915): range_filter without radius is silently ignored;
-        # the search falls back to a normal top-K search. Just verify it succeeds.
-        range_search_params = {"metric_type": "COSINE",
-                               "params": {"range_filter": 0.5}}
-        search_res, _ = self.search(client, self.collection_name,
-                    data=search_vectors[:default_nq],
-                    anns_field=default_search_field,
-                    search_params=range_search_params,
-                    limit=default_limit,
-                    filter=default_search_exp)
-        # verify search returns results (range_filter without radius behaves as normal top-K)
-        for hits in search_res:
-            assert len(hits) > 0
-        # 4. range search with IP (should fail - metric mismatch)
-        range_search_params = {"metric_type": "IP",
-                               "params": {"range_filter": 1}}
+        # range_filter without radius must be rejected (COSINE)
         self.search(client, self.collection_name,
                     data=search_vectors[:default_nq],
                     anns_field=default_search_field,
-                    search_params=range_search_params,
+                    search_params={"metric_type": "COSINE", "params": {"range_filter": 0.5}},
                     limit=default_limit,
                     filter=default_search_exp,
                     check_task=CheckTasks.err_res,
-                    check_items={ct.err_code: 65535,
-                                 ct.err_msg: "metric type not match: "
-                                             "invalid parameter[expected=COSINE][actual=IP]"})
+                    check_items={ct.err_code: 1100,
+                                 ct.err_msg: "range_filter requires radius to be set"})
+
+        # range_filter without radius must be rejected (IP)
+        self.search(client, self.collection_name,
+                    data=search_vectors[:default_nq],
+                    anns_field=default_search_field,
+                    search_params={"metric_type": "IP", "params": {"range_filter": 0.5}},
+                    limit=default_limit,
+                    filter=default_search_exp,
+                    check_task=CheckTasks.err_res,
+                    check_items={ct.err_code: 1100,
+                                 ct.err_msg: "range_filter requires radius to be set"})
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_range_search_radius_range_filter_not_in_params(self):

--- a/tests/python_client/milvus_client_v2/test_milvus_client_search_pagination.py
+++ b/tests/python_client/milvus_client_v2/test_milvus_client_search_pagination.py
@@ -210,14 +210,30 @@ class TestMilvusClientSearchPagination(TestMilvusClientV2Base):
         """
         target: test search bfloat16 vectors with pagination
         method: 1. connect and create a collection
-                2. search bfloat16 vectors with pagination
-                3. search with offset+limit
-                4. compare with the search results whose corresponding ids should be the same
-        expected: search successfully and ids is correct
+                2. search bfloat16 vectors with pagination (with explicit search_list_size)
+                3. search a full reference (same search_list_size) without pagination
+                4. compare: per-page overlap >= 90%, and overall recall across all pages >= 95%
+        expected: search successfully and ids are consistent
+
+        Note on DISKANN pagination consistency:
+            When offset is set, Milvus internally searches with topk = limit + offset.
+            Without an explicit search_list_size, DISKANN uses a search depth proportional
+            to topk — so paginated searches (e.g. topk=200 for page 1) explore far fewer
+            graph nodes than the full search (topk=1000). This causes boundary candidates
+            (those at the edge of each page) to differ between calls, producing ~76-79%
+            overlap and flaky failures against an 80% threshold.
+
+            Fix: pin search_list_size=1200 on both paginated and full searches so both
+            explore the same set of candidate neighbours. Per-page overlap then rises
+            to ~95%+ and overall recall across all pages reaches ~99%+.
         """
         client = self._client()
         # 1. Create collection with schema
         collection_name = self.collection_name
+
+        # Pin search_list_size so paginated and full searches explore the same DISKANN
+        # candidate pool, eliminating topk-driven depth differences.
+        diskann_search_list_size = 1200  # must be >= limit * pages (1000)
 
         # 2. Search with pagination for 10 pages
         limit = 100
@@ -226,7 +242,7 @@ class TestMilvusClientSearchPagination(TestMilvusClientV2Base):
         all_pages_results = []
         for page in range(pages):
             offset = page * limit
-            search_params = {"offset": offset}
+            search_params = {"offset": offset, "params": {"search_list_size": diskann_search_list_size}}
             search_res_with_offset, _ = self.search(
                 client,
                 collection_name,
@@ -244,8 +260,8 @@ class TestMilvusClientSearchPagination(TestMilvusClientV2Base):
             )
             all_pages_results.append(search_res_with_offset)
 
-        # 3. Search without pagination
-        search_params_full = {}
+        # 3. Full reference search — same search_list_size so candidate pools match
+        search_params_full = {"params": {"search_list_size": diskann_search_list_size}}
         search_res_full, _ = self.search(
             client,
             collection_name,
@@ -255,17 +271,25 @@ class TestMilvusClientSearchPagination(TestMilvusClientV2Base):
             limit=limit * pages
         )
 
-        # 4. Compare results - verify pagination results overlap with full search results
-        for p in range(pages):
-            page_res = all_pages_results[p]
-            for i in range(default_nq):
-                page_ids = [page_res[i][j].get('id') for j in range(limit)]
+        # 4. Validate results
+        for i in range(default_nq):
+            all_page_ids = set()
+            for p in range(pages):
+                page_ids = [all_pages_results[p][i][j].get('id') for j in range(limit)]
                 ids_in_full = [search_res_full[i][p * limit:p * limit + limit][j].get('id') for j in range(limit)]
                 intersection_ids = set(ids_in_full).intersection(set(page_ids))
                 overlap_ratio = len(intersection_ids) / limit * 100
                 log.debug(f"page[{p}], nq[{i}], overlap: {overlap_ratio}%")
-                assert overlap_ratio >= 80, \
-                    f"bfloat16 pagination overlap too low: {overlap_ratio}% (page={p}, nq={i})"
+                assert overlap_ratio >= 90, \
+                    f"bfloat16 pagination per-page overlap too low: {overlap_ratio}% (page={p}, nq={i})"
+                all_page_ids.update(page_ids)
+
+            # Overall recall: union of all paginated results vs full search
+            full_ids = {search_res_full[i][j].get('id') for j in range(limit * pages)}
+            overall_recall = len(all_page_ids & full_ids) / len(full_ids) * 100
+            log.debug(f"nq[{i}], overall recall: {overall_recall:.1f}%")
+            assert overall_recall >= 95, \
+                f"bfloat16 pagination overall recall too low: {overall_recall:.1f}% (nq={i})"
 
     @pytest.mark.tags(CaseLabel.L0)
     def test_search_sparse_with_pagination_default(self):

--- a/tests/python_client/testcases/test_large_topk.py
+++ b/tests/python_client/testcases/test_large_topk.py
@@ -13,7 +13,7 @@ from base.client_v2_base import TestMilvusClientV2Base
 from common import common_func as cf
 from common import common_type as ct
 from common.common_type import CaseLabel, CheckTasks
-from pymilvus import DataType, MilvusException
+from pymilvus import DataType, MilvusException, AnnSearchRequest, RRFRanker
 
 prefix = "large_topk"
 default_nb = 3000          # > 1024 to trigger IVF index build
@@ -180,6 +180,46 @@ class TestLargeTopkShared(TestMilvusClientV2Base):
                     anns_field=vec_field, limit=large_topk_first,
                     check_task=CheckTasks.err_res,
                     check_items=error)
+
+    # Note: search_iterator and query_iterator are NOT affected by query_mode=large_topk.
+    # The SDK enforces batch_size <= 16384 client-side (ParamError, unrelated to large_topk).
+    # The iterator `limit` (total result count) uses internal pagination with batch_size <= 16384,
+    # so per-request topk never exceeds 16384. No large_topk-specific iterator tests are needed.
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_query_large_limit(self):
+        """
+        target: verify query() with limit > 16384 works when query_mode=large_topk is set
+        method: query col_large_topk with limit=large_topk_first, verify results returned
+        expected: returns large_topk_first results without error
+        """
+        client = self._client()
+        res = client.query(
+            self.col_large_topk,
+            filter="",
+            output_fields=["id"],
+            limit=large_topk_first,
+        )
+        assert len(res) == large_topk_first, \
+            f"Expected {large_topk_first} results, got {len(res)}"
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_query_without_property_fails(self):
+        """
+        target: verify query() with limit > 16384 is rejected when query_mode=large_topk is NOT set
+        method: query col_normal with limit=large_topk_first
+        expected: MilvusException with invalid topk message
+        """
+        client = self._client()
+        with pytest.raises(MilvusException) as exc_info:
+            client.query(
+                self.col_normal,
+                filter="",
+                output_fields=["id"],
+                limit=large_topk_first,
+            )
+        assert str(large_topk_first) in str(exc_info.value), \
+            f"Expected topk error, got: {exc_info.value}"
 
 
 # ---------------------------------------------------------------------------
@@ -537,4 +577,105 @@ class TestLargeTopkIndependent(TestMilvusClientV2Base):
                     anns_field=vec_field, limit=large_topk_first,
                     check_task=CheckTasks.err_res,
                     check_items=error)
+
+    # Note: search_iterator and query_iterator are NOT affected by query_mode=large_topk.
+    # The SDK enforces batch_size <= 16384 client-side (ParamError code=1, regardless of property).
+    # Iterator `limit` (total results) uses internal pagination with batch_size <= 16384 per request,
+    # so per-request topk never exceeds 16384. No large_topk-specific iterator tests are needed.
+
+    # -------------------------------------------------------------------------
+    # Hybrid search interface tests
+    # -------------------------------------------------------------------------
+
+    def _setup_dual_vec_col(self, client, enable_large_topk=True, nb=default_nb):
+        """Create collection with two float vector fields for hybrid search tests.
+        Uses IVF_FLAT index to keep index-build time reasonable for large nb."""
+        col = cf.gen_collection_name_by_testcase_name(module_index=2)
+        schema = self.create_schema(client)[0]
+        schema.add_field("id", DataType.INT64, is_primary=True, auto_id=True)
+        schema.add_field(vec_field, DataType.FLOAT_VECTOR, dim=default_dim)
+        schema.add_field("vec2", DataType.FLOAT_VECTOR, dim=default_dim)
+        query_mode_props = {"query_mode": "large_topk"} if enable_large_topk else None
+        self.create_collection(client, col, schema=schema,
+                               properties=query_mode_props, force_teardown=True)
+        index_params = self.prepare_index_params(client)[0]
+        index_params.add_index(vec_field, index_type="IVF_FLAT", metric_type="L2",
+                               params={"nlist": 64})
+        index_params.add_index("vec2", index_type="IVF_FLAT", metric_type="L2",
+                               params={"nlist": 64})
+        self.create_index(client, col, index_params)
+        self.load_collection(client, col)
+        if nb > 0:
+            rows = [{vec_field: cf.gen_vectors(1, default_dim)[0],
+                     "vec2": cf.gen_vectors(1, default_dim)[0]} for _ in range(nb)]
+            self.insert(client, col, rows)
+            self.flush(client, col)
+        return col
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_hybrid_search_large_topk(self):
+        """
+        target: verify hybrid_search with limit > 16384 works when query_mode=large_topk is set
+        method:
+            1. create collection with two float vector fields and query_mode=large_topk
+            2. insert large_topk_total rows with IVF_FLAT index
+            3. hybrid_search with limit=large_topk_first using RRFRanker
+        expected: hybrid_search completes without error; returns > 0 results; no error code
+        """
+        client = self._client()
+        col = self._setup_dual_vec_col(client, enable_large_topk=True, nb=large_topk_total)
+        req_list = [
+            AnnSearchRequest(
+                data=cf.gen_vectors(default_nq, default_dim),
+                anns_field=vec_field,
+                param={"metric_type": "L2", "nprobe": 16},
+                limit=large_topk_first,
+            ),
+            AnnSearchRequest(
+                data=cf.gen_vectors(default_nq, default_dim),
+                anns_field="vec2",
+                param={"metric_type": "L2", "nprobe": 16},
+                limit=large_topk_first,
+            ),
+        ]
+        res, _ = self.hybrid_search(client, col,
+                                    reqs=req_list, ranker=RRFRanker(),
+                                    limit=large_topk_first)
+        assert len(res) == default_nq, f"Expected {default_nq} query results, got {len(res)}"
+        for hits in res:
+            assert len(hits) > 0, "Expected non-empty hybrid search results"
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_hybrid_search_without_property_fails(self):
+        """
+        target: verify hybrid_search with limit > 16384 is rejected when query_mode=large_topk is NOT set
+        method:
+            1. create collection with two float vector fields and NO query_mode property
+            2. hybrid_search with limit=large_topk_first
+        expected: MilvusException with invalid topk message
+        """
+        client = self._client()
+        col = self._setup_dual_vec_col(client, enable_large_topk=False)
+        req_list = [
+            AnnSearchRequest(
+                data=cf.gen_vectors(default_nq, default_dim),
+                anns_field=vec_field,
+                param={"metric_type": "L2"},
+                limit=large_topk_first,
+            ),
+            AnnSearchRequest(
+                data=cf.gen_vectors(default_nq, default_dim),
+                anns_field="vec2",
+                param={"metric_type": "L2"},
+                limit=large_topk_first,
+            ),
+        ]
+        # hybrid_search uses "invalid max query result window" (not "topk [N] is invalid")
+        error = {ct.err_code: 65535,
+                 ct.err_msg: f"invalid max query result window, (offset+limit) should be in range [1, 16384], but got {large_topk_first}"}
+        self.hybrid_search(client, col,
+                           reqs=req_list, ranker=RRFRanker(),
+                           limit=large_topk_first,
+                           check_task=CheckTasks.err_res,
+                           check_items=error)
 


### PR DESCRIPTION
Cherry-pick from master

pr: #48896
pr: #48934
pr: #49033
pr: #49112
pr: #49113

## Summary

Combined cherry-pick of test coverage improvements and bug fixes from master to 3.0 branch.

### Changes Included

- **test**: add query/hybrid_search coverage for query_mode=large_topk (#48896)
- **fix**: reject range_filter without radius in search params (#48934)
- **test**: fix flaky bfloat16 pagination test by pinning DISKANN search_list_size (#49033)
- **fix**: prevent nil pointer panic in go_client teardown when Milvus is unreachable (#49112)
- **test**: update search iterator mul-db test to reflect SearchIteratorV2 behavior (#49113)
- **test**: update test_range_search_only_range_filter to verify reject behavior (#49113)

🤖 Generated with [Claude Code](https://claude.com/claude-code)