### PR TITLE
fix: Set MinIO CA cert default to empty

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -114,7 +114,7 @@ minio:
   secretAccessKey: minioadmin
   useSSL: false # Switch value to control if to access the MinIO or S3 service through SSL.
   ssl:
-    tlsCACert: /path/to/public.crt # path to your CACert file
+    tlsCACert:  # path to your CACert file
     # TLS minimum version for MinIO/S3 SSL connections.
     # Optional values: "default", "1.0", "1.1", "1.2", "1.3".
     # When set to "default", the SDK/runtime default is used (typically TLS 1.2).

--- a/pkg/util/paramtable/service_param.go
+++ b/pkg/util/paramtable/service_param.go
@@ -1558,10 +1558,11 @@ The default value applies to MinIO or S3 service that started with the default d
 	p.UseSSL.Init(base.mgr)
 
 	p.SslCACert = ParamItem{
-		Key:     "minio.ssl.tlsCACert",
-		Version: "2.3.12",
-		Doc:     "path to your CACert file",
-		Export:  true,
+		Key:          "minio.ssl.tlsCACert",
+		Version:      "2.3.12",
+		DefaultValue: "",
+		Doc:          "path to your CACert file",
+		Export:       true,
 	}
 	p.SslCACert.Init(base.mgr)
 

--- a/pkg/util/paramtable/service_param_test.go
+++ b/pkg/util/paramtable/service_param_test.go
@@ -366,7 +366,7 @@ func TestServiceParam(t *testing.T) {
 
 		assert.Equal(t, Params.UseSSL.GetAsBool(), false)
 
-		assert.NotEmpty(t, Params.SslCACert.GetValue())
+		assert.Empty(t, Params.SslCACert.GetValue())
 
 		assert.Equal(t, Params.UseIAM.GetAsBool(), false)
 


### PR DESCRIPTION
issue: #49437

Make minio.ssl.tlsCACert default to an empty value instead of the placeholder /path/to/public.crt. This way Milvus will not set SSL_CERT_FILE by default, and the process env only gets touched when the user actually configures a custom CA file. The generated milvus.yaml and the related paramtable test are updated to match the new default.