### PR TITLE
fix: [3.0] use overwrite resolver for manifest updates (#49467)

### DIFF
--- a/internal/datanode/compactor/l0_compactor.go
+++ b/internal/datanode/compactor/l0_compactor.go
@@ -310,7 +310,7 @@ func (t *LevelZeroCompactionTask) splitAndWrite(
 			// Check if this is a V2 segment (has manifest)
 			if segment.GetManifest() != "" {
 				// V2: Update manifest with new deltalog
-				newManifest, err := packed.AddDeltaLogsToManifest(
+				newManifest, err := packed.AddDeltaLogsToManifestOverwrite(
 					segment.GetManifest(),
 					t.compactionParams.StorageConfig,
 					[]packed.DeltaLogEntry{{Path: path, NumEntries: int64(len(deletes.pks))}},

--- a/internal/storagev2/packed/transaction.go
+++ b/internal/storagev2/packed/transaction.go
@@ -67,6 +67,24 @@ func AddDeltaLogsToManifest(
 	storageConfig *indexpb.StorageConfig,
 	deltaLogs []DeltaLogEntry,
 ) (string, error) {
+	return addDeltaLogsToManifest(manifestPath, storageConfig, deltaLogs, C.int32_t(0))
+}
+
+// AddDeltaLogsToManifestOverwrite adds delta logs using overwrite conflict resolution.
+func AddDeltaLogsToManifestOverwrite(
+	manifestPath string,
+	storageConfig *indexpb.StorageConfig,
+	deltaLogs []DeltaLogEntry,
+) (string, error) {
+	return addDeltaLogsToManifest(manifestPath, storageConfig, deltaLogs, C.LOON_TRANSACTION_RESOLVE_OVERWRITE)
+}
+
+func addDeltaLogsToManifest(
+	manifestPath string,
+	storageConfig *indexpb.StorageConfig,
+	deltaLogs []DeltaLogEntry,
+	resolveID C.int32_t,
+) (string, error) {
 	if len(deltaLogs) == 0 {
 		return manifestPath, nil
 	}
@@ -92,7 +110,7 @@ func AddDeltaLogsToManifest(
 
 	// Start transaction
 	var transactionHandle C.LoonTransactionHandle
-	result := C.loon_transaction_begin(cBasePath, cProperties, C.int64_t(version), C.int32_t(0) /* resolve_id */, getRetryLimit() /* retry_limit */, &transactionHandle)
+	result := C.loon_transaction_begin(cBasePath, cProperties, C.int64_t(version), resolveID /* resolve_id */, getRetryLimit() /* retry_limit */, &transactionHandle)
 	if err := HandleLoonFFIResult(result); err != nil {
 		return "", fmt.Errorf("failed to begin transaction: %w", err)
 	}
@@ -221,7 +239,7 @@ func AddStatsToManifest(
 	defer C.free(unsafe.Pointer(cBasePath))
 
 	var transactionHandle C.LoonTransactionHandle
-	result := C.loon_transaction_begin(cBasePath, cProperties, C.int64_t(version), C.int32_t(0) /* resolve_id */, getRetryLimit() /* retry_limit */, &transactionHandle)
+	result := C.loon_transaction_begin(cBasePath, cProperties, C.int64_t(version), C.LOON_TRANSACTION_RESOLVE_OVERWRITE /* resolve_id */, getRetryLimit() /* retry_limit */, &transactionHandle)
 	if err := HandleLoonFFIResult(result); err != nil {
 		return "", fmt.Errorf("failed to begin transaction: %w", err)
 	}


### PR DESCRIPTION
Cherry-pick from master
pr: #49467
Related to #49457 #49462

Use overwrite conflict resolution when adding L0 compaction deltalogs and manifest stats so these updates commit from their base manifest version.