### PR TITLE
fix: [2.6] dispatch reopen segment tasks in querycoord

### DIFF
--- a/internal/querycoordv2/task/executor.go
+++ b/internal/querycoordv2/task/executor.go
@@ -231,7 +231,7 @@ func (ex *Executor) removeTask(task Task, step int) {
 
 func (ex *Executor) executeSegmentAction(task *SegmentTask, step int) {
 	switch task.Actions()[step].Type() {
-	case ActionTypeGrow, ActionTypeUpdate, ActionTypeStatsUpdate:
+	case ActionTypeGrow, ActionTypeUpdate, ActionTypeStatsUpdate, ActionTypeReopen:
 		ex.loadSegment(task, step)
 
 	case ActionTypeReduce:

--- a/internal/querycoordv2/task/task_test.go
+++ b/internal/querycoordv2/task/task_test.go
@@ -178,6 +178,7 @@ func (suite *TaskSuite) BeforeTest(suiteName, testName string) {
 	case "TestSubscribeChannelTask",
 		"TestUnsubscribeChannelTask",
 		"TestLoadSegmentTask",
+		"TestLoadSegmentReopenTask",
 		"TestLoadSegmentTaskNotIndex",
 		"TestLoadSegmentTaskFailed",
 		"TestTaskCanceled",
@@ -532,6 +533,110 @@ func (suite *TaskSuite) TestLoadSegmentTask() {
 		suite.Equal(TaskStatusSucceeded, task.Status())
 		suite.NoError(task.Err())
 	}
+}
+
+func (suite *TaskSuite) TestLoadSegmentReopenTask() {
+	ctx := context.Background()
+	timeout := 10 * time.Second
+	targetNode := int64(3)
+	partition := int64(100)
+	segmentID := suite.loadSegments[0]
+	channel := &datapb.VchannelInfo{
+		CollectionID: suite.collection,
+		ChannelName:  Params.CommonCfg.RootCoordDml.GetValue() + "-test",
+	}
+
+	suite.broker.EXPECT().DescribeCollection(mock.Anything, suite.collection).RunAndReturn(func(ctx context.Context, i int64) (*milvuspb.DescribeCollectionResponse, error) {
+		return &milvuspb.DescribeCollectionResponse{
+			Schema: &schemapb.CollectionSchema{
+				Name: "TestLoadSegmentReopenTask",
+				Fields: []*schemapb.FieldSchema{
+					{FieldID: 100, Name: "vec", DataType: schemapb.DataType_FloatVector},
+				},
+			},
+		}, nil
+	})
+	suite.broker.EXPECT().ListIndexes(mock.Anything, suite.collection).Return([]*indexpb.IndexInfo{
+		{
+			CollectionID: suite.collection,
+		},
+	}, nil)
+	suite.broker.EXPECT().GetSegmentInfo(mock.Anything, segmentID).Return([]*datapb.SegmentInfo{
+		{
+			ID:            segmentID,
+			CollectionID:  suite.collection,
+			PartitionID:   partition,
+			InsertChannel: channel.ChannelName,
+		},
+	}, nil)
+	suite.broker.EXPECT().GetIndexInfo(mock.Anything, suite.collection, segmentID).Return(nil, nil)
+	suite.cluster.EXPECT().LoadSegments(mock.Anything, targetNode, mock.MatchedBy(func(req *querypb.LoadSegmentsRequest) bool {
+		return req.GetLoadScope() == querypb.LoadScope_Reopen &&
+			req.GetDstNodeID() == targetNode &&
+			len(req.GetInfos()) == 1 &&
+			req.GetInfos()[0].GetSegmentID() == segmentID
+	})).Return(merr.Success(), nil)
+
+	suite.dist.ChannelDistManager.Update(targetNode, &meta.DmChannel{
+		VchannelInfo: channel,
+		Node:         targetNode,
+		Version:      1,
+		View: &meta.LeaderView{
+			ID:           targetNode,
+			CollectionID: suite.collection,
+			Channel:      channel.ChannelName,
+			Status:       &querypb.LeaderViewStatus{Serviceable: true},
+		},
+	})
+
+	segment := &datapb.SegmentInfo{
+		ID:            segmentID,
+		CollectionID:  suite.collection,
+		InsertChannel: channel.ChannelName,
+		PartitionID:   1,
+	}
+	task, err := NewSegmentTask(
+		ctx,
+		timeout,
+		WrapIDSource(0),
+		suite.collection,
+		suite.replica,
+		commonpb.LoadPriority_LOW,
+		NewSegmentAction(targetNode, ActionTypeReopen, channel.GetChannelName(), segmentID),
+	)
+	suite.NoError(err)
+	err = suite.scheduler.Add(task)
+	suite.NoError(err)
+
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection).Return([]*datapb.VchannelInfo{channel}, []*datapb.SegmentInfo{segment}, nil)
+	suite.target.UpdateCollectionNextTarget(ctx, suite.collection)
+	suite.AssertTaskNum(0, 1, 0, 1)
+
+	suite.dispatchAndWait(targetNode)
+	suite.assertExecutedFlagChan(targetNode)
+	suite.AssertTaskNum(1, 0, 0, 1)
+
+	suite.dist.ChannelDistManager.Update(targetNode, &meta.DmChannel{
+		VchannelInfo: &datapb.VchannelInfo{
+			CollectionID: suite.collection,
+			ChannelName:  channel.ChannelName,
+		},
+		Node:    targetNode,
+		Version: 1,
+		View: &meta.LeaderView{
+			ID:           targetNode,
+			CollectionID: suite.collection,
+			Segments: map[int64]*querypb.SegmentDist{
+				segmentID: &querypb.SegmentDist{NodeID: targetNode, Version: 0},
+			},
+			Channel: channel.ChannelName,
+		},
+	})
+	suite.dist.SegmentDistManager.Update(targetNode, meta.SegmentFromInfo(segment))
+	suite.dispatchAndWait(targetNode)
+	suite.AssertTaskNum(0, 0, 0, 0)
+	suite.Equal(TaskStatusSucceeded, task.Status())
+	suite.NoError(task.Err())
 }
 
 func (suite *TaskSuite) TestLoadSegmentTaskNotIndex() {

--- a/internal/querycoordv2/task/task_test.go
+++ b/internal/querycoordv2/task/task_test.go
@@ -627,7 +627,7 @@ func (suite *TaskSuite) TestLoadSegmentReopenTask() {
 			ID:           targetNode,
 			CollectionID: suite.collection,
 			Segments: map[int64]*querypb.SegmentDist{
-				segmentID: &querypb.SegmentDist{NodeID: targetNode, Version: 0},
+				segmentID: {NodeID: targetNode, Version: 0},
 			},
 			Channel: channel.ChannelName,
 		},

--- a/internal/querycoordv2/task/utils.go
+++ b/internal/querycoordv2/task/utils.go
@@ -97,7 +97,7 @@ func GetTaskType(task Task) Type {
 		return TaskTypeGrow
 	case task.Actions()[0].Type() == ActionTypeReduce:
 		return TaskTypeReduce
-	case task.Actions()[0].Type() == ActionTypeUpdate:
+	case task.Actions()[0].Type() == ActionTypeUpdate || task.Actions()[0].Type() == ActionTypeReopen:
 		return TaskTypeUpdate
 	case task.Actions()[0].Type() == ActionTypeStatsUpdate:
 		return TaskTypeStatsUpdate

--- a/internal/querycoordv2/task/utils_test.go
+++ b/internal/querycoordv2/task/utils_test.go
@@ -92,6 +92,48 @@ func (s *UtilsSuite) TestPackLoadSegmentRequest() {
 	}
 }
 
+func (s *UtilsSuite) TestGetTaskTypeReopen() {
+	action := NewSegmentAction(1, ActionTypeReopen, "test-ch", 100)
+	task, err := NewSegmentTask(
+		context.Background(),
+		time.Second,
+		nil,
+		1,
+		newReplicaDefaultRG(10),
+		commonpb.LoadPriority_LOW,
+		action,
+	)
+	s.NoError(err)
+
+	s.Equal(TaskTypeUpdate, GetTaskType(task))
+}
+
+func (s *UtilsSuite) TestPackLoadSegmentRequestReopen() {
+	action := NewSegmentAction(1, ActionTypeReopen, "test-ch", 100)
+	task, err := NewSegmentTask(
+		context.Background(),
+		time.Second,
+		nil,
+		1,
+		newReplicaDefaultRG(10),
+		commonpb.LoadPriority_LOW,
+		action,
+	)
+	s.NoError(err)
+
+	req := packLoadSegmentRequest(
+		task,
+		action,
+		&schemapb.CollectionSchema{},
+		nil,
+		&querypb.LoadMetaInfo{LoadType: querypb.LoadType_LoadCollection},
+		&querypb.SegmentLoadInfo{},
+		nil,
+	)
+
+	s.Equal(querypb.LoadScope_Reopen, req.GetLoadScope())
+}
+
 func (s *UtilsSuite) TestPackLoadSegmentRequestMmapDuplicateBug() {
 	// This test demonstrates the bug where mmap.enabled is appended twice to field TypeParams
 	ctx := context.Background()

--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -519,8 +519,7 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 	}
 	log.Debug("work loads segments done")
 
-	// load index segment need no stream delete and distribution change
-	if req.GetLoadScope() == querypb.LoadScope_Index {
+	if req.GetLoadScope() == querypb.LoadScope_Index || req.GetLoadScope() == querypb.LoadScope_Reopen {
 		return nil
 	}
 

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -694,6 +694,52 @@ func (s *DelegatorDataSuite) TestLoadSegments() {
 		}, segmentEntryCoreFields(sealed[0].Segments))
 	})
 
+	s.Run("load_scope_reopen_skips_post_load", func() {
+		defer func() {
+			s.workerManager.ExpectedCalls = nil
+			s.loader.ExpectedCalls = nil
+		}()
+
+		workers := make(map[int64]*cluster.MockWorker)
+		worker1 := &cluster.MockWorker{}
+		workers[1] = worker1
+
+		worker1.EXPECT().LoadSegments(mock.Anything, mock.MatchedBy(func(req *querypb.LoadSegmentsRequest) bool {
+			return req.GetLoadScope() == querypb.LoadScope_Reopen
+		})).Return(nil)
+		s.workerManager.EXPECT().GetWorker(mock.Anything, mock.AnythingOfType("int64")).Call.Return(func(_ context.Context, nodeID int64) cluster.Worker {
+			return workers[nodeID]
+		}, nil)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		err := s.delegator.LoadSegments(ctx, &querypb.LoadSegmentsRequest{
+			Base:         commonpbutil.NewMsgBase(),
+			DstNodeID:    1,
+			CollectionID: s.collectionID,
+			LoadScope:    querypb.LoadScope_Reopen,
+			Infos: []*querypb.SegmentLoadInfo{
+				{
+					SegmentID:     101,
+					PartitionID:   500,
+					StartPosition: &msgpb.MsgPosition{Timestamp: 20000},
+					DeltaPosition: &msgpb.MsgPosition{Timestamp: 20000},
+					Level:         datapb.SegmentLevel_L1,
+					InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", s.collectionID),
+				},
+			},
+		})
+
+		s.NoError(err)
+		sealed, _ := s.delegator.GetSegmentInfo(false)
+		hasReopenSegment := lo.SomeBy(sealed, func(info SnapshotItem) bool {
+			return lo.SomeBy(info.Segments, func(segment SegmentEntry) bool {
+				return segment.SegmentID == 101
+			})
+		})
+		s.False(hasReopenSegment)
+	})
+
 	s.Run("load_segments_with_delete", func() {
 		defer func() {
 			s.workerManager.ExpectedCalls = nil


### PR DESCRIPTION
Backport part of:
pr: #49005
Related to #49424

Route ActionTypeReopen through the existing load segment path so reopen tasks send LoadScope_Reopen RPCs and release executor capacity. Classify reopen tasks as update tasks, skip delegator post-load handling for reopen, and add regression coverage for the dispatch and request scope.