### PR TITLE
fix: reject oversized index params

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -341,6 +341,7 @@ proxy:
   # If the number of result entries exceeds this limit, the search will be rejected.
   # Disabled if the value is less or equal to 0.
   maxResultEntries: -1
+  maxIndexParamsSize: 102400 # maximum total size of index params in bytes for create index requests
   accessLog:
     enable: false # Whether to enable the access log feature.
     minioEnable: false # Whether to upload local access log files to MinIO. This parameter can be specified when proxy.accessLog.filename is not empty.

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -336,12 +336,12 @@ proxy:
   dclConcurrency: 16 # The concurrent execution number of DCL at proxy.
   mustUsePartitionKey: false # switch for whether proxy must use partition key for the collection
   resolveAliasForPrivilege: true # switch for whether proxy shall resolve alias to actual collection name during RBAC privilege checks
+  maxIndexParamsSize: 102400 # maximum total size of index params in bytes for create index requests
   # maximum number of result entries, typically Nq * TopK * GroupSize. 
   # It costs additional memory and time to process a large number of result entries. 
   # If the number of result entries exceeds this limit, the search will be rejected.
   # Disabled if the value is less or equal to 0.
   maxResultEntries: -1
-  maxIndexParamsSize: 102400 # maximum total size of index params in bytes for create index requests
   accessLog:
     enable: false # Whether to enable the access log feature.
     minioEnable: false # Whether to upload local access log files to MinIO. This parameter can be specified when proxy.accessLog.filename is not empty.

--- a/internal/proxy/task_index.go
+++ b/internal/proxy/task_index.go
@@ -204,6 +204,30 @@ func wrapUserIndexParams(metricType string) []*commonpb.KeyValuePair {
 	}
 }
 
+func checkIndexParamsSize(size int) error {
+	maxIndexParamsSize := paramtable.Get().ProxyCfg.MaxIndexParamsSize.GetAsInt()
+	if size > maxIndexParamsSize {
+		return merr.WrapErrParameterInvalidMsg("index params size exceeds limit: %d > %d", size, maxIndexParamsSize)
+	}
+	return nil
+}
+
+func validateIndexParamsSize(params ...*commonpb.KeyValuePair) error {
+	size := 0
+	for _, param := range params {
+		size += len(param.GetKey()) + len(param.GetValue())
+	}
+	return checkIndexParamsSize(size)
+}
+
+func validateIndexParamsMapSize(params map[string]string) error {
+	size := 0
+	for k, v := range params {
+		size += len(k) + len(v)
+	}
+	return checkIndexParamsSize(size)
+}
+
 func (cit *createIndexTask) parseFunctionParamsToIndex(indexParamsMap map[string]string) error {
 	if !cit.fieldSchema.GetIsFunctionOutput() {
 		return nil
@@ -242,6 +266,9 @@ func (cit *createIndexTask) parseFunctionParamsToIndex(indexParamsMap map[string
 
 func (cit *createIndexTask) parseIndexParams(ctx context.Context) error {
 	cit.newExtraParams = cit.req.GetExtraParams()
+	if err := validateIndexParamsSize(cit.newExtraParams...); err != nil {
+		return err
+	}
 
 	isVecIndex := typeutil.IsVectorType(cit.fieldSchema.DataType)
 	indexParamsMap := make(map[string]string)
@@ -270,6 +297,10 @@ func (cit *createIndexTask) parseIndexParams(ctx context.Context) error {
 	}
 	if jsonCastFunction, exist := indexParamsMap[common.JSONCastFunctionKey]; exist {
 		indexParamsMap[common.JSONCastFunctionKey] = strings.ToUpper(strings.TrimSpace(jsonCastFunction))
+	}
+
+	if err := validateIndexParamsMapSize(indexParamsMap); err != nil {
+		return err
 	}
 
 	if err := ValidateAutoIndexMmapConfig(isVecIndex, indexParamsMap); err != nil {
@@ -557,6 +588,10 @@ func (cit *createIndexTask) parseIndexParams(ctx context.Context) error {
 		if _, exist := indexParamsMap[common.JSONPathKey]; !exist {
 			indexParamsMap[common.JSONPathKey] = cit.req.FieldName
 		}
+	}
+
+	if err := validateIndexParamsMapSize(indexParamsMap); err != nil {
+		return err
 	}
 
 	err := checkTrain(ctx, cit.fieldSchema, indexParamsMap)

--- a/internal/proxy/task_index_test.go
+++ b/internal/proxy/task_index_test.go
@@ -405,6 +405,140 @@ func Test_deduplicate_parseIndexParams(t *testing.T) {
 	})
 }
 
+func Test_parseIndexParamsAllowsParsableParamsWithinSize(t *testing.T) {
+	paramtable.Init()
+	Params.Save(Params.ProxyCfg.MaxIndexParamsSize.Key, strconv.Itoa(100*1024))
+	defer Params.Reset(Params.ProxyCfg.MaxIndexParamsSize.Key)
+
+	params, err := json.Marshal(map[string]any{
+		"custom_param": strings.Repeat("A", 1024),
+	})
+	assert.NoError(t, err)
+
+	cit := &createIndexTask{
+		req: &milvuspb.CreateIndexRequest{
+			ExtraParams: []*commonpb.KeyValuePair{
+				{Key: common.IndexTypeKey, Value: indexparamcheck.IndexINVERTED},
+				{Key: common.ParamsKey, Value: string(params)},
+			},
+		},
+		fieldSchema: &schemapb.FieldSchema{
+			FieldID:  101,
+			Name:     "FieldID",
+			DataType: schemapb.DataType_VarChar,
+		},
+	}
+
+	err = cit.parseIndexParams(context.TODO())
+	assert.NoError(t, err)
+	assert.Contains(t, cit.newIndexParams, &commonpb.KeyValuePair{Key: "custom_param", Value: strings.Repeat("A", 1024)})
+}
+
+func Test_parseIndexParamsRejectsConfiguredMaxIndexParamsSize(t *testing.T) {
+	paramtable.Init()
+	Params.Save(Params.ProxyCfg.MaxIndexParamsSize.Key, "64")
+	defer Params.Reset(Params.ProxyCfg.MaxIndexParamsSize.Key)
+
+	params, err := json.Marshal(map[string]any{
+		"custom_param": strings.Repeat("A", 128),
+	})
+	assert.NoError(t, err)
+
+	cit := &createIndexTask{
+		req: &milvuspb.CreateIndexRequest{
+			ExtraParams: []*commonpb.KeyValuePair{
+				{Key: common.IndexTypeKey, Value: indexparamcheck.IndexINVERTED},
+				{Key: common.ParamsKey, Value: string(params)},
+			},
+		},
+		fieldSchema: &schemapb.FieldSchema{
+			FieldID:  101,
+			Name:     "FieldID",
+			DataType: schemapb.DataType_VarChar,
+		},
+	}
+
+	err = cit.parseIndexParams(context.TODO())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "index params size")
+	assert.Contains(t, err.Error(), "64")
+}
+
+func Test_parseIndexParamsRejectsOversizedParams(t *testing.T) {
+	params, err := json.Marshal(map[string]any{
+		"malicious_padding": strings.Repeat("A", 100*1024),
+	})
+	assert.NoError(t, err)
+
+	cit := &createIndexTask{
+		req: &milvuspb.CreateIndexRequest{
+			ExtraParams: []*commonpb.KeyValuePair{
+				{Key: common.IndexTypeKey, Value: indexparamcheck.IndexINVERTED},
+				{Key: common.ParamsKey, Value: string(params)},
+			},
+		},
+		fieldSchema: &schemapb.FieldSchema{
+			FieldID:  101,
+			Name:     "FieldID",
+			DataType: schemapb.DataType_VarChar,
+		},
+	}
+
+	err = cit.parseIndexParams(context.TODO())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "index params size")
+}
+
+func Test_parseIndexParamsRejectsOversizedRawParams(t *testing.T) {
+	cit := &createIndexTask{
+		req: &milvuspb.CreateIndexRequest{
+			ExtraParams: []*commonpb.KeyValuePair{
+				{Key: common.IndexTypeKey, Value: indexparamcheck.IndexINVERTED},
+				{Key: common.ParamsKey, Value: strings.Repeat(" ", 100*1024) + `{"custom_param":"A"}`},
+			},
+		},
+		fieldSchema: &schemapb.FieldSchema{
+			FieldID:  101,
+			Name:     "FieldID",
+			DataType: schemapb.DataType_VarChar,
+		},
+	}
+
+	err := cit.parseIndexParams(context.TODO())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "index params size")
+}
+
+func Test_parseIndexParamsRejectsFinalIndexParamsOverLimit(t *testing.T) {
+	paramtable.Init()
+	Params.Save(Params.ProxyCfg.MaxIndexParamsSize.Key, "128")
+	Params.Save(Params.AutoIndexConfig.Enable.Key, "false")
+	Params.Save(Params.AutoIndexConfig.IndexParams.Key, `{"M": 18,"efConstruction": 240,"index_type": "HNSW", "metric_type": "COSINE", "large_config": "`+strings.Repeat("A", 128)+`"}`)
+	defer Params.Reset(Params.ProxyCfg.MaxIndexParamsSize.Key)
+	defer Params.Reset(Params.AutoIndexConfig.Enable.Key)
+	defer Params.Reset(Params.AutoIndexConfig.IndexParams.Key)
+
+	cit := &createIndexTask{
+		req: &milvuspb.CreateIndexRequest{
+			ExtraParams: []*commonpb.KeyValuePair{
+				{Key: common.MetricTypeKey, Value: "L2"},
+			},
+		},
+		fieldSchema: &schemapb.FieldSchema{
+			FieldID:  101,
+			Name:     "FieldID",
+			DataType: schemapb.DataType_FloatVector,
+			TypeParams: []*commonpb.KeyValuePair{
+				{Key: common.DimKey, Value: "128"},
+			},
+		},
+	}
+
+	err := cit.parseIndexParams(context.TODO())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "index params size")
+}
+
 func Test_parseIndexParams(t *testing.T) {
 	cit := &createIndexTask{
 		Condition: nil,

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2034,6 +2034,7 @@ type proxyConfig struct {
 	ResolveAliasForPrivilege        ParamItem `refreshable:"true"`
 	MaxVarCharLength                ParamItem `refreshable:"false"`
 	MaxTextLength                   ParamItem `refreshable:"false"`
+	MaxIndexParamsSize              ParamItem `refreshable:"true"`
 	MaxResultEntries                ParamItem `refreshable:"true"`
 	EnableCachedServiceProvider     ParamItem `refreshable:"true"`
 
@@ -2498,6 +2499,15 @@ please adjust in embedded Milvus: false`,
 		Doc:          "maximum number of characters for a row of the text field",
 	}
 	p.MaxTextLength.Init(base.mgr)
+
+	p.MaxIndexParamsSize = ParamItem{
+		Key:          "proxy.maxIndexParamsSize",
+		Version:      "3.0.0",
+		DefaultValue: strconv.Itoa(100 * 1024),
+		Doc:          "maximum total size of index params in bytes for create index requests",
+		Export:       true,
+	}
+	p.MaxIndexParamsSize.Init(base.mgr)
 
 	p.MaxResultEntries = ParamItem{
 		Key:          "proxy.maxResultEntries",

--- a/tests/go_client/testcases/load_release_test.go
+++ b/tests/go_client/testcases/load_release_test.go
@@ -515,8 +515,10 @@ func TestLoadPartialFieldsPartitions(t *testing.T) {
 
 	// load parName partition with different partial fields
 	diffFields := []string{common.DefaultInt64FieldName, common.DefaultFloatVecFieldName, common.DefaultVarcharFieldName}
-	_, errPar := mc.LoadPartitions(ctx, clientv2.NewLoadPartitionsOption(schema.CollectionName, parName).WithLoadFields(diffFields...))
+	taskDiff, errPar := mc.LoadPartitions(ctx, clientv2.NewLoadPartitionsOption(schema.CollectionName, parName).WithLoadFields(diffFields...))
 	common.CheckErr(t, errPar, true)
+	err = taskDiff.Await(ctx)
+	common.CheckErr(t, err, true)
 	queryPar, errPar := mc.Query(ctx, clientv2.NewQueryOption(schema.CollectionName).WithOutputFields(diffFields...).WithPartitions(parName).WithLimit(common.DefaultLimit))
 	common.CheckErr(t, errPar, true)
 	common.CheckOutputFields(t, diffFields, queryPar.Fields)


### PR DESCRIPTION
## Summary
- Add `proxy.maxIndexParamsSize` to cap create index parameter payloads before coordinator persistence.
- Reject oversized raw `ExtraParams`, expanded JSON params, and final merged index params in proxy.
- Cover normal-sized params and oversized payload regressions in `parseIndexParams` tests.

issue: #48330

## Test plan
- [ ] Not run locally: `go test -tags dynamic,test -gcflags=\"all=-N -l\" -count=1 ./internal/proxy -run 'Test_parseIndexParams(Rejects|Allows)'` requires generated segcore C/C++ headers not available in this local checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)