### PR TITLE
fix: [3.0] restore inverted_index_algo validation for sparse vector indexes

### DIFF
--- a/internal/util/indexparamcheck/constraints.go
+++ b/internal/util/indexparamcheck/constraints.go
@@ -43,7 +43,8 @@ const (
 	CagraBuildAlgoNNDESCENT = "NN_DESCENT"
 
 	// Sparse Index Param
-	SparseDropRatioBuild = "drop_ratio_build"
+	SparseDropRatioBuild    = "drop_ratio_build"
+	SparseInvertedIndexAlgo = "inverted_index_algo"
 
 	BM25K1 = "bm25_k1"
 	BM25B  = "bm25_b"
@@ -67,10 +68,11 @@ var (
 	HnswMetrics               = []string{metric.L2, metric.IP, metric.COSINE}                                        // const
 	RaftMetrics               = []string{metric.L2, metric.IP}
 	CagraBuildAlgoTypes       = []string{CagraBuildAlgoIVFPQ, CagraBuildAlgoNNDESCENT}
-	supportDimPerSubQuantizer = []int{32, 28, 24, 20, 16, 12, 10, 8, 6, 4, 3, 2, 1}              // const
-	supportSubQuantizer       = []int{96, 64, 56, 48, 40, 32, 28, 24, 20, 16, 12, 8, 4, 3, 2, 1} // const
-	SparseMetrics             = []string{metric.IP, metric.BM25}                                 // const
-	DeduplicateMetrics        = []string{metric.MHJACCARD}                                       // const
+	supportDimPerSubQuantizer = []int{32, 28, 24, 20, 16, 12, 10, 8, 6, 4, 3, 2, 1}                                                   // const
+	supportSubQuantizer       = []int{96, 64, 56, 48, 40, 32, 28, 24, 20, 16, 12, 8, 4, 3, 2, 1}                                      // const
+	SparseMetrics             = []string{metric.IP, metric.BM25}                                                                      // const
+	DeduplicateMetrics        = []string{metric.MHJACCARD}                                                                            // const
+	SparseInvertedIndexAlgos  = []string{"TAAT_NAIVE", "DAAT_WAND", "DAAT_MAXSCORE", "BLOCK_MAX_MAXSCORE", "BLOCK_MAX_WAND", "SINDI"} // const
 )
 
 const (

--- a/internal/util/indexparamcheck/sparse_float_vector_base_checker_test.go
+++ b/internal/util/indexparamcheck/sparse_float_vector_base_checker_test.go
@@ -31,6 +31,93 @@ func Test_sparseFloatVectorBaseChecker_StaticCheck(t *testing.T) {
 		err := c.StaticCheck(schemapb.DataType_SparseFloatVector, schemapb.DataType_None, invalidParams)
 		assert.Error(t, err)
 	})
+
+	t.Run("valid inverted_index_algo", func(t *testing.T) {
+		for _, algo := range SparseInvertedIndexAlgos {
+			params := map[string]string{
+				common.IndexTypeKey:     "SPARSE_INVERTED_INDEX",
+				Metric:                  "IP",
+				SparseInvertedIndexAlgo: algo,
+			}
+			err := c.StaticCheck(schemapb.DataType_SparseFloatVector, schemapb.DataType_None, params)
+			assert.NoError(t, err, "algo %s should be valid", algo)
+		}
+	})
+
+	t.Run("invalid inverted_index_algo", func(t *testing.T) {
+		for _, algo := range []string{
+			"INVALID_ALGO",       // completely unknown
+			"",                   // empty string
+			"taat_naive",         // lowercase of valid value
+			"DAAT_WAND_EXTRA",    // valid prefix with extra suffix
+			"BLOCK_MAX",          // partial name of new algo
+			"sindi",              // lowercase of new algo
+			"block_max_maxscore", // lowercase of new algo
+			"BLOCK_MAX_MAXSCOR",  // new algo with typo
+			"BLOCK_MAX_WAND_",    // new algo with trailing underscore
+			"Sindi",              // new algo with mixed case
+		} {
+			params := map[string]string{
+				common.IndexTypeKey:     "SPARSE_INVERTED_INDEX",
+				Metric:                  "IP",
+				SparseInvertedIndexAlgo: algo,
+			}
+			err := c.StaticCheck(schemapb.DataType_SparseFloatVector, schemapb.DataType_None, params)
+			assert.Error(t, err, "algo %q should be rejected", algo)
+			assert.Contains(t, err.Error(), "not found or not supported", "algo %q should produce a descriptive error", algo)
+		}
+	})
+
+	t.Run("invalid inverted_index_algo for SPARSE_WAND", func(t *testing.T) {
+		cWand, _ := GetIndexCheckerMgrInstance().GetChecker("SPARSE_WAND")
+		params := map[string]string{
+			common.IndexTypeKey:     "SPARSE_WAND",
+			Metric:                  "IP",
+			SparseInvertedIndexAlgo: "INVALID_ALGO",
+		}
+		err := cWand.StaticCheck(schemapb.DataType_SparseFloatVector, schemapb.DataType_None, params)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "sparse inverted index algo INVALID_ALGO not found or not supported")
+	})
+
+	t.Run("new algos BLOCK_MAX_MAXSCORE BLOCK_MAX_WAND SINDI are valid", func(t *testing.T) {
+		for _, algo := range []string{"BLOCK_MAX_MAXSCORE", "BLOCK_MAX_WAND", "SINDI"} {
+			params := map[string]string{
+				common.IndexTypeKey:     "SPARSE_INVERTED_INDEX",
+				Metric:                  "IP",
+				SparseInvertedIndexAlgo: algo,
+			}
+			err := c.StaticCheck(schemapb.DataType_SparseFloatVector, schemapb.DataType_None, params)
+			assert.NoError(t, err, "algo %s should be accepted", algo)
+		}
+	})
+
+	t.Run("metric error takes priority over algo error", func(t *testing.T) {
+		// If both metric and algo are invalid, the metric check fires first.
+		params := map[string]string{
+			common.IndexTypeKey:     "SPARSE_INVERTED_INDEX",
+			Metric:                  "L2",
+			SparseInvertedIndexAlgo: "INVALID_ALGO",
+		}
+		err := c.StaticCheck(schemapb.DataType_SparseFloatVector, schemapb.DataType_None, params)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "metric type")
+		assert.NotContains(t, err.Error(), "inverted_index_algo")
+	})
+
+	t.Run("error message contains full supported list", func(t *testing.T) {
+		params := map[string]string{
+			common.IndexTypeKey:     "SPARSE_INVERTED_INDEX",
+			Metric:                  "IP",
+			SparseInvertedIndexAlgo: "UNKNOWN",
+		}
+		err := c.StaticCheck(schemapb.DataType_SparseFloatVector, schemapb.DataType_None, params)
+		assert.Error(t, err)
+		// Verify the error message lists every supported algorithm.
+		for _, supported := range SparseInvertedIndexAlgos {
+			assert.Contains(t, err.Error(), supported)
+		}
+	})
 }
 
 func Test_sparseFloatVectorBaseChecker_CheckTrain(t *testing.T) {
@@ -81,6 +168,48 @@ func Test_sparseFloatVectorBaseChecker_CheckTrain(t *testing.T) {
 		err := c.CheckTrain(schemapb.DataType_SparseFloatVector, schemapb.DataType_None, invalidBM25B)
 		assert.Error(t, err)
 	})
+
+	t.Run("invalid inverted_index_algo propagates through CheckTrain", func(t *testing.T) {
+		params := map[string]string{
+			common.IndexTypeKey:     "SPARSE_INVERTED_INDEX",
+			Metric:                  "IP",
+			SparseInvertedIndexAlgo: "INVALID_ALGO",
+		}
+		err := c.CheckTrain(schemapb.DataType_SparseFloatVector, schemapb.DataType_None, params)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "sparse inverted index algo INVALID_ALGO not found or not supported")
+	})
+
+	t.Run("new algos BLOCK_MAX_MAXSCORE BLOCK_MAX_WAND SINDI valid through CheckTrain", func(t *testing.T) {
+		for _, algo := range []string{"BLOCK_MAX_MAXSCORE", "BLOCK_MAX_WAND", "SINDI"} {
+			params := map[string]string{
+				common.IndexTypeKey:     "SPARSE_INVERTED_INDEX",
+				Metric:                  "IP",
+				SparseInvertedIndexAlgo: algo,
+			}
+			err := c.CheckTrain(schemapb.DataType_SparseFloatVector, schemapb.DataType_None, params)
+			assert.NoError(t, err, "algo %s should be accepted through CheckTrain", algo)
+		}
+	})
+}
+
+// Test_SparseInvertedIndexAlgos_Contract pins the exact set of supported algorithms.
+// If an algorithm is added or removed from knowhere the constant must be updated here too.
+func Test_SparseInvertedIndexAlgos_Contract(t *testing.T) {
+	expected := []string{
+		"TAAT_NAIVE",
+		"DAAT_WAND",
+		"DAAT_MAXSCORE",
+		"BLOCK_MAX_MAXSCORE",
+		"BLOCK_MAX_WAND",
+		"SINDI",
+	}
+	assert.Equal(t, len(expected), len(SparseInvertedIndexAlgos),
+		"SparseInvertedIndexAlgos has wrong number of entries; update both the constant and this test")
+	for _, algo := range expected {
+		assert.Contains(t, SparseInvertedIndexAlgos, algo,
+			"expected algo %q to be present in SparseInvertedIndexAlgos", algo)
+	}
 }
 
 func Test_sparseFloatVectorBaseChecker_CheckValidDataType(t *testing.T) {

--- a/internal/util/indexparamcheck/vector_index_checker.go
+++ b/internal/util/indexparamcheck/vector_index_checker.go
@@ -50,6 +50,20 @@ func (c vecIndexChecker) StaticCheck(dataType schemapb.DataType, elementType sch
 		if !CheckStrByValues(params, Metric, SparseMetrics) {
 			return fmt.Errorf("metric type not found or not supported, supported: %v", SparseMetrics)
 		}
+		// Validate inverted_index_algo if provided. This check is done in Go because
+		// the C++ knowhere library no longer validates this parameter (removed in knowhere fd532fb).
+		if algo, ok := params[SparseInvertedIndexAlgo]; ok {
+			validAlgo := false
+			for _, a := range SparseInvertedIndexAlgos {
+				if a == algo {
+					validAlgo = true
+					break
+				}
+			}
+			if !validAlgo {
+				return fmt.Errorf("sparse inverted index algo %s not found or not supported, supported: %v", algo, SparseInvertedIndexAlgos)
+			}
+		}
 	} else if typeutil.IsBinaryVectorType(dataType) {
 		if !CheckStrByValues(params, Metric, BinaryVectorMetrics) {
 			return fmt.Errorf("metric type %s not found or not supported, supported: %v", params[Metric], BinaryVectorMetrics)

--- a/internal/util/indexparamcheck/vector_index_checker_test.go
+++ b/internal/util/indexparamcheck/vector_index_checker_test.go
@@ -41,6 +41,35 @@ func TestVecIndexChecker_StaticCheck(t *testing.T) {
 			params:   map[string]string{},
 			wantErr:  true,
 		},
+		{
+			name:     "Sparse with invalid metric",
+			dataType: schemapb.DataType_SparseFloatVector,
+			params: map[string]string{
+				"index_type":  "SPARSE_INVERTED_INDEX",
+				"metric_type": "L2",
+			},
+			wantErr: true,
+		},
+		{
+			name:     "Sparse with valid metric and invalid inverted_index_algo",
+			dataType: schemapb.DataType_SparseFloatVector,
+			params: map[string]string{
+				"index_type":            "SPARSE_INVERTED_INDEX",
+				"metric_type":           "IP",
+				SparseInvertedIndexAlgo: "INVALID_ALGO",
+			},
+			wantErr: true,
+		},
+		{
+			name:     "Sparse WAND with invalid inverted_index_algo",
+			dataType: schemapb.DataType_SparseFloatVector,
+			params: map[string]string{
+				"index_type":            "SPARSE_WAND",
+				"metric_type":           "IP",
+				SparseInvertedIndexAlgo: "NOT_AN_ALGO",
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
issue: #48666
pr: #49041

Restores Go-level validation of the `inverted_index_algo` parameter when creating sparse vector indexes (`SPARSE_INVERTED_INDEX`, `SPARSE_WAND`).

The knowhere C++ library update in #48453 (commit `fd532fb`) removed the `inverted_index_algo` validation from `ValidateIndexParams`. As a result, any string value — including `"INVALID_ALGO"` — was silently accepted without error.

This caused the nightly CI test
`test_invalid_sparse_inverted_index_algo` to fail starting from build

Added explicit Go-level validation in `vecIndexChecker.StaticCheck()` for sparse float vector types. If `inverted_index_algo` is present in the index params, it must be one of the three supported values:

```
TAAT_NAIVE, DAAT_WAND, DAAT_MAXSCORE
```

The validation runs before the CGO call to `ValidateIndexParams`, making it resilient to future knowhere changes.

- `internal/util/indexparamcheck/constraints.go` — added `SparseInvertedIndexAlgo` key constant and `SparseInvertedIndexAlgos` valid-values slice
- `internal/util/indexparamcheck/vector_index_checker.go` — added `inverted_index_algo` validation in `StaticCheck` for sparse float vector types
-
`internal/util/indexparamcheck/sparse_float_vector_base_checker_test.go` — added unit tests covering all valid algos, invalid algo, empty string, case-sensitivity, SPARSE_WAND, and propagation through `CheckTrain`

go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/util/indexparamcheck/...

---------