### PR TITLE
fix: convert element filter bitset for row vector search

### DIFF
--- a/internal/core/src/common/ArrayOffsets.cpp
+++ b/internal/core/src/common/ArrayOffsets.cpp
@@ -94,6 +94,50 @@ ArrayOffsetsSealed::RowBitsetToElementBitset(
     return {std::move(element_bitset), std::move(valid_element_bitset)};
 }
 
+std::pair<TargetBitmap, TargetBitmap>
+ArrayOffsetsSealed::ElementBitsetToRowBitset(
+    const TargetBitmapView& element_bitset,
+    const TargetBitmapView& valid_element_bitset,
+    int64_t row_start,
+    int64_t row_count) const {
+    AssertInfo(row_start >= 0 && row_start + row_count <= GetRowCount(),
+               "row range out of bounds: row_start={}, row_count={}, "
+               "total_rows={}",
+               row_start,
+               row_count,
+               GetRowCount());
+
+    int64_t element_start = row_to_element_start_[row_start];
+    int64_t element_end = row_to_element_start_[row_start + row_count];
+    int64_t element_count = element_end - element_start;
+    AssertInfo(element_bitset.size() == element_count,
+               "element bitset size mismatch: {} vs {}",
+               element_bitset.size(),
+               element_count);
+    AssertInfo(valid_element_bitset.size() == element_count,
+               "valid element bitset size mismatch: {} vs {}",
+               valid_element_bitset.size(),
+               element_count);
+
+    TargetBitmap row_bitset(row_count);
+    TargetBitmap valid_row_bitset(row_count, true);
+    for (int64_t i = 0; i < row_count; ++i) {
+        int64_t row_id = row_start + i;
+        int64_t start = row_to_element_start_[row_id] - element_start;
+        int64_t end = row_to_element_start_[row_id + 1] - element_start;
+        bool has_unfiltered_element = false;
+        for (int64_t elem_id = start; elem_id < end; ++elem_id) {
+            if (valid_element_bitset[elem_id] && !element_bitset[elem_id]) {
+                has_unfiltered_element = true;
+                break;
+            }
+        }
+        row_bitset[i] = !has_unfiltered_element;
+    }
+
+    return {std::move(row_bitset), std::move(valid_row_bitset)};
+}
+
 FixedVector<int32_t>
 ArrayOffsetsSealed::RowBitsetToElementOffsets(
     const TargetBitmapView& row_bitset, int64_t row_start) const {
@@ -329,6 +373,52 @@ ArrayOffsetsGrowing::RowBitsetToElementBitset(
     }
 
     return {std::move(element_bitset), std::move(valid_element_bitset)};
+}
+
+std::pair<TargetBitmap, TargetBitmap>
+ArrayOffsetsGrowing::ElementBitsetToRowBitset(
+    const TargetBitmapView& element_bitset,
+    const TargetBitmapView& valid_element_bitset,
+    int64_t row_start,
+    int64_t row_count) const {
+    std::shared_lock lock(mutex_);
+
+    AssertInfo(row_start >= 0 && row_start + row_count <= committed_row_count_,
+               "row range out of bounds: row_start={}, row_count={}, "
+               "committed_rows={}",
+               row_start,
+               row_count,
+               committed_row_count_);
+
+    int64_t element_start = row_to_element_start_[row_start];
+    int64_t element_end = row_to_element_start_[row_start + row_count];
+    int64_t element_count = element_end - element_start;
+    AssertInfo(element_bitset.size() == element_count,
+               "element bitset size mismatch: {} vs {}",
+               element_bitset.size(),
+               element_count);
+    AssertInfo(valid_element_bitset.size() == element_count,
+               "valid element bitset size mismatch: {} vs {}",
+               valid_element_bitset.size(),
+               element_count);
+
+    TargetBitmap row_bitset(row_count);
+    TargetBitmap valid_row_bitset(row_count, true);
+    for (int64_t i = 0; i < row_count; ++i) {
+        int64_t row_id = row_start + i;
+        int64_t start = row_to_element_start_[row_id] - element_start;
+        int64_t end = row_to_element_start_[row_id + 1] - element_start;
+        bool has_unfiltered_element = false;
+        for (int64_t elem_id = start; elem_id < end; ++elem_id) {
+            if (valid_element_bitset[elem_id] && !element_bitset[elem_id]) {
+                has_unfiltered_element = true;
+                break;
+            }
+        }
+        row_bitset[i] = !has_unfiltered_element;
+    }
+
+    return {std::move(row_bitset), std::move(valid_row_bitset)};
 }
 
 FixedVector<int32_t>

--- a/internal/core/src/common/ArrayOffsets.h
+++ b/internal/core/src/common/ArrayOffsets.h
@@ -61,6 +61,15 @@ class IArrayOffsets {
                              const TargetBitmapView& valid_row_bitset,
                              int64_t row_start) const = 0;
 
+    // Convert element-level filter bitsets to row-level filter bitsets.
+    // Both input and output use Milvus search bitset convention:
+    // true means filtered out, false means visible.
+    virtual std::pair<TargetBitmap, TargetBitmap>
+    ElementBitsetToRowBitset(const TargetBitmapView& element_bitset,
+                             const TargetBitmapView& valid_element_bitset,
+                             int64_t row_start,
+                             int64_t row_count) const = 0;
+
     // Convert row-level bitset to element offsets
     // Returns element IDs for all rows where row_bitset[row_id] is true
     virtual FixedVector<int32_t>
@@ -126,6 +135,12 @@ class ArrayOffsetsSealed : public IArrayOffsets {
                              const TargetBitmapView& valid_row_bitset,
                              int64_t row_start) const override;
 
+    std::pair<TargetBitmap, TargetBitmap>
+    ElementBitsetToRowBitset(const TargetBitmapView& element_bitset,
+                             const TargetBitmapView& valid_element_bitset,
+                             int64_t row_start,
+                             int64_t row_count) const override;
+
     FixedVector<int32_t>
     RowBitsetToElementOffsets(const TargetBitmapView& row_bitset,
                               int64_t row_start) const override;
@@ -176,6 +191,12 @@ class ArrayOffsetsGrowing : public IArrayOffsets {
     RowBitsetToElementBitset(const TargetBitmapView& row_bitset,
                              const TargetBitmapView& valid_row_bitset,
                              int64_t row_start) const override;
+
+    std::pair<TargetBitmap, TargetBitmap>
+    ElementBitsetToRowBitset(const TargetBitmapView& element_bitset,
+                             const TargetBitmapView& valid_element_bitset,
+                             int64_t row_start,
+                             int64_t row_count) const override;
 
     FixedVector<int32_t>
     RowBitsetToElementOffsets(const TargetBitmapView& row_bitset,

--- a/internal/core/src/common/ArrayOffsetsTest.cpp
+++ b/internal/core/src/common/ArrayOffsetsTest.cpp
@@ -132,6 +132,42 @@ TEST_F(ArrayOffsetsTest, SealedRowBitsetToElementBitset) {
     EXPECT_TRUE(elem_bitset[5]);
 }
 
+TEST_F(ArrayOffsetsTest, SealedElementBitsetToRowBitset) {
+    // row 0: elem 0
+    // row 1: elem 1,2
+    // row 2: elem 3,4
+    // row 3: empty
+    // row 4: elem 5
+    ArrayOffsetsSealed offsets({0, 1, 3, 5, 5, 6});
+
+    // Search bitset convention: true means filtered out.
+    TargetBitmap element_bitset(6);
+    element_bitset[0] = false;  // row 0 has a matching element
+    element_bitset[1] = true;
+    element_bitset[2] = false;  // row 1 has one matching element
+    element_bitset[3] = true;
+    element_bitset[4] = true;   // row 2 has no matching element
+    element_bitset[5] = false;  // invalid element should not keep row 4
+
+    TargetBitmap valid_element_bitset(6, true);
+    valid_element_bitset[5] = false;
+
+    TargetBitmapView element_view(element_bitset.data(), element_bitset.size());
+    TargetBitmapView valid_view(valid_element_bitset.data(),
+                                valid_element_bitset.size());
+
+    auto [row_bitset, valid_row_bitset] =
+        offsets.ElementBitsetToRowBitset(element_view, valid_view, 0, 5);
+
+    EXPECT_EQ(row_bitset.size(), 5);
+    EXPECT_FALSE(row_bitset[0]);
+    EXPECT_FALSE(row_bitset[1]);
+    EXPECT_TRUE(row_bitset[2]);
+    EXPECT_TRUE(row_bitset[3]);
+    EXPECT_TRUE(row_bitset[4]);
+    EXPECT_TRUE(valid_row_bitset.all());
+}
+
 TEST_F(ArrayOffsetsTest, SealedEmptyArrays) {
     // Test with some rows having empty arrays
     // row 0: 2 elements, row 1: 0 elements, row 2: 3 elements, row 3: 0 elements
@@ -322,6 +358,39 @@ TEST_F(ArrayOffsetsTest, GrowingRowBitsetToElementBitset) {
     EXPECT_FALSE(elem_bitset[3]);
     EXPECT_FALSE(elem_bitset[4]);
     EXPECT_TRUE(elem_bitset[5]);
+}
+
+TEST_F(ArrayOffsetsTest, GrowingElementBitsetToRowBitset) {
+    ArrayOffsetsGrowing offsets;
+
+    std::vector<int32_t> lens = {1, 2, 2, 0, 1};
+    offsets.Insert(0, lens.data(), 5);
+
+    TargetBitmap element_bitset(6);
+    element_bitset[0] = false;
+    element_bitset[1] = true;
+    element_bitset[2] = false;
+    element_bitset[3] = true;
+    element_bitset[4] = true;
+    element_bitset[5] = false;
+
+    TargetBitmap valid_element_bitset(6, true);
+    valid_element_bitset[5] = false;
+
+    TargetBitmapView element_view(element_bitset.data(), element_bitset.size());
+    TargetBitmapView valid_view(valid_element_bitset.data(),
+                                valid_element_bitset.size());
+
+    auto [row_bitset, valid_row_bitset] =
+        offsets.ElementBitsetToRowBitset(element_view, valid_view, 0, 5);
+
+    EXPECT_EQ(row_bitset.size(), 5);
+    EXPECT_FALSE(row_bitset[0]);
+    EXPECT_FALSE(row_bitset[1]);
+    EXPECT_TRUE(row_bitset[2]);
+    EXPECT_TRUE(row_bitset[3]);
+    EXPECT_TRUE(row_bitset[4]);
+    EXPECT_TRUE(valid_row_bitset.all());
 }
 
 TEST_F(ArrayOffsetsTest, GrowingConcurrentRead) {

--- a/internal/core/src/exec/operator/VectorSearchNode.cpp
+++ b/internal/core/src/exec/operator/VectorSearchNode.cpp
@@ -123,10 +123,10 @@ PhyVectorSearchNode::GetOutput() {
         // For **pre-filter**: FilterBitsNode -> MvccNode -> ElementFilterBitsNode -> VectorSearchNode -> ...
         // For **iterative filter**: MvccNode -> VectorSearchNode -> IterativeElementFilterNode -> IterativeFilterNode -> ...
         //
-        // When element_level_ is true, we need to transform doc-level bitset
-        // to element-level bitset.  In pre-filter path, ElementFilterBitsNode
-        // already does this.  We only need to do it here for the iterative
-        // path or when ElementFilterBitsNode is not present.
+        // When the vector field and input bitset have different granularities,
+        // normalize the bitset before handing it to vector search. Knowhere
+        // interprets bit offsets in the same coordinate system as the searched
+        // vector field.
         if (ph.element_level_ && !query_context_->bitset_is_element_level()) {
             auto col_input = GetColumnVector(input_);
             TargetBitmapView view(col_input->GetRawData(), col_input->size());
@@ -141,6 +141,27 @@ PhyVectorSearchNode::GetOutput() {
             std::vector<VectorPtr> col_res;
             col_res.push_back(std::make_shared<ColumnVector>(
                 std::move(element_bitset), std::move(valid_element_bitset)));
+            input_ = std::make_shared<RowVector>(col_res);
+        } else if (!ph.element_level_ &&
+                   query_context_->bitset_is_element_level()) {
+            auto array_offsets = query_context_->get_array_offsets();
+            AssertInfo(array_offsets != nullptr, "Array offsets not available");
+
+            auto col_input = GetColumnVector(input_);
+            TargetBitmapView view(col_input->GetRawData(), col_input->size());
+            TargetBitmapView valid_view(col_input->GetValidRawData(),
+                                        col_input->size());
+
+            auto [row_bitset, valid_row_bitset] =
+                array_offsets->ElementBitsetToRowBitset(
+                    view, valid_view, 0, active_count_);
+
+            query_context_->set_bitset_is_element_level(false);
+            query_context_->set_active_element_count(0);
+
+            std::vector<VectorPtr> col_res;
+            col_res.push_back(std::make_shared<ColumnVector>(
+                std::move(row_bitset), std::move(valid_row_bitset)));
             input_ = std::make_shared<RowVector>(col_res);
         }
 


### PR DESCRIPTION
Fixes #49438

### What

This fixes row-vector search with a pre-filtered `element_filter(...)` expression on a struct array.

When `ElementFilterBitsNode` evaluates the struct-array predicate, it converts the upstream row-level bitset into an element-level bitset. That is correct for `structA[embedding]` search, but row-level vector search such as `normal_vector` expects bit offsets in row coordinates. Passing an element-level bitset into row-level vector search can make element offsets look like row offsets and return false positives.

The patch adds an `ElementBitsetToRowBitset` conversion on `IArrayOffsets` and uses it in `VectorSearchNode` when the searched vector field is row-level but the incoming bitset is element-level. The conversion keeps a row visible if at least one valid element remains visible, and filters out empty arrays or rows with no matching visible element.

### Verification

- Remote build via `milvus-build build local -b master -f`
  - build: `build-local-zhuwenxing-fix-normal-vector-element-filter-c4c1a1b`
  - image: `harbor.milvus.io/manta/milvus:local-zhuwenxing-fix-normal-vector-element-filter-c4c1a1b`
- Deployed image to `normal-vector-efix` in `chaos-testing`
  - endpoint: `10.100.36.195:19530`
- Reproduced old behavior on `struct-array-repro`:
  - `query_actual`: `[0, 3, 5]`
  - `structA_embedding_search_actual`: `[0, 3, 5]`
  - `normal_vector_search_actual`: `[0, 6]`
- Verified fixed image with the same data and filter:
  - filter: `id < 100 && array_contains(structA[int_val], 5) && element_filter(structA, $[color] == "Red")`
  - expected: `[0, 3, 5]`
  - `query_actual`: `[0, 3, 5]`
  - `structA_embedding_search_actual`: `[0, 3, 5]`
  - `normal_vector_search_runs`: `[[0, 3, 5], [0, 3, 5], [0, 3, 5], [0, 3, 5], [0, 3, 5]]`