### PR TITLE
fix: resolve GPU build link failures

### DIFF
--- a/internal/core/thirdparty/knowhere/CMakeLists.txt
+++ b/internal/core/thirdparty/knowhere/CMakeLists.txt
@@ -37,6 +37,8 @@ endif()
 
 if ( MILVUS_GPU_VERSION STREQUAL "ON" )
     set(WITH_CUVS ON CACHE BOOL "" FORCE )
+    set(raft_DIR "${FETCHCONTENT_BASE_DIR}/raft-build" CACHE PATH "Path to raft build directory" FORCE)
+    set(rmm_DIR "${FETCHCONTENT_BASE_DIR}/rmm-build" CACHE PATH "Path to rmm build directory" FORCE)
 endif ()
 
 if ( WITH_SVS STREQUAL "ON" )
@@ -77,6 +79,26 @@ if ( WITH_SVS STREQUAL "ON" )
                 FILES_MATCHING PATTERN "libsvs_runtime.so*")
     else()
         message(WARNING "SVS enabled but ${_SVS_LIB_DIR} not found \u2014 libsvs_runtime.so will not be installed")
+    endif()
+endif()
+
+if ( WITH_CUVS STREQUAL "ON" )
+    set( _RMM_LIB_DIR "${FETCHCONTENT_BASE_DIR}/rmm-build" )
+    if ( EXISTS "${_RMM_LIB_DIR}" )
+        install(DIRECTORY ${_RMM_LIB_DIR}/
+                DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}
+                FILES_MATCHING PATTERN "librmm.so*")
+    else()
+        message(WARNING "cuVS enabled but ${_RMM_LIB_DIR} not found \u2014 librmm.so will not be installed")
+    endif()
+
+    set( _RAPIDS_LOGGER_LIB_DIR "${FETCHCONTENT_BASE_DIR}/rapids_logger-build" )
+    if ( EXISTS "${_RAPIDS_LOGGER_LIB_DIR}" )
+        install(DIRECTORY ${_RAPIDS_LOGGER_LIB_DIR}/
+                DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}
+                FILES_MATCHING PATTERN "librapids_logger.so*")
+    else()
+        message(WARNING "cuVS enabled but ${_RAPIDS_LOGGER_LIB_DIR} not found \u2014 librapids_logger.so will not be installed")
     endif()
 endif()
 

--- a/pkg/util/hardware/gpu_mem_info_cuda.go
+++ b/pkg/util/hardware/gpu_mem_info_cuda.go
@@ -16,7 +16,7 @@ typedef struct {
 } GPUMemoryInfo;
 
 // Function to get memory info for all GPUs
-int getAllGPUMemoryInfo(GPUMemoryInfo** infos) {
+static int getAllGPUMemoryInfo(GPUMemoryInfo** infos) {
     int deviceCount = 0;
     cudaError_t err = cudaGetDeviceCount(&deviceCount);
     if (err != cudaSuccess || deviceCount == 0) {


### PR DESCRIPTION
## Summary
- Set RAPIDS package dirs for GPU builds so local cuVS package resolution can find `raft::raft` and `rmm::rmm`.
- Install cuVS runtime dependencies `librmm.so*` and `librapids_logger.so*` alongside Milvus core libraries.
- Make the CUDA cgo GPU memory helper `static` to avoid duplicate global symbols during Go link.

issue: #49368

## Test plan
- [ ] `make milvus-gpu > output.txt 2>&1`
- [ ] Check `internal/core/output/lib/librmm.so*` and `internal/core/output/lib/librapids_logger.so*` exist after build.
- [ ] Check `ldd internal/core/output/lib/libknowhere.so` does not report missing `librmm` or `librapids_logger`.

Generated with Claude Code