### PR TITLE
build(deps): [3.0] bump milvus-storage to 23399cf

### DIFF
--- a/internal/core/thirdparty/milvus-storage/CMakeLists.txt
+++ b/internal/core/thirdparty/milvus-storage/CMakeLists.txt
@@ -15,7 +15,7 @@
 milvus_add_pkg_config("milvus-storage")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
 
-set( milvus-storage_VERSION 6f38add)
+set( milvus-storage_VERSION 23399cf)
 set( GIT_REPOSITORY  "https://github.com/milvus-io/milvus-storage.git")
 message(STATUS "milvus-storage repo: ${GIT_REPOSITORY}")
 message(STATUS "milvus-storage version: ${milvus-storage_VERSION}")


### PR DESCRIPTION
## Summary

Bump the 3.0 branch milvus-storage dependency from `6f38add` to the latest commit on `milvus-storage` 3.0: `23399cff6ab744ed9c459828d039e898e0bf6f37`.

## Test plan

Not run locally; dependency-only bump, CI will build against the updated storage revision.

pr: #49367