### PR TITLE
enhance: batch json flat index operations

### DIFF
--- a/internal/core/src/index/JsonFlatIndex.h
+++ b/internal/core/src/index/JsonFlatIndex.h
@@ -39,9 +39,7 @@ class JsonFlatIndexQueryExecutor : public InvertedIndexTantivy<T> {
         tracer::AutoSpan span("JsonFlatIndexQueryExecutor::In",
                               tracer::GetRootSpan());
         TargetBitmap bitset(this->Count());
-        for (size_t i = 0; i < n; ++i) {
-            this->wrapper_->json_term_query(json_path_, values[i], &bitset);
-        }
+        this->wrapper_->json_terms_query(json_path_, values, n, &bitset);
         return bitset;
     }
 
@@ -62,10 +60,8 @@ class JsonFlatIndexQueryExecutor : public InvertedIndexTantivy<T> {
         tracer::AutoSpan span("JsonFlatIndexQueryExecutor::InApplyFilter",
                               tracer::GetRootSpan());
         TargetBitmap bitset(this->Count());
-        for (size_t i = 0; i < n; ++i) {
-            this->wrapper_->json_term_query(json_path_, values[i], &bitset);
-            apply_hits_with_filter(bitset, filter);
-        }
+        this->wrapper_->json_terms_query(json_path_, values, n, &bitset);
+        apply_hits_with_filter(bitset, filter);
         return bitset;
     }
 
@@ -77,10 +73,8 @@ class JsonFlatIndexQueryExecutor : public InvertedIndexTantivy<T> {
         tracer::AutoSpan span("JsonFlatIndexQueryExecutor::InApplyCallback",
                               tracer::GetRootSpan());
         TargetBitmap bitset(this->Count());
-        for (size_t i = 0; i < n; ++i) {
-            this->wrapper_->json_term_query(json_path_, values[i], &bitset);
-            apply_hits_with_callback(bitset, callback);
-        }
+        this->wrapper_->json_terms_query(json_path_, values, n, &bitset);
+        apply_hits_with_callback(bitset, callback);
     }
 
     const TargetBitmap
@@ -88,9 +82,7 @@ class JsonFlatIndexQueryExecutor : public InvertedIndexTantivy<T> {
         tracer::AutoSpan span("JsonFlatIndexQueryExecutor::NotIn",
                               tracer::GetRootSpan());
         TargetBitmap bitset(this->Count());
-        for (size_t i = 0; i < n; ++i) {
-            this->wrapper_->json_term_query(json_path_, values[i], &bitset);
-        }
+        this->wrapper_->json_terms_query(json_path_, values, n, &bitset);
 
         bitset.flip();
 

--- a/internal/core/thirdparty/tantivy/tantivy-binding/include/tantivy-binding.h
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/include/tantivy-binding.h
@@ -256,6 +256,30 @@ RustResult tantivy_json_term_query_keyword(void *ptr,
                                            const char *term,
                                            void *bitset);
 
+RustResult tantivy_json_terms_query_i64(void *ptr,
+                                        const char *json_path,
+                                        const int64_t *terms,
+                                        uintptr_t len,
+                                        void *bitset);
+
+RustResult tantivy_json_terms_query_f64(void *ptr,
+                                        const char *json_path,
+                                        const double *terms,
+                                        uintptr_t len,
+                                        void *bitset);
+
+RustResult tantivy_json_terms_query_bool(void *ptr,
+                                         const char *json_path,
+                                         const bool *terms,
+                                         uintptr_t len,
+                                         void *bitset);
+
+RustResult tantivy_json_terms_query_keyword(void *ptr,
+                                            const char *json_path,
+                                            const char *const *terms,
+                                            uintptr_t len,
+                                            void *bitset);
+
 RustResult tantivy_json_exist_query(void *ptr, const char *json_path, void *bitset);
 
 RustResult tantivy_json_range_query_i64(void *ptr,
@@ -432,6 +456,11 @@ RustResult tantivy_index_add_json_key_stats_data_by_batch(void *ptr,
                                                           uintptr_t len);
 
 RustResult tantivy_index_add_json(void *ptr, const char *s, int64_t offset);
+
+RustResult tantivy_index_add_json_batch(void *ptr,
+                                        const char *const *array,
+                                        uintptr_t len,
+                                        int64_t offset_begin);
 
 RustResult tantivy_index_add_array_json(void *ptr,
                                         const char *const *array,

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/index_reader.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/index_reader.rs
@@ -25,6 +25,10 @@ use crate::error::{Result, TantivyBindingError};
 // TermSetQuery when larger than this threshold. This value is based on some experiments.
 const BATCH_THRESHOLD: usize = 10000;
 
+// Threshold for JSON batch-in query. JSON term construction is more expensive (path encoding),
+// so TermSetQuery becomes beneficial at a lower threshold than for non-JSON fields.
+const JSON_BATCH_THRESHOLD: usize = 10;
+
 #[allow(dead_code)]
 pub(crate) struct IndexReaderWrapper {
     pub(crate) field_name: String,
@@ -464,6 +468,88 @@ impl IndexReaderWrapper {
         let mut json_term = Term::from_field_json_path(self.field, json_path, false);
         json_term.append_type_and_str(term);
         let q = TermQuery::new(json_term, IndexRecordOption::Basic);
+        self.search(&q, bitset)
+    }
+
+    // Batch JSON terms queries - execute all terms in a single search when possible
+    pub fn json_terms_query_i64(
+        &self,
+        json_path: &str,
+        terms: &[i64],
+        bitset: *mut c_void,
+    ) -> Result<()> {
+        if terms.len() < JSON_BATCH_THRESHOLD {
+            return terms
+                .iter()
+                .try_for_each(|&term| self.json_term_query_i64(json_path, term, bitset));
+        }
+        let term_vec: Vec<_> = terms
+            .iter()
+            .map(|&t| {
+                let mut json_term = Term::from_field_json_path(self.field, json_path, false);
+                json_term.append_type_and_fast_value(t);
+                json_term
+            })
+            .collect();
+        let q = TermSetQuery::new(term_vec);
+        self.search(&q, bitset)
+    }
+
+    pub fn json_terms_query_f64(
+        &self,
+        json_path: &str,
+        terms: &[f64],
+        bitset: *mut c_void,
+    ) -> Result<()> {
+        if terms.len() < JSON_BATCH_THRESHOLD {
+            return terms
+                .iter()
+                .try_for_each(|&term| self.json_term_query_f64(json_path, term, bitset));
+        }
+        let term_vec: Vec<_> = terms
+            .iter()
+            .map(|&t| {
+                let mut json_term = Term::from_field_json_path(self.field, json_path, false);
+                json_term.append_type_and_fast_value(t);
+                json_term
+            })
+            .collect();
+        let q = TermSetQuery::new(term_vec);
+        self.search(&q, bitset)
+    }
+
+    pub fn json_terms_query_bool(
+        &self,
+        json_path: &str,
+        terms: &[bool],
+        bitset: *mut c_void,
+    ) -> Result<()> {
+        // bool has at most 2 distinct values, always use per-term
+        terms
+            .iter()
+            .try_for_each(|&term| self.json_term_query_bool(json_path, term, bitset))
+    }
+
+    pub fn json_terms_query_keyword(
+        &self,
+        json_path: &str,
+        terms: &[*const c_char],
+        bitset: *mut c_void,
+    ) -> Result<()> {
+        if terms.len() < JSON_BATCH_THRESHOLD {
+            return terms.iter().try_for_each(|&term| {
+                let term_str = c_ptr_to_str(term)?;
+                self.json_term_query_keyword(json_path, term_str, bitset)
+            });
+        }
+        let mut term_vec = Vec::with_capacity(terms.len());
+        for &term in terms {
+            let term_str = c_ptr_to_str(term)?;
+            let mut json_term = Term::from_field_json_path(self.field, json_path, false);
+            json_term.append_type_and_str(term_str);
+            term_vec.push(json_term);
+        }
+        let q = TermSetQuery::new(term_vec);
         self.search(&q, bitset)
     }
 

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/index_reader_c.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/index_reader_c.rs
@@ -377,6 +377,67 @@ pub extern "C" fn tantivy_json_term_query_keyword(
     }
 }
 
+// Batch JSON terms queries
+#[no_mangle]
+pub extern "C" fn tantivy_json_terms_query_i64(
+    ptr: *mut c_void,
+    json_path: *const c_char,
+    terms: *const i64,
+    len: usize,
+    bitset: *mut c_void,
+) -> RustResult {
+    let real = ptr as *mut IndexReaderWrapper;
+    let json_path = cstr_to_str!(json_path);
+    let terms = unsafe { convert_to_rust_slice!(terms, len) };
+    unsafe { (*real).json_terms_query_i64(json_path, terms, bitset).into() }
+}
+
+#[no_mangle]
+pub extern "C" fn tantivy_json_terms_query_f64(
+    ptr: *mut c_void,
+    json_path: *const c_char,
+    terms: *const f64,
+    len: usize,
+    bitset: *mut c_void,
+) -> RustResult {
+    let real = ptr as *mut IndexReaderWrapper;
+    let json_path = cstr_to_str!(json_path);
+    let terms = unsafe { convert_to_rust_slice!(terms, len) };
+    unsafe { (*real).json_terms_query_f64(json_path, terms, bitset).into() }
+}
+
+#[no_mangle]
+pub extern "C" fn tantivy_json_terms_query_bool(
+    ptr: *mut c_void,
+    json_path: *const c_char,
+    terms: *const bool,
+    len: usize,
+    bitset: *mut c_void,
+) -> RustResult {
+    let real = ptr as *mut IndexReaderWrapper;
+    let json_path = cstr_to_str!(json_path);
+    let terms = unsafe { convert_to_rust_slice!(terms, len) };
+    unsafe { (*real).json_terms_query_bool(json_path, terms, bitset).into() }
+}
+
+#[no_mangle]
+pub extern "C" fn tantivy_json_terms_query_keyword(
+    ptr: *mut c_void,
+    json_path: *const c_char,
+    terms: *const *const c_char,
+    len: usize,
+    bitset: *mut c_void,
+) -> RustResult {
+    let real = ptr as *mut IndexReaderWrapper;
+    let json_path = cstr_to_str!(json_path);
+    let terms = unsafe { convert_to_rust_slice!(terms, len) };
+    unsafe {
+        (*real)
+            .json_terms_query_keyword(json_path, terms, bitset)
+            .into()
+    }
+}
+
 #[no_mangle]
 pub extern "C" fn tantivy_json_exist_query(
     ptr: *mut c_void,

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/index_reader_c.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/index_reader_c.rs
@@ -389,7 +389,11 @@ pub extern "C" fn tantivy_json_terms_query_i64(
     let real = ptr as *mut IndexReaderWrapper;
     let json_path = cstr_to_str!(json_path);
     let terms = unsafe { convert_to_rust_slice!(terms, len) };
-    unsafe { (*real).json_terms_query_i64(json_path, terms, bitset).into() }
+    unsafe {
+        (*real)
+            .json_terms_query_i64(json_path, terms, bitset)
+            .into()
+    }
 }
 
 #[no_mangle]
@@ -403,7 +407,11 @@ pub extern "C" fn tantivy_json_terms_query_f64(
     let real = ptr as *mut IndexReaderWrapper;
     let json_path = cstr_to_str!(json_path);
     let terms = unsafe { convert_to_rust_slice!(terms, len) };
-    unsafe { (*real).json_terms_query_f64(json_path, terms, bitset).into() }
+    unsafe {
+        (*real)
+            .json_terms_query_f64(json_path, terms, bitset)
+            .into()
+    }
 }
 
 #[no_mangle]
@@ -417,7 +425,11 @@ pub extern "C" fn tantivy_json_terms_query_bool(
     let real = ptr as *mut IndexReaderWrapper;
     let json_path = cstr_to_str!(json_path);
     let terms = unsafe { convert_to_rust_slice!(terms, len) };
-    unsafe { (*real).json_terms_query_bool(json_path, terms, bitset).into() }
+    unsafe {
+        (*real)
+            .json_terms_query_bool(json_path, terms, bitset)
+            .into()
+    }
 }
 
 #[no_mangle]

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/index_writer.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/index_writer.rs
@@ -115,6 +115,19 @@ impl IndexWriterWrapper {
         }
     }
 
+    pub fn add_json_batch(&mut self, datas: &[*const c_char], offset_begin: i64) -> Result<()> {
+        match self {
+            IndexWriterWrapper::V5(_) => {
+                return Err(TantivyBindingError::InternalError(
+                    "add json batch with tantivy index version 5 is not supported".into(),
+                ));
+            }
+            IndexWriterWrapper::V7(writer) => {
+                writer.add_json_batch(datas, offset_begin as u32)
+            }
+        }
+    }
+
     pub fn add_array_json(&mut self, datas: &[*const c_char], offset: Option<i64>) -> Result<()> {
         match self {
             IndexWriterWrapper::V5(_) => {

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/index_writer.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/index_writer.rs
@@ -122,9 +122,7 @@ impl IndexWriterWrapper {
                     "add json batch with tantivy index version 5 is not supported".into(),
                 ));
             }
-            IndexWriterWrapper::V7(writer) => {
-                writer.add_json_batch(datas, offset_begin as u32)
-            }
+            IndexWriterWrapper::V7(writer) => writer.add_json_batch(datas, offset_begin as u32),
         }
     }
 

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/index_writer_c.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/index_writer_c.rs
@@ -460,6 +460,20 @@ pub extern "C" fn tantivy_index_add_json(
 }
 
 #[no_mangle]
+pub extern "C" fn tantivy_index_add_json_batch(
+    ptr: *mut c_void,
+    array: *const *const c_char,
+    len: usize,
+    offset_begin: i64,
+) -> RustResult {
+    let real = ptr as *mut IndexWriterWrapper;
+    unsafe {
+        let arr = convert_to_rust_slice!(array, len);
+        (*real).add_json_batch(arr, offset_begin).into()
+    }
+}
+
+#[no_mangle]
 pub extern "C" fn tantivy_index_add_array_json(
     ptr: *mut c_void,
     array: *const *const c_char,

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/index_writer_v7/index_writer.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/index_writer_v7/index_writer.rs
@@ -206,6 +206,18 @@ impl IndexWriterWrapperImpl {
         self.add_document(document, offset)
     }
 
+    /// Batch add multiple JSON documents, each as a separate document with sequential offsets.
+    pub fn add_json_batch(&mut self, datas: &[*const c_char], offset_begin: u32) -> Result<()> {
+        for (i, &data_ptr) in datas.iter().enumerate() {
+            let data = c_ptr_to_str(data_ptr)?;
+            let j = serde_json::from_str::<serde_json::Value>(data)?;
+            let mut document = TantivyDocument::default();
+            j.add_to_document(self.field.field_id(), &mut document);
+            self.add_document(document, offset_begin + i as u32)?;
+        }
+        Ok(())
+    }
+
     pub fn add_array_json(&mut self, datas: &[*const c_char], offset: u32) -> Result<()> {
         let mut document = TantivyDocument::default();
         for element in datas {

--- a/internal/core/thirdparty/tantivy/tantivy-wrapper.h
+++ b/internal/core/thirdparty/tantivy/tantivy-wrapper.h
@@ -1154,8 +1154,7 @@ struct TantivyIndexWrapper {
                 for (size_t i = 0; i < n; ++i)
                     i64_values[i] = static_cast<int64_t>(values[i]);
                 auto res_i64 = tantivy_json_terms_query_i64(
-                    reader_, json_path.c_str(),
-                    i64_values.data(), n, bitset);
+                    reader_, json_path.c_str(), i64_values.data(), n, bitset);
                 AssertInfo(res_i64.success,
                            "TantivyIndexWrapper.json_terms_query i64: {}",
                            res_i64.error);
@@ -1166,8 +1165,7 @@ struct TantivyIndexWrapper {
                 for (size_t i = 0; i < n; ++i)
                     f64_values[i] = static_cast<double>(values[i]);
                 return tantivy_json_terms_query_f64(
-                    reader_, json_path.c_str(),
-                    f64_values.data(), n, bitset);
+                    reader_, json_path.c_str(), f64_values.data(), n, bitset);
             }
 
             if constexpr (std::is_floating_point_v<T>) {
@@ -1180,26 +1178,30 @@ struct TantivyIndexWrapper {
                     }
                 }
                 if (!int_values.empty()) {
-                    auto res_i64 = tantivy_json_terms_query_i64(
-                        reader_, json_path.c_str(),
-                        int_values.data(), int_values.size(), bitset);
+                    auto res_i64 =
+                        tantivy_json_terms_query_i64(reader_,
+                                                     json_path.c_str(),
+                                                     int_values.data(),
+                                                     int_values.size(),
+                                                     bitset);
                     AssertInfo(res_i64.success,
                                "TantivyIndexWrapper.json_terms_query i64: {}",
                                res_i64.error);
                     free_rust_result(res_i64);
                 }
                 return tantivy_json_terms_query_f64(
-                    reader_, json_path.c_str(),
-                    reinterpret_cast<const double*>(values), n, bitset);
+                    reader_,
+                    json_path.c_str(),
+                    reinterpret_cast<const double*>(values),
+                    n,
+                    bitset);
             }
 
             if constexpr (std::is_same_v<T, std::string>) {
                 std::vector<const char*> c_strs(n);
-                for (size_t i = 0; i < n; ++i)
-                    c_strs[i] = values[i].c_str();
+                for (size_t i = 0; i < n; ++i) c_strs[i] = values[i].c_str();
                 return tantivy_json_terms_query_keyword(
-                    reader_, json_path.c_str(),
-                    c_strs.data(), n, bitset);
+                    reader_, json_path.c_str(), c_strs.data(), n, bitset);
             }
 
             throw fmt::format(

--- a/internal/core/thirdparty/tantivy/tantivy-wrapper.h
+++ b/internal/core/thirdparty/tantivy/tantivy-wrapper.h
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <cmath>
 #include <sstream>
 #include <fmt/format.h>
 #include <set>
@@ -352,11 +353,19 @@ struct TantivyIndexWrapper {
     void
     add_json_data(const Json* array, uintptr_t len, int64_t offset_begin) {
         assert(!finished_);
-        for (uintptr_t i = 0; i < len; i++) {
-            auto res = RustResultWrapper(tantivy_index_add_json(
-                writer_, array[i].data().data(), offset_begin + i));
+        // Batch add: collect c_str pointers and send in one FFI call
+        constexpr uintptr_t BATCH_SIZE = 1024;
+        for (uintptr_t start = 0; start < len; start += BATCH_SIZE) {
+            uintptr_t end = std::min(start + BATCH_SIZE, len);
+            uintptr_t batch_len = end - start;
+            std::vector<const char*> ptrs(batch_len);
+            for (uintptr_t i = 0; i < batch_len; ++i) {
+                ptrs[i] = array[start + i].data().data();
+            }
+            auto res = RustResultWrapper(tantivy_index_add_json_batch(
+                writer_, ptrs.data(), batch_len, offset_begin + start));
             AssertInfo(res.result_->success,
-                       "failed to add json: {}",
+                       "failed to add json batch: {}",
                        res.result_->error);
         }
     }
@@ -1122,6 +1131,88 @@ struct TantivyIndexWrapper {
                    res.result_->error);
         AssertInfo(res.result_->value.tag == Value::Tag::None,
                    "TantivyIndexWrapper.json_term_query: invalid result type");
+    }
+
+    // Batch json terms query - all values in a single call
+    template <typename T>
+    void
+    json_terms_query(const std::string& json_path,
+                     const T* values,
+                     size_t n,
+                     void* bitset) {
+        auto array = [&]() {
+            if constexpr (std::is_same_v<T, bool>) {
+                return tantivy_json_terms_query_bool(
+                    reader_, json_path.c_str(), values, n, bitset);
+            }
+
+            if constexpr (std::is_integral_v<T>) {
+                // For JSON integer fields, we need to query both i64 and f64
+                // because JSON numbers can be stored as either type.
+                // First batch-query i64, then batch-query f64.
+                std::vector<int64_t> i64_values(n);
+                for (size_t i = 0; i < n; ++i)
+                    i64_values[i] = static_cast<int64_t>(values[i]);
+                auto res_i64 = tantivy_json_terms_query_i64(
+                    reader_, json_path.c_str(),
+                    i64_values.data(), n, bitset);
+                AssertInfo(res_i64.success,
+                           "TantivyIndexWrapper.json_terms_query i64: {}",
+                           res_i64.error);
+                free_rust_result(res_i64);
+
+                // Also query as f64 since JSON doesn't distinguish int/float
+                std::vector<double> f64_values(n);
+                for (size_t i = 0; i < n; ++i)
+                    f64_values[i] = static_cast<double>(values[i]);
+                return tantivy_json_terms_query_f64(
+                    reader_, json_path.c_str(),
+                    f64_values.data(), n, bitset);
+            }
+
+            if constexpr (std::is_floating_point_v<T>) {
+                // Query matching integers first (for values without fractional part)
+                std::vector<int64_t> int_values;
+                int_values.reserve(n);
+                for (size_t i = 0; i < n; ++i) {
+                    if (std::floor(values[i]) == values[i]) {
+                        int_values.push_back(static_cast<int64_t>(values[i]));
+                    }
+                }
+                if (!int_values.empty()) {
+                    auto res_i64 = tantivy_json_terms_query_i64(
+                        reader_, json_path.c_str(),
+                        int_values.data(), int_values.size(), bitset);
+                    AssertInfo(res_i64.success,
+                               "TantivyIndexWrapper.json_terms_query i64: {}",
+                               res_i64.error);
+                    free_rust_result(res_i64);
+                }
+                return tantivy_json_terms_query_f64(
+                    reader_, json_path.c_str(),
+                    reinterpret_cast<const double*>(values), n, bitset);
+            }
+
+            if constexpr (std::is_same_v<T, std::string>) {
+                std::vector<const char*> c_strs(n);
+                for (size_t i = 0; i < n; ++i)
+                    c_strs[i] = values[i].c_str();
+                return tantivy_json_terms_query_keyword(
+                    reader_, json_path.c_str(),
+                    c_strs.data(), n, bitset);
+            }
+
+            throw fmt::format(
+                "InvertedIndex.json_terms_query: unsupported data type: {}",
+                typeid(T).name());
+            return RustResult();
+        }();
+        auto res = RustResultWrapper(array);
+        AssertInfo(res.result_->success,
+                   "TantivyIndexWrapper.json_terms_query: {}",
+                   res.result_->error);
+        AssertInfo(res.result_->value.tag == Value::Tag::None,
+                   "TantivyIndexWrapper.json_terms_query: invalid result type");
     }
 
     void


### PR DESCRIPTION
Batch JSON document ingestion across the Tantivy FFI boundary and add JSON terms query APIs for flat index IN predicates. Use TermSetQuery for larger JSON IN lists while preserving per-term execution for small lists and bool terms.

issue: #48609