### PR TITLE
fix: [3.0][skip e2e] add missing distribution.Flush() in TestLoadSegmentsWithoutBloomFilter (#49356)

### DIFF
--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -983,6 +983,7 @@ func (s *DelegatorDataSuite) TestLoadSegmentsWithoutBloomFilter() {
 	})
 
 	s.Require().NoError(err)
+	s.delegator.distribution.Flush()
 	sealed, _ := s.delegator.GetSegmentInfo(false)
 	s.Require().Equal(1, len(sealed))
 	s.Require().Equal(1, len(sealed[0].Segments))


### PR DESCRIPTION
Cherry-pick from master
pr: #49356
issue: #49354

After #48824 moved snapshot regeneration to a background goroutine, GetSegmentInfo can race the snapshot update and observe an empty sealed list right after LoadSegments returns. Other tests in the same file already call distribution.Flush() to synchronously regenerate the snapshot before reading; TestLoadSegmentsWithoutBloomFilter (added earlier in #48701) was missed.

Add the same Flush() call to make the test deterministic.