### PR TITLE
fix: resolve 2 flaky unit tests in delegator and target observer

### DIFF
--- a/internal/querycoordv2/observers/target_observer_test.go
+++ b/internal/querycoordv2/observers/target_observer_test.go
@@ -265,17 +265,18 @@ func (suite *TargetObserverSuite) TestIncrementalUpdate_WithNewSegment() {
 	suite.broker.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(nil, nil).Maybe()
 	suite.broker.EXPECT().ListIndexes(mock.Anything, mock.Anything).Return(nil, nil).Maybe()
 
-	// Wait for observer to automatically discover the new segment
-	// The background goroutine should detect segment 13 and update NextTarget
+	// Manually trigger update so the observer discovers the new segment immediately
+	// instead of waiting for the background ticker (default interval 10s, which would
+	// make Eventually flaky when timeout < ticker interval).
+	ready, err := suite.observer.UpdateNextTarget(suite.collectionID)
+	suite.NoError(err)
+
+	// Verify the observer picked up segment 13 in NextTarget
 	suite.Eventually(func() bool {
 		return len(suite.targetMgr.GetSealedSegmentsByCollection(ctx, suite.collectionID, meta.NextTarget)) == 3 &&
 			len(suite.targetMgr.GetDmChannelsByCollection(ctx, suite.collectionID, meta.NextTarget)) == 2
 	}, 7*time.Second, 1*time.Second)
 	suite.broker.AssertExpectations(suite.T())
-
-	// Manually trigger update to ensure NextTarget is ready
-	ready, err := suite.observer.UpdateNextTarget(suite.collectionID)
-	suite.NoError(err)
 
 	// Simulate nodes loading the new segment 13
 	suite.distMgr.ChannelDistManager.Update(2, &meta.DmChannel{

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -936,8 +936,22 @@ func (s *DelegatorDataSuite) TestLoadSegments() {
 }
 
 func (s *DelegatorDataSuite) TestLoadSegmentsWithoutBloomFilter() {
+	defer func() {
+		s.workerManager.ExpectedCalls = nil
+		s.loader.ExpectedCalls = nil
+	}()
+
 	paramtable.Get().Save(paramtable.Get().CommonCfg.BloomFilterEnabled.Key, "false")
 	defer paramtable.Get().Reset(paramtable.Get().CommonCfg.BloomFilterEnabled.Key)
+
+	s.loader.EXPECT().LoadBloomFilterSet(mock.Anything, s.collectionID, mock.Anything).
+		Call.Return(func(ctx context.Context, collectionID int64, infos ...*querypb.SegmentLoadInfo) []*pkoracle.BloomFilterSet {
+		return lo.Map(infos, func(info *querypb.SegmentLoadInfo, _ int) *pkoracle.BloomFilterSet {
+			return pkoracle.NewBloomFilterSet(info.GetSegmentID(), info.GetPartitionID(), commonpb.SegmentState_Sealed)
+		})
+	}, func(ctx context.Context, collectionID int64, infos ...*querypb.SegmentLoadInfo) error {
+		return nil
+	})
 
 	workers := make(map[int64]*cluster.MockWorker)
 	worker1 := &cluster.MockWorker{}
@@ -945,34 +959,9 @@ func (s *DelegatorDataSuite) TestLoadSegmentsWithoutBloomFilter() {
 
 	worker1.EXPECT().LoadSegments(mock.Anything, mock.AnythingOfType("*querypb.LoadSegmentsRequest")).
 		Return(nil)
-	worker1.EXPECT().Delete(mock.Anything, mock.AnythingOfType("*querypb.DeleteRequest")).
-		RunAndReturn(func(ctx context.Context, req *querypb.DeleteRequest) error {
-			s.Equal(int64(100), req.GetSegmentId())
-			s.Equal(querypb.DataScope_Historical, req.GetScope())
-			s.ElementsMatch([]int64{1, 10}, req.GetPrimaryKeys().GetIntId().GetData())
-			s.ElementsMatch([]uint64{10, 10}, req.GetTimestamps())
-			return nil
-		}).Once()
 	s.workerManager.EXPECT().GetWorker(mock.Anything, mock.AnythingOfType("int64")).Call.Return(func(_ context.Context, nodeID int64) cluster.Worker {
 		return workers[nodeID]
 	}, nil)
-
-	// Mock LoadBloomFilterSet to return metadata-only stubs (BF disabled path)
-	stubCandidate := pkoracle.NewBloomFilterSet(100, 500, commonpb.SegmentState_Sealed)
-	s.loader.EXPECT().LoadBloomFilterSet(mock.Anything, mock.AnythingOfType("int64"), mock.Anything).
-		Return([]*pkoracle.BloomFilterSet{stubCandidate}, nil)
-
-	s.delegator.ProcessDelete([]*DeleteData{
-		{
-			PartitionID: 500,
-			PrimaryKeys: []storage.PrimaryKey{
-				storage.NewInt64PrimaryKey(1),
-				storage.NewInt64PrimaryKey(10),
-			},
-			Timestamps: []uint64{10, 10},
-			RowCount:   2,
-		},
-	}, 10)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -993,7 +982,7 @@ func (s *DelegatorDataSuite) TestLoadSegmentsWithoutBloomFilter() {
 		},
 	})
 
-	s.NoError(err)
+	s.Require().NoError(err)
 	sealed, _ := s.delegator.GetSegmentInfo(false)
 	s.Require().Equal(1, len(sealed))
 	s.Require().Equal(1, len(sealed[0].Segments))


### PR DESCRIPTION
## Summary

Port of #49305 (3.0 branch) to master. Fixes the same 2 flaky tests:

1. **TestIncrementalUpdate_WithNewSegment** (target_observer): The test relied on a background ticker (default 10s interval) to discover new segments, but used `Eventually` with only 7s timeout — guaranteed flaky. Fix: call `UpdateNextTarget()` before `Eventually` to trigger discovery immediately.

2. **TestLoadSegmentsWithoutBloomFilter** (delegator_data): Mock expectations leaked from prior tests in the suite, and a hardcoded `LoadBloomFilterSet` stub didn't match actual segment info. Fix: clear `ExpectedCalls` on teardown, use dynamic mock that returns stubs matching actual input, remove unrelated `ProcessDelete`/`Delete` assertions, use `Require().NoError` for fail-fast.

pr: #49305

## Test plan
- [x] Verified changes are identical to the 3.0 fix (#49305)
- [ ] CI passes for `go test ./internal/querycoordv2/observers/...` and `go test ./internal/querynodev2/delegator/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)