### PR TITLE
enhance: propagate cancellation in external manifest load

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -607,14 +607,18 @@ ChunkedSegmentSealedImpl::LoadFieldData(const LoadFieldDataInfo& load_info,
 }
 
 void
-ChunkedSegmentSealedImpl::LoadColumnGroups(const std::string& manifest_path) {
+ChunkedSegmentSealedImpl::LoadColumnGroups(const std::string& manifest_path,
+                                           milvus::OpContext* op_ctx) {
     auto load_cg_start = std::chrono::high_resolution_clock::now();
     LOG_INFO(
         "[LoadColumnGroups] segment {} start, manifest {}", id_, manifest_path);
+
     auto properties = std::make_shared<milvus_storage::api::Properties>(
         *milvus::storage::LoonFFIPropertiesSingleton::GetInstance()
              .GetProperties());
     auto load_info = std::atomic_load(&segment_load_info_);
+    CheckCancellation(
+        op_ctx, id_, "ChunkedSegmentSealedImpl::LoadColumnGroups(manifest)");
     auto column_groups = load_info->GetColumnGroups();
 
     // External collections: inject extfs.{collectionID}.* derived from
@@ -656,6 +660,8 @@ ChunkedSegmentSealedImpl::LoadColumnGroups(const std::string& manifest_path) {
                                                       needed_columns,
                                                       *properties);
     }
+    CheckCancellation(
+        op_ctx, id_, "ChunkedSegmentSealedImpl::LoadColumnGroups(manifest)");
 
     auto reader_create_ms =
         std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -752,13 +758,18 @@ ChunkedSegmentSealedImpl::LoadColumnGroups(const std::string& manifest_path) {
                                    properties,
                                    cg_index = task.cg_index,
                                    field_ids = std::move(task.field_ids),
-                                   eager_load = task.eager_load] {
+                                   eager_load = task.eager_load,
+                                   op_ctx] {
+            CheckCancellation(op_ctx,
+                              id_,
+                              cg_index,
+                              "ChunkedSegmentSealedImpl::LoadColumnGroup()");
             LoadColumnGroup(column_groups,
                             properties,
                             cg_index,
                             field_ids,
                             eager_load,
-                            /*op_ctx=*/nullptr,
+                            op_ctx,
                             /*is_replace=*/false);
         });
         load_group_futures.emplace_back(std::move(future));
@@ -4164,7 +4175,7 @@ ChunkedSegmentSealedImpl::ApplyLoadDiff(milvus::OpContext* op_ctx,
     // load column groups
     if (diff.load_external_manifest) {
         // External collections: load via manifest path
-        LoadColumnGroups(segment_load_info.GetManifestPath());
+        LoadColumnGroups(segment_load_info.GetManifestPath(), op_ctx);
     } else {
         bool has_cg_changes = !diff.column_groups_to_load.empty() ||
                               !diff.column_groups_to_replace.empty() ||

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -613,12 +613,16 @@ ChunkedSegmentSealedImpl::LoadColumnGroups(const std::string& manifest_path,
     LOG_INFO(
         "[LoadColumnGroups] segment {} start, manifest {}", id_, manifest_path);
 
-    auto properties = std::make_shared<milvus_storage::api::Properties>(
-        *milvus::storage::LoonFFIPropertiesSingleton::GetInstance()
-             .GetProperties());
-    auto load_info = std::atomic_load(&segment_load_info_);
     CheckCancellation(
         op_ctx, id_, "ChunkedSegmentSealedImpl::LoadColumnGroups(manifest)");
+    auto base_properties =
+        milvus::storage::LoonFFIPropertiesSingleton::GetInstance()
+            .GetProperties();
+    AssertInfo(base_properties != nullptr,
+               "Loon FFI properties are not initialized");
+    auto properties =
+        std::make_shared<milvus_storage::api::Properties>(*base_properties);
+    auto load_info = std::atomic_load(&segment_load_info_);
     auto column_groups = load_info->GetColumnGroups();
 
     // External collections: inject extfs.{collectionID}.* derived from

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -1184,7 +1184,8 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
 
     // Load column groups from a manifest file path (for external collections)
     void
-    LoadColumnGroups(const std::string& manifest_path);
+    LoadColumnGroups(const std::string& manifest_path,
+                     milvus::OpContext* op_ctx = nullptr);
 
     /**
      * @brief Load a single column group at the specified index

--- a/internal/core/src/segcore/LoadCancellationTest.cpp
+++ b/internal/core/src/segcore/LoadCancellationTest.cpp
@@ -93,6 +93,38 @@ TEST(LoadCancellationSegment, CreateTextIndexCancellationSealed) {
         SegcoreError);
 }
 
+TEST(LoadCancellationSegment, ExternalManifestLoadCancellationSealed) {
+    auto schema = std::make_shared<Schema>();
+    auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
+    schema->set_primary_field_id(pk_fid);
+    schema->set_external_source("s3://bucket/path");
+    auto segment = CreateSealedSegment(
+        schema, nullptr, -1, SegcoreConfig::default_config(), true);
+
+    proto::segcore::SegmentLoadInfo load_info;
+    load_info.set_segmentid(1);
+    load_info.set_collectionid(1);
+    load_info.set_partitionid(1);
+    load_info.set_num_of_rows(1);
+    load_info.set_manifest_path("not-json");
+    segment->SetLoadInfo(load_info);
+
+    folly::CancellationSource source;
+    source.requestCancellation();
+    OpContext op_ctx(source.getToken());
+    tracer::TraceContext trace_ctx;
+    EXPECT_THROW(
+        {
+            try {
+                segment->Load(trace_ctx, &op_ctx);
+            } catch (const SegcoreError& e) {
+                EXPECT_EQ(e.get_error_code(), ErrorCode::FollyCancel);
+                throw;
+            }
+        },
+        SegcoreError);
+}
+
 // Test for Segment CreateTextIndex cancellation (growing segment)
 TEST(LoadCancellationSegment, CreateTextIndexCancellationGrowing) {
     auto schema = std::make_shared<Schema>();

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -2137,7 +2137,7 @@ SegmentGrowingImpl::Load(milvus::tracer::TraceContext& trace_ctx,
 
     auto manifest_path = load_info_.manifest_path();
     if (manifest_path != "") {
-        LoadColumnsGroups(manifest_path);
+        LoadColumnsGroups(manifest_path, op_ctx);
         return;
     }
 
@@ -2193,9 +2193,12 @@ SegmentGrowingImpl::Load(milvus::tracer::TraceContext& trace_ctx,
 }
 
 void
-SegmentGrowingImpl::LoadColumnsGroups(std::string manifest_path) {
+SegmentGrowingImpl::LoadColumnsGroups(std::string manifest_path,
+                                      milvus::OpContext* op_ctx) {
     LOG_INFO(
         "Loading segment {} field data with manifest {}", id_, manifest_path);
+    CheckCancellation(op_ctx, id_, "SegmentGrowingImpl::LoadColumnsGroups()");
+
     // size_t num_rows = storage::GetNumRowsForLoadInfo(infos);
     auto num_rows = load_info_.num_of_rows();
     auto primary_field_id =
@@ -2215,8 +2218,10 @@ SegmentGrowingImpl::LoadColumnsGroups(std::string manifest_path) {
         std::future<std::unordered_map<FieldId, std::vector<FieldDataPtr>>>>
         load_group_futures;
     for (int64_t i = 0; i < column_groups->size(); ++i) {
-        auto future = pool.Submit([this, column_groups, properties, i] {
-            return LoadColumnGroup(column_groups, properties, i);
+        auto future = pool.Submit([this, column_groups, properties, i, op_ctx] {
+            CheckCancellation(
+                op_ctx, id_, i, "SegmentGrowingImpl::LoadColumnGroup()");
+            return LoadColumnGroup(column_groups, properties, i, op_ctx);
         });
         load_group_futures.emplace_back(std::move(future));
     }
@@ -2273,7 +2278,8 @@ std::unordered_map<FieldId, std::vector<FieldDataPtr>>
 SegmentGrowingImpl::LoadColumnGroup(
     const std::shared_ptr<milvus_storage::api::ColumnGroups>& column_groups,
     const std::shared_ptr<milvus_storage::api::Properties>& properties,
-    int64_t index) {
+    int64_t index,
+    milvus::OpContext* op_ctx) {
     AssertInfo(index < column_groups->size(),
                "load column group index out of range");
     auto column_group = column_groups->at(index);
@@ -2307,8 +2313,10 @@ SegmentGrowingImpl::LoadColumnGroup(
     auto part_futures = std::vector<
         std::future<std::vector<std::shared_ptr<arrow::RecordBatch>>>>();
     for (const auto& part : split_result) {
-        part_futures.emplace_back(
-            thread_pool.Submit([chunk_reader = chunk_reader.get(), part]() {
+        part_futures.emplace_back(thread_pool.Submit(
+            [chunk_reader = chunk_reader.get(), part, op_ctx]() {
+                CheckCancellation(
+                    op_ctx, -1, "SegmentGrowingImpl::LoadColumnGroup()");
                 std::vector<int64_t> chunk_ids(part.count);
                 std::iota(chunk_ids.begin(), chunk_ids.end(), part.offset);
 
@@ -2318,9 +2326,24 @@ SegmentGrowingImpl::LoadColumnGroup(
             }));
     }
 
-    std::unordered_map<FieldId, std::vector<FieldDataPtr>> field_data_map;
+    std::vector<std::vector<std::shared_ptr<arrow::RecordBatch>>> part_results;
+    part_results.reserve(part_futures.size());
+    std::vector<std::exception_ptr> load_exceptions;
     for (auto& future : part_futures) {
-        auto part_result = future.get();
+        try {
+            part_results.emplace_back(future.get());
+        } catch (...) {
+            load_exceptions.push_back(std::current_exception());
+        }
+    }
+    if (!load_exceptions.empty()) {
+        std::rethrow_exception(load_exceptions[0]);
+    }
+
+    CheckCancellation(
+        op_ctx, id_, index, "SegmentGrowingImpl::LoadColumnGroup()");
+    std::unordered_map<FieldId, std::vector<FieldDataPtr>> field_data_map;
+    for (auto& part_result : part_results) {
         for (auto& record_batch : part_result) {
             // result->emplace_back(std::move(record_batch));
             auto batch_num_rows = record_batch->num_rows();

--- a/internal/core/src/segcore/SegmentGrowingImpl.h
+++ b/internal/core/src/segcore/SegmentGrowingImpl.h
@@ -756,7 +756,8 @@ class SegmentGrowingImpl : public SegmentGrowing {
      * @param manifest_path JSON string containing base_path and version fields
      */
     void
-    LoadColumnsGroups(std::string manifest_path);
+    LoadColumnsGroups(std::string manifest_path,
+                      milvus::OpContext* op_ctx = nullptr);
 
     /**
      * @brief Load a single column group and return field data
@@ -773,7 +774,8 @@ class SegmentGrowingImpl : public SegmentGrowing {
     LoadColumnGroup(
         const std::shared_ptr<milvus_storage::api::ColumnGroups>& column_groups,
         const std::shared_ptr<milvus_storage::api::Properties>& properties,
-        int64_t index);
+        int64_t index,
+        milvus::OpContext* op_ctx = nullptr);
 
     void
     InitializeArrayOffsets();


### PR DESCRIPTION
issue: #49414

- Thread `OpContext` through sealed and growing external manifest load paths.
- Add cancellation checks around manifest/reader setup and per-column-group load work.
- Keep `SegmentLoadInfo::GetColumnGroups` as a pure manifest metadata cache.
- Add a sealed external manifest load cancellation regression test.