### PR TITLE
fix: use 3.0 as fallback branch name in version string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ index_engine = knowhere
 # both -c options and GIT_CONFIG_COUNT env vars are processed.
 $(shell git config --global --add safe.directory '*' 2>/dev/null)
 
-export GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD 2>/dev/null | grep -v '^HEAD$$' || echo "$${GITHUB_REF_NAME:-$${BRANCH_NAME:-unknown}}")
+export GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD 2>/dev/null | grep -v '^HEAD$$' || echo "$${GITHUB_REF_NAME:-$${BRANCH_NAME:-3.0}}")
 GIT_BRANCH_SAFE=$(shell echo "$(GIT_BRANCH)" | tr '/' '-')
 
 ifeq (${ENABLE_AZURE}, false)


### PR DESCRIPTION
## Problem

On the 3.0 branch, `get_server_version()` (and `system info`) returns `unknown-20260423-xxxxx` instead of the expected `3.0-DATE-COMMIT`.

**Root cause chain:**
1. CI builds run in detached HEAD state → `git rev-parse --abbrev-ref HEAD` returns `"HEAD"`, which is filtered out by `grep -v '^HEAD$'`
2. Neither `GITHUB_REF_NAME` nor `BRANCH_NAME` is set in the build environment for branch builds
3. Makefile falls back to the literal string `"unknown"`
4. Binary is compiled with `MILVUS_VERSION=unknown-DATE-COMMIT`
5. `GetVersion` RPC returns `unknown-DATE-COMMIT`

## Fix

Change the last-resort fallback in `GIT_BRANCH` detection from `"unknown"` to `"3.0"`:

```makefile
# Before
export GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD 2>/dev/null | grep -v '^HEAD$$' || echo "$${GITHUB_REF_NAME:-$${BRANCH_NAME:-unknown}}")

# After
export GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD 2>/dev/null | grep -v '^HEAD$$' || echo "$${GITHUB_REF_NAME:-$${BRANCH_NAME:-3.0}}")
```

## Impact

| Build scenario | Before | After |
|---|---|---|
| Nightly / branch-trigger CI build | `unknown-DATE-COMMIT` ❌ | `3.0-DATE-COMMIT` ✅ |
| Formal release (on `v3.0.x` tag) | `3.0.0` ✅ | `3.0.0` ✅ (unaffected — uses git tag, never reaches fallback) |
| Local dev with checked-out branch | `3.0` ✅ | `3.0` ✅ (unchanged — git returns branch name directly) |
| CI with `GITHUB_REF_NAME` or `BRANCH_NAME` set | already correct | unchanged |

issue: #49300

🤖 Generated with [Claude Code](https://claude.com/claude-code)