### PR TITLE
fix: reuse resolved field ids for binlog load info

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -5058,6 +5058,7 @@ ChunkedSegmentSealedImpl::LoadBatchFieldData(
         LoadFieldDataInfo load_field_data_info;
         load_field_data_info.storage_version =
             load_info_snapshot->GetStorageVersion();
+        bool has_child_fields = field_binlog.child_fields_size() > 0;
         auto fields_to_load = field_ids;
         AssertInfo(!fields_to_load.empty(),
                    "load field data with empty field list");
@@ -5128,6 +5129,12 @@ ChunkedSegmentSealedImpl::LoadBatchFieldData(
         // Build FieldBinlogInfo
         FieldBinlogInfo field_binlog_info;
         field_binlog_info.field_id = group_id;
+        if (has_child_fields) {
+            field_binlog_info.child_field_ids.reserve(fields_to_load.size());
+            for (const auto& field_id : fields_to_load) {
+                field_binlog_info.child_field_ids.push_back(field_id.get());
+            }
+        }
 
         // Calculate total row count and collect binlog paths
         int64_t total_entries = 0;

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -5054,6 +5054,7 @@ ChunkedSegmentSealedImpl::LoadBatchFieldData(
 
     auto load_info_snapshot = std::atomic_load(&segment_load_info_);
     std::map<FieldId, LoadFieldDataInfo> field_data_to_load;
+    std::map<FieldId, std::vector<int64_t>> child_field_ids_by_group;
     for (auto& [field_ids, field_binlog] : field_binlog_to_load) {
         LoadFieldDataInfo load_field_data_info;
         load_field_data_info.storage_version =
@@ -5130,9 +5131,15 @@ ChunkedSegmentSealedImpl::LoadBatchFieldData(
         FieldBinlogInfo field_binlog_info;
         field_binlog_info.field_id = group_id;
         if (has_child_fields) {
-            field_binlog_info.child_field_ids.reserve(fields_to_load.size());
+            auto& merged_child_field_ids =
+                child_field_ids_by_group[FieldId(group_id)];
             for (const auto& field_id : fields_to_load) {
-                field_binlog_info.child_field_ids.push_back(field_id.get());
+                auto child_field_id = field_id.get();
+                if (std::find(merged_child_field_ids.begin(),
+                              merged_child_field_ids.end(),
+                              child_field_id) == merged_child_field_ids.end()) {
+                    merged_child_field_ids.push_back(child_field_id);
+                }
             }
         }
 
@@ -5166,6 +5173,19 @@ ChunkedSegmentSealedImpl::LoadBatchFieldData(
         load_field_data_info.field_infos[group_id] = field_binlog_info;
 
         field_data_to_load[FieldId(group_id)] = load_field_data_info;
+    }
+
+    for (const auto& [group_id, child_field_ids] : child_field_ids_by_group) {
+        auto load_iter = field_data_to_load.find(group_id);
+        if (load_iter == field_data_to_load.end()) {
+            continue;
+        }
+        auto field_info_iter =
+            load_iter->second.field_infos.find(group_id.get());
+        if (field_info_iter == load_iter->second.field_infos.end()) {
+            continue;
+        }
+        field_info_iter->second.child_field_ids = child_field_ids;
     }
 
     auto& pool = ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::MIDDLE);

--- a/internal/core/src/segcore/ChunkedSegmentSealedStorageV2Test.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedStorageV2Test.cpp
@@ -242,6 +242,47 @@ INSTANTIATE_TEST_SUITE_P(TestChunkSegmentStorageV2,
                          TestChunkSegmentStorageV2,
                          testing::Bool());
 
+TEST_P(TestChunkSegmentStorageV2,
+       LoadBatchFieldDataMergesDuplicateGroupChildIds) {
+    auto fresh_segment = segcore::CreateSealedSegment(
+        schema_, nullptr, -1, segcore::SegcoreConfig::default_config(), true);
+    auto* sealed = dynamic_cast<ChunkedSegmentSealedImpl*>(fresh_segment.get());
+    ASSERT_NE(sealed, nullptr);
+
+    proto::segcore::SegmentLoadInfo segment_load_info;
+    segment_load_info.set_segmentid(100);
+    segment_load_info.set_num_of_rows(chunk_num * test_data_count);
+    segment_load_info.set_storageversion(2);
+    sealed->SetLoadInfo(segment_load_info);
+
+    auto int64_field = fields.at("int64");
+    auto pk_field = fields.at("pk");
+    constexpr int64_t group_id = 0;
+    const auto& group_info = load_info_.field_infos.at(group_id);
+    ASSERT_FALSE(group_info.insert_files.empty());
+
+    proto::segcore::FieldBinlog group_binlog;
+    group_binlog.set_fieldid(group_id);
+    group_binlog.add_child_fields(int64_field.get());
+    group_binlog.add_child_fields(pk_field.get());
+    auto* binlog = group_binlog.add_binlogs();
+    binlog->set_log_path(group_info.insert_files[0]);
+    binlog->set_entries_num(group_info.row_count);
+    binlog->set_memory_size(1);
+
+    std::vector<std::pair<std::vector<FieldId>, proto::segcore::FieldBinlog>>
+        binlogs_to_load;
+    binlogs_to_load.emplace_back(std::vector<FieldId>{int64_field},
+                                 group_binlog);
+    binlogs_to_load.emplace_back(std::vector<FieldId>{pk_field}, group_binlog);
+
+    milvus::tracer::TraceContext trace_ctx;
+    sealed->LoadBatchFieldData(trace_ctx, binlogs_to_load);
+
+    EXPECT_TRUE(sealed->HasFieldData(int64_field));
+    EXPECT_TRUE(sealed->HasFieldData(pk_field));
+}
+
 TEST_P(TestChunkSegmentStorageV2, TestTermExpr) {
     bool pk_is_string = GetParam();
     // query int64 expr

--- a/internal/core/src/segcore/ChunkedSegmentSealedStorageV2Test.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedStorageV2Test.cpp
@@ -261,23 +261,19 @@ TEST_P(TestChunkSegmentStorageV2,
     const auto& group_info = load_info_.field_infos.at(group_id);
     ASSERT_FALSE(group_info.insert_files.empty());
 
-    proto::segcore::FieldBinlog group_binlog;
-    group_binlog.set_fieldid(group_id);
-    group_binlog.add_child_fields(int64_field.get());
-    group_binlog.add_child_fields(pk_field.get());
-    auto* binlog = group_binlog.add_binlogs();
-    binlog->set_log_path(group_info.insert_files[0]);
-    binlog->set_entries_num(group_info.row_count);
-    binlog->set_memory_size(1);
+    auto add_group_binlog = [&](FieldId child_field) {
+        auto* group_binlog = segment_load_info.add_binlog_paths();
+        group_binlog->set_fieldid(group_id);
+        group_binlog->add_child_fields(child_field.get());
+        auto* binlog = group_binlog->add_binlogs();
+        binlog->set_log_path(group_info.insert_files[0]);
+        binlog->set_entries_num(group_info.row_count);
+        binlog->set_memory_size(1);
+    };
+    add_group_binlog(int64_field);
+    add_group_binlog(pk_field);
 
-    std::vector<std::pair<std::vector<FieldId>, proto::segcore::FieldBinlog>>
-        binlogs_to_load;
-    binlogs_to_load.emplace_back(std::vector<FieldId>{int64_field},
-                                 group_binlog);
-    binlogs_to_load.emplace_back(std::vector<FieldId>{pk_field}, group_binlog);
-
-    milvus::tracer::TraceContext trace_ctx;
-    sealed->LoadBatchFieldData(trace_ctx, binlogs_to_load);
+    sealed->Reopen(nullptr, segment_load_info);
 
     EXPECT_TRUE(sealed->HasFieldData(int64_field));
     EXPECT_TRUE(sealed->HasFieldData(pk_field));


### PR DESCRIPTION
issue: #49526

### What
- Reuse field ids already resolved by `LoadDiff` in `LoadBatchFieldData` instead of appending child fields again.
- Propagate resolved child field ids into `FieldBinlogInfo` so downstream StorageV2 loading can avoid reopening parquet metadata to resolve column-group fields.

### Why
`field_ids` may already be populated before `LoadBatchFieldData`; appending `child_fields` again can duplicate fields like `101,101`, causing repeated field loads. Passing the resolved field ids through `FieldBinlogInfo` also avoids the slow fallback path in `load_column_group_data_internal`.