### PR TITLE
enhance: [3.0][ExternalTable Part10] enable function output fields on external collections

### DIFF
--- a/internal/core/src/common/Schema.cpp
+++ b/internal/core/src/common/Schema.cpp
@@ -129,6 +129,13 @@ Schema::ParseFrom(const milvus::proto::schema::CollectionSchema& schema_proto) {
         schema->set_external_spec(schema_proto.external_spec());
     }
 
+    // Collect function output field ids from FunctionSchema list.
+    for (const auto& fn : schema_proto.functions()) {
+        for (auto out_id : fn.output_field_ids()) {
+            schema->add_function_output_field_id(FieldId(out_id));
+        }
+    }
+
     return schema;
 }
 
@@ -237,8 +244,14 @@ Schema::GetExternalColumnNames() const {
     auto columns = std::make_shared<std::vector<std::string>>();
     for (const auto& field_id : field_ids_) {
         auto it = fields_.find(field_id);
-        if (it != fields_.end() && it->second.is_external_field()) {
+        if (it == fields_.end())
+            continue;
+        if (it->second.is_external_field()) {
             columns->push_back(it->second.get_external_field());
+        } else if (is_function_output(field_id)) {
+            // Function output fields are computed and stored in the manifest
+            // alongside external columns. Use field name as column name.
+            columns->push_back(it->second.get_name().get());
         }
     }
     return columns;
@@ -250,6 +263,11 @@ Schema::ResolveColumnFieldId(const std::string& column_name) const {
         for (const auto& [fid, meta] : fields_) {
             if (meta.is_external_field() &&
                 meta.get_external_field() == column_name) {
+                return fid;
+            }
+            // Function output fields use field name as column name in manifest
+            if (is_function_output(fid) &&
+                meta.get_name().get() == column_name) {
                 return fid;
             }
         }

--- a/internal/core/src/common/Schema.h
+++ b/internal/core/src/common/Schema.h
@@ -539,6 +539,41 @@ class Schema {
     std::pair<bool, std::string>
     WarmupPolicy(const FieldId& field, bool is_vector, bool is_index) const;
 
+    // True if the field is declared as a function output (derived from the
+    // FunctionSchema list on the collection proto).
+    bool
+    is_function_output(const FieldId& field_id) const {
+        return function_output_field_ids_.count(field_id) > 0;
+    }
+
+    const std::unordered_set<FieldId>&
+    function_output_field_ids() const {
+        return function_output_field_ids_;
+    }
+
+    void
+    add_function_output_field_id(const FieldId& field_id) {
+        function_output_field_ids_.insert(field_id);
+    }
+
+    // Storage column name used by packed manifests for a given field:
+    // external_field mapping for external input columns, the field name for
+    // function-output columns, the numeric field id otherwise.
+    std::string
+    get_storage_column_name(const FieldId& field_id) const {
+        const auto& meta = operator[](field_id);
+        if (meta.is_external_field()) {
+            return meta.get_external_field();
+        }
+        // External collections store function-output columns by field name
+        // (written by function_executor). Internal collections store them by
+        // numeric field_id like any other field.
+        if (is_external_collection() && is_function_output(field_id)) {
+            return meta.get_name().get();
+        }
+        return std::to_string(field_id.get());
+    }
+
  private:
     int64_t debug_id = START_USER_FIELDID;
     std::vector<FieldId> field_ids_;
@@ -585,6 +620,10 @@ class Schema {
         external_source_;  // External data source identifier (e.g., S3 path, table name)
     std::string
         external_spec_;  // External data source specification (JSON format)
+
+    // Field ids declared as function outputs in the collection's FunctionSchema
+    // list. Populated during ParseFrom after all fields are added.
+    std::unordered_set<FieldId> function_output_field_ids_;
 };
 
 using SchemaPtr = std::shared_ptr<Schema>;

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -278,6 +278,11 @@ ChunkedSegmentSealedImpl::PinPkIndex(milvus::OpContext* op_ctx) const {
 
 bool
 ChunkedSegmentSealedImpl::Contain(const PkType& pk) const {
+    // Zero-storage pk2offset (VirtualPKOffsetMap) resolves PKs by bit-extract.
+    // Skips PinPkIndex + sorted-pk binary search on the virtual PK column.
+    if (insert_record_.pk2offset_is_zero_storage()) {
+        return insert_record_.contain(pk);
+    }
     auto pk_index = PinPkIndex(nullptr);
     if (pk_index.get() != nullptr && pk_index.get()->has_pk2offset()) {
         return pk_index.get()->contain(pk);
@@ -1769,6 +1774,16 @@ ChunkedSegmentSealedImpl::search_pks(BitsetType& bitset,
         return;
     }
     BitsetTypeView bitset_view(bitset);
+
+    // See Contain() — same zero-storage pk2offset fast path.
+    if (insert_record_.pk2offset_is_zero_storage()) {
+        for (auto& pk : pks) {
+            insert_record_.search_pk_range(
+                pk, proto::plan::OpType::Equal, bitset_view);
+        }
+        return;
+    }
+
     if (!is_sorted_by_pk_) {
         auto pk_index = PinPkIndex(nullptr);
         auto* pk_cell = pk_index.get();
@@ -1961,6 +1976,11 @@ ChunkedSegmentSealedImpl::pk_range(milvus::OpContext* op_ctx,
                                    proto::plan::OpType op,
                                    const PkType& pk,
                                    BitsetTypeView& bitset) const {
+    // See Contain() — same zero-storage pk2offset fast path.
+    if (insert_record_.pk2offset_is_zero_storage()) {
+        insert_record_.search_pk_range(pk, op, bitset);
+        return;
+    }
     if (!is_sorted_by_pk_) {
         auto pk_index = PinPkIndex(op_ctx);
         auto* pk_cell = pk_index.get();
@@ -2013,6 +2033,12 @@ ChunkedSegmentSealedImpl::pk_binary_range(milvus::OpContext* op_ctx,
                                           const PkType& upper_pk,
                                           bool upper_inclusive,
                                           BitsetTypeView& bitset) const {
+    // See Contain() — same zero-storage pk2offset fast path.
+    if (insert_record_.pk2offset_is_zero_storage()) {
+        insert_record_.search_pk_binary_range(
+            lower_pk, lower_inclusive, upper_pk, upper_inclusive, bitset);
+        return;
+    }
     if (!is_sorted_by_pk_) {
         auto pk_index = PinPkIndex(op_ctx);
         auto* pk_cell = pk_index.get();
@@ -4270,12 +4296,7 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
     auto needed_columns = std::make_shared<std::vector<std::string>>();
     needed_columns->reserve(milvus_field_ids.size());
     for (const auto& fid : milvus_field_ids) {
-        const auto& field_meta = (*schema_)[fid];
-        if (field_meta.is_external_field()) {
-            needed_columns->push_back(field_meta.get_external_field());
-        } else {
-            needed_columns->push_back(std::to_string(fid.get()));
-        }
+        needed_columns->push_back(schema_->get_storage_column_name(fid));
     }
     auto chunk_reader_result = reader_->get_chunk_reader(index, needed_columns);
     AssertInfo(chunk_reader_result.ok(),
@@ -4965,10 +4986,11 @@ ChunkedSegmentSealedImpl::TryTakeForRetrieve(
             continue;
         }
         auto& field_meta = schema_->operator[](field_id);
-        if (!field_meta.is_external_field()) {
+        if (!field_meta.is_external_field() &&
+            !schema_->is_function_output(field_id)) {
             continue;
         }
-        needed_columns->push_back(field_meta.get_external_field());
+        needed_columns->push_back(schema_->get_storage_column_name(field_id));
         take_field_ids.push_back(field_id);
         take_field_metas.push_back(&field_meta);
     }
@@ -5004,17 +5026,17 @@ ChunkedSegmentSealedImpl::TryTakeForRetrieve(
         ext_field_idx[take_field_ids[fi].get()] = fi;
     }
 
-    // Pre-combine Arrow chunks for each external column
+    // Pre-combine Arrow chunks for each external / function-output column
     std::vector<std::shared_ptr<arrow::Array>> combined_arrays(
         take_field_ids.size());
     for (size_t fi = 0; fi < take_field_ids.size(); fi++) {
-        auto ext_name = take_field_metas[fi]->get_external_field();
-        auto col = table->GetColumnByName(ext_name);
+        auto col_name = schema_->get_storage_column_name(take_field_ids[fi]);
+        auto col = table->GetColumnByName(col_name);
         if (!col || col->num_chunks() == 0) {
             LOG_WARN(
                 "[TakeAPI] column '{}' not found in take result for "
                 "segment {}",
-                ext_name,
+                col_name,
                 id_);
             return false;
         }
@@ -5056,8 +5078,9 @@ ChunkedSegmentSealedImpl::TryTakeForRetrieve(
 
         auto& field_meta = schema_->operator[](field_id);
 
-        // Virtual PK field (not external, computed on-the-fly)
-        if (!field_meta.is_external_field()) {
+        // Virtual PK field (not external, not function-output, computed on-the-fly)
+        if (!field_meta.is_external_field() &&
+            !schema_->is_function_output(field_id)) {
             if (is_pk_field(field_id) &&
                 field_meta.get_data_type() == DataType::INT64) {
                 auto data_array = std::make_unique<DataArray>();
@@ -5080,7 +5103,7 @@ ChunkedSegmentSealedImpl::TryTakeForRetrieve(
             continue;
         }
 
-        // External field — convert from take() result
+        // External or function-output field — convert from take() result
         auto it = ext_field_idx.find(field_id.get());
         if (it == ext_field_idx.end()) {
             continue;
@@ -5094,11 +5117,12 @@ ChunkedSegmentSealedImpl::TryTakeForRetrieve(
         auto data_array =
             ArrowToDataArray(arr, field_meta, ctx.result_mapping, size);
         if (!data_array) {
+            auto fname = schema_->get_storage_column_name(field_id);
             LOG_WARN(
                 "[TakeAPI] unsupported data type {} for field '{}', "
                 "falling back",
                 static_cast<int>(field_meta.get_data_type()),
-                field_meta.get_external_field());
+                fname);
             results->clear_fields_data();
             results->clear_ids();
             return false;
@@ -5132,16 +5156,17 @@ ChunkedSegmentSealedImpl::TryTakeForSearch(const query::Plan* plan,
         return false;
     }
 
-    // Collect needed external columns
+    // Collect needed external + function-output columns
     auto needed_columns = std::make_shared<std::vector<std::string>>();
     std::vector<FieldId> take_field_ids;
     std::vector<const FieldMeta*> take_field_metas;
     for (auto field_id : plan->target_entries_) {
         auto& field_meta = schema_->operator[](field_id);
-        if (!field_meta.is_external_field()) {
+        if (!field_meta.is_external_field() &&
+            !schema_->is_function_output(field_id)) {
             continue;
         }
-        needed_columns->push_back(field_meta.get_external_field());
+        needed_columns->push_back(schema_->get_storage_column_name(field_id));
         take_field_ids.push_back(field_id);
         take_field_metas.push_back(&field_meta);
     }
@@ -5168,11 +5193,11 @@ ChunkedSegmentSealedImpl::TryTakeForSearch(const query::Plan* plan,
     for (size_t fi = 0; fi < take_field_ids.size(); fi++) {
         auto field_id = take_field_ids[fi];
         auto& field_meta = *take_field_metas[fi];
-        auto ext_name = field_meta.get_external_field();
-        auto col = table->GetColumnByName(ext_name);
+        auto col_name = schema_->get_storage_column_name(field_id);
+        auto col = table->GetColumnByName(col_name);
         if (!col || col->num_chunks() == 0) {
             LOG_WARN("[TakeAPI] search column '{}' not found for segment {}",
-                     ext_name,
+                     col_name,
                      id_);
             return false;
         }
@@ -5198,7 +5223,7 @@ ChunkedSegmentSealedImpl::TryTakeForSearch(const query::Plan* plan,
                 "[TakeAPI] search: unsupported type {} for '{}', "
                 "falling back",
                 static_cast<int>(field_meta.get_data_type()),
-                ext_name);
+                col_name);
             results.output_fields_data_.clear();
             return false;
         }

--- a/internal/core/src/segcore/InsertRecord.h
+++ b/internal/core/src/segcore/InsertRecord.h
@@ -288,6 +288,15 @@ class OffsetMap {
 
     virtual size_t
     memory_size() const = 0;
+
+    // Returns true if the implementation stores nothing per-row (e.g.
+    // VirtualPKOffsetMap derives pk→offset via bit-extract). Callers that
+    // fall back to full pk-column scans (GetAllChunks + two-pointers) can
+    // short-circuit to find_range() when this is true — O(M) not O(M+N).
+    virtual bool
+    is_zero_storage() const {
+        return false;
+    }
 };
 
 template <typename T>
@@ -956,6 +965,11 @@ class VirtualPKOffsetMap : public OffsetMap {
         return sizeof(VirtualPKOffsetMap);
     }
 
+    bool
+    is_zero_storage() const override {
+        return true;
+    }
+
  private:
     int64_t truncated_segment_id_;
     int64_t shifted_segment_id_;
@@ -1010,6 +1024,14 @@ class InsertRecordSealed {
     bool
     contain(const PkType& pk) const {
         return pk2offset_->contain(pk);
+    }
+
+    // Returns true when the owned pk2offset_ is zero-storage (currently only
+    // VirtualPKOffsetMap). Sealed search_pks uses this to short-circuit the
+    // sorted two-pointers path.
+    bool
+    pk2offset_is_zero_storage() const {
+        return pk2offset_ != nullptr && pk2offset_->is_zero_storage();
     }
 
     std::vector<SegOffset>

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
@@ -416,10 +416,17 @@ ManifestGroupTranslator::load_group_chunk(
         try {
             field_id = std::stoll(column_name);
         } catch (const std::exception&) {
-            // External collection fallback: resolve by column name
+            // External collection fallback: column_name is non-numeric, so it
+            // comes from an external manifest — either an external_field
+            // mapping or a function-output field name. Normal fields are
+            // stored by numeric field id and take the stoll path above.
             for (const auto& [fid, meta] : field_metas_) {
                 if (meta.is_external_field() &&
                     meta.get_external_field() == column_name) {
+                    field_id = fid.get();
+                    break;
+                }
+                if (meta.get_name().get() == column_name) {
                     field_id = fid.get();
                     break;
                 }

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -1509,8 +1509,12 @@ GetFieldDatasFromManifest(
     auto column_groups = std::make_shared<milvus_storage::api::ColumnGroups>(
         loon_manifest->columnGroups());
 
-    // Determine the column name to use: external fields use their external name,
-    // internal fields use the numeric field ID string.
+    // Determine the column name to use:
+    //   - external input fields: external column name
+    //   - internal fields: numeric field ID string
+    //   - function output fields on external collections: field name fallback
+    //     (external function_executor writes columns into the manifest by
+    //     field name; internal BM25 uses numeric field_id like other fields)
     std::string column_name;
     const auto& ext_field = field_meta.field_schema.external_field();
     if (!ext_field.empty()) {
@@ -1520,14 +1524,23 @@ GetFieldDatasFromManifest(
     }
 
     // TODO remove manual check after loon support read null for non-exists field
-    bool field_exists = false;
-    for (size_t i = 0; i < column_groups->size() && !field_exists; i++) {
-        auto column_group = column_groups->at(i);
-        for (const auto& column : column_group->columns) {
-            if (column == column_name) {
-                field_exists = true;
-                break;
+    auto column_exists = [&](const std::string& name) {
+        for (size_t i = 0; i < column_groups->size(); i++) {
+            for (const auto& column : column_groups->at(i)->columns) {
+                if (column == name) {
+                    return true;
+                }
             }
+        }
+        return false;
+    };
+    bool field_exists = column_exists(column_name);
+    if (!field_exists && field_meta.field_schema.is_function_output()) {
+        // External function output fallback: try field name.
+        const auto& fname = field_meta.field_schema.name();
+        if (!fname.empty() && column_exists(fname)) {
+            column_name = fname;
+            field_exists = true;
         }
     }
     if (!field_exists) {

--- a/internal/core/src/storage/loon_ffi/ffi_reader_c.cpp
+++ b/internal/core/src/storage/loon_ffi/ffi_reader_c.cpp
@@ -141,12 +141,12 @@ NewPackedFFIReaderWithManifest(const LoonManifest* loon_manifest,
         auto properties =
             MakeInternalPropertiesFromStorageConfig(c_storage_config);
         if (external_source != nullptr && external_source[0] != '\0') {
-            InjectExtfsProperties(*properties,
-                                  collection_id,
-                                  std::string(external_source),
-                                  external_spec != nullptr
-                                      ? std::string(external_spec)
-                                      : std::string());
+            InjectExternalSpecProperties(*properties,
+                                         collection_id,
+                                         std::string(external_source),
+                                         external_spec != nullptr
+                                             ? std::string(external_spec)
+                                             : std::string());
         }
         auto column_groups =
             std::make_shared<milvus_storage::api::ColumnGroups>();

--- a/internal/core/src/storage/loon_ffi/ffi_reader_c.cpp
+++ b/internal/core/src/storage/loon_ffi/ffi_reader_c.cpp
@@ -131,12 +131,23 @@ NewPackedFFIReaderWithManifest(const LoonManifest* loon_manifest,
                                int64_t needed_columns_size,
                                CFFIPackedReader* c_loon_reader,
                                CStorageConfig c_storage_config,
-                               CPluginContext* c_plugin_context) {
+                               CPluginContext* c_plugin_context,
+                               int64_t collection_id,
+                               const char* external_source,
+                               const char* external_spec) {
     SCOPE_CGO_CALL_METRIC();
 
     try {
         auto properties =
             MakeInternalPropertiesFromStorageConfig(c_storage_config);
+        if (external_source != nullptr && external_source[0] != '\0') {
+            InjectExtfsProperties(*properties,
+                                  collection_id,
+                                  std::string(external_source),
+                                  external_spec != nullptr
+                                      ? std::string(external_spec)
+                                      : std::string());
+        }
         auto column_groups =
             std::make_shared<milvus_storage::api::ColumnGroups>();
         auto status = milvus_storage::column_groups_import(

--- a/internal/core/src/storage/loon_ffi/ffi_reader_c.h
+++ b/internal/core/src/storage/loon_ffi/ffi_reader_c.h
@@ -110,7 +110,10 @@ NewPackedFFIReaderWithManifest(const LoonManifest* loon_manifest,
                                int64_t needed_columns_size,
                                CFFIPackedReader* c_loon_reader,
                                CStorageConfig c_storage_config,
-                               CPluginContext* c_plugin_context);
+                               CPluginContext* c_plugin_context,
+                               int64_t collection_id,
+                               const char* external_source,
+                               const char* external_spec);
 
 /**
  * @brief Gets an ArrowArrayStream from the FFI reader for streaming data access.

--- a/internal/datacoord/task_refresh_external_collection.go
+++ b/internal/datacoord/task_refresh_external_collection.go
@@ -271,6 +271,7 @@ func (t *refreshExternalCollectionTask) SetJobInfo(ctx context.Context, resp *da
 	partitionID := collInfo.Partitions[0]
 	for _, seg := range updatedSegments {
 		seg.State = commonpb.SegmentState_Flushed
+		seg.IsSorted = true // external segments skip sort compaction pipeline
 		if seg.InsertChannel == "" {
 			seg.InsertChannel = insertChannel
 		}

--- a/internal/datanode/external/function_executor.go
+++ b/internal/datanode/external/function_executor.go
@@ -1,0 +1,322 @@
+package external
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/memory"
+	"github.com/samber/lo"
+	"go.uber.org/zap"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/storagecommon"
+	"github.com/milvus-io/milvus/internal/storagev2/packed"
+	"github.com/milvus-io/milvus/internal/util/function/embedding"
+	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
+)
+
+// defaultReadBufferSize matches the buffer size used elsewhere for FFIPackedReader.
+const defaultReadBufferSize = 64 * 1024 * 1024
+
+// ExecuteFunctionsForSegment computes function-output columns for an external
+// segment and returns a manifest that references both the external original
+// files (for input columns) and a newly written packed file (for function
+// output columns).
+//
+// Streaming pipeline (no full-segment InsertData materialization):
+//  1. Build an input manifest referencing the segment's external fragments.
+//  2. Open FFIPackedReader on input + FFIPackedWriter on outputs.
+//  3. For each Arrow batch read: convert to InsertData, run functions, append
+//     BM25 stats, build output Record, write to packed file.
+//  4. Close writer (commits manifest).
+//  5. Serialize accumulated BM25 stats and add to manifest.
+//
+// Memory: peak ~ one Arrow batch (default 64 MiB) regardless of segment size.
+// Input columns are never copied — segments reference the external original
+// files via the same column-group layout Segcore already uses.
+func ExecuteFunctionsForSegment(
+	ctx context.Context,
+	schema *schemapb.CollectionSchema,
+	fragments []packed.Fragment,
+	format string,
+	storageConfig *indexpb.StorageConfig,
+	collectionID int64,
+	segmentID int64,
+	clusterID string,
+) (string, error) {
+	log := log.Ctx(ctx)
+	log.Info("executing functions for external table segment",
+		zap.Int64("segmentID", segmentID),
+		zap.Int("numFragments", len(fragments)),
+		zap.Int("numFunctions", len(schema.GetFunctions())))
+
+	basePath := fmt.Sprintf("external/%d/segments/%d", collectionID, segmentID)
+	inputColumns := packed.GetColumnNamesFromSchema(schema)
+
+	inputManifestPath, err := packed.CreateSegmentManifestWithBasePath(
+		ctx, basePath, format, inputColumns, fragments, storageConfig)
+	if err != nil {
+		return "", fmt.Errorf("create input manifest: %w", err)
+	}
+	_, inputVersion, err := packed.UnmarshalManifestPath(inputManifestPath)
+	if err != nil {
+		return "", fmt.Errorf("parse input manifest path: %w", err)
+	}
+
+	outputFields, outputSchema, err := buildOutputSchema(schema)
+	if err != nil {
+		return "", err
+	}
+	outputArrow, err := storage.ConvertToArrowSchema(outputSchema, false)
+	if err != nil {
+		return "", err
+	}
+
+	reader, err := openInputReader(schema, inputManifestPath, inputColumns, storageConfig, collectionID)
+	if err != nil {
+		return "", err
+	}
+	defer reader.Release()
+
+	colGroups := []storagecommon.ColumnGroup{{Columns: lo.Range(len(outputFields))}}
+	writer, err := packed.NewFFIPackedWriter(
+		basePath, inputVersion, outputArrow, colGroups, storageConfig, nil)
+	if err != nil {
+		return "", fmt.Errorf("open output writer: %w", err)
+	}
+	// Destroy is idempotent; Close also calls it on success, so this defer
+	// only releases resources when streamBatches/Close fails before commit.
+	defer writer.Destroy()
+	writer.AsNewColumnGroups()
+
+	bm25Acc := newBM25Accumulators(schema)
+
+	totalRows, err := streamBatches(ctx, schema, outputSchema, outputArrow,
+		reader, writer, bm25Acc, clusterID)
+	if err != nil {
+		return "", err
+	}
+
+	manifestPath, err := writer.Close()
+	if err != nil {
+		return "", fmt.Errorf("close output writer: %w", err)
+	}
+
+	manifestPath, err = finalizeBM25Stats(ctx, bm25Acc, storageConfig, manifestPath)
+	if err != nil {
+		return "", err
+	}
+
+	log.Info("function execution completed",
+		zap.Int64("segmentID", segmentID),
+		zap.Int64("rows", totalRows),
+		zap.String("manifestPath", manifestPath))
+	return manifestPath, nil
+}
+
+// buildOutputSchema returns the output FieldSchema list and a wrapping
+// CollectionSchema used for arrow conversion. Errors if the schema declares no
+// function outputs (the executor should not have been invoked at all).
+func buildOutputSchema(schema *schemapb.CollectionSchema) ([]*schemapb.FieldSchema, *schemapb.CollectionSchema, error) {
+	var outputFields []*schemapb.FieldSchema
+	for _, f := range schema.GetFields() {
+		if f.GetIsFunctionOutput() {
+			outputFields = append(outputFields, f)
+		}
+	}
+	if len(outputFields) == 0 {
+		return nil, nil, fmt.Errorf("no function output fields; executor should not have been invoked")
+	}
+	return outputFields, &schemapb.CollectionSchema{
+		Name:   schema.GetName(),
+		Fields: outputFields,
+	}, nil
+}
+
+func openInputReader(
+	schema *schemapb.CollectionSchema,
+	manifestPath string,
+	inputColumns []string,
+	storageConfig *indexpb.StorageConfig,
+	collectionID int64,
+) (*packed.FFIPackedReader, error) {
+	inputSchema := buildInputSchema(schema)
+	arrowSchema, err := storage.ConvertToArrowSchema(inputSchema, false)
+	if err != nil {
+		return nil, fmt.Errorf("convert input schema to arrow: %w", err)
+	}
+	reader, err := packed.NewFFIPackedReader(
+		manifestPath, arrowSchema, inputColumns, defaultReadBufferSize,
+		storageConfig, nil,
+		packed.ExternalReaderContext{
+			CollectionID: collectionID,
+			Source:       schema.GetExternalSource(),
+			Spec:         schema.GetExternalSpec(),
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("open input manifest: %w", err)
+	}
+	return reader, nil
+}
+
+// buildInputSchema returns a CollectionSchema with only fields that exist in
+// external source data: drops function outputs and external system fields.
+func buildInputSchema(schema *schemapb.CollectionSchema) *schemapb.CollectionSchema {
+	inputSchema := &schemapb.CollectionSchema{Name: schema.GetName()}
+	for _, f := range schema.GetFields() {
+		if f.GetIsFunctionOutput() || typeutil.IsExternalSystemOrVirtualField(f.GetName()) {
+			continue
+		}
+		inputSchema.Fields = append(inputSchema.Fields, f)
+	}
+	return inputSchema
+}
+
+func streamBatches(
+	ctx context.Context,
+	schema *schemapb.CollectionSchema,
+	outputSchema *schemapb.CollectionSchema,
+	outputArrow *arrow.Schema,
+	reader *packed.FFIPackedReader,
+	writer *packed.FFIPackedWriter,
+	bm25Acc map[int64]*storage.BM25Stats,
+	clusterID string,
+) (int64, error) {
+	var totalRows int64
+	for {
+		rec, err := reader.ReadNext()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return totalRows, fmt.Errorf("read input batch: %w", err)
+		}
+		if rec == nil {
+			break
+		}
+
+		batch, err := storage.ArrowRecordToInsertData(rec, schema)
+		rec.Release()
+		if err != nil {
+			return totalRows, fmt.Errorf("arrow to InsertData: %w", err)
+		}
+		if batch.GetRowNum() == 0 {
+			continue
+		}
+
+		if err := embedding.RunAll(ctx, schema, batch, embedding.RunOptions{
+			ClusterID: clusterID,
+			DBName:    schema.GetDbName(),
+		}); err != nil {
+			return totalRows, fmt.Errorf("execute functions: %w", err)
+		}
+
+		if err := accumulateBM25Stats(batch, bm25Acc); err != nil {
+			return totalRows, err
+		}
+
+		if err := writeOutputBatch(batch, outputSchema, outputArrow, writer); err != nil {
+			return totalRows, fmt.Errorf("write output batch: %w", err)
+		}
+		totalRows += int64(batch.GetRowNum())
+	}
+	return totalRows, nil
+}
+
+func writeOutputBatch(
+	batch *storage.InsertData,
+	outputSchema *schemapb.CollectionSchema,
+	outputArrow *arrow.Schema,
+	writer *packed.FFIPackedWriter,
+) error {
+	builder := array.NewRecordBuilder(memory.DefaultAllocator, outputArrow)
+	defer builder.Release()
+	if err := storage.BuildRecord(builder, batch, outputSchema); err != nil {
+		return err
+	}
+	rec := builder.NewRecord()
+	defer rec.Release()
+	return writer.WriteRecordBatch(rec)
+}
+
+// newBM25Accumulators creates a stats accumulator per BM25 output field id.
+// Returns an empty map if the schema declares no BM25 functions.
+func newBM25Accumulators(schema *schemapb.CollectionSchema) map[int64]*storage.BM25Stats {
+	acc := make(map[int64]*storage.BM25Stats)
+	for _, fn := range schema.GetFunctions() {
+		if fn.GetType() != schemapb.FunctionType_BM25 {
+			continue
+		}
+		for _, outID := range fn.GetOutputFieldIds() {
+			acc[outID] = storage.NewBM25Stats()
+		}
+	}
+	return acc
+}
+
+// accumulateBM25Stats appends per-batch sparse vectors into the running
+// per-field stats accumulator. avgdl/IDF need full-segment counts, so the
+// accumulator persists across batches and is serialized once at the end.
+func accumulateBM25Stats(batch *storage.InsertData, acc map[int64]*storage.BM25Stats) error {
+	for outID, stats := range acc {
+		raw, present := batch.Data[outID]
+		if !present || raw == nil {
+			return fmt.Errorf(
+				"BM25 output field %d missing from batch; executeFunctions did not populate it",
+				outID)
+		}
+		fd, ok := raw.(*storage.SparseFloatVectorFieldData)
+		if !ok {
+			return fmt.Errorf(
+				"BM25 output field %d has wrong type %T (want *SparseFloatVectorFieldData)",
+				outID, raw)
+		}
+		stats.AppendFieldData(fd)
+	}
+	return nil
+}
+
+// finalizeBM25Stats serializes each per-field accumulator, writes the blob to
+// its packed BM25StatsPath, and registers entries on the manifest. Required
+// by QueryNode's idf_oracle for BM25 search.
+func finalizeBM25Stats(
+	ctx context.Context,
+	acc map[int64]*storage.BM25Stats,
+	storageConfig *indexpb.StorageConfig,
+	manifestPath string,
+) (string, error) {
+	if len(acc) == 0 {
+		return manifestPath, nil
+	}
+	log := log.Ctx(ctx)
+
+	basePath, _, err := packed.UnmarshalManifestPath(manifestPath)
+	if err != nil {
+		return "", fmt.Errorf("parse manifest path: %w", err)
+	}
+
+	entries := make([]packed.StatEntry, 0, len(acc))
+	for outID, stats := range acc {
+		blob, err := stats.Serialize()
+		if err != nil {
+			return "", fmt.Errorf("serialize bm25 stats for field %d: %w", outID, err)
+		}
+		fullPath := packed.BM25StatsPath(basePath, outID, 0)
+		if err := packed.WriteFile(storageConfig, fullPath, blob); err != nil {
+			return "", fmt.Errorf("write bm25 stats file %s: %w", fullPath, err)
+		}
+		entries = append(entries, packed.BM25StatsEntry(outID, fullPath, len(blob)))
+		log.Info("registered bm25 stats",
+			zap.Int64("fieldID", outID),
+			zap.Int("bytes", len(blob)),
+			zap.Int64("numRow", stats.NumRow()))
+	}
+	return packed.AddStatsToManifest(manifestPath, storageConfig, entries)
+}

--- a/internal/datanode/external/task_update.go
+++ b/internal/datanode/external/task_update.go
@@ -519,7 +519,13 @@ func (t *RefreshExternalCollectionTask) balanceFragmentsToSegments(ctx context.C
 			if err := ctx.Err(); err != nil {
 				return "", err
 			}
-			manifestPath, err := t.createManifestForSegment(ctx, work.segmentID, work.fragments)
+			var manifestPath string
+			var err error
+			if t.hasFunctions() {
+				manifestPath, err = t.createManifestWithFunctions(ctx, work.segmentID, work.fragments)
+			} else {
+				manifestPath, err = t.createManifestForSegment(ctx, work.segmentID, work.fragments)
+			}
 			if err != nil {
 				return "", fmt.Errorf("failed to create manifest for segment %d: %w", work.segmentID, err)
 			}
@@ -690,6 +696,33 @@ func (t *RefreshExternalCollectionTask) createManifestForSegment(
 		t.columns,
 		fragments,
 		t.req.GetStorageConfig(),
+	)
+}
+
+// hasFunctions returns true if the schema defines any functions.
+func (t *RefreshExternalCollectionTask) hasFunctions() bool {
+	return len(t.req.GetSchema().GetFunctions()) > 0
+}
+
+// createManifestWithFunctions builds an input manifest from the segment's
+// fragments, runs schema functions, and appends a function-output column group
+// on top. External input files are referenced, never copied.
+func (t *RefreshExternalCollectionTask) createManifestWithFunctions(
+	ctx context.Context,
+	segmentID int64,
+	fragments []packed.Fragment,
+) (string, error) {
+	clusterID := paramtable.Get().CommonCfg.ClusterPrefix.GetValue()
+
+	return ExecuteFunctionsForSegment(
+		ctx,
+		t.req.GetSchema(),
+		fragments,
+		t.parsedSpec.Format,
+		t.req.GetStorageConfig(),
+		t.req.GetCollectionID(),
+		segmentID,
+		clusterID,
 	)
 }
 

--- a/internal/datanode/external/task_update.go
+++ b/internal/datanode/external/task_update.go
@@ -58,6 +58,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/util/externalspec"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/timerecord"
+	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
 func ensureContext(ctx context.Context) error {
@@ -580,6 +581,10 @@ func (t *RefreshExternalCollectionTask) balanceFragmentsToSegments(ctx context.C
 	sampleRows := paramtable.Get().QueryNodeCfg.ExternalCollectionSampleRows.GetAsInt()
 	segmentAvgBytes := make([]int64, len(works))
 	var fallbackAvg int64
+	functionOutputAvgBytes, err := estimateFunctionOutputBytesPerRow(t.req.GetSchema())
+	if err != nil {
+		return nil, err
+	}
 
 	sampleOne := func(manifestPath string) (int64, bool) {
 		fieldSizes, err := packed.SampleExternalFieldSizes(
@@ -657,7 +662,7 @@ func (t *RefreshExternalCollectionTask) balanceFragmentsToSegments(ctx context.C
 	// Phase 4: Build result and mappings (sequential, lightweight)
 	result := make([]*datapb.SegmentInfo, 0, len(works))
 	for i, work := range works {
-		memorySize := segmentAvgBytes[i] * work.rowCount
+		memorySize := (segmentAvgBytes[i] + functionOutputAvgBytes) * work.rowCount
 		seg := &datapb.SegmentInfo{
 			ID:             work.segmentID,
 			CollectionID:   t.req.GetCollectionID(),
@@ -752,6 +757,26 @@ func buildFakeBinlogs(logID, numRows, memorySize int64, schema *schemapb.Collect
 			},
 		},
 	}
+}
+
+// estimateFunctionOutputBytesPerRow computes the per-row memory estimate for
+// fields generated during refresh. These fields are not present in external
+// source samples, so add them explicitly to the fake binlog memory size.
+func estimateFunctionOutputBytesPerRow(schema *schemapb.CollectionSchema) (int64, error) {
+	var total int64
+	for _, field := range schema.GetFields() {
+		if !field.GetIsFunctionOutput() {
+			continue
+		}
+		size, err := typeutil.EstimateSizePerRecord(&schemapb.CollectionSchema{
+			Fields: []*schemapb.FieldSchema{field},
+		})
+		if err != nil {
+			return 0, fmt.Errorf("estimate function output field %s: %w", field.GetName(), err)
+		}
+		total += int64(size)
+	}
+	return total, nil
 }
 
 // sumFieldSizes computes total avgBytesPerRow from per-field sampling results.

--- a/internal/datanode/external/task_update_test.go
+++ b/internal/datanode/external/task_update_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/bytedance/mockey"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
@@ -1548,6 +1549,135 @@ func (s *RefreshExternalCollectionTaskSuite) TestBalanceFragmentsToSegments_Empt
 // balanceFragmentsToSegments correctly passes storageConfig and specExtfs
 // (built from parsedSpec) to SampleExternalFieldSizes. This is the core change
 // that eliminates the dependency on C++ LoonFFIPropertiesSingleton.
+func (s *RefreshExternalCollectionTaskSuite) TestEstimateFunctionOutputBytesPerRow_NoOutputs() {
+	bytes, err := estimateFunctionOutputBytesPerRow(&schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "text", DataType: schemapb.DataType_VarChar},
+		},
+	})
+
+	s.NoError(err)
+	s.Equal(int64(0), bytes)
+}
+
+func (s *RefreshExternalCollectionTaskSuite) TestEstimateFunctionOutputBytesPerRow_VectorOutputs() {
+	bytes, err := estimateFunctionOutputBytesPerRow(&schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{
+				FieldID:          101,
+				Name:             "float_vec",
+				DataType:         schemapb.DataType_FloatVector,
+				IsFunctionOutput: true,
+				TypeParams:       []*commonpb.KeyValuePair{{Key: "dim", Value: "4"}},
+			},
+			{
+				FieldID:          102,
+				Name:             "int8_vec",
+				DataType:         schemapb.DataType_Int8Vector,
+				IsFunctionOutput: true,
+				TypeParams:       []*commonpb.KeyValuePair{{Key: "dim", Value: "8"}},
+			},
+			{
+				FieldID:          103,
+				Name:             "binary_vec",
+				DataType:         schemapb.DataType_BinaryVector,
+				IsFunctionOutput: true,
+				TypeParams:       []*commonpb.KeyValuePair{{Key: "dim", Value: "64"}},
+			},
+		},
+	})
+
+	s.NoError(err)
+	s.Equal(int64(16+8+8), bytes)
+}
+
+func (s *RefreshExternalCollectionTaskSuite) TestEstimateFunctionOutputBytesPerRow_ScalarOutputs() {
+	bytes, err := estimateFunctionOutputBytesPerRow(&schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 101, Name: "score", DataType: schemapb.DataType_Int64, IsFunctionOutput: true},
+			{
+				FieldID:          102,
+				Name:             "label",
+				DataType:         schemapb.DataType_VarChar,
+				IsFunctionOutput: true,
+				TypeParams:       []*commonpb.KeyValuePair{{Key: "max_length", Value: "20"}},
+			},
+		},
+	})
+
+	s.NoError(err)
+	s.Equal(int64(8+20), bytes)
+}
+
+func (s *RefreshExternalCollectionTaskSuite) TestEstimateFunctionOutputBytesPerRow_InvalidOutputField() {
+	_, err := estimateFunctionOutputBytesPerRow(&schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 101, Name: "bad_text", DataType: schemapb.DataType_VarChar, IsFunctionOutput: true},
+		},
+	})
+
+	s.Error(err)
+	s.Contains(err.Error(), "estimate function output field bad_text")
+}
+
+func (s *RefreshExternalCollectionTaskSuite) TestBalanceFragmentsToSegments_AddsFunctionOutputMemorySize() {
+	paramtable.Init()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req := &datapb.RefreshExternalCollectionTaskRequest{
+		CollectionID:           s.collectionID,
+		TaskID:                 s.taskID,
+		PreAllocatedSegmentIds: &datapb.IDRange{Begin: 100, End: 200},
+		StorageConfig:          &indexpb.StorageConfig{StorageType: "local"},
+		ExternalSource:         "s3://bucket/data/",
+		ExternalSpec:           `{"format":"parquet"}`,
+		Schema: &schemapb.CollectionSchema{
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "text", DataType: schemapb.DataType_VarChar, ExternalField: "text_col"},
+				{
+					FieldID:          101,
+					Name:             "embedding",
+					DataType:         schemapb.DataType_FloatVector,
+					IsFunctionOutput: true,
+					TypeParams:       []*commonpb.KeyValuePair{{Key: "dim", Value: "4"}},
+				},
+				{
+					FieldID:          102,
+					Name:             "scalar_output",
+					DataType:         schemapb.DataType_VarChar,
+					IsFunctionOutput: true,
+					TypeParams:       []*commonpb.KeyValuePair{{Key: "max_length", Value: "20"}},
+				},
+			},
+		},
+	}
+
+	task := NewRefreshExternalCollectionTask(ctx, req)
+	task.preallocatedIDRange = req.GetPreAllocatedSegmentIds()
+	task.nextAllocID = task.preallocatedIDRange.Begin
+	task.parsedSpec = &externalspec.ExternalSpec{Format: "parquet"}
+
+	m1 := mockey.Mock(packed.CreateSegmentManifestWithBasePath).
+		To(func(ctx context.Context, basePath, format string, columns []string, fragments []packed.Fragment, storageConfig *indexpb.StorageConfig) (string, error) {
+			return fmt.Sprintf("%s/manifest.json", basePath), nil
+		}).Build()
+	defer m1.UnPatch()
+
+	m2 := mockey.Mock(packed.SampleExternalFieldSizes).
+		Return(map[string]int64{"text_col": 64}, nil).Build()
+	defer m2.UnPatch()
+
+	fragments := []packed.Fragment{{FragmentID: 1, RowCount: 10}}
+
+	result, err := task.balanceFragmentsToSegments(context.Background(), fragments)
+	s.NoError(err)
+	s.Len(result, 1)
+	s.Len(result[0].GetBinlogs(), 1)
+	s.Len(result[0].GetBinlogs()[0].GetBinlogs(), 1)
+	s.Equal(int64((64+16+20)*10), result[0].GetBinlogs()[0].GetBinlogs()[0].GetMemorySize())
+}
+
 func (s *RefreshExternalCollectionTaskSuite) TestBalanceFragmentsToSegments_PassesStorageConfigAndSpecExtfs() {
 	paramtable.Init()
 

--- a/internal/datanode/importv2/util.go
+++ b/internal/datanode/importv2/util.go
@@ -36,9 +36,7 @@ import (
 	"github.com/milvus-io/milvus/internal/flushcommon/syncmgr"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
-	"github.com/milvus-io/milvus/internal/util/function"
 	"github.com/milvus-io/milvus/internal/util/function/embedding"
-	"github.com/milvus-io/milvus/internal/util/function/models"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/metrics"
@@ -443,164 +441,14 @@ func FillDynamicData(schema *schemapb.CollectionSchema, data *storage.InsertData
 
 func RunEmbeddingFunction(task *ImportTask, data *storage.InsertData) error {
 	log.Info("start to run embedding function")
-	if err := RunDenseEmbedding(task, data); err != nil {
-		return err
-	}
-
-	if err := RunBm25Function(task, data); err != nil {
-		return err
-	}
-
-	if err := RunMinHashFunction(task, data); err != nil {
-		return err
-	}
-	return nil
-}
-
-func RunDenseEmbedding(task *ImportTask, data *storage.InsertData) error {
-	log.Info("start to run dense embedding")
 	schema := task.GetSchema()
-	allowNonBM25Outputs := common.GetCollectionAllowInsertNonBM25FunctionOutputs(schema.Properties)
-	log.Info("allowNonBM25Outputs", zap.Any("allowNonBM25Outputs", allowNonBM25Outputs))
-	fieldIDs := lo.Keys(lo.PickBy(data.Data, func(_ int64, fd storage.FieldData) bool {
-		return fd.RowNum() > 0
-	}))
-	needProcessFunctions, err := typeutil.GetNeedProcessFunctions(fieldIDs, schema.Functions, allowNonBM25Outputs, false)
-	if err != nil {
+	allowNonBM25Outputs := common.GetCollectionAllowInsertNonBM25FunctionOutputs(schema.GetProperties())
+	if err := embedding.RunAll(context.Background(), schema, data, embedding.RunOptions{
+		ClusterID:           task.req.GetClusterID(),
+		DBName:              schema.GetDbName(),
+		AllowNonBM25Outputs: allowNonBM25Outputs,
+	}); err != nil {
 		return errors.Wrap(merr.ErrInvalidInsertData, err.Error())
-	}
-	log.Info("needProcessFunctions", zap.Any("needProcessFunctions", needProcessFunctions))
-	if embedding.HasNonBM25AndMinHashFunctions(schema.Functions, []int64{}) {
-		log.Info("has non bm25/minhash functions")
-		extraInfo := &models.ModelExtraInfo{
-			ClusterID: task.req.ClusterID,
-			DBName:    task.req.Schema.DbName,
-		}
-		exec, err := embedding.NewFunctionExecutor(schema, needProcessFunctions, extraInfo)
-		if err != nil {
-			return err
-		}
-		if err := exec.ProcessBulkInsert(context.Background(), data); err != nil {
-			return err
-		}
-		log.Info("end to run dense embedding")
-	}
-	return nil
-}
-
-func RunBm25Function(task *ImportTask, data *storage.InsertData) error {
-	log.Info("start to run bm25 function")
-	fns := task.GetSchema().GetFunctions()
-	for _, fn := range fns {
-		if fn.GetType() != schemapb.FunctionType_BM25 {
-			continue
-		}
-		runner, err := function.NewFunctionRunner(task.GetSchema(), fn)
-		if err != nil {
-			return err
-		}
-
-		if runner == nil {
-			continue
-		}
-
-		inputFieldIDs := lo.Map(runner.GetInputFields(), func(field *schemapb.FieldSchema, _ int) int64 { return field.GetFieldID() })
-		inputDatas := make([]any, 0, len(inputFieldIDs))
-		for _, inputFieldID := range inputFieldIDs {
-			inputDatas = append(inputDatas, data.Data[inputFieldID].GetDataRows())
-		}
-
-		outputFieldData, err := runner.BatchRun(inputDatas...)
-		runner.Close()
-		if err != nil {
-			return err
-		}
-		for i, outputFieldID := range fn.OutputFieldIds {
-			outputField := typeutil.GetField(task.GetSchema(), outputFieldID)
-			// TODO: added support for vector output field only, scalar output field in function is not supported yet
-			switch outputField.GetDataType() {
-			case schemapb.DataType_FloatVector:
-				data.Data[outputFieldID] = outputFieldData[i].(*storage.FloatVectorFieldData)
-			case schemapb.DataType_BFloat16Vector:
-				data.Data[outputFieldID] = outputFieldData[i].(*storage.BFloat16VectorFieldData)
-			case schemapb.DataType_Float16Vector:
-				data.Data[outputFieldID] = outputFieldData[i].(*storage.Float16VectorFieldData)
-			case schemapb.DataType_BinaryVector:
-				data.Data[outputFieldID] = outputFieldData[i].(*storage.BinaryVectorFieldData)
-			case schemapb.DataType_SparseFloatVector:
-				sparseArray := outputFieldData[i].(*schemapb.SparseFloatArray)
-				data.Data[outputFieldID] = &storage.SparseFloatVectorFieldData{
-					SparseFloatArray: schemapb.SparseFloatArray{
-						Dim:      sparseArray.GetDim(),
-						Contents: sparseArray.GetContents(),
-					},
-				}
-			default:
-				return fmt.Errorf("unsupported output data type for embedding function: %s", outputField.GetDataType().String())
-			}
-		}
-	}
-	return nil
-}
-
-func RunMinHashFunction(task *ImportTask, data *storage.InsertData) error {
-	fns := task.GetSchema().GetFunctions()
-	for _, fn := range fns {
-		if fn.GetType() != schemapb.FunctionType_MinHash {
-			continue
-		}
-		runner, err := function.NewFunctionRunner(task.GetSchema(), fn)
-		if err != nil {
-			return err
-		}
-
-		if runner == nil {
-			continue
-		}
-
-		inputFieldIDs := lo.Map(runner.GetInputFields(), func(field *schemapb.FieldSchema, _ int) int64 { return field.GetFieldID() })
-		inputDatas := make([]any, 0, len(inputFieldIDs))
-		for _, inputFieldID := range inputFieldIDs {
-			inputDatas = append(inputDatas, data.Data[inputFieldID].GetDataRows())
-		}
-
-		output, err := runner.BatchRun(inputDatas...)
-		runner.Close()
-		if err != nil {
-			return err
-		}
-
-		// Sanity check: ensure BatchRun returned at least one output
-		if len(output) == 0 {
-			return errors.New("MinHash embedding failed: runner.BatchRun returned empty output")
-		}
-
-		// MinHash function has only one output field
-		fieldData, ok := output[0].(*schemapb.FieldData)
-		if !ok {
-			return errors.New("MinHash embedding failed: MinHash runner output not FieldData")
-		}
-
-		vectorField := fieldData.GetVectors()
-		if vectorField == nil {
-			return errors.New("MinHash embedding failed: output is not a vector field")
-		}
-
-		binaryVector := vectorField.GetBinaryVector()
-		if binaryVector == nil {
-			return errors.New("MinHash embedding failed: output is not a binary vector")
-		}
-
-		outputFields := runner.GetOutputFields()
-		if len(outputFields) == 0 {
-			return errors.New("MinHash embedding failed: runner has no output fields")
-		}
-
-		outputFieldId := outputFields[0].GetFieldID()
-		data.Data[outputFieldId] = &storage.BinaryVectorFieldData{
-			Data: binaryVector,
-			Dim:  int(vectorField.GetDim()),
-		}
 	}
 	return nil
 }

--- a/internal/proxy/impl_test.go
+++ b/internal/proxy/impl_test.go
@@ -2130,7 +2130,7 @@ func TestProxy_ManualCompaction_ExternalCollection(t *testing.T) {
 		Name:           "external_col",
 		ExternalSource: "s3://bucket/path",
 		Fields: []*schemapb.FieldSchema{
-			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true, ExternalField: "ext_id"},
+			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, ExternalField: "ext_id"},
 		},
 	}
 
@@ -2162,7 +2162,7 @@ func TestProxy_Insert_ExternalCollection(t *testing.T) {
 	externalSchema := &schemapb.CollectionSchema{
 		Name: "external_col",
 		Fields: []*schemapb.FieldSchema{
-			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true, ExternalField: "ext_id"},
+			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, ExternalField: "ext_id"},
 		},
 	}
 
@@ -2191,7 +2191,7 @@ func TestProxy_Delete_ExternalCollection(t *testing.T) {
 	externalSchema := &schemapb.CollectionSchema{
 		Name: "external_col",
 		Fields: []*schemapb.FieldSchema{
-			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true, ExternalField: "ext_id"},
+			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, ExternalField: "ext_id"},
 		},
 	}
 
@@ -2221,7 +2221,7 @@ func TestProxy_Upsert_ExternalCollection(t *testing.T) {
 	externalSchema := &schemapb.CollectionSchema{
 		Name: "external_col",
 		Fields: []*schemapb.FieldSchema{
-			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true, ExternalField: "ext_id"},
+			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, ExternalField: "ext_id"},
 		},
 	}
 
@@ -2250,7 +2250,7 @@ func TestProxy_Flush_ExternalCollection(t *testing.T) {
 	externalSchema := &schemapb.CollectionSchema{
 		Name: "external_col",
 		Fields: []*schemapb.FieldSchema{
-			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true, ExternalField: "ext_id"},
+			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, ExternalField: "ext_id"},
 		},
 	}
 
@@ -2279,7 +2279,7 @@ func TestProxy_CreatePartition_ExternalCollection(t *testing.T) {
 	externalSchema := &schemapb.CollectionSchema{
 		Name: "external_col",
 		Fields: []*schemapb.FieldSchema{
-			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true, ExternalField: "ext_id"},
+			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, ExternalField: "ext_id"},
 		},
 	}
 
@@ -2309,7 +2309,7 @@ func TestProxy_DropPartition_ExternalCollection(t *testing.T) {
 	externalSchema := &schemapb.CollectionSchema{
 		Name: "external_col",
 		Fields: []*schemapb.FieldSchema{
-			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true, ExternalField: "ext_id"},
+			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, ExternalField: "ext_id"},
 		},
 	}
 
@@ -2339,7 +2339,7 @@ func TestProxy_ImportV2_ExternalCollection(t *testing.T) {
 	externalSchema := &schemapb.CollectionSchema{
 		Name: "external_col",
 		Fields: []*schemapb.FieldSchema{
-			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true, ExternalField: "ext_id"},
+			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, ExternalField: "ext_id"},
 		},
 	}
 
@@ -2368,7 +2368,7 @@ func TestProxy_AddCollectionField_ExternalCollection(t *testing.T) {
 	externalSchema := &schemapb.CollectionSchema{
 		Name: "external_col",
 		Fields: []*schemapb.FieldSchema{
-			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true, ExternalField: "ext_id"},
+			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, ExternalField: "ext_id"},
 		},
 	}
 
@@ -2400,7 +2400,7 @@ func TestProxy_AlterCollectionField_ExternalCollection(t *testing.T) {
 	externalSchema := &schemapb.CollectionSchema{
 		Name: "external_col",
 		Fields: []*schemapb.FieldSchema{
-			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true, ExternalField: "ext_id"},
+			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, ExternalField: "ext_id"},
 		},
 	}
 

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -425,16 +425,18 @@ func (t *createCollectionTask) PreExecute(ctx context.Context) error {
 	t.schema.AutoID = false
 	t.schema.DbName = t.GetDbName()
 
-	isExternalCollection := typeutil.IsExternalCollection(t.schema)
-	if err := typeutil.NormalizeAndValidateExternalCollectionSchema(t.schema); err != nil {
-		return err
-	}
-
+	// validateFunction must run first: it sets IsFunctionOutput=true on output fields.
+	// NormalizeAndValidateExternalCollectionSchema depends on this flag.
 	disableCheck, err := common.IsDisableFuncRuntimeCheck(t.GetProperties()...)
 	if err != nil {
 		return err
 	}
 	if err := validateFunction(t.schema, "", disableCheck); err != nil {
+		return err
+	}
+
+	isExternalCollection := typeutil.IsExternalCollection(t.schema)
+	if err := typeutil.NormalizeAndValidateExternalCollectionSchema(t.schema); err != nil {
 		return err
 	}
 

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -1855,26 +1855,9 @@ func TestCreateCollectionTaskExternalCollection(t *testing.T) {
 		assert.Equal(t, "vec_field", freshTask.schema.Fields[2].Name)
 	})
 
-	t.Run("functions forbidden", func(t *testing.T) {
-		schema := buildExternalSchema()
-		schema.Functions = []*schemapb.FunctionSchema{{Name: "test_func"}}
-		task.Schema = marshal(schema)
-		err := task.PreExecute(ctx)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "does not support functions")
-	})
-
 	t.Run("dynamic field forbidden", func(t *testing.T) {
 		schema := buildExternalSchema()
 		schema.EnableDynamicField = true
-		task.Schema = marshal(schema)
-		err := task.PreExecute(ctx)
-		assert.Error(t, err)
-	})
-
-	t.Run("primary key forbidden", func(t *testing.T) {
-		schema := buildExternalSchema()
-		schema.Fields[0].IsPrimaryKey = true
 		task.Schema = marshal(schema)
 		err := task.PreExecute(ctx)
 		assert.Error(t, err)

--- a/internal/rootcoord/create_collection_task_test.go
+++ b/internal/rootcoord/create_collection_task_test.go
@@ -970,42 +970,6 @@ func Test_createCollectionTask_validateSchema(t *testing.T) {
 		err := task.validateSchema(context.TODO(), schema)
 		assert.Error(t, err)
 	})
-
-	t.Run("external schema reject functions", func(t *testing.T) {
-		collectionName := funcutil.GenRandomStr()
-		task := createCollectionTask{
-			Req: &milvuspb.CreateCollectionRequest{
-				Base:           &commonpb.MsgBase{MsgType: commonpb.MsgType_CreateCollection},
-				CollectionName: collectionName,
-			},
-		}
-		schema := &schemapb.CollectionSchema{
-			Name:           collectionName,
-			ExternalSource: "s3://bucket/object",
-			ExternalSpec:   `{"format":"parquet"}`,
-			Fields: []*schemapb.FieldSchema{
-				{
-					Name:          "text_field",
-					DataType:      schemapb.DataType_VarChar,
-					ExternalField: "text_col",
-					TypeParams: []*commonpb.KeyValuePair{
-						{Key: common.MaxLengthKey, Value: "64"},
-					},
-				},
-				{
-					Name:          "vec_field",
-					DataType:      schemapb.DataType_FloatVector,
-					ExternalField: "vec_col",
-					TypeParams: []*commonpb.KeyValuePair{
-						{Key: common.DimKey, Value: "16"},
-					},
-				},
-			},
-			Functions: []*schemapb.FunctionSchema{{Name: "test_func"}},
-		}
-		err := task.validateSchema(context.TODO(), schema)
-		assert.Error(t, err)
-	})
 }
 
 func Test_createCollectionTask_prepareSchema(t *testing.T) {

--- a/internal/storage/arrow_to_insert.go
+++ b/internal/storage/arrow_to_insert.go
@@ -1,0 +1,102 @@
+// Copyright 2024 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"fmt"
+
+	"github.com/apache/arrow/go/v17/arrow"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
+)
+
+// ArrowRecordToInsertData converts an arrow.Record into *InsertData using the
+// provided collection schema. Columns are matched between the arrow record and
+// the schema by name.
+//
+// Fields present in the schema but absent from the arrow record are left empty
+// in the returned InsertData (intended for function-output fields that will be
+// filled in later by the function executor).
+//
+// Fields are deserialised via serdeMap row-by-row, so nullable ValidData is
+// populated correctly through each FieldData's AppendRow implementation.
+func ArrowRecordToInsertData(
+	rec arrow.Record,
+	schema *schemapb.CollectionSchema,
+) (*InsertData, error) {
+	insertData, err := NewInsertDataWithFunctionOutputField(schema)
+	if err != nil {
+		return nil, err
+	}
+	if rec == nil || rec.NumRows() == 0 {
+		return insertData, nil
+	}
+
+	arrowSchema := rec.Schema()
+	numRows := int(rec.NumRows())
+
+	for _, field := range schema.GetFields() {
+		// External input columns are named by ExternalField in the arrow
+		// record (the reader uses the source-table column name, not the
+		// milvus field name). Internal columns use the field name.
+		columnName := field.GetName()
+		if ext := field.GetExternalField(); ext != "" {
+			columnName = ext
+		}
+		indices := arrowSchema.FieldIndices(columnName)
+		if len(indices) == 0 {
+			// Field not present in arrow record (e.g. function output, system field).
+			continue
+		}
+		col := rec.Column(indices[0])
+		dt := field.GetDataType()
+
+		dim := 0
+		if typeutil.IsVectorType(dt) {
+			d, _ := typeutil.GetDim(field)
+			dim = int(d)
+		}
+		elementType := schemapb.DataType_None
+		if dt == schemapb.DataType_ArrayOfVector {
+			elementType = field.GetElementType()
+		}
+
+		fd, ok := insertData.Data[field.GetFieldID()]
+		if !ok {
+			return nil, fmt.Errorf("field %s (ID=%d) not initialized in InsertData",
+				field.GetName(), field.GetFieldID())
+		}
+
+		entry, ok := serdeMap[dt]
+		if !ok {
+			return nil, fmt.Errorf("unsupported data type %s for field %s", dt, field.GetName())
+		}
+
+		for i := 0; i < numRows; i++ {
+			val, err := entry.deserialize(col, i, elementType, dim, true /* shouldCopy */)
+			if err != nil {
+				return nil, fmt.Errorf("deserialize field %s row %d: %w",
+					field.GetName(), i, err)
+			}
+			if err := fd.AppendRow(val); err != nil {
+				return nil, fmt.Errorf("append field %s row %d: %w",
+					field.GetName(), i, err)
+			}
+		}
+	}
+
+	return insertData, nil
+}

--- a/internal/storage/record_reader.go
+++ b/internal/storage/record_reader.go
@@ -249,7 +249,7 @@ func NewManifestReader(manifest string,
 }
 
 func (mr *ManifestReader) init() error {
-	reader, err := packed.NewFFIPackedReader(mr.manifest, mr.arrowSchema, mr.neededColumns, mr.bufferSize, mr.storageConfig, mr.storagePluginContext)
+	reader, err := packed.NewFFIPackedReader(mr.manifest, mr.arrowSchema, mr.neededColumns, mr.bufferSize, mr.storageConfig, mr.storagePluginContext, packed.ExternalReaderContext{})
 	if err != nil {
 		return err
 	}

--- a/internal/storagev2/packed/packed_reader_ffi.go
+++ b/internal/storagev2/packed/packed_reader_ffi.go
@@ -39,7 +39,19 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
 )
 
-func NewFFIPackedReader(manifestPath string, schema *arrow.Schema, neededColumns []string, bufferSize int64, storageConfig *indexpb.StorageConfig, storagePluginContext *indexcgopb.StoragePluginContext) (*FFIPackedReader, error) {
+// ExternalReaderContext carries per-collection context needed by the FFI
+// reader to resolve extfs aliases for external collections. Zero value is
+// safe for non-external collections.
+type ExternalReaderContext struct {
+	CollectionID int64
+	Source       string
+	Spec         string
+}
+
+func NewFFIPackedReader(manifestPath string, schema *arrow.Schema, neededColumns []string, bufferSize int64, storageConfig *indexpb.StorageConfig, storagePluginContext *indexcgopb.StoragePluginContext, ext ExternalReaderContext) (*FFIPackedReader, error) {
+	collectionID := ext.CollectionID
+	externalSource := ext.Source
+	externalSpec := ext.Spec
 	cLoonManifest, err := GetManifestHandle(manifestPath, storageConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get manifest")
@@ -110,7 +122,19 @@ func NewFFIPackedReader(manifestPath string, schema *arrow.Schema, neededColumns
 		cNeededColumnArray := (**C.char)(unsafe.Pointer(&cNeededColumn[0]))
 		cNumColumns := C.int64_t(len(neededColumns))
 
-		status = C.NewPackedFFIReaderWithManifest(cLoonManifest, cSchema, cNeededColumnArray, cNumColumns, &cPackedReader, cStorageConfig, pluginContextPtr)
+		// Avoid C.CString allocations on the non-external hot path. The C side
+		// treats nullptr the same as an empty string (empty-source guard).
+		var cExternalSource, cExternalSpec *C.char
+		if externalSource != "" {
+			cExternalSource = C.CString(externalSource)
+			defer C.free(unsafe.Pointer(cExternalSource))
+			if externalSpec != "" {
+				cExternalSpec = C.CString(externalSpec)
+				defer C.free(unsafe.Pointer(cExternalSpec))
+			}
+		}
+
+		status = C.NewPackedFFIReaderWithManifest(cLoonManifest, cSchema, cNeededColumnArray, cNumColumns, &cPackedReader, cStorageConfig, pluginContextPtr, C.int64_t(collectionID), cExternalSource, cExternalSpec)
 	} else {
 		return nil, fmt.Errorf("storageConfig is required")
 	}

--- a/internal/storagev2/packed/packed_reader_ffi_test.go
+++ b/internal/storagev2/packed/packed_reader_ffi_test.go
@@ -114,7 +114,7 @@ func TestPackedFFIReader(t *testing.T) {
 
 	// Create FFI packed reader
 	neededColumns := []string{"pk", "vector"}
-	reader, err := NewFFIPackedReader(manifest, schema, neededColumns, 8192, storageConfig, nil)
+	reader, err := NewFFIPackedReader(manifest, schema, neededColumns, 8192, storageConfig, nil, ExternalReaderContext{})
 	require.NoError(t, err)
 	require.NotNil(t, reader)
 
@@ -261,7 +261,7 @@ func TestPackedFFIReaderPartialColumns(t *testing.T) {
 		schema.Field(1),
 	}, nil)
 
-	reader, err := NewFFIPackedReader(manifest, partialSchema, neededColumns, 8192, storageConfig, nil)
+	reader, err := NewFFIPackedReader(manifest, partialSchema, neededColumns, 8192, storageConfig, nil, ExternalReaderContext{})
 	require.NoError(t, err)
 	require.NotNil(t, reader)
 
@@ -389,7 +389,7 @@ func TestPackedFFIReaderMultipleBatches(t *testing.T) {
 	}
 
 	neededColumns := []string{"pk", "vector"}
-	reader, err := NewFFIPackedReader(manifest, schema, neededColumns, 8192, storageConfig, nil)
+	reader, err := NewFFIPackedReader(manifest, schema, neededColumns, 8192, storageConfig, nil, ExternalReaderContext{})
 	require.NoError(t, err)
 
 	totalRowsRead := int64(0)

--- a/internal/storagev2/packed/packed_writer_ffi.go
+++ b/internal/storagev2/packed/packed_writer_ffi.go
@@ -151,6 +151,15 @@ func NewFFIPackedWriter(basePath string, baseVersion int64, schema *arrow.Schema
 	}, nil
 }
 
+// AsNewColumnGroups marks this writer so that Close() calls loon_transaction_add_column_group
+// for each written column group instead of loon_transaction_append_files.
+// Call this when the written columns are brand-new additions to an existing manifest
+// (e.g. function-field backfill), not when appending more files to the same column structure.
+func (pw *FFIPackedWriter) AsNewColumnGroups() *FFIPackedWriter {
+	pw.addNewColumnGroups = true
+	return pw
+}
+
 func (pw *FFIPackedWriter) WriteRecordBatch(recordBatch arrow.Record) error {
 	var caa cdata.CArrowArray
 	var cas cdata.CArrowSchema
@@ -167,7 +176,25 @@ func (pw *FFIPackedWriter) WriteRecordBatch(recordBatch arrow.Record) error {
 	return HandleLoonFFIResult(result)
 }
 
+// Destroy releases the underlying C writer handle and properties. Idempotent;
+// safe to call multiple times. Use as `defer w.Destroy()` after construction so
+// resources are freed on every error path (Close already invokes Destroy on
+// success).
+func (pw *FFIPackedWriter) Destroy() {
+	if pw.destroyed {
+		return
+	}
+	pw.destroyed = true
+	C.loon_writer_destroy(pw.cWriterHandle)
+	if pw.cProperties != nil {
+		C.loon_properties_free(pw.cProperties)
+		pw.cProperties = nil
+	}
+}
+
 func (pw *FFIPackedWriter) Close() (string, error) {
+	defer pw.Destroy()
+
 	var cColumnGroups *C.LoonColumnGroups
 
 	result := C.loon_writer_close(pw.cWriterHandle, nil, nil, 0, &cColumnGroups)
@@ -185,9 +212,20 @@ func (pw *FFIPackedWriter) Close() (string, error) {
 	}
 	defer C.loon_transaction_destroy(transationHandle)
 
-	result = C.loon_transaction_append_files(transationHandle, cColumnGroups)
-	if err := HandleLoonFFIResult(result); err != nil {
-		return "", err
+	if pw.addNewColumnGroups {
+		numGroups := int(cColumnGroups.num_of_column_groups)
+		colGroupSlice := (*[1 << 20]C.LoonColumnGroup)(unsafe.Pointer(cColumnGroups.column_group_array))[:numGroups:numGroups]
+		for i := range colGroupSlice {
+			result = C.loon_transaction_add_column_group(transationHandle, &colGroupSlice[i])
+			if err := HandleLoonFFIResult(result); err != nil {
+				return "", err
+			}
+		}
+	} else {
+		result = C.loon_transaction_append_files(transationHandle, cColumnGroups)
+		if err := HandleLoonFFIResult(result); err != nil {
+			return "", err
+		}
 	}
 
 	var cCommitVersion C.int64_t
@@ -198,6 +236,5 @@ func (pw *FFIPackedWriter) Close() (string, error) {
 
 	log.Info("FFI writer closed", zap.Int64("version", int64(cCommitVersion)))
 
-	defer C.loon_properties_free(pw.cProperties)
 	return MarshalManifestPath(pw.basePath, int64(cCommitVersion)), nil
 }

--- a/internal/storagev2/packed/stat_entry_builders.go
+++ b/internal/storagev2/packed/stat_entry_builders.go
@@ -20,6 +20,22 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 )
 
+// BM25StatsPath returns the packed file path for the BM25 stats blob of a
+// given output field. Layout must stay in sync with QueryNode's StatsResolver
+// (internal/storagev2/packed/stats_resolver.go resolveStatPaths).
+func BM25StatsPath(basePath string, fieldID int64, batch int) string {
+	return fmt.Sprintf("%s/_stats/bm25.%d/%d", basePath, fieldID, batch)
+}
+
+// BM25StatsEntry builds a StatEntry for a BM25 stats blob.
+func BM25StatsEntry(fieldID int64, filePath string, memorySize int) StatEntry {
+	return StatEntry{
+		Key:      fmt.Sprintf("bm25.%d", fieldID),
+		Files:    []string{filePath},
+		Metadata: map[string]string{"memory_size": fmt.Sprintf("%d", memorySize)},
+	}
+}
+
 // FieldBinlogStatEntry builds a StatEntry from a FieldBinlog with the given key prefix.
 // For example: FieldBinlogStatEntry("bloom_filter", stats.GetFieldID(), stats)
 func FieldBinlogStatEntry(prefix string, fieldID int64, fb *datapb.FieldBinlog) StatEntry {

--- a/internal/storagev2/packed/type.go
+++ b/internal/storagev2/packed/type.go
@@ -35,10 +35,14 @@ type PackedWriter struct {
 }
 
 type FFIPackedWriter struct {
-	basePath      string
-	baseVersion   int64
-	cWriterHandle C.LoonWriterHandle
-	cProperties   *C.LoonProperties
+	basePath           string
+	baseVersion        int64
+	cWriterHandle      C.LoonWriterHandle
+	cProperties        *C.LoonProperties
+	addNewColumnGroups bool
+	// destroyed guards Destroy() against double-free when both Close() and a
+	// caller-side defer Destroy() run.
+	destroyed bool
 }
 
 type PackedReader struct {

--- a/internal/storagev2/packed/utils.go
+++ b/internal/storagev2/packed/utils.go
@@ -324,6 +324,9 @@ func GetColumnNamesFromSchema(schema *schemapb.CollectionSchema) []string {
 	isExternal := schema.GetExternalSource() != ""
 	var columns []string
 	for _, field := range schema.GetFields() {
+		if field.GetIsFunctionOutput() {
+			continue // function output fields don't exist in external data
+		}
 		extField := field.GetExternalField()
 		if extField != "" {
 			columns = append(columns, extField)

--- a/internal/util/function/embedding/runner.go
+++ b/internal/util/function/embedding/runner.go
@@ -1,0 +1,242 @@
+// Copyright 2025 Zilliz
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package embedding
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cockroachdb/errors"
+	"github.com/samber/lo"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/util/function"
+	"github.com/milvus-io/milvus/internal/util/function/models"
+	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
+)
+
+// RunOptions packs runtime context required by some function runners.
+type RunOptions struct {
+	// ClusterID and DBName feed TextEmbedding model RPC headers.
+	ClusterID string
+	DBName    string
+	// AllowNonBM25Outputs controls whether GetNeedProcessFunctions accepts
+	// pre-existing non-BM25 outputs in the data (import sets via collection
+	// property; external table refresh leaves false).
+	AllowNonBM25Outputs bool
+}
+
+// RunAll executes TextEmbedding, BM25, and MinHash functions declared on
+// schema over data in-place. Function outputs are written into data.Data
+// keyed by the output field id.
+//
+// Order matters: TextEmbedding must run before BM25/MinHash. RunTextEmbedding
+// calls GetNeedProcessFunctions which rejects any input containing BM25 output
+// field ids (it cannot tell a freshly-computed column from a user-supplied
+// one). Populating those columns first would cause the subsequent
+// GetNeedProcessFunctions check to error.
+//
+// Single canonical entry point shared by import and external-table refresh.
+func RunAll(
+	ctx context.Context,
+	schema *schemapb.CollectionSchema,
+	data *storage.InsertData,
+	opts RunOptions,
+) error {
+	if err := RunTextEmbedding(ctx, schema, data, opts); err != nil {
+		return err
+	}
+	if err := RunBM25(schema, data); err != nil {
+		return err
+	}
+	return RunMinHash(schema, data)
+}
+
+// RunBM25 executes every BM25 function in schema over data, dispatching the
+// runner output into the appropriate FieldData type for each output field.
+func RunBM25(schema *schemapb.CollectionSchema, data *storage.InsertData) error {
+	for _, fn := range schema.GetFunctions() {
+		if fn.GetType() != schemapb.FunctionType_BM25 {
+			continue
+		}
+		if err := runOne(schema, fn, data, assignBM25Output); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RunMinHash executes every MinHash function in schema over data.
+func RunMinHash(schema *schemapb.CollectionSchema, data *storage.InsertData) error {
+	for _, fn := range schema.GetFunctions() {
+		if fn.GetType() != schemapb.FunctionType_MinHash {
+			continue
+		}
+		if err := runOne(schema, fn, data, assignMinHashOutput); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RunTextEmbedding executes any non-BM25/non-MinHash functions (currently
+// TextEmbedding) via the batched function executor.
+func RunTextEmbedding(
+	ctx context.Context,
+	schema *schemapb.CollectionSchema,
+	data *storage.InsertData,
+	opts RunOptions,
+) error {
+	if !HasNonBM25AndMinHashFunctions(schema.GetFunctions(), []int64{}) {
+		return nil
+	}
+	fieldIDs := lo.Keys(lo.PickBy(data.Data, func(_ int64, fd storage.FieldData) bool {
+		return fd.RowNum() > 0
+	}))
+	needProcess, err := typeutil.GetNeedProcessFunctions(
+		fieldIDs, schema.GetFunctions(), opts.AllowNonBM25Outputs, false)
+	if err != nil {
+		return err
+	}
+	if len(needProcess) == 0 {
+		return nil
+	}
+	exec, err := NewFunctionExecutor(schema, needProcess,
+		&models.ModelExtraInfo{ClusterID: opts.ClusterID, DBName: opts.DBName})
+	if err != nil {
+		return err
+	}
+	if err := exec.ProcessBulkInsert(ctx, data); err != nil {
+		return fmt.Errorf("text embedding: %w", err)
+	}
+	return nil
+}
+
+// runOne is the shared body for BM25 and MinHash: build a runner, collect
+// inputs, BatchRun, then hand outputs to the type-specific assignFn.
+func runOne(
+	schema *schemapb.CollectionSchema,
+	fn *schemapb.FunctionSchema,
+	data *storage.InsertData,
+	assignFn func(*schemapb.CollectionSchema, *schemapb.FunctionSchema, function.FunctionRunner, []any, *storage.InsertData) error,
+) error {
+	runner, err := function.NewFunctionRunner(schema, fn)
+	if err != nil {
+		return fmt.Errorf("%s runner: %w", fn.GetType(), err)
+	}
+	if runner == nil {
+		return nil
+	}
+	defer runner.Close()
+
+	inputs := make([]any, 0, len(runner.GetInputFields()))
+	for _, f := range runner.GetInputFields() {
+		inputs = append(inputs, data.Data[f.GetFieldID()].GetDataRows())
+	}
+	outputs, err := runner.BatchRun(inputs...)
+	if err != nil {
+		return fmt.Errorf("%s execution: %w", fn.GetType(), err)
+	}
+	return assignFn(schema, fn, runner, outputs, data)
+}
+
+func assignBM25Output(
+	schema *schemapb.CollectionSchema,
+	fn *schemapb.FunctionSchema,
+	_ function.FunctionRunner,
+	outputs []any,
+	data *storage.InsertData,
+) error {
+	if len(outputs) != len(fn.GetOutputFieldIds()) {
+		return fmt.Errorf("BM25 runner output count mismatch: got %d, expected %d",
+			len(outputs), len(fn.GetOutputFieldIds()))
+	}
+	for i, outID := range fn.GetOutputFieldIds() {
+		outField := typeutil.GetField(schema, outID)
+		switch outField.GetDataType() {
+		case schemapb.DataType_FloatVector:
+			fd, ok := outputs[i].(*storage.FloatVectorFieldData)
+			if !ok {
+				return fmt.Errorf("BM25 output %d: want *FloatVectorFieldData, got %T", outID, outputs[i])
+			}
+			data.Data[outID] = fd
+		case schemapb.DataType_BFloat16Vector:
+			fd, ok := outputs[i].(*storage.BFloat16VectorFieldData)
+			if !ok {
+				return fmt.Errorf("BM25 output %d: want *BFloat16VectorFieldData, got %T", outID, outputs[i])
+			}
+			data.Data[outID] = fd
+		case schemapb.DataType_Float16Vector:
+			fd, ok := outputs[i].(*storage.Float16VectorFieldData)
+			if !ok {
+				return fmt.Errorf("BM25 output %d: want *Float16VectorFieldData, got %T", outID, outputs[i])
+			}
+			data.Data[outID] = fd
+		case schemapb.DataType_BinaryVector:
+			fd, ok := outputs[i].(*storage.BinaryVectorFieldData)
+			if !ok {
+				return fmt.Errorf("BM25 output %d: want *BinaryVectorFieldData, got %T", outID, outputs[i])
+			}
+			data.Data[outID] = fd
+		case schemapb.DataType_SparseFloatVector:
+			sparse, ok := outputs[i].(*schemapb.SparseFloatArray)
+			if !ok {
+				return fmt.Errorf("BM25 output %d: want *SparseFloatArray, got %T", outID, outputs[i])
+			}
+			data.Data[outID] = &storage.SparseFloatVectorFieldData{
+				SparseFloatArray: schemapb.SparseFloatArray{
+					Dim: sparse.GetDim(), Contents: sparse.GetContents(),
+				},
+			}
+		default:
+			return fmt.Errorf("unsupported BM25 output type %s for field %d",
+				outField.GetDataType(), outID)
+		}
+	}
+	return nil
+}
+
+func assignMinHashOutput(
+	_ *schemapb.CollectionSchema,
+	_ *schemapb.FunctionSchema,
+	runner function.FunctionRunner,
+	outputs []any,
+	data *storage.InsertData,
+) error {
+	if len(outputs) == 0 {
+		return errors.New("MinHash runner returned empty output")
+	}
+	fd, ok := outputs[0].(*schemapb.FieldData)
+	if !ok {
+		return fmt.Errorf("MinHash output 0: want *FieldData, got %T", outputs[0])
+	}
+	vec := fd.GetVectors()
+	if vec == nil {
+		return errors.New("MinHash output is not a vector field")
+	}
+	binVec := vec.GetBinaryVector()
+	if binVec == nil {
+		return errors.New("MinHash output is not a binary vector")
+	}
+	outFields := runner.GetOutputFields()
+	if len(outFields) == 0 {
+		return errors.New("MinHash runner has no output fields")
+	}
+	data.Data[outFields[0].GetFieldID()] = &storage.BinaryVectorFieldData{
+		Data: binVec, Dim: int(vec.GetDim()),
+	}
+	return nil
+}

--- a/pkg/util/typeutil/schema.go
+++ b/pkg/util/typeutil/schema.go
@@ -2264,10 +2264,6 @@ func NormalizeAndValidateExternalCollectionSchema(schema *schemapb.CollectionSch
 			schema.GetName(), schema.GetExternalSource(), schema.GetExternalSpec())
 	}
 
-	if len(schema.GetFunctions()) > 0 {
-		return fmt.Errorf("external collection %s does not support functions", schema.GetName())
-	}
-
 	if schema.GetEnableDynamicField() {
 		return fmt.Errorf("external collection %s does not support dynamic field", schema.GetName())
 	}
@@ -2280,12 +2276,20 @@ func NormalizeAndValidateExternalCollectionSchema(schema *schemapb.CollectionSch
 	// field leaves the input schema untouched.
 	externalFieldOwners := make(map[string][]*schemapb.FieldSchema)
 	for _, field := range schema.GetFields() {
-		if isExternalSystemOrVirtualField(field.GetName()) {
+		if IsExternalSystemOrVirtualField(field.GetName()) {
+			continue
+		}
+
+		// Function output fields are computed internally, skip all external-data checks.
+		if field.GetIsFunctionOutput() {
+			if field.GetExternalField() != "" {
+				return fmt.Errorf("function output field '%s' in external collection %s must not have external_field mapping", field.GetName(), schema.GetName())
+			}
 			continue
 		}
 
 		if field.GetIsPrimaryKey() {
-			return fmt.Errorf("external collection %s does not support primary key field %s", schema.GetName(), field.GetName())
+			return fmt.Errorf("external collection %s does not support user-defined primary key field %s", schema.GetName(), field.GetName())
 		}
 		if field.GetIsPartitionKey() {
 			return fmt.Errorf("external collection %s does not support partition key field %s", schema.GetName(), field.GetName())
@@ -2334,7 +2338,11 @@ func NormalizeAndValidateExternalCollectionSchema(schema *schemapb.CollectionSch
 	// Force nullable for external fields: Parquet columns can contain nulls,
 	// and a non-nullable field would silently produce incorrect results.
 	for _, field := range schema.GetFields() {
-		if isExternalSystemOrVirtualField(field.GetName()) {
+		if IsExternalSystemOrVirtualField(field.GetName()) {
+			continue
+		}
+		// Function output fields are computed internally.
+		if field.GetIsFunctionOutput() {
 			continue
 		}
 		if !field.GetNullable() {
@@ -2345,7 +2353,10 @@ func NormalizeAndValidateExternalCollectionSchema(schema *schemapb.CollectionSch
 	return nil
 }
 
-func isExternalSystemOrVirtualField(name string) bool {
+// IsExternalSystemOrVirtualField returns true for names reserved by the
+// external-table pipeline (RowID, Timestamp, VirtualPK) and never present in
+// user-provided external source data.
+func IsExternalSystemOrVirtualField(name string) bool {
 	return name == common.RowIDFieldName ||
 		name == common.TimeStampFieldName ||
 		name == common.VirtualPKFieldName

--- a/pkg/util/typeutil/schema_test.go
+++ b/pkg/util/typeutil/schema_test.go
@@ -5176,12 +5176,10 @@ func TestNormalizeAndValidateExternalCollectionSchema(t *testing.T) {
 		assert.NoError(t, NormalizeAndValidateExternalCollectionSchema(schema))
 	})
 
-	t.Run("functions disabled", func(t *testing.T) {
+	t.Run("functions allowed", func(t *testing.T) {
 		schema := buildSchema()
 		schema.Functions = []*schemapb.FunctionSchema{{Name: "test_func"}}
-		err := NormalizeAndValidateExternalCollectionSchema(schema)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "does not support functions")
+		assert.NoError(t, NormalizeAndValidateExternalCollectionSchema(schema))
 	})
 
 	t.Run("dynamic field disabled", func(t *testing.T) {

--- a/tests/go_client/testcases/external_table_function_test.go
+++ b/tests/go_client/testcases/external_table_function_test.go
@@ -1,0 +1,759 @@
+package testcases
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"hash/fnv"
+	"io"
+	"math"
+	mrand "math/rand"
+	"net"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/memory"
+	"github.com/apache/arrow/go/v17/parquet/pqarrow"
+	miniogo "github.com/minio/minio-go/v7"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/client/v2/column"
+	"github.com/milvus-io/milvus/client/v2/entity"
+	"github.com/milvus-io/milvus/client/v2/index"
+	client "github.com/milvus-io/milvus/client/v2/milvusclient"
+	"github.com/milvus-io/milvus/tests/go_client/common"
+	hp "github.com/milvus-io/milvus/tests/go_client/testcases/helper"
+)
+
+func generateTextParquetBytes(numRows int64, startID int64) ([]byte, error) {
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "text", Type: arrow.BinaryTypes.String},
+	}, nil)
+
+	var buf bytes.Buffer
+	writer, err := pqarrow.NewFileWriter(arrowSchema, &buf, nil, pqarrow.DefaultWriterProps())
+	if err != nil {
+		return nil, err
+	}
+
+	pool := memory.NewGoAllocator()
+	builder := array.NewRecordBuilder(pool, arrowSchema)
+	defer builder.Release()
+
+	texts := []string{
+		"the quick brown fox jumps over the lazy dog",
+		"a fast red fox leaps across the sleeping hound",
+		"machine learning algorithms process large datasets efficiently",
+		"deep neural networks learn complex patterns from data",
+		"natural language processing enables text understanding",
+		"vector databases store and search high dimensional embeddings",
+		"distributed systems handle concurrent requests at scale",
+		"cloud computing provides elastic infrastructure resources",
+		"search engines index documents for fast retrieval",
+		"information retrieval systems rank results by relevance",
+	}
+
+	idBuilder := builder.Field(0).(*array.Int64Builder)
+	textBuilder := builder.Field(1).(*array.StringBuilder)
+	for i := int64(0); i < numRows; i++ {
+		idBuilder.Append(startID + i)
+		textBuilder.Append(texts[i%int64(len(texts))])
+	}
+
+	record := builder.NewRecord()
+	defer record.Release()
+	if err := writer.Write(record); err != nil {
+		return nil, err
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// TestExternalTableBM25Function tests create → refresh → index → load → query → search
+// for an external table with BM25 function output field.
+func TestExternalTableBM25Function(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	minioCfg := getMinIOConfig()
+	minioClient, err := newMinIOClient(minioCfg)
+	if err != nil {
+		t.Skipf("MinIO unavailable: %v", err)
+	}
+	exists, err := minioClient.BucketExists(ctx, minioCfg.bucket)
+	if err != nil || !exists {
+		t.Skipf("MinIO bucket %q not accessible", minioCfg.bucket)
+	}
+
+	collName := common.GenRandomString("ext_bm25", 6)
+	extPath := fmt.Sprintf("external-e2e-test/%s", collName)
+
+	// Step 1: Upload text parquet to MinIO
+	const numFiles, rowsPerFile = 10, int64(3000)
+	totalRows := int64(numFiles) * rowsPerFile
+	for i := 0; i < numFiles; i++ {
+		data, err := generateTextParquetBytes(rowsPerFile, int64(i)*rowsPerFile)
+		require.NoError(t, err)
+		key := fmt.Sprintf("%s/data%d.parquet", extPath, i)
+		_, err = minioClient.PutObject(ctx, minioCfg.bucket, key,
+			bytes.NewReader(data), int64(len(data)),
+			miniogo.PutObjectOptions{ContentType: "application/octet-stream"})
+		require.NoError(t, err)
+		t.Logf("Uploaded %s (%d rows)", key, rowsPerFile)
+	}
+	t.Cleanup(func() {
+		cleanupMinIOPrefix(context.Background(), minioClient, minioCfg.bucket, extPath+"/")
+	})
+
+	// Step 2: Create external collection with PK + BM25 function
+	schema := entity.NewSchema().
+		WithName(collName).
+		WithExternalSource(extPath).
+		WithExternalSpec(`{"format":"parquet"}`).
+		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).
+			WithExternalField("id")).
+		WithField(entity.NewField().WithName("text").WithDataType(entity.FieldTypeVarChar).
+			WithMaxLength(1024).WithExternalField("text").
+			WithEnableAnalyzer(true).WithAnalyzerParams(map[string]any{"tokenizer": "standard"})).
+		WithField(entity.NewField().WithName("sparse_vec").WithDataType(entity.FieldTypeSparseVector)).
+		WithFunction(entity.NewFunction().WithName("bm25_fn").
+			WithInputFields("text").WithOutputFields("sparse_vec").WithType(entity.FunctionTypeBM25))
+
+	err = mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, true)
+	t.Logf("Created collection: %s", collName)
+	t.Cleanup(func() {
+		_ = mc.DropCollection(context.Background(), client.NewDropCollectionOption(collName))
+	})
+
+	coll, err := mc.DescribeCollection(ctx, client.NewDescribeCollectionOption(collName))
+	common.CheckErr(t, err, true)
+	require.Equal(t, extPath, coll.Schema.ExternalSource)
+	require.Len(t, coll.Schema.Functions, 1)
+
+	// Step 3: Refresh
+	refreshResult, err := mc.RefreshExternalCollection(ctx,
+		client.NewRefreshExternalCollectionOption(collName))
+	common.CheckErr(t, err, true)
+	t.Logf("Refresh job: %d", refreshResult.JobID)
+
+	deadline := time.After(180 * time.Second)
+	ticker := time.NewTicker(3 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-deadline:
+			t.Fatalf("Refresh timed out")
+		case <-ticker.C:
+			p, err := mc.GetRefreshExternalCollectionProgress(ctx,
+				client.NewGetRefreshExternalCollectionProgressOption(refreshResult.JobID))
+			require.NoError(t, err)
+			t.Logf("Refresh: state=%s", p.State)
+			if p.State == entity.RefreshStateCompleted {
+				goto refreshDone
+			}
+			if p.State == entity.RefreshStateFailed {
+				t.Fatalf("Refresh failed: %s", p.Reason)
+			}
+		}
+	}
+refreshDone:
+
+	stats, err := mc.GetCollectionStats(ctx, client.NewGetCollectionStatsOption(collName))
+	common.CheckErr(t, err, true)
+	rc, _ := strconv.ParseInt(stats["row_count"], 10, 64)
+	require.Equal(t, totalRows, rc)
+	t.Logf("Verified row count: %d", rc)
+
+	// Step 4: Create index
+	sparseIdx := index.NewSparseInvertedIndex(entity.BM25, 0.1)
+	idxTask, err := mc.CreateIndex(ctx, client.NewCreateIndexOption(collName, "sparse_vec", sparseIdx))
+	common.CheckErr(t, err, true)
+	err = idxTask.Await(ctx)
+	common.CheckErr(t, err, true)
+	t.Log("Index created")
+
+	// Step 5: Load collection
+	loadTask, err := mc.LoadCollection(ctx, client.NewLoadCollectionOption(collName))
+	common.CheckErr(t, err, true)
+	err = loadTask.Await(ctx)
+	common.CheckErr(t, err, true)
+	t.Log("Collection loaded")
+
+	// Step 6: BM25 search — each query should rank the matching text class first.
+	// Corpus repeats 10 distinct sentences, so rows where id%10 matches the
+	// queried class should dominate the top results.
+	cases := []struct {
+		query       string
+		expectedMod int64
+	}{
+		{"machine learning", 2},
+		{"vector databases", 5},
+		{"neural networks", 3},
+		{"cloud computing", 7},
+	}
+	for _, c := range cases {
+		res, err := mc.Search(ctx, client.NewSearchOption(collName, 10,
+			[]entity.Vector{entity.Text(c.query)}).
+			WithANNSField("sparse_vec").
+			WithOutputFields("id"))
+		common.CheckErr(t, err, true)
+		require.Greater(t, len(res), 0)
+		hits := res[0]
+		require.Greater(t, hits.Len(), 0, "BM25 %q must match", c.query)
+		// All top results must belong to the expected text class (id % 10).
+		idCol, ok := hits.GetColumn("id").(*column.ColumnInt64)
+		require.True(t, ok, "id column present")
+		for i := 0; i < hits.Len(); i++ {
+			require.Equal(t, c.expectedMod, idCol.Data()[i]%10,
+				"query %q hit id=%d (score=%f) should be from class %d",
+				c.query, idCol.Data()[i], hits.Scores[i], c.expectedMod)
+		}
+		t.Logf("BM25 %q → %d hits, all in class %d (top-5 ids=%v scores=%v)",
+			c.query, hits.Len(), c.expectedMod, idCol.Data()[:min(5, hits.Len())],
+			hits.Scores[:min(5, hits.Len())])
+	}
+
+	// Note: BM25 sparse_vec is intentionally not retrievable by users
+	// (CanRetrieveRawFieldData returns false for BM25 function outputs),
+	// so the take() fast path for function-output fields is exercised in
+	// the MinHash test below (mh_sig is user-visible).
+
+	t.Log("All E2E steps passed: create → refresh → index → load → search ✓")
+}
+
+// generateMinHashParquetBytes writes a parquet file with int64 id + varchar
+// doc where each row is a phrase with controlled shingle overlap, so MinHash
+// signatures give distinguishable Jaccard similarities.
+func generateMinHashParquetBytes(numRows int64, startID int64) ([]byte, error) {
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "doc", Type: arrow.BinaryTypes.String},
+	}, nil)
+	var buf bytes.Buffer
+	writer, err := pqarrow.NewFileWriter(arrowSchema, &buf, nil, pqarrow.DefaultWriterProps())
+	if err != nil {
+		return nil, err
+	}
+	pool := memory.NewGoAllocator()
+	builder := array.NewRecordBuilder(pool, arrowSchema)
+	defer builder.Release()
+
+	// 5 classes, 5 near-duplicate phrases per class → high within-class Jaccard.
+	classes := [][]string{
+		{
+			"the quick brown fox jumps over the lazy dog today",
+			"the quick brown fox jumps over the lazy dog again",
+			"a quick brown fox jumps over the lazy dog today",
+			"the quick brown fox leaps over the lazy dog today",
+			"the quick brown fox jumps over a lazy dog today",
+		},
+		{
+			"machine learning models process large datasets efficiently",
+			"machine learning models process huge datasets efficiently",
+			"machine learning systems process large datasets efficiently",
+			"machine learning models analyze large datasets efficiently",
+			"machine learning models process large datasets quickly",
+		},
+		{
+			"vector databases store and search high dimensional embeddings",
+			"vector databases index and search high dimensional embeddings",
+			"vector databases store and retrieve high dimensional embeddings",
+			"vector databases store and search dense dimensional embeddings",
+			"vector databases store and search high quality embeddings",
+		},
+		{
+			"distributed systems handle concurrent requests at massive scale",
+			"distributed systems handle parallel requests at massive scale",
+			"distributed services handle concurrent requests at massive scale",
+			"distributed systems handle concurrent queries at massive scale",
+			"distributed systems handle concurrent requests at enormous scale",
+		},
+		{
+			"natural language processing enables text understanding widely",
+			"natural language processing enables text analysis widely",
+			"natural language processing allows text understanding widely",
+			"natural language models enable text understanding widely",
+			"natural language processing enables language understanding widely",
+		},
+	}
+
+	idBuilder := builder.Field(0).(*array.Int64Builder)
+	docBuilder := builder.Field(1).(*array.StringBuilder)
+	for i := int64(0); i < numRows; i++ {
+		classIdx := i % int64(len(classes))
+		variantIdx := (i / int64(len(classes))) % int64(len(classes[classIdx]))
+		idBuilder.Append(startID + i)
+		docBuilder.Append(classes[classIdx][variantIdx])
+	}
+	record := builder.NewRecord()
+	defer record.Release()
+	if err := writer.Write(record); err != nil {
+		return nil, err
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// TestExternalTableMinHashFunction verifies MinHash function output on an
+// external collection: refresh computes the MinHash signature over the doc
+// field, index + load bring it online, and MINHASH_LSH search with the same
+// input phrase ranks same-class rows at the top.
+func TestExternalTableMinHashFunction(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	minioCfg := getMinIOConfig()
+	minioClient, err := newMinIOClient(minioCfg)
+	if err != nil {
+		t.Skipf("MinIO unavailable: %v", err)
+	}
+	exists, err := minioClient.BucketExists(ctx, minioCfg.bucket)
+	if err != nil || !exists {
+		t.Skipf("MinIO bucket %q not accessible", minioCfg.bucket)
+	}
+
+	collName := common.GenRandomString("ext_minhash", 6)
+	extPath := fmt.Sprintf("external-e2e-test/%s", collName)
+
+	const numFiles, rowsPerFile = 10, int64(3000)
+	totalRows := int64(numFiles) * rowsPerFile
+	for i := 0; i < numFiles; i++ {
+		data, err := generateMinHashParquetBytes(rowsPerFile, int64(i)*rowsPerFile)
+		require.NoError(t, err)
+		key := fmt.Sprintf("%s/data%d.parquet", extPath, i)
+		_, err = minioClient.PutObject(ctx, minioCfg.bucket, key,
+			bytes.NewReader(data), int64(len(data)),
+			miniogo.PutObjectOptions{ContentType: "application/octet-stream"})
+		require.NoError(t, err)
+	}
+	t.Cleanup(func() {
+		cleanupMinIOPrefix(context.Background(), minioClient, minioCfg.bucket, extPath+"/")
+	})
+
+	// MinHash signature vector: num_hashes=16 → dim=512, stored as BinaryVector.
+	const numHashes = 16
+	const mhDim = numHashes * 32
+
+	schema := entity.NewSchema().
+		WithName(collName).
+		WithExternalSource(extPath).
+		WithExternalSpec(`{"format":"parquet"}`).
+		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).
+			WithExternalField("id")).
+		WithField(entity.NewField().WithName("doc").WithDataType(entity.FieldTypeVarChar).
+			WithMaxLength(1024).WithExternalField("doc").
+			WithEnableAnalyzer(true).WithAnalyzerParams(map[string]any{"tokenizer": "standard"})).
+		WithField(entity.NewField().WithName("mh_sig").WithDataType(entity.FieldTypeBinaryVector).
+			WithDim(mhDim)).
+		WithFunction(entity.NewFunction().WithName("mh_fn").
+			WithInputFields("doc").WithOutputFields("mh_sig").
+			WithType(schemapb.FunctionType_MinHash).
+			WithParam("num_hashes", strconv.Itoa(numHashes)).
+			WithParam("shingle_size", "3"))
+
+	err = mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, true)
+	t.Cleanup(func() {
+		_ = mc.DropCollection(context.Background(), client.NewDropCollectionOption(collName))
+	})
+
+	// Refresh
+	refreshResult, err := mc.RefreshExternalCollection(ctx,
+		client.NewRefreshExternalCollectionOption(collName))
+	common.CheckErr(t, err, true)
+	deadline := time.After(180 * time.Second)
+	ticker := time.NewTicker(3 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-deadline:
+			t.Fatalf("Refresh timed out")
+		case <-ticker.C:
+			p, err := mc.GetRefreshExternalCollectionProgress(ctx,
+				client.NewGetRefreshExternalCollectionProgressOption(refreshResult.JobID))
+			require.NoError(t, err)
+			if p.State == entity.RefreshStateCompleted {
+				goto mhRefreshDone
+			}
+			if p.State == entity.RefreshStateFailed {
+				t.Fatalf("Refresh failed: %s", p.Reason)
+			}
+		}
+	}
+mhRefreshDone:
+
+	stats, err := mc.GetCollectionStats(ctx, client.NewGetCollectionStatsOption(collName))
+	common.CheckErr(t, err, true)
+	rc, _ := strconv.ParseInt(stats["row_count"], 10, 64)
+	require.Equal(t, totalRows, rc)
+
+	// MINHASH_LSH index with Jaccard metric and lsh_band=4.
+	mhIdx := index.NewMinHashLSHIndex(entity.JACCARD, 4).WithRawData(true)
+	idxTask, err := mc.CreateIndex(ctx, client.NewCreateIndexOption(collName, "mh_sig", mhIdx))
+	common.CheckErr(t, err, true)
+	err = idxTask.Await(ctx)
+	common.CheckErr(t, err, true)
+
+	loadTask, err := mc.LoadCollection(ctx, client.NewLoadCollectionOption(collName))
+	common.CheckErr(t, err, true)
+	err = loadTask.Await(ctx)
+	common.CheckErr(t, err, true)
+
+	// Search: pass raw text; server runs MinHash function on it to get query sig.
+	queries := []struct {
+		text        string
+		expectedMod int64
+	}{
+		{"the quick brown fox jumps over the lazy dog today", 0},
+		{"machine learning models process large datasets efficiently", 1},
+		{"vector databases store and search high dimensional embeddings", 2},
+		{"distributed systems handle concurrent requests at massive scale", 3},
+		{"natural language processing enables text understanding widely", 4},
+	}
+	for _, q := range queries {
+		res, err := mc.Search(ctx, client.NewSearchOption(collName, 10,
+			[]entity.Vector{entity.Text(q.text)}).
+			WithANNSField("mh_sig").
+			WithOutputFields("id"))
+		common.CheckErr(t, err, true)
+		require.Greater(t, len(res), 0)
+		hits := res[0]
+		require.Greater(t, hits.Len(), 0, "MinHash search %q must match", q.text)
+		idCol, ok := hits.GetColumn("id").(*column.ColumnInt64)
+		require.True(t, ok)
+		// Majority of hits must share the query's class (allow a few LSH false-positives).
+		matched := 0
+		for i := 0; i < hits.Len(); i++ {
+			if idCol.Data()[i]%int64(len(queries)) == q.expectedMod {
+				matched++
+			}
+		}
+		require.GreaterOrEqualf(t, matched, hits.Len()/2+1,
+			"MinHash %q: only %d/%d hits in class %d",
+			q.text, matched, hits.Len(), q.expectedMod)
+		t.Logf("MinHash %q → %d/%d hits in class %d", q.text, matched, hits.Len(), q.expectedMod)
+	}
+
+	// Exercise take() fast path for the MinHash signature output.
+	takeRes, err := mc.Search(ctx, client.NewSearchOption(collName, 5,
+		[]entity.Vector{entity.Text(queries[0].text)}).
+		WithANNSField("mh_sig").
+		WithOutputFields("id", "mh_sig"))
+	common.CheckErr(t, err, true)
+	require.Greater(t, len(takeRes), 0)
+	sigCol, ok := takeRes[0].GetColumn("mh_sig").(*column.ColumnBinaryVector)
+	require.True(t, ok, "mh_sig output column must be present")
+	require.Equal(t, takeRes[0].Len(), sigCol.Len())
+	require.Greater(t, len(sigCol.Data()), 0)
+	t.Logf("take() path returned %d mh_sig rows (%d bytes/row)", sigCol.Len(),
+		len(sigCol.Data()[0]))
+
+	t.Log("MinHash E2E passed: create → refresh → index → load → search ✓")
+}
+
+// generateDocParquetBytes writes a parquet file with int64 id + varchar doc,
+// where each row repeats one of N distinct phrases. Rows with the same phrase
+// share the same deterministic TEI embedding (see mockTEIEmbed), so a
+// Top-K vector search with the phrase as the query should hit rows of the
+// same class first.
+func generateDocParquetBytes(numRows int64, startID int64, phrases []string) ([]byte, error) {
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "doc", Type: arrow.BinaryTypes.String},
+	}, nil)
+	var buf bytes.Buffer
+	writer, err := pqarrow.NewFileWriter(arrowSchema, &buf, nil, pqarrow.DefaultWriterProps())
+	if err != nil {
+		return nil, err
+	}
+	pool := memory.NewGoAllocator()
+	builder := array.NewRecordBuilder(pool, arrowSchema)
+	defer builder.Release()
+
+	idBuilder := builder.Field(0).(*array.Int64Builder)
+	docBuilder := builder.Field(1).(*array.StringBuilder)
+	for i := int64(0); i < numRows; i++ {
+		idBuilder.Append(startID + i)
+		docBuilder.Append(phrases[i%int64(len(phrases))])
+	}
+	record := builder.NewRecord()
+	defer record.Release()
+	if err := writer.Write(record); err != nil {
+		return nil, err
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// mockTEIEmbed returns a deterministic, length-independent embedding for a
+// given phrase. Identical text → identical vector, so two rows with the same
+// phrase are collinear and land at distance 0 under L2.
+func mockTEIEmbed(text string, dim int) []float32 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(text))
+	seed := h.Sum64()
+	vec := make([]float32, dim)
+	rng := mrand.New(mrand.NewSource(int64(seed)))
+	var norm float64
+	for i := 0; i < dim; i++ {
+		v := rng.NormFloat64()
+		vec[i] = float32(v)
+		norm += v * v
+	}
+	norm = math.Sqrt(norm)
+	if norm == 0 {
+		norm = 1
+	}
+	for i := range vec {
+		vec[i] = float32(float64(vec[i]) / norm)
+	}
+	return vec
+}
+
+// startMockTEIServer spins up an HTTP server implementing the TEI /embed API
+// on 127.0.0.1:<random>. Returns the endpoint URL and a stop func.
+func startMockTEIServer(t *testing.T, dim int) (endpoint string, stop func()) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/embed", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method", http.StatusMethodNotAllowed)
+			return
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		defer r.Body.Close()
+		var req struct {
+			Inputs []string `json:"inputs"`
+		}
+		if err := json.Unmarshal(body, &req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		out := make([][]float32, len(req.Inputs))
+		for i, s := range req.Inputs {
+			out[i] = mockTEIEmbed(s, dim)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(out)
+	})
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	})
+
+	srv := &http.Server{Handler: mux, ReadHeaderTimeout: 10 * time.Second}
+	go func() { _ = srv.Serve(ln) }()
+
+	// Milvus runs as a native process on this host in the local E2E setup,
+	// so loopback is reachable directly. (Dockerised Milvus would need
+	// host.docker.internal on macOS or host-network on Linux.)
+	endpoint = fmt.Sprintf("http://127.0.0.1:%d", ln.Addr().(*net.TCPAddr).Port)
+	t.Logf("mock TEI listening on %s", endpoint)
+
+	stop = func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	}
+	return endpoint, stop
+}
+
+// TestExternalTableTextEmbeddingFunction verifies TextEmbedding function output
+// on an external collection: refresh streams docs through a mock TEI server to
+// compute the dense column, index + load bring it online, and a vector search
+// with the same phrase ranks rows of the same class first.
+func TestExternalTableTextEmbeddingFunction(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	minioCfg := getMinIOConfig()
+	minioClient, err := newMinIOClient(minioCfg)
+	if err != nil {
+		t.Skipf("MinIO unavailable: %v", err)
+	}
+	exists, err := minioClient.BucketExists(ctx, minioCfg.bucket)
+	if err != nil || !exists {
+		t.Skipf("MinIO bucket %q not accessible", minioCfg.bucket)
+	}
+
+	const dim = 64
+	teiEndpoint, stopTEI := startMockTEIServer(t, dim)
+	defer stopTEI()
+
+	phrases := []string{
+		"machine learning models process large datasets",
+		"vector databases store high dimensional embeddings",
+		"distributed systems handle concurrent requests",
+		"natural language processing enables text understanding",
+		"cloud computing provides elastic infrastructure",
+	}
+
+	collName := common.GenRandomString("ext_tei", 6)
+	extPath := fmt.Sprintf("external-e2e-test/%s", collName)
+
+	const numFiles, rowsPerFile = 10, int64(3000)
+	totalRows := int64(numFiles) * rowsPerFile
+	for i := 0; i < numFiles; i++ {
+		data, err := generateDocParquetBytes(rowsPerFile, int64(i)*rowsPerFile, phrases)
+		require.NoError(t, err)
+		key := fmt.Sprintf("%s/data%d.parquet", extPath, i)
+		_, err = minioClient.PutObject(ctx, minioCfg.bucket, key,
+			bytes.NewReader(data), int64(len(data)),
+			miniogo.PutObjectOptions{ContentType: "application/octet-stream"})
+		require.NoError(t, err)
+		t.Logf("Uploaded %s (%d rows)", key, rowsPerFile)
+	}
+	t.Cleanup(func() {
+		cleanupMinIOPrefix(context.Background(), minioClient, minioCfg.bucket, extPath+"/")
+	})
+
+	schema := entity.NewSchema().
+		WithName(collName).
+		WithExternalSource(extPath).
+		WithExternalSpec(`{"format":"parquet"}`).
+		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).
+			WithExternalField("id")).
+		WithField(entity.NewField().WithName("doc").WithDataType(entity.FieldTypeVarChar).
+			WithMaxLength(1024).WithExternalField("doc")).
+		WithField(entity.NewField().WithName("dense").WithDataType(entity.FieldTypeFloatVector).
+			WithDim(dim)).
+		WithFunction(entity.NewFunction().WithName("tei_fn").
+			WithInputFields("doc").WithOutputFields("dense").
+			WithType(entity.FunctionTypeTextEmbedding).
+			WithParam("provider", "TEI").
+			WithParam("endpoint", teiEndpoint))
+
+	err = mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, true)
+	t.Logf("Created collection: %s", collName)
+	t.Cleanup(func() {
+		_ = mc.DropCollection(context.Background(), client.NewDropCollectionOption(collName))
+	})
+
+	refreshResult, err := mc.RefreshExternalCollection(ctx,
+		client.NewRefreshExternalCollectionOption(collName))
+	common.CheckErr(t, err, true)
+	t.Logf("Refresh job: %d", refreshResult.JobID)
+
+	deadline := time.After(180 * time.Second)
+	ticker := time.NewTicker(3 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-deadline:
+			t.Fatalf("Refresh timed out")
+		case <-ticker.C:
+			p, err := mc.GetRefreshExternalCollectionProgress(ctx,
+				client.NewGetRefreshExternalCollectionProgressOption(refreshResult.JobID))
+			require.NoError(t, err)
+			t.Logf("Refresh: state=%s", p.State)
+			if p.State == entity.RefreshStateCompleted {
+				goto teiRefreshDone
+			}
+			if p.State == entity.RefreshStateFailed {
+				t.Fatalf("Refresh failed: %s", p.Reason)
+			}
+		}
+	}
+teiRefreshDone:
+
+	stats, err := mc.GetCollectionStats(ctx, client.NewGetCollectionStatsOption(collName))
+	common.CheckErr(t, err, true)
+	rc, _ := strconv.ParseInt(stats["row_count"], 10, 64)
+	require.Equal(t, totalRows, rc)
+	t.Logf("Verified row count: %d", rc)
+
+	idxTask, err := mc.CreateIndex(ctx, client.NewCreateIndexOption(collName, "dense",
+		index.NewFlatIndex(entity.L2)))
+	common.CheckErr(t, err, true)
+	require.NoError(t, idxTask.Await(ctx))
+	t.Log("Index created")
+
+	loadTask, err := mc.LoadCollection(ctx, client.NewLoadCollectionOption(collName))
+	common.CheckErr(t, err, true)
+	require.NoError(t, loadTask.Await(ctx))
+	t.Log("Collection loaded")
+
+	// For each class, query with its phrase and verify the top hits share
+	// class == id % len(phrases).
+	numClasses := int64(len(phrases))
+	for classID, phrase := range phrases {
+		res, err := mc.Search(ctx, client.NewSearchOption(collName, 10,
+			[]entity.Vector{entity.Text(phrase)}).
+			WithANNSField("dense").
+			WithOutputFields("id"))
+		common.CheckErr(t, err, true)
+		require.Greater(t, len(res), 0)
+		hits := res[0]
+		require.Greater(t, hits.Len(), 0)
+		idCol, ok := hits.GetColumn("id").(*column.ColumnInt64)
+		require.True(t, ok)
+		matched := 0
+		for i := 0; i < hits.Len(); i++ {
+			if idCol.Data()[i]%numClasses == int64(classID) {
+				matched++
+			}
+		}
+		// Deterministic embedding → same-class rows cluster at distance 0,
+		// so at least Top-K/classes hits must match exactly.
+		minMatched := hits.Len() / int(numClasses)
+		if minMatched < 1 {
+			minMatched = 1
+		}
+		require.GreaterOrEqualf(t, matched, minMatched,
+			"TextEmbedding %q: only %d/%d hits in class %d", phrase, matched, hits.Len(), classID)
+		t.Logf("TextEmbedding %q → %d/%d hits in class %d", phrase, matched, hits.Len(), classID)
+	}
+
+	// Exercise the take() fast path: retrieve id + dense together. Proxy
+	// issues a requery to fetch the dense vector, which exercises
+	// VirtualPKChunkedColumn GetAllChunks + take() for function output.
+	takeRes, err := mc.Search(ctx, client.NewSearchOption(collName, 5,
+		[]entity.Vector{entity.Text(phrases[0])}).
+		WithANNSField("dense").
+		WithOutputFields("id", "dense"))
+	common.CheckErr(t, err, true)
+	require.Greater(t, len(takeRes), 0)
+	denseCol, ok := takeRes[0].GetColumn("dense").(*column.ColumnFloatVector)
+	require.True(t, ok, "dense output column must be present")
+	require.Equal(t, takeRes[0].Len(), denseCol.Len())
+	require.Greater(t, len(denseCol.Data()), 0)
+	require.Equal(t, dim, len(denseCol.Data()[0]))
+	// Verify deterministic embedding: every hit for phrases[0] must carry
+	// exactly the vector mockTEIEmbed(phrases[0]).
+	expected := mockTEIEmbed(phrases[0], dim)
+	idCol := takeRes[0].GetColumn("id").(*column.ColumnInt64)
+	for i := 0; i < denseCol.Len(); i++ {
+		if idCol.Data()[i]%int64(len(phrases)) != 0 {
+			continue
+		}
+		got := denseCol.Data()[i]
+		for j := 0; j < dim; j++ {
+			require.InDelta(t, expected[j], got[j], 1e-5,
+				"row %d (id=%d) dim %d", i, idCol.Data()[i], j)
+		}
+	}
+	t.Logf("take() path returned %d dense rows (%d floats/row), values match mock TEI",
+		denseCol.Len(), len(denseCol.Data()[0]))
+
+	t.Log("TextEmbedding E2E passed: create → refresh → index → load → search ✓")
+}

--- a/tests/go_client/testcases/external_table_test.go
+++ b/tests/go_client/testcases/external_table_test.go
@@ -146,7 +146,7 @@ func TestCreateExternalCollectionWithPrimaryKey(t *testing.T) {
 
 	// Create collection should fail - external collections don't support primary key
 	err := mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
-	common.CheckErr(t, err, false, "does not support primary key")
+	common.CheckErr(t, err, false, "does not support user-defined primary key")
 }
 
 // TestCreateExternalCollectionWithDynamicField tests that creating external collection


### PR DESCRIPTION
Cherry-pick of [#49307](https://github.com/milvus-io/milvus/pull/49307) to 3.0.

pr: #49307

## Summary

Part 10 of the External Table series. Enables BM25 / MinHash / TextEmbedding function output fields on external collections.

Related: [#45881](https://github.com/milvus-io/milvus/issues/45881) (External Collection Lakehouse Integration tracking).

### Conflict resolution
- `internal/proxy/impl_test.go` — mechanical `IsPrimaryKey: true, ` removal on 11 external-collection test setup lines (3.0 baseline kept intact).

### Test Plan
- [x] Cherry-pick applies with single mechanical conflict resolved
- [x] Same UT + E2E coverage as master #49307