### PR TITLE
enhance: fast-fail proxy Enqueue and non-blocking task queue notifier (#49223)

### DIFF
--- a/internal/proxy/task_scheduler.go
+++ b/internal/proxy/task_scheduler.go
@@ -173,6 +173,17 @@ func (queue *baseTaskQueue) Enqueue(t task) error {
 		return err
 	}
 
+	// Fast-fail when the queue is already full, before any potentially-blocking
+	// allocation. The authoritative check remains in addUnissuedTask; this
+	// snapshot only prevents a rejected request from queuing behind a slow
+	// TSO/ID allocator (#49223).
+	queue.utLock.RLock()
+	full := queue.utFull()
+	queue.utLock.RUnlock()
+	if full {
+		return merr.WrapErrTooManyRequests(int32(queue.getMaxTaskNum()))
+	}
+
 	var ts Timestamp
 	var id UniqueID
 	if t.CanSkipAllocTimestamp() {

--- a/internal/proxy/task_scheduler.go
+++ b/internal/proxy/task_scheduler.go
@@ -93,7 +93,13 @@ func (queue *baseTaskQueue) addUnissuedTask(t task) error {
 		return merr.WrapErrTooManyRequests(int32(queue.getMaxTaskNum()))
 	}
 	queue.unissuedTasks.PushBack(t)
-	queue.utBufChan <- 1
+	// utBufChan is an edge-triggered, capacity-1 notifier: a pending token
+	// means "the unissued list is non-empty, wake the scheduler". Concurrent
+	// sends coalesce; the scheduler drains the list on each wake.
+	select {
+	case queue.utBufChan <- 1:
+	default:
+	}
 	return nil
 }
 
@@ -228,7 +234,7 @@ func newBaseTaskQueue(tsoAllocatorIns tsoAllocator) *baseTaskQueue {
 		utLock:          sync.RWMutex{},
 		atLock:          sync.RWMutex{},
 		maxTaskNum:      Params.ProxyCfg.MaxTaskNum.GetAsInt64(),
-		utBufChan:       make(chan int, Params.ProxyCfg.MaxTaskNum.GetAsInt()),
+		utBufChan:       make(chan int, 1),
 		tsoAllocatorIns: tsoAllocatorIns,
 	}
 }
@@ -544,10 +550,10 @@ func (sched *taskScheduler) definitionLoop() {
 		case <-sched.ctx.Done():
 			return
 		case <-sched.ddQueue.utChan():
-			if !sched.ddQueue.utEmpty() {
-				t := sched.scheduleDdTask()
+			for t := sched.scheduleDdTask(); t != nil; t = sched.scheduleDdTask() {
+				task := t
 				pool.Submit(func() (struct{}, error) {
-					sched.processTask(t, sched.ddQueue)
+					sched.processTask(task, sched.ddQueue)
 					return struct{}{}, nil
 				})
 			}
@@ -567,10 +573,10 @@ func (sched *taskScheduler) controlLoop() {
 		case <-sched.ctx.Done():
 			return
 		case <-sched.dcQueue.utChan():
-			if !sched.dcQueue.utEmpty() {
-				t := sched.scheduleDcTask()
+			for t := sched.scheduleDcTask(); t != nil; t = sched.scheduleDcTask() {
+				task := t
 				pool.Submit(func() (struct{}, error) {
-					sched.processTask(t, sched.dcQueue)
+					sched.processTask(task, sched.dcQueue)
 					return struct{}{}, nil
 				})
 			}
@@ -588,10 +594,10 @@ func (sched *taskScheduler) manipulationLoop() {
 		case <-sched.ctx.Done():
 			return
 		case <-sched.dmQueue.utChan():
-			if !sched.dmQueue.utEmpty() {
-				t := sched.scheduleDmTask()
+			for t := sched.scheduleDmTask(); t != nil; t = sched.scheduleDmTask() {
+				task := t
 				pool.Submit(func() (struct{}, error) {
-					sched.processTask(t, sched.dmQueue)
+					sched.processTask(task, sched.dmQueue)
 					return struct{}{}, nil
 				})
 			}
@@ -614,19 +620,17 @@ func (sched *taskScheduler) queryLoop() {
 		case <-sched.ctx.Done():
 			return
 		case <-sched.dqQueue.utChan():
-			if !sched.dqQueue.utEmpty() {
-				t := sched.scheduleDqTask()
+			for t := sched.scheduleDqTask(); t != nil; t = sched.scheduleDqTask() {
+				task := t
 				p := pool
 				// if task is sub task spawned by another, use sub task pool in case of deadlock
-				if t.IsSubTask() {
+				if task.IsSubTask() {
 					p = subTaskPool
 				}
 				p.Submit(func() (struct{}, error) {
-					sched.processTask(t, sched.dqQueue)
+					sched.processTask(task, sched.dqQueue)
 					return struct{}{}, nil
 				})
-			} else {
-				log.Ctx(context.TODO()).Debug("query queue is empty ...")
 			}
 			sched.dqQueue.updateMetrics()
 		}

--- a/internal/proxy/task_scheduler_test.go
+++ b/internal/proxy/task_scheduler_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math/rand"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -34,6 +35,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/mq/msgstream"
 	"github.com/milvus-io/milvus/pkg/v2/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 )
 
 func TestBaseTaskQueue(t *testing.T) {
@@ -675,4 +677,49 @@ func TestTaskScheduler_SkipAllocTimestamp(t *testing.T) {
 		err := queue.Enqueue(st)
 		assert.Error(t, err)
 	})
+}
+
+// blockingTsoAllocator blocks AllocOne on the caller's context so that a test
+// can distinguish "we reached the TSO allocator" from "we fast-failed".
+type blockingTsoAllocator struct {
+	calls atomic.Int64
+}
+
+func (b *blockingTsoAllocator) AllocOne(ctx context.Context) (Timestamp, error) {
+	b.calls.Add(1)
+	<-ctx.Done()
+	return 0, ctx.Err()
+}
+
+// TestBaseTaskQueue_EnqueueFastFailBeforeAlloc verifies that Enqueue rejects
+// a task immediately with ErrServiceTooManyRequests when the queue is already
+// full, without invoking the TSO allocator. Regression test for #49223.
+func TestBaseTaskQueue_EnqueueFastFailBeforeAlloc(t *testing.T) {
+	tsoAllocatorIns := newMockTsoAllocator()
+	queue := newBaseTaskQueue(tsoAllocatorIns)
+	queue.setMaxTaskNum(2)
+
+	// Fill queue to capacity with the non-blocking mock allocator.
+	for i := 0; i < 2; i++ {
+		assert.NoError(t, queue.Enqueue(newDefaultMockTask()))
+	}
+	assert.True(t, queue.utFull())
+
+	// Swap in an allocator that would hang forever if reached.
+	blocking := &blockingTsoAllocator{}
+	queue.tsoAllocatorIns = blocking
+
+	done := make(chan error, 1)
+	go func() {
+		done <- queue.Enqueue(newDefaultMockTask())
+	}()
+
+	select {
+	case err := <-done:
+		assert.ErrorIs(t, err, merr.ErrServiceTooManyRequests)
+	case <-time.After(2 * time.Second):
+		t.Fatalf("Enqueue did not fast-fail; reached blocking TSO allocator")
+	}
+	assert.Equal(t, int64(0), blocking.calls.Load(),
+		"Enqueue must not reach the TSO allocator when the queue is already full")
 }

--- a/internal/proxy/task_scheduler_test.go
+++ b/internal/proxy/task_scheduler_test.go
@@ -104,7 +104,7 @@ func TestBaseTaskQueue(t *testing.T) {
 	assert.NotNil(t, activeTask)
 
 	// test utFull
-	queue.setMaxTaskNum(10) // not accurate, full also means utBufChan block
+	queue.setMaxTaskNum(10) // utBufChan is an edge-triggered notifier; capacity is tracked by utFull
 	for i := 0; i < int(queue.getMaxTaskNum()); i++ {
 		err = queue.Enqueue(newDefaultMockTask())
 		assert.NoError(t, err)
@@ -180,7 +180,7 @@ func TestDdTaskQueue(t *testing.T) {
 	assert.NotNil(t, activeTask)
 
 	// test utFull
-	queue.setMaxTaskNum(10) // not accurate, full also means utBufChan block
+	queue.setMaxTaskNum(10) // utBufChan is an edge-triggered notifier; capacity is tracked by utFull
 	for i := 0; i < int(queue.getMaxTaskNum()); i++ {
 		err = queue.Enqueue(newDefaultMockDdlTask())
 		assert.NoError(t, err)
@@ -256,7 +256,7 @@ func TestDmTaskQueue_Basic(t *testing.T) {
 	assert.NotNil(t, activeTask)
 
 	// test utFull
-	queue.setMaxTaskNum(10) // not accurate, full also means utBufChan block
+	queue.setMaxTaskNum(10) // utBufChan is an edge-triggered notifier; capacity is tracked by utFull
 	for i := 0; i < int(queue.getMaxTaskNum()); i++ {
 		err = queue.Enqueue(newDefaultMockDmlTask())
 		assert.NoError(t, err)
@@ -479,7 +479,7 @@ func TestDqTaskQueue(t *testing.T) {
 	assert.NotNil(t, activeTask)
 
 	// test utFull
-	queue.setMaxTaskNum(10) // not accurate, full also means utBufChan block
+	queue.setMaxTaskNum(10) // utBufChan is an edge-triggered notifier; capacity is tracked by utFull
 	for i := 0; i < int(queue.getMaxTaskNum()); i++ {
 		err = queue.Enqueue(newDefaultMockDqlTask())
 		assert.NoError(t, err)
@@ -722,4 +722,41 @@ func TestBaseTaskQueue_EnqueueFastFailBeforeAlloc(t *testing.T) {
 	}
 	assert.Equal(t, int64(0), blocking.calls.Load(),
 		"Enqueue must not reach the TSO allocator when the queue is already full")
+}
+
+// TestBaseTaskQueue_NotifierCoalesces verifies that utBufChan is an edge-
+// triggered notifier: many enqueues produce at most one pending token.
+func TestBaseTaskQueue_NotifierCoalesces(t *testing.T) {
+	queue := newBaseTaskQueue(newMockTsoAllocator())
+	queue.setMaxTaskNum(100)
+
+	for i := 0; i < 10; i++ {
+		assert.NoError(t, queue.Enqueue(newDefaultMockTask()))
+	}
+
+	assert.Equal(t, 1, cap(queue.utBufChan), "utBufChan must be a capacity-1 notifier")
+	assert.Equal(t, 1, len(queue.utChan()), "concurrent enqueues must coalesce to a single pending token")
+}
+
+// TestBaseTaskQueue_EnqueueNotifierNonBlocking verifies that a flood of
+// enqueues completes without a consumer draining utBufChan — i.e. the
+// notifier send must not block Enqueue.
+func TestBaseTaskQueue_EnqueueNotifierNonBlocking(t *testing.T) {
+	queue := newBaseTaskQueue(newMockTsoAllocator())
+	queue.setMaxTaskNum(1024)
+
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 64; i++ {
+			assert.NoError(t, queue.Enqueue(newDefaultMockTask()))
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("Enqueue blocked on utBufChan send")
+	}
+	assert.Equal(t, 1, len(queue.utChan()))
 }


### PR DESCRIPTION
issue: #49223
pr: #49248

## Summary

Two targeted fixes to `baseTaskQueue` in the proxy, addressing the traffic-storm amplification described in #49223:

1. **Fast-fail `Enqueue` before TSO/ID allocation.** `baseTaskQueue.Enqueue` now takes an `RLock`-protected `utFull` snapshot at the top and returns `merr.ErrServiceTooManyRequests` immediately when the queue is at capacity — before calling `tsoAllocatorIns.AllocOne` or `globalMetaCache.AllocID`. Previously, a request that was going to be rejected still had to queue behind a slow upstream allocator (e.g. `mixCoord.AllocID` under lock during a rootcoord/mixcoord hiccup), inflating "too many concurrent requests" tail latency to tens of seconds and amplifying memory pressure on the proxy. The authoritative check inside `addUnissuedTask` is preserved as the final safeguard.

2. **`utBufChan` is now a capacity-1 edge-triggered notifier.** `addUnissuedTask` does a non-blocking send that coalesces concurrent notifications, and all four scheduler loops (`definitionLoop`, `controlLoop`, `manipulationLoop`, `queryLoop`) drain the `unissuedTasks` list on each wake-up instead of servicing one task per notification. This decouples `Enqueue` throughput from scheduler consumption rate and removes the hidden per-task blocking send that previously existed on the notifier.

`MetaCache.AllocID` is intentionally left untouched in this PR — a follow-up will decouple its global lock refill separately.

## Test Plan

- [x] New unit tests in `internal/proxy/task_scheduler_test.go`:
  - `TestBaseTaskQueue_EnqueueFastFailBeforeAlloc` — swaps in a `blockingTsoAllocator` after filling the queue; asserts `Enqueue` returns `ErrServiceTooManyRequests` without reaching `AllocOne`.
  - `TestBaseTaskQueue_NotifierCoalesces` — 10 enqueues yield a single pending token; `cap(utBufChan) == 1`.
  - `TestBaseTaskQueue_EnqueueNotifierNonBlocking` — 64 concurrent enqueues complete without a consumer.
- [x] Existing `TestBaseTaskQueue`, `TestDdTaskQueue`, `TestDmTaskQueue_*`, `TestDqTaskQueue`, `TestTaskScheduler`, `TestTaskScheduler_concurrentPushAndPop`, `TestTaskScheduler_SkipAllocTimestamp` all still pass.
- [x] Race detector clean on the affected tests (`go test -race ./internal/proxy -run 'TestBaseTaskQueue|TestDdTaskQueue|TestDmTaskQueue|TestDqTaskQueue|TestTaskScheduler'`).
- [x] `make fmt` / `go vet ./internal/proxy` clean.