### PR TITLE
fix: [cp2.6]add mutex to broadcaster registry and balance singleton to fix data race

### DIFF
--- a/internal/streamingcoord/server/balancer/balance/singleton.go
+++ b/internal/streamingcoord/server/balancer/balance/singleton.go
@@ -2,24 +2,37 @@ package balance
 
 import (
 	"context"
+	"sync"
 
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/balancer"
 	"github.com/milvus-io/milvus/pkg/v2/util/syncutil"
 )
 
-var singleton = syncutil.NewFuture[balancer.Balancer]()
+var (
+	singletonMu sync.RWMutex
+	singleton   = syncutil.NewFuture[balancer.Balancer]()
+)
 
 func Register(balancer balancer.Balancer) {
-	singleton.Set(balancer)
+	singletonMu.RLock()
+	s := singleton
+	singletonMu.RUnlock()
+	s.Set(balancer)
 }
 
 func GetWithContext(ctx context.Context) (balancer.Balancer, error) {
-	return singleton.GetWithContext(ctx)
+	singletonMu.RLock()
+	s := singleton
+	singletonMu.RUnlock()
+	return s.GetWithContext(ctx)
 }
 
 func Release() {
-	if !singleton.Ready() {
+	singletonMu.RLock()
+	s := singleton
+	singletonMu.RUnlock()
+	if !s.Ready() {
 		return
 	}
-	singleton.Get().Close()
+	s.Get().Close()
 }

--- a/internal/streamingcoord/server/balancer/balance/test_utility.go
+++ b/internal/streamingcoord/server/balancer/balance/test_utility.go
@@ -9,5 +9,7 @@ import (
 )
 
 func ResetBalancer() {
+	singletonMu.Lock()
+	defer singletonMu.Unlock()
 	singleton = syncutil.NewFuture[balancer.Balancer]()
 }

--- a/internal/streamingcoord/server/broadcaster/registry/ack_message_callback.go
+++ b/internal/streamingcoord/server/broadcaster/registry/ack_message_callback.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/cockroachdb/errors"
 	"google.golang.org/protobuf/proto"
@@ -19,12 +20,19 @@ type (
 )
 
 // messageAckCallbacks is the map of message type to the callback function.
-var messageAckCallbacks map[message.MessageTypeWithVersion]*syncutil.Future[messageInnerAckCallback]
+// Protected by messageAckCallbacksMu for concurrent access from tests (ResetRegistration)
+// and broadcaster goroutines (CallMessageAckCallback).
+var (
+	messageAckCallbacksMu sync.RWMutex
+	messageAckCallbacks   map[message.MessageTypeWithVersion]*syncutil.Future[messageInnerAckCallback]
+)
 
 // registerMessageAckCallback registers the callback function for the message type.
 func registerMessageAckCallback[H proto.Message, B proto.Message](callback MessageAckCallback[H, B]) {
 	typ := message.MustGetMessageTypeWithVersion[H, B]()
+	messageAckCallbacksMu.RLock()
 	future, ok := messageAckCallbacks[typ]
+	messageAckCallbacksMu.RUnlock()
 	if !ok {
 		panic(fmt.Sprintf("the future of message callback for type %s is not registered", typ))
 	}
@@ -43,7 +51,9 @@ func registerMessageAckCallback[H proto.Message, B proto.Message](callback Messa
 // CallMessageAckCallback calls the callback function for the message type.
 func CallMessageAckCallback(ctx context.Context, msg message.BroadcastMutableMessage, result map[string]*message.AppendResult) error {
 	version := msg.MessageTypeWithVersion()
+	messageAckCallbacksMu.RLock()
 	callbackFuture, ok := messageAckCallbacks[version]
+	messageAckCallbacksMu.RUnlock()
 	if !ok {
 		// No callback need tobe called, return nil
 		return nil

--- a/internal/streamingcoord/server/broadcaster/registry/ack_once_message_callback.go
+++ b/internal/streamingcoord/server/broadcaster/registry/ack_once_message_callback.go
@@ -20,12 +20,19 @@ type (
 )
 
 // messageAckOnceCallbacks is the map of message type to the ack once callback function.
-var messageAckOnceCallbacks map[message.MessageTypeWithVersion]*syncutil.Future[messageInnerAckOnceCallback]
+// Protected by messageAckOnceCallbacksMu for concurrent access from tests (ResetRegistration)
+// and broadcaster goroutines (CallMessageAckOnceCallbacks).
+var (
+	messageAckOnceCallbacksMu sync.RWMutex
+	messageAckOnceCallbacks   map[message.MessageTypeWithVersion]*syncutil.Future[messageInnerAckOnceCallback]
+)
 
 // registerMessageAckOnceCallback registers the ack once callback function for the message type.
 func registerMessageAckOnceCallback[H proto.Message, B proto.Message](callback MessageAckOnceCallback[H, B]) {
 	typ := message.MustGetMessageTypeWithVersion[H, B]()
+	messageAckOnceCallbacksMu.RLock()
 	future, ok := messageAckOnceCallbacks[typ]
+	messageAckOnceCallbacksMu.RUnlock()
 	if !ok {
 		panic(fmt.Sprintf("the future of ack once callback for type %s is not registered", typ))
 	}
@@ -70,7 +77,9 @@ func CallMessageAckOnceCallbacks(ctx context.Context, msgs ...message.ImmutableM
 
 // callMessageAckOnceCallback calls the ack once callback function for the message type.
 func callMessageAckOnceCallback(ctx context.Context, msg message.ImmutableMessage) error {
+	messageAckOnceCallbacksMu.RLock()
 	callbackFuture, ok := messageAckOnceCallbacks[msg.MessageTypeWithVersion()]
+	messageAckOnceCallbacksMu.RUnlock()
 	if !ok {
 		// No callback need tobe called, return nil
 		return nil

--- a/internal/streamingcoord/server/broadcaster/registry/specialized_ack_once_callback.go
+++ b/internal/streamingcoord/server/broadcaster/registry/specialized_ack_once_callback.go
@@ -25,6 +25,8 @@ import (
 var RegisterTruncateCollectionV2AckOnceCallback = registerMessageAckOnceCallback[*message.TruncateCollectionMessageHeader, *message.TruncateCollectionMessageBody]
 
 func resetMessageAckOnceCallbacks() {
+	messageAckOnceCallbacksMu.Lock()
+	defer messageAckOnceCallbacksMu.Unlock()
 	messageAckOnceCallbacks = map[message.MessageTypeWithVersion]*syncutil.Future[messageInnerAckOnceCallback]{
 		message.MessageTypeTruncateCollectionV2: syncutil.NewFuture[messageInnerAckOnceCallback](),
 	}

--- a/internal/streamingcoord/server/broadcaster/registry/specialized_callback.go
+++ b/internal/streamingcoord/server/broadcaster/registry/specialized_callback.go
@@ -68,6 +68,8 @@ var (
 
 // resetMessageAckCallbacks resets the message ack callbacks.
 func resetMessageAckCallbacks() {
+	messageAckCallbacksMu.Lock()
+	defer messageAckCallbacksMu.Unlock()
 	messageAckCallbacks = map[message.MessageTypeWithVersion]*syncutil.Future[messageInnerAckCallback]{
 		message.MessageTypeImportV1: syncutil.NewFuture[messageInnerAckCallback](),
 


### PR DESCRIPTION
Cherry-pick from master

pr: #49140
issue: #48586

## Summary

Cherry-picked from master PR #49140 (merged) to fix flaky DATA RACE in `TestDoForcePromoteFixIncompleteBroadcasts/full_lifecycle_no_incomplete_tasks` on 2.6 branch.

- Add `sync.RWMutex` to protect `messageAckCallbacks` and `messageAckOnceCallbacks` package-level maps in `broadcaster/registry` from concurrent read/write access
- Add `sync.RWMutex` to protect `balance.singleton` Future from concurrent replacement and read

Root cause: `ResetRegistration()` (called from test cleanup) writes new maps while `CallMessageAckCallback()` / `CallMessageAckOnceCallbacks()` read them concurrently from broadcaster goroutines, causing DATA RACE.

## Conflict resolution

`internal/streamingcoord/server/balancer/balance/singleton.go` — dropped the wrapper for `SetFileResourceChecker`, which doesn't exist on 2.6 (added later on master). All other mutex additions applied cleanly.

## Verification

- [x] Conflict resolution mechanically correct (function not present on 2.6)
- [x] No conflict markers
- [x] Code change verified against master diff