### PR TITLE
fix: update GPU Docker images to CUDA 12.9

### DIFF
--- a/.env
+++ b/.env
@@ -5,11 +5,11 @@ IMAGE_ARCH=amd64
 OS_NAME=ubuntu22.04
 
 # for services.builder.image in docker-compose.yml
-DATE_VERSION=20260427-3ae4cb2
-LATEST_DATE_VERSION=20260427-3ae4cb2
+DATE_VERSION=20260506-b5f57d9
+LATEST_DATE_VERSION=20260506-b5f57d9
 # for services.gpubuilder.image in docker-compose.yml
-GPU_DATE_VERSION=20260427-3ae4cb2
-LATEST_GPU_DATE_VERSION=20260427-3ae4cb2
+GPU_DATE_VERSION=20260506-b5f57d9
+LATEST_GPU_DATE_VERSION=20260506-b5f57d9
 
 # for other services in docker-compose.yml
 MINIO_ADDRESS=minio:9000
@@ -17,4 +17,3 @@ PULSAR_ADDRESS=pulsar://pulsar:6650
 ETCD_ENDPOINTS=etcd:2379
 AZURITE_CONNECTION_STRING="DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;"
 ENABLE_GCP_NATIVE=ON
-

--- a/build/docker/builder/gpu/ubuntu22.04/Dockerfile
+++ b/build/docker/builder/gpu/ubuntu22.04/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.8.0-devel-ubuntu22.04 as builder
+FROM nvidia/cuda:12.9.1-devel-ubuntu22.04 as builder
 
 ARG TARGETARCH
 

--- a/build/docker/milvus/gpu/ubuntu22.04/Dockerfile
+++ b/build/docker/milvus/gpu/ubuntu22.04/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.8.0-runtime-ubuntu22.04
+FROM nvidia/cuda:12.9.1-runtime-ubuntu22.04
 
 ARG TARGETARCH
 


### PR DESCRIPTION
## Summary
- Update the supported Ubuntu 22.04 GPU builder and runtime images from CUDA 11.8.0 to CUDA 12.9.1.
- Drop Ubuntu 20.04 GPU compatibility from this CUDA 12.9 update path.
- Align Milvus GPU Docker images with Knowhere v3.0.1 / cuVS 26.02, which officially supports CUDA 12.9+.

issue: #49515

## Test plan
- [x] `git diff --check`
- [x] `docker manifest inspect nvidia/cuda:12.9.1-devel-ubuntu22.04`
- [x] `docker manifest inspect nvidia/cuda:12.9.1-runtime-ubuntu22.04`
- [x] `ci-v2/build`
- [x] `ci-v2/code-check`
- [x] `ci-v2/ut-go`
- [x] `ci-v2/ut-cpp`
- [x] `ci-v2/integration-test`
- [x] `ci-v2/e2e-default`
- [x] `ci-v2/go-sdk`
- [x] `ci-v2/build-ut-cov`
