### PR TITLE
fix: external table stability pack for alter tuple, refresh, spec validation, and datanode edge cases

### DIFF
--- a/internal/core/src/common/ChunkWriter.cpp
+++ b/internal/core/src/common/ChunkWriter.cpp
@@ -55,6 +55,10 @@ StringChunkWriter::calculate_size(const arrow::ArrayVector& array_vec) {
     offsets_.reserve(offset_num);
     for (const auto& data : array_vec) {
         auto array = std::dynamic_pointer_cast<arrow::BinaryArray>(data);
+        AssertInfo(array != nullptr,
+                   "StringChunkWriter expects arrow::BinaryArray, got "
+                   "type id {}; upstream normalizer must coerce to BINARY",
+                   data ? static_cast<int>(data->type_id()) : -1);
         for (int i = 0; i < array->length(); i++) {
             offsets_.push_back(static_cast<uint32_t>(cursor));
             cursor += array->GetView(i).size();
@@ -89,6 +93,10 @@ StringChunkWriter::write_to_target(const arrow::ArrayVector& array_vec,
 
     for (const auto& data : array_vec) {
         auto array = std::dynamic_pointer_cast<arrow::BinaryArray>(data);
+        AssertInfo(array != nullptr,
+                   "StringChunkWriter expects arrow::BinaryArray, got "
+                   "type id {}; upstream normalizer must coerce to BINARY",
+                   data ? static_cast<int>(data->type_id()) : -1);
         for (int i = 0; i < array->length(); i++) {
             auto str = array->GetView(i);
             target->write(str.data(), str.size());
@@ -121,6 +129,10 @@ JSONChunkWriter::calculate_size(const arrow::ArrayVector& array_vec) {
     offsets_.reserve(offset_num);
     for (const auto& data : array_vec) {
         auto array = std::dynamic_pointer_cast<arrow::BinaryArray>(data);
+        AssertInfo(array != nullptr,
+                   "JSONChunkWriter expects arrow::BinaryArray, got "
+                   "type id {}; upstream normalizer must coerce to BINARY",
+                   data ? static_cast<int>(data->type_id()) : -1);
         for (int i = 0; i < array->length(); i++) {
             offsets_.push_back(static_cast<uint32_t>(cursor));
             cursor += array->GetView(i).size();
@@ -184,6 +196,10 @@ GeometryChunkWriter::calculate_size(const arrow::ArrayVector& array_vec) {
     offsets_.reserve(offset_num);
     for (const auto& data : array_vec) {
         auto array = std::dynamic_pointer_cast<arrow::BinaryArray>(data);
+        AssertInfo(array != nullptr,
+                   "GeometryChunkWriter expects arrow::BinaryArray, got "
+                   "type id {}; upstream normalizer must coerce to BINARY",
+                   data ? static_cast<int>(data->type_id()) : -1);
         for (int64_t i = 0; i < array->length(); ++i) {
             offsets_.push_back(static_cast<uint32_t>(cursor));
             cursor += array->GetView(i).size();
@@ -217,6 +233,10 @@ GeometryChunkWriter::write_to_target(
 
     for (const auto& data : array_vec) {
         auto array = std::dynamic_pointer_cast<arrow::BinaryArray>(data);
+        AssertInfo(array != nullptr,
+                   "GeometryChunkWriter expects arrow::BinaryArray, got "
+                   "type id {}; upstream normalizer must coerce to BINARY",
+                   data ? static_cast<int>(data->type_id()) : -1);
         for (int64_t i = 0; i < array->length(); ++i) {
             auto str = array->GetView(i);
             target->write(str.data(), str.size());
@@ -254,6 +274,10 @@ ArrayChunkWriter::calculate_size(const arrow::ArrayVector& array_vec) {
 
     for (const auto& data : array_vec) {
         auto array = std::dynamic_pointer_cast<arrow::BinaryArray>(data);
+        AssertInfo(array != nullptr,
+                   "ArrayChunkWriter expects arrow::BinaryArray, got "
+                   "type id {}; upstream normalizer must coerce to BINARY",
+                   data ? static_cast<int>(data->type_id()) : -1);
         for (int64_t i = 0; i < array->length(); ++i) {
             auto str = array->GetView(i);
             ScalarFieldProto scalar_array;

--- a/internal/core/src/segcore/external_utils_c.cpp
+++ b/internal/core/src/segcore/external_utils_c.cpp
@@ -29,6 +29,7 @@
 #include "milvus-storage/column_groups.h"
 #include "milvus-storage/manifest.h"
 #include "milvus-storage/reader.h"
+#include "storage/Util.h"
 #include "storage/loon_ffi/util.h"
 
 static CStatus
@@ -127,7 +128,12 @@ SampleExternalSegmentFieldSizes(const char* manifest_path,
             int64_t col_bytes = 0;
             auto chunked = table->column(i);
             for (int c = 0; c < chunked->num_chunks(); c++) {
-                col_bytes += calcArrayDataSize(chunked->chunk(c)->data());
+                // Single view-variant elimination via shared helper.
+                // (issue #49352: vortex schemaless emits view types whose
+                // buffer layout differs; canonicalize before sizing.)
+                auto chunk = milvus::storage::CanonicalizeArrowVariants(
+                    chunked->chunk(c));
+                col_bytes += calcArrayDataSize(chunk->data());
             }
 
             auto name = table->field(i)->name();

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -14,11 +14,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <limits>
 #include <memory>
 
 #include "arrow/array/builder_binary.h"
 #include "arrow/array/builder_nested.h"
 #include "arrow/array/builder_primitive.h"
+#include "arrow/array/concatenate.h"
+#include "arrow/buffer_builder.h"
 #include <arrow/c/bridge.h>
 #include "arrow/scalar.h"
 #include "arrow/type_fwd.h"
@@ -1850,6 +1853,449 @@ ConvertStringArrayToBinary(const arrow::ArrayVector& arrays) {
     return result;
 }
 
+// Coerce any binary-like Arrow array to canonical BinaryArray.
+// Source readers (e.g. vortex) may produce LARGE_BINARY / BINARY_VIEW /
+// LARGE_STRING / STRING_VIEW for the same logical bytes; downstream
+// ChunkWriters dynamic_cast to BinaryArray and would null-deref.
+arrow::ArrayVector
+CoerceToBinary(const arrow::ArrayVector& arrays) {
+    arrow::ArrayVector result;
+    result.reserve(arrays.size());
+    for (const auto& arr : arrays) {
+        const auto tid = arr->type_id();
+        if (tid == arrow::Type::BINARY) {
+            result.push_back(arr);
+            continue;
+        }
+        if (tid == arrow::Type::STRING) {
+            // Zero-copy: identical buffer layout
+            auto d = arr->data();
+            auto bin = arrow::ArrayData::Make(arrow::binary(),
+                                              d->length,
+                                              d->buffers,
+                                              d->null_count,
+                                              d->offset);
+            result.push_back(std::make_shared<arrow::BinaryArray>(bin));
+            continue;
+        }
+        if (tid == arrow::Type::LARGE_BINARY ||
+            tid == arrow::Type::LARGE_STRING ||
+            tid == arrow::Type::BINARY_VIEW ||
+            tid == arrow::Type::STRING_VIEW) {
+            // Different offset/buffer layout -> rebuild via builder.
+            arrow::BinaryBuilder builder;
+            auto status = builder.Reserve(arr->length());
+            AssertInfo(status.ok(),
+                       "BinaryBuilder reserve failed: " + status.ToString());
+            switch (tid) {
+                case arrow::Type::LARGE_BINARY: {
+                    auto src =
+                        std::static_pointer_cast<arrow::LargeBinaryArray>(arr);
+                    for (int64_t i = 0; i < src->length(); ++i) {
+                        if (src->IsNull(i)) {
+                            status = builder.AppendNull();
+                        } else {
+                            auto v = src->GetView(i);
+                            status = builder.Append(
+                                reinterpret_cast<const uint8_t*>(v.data()),
+                                v.size());
+                        }
+                        AssertInfo(status.ok(),
+                                   "BinaryBuilder append failed: " +
+                                       status.ToString());
+                    }
+                    break;
+                }
+                case arrow::Type::LARGE_STRING: {
+                    auto src =
+                        std::static_pointer_cast<arrow::LargeStringArray>(arr);
+                    for (int64_t i = 0; i < src->length(); ++i) {
+                        if (src->IsNull(i)) {
+                            status = builder.AppendNull();
+                        } else {
+                            auto v = src->GetView(i);
+                            status = builder.Append(
+                                reinterpret_cast<const uint8_t*>(v.data()),
+                                v.size());
+                        }
+                        AssertInfo(status.ok(),
+                                   "BinaryBuilder append failed: " +
+                                       status.ToString());
+                    }
+                    break;
+                }
+                case arrow::Type::BINARY_VIEW: {
+                    auto src =
+                        std::static_pointer_cast<arrow::BinaryViewArray>(arr);
+                    for (int64_t i = 0; i < src->length(); ++i) {
+                        if (src->IsNull(i)) {
+                            status = builder.AppendNull();
+                        } else {
+                            auto v = src->GetView(i);
+                            status = builder.Append(
+                                reinterpret_cast<const uint8_t*>(v.data()),
+                                v.size());
+                        }
+                        AssertInfo(status.ok(),
+                                   "BinaryBuilder append failed: " +
+                                       status.ToString());
+                    }
+                    break;
+                }
+                case arrow::Type::STRING_VIEW: {
+                    auto src =
+                        std::static_pointer_cast<arrow::StringViewArray>(arr);
+                    for (int64_t i = 0; i < src->length(); ++i) {
+                        if (src->IsNull(i)) {
+                            status = builder.AppendNull();
+                        } else {
+                            auto v = src->GetView(i);
+                            status = builder.Append(
+                                reinterpret_cast<const uint8_t*>(v.data()),
+                                v.size());
+                        }
+                        AssertInfo(status.ok(),
+                                   "BinaryBuilder append failed: " +
+                                       status.ToString());
+                    }
+                    break;
+                }
+                default:
+                    break;
+            }
+            std::shared_ptr<arrow::Array> out;
+            status = builder.Finish(&out);
+            AssertInfo(
+                status.ok(),
+                "BinaryBuilder finish failed: " + status.ToString());
+            result.push_back(out);
+            continue;
+        }
+        result.push_back(arr);
+    }
+    return result;
+}
+
+// Forward decl: defined alongside CanonicalizeArrowVariants below.
+static std::shared_ptr<arrow::Buffer>
+RebuildNullBitmap(const std::shared_ptr<arrow::Array>& array);
+
+// Coerce LARGE_LIST / LIST_VIEW to canonical (32-bit offset) ListArray.
+// Vortex schemaless mode may emit list variants for the same logical
+// List<T>; downstream code (ConvertListToProtobufBinary,
+// NormalizeVectorArrayInner, ArrowListToScalarFieldProto) expects
+// arrow::ListArray and would static_cast-fail otherwise.
+arrow::ArrayVector
+CoerceToList(const arrow::ArrayVector& arrays) {
+    arrow::ArrayVector result;
+    result.reserve(arrays.size());
+    for (const auto& arr : arrays) {
+        const auto tid = arr->type_id();
+        if (tid != arrow::Type::LARGE_LIST &&
+            tid != arrow::Type::LIST_VIEW) {
+            result.push_back(arr);
+            continue;
+        }
+
+        std::shared_ptr<arrow::Array> values;
+        std::vector<std::pair<int64_t, int64_t>> ranges;
+        ranges.reserve(arr->length());
+        if (tid == arrow::Type::LARGE_LIST) {
+            auto la = std::static_pointer_cast<arrow::LargeListArray>(arr);
+            values = la->values();
+            for (int64_t i = 0; i < la->length(); ++i) {
+                int64_t s = la->value_offset(i);
+                int64_t e = s + la->value_length(i);
+                ranges.emplace_back(s, e);
+            }
+        } else {
+            auto lv = std::static_pointer_cast<arrow::ListViewArray>(arr);
+            values = lv->values();
+            for (int64_t i = 0; i < lv->length(); ++i) {
+                int64_t s = lv->value_offset(i);
+                int64_t e = s + lv->value_length(i);
+                ranges.emplace_back(s, e);
+            }
+        }
+
+        arrow::Int32Builder offset_builder;
+        auto status = offset_builder.Reserve(arr->length() + 1);
+        AssertInfo(status.ok(),
+                   "CoerceToList: offset reserve failed: " + status.ToString());
+        std::vector<std::shared_ptr<arrow::Array>> value_slices;
+        int32_t cur = 0;
+        status = offset_builder.Append(0);
+        AssertInfo(status.ok(), "CoerceToList: offset append failed");
+        for (int64_t i = 0; i < arr->length(); ++i) {
+            if (!arr->IsNull(i)) {
+                auto [s, e] = ranges[i];
+                int64_t len = e - s;
+                AssertInfo(cur + len <= INT32_MAX,
+                           "CoerceToList: offset overflows int32");
+                value_slices.push_back(values->Slice(s, len));
+                cur += static_cast<int32_t>(len);
+            }
+            status = offset_builder.Append(cur);
+            AssertInfo(status.ok(), "CoerceToList: offset append failed");
+        }
+        std::shared_ptr<arrow::Array> offsets_arr;
+        status = offset_builder.Finish(&offsets_arr);
+        AssertInfo(status.ok(),
+                   "CoerceToList: offset finish failed: " + status.ToString());
+
+        std::shared_ptr<arrow::Array> concat_values;
+        if (value_slices.empty()) {
+            auto empty = arrow::MakeArrayOfNull(values->type(), 0);
+            AssertInfo(empty.ok(), "CoerceToList: empty values failed");
+            concat_values = *empty;
+        } else {
+            auto concat = arrow::Concatenate(value_slices);
+            AssertInfo(concat.ok(),
+                       "CoerceToList: concat failed: " +
+                           concat.status().ToString());
+            concat_values = *concat;
+        }
+
+        auto offsets_buf =
+            std::static_pointer_cast<arrow::Int32Array>(offsets_arr)
+                ->values();
+        auto list_arr = std::make_shared<arrow::ListArray>(
+            arrow::list(values->type()),
+            arr->length(),
+            offsets_buf,
+            concat_values,
+            RebuildNullBitmap(arr),
+            arr->null_count(),
+            0);
+        result.push_back(list_arr);
+    }
+    return result;
+}
+
+// Rebuild null bitmap as a fresh buffer at offset=0.
+// Required when constructing a new arrow::Array that does not share the
+// input's logical offset — direct reuse of `array->null_bitmap()` is
+// incorrect for sliced inputs (offset != 0) because callers will read the
+// bitmap starting at bit 0 instead of bit `array->offset()`.
+static std::shared_ptr<arrow::Buffer>
+RebuildNullBitmap(const std::shared_ptr<arrow::Array>& array) {
+    if (array->null_count() == 0) {
+        return nullptr;
+    }
+    arrow::TypedBufferBuilder<bool> bb;
+    auto status = bb.Reserve(array->length());
+    AssertInfo(status.ok(),
+               "RebuildNullBitmap: reserve failed: " + status.ToString());
+    for (int64_t i = 0; i < array->length(); ++i) {
+        bb.UnsafeAppend(!array->IsNull(i));
+    }
+    std::shared_ptr<arrow::Buffer> buf;
+    status = bb.Finish(&buf);
+    AssertInfo(status.ok(),
+               "RebuildNullBitmap: finish failed: " + status.ToString());
+    return buf;
+}
+
+// Single-source-of-truth view-variant elimination. Callers that ingest
+// vortex (or any schemaless reader that may emit *_VIEW / LARGE_* layouts)
+// route arrays through this helper before any type-id dispatch. Pure
+// type/layout normalization — no semantic conversion (no WKT→WKB,
+// no Timestamp→Int64, etc).
+//
+//   STRING_VIEW / LARGE_STRING -> STRING
+//   BINARY_VIEW / LARGE_BINARY -> BINARY
+//   LARGE_LIST  / LIST_VIEW    -> LIST  (recurses into inner values)
+//   LIST                       -> LIST  (recurses into inner values)
+//   FIXED_SIZE_LIST            -> FIXED_SIZE_LIST (recurses into inner values)
+//   anything else              -> unchanged
+std::shared_ptr<arrow::Array>
+CanonicalizeArrowVariants(const std::shared_ptr<arrow::Array>& array) {
+    const auto tid = array->type_id();
+
+    // Variable-length string variants -> STRING
+    if (tid == arrow::Type::STRING_VIEW ||
+        tid == arrow::Type::LARGE_STRING) {
+        arrow::StringBuilder builder;
+        auto status = builder.Reserve(array->length());
+        AssertInfo(status.ok(),
+                   "CanonicalizeArrowVariants: string reserve failed");
+        if (tid == arrow::Type::STRING_VIEW) {
+            auto src = std::static_pointer_cast<arrow::StringViewArray>(array);
+            for (int64_t i = 0; i < src->length(); ++i) {
+                if (src->IsNull(i)) {
+                    AssertInfo(builder.AppendNull().ok(), "appendnull");
+                } else {
+                    auto v = src->GetView(i);
+                    AssertInfo(builder.Append(v.data(), v.size()).ok(),
+                               "append str");
+                }
+            }
+        } else {
+            auto src = std::static_pointer_cast<arrow::LargeStringArray>(array);
+            for (int64_t i = 0; i < src->length(); ++i) {
+                if (src->IsNull(i)) {
+                    AssertInfo(builder.AppendNull().ok(), "appendnull");
+                } else {
+                    auto v = src->GetView(i);
+                    AssertInfo(builder.Append(v.data(), v.size()).ok(),
+                               "append str");
+                }
+            }
+        }
+        std::shared_ptr<arrow::Array> out;
+        AssertInfo(builder.Finish(&out).ok(), "string finish");
+        return out;
+    }
+
+    // Variable-length binary variants -> BINARY
+    if (tid == arrow::Type::BINARY_VIEW ||
+        tid == arrow::Type::LARGE_BINARY) {
+        arrow::BinaryBuilder builder;
+        auto status = builder.Reserve(array->length());
+        AssertInfo(status.ok(),
+                   "CanonicalizeArrowVariants: binary reserve failed");
+        if (tid == arrow::Type::BINARY_VIEW) {
+            auto src = std::static_pointer_cast<arrow::BinaryViewArray>(array);
+            for (int64_t i = 0; i < src->length(); ++i) {
+                if (src->IsNull(i)) {
+                    AssertInfo(builder.AppendNull().ok(), "appendnull");
+                } else {
+                    auto v = src->GetView(i);
+                    AssertInfo(builder
+                                   .Append(reinterpret_cast<const uint8_t*>(
+                                               v.data()),
+                                           v.size())
+                                   .ok(),
+                               "append bin");
+                }
+            }
+        } else {
+            auto src = std::static_pointer_cast<arrow::LargeBinaryArray>(array);
+            for (int64_t i = 0; i < src->length(); ++i) {
+                if (src->IsNull(i)) {
+                    AssertInfo(builder.AppendNull().ok(), "appendnull");
+                } else {
+                    auto v = src->GetView(i);
+                    AssertInfo(builder
+                                   .Append(reinterpret_cast<const uint8_t*>(
+                                               v.data()),
+                                           v.size())
+                                   .ok(),
+                               "append bin");
+                }
+            }
+        }
+        std::shared_ptr<arrow::Array> out;
+        AssertInfo(builder.Finish(&out).ok(), "binary finish");
+        return out;
+    }
+
+    // List variants -> LIST (recursively canonicalize values)
+    if (tid == arrow::Type::LARGE_LIST || tid == arrow::Type::LIST_VIEW ||
+        tid == arrow::Type::LIST) {
+        std::shared_ptr<arrow::Array> values;
+        std::vector<std::pair<int64_t, int64_t>> ranges;
+        ranges.reserve(array->length());
+        if (tid == arrow::Type::LIST) {
+            auto la = std::static_pointer_cast<arrow::ListArray>(array);
+            values = la->values();
+            for (int64_t i = 0; i < la->length(); ++i) {
+                int64_t s = la->value_offset(i);
+                ranges.emplace_back(s, s + la->value_length(i));
+            }
+        } else if (tid == arrow::Type::LARGE_LIST) {
+            auto la = std::static_pointer_cast<arrow::LargeListArray>(array);
+            values = la->values();
+            for (int64_t i = 0; i < la->length(); ++i) {
+                int64_t s = la->value_offset(i);
+                ranges.emplace_back(s, s + la->value_length(i));
+            }
+        } else {
+            auto lv = std::static_pointer_cast<arrow::ListViewArray>(array);
+            values = lv->values();
+            for (int64_t i = 0; i < lv->length(); ++i) {
+                int64_t s = lv->value_offset(i);
+                ranges.emplace_back(s, s + lv->value_length(i));
+            }
+        }
+
+        auto canonical_values = CanonicalizeArrowVariants(values);
+
+        // Fast path: already canonical LIST and inner unchanged -> return as-is
+        if (tid == arrow::Type::LIST &&
+            canonical_values.get() == values.get()) {
+            return array;
+        }
+
+        // Rebuild offsets + slice canonical values per row
+        arrow::Int32Builder offset_builder;
+        AssertInfo(offset_builder.Reserve(array->length() + 1).ok(),
+                   "offset reserve");
+        std::vector<std::shared_ptr<arrow::Array>> slices;
+        int32_t cur = 0;
+        AssertInfo(offset_builder.Append(0).ok(), "offset append");
+        for (int64_t i = 0; i < array->length(); ++i) {
+            if (!array->IsNull(i)) {
+                auto [s, e] = ranges[i];
+                int64_t len = e - s;
+                AssertInfo(cur + len <= INT32_MAX,
+                           "CanonicalizeArrowVariants: int32 offset overflow");
+                slices.push_back(canonical_values->Slice(s, len));
+                cur += static_cast<int32_t>(len);
+            }
+            AssertInfo(offset_builder.Append(cur).ok(), "offset append");
+        }
+        std::shared_ptr<arrow::Array> offsets_arr;
+        AssertInfo(offset_builder.Finish(&offsets_arr).ok(), "offset finish");
+
+        std::shared_ptr<arrow::Array> concat_values;
+        if (slices.empty()) {
+            auto empty = arrow::MakeArrayOfNull(canonical_values->type(), 0);
+            AssertInfo(empty.ok(), "empty values");
+            concat_values = *empty;
+        } else {
+            auto concat = arrow::Concatenate(slices);
+            AssertInfo(concat.ok(),
+                       "concat: " + concat.status().ToString());
+            concat_values = *concat;
+        }
+
+        auto offsets_buf =
+            std::static_pointer_cast<arrow::Int32Array>(offsets_arr)
+                ->values();
+        return std::make_shared<arrow::ListArray>(
+            arrow::list(canonical_values->type()),
+            array->length(),
+            offsets_buf,
+            concat_values,
+            RebuildNullBitmap(array),
+            array->null_count(),
+            0);
+    }
+
+    // FIXED_SIZE_LIST: recurse into values only (layout already canonical)
+    if (tid == arrow::Type::FIXED_SIZE_LIST) {
+        auto fsl = std::static_pointer_cast<arrow::FixedSizeListArray>(array);
+        auto inner = fsl->values();
+        auto canonical_inner = CanonicalizeArrowVariants(inner);
+        if (canonical_inner.get() == inner.get()) {
+            return array;
+        }
+        auto fsl_type = std::static_pointer_cast<arrow::FixedSizeListType>(
+            fsl->type());
+        return std::make_shared<arrow::FixedSizeListArray>(
+            arrow::fixed_size_list(canonical_inner->type(),
+                                   fsl_type->list_size()),
+            fsl->length(),
+            canonical_inner,
+            RebuildNullBitmap(fsl),
+            fsl->null_count(),
+            0);
+    }
+
+    return array;
+}
+
 arrow::ArrayVector
 ConvertWKTStringArrayToWKBBinary(const arrow::ArrayVector& arrays) {
     arrow::ArrayVector result;
@@ -1859,22 +2305,37 @@ ConvertWKTStringArrayToWKBBinary(const arrow::ArrayVector& arrays) {
     AssertInfo(ctx != nullptr, "Failed to initialize GEOS context");
 
     for (const auto& arr : arrays) {
-        if (arr->type_id() != arrow::Type::STRING) {
+        const auto tid = arr->type_id();
+        if (tid != arrow::Type::STRING && tid != arrow::Type::LARGE_STRING &&
+            tid != arrow::Type::STRING_VIEW) {
             result.push_back(arr);
             continue;
         }
-        auto str_array = std::static_pointer_cast<arrow::StringArray>(arr);
+        auto get_string = [&](int64_t i) -> std::string {
+            if (tid == arrow::Type::STRING) {
+                return std::static_pointer_cast<arrow::StringArray>(arr)
+                    ->GetString(i);
+            }
+            if (tid == arrow::Type::LARGE_STRING) {
+                return std::static_pointer_cast<arrow::LargeStringArray>(arr)
+                    ->GetString(i);
+            }
+            auto sv =
+                std::static_pointer_cast<arrow::StringViewArray>(arr)->GetView(
+                    i);
+            return std::string(sv.data(), sv.size());
+        };
         arrow::BinaryBuilder builder;
-        auto status = builder.Reserve(str_array->length());
+        auto status = builder.Reserve(arr->length());
         AssertInfo(status.ok(),
                    "BinaryBuilder reserve failed: " + status.ToString());
-        for (int64_t i = 0; i < str_array->length(); ++i) {
-            if (str_array->IsNull(i)) {
+        for (int64_t i = 0; i < arr->length(); ++i) {
+            if (arr->IsNull(i)) {
                 status = builder.AppendNull();
                 AssertInfo(status.ok(), "AppendNull failed");
                 continue;
             }
-            auto wkt = str_array->GetString(i);
+            auto wkt = get_string(i);
             Geometry geom(ctx, wkt.c_str());
             auto wkb = geom.to_wkb_string();
             status = builder.Append(wkb);
@@ -2049,13 +2510,96 @@ NormalizeArrowForChunkWriter(const arrow::ArrayVector& arrays,
     return result;
 }
 
+// Narrow an arrow integer array to a smaller-width integer builder.
+// Required because some external sources (notably iceberg) only have
+// IntegerType / LongType and widen Int8/Int16 to Int32/Int64 on read.
+// Without explicit narrowing, downstream FillFieldData reinterpret_casts
+// the wider buffer as the narrower type and reads bytewise garbage.
+template <typename SrcArray, typename DstBuilder, typename DstT>
+static std::shared_ptr<arrow::Array>
+NarrowIntArray(const std::shared_ptr<arrow::Array>& src_arr,
+               const char* dst_name) {
+    auto src = std::static_pointer_cast<SrcArray>(src_arr);
+    DstBuilder builder;
+    auto status = builder.Reserve(src->length());
+    AssertInfo(status.ok(),
+               "NarrowIntArray reserve failed: " + status.ToString());
+    constexpr auto lo = std::numeric_limits<DstT>::min();
+    constexpr auto hi = std::numeric_limits<DstT>::max();
+    for (int64_t i = 0; i < src->length(); ++i) {
+        if (src->IsNull(i)) {
+            AssertInfo(builder.AppendNull().ok(), "AppendNull failed");
+            continue;
+        }
+        auto v = src->Value(i);
+        AssertInfo(v >= lo && v <= hi,
+                   "{} narrowing overflow: source value {} out of range "
+                   "[{}, {}]",
+                   dst_name,
+                   static_cast<int64_t>(v),
+                   static_cast<int64_t>(lo),
+                   static_cast<int64_t>(hi));
+        AssertInfo(builder.Append(static_cast<DstT>(v)).ok(),
+                   "Append narrowed int failed");
+    }
+    std::shared_ptr<arrow::Array> out;
+    AssertInfo(builder.Finish(&out).ok(),
+               "NarrowIntArray finish failed");
+    return out;
+}
+
+// Dispatch wider-int arrow source to a narrower milvus int field by
+// matching (DataType, arrow::Type::type). Returns nullptr if no narrowing
+// applies; caller continues original dispatch.
+static std::shared_ptr<arrow::Array>
+MaybeNarrowInt(DataType data_type,
+               const std::shared_ptr<arrow::Array>& array) {
+    auto type_id = array->type_id();
+    if (data_type == DataType::INT8) {
+        if (type_id == arrow::Type::INT16)
+            return NarrowIntArray<arrow::Int16Array, arrow::Int8Builder,
+                                  int8_t>(array, "INT8");
+        if (type_id == arrow::Type::INT32)
+            return NarrowIntArray<arrow::Int32Array, arrow::Int8Builder,
+                                  int8_t>(array, "INT8");
+        if (type_id == arrow::Type::INT64)
+            return NarrowIntArray<arrow::Int64Array, arrow::Int8Builder,
+                                  int8_t>(array, "INT8");
+    }
+    if (data_type == DataType::INT16) {
+        if (type_id == arrow::Type::INT32)
+            return NarrowIntArray<arrow::Int32Array, arrow::Int16Builder,
+                                  int16_t>(array, "INT16");
+        if (type_id == arrow::Type::INT64)
+            return NarrowIntArray<arrow::Int64Array, arrow::Int16Builder,
+                                  int16_t>(array, "INT16");
+    }
+    if (data_type == DataType::INT32 && type_id == arrow::Type::INT64) {
+        return NarrowIntArray<arrow::Int64Array, arrow::Int32Builder,
+                              int32_t>(array, "INT32");
+    }
+    return nullptr;
+}
+
 // Overload for callers without FieldMeta.
 std::shared_ptr<arrow::Array>
-NormalizeExternalArrow(const std::shared_ptr<arrow::Array>& array,
+NormalizeExternalArrow(const std::shared_ptr<arrow::Array>& array_in,
                        DataType data_type,
                        int64_t dim,
                        bool nullable,
                        DataType element_type) {
+    // Single view-variant elimination pass: STRING_VIEW/LARGE_STRING -> STRING,
+    // BINARY_VIEW/LARGE_BINARY -> BINARY, LARGE_LIST/LIST_VIEW -> LIST
+    // (recursive into list inner). Downstream branches only need to dispatch
+    // on canonical type_ids.
+    auto array = CanonicalizeArrowVariants(array_in);
+    // Integer narrowing: source readers (e.g. iceberg) may widen Int8/Int16
+    // to Int32/Int64 because their type system lacks narrow ints. Narrow
+    // explicitly so downstream FillFieldData reinterpret-cast doesn't read
+    // bytewise garbage.
+    if (auto narrowed = MaybeNarrowInt(data_type, array); narrowed != nullptr) {
+        array = narrowed;
+    }
     auto type_id = array->type_id();
 
     // Dense vectors
@@ -2077,17 +2621,29 @@ NormalizeExternalArrow(const std::shared_ptr<arrow::Array>& array,
         auto result = NormalizeVectorArrayInner({array}, element_type, dim);
         return result[0];
     }
-    // Geometry: WKT → WKB
+    // Geometry STRING input -> WKT, convert to WKB.
+    // (View/large-string variants already canonicalized to STRING above.)
     if (data_type == DataType::GEOMETRY && type_id == arrow::Type::STRING) {
         auto result = ConvertWKTStringArrayToWKBBinary({array});
         return result[0];
     }
-    // JSON/VARCHAR/STRING/TEXT: String → Binary
+    // Geometry BINARY input -> already WKB, no-op (issue #49353).
+    if (data_type == DataType::GEOMETRY && type_id == arrow::Type::BINARY) {
+        return array;
+    }
+    // JSON/VARCHAR/STRING/TEXT: String -> Binary (canonical internal repr).
+    // (View/large variants already canonicalized to STRING above; issue #49352.)
     if ((data_type == DataType::VARCHAR || data_type == DataType::STRING ||
          data_type == DataType::TEXT || data_type == DataType::JSON) &&
         type_id == arrow::Type::STRING) {
         auto result = ConvertStringArrayToBinary({array});
         return result[0];
+    }
+    // JSON/VARCHAR/STRING/TEXT: BINARY input is already canonical.
+    if ((data_type == DataType::VARCHAR || data_type == DataType::STRING ||
+         data_type == DataType::TEXT || data_type == DataType::JSON) &&
+        type_id == arrow::Type::BINARY) {
+        return array;
     }
     // Timestamptz: Timestamp → Int64
     if (data_type == DataType::TIMESTAMPTZ &&
@@ -2163,6 +2719,24 @@ ArrowListToScalarFieldProto(const std::shared_ptr<arrow::ListArray>& list_array,
             auto* d = sf.mutable_string_data();
             for (int64_t j = start; j < end; j++)
                 d->add_data(typed->GetString(j));
+            break;
+        }
+        case arrow::Type::LARGE_STRING: {
+            auto typed =
+                std::static_pointer_cast<arrow::LargeStringArray>(values);
+            auto* d = sf.mutable_string_data();
+            for (int64_t j = start; j < end; j++)
+                d->add_data(typed->GetString(j));
+            break;
+        }
+        case arrow::Type::STRING_VIEW: {
+            auto typed =
+                std::static_pointer_cast<arrow::StringViewArray>(values);
+            auto* d = sf.mutable_string_data();
+            for (int64_t j = start; j < end; j++) {
+                auto sv = typed->GetView(j);
+                d->add_data(std::string(sv.data(), sv.size()));
+            }
             break;
         }
         default:

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -1965,9 +1965,8 @@ CoerceToBinary(const arrow::ArrayVector& arrays) {
             }
             std::shared_ptr<arrow::Array> out;
             status = builder.Finish(&out);
-            AssertInfo(
-                status.ok(),
-                "BinaryBuilder finish failed: " + status.ToString());
+            AssertInfo(status.ok(),
+                       "BinaryBuilder finish failed: " + status.ToString());
             result.push_back(out);
             continue;
         }
@@ -1991,8 +1990,7 @@ CoerceToList(const arrow::ArrayVector& arrays) {
     result.reserve(arrays.size());
     for (const auto& arr : arrays) {
         const auto tid = arr->type_id();
-        if (tid != arrow::Type::LARGE_LIST &&
-            tid != arrow::Type::LIST_VIEW) {
+        if (tid != arrow::Type::LARGE_LIST && tid != arrow::Type::LIST_VIEW) {
             result.push_back(arr);
             continue;
         }
@@ -2050,23 +2048,22 @@ CoerceToList(const arrow::ArrayVector& arrays) {
             concat_values = *empty;
         } else {
             auto concat = arrow::Concatenate(value_slices);
-            AssertInfo(concat.ok(),
-                       "CoerceToList: concat failed: " +
-                           concat.status().ToString());
+            AssertInfo(
+                concat.ok(),
+                "CoerceToList: concat failed: " + concat.status().ToString());
             concat_values = *concat;
         }
 
         auto offsets_buf =
-            std::static_pointer_cast<arrow::Int32Array>(offsets_arr)
-                ->values();
-        auto list_arr = std::make_shared<arrow::ListArray>(
-            arrow::list(values->type()),
-            arr->length(),
-            offsets_buf,
-            concat_values,
-            RebuildNullBitmap(arr),
-            arr->null_count(),
-            0);
+            std::static_pointer_cast<arrow::Int32Array>(offsets_arr)->values();
+        auto list_arr =
+            std::make_shared<arrow::ListArray>(arrow::list(values->type()),
+                                               arr->length(),
+                                               offsets_buf,
+                                               concat_values,
+                                               RebuildNullBitmap(arr),
+                                               arr->null_count(),
+                                               0);
         result.push_back(list_arr);
     }
     return result;
@@ -2113,8 +2110,7 @@ CanonicalizeArrowVariants(const std::shared_ptr<arrow::Array>& array) {
     const auto tid = array->type_id();
 
     // Variable-length string variants -> STRING
-    if (tid == arrow::Type::STRING_VIEW ||
-        tid == arrow::Type::LARGE_STRING) {
+    if (tid == arrow::Type::STRING_VIEW || tid == arrow::Type::LARGE_STRING) {
         arrow::StringBuilder builder;
         auto status = builder.Reserve(array->length());
         AssertInfo(status.ok(),
@@ -2148,8 +2144,7 @@ CanonicalizeArrowVariants(const std::shared_ptr<arrow::Array>& array) {
     }
 
     // Variable-length binary variants -> BINARY
-    if (tid == arrow::Type::BINARY_VIEW ||
-        tid == arrow::Type::LARGE_BINARY) {
+    if (tid == arrow::Type::BINARY_VIEW || tid == arrow::Type::LARGE_BINARY) {
         arrow::BinaryBuilder builder;
         auto status = builder.Reserve(array->length());
         AssertInfo(status.ok(),
@@ -2161,12 +2156,12 @@ CanonicalizeArrowVariants(const std::shared_ptr<arrow::Array>& array) {
                     AssertInfo(builder.AppendNull().ok(), "appendnull");
                 } else {
                     auto v = src->GetView(i);
-                    AssertInfo(builder
-                                   .Append(reinterpret_cast<const uint8_t*>(
-                                               v.data()),
-                                           v.size())
-                                   .ok(),
-                               "append bin");
+                    AssertInfo(
+                        builder
+                            .Append(reinterpret_cast<const uint8_t*>(v.data()),
+                                    v.size())
+                            .ok(),
+                        "append bin");
                 }
             }
         } else {
@@ -2176,12 +2171,12 @@ CanonicalizeArrowVariants(const std::shared_ptr<arrow::Array>& array) {
                     AssertInfo(builder.AppendNull().ok(), "appendnull");
                 } else {
                     auto v = src->GetView(i);
-                    AssertInfo(builder
-                                   .Append(reinterpret_cast<const uint8_t*>(
-                                               v.data()),
-                                           v.size())
-                                   .ok(),
-                               "append bin");
+                    AssertInfo(
+                        builder
+                            .Append(reinterpret_cast<const uint8_t*>(v.data()),
+                                    v.size())
+                            .ok(),
+                        "append bin");
                 }
             }
         }
@@ -2255,14 +2250,12 @@ CanonicalizeArrowVariants(const std::shared_ptr<arrow::Array>& array) {
             concat_values = *empty;
         } else {
             auto concat = arrow::Concatenate(slices);
-            AssertInfo(concat.ok(),
-                       "concat: " + concat.status().ToString());
+            AssertInfo(concat.ok(), "concat: " + concat.status().ToString());
             concat_values = *concat;
         }
 
         auto offsets_buf =
-            std::static_pointer_cast<arrow::Int32Array>(offsets_arr)
-                ->values();
+            std::static_pointer_cast<arrow::Int32Array>(offsets_arr)->values();
         return std::make_shared<arrow::ListArray>(
             arrow::list(canonical_values->type()),
             array->length(),
@@ -2281,8 +2274,8 @@ CanonicalizeArrowVariants(const std::shared_ptr<arrow::Array>& array) {
         if (canonical_inner.get() == inner.get()) {
             return array;
         }
-        auto fsl_type = std::static_pointer_cast<arrow::FixedSizeListType>(
-            fsl->type());
+        auto fsl_type =
+            std::static_pointer_cast<arrow::FixedSizeListType>(fsl->type());
         return std::make_shared<arrow::FixedSizeListArray>(
             arrow::fixed_size_list(canonical_inner->type(),
                                    fsl_type->list_size()),
@@ -2543,8 +2536,7 @@ NarrowIntArray(const std::shared_ptr<arrow::Array>& src_arr,
                    "Append narrowed int failed");
     }
     std::shared_ptr<arrow::Array> out;
-    AssertInfo(builder.Finish(&out).ok(),
-               "NarrowIntArray finish failed");
+    AssertInfo(builder.Finish(&out).ok(), "NarrowIntArray finish failed");
     return out;
 }
 
@@ -2552,31 +2544,35 @@ NarrowIntArray(const std::shared_ptr<arrow::Array>& src_arr,
 // matching (DataType, arrow::Type::type). Returns nullptr if no narrowing
 // applies; caller continues original dispatch.
 static std::shared_ptr<arrow::Array>
-MaybeNarrowInt(DataType data_type,
-               const std::shared_ptr<arrow::Array>& array) {
+MaybeNarrowInt(DataType data_type, const std::shared_ptr<arrow::Array>& array) {
     auto type_id = array->type_id();
     if (data_type == DataType::INT8) {
         if (type_id == arrow::Type::INT16)
-            return NarrowIntArray<arrow::Int16Array, arrow::Int8Builder,
+            return NarrowIntArray<arrow::Int16Array,
+                                  arrow::Int8Builder,
                                   int8_t>(array, "INT8");
         if (type_id == arrow::Type::INT32)
-            return NarrowIntArray<arrow::Int32Array, arrow::Int8Builder,
+            return NarrowIntArray<arrow::Int32Array,
+                                  arrow::Int8Builder,
                                   int8_t>(array, "INT8");
         if (type_id == arrow::Type::INT64)
-            return NarrowIntArray<arrow::Int64Array, arrow::Int8Builder,
+            return NarrowIntArray<arrow::Int64Array,
+                                  arrow::Int8Builder,
                                   int8_t>(array, "INT8");
     }
     if (data_type == DataType::INT16) {
         if (type_id == arrow::Type::INT32)
-            return NarrowIntArray<arrow::Int32Array, arrow::Int16Builder,
+            return NarrowIntArray<arrow::Int32Array,
+                                  arrow::Int16Builder,
                                   int16_t>(array, "INT16");
         if (type_id == arrow::Type::INT64)
-            return NarrowIntArray<arrow::Int64Array, arrow::Int16Builder,
+            return NarrowIntArray<arrow::Int64Array,
+                                  arrow::Int16Builder,
                                   int16_t>(array, "INT16");
     }
     if (data_type == DataType::INT32 && type_id == arrow::Type::INT64) {
-        return NarrowIntArray<arrow::Int64Array, arrow::Int32Builder,
-                              int32_t>(array, "INT32");
+        return NarrowIntArray<arrow::Int64Array, arrow::Int32Builder, int32_t>(
+            array, "INT32");
     }
     return nullptr;
 }

--- a/internal/core/src/storage/Util.h
+++ b/internal/core/src/storage/Util.h
@@ -529,4 +529,26 @@ arrow::ArrayVector
 NormalizeArrowForChunkWriter(const arrow::ArrayVector& arrays,
                              const FieldMeta& field_meta);
 
+// Coerce any binary-like array (LARGE_BINARY / BINARY_VIEW /
+// LARGE_STRING / STRING_VIEW / STRING) to canonical BinaryArray.
+// Required because vortex schemaless mode emits view variants for the
+// whole variable-length family; downstream paths assume canonical layout.
+arrow::ArrayVector
+CoerceToBinary(const arrow::ArrayVector& arrays);
+
+// Coerce LARGE_LIST / LIST_VIEW to canonical (32-bit offset) ListArray.
+// Vortex schemaless mode may emit list variants for the same logical
+// List<T>; downstream code expects arrow::ListArray.
+arrow::ArrayVector
+CoerceToList(const arrow::ArrayVector& arrays);
+
+// Single source of truth for view/large-variant elimination.
+// STRING_VIEW/LARGE_STRING -> STRING, BINARY_VIEW/LARGE_BINARY -> BINARY,
+// LARGE_LIST/LIST_VIEW -> LIST (recursive into List/FixedSizeList inner).
+// Pure type/layout normalization, no semantic conversion. Callers ingesting
+// schemaless readers (vortex) should route arrays through this helper before
+// any type-id dispatch (refresh / load / sample / etc).
+std::shared_ptr<arrow::Array>
+CanonicalizeArrowVariants(const std::shared_ptr<arrow::Array>& array);
+
 }  // namespace milvus::storage

--- a/internal/core/src/storage/loon_ffi/util.cpp
+++ b/internal/core/src/storage/loon_ffi/util.cpp
@@ -466,8 +466,19 @@ InjectExternalSpecProperties(milvus_storage::api::Properties& properties,
 
     // Layer 0: zero-init bool fields only (milvus-storage rejects empty
     // strings on enum-constrained keys like cloud_provider).
+    //
+    // "anonymous" is intentionally skipped: milvus-storage's fs.* property
+    // registry does not yet declare PROPERTY_FS_ANONYMOUS, so any SetValue
+    // on "extfs.<cid>.anonymous" hits strict "undefined key" in
+    // ExtractExternalFsProperties (iceberg explore path). Skipping the
+    // default zero-init keeps the slot absent — equivalent to anonymous=false
+    // — so the default credential path stays unaffected. Once the upstream
+    // registry adds the key, this skip can be removed without further
+    // changes (and user-supplied anonymous=true via Layer 2 will start
+    // working automatically — we deliberately do NOT drop it on Layer 2 so
+    // the future fix is a one-line revert here).
     for (const auto& [name, is_bool] : kExtfsFields) {
-        if (is_bool) {
+        if (is_bool && name != "anonymous") {
             properties[extfs_prefix + name] = std::string("false");
         }
     }

--- a/internal/core/src/storage/loon_ffi/util.cpp
+++ b/internal/core/src/storage/loon_ffi/util.cpp
@@ -687,7 +687,8 @@ InjectExternalSpecProperties(milvus_storage::api::Properties& properties,
                     if (snapshot_field.get_string().get(snapshot_view) ==
                         simdjson::SUCCESS) {
                         try {
-                            snapshot_id = std::stoll(std::string(snapshot_view));
+                            snapshot_id =
+                                std::stoll(std::string(snapshot_view));
                             int_err = simdjson::SUCCESS;
                         } catch (const std::exception& e) {
                             LOG_WARN(

--- a/internal/core/src/storage/loon_ffi/util.cpp
+++ b/internal/core/src/storage/loon_ffi/util.cpp
@@ -20,6 +20,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -678,10 +679,26 @@ InjectExternalSpecProperties(milvus_storage::api::Properties& properties,
             simdjson::SUCCESS) {
             std::string format{format_view};
             if (format == "iceberg-table") {
+                auto snapshot_field = doc.find_field("snapshot_id");
                 int64_t snapshot_id = 0;
-                if (doc.find_field("snapshot_id")
-                        .get_int64()
-                        .get(snapshot_id) == simdjson::SUCCESS) {
+                auto int_err = snapshot_field.get_int64().get(snapshot_id);
+                if (int_err == simdjson::INCORRECT_TYPE) {
+                    std::string_view snapshot_view;
+                    if (snapshot_field.get_string().get(snapshot_view) ==
+                        simdjson::SUCCESS) {
+                        try {
+                            snapshot_id = std::stoll(std::string(snapshot_view));
+                            int_err = simdjson::SUCCESS;
+                        } catch (const std::exception& e) {
+                            LOG_WARN(
+                                "iceberg snapshot_id parse failed "
+                                "(collection_id={}): {}",
+                                collection_id,
+                                e.what());
+                        }
+                    }
+                }
+                if (int_err == simdjson::SUCCESS) {
                     milvus_storage::api::SetValue(
                         properties,
                         "iceberg.snapshot_id",

--- a/internal/core/src/storage/loon_ffi/util.cpp
+++ b/internal/core/src/storage/loon_ffi/util.cpp
@@ -569,6 +569,15 @@ InjectExternalSpecProperties(milvus_storage::api::Properties& properties,
                         } else if (key == "region") {
                             spec_region = val;
                         }
+                        // "minio" is a Milvus-only cloud_provider sentinel
+                        // meaning "self-hosted S3-compatible, do not derive
+                        // endpoint and do not swap host". loon's allowlist
+                        // does not include it, so propagate the value only
+                        // for our swap-decision logic above and drop it
+                        // before reaching loon.
+                        if (key == "cloud_provider" && val == "minio") {
+                            continue;
+                        }
                         milvus_storage::api::SetValue(
                             properties,
                             (extfs_prefix + key).c_str(),
@@ -608,23 +617,15 @@ InjectExternalSpecProperties(milvus_storage::api::Properties& properties,
     //   keys (`s3://endpoint/bucket`). Comparing derive result with host
     //   handles both cases correctly — the derived endpoint string is a
     //   stable cloud-provider identifier, not dependent on path structure.
-    // Infer cloud_provider from scheme when spec omits it. Mirror of Go
-    // externalspec.ValidateExtfsComplete; keep lists in lockstep.
-    std::string effective_cp = spec_cloud_provider;
-    if (effective_cp.empty()) {
-        if (scheme == "s3" || scheme == "s3a" || scheme == "aws") {
-            effective_cp = "aws";
-        } else if (scheme == "gs" || scheme == "gcs") {
-            effective_cp = "gcp";
-        } else if (scheme == "oss") {
-            effective_cp = "aliyun";
-        } else if (scheme == "cos") {
-            effective_cp = "tencent";
-        } else if (scheme == "obs") {
-            effective_cp = "huawei";
-        }
-    }
-    std::string derived = DeriveEndpoint(effective_cp, spec_region);
+    // Swap decision uses ONLY the user-supplied cloud_provider, never a
+    // scheme-inferred fallback. Self-hosted MinIO with
+    // `s3://localhost:9000/bucket/...` is Milvus-form; inferring
+    // cloud_provider=aws from scheme=s3 would produce
+    // derived=https://s3.<region>.amazonaws.com, falsely classify host
+    // as a bucket, and swap. When the user does not declare
+    // cloud_provider, DeriveEndpoint returns empty and the URI is
+    // treated as Milvus-form (host is endpoint).
+    std::string derived = DeriveEndpoint(spec_cloud_provider, spec_region);
     // Cloud-family host suffix check: if URI.host ends with a known cloud
     // provider domain (AWS, GCP, Aliyun, Tencent, Huawei, Azure — all
     // endpoint variants including global/accelerate/dualstack/FIPS/VPC), the

--- a/internal/core/unittest/CMakeLists.txt
+++ b/internal/core/unittest/CMakeLists.txt
@@ -65,6 +65,7 @@ set(MILVUS_TEST_FILES
         test_virtual_pk.cpp
         test_mvcc_fast_path.cpp
         test_external_take.cpp
+        test_arrow_canonicalize.cpp
         TextLobSpilloverTest.cpp
         )
 

--- a/internal/core/unittest/test_arrow_canonicalize.cpp
+++ b/internal/core/unittest/test_arrow_canonicalize.cpp
@@ -68,11 +68,10 @@ MakeBinaryViewArray(const std::vector<std::string>& vals,
         if (!valid[i]) {
             EXPECT_TRUE(b.AppendNull().ok());
         } else {
-            EXPECT_TRUE(b
-                           .Append(reinterpret_cast<const uint8_t*>(
-                                       vals[i].data()),
-                                   vals[i].size())
-                           .ok());
+            EXPECT_TRUE(
+                b.Append(reinterpret_cast<const uint8_t*>(vals[i].data()),
+                         vals[i].size())
+                    .ok());
         }
     }
     std::shared_ptr<arrow::Array> out;
@@ -88,11 +87,10 @@ MakeLargeBinaryArray(const std::vector<std::string>& vals,
         if (!valid[i]) {
             EXPECT_TRUE(b.AppendNull().ok());
         } else {
-            EXPECT_TRUE(b
-                           .Append(reinterpret_cast<const uint8_t*>(
-                                       vals[i].data()),
-                                   vals[i].size())
-                           .ok());
+            EXPECT_TRUE(
+                b.Append(reinterpret_cast<const uint8_t*>(vals[i].data()),
+                         vals[i].size())
+                    .ok());
         }
     }
     std::shared_ptr<arrow::Array> out;
@@ -174,15 +172,15 @@ TEST(CanonicalizeArrowVariants, CanonicalIntPassthrough) {
 }
 
 TEST(CanonicalizeArrowVariants, LargeListToList) {
-    auto values = MakeLargeStringArray({"a", "b", "c", "d"},
-                                       {true, true, true, true});
+    auto values =
+        MakeLargeStringArray({"a", "b", "c", "d"}, {true, true, true, true});
     // Build LargeListArray with offsets [0, 2, 2, 4] -> [[a,b], [], [c,d]]
     arrow::Int64Builder ob;
     ASSERT_TRUE(ob.AppendValues({0, 2, 2, 4}).ok());
     std::shared_ptr<arrow::Array> offsets;
     ASSERT_TRUE(ob.Finish(&offsets).ok());
-    auto large_list_result = arrow::LargeListArray::FromArrays(*offsets,
-                                                               *values);
+    auto large_list_result =
+        arrow::LargeListArray::FromArrays(*offsets, *values);
     ASSERT_TRUE(large_list_result.ok());
     auto in = *large_list_result;
 
@@ -203,8 +201,7 @@ TEST(CanonicalizeArrowVariants, LargeListToList) {
 }
 
 TEST(CanonicalizeArrowVariants, ListWithStringViewInnerRecurses) {
-    auto values =
-        MakeStringViewArray({"x", "y", "z"}, {true, true, true});
+    auto values = MakeStringViewArray({"x", "y", "z"}, {true, true, true});
     arrow::Int32Builder ob;
     ASSERT_TRUE(ob.AppendValues({0, 1, 3}).ok());
     std::shared_ptr<arrow::Array> offsets;
@@ -253,8 +250,7 @@ TEST(CoerceToBinary, StringToBinaryZeroCopy) {
 
 TEST(CoerceToBinary, BinaryPassthrough) {
     arrow::BinaryBuilder b;
-    ASSERT_TRUE(
-        b.Append(reinterpret_cast<const uint8_t*>("xy"), 2).ok());
+    ASSERT_TRUE(b.Append(reinterpret_cast<const uint8_t*>("xy"), 2).ok());
     std::shared_ptr<arrow::Array> in;
     ASSERT_TRUE(b.Finish(&in).ok());
     auto out = CoerceToBinary({in})[0];
@@ -298,7 +294,8 @@ MakeInt32Array(const std::vector<int32_t>& vals,
 }  // namespace
 
 TEST(IntegerNarrowing, Int32ToInt8) {
-    auto in = MakeInt32Array({0, 1, 99, -128, 127}, {true, true, true, true, true});
+    auto in =
+        MakeInt32Array({0, 1, 99, -128, 127}, {true, true, true, true, true});
     auto out = milvus::storage::NormalizeExternalArrow(
         in, milvus::DataType::INT8, 0, false, milvus::DataType::NONE);
     ASSERT_EQ(out->type_id(), arrow::Type::INT8);
@@ -311,7 +308,8 @@ TEST(IntegerNarrowing, Int32ToInt8) {
 }
 
 TEST(IntegerNarrowing, Int32ToInt16) {
-    auto in = MakeInt32Array({0, 1000, -32768, 32767}, {true, true, true, true});
+    auto in =
+        MakeInt32Array({0, 1000, -32768, 32767}, {true, true, true, true});
     auto out = milvus::storage::NormalizeExternalArrow(
         in, milvus::DataType::INT16, 0, false, milvus::DataType::NONE);
     ASSERT_EQ(out->type_id(), arrow::Type::INT16);
@@ -390,9 +388,13 @@ TEST(CanonicalizeArrowVariants, SlicedLargeListNullsPreserved) {
     std::shared_ptr<arrow::Buffer> null_buf;
     ASSERT_TRUE(nb.Finish(&null_buf).ok());
     auto large_list = std::make_shared<arrow::LargeListArray>(
-        arrow::large_list(values->type()), 4,
+        arrow::large_list(values->type()),
+        4,
         std::static_pointer_cast<arrow::Int64Array>(offsets)->values(),
-        values, null_buf, 1, 0);
+        values,
+        null_buf,
+        1,
+        0);
 
     // Slice from offset 1, length 3: should yield [NULL, [c,d], [e,f]]
     auto sliced = large_list->Slice(1, 3);
@@ -413,9 +415,8 @@ TEST(CanonicalizeArrowVariants, SlicedLargeListNullsPreserved) {
 }
 
 TEST(CanonicalizeArrowVariants, SlicedFixedSizeListNullsPreserved) {
-    auto values =
-        MakeStringViewArray({"a", "b", "c", "d", "e", "f"},
-                            {true, true, true, true, true, true});
+    auto values = MakeStringViewArray({"a", "b", "c", "d", "e", "f"},
+                                      {true, true, true, true, true, true});
     arrow::TypedBufferBuilder<bool> nb;
     ASSERT_TRUE(nb.Reserve(3).ok());
     nb.UnsafeAppend(true);
@@ -458,9 +459,13 @@ TEST(CoerceToList, SlicedLargeListNullsPreserved) {
     std::shared_ptr<arrow::Buffer> null_buf;
     ASSERT_TRUE(nb.Finish(&null_buf).ok());
     auto ll = std::make_shared<arrow::LargeListArray>(
-        arrow::large_list(values->type()), 4,
-        std::static_pointer_cast<arrow::Int64Array>(offsets)->values(), values,
-        null_buf, 1, 0);
+        arrow::large_list(values->type()),
+        4,
+        std::static_pointer_cast<arrow::Int64Array>(offsets)->values(),
+        values,
+        null_buf,
+        1,
+        0);
     auto sliced = ll->Slice(1, 3);
 
     auto out = CoerceToList({sliced})[0];

--- a/internal/core/unittest/test_arrow_canonicalize.cpp
+++ b/internal/core/unittest/test_arrow_canonicalize.cpp
@@ -1,0 +1,495 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+#include <arrow/array.h>
+#include <arrow/array/builder_binary.h>
+#include <arrow/array/builder_nested.h>
+#include <arrow/array/builder_primitive.h>
+#include <arrow/type.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "common/EasyAssert.h"
+#include "storage/Util.h"
+
+using milvus::storage::CanonicalizeArrowVariants;
+using milvus::storage::CoerceToBinary;
+using milvus::storage::CoerceToList;
+
+namespace {
+
+std::shared_ptr<arrow::Array>
+MakeStringViewArray(const std::vector<std::string>& vals,
+                    const std::vector<bool>& valid) {
+    arrow::StringViewBuilder b;
+    for (size_t i = 0; i < vals.size(); ++i) {
+        if (!valid[i]) {
+            EXPECT_TRUE(b.AppendNull().ok());
+        } else {
+            EXPECT_TRUE(b.Append(vals[i]).ok());
+        }
+    }
+    std::shared_ptr<arrow::Array> out;
+    EXPECT_TRUE(b.Finish(&out).ok());
+    return out;
+}
+
+std::shared_ptr<arrow::Array>
+MakeLargeStringArray(const std::vector<std::string>& vals,
+                     const std::vector<bool>& valid) {
+    arrow::LargeStringBuilder b;
+    for (size_t i = 0; i < vals.size(); ++i) {
+        if (!valid[i]) {
+            EXPECT_TRUE(b.AppendNull().ok());
+        } else {
+            EXPECT_TRUE(b.Append(vals[i]).ok());
+        }
+    }
+    std::shared_ptr<arrow::Array> out;
+    EXPECT_TRUE(b.Finish(&out).ok());
+    return out;
+}
+
+std::shared_ptr<arrow::Array>
+MakeBinaryViewArray(const std::vector<std::string>& vals,
+                    const std::vector<bool>& valid) {
+    arrow::BinaryViewBuilder b;
+    for (size_t i = 0; i < vals.size(); ++i) {
+        if (!valid[i]) {
+            EXPECT_TRUE(b.AppendNull().ok());
+        } else {
+            EXPECT_TRUE(b
+                           .Append(reinterpret_cast<const uint8_t*>(
+                                       vals[i].data()),
+                                   vals[i].size())
+                           .ok());
+        }
+    }
+    std::shared_ptr<arrow::Array> out;
+    EXPECT_TRUE(b.Finish(&out).ok());
+    return out;
+}
+
+std::shared_ptr<arrow::Array>
+MakeLargeBinaryArray(const std::vector<std::string>& vals,
+                     const std::vector<bool>& valid) {
+    arrow::LargeBinaryBuilder b;
+    for (size_t i = 0; i < vals.size(); ++i) {
+        if (!valid[i]) {
+            EXPECT_TRUE(b.AppendNull().ok());
+        } else {
+            EXPECT_TRUE(b
+                           .Append(reinterpret_cast<const uint8_t*>(
+                                       vals[i].data()),
+                                   vals[i].size())
+                           .ok());
+        }
+    }
+    std::shared_ptr<arrow::Array> out;
+    EXPECT_TRUE(b.Finish(&out).ok());
+    return out;
+}
+
+}  // namespace
+
+// ===== CanonicalizeArrowVariants =====
+
+TEST(CanonicalizeArrowVariants, StringViewToString) {
+    auto in = MakeStringViewArray({"a", "bb", "ccc"}, {true, true, true});
+    auto out = CanonicalizeArrowVariants(in);
+    ASSERT_EQ(out->type_id(), arrow::Type::STRING);
+    auto sa = std::static_pointer_cast<arrow::StringArray>(out);
+    ASSERT_EQ(sa->length(), 3);
+    EXPECT_EQ(sa->GetString(0), "a");
+    EXPECT_EQ(sa->GetString(1), "bb");
+    EXPECT_EQ(sa->GetString(2), "ccc");
+}
+
+TEST(CanonicalizeArrowVariants, StringViewWithNull) {
+    auto in = MakeStringViewArray({"x", "", "z"}, {true, false, true});
+    auto out = CanonicalizeArrowVariants(in);
+    ASSERT_EQ(out->type_id(), arrow::Type::STRING);
+    auto sa = std::static_pointer_cast<arrow::StringArray>(out);
+    EXPECT_EQ(sa->null_count(), 1);
+    EXPECT_TRUE(sa->IsNull(1));
+    EXPECT_EQ(sa->GetString(0), "x");
+    EXPECT_EQ(sa->GetString(2), "z");
+}
+
+TEST(CanonicalizeArrowVariants, LargeStringToString) {
+    auto in = MakeLargeStringArray({"hello", "world"}, {true, true});
+    auto out = CanonicalizeArrowVariants(in);
+    ASSERT_EQ(out->type_id(), arrow::Type::STRING);
+    auto sa = std::static_pointer_cast<arrow::StringArray>(out);
+    EXPECT_EQ(sa->GetString(0), "hello");
+    EXPECT_EQ(sa->GetString(1), "world");
+}
+
+TEST(CanonicalizeArrowVariants, BinaryViewToBinary) {
+    std::string b1{"\x01\x02", 2};
+    std::string b2{"\xff\xfe\xfd", 3};
+    auto in = MakeBinaryViewArray({b1, b2}, {true, true});
+    auto out = CanonicalizeArrowVariants(in);
+    ASSERT_EQ(out->type_id(), arrow::Type::BINARY);
+    auto ba = std::static_pointer_cast<arrow::BinaryArray>(out);
+    EXPECT_EQ(ba->GetString(0), b1);
+    EXPECT_EQ(ba->GetString(1), b2);
+}
+
+TEST(CanonicalizeArrowVariants, LargeBinaryToBinary) {
+    auto in = MakeLargeBinaryArray({"abc", "de"}, {true, true});
+    auto out = CanonicalizeArrowVariants(in);
+    ASSERT_EQ(out->type_id(), arrow::Type::BINARY);
+    auto ba = std::static_pointer_cast<arrow::BinaryArray>(out);
+    EXPECT_EQ(ba->GetString(0), "abc");
+    EXPECT_EQ(ba->GetString(1), "de");
+}
+
+TEST(CanonicalizeArrowVariants, CanonicalStringPassthrough) {
+    arrow::StringBuilder b;
+    ASSERT_TRUE(b.Append("foo").ok());
+    std::shared_ptr<arrow::Array> in;
+    ASSERT_TRUE(b.Finish(&in).ok());
+    auto out = CanonicalizeArrowVariants(in);
+    EXPECT_EQ(out.get(), in.get());  // zero-copy passthrough
+}
+
+TEST(CanonicalizeArrowVariants, CanonicalIntPassthrough) {
+    arrow::Int32Builder b;
+    ASSERT_TRUE(b.Append(42).ok());
+    std::shared_ptr<arrow::Array> in;
+    ASSERT_TRUE(b.Finish(&in).ok());
+    auto out = CanonicalizeArrowVariants(in);
+    EXPECT_EQ(out.get(), in.get());
+}
+
+TEST(CanonicalizeArrowVariants, LargeListToList) {
+    auto values = MakeLargeStringArray({"a", "b", "c", "d"},
+                                       {true, true, true, true});
+    // Build LargeListArray with offsets [0, 2, 2, 4] -> [[a,b], [], [c,d]]
+    arrow::Int64Builder ob;
+    ASSERT_TRUE(ob.AppendValues({0, 2, 2, 4}).ok());
+    std::shared_ptr<arrow::Array> offsets;
+    ASSERT_TRUE(ob.Finish(&offsets).ok());
+    auto large_list_result = arrow::LargeListArray::FromArrays(*offsets,
+                                                               *values);
+    ASSERT_TRUE(large_list_result.ok());
+    auto in = *large_list_result;
+
+    auto out = CanonicalizeArrowVariants(in);
+    ASSERT_EQ(out->type_id(), arrow::Type::LIST);
+    auto la = std::static_pointer_cast<arrow::ListArray>(out);
+    ASSERT_EQ(la->length(), 3);
+    // Inner values must be canonical STRING
+    EXPECT_EQ(la->values()->type_id(), arrow::Type::STRING);
+    auto inner = std::static_pointer_cast<arrow::StringArray>(la->values());
+    EXPECT_EQ(la->value_length(0), 2);
+    EXPECT_EQ(la->value_length(1), 0);
+    EXPECT_EQ(la->value_length(2), 2);
+    EXPECT_EQ(inner->GetString(la->value_offset(0) + 0), "a");
+    EXPECT_EQ(inner->GetString(la->value_offset(0) + 1), "b");
+    EXPECT_EQ(inner->GetString(la->value_offset(2) + 0), "c");
+    EXPECT_EQ(inner->GetString(la->value_offset(2) + 1), "d");
+}
+
+TEST(CanonicalizeArrowVariants, ListWithStringViewInnerRecurses) {
+    auto values =
+        MakeStringViewArray({"x", "y", "z"}, {true, true, true});
+    arrow::Int32Builder ob;
+    ASSERT_TRUE(ob.AppendValues({0, 1, 3}).ok());
+    std::shared_ptr<arrow::Array> offsets;
+    ASSERT_TRUE(ob.Finish(&offsets).ok());
+    auto list_result = arrow::ListArray::FromArrays(*offsets, *values);
+    ASSERT_TRUE(list_result.ok());
+    auto in = *list_result;
+
+    auto out = CanonicalizeArrowVariants(in);
+    ASSERT_EQ(out->type_id(), arrow::Type::LIST);
+    auto la = std::static_pointer_cast<arrow::ListArray>(out);
+    EXPECT_EQ(la->values()->type_id(), arrow::Type::STRING);
+    EXPECT_EQ(la->length(), 2);
+}
+
+TEST(CanonicalizeArrowVariants, FixedSizeListWithViewInnerRecurses) {
+    auto values =
+        MakeStringViewArray({"a", "b", "c", "d"}, {true, true, true, true});
+    auto fsl = std::make_shared<arrow::FixedSizeListArray>(
+        arrow::fixed_size_list(values->type(), 2), 2, values);
+    auto out = CanonicalizeArrowVariants(fsl);
+    ASSERT_EQ(out->type_id(), arrow::Type::FIXED_SIZE_LIST);
+    auto fsla = std::static_pointer_cast<arrow::FixedSizeListArray>(out);
+    EXPECT_EQ(fsla->values()->type_id(), arrow::Type::STRING);
+}
+
+TEST(CanonicalizeArrowVariants, EmptyArray) {
+    auto in = MakeStringViewArray({}, {});
+    auto out = CanonicalizeArrowVariants(in);
+    ASSERT_EQ(out->type_id(), arrow::Type::STRING);
+    EXPECT_EQ(out->length(), 0);
+}
+
+// ===== CoerceToBinary =====
+
+TEST(CoerceToBinary, StringToBinaryZeroCopy) {
+    arrow::StringBuilder b;
+    ASSERT_TRUE(b.Append("hello").ok());
+    std::shared_ptr<arrow::Array> in;
+    ASSERT_TRUE(b.Finish(&in).ok());
+    auto out = CoerceToBinary({in})[0];
+    ASSERT_EQ(out->type_id(), arrow::Type::BINARY);
+    auto ba = std::static_pointer_cast<arrow::BinaryArray>(out);
+    EXPECT_EQ(ba->GetString(0), "hello");
+}
+
+TEST(CoerceToBinary, BinaryPassthrough) {
+    arrow::BinaryBuilder b;
+    ASSERT_TRUE(
+        b.Append(reinterpret_cast<const uint8_t*>("xy"), 2).ok());
+    std::shared_ptr<arrow::Array> in;
+    ASSERT_TRUE(b.Finish(&in).ok());
+    auto out = CoerceToBinary({in})[0];
+    EXPECT_EQ(out.get(), in.get());
+}
+
+TEST(CoerceToBinary, AllVariantsToBinary) {
+    auto sv = MakeStringViewArray({"a"}, {true});
+    auto ls = MakeLargeStringArray({"bb"}, {true});
+    auto bv = MakeBinaryViewArray({"ccc"}, {true});
+    auto lb = MakeLargeBinaryArray({"dddd"}, {true});
+    for (const auto& in : {sv, ls, bv, lb}) {
+        auto out = CoerceToBinary({in})[0];
+        ASSERT_EQ(out->type_id(), arrow::Type::BINARY);
+    }
+}
+
+// ===== Integer narrowing (via NormalizeExternalArrow) =====
+// MaybeNarrowInt is exercised through NormalizeExternalArrow because the
+// helper itself is static. These tests build wider arrow ints and assert the
+// returned array is the narrower target type with values intact.
+
+#include "common/FieldMeta.h"
+
+namespace {
+std::shared_ptr<arrow::Array>
+MakeInt32Array(const std::vector<int32_t>& vals,
+               const std::vector<bool>& valid) {
+    arrow::Int32Builder b;
+    for (size_t i = 0; i < vals.size(); ++i) {
+        if (!valid[i]) {
+            EXPECT_TRUE(b.AppendNull().ok());
+        } else {
+            EXPECT_TRUE(b.Append(vals[i]).ok());
+        }
+    }
+    std::shared_ptr<arrow::Array> out;
+    EXPECT_TRUE(b.Finish(&out).ok());
+    return out;
+}
+}  // namespace
+
+TEST(IntegerNarrowing, Int32ToInt8) {
+    auto in = MakeInt32Array({0, 1, 99, -128, 127}, {true, true, true, true, true});
+    auto out = milvus::storage::NormalizeExternalArrow(
+        in, milvus::DataType::INT8, 0, false, milvus::DataType::NONE);
+    ASSERT_EQ(out->type_id(), arrow::Type::INT8);
+    auto ia = std::static_pointer_cast<arrow::Int8Array>(out);
+    EXPECT_EQ(ia->Value(0), 0);
+    EXPECT_EQ(ia->Value(1), 1);
+    EXPECT_EQ(ia->Value(2), 99);
+    EXPECT_EQ(ia->Value(3), -128);
+    EXPECT_EQ(ia->Value(4), 127);
+}
+
+TEST(IntegerNarrowing, Int32ToInt16) {
+    auto in = MakeInt32Array({0, 1000, -32768, 32767}, {true, true, true, true});
+    auto out = milvus::storage::NormalizeExternalArrow(
+        in, milvus::DataType::INT16, 0, false, milvus::DataType::NONE);
+    ASSERT_EQ(out->type_id(), arrow::Type::INT16);
+    auto ia = std::static_pointer_cast<arrow::Int16Array>(out);
+    EXPECT_EQ(ia->Value(2), -32768);
+    EXPECT_EQ(ia->Value(3), 32767);
+}
+
+TEST(IntegerNarrowing, Int32ToInt8WithNulls) {
+    auto in = MakeInt32Array({5, 0, 7}, {true, false, true});
+    auto out = milvus::storage::NormalizeExternalArrow(
+        in, milvus::DataType::INT8, 0, true, milvus::DataType::NONE);
+    ASSERT_EQ(out->type_id(), arrow::Type::INT8);
+    EXPECT_EQ(out->null_count(), 1);
+    EXPECT_TRUE(out->IsNull(1));
+}
+
+TEST(IntegerNarrowing, OverflowAsserts) {
+    auto in = MakeInt32Array({999}, {true});  // > INT8_MAX
+    EXPECT_THROW(
+        milvus::storage::NormalizeExternalArrow(
+            in, milvus::DataType::INT8, 0, false, milvus::DataType::NONE),
+        std::exception);
+}
+
+TEST(IntegerNarrowing, NoNarrowOnExactMatch) {
+    arrow::Int8Builder b;
+    ASSERT_TRUE(b.Append(int8_t{5}).ok());
+    std::shared_ptr<arrow::Array> in;
+    ASSERT_TRUE(b.Finish(&in).ok());
+    auto out = milvus::storage::NormalizeExternalArrow(
+        in, milvus::DataType::INT8, 0, false, milvus::DataType::NONE);
+    EXPECT_EQ(out.get(), in.get());
+}
+
+// ===== CoerceToList =====
+
+TEST(CoerceToList, LargeListToList) {
+    arrow::Int32Builder vb;
+    ASSERT_TRUE(vb.AppendValues({1, 2, 3, 4}).ok());
+    std::shared_ptr<arrow::Array> values;
+    ASSERT_TRUE(vb.Finish(&values).ok());
+
+    arrow::Int64Builder ob;
+    ASSERT_TRUE(ob.AppendValues({0, 2, 4}).ok());
+    std::shared_ptr<arrow::Array> offsets;
+    ASSERT_TRUE(ob.Finish(&offsets).ok());
+    auto large_list = *arrow::LargeListArray::FromArrays(*offsets, *values);
+
+    auto out = CoerceToList({large_list})[0];
+    ASSERT_EQ(out->type_id(), arrow::Type::LIST);
+    auto la = std::static_pointer_cast<arrow::ListArray>(out);
+    EXPECT_EQ(la->length(), 2);
+    EXPECT_EQ(la->value_length(0), 2);
+    EXPECT_EQ(la->value_length(1), 2);
+}
+
+// ===== Sliced-input nullability =====
+
+TEST(CanonicalizeArrowVariants, SlicedLargeListNullsPreserved) {
+    // values: [a, b, c, d, e, f]
+    auto values = MakeLargeStringArray({"a", "b", "c", "d", "e", "f"},
+                                       {true, true, true, true, true, true});
+    // 4 rows: [a,b], NULL, [c,d], [e,f]
+    arrow::Int64Builder ob;
+    ASSERT_TRUE(ob.AppendValues({0, 2, 2, 4, 6}).ok());
+    std::shared_ptr<arrow::Array> offsets;
+    ASSERT_TRUE(ob.Finish(&offsets).ok());
+    // null bitmap for the LargeListArray: row 1 is null
+    arrow::TypedBufferBuilder<bool> nb;
+    ASSERT_TRUE(nb.Reserve(4).ok());
+    nb.UnsafeAppend(true);
+    nb.UnsafeAppend(false);
+    nb.UnsafeAppend(true);
+    nb.UnsafeAppend(true);
+    std::shared_ptr<arrow::Buffer> null_buf;
+    ASSERT_TRUE(nb.Finish(&null_buf).ok());
+    auto large_list = std::make_shared<arrow::LargeListArray>(
+        arrow::large_list(values->type()), 4,
+        std::static_pointer_cast<arrow::Int64Array>(offsets)->values(),
+        values, null_buf, 1, 0);
+
+    // Slice from offset 1, length 3: should yield [NULL, [c,d], [e,f]]
+    auto sliced = large_list->Slice(1, 3);
+    ASSERT_TRUE(sliced->IsNull(0));
+    ASSERT_FALSE(sliced->IsNull(1));
+
+    auto out = CanonicalizeArrowVariants(sliced);
+    ASSERT_EQ(out->type_id(), arrow::Type::LIST);
+    ASSERT_EQ(out->length(), 3);
+    EXPECT_EQ(out->null_count(), 1);
+    EXPECT_TRUE(out->IsNull(0));
+    EXPECT_FALSE(out->IsNull(1));
+    EXPECT_FALSE(out->IsNull(2));
+    auto la = std::static_pointer_cast<arrow::ListArray>(out);
+    EXPECT_EQ(la->value_length(0), 0);  // null row → empty range
+    EXPECT_EQ(la->value_length(1), 2);
+    EXPECT_EQ(la->value_length(2), 2);
+}
+
+TEST(CanonicalizeArrowVariants, SlicedFixedSizeListNullsPreserved) {
+    auto values =
+        MakeStringViewArray({"a", "b", "c", "d", "e", "f"},
+                            {true, true, true, true, true, true});
+    arrow::TypedBufferBuilder<bool> nb;
+    ASSERT_TRUE(nb.Reserve(3).ok());
+    nb.UnsafeAppend(true);
+    nb.UnsafeAppend(false);
+    nb.UnsafeAppend(true);
+    std::shared_ptr<arrow::Buffer> null_buf;
+    ASSERT_TRUE(nb.Finish(&null_buf).ok());
+    auto fsl = std::make_shared<arrow::FixedSizeListArray>(
+        arrow::fixed_size_list(values->type(), 2), 3, values, null_buf, 1, 0);
+
+    auto sliced = fsl->Slice(1, 2);
+    ASSERT_TRUE(sliced->IsNull(0));
+    ASSERT_FALSE(sliced->IsNull(1));
+
+    auto out = CanonicalizeArrowVariants(sliced);
+    ASSERT_EQ(out->type_id(), arrow::Type::FIXED_SIZE_LIST);
+    EXPECT_EQ(out->length(), 2);
+    EXPECT_EQ(out->null_count(), 1);
+    EXPECT_TRUE(out->IsNull(0));
+    EXPECT_FALSE(out->IsNull(1));
+    auto fsla = std::static_pointer_cast<arrow::FixedSizeListArray>(out);
+    EXPECT_EQ(fsla->values()->type_id(), arrow::Type::STRING);
+}
+
+TEST(CoerceToList, SlicedLargeListNullsPreserved) {
+    arrow::Int32Builder vb;
+    ASSERT_TRUE(vb.AppendValues({1, 2, 3, 4, 5, 6}).ok());
+    std::shared_ptr<arrow::Array> values;
+    ASSERT_TRUE(vb.Finish(&values).ok());
+    arrow::Int64Builder ob;
+    ASSERT_TRUE(ob.AppendValues({0, 2, 2, 4, 6}).ok());
+    std::shared_ptr<arrow::Array> offsets;
+    ASSERT_TRUE(ob.Finish(&offsets).ok());
+    arrow::TypedBufferBuilder<bool> nb;
+    ASSERT_TRUE(nb.Reserve(4).ok());
+    nb.UnsafeAppend(true);
+    nb.UnsafeAppend(false);
+    nb.UnsafeAppend(true);
+    nb.UnsafeAppend(true);
+    std::shared_ptr<arrow::Buffer> null_buf;
+    ASSERT_TRUE(nb.Finish(&null_buf).ok());
+    auto ll = std::make_shared<arrow::LargeListArray>(
+        arrow::large_list(values->type()), 4,
+        std::static_pointer_cast<arrow::Int64Array>(offsets)->values(), values,
+        null_buf, 1, 0);
+    auto sliced = ll->Slice(1, 3);
+
+    auto out = CoerceToList({sliced})[0];
+    ASSERT_EQ(out->type_id(), arrow::Type::LIST);
+    EXPECT_EQ(out->length(), 3);
+    EXPECT_EQ(out->null_count(), 1);
+    EXPECT_TRUE(out->IsNull(0));
+}
+
+TEST(CanonicalizeArrowVariants, AllNullStringView) {
+    auto in = MakeStringViewArray({"x", "y", "z"}, {false, false, false});
+    auto out = CanonicalizeArrowVariants(in);
+    ASSERT_EQ(out->type_id(), arrow::Type::STRING);
+    EXPECT_EQ(out->null_count(), 3);
+    EXPECT_TRUE(out->IsNull(0));
+    EXPECT_TRUE(out->IsNull(1));
+    EXPECT_TRUE(out->IsNull(2));
+}
+
+TEST(CoerceToList, ListPassthrough) {
+    arrow::Int32Builder vb;
+    ASSERT_TRUE(vb.AppendValues({1, 2}).ok());
+    std::shared_ptr<arrow::Array> values;
+    ASSERT_TRUE(vb.Finish(&values).ok());
+    arrow::Int32Builder ob;
+    ASSERT_TRUE(ob.AppendValues({0, 2}).ok());
+    std::shared_ptr<arrow::Array> offsets;
+    ASSERT_TRUE(ob.Finish(&offsets).ok());
+    auto in = *arrow::ListArray::FromArrays(*offsets, *values);
+    auto out = CoerceToList({in})[0];
+    EXPECT_EQ(out.get(), in.get());
+}

--- a/internal/core/unittest/test_external_take.cpp
+++ b/internal/core/unittest/test_external_take.cpp
@@ -1777,12 +1777,45 @@ TEST(InjectExtfsAllowlist, URIWithoutTrailingSlashParsed) {
               "mybucket");
 }
 
-// Regression: anonymous is a bool field and must be zero-initialized by
-// Layer 0 so stale Properties reuse cannot leak anonymous=true across
-// collections.
-TEST(InjectExtfsAllowlist, AnonymousIsZeroInitialized) {
+// milvus-storage's fs.* property registry does not yet declare
+// PROPERTY_FS_ANONYMOUS. Until upstream registers the key,
+// InjectExternalSpecProperties must not zero-init extfs.{cid}.anonymous
+// in Layer 0 — any SetValue on that slot triggers a strict "undefined
+// key" error in ExtractExternalFsProperties on the iceberg explore path.
+//
+// We deliberately do NOT also drop user-supplied anonymous=true from
+// Layer 2: when upstream finally registers the key, removing the Layer 0
+// skip below is the only change needed for anonymous to start working.
+// User-supplied anonymous=true today still surfaces the same upstream
+// "undefined key" error, which is the right signal — silent no-op would
+// be worse (caller would think public-bucket access is configured).
+TEST(InjectExtfsAllowlist, AnonymousLayer0Skipped) {
     milvus_storage::api::Properties props;
-    // Pre-seed the slot to simulate stale reuse.
+    const int64_t coll_id = 42;
+    std::string spec =
+        R"({"format":"parquet","extfs":{"access_key_id":"AK","access_key_value":"SK","region":"us-east-1"}})";
+
+    ::InjectExternalSpecProperties(
+        props, coll_id, "s3://s3.amazonaws.com/bucket/key", spec);
+
+    // Other bool fields still get Layer 0 zero-init: sanity check the
+    // skip is anonymous-specific, not a wholesale Layer 0 regression.
+    // (use_ssl is excluded — Layer 1 derives it from the URI scheme and
+    // overwrites the Layer 0 default.)
+    EXPECT_EQ(std::get<std::string>(props.at("extfs.42.use_iam")), "false");
+    EXPECT_EQ(std::get<std::string>(props.at("extfs.42.use_virtual_host")),
+              "false");
+    // anonymous slot must be absent — no Layer 0 write, no SetValue.
+    EXPECT_EQ(props.count("extfs.42.anonymous"), 0u);
+}
+
+TEST(InjectExtfsAllowlist, AnonymousLayer0SkippedWithStalePreseed) {
+    // Pre-seed the slot to simulate stale Properties reuse. Layer 0 skip
+    // must not overwrite or clear it (the skip is a continue, not a
+    // SetValue("")). The pre-existing value is left as-is so the caller's
+    // intent — including a future caller that has explicitly chosen to
+    // route anonymous via a separate channel — survives.
+    milvus_storage::api::Properties props;
     props["extfs.42.anonymous"] = std::string("true");
     const int64_t coll_id = 42;
     std::string spec =
@@ -1791,8 +1824,7 @@ TEST(InjectExtfsAllowlist, AnonymousIsZeroInitialized) {
     ::InjectExternalSpecProperties(
         props, coll_id, "s3://s3.amazonaws.com/bucket/key", spec);
 
-    // Layer 0 must overwrite the stale value with "false".
-    EXPECT_EQ(std::get<std::string>(props.at("extfs.42.anonymous")), "false");
+    EXPECT_EQ(std::get<std::string>(props.at("extfs.42.anonymous")), "true");
 }
 
 // ============================================================

--- a/internal/core/unittest/test_external_take.cpp
+++ b/internal/core/unittest/test_external_take.cpp
@@ -1767,14 +1767,40 @@ TEST(InjectExtfsAllowlist, InvalidJsonIsHandledGracefully) {
 TEST(InjectExtfsAllowlist, URIWithoutTrailingSlashParsed) {
     milvus_storage::api::Properties props;
     const int64_t coll_id = 42;
+    // Explicit cloud_provider=aws opts into AWS-form parsing. Without it,
+    // the swap is suppressed (Milvus-form, host treated as endpoint) — see
+    // ExplicitCloudProviderRequiredForAwsFormSwap below.
     std::string spec =
-        R"({"format":"parquet","extfs":{"access_key_id":"AK","access_key_value":"SK","region":"us-east-1"}})";
+        R"({"format":"parquet","extfs":{"access_key_id":"AK","access_key_value":"SK","region":"us-east-1","cloud_provider":"aws"}})";
 
     EXPECT_NO_THROW(
         ::InjectExternalSpecProperties(props, coll_id, "s3://mybucket", spec));
     // AWS-form path: URI.host=bucket, derived endpoint=regional S3.
     EXPECT_EQ(std::get<std::string>(props.at("extfs.42.bucket_name")),
               "mybucket");
+}
+
+// Regression: scheme-based cloud_provider inference must NOT drive the
+// AWS-form swap. Self-hosted MinIO at `s3://localhost:9000/bucket/key`
+// without an explicit cloud_provider must be treated as Milvus-form
+// (host=endpoint, no swap). Auto-inferring cp=aws would falsely classify
+// `localhost:9000` as a bucket.
+TEST(InjectExtfsAllowlist, ExplicitCloudProviderRequiredForAwsFormSwap) {
+    milvus_storage::api::Properties props;
+    const int64_t coll_id = 42;
+    std::string spec =
+        R"({"format":"parquet","extfs":{"access_key_id":"AK","access_key_value":"SK","region":"us-east-1"}})";
+
+    ::InjectExternalSpecProperties(
+        props, coll_id, "s3://localhost:9000/bucket/key", spec);
+
+    // No cloud_provider → no swap. Layer 0 zero-init may seed empty slots,
+    // but the swap path must NOT write URI.host as bucket_name (which would
+    // misclassify localhost:9000 as a bucket name).
+    if (props.count("extfs.42.bucket_name")) {
+        EXPECT_NE(std::get<std::string>(props.at("extfs.42.bucket_name")),
+                  "localhost:9000");
+    }
 }
 
 // milvus-storage's fs.* property registry does not yet declare

--- a/internal/core/unittest/test_external_take.cpp
+++ b/internal/core/unittest/test_external_take.cpp
@@ -1853,6 +1853,19 @@ TEST(InjectExtfsAllowlist, AnonymousLayer0SkippedWithStalePreseed) {
     EXPECT_EQ(std::get<std::string>(props.at("extfs.42.anonymous")), "true");
 }
 
+TEST(InjectExtfsAllowlist, IcebergSnapshotIDAcceptsString) {
+    milvus_storage::api::Properties props;
+    const int64_t coll_id = 42;
+    std::string spec =
+        R"({"format":"iceberg-table","snapshot_id":"5320540205222981137"})";
+
+    ::InjectExternalSpecProperties(
+        props, coll_id, "s3://s3.amazonaws.com/bucket/key", spec);
+
+    EXPECT_EQ(std::get<std::string>(props.at("iceberg.snapshot_id")),
+              "5320540205222981137");
+}
+
 // ============================================================
 // Tests for NormalizeExternalArrow and internal-vs-external
 // VARCHAR handling (regression for index build opt_field crash)

--- a/internal/datacoord/external_collection_refresh_manager.go
+++ b/internal/datacoord/external_collection_refresh_manager.go
@@ -664,20 +664,11 @@ func (m *externalCollectionRefreshManager) createTasksForJob(
 	if len(allFiles) == 0 {
 		return nil, newNonRetriableJobError("no files found in external source: %s", job.GetExternalSource())
 	}
-	// Reject zero-total-rows sources up front: a non-empty file list whose
-	// rows sum to zero (e.g. user-supplied empty parquet) would otherwise
-	// reach datanode's balanceFragmentsToSegments which divides by zero
-	// and crashes the process. Treat as non-retriable so the operator gets
-	// a clear failure signal instead of a CrashLoopBackOff. Fix for #49225.
-	var totalRows int64
-	for _, f := range allFiles {
-		totalRows += f.NumRows
-	}
-	if totalRows == 0 {
-		return nil, newNonRetriableJobError(
-			"external source %s has %d files but zero total rows; nothing to refresh",
-			job.GetExternalSource(), len(allFiles))
-	}
+	// NOTE: zero-total-rows cannot be detected here. PlainFormat::explore
+	// hardcodes start_index/end_index to -1 as sentinels and never reads
+	// parquet metadata, so FileInfo.NumRows carries -1, not a real row count.
+	// The real guard lives at datanode's balanceFragmentsToSegments, where
+	// fragment RowCount is populated from manifest (endRow - startRow).
 	log.Info("explored external files for task splitting",
 		zap.Int("totalFiles", len(allFiles)),
 		zap.String("manifestPath", manifestPath))

--- a/internal/datacoord/external_collection_refresh_manager_test.go
+++ b/internal/datacoord/external_collection_refresh_manager_test.go
@@ -256,53 +256,6 @@ func TestExternalCollectionRefreshManager_SubmitRefreshJobWithID(t *testing.T) {
 		assert.Empty(t, job.GetTaskIds(), "no tasks should be persisted after async failure")
 	})
 
-	t.Run("zero_total_rows_marks_job_failed_non_retriable", func(t *testing.T) {
-		// Regression for #49225: a non-empty file list whose row counts sum
-		// to zero (e.g. user-supplied empty parquet) used to make datanode
-		// crash with "integer divide by zero". Now createTasksForJob must
-		// reject this case as a non-retriable error and Phase B must
-		// transition the job to JobStateFailed instead of leaving it in
-		// Init for the checker tick to retry forever.
-		refreshMeta := createTestRefreshMeta(t)
-		alloc := &stubAllocator{nextID: 1000}
-		scheduler := newStubScheduler()
-
-		collections := typeutil.NewConcurrentMap[UniqueID, *collectionInfo]()
-		collections.Insert(100, &collectionInfo{
-			ID: 100,
-			Schema: &schemapb.CollectionSchema{
-				Name:           "test_collection",
-				ExternalSource: "s3://bucket/empty",
-				ExternalSpec:   `{"format":"parquet"}`,
-			},
-		})
-		mt := &meta{collections: collections}
-
-		mockIsExternal := mockey.Mock(typeutil.IsExternalCollection).Return(true).Build()
-		defer mockIsExternal.UnPatch()
-
-		// One file, zero rows — passes the existing len()==0 check but
-		// must trip the new totalRows==0 guard.
-		mockExplore := mockey.Mock((*externalCollectionRefreshManager).exploreExternalFiles).
-			Return([]*datapb.ExternalFileInfo{{FilePath: "s3://bucket/empty/empty.parquet", NumRows: 0}}, "s3://bucket/empty/manifest", nil).Build()
-		defer mockExplore.UnPatch()
-
-		manager := NewExternalCollectionRefreshManager(ctx, mt, scheduler, alloc, refreshMeta, nil, testCollectionGetter(mt), nil, nil)
-
-		_, err := manager.SubmitRefreshJobWithID(ctx, 1, 100, "test_collection", "", "")
-		assert.NoError(t, err)
-
-		// Wait for Phase B to finish.
-		manager.Stop()
-
-		job := refreshMeta.GetJob(1)
-		assert.NotNil(t, job)
-		assert.Equal(t, indexpb.JobState_JobStateFailed, job.GetState(),
-			"non-retriable error must transition job to Failed, not leave in Init")
-		assert.Contains(t, job.GetFailReason(), "zero total rows",
-			"reason must explain why so operators can act")
-	})
-
 	t.Run("ffi_explore_error_marks_job_failed_non_retriable", func(t *testing.T) {
 		// Regression for #49233: any FFI failure during explore (NoSuchBucket,
 		// AccessDenied, DNS NXDOMAIN, malformed URI, ...) is wrapped by the

--- a/internal/datanode/external/manager.go
+++ b/internal/datanode/external/manager.go
@@ -18,6 +18,8 @@ package external
 
 import (
 	"context"
+	"fmt"
+	"runtime/debug"
 	"sync"
 
 	"go.uber.org/zap"
@@ -242,8 +244,24 @@ func (m *ExternalCollectionManager) SubmitTask(
 	}
 
 	// Submit to pool
-	m.pool.Submit(func() (any, error) {
+	m.pool.Submit(func() (_ any, retErr error) {
 		defer cancel()
+		// Defense-in-depth: isolate panics in a single task so a buggy
+		// external source cannot crash the whole datanode process (e.g.
+		// divide-by-zero from a zero-row parquet, fix for #49225).
+		defer func() {
+			if r := recover(); r != nil {
+				stack := debug.Stack()
+				log.Error("external collection task panicked",
+					zap.Int64("taskID", taskID),
+					zap.Int64("collectionID", req.GetCollectionID()),
+					zap.Any("panic", r),
+					zap.ByteString("stack", stack))
+				reason := fmt.Sprintf("task panicked: %v", r)
+				m.UpdateResult(clusterID, taskID, indexpb.JobState_JobStateFailed, reason, info.KeptSegments, nil)
+				retErr = fmt.Errorf("%s", reason)
+			}
+		}()
 		log.Info("executing external collection task in pool",
 			zap.Int64("taskID", taskID),
 			zap.Int64("collectionID", req.GetCollectionID()))

--- a/internal/datanode/external/manager_test.go
+++ b/internal/datanode/external/manager_test.go
@@ -162,6 +162,44 @@ func TestExternalCollectionManager_SubmitTask_Failure(t *testing.T) {
 	assert.Equal(t, expectedError.Error(), info.FailReason)
 }
 
+// Regression for #49225: a panic inside taskFunc (e.g. divide-by-zero from a
+// malformed external parquet) must be isolated to the task — the manager pool
+// goroutine must NOT crash the process, and the task must surface as Failed.
+func TestExternalCollectionManager_SubmitTask_PanicIsolated(t *testing.T) {
+	ctx := context.Background()
+	manager := NewExternalCollectionManager(ctx, 4)
+	defer manager.Close()
+
+	clusterID := "test-cluster"
+	taskID := int64(4242)
+	collID := int64(9999)
+
+	req := &datapb.RefreshExternalCollectionTaskRequest{
+		TaskID:       taskID,
+		CollectionID: collID,
+	}
+
+	taskFunc := func(ctx context.Context) (*datapb.RefreshExternalCollectionTaskResponse, error) {
+		var zero int64
+		// Reproduces the original #49225 crash shape.
+		_ = int64(1) / zero
+		return nil, nil
+	}
+
+	err := manager.SubmitTask(clusterID, req, taskFunc)
+	assert.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		info := manager.Get(clusterID, taskID)
+		return info != nil && info.State == indexpb.JobState_JobStateFailed
+	}, time.Second, 10*time.Millisecond)
+
+	info := manager.Get(clusterID, taskID)
+	assert.NotNil(t, info)
+	assert.Equal(t, indexpb.JobState_JobStateFailed, info.State)
+	assert.Contains(t, info.FailReason, "panic")
+}
+
 func TestExternalCollectionManager_CancelTask(t *testing.T) {
 	ctx := context.Background()
 	manager := NewExternalCollectionManager(ctx, 4)

--- a/internal/datanode/external/task_update.go
+++ b/internal/datanode/external/task_update.go
@@ -596,7 +596,6 @@ func (t *RefreshExternalCollectionTask) balanceFragmentsToSegments(ctx context.C
 		}
 	}
 
-
 	sampleOne := func(manifestPath string) (int64, bool) {
 		fieldSizes, err := packed.SampleExternalFieldSizes(
 			manifestPath, sampleRows,

--- a/internal/datanode/external/task_update.go
+++ b/internal/datanode/external/task_update.go
@@ -56,6 +56,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/conc"
 	"github.com/milvus-io/milvus/pkg/v2/util/externalspec"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/timerecord"
 )
@@ -413,6 +414,14 @@ func (t *RefreshExternalCollectionTask) balanceFragmentsToSegments(ctx context.C
 			return nil, err
 		}
 		totalRows += f.RowCount
+	}
+
+	// Guard against zero-row parquet files that would cause divide-by-zero below.
+	// Fragment-level RowCount comes from manifest (endRow - startRow) and reflects real row counts,
+	// unlike datacoord's pre-split FileInfo.NumRows which carries a -1 sentinel from PlainFormat::explore.
+	if totalRows == 0 {
+		return nil, merr.WrapErrParameterInvalidMsg(
+			fmt.Sprintf("external source has %d fragments but zero total rows", len(fragments)))
 	}
 
 	// Get target rows per segment from configuration

--- a/internal/datanode/external/task_update.go
+++ b/internal/datanode/external/task_update.go
@@ -43,6 +43,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"go.uber.org/zap"
@@ -584,6 +585,18 @@ func (t *RefreshExternalCollectionTask) balanceFragmentsToSegments(ctx context.C
 	segmentAvgBytes := make([]int64, len(works))
 	var fallbackAvg int64
 
+	// firstSampleErr captures the first underlying sampling failure so we
+	// can surface the real root cause (e.g. "Column 'xxx' not found in
+	// schema" from an external_field typo, issue #48637) to the client
+	// instead of a generic "sampling failed for all N segment(s)" message.
+	var firstSampleErr error
+	recordErr := func(err error) {
+		if firstSampleErr == nil {
+			firstSampleErr = err
+		}
+	}
+
+
 	sampleOne := func(manifestPath string) (int64, bool) {
 		fieldSizes, err := packed.SampleExternalFieldSizes(
 			manifestPath, sampleRows,
@@ -596,6 +609,7 @@ func (t *RefreshExternalCollectionTask) balanceFragmentsToSegments(ctx context.C
 			log.Warn("failed to sample external field sizes",
 				zap.String("manifestPath", manifestPath),
 				zap.Error(err))
+			recordErr(err)
 			return 0, false
 		}
 		total := sumFieldSizes(fieldSizes, t.req.GetSchema())
@@ -608,6 +622,7 @@ func (t *RefreshExternalCollectionTask) balanceFragmentsToSegments(ctx context.C
 			log.Warn("external field size sample produced non-positive total",
 				zap.String("manifestPath", manifestPath),
 				zap.Int64("total", total))
+			recordErr(fmt.Errorf("sampled field sizes sum to %d (schema may have no external_field mappings, or sampled rows are empty)", total))
 			return 0, false
 		}
 		return total, true
@@ -641,12 +656,23 @@ func (t *RefreshExternalCollectionTask) balanceFragmentsToSegments(ctx context.C
 		// resource estimator and risk OOM on load. We prefer a loud
 		// failure (retry-eligible via the task state machine) over a
 		// silent success that corrupts downstream accounting.
+		//
+		// Embed firstSampleErr (issue #48637) so the client-facing
+		// RefreshFailed reason names the root cause (e.g. column not
+		// found in parquet) rather than forcing the operator to SSH
+		// into datanode logs.
 		if fallbackAvg == 0 {
-			return nil, fmt.Errorf(
-				"external field size sampling failed for all %d segment(s); "+
-					"refusing to emit segments with MemorySize=0 (would risk QueryNode OOM on load). "+
-					"check sample logs above for the root cause",
-				len(manifestPaths))
+			rootCause := "unknown (no sample attempted)"
+			if firstSampleErr != nil {
+				rootCause = firstSampleErr.Error()
+			}
+			hint := ""
+			if strings.Contains(rootCause, "not found in schema") {
+				hint = "; check external_field mappings in collection schema against actual parquet columns"
+			}
+			return nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf(
+				"external field size sampling failed for all %d segment(s): %s%s",
+				len(manifestPaths), rootCause, hint))
 		}
 		// Fill any zero slots (sampling failed mid-loop) with the first
 		// successful average so every segment gets a non-zero MemorySize.

--- a/internal/datanode/external/task_update_test.go
+++ b/internal/datanode/external/task_update_test.go
@@ -1128,6 +1128,57 @@ func (s *RefreshExternalCollectionTaskSuite) TestBalanceFragmentsToSegments_Samp
 	s.Nil(result)
 }
 
+// Regression for #48637: when external_field mappings point to columns
+// absent in the parquet file, SampleExternalFieldSizes returns a real
+// error like "Column 'wrong_col_a' not found in schema". That error
+// must propagate to the task error (and thus to the RefreshFailed
+// reason surfaced to the client) rather than being swallowed as a
+// generic "sampling failed for all N segment(s)" message.
+func (s *RefreshExternalCollectionTaskSuite) TestBalanceFragmentsToSegments_SamplingError_RootCausePropagated() {
+	paramtable.Init()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req := &datapb.RefreshExternalCollectionTaskRequest{
+		CollectionID:           s.collectionID,
+		TaskID:                 s.taskID,
+		PreAllocatedSegmentIds: &datapb.IDRange{Begin: 100, End: 200},
+		StorageConfig:          &indexpb.StorageConfig{StorageType: "local"},
+		ExternalSource:         "s3://bucket/data/",
+		ExternalSpec:           `{"format":"parquet"}`,
+		Schema: &schemapb.CollectionSchema{
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "text", ExternalField: "wrong_col_a"},
+			},
+		},
+	}
+
+	task := NewRefreshExternalCollectionTask(ctx, req)
+	task.preallocatedIDRange = req.GetPreAllocatedSegmentIds()
+	task.nextAllocID = task.preallocatedIDRange.Begin
+	task.parsedSpec = &externalspec.ExternalSpec{Format: "parquet"}
+
+	m1 := mockey.Mock(packed.CreateSegmentManifestWithBasePath).
+		To(func(ctx context.Context, basePath, format string, columns []string, fragments []packed.Fragment, storageConfig *indexpb.StorageConfig) (string, error) {
+			return fmt.Sprintf("%s/manifest.json", basePath), nil
+		}).Build()
+	defer m1.UnPatch()
+
+	cppErr := fmt.Errorf("Invalid: Column 'wrong_col_a' not found in schema. [path=data.parquet]")
+	m2 := mockey.Mock(packed.SampleExternalFieldSizes).Return(nil, cppErr).Build()
+	defer m2.UnPatch()
+
+	fragments := []packed.Fragment{{FragmentID: 1, RowCount: 500}}
+
+	result, err := task.balanceFragmentsToSegments(context.Background(), fragments)
+	s.Error(err)
+	s.Nil(result)
+	// Root cause string must reach the client-facing task error.
+	s.Contains(err.Error(), "Column 'wrong_col_a' not found in schema")
+	// And emit actionable hint guiding the user to the real fix.
+	s.Contains(err.Error(), "external_field mappings")
+}
+
 // Regression: the samplePerSegment=true branch of Phase 3 was previously
 // uncovered by tests. This exercise is three parts:
 //  1. All per-segment samples succeed → each segment gets its own

--- a/internal/datanode/external/task_update_test.go
+++ b/internal/datanode/external/task_update_test.go
@@ -172,6 +172,32 @@ func (s *RefreshExternalCollectionTaskSuite) TestBalanceFragmentsToSegments_Empt
 	s.Nil(result)
 }
 
+// Regression for #49225: zero-row parquet produces fragments whose RowCount
+// sums to 0 and previously triggered divide-by-zero panic in
+// balanceFragmentsToSegments. Must return error, never panic.
+func (s *RefreshExternalCollectionTaskSuite) TestBalanceFragmentsToSegments_ZeroTotalRowsWithFragments() {
+	paramtable.Init()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req := &datapb.RefreshExternalCollectionTaskRequest{
+		CollectionID: s.collectionID,
+		TaskID:       s.taskID,
+	}
+	task := NewRefreshExternalCollectionTask(ctx, req)
+
+	fragments := []packed.Fragment{
+		{FragmentID: 1, RowCount: 0, FilePath: "s3://bucket/zero.parquet"},
+		{FragmentID: 2, RowCount: 0, FilePath: "s3://bucket/zero2.parquet"},
+	}
+	s.NotPanics(func() {
+		result, err := task.balanceFragmentsToSegments(context.Background(), fragments)
+		s.Error(err)
+		s.Nil(result)
+		s.Contains(err.Error(), "zero total rows")
+	})
+}
+
 func (s *RefreshExternalCollectionTaskSuite) TestBalanceFragmentsToSegments_SingleFragment() {
 	paramtable.Init()
 

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -913,7 +913,18 @@ func (node *Proxy) DescribeCollection(ctx context.Context, request *milvuspb.Des
 			Status: merr.Status(err),
 		}, nil
 	}
-	return interceptor.Call(ctx, request)
+	resp, err := interceptor.Call(ctx, request)
+	// Single-point redaction at the API edge. The persisted spec carries
+	// extfs credentials (access_key_id / access_key_value / ssl_ca_cert)
+	// that internal callers (refresh / load) need raw via the same
+	// mixCoord.DescribeCollection RPC; redacting at source would break
+	// FFI auth. Sanitize here so every provider path (cached / remote)
+	// converges through one spot — adding a new provider does not
+	// re-introduce the leak.
+	if resp != nil && resp.GetSchema() != nil {
+		resp.Schema.ExternalSpec = externalspec.RedactExternalSpec(resp.Schema.ExternalSpec)
+	}
+	return resp, err
 }
 
 func (node *Proxy) BatchDescribeCollection(ctx context.Context, request *milvuspb.BatchDescribeCollectionRequest) (*milvuspb.BatchDescribeCollectionResponse, error) {

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -1692,6 +1692,24 @@ func (t *alterCollectionTask) PreExecute(ctx context.Context) error {
 		return merr.WrapErrParameterInvalidMsg("cannot provide both DeleteKeys and ExtraParams")
 	}
 
+	// External source/spec form an atomic tuple bound to the physical data
+	// layout. The only supported way to change them is RefreshExternalCollection,
+	// which applies them atomically and re-runs the data load pipeline.
+	for _, prop := range t.GetProperties() {
+		if prop.GetKey() == common.CollectionExternalSource || prop.GetKey() == common.CollectionExternalSpec {
+			return merr.WrapErrParameterInvalidMsg(
+				"cannot alter %s via alter_collection_properties; use RefreshExternalCollection instead",
+				prop.GetKey())
+		}
+	}
+	for _, key := range t.GetDeleteKeys() {
+		if key == common.CollectionExternalSource || key == common.CollectionExternalSpec {
+			return merr.WrapErrParameterInvalidMsg(
+				"cannot delete %s; external source/spec are immutable post-create except via RefreshExternalCollection",
+				key)
+		}
+	}
+
 	collSchema, err := globalMetaCache.GetCollectionSchema(ctx, t.GetDbName(), t.CollectionName)
 	if err != nil {
 		return err

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -468,6 +468,18 @@ func (t *createCollectionTask) PreExecute(ctx context.Context) error {
 		return err
 	}
 
+	// Reject reserved system field names supplied by the user before any
+	// server-side injection runs. __virtual_pk__ is the internal PK name
+	// auto-injected for external collections; RowID and Timestamp are
+	// segcore-internal columns. Allowing a user field under these names
+	// would create a namespace trap for any tooling that assumes they are
+	// system-owned (issue #49314). Must run before
+	// injectVirtualPKForExternalCollection so the check only sees
+	// user-supplied fields.
+	if err := validateReservedFieldNames(t.schema); err != nil {
+		return err
+	}
+
 	// For external collections, inject virtual PK field if no PK exists
 	if isExternalCollection {
 		if err := injectVirtualPKForExternalCollection(t.schema); err != nil {
@@ -700,7 +712,7 @@ func validateAddFieldRequest(schema *schemapb.CollectionSchema, newFieldSchema *
 	if _, ok := schemapb.DataType_name[int32(newFieldSchema.GetDataType())]; !ok || newFieldSchema.GetDataType() == schemapb.DataType_None {
 		return merr.WrapErrParameterInvalid("valid field", fmt.Sprintf("field data type: %s is not supported", newFieldSchema.GetDataType()))
 	}
-	if funcutil.SliceContain([]string{common.RowIDFieldName, common.TimeStampFieldName, common.MetaFieldName, common.NamespaceFieldName}, newFieldSchema.GetName()) {
+	if funcutil.SliceContain([]string{common.RowIDFieldName, common.TimeStampFieldName, common.MetaFieldName, common.NamespaceFieldName, common.VirtualPKFieldName}, newFieldSchema.GetName()) {
 		return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("not support to add system field, field name = %s", newFieldSchema.GetName()))
 	}
 	if newFieldSchema.GetIsPrimaryKey() {

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -1054,7 +1054,26 @@ func (t *truncateCollectionTask) OnEnqueue() error {
 }
 
 func (t *truncateCollectionTask) PreExecute(ctx context.Context) error {
-	return validateCollectionName(t.CollectionName)
+	if err := validateCollectionName(t.CollectionName); err != nil {
+		return err
+	}
+	// Truncate is a destructive op on internal segments. External collections
+	// have no internal data to truncate — their authoritative data lives in
+	// the user's object store and is materialized by RefreshExternalCollection.
+	// Allowing truncate would either no-op silently (misleading) or wipe the
+	// generated segment metadata while leaving the external source intact,
+	// putting the collection in an inconsistent state from which the next
+	// load/search would fail. Reject up front; users who want to reset the
+	// view should use RefreshExternalCollection or DropCollection.
+	collSchema, err := globalMetaCache.GetCollectionSchema(ctx, t.GetDbName(), t.GetCollectionName())
+	if err != nil {
+		return err
+	}
+	if typeutil.IsExternalCollection(collSchema.CollectionSchema) {
+		return merr.WrapErrParameterInvalidMsg(
+			"truncate is not supported on external collections; use RefreshExternalCollection to refresh the data view, or DropCollection to remove it")
+	}
+	return nil
 }
 
 func (t *truncateCollectionTask) Execute(ctx context.Context) error {

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -1247,6 +1247,10 @@ func (t *describeCollectionTask) Execute(ctx context.Context) error {
 	t.result.Schema.AutoID = result.Schema.AutoID
 	t.result.Schema.EnableDynamicField = result.Schema.EnableDynamicField
 	t.result.Schema.ExternalSource = result.Schema.ExternalSource
+	// Pass spec through unredacted; the public proxy.DescribeCollection
+	// entry point applies RedactExternalSpec uniformly across cached and
+	// remote provider paths so internal-only callers of this task path
+	// (if any) still observe raw creds for FFI auth.
 	t.result.Schema.ExternalSpec = result.Schema.ExternalSpec
 	t.result.Schema.EnableNamespace = result.Schema.EnableNamespace
 	t.result.CollectionID = result.CollectionID

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -7254,3 +7254,54 @@ func TestAlterCollectionSchemaTask(t *testing.T) {
 		})
 	})
 }
+
+// TestAlterCollection_RejectExternalTupleMutation verifies the proxy-layer
+// guard rejects user alter_collection_properties calls that target the
+// external_source / external_spec tuple. Mutation of this tuple is reserved
+// to RefreshExternalCollection; see issue #49335.
+func TestAlterCollection_RejectExternalTupleMutation(t *testing.T) {
+	ctx := context.Background()
+	task := &alterCollectionTask{
+		AlterCollectionRequest: &milvuspb.AlterCollectionRequest{
+			Base:           &commonpb.MsgBase{MsgType: commonpb.MsgType_AlterCollection},
+			DbName:         dbName,
+			CollectionName: "ext_guard_test",
+		},
+	}
+
+	t.Run("reject properties with external_source", func(t *testing.T) {
+		task.AlterCollectionRequest.Properties = []*commonpb.KeyValuePair{
+			{Key: common.CollectionExternalSource, Value: "s3://bucket/a/"},
+		}
+		task.AlterCollectionRequest.DeleteKeys = nil
+		err := task.PreExecute(ctx)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "RefreshExternalCollection")
+	})
+
+	t.Run("reject properties with external_spec", func(t *testing.T) {
+		task.AlterCollectionRequest.Properties = []*commonpb.KeyValuePair{
+			{Key: common.CollectionExternalSpec, Value: `{"format":"parquet"}`},
+		}
+		task.AlterCollectionRequest.DeleteKeys = nil
+		err := task.PreExecute(ctx)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "RefreshExternalCollection")
+	})
+
+	t.Run("reject delete of external_source", func(t *testing.T) {
+		task.AlterCollectionRequest.Properties = nil
+		task.AlterCollectionRequest.DeleteKeys = []string{common.CollectionExternalSource}
+		err := task.PreExecute(ctx)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "immutable")
+	})
+
+	t.Run("reject delete of external_spec", func(t *testing.T) {
+		task.AlterCollectionRequest.Properties = nil
+		task.AlterCollectionRequest.DeleteKeys = []string{common.CollectionExternalSpec}
+		err := task.PreExecute(ctx)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "immutable")
+	})
+}

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -2301,6 +2301,68 @@ func TestDescribeCollectionTask_FilterNamespaceField(t *testing.T) {
 	assert.Equal(t, collectionName, task.result.GetCollectionName())
 }
 
+// Security regression: DescribeCollection must redact credentials embedded in
+// ExternalSpec.extfs (access_key_id / access_key_value / ssl_ca_cert) before
+// returning to the client. Any caller with Describe privilege would otherwise
+// be able to read another tenant's object-storage credentials out of the
+// persisted collection metadata.
+func TestDescribeCollectionTask_RedactsExternalSpecCredentials(t *testing.T) {
+	mix := NewMixCoordMock()
+	ctx := context.Background()
+	InitMetaCache(ctx, mix)
+
+	collectionName := "TestDescribeCollectionTask_RedactsExternalSpecCredentials"
+
+	rawSpec := `{"format":"parquet","extfs":{"access_key_id":"AKIAEXAMPLE","access_key_value":"SUPERSECRET","region":"us-east-1"}}`
+
+	schema := &schemapb.CollectionSchema{
+		Name:           collectionName,
+		ExternalSource: "s3://my-bucket/data/",
+		ExternalSpec:   rawSpec,
+		Fields: []*schemapb.FieldSchema{
+			{
+				FieldID:      common.StartOfUserFieldID,
+				Name:         "id",
+				IsPrimaryKey: true,
+				DataType:     schemapb.DataType_Int64,
+			},
+		},
+	}
+
+	mix.SetDescribeCollectionFunc(func(ctx context.Context, request *milvuspb.DescribeCollectionRequest) (*milvuspb.DescribeCollectionResponse, error) {
+		return &milvuspb.DescribeCollectionResponse{
+			Status:       merr.Success(),
+			Schema:       schema,
+			CollectionID: 1,
+		}, nil
+	})
+
+	task := &describeCollectionTask{
+		Condition: NewTaskCondition(ctx),
+		DescribeCollectionRequest: &milvuspb.DescribeCollectionRequest{
+			Base:           &commonpb.MsgBase{MsgType: commonpb.MsgType_DescribeCollection},
+			CollectionName: collectionName,
+		},
+		ctx:      ctx,
+		mixCoord: mix,
+	}
+
+	assert.NoError(t, task.PreExecute(ctx))
+	assert.NoError(t, task.Execute(ctx))
+
+	// describeCollectionTask now passes ExternalSpec through unredacted —
+	// redaction lives at the public proxy.DescribeCollection edge so both
+	// cached and remote provider paths converge through one sanitizer.
+	// The task-level result must still carry raw creds so that the
+	// post-task wrapper can choose to redact (user-facing) or not
+	// (internal callers, if added later, that need raw spec for FFI).
+	out := task.result.Schema.ExternalSpec
+	assert.Contains(t, out, "AKIAEXAMPLE",
+		"task-level result must carry raw spec; redaction is applied at proxy edge")
+	assert.Contains(t, out, "SUPERSECRET",
+		"task-level result must carry raw spec; redaction is applied at proxy edge")
+}
+
 func TestDescribeCollectionTask_ShardsNum2(t *testing.T) {
 	mix := NewMixCoordMock()
 	ctx := context.Background()

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -3596,7 +3596,7 @@ func Test_truncateCollectionTask_PreExecute(t *testing.T) {
 	regBytes, err := proto.Marshal(regularSchema)
 	require.NoError(t, err)
 	_, err = mix.CreateCollection(ctx, &milvuspb.CreateCollectionRequest{
-		Base: &commonpb.MsgBase{MsgType: commonpb.MsgType_CreateCollection},
+		Base:   &commonpb.MsgBase{MsgType: commonpb.MsgType_CreateCollection},
 		DbName: dbName, CollectionName: regularName, Schema: regBytes, ShardsNum: 1,
 	})
 	require.NoError(t, err)
@@ -3607,14 +3607,16 @@ func Test_truncateCollectionTask_PreExecute(t *testing.T) {
 		ExternalSpec:   `{"format":"parquet"}`,
 		Fields: []*schemapb.FieldSchema{
 			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true, ExternalField: "id"},
-			{FieldID: 101, Name: "vec", DataType: schemapb.DataType_FloatVector, ExternalField: "vec",
-				TypeParams: []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "4"}}},
+			{
+				FieldID: 101, Name: "vec", DataType: schemapb.DataType_FloatVector, ExternalField: "vec",
+				TypeParams: []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "4"}},
+			},
 		},
 	}
 	extBytes, err := proto.Marshal(extSchema)
 	require.NoError(t, err)
 	_, err = mix.CreateCollection(ctx, &milvuspb.CreateCollectionRequest{
-		Base: &commonpb.MsgBase{MsgType: commonpb.MsgType_CreateCollection},
+		Base:   &commonpb.MsgBase{MsgType: commonpb.MsgType_CreateCollection},
 		DbName: dbName, CollectionName: externalName, Schema: extBytes, ShardsNum: 1,
 	})
 	require.NoError(t, err)
@@ -7319,36 +7321,36 @@ func TestAlterCollection_RejectExternalTupleMutation(t *testing.T) {
 	}
 
 	t.Run("reject properties with external_source", func(t *testing.T) {
-		task.AlterCollectionRequest.Properties = []*commonpb.KeyValuePair{
+		task.Properties = []*commonpb.KeyValuePair{
 			{Key: common.CollectionExternalSource, Value: "s3://bucket/a/"},
 		}
-		task.AlterCollectionRequest.DeleteKeys = nil
+		task.DeleteKeys = nil
 		err := task.PreExecute(ctx)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "RefreshExternalCollection")
 	})
 
 	t.Run("reject properties with external_spec", func(t *testing.T) {
-		task.AlterCollectionRequest.Properties = []*commonpb.KeyValuePair{
+		task.Properties = []*commonpb.KeyValuePair{
 			{Key: common.CollectionExternalSpec, Value: `{"format":"parquet"}`},
 		}
-		task.AlterCollectionRequest.DeleteKeys = nil
+		task.DeleteKeys = nil
 		err := task.PreExecute(ctx)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "RefreshExternalCollection")
 	})
 
 	t.Run("reject delete of external_source", func(t *testing.T) {
-		task.AlterCollectionRequest.Properties = nil
-		task.AlterCollectionRequest.DeleteKeys = []string{common.CollectionExternalSource}
+		task.Properties = nil
+		task.DeleteKeys = []string{common.CollectionExternalSource}
 		err := task.PreExecute(ctx)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "immutable")
 	})
 
 	t.Run("reject delete of external_spec", func(t *testing.T) {
-		task.AlterCollectionRequest.Properties = nil
-		task.AlterCollectionRequest.DeleteKeys = []string{common.CollectionExternalSpec}
+		task.Properties = nil
+		task.DeleteKeys = []string{common.CollectionExternalSpec}
 		err := task.PreExecute(ctx)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "immutable")

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -3584,18 +3584,67 @@ func Test_dropCollectionTask_PostExecute(t *testing.T) {
 }
 
 func Test_truncateCollectionTask_PreExecute(t *testing.T) {
-	tct := &truncateCollectionTask{TruncateCollectionRequest: &milvuspb.TruncateCollectionRequest{
-		Base:           &commonpb.MsgBase{},
-		CollectionName: "valid",
-	}}
+	mix := NewMixCoordMock()
 	ctx := context.Background()
-	err := tct.PreExecute(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, InitMetaCache(ctx, mix))
 
-	// Test invalid collection name
-	tct.CollectionName = "#0xc0de"
-	err = tct.PreExecute(ctx)
-	assert.Error(t, err)
+	dbName := ""
+	regularName := "regular_truncate_" + funcutil.GenRandomStr()
+	externalName := "ext_truncate_" + funcutil.GenRandomStr()
+
+	regularSchema := constructCollectionSchema("pk", "fvec", 4, regularName)
+	regBytes, err := proto.Marshal(regularSchema)
+	require.NoError(t, err)
+	_, err = mix.CreateCollection(ctx, &milvuspb.CreateCollectionRequest{
+		Base: &commonpb.MsgBase{MsgType: commonpb.MsgType_CreateCollection},
+		DbName: dbName, CollectionName: regularName, Schema: regBytes, ShardsNum: 1,
+	})
+	require.NoError(t, err)
+
+	extSchema := &schemapb.CollectionSchema{
+		Name:           externalName,
+		ExternalSource: "s3://bucket/path/",
+		ExternalSpec:   `{"format":"parquet"}`,
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true, ExternalField: "id"},
+			{FieldID: 101, Name: "vec", DataType: schemapb.DataType_FloatVector, ExternalField: "vec",
+				TypeParams: []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "4"}}},
+		},
+	}
+	extBytes, err := proto.Marshal(extSchema)
+	require.NoError(t, err)
+	_, err = mix.CreateCollection(ctx, &milvuspb.CreateCollectionRequest{
+		Base: &commonpb.MsgBase{MsgType: commonpb.MsgType_CreateCollection},
+		DbName: dbName, CollectionName: externalName, Schema: extBytes, ShardsNum: 1,
+	})
+	require.NoError(t, err)
+
+	t.Run("regular collection passes", func(t *testing.T) {
+		tct := &truncateCollectionTask{TruncateCollectionRequest: &milvuspb.TruncateCollectionRequest{
+			Base: &commonpb.MsgBase{}, DbName: dbName, CollectionName: regularName,
+		}}
+		assert.NoError(t, tct.PreExecute(ctx))
+	})
+
+	t.Run("invalid collection name rejected", func(t *testing.T) {
+		tct := &truncateCollectionTask{TruncateCollectionRequest: &milvuspb.TruncateCollectionRequest{
+			Base: &commonpb.MsgBase{}, CollectionName: "#0xc0de",
+		}}
+		assert.Error(t, tct.PreExecute(ctx))
+	})
+
+	// Truncate is destructive on internal segments and meaningless for
+	// external collections (data lives in user object store). Reject up
+	// front to prevent silent no-op or inconsistent meta state.
+	t.Run("external collection rejected", func(t *testing.T) {
+		tct := &truncateCollectionTask{TruncateCollectionRequest: &milvuspb.TruncateCollectionRequest{
+			Base: &commonpb.MsgBase{}, DbName: dbName, CollectionName: externalName,
+		}}
+		err := tct.PreExecute(ctx)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "external collection")
+		assert.Contains(t, err.Error(), "RefreshExternalCollection")
+	})
 }
 
 func Test_truncateCollectionTask_Execute(t *testing.T) {

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -765,6 +765,42 @@ func validatePrimaryKey(coll *schemapb.CollectionSchema) error {
 	return nil
 }
 
+// validateReservedFieldNames rejects user-supplied schema fields whose name
+// collides with a system-reserved identifier (RowID, Timestamp,
+// __virtual_pk__). Must be called BEFORE server-side injection of the
+// virtual PK so the check only applies to user input. Applies to regular
+// and struct-array fields alike. Fix for issue #49314.
+func validateReservedFieldNames(schema *schemapb.CollectionSchema) error {
+	reserved := map[string]struct{}{
+		common.RowIDFieldName:      {},
+		common.TimeStampFieldName:  {},
+		common.VirtualPKFieldName:  {},
+	}
+	check := func(name string) error {
+		if _, ok := reserved[name]; ok {
+			return merr.WrapErrFieldNameInvalid(name,
+				fmt.Sprintf("field name %q is reserved for internal use and cannot be used in user schemas", name))
+		}
+		return nil
+	}
+	for _, f := range schema.GetFields() {
+		if err := check(f.GetName()); err != nil {
+			return err
+		}
+	}
+	for _, saf := range schema.GetStructArrayFields() {
+		if err := check(saf.GetName()); err != nil {
+			return err
+		}
+		for _, f := range saf.GetFields() {
+			if err := check(f.GetName()); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 // injectVirtualPKForExternalCollection adds a virtual PK field for external collections
 // if no primary key field exists. External collections use virtual PKs in the format:
 // (segmentID << 32) | offset

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -772,9 +772,9 @@ func validatePrimaryKey(coll *schemapb.CollectionSchema) error {
 // and struct-array fields alike. Fix for issue #49314.
 func validateReservedFieldNames(schema *schemapb.CollectionSchema) error {
 	reserved := map[string]struct{}{
-		common.RowIDFieldName:      {},
-		common.TimeStampFieldName:  {},
-		common.VirtualPKFieldName:  {},
+		common.RowIDFieldName:     {},
+		common.TimeStampFieldName: {},
+		common.VirtualPKFieldName: {},
 	}
 	check := func(name string) error {
 		if _, ok := reserved[name]; ok {

--- a/internal/proxy/util_test.go
+++ b/internal/proxy/util_test.go
@@ -188,6 +188,52 @@ func TestValidateFieldName(t *testing.T) {
 	}
 }
 
+// Regression for #49314: user-supplied field named __virtual_pk__ (or
+// RowID / Timestamp) must be rejected at CreateCollection to keep the
+// system namespace clean. Covers regular fields and struct-array
+// fields (both the struct name and its inner fields).
+func TestValidateReservedFieldNames(t *testing.T) {
+	// Accepts non-reserved names.
+	ok := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{Name: "id"},
+			{Name: "embedding"},
+		},
+	}
+	assert.NoError(t, validateReservedFieldNames(ok))
+
+	for _, reserved := range []string{
+		common.VirtualPKFieldName,
+		common.RowIDFieldName,
+		common.TimeStampFieldName,
+	} {
+		s := &schemapb.CollectionSchema{
+			Fields: []*schemapb.FieldSchema{
+				{Name: reserved, DataType: schemapb.DataType_Int64},
+			},
+		}
+		err := validateReservedFieldNames(s)
+		assert.Error(t, err, "reserved name %q must be rejected", reserved)
+		assert.Contains(t, err.Error(), "reserved")
+	}
+
+	// Struct-array field name collision.
+	s := &schemapb.CollectionSchema{
+		StructArrayFields: []*schemapb.StructArrayFieldSchema{
+			{Name: common.VirtualPKFieldName, Fields: []*schemapb.FieldSchema{{Name: "a"}}},
+		},
+	}
+	assert.Error(t, validateReservedFieldNames(s))
+
+	// Struct-array inner field name collision.
+	s2 := &schemapb.CollectionSchema{
+		StructArrayFields: []*schemapb.StructArrayFieldSchema{
+			{Name: "ok_struct", Fields: []*schemapb.FieldSchema{{Name: common.RowIDFieldName}}},
+		},
+	}
+	assert.Error(t, validateReservedFieldNames(s2))
+}
+
 func TestValidateDimension(t *testing.T) {
 	fieldSchema := &schemapb.FieldSchema{
 		DataType: schemapb.DataType_FloatVector,

--- a/internal/rootcoord/create_collection_task_test.go
+++ b/internal/rootcoord/create_collection_task_test.go
@@ -914,7 +914,7 @@ func Test_createCollectionTask_validateSchema(t *testing.T) {
 		schema := &schemapb.CollectionSchema{
 			Name:           collectionName,
 			ExternalSource: "s3://bucket/object",
-			ExternalSpec:   `{"format":"parquet","extfs":{"region":"us-west-2","anonymous":"true"}}`,
+			ExternalSpec:   `{"format":"parquet","extfs":{"region":"us-west-2","anonymous":"true","cloud_provider":"aws"}}`,
 			Fields: []*schemapb.FieldSchema{
 				{
 					Name:          "text_field",

--- a/internal/rootcoord/ddl_callbacks_alter_collection_properties.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_properties.go
@@ -48,27 +48,6 @@ func (c *Core) broadcastAlterCollectionForAlterCollection(ctx context.Context, r
 		return merr.WrapErrParameterInvalidMsg("cannot delete key %s, dynamic field schema could support set to true/false", common.EnableDynamicSchemaKey)
 	}
 
-	// External source/spec form an atomic tuple bound to the physical data
-	// layout. Mutating them via alter has historically allowed partial
-	// updates (only one of the pair set), which silently clears the other
-	// because both share a single update mask. The canonical and only
-	// supported way to change them is RefreshExternalCollection, which
-	// applies them atomically and re-runs the data load pipeline.
-	for _, prop := range req.GetProperties() {
-		if prop.GetKey() == common.CollectionExternalSource || prop.GetKey() == common.CollectionExternalSpec {
-			return merr.WrapErrParameterInvalidMsg(
-				"cannot alter %s via alter_collection_properties; use RefreshExternalCollection instead",
-				prop.GetKey())
-		}
-	}
-	for _, key := range req.GetDeleteKeys() {
-		if key == common.CollectionExternalSource || key == common.CollectionExternalSpec {
-			return merr.WrapErrParameterInvalidMsg(
-				"cannot delete %s; external source/spec are immutable post-create except via RefreshExternalCollection",
-				key)
-		}
-	}
-
 	// Validate timezone
 	tz, exist := funcutil.TryGetAttrByKeyFromRepeatedKV(common.TimezoneKey, req.GetProperties())
 	if exist && !timestamptz.IsTimezoneValid(tz) {
@@ -126,6 +105,22 @@ func (c *Core) broadcastAlterCollectionForAlterCollection(ctx context.Context, r
 				udpates.ConsistencyLevel = lv
 				header.UpdateMask.Paths = append(header.UpdateMask.Paths, message.FieldMaskCollectionConsistencyLevel)
 			}
+		case common.CollectionExternalSource:
+			if udpates.Schema == nil {
+				udpates.Schema = &schemapb.CollectionSchema{}
+			}
+			udpates.Schema.ExternalSource = prop.GetValue()
+			if !funcutil.SliceContain(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec) {
+				header.UpdateMask.Paths = append(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec)
+			}
+		case common.CollectionExternalSpec:
+			if udpates.Schema == nil {
+				udpates.Schema = &schemapb.CollectionSchema{}
+			}
+			udpates.Schema.ExternalSpec = prop.GetValue()
+			if !funcutil.SliceContain(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec) {
+				header.UpdateMask.Paths = append(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec)
+			}
 		default:
 			newProperties[prop.GetKey()] = prop.GetValue()
 		}
@@ -169,6 +164,14 @@ func (c *Core) broadcastAlterCollectionForAlterCollection(ctx context.Context, r
 		// Build schema snapshot with updated properties (schema version should NOT be changed for properties-only alter).
 		schema := coll.ToCollectionSchemaPB()
 		schema.Properties = newPropsKeyValuePairs
+		// Preserve ExternalSource/ExternalSpec from current collection state
+		// unless this alter is itself updating them (refresh-completion sync).
+		if udpates.Schema != nil && udpates.Schema.ExternalSource != "" {
+			schema.ExternalSource = udpates.Schema.ExternalSource
+		}
+		if udpates.Schema != nil && udpates.Schema.ExternalSpec != "" {
+			schema.ExternalSpec = udpates.Schema.ExternalSpec
+		}
 		udpates.Schema = schema
 	}
 

--- a/internal/rootcoord/ddl_callbacks_alter_collection_properties_test.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_properties_test.go
@@ -504,7 +504,7 @@ func TestDDLCallbacksAlterCollectionProperties_TTLFieldPreservesExternalSpec(t *
 		Description:    "description",
 		AutoID:         false,
 		ExternalSource: "s3://bucket/ttl-path",
-		ExternalSpec:   `{"format":"parquet","extfs":{"anonymous":"true","region":"us-east-1"}}`,
+		ExternalSpec:   `{"format":"parquet","extfs":{"anonymous":"true","region":"us-east-1","cloud_provider":"aws"}}`,
 		Fields: []*schemapb.FieldSchema{
 			{Name: "id", DataType: schemapb.DataType_Int64, ExternalField: "id"},
 			{Name: "ttl", DataType: schemapb.DataType_Timestamptz, ExternalField: "ttl"},
@@ -526,7 +526,7 @@ func TestDDLCallbacksAlterCollectionProperties_TTLFieldPreservesExternalSpec(t *
 	})
 	require.NoError(t, merr.CheckRPCCall(resp, err))
 	assertExternalSource(t, ctx, core, dbName, collectionName, "s3://bucket/ttl-path")
-	assertExternalSpec(t, ctx, core, dbName, collectionName, `{"format":"parquet","extfs":{"anonymous":"true","region":"us-east-1"}}`)
+	assertExternalSpec(t, ctx, core, dbName, collectionName, `{"format":"parquet","extfs":{"anonymous":"true","region":"us-east-1","cloud_provider":"aws"}}`)
 
 	// Alter TTL field only — must preserve previously persisted external source/spec.
 	resp, err = core.AlterCollection(ctx, &milvuspb.AlterCollectionRequest{
@@ -538,7 +538,7 @@ func TestDDLCallbacksAlterCollectionProperties_TTLFieldPreservesExternalSpec(t *
 	})
 	require.NoError(t, merr.CheckRPCCall(resp, err))
 	assertExternalSource(t, ctx, core, dbName, collectionName, "s3://bucket/ttl-path")
-	assertExternalSpec(t, ctx, core, dbName, collectionName, `{"format":"parquet","extfs":{"anonymous":"true","region":"us-east-1"}}`)
+	assertExternalSpec(t, ctx, core, dbName, collectionName, `{"format":"parquet","extfs":{"anonymous":"true","region":"us-east-1","cloud_provider":"aws"}}`)
 
 	// TTL with invalid field name still rejected.
 	resp, err = core.AlterCollection(ctx, &milvuspb.AlterCollectionRequest{

--- a/internal/rootcoord/ddl_callbacks_alter_collection_properties_test.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_properties_test.go
@@ -563,67 +563,137 @@ func assertExternalSpec(t *testing.T, ctx context.Context, core *Core, dbName st
 	require.Equal(t, expectedSpec, coll.ExternalSpec)
 }
 
-func TestDDLCallbacksAlterCollectionProperties_RejectExternalSourceSpec(t *testing.T) {
+// TestDDLCallbacksAlterCollectionProperties_AcceptExternalSourceSpec verifies
+// rootcoord accepts external_source/external_spec updates via AlterCollection.
+// User-facing rejection lives in the proxy layer (see issue #49335); rootcoord
+// trusts internal callers so the refresh-completion sync path
+// (updateExternalSchemaViaWAL) can persist a new tuple after a successful
+// override refresh.
+func TestDDLCallbacksAlterCollectionProperties_AcceptExternalSourceSpec(t *testing.T) {
 	core := initStreamingSystemAndCore(t)
 	ctx := context.Background()
 
 	dbName := "testDB" + funcutil.RandomString(10)
-	collectionName := "testRejectExt" + funcutil.RandomString(10)
-	createCollectionForTest(t, ctx, core, dbName, collectionName)
+	collectionName := "testAcceptExt" + funcutil.RandomString(10)
 
-	cases := []struct {
-		name string
-		req  *milvuspb.AlterCollectionRequest
-	}{
-		{
-			name: "set external_source via alter",
-			req: &milvuspb.AlterCollectionRequest{
-				DbName: dbName, CollectionName: collectionName,
-				Properties: []*commonpb.KeyValuePair{
-					{Key: common.CollectionExternalSource, Value: "s3://bucket/path"},
-				},
-			},
+	resp, err := core.CreateDatabase(ctx, &milvuspb.CreateDatabaseRequest{DbName: dbName})
+	require.NoError(t, merr.CheckRPCCall(resp, err))
+	testSchema := &schemapb.CollectionSchema{
+		Name: collectionName,
+		Fields: []*schemapb.FieldSchema{
+			{Name: "field1", DataType: schemapb.DataType_Int64},
 		},
-		{
-			name: "set external_spec via alter",
-			req: &milvuspb.AlterCollectionRequest{
-				DbName: dbName, CollectionName: collectionName,
-				Properties: []*commonpb.KeyValuePair{
-					{Key: common.CollectionExternalSpec, Value: `{"format":"parquet"}`},
-				},
-			},
-		},
-		{
-			name: "set both via alter",
-			req: &milvuspb.AlterCollectionRequest{
-				DbName: dbName, CollectionName: collectionName,
-				Properties: []*commonpb.KeyValuePair{
-					{Key: common.CollectionExternalSource, Value: "s3://bucket/path"},
-					{Key: common.CollectionExternalSpec, Value: `{"format":"parquet"}`},
-				},
-			},
-		},
-		{
-			name: "delete external_source",
-			req: &milvuspb.AlterCollectionRequest{
-				DbName: dbName, CollectionName: collectionName,
-				DeleteKeys: []string{common.CollectionExternalSource},
-			},
-		},
-		{
-			name: "delete external_spec",
-			req: &milvuspb.AlterCollectionRequest{
-				DbName: dbName, CollectionName: collectionName,
-				DeleteKeys: []string{common.CollectionExternalSpec},
-			},
-		},
+		ExternalSource: "s3://bucket/old/",
+		ExternalSpec:   `{"format":"parquet"}`,
 	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			resp, err := core.AlterCollection(ctx, tc.req)
-			require.ErrorIs(t, merr.CheckRPCCall(resp, err), merr.ErrParameterInvalid)
-		})
+	schemaBytes, err := proto.Marshal(testSchema)
+	require.NoError(t, err)
+	resp, err = core.CreateCollection(ctx, &milvuspb.CreateCollectionRequest{
+		DbName:           dbName,
+		CollectionName:   collectionName,
+		Schema:           schemaBytes,
+		ConsistencyLevel: commonpb.ConsistencyLevel_Bounded,
+	})
+	require.NoError(t, merr.CheckRPCCall(resp, err))
+	assertExternalSource(t, ctx, core, dbName, collectionName, "s3://bucket/old/")
+
+	resp, err = core.AlterCollection(ctx, &milvuspb.AlterCollectionRequest{
+		DbName: dbName, CollectionName: collectionName,
+		Properties: []*commonpb.KeyValuePair{
+			{Key: common.CollectionExternalSource, Value: "s3://bucket/new/"},
+			{Key: common.CollectionExternalSpec, Value: `{"format":"parquet"}`},
+		},
+	})
+	require.NoError(t, merr.CheckRPCCall(resp, err))
+	assertExternalSource(t, ctx, core, dbName, collectionName, "s3://bucket/new/")
+	assertExternalSpec(t, ctx, core, dbName, collectionName, `{"format":"parquet"}`)
+}
+
+// Regression for #49335: refresh override path may carry source-only updates
+// (or spec-only) since the tuple is preserved by the refresh manager. A
+// partial alter must not blank the unspecified half by writing an empty
+// string into the schema snapshot.
+func TestDDLCallbacksAlterCollectionProperties_PartialExternalUpdatePreservesOther(t *testing.T) {
+	core := initStreamingSystemAndCore(t)
+	ctx := context.Background()
+
+	dbName := "testDB" + funcutil.RandomString(10)
+	collectionName := "testPartialExt" + funcutil.RandomString(10)
+
+	resp, err := core.CreateDatabase(ctx, &milvuspb.CreateDatabaseRequest{DbName: dbName})
+	require.NoError(t, merr.CheckRPCCall(resp, err))
+	testSchema := &schemapb.CollectionSchema{
+		Name: collectionName,
+		Fields: []*schemapb.FieldSchema{
+			{Name: "field1", DataType: schemapb.DataType_Int64},
+		},
+		ExternalSource: "s3://bucket/old/",
+		ExternalSpec:   `{"format":"parquet","extfs":{"region":"us-east-1"}}`,
 	}
+	schemaBytes, err := proto.Marshal(testSchema)
+	require.NoError(t, err)
+	resp, err = core.CreateCollection(ctx, &milvuspb.CreateCollectionRequest{
+		DbName:           dbName,
+		CollectionName:   collectionName,
+		Schema:           schemaBytes,
+		ConsistencyLevel: commonpb.ConsistencyLevel_Bounded,
+	})
+	require.NoError(t, merr.CheckRPCCall(resp, err))
+
+	// Source-only update; spec must be preserved verbatim.
+	resp, err = core.AlterCollection(ctx, &milvuspb.AlterCollectionRequest{
+		DbName: dbName, CollectionName: collectionName,
+		Properties: []*commonpb.KeyValuePair{
+			{Key: common.CollectionExternalSource, Value: "s3://bucket/new/"},
+		},
+	})
+	require.NoError(t, merr.CheckRPCCall(resp, err))
+	assertExternalSource(t, ctx, core, dbName, collectionName, "s3://bucket/new/")
+	assertExternalSpec(t, ctx, core, dbName, collectionName, `{"format":"parquet","extfs":{"region":"us-east-1"}}`)
+}
+
+// Regression for #49335: alter that mixes external_source with a regular
+// property (e.g. consistency level or replica number) must update both halves
+// — the external tuple goes to the schema snapshot and the regular property
+// to the Properties map. Neither side may swallow the other.
+func TestDDLCallbacksAlterCollectionProperties_MixedExternalAndRegular(t *testing.T) {
+	core := initStreamingSystemAndCore(t)
+	ctx := context.Background()
+
+	dbName := "testDB" + funcutil.RandomString(10)
+	collectionName := "testMixedExt" + funcutil.RandomString(10)
+
+	resp, err := core.CreateDatabase(ctx, &milvuspb.CreateDatabaseRequest{DbName: dbName})
+	require.NoError(t, merr.CheckRPCCall(resp, err))
+	testSchema := &schemapb.CollectionSchema{
+		Name: collectionName,
+		Fields: []*schemapb.FieldSchema{
+			{Name: "field1", DataType: schemapb.DataType_Int64},
+		},
+		ExternalSource: "s3://bucket/old/",
+		ExternalSpec:   `{"format":"parquet"}`,
+	}
+	schemaBytes, err := proto.Marshal(testSchema)
+	require.NoError(t, err)
+	resp, err = core.CreateCollection(ctx, &milvuspb.CreateCollectionRequest{
+		DbName:           dbName,
+		CollectionName:   collectionName,
+		Properties:       []*commonpb.KeyValuePair{{Key: common.CollectionReplicaNumber, Value: "1"}},
+		Schema:           schemaBytes,
+		ConsistencyLevel: commonpb.ConsistencyLevel_Bounded,
+	})
+	require.NoError(t, merr.CheckRPCCall(resp, err))
+
+	resp, err = core.AlterCollection(ctx, &milvuspb.AlterCollectionRequest{
+		DbName: dbName, CollectionName: collectionName,
+		Properties: []*commonpb.KeyValuePair{
+			{Key: common.CollectionExternalSource, Value: "s3://bucket/new/"},
+			{Key: common.CollectionReplicaNumber, Value: "2"},
+		},
+	})
+	require.NoError(t, merr.CheckRPCCall(resp, err))
+	assertExternalSource(t, ctx, core, dbName, collectionName, "s3://bucket/new/")
+	assertReplicaNumber(t, ctx, core, dbName, collectionName, 2)
 }
 
 func createCollectionForTest(t *testing.T, ctx context.Context, core *Core, dbName string, collectionName string) {

--- a/internal/storagev2/packed/explore_ffi.go
+++ b/internal/storagev2/packed/explore_ffi.go
@@ -59,7 +59,13 @@ func filterFileInfosByFormat(fileInfos []FileInfo, format string) ([]FileInfo, i
 	return filtered, len(fileInfos) - len(filtered)
 }
 
-// FileInfo represents information about an external file
+// FileInfo represents information about an external file.
+//
+// WARNING: When produced by ExploreFiles (which calls loon_exttable_explore),
+// NumRows is the Loon end_index sentinel (-1 for parquet via PlainFormat::explore)
+// rather than a real row count. Do NOT compare NumRows against 0 or treat it as
+// a row total at this layer. Real row counts are only available after manifest
+// construction where Fragment.RowCount = endRow - startRow.
 type FileInfo struct {
 	FilePath string
 	NumRows  int64

--- a/internal/storagev2/packed/explore_ffi.go
+++ b/internal/storagev2/packed/explore_ffi.go
@@ -27,6 +27,7 @@ import "C"
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"unsafe"
 
@@ -57,6 +58,25 @@ func filterFileInfosByFormat(fileInfos []FileInfo, format string) ([]FileInfo, i
 		}
 	}
 	return filtered, len(fileInfos) - len(filtered)
+}
+
+// NormalizeFileInfos returns the manifest file list as it must be seen by
+// every consumer of the explore manifest: sorted lexicographically by
+// FilePath, then filtered to the requested format. Sorting is mandatory
+// because the underlying arrow filesystem GetFileInfo gives no ordering
+// guarantee — without it, DataCoord and DataNode would slice the same
+// fileIndex range against different orderings and pick different files
+// (leading to silent data loss or "Invalid parquet magic" task failures
+// when stray Spark `_SUCCESS`/`.crc`/README files land in the picked
+// window). Both DataCoord (when splitting tasks) and DataNode (when
+// resolving fileIndexBegin/End) MUST apply this transform on top of
+// ReadFileInfosFromManifestPath so they observe the same indexed view.
+func NormalizeFileInfos(fileInfos []FileInfo, format string) ([]FileInfo, int) {
+	// Sort by path first so lex order is stable across processes.
+	sort.Slice(fileInfos, func(i, j int) bool {
+		return fileInfos[i].FilePath < fileInfos[j].FilePath
+	})
+	return filterFileInfosByFormat(fileInfos, format)
 }
 
 // FileInfo represents information about an external file.
@@ -177,7 +197,10 @@ func ExploreFilesReturnManifestPath(
 		return nil, "", err
 	}
 
-	fileInfos, skipped := filterFileInfosByFormat(fileInfos, format)
+	// Sort + format-filter: produces a deterministic indexed view that
+	// DataNode will reproduce against the same manifest. See
+	// NormalizeFileInfos doc for the index-drift bug this prevents.
+	fileInfos, skipped := NormalizeFileInfos(fileInfos, format)
 	if skipped > 0 {
 		log.Info("Skipped files with non-matching format during explore",
 			zap.Int("skippedCount", skipped),

--- a/internal/storagev2/packed/exttable_test.go
+++ b/internal/storagev2/packed/exttable_test.go
@@ -493,6 +493,41 @@ func TestFilterFileInfosByFormat(t *testing.T) {
 	assert.Equal(t, 0, skipped)
 }
 
+// Regression for index-drift bug: DataCoord and DataNode both call
+// NormalizeFileInfos on the same raw manifest and MUST produce the
+// identical indexed view, regardless of input ordering. Without sort,
+// arrow's GetFileInfo can return files in different orders on each
+// process and the [fileIndexBegin, fileIndexEnd) slice picks different
+// files on the two sides, leading to silent data loss or "Invalid
+// parquet magic" failures on Spark `_SUCCESS`/`.crc` strays.
+func TestNormalizeFileInfos_StableSortAndFilter(t *testing.T) {
+	rawA := []FileInfo{
+		{FilePath: "data/_SUCCESS"},
+		{FilePath: "data/part-2.parquet"},
+		{FilePath: "data/.crc"},
+		{FilePath: "data/part-1.parquet"},
+		{FilePath: "data/README.md"},
+	}
+	// Reordered "DataNode side" view (arrow GetFileInfo gives no order).
+	rawB := []FileInfo{
+		{FilePath: "data/part-1.parquet"},
+		{FilePath: "data/README.md"},
+		{FilePath: "data/_SUCCESS"},
+		{FilePath: "data/part-2.parquet"},
+		{FilePath: "data/.crc"},
+	}
+
+	gotA, skippedA := NormalizeFileInfos(rawA, "parquet")
+	gotB, skippedB := NormalizeFileInfos(rawB, "parquet")
+
+	assert.Equal(t, 2, len(gotA))
+	assert.Equal(t, 3, skippedA)
+	assert.Equal(t, gotA, gotB, "two views of same manifest must produce identical indexed slice")
+	assert.Equal(t, "data/part-1.parquet", gotA[0].FilePath)
+	assert.Equal(t, "data/part-2.parquet", gotA[1].FilePath)
+	assert.Equal(t, skippedA, skippedB)
+}
+
 func TestMakePropertiesFromStorageConfig_ExtraKVsOverride(t *testing.T) {
 	// Test that extraKVs can add per-collection extfs properties
 	config := &indexpb.StorageConfig{

--- a/internal/storagev2/packed/utils.go
+++ b/internal/storagev2/packed/utils.go
@@ -198,9 +198,21 @@ func FetchFragmentsFromExternalSourceWithRange(
 	if err != nil {
 		return nil, fmt.Errorf("failed to read explore manifest: %w", err)
 	}
+	rawCount := len(fileInfos)
+	// Apply the same sort+format-filter that DataCoord used to derive
+	// fileIndexBegin/End. The manifest persists the raw arrow listing
+	// (Spark `_SUCCESS`, `.crc`, README, etc.) so slicing it directly
+	// against DataCoord's filtered indices would pick the wrong files —
+	// either a non-parquet stray triggering "Invalid parquet magic", or
+	// a real parquet getting silently dropped. NormalizeFileInfos must
+	// stay byte-for-byte identical to the DataCoord-side call so both
+	// indexed views agree.
+	fileInfos, skipped := NormalizeFileInfos(fileInfos, format)
 	log.Info("Read file list from explore manifest",
 		zap.String("manifestPath", exploreManifestPath),
-		zap.Int("totalFileCount", len(fileInfos)),
+		zap.Int("rawFileCount", rawCount),
+		zap.Int("normalizedFileCount", len(fileInfos)),
+		zap.Int("skippedNonFormat", skipped),
 		zap.Duration("readDuration", time.Since(exploreStart)))
 
 	// Slice to assigned range.

--- a/pkg/util/externalspec/external_spec.go
+++ b/pkg/util/externalspec/external_spec.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/url"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
@@ -103,10 +104,54 @@ var validCloudProviders = map[string]bool{
 
 // ExternalSpec represents the parsed external collection specification
 type ExternalSpec struct {
-	Format     string            `json:"format"`                       // one of Format* constants
-	Columns    []string          `json:"columns"`                      // optional: specific columns to load
-	Extfs      map[string]string `json:"extfs,omitempty"`              // optional: extfs config overrides (non-sensitive only)
-	SnapshotID *int64            `json:"snapshot_id,string,omitempty"` // Iceberg snapshot ID (required for iceberg-table); string-encoded to preserve int64 precision in JS/JSON clients
+	Format     string            `json:"format"`          // one of Format* constants
+	Columns    []string          `json:"columns"`         // optional: specific columns to load
+	Extfs      map[string]string `json:"extfs,omitempty"` // optional: extfs config overrides (non-sensitive only)
+	SnapshotID *int64            `json:"snapshot_id,omitempty"`
+}
+
+func (s *ExternalSpec) UnmarshalJSON(data []byte) error {
+	type externalSpec ExternalSpec
+	var raw struct {
+		externalSpec
+		SnapshotID json.RawMessage `json:"snapshot_id"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	*s = ExternalSpec(raw.externalSpec)
+	if len(raw.SnapshotID) == 0 || string(raw.SnapshotID) == "null" {
+		return nil
+	}
+	var n int64
+	if err := json.Unmarshal(raw.SnapshotID, &n); err == nil {
+		s.SnapshotID = &n
+		return nil
+	}
+	var str string
+	if err := json.Unmarshal(raw.SnapshotID, &str); err != nil {
+		return err
+	}
+	parsed, err := strconv.ParseInt(str, 10, 64)
+	if err != nil {
+		return err
+	}
+	s.SnapshotID = &parsed
+	return nil
+}
+
+func (s ExternalSpec) MarshalJSON() ([]byte, error) {
+	type externalSpec ExternalSpec
+	var raw struct {
+		externalSpec
+		SnapshotID *string `json:"snapshot_id,omitempty"`
+	}
+	raw.externalSpec = externalSpec(s)
+	if s.SnapshotID != nil {
+		str := strconv.FormatInt(*s.SnapshotID, 10)
+		raw.SnapshotID = &str
+	}
+	return json.Marshal(raw)
 }
 
 // supportedFormats lists the file formats supported for external collections

--- a/pkg/util/externalspec/external_spec.go
+++ b/pkg/util/externalspec/external_spec.go
@@ -103,9 +103,9 @@ var validCloudProviders = map[string]bool{
 
 // ExternalSpec represents the parsed external collection specification
 type ExternalSpec struct {
-	Format     string            `json:"format"`                // one of Format* constants
-	Columns    []string          `json:"columns"`               // optional: specific columns to load
-	Extfs      map[string]string `json:"extfs,omitempty"`       // optional: extfs config overrides (non-sensitive only)
+	Format     string            `json:"format"`                       // one of Format* constants
+	Columns    []string          `json:"columns"`                      // optional: specific columns to load
+	Extfs      map[string]string `json:"extfs,omitempty"`              // optional: extfs config overrides (non-sensitive only)
 	SnapshotID *int64            `json:"snapshot_id,string,omitempty"` // Iceberg snapshot ID (required for iceberg-table); string-encoded to preserve int64 precision in JS/JSON clients
 }
 

--- a/pkg/util/externalspec/external_spec.go
+++ b/pkg/util/externalspec/external_spec.go
@@ -87,7 +87,7 @@ type ExternalSpec struct {
 	Format     string            `json:"format"`                // one of Format* constants
 	Columns    []string          `json:"columns"`               // optional: specific columns to load
 	Extfs      map[string]string `json:"extfs,omitempty"`       // optional: extfs config overrides (non-sensitive only)
-	SnapshotID *int64            `json:"snapshot_id,omitempty"` // Iceberg snapshot ID (required for iceberg-table)
+	SnapshotID *int64            `json:"snapshot_id,string,omitempty"` // Iceberg snapshot ID (required for iceberg-table); string-encoded to preserve int64 precision in JS/JSON clients
 }
 
 // supportedFormats lists the file formats supported for external collections

--- a/pkg/util/externalspec/external_spec.go
+++ b/pkg/util/externalspec/external_spec.go
@@ -80,7 +80,26 @@ const (
 	CloudProviderTencent = "tencent"
 	CloudProviderHuawei  = "huawei"
 	CloudProviderAzure   = "azure"
+	// CloudProviderMinIO opts the request into Milvus-form URI parsing
+	// (scheme://endpoint/bucket/key). Use for self-hosted S3-compatible
+	// stores (MinIO, Ceph RGW, Garage, etc.) where no canonical cloud
+	// endpoint exists and the URI host must be treated as the endpoint.
+	CloudProviderMinIO = "minio"
 )
+
+// validCloudProviders gates extfs.cloud_provider values. Inference from URI
+// scheme was previously allowed but produced silent misconfiguration when a
+// scheme mapped to multiple providers (s3:// → AWS S3 vs self-hosted MinIO).
+// Forcing an explicit value moves the disambiguation to the API boundary.
+var validCloudProviders = map[string]bool{
+	CloudProviderAWS:     true,
+	CloudProviderGCP:     true,
+	CloudProviderAliyun:  true,
+	CloudProviderTencent: true,
+	CloudProviderHuawei:  true,
+	CloudProviderAzure:   true,
+	CloudProviderMinIO:   true,
+}
 
 // ExternalSpec represents the parsed external collection specification
 type ExternalSpec struct {
@@ -256,6 +275,20 @@ func ValidateSourceAndSpec(externalSource, externalSpec string) error {
 // anonymous=true), and region for AWS-family schemes. role_arn subsumes
 // use_iam (do not double-count). No inheritance from Milvus fs.* config.
 func ValidateExtfsComplete(externalSource string, extfs map[string]string) error {
+	// extfs.cloud_provider is required and must be from the allowed set.
+	// Inferring cloud_provider from URI scheme is ambiguous (s3:// matches
+	// AWS S3 and self-hosted MinIO; no scheme-only signal can pick the
+	// correct URI parsing form, auth protocol, or default endpoint). Force
+	// the caller to be explicit so misconfiguration fails at the API
+	// boundary instead of silently routing to the wrong backend.
+	cp := strings.ToLower(extfs[ExtfsKeyCloudProvider])
+	if cp == "" {
+		return fmt.Errorf("extfs.cloud_provider is required: one of [aws, gcp, aliyun, tencent, huawei, azure, minio]; inferring from URI scheme is ambiguous (e.g. s3:// matches both AWS S3 and self-hosted MinIO)")
+	}
+	if !validCloudProviders[cp] {
+		return fmt.Errorf("extfs.cloud_provider=%q is not supported: must be one of [aws, gcp, aliyun, tencent, huawei, azure, minio]", cp)
+	}
+
 	hasAKSK := extfs[ExtfsKeyAccessKeyID] != "" && extfs[ExtfsKeyAccessKeyValue] != ""
 	hasAKOnly := (extfs[ExtfsKeyAccessKeyID] != "") != (extfs[ExtfsKeyAccessKeyValue] != "")
 	hasRoleARN := extfs[ExtfsKeyRoleARN] != ""
@@ -288,7 +321,6 @@ func ValidateExtfsComplete(externalSource string, extfs map[string]string) error
 	}
 
 	if hasGCPImpersonation {
-		cp := strings.ToLower(extfs[ExtfsKeyCloudProvider])
 		if scheme != "" && scheme != SchemeGS && scheme != SchemeGCS && cp != CloudProviderGCP {
 			return fmt.Errorf("extfs.gcp_target_service_account is only valid for GCP (scheme=gs/gcs or cloud_provider=gcp), got scheme=%q cloud_provider=%q", scheme, cp)
 		}
@@ -302,14 +334,13 @@ func ValidateExtfsComplete(externalSource string, extfs map[string]string) error
 		return fmt.Errorf("extfs.region is required for scheme %q (AWS-family schemes need region for SigV4 signing)", scheme)
 	}
 
-	// Azure consistency: scheme=azure requires cloud_provider=azure (or unset),
-	// and cloud_provider=azure requires scheme=azure. Pairing guards against
+	// Azure consistency: scheme=azure requires cloud_provider=azure, and
+	// cloud_provider=azure requires scheme=azure. Pairing guards against
 	// misconfigured dispatch to a non-Azure storage backend.
-	cpLower := strings.ToLower(extfs[ExtfsKeyCloudProvider])
-	if scheme == SchemeAzure && cpLower != "" && cpLower != CloudProviderAzure {
-		return fmt.Errorf("scheme=azure requires extfs.cloud_provider to be %q or unset, got %q", CloudProviderAzure, cpLower)
+	if scheme == SchemeAzure && cp != CloudProviderAzure {
+		return fmt.Errorf("scheme=azure requires extfs.cloud_provider=%q, got %q", CloudProviderAzure, cp)
 	}
-	if cpLower == CloudProviderAzure && scheme != "" && scheme != SchemeAzure {
+	if cp == CloudProviderAzure && scheme != "" && scheme != SchemeAzure {
 		return fmt.Errorf("extfs.cloud_provider=azure requires scheme=azure, got scheme=%q", scheme)
 	}
 
@@ -333,26 +364,11 @@ func ValidateExtfsComplete(externalSource string, extfs map[string]string) error
 			pathSegs = 0
 		}
 		if pathSegs <= 1 {
-			// AWS-form: endpoint must be derivable. Infer cloud_provider
-			// from scheme when omitted (conventional mapping). minio stays
-			// empty — it has no canonical cp and must use Milvus-form URI.
-			effectiveCP := cpLower
-			if effectiveCP == "" {
-				switch scheme {
-				case SchemeS3, SchemeS3A, SchemeAWS:
-					effectiveCP = CloudProviderAWS
-				case SchemeGS, SchemeGCS:
-					effectiveCP = CloudProviderGCP
-				case SchemeOSS:
-					effectiveCP = CloudProviderAliyun
-				case SchemeCOS:
-					effectiveCP = CloudProviderTencent
-				case SchemeOBS:
-					effectiveCP = CloudProviderHuawei
-				}
-			}
-			if DeriveEndpoint(effectiveCP, extfs[ExtfsKeyRegion]) == "" {
-				return fmt.Errorf("cannot resolve endpoint for %q: set extfs.cloud_provider + extfs.region, or use Milvus-form URI scheme://<endpoint>/<bucket>/<key>", externalSource)
+			// AWS-form: endpoint must be derivable from the user-supplied
+			// cloud_provider + region. cp=minio has no canonical endpoint
+			// and must use Milvus-form URI to embed the host explicitly.
+			if DeriveEndpoint(cp, extfs[ExtfsKeyRegion]) == "" {
+				return fmt.Errorf("cannot resolve endpoint for %q with cloud_provider=%q: set extfs.region, or use Milvus-form URI scheme://<endpoint>/<bucket>/<key>", externalSource, cp)
 			}
 		}
 	}

--- a/pkg/util/externalspec/external_spec_test.go
+++ b/pkg/util/externalspec/external_spec_test.go
@@ -155,7 +155,7 @@ func TestValidateExternalSource(t *testing.T) {
 // minimalValidSpec returns an extfs block that ValidateExtfsComplete accepts
 // for AWS-family schemes: AK/SK pair + region.
 func minimalValidSpec() string {
-	return `{"format":"parquet","extfs":{"access_key_id":"AK","access_key_value":"SK","region":"us-east-1"}}`
+	return `{"format":"parquet","extfs":{"access_key_id":"AK","access_key_value":"SK","region":"us-east-1","cloud_provider":"aws"}}`
 }
 
 func TestValidateSourceAndSpec(t *testing.T) {
@@ -183,91 +183,111 @@ func TestValidateSourceAndSpec(t *testing.T) {
 
 	t.Run("missing_region_for_aws_scheme_rejected", func(t *testing.T) {
 		err := ValidateSourceAndSpec("s3://bucket/prefix",
-			`{"format":"parquet","extfs":{"access_key_id":"AK","access_key_value":"SK"}}`)
+			`{"format":"parquet","extfs":{"access_key_id":"AK","access_key_value":"SK","cloud_provider":"aws"}}`)
 		require.Error(t, err)
+	})
+
+	t.Run("missing_cloud_provider_rejected", func(t *testing.T) {
+		err := ValidateSourceAndSpec("s3://bucket/prefix",
+			`{"format":"parquet","extfs":{"access_key_id":"AK","access_key_value":"SK","region":"us-east-1"}}`)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cloud_provider is required")
+	})
+
+	t.Run("invalid_cloud_provider_rejected", func(t *testing.T) {
+		err := ValidateSourceAndSpec("s3://bucket/prefix",
+			`{"format":"parquet","extfs":{"access_key_id":"AK","access_key_value":"SK","region":"us-east-1","cloud_provider":"unknown"}}`)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "is not supported")
+	})
+
+	t.Run("minio_cloud_provider_milvus_form", func(t *testing.T) {
+		err := ValidateSourceAndSpec("s3://localhost:9000/mybucket/path",
+			`{"format":"parquet","extfs":{"access_key_id":"AK","access_key_value":"SK","region":"us-east-1","cloud_provider":"minio"}}`)
+		assert.NoError(t, err)
 	})
 
 	t.Run("gcs_scheme_does_not_require_region", func(t *testing.T) {
 		err := ValidateSourceAndSpec("gs://bucket/prefix",
-			`{"format":"parquet","extfs":{"access_key_id":"AK","access_key_value":"SK"}}`)
+			`{"format":"parquet","extfs":{"access_key_id":"AK","access_key_value":"SK","cloud_provider":"gcp"}}`)
 		assert.NoError(t, err)
 	})
 
 	t.Run("role_arn_mode", func(t *testing.T) {
 		err := ValidateSourceAndSpec("s3://bucket/prefix",
-			`{"format":"parquet","extfs":{"role_arn":"arn:aws:iam::1:role/r","region":"us-east-1"}}`)
+			`{"format":"parquet","extfs":{"role_arn":"arn:aws:iam::1:role/r","region":"us-east-1","cloud_provider":"aws"}}`)
 		assert.NoError(t, err)
 	})
 
 	t.Run("use_iam_alone_mode", func(t *testing.T) {
 		err := ValidateSourceAndSpec("s3://bucket/prefix",
-			`{"format":"parquet","extfs":{"use_iam":"true","region":"us-east-1"}}`)
+			`{"format":"parquet","extfs":{"use_iam":"true","region":"us-east-1","cloud_provider":"aws"}}`)
 		assert.NoError(t, err)
 	})
 
 	t.Run("anonymous_mode", func(t *testing.T) {
 		err := ValidateSourceAndSpec("s3://bucket/prefix",
-			`{"format":"parquet","extfs":{"anonymous":"true","region":"us-east-1"}}`)
+			`{"format":"parquet","extfs":{"anonymous":"true","region":"us-east-1","cloud_provider":"aws"}}`)
 		assert.NoError(t, err)
 	})
 
 	t.Run("ak_without_sk_rejected", func(t *testing.T) {
 		err := ValidateSourceAndSpec("s3://bucket/prefix",
-			`{"format":"parquet","extfs":{"access_key_id":"AK","region":"us-east-1"}}`)
+			`{"format":"parquet","extfs":{"access_key_id":"AK","region":"us-east-1","cloud_provider":"aws"}}`)
 		require.Error(t, err)
 	})
 
 	t.Run("anonymous_with_aksk_rejected", func(t *testing.T) {
 		err := ValidateSourceAndSpec("s3://bucket/prefix",
-			`{"format":"parquet","extfs":{"anonymous":"true","access_key_id":"AK","access_key_value":"SK","region":"us-east-1"}}`)
+			`{"format":"parquet","extfs":{"anonymous":"true","access_key_id":"AK","access_key_value":"SK","region":"us-east-1","cloud_provider":"aws"}}`)
 		require.Error(t, err)
 	})
 
 	t.Run("multiple_modes_rejected", func(t *testing.T) {
 		err := ValidateSourceAndSpec("s3://bucket/prefix",
-			`{"format":"parquet","extfs":{"role_arn":"arn:aws:iam::1:role/r","access_key_id":"AK","access_key_value":"SK","region":"us-east-1"}}`)
+			`{"format":"parquet","extfs":{"role_arn":"arn:aws:iam::1:role/r","access_key_id":"AK","access_key_value":"SK","region":"us-east-1","cloud_provider":"aws"}}`)
 		require.Error(t, err)
 	})
 
 	t.Run("gcp_impersonation_mode", func(t *testing.T) {
 		err := ValidateSourceAndSpec("gs://bucket/prefix",
-			`{"format":"parquet","extfs":{"gcp_target_service_account":"sa@proj.iam.gserviceaccount.com"}}`)
+			`{"format":"parquet","extfs":{"gcp_target_service_account":"sa@proj.iam.gserviceaccount.com","cloud_provider":"gcp"}}`)
 		assert.NoError(t, err)
 	})
 
 	t.Run("gcp_impersonation_with_gcs_scheme", func(t *testing.T) {
 		err := ValidateSourceAndSpec("gcs://bucket/prefix",
-			`{"format":"parquet","extfs":{"gcp_target_service_account":"sa@proj.iam.gserviceaccount.com"}}`)
+			`{"format":"parquet","extfs":{"gcp_target_service_account":"sa@proj.iam.gserviceaccount.com","cloud_provider":"gcp"}}`)
 		assert.NoError(t, err)
 	})
 
 	t.Run("gcp_impersonation_on_aws_scheme_rejected", func(t *testing.T) {
 		err := ValidateSourceAndSpec("s3://bucket/prefix",
-			`{"format":"parquet","extfs":{"gcp_target_service_account":"sa@proj.iam.gserviceaccount.com","region":"us-east-1"}}`)
+			`{"format":"parquet","extfs":{"gcp_target_service_account":"sa@proj.iam.gserviceaccount.com","region":"us-east-1","cloud_provider":"aws"}}`)
 		require.Error(t, err)
 	})
 
 	t.Run("gcp_impersonation_malformed_email_rejected", func(t *testing.T) {
 		err := ValidateSourceAndSpec("gs://bucket/prefix",
-			`{"format":"parquet","extfs":{"gcp_target_service_account":"not-an-email"}}`)
+			`{"format":"parquet","extfs":{"gcp_target_service_account":"not-an-email","cloud_provider":"gcp"}}`)
 		require.Error(t, err)
 	})
 
 	t.Run("gcp_impersonation_missing_at_sign_rejected", func(t *testing.T) {
 		err := ValidateSourceAndSpec("gs://bucket/prefix",
-			`{"format":"parquet","extfs":{"gcp_target_service_account":"saproj.iam.gserviceaccount.com"}}`)
+			`{"format":"parquet","extfs":{"gcp_target_service_account":"saproj.iam.gserviceaccount.com","cloud_provider":"gcp"}}`)
 		require.Error(t, err)
 	})
 
 	t.Run("gcp_impersonation_with_aksk_rejected", func(t *testing.T) {
 		err := ValidateSourceAndSpec("gs://bucket/prefix",
-			`{"format":"parquet","extfs":{"gcp_target_service_account":"sa@proj.iam.gserviceaccount.com","access_key_id":"AK","access_key_value":"SK"}}`)
+			`{"format":"parquet","extfs":{"gcp_target_service_account":"sa@proj.iam.gserviceaccount.com","access_key_id":"AK","access_key_value":"SK","cloud_provider":"gcp"}}`)
 		require.Error(t, err)
 	})
 
 	t.Run("gcp_impersonation_with_anonymous_rejected", func(t *testing.T) {
 		err := ValidateSourceAndSpec("gs://bucket/prefix",
-			`{"format":"parquet","extfs":{"gcp_target_service_account":"sa@proj.iam.gserviceaccount.com","anonymous":"true"}}`)
+			`{"format":"parquet","extfs":{"gcp_target_service_account":"sa@proj.iam.gserviceaccount.com","anonymous":"true","cloud_provider":"gcp"}}`)
 		require.Error(t, err)
 	})
 }
@@ -364,6 +384,7 @@ func TestValidateExtfsComplete_Azure(t *testing.T) {
 		err := ValidateExtfsComplete("azure://core.windows.net/container/path", map[string]string{
 			"access_key_id":    "mystorageacct",
 			"access_key_value": "base64key",
+			"cloud_provider":   "azure",
 		})
 		assert.NoError(t, err)
 	})
@@ -392,6 +413,7 @@ func TestValidateExtfsComplete_Azure(t *testing.T) {
 	t.Run("azure_with_gcp_target_service_account_rejected", func(t *testing.T) {
 		err := ValidateExtfsComplete("azure://core.windows.net/container/path", map[string]string{
 			"gcp_target_service_account": "sa@proj.iam.gserviceaccount.com",
+			"cloud_provider":             "azure",
 		})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "only valid for GCP")

--- a/pkg/util/externalspec/external_spec_test.go
+++ b/pkg/util/externalspec/external_spec_test.go
@@ -397,3 +397,33 @@ func TestValidateExtfsComplete_Azure(t *testing.T) {
 		assert.Contains(t, err.Error(), "only valid for GCP")
 	})
 }
+
+// TestParseExternalSpec_SnapshotIDStringEncoded covers the JS/JSON-safe
+// string form of snapshot_id (Iceberg int64 IDs exceed JS Number.MAX_SAFE_INTEGER).
+// Bare-number form is rejected by `,string` json tag — clients must quote the value.
+func TestParseExternalSpec_SnapshotIDStringEncoded(t *testing.T) {
+	t.Run("string_form_accepted", func(t *testing.T) {
+		spec, err := ParseExternalSpec(`{"format":"iceberg-table","snapshot_id":"5320540205222981137"}`)
+		require.NoError(t, err)
+		require.NotNil(t, spec.SnapshotID)
+		assert.Equal(t, int64(5320540205222981137), *spec.SnapshotID)
+	})
+
+	t.Run("bare_number_rejected", func(t *testing.T) {
+		_, err := ParseExternalSpec(`{"format":"iceberg-table","snapshot_id":5320540205222981137}`)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid external spec JSON")
+	})
+
+	t.Run("non_numeric_string_rejected", func(t *testing.T) {
+		_, err := ParseExternalSpec(`{"format":"iceberg-table","snapshot_id":"abc"}`)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid external spec JSON")
+	})
+
+	t.Run("omitted_yields_nil", func(t *testing.T) {
+		spec, err := ParseExternalSpec(`{"format":"iceberg-table"}`)
+		require.NoError(t, err)
+		assert.Nil(t, spec.SnapshotID)
+	})
+}

--- a/pkg/util/externalspec/external_spec_test.go
+++ b/pkg/util/externalspec/external_spec_test.go
@@ -420,10 +420,7 @@ func TestValidateExtfsComplete_Azure(t *testing.T) {
 	})
 }
 
-// TestParseExternalSpec_SnapshotIDStringEncoded covers the JS/JSON-safe
-// string form of snapshot_id (Iceberg int64 IDs exceed JS Number.MAX_SAFE_INTEGER).
-// Bare-number form is rejected by `,string` json tag — clients must quote the value.
-func TestParseExternalSpec_SnapshotIDStringEncoded(t *testing.T) {
+func TestParseExternalSpec_SnapshotID(t *testing.T) {
 	t.Run("string_form_accepted", func(t *testing.T) {
 		spec, err := ParseExternalSpec(`{"format":"iceberg-table","snapshot_id":"5320540205222981137"}`)
 		require.NoError(t, err)
@@ -431,10 +428,11 @@ func TestParseExternalSpec_SnapshotIDStringEncoded(t *testing.T) {
 		assert.Equal(t, int64(5320540205222981137), *spec.SnapshotID)
 	})
 
-	t.Run("bare_number_rejected", func(t *testing.T) {
-		_, err := ParseExternalSpec(`{"format":"iceberg-table","snapshot_id":5320540205222981137}`)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "invalid external spec JSON")
+	t.Run("bare_number_accepted", func(t *testing.T) {
+		spec, err := ParseExternalSpec(`{"format":"iceberg-table","snapshot_id":5320540205222981137}`)
+		require.NoError(t, err)
+		require.NotNil(t, spec.SnapshotID)
+		assert.Equal(t, int64(5320540205222981137), *spec.SnapshotID)
 	})
 
 	t.Run("non_numeric_string_rejected", func(t *testing.T) {
@@ -448,4 +446,10 @@ func TestParseExternalSpec_SnapshotIDStringEncoded(t *testing.T) {
 		require.NoError(t, err)
 		assert.Nil(t, spec.SnapshotID)
 	})
+}
+
+func TestRedactExternalSpec_SnapshotIDNumber(t *testing.T) {
+	redacted := RedactExternalSpec(`{"format":"iceberg-table","snapshot_id":5320540205222981137}`)
+	assert.Contains(t, redacted, `"snapshot_id":"5320540205222981137"`)
+	assert.NotEqual(t, "<invalid spec>", redacted)
 }

--- a/tests/go_client/testcases/collection_test.go
+++ b/tests/go_client/testcases/collection_test.go
@@ -584,6 +584,39 @@ func TestCreateCollectionWithInvalidFieldName(t *testing.T) {
 	}
 }
 
+// Regression for #49314: field names reserved by the server
+// (__virtual_pk__ auto-injected for external collections; RowID and
+// Timestamp segcore-internal columns) must be rejected at
+// CreateCollection for both regular and external collections.
+func TestCreateCollectionRejectsReservedFieldNames(t *testing.T) {
+	t.Parallel()
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	reserved := []string{"__virtual_pk__", "RowID", "Timestamp"}
+
+	for _, name := range reserved {
+		name := name
+		t.Run(name+"_as_pk", func(t *testing.T) {
+			collName := common.GenRandomString("reserved", 6)
+			pk := entity.NewField().WithName(name).WithDataType(entity.FieldTypeInt64).WithIsPrimaryKey(true)
+			vec := entity.NewField().WithName("vec").WithDataType(entity.FieldTypeFloatVector).WithDim(8)
+			schema := entity.NewSchema().WithName(collName).WithField(pk).WithField(vec)
+			err := mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
+			common.CheckErr(t, err, false, "reserved")
+		})
+		t.Run(name+"_as_scalar", func(t *testing.T) {
+			collName := common.GenRandomString("reserved", 6)
+			pk := entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithIsPrimaryKey(true)
+			scalar := entity.NewField().WithName(name).WithDataType(entity.FieldTypeInt64)
+			vec := entity.NewField().WithName("vec").WithDataType(entity.FieldTypeFloatVector).WithDim(8)
+			schema := entity.NewSchema().WithName(collName).WithField(pk).WithField(scalar).WithField(vec)
+			err := mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
+			common.CheckErr(t, err, false, "reserved")
+		})
+	}
+}
+
 // create collection with invalid collection name: invalid str, schemaName isn't equal to collectionName, schema name is empty
 func TestCreateCollectionWithInvalidCollectionName(t *testing.T) {
 	t.Parallel()

--- a/tests/go_client/testcases/external_table_iceberg_e2e_test.go
+++ b/tests/go_client/testcases/external_table_iceberg_e2e_test.go
@@ -325,7 +325,12 @@ func TestExternalCollectionMultipleDataTypesIceberg(t *testing.T) {
 			"region":           "us-east-1",
 			"use_ssl":          "false",
 			"use_virtual_host": "false",
-			"cloud_provider":   "aws",
+			// `minio` sentinel: tells milvus to treat URI host as
+			// endpoint instead of swapping for AWS canonical endpoint.
+			// `aws` would derive s3.us-east-1.amazonaws.com and fail
+			// the (address, bucket) lookup against the URI host
+			// `localhost:9000`.
+			"cloud_provider":   "minio",
 			"access_key_id":    minioAccessKey,
 			"access_key_value": minioSecretKey,
 		},

--- a/tests/go_client/testcases/external_table_iceberg_e2e_test.go
+++ b/tests/go_client/testcases/external_table_iceberg_e2e_test.go
@@ -1,6 +1,7 @@
 package testcases
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -81,7 +82,7 @@ func TestExternalTableIcebergE2E(t *testing.T) {
 	// Build ExternalSpec with extfs for MinIO access (same pattern as cross-bucket parquet E2E)
 	type externalSpecJSON struct {
 		Format     string            `json:"format"`
-		SnapshotID int64             `json:"snapshot_id"`
+		SnapshotID int64             `json:"snapshot_id,string"`
 		Extfs      map[string]string `json:"extfs,omitempty"`
 	}
 	specObj := externalSpecJSON{
@@ -248,4 +249,103 @@ func icebergEnvOrDefault(key, defaultVal string) string {
 		return v
 	}
 	return defaultVal
+}
+
+// createIcebergMultiTypeTable runs the Python script to create the 18-column
+// multi-type iceberg table on MinIO.
+func createIcebergMultiTypeTable(t *testing.T, endpoint, accessKey, secretKey, bucket, tablePath string, numRows, vecDim, binVecDim int) icebergTableInfo {
+	t.Helper()
+
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok, "failed to get caller info")
+	scriptPath := filepath.Join(filepath.Dir(thisFile), "testdata", "create_iceberg_multi_type_table.py")
+	infoPath := filepath.Join(t.TempDir(), "iceberg_multi_type_info.json")
+
+	cmd := exec.Command("python3", scriptPath, // #nosec G204
+		"--endpoint", endpoint,
+		"--access-key", accessKey,
+		"--secret-key", secretKey,
+		"--bucket", bucket,
+		"--table-path", tablePath,
+		"--num-rows", fmt.Sprintf("%d", numRows),
+		"--vec-dim", fmt.Sprintf("%d", vecDim),
+		"--bin-vec-dim", fmt.Sprintf("%d", binVecDim),
+		"--output", infoPath,
+	)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	require.NoError(t, err, "failed to create iceberg multi-type table via Python script")
+
+	data, err := os.ReadFile(infoPath)
+	require.NoError(t, err)
+
+	var info icebergTableInfo
+	require.NoError(t, json.Unmarshal(data, &info))
+	return info
+}
+
+// TestExternalCollectionMultipleDataTypesIceberg mirrors the parquet/vortex/lance
+// multi-type tests for the iceberg-table source. Iceberg lacks Int8/Int16
+// primitives so int8_val/int16_val are widened to Int32 in the source schema;
+// milvus narrows them on read.
+func TestExternalCollectionMultipleDataTypesIceberg(t *testing.T) {
+	t.Parallel()
+
+	if err := checkPythonDeps("python3", "pyarrow", "pyiceberg"); err != nil {
+		t.Skipf("Python deps for Iceberg unavailable, skipping: %v", err)
+	}
+
+	minioAddr := envOrDefault("MINIO_ADDRESS", "localhost:9000")
+	minioEndpoint := icebergEnvOrDefault("ICEBERG_MINIO_ENDPOINT", "http://"+minioAddr)
+	minioAccessKey := icebergEnvOrDefault("ICEBERG_MINIO_ACCESS_KEY", "minioadmin")
+	minioSecretKey := icebergEnvOrDefault("ICEBERG_MINIO_SECRET_KEY", "minioadmin")
+	bucket := icebergEnvOrDefault("ICEBERG_MINIO_BUCKET", "a-bucket")
+
+	collName := common.GenRandomString("ext_multi_iceberg", 6)
+	tablePath := fmt.Sprintf("iceberg-test/%s", collName)
+
+	const numRows = 100
+	tableInfo := createIcebergMultiTypeTable(t, minioEndpoint, minioAccessKey,
+		minioSecretKey, bucket, tablePath, numRows, testVecDim, testBinVecDim)
+
+	minioHost := strings.TrimPrefix(strings.TrimPrefix(minioEndpoint, "http://"), "https://")
+	externalSource := toMilvusURI(tableInfo.MetadataLocation, minioHost)
+
+	type externalSpecJSON struct {
+		Format     string            `json:"format"`
+		SnapshotID int64             `json:"snapshot_id,string"`
+		Extfs      map[string]string `json:"extfs,omitempty"`
+	}
+	specObj := externalSpecJSON{
+		Format:     "iceberg-table",
+		SnapshotID: tableInfo.SnapshotID,
+		Extfs: map[string]string{
+			"bucket_name":      bucket,
+			"region":           "us-east-1",
+			"use_ssl":          "false",
+			"use_virtual_host": "false",
+			"cloud_provider":   "aws",
+			"access_key_id":    minioAccessKey,
+			"access_key_value": minioSecretKey,
+		},
+	}
+	specBytes, err := json.Marshal(specObj)
+	require.NoError(t, err)
+	externalSpec := string(specBytes)
+
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	t.Cleanup(func() {
+		_ = mc.DropCollection(context.Background(), client.NewDropCollectionOption(collName))
+	})
+
+	schema := buildMultiTypeExternalSchema(collName, externalSource, externalSpec)
+
+	err = mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, true)
+	t.Logf("Created multi-type iceberg external collection: %s", collName)
+
+	runMultiTypeRefreshIndexLoadVerifyWithSourceSpec(ctx, t, mc, collName, int64(numRows), externalSource, externalSpec)
 }

--- a/tests/go_client/testcases/external_table_refresh_test.go
+++ b/tests/go_client/testcases/external_table_refresh_test.go
@@ -1232,7 +1232,8 @@ func TestExternalCollectionMultipleDataTypes(t *testing.T) {
 // generateMultiTypeParquetBytes / generate_multi_type_vortex_data.py with
 // the given numRows.
 func runMultiTypeRefreshIndexLoadVerify(ctx context.Context, t *testing.T,
-	mc *base.MilvusClient, collName string, numRows int64) {
+	mc *base.MilvusClient, collName string, numRows int64,
+) {
 	runMultiTypeRefreshIndexLoadVerifyWithSourceSpec(ctx, t, mc, collName, numRows, "", "")
 }
 
@@ -1240,7 +1241,8 @@ func runMultiTypeRefreshIndexLoadVerify(ctx context.Context, t *testing.T,
 // source+spec (used by iceberg paths that re-supply extfs credentials on
 // refresh; proxy now enforces both-or-neither).
 func runMultiTypeRefreshIndexLoadVerifyWithSourceSpec(ctx context.Context, t *testing.T,
-	mc *base.MilvusClient, collName string, numRows int64, refreshSource, refreshSpec string) {
+	mc *base.MilvusClient, collName string, numRows int64, refreshSource, refreshSpec string,
+) {
 	// ---------------------------------------------------------------
 	// Step 3: Refresh + index all vector fields + load
 	// ---------------------------------------------------------------
@@ -1540,7 +1542,6 @@ func runMultiTypeRefreshIndexLoadVerifyWithSourceSpec(ctx context.Context, t *te
 	require.Equal(t, 25, compoundRes.GetColumn("id").Len(),
 		`compound filter: bool_val==true AND int32_val<5000 AND varchar like "str_00%" → 25 rows`)
 	t.Log("Compound filter across types (incl. varchar) passed")
-
 }
 
 // --- Lance format helpers ---
@@ -3353,7 +3354,10 @@ func TestRefreshExternalCollectionOverridePersistsNewSource(t *testing.T) {
 	require.NoError(t, err)
 	dataB, err := generateParquetBytes(8, 1000)
 	require.NoError(t, err)
-	for _, p := range []struct{ path string; bytes []byte }{{pathA, dataA}, {pathB, dataB}} {
+	for _, p := range []struct {
+		path  string
+		bytes []byte
+	}{{pathA, dataA}, {pathB, dataB}} {
 		_, err = minioClient.PutObject(ctx, minioCfg.bucket,
 			fmt.Sprintf("%s/data.parquet", p.path),
 			bytes.NewReader(p.bytes), int64(len(p.bytes)),
@@ -3468,11 +3472,11 @@ func TestRefreshExternalCollectionFiltersNonParquetStrays(t *testing.T) {
 	}
 	// Stray non-parquet files interleaved by lex order with the parquets.
 	strays := map[string][]byte{
-		"_SUCCESS":     []byte(""),
-		"_committed":   []byte("xyz"),
-		"part-00.crc":  []byte("crc-checksum-bytes"),
-		"README.md":    []byte("# this dir\n"),
-		"metadata":     []byte(`{"v":1}`),
+		"_SUCCESS":    []byte(""),
+		"_committed":  []byte("xyz"),
+		"part-00.crc": []byte("crc-checksum-bytes"),
+		"README.md":   []byte("# this dir\n"),
+		"metadata":    []byte(`{"v":1}`),
 	}
 	for name, payload := range strays {
 		_, err = minioClient.PutObject(ctx, minioCfg.bucket,

--- a/tests/go_client/testcases/external_table_refresh_test.go
+++ b/tests/go_client/testcases/external_table_refresh_test.go
@@ -3218,3 +3218,104 @@ func waitRefreshTerminal(t *testing.T, ctx context.Context, mc *client.Client, j
 		}
 	}
 }
+
+// Regression for the explore-manifest index-drift bug: the source
+// directory is intentionally polluted with non-parquet strays
+// (`_SUCCESS`, `.crc`, `README.md`) interleaved with valid parquet
+// shards. Pre-fix, DataCoord filtered them out before slicing tasks
+// while DataNode read the unfiltered manifest and sliced against the
+// stale index space — picking `_SUCCESS` as a "parquet" file and
+// failing with "Invalid parquet magic" or silently dropping a real
+// shard. Post-fix, both layers normalize (sort + format-filter) the
+// manifest identically, so refresh completes and total row count
+// matches the sum of the parquet shards only.
+func TestRefreshExternalCollectionFiltersNonParquetStrays(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	minioCfg := getMinIOConfig()
+	minioClient, err := newMinIOClient(minioCfg)
+	require.NoError(t, err)
+	exists, err := minioClient.BucketExists(ctx, minioCfg.bucket)
+	if err != nil || !exists {
+		t.Skipf("MinIO bucket %q not accessible, skipping", minioCfg.bucket)
+	}
+
+	collName := common.GenRandomString("ext_strays", 6)
+	extPath := fmt.Sprintf("external-e2e-test/%s", collName)
+
+	// 3 valid parquet shards, varying sizes to detect index drift.
+	const rowsPerShard = int64(8)
+	const numShards = 3
+	for i := 0; i < numShards; i++ {
+		data, err := generateParquetBytes(rowsPerShard, int64(i)*rowsPerShard)
+		require.NoError(t, err)
+		_, err = minioClient.PutObject(ctx, minioCfg.bucket,
+			fmt.Sprintf("%s/part-%05d.parquet", extPath, i),
+			bytes.NewReader(data), int64(len(data)),
+			miniogo.PutObjectOptions{ContentType: "application/octet-stream"})
+		require.NoError(t, err)
+	}
+	// Stray non-parquet files interleaved by lex order with the parquets.
+	strays := map[string][]byte{
+		"_SUCCESS":     []byte(""),
+		"_committed":   []byte("xyz"),
+		"part-00.crc":  []byte("crc-checksum-bytes"),
+		"README.md":    []byte("# this dir\n"),
+		"metadata":     []byte(`{"v":1}`),
+	}
+	for name, payload := range strays {
+		_, err = minioClient.PutObject(ctx, minioCfg.bucket,
+			fmt.Sprintf("%s/%s", extPath, name),
+			bytes.NewReader(payload), int64(len(payload)),
+			miniogo.PutObjectOptions{ContentType: "application/octet-stream"})
+		require.NoError(t, err)
+	}
+	t.Cleanup(func() {
+		cleanupMinIOPrefix(context.Background(), minioClient, minioCfg.bucket,
+			fmt.Sprintf("%s/", extPath))
+	})
+
+	schema := entity.NewSchema().
+		WithName(collName).
+		WithExternalSource(extPath).
+		WithExternalSpec(`{"format":"parquet"}`).
+		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithExternalField("id")).
+		WithField(entity.NewField().WithName("value").WithDataType(entity.FieldTypeFloat).WithExternalField("value")).
+		WithField(entity.NewField().WithName("embedding").WithDataType(entity.FieldTypeFloatVector).
+			WithDim(testVecDim).WithExternalField("embedding"))
+	err = mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, true)
+	t.Cleanup(func() {
+		_ = mc.DropCollection(context.Background(), client.NewDropCollectionOption(collName))
+	})
+
+	refresh, err := mc.RefreshExternalCollection(ctx,
+		client.NewRefreshExternalCollectionOption(collName))
+	common.CheckErr(t, err, true)
+	waitRefreshTerminal(t, ctx, mc, refresh.JobID, entity.RefreshStateCompleted)
+
+	// Load + count to assert no shard was dropped and no stray was read
+	// (a stray would either fail load or — worse — succeed silently with
+	// the wrong row count if the bug let mis-sliced indices slip
+	// through).
+	idxOpt := client.NewCreateIndexOption(collName, "embedding", index.NewAutoIndex(entity.MetricType("L2")))
+	err = mc.CreateIndex(ctx, idxOpt).Wait()
+	common.CheckErr(t, err, true)
+	loadTask, err := mc.LoadCollection(ctx, client.NewLoadCollectionOption(collName))
+	common.CheckErr(t, err, true)
+	require.NoError(t, loadTask.Wait())
+
+	res, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithFilter("").
+		WithOutputFields(common.QueryCountFieldName).
+		WithConsistencyLevel(entity.ClStrong))
+	require.NoError(t, err)
+	require.Greater(t, len(res.Fields), 0)
+	got := res.Fields[0].FieldData().GetScalars().GetLongData().GetData()
+	require.Len(t, got, 1)
+	expected := rowsPerShard * numShards
+	require.Equal(t, expected, got[0],
+		"row count must equal sum of parquet shards (%d); strays must be filtered, no shard may be dropped",
+		expected)
+}

--- a/tests/go_client/testcases/external_table_refresh_test.go
+++ b/tests/go_client/testcases/external_table_refresh_test.go
@@ -81,7 +81,7 @@ func extTestURI(cfg minioConfig, relPath string) string {
 // Tier-2 endpoint derivation that redirects the URI at AWS S3.
 func extTestSpec(cfg minioConfig, format string) string {
 	return fmt.Sprintf(
-		`{"format":%q,"extfs":{"access_key_id":%q,"access_key_value":%q,"region":"us-east-1","use_ssl":"false","use_virtual_host":"false"}}`,
+		`{"format":%q,"extfs":{"access_key_id":%q,"access_key_value":%q,"region":"us-east-1","use_ssl":"false","use_virtual_host":"false","cloud_provider":"minio"}}`,
 		format, cfg.accessKey, cfg.secretKey)
 }
 
@@ -1213,37 +1213,48 @@ func TestExternalCollectionMultipleDataTypes(t *testing.T) {
 	// ---------------------------------------------------------------
 	// Step 2: Create external collection with multi-type schema
 	// ---------------------------------------------------------------
-	schema := entity.NewSchema().
-		WithName(collName).
-		WithExternalSource(extTestURI(minioCfg, extPath)).
-		WithExternalSpec(extTestSpec(minioCfg, "parquet")).
-		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithExternalField("id")).
-		WithField(entity.NewField().WithName("bool_val").WithDataType(entity.FieldTypeBool).WithExternalField("bool_val")).
-		WithField(entity.NewField().WithName("int8_val").WithDataType(entity.FieldTypeInt8).WithExternalField("int8_val")).
-		WithField(entity.NewField().WithName("int16_val").WithDataType(entity.FieldTypeInt16).WithExternalField("int16_val")).
-		WithField(entity.NewField().WithName("int32_val").WithDataType(entity.FieldTypeInt32).WithExternalField("int32_val")).
-		WithField(entity.NewField().WithName("float_val").WithDataType(entity.FieldTypeFloat).WithExternalField("float_val")).
-		WithField(entity.NewField().WithName("double_val").WithDataType(entity.FieldTypeDouble).WithExternalField("double_val")).
-		WithField(entity.NewField().WithName("varchar_val").WithDataType(entity.FieldTypeVarChar).WithMaxLength(64).WithExternalField("varchar_val")).
-		WithField(entity.NewField().WithName("json_val").WithDataType(entity.FieldTypeJSON).WithExternalField("json_val")).
-		WithField(entity.NewField().WithName("array_int").WithDataType(entity.FieldTypeArray).WithElementType(entity.FieldTypeInt32).WithMaxCapacity(16).WithExternalField("array_int")).
-		WithField(entity.NewField().WithName("array_str").WithDataType(entity.FieldTypeArray).WithElementType(entity.FieldTypeVarChar).WithMaxLength(64).WithMaxCapacity(16).WithExternalField("array_str")).
-		WithField(entity.NewField().WithName("ts_val").WithDataType(entity.FieldTypeTimestamptz).WithExternalField("ts_val")).
-		WithField(entity.NewField().WithName("geo_val").WithDataType(entity.FieldTypeGeometry).WithExternalField("geo_val")).
-		WithField(entity.NewField().WithName("embedding").WithDataType(entity.FieldTypeFloatVector).WithDim(testVecDim).WithExternalField("embedding")).
-		WithField(entity.NewField().WithName("bin_vec").WithDataType(entity.FieldTypeBinaryVector).WithDim(testBinVecDim).WithExternalField("bin_vec")).
-		WithField(entity.NewField().WithName("fp16_vec").WithDataType(entity.FieldTypeFloat16Vector).WithDim(testVecDim).WithExternalField("fp16_vec")).
-		WithField(entity.NewField().WithName("bf16_vec").WithDataType(entity.FieldTypeBFloat16Vector).WithDim(testVecDim).WithExternalField("bf16_vec")).
-		WithField(entity.NewField().WithName("int8_vec").WithDataType(entity.FieldTypeInt8Vector).WithDim(testVecDim).WithExternalField("int8_vec"))
+	schema := buildMultiTypeExternalSchema(collName,
+		extTestURI(minioCfg, extPath),
+		extTestSpec(minioCfg, "parquet"))
 
 	err = mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
 	common.CheckErr(t, err, true)
 	t.Logf("Created multi-type external collection: %s", collName)
 
+	runMultiTypeRefreshIndexLoadVerify(ctx, t, mc, collName, numRows)
+}
+
+// runMultiTypeRefreshIndexLoadVerify drives the post-create stages of the
+// multi-type external-collection test (refresh -> index all vector fields ->
+// load -> exhaustive query/search verification). Shared between the parquet
+// and vortex multi-type tests so the same schema + verification plan covers
+// both formats.  Assumes the dataset shape produced by
+// generateMultiTypeParquetBytes / generate_multi_type_vortex_data.py with
+// the given numRows.
+func runMultiTypeRefreshIndexLoadVerify(ctx context.Context, t *testing.T,
+	mc *base.MilvusClient, collName string, numRows int64) {
+	runMultiTypeRefreshIndexLoadVerifyWithSourceSpec(ctx, t, mc, collName, numRows, "", "")
+}
+
+// runMultiTypeRefreshIndexLoadVerifyWithSourceSpec accepts optional refresh
+// source+spec (used by iceberg paths that re-supply extfs credentials on
+// refresh; proxy now enforces both-or-neither).
+func runMultiTypeRefreshIndexLoadVerifyWithSourceSpec(ctx context.Context, t *testing.T,
+	mc *base.MilvusClient, collName string, numRows int64, refreshSource, refreshSpec string) {
 	// ---------------------------------------------------------------
 	// Step 3: Refresh + index all vector fields + load
 	// ---------------------------------------------------------------
-	refreshAndWait(ctx, t, mc, collName)
+	if refreshSource == "" && refreshSpec == "" {
+		refreshAndWait(ctx, t, mc, collName)
+	} else {
+		opt := client.NewRefreshExternalCollectionOption(collName).
+			WithExternalSource(refreshSource).
+			WithExternalSpec(refreshSpec)
+		refreshResult, err := mc.RefreshExternalCollection(ctx, opt)
+		common.CheckErr(t, err, true)
+		require.Greater(t, refreshResult.JobID, int64(0))
+		waitForRefreshComplete(ctx, t, mc, refreshResult.JobID, 120*time.Second)
+	}
 
 	// Create index on all vector fields
 	for _, vecField := range []string{"embedding", "bin_vec", "fp16_vec", "bf16_vec", "int8_vec"} {
@@ -1529,6 +1540,7 @@ func TestExternalCollectionMultipleDataTypes(t *testing.T) {
 	require.Equal(t, 25, compoundRes.GetColumn("id").Len(),
 		`compound filter: bool_val==true AND int32_val<5000 AND varchar like "str_00%" → 25 rows`)
 	t.Log("Compound filter across types (incl. varchar) passed")
+
 }
 
 // --- Lance format helpers ---
@@ -1861,6 +1873,58 @@ func generateVortexDataOnMinIO(t *testing.T, pythonBin, outputPath string, numRo
 	t.Logf("Generated vortex data: %s", out)
 }
 
+// generateMultiTypeVortexDataOnMinIO mirrors generateMultiTypeParquetBytes but
+// writes a vortex file. Used by TestExternalCollectionMultipleDataTypesVortex
+// to exercise the full schema (Bool/Int*/Float*/VarChar/JSON/Array/Timestamp/
+// Geometry + all vector dtypes) against vortex format. Vortex Python writer
+// doesn't support FixedSizeBinary, so binary-flavored vectors are stored as
+// FixedSizeList<UInt8> (milvus normalizes both to its internal layout).
+func generateMultiTypeVortexDataOnMinIO(t *testing.T, pythonBin, outputPath string, numRows, vecDim, binVecDim int) {
+	t.Helper()
+	minioCfg := getMinIOConfig()
+
+	out, err := runPythonScript(t, pythonBin, "generate_multi_type_vortex_data.py",
+		map[string]string{
+			"MINIO_ADDRESS":    minioCfg.address,
+			"MINIO_ACCESS_KEY": minioCfg.accessKey,
+			"MINIO_SECRET_KEY": minioCfg.secretKey,
+			"MINIO_BUCKET":     minioCfg.bucket,
+		},
+		outputPath, strconv.Itoa(numRows), strconv.Itoa(vecDim), strconv.Itoa(binVecDim))
+	require.NoError(t, err, "generate multi-type vortex data: %s", out)
+	require.Contains(t, out, "OK", "multi-type vortex data generation should succeed")
+	t.Logf("Generated multi-type vortex data: %s", out)
+}
+
+// buildMultiTypeExternalSchema constructs the schema mirroring the one used
+// by TestExternalCollectionMultipleDataTypes. Shared across format tests so
+// that the same field set + index plan can be exercised with parquet, vortex,
+// lance, etc.
+func buildMultiTypeExternalSchema(collName, externalSource, externalSpec string) *entity.Schema {
+	return entity.NewSchema().
+		WithName(collName).
+		WithExternalSource(externalSource).
+		WithExternalSpec(externalSpec).
+		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithExternalField("id")).
+		WithField(entity.NewField().WithName("bool_val").WithDataType(entity.FieldTypeBool).WithExternalField("bool_val")).
+		WithField(entity.NewField().WithName("int8_val").WithDataType(entity.FieldTypeInt8).WithExternalField("int8_val")).
+		WithField(entity.NewField().WithName("int16_val").WithDataType(entity.FieldTypeInt16).WithExternalField("int16_val")).
+		WithField(entity.NewField().WithName("int32_val").WithDataType(entity.FieldTypeInt32).WithExternalField("int32_val")).
+		WithField(entity.NewField().WithName("float_val").WithDataType(entity.FieldTypeFloat).WithExternalField("float_val")).
+		WithField(entity.NewField().WithName("double_val").WithDataType(entity.FieldTypeDouble).WithExternalField("double_val")).
+		WithField(entity.NewField().WithName("varchar_val").WithDataType(entity.FieldTypeVarChar).WithMaxLength(64).WithExternalField("varchar_val")).
+		WithField(entity.NewField().WithName("json_val").WithDataType(entity.FieldTypeJSON).WithExternalField("json_val")).
+		WithField(entity.NewField().WithName("array_int").WithDataType(entity.FieldTypeArray).WithElementType(entity.FieldTypeInt32).WithMaxCapacity(16).WithExternalField("array_int")).
+		WithField(entity.NewField().WithName("array_str").WithDataType(entity.FieldTypeArray).WithElementType(entity.FieldTypeVarChar).WithMaxLength(64).WithMaxCapacity(16).WithExternalField("array_str")).
+		WithField(entity.NewField().WithName("ts_val").WithDataType(entity.FieldTypeTimestamptz).WithExternalField("ts_val")).
+		WithField(entity.NewField().WithName("geo_val").WithDataType(entity.FieldTypeGeometry).WithExternalField("geo_val")).
+		WithField(entity.NewField().WithName("embedding").WithDataType(entity.FieldTypeFloatVector).WithDim(testVecDim).WithExternalField("embedding")).
+		WithField(entity.NewField().WithName("bin_vec").WithDataType(entity.FieldTypeBinaryVector).WithDim(testBinVecDim).WithExternalField("bin_vec")).
+		WithField(entity.NewField().WithName("fp16_vec").WithDataType(entity.FieldTypeFloat16Vector).WithDim(testVecDim).WithExternalField("fp16_vec")).
+		WithField(entity.NewField().WithName("bf16_vec").WithDataType(entity.FieldTypeBFloat16Vector).WithDim(testVecDim).WithExternalField("bf16_vec")).
+		WithField(entity.NewField().WithName("int8_vec").WithDataType(entity.FieldTypeInt8Vector).WithDim(testVecDim).WithExternalField("int8_vec"))
+}
+
 // TestExternalCollectionVortexFormat tests external collections with vortex format:
 //  1. Generate vortex dataset on MinIO using the generate_vortex_data tool
 //  2. Create external collection with vortex format
@@ -1932,6 +1996,27 @@ func TestExternalCollectionVortexFormat(t *testing.T) {
 				WithDataType(entity.FieldTypeFloatVector).
 				WithDim(testVecDim).
 				WithExternalField("embedding"),
+		).
+		// VARCHAR / JSON / GEOMETRY trigger vortex-specific bugs (#49352, #49353)
+		// that are not covered by the int/float/vector-only baseline.
+		WithField(
+			entity.NewField().
+				WithName("varchar_val").
+				WithDataType(entity.FieldTypeVarChar).
+				WithMaxLength(64).
+				WithExternalField("varchar_val"),
+		).
+		WithField(
+			entity.NewField().
+				WithName("json_val").
+				WithDataType(entity.FieldTypeJSON).
+				WithExternalField("json_val"),
+		).
+		WithField(
+			entity.NewField().
+				WithName("geo_val").
+				WithDataType(entity.FieldTypeGeometry).
+				WithExternalField("geo_val"),
 		)
 
 	err = mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
@@ -2078,6 +2163,127 @@ func TestExternalCollectionVortexFormat(t *testing.T) {
 	t.Logf("Hybrid search (id in [50000,60000)) returned %d results with correct values", hybridRes[0].ResultCount)
 
 	t.Log("Vortex format external collection test passed!")
+}
+
+// TestExternalCollectionMultipleDataTypesVortex mirrors
+// TestExternalCollectionMultipleDataTypes but writes the dataset in vortex
+// format. It exercises the same multi-type schema (Bool/Int*/Float*/VarChar/
+// JSON/Array/Timestamp/Geometry + all vector dtypes) and the same
+// refresh/index/load/query/search verification plan, ensuring vortex matches
+// parquet behavior across the entire type matrix.
+func TestExternalCollectionMultipleDataTypesVortex(t *testing.T) {
+	t.Parallel()
+
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	minioCfg := getMinIOConfig()
+	minioClient, err := newMinIOClient(minioCfg)
+	require.NoError(t, err)
+
+	exists, err := minioClient.BucketExists(ctx, minioCfg.bucket)
+	if err != nil || !exists {
+		t.Skipf("MinIO bucket %q not accessible, skipping", minioCfg.bucket)
+	}
+
+	// vortex-data >= 0.56.0 requires Python >= 3.11
+	pythonBin, err := findPython3ForVortex()
+	if err != nil {
+		t.Skipf("Python >= 3.11 not found for Vortex, skipping: %v", err)
+	}
+	if err := checkPythonDeps(pythonBin, "pyarrow", "vortex", "obstore"); err != nil {
+		t.Skipf("Python deps for Vortex unavailable, skipping: %v", err)
+	}
+
+	collName := common.GenRandomString("ext_multi_vortex", 6)
+	extPath := fmt.Sprintf("external-e2e-test/%s", collName)
+
+	t.Cleanup(func() {
+		cleanupMinIOPrefix(context.Background(), minioClient, minioCfg.bucket, extPath+"/")
+		_ = mc.DropCollection(context.Background(), client.NewDropCollectionOption(collName))
+	})
+
+	// Step 1: Generate multi-type vortex dataset on MinIO
+	const numRows = int64(100)
+	generateMultiTypeVortexDataOnMinIO(t, pythonBin, extPath, int(numRows), testVecDim, testBinVecDim)
+
+	// Step 2: Create external collection with shared multi-type schema
+	schema := buildMultiTypeExternalSchema(collName,
+		extTestURI(minioCfg, extPath),
+		extTestSpec(minioCfg, "vortex"))
+
+	err = mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, true)
+	t.Logf("Created multi-type vortex external collection: %s", collName)
+
+	// Step 3 onwards: shared refresh + index + load + verify
+	runMultiTypeRefreshIndexLoadVerify(ctx, t, mc, collName, numRows)
+}
+
+// generateMultiTypeLanceDataOnMinIO writes a Lance dataset on MinIO using the
+// shared 18-column multi-type schema. Used by
+// TestExternalCollectionMultipleDataTypesLance.
+func generateMultiTypeLanceDataOnMinIO(t *testing.T, s3URI string, numRows, vecDim, binVecDim int) {
+	t.Helper()
+	minioCfg := getMinIOConfig()
+
+	out, err := runPythonScript(t, "python3", "generate_multi_type_lance_data.py",
+		map[string]string{
+			"MINIO_ADDRESS":    minioCfg.address,
+			"MINIO_ACCESS_KEY": minioCfg.accessKey,
+			"MINIO_SECRET_KEY": minioCfg.secretKey,
+		},
+		s3URI, strconv.Itoa(numRows), strconv.Itoa(vecDim), strconv.Itoa(binVecDim))
+	require.NoError(t, err, "generate multi-type lance data: %s", out)
+	require.Contains(t, out, "OK", "multi-type lance data generation should succeed")
+	t.Logf("Generated multi-type lance data: %s", out)
+}
+
+// TestExternalCollectionMultipleDataTypesLance mirrors
+// TestExternalCollectionMultipleDataTypesVortex but writes the dataset in lance
+// format. Exercises the same multi-type schema and shared
+// refresh/index/load/query/search verification across the lance bridge.
+func TestExternalCollectionMultipleDataTypesLance(t *testing.T) {
+	t.Parallel()
+
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	minioCfg := getMinIOConfig()
+	minioClient, err := newMinIOClient(minioCfg)
+	require.NoError(t, err)
+
+	exists, err := minioClient.BucketExists(ctx, minioCfg.bucket)
+	if err != nil || !exists {
+		t.Skipf("MinIO bucket %q not accessible, skipping", minioCfg.bucket)
+	}
+
+	if err := checkPythonDeps("python3", "pyarrow", "lance"); err != nil {
+		t.Skipf("Python deps for Lance unavailable, skipping: %v", err)
+	}
+
+	collName := common.GenRandomString("ext_multi_lance", 6)
+	extPath := fmt.Sprintf("external-e2e-test/%s", collName)
+
+	t.Cleanup(func() {
+		cleanupMinIOPrefix(context.Background(), minioClient, minioCfg.bucket, extPath+"/")
+		_ = mc.DropCollection(context.Background(), client.NewDropCollectionOption(collName))
+	})
+
+	const numRows = int64(100)
+	// Lance writer takes a full s3:// URI (different from vortex's relative path).
+	s3URI := fmt.Sprintf("s3://%s/%s", minioCfg.bucket, extPath)
+	generateMultiTypeLanceDataOnMinIO(t, s3URI, int(numRows), testVecDim, testBinVecDim)
+
+	schema := buildMultiTypeExternalSchema(collName,
+		extTestURI(minioCfg, extPath),
+		extTestSpec(minioCfg, "lance-table"))
+
+	err = mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, true)
+	t.Logf("Created multi-type lance external collection: %s", collName)
+
+	runMultiTypeRefreshIndexLoadVerify(ctx, t, mc, collName, numRows)
 }
 
 // TestExternalCollectionFloat32ListVector verifies that external collections
@@ -2570,7 +2776,7 @@ func TestExternalSourceFormats(t *testing.T) {
 	// still required by ValidateExtfsComplete for s3-family schemes, but
 	// the endpoint must come from the URI host (Milvus form).
 	extfsFragment := fmt.Sprintf(
-		`"extfs":{"access_key_id":%q,"access_key_value":%q,"region":"us-east-1","use_ssl":"false","use_virtual_host":"false"}`,
+		`"extfs":{"access_key_id":%q,"access_key_value":%q,"region":"us-east-1","use_ssl":"false","use_virtual_host":"false","cloud_provider":"minio"}`,
 		minioCfg.accessKey, minioCfg.secretKey)
 
 	type testCase struct {
@@ -2916,8 +3122,8 @@ func TestRefreshExternalCollectionZeroRowParquet(t *testing.T) {
 
 	schema := entity.NewSchema().
 		WithName(collName).
-		WithExternalSource(extPath).
-		WithExternalSpec(`{"format":"parquet"}`).
+		WithExternalSource(extTestURI(minioCfg, extPath)).
+		WithExternalSpec(extTestSpec(minioCfg, "parquet")).
 		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithExternalField("id")).
 		WithField(entity.NewField().WithName("value").WithDataType(entity.FieldTypeFloat).WithExternalField("value")).
 		WithField(entity.NewField().WithName("embedding").WithDataType(entity.FieldTypeFloatVector).
@@ -3007,8 +3213,8 @@ func TestRefreshExternalCollectionWrongExternalField(t *testing.T) {
 	// Schema maps "embedding" to a column "wrong_col_a" that does not exist.
 	schema := entity.NewSchema().
 		WithName(collName).
-		WithExternalSource(extPath).
-		WithExternalSpec(`{"format":"parquet"}`).
+		WithExternalSource(extTestURI(minioCfg, extPath)).
+		WithExternalSpec(extTestSpec(minioCfg, "parquet")).
 		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithExternalField("id")).
 		WithField(entity.NewField().WithName("embedding").WithDataType(entity.FieldTypeFloatVector).
 			WithDim(testVecDim).WithExternalField("wrong_col_a"))
@@ -3078,7 +3284,7 @@ func TestDescribeExternalCollectionRedactsCredentials(t *testing.T) {
 	// Embed secret credentials in extfs; they are persisted into etcd and
 	// must NOT flow back out unredacted through DescribeCollection.
 	rawSpec := fmt.Sprintf(
-		`{"format":"parquet","extfs":{"access_key_id":%q,"access_key_value":%q,"region":"us-east-1","use_ssl":"false","use_virtual_host":"false"}}`,
+		`{"format":"parquet","extfs":{"access_key_id":%q,"access_key_value":%q,"region":"us-east-1","use_ssl":"false","use_virtual_host":"false","cloud_provider":"minio"}}`,
 		"AKIAEXAMPLELEAKME", "supersecretvaluemustnotleak")
 
 	schema := entity.NewSchema().
@@ -3159,11 +3365,15 @@ func TestRefreshExternalCollectionOverridePersistsNewSource(t *testing.T) {
 			fmt.Sprintf("external-e2e-test/%s/", collName))
 	})
 
+	uriA := extTestURI(minioCfg, pathA)
+	uriB := extTestURI(minioCfg, pathB)
+	spec := extTestSpec(minioCfg, "parquet")
+
 	// Create with SRC_A.
 	schema := entity.NewSchema().
 		WithName(collName).
-		WithExternalSource(pathA).
-		WithExternalSpec(`{"format":"parquet"}`).
+		WithExternalSource(uriA).
+		WithExternalSpec(spec).
 		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithExternalField("id")).
 		WithField(entity.NewField().WithName("value").WithDataType(entity.FieldTypeFloat).WithExternalField("value")).
 		WithField(entity.NewField().WithName("embedding").WithDataType(entity.FieldTypeFloatVector).
@@ -3183,19 +3393,19 @@ func TestRefreshExternalCollectionOverridePersistsNewSource(t *testing.T) {
 	// Override refresh to SRC_B with explicit external_source.
 	refreshB, err := mc.RefreshExternalCollection(ctx,
 		client.NewRefreshExternalCollectionOption(collName).
-			WithExternalSource(pathB).
-			WithExternalSpec(`{"format":"parquet"}`))
+			WithExternalSource(uriB).
+			WithExternalSpec(spec))
 	common.CheckErr(t, err, true)
 	waitRefreshTerminal(t, ctx, mc, refreshB.JobID, entity.RefreshStateCompleted)
 
 	// Persisted schema must now reflect SRC_B. Pre-fix this still showed pathA.
 	desc, err := mc.DescribeCollection(ctx, client.NewDescribeCollectionOption(collName))
 	require.NoError(t, err)
-	require.Equal(t, pathB, desc.Schema.ExternalSource,
+	require.Equal(t, uriB, desc.Schema.ExternalSource,
 		"override refresh must persist new external_source; pre-fix #49335 left it stale")
 }
 
-func waitRefreshTerminal(t *testing.T, ctx context.Context, mc *client.Client, jobID int64, expect entity.RefreshExternalCollectionState) {
+func waitRefreshTerminal(t *testing.T, ctx context.Context, mc *base.MilvusClient, jobID int64, expect entity.RefreshExternalCollectionState) {
 	t.Helper()
 	deadline := time.After(60 * time.Second)
 	ticker := time.NewTicker(2 * time.Second)
@@ -3278,8 +3488,8 @@ func TestRefreshExternalCollectionFiltersNonParquetStrays(t *testing.T) {
 
 	schema := entity.NewSchema().
 		WithName(collName).
-		WithExternalSource(extPath).
-		WithExternalSpec(`{"format":"parquet"}`).
+		WithExternalSource(extTestURI(minioCfg, extPath)).
+		WithExternalSpec(extTestSpec(minioCfg, "parquet")).
 		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithExternalField("id")).
 		WithField(entity.NewField().WithName("value").WithDataType(entity.FieldTypeFloat).WithExternalField("value")).
 		WithField(entity.NewField().WithName("embedding").WithDataType(entity.FieldTypeFloatVector).
@@ -3300,11 +3510,12 @@ func TestRefreshExternalCollectionFiltersNonParquetStrays(t *testing.T) {
 	// the wrong row count if the bug let mis-sliced indices slip
 	// through).
 	idxOpt := client.NewCreateIndexOption(collName, "embedding", index.NewAutoIndex(entity.MetricType("L2")))
-	err = mc.CreateIndex(ctx, idxOpt).Wait()
+	idxTask, err := mc.CreateIndex(ctx, idxOpt)
 	common.CheckErr(t, err, true)
+	require.NoError(t, idxTask.Await(ctx))
 	loadTask, err := mc.LoadCollection(ctx, client.NewLoadCollectionOption(collName))
 	common.CheckErr(t, err, true)
-	require.NoError(t, loadTask.Wait())
+	require.NoError(t, loadTask.Await(ctx))
 
 	res, err := mc.Query(ctx, client.NewQueryOption(collName).
 		WithFilter("").

--- a/tests/go_client/testcases/external_table_refresh_test.go
+++ b/tests/go_client/testcases/external_table_refresh_test.go
@@ -1704,7 +1704,9 @@ func TestExternalCollectionLanceFormat(t *testing.T) {
 	coll, err := mc.DescribeCollection(ctx, client.NewDescribeCollectionOption(collName))
 	common.CheckErr(t, err, true)
 	require.Equal(t, extTestURI(minioCfg, extPath), coll.Schema.ExternalSource)
-	require.Equal(t, extTestSpec(minioCfg, "lance-table"), coll.Schema.ExternalSpec)
+	// Spec redacted at proxy edge.
+	require.Contains(t, coll.Schema.ExternalSpec, `"format":"lance-table"`)
+	require.Contains(t, coll.Schema.ExternalSpec, `"access_key_id":"***"`)
 
 	// ---------------------------------------------------------------
 	// Step 3: Refresh and wait for completion
@@ -1943,7 +1945,9 @@ func TestExternalCollectionVortexFormat(t *testing.T) {
 	coll, err := mc.DescribeCollection(ctx, client.NewDescribeCollectionOption(collName))
 	common.CheckErr(t, err, true)
 	require.Equal(t, extTestURI(minioCfg, extPath), coll.Schema.ExternalSource)
-	require.Equal(t, extTestSpec(minioCfg, "vortex"), coll.Schema.ExternalSpec)
+	// Spec redacted at proxy edge.
+	require.Contains(t, coll.Schema.ExternalSpec, `"format":"vortex"`)
+	require.Contains(t, coll.Schema.ExternalSpec, `"access_key_id":"***"`)
 
 	// ---------------------------------------------------------------
 	// Step 3: Refresh and wait for completion
@@ -2471,7 +2475,12 @@ func TestRefreshExternalCollectionUpdatesSchema(t *testing.T) {
 	coll, err := mc.DescribeCollection(ctx, client.NewDescribeCollectionOption(collName))
 	common.CheckErr(t, err, true)
 	require.Equal(t, pathV1, coll.Schema.ExternalSource, "initial ExternalSource should be pathV1")
-	require.Equal(t, specV1, coll.Schema.ExternalSpec, "initial ExternalSpec should be specV1")
+	// DescribeCollection redacts secret extfs values at the proxy edge;
+	// assert format + non-secret keys + redaction markers, not byte-equality.
+	require.Contains(t, coll.Schema.ExternalSpec, `"format":"parquet"`)
+	require.Contains(t, coll.Schema.ExternalSpec, `"access_key_id":"***"`)
+	require.Contains(t, coll.Schema.ExternalSpec, `"access_key_value":"***"`)
+	require.Contains(t, coll.Schema.ExternalSpec, `"region":"us-east-1"`)
 
 	// ---------------------------------------------------------------
 	// Step 2: First refresh (with default source/spec) — establishes baseline
@@ -2505,9 +2514,13 @@ func TestRefreshExternalCollectionUpdatesSchema(t *testing.T) {
 	common.CheckErr(t, err, true)
 	require.Equal(t, pathV2, coll2.Schema.ExternalSource,
 		"ExternalSource should be updated to pathV2 after refresh")
-	require.Equal(t, specV2, coll2.Schema.ExternalSpec,
-		"ExternalSpec should be updated to specV2 after refresh")
+	// Redacted via proxy edge; verify shape + non-secret values.
+	require.Contains(t, coll2.Schema.ExternalSpec, `"format":"parquet"`)
+	require.Contains(t, coll2.Schema.ExternalSpec, `"access_key_id":"***"`)
+	require.Contains(t, coll2.Schema.ExternalSpec, `"access_key_value":"***"`)
+	require.Contains(t, coll2.Schema.ExternalSpec, `"region":"us-east-1"`)
 	t.Logf("Verified: schema updated — source=%s, spec=%s", coll2.Schema.ExternalSource, coll2.Schema.ExternalSpec)
+	_ = specV2 // value used to drive the refresh; final spec compared structurally above.
 }
 
 // TestExternalSourceFormats is a table-driven test covering the 3 supported
@@ -3044,4 +3057,59 @@ func TestRefreshExternalCollectionWrongExternalField(t *testing.T) {
 		"reason must state the column was not found; got %q", finalReason)
 	require.Contains(t, finalReason, "external_field mappings",
 		"reason must hint at the real fix; got %q", finalReason)
+}
+
+// Security regression: DescribeCollection must redact secret extfs keys
+// (access_key_id / access_key_value / ssl_ca_cert) in the ExternalSpec
+// JSON returned to the client. Any caller with Describe privilege would
+// otherwise be able to read another tenant's object-storage credentials.
+func TestDescribeExternalCollectionRedactsCredentials(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	minioCfg := getMinIOConfig()
+	if _, err := newMinIOClient(minioCfg); err != nil {
+		t.Skipf("MinIO unavailable, skipping: %v", err)
+	}
+
+	collName := common.GenRandomString("ext_redact", 6)
+	extPath := fmt.Sprintf("external-e2e-test/%s", collName)
+
+	// Embed secret credentials in extfs; they are persisted into etcd and
+	// must NOT flow back out unredacted through DescribeCollection.
+	rawSpec := fmt.Sprintf(
+		`{"format":"parquet","extfs":{"access_key_id":%q,"access_key_value":%q,"region":"us-east-1","use_ssl":"false","use_virtual_host":"false"}}`,
+		"AKIAEXAMPLELEAKME", "supersecretvaluemustnotleak")
+
+	schema := entity.NewSchema().
+		WithName(collName).
+		WithExternalSource(extTestURI(minioCfg, extPath)).
+		WithExternalSpec(rawSpec).
+		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithExternalField("id")).
+		WithField(entity.NewField().WithName("embedding").WithDataType(entity.FieldTypeFloatVector).
+			WithDim(testVecDim).WithExternalField("embedding"))
+
+	err := mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, true)
+	t.Cleanup(func() {
+		_ = mc.DropCollection(context.Background(), client.NewDropCollectionOption(collName))
+	})
+
+	desc, err := mc.DescribeCollection(ctx, client.NewDescribeCollectionOption(collName))
+	require.NoError(t, err)
+
+	returnedSpec := desc.Schema.ExternalSpec
+	t.Logf("returned ExternalSpec: %s", returnedSpec)
+
+	require.NotContains(t, returnedSpec, "AKIAEXAMPLELEAKME",
+		"access_key_id plaintext leaked via DescribeCollection")
+	require.NotContains(t, returnedSpec, "supersecretvaluemustnotleak",
+		"access_key_value plaintext leaked via DescribeCollection")
+	require.Contains(t, returnedSpec, `"access_key_id":"***"`,
+		"access_key_id must be redacted to ***")
+	require.Contains(t, returnedSpec, `"access_key_value":"***"`,
+		"access_key_value must be redacted to ***")
+	// Non-secret values remain visible for operator troubleshooting.
+	require.Contains(t, returnedSpec, `"region":"us-east-1"`,
+		"non-secret extfs values must remain readable")
 }

--- a/tests/go_client/testcases/external_table_refresh_test.go
+++ b/tests/go_client/testcases/external_table_refresh_test.go
@@ -3113,3 +3113,108 @@ func TestDescribeExternalCollectionRedactsCredentials(t *testing.T) {
 	require.Contains(t, returnedSpec, `"region":"us-east-1"`,
 		"non-secret extfs values must remain readable")
 }
+
+// Regression for issue #49335: a refresh_external_collection call carrying
+// an explicit (external_source, external_spec) override must persist the
+// new tuple back into the collection schema, so that subsequent
+// describe_collection reflects the new source AND a later reuse-path
+// refresh (no override) targets the new source rather than silently
+// reverting to the original one.
+//
+// Pre-fix behavior: the post-completion schema-sync path
+// (server_external_schema_updater.updateExternalSchemaViaWAL) went through
+// AlterCollection, which the atomic-tuple guard introduced in PR #49302
+// rejected — the data load against NEW succeeded but the persisted
+// schema stayed pointing at OLD forever.
+func TestRefreshExternalCollectionOverridePersistsNewSource(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	minioCfg := getMinIOConfig()
+	minioClient, err := newMinIOClient(minioCfg)
+	require.NoError(t, err)
+	exists, err := minioClient.BucketExists(ctx, minioCfg.bucket)
+	if err != nil || !exists {
+		t.Skipf("MinIO bucket %q not accessible, skipping", minioCfg.bucket)
+	}
+
+	collName := common.GenRandomString("ext_override", 6)
+	pathA := fmt.Sprintf("external-e2e-test/%s/a", collName)
+	pathB := fmt.Sprintf("external-e2e-test/%s/b", collName)
+
+	// Upload distinct parquet payloads to bucket/A and bucket/B.
+	dataA, err := generateParquetBytes(8, 0)
+	require.NoError(t, err)
+	dataB, err := generateParquetBytes(8, 1000)
+	require.NoError(t, err)
+	for _, p := range []struct{ path string; bytes []byte }{{pathA, dataA}, {pathB, dataB}} {
+		_, err = minioClient.PutObject(ctx, minioCfg.bucket,
+			fmt.Sprintf("%s/data.parquet", p.path),
+			bytes.NewReader(p.bytes), int64(len(p.bytes)),
+			miniogo.PutObjectOptions{ContentType: "application/octet-stream"})
+		require.NoError(t, err)
+	}
+	t.Cleanup(func() {
+		cleanupMinIOPrefix(context.Background(), minioClient, minioCfg.bucket,
+			fmt.Sprintf("external-e2e-test/%s/", collName))
+	})
+
+	// Create with SRC_A.
+	schema := entity.NewSchema().
+		WithName(collName).
+		WithExternalSource(pathA).
+		WithExternalSpec(`{"format":"parquet"}`).
+		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithExternalField("id")).
+		WithField(entity.NewField().WithName("value").WithDataType(entity.FieldTypeFloat).WithExternalField("value")).
+		WithField(entity.NewField().WithName("embedding").WithDataType(entity.FieldTypeFloatVector).
+			WithDim(testVecDim).WithExternalField("embedding"))
+	err = mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, true)
+	t.Cleanup(func() {
+		_ = mc.DropCollection(context.Background(), client.NewDropCollectionOption(collName))
+	})
+
+	// Initial refresh against SRC_A (reuse path).
+	refreshA, err := mc.RefreshExternalCollection(ctx,
+		client.NewRefreshExternalCollectionOption(collName))
+	common.CheckErr(t, err, true)
+	waitRefreshTerminal(t, ctx, mc, refreshA.JobID, entity.RefreshStateCompleted)
+
+	// Override refresh to SRC_B with explicit external_source.
+	refreshB, err := mc.RefreshExternalCollection(ctx,
+		client.NewRefreshExternalCollectionOption(collName).
+			WithExternalSource(pathB).
+			WithExternalSpec(`{"format":"parquet"}`))
+	common.CheckErr(t, err, true)
+	waitRefreshTerminal(t, ctx, mc, refreshB.JobID, entity.RefreshStateCompleted)
+
+	// Persisted schema must now reflect SRC_B. Pre-fix this still showed pathA.
+	desc, err := mc.DescribeCollection(ctx, client.NewDescribeCollectionOption(collName))
+	require.NoError(t, err)
+	require.Equal(t, pathB, desc.Schema.ExternalSource,
+		"override refresh must persist new external_source; pre-fix #49335 left it stale")
+}
+
+func waitRefreshTerminal(t *testing.T, ctx context.Context, mc *client.Client, jobID int64, expect entity.RefreshExternalCollectionState) {
+	t.Helper()
+	deadline := time.After(60 * time.Second)
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-deadline:
+			t.Fatalf("refresh job %d did not reach terminal state within 60s", jobID)
+		case <-ticker.C:
+			progress, err := mc.GetRefreshExternalCollectionProgress(ctx,
+				client.NewGetRefreshExternalCollectionProgressOption(jobID))
+			require.NoError(t, err)
+			t.Logf("Job %d: state=%s reason=%q", jobID, progress.State, progress.Reason)
+			if progress.State == entity.RefreshStateCompleted ||
+				progress.State == entity.RefreshStateFailed {
+				require.Equal(t, expect, progress.State,
+					"refresh terminal state mismatch (reason=%s)", progress.Reason)
+				return
+			}
+		}
+	}
+}

--- a/tests/go_client/testcases/external_table_refresh_test.go
+++ b/tests/go_client/testcases/external_table_refresh_test.go
@@ -2956,3 +2956,92 @@ func TestRefreshExternalCollectionZeroRowParquet(t *testing.T) {
 	require.Contains(t, strings.ToLower(finalReason), "zero",
 		"failure reason should mention zero rows so operators can act; got %q", finalReason)
 }
+
+// Regression for issue #48637: a typo in external_field mapping (name
+// points to a column that does not exist in the parquet) must surface
+// the C++ "Column 'xxx' not found in schema" root cause in the
+// RefreshFailed reason returned to the client, not the generic
+// "sampling failed for all N segment(s)" message that forces operators
+// to SSH into datanode logs.
+func TestRefreshExternalCollectionWrongExternalField(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	minioCfg := getMinIOConfig()
+	minioClient, err := newMinIOClient(minioCfg)
+	require.NoError(t, err)
+	exists, err := minioClient.BucketExists(ctx, minioCfg.bucket)
+	if err != nil || !exists {
+		t.Skipf("MinIO bucket %q not accessible, skipping", minioCfg.bucket)
+	}
+
+	collName := common.GenRandomString("ext_wrong_field", 6)
+	extPath := fmt.Sprintf("external-e2e-test/%s", collName)
+
+	// Well-formed parquet with real columns id/value/embedding.
+	data, err := generateParquetBytes(8, 0)
+	require.NoError(t, err)
+	_, err = minioClient.PutObject(ctx, minioCfg.bucket,
+		fmt.Sprintf("%s/data.parquet", extPath),
+		bytes.NewReader(data), int64(len(data)),
+		miniogo.PutObjectOptions{ContentType: "application/octet-stream"})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		cleanupMinIOPrefix(context.Background(), minioClient, minioCfg.bucket,
+			fmt.Sprintf("%s/", extPath))
+	})
+
+	// Schema maps "embedding" to a column "wrong_col_a" that does not exist.
+	schema := entity.NewSchema().
+		WithName(collName).
+		WithExternalSource(extPath).
+		WithExternalSpec(`{"format":"parquet"}`).
+		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithExternalField("id")).
+		WithField(entity.NewField().WithName("embedding").WithDataType(entity.FieldTypeFloatVector).
+			WithDim(testVecDim).WithExternalField("wrong_col_a"))
+
+	err = mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, true)
+	t.Cleanup(func() {
+		_ = mc.DropCollection(context.Background(), client.NewDropCollectionOption(collName))
+	})
+
+	refreshResult, err := mc.RefreshExternalCollection(ctx,
+		client.NewRefreshExternalCollectionOption(collName))
+	common.CheckErr(t, err, true)
+	jobID := refreshResult.JobID
+
+	deadline := time.After(60 * time.Second)
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	var finalState entity.RefreshExternalCollectionState
+	var finalReason string
+	for done := false; !done; {
+		select {
+		case <-deadline:
+			t.Fatalf("Refresh job %d did not reach terminal state within 60s", jobID)
+		case <-ticker.C:
+			progress, err := mc.GetRefreshExternalCollectionProgress(ctx,
+				client.NewGetRefreshExternalCollectionProgressOption(jobID))
+			require.NoError(t, err)
+			t.Logf("Job %d: state=%s reason=%q", jobID, progress.State, progress.Reason)
+			if progress.State == entity.RefreshStateCompleted ||
+				progress.State == entity.RefreshStateFailed {
+				finalState = progress.State
+				finalReason = progress.Reason
+				done = true
+			}
+		}
+	}
+
+	require.Equal(t, entity.RefreshStateFailed, finalState,
+		"wrong external_field must surface as RefreshFailed")
+	// Root cause from C++ layer must reach the client.
+	require.Contains(t, finalReason, "wrong_col_a",
+		"reason must name the offending column; got %q", finalReason)
+	require.Contains(t, strings.ToLower(finalReason), "not found",
+		"reason must state the column was not found; got %q", finalReason)
+	require.Contains(t, finalReason, "external_field mappings",
+		"reason must hint at the real fix; got %q", finalReason)
+}

--- a/tests/go_client/testcases/external_table_test.go
+++ b/tests/go_client/testcases/external_table_test.go
@@ -25,7 +25,7 @@ func TestCreateExternalCollection(t *testing.T) {
 	schema := entity.NewSchema().
 		WithName(collName).
 		WithExternalSource("s3://test-bucket/data/").
-		WithExternalSpec(`{"format": "parquet","extfs":{"access_key_id":"dummy","access_key_value":"dummy","region":"us-east-1"}}`).
+		WithExternalSpec(`{"format": "parquet","extfs":{"access_key_id":"dummy","access_key_value":"dummy","region":"us-east-1","cloud_provider":"aws"}}`).
 		WithField(
 			entity.NewField().
 				WithName("text").
@@ -56,7 +56,7 @@ func TestCreateExternalCollection(t *testing.T) {
 
 	// Verify external source and spec
 	require.Equal(t, "s3://test-bucket/data/", coll.Schema.ExternalSource)
-	require.Equal(t, `{"format": "parquet","extfs":{"access_key_id":"dummy","access_key_value":"dummy","region":"us-east-1"}}`, coll.Schema.ExternalSpec)
+	require.Equal(t, `{"format": "parquet","extfs":{"access_key_id":"dummy","access_key_value":"dummy","region":"us-east-1","cloud_provider":"aws"}}`, coll.Schema.ExternalSpec)
 
 	// Verify fields (user-defined fields + auto-generated __virtual_pk__)
 	require.Len(t, coll.Schema.Fields, 3)
@@ -99,7 +99,7 @@ func TestCreateExternalCollectionMissingExternalField(t *testing.T) {
 	schema := entity.NewSchema().
 		WithName(collName).
 		WithExternalSource("s3://test-bucket/data/").
-		WithExternalSpec(`{"format": "parquet","extfs":{"access_key_id":"dummy","access_key_value":"dummy","region":"us-east-1"}}`).
+		WithExternalSpec(`{"format": "parquet","extfs":{"access_key_id":"dummy","access_key_value":"dummy","region":"us-east-1","cloud_provider":"aws"}}`).
 		WithField(
 			entity.NewField().
 				WithName("text").
@@ -134,7 +134,7 @@ func TestCreateExternalCollectionWithPrimaryKey(t *testing.T) {
 	schema := entity.NewSchema().
 		WithName(collName).
 		WithExternalSource("s3://test-bucket/data/").
-		WithExternalSpec(`{"format": "parquet","extfs":{"access_key_id":"dummy","access_key_value":"dummy","region":"us-east-1"}}`).
+		WithExternalSpec(`{"format": "parquet","extfs":{"access_key_id":"dummy","access_key_value":"dummy","region":"us-east-1","cloud_provider":"aws"}}`).
 		WithField(
 			entity.NewField().
 				WithName("id").
@@ -169,7 +169,7 @@ func TestCreateExternalCollectionWithDynamicField(t *testing.T) {
 	schema := entity.NewSchema().
 		WithName(collName).
 		WithExternalSource("s3://test-bucket/data/").
-		WithExternalSpec(`{"format": "parquet","extfs":{"access_key_id":"dummy","access_key_value":"dummy","region":"us-east-1"}}`).
+		WithExternalSpec(`{"format": "parquet","extfs":{"access_key_id":"dummy","access_key_value":"dummy","region":"us-east-1","cloud_provider":"aws"}}`).
 		WithDynamicFieldEnabled(true).
 		WithField(
 			entity.NewField().
@@ -205,7 +205,7 @@ func TestCreateExternalCollectionWithAutoID(t *testing.T) {
 	schema := entity.NewSchema().
 		WithName(collName).
 		WithExternalSource("s3://test-bucket/data/").
-		WithExternalSpec(`{"format": "parquet","extfs":{"access_key_id":"dummy","access_key_value":"dummy","region":"us-east-1"}}`).
+		WithExternalSpec(`{"format": "parquet","extfs":{"access_key_id":"dummy","access_key_value":"dummy","region":"us-east-1","cloud_provider":"aws"}}`).
 		WithField(
 			entity.NewField().
 				WithName("id").
@@ -240,7 +240,7 @@ func TestCreateExternalCollectionWithPartitionKey(t *testing.T) {
 	schema := entity.NewSchema().
 		WithName(collName).
 		WithExternalSource("s3://test-bucket/data/").
-		WithExternalSpec(`{"format": "parquet","extfs":{"access_key_id":"dummy","access_key_value":"dummy","region":"us-east-1"}}`).
+		WithExternalSpec(`{"format": "parquet","extfs":{"access_key_id":"dummy","access_key_value":"dummy","region":"us-east-1","cloud_provider":"aws"}}`).
 		WithField(
 			entity.NewField().
 				WithName("category").
@@ -276,7 +276,7 @@ func TestCreateExternalCollectionMultipleVectorFields(t *testing.T) {
 	schema := entity.NewSchema().
 		WithName(collName).
 		WithExternalSource("s3://test-bucket/data/").
-		WithExternalSpec(`{"format": "parquet","extfs":{"access_key_id":"dummy","access_key_value":"dummy","region":"us-east-1"}}`).
+		WithExternalSpec(`{"format": "parquet","extfs":{"access_key_id":"dummy","access_key_value":"dummy","region":"us-east-1","cloud_provider":"aws"}}`).
 		WithField(
 			entity.NewField().
 				WithName("text").

--- a/tests/go_client/testcases/external_table_test.go
+++ b/tests/go_client/testcases/external_table_test.go
@@ -1,6 +1,7 @@
 package testcases
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -56,7 +57,16 @@ func TestCreateExternalCollection(t *testing.T) {
 
 	// Verify external source and spec
 	require.Equal(t, "s3://test-bucket/data/", coll.Schema.ExternalSource)
-	require.Equal(t, `{"format": "parquet","extfs":{"access_key_id":"dummy","access_key_value":"dummy","region":"us-east-1","cloud_provider":"aws"}}`, coll.Schema.ExternalSpec)
+	var spec struct {
+		Format string            `json:"format"`
+		Extfs  map[string]string `json:"extfs"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(coll.Schema.ExternalSpec), &spec))
+	require.Equal(t, "parquet", spec.Format)
+	require.Equal(t, "aws", spec.Extfs["cloud_provider"])
+	require.Equal(t, "us-east-1", spec.Extfs["region"])
+	require.Equal(t, "***", spec.Extfs["access_key_id"])
+	require.Equal(t, "***", spec.Extfs["access_key_value"])
 
 	// Verify fields (user-defined fields + auto-generated __virtual_pk__)
 	require.Len(t, coll.Schema.Fields, 3)

--- a/tests/go_client/testcases/generate_multi_type_lance_data.py
+++ b/tests/go_client/testcases/generate_multi_type_lance_data.py
@@ -35,6 +35,7 @@ lance_bridgeimpl.rs note in generate_lance_data.py).
 Environment variables:
     MINIO_ADDRESS, MINIO_ACCESS_KEY, MINIO_SECRET_KEY
 """
+
 import json
 import os
 import struct
@@ -77,10 +78,7 @@ def main():
     double_vals = [float(i) * 0.01 for i in ids]
     varchar_vals = [f"str_{i:04d}" for i in ids]
     # Compact JSON (no spaces) — matches verifier substring assertions.
-    json_vals = [
-        json.dumps({"key": i, "name": f"item_{i}"}, separators=(",", ":"))
-        for i in ids
-    ]
+    json_vals = [json.dumps({"key": i, "name": f"item_{i}"}, separators=(",", ":")) for i in ids]
 
     array_int_vals = [[i, i * 2, i * 3] for i in ids]
     array_str_vals = [[f"tag_{i}_a", f"tag_{i}_b"] for i in ids]
@@ -92,41 +90,38 @@ def main():
     geo_vals = [f"POINT({i} {i * 0.1:.1f})" for i in ids]
 
     # FloatVector packed as float32 bytes
-    embedding_rows = [
-        struct.pack(f"{vec_dim}f", *[float(i) * 0.1 + d for d in range(vec_dim)])
-        for i in ids
-    ]
+    embedding_rows = [struct.pack(f"{vec_dim}f", *[float(i) * 0.1 + d for d in range(vec_dim)]) for i in ids]
 
     def gen_bytes_block(byte_width):
-        return [
-            bytes((i + b) % 256 for b in range(byte_width)) for i in ids
-        ]
+        return [bytes((i + b) % 256 for b in range(byte_width)) for i in ids]
 
     bin_vec_rows = gen_bytes_block(bin_vec_byte_width)
     fp16_vec_rows = gen_bytes_block(fp16_byte_width)
     bf16_vec_rows = gen_bytes_block(bf16_byte_width)
     int8_vec_rows = gen_bytes_block(int8_vec_byte_width)
 
-    schema = pa.schema([
-        pa.field("id", pa.int64()),
-        pa.field("bool_val", pa.bool_()),
-        pa.field("int8_val", pa.int8()),
-        pa.field("int16_val", pa.int16()),
-        pa.field("int32_val", pa.int32()),
-        pa.field("float_val", pa.float32()),
-        pa.field("double_val", pa.float64()),
-        pa.field("varchar_val", pa.string()),
-        pa.field("json_val", pa.string()),
-        pa.field("array_int", pa.list_(pa.int32())),
-        pa.field("array_str", pa.list_(pa.string())),
-        pa.field("ts_val", pa.timestamp("us", tz="UTC")),
-        pa.field("geo_val", pa.string()),
-        pa.field("embedding", pa.binary(embedding_byte_width)),
-        pa.field("bin_vec", pa.binary(bin_vec_byte_width)),
-        pa.field("fp16_vec", pa.binary(fp16_byte_width)),
-        pa.field("bf16_vec", pa.binary(bf16_byte_width)),
-        pa.field("int8_vec", pa.binary(int8_vec_byte_width)),
-    ])
+    schema = pa.schema(
+        [
+            pa.field("id", pa.int64()),
+            pa.field("bool_val", pa.bool_()),
+            pa.field("int8_val", pa.int8()),
+            pa.field("int16_val", pa.int16()),
+            pa.field("int32_val", pa.int32()),
+            pa.field("float_val", pa.float32()),
+            pa.field("double_val", pa.float64()),
+            pa.field("varchar_val", pa.string()),
+            pa.field("json_val", pa.string()),
+            pa.field("array_int", pa.list_(pa.int32())),
+            pa.field("array_str", pa.list_(pa.string())),
+            pa.field("ts_val", pa.timestamp("us", tz="UTC")),
+            pa.field("geo_val", pa.string()),
+            pa.field("embedding", pa.binary(embedding_byte_width)),
+            pa.field("bin_vec", pa.binary(bin_vec_byte_width)),
+            pa.field("fp16_vec", pa.binary(fp16_byte_width)),
+            pa.field("bf16_vec", pa.binary(bf16_byte_width)),
+            pa.field("int8_vec", pa.binary(int8_vec_byte_width)),
+        ]
+    )
 
     table = pa.table(
         {
@@ -166,10 +161,7 @@ def main():
         mode="overwrite",
         storage_options=storage_options,
     )
-    print(
-        f"OK rows={ds.count_rows()} fragments={len(ds.get_fragments())} "
-        f"uri={s3_uri}"
-    )
+    print(f"OK rows={ds.count_rows()} fragments={len(ds.get_fragments())} uri={s3_uri}")
 
 
 if __name__ == "__main__":

--- a/tests/go_client/testcases/generate_multi_type_lance_data.py
+++ b/tests/go_client/testcases/generate_multi_type_lance_data.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Generate Lance dataset matching the multi-type schema used by the
+parquet/vortex TestExternalCollectionMultipleDataTypes tests.
+
+Usage:
+    python3 generate_multi_type_lance_data.py <s3_uri> <num_rows> <vec_dim> <bin_vec_dim>
+
+Example:
+    python3 generate_multi_type_lance_data.py \
+        s3://a-bucket/files/external-e2e-test/lance_multi 100 4 8
+
+Schema mirrors generateMultiTypeParquetBytes() / generate_multi_type_vortex_data.py:
+    - id            (Int64)
+    - bool_val      (Bool)
+    - int8_val      (Int8)
+    - int16_val     (Int16)
+    - int32_val     (Int32)
+    - float_val     (Float32)
+    - double_val    (Float64)
+    - varchar_val   (String)
+    - json_val      (String, JSON text)
+    - array_int     (List<Int32>)
+    - array_str     (List<String>)
+    - ts_val        (Timestamp[us, UTC])
+    - geo_val       (String, WKT POINT)
+    - embedding     (FixedSizeBinary[vec_dim * 4])
+    - bin_vec       (FixedSizeBinary[bin_vec_dim/8])
+    - fp16_vec      (FixedSizeBinary[vec_dim*2])
+    - bf16_vec      (FixedSizeBinary[vec_dim*2])
+    - int8_vec      (FixedSizeBinary[vec_dim])
+
+Lance bridge in milvus-storage uses FixedSizeBinary for vectors (see
+lance_bridgeimpl.rs note in generate_lance_data.py).
+
+Environment variables:
+    MINIO_ADDRESS, MINIO_ACCESS_KEY, MINIO_SECRET_KEY
+"""
+import json
+import os
+import struct
+import sys
+
+import lance
+import pyarrow as pa
+
+
+def main():
+    if len(sys.argv) < 5:
+        print(
+            f"Usage: {sys.argv[0]} <s3_uri> <num_rows> <vec_dim> <bin_vec_dim>",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    s3_uri = sys.argv[1]
+    num_rows = int(sys.argv[2])
+    vec_dim = int(sys.argv[3])
+    bin_vec_dim = int(sys.argv[4])
+
+    endpoint = os.environ.get("MINIO_ADDRESS", "localhost:9000")
+    access_key = os.environ.get("MINIO_ACCESS_KEY", "minioadmin")
+    secret_key = os.environ.get("MINIO_SECRET_KEY", "minioadmin")
+
+    embedding_byte_width = vec_dim * 4
+    bin_vec_byte_width = bin_vec_dim // 8
+    fp16_byte_width = vec_dim * 2
+    bf16_byte_width = vec_dim * 2
+    int8_vec_byte_width = vec_dim
+
+    ids = list(range(num_rows))
+
+    bool_vals = [i % 2 == 0 for i in ids]
+    int8_vals = [i % 100 for i in ids]
+    int16_vals = [i * 10 for i in ids]
+    int32_vals = [i * 100 for i in ids]
+    float_vals = [float(i) * 1.5 for i in ids]
+    double_vals = [float(i) * 0.01 for i in ids]
+    varchar_vals = [f"str_{i:04d}" for i in ids]
+    # Compact JSON (no spaces) — matches verifier substring assertions.
+    json_vals = [
+        json.dumps({"key": i, "name": f"item_{i}"}, separators=(",", ":"))
+        for i in ids
+    ]
+
+    array_int_vals = [[i, i * 2, i * 3] for i in ids]
+    array_str_vals = [[f"tag_{i}_a", f"tag_{i}_b"] for i in ids]
+
+    # Timestamp[us]: 2025-01-01T00:00:00Z = 1735689600000000us + i hours
+    ts_vals = [1735689600000000 + i * 3600000000 for i in ids]
+
+    # Geometry: WKT POINT
+    geo_vals = [f"POINT({i} {i * 0.1:.1f})" for i in ids]
+
+    # FloatVector packed as float32 bytes
+    embedding_rows = [
+        struct.pack(f"{vec_dim}f", *[float(i) * 0.1 + d for d in range(vec_dim)])
+        for i in ids
+    ]
+
+    def gen_bytes_block(byte_width):
+        return [
+            bytes((i + b) % 256 for b in range(byte_width)) for i in ids
+        ]
+
+    bin_vec_rows = gen_bytes_block(bin_vec_byte_width)
+    fp16_vec_rows = gen_bytes_block(fp16_byte_width)
+    bf16_vec_rows = gen_bytes_block(bf16_byte_width)
+    int8_vec_rows = gen_bytes_block(int8_vec_byte_width)
+
+    schema = pa.schema([
+        pa.field("id", pa.int64()),
+        pa.field("bool_val", pa.bool_()),
+        pa.field("int8_val", pa.int8()),
+        pa.field("int16_val", pa.int16()),
+        pa.field("int32_val", pa.int32()),
+        pa.field("float_val", pa.float32()),
+        pa.field("double_val", pa.float64()),
+        pa.field("varchar_val", pa.string()),
+        pa.field("json_val", pa.string()),
+        pa.field("array_int", pa.list_(pa.int32())),
+        pa.field("array_str", pa.list_(pa.string())),
+        pa.field("ts_val", pa.timestamp("us", tz="UTC")),
+        pa.field("geo_val", pa.string()),
+        pa.field("embedding", pa.binary(embedding_byte_width)),
+        pa.field("bin_vec", pa.binary(bin_vec_byte_width)),
+        pa.field("fp16_vec", pa.binary(fp16_byte_width)),
+        pa.field("bf16_vec", pa.binary(bf16_byte_width)),
+        pa.field("int8_vec", pa.binary(int8_vec_byte_width)),
+    ])
+
+    table = pa.table(
+        {
+            "id": pa.array(ids, type=pa.int64()),
+            "bool_val": pa.array(bool_vals, type=pa.bool_()),
+            "int8_val": pa.array(int8_vals, type=pa.int8()),
+            "int16_val": pa.array(int16_vals, type=pa.int16()),
+            "int32_val": pa.array(int32_vals, type=pa.int32()),
+            "float_val": pa.array(float_vals, type=pa.float32()),
+            "double_val": pa.array(double_vals, type=pa.float64()),
+            "varchar_val": pa.array(varchar_vals, type=pa.string()),
+            "json_val": pa.array(json_vals, type=pa.string()),
+            "array_int": pa.array(array_int_vals, type=pa.list_(pa.int32())),
+            "array_str": pa.array(array_str_vals, type=pa.list_(pa.string())),
+            "ts_val": pa.array(ts_vals, type=pa.timestamp("us", tz="UTC")),
+            "geo_val": pa.array(geo_vals, type=pa.string()),
+            "embedding": pa.array(embedding_rows, type=pa.binary(embedding_byte_width)),
+            "bin_vec": pa.array(bin_vec_rows, type=pa.binary(bin_vec_byte_width)),
+            "fp16_vec": pa.array(fp16_vec_rows, type=pa.binary(fp16_byte_width)),
+            "bf16_vec": pa.array(bf16_vec_rows, type=pa.binary(bf16_byte_width)),
+            "int8_vec": pa.array(int8_vec_rows, type=pa.binary(int8_vec_byte_width)),
+        },
+        schema=schema,
+    )
+
+    storage_options = {
+        "aws_access_key_id": access_key,
+        "aws_secret_access_key": secret_key,
+        "aws_endpoint": f"http://{endpoint}",
+        "aws_region": "us-east-1",
+        "allow_http": "true",
+    }
+
+    ds = lance.write_dataset(
+        table,
+        s3_uri,
+        mode="overwrite",
+        storage_options=storage_options,
+    )
+    print(
+        f"OK rows={ds.count_rows()} fragments={len(ds.get_fragments())} "
+        f"uri={s3_uri}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/go_client/testcases/generate_multi_type_vortex_data.py
+++ b/tests/go_client/testcases/generate_multi_type_vortex_data.py
@@ -32,6 +32,7 @@ representation (NormalizeVectorArrays handles the conversion).
 Environment variables:
     MINIO_ADDRESS, MINIO_ACCESS_KEY, MINIO_SECRET_KEY, MINIO_BUCKET
 """
+
 import json
 import os
 import sys
@@ -73,10 +74,7 @@ def main():
     float_vals = [float(i) * 1.5 for i in ids]
     double_vals = [float(i) * 0.01 for i in ids]
     varchar_vals = [f"str_{i:04d}" for i in ids]
-    json_vals = [
-        json.dumps({"key": i, "name": f"item_{i}"}, separators=(",", ":"))
-        for i in ids
-    ]
+    json_vals = [json.dumps({"key": i, "name": f"item_{i}"}, separators=(",", ":")) for i in ids]
 
     # Array<Int32>: [i*1, i*2, i*3]
     array_int_vals = [[i, i * 2, i * 3] for i in ids]
@@ -95,7 +93,8 @@ def main():
         for d in range(vec_dim):
             embedding_flat.append(float(i) * 0.1 + d)
     embedding_arr = pa.FixedSizeListArray.from_arrays(
-        pa.array(embedding_flat, type=pa.float32()), vec_dim,
+        pa.array(embedding_flat, type=pa.float32()),
+        vec_dim,
     )
 
     # BinaryVector / FP16 / BF16 / Int8Vector — all FixedSizeList<UInt8>
@@ -105,7 +104,8 @@ def main():
             for b in range(byte_width):
                 flat.append((i + b) % 256)
         return pa.FixedSizeListArray.from_arrays(
-            pa.array(flat, type=pa.uint8()), byte_width,
+            pa.array(flat, type=pa.uint8()),
+            byte_width,
         )
 
     bin_vec_arr = gen_uint8_block(bin_vec_byte_width)
@@ -113,26 +113,28 @@ def main():
     bf16_vec_arr = gen_uint8_block(bf16_byte_width)
     int8_vec_arr = gen_uint8_block(int8_vec_byte_width)
 
-    table = pa.table({
-        "id": pa.array(ids, type=pa.int64()),
-        "bool_val": pa.array(bool_vals, type=pa.bool_()),
-        "int8_val": pa.array(int8_vals, type=pa.int8()),
-        "int16_val": pa.array(int16_vals, type=pa.int16()),
-        "int32_val": pa.array(int32_vals, type=pa.int32()),
-        "float_val": pa.array(float_vals, type=pa.float32()),
-        "double_val": pa.array(double_vals, type=pa.float64()),
-        "varchar_val": pa.array(varchar_vals, type=pa.string()),
-        "json_val": pa.array(json_vals, type=pa.string()),
-        "array_int": pa.array(array_int_vals, type=pa.list_(pa.int32())),
-        "array_str": pa.array(array_str_vals, type=pa.list_(pa.string())),
-        "ts_val": pa.array(ts_vals, type=pa.timestamp("us", tz="UTC")),
-        "geo_val": pa.array(geo_vals, type=pa.string()),
-        "embedding": embedding_arr,
-        "bin_vec": bin_vec_arr,
-        "fp16_vec": fp16_vec_arr,
-        "bf16_vec": bf16_vec_arr,
-        "int8_vec": int8_vec_arr,
-    })
+    table = pa.table(
+        {
+            "id": pa.array(ids, type=pa.int64()),
+            "bool_val": pa.array(bool_vals, type=pa.bool_()),
+            "int8_val": pa.array(int8_vals, type=pa.int8()),
+            "int16_val": pa.array(int16_vals, type=pa.int16()),
+            "int32_val": pa.array(int32_vals, type=pa.int32()),
+            "float_val": pa.array(float_vals, type=pa.float32()),
+            "double_val": pa.array(double_vals, type=pa.float64()),
+            "varchar_val": pa.array(varchar_vals, type=pa.string()),
+            "json_val": pa.array(json_vals, type=pa.string()),
+            "array_int": pa.array(array_int_vals, type=pa.list_(pa.int32())),
+            "array_str": pa.array(array_str_vals, type=pa.list_(pa.string())),
+            "ts_val": pa.array(ts_vals, type=pa.timestamp("us", tz="UTC")),
+            "geo_val": pa.array(geo_vals, type=pa.string()),
+            "embedding": embedding_arr,
+            "bin_vec": bin_vec_arr,
+            "fp16_vec": fp16_vec_arr,
+            "bf16_vec": bf16_vec_arr,
+            "int8_vec": int8_vec_arr,
+        }
+    )
 
     with tempfile.NamedTemporaryFile(suffix=".vortex", delete=False) as tmp:
         tmp_path = tmp.name

--- a/tests/go_client/testcases/generate_multi_type_vortex_data.py
+++ b/tests/go_client/testcases/generate_multi_type_vortex_data.py
@@ -34,14 +34,13 @@ Environment variables:
 """
 import json
 import os
-import struct
 import sys
 import tempfile
 
 import obstore
 import pyarrow as pa
-import vortex.io  # noqa: F401
 import vortex as vx
+import vortex.io  # noqa: F401
 from obstore.store import S3Store
 
 

--- a/tests/go_client/testcases/generate_multi_type_vortex_data.py
+++ b/tests/go_client/testcases/generate_multi_type_vortex_data.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Generate Vortex dataset matching the multi-type schema used by the
+parquet TestExternalCollectionMultipleDataTypes test.
+
+Usage:
+    python3 generate_multi_type_vortex_data.py <output_path> <num_rows> <vec_dim> <bin_vec_dim>
+
+Schema mirrors generateMultiTypeParquetBytes():
+    - id            (Int64)
+    - bool_val      (Bool)
+    - int8_val      (Int8)
+    - int16_val     (Int16)
+    - int32_val     (Int32)
+    - float_val     (Float32)
+    - double_val    (Float64)
+    - varchar_val   (String)
+    - json_val      (String, JSON text)
+    - array_int     (List<Int32>)
+    - array_str     (List<String>)
+    - ts_val        (Timestamp[us, UTC])
+    - geo_val       (String, WKT POINT)
+    - embedding     (FixedSizeList<Float32, vec_dim>)
+    - bin_vec       (FixedSizeList<UInt8, bin_vec_dim/8>)
+    - fp16_vec      (FixedSizeList<UInt8, vec_dim*2>)
+    - bf16_vec      (FixedSizeList<UInt8, vec_dim*2>)
+    - int8_vec      (FixedSizeList<UInt8, vec_dim>)
+
+vortex-data 0.56.0 doesn't support FixedSizeBinary directly; binary
+vectors are written as FixedSizeList<UInt8>, matching milvus's internal
+representation (NormalizeVectorArrays handles the conversion).
+
+Environment variables:
+    MINIO_ADDRESS, MINIO_ACCESS_KEY, MINIO_SECRET_KEY, MINIO_BUCKET
+"""
+import json
+import os
+import struct
+import sys
+import tempfile
+
+import obstore
+import pyarrow as pa
+import vortex.io  # noqa: F401
+import vortex as vx
+from obstore.store import S3Store
+
+
+def main():
+    if len(sys.argv) < 5:
+        print(f"Usage: {sys.argv[0]} <output_path> <num_rows> <vec_dim> <bin_vec_dim>", file=sys.stderr)
+        sys.exit(1)
+
+    output_path = sys.argv[1]
+    num_rows = int(sys.argv[2])
+    vec_dim = int(sys.argv[3])
+    bin_vec_dim = int(sys.argv[4])
+
+    endpoint = os.environ.get("MINIO_ADDRESS", "localhost:9000")
+    access_key = os.environ.get("MINIO_ACCESS_KEY", "minioadmin")
+    secret_key = os.environ.get("MINIO_SECRET_KEY", "minioadmin")
+    bucket = os.environ.get("MINIO_BUCKET", "a-bucket")
+
+    bin_vec_byte_width = bin_vec_dim // 8
+    fp16_byte_width = vec_dim * 2
+    bf16_byte_width = vec_dim * 2
+    int8_vec_byte_width = vec_dim
+
+    ids = list(range(num_rows))
+
+    bool_vals = [i % 2 == 0 for i in ids]
+    int8_vals = [i % 100 for i in ids]
+    int16_vals = [i * 10 for i in ids]
+    int32_vals = [i * 100 for i in ids]
+    float_vals = [float(i) * 1.5 for i in ids]
+    double_vals = [float(i) * 0.01 for i in ids]
+    varchar_vals = [f"str_{i:04d}" for i in ids]
+    json_vals = [
+        json.dumps({"key": i, "name": f"item_{i}"}, separators=(",", ":"))
+        for i in ids
+    ]
+
+    # Array<Int32>: [i*1, i*2, i*3]
+    array_int_vals = [[i, i * 2, i * 3] for i in ids]
+    # Array<String>: ["tag_<i>_a", "tag_<i>_b"]
+    array_str_vals = [[f"tag_{i}_a", f"tag_{i}_b"] for i in ids]
+
+    # Timestamp[us]: 2025-01-01T00:00:00Z = 1735689600000000us + i hours
+    ts_vals = [1735689600000000 + i * 3600000000 for i in ids]
+
+    # Geometry: WKT POINT
+    geo_vals = [f"POINT({i} {i * 0.1:.1f})" for i in ids]
+
+    # FloatVector
+    embedding_flat = []
+    for i in ids:
+        for d in range(vec_dim):
+            embedding_flat.append(float(i) * 0.1 + d)
+    embedding_arr = pa.FixedSizeListArray.from_arrays(
+        pa.array(embedding_flat, type=pa.float32()), vec_dim,
+    )
+
+    # BinaryVector / FP16 / BF16 / Int8Vector — all FixedSizeList<UInt8>
+    def gen_uint8_block(byte_width):
+        flat = []
+        for i in ids:
+            for b in range(byte_width):
+                flat.append((i + b) % 256)
+        return pa.FixedSizeListArray.from_arrays(
+            pa.array(flat, type=pa.uint8()), byte_width,
+        )
+
+    bin_vec_arr = gen_uint8_block(bin_vec_byte_width)
+    fp16_vec_arr = gen_uint8_block(fp16_byte_width)
+    bf16_vec_arr = gen_uint8_block(bf16_byte_width)
+    int8_vec_arr = gen_uint8_block(int8_vec_byte_width)
+
+    table = pa.table({
+        "id": pa.array(ids, type=pa.int64()),
+        "bool_val": pa.array(bool_vals, type=pa.bool_()),
+        "int8_val": pa.array(int8_vals, type=pa.int8()),
+        "int16_val": pa.array(int16_vals, type=pa.int16()),
+        "int32_val": pa.array(int32_vals, type=pa.int32()),
+        "float_val": pa.array(float_vals, type=pa.float32()),
+        "double_val": pa.array(double_vals, type=pa.float64()),
+        "varchar_val": pa.array(varchar_vals, type=pa.string()),
+        "json_val": pa.array(json_vals, type=pa.string()),
+        "array_int": pa.array(array_int_vals, type=pa.list_(pa.int32())),
+        "array_str": pa.array(array_str_vals, type=pa.list_(pa.string())),
+        "ts_val": pa.array(ts_vals, type=pa.timestamp("us", tz="UTC")),
+        "geo_val": pa.array(geo_vals, type=pa.string()),
+        "embedding": embedding_arr,
+        "bin_vec": bin_vec_arr,
+        "fp16_vec": fp16_vec_arr,
+        "bf16_vec": bf16_vec_arr,
+        "int8_vec": int8_vec_arr,
+    })
+
+    with tempfile.NamedTemporaryFile(suffix=".vortex", delete=False) as tmp:
+        tmp_path = tmp.name
+    vx.io.write(table, tmp_path)
+    data = open(tmp_path, "rb").read()
+    os.unlink(tmp_path)
+
+    store = S3Store(
+        bucket=bucket,
+        config={
+            "access_key_id": access_key,
+            "secret_access_key": secret_key,
+            "endpoint_url": f"http://{endpoint}",
+            "region": "us-east-1",
+            "allow_http": "true",
+        },
+    )
+
+    file_key = f"{output_path}/data.vortex"
+    obstore.put(store, file_key, data)
+
+    print(f"OK rows={num_rows} file={file_key}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/go_client/testcases/generate_vortex_data.py
+++ b/tests/go_client/testcases/generate_vortex_data.py
@@ -27,6 +27,7 @@ Environment variables:
 
 Requires: vortex-data>=0.56.0, pyarrow, obstore (pip install in Python >=3.11)
 """
+
 import json
 import os
 import struct
@@ -71,21 +72,24 @@ def main():
         flat_bytes.extend(struct.pack(f"{dim}f", *[float(i) * 0.1 + j for j in range(dim)]))
 
     embedding_arr = pa.FixedSizeListArray.from_arrays(
-        pa.array(flat_bytes, type=pa.uint8()), byte_width,
+        pa.array(flat_bytes, type=pa.uint8()),
+        byte_width,
     )
 
     varchar_vals = [f"vc_{i}" for i in ids]
     json_vals = [json.dumps({"k": i, "name": f"item_{i}"}) for i in ids]
     geo_vals = [encode_wkb_point(float(i), float(i) * 0.1) for i in ids]
 
-    table = pa.table({
-        "id": pa.array(ids, type=pa.int64()),
-        "value": pa.array(values, type=pa.float32()),
-        "embedding": embedding_arr,
-        "varchar_val": pa.array(varchar_vals, type=pa.string()),
-        "json_val": pa.array(json_vals, type=pa.string()),
-        "geo_val": pa.array(geo_vals, type=pa.binary()),
-    })
+    table = pa.table(
+        {
+            "id": pa.array(ids, type=pa.int64()),
+            "value": pa.array(values, type=pa.float32()),
+            "embedding": embedding_arr,
+            "varchar_val": pa.array(varchar_vals, type=pa.string()),
+            "json_val": pa.array(json_vals, type=pa.string()),
+            "geo_val": pa.array(geo_vals, type=pa.binary()),
+        }
+    )
 
     # vx.io.write() only writes to local filesystem.
     # Write locally then upload to MinIO via obstore.

--- a/tests/go_client/testcases/generate_vortex_data.py
+++ b/tests/go_client/testcases/generate_vortex_data.py
@@ -8,9 +8,16 @@ Example:
     python3 generate_vortex_data.py external-e2e-test/vortex_test 2000 4
 
 Schema:
-    - id (Int64)
-    - value (Float32)
+    - id        (Int64)
+    - value     (Float32)
     - embedding (FixedSizeList<UInt8>[dim * sizeof(float32)])
+    - varchar_val (String)            # exercises Arrow string -> VARCHAR
+    - json_val    (String)            # exercises Arrow string -> JSON
+    - geo_val     (Binary, WKB POINT) # exercises Arrow binary -> GEOMETRY
+
+The string + binary columns are required to repro vortex-specific bugs:
+    - issue #49352: vortex VARCHAR/JSON refresh "Expected 2 buffers, got 3"
+    - issue #49353: vortex GEOMETRY load SIGSEGV
 
 Environment variables:
     MINIO_ADDRESS   (default: localhost:9000)
@@ -20,6 +27,7 @@ Environment variables:
 
 Requires: vortex-data>=0.56.0, pyarrow, obstore (pip install in Python >=3.11)
 """
+import json
 import os
 import struct
 import sys
@@ -30,6 +38,11 @@ import pyarrow as pa
 import vortex.io  # noqa: F401 — ensure vx.io is importable
 import vortex as vx
 from obstore.store import S3Store
+
+
+def encode_wkb_point(x: float, y: float) -> bytes:
+    # WKB layout (little-endian POINT): 1B order + 4B type + 8B x + 8B y
+    return struct.pack("<BIdd", 1, 1, x, y)
 
 
 def main():
@@ -60,10 +73,18 @@ def main():
     embedding_arr = pa.FixedSizeListArray.from_arrays(
         pa.array(flat_bytes, type=pa.uint8()), byte_width,
     )
+
+    varchar_vals = [f"vc_{i}" for i in ids]
+    json_vals = [json.dumps({"k": i, "name": f"item_{i}"}) for i in ids]
+    geo_vals = [encode_wkb_point(float(i), float(i) * 0.1) for i in ids]
+
     table = pa.table({
         "id": pa.array(ids, type=pa.int64()),
         "value": pa.array(values, type=pa.float32()),
         "embedding": embedding_arr,
+        "varchar_val": pa.array(varchar_vals, type=pa.string()),
+        "json_val": pa.array(json_vals, type=pa.string()),
+        "geo_val": pa.array(geo_vals, type=pa.binary()),
     })
 
     # vx.io.write() only writes to local filesystem.

--- a/tests/go_client/testcases/generate_vortex_data.py
+++ b/tests/go_client/testcases/generate_vortex_data.py
@@ -35,8 +35,8 @@ import tempfile
 
 import obstore
 import pyarrow as pa
-import vortex.io  # noqa: F401 — ensure vx.io is importable
 import vortex as vx
+import vortex.io  # noqa: F401 — ensure vx.io is importable
 from obstore.store import S3Store
 
 

--- a/tests/go_client/testcases/testdata/create_iceberg_multi_type_table.py
+++ b/tests/go_client/testcases/testdata/create_iceberg_multi_type_table.py
@@ -55,21 +55,13 @@ def create_test_data(num_rows: int, vec_dim: int, bin_vec_dim: int) -> pa.Table:
     float_vals = [float(i) * 1.5 for i in ids]
     double_vals = [float(i) * 0.01 for i in ids]
     varchar_vals = [f"str_{i:04d}" for i in ids]
-    json_vals = [
-        json.dumps({"key": i, "name": f"item_{i}"}, separators=(",", ":"))
-        for i in ids
-    ]
+    json_vals = [json.dumps({"key": i, "name": f"item_{i}"}, separators=(",", ":")) for i in ids]
     array_int_vals = [[i, i * 2, i * 3] for i in ids]
     array_str_vals = [[f"tag_{i}_a", f"tag_{i}_b"] for i in ids]
     ts_vals = [1735689600000000 + i * 3600000000 for i in ids]
     geo_vals = [f"POINT({i} {i * 0.1:.1f})" for i in ids]
 
-    embedding_rows = [
-        struct.pack(
-            f"{vec_dim}f", *[float(i) * 0.1 + d for d in range(vec_dim)]
-        )
-        for i in ids
-    ]
+    embedding_rows = [struct.pack(f"{vec_dim}f", *[float(i) * 0.1 + d for d in range(vec_dim)]) for i in ids]
 
     def gen_bytes_block(byte_width):
         return [bytes((i + b) % 256 for b in range(byte_width)) for i in ids]
@@ -79,26 +71,28 @@ def create_test_data(num_rows: int, vec_dim: int, bin_vec_dim: int) -> pa.Table:
     bf16_vec_rows = gen_bytes_block(bf16_byte_width)
     int8_vec_rows = gen_bytes_block(int8_vec_byte_width)
 
-    schema = pa.schema([
-        pa.field("id", pa.int64()),
-        pa.field("bool_val", pa.bool_()),
-        pa.field("int8_val", pa.int8()),
-        pa.field("int16_val", pa.int16()),
-        pa.field("int32_val", pa.int32()),
-        pa.field("float_val", pa.float32()),
-        pa.field("double_val", pa.float64()),
-        pa.field("varchar_val", pa.string()),
-        pa.field("json_val", pa.string()),
-        pa.field("array_int", pa.list_(pa.int32())),
-        pa.field("array_str", pa.list_(pa.string())),
-        pa.field("ts_val", pa.timestamp("us", tz="UTC")),
-        pa.field("geo_val", pa.string()),
-        pa.field("embedding", pa.binary(embedding_byte_width)),
-        pa.field("bin_vec", pa.binary(bin_vec_byte_width)),
-        pa.field("fp16_vec", pa.binary(fp16_byte_width)),
-        pa.field("bf16_vec", pa.binary(bf16_byte_width)),
-        pa.field("int8_vec", pa.binary(int8_vec_byte_width)),
-    ])
+    schema = pa.schema(
+        [
+            pa.field("id", pa.int64()),
+            pa.field("bool_val", pa.bool_()),
+            pa.field("int8_val", pa.int8()),
+            pa.field("int16_val", pa.int16()),
+            pa.field("int32_val", pa.int32()),
+            pa.field("float_val", pa.float32()),
+            pa.field("double_val", pa.float64()),
+            pa.field("varchar_val", pa.string()),
+            pa.field("json_val", pa.string()),
+            pa.field("array_int", pa.list_(pa.int32())),
+            pa.field("array_str", pa.list_(pa.string())),
+            pa.field("ts_val", pa.timestamp("us", tz="UTC")),
+            pa.field("geo_val", pa.string()),
+            pa.field("embedding", pa.binary(embedding_byte_width)),
+            pa.field("bin_vec", pa.binary(bin_vec_byte_width)),
+            pa.field("fp16_vec", pa.binary(fp16_byte_width)),
+            pa.field("bf16_vec", pa.binary(bf16_byte_width)),
+            pa.field("int8_vec", pa.binary(int8_vec_byte_width)),
+        ]
+    )
 
     return pa.table(
         {
@@ -208,8 +202,8 @@ def main():
     }
     print(json.dumps(result, indent=2))
 
-    output_path = args.output if args.output else os.path.join(
-        os.path.dirname(__file__), "iceberg_multi_type_info.json"
+    output_path = (
+        args.output if args.output else os.path.join(os.path.dirname(__file__), "iceberg_multi_type_info.json")
     )
     with open(output_path, "w") as f:
         json.dump(result, f, indent=2)

--- a/tests/go_client/testcases/testdata/create_iceberg_multi_type_table.py
+++ b/tests/go_client/testcases/testdata/create_iceberg_multi_type_table.py
@@ -26,7 +26,6 @@ import pyarrow as pa
 from pyiceberg.catalog.sql import SqlCatalog
 from pyiceberg.schema import Schema
 from pyiceberg.types import (
-    BinaryType,
     BooleanType,
     DoubleType,
     FixedType,

--- a/tests/go_client/testcases/testdata/create_iceberg_multi_type_table.py
+++ b/tests/go_client/testcases/testdata/create_iceberg_multi_type_table.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Create Iceberg table mirroring the 18-column multi-type schema used by
+parquet/vortex/lance TestExternalCollectionMultipleDataTypes tests.
+
+Schema names + semantics match generate_multi_type_vortex_data.py and
+generate_multi_type_lance_data.py. Exercises the same milvus type matrix
+across the iceberg-table source path.
+
+Iceberg type mapping notes:
+  - Int8/Int16 use IntegerType (iceberg lacks narrow ints); milvus narrows.
+  - Vector fields use FixedType(byte_width) (iceberg's fixed-length binary).
+  - Geometry uses StringType (WKT) — milvus converts WKT->WKB.
+
+Usage:
+    python3 create_iceberg_multi_type_table.py \
+        [--endpoint http://localhost:9000] [--num-rows 100] \
+        [--vec-dim 4] [--bin-vec-dim 8] [--output info.json]
+"""
+
+import argparse
+import json
+import os
+import struct
+
+import pyarrow as pa
+from pyiceberg.catalog.sql import SqlCatalog
+from pyiceberg.schema import Schema
+from pyiceberg.types import (
+    BinaryType,
+    BooleanType,
+    DoubleType,
+    FixedType,
+    FloatType,
+    IntegerType,
+    ListType,
+    LongType,
+    NestedField,
+    StringType,
+    TimestamptzType,
+)
+
+
+def create_test_data(num_rows: int, vec_dim: int, bin_vec_dim: int) -> pa.Table:
+    embedding_byte_width = vec_dim * 4
+    bin_vec_byte_width = bin_vec_dim // 8
+    fp16_byte_width = vec_dim * 2
+    bf16_byte_width = vec_dim * 2
+    int8_vec_byte_width = vec_dim
+
+    ids = list(range(num_rows))
+
+    bool_vals = [i % 2 == 0 for i in ids]
+    int8_vals = [i % 100 for i in ids]
+    int16_vals = [i * 10 for i in ids]
+    int32_vals = [i * 100 for i in ids]
+    float_vals = [float(i) * 1.5 for i in ids]
+    double_vals = [float(i) * 0.01 for i in ids]
+    varchar_vals = [f"str_{i:04d}" for i in ids]
+    json_vals = [
+        json.dumps({"key": i, "name": f"item_{i}"}, separators=(",", ":"))
+        for i in ids
+    ]
+    array_int_vals = [[i, i * 2, i * 3] for i in ids]
+    array_str_vals = [[f"tag_{i}_a", f"tag_{i}_b"] for i in ids]
+    ts_vals = [1735689600000000 + i * 3600000000 for i in ids]
+    geo_vals = [f"POINT({i} {i * 0.1:.1f})" for i in ids]
+
+    embedding_rows = [
+        struct.pack(
+            f"{vec_dim}f", *[float(i) * 0.1 + d for d in range(vec_dim)]
+        )
+        for i in ids
+    ]
+
+    def gen_bytes_block(byte_width):
+        return [bytes((i + b) % 256 for b in range(byte_width)) for i in ids]
+
+    bin_vec_rows = gen_bytes_block(bin_vec_byte_width)
+    fp16_vec_rows = gen_bytes_block(fp16_byte_width)
+    bf16_vec_rows = gen_bytes_block(bf16_byte_width)
+    int8_vec_rows = gen_bytes_block(int8_vec_byte_width)
+
+    schema = pa.schema([
+        pa.field("id", pa.int64()),
+        pa.field("bool_val", pa.bool_()),
+        pa.field("int8_val", pa.int8()),
+        pa.field("int16_val", pa.int16()),
+        pa.field("int32_val", pa.int32()),
+        pa.field("float_val", pa.float32()),
+        pa.field("double_val", pa.float64()),
+        pa.field("varchar_val", pa.string()),
+        pa.field("json_val", pa.string()),
+        pa.field("array_int", pa.list_(pa.int32())),
+        pa.field("array_str", pa.list_(pa.string())),
+        pa.field("ts_val", pa.timestamp("us", tz="UTC")),
+        pa.field("geo_val", pa.string()),
+        pa.field("embedding", pa.binary(embedding_byte_width)),
+        pa.field("bin_vec", pa.binary(bin_vec_byte_width)),
+        pa.field("fp16_vec", pa.binary(fp16_byte_width)),
+        pa.field("bf16_vec", pa.binary(bf16_byte_width)),
+        pa.field("int8_vec", pa.binary(int8_vec_byte_width)),
+    ])
+
+    return pa.table(
+        {
+            "id": pa.array(ids, type=pa.int64()),
+            "bool_val": pa.array(bool_vals, type=pa.bool_()),
+            "int8_val": pa.array(int8_vals, type=pa.int8()),
+            "int16_val": pa.array(int16_vals, type=pa.int16()),
+            "int32_val": pa.array(int32_vals, type=pa.int32()),
+            "float_val": pa.array(float_vals, type=pa.float32()),
+            "double_val": pa.array(double_vals, type=pa.float64()),
+            "varchar_val": pa.array(varchar_vals, type=pa.string()),
+            "json_val": pa.array(json_vals, type=pa.string()),
+            "array_int": pa.array(array_int_vals, type=pa.list_(pa.int32())),
+            "array_str": pa.array(array_str_vals, type=pa.list_(pa.string())),
+            "ts_val": pa.array(ts_vals, type=pa.timestamp("us", tz="UTC")),
+            "geo_val": pa.array(geo_vals, type=pa.string()),
+            "embedding": pa.array(embedding_rows, type=pa.binary(embedding_byte_width)),
+            "bin_vec": pa.array(bin_vec_rows, type=pa.binary(bin_vec_byte_width)),
+            "fp16_vec": pa.array(fp16_vec_rows, type=pa.binary(fp16_byte_width)),
+            "bf16_vec": pa.array(bf16_vec_rows, type=pa.binary(bf16_byte_width)),
+            "int8_vec": pa.array(int8_vec_rows, type=pa.binary(int8_vec_byte_width)),
+        },
+        schema=schema,
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Create Iceberg multi-type table on MinIO")
+    parser.add_argument("--endpoint", default="http://localhost:9000")
+    parser.add_argument("--access-key", default="minioadmin")
+    parser.add_argument("--secret-key", default="minioadmin")
+    parser.add_argument("--bucket", default="a-bucket")
+    parser.add_argument("--table-path", default="iceberg-test/multi_type_table")
+    parser.add_argument("--num-rows", type=int, default=100)
+    parser.add_argument("--vec-dim", type=int, default=4)
+    parser.add_argument("--bin-vec-dim", type=int, default=8)
+    parser.add_argument("--output", default="")
+    args = parser.parse_args()
+
+    embedding_byte_width = args.vec_dim * 4
+    bin_vec_byte_width = args.bin_vec_dim // 8
+    fp16_byte_width = args.vec_dim * 2
+    bf16_byte_width = args.vec_dim * 2
+    int8_vec_byte_width = args.vec_dim
+
+    warehouse_path = f"s3://{args.bucket}/{args.table_path}"
+
+    catalog = SqlCatalog(
+        "test_catalog",
+        **{
+            "uri": "sqlite:///:memory:",
+            "s3.endpoint": args.endpoint,
+            "s3.access-key-id": args.access_key,
+            "s3.secret-access-key": args.secret_key,
+            "s3.region": "us-east-1",
+            "warehouse": warehouse_path,
+        },
+    )
+
+    try:
+        catalog.create_namespace("default")
+    except Exception:
+        pass
+
+    iceberg_schema = Schema(
+        NestedField(1, "id", LongType(), required=False),
+        NestedField(2, "bool_val", BooleanType(), required=False),
+        NestedField(3, "int8_val", IntegerType(), required=False),
+        NestedField(4, "int16_val", IntegerType(), required=False),
+        NestedField(5, "int32_val", IntegerType(), required=False),
+        NestedField(6, "float_val", FloatType(), required=False),
+        NestedField(7, "double_val", DoubleType(), required=False),
+        NestedField(8, "varchar_val", StringType(), required=False),
+        NestedField(9, "json_val", StringType(), required=False),
+        NestedField(10, "array_int", ListType(20, IntegerType(), element_required=False), required=False),
+        NestedField(11, "array_str", ListType(21, StringType(), element_required=False), required=False),
+        NestedField(12, "ts_val", TimestamptzType(), required=False),
+        NestedField(13, "geo_val", StringType(), required=False),
+        NestedField(14, "embedding", FixedType(embedding_byte_width), required=False),
+        NestedField(15, "bin_vec", FixedType(bin_vec_byte_width), required=False),
+        NestedField(16, "fp16_vec", FixedType(fp16_byte_width), required=False),
+        NestedField(17, "bf16_vec", FixedType(bf16_byte_width), required=False),
+        NestedField(18, "int8_vec", FixedType(int8_vec_byte_width), required=False),
+    )
+
+    table_name = "default.multi_type"
+    try:
+        catalog.drop_table(table_name)
+    except Exception:
+        pass
+
+    table = catalog.create_table(table_name, schema=iceberg_schema)
+
+    data = create_test_data(args.num_rows, args.vec_dim, args.bin_vec_dim)
+    table.append(data)
+
+    table = catalog.load_table(table_name)
+    snapshot = table.current_snapshot()
+
+    result = {
+        "table_location": table.location(),
+        "metadata_location": table.metadata_location,
+        "snapshot_id": snapshot.snapshot_id,
+        "num_rows": args.num_rows,
+        "vec_dim": args.vec_dim,
+        "bin_vec_dim": args.bin_vec_dim,
+    }
+    print(json.dumps(result, indent=2))
+
+    output_path = args.output if args.output else os.path.join(
+        os.path.dirname(__file__), "iceberg_multi_type_info.json"
+    )
+    with open(output_path, "w") as f:
+        json.dump(result, f, indent=2)
+    print(f"\nTable info written to: {output_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
issue: #49335, #48830, #49338, #49334, #49292, #49336

## Summary
This PR delivers a stability hardening pack for external table lifecycle and spec handling.

### 1) Alter/Refresh metadata correctness
- Guard invalid tuple transitions in alter-collection path.
- Persist refreshed external tuple on refresh completion.
- Disable unsupported `TruncateCollection` on external collections.

### 2) ExternalSpec safety and contract clarity
- Require explicit `cloud_provider`; remove scheme-based inference.
- Redact credentials from `DescribeCollection`.
- Reserve system field names (including `__virtual_pk__`) from user schema.

### 3) Runtime robustness and edge-case handling
- Skip anonymous entries in extfs Layer0 zero-init.
- Align DataNode explore-manifest sort + format-filter behavior.
- Prevent datanode crash on zero-row parquet.
- Surface real sampling error in `RefreshFailed`.
- Improve compatibility for vortex schemaless view and large Arrow type variants.

## Why
External-table alter/refresh flows had validation and persistence gaps, plus multiple edge-case failures in runtime paths.
This PR closes those gaps to make behavior safer, deterministic, and debuggable.

## Test Plan
- Unit:
  - `pkg/util/externalspec/external_spec_test.go`
  - `internal/rootcoord/create_collection_task_test.go`
  - `internal/rootcoord/ddl_callbacks_alter_collection_properties_test.go`
  - `internal/core/unittest/test_external_take.cpp`
- E2E / go client:
  - `tests/go_client/testcases/external_table_test.go`
  - `tests/go_client/testcases/external_table_iceberg_e2e_test.go`