### PR TITLE
build(deps): bump build-env image to 20260427-3ae4cb2 (Rust 1.92)

### DIFF
--- a/.env
+++ b/.env
@@ -5,11 +5,11 @@ IMAGE_ARCH=amd64
 OS_NAME=ubuntu22.04
 
 # for services.builder.image in docker-compose.yml
-DATE_VERSION=20260419-63b9f9f
-LATEST_DATE_VERSION=20260419-63b9f9f
+DATE_VERSION=20260427-3ae4cb2
+LATEST_DATE_VERSION=20260427-3ae4cb2
 # for services.gpubuilder.image in docker-compose.yml
-GPU_DATE_VERSION=20260419-63b9f9f
-LATEST_GPU_DATE_VERSION=20260419-63b9f9f
+GPU_DATE_VERSION=20260427-3ae4cb2
+LATEST_GPU_DATE_VERSION=20260427-3ae4cb2
 
 # for other services in docker-compose.yml
 MINIO_ADDRESS=minio:9000


### PR DESCRIPTION
## Summary

Bump builder image tags in `.env` to `20260427-3ae4cb2`, which includes Rust 1.92 from #49362.

- `DATE_VERSION`: `20260419-63b9f9f` → `20260427-3ae4cb2`
- `GPU_DATE_VERSION`: `20260419-63b9f9f` → `20260427-3ae4cb2`

The new images were built by [build-env-pipeline#33](https://jenkins-milvus-ci.milvus.io/job/MILVUS-RELEASE-PIPELINES/job/build-env-pipeline/33/).