### PR TITLE
fix: use 3.0 as fallback branch name in version string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ index_engine = knowhere
 # both -c options and GIT_CONFIG_COUNT env vars are processed.
 $(shell git config --global --add safe.directory '*' 2>/dev/null)
 
-export GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD 2>/dev/null | grep -v '^HEAD$$' || echo "$${GITHUB_REF_NAME:-$${BRANCH_NAME:-unknown}}")
+export GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD 2>/dev/null | grep -v '^HEAD$$' || echo "$${GITHUB_REF_NAME:-$${BRANCH_NAME:-3.0}}")
 GIT_BRANCH_SAFE=$(shell echo "$(GIT_BRANCH)" | tr '/' '-')
 
 ifeq (${ENABLE_AZURE}, false)


### PR DESCRIPTION
## Problem

On the 3.0 branch, CI builds can run in detached HEAD state where `git rev-parse --abbrev-ref HEAD` returns `HEAD`. When neither `GITHUB_REF_NAME` nor `BRANCH_NAME` is set, the Makefile currently falls back to `unknown`, producing `unknown-DATE-COMMIT` in `MILVUS_VERSION`.

This is a resubmission of #49299 because that merged commit was dropped from the current 3.0 branch history after the branch was force-updated.

## Fix

Change the last-resort fallback in `GIT_BRANCH` detection from `unknown` to `3.0` for the 3.0 branch. Formal release builds remain unaffected because exact git tags are used before this fallback.

## Verification

- `git diff --check upstream/3.0..HEAD`
- In a detached HEAD worktree with `GITHUB_REF_NAME` and `BRANCH_NAME` unset, `make -pn print-build-info` expands `MILVUS_VERSION := 3.0-20260429-8fec52359b`.

issue: #49300

/kind bug
/area compilation
