### PR TITLE
fix: optimize external table load path

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -607,10 +607,13 @@ ChunkedSegmentSealedImpl::LoadFieldData(const LoadFieldDataInfo& load_info,
 }
 
 void
-ChunkedSegmentSealedImpl::LoadColumnGroups(const std::string& manifest_path) {
+ChunkedSegmentSealedImpl::LoadColumnGroups(const std::string& manifest_path,
+                                           milvus::OpContext* op_ctx) {
     auto load_cg_start = std::chrono::high_resolution_clock::now();
     LOG_INFO(
         "[LoadColumnGroups] segment {} start, manifest {}", id_, manifest_path);
+    CheckCancellation(
+        op_ctx, id_, "ChunkedSegmentSealedImpl::LoadColumnGroups()");
     auto properties = std::make_shared<milvus_storage::api::Properties>(
         *milvus::storage::LoonFFIPropertiesSingleton::GetInstance()
              .GetProperties());
@@ -637,7 +640,7 @@ ChunkedSegmentSealedImpl::LoadColumnGroups(const std::string& manifest_path) {
     // let the Reader derive types from file metadata (Parquet footer).
     // FillFieldData handles Parquet-native → Milvus type conversion.
     //
-    // This overload (LoadColumnGroups(manifest_path)) is reached only via
+    // This overload is reached only via
     // ApplyLoadDiff when load_external_manifest is set, which in turn is
     // gated on is_external_collection() — see SegmentLoadInfo.cpp where the
     // flag is assigned. The non-external path uses LoadColumnGroups(
@@ -744,7 +747,7 @@ ChunkedSegmentSealedImpl::LoadColumnGroups(const std::string& manifest_path) {
         tasks.size(),
         cg_field_ids.size());
 
-    auto& pool = ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::LOW);
+    auto& pool = ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::MIDDLE);
     std::vector<std::future<void>> load_group_futures;
     for (auto& task : tasks) {
         auto future = pool.Submit([this,
@@ -752,13 +755,18 @@ ChunkedSegmentSealedImpl::LoadColumnGroups(const std::string& manifest_path) {
                                    properties,
                                    cg_index = task.cg_index,
                                    field_ids = std::move(task.field_ids),
-                                   eager_load = task.eager_load] {
+                                   eager_load = task.eager_load,
+                                   op_ctx] {
+            CheckCancellation(op_ctx,
+                              id_,
+                              cg_index,
+                              "ChunkedSegmentSealedImpl::LoadColumnGroup()");
             LoadColumnGroup(column_groups,
                             properties,
                             cg_index,
                             field_ids,
                             eager_load,
-                            /*op_ctx=*/nullptr,
+                            op_ctx,
                             /*is_replace=*/false);
         });
         load_group_futures.emplace_back(std::move(future));
@@ -4201,7 +4209,7 @@ ChunkedSegmentSealedImpl::ApplyLoadDiff(milvus::OpContext* op_ctx,
     // load column groups
     if (diff.load_external_manifest) {
         // External collections: load via manifest path
-        LoadColumnGroups(segment_load_info.GetManifestPath());
+        LoadColumnGroups(segment_load_info.GetManifestPath(), op_ctx);
     } else {
         bool has_cg_changes = !diff.column_groups_to_load.empty() ||
                               !diff.column_groups_to_replace.empty() ||

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -1200,7 +1200,8 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
 
     // Load column groups from a manifest file path (for external collections)
     void
-    LoadColumnGroups(const std::string& manifest_path);
+    LoadColumnGroups(const std::string& manifest_path,
+                     milvus::OpContext* op_ctx = nullptr);
 
     /**
      * @brief Load a single column group at the specified index

--- a/internal/core/src/segcore/LoadCancellationTest.cpp
+++ b/internal/core/src/segcore/LoadCancellationTest.cpp
@@ -120,6 +120,42 @@ TEST(LoadCancellationSegment, CreateTextIndexCancellationGrowing) {
 // since the cancellation check happens before the analyzer validation. If cancellation
 // doesn't throw, the function continues and would need proper analyzer setup to succeed.
 
+TEST(LoadCancellationSegment, LoadExternalManifestPreCancelled) {
+    auto schema = std::make_shared<Schema>();
+    auto pk_fid = FieldId(100);
+    schema->AddField(FieldMeta(
+        FieldName("pk"), pk_fid, DataType::INT64, false, std::nullopt, "pk"));
+    schema->set_primary_field_id(pk_fid);
+    schema->set_external_source("s3://test-bucket/data");
+    schema->set_external_spec(R"({"format":"parquet"})");
+    auto segment = CreateSealedSegment(
+        schema, nullptr, -1, SegcoreConfig::default_config(), true);
+
+    milvus::proto::segcore::SegmentLoadInfo load_info;
+    load_info.set_collectionid(1);
+    load_info.set_partitionid(1);
+    load_info.set_segmentid(1);
+    load_info.set_num_of_rows(1);
+    load_info.set_manifest_path("invalid-manifest-path");
+
+    folly::CancellationSource source;
+    source.requestCancellation();
+    OpContext op_ctx(source.getToken());
+    milvus::tracer::TraceContext trace_ctx;
+    segment->SetLoadInfo(load_info);
+
+    EXPECT_THROW(
+        {
+            try {
+                segment->Load(trace_ctx, &op_ctx);
+            } catch (const SegcoreError& e) {
+                EXPECT_EQ(e.get_error_code(), ErrorCode::FollyCancel);
+                throw;
+            }
+        },
+        SegcoreError);
+}
+
 // Test cancellation during loop operation
 TEST(LoadCancellationUtility, CancellationDuringLoop) {
     folly::CancellationSource source;

--- a/internal/core/unittest/test_external_take.cpp
+++ b/internal/core/unittest/test_external_take.cpp
@@ -244,7 +244,7 @@ BuildExternalSchema() {
     info.vec_id = FieldId(108);
 
     // Scalar fields: FieldMeta(name, id, type, nullable, default_value, external_field)
-    // All external fields are nullable=true (forced by ValidateExternalCollectionSchema)
+    // External scalar fields are nullable=true (forced by ValidateExternalCollectionSchema)
     schema->AddField(FieldMeta(FieldName("bool_col"),
                                info.bool_id,
                                DataType::BOOL,
@@ -384,7 +384,7 @@ BuildExternalSchemaWithVirtualPK() {
                                DataType::INT64,
                                false,
                                std::nullopt));
-    // External fields (nullable=true, forced by ValidateExternalCollectionSchema)
+    // External scalar fields (nullable=true, forced by ValidateExternalCollectionSchema)
     schema->AddField(FieldMeta(FieldName("int32_col"),
                                info.int32_id,
                                DataType::INT32,

--- a/internal/storagev2/packed/explore_ffi.go
+++ b/internal/storagev2/packed/explore_ffi.go
@@ -27,6 +27,7 @@ import "C"
 
 import (
 	"fmt"
+	"net/url"
 	"sort"
 	"strings"
 	"unsafe"
@@ -104,9 +105,6 @@ func GetFileInfo(
 	cFormat := C.CString(format)
 	defer C.free(unsafe.Pointer(cFormat))
 
-	cFilePath := C.CString(filePath)
-	defer C.free(unsafe.Pointer(cFilePath))
-
 	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create properties: %w", err)
@@ -115,6 +113,13 @@ func GetFileInfo(
 	if err := injectExternalSpecProperties(cProperties, extfs.CollectionID, extfs.Source, extfs.Spec); err != nil {
 		return nil, fmt.Errorf("inject extfs: %w", err)
 	}
+
+	normalizedFilePath, err := normalizeExternalPathForStorage(filePath, cProperties, extfs)
+	if err != nil {
+		return nil, fmt.Errorf("normalize external file path: %w", err)
+	}
+	cFilePath := C.CString(normalizedFilePath)
+	defer C.free(unsafe.Pointer(cFilePath))
 
 	var numRows C.uint64_t
 
@@ -127,6 +132,66 @@ func GetFileInfo(
 		FilePath: filePath,
 		NumRows:  int64(numRows),
 	}, nil
+}
+
+func normalizeExternalPathForStorage(path string, properties *C.LoonProperties, extfs ExternalSpecContext) (string, error) {
+	if extfs.Source == "" || path == "" || properties == nil {
+		return path, nil
+	}
+
+	u, err := url.Parse(path)
+	if err != nil {
+		return "", err
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return path, nil
+	}
+
+	prefix := ExtfsPrefixForCollection(extfs.CollectionID)
+	address := loonPropertyString(properties, prefix+"address")
+	bucketName := loonPropertyString(properties, prefix+"bucket_name")
+	if address == "" || bucketName == "" || bucketName != u.Host {
+		return path, nil
+	}
+
+	addressHost, err := propertyAddressHost(address)
+	if err != nil {
+		return "", err
+	}
+	if addressHost == "" || addressHost == u.Host {
+		return path, nil
+	}
+
+	oldPath := strings.TrimPrefix(u.Path, "/")
+	if oldPath == "" {
+		u.Path = "/" + bucketName
+	} else {
+		u.Path = "/" + bucketName + "/" + oldPath
+	}
+	u.RawPath = ""
+	u.Host = addressHost
+	return u.String(), nil
+}
+
+func loonPropertyString(properties *C.LoonProperties, key string) string {
+	cKey := C.CString(key)
+	defer C.free(unsafe.Pointer(cKey))
+	cValue := C.loon_properties_get(properties, cKey)
+	if cValue == nil {
+		return ""
+	}
+	return C.GoString(cValue)
+}
+
+func propertyAddressHost(address string) (string, error) {
+	if !strings.Contains(address, "://") {
+		return address, nil
+	}
+	u, err := url.Parse(address)
+	if err != nil {
+		return "", err
+	}
+	return u.Host, nil
 }
 
 // ExploreFilesReturnManifestPath is like ExploreFiles but also returns the manifest path
@@ -157,8 +222,6 @@ func ExploreFilesReturnManifestPath(
 	defer C.free(unsafe.Pointer(cFormat))
 	cBaseDir := C.CString(baseDir)
 	defer C.free(unsafe.Pointer(cBaseDir))
-	cExploreDir := C.CString(exploreDir)
-	defer C.free(unsafe.Pointer(cExploreDir))
 
 	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
 	if err != nil {
@@ -168,6 +231,13 @@ func ExploreFilesReturnManifestPath(
 	if err := injectExternalSpecProperties(cProperties, extfs.CollectionID, extfs.Source, extfs.Spec); err != nil {
 		return nil, "", fmt.Errorf("inject extfs: %w", err)
 	}
+
+	normalizedExploreDir, err := normalizeExternalPathForStorage(exploreDir, cProperties, extfs)
+	if err != nil {
+		return nil, "", fmt.Errorf("normalize external explore path: %w", err)
+	}
+	cExploreDir := C.CString(normalizedExploreDir)
+	defer C.free(unsafe.Pointer(cExploreDir))
 
 	var numFiles C.uint64_t
 	var outColumnGroupsPath *C.char

--- a/internal/storagev2/packed/exttable_test.go
+++ b/internal/storagev2/packed/exttable_test.go
@@ -547,6 +547,123 @@ func TestMakePropertiesFromStorageConfig_ExtraKVsOverride(t *testing.T) {
 	defer FreeProperties(props)
 }
 
+func TestNormalizeExternalPathForStorage_UsesInjectedExtfsEndpoint(t *testing.T) {
+	config := &indexpb.StorageConfig{
+		StorageType: "local",
+		BucketName:  "/tmp",
+		RootPath:    "/tmp",
+	}
+	extfs := ExternalSpecContext{
+		CollectionID: 42,
+		Source:       "s3://liyiyang-test/all_types_v2/",
+		Spec:         `{"format":"parquet","extfs":{"cloud_provider":"aws","region":"us-west-2","access_key_id":"ak","access_key_value":"sk"}}`,
+	}
+
+	props, err := MakePropertiesFromStorageConfig(config, nil)
+	require.NoError(t, err)
+	defer FreeProperties(props)
+	require.NoError(t, injectExternalSpecProperties(props, extfs.CollectionID, extfs.Source, extfs.Spec))
+
+	got, err := normalizeExternalPathForStorage(extfs.Source, props, extfs)
+	require.NoError(t, err)
+	assert.Equal(t, "s3://s3.us-west-2.amazonaws.com/liyiyang-test/all_types_v2/", got)
+
+	got, err = normalizeExternalPathForStorage("s3://liyiyang-test/a/b/file.parquet?versionId=1", props, extfs)
+	require.NoError(t, err)
+	assert.Equal(t, "s3://s3.us-west-2.amazonaws.com/liyiyang-test/a/b/file.parquet?versionId=1", got)
+}
+
+func TestNormalizeExternalPathForStorage_EndpointFormUnchanged(t *testing.T) {
+	config := &indexpb.StorageConfig{
+		StorageType: "local",
+		BucketName:  "/tmp",
+		RootPath:    "/tmp",
+	}
+	source := "s3://s3.us-west-2.amazonaws.com/liyiyang-test/all_types_v2/"
+	extfs := ExternalSpecContext{
+		CollectionID: 42,
+		Source:       source,
+		Spec:         `{"format":"parquet","extfs":{"cloud_provider":"aws","region":"us-west-2","access_key_id":"ak","access_key_value":"sk"}}`,
+	}
+
+	props, err := MakePropertiesFromStorageConfig(config, nil)
+	require.NoError(t, err)
+	defer FreeProperties(props)
+	require.NoError(t, injectExternalSpecProperties(props, extfs.CollectionID, extfs.Source, extfs.Spec))
+
+	got, err := normalizeExternalPathForStorage(source, props, extfs)
+	require.NoError(t, err)
+	assert.Equal(t, source, got)
+}
+
+func TestNormalizeExternalPathForStorage_NoRewriteCases(t *testing.T) {
+	config := &indexpb.StorageConfig{
+		StorageType: "local",
+		BucketName:  "/tmp",
+		RootPath:    "/tmp",
+	}
+	prefix := ExtfsPrefixForCollection(42)
+	props, err := MakePropertiesFromStorageConfig(config, map[string]string{
+		prefix + "address":     "https://s3.us-west-2.amazonaws.com",
+		prefix + "bucket_name": "liyiyang-test",
+	})
+	require.NoError(t, err)
+	defer FreeProperties(props)
+
+	path := "s3://liyiyang-test/all_types_v2/"
+
+	got, err := normalizeExternalPathForStorage(path, props, ExternalSpecContext{CollectionID: 42})
+	require.NoError(t, err)
+	assert.Equal(t, path, got)
+
+	got, err = normalizeExternalPathForStorage(
+		path,
+		nil,
+		ExternalSpecContext{CollectionID: 42, Source: "s3://liyiyang-test/all_types_v2/"},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, path, got)
+
+	got, err = normalizeExternalPathForStorage(
+		"relative/path",
+		props,
+		ExternalSpecContext{CollectionID: 42, Source: "s3://liyiyang-test/all_types_v2/"},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "relative/path", got)
+
+	got, err = normalizeExternalPathForStorage(
+		"s3://other-bucket/all_types_v2/",
+		props,
+		ExternalSpecContext{CollectionID: 42, Source: "s3://liyiyang-test/all_types_v2/"},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "s3://other-bucket/all_types_v2/", got)
+}
+
+func TestNormalizeExternalPathForStorage_BareAddress(t *testing.T) {
+	config := &indexpb.StorageConfig{
+		StorageType: "local",
+		BucketName:  "/tmp",
+		RootPath:    "/tmp",
+	}
+	prefix := ExtfsPrefixForCollection(42)
+	props, err := MakePropertiesFromStorageConfig(config, map[string]string{
+		prefix + "address":     "s3.us-west-2.amazonaws.com",
+		prefix + "bucket_name": "liyiyang-test",
+	})
+	require.NoError(t, err)
+	defer FreeProperties(props)
+
+	got, err := normalizeExternalPathForStorage(
+		"s3://liyiyang-test/all_types_v2/",
+		props,
+		ExternalSpecContext{CollectionID: 42, Source: "s3://liyiyang-test/all_types_v2/"},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "s3://s3.us-west-2.amazonaws.com/liyiyang-test/all_types_v2/", got)
+}
+
 // ==================== SampleExternalFieldSizes Tests ====================
 
 func TestSampleExternalFieldSizes_NilStorageConfig(t *testing.T) {

--- a/pkg/util/typeutil/schema.go
+++ b/pkg/util/typeutil/schema.go
@@ -2247,10 +2247,10 @@ func GetPrimaryFieldSchema(schema *schemapb.CollectionSchema) (*schemapb.FieldSc
 }
 
 // NormalizeAndValidateExternalCollectionSchema ensures unsupported features are
-// disabled for external collections AND mutates each user field to set
-// nullable=true. The mutation is intentional: external Parquet sources may
-// contain nulls in any column, and a non-nullable field would silently produce
-// incorrect results when reading those nulls. The function is named
+// disabled for external collections AND mutates each non-vector user field to
+// set nullable=true. The mutation is intentional: external Parquet sources may
+// contain nulls in scalar columns, and a non-nullable scalar field would silently
+// produce incorrect results when reading those nulls. The function is named
 // "NormalizeAndValidate" so callers know it has a write-back side effect.
 //
 // Validation runs in two passes: pass 1 checks every field; pass 2 mutates
@@ -2341,10 +2341,15 @@ func NormalizeAndValidateExternalCollectionSchema(schema *schemapb.CollectionSch
 	}
 
 	// Pass 2: normalize. All fields passed validation; safe to mutate.
-	// Force nullable for external fields: Parquet columns can contain nulls,
-	// and a non-nullable field would silently produce incorrect results.
+	// Force nullable for external scalar fields: Parquet columns can contain
+	// nulls, and non-nullable scalars would silently produce incorrect results.
 	for _, field := range schema.GetFields() {
 		if isExternalSystemOrVirtualField(field.GetName()) {
+			continue
+		}
+		if IsVectorType(field.GetDataType()) {
+			// External nullable vectors currently build incorrect offset mapping.
+			// Restore forced nullable after the offset mapping path is fixed.
 			continue
 		}
 		if !field.GetNullable() {

--- a/pkg/util/typeutil/schema_test.go
+++ b/pkg/util/typeutil/schema_test.go
@@ -5373,16 +5373,15 @@ func TestNormalizeAndValidateExternalCollectionSchema(t *testing.T) {
 		}
 	})
 
-	t.Run("user fields forced nullable", func(t *testing.T) {
+	t.Run("user scalar fields forced nullable but vector fields unchanged", func(t *testing.T) {
 		schema := buildSchema()
 		for _, f := range schema.GetFields() {
 			assert.False(t, f.GetNullable())
 		}
 		err := NormalizeAndValidateExternalCollectionSchema(schema)
 		assert.NoError(t, err)
-		for _, f := range schema.GetFields() {
-			assert.True(t, f.GetNullable(), "field %s should be nullable", f.GetName())
-		}
+		assert.True(t, schema.GetFields()[0].GetNullable(), "scalar field should be nullable")
+		assert.False(t, schema.GetFields()[1].GetNullable(), "vector field should remain non-nullable")
 	})
 
 	t.Run("virtual pk stays non-nullable", func(t *testing.T) {
@@ -5397,9 +5396,12 @@ func TestNormalizeAndValidateExternalCollectionSchema(t *testing.T) {
 		err := NormalizeAndValidateExternalCollectionSchema(schema)
 		assert.NoError(t, err)
 		for _, f := range schema.GetFields() {
-			if f.GetName() == common.VirtualPKFieldName {
+			switch f.GetName() {
+			case common.VirtualPKFieldName:
 				assert.False(t, f.GetNullable(), "virtual PK should remain non-nullable")
-			} else {
+			case "vec":
+				assert.False(t, f.GetNullable(), "vector field should remain non-nullable")
+			default:
 				assert.True(t, f.GetNullable())
 			}
 		}


### PR DESCRIPTION
issue: #45881

## Summary

Optimize external table loading around source path resolution, manifest loading, and schema normalization.

- Normalize external explore and file-info paths against injected extfs properties before calling loon FFI, so AWS-form sources can use the derived storage endpoint correctly.
- Propagate Reopen cancellation into external manifest column-group loading.
- Keep external vector fields non-nullable until nullable vector offset mapping is fixed.

## Test plan

- `git diff --check HEAD~1..HEAD`
- Not run locally; C++/storage changes require rebuilding core.
