### PR TITLE
fix: support streamingcoord meta key compatibility

### DIFF
--- a/internal/metastore/kv/streamingcoord/constant.go
+++ b/internal/metastore/kv/streamingcoord/constant.go
@@ -4,8 +4,8 @@ const (
 	MetaPrefix          = "streamingcoord-meta/"
 	PChannelMetaPrefix  = MetaPrefix + "pchannel/"
 	BroadcastTaskPrefix = MetaPrefix + "broadcast-task/"
-	VersionPrefix       = MetaPrefix + "version/"
-	CChannelMetaPrefix  = MetaPrefix + "cchannel/"
+	VersionKey          = MetaPrefix + "version"
+	CChannelMetaKey     = MetaPrefix + "cchannel"
 
 	// Replicate
 	ReplicatePChannelMetaPrefix = MetaPrefix + "replicating-pchannel/"

--- a/internal/metastore/kv/streamingcoord/kv_catalog.go
+++ b/internal/metastore/kv/streamingcoord/kv_catalog.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/cockroachdb/errors"
 	"google.golang.org/protobuf/proto"
@@ -48,16 +49,21 @@ type catalog struct {
 
 // GetCChannel returns the control channel
 func (c *catalog) GetCChannel(ctx context.Context) (*streamingpb.CChannelMeta, error) {
-	value, err := c.metaKV.Load(ctx, CChannelMetaPrefix)
+	value, needRepair, found, err := c.loadMetaWithLegacyTrailingSlash(ctx, CChannelMetaKey)
 	if err != nil {
-		if errors.Is(err, merr.ErrIoKeyNotFound) {
-			return nil, nil
-		}
 		return nil, err
+	}
+	if !found {
+		return nil, nil
 	}
 	info := &streamingpb.CChannelMeta{}
 	if err = proto.Unmarshal([]byte(value), info); err != nil {
 		return nil, errors.Wrapf(err, "unmarshal cchannel meta failed")
+	}
+	if needRepair {
+		if err = c.saveAndRemoveLegacyMeta(ctx, CChannelMetaKey, value); err != nil {
+			return nil, err
+		}
 	}
 	return info, nil
 }
@@ -68,21 +74,26 @@ func (c *catalog) SaveCChannel(ctx context.Context, info *streamingpb.CChannelMe
 	if err != nil {
 		return errors.Wrapf(err, "marshal cchannel meta failed")
 	}
-	return c.metaKV.Save(ctx, CChannelMetaPrefix, string(v))
+	return c.saveAndRemoveLegacyMeta(ctx, CChannelMetaKey, string(v))
 }
 
 // GetVersion returns the streaming version
 func (c *catalog) GetVersion(ctx context.Context) (*streamingpb.StreamingVersion, error) {
-	value, err := c.metaKV.Load(ctx, VersionPrefix)
+	value, needRepair, found, err := c.loadMetaWithLegacyTrailingSlash(ctx, VersionKey)
 	if err != nil {
-		if errors.Is(err, merr.ErrIoKeyNotFound) {
-			return nil, nil
-		}
 		return nil, err
+	}
+	if !found {
+		return nil, nil
 	}
 	info := &streamingpb.StreamingVersion{}
 	if err = proto.Unmarshal([]byte(value), info); err != nil {
 		return nil, errors.Wrapf(err, "unmarshal streaming version failed")
+	}
+	if needRepair {
+		if err = c.saveAndRemoveLegacyMeta(ctx, VersionKey, value); err != nil {
+			return nil, err
+		}
 	}
 	return info, nil
 }
@@ -96,7 +107,34 @@ func (c *catalog) SaveVersion(ctx context.Context, version *streamingpb.Streamin
 	if err != nil {
 		return errors.Wrapf(err, "marshal streaming version failed")
 	}
-	return c.metaKV.Save(ctx, VersionPrefix, string(v))
+	return c.saveAndRemoveLegacyMeta(ctx, VersionKey, string(v))
+}
+
+func (c *catalog) loadMetaWithLegacyTrailingSlash(ctx context.Context, key string) (string, bool, bool, error) {
+	keys, values, err := c.metaKV.LoadWithPrefix(ctx, key)
+	if err != nil {
+		return "", false, false, err
+	}
+	var canonicalValue, legacyValue string
+	foundCanonical, foundLegacy := false, false
+	for i, loadedKey := range keys {
+		switch {
+		case strings.HasSuffix(loadedKey, key):
+			canonicalValue = values[i]
+			foundCanonical = true
+		case strings.HasSuffix(loadedKey, "/"):
+			legacyValue = values[i]
+			foundLegacy = true
+		}
+	}
+	if foundCanonical {
+		return canonicalValue, foundLegacy, true, nil
+	}
+	return legacyValue, foundLegacy, foundLegacy, nil
+}
+
+func (c *catalog) saveAndRemoveLegacyMeta(ctx context.Context, key, value string) error {
+	return c.metaKV.MultiSaveAndRemove(ctx, map[string]string{key: value}, []string{key + "/"})
 }
 
 // ListPChannels returns all pchannels

--- a/internal/metastore/kv/streamingcoord/kv_catalog.go
+++ b/internal/metastore/kv/streamingcoord/kv_catalog.go
@@ -111,6 +111,7 @@ func (c *catalog) SaveVersion(ctx context.Context, version *streamingpb.Streamin
 }
 
 func (c *catalog) loadMetaWithLegacyTrailingSlash(ctx context.Context, key string) (string, bool, bool, error) {
+	// Callers must serialize Get/Save for key; read repair is not CAS.
 	keys, values, err := c.metaKV.LoadWithPrefix(ctx, key)
 	if err != nil {
 		return "", false, false, err
@@ -122,7 +123,7 @@ func (c *catalog) loadMetaWithLegacyTrailingSlash(ctx context.Context, key strin
 		case strings.HasSuffix(loadedKey, key):
 			canonicalValue = values[i]
 			foundCanonical = true
-		case strings.HasSuffix(loadedKey, "/"):
+		case strings.HasSuffix(loadedKey, key+"/"):
 			legacyValue = values[i]
 			foundLegacy = true
 		}

--- a/internal/metastore/kv/streamingcoord/kv_catalog_test.go
+++ b/internal/metastore/kv/streamingcoord/kv_catalog_test.go
@@ -242,6 +242,20 @@ func TestCatalog_CChannelMetaKeyCompatibility(t *testing.T) {
 		kv.AssertNotCalled(t, "MultiSaveAndRemove", mock.Anything, mock.Anything, mock.Anything)
 	})
 
+	t.Run("ignores sibling keys ending with slash", func(t *testing.T) {
+		catalog, kvStorage, kv := newTestCatalog(t)
+		siblingValue, err := proto.Marshal(&streamingpb.CChannelMeta{Pchannel: "sibling-channel"})
+		require.NoError(t, err)
+		kvStorage[canonicalCChannelMetaKeyForTest+"-foo/"] = string(siblingValue)
+
+		cchannel, err := catalog.GetCChannel(ctx)
+
+		require.NoError(t, err)
+		assert.Nil(t, cchannel)
+		kv.AssertNotCalled(t, "Remove", mock.Anything, legacyCChannelMetaKeyForTest)
+		kv.AssertNotCalled(t, "MultiSaveAndRemove", mock.Anything, mock.Anything, mock.Anything)
+	})
+
 	t.Run("save writes canonical key and removes legacy key", func(t *testing.T) {
 		catalog, kvStorage, _ := newTestCatalog(t)
 		legacyValue, err := proto.Marshal(&streamingpb.CChannelMeta{Pchannel: "legacy-channel"})
@@ -356,6 +370,20 @@ func TestCatalog_VersionMetaKeyCompatibility(t *testing.T) {
 		childValue, err := proto.Marshal(&streamingpb.StreamingVersion{Version: 3})
 		require.NoError(t, err)
 		kvStorage[canonicalVersionKeyForTest+"/child"] = string(childValue)
+
+		version, err := catalog.GetVersion(ctx)
+
+		require.NoError(t, err)
+		assert.Nil(t, version)
+		kv.AssertNotCalled(t, "Remove", mock.Anything, legacyVersionKeyForTest)
+		kv.AssertNotCalled(t, "MultiSaveAndRemove", mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	t.Run("ignores sibling keys ending with slash", func(t *testing.T) {
+		catalog, kvStorage, kv := newTestCatalog(t)
+		siblingValue, err := proto.Marshal(&streamingpb.StreamingVersion{Version: 3})
+		require.NoError(t, err)
+		kvStorage[canonicalVersionKeyForTest+"-foo/"] = string(siblingValue)
 
 		version, err := catalog.GetVersion(ctx)
 

--- a/internal/metastore/kv/streamingcoord/kv_catalog_test.go
+++ b/internal/metastore/kv/streamingcoord/kv_catalog_test.go
@@ -2,52 +2,100 @@ package streamingcoord
 
 import (
 	"context"
+	"maps"
 	"strings"
 	"testing"
 
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus/internal/metastore"
+	"github.com/milvus-io/milvus/pkg/v3/kv/predicates"
 	"github.com/milvus-io/milvus/pkg/v3/mocks/mock_kv"
 	"github.com/milvus-io/milvus/pkg/v3/proto/streamingpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
-func TestCatalog(t *testing.T) {
-	kv := mock_kv.NewMockMetaKv(t)
+const (
+	canonicalCChannelMetaKeyForTest = "streamingcoord-meta/cchannel"
+	legacyCChannelMetaKeyForTest    = canonicalCChannelMetaKeyForTest + "/"
+	canonicalVersionKeyForTest      = "streamingcoord-meta/version"
+	legacyVersionKeyForTest         = canonicalVersionKeyForTest + "/"
+)
 
+func newTestCatalog(t *testing.T) (metastore.StreamingCoordCataLog, map[string]string, *mock_kv.MockMetaKv) {
+	kv := mock_kv.NewMockMetaKv(t)
 	kvStorage := make(map[string]string)
-	kv.EXPECT().Load(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, s string) (string, error) {
-		return kvStorage[s], nil
-	})
-	kv.EXPECT().LoadWithPrefix(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, s string) ([]string, []string, error) {
+	kv.EXPECT().Load(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, key string) (string, error) {
+		value, ok := kvStorage[key]
+		if !ok {
+			return "", merr.WrapErrIoKeyNotFound(key)
+		}
+		return value, nil
+	}).Maybe()
+	kv.EXPECT().LoadWithPrefix(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, prefix string) ([]string, []string, error) {
 		keys := make([]string, 0, len(kvStorage))
 		vals := make([]string, 0, len(kvStorage))
-		for k, v := range kvStorage {
-			if strings.HasPrefix(k, s) {
-				keys = append(keys, k)
-				vals = append(vals, v)
+		for key, value := range kvStorage {
+			if strings.HasPrefix(key, prefix) {
+				keys = append(keys, key)
+				vals = append(vals, value)
 			}
 		}
 		return keys, vals, nil
-	})
-	kv.EXPECT().MultiSave(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, kvs map[string]string) error {
-		for k, v := range kvs {
-			kvStorage[k] = v
+	}).Maybe()
+	kv.EXPECT().MultiLoad(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, keys []string) ([]string, error) {
+		values := make([]string, 0, len(keys))
+		missing := make([]string, 0)
+		for _, key := range keys {
+			value, ok := kvStorage[key]
+			if !ok {
+				missing = append(missing, key)
+			}
+			values = append(values, value)
 		}
+		if len(missing) > 0 {
+			return values, errors.New("missing keys")
+		}
+		return values, nil
+	}).Maybe()
+	kv.EXPECT().MultiSave(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, kvs map[string]string) error {
+		maps.Copy(kvStorage, kvs)
 		return nil
-	})
+	}).Maybe()
+	kv.EXPECT().MultiSaveAndRemove(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, saves map[string]string, removals []string, preds ...predicates.Predicate) error {
+		if len(preds) > 0 {
+			return merr.WrapErrServiceUnavailable("predicates not supported")
+		}
+		for _, key := range removals {
+			delete(kvStorage, key)
+		}
+		maps.Copy(kvStorage, saves)
+		return nil
+	}).Maybe()
 	kv.EXPECT().Save(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, key, value string) error {
 		kvStorage[key] = value
 		return nil
-	})
+	}).Maybe()
 	kv.EXPECT().Remove(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, key string) error {
 		delete(kvStorage, key)
 		return nil
-	})
+	}).Maybe()
+	return NewCataLog(kv), kvStorage, kv
+}
 
-	catalog := NewCataLog(kv)
+func TestCatalogMetaKeys(t *testing.T) {
+	assert.Equal(t, canonicalCChannelMetaKeyForTest, CChannelMetaKey)
+	assert.Equal(t, canonicalVersionKeyForTest, VersionKey)
+}
+
+func TestCatalog(t *testing.T) {
+	catalog, _, kv := newTestCatalog(t)
+
 	metas, err := catalog.ListPChannel(context.Background())
 	assert.NoError(t, err)
 	assert.Empty(t, metas)
@@ -129,20 +177,241 @@ func TestCatalog(t *testing.T) {
 	assert.Nil(t, tasks)
 }
 
-func TestCatalog_ReplicationCatalog(t *testing.T) {
-	kv := mock_kv.NewMockMetaKv(t)
-	kvStorage := make(map[string]string)
-	kv.EXPECT().Load(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, s string) (string, error) {
-		return kvStorage[s], nil
-	})
-	kv.EXPECT().MultiSave(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, kvs map[string]string) error {
-		for k, v := range kvs {
-			kvStorage[k] = v
-		}
-		return nil
+func TestCatalog_CChannelMetaKeyCompatibility(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("reads and repairs legacy key", func(t *testing.T) {
+		catalog, kvStorage, _ := newTestCatalog(t)
+		legacyValue, err := proto.Marshal(&streamingpb.CChannelMeta{Pchannel: "legacy-channel"})
+		require.NoError(t, err)
+		kvStorage[legacyCChannelMetaKeyForTest] = string(legacyValue)
+
+		cchannel, err := catalog.GetCChannel(ctx)
+
+		require.NoError(t, err)
+		require.NotNil(t, cchannel)
+		assert.Equal(t, "legacy-channel", cchannel.GetPchannel())
+		assert.Contains(t, kvStorage, canonicalCChannelMetaKeyForTest)
+		assert.NotContains(t, kvStorage, legacyCChannelMetaKeyForTest)
 	})
 
-	catalog := NewCataLog(kv)
+	t.Run("prefers canonical key", func(t *testing.T) {
+		catalog, kvStorage, _ := newTestCatalog(t)
+		canonicalValue, err := proto.Marshal(&streamingpb.CChannelMeta{Pchannel: "canonical-channel"})
+		require.NoError(t, err)
+		legacyValue, err := proto.Marshal(&streamingpb.CChannelMeta{Pchannel: "legacy-channel"})
+		require.NoError(t, err)
+		kvStorage[canonicalCChannelMetaKeyForTest] = string(canonicalValue)
+		kvStorage[legacyCChannelMetaKeyForTest] = string(legacyValue)
+
+		cchannel, err := catalog.GetCChannel(ctx)
+
+		require.NoError(t, err)
+		require.NotNil(t, cchannel)
+		assert.Equal(t, "canonical-channel", cchannel.GetPchannel())
+		assert.Contains(t, kvStorage, canonicalCChannelMetaKeyForTest)
+		assert.NotContains(t, kvStorage, legacyCChannelMetaKeyForTest)
+	})
+
+	t.Run("does not repair when only canonical key exists", func(t *testing.T) {
+		catalog, kvStorage, kv := newTestCatalog(t)
+		canonicalValue, err := proto.Marshal(&streamingpb.CChannelMeta{Pchannel: "canonical-channel"})
+		require.NoError(t, err)
+		kvStorage[canonicalCChannelMetaKeyForTest] = string(canonicalValue)
+
+		cchannel, err := catalog.GetCChannel(ctx)
+
+		require.NoError(t, err)
+		require.NotNil(t, cchannel)
+		assert.Equal(t, "canonical-channel", cchannel.GetPchannel())
+		kv.AssertNotCalled(t, "Remove", mock.Anything, legacyCChannelMetaKeyForTest)
+		kv.AssertNotCalled(t, "MultiSaveAndRemove", mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	t.Run("ignores child keys", func(t *testing.T) {
+		catalog, kvStorage, kv := newTestCatalog(t)
+		childValue, err := proto.Marshal(&streamingpb.CChannelMeta{Pchannel: "child-channel"})
+		require.NoError(t, err)
+		kvStorage[canonicalCChannelMetaKeyForTest+"/child"] = string(childValue)
+
+		cchannel, err := catalog.GetCChannel(ctx)
+
+		require.NoError(t, err)
+		assert.Nil(t, cchannel)
+		kv.AssertNotCalled(t, "Remove", mock.Anything, legacyCChannelMetaKeyForTest)
+		kv.AssertNotCalled(t, "MultiSaveAndRemove", mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	t.Run("save writes canonical key and removes legacy key", func(t *testing.T) {
+		catalog, kvStorage, _ := newTestCatalog(t)
+		legacyValue, err := proto.Marshal(&streamingpb.CChannelMeta{Pchannel: "legacy-channel"})
+		require.NoError(t, err)
+		kvStorage[legacyCChannelMetaKeyForTest] = string(legacyValue)
+
+		err = catalog.SaveCChannel(ctx, &streamingpb.CChannelMeta{Pchannel: "saved-channel"})
+
+		require.NoError(t, err)
+		assert.Contains(t, kvStorage, canonicalCChannelMetaKeyForTest)
+		assert.NotContains(t, kvStorage, legacyCChannelMetaKeyForTest)
+		cchannel, err := catalog.GetCChannel(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, cchannel)
+		assert.Equal(t, "saved-channel", cchannel.GetPchannel())
+	})
+
+	t.Run("keeps legacy key when read repair value is invalid", func(t *testing.T) {
+		catalog, kvStorage, _ := newTestCatalog(t)
+		kvStorage[legacyCChannelMetaKeyForTest] = "invalid"
+
+		cchannel, err := catalog.GetCChannel(ctx)
+
+		assert.Error(t, err)
+		assert.Nil(t, cchannel)
+		assert.NotContains(t, kvStorage, canonicalCChannelMetaKeyForTest)
+		assert.Contains(t, kvStorage, legacyCChannelMetaKeyForTest)
+	})
+
+	t.Run("does not fall back when canonical value is invalid", func(t *testing.T) {
+		catalog, kvStorage, _ := newTestCatalog(t)
+		legacyValue, err := proto.Marshal(&streamingpb.CChannelMeta{Pchannel: "legacy-channel"})
+		require.NoError(t, err)
+		kvStorage[canonicalCChannelMetaKeyForTest] = "invalid"
+		kvStorage[legacyCChannelMetaKeyForTest] = string(legacyValue)
+
+		cchannel, err := catalog.GetCChannel(ctx)
+
+		assert.Error(t, err)
+		assert.Nil(t, cchannel)
+		assert.Contains(t, kvStorage, canonicalCChannelMetaKeyForTest)
+		assert.Contains(t, kvStorage, legacyCChannelMetaKeyForTest)
+	})
+}
+
+func TestCatalog_VersionMetaKeyCompatibility(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("reads and repairs legacy key", func(t *testing.T) {
+		catalog, kvStorage, _ := newTestCatalog(t)
+		legacyValue, err := proto.Marshal(&streamingpb.StreamingVersion{Version: 1})
+		require.NoError(t, err)
+		kvStorage[legacyVersionKeyForTest] = string(legacyValue)
+
+		version, err := catalog.GetVersion(ctx)
+
+		require.NoError(t, err)
+		require.NotNil(t, version)
+		assert.Equal(t, int64(1), version.GetVersion())
+		assert.Contains(t, kvStorage, canonicalVersionKeyForTest)
+		assert.NotContains(t, kvStorage, legacyVersionKeyForTest)
+	})
+
+	t.Run("prefers canonical key", func(t *testing.T) {
+		catalog, kvStorage, _ := newTestCatalog(t)
+		canonicalValue, err := proto.Marshal(&streamingpb.StreamingVersion{Version: 2})
+		require.NoError(t, err)
+		legacyValue, err := proto.Marshal(&streamingpb.StreamingVersion{Version: 1})
+		require.NoError(t, err)
+		kvStorage[canonicalVersionKeyForTest] = string(canonicalValue)
+		kvStorage[legacyVersionKeyForTest] = string(legacyValue)
+
+		version, err := catalog.GetVersion(ctx)
+
+		require.NoError(t, err)
+		require.NotNil(t, version)
+		assert.Equal(t, int64(2), version.GetVersion())
+		assert.Contains(t, kvStorage, canonicalVersionKeyForTest)
+		assert.NotContains(t, kvStorage, legacyVersionKeyForTest)
+	})
+
+	t.Run("does not repair when only canonical key exists", func(t *testing.T) {
+		catalog, kvStorage, kv := newTestCatalog(t)
+		canonicalValue, err := proto.Marshal(&streamingpb.StreamingVersion{Version: 2})
+		require.NoError(t, err)
+		kvStorage[canonicalVersionKeyForTest] = string(canonicalValue)
+
+		version, err := catalog.GetVersion(ctx)
+
+		require.NoError(t, err)
+		require.NotNil(t, version)
+		assert.Equal(t, int64(2), version.GetVersion())
+		kv.AssertNotCalled(t, "Remove", mock.Anything, legacyVersionKeyForTest)
+		kv.AssertNotCalled(t, "MultiSaveAndRemove", mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	t.Run("reads empty canonical value", func(t *testing.T) {
+		catalog, kvStorage, _ := newTestCatalog(t)
+		canonicalValue, err := proto.Marshal(&streamingpb.StreamingVersion{})
+		require.NoError(t, err)
+		kvStorage[canonicalVersionKeyForTest] = string(canonicalValue)
+
+		version, err := catalog.GetVersion(ctx)
+
+		require.NoError(t, err)
+		require.NotNil(t, version)
+		assert.Equal(t, int64(0), version.GetVersion())
+	})
+
+	t.Run("ignores child keys", func(t *testing.T) {
+		catalog, kvStorage, kv := newTestCatalog(t)
+		childValue, err := proto.Marshal(&streamingpb.StreamingVersion{Version: 3})
+		require.NoError(t, err)
+		kvStorage[canonicalVersionKeyForTest+"/child"] = string(childValue)
+
+		version, err := catalog.GetVersion(ctx)
+
+		require.NoError(t, err)
+		assert.Nil(t, version)
+		kv.AssertNotCalled(t, "Remove", mock.Anything, legacyVersionKeyForTest)
+		kv.AssertNotCalled(t, "MultiSaveAndRemove", mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	t.Run("save writes canonical key and removes legacy key", func(t *testing.T) {
+		catalog, kvStorage, _ := newTestCatalog(t)
+		legacyValue, err := proto.Marshal(&streamingpb.StreamingVersion{Version: 1})
+		require.NoError(t, err)
+		kvStorage[legacyVersionKeyForTest] = string(legacyValue)
+
+		err = catalog.SaveVersion(ctx, &streamingpb.StreamingVersion{Version: 2})
+
+		require.NoError(t, err)
+		assert.Contains(t, kvStorage, canonicalVersionKeyForTest)
+		assert.NotContains(t, kvStorage, legacyVersionKeyForTest)
+		version, err := catalog.GetVersion(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, version)
+		assert.Equal(t, int64(2), version.GetVersion())
+	})
+
+	t.Run("keeps legacy key when read repair value is invalid", func(t *testing.T) {
+		catalog, kvStorage, _ := newTestCatalog(t)
+		kvStorage[legacyVersionKeyForTest] = "invalid"
+
+		version, err := catalog.GetVersion(ctx)
+
+		assert.Error(t, err)
+		assert.Nil(t, version)
+		assert.NotContains(t, kvStorage, canonicalVersionKeyForTest)
+		assert.Contains(t, kvStorage, legacyVersionKeyForTest)
+	})
+
+	t.Run("does not fall back when canonical value is invalid", func(t *testing.T) {
+		catalog, kvStorage, _ := newTestCatalog(t)
+		legacyValue, err := proto.Marshal(&streamingpb.StreamingVersion{Version: 1})
+		require.NoError(t, err)
+		kvStorage[canonicalVersionKeyForTest] = "invalid"
+		kvStorage[legacyVersionKeyForTest] = string(legacyValue)
+
+		version, err := catalog.GetVersion(ctx)
+
+		assert.Error(t, err)
+		assert.Nil(t, version)
+		assert.Contains(t, kvStorage, canonicalVersionKeyForTest)
+		assert.Contains(t, kvStorage, legacyVersionKeyForTest)
+	})
+}
+
+func TestCatalog_ReplicationCatalog(t *testing.T) {
+	catalog, _, _ := newTestCatalog(t)
 
 	// ReplicateConfiguration test
 	config := &commonpb.ReplicateConfiguration{


### PR DESCRIPTION
issue: #49377
pr: #49448

PR https://github.com/milvus-io/milvus/pull/48053 changed the StreamingCoord meta prefix handling and caused singleton meta keys such as cchannel and version to be written with trailing slashes in affected builds.

The current impact is not severe, but this keeps the meta implementation aligned with the historical canonical key format while remaining compatible with already-written trailing-slash keys.