### PR TITLE
enhance: Validate external schema during sample

### DIFF
--- a/internal/core/src/common/FieldDataInterface.h
+++ b/internal/core/src/common/FieldDataInterface.h
@@ -592,6 +592,21 @@ class FieldDataStringImpl : public FieldDataImpl<std::string, true> {
     }
 
     void
+    FillFieldData(const std::shared_ptr<arrow::Array> array) override {
+        AssertInfo(
+            array->type()->id() == arrow::Type::type::STRING ||
+                array->type()->id() == arrow::Type::type::BINARY,
+            "inconsistent data type, expected: STRING or BINARY, got: {}",
+            array->type()->ToString());
+        if (array->type()->id() == arrow::Type::type::STRING) {
+            return FillFieldData(
+                std::dynamic_pointer_cast<arrow::StringArray>(array));
+        }
+        return FillFieldData(
+            std::dynamic_pointer_cast<arrow::BinaryArray>(array));
+    }
+
+    void
     FillFieldData(const std::shared_ptr<arrow::StringArray>& array) override {
         auto n = array->length();
         if (n == 0) {
@@ -599,6 +614,37 @@ class FieldDataStringImpl : public FieldDataImpl<std::string, true> {
         }
 
         std::lock_guard lck(tell_mutex_);
+        null_count_ += array->null_count();
+        if (length_ + n > get_num_rows()) {
+            resize_field_data(length_ + n);
+        }
+
+        for (int64_t i = 0; i < n; ++i) {
+            data_[length_ + i] = std::string(array->GetView(i));
+        }
+        if (IsNullable()) {
+            auto valid_data = array->null_bitmap_data();
+            if (valid_data != nullptr) {
+                bitset::detail::ElementWiseBitsetPolicy<uint8_t>::op_copy(
+                    valid_data,
+                    array->offset(),
+                    valid_data_.data(),
+                    length_,
+                    n);
+            }
+        }
+        length_ += n;
+    }
+
+    void
+    FillFieldData(const std::shared_ptr<arrow::BinaryArray>& array) override {
+        auto n = array->length();
+        if (n == 0) {
+            return;
+        }
+
+        std::lock_guard lck(tell_mutex_);
+        null_count_ += array->null_count();
         if (length_ + n > get_num_rows()) {
             resize_field_data(length_ + n);
         }

--- a/internal/core/src/segcore/external_utils_c.cpp
+++ b/internal/core/src/segcore/external_utils_c.cpp
@@ -21,14 +21,18 @@
 #include <functional>
 #include <numeric>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "arrow/array.h"
 #include "arrow/table.h"
+#include "common/FieldMeta.h"
+#include "fmt/format.h"
 #include "log/Log.h"
 #include "milvus-storage/column_groups.h"
 #include "milvus-storage/manifest.h"
 #include "milvus-storage/reader.h"
+#include "pb/schema.pb.h"
 #include "storage/Util.h"
 #include "storage/loon_ffi/util.h"
 
@@ -45,6 +49,7 @@ SampleExternalSegmentFieldSizes(const char* manifest_path,
                                 int sample_rows,
                                 int64_t collection_id,
                                 const LoonProperties* c_properties,
+                                CProto collection_schema,
                                 CFieldMemSizeList* out) {
     try {
         if (manifest_path == nullptr || manifest_path[0] == '\0') {
@@ -103,6 +108,25 @@ SampleExternalSegmentFieldSizes(const char* manifest_path,
             return MakeCStatusError("sample returned 0 rows");
         }
 
+        std::vector<milvus::FieldMeta> external_fields;
+        if (collection_schema.proto_blob != nullptr &&
+            collection_schema.proto_size > 0) {
+            milvus::proto::schema::CollectionSchema schema;
+            auto ok = schema.ParseFromArray(collection_schema.proto_blob,
+                                            collection_schema.proto_size);
+            if (!ok) {
+                return MakeCStatusError("failed to parse collection schema");
+            }
+            external_fields.reserve(schema.fields_size());
+            for (const auto& field_schema : schema.fields()) {
+                if (field_schema.external_field().empty()) {
+                    continue;
+                }
+                external_fields.emplace_back(
+                    milvus::FieldMeta::ParseFrom(field_schema));
+            }
+        }
+
         // 6. Calculate per-column Arrow buffer size (recursive for nested types)
         std::function<int64_t(const std::shared_ptr<arrow::ArrayData>&)>
             calcArrayDataSize =
@@ -119,36 +143,66 @@ SampleExternalSegmentFieldSizes(const char* manifest_path,
             return total;
         };
 
-        int num_cols = table->num_columns();
-        out->sizes = static_cast<CFieldMemSize*>(
-            malloc(sizeof(CFieldMemSize) * num_cols));
-        out->count = num_cols;
-
-        for (int i = 0; i < num_cols; i++) {
-            int64_t col_bytes = 0;
-            auto chunked = table->column(i);
-            for (int c = 0; c < chunked->num_chunks(); c++) {
-                // Single view-variant elimination via shared helper.
-                // (issue #49352: vortex schemaless emits view types whose
-                // buffer layout differs; canonicalize before sizing.)
-                auto chunk = milvus::storage::CanonicalizeArrowVariants(
-                    chunked->chunk(c));
-                col_bytes += calcArrayDataSize(chunk->data());
-            }
-
-            auto name = table->field(i)->name();
+        auto fill_size = [](CFieldMemSize& out_size,
+                            const std::string& name,
+                            int64_t avg_mem_bytes) {
             char* name_copy = static_cast<char*>(malloc(name.size() + 1));
             std::memcpy(name_copy, name.c_str(), name.size() + 1);
+            out_size.field_name = name_copy;
+            out_size.avg_mem_bytes = avg_mem_bytes;
+        };
 
-            out->sizes[i].field_name = name_copy;
-            out->sizes[i].avg_mem_bytes = col_bytes / num_rows;
+        std::vector<std::pair<std::string, int64_t>> sampled_sizes;
+        if (!external_fields.empty()) {
+            sampled_sizes.reserve(external_fields.size());
+            for (const auto& field_meta : external_fields) {
+                const auto& column_name = field_meta.get_external_field();
+                auto chunked = table->GetColumnByName(column_name);
+                if (chunked == nullptr) {
+                    return MakeCStatusError(
+                        fmt::format("Column '{}' not found in schema",
+                                    column_name)
+                            .c_str());
+                }
+
+                int64_t col_bytes = 0;
+                for (int c = 0; c < chunked->num_chunks(); c++) {
+                    auto chunk = milvus::storage::NormalizeExternalArrow(
+                        chunked->chunk(c), field_meta);
+                    col_bytes += calcArrayDataSize(chunk->data());
+                }
+                sampled_sizes.emplace_back(column_name, col_bytes / num_rows);
+            }
+        } else {
+            int num_cols = table->num_columns();
+            sampled_sizes.reserve(num_cols);
+            for (int i = 0; i < num_cols; i++) {
+                int64_t col_bytes = 0;
+                auto chunked = table->column(i);
+                for (int c = 0; c < chunked->num_chunks(); c++) {
+                    auto chunk = milvus::storage::CanonicalizeArrowVariants(
+                        chunked->chunk(c));
+                    col_bytes += calcArrayDataSize(chunk->data());
+                }
+
+                sampled_sizes.emplace_back(table->field(i)->name(),
+                                           col_bytes / num_rows);
+            }
+        }
+
+        out->sizes = static_cast<CFieldMemSize*>(
+            malloc(sizeof(CFieldMemSize) * sampled_sizes.size()));
+        out->count = static_cast<int>(sampled_sizes.size());
+        for (size_t i = 0; i < sampled_sizes.size(); i++) {
+            fill_size(
+                out->sizes[i], sampled_sizes[i].first, sampled_sizes[i].second);
         }
 
         LOG_INFO(
             "SampleExternalSegmentFieldSizes: sampled {} rows, {} "
             "columns from manifest {}",
             num_rows,
-            num_cols,
+            sampled_sizes.size(),
             manifest_path);
 
         CStatus ok;

--- a/internal/core/src/segcore/external_utils_c.h
+++ b/internal/core/src/segcore/external_utils_c.h
@@ -50,6 +50,7 @@ SampleExternalSegmentFieldSizes(const char* manifest_path,
                                 int sample_rows,
                                 int64_t collection_id,
                                 const LoonProperties* properties,
+                                CProto collection_schema,
                                 CFieldMemSizeList* out);
 
 void

--- a/internal/core/src/storage/DataCodecTest.cpp
+++ b/internal/core/src/storage/DataCodecTest.cpp
@@ -14,6 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <arrow/array.h>
+#include <arrow/builder.h>
 #include <folly/FBVector.h>
 #include <gtest/gtest.h>
 #include <simdjson.h>
@@ -33,6 +35,7 @@
 #include "common/EasyAssert.h"
 #include "common/FieldData.h"
 #include "common/FieldDataInterface.h"
+#include "common/FieldMeta.h"
 #include "common/Geometry.h"
 #include "common/Json.h"
 #include "common/TypeTraits.h"
@@ -56,6 +59,227 @@
 #include "test_utils/DataGen.h"
 
 using namespace milvus;
+
+TEST(storage, ExternalVarCharStringNormalizesToBinaryAndFillSucceeds) {
+    arrow::StringBuilder builder;
+    ASSERT_TRUE(builder.Append("hello").ok());
+    ASSERT_TRUE(builder.Append("world").ok());
+    std::shared_ptr<arrow::Array> string_array;
+    ASSERT_TRUE(builder.Finish(&string_array).ok());
+
+    auto normalized = storage::NormalizeExternalArrow(
+        string_array, DataType::VARCHAR, 0, false, DataType::NONE);
+    ASSERT_EQ(normalized->type_id(), arrow::Type::BINARY);
+
+    auto field_data = storage::CreateFieldData(storage::DataType::VARCHAR,
+                                               DataType::NONE,
+                                               false,
+                                               normalized->length());
+    auto chunked_array = std::make_shared<arrow::ChunkedArray>(normalized);
+    EXPECT_NO_THROW(field_data->FillFieldData(chunked_array));
+}
+
+TEST(storage, ExternalVarCharBinaryFillSucceeds) {
+    arrow::BinaryBuilder builder;
+    ASSERT_TRUE(builder.Append("hello").ok());
+    ASSERT_TRUE(builder.Append("world").ok());
+    std::shared_ptr<arrow::Array> binary_array;
+    ASSERT_TRUE(builder.Finish(&binary_array).ok());
+
+    auto normalized = storage::NormalizeExternalArrow(
+        binary_array, DataType::VARCHAR, 0, false, DataType::NONE);
+    ASSERT_EQ(normalized->type_id(), arrow::Type::BINARY);
+
+    auto field_data = storage::CreateFieldData(storage::DataType::VARCHAR,
+                                               DataType::NONE,
+                                               false,
+                                               normalized->length());
+    auto chunked_array = std::make_shared<arrow::ChunkedArray>(normalized);
+    EXPECT_NO_THROW(field_data->FillFieldData(chunked_array));
+}
+
+TEST(storage, ExternalVarCharInt64NormalizeFails) {
+    arrow::Int64Builder builder;
+    ASSERT_TRUE(builder.Append(1).ok());
+    ASSERT_TRUE(builder.Append(2).ok());
+    std::shared_ptr<arrow::Array> int64_array;
+    ASSERT_TRUE(builder.Finish(&int64_array).ok());
+
+    EXPECT_ANY_THROW(storage::NormalizeExternalArrow(
+        int64_array, DataType::VARCHAR, 0, false, DataType::NONE));
+}
+
+TEST(storage, ExternalInt8Int64NormalizeFails) {
+    arrow::Int64Builder builder;
+    ASSERT_TRUE(builder.Append(1).ok());
+    ASSERT_TRUE(builder.Append(2).ok());
+    std::shared_ptr<arrow::Array> int64_array;
+    ASSERT_TRUE(builder.Finish(&int64_array).ok());
+
+    EXPECT_ANY_THROW(storage::NormalizeExternalArrow(
+        int64_array, DataType::INT8, 0, false, DataType::NONE));
+}
+
+TEST(storage, ExternalSampleSchemaValidationRejectsMismatchedIntType) {
+    arrow::Int64Builder builder;
+    ASSERT_TRUE(builder.Append(1).ok());
+    ASSERT_TRUE(builder.Append(2).ok());
+    std::shared_ptr<arrow::Array> int64_array;
+    ASSERT_TRUE(builder.Finish(&int64_array).ok());
+
+    proto::schema::FieldSchema field_schema;
+    field_schema.set_fieldid(100);
+    field_schema.set_name("age");
+    field_schema.set_external_field("age_col");
+    field_schema.set_data_type(proto::schema::DataType::Int8);
+    auto field_meta = FieldMeta::ParseFrom(field_schema);
+
+    EXPECT_ANY_THROW(storage::NormalizeExternalArrow(int64_array, field_meta));
+}
+
+TEST(storage, ExternalVarCharLargeStringNormalizesAndFillSucceeds) {
+    arrow::LargeStringBuilder builder;
+    ASSERT_TRUE(builder.Append("hello").ok());
+    ASSERT_TRUE(builder.Append("world").ok());
+    std::shared_ptr<arrow::Array> large_string_array;
+    ASSERT_TRUE(builder.Finish(&large_string_array).ok());
+
+    auto normalized = storage::NormalizeExternalArrow(
+        large_string_array, DataType::VARCHAR, 0, false, DataType::NONE);
+    ASSERT_EQ(normalized->type_id(), arrow::Type::BINARY);
+
+    auto field_data = storage::CreateFieldData(storage::DataType::VARCHAR,
+                                               DataType::NONE,
+                                               false,
+                                               normalized->length());
+    auto chunked_array = std::make_shared<arrow::ChunkedArray>(normalized);
+    EXPECT_NO_THROW(field_data->FillFieldData(chunked_array));
+}
+
+TEST(storage, ExternalArrayListNormalizesToBinary) {
+    auto value_builder = std::make_shared<arrow::Int64Builder>();
+    arrow::ListBuilder builder(arrow::default_memory_pool(), value_builder);
+    auto& int_builder =
+        dynamic_cast<arrow::Int64Builder&>(*builder.value_builder());
+
+    ASSERT_TRUE(builder.Append().ok());
+    ASSERT_TRUE(int_builder.Append(1).ok());
+    ASSERT_TRUE(int_builder.Append(2).ok());
+    ASSERT_TRUE(builder.Append().ok());
+    ASSERT_TRUE(int_builder.Append(3).ok());
+
+    std::shared_ptr<arrow::Array> list_array;
+    ASSERT_TRUE(builder.Finish(&list_array).ok());
+
+    auto normalized = storage::NormalizeExternalArrow(
+        list_array, DataType::ARRAY, 0, false, DataType::INT64);
+    ASSERT_EQ(normalized->type_id(), arrow::Type::BINARY);
+}
+
+TEST(storage, ExternalFloatVectorListNormalizesToFixedSizeBinary) {
+    auto value_builder = std::make_shared<arrow::FloatBuilder>();
+    arrow::ListBuilder builder(arrow::default_memory_pool(), value_builder);
+    auto& float_builder =
+        dynamic_cast<arrow::FloatBuilder&>(*builder.value_builder());
+
+    ASSERT_TRUE(builder.Append().ok());
+    ASSERT_TRUE(float_builder.Append(1.0F).ok());
+    ASSERT_TRUE(float_builder.Append(2.0F).ok());
+    ASSERT_TRUE(builder.Append().ok());
+    ASSERT_TRUE(float_builder.Append(3.0F).ok());
+    ASSERT_TRUE(float_builder.Append(4.0F).ok());
+
+    std::shared_ptr<arrow::Array> list_array;
+    ASSERT_TRUE(builder.Finish(&list_array).ok());
+
+    auto normalized = storage::NormalizeExternalArrow(
+        list_array, DataType::VECTOR_FLOAT, 2, false, DataType::NONE);
+    ASSERT_EQ(normalized->type_id(), arrow::Type::FIXED_SIZE_BINARY);
+}
+
+TEST(storage, ExternalNullableFloatVectorBinaryIsAccepted) {
+    std::array<float, 2> row = {1.0F, 2.0F};
+    arrow::BinaryBuilder builder;
+    ASSERT_TRUE(builder
+                    .Append(reinterpret_cast<const uint8_t*>(row.data()),
+                            sizeof(float) * row.size())
+                    .ok());
+    std::shared_ptr<arrow::Array> binary_array;
+    ASSERT_TRUE(builder.Finish(&binary_array).ok());
+
+    auto normalized = storage::NormalizeExternalArrow(
+        binary_array, DataType::VECTOR_FLOAT, 2, true, DataType::NONE);
+    ASSERT_EQ(normalized->type_id(), arrow::Type::BINARY);
+}
+
+TEST(storage, ExternalBinaryVectorListNormalizeFails) {
+    auto value_builder = std::make_shared<arrow::UInt8Builder>();
+    arrow::ListBuilder builder(arrow::default_memory_pool(), value_builder);
+    auto& byte_builder =
+        dynamic_cast<arrow::UInt8Builder&>(*builder.value_builder());
+
+    ASSERT_TRUE(builder.Append().ok());
+    ASSERT_TRUE(byte_builder.Append(0).ok());
+    ASSERT_TRUE(byte_builder.Append(1).ok());
+
+    std::shared_ptr<arrow::Array> list_array;
+    ASSERT_TRUE(builder.Finish(&list_array).ok());
+
+    EXPECT_ANY_THROW(storage::NormalizeExternalArrow(
+        list_array, DataType::VECTOR_BINARY, 16, false, DataType::NONE));
+}
+
+TEST(storage, ExternalNullableVarCharBinaryPreservesNullCount) {
+    arrow::BinaryBuilder builder;
+    ASSERT_TRUE(builder.Append("hello").ok());
+    ASSERT_TRUE(builder.AppendNull().ok());
+    ASSERT_TRUE(builder.Append("world").ok());
+    std::shared_ptr<arrow::Array> binary_array;
+    ASSERT_TRUE(builder.Finish(&binary_array).ok());
+
+    auto normalized = storage::NormalizeExternalArrow(
+        binary_array, DataType::VARCHAR, 0, true, DataType::NONE);
+    ASSERT_EQ(normalized->type_id(), arrow::Type::BINARY);
+
+    auto field_data = storage::CreateFieldData(
+        storage::DataType::VARCHAR, DataType::NONE, true, normalized->length());
+    auto chunked_array = std::make_shared<arrow::ChunkedArray>(normalized);
+    ASSERT_NO_THROW(field_data->FillFieldData(chunked_array));
+    EXPECT_EQ(field_data->get_null_count(), 1);
+    EXPECT_EQ(field_data->get_valid_rows(), 2);
+    EXPECT_FALSE(field_data->is_valid(1));
+}
+
+TEST(storage, ExternalNullableVarCharBinaryAccumulatesNullCountAcrossChunks) {
+    arrow::BinaryBuilder first_builder;
+    ASSERT_TRUE(first_builder.Append("hello").ok());
+    ASSERT_TRUE(first_builder.AppendNull().ok());
+    std::shared_ptr<arrow::Array> first_array;
+    ASSERT_TRUE(first_builder.Finish(&first_array).ok());
+
+    arrow::BinaryBuilder second_builder;
+    ASSERT_TRUE(second_builder.AppendNull().ok());
+    ASSERT_TRUE(second_builder.Append("world").ok());
+    std::shared_ptr<arrow::Array> second_array;
+    ASSERT_TRUE(second_builder.Finish(&second_array).ok());
+
+    auto first_normalized = storage::NormalizeExternalArrow(
+        first_array, DataType::VARCHAR, 0, true, DataType::NONE);
+    auto second_normalized = storage::NormalizeExternalArrow(
+        second_array, DataType::VARCHAR, 0, true, DataType::NONE);
+    ASSERT_EQ(first_normalized->type_id(), arrow::Type::BINARY);
+    ASSERT_EQ(second_normalized->type_id(), arrow::Type::BINARY);
+
+    auto field_data = storage::CreateFieldData(
+        storage::DataType::VARCHAR, DataType::NONE, true, 4);
+    auto chunked_array = std::make_shared<arrow::ChunkedArray>(
+        arrow::ArrayVector{first_normalized, second_normalized});
+    ASSERT_NO_THROW(field_data->FillFieldData(chunked_array));
+    EXPECT_EQ(field_data->get_null_count(), 2);
+    EXPECT_EQ(field_data->get_valid_rows(), 2);
+    EXPECT_FALSE(field_data->is_valid(1));
+    EXPECT_FALSE(field_data->is_valid(2));
+}
 
 TEST(storage, InsertDataBool) {
     FixedVector<bool> data = {true, false, true, false, true};

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -14,7 +14,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <limits>
 #include <memory>
 
 #include "arrow/array/builder_binary.h"
@@ -2675,80 +2674,6 @@ NormalizeArrowForChunkWriter(const arrow::ArrayVector& arrays,
     return result;
 }
 
-// Narrow an arrow integer array to a smaller-width integer builder.
-// Required because some external sources (notably iceberg) only have
-// IntegerType / LongType and widen Int8/Int16 to Int32/Int64 on read.
-// Without explicit narrowing, downstream FillFieldData reinterpret_casts
-// the wider buffer as the narrower type and reads bytewise garbage.
-template <typename SrcArray, typename DstBuilder, typename DstT>
-static std::shared_ptr<arrow::Array>
-NarrowIntArray(const std::shared_ptr<arrow::Array>& src_arr,
-               const char* dst_name) {
-    auto src = std::static_pointer_cast<SrcArray>(src_arr);
-    DstBuilder builder;
-    auto status = builder.Reserve(src->length());
-    AssertInfo(status.ok(),
-               "NarrowIntArray reserve failed: " + status.ToString());
-    constexpr auto lo = std::numeric_limits<DstT>::min();
-    constexpr auto hi = std::numeric_limits<DstT>::max();
-    for (int64_t i = 0; i < src->length(); ++i) {
-        if (src->IsNull(i)) {
-            AssertInfo(builder.AppendNull().ok(), "AppendNull failed");
-            continue;
-        }
-        auto v = src->Value(i);
-        AssertInfo(v >= lo && v <= hi,
-                   "{} narrowing overflow: source value {} out of range "
-                   "[{}, {}]",
-                   dst_name,
-                   static_cast<int64_t>(v),
-                   static_cast<int64_t>(lo),
-                   static_cast<int64_t>(hi));
-        AssertInfo(builder.Append(static_cast<DstT>(v)).ok(),
-                   "Append narrowed int failed");
-    }
-    std::shared_ptr<arrow::Array> out;
-    AssertInfo(builder.Finish(&out).ok(), "NarrowIntArray finish failed");
-    return out;
-}
-
-// Dispatch wider-int arrow source to a narrower milvus int field by
-// matching (DataType, arrow::Type::type). Returns nullptr if no narrowing
-// applies; caller continues original dispatch.
-static std::shared_ptr<arrow::Array>
-MaybeNarrowInt(DataType data_type, const std::shared_ptr<arrow::Array>& array) {
-    auto type_id = array->type_id();
-    if (data_type == DataType::INT8) {
-        if (type_id == arrow::Type::INT16)
-            return NarrowIntArray<arrow::Int16Array,
-                                  arrow::Int8Builder,
-                                  int8_t>(array, "INT8");
-        if (type_id == arrow::Type::INT32)
-            return NarrowIntArray<arrow::Int32Array,
-                                  arrow::Int8Builder,
-                                  int8_t>(array, "INT8");
-        if (type_id == arrow::Type::INT64)
-            return NarrowIntArray<arrow::Int64Array,
-                                  arrow::Int8Builder,
-                                  int8_t>(array, "INT8");
-    }
-    if (data_type == DataType::INT16) {
-        if (type_id == arrow::Type::INT32)
-            return NarrowIntArray<arrow::Int32Array,
-                                  arrow::Int16Builder,
-                                  int16_t>(array, "INT16");
-        if (type_id == arrow::Type::INT64)
-            return NarrowIntArray<arrow::Int64Array,
-                                  arrow::Int16Builder,
-                                  int16_t>(array, "INT16");
-    }
-    if (data_type == DataType::INT32 && type_id == arrow::Type::INT64) {
-        return NarrowIntArray<arrow::Int64Array, arrow::Int32Builder, int32_t>(
-            array, "INT32");
-    }
-    return nullptr;
-}
-
 std::shared_ptr<arrow::DataType>
 ExpectedScalarArrowType(DataType data_type) {
     switch (data_type) {
@@ -2807,13 +2732,6 @@ NormalizeExternalArrow(const std::shared_ptr<arrow::Array>& array_in,
     // (recursive into list inner). Downstream branches only need to dispatch
     // on canonical type_ids.
     auto array = CanonicalizeArrowVariants(array_in);
-    // Integer narrowing: source readers (e.g. iceberg) may widen Int8/Int16
-    // to Int32/Int64 because their type system lacks narrow ints. Narrow
-    // explicitly so downstream FillFieldData reinterpret-cast doesn't read
-    // bytewise garbage.
-    if (auto narrowed = MaybeNarrowInt(data_type, array); narrowed != nullptr) {
-        array = narrowed;
-    }
     auto type_id = array->type_id();
 
     if (data_type == DataType::TIMESTAMPTZ) {

--- a/internal/core/unittest/test_arrow_canonicalize.cpp
+++ b/internal/core/unittest/test_arrow_canonicalize.cpp
@@ -268,10 +268,9 @@ TEST(CoerceToBinary, AllVariantsToBinary) {
     }
 }
 
-// ===== Integer narrowing (via NormalizeExternalArrow) =====
-// MaybeNarrowInt is exercised through NormalizeExternalArrow because the
-// helper itself is static. These tests build wider arrow ints and assert the
-// returned array is the narrower target type with values intact.
+// ===== Scalar numeric mismatch rejection (via NormalizeExternalArrow) =====
+// External Arrow numeric types must match the Milvus scalar type exactly.
+// Wider integer inputs are rejected instead of implicitly narrowed.
 
 #include "common/FieldMeta.h"
 
@@ -325,49 +324,41 @@ MakeDoubleArray(const std::vector<double>& vals,
 }
 }  // namespace
 
-TEST(IntegerNarrowing, Int32ToInt8) {
+TEST(ScalarNumericMismatch, Int32RejectsInt8) {
     auto in =
         MakeInt32Array({0, 1, 99, -128, 127}, {true, true, true, true, true});
-    auto out = milvus::storage::NormalizeExternalArrow(
-        in, milvus::DataType::INT8, 0, false, milvus::DataType::NONE);
-    ASSERT_EQ(out->type_id(), arrow::Type::INT8);
-    auto ia = std::static_pointer_cast<arrow::Int8Array>(out);
-    EXPECT_EQ(ia->Value(0), 0);
-    EXPECT_EQ(ia->Value(1), 1);
-    EXPECT_EQ(ia->Value(2), 99);
-    EXPECT_EQ(ia->Value(3), -128);
-    EXPECT_EQ(ia->Value(4), 127);
-}
-
-TEST(IntegerNarrowing, Int32ToInt16) {
-    auto in =
-        MakeInt32Array({0, 1000, -32768, 32767}, {true, true, true, true});
-    auto out = milvus::storage::NormalizeExternalArrow(
-        in, milvus::DataType::INT16, 0, false, milvus::DataType::NONE);
-    ASSERT_EQ(out->type_id(), arrow::Type::INT16);
-    auto ia = std::static_pointer_cast<arrow::Int16Array>(out);
-    EXPECT_EQ(ia->Value(2), -32768);
-    EXPECT_EQ(ia->Value(3), 32767);
-}
-
-TEST(IntegerNarrowing, Int32ToInt8WithNulls) {
-    auto in = MakeInt32Array({5, 0, 7}, {true, false, true});
-    auto out = milvus::storage::NormalizeExternalArrow(
-        in, milvus::DataType::INT8, 0, true, milvus::DataType::NONE);
-    ASSERT_EQ(out->type_id(), arrow::Type::INT8);
-    EXPECT_EQ(out->null_count(), 1);
-    EXPECT_TRUE(out->IsNull(1));
-}
-
-TEST(IntegerNarrowing, OverflowAsserts) {
-    auto in = MakeInt32Array({999}, {true});  // > INT8_MAX
     EXPECT_THROW(
         milvus::storage::NormalizeExternalArrow(
             in, milvus::DataType::INT8, 0, false, milvus::DataType::NONE),
         std::exception);
 }
 
-TEST(IntegerNarrowing, NoNarrowOnExactMatch) {
+TEST(ScalarNumericMismatch, Int32RejectsInt16) {
+    auto in =
+        MakeInt32Array({0, 1000, -32768, 32767}, {true, true, true, true});
+    EXPECT_THROW(
+        milvus::storage::NormalizeExternalArrow(
+            in, milvus::DataType::INT16, 0, false, milvus::DataType::NONE),
+        std::exception);
+}
+
+TEST(ScalarNumericMismatch, Int32RejectsInt8WithNulls) {
+    auto in = MakeInt32Array({5, 0, 7}, {true, false, true});
+    EXPECT_THROW(
+        milvus::storage::NormalizeExternalArrow(
+            in, milvus::DataType::INT8, 0, true, milvus::DataType::NONE),
+        std::exception);
+}
+
+TEST(ScalarNumericMismatch, Int32RejectsInt8EvenWhenInRange) {
+    auto in = MakeInt32Array({5}, {true});
+    EXPECT_THROW(
+        milvus::storage::NormalizeExternalArrow(
+            in, milvus::DataType::INT8, 0, false, milvus::DataType::NONE),
+        std::exception);
+}
+
+TEST(ScalarNumericMismatch, ExactMatchPassesThrough) {
     arrow::Int8Builder b;
     ASSERT_TRUE(b.Append(int8_t{5}).ok());
     std::shared_ptr<arrow::Array> in;

--- a/internal/core/unittest/test_external_take.cpp
+++ b/internal/core/unittest/test_external_take.cpp
@@ -1932,10 +1932,8 @@ TEST(NormalizeExternalArrow, VarcharFillFieldDataSucceedsWithString) {
     EXPECT_EQ(field_data->get_num_rows(), 3);
 }
 
-// FillFieldData for VARCHAR crashes with arrow::BINARY input (after normalize).
-// This is the exact bug scenario: internal binlog VARCHAR (STRING) gets
-// normalized to BINARY, then FillFieldData asserts STRING → crash.
-TEST(NormalizeExternalArrow, VarcharFillFieldDataFailsWithBinary) {
+// FillFieldData for VARCHAR accepts arrow::BINARY input after normalize.
+TEST(NormalizeExternalArrow, VarcharFillFieldDataSucceedsWithBinary) {
     auto str_array = MakeStringArray({"hello", "world"});
 
     // Simulate what NormalizeExternalArrow does: STRING → BINARY
@@ -1949,8 +1947,8 @@ TEST(NormalizeExternalArrow, VarcharFillFieldDataFailsWithBinary) {
 
     // Use base class pointer to avoid overload ambiguity.
     milvus::FieldDataBase* base = field_data.get();
-    // This must fail because FillFieldData asserts arrow::STRING for VARCHAR.
-    EXPECT_THROW(base->FillFieldData(chunked), std::exception);
+    EXPECT_NO_THROW(base->FillFieldData(chunked));
+    EXPECT_EQ(field_data->get_num_rows(), 2);
 }
 
 // JSON STRING passes through NormalizeExternalArrow → BINARY (expected).

--- a/internal/datanode/external/task_update.go
+++ b/internal/datanode/external/task_update.go
@@ -602,6 +602,7 @@ func (t *RefreshExternalCollectionTask) balanceFragmentsToSegments(ctx context.C
 			t.req.GetCollectionID(),
 			t.req.GetExternalSource(),
 			t.req.GetExternalSpec(),
+			t.req.GetSchema(),
 			t.req.GetStorageConfig(),
 		)
 		if err != nil {

--- a/internal/datanode/external/task_update_test.go
+++ b/internal/datanode/external/task_update_test.go
@@ -1179,6 +1179,56 @@ func (s *RefreshExternalCollectionTaskSuite) TestBalanceFragmentsToSegments_Samp
 	s.Contains(err.Error(), "external_field mappings")
 }
 
+func (s *RefreshExternalCollectionTaskSuite) TestBalanceFragmentsToSegments_SamplingTypeMismatchFails() {
+	paramtable.Init()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req := &datapb.RefreshExternalCollectionTaskRequest{
+		CollectionID:           s.collectionID,
+		TaskID:                 s.taskID,
+		PreAllocatedSegmentIds: &datapb.IDRange{Begin: 100, End: 200},
+		StorageConfig:          &indexpb.StorageConfig{StorageType: "local"},
+		ExternalSource:         "s3://bucket/data/",
+		ExternalSpec:           `{"format":"parquet"}`,
+		Schema: &schemapb.CollectionSchema{
+			Fields: []*schemapb.FieldSchema{
+				{
+					FieldID:       100,
+					Name:          "age",
+					DataType:      schemapb.DataType_Int8,
+					ExternalField: "age_col",
+				},
+			},
+		},
+	}
+
+	task := NewRefreshExternalCollectionTask(ctx, req)
+	task.preallocatedIDRange = req.GetPreAllocatedSegmentIds()
+	task.nextAllocID = task.preallocatedIDRange.Begin
+	task.parsedSpec = &externalspec.ExternalSpec{Format: "parquet"}
+
+	m1 := mockey.Mock(packed.CreateSegmentManifestWithBasePath).
+		To(func(ctx context.Context, basePath, format string, columns []string, fragments []packed.Fragment, storageConfig *indexpb.StorageConfig) (string, error) {
+			return fmt.Sprintf("%s/manifest.json", basePath), nil
+		}).Build()
+	defer m1.UnPatch()
+
+	typeMismatchErr := fmt.Errorf("field type mismatch, expected Arrow int8, actual Arrow int64")
+	m2 := mockey.Mock(packed.SampleExternalFieldSizes).Return(nil, typeMismatchErr).Build()
+	defer m2.UnPatch()
+
+	fragments := []packed.Fragment{{FragmentID: 1, RowCount: 500}}
+
+	result, err := task.balanceFragmentsToSegments(context.Background(), fragments)
+	s.Error(err)
+	s.Nil(result)
+	s.Contains(err.Error(), "sampling failed")
+	s.Contains(err.Error(), "field type mismatch")
+	s.Contains(err.Error(), "expected Arrow int8")
+	s.Contains(err.Error(), "actual Arrow int64")
+}
+
 // Regression: the samplePerSegment=true branch of Phase 3 was previously
 // uncovered by tests. This exercise is three parts:
 //  1. All per-segment samples succeed → each segment gets its own
@@ -1226,7 +1276,7 @@ func (s *RefreshExternalCollectionTaskSuite) TestBalanceFragmentsToSegments_PerS
 	var callCount int32
 	perCallSizes := []int64{50, 100, 200}
 	m2 := mockey.Mock(packed.SampleExternalFieldSizes).
-		To(func(manifestPath string, rows int, collectionID int64, externalSource, externalSpec string, storageConfig *indexpb.StorageConfig) (map[string]int64, error) {
+		To(func(manifestPath string, rows int, collectionID int64, externalSource, externalSpec string, schema *schemapb.CollectionSchema, storageConfig *indexpb.StorageConfig) (map[string]int64, error) {
 			idx := int(atomic.AddInt32(&callCount, 1)) - 1
 			if idx >= len(perCallSizes) {
 				idx = len(perCallSizes) - 1
@@ -1295,7 +1345,7 @@ func (s *RefreshExternalCollectionTaskSuite) TestBalanceFragmentsToSegments_PerS
 	// not the third (250), since fallbackAvg latches on the first success.
 	var callCount int32
 	m2 := mockey.Mock(packed.SampleExternalFieldSizes).
-		To(func(manifestPath string, rows int, collectionID int64, externalSource, externalSpec string, storageConfig *indexpb.StorageConfig) (map[string]int64, error) {
+		To(func(manifestPath string, rows int, collectionID int64, externalSource, externalSpec string, schema *schemapb.CollectionSchema, storageConfig *indexpb.StorageConfig) (map[string]int64, error) {
 			idx := int(atomic.AddInt32(&callCount, 1)) - 1
 			switch idx {
 			case 0:
@@ -1669,8 +1719,10 @@ func (s *RefreshExternalCollectionTaskSuite) TestBalanceFragmentsToSegments_Pass
 
 	var capturedStorageConfig *indexpb.StorageConfig
 	var capturedExternalSpec string
+	var capturedSchema *schemapb.CollectionSchema
 	m2 := mockey.Mock(packed.SampleExternalFieldSizes).
-		To(func(manifestPath string, rows int, collectionID int64, externalSource, externalSpec string, storageConfig *indexpb.StorageConfig) (map[string]int64, error) {
+		To(func(manifestPath string, rows int, collectionID int64, externalSource, externalSpec string, schema *schemapb.CollectionSchema, storageConfig *indexpb.StorageConfig) (map[string]int64, error) {
+			capturedSchema = schema
 			capturedStorageConfig = storageConfig
 			capturedExternalSpec = externalSpec
 			return map[string]int64{"vec_col": 3072}, nil
@@ -1690,6 +1742,7 @@ func (s *RefreshExternalCollectionTaskSuite) TestBalanceFragmentsToSegments_Pass
 	s.Equal(expectedStorageConfig.GetAddress(), capturedStorageConfig.GetAddress())
 	s.Equal(expectedStorageConfig.GetBucketName(), capturedStorageConfig.GetBucketName())
 	s.Equal(expectedStorageConfig.GetStorageType(), capturedStorageConfig.GetStorageType())
+	s.Equal(req.GetSchema(), capturedSchema, "schema must be passed to SampleExternalFieldSizes")
 
 	// Verify raw externalSpec JSON is forwarded so C++ InjectExternalSpecProperties
 	// can derive extfs.* overrides.
@@ -1732,7 +1785,7 @@ func (s *RefreshExternalCollectionTaskSuite) TestBalanceFragmentsToSegments_NilS
 	var capturedStorageConfig *indexpb.StorageConfig
 	var capturedExternalSpec string
 	m2 := mockey.Mock(packed.SampleExternalFieldSizes).
-		To(func(manifestPath string, rows int, collectionID int64, externalSource, externalSpec string, storageConfig *indexpb.StorageConfig) (map[string]int64, error) {
+		To(func(manifestPath string, rows int, collectionID int64, externalSource, externalSpec string, schema *schemapb.CollectionSchema, storageConfig *indexpb.StorageConfig) (map[string]int64, error) {
 			capturedStorageConfig = storageConfig
 			capturedExternalSpec = externalSpec
 			return map[string]int64{"text_col": 64}, nil

--- a/internal/storagev2/packed/exttable_test.go
+++ b/internal/storagev2/packed/exttable_test.go
@@ -554,6 +554,7 @@ func TestSampleExternalFieldSizes_NilStorageConfig(t *testing.T) {
 		`{"base_path":"/tmp","ver":1}`, 100, 42,
 		"s3://bucket/data/", `{"format":"parquet"}`,
 		nil,
+		nil,
 	)
 	assert.Nil(t, result)
 	assert.Error(t, err)
@@ -569,6 +570,7 @@ func TestSampleExternalFieldSizes_EmptyManifestPath(t *testing.T) {
 	result, err := SampleExternalFieldSizes(
 		"", 100, 42,
 		"", "",
+		nil,
 		config,
 	)
 	assert.Nil(t, result)
@@ -586,6 +588,7 @@ func TestSampleExternalFieldSizes_InvalidManifestPath(t *testing.T) {
 	result, err := SampleExternalFieldSizes(
 		`{"base_path":"/nonexistent/path","ver":1}`, 100, 42,
 		"", "",
+		nil,
 		config,
 	)
 	assert.Nil(t, result)
@@ -604,6 +607,7 @@ func TestSampleExternalFieldSizes_WithSpec(t *testing.T) {
 		`{"base_path":"/nonexistent","ver":1}`, 100, 42,
 		"s3://s3.us-west-2.amazonaws.com/ext-bucket/data/",
 		`{"format":"parquet","extfs":{"region":"us-west-2","use_ssl":"true"}}`,
+		nil,
 		config,
 	)
 	assert.Nil(t, result)

--- a/internal/storagev2/packed/ffi_sample.go
+++ b/internal/storagev2/packed/ffi_sample.go
@@ -26,8 +26,12 @@ import "C"
 
 import (
 	"fmt"
+	"runtime"
 	"unsafe"
 
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
 )
 
@@ -44,6 +48,7 @@ func SampleExternalFieldSizes(
 	collectionID int64,
 	externalSource string,
 	externalSpec string,
+	schema *schemapb.CollectionSchema,
 	storageConfig *indexpb.StorageConfig,
 ) (map[string]int64, error) {
 	if storageConfig == nil {
@@ -65,11 +70,26 @@ func SampleExternalFieldSizes(
 	cManifestPath := C.CString(manifestPath)
 	defer C.free(unsafe.Pointer(cManifestPath))
 
+	var cSchema C.CProto
+	var schemaBytes []byte
+	if schema != nil {
+		schemaBytes, err = proto.Marshal(schema)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal collection schema: %w", err)
+		}
+		if len(schemaBytes) > 0 {
+			cSchema.proto_blob = unsafe.Pointer(&schemaBytes[0])
+			cSchema.proto_size = C.int64_t(len(schemaBytes))
+		}
+	}
+
 	var result C.CFieldMemSizeList
 	status := C.SampleExternalSegmentFieldSizes(
 		cManifestPath, C.int(sampleRows),
 		C.int64_t(collectionID), cProperties,
+		cSchema,
 		&result)
+	runtime.KeepAlive(schemaBytes)
 	defer C.FreeCFieldMemSizeList(&result)
 
 	if err := ConsumeCStatusIntoError(&status); err != nil {

--- a/tests/go_client/testcases/external_table_iceberg_e2e_test.go
+++ b/tests/go_client/testcases/external_table_iceberg_e2e_test.go
@@ -89,10 +89,11 @@ func TestExternalTableIcebergE2E(t *testing.T) {
 		Format:     "iceberg-table",
 		SnapshotID: tableInfo.SnapshotID,
 		Extfs: map[string]string{
+			"bucket_name":      bucket,
 			"region":           "us-east-1",
 			"use_ssl":          "false",
 			"use_virtual_host": "false",
-			"cloud_provider":   "aws",
+			"cloud_provider":   "minio",
 			"access_key_id":    minioAccessKey,
 			"access_key_value": minioSecretKey,
 		},
@@ -138,6 +139,7 @@ func TestExternalTableIcebergE2E(t *testing.T) {
 	refreshStart := time.Now()
 	refreshResult, err := mc.RefreshExternalCollection(ctx,
 		client.NewRefreshExternalCollectionOption(collName).
+			WithExternalSource(externalSource).
 			WithExternalSpec(externalSpec))
 	common.CheckErr(t, err, true)
 	jobID := refreshResult.JobID
@@ -208,6 +210,103 @@ refreshDone:
 	t.Logf("[Phase 5] Query returned %d rows", queryResult.GetColumn("pk").Len())
 
 	t.Log("=== Iceberg E2E Test PASSED ===")
+}
+
+// TestExternalTableIcebergRefreshFailsOnSchemaTypeMismatch verifies that
+// RefreshExternalCollection fails during sample when the collection schema
+// declares a different type from the external Arrow column type.
+func TestExternalTableIcebergRefreshFailsOnSchemaTypeMismatch(t *testing.T) {
+	if err := checkPythonDeps("python3", "pyarrow", "pyiceberg"); err != nil {
+		t.Skipf("Python deps for Iceberg unavailable, skipping: %v", err)
+	}
+
+	minioAddr := envOrDefault("MINIO_ADDRESS", "localhost:9000")
+	minioEndpoint := icebergEnvOrDefault("ICEBERG_MINIO_ENDPOINT", "http://"+minioAddr)
+	minioAccessKey := icebergEnvOrDefault("ICEBERG_MINIO_ACCESS_KEY", "minioadmin")
+	minioSecretKey := icebergEnvOrDefault("ICEBERG_MINIO_SECRET_KEY", "minioadmin")
+	bucket := icebergEnvOrDefault("ICEBERG_MINIO_BUCKET", "a-bucket")
+	collName := common.GenRandomString("iceberg_schema_mismatch", 6)
+	tablePath := fmt.Sprintf("iceberg-test/%s", collName)
+
+	tableInfo := createIcebergTestTable(
+		t, minioEndpoint, minioAccessKey, minioSecretKey,
+		bucket, tablePath, "16", "4")
+
+	minioHost := strings.TrimPrefix(strings.TrimPrefix(minioEndpoint, "http://"), "https://")
+	externalSource := toMilvusURI(tableInfo.MetadataLocation, minioHost)
+
+	type externalSpecJSON struct {
+		Format     string            `json:"format"`
+		SnapshotID int64             `json:"snapshot_id,string"`
+		Extfs      map[string]string `json:"extfs,omitempty"`
+	}
+	specObj := externalSpecJSON{
+		Format:     "iceberg-table",
+		SnapshotID: tableInfo.SnapshotID,
+		Extfs: map[string]string{
+			"bucket_name":      bucket,
+			"region":           "us-east-1",
+			"use_ssl":          "false",
+			"use_virtual_host": "false",
+			"cloud_provider":   "minio",
+			"access_key_id":    minioAccessKey,
+			"access_key_value": minioSecretKey,
+		},
+	}
+	specBytes, err := json.Marshal(specObj)
+	require.NoError(t, err)
+	externalSpec := string(specBytes)
+
+	ctx := hp.CreateContext(t, 10*time.Minute)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+	t.Cleanup(func() {
+		_ = mc.DropCollection(context.Background(), client.NewDropCollectionOption(collName))
+	})
+
+	schema := entity.NewSchema().
+		WithName(collName).
+		WithExternalSource(externalSource).
+		WithExternalSpec(externalSpec).
+		WithField(entity.NewField().WithName("pk").WithDataType(entity.FieldTypeInt64).WithExternalField("pk")).
+		// The external Iceberg column "label" is a string, but the Milvus
+		// schema intentionally declares it as Int64. Refresh should fail
+		// while sampling field sizes, before load/search.
+		WithField(entity.NewField().WithName("label_as_int").WithDataType(entity.FieldTypeInt64).WithExternalField("label")).
+		WithField(entity.NewField().WithName("vector").WithDataType(entity.FieldTypeFloatVector).WithDim(int64(tableInfo.Dim)).WithExternalField("vector"))
+
+	err = mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, true)
+
+	refreshResult, err := mc.RefreshExternalCollection(ctx,
+		client.NewRefreshExternalCollectionOption(collName).
+			WithExternalSource(externalSource).
+			WithExternalSpec(externalSpec))
+	common.CheckErr(t, err, true)
+
+	deadline := time.After(5 * time.Minute)
+	ticker := time.NewTicker(3 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-deadline:
+			t.Fatalf("refresh did not fail on schema type mismatch before timeout")
+		case <-ticker.C:
+			progress, err := mc.GetRefreshExternalCollectionProgress(ctx,
+				client.NewGetRefreshExternalCollectionProgressOption(refreshResult.JobID))
+			require.NoError(t, err)
+			t.Logf("schema mismatch refresh job %d: state=%s reason=%s",
+				refreshResult.JobID, progress.State, progress.Reason)
+			switch progress.State {
+			case entity.RefreshStateCompleted:
+				t.Fatalf("refresh unexpectedly completed despite label string -> Int64 schema mismatch")
+			case entity.RefreshStateFailed:
+				require.Contains(t, progress.Reason, "field type mismatch")
+				require.Contains(t, progress.Reason, "expected Arrow int64")
+				require.Contains(t, progress.Reason, "actual Arrow string")
+				return
+			}
+		}
+	}
 }
 
 // createIcebergTestTable runs the Python script to create an Iceberg table on MinIO.


### PR DESCRIPTION
issue: #45691

This PR validates external table Arrow field types while sampling field sizes so schema mismatches fail before refresh planning continues.

It passes the collection schema through the sample FFI path, normalizes supported Arrow variants against FieldMeta, and removes implicit integer narrowing for external Arrow input.

Tests:
- make milvus
- /tmp/external.test -test.run TestRefreshExternalCollectionTaskSuite/TestBalanceFragmentsToSegments_SamplingTypeMismatchFails -test.v -test.count=1
- go test -tags dynamic,test github.com/milvus-io/milvus/tests/go_client/testcases -run TestExternalTableIcebergRefreshFailsOnSchemaTypeMismatch -v -count=1