### PR TITLE
test: fix InsertChecker/UpsertChecker false failures on SchemaMismatchRetryableException

### DIFF
--- a/tests/python_client/chaos/checker.py
+++ b/tests/python_client/chaos/checker.py
@@ -31,6 +31,7 @@ from pymilvus import (
     connections,
 )
 from pymilvus.bulk_writer import BulkFileType, RemoteBulkWriter
+from pymilvus.exceptions import SchemaMismatchRetryableException
 from pymilvus.client.embedding_list import EmbeddingList
 from pymilvus.milvus_client.index import IndexParams
 from utils.api_request import Error
@@ -1444,6 +1445,30 @@ class InsertChecker(Checker):
                 timeout=timeout,
             )
             return res, True
+        except SchemaMismatchRetryableException:
+            # Schema changed concurrently (AddVectorFieldChecker). The server rejected the request
+            # because the schema_timestamp in the request is stale (not a missing-field issue —
+            # new fields are always nullable). Invalidate the SDK schema cache so the next
+            # insert_rows() picks up the new schema_timestamp, then retry once.
+            log.debug("[InsertChecker] schema_timestamp stale, invalidating cache and retrying")
+            try:
+                self.milvus_client._get_connection()._invalidate_schema(self.c_name)
+            except Exception:
+                pass
+            data = cf.gen_row_data_by_schema(nb=constants.DELTA_PER_INS, schema=self.get_schema())
+            for i in range(len(data)):
+                data[i][self.int64_field_name] = int(time.time() * self.scale)
+            try:
+                res = self.milvus_client.insert(
+                    collection_name=self.c_name,
+                    data=data,
+                    partition_name=self.p_names[0] if self.p_names else None,
+                    timeout=timeout,
+                )
+                return res, True
+            except Exception as e:
+                log.info(f"insert error (retry): {e}")
+                return str(e), False
         except Exception as e:
             log.info(f"insert error: {e}")
             return str(e), False
@@ -1576,6 +1601,21 @@ class UpsertChecker(Checker):
         try:
             res = self.milvus_client.upsert(collection_name=self.c_name, data=self.data, timeout=timeout)
             return res, True
+        except SchemaMismatchRetryableException:
+            # Schema changed concurrently (AddVectorFieldChecker). Invalidate the SDK schema cache
+            # so the next upsert_rows() fetches the new schema_timestamp, then retry once.
+            log.debug("[UpsertChecker] schema_timestamp stale, invalidating cache and retrying")
+            try:
+                self.milvus_client._get_connection()._invalidate_schema(self.c_name)
+            except Exception:
+                pass
+            self.data = cf.gen_row_data_by_schema(nb=constants.DELTA_PER_INS, schema=self.get_schema())
+            try:
+                res = self.milvus_client.upsert(collection_name=self.c_name, data=self.data, timeout=timeout)
+                return res, True
+            except Exception as e:
+                log.info(f"upsert failed (retry): {e}")
+                return str(e), False
         except Exception as e:
             log.info(f"upsert failed: {e}")
             return str(e), False


### PR DESCRIPTION
## Summary

Fix false failures in `InsertChecker` and `UpsertChecker` when `AddVectorFieldChecker` runs concurrently during chaos tests.

issue: #49329

### Root Cause

When `AddVectorFieldChecker` adds a nullable vector field, the server increments the collection's schema version (`schema_timestamp`). The pymilvus SDK embeds the cached `schema_timestamp` in each insert/upsert gRPC request. If the cached value is stale, the server rejects the request with `SchemaMismatch` (error code 62), which pymilvus raises as `SchemaMismatchRetryableException`.

The data itself is always valid — new fields are always nullable, so omitting them is fine. The rejection is purely a schema version check.

### Fix

Catch `SchemaMismatchRetryableException` in both `InsertChecker.insert_entities()` and `UpsertChecker.upsert_entities()`. On catch:
1. Call `_invalidate_schema()` to flush the stale cache entry (same mechanism as pymilvus's internal `retry_on_schema_mismatch` decorator used by `upsert_rows`)
2. Regenerate row data with the refreshed schema
3. Retry the operation once

Note: `insert_rows` has no `@retry_on_schema_mismatch` decorator (unlike `upsert_rows`), so the exception always propagates and must be handled at the checker level.

### Changes

- `tests/python_client/chaos/checker.py`: add `SchemaMismatchRetryableException` import and retry-with-cache-invalidation handlers in `InsertChecker` and `UpsertChecker`

🤖 Generated with [Claude Code](https://claude.com/claude-code)