### PR TITLE
fix: [3.0] external table corner cases for invalid arguments

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -2833,6 +2833,13 @@ ChunkedSegmentSealedImpl::get_raw_data(milvus::OpContext* op_ctx,
         }
 
         case DataType::ARRAY: {
+            // Carry the element type into the response so the caller (and
+            // SDK) can dispatch on it. Without this, callers parse a
+            // headless ScalarField_ArrayData and reject it with
+            // "unsupported element type None". Regression fix for #48619.
+            ret->mutable_scalars()->mutable_array_data()->set_element_type(
+                static_cast<milvus::proto::schema::DataType>(
+                    field_meta.get_element_type()));
             bulk_subscript_array_impl(
                 op_ctx,
                 column.get(),
@@ -4753,6 +4760,10 @@ ChunkedSegmentSealedImpl::ArrowToDataArray(
         case DataType::ARRAY: {
             // NormalizeExternalArrow already converted List→Binary(protobuf).
             auto obj = data_array->mutable_scalars()->mutable_array_data();
+            // Same element_type carry-through as the chunked sealed path
+            // above; without it the SDK rejects the response. Fix for #48619.
+            obj->set_element_type(static_cast<milvus::proto::schema::DataType>(
+                field_meta.get_element_type()));
             auto typed = std::static_pointer_cast<arrow::BinaryArray>(arr);
             for (int64_t i = 0; i < size; i++) {
                 auto val = typed->Value(result_mapping[i]);

--- a/internal/datacoord/external_collection_refresh_manager.go
+++ b/internal/datacoord/external_collection_refresh_manager.go
@@ -106,6 +106,12 @@ type ExternalCollectionRefreshManager interface {
 
 	// ListJobs returns jobs for the given collection, sorted by start_time descending
 	ListJobs(ctx context.Context, collectionID int64) ([]*datapb.ExternalCollectionRefreshJob, error)
+
+	// GetActiveJobByCollectionID returns the in-progress (Init/InProgress/Retry)
+	// refresh job for the collection if one exists, or nil. Used by the RPC
+	// handler to surface duplicate refresh requests synchronously instead of
+	// allocating a fresh jobID that the WAL ack callback will silently drop.
+	GetActiveJobByCollectionID(collectionID int64) *datapb.ExternalCollectionRefreshJob
 }
 
 var _ ExternalCollectionRefreshManager = (*externalCollectionRefreshManager)(nil)
@@ -784,6 +790,13 @@ func (m *externalCollectionRefreshManager) ListJobs(ctx context.Context, collect
 	}
 
 	return result, nil
+}
+
+// GetActiveJobByCollectionID delegates to the meta layer. The underlying meta
+// query takes the per-collection job lock, so concurrent AddJob calls observe
+// a consistent view.
+func (m *externalCollectionRefreshManager) GetActiveJobByCollectionID(collectionID int64) *datapb.ExternalCollectionRefreshJob {
+	return m.refreshMeta.GetActiveJobByCollectionID(collectionID)
 }
 
 // exploreExternalFiles calls ExploreFiles once on DataCoord and returns the full file list.

--- a/internal/datacoord/external_collection_refresh_manager.go
+++ b/internal/datacoord/external_collection_refresh_manager.go
@@ -642,6 +642,17 @@ func (m *externalCollectionRefreshManager) createTasksForJob(
 	// Manifest is written to S3 so DataNodes can read file info by range.
 	allFiles, manifestPath, err := m.exploreExternalFiles(ctx, job)
 	if err != nil {
+		// Any FFI failure during explore is terminal for this job: the
+		// source is unreachable, denied, malformed, or absent and no
+		// amount of in-loop retrying can change that. Surface as
+		// non-retriable so the user gets a clear RefreshFailed signal
+		// (with the underlying error attached) and can re-issue refresh
+		// after fixing the source. Pure in-process errors (ctx cancel,
+		// etcd unavailable, etc.) keep the existing transient path so
+		// a real outage still gets retried.
+		if errors.Is(err, packed.ErrLoonTransient) {
+			return nil, newNonRetriableJobError("explore external files failed: %v", err)
+		}
 		return nil, fmt.Errorf("failed to explore external files: %w", err)
 	}
 	if len(allFiles) == 0 {

--- a/internal/datacoord/external_collection_refresh_manager.go
+++ b/internal/datacoord/external_collection_refresh_manager.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
@@ -37,6 +38,20 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
+
+// nonRetriableJobError marks a refresh-job submission failure that must NOT
+// be retried by the checker tick (e.g. empty source, zero-row source, bucket
+// not found). ensureTasksForInitJob recognizes it and transitions the job
+// straight to Failed instead of leaving it in Init for endless retry.
+type nonRetriableJobError struct {
+	reason string
+}
+
+func (e *nonRetriableJobError) Error() string { return e.reason }
+
+func newNonRetriableJobError(format string, args ...interface{}) error {
+	return &nonRetriableJobError{reason: fmt.Sprintf(format, args...)}
+}
 
 // exploreTempDirForJob returns the per-job explore temp directory path used
 // both when datacoord writes the explore manifest and when cleanupExploreTempForJob
@@ -577,10 +592,23 @@ func (m *externalCollectionRefreshManager) ensureTasksForInitJob(jobID int64) {
 
 		tasks, err := m.createTasksForJob(ctx, freshJob)
 		if err != nil {
-			// Leave the job in Init state so the checker tick / WAL redelivery
-			// path retries on the next cycle. Do not transition to Failed here:
-			// transient S3 blips should not trip a one-shot failure. The
-			// tryTimeoutJob path bounds how long a stuck job can linger.
+			// Non-retriable failures (empty source, zero-row source, etc.)
+			// must transition the job to Failed immediately. Otherwise the
+			// checker tick keeps re-running the same explore that will fail
+			// the same way forever, giving operators no signal to act on.
+			var perm *nonRetriableJobError
+			if errors.As(err, &perm) {
+				log.Warn("non-retriable error in task creation, marking job failed",
+					zap.Error(err))
+				if _, uerr := m.refreshMeta.UpdateJobState(jobID,
+					indexpb.JobState_JobStateFailed, perm.Error()); uerr != nil {
+					log.Warn("failed to mark job failed", zap.Error(uerr))
+				}
+				return
+			}
+			// Transient failures (e.g. S3 blip) — leave in Init so the
+			// checker tick / WAL redelivery path retries. tryTimeoutJob
+			// bounds how long a stuck job can linger.
 			log.Warn("async task creation failed, will retry on next checker tick",
 				zap.Error(err))
 			return
@@ -617,7 +645,21 @@ func (m *externalCollectionRefreshManager) createTasksForJob(
 		return nil, fmt.Errorf("failed to explore external files: %w", err)
 	}
 	if len(allFiles) == 0 {
-		return nil, fmt.Errorf("no files found in external source: %s", job.GetExternalSource())
+		return nil, newNonRetriableJobError("no files found in external source: %s", job.GetExternalSource())
+	}
+	// Reject zero-total-rows sources up front: a non-empty file list whose
+	// rows sum to zero (e.g. user-supplied empty parquet) would otherwise
+	// reach datanode's balanceFragmentsToSegments which divides by zero
+	// and crashes the process. Treat as non-retriable so the operator gets
+	// a clear failure signal instead of a CrashLoopBackOff. Fix for #49225.
+	var totalRows int64
+	for _, f := range allFiles {
+		totalRows += f.NumRows
+	}
+	if totalRows == 0 {
+		return nil, newNonRetriableJobError(
+			"external source %s has %d files but zero total rows; nothing to refresh",
+			job.GetExternalSource(), len(allFiles))
 	}
 	log.Info("explored external files for task splitting",
 		zap.Int("totalFiles", len(allFiles)),

--- a/internal/datacoord/external_collection_refresh_manager_test.go
+++ b/internal/datacoord/external_collection_refresh_manager_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
@@ -300,6 +301,52 @@ func TestExternalCollectionRefreshManager_SubmitRefreshJobWithID(t *testing.T) {
 			"non-retriable error must transition job to Failed, not leave in Init")
 		assert.Contains(t, job.GetFailReason(), "zero total rows",
 			"reason must explain why so operators can act")
+	})
+
+	t.Run("ffi_explore_error_marks_job_failed_non_retriable", func(t *testing.T) {
+		// Regression for #49233: any FFI failure during explore (NoSuchBucket,
+		// AccessDenied, DNS NXDOMAIN, malformed URI, ...) is wrapped by the
+		// loon FFI layer as ErrLoonTransient. Without classification this
+		// looped forever as RefreshPending. Treat all FFI explore failures
+		// as terminal so the job transitions to RefreshFailed and the user
+		// gets a clear signal.
+		refreshMeta := createTestRefreshMeta(t)
+		alloc := &stubAllocator{nextID: 1000}
+		scheduler := newStubScheduler()
+
+		collections := typeutil.NewConcurrentMap[UniqueID, *collectionInfo]()
+		collections.Insert(100, &collectionInfo{
+			ID: 100,
+			Schema: &schemapb.CollectionSchema{
+				Name:           "test_collection",
+				ExternalSource: "s3://bucket-does-not-exist/path",
+				ExternalSpec:   `{"format":"parquet"}`,
+			},
+		})
+		mt := &meta{collections: collections}
+
+		mockIsExternal := mockey.Mock(typeutil.IsExternalCollection).Return(true).Build()
+		defer mockIsExternal.UnPatch()
+
+		ffiErr := errors.Wrap(packed.ErrLoonTransient, "FFI operation failed: AWS Error NO_SUCH_BUCKET during ListObjectsV2")
+		mockExplore := mockey.Mock((*externalCollectionRefreshManager).exploreExternalFiles).
+			Return(nil, "", ffiErr).Build()
+		defer mockExplore.UnPatch()
+
+		manager := NewExternalCollectionRefreshManager(ctx, mt, scheduler, alloc, refreshMeta, nil, testCollectionGetter(mt), nil, nil)
+
+		_, err := manager.SubmitRefreshJobWithID(ctx, 1, 100, "test_collection", "", "")
+		assert.NoError(t, err)
+
+		manager.Stop()
+
+		job := refreshMeta.GetJob(1)
+		assert.NotNil(t, job)
+		assert.Equal(t, indexpb.JobState_JobStateFailed, job.GetState(),
+			"FFI explore failure must transition job to Failed, not loop in Init")
+		assert.Contains(t, job.GetFailReason(), "explore external files failed")
+		assert.Contains(t, job.GetFailReason(), "NO_SUCH_BUCKET",
+			"underlying error must be surfaced to operators")
 	})
 
 	t.Run("reject_when_active_job_exists", func(t *testing.T) {

--- a/internal/datacoord/external_collection_refresh_manager_test.go
+++ b/internal/datacoord/external_collection_refresh_manager_test.go
@@ -255,6 +255,53 @@ func TestExternalCollectionRefreshManager_SubmitRefreshJobWithID(t *testing.T) {
 		assert.Empty(t, job.GetTaskIds(), "no tasks should be persisted after async failure")
 	})
 
+	t.Run("zero_total_rows_marks_job_failed_non_retriable", func(t *testing.T) {
+		// Regression for #49225: a non-empty file list whose row counts sum
+		// to zero (e.g. user-supplied empty parquet) used to make datanode
+		// crash with "integer divide by zero". Now createTasksForJob must
+		// reject this case as a non-retriable error and Phase B must
+		// transition the job to JobStateFailed instead of leaving it in
+		// Init for the checker tick to retry forever.
+		refreshMeta := createTestRefreshMeta(t)
+		alloc := &stubAllocator{nextID: 1000}
+		scheduler := newStubScheduler()
+
+		collections := typeutil.NewConcurrentMap[UniqueID, *collectionInfo]()
+		collections.Insert(100, &collectionInfo{
+			ID: 100,
+			Schema: &schemapb.CollectionSchema{
+				Name:           "test_collection",
+				ExternalSource: "s3://bucket/empty",
+				ExternalSpec:   `{"format":"parquet"}`,
+			},
+		})
+		mt := &meta{collections: collections}
+
+		mockIsExternal := mockey.Mock(typeutil.IsExternalCollection).Return(true).Build()
+		defer mockIsExternal.UnPatch()
+
+		// One file, zero rows — passes the existing len()==0 check but
+		// must trip the new totalRows==0 guard.
+		mockExplore := mockey.Mock((*externalCollectionRefreshManager).exploreExternalFiles).
+			Return([]*datapb.ExternalFileInfo{{FilePath: "s3://bucket/empty/empty.parquet", NumRows: 0}}, "s3://bucket/empty/manifest", nil).Build()
+		defer mockExplore.UnPatch()
+
+		manager := NewExternalCollectionRefreshManager(ctx, mt, scheduler, alloc, refreshMeta, nil, testCollectionGetter(mt), nil, nil)
+
+		_, err := manager.SubmitRefreshJobWithID(ctx, 1, 100, "test_collection", "", "")
+		assert.NoError(t, err)
+
+		// Wait for Phase B to finish.
+		manager.Stop()
+
+		job := refreshMeta.GetJob(1)
+		assert.NotNil(t, job)
+		assert.Equal(t, indexpb.JobState_JobStateFailed, job.GetState(),
+			"non-retriable error must transition job to Failed, not leave in Init")
+		assert.Contains(t, job.GetFailReason(), "zero total rows",
+			"reason must explain why so operators can act")
+	})
+
 	t.Run("reject_when_active_job_exists", func(t *testing.T) {
 		now := time.Now().UnixMilli()
 		existingJob := &datapb.ExternalCollectionRefreshJob{

--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -2619,16 +2619,6 @@ func (s *Server) RefreshExternalCollection(ctx context.Context, req *datapb.Refr
 		}, nil
 	}
 
-	// Pre-allocate JobID for idempotency (ensures same JobID even if retry after failure)
-	allocatedJobID, err := s.allocator.AllocID(ctx)
-	if err != nil {
-		log.Warn("failed to allocate job ID", zap.Error(err))
-		return &datapb.RefreshExternalCollectionResponse{
-			Status: merr.Status(err),
-		}, nil
-	}
-	log.Info("pre-allocated job ID for refresh", zap.Int64("jobID", allocatedJobID))
-
 	// Start broadcaster with resource lock (shared DB + exclusive collection)
 	b, err := s.startBroadcastWithCollectionID(ctx, req.GetCollectionId())
 	if err != nil {
@@ -2638,6 +2628,37 @@ func (s *Server) RefreshExternalCollection(ctx context.Context, req *datapb.Refr
 		}, nil
 	}
 	defer b.Close()
+
+	// Synchronous duplicate detection at the RPC edge. The WAL ack callback
+	// already rejects duplicates, but it does so AFTER the RPC has already
+	// returned a fresh jobID to the client; that jobID then dies silently and
+	// the client polls it forever. Surfacing the in-progress jobID here
+	// (along with merr.ErrTaskDuplicate) lets the caller switch to polling
+	// the real job. The remaining TOCTOU window between this read and the
+	// ack-side AddJob falls back to the existing ack-side rejection, i.e.
+	// today's behavior — never worse.
+	if active := s.externalCollectionRefreshManager.GetActiveJobByCollectionID(req.GetCollectionId()); active != nil {
+		log.Info("refresh job already in progress, rejecting at RPC edge",
+			zap.Int64("existingJobID", active.GetJobId()),
+			zap.String("existingState", active.GetState().String()))
+		return &datapb.RefreshExternalCollectionResponse{
+			Status: merr.Status(merr.WrapErrTaskDuplicate(
+				"refresh_external_collection",
+				fmt.Sprintf("refresh job %d is already in progress for collection %s; poll that jobID or wait for it to complete",
+					active.GetJobId(), req.GetCollectionName()))),
+			JobId: active.GetJobId(),
+		}, nil
+	}
+
+	// Pre-allocate JobID for idempotency (ensures same JobID even if retry after failure)
+	allocatedJobID, err := s.allocator.AllocID(ctx)
+	if err != nil {
+		log.Warn("failed to allocate job ID", zap.Error(err))
+		return &datapb.RefreshExternalCollectionResponse{
+			Status: merr.Status(err),
+		}, nil
+	}
+	log.Info("pre-allocated job ID for refresh", zap.Int64("jobID", allocatedJobID))
 
 	// Build and broadcast the message
 	msg := message.NewRefreshExternalCollectionMessageBuilderV2().

--- a/internal/datacoord/services_test.go
+++ b/internal/datacoord/services_test.go
@@ -3780,6 +3780,15 @@ func TestServer_RefreshExternalCollection(t *testing.T) {
 		}
 		server.stateCode.Store(commonpb.StateCode_Healthy)
 
+		// Bypass startBroadcast (broker not wired in test) and the new
+		// duplicate-active-job pre-check (refreshMeta is nil here).
+		mockStartBroadcast := mockey.Mock((*Server).startBroadcastWithCollectionID).Return(&struct{ broadcaster.BroadcastAPI }{}, nil).Build()
+		defer mockStartBroadcast.UnPatch()
+		mockClose := mockey.Mock((*struct{ broadcaster.BroadcastAPI }).Close).Return().Build()
+		defer mockClose.UnPatch()
+		mockGetActive := mockey.Mock((*externalCollectionRefreshManager).GetActiveJobByCollectionID).Return(nil).Build()
+		defer mockGetActive.UnPatch()
+
 		resp, err := server.RefreshExternalCollection(ctx, &datapb.RefreshExternalCollectionRequest{
 			CollectionId:   100,
 			CollectionName: "test_collection",
@@ -3789,17 +3798,46 @@ func TestServer_RefreshExternalCollection(t *testing.T) {
 		assert.Error(t, merr.Error(resp.GetStatus()))
 	})
 
+	t.Run("rejects_when_active_job_in_progress", func(t *testing.T) {
+		ctx := context.Background()
+
+		mockRefreshMgr := &externalCollectionRefreshManager{}
+		server := &Server{
+			externalCollectionRefreshManager: mockRefreshMgr,
+		}
+		server.stateCode.Store(commonpb.StateCode_Healthy)
+
+		mockStartBroadcast := mockey.Mock((*Server).startBroadcastWithCollectionID).Return(&struct{ broadcaster.BroadcastAPI }{}, nil).Build()
+		defer mockStartBroadcast.UnPatch()
+		mockClose := mockey.Mock((*struct{ broadcaster.BroadcastAPI }).Close).Return().Build()
+		defer mockClose.UnPatch()
+		mockGetActive := mockey.Mock((*externalCollectionRefreshManager).GetActiveJobByCollectionID).Return(&datapb.ExternalCollectionRefreshJob{
+			JobId:        12345,
+			CollectionId: 100,
+			State:        indexpb.JobState_JobStateInProgress,
+		}).Build()
+		defer mockGetActive.UnPatch()
+
+		resp, err := server.RefreshExternalCollection(ctx, &datapb.RefreshExternalCollectionRequest{
+			CollectionId:   100,
+			CollectionName: "test_collection",
+		})
+
+		assert.NoError(t, err)
+		assert.ErrorIs(t, merr.Error(resp.GetStatus()), merr.ErrTaskDuplicate)
+		assert.Equal(t, int64(12345), resp.GetJobId(),
+			"existing jobID must be returned so the client can poll it")
+		assert.Contains(t, resp.GetStatus().GetReason(), "12345")
+	})
+
 	t.Run("start_broadcaster_failed", func(t *testing.T) {
 		ctx := context.Background()
 
-		mockAllocator := allocator.NewMockAllocator(t)
-		mockAllocator.EXPECT().AllocID(mock.Anything).Return(int64(123), nil)
-
-		// Create a mock refresh manager (non-nil)
+		// startBroadcast now runs before AllocID, so AllocID should never
+		// be reached when the broadcaster fails to start.
 		mockRefreshMgr := &externalCollectionRefreshManager{}
 
 		server := &Server{
-			allocator:                        mockAllocator,
 			externalCollectionRefreshManager: mockRefreshMgr,
 		}
 		server.stateCode.Store(commonpb.StateCode_Healthy)

--- a/internal/metastore/model/collection.go
+++ b/internal/metastore/model/collection.go
@@ -194,8 +194,17 @@ func (c *Collection) ApplyUpdates(header *message.AlterCollectionMessageHeader, 
 			c.ExternalSource = updates.Schema.ExternalSource
 			c.ExternalSpec = updates.Schema.ExternalSpec
 		case message.FieldMaskCollectionExternalSpec:
-			c.ExternalSource = updates.Schema.ExternalSource
-			c.ExternalSpec = updates.Schema.ExternalSpec
+			// Defensive: only overwrite when the update carries a value.
+			// Legacy WAL messages from before the atomic-tuple invariant may
+			// arrive with one half empty; preserving the existing field in
+			// that case avoids silently clearing a previously persisted
+			// source or spec on replay.
+			if v := updates.Schema.GetExternalSource(); v != "" {
+				c.ExternalSource = v
+			}
+			if v := updates.Schema.GetExternalSpec(); v != "" {
+				c.ExternalSpec = v
+			}
 		}
 	}
 }

--- a/internal/metastore/model/collection_test.go
+++ b/internal/metastore/model/collection_test.go
@@ -20,11 +20,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	pb "github.com/milvus-io/milvus/pkg/v2/proto/etcdpb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/messagespb"
+	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
 )
 
 var (
@@ -613,4 +616,55 @@ func TestClone(t *testing.T) {
 	assert.Equal(t, clone1, collection)
 	clone2 := collection.ShallowClone()
 	assert.Equal(t, clone2, collection)
+}
+
+func TestApplyUpdates_ExternalSpecMaskOnlyOverwriteNonEmpty(t *testing.T) {
+	mkBody := func(src, spec string) (*message.AlterCollectionMessageHeader, *message.AlterCollectionMessageBody) {
+		hdr := &message.AlterCollectionMessageHeader{
+			UpdateMask: &fieldmaskpb.FieldMask{
+				Paths: []string{message.FieldMaskCollectionExternalSpec},
+			},
+		}
+		body := &message.AlterCollectionMessageBody{
+			Updates: &messagespb.AlterCollectionMessageUpdates{
+				Schema: &schemapb.CollectionSchema{
+					ExternalSource: src,
+					ExternalSpec:   spec,
+				},
+			},
+		}
+		return hdr, body
+	}
+
+	t.Run("both empty preserves existing", func(t *testing.T) {
+		c := &Collection{ExternalSource: "s3://orig", ExternalSpec: `{"format":"parquet"}`}
+		hdr, body := mkBody("", "")
+		c.ApplyUpdates(hdr, body)
+		assert.Equal(t, "s3://orig", c.ExternalSource)
+		assert.Equal(t, `{"format":"parquet"}`, c.ExternalSpec)
+	})
+
+	t.Run("source only overwrites source preserves spec", func(t *testing.T) {
+		c := &Collection{ExternalSource: "s3://orig", ExternalSpec: `{"format":"parquet"}`}
+		hdr, body := mkBody("s3://new", "")
+		c.ApplyUpdates(hdr, body)
+		assert.Equal(t, "s3://new", c.ExternalSource)
+		assert.Equal(t, `{"format":"parquet"}`, c.ExternalSpec)
+	})
+
+	t.Run("spec only overwrites spec preserves source", func(t *testing.T) {
+		c := &Collection{ExternalSource: "s3://orig", ExternalSpec: `{"format":"parquet"}`}
+		hdr, body := mkBody("", `{"format":"lance"}`)
+		c.ApplyUpdates(hdr, body)
+		assert.Equal(t, "s3://orig", c.ExternalSource)
+		assert.Equal(t, `{"format":"lance"}`, c.ExternalSpec)
+	})
+
+	t.Run("both overwrite both", func(t *testing.T) {
+		c := &Collection{ExternalSource: "s3://orig", ExternalSpec: `{"format":"parquet"}`}
+		hdr, body := mkBody("s3://new", `{"format":"lance"}`)
+		c.ApplyUpdates(hdr, body)
+		assert.Equal(t, "s3://new", c.ExternalSource)
+		assert.Equal(t, `{"format":"lance"}`, c.ExternalSpec)
+	})
 }

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -7505,6 +7505,19 @@ func (node *Proxy) RefreshExternalCollection(ctx context.Context, req *milvuspb.
 		}, nil
 	}
 
+	// External source and spec form an atomic tuple. Either omit both
+	// (reuse the persisted pair) or pass both (atomic override). Passing
+	// only one would silently use the empty value for the other downstream.
+	srcSet := req.GetExternalSource() != ""
+	specSet := req.GetExternalSpec() != ""
+	if srcSet != specSet {
+		return &milvuspb.RefreshExternalCollectionResponse{
+			Status: merr.Status(merr.WrapErrParameterInvalidMsg(
+				"external_source and external_spec must be both provided or both omitted on refresh (got source=%q, spec=%q)",
+				req.GetExternalSource(), req.GetExternalSpec())),
+		}, nil
+	}
+
 	// Get collection info from cache (includes schema for validation)
 	collectionInfo, err := globalMetaCache.GetCollectionInfo(ctx, req.GetDbName(), req.GetCollectionName(), 0)
 	if err != nil {

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -7548,6 +7548,25 @@ func (node *Proxy) RefreshExternalCollection(ctx context.Context, req *milvuspb.
 		}, nil
 	}
 
+	// Reuse path: caller did not provide override. The persisted
+	// (source, spec) on the collection must both be non-empty, otherwise
+	// downstream would look for files at "" and the job would fail with
+	// "no files found" after enqueue. Reject early so the user gets
+	// InvalidArgument instead of a stuck-then-failed job. Both halves are
+	// checked to defensively reassert the atomic-tuple invariant in case
+	// any legacy collection holds a half-initialized pair.
+	if !srcSet {
+		persistedSrc := collectionInfo.schema.GetExternalSource()
+		persistedSpec := collectionInfo.schema.GetExternalSpec()
+		if persistedSrc == "" || persistedSpec == "" {
+			return &milvuspb.RefreshExternalCollectionResponse{
+				Status: merr.Status(merr.WrapErrParameterInvalidMsg(
+					"collection %s has no persisted external_source/external_spec; provide both in the refresh request to initialize",
+					req.GetCollectionName())),
+			}, nil
+		}
+	}
+
 	collectionID := collectionInfo.collID
 
 	// Call DataCoord to refresh the external collection

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -66,6 +66,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/util"
 	"github.com/milvus-io/milvus/pkg/v2/util/commonpbutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/crypto"
+	"github.com/milvus-io/milvus/pkg/v2/util/externalspec"
 	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/logutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
@@ -7516,6 +7517,18 @@ func (node *Proxy) RefreshExternalCollection(ctx context.Context, req *milvuspb.
 				"external_source and external_spec must be both provided or both omitted on refresh (got source=%q, spec=%q)",
 				req.GetExternalSource(), req.GetExternalSpec())),
 		}, nil
+	}
+
+	// Defense in depth: refresh is the only post-create mutation path for
+	// (source, spec); enforce the same scheme allowlist and spec validation
+	// that CreateCollection runs, otherwise alter-bypass via refresh would
+	// allow SSRF (file://, http://169.254.169.254/, userinfo URLs, etc.).
+	if srcSet {
+		if err := externalspec.ValidateSourceAndSpec(req.GetExternalSource(), req.GetExternalSpec()); err != nil {
+			return &milvuspb.RefreshExternalCollectionResponse{
+				Status: merr.Status(err),
+			}, nil
+		}
 	}
 
 	// Get collection info from cache (includes schema for validation)

--- a/internal/proxy/impl_test.go
+++ b/internal/proxy/impl_test.go
@@ -2615,9 +2615,9 @@ func TestProxy_RefreshExternalCollection_AtomicSourceSpec(t *testing.T) {
 	node.UpdateStateCode(commonpb.StateCode_Healthy)
 
 	cases := []struct {
-		name        string
-		src, spec   string
-		wantSubstr  string
+		name       string
+		src, spec  string
+		wantSubstr string
 	}{
 		{"source only rejected", "s3://bucket/p", "", "both provided or both omitted"},
 		{"spec only rejected", "", `{"format":"parquet"}`, "both provided or both omitted"},

--- a/internal/proxy/impl_test.go
+++ b/internal/proxy/impl_test.go
@@ -2642,3 +2642,57 @@ func TestProxy_RefreshExternalCollection_AtomicSourceSpec(t *testing.T) {
 		})
 	}
 }
+
+func TestProxy_RefreshExternalCollection_ReusePathRequiresPersistedSourceSpec(t *testing.T) {
+	factory := dependency.NewDefaultFactory(true)
+	ctx := context.Background()
+	node, err := NewProxy(ctx, factory)
+	require.NoError(t, err)
+	node.UpdateStateCode(commonpb.StateCode_Healthy)
+
+	mkInfo := func(src, spec string) *collectionInfo {
+		schema := &schemapb.CollectionSchema{
+			Name:           "demo",
+			ExternalSource: src,
+			ExternalSpec:   spec,
+			Fields: []*schemapb.FieldSchema{
+				{Name: "id", DataType: schemapb.DataType_Int64, ExternalField: "id"},
+			},
+		}
+		return &collectionInfo{
+			collID: 1,
+			schema: &schemaInfo{CollectionSchema: schema},
+		}
+	}
+
+	cases := []struct {
+		name      string
+		persisted *collectionInfo
+		wantErr   bool
+	}{
+		{"persisted both empty rejected", mkInfo("", ""), true},
+		{"persisted source empty rejected", mkInfo("", `{"format":"parquet"}`), true},
+		{"persisted spec empty rejected", mkInfo("s3://bucket/p", ""), true},
+	}
+	cacheBak := globalMetaCache
+	defer func() { globalMetaCache = cacheBak }()
+	globalMetaCache = &MetaCache{}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := mockey.Mock((*MetaCache).GetCollectionInfo).Return(tc.persisted, nil).Build()
+			defer m.UnPatch()
+
+			resp, err := node.RefreshExternalCollection(ctx, &milvuspb.RefreshExternalCollectionRequest{
+				CollectionName: "demo",
+			})
+			require.NoError(t, err)
+			if tc.wantErr {
+				require.ErrorIs(t, merr.Error(resp.GetStatus()), merr.ErrParameterInvalid)
+				assert.Contains(t, resp.GetStatus().GetReason(), "no persisted external_source")
+			} else {
+				require.NoError(t, merr.Error(resp.GetStatus()))
+			}
+		})
+	}
+}

--- a/internal/proxy/impl_test.go
+++ b/internal/proxy/impl_test.go
@@ -2606,3 +2606,36 @@ func TestProxy_BatchUpdateManifest(t *testing.T) {
 		})
 	})
 }
+
+func TestProxy_RefreshExternalCollection_AtomicSourceSpec(t *testing.T) {
+	factory := dependency.NewDefaultFactory(true)
+	ctx := context.Background()
+	node, err := NewProxy(ctx, factory)
+	require.NoError(t, err)
+	node.UpdateStateCode(commonpb.StateCode_Healthy)
+
+	cases := []struct {
+		name      string
+		src, spec string
+		wantErr   bool
+	}{
+		{"source only rejected", "s3://bucket/p", "", true},
+		{"spec only rejected", "", `{"format":"parquet"}`, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := node.RefreshExternalCollection(ctx, &milvuspb.RefreshExternalCollectionRequest{
+				CollectionName: "any_collection",
+				ExternalSource: tc.src,
+				ExternalSpec:   tc.spec,
+			})
+			require.NoError(t, err)
+			if tc.wantErr {
+				require.ErrorIs(t, merr.Error(resp.GetStatus()), merr.ErrParameterInvalid)
+				assert.Contains(t, resp.GetStatus().GetReason(), "both provided or both omitted")
+			} else {
+				require.NoError(t, merr.Error(resp.GetStatus()))
+			}
+		})
+	}
+}

--- a/internal/proxy/impl_test.go
+++ b/internal/proxy/impl_test.go
@@ -2615,12 +2615,17 @@ func TestProxy_RefreshExternalCollection_AtomicSourceSpec(t *testing.T) {
 	node.UpdateStateCode(commonpb.StateCode_Healthy)
 
 	cases := []struct {
-		name      string
-		src, spec string
-		wantErr   bool
+		name        string
+		src, spec   string
+		wantSubstr  string
 	}{
-		{"source only rejected", "s3://bucket/p", "", true},
-		{"spec only rejected", "", `{"format":"parquet"}`, true},
+		{"source only rejected", "s3://bucket/p", "", "both provided or both omitted"},
+		{"spec only rejected", "", `{"format":"parquet"}`, "both provided or both omitted"},
+		{"http scheme rejected", "http://169.254.169.254/metadata", `{"format":"parquet"}`, "scheme"},
+		{"file scheme rejected", "file:///etc/passwd", `{"format":"parquet"}`, "scheme"},
+		{"ftp scheme rejected", "ftp://internal/data", `{"format":"parquet"}`, "scheme"},
+		{"unknown scheme rejected", "xyz://nope/", `{"format":"parquet"}`, "scheme"},
+		{"userinfo rejected", "s3://ak:sk@bucket/prefix", `{"format":"parquet"}`, ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -2630,11 +2635,9 @@ func TestProxy_RefreshExternalCollection_AtomicSourceSpec(t *testing.T) {
 				ExternalSpec:   tc.spec,
 			})
 			require.NoError(t, err)
-			if tc.wantErr {
-				require.ErrorIs(t, merr.Error(resp.GetStatus()), merr.ErrParameterInvalid)
-				assert.Contains(t, resp.GetStatus().GetReason(), "both provided or both omitted")
-			} else {
-				require.NoError(t, merr.Error(resp.GetStatus()))
+			require.ErrorIs(t, merr.Error(resp.GetStatus()), merr.ErrParameterInvalid)
+			if tc.wantSubstr != "" {
+				assert.Contains(t, resp.GetStatus().GetReason(), tc.wantSubstr)
 			}
 		})
 	}

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -1780,6 +1780,7 @@ func TestCreateCollectionTaskExternalCollection(t *testing.T) {
 		return &schemapb.CollectionSchema{
 			Name:           collectionName,
 			ExternalSource: "s3://bucket/prefix",
+			ExternalSpec:   `{"format":"parquet"}`,
 			Fields: []*schemapb.FieldSchema{
 				{
 					FieldID:       1,

--- a/internal/rootcoord/create_collection_task_test.go
+++ b/internal/rootcoord/create_collection_task_test.go
@@ -914,6 +914,7 @@ func Test_createCollectionTask_validateSchema(t *testing.T) {
 		schema := &schemapb.CollectionSchema{
 			Name:           collectionName,
 			ExternalSource: "s3://bucket/object",
+			ExternalSpec:   `{"format":"parquet"}`,
 			Fields: []*schemapb.FieldSchema{
 				{
 					Name:          "text_field",
@@ -948,6 +949,7 @@ func Test_createCollectionTask_validateSchema(t *testing.T) {
 		schema := &schemapb.CollectionSchema{
 			Name:           collectionName,
 			ExternalSource: "s3://bucket/object",
+			ExternalSpec:   `{"format":"parquet"}`,
 			Fields: []*schemapb.FieldSchema{
 				{
 					Name:          "pk",
@@ -980,6 +982,7 @@ func Test_createCollectionTask_validateSchema(t *testing.T) {
 		schema := &schemapb.CollectionSchema{
 			Name:           collectionName,
 			ExternalSource: "s3://bucket/object",
+			ExternalSpec:   `{"format":"parquet"}`,
 			Fields: []*schemapb.FieldSchema{
 				{
 					Name:          "text_field",
@@ -2003,6 +2006,7 @@ func TestNamespaceProperty(t *testing.T) {
 		schema := &schemapb.CollectionSchema{
 			Name:            collectionName,
 			ExternalSource:  "s3://bucket/path",
+			ExternalSpec:    `{"format":"parquet"}`,
 			EnableNamespace: true,
 			Fields: []*schemapb.FieldSchema{
 				{

--- a/internal/rootcoord/ddl_callbacks_alter_collection_properties.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_properties.go
@@ -49,6 +49,27 @@ func (c *Core) broadcastAlterCollectionForAlterCollection(ctx context.Context, r
 		return merr.WrapErrParameterInvalidMsg("cannot delete key %s, dynamic field schema could support set to true/false", common.EnableDynamicSchemaKey)
 	}
 
+	// External source/spec form an atomic tuple bound to the physical data
+	// layout. Mutating them via alter has historically allowed partial
+	// updates (only one of the pair set), which silently clears the other
+	// because both share a single update mask. The canonical and only
+	// supported way to change them is RefreshExternalCollection, which
+	// applies them atomically and re-runs the data load pipeline.
+	for _, prop := range req.GetProperties() {
+		if prop.GetKey() == common.CollectionExternalSource || prop.GetKey() == common.CollectionExternalSpec {
+			return merr.WrapErrParameterInvalidMsg(
+				"cannot alter %s via alter_collection_properties; use RefreshExternalCollection instead",
+				prop.GetKey())
+		}
+	}
+	for _, key := range req.GetDeleteKeys() {
+		if key == common.CollectionExternalSource || key == common.CollectionExternalSpec {
+			return merr.WrapErrParameterInvalidMsg(
+				"cannot delete %s; external source/spec are immutable post-create except via RefreshExternalCollection",
+				key)
+		}
+	}
+
 	// Validate timezone
 	tz, exist := funcutil.TryGetAttrByKeyFromRepeatedKV(common.TimezoneKey, req.GetProperties())
 	if exist && !timestamptz.IsTimezoneValid(tz) {
@@ -106,22 +127,6 @@ func (c *Core) broadcastAlterCollectionForAlterCollection(ctx context.Context, r
 				udpates.ConsistencyLevel = lv
 				header.UpdateMask.Paths = append(header.UpdateMask.Paths, message.FieldMaskCollectionConsistencyLevel)
 			}
-		case common.CollectionExternalSource:
-			if udpates.Schema == nil {
-				udpates.Schema = &schemapb.CollectionSchema{}
-			}
-			udpates.Schema.ExternalSource = prop.GetValue()
-			if !funcutil.SliceContain(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec) {
-				header.UpdateMask.Paths = append(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec)
-			}
-		case common.CollectionExternalSpec:
-			if udpates.Schema == nil {
-				udpates.Schema = &schemapb.CollectionSchema{}
-			}
-			udpates.Schema.ExternalSpec = prop.GetValue()
-			if !funcutil.SliceContain(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec) {
-				header.UpdateMask.Paths = append(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec)
-			}
 		default:
 			newProperties[prop.GetKey()] = prop.GetValue()
 		}
@@ -174,11 +179,12 @@ func (c *Core) broadcastAlterCollectionForAlterCollection(ctx context.Context, r
 			Properties:         newPropsKeyValuePairs,
 			Version:            coll.SchemaVersion,
 		}
-		// Preserve ExternalSource/ExternalSpec if they were set earlier in this request.
-		if udpates.Schema != nil {
-			schema.ExternalSource = udpates.Schema.ExternalSource
-			schema.ExternalSpec = udpates.Schema.ExternalSpec
-		}
+		// Preserve ExternalSource/ExternalSpec from current collection state.
+		// Alter never mutates them (rejected at request entry above), but the
+		// TTL-driven schema snapshot must still carry them so downstream
+		// consumers see a complete schema.
+		schema.ExternalSource = coll.ExternalSource
+		schema.ExternalSpec = coll.ExternalSpec
 		udpates.Schema = schema
 	}
 

--- a/internal/rootcoord/ddl_callbacks_alter_collection_properties_test.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_properties_test.go
@@ -281,8 +281,10 @@ func TestDDLCallbacksAlterCollectionProperties_TTLFieldPreservesExternalSpec(t *
 		Fields: []*schemapb.FieldSchema{
 			{Name: "id", DataType: schemapb.DataType_Int64, ExternalField: "id"},
 			{Name: "ttl", DataType: schemapb.DataType_Timestamptz, ExternalField: "ttl"},
-			{Name: "vec", DataType: schemapb.DataType_FloatVector, ExternalField: "vec",
-				TypeParams: []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "4"}}},
+			{
+				Name: "vec", DataType: schemapb.DataType_FloatVector, ExternalField: "vec",
+				TypeParams: []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "4"}},
+			},
 		},
 	}
 	schemaBytes, err := proto.Marshal(testSchema)

--- a/internal/rootcoord/ddl_callbacks_alter_collection_properties_test.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_properties_test.go
@@ -264,19 +264,25 @@ func TestDDLCallbacksAlterCollectionProperties_TTLFieldPreservesExternalSpec(t *
 	dbName := "testDB" + funcutil.RandomString(10)
 	collectionName := "testCollectionTTLExtSpec" + funcutil.RandomString(10)
 
-	// Create collection with a ttl field.
 	resp, err := core.CreateDatabase(ctx, &milvuspb.CreateDatabaseRequest{
 		DbName: dbName,
 	})
 	require.NoError(t, merr.CheckRPCCall(resp, err))
 
+	// Create as external collection with both source and spec atomically set.
+	// Alter is no longer permitted to mutate source/spec; the TTL alter must
+	// nevertheless preserve them when it triggers a schema snapshot rebuild.
 	testSchema := &schemapb.CollectionSchema{
-		Name:        collectionName,
-		Description: "description",
-		AutoID:      false,
+		Name:           collectionName,
+		Description:    "description",
+		AutoID:         false,
+		ExternalSource: "s3://bucket/ttl-path",
+		ExternalSpec:   `{"format":"parquet"}`,
 		Fields: []*schemapb.FieldSchema{
-			{Name: "field1", DataType: schemapb.DataType_Int64},
-			{Name: "ttl", DataType: schemapb.DataType_Timestamptz, Nullable: true},
+			{Name: "id", DataType: schemapb.DataType_Int64, ExternalField: "id"},
+			{Name: "ttl", DataType: schemapb.DataType_Timestamptz, ExternalField: "ttl"},
+			{Name: "vec", DataType: schemapb.DataType_FloatVector, ExternalField: "vec",
+				TypeParams: []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "4"}}},
 		},
 	}
 	schemaBytes, err := proto.Marshal(testSchema)
@@ -287,42 +293,29 @@ func TestDDLCallbacksAlterCollectionProperties_TTLFieldPreservesExternalSpec(t *
 		Properties:       []*commonpb.KeyValuePair{{Key: common.CollectionReplicaNumber, Value: "1"}},
 		Schema:           schemaBytes,
 		ConsistencyLevel: commonpb.ConsistencyLevel_Bounded,
+		ShardsNum:        1,
 	})
 	require.NoError(t, merr.CheckRPCCall(resp, err))
+	assertExternalSource(t, ctx, core, dbName, collectionName, "s3://bucket/ttl-path")
+	assertExternalSpec(t, ctx, core, dbName, collectionName, `{"format":"parquet"}`)
 
-	// Set ExternalSource + ExternalSpec + TTL field in a single AlterCollection request.
-	// This exercises the code path where TTL schema refresh must preserve ExternalSource/ExternalSpec.
+	// Alter TTL field only — must preserve previously persisted external source/spec.
 	resp, err = core.AlterCollection(ctx, &milvuspb.AlterCollectionRequest{
 		DbName:         dbName,
 		CollectionName: collectionName,
 		Properties: []*commonpb.KeyValuePair{
-			{Key: common.CollectionExternalSource, Value: "s3://bucket/ttl-path"},
-			{Key: common.CollectionExternalSpec, Value: `{"format":"iceberg"}`},
 			{Key: common.CollectionTTLFieldKey, Value: "ttl"},
 		},
 	})
 	require.NoError(t, merr.CheckRPCCall(resp, err))
 	assertExternalSource(t, ctx, core, dbName, collectionName, "s3://bucket/ttl-path")
-	assertExternalSpec(t, ctx, core, dbName, collectionName, `{"format":"iceberg"}`)
-	assertSchemaVersion(t, ctx, core, dbName, collectionName, 0)
+	assertExternalSpec(t, ctx, core, dbName, collectionName, `{"format":"parquet"}`)
 
-	// Set TTL field only (no ExternalSource/ExternalSpec) — should NOT carry over stale external values.
+	// TTL with invalid field name still rejected.
 	resp, err = core.AlterCollection(ctx, &milvuspb.AlterCollectionRequest{
 		DbName:         dbName,
 		CollectionName: collectionName,
 		Properties: []*commonpb.KeyValuePair{
-			{Key: common.CollectionTTLFieldKey, Value: "ttl"},
-		},
-	})
-	// Idempotent — same TTL value, no schema change expected.
-	require.NoError(t, merr.CheckRPCCall(resp, err))
-
-	// Set TTL field with invalid field name should fail.
-	resp, err = core.AlterCollection(ctx, &milvuspb.AlterCollectionRequest{
-		DbName:         dbName,
-		CollectionName: collectionName,
-		Properties: []*commonpb.KeyValuePair{
-			{Key: common.CollectionExternalSource, Value: "s3://bucket/new"},
 			{Key: common.CollectionTTLFieldKey, Value: "nonexistent_field"},
 		},
 	})
@@ -341,73 +334,67 @@ func assertExternalSpec(t *testing.T, ctx context.Context, core *Core, dbName st
 	require.Equal(t, expectedSpec, coll.ExternalSpec)
 }
 
-func TestDDLCallbacksAlterCollectionProperties_ExternalSpec(t *testing.T) {
+func TestDDLCallbacksAlterCollectionProperties_RejectExternalSourceSpec(t *testing.T) {
 	core := initStreamingSystemAndCore(t)
 	ctx := context.Background()
 
 	dbName := "testDB" + funcutil.RandomString(10)
-	collectionName := "testCollectionExtSpec" + funcutil.RandomString(10)
-
+	collectionName := "testRejectExt" + funcutil.RandomString(10)
 	createCollectionForTest(t, ctx, core, dbName, collectionName)
 
-	// Initially external source/spec should be empty.
-	assertExternalSource(t, ctx, core, dbName, collectionName, "")
-	assertExternalSpec(t, ctx, core, dbName, collectionName, "")
-
-	// Alter collection to set external_source and external_spec.
-	resp, err := core.AlterCollection(ctx, &milvuspb.AlterCollectionRequest{
-		DbName:         dbName,
-		CollectionName: collectionName,
-		Properties: []*commonpb.KeyValuePair{
-			{Key: common.CollectionExternalSource, Value: "s3://bucket/path"},
-			{Key: common.CollectionExternalSpec, Value: `{"format":"parquet"}`},
+	cases := []struct {
+		name string
+		req  *milvuspb.AlterCollectionRequest
+	}{
+		{
+			name: "set external_source via alter",
+			req: &milvuspb.AlterCollectionRequest{
+				DbName: dbName, CollectionName: collectionName,
+				Properties: []*commonpb.KeyValuePair{
+					{Key: common.CollectionExternalSource, Value: "s3://bucket/path"},
+				},
+			},
 		},
-	})
-	require.NoError(t, merr.CheckRPCCall(resp, err))
-	assertExternalSource(t, ctx, core, dbName, collectionName, "s3://bucket/path")
-	assertExternalSpec(t, ctx, core, dbName, collectionName, `{"format":"parquet"}`)
-	assertSchemaVersion(t, ctx, core, dbName, collectionName, 0)
-
-	// Update external_source only.
-	resp, err = core.AlterCollection(ctx, &milvuspb.AlterCollectionRequest{
-		DbName:         dbName,
-		CollectionName: collectionName,
-		Properties: []*commonpb.KeyValuePair{
-			{Key: common.CollectionExternalSource, Value: "s3://bucket/new-path"},
+		{
+			name: "set external_spec via alter",
+			req: &milvuspb.AlterCollectionRequest{
+				DbName: dbName, CollectionName: collectionName,
+				Properties: []*commonpb.KeyValuePair{
+					{Key: common.CollectionExternalSpec, Value: `{"format":"parquet"}`},
+				},
+			},
 		},
-	})
-	require.NoError(t, merr.CheckRPCCall(resp, err))
-	assertExternalSource(t, ctx, core, dbName, collectionName, "s3://bucket/new-path")
-	// external_spec should be reset to empty since only source was sent in this request.
-	assertSchemaVersion(t, ctx, core, dbName, collectionName, 0)
-
-	// Update external_spec only.
-	resp, err = core.AlterCollection(ctx, &milvuspb.AlterCollectionRequest{
-		DbName:         dbName,
-		CollectionName: collectionName,
-		Properties: []*commonpb.KeyValuePair{
-			{Key: common.CollectionExternalSpec, Value: `{"format":"lance","version":3}`},
+		{
+			name: "set both via alter",
+			req: &milvuspb.AlterCollectionRequest{
+				DbName: dbName, CollectionName: collectionName,
+				Properties: []*commonpb.KeyValuePair{
+					{Key: common.CollectionExternalSource, Value: "s3://bucket/path"},
+					{Key: common.CollectionExternalSpec, Value: `{"format":"parquet"}`},
+				},
+			},
 		},
-	})
-	require.NoError(t, merr.CheckRPCCall(resp, err))
-	assertExternalSpec(t, ctx, core, dbName, collectionName, `{"format":"lance","version":3}`)
-	assertSchemaVersion(t, ctx, core, dbName, collectionName, 0)
-
-	// Mix external_source with normal properties.
-	resp, err = core.AlterCollection(ctx, &milvuspb.AlterCollectionRequest{
-		DbName:         dbName,
-		CollectionName: collectionName,
-		Properties: []*commonpb.KeyValuePair{
-			{Key: common.CollectionExternalSource, Value: "s3://bucket/mixed"},
-			{Key: common.CollectionExternalSpec, Value: `{"format":"parquet"}`},
-			{Key: common.CollectionDescription, Value: "updated description"},
+		{
+			name: "delete external_source",
+			req: &milvuspb.AlterCollectionRequest{
+				DbName: dbName, CollectionName: collectionName,
+				DeleteKeys: []string{common.CollectionExternalSource},
+			},
 		},
-	})
-	require.NoError(t, merr.CheckRPCCall(resp, err))
-	assertExternalSource(t, ctx, core, dbName, collectionName, "s3://bucket/mixed")
-	assertExternalSpec(t, ctx, core, dbName, collectionName, `{"format":"parquet"}`)
-	assertDescription(t, ctx, core, dbName, collectionName, "updated description")
-	assertSchemaVersion(t, ctx, core, dbName, collectionName, 0)
+		{
+			name: "delete external_spec",
+			req: &milvuspb.AlterCollectionRequest{
+				DbName: dbName, CollectionName: collectionName,
+				DeleteKeys: []string{common.CollectionExternalSpec},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := core.AlterCollection(ctx, tc.req)
+			require.ErrorIs(t, merr.CheckRPCCall(resp, err), merr.ErrParameterInvalid)
+		})
+	}
 }
 
 func createCollectionForTest(t *testing.T, ctx context.Context, core *Core, dbName string, collectionName string) {

--- a/pkg/util/typeutil/schema.go
+++ b/pkg/util/typeutil/schema.go
@@ -2213,6 +2213,7 @@ func NormalizeAndValidateExternalCollectionSchema(schema *schemapb.CollectionSch
 
 	// Pass 1: validate all user fields. No mutation here so a failure at any
 	// field leaves the input schema untouched.
+	externalFieldOwners := make(map[string][]*schemapb.FieldSchema)
 	for _, field := range schema.GetFields() {
 		if isExternalSystemOrVirtualField(field.GetName()) {
 			continue
@@ -2244,6 +2245,24 @@ func NormalizeAndValidateExternalCollectionSchema(schema *schemapb.CollectionSch
 			return fmt.Errorf("external collection %s does not support field type %s on field %s",
 				schema.GetName(), field.GetDataType().String(), field.GetName())
 		}
+
+		ext := field.GetExternalField()
+		externalFieldOwners[ext] = append(externalFieldOwners[ext], field)
+	}
+
+	// Each external_field column must back at most one user field. A single
+	// physical column cannot satisfy two distinct type bindings, and even
+	// same-type aliasing has no semantic value here.
+	for ext, owners := range externalFieldOwners {
+		if len(owners) <= 1 {
+			continue
+		}
+		parts := make([]string, 0, len(owners))
+		for _, f := range owners {
+			parts = append(parts, fmt.Sprintf("%s (%s)", f.GetName(), f.GetDataType().String()))
+		}
+		return fmt.Errorf("external_field %q is mapped by multiple fields: %s; each external_field must be referenced by at most one user field",
+			ext, strings.Join(parts, ", "))
 	}
 
 	// Pass 2: normalize. All fields passed validation; safe to mutate.

--- a/pkg/util/typeutil/schema.go
+++ b/pkg/util/typeutil/schema.go
@@ -2199,6 +2199,17 @@ func NormalizeAndValidateExternalCollectionSchema(schema *schemapb.CollectionSch
 		return nil
 	}
 
+	// External source and spec form an atomic tuple. They must be both
+	// empty (deferred to a later refresh) or both non-empty (ready to
+	// load). One-without-the-other leaves the collection in a half-
+	// initialized state that no refresh path can recover from cleanly.
+	srcSet := schema.GetExternalSource() != ""
+	specSet := schema.GetExternalSpec() != ""
+	if srcSet != specSet {
+		return fmt.Errorf("external collection %s requires external_source and external_spec to be both set or both empty (got source=%q, spec=%q)",
+			schema.GetName(), schema.GetExternalSource(), schema.GetExternalSpec())
+	}
+
 	if len(schema.GetFunctions()) > 0 {
 		return fmt.Errorf("external collection %s does not support functions", schema.GetName())
 	}

--- a/pkg/util/typeutil/schema_test.go
+++ b/pkg/util/typeutil/schema_test.go
@@ -5243,6 +5243,34 @@ func TestNormalizeAndValidateExternalCollectionSchema(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("duplicate external_field rejected different types", func(t *testing.T) {
+		schema := buildSchema()
+		schema.Fields = append(schema.Fields, &schemapb.FieldSchema{
+			Name:          "dup_int",
+			DataType:      schemapb.DataType_Int64,
+			ExternalField: "text_col",
+		})
+		err := NormalizeAndValidateExternalCollectionSchema(schema)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "text_col")
+		assert.Contains(t, err.Error(), "mapped by multiple fields")
+	})
+
+	t.Run("duplicate external_field rejected same type", func(t *testing.T) {
+		schema := buildSchema()
+		schema.Fields = append(schema.Fields, &schemapb.FieldSchema{
+			Name:          "text_alias",
+			DataType:      schemapb.DataType_VarChar,
+			ExternalField: "text_col",
+			TypeParams: []*commonpb.KeyValuePair{
+				{Key: common.MaxLengthKey, Value: "32"},
+			},
+		})
+		err := NormalizeAndValidateExternalCollectionSchema(schema)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "mapped by multiple fields")
+	})
+
 	t.Run("unsupported field types rejected", func(t *testing.T) {
 		unsupportedTypes := []schemapb.DataType{
 			schemapb.DataType_SparseFloatVector,

--- a/pkg/util/typeutil/schema_test.go
+++ b/pkg/util/typeutil/schema_test.go
@@ -5137,6 +5137,7 @@ func TestNormalizeAndValidateExternalCollectionSchema(t *testing.T) {
 		return &schemapb.CollectionSchema{
 			Name:           "external",
 			ExternalSource: "s3://bucket/path",
+			ExternalSpec:   `{"format":"parquet"}`,
 			Fields: []*schemapb.FieldSchema{
 				{
 					Name:          "text",
@@ -5243,6 +5244,40 @@ func TestNormalizeAndValidateExternalCollectionSchema(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("source set without spec rejected", func(t *testing.T) {
+		schema := buildSchema()
+		schema.ExternalSource = "s3://bucket/path"
+		schema.ExternalSpec = ""
+		err := NormalizeAndValidateExternalCollectionSchema(schema)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "both set or both empty")
+	})
+
+	t.Run("spec set without source rejected", func(t *testing.T) {
+		schema := buildSchema()
+		schema.ExternalSource = ""
+		schema.ExternalSpec = `{"format":"parquet"}`
+		err := NormalizeAndValidateExternalCollectionSchema(schema)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "both set or both empty")
+	})
+
+	t.Run("both empty allowed deferred refresh", func(t *testing.T) {
+		schema := buildSchema()
+		schema.ExternalSource = ""
+		schema.ExternalSpec = ""
+		err := NormalizeAndValidateExternalCollectionSchema(schema)
+		assert.NoError(t, err)
+	})
+
+	t.Run("both set allowed", func(t *testing.T) {
+		schema := buildSchema()
+		schema.ExternalSource = "s3://bucket/path"
+		schema.ExternalSpec = `{"format":"parquet"}`
+		err := NormalizeAndValidateExternalCollectionSchema(schema)
+		assert.NoError(t, err)
+	})
+
 	t.Run("duplicate external_field rejected different types", func(t *testing.T) {
 		schema := buildSchema()
 		schema.Fields = append(schema.Fields, &schemapb.FieldSchema{
@@ -5317,6 +5352,7 @@ func TestNormalizeAndValidateExternalCollectionSchema(t *testing.T) {
 			schema := &schemapb.CollectionSchema{
 				Name:           "external",
 				ExternalSource: "s3://bucket/path",
+				ExternalSpec:   `{"format":"parquet"}`,
 				Fields: []*schemapb.FieldSchema{
 					{
 						Name:          "vec",

--- a/tests/go_client/testcases/external_table_refresh_test.go
+++ b/tests/go_client/testcases/external_table_refresh_test.go
@@ -167,6 +167,7 @@ func generateMultiTypeParquetBytes(numRows int64, startID int64) ([]byte, error)
 			{Name: "varchar_val", Type: arrow.BinaryTypes.String},
 			{Name: "json_val", Type: arrow.BinaryTypes.String},
 			{Name: "array_int", Type: arrow.ListOf(arrow.PrimitiveTypes.Int32)},
+			{Name: "array_str", Type: arrow.ListOf(arrow.BinaryTypes.String)},
 			{Name: "ts_val", Type: tsType},
 			{Name: "geo_val", Type: arrow.BinaryTypes.String},
 			{Name: "embedding", Type: arrow.FixedSizeListOf(testVecDim, arrow.PrimitiveTypes.Float32)},
@@ -199,14 +200,16 @@ func generateMultiTypeParquetBytes(numRows int64, startID int64) ([]byte, error)
 	jsonBuilder := builder.Field(8).(*array.StringBuilder)
 	arrayIntBuilder := builder.Field(9).(*array.ListBuilder)
 	arrayIntValueBuilder := arrayIntBuilder.ValueBuilder().(*array.Int32Builder)
-	tsBuilder := builder.Field(10).(*array.TimestampBuilder)
-	geoBuilder := builder.Field(11).(*array.StringBuilder)
-	embeddingBuilder := builder.Field(12).(*array.FixedSizeListBuilder)
+	arrayStrBuilder := builder.Field(10).(*array.ListBuilder)
+	arrayStrValueBuilder := arrayStrBuilder.ValueBuilder().(*array.StringBuilder)
+	tsBuilder := builder.Field(11).(*array.TimestampBuilder)
+	geoBuilder := builder.Field(12).(*array.StringBuilder)
+	embeddingBuilder := builder.Field(13).(*array.FixedSizeListBuilder)
 	vecValueBuilder := embeddingBuilder.ValueBuilder().(*array.Float32Builder)
-	binVecBuilder := builder.Field(13).(*array.FixedSizeBinaryBuilder)
-	fp16VecBuilder := builder.Field(14).(*array.FixedSizeBinaryBuilder)
-	bf16VecBuilder := builder.Field(15).(*array.FixedSizeBinaryBuilder)
-	int8VecBuilder := builder.Field(16).(*array.FixedSizeBinaryBuilder)
+	binVecBuilder := builder.Field(14).(*array.FixedSizeBinaryBuilder)
+	fp16VecBuilder := builder.Field(15).(*array.FixedSizeBinaryBuilder)
+	bf16VecBuilder := builder.Field(16).(*array.FixedSizeBinaryBuilder)
+	int8VecBuilder := builder.Field(17).(*array.FixedSizeBinaryBuilder)
 
 	for i := int64(0); i < numRows; i++ {
 		idx := startID + i
@@ -227,6 +230,12 @@ func generateMultiTypeParquetBytes(numRows int64, startID int64) ([]byte, error)
 		arrayIntValueBuilder.Append(int32(idx * 1))
 		arrayIntValueBuilder.Append(int32(idx * 2))
 		arrayIntValueBuilder.Append(int32(idx * 3))
+
+		// Array[VarChar]: ["tag_<idx>_a", "tag_<idx>_b"] — exact shape from
+		// issue #48619 reproduction (List<String> from Parquet).
+		arrayStrBuilder.Append(true)
+		arrayStrValueBuilder.Append(fmt.Sprintf("tag_%d_a", idx))
+		arrayStrValueBuilder.Append(fmt.Sprintf("tag_%d_b", idx))
 
 		// Timestamptz: base time + idx hours (microseconds since epoch)
 		// 2025-01-01T00:00:00Z = 1735689600 seconds = 1735689600000000 microseconds
@@ -1179,6 +1188,7 @@ func TestExternalCollectionMultipleDataTypes(t *testing.T) {
 		WithField(entity.NewField().WithName("varchar_val").WithDataType(entity.FieldTypeVarChar).WithMaxLength(64).WithExternalField("varchar_val")).
 		WithField(entity.NewField().WithName("json_val").WithDataType(entity.FieldTypeJSON).WithExternalField("json_val")).
 		WithField(entity.NewField().WithName("array_int").WithDataType(entity.FieldTypeArray).WithElementType(entity.FieldTypeInt32).WithMaxCapacity(16).WithExternalField("array_int")).
+		WithField(entity.NewField().WithName("array_str").WithDataType(entity.FieldTypeArray).WithElementType(entity.FieldTypeVarChar).WithMaxLength(64).WithMaxCapacity(16).WithExternalField("array_str")).
 		WithField(entity.NewField().WithName("ts_val").WithDataType(entity.FieldTypeTimestamptz).WithExternalField("ts_val")).
 		WithField(entity.NewField().WithName("geo_val").WithDataType(entity.FieldTypeGeometry).WithExternalField("geo_val")).
 		WithField(entity.NewField().WithName("embedding").WithDataType(entity.FieldTypeFloatVector).WithDim(testVecDim).WithExternalField("embedding")).
@@ -1427,6 +1437,45 @@ func TestExternalCollectionMultipleDataTypes(t *testing.T) {
 	arrayMatchID, _ := arrayRes.GetColumn("id").GetAsInt64(0)
 	require.Equal(t, int64(99), arrayMatchID)
 	t.Logf("Array filter: matched id=%d", arrayMatchID)
+
+	// ---------------------------------------------------------------
+	// Step 12f: Array as OUTPUT field — regression for issue #48619
+	// Querying with array_int / array_str in output_fields used to crash
+	// segcore (SIGSEGV in ArrayChunkWriter::calculate_size) because the
+	// external chunk loader passed an arrow::ListArray where Milvus
+	// expected a BinaryArray of serialized ScalarFieldProto bytes.
+	// ---------------------------------------------------------------
+	arrayIntOut, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithConsistencyLevel(entity.ClStrong).
+		WithFilter("id == 42").
+		WithOutputFields("id", "array_int"))
+	common.CheckErr(t, err, true)
+	require.Equal(t, 1, arrayIntOut.GetColumn("id").Len(), "should find id==42")
+	t.Logf("Array(Int32) as output field returned %d row(s) without crash",
+		arrayIntOut.GetColumn("id").Len())
+
+	arrayStrOut, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithConsistencyLevel(entity.ClStrong).
+		WithFilter("id == 42").
+		WithOutputFields("id", "array_str"))
+	common.CheckErr(t, err, true)
+	require.Equal(t, 1, arrayStrOut.GetColumn("id").Len(), "should find id==42")
+	t.Logf("Array(VarChar) as output field returned %d row(s) without crash",
+		arrayStrOut.GetColumn("id").Len())
+
+	// ---------------------------------------------------------------
+	// Step 12g: Geometry as OUTPUT field across many rows — exercise
+	// chunked-load path (single-row check at step 12c only loads one
+	// chunk; querying many rows pulls more cells through the translator).
+	// ---------------------------------------------------------------
+	geoBulkRes, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithConsistencyLevel(entity.ClStrong).
+		WithFilter("id < 50").
+		WithOutputFields("id", "geo_val"))
+	common.CheckErr(t, err, true)
+	require.Equal(t, 50, geoBulkRes.GetColumn("id").Len(), "id<50 should be 50 rows")
+	t.Logf("Geometry as output field across %d rows without crash",
+		geoBulkRes.GetColumn("id").Len())
 
 	// ---------------------------------------------------------------
 	// Step 13: Compound filter across types — bool AND int range AND varchar

--- a/tests/go_client/testcases/external_table_refresh_test.go
+++ b/tests/go_client/testcases/external_table_refresh_test.go
@@ -2757,3 +2757,109 @@ func TestExternalCollectionLoadPerfProfile(t *testing.T) {
 	t.Logf("Raw vector data: %.1f MB", float64(totalRows)*float64(vecDim)*4/1048576.0)
 	t.Logf("Estimated total row size: %d bytes (vec=%d + scalars~30)", vecDim*4+30, vecDim*4)
 }
+
+// TestRefreshExternalCollectionZeroRowParquet covers issue #49225:
+//
+// A zero-row parquet file in the external bucket previously crashed
+// datanode with "integer divide by zero" inside balanceFragmentsToSegments,
+// putting the standalone Milvus pod into CrashLoopBackOff. The fix
+// short-circuits at DataCoord.createTasksForJob, marking the refresh job
+// Failed with a non-retriable reason instead.
+//
+// Pass criteria:
+//  1. refresh_external_collection accepts the request and returns a job_id.
+//  2. The job transitions to a terminal state (Failed expected) within the
+//     poll deadline — i.e. it does NOT hang in Pending forever AND the
+//     datanode does NOT crash mid-poll.
+//  3. The Failed reason mentions zero rows so operators have actionable
+//     signal.
+func TestRefreshExternalCollectionZeroRowParquet(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	minioCfg := getMinIOConfig()
+	minioClient, err := newMinIOClient(minioCfg)
+	require.NoError(t, err)
+
+	exists, err := minioClient.BucketExists(ctx, minioCfg.bucket)
+	if err != nil || !exists {
+		t.Skipf("MinIO bucket %q not accessible (exists=%v, err=%v), skipping",
+			minioCfg.bucket, exists, err)
+	}
+
+	collName := common.GenRandomString("ext_zero_row", 6)
+	extPath := fmt.Sprintf("external-e2e-test/%s", collName)
+
+	// Upload a single well-formed parquet file with zero rows.
+	data, err := generateParquetBytes(0, 0)
+	require.NoError(t, err, "generate zero-row parquet")
+	require.NotEmpty(t, data, "zero-row parquet must still be a valid file with header/footer")
+
+	objectKey := fmt.Sprintf("%s/empty.parquet", extPath)
+	_, err = minioClient.PutObject(ctx, minioCfg.bucket, objectKey,
+		bytes.NewReader(data), int64(len(data)),
+		miniogo.PutObjectOptions{ContentType: "application/octet-stream"})
+	require.NoError(t, err, "upload zero-row parquet to MinIO")
+	t.Logf("Uploaded zero-row parquet %s/%s (%d bytes)",
+		minioCfg.bucket, objectKey, len(data))
+
+	t.Cleanup(func() {
+		cleanupMinIOPrefix(context.Background(), minioClient, minioCfg.bucket,
+			fmt.Sprintf("%s/", extPath))
+	})
+
+	schema := entity.NewSchema().
+		WithName(collName).
+		WithExternalSource(extPath).
+		WithExternalSpec(`{"format":"parquet"}`).
+		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithExternalField("id")).
+		WithField(entity.NewField().WithName("value").WithDataType(entity.FieldTypeFloat).WithExternalField("value")).
+		WithField(entity.NewField().WithName("embedding").WithDataType(entity.FieldTypeFloatVector).
+			WithDim(testVecDim).WithExternalField("embedding"))
+
+	err = mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, true)
+	t.Cleanup(func() {
+		_ = mc.DropCollection(context.Background(), client.NewDropCollectionOption(collName))
+	})
+
+	refreshResult, err := mc.RefreshExternalCollection(ctx,
+		client.NewRefreshExternalCollectionOption(collName))
+	common.CheckErr(t, err, true)
+	require.Greater(t, refreshResult.JobID, int64(0))
+	jobID := refreshResult.JobID
+	t.Logf("Started refresh job: %d", jobID)
+
+	// Must reach a terminal state within 60s. Before the fix this loop hit
+	// the deadline because the datanode CrashLoopBackOff prevented any task
+	// from running to completion.
+	deadline := time.After(60 * time.Second)
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	var finalState entity.RefreshExternalCollectionState
+	var finalReason string
+	for done := false; !done; {
+		select {
+		case <-deadline:
+			t.Fatalf("Refresh job %d did not reach terminal state within 60s "+
+				"(zero-row parquet likely panicked datanode)", jobID)
+		case <-ticker.C:
+			progress, err := mc.GetRefreshExternalCollectionProgress(ctx,
+				client.NewGetRefreshExternalCollectionProgressOption(jobID))
+			require.NoError(t, err)
+			t.Logf("Job %d: state=%s reason=%q", jobID, progress.State, progress.Reason)
+			if progress.State == entity.RefreshStateCompleted ||
+				progress.State == entity.RefreshStateFailed {
+				finalState = progress.State
+				finalReason = progress.Reason
+				done = true
+			}
+		}
+	}
+
+	require.Equal(t, entity.RefreshStateFailed, finalState,
+		"zero-row external source must surface as RefreshFailed, not silent Completed")
+	require.Contains(t, strings.ToLower(finalReason), "zero",
+		"failure reason should mention zero rows so operators can act; got %q", finalReason)
+}


### PR DESCRIPTION
Cherry-pick of [#49302](https://github.com/milvus-io/milvus/pull/49302) to 3.0.

## Summary

Harden external collection RPCs and refresh pipeline against invalid argument
corner cases. Each fix is one commit; every issue is independently testable.

| Commit | Issue | Fix |
|---|---|---|
| 1 | [#49225](https://github.com/milvus-io/milvus/issues/49225) | reject zero-row external sources at task creation; classify as non-retriable so the job goes RefreshFailed instead of crashing datanode with integer divide by zero |
| 2 | [#48619](https://github.com/milvus-io/milvus/issues/48619) | set element_type on ARRAY bulk_subscript responses for external segments so clients can decode Array(Int32) / Array(VarChar) outputs |
| 3 | [#49235](https://github.com/milvus-io/milvus/issues/49235) | reject duplicate external_field mapping at create-time schema validation |
| 4 | [#49229](https://github.com/milvus-io/milvus/issues/49229) | treat (external_source, external_spec) as an immutable atomic tuple: alter rejects both keys, create requires both-or-neither, refresh requires both-or-neither, apply path only overwrites non-empty fields |
| 5 | [#49224](https://github.com/milvus-io/milvus/issues/49224) | enforce external_source scheme allowlist on RefreshExternalCollection (closes the alter-bypass SSRF surface for refresh) |
| 6 | [#49230](https://github.com/milvus-io/milvus/issues/49230) | reject RefreshExternalCollection when the collection has no persisted external_source/external_spec; previously the job entered permanent retry |
| 7 | [#49233](https://github.com/milvus-io/milvus/issues/49233) | classify FFI explore failures as non-retriable refresh job errors so NoSuchBucket / AccessDenied / DNS NXDOMAIN / malformed URI surface as RefreshFailed instead of looping forever |
| 8 | [#49231](https://github.com/milvus-io/milvus/issues/49231) | surface in-progress refresh jobID at the synchronous RPC edge with ErrTaskDuplicate, so concurrent refresh callers get the existing jobID instead of a fresh one that the WAL ack callback silently drops |

## Test plan

- [x] go unit tests verified locally on 3.0 base:
  - internal/datacoord/external_collection_refresh_manager_test.go
  - internal/datacoord/services_test.go
  - internal/proxy/impl_test.go
  - internal/metastore/model/collection_test.go
  - pkg/util/typeutil/schema_test.go
  - internal/rootcoord/ddl_callbacks_alter_collection_properties_test.go
- [x] go_client e2e covered on master via #49302

issue: #49225 #48619 #49235 #49229 #49224 #49230 #49233 #49231
pr: #49302