### PR TITLE
fix: sync up drop collection ack

### DIFF
--- a/internal/rootcoord/ddl_callbacks_drop_collection.go
+++ b/internal/rootcoord/ddl_callbacks_drop_collection.go
@@ -61,7 +61,7 @@ func (c *Core) broadcastDropCollectionV1(ctx context.Context, req *milvuspb.Drop
 	msg := message.NewDropCollectionMessageBuilderV1().
 		WithHeader(dropCollectionTask.header).
 		WithBody(dropCollectionTask.body).
-		WithBroadcast(channels).
+		WithBroadcast(channels, message.OptBuildBroadcastAckSyncUp()).
 		MustBuildBroadcast()
 	if _, err := broadcaster.Broadcast(ctx, msg); err != nil {
 		return err


### PR DESCRIPTION
relate: #48612

## Summary
Enable AckSyncUp for all DropCollection broadcasts so drop acknowledgement waits for downstream DDL handling instead of using the default FastAck path.