### PR TITLE
test: add missing schemaVersion arg to l0wb.BufferData calls in write_buffer_test

### DIFF
--- a/internal/flushcommon/writebuffer/write_buffer_test.go
+++ b/internal/flushcommon/writebuffer/write_buffer_test.go
@@ -360,7 +360,7 @@ func (s *WriteBufferSuite) TestEvictBuffer() {
 				},
 			},
 		}
-		err = l0wb.BufferData(nil, firstDeleteMsgs, &msgpb.MsgPosition{Timestamp: 100}, &msgpb.MsgPosition{Timestamp: 200})
+		err = l0wb.BufferData(nil, firstDeleteMsgs, &msgpb.MsgPosition{Timestamp: 100}, &msgpb.MsgPosition{Timestamp: 200}, 0)
 		s.Require().NoError(err)
 
 		evictDone := make(chan struct{})
@@ -387,7 +387,7 @@ func (s *WriteBufferSuite) TestEvictBuffer() {
 
 		bufferDataDone := make(chan error, 1)
 		go func() {
-			bufferDataDone <- l0wb.BufferData(nil, secondDeleteMsgs, &msgpb.MsgPosition{Timestamp: 300}, &msgpb.MsgPosition{Timestamp: 350})
+			bufferDataDone <- l0wb.BufferData(nil, secondDeleteMsgs, &msgpb.MsgPosition{Timestamp: 300}, &msgpb.MsgPosition{Timestamp: 350}, 0)
 		}()
 
 		select {


### PR DESCRIPTION
## Summary
- PR #48809 added a new \`schemaVersion int32\` parameter to \`l0WriteBuffer.BufferData\`.
- PR #49218 landed new tests in \`write_buffer_test.go\` after #48809 was merged, but used the old 4-arg signature.
- Result: static-check on master fails with typecheck errors for any PR that rebases onto the latest master.

## Fix
Append \`0\` as the \`schemaVersion\` argument to the two stale test call sites (lines 363 and 390).

## Test plan
- [x] \`golangci-lint run --build-tags dynamic,test ./internal/flushcommon/writebuffer/...\` passes locally
- [x] \`go vet -tags dynamic,test ./internal/flushcommon/writebuffer/...\` passes

issue: #45881