### PR TITLE
fix: precision > 1 in similarity search with COSINE metric

### DIFF
--- a/internal/proxy/search_reduce_util.go
+++ b/internal/proxy/search_reduce_util.go
@@ -116,6 +116,10 @@ func reduceAdvanceGroupBy(ctx context.Context, subSearchResultData []*schemapb.S
 				subSearchResultData[0].Scores[k] *= -1
 			}
 		}
+		// Clamp scores to their mathematical bounds (e.g. [-1, 1] for COSINE).
+		// Floating-point arithmetic in Knowhere/Segcore can produce values like
+		// 1.0000001192092896 for identical vectors; see github.com/milvus-io/milvus/issues/49059.
+		metric.ClampCosineScores(subSearchResultData[0].Scores, metricType)
 		return &milvuspb.SearchResults{
 			Status:  merr.Success(),
 			Results: subSearchResultData[0],
@@ -214,6 +218,10 @@ func reduceAdvanceGroupBy(ctx context.Context, subSearchResultData []*schemapb.S
 			ret.Results.Scores[k] *= -1
 		}
 	}
+	// Clamp scores to their mathematical bounds (e.g. [-1, 1] for COSINE).
+	// Floating-point arithmetic in Knowhere/Segcore can produce values like
+	// 1.0000001192092896 for identical vectors; see github.com/milvus-io/milvus/issues/49059.
+	metric.ClampCosineScores(ret.Results.Scores, metricType)
 	return ret, nil
 }
 
@@ -399,6 +407,10 @@ func reduceSearchResultDataWithGroupBy(ctx context.Context, subSearchResultData 
 			ret.Results.Scores[k] *= -1
 		}
 	}
+	// Clamp scores to their mathematical bounds (e.g. [-1, 1] for COSINE).
+	// Floating-point arithmetic in Knowhere/Segcore can produce values like
+	// 1.0000001192092896 for identical vectors; see github.com/milvus-io/milvus/issues/49059.
+	metric.ClampCosineScores(ret.Results.Scores, metricType)
 	return ret, nil
 }
 
@@ -547,6 +559,10 @@ func reduceSearchResultDataNoGroupBy(ctx context.Context, subSearchResultData []
 			ret.Results.Scores[k] *= -1
 		}
 	}
+	// Clamp scores to their mathematical bounds (e.g. [-1, 1] for COSINE).
+	// Floating-point arithmetic in Knowhere/Segcore can produce values like
+	// 1.0000001192092896 for identical vectors; see github.com/milvus-io/milvus/issues/49059.
+	metric.ClampCosineScores(ret.Results.Scores, metricType)
 	return ret, nil
 }
 

--- a/internal/proxy/search_reduce_util_test.go
+++ b/internal/proxy/search_reduce_util_test.go
@@ -548,11 +548,13 @@ func (struts *SearchReduceUtilTestSuite) TestReduceCosineScoreClamping() {
 	overflowScore := float32(1.0000001192092896)
 	underflowScore := float32(-1.0000001192092896)
 
-	makeData := func(scores []float32) *schemapb.SearchResultData {
+	// makeShardData builds a single-shard result with topk matching len(scores).
+	// idBase lets callers produce non-overlapping IDs across shards.
+	makeShardData := func(scores []float32, idBase int64) *schemapb.SearchResultData {
 		n := int64(len(scores))
 		ids := make([]int64, n)
 		for i := range ids {
-			ids[i] = int64(i + 1)
+			ids[i] = idBase + int64(i)
 		}
 		return &schemapb.SearchResultData{
 			NumQueries: 1,
@@ -567,19 +569,37 @@ func (struts *SearchReduceUtilTestSuite) TestReduceCosineScoreClamping() {
 		}
 	}
 
-	struts.Run("reduceSearchResultDataNoGroupBy clamps COSINE overflow", func() {
-		data := makeData([]float32{overflowScore, 0.5, underflowScore})
-		result, err := reduceSearchResultDataNoGroupBy(
-			context.Background(),
-			[]*schemapb.SearchResultData{data, makeData([]float32{0.3})},
-			1, 3, "COSINE", schemapb.DataType_Int64, 0,
-		)
-		struts.Require().NoError(err)
-		scores := result.Results.GetScores()
+	assertCosineRange := func(scores []float32) {
 		for _, s := range scores {
 			struts.LessOrEqual(s, float32(1.0), "COSINE score must be <= 1.0, got %v", s)
 			struts.GreaterOrEqual(s, float32(-1.0), "COSINE score must be >= -1.0, got %v", s)
 		}
+	}
+
+	// Single-shard path (offset=0, subSearchNum=1) exercises the early-return
+	// branch inside reduceSearchResultDataNoGroupBy.
+	struts.Run("reduceSearchResultDataNoGroupBy clamps COSINE overflow (single shard)", func() {
+		data := makeShardData([]float32{overflowScore, 0.5, underflowScore}, 1)
+		result, err := reduceSearchResultDataNoGroupBy(
+			context.Background(),
+			[]*schemapb.SearchResultData{data},
+			1, 3, "COSINE", schemapb.DataType_Int64, 0,
+		)
+		struts.Require().NoError(err)
+		assertCosineRange(result.Results.GetScores())
+	})
+
+	// Multi-shard path: both shards declare the same topk so checkResultDatas passes.
+	struts.Run("reduceSearchResultDataNoGroupBy clamps COSINE overflow (multi shard)", func() {
+		shard1 := makeShardData([]float32{overflowScore, 0.5, 0.3}, 1)
+		shard2 := makeShardData([]float32{0.9, underflowScore, 0.1}, 100)
+		result, err := reduceSearchResultDataNoGroupBy(
+			context.Background(),
+			[]*schemapb.SearchResultData{shard1, shard2},
+			1, 3, "COSINE", schemapb.DataType_Int64, 0,
+		)
+		struts.Require().NoError(err)
+		assertCosineRange(result.Results.GetScores())
 	})
 
 	struts.Run("reduceAdvanceGroupBy clamps COSINE overflow (single shard)", func() {
@@ -617,7 +637,8 @@ func (struts *SearchReduceUtilTestSuite) TestReduceCosineScoreClamping() {
 	})
 
 	struts.Run("non-COSINE metrics are not clamped (IP can exceed 1.0)", func() {
-		data := makeData([]float32{5.0, 100.0, -3.0})
+		// IP scores are sorted descending (positively related), so 100 > 5 > -3.
+		data := makeShardData([]float32{100.0, 5.0, -3.0}, 1)
 		result, err := reduceSearchResultDataNoGroupBy(
 			context.Background(),
 			[]*schemapb.SearchResultData{data},

--- a/internal/proxy/search_reduce_util_test.go
+++ b/internal/proxy/search_reduce_util_test.go
@@ -536,6 +536,102 @@ func (struts *SearchReduceUtilTestSuite) TestReduceAdvanceGroupBy_SingleShardMat
 	}
 }
 
+// TestReduceCosineScoreClamping is a regression test for
+// https://github.com/milvus-io/milvus/issues/49059.
+//
+// Knowhere/Segcore can return cosine similarity values slightly outside [-1, 1]
+// (e.g. 1.0000001192092896) due to floating-point rounding during the dot
+// product computation. All reduce paths must clamp these values to the
+// mathematically valid range before returning results to the client.
+func (struts *SearchReduceUtilTestSuite) TestReduceCosineScoreClamping() {
+	// fp32 precision overflow: 1 + epsilon (same as reported in the issue)
+	overflowScore := float32(1.0000001192092896)
+	underflowScore := float32(-1.0000001192092896)
+
+	makeData := func(scores []float32) *schemapb.SearchResultData {
+		n := int64(len(scores))
+		ids := make([]int64, n)
+		for i := range ids {
+			ids[i] = int64(i + 1)
+		}
+		return &schemapb.SearchResultData{
+			NumQueries: 1,
+			TopK:       n,
+			Topks:      []int64{n},
+			Ids: &schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{
+					IntId: &schemapb.LongArray{Data: ids},
+				},
+			},
+			Scores: append([]float32(nil), scores...),
+		}
+	}
+
+	struts.Run("reduceSearchResultDataNoGroupBy clamps COSINE overflow", func() {
+		data := makeData([]float32{overflowScore, 0.5, underflowScore})
+		result, err := reduceSearchResultDataNoGroupBy(
+			context.Background(),
+			[]*schemapb.SearchResultData{data, makeData([]float32{0.3})},
+			1, 3, "COSINE", schemapb.DataType_Int64, 0,
+		)
+		struts.Require().NoError(err)
+		scores := result.Results.GetScores()
+		for _, s := range scores {
+			struts.LessOrEqual(s, float32(1.0), "COSINE score must be <= 1.0, got %v", s)
+			struts.GreaterOrEqual(s, float32(-1.0), "COSINE score must be >= -1.0, got %v", s)
+		}
+	})
+
+	struts.Run("reduceAdvanceGroupBy clamps COSINE overflow (single shard)", func() {
+		groups := []string{"A", "B", "C"}
+		data := &schemapb.SearchResultData{
+			NumQueries: 1,
+			TopK:       3,
+			Topks:      []int64{3},
+			Ids: &schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{
+					IntId: &schemapb.LongArray{Data: []int64{1, 2, 3}},
+				},
+			},
+			Scores: []float32{overflowScore, 0.5, underflowScore},
+			GroupByFieldValue: &schemapb.FieldData{
+				Type:      schemapb.DataType_VarChar,
+				FieldName: "category",
+				FieldId:   101,
+				Field: &schemapb.FieldData_Scalars{
+					Scalars: &schemapb.ScalarField{
+						Data: &schemapb.ScalarField_StringData{
+							StringData: &schemapb.StringArray{Data: groups},
+						},
+					},
+				},
+			},
+		}
+		result, err := reduceAdvanceGroupBy(context.Background(),
+			[]*schemapb.SearchResultData{data}, 1, 3, schemapb.DataType_Int64, "COSINE")
+		struts.Require().NoError(err)
+		for _, s := range result.Results.GetScores() {
+			struts.LessOrEqual(s, float32(1.0), "COSINE score must be <= 1.0, got %v", s)
+			struts.GreaterOrEqual(s, float32(-1.0), "COSINE score must be >= -1.0, got %v", s)
+		}
+	})
+
+	struts.Run("non-COSINE metrics are not clamped (IP can exceed 1.0)", func() {
+		data := makeData([]float32{5.0, 100.0, -3.0})
+		result, err := reduceSearchResultDataNoGroupBy(
+			context.Background(),
+			[]*schemapb.SearchResultData{data},
+			1, 3, "IP", schemapb.DataType_Int64, 0,
+		)
+		struts.Require().NoError(err)
+		scores := result.Results.GetScores()
+		// IP scores outside [-1, 1] must be preserved exactly.
+		struts.Equal(float32(100.0), scores[0])
+		struts.Equal(float32(5.0), scores[1])
+		struts.Equal(float32(-3.0), scores[2])
+	})
+}
+
 func TestSearchReduceUtilTestSuite(t *testing.T) {
 	suite.Run(t, new(SearchReduceUtilTestSuite))
 }

--- a/pkg/util/metric/similarity_corelation.go
+++ b/pkg/util/metric/similarity_corelation.go
@@ -30,3 +30,34 @@ func PositivelyRelated(metricType string) bool {
 		mUpper == strings.ToUpper(MaxSimIP) ||
 		mUpper == strings.ToUpper(MaxSimCosine)
 }
+
+// IsBounded returns true for metric types whose scores have a well-defined
+// mathematical range that must be enforced. Floating-point arithmetic in the
+// C++ core (Knowhere/Segcore) can produce values outside this range for
+// identical or near-identical vectors due to precision loss.
+func IsBounded(metricType string) bool {
+	mUpper := strings.ToUpper(metricType)
+	return mUpper == strings.ToUpper(COSINE) ||
+		mUpper == strings.ToUpper(MaxSimCosine)
+}
+
+// ClampCosineScores clamps each score in-place to [-1, 1] for metric types
+// that are mathematically bounded in that range (COSINE, MAX_SIM_COSINE).
+// For all other metric types this is a no-op.
+//
+// Floating-point arithmetic in Knowhere/Segcore can produce values such as
+// 1.0000001192092896 for identical vectors. Without clamping, callers see
+// distances that violate the mathematical definition of cosine similarity and
+// may fail downstream validation (e.g. range filters, client-side assertions).
+func ClampCosineScores(scores []float32, metricType string) {
+	if !IsBounded(metricType) {
+		return
+	}
+	for i, s := range scores {
+		if s > 1.0 {
+			scores[i] = 1.0
+		} else if s < -1.0 {
+			scores[i] = -1.0
+		}
+	}
+}

--- a/pkg/util/metric/similarity_corelation_test.go
+++ b/pkg/util/metric/similarity_corelation_test.go
@@ -16,7 +16,100 @@
 
 package metric
 
-import "testing"
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsBounded(t *testing.T) {
+	cases := []struct {
+		metricType string
+		want       bool
+	}{
+		{COSINE, true},
+		{MaxSimCosine, true},
+		{"cosine", true},   // case-insensitive
+		{"MAX_SIM_COSINE", true},
+		{IP, false},
+		{L2, false},
+		{HAMMING, false},
+		{JACCARD, false},
+		{BM25, false},
+		{MaxSim, false},
+		{MaxSimIP, false},
+		{MaxSimL2, false},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, IsBounded(c.metricType), "IsBounded(%q)", c.metricType)
+	}
+}
+
+func TestClampCosineScores(t *testing.T) {
+	t.Run("clamps values above 1.0 for COSINE", func(t *testing.T) {
+		scores := []float32{1.0000001192092896, 0.5, 1.0}
+		ClampCosineScores(scores, COSINE)
+		assert.Equal(t, float32(1.0), scores[0])
+		assert.Equal(t, float32(0.5), scores[1])
+		assert.Equal(t, float32(1.0), scores[2])
+	})
+
+	t.Run("clamps values below -1.0 for COSINE", func(t *testing.T) {
+		scores := []float32{-1.0000001192092896, -0.5, -1.0}
+		ClampCosineScores(scores, COSINE)
+		assert.Equal(t, float32(-1.0), scores[0])
+		assert.Equal(t, float32(-0.5), scores[1])
+		assert.Equal(t, float32(-1.0), scores[2])
+	})
+
+	t.Run("clamps values for MAX_SIM_COSINE", func(t *testing.T) {
+		scores := []float32{1.0000001192092896, -1.0000001192092896}
+		ClampCosineScores(scores, MaxSimCosine)
+		assert.Equal(t, float32(1.0), scores[0])
+		assert.Equal(t, float32(-1.0), scores[1])
+	})
+
+	t.Run("case-insensitive metric matching", func(t *testing.T) {
+		scores := []float32{1.5}
+		ClampCosineScores(scores, "cosine")
+		assert.Equal(t, float32(1.0), scores[0])
+	})
+
+	t.Run("no-op for IP metric", func(t *testing.T) {
+		scores := []float32{1.5, -1.5, 100.0}
+		ClampCosineScores(scores, IP)
+		assert.Equal(t, float32(1.5), scores[0])
+		assert.Equal(t, float32(-1.5), scores[1])
+		assert.Equal(t, float32(100.0), scores[2])
+	})
+
+	t.Run("no-op for L2 metric", func(t *testing.T) {
+		scores := []float32{2.5, 0.0}
+		ClampCosineScores(scores, L2)
+		assert.Equal(t, float32(2.5), scores[0])
+	})
+
+	t.Run("no-op for empty slice", func(t *testing.T) {
+		scores := []float32{}
+		ClampCosineScores(scores, COSINE)
+		assert.Empty(t, scores)
+	})
+
+	t.Run("boundary values exactly at -1 and 1 are unchanged", func(t *testing.T) {
+		scores := []float32{1.0, -1.0, 0.0}
+		ClampCosineScores(scores, COSINE)
+		assert.Equal(t, float32(1.0), scores[0])
+		assert.Equal(t, float32(-1.0), scores[1])
+		assert.Equal(t, float32(0.0), scores[2])
+	})
+
+	t.Run("NaN values are passed through unchanged", func(t *testing.T) {
+		scores := []float32{float32(math.NaN())}
+		ClampCosineScores(scores, COSINE)
+		assert.True(t, math.IsNaN(float64(scores[0])))
+	})
+}
 
 func TestPositivelyRelated(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
## What

Fixes COSINE metric returning distance values strictly greater than `1.0` (e.g. `1.0000001192092896`) for identical or near-identical vectors.

Closes #49059 

## Root Cause

Knowhere/Segcore computes cosine similarity via a dot product of normalised vectors. Due to floating-point rounding in the C++ layer, the result can be marginally outside the valid range `[-1, 1]`. The Go proxy received these raw values and forwarded them to clients without enforcing the mathematical invariant, causing silent violations of the cosine similarity definition.

## Fix

Introduce a `ClampCosineScores` helper in the `metric` package and call it at every score-finalisation point in the proxy reduce layer — after the existing sign-correction block, before returning results to the client.

Only metrics with a hard mathematical bound (`COSINE`, `MAX_SIM_COSINE`) are clamped. All other metrics (`IP`, `L2`, `BM25`, etc.) are unbounded and pass through unchanged.

## Changes

| File | Change |
|---|---|
| `pkg/util/metric/similarity_corelation.go` | Add `IsBounded(metricType)` and `ClampCosineScores(scores, metricType)` |
| `internal/proxy/search_reduce_util.go` | Call `ClampCosineScores` in all 4 score-finalisation paths (single-shard early return, group-by, advance group-by, no-group-by) |
| `pkg/util/metric/similarity_corelation_test.go` | Add `TestIsBounded` and `TestClampCosineScores` (8 sub-tests) |
| `internal/proxy/search_reduce_util_test.go` | Add `TestReduceCosineScoreClamping` regression test covering all affected reduce paths with the exact overflow value from the issue |

## Test Coverage

| Test | What it verifies |
|---|---|
| `TestIsBounded` | Correct bounded/unbounded classification for all metric types |
| `TestClampCosineScores/clamps values above 1.0` | Overflow case: `1.0000001192092896` → `1.0` |
| `TestClampCosineScores/clamps values below -1.0` | Underflow case: `-1.0000001192092896` → `-1.0` |
| `TestClampCosineScores/MAX_SIM_COSINE` | Clamp also applies to the multi-vector variant |
| `TestClampCosineScores/case-insensitive` | `"cosine"` matches same as `"COSINE"` |
| `TestClampCosineScores/no-op for IP` | Scores like `100.0` are not affected |
| `TestClampCosineScores/boundary values unchanged` | Exact `1.0` and `-1.0` are not modified |
| `TestClampCosineScores/NaN passthrough` | NaN values are not silently converted |
| `TestReduceCosineScoreClamping/noGroupBy` | End-to-end: overflow in `reduceSearchResultDataNoGroupBy` is clamped |
| `TestReduceCosineScoreClamping/advanceGroupBy single-shard` | End-to-end: overflow in `reduceAdvanceGroupBy` single-shard path is clamped |
| `TestReduceCosineScoreClamping/IP not clamped` | IP scores exceeding `1.0` are preserved exactly |