### PR TITLE
fix: Compact nullable vector take output

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -5207,7 +5207,17 @@ ChunkedSegmentSealedImpl::ArrowToDataArray(
             auto vectors = data_array->mutable_vectors();
             vectors->set_dim(dim);
             auto float_data = vectors->mutable_float_vector();
-            float_data->mutable_data()->Resize(size * dim, 0.0f);
+            int64_t valid_count = size;
+            if (field_meta.is_nullable()) {
+                valid_count = 0;
+                for (int64_t i = 0; i < size; i++) {
+                    if (arr->IsValid(result_mapping[i])) {
+                        valid_count++;
+                    }
+                }
+            }
+            float_data->mutable_data()->Resize(valid_count * dim, 0.0f);
+            int64_t data_pos = 0;
             for (int64_t i = 0; i < size; i++) {
                 auto idx = result_mapping[i];
                 if (arr->IsNull(idx)) {
@@ -5227,7 +5237,9 @@ ChunkedSegmentSealedImpl::ArrowToDataArray(
                 auto floats = reinterpret_cast<const float*>(val);
                 std::copy(floats,
                           floats + dim,
-                          float_data->mutable_data()->mutable_data() + i * dim);
+                          float_data->mutable_data()->mutable_data() +
+                              data_pos * dim);
+                data_pos++;
             }
             break;
         }

--- a/internal/core/unittest/test_external_take.cpp
+++ b/internal/core/unittest/test_external_take.cpp
@@ -209,6 +209,29 @@ BuildTestArrowTable() {
                                vec_arr});
 }
 
+std::shared_ptr<arrow::Table>
+BuildNullableVectorArrowTable() {
+    auto fsb_type = arrow::fixed_size_binary(kVecDim * sizeof(float));
+    arrow::FixedSizeBinaryBuilder vec_b(fsb_type);
+    for (int i = 0; i < 3; i++) {
+        if (i == 1) {
+            EXPECT_TRUE(vec_b.AppendNull().ok());
+            continue;
+        }
+        float v[kVecDim];
+        for (int d = 0; d < kVecDim; d++) {
+            v[d] = static_cast<float>(i * kVecDim + d);
+        }
+        EXPECT_TRUE(vec_b.Append(reinterpret_cast<const uint8_t*>(v)).ok());
+    }
+    auto vec_arr = vec_b.Finish().ValueOrDie();
+
+    auto schema = arrow::schema({
+        arrow::field("vec_col", fsb_type),
+    });
+    return arrow::Table::Make(schema, {vec_arr});
+}
+
 // Build an external schema with all supported types.
 // Returns {schema, field_ids} where field_ids are in order:
 // bool, int8, int16, int32, int64, float, double, varchar, vec
@@ -629,6 +652,44 @@ TEST(ExternalTakeTest, TryTakeForRetrieve_MultiTypes) {
     EXPECT_FLOAT_EQ(fv.data(8), 16.0f);
 }
 
+TEST(ExternalTakeTest, TryTakeForRetrieve_NullableVectorUsesCompactData) {
+    auto info = BuildExternalSchema();
+    auto table = BuildNullableVectorArrowTable();
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, info.schema);
+    segment->SetReaderForTesting(std::make_unique<MockTakeReader>(table));
+    segment->SetUseTakeForOutputForTesting(true);
+
+    auto plan = std::make_unique<query::RetrievePlan>(info.schema);
+    plan->field_ids_ = {info.vec_id};
+
+    auto results = std::make_unique<proto::segcore::RetrieveResults>();
+    std::vector<int64_t> offsets = {0, 1, 2};
+
+    bool ok = segment->TryTakeForRetrieve(
+        plan.get(), results, offsets.data(), offsets.size(), false, false);
+    ASSERT_TRUE(ok);
+    ASSERT_EQ(results->fields_data_size(), 1);
+
+    auto& vec_data = results->fields_data(0);
+    ASSERT_EQ(vec_data.field_id(), info.vec_id.get());
+    ASSERT_EQ(vec_data.valid_data_size(), 3);
+    EXPECT_TRUE(vec_data.valid_data(0));
+    EXPECT_FALSE(vec_data.valid_data(1));
+    EXPECT_TRUE(vec_data.valid_data(2));
+
+    auto& fv = vec_data.vectors().float_vector();
+    ASSERT_EQ(fv.data_size(), 2 * kVecDim);
+    EXPECT_FLOAT_EQ(fv.data(0), 0.0f);
+    EXPECT_FLOAT_EQ(fv.data(1), 1.0f);
+    EXPECT_FLOAT_EQ(fv.data(2), 2.0f);
+    EXPECT_FLOAT_EQ(fv.data(3), 3.0f);
+    EXPECT_FLOAT_EQ(fv.data(4), 8.0f);
+    EXPECT_FLOAT_EQ(fv.data(5), 9.0f);
+    EXPECT_FLOAT_EQ(fv.data(6), 10.0f);
+    EXPECT_FLOAT_EQ(fv.data(7), 11.0f);
+}
+
 // Test TryTakeForSearch with all supported data types
 TEST(ExternalTakeTest, TryTakeForSearch_MultiTypes) {
     auto [schema,
@@ -713,6 +774,41 @@ TEST(ExternalTakeTest, TryTakeForSearch_MultiTypes) {
     // Row 1: [4,5,6,7], Row 3: [12,13,14,15]
     EXPECT_FLOAT_EQ(vec_arr->vectors().float_vector().data(0), 4.0f);
     EXPECT_FLOAT_EQ(vec_arr->vectors().float_vector().data(4), 12.0f);
+}
+
+TEST(ExternalTakeTest, TryTakeForSearch_NullableVectorUsesCompactData) {
+    auto info = BuildExternalSchema();
+    auto table = BuildNullableVectorArrowTable();
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, info.schema);
+    segment->SetReaderForTesting(std::make_unique<MockTakeReader>(table));
+    segment->SetUseTakeForOutputForTesting(true);
+
+    auto plan = std::make_unique<query::Plan>(info.schema);
+    plan->target_entries_ = {info.vec_id};
+
+    std::vector<int64_t> seg_offsets = {0, 1, 2};
+    SearchResult results;
+    bool ok = segment->TestTryTakeForSearch(
+        plan.get(), seg_offsets.data(), seg_offsets.size(), results);
+    ASSERT_TRUE(ok);
+
+    auto& vec_data = results.output_fields_data_.at(info.vec_id);
+    ASSERT_EQ(vec_data->valid_data_size(), 3);
+    EXPECT_TRUE(vec_data->valid_data(0));
+    EXPECT_FALSE(vec_data->valid_data(1));
+    EXPECT_TRUE(vec_data->valid_data(2));
+
+    auto& fv = vec_data->vectors().float_vector();
+    ASSERT_EQ(fv.data_size(), 2 * kVecDim);
+    EXPECT_FLOAT_EQ(fv.data(0), 0.0f);
+    EXPECT_FLOAT_EQ(fv.data(1), 1.0f);
+    EXPECT_FLOAT_EQ(fv.data(2), 2.0f);
+    EXPECT_FLOAT_EQ(fv.data(3), 3.0f);
+    EXPECT_FLOAT_EQ(fv.data(4), 8.0f);
+    EXPECT_FLOAT_EQ(fv.data(5), 9.0f);
+    EXPECT_FLOAT_EQ(fv.data(6), 10.0f);
+    EXPECT_FLOAT_EQ(fv.data(7), 11.0f);
 }
 
 // Test fallback: returns false for non-external collection

--- a/tests/go_client/testcases/external_table_refresh_test.go
+++ b/tests/go_client/testcases/external_table_refresh_test.go
@@ -3,7 +3,9 @@ package testcases
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"fmt"
+	"math"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -151,6 +153,60 @@ func generateParquetBytes(numRows int64, startID int64) ([]byte, error) {
 			vecValueBuilder.Append(float32(startID+i)*0.1 + float32(d))
 		}
 	}
+
+	record := builder.NewRecord()
+	defer record.Release()
+
+	if err := writer.Write(record); err != nil {
+		return nil, fmt.Errorf("write record: %w", err)
+	}
+	if err := writer.Close(); err != nil {
+		return nil, fmt.Errorf("close writer: %w", err)
+	}
+
+	return buf.Bytes(), nil
+}
+
+// generateNullableFloatVectorParquetBytes creates a Parquet file with rows:
+//   - id=0, embedding=[0,1,2,3]
+//   - id=1, embedding=null
+//   - id=2, embedding=[8,9,10,11]
+func generateNullableFloatVectorParquetBytes() ([]byte, error) {
+	arrowSchema := arrow.NewSchema(
+		[]arrow.Field{
+			{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+			{Name: "embedding", Type: &arrow.FixedSizeBinaryType{ByteWidth: testVecDim * 4}, Nullable: true},
+		},
+		nil,
+	)
+
+	var buf bytes.Buffer
+	writer, err := pqarrow.NewFileWriter(arrowSchema, &buf, nil, pqarrow.DefaultWriterProps())
+	if err != nil {
+		return nil, fmt.Errorf("create parquet writer: %w", err)
+	}
+
+	pool := memory.NewGoAllocator()
+	builder := array.NewRecordBuilder(pool, arrowSchema)
+	defer builder.Release()
+
+	idBuilder := builder.Field(0).(*array.Int64Builder)
+	embeddingBuilder := builder.Field(1).(*array.FixedSizeBinaryBuilder)
+
+	appendVector := func(values []float32) {
+		raw := make([]byte, testVecDim*4)
+		for i, value := range values {
+			binary.LittleEndian.PutUint32(raw[i*4:(i+1)*4], math.Float32bits(value))
+		}
+		embeddingBuilder.Append(raw)
+	}
+
+	idBuilder.Append(0)
+	appendVector([]float32{0, 1, 2, 3})
+	idBuilder.Append(1)
+	embeddingBuilder.AppendNull()
+	idBuilder.Append(2)
+	appendVector([]float32{8, 9, 10, 11})
 
 	record := builder.NewRecord()
 	defer record.Release()
@@ -1012,6 +1068,106 @@ indexAndLoad:
 	require.NotNil(t, embCol, "embedding column should be present in output")
 	require.Equal(t, 1, embCol.Len(), "embedding column should have 1 row")
 	t.Log("Query with embedding output field succeeded")
+}
+
+func TestExternalCollectionNullableFloatVectorTakeOutput(t *testing.T) {
+	t.Parallel()
+
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	minioCfg := getMinIOConfig()
+	minioClient, err := newMinIOClient(minioCfg)
+	require.NoError(t, err)
+
+	exists, err := minioClient.BucketExists(ctx, minioCfg.bucket)
+	if err != nil || !exists {
+		t.Skipf("MinIO bucket %q not accessible (exists=%v, err=%v), skipping",
+			minioCfg.bucket, exists, err)
+	}
+
+	collName := common.GenRandomString("ext_nullable_vec", 6)
+	extPath := fmt.Sprintf("external-e2e-test/%s", collName)
+
+	data, err := generateNullableFloatVectorParquetBytes()
+	require.NoError(t, err, "generate nullable vector parquet")
+
+	objectKey := fmt.Sprintf("%s/data.parquet", extPath)
+	uploadParquetToMinIO(ctx, t, minioClient, minioCfg.bucket, objectKey, data)
+
+	t.Cleanup(func() {
+		cleanupMinIOPrefix(context.Background(), minioClient, minioCfg.bucket,
+			fmt.Sprintf("%s/", extPath))
+	})
+
+	schema := entity.NewSchema().
+		WithName(collName).
+		WithExternalSource(extTestURI(minioCfg, extPath)).
+		WithExternalSpec(extTestSpec(minioCfg, "parquet")).
+		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithExternalField("id")).
+		WithField(entity.NewField().WithName("embedding").WithDataType(entity.FieldTypeFloatVector).
+			WithDim(testVecDim).WithNullable(true).WithExternalField("embedding"))
+
+	err = mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, true)
+	t.Cleanup(func() {
+		_ = mc.DropCollection(context.Background(), client.NewDropCollectionOption(collName))
+	})
+
+	refreshAndWait(ctx, t, mc, collName)
+	indexAndLoadCollection(ctx, t, mc, collName, "embedding")
+
+	queryRes, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithConsistencyLevel(entity.ClStrong).
+		WithFilter("id >= 0").
+		WithOutputFields("id", "embedding"))
+	common.CheckErr(t, err, true)
+	require.Equal(t, 3, queryRes.ResultCount)
+
+	idCol := queryRes.GetColumn("id")
+	embeddingCol := queryRes.GetColumn("embedding")
+	require.NotNil(t, idCol)
+	require.NotNil(t, embeddingCol)
+
+	type vectorRow struct {
+		isNull bool
+		vector []float32
+	}
+	rows := make(map[int64]vectorRow, queryRes.ResultCount)
+	for i := 0; i < queryRes.ResultCount; i++ {
+		id, err := idCol.GetAsInt64(i)
+		require.NoError(t, err)
+		isNull, err := embeddingCol.IsNull(i)
+		require.NoError(t, err)
+
+		row := vectorRow{isNull: isNull}
+		if !isNull {
+			raw, err := embeddingCol.Get(i)
+			require.NoError(t, err)
+			vec, ok := raw.(entity.FloatVector)
+			require.Truef(t, ok, "embedding row %d has unexpected type %T", i, raw)
+			row.vector = []float32(vec)
+		}
+		rows[id] = row
+	}
+
+	require.Len(t, rows, 3)
+
+	assertVector := func(id int64, expected []float32) {
+		t.Helper()
+		row, ok := rows[id]
+		require.True(t, ok, "missing row id=%d", id)
+		require.False(t, row.isNull, "embedding should not be null for id=%d", id)
+		require.Equal(t, len(expected), len(row.vector), "embedding dim mismatch for id=%d", id)
+		for i := range expected {
+			require.InDelta(t, expected[i], row.vector[i], 1e-6,
+				"embedding[%d] mismatch for id=%d", i, id)
+		}
+	}
+
+	assertVector(0, []float32{0, 1, 2, 3})
+	require.True(t, rows[1].isNull, "embedding should be null for id=1")
+	assertVector(2, []float32{8, 9, 10, 11})
 }
 
 // TestExternalCollectionIncrementalRefresh tests that refreshing an external collection


### PR DESCRIPTION
## What changed

- Compact nullable FloatVector output data when external collection take output is enabled.
- Add C++ coverage for retrieve and search take output with nullable vectors.
- Add a Go e2e test for external parquet data containing valid, null, valid vectors.

## Why

External take output stores nullable vector data in compact form. The previous
conversion sized the output payload by total rows and wrote valid vectors by
the original row index. When a null vector appeared before a valid vector, the
later vector could be written at the wrong offset and returned as zeros.

Fixes https://github.com/milvus-io/milvus/issues/49519

## Validation

- `internal/core/output/unittest/all_tests --gtest_filter='ExternalTakeTest.*'`
- `GOTOOLCHAIN=go1.25.9 make build-go`
- `GOTOOLCHAIN=go1.25.9 go test -tags dynamic,test ./testcases -run TestExternalCollectionNullableFloatVectorTakeOutput -v -count=1`
- `git diff --check`
