### PR TITLE
enhance: [2.6] add $partial_update field to proxy access log for Upsert (#49348)

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -359,6 +359,9 @@ proxy:
       search:
         format: "[$time_now] [ACCESS] <$user_name: $user_addr> $method_name [status: $method_status] [code: $error_code] [sdk: $sdk_version] [msg: $error_msg] [traceID: $trace_id] [timeCost: $time_cost] [database: $database_name] [collection: $collection_name] [partitions: $partition_name] [expr: $method_expr] [nq: $nq] [params: $search_params]"
         methods: "HybridSearch, Search"
+      upsert:
+        format: "[$time_now] [ACCESS] <$user_name: $user_addr> $method_name [status: $method_status] [code: $error_code] [sdk: $sdk_version] [msg: $error_msg] [traceID: $trace_id] [timeCost: $time_cost] [database: $database_name] [collection: $collection_name] [partitions: $partition_name] [partial_update: $partial_update]"
+        methods: Upsert
     cacheSize: 0 # Size of log of write cache, in byte. (Close write cache if size was 0)
     cacheFlushInterval: 3 # time interval of auto flush write cache, in seconds. (Close auto flush if interval was 0)
   connectionCheckIntervalSeconds: 120 # the interval time(in seconds) for connection manager to scan inactive client info

--- a/internal/proxy/accesslog/info/grpc_info.go
+++ b/internal/proxy/accesslog/info/grpc_info.go
@@ -383,3 +383,10 @@ func (i *GrpcAccessInfo) TemplateValueLength() string {
 
 	return fmt.Sprint(m)
 }
+
+func (i *GrpcAccessInfo) PartialUpdate() string {
+	if req, ok := i.req.(*milvuspb.UpsertRequest); ok {
+		return fmt.Sprint(req.GetPartialUpdate())
+	}
+	return NotAny
+}

--- a/internal/proxy/accesslog/info/grpc_info_test.go
+++ b/internal/proxy/accesslog/info/grpc_info_test.go
@@ -216,6 +216,17 @@ func (s *GrpcAccessInfoSuite) TestOutputFields() {
 	s.Equal(fmt.Sprint(fields), result[0])
 }
 
+func (s *GrpcAccessInfoSuite) TestPartialUpdate() {
+	// non-Upsert request -> NotAny
+	s.Equal(NotAny, Get(s.info, "$partial_update")[0])
+
+	s.info.req = &milvuspb.UpsertRequest{PartialUpdate: false}
+	s.Equal("false", Get(s.info, "$partial_update")[0])
+
+	s.info.req = &milvuspb.UpsertRequest{PartialUpdate: true}
+	s.Equal("true", Get(s.info, "$partial_update")[0])
+}
+
 func (s *GrpcAccessInfoSuite) TestConsistencyLevel() {
 	result := Get(s.info, "$consistency_level")
 	s.Equal(Unknown, result[0])

--- a/internal/proxy/accesslog/info/info.go
+++ b/internal/proxy/accesslog/info/info.go
@@ -56,6 +56,7 @@ var MetricFuncMap = map[string]getMetricFunc{
 	"$query_params":          getQueryParams,
 	"$client_request_time":   getClientRequestTime,
 	"$template_value_length": getTemplateValueLength,
+	"$partial_update":        getPartialUpdate,
 }
 
 type AccessInfo interface {
@@ -85,6 +86,7 @@ type AccessInfo interface {
 	QueryParams() string
 	ClientRequestTime() string
 	TemplateValueLength() string
+	PartialUpdate() string
 	SetActualConsistencyLevel(commonpb.ConsistencyLevel)
 }
 
@@ -207,4 +209,8 @@ func getClientRequestTime(i AccessInfo) string {
 
 func getTemplateValueLength(i AccessInfo) string {
 	return i.TemplateValueLength()
+}
+
+func getPartialUpdate(i AccessInfo) string {
+	return i.PartialUpdate()
 }

--- a/internal/proxy/accesslog/info/restful_info.go
+++ b/internal/proxy/accesslog/info/restful_info.go
@@ -287,3 +287,10 @@ func (i *RestfulInfo) TemplateValueLength() string {
 
 	return fmt.Sprint(m)
 }
+
+func (i *RestfulInfo) PartialUpdate() string {
+	if req, ok := i.req.(*milvuspb.UpsertRequest); ok {
+		return fmt.Sprint(req.GetPartialUpdate())
+	}
+	return NotAny
+}

--- a/internal/proxy/accesslog/info/restful_info_test.go
+++ b/internal/proxy/accesslog/info/restful_info_test.go
@@ -187,6 +187,19 @@ func (s *RestfulAccessInfoSuite) TestOutputFields() {
 	s.Equal(fmt.Sprint(fields), result[0])
 }
 
+func (s *RestfulAccessInfoSuite) TestPartialUpdate() {
+	// non-Upsert request -> NotAny
+	s.Equal(NotAny, Get(s.info, "$partial_update")[0])
+
+	s.ctx.Set(ContextRequest, &milvuspb.UpsertRequest{PartialUpdate: false})
+	s.info.InitReq()
+	s.Equal("false", Get(s.info, "$partial_update")[0])
+
+	s.ctx.Set(ContextRequest, &milvuspb.UpsertRequest{PartialUpdate: true})
+	s.info.InitReq()
+	s.Equal("true", Get(s.info, "$partial_update")[0])
+}
+
 func (s *RestfulAccessInfoSuite) TestConsistencyLevel() {
 	result := Get(s.info, "$consistency_level")
 	s.Equal(Unknown, result[0])


### PR DESCRIPTION
Cherry-pick from master
pr: #49348

UpsertRequest carries `bool partial_update`, and task_upsert may implicitly promote a request to partial_update=true when any field carries a FieldPartialUpdateOp != REPLACE. Today the proxy access log exposes neither — every Upsert line falls through to the generic `base` formatter and operators triaging a partial-update incident cannot tell from logs alone whether a given Upsert was full or partial.

Add `$partial_update` to the access-log formatter vocabulary alongside the existing 27 metrics:

- info.go: register $partial_update in MetricFuncMap; add PartialUpdate() string to the AccessInfo interface; add the getPartialUpdate delegator.
- grpc_info.go / restful_info.go: implement PartialUpdate() — type- assert *milvuspb.UpsertRequest and return fmt.Sprint of GetPartialUpdate(); return NotAny ("n/a") for any other type.
- configs/milvus.yaml: add a dedicated `upsert` formatter bound to methods: "Upsert" so the new field shows up out of the box without polluting the shared `base` formatter.

Implicit promotion (task_upsert.go:1308-1309) is reflected for free: UnaryAccessLogInterceptor writes the log after handler() returns, and the *UpsertRequest pointer on GrpcAccessInfo is the same instance the task mutates, so the type-asserted GetPartialUpdate() reads the promoted value without any SetPartialUpdate(ctx, …) writeback.

Tests: TestPartialUpdate added to both GrpcAccessInfoSuite and RestfulAccessInfoSuite (non-Upsert -> "n/a"; PartialUpdate=false -> "false"; PartialUpdate=true -> "true"). Both suites stay green end-to-end.

issue: #49347

---------