### PR TITLE
fix: [3.0] honor withUnserviceableShards in QueryCoord GetShardLeaders (#49305)

### DIFF
--- a/internal/querycoordv2/services_test.go
+++ b/internal/querycoordv2/services_test.go
@@ -1912,6 +1912,49 @@ func (suite *ServiceSuite) TestGetShardLeadersFailed() {
 	suite.True(errors.Is(merr.Error(resp.GetStatus()), merr.ErrCollectionNotLoaded))
 }
 
+func (suite *ServiceSuite) TestGetShardLeadersWithUnserviceableShards() {
+	suite.loadAll()
+	ctx := context.Background()
+	server := suite.server
+
+	for _, collection := range suite.collections {
+		// Mirror the state PutCollection writes during a replica-count change:
+		// Status=Loading, LoadPercentage=0, even though existing replicas still hold data.
+		suite.updateCollectionStatus(ctx, collection, querypb.LoadStatus_Loading)
+		suite.updateChannelDist(ctx, collection)
+		suite.fetchHeartbeats(time.Now())
+
+		// Strict path (WithUnserviceableShards=false) still rejects as before.
+		strictReq := &querypb.GetShardLeadersRequest{CollectionID: collection}
+		strictResp, err := server.GetShardLeaders(ctx, strictReq)
+		suite.NoError(err)
+		suite.True(errors.Is(merr.Error(strictResp.GetStatus()), merr.ErrCollectionNotFullyLoaded))
+
+		// Relaxed path (WithUnserviceableShards=true) now skips checkLoadStatus
+		// and returns the current shard leaders so the proxy can route by Serviceable.
+		relaxedReq := &querypb.GetShardLeadersRequest{
+			CollectionID:            collection,
+			WithUnserviceableShards: true,
+		}
+		relaxedResp, err := server.GetShardLeaders(ctx, relaxedReq)
+		suite.NoError(err)
+		suite.Equal(commonpb.ErrorCode_Success, relaxedResp.GetStatus().GetErrorCode())
+		suite.Len(relaxedResp.GetShards(), len(suite.channels[collection]))
+		for _, shard := range relaxedResp.GetShards() {
+			suite.Len(shard.GetServiceable(), len(shard.GetNodeIds()))
+		}
+	}
+
+	// Existence check still fires even when WithUnserviceableShards=true.
+	ghostReq := &querypb.GetShardLeadersRequest{
+		CollectionID:            -1,
+		WithUnserviceableShards: true,
+	}
+	ghostResp, err := server.GetShardLeaders(ctx, ghostReq)
+	suite.NoError(err)
+	suite.True(errors.Is(merr.Error(ghostResp.GetStatus()), merr.ErrCollectionNotLoaded))
+}
+
 func (suite *ServiceSuite) TestHandleNodeUp() {
 	suite.server.replicaObserver = observers.NewReplicaObserver(
 		suite.server.meta,

--- a/internal/querycoordv2/utils/util.go
+++ b/internal/querycoordv2/utils/util.go
@@ -135,12 +135,18 @@ func CheckSegmentDataReady(ctx context.Context, collectionID int64, distManager 
 	return nil
 }
 
-func checkLoadStatus(ctx context.Context, m *meta.Meta, collectionID int64) error {
+func checkLoadStatus(ctx context.Context, m *meta.Meta, collectionID int64, withUnserviceableShards bool) error {
 	percentage := m.CalculateLoadPercentage(ctx, collectionID)
 	if percentage < 0 {
 		err := merr.WrapErrCollectionNotLoaded(collectionID)
 		log.Ctx(ctx).Warn("failed to GetShardLeaders", zap.Error(err))
 		return err
+	}
+	// When the caller accepts unserviceable shards (e.g. proxy refreshing its
+	// shard-leader cache during replica reconfig), skip the full-load gate so
+	// the caller can route by the per-leader Serviceable flag instead.
+	if withUnserviceableShards {
+		return nil
 	}
 	collection := m.GetCollection(ctx, collectionID)
 	if collection != nil && collection.GetStatus() == querypb.LoadStatus_Loaded {
@@ -216,8 +222,7 @@ func GetShardLeaders(ctx context.Context,
 	collectionID int64,
 	withUnserviceableShards bool,
 ) ([]*querypb.ShardLeadersList, error) {
-	// skip check load status if withUnserviceableShards is true
-	if err := checkLoadStatus(ctx, m, collectionID); err != nil {
+	if err := checkLoadStatus(ctx, m, collectionID, withUnserviceableShards); err != nil {
 		return nil, err
 	}
 
@@ -255,7 +260,7 @@ func CheckCollectionsQueryable(ctx context.Context, m *meta.Meta, targetMgr meta
 // checkCollectionQueryable check all channels are watched and all segments are loaded for this collection
 func checkCollectionQueryable(ctx context.Context, m *meta.Meta, targetMgr meta.TargetManagerInterface, dist *meta.DistributionManager, nodeMgr *session.NodeManager, coll *meta.Collection) error {
 	collectionID := coll.GetCollectionID()
-	if err := checkLoadStatus(ctx, m, collectionID); err != nil {
+	if err := checkLoadStatus(ctx, m, collectionID, false); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Cherry-pick from master
pr: #49305

issue: #49304

GetShardLeaders had a comment claiming "skip check load status if withUnserviceableShards is true", but the implementation called checkLoadStatus unconditionally. During a LoadCollection replica-count change, LoadCollectionJob.Execute resets the collection's Status to Loading and LoadPercentage to 0 via PutCollection and immediately invalidates every proxy shard-leader cache. The proxy's next cache-miss refresh asks for shard leaders with WithUnserviceableShards=true so it can route by the per-leader Serviceable flag, but QueryCoord's checkLoadStatus rejects the request with ErrCollectionNotFullyLoaded, producing a collection-wide query outage that lasts until the new replica finishes loading.

Make the behavior match the comment:

- Add a withUnserviceableShards parameter to checkLoadStatus. Keep the existence check (percentage < 0 -> ErrCollectionNotLoaded) — returning an empty leader list for a collection that was never loaded would only mask the real error. Skip the fully-loaded gate when the caller accepts unserviceable shards, so the proxy can route by Serviceable.
- Pass req.WithUnserviceableShards through GetShardLeaders. Drop the stale skip-comment.
- Pass false explicitly from checkCollectionQueryable (the internal observer path must still require a fully loaded collection).
- Add TestGetShardLeadersWithUnserviceableShards covering: strict path still rejects during Status=Loading (regression); relaxed path returns leaders with Serviceable aligned to NodeIds; non-existent collection still returns ErrCollectionNotLoaded even when the relaxed flag is set.

The proxy side (internal/proxy/shardclient/manager.go, internal/proxy/shardclient/lb_policy.go) already sends WithUnserviceableShards=true and prefers serviceable nodes with a fallback to candidate nodes, so no proxy changes are needed.