### PR TITLE
enhance: Normalize external Arrow with field metadata

### DIFF
--- a/internal/core/src/storage/DataCodecTest.cpp
+++ b/internal/core/src/storage/DataCodecTest.cpp
@@ -60,6 +60,38 @@
 
 using namespace milvus;
 
+namespace {
+
+FieldMeta
+MakeExternalFieldMetaForTest(DataType data_type,
+                             DataType element_type = DataType::NONE,
+                             bool nullable = false,
+                             int64_t dim = 0) {
+    proto::schema::FieldSchema field_schema;
+    field_schema.set_fieldid(1000);
+    field_schema.set_name("field");
+    field_schema.set_external_field("field_col");
+    field_schema.set_data_type(ToProtoDataType(data_type));
+    field_schema.set_nullable(nullable);
+    if (element_type != DataType::NONE) {
+        field_schema.set_element_type(ToProtoDataType(element_type));
+    }
+    if (IsStringDataType(data_type)) {
+        auto* max_length = field_schema.add_type_params();
+        max_length->set_key("max_length");
+        max_length->set_value("1024");
+    }
+    if (IsVectorDataType(data_type) &&
+        !IsSparseFloatVectorDataType(data_type)) {
+        auto* dim_param = field_schema.add_type_params();
+        dim_param->set_key("dim");
+        dim_param->set_value(std::to_string(dim));
+    }
+    return FieldMeta::ParseFrom(field_schema);
+}
+
+}  // namespace
+
 TEST(storage, ExternalVarCharStringNormalizesToBinaryAndFillSucceeds) {
     arrow::StringBuilder builder;
     ASSERT_TRUE(builder.Append("hello").ok());
@@ -67,8 +99,8 @@ TEST(storage, ExternalVarCharStringNormalizesToBinaryAndFillSucceeds) {
     std::shared_ptr<arrow::Array> string_array;
     ASSERT_TRUE(builder.Finish(&string_array).ok());
 
-    auto normalized = storage::NormalizeExternalArrow(
-        string_array, DataType::VARCHAR, 0, false, DataType::NONE);
+    auto field_meta = MakeExternalFieldMetaForTest(DataType::VARCHAR);
+    auto normalized = storage::NormalizeExternalArrow(string_array, field_meta);
     ASSERT_EQ(normalized->type_id(), arrow::Type::BINARY);
 
     auto field_data = storage::CreateFieldData(storage::DataType::VARCHAR,
@@ -86,8 +118,8 @@ TEST(storage, ExternalVarCharBinaryFillSucceeds) {
     std::shared_ptr<arrow::Array> binary_array;
     ASSERT_TRUE(builder.Finish(&binary_array).ok());
 
-    auto normalized = storage::NormalizeExternalArrow(
-        binary_array, DataType::VARCHAR, 0, false, DataType::NONE);
+    auto field_meta = MakeExternalFieldMetaForTest(DataType::VARCHAR);
+    auto normalized = storage::NormalizeExternalArrow(binary_array, field_meta);
     ASSERT_EQ(normalized->type_id(), arrow::Type::BINARY);
 
     auto field_data = storage::CreateFieldData(storage::DataType::VARCHAR,
@@ -105,8 +137,8 @@ TEST(storage, ExternalVarCharInt64NormalizeFails) {
     std::shared_ptr<arrow::Array> int64_array;
     ASSERT_TRUE(builder.Finish(&int64_array).ok());
 
-    EXPECT_ANY_THROW(storage::NormalizeExternalArrow(
-        int64_array, DataType::VARCHAR, 0, false, DataType::NONE));
+    auto field_meta = MakeExternalFieldMetaForTest(DataType::VARCHAR);
+    EXPECT_ANY_THROW(storage::NormalizeExternalArrow(int64_array, field_meta));
 }
 
 TEST(storage, ExternalInt8Int64NormalizeFails) {
@@ -116,8 +148,8 @@ TEST(storage, ExternalInt8Int64NormalizeFails) {
     std::shared_ptr<arrow::Array> int64_array;
     ASSERT_TRUE(builder.Finish(&int64_array).ok());
 
-    EXPECT_ANY_THROW(storage::NormalizeExternalArrow(
-        int64_array, DataType::INT8, 0, false, DataType::NONE));
+    auto field_meta = MakeExternalFieldMetaForTest(DataType::INT8);
+    EXPECT_ANY_THROW(storage::NormalizeExternalArrow(int64_array, field_meta));
 }
 
 TEST(storage, ExternalSampleSchemaValidationRejectsMismatchedIntType) {
@@ -134,7 +166,88 @@ TEST(storage, ExternalSampleSchemaValidationRejectsMismatchedIntType) {
     field_schema.set_data_type(proto::schema::DataType::Int8);
     auto field_meta = FieldMeta::ParseFrom(field_schema);
 
-    EXPECT_ANY_THROW(storage::NormalizeExternalArrow(int64_array, field_meta));
+    try {
+        storage::NormalizeExternalArrow(int64_array, field_meta);
+        FAIL() << "expected NormalizeExternalArrow to reject mismatched type";
+    } catch (const std::exception& e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("field 'age'"), std::string::npos);
+        EXPECT_NE(msg.find("external_field 'age_col'"), std::string::npos);
+        EXPECT_NE(msg.find("field type mismatch"), std::string::npos);
+        EXPECT_NE(msg.find("expected Arrow int8"), std::string::npos);
+        EXPECT_NE(msg.find("actual Arrow int64"), std::string::npos);
+    }
+}
+
+TEST(storage,
+     ExternalSampleSchemaValidationRejectsMismatchedVectorElementType) {
+    auto value_builder = std::make_shared<arrow::Int64Builder>();
+    arrow::ListBuilder builder(arrow::default_memory_pool(), value_builder);
+    auto& int_builder =
+        dynamic_cast<arrow::Int64Builder&>(*builder.value_builder());
+
+    ASSERT_TRUE(builder.Append().ok());
+    ASSERT_TRUE(int_builder.Append(1).ok());
+    ASSERT_TRUE(int_builder.Append(2).ok());
+    std::shared_ptr<arrow::Array> list_array;
+    ASSERT_TRUE(builder.Finish(&list_array).ok());
+
+    proto::schema::FieldSchema field_schema;
+    field_schema.set_fieldid(101);
+    field_schema.set_name("embedding");
+    field_schema.set_external_field("embedding_col");
+    field_schema.set_data_type(proto::schema::DataType::FloatVector);
+    auto* dim = field_schema.add_type_params();
+    dim->set_key("dim");
+    dim->set_value("2");
+    auto field_meta = FieldMeta::ParseFrom(field_schema);
+
+    try {
+        storage::NormalizeExternalArrow(list_array, field_meta);
+        FAIL() << "expected NormalizeExternalArrow to reject mismatched vector "
+                  "element type";
+    } catch (const std::exception& e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("field 'embedding'"), std::string::npos);
+        EXPECT_NE(msg.find("external_field 'embedding_col'"),
+                  std::string::npos);
+        EXPECT_NE(msg.find("vector element type mismatch"), std::string::npos);
+        EXPECT_NE(msg.find("expected float"), std::string::npos);
+        EXPECT_NE(msg.find("actual int64"), std::string::npos);
+    }
+}
+
+TEST(storage, ExternalSampleSchemaValidationRejectsMismatchedArrayElementType) {
+    auto value_builder = std::make_shared<arrow::StringBuilder>();
+    arrow::ListBuilder builder(arrow::default_memory_pool(), value_builder);
+    auto& string_builder =
+        dynamic_cast<arrow::StringBuilder&>(*builder.value_builder());
+
+    ASSERT_TRUE(builder.Append().ok());
+    ASSERT_TRUE(string_builder.Append("1").ok());
+    std::shared_ptr<arrow::Array> list_array;
+    ASSERT_TRUE(builder.Finish(&list_array).ok());
+
+    proto::schema::FieldSchema field_schema;
+    field_schema.set_fieldid(102);
+    field_schema.set_name("tags");
+    field_schema.set_external_field("tags_col");
+    field_schema.set_data_type(proto::schema::DataType::Array);
+    field_schema.set_element_type(proto::schema::DataType::Int64);
+    auto field_meta = FieldMeta::ParseFrom(field_schema);
+
+    try {
+        storage::NormalizeExternalArrow(list_array, field_meta);
+        FAIL() << "expected NormalizeExternalArrow to reject mismatched array "
+                  "element type";
+    } catch (const std::exception& e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("field 'tags'"), std::string::npos);
+        EXPECT_NE(msg.find("external_field 'tags_col'"), std::string::npos);
+        EXPECT_NE(msg.find("array element type mismatch"), std::string::npos);
+        EXPECT_NE(msg.find("expected INT64"), std::string::npos);
+        EXPECT_NE(msg.find("actual STRING"), std::string::npos);
+    }
 }
 
 TEST(storage, ExternalVarCharLargeStringNormalizesAndFillSucceeds) {
@@ -144,8 +257,9 @@ TEST(storage, ExternalVarCharLargeStringNormalizesAndFillSucceeds) {
     std::shared_ptr<arrow::Array> large_string_array;
     ASSERT_TRUE(builder.Finish(&large_string_array).ok());
 
-    auto normalized = storage::NormalizeExternalArrow(
-        large_string_array, DataType::VARCHAR, 0, false, DataType::NONE);
+    auto field_meta = MakeExternalFieldMetaForTest(DataType::VARCHAR);
+    auto normalized =
+        storage::NormalizeExternalArrow(large_string_array, field_meta);
     ASSERT_EQ(normalized->type_id(), arrow::Type::BINARY);
 
     auto field_data = storage::CreateFieldData(storage::DataType::VARCHAR,
@@ -171,8 +285,9 @@ TEST(storage, ExternalArrayListNormalizesToBinary) {
     std::shared_ptr<arrow::Array> list_array;
     ASSERT_TRUE(builder.Finish(&list_array).ok());
 
-    auto normalized = storage::NormalizeExternalArrow(
-        list_array, DataType::ARRAY, 0, false, DataType::INT64);
+    auto field_meta =
+        MakeExternalFieldMetaForTest(DataType::ARRAY, DataType::INT64);
+    auto normalized = storage::NormalizeExternalArrow(list_array, field_meta);
     ASSERT_EQ(normalized->type_id(), arrow::Type::BINARY);
 }
 
@@ -192,8 +307,9 @@ TEST(storage, ExternalFloatVectorListNormalizesToFixedSizeBinary) {
     std::shared_ptr<arrow::Array> list_array;
     ASSERT_TRUE(builder.Finish(&list_array).ok());
 
-    auto normalized = storage::NormalizeExternalArrow(
-        list_array, DataType::VECTOR_FLOAT, 2, false, DataType::NONE);
+    auto field_meta = MakeExternalFieldMetaForTest(
+        DataType::VECTOR_FLOAT, DataType::NONE, false, 2);
+    auto normalized = storage::NormalizeExternalArrow(list_array, field_meta);
     ASSERT_EQ(normalized->type_id(), arrow::Type::FIXED_SIZE_BINARY);
 }
 
@@ -207,8 +323,9 @@ TEST(storage, ExternalNullableFloatVectorBinaryIsAccepted) {
     std::shared_ptr<arrow::Array> binary_array;
     ASSERT_TRUE(builder.Finish(&binary_array).ok());
 
-    auto normalized = storage::NormalizeExternalArrow(
-        binary_array, DataType::VECTOR_FLOAT, 2, true, DataType::NONE);
+    auto field_meta = MakeExternalFieldMetaForTest(
+        DataType::VECTOR_FLOAT, DataType::NONE, true, 2);
+    auto normalized = storage::NormalizeExternalArrow(binary_array, field_meta);
     ASSERT_EQ(normalized->type_id(), arrow::Type::BINARY);
 }
 
@@ -225,8 +342,9 @@ TEST(storage, ExternalBinaryVectorListNormalizeFails) {
     std::shared_ptr<arrow::Array> list_array;
     ASSERT_TRUE(builder.Finish(&list_array).ok());
 
-    EXPECT_ANY_THROW(storage::NormalizeExternalArrow(
-        list_array, DataType::VECTOR_BINARY, 16, false, DataType::NONE));
+    auto field_meta = MakeExternalFieldMetaForTest(
+        DataType::VECTOR_BINARY, DataType::NONE, false, 16);
+    EXPECT_ANY_THROW(storage::NormalizeExternalArrow(list_array, field_meta));
 }
 
 TEST(storage, ExternalNullableVarCharBinaryPreservesNullCount) {
@@ -237,8 +355,9 @@ TEST(storage, ExternalNullableVarCharBinaryPreservesNullCount) {
     std::shared_ptr<arrow::Array> binary_array;
     ASSERT_TRUE(builder.Finish(&binary_array).ok());
 
-    auto normalized = storage::NormalizeExternalArrow(
-        binary_array, DataType::VARCHAR, 0, true, DataType::NONE);
+    auto field_meta =
+        MakeExternalFieldMetaForTest(DataType::VARCHAR, DataType::NONE, true);
+    auto normalized = storage::NormalizeExternalArrow(binary_array, field_meta);
     ASSERT_EQ(normalized->type_id(), arrow::Type::BINARY);
 
     auto field_data = storage::CreateFieldData(
@@ -263,10 +382,12 @@ TEST(storage, ExternalNullableVarCharBinaryAccumulatesNullCountAcrossChunks) {
     std::shared_ptr<arrow::Array> second_array;
     ASSERT_TRUE(second_builder.Finish(&second_array).ok());
 
-    auto first_normalized = storage::NormalizeExternalArrow(
-        first_array, DataType::VARCHAR, 0, true, DataType::NONE);
-    auto second_normalized = storage::NormalizeExternalArrow(
-        second_array, DataType::VARCHAR, 0, true, DataType::NONE);
+    auto field_meta =
+        MakeExternalFieldMetaForTest(DataType::VARCHAR, DataType::NONE, true);
+    auto first_normalized =
+        storage::NormalizeExternalArrow(first_array, field_meta);
+    auto second_normalized =
+        storage::NormalizeExternalArrow(second_array, field_meta);
     ASSERT_EQ(first_normalized->type_id(), arrow::Type::BINARY);
     ASSERT_EQ(second_normalized->type_id(), arrow::Type::BINARY);
 

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -79,6 +79,14 @@ std::map<std::string, ChunkManagerType> ChunkManagerType_Map = {
     {"remote", ChunkManagerType::Remote},
     {"opendal", ChunkManagerType::OpenDAL}};
 
+static std::shared_ptr<arrow::Array>
+NormalizeExternalArrowByType(const std::shared_ptr<arrow::Array>& array,
+                             DataType data_type,
+                             int64_t dim,
+                             bool nullable,
+                             DataType element_type,
+                             const FieldMeta& field_meta);
+
 enum class CloudProviderType : int8_t {
     UNKNOWN = 0,
     AWS = 1,
@@ -1540,10 +1548,18 @@ GetFieldDatasFromManifest(
 
     bool nullable = field_meta.field_schema.nullable();
     bool is_external = !ext_field.empty();
+    std::optional<FieldMeta> normalize_field_meta;
+    if (is_external) {
+        auto schema = field_meta.field_schema;
+        if (schema.fieldid() == 0) {
+            schema.set_fieldid(field_meta.field_id);
+        }
+        normalize_field_meta.emplace(FieldMeta::ParseFrom(schema));
+    }
 
-    // External tables: schemaless reader — let the reader derive types from
+    // External tables: schemaless reader - let the reader derive types from
     // file metadata, then normalize Arrow types to Milvus internal format.
-    // Internal tables: explicit schema reader — the reader returns data in
+    // Internal tables: explicit schema reader - the reader returns data in
     // the exact Milvus-native Arrow types, no normalization needed.
     std::shared_ptr<arrow::Schema> reader_schema = nullptr;
     if (!is_external) {
@@ -1599,11 +1615,13 @@ GetFieldDatasFromManifest(
 
         auto raw_column = batch->GetColumnByName(column_name);
         if (is_external) {
-            raw_column = NormalizeExternalArrow(raw_column,
-                                                data_type.value(),
-                                                dim,
-                                                nullable,
-                                                element_type.value());
+            raw_column =
+                NormalizeExternalArrowByType(raw_column,
+                                             data_type.value(),
+                                             dim,
+                                             nullable,
+                                             element_type.value(),
+                                             normalize_field_meta.value());
         }
         auto chunked_array = std::make_shared<arrow::ChunkedArray>(raw_column);
         auto field_data = CreateFieldData(
@@ -1692,16 +1710,25 @@ GetFieldIDList(FieldId column_group_id,
     return field_id_list;
 }
 
+std::string
+FieldErrorSuffix(const FieldMeta& field_meta) {
+    return fmt::format(" for field '{}' (external_field '{}')",
+                       field_meta.get_name().get(),
+                       field_meta.get_external_field());
+}
+
 void
 ValidateFixedSizeBinaryVectorWidth(const std::shared_ptr<arrow::Array>& array,
                                    DataType data_type,
-                                   int dim) {
+                                   int dim,
+                                   const FieldMeta& field_meta) {
     auto fsb_array =
         std::static_pointer_cast<arrow::FixedSizeBinaryArray>(array);
     int byte_width = GetDataTypeSize(data_type, dim);
     AssertInfo(fsb_array->byte_width() == byte_width,
-               "vector byte width mismatch, expected {} bytes for "
+               "vector byte width mismatch{}, expected {} bytes for "
                "dim {}, actual {} bytes",
+               FieldErrorSuffix(field_meta),
                byte_width,
                dim,
                fsb_array->byte_width());
@@ -1710,7 +1737,8 @@ ValidateFixedSizeBinaryVectorWidth(const std::shared_ptr<arrow::Array>& array,
 void
 ValidateBinaryVectorWidth(const std::shared_ptr<arrow::Array>& array,
                           DataType data_type,
-                          int dim) {
+                          int dim,
+                          const FieldMeta& field_meta) {
     auto binary_array = std::static_pointer_cast<arrow::BinaryArray>(array);
     int byte_width = GetDataTypeSize(data_type, dim);
     for (int64_t i = 0; i < binary_array->length(); ++i) {
@@ -1719,8 +1747,9 @@ ValidateBinaryVectorWidth(const std::shared_ptr<arrow::Array>& array,
         }
         auto actual_width = binary_array->value_length(i);
         AssertInfo(actual_width == byte_width,
-                   "vector byte width mismatch, expected {} bytes for "
+                   "vector byte width mismatch{}, expected {} bytes for "
                    "dim {}, actual {} bytes at row {}",
+                   FieldErrorSuffix(field_meta),
                    byte_width,
                    dim,
                    actual_width,
@@ -1745,7 +1774,8 @@ ValidateNoNullValuesInRange(const std::shared_ptr<arrow::Array>& values,
 }
 
 arrow::Type::type
-ExpectedVectorListElementArrowType(DataType data_type) {
+ExpectedVectorListElementArrowType(DataType data_type,
+                                   const FieldMeta& field_meta) {
     switch (data_type) {
         case DataType::VECTOR_FLOAT:
             return arrow::Type::FLOAT;
@@ -1756,11 +1786,13 @@ ExpectedVectorListElementArrowType(DataType data_type) {
         case DataType::VECTOR_BINARY:
         case DataType::VECTOR_BFLOAT16:
             ThrowInfo(ErrorCode::Unsupported,
-                      "vector list input is not supported for {}",
+                      "vector list input{} is not supported for {}",
+                      FieldErrorSuffix(field_meta),
                       data_type);
         default:
             ThrowInfo(ErrorCode::Unsupported,
-                      "unsupported vector list input for {}",
+                      "unsupported vector list input{} for {}",
+                      FieldErrorSuffix(field_meta),
                       data_type);
     }
 }
@@ -1781,10 +1813,14 @@ ArrowTypeName(arrow::Type::type type) {
 
 void
 ValidateVectorListElementType(
-    const std::shared_ptr<arrow::DataType>& actual_type, DataType data_type) {
-    auto expected_type = ExpectedVectorListElementArrowType(data_type);
+    const std::shared_ptr<arrow::DataType>& actual_type,
+    DataType data_type,
+    const FieldMeta& field_meta) {
+    auto expected_type =
+        ExpectedVectorListElementArrowType(data_type, field_meta);
     AssertInfo(actual_type->id() == expected_type,
-               "vector element type mismatch, expected {}, actual {}",
+               "vector element type mismatch{}, expected {}, actual {}",
+               FieldErrorSuffix(field_meta),
                ArrowTypeName(expected_type),
                actual_type->ToString());
 }
@@ -1792,7 +1828,8 @@ ValidateVectorListElementType(
 arrow::ArrayVector
 NormalizeVectorArraysToFixedSizeBinary(const arrow::ArrayVector& arrays,
                                        DataType data_type,
-                                       int dim) {
+                                       int dim,
+                                       const FieldMeta& field_meta) {
     int byte_width = GetDataTypeSize(data_type, dim);
     auto fsb_type = arrow::fixed_size_binary(byte_width);
 
@@ -1802,7 +1839,8 @@ NormalizeVectorArraysToFixedSizeBinary(const arrow::ArrayVector& arrays,
     for (const auto& array : arrays) {
         auto type_id = array->type_id();
         if (type_id == arrow::Type::FIXED_SIZE_BINARY) {
-            ValidateFixedSizeBinaryVectorWidth(array, data_type, dim);
+            ValidateFixedSizeBinaryVectorWidth(
+                array, data_type, dim, field_meta);
             result.push_back(array);
             continue;
         }
@@ -1821,11 +1859,13 @@ NormalizeVectorArraysToFixedSizeBinary(const arrow::ArrayVector& arrays,
         if (type_id == arrow::Type::LIST) {
             auto list_array = std::static_pointer_cast<arrow::ListArray>(array);
             auto values = list_array->values();
-            ValidateVectorListElementType(values->type(), data_type);
+            ValidateVectorListElementType(
+                values->type(), data_type, field_meta);
             int elem_bit_width = values->type()->bit_width();
             AssertInfo(elem_bit_width > 0 && elem_bit_width % 8 == 0,
-                       "Vector list element must be fixed-width byte-aligned "
-                       "type, got bit_width={}",
+                       "vector list element{} must be fixed-width "
+                       "byte-aligned type, got bit_width={}",
+                       FieldErrorSuffix(field_meta),
                        elem_bit_width);
             int elem_byte_size = elem_bit_width / 8;
             auto raw = reinterpret_cast<const uint8_t*>(
@@ -1835,8 +1875,9 @@ NormalizeVectorArraysToFixedSizeBinary(const arrow::ArrayVector& arrays,
                     auto offset = list_array->value_offset(i);
                     auto actual_dim = list_array->value_offset(i + 1) - offset;
                     AssertInfo(actual_dim == dim,
-                               "vector dimension mismatch, expected {}, "
+                               "vector dimension mismatch{}, expected {}, "
                                "actual {} at row {}",
+                               FieldErrorSuffix(field_meta),
                                dim,
                                actual_dim,
                                i);
@@ -1851,15 +1892,18 @@ NormalizeVectorArraysToFixedSizeBinary(const arrow::ArrayVector& arrays,
             auto fsl_array =
                 std::static_pointer_cast<arrow::FixedSizeListArray>(array);
             auto values = fsl_array->values();
-            ValidateVectorListElementType(values->type(), data_type);
+            ValidateVectorListElementType(
+                values->type(), data_type, field_meta);
             int elem_bit_width = values->type()->bit_width();
             AssertInfo(elem_bit_width > 0 && elem_bit_width % 8 == 0,
-                       "Vector list element must be fixed-width byte-aligned "
-                       "type, got bit_width={}",
+                       "vector list element{} must be fixed-width "
+                       "byte-aligned type, got bit_width={}",
+                       FieldErrorSuffix(field_meta),
                        elem_bit_width);
             int elem_byte_size = elem_bit_width / 8;
             AssertInfo(fsl_array->value_length() == dim,
-                       "vector dimension mismatch, expected {}, actual {}",
+                       "vector dimension mismatch{}, expected {}, actual {}",
+                       FieldErrorSuffix(field_meta),
                        dim,
                        fsl_array->value_length());
             auto raw = reinterpret_cast<const uint8_t*>(
@@ -1876,7 +1920,8 @@ NormalizeVectorArraysToFixedSizeBinary(const arrow::ArrayVector& arrays,
             }
         } else {
             ThrowInfo(ErrorCode::Unsupported,
-                      "Unsupported arrow type for vector normalization: {}",
+                      "unsupported arrow type for vector normalization{}: {}",
+                      FieldErrorSuffix(field_meta),
                       array->type()->ToString());
         }
 
@@ -2185,7 +2230,7 @@ CoerceToList(const arrow::ArrayVector& arrays) {
 
 // Rebuild null bitmap as a fresh buffer at offset=0.
 // Required when constructing a new arrow::Array that does not share the
-// input's logical offset — direct reuse of `array->null_bitmap()` is
+// input's logical offset - direct reuse of `array->null_bitmap()` is
 // incorrect for sliced inputs (offset != 0) because callers will read the
 // bitmap starting at bit 0 instead of bit `array->offset()`.
 static std::shared_ptr<arrow::Buffer>
@@ -2210,8 +2255,8 @@ RebuildNullBitmap(const std::shared_ptr<arrow::Array>& array) {
 // Single-source-of-truth view-variant elimination. Callers that ingest
 // vortex (or any schemaless reader that may emit *_VIEW / LARGE_* layouts)
 // route arrays through this helper before any type-id dispatch. Pure
-// type/layout normalization — no semantic conversion (no WKT→WKB,
-// no Timestamp→Int64, etc).
+// type/layout normalization - no semantic conversion (no WKT->WKB,
+// no Timestamp->Int64, etc).
 //
 //   STRING_VIEW / LARGE_STRING -> STRING
 //   BINARY_VIEW / LARGE_BINARY -> BINARY
@@ -2492,7 +2537,8 @@ ConvertTimestampToInt64(const arrow::ArrayVector& arrays) {
 }
 
 DataType
-ArrowListElementTypeToMilvus(const std::shared_ptr<arrow::Array>& values) {
+ArrowListElementTypeToMilvus(const std::shared_ptr<arrow::Array>& values,
+                             const FieldMeta& field_meta) {
     switch (values->type_id()) {
         case arrow::Type::BOOL:
             return DataType::BOOL;
@@ -2514,7 +2560,8 @@ ArrowListElementTypeToMilvus(const std::shared_ptr<arrow::Array>& values) {
             return DataType::STRING;
         default:
             ThrowInfo(ErrorCode::Unsupported,
-                      "unsupported array element arrow type: {}",
+                      "unsupported array element arrow type{}: {}",
+                      FieldErrorSuffix(field_meta),
                       values->type()->ToString());
     }
 }
@@ -2529,7 +2576,8 @@ IsCompatibleArrayElementType(DataType actual_type, DataType expected_type) {
 
 arrow::ArrayVector
 ConvertListToProtobufBinary(const arrow::ArrayVector& arrays,
-                            DataType element_type) {
+                            DataType element_type,
+                            const FieldMeta& field_meta) {
     arrow::ArrayVector result;
     result.reserve(arrays.size());
     for (const auto& arr : arrays) {
@@ -2539,10 +2587,11 @@ ConvertListToProtobufBinary(const arrow::ArrayVector& arrays,
         }
         auto list_arr = std::static_pointer_cast<arrow::ListArray>(arr);
         auto actual_element_type =
-            ArrowListElementTypeToMilvus(list_arr->values());
+            ArrowListElementTypeToMilvus(list_arr->values(), field_meta);
         AssertInfo(
             IsCompatibleArrayElementType(actual_element_type, element_type),
-            "array element type mismatch, expected {}, actual {}",
+            "array element type mismatch{}, expected {}, actual {}",
+            FieldErrorSuffix(field_meta),
             element_type,
             actual_element_type);
         arrow::BinaryBuilder builder;
@@ -2575,7 +2624,8 @@ arrow::ArrayVector
 NormalizeVectorArrays(const arrow::ArrayVector& arrays,
                       DataType data_type,
                       int64_t dim,
-                      bool nullable) {
+                      bool nullable,
+                      const FieldMeta& field_meta) {
     if (arrays.empty()) {
         return arrays;
     }
@@ -2585,7 +2635,8 @@ NormalizeVectorArrays(const arrow::ArrayVector& arrays,
     for (const auto& array : arrays) {
         auto type_id = array->type_id();
         if (type_id == arrow::Type::BINARY && nullable) {
-            ValidateBinaryVectorWidth(array, data_type, static_cast<int>(dim));
+            ValidateBinaryVectorWidth(
+                array, data_type, static_cast<int>(dim), field_meta);
             result.push_back(array);
             continue;
         }
@@ -2593,11 +2644,11 @@ NormalizeVectorArrays(const arrow::ArrayVector& arrays,
         arrow::ArrayVector fsb;
         if (type_id == arrow::Type::FIXED_SIZE_BINARY) {
             ValidateFixedSizeBinaryVectorWidth(
-                array, data_type, static_cast<int>(dim));
+                array, data_type, static_cast<int>(dim), field_meta);
             fsb.push_back(array);
         } else {
             fsb = NormalizeVectorArraysToFixedSizeBinary(
-                {array}, data_type, static_cast<int>(dim));
+                {array}, data_type, static_cast<int>(dim), field_meta);
         }
 
         if (nullable) {
@@ -2613,7 +2664,8 @@ NormalizeVectorArrays(const arrow::ArrayVector& arrays,
 arrow::ArrayVector
 NormalizeVectorArrayInner(const arrow::ArrayVector& arrays,
                           DataType element_type,
-                          int64_t dim) {
+                          int64_t dim,
+                          const FieldMeta& field_meta) {
     arrow::ArrayVector result;
     result.reserve(arrays.size());
     for (const auto& arr : arrays) {
@@ -2625,13 +2677,18 @@ NormalizeVectorArrayInner(const arrow::ArrayVector& arrays,
         AssertInfo(list_arr->null_count() == 0,
                    "VECTOR_ARRAY does not support null rows");
         if (list_arr->values()->type_id() == arrow::Type::FIXED_SIZE_BINARY) {
-            ValidateFixedSizeBinaryVectorWidth(
-                list_arr->values(), element_type, static_cast<int>(dim));
+            ValidateFixedSizeBinaryVectorWidth(list_arr->values(),
+                                               element_type,
+                                               static_cast<int>(dim),
+                                               field_meta);
             result.push_back(arr);
             continue;
         }
-        auto normalized = NormalizeVectorArraysToFixedSizeBinary(
-            {list_arr->values()}, element_type, static_cast<int>(dim));
+        auto normalized =
+            NormalizeVectorArraysToFixedSizeBinary({list_arr->values()},
+                                                   element_type,
+                                                   static_cast<int>(dim),
+                                                   field_meta);
         auto rebuilt =
             arrow::ListArray::FromArrays(*list_arr->offsets(), *normalized[0]);
         AssertInfo(rebuilt.ok(),
@@ -2655,8 +2712,8 @@ NormalizeExternalArrow(const std::shared_ptr<arrow::Array>& array,
     auto element_type = IsVectorArrayDataType(dt) || IsArrayDataType(dt)
                             ? field_meta.get_element_type()
                             : DataType::NONE;
-    return NormalizeExternalArrow(
-        array, dt, dim, field_meta.is_nullable(), element_type);
+    return NormalizeExternalArrowByType(
+        array, dt, dim, field_meta.is_nullable(), element_type, field_meta);
 }
 
 // Load path: batch wrapper.
@@ -2698,35 +2755,37 @@ ExpectedScalarArrowType(DataType data_type) {
 
 void
 ValidateScalarArrowType(DataType data_type,
-                        const std::shared_ptr<arrow::Array>& array) {
+                        const std::shared_ptr<arrow::Array>& array,
+                        const FieldMeta& field_meta) {
     auto expected_type = ExpectedScalarArrowType(data_type);
     if (expected_type == nullptr) {
         return;
     }
     AssertInfo(array->type()->Equals(*expected_type),
-               "field type mismatch, expected Arrow {}, actual Arrow {}",
+               "field type mismatch{}, expected Arrow {}, actual Arrow {}",
+               FieldErrorSuffix(field_meta),
                expected_type->ToString(),
                array->type()->ToString());
 }
 
 void
-AssertExternalArrowType(DataType data_type,
-                        const std::shared_ptr<arrow::Array>& array,
-                        const std::string& expected) {
+AssertExternalArrowType(const std::shared_ptr<arrow::Array>& array,
+                        const std::string& expected,
+                        const FieldMeta& field_meta) {
     ThrowInfo(ErrorCode::Unsupported,
-              "field type mismatch for {}, expected Arrow {}, actual Arrow {}",
-              data_type,
+              "field type mismatch{}, expected Arrow {}, actual Arrow {}",
+              FieldErrorSuffix(field_meta),
               expected,
               array->type()->ToString());
 }
 
-// Overload for callers without FieldMeta.
-std::shared_ptr<arrow::Array>
-NormalizeExternalArrow(const std::shared_ptr<arrow::Array>& array_in,
-                       DataType data_type,
-                       int64_t dim,
-                       bool nullable,
-                       DataType element_type) {
+static std::shared_ptr<arrow::Array>
+NormalizeExternalArrowByType(const std::shared_ptr<arrow::Array>& array_in,
+                             DataType data_type,
+                             int64_t dim,
+                             bool nullable,
+                             DataType element_type,
+                             const FieldMeta& field_meta) {
     // Single view-variant elimination pass: STRING_VIEW/LARGE_STRING -> STRING,
     // BINARY_VIEW/LARGE_BINARY -> BINARY, LARGE_LIST/LIST_VIEW -> LIST
     // (recursive into list inner). Downstream branches only need to dispatch
@@ -2742,16 +2801,16 @@ NormalizeExternalArrow(const std::shared_ptr<arrow::Array>& array_in,
         if (type_id == arrow::Type::INT64) {
             return array;
         }
-        AssertExternalArrowType(data_type, array, "timestamp or int64");
+        AssertExternalArrowType(array, "timestamp or int64", field_meta);
     }
 
-    ValidateScalarArrowType(data_type, array);
+    ValidateScalarArrowType(data_type, array, field_meta);
 
     if (IsSparseFloatVectorDataType(data_type)) {
         if (type_id == arrow::Type::BINARY) {
             return array;
         }
-        AssertExternalArrowType(data_type, array, "binary");
+        AssertExternalArrowType(array, "binary", field_meta);
     }
 
     // Dense vectors
@@ -2760,25 +2819,28 @@ NormalizeExternalArrow(const std::shared_ptr<arrow::Array>& array_in,
         !IsVectorArrayDataType(data_type)) {
         if (type_id == arrow::Type::FIXED_SIZE_BINARY && !nullable) {
             ValidateFixedSizeBinaryVectorWidth(
-                array, data_type, static_cast<int>(dim));
+                array, data_type, static_cast<int>(dim), field_meta);
             return array;
         }
         if (type_id == arrow::Type::BINARY && nullable) {
-            ValidateBinaryVectorWidth(array, data_type, static_cast<int>(dim));
+            ValidateBinaryVectorWidth(
+                array, data_type, static_cast<int>(dim), field_meta);
             return array;
         }
-        auto result = NormalizeVectorArrays({array}, data_type, dim, nullable);
+        auto result = NormalizeVectorArrays(
+            {array}, data_type, dim, nullable, field_meta);
         return result[0];
     }
-    // VectorArray inner: List<List<scalar>> → List<FixedSizeBinary>
+    // VectorArray inner: List<List<scalar>> -> List<FixedSizeBinary>
     if (IsVectorArrayDataType(data_type)) {
         AssertInfo(element_type != DataType::NONE,
                    "element_type must be specified for VECTOR_ARRAY");
         if (type_id == arrow::Type::LIST) {
-            auto result = NormalizeVectorArrayInner({array}, element_type, dim);
+            auto result = NormalizeVectorArrayInner(
+                {array}, element_type, dim, field_meta);
             return result[0];
         }
-        AssertExternalArrowType(data_type, array, "list");
+        AssertExternalArrowType(array, "list", field_meta);
     }
     // Geometry STRING input -> WKT, convert to WKB.
     // (View/large-string variants already canonicalized to STRING above.)
@@ -2791,7 +2853,7 @@ NormalizeExternalArrow(const std::shared_ptr<arrow::Array>& array_in,
         return array;
     }
     if (data_type == DataType::GEOMETRY) {
-        AssertExternalArrowType(data_type, array, "string or binary");
+        AssertExternalArrowType(array, "string or binary", field_meta);
     }
     // JSON/VARCHAR/STRING/TEXT: String -> Binary (canonical internal repr).
     // (View/large variants already canonicalized to STRING above; issue #49352.)
@@ -2806,18 +2868,19 @@ NormalizeExternalArrow(const std::shared_ptr<arrow::Array>& array_in,
         return array;
     }
     if (IsStringDataType(data_type) || data_type == DataType::JSON) {
-        AssertExternalArrowType(data_type, array, "string or binary");
+        AssertExternalArrowType(array, "string or binary", field_meta);
     }
-    // Array: List → Protobuf Binary
+    // Array: List -> Protobuf Binary
     if (data_type == DataType::ARRAY && type_id == arrow::Type::LIST) {
-        auto result = ConvertListToProtobufBinary({array}, element_type);
+        auto result =
+            ConvertListToProtobufBinary({array}, element_type, field_meta);
         return result[0];
     }
     if (data_type == DataType::ARRAY && type_id == arrow::Type::BINARY) {
         return array;
     }
     if (data_type == DataType::ARRAY) {
-        AssertExternalArrowType(data_type, array, "list or binary");
+        AssertExternalArrowType(array, "list or binary", field_meta);
     }
     return array;
 }

--- a/internal/core/src/storage/Util.h
+++ b/internal/core/src/storage/Util.h
@@ -423,15 +423,6 @@ GetFieldIDList(FieldId column_group_id,
                const std::shared_ptr<arrow::Schema>& arrow_schema,
                milvus_storage::ArrowFileSystemPtr fs);
 
-// Convert LIST or FIXED_SIZE_LIST arrays to FixedSizeBinary.
-// External files store vectors in list format (e.g. List<Float32>);
-// Milvus expects FixedSizeBinary (raw bytes). Returns the input
-// unchanged if already FixedSizeBinary.
-arrow::ArrayVector
-NormalizeVectorArraysToFixedSizeBinary(const arrow::ArrayVector& arrays,
-                                       DataType data_type,
-                                       int dim);
-
 // Convert a single row of an Arrow ListArray to a protobuf ScalarField.
 // The element type is inferred from the ListArray's value type.
 // Supported value types: BOOL, INT8, INT16, INT32, INT64, FLOAT, DOUBLE, STRING.
@@ -464,7 +455,7 @@ ConvertToMicroseconds(int64_t value, arrow::TimeUnit::type unit) {
 
 // --- Tier 1: Atomic conversion helpers ---
 
-// Convert FixedSizeBinaryArray → BinaryArray (for nullable vectors).
+// Convert FixedSizeBinaryArray -> BinaryArray (for nullable vectors).
 // Null rows are skipped in the data buffer; offsets encode the gaps.
 arrow::ArrayVector
 ConvertFixedSizeBinaryToBinary(const arrow::ArrayVector& arrays);
@@ -473,32 +464,13 @@ ConvertFixedSizeBinaryToBinary(const arrow::ArrayVector& arrays);
 arrow::ArrayVector
 ConvertStringArrayToBinary(const arrow::ArrayVector& arrays);
 
-// Convert StringArray (WKT) → BinaryArray (WKB) via GEOS.
+// Convert StringArray (WKT) -> BinaryArray (WKB) via GEOS.
 arrow::ArrayVector
 ConvertWKTStringArrayToWKBBinary(const arrow::ArrayVector& arrays);
 
-// Convert TimestampArray → Int64Array (microseconds).
+// Convert TimestampArray -> Int64Array (microseconds).
 arrow::ArrayVector
 ConvertTimestampToInt64(const arrow::ArrayVector& arrays);
-
-// Convert ListArray<Scalar> → BinaryArray (protobuf-serialized ScalarFieldProto).
-arrow::ArrayVector
-ConvertListToProtobufBinary(const arrow::ArrayVector& arrays,
-                            DataType element_type);
-
-// Unified vector normalization: List/FSList → final format.
-// Non-nullable → FixedSizeBinaryArray; nullable → BinaryArray.
-arrow::ArrayVector
-NormalizeVectorArrays(const arrow::ArrayVector& arrays,
-                      DataType data_type,
-                      int64_t dim,
-                      bool nullable);
-
-// Normalize VectorArray inner arrays: List<List<Float>> → List<FixedSizeBinary>.
-arrow::ArrayVector
-NormalizeVectorArrayInner(const arrow::ArrayVector& arrays,
-                          DataType element_type,
-                          int64_t dim);
 
 // --- Tier 2: Per-consumer entry points ---
 
@@ -506,24 +478,16 @@ NormalizeVectorArrayInner(const arrow::ArrayVector& arrays,
 // Milvus internal arrow types. All consumer-specific entry points delegate here.
 //
 // Conversions:
-//   VARCHAR/STRING/TEXT/JSON: String → Binary (zero-copy)
-//   Geometry: String(WKT) → Binary(WKB) via GEOS; Binary stays as-is
-//   Timestamptz: Timestamp → Int64 (microseconds)
-//   Array: List(element) → Binary (protobuf)
-//   Vectors: various → FixedSizeBinary
-//   VectorArray: List<List<scalar>> → List<FixedSizeBinary>
+//   VARCHAR/STRING/TEXT/JSON: String -> Binary (zero-copy)
+//   Geometry: String(WKT) -> Binary(WKB) via GEOS; Binary stays as-is
+//   Timestamptz: Timestamp -> Int64 (microseconds)
+//   Array: List(element) -> Binary (protobuf)
+//   Vectors: various -> FixedSizeBinary
+//   VectorArray: List<List<scalar>> -> List<FixedSizeBinary>
 //
 std::shared_ptr<arrow::Array>
 NormalizeExternalArrow(const std::shared_ptr<arrow::Array>& array,
                        const FieldMeta& field_meta);
-
-// Overload for callers without FieldMeta (e.g. index build path).
-std::shared_ptr<arrow::Array>
-NormalizeExternalArrow(const std::shared_ptr<arrow::Array>& array,
-                       DataType data_type,
-                       int64_t dim,
-                       bool nullable,
-                       DataType element_type = DataType::NONE);
 
 // Load path: batch wrapper around NormalizeExternalArrow.
 arrow::ArrayVector

--- a/internal/core/unittest/test_arrow_canonicalize.cpp
+++ b/internal/core/unittest/test_arrow_canonicalize.cpp
@@ -16,10 +16,13 @@
 #include <gtest/gtest.h>
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
 #include "common/EasyAssert.h"
+#include "common/FieldMeta.h"
+#include "common/Types.h"
 #include "storage/Util.h"
 
 using milvus::storage::CanonicalizeArrowVariants;
@@ -268,13 +271,67 @@ TEST(CoerceToBinary, AllVariantsToBinary) {
     }
 }
 
-// ===== Scalar numeric mismatch rejection (via NormalizeExternalArrow) =====
-// External Arrow numeric types must match the Milvus scalar type exactly.
-// Wider integer inputs are rejected instead of implicitly narrowed.
-
-#include "common/FieldMeta.h"
-
 namespace {
+milvus::FieldMeta
+MakeExternalFieldMetaForTest(milvus::DataType data_type,
+                             int64_t dim,
+                             bool nullable,
+                             milvus::DataType element_type) {
+    const auto name = milvus::FieldName("field");
+    const auto field_id = milvus::FieldId(1000);
+    const auto external_field = "external_field";
+    if (data_type == milvus::DataType::VECTOR_ARRAY) {
+        return milvus::FieldMeta(name,
+                                 field_id,
+                                 data_type,
+                                 element_type,
+                                 dim,
+                                 std::nullopt,
+                                 external_field);
+    }
+    if (milvus::IsVectorDataType(data_type)) {
+        return milvus::FieldMeta(name,
+                                 field_id,
+                                 data_type,
+                                 dim,
+                                 std::nullopt,
+                                 nullable,
+                                 std::nullopt,
+                                 external_field);
+    }
+    if (milvus::IsStringDataType(data_type)) {
+        return milvus::FieldMeta(name,
+                                 field_id,
+                                 data_type,
+                                 65535,
+                                 nullable,
+                                 std::nullopt,
+                                 external_field);
+    }
+    if (milvus::IsArrayDataType(data_type)) {
+        return milvus::FieldMeta(name,
+                                 field_id,
+                                 data_type,
+                                 element_type,
+                                 nullable,
+                                 std::nullopt,
+                                 external_field);
+    }
+    return milvus::FieldMeta(
+        name, field_id, data_type, nullable, std::nullopt, external_field);
+}
+
+std::shared_ptr<arrow::Array>
+NormalizeVectorArraysToFixedSizeBinaryForTest(
+    const std::vector<std::shared_ptr<arrow::Array>>& arrays,
+    milvus::DataType data_type,
+    int64_t dim) {
+    AssertInfo(arrays.size() == 1, "test helper expects one array");
+    auto field_meta = MakeExternalFieldMetaForTest(
+        data_type, dim, false, milvus::DataType::NONE);
+    return milvus::storage::NormalizeExternalArrow(arrays.front(), field_meta);
+}
+
 std::shared_ptr<arrow::Array>
 MakeInt32Array(const std::vector<int32_t>& vals,
                const std::vector<bool>& valid) {
@@ -324,38 +381,42 @@ MakeDoubleArray(const std::vector<double>& vals,
 }
 }  // namespace
 
+// ===== Scalar numeric mismatch rejection (via NormalizeExternalArrow) =====
+// External Arrow numeric types must match the Milvus scalar type exactly.
+// Wider integer inputs are rejected instead of implicitly narrowed.
+
 TEST(ScalarNumericMismatch, Int32RejectsInt8) {
     auto in =
         MakeInt32Array({0, 1, 99, -128, 127}, {true, true, true, true, true});
-    EXPECT_THROW(
-        milvus::storage::NormalizeExternalArrow(
-            in, milvus::DataType::INT8, 0, false, milvus::DataType::NONE),
-        std::exception);
+    auto field_meta = MakeExternalFieldMetaForTest(
+        milvus::DataType::INT8, 0, false, milvus::DataType::NONE);
+    EXPECT_THROW(milvus::storage::NormalizeExternalArrow(in, field_meta),
+                 std::exception);
 }
 
 TEST(ScalarNumericMismatch, Int32RejectsInt16) {
     auto in =
         MakeInt32Array({0, 1000, -32768, 32767}, {true, true, true, true});
-    EXPECT_THROW(
-        milvus::storage::NormalizeExternalArrow(
-            in, milvus::DataType::INT16, 0, false, milvus::DataType::NONE),
-        std::exception);
+    auto field_meta = MakeExternalFieldMetaForTest(
+        milvus::DataType::INT16, 0, false, milvus::DataType::NONE);
+    EXPECT_THROW(milvus::storage::NormalizeExternalArrow(in, field_meta),
+                 std::exception);
 }
 
 TEST(ScalarNumericMismatch, Int32RejectsInt8WithNulls) {
     auto in = MakeInt32Array({5, 0, 7}, {true, false, true});
-    EXPECT_THROW(
-        milvus::storage::NormalizeExternalArrow(
-            in, milvus::DataType::INT8, 0, true, milvus::DataType::NONE),
-        std::exception);
+    auto field_meta = MakeExternalFieldMetaForTest(
+        milvus::DataType::INT8, 0, true, milvus::DataType::NONE);
+    EXPECT_THROW(milvus::storage::NormalizeExternalArrow(in, field_meta),
+                 std::exception);
 }
 
 TEST(ScalarNumericMismatch, Int32RejectsInt8EvenWhenInRange) {
     auto in = MakeInt32Array({5}, {true});
-    EXPECT_THROW(
-        milvus::storage::NormalizeExternalArrow(
-            in, milvus::DataType::INT8, 0, false, milvus::DataType::NONE),
-        std::exception);
+    auto field_meta = MakeExternalFieldMetaForTest(
+        milvus::DataType::INT8, 0, false, milvus::DataType::NONE);
+    EXPECT_THROW(milvus::storage::NormalizeExternalArrow(in, field_meta),
+                 std::exception);
 }
 
 TEST(ScalarNumericMismatch, ExactMatchPassesThrough) {
@@ -363,8 +424,9 @@ TEST(ScalarNumericMismatch, ExactMatchPassesThrough) {
     ASSERT_TRUE(b.Append(int8_t{5}).ok());
     std::shared_ptr<arrow::Array> in;
     ASSERT_TRUE(b.Finish(&in).ok());
-    auto out = milvus::storage::NormalizeExternalArrow(
-        in, milvus::DataType::INT8, 0, false, milvus::DataType::NONE);
+    auto field_meta = MakeExternalFieldMetaForTest(
+        milvus::DataType::INT8, 0, false, milvus::DataType::NONE);
+    auto out = milvus::storage::NormalizeExternalArrow(in, field_meta);
     EXPECT_EQ(out.get(), in.get());
 }
 
@@ -374,10 +436,10 @@ TEST(NormalizeExternalArrow, Int64RejectsString) {
     std::shared_ptr<arrow::Array> input;
     ASSERT_TRUE(builder.Finish(&input).ok());
 
-    EXPECT_THROW(
-        milvus::storage::NormalizeExternalArrow(
-            input, milvus::DataType::INT64, 0, false, milvus::DataType::NONE),
-        std::exception);
+    auto field_meta = MakeExternalFieldMetaForTest(
+        milvus::DataType::INT64, 0, false, milvus::DataType::NONE);
+    EXPECT_THROW(milvus::storage::NormalizeExternalArrow(input, field_meta),
+                 std::exception);
 }
 
 TEST(NormalizeExternalArrow, Issue49392ScalarMismatchesReject) {
@@ -394,35 +456,30 @@ TEST(NormalizeExternalArrow, Issue49392ScalarMismatchesReject) {
                            milvus::DataType::FLOAT,
                            milvus::DataType::DOUBLE,
                            milvus::DataType::TIMESTAMPTZ}) {
+        auto field_meta = MakeExternalFieldMetaForTest(
+            data_type, 0, false, milvus::DataType::NONE);
         EXPECT_THROW(
-            milvus::storage::NormalizeExternalArrow(
-                string_input, data_type, 0, false, milvus::DataType::NONE),
+            milvus::storage::NormalizeExternalArrow(string_input, field_meta),
             std::exception);
     }
 
     auto int64_input = MakeInt64Array({1, 2}, {true, true});
+    auto float_field_meta = MakeExternalFieldMetaForTest(
+        milvus::DataType::FLOAT, 0, false, milvus::DataType::NONE);
     EXPECT_THROW(
-        milvus::storage::NormalizeExternalArrow(int64_input,
-                                                milvus::DataType::FLOAT,
-                                                0,
-                                                false,
-                                                milvus::DataType::NONE),
+        milvus::storage::NormalizeExternalArrow(int64_input, float_field_meta),
         std::exception);
+    auto double_field_meta = MakeExternalFieldMetaForTest(
+        milvus::DataType::DOUBLE, 0, false, milvus::DataType::NONE);
     EXPECT_THROW(
-        milvus::storage::NormalizeExternalArrow(int64_input,
-                                                milvus::DataType::DOUBLE,
-                                                0,
-                                                false,
-                                                milvus::DataType::NONE),
+        milvus::storage::NormalizeExternalArrow(int64_input, double_field_meta),
         std::exception);
 
     auto double_input = MakeDoubleArray({1.0, 2.0}, {true, true});
+    auto int64_field_meta = MakeExternalFieldMetaForTest(
+        milvus::DataType::INT64, 0, false, milvus::DataType::NONE);
     EXPECT_THROW(
-        milvus::storage::NormalizeExternalArrow(double_input,
-                                                milvus::DataType::INT64,
-                                                0,
-                                                false,
-                                                milvus::DataType::NONE),
+        milvus::storage::NormalizeExternalArrow(double_input, int64_field_meta),
         std::exception);
 }
 
@@ -433,21 +490,15 @@ TEST(NormalizeExternalArrow, TimestamptzAcceptsTimestampAndInt64) {
     std::shared_ptr<arrow::Array> timestamp_input;
     ASSERT_TRUE(builder.Finish(&timestamp_input).ok());
 
+    auto field_meta = MakeExternalFieldMetaForTest(
+        milvus::DataType::TIMESTAMPTZ, 0, false, milvus::DataType::NONE);
     auto timestamp_out =
-        milvus::storage::NormalizeExternalArrow(timestamp_input,
-                                                milvus::DataType::TIMESTAMPTZ,
-                                                0,
-                                                false,
-                                                milvus::DataType::NONE);
+        milvus::storage::NormalizeExternalArrow(timestamp_input, field_meta);
     ASSERT_EQ(timestamp_out->type_id(), arrow::Type::INT64);
 
     auto int64_input = MakeInt64Array({1000, 2000}, {true, true});
     auto int64_out =
-        milvus::storage::NormalizeExternalArrow(int64_input,
-                                                milvus::DataType::TIMESTAMPTZ,
-                                                0,
-                                                false,
-                                                milvus::DataType::NONE);
+        milvus::storage::NormalizeExternalArrow(int64_input, field_meta);
     EXPECT_EQ(int64_out.get(), int64_input.get());
 }
 
@@ -458,9 +509,10 @@ TEST(NormalizeExternalArrow, StringLikeFieldsRejectInt64) {
                            milvus::DataType::TEXT,
                            milvus::DataType::JSON,
                            milvus::DataType::GEOMETRY}) {
+        auto field_meta = MakeExternalFieldMetaForTest(
+            data_type, 0, false, milvus::DataType::NONE);
         EXPECT_THROW(
-            milvus::storage::NormalizeExternalArrow(
-                int64_input, data_type, 0, false, milvus::DataType::NONE),
+            milvus::storage::NormalizeExternalArrow(int64_input, field_meta),
             std::exception);
     }
 }
@@ -477,7 +529,7 @@ TEST(NormalizeVectorArraysToFixedSizeBinary, ListDimMismatchAsserts) {
     ASSERT_TRUE(offsets_builder.Finish(&offsets).ok());
 
     auto input = *arrow::ListArray::FromArrays(*offsets, *values);
-    EXPECT_THROW(milvus::storage::NormalizeVectorArraysToFixedSizeBinary(
+    EXPECT_THROW(NormalizeVectorArraysToFixedSizeBinaryForTest(
                      {input}, milvus::DataType::VECTOR_FLOAT, 2),
                  std::exception);
 }
@@ -494,7 +546,7 @@ TEST(NormalizeVectorArraysToFixedSizeBinary, ListElementTypeMismatchAsserts) {
     ASSERT_TRUE(offsets_builder.Finish(&offsets).ok());
 
     auto input = *arrow::ListArray::FromArrays(*offsets, *values);
-    EXPECT_THROW(milvus::storage::NormalizeVectorArraysToFixedSizeBinary(
+    EXPECT_THROW(NormalizeVectorArraysToFixedSizeBinaryForTest(
                      {input}, milvus::DataType::VECTOR_FLOAT, 2),
                  std::exception);
 }
@@ -512,7 +564,7 @@ TEST(NormalizeVectorArraysToFixedSizeBinary, ListNullElementAsserts) {
     ASSERT_TRUE(offsets_builder.Finish(&offsets).ok());
 
     auto input = *arrow::ListArray::FromArrays(*offsets, *values);
-    EXPECT_THROW(milvus::storage::NormalizeVectorArraysToFixedSizeBinary(
+    EXPECT_THROW(NormalizeVectorArraysToFixedSizeBinaryForTest(
                      {input}, milvus::DataType::VECTOR_FLOAT, 2),
                  std::exception);
 }
@@ -525,7 +577,7 @@ TEST(NormalizeVectorArraysToFixedSizeBinary, FixedSizeListDimMismatchAsserts) {
 
     auto input = std::make_shared<arrow::FixedSizeListArray>(
         arrow::fixed_size_list(arrow::float32(), 3), 1, values);
-    EXPECT_THROW(milvus::storage::NormalizeVectorArraysToFixedSizeBinary(
+    EXPECT_THROW(NormalizeVectorArraysToFixedSizeBinaryForTest(
                      {input}, milvus::DataType::VECTOR_FLOAT, 2),
                  std::exception);
 }
@@ -539,7 +591,7 @@ TEST(NormalizeVectorArraysToFixedSizeBinary,
 
     auto input = std::make_shared<arrow::FixedSizeListArray>(
         arrow::fixed_size_list(arrow::int64(), 2), 1, values);
-    EXPECT_THROW(milvus::storage::NormalizeVectorArraysToFixedSizeBinary(
+    EXPECT_THROW(NormalizeVectorArraysToFixedSizeBinaryForTest(
                      {input}, milvus::DataType::VECTOR_FLOAT, 2),
                  std::exception);
 }
@@ -552,7 +604,7 @@ TEST(NormalizeVectorArraysToFixedSizeBinary, BinaryVectorRejectsFixedSizeList) {
 
     auto input = std::make_shared<arrow::FixedSizeListArray>(
         arrow::fixed_size_list(arrow::int8(), 8), 1, values);
-    EXPECT_THROW(milvus::storage::NormalizeVectorArraysToFixedSizeBinary(
+    EXPECT_THROW(NormalizeVectorArraysToFixedSizeBinaryForTest(
                      {input}, milvus::DataType::VECTOR_BINARY, 8),
                  std::exception);
 }
@@ -566,7 +618,7 @@ TEST(NormalizeVectorArraysToFixedSizeBinary,
 
     auto input = std::make_shared<arrow::FixedSizeListArray>(
         arrow::fixed_size_list(arrow::int16(), 2), 1, values);
-    EXPECT_THROW(milvus::storage::NormalizeVectorArraysToFixedSizeBinary(
+    EXPECT_THROW(NormalizeVectorArraysToFixedSizeBinaryForTest(
                      {input}, milvus::DataType::VECTOR_BFLOAT16, 2),
                  std::exception);
 }
@@ -580,7 +632,7 @@ TEST(NormalizeVectorArraysToFixedSizeBinary,
     std::shared_ptr<arrow::Array> input;
     ASSERT_TRUE(builder.Finish(&input).ok());
 
-    EXPECT_THROW(milvus::storage::NormalizeVectorArraysToFixedSizeBinary(
+    EXPECT_THROW(NormalizeVectorArraysToFixedSizeBinaryForTest(
                      {input}, milvus::DataType::VECTOR_FLOAT, 2),
                  std::exception);
 }
@@ -605,8 +657,10 @@ TEST(NormalizeVectorArrays, MixedChunkTypesNormalizeIndependently) {
     ASSERT_TRUE(offsets_builder.Finish(&offsets).ok());
 
     auto list_input = *arrow::ListArray::FromArrays(*offsets, *values);
-    auto out = milvus::storage::NormalizeVectorArrays(
-        {fsb_input, list_input}, milvus::DataType::VECTOR_FLOAT, 2, false);
+    auto field_meta = MakeExternalFieldMetaForTest(
+        milvus::DataType::VECTOR_FLOAT, 2, false, milvus::DataType::NONE);
+    auto out = milvus::storage::NormalizeArrowForChunkWriter(
+        {fsb_input, list_input}, field_meta);
 
     ASSERT_EQ(out.size(), 2);
     EXPECT_EQ(out[0]->type_id(), arrow::Type::FIXED_SIZE_BINARY);
@@ -628,13 +682,10 @@ TEST(NormalizeExternalArrow, NullableFloatVectorRejectsBinaryWidthMismatch) {
     std::shared_ptr<arrow::Array> input;
     ASSERT_TRUE(builder.Finish(&input).ok());
 
-    EXPECT_THROW(
-        milvus::storage::NormalizeExternalArrow(input,
-                                                milvus::DataType::VECTOR_FLOAT,
-                                                2,
-                                                true,
-                                                milvus::DataType::NONE),
-        std::exception);
+    auto field_meta = MakeExternalFieldMetaForTest(
+        milvus::DataType::VECTOR_FLOAT, 2, true, milvus::DataType::NONE);
+    EXPECT_THROW(milvus::storage::NormalizeExternalArrow(input, field_meta),
+                 std::exception);
 }
 
 TEST(NormalizeExternalArrow, FloatVectorRejectsFixedSizeBinaryWidthMismatch) {
@@ -645,13 +696,10 @@ TEST(NormalizeExternalArrow, FloatVectorRejectsFixedSizeBinaryWidthMismatch) {
     std::shared_ptr<arrow::Array> input;
     ASSERT_TRUE(builder.Finish(&input).ok());
 
-    EXPECT_THROW(
-        milvus::storage::NormalizeExternalArrow(input,
-                                                milvus::DataType::VECTOR_FLOAT,
-                                                2,
-                                                false,
-                                                milvus::DataType::NONE),
-        std::exception);
+    auto field_meta = MakeExternalFieldMetaForTest(
+        milvus::DataType::VECTOR_FLOAT, 2, false, milvus::DataType::NONE);
+    EXPECT_THROW(milvus::storage::NormalizeExternalArrow(input, field_meta),
+                 std::exception);
 }
 
 TEST(NormalizeExternalArrow,
@@ -663,13 +711,10 @@ TEST(NormalizeExternalArrow,
     std::shared_ptr<arrow::Array> input;
     ASSERT_TRUE(builder.Finish(&input).ok());
 
-    EXPECT_THROW(
-        milvus::storage::NormalizeExternalArrow(input,
-                                                milvus::DataType::VECTOR_FLOAT,
-                                                2,
-                                                true,
-                                                milvus::DataType::NONE),
-        std::exception);
+    auto field_meta = MakeExternalFieldMetaForTest(
+        milvus::DataType::VECTOR_FLOAT, 2, true, milvus::DataType::NONE);
+    EXPECT_THROW(milvus::storage::NormalizeExternalArrow(input, field_meta),
+                 std::exception);
 }
 
 TEST(NormalizeExternalArrow, FloatVectorRejectsFixedSizeListInt64) {
@@ -680,13 +725,10 @@ TEST(NormalizeExternalArrow, FloatVectorRejectsFixedSizeListInt64) {
 
     auto input = std::make_shared<arrow::FixedSizeListArray>(
         arrow::fixed_size_list(arrow::int64(), 2), 1, values);
-    EXPECT_THROW(
-        milvus::storage::NormalizeExternalArrow(input,
-                                                milvus::DataType::VECTOR_FLOAT,
-                                                2,
-                                                false,
-                                                milvus::DataType::NONE),
-        std::exception);
+    auto field_meta = MakeExternalFieldMetaForTest(
+        milvus::DataType::VECTOR_FLOAT, 2, false, milvus::DataType::NONE);
+    EXPECT_THROW(milvus::storage::NormalizeExternalArrow(input, field_meta),
+                 std::exception);
 }
 
 TEST(NormalizeExternalArrow, VectorArrayRejectsFixedSizeBinaryWidthMismatch) {
@@ -704,24 +746,24 @@ TEST(NormalizeExternalArrow, VectorArrayRejectsFixedSizeBinaryWidthMismatch) {
     ASSERT_TRUE(offsets_builder.Finish(&offsets).ok());
 
     auto input = *arrow::ListArray::FromArrays(*offsets, *values_array);
-    EXPECT_THROW(
-        milvus::storage::NormalizeExternalArrow(input,
-                                                milvus::DataType::VECTOR_ARRAY,
-                                                2,
-                                                false,
-                                                milvus::DataType::VECTOR_FLOAT),
-        std::exception);
+    auto field_meta =
+        MakeExternalFieldMetaForTest(milvus::DataType::VECTOR_ARRAY,
+                                     2,
+                                     false,
+                                     milvus::DataType::VECTOR_FLOAT);
+    EXPECT_THROW(milvus::storage::NormalizeExternalArrow(input, field_meta),
+                 std::exception);
 }
 
 TEST(NormalizeExternalArrow, VectorArrayRejectsNonListInput) {
     auto input = MakeInt64Array({1, 2}, {true, true});
-    EXPECT_THROW(
-        milvus::storage::NormalizeExternalArrow(input,
-                                                milvus::DataType::VECTOR_ARRAY,
-                                                2,
-                                                false,
-                                                milvus::DataType::VECTOR_FLOAT),
-        std::exception);
+    auto field_meta =
+        MakeExternalFieldMetaForTest(milvus::DataType::VECTOR_ARRAY,
+                                     2,
+                                     false,
+                                     milvus::DataType::VECTOR_FLOAT);
+    EXPECT_THROW(milvus::storage::NormalizeExternalArrow(input, field_meta),
+                 std::exception);
 }
 
 TEST(NormalizeExternalArrow, VectorArrayRejectsOuterNullRow) {
@@ -758,13 +800,13 @@ TEST(NormalizeExternalArrow, VectorArrayRejectsOuterNullRow) {
                                            null_bitmap,
                                            1);
 
-    EXPECT_THROW(
-        milvus::storage::NormalizeExternalArrow(input,
-                                                milvus::DataType::VECTOR_ARRAY,
-                                                2,
-                                                false,
-                                                milvus::DataType::VECTOR_FLOAT),
-        std::exception);
+    auto field_meta =
+        MakeExternalFieldMetaForTest(milvus::DataType::VECTOR_ARRAY,
+                                     2,
+                                     false,
+                                     milvus::DataType::VECTOR_FLOAT);
+    EXPECT_THROW(milvus::storage::NormalizeExternalArrow(input, field_meta),
+                 std::exception);
 }
 
 TEST(NormalizeExternalArrow, SparseVectorRejectsString) {
@@ -773,12 +815,12 @@ TEST(NormalizeExternalArrow, SparseVectorRejectsString) {
     std::shared_ptr<arrow::Array> input;
     ASSERT_TRUE(builder.Finish(&input).ok());
 
-    EXPECT_THROW(milvus::storage::NormalizeExternalArrow(
-                     input,
-                     milvus::DataType::VECTOR_SPARSE_U32_F32,
-                     0,
-                     false,
-                     milvus::DataType::NONE),
+    auto field_meta =
+        MakeExternalFieldMetaForTest(milvus::DataType::VECTOR_SPARSE_U32_F32,
+                                     0,
+                                     false,
+                                     milvus::DataType::NONE);
+    EXPECT_THROW(milvus::storage::NormalizeExternalArrow(input, field_meta),
                  std::exception);
 }
 
@@ -794,10 +836,10 @@ TEST(NormalizeExternalArrow, ArrayInt64RejectsStringList) {
     ASSERT_TRUE(offsets_builder.Finish(&offsets).ok());
 
     auto input = *arrow::ListArray::FromArrays(*offsets, *values);
-    EXPECT_THROW(
-        milvus::storage::NormalizeExternalArrow(
-            input, milvus::DataType::ARRAY, 0, false, milvus::DataType::INT64),
-        std::exception);
+    auto field_meta = MakeExternalFieldMetaForTest(
+        milvus::DataType::ARRAY, 0, false, milvus::DataType::INT64);
+    EXPECT_THROW(milvus::storage::NormalizeExternalArrow(input, field_meta),
+                 std::exception);
 }
 
 TEST(NormalizeExternalArrow, ArrayInt64RejectsNullElement) {
@@ -813,10 +855,10 @@ TEST(NormalizeExternalArrow, ArrayInt64RejectsNullElement) {
     ASSERT_TRUE(offsets_builder.Finish(&offsets).ok());
 
     auto input = *arrow::ListArray::FromArrays(*offsets, *values);
-    EXPECT_THROW(
-        milvus::storage::NormalizeExternalArrow(
-            input, milvus::DataType::ARRAY, 0, false, milvus::DataType::INT64),
-        std::exception);
+    auto field_meta = MakeExternalFieldMetaForTest(
+        milvus::DataType::ARRAY, 0, false, milvus::DataType::INT64);
+    EXPECT_THROW(milvus::storage::NormalizeExternalArrow(input, field_meta),
+                 std::exception);
 }
 
 TEST(NormalizeExternalArrow, ArrayVarcharRejectsInt64List) {
@@ -831,13 +873,10 @@ TEST(NormalizeExternalArrow, ArrayVarcharRejectsInt64List) {
     ASSERT_TRUE(offsets_builder.Finish(&offsets).ok());
 
     auto input = *arrow::ListArray::FromArrays(*offsets, *values);
-    EXPECT_THROW(
-        milvus::storage::NormalizeExternalArrow(input,
-                                                milvus::DataType::ARRAY,
-                                                0,
-                                                false,
-                                                milvus::DataType::VARCHAR),
-        std::exception);
+    auto field_meta = MakeExternalFieldMetaForTest(
+        milvus::DataType::ARRAY, 0, false, milvus::DataType::VARCHAR);
+    EXPECT_THROW(milvus::storage::NormalizeExternalArrow(input, field_meta),
+                 std::exception);
 }
 
 TEST(NormalizeExternalArrow, ArrayVarcharAcceptsStringList) {
@@ -852,8 +891,9 @@ TEST(NormalizeExternalArrow, ArrayVarcharAcceptsStringList) {
     ASSERT_TRUE(offsets_builder.Finish(&offsets).ok());
 
     auto input = *arrow::ListArray::FromArrays(*offsets, *values);
-    auto out = milvus::storage::NormalizeExternalArrow(
-        input, milvus::DataType::ARRAY, 0, false, milvus::DataType::VARCHAR);
+    auto field_meta = MakeExternalFieldMetaForTest(
+        milvus::DataType::ARRAY, 0, false, milvus::DataType::VARCHAR);
+    auto out = milvus::storage::NormalizeExternalArrow(input, field_meta);
     ASSERT_EQ(out->type_id(), arrow::Type::BINARY);
     ASSERT_EQ(out->length(), 1);
     EXPECT_FALSE(out->IsNull(0));

--- a/internal/core/unittest/test_external_take.cpp
+++ b/internal/core/unittest/test_external_take.cpp
@@ -1873,6 +1873,55 @@ TEST(InjectExtfsAllowlist, IcebergSnapshotIDAcceptsString) {
 
 namespace {
 
+FieldMeta
+MakeExternalFieldMetaForNormalizeTest(DataType data_type,
+                                      int64_t dim,
+                                      bool nullable,
+                                      DataType element_type) {
+    const auto name = FieldName("field");
+    const auto field_id = FieldId(1000);
+    const auto external_field = "external_field";
+    if (data_type == DataType::VECTOR_ARRAY) {
+        return FieldMeta(name,
+                         field_id,
+                         data_type,
+                         element_type,
+                         dim,
+                         std::nullopt,
+                         external_field);
+    }
+    if (IsVectorDataType(data_type)) {
+        return FieldMeta(name,
+                         field_id,
+                         data_type,
+                         dim,
+                         std::nullopt,
+                         nullable,
+                         std::nullopt,
+                         external_field);
+    }
+    if (IsStringDataType(data_type)) {
+        return FieldMeta(name,
+                         field_id,
+                         data_type,
+                         65535,
+                         nullable,
+                         std::nullopt,
+                         external_field);
+    }
+    if (IsArrayDataType(data_type)) {
+        return FieldMeta(name,
+                         field_id,
+                         data_type,
+                         element_type,
+                         nullable,
+                         std::nullopt,
+                         external_field);
+    }
+    return FieldMeta(
+        name, field_id, data_type, nullable, std::nullopt, external_field);
+}
+
 std::shared_ptr<arrow::StringArray>
 MakeStringArray(const std::vector<std::string>& values) {
     arrow::StringBuilder builder;
@@ -1892,8 +1941,10 @@ TEST(NormalizeExternalArrow, VarcharStringConvertedToBinary) {
     auto str_array = MakeStringArray({"hello", "world", "test"});
     ASSERT_EQ(str_array->type_id(), arrow::Type::STRING);
 
-    auto result = milvus::storage::NormalizeExternalArrow(
-        str_array, milvus::DataType::VARCHAR, 0, false, milvus::DataType::NONE);
+    auto field_meta = MakeExternalFieldMetaForNormalizeTest(
+        milvus::DataType::VARCHAR, 0, false, milvus::DataType::NONE);
+    auto result =
+        milvus::storage::NormalizeExternalArrow(str_array, field_meta);
 
     EXPECT_EQ(result->type_id(), arrow::Type::BINARY);
     EXPECT_EQ(result->length(), 3);
@@ -1909,8 +1960,10 @@ TEST(NormalizeExternalArrow, VarcharBinaryPassthrough) {
     auto bin_array = std::make_shared<arrow::BinaryArray>(bin_data);
     ASSERT_EQ(bin_array->type_id(), arrow::Type::BINARY);
 
-    auto result = milvus::storage::NormalizeExternalArrow(
-        bin_array, milvus::DataType::VARCHAR, 0, false, milvus::DataType::NONE);
+    auto field_meta = MakeExternalFieldMetaForNormalizeTest(
+        milvus::DataType::VARCHAR, 0, false, milvus::DataType::NONE);
+    auto result =
+        milvus::storage::NormalizeExternalArrow(bin_array, field_meta);
 
     // BINARY is not STRING, so the String→Binary branch does not fire; passthrough.
     EXPECT_EQ(result->type_id(), arrow::Type::BINARY);
@@ -1937,8 +1990,10 @@ TEST(NormalizeExternalArrow, VarcharFillFieldDataSucceedsWithBinary) {
     auto str_array = MakeStringArray({"hello", "world"});
 
     // Simulate what NormalizeExternalArrow does: STRING → BINARY
-    auto normalized = milvus::storage::NormalizeExternalArrow(
-        str_array, milvus::DataType::VARCHAR, 0, false, milvus::DataType::NONE);
+    auto field_meta = MakeExternalFieldMetaForNormalizeTest(
+        milvus::DataType::VARCHAR, 0, false, milvus::DataType::NONE);
+    auto normalized =
+        milvus::storage::NormalizeExternalArrow(str_array, field_meta);
     ASSERT_EQ(normalized->type_id(), arrow::Type::BINARY);
 
     auto chunked = std::make_shared<arrow::ChunkedArray>(normalized);
@@ -1956,8 +2011,10 @@ TEST(NormalizeExternalArrow, JsonStringConvertedToBinary) {
     auto str_array = MakeStringArray({R"({"a":1})", R"({"b":2})"});
     ASSERT_EQ(str_array->type_id(), arrow::Type::STRING);
 
-    auto result = milvus::storage::NormalizeExternalArrow(
-        str_array, milvus::DataType::JSON, 0, false, milvus::DataType::NONE);
+    auto field_meta = MakeExternalFieldMetaForNormalizeTest(
+        milvus::DataType::JSON, 0, false, milvus::DataType::NONE);
+    auto result =
+        milvus::storage::NormalizeExternalArrow(str_array, field_meta);
 
     EXPECT_EQ(result->type_id(), arrow::Type::BINARY);
     EXPECT_EQ(result->length(), 2);
@@ -1970,8 +2027,9 @@ TEST(NormalizeExternalArrow, NonMatchingTypePassthrough) {
     assert(s.ok());
     auto arr = builder.Finish().ValueOrDie();
 
-    auto result = milvus::storage::NormalizeExternalArrow(
-        arr, milvus::DataType::INT64, 0, false, milvus::DataType::NONE);
+    auto field_meta = MakeExternalFieldMetaForNormalizeTest(
+        milvus::DataType::INT64, 0, false, milvus::DataType::NONE);
+    auto result = milvus::storage::NormalizeExternalArrow(arr, field_meta);
 
     EXPECT_EQ(result->type_id(), arrow::Type::INT64);
     EXPECT_EQ(result.get(), arr.get());


### PR DESCRIPTION
issue: #45881

## What changed

This PR passes `FieldMeta` through external Arrow normalization so
conversion and validation errors include both the Milvus field name and
the configured `external_field` name.

It also keeps the public `NormalizeExternalArrow` entry point
schema-driven and updates C++ tests for vector/list normalization and
field-aware error messages.

## Validation

- Ubuntu builder `make cppcheck`
- Related C++ UT filter: 70 tests passed

Full `make test-cpp` was also attempted earlier; it failed in existing
`TextMatch.*` tests unrelated to this change.
