### PR TITLE
fix: [2.6] bump lz4_flex for CVE-2026-32829

### DIFF
--- a/internal/core/thirdparty/tantivy/tantivy-binding/Cargo.lock
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/Cargo.lock
@@ -2750,9 +2750,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
 
 [[package]]
 name = "maplit"


### PR DESCRIPTION
## Summary
- Upgrade Rust `lz4_flex` in the Tantivy binding lockfile to 0.11.6 to remediate CVE-2026-32829.
- Backport the master dependency-only security fix to 2.6.

## Test plan
- [x] `cargo tree --manifest-path internal/core/thirdparty/tantivy/tantivy-binding/Cargo.toml -i lz4_flex --locked`
- [x] `SDKROOT=$(xcrun --show-sdk-path) cargo check --manifest-path internal/core/thirdparty/tantivy/tantivy-binding/Cargo.toml --locked`

issue: #49472
pr: #49505

🤖 Generated with [Claude Code](https://claude.com/claude-code)