### PR TITLE
fix: use record batch column order when loading column groups

### DIFF
--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -2322,10 +2322,9 @@ SegmentGrowingImpl::LoadColumnGroup(
     for (auto& future : part_futures) {
         auto part_result = future.get();
         for (auto& record_batch : part_result) {
-            // result->emplace_back(std::move(record_batch));
             auto batch_num_rows = record_batch->num_rows();
-            for (auto i = 0; i < column_group->columns.size(); ++i) {
-                auto column = column_group->columns[i];
+            for (auto i = 0; i < record_batch->num_columns(); ++i) {
+                auto column = record_batch->column_name(i);
 
                 auto field_id = FieldId(std::stoll(column));
 
@@ -2343,7 +2342,7 @@ SegmentGrowingImpl::LoadColumnGroup(
                     batch_num_rows);
                 auto array = record_batch->column(i);
                 field_data->FillFieldData(array);
-                field_data_map[FieldId(field_id)].push_back(field_data);
+                field_data_map[field_id].push_back(field_data);
             }
         }
     }


### PR DESCRIPTION
Related to #49217

Load column group field data by iterating the Arrow RecordBatch columns and deriving the FieldId from each column name, so field data stays aligned with the actual batch schema even when column group metadata order differs.