### PR TITLE
fix: [2.6.15] backport L0 compaction self-heal and fast finish

### DIFF
--- a/internal/datacoord/compaction_l0_view.go
+++ b/internal/datacoord/compaction_l0_view.go
@@ -2,6 +2,7 @@ package datacoord
 
 import (
 	"fmt"
+	"math"
 	"sort"
 
 	"github.com/samber/lo"
@@ -9,6 +10,25 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
+
+// resolveLatestDeletePos returns the position used as the L0 trigger Pos.
+// When dataCoord.compaction.levelzero.forceSelectAllSegments is enabled, it
+// returns a max-timestamp position so that all L1/L2 segments pass the
+// startPos < taskPos filter in selectFlushedSegment — used during repair to
+// recover from wrong StartPosition metadata caused by the import position bug.
+func resolveLatestDeletePos(latestL0DmlPos *msgpb.MsgPosition) *msgpb.MsgPosition {
+	if paramtable.Get().DataCoordCfg.LevelZeroCompactionForceSelectAll.GetAsBool() {
+		channel := ""
+		if latestL0DmlPos != nil {
+			channel = latestL0DmlPos.GetChannelName()
+		}
+		return &msgpb.MsgPosition{
+			ChannelName: channel,
+			Timestamp:   math.MaxUint64,
+		}
+	}
+	return latestL0DmlPos
+}
 
 // LevelZeroCompactionView holds all compactable L0 segments in a compaction group
 // Trigger use static algorithm, it will selects l0Segments according to the min and max threshold
@@ -81,7 +101,7 @@ func (v *LevelZeroCompactionView) ForceTrigger() (CompactionView, string) {
 		return &LevelZeroCompactionView{
 			label:           v.label,
 			l0Segments:      targetViews,
-			latestDeletePos: latestL0.dmlPos,
+			latestDeletePos: resolveLatestDeletePos(latestL0.dmlPos),
 			triggerID:       v.triggerID,
 		}, reason
 	}
@@ -112,7 +132,7 @@ func (v *LevelZeroCompactionView) ForceTriggerAll() ([]CompactionView, string) {
 		roundView := &LevelZeroCompactionView{
 			label:           v.label,
 			l0Segments:      targetViews,
-			latestDeletePos: latestL0.dmlPos,
+			latestDeletePos: resolveLatestDeletePos(latestL0.dmlPos),
 			triggerID:       v.triggerID,
 		}
 		resultViews = append(resultViews, roundView)
@@ -144,7 +164,7 @@ func (v *LevelZeroCompactionView) Trigger() (CompactionView, string) {
 		return &LevelZeroCompactionView{
 			label:           v.label,
 			l0Segments:      targetViews,
-			latestDeletePos: latestL0.dmlPos,
+			latestDeletePos: resolveLatestDeletePos(latestL0.dmlPos),
 			triggerID:       v.triggerID,
 		}, reason
 	}

--- a/internal/datacoord/compaction_l0_view_test.go
+++ b/internal/datacoord/compaction_l0_view_test.go
@@ -1,6 +1,7 @@
 package datacoord
 
 import (
+	"math"
 	"testing"
 
 	"github.com/samber/lo"
@@ -224,4 +225,82 @@ func (s *LevelZeroSegmentsViewSuite) TestForceTrigger() {
 			log.Info("test forceTrigger", zap.Any("trigger reason", reason))
 		})
 	}
+}
+
+func (s *LevelZeroSegmentsViewSuite) TestResolveLatestDeletePos() {
+	paramtable.Init()
+	dmlPos := &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 12345}
+
+	s.Run("default_returns_dml_pos", func() {
+		paramtable.Get().Save("dataCoord.compaction.levelzero.forceSelectAllSegments", "false")
+		defer paramtable.Get().Reset("dataCoord.compaction.levelzero.forceSelectAllSegments")
+
+		got := resolveLatestDeletePos(dmlPos)
+		s.Equal(dmlPos, got)
+	})
+
+	s.Run("force_select_returns_max_timestamp", func() {
+		paramtable.Get().Save("dataCoord.compaction.levelzero.forceSelectAllSegments", "true")
+		defer paramtable.Get().Reset("dataCoord.compaction.levelzero.forceSelectAllSegments")
+
+		got := resolveLatestDeletePos(dmlPos)
+		s.Equal(uint64(math.MaxUint64), got.GetTimestamp())
+		s.Equal("ch-1", got.GetChannelName())
+	})
+
+	s.Run("force_select_with_nil_pos", func() {
+		paramtable.Get().Save("dataCoord.compaction.levelzero.forceSelectAllSegments", "true")
+		defer paramtable.Get().Reset("dataCoord.compaction.levelzero.forceSelectAllSegments")
+
+		got := resolveLatestDeletePos(nil)
+		s.Equal(uint64(math.MaxUint64), got.GetTimestamp())
+		s.Equal("", got.GetChannelName())
+	})
+
+	s.Run("trigger_uses_resolved_pos_when_force_select_enabled", func() {
+		paramtable.Get().Save("dataCoord.compaction.levelzero.forceSelectAllSegments", "true")
+		defer paramtable.Get().Reset("dataCoord.compaction.levelzero.forceSelectAllSegments")
+
+		label := s.v.GetGroupLabel()
+		views := []*SegmentView{
+			genTestL0SegmentView(100, label, 20000),
+			genTestL0SegmentView(101, label, 10000),
+			genTestL0SegmentView(102, label, 30000),
+		}
+		for _, v := range views {
+			v.DeltalogCount = 100
+			v.DeltaSize = 1
+			v.DeltaRowCount = 1
+		}
+		s.v.l0Segments = views
+
+		gotView, _ := s.v.Trigger()
+		s.Require().NotNil(gotView)
+		levelZeroView, ok := gotView.(*LevelZeroCompactionView)
+		s.Require().True(ok)
+		s.Equal(uint64(math.MaxUint64), levelZeroView.latestDeletePos.GetTimestamp())
+	})
+
+	s.Run("force_trigger_uses_resolved_pos_when_force_select_enabled", func() {
+		paramtable.Get().Save("dataCoord.compaction.levelzero.forceSelectAllSegments", "true")
+		defer paramtable.Get().Reset("dataCoord.compaction.levelzero.forceSelectAllSegments")
+
+		label := s.v.GetGroupLabel()
+		views := []*SegmentView{
+			genTestL0SegmentView(100, label, 20000),
+			genTestL0SegmentView(101, label, 10000),
+		}
+		for _, v := range views {
+			v.DeltalogCount = 1
+			v.DeltaSize = 1
+			v.DeltaRowCount = 1
+		}
+		s.v.l0Segments = views
+
+		gotView, _ := s.v.ForceTrigger()
+		s.Require().NotNil(gotView)
+		levelZeroView, ok := gotView.(*LevelZeroCompactionView)
+		s.Require().True(ok)
+		s.Equal(uint64(math.MaxUint64), levelZeroView.latestDeletePos.GetTimestamp())
+	})
 }

--- a/internal/datacoord/compaction_task_l0.go
+++ b/internal/datacoord/compaction_task_l0.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/cockroachdb/errors"
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
@@ -96,6 +95,32 @@ func (t *l0CompactionTask) CreateTaskOnWorker(nodeID int64, cluster session.Clus
 		return
 	}
 
+	// Check if this is a fast finish case (no target segments to compact with)
+	// Fast finish plan only contains L0 input segments, no target L1/L2 segments
+	if len(plan.SegmentBinlogs) == len(t.GetTaskProto().GetInputSegments()) {
+		log.Info("l0CompactionTask fast finish: no target segments, directly marking L0 segments as dropped",
+			zap.Int64("planID", t.GetTaskProto().GetPlanID()))
+
+		// Save segment meta with empty output segments (marks L0 input segments as dropped)
+		if err = t.saveSegmentMeta([]*datapb.CompactionSegment{}); err != nil {
+			log.Warn("l0CompactionTask fast finish failed to save segment meta", zap.Error(err))
+			err = t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_failed), setFailReason(err.Error()))
+			if err != nil {
+				log.Warn("l0CompactionTask failed to updateAndSaveTaskMeta", zap.Error(err))
+			}
+			return
+		}
+
+		// Transition to meta_saved state
+		if err = t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_meta_saved)); err != nil {
+			log.Warn("l0CompactionTask fast finish failed to save task meta_saved state", zap.Error(err))
+			return
+		}
+
+		log.Info("l0CompactionTask fast finish completed", zap.Int64("planID", t.GetTaskProto().GetPlanID()))
+		return
+	}
+
 	err = cluster.CreateCompaction(nodeID, plan)
 	if err != nil {
 		originNodeID := t.GetTaskProto().GetNodeID()
@@ -140,7 +165,7 @@ func (t *l0CompactionTask) QueryTaskOnWorker(cluster session.Cluster) {
 			return
 		}
 
-		if err = t.saveSegmentMeta(result); err != nil {
+		if err = t.saveSegmentMeta(result.GetSegments()); err != nil {
 			log.Warn("l0CompactionTask failed to save segment meta", zap.Error(err))
 			return
 		}
@@ -353,9 +378,10 @@ func (t *l0CompactionTask) BuildCompactionRequest() (*datapb.CompactionPlan, err
 		return nil, err
 	}
 	if len(flushedSegments) == 0 {
-		// TODO fast finish l0 segment, just drop l0 segment
-		log.Info("l0Compaction available non-L0 Segments is empty ")
-		return nil, errors.Errorf("Selected zero L1/L2 segments for the position=%v", taskProto.GetPos())
+		// Fast finish: no target segments to compact with, return plan with only L0 segments
+		log.Info("l0Compaction available non-L0 Segments is empty, will fast finish",
+			zap.Any("target position", taskProto.GetPos()))
+		return plan, nil
 	}
 
 	segments = append(segments, flushedSegments...)
@@ -416,9 +442,9 @@ func (t *l0CompactionTask) saveTaskMeta(task *datapb.CompactionTask) error {
 	return t.meta.SaveCompactionTask(context.TODO(), task)
 }
 
-func (t *l0CompactionTask) saveSegmentMeta(result *datapb.CompactionPlanResult) error {
+func (t *l0CompactionTask) saveSegmentMeta(outputSegs []*datapb.CompactionSegment) error {
 	var operators []UpdateOperator
-	for _, seg := range result.GetSegments() {
+	for _, seg := range outputSegs {
 		operators = append(operators, AddBinlogsOperator(seg.GetSegmentID(), nil, nil, seg.GetDeltalogs(), nil))
 	}
 

--- a/internal/datacoord/compaction_task_l0_test.go
+++ b/internal/datacoord/compaction_task_l0_test.go
@@ -26,10 +26,12 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/datacoord/session"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
 func TestL0CompactionTaskSuite(t *testing.T) {
@@ -156,42 +158,67 @@ func (s *L0CompactionTaskSuite) TestProcessRefreshPlan_SelectZeroSegmentsL0() {
 		State:         datapb.CompactionTaskState_executing,
 		InputSegments: []int64{100, 101},
 	}, nil, s.mockMeta)
-	_, err := task.BuildCompactionRequest()
-	s.Error(err)
+	plan, err := task.BuildCompactionRequest()
+	// Fast finish: should return a plan with only L0 segments (no error)
+	s.NoError(err)
+	s.Require().NotNil(plan)
+	// Verify plan only contains L0 input segments (2 segments)
+	s.Equal(2, len(plan.GetSegmentBinlogs()))
+	segIDs := lo.Map(plan.GetSegmentBinlogs(), func(b *datapb.CompactionSegmentBinlogs, _ int) int64 {
+		return b.GetSegmentID()
+	})
+	s.ElementsMatch([]int64{100, 101}, segIDs)
+	// Verify no binlog IDs were allocated for fast finish
+	s.Nil(plan.GetPreAllocatedLogIDs())
 }
 
 func (s *L0CompactionTaskSuite) TestBuildCompactionRequestFailed_AllocFailed() {
-	var task CompactionTask
+	channel := "Ch-1"
+	deltaLogs := []*datapb.FieldBinlog{getFieldBinlogIDs(101, 3)}
 
-	s.mockAlloc.EXPECT().AllocN(mock.Anything).Return(100, 200, errors.New("mock alloc err"))
+	s.mockMeta.EXPECT().SelectSegments(mock.Anything, mock.Anything, mock.Anything).Return(
+		[]*SegmentInfo{
+			{SegmentInfo: &datapb.SegmentInfo{
+				ID:            200,
+				Level:         datapb.SegmentLevel_L1,
+				InsertChannel: channel,
+			}},
+			{SegmentInfo: &datapb.SegmentInfo{
+				ID:            201,
+				Level:         datapb.SegmentLevel_L1,
+				InsertChannel: channel,
+			}},
+			{SegmentInfo: &datapb.SegmentInfo{
+				ID:            202,
+				Level:         datapb.SegmentLevel_L1,
+				InsertChannel: channel,
+			}},
+		},
+	)
 
-	meta, err := newMemoryMeta(s.T())
-	s.NoError(err)
-	task = &l0CompactionTask{
-		allocator: s.mockAlloc,
-		meta:      meta,
-	}
-	task.SetTask(&datapb.CompactionTask{})
-	_, err = task.BuildCompactionRequest()
-	s.T().Logf("err=%v", err)
-	s.Error(err)
+	s.mockMeta.EXPECT().GetHealthySegment(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, segID int64) *SegmentInfo {
+		return &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{
+			ID:            segID,
+			Level:         datapb.SegmentLevel_L0,
+			InsertChannel: channel,
+			State:         commonpb.SegmentState_Flushed,
+			Deltalogs:     deltaLogs,
+		}}
+	}).Times(2)
+	task := newL0CompactionTask(&datapb.CompactionTask{
+		PlanID:        1,
+		TriggerID:     19530,
+		CollectionID:  1,
+		PartitionID:   10,
+		Type:          datapb.CompactionType_Level0DeleteCompaction,
+		NodeID:        1,
+		State:         datapb.CompactionTaskState_executing,
+		InputSegments: []int64{100, 101},
+	}, s.mockAlloc, s.mockMeta)
 
-	task = &mixCompactionTask{
-		allocator: s.mockAlloc,
-		meta:      meta,
-		ievm:      newMockVersionManager(),
-	}
-	task.SetTask(&datapb.CompactionTask{})
-	_, err = task.BuildCompactionRequest()
-	s.T().Logf("err=%v", err)
-	s.Error(err)
+	s.mockAlloc.EXPECT().AllocN(mock.Anything).Return(0, 0, errors.New("mock alloc err"))
 
-	task = &clusteringCompactionTask{
-		allocator: s.mockAlloc,
-		meta:      meta,
-	}
-	task.SetTask(&datapb.CompactionTask{})
-	_, err = task.BuildCompactionRequest()
+	_, err := task.BuildCompactionRequest()
 	s.T().Logf("err=%v", err)
 	s.Error(err)
 }
@@ -524,5 +551,153 @@ func (s *L0CompactionTaskSuite) TestPorcessStateTrans() {
 			res := t.Process()
 			s.Equal(tc.processResult, res)
 		}
+	})
+}
+
+// TestSelectFlushedSegment_ForceSelectAllFlag exercises the flag end-to-end:
+// build an L0 view, call Trigger() with the flag off / on, feed the resulting
+// latestDeletePos into an l0CompactionTask (the same wiring
+// compaction_trigger_v2.go uses), and verify selectFlushedSegment's output
+// actually changes based on the flag. A high-StartPosition segment (the
+// shape silently dropped by the import-position bug) is excluded with the
+// flag off and included with the flag on.
+func (s *L0CompactionTaskSuite) TestSelectFlushedSegment_ForceSelectAllFlag() {
+	paramtable.Init()
+	const flagKey = "dataCoord.compaction.levelzero.forceSelectAllSegments"
+
+	channel := "ch-1"
+	collectionID := int64(1)
+	partitionID := int64(10)
+	label := &CompactionGroupLabel{
+		CollectionID: collectionID,
+		PartitionID:  partitionID,
+		Channel:      channel,
+	}
+
+	// Flushed L1 segments visible to selectFlushedSegment. The one with
+	// StartPosition > realL0DmlTs is the case we care about — it would
+	// normally be filtered out by `startPos < taskPos`.
+	const realL0DmlTs = uint64(5000)
+	lowPosSeg := &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{
+		ID:            200,
+		CollectionID:  collectionID,
+		PartitionID:   partitionID,
+		InsertChannel: channel,
+		Level:         datapb.SegmentLevel_L1,
+		State:         commonpb.SegmentState_Flushed,
+		StartPosition: &msgpb.MsgPosition{ChannelName: channel, Timestamp: 3000},
+	}}
+	highPosSeg := &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{
+		ID:            201,
+		CollectionID:  collectionID,
+		PartitionID:   partitionID,
+		InsertChannel: channel,
+		Level:         datapb.SegmentLevel_L1,
+		State:         commonpb.SegmentState_Flushed,
+		StartPosition: &msgpb.MsgPosition{ChannelName: channel, Timestamp: 20000},
+	}}
+
+	// Mockery's SelectSegments returns whatever we tell it without applying
+	// filters. We need the real filter logic to run so the `startPos <
+	// taskPos` predicate is actually exercised — install RunAndReturn that
+	// evaluates each SegmentFilter.Match against our fixed segment set.
+	installFilteringMock := func() {
+		s.mockMeta.EXPECT().SelectSegments(mock.Anything, mock.Anything, mock.Anything).
+			RunAndReturn(func(ctx context.Context, filters ...SegmentFilter) []*SegmentInfo {
+				all := []*SegmentInfo{lowPosSeg, highPosSeg}
+				result := make([]*SegmentInfo, 0, len(all))
+				for _, seg := range all {
+					matched := true
+					for _, f := range filters {
+						if !f.Match(seg) {
+							matched = false
+							break
+						}
+					}
+					if matched {
+						result = append(result, seg)
+					}
+				}
+				return result
+			})
+	}
+
+	// Build an L0 view with a couple of L0 segments whose dmlPos is
+	// `realL0DmlTs`. Trigger() runs resolveLatestDeletePos under the current
+	// flag value, so the returned view's latestDeletePos reflects the flag.
+	buildView := func() *LevelZeroCompactionView {
+		l0Segs := []*SegmentView{
+			{
+				ID:            100,
+				label:         label,
+				dmlPos:        &msgpb.MsgPosition{ChannelName: channel, Timestamp: realL0DmlTs},
+				Level:         datapb.SegmentLevel_L0,
+				State:         commonpb.SegmentState_Flushed,
+				DeltalogCount: 100,
+				DeltaSize:     1,
+				DeltaRowCount: 1,
+			},
+			{
+				ID:            101,
+				label:         label,
+				dmlPos:        &msgpb.MsgPosition{ChannelName: channel, Timestamp: realL0DmlTs},
+				Level:         datapb.SegmentLevel_L0,
+				State:         commonpb.SegmentState_Flushed,
+				DeltalogCount: 100,
+				DeltaSize:     1,
+				DeltaRowCount: 1,
+			},
+		}
+		return &LevelZeroCompactionView{
+			label:           label,
+			l0Segments:      l0Segs,
+			latestDeletePos: &msgpb.MsgPosition{ChannelName: channel, Timestamp: realL0DmlTs},
+			triggerID:       19530,
+		}
+	}
+
+	// Mirrors compaction_trigger_v2.go:406 — feed the triggered view's
+	// latestDeletePos into task.Pos and run selectFlushedSegment.
+	runSelectWithTriggeredPos := func() []int64 {
+		installFilteringMock()
+		srcView := buildView()
+		triggered, reason := srcView.Trigger()
+		s.Require().NotNil(triggered, "Trigger returned nil: %s", reason)
+		triggeredView := triggered.(*LevelZeroCompactionView)
+
+		task := newL0CompactionTask(&datapb.CompactionTask{
+			PlanID:        1,
+			TriggerID:     19530,
+			CollectionID:  collectionID,
+			PartitionID:   partitionID,
+			Channel:       channel,
+			Type:          datapb.CompactionType_Level0DeleteCompaction,
+			NodeID:        1,
+			State:         datapb.CompactionTaskState_executing,
+			InputSegments: []int64{100, 101},
+			Pos:           triggeredView.latestDeletePos,
+		}, nil, s.mockMeta)
+
+		flushed, _, err := task.selectFlushedSegment()
+		s.Require().NoError(err)
+		return lo.Map(flushed, func(seg *SegmentInfo, _ int) int64 { return seg.GetID() })
+	}
+
+	s.Run("flag_off_excludes_high_start_position_segment", func() {
+		paramtable.Get().Save(flagKey, "false")
+		defer paramtable.Get().Reset(flagKey)
+
+		gotIDs := runSelectWithTriggeredPos()
+		s.ElementsMatch([]int64{200}, gotIDs,
+			"with flag off, segment 201 (StartPosition=20000 > taskPos=%d) must be excluded", realL0DmlTs)
+	})
+
+	s.Run("flag_on_includes_high_start_position_segment", func() {
+		paramtable.Get().Save(flagKey, "true")
+		defer paramtable.Get().Reset(flagKey)
+
+		gotIDs := runSelectWithTriggeredPos()
+		s.ElementsMatch([]int64{200, 201}, gotIDs,
+			"with flag on, resolveLatestDeletePos must lift taskPos so segment 201 is included")
 	})
 }

--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -1737,6 +1737,37 @@ func getMinPosition(positions []*msgpb.MsgPosition) *msgpb.MsgPosition {
 	return minPos
 }
 
+func getMaxPosition(positions []*msgpb.MsgPosition) *msgpb.MsgPosition {
+	var maxPos *msgpb.MsgPosition
+	for _, pos := range positions {
+		if maxPos == nil ||
+			pos != nil && pos.GetTimestamp() > maxPos.GetTimestamp() {
+			maxPos = pos
+		}
+	}
+	return maxPos
+}
+
+// recalculateSegmentPosition recalculates StartPosition and DmlPosition from
+// actual binlog timestamps on the compaction result segment. This makes compaction
+// self-healing: wrong positions from import or prior compaction are corrected.
+// Also fixes the DmlPosition bug where getMinPosition was used instead of max.
+// Falls back to the provided fallback positions if binlog timestamps are unavailable
+// (e.g., legacy segments without TimestampFrom/TimestampTo populated).
+func recalculateSegmentPosition(binlogs []*datapb.FieldBinlog, channel string, fallbackStart, fallbackDml *msgpb.MsgPosition) (startPos, dmlPos *msgpb.MsgPosition) {
+	minTs, maxTs := extractTimestampFromBinlogs(binlogs)
+	if minTs > 0 && minTs != math.MaxUint64 && maxTs > 0 {
+		return &msgpb.MsgPosition{
+				ChannelName: channel,
+				Timestamp:   minTs,
+			}, &msgpb.MsgPosition{
+				ChannelName: channel,
+				Timestamp:   maxTs,
+			}
+	}
+	return fallbackStart, fallbackDml
+}
+
 func (m *meta) completeClusterCompactionMutation(t *datapb.CompactionTask, result *datapb.CompactionPlanResult) ([]*SegmentInfo, *segMetricMutation, error) {
 	log := log.Ctx(context.TODO()).With(zap.Int64("planID", t.GetPlanID()),
 		zap.String("type", t.GetType().String()),
@@ -1772,7 +1803,16 @@ func (m *meta) completeClusterCompactionMutation(t *datapb.CompactionTask, resul
 		compactFromSegIDs = append(compactFromSegIDs, cloned.GetID())
 	}
 
+	// Compute fallback positions from source segments (used when binlog timestamps unavailable)
+	fallbackStart := getMinPosition(lo.Map(compactFromSegInfos, func(info *SegmentInfo, _ int) *msgpb.MsgPosition {
+		return info.GetStartPosition()
+	}))
+	fallbackDml := getMaxPosition(lo.Map(compactFromSegInfos, func(info *SegmentInfo, _ int) *msgpb.MsgPosition {
+		return info.GetDmlPosition()
+	}))
+
 	for _, seg := range result.GetSegments() {
+		startPos, dmlPos := recalculateSegmentPosition(seg.GetInsertLogs(), t.GetChannel(), fallbackStart, fallbackDml)
 		segmentInfo := &datapb.SegmentInfo{
 			ID:                  seg.GetSegmentID(),
 			CollectionID:        compactFromSegInfos[0].CollectionID,
@@ -1787,12 +1827,8 @@ func (m *meta) completeClusterCompactionMutation(t *datapb.CompactionTask, resul
 			CompactionFrom:      compactFromSegIDs,
 			LastExpireTime:      tsoutil.ComposeTSByTime(time.Unix(t.GetStartTime(), 0), 0),
 			Level:               datapb.SegmentLevel_L2,
-			StartPosition: getMinPosition(lo.Map(compactFromSegInfos, func(info *SegmentInfo, _ int) *msgpb.MsgPosition {
-				return info.GetStartPosition()
-			})),
-			DmlPosition: getMinPosition(lo.Map(compactFromSegInfos, func(info *SegmentInfo, _ int) *msgpb.MsgPosition {
-				return info.GetDmlPosition()
-			})),
+			StartPosition:       startPos,
+			DmlPosition:         dmlPos,
 			// visible after stats and index
 			IsInvisible:    true,
 			StorageVersion: seg.GetStorageVersion(),
@@ -1877,8 +1913,17 @@ func (m *meta) completeMixCompactionMutation(
 
 	log = log.With(zap.Int64s("compactFrom", compactFromSegIDs))
 
+	// Compute fallback positions from source segments (used when binlog timestamps unavailable)
+	fallbackStart := getMinPosition(lo.Map(compactFromSegInfos, func(info *SegmentInfo, _ int) *msgpb.MsgPosition {
+		return info.GetStartPosition()
+	}))
+	fallbackDml := getMaxPosition(lo.Map(compactFromSegInfos, func(info *SegmentInfo, _ int) *msgpb.MsgPosition {
+		return info.GetDmlPosition()
+	}))
+
 	compactToSegments := make([]*SegmentInfo, 0)
 	for _, compactToSegment := range result.GetSegments() {
+		startPos, dmlPos := recalculateSegmentPosition(compactToSegment.GetInsertLogs(), t.GetChannel(), fallbackStart, fallbackDml)
 		compactToSegmentInfo := NewSegmentInfo(
 			&datapb.SegmentInfo{
 				ID:            compactToSegment.GetSegmentID(),
@@ -1899,14 +1944,10 @@ func (m *meta) completeMixCompactionMutation(
 				LastExpireTime:      tsoutil.ComposeTSByTime(time.Unix(t.GetStartTime(), 0), 0),
 				Level:               datapb.SegmentLevel_L1,
 				StorageVersion:      compactToSegment.GetStorageVersion(),
-				StartPosition: getMinPosition(lo.Map(compactFromSegInfos, func(info *SegmentInfo, _ int) *msgpb.MsgPosition {
-					return info.GetStartPosition()
-				})),
-				DmlPosition: getMinPosition(lo.Map(compactFromSegInfos, func(info *SegmentInfo, _ int) *msgpb.MsgPosition {
-					return info.GetDmlPosition()
-				})),
-				IsSorted:     compactToSegment.GetIsSorted(),
-				ManifestPath: compactToSegment.GetManifest(),
+				StartPosition:       startPos,
+				DmlPosition:         dmlPos,
+				IsSorted:            compactToSegment.GetIsSorted(),
+				ManifestPath:        compactToSegment.GetManifest(),
 			})
 
 		if compactToSegmentInfo.GetNumOfRows() == 0 {
@@ -2384,14 +2425,17 @@ func (m *meta) completeSortCompactionMutation(
 
 	resultSegment := result.GetSegments()[0]
 
+	startPos, dmlPos := recalculateSegmentPosition(resultSegment.GetInsertLogs(), oldSegment.GetInsertChannel(),
+		oldSegment.GetStartPosition(), oldSegment.GetDmlPosition())
+
 	segmentInfo := &datapb.SegmentInfo{
 		CollectionID:              oldSegment.GetCollectionID(),
 		PartitionID:               oldSegment.GetPartitionID(),
 		InsertChannel:             oldSegment.GetInsertChannel(),
 		MaxRowNum:                 oldSegment.GetMaxRowNum(),
 		LastExpireTime:            oldSegment.GetLastExpireTime(),
-		StartPosition:             oldSegment.GetStartPosition(),
-		DmlPosition:               oldSegment.GetDmlPosition(),
+		StartPosition:             startPos,
+		DmlPosition:               dmlPos,
 		IsImporting:               oldSegment.GetIsImporting(),
 		State:                     commonpb.SegmentState_Flushed,
 		Level:                     oldSegment.GetLevel(),

--- a/internal/datacoord/meta_test.go
+++ b/internal/datacoord/meta_test.go
@@ -651,6 +651,432 @@ func (suite *MetaBasicSuite) TestCompleteCompactionMutation() {
 	})
 }
 
+func (suite *MetaBasicSuite) TestGetMaxPosition() {
+	suite.Run("nil_positions", func() {
+		pos := getMaxPosition(nil)
+		suite.Nil(pos)
+	})
+
+	suite.Run("single_position", func() {
+		p := &msgpb.MsgPosition{Timestamp: 100}
+		pos := getMaxPosition([]*msgpb.MsgPosition{p})
+		suite.Equal(uint64(100), pos.GetTimestamp())
+	})
+
+	suite.Run("multiple_positions", func() {
+		pos := getMaxPosition([]*msgpb.MsgPosition{
+			{Timestamp: 100},
+			{Timestamp: 300},
+			{Timestamp: 200},
+		})
+		suite.Equal(uint64(300), pos.GetTimestamp())
+	})
+
+	suite.Run("with_nil_entries", func() {
+		pos := getMaxPosition([]*msgpb.MsgPosition{
+			nil,
+			{Timestamp: 50},
+			nil,
+			{Timestamp: 200},
+		})
+		suite.Equal(uint64(200), pos.GetTimestamp())
+	})
+}
+
+func (suite *MetaBasicSuite) TestRecalculateSegmentPosition() {
+	channel := "ch-1"
+	fallbackStart := &msgpb.MsgPosition{ChannelName: channel, Timestamp: 10}
+	fallbackDml := &msgpb.MsgPosition{ChannelName: channel, Timestamp: 90}
+
+	suite.Run("recalculates_from_binlog_timestamps", func() {
+		binlogs := []*datapb.FieldBinlog{
+			{
+				FieldID: 0,
+				Binlogs: []*datapb.Binlog{
+					{LogID: 1, TimestampFrom: 100, TimestampTo: 200},
+					{LogID: 2, TimestampFrom: 150, TimestampTo: 300},
+				},
+			},
+			{
+				FieldID: 1,
+				Binlogs: []*datapb.Binlog{
+					{LogID: 3, TimestampFrom: 80, TimestampTo: 250},
+				},
+			},
+		}
+		startPos, dmlPos := recalculateSegmentPosition(binlogs, channel, fallbackStart, fallbackDml)
+		suite.Equal(uint64(80), startPos.GetTimestamp())
+		suite.Equal(uint64(300), dmlPos.GetTimestamp())
+		suite.Equal(channel, startPos.GetChannelName())
+		suite.Equal(channel, dmlPos.GetChannelName())
+	})
+
+	suite.Run("fallback_when_timestamps_zero", func() {
+		binlogs := []*datapb.FieldBinlog{
+			{
+				FieldID: 0,
+				Binlogs: []*datapb.Binlog{
+					{LogID: 1, TimestampFrom: 0, TimestampTo: 0},
+				},
+			},
+		}
+		startPos, dmlPos := recalculateSegmentPosition(binlogs, channel, fallbackStart, fallbackDml)
+		suite.Equal(fallbackStart, startPos)
+		suite.Equal(fallbackDml, dmlPos)
+	})
+
+	suite.Run("fallback_when_no_binlogs", func() {
+		startPos, dmlPos := recalculateSegmentPosition(nil, channel, fallbackStart, fallbackDml)
+		suite.Equal(fallbackStart, startPos)
+		suite.Equal(fallbackDml, dmlPos)
+	})
+
+	suite.Run("fallback_when_empty_binlogs", func() {
+		startPos, dmlPos := recalculateSegmentPosition([]*datapb.FieldBinlog{}, channel, fallbackStart, fallbackDml)
+		suite.Equal(fallbackStart, startPos)
+		suite.Equal(fallbackDml, dmlPos)
+	})
+}
+
+func (suite *MetaBasicSuite) TestCompleteCompactionMutation_RecalculatePositions() {
+	mockChMgr := mocks.NewChunkManager(suite.T())
+
+	// Helper to build FieldBinlog with timestamps
+	fieldBinlogWithTimestamps := func(fieldID int64, logID int64, tsFrom, tsTo uint64) *datapb.FieldBinlog {
+		return &datapb.FieldBinlog{
+			FieldID: fieldID,
+			Binlogs: []*datapb.Binlog{
+				{LogID: logID, TimestampFrom: tsFrom, TimestampTo: tsTo},
+			},
+		}
+	}
+
+	suite.Run("mix_compaction_recalculates_positions_from_binlogs", func() {
+		latestSegments := NewSegmentsInfo()
+		for segID, segment := range map[UniqueID]*SegmentInfo{
+			1: {SegmentInfo: &datapb.SegmentInfo{
+				ID:            1,
+				CollectionID:  100,
+				PartitionID:   10,
+				State:         commonpb.SegmentState_Flushed,
+				Level:         datapb.SegmentLevel_L1,
+				Binlogs:       []*datapb.FieldBinlog{getFieldBinlogIDs(0, 10000)},
+				Statslogs:     []*datapb.FieldBinlog{getFieldBinlogIDs(0, 20000)},
+				NumOfRows:     2,
+				StartPosition: &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 999},
+				DmlPosition:   &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 1},
+			}},
+			2: {SegmentInfo: &datapb.SegmentInfo{
+				ID:            2,
+				CollectionID:  100,
+				PartitionID:   10,
+				State:         commonpb.SegmentState_Flushed,
+				Level:         datapb.SegmentLevel_L1,
+				Binlogs:       []*datapb.FieldBinlog{getFieldBinlogIDs(0, 11000)},
+				Statslogs:     []*datapb.FieldBinlog{getFieldBinlogIDs(0, 21000)},
+				NumOfRows:     2,
+				StartPosition: &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 888},
+				DmlPosition:   &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 2},
+			}},
+		} {
+			latestSegments.SetSegment(segID, segment)
+		}
+
+		result := &datapb.CompactionPlanResult{
+			Segments: []*datapb.CompactionSegment{{
+				SegmentID:           3,
+				InsertLogs:          []*datapb.FieldBinlog{fieldBinlogWithTimestamps(0, 50000, 100, 500)},
+				Field2StatslogPaths: []*datapb.FieldBinlog{getFieldBinlogIDs(0, 50001)},
+				NumOfRows:           4,
+			}},
+		}
+		task := &datapb.CompactionTask{
+			InputSegments: []UniqueID{1, 2},
+			Type:          datapb.CompactionType_MixCompaction,
+			Channel:       "ch-1",
+		}
+		m := &meta{
+			catalog:      &datacoord.Catalog{MetaKv: NewMetaMemoryKV()},
+			segments:     latestSegments,
+			chunkManager: mockChMgr,
+		}
+
+		infos, _, err := m.CompleteCompactionMutation(context.TODO(), task, result)
+		suite.NoError(err)
+		suite.Require().Equal(1, len(infos))
+
+		// Should use binlog timestamps, NOT inherited positions
+		suite.Equal(uint64(100), infos[0].GetStartPosition().GetTimestamp())
+		suite.Equal(uint64(500), infos[0].GetDmlPosition().GetTimestamp())
+		suite.Equal("ch-1", infos[0].GetStartPosition().GetChannelName())
+	})
+
+	suite.Run("mix_compaction_fallback_when_no_timestamps", func() {
+		latestSegments := NewSegmentsInfo()
+		for segID, segment := range map[UniqueID]*SegmentInfo{
+			1: {SegmentInfo: &datapb.SegmentInfo{
+				ID:            1,
+				CollectionID:  100,
+				PartitionID:   10,
+				State:         commonpb.SegmentState_Flushed,
+				Level:         datapb.SegmentLevel_L1,
+				Binlogs:       []*datapb.FieldBinlog{getFieldBinlogIDs(0, 10000)},
+				Statslogs:     []*datapb.FieldBinlog{getFieldBinlogIDs(0, 20000)},
+				NumOfRows:     2,
+				StartPosition: &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 50},
+				DmlPosition:   &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 200},
+			}},
+			2: {SegmentInfo: &datapb.SegmentInfo{
+				ID:            2,
+				CollectionID:  100,
+				PartitionID:   10,
+				State:         commonpb.SegmentState_Flushed,
+				Level:         datapb.SegmentLevel_L1,
+				Binlogs:       []*datapb.FieldBinlog{getFieldBinlogIDs(0, 11000)},
+				Statslogs:     []*datapb.FieldBinlog{getFieldBinlogIDs(0, 21000)},
+				NumOfRows:     2,
+				StartPosition: &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 100},
+				DmlPosition:   &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 300},
+			}},
+		} {
+			latestSegments.SetSegment(segID, segment)
+		}
+
+		// Result binlogs have no timestamps (legacy)
+		result := &datapb.CompactionPlanResult{
+			Segments: []*datapb.CompactionSegment{{
+				SegmentID:           3,
+				InsertLogs:          []*datapb.FieldBinlog{getFieldBinlogIDs(0, 50000)},
+				Field2StatslogPaths: []*datapb.FieldBinlog{getFieldBinlogIDs(0, 50001)},
+				NumOfRows:           4,
+			}},
+		}
+		task := &datapb.CompactionTask{
+			InputSegments: []UniqueID{1, 2},
+			Type:          datapb.CompactionType_MixCompaction,
+			Channel:       "ch-1",
+		}
+		m := &meta{
+			catalog:      &datacoord.Catalog{MetaKv: NewMetaMemoryKV()},
+			segments:     latestSegments,
+			chunkManager: mockChMgr,
+		}
+
+		infos, _, err := m.CompleteCompactionMutation(context.TODO(), task, result)
+		suite.NoError(err)
+		suite.Require().Equal(1, len(infos))
+
+		// Fallback: StartPosition = min, DmlPosition = max of source segments
+		suite.Equal(uint64(50), infos[0].GetStartPosition().GetTimestamp())
+		suite.Equal(uint64(300), infos[0].GetDmlPosition().GetTimestamp())
+	})
+
+	suite.Run("cluster_compaction_recalculates_positions", func() {
+		latestSegments := NewSegmentsInfo()
+		for segID, segment := range map[UniqueID]*SegmentInfo{
+			1: {SegmentInfo: &datapb.SegmentInfo{
+				ID:            1,
+				CollectionID:  100,
+				PartitionID:   10,
+				State:         commonpb.SegmentState_Flushed,
+				Level:         datapb.SegmentLevel_L1,
+				Binlogs:       []*datapb.FieldBinlog{getFieldBinlogIDs(0, 10000)},
+				Statslogs:     []*datapb.FieldBinlog{getFieldBinlogIDs(0, 20000)},
+				NumOfRows:     2,
+				StartPosition: &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 999},
+				DmlPosition:   &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 1},
+			}},
+			2: {SegmentInfo: &datapb.SegmentInfo{
+				ID:            2,
+				CollectionID:  100,
+				PartitionID:   10,
+				State:         commonpb.SegmentState_Flushed,
+				Level:         datapb.SegmentLevel_L1,
+				Binlogs:       []*datapb.FieldBinlog{getFieldBinlogIDs(0, 11000)},
+				Statslogs:     []*datapb.FieldBinlog{getFieldBinlogIDs(0, 21000)},
+				NumOfRows:     2,
+				StartPosition: &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 888},
+				DmlPosition:   &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 2},
+			}},
+		} {
+			latestSegments.SetSegment(segID, segment)
+		}
+
+		result := &datapb.CompactionPlanResult{
+			Segments: []*datapb.CompactionSegment{{
+				SegmentID:           3,
+				InsertLogs:          []*datapb.FieldBinlog{fieldBinlogWithTimestamps(0, 50000, 150, 600)},
+				Field2StatslogPaths: []*datapb.FieldBinlog{getFieldBinlogIDs(0, 50001)},
+				NumOfRows:           4,
+			}},
+		}
+		task := &datapb.CompactionTask{
+			InputSegments: []UniqueID{1, 2},
+			Type:          datapb.CompactionType_ClusteringCompaction,
+			Channel:       "ch-1",
+		}
+		m := &meta{
+			catalog:      &datacoord.Catalog{MetaKv: NewMetaMemoryKV()},
+			segments:     latestSegments,
+			chunkManager: mockChMgr,
+		}
+
+		infos, _, err := m.CompleteCompactionMutation(context.TODO(), task, result)
+		suite.NoError(err)
+		suite.Require().Equal(1, len(infos))
+
+		suite.Equal(uint64(150), infos[0].GetStartPosition().GetTimestamp())
+		suite.Equal(uint64(600), infos[0].GetDmlPosition().GetTimestamp())
+		suite.Equal(datapb.SegmentLevel_L2, infos[0].GetLevel())
+	})
+
+	suite.Run("cluster_compaction_fallback_when_no_timestamps", func() {
+		latestSegments := NewSegmentsInfo()
+		for segID, segment := range map[UniqueID]*SegmentInfo{
+			1: {SegmentInfo: &datapb.SegmentInfo{
+				ID:            1,
+				CollectionID:  100,
+				PartitionID:   10,
+				State:         commonpb.SegmentState_Flushed,
+				Level:         datapb.SegmentLevel_L1,
+				Binlogs:       []*datapb.FieldBinlog{getFieldBinlogIDs(0, 10000)},
+				Statslogs:     []*datapb.FieldBinlog{getFieldBinlogIDs(0, 20000)},
+				NumOfRows:     2,
+				StartPosition: &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 50},
+				DmlPosition:   &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 400},
+			}},
+			2: {SegmentInfo: &datapb.SegmentInfo{
+				ID:            2,
+				CollectionID:  100,
+				PartitionID:   10,
+				State:         commonpb.SegmentState_Flushed,
+				Level:         datapb.SegmentLevel_L1,
+				Binlogs:       []*datapb.FieldBinlog{getFieldBinlogIDs(0, 11000)},
+				Statslogs:     []*datapb.FieldBinlog{getFieldBinlogIDs(0, 21000)},
+				NumOfRows:     2,
+				StartPosition: &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 80},
+				DmlPosition:   &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 500},
+			}},
+		} {
+			latestSegments.SetSegment(segID, segment)
+		}
+
+		result := &datapb.CompactionPlanResult{
+			Segments: []*datapb.CompactionSegment{{
+				SegmentID:           3,
+				InsertLogs:          []*datapb.FieldBinlog{getFieldBinlogIDs(0, 50000)},
+				Field2StatslogPaths: []*datapb.FieldBinlog{getFieldBinlogIDs(0, 50001)},
+				NumOfRows:           4,
+			}},
+		}
+		task := &datapb.CompactionTask{
+			InputSegments: []UniqueID{1, 2},
+			Type:          datapb.CompactionType_ClusteringCompaction,
+			Channel:       "ch-1",
+		}
+		m := &meta{
+			catalog:      &datacoord.Catalog{MetaKv: NewMetaMemoryKV()},
+			segments:     latestSegments,
+			chunkManager: mockChMgr,
+		}
+
+		infos, _, err := m.CompleteCompactionMutation(context.TODO(), task, result)
+		suite.NoError(err)
+		suite.Require().Equal(1, len(infos))
+
+		suite.Equal(uint64(50), infos[0].GetStartPosition().GetTimestamp())
+		suite.Equal(uint64(500), infos[0].GetDmlPosition().GetTimestamp())
+	})
+
+	suite.Run("sort_compaction_recalculates_positions", func() {
+		latestSegments := NewSegmentsInfo()
+		latestSegments.SetSegment(1, &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{
+			ID:             1,
+			CollectionID:   100,
+			PartitionID:    10,
+			State:          commonpb.SegmentState_Flushed,
+			Level:          datapb.SegmentLevel_L2,
+			Binlogs:        []*datapb.FieldBinlog{getFieldBinlogIDs(0, 10000)},
+			Statslogs:      []*datapb.FieldBinlog{getFieldBinlogIDs(0, 20000)},
+			NumOfRows:      2,
+			StartPosition:  &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 999},
+			DmlPosition:    &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 1},
+			InsertChannel:  "ch-1",
+			StorageVersion: storage.StorageV1,
+		}})
+
+		result := &datapb.CompactionPlanResult{
+			Segments: []*datapb.CompactionSegment{{
+				SegmentID:           2,
+				InsertLogs:          []*datapb.FieldBinlog{fieldBinlogWithTimestamps(0, 50000, 200, 800)},
+				Field2StatslogPaths: []*datapb.FieldBinlog{getFieldBinlogIDs(0, 50001)},
+				NumOfRows:           2,
+				StorageVersion:      storage.StorageV2,
+			}},
+		}
+		task := &datapb.CompactionTask{
+			InputSegments: []UniqueID{1},
+			Type:          datapb.CompactionType_SortCompaction,
+		}
+		m := &meta{
+			catalog:      &datacoord.Catalog{MetaKv: NewMetaMemoryKV()},
+			segments:     latestSegments,
+			chunkManager: mockChMgr,
+		}
+
+		infos, _, err := m.CompleteCompactionMutation(context.TODO(), task, result)
+		suite.NoError(err)
+		suite.Require().Equal(1, len(infos))
+
+		suite.Equal(uint64(200), infos[0].GetStartPosition().GetTimestamp())
+		suite.Equal(uint64(800), infos[0].GetDmlPosition().GetTimestamp())
+	})
+
+	suite.Run("sort_compaction_fallback_when_no_timestamps", func() {
+		latestSegments := NewSegmentsInfo()
+		latestSegments.SetSegment(1, &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{
+			ID:             1,
+			CollectionID:   100,
+			PartitionID:    10,
+			State:          commonpb.SegmentState_Flushed,
+			Level:          datapb.SegmentLevel_L2,
+			Binlogs:        []*datapb.FieldBinlog{getFieldBinlogIDs(0, 10000)},
+			Statslogs:      []*datapb.FieldBinlog{getFieldBinlogIDs(0, 20000)},
+			NumOfRows:      2,
+			StartPosition:  &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 77},
+			DmlPosition:    &msgpb.MsgPosition{ChannelName: "ch-1", Timestamp: 333},
+			InsertChannel:  "ch-1",
+			StorageVersion: storage.StorageV1,
+		}})
+
+		result := &datapb.CompactionPlanResult{
+			Segments: []*datapb.CompactionSegment{{
+				SegmentID:           2,
+				InsertLogs:          []*datapb.FieldBinlog{getFieldBinlogIDs(0, 50000)},
+				Field2StatslogPaths: []*datapb.FieldBinlog{getFieldBinlogIDs(0, 50001)},
+				NumOfRows:           2,
+				StorageVersion:      storage.StorageV2,
+			}},
+		}
+		task := &datapb.CompactionTask{
+			InputSegments: []UniqueID{1},
+			Type:          datapb.CompactionType_SortCompaction,
+		}
+		m := &meta{
+			catalog:      &datacoord.Catalog{MetaKv: NewMetaMemoryKV()},
+			segments:     latestSegments,
+			chunkManager: mockChMgr,
+		}
+
+		infos, _, err := m.CompleteCompactionMutation(context.TODO(), task, result)
+		suite.NoError(err)
+		suite.Require().Equal(1, len(infos))
+
+		suite.Equal(uint64(77), infos[0].GetStartPosition().GetTimestamp())
+		suite.Equal(uint64(333), infos[0].GetDmlPosition().GetTimestamp())
+	})
+}
+
 func (suite *MetaBasicSuite) TestSetSegment() {
 	meta := suite.meta
 	catalog := mocks2.NewDataCoordCatalog(suite.T())

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -4821,6 +4821,7 @@ type dataCoordConfig struct {
 	LevelZeroCompactionTriggerMaxSize        ParamItem `refreshable:"true"`
 	LevelZeroCompactionTriggerDeltalogMinNum ParamItem `refreshable:"true"`
 	LevelZeroCompactionTriggerDeltalogMaxNum ParamItem `refreshable:"true"`
+	LevelZeroCompactionForceSelectAll        ParamItem `refreshable:"true"`
 
 	// Garbage Collection
 	EnableGarbageCollection     ParamItem `refreshable:"false"`
@@ -5419,6 +5420,16 @@ During compaction, the size of segment # of rows is able to exceed segment max #
 		Export:       true,
 	}
 	p.LevelZeroCompactionTriggerDeltalogMaxNum.Init(base.mgr)
+
+	p.LevelZeroCompactionForceSelectAll = ParamItem{
+		Key:          "dataCoord.compaction.levelzero.forceSelectAllSegments",
+		Version:      "2.6.15",
+		DefaultValue: "false",
+		Doc: "When enabled, L0 compaction selects all L1/L2 segments regardless of position filtering. " +
+			"Use during repair to bypass wrong StartPosition metadata from the import position bug.",
+		Export: false,
+	}
+	p.LevelZeroCompactionForceSelectAll.Init(base.mgr)
 
 	p.IndexMemSizeEstimateMultiplier = ParamItem{
 		Key:          "dataCoord.index.memSizeEstimateMultiplier",


### PR DESCRIPTION
See also: #46435, #48907
pr: #48910
pr: #47154

Backports two L0 compaction fixes:
- self-heal compaction segment positions and add L0 force-select bypass
- fast finish L0 compaction when there are zero L1/L2 target segments