### PR TITLE
fix: [3.0] strip basePath prefix from text/json stats Files for V2 legacy segments (#49196)

### DIFF
--- a/internal/util/segcore/segment.go
+++ b/internal/util/segcore/segment.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"fmt"
 	"runtime"
+	"strings"
 	"unsafe"
 
 	"github.com/cockroachdb/errors"
@@ -553,14 +554,37 @@ func convertTextIndexStats(src map[int64]*datapb.TextIndexStats, basePaths map[i
 			continue
 		}
 
+		files := v.GetFiles()
+		basePath := basePaths[k]
+		// V2 legacy segments may carry full paths in Files (reconstructed by
+		// metautil.BuildTextLogPaths on etcd load). The C++ loader expects
+		// relative filenames and prepends BasePath itself, so strip any
+		// basePath prefix here to honor the contract.
+		if basePath != "" {
+			prefix := basePath + "/"
+			stripped := make([]string, len(files))
+			for i, f := range files {
+				stripped[i] = strings.TrimPrefix(f, prefix)
+			}
+			files = stripped
+		}
+		log.Info("convertTextIndexStats",
+			zap.Int64("fieldID", v.GetFieldID()),
+			zap.Int64("buildID", v.GetBuildID()),
+			zap.Int64("version", v.GetVersion()),
+			zap.String("basePath", basePath),
+			zap.Int("fileCount", len(files)),
+			zap.Strings("files", files),
+		)
+
 		result[k] = &segcorepb.TextIndexStats{
 			FieldID:    v.GetFieldID(),
 			Version:    v.GetVersion(),
-			Files:      v.GetFiles(),
+			Files:      files,
 			LogSize:    v.GetLogSize(),
 			MemorySize: v.GetMemorySize(),
 			BuildID:    v.GetBuildID(),
-			BasePath:   basePaths[k],
+			BasePath:   basePath,
 		}
 	}
 	return result
@@ -578,15 +602,37 @@ func convertJSONKeyStats(src map[int64]*datapb.JsonKeyStats, basePaths map[int64
 			continue
 		}
 
+		files := v.GetFiles()
+		basePath := basePaths[k]
+		// V2 legacy segments may carry full paths in Files; strip basePath
+		// prefix so the C++ loader (which prepends BasePath) sees relative
+		// filenames. See convertTextIndexStats for details.
+		if basePath != "" {
+			prefix := basePath + "/"
+			stripped := make([]string, len(files))
+			for i, f := range files {
+				stripped[i] = strings.TrimPrefix(f, prefix)
+			}
+			files = stripped
+		}
+		log.Info("convertJSONKeyStats",
+			zap.Int64("fieldID", v.GetFieldID()),
+			zap.Int64("buildID", v.GetBuildID()),
+			zap.Int64("version", v.GetVersion()),
+			zap.String("basePath", basePath),
+			zap.Int("fileCount", len(files)),
+			zap.Strings("files", files),
+		)
+
 		result[k] = &segcorepb.JsonKeyStats{
 			FieldID:                v.GetFieldID(),
 			Version:                v.GetVersion(),
-			Files:                  v.GetFiles(),
+			Files:                  files,
 			LogSize:                v.GetLogSize(),
 			MemorySize:             v.GetMemorySize(),
 			BuildID:                v.GetBuildID(),
 			JsonKeyStatsDataFormat: v.GetJsonKeyStatsDataFormat(),
-			BasePath:               basePaths[k],
+			BasePath:               basePath,
 		}
 	}
 	return result


### PR DESCRIPTION
Cherry-pick from master
pr: #49196

When loading a V2 (non-manifest) text-indexed segment upgraded from 2.6, segcore fails with GetObjectSize 404 because the remote object key carries the text_log/{buildID}/.../{fieldID}/ prefix twice, e.g. "files/text_log/.../102/files/text_log/.../102/.managed.json_0".

Root cause: the Go->C++ contract declared in pkg/proto/segcore.proto -- "base_path ... files are relative to this path" -- was broken on the V2 legacy load path. DataCoord's kv_catalog reconstructs full paths via metautil.BuildTextLogPaths on etcd load, then convertTextIndexStats / convertJSONKeyStats passed those full paths straight into segcorepb.TextIndexStats.Files while also setting BasePath. C++ TextMatchIndex::Load then prepended base_path a second time. V3 manifest segments were unaffected because
packed.stats_resolver.stripBasePathPrefix strips the prefix before returning.

Fix: in convertTextIndexStats / convertJSONKeyStats, strip the BasePath prefix from each entry of Files before handing off to C++. TrimPrefix is a no-op for V3 (Files already relative) and for the empty-basePath defensive case, so V3 / new-segment behavior is preserved.

issue: #48547