### PR TITLE
test: [cp3.0] fix chaos checker false failures and update snapshot API

### DIFF
--- a/tests/python_client/base/client_v2_base.py
+++ b/tests/python_client/base/client_v2_base.py
@@ -1149,27 +1149,32 @@ class TestMilvusClientV2Base(Base):
                         timeout=None, check_task=None, check_items=None, **kwargs):
         """Create a snapshot for a collection.
 
-        Note: Parameter order follows SDK convention - collection_name first, then snapshot_name.
+        Note: wrapper keeps ``collection_name`` before ``snapshot_name`` for test
+        readability, but the SDK signature is ``create_snapshot(snapshot_name,
+        collection_name, ...)`` so we forward positionals in SDK order.
         """
         timeout = TIMEOUT if timeout is None else timeout
         kwargs.update({"timeout": timeout})
 
         func_name = sys._getframe().f_code.co_name
-        res, check = api_request([client.create_snapshot, collection_name, snapshot_name, description], **kwargs)
+        res, check = api_request([client.create_snapshot, snapshot_name, collection_name],
+                                 description=description, **kwargs)
         check_result = ResponseChecker(res, func_name, check_task, check_items, check,
                                        snapshot_name=snapshot_name, collection_name=collection_name,
                                        **kwargs).run()
         return res, check_result
 
     @trace()
-    def drop_snapshot(self, client, snapshot_name, timeout=None, check_task=None, check_items=None, **kwargs):
+    def drop_snapshot(self, client, snapshot_name, collection_name,
+                      timeout=None, check_task=None, check_items=None, **kwargs):
         timeout = TIMEOUT if timeout is None else timeout
         kwargs.update({"timeout": timeout})
 
         func_name = sys._getframe().f_code.co_name
-        res, check = api_request([client.drop_snapshot, snapshot_name], **kwargs)
+        res, check = api_request([client.drop_snapshot, snapshot_name, collection_name], **kwargs)
         check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       snapshot_name=snapshot_name, **kwargs).run()
+                                       snapshot_name=snapshot_name, collection_name=collection_name,
+                                       **kwargs).run()
         return res, check_result
 
     @trace()
@@ -1184,26 +1189,37 @@ class TestMilvusClientV2Base(Base):
         return res, check_result
 
     @trace()
-    def describe_snapshot(self, client, snapshot_name, timeout=None, check_task=None, check_items=None, **kwargs):
+    def describe_snapshot(self, client, snapshot_name, collection_name,
+                          timeout=None, check_task=None, check_items=None, **kwargs):
         timeout = TIMEOUT if timeout is None else timeout
         kwargs.update({"timeout": timeout})
 
         func_name = sys._getframe().f_code.co_name
-        res, check = api_request([client.describe_snapshot, snapshot_name], **kwargs)
+        res, check = api_request([client.describe_snapshot, snapshot_name, collection_name], **kwargs)
         check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       snapshot_name=snapshot_name, **kwargs).run()
+                                       snapshot_name=snapshot_name, collection_name=collection_name,
+                                       **kwargs).run()
         return res, check_result
 
     @trace()
-    def restore_snapshot(self, client, snapshot_name, collection_name,
+    def restore_snapshot(self, client, snapshot_name, target_collection_name,
+                         source_collection_name="",
                          timeout=None, check_task=None, check_items=None, **kwargs):
+        """Restore a snapshot into a new collection.
+
+        SDK positional order is ``(snapshot_name, source_collection_name,
+        target_collection_name)`` and ``source_collection_name`` is now required.
+        """
         timeout = TIMEOUT if timeout is None else timeout
         kwargs.update({"timeout": timeout})
 
         func_name = sys._getframe().f_code.co_name
-        res, check = api_request([client.restore_snapshot, snapshot_name, collection_name], **kwargs)
+        res, check = api_request([client.restore_snapshot, snapshot_name,
+                                  source_collection_name, target_collection_name], **kwargs)
         check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       snapshot_name=snapshot_name, collection_name=collection_name,
+                                       snapshot_name=snapshot_name,
+                                       target_collection_name=target_collection_name,
+                                       source_collection_name=source_collection_name,
                                        **kwargs).run()
         return res, check_result
 

--- a/tests/python_client/chaos/checker.py
+++ b/tests/python_client/chaos/checker.py
@@ -1,32 +1,41 @@
+import functools
+import json
 import math
-import pytest
-import unittest
-from enum import Enum
 import random
 import re
-import time
 import threading
+import time
+import unittest
 import uuid
-import json
-import pandas as pd
-from datetime import datetime, timezone
-from prettytable import PrettyTable
-import functools
 from collections import Counter
+from datetime import datetime, timezone
+from enum import Enum
 from time import sleep
-from pymilvus import AnnSearchRequest, RRFRanker, MilvusClient, DataType, CollectionSchema, connections, LexicalHighlighter
-from pymilvus.milvus_client.index import IndexParams
-from pymilvus.bulk_writer import RemoteBulkWriter, BulkFileType
-from pymilvus.client.embedding_list import EmbeddingList
+
+import pandas as pd
+import pytest
+from chaos import constants
 from common import common_func as cf
 from common import common_type as ct
-from common.milvus_sys import MilvusSys
-from chaos import constants
-from faker import Faker
-
 from common.common_type import CheckTasks
-from utils.util_log import test_log as log
+from common.milvus_sys import MilvusSys
+from faker import Faker
+from prettytable import PrettyTable
+from pymilvus import (
+    AnnSearchRequest,
+    CollectionSchema,
+    DataType,
+    LexicalHighlighter,
+    MilvusClient,
+    RRFRanker,
+    connections,
+)
+from pymilvus.bulk_writer import BulkFileType, RemoteBulkWriter
+from pymilvus.client.embedding_list import EmbeddingList
+from pymilvus.exceptions import SchemaMismatchRetryableException
+from pymilvus.milvus_client.index import IndexParams
 from utils.api_request import Error
+from utils.util_log import test_log as log
 
 event_lock = threading.Lock()
 request_lock = threading.Lock()
@@ -34,7 +43,7 @@ request_lock = threading.Lock()
 
 def get_chaos_info():
     try:
-        with open(constants.CHAOS_INFO_SAVE_PATH, 'r') as f:
+        with open(constants.CHAOS_INFO_SAVE_PATH) as f:
             chaos_info = json.load(f)
     except Exception as e:
         log.warning(f"get_chaos_info error: {e}")
@@ -52,27 +61,22 @@ class Singleton(type):
 
 
 class EventRecords(metaclass=Singleton):
-
     def __init__(self):
         self.file_name = f"/tmp/ci_logs/event_records_{uuid.uuid4()}.jsonl"
 
     def insert(self, event_name, event_status, ts=None):
         log.info(f"insert event: {event_name}, {event_status}")
-        insert_ts = datetime.fromtimestamp(time.time()).strftime('%Y-%m-%d %H:%M:%S.%f') if ts is None else ts
-        data = {
-            "event_name": event_name,
-            "event_status": event_status,
-            "event_ts": insert_ts
-        }
+        insert_ts = datetime.fromtimestamp(time.time()).strftime("%Y-%m-%d %H:%M:%S.%f") if ts is None else ts
+        data = {"event_name": event_name, "event_status": event_status, "event_ts": insert_ts}
         with event_lock:
-            with open(self.file_name, 'a') as f:
-                f.write(json.dumps(data) + '\n')
+            with open(self.file_name, "a") as f:
+                f.write(json.dumps(data) + "\n")
 
     def get_records_df(self):
         with event_lock:
             try:
                 records = []
-                with open(self.file_name, 'r') as f:
+                with open(self.file_name) as f:
                     for line in f:
                         line = line.strip()
                         if line:
@@ -88,7 +92,6 @@ class EventRecords(metaclass=Singleton):
 
 
 class RequestRecords(metaclass=Singleton):
-
     def __init__(self):
         self.file_name = f"/tmp/ci_logs/request_records_{uuid.uuid4()}.jsonl"
         self.buffer = []
@@ -99,7 +102,7 @@ class RequestRecords(metaclass=Singleton):
             "collection_name": collection_name,
             "start_time": start_time,
             "time_cost": time_cost,
-            "result": result
+            "result": result,
         }
         with request_lock:
             self.buffer.append(data)
@@ -110,9 +113,9 @@ class RequestRecords(metaclass=Singleton):
         if not self.buffer:
             return
         try:
-            with open(self.file_name, 'a') as f:
+            with open(self.file_name, "a") as f:
                 for record in self.buffer:
-                    f.write(json.dumps(record) + '\n')
+                    f.write(json.dumps(record) + "\n")
             self.buffer = []
         except Exception as e:
             log.error(f"RequestRecords flush error: {e}")
@@ -126,13 +129,15 @@ class RequestRecords(metaclass=Singleton):
         with request_lock:
             try:
                 records = []
-                with open(self.file_name, 'r') as f:
+                with open(self.file_name) as f:
                     for line in f:
                         line = line.strip()
                         if line:
                             records.append(json.loads(line))
                 if not records:
-                    return pd.DataFrame(columns=["operation_name", "collection_name", "start_time", "time_cost", "result"])
+                    return pd.DataFrame(
+                        columns=["operation_name", "collection_name", "start_time", "time_cost", "result"]
+                    )
                 return pd.DataFrame(records)
             except FileNotFoundError:
                 return pd.DataFrame(columns=["operation_name", "collection_name", "start_time", "time_cost", "result"])
@@ -142,52 +147,60 @@ class RequestRecords(metaclass=Singleton):
 
 
 class ResultAnalyzer:
-
     def __init__(self):
         rr = RequestRecords()
         df = rr.get_records_df()
         df["start_time"] = pd.to_datetime(df["start_time"])
-        df = df.sort_values(by='start_time')
+        df = df.sort_values(by="start_time")
         self.df = df
         self.chaos_info = get_chaos_info()
-        self.chaos_start_time = self.chaos_info['create_time'] if self.chaos_info is not None else None
-        self.chaos_end_time = self.chaos_info['delete_time'] if self.chaos_info is not None else None
-        self.recovery_time = self.chaos_info['recovery_time'] if self.chaos_info is not None else None
+        self.chaos_start_time = self.chaos_info["create_time"] if self.chaos_info is not None else None
+        self.chaos_end_time = self.chaos_info["delete_time"] if self.chaos_info is not None else None
+        self.recovery_time = self.chaos_info["recovery_time"] if self.chaos_info is not None else None
 
     def get_stage_success_rate(self):
         df = self.df
         window = pd.offsets.Milli(1000)
 
-        result = df.groupby([pd.Grouper(key='start_time', freq=window), 'operation_name']).apply(lambda x: pd.Series({
-            'success_count': x[x['result'] == 'True'].shape[0],
-            'failed_count': x[x['result'] == 'False'].shape[0]
-        }))
+        result = df.groupby([pd.Grouper(key="start_time", freq=window), "operation_name"]).apply(
+            lambda x: pd.Series(
+                {"success_count": x[x["result"] == "True"].shape[0], "failed_count": x[x["result"] == "False"].shape[0]}
+            )
+        )
         data = result.reset_index()
-        data['success_rate'] = data['success_count'] / (data['success_count'] + data['failed_count']).replace(0, 1)
-        grouped_data = data.groupby('operation_name')
+        data["success_rate"] = data["success_count"] / (data["success_count"] + data["failed_count"]).replace(0, 1)
+        grouped_data = data.groupby("operation_name")
         if self.chaos_info is None:
-            chaos_start_time = datetime.fromtimestamp(time.time()).strftime('%Y-%m-%d %H:%M:%S.%f')
-            chaos_end_time = datetime.fromtimestamp(time.time()).strftime('%Y-%m-%d %H:%M:%S.%f')
-            recovery_time = datetime.fromtimestamp(time.time()).strftime('%Y-%m-%d %H:%M:%S.%f')
+            chaos_start_time = datetime.fromtimestamp(time.time()).strftime("%Y-%m-%d %H:%M:%S.%f")
+            chaos_end_time = datetime.fromtimestamp(time.time()).strftime("%Y-%m-%d %H:%M:%S.%f")
+            recovery_time = datetime.fromtimestamp(time.time()).strftime("%Y-%m-%d %H:%M:%S.%f")
         else:
-            chaos_start_time = self.chaos_info['create_time']
-            chaos_end_time = self.chaos_info['delete_time']
-            recovery_time = self.chaos_info['recovery_time']
+            chaos_start_time = self.chaos_info["create_time"]
+            chaos_end_time = self.chaos_info["delete_time"]
+            recovery_time = self.chaos_info["recovery_time"]
         stage_success_rate = {}
         for name, group in grouped_data:
             log.info(f"operation_name: {name}")
             # spilt data to 3 parts by chaos start time and chaos end time and aggregate the success rate
-            data_before_chaos = group[group['start_time'] < chaos_start_time].agg(
-                {'success_rate': 'mean', 'failed_count': 'sum', 'success_count': 'sum'})
+            data_before_chaos = group[group["start_time"] < chaos_start_time].agg(
+                {"success_rate": "mean", "failed_count": "sum", "success_count": "sum"}
+            )
             data_during_chaos = group[
-                (group['start_time'] >= chaos_start_time) & (group['start_time'] <= chaos_end_time)].agg(
-                {'success_rate': 'mean', 'failed_count': 'sum', 'success_count': 'sum'})
-            data_after_chaos = group[group['start_time'] > recovery_time].agg(
-                {'success_rate': 'mean', 'failed_count': 'sum', 'success_count': 'sum'})
+                (group["start_time"] >= chaos_start_time) & (group["start_time"] <= chaos_end_time)
+            ].agg({"success_rate": "mean", "failed_count": "sum", "success_count": "sum"})
+            data_after_chaos = group[group["start_time"] > recovery_time].agg(
+                {"success_rate": "mean", "failed_count": "sum", "success_count": "sum"}
+            )
             stage_success_rate[name] = {
-                'before_chaos': f"{data_before_chaos['success_rate']}({data_before_chaos['success_count']}/{data_before_chaos['success_count'] + data_before_chaos['failed_count']})" if not data_before_chaos.empty else "no data",
-                'during_chaos': f"{data_during_chaos['success_rate']}({data_during_chaos['success_count']}/{data_during_chaos['success_count'] + data_during_chaos['failed_count']})" if not data_during_chaos.empty else "no data",
-                'after_chaos': f"{data_after_chaos['success_rate']}({data_after_chaos['success_count']}/{data_after_chaos['success_count'] + data_after_chaos['failed_count']})" if not data_after_chaos.empty else "no data",
+                "before_chaos": f"{data_before_chaos['success_rate']}({data_before_chaos['success_count']}/{data_before_chaos['success_count'] + data_before_chaos['failed_count']})"
+                if not data_before_chaos.empty
+                else "no data",
+                "during_chaos": f"{data_during_chaos['success_rate']}({data_during_chaos['success_count']}/{data_during_chaos['success_count'] + data_during_chaos['failed_count']})"
+                if not data_during_chaos.empty
+                else "no data",
+                "after_chaos": f"{data_after_chaos['success_rate']}({data_after_chaos['success_count']}/{data_after_chaos['success_count'] + data_after_chaos['failed_count']})"
+                if not data_after_chaos.empty
+                else "no data",
             }
         log.info(f"stage_success_rate: {stage_success_rate}")
         return stage_success_rate
@@ -195,76 +208,80 @@ class ResultAnalyzer:
     def get_realtime_success_rate(self, interval=10):
         df = self.df
         window = pd.offsets.Second(interval)
-        result = df.groupby([pd.Grouper(key='start_time', freq=window), 'operation_name']).apply(lambda x: pd.Series({
-            'success_count': x[x['result'] == 'True'].shape[0],
-            'failed_count': x[x['result'] == 'False'].shape[0]
-        }))
+        result = df.groupby([pd.Grouper(key="start_time", freq=window), "operation_name"]).apply(
+            lambda x: pd.Series(
+                {"success_count": x[x["result"] == "True"].shape[0], "failed_count": x[x["result"] == "False"].shape[0]}
+            )
+        )
         data = result.reset_index()
-        data['success_rate'] = data['success_count'] / (data['success_count'] + data['failed_count']).replace(0, 1)
-        grouped_data = data.groupby('operation_name')
+        data["success_rate"] = data["success_count"] / (data["success_count"] + data["failed_count"]).replace(0, 1)
+        grouped_data = data.groupby("operation_name")
         return grouped_data
 
     def show_result_table(self):
         table = PrettyTable()
-        table.field_names = ['operation_name', 'before_chaos',
-                             f'during_chaos: {self.chaos_start_time}~{self.recovery_time}',
-                             'after_chaos']
+        table.field_names = [
+            "operation_name",
+            "before_chaos",
+            f"during_chaos: {self.chaos_start_time}~{self.recovery_time}",
+            "after_chaos",
+        ]
         data = self.get_stage_success_rate()
         for operation, values in data.items():
-            row = [operation, values['before_chaos'], values['during_chaos'], values['after_chaos']]
+            row = [operation, values["before_chaos"], values["during_chaos"], values["after_chaos"]]
             table.add_row(row)
         log.info(f"succ rate for operations in different stage\n{table}")
 
 
 class Op(Enum):
-    create = 'create'  # short name for create collection
-    create_db = 'create_db'
-    create_collection = 'create_collection'
-    create_partition = 'create_partition'
-    insert = 'insert'
-    insert_freshness = 'insert_freshness'
-    upsert = 'upsert'
-    upsert_freshness = 'upsert_freshness'
-    partial_update = 'partial_update'
-    flush = 'flush'
-    index = 'index'
-    create_index = 'create_index'
-    drop_index = 'drop_index'
-    load = 'load'
-    load_collection = 'load_collection'
-    load_partition = 'load_partition'
-    release = 'release'
-    release_collection = 'release_collection'
-    release_partition = 'release_partition'
-    search = 'search'
-    tensor_search = 'tensor_search'
-    full_text_search = 'full_text_search'
-    minhash_search = 'minhash_search'
-    hybrid_search = 'hybrid_search'
-    query = 'query'
-    text_match = 'text_match'
-    phrase_match = 'phrase_match'
-    json_query = 'json_query'
-    geo_query = 'geo_query'
-    delete = 'delete'
-    delete_freshness = 'delete_freshness'
-    compact = 'compact'
-    drop = 'drop'  # short name for drop collection
-    drop_db = 'drop_db'
-    drop_collection = 'drop_collection'
-    drop_partition = 'drop_partition'
-    load_balance = 'load_balance'
-    bulk_insert = 'bulk_insert'
-    alter_collection = 'alter_collection'
-    add_field = 'add_field'
-    add_vector_field = 'add_vector_field'
-    null_vector_search = 'null_vector_search'
-    null_vector_query = 'null_vector_query'
-    rename_collection = 'rename_collection'
-    snapshot = 'snapshot'
-    restore_snapshot = 'restore_snapshot'
-    entity_ttl = 'entity_ttl'
-    unknown = 'unknown'
+    create = "create"  # short name for create collection
+    create_db = "create_db"
+    create_collection = "create_collection"
+    create_partition = "create_partition"
+    insert = "insert"
+    insert_freshness = "insert_freshness"
+    upsert = "upsert"
+    upsert_freshness = "upsert_freshness"
+    partial_update = "partial_update"
+    flush = "flush"
+    index = "index"
+    create_index = "create_index"
+    drop_index = "drop_index"
+    load = "load"
+    load_collection = "load_collection"
+    load_partition = "load_partition"
+    release = "release"
+    release_collection = "release_collection"
+    release_partition = "release_partition"
+    search = "search"
+    tensor_search = "tensor_search"
+    full_text_search = "full_text_search"
+    minhash_search = "minhash_search"
+    hybrid_search = "hybrid_search"
+    query = "query"
+    text_match = "text_match"
+    phrase_match = "phrase_match"
+    json_query = "json_query"
+    geo_query = "geo_query"
+    delete = "delete"
+    delete_freshness = "delete_freshness"
+    compact = "compact"
+    drop = "drop"  # short name for drop collection
+    drop_db = "drop_db"
+    drop_collection = "drop_collection"
+    drop_partition = "drop_partition"
+    load_balance = "load_balance"
+    bulk_insert = "bulk_insert"
+    alter_collection = "alter_collection"
+    add_field = "add_field"
+    add_vector_field = "add_vector_field"
+    null_vector_search = "null_vector_search"
+    null_vector_query = "null_vector_query"
+    rename_collection = "rename_collection"
+    snapshot = "snapshot"
+    restore_snapshot = "restore_snapshot"
+    entity_ttl = "entity_ttl"
+    unknown = "unknown"
 
 
 timeout = 120
@@ -272,7 +289,7 @@ search_timeout = 10
 query_timeout = 10
 
 enable_traceback = False
-DEFAULT_FMT = '[start time:{start_time}][time cost:{elapsed:0.8f}s][operation_name:{operation_name}][collection name:{collection_name}] -> {result!r}'
+DEFAULT_FMT = "[start time:{start_time}][time cost:{elapsed:0.8f}s][operation_name:{operation_name}][collection name:{collection_name}] -> {result!r}"
 
 request_records = RequestRecords()
 
@@ -296,28 +313,28 @@ def normalize_error_message(error_msg):
     messages = re.findall(r'message[=:]\s*["\']?([^"\'>,\)]+)', msg, re.IGNORECASE)
     if messages:
         # Combine all message content and keep only letters and spaces
-        combined = ' '.join(messages)
-        combined = re.sub(r'[^a-zA-Z\s]', ' ', combined)
-        combined = re.sub(r'\s+', ' ', combined).strip()
+        combined = " ".join(messages)
+        combined = re.sub(r"[^a-zA-Z\s]", " ", combined)
+        combined = re.sub(r"\s+", " ", combined).strip()
         return combined
     # Fallback: extract text from details= if no message found
     details = re.findall(r'details\s*=\s*"([^"]+)"', msg)
     if details:
-        combined = ' '.join(details)
-        combined = re.sub(r'[^a-zA-Z\s]', ' ', combined)
-        combined = re.sub(r'\s+', ' ', combined).strip()
+        combined = " ".join(details)
+        combined = re.sub(r"[^a-zA-Z\s]", " ", combined)
+        combined = re.sub(r"\s+", " ", combined).strip()
         return combined
     # Last fallback: keep only letters from entire message
-    msg = re.sub(r'[^a-zA-Z\s]', ' ', msg)
-    msg = re.sub(r'\s+', ' ', msg).strip()
+    msg = re.sub(r"[^a-zA-Z\s]", " ", msg)
+    msg = re.sub(r"\s+", " ", msg).strip()
     return msg
 
 
-def trace(fmt=DEFAULT_FMT, prefix='test', flag=True):
+def trace(fmt=DEFAULT_FMT, prefix="test", flag=True):
     def decorate(func):
         @functools.wraps(func)
         def inner_wrapper(self, *args, **kwargs):
-            start_time = datetime.fromtimestamp(time.time()).strftime('%Y-%m-%d %H:%M:%S.%f')
+            start_time = datetime.fromtimestamp(time.time()).strftime("%Y-%m-%d %H:%M:%S.%f")
             start_time_ts = time.time()
             t0 = time.perf_counter()
             res, result = func(self, *args, **kwargs)
@@ -337,18 +354,20 @@ def trace(fmt=DEFAULT_FMT, prefix='test', flag=True):
                 log.debug(log_str)
             if result:
                 self.rsp_times.append(elapsed)
-                self.average_time = (
-                                            elapsed + self.average_time * self._succ) / (self._succ + 1)
+                self.average_time = (elapsed + self.average_time * self._succ) / (self._succ + 1)
                 self._succ += 1
                 # add first success record if there is no success record before
-                if len(self.fail_records) > 0 and self.fail_records[-1][0] == "failure" and \
-                        self._succ + self._fail == self.fail_records[-1][1] + 1:
+                if (
+                    len(self.fail_records) > 0
+                    and self.fail_records[-1][0] == "failure"
+                    and self._succ + self._fail == self.fail_records[-1][1] + 1
+                ):
                     self.fail_records.append(("success", self._succ + self._fail, start_time, start_time_ts))
             else:
                 self._fail += 1
                 self.fail_records.append(("failure", self._succ + self._fail, start_time, start_time_ts))
                 # Collect unique error messages (normalized to group similar errors)
-                if hasattr(res, 'message'):
+                if hasattr(res, "message"):
                     normalized_msg = normalize_error_message(res.message)
                 elif res is not None:
                     normalized_msg = normalize_error_message(str(res))
@@ -370,13 +389,13 @@ def exception_handler():
             function_name = None
             try:
                 function_name = func.__name__
-                class_name = getattr(self, '__class__', None).__name__ if self else None
+                class_name = getattr(self, "__class__", None).__name__ if self else None
                 res, result = func(self, *args, **kwargs)
                 return res, result
             except Exception as e:
                 log_row_length = 300
                 e_str = str(e)
-                log_e = e_str[0:log_row_length] + '......' if len(e_str) > log_row_length else e_str
+                log_e = e_str[0:log_row_length] + "......" if len(e_str) > log_row_length else e_str
                 if class_name:
                     log_message = f"Error in {class_name}.{function_name}: {log_e}"
                 else:
@@ -397,8 +416,17 @@ class Checker:
        b. count operations and success rate
     """
 
-    def __init__(self, collection_name=None, partition_name=None, shards_num=2, dim=8, insert_data=True,
-                 schema=None, replica_number=0, **kwargs):
+    def __init__(
+        self,
+        collection_name=None,
+        partition_name=None,
+        shards_num=2,
+        dim=8,
+        insert_data=True,
+        schema=None,
+        replica_number=0,
+        **kwargs,
+    ):
         self.recovery_time = 0
         self._succ = 0
         self._fail = 0
@@ -407,7 +435,7 @@ class Checker:
         self._keep_running = True
         self.rsp_times = []
         self.average_time = 0
-        self.scale = 1 * 10 ** 6
+        self.scale = 1 * 10**6
         self.files = []
         self.word_freq = Counter()
         self.ms = MilvusSys()
@@ -427,13 +455,8 @@ class Checker:
 
         # Also create a connection for low-level APIs that MilvusClient doesn't support
         self.alias = cf.gen_unique_str("checker_alias_")
-        connections.connect(
-            alias=self.alias,
-            uri=uri,
-            token=token
-        )
-        c_name = collection_name if collection_name is not None else cf.gen_unique_str(
-            'Checker_')
+        connections.connect(alias=self.alias, uri=uri, token=token)
+        c_name = collection_name if collection_name is not None else cf.gen_unique_str("Checker_")
         self.c_name = c_name
         p_name = partition_name if partition_name is not None else "_default"
         self.p_name = p_name
@@ -446,7 +469,15 @@ class Checker:
         else:
             enable_struct_array_field = kwargs.get("enable_struct_array_field", True)
             enable_dynamic_field = kwargs.get("enable_dynamic_field", True)
-            schema = cf.gen_all_datatype_collection_schema(dim=dim, enable_struct_array_field=enable_struct_array_field, enable_dynamic_field=enable_dynamic_field) if schema is None else schema
+            schema = (
+                cf.gen_all_datatype_collection_schema(
+                    dim=dim,
+                    enable_struct_array_field=enable_struct_array_field,
+                    enable_dynamic_field=enable_dynamic_field,
+                )
+                if schema is None
+                else schema
+            )
 
         log.debug(f"schema: {schema}")
         self.schema = schema
@@ -463,7 +494,7 @@ class Checker:
                 schema=schema,
                 shards_num=shards_num,
                 consistency_level="Strong",
-                timeout=timeout
+                timeout=timeout,
             )
         self.scalar_field_names = cf.get_scalar_field_name_list(schema=schema)
         self.json_field_names = cf.get_json_field_name_list(schema=schema)
@@ -475,7 +506,9 @@ class Checker:
         self.minhash_field_names = cf.get_minhash_vec_field_name_list(schema=schema)
         self.emb_list_field_names = cf.get_emb_list_field_name_list(schema=schema)
         # Exclude minhash output fields from binary vector fields (they need MINHASH_LSH index)
-        self.binary_vector_field_names = [f for f in self.binary_vector_field_names if f not in self.minhash_field_names]
+        self.binary_vector_field_names = [
+            f for f in self.binary_vector_field_names if f not in self.minhash_field_names
+        ]
 
         # Get existing indexes and their fields
         indexed_fields = set()
@@ -484,8 +517,8 @@ class Checker:
             for idx_name in index_names:
                 try:
                     idx_info = self.milvus_client.describe_index(c_name, idx_name)
-                    if 'field_name' in idx_info:
-                        indexed_fields.add(idx_info['field_name'])
+                    if "field_name" in idx_info:
+                        indexed_fields.add(idx_info["field_name"])
                 except Exception as e:
                     log.debug(f"Failed to describe index {idx_name}: {e}")
         except Exception as e:
@@ -500,11 +533,7 @@ class Checker:
             try:
                 index_params = IndexParams()
                 index_params.add_index(field_name=f, index_type="INVERTED")
-                self.milvus_client.create_index(
-                    collection_name=c_name,
-                    index_params=index_params,
-                    timeout=timeout
-                )
+                self.milvus_client.create_index(collection_name=c_name, index_params=index_params, timeout=timeout)
             except Exception as e:
                 log.debug(f"Failed to create index for {f}: {e}")
 
@@ -518,13 +547,9 @@ class Checker:
                     index_params.add_index(
                         field_name=f,
                         index_type="INVERTED",
-                        params={"json_path": f"{f}['{json_path}']", "json_cast_type": json_cast}
+                        params={"json_path": f"{f}['{json_path}']", "json_cast_type": json_cast},
                     )
-                    self.milvus_client.create_index(
-                        collection_name=c_name,
-                        index_params=index_params,
-                        timeout=timeout
-                    )
+                    self.milvus_client.create_index(collection_name=c_name, index_params=index_params, timeout=timeout)
                 except Exception as e:
                     log.debug(f"Failed to create json index for {f}['{json_path}']: {e}")
 
@@ -535,11 +560,7 @@ class Checker:
             try:
                 index_params = IndexParams()
                 index_params.add_index(field_name=f, index_type="RTREE")
-                self.milvus_client.create_index(
-                    collection_name=c_name,
-                    index_params=index_params,
-                    timeout=timeout
-                )
+                self.milvus_client.create_index(collection_name=c_name, index_params=index_params, timeout=timeout)
             except Exception as e:
                 log.debug(f"Failed to create index for {f}: {e}")
 
@@ -552,11 +573,7 @@ class Checker:
                 continue
             try:
                 index_params = create_index_params_from_dict(f, constants.DEFAULT_INDEX_PARAM)
-                self.milvus_client.create_index(
-                    collection_name=c_name,
-                    index_params=index_params,
-                    timeout=timeout
-                )
+                self.milvus_client.create_index(collection_name=c_name, index_params=index_params, timeout=timeout)
                 log.debug(f"Created index for float vector field {f}")
                 indexed_fields.add(f)
                 vector_index_created = True
@@ -571,11 +588,7 @@ class Checker:
                 continue
             try:
                 index_params = create_index_params_from_dict(f, constants.DEFAULT_INT8_INDEX_PARAM)
-                self.milvus_client.create_index(
-                    collection_name=c_name,
-                    index_params=index_params,
-                    timeout=timeout
-                )
+                self.milvus_client.create_index(collection_name=c_name, index_params=index_params, timeout=timeout)
                 log.debug(f"Created index for int8 vector field {f}")
                 indexed_fields.add(f)
                 vector_index_created = True
@@ -590,11 +603,7 @@ class Checker:
                 continue
             try:
                 index_params = create_index_params_from_dict(f, constants.DEFAULT_BINARY_INDEX_PARAM)
-                self.milvus_client.create_index(
-                    collection_name=c_name,
-                    index_params=index_params,
-                    timeout=timeout
-                )
+                self.milvus_client.create_index(collection_name=c_name, index_params=index_params, timeout=timeout)
                 log.debug(f"Created index for binary vector field {f}")
                 indexed_fields.add(f)
                 vector_index_created = True
@@ -607,11 +616,7 @@ class Checker:
                 continue
             try:
                 index_params = create_index_params_from_dict(f, constants.DEFAULT_BM25_INDEX_PARAM)
-                self.milvus_client.create_index(
-                    collection_name=c_name,
-                    index_params=index_params,
-                    timeout=timeout
-                )
+                self.milvus_client.create_index(collection_name=c_name, index_params=index_params, timeout=timeout)
                 log.debug(f"Created index for bm25 sparse field {f}")
             except Exception as e:
                 log.warning(f"Failed to create index for {f}: {e}")
@@ -622,11 +627,7 @@ class Checker:
                 continue
             try:
                 index_params = create_index_params_from_dict(f, constants.DEFAULT_MINHASH_INDEX_PARAM)
-                self.milvus_client.create_index(
-                    collection_name=c_name,
-                    index_params=index_params,
-                    timeout=timeout
-                )
+                self.milvus_client.create_index(collection_name=c_name, index_params=index_params, timeout=timeout)
                 log.debug(f"Created index for minhash field {f}")
                 indexed_fields.add(f)
                 vector_index_created = True
@@ -639,11 +640,7 @@ class Checker:
                 continue
             try:
                 index_params = create_index_params_from_dict(f, constants.DEFAULT_EMB_LIST_INDEX_PARAM)
-                self.milvus_client.create_index(
-                    collection_name=c_name,
-                    index_params=index_params,
-                    timeout=timeout
-                )
+                self.milvus_client.create_index(collection_name=c_name, index_params=index_params, timeout=timeout)
                 log.debug(f"Created index for emb list field {f}")
             except Exception as e:
                 log.warning(f"Failed to create index for {f}: {e}")
@@ -657,7 +654,9 @@ class Checker:
             except Exception as e:
                 log.warning(f"Failed to load collection {c_name}: {e}. Collection may need to be loaded manually.")
         else:
-            log.warning(f"No vector index created for collection {c_name}, skipping load. You may need to create indexes and load manually.")
+            log.warning(
+                f"No vector index created for collection {c_name}, skipping load. You may need to create indexes and load manually."
+            )
 
         # Create partition if specified
         if p_name != "_default" and not self.milvus_client.has_partition(c_name, p_name):
@@ -701,16 +700,19 @@ class Checker:
             # Check for struct array fields (common names: struct_array, metadata, etc.)
             for key, value in data[0].items():
                 if isinstance(value, list) and value and isinstance(value[0], dict):
-                    log.debug(f"[insert_data] Found potential struct array field '{key}': {len(value)} items, first item: {value[0]}")
+                    log.debug(
+                        f"[insert_data] Found potential struct array field '{key}': {len(value)} items, first item: {value[0]}"
+                    )
 
         try:
             res = self.milvus_client.insert(
-                                             collection_name=self.c_name,
-                                             data=data,
-                                             partition_name=partition_name,
-                                             timeout=timeout,
-                                             enable_traceback=enable_traceback,
-                                             check_task=CheckTasks.check_nothing)
+                collection_name=self.c_name,
+                data=data,
+                partition_name=partition_name,
+                timeout=timeout,
+                enable_traceback=enable_traceback,
+                check_task=CheckTasks.check_nothing,
+            )
             return res, True
         except Exception as e:
             return str(e), False
@@ -725,8 +727,7 @@ class Checker:
         succ_rate = self.succ_rate()
         total = self.total()
         rsp_times = self.rsp_times
-        average_time = 0 if len(rsp_times) == 0 else sum(
-            rsp_times) / len(rsp_times)
+        average_time = 0 if len(rsp_times) == 0 else sum(rsp_times) / len(rsp_times)
         max_time = 0 if len(rsp_times) == 0 else max(rsp_times)
         min_time = 0 if len(rsp_times) == 0 else min(rsp_times)
         checker_name = self.__class__.__name__
@@ -765,24 +766,22 @@ class Checker:
         recovery_time = end - start  # second
         self.recovery_time = recovery_time
         checker_name = self.__class__.__name__
-        log.info(f"{checker_name} recovery time is {self.recovery_time}, start at {self.fail_records[0][2]}, "
-                 f"end at {self.fail_records[-1][2]}")
+        log.info(
+            f"{checker_name} recovery time is {self.recovery_time}, start at {self.fail_records[0][2]}, "
+            f"end at {self.fail_records[-1][2]}"
+        )
         return recovery_time
 
-    def prepare_bulk_insert_data(self,
-                                 nb=constants.ENTITIES_FOR_BULKINSERT,
-                                 file_type="npy",
-                                 minio_endpoint="127.0.0.1:9000",
-                                 bucket_name=None):
+    def prepare_bulk_insert_data(
+        self, nb=constants.ENTITIES_FOR_BULKINSERT, file_type="npy", minio_endpoint="127.0.0.1:9000", bucket_name=None
+    ):
         schema = self.schema
         bucket_name = self.bucket_name if bucket_name is None else bucket_name
         log.info("prepare data for bulk insert")
         try:
-            files = cf.prepare_bulk_insert_data(schema=schema,
-                                                nb=nb,
-                                                file_type=file_type,
-                                                minio_endpoint=minio_endpoint,
-                                                bucket_name=bucket_name)
+            files = cf.prepare_bulk_insert_data(
+                schema=schema, nb=nb, file_type=file_type, minio_endpoint=minio_endpoint, bucket_name=bucket_name
+            )
             self.files = files
             return files, True
         except Exception as e:
@@ -792,6 +791,7 @@ class Checker:
     def do_bulk_insert(self):
         log.info(f"bulk insert collection name: {self.c_name}")
         from pymilvus import utility
+
         task_ids = utility.do_bulk_insert(collection_name=self.c_name, files=self.files, using=self.alias)
         log.info(f"task ids {task_ids}")
         completed = utility.wait_for_bulk_insert_tasks_completed(task_ids=[task_ids], timeout=720, using=self.alias)
@@ -801,7 +801,13 @@ class Checker:
 class CollectionLoadChecker(Checker):
     """check collection load operations in a dependent thread"""
 
-    def __init__(self, collection_name=None, shards_num=2, replica_number=0, schema=None, ):
+    def __init__(
+        self,
+        collection_name=None,
+        shards_num=2,
+        replica_number=0,
+        schema=None,
+    ):
         self.replica_number = replica_number
         if collection_name is None:
             collection_name = cf.gen_unique_str("CollectionLoadChecker_")
@@ -831,7 +837,13 @@ class CollectionLoadChecker(Checker):
 class CollectionReleaseChecker(Checker):
     """check collection release operations in a dependent thread"""
 
-    def __init__(self, collection_name=None, shards_num=2, replica_number=0, schema=None, ):
+    def __init__(
+        self,
+        collection_name=None,
+        shards_num=2,
+        replica_number=0,
+        schema=None,
+    ):
         self.replica_number = replica_number
         if collection_name is None:
             collection_name = cf.gen_unique_str("CollectionReleaseChecker_")
@@ -859,11 +871,16 @@ class CollectionReleaseChecker(Checker):
             sleep(constants.WAIT_PER_OP)
 
 
-
 class CollectionRenameChecker(Checker):
     """check collection rename operations in a dependent thread"""
 
-    def __init__(self, collection_name=None, shards_num=2, replica_number=0, schema=None, ):
+    def __init__(
+        self,
+        collection_name=None,
+        shards_num=2,
+        replica_number=0,
+        schema=None,
+    ):
         self.replica_number = replica_number
         if collection_name is None:
             collection_name = cf.gen_unique_str("CollectionRenameChecker_")
@@ -899,7 +916,13 @@ class CollectionRenameChecker(Checker):
 class PartitionLoadChecker(Checker):
     """check partition load operations in a dependent thread"""
 
-    def __init__(self, collection_name=None, shards_num=2, replica_number=0, schema=None, ):
+    def __init__(
+        self,
+        collection_name=None,
+        shards_num=2,
+        replica_number=0,
+        schema=None,
+    ):
         self.replica_number = replica_number
         if collection_name is None:
             collection_name = cf.gen_unique_str("PartitionLoadChecker_")
@@ -910,7 +933,9 @@ class PartitionLoadChecker(Checker):
     @trace()
     def load_partition(self):
         try:
-            self.milvus_client.load_partitions(collection_name=self.c_name, partition_names=[self.p_name], replica_number=self.replica_number)
+            self.milvus_client.load_partitions(
+                collection_name=self.c_name, partition_names=[self.p_name], replica_number=self.replica_number
+            )
             return None, True
         except Exception as e:
             return str(e), False
@@ -931,14 +956,22 @@ class PartitionLoadChecker(Checker):
 class PartitionReleaseChecker(Checker):
     """check partition release operations in a dependent thread"""
 
-    def __init__(self, collection_name=None, shards_num=2, replica_number=0, schema=None, ):
+    def __init__(
+        self,
+        collection_name=None,
+        shards_num=2,
+        replica_number=0,
+        schema=None,
+    ):
         self.replica_number = replica_number
         if collection_name is None:
             collection_name = cf.gen_unique_str("PartitionReleaseChecker_")
         p_name = cf.gen_unique_str("PartitionReleaseChecker_")
         super().__init__(collection_name=collection_name, shards_num=shards_num, schema=schema, partition_name=p_name)
         self.milvus_client.release_collection(collection_name=self.c_name)
-        self.milvus_client.load_partitions(collection_name=self.c_name, partition_names=[self.p_name], replica_number=self.replica_number)
+        self.milvus_client.load_partitions(
+            collection_name=self.c_name, partition_names=[self.p_name], replica_number=self.replica_number
+        )
 
     @trace()
     def release_partition(self):
@@ -952,7 +985,9 @@ class PartitionReleaseChecker(Checker):
     def run_task(self):
         res, result = self.release_partition()
         if result:
-            self.milvus_client.load_partitions(collection_name=self.c_name, partition_names=[self.p_name], replica_number=self.replica_number)
+            self.milvus_client.load_partitions(
+                collection_name=self.c_name, partition_names=[self.p_name], replica_number=self.replica_number
+            )
         return res, result
 
     def keep_running(self):
@@ -984,7 +1019,7 @@ class SearchChecker(Checker):
                 search_params=self.search_param,
                 limit=5,
                 partition_names=self.p_names,
-                timeout=search_timeout
+                timeout=search_timeout,
             )
             return res, True
         except Exception as e:
@@ -1008,6 +1043,7 @@ class SearchChecker(Checker):
         while self._keep_running:
             self.run_task()
             sleep(constants.WAIT_PER_OP / 10)
+
 
 class TensorSearchChecker(Checker):
     """check search operations for struct array vector fields in a dependent thread"""
@@ -1042,7 +1078,7 @@ class TensorSearchChecker(Checker):
                 search_params=self.search_param,
                 limit=5,
                 partition_names=self.p_names,
-                timeout=search_timeout
+                timeout=search_timeout,
             )
             return res, True
         except Exception as e:
@@ -1081,7 +1117,13 @@ class TensorSearchChecker(Checker):
 class FullTextSearchChecker(Checker):
     """check full text search operations in a dependent thread"""
 
-    def __init__(self, collection_name=None, shards_num=2, replica_number=0, schema=None, ):
+    def __init__(
+        self,
+        collection_name=None,
+        shards_num=2,
+        replica_number=0,
+        schema=None,
+    ):
         if collection_name is None:
             collection_name = cf.gen_unique_str("FullTextSearchChecker_")
         super().__init__(collection_name=collection_name, shards_num=shards_num, schema=schema)
@@ -1092,11 +1134,7 @@ class FullTextSearchChecker(Checker):
         bm25_anns_field = random.choice(self.bm25_sparse_field_names)
         # Create highlighter for full text search results
         highlighter = LexicalHighlighter(
-            pre_tags=["<em>"],
-            post_tags=["</em>"],
-            highlight_search_text=True,
-            fragment_offset=10,
-            fragment_size=50
+            pre_tags=["<em>"], post_tags=["</em>"], highlight_search_text=True, fragment_offset=10, fragment_size=50
         )
         try:
             res = self.milvus_client.search(
@@ -1107,7 +1145,7 @@ class FullTextSearchChecker(Checker):
                 limit=5,
                 partition_names=self.p_names,
                 timeout=search_timeout,
-                highlighter=highlighter
+                highlighter=highlighter,
             )
             return res, True
         except Exception as e:
@@ -1127,7 +1165,13 @@ class FullTextSearchChecker(Checker):
 class MinHashSearchChecker(Checker):
     """check minhash search operations in a dependent thread"""
 
-    def __init__(self, collection_name=None, shards_num=2, replica_number=1, schema=None, ):
+    def __init__(
+        self,
+        collection_name=None,
+        shards_num=2,
+        replica_number=1,
+        schema=None,
+    ):
         if collection_name is None:
             collection_name = cf.gen_unique_str("MinHashSearchChecker_")
         super().__init__(collection_name=collection_name, shards_num=shards_num, schema=schema)
@@ -1144,7 +1188,7 @@ class MinHashSearchChecker(Checker):
                 search_params=constants.DEFAULT_MINHASH_SEARCH_PARAM,
                 limit=5,
                 partition_names=self.p_names,
-                timeout=search_timeout
+                timeout=search_timeout,
             )
             return res, True
         except Exception as e:
@@ -1164,7 +1208,13 @@ class MinHashSearchChecker(Checker):
 class HybridSearchChecker(Checker):
     """check hybrid search operations in a dependent thread"""
 
-    def __init__(self, collection_name=None, shards_num=2, replica_number=0, schema=None, ):
+    def __init__(
+        self,
+        collection_name=None,
+        shards_num=2,
+        replica_number=0,
+        schema=None,
+    ):
         if collection_name is None:
             collection_name = cf.gen_unique_str("HybridSearchChecker_")
         super().__init__(collection_name=collection_name, shards_num=shards_num, schema=schema)
@@ -1202,7 +1252,7 @@ class HybridSearchChecker(Checker):
                 ranker=RRFRanker(),
                 limit=10,
                 partition_names=self.p_names,
-                timeout=search_timeout
+                timeout=search_timeout,
             )
             return res, True
         except Exception as e:
@@ -1236,7 +1286,7 @@ class InsertFlushChecker(Checker):
                 self.milvus_client.insert(
                     collection_name=self.c_name,
                     data=cf.gen_row_data_by_schema(nb=constants.ENTITIES_FOR_SEARCH, schema=self.get_schema()),
-                    timeout=timeout
+                    timeout=timeout,
                 )
                 insert_result = True
             except Exception:
@@ -1294,7 +1344,7 @@ class FlushChecker(Checker):
             self.milvus_client.insert(
                 collection_name=self.c_name,
                 data=cf.gen_row_data_by_schema(nb=constants.ENTITIES_FOR_SEARCH, schema=self.get_schema()),
-                timeout=timeout
+                timeout=timeout,
             )
             res, result = self.flush()
             return res, result
@@ -1322,19 +1372,16 @@ class AddFieldChecker(Checker):
     def add_field(self):
         try:
             new_field_name = cf.gen_unique_str("new_field_")
-            self.milvus_client.add_collection_field(collection_name=self.c_name,
-                                                    field_name=new_field_name,
-                                                    data_type=DataType.INT64,
-                                                    nullable=True)
+            self.milvus_client.add_collection_field(
+                collection_name=self.c_name, field_name=new_field_name, data_type=DataType.INT64, nullable=True
+            )
             log.debug(f"add field {new_field_name} to collection {self.c_name}")
             time.sleep(1)
             _, result = self.insert_data()
-            res = self.milvus_client.query(collection_name=self.c_name,
-                                           filter=f"{new_field_name} >= 0",
-                                           output_fields=[new_field_name])
-            result = True
-            if result:
-                log.debug(f"query with field {new_field_name} success")
+            _ = self.milvus_client.query(
+                collection_name=self.c_name, filter=f"{new_field_name} >= 0", output_fields=[new_field_name]
+            )
+            log.debug(f"query with field {new_field_name} success")
             return None, result
         except Exception as e:
             log.error(e)
@@ -1351,7 +1398,6 @@ class AddFieldChecker(Checker):
             sleep(constants.WAIT_PER_OP * 6)
 
 
-
 class InsertChecker(Checker):
     """check insert operations in a dependent thread"""
 
@@ -1363,9 +1409,9 @@ class InsertChecker(Checker):
         stats = self.milvus_client.get_collection_stats(collection_name=self.c_name)
         self.initial_entities = stats.get("row_count", 0)
         self.inserted_data = []
-        self.scale = 1 * 10 ** 6
+        self.scale = 1 * 10**6
         self.start_time_stamp = int(time.time() * self.scale)  # us
-        self.term_expr = f'{self.int64_field_name} >= {self.start_time_stamp}'
+        self.term_expr = f"{self.int64_field_name} >= {self.start_time_stamp}"
 
     @trace()
     def insert_entities(self):
@@ -1387,14 +1433,42 @@ class InsertChecker(Checker):
             # Check for struct array fields (common names: struct_array, metadata, etc.)
             for key, value in data[0].items():
                 if isinstance(value, list) and value and isinstance(value[0], dict):
-                    log.debug(f"[InsertChecker] Found potential struct array field '{key}': {len(value)} items, first item: {value[0]}")
+                    log.debug(
+                        f"[InsertChecker] Found potential struct array field '{key}': {len(value)} items, first item: {value[0]}"
+                    )
 
         try:
-            res = self.milvus_client.insert(collection_name=self.c_name,
-                                           data=data,
-                                           partition_name=self.p_names[0] if self.p_names else None,
-                                           timeout=timeout)
+            res = self.milvus_client.insert(
+                collection_name=self.c_name,
+                data=data,
+                partition_name=self.p_names[0] if self.p_names else None,
+                timeout=timeout,
+            )
             return res, True
+        except SchemaMismatchRetryableException:
+            # Schema changed concurrently (AddVectorFieldChecker). The server rejected the request
+            # because the schema_timestamp in the request is stale (not a missing-field issue —
+            # new fields are always nullable). Invalidate the SDK schema cache so the next
+            # insert_rows() picks up the new schema_timestamp, then retry once.
+            log.debug("[InsertChecker] schema_timestamp stale, invalidating cache and retrying")
+            try:
+                self.milvus_client._get_connection()._invalidate_schema(self.c_name)
+            except Exception:
+                pass
+            data = cf.gen_row_data_by_schema(nb=constants.DELTA_PER_INS, schema=self.get_schema())
+            for i in range(len(data)):
+                data[i][self.int64_field_name] = int(time.time() * self.scale)
+            try:
+                res = self.milvus_client.insert(
+                    collection_name=self.c_name,
+                    data=data,
+                    partition_name=self.p_names[0] if self.p_names else None,
+                    timeout=timeout,
+                )
+                return res, True
+            except Exception as e:
+                log.info(f"insert error (retry): {e}")
+                return str(e), False
         except Exception as e:
             log.info(f"insert error: {e}")
             return str(e), False
@@ -1419,16 +1493,20 @@ class InsertChecker(Checker):
             log.error(f"create index error: {e}")
         self.milvus_client.load_collection(collection_name=self.c_name)
         end_time_stamp = int(time.time() * self.scale)
-        self.term_expr = f'{self.int64_field_name} >= {self.start_time_stamp} and ' \
-                         f'{self.int64_field_name} <= {end_time_stamp}'
+        self.term_expr = (
+            f"{self.int64_field_name} >= {self.start_time_stamp} and {self.int64_field_name} <= {end_time_stamp}"
+        )
         data_in_client = []
         for d in self.inserted_data:
             if self.start_time_stamp <= d <= end_time_stamp:
                 data_in_client.append(d)
-        res = self.milvus_client.query(collection_name=self.c_name, filter=self.term_expr,
-                                      output_fields=[f'{self.int64_field_name}'],
-                                      limit=len(data_in_client) * 2, timeout=timeout)
-        result = True
+        res = self.milvus_client.query(
+            collection_name=self.c_name,
+            filter=self.term_expr,
+            output_fields=[f"{self.int64_field_name}"],
+            limit=len(data_in_client) * 2,
+            timeout=timeout,
+        )
 
         data_in_server = []
         for r in res:
@@ -1449,9 +1527,9 @@ class InsertFreshnessChecker(Checker):
         stats = self.milvus_client.get_collection_stats(collection_name=self.c_name)
         self.initial_entities = stats.get("row_count", 0)
         self.inserted_data = []
-        self.scale = 1 * 10 ** 6
+        self.scale = 1 * 10**6
         self.start_time_stamp = int(time.time() * self.scale)  # us
-        self.term_expr = f'{self.int64_field_name} >= {self.start_time_stamp}'
+        self.term_expr = f"{self.int64_field_name} >= {self.start_time_stamp}"
 
     def insert_entities(self):
         data = cf.gen_row_data_by_schema(nb=constants.DELTA_PER_INS, schema=self.get_schema())
@@ -1464,26 +1542,30 @@ class InsertFreshnessChecker(Checker):
         data[0] = ts_data  # set timestamp (ms) as int64
         log.debug(f"insert data: {len(ts_data)}")
         try:
-            res = self.milvus_client.insert(collection_name=self.c_name,
-                                           data=data,
-                                           partition_name=self.p_names[0] if self.p_names else None,
-                                           timeout=timeout)
+            res = self.milvus_client.insert(
+                collection_name=self.c_name,
+                data=data,
+                partition_name=self.p_names[0] if self.p_names else None,
+                timeout=timeout,
+            )
             result = True
         except Exception as e:
             res = str(e)
             result = False
         self.latest_data = ts_data[-1]
-        self.term_expr = f'{self.int64_field_name} == {self.latest_data}'
+        self.term_expr = f"{self.int64_field_name} == {self.latest_data}"
         return res, result
 
     @trace()
     def insert_freshness(self):
         while True:
             try:
-                res = self.milvus_client.query(collection_name=self.c_name,
-                                              filter=self.term_expr,
-                                              output_fields=[f'{self.int64_field_name}'],
-                                              timeout=timeout)
+                res = self.milvus_client.query(
+                    collection_name=self.c_name,
+                    filter=self.term_expr,
+                    output_fields=[f"{self.int64_field_name}"],
+                    timeout=timeout,
+                )
                 result = True
             except Exception as e:
                 res = str(e)
@@ -1517,10 +1599,23 @@ class UpsertChecker(Checker):
     @trace()
     def upsert_entities(self):
         try:
-            res = self.milvus_client.upsert(collection_name=self.c_name,
-                                           data=self.data,
-                                           timeout=timeout)
+            res = self.milvus_client.upsert(collection_name=self.c_name, data=self.data, timeout=timeout)
             return res, True
+        except SchemaMismatchRetryableException:
+            # Schema changed concurrently (AddVectorFieldChecker). Invalidate the SDK schema cache
+            # so the next upsert_rows() fetches the new schema_timestamp, then retry once.
+            log.debug("[UpsertChecker] schema_timestamp stale, invalidating cache and retrying")
+            try:
+                self.milvus_client._get_connection()._invalidate_schema(self.c_name)
+            except Exception:
+                pass
+            self.data = cf.gen_row_data_by_schema(nb=constants.DELTA_PER_INS, schema=self.get_schema())
+            try:
+                res = self.milvus_client.upsert(collection_name=self.c_name, data=self.data, timeout=timeout)
+                return res, True
+            except Exception as e:
+                log.info(f"upsert failed (retry): {e}")
+                return str(e), False
         except Exception as e:
             log.info(f"upsert failed: {e}")
             return str(e), False
@@ -1529,9 +1624,9 @@ class UpsertChecker(Checker):
     def run_task(self):
         # half of the data is upsert, the other half is insert
         rows = len(self.data)
-        pk_old = [d[self.int64_field_name] for d in self.data[:rows // 2]]
+        pk_old = [d[self.int64_field_name] for d in self.data[: rows // 2]]
         self.data = cf.gen_row_data_by_schema(nb=constants.DELTA_PER_INS, schema=self.get_schema())
-        pk_new = [d[self.int64_field_name] for d in self.data[rows // 2:]]
+        pk_new = [d[self.int64_field_name] for d in self.data[rows // 2 :]]
         pk_update = pk_old + pk_new
         for i in range(rows):
             self.data[i][self.int64_field_name] = pk_update[i]
@@ -1557,9 +1652,7 @@ class UpsertFreshnessChecker(Checker):
 
     def upsert_entities(self):
         try:
-            res = self.milvus_client.upsert(collection_name=self.c_name,
-                                           data=self.data,
-                                           timeout=timeout)
+            res = self.milvus_client.upsert(collection_name=self.c_name, data=self.data, timeout=timeout)
             return res, True
         except Exception as e:
             return str(e), False
@@ -1568,10 +1661,12 @@ class UpsertFreshnessChecker(Checker):
     def upsert_freshness(self):
         while True:
             try:
-                res = self.milvus_client.query(collection_name=self.c_name,
-                                              filter=self.term_expr,
-                                              output_fields=[f'{self.int64_field_name}'],
-                                              timeout=timeout)
+                res = self.milvus_client.query(
+                    collection_name=self.c_name,
+                    filter=self.term_expr,
+                    output_fields=[f"{self.int64_field_name}"],
+                    timeout=timeout,
+                )
                 result = True
             except Exception as e:
                 res = str(e)
@@ -1585,13 +1680,13 @@ class UpsertFreshnessChecker(Checker):
     def run_task(self):
         # half of the data is upsert, the other half is insert
         rows = len(self.data[0])
-        pk_old = self.data[0][:rows // 2]
+        pk_old = self.data[0][: rows // 2]
         self.data = cf.gen_row_data_by_schema(nb=constants.DELTA_PER_INS, schema=self.get_schema())
-        pk_new = self.data[0][rows // 2:]
+        pk_new = self.data[0][rows // 2 :]
         pk_update = pk_old + pk_new
         self.data[0] = pk_update
         self.latest_data = self.data[0][-1]
-        self.term_expr = f'{self.int64_field_name} == {self.latest_data}'
+        self.term_expr = f"{self.int64_field_name} == {self.latest_data}"
         res, result = self.upsert_entities()
         res, result = self.upsert_freshness()
         return res, result
@@ -1600,25 +1695,42 @@ class UpsertFreshnessChecker(Checker):
         while self._keep_running:
             self.run_task()
             sleep(constants.WAIT_PER_OP * 6)
-    
+
+
 class PartialUpdateChecker(Checker):
     """check partial update operations in a dependent thread"""
 
     def __init__(self, collection_name=None, shards_num=2, schema=None):
         if collection_name is None:
             collection_name = cf.gen_unique_str("PartialUpdateChecker_")
-        super().__init__(collection_name=collection_name, shards_num=shards_num, schema=schema, enable_struct_array_field=False)
+        super().__init__(
+            collection_name=collection_name, shards_num=shards_num, schema=schema, enable_struct_array_field=False
+        )
         self.data = cf.gen_row_data_by_schema(nb=constants.DELTA_PER_INS, schema=self.get_schema())
 
     @trace()
     def partial_update_entities(self):
         try:
-
-            res = self.milvus_client.upsert(collection_name=self.c_name,
-                                           data=self.data,
-                                           partial_update=True,
-                                           timeout=timeout)
+            res = self.milvus_client.upsert(
+                collection_name=self.c_name, data=self.data, partial_update=True, timeout=timeout
+            )
             return res, True
+        except SchemaMismatchRetryableException:
+            # Schema changed concurrently (AddVectorFieldChecker). Invalidate the SDK schema cache
+            # so the next upsert_rows() fetches the new schema_timestamp, then retry once.
+            log.debug("[PartialUpdateChecker] schema_timestamp stale, invalidating cache and retrying")
+            try:
+                self.milvus_client._get_connection()._invalidate_schema(self.c_name)
+            except Exception:
+                pass
+            try:
+                res = self.milvus_client.upsert(
+                    collection_name=self.c_name, data=self.data, partial_update=True, timeout=timeout
+                )
+                return res, True
+            except Exception as e:
+                log.info(f"partial update failed (retry): {e}")
+                return str(e), False
         except Exception as e:
             log.info(f"error {e}")
             return str(e), False
@@ -1640,8 +1752,7 @@ class PartialUpdateChecker(Checker):
             # Choose subset fields to update: always include PK + one non-PK field if available
             num = count % num_fields
             desired_fields = [pk_field_name, schema["fields"][num if num != 0 else 1]["name"]]
-            partial_rows = cf.gen_row_data_by_schema(nb=rows, schema=schema,
-                                                    desired_field_names=desired_fields)
+            partial_rows = cf.gen_row_data_by_schema(nb=rows, schema=schema, desired_field_names=desired_fields)
             self.data = partial_rows
         res, result = self.partial_update_entities()
         return res, result
@@ -1667,9 +1778,9 @@ class CollectionCreateChecker(Checker):
         try:
             collection_name = cf.gen_unique_str("CreateChecker_")
             schema = cf.gen_default_collection_schema()
-            self.milvus_client.create_collection(collection_name=collection_name,
-                                                schema=schema,
-                                                consistency_level="Strong")
+            self.milvus_client.create_collection(
+                collection_name=collection_name, schema=schema, consistency_level="Strong"
+            )
             return None, True
         except Exception as e:
             return str(e), False
@@ -1703,7 +1814,9 @@ class CollectionDropChecker(Checker):
         for i in range(pool_size):
             collection_name = cf.gen_unique_str("DropChecker_")
             try:
-                self.milvus_client.create_collection(collection_name=collection_name, schema=schema, consistency_level="Strong")
+                self.milvus_client.create_collection(
+                    collection_name=collection_name, schema=schema, consistency_level="Strong"
+                )
                 self.collection_pool.append(collection_name)
             except Exception as e:
                 log.error(f"Failed to create collection {collection_name}: {e}")
@@ -1762,8 +1875,7 @@ class PartitionCreateChecker(Checker):
     def create_partition(self):
         try:
             partition_name = cf.gen_unique_str("PartitionCreateChecker_")
-            self.milvus_client.create_partition(collection_name=self.c_name,
-                                               partition_name=partition_name)
+            self.milvus_client.create_partition(collection_name=self.c_name, partition_name=partition_name)
             return None, True
         except Exception as e:
             return str(e), False
@@ -1893,9 +2005,11 @@ class IndexCreateChecker(Checker):
             collection_name = cf.gen_unique_str("IndexChecker_")
         super().__init__(collection_name=collection_name, schema=schema)
         for i in range(5):
-            self.milvus_client.insert(collection_name=self.c_name,
-                                     data=cf.gen_row_data_by_schema(nb=constants.ENTITIES_FOR_SEARCH, schema=self.get_schema()),
-                                     timeout=timeout)
+            self.milvus_client.insert(
+                collection_name=self.c_name,
+                data=cf.gen_row_data_by_schema(nb=constants.ENTITIES_FOR_SEARCH, schema=self.get_schema()),
+                timeout=timeout,
+            )
         # do as a flush before indexing
         stats = self.milvus_client.get_collection_stats(collection_name=self.c_name)
         log.debug(f"Index ready entities: {stats.get('row_count', 0)}")
@@ -1904,8 +2018,7 @@ class IndexCreateChecker(Checker):
     def create_index(self):
         try:
             index_params = create_index_params_from_dict(self.float_vector_field_name, constants.DEFAULT_INDEX_PARAM)
-            self.milvus_client.create_index(collection_name=self.c_name,
-                                           index_params=index_params)
+            self.milvus_client.create_index(collection_name=self.c_name, index_params=index_params)
             return None, True
         except Exception as e:
             return str(e), False
@@ -1934,8 +2047,11 @@ class IndexDropChecker(Checker):
             collection_name = cf.gen_unique_str("IndexChecker_")
         super().__init__(collection_name=collection_name, schema=schema)
         for i in range(5):
-            self.milvus_client.insert(collection_name=self.c_name, data=cf.gen_row_data_by_schema(nb=constants.ENTITIES_FOR_SEARCH, schema=self.get_schema()),
-                               timeout=timeout)
+            self.milvus_client.insert(
+                collection_name=self.c_name,
+                data=cf.gen_row_data_by_schema(nb=constants.ENTITIES_FOR_SEARCH, schema=self.get_schema()),
+                timeout=timeout,
+            )
         # do as a flush before indexing
         stats = self.milvus_client.get_collection_stats(collection_name=self.c_name)
         log.debug(f"Index ready entities: {stats.get('row_count', 0)}")
@@ -1953,14 +2069,18 @@ class IndexDropChecker(Checker):
     def run_task(self):
         res, result = self.drop_index()
         if result:
-            self.milvus_client.create_collection(collection_name=cf.gen_unique_str("IndexDropChecker_"), schema=self.schema, consistency_level="Strong")
+            self.milvus_client.create_collection(
+                collection_name=cf.gen_unique_str("IndexDropChecker_"), schema=self.schema, consistency_level="Strong"
+            )
             index_params = create_index_params_from_dict(self.float_vector_field_name, constants.DEFAULT_INDEX_PARAM)
             self.milvus_client.create_index(collection_name=self.c_name, index_params=index_params)
         return res, result
 
     def keep_running(self):
         while self._keep_running:
-            self.milvus_client.create_collection(collection_name=cf.gen_unique_str("IndexDropChecker_"), schema=self.schema, consistency_level="Strong")
+            self.milvus_client.create_collection(
+                collection_name=cf.gen_unique_str("IndexDropChecker_"), schema=self.schema, consistency_level="Strong"
+            )
             index_params = create_index_params_from_dict(self.float_vector_field_name, constants.DEFAULT_INDEX_PARAM)
             self.milvus_client.create_index(collection_name=self.c_name, index_params=index_params)
             self.run_task()
@@ -1976,14 +2096,18 @@ class QueryChecker(Checker):
         super().__init__(collection_name=collection_name, shards_num=shards_num, schema=schema)
         index_params = create_index_params_from_dict(self.float_vector_field_name, constants.DEFAULT_INDEX_PARAM)
         self.milvus_client.create_index(collection_name=self.c_name, index_params=index_params)
-        self.milvus_client.load_collection(collection_name=self.c_name, replica_number=replica_number)  # do load before query
+        self.milvus_client.load_collection(
+            collection_name=self.c_name, replica_number=replica_number
+        )  # do load before query
         self.insert_data()
         self.term_expr = f"{self.int64_field_name} > 0"
 
     @trace()
     def query(self):
         try:
-            res = self.milvus_client.query(collection_name=self.c_name, filter=self.term_expr, limit=5, timeout=query_timeout)
+            res = self.milvus_client.query(
+                collection_name=self.c_name, filter=self.term_expr, limit=5, timeout=query_timeout
+            )
             return res, True
         except Exception as e:
             log.info(f"query error: {e}")
@@ -2023,7 +2147,7 @@ class TextMatchChecker(Checker):
             pre_tags=["<em>"],
             post_tags=["</em>"],
             highlight_search_text=False,
-            highlight_query=[{"type": "TextMatch", "field": self.text_match_field_name, "text": self.key_word}]
+            highlight_query=[{"type": "TextMatch", "field": self.text_match_field_name, "text": self.key_word}],
         )
         try:
             res = self.milvus_client.search(
@@ -2035,7 +2159,7 @@ class TextMatchChecker(Checker):
                 limit=5,
                 output_fields=[self.text_match_field_name],
                 timeout=search_timeout,
-                highlighter=highlighter
+                highlighter=highlighter,
             )
             return res, True
         except Exception as e:
@@ -2065,18 +2189,22 @@ class PhraseMatchChecker(Checker):
         super().__init__(collection_name=collection_name, shards_num=shards_num, schema=schema)
         index_params = create_index_params_from_dict(self.float_vector_field_name, constants.DEFAULT_INDEX_PARAM)
         self.milvus_client.create_index(collection_name=self.c_name, index_params=index_params)
-        self.milvus_client.load_collection(collection_name=self.c_name, replica_number=replica_number)  # do load before query
+        self.milvus_client.load_collection(
+            collection_name=self.c_name, replica_number=replica_number
+        )  # do load before query
         self.insert_data()
         key_word_1 = self.word_freq.most_common(2)[0][0]
         key_word_2 = self.word_freq.most_common(2)[1][0]
-        slop=5
+        slop = 5
         text_match_field_name = random.choice(self.text_match_field_name_list)
         self.term_expr = f"PHRASE_MATCH({text_match_field_name}, '{key_word_1} {key_word_2}', {slop})"
 
     @trace()
     def phrase_match(self):
         try:
-            res = self.milvus_client.query(collection_name=self.c_name, filter=self.term_expr, limit=5, timeout=query_timeout)
+            res = self.milvus_client.query(
+                collection_name=self.c_name, filter=self.term_expr, limit=5, timeout=query_timeout
+            )
             return res, True
         except Exception as e:
             log.info(f"phrase_match error: {e}")
@@ -2086,7 +2214,7 @@ class PhraseMatchChecker(Checker):
     def run_task(self):
         key_word_1 = self.word_freq.most_common(2)[0][0]
         key_word_2 = self.word_freq.most_common(2)[1][0]
-        slop=5
+        slop = 5
         text_match_field_name = random.choice(self.text_match_field_name_list)
         self.term_expr = f"PHRASE_MATCH({text_match_field_name}, '{key_word_1} {key_word_2}', {slop})"
         res, result = self.phrase_match()
@@ -2107,7 +2235,9 @@ class JsonQueryChecker(Checker):
         super().__init__(collection_name=collection_name, shards_num=shards_num, schema=schema)
         index_params = create_index_params_from_dict(self.float_vector_field_name, constants.DEFAULT_INDEX_PARAM)
         self.milvus_client.create_index(collection_name=self.c_name, index_params=index_params)
-        self.milvus_client.load_collection(collection_name=self.c_name, replica_number=replica_number)  # do load before query
+        self.milvus_client.load_collection(
+            collection_name=self.c_name, replica_number=replica_number
+        )  # do load before query
         self.insert_data()
         self.term_expr = self.get_term_expr()
 
@@ -2117,19 +2247,20 @@ class JsonQueryChecker(Checker):
         address_list = [fake.address() for _ in range(10)]
         name_list = [fake.name() for _ in range(10)]
         number_list = [random.randint(0, 100) for _ in range(10)]
-        path = random.choice([ "name", "count"])
+        path = random.choice(["name", "count"])
         path_value = {
-            "address": address_list, # TODO not used in json query because of issue
+            "address": address_list,  # TODO not used in json query because of issue
             "name": name_list,
-            "count": number_list
+            "count": number_list,
         }
         return f"{json_field_name}['{path}'] <= '{path_value[path][random.randint(0, len(path_value[path]) - 1)]}'"
-        
 
     @trace()
     def json_query(self):
         try:
-            res = self.milvus_client.query(collection_name=self.c_name, filter=self.term_expr, limit=5, timeout=query_timeout)
+            res = self.milvus_client.query(
+                collection_name=self.c_name, filter=self.term_expr, limit=5, timeout=query_timeout
+            )
             return res, True
         except Exception as e:
             log.info(f"json_query error: {e}")
@@ -2146,6 +2277,7 @@ class JsonQueryChecker(Checker):
             self.run_task()
             sleep(constants.WAIT_PER_OP / 10)
 
+
 class GeoQueryChecker(Checker):
     """check geometry query operations in a dependent thread"""
 
@@ -2155,7 +2287,9 @@ class GeoQueryChecker(Checker):
         super().__init__(collection_name=collection_name, shards_num=shards_num, schema=schema)
         index_params = create_index_params_from_dict(self.float_vector_field_name, constants.DEFAULT_INDEX_PARAM)
         self.milvus_client.create_index(collection_name=self.c_name, index_params=index_params)
-        self.milvus_client.load_collection(collection_name=self.c_name, replica_number=replica_number)  # do load before query
+        self.milvus_client.load_collection(
+            collection_name=self.c_name, replica_number=replica_number
+        )  # do load before query
         self.insert_data()
         self.term_expr = self.get_term_expr()
 
@@ -2163,12 +2297,13 @@ class GeoQueryChecker(Checker):
         geometry_field_name = random.choice(self.geometry_field_names)
         query_polygon = "POLYGON ((-180 -90, 180 -90, 180 90, -180 90, -180 -90))"
         return f"ST_WITHIN({geometry_field_name}, '{query_polygon}')"
-        
 
     @trace()
     def geo_query(self):
         try:
-            res = self.milvus_client.query(collection_name=self.c_name, filter=self.term_expr, limit=5, timeout=query_timeout)
+            res = self.milvus_client.query(
+                collection_name=self.c_name, filter=self.term_expr, limit=5, timeout=query_timeout
+            )
             return res, True
         except Exception as e:
             log.info(f"geo_query error: {e}")
@@ -2197,28 +2332,45 @@ class DeleteChecker(Checker):
         self.milvus_client.create_index(collection_name=self.c_name, index_params=index_params)
         self.milvus_client.load_collection(collection_name=self.c_name)  # load before query
         self.insert_data()
-        query_expr = f'{self.int64_field_name} > 0'
-        res = self.milvus_client.query(collection_name=self.c_name, filter=query_expr, output_fields=[self.int64_field_name], partition_name=self.p_name)
+        query_expr = f"{self.int64_field_name} > 0"
+        res = self.milvus_client.query(
+            collection_name=self.c_name,
+            filter=query_expr,
+            output_fields=[self.int64_field_name],
+            partition_name=self.p_name,
+        )
         self.ids = [r[self.int64_field_name] for r in res]
         self.query_expr = query_expr
-        delete_ids = self.ids[:len(self.ids) // 2]  # delete half of ids
-        self.delete_expr = f'{self.int64_field_name} in {delete_ids}'
+        delete_ids = self.ids[: len(self.ids) // 2]  # delete half of ids
+        self.delete_expr = f"{self.int64_field_name} in {delete_ids}"
 
     def update_delete_expr(self):
-        res = self.milvus_client.query(collection_name=self.c_name, filter=self.query_expr, output_fields=[self.int64_field_name], partition_name=self.p_name)
+        res = self.milvus_client.query(
+            collection_name=self.c_name,
+            filter=self.query_expr,
+            output_fields=[self.int64_field_name],
+            partition_name=self.p_name,
+        )
         all_ids = [r[self.int64_field_name] for r in res]
         if len(all_ids) < 100:
             # insert data to make sure there are enough ids to delete
             self.insert_data(nb=10000)
-            res = self.milvus_client.query(collection_name=self.c_name, filter=self.query_expr, output_fields=[self.int64_field_name], partition_name=self.p_name)
+            res = self.milvus_client.query(
+                collection_name=self.c_name,
+                filter=self.query_expr,
+                output_fields=[self.int64_field_name],
+                partition_name=self.p_name,
+            )
             all_ids = [r[self.int64_field_name] for r in res]
         delete_ids = all_ids[:3000]  # delete 3000 ids
-        self.delete_expr = f'{self.int64_field_name} in {delete_ids}'
+        self.delete_expr = f"{self.int64_field_name} in {delete_ids}"
 
     @trace()
     def delete_entities(self):
         try:
-            res = self.milvus_client.delete(collection_name=self.c_name, filter=self.delete_expr, timeout=timeout, partition_name=self.p_name)
+            res = self.milvus_client.delete(
+                collection_name=self.c_name, filter=self.delete_expr, timeout=timeout, partition_name=self.p_name
+            )
             return res, True
         except Exception as e:
             log.info(f"delete_entities error: {e}")
@@ -2247,27 +2399,44 @@ class DeleteFreshnessChecker(Checker):
         self.milvus_client.create_index(collection_name=self.c_name, index_params=index_params)
         self.milvus_client.load_collection(collection_name=self.c_name)  # load before query
         self.insert_data()
-        query_expr = f'{self.int64_field_name} > 0'
-        res = self.milvus_client.query(collection_name=self.c_name, filter=query_expr, output_fields=[self.int64_field_name], partition_name=self.p_name)
+        query_expr = f"{self.int64_field_name} > 0"
+        res = self.milvus_client.query(
+            collection_name=self.c_name,
+            filter=query_expr,
+            output_fields=[self.int64_field_name],
+            partition_name=self.p_name,
+        )
         self.ids = [r[self.int64_field_name] for r in res]
         self.query_expr = query_expr
-        delete_ids = self.ids[:len(self.ids) // 2]  # delete half of ids
-        self.delete_expr = f'{self.int64_field_name} in {delete_ids}'
+        delete_ids = self.ids[: len(self.ids) // 2]  # delete half of ids
+        self.delete_expr = f"{self.int64_field_name} in {delete_ids}"
 
     def update_delete_expr(self):
-        res = self.milvus_client.query(collection_name=self.c_name, filter=self.query_expr, output_fields=[self.int64_field_name], partition_name=self.p_name)
+        res = self.milvus_client.query(
+            collection_name=self.c_name,
+            filter=self.query_expr,
+            output_fields=[self.int64_field_name],
+            partition_name=self.p_name,
+        )
         all_ids = [r[self.int64_field_name] for r in res]
         if len(all_ids) < 100:
             # insert data to make sure there are enough ids to delete
             self.insert_data(nb=10000)
-            res = self.milvus_client.query(collection_name=self.c_name, filter=self.query_expr, output_fields=[self.int64_field_name], partition_name=self.p_name)
+            res = self.milvus_client.query(
+                collection_name=self.c_name,
+                filter=self.query_expr,
+                output_fields=[self.int64_field_name],
+                partition_name=self.p_name,
+            )
             all_ids = [r[self.int64_field_name] for r in res]
-        delete_ids = all_ids[:len(all_ids) // 2]  # delete half of ids
-        self.delete_expr = f'{self.int64_field_name} in {delete_ids}'
+        delete_ids = all_ids[: len(all_ids) // 2]  # delete half of ids
+        self.delete_expr = f"{self.int64_field_name} in {delete_ids}"
 
     def delete_entities(self):
         try:
-            res = self.milvus_client.delete(collection_name=self.c_name, filter=self.delete_expr, timeout=timeout, partition_name=self.p_name)
+            res = self.milvus_client.delete(
+                collection_name=self.c_name, filter=self.delete_expr, timeout=timeout, partition_name=self.p_name
+            )
             return res, True
         except Exception as e:
             log.info(f"delete_entities error: {e}")
@@ -2277,7 +2446,12 @@ class DeleteFreshnessChecker(Checker):
     def delete_freshness(self):
         try:
             while True:
-                res = self.milvus_client.query(collection_name=self.c_name, filter=self.delete_expr, output_fields=[f'{self.int64_field_name}'], timeout=timeout)
+                res = self.milvus_client.query(
+                    collection_name=self.c_name,
+                    filter=self.delete_expr,
+                    output_fields=[f"{self.int64_field_name}"],
+                    timeout=timeout,
+                )
                 if len(res) == 0:
                     break
             return res, True
@@ -2313,6 +2487,7 @@ class CompactChecker(Checker):
     @trace()
     def compact(self):
         from pymilvus import Collection
+
         collection = Collection(name=self.c_name, using=self.alias)
         res = collection.compact(timeout=timeout)
         collection.wait_for_compaction_completed()
@@ -2347,12 +2522,20 @@ class LoadBalanceChecker(Checker):
     @trace()
     def load_balance(self):
         from pymilvus import utility
-        res = utility.load_balance(collection_name=self.c_name, src_node_id=self.src_node_id, dst_node_ids=self.dst_node_ids, sealed_segment_ids=self.sealed_segment_ids, using=self.alias)
+
+        res = utility.load_balance(
+            collection_name=self.c_name,
+            src_node_id=self.src_node_id,
+            dst_node_ids=self.dst_node_ids,
+            sealed_segment_ids=self.sealed_segment_ids,
+            using=self.alias,
+        )
         return res, True
 
     def prepare(self):
         """prepare load balance params"""
         from pymilvus import Collection
+
         collection = Collection(name=self.c_name, using=self.alias)
         res = collection.get_replicas()
         # find a group which has multi nodes
@@ -2364,6 +2547,7 @@ class LoadBalanceChecker(Checker):
         self.src_node_id = group_nodes[0]
         self.dst_node_ids = group_nodes[1:]
         from pymilvus import utility
+
         res = utility.get_query_segment_info(self.c_name, using=self.alias)
         segment_distribution = cf.get_segment_distribution(res)
         self.sealed_segment_ids = segment_distribution[self.src_node_id]["sealed"]
@@ -2383,8 +2567,17 @@ class LoadBalanceChecker(Checker):
 class BulkInsertChecker(Checker):
     """check bulk insert operations in a dependent thread"""
 
-    def __init__(self, collection_name=None, files=[], use_one_collection=False, dim=ct.default_dim,
-                 schema=None, insert_data=False, minio_endpoint=None, bucket_name=None):
+    def __init__(
+        self,
+        collection_name=None,
+        files=[],
+        use_one_collection=False,
+        dim=ct.default_dim,
+        schema=None,
+        insert_data=False,
+        minio_endpoint=None,
+        bucket_name=None,
+    ):
         if collection_name is None:
             collection_name = cf.gen_unique_str("BulkInsertChecker_")
         super().__init__(collection_name=collection_name, dim=dim, schema=schema, insert_data=insert_data)
@@ -2400,17 +2593,16 @@ class BulkInsertChecker(Checker):
 
     def prepare(self, data_size=100000):
         with RemoteBulkWriter(
-                schema=self.schema,
-                file_type=BulkFileType.NUMPY,
-                remote_path="bulk_data",
-                connect_param=RemoteBulkWriter.ConnectParam(
-                    endpoint=self.minio_endpoint,
-                    access_key="minioadmin",
-                    secret_key="minioadmin",
-                    bucket_name=self.bucket_name
-                )
+            schema=self.schema,
+            file_type=BulkFileType.NUMPY,
+            remote_path="bulk_data",
+            connect_param=RemoteBulkWriter.ConnectParam(
+                endpoint=self.minio_endpoint,
+                access_key="minioadmin",
+                secret_key="minioadmin",
+                bucket_name=self.bucket_name,
+            ),
         ) as remote_writer:
-
             for _ in range(data_size):
                 row = cf.gen_row_data_by_schema(nb=1, schema=self.get_schema())[0]
                 remote_writer.append_row(row)
@@ -2427,6 +2619,7 @@ class BulkInsertChecker(Checker):
 
     def get_bulk_insert_task_state(self):
         from pymilvus import utility
+
         state_map = {}
         for task_id in self.failed_tasks_id:
             state = utility.get_bulk_insert_state(task_id=task_id, using=self.alias)
@@ -2437,6 +2630,7 @@ class BulkInsertChecker(Checker):
     def bulk_insert(self):
         log.info(f"bulk insert collection name: {self.c_name}")
         from pymilvus import utility
+
         task_ids = utility.do_bulk_insert(collection_name=self.c_name, files=self.files, using=self.alias)
         log.info(f"task ids {task_ids}")
         completed = utility.wait_for_bulk_insert_tasks_completed(task_ids=[task_ids], timeout=720, using=self.alias)
@@ -2450,7 +2644,9 @@ class BulkInsertChecker(Checker):
                 log.debug(f"check failed task: {self.c_name}")
             else:
                 self.c_name = cf.gen_unique_str("BulkInsertChecker_")
-        self.milvus_client.create_collection(collection_name=self.c_name, schema=self.schema, consistency_level="Strong")
+        self.milvus_client.create_collection(
+            collection_name=self.c_name, schema=self.schema, consistency_level="Strong"
+        )
         log.info(f"collection schema: {self.milvus_client.describe_collection(self.c_name)}")
         # bulk insert data
         num_entities = self.milvus_client.get_collection_stats(collection_name=self.c_name).get("row_count", 0)
@@ -2479,15 +2675,16 @@ class AlterCollectionChecker(Checker):
         res = self.milvus_client.describe_collection(collection_name=self.c_name)
         log.info(f"before alter collection {self.c_name} schema: {res}")
         # alter collection attributes
-        self.milvus_client.alter_collection_properties(collection_name=self.c_name,
-                                                       properties={"mmap.enabled": True})
-        self.milvus_client.alter_collection_properties(collection_name=self.c_name,
-                                                       properties={"collection.ttl.seconds": 3600})
-        self.milvus_client.alter_collection_properties(collection_name=self.c_name, 
-                                                       properties={"dynamicfield.enabled": True})
+        self.milvus_client.alter_collection_properties(collection_name=self.c_name, properties={"mmap.enabled": True})
+        self.milvus_client.alter_collection_properties(
+            collection_name=self.c_name, properties={"collection.ttl.seconds": 3600}
+        )
+        self.milvus_client.alter_collection_properties(
+            collection_name=self.c_name, properties={"dynamicfield.enabled": True}
+        )
         res = self.milvus_client.describe_collection(collection_name=self.c_name)
         log.info(f"after alter collection {self.c_name} schema: {res}")
-        
+
     @trace()
     def alter_check(self):
         try:
@@ -2497,7 +2694,7 @@ class AlterCollectionChecker(Checker):
                 return res, False
             if properties.get("collection.ttl.seconds") != "3600":
                 return res, False
-            if res["enable_dynamic_field"] != True:
+            if not res["enable_dynamic_field"]:
                 return res, False
             return res, True
         except Exception as e:
@@ -2536,14 +2733,12 @@ class SnapshotChecker(Checker):
         try:
             # 1. Create snapshot
             self.snapshot_name = cf.gen_unique_str("snapshot_")
-            self.milvus_client.create_snapshot(self.c_name, self.snapshot_name)
+            self.milvus_client.create_snapshot(self.snapshot_name, self.c_name)
             log.info(f"[SnapshotChecker] Created snapshot {self.snapshot_name} for {self.c_name}")
 
             # 2. Restore to new collection
             self.restored_collection = cf.gen_unique_str("restored_")
-            job_id = self.milvus_client.restore_snapshot(
-                self.snapshot_name, self.restored_collection
-            )
+            job_id = self.milvus_client.restore_snapshot(self.snapshot_name, self.c_name, self.restored_collection)
             log.info(f"[SnapshotChecker] Started restore job {job_id}")
 
             # 3. Wait for restore completion
@@ -2553,7 +2748,7 @@ class SnapshotChecker(Checker):
                 state = self.milvus_client.get_restore_snapshot_state(job_id)
                 log.debug(f"[SnapshotChecker] Restore state: {state.state}")
                 if state.state == "RestoreSnapshotCompleted":
-                    log.info(f"[SnapshotChecker] Restore completed in {time.time()-start_time:.1f}s")
+                    log.info(f"[SnapshotChecker] Restore completed in {time.time() - start_time:.1f}s")
                     return None, True
                 if state.state == "RestoreSnapshotFailed":
                     return f"Restore failed: {state.reason}", False
@@ -2577,7 +2772,7 @@ class SnapshotChecker(Checker):
             log.warning(f"[SnapshotChecker] Failed to drop restored collection: {e}")
         try:
             if self.snapshot_name:
-                self.milvus_client.drop_snapshot(self.snapshot_name)
+                self.milvus_client.drop_snapshot(self.snapshot_name, collection_name=self.c_name)
                 log.debug(f"[SnapshotChecker] Dropped snapshot {self.snapshot_name}")
                 self.snapshot_name = None
         except Exception as e:
@@ -2632,7 +2827,7 @@ class SnapshotRestoreChecker(Checker):
             collection_name=self.c_name,
             filter=f"{self.int64_field_name} >= 0",
             output_fields=[self.int64_field_name],
-            limit=nb
+            limit=nb,
         )
         if not res:
             return
@@ -2645,11 +2840,7 @@ class SnapshotRestoreChecker(Checker):
 
     def _do_delete(self, nb=5):
         """Delete rows from the checker's own collection, keeping at least 100 rows."""
-        count_res = self.milvus_client.query(
-            collection_name=self.c_name,
-            filter="",
-            output_fields=["count(*)"]
-        )
+        count_res = self.milvus_client.query(collection_name=self.c_name, filter="", output_fields=["count(*)"])
         row_count = count_res[0]["count(*)"] if count_res else 0
         if row_count <= 100:
             return
@@ -2657,7 +2848,7 @@ class SnapshotRestoreChecker(Checker):
             collection_name=self.c_name,
             filter=f"{self.int64_field_name} >= 0",
             output_fields=[self.int64_field_name],
-            limit=nb
+            limit=nb,
         )
         if not res:
             return
@@ -2668,13 +2859,13 @@ class SnapshotRestoreChecker(Checker):
 
     def _do_dml_operations(self):
         """Execute a random DML operation on the checker's own collection."""
-        op = random.choice(['insert', 'upsert', 'delete'])
+        op = random.choice(["insert", "upsert", "delete"])
         try:
-            if op == 'insert':
+            if op == "insert":
                 self._do_insert(nb=10)
-            elif op == 'upsert':
+            elif op == "upsert":
                 self._do_upsert(nb=5)
-            elif op == 'delete':
+            elif op == "delete":
                 self._do_delete(nb=5)
         except Exception as e:
             log.warning(f"[SnapshotRestoreChecker] DML operation {op} failed: {e}")
@@ -2683,10 +2874,7 @@ class SnapshotRestoreChecker(Checker):
         """Capture current collection state after flush."""
         try:
             res = self.milvus_client.query(
-                collection_name=self.c_name,
-                filter="",
-                output_fields=["count(*)"],
-                consistency_level="Strong"
+                collection_name=self.c_name, filter="", output_fields=["count(*)"], consistency_level="Strong"
             )
             self.snapshot_row_count = res[0]["count(*)"] if res else 0
 
@@ -2697,13 +2885,15 @@ class SnapshotRestoreChecker(Checker):
                     filter=f"{self.int64_field_name} >= 0",
                     output_fields=[self.int64_field_name],
                     limit=sample_size,
-                    consistency_level="Strong"
+                    consistency_level="Strong",
                 )
                 self.snapshot_sample_pks = [r[self.int64_field_name] for r in res]
             else:
                 self.snapshot_sample_pks = []
 
-            log.info(f"[SnapshotRestoreChecker] Captured snapshot state: row_count={self.snapshot_row_count}, sample_pks={len(self.snapshot_sample_pks)}")
+            log.info(
+                f"[SnapshotRestoreChecker] Captured snapshot state: row_count={self.snapshot_row_count}, sample_pks={len(self.snapshot_sample_pks)}"
+            )
         except Exception as e:
             log.warning(f"Failed to capture snapshot state: {e}")
             self.snapshot_row_count = 0
@@ -2719,14 +2909,13 @@ class SnapshotRestoreChecker(Checker):
 
         try:
             res = self.milvus_client.query(
-                collection_name=restored_name,
-                filter="",
-                output_fields=["count(*)"],
-                consistency_level="Strong"
+                collection_name=restored_name, filter="", output_fields=["count(*)"], consistency_level="Strong"
             )
             actual_count = res[0]["count(*)"] if res else 0
 
-            log.info(f"[SnapshotRestoreChecker] Verify restored data: expected={self.snapshot_row_count}, actual={actual_count}")
+            log.info(
+                f"[SnapshotRestoreChecker] Verify restored data: expected={self.snapshot_row_count}, actual={actual_count}"
+            )
 
             if actual_count != self.snapshot_row_count:
                 return False, f"Row count mismatch: expected {self.snapshot_row_count}, got {actual_count}"
@@ -2737,7 +2926,7 @@ class SnapshotRestoreChecker(Checker):
                     collection_name=restored_name,
                     filter=filter_expr,
                     output_fields=[self.int64_field_name],
-                    consistency_level="Strong"
+                    consistency_level="Strong",
                 )
                 found_pks = {r[self.int64_field_name] for r in res}
                 expected_pks = set(self.snapshot_sample_pks)
@@ -2758,25 +2947,27 @@ class SnapshotRestoreChecker(Checker):
                 self._do_dml_operations()
                 time.sleep(0.1)
 
-            # 2. Flush and capture state (no lock needed - this is our own collection)
+            # 2. Flush and create snapshot (no lock needed - this is our own collection)
             self.milvus_client.flush(collection_name=self.c_name)
             log.debug(f"Flushed collection {self.c_name}")
             time.sleep(1)
 
+            # 3. Create snapshot first, then capture state.
+            # Capturing state AFTER snapshot creation ensures the count query's
+            # guarantee timestamp >= snapshot's timestamp, so the count reflects
+            # at least all data the snapshot contains. Since no DML happens between
+            # snapshot creation and the count, they will match exactly.
+            self.snapshot_name = cf.gen_unique_str("snapshot_")
+            self.milvus_client.create_snapshot(self.snapshot_name, self.c_name)
+            log.info(f"Created snapshot {self.snapshot_name} for collection {self.c_name}")
+
             self._capture_snapshot_state()
             row_count_before = self.snapshot_row_count
-            log.info(f"State before snapshot: row_count={row_count_before}, sample_pks={len(self.snapshot_sample_pks)}")
-
-            # 3. Create snapshot
-            self.snapshot_name = cf.gen_unique_str("snapshot_")
-            self.milvus_client.create_snapshot(self.c_name, self.snapshot_name)
-            log.info(f"Created snapshot {self.snapshot_name} for collection {self.c_name}")
+            log.info(f"State after snapshot: row_count={row_count_before}, sample_pks={len(self.snapshot_sample_pks)}")
 
             # 4. Restore to new collection
             self.restored_collection = cf.gen_unique_str("restored_")
-            job_id = self.milvus_client.restore_snapshot(
-                self.snapshot_name, self.restored_collection
-            )
+            job_id = self.milvus_client.restore_snapshot(self.snapshot_name, self.c_name, self.restored_collection)
             log.info(f"Started restore job {job_id} to collection {self.restored_collection}")
 
             # 5. Wait for restore completion
@@ -2786,7 +2977,7 @@ class SnapshotRestoreChecker(Checker):
                 state = self.milvus_client.get_restore_snapshot_state(job_id)
                 log.debug(f"Restore state: {state.state}")
                 if state.state == "RestoreSnapshotCompleted":
-                    log.info(f"Restore job {job_id} completed in {time.time()-start_time:.1f}s")
+                    log.info(f"Restore job {job_id} completed in {time.time() - start_time:.1f}s")
                     break
                 if state.state == "RestoreSnapshotFailed":
                     return f"Restore failed: {state.reason}", False
@@ -2820,7 +3011,7 @@ class SnapshotRestoreChecker(Checker):
 
         try:
             if self.snapshot_name:
-                self.milvus_client.drop_snapshot(self.snapshot_name)
+                self.milvus_client.drop_snapshot(self.snapshot_name, collection_name=self.c_name)
                 log.debug(f"Dropped snapshot {self.snapshot_name}")
                 self.snapshot_name = None
         except Exception as e:
@@ -2849,12 +3040,10 @@ class NullVectorSearchChecker(Checker):
         # Collect nullable dense vector fields
         self.nullable_vector_fields = []
         for field in self.schema.fields:
-            if field.dtype in ct.all_dense_vector_types and getattr(field, 'nullable', False):
-                self.nullable_vector_fields.append({
-                    "name": field.name,
-                    "dim": getattr(field, 'dim', ct.default_dim),
-                    "dtype": field.dtype
-                })
+            if field.dtype in ct.all_dense_vector_types and getattr(field, "nullable", False):
+                self.nullable_vector_fields.append(
+                    {"name": field.name, "dim": getattr(field, "dim", ct.default_dim), "dtype": field.dtype}
+                )
         self.data = None
         self.anns_field_name = None
         self.search_param = None
@@ -2870,7 +3059,7 @@ class NullVectorSearchChecker(Checker):
                 search_params=self.search_param,
                 limit=5,
                 partition_names=self.p_names,
-                timeout=search_timeout
+                timeout=search_timeout,
             )
             return res, True
         except Exception as e:
@@ -2903,7 +3092,7 @@ class NullVectorSearchChecker(Checker):
         try:
             for hits in res:
                 for hit in hits:
-                    if math.isnan(hit.get('distance', 0)):
+                    if math.isnan(hit.get("distance", 0)):
                         has_nan = True
                         break
                 if has_nan:
@@ -2913,8 +3102,10 @@ class NullVectorSearchChecker(Checker):
 
         if has_nan:
             self._nan_consecutive += 1
-            log.warning(f"[NullVectorSearchChecker] NaN distance on '{self.anns_field_name}' "
-                        f"(consecutive={self._nan_consecutive}/{self.NAN_THRESHOLD})")
+            log.warning(
+                f"[NullVectorSearchChecker] NaN distance on '{self.anns_field_name}' "
+                f"(consecutive={self._nan_consecutive}/{self.NAN_THRESHOLD})"
+            )
             if self._nan_consecutive >= self.NAN_THRESHOLD:
                 self._nan_consecutive = 0
                 return "null vector leaked into search index (NaN distance)", False
@@ -2930,7 +3121,18 @@ class NullVectorSearchChecker(Checker):
 
 
 class NullVectorQueryChecker(Checker):
-    """check query operations on nullable vector fields, validate null/non-null ratio consistency"""
+    """check query operations on nullable vector fields.
+
+    Verifies that rows inserted with non-null vector values remain correctly
+    queryable under chaos.  At init time a sample of PKs whose nullable vector
+    field is non-null is collected; each query() call fetches those specific rows
+    and asserts they are still non-null.
+
+    Avoids using 'vec_field is not null' as a server-side filter because Milvus
+    does not yet support IsNull/IsNotNull on vector fields.  Excludes dynamically-
+    added new_vec_* fields: segments sealed before those fields were added have
+    all-null values by design, so sampling those fields at init would yield no PKs.
+    """
 
     def __init__(self, collection_name=None, shards_num=2, replica_number=1, schema=None):
         if collection_name is None:
@@ -2940,32 +3142,96 @@ class NullVectorQueryChecker(Checker):
         self.milvus_client.create_index(collection_name=self.c_name, index_params=index_params)
         self.milvus_client.load_collection(collection_name=self.c_name, replica_number=replica_number)
         self.insert_data()
-        # Collect nullable dense vector field names
+        # Only collect nullable dense vector fields from the original schema.
+        # Exclude new_vec_* (dynamically added by AddVectorFieldChecker): pre-existing
+        # segments have all-null for those fields by design.
         self.nullable_vector_fields = []
         for field in self.schema.fields:
-            if field.dtype in ct.all_dense_vector_types and getattr(field, 'nullable', False):
-                self.nullable_vector_fields.append(field.name)
+            if field.dtype in ct.all_dense_vector_types and getattr(field, "nullable", False):
+                if not field.name.startswith("new_vec_"):
+                    self.nullable_vector_fields.append(field.name)
         self.term_expr = f"{self.int64_field_name} > 0"
+        # Sample PKs that are known to have non-null data for each nullable field.
+        # gen_row_data_by_schema inserts 80% non-null for nullable vector fields, so
+        # a large-enough query will always find non-null rows among original schema fields.
+        self._non_null_pk_samples = self._collect_non_null_pk_samples()
+
+    def _collect_non_null_pk_samples(self, sample_size=20):
+        """Return {field_name: [pk, ...]} for rows with non-null vector data."""
+        samples = {}
+        for field_name in self.nullable_vector_fields:
+            try:
+                res = self.milvus_client.query(
+                    collection_name=self.c_name,
+                    filter=self.term_expr,
+                    output_fields=[self.int64_field_name, field_name],
+                    limit=500,
+                    timeout=query_timeout,
+                )
+                non_null_pks = [r[self.int64_field_name] for r in res if r.get(field_name) is not None]
+                samples[field_name] = non_null_pks[:sample_size]
+                log.info(
+                    f"[NullVectorQueryChecker] field='{field_name}': sampled {len(samples[field_name])} non-null PKs"
+                )
+            except Exception as e:
+                log.warning(f"[NullVectorQueryChecker] failed to sample non-null PKs for '{field_name}': {e}")
+                samples[field_name] = []
+        return samples
 
     @trace()
     def query(self):
         try:
             vec_field = random.choice(self.nullable_vector_fields)
+            pks = self._non_null_pk_samples.get(vec_field, [])
+
+            if not pks:
+                # No sampled PKs — fall back to a plain scalar filter with Python-side check.
+                # For original-schema nullable fields (80% non-null insert ratio) an all-null
+                # result over limit=50 rows is statistically implausible and signals corruption.
+                res = self.milvus_client.query(
+                    collection_name=self.c_name,
+                    filter=self.term_expr,
+                    output_fields=[self.int64_field_name, vec_field],
+                    limit=50,
+                    timeout=query_timeout,
+                )
+                non_null = [r for r in res if r.get(vec_field) is not None]
+                if res and not non_null:
+                    return (f"all {len(res)} rows have null '{vec_field}', possible data corruption"), False
+                log.debug(f"[NullVectorQueryChecker] fallback: '{vec_field}' {len(non_null)}/{len(res)} non-null")
+                return res, True
+
+            # Query a random subset of known non-null PKs and verify they are still non-null.
+            sample_pks = random.sample(pks, min(10, len(pks)))
             res = self.milvus_client.query(
                 collection_name=self.c_name,
-                filter=self.term_expr,
+                filter=f"{self.int64_field_name} in {sample_pks}",
                 output_fields=[self.int64_field_name, vec_field],
-                limit=50,
-                timeout=query_timeout
+                timeout=query_timeout,
             )
-            # Validate: all-null results indicate possible data corruption
-            null_count = sum(1 for r in res if r.get(vec_field) is None)
-            non_null_count = len(res) - null_count
-            log.debug(f"[NullVectorQueryChecker] field='{vec_field}': "
-                      f"{len(res)} results, {null_count} null, {non_null_count} non-null")
-            if len(res) > 10 and null_count == len(res):
-                return (f"all {len(res)} vectors are null for field '{vec_field}', "
-                        f"possible data corruption"), False
+            if not res:
+                # Empty result — sampled PKs may have been deleted by concurrent DeleteChecker.
+                # Refresh sample so subsequent calls use valid PKs, and treat as non-failure.
+                self._non_null_pk_samples = self._collect_non_null_pk_samples()
+                log.debug(
+                    f"[NullVectorQueryChecker] field='{vec_field}': 0/{len(sample_pks)} PKs returned "
+                    f"— rows may have been deleted; sample refreshed"
+                )
+                return res, True
+            null_rows = [r for r in res if r.get(vec_field) is None]
+            if null_rows:
+                # Null rows for sampled PKs can legitimately happen when UpsertChecker
+                # overwrites those rows with null vector values (nullable field). Treat
+                # as stale sample rather than data corruption, refresh, and skip.
+                self._non_null_pk_samples = self._collect_non_null_pk_samples()
+                log.debug(
+                    f"[NullVectorQueryChecker] field='{vec_field}': {len(null_rows)}/{len(res)} null rows "
+                    f"— may have been upserted with null; sample refreshed"
+                )
+                return res, True
+            log.debug(
+                f"[NullVectorQueryChecker] field='{vec_field}': {len(res)}/{len(sample_pks)} non-null rows verified"
+            )
             return res, True
         except Exception as e:
             log.info(f"[NullVectorQueryChecker] query error: {e}")
@@ -3006,15 +3272,19 @@ class AddVectorFieldChecker(Checker):
                 field_name=new_vec_field,
                 data_type=DataType.FLOAT_VECTOR,
                 dim=dim,
-                nullable=True)
+                nullable=True,
+            )
             log.debug(f"[AddVectorFieldChecker] added field {new_vec_field} (dim={dim})")
             time.sleep(1)
 
             # Create HNSW index for new vector field
             index_params = IndexParams()
-            index_params.add_index(field_name=new_vec_field, index_type="HNSW",
-                                   metric_type="COSINE",
-                                   params={"M": 16, "efConstruction": 200})
+            index_params.add_index(
+                field_name=new_vec_field,
+                index_type="HNSW",
+                metric_type="COSINE",
+                params={"M": 16, "efConstruction": 200},
+            )
             self.milvus_client.create_index(collection_name=self.c_name, index_params=index_params)
             log.debug(f"[AddVectorFieldChecker] created index for {new_vec_field}")
 
@@ -3029,7 +3299,7 @@ class AddVectorFieldChecker(Checker):
                 filter=f"{self.int64_field_name} > 0",
                 output_fields=[new_vec_field],
                 limit=10,
-                timeout=query_timeout
+                timeout=query_timeout,
             )
             if len(res) == 0:
                 return "query returned 0 rows after add vector field", False
@@ -3040,7 +3310,7 @@ class AddVectorFieldChecker(Checker):
         except Exception as e:
             # When vector field limit is reached, fallback to insert only
             if "maximum vector field" in str(e):
-                log.info(f"[AddVectorFieldChecker] vector field limit reached, fallback to insert only")
+                log.info("[AddVectorFieldChecker] vector field limit reached, fallback to insert only")
                 try:
                     _, insert_result = self.insert_data()
                     return None, insert_result
@@ -3087,17 +3357,21 @@ class EntityTTLChecker(Checker):
             collection_name = cf.gen_unique_str("EntityTTLChecker_")
 
         # Build TTL-specific schema
-        from pymilvus import CollectionSchema as CS, FieldSchema
-        schema = CS(fields=[
-            FieldSchema(name="pk", dtype=DataType.INT64, is_primary=True, auto_id=True),
-            FieldSchema(name="vector", dtype=DataType.FLOAT_VECTOR, dim=self.DIM),
-            FieldSchema(name="bucket", dtype=DataType.VARCHAR, max_length=16),
-            FieldSchema(name="ttl", dtype=DataType.TIMESTAMPTZ, nullable=True),
-        ], enable_dynamic_field=False)
+        from pymilvus import CollectionSchema as CS
+        from pymilvus import FieldSchema
+
+        schema = CS(
+            fields=[
+                FieldSchema(name="pk", dtype=DataType.INT64, is_primary=True, auto_id=True),
+                FieldSchema(name="vector", dtype=DataType.FLOAT_VECTOR, dim=self.DIM),
+                FieldSchema(name="bucket", dtype=DataType.VARCHAR, max_length=16),
+                FieldSchema(name="ttl", dtype=DataType.TIMESTAMPTZ, nullable=True),
+            ],
+            enable_dynamic_field=False,
+        )
 
         # Skip default data insertion — we manage our own inserts
-        super().__init__(collection_name=collection_name, schema=schema,
-                         insert_data=False, dim=self.DIM, **kwargs)
+        super().__init__(collection_name=collection_name, schema=schema, insert_data=False, dim=self.DIM, **kwargs)
 
         # Set collection TTL properties
         self.milvus_client.alter_collection_properties(
@@ -3118,8 +3392,7 @@ class EntityTTLChecker(Checker):
         self.inserted_counts = {b: 0 for b in self.BUCKETS}
         self._counts_lock = threading.Lock()
 
-        log.info(f"EntityTTLChecker initialized: collection={self.c_name}, "
-                 f"bucket_expiry={self.bucket_expiry}")
+        log.info(f"EntityTTLChecker initialized: collection={self.c_name}, bucket_expiry={self.bucket_expiry}")
 
     def _get_ttl_value(self, bucket_name):
         """Get the fixed TTL timestamp string for a bucket."""
@@ -3140,11 +3413,9 @@ class EntityTTLChecker(Checker):
         bucket_name = random.choice(list(self.BUCKETS.keys()))
         ttl_value = self._get_ttl_value(bucket_name)
         vectors = cf.gen_vectors(self.INSERT_NB, self.DIM)
-        rows = [{"vector": list(vectors[i]), "bucket": bucket_name,
-                 "ttl": ttl_value} for i in range(self.INSERT_NB)]
+        rows = [{"vector": list(vectors[i]), "bucket": bucket_name, "ttl": ttl_value} for i in range(self.INSERT_NB)]
         try:
-            self.milvus_client.insert(collection_name=self.c_name, data=rows,
-                                      timeout=timeout)
+            self.milvus_client.insert(collection_name=self.c_name, data=rows, timeout=timeout)
             with self._counts_lock:
                 self.inserted_counts[bucket_name] += self.INSERT_NB
             log.debug(f"EntityTTLChecker inserted {self.INSERT_NB} rows into bucket '{bucket_name}'")
@@ -3202,21 +3473,21 @@ class EntityTTLChecker(Checker):
                 expected = 0
                 ok = actual_count == 0
                 if not ok:
-                    log.error(f"EntityTTLChecker bucket '{bucket_name}': "
-                              f"expected 0 (expired), got {actual_count}")
+                    log.error(f"EntityTTLChecker bucket '{bucket_name}': expected 0 (expired), got {actual_count}")
                     all_ok = False
             else:
                 # All data should be present
                 expected = total_inserted
                 ok = actual_count == expected
                 if not ok:
-                    log.error(f"EntityTTLChecker bucket '{bucket_name}': "
-                              f"expected {expected}, got {actual_count}")
+                    log.error(f"EntityTTLChecker bucket '{bucket_name}': expected {expected}, got {actual_count}")
                     all_ok = False
 
             results[bucket_name] = {
-                "expected": expected, "actual": actual_count,
-                "expired": expired, "ok": ok,
+                "expected": expected,
+                "actual": actual_count,
+                "expired": expired,
+                "ok": ok,
             }
 
         log.info(f"EntityTTLChecker verify: {results}")
@@ -3263,5 +3534,5 @@ class TestResultAnalyzer(unittest.TestCase):
         print(res)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/python_client/milvus_client/test_milvus_client_snapshot.py
+++ b/tests/python_client/milvus_client/test_milvus_client_snapshot.py
@@ -9,6 +9,7 @@ from common import common_func as cf
 from common import common_type as ct
 from common.common_type import CaseLabel, CheckTasks
 from pymilvus import DataType
+from ml_dtypes import bfloat16
 
 
 prefix = "snapshot"
@@ -36,7 +37,6 @@ default_float_field_name = ct.default_float_field_name
 default_string_field_name = ct.default_string_field_name
 
 
-@pytest.mark.skip(reason="pymilvus SDK does not yet support collection_name for snapshot APIs")
 class TestMilvusClientSnapshotDefault(TestMilvusClientV2Base):
     """Test snapshot basic operations - L0 smoke tests"""
 
@@ -72,13 +72,13 @@ class TestMilvusClientSnapshotDefault(TestMilvusClientV2Base):
         assert snapshot_name in snapshots, f"Snapshot {snapshot_name} not found in list"
 
         # 4. Describe snapshot
-        info, _ = self.describe_snapshot(client, snapshot_name)
+        info, _ = self.describe_snapshot(client, snapshot_name, collection_name)
         assert info.name == snapshot_name
         assert info.collection_name == collection_name
         assert info.create_ts > 0
 
         # 5. Drop snapshot
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
 
         # 6. Verify snapshot is dropped
         snapshots, _ = self.list_snapshots(client, collection_name=collection_name)
@@ -112,7 +112,8 @@ class TestMilvusClientSnapshotDefault(TestMilvusClientV2Base):
         self.create_snapshot(client, collection_name, snapshot_name)
 
         # 3. Restore snapshot to new collection
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         assert job_id > 0, "restore_snapshot should return a valid job_id"
 
         # 4. Wait for restore to complete
@@ -127,12 +128,11 @@ class TestMilvusClientSnapshotDefault(TestMilvusClientV2Base):
             f"Restored collection should have {default_nb} rows, got {restored_count}"
 
         # 6. Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
 
 
-@pytest.mark.skip(reason="pymilvus SDK does not yet support collection_name for snapshot APIs")
 class TestMilvusClientSnapshotCreateInvalid(TestMilvusClientV2Base):
     """Test create_snapshot with invalid parameters - L1"""
 
@@ -206,7 +206,7 @@ class TestMilvusClientSnapshotCreateInvalid(TestMilvusClientV2Base):
                              check_task=CheckTasks.err_res, check_items=error)
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_snapshot_create_empty_collection(self):
@@ -227,10 +227,9 @@ class TestMilvusClientSnapshotCreateInvalid(TestMilvusClientV2Base):
         assert snapshot_name in snapshots
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
 
 
-@pytest.mark.skip(reason="pymilvus SDK does not yet support collection_name for snapshot APIs")
 class TestMilvusClientSnapshotDropInvalid(TestMilvusClientV2Base):
     """Test drop_snapshot with invalid parameters - L1"""
 
@@ -244,9 +243,9 @@ class TestMilvusClientSnapshotDropInvalid(TestMilvusClientV2Base):
         """
         client = self._client()
 
-        # SDK validates snapshot_name and raises ParamError
+        # SDK validates snapshot_name and raises ParamError before checking collection_name
         error = {ct.err_code: 1, ct.err_msg: "snapshot_name must be a non-empty string"}
-        self.drop_snapshot(client, snapshot_name,
+        self.drop_snapshot(client, snapshot_name, "",
                            check_task=CheckTasks.err_res, check_items=error)
 
     @pytest.mark.tags(CaseLabel.L1)
@@ -259,10 +258,12 @@ class TestMilvusClientSnapshotDropInvalid(TestMilvusClientV2Base):
         Fixed in PR #47096: Server now validates snapshot names using standard naming rules.
         """
         client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        self.create_collection(client, collection_name, default_dim)
 
         # Server validates snapshot name and rejects whitespace-only names
         error = {ct.err_code: 1100, ct.err_msg: "snapshot name should be not empty"}
-        self.drop_snapshot(client, " ",
+        self.drop_snapshot(client, " ", collection_name,
                            check_task=CheckTasks.err_res, check_items=error)
 
     @pytest.mark.tags(CaseLabel.L1)
@@ -273,13 +274,14 @@ class TestMilvusClientSnapshotDropInvalid(TestMilvusClientV2Base):
         expected: should succeed (idempotent behavior)
         """
         client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        self.create_collection(client, collection_name, default_dim)
         snapshot_name = cf.gen_unique_str("non_existent")
 
         # Should not raise exception (idempotent)
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
 
 
-@pytest.mark.skip(reason="pymilvus SDK does not yet support collection_name for snapshot APIs")
 class TestMilvusClientSnapshotListDescribe(TestMilvusClientV2Base):
     """Test list_snapshots and describe_snapshot - L1"""
 
@@ -307,7 +309,7 @@ class TestMilvusClientSnapshotListDescribe(TestMilvusClientV2Base):
 
         # Cleanup
         for name in snapshot_names:
-            self.drop_snapshot(client, name)
+            self.drop_snapshot(client, name, collection_name)
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_snapshot_list_by_collection(self):
@@ -334,8 +336,8 @@ class TestMilvusClientSnapshotListDescribe(TestMilvusClientV2Base):
         assert snapshot_name2 not in snapshots
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name1)
-        self.drop_snapshot(client, snapshot_name2)
+        self.drop_snapshot(client, snapshot_name1, collection_name1)
+        self.drop_snapshot(client, snapshot_name2, collection_name2)
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_snapshot_list_empty(self):
@@ -359,10 +361,12 @@ class TestMilvusClientSnapshotListDescribe(TestMilvusClientV2Base):
         expected: raise exception
         """
         client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        self.create_collection(client, collection_name, default_dim)
         snapshot_name = cf.gen_unique_str("non_existent")
 
         error = {ct.err_code: 1, ct.err_msg: "not found"}
-        self.describe_snapshot(client, snapshot_name,
+        self.describe_snapshot(client, snapshot_name, collection_name,
                                check_task=CheckTasks.err_res, check_items=error)
 
     @pytest.mark.tags(CaseLabel.L1)
@@ -380,14 +384,13 @@ class TestMilvusClientSnapshotListDescribe(TestMilvusClientV2Base):
         self.create_collection(client, collection_name, default_dim)
         self.create_snapshot(client, collection_name, snapshot_name, description=description)
 
-        info, _ = self.describe_snapshot(client, snapshot_name)
+        info, _ = self.describe_snapshot(client, snapshot_name, collection_name)
         assert info.description == description
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
 
 
-@pytest.mark.skip(reason="pymilvus SDK does not yet support collection_name for snapshot APIs")
 class TestMilvusClientSnapshotRestoreInvalid(TestMilvusClientV2Base):
     """Test restore_snapshot with invalid parameters - L1"""
 
@@ -399,11 +402,14 @@ class TestMilvusClientSnapshotRestoreInvalid(TestMilvusClientV2Base):
         expected: raise exception
         """
         client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        self.create_collection(client, collection_name, default_dim)
         snapshot_name = cf.gen_unique_str("non_existent")
-        collection_name = cf.gen_unique_str(prefix)
+        target_collection_name = cf.gen_unique_str(prefix + "_target")
 
         error = {ct.err_code: 1, ct.err_msg: "not found"}
-        self.restore_snapshot(client, snapshot_name, collection_name,
+        self.restore_snapshot(client, snapshot_name, target_collection_name,
+                              source_collection_name=collection_name,
                               check_task=CheckTasks.err_res, check_items=error)
 
     @pytest.mark.tags(CaseLabel.L1)
@@ -427,13 +433,13 @@ class TestMilvusClientSnapshotRestoreInvalid(TestMilvusClientV2Base):
 
         error = {ct.err_code: 65535, ct.err_msg: "duplicate collection"}
         self.restore_snapshot(client, snapshot_name, target_collection_name,
+                              source_collection_name=collection_name,
                               check_task=CheckTasks.err_res, check_items=error)
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
 
 
-@pytest.mark.skip(reason="pymilvus SDK does not yet support collection_name for snapshot APIs")
 class TestMilvusClientSnapshotRestoreState(TestMilvusClientV2Base):
     """Test get_restore_snapshot_state and list_restore_snapshot_jobs - L1"""
 
@@ -464,7 +470,6 @@ class TestMilvusClientSnapshotRestoreState(TestMilvusClientV2Base):
         assert isinstance(jobs, list), "list_restore_snapshot_jobs should return a list"
 
 
-@pytest.mark.skip(reason="pymilvus SDK does not yet support collection_name for snapshot APIs")
 class TestMilvusClientSnapshotDataTypes(TestMilvusClientV2Base):
     """Test snapshot with various data types - L2"""
 
@@ -492,7 +497,8 @@ class TestMilvusClientSnapshotDataTypes(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify data
@@ -504,7 +510,7 @@ class TestMilvusClientSnapshotDataTypes(TestMilvusClientV2Base):
         assert ids == list(range(100))
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -540,7 +546,8 @@ class TestMilvusClientSnapshotDataTypes(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify data
@@ -550,7 +557,7 @@ class TestMilvusClientSnapshotDataTypes(TestMilvusClientV2Base):
         assert len(res) == 100
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -589,7 +596,8 @@ class TestMilvusClientSnapshotDataTypes(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify data count
@@ -599,7 +607,7 @@ class TestMilvusClientSnapshotDataTypes(TestMilvusClientV2Base):
         assert res[0]["count(*)"] == 100
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -637,7 +645,8 @@ class TestMilvusClientSnapshotDataTypes(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify JSON data
@@ -647,7 +656,7 @@ class TestMilvusClientSnapshotDataTypes(TestMilvusClientV2Base):
         assert res[0]["metadata"]["key"] == "value_0"
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -685,7 +694,8 @@ class TestMilvusClientSnapshotDataTypes(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify dynamic field data
@@ -696,12 +706,11 @@ class TestMilvusClientSnapshotDataTypes(TestMilvusClientV2Base):
         assert res[0]["dynamic_field_2"] == 0
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
 
 
-@pytest.mark.skip(reason="pymilvus SDK does not yet support collection_name for snapshot APIs")
 class TestMilvusClientSnapshotPartition(TestMilvusClientV2Base):
     """Test snapshot with partitions - L2"""
 
@@ -737,7 +746,8 @@ class TestMilvusClientSnapshotPartition(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify partitions are preserved
@@ -754,7 +764,7 @@ class TestMilvusClientSnapshotPartition(TestMilvusClientV2Base):
             assert res[0]["count(*)"] == 100, f"Partition {p_name} should have 100 rows"
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -790,7 +800,8 @@ class TestMilvusClientSnapshotPartition(TestMilvusClientV2Base):
         self.drop_partition(client, collection_name, partition_name)
 
         # Restore snapshot
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify partition is restored
@@ -805,12 +816,11 @@ class TestMilvusClientSnapshotPartition(TestMilvusClientV2Base):
         assert res[0]["count(*)"] == 100
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
 
 
-@pytest.mark.skip(reason="pymilvus SDK does not yet support collection_name for snapshot APIs")
 class TestMilvusClientSnapshotDataOperations(TestMilvusClientV2Base):
     """Test snapshot with data operations - L2"""
 
@@ -845,7 +855,8 @@ class TestMilvusClientSnapshotDataOperations(TestMilvusClientV2Base):
         self.create_snapshot(client, collection_name, snapshot_name)
 
         # Restore
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify only 50 rows remain
@@ -855,7 +866,7 @@ class TestMilvusClientSnapshotDataOperations(TestMilvusClientV2Base):
         assert res[0]["count(*)"] == 50
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -898,7 +909,8 @@ class TestMilvusClientSnapshotDataOperations(TestMilvusClientV2Base):
         assert res[0]["count(*)"] == 150
 
         # Restore snapshot
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Restored collection should only have 100 rows (point-in-time)
@@ -908,7 +920,7 @@ class TestMilvusClientSnapshotDataOperations(TestMilvusClientV2Base):
         assert res[0]["count(*)"] == 100
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -973,7 +985,8 @@ class TestMilvusClientSnapshotDataOperations(TestMilvusClientV2Base):
         log.info("Created snapshot (without triggering flush)")
 
         # Restore snapshot to new collection
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify restored collection data count
@@ -1001,12 +1014,11 @@ class TestMilvusClientSnapshotDataOperations(TestMilvusClientV2Base):
         log.info("Verified: Snapshot does NOT include growing segment data")
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
 
 
-@pytest.mark.skip(reason="pymilvus SDK does not yet support collection_name for snapshot APIs")
 class TestMilvusClientSnapshotIndex(TestMilvusClientV2Base):
     """Test snapshot with various index types - L2"""
 
@@ -1045,7 +1057,8 @@ class TestMilvusClientSnapshotIndex(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify index is preserved
@@ -1060,12 +1073,11 @@ class TestMilvusClientSnapshotIndex(TestMilvusClientV2Base):
         assert len(res[0]) == 10
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
 
 
-@pytest.mark.skip(reason="pymilvus SDK does not yet support collection_name for snapshot APIs")
 class TestMilvusClientSnapshotDataIntegrity(TestMilvusClientV2Base):
     """Test snapshot data integrity - verify actual data content, not just counts"""
 
@@ -1094,7 +1106,8 @@ class TestMilvusClientSnapshotDataIntegrity(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Query all vectors from restored collection
@@ -1112,7 +1125,7 @@ class TestMilvusClientSnapshotDataIntegrity(TestMilvusClientV2Base):
                     f"Vector mismatch at id={row['id']}, dim={j}"
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -1145,7 +1158,8 @@ class TestMilvusClientSnapshotDataIntegrity(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Search on restored collection with same queries
@@ -1161,7 +1175,7 @@ class TestMilvusClientSnapshotDataIntegrity(TestMilvusClientV2Base):
                 f"Search results mismatch for query {i}: original={original_ids}, restored={restored_ids}"
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -1206,7 +1220,8 @@ class TestMilvusClientSnapshotDataIntegrity(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Query and verify all scalar values
@@ -1223,12 +1238,11 @@ class TestMilvusClientSnapshotDataIntegrity(TestMilvusClientV2Base):
             assert row["varchar_field"] == f"string_value_{i}", f"varchar_field mismatch at id={i}"
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
 
 
-@pytest.mark.skip(reason="pymilvus SDK does not yet support collection_name for snapshot APIs")
 class TestMilvusClientSnapshotBoundary(TestMilvusClientV2Base):
     """Test snapshot boundary conditions and edge cases"""
 
@@ -1263,7 +1277,7 @@ class TestMilvusClientSnapshotBoundary(TestMilvusClientV2Base):
                 snapshots, _ = self.list_snapshots(client, collection_name=collection_name)
                 if name in snapshots:
                     results[name] = "accepted"
-                    self.drop_snapshot(client, name)
+                    self.drop_snapshot(client, name, collection_name)
                 else:
                     results[name] = "created but not listed"
             except Exception as e:
@@ -1290,7 +1304,7 @@ class TestMilvusClientSnapshotBoundary(TestMilvusClientV2Base):
             name = "s" * length
             try:
                 self.create_snapshot(client, collection_name, name)
-                self.drop_snapshot(client, name)
+                self.drop_snapshot(client, name, collection_name)
             except Exception as e:
                 found_limit = length
                 log.info(f"Snapshot name length limit is less than {length}: {e}")
@@ -1324,7 +1338,8 @@ class TestMilvusClientSnapshotBoundary(TestMilvusClientV2Base):
         self.flush(client, collection_name)
 
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
 
         # Track progress
         progress_values = []
@@ -1354,7 +1369,7 @@ class TestMilvusClientSnapshotBoundary(TestMilvusClientV2Base):
         assert final_state.time_cost > 0, "time_cost should be > 0 after completion"
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -1392,7 +1407,8 @@ class TestMilvusClientSnapshotBoundary(TestMilvusClientV2Base):
         # Restore each snapshot and verify correct count
         for i, snapshot_name in enumerate(snapshots):
             restored_name = cf.gen_unique_str(prefix + "_restored")
-            job_id, _ = self.restore_snapshot(client, snapshot_name, restored_name)
+            job_id, _ = self.restore_snapshot(client, snapshot_name, restored_name,
+                                                      source_collection_name=collection_name)
             wait_for_restore_complete(client, job_id)
 
             self.load_collection(client, restored_name)
@@ -1406,7 +1422,7 @@ class TestMilvusClientSnapshotBoundary(TestMilvusClientV2Base):
 
         # Cleanup
         for snapshot_name in snapshots:
-            self.drop_snapshot(client, snapshot_name)
+            self.drop_snapshot(client, snapshot_name, collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_snapshot_concurrent_restore(self):
@@ -1440,7 +1456,8 @@ class TestMilvusClientSnapshotBoundary(TestMilvusClientV2Base):
         for i in range(num_restores):
             restored_name = cf.gen_unique_str(prefix + f"_restored_{i}")
             restored_names.append(restored_name)
-            job_id, _ = self.restore_snapshot(client, snapshot_name, restored_name)
+            job_id, _ = self.restore_snapshot(client, snapshot_name, restored_name,
+                                                      source_collection_name=collection_name)
             restore_jobs.append(job_id)
 
         # Wait for all to complete
@@ -1455,11 +1472,10 @@ class TestMilvusClientSnapshotBoundary(TestMilvusClientV2Base):
             self.drop_collection(client, restored_name)
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
 
 
 
-@pytest.mark.skip(reason="pymilvus SDK does not yet support collection_name for snapshot APIs")
 class TestMilvusClientSnapshotNegative(TestMilvusClientV2Base):
     """Test snapshot negative scenarios and error handling"""
 
@@ -1487,21 +1503,23 @@ class TestMilvusClientSnapshotNegative(TestMilvusClientV2Base):
         self.create_snapshot(client, collection_name, snapshot_name)
 
         # Delete snapshot
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
 
         # Try to restore - should fail
         error = {ct.err_code: 1, ct.err_msg: "not found"}
         self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                              source_collection_name=collection_name,
                               check_task=CheckTasks.err_res, check_items=error)
 
     @pytest.mark.tags(CaseLabel.L2)
-    def test_snapshot_list_after_drop_collection(self):
+    def test_snapshot_cascade_delete_on_drop_collection(self):
         """
-        target: test listing snapshots after source collection is dropped
-        method: create snapshot, drop collection, list snapshots
-        expected: snapshot should still be listable (snapshot is independent)
+        target: test snapshots are cascade deleted when collection is dropped
+        method: create snapshot, drop collection, recreate collection, list snapshots
+        expected: snapshots should be automatically deleted with the collection
 
-        Fixed in PR #47096: Server now handles empty collection_name by listing all snapshots.
+        Changed in PR #48143: snapshot lifecycle is now bound to collection.
+        Dropping a collection cascades to delete all its snapshots.
         """
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
@@ -1518,25 +1536,20 @@ class TestMilvusClientSnapshotNegative(TestMilvusClientV2Base):
         self.flush(client, collection_name)
         self.create_snapshot(client, collection_name, snapshot_name)
 
-        # Drop original collection
+        # Verify snapshot exists before drop
+        snapshots, _ = self.list_snapshots(client, collection_name=collection_name)
+        assert snapshot_name in snapshots, "Snapshot should exist before collection drop"
+
+        # Drop collection - should cascade delete snapshots
         self.drop_collection(client, collection_name)
 
-        # Snapshot should still be listable
-        snapshots, _ = self.list_snapshots(client)
-        assert snapshot_name in snapshots, "Snapshot should exist after collection drop"
+        # Recreate collection with same name (this is a new collection)
+        self.create_collection(client, collection_name, default_dim)
 
-        # Should be able to restore to new collection
-        restored_collection_name = cf.gen_unique_str(prefix + "_restored")
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
-        wait_for_restore_complete(client, job_id)
-
-        self.load_collection(client, restored_collection_name)
-        res, _ = self.query(client, restored_collection_name, filter="id >= 0", output_fields=["count(*)"])
-        assert res[0]["count(*)"] == 100
-
-        # Cleanup
-        self.drop_snapshot(client, snapshot_name)
-        self.drop_collection(client, restored_collection_name)
+        # Snapshots should not exist for the new collection
+        snapshots, _ = self.list_snapshots(client, collection_name=collection_name)
+        assert len(snapshots) == 0, \
+            "Snapshots should be cascade deleted when collection is dropped"
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_snapshot_schema_consistency_autoID(self):
@@ -1569,26 +1582,26 @@ class TestMilvusClientSnapshotNegative(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify schema of restored collection
         desc = client.describe_collection(restored_collection_name)
         # Check auto_id is preserved
         pk_field = [f for f in desc["fields"] if f.get("is_primary")][0]
-        assert pk_field.get("auto_id", False) == True, "auto_id should be preserved"
+        assert pk_field.get("auto_id", False), "auto_id should be preserved"
 
         # Verify can insert without id
         new_rows = [{"vector": list(rng.random(default_dim))} for _ in range(10)]
         self.insert(client, restored_collection_name, new_rows)
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
 
 
-@pytest.mark.skip(reason="pymilvus SDK does not yet support collection_name for snapshot APIs")
 class TestMilvusClientSnapshotAllDataTypes(TestMilvusClientV2Base):
     """
     L2 Test - Snapshot with all data types matrix testing
@@ -1643,7 +1656,8 @@ class TestMilvusClientSnapshotAllDataTypes(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify all scalar data
@@ -1666,7 +1680,7 @@ class TestMilvusClientSnapshotAllDataTypes(TestMilvusClientV2Base):
             assert row["varchar_field"] == f"string_{i}", f"varchar_field mismatch at id={i}"
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -1712,7 +1726,8 @@ class TestMilvusClientSnapshotAllDataTypes(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify array data
@@ -1727,7 +1742,7 @@ class TestMilvusClientSnapshotAllDataTypes(TestMilvusClientV2Base):
         assert row["bool_array"] == [j % 2 == 0 for j in range(5)]
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -1782,7 +1797,8 @@ class TestMilvusClientSnapshotAllDataTypes(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify data count
@@ -1798,7 +1814,7 @@ class TestMilvusClientSnapshotAllDataTypes(TestMilvusClientV2Base):
         assert len(search_res[0]) == 10
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -1844,7 +1860,8 @@ class TestMilvusClientSnapshotAllDataTypes(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify nullable fields
@@ -1869,12 +1886,235 @@ class TestMilvusClientSnapshotAllDataTypes(TestMilvusClientV2Base):
         assert abs(res[0]["nullable_float"] - 3.5) < 1e-5
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
+        self.drop_collection(client, restored_collection_name)
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_snapshot_with_comprehensive_schema(self):
+        """
+        target: test snapshot with comprehensive schema covering all data types
+        method: use gen_all_datatype_collection_schema (all scalars, arrays, vectors,
+                struct array, BM25 function, MinHash function, nullable fields, text match)
+                then snapshot and restore, verify data integrity
+        expected: all field data should be preserved correctly after restore
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        snapshot_name = cf.gen_unique_str(prefix)
+        restored_collection_name = cf.gen_unique_str(prefix + "_restored")
+
+        # Generate comprehensive schema with all data types
+        schema = cf.gen_all_datatype_collection_schema(
+            dim=default_dim,
+            enable_struct_array_field=True,
+            enable_dynamic_field=True,
+            nullable=True
+        )
+
+        # Create indexes for vector fields
+        index_params = client.prepare_index_params()
+        index_params.add_index("float_vector", metric_type="COSINE")
+        index_params.add_index("text_sparse_emb", metric_type="BM25",
+                               index_type="SPARSE_INVERTED_INDEX")
+        index_params.add_index("minhash_emb", metric_type="HAMMING")
+        # Struct array inner vector field also needs index
+        index_params.add_index("array_struct[float_vector]", metric_type="COSINE")
+
+        self.create_collection(client, collection_name, schema=schema,
+                               index_params=index_params)
+
+        # Generate row data using schema-based data generator
+        nb = 200
+        data = cf.gen_row_data_by_schema(nb=nb, schema=schema)
+        self.insert(client, collection_name, data)
+        self.flush(client, collection_name)
+
+        # Verify source collection
+        self.load_collection(client, collection_name)
+        res, _ = self.query(client, collection_name, filter="",
+                            output_fields=["count(*)"])
+        assert res[0]["count(*)"] == nb
+
+        # Create snapshot and restore
+        self.create_snapshot(client, collection_name, snapshot_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
+        wait_for_restore_complete(client, job_id)
+
+        # Verify restored data count
+        self.load_collection(client, restored_collection_name)
+        res, _ = self.query(client, restored_collection_name, filter="",
+                            output_fields=["count(*)"])
+        assert res[0]["count(*)"] == nb, \
+            f"Expected {nb} rows, got {res[0]['count(*)']}"
+
+        # Verify text match works (BM25 function preserved)
+        res, _ = self.query(client, restored_collection_name,
+                            filter='TEXT_MATCH(text, "the")',
+                            output_fields=["id", "text"])
+        log.info(f"Text match results: {len(res)} rows")
+
+        # Verify float vector search works
+        rng = np.random.default_rng(seed=19530)
+        search_vectors = [list(rng.random(default_dim))]
+        search_res, _ = self.search(client, restored_collection_name, search_vectors,
+                                    anns_field="float_vector", limit=10,
+                                    output_fields=["id"])
+        assert len(search_res[0]) > 0, "Float vector search should return results"
+
+        # Verify scalar fields are preserved (PK field name is "int64")
+        res, _ = self.query(client, restored_collection_name,
+                            filter="int64 >= 0",
+                            output_fields=["int64", "varchar", "json_field",
+                                           "array_int", "array_bool", "array_struct"],
+                            limit=10)
+        assert len(res) > 0
+        # Check at least one row has non-null array fields
+        has_array_data = False
+        has_struct_data = False
+        for row in res:
+            arr = row.get("array_int")
+            if arr is not None and len(arr) > 0:
+                has_array_data = True
+            struct_arr = row.get("array_struct")
+            if struct_arr is not None and len(struct_arr) > 0:
+                has_struct_data = True
+                assert "name" in struct_arr[0], "Struct element should have 'name'"
+                assert "age" in struct_arr[0], "Struct element should have 'age'"
+        assert has_array_data, "Should have rows with array_int data"
+        assert has_struct_data, "Should have rows with array_struct data"
+
+        # Cleanup
+        self.drop_snapshot(client, snapshot_name, collection_name)
+        self.drop_collection(client, restored_collection_name)
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_snapshot_with_bfloat16_vector(self):
+        """
+        target: test snapshot with BFloat16 vector type
+        method: create collection with BFloat16Vector field, snapshot and restore
+        expected: BFloat16 vector data should be preserved correctly
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        snapshot_name = cf.gen_unique_str(prefix)
+        restored_collection_name = cf.gen_unique_str(prefix + "_restored")
+
+        schema = client.create_schema(enable_dynamic_field=False, auto_id=False)
+        schema.add_field("id", DataType.INT64, is_primary=True)
+        schema.add_field("float_vector", DataType.FLOAT_VECTOR, dim=default_dim)
+        schema.add_field("bfloat16_vector", DataType.BFLOAT16_VECTOR, dim=default_dim)
+
+        index_params = client.prepare_index_params()
+        index_params.add_index("float_vector", metric_type="COSINE")
+        index_params.add_index("bfloat16_vector", metric_type="L2")
+
+        self.create_collection(client, collection_name, schema=schema,
+                               index_params=index_params)
+
+        rng = np.random.default_rng(seed=19530)
+        rows = [{
+            "id": i,
+            "float_vector": list(rng.random(default_dim)),
+            "bfloat16_vector": np.array(rng.random(default_dim), dtype=bfloat16),
+        } for i in range(100)]
+        self.insert(client, collection_name, rows)
+        self.flush(client, collection_name)
+
+        # Create snapshot and restore
+        self.create_snapshot(client, collection_name, snapshot_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
+        wait_for_restore_complete(client, job_id)
+
+        # Verify data count
+        self.load_collection(client, restored_collection_name)
+        res, _ = self.query(client, restored_collection_name,
+                            filter="id >= 0", output_fields=["count(*)"])
+        assert res[0]["count(*)"] == 100
+
+        # Verify search on bfloat16 vector works
+        search_vectors = [np.array(rng.random(default_dim), dtype=bfloat16)]
+        res, _ = self.search(client, restored_collection_name, search_vectors,
+                             anns_field="bfloat16_vector", limit=10,
+                             output_fields=["id"])
+        assert len(res[0]) == 10
+
+        # Cleanup
+        self.drop_snapshot(client, snapshot_name, collection_name)
+        self.drop_collection(client, restored_collection_name)
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_snapshot_with_all_array_element_types(self):
+        """
+        target: test snapshot with all array element types
+        method: create collection with Array[Int8/Int16/Int32/Int64/Float/Double/Bool/VarChar]
+        expected: all array data should be preserved correctly after restore
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        snapshot_name = cf.gen_unique_str(prefix)
+        restored_collection_name = cf.gen_unique_str(prefix + "_restored")
+
+        schema = client.create_schema(enable_dynamic_field=False, auto_id=False)
+        schema.add_field("id", DataType.INT64, is_primary=True)
+        schema.add_field("vector", DataType.FLOAT_VECTOR, dim=default_dim)
+        schema.add_field("arr_int8", DataType.ARRAY, element_type=DataType.INT8, max_capacity=20)
+        schema.add_field("arr_int16", DataType.ARRAY, element_type=DataType.INT16, max_capacity=20)
+        schema.add_field("arr_int32", DataType.ARRAY, element_type=DataType.INT32, max_capacity=20)
+        schema.add_field("arr_int64", DataType.ARRAY, element_type=DataType.INT64, max_capacity=20)
+        schema.add_field("arr_float", DataType.ARRAY, element_type=DataType.FLOAT, max_capacity=20)
+        schema.add_field("arr_double", DataType.ARRAY, element_type=DataType.DOUBLE, max_capacity=20)
+        schema.add_field("arr_bool", DataType.ARRAY, element_type=DataType.BOOL, max_capacity=20)
+        schema.add_field("arr_varchar", DataType.ARRAY, element_type=DataType.VARCHAR,
+                         max_length=100, max_capacity=20)
+
+        index_params = client.prepare_index_params()
+        index_params.add_index("vector", metric_type="COSINE")
+
+        self.create_collection(client, collection_name, schema=schema,
+                               index_params=index_params)
+
+        rng = np.random.default_rng(seed=19530)
+        rows = [{
+            "id": i,
+            "vector": list(rng.random(default_dim)),
+            "arr_int8": [int(np.int8(j)) for j in range(5)],
+            "arr_int16": [int(np.int16(i * 10 + j)) for j in range(5)],
+            "arr_int32": [i * 100 + j for j in range(5)],
+            "arr_int64": [i * 1000 + j for j in range(5)],
+            "arr_float": [float(i * 0.1 + j * 0.01) for j in range(5)],
+            "arr_double": [float(i * 1.1 + j * 0.11) for j in range(5)],
+            "arr_bool": [j % 2 == 0 for j in range(5)],
+            "arr_varchar": [f"s_{i}_{j}" for j in range(5)],
+        } for i in range(100)]
+        self.insert(client, collection_name, rows)
+        self.flush(client, collection_name)
+
+        # Create snapshot and restore
+        self.create_snapshot(client, collection_name, snapshot_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
+        wait_for_restore_complete(client, job_id)
+
+        # Verify data
+        self.load_collection(client, restored_collection_name)
+        res, _ = self.query(client, restored_collection_name,
+                            filter="id == 5",
+                            output_fields=["arr_int8", "arr_int16", "arr_int32", "arr_int64",
+                                           "arr_float", "arr_double", "arr_bool", "arr_varchar"])
+        assert len(res) == 1
+        row = res[0]
+        assert row["arr_int32"] == [500, 501, 502, 503, 504]
+        assert row["arr_int64"] == [5000, 5001, 5002, 5003, 5004]
+        assert row["arr_bool"] == [True, False, True, False, True]
+        assert row["arr_varchar"] == ["s_5_0", "s_5_1", "s_5_2", "s_5_3", "s_5_4"]
+
+        # Cleanup
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
 
-
-@pytest.mark.skip(reason="pymilvus SDK does not yet support collection_name for snapshot APIs")
 class TestMilvusClientSnapshotAllIndexTypes(TestMilvusClientV2Base):
     """
     L2 Test - Snapshot with all index types testing
@@ -1912,7 +2152,8 @@ class TestMilvusClientSnapshotAllIndexTypes(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify index and search
@@ -1923,7 +2164,7 @@ class TestMilvusClientSnapshotAllIndexTypes(TestMilvusClientV2Base):
         assert len(res[0]) == 10
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -1957,7 +2198,8 @@ class TestMilvusClientSnapshotAllIndexTypes(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify search works
@@ -1968,7 +2210,7 @@ class TestMilvusClientSnapshotAllIndexTypes(TestMilvusClientV2Base):
         assert len(res[0]) == 10
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -2002,7 +2244,8 @@ class TestMilvusClientSnapshotAllIndexTypes(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify search works
@@ -2013,7 +2256,7 @@ class TestMilvusClientSnapshotAllIndexTypes(TestMilvusClientV2Base):
         assert len(res[0]) == 10
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -2046,7 +2289,8 @@ class TestMilvusClientSnapshotAllIndexTypes(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify search works
@@ -2057,7 +2301,7 @@ class TestMilvusClientSnapshotAllIndexTypes(TestMilvusClientV2Base):
         assert len(res[0]) == 10
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -2091,7 +2335,8 @@ class TestMilvusClientSnapshotAllIndexTypes(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify search works
@@ -2102,7 +2347,7 @@ class TestMilvusClientSnapshotAllIndexTypes(TestMilvusClientV2Base):
         assert len(res[0]) == 10
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -2143,7 +2388,8 @@ class TestMilvusClientSnapshotAllIndexTypes(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify scalar index works with filter
@@ -2157,12 +2403,11 @@ class TestMilvusClientSnapshotAllIndexTypes(TestMilvusClientV2Base):
         assert res[0]["count(*)"] == 100  # 500/5 = 100 rows with tag='tag_3'
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
 
 
-@pytest.mark.skip(reason="pymilvus SDK does not yet support collection_name for snapshot APIs")
 class TestMilvusClientSnapshotCollectionProperties(TestMilvusClientV2Base):
     """
     L2 Test - Snapshot with collection properties testing
@@ -2201,7 +2446,8 @@ class TestMilvusClientSnapshotCollectionProperties(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify description is preserved
@@ -2210,7 +2456,7 @@ class TestMilvusClientSnapshotCollectionProperties(TestMilvusClientV2Base):
             f"Description should be preserved, got: {desc.get('description')}"
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -2249,7 +2495,8 @@ class TestMilvusClientSnapshotCollectionProperties(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify shard count is preserved
@@ -2260,7 +2507,7 @@ class TestMilvusClientSnapshotCollectionProperties(TestMilvusClientV2Base):
             f"Shard count should be {num_shards}, got: {restored_shards}"
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -2298,7 +2545,8 @@ class TestMilvusClientSnapshotCollectionProperties(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify consistency level is preserved
@@ -2309,7 +2557,7 @@ class TestMilvusClientSnapshotCollectionProperties(TestMilvusClientV2Base):
         assert restored_consistency is not None
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -2346,7 +2594,8 @@ class TestMilvusClientSnapshotCollectionProperties(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify partition key is preserved in schema
@@ -2354,7 +2603,7 @@ class TestMilvusClientSnapshotCollectionProperties(TestMilvusClientV2Base):
         fields = desc.get("fields", [])
         category_field = [f for f in fields if f.get("name") == "category"]
         assert len(category_field) == 1
-        assert category_field[0].get("is_partition_key") == True, \
+        assert category_field[0].get("is_partition_key"), \
             "Partition key should be preserved"
 
         # Verify data
@@ -2364,12 +2613,11 @@ class TestMilvusClientSnapshotCollectionProperties(TestMilvusClientV2Base):
         assert res[0]["count(*)"] == 500
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
 
 
-@pytest.mark.skip(reason="pymilvus SDK does not yet support collection_name for snapshot APIs")
 class TestMilvusClientSnapshotDataOperationsExtended(TestMilvusClientV2Base):
     """
     L2 Test - Snapshot after various data operations
@@ -2415,7 +2663,8 @@ class TestMilvusClientSnapshotDataOperationsExtended(TestMilvusClientV2Base):
         self.create_snapshot(client, collection_name, snapshot_name)
 
         # Restore
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify
@@ -2448,7 +2697,7 @@ class TestMilvusClientSnapshotDataOperationsExtended(TestMilvusClientV2Base):
         assert res[0]["varchar"] == "updated_125"
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -2490,7 +2739,8 @@ class TestMilvusClientSnapshotDataOperationsExtended(TestMilvusClientV2Base):
         self.create_snapshot(client, collection_name, snapshot_name)
 
         # Restore
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify data count (should be 700: 1000 - 300 deleted)
@@ -2505,7 +2755,7 @@ class TestMilvusClientSnapshotDataOperationsExtended(TestMilvusClientV2Base):
         assert res[0]["count(*)"] == 0, "Deleted data should not be present"
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -2561,11 +2811,13 @@ class TestMilvusClientSnapshotDataOperationsExtended(TestMilvusClientV2Base):
         log.info("Created snapshot with IVF_FLAT index")
 
         # Restore snapshot 1 (HNSW)
-        job_id_1, _ = self.restore_snapshot(client, snapshot_name_1, restored_collection_name_1)
+        job_id_1, _ = self.restore_snapshot(client, snapshot_name_1, restored_collection_name_1,
+                                                  source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id_1)
 
         # Restore snapshot 2 (IVF_FLAT)
-        job_id_2, _ = self.restore_snapshot(client, snapshot_name_2, restored_collection_name_2)
+        job_id_2, _ = self.restore_snapshot(client, snapshot_name_2, restored_collection_name_2,
+                                                  source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id_2)
 
         # Verify both collections can search
@@ -2577,8 +2829,8 @@ class TestMilvusClientSnapshotDataOperationsExtended(TestMilvusClientV2Base):
             assert len(res[0]) == 10, f"Search should return 10 results for {restored_name}"
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name_1)
-        self.drop_snapshot(client, snapshot_name_2)
+        self.drop_snapshot(client, snapshot_name_1, collection_name)
+        self.drop_snapshot(client, snapshot_name_2, collection_name)
         self.drop_collection(client, restored_collection_name_1)
         self.drop_collection(client, restored_collection_name_2)
 
@@ -2613,7 +2865,8 @@ class TestMilvusClientSnapshotDataOperationsExtended(TestMilvusClientV2Base):
         self.create_snapshot(client, collection_name, snapshot_name)
 
         # Restore
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify all data
@@ -2630,7 +2883,7 @@ class TestMilvusClientSnapshotDataOperationsExtended(TestMilvusClientV2Base):
         assert ids == list(range(total_rows)), "All IDs should be present"
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -2678,7 +2931,8 @@ class TestMilvusClientSnapshotDataOperationsExtended(TestMilvusClientV2Base):
         self.create_snapshot(client, collection_name, snapshot_name)
 
         # Restore
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify final state
@@ -2710,7 +2964,7 @@ class TestMilvusClientSnapshotDataOperationsExtended(TestMilvusClientV2Base):
         assert res[0]["varchar"] == "upserted_225"
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -2759,7 +3013,8 @@ class TestMilvusClientSnapshotDataOperationsExtended(TestMilvusClientV2Base):
         self.create_snapshot(client, collection_name, snapshot_name)
 
         # Restore
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify data
@@ -2775,7 +3030,7 @@ class TestMilvusClientSnapshotDataOperationsExtended(TestMilvusClientV2Base):
             assert res[0]["count(*)"] == 100, f"Category {cat} should have 100 rows"
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -2816,7 +3071,8 @@ class TestMilvusClientSnapshotDataOperationsExtended(TestMilvusClientV2Base):
 
         # Create snapshot and restore
         self.create_snapshot(client, collection_name, snapshot_name)
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_collection_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         # Verify dynamic field data
@@ -2828,7 +3084,7 @@ class TestMilvusClientSnapshotDataOperationsExtended(TestMilvusClientV2Base):
         assert res[0]["dynamic_str"] == "dynamic_50"
         assert res[0]["dynamic_int"] == 5000
         assert abs(res[0]["dynamic_float"] - 25.0) < 1e-5
-        assert res[0]["dynamic_bool"] == True
+        assert res[0]["dynamic_bool"]
 
         # Verify all data count
         res, _ = self.query(client, restored_collection_name,
@@ -2836,12 +3092,11 @@ class TestMilvusClientSnapshotDataOperationsExtended(TestMilvusClientV2Base):
         assert res[0]["count(*)"] == 100
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 
 
 
-@pytest.mark.skip(reason="pymilvus SDK does not yet support collection_name for snapshot APIs")
 class TestMilvusClientSnapshotConcurrency(TestMilvusClientV2Base):
     """
     Test concurrent operations for snapshot feature.
@@ -2872,7 +3127,7 @@ class TestMilvusClientSnapshotConcurrency(TestMilvusClientV2Base):
             try:
                 # Directly call client method to bypass ResponseChecker framework
                 # This allows us to capture the real MilvusException with original error message
-                client.create_snapshot(collection_name, snapshot_name)
+                client.create_snapshot(snapshot_name, collection_name)
                 results.append("success")
             except Exception as e:
                 errors.append(str(e))
@@ -2896,7 +3151,7 @@ class TestMilvusClientSnapshotConcurrency(TestMilvusClientV2Base):
                 f"Unexpected error: {err}"
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_snapshot_captures_consistent_point_in_time(self):
@@ -2953,13 +3208,14 @@ class TestMilvusClientSnapshotConcurrency(TestMilvusClientV2Base):
         inserter.join()
 
         # Get snapshot info
-        info, _ = self.describe_snapshot(client, snapshot_name)
+        info, _ = self.describe_snapshot(client, snapshot_name, collection_name)
         log.info(f"Snapshot created at ts: {info.create_ts}")
         log.info(f"Total inserted: {insert_count[0]}")
 
         # Restore and verify consistency
         restored_name = cf.gen_unique_str(prefix + "_restored")
-        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_name)
+        job_id, _ = self.restore_snapshot(client, snapshot_name, restored_name,
+                                          source_collection_name=collection_name)
         wait_for_restore_complete(client, job_id)
 
         self.load_collection(client, restored_name)
@@ -2977,7 +3233,7 @@ class TestMilvusClientSnapshotConcurrency(TestMilvusClientV2Base):
             f"Should not exceed total inserted: {restored_count} > {insert_count[0]}"
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -3010,7 +3266,8 @@ class TestMilvusClientSnapshotConcurrency(TestMilvusClientV2Base):
         def restore_thread(idx):
             restored_name = cf.gen_unique_str(prefix + f"_concurrent_{idx}")
             try:
-                job_id, _ = self.restore_snapshot(client, snapshot_name, restored_name)
+                job_id, _ = self.restore_snapshot(client, snapshot_name, restored_name,
+                                                      source_collection_name=collection_name)
                 with lock:
                     job_ids.append(job_id)
                     restored_names.append(restored_name)
@@ -3034,6 +3291,6 @@ class TestMilvusClientSnapshotConcurrency(TestMilvusClientV2Base):
             assert res[0]["count(*)"] == 500, f"{name} should have 500 rows"
 
         # Cleanup
-        self.drop_snapshot(client, snapshot_name)
+        self.drop_snapshot(client, snapshot_name, collection_name)
         for name in restored_names:
             self.drop_collection(client, name)

--- a/tests/python_client/requirements.txt
+++ b/tests/python_client/requirements.txt
@@ -23,8 +23,8 @@ pytest-sugar==0.9.5
 pytest-random-order
 
 # pymilvus
-pymilvus==2.7.0rc175
-pymilvus[bulk_writer]==2.7.0rc175
+pymilvus==2.7.0rc197
+pymilvus[bulk_writer]==2.7.0rc197
 # for protobuf
 protobuf>=5.29.5
 


### PR DESCRIPTION
Cherry-pick from master
pr: #49085
pr: #49263
pr: #49287
pr: #49322
pr: #49330
pr: #49336
pr: #48830

## Summary

Batch cherry-pick of 7 test fixes and improvements from master to 3.0 branch.

### #49085: refactor snapshot tests for collection-scoped snapshot API
- Update `create_snapshot` / `restore_snapshot` / `drop_snapshot` call signatures with required `collection_name`
- Bump pymilvus from `rc175` to `rc197`

### #49263: fix NullVectorQueryChecker false positive for dynamically-added fields
- Exclude `new_vec_*` fields from `nullable_vector_fields`: segments sealed before these fields are added legitimately have all-null values

### #49287: refactor NullVectorQueryChecker to PK-sampling approach
- Avoid `is not null` server-side filter on vector fields (unsupported in 3.0)
- Use `_collect_non_null_pk_samples()` to sample known non-null PKs at init

### #49322: handle stale PKs when rows deleted concurrently
- When sampled PKs are all deleted by concurrent DeleteChecker, refresh sample instead of reporting data corruption

### #49330: fix InsertChecker/UpsertChecker false failures on SchemaMismatchRetryableException
- Catch `SchemaMismatchRetryableException`, invalidate SDK schema cache, retry once

### #49336: fix NullVectorQueryChecker false positive when UpsertChecker overwrites with null
- Treat `null_rows` result as stale sample and refresh
- Fix PartialUpdateChecker with same SchemaMismatch retry pattern

### #48830: fix SnapshotRestoreChecker row count mismatch
- Capture snapshot state AFTER creating the snapshot to ensure count timestamp >= snapshot timestamp

issue: #49262
issue: #49329

🤖 Generated with [Claude Code](https://claude.com/claude-code)