### PR TITLE
test: fix NullVectorQueryChecker false positive when UpsertChecker overwrites with null

### DIFF
--- a/tests/python_client/chaos/checker.py
+++ b/tests/python_client/chaos/checker.py
@@ -3200,10 +3200,15 @@ class NullVectorQueryChecker(Checker):
                 return res, True
             null_rows = [r for r in res if r.get(vec_field) is None]
             if null_rows:
-                return (
-                    f"{len(null_rows)}/{len(res)} rows returned null for '{vec_field}' "
-                    f"despite being queried by known non-null PKs"
-                ), False
+                # Null rows for sampled PKs can legitimately happen when UpsertChecker
+                # overwrites those rows with null vector values (nullable field). Treat
+                # as stale sample rather than data corruption, refresh, and skip.
+                self._non_null_pk_samples = self._collect_non_null_pk_samples()
+                log.debug(
+                    f"[NullVectorQueryChecker] field='{vec_field}': {len(null_rows)}/{len(res)} null rows "
+                    f"— may have been upserted with null; sample refreshed"
+                )
+                return res, True
             log.debug(
                 f"[NullVectorQueryChecker] field='{vec_field}': {len(res)}/{len(sample_pks)} non-null rows verified"
             )

--- a/tests/python_client/chaos/checker.py
+++ b/tests/python_client/chaos/checker.py
@@ -31,8 +31,8 @@ from pymilvus import (
     connections,
 )
 from pymilvus.bulk_writer import BulkFileType, RemoteBulkWriter
-from pymilvus.exceptions import SchemaMismatchRetryableException
 from pymilvus.client.embedding_list import EmbeddingList
+from pymilvus.exceptions import SchemaMismatchRetryableException
 from pymilvus.milvus_client.index import IndexParams
 from utils.api_request import Error
 from utils.util_log import test_log as log
@@ -1715,6 +1715,22 @@ class PartialUpdateChecker(Checker):
                 collection_name=self.c_name, data=self.data, partial_update=True, timeout=timeout
             )
             return res, True
+        except SchemaMismatchRetryableException:
+            # Schema changed concurrently (AddVectorFieldChecker). Invalidate the SDK schema cache
+            # so the next upsert_rows() fetches the new schema_timestamp, then retry once.
+            log.debug("[PartialUpdateChecker] schema_timestamp stale, invalidating cache and retrying")
+            try:
+                self.milvus_client._get_connection()._invalidate_schema(self.c_name)
+            except Exception:
+                pass
+            try:
+                res = self.milvus_client.upsert(
+                    collection_name=self.c_name, data=self.data, partial_update=True, timeout=timeout
+                )
+                return res, True
+            except Exception as e:
+                log.info(f"partial update failed (retry): {e}")
+                return str(e), False
         except Exception as e:
             log.info(f"error {e}")
             return str(e), False


### PR DESCRIPTION
## Summary

Fix two categories of checker false failures in concurrent chaos tests.

issue: #49329

### Fix 1: NullVectorQueryChecker false positive on null rows

When `UpsertChecker` runs concurrently on the shared collection, it can
legitimately overwrite rows with null nullable vector values (20% null
probability in `gen_row_data_by_schema`). After `_non_null_pk_samples` is
refreshed, the newly sampled PKs may include rows inserted by `UpsertChecker`
which are then overwritten with null on the next upsert cycle.

**Fix**: treat `null_rows` (like empty results) as a stale sample event — refresh
the sample and return `True`. The all-null fallback path still detects systematic
data corruption when no non-null rows can be found at all.

### Fix 2: PartialUpdateChecker false failures on SchemaMismatchRetryableException

`PartialUpdateChecker` calls `milvus_client.upsert(..., partial_update=True)` which
hits the same schema_timestamp version check as InsertChecker/UpsertChecker (already
fixed in #49330). When `AddVectorFieldChecker` adds a nullable vector field, the
server increments the schema version and rejects stale-timestamp requests.

`PartialUpdateChecker` is used by `test_single_request_operation.py`.

**Fix**: same pattern as the already-fixed checkers — catch
`SchemaMismatchRetryableException`, call `_invalidate_schema()`, retry once.

### Not fixed (don't need it)

- `InsertFreshnessChecker` / `UpsertFreshnessChecker`: no test uses them (legacy)
- `InsertFlushChecker`: no test uses it (legacy)
- `EntityTTLChecker`: uses its own collection with a fixed schema, unaffected by `AddVectorFieldChecker`
- `SnapshotRestoreChecker._do_dml_operations()`: `SchemaMismatch` already caught as `log.warning`, not counted in succ_rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)