### PR TITLE
enhance: [cp3.0]Add GetReplicateConfiguration Go client API

### DIFF
--- a/client/milvusclient/replicate.go
+++ b/client/milvusclient/replicate.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"google.golang.org/grpc"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
@@ -18,6 +19,20 @@ func (c *Client) UpdateReplicateConfiguration(ctx context.Context, req *milvuspb
 		return merr.CheckRPCCall(resp, err)
 	})
 	return err
+}
+
+// GetReplicateConfiguration gets the current replicate configuration from the Milvus cluster.
+func (c *Client) GetReplicateConfiguration(ctx context.Context, opts ...grpc.CallOption) (*commonpb.ReplicateConfiguration, error) {
+	var config *commonpb.ReplicateConfiguration
+	err := c.callService(func(milvusService milvuspb.MilvusServiceClient) error {
+		resp, err := milvusService.GetReplicateConfiguration(ctx, &milvuspb.GetReplicateConfigurationRequest{}, opts...)
+		if err := merr.CheckRPCCall(resp, err); err != nil {
+			return err
+		}
+		config = resp.GetConfiguration()
+		return nil
+	})
+	return config, err
 }
 
 // GetReplicateInfo gets replicate information from the Milvus cluster

--- a/client/milvusclient/replicate_test.go
+++ b/client/milvusclient/replicate_test.go
@@ -1,0 +1,88 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package milvusclient
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+)
+
+type ReplicateSuite struct {
+	MockSuiteBase
+}
+
+func (s *ReplicateSuite) TestGetReplicateConfiguration() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s.Run("success", func() {
+		expectedConfig := &commonpb.ReplicateConfiguration{
+			Clusters: []*commonpb.MilvusCluster{
+				{
+					ClusterId: "source-cluster",
+					Pchannels: []string{"source-channel-1"},
+					ConnectionParam: &commonpb.ConnectionParam{
+						Uri: "localhost:19530",
+					},
+				},
+				{
+					ClusterId: "target-cluster",
+					Pchannels: []string{"target-channel-1"},
+					ConnectionParam: &commonpb.ConnectionParam{
+						Uri: "localhost:19531",
+					},
+				},
+			},
+			CrossClusterTopology: []*commonpb.CrossClusterTopology{
+				{SourceClusterId: "source-cluster", TargetClusterId: "target-cluster"},
+			},
+		}
+
+		s.mock.EXPECT().GetReplicateConfiguration(mock.Anything, mock.Anything).RunAndReturn(
+			func(ctx context.Context, req *milvuspb.GetReplicateConfigurationRequest) (*milvuspb.GetReplicateConfigurationResponse, error) {
+				s.NotNil(req)
+				return &milvuspb.GetReplicateConfigurationResponse{
+					Status:        merr.Success(),
+					Configuration: expectedConfig,
+				}, nil
+			}).Once()
+
+		config, err := s.client.GetReplicateConfiguration(ctx)
+		s.NoError(err)
+		s.True(proto.Equal(expectedConfig, config))
+	})
+
+	s.Run("failure", func() {
+		s.mock.EXPECT().GetReplicateConfiguration(mock.Anything, mock.Anything).
+			Return(nil, merr.WrapErrServiceInternal("mocked")).Once()
+
+		_, err := s.client.GetReplicateConfiguration(ctx)
+		s.Error(err)
+	})
+}
+
+func TestReplicate(t *testing.T) {
+	suite.Run(t, new(ReplicateSuite))
+}


### PR DESCRIPTION
Cherry-pick from master (PR still open)

pr: #49481
issue: #47392

## Summary

Cherry-picked from master PR #49481 (open - preemptive backport).

**Note**: Original PR is still open. This CP PR should be updated if the original PR changes.

## Verification

- [x] File count matches original PR
- [x] Code changes verified
- [x] No conflict markers
- [x] `git diff --cached --check`
- [x] `env GOROOT=/opt/homebrew/Cellar/go@1.25/1.25.9/libexec go test ./milvusclient -run TestReplicate/TestGetReplicateConfiguration`
