### PR TITLE
fix: [2.6] [RBAC] stop shipping built-in privilege groups in yaml to eliminate drift

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -985,30 +985,6 @@ common:
     rootShouldBindRole: false # Whether the root user should bind a role when the authorization is enabled.
     enablePublicPrivilege: true # Whether to enable public privilege
     exprEnabled: false # Whether to enable the /expr endpoint for debugging. When enabled, only root user can access it via HTTP Basic Auth on Proxy nodes.
-    rbac:
-      overrideBuiltInPrivilegeGroups:
-        enabled: false # Whether to override build-in privilege groups
-      cluster:
-        readonly:
-          privileges: ListDatabases,SelectOwnership,SelectUser,DescribeResourceGroup,ListResourceGroups,ListPrivilegeGroups # Cluster level readonly privileges
-        readwrite:
-          privileges: ListDatabases,SelectOwnership,SelectUser,DescribeResourceGroup,ListResourceGroups,ListPrivilegeGroups,FlushAll,TransferNode,TransferReplica,UpdateResourceGroups # Cluster level readwrite privileges
-        admin:
-          privileges: ListDatabases,SelectOwnership,SelectUser,DescribeResourceGroup,ListResourceGroups,ListPrivilegeGroups,FlushAll,TransferNode,TransferReplica,UpdateResourceGroups,BackupRBAC,RestoreRBAC,CreateDatabase,DropDatabase,CreateOwnership,DropOwnership,ManageOwnership,CreateResourceGroup,DropResourceGroup,UpdateUser,RenameCollection,CreatePrivilegeGroup,DropPrivilegeGroup,OperatePrivilegeGroup,UpdateReplicateConfiguration # Cluster level admin privileges
-      database:
-        readonly:
-          privileges: ShowCollections,DescribeDatabase # Database level readonly privileges
-        readwrite:
-          privileges: ShowCollections,DescribeDatabase,AlterDatabase # Database level readwrite privileges
-        admin:
-          privileges: ShowCollections,DescribeDatabase,AlterDatabase,CreateCollection,DropCollection # Database level admin privileges
-      collection:
-        readonly:
-          privileges: Query,Search,IndexDetail,GetFlushState,GetLoadState,GetLoadingProgress,HasPartition,ShowPartitions,DescribeCollection,DescribeAlias,GetStatistics,ListAliases,GetImportProgress,ListImport # Collection level readonly privileges
-        readwrite:
-          privileges: Query,Search,IndexDetail,GetFlushState,GetLoadState,GetLoadingProgress,HasPartition,ShowPartitions,DescribeCollection,DescribeAlias,GetStatistics,ListAliases,GetImportProgress,ListImport,Load,Release,Insert,Delete,Upsert,Import,Flush,Compaction,LoadBalance,CreateIndex,DropIndex,CreatePartition,DropPartition,AddCollectionField # Collection level readwrite privileges
-        admin:
-          privileges: Query,Search,IndexDetail,GetFlushState,GetLoadState,GetLoadingProgress,HasPartition,ShowPartitions,DescribeCollection,DescribeAlias,GetStatistics,ListAliases,GetImportProgress,ListImport,Load,Release,Insert,Delete,Upsert,Import,Flush,Compaction,LoadBalance,CreateIndex,DropIndex,CreatePartition,DropPartition,AddCollectionField,CreateAlias,DropAlias # Collection level admin privileges
     internaltlsEnabled: false
     tlsMode: 0
   session:

--- a/pkg/util/paramtable/rbac_config_test.go
+++ b/pkg/util/paramtable/rbac_config_test.go
@@ -17,9 +17,15 @@
 package paramtable
 
 import (
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
+
+	"github.com/milvus-io/milvus/pkg/v2/util"
 )
 
 func TestRbacConfig_DefaultPrivileges(t *testing.T) {
@@ -27,7 +33,6 @@ func TestRbacConfig_DefaultPrivileges(t *testing.T) {
 	params.Init(NewBaseTable(SkipRemote(true)))
 	cfg := &params.RbacConfig
 	assert.Equal(t, len(cfg.GetDefaultPrivilegeGroupNames()), 9)
-	assert.Equal(t, cfg.Enabled.GetAsBool(), false)
 	assert.Equal(t, cfg.ClusterReadOnlyPrivileges.GetAsStrings(), cfg.GetDefaultPrivilegeGroupPrivileges("ClusterReadOnly"))
 	assert.Equal(t, cfg.ClusterReadWritePrivileges.GetAsStrings(), cfg.GetDefaultPrivilegeGroupPrivileges("ClusterReadWrite"))
 	assert.Equal(t, cfg.ClusterAdminPrivileges.GetAsStrings(), cfg.GetDefaultPrivilegeGroupPrivileges("ClusterAdmin"))
@@ -45,14 +50,85 @@ func TestRbacConfig_OverridePrivileges(t *testing.T) {
 
 	clusterReadWrite := `SelectOwnership,SelectUser,DescribeResourceGroup`
 
-	params.Save(params.RbacConfig.Enabled.Key, "true")
 	params.Save(params.RbacConfig.ClusterReadWritePrivileges.Key, clusterReadWrite)
 
 	defer func() {
-		params.Reset(params.RbacConfig.Enabled.Key)
 		params.Reset(params.RbacConfig.ClusterReadWritePrivileges.Key)
 	}()
 
 	group := params.RbacConfig.GetDefaultPrivilegeGroup("ClusterReadWrite")
 	assert.Equal(t, len(group.Privileges), 3)
+}
+
+// TestRbacConfig_NoYamlKey_FallsBackToDefault locks the invariant that, when the
+// 9 built-in privilege group yaml keys are absent (which is the post-#49167 shipping
+// state), ParamItem.GetAsStrings() returns the current Go constants from util.*Privileges.
+// This is what makes the fix structurally correct: adding a new privilege to a
+// constant array in pkg/util/constant.go automatically flows through at runtime
+// without needing to touch configs/milvus.yaml.
+func TestRbacConfig_NoYamlKey_FallsBackToDefault(t *testing.T) {
+	params := ComponentParam{}
+	params.Init(NewBaseTable(SkipRemote(true)))
+	cfg := &params.RbacConfig
+
+	assert.Equal(t, cfg.ClusterReadOnlyPrivileges.GetAsStrings(), util.ClusterReadOnlyPrivileges)
+	assert.Equal(t, cfg.ClusterReadWritePrivileges.GetAsStrings(), util.ClusterReadWritePrivileges)
+	assert.Equal(t, cfg.ClusterAdminPrivileges.GetAsStrings(), util.ClusterAdminPrivileges)
+	assert.Equal(t, cfg.DBReadOnlyPrivileges.GetAsStrings(), util.DatabaseReadOnlyPrivileges)
+	assert.Equal(t, cfg.DBReadWritePrivileges.GetAsStrings(), util.DatabaseReadWritePrivileges)
+	assert.Equal(t, cfg.DBAdminPrivileges.GetAsStrings(), util.DatabaseAdminPrivileges)
+	assert.Equal(t, cfg.CollectionReadOnlyPrivileges.GetAsStrings(), util.CollectionReadOnlyPrivileges)
+	assert.Equal(t, cfg.CollectionReadWritePrivileges.GetAsStrings(), util.CollectionReadWritePrivileges)
+	assert.Equal(t, cfg.CollectionAdminPrivileges.GetAsStrings(), util.CollectionAdminPrivileges)
+}
+
+// TestRbacConfig_EmptyStringMeansEmptyGroup locks the semantic that an empty
+// yaml value (e.g. `privileges:` with no value) means "this group has no
+// privileges" — the user's explicit intent. This must NOT silently fall back
+// to the Go default. A deployment (e.g. managed cloud) may legitimately want
+// to zero out a built-in group; preserving that capability matters.
+func TestRbacConfig_EmptyStringMeansEmptyGroup(t *testing.T) {
+	params := ComponentParam{}
+	params.Init(NewBaseTable(SkipRemote(true)))
+
+	params.Save(params.RbacConfig.ClusterAdminPrivileges.Key, "")
+	defer params.Reset(params.RbacConfig.ClusterAdminPrivileges.Key)
+
+	got := params.RbacConfig.ClusterAdminPrivileges.GetAsStrings()
+	assert.NotEqual(t, util.ClusterAdminPrivileges, got,
+		"empty yaml value must not silently fall back to Go defaults")
+	// Accept either [] or [""], both are unambiguous "no privileges".
+	if len(got) == 1 {
+		assert.Equal(t, "", got[0])
+	} else {
+		assert.Empty(t, got)
+	}
+}
+
+// TestMilvusYamlHasNoRbacBuiltinPrivilegeKeys guards against accidentally
+// re-adding RBAC privilege group keys to configs/milvus.yaml (via Export=true
+// flip, hand edit, or regeneration with the wrong flags). The shipping yaml
+// must not contain these keys; defaults must come from Go source.
+func TestMilvusYamlHasNoRbacBuiltinPrivilegeKeys(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	assert.True(t, ok, "runtime.Caller failed")
+	// filepath.Dir(thisFile) is pkg/util/paramtable — 3 levels up is repo root
+	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..", "..")
+	yamlPath := filepath.Join(repoRoot, "configs", "milvus.yaml")
+
+	raw, err := os.ReadFile(yamlPath)
+	assert.NoError(t, err, "reading %s", yamlPath)
+
+	var tree map[string]interface{}
+	err = yaml.Unmarshal(raw, &tree)
+	assert.NoError(t, err)
+
+	// Drill into common.security.rbac
+	common, _ := tree["common"].(map[interface{}]interface{})
+	security, _ := common["security"].(map[interface{}]interface{})
+	rbac, present := security["rbac"]
+	assert.False(t, present,
+		"configs/milvus.yaml must not contain common.security.rbac.* keys; "+
+			"built-in privilege group defaults live in pkg/util/constant.go, not yaml. "+
+			"found: %v", rbac)
 }

--- a/pkg/util/paramtable/rbac_param.go
+++ b/pkg/util/paramtable/rbac_param.go
@@ -11,7 +11,6 @@ import (
 )
 
 type rbacConfig struct {
-	Enabled                    ParamItem `refreshable:"false"`
 	ClusterReadOnlyPrivileges  ParamItem `refreshable:"false"`
 	ClusterReadWritePrivileges ParamItem `refreshable:"false"`
 	ClusterAdminPrivileges     ParamItem `refreshable:"false"`
@@ -26,21 +25,12 @@ type rbacConfig struct {
 }
 
 func (p *rbacConfig) init(base *BaseTable) {
-	p.Enabled = ParamItem{
-		Key:          "common.security.rbac.overrideBuiltInPrivilegeGroups.enabled",
-		DefaultValue: "false",
-		Version:      "2.4.16",
-		Doc:          "Whether to override build-in privilege groups",
-		Export:       true,
-	}
-	p.Enabled.Init(base.mgr)
-
 	p.ClusterReadOnlyPrivileges = ParamItem{
 		Key:          "common.security.rbac.cluster.readonly.privileges",
 		DefaultValue: strings.Join(util.ClusterReadOnlyPrivileges, ","),
 		Version:      "2.4.16",
 		Doc:          "Cluster level readonly privileges",
-		Export:       true,
+		Export:       false,
 	}
 	p.ClusterReadOnlyPrivileges.Init(base.mgr)
 
@@ -49,7 +39,7 @@ func (p *rbacConfig) init(base *BaseTable) {
 		DefaultValue: strings.Join(util.ClusterReadWritePrivileges, ","),
 		Version:      "2.4.16",
 		Doc:          "Cluster level readwrite privileges",
-		Export:       true,
+		Export:       false,
 	}
 	p.ClusterReadWritePrivileges.Init(base.mgr)
 
@@ -58,7 +48,7 @@ func (p *rbacConfig) init(base *BaseTable) {
 		DefaultValue: strings.Join(util.ClusterAdminPrivileges, ","),
 		Version:      "2.4.16",
 		Doc:          "Cluster level admin privileges",
-		Export:       true,
+		Export:       false,
 	}
 	p.ClusterAdminPrivileges.Init(base.mgr)
 
@@ -67,7 +57,7 @@ func (p *rbacConfig) init(base *BaseTable) {
 		DefaultValue: strings.Join(util.DatabaseReadOnlyPrivileges, ","),
 		Version:      "2.4.16",
 		Doc:          "Database level readonly privileges",
-		Export:       true,
+		Export:       false,
 	}
 	p.DBReadOnlyPrivileges.Init(base.mgr)
 
@@ -76,7 +66,7 @@ func (p *rbacConfig) init(base *BaseTable) {
 		DefaultValue: strings.Join(util.DatabaseReadWritePrivileges, ","),
 		Version:      "2.4.16",
 		Doc:          "Database level readwrite privileges",
-		Export:       true,
+		Export:       false,
 	}
 	p.DBReadWritePrivileges.Init(base.mgr)
 
@@ -85,7 +75,7 @@ func (p *rbacConfig) init(base *BaseTable) {
 		DefaultValue: strings.Join(util.DatabaseAdminPrivileges, ","),
 		Version:      "2.4.16",
 		Doc:          "Database level admin privileges",
-		Export:       true,
+		Export:       false,
 	}
 	p.DBAdminPrivileges.Init(base.mgr)
 
@@ -94,7 +84,7 @@ func (p *rbacConfig) init(base *BaseTable) {
 		DefaultValue: strings.Join(util.CollectionReadOnlyPrivileges, ","),
 		Version:      "2.4.16",
 		Doc:          "Collection level readonly privileges",
-		Export:       true,
+		Export:       false,
 	}
 	p.CollectionReadOnlyPrivileges.Init(base.mgr)
 
@@ -103,7 +93,7 @@ func (p *rbacConfig) init(base *BaseTable) {
 		DefaultValue: strings.Join(util.CollectionReadWritePrivileges, ","),
 		Version:      "2.4.16",
 		Doc:          "Collection level readwrite privileges",
-		Export:       true,
+		Export:       false,
 	}
 	p.CollectionReadWritePrivileges.Init(base.mgr)
 
@@ -112,7 +102,7 @@ func (p *rbacConfig) init(base *BaseTable) {
 		DefaultValue: strings.Join(util.CollectionAdminPrivileges, ","),
 		Version:      "2.4.16",
 		Doc:          "Collection level admin privileges",
-		Export:       true,
+		Export:       false,
 	}
 	p.CollectionAdminPrivileges.Init(base.mgr)
 }


### PR DESCRIPTION
Cherry-pick of master PR #49201 onto 2.6.

issue: #49167
pr: #49201

## Summary
Flip `Export: false` on the 9 built-in RBAC privilege-group ParamItems and remove the dead `overrideBuiltInPrivilegeGroups.enabled` flag, so `configs/milvus.yaml` no longer ships those keys. Runtime falls through to the Go constants in `pkg/util/constant.go`. yaml override path (FileSource > DefaultValue) is unchanged.

## Runtime verification

Built locally on this branch and inspected `CollectionReadWrite` via `MilvusClient.list_privilege_groups()`.

| Scenario | `user.yaml` | `CollectionReadWrite` | Conclusion |
|---|---|---|---|
| **A** no key | — | 28 privileges (full Go constant list) | Fallthrough to `DefaultValue` works → drift eliminated |
| **B** key with value | `privileges: Query,Search` | exactly `{Query, Search}` | FileSource override still wins → Cloud unchanged |
| **C** key empty | `privileges:` (or `""`) | 0 privileges | Empty value preserved as explicit intent, not rewritten |

All three pass.