### PR TITLE
fix: [cp2.5.13] fail to get string views due to chunk bound empty loop

### DIFF
--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -698,8 +698,9 @@ class SegmentExpr : public Expr {
 
             // if segment is chunked, type won't be growing
             int64_t size = segment_->chunk_size(field_id_, i) - data_pos;
-
             size = std::min(size, batch_size_ - processed_size);
+            if (size == 0)
+                continue;  //do not go empty-loop at the bound of the chunk
 
             auto& skip_index = segment_->GetSkipIndex();
             if (!skip_func || !skip_func(skip_index, field_id_, i)) {
@@ -1032,7 +1033,8 @@ class SegmentExpr : public Expr {
             }
 
             size = std::min(size, batch_size_ - processed_size);
-
+            if (size == 0)
+                continue;  //do not go empty-loop at the bound of the chunk
             bool access_sealed_variable_column = false;
             if constexpr (std::is_same_v<T, std::string_view> ||
                           std::is_same_v<T, Json> ||


### PR DESCRIPTION
Cherry-pick of #43483 (backport of #41452, related: #41300) from `hotfix-2.5.15` to `hotfix-2.5.13`.

## Summary
- Fix failure to get string views caused by empty loop at chunk bound.
- Single-file change in `internal/core/src/exec/expression/Expr.h` (+4/-2); clean cherry-pick, no conflicts.

## Test plan
- [ ] CI green on `hotfix-2.5.13`