### PR TITLE
enhance: terminal task queries may have empty result payloads

### DIFF
--- a/internal/datacoord/compaction_task_backfill.go
+++ b/internal/datacoord/compaction_task_backfill.go
@@ -259,13 +259,15 @@ func (t *backfillCompactionTask) QueryTaskOnWorker(cluster session.Cluster) {
 	result, err := cluster.QueryCompaction(t.GetTaskProto().GetNodeID(), &datapb.CompactionStateRequest{
 		PlanID: t.GetTaskProto().GetPlanID(),
 	})
-	if err != nil || result == nil {
-		if errors.Is(err, merr.ErrNodeNotFound) {
-			if err := t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_pipelining), setNodeID(NullNodeID)); err != nil {
-				log.Warn("backfillCompactionTask failed to updateAndSaveTaskMeta", zap.Error(err))
-			}
+	if err != nil {
+		if err := t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_pipelining), setNodeID(NullNodeID)); err != nil {
+			log.Warn("backfillCompactionTask failed to updateAndSaveTaskMeta", zap.Error(err))
 		}
 		log.Warn("backfillCompactionTask failed to get compaction result", zap.Error(err))
+		return
+	}
+	if result == nil {
+		log.Warn("backfillCompactionTask failed to get compaction result")
 		return
 	}
 	switch result.GetState() {

--- a/internal/datacoord/compaction_task_backfill_test.go
+++ b/internal/datacoord/compaction_task_backfill_test.go
@@ -299,6 +299,16 @@ func (s *BackfillCompactionTaskSuite) TestQueryTaskOnWorker() {
 		s.Equal(int64(-1), task.GetTaskProto().GetNodeID())
 	})
 
+	s.Run("QueryTaskOnWorker, query error", func() {
+		task := s.generateBasicTask()
+		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_executing), setNodeID(1)))
+		cluster := session.NewMockCluster(s.T())
+		cluster.EXPECT().QueryCompaction(mock.Anything, mock.Anything).Return(nil, errors.New("query task result payload is empty")).Once()
+		task.QueryTaskOnWorker(cluster)
+		s.Equal(datapb.CompactionTaskState_pipelining, task.GetTaskProto().GetState())
+		s.Equal(int64(-1), task.GetTaskProto().GetNodeID())
+	})
+
 	s.Run("QueryTaskOnWorker, result is nil", func() {
 		task := s.generateBasicTask()
 		task.SetTask(task.ShadowClone(setState(datapb.CompactionTaskState_executing), setNodeID(1)))

--- a/internal/datacoord/copy_segment_task.go
+++ b/internal/datacoord/copy_segment_task.go
@@ -22,6 +22,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
@@ -402,6 +403,11 @@ func (t *copySegmentTask) QueryTaskOnWorker(cluster session.Cluster) {
 	resp, err := cluster.QueryCopySegment(nodeID, req)
 	// Handle RPC error separately to avoid nil resp dereference
 	if err != nil {
+		if errors.Is(err, merr.ErrTaskResultEmpty) {
+			log.Warn("copy segment task result payload is empty, will retry query",
+				WrapCopySegmentTaskLog(t, zap.Error(err))...)
+			return
+		}
 		t.markTaskAndJobFailed(fmt.Sprintf("query copy segment RPC failed: %v", err))
 		return
 	}

--- a/internal/datacoord/copy_segment_task_test.go
+++ b/internal/datacoord/copy_segment_task_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
+	"github.com/milvus-io/milvus/internal/datacoord/session"
 	"github.com/milvus-io/milvus/internal/metastore"
 	catalogmocks "github.com/milvus-io/milvus/internal/metastore/mocks"
 	"github.com/milvus-io/milvus/internal/metastore/model"
@@ -37,6 +38,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/taskcommon"
 	"github.com/milvus-io/milvus/pkg/v3/util/lock"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/timerecord"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
@@ -677,6 +679,41 @@ func (s *CopySegmentTaskSuite) TestSyncVectorScalarIndexes_AddSegmentIndexError(
 	syncErr := syncVectorScalarIndexes(context.Background(), result, task, m, copyMeta)
 	s.Error(syncErr)
 	s.Contains(syncErr.Error(), "catalog error")
+}
+
+func (s *CopySegmentTaskSuite) TestQueryTaskOnWorker_TaskResultEmptyKeepsTaskInProgress() {
+	copyCatalog := catalogmocks.NewDataCoordCatalog(s.T())
+	copyCatalog.EXPECT().ListCopySegmentJobs(mock.Anything).Return(nil, nil)
+	copyCatalog.EXPECT().ListCopySegmentTasks(mock.Anything).Return(nil, nil)
+	copyCatalog.EXPECT().SaveCopySegmentJob(mock.Anything, mock.Anything).Return(nil).Maybe()
+	copyCatalog.EXPECT().SaveCopySegmentTask(mock.Anything, mock.Anything).Return(nil).Maybe()
+	copyMeta, err := NewCopySegmentMeta(context.TODO(), copyCatalog, nil, nil, nil)
+	s.NoError(err)
+
+	job := &copySegmentJob{
+		CopySegmentJob: &datapb.CopySegmentJob{
+			JobId: 100,
+			State: datapb.CopySegmentJobState_CopySegmentJobExecuting,
+		},
+		tr: timerecord.NewTimeRecorder("test job"),
+	}
+	s.NoError(copyMeta.AddJob(context.TODO(), job))
+
+	task := createTestCopyTask(1, 100).(*copySegmentTask)
+	task.copyMeta = copyMeta
+	s.NoError(copyMeta.AddTask(context.TODO(), task))
+
+	cluster := session.NewMockCluster(s.T())
+	cluster.EXPECT().QueryCopySegment(task.GetNodeId(), mock.Anything).
+		Return(nil, errors.Wrap(merr.ErrTaskResultEmpty, "copy segment task 1001 is terminal with empty result payload")).
+		Once()
+
+	task.QueryTaskOnWorker(cluster)
+
+	metaTask := copyMeta.GetTask(context.TODO(), task.GetTaskId())
+	s.Equal(datapb.CopySegmentTaskState_CopySegmentTaskInProgress, metaTask.GetState())
+	metaJob := copyMeta.GetJob(context.TODO(), task.GetJobId())
+	s.Equal(datapb.CopySegmentJobState_CopySegmentJobExecuting, metaJob.GetState())
 }
 
 func TestAssembleCopySegmentRequest_SourceSegmentNotFound(t *testing.T) {

--- a/internal/datacoord/session/cluster.go
+++ b/internal/datacoord/session/cluster.go
@@ -18,6 +18,7 @@ package session
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -112,6 +113,15 @@ func NewCluster(nm NodeManager) Cluster {
 		nm: nm,
 	}
 	return c
+}
+
+func hasTaskResultPayload(resp *workerpb.QueryTaskResponse) bool {
+	return len(resp.GetPayload()) > 0
+}
+
+func errTerminalEmptyPayload(taskType taskcommon.Type, taskID int64, state taskcommon.State, reason string) error {
+	return fmt.Errorf("%s task %d is terminal with empty result payload, state=%s, reason=%s",
+		taskType, taskID, state.String(), reason)
 }
 
 func (c *cluster) createTask(nodeID int64, in proto.Message, properties taskcommon.Properties) error {
@@ -260,15 +270,18 @@ func (c *cluster) QueryCompaction(nodeID int64, in *datapb.CompactionStateReques
 	case taskcommon.None, taskcommon.Init, taskcommon.Retry:
 		return defaultResult, nil
 	case taskcommon.InProgress:
-		if resp.GetPayload() != nil {
+		if hasTaskResultPayload(resp) {
 			return payloadResultF()
 		}
 		return defaultResult, nil
 	case taskcommon.Finished, taskcommon.Failed:
-		if resp.GetPayload() != nil {
+		if hasTaskResultPayload(resp) {
 			return payloadResultF()
 		}
-		panic("the compaction result payload must not be empty with Finished/Failed state")
+		reason := taskcommon.NewProperties(resp.GetProperties()).GetTaskReason()
+		log.Warn("the compaction result payload is empty",
+			zap.Int64("taskID", in.GetPlanID()), zap.String("state", state.String()), zap.String("reason", reason))
+		return nil, errTerminalEmptyPayload(taskcommon.Compaction, in.GetPlanID(), state, reason)
 	default:
 		panic("should not happen")
 	}
@@ -332,17 +345,17 @@ func (c *cluster) QueryPreImport(nodeID int64, in *datapb.QueryPreImportRequest)
 	case taskcommon.None, taskcommon.Init, taskcommon.Retry:
 		return defaultResult, nil
 	case taskcommon.InProgress:
-		if resp.GetPayload() != nil {
+		if hasTaskResultPayload(resp) {
 			return payloadResultF()
 		}
 		return defaultResult, nil
 	case taskcommon.Finished, taskcommon.Failed:
-		if resp.GetPayload() != nil {
+		if hasTaskResultPayload(resp) {
 			return payloadResultF()
 		}
-		log.Warn("the preImport result payload must not be empty",
-			zap.Int64("taskID", in.GetTaskID()), zap.String("state", state.String()))
-		panic("the preImport result payload must not be empty with Finished/Failed state")
+		log.Warn("the preImport result payload is empty",
+			zap.Int64("taskID", in.GetTaskID()), zap.String("state", state.String()), zap.String("reason", reason))
+		return nil, errTerminalEmptyPayload(taskcommon.PreImport, in.GetTaskID(), state, reason)
 	default:
 		panic("should not happen")
 	}
@@ -379,17 +392,17 @@ func (c *cluster) QueryImport(nodeID int64, in *datapb.QueryImportRequest) (*dat
 	case taskcommon.None, taskcommon.Init, taskcommon.Retry:
 		return defaultResult, nil
 	case taskcommon.InProgress:
-		if resp.GetPayload() != nil {
+		if hasTaskResultPayload(resp) {
 			return payloadResultF()
 		}
 		return defaultResult, nil
 	case taskcommon.Finished, taskcommon.Failed:
-		if resp.GetPayload() != nil {
+		if hasTaskResultPayload(resp) {
 			return payloadResultF()
 		}
-		log.Warn("the import result payload must not be empty",
-			zap.Int64("taskID", in.GetTaskID()), zap.String("state", state.String()))
-		panic("the import result payload must not be empty with Finished/Failed state")
+		log.Warn("the import result payload is empty",
+			zap.Int64("taskID", in.GetTaskID()), zap.String("state", state.String()), zap.String("reason", reason))
+		return nil, errTerminalEmptyPayload(taskcommon.Import, in.GetTaskID(), state, reason)
 	default:
 		panic("should not happen")
 	}
@@ -454,17 +467,17 @@ func (c *cluster) QueryIndex(nodeID int64, in *workerpb.QueryJobsRequest) (*work
 	case taskcommon.None, taskcommon.Init, taskcommon.Retry:
 		return defaultResult, nil
 	case taskcommon.InProgress:
-		if resp.GetPayload() != nil {
+		if hasTaskResultPayload(resp) {
 			return payloadResultF()
 		}
 		return defaultResult, nil
 	case taskcommon.Finished, taskcommon.Failed:
-		if resp.GetPayload() != nil {
+		if hasTaskResultPayload(resp) {
 			return payloadResultF()
 		}
-		log.Warn("the index result payload must not be empty",
-			zap.Int64("taskID", in.GetTaskIDs()[0]), zap.String("state", state.String()))
-		panic("the index result payload must not be empty with Finished/Failed state")
+		log.Warn("the index result payload is empty",
+			zap.Int64("taskID", in.GetTaskIDs()[0]), zap.String("state", state.String()), zap.String("reason", reason))
+		return nil, errTerminalEmptyPayload(taskcommon.Index, in.GetTaskIDs()[0], state, reason)
 	default:
 		panic("should not happen")
 	}
@@ -529,18 +542,18 @@ func (c *cluster) QueryStats(nodeID int64, in *workerpb.QueryJobsRequest) (*work
 	case taskcommon.None, taskcommon.Init, taskcommon.Retry:
 		return defaultResult, nil
 	case taskcommon.InProgress:
-		if resp.GetPayload() != nil {
+		if hasTaskResultPayload(resp) {
 			return payloadResultF()
 		}
 		return defaultResult, nil
 
 	case taskcommon.Finished, taskcommon.Failed:
-		if resp.GetPayload() != nil {
+		if hasTaskResultPayload(resp) {
 			return payloadResultF()
 		}
-		log.Warn("the stats result payload must not be empty",
-			zap.Int64("taskID", in.GetTaskIDs()[0]), zap.String("state", state.String()))
-		panic("the stats result payload must not be empty with Finished/Failed state")
+		log.Warn("the stats result payload is empty",
+			zap.Int64("taskID", in.GetTaskIDs()[0]), zap.String("state", state.String()), zap.String("reason", reason))
+		return nil, errTerminalEmptyPayload(taskcommon.Stats, in.GetTaskIDs()[0], state, reason)
 	default:
 		panic("should not happen")
 	}
@@ -603,17 +616,17 @@ func (c *cluster) QueryAnalyze(nodeID int64, in *workerpb.QueryJobsRequest) (*wo
 	case taskcommon.None, taskcommon.Init, taskcommon.Retry:
 		return defaultResult, nil
 	case taskcommon.InProgress:
-		if resp.GetPayload() != nil {
+		if hasTaskResultPayload(resp) {
 			return payloadResultF()
 		}
 		return defaultResult, nil
 	case taskcommon.Finished, taskcommon.Failed:
-		if resp.GetPayload() != nil {
+		if hasTaskResultPayload(resp) {
 			return payloadResultF()
 		}
-		log.Warn("the analyze result payload must not be empty",
-			zap.Int64("taskID", in.GetTaskIDs()[0]), zap.String("state", state.String()))
-		panic("the analyze result payload must not be empty with Finished/Failed state")
+		log.Warn("the analyze result payload is empty",
+			zap.Int64("taskID", in.GetTaskIDs()[0]), zap.String("state", state.String()), zap.String("reason", reason))
+		return nil, errTerminalEmptyPayload(taskcommon.Analyze, in.GetTaskIDs()[0], state, reason)
 	default:
 		panic("should not happen")
 	}
@@ -679,6 +692,20 @@ func (c *cluster) QueryRefreshExternalCollectionTask(nodeID int64, taskID int64)
 		return nil, err
 	}
 
+	if !hasTaskResultPayload(resp) {
+		resProperties := taskcommon.NewProperties(resp.GetProperties())
+		state, err := resProperties.GetTaskState()
+		if err != nil {
+			return nil, err
+		}
+		reason := resProperties.GetTaskReason()
+		if state == taskcommon.Finished || state == taskcommon.Failed {
+			log.Warn("the refresh external collection result payload is empty",
+				zap.Int64("taskID", taskID), zap.String("state", state.String()), zap.String("reason", reason))
+			return nil, errTerminalEmptyPayload(taskcommon.RefreshExternalCollection, taskID, state, reason)
+		}
+	}
+
 	// Unmarshal the response payload
 	result := &datapb.RefreshExternalCollectionTaskResponse{}
 	if err := proto.Unmarshal(resp.GetPayload(), result); err != nil {
@@ -739,17 +766,17 @@ func (c *cluster) QueryCopySegment(nodeID int64, in *datapb.QueryCopySegmentRequ
 	case taskcommon.None, taskcommon.Init, taskcommon.Retry:
 		return defaultResult, nil
 	case taskcommon.InProgress:
-		if resp.GetPayload() != nil {
+		if hasTaskResultPayload(resp) {
 			return payloadResultF()
 		}
 		return defaultResult, nil
 	case taskcommon.Finished, taskcommon.Failed:
-		if resp.GetPayload() != nil {
+		if hasTaskResultPayload(resp) {
 			return payloadResultF()
 		}
-		log.Warn("the copy segment result payload must not be empty",
-			zap.Int64("taskID", in.GetTaskID()), zap.String("state", state.String()))
-		panic("the copy segment result payload must not be empty with Finished/Failed state")
+		log.Warn("the copy segment result payload is empty",
+			zap.Int64("taskID", in.GetTaskID()), zap.String("state", state.String()), zap.String("reason", reason))
+		return nil, errTerminalEmptyPayload(taskcommon.CopySegment, in.GetTaskID(), state, reason)
 	default:
 		panic("should not happen")
 	}

--- a/internal/datacoord/session/cluster.go
+++ b/internal/datacoord/session/cluster.go
@@ -18,10 +18,10 @@ package session
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 
@@ -120,7 +120,7 @@ func hasTaskResultPayload(resp *workerpb.QueryTaskResponse) bool {
 }
 
 func errTerminalEmptyPayload(taskType taskcommon.Type, taskID int64, state taskcommon.State, reason string) error {
-	return fmt.Errorf("%s task %d is terminal with empty result payload, state=%s, reason=%s",
+	return errors.Wrapf(merr.ErrTaskResultEmpty, "%s task %d is terminal with empty result payload, state=%s, reason=%s",
 		taskType, taskID, state.String(), reason)
 }
 

--- a/internal/datacoord/session/cluster_test.go
+++ b/internal/datacoord/session/cluster_test.go
@@ -333,6 +333,27 @@ func TestCluster_Import(t *testing.T) {
 		assert.NotNil(t, result)
 	})
 
+	t.Run("query import finished with empty payload returns error", func(t *testing.T) {
+		mockNodeManager := NewMockNodeManager(t)
+		cluster := NewCluster(mockNodeManager)
+
+		mockClient := mocks.NewMockDataNodeClient(t)
+		mockNodeManager.EXPECT().GetClient(mock.Anything).Return(mockClient, nil)
+
+		properties := taskcommon.NewProperties(nil)
+		properties.AppendTaskState(taskcommon.Finished)
+		properties.AppendReason("result payload is empty")
+		mockClient.EXPECT().QueryTask(mock.Anything, mock.Anything).Return(&workerpb.QueryTaskResponse{
+			Status:     merr.Success(),
+			Properties: properties,
+		}, nil)
+
+		result, err := cluster.QueryImport(1, &datapb.QueryImportRequest{TaskID: 1})
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "result payload is empty")
+	})
+
 	t.Run("drop import", func(t *testing.T) {
 		mockNodeManager := NewMockNodeManager(t)
 		cluster := NewCluster(mockNodeManager)
@@ -346,6 +367,108 @@ func TestCluster_Import(t *testing.T) {
 		err := cluster.DropImport(1, 1)
 		assert.NoError(t, err)
 	})
+}
+
+func TestCluster_QueryTerminalEmptyPayloadReturnsError(t *testing.T) {
+	testCases := []struct {
+		name      string
+		taskType  taskcommon.Type
+		queryFunc func(Cluster) error
+	}{
+		{
+			name:     "compaction",
+			taskType: taskcommon.Compaction,
+			queryFunc: func(cluster Cluster) error {
+				_, err := cluster.QueryCompaction(1, &datapb.CompactionStateRequest{PlanID: 1})
+				return err
+			},
+		},
+		{
+			name:     "preimport",
+			taskType: taskcommon.PreImport,
+			queryFunc: func(cluster Cluster) error {
+				_, err := cluster.QueryPreImport(1, &datapb.QueryPreImportRequest{TaskID: 1})
+				return err
+			},
+		},
+		{
+			name:     "import",
+			taskType: taskcommon.Import,
+			queryFunc: func(cluster Cluster) error {
+				_, err := cluster.QueryImport(1, &datapb.QueryImportRequest{TaskID: 1})
+				return err
+			},
+		},
+		{
+			name:     "index",
+			taskType: taskcommon.Index,
+			queryFunc: func(cluster Cluster) error {
+				_, err := cluster.QueryIndex(1, &workerpb.QueryJobsRequest{TaskIDs: []int64{1}})
+				return err
+			},
+		},
+		{
+			name:     "stats",
+			taskType: taskcommon.Stats,
+			queryFunc: func(cluster Cluster) error {
+				_, err := cluster.QueryStats(1, &workerpb.QueryJobsRequest{TaskIDs: []int64{1}})
+				return err
+			},
+		},
+		{
+			name:     "analyze",
+			taskType: taskcommon.Analyze,
+			queryFunc: func(cluster Cluster) error {
+				_, err := cluster.QueryAnalyze(1, &workerpb.QueryJobsRequest{TaskIDs: []int64{1}})
+				return err
+			},
+		},
+		{
+			name:     "refresh external collection",
+			taskType: taskcommon.RefreshExternalCollection,
+			queryFunc: func(cluster Cluster) error {
+				_, err := cluster.QueryRefreshExternalCollectionTask(1, 1)
+				return err
+			},
+		},
+		{
+			name:     "copy segment",
+			taskType: taskcommon.CopySegment,
+			queryFunc: func(cluster Cluster) error {
+				_, err := cluster.QueryCopySegment(1, &datapb.QueryCopySegmentRequest{TaskID: 1})
+				return err
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		for _, state := range []taskcommon.State{taskcommon.Finished, taskcommon.Failed} {
+			t.Run(tc.name+"_"+state.String(), func(t *testing.T) {
+				mockNodeManager := NewMockNodeManager(t)
+				cluster := NewCluster(mockNodeManager)
+
+				mockClient := mocks.NewMockDataNodeClient(t)
+				mockNodeManager.EXPECT().GetClient(mock.Anything).Return(mockClient, nil)
+
+				properties := taskcommon.NewProperties(nil)
+				properties.AppendTaskState(state)
+				properties.AppendReason("result payload is empty")
+				mockClient.EXPECT().QueryTask(mock.Anything, mock.Anything).Return(&workerpb.QueryTaskResponse{
+					Status:     merr.Success(),
+					Properties: properties,
+				}, nil)
+
+				var err error
+				assert.NotPanics(t, func() {
+					err = tc.queryFunc(cluster)
+				})
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), string(tc.taskType))
+				assert.Contains(t, err.Error(), state.String())
+				assert.Contains(t, err.Error(), "result payload is empty")
+			})
+		}
+	}
 }
 
 func TestCluster_Index(t *testing.T) {

--- a/internal/datacoord/session/cluster_test.go
+++ b/internal/datacoord/session/cluster_test.go
@@ -294,7 +294,10 @@ func TestCluster_Import(t *testing.T) {
 		// Mock response
 		properties := taskcommon.NewProperties(nil)
 		properties.AppendTaskState(taskcommon.Finished)
-		expectedResult := &datapb.QueryPreImportResponse{}
+		expectedResult := &datapb.QueryPreImportResponse{
+			TaskID: 1,
+			State:  datapb.ImportTaskStateV2_Completed,
+		}
 		payload, _ := proto.Marshal(expectedResult)
 		mockClient.EXPECT().QueryTask(mock.Anything, mock.Anything).Return(&workerpb.QueryTaskResponse{
 			Status:     merr.Success(),
@@ -319,7 +322,10 @@ func TestCluster_Import(t *testing.T) {
 		// Mock response
 		properties := taskcommon.NewProperties(nil)
 		properties.AppendTaskState(taskcommon.Finished)
-		expectedResult := &datapb.QueryImportResponse{}
+		expectedResult := &datapb.QueryImportResponse{
+			TaskID: 1,
+			State:  datapb.ImportTaskStateV2_Completed,
+		}
 		payload, _ := proto.Marshal(expectedResult)
 		mockClient.EXPECT().QueryTask(mock.Anything, mock.Anything).Return(&workerpb.QueryTaskResponse{
 			Status:     merr.Success(),

--- a/internal/datacoord/session/cluster_test.go
+++ b/internal/datacoord/session/cluster_test.go
@@ -443,30 +443,39 @@ func TestCluster_QueryTerminalEmptyPayloadReturnsError(t *testing.T) {
 
 	for _, tc := range testCases {
 		for _, state := range []taskcommon.State{taskcommon.Finished, taskcommon.Failed} {
-			t.Run(tc.name+"_"+state.String(), func(t *testing.T) {
-				mockNodeManager := NewMockNodeManager(t)
-				cluster := NewCluster(mockNodeManager)
+			for _, payloadCase := range []struct {
+				name    string
+				payload []byte
+			}{
+				{name: "nil_payload"},
+				{name: "empty_payload", payload: []byte{}},
+			} {
+				t.Run(tc.name+"_"+state.String()+"_"+payloadCase.name, func(t *testing.T) {
+					mockNodeManager := NewMockNodeManager(t)
+					cluster := NewCluster(mockNodeManager)
 
-				mockClient := mocks.NewMockDataNodeClient(t)
-				mockNodeManager.EXPECT().GetClient(mock.Anything).Return(mockClient, nil)
+					mockClient := mocks.NewMockDataNodeClient(t)
+					mockNodeManager.EXPECT().GetClient(mock.Anything).Return(mockClient, nil)
 
-				properties := taskcommon.NewProperties(nil)
-				properties.AppendTaskState(state)
-				properties.AppendReason("result payload is empty")
-				mockClient.EXPECT().QueryTask(mock.Anything, mock.Anything).Return(&workerpb.QueryTaskResponse{
-					Status:     merr.Success(),
-					Properties: properties,
-				}, nil)
+					properties := taskcommon.NewProperties(nil)
+					properties.AppendTaskState(state)
+					properties.AppendReason("result payload is empty")
+					mockClient.EXPECT().QueryTask(mock.Anything, mock.Anything).Return(&workerpb.QueryTaskResponse{
+						Status:     merr.Success(),
+						Properties: properties,
+						Payload:    payloadCase.payload,
+					}, nil)
 
-				var err error
-				assert.NotPanics(t, func() {
-					err = tc.queryFunc(cluster)
+					var err error
+					assert.NotPanics(t, func() {
+						err = tc.queryFunc(cluster)
+					})
+					assert.Error(t, err)
+					assert.Contains(t, err.Error(), tc.taskType)
+					assert.Contains(t, err.Error(), state.String())
+					assert.Contains(t, err.Error(), "result payload is empty")
 				})
-				assert.Error(t, err)
-				assert.Contains(t, err.Error(), string(tc.taskType))
-				assert.Contains(t, err.Error(), state.String())
-				assert.Contains(t, err.Error(), "result payload is empty")
-			})
+			}
 		}
 	}
 }

--- a/internal/datacoord/session/cluster_test.go
+++ b/internal/datacoord/session/cluster_test.go
@@ -357,6 +357,7 @@ func TestCluster_Import(t *testing.T) {
 		result, err := cluster.QueryImport(1, &datapb.QueryImportRequest{TaskID: 1})
 		assert.Error(t, err)
 		assert.Nil(t, result)
+		assert.ErrorIs(t, err, merr.ErrTaskResultEmpty)
 		assert.Contains(t, err.Error(), "result payload is empty")
 	})
 
@@ -477,6 +478,7 @@ func TestCluster_QueryTerminalEmptyPayloadReturnsError(t *testing.T) {
 						err = tc.queryFunc(cluster)
 					})
 					assert.Error(t, err)
+					assert.ErrorIs(t, err, merr.ErrTaskResultEmpty)
 					assert.Contains(t, err.Error(), tc.taskType)
 					assert.Contains(t, err.Error(), state.String())
 					assert.Contains(t, err.Error(), "result payload is empty")

--- a/internal/datacoord/task_refresh_external_collection.go
+++ b/internal/datacoord/task_refresh_external_collection.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
@@ -32,6 +33,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/taskcommon"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -502,6 +504,10 @@ func (t *refreshExternalCollectionTask) QueryTaskOnWorker(cluster session.Cluste
 	// Query task status from worker
 	resp, err := cluster.QueryRefreshExternalCollectionTask(t.GetNodeId(), t.GetTaskId())
 	if err != nil {
+		if errors.Is(err, merr.ErrTaskResultEmpty) {
+			log.Warn("refresh task result payload is empty, will retry query", zap.Error(err))
+			return
+		}
 		log.Warn("query refresh task result failed", zap.Error(err))
 		// If query fails, mark task as failed
 		if updateErr := t.UpdateStateWithMeta(indexpb.JobState_JobStateFailed, fmt.Sprintf("query task failed: %v", err)); updateErr != nil {

--- a/internal/datacoord/task_refresh_external_collection_test.go
+++ b/internal/datacoord/task_refresh_external_collection_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/taskcommon"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
@@ -944,6 +945,49 @@ func TestRefreshExternalCollectionTask_QueryTaskOnWorker(t *testing.T) {
 		metaTask := refreshMeta.GetTask(1001)
 		assert.Equal(t, indexpb.JobState_JobStateFailed, metaTask.GetState())
 		assert.Contains(t, metaTask.GetFailReason(), "query task failed")
+	})
+
+	t.Run("task_result_empty_keeps_task_in_progress", func(t *testing.T) {
+		catalog := &stubCatalog{}
+		refreshMeta, err := newExternalCollectionRefreshMeta(context.Background(), catalog)
+		assert.NoError(t, err)
+
+		job := &datapb.ExternalCollectionRefreshJob{
+			JobId:          1,
+			CollectionId:   100,
+			State:          indexpb.JobState_JobStateInProgress,
+			ExternalSource: "s3://bucket/path",
+			ExternalSpec:   "iceberg",
+		}
+		err = refreshMeta.AddJob(job)
+		assert.NoError(t, err)
+
+		protoTask := &datapb.ExternalCollectionRefreshTask{
+			TaskId:         1001,
+			JobId:          1,
+			CollectionId:   100,
+			NodeId:         1,
+			State:          indexpb.JobState_JobStateInProgress,
+			ExternalSource: "s3://bucket/path",
+			ExternalSpec:   "iceberg",
+		}
+		err = refreshMeta.AddTask(protoTask)
+		assert.NoError(t, err)
+
+		alloc := &stubAllocator{nextID: 99999}
+		task := newRefreshExternalCollectionTask(protoTask, refreshMeta, nil, alloc)
+
+		cluster := &stubCluster{}
+		mockQuery := mockey.Mock(mockey.GetMethod(cluster, "QueryRefreshExternalCollectionTask")).
+			Return(nil, errors.Wrap(merr.ErrTaskResultEmpty, "refresh external collection task 1001 is terminal with empty result payload")).
+			Build()
+		defer mockQuery.UnPatch()
+
+		task.QueryTaskOnWorker(cluster)
+
+		metaTask := refreshMeta.GetTask(1001)
+		assert.Equal(t, indexpb.JobState_JobStateInProgress, metaTask.GetState())
+		assert.Empty(t, metaTask.GetFailReason())
 	})
 
 	t.Run("task_in_progress", func(t *testing.T) {

--- a/pkg/util/merr/errors.go
+++ b/pkg/util/merr/errors.go
@@ -119,6 +119,7 @@ var (
 	ErrIndexNotSupported = newMilvusError("index type not supported", 701, false)
 	ErrIndexDuplicate    = newMilvusError("index duplicates", 702, false)
 	ErrTaskDuplicate     = newMilvusError("task duplicates", 703, false)
+	ErrTaskResultEmpty   = newMilvusError("task result empty", 704, true)
 
 	// Database related
 	ErrDatabaseNotFound         = newMilvusError("database not found", 800, false)


### PR DESCRIPTION
## Summary

Fixes #49444

DataCoord session query adapters can receive a terminal worker task state with an empty result payload when the worker no longer has the structured result. Previously most task query paths panicked in this case, while import returned a synthetic retry response. This keeps the behavior generic: terminal empty payloads are surfaced as query errors so callers can use their existing retry/error handling without panics or zero-value terminal results.

## Changes

- Return an error instead of panicking for terminal empty payloads in compaction, pre-import, import, index, stats, analyze, refresh-external-collection, and copy-segment task queries.
- Treat zero-length payloads the same as nil payloads before unmarshalling task results.
- Add regression coverage for both `Finished` and `Failed` terminal states across the DataCoord session query adapters.

## Test Plan

- [x] `gofmt -w internal/datacoord/session/cluster.go internal/datacoord/session/cluster_test.go`
- [x] `git diff --check`
- [ ] `./bin/gofumpt -d internal/datacoord/session/cluster.go internal/datacoord/session/cluster_test.go` (blocked locally: `./bin/gofumpt` not found)
- [ ] `./bin/gci diff internal/datacoord/session/cluster.go internal/datacoord/session/cluster_test.go --skip-generated -s standard -s default -s "prefix(github.com/milvus-io)" --custom-order` (blocked locally: `./bin/gci` not found)
- [ ] `go test -tags dynamic,test ./internal/datacoord/session -run 'TestCluster_QueryTerminalEmptyPayloadReturnsError|TestCluster_Import/query_import_finished_with_empty_payload_returns_error' -count=1` (blocked locally: missing pkg-config dependencies `rocksdb.pc` and `milvus_core.pc`)
