### PR TITLE
fix: [3.0] temporarily retry schema consistency gate in proxy

### DIFF
--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -990,9 +990,13 @@ func (node *Proxy) AddCollectionField(ctx context.Context, request *milvuspb.Add
 	}
 	defer node.alterSchemaInFlight.Delete(collKey)
 
-	// Block until all segments have caught up to the current schema version,
-	// preventing a new field addition while a previous backfill is still in progress.
-	if err := node.checkSchemaVersionConsistency(ctx, request.DbName, request.CollectionName); err != nil {
+	// TEMP: SDKs do not consistently retry retryable DDL errors yet.
+	// Retry the schema consistency gate in Proxy first to hide short backfill
+	// convergence windows from clients until SDK retry handling is fixed.
+	if err := retry.Handle(ctx, func() (bool, error) {
+		err := node.checkSchemaVersionConsistency(ctx, request.DbName, request.CollectionName)
+		return merr.IsRetryableErr(err), err
+	}); err != nil {
 		return merr.Status(err), nil
 	}
 
@@ -1082,8 +1086,13 @@ func (node *Proxy) AlterCollectionSchema(ctx context.Context, request *milvuspb.
 	}
 	defer node.alterSchemaInFlight.Delete(collKey)
 
-	// Check schema version consistency before proceeding with alter collection schema
-	if err := node.checkSchemaVersionConsistency(ctx, request.DbName, request.CollectionName); err != nil {
+	// TEMP: SDKs do not consistently retry retryable DDL errors yet.
+	// Retry the schema consistency gate in Proxy first to hide short backfill
+	// convergence windows from clients until SDK retry handling is fixed.
+	if err := retry.Handle(ctx, func() (bool, error) {
+		err := node.checkSchemaVersionConsistency(ctx, request.DbName, request.CollectionName)
+		return merr.IsRetryableErr(err), err
+	}); err != nil {
 		return &milvuspb.AlterCollectionSchemaResponse{
 			AlterStatus: merr.Status(err),
 		}, nil
@@ -1224,9 +1233,7 @@ func (node *Proxy) checkSchemaVersionConsistency(ctx context.Context, dbName, co
 		return merr.WrapErrParameterInvalidMsg("incomplete schema version consistency stats from DataCoord")
 	}
 	if consistentSegments < totalSegments {
-		return merr.WrapErrParameterInvalidMsg(
-			"schema version consistency check failed: %d/%d segments are consistent, required 100%%",
-			consistentSegments, totalSegments)
+		return merr.WrapErrCollectionSchemaVersionNotReady(collectionName, consistentSegments, totalSegments)
 	}
 	return nil
 }

--- a/internal/proxy/impl_test.go
+++ b/internal/proxy/impl_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/apache/pulsar-client-go/pulsar"
 	"github.com/bytedance/mockey"
@@ -2404,16 +2405,55 @@ func TestProxy_AddCollectionField_SchemaVersionGate(t *testing.T) {
 			}, nil).Build()
 
 			mockey.Mock((*Proxy).checkSchemaVersionConsistency).Return(
-				merr.WrapErrParameterInvalidMsg("consistency check failed"),
+				merr.WrapErrCollectionSchemaVersionNotReady("test_coll", 1, 3),
 			).Build()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+			defer cancel()
+
+			resp, err := node.AddCollectionField(ctx, &milvuspb.AddCollectionFieldRequest{
+				DbName:         "default",
+				CollectionName: "test_coll",
+			})
+			assert.NoError(t, err)
+			assert.ErrorIs(t, merr.Error(resp), merr.ErrCollectionSchemaVersionNotReady)
+			assert.True(t, resp.GetRetriable())
+			assert.Equal(t, commonpb.ErrorCode_NotReadyServe, resp.GetErrorCode())
+		})
+	})
+
+	t.Run("consistency check retries until success", func(t *testing.T) {
+		mockey.PatchConvey("consistency check retries AddCollectionField", t, func() {
+			node := createTestProxy()
+			defer node.sched.Close()
+
+			mockey.Mock((*Proxy).DescribeCollection).Return(&milvuspb.DescribeCollectionResponse{
+				Status: merr.Success(),
+				Schema: &schemapb.CollectionSchema{Name: "test_coll"},
+			}, nil).Build()
+
+			attempt := 0
+			mockey.Mock((*Proxy).checkSchemaVersionConsistency).To(func(*Proxy, context.Context, string, string) error {
+				attempt++
+				if attempt == 1 {
+					return merr.WrapErrCollectionSchemaVersionNotReady("test_coll", 1, 3)
+				}
+				return nil
+			}).Build()
+
+			mockey.Mock((*ddTaskQueue).Enqueue).To(func(_ *ddTaskQueue, t task) error {
+				_ = t.OnEnqueue()
+				return nil
+			}).Build()
+			mockey.Mock((*TaskCondition).WaitToFinish).Return(nil).Build()
 
 			resp, err := node.AddCollectionField(context.Background(), &milvuspb.AddCollectionFieldRequest{
 				DbName:         "default",
 				CollectionName: "test_coll",
 			})
 			assert.NoError(t, err)
-			assert.Error(t, merr.Error(resp))
-			assert.Contains(t, resp.GetReason(), "consistency check failed")
+			assert.True(t, merr.Ok(resp))
+			assert.Equal(t, 2, attempt)
 		})
 	})
 
@@ -2720,14 +2760,19 @@ func TestProxy_AlterCollectionSchema(t *testing.T) {
 			}, nil).Build()
 
 			mockey.Mock((*Proxy).checkSchemaVersionConsistency).Return(
-				merr.WrapErrParameterInvalidMsg("consistency check failed"),
+				merr.WrapErrCollectionSchemaVersionNotReady("test_coll", 1, 3),
 			).Build()
 
-			resp, err := node.AlterCollectionSchema(context.Background(), &milvuspb.AlterCollectionSchemaRequest{
+			ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+			defer cancel()
+
+			resp, err := node.AlterCollectionSchema(ctx, &milvuspb.AlterCollectionSchemaRequest{
 				CollectionName: "test_coll",
 			})
 			assert.NoError(t, err)
-			assert.Error(t, merr.Error(resp.GetAlterStatus()))
+			assert.ErrorIs(t, merr.Error(resp.GetAlterStatus()), merr.ErrCollectionSchemaVersionNotReady)
+			assert.True(t, resp.GetAlterStatus().GetRetriable())
+			assert.Equal(t, commonpb.ErrorCode_NotReadyServe, resp.GetAlterStatus().GetErrorCode())
 		})
 	})
 
@@ -2921,9 +2966,12 @@ func TestCheckSchemaVersionConsistency(t *testing.T) {
 				}).Build()
 
 			err := node.checkSchemaVersionConsistency(context.Background(), "db", "coll")
-			assert.Error(t, err)
+			assert.ErrorIs(t, err, merr.ErrCollectionSchemaVersionNotReady)
 			assert.Contains(t, err.Error(), "5")
 			assert.Contains(t, err.Error(), "10")
+			status := merr.Status(err)
+			assert.True(t, status.GetRetriable())
+			assert.Equal(t, commonpb.ErrorCode_NotReadyServe, status.GetErrorCode())
 		})
 	})
 

--- a/pkg/util/merr/errors.go
+++ b/pkg/util/merr/errors.go
@@ -71,8 +71,9 @@ var (
 	ErrCollectionOnRecovering                  = newMilvusError("collection on recovering", 106, true)
 	ErrCollectionVectorClusteringKeyNotAllowed = newMilvusError("vector clustering key not allowed", 107, false)
 	// Deprecated, keep it only for reserving the error code
-	ErrCollectionReplicateMode  = newMilvusError("can't operate on the collection under standby mode", 108, false)
-	ErrCollectionSchemaMismatch = newMilvusError("collection schema mismatch", 109, false)
+	ErrCollectionReplicateMode         = newMilvusError("can't operate on the collection under standby mode", 108, false)
+	ErrCollectionSchemaMismatch        = newMilvusError("collection schema mismatch", 109, false)
+	ErrCollectionSchemaVersionNotReady = newMilvusError("collection schema version not ready", 110, true)
 	// Partition related
 	ErrPartitionNotFound       = newMilvusError("partition not found", 200, false)
 	ErrPartitionNotLoaded      = newMilvusError("partition not loaded", 201, false)

--- a/pkg/util/merr/errors_test.go
+++ b/pkg/util/merr/errors_test.go
@@ -90,6 +90,9 @@ func (s *ErrSuite) TestWrap() {
 	s.ErrorIs(WrapErrCollectionOnRecovering("test_collection", "channel lost %s", "dev"), ErrCollectionOnRecovering)
 	s.ErrorIs(WrapErrCollectionVectorClusteringKeyNotAllowed("test_collection", "field"), ErrCollectionVectorClusteringKeyNotAllowed)
 	s.ErrorIs(WrapErrCollectionSchemaMisMatch("schema mismatch", "field"), ErrCollectionSchemaMismatch)
+	s.ErrorIs(WrapErrCollectionSchemaVersionNotReady("test_collection", 1, 3), ErrCollectionSchemaVersionNotReady)
+	s.True(Status(WrapErrCollectionSchemaVersionNotReady("test_collection", 1, 3)).GetRetriable())
+	s.Equal(commonpb.ErrorCode_NotReadyServe, Status(WrapErrCollectionSchemaVersionNotReady("test_collection", 1, 3)).GetErrorCode())
 	// Partition related
 	s.ErrorIs(WrapErrPartitionNotFound("test_partition", "failed to get partition"), ErrPartitionNotFound)
 	s.ErrorIs(WrapErrPartitionNotLoaded("test_partition", "failed to query"), ErrPartitionNotLoaded)

--- a/pkg/util/merr/utils.go
+++ b/pkg/util/merr/utils.go
@@ -175,7 +175,7 @@ func StatusWithErrorCode(err error, code commonpb.ErrorCode) *commonpb.Status {
 
 func oldCode(code int32) commonpb.ErrorCode {
 	switch code {
-	case ErrServiceNotReady.code():
+	case ErrServiceNotReady.code(), ErrCollectionSchemaVersionNotReady.code():
 		return commonpb.ErrorCode_NotReadyServe
 
 	case ErrCollectionNotFound.code():
@@ -582,6 +582,14 @@ func WrapErrCollectionSchemaMisMatch(collection any, msg ...string) error {
 		err = errors.Wrap(err, strings.Join(msg, "->"))
 	}
 	return err
+}
+
+func WrapErrCollectionSchemaVersionNotReady(collection any, consistentSegments, totalSegments int) error {
+	return wrapFieldsWithDesc(
+		ErrCollectionSchemaVersionNotReady,
+		fmt.Sprintf("%d/%d segments are consistent, required 100%%", consistentSegments, totalSegments),
+		value("collection", collection),
+	)
 }
 
 func WrapErrAliasNotFound(db any, alias any, msg ...string) error {


### PR DESCRIPTION
Cherry-pick from master
pr: #49385

Related to #49350

Retry checkSchemaVersionConsistency in Proxy as a temporary server-side workaround while SDKs do not correctly handle retryable schema gate errors. Also return ErrCollectionSchemaVersionNotReady so incomplete backfill convergence is reported as NotReadyServe instead of invalid parameter.