### PR TITLE
enhance: [3.0] [ExternalTable Part8 - 3/4] add Iceberg external table support

### DIFF
--- a/internal/core/conanfile.py
+++ b/internal/core/conanfile.py
@@ -104,6 +104,7 @@ class MilvusConan(ConanFile):
             self.options["arrow"].with_jemalloc = False
             # Use OpenSSL for libcurl on macOS
             self.options["libcurl"].with_ssl = "openssl"
+        self.options["arrow"].with_azure = True
 
     def requirements(self):
         # force=True: override transitive dependency versions (same behavior as Conan 1)
@@ -120,6 +121,10 @@ class MilvusConan(ConanFile):
         self.requires("fmt/11.0.2#eb98daa559c7c59d591f4720dde4cd5c", force=True)
         self.requires("rapidjson/cci.20230929#0a3982e5f4fa453a9b9cd0dd5b1dcb3a", force=True)
         self.requires("aws-sdk-cpp/1.11.692@milvus/dev#c309ce91fa572fff68f9f4e36d477a04")
+        # azure-sdk-for-cpp is a transitive dep of Arrow, but must be declared
+        # as a direct dep so CMakeDeps generates standalone cmake config files.
+        # Without this, find_package(Azure) can't find include directories.
+        self.requires("azure-sdk-for-cpp/1.11.3@milvus/dev#395e8e7a0c29644d41ef160088128f14")
         # Force snappy/lz4 versions to override Arrow's older transitive deps
         # (arrow/*:with_snappy and arrow/*:with_lz4 are enabled for Parquet decoding)
         self.requires("snappy/1.2.1#b940695c64ccbff63c1aabd4b1eee3f3", force=True)

--- a/internal/core/thirdparty/milvus-storage/CMakeLists.txt
+++ b/internal/core/thirdparty/milvus-storage/CMakeLists.txt
@@ -15,7 +15,7 @@
 milvus_add_pkg_config("milvus-storage")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
 
-set( milvus-storage_VERSION 4351a0c)
+set( milvus-storage_VERSION fd3757b)
 set( GIT_REPOSITORY  "https://github.com/milvus-io/milvus-storage.git")
 message(STATUS "milvus-storage repo: ${GIT_REPOSITORY}")
 message(STATUS "milvus-storage version: ${milvus-storage_VERSION}")

--- a/internal/datacoord/external_collection_refresh_manager.go
+++ b/internal/datacoord/external_collection_refresh_manager.go
@@ -753,6 +753,9 @@ func (m *externalCollectionRefreshManager) exploreExternalFiles(
 	extfsPrefix := packed.ExtfsPrefixForCollection(job.GetCollectionId())
 	specExtfs := spec.BuildExtfsOverrides(extfsPrefix)
 	extfsOverrides := packed.BuildExtfsOverrides(job.GetExternalSource(), storageConfig, extfsPrefix, specExtfs)
+	for k, v := range spec.BuildFormatProperties() {
+		extfsOverrides[k] = v
+	}
 
 	exploreBaseDir := exploreTempDirForJob(job.GetJobId())
 	fileInfos, manifestPath, err := packed.ExploreFilesReturnManifestPath(

--- a/internal/datanode/external/task_update.go
+++ b/internal/datanode/external/task_update.go
@@ -321,9 +321,10 @@ func (t *RefreshExternalCollectionTask) fetchFragmentsFromExternalSource(ctx con
 		t.req.GetFileIndexEnd(),
 		manifestPath,
 		packed.ExternalFetchOptions{
-			CollectionID: t.req.GetCollectionID(),
-			SpecExtfs:    specExtfs,
-			RowLimit:     targetRowsPerSegment,
+			CollectionID:     t.req.GetCollectionID(),
+			SpecExtfs:        specExtfs,
+			FormatProperties: t.parsedSpec.BuildFormatProperties(),
+			RowLimit:         targetRowsPerSegment,
 		},
 	)
 }

--- a/internal/storagev2/packed/exttable_test.go
+++ b/internal/storagev2/packed/exttable_test.go
@@ -373,14 +373,6 @@ func TestMarshalManifestPath_EmptyBasePath(t *testing.T) {
 	assert.Equal(t, int64(0), ver)
 }
 
-func TestCreateSegmentManifest_CanceledContext(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // cancel immediately
-
-	_, err := CreateSegmentManifest(ctx, 1, 1, "parquet", []string{"col1"}, nil, nil)
-	assert.ErrorIs(t, err, context.Canceled)
-}
-
 func TestCreateSegmentManifestWithBasePath_CanceledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/internal/storagev2/packed/utils.go
+++ b/internal/storagev2/packed/utils.go
@@ -88,8 +88,9 @@ func SplitFileToFragments(
 // ExternalFetchOptions groups per-collection external table parameters
 // to keep function signatures clean.
 type ExternalFetchOptions struct {
-	CollectionID int64
-	SpecExtfs    map[string]string // extfs overrides from ExternalSpec (already prefix-keyed)
+	CollectionID     int64
+	SpecExtfs        map[string]string // extfs overrides from ExternalSpec (already prefix-keyed)
+	FormatProperties map[string]string // format-specific properties (e.g., "iceberg.snapshot_id")
 	// RowLimit caps rows per fragment when splitting large files. Zero (or
 	// negative) falls back to DefaultFragmentRowLimit.
 	RowLimit int64
@@ -189,6 +190,9 @@ func FetchFragmentsFromExternalSourceWithRange(
 
 	extfsPrefix := ExtfsPrefixForCollection(opts.CollectionID)
 	extfsOverrides := BuildExtfsOverrides(externalSource, storageConfig, extfsPrefix, opts.SpecExtfs)
+	for k, v := range opts.FormatProperties {
+		extfsOverrides[k] = v
+	}
 
 	exploreStart := time.Now()
 	fileInfos, err := ReadFileInfosFromManifestPath(exploreManifestPath, storageConfig)
@@ -277,40 +281,6 @@ func BuildCurrentSegmentFragments(
 		}
 	}
 	return result, nil
-}
-
-// CreateSegmentManifest creates a manifest file for a segment with the given fragments.
-// This is a convenience wrapper around CreateManifestForSegment.
-func CreateSegmentManifest(
-	ctx context.Context,
-	collectionID int64,
-	segmentID int64,
-	format string,
-	columns []string,
-	fragments []Fragment,
-	storageConfig *indexpb.StorageConfig,
-) (string, error) {
-	select {
-	case <-ctx.Done():
-		return "", ctx.Err()
-	default:
-	}
-
-	// Build manifest base path
-	basePath := fmt.Sprintf("external/%d/segments/%d", collectionID, segmentID)
-
-	manifestPath, err := CreateManifestForSegment(
-		basePath,
-		columns,
-		format,
-		fragments,
-		storageConfig,
-	)
-	if err != nil {
-		return "", err
-	}
-
-	return manifestPath, nil
 }
 
 // CreateSegmentManifestWithBasePath creates a manifest file with a custom base path.

--- a/tests/go_client/Dockerfile
+++ b/tests/go_client/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/*
 # Required packages for external table tests (must succeed)
 RUN pip3 install --no-cache-dir --break-system-packages \
-    pyarrow==23.0.1 lance==1.2.1 obstore==0.9.1
+    pyarrow==23.0.1 lance==1.2.1 obstore==0.9.1 'pyiceberg[sql-sqlite]==0.8.1'
 # Optional: vortex-data has Rust native deps that may not build on all platforms.
 # Version must match the Rust vortex crate version in milvus-storage.
 RUN pip3 install --no-cache-dir --break-system-packages \

--- a/tests/go_client/requirements.txt
+++ b/tests/go_client/requirements.txt
@@ -5,3 +5,4 @@ pyarrow==23.0.1
 lance==1.2.1
 vortex-data==0.56.0
 obstore==0.9.1
+pyiceberg[sql-sqlite]==0.8.1

--- a/tests/go_client/testcases/external_table_iceberg_e2e_test.go
+++ b/tests/go_client/testcases/external_table_iceberg_e2e_test.go
@@ -1,0 +1,249 @@
+package testcases
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus/client/v2/entity"
+	"github.com/milvus-io/milvus/client/v2/index"
+	client "github.com/milvus-io/milvus/client/v2/milvusclient"
+	"github.com/milvus-io/milvus/tests/go_client/common"
+	hp "github.com/milvus-io/milvus/tests/go_client/testcases/helper"
+)
+
+// icebergTableInfo holds the output from the Python Iceberg table creator.
+type icebergTableInfo struct {
+	TableLocation    string `json:"table_location"`
+	MetadataLocation string `json:"metadata_location"`
+	SnapshotID       int64  `json:"snapshot_id"`
+	NumRows          int    `json:"num_rows"`
+	Dim              int    `json:"dim"`
+}
+
+// toMilvusURI converts an Iceberg-native URI (s3://bucket/key) to Milvus format (s3://host/bucket/key).
+func toMilvusURI(icebergURI, host string) string {
+	u, err := url.Parse(icebergURI)
+	if err != nil || u.Scheme == "" {
+		return icebergURI
+	}
+	// s3://bucket/key → bucket = u.Host, key = u.Path
+	return fmt.Sprintf("%s://%s/%s%s", u.Scheme, host, u.Host, u.Path)
+}
+
+// TestExternalTableIcebergE2E tests the full Iceberg external table pipeline:
+//
+//	Create Iceberg table on MinIO → CreateCollection (format=iceberg-table) →
+//	Refresh (with snapshot_id) → Load → Search → Query → Drop.
+//
+// The externalSource uses Milvus standard URI format (s3://host/bucket/path/metadata.json),
+// same as parquet and lance external tables. MinIO connection details are passed via extfs.
+//
+// Run:
+//
+//	go test -v -run TestExternalTableIcebergE2E -timeout 30m -tags dynamic,test
+func TestExternalTableIcebergE2E(t *testing.T) {
+	if err := checkPythonDeps("python3", "pyarrow", "pyiceberg"); err != nil {
+		t.Skipf("Python deps for Iceberg unavailable, skipping: %v", err)
+	}
+
+	// Derive the default Iceberg MinIO endpoint from MINIO_ADDRESS (shared env var)
+	// so that all external table tests use a single address knob.
+	minioAddr := envOrDefault("MINIO_ADDRESS", "localhost:9000")
+	minioEndpoint := icebergEnvOrDefault("ICEBERG_MINIO_ENDPOINT", "http://"+minioAddr)
+	minioAccessKey := icebergEnvOrDefault("ICEBERG_MINIO_ACCESS_KEY", "minioadmin")
+	minioSecretKey := icebergEnvOrDefault("ICEBERG_MINIO_SECRET_KEY", "minioadmin")
+	bucket := icebergEnvOrDefault("ICEBERG_MINIO_BUCKET", "a-bucket")
+	tablePath := icebergEnvOrDefault("ICEBERG_TABLE_PATH", "iceberg-test/e2e_test_table")
+	numRows := icebergEnvOrDefault("ICEBERG_NUM_ROWS", "1000")
+	dim := icebergEnvOrDefault("ICEBERG_DIM", "128")
+
+	// --- Phase 0: Create Iceberg table on MinIO using Python script ---
+	t.Log("[Phase 0] Creating Iceberg test table on MinIO...")
+	tableInfo := createIcebergTestTable(t, minioEndpoint, minioAccessKey, minioSecretKey, bucket, tablePath, numRows, dim)
+	t.Logf("[Phase 0] Iceberg table created: metadata=%s, snapshot_id=%d, rows=%d",
+		tableInfo.MetadataLocation, tableInfo.SnapshotID, tableInfo.NumRows)
+
+	// Convert Iceberg-native URI (s3://bucket/key) to Milvus format (s3://host/bucket/key)
+	// to match the URI convention used by parquet/lance external tables.
+	minioHost := strings.TrimPrefix(strings.TrimPrefix(minioEndpoint, "http://"), "https://")
+	externalSource := toMilvusURI(tableInfo.MetadataLocation, minioHost)
+
+	// Build ExternalSpec with extfs for MinIO access (same pattern as cross-bucket parquet E2E)
+	type externalSpecJSON struct {
+		Format     string            `json:"format"`
+		SnapshotID int64             `json:"snapshot_id"`
+		Extfs      map[string]string `json:"extfs,omitempty"`
+	}
+	specObj := externalSpecJSON{
+		Format:     "iceberg-table",
+		SnapshotID: tableInfo.SnapshotID,
+		Extfs: map[string]string{
+			"region":           "us-east-1",
+			"use_ssl":          "false",
+			"use_virtual_host": "false",
+			"cloud_provider":   "aws",
+			"access_key_id":    minioAccessKey,
+			"access_key_value": minioSecretKey,
+		},
+	}
+	specBytes, err := json.Marshal(specObj)
+	require.NoError(t, err)
+	externalSpec := string(specBytes)
+
+	t.Logf("=== Iceberg E2E Test ===")
+	t.Logf("External Source: %s", externalSource)
+	t.Logf("External Spec:  %s", externalSpec)
+
+	// --- Phase 1: Create external collection ---
+	ctx := hp.CreateContext(t, 30*time.Minute)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	collName := fmt.Sprintf("iceberg_e2e_%d", time.Now().UnixMilli())
+	schema := entity.NewSchema().
+		WithName(collName).
+		WithExternalSource(externalSource).
+		WithExternalSpec(fmt.Sprintf(`{"format":"iceberg-table","snapshot_id":%d}`, tableInfo.SnapshotID)).
+		WithField(entity.NewField().WithName("pk").WithDataType(entity.FieldTypeInt64).WithExternalField("pk")).
+		WithField(entity.NewField().WithName("label").WithDataType(entity.FieldTypeVarChar).WithMaxLength(256).WithExternalField("label")).
+		WithField(entity.NewField().WithName("vector").WithDataType(entity.FieldTypeFloatVector).WithDim(int64(tableInfo.Dim)).WithExternalField("vector"))
+
+	t.Log("[Phase 1] Creating external collection...")
+	err = mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, true)
+	t.Logf("[Phase 1] Created collection: %s", collName)
+	defer func() {
+		t.Log("[Cleanup] Dropping collection...")
+		_ = mc.DropCollection(ctx, client.NewDropCollectionOption(collName))
+	}()
+
+	coll, err := mc.DescribeCollection(ctx, client.NewDescribeCollectionOption(collName))
+	require.NoError(t, err)
+	t.Logf("[Phase 1] Collection has %d fields, externalSource=%s", len(coll.Schema.Fields), coll.Schema.ExternalSource)
+
+	// --- Phase 2: Refresh ---
+	t.Log("[Phase 2] Triggering refresh...")
+	refreshStart := time.Now()
+	refreshResult, err := mc.RefreshExternalCollection(ctx,
+		client.NewRefreshExternalCollectionOption(collName).
+			WithExternalSpec(externalSpec))
+	common.CheckErr(t, err, true)
+	jobID := refreshResult.JobID
+	t.Logf("[Phase 2] Refresh triggered, jobID=%d", jobID)
+
+	deadline := time.After(10 * time.Minute)
+	ticker := time.NewTicker(3 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-deadline:
+			t.Fatalf("[Phase 2] Refresh timed out after %s", time.Since(refreshStart))
+		case <-ticker.C:
+			progress, err := mc.GetRefreshExternalCollectionProgress(ctx,
+				client.NewGetRefreshExternalCollectionProgressOption(jobID))
+			require.NoError(t, err)
+			elapsed := time.Since(refreshStart)
+			t.Logf("[Phase 2] Job %d: state=%s, elapsed=%s", jobID, progress.State, elapsed.Round(time.Second))
+			if progress.State == entity.RefreshStateCompleted {
+				t.Logf("[Phase 2] Refresh completed in %s", elapsed)
+				goto refreshDone
+			}
+			if progress.State == entity.RefreshStateFailed {
+				t.Fatalf("[Phase 2] Refresh FAILED after %s: %s", elapsed, progress.Reason)
+			}
+		}
+	}
+refreshDone:
+
+	// --- Phase 3: Create index + Load ---
+	t.Log("[Phase 3] Creating index on vector field...")
+	idxTask, err := mc.CreateIndex(ctx,
+		client.NewCreateIndexOption(collName, "vector", index.NewFlatIndex(entity.COSINE)))
+	require.NoError(t, err)
+	err = idxTask.Await(ctx)
+	require.NoError(t, err)
+
+	t.Log("[Phase 3] Loading collection...")
+	loadStart := time.Now()
+	loadTask, err := mc.LoadCollection(ctx, client.NewLoadCollectionOption(collName))
+	require.NoError(t, err)
+	err = loadTask.Await(ctx)
+	require.NoError(t, err)
+	t.Logf("[Phase 3] Collection loaded in %s", time.Since(loadStart))
+
+	// --- Phase 4: Search ---
+	t.Log("[Phase 4] Searching...")
+	queryVec := make([]float32, tableInfo.Dim)
+	for i := range queryVec {
+		queryVec[i] = 0.1
+	}
+	searchResult, err := mc.Search(ctx,
+		client.NewSearchOption(collName, 10, []entity.Vector{entity.FloatVector(queryVec)}).
+			WithOutputFields("pk", "label"))
+	require.NoError(t, err)
+	require.NotEmpty(t, searchResult)
+	require.Greater(t, searchResult[0].ResultCount, 0)
+	t.Logf("[Phase 4] Search returned %d results", searchResult[0].ResultCount)
+
+	// --- Phase 5: Query ---
+	t.Log("[Phase 5] Querying...")
+	queryResult, err := mc.Query(ctx,
+		client.NewQueryOption(collName).
+			WithFilter("pk < 10").
+			WithOutputFields("pk", "label"))
+	require.NoError(t, err)
+	require.NotNil(t, queryResult)
+	t.Logf("[Phase 5] Query returned %d rows", queryResult.GetColumn("pk").Len())
+
+	t.Log("=== Iceberg E2E Test PASSED ===")
+}
+
+// createIcebergTestTable runs the Python script to create an Iceberg table on MinIO.
+func createIcebergTestTable(t *testing.T, endpoint, accessKey, secretKey, bucket, tablePath, numRows, dim string) icebergTableInfo {
+	t.Helper()
+
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok, "failed to get caller info")
+	scriptPath := filepath.Join(filepath.Dir(thisFile), "testdata", "create_iceberg_table.py")
+	infoPath := filepath.Join(t.TempDir(), "iceberg_table_info.json")
+
+	cmd := exec.Command("python3", scriptPath, // #nosec G204
+		"--endpoint", endpoint,
+		"--access-key", accessKey,
+		"--secret-key", secretKey,
+		"--bucket", bucket,
+		"--table-path", tablePath,
+		"--num-rows", numRows,
+		"--dim", dim,
+		"--output", infoPath,
+	)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	require.NoError(t, err, "failed to create Iceberg test table via Python script")
+
+	data, err := os.ReadFile(infoPath)
+	require.NoError(t, err, "failed to read iceberg_table_info.json")
+
+	var info icebergTableInfo
+	err = json.Unmarshal(data, &info)
+	require.NoError(t, err, "failed to parse iceberg_table_info.json")
+
+	return info
+}
+
+func icebergEnvOrDefault(key, defaultVal string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return defaultVal
+}

--- a/tests/go_client/testcases/testdata/create_iceberg_table.py
+++ b/tests/go_client/testcases/testdata/create_iceberg_table.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""
+Create an Iceberg table with test data on MinIO (local S3-compatible storage).
+This data is used by the Iceberg external table E2E test.
+
+Schema: pk (int64), label (string), vector (list<float32>[128])
+
+Usage:
+    python3 create_iceberg_table.py [--endpoint http://localhost:9000] [--num-rows 1000]
+"""
+
+import argparse
+import json
+import os
+import random
+
+import pyarrow as pa
+from pyiceberg.catalog.sql import SqlCatalog
+from pyiceberg.schema import Schema
+from pyiceberg.types import (
+    FloatType,
+    ListType,
+    LongType,
+    NestedField,
+    StringType,
+)
+
+
+def create_test_data(num_rows: int, dim: int = 128) -> pa.Table:
+    """Create test data as a PyArrow table."""
+    random.seed(42)
+
+    pks = list(range(num_rows))
+    labels = [f"label_{i}" for i in range(num_rows)]
+    vectors = [[random.uniform(-1.0, 1.0) for _ in range(dim)] for _ in range(num_rows)]
+
+    schema = pa.schema(
+        [
+            pa.field("pk", pa.int64()),
+            pa.field("label", pa.string()),
+            pa.field("vector", pa.list_(pa.float32(), dim)),
+        ]
+    )
+
+    return pa.table(
+        {
+            "pk": pa.array(pks, type=pa.int64()),
+            "label": pa.array(labels, type=pa.string()),
+            "vector": pa.array(vectors, type=pa.list_(pa.float32(), dim)),
+        },
+        schema=schema,
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Create Iceberg test table on MinIO")
+    parser.add_argument("--endpoint", default="http://localhost:9000", help="MinIO endpoint")
+    parser.add_argument("--access-key", default="minioadmin", help="MinIO access key")
+    parser.add_argument("--secret-key", default="minioadmin", help="MinIO secret key")
+    parser.add_argument("--bucket", default="a-bucket", help="MinIO bucket name")
+    parser.add_argument("--table-path", default="iceberg-test/e2e_test_table", help="Table path in bucket")
+    parser.add_argument("--num-rows", type=int, default=1000, help="Number of rows to generate")
+    parser.add_argument("--dim", type=int, default=128, help="Vector dimension")
+    parser.add_argument("--output", default="", help="Output JSON path (default: testdata/iceberg_table_info.json)")
+    args = parser.parse_args()
+
+    warehouse_path = f"s3://{args.bucket}/{args.table_path}"
+
+    # Create catalog using SQL (SQLite in-memory for one-time use)
+    catalog = SqlCatalog(
+        "test_catalog",
+        **{
+            "uri": "sqlite:///:memory:",
+            "s3.endpoint": args.endpoint,
+            "s3.access-key-id": args.access_key,
+            "s3.secret-access-key": args.secret_key,
+            "s3.region": "us-east-1",
+            "warehouse": warehouse_path,
+        },
+    )
+
+    # Create namespace
+    try:
+        catalog.create_namespace("default")
+    except Exception:
+        pass  # namespace may already exist
+
+    # Define Iceberg schema
+    iceberg_schema = Schema(
+        NestedField(1, "pk", LongType(), required=False),
+        NestedField(2, "label", StringType(), required=False),
+        NestedField(
+            3,
+            "vector",
+            ListType(4, FloatType(), element_required=False),
+            required=False,
+        ),
+    )
+
+    # Create table
+    table_name = "default.e2e_test"
+    try:
+        catalog.drop_table(table_name)
+    except Exception:
+        pass
+
+    table = catalog.create_table(table_name, schema=iceberg_schema)
+
+    # Generate and append data
+    data = create_test_data(args.num_rows, args.dim)
+    table.append(data)
+
+    # Refresh to get latest snapshot
+    table = catalog.load_table(table_name)
+    snapshot = table.current_snapshot()
+
+    result = {
+        "table_location": table.location(),
+        "metadata_location": table.metadata_location,
+        "snapshot_id": snapshot.snapshot_id,
+        "num_rows": args.num_rows,
+        "dim": args.dim,
+    }
+
+    print(json.dumps(result, indent=2))
+
+    # Write to file for the E2E test to consume
+    output_path = args.output if args.output else os.path.join(os.path.dirname(__file__), "iceberg_table_info.json")
+    with open(output_path, "w") as f:
+        json.dump(result, f, indent=2)
+    print(f"\nTable info written to: {output_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
issue: #45881
pr: #49172

Cherry-pick of #49172 (still open on master, head SHA 3ee675d735) to 3.0. Requires #49215 (Part8 2/4 cp, already merged on 3.0).

## Summary

Part 3/4 of External Table Part 8 series. Adds Iceberg external table support.

### What's in this PR

- Add `iceberg-table` format to `ExternalSpec` with `SnapshotID` field
- Pass `iceberg.snapshot_id` via `FormatProperties` to milvus-storage FFI
- Wire `FormatProperties` into `FetchFragmentsFromExternalSourceWithRange` extfs overrides
- Bump milvus-storage submodule to `fd3757b` (includes PR #471: Iceberg S3 access fix)
- Add `FindAzure` shim for Conan azure-sdk cmake compatibility
- Add Iceberg E2E test (pyiceberg + MinIO) in `tests/go_client/testcases/external_table_iceberg_e2e_test.go`

## Conflict resolution

Clean cherry-pick — 1 auto-merge (`conanfile.py`), 0 manual conflicts.

## Test plan

- [x] `go vet -tags dynamic,test` on datacoord/datanode-external/storagev2-packed — 0 issues
- [ ] CI: unit tests, integration tests, e2e