### PR TITLE
fix: make schema consistency backfill errors retryable

### DIFF
--- a/internal/proxy/impl_test.go
+++ b/internal/proxy/impl_test.go
@@ -2966,7 +2966,9 @@ func TestCheckSchemaVersionConsistency(t *testing.T) {
 				}).Build()
 
 			err := node.checkSchemaVersionConsistency(context.Background(), "db", "coll")
+			assert.Error(t, err)
 			assert.ErrorIs(t, err, merr.ErrCollectionSchemaVersionNotReady)
+			assert.NotErrorIs(t, err, merr.ErrParameterInvalid)
 			assert.Contains(t, err.Error(), "5")
 			assert.Contains(t, err.Error(), "10")
 			status := merr.Status(err)

--- a/tests/python_client/milvus_client/test_add_field_feature.py
+++ b/tests/python_client/milvus_client/test_add_field_feature.py
@@ -9,8 +9,9 @@ from common import common_func as cf
 from common import common_type as ct
 from common.common_type import CaseLabel, CheckTasks
 from pymilvus import AnnSearchRequest, RRFRanker
+from pymilvus.exceptions import MilvusException
 from pymilvus.orm.types import CONSISTENCY_STRONG
-from utils.util_pymilvus import DataType
+from utils.util_pymilvus import DataType, restart_server
 
 prefix = "add_field"
 default_vector_field_name = "vector"
@@ -1423,6 +1424,80 @@ class TestMilvusClientAddFieldFeature(TestMilvusClientV2Base):
         )
 
         self.drop_collection(client, collection_name)
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_milvus_client_add_field_retry_after_restart_during_backfill(self, args):
+        """
+        target: verify AddCollectionField remains retryable after restart while previous backfill catches up
+        method: create flushed segments, add one nullable field, restart server, retry adding another field
+        expected: transient schema-version inconsistency returns code 1 service-not-ready, then retry succeeds
+        """
+        if "service_name" not in args or not args["service_name"]:
+            pytest.skip("Skip restart case if service name not provided")
+
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        dim = 128
+        batch = 2000
+
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=dim)
+        index_params = self.prepare_index_params(client)[0]
+        index_params.add_index(field_name=default_vector_field_name, index_type="AUTOINDEX", metric_type="L2")
+        self.create_collection(client, collection_name, schema=schema, index_params=index_params)
+
+        schema_res = self.describe_collection(client, collection_name)[0]
+        for batch_id in range(3):
+            rows = cf.gen_row_data_by_schema(nb=batch, schema=schema_res, start=batch_id * batch)
+            self.insert(client, collection_name, rows)
+            self.flush(client, collection_name)
+
+        self.add_collection_field(
+            client,
+            collection_name,
+            field_name="field_v1",
+            data_type=DataType.INT64,
+            nullable=True,
+            default_value=0,
+        )
+        assert restart_server(args["service_name"])
+
+        retryable_seen = False
+        deadline = time.time() + 120
+        while time.time() < deadline:
+            retry_client = self._client(timeout=10)
+            try:
+                retry_client.add_collection_field(
+                    collection_name=collection_name,
+                    field_name="field_v2",
+                    data_type=DataType.INT64,
+                    nullable=True,
+                    default_value=0,
+                    timeout=10,
+                )
+                if retryable_seen:
+                    break
+                stats, _ = self.get_collection_stats(retry_client, collection_name)
+                if stats.get("schema_version_consistent_segments") == stats.get("schema_version_total_segments"):
+                    break
+            except MilvusException as err:
+                message = str(err)
+                if "field_v2" in message and "already" in message.lower():
+                    break
+                assert err.code != 1100, message
+                assert err.code == 1, message
+                assert "schema version consistency check failed" in message
+                retryable_seen = True
+                time.sleep(1)
+            finally:
+                self.close(retry_client)
+        else:
+            raise AssertionError("field_v2 was not added before retry deadline")
+
+        fields = [field["name"] for field in self.describe_collection(client, collection_name)[0]["fields"]]
+        assert "field_v1" in fields
+        assert "field_v2" in fields
 
 
 class TestMilvusClientAddFieldFeatureInvalid(TestMilvusClientV2Base):

--- a/tests/python_client/utils/util_pymilvus.py
+++ b/tests/python_client/utils/util_pymilvus.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import random
 import string
 import threading
@@ -804,7 +805,7 @@ def restart_server(helm_release_name):
     res = True
     timeout = 120
     from kubernetes import client, config
-    client.rest.logger.setLevel(log.WARNING)
+    client.rest.logger.setLevel(logging.WARNING)
 
     # service_name = "%s.%s.svc.cluster.local" % (helm_release_name, namespace)
     init_k8s_client_config()


### PR DESCRIPTION
## Summary
- Return service-not-ready instead of invalid-parameter when AddCollectionField observes schema-version backfill lag.
- Add Proxy regression coverage and a MilvusClient restart/backfill regression case for the issue flow.

## Test plan
- `docker run --rm -e GOTOOLCHAIN=go1.25.9 -e PKG_CONFIG_PATH=/go/src/github.com/milvus-io/milvus/internal/core/output/lib/pkgconfig -e LD_LIBRARY_PATH=/go/src/github.com/milvus-io/milvus/internal/core/output/lib -v /home/ubuntu/skills/issue_review/milvus_issue_49350/milvus:/go/src/github.com/milvus-io/milvus -w /go/src/github.com/milvus-io/milvus milvusdb/milvus-env:ubuntu22.04-latest bash -lc 'go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/proxy -run "TestProxy_AddCollectionField_SchemaVersionGate|TestCheckSchemaVersionConsistency"'`
- `COMPOSE_FILE=docker-compose.patched.yml PHASE=prepare_kill_probe python3 repro_49350.py` (observed code=1 service-not-ready, then retry success)
- `python3 -m py_compile tests/python_client/milvus_client/test_add_field_feature.py && git diff --check`
- Python pytest selection not run locally because pytest is not installed in this environment.

issue: #49350

Generated with [Claude Code](https://claude.com/claude-code)
