### PR TITLE
fix: [2.6] stop dropping EnableNamespace and other schema fields on rootcoord broadcasts (#49360)

### DIFF
--- a/internal/metastore/model/collection.go
+++ b/internal/metastore/model/collection.go
@@ -49,6 +49,7 @@ type Collection struct {
 	Properties           []*commonpb.KeyValuePair
 	State                pb.CollectionState
 	EnableDynamicField   bool
+	EnableNamespace      bool
 	UpdateTimestamp      uint64
 	SchemaVersion        int32
 	ShardInfos           map[string]*ShardInfo
@@ -86,6 +87,7 @@ func (c *Collection) ShallowClone() *Collection {
 		Properties:           c.Properties,
 		State:                c.State,
 		EnableDynamicField:   c.EnableDynamicField,
+		EnableNamespace:      c.EnableNamespace,
 		Functions:            c.Functions,
 		UpdateTimestamp:      c.UpdateTimestamp,
 		SchemaVersion:        c.SchemaVersion,
@@ -123,10 +125,34 @@ func (c *Collection) Clone() *Collection {
 		Properties:           common.CloneKeyValuePairs(c.Properties),
 		State:                c.State,
 		EnableDynamicField:   c.EnableDynamicField,
+		EnableNamespace:      c.EnableNamespace,
 		Functions:            CloneFunctions(c.Functions),
 		UpdateTimestamp:      c.UpdateTimestamp,
 		SchemaVersion:        c.SchemaVersion,
 		ShardInfos:           shardInfos,
+	}
+}
+
+// ToCollectionSchemaPB returns a schemapb.CollectionSchema populated from the
+// current Collection. All schema-level fields are copied verbatim — callers
+// override Version, Properties, EnableDynamicField, etc. after the call when
+// the operation requires a different value.
+//
+// Centralizing the conversion here ensures that newly added schema fields are
+// propagated consistently across every rootcoord broadcast/response path.
+func (c *Collection) ToCollectionSchemaPB() *schemapb.CollectionSchema {
+	return &schemapb.CollectionSchema{
+		Name:               c.Name,
+		Description:        c.Description,
+		AutoID:             c.AutoID,
+		Fields:             MarshalFieldModels(c.Fields),
+		StructArrayFields:  MarshalStructArrayFieldModels(c.StructArrayFields),
+		Functions:          MarshalFunctionModels(c.Functions),
+		EnableDynamicField: c.EnableDynamicField,
+		EnableNamespace:    c.EnableNamespace,
+		Properties:         c.Properties,
+		DbName:             c.DBName,
+		Version:            c.SchemaVersion,
 	}
 }
 
@@ -172,6 +198,7 @@ func (c *Collection) ApplyUpdates(header *message.AlterCollectionMessageHeader, 
 			c.AutoID = updates.Schema.AutoID
 			c.Fields = UnmarshalFieldModels(updates.Schema.Fields)
 			c.EnableDynamicField = updates.Schema.EnableDynamicField
+			c.EnableNamespace = updates.Schema.EnableNamespace
 			c.Functions = UnmarshalFunctionModels(updates.Schema.Functions)
 			c.StructArrayFields = UnmarshalStructArrayFieldModels(updates.Schema.StructArrayFields)
 			c.SchemaVersion = updates.Schema.Version
@@ -229,6 +256,7 @@ func UnmarshalCollectionModel(coll *pb.CollectionInfo) *Collection {
 		State:                coll.State,
 		Properties:           coll.Properties,
 		EnableDynamicField:   coll.Schema.EnableDynamicField,
+		EnableNamespace:      coll.Schema.EnableNamespace,
 		UpdateTimestamp:      coll.UpdateTimestamp,
 		SchemaVersion:        coll.Schema.Version,
 		ShardInfos:           shardInfos,
@@ -281,6 +309,7 @@ func marshalCollectionModelWithConfig(coll *Collection, c *config) *pb.Collectio
 		Description:        coll.Description,
 		AutoID:             coll.AutoID,
 		EnableDynamicField: coll.EnableDynamicField,
+		EnableNamespace:    coll.EnableNamespace,
 		DbName:             coll.DBName,
 		Version:            coll.SchemaVersion,
 	}

--- a/internal/metastore/model/collection_test.go
+++ b/internal/metastore/model/collection_test.go
@@ -127,6 +127,41 @@ func TestUnmarshalCollectionModel(t *testing.T) {
 	assert.Nil(t, UnmarshalCollectionModel(nil))
 }
 
+func TestCollection_ToCollectionSchemaPB(t *testing.T) {
+	// All schema-level fields populated with non-zero values so a future
+	// addition that forgets to wire ToCollectionSchemaPB will trip an
+	// assertion below — this is the tripwire that prevents the historical
+	// "missing EnableNamespace on broadcast" class of bugs from recurring.
+	props := []*commonpb.KeyValuePair{{Key: "k", Value: "v"}}
+	coll := &Collection{
+		Name:               "c",
+		DBName:             "db",
+		Description:        "desc",
+		AutoID:             true,
+		Fields:             []*Field{fieldModel},
+		StructArrayFields:  []*StructArrayField{structFieldModel},
+		Functions:          []*Function{functionModel},
+		EnableDynamicField: true,
+		EnableNamespace:    true,
+		Properties:         props,
+		SchemaVersion:      7,
+	}
+
+	schema := coll.ToCollectionSchemaPB()
+
+	assert.Equal(t, "c", schema.GetName())
+	assert.Equal(t, "db", schema.GetDbName())
+	assert.Equal(t, "desc", schema.GetDescription())
+	assert.True(t, schema.GetAutoID())
+	assert.Equal(t, MarshalFieldModels(coll.Fields), schema.GetFields())
+	assert.Equal(t, MarshalStructArrayFieldModels(coll.StructArrayFields), schema.GetStructArrayFields())
+	assert.Equal(t, MarshalFunctionModels(coll.Functions), schema.GetFunctions())
+	assert.True(t, schema.GetEnableDynamicField())
+	assert.True(t, schema.GetEnableNamespace())
+	assert.Equal(t, props, schema.GetProperties())
+	assert.Equal(t, int32(7), schema.GetVersion())
+}
+
 func TestMarshalCollectionModel(t *testing.T) {
 	assert.Nil(t, MarshalCollectionModel(nil))
 }

--- a/internal/proxy/search_proto_bench_test.go
+++ b/internal/proxy/search_proto_bench_test.go
@@ -1,0 +1,179 @@
+package proxy
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/internalpb"
+)
+
+// buildBenchSearchResultData builds a SearchResultData with n int64 IDs and n float32 scores.
+func buildBenchSearchResultData(n int) *schemapb.SearchResultData {
+	ids := make([]int64, n)
+	scores := make([]float32, n)
+	for i := 0; i < n; i++ {
+		ids[i] = rand.Int63()
+		scores[i] = rand.Float32()
+	}
+	return &schemapb.SearchResultData{
+		NumQueries: 1,
+		TopK:       int64(n),
+		Scores:     scores,
+		Ids: &schemapb.IDs{
+			IdField: &schemapb.IDs_IntId{
+				IntId: &schemapb.LongArray{Data: ids},
+			},
+		},
+		Topks: []int64{int64(n)},
+	}
+}
+
+// buildBenchSearchResults builds a full SearchResults (as sent over GRPC between QN→Proxy)
+// with the SearchResultData pre-marshaled into SlicedBlob.
+func buildBenchSearchResults(n int) (*internalpb.SearchResults, error) {
+	data := buildBenchSearchResultData(n)
+	blob, err := proto.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+	return &internalpb.SearchResults{
+		Status:     &commonpb.Status{ErrorCode: commonpb.ErrorCode_Success},
+		MetricType: "IP",
+		NumQueries: 1,
+		TopK:       int64(n),
+		SlicedBlob: blob,
+		ChannelsMvcc: map[string]uint64{
+			"dml_0_channel": 100,
+		},
+		CostAggregation: &internalpb.CostAggregation{
+			ResponseTime:         10,
+			ServiceTime:          8,
+			TotalNQ:              1,
+			TotalRelatedDataSize: 1024,
+		},
+	}, nil
+}
+
+// ---------- SearchResultData (inner blob) benchmarks ----------
+
+func BenchmarkSearchResultData_Marshal(b *testing.B) {
+	for _, n := range []int{100, 1000, 3000, 10000} {
+		data := buildBenchSearchResultData(n)
+		b.Run(fmt.Sprintf("%d_ids", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, err := proto.Marshal(data)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkSearchResultData_Unmarshal(b *testing.B) {
+	for _, n := range []int{100, 1000, 3000, 10000} {
+		data := buildBenchSearchResultData(n)
+		blob, _ := proto.Marshal(data)
+		b.Run(fmt.Sprintf("%d_ids/size=%dB", n, len(blob)), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				var out schemapb.SearchResultData
+				if err := proto.Unmarshal(blob, &out); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// ---------- SearchResults (full GRPC response) benchmarks ----------
+
+func BenchmarkSearchResults_Marshal(b *testing.B) {
+	for _, n := range []int{100, 1000, 3000, 10000} {
+		resp, err := buildBenchSearchResults(n)
+		if err != nil {
+			b.Fatal(err)
+		}
+		totalSize := proto.Size(resp)
+		b.Run(fmt.Sprintf("%d_ids/total=%dB", n, totalSize), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, err := proto.Marshal(resp)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkSearchResults_Unmarshal(b *testing.B) {
+	for _, n := range []int{100, 1000, 3000, 10000} {
+		resp, err := buildBenchSearchResults(n)
+		if err != nil {
+			b.Fatal(err)
+		}
+		wire, _ := proto.Marshal(resp)
+		b.Run(fmt.Sprintf("%d_ids/wire=%dB", n, len(wire)), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				var out internalpb.SearchResults
+				if err := proto.Unmarshal(wire, &out); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// ---------- Full round-trip: simulates QN serialize → GRPC transport → Proxy deserialize ----------
+
+func BenchmarkSearchResults_FullRoundTrip(b *testing.B) {
+	for _, n := range []int{100, 1000, 3000, 10000} {
+		data := buildBenchSearchResultData(n)
+		b.Run(fmt.Sprintf("%d_ids", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				// Step 1: QN marshals inner SearchResultData → SlicedBlob
+				blob, err := proto.Marshal(data)
+				if err != nil {
+					b.Fatal(err)
+				}
+
+				// Step 2: QN builds SearchResults response
+				resp := &internalpb.SearchResults{
+					Status:       &commonpb.Status{ErrorCode: commonpb.ErrorCode_Success},
+					MetricType:   "IP",
+					NumQueries:   1,
+					TopK:         int64(n),
+					SlicedBlob:   blob,
+					ChannelsMvcc: map[string]uint64{"ch": 100},
+				}
+
+				// Step 3: GRPC framework marshals full response (QN side)
+				wire, err := proto.Marshal(resp)
+				if err != nil {
+					b.Fatal(err)
+				}
+
+				// Step 4: GRPC framework unmarshals full response (Proxy side)
+				var recvResp internalpb.SearchResults
+				if err := proto.Unmarshal(wire, &recvResp); err != nil {
+					b.Fatal(err)
+				}
+
+				// Step 5: Proxy decodeSearchResults - unmarshal inner blob
+				var recvData schemapb.SearchResultData
+				if err := proto.Unmarshal(recvResp.SlicedBlob, &recvData); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/internal/rootcoord/broker.go
+++ b/internal/rootcoord/broker.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
-	"github.com/milvus-io/milvus/internal/metastore/model"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
@@ -253,16 +252,8 @@ func (b *ServerBroker) BroadcastAlteredCollection(ctx context.Context, collectio
 		partitionIDs = append(partitionIDs, p.PartitionID)
 	}
 	dcReq := &datapb.AlterCollectionRequest{
-		CollectionID: collectionID,
-		Schema: &schemapb.CollectionSchema{
-			Name:              colMeta.Name,
-			Description:       colMeta.Description,
-			AutoID:            colMeta.AutoID,
-			Fields:            model.MarshalFieldModels(colMeta.Fields),
-			StructArrayFields: model.MarshalStructArrayFieldModels(colMeta.StructArrayFields),
-			Functions:         model.MarshalFunctionModels(colMeta.Functions),
-			Properties:        colMeta.Properties,
-		},
+		CollectionID:   collectionID,
+		Schema:         colMeta.ToCollectionSchemaPB(),
 		PartitionIDs:   partitionIDs,
 		StartPositions: colMeta.StartPositions,
 		Properties:     colMeta.Properties,

--- a/internal/rootcoord/ddl_callbacks_alter_collection_add_field.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_add_field.go
@@ -10,7 +10,6 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
-	"github.com/milvus-io/milvus/internal/metastore/model"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/proto/messagespb"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
@@ -63,17 +62,8 @@ func (c *Core) broadcastAlterCollectionForAddField(ctx context.Context, req *mil
 	// assign a new field id.
 	fieldSchema.FieldID = nextFieldID(coll)
 	// build new collection schema.
-	schema := &schemapb.CollectionSchema{
-		Name:               coll.Name,
-		Description:        coll.Description,
-		AutoID:             coll.AutoID,
-		Fields:             model.MarshalFieldModels(coll.Fields),
-		StructArrayFields:  model.MarshalStructArrayFieldModels(coll.StructArrayFields),
-		Functions:          model.MarshalFunctionModels(coll.Functions),
-		EnableDynamicField: coll.EnableDynamicField,
-		Properties:         coll.Properties,
-		Version:            coll.SchemaVersion + 1,
-	}
+	schema := coll.ToCollectionSchemaPB()
+	schema.Version = coll.SchemaVersion + 1
 	schema.Fields = append(schema.Fields, fieldSchema)
 
 	cacheExpirations, err := c.getCacheExpireForCollection(ctx, req.GetDbName(), req.GetCollectionName())

--- a/internal/rootcoord/ddl_callbacks_alter_collection_field.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_field.go
@@ -7,9 +7,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
-	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
-	"github.com/milvus-io/milvus/internal/metastore/model"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/proto/messagespb"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
@@ -54,17 +52,8 @@ func (c *Core) broadcastAlterCollectionV2ForAlterCollectionField(ctx context.Con
 	}
 
 	// build new collection schema.
-	schema := &schemapb.CollectionSchema{
-		Name:               coll.Name,
-		Description:        coll.Description,
-		AutoID:             coll.AutoID,
-		Fields:             model.MarshalFieldModels(coll.Fields),
-		StructArrayFields:  model.MarshalStructArrayFieldModels(coll.StructArrayFields),
-		Functions:          model.MarshalFunctionModels(coll.Functions),
-		EnableDynamicField: coll.EnableDynamicField,
-		Properties:         coll.Properties,
-		Version:            coll.SchemaVersion + 1,
-	}
+	schema := coll.ToCollectionSchemaPB()
+	schema.Version = coll.SchemaVersion + 1
 	for _, field := range schema.Fields {
 		if field.Name == req.GetFieldName() {
 			field.TypeParams = newFieldProperties

--- a/internal/rootcoord/ddl_callbacks_alter_collection_properties.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_properties.go
@@ -12,7 +12,6 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
-	"github.com/milvus-io/milvus/internal/metastore/model"
 	"github.com/milvus-io/milvus/internal/util/hookutil"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/log"
@@ -185,17 +184,9 @@ func (c *Core) broadcastAlterCollectionForAlterDynamicField(ctx context.Context,
 	}
 
 	fieldSchema.FieldID = nextFieldID(coll)
-	schema := &schemapb.CollectionSchema{
-		Name:               coll.Name,
-		Description:        coll.Description,
-		AutoID:             coll.AutoID,
-		Fields:             model.MarshalFieldModels(coll.Fields),
-		StructArrayFields:  model.MarshalStructArrayFieldModels(coll.StructArrayFields),
-		Functions:          model.MarshalFunctionModels(coll.Functions),
-		EnableDynamicField: targetValue,
-		Properties:         coll.Properties,
-		Version:            coll.SchemaVersion + 1,
-	}
+	schema := coll.ToCollectionSchemaPB()
+	schema.Version = coll.SchemaVersion + 1
+	schema.EnableDynamicField = targetValue
 	schema.Fields = append(schema.Fields, fieldSchema)
 
 	channels := make([]string, 0, len(coll.VirtualChannelNames)+1)

--- a/internal/rootcoord/ddl_callbacks_collection_function.go
+++ b/internal/rootcoord/ddl_callbacks_collection_function.go
@@ -37,17 +37,8 @@ import (
 
 func callAlterCollection(ctx context.Context, c *Core, broadcaster broadcaster.BroadcastAPI, coll *model.Collection, dbName string, collectionName string) error {
 	// build new collection schema.
-	schema := &schemapb.CollectionSchema{
-		Name:               coll.Name,
-		Description:        coll.Description,
-		AutoID:             coll.AutoID,
-		Fields:             model.MarshalFieldModels(coll.Fields),
-		StructArrayFields:  model.MarshalStructArrayFieldModels(coll.StructArrayFields),
-		Functions:          model.MarshalFunctionModels(coll.Functions),
-		EnableDynamicField: coll.EnableDynamicField,
-		Properties:         coll.Properties,
-		Version:            coll.SchemaVersion + 1,
-	}
+	schema := coll.ToCollectionSchemaPB()
+	schema.Version = coll.SchemaVersion + 1
 
 	cacheExpirations, err := c.getCacheExpireForCollection(ctx, dbName, collectionName)
 	if err != nil {

--- a/internal/rootcoord/ddl_callbacks_create_collection.go
+++ b/internal/rootcoord/ddl_callbacks_create_collection.go
@@ -202,6 +202,7 @@ func newCollectionModel(header *message.CreateCollectionMessageHeader, body *mes
 		Partitions:           partitions,
 		Properties:           properties,
 		EnableDynamicField:   body.CollectionSchema.EnableDynamicField,
+		EnableNamespace:      body.CollectionSchema.EnableNamespace,
 		UpdateTimestamp:      ts,
 		SchemaVersion:        0,
 		ShardInfos:           shardInfos,

--- a/internal/rootcoord/root_coord.go
+++ b/internal/rootcoord/root_coord.go
@@ -35,7 +35,6 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
-	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/allocator"
 	"github.com/milvus-io/milvus/internal/coordinator/snmanager"
 	etcdkv "github.com/milvus-io/milvus/internal/kv/etcd"
@@ -1077,16 +1076,10 @@ func convertModelToDesc(collInfo *model.Collection, aliases []string, dbName str
 		DbName: dbName,
 	}
 
-	resp.Schema = &schemapb.CollectionSchema{
-		Name:               collInfo.Name,
-		Description:        collInfo.Description,
-		AutoID:             collInfo.AutoID,
-		Fields:             model.MarshalFieldModels(collInfo.Fields),
-		StructArrayFields:  model.MarshalStructArrayFieldModels(collInfo.StructArrayFields),
-		Functions:          model.MarshalFunctionModels(collInfo.Functions),
-		EnableDynamicField: collInfo.EnableDynamicField,
-		Properties:         collInfo.Properties,
-	}
+	resp.Schema = collInfo.ToCollectionSchemaPB()
+	// Use the dbName parameter (resolved from the request) for consistency
+	// with resp.DbName; the model's DBName may not always be in sync.
+	resp.Schema.DbName = dbName
 	resp.CollectionID = collInfo.CollectionID
 	resp.VirtualChannelNames = collInfo.VirtualChannelNames
 	resp.PhysicalChannelNames = collInfo.PhysicalChannelNames


### PR DESCRIPTION
In 2.6 schemapb.CollectionSchema gained EnableNamespace (proto field 15), but rootcoord constructs the schema proto by hand at 6 sites: the AddField / AlterField / AlterFunction DDL callbacks, the BroadcastAlteredCollection RPC to DataCoord, the dynamic-field path in AlterCollection, and the DescribeCollection response. Each literal enumerates the fields it copies, and they have drifted: every site drops EnableNamespace on broadcast, broker.go additionally drops EnableDynamicField / Version / DbName. The rootcoord-side *model.Collection didn't carry EnableNamespace at all, so the field was silently lost on every read/write round-trip through the model layer.

Convert the literals to a single helper on the model:

- Add EnableNamespace to model.Collection and propagate it through ShallowClone, Clone, ApplyUpdates, UnmarshalCollectionModel, and marshalCollectionModelWithConfig so the model stops losing it.
- Add (*model.Collection).ToCollectionSchemaPB() in internal/metastore/model/collection.go. It copies every schema-level field once (Name, Description, AutoID, Fields, StructArrayFields, Functions, EnableDynamicField, EnableNamespace, Properties, DbName, SchemaVersion). Future additions live here only.
- Replace all 6 literal sites in internal/rootcoord/ with the helper. Operation-specific overrides become explicit field assignments on the returned schema:
  * Version = SchemaVersion + 1 for AddField / AlterField / AlterFunction / dynamic-field-enable; unchanged for BroadcastAlteredCollection.
  * EnableDynamicField = targetValue for the dynamic-field-enable path.
  * Fields/Functions get appended after construction where the DDL adds new ones. DescribeCollection keeps overriding DbName with the request-resolved dbName for resp.DbName/resp.Schema.DbName consistency.
- Add TestCollection_ToCollectionSchemaPB asserting every field round- trips. This is the tripwire: any future addition that forgets to wire the helper will fail this test before it reaches a broadcast path.

Behavior change for DataCoord: BroadcastAlteredCollection.Schema now carries EnableDynamicField, EnableNamespace, Version and DbName which it had been silently losing. DataCoord consumers only read the fields they care about, so populating extras is a fix, not a regression.

issue: #49359
pr: #49360