### PR TITLE
fix: stop dropping ExternalSource and other 2.6.5+ schema fields on rootcoord broadcasts

### DIFF
--- a/internal/metastore/model/collection.go
+++ b/internal/metastore/model/collection.go
@@ -147,6 +147,33 @@ func (c *Collection) Clone() *Collection {
 	}
 }
 
+// ToCollectionSchemaPB returns a schemapb.CollectionSchema populated from the
+// current Collection. All schema-level fields are copied verbatim — callers
+// override Version, Properties, EnableDynamicField, DoPhysicalBackfill, etc.
+// after the call when the operation requires a different value.
+//
+// Centralizing the conversion here ensures that newly added schema fields are
+// propagated consistently across every rootcoord broadcast/response path.
+func (c *Collection) ToCollectionSchemaPB() *schemapb.CollectionSchema {
+	return &schemapb.CollectionSchema{
+		Name:               c.Name,
+		Description:        c.Description,
+		AutoID:             c.AutoID,
+		Fields:             MarshalFieldModels(c.Fields),
+		StructArrayFields:  MarshalStructArrayFieldModels(c.StructArrayFields),
+		Functions:          MarshalFunctionModels(c.Functions),
+		EnableDynamicField: c.EnableDynamicField,
+		EnableNamespace:    c.EnableNamespace,
+		Properties:         c.Properties,
+		DbName:             c.DBName,
+		Version:            c.SchemaVersion,
+		FileResourceIds:    c.FileResourceIds,
+		ExternalSource:     c.ExternalSource,
+		ExternalSpec:       c.ExternalSpec,
+		DoPhysicalBackfill: c.DoPhysicalBackfill,
+	}
+}
+
 func (c *Collection) GetPartitionNum(filterUnavailable bool) int {
 	if !filterUnavailable {
 		return len(c.Partitions)

--- a/internal/metastore/model/collection_test.go
+++ b/internal/metastore/model/collection_test.go
@@ -668,3 +668,46 @@ func TestApplyUpdates_ExternalSpecMaskOnlyOverwriteNonEmpty(t *testing.T) {
 		assert.Equal(t, `{"format":"lance"}`, c.ExternalSpec)
 	})
 }
+
+func TestCollection_ToCollectionSchemaPB(t *testing.T) {
+	// All schema-level fields populated with non-zero values so a future
+	// addition that forgets to wire ToCollectionSchemaPB will trip an
+	// assertion below — this is the tripwire that prevents the historical
+	// "missing ExternalSource on broadcast" class of bugs from recurring.
+	props := []*commonpb.KeyValuePair{{Key: "k", Value: "v"}}
+	coll := &Collection{
+		Name:               "c",
+		DBName:             "db",
+		Description:        "desc",
+		AutoID:             true,
+		Fields:             []*Field{fieldModel},
+		StructArrayFields:  []*StructArrayField{structFieldModel},
+		Functions:          []*Function{functionModel},
+		EnableDynamicField: true,
+		EnableNamespace:    true,
+		Properties:         props,
+		SchemaVersion:      7,
+		FileResourceIds:    []int64{11, 22},
+		ExternalSource:     "s3://bucket/dataset",
+		ExternalSpec:       `{"format":"parquet"}`,
+		DoPhysicalBackfill: true,
+	}
+
+	schema := coll.ToCollectionSchemaPB()
+
+	assert.Equal(t, "c", schema.GetName())
+	assert.Equal(t, "db", schema.GetDbName())
+	assert.Equal(t, "desc", schema.GetDescription())
+	assert.True(t, schema.GetAutoID())
+	assert.Equal(t, MarshalFieldModels(coll.Fields), schema.GetFields())
+	assert.Equal(t, MarshalStructArrayFieldModels(coll.StructArrayFields), schema.GetStructArrayFields())
+	assert.Equal(t, MarshalFunctionModels(coll.Functions), schema.GetFunctions())
+	assert.True(t, schema.GetEnableDynamicField())
+	assert.True(t, schema.GetEnableNamespace())
+	assert.Equal(t, props, schema.GetProperties())
+	assert.Equal(t, int32(7), schema.GetVersion())
+	assert.Equal(t, []int64{11, 22}, schema.GetFileResourceIds())
+	assert.Equal(t, "s3://bucket/dataset", schema.GetExternalSource())
+	assert.Equal(t, `{"format":"parquet"}`, schema.GetExternalSpec())
+	assert.True(t, schema.GetDoPhysicalBackfill())
+}

--- a/internal/rootcoord/broker.go
+++ b/internal/rootcoord/broker.go
@@ -26,7 +26,6 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
-	"github.com/milvus-io/milvus/internal/metastore/model"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
@@ -255,18 +254,8 @@ func (b *ServerBroker) BroadcastAlteredCollection(ctx context.Context, collectio
 		partitionIDs = append(partitionIDs, p.PartitionID)
 	}
 	dcReq := &datapb.AlterCollectionRequest{
-		CollectionID: collectionID,
-		Schema: &schemapb.CollectionSchema{
-			Name:               colMeta.Name,
-			Description:        colMeta.Description,
-			AutoID:             colMeta.AutoID,
-			Fields:             model.MarshalFieldModels(colMeta.Fields),
-			StructArrayFields:  model.MarshalStructArrayFieldModels(colMeta.StructArrayFields),
-			Functions:          model.MarshalFunctionModels(colMeta.Functions),
-			Properties:         colMeta.Properties,
-			Version:            colMeta.SchemaVersion,
-			DoPhysicalBackfill: colMeta.DoPhysicalBackfill,
-		},
+		CollectionID:   collectionID,
+		Schema:         colMeta.ToCollectionSchemaPB(),
 		PartitionIDs:   partitionIDs,
 		StartPositions: colMeta.StartPositions,
 		Properties:     colMeta.Properties,

--- a/internal/rootcoord/ddl_callbacks_alter_collection_add_field.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_add_field.go
@@ -10,7 +10,6 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
-	"github.com/milvus-io/milvus/internal/metastore/model"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/proto/messagespb"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
@@ -63,17 +62,8 @@ func (c *Core) broadcastAlterCollectionForAddField(ctx context.Context, req *mil
 	// assign a new field id.
 	fieldSchema.FieldID = nextFieldID(coll)
 	// build new collection schema.
-	schema := &schemapb.CollectionSchema{
-		Name:               coll.Name,
-		Description:        coll.Description,
-		AutoID:             coll.AutoID,
-		Fields:             model.MarshalFieldModels(coll.Fields),
-		StructArrayFields:  model.MarshalStructArrayFieldModels(coll.StructArrayFields),
-		Functions:          model.MarshalFunctionModels(coll.Functions),
-		EnableDynamicField: coll.EnableDynamicField,
-		Properties:         coll.Properties,
-		Version:            coll.SchemaVersion + 1,
-	}
+	schema := coll.ToCollectionSchemaPB()
+	schema.Version = coll.SchemaVersion + 1
 	schema.Fields = append(schema.Fields, fieldSchema)
 
 	cacheExpirations, err := c.getCacheExpireForCollection(ctx, req.GetDbName(), req.GetCollectionName())

--- a/internal/rootcoord/ddl_callbacks_alter_collection_field.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_field.go
@@ -7,9 +7,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
-	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
-	"github.com/milvus-io/milvus/internal/metastore/model"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/proto/messagespb"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
@@ -54,17 +52,8 @@ func (c *Core) broadcastAlterCollectionV2ForAlterCollectionField(ctx context.Con
 	}
 
 	// build new collection schema.
-	schema := &schemapb.CollectionSchema{
-		Name:               coll.Name,
-		Description:        coll.Description,
-		AutoID:             coll.AutoID,
-		Fields:             model.MarshalFieldModels(coll.Fields),
-		StructArrayFields:  model.MarshalStructArrayFieldModels(coll.StructArrayFields),
-		Functions:          model.MarshalFunctionModels(coll.Functions),
-		EnableDynamicField: coll.EnableDynamicField,
-		Properties:         coll.Properties,
-		Version:            coll.SchemaVersion + 1,
-	}
+	schema := coll.ToCollectionSchemaPB()
+	schema.Version = coll.SchemaVersion + 1
 	for _, field := range schema.Fields {
 		if field.Name == req.GetFieldName() {
 			field.TypeParams = newFieldProperties

--- a/internal/rootcoord/ddl_callbacks_alter_collection_properties.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_properties.go
@@ -12,7 +12,6 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
-	"github.com/milvus-io/milvus/internal/metastore/model"
 	"github.com/milvus-io/milvus/internal/util/hookutil"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/log"
@@ -168,23 +167,8 @@ func (c *Core) broadcastAlterCollectionForAlterCollection(ctx context.Context, r
 		}
 
 		// Build schema snapshot with updated properties (schema version should NOT be changed for properties-only alter).
-		schema := &schemapb.CollectionSchema{
-			Name:               coll.Name,
-			Description:        coll.Description,
-			AutoID:             coll.AutoID,
-			Fields:             model.MarshalFieldModels(coll.Fields),
-			StructArrayFields:  model.MarshalStructArrayFieldModels(coll.StructArrayFields),
-			Functions:          model.MarshalFunctionModels(coll.Functions),
-			EnableDynamicField: coll.EnableDynamicField,
-			Properties:         newPropsKeyValuePairs,
-			Version:            coll.SchemaVersion,
-		}
-		// Preserve ExternalSource/ExternalSpec from current collection state.
-		// Alter never mutates them (rejected at request entry above), but the
-		// TTL-driven schema snapshot must still carry them so downstream
-		// consumers see a complete schema.
-		schema.ExternalSource = coll.ExternalSource
-		schema.ExternalSpec = coll.ExternalSpec
+		schema := coll.ToCollectionSchemaPB()
+		schema.Properties = newPropsKeyValuePairs
 		udpates.Schema = schema
 	}
 
@@ -255,17 +239,9 @@ func (c *Core) broadcastAlterCollectionForAlterDynamicField(ctx context.Context,
 	}
 
 	fieldSchema.FieldID = nextFieldID(coll)
-	schema := &schemapb.CollectionSchema{
-		Name:               coll.Name,
-		Description:        coll.Description,
-		AutoID:             coll.AutoID,
-		Fields:             model.MarshalFieldModels(coll.Fields),
-		StructArrayFields:  model.MarshalStructArrayFieldModels(coll.StructArrayFields),
-		Functions:          model.MarshalFunctionModels(coll.Functions),
-		EnableDynamicField: targetValue,
-		Properties:         coll.Properties,
-		Version:            coll.SchemaVersion + 1,
-	}
+	schema := coll.ToCollectionSchemaPB()
+	schema.Version = coll.SchemaVersion + 1
+	schema.EnableDynamicField = targetValue
 	schema.Fields = append(schema.Fields, fieldSchema)
 
 	channels := make([]string, 0, len(coll.VirtualChannelNames)+1)

--- a/internal/rootcoord/ddl_callbacks_alter_collection_schema.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_schema.go
@@ -25,7 +25,6 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
-	"github.com/milvus-io/milvus/internal/metastore/model"
 	"github.com/milvus-io/milvus/pkg/v2/proto/messagespb"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
@@ -139,25 +138,14 @@ func (c *Core) broadcastAlterCollectionSchema(ctx context.Context, req *milvuspb
 	}
 
 	// 6. build new collection schema.
-	schema := &schemapb.CollectionSchema{
-		Name:               coll.Name,
-		Description:        coll.Description,
-		AutoID:             coll.AutoID,
-		Fields:             model.MarshalFieldModels(coll.Fields),
-		StructArrayFields:  model.MarshalStructArrayFieldModels(coll.StructArrayFields),
-		Functions:          model.MarshalFunctionModels(coll.Functions),
-		EnableDynamicField: coll.EnableDynamicField,
-		Properties:         coll.Properties,
-		DbName:             coll.DBName,
-		FileResourceIds:    coll.FileResourceIds,
-		// Version is incremented by 1. No CAS is needed here because Proxy's
-		// checkSchemaVersionConsistency gate blocks new AlterCollectionSchema calls
-		// until the previous backfill reaches 100% consistency, and DDL requests
-		// are serialized through a single DDL queue — so concurrent schema changes
-		// that could produce duplicate version numbers are impossible.
-		Version:            coll.SchemaVersion + 1,
-		DoPhysicalBackfill: addRequest.GetDoPhysicalBackfill(),
-	}
+	schema := coll.ToCollectionSchemaPB()
+	// Version is incremented by 1. No CAS is needed here because Proxy's
+	// checkSchemaVersionConsistency gate blocks new AlterCollectionSchema calls
+	// until the previous backfill reaches 100% consistency, and DDL requests
+	// are serialized through a single DDL queue — so concurrent schema changes
+	// that could produce duplicate version numbers are impossible.
+	schema.Version = coll.SchemaVersion + 1
+	schema.DoPhysicalBackfill = addRequest.GetDoPhysicalBackfill()
 	schema.Fields = append(schema.Fields, fieldSchemas...)
 	schema.Functions = append(schema.Functions, functionSchema)
 

--- a/internal/rootcoord/ddl_callbacks_collection_function.go
+++ b/internal/rootcoord/ddl_callbacks_collection_function.go
@@ -37,17 +37,8 @@ import (
 
 func callAlterCollection(ctx context.Context, c *Core, broadcaster broadcaster.BroadcastAPI, coll *model.Collection, dbName string, collectionName string) error {
 	// build new collection schema.
-	schema := &schemapb.CollectionSchema{
-		Name:               coll.Name,
-		Description:        coll.Description,
-		AutoID:             coll.AutoID,
-		Fields:             model.MarshalFieldModels(coll.Fields),
-		StructArrayFields:  model.MarshalStructArrayFieldModels(coll.StructArrayFields),
-		Functions:          model.MarshalFunctionModels(coll.Functions),
-		EnableDynamicField: coll.EnableDynamicField,
-		Properties:         coll.Properties,
-		Version:            coll.SchemaVersion + 1,
-	}
+	schema := coll.ToCollectionSchemaPB()
+	schema.Version = coll.SchemaVersion + 1
 
 	cacheExpirations, err := c.getCacheExpireForCollection(ctx, dbName, collectionName)
 	if err != nil {

--- a/internal/rootcoord/root_coord.go
+++ b/internal/rootcoord/root_coord.go
@@ -35,7 +35,6 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
-	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/allocator"
 	"github.com/milvus-io/milvus/internal/coordinator/snmanager"
 	etcdkv "github.com/milvus-io/milvus/internal/kv/etcd"
@@ -1191,23 +1190,10 @@ func convertModelToDesc(collInfo *model.Collection, aliases []string, dbName str
 		DbName: dbName,
 	}
 
-	resp.Schema = &schemapb.CollectionSchema{
-		Name:               collInfo.Name,
-		Description:        collInfo.Description,
-		AutoID:             collInfo.AutoID,
-		Fields:             model.MarshalFieldModels(collInfo.Fields),
-		StructArrayFields:  model.MarshalStructArrayFieldModels(collInfo.StructArrayFields),
-		Functions:          model.MarshalFunctionModels(collInfo.Functions),
-		EnableDynamicField: collInfo.EnableDynamicField,
-		EnableNamespace:    collInfo.EnableNamespace,
-		Properties:         collInfo.Properties,
-		FileResourceIds:    collInfo.FileResourceIds,
-		ExternalSource:     collInfo.ExternalSource,
-		ExternalSpec:       collInfo.ExternalSpec,
-		DbName:             dbName, // Use dbName parameter for consistency with resp.DbName
-		Version:            collInfo.SchemaVersion,
-		DoPhysicalBackfill: collInfo.DoPhysicalBackfill,
-	}
+	resp.Schema = collInfo.ToCollectionSchemaPB()
+	// Use the dbName parameter (resolved from the request) for consistency
+	// with resp.DbName; the model's DBName may not always be in sync.
+	resp.Schema.DbName = dbName
 	resp.CollectionID = collInfo.CollectionID
 	resp.VirtualChannelNames = collInfo.VirtualChannelNames
 	resp.PhysicalChannelNames = collInfo.PhysicalChannelNames


### PR DESCRIPTION
schemapb.CollectionSchema gained five new fields in 2.6.5+ — ExternalSource, ExternalSpec, DoPhysicalBackfill, FileResourceIds and EnableNamespace (proto fields 11–15). rootcoord constructs the proto by hand at 8 sites: the AddField / AlterField / AlterSchema / AlterFunction / AlterCollection DDL callbacks, the BroadcastAlteredCollection RPC to DataCoord, the TTL- and dynamic-field paths in AlterCollection, and the DescribeCollection response. Each literal has to enumerate every field it copies, and over several PRs they have drifted: 6 of the 8 paths drop ExternalSource on every broadcast, 7 drop EnableNamespace, and the loss pattern for DoPhysicalBackfill / FileResourceIds is ad-hoc. The rootcoord-side *model.Collection still has the data; only the schema snapshot it broadcasts to DataCoord and writes into the AlterCollection WAL messages is missing fields. Downstream components that consume those fields silently see zeros after any benign DDL.

Convert the literals to a single helper on the model:

- Add (*model.Collection).ToCollectionSchemaPB() in internal/metastore/model/collection.go. It copies every schema-level field once (Name, Description, AutoID, Fields, StructArrayFields, Functions, EnableDynamicField, EnableNamespace, Properties, DbName, SchemaVersion, FileResourceIds, ExternalSource, ExternalSpec, DoPhysicalBackfill). Future additions live here only.
- Replace all 8 literal sites in internal/rootcoord/ with the helper. Operation-specific overrides become explicit field assignments on the returned schema:
    * Version = SchemaVersion + 1 for AddField / AlterField / AlterSchema / AlterFunction / dynamic-field-enable; unchanged for the TTL property snapshot and BroadcastAlteredCollection.
    * Properties = newPropsKeyValuePairs for the TTL path.
    * EnableDynamicField = targetValue for the dynamic-field-enable path.
    * DoPhysicalBackfill = addRequest.GetDoPhysicalBackfill() for AlterSchema (request-driven, not coll-driven).
    * Fields/Functions get appended after construction where the DDL adds new ones. DescribeCollection keeps overriding DbName with the request-resolved dbName for resp.DbName/resp.Schema.DbName consistency.
- Drop the now-redundant explicit ExternalSource/ExternalSpec assignments the TTL path used to need.
- Add TestCollection_ToCollectionSchemaPB asserting every field round- trips. This is the tripwire: any future addition that forgets to wire the helper will fail this test before it reaches a broadcast path.

Behavior change for DataCoord: BroadcastAlteredCollection.Schema now carries ExternalSource, ExternalSpec, FileResourceIds, EnableNamespace, EnableDynamicField and DbName which it had been silently losing. DataCoord consumers only read the fields they care about, so populating extras is a fix, not a regression.

issue: #49359