### PR TITLE
build(deps): bump rust to 1.92 in builder images and install scripts

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -89,7 +89,7 @@ The following specification (either physical or virtual machine resources) is re
 | Go | 1.21 | Required. Install from https://go.dev/dl/ |
 | CMake | 3.26 | Auto-installed by install_deps.sh |
 | Conan | 2.25.1 | Auto-installed by install_deps.sh |
-| Rust | 1.89 | Auto-installed by install_deps.sh |
+| Rust | 1.92 | Auto-installed by install_deps.sh |
 
 ### Compiler Setup
 

--- a/build/docker/builder/cpu/amazonlinux2023/Dockerfile
+++ b/build/docker/builder/cpu/amazonlinux2023/Dockerfile
@@ -47,7 +47,7 @@ RUN mkdir -p /home/milvus/.vscode-server/extensions \
 COPY --chown=0:0 build/docker/builder/entrypoint.sh /
 
 RUN curl https://sh.rustup.rs -sSf | \
-    sh -s -- --default-toolchain=1.89 -y
+    sh -s -- --default-toolchain=1.92 -y
 
 ENV PATH=/root/.cargo/bin:$PATH
 

--- a/build/docker/builder/cpu/rockylinux9/Dockerfile
+++ b/build/docker/builder/cpu/rockylinux9/Dockerfile
@@ -47,7 +47,7 @@ RUN mkdir -p /home/milvus/.vscode-server/extensions \
 COPY --chown=0:0 build/docker/builder/entrypoint.sh /
 
 RUN curl https://sh.rustup.rs -sSf | \
-    sh -s -- --default-toolchain=1.89 -y
+    sh -s -- --default-toolchain=1.92 -y
 
 ENV PATH=/root/.cargo/bin:$PATH
 

--- a/build/docker/builder/cpu/ubuntu20.04/Dockerfile
+++ b/build/docker/builder/cpu/ubuntu20.04/Dockerfile
@@ -55,7 +55,7 @@ RUN mkdir -p /home/milvus/.vscode-server/extensions \
 COPY --chown=0:0 build/docker/builder/entrypoint.sh /
 
 RUN curl https://sh.rustup.rs -sSf | \
-    sh -s -- --default-toolchain=1.89 -y
+    sh -s -- --default-toolchain=1.92 -y
 
 ENV PATH=/root/.cargo/bin:$PATH
 

--- a/build/docker/builder/cpu/ubuntu22.04/Dockerfile
+++ b/build/docker/builder/cpu/ubuntu22.04/Dockerfile
@@ -52,7 +52,7 @@ RUN mkdir -p /home/milvus/.vscode-server/extensions \
 COPY --chown=0:0 build/docker/builder/entrypoint.sh /
 
 RUN curl https://sh.rustup.rs -sSf | \
-    sh -s -- --default-toolchain=1.89 -y
+    sh -s -- --default-toolchain=1.92 -y
 
 ENV PATH=/root/.cargo/bin:$PATH
 

--- a/build/docker/builder/cpu/ubuntu24.04/Dockerfile
+++ b/build/docker/builder/cpu/ubuntu24.04/Dockerfile
@@ -48,7 +48,7 @@ RUN mkdir -p /home/milvus/.vscode-server/extensions \
 COPY --chown=0:0 build/docker/builder/entrypoint.sh /
 
 RUN curl https://sh.rustup.rs -sSf | \
-    sh -s -- --default-toolchain=1.89 -y
+    sh -s -- --default-toolchain=1.92 -y
 
 ENV PATH=/root/.cargo/bin:$PATH
 

--- a/build/docker/builder/gpu/ubuntu20.04/Dockerfile
+++ b/build/docker/builder/gpu/ubuntu20.04/Dockerfile
@@ -80,7 +80,7 @@ RUN wget -O /tini https://github.com/krallin/tini/releases/download/v0.19.0/tini
     chmod +x /tini
 
 RUN curl https://sh.rustup.rs -sSf | \
-    sh -s -- --default-toolchain=1.89 -y
+    sh -s -- --default-toolchain=1.92 -y
 
 ENV PATH=/root/.cargo/bin:$PATH
 

--- a/build/docker/builder/gpu/ubuntu22.04/Dockerfile
+++ b/build/docker/builder/gpu/ubuntu22.04/Dockerfile
@@ -21,7 +21,7 @@ RUN mkdir -p /usr/local/go && wget -qO- "https://go.dev/dl/go1.25.9.linux-$TARGE
 RUN pip3 install conan==2.25.1
 # Install rust
 RUN curl https://sh.rustup.rs -sSf | \
-    sh -s -- --default-toolchain=1.89 -y
+    sh -s -- --default-toolchain=1.92 -y
 ENV PATH=/root/.cargo/bin:/usr/local/bin:/usr/local/go/bin:$PATH
 
 # refer: https://code.visualstudio.com/docs/remote/containers-advanced#_avoiding-extension-reinstalls-on-container-rebuild

--- a/scripts/3rdparty_build.sh
+++ b/scripts/3rdparty_build.sh
@@ -310,15 +310,15 @@ if command -v cargo >/dev/null 2>&1; then
     unameOut="$(uname -s)"
     case "${unameOut}" in
         Darwin*)
-          echo "running on mac os, reinstall rust 1.89"
+          echo "running on mac os, reinstall rust 1.92"
           # github will install rust 1.74 by default.
           # https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md
-          rustup install 1.89
-          rustup default 1.89;;
+          rustup install 1.92
+          rustup default 1.92;;
         *)
           echo "not running on mac os, no need to reinstall rust";;
     esac
 else
-    bash -c "curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain=1.89 -y" || { echo 'rustup install failed'; exit 1;}
+    bash -c "curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain=1.92 -y" || { echo 'rustup install failed'; exit 1;}
     source $HOME/.cargo/env
 fi

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -58,7 +58,7 @@ print_error() {
 MIN_CMAKE_VERSION="3.26"
 MIN_GO_VERSION="1.21"
 CONAN_VERSION="2.25.1"
-RUST_VERSION="1.89"
+RUST_VERSION="1.92"
 
 #######################################
 # Check if a command exists


### PR DESCRIPTION
issue: [#45691](https://github.com/milvus-io/milvus/issues/45691)

## Summary

Bump rust toolchain `1.89 → 1.92` only in installation paths (Dockerfiles + install scripts).

## Why

milvus-storage HEAD upgrades `iceberg` crate `0.8 → 0.9`, which declares `edition = "2024"` and `rust-version = "1.92"`. The new MSRV requires the builder image to ship rust 1.92 before milvus can take that milvus-storage commit.

This PR is the **first step**:
1. Bump rust toolchain in installation scripts and Dockerfiles.
2. Once merged, builder image is republished with rust 1.92.
3. Follow-up PR will bump `.env` `DATE_VERSION` to the new tag, switch `cargo +1.89` → `cargo +1.92` in `internal/core/thirdparty/{tantivy,opendal}/CMakeLists.txt`, and bump milvus-storage to the iceberg-0.9 commit.

This split avoids the chicken-egg problem: changing the cargo pin or milvus-storage version in this PR would fail CI, since the currently pinned builder image only ships rust 1.89.

## Files changed

| File | Change |
|---|---|
| `scripts/install_deps.sh` | `RUST_VERSION="1.89"` → `1.92` |
| `scripts/3rdparty_build.sh` | rust toolchain `1.89` → `1.92` (mac + linux paths) |
| `build/docker/builder/{cpu,gpu}/*/Dockerfile` (7 files) | rustup `--default-toolchain=1.89` → `1.92` |
| `DEVELOPMENT.md` | doc table rust version |

## Test plan

- [ ] CI passes on existing builder image (no behaviour change for current build path)
- [ ] After merge, builder image is republished with rust 1.92
- [ ] Follow-up PR can then bump `.env` and milvus-storage