### PR TITLE
test: pay down ruff lint debt in func_check.py and test_index.py

### DIFF
--- a/tests/python_client/check/func_check.py
+++ b/tests/python_client/check/func_check.py
@@ -1,21 +1,21 @@
-import pandas.core.frame
-from pymilvus.client.types import CompactionPlans
-from pymilvus import Role
-
-from utils.util_log import test_log as log
-from common import common_type as ct
-from common import common_func as cf
-from common.common_type import CheckTasks, Connect_Object_Name
-# from common.code_mapping import ErrorCode, ErrorMessage
-from pymilvus import Collection, Partition, ResourceGroupInfo, DataType
 import check.param_check as pc
 import numpy as np
+import pandas.core.frame
+from common import common_func as cf
+from common import common_type as ct
+from common.common_type import CheckTasks
 from ml_dtypes import bfloat16
+
+# from common.code_mapping import ErrorCode, ErrorMessage
+from pymilvus import Collection, DataType, Partition, ResourceGroupInfo, Role
+from pymilvus.client.types import CompactionPlans
+from utils.util_log import test_log as log
+
 
 class Error:
     def __init__(self, error):
-        self.code = getattr(error, 'code', -1)
-        self.message = getattr(error, 'message', str(error))
+        self.code = getattr(error, "code", -1)
+        self.message = getattr(error, "message", str(error))
 
     def __str__(self):
         return f"Error(code={self.code}, message={self.message})"
@@ -141,7 +141,6 @@ class ResponseChecker:
         assert actual is False, f"Response of API {self.func_name} expect get error, but success"
         assert len(error_dict) > 0
         if isinstance(res, Error):
-            error_code = error_dict[ct.err_code]
             # assert res.code == error_code or error_dict[ct.err_msg] in res.message, (
             #     f"Response of API {self.func_name} "
             #     f"expect get error code {error_dict[ct.err_code]} or error message {error_dict[ct.err_code]}, "
@@ -149,27 +148,30 @@ class ResponseChecker:
             assert error_dict[ct.err_msg] in res.message, (
                 f"Response of API {self.func_name} "
                 f"expect get error message {error_dict[ct.err_code]}, "
-                f"but got {res.code} {res.message}")
+                f"but got {res.code} {res.message}"
+            )
 
         else:
-            log.error("[CheckFunc] Response of API is not an error: %s" % str(res))
-            assert False, (f"Response of API expect get error code {error_dict[ct.err_code]} or "
-                           f"error message {error_dict[ct.err_code]}"
-                           f"but success")
+            log.error(f"[CheckFunc] Response of API is not an error: {str(res)}")
+            assert False, (
+                f"Response of API expect get error code {error_dict[ct.err_code]} or "
+                f"error message {error_dict[ct.err_code]}"
+                f"but success"
+            )
         return True
 
     @staticmethod
     def check_value_equal(res, func_name, params):
-        """ check response of connection interface that result is normal """
+        """check response of connection interface that result is normal"""
 
         if func_name == "list_connections":
             if not isinstance(res, list):
-                log.error("[CheckFunc] Response of list_connections is not a list: %s" % str(res))
+                log.error(f"[CheckFunc] Response of list_connections is not a list: {str(res)}")
                 assert False
 
             list_content = params.get(ct.list_content, None)
             if not isinstance(list_content, list):
-                log.error("[CheckFunc] Check param of list_content is not a list: %s" % str(list_content))
+                log.error(f"[CheckFunc] Check param of list_content is not a list: {str(list_content)}")
                 assert False
 
             new_res = pc.get_connect_object_name(res)
@@ -206,7 +208,7 @@ class ResponseChecker:
         exp_func_name = "init_collection"
         exp_func_name_2 = "construct_from_dataframe"
         if func_name != exp_func_name and func_name != exp_func_name_2:
-            log.warning("The function name is {} rather than {}".format(func_name, exp_func_name))
+            log.warning(f"The function name is {func_name} rather than {exp_func_name}")
         if isinstance(res, Collection):
             collection = res
         elif isinstance(res, tuple):
@@ -242,7 +244,7 @@ class ResponseChecker:
         """
         exp_func_name = "describe_collection"
         if func_name != exp_func_name:
-            log.warning("The function name is {} rather than {}".format(func_name, exp_func_name))
+            log.warning(f"The function name is {func_name} rather than {exp_func_name}")
         if len(check_items) == 0:
             raise Exception("No expect values found in the check task")
         if check_items.get("collection_name", None) is not None:
@@ -313,7 +315,7 @@ class ResponseChecker:
         """
         exp_func_name = "describe_collection"
         if func_name != exp_func_name:
-            log.warning("The function name is {} rather than {}".format(func_name, exp_func_name))
+            log.warning(f"The function name is {func_name} rather than {exp_func_name}")
         if len(check_items) == 0:
             raise Exception("No expect values found in the check task")
         if check_items.get("collection_name", None) is not None:
@@ -321,7 +323,7 @@ class ResponseChecker:
         for key in check_items.keys():
             for field in res["fields"]:
                 if field["name"] == key:
-                    assert field['params'].items() >= check_items[key].items()
+                    assert field["params"].items() >= check_items[key].items()
         return True
 
     @staticmethod
@@ -339,7 +341,7 @@ class ResponseChecker:
         """
         exp_func_name = "describe_database"
         if func_name != exp_func_name:
-            log.warning("The function name is {} rather than {}".format(func_name, exp_func_name))
+            log.warning(f"The function name is {func_name} rather than {exp_func_name}")
         if len(check_items) == 0:
             raise Exception("No expect values found in the check task")
         if check_items.get("db_name", None) is not None:
@@ -368,7 +370,7 @@ class ResponseChecker:
     def check_partition_property(partition, func_name, check_items):
         exp_func_name = "init_partition"
         if func_name != exp_func_name:
-            log.warning("The function name is {} rather than {}".format(func_name, exp_func_name))
+            log.warning(f"The function name is {func_name} rather than {exp_func_name}")
         if not isinstance(partition, Partition):
             raise Exception("The result to check isn't partition type object")
         if len(check_items) == 0:
@@ -387,7 +389,7 @@ class ResponseChecker:
     def check_rg_property(rg, func_name, check_items):
         exp_func_name = "describe_resource_group"
         if func_name != exp_func_name:
-            log.warning("The function name is {} rather than {}".format(func_name, exp_func_name))
+            log.warning(f"The function name is {func_name} rather than {exp_func_name}")
         if not isinstance(rg, ResourceGroupInfo):
             raise Exception("The result to check isn't ResourceGroupInfo type object")
         if len(check_items) == 0:
@@ -417,10 +419,13 @@ class ResponseChecker:
         """
         log.info("search_results_check: checking the searching results")
         enable_milvus_client_api = check_items.get("enable_milvus_client_api", False)
-        pk_name = check_items.get("pk_name", ct.default_primary_field_name) if enable_milvus_client_api is False \
-            else check_items.get("pk_name", 'id')
+        pk_name = (
+            check_items.get("pk_name", ct.default_primary_field_name)
+            if enable_milvus_client_api is False
+            else check_items.get("pk_name", "id")
+        )
 
-        if func_name != 'search' and func_name != 'hybrid_search':
+        if func_name != "search" and func_name != "hybrid_search":
             log.warning("The function name is {} rather than {} or {}".format(func_name, "search", "hybrid_search"))
         if len(check_items) == 0:
             raise Exception("No expect values found in the check task")
@@ -436,9 +441,10 @@ class ResponseChecker:
                     original_entities = pandas.DataFrame(original_entities)
                 pc.output_field_value_check(search_res, original_entities, pk_name=pk_name)
         if len(search_res) != check_items["nq"]:
-            log.error("search_results_check: Numbers of query searched(nq) (%d) "
-                      "is not equal with expected (%d)"
-                      % (len(search_res), check_items["nq"]))
+            log.error(
+                f"search_results_check: Numbers of query searched(nq) ({len(search_res)}) "
+                f"is not equal with expected ({check_items['nq']})"
+            )
             assert len(search_res) == check_items["nq"]
         else:
             log.info("search_results_check: Numbers of query searched is correct")
@@ -449,15 +455,17 @@ class ResponseChecker:
             if enable_milvus_client_api:
                 for hit in hits:
                     ids.append(hit[pk_name])
-                    distances.append(hit['distance'])
+                    distances.append(hit["distance"])
             else:
                 ids = list(hits.ids)
                 distances = list(hits.distances)
-            if check_items.get("limit", None) is not None \
-                    and ((len(hits) != check_items["limit"]) or (len(set(ids)) != check_items["limit"])):
-                log.error("search_results_check: limit(topK) searched (%d) "
-                          "is not equal with expected (%d)"
-                          % (len(hits), check_items["limit"]))
+            if check_items.get("limit", None) is not None and (
+                (len(hits) != check_items["limit"]) or (len(set(ids)) != check_items["limit"])
+            ):
+                log.error(
+                    f"search_results_check: limit(topK) searched ({len(hits)}) "
+                    f"is not equal with expected ({check_items['limit']})"
+                )
                 assert len(hits) == check_items["limit"]
                 assert len(set(ids)) == check_items["limit"]
             if check_items.get("ids", None) is not None:
@@ -467,7 +475,7 @@ class ResponseChecker:
                     assert ids_match
             if check_items.get("metric", None) is not None:
                 # verify the distances are already sorted
-                num_to_check = min(100, len(distances))   # check 100 items if more than that
+                num_to_check = min(100, len(distances))  # check 100 items if more than that
                 if check_items.get("metric").upper() in ["IP", "COSINE", "BM25"]:
                     assert distances[:num_to_check] == sorted(distances[:num_to_check], reverse=True)
                 else:
@@ -479,8 +487,7 @@ class ResponseChecker:
             else:
                 pass  # just check nq and topk, not specific ids need check
 
-        log.info("search_results_check: limit (topK) and "
-                 "ids searched for %d queries are correct" % len(search_res))
+        log.info(f"search_results_check: limit (topK) and ids searched for {len(search_res)} queries are correct")
         return True
 
     @staticmethod
@@ -493,7 +500,7 @@ class ResponseChecker:
         expected: check the search is ok
         """
         log.info("search_iterator_results_check: checking the searching results")
-        if func_name != 'search_iterator':
+        if func_name != "search_iterator":
             log.warning("The function name is {} rather than {}".format(func_name, "search_iterator"))
         search_iterator = search_res
         expected_batch_size = check_items.get("batch_size", None)
@@ -557,7 +564,7 @@ class ResponseChecker:
                             The type of with_vec value is bool, True value means check vector field, False otherwise
         :type check_items: dict
         """
-        if func_name != 'query':
+        if func_name != "query":
             log.warning("The function name is {} rather than {}".format(func_name, "query"))
         if not isinstance(query_res, list):
             raise Exception("The query result to check isn't list type object")
@@ -571,39 +578,47 @@ class ResponseChecker:
             assert count == query_res[0].get("count(*)", None)
             return True
         if exp_limit is None and exp_res is None and check_items.get("output_fields") is None:
-            raise Exception(f"No expected values would be checked in the check task")
+            raise Exception("No expected values would be checked in the check task")
         if exp_limit is not None:
             assert len(query_res) == exp_limit
         output_fields = check_items.get("output_fields", None)
         if output_fields is not None:
             for row in query_res:
-                assert set(output_fields) == set(row.keys()), \
+                assert set(output_fields) == set(row.keys()), (
                     f"output_fields check failed: expected {output_fields}, got {list(row.keys())}"
+                )
         # pk_name = check_items.get("pk_name", ct.default_primary_field_name)
         if exp_res is not None:
             if with_vec is True:
-                vector_type = check_items.get('vector_type', 'FLOAT_VECTOR')
-                vector_field = check_items.get('vector_field', 'vector')
+                vector_type = check_items.get("vector_type", "FLOAT_VECTOR")
+                vector_field = check_items.get("vector_field", "vector")
                 if vector_type == DataType.FLOAT16_VECTOR:
                     for single_query_result in query_res:
                         if single_query_result[vector_field]:
-                            single_query_result[vector_field] = np.frombuffer(single_query_result[vector_field][0], dtype=np.float16).tolist()
+                            single_query_result[vector_field] = np.frombuffer(
+                                single_query_result[vector_field][0], dtype=np.float16
+                            ).tolist()
                 if vector_type == DataType.BFLOAT16_VECTOR:
                     for single_query_result in query_res:
                         if single_query_result[vector_field]:
-                            single_query_result[vector_field] = np.frombuffer(single_query_result[vector_field][0], dtype=bfloat16).tolist()
+                            single_query_result[vector_field] = np.frombuffer(
+                                single_query_result[vector_field][0], dtype=bfloat16
+                            ).tolist()
                 if vector_type == DataType.INT8_VECTOR:
                     for single_query_result in query_res:
                         if single_query_result[vector_field]:
-                            single_query_result[vector_field] = np.frombuffer(single_query_result[vector_field][0], dtype=np.int8).tolist()
+                            single_query_result[vector_field] = np.frombuffer(
+                                single_query_result[vector_field][0], dtype=np.int8
+                            ).tolist()
             if isinstance(query_res, list):
                 debug_mode = check_items.get("debug_mode", False)
                 if debug_mode is True:
                     assert pc.compare_lists_with_epsilon_ignore_dict_order_deepdiff(a=query_res, b=exp_res)
                 else:
-                    assert pc.compare_lists_with_epsilon_ignore_dict_order(a=query_res, b=exp_res), \
-                        f"there exists different values between query_results and expected_results, " \
-                        f"use debug_mode in check_items to print the difference entity by entity(but it is slow)"
+                    assert pc.compare_lists_with_epsilon_ignore_dict_order(a=query_res, b=exp_res), (
+                        "there exists different values between query_results and expected_results, "
+                        "use debug_mode in check_items to print the difference entity by entity(but it is slow)"
+                    )
             else:
                 log.error(f"Query result {query_res} is not list")
                 return False
@@ -620,7 +635,7 @@ class ResponseChecker:
         expected: check the search is ok
         """
         log.info("query_iterator_results_check: checking the query results")
-        if func_name != 'query_iterator':
+        if func_name != "query_iterator":
             log.warning("The function name is {} rather than {}".format(func_name, "query_iterator"))
         query_iterator = query_res
         pk_list = []
@@ -641,7 +656,7 @@ class ResponseChecker:
             assert len(pk_list) == check_items["count"]
         if check_items.get("exp_ids", None):
             assert pk_list == check_items["exp_ids"]
-        log.info("check: total %d results" % len(pk_list))
+        log.info(f"check: total {len(pk_list)} results")
 
         return True
 
@@ -656,7 +671,7 @@ class ResponseChecker:
         :param func_name: Query API name
         :type func_name: str
         """
-        if func_name != 'query':
+        if func_name != "query":
             log.warning("The function name is {} rather than {}".format(func_name, "query"))
         if not isinstance(query_res, list):
             raise Exception("The query result to check isn't list type object")
@@ -673,7 +688,7 @@ class ResponseChecker:
         :param func_name: Query API name
         :type func_name: str
         """
-        if func_name != 'query':
+        if func_name != "query":
             log.warning("The function name is {} rather than {}".format(func_name, "query"))
         if not isinstance(query_res, list):
             raise Exception("The query result to check isn't list type object")
@@ -681,7 +696,7 @@ class ResponseChecker:
 
     @staticmethod
     def check_distance(distance_res, func_name, check_items):
-        if func_name != 'calc_distance':
+        if func_name != "calc_distance":
             log.warning("The function name is {} rather than {}".format(func_name, "calc_distance"))
         if not isinstance(distance_res, list):
             raise Exception("The distance result to check isn't list type object")
@@ -691,9 +706,7 @@ class ResponseChecker:
         vectors_r = check_items["vectors_r"]
         metric = check_items.get("metric", "L2")
         sqrt = check_items.get("sqrt", False)
-        cf.compare_distance_2d_vector(vectors_l, vectors_r,
-                                      distance_res,
-                                      metric, sqrt)
+        cf.compare_distance_2d_vector(vectors_l, vectors_r, distance_res, metric, sqrt)
 
         return True
 
@@ -712,9 +725,9 @@ class ResponseChecker:
                             plans_num represent the delete compact plans number
         :type: dict
         """
-        to_check_func = 'get_compaction_plans'
+        to_check_func = "get_compaction_plans"
         if func_name != to_check_func:
-            log.warning("The function name is {} rather than {}".format(func_name, to_check_func))
+            log.warning(f"The function name is {func_name} rather than {to_check_func}")
         if not isinstance(compaction_plans, CompactionPlans):
             raise Exception("The compaction_plans result to check isn't CompactionPlans type object")
 
@@ -739,9 +752,9 @@ class ResponseChecker:
                             segment_num represent how many segments are expected to be merged, default is 2
         :type: dict
         """
-        to_check_func = 'get_compaction_plans'
+        to_check_func = "get_compaction_plans"
         if func_name != to_check_func:
-            log.warning("The function name is {} rather than {}".format(func_name, to_check_func))
+            log.warning(f"The function name is {func_name} rather than {to_check_func}")
         if not isinstance(compaction_plans, CompactionPlans):
             raise Exception("The compaction_plans result to check isn't CompactionPlans type object")
 
@@ -754,7 +767,7 @@ class ResponseChecker:
     def check_role_property(role, func_name, check_items):
         exp_func_name = "create_role"
         if func_name != exp_func_name:
-            log.warning("The function name is {} rather than {}".format(func_name, exp_func_name))
+            log.warning(f"The function name is {func_name} rather than {exp_func_name}")
         if not isinstance(role, Role):
             raise Exception("The result to check isn't role type object")
         if check_items is None:
@@ -769,7 +782,7 @@ class ResponseChecker:
         if isinstance(res, Error):
             assert "permission deny" in res.message
         else:
-            log.error("[CheckFunc] Response of API is not an error: %s" % str(res))
+            log.error(f"[CheckFunc] Response of API is not an error: {str(res)}")
             assert False
         return True
 
@@ -779,7 +792,7 @@ class ResponseChecker:
         if isinstance(res, Error):
             assert "auth check failure" in res.message
         else:
-            log.error("[CheckFunc] Response of API is not an error: %s" % str(res))
+            log.error(f"[CheckFunc] Response of API is not an error: {str(res)}")
             assert False
         return True
 
@@ -813,7 +826,7 @@ class ResponseChecker:
         """
         exp_func_name = "describe_index"
         if func_name != exp_func_name:
-            log.warning("The function name is {} rather than {}".format(func_name, exp_func_name))
+            log.warning(f"The function name is {func_name} rather than {exp_func_name}")
         if len(check_items) == 0:
             raise Exception("No expect values found in the check task")
         if check_items.get("json_cast_type", None) is not None:

--- a/tests/python_client/testcases/test_index.py
+++ b/tests/python_client/testcases/test_index.py
@@ -1,27 +1,33 @@
-import random
-from time import sleep
-
-import numpy as np
-import pytest
 import copy
+import random
+import time
 
+import pytest
 from base.client_base import TestcaseBase
 from base.index_wrapper import ApiIndexWrapper
-from base.collection_wrapper import ApiCollectionWrapper
-from utils.util_log import test_log as log
 from common import common_func as cf
 from common import common_type as ct
-from common.common_type import CaseLabel, CheckTasks
 from common.code_mapping import CollectionErrorMessage as clem
 from common.code_mapping import IndexErrorMessage as iem
 from common.common_params import (
-    IndexName, FieldParams, IndexPrams, DefaultVectorIndexParams, DefaultScalarIndexParams, MetricType, AlterIndexParams
+    AlterIndexParams,
+    DefaultScalarIndexParams,
+    DefaultVectorIndexParams,
+    FieldParams,
+    IndexName,
+    IndexPrams,
+    MetricType,
 )
-
-from utils.util_pymilvus import *
-from common.constants import *
-from pymilvus.exceptions import MilvusException
+from common.common_type import CaseLabel, CheckTasks
 from pymilvus import DataType
+from pymilvus.exceptions import MilvusException
+from utils.util_log import test_log as log
+from utils.util_pymilvus import (
+    MyThread,
+    default_binary_vec_field_name,
+    default_dim,
+    default_float_vec_field_name,
+)
 
 prefix = "index"
 default_schema = cf.gen_default_collection_schema()
@@ -57,7 +63,7 @@ default_nb = ct.default_nb
 
 @pytest.mark.tags(CaseLabel.GPU)
 class TestIndexParams(TestcaseBase):
-    """ Test case of index interface """
+    """Test case of index interface"""
 
     @pytest.mark.tags(CaseLabel.L1)
     @pytest.mark.parametrize("collection", [None, "coll"])
@@ -68,8 +74,13 @@ class TestIndexParams(TestcaseBase):
         expected: raise exception
         """
         self._connect()
-        self.index_wrap.init_index(collection, default_field_name, default_index_params, check_task=CheckTasks.err_res,
-                                   check_items={ct.err_code: 0, ct.err_msg: clem.CollectionType})
+        self.index_wrap.init_index(
+            collection,
+            default_field_name,
+            default_index_params,
+            check_task=CheckTasks.err_res,
+            check_items={ct.err_code: 0, ct.err_msg: clem.CollectionType},
+        )
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_index_field_name_not_existed(self):
@@ -82,10 +93,13 @@ class TestIndexParams(TestcaseBase):
 
         collection_w = self.init_collection_wrap(name=collection_name)
         fieldname = "non_existing"
-        self.index_wrap.init_index(collection_w.collection, fieldname, default_index_params,
-                                   check_task=CheckTasks.err_res,
-                                   check_items={ct.err_code: 65535,
-                                                ct.err_msg: f"cannot create index on non-exist field: {fieldname}"})
+        self.index_wrap.init_index(
+            collection_w.collection,
+            fieldname,
+            default_index_params,
+            check_task=CheckTasks.err_res,
+            check_items={ct.err_code: 65535, ct.err_msg: f"cannot create index on non-exist field: {fieldname}"},
+        )
 
     @pytest.mark.tags(CaseLabel.L0)
     @pytest.mark.parametrize("index_type", ["non_exiting_type", 100])
@@ -99,9 +113,13 @@ class TestIndexParams(TestcaseBase):
         collection_w = self.init_collection_wrap(name=c_name)
         index_params = copy.deepcopy(default_index_params)
         index_params["index_type"] = index_type
-        self.index_wrap.init_index(collection_w.collection, default_field_name, index_params,
-                                   check_task=CheckTasks.err_res,
-                                   check_items={ct.err_code: 1100, ct.err_msg: "invalid parameter["})
+        self.index_wrap.init_index(
+            collection_w.collection,
+            default_field_name,
+            index_params,
+            check_task=CheckTasks.err_res,
+            check_items={ct.err_code: 1100, ct.err_msg: "invalid parameter["},
+        )
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_index_type_not_supported(self):
@@ -114,9 +132,13 @@ class TestIndexParams(TestcaseBase):
         collection_w = self.init_collection_wrap(name=c_name)
         index_params = copy.deepcopy(default_index_params)
         index_params["index_type"] = "IVFFFFFFF"
-        self.index_wrap.init_index(collection_w.collection, default_field_name, index_params,
-                                   check_task=CheckTasks.err_res,
-                                   check_items={ct.err_code: 999, ct.err_msg: ""})
+        self.index_wrap.init_index(
+            collection_w.collection,
+            default_field_name,
+            index_params,
+            check_task=CheckTasks.err_res,
+            check_items={ct.err_code: 999, ct.err_msg: ""},
+        )
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_index_params_invalid(self, get_invalid_index_params):
@@ -128,9 +150,13 @@ class TestIndexParams(TestcaseBase):
         c_name = cf.gen_unique_str(prefix)
         collection_w = self.init_collection_wrap(name=c_name)
         index_params = get_invalid_index_params
-        self.index_wrap.init_index(collection_w.collection, default_field_name, index_params,
-                                   check_task=CheckTasks.err_res,
-                                   check_items={ct.err_code: 1, ct.err_msg: ""})
+        self.index_wrap.init_index(
+            collection_w.collection,
+            default_field_name,
+            index_params,
+            check_task=CheckTasks.err_res,
+            check_items={ct.err_code: 1, ct.err_msg: ""},
+        )
 
     @pytest.mark.tags(CaseLabel.L1)
     @pytest.mark.parametrize("index_name", ["_1ndeX", "In_t0"])
@@ -160,13 +186,17 @@ class TestIndexParams(TestcaseBase):
         """
         self._connect()
         collection_w = self.init_collection_wrap()
-        self.index_wrap.init_index(collection_w.collection, default_field_name, default_index_params,
-                                   index_name=index_name)
-        self.index_wrap.init_index(collection_w.collection, ct.default_int64_field_name, default_index_params,
-                                   index_name=index_name,
-                                   check_task=CheckTasks.err_res,
-                                   check_items={ct.err_code: 1,
-                                                ct.err_msg: "invalid parameter"})
+        self.index_wrap.init_index(
+            collection_w.collection, default_field_name, default_index_params, index_name=index_name
+        )
+        self.index_wrap.init_index(
+            collection_w.collection,
+            ct.default_int64_field_name,
+            default_index_params,
+            index_name=index_name,
+            check_task=CheckTasks.err_res,
+            check_items={ct.err_code: 1, ct.err_msg: "invalid parameter"},
+        )
 
     @pytest.mark.tags(CaseLabel.L1)
     # @pytest.mark.xfail(reason="issue 19181")
@@ -178,18 +208,20 @@ class TestIndexParams(TestcaseBase):
         expected: raise exception
         """
         c_name = cf.gen_unique_str(prefix)
-        index_name = get_invalid_index_name
         collection_w = self.init_collection_wrap(name=c_name)
-        self.index_wrap.init_index(collection_w.collection, default_field_name, default_index_params,
-                                   index_name=get_invalid_index_name,
-                                   check_task=CheckTasks.err_res,
-                                   check_items={ct.err_code: 1,
-                                                ct.err_msg: "Invalid index name"})
+        self.index_wrap.init_index(
+            collection_w.collection,
+            default_field_name,
+            default_index_params,
+            index_name=get_invalid_index_name,
+            check_task=CheckTasks.err_res,
+            check_items={ct.err_code: 1, ct.err_msg: "Invalid index name"},
+        )
 
 
 @pytest.mark.tags(CaseLabel.GPU)
 class TestIndexOperation(TestcaseBase):
-    """ Test case of index interface """
+    """Test case of index interface"""
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_index_create_with_different_indexes(self):
@@ -201,10 +233,14 @@ class TestIndexOperation(TestcaseBase):
         c_name = cf.gen_unique_str(prefix)
         collection_w = self.init_collection_wrap(name=c_name)
         self.index_wrap.init_index(collection_w.collection, default_field_name, default_index_params)
-        error = {ct.err_code: 65535, ct.err_msg: "CreateIndex failed: at most one "
-                                                 "distinct index is allowed per field"}
-        self.index_wrap.init_index(collection_w.collection, default_field_name, default_ivf_flat_index,
-                                   check_task=CheckTasks.err_res, check_items=error)
+        error = {ct.err_code: 65535, ct.err_msg: "CreateIndex failed: at most one distinct index is allowed per field"}
+        self.index_wrap.init_index(
+            collection_w.collection,
+            default_field_name,
+            default_ivf_flat_index,
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
         assert len(collection_w.indexes) == 1
         assert collection_w.indexes[0].params["index_type"] == default_index_params["index_type"]
@@ -233,10 +269,13 @@ class TestIndexOperation(TestcaseBase):
         """
         collection_w = self.init_collection_general(prefix, True, nb=200, is_index=False)[0]
         collection_w.create_index(ct.default_int64_field_name, {})
-        collection_w.load(check_task=CheckTasks.err_res,
-                          check_items={ct.err_code: 65535,
-                                       ct.err_msg: "there is no vector index on field: [float_vector], "
-                                                   "please create index firstly"})
+        collection_w.load(
+            check_task=CheckTasks.err_res,
+            check_items={
+                ct.err_code: 65535,
+                ct.err_msg: "there is no vector index on field: [float_vector], please create index firstly",
+            },
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_index_create_on_array_field(self):
@@ -317,9 +356,14 @@ class TestIndexOperation(TestcaseBase):
 
         # create index with the same index name and different index params
         error = {ct.err_code: 999, ct.err_msg: "at most one distinct index is allowed per field"}
-        self.index_wrap.init_index(collection_w.collection, default_field_name, index_params2, index_name=index_name,
-                                   check_task=CheckTasks.err_res,
-                                   check_items=error)
+        self.index_wrap.init_index(
+            collection_w.collection,
+            default_field_name,
+            index_params2,
+            index_name=index_name,
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
         # create index with the same index name and same index params
         self.index_wrap.init_index(collection_w.collection, default_field_name, index_params)
 
@@ -338,7 +382,8 @@ class TestIndexOperation(TestcaseBase):
         str_field = cf.gen_string_field(name="str_field")
         str_field2 = cf.gen_string_field(name="str_field2")
         schema, _ = self.collection_schema_wrap.init_collection_schema(
-            [id_field, vec_field, vec_field2, str_field, str_field2])
+            [id_field, vec_field, vec_field2, str_field, str_field2]
+        )
         collection_w = self.init_collection_wrap(schema=schema)
         vec_index = ct.default_index
         vec_index_name = "my_index"
@@ -346,21 +391,21 @@ class TestIndexOperation(TestcaseBase):
         # create same index name on different vector fields
         error = {ct.err_code: 999, ct.err_msg: "at most one distinct index is allowed per field"}
         collection_w.create_index(vec_field.name, vec_index, index_name=vec_index_name)
-        collection_w.create_index(vec_field2.name, vec_index, index_name=vec_index_name,
-                                  check_task=CheckTasks.err_res,
-                                  check_items=error)
+        collection_w.create_index(
+            vec_field2.name, vec_index, index_name=vec_index_name, check_task=CheckTasks.err_res, check_items=error
+        )
 
         # create same index name on different scalar fields
-        collection_w.create_index(str_field.name, index_name=vec_index_name,
-                                  check_task=CheckTasks.err_res,
-                                  check_items=error)
+        collection_w.create_index(
+            str_field.name, index_name=vec_index_name, check_task=CheckTasks.err_res, check_items=error
+        )
 
         # create same salar index nae on different scalar fields
         index_name = "scalar_index"
         collection_w.create_index(str_field.name, index_name=index_name)
-        collection_w.create_index(str_field2.name, index_name=index_name,
-                                  check_task=CheckTasks.err_res,
-                                  check_items=error)
+        collection_w.create_index(
+            str_field2.name, index_name=index_name, check_task=CheckTasks.err_res, check_items=error
+        )
         all_indexes = collection_w.indexes
         assert len(all_indexes) == 2
         assert all_indexes[0].index_name != all_indexes[1].index_name
@@ -397,7 +442,7 @@ class TestIndexOperation(TestcaseBase):
 
 @pytest.mark.tags(CaseLabel.GPU)
 class TestIndexAdvanced(TestcaseBase):
-    """ Test case of index interface """
+    """Test case of index interface"""
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_index_drop_multi_collections(self):
@@ -425,6 +470,7 @@ class TestNewIndexBase(TestcaseBase):
       The following cases are used to test `create_index` function
     ******************************************************************
     """
+
     @pytest.mark.tags(CaseLabel.L0)
     @pytest.mark.parametrize("index_type", ct.all_index_types[0:8])
     def test_create_index_default(self, index_type):
@@ -439,8 +485,9 @@ class TestNewIndexBase(TestcaseBase):
         collection_w.insert(data=data)
         params = cf.get_index_params_params(index_type)
         index_params = {"index_type": index_type, "metric_type": "L2", "params": params}
-        collection_w.create_index(ct.default_float_vec_field_name, index_params=index_params,
-                                  index_name=ct.default_index_name)
+        collection_w.create_index(
+            ct.default_float_vec_field_name, index_params=index_params, index_name=ct.default_index_name
+        )
         assert len(collection_w.indexes) == 1
         collection_w.drop_index(index_name=ct.default_index_name)
         assert len(collection_w.indexes) == 0
@@ -456,12 +503,13 @@ class TestNewIndexBase(TestcaseBase):
         collection_w = self.init_collection_wrap(name=c_name)
         data = cf.gen_default_list_data()
         collection_w.insert(data=data)
-        collection_w.create_index(ct.default_int8_field_name, default_index_params,
-                                  index_name=ct.default_index_name,
-                                  check_task=CheckTasks.err_res,
-                                  check_items={ct.err_code: 65535,
-                                               ct.err_msg: "cannot create index on non-exist field: int8"}
-                                  )
+        collection_w.create_index(
+            ct.default_int8_field_name,
+            default_index_params,
+            index_name=ct.default_index_name,
+            check_task=CheckTasks.err_res,
+            check_items={ct.err_code: 65535, ct.err_msg: "cannot create index on non-exist field: int8"},
+        )
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_create_index_partition(self):
@@ -510,9 +558,12 @@ class TestNewIndexBase(TestcaseBase):
         self.connection_wrap.remove_connection(ct.default_alias)
         res_list, _ = self.connection_wrap.list_connections()
         assert ct.default_alias not in res_list
-        collection_w.create_index(ct.default_float_vec_field_name, ct.default_index,
-                                  check_task=CheckTasks.err_res,
-                                  check_items={ct.err_code: 999, ct.err_msg: "should create connection first"})
+        collection_w.create_index(
+            ct.default_float_vec_field_name,
+            ct.default_index,
+            check_task=CheckTasks.err_res,
+            check_items={ct.err_code: 999, ct.err_msg: "should create connection first"},
+        )
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_create_index_search_with_query_vectors(self):
@@ -529,9 +580,9 @@ class TestNewIndexBase(TestcaseBase):
         collection_w.create_index(ct.default_float_vec_field_name, default_index_params)
         collection_w.load()
         vectors = [[random.random() for _ in range(default_dim)] for _ in range(default_nq)]
-        collection_w.search(vectors[:default_nq], default_search_field,
-                            default_search_params, default_limit,
-                            default_search_exp)
+        collection_w.search(
+            vectors[:default_nq], default_search_field, default_search_params, default_limit, default_search_exp
+        )
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_create_index_multithread(self):
@@ -585,10 +636,16 @@ class TestNewIndexBase(TestcaseBase):
         data = cf.gen_default_list_data(default_nb)
         collection_w.insert(data=data)
         collection_w.create_index(ct.default_float_vec_field_name, default_index_params, index_name="a")
-        collection_w.create_index(ct.default_float_vec_field_name, default_index_params, index_name="b",
-                                  check_task=CheckTasks.err_res,
-                                  check_items={ct.err_code: 999,
-                                               ct.err_msg: "CreateIndex failed: creating multiple indexes on same field is not supported"})
+        collection_w.create_index(
+            ct.default_float_vec_field_name,
+            default_index_params,
+            index_name="b",
+            check_task=CheckTasks.err_res,
+            check_items={
+                ct.err_code: 999,
+                ct.err_msg: "CreateIndex failed: creating multiple indexes on same field is not supported",
+            },
+        )
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_create_index_repeatedly_new(self):
@@ -601,8 +658,10 @@ class TestNewIndexBase(TestcaseBase):
         collection_w = self.init_collection_wrap(name=c_name)
         data = cf.gen_default_list_data()
         collection_w.insert(data=data)
-        index_prams = [default_ivf_flat_index,
-                       {"metric_type": "L2", "index_type": "IVF_SQ8", "params": {"nlist": 1024}}]
+        index_prams = [
+            default_ivf_flat_index,
+            {"metric_type": "L2", "index_type": "IVF_SQ8", "params": {"nlist": 1024}},
+        ]
         for index in index_prams:
             index_name = cf.gen_unique_str("name")
             collection_w.create_index(default_float_vec_field_name, index, index_name=index_name)
@@ -671,9 +730,9 @@ class TestNewIndexBase(TestcaseBase):
         collection_w.create_index(ct.default_float_vec_field_name, default_ip_index_params)
         collection_w.load()
         vectors = [[random.random() for _ in range(default_dim)] for _ in range(default_nq)]
-        collection_w.search(vectors[:default_nq], default_search_field,
-                            default_search_ip_params, default_limit,
-                            default_search_exp)
+        collection_w.search(
+            vectors[:default_nq], default_search_field, default_search_ip_params, default_limit, default_search_exp
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_create_index_multithread_ip(self):
@@ -742,8 +801,10 @@ class TestNewIndexBase(TestcaseBase):
         collection_w = self.init_collection_wrap(name=c_name)
         data = cf.gen_default_list_data()
         collection_w.insert(data=data)
-        index_prams = [default_ip_index_params,
-                       {"metric_type": "IP", "index_type": "IVF_SQ8", "params": {"nlist": 1024}}]
+        index_prams = [
+            default_ip_index_params,
+            {"metric_type": "IP", "index_type": "IVF_SQ8", "params": {"nlist": 1024}},
+        ]
         for index in index_prams:
             index_name = cf.gen_unique_str("name")
             collection_w.create_index(default_float_vec_field_name, index, index_name=index_name)
@@ -756,6 +817,7 @@ class TestNewIndexBase(TestcaseBase):
          The following cases are used to test `drop_index` function
        ******************************************************************
     """
+
     @pytest.mark.tags(CaseLabel.L2)
     def test_drop_index_repeatedly(self):
         """
@@ -767,8 +829,7 @@ class TestNewIndexBase(TestcaseBase):
         collection_w = self.init_collection_wrap(name=c_name)
         params = cf.get_index_params_params("HNSW")
         index_params = {"index_type": "HNSW", "metric_type": "L2", "params": params}
-        collection_w.create_index(ct.default_float_vec_field_name, index_params,
-                                  index_name=ct.default_index_name)
+        collection_w.create_index(ct.default_float_vec_field_name, index_params, index_name=ct.default_index_name)
         assert len(collection_w.indexes) == 1
         collection_w.drop_index(index_name=ct.default_index_name)
         assert len(collection_w.indexes) == 0
@@ -785,11 +846,15 @@ class TestNewIndexBase(TestcaseBase):
 
         c_name = cf.gen_unique_str(prefix)
         collection_w = self.init_collection_wrap(c_name)
-        collection_w.create_index(ct.default_float_vec_field_name, default_index_params,
-                                  index_name=ct.default_index_name)
+        collection_w.create_index(
+            ct.default_float_vec_field_name, default_index_params, index_name=ct.default_index_name
+        )
         self.connection_wrap.remove_connection(ct.default_alias)
-        collection_w.drop_index(index_name=ct.default_index_name, check_task=CheckTasks.err_res,
-                                check_items={ct.err_code: 999, ct.err_msg: "should create connection first."})
+        collection_w.drop_index(
+            index_name=ct.default_index_name,
+            check_task=CheckTasks.err_res,
+            check_items={ct.err_code: 999, ct.err_msg: "should create connection first."},
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_create_drop_index_repeatedly(self):
@@ -803,8 +868,7 @@ class TestNewIndexBase(TestcaseBase):
         params = cf.get_index_params_params("HNSW")
         index_params = {"index_type": "HNSW", "metric_type": "L2", "params": params}
         for i in range(4):
-            collection_w.create_index(ct.default_float_vec_field_name, index_params,
-                                      index_name=ct.default_index_name)
+            collection_w.create_index(ct.default_float_vec_field_name, index_params, index_name=ct.default_index_name)
             assert len(collection_w.indexes) == 1
             collection_w.drop_index(index_name=ct.default_index_name)
             assert len(collection_w.indexes) == 0
@@ -867,29 +931,33 @@ class TestNewIndexBase(TestcaseBase):
         c_name = cf.gen_unique_str(prefix)
         collection_w = self.init_collection_wrap(c_name, schema=default_schema)
         collection_w.insert(cf.gen_default_list_data())
-        collection_w.create_index(ct.default_float_vec_field_name, default_index_params,
-                                  index_name=ct.default_index_name)
-        collection_w.alter_index(ct.default_index_name, {'mmap.enabled': True})
-        assert collection_w.index()[0].params["mmap.enabled"] == 'True'
+        collection_w.create_index(
+            ct.default_float_vec_field_name, default_index_params, index_name=ct.default_index_name
+        )
+        collection_w.alter_index(ct.default_index_name, {"mmap.enabled": True})
+        assert collection_w.index()[0].params["mmap.enabled"] == "True"
         collection_w.load()
         collection_w.release()
-        collection_w.alter_index(ct.default_index_name, {'mmap.enabled': False})
+        collection_w.alter_index(ct.default_index_name, {"mmap.enabled": False})
         collection_w.load()
-        assert collection_w.index()[0].params["mmap.enabled"] == 'False'
+        assert collection_w.index()[0].params["mmap.enabled"] == "False"
         vectors = [[random.random() for _ in range(default_dim)] for _ in range(default_nq)]
-        collection_w.search(vectors[:default_nq], default_search_field,
-                            default_search_params, default_limit,
-                            default_search_exp)
+        collection_w.search(
+            vectors[:default_nq], default_search_field, default_search_params, default_limit, default_search_exp
+        )
         collection_w.release()
-        collection_w.alter_index(ct.default_index_name, {'mmap.enabled': True})
-        assert collection_w.index()[0].params["mmap.enabled"] == 'True'
+        collection_w.alter_index(ct.default_index_name, {"mmap.enabled": True})
+        assert collection_w.index()[0].params["mmap.enabled"] == "True"
         collection_w.load()
-        collection_w.search(vectors[:default_nq], default_search_field,
-                            default_search_params, default_limit,
-                            default_search_exp,
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": default_nq,
-                                         "limit": default_limit})
+        collection_w.search(
+            vectors[:default_nq],
+            default_search_field,
+            default_search_params,
+            default_limit,
+            default_search_exp,
+            check_task=CheckTasks.check_search_results,
+            check_items={"nq": default_nq, "limit": default_limit},
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("index", ct.all_index_types[:7])
@@ -904,18 +972,21 @@ class TestNewIndexBase(TestcaseBase):
         params = cf.get_index_params_params(index)
         default_index = {"index_type": index, "params": params, "metric_type": "L2"}
         collection_w.create_index(field_name, default_index, index_name=f"mmap_index_{index}")
-        collection_w.alter_index(f"mmap_index_{index}", {'mmap.enabled': True})
-        assert collection_w.index()[0].params["mmap.enabled"] == 'True'
+        collection_w.alter_index(f"mmap_index_{index}", {"mmap.enabled": True})
+        assert collection_w.index()[0].params["mmap.enabled"] == "True"
         collection_w.drop_index(index_name=f"mmap_index_{index}")
         collection_w.create_index(field_name, default_index, index_name=f"index_{index}")
         collection_w.load()
         vectors = [[random.random() for _ in range(default_dim)] for _ in range(default_nq)]
-        collection_w.search(vectors[:default_nq], default_search_field,
-                            default_search_params, default_limit,
-                            default_search_exp,
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": default_nq,
-                                         "limit": default_limit})
+        collection_w.search(
+            vectors[:default_nq],
+            default_search_field,
+            default_search_params,
+            default_limit,
+            default_search_exp,
+            check_task=CheckTasks.check_search_results,
+            check_items={"nq": default_nq, "limit": default_limit},
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_rebuild_mmap_index(self):
@@ -927,47 +998,53 @@ class TestNewIndexBase(TestcaseBase):
         self._connect()
         c_name = cf.gen_unique_str(prefix)
         collection_w = self.init_collection_general(c_name, insert_data=True, is_index=False)[0]
-        collection_w.create_index(ct.default_float_vec_field_name, default_index_params,
-                                  index_name=ct.default_index_name)
-        collection_w.set_properties({'mmap.enabled': True})
+        collection_w.create_index(
+            ct.default_float_vec_field_name, default_index_params, index_name=ct.default_index_name
+        )
+        collection_w.set_properties({"mmap.enabled": True})
         pro = collection_w.describe()[0].get("properties")
-        assert pro["mmap.enabled"] == 'True'
-        collection_w.alter_index(ct.default_index_name, {'mmap.enabled': True})
-        assert collection_w.index()[0].params["mmap.enabled"] == 'True'
+        assert pro["mmap.enabled"] == "True"
+        collection_w.alter_index(ct.default_index_name, {"mmap.enabled": True})
+        assert collection_w.index()[0].params["mmap.enabled"] == "True"
         collection_w.insert(cf.gen_default_list_data())
         collection_w.flush()
 
         # check if mmap works after rebuild index
-        collection_w.create_index(ct.default_float_vec_field_name, default_index_params,
-                                  index_name=ct.default_index_name)
-        assert collection_w.index()[0].params["mmap.enabled"] == 'True'
+        collection_w.create_index(
+            ct.default_float_vec_field_name, default_index_params, index_name=ct.default_index_name
+        )
+        assert collection_w.index()[0].params["mmap.enabled"] == "True"
 
         collection_w.load()
         collection_w.release()
 
         # check if mmap works after reloading and rebuilding index.
-        collection_w.create_index(ct.default_float_vec_field_name, default_index_params,
-                                  index_name=ct.default_index_name)
-        assert collection_w.index()[0].params["mmap.enabled"] == 'True'
+        collection_w.create_index(
+            ct.default_float_vec_field_name, default_index_params, index_name=ct.default_index_name
+        )
+        assert collection_w.index()[0].params["mmap.enabled"] == "True"
         pro = collection_w.describe()[0].get("properties")
-        assert pro["mmap.enabled"] == 'True'
+        assert pro["mmap.enabled"] == "True"
 
         collection_w.load()
         vectors = [[random.random() for _ in range(default_dim)] for _ in range(default_nq)]
-        collection_w.search(vectors[:default_nq], default_search_field,
-                            default_search_params, default_limit,
-                            default_search_exp,
-                            check_task=CheckTasks.check_search_results,
-                            check_items={"nq": default_nq,
-                                         "limit": default_limit})
+        collection_w.search(
+            vectors[:default_nq],
+            default_search_field,
+            default_search_params,
+            default_limit,
+            default_search_exp,
+            check_task=CheckTasks.check_search_results,
+            check_items={"nq": default_nq, "limit": default_limit},
+        )
 
 
 @pytest.mark.tags(CaseLabel.GPU)
 class TestNewIndexBinary(TestcaseBase):
     """
-        ******************************************************************
-          The following cases are used to test `create_index` function
-        ******************************************************************
+    ******************************************************************
+      The following cases are used to test `create_index` function
+    ******************************************************************
     """
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -996,8 +1073,9 @@ class TestNewIndexBinary(TestcaseBase):
         df, _ = cf.gen_default_binary_dataframe_data()
         ins_res, _ = partition_w.insert(df)
         assert len(ins_res.primary_keys) == len(df)
-        collection_w.create_index(default_binary_vec_field_name, default_binary_index_params,
-                                  index_name=binary_field_name)
+        collection_w.create_index(
+            default_binary_vec_field_name, default_binary_index_params, index_name=binary_field_name
+        )
         assert collection_w.has_index(index_name=binary_field_name)[0] is True
         assert len(collection_w.indexes) == 1
 
@@ -1012,13 +1090,14 @@ class TestNewIndexBinary(TestcaseBase):
         collection_w = self.init_collection_wrap(name=c_name, schema=default_binary_schema)
         df, _ = cf.gen_default_binary_dataframe_data()
         collection_w.insert(data=df)
-        collection_w.create_index(default_binary_vec_field_name, default_binary_index_params,
-                                  index_name=binary_field_name)
+        collection_w.create_index(
+            default_binary_vec_field_name, default_binary_index_params, index_name=binary_field_name
+        )
         collection_w.load()
         _, vectors = cf.gen_binary_vectors(default_nq, default_dim)
-        collection_w.search(vectors[:default_nq], binary_field_name,
-                            default_search_binary_params, default_limit,
-                            default_search_exp)
+        collection_w.search(
+            vectors[:default_nq], binary_field_name, default_search_binary_params, default_limit, default_search_exp
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_create_index_invalid_metric_type_binary(self):
@@ -1029,11 +1108,14 @@ class TestNewIndexBinary(TestcaseBase):
         """
         c_name = cf.gen_unique_str(prefix)
         collection_w = self.init_collection_wrap(name=c_name, schema=default_binary_schema)
-        binary_index_params = {'index_type': 'BIN_IVF_FLAT', 'metric_type': 'L2', 'params': {'nlist': 64}}
-        collection_w.create_index(default_binary_vec_field_name, binary_index_params,
-                                  index_name=binary_field_name, check_task=CheckTasks.err_res,
-                                  check_items={ct.err_code: 999,
-                                               ct.err_msg: "binary vector index does not support metric type: L2"})
+        binary_index_params = {"index_type": "BIN_IVF_FLAT", "metric_type": "L2", "params": {"nlist": 64}}
+        collection_w.create_index(
+            default_binary_vec_field_name,
+            binary_index_params,
+            index_name=binary_field_name,
+            check_task=CheckTasks.err_res,
+            check_items={ct.err_code: 999, ct.err_msg: "binary vector index does not support metric type: L2"},
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("metric_type", ["L2", "IP", "COSINE", "JACCARD", "HAMMING"])
@@ -1045,14 +1127,14 @@ class TestNewIndexBinary(TestcaseBase):
         """
         c_name = cf.gen_unique_str(prefix)
         collection_w = self.init_collection_wrap(name=c_name, schema=default_binary_schema)
-        binary_index_params = {'index_type': 'HNSW', "M": '18', "efConstruction": '240', 'metric_type': metric_type}
+        binary_index_params = {"index_type": "HNSW", "M": "18", "efConstruction": "240", "metric_type": metric_type}
         if metric_type in ["JACCARD", "HAMMING"]:
             collection_w.create_index(default_binary_vec_field_name, binary_index_params)
         else:
             error = {ct.err_code: 999, ct.err_msg: f"binary vector index does not support metric type: {metric_type}"}
-            collection_w.create_index(default_binary_vec_field_name, binary_index_params,
-                                      check_task=CheckTasks.err_res,
-                                      check_items=error)
+            collection_w.create_index(
+                default_binary_vec_field_name, binary_index_params, check_task=CheckTasks.err_res, check_items=error
+            )
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("metric", ct.binary_metrics)
@@ -1084,8 +1166,9 @@ class TestNewIndexBinary(TestcaseBase):
         collection_w = self.init_collection_wrap(name=c_name, schema=default_binary_schema)
         df, _ = cf.gen_default_binary_dataframe_data()
         collection_w.insert(data=df)
-        collection_w.create_index(default_binary_vec_field_name, default_binary_index_params,
-                                  index_name=binary_field_name)
+        collection_w.create_index(
+            default_binary_vec_field_name, default_binary_index_params, index_name=binary_field_name
+        )
         assert len(collection_w.indexes) == 1
         collection_w.drop_index(index_name=binary_field_name)
         assert len(collection_w.indexes) == 0
@@ -1106,8 +1189,9 @@ class TestNewIndexBinary(TestcaseBase):
         df, _ = cf.gen_default_binary_dataframe_data()
         ins_res, _ = partition_w.insert(df)
         assert len(ins_res.primary_keys) == len(df)
-        collection_w.create_index(default_binary_vec_field_name, default_binary_index_params,
-                                  index_name=binary_field_name)
+        collection_w.create_index(
+            default_binary_vec_field_name, default_binary_index_params, index_name=binary_field_name
+        )
         assert collection_w.has_index(index_name=binary_field_name)[0] is True
         assert len(collection_w.indexes) == 1
         collection_w.drop_index(index_name=binary_field_name)
@@ -1147,8 +1231,13 @@ class TestIndexInvalid(TestcaseBase):
         """
         collection_w = self.init_collection_wrap()
         error = {ct.err_code: 999, ct.err_msg: f"Invalid index name: {invalid_index_name}"}
-        collection_w.create_index(ct.default_float_vec_field_name, default_index_params, index_name=invalid_index_name,
-                                  check_task=CheckTasks.err_res, check_items=error)
+        collection_w.create_index(
+            ct.default_float_vec_field_name,
+            default_index_params,
+            index_name=invalid_index_name,
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
         # drop index with an invalid index name
         collection_w.drop_index(index_name=invalid_index_name)
@@ -1164,12 +1253,13 @@ class TestIndexInvalid(TestcaseBase):
         collection_w = self.init_collection_general(prefix, True, nb=100, is_index=False)[0]
         collection_w.create_index(ct.default_float_vec_field_name, ct.default_index)
         collection_w.load()
-        collection_w.drop_index(check_task=CheckTasks.err_res,
-                                check_items={ct.err_code: 1100,
-                                             ct.err_msg: "vector index cannot be dropped on loaded collection"})
+        collection_w.drop_index(
+            check_task=CheckTasks.err_res,
+            check_items={ct.err_code: 1100, ct.err_msg: "vector index cannot be dropped on loaded collection"},
+        )
 
     @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.parametrize("n_trees", [-1, 1025, 'a'])
+    @pytest.mark.parametrize("n_trees", [-1, 1025, "a"])
     def test_annoy_index_with_invalid_params(self, n_trees):
         """
         target: test create index with invalid params
@@ -1179,11 +1269,12 @@ class TestIndexInvalid(TestcaseBase):
         """
         collection_w = self.init_collection_general(prefix, True, nb=100, is_index=False)[0]
         index_annoy = {"index_type": "ANNOY", "params": {"n_trees": n_trees}, "metric_type": "L2"}
-        collection_w.create_index("float_vector", index_annoy,
-                                  check_task=CheckTasks.err_res,
-                                  check_items={"err_code": 1100,
-                                               "err_msg": "invalid index type: ANNOY"})
-
+        collection_w.create_index(
+            "float_vector",
+            index_annoy,
+            check_task=CheckTasks.err_res,
+            check_items={"err_code": 1100, "err_msg": "invalid index type: ANNOY"},
+        )
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_create_scalar_index_on_vector_field(self, scalar_index, vector_data_type):
@@ -1192,13 +1283,16 @@ class TestIndexInvalid(TestcaseBase):
         method: 1.create collection, and create index
         expected: Raise exception
         """
-        collection_w = self.init_collection_general(prefix, True, nb=100,
-                                                    is_index=False, vector_data_type=vector_data_type)[0]
+        collection_w = self.init_collection_general(
+            prefix, True, nb=100, is_index=False, vector_data_type=vector_data_type
+        )[0]
         scalar_index_params = {"index_type": scalar_index}
-        collection_w.create_index(ct.default_float_vec_field_name, index_params=scalar_index_params,
-                                  check_task=CheckTasks.err_res,
-                                  check_items={ct.err_code: 1100,
-                                               ct.err_msg: f"invalid index params"})
+        collection_w.create_index(
+            ct.default_float_vec_field_name,
+            index_params=scalar_index_params,
+            check_task=CheckTasks.err_res,
+            check_items={ct.err_code: 1100, ct.err_msg: "invalid index params"},
+        )
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_create_scalar_index_on_binary_vector_field(self, scalar_index):
@@ -1209,10 +1303,12 @@ class TestIndexInvalid(TestcaseBase):
         """
         collection_w = self.init_collection_general(prefix, is_binary=True, is_index=False)[0]
         scalar_index_params = {"index_type": scalar_index}
-        collection_w.create_index(ct.default_binary_vec_field_name, index_params=scalar_index_params,
-                                  check_task=CheckTasks.err_res,
-                                  check_items={ct.err_code: 1100,
-                                               ct.err_msg: "metric type not set for vector index"})
+        collection_w.create_index(
+            ct.default_binary_vec_field_name,
+            index_params=scalar_index_params,
+            check_task=CheckTasks.err_res,
+            check_items={ct.err_code: 1100, ct.err_msg: "metric type not set for vector index"},
+        )
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_create_inverted_index_on_json_field(self, vector_data_type):
@@ -1222,7 +1318,11 @@ class TestIndexInvalid(TestcaseBase):
         expected: success
         """
         collection_w = self.init_collection_general(prefix, is_index=False, vector_data_type=vector_data_type)[0]
-        scalar_index_params = {"index_type": "INVERTED", "json_cast_type": "double", "json_path": ct.default_json_field_name+"['a']"}
+        scalar_index_params = {
+            "index_type": "INVERTED",
+            "json_cast_type": "double",
+            "json_path": ct.default_json_field_name + "['a']",
+        }
         collection_w.create_index(ct.default_json_field_name, index_params=scalar_index_params)
 
     @pytest.mark.tags(CaseLabel.L1)
@@ -1251,10 +1351,13 @@ class TestIndexInvalid(TestcaseBase):
         # 2. create index
         scalar_index_params = {"index_type": "INVERTED"}
         collection_w.create_index(ct.default_float_field_name, index_params=scalar_index_params)
-        collection_w.load(check_task=CheckTasks.err_res,
-                          check_items={ct.err_code: 65535,
-                                       ct.err_msg: "there is no vector index on field: [float_vector], "
-                                                   "please create index firstly"})
+        collection_w.load(
+            check_task=CheckTasks.err_res,
+            check_items={
+                ct.err_code: 65535,
+                ct.err_msg: "there is no vector index on field: [float_vector], please create index firstly",
+            },
+        )
 
     @pytest.mark.tags(CaseLabel.L1)
     @pytest.mark.parametrize("scalar_index", ["STL_SORT", "INVERTED"])
@@ -1273,11 +1376,15 @@ class TestIndexInvalid(TestcaseBase):
         vector_name_list = cf.extract_vector_field_name_list(collection_w)
         flat_index = {"index_type": "FLAT", "params": {}, "metric_type": "L2"}
         collection_w.create_index(ct.default_float_vec_field_name, flat_index)
-        collection_w.load(check_task=CheckTasks.err_res,
-                          check_items={ct.err_code: 65535,
-                                       ct.err_msg: f"there is no vector index on field: "
-                                                   f"[{vector_name_list[0]} {vector_name_list[1]}], "
-                                                   f"please create index firstly"})
+        collection_w.load(
+            check_task=CheckTasks.err_res,
+            check_items={
+                ct.err_code: 65535,
+                ct.err_msg: f"there is no vector index on field: "
+                f"[{vector_name_list[0]} {vector_name_list[1]}], "
+                f"please create index firstly",
+            },
+        )
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_set_non_exist_index_mmap(self):
@@ -1289,12 +1396,15 @@ class TestIndexInvalid(TestcaseBase):
         c_name = cf.gen_unique_str(prefix)
         collection_w = self.init_collection_wrap(c_name, schema=default_schema)
         collection_w.insert(cf.gen_default_list_data())
-        collection_w.create_index(ct.default_float_vec_field_name, index_params=ct.default_flat_index,
-                                  index_name=ct.default_index_name)
-        collection_w.alter_index("random_index_345", {'mmap.enabled': True},
-                                 check_task=CheckTasks.err_res,
-                                 check_items={ct.err_code: 65535,
-                                              ct.err_msg: f"index not found"})
+        collection_w.create_index(
+            ct.default_float_vec_field_name, index_params=ct.default_flat_index, index_name=ct.default_index_name
+        )
+        collection_w.alter_index(
+            "random_index_345",
+            {"mmap.enabled": True},
+            check_task=CheckTasks.err_res,
+            check_items={ct.err_code: 65535, ct.err_msg: "index not found"},
+        )
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_load_mmap_index(self):
@@ -1308,13 +1418,16 @@ class TestIndexInvalid(TestcaseBase):
         c_name = cf.gen_unique_str(prefix)
         collection_w = self.init_collection_wrap(c_name, schema=default_schema)
         collection_w.insert(cf.gen_default_list_data())
-        collection_w.create_index(ct.default_float_vec_field_name, index_params=ct.default_flat_index,
-                                  index_name=ct.default_index_name)
+        collection_w.create_index(
+            ct.default_float_vec_field_name, index_params=ct.default_flat_index, index_name=ct.default_index_name
+        )
         collection_w.load()
-        collection_w.alter_index(binary_field_name, {'mmap.enabled': True},
-                                 check_task=CheckTasks.err_res,
-                                 check_items={ct.err_code: 104,
-                                              ct.err_msg: f"can't alter index on loaded collection"})
+        collection_w.alter_index(
+            binary_field_name,
+            {"mmap.enabled": True},
+            check_task=CheckTasks.err_res,
+            check_items={ct.err_code: 104, ct.err_msg: "can't alter index on loaded collection"},
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_turning_on_mmap_for_scalar_index(self):
@@ -1332,10 +1445,12 @@ class TestIndexInvalid(TestcaseBase):
             scalar_index_params = {"index_type": f"{scalar_index[i]}"}
             collection_w.create_index(scalar_fields[i], index_params=scalar_index_params, index_name=index_name)
             assert collection_w.has_index(index_name=index_name)[0] is True
-            collection_w.alter_index(index_name, {'mmap.enabled': True},
-                                     check_task=CheckTasks.err_res,
-                                     check_items={ct.err_code: 65535,
-                                                  ct.err_msg: f"index type {scalar_index[i]} does not support mmap"})
+            collection_w.alter_index(
+                index_name,
+                {"mmap.enabled": True},
+                check_task=CheckTasks.err_res,
+                check_items={ct.err_code: 65535, ct.err_msg: f"index type {scalar_index[i]} does not support mmap"},
+            )
             collection_w.drop_index(index_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -1348,28 +1463,39 @@ class TestIndexInvalid(TestcaseBase):
         c_name = cf.gen_unique_str(prefix)
         collection_w = self.init_collection_wrap(c_name, schema=default_schema)
         collection_w.insert(cf.gen_default_list_data())
-        collection_w.create_index(ct.default_float_vec_field_name, default_index_params,
-                                  index_name=ct.default_index_name)
-        collection_w.alter_index(ct.default_index_name, {'mmap.enabled': "error_value"},
-                                 check_task=CheckTasks.err_res,
-                                 check_items={ct.err_code: 65535,
-                                              ct.err_msg: f"invalid mmap.enabled value"})
-        collection_w.alter_index(ct.default_index_name, {"error_param_key": 123},
-                                 check_task=CheckTasks.err_res,
-                                 check_items={ct.err_code: 1100,
-                                              ct.err_msg: "error_param_key is not a configable index property:"})
-        collection_w.alter_index(ct.default_index_name, ["error_param_type"],
-                                 check_task=CheckTasks.err_res,
-                                 check_items={ct.err_code: 1,
-                                              ct.err_msg: f"Unexpected error"})
-        collection_w.alter_index(ct.default_index_name, None,
-                                 check_task=CheckTasks.err_res,
-                                 check_items={ct.err_code: 1,
-                                              ct.err_msg: "properties should not be None"})
-        collection_w.alter_index(ct.default_index_name, 1000,
-                                 check_task=CheckTasks.err_res,
-                                 check_items={ct.err_code: 1,
-                                              ct.err_msg: f"<'int' object has no attribute 'items'"})
+        collection_w.create_index(
+            ct.default_float_vec_field_name, default_index_params, index_name=ct.default_index_name
+        )
+        collection_w.alter_index(
+            ct.default_index_name,
+            {"mmap.enabled": "error_value"},
+            check_task=CheckTasks.err_res,
+            check_items={ct.err_code: 65535, ct.err_msg: "invalid mmap.enabled value"},
+        )
+        collection_w.alter_index(
+            ct.default_index_name,
+            {"error_param_key": 123},
+            check_task=CheckTasks.err_res,
+            check_items={ct.err_code: 1100, ct.err_msg: "error_param_key is not a configable index property:"},
+        )
+        collection_w.alter_index(
+            ct.default_index_name,
+            ["error_param_type"],
+            check_task=CheckTasks.err_res,
+            check_items={ct.err_code: 1, ct.err_msg: "Unexpected error"},
+        )
+        collection_w.alter_index(
+            ct.default_index_name,
+            None,
+            check_task=CheckTasks.err_res,
+            check_items={ct.err_code: 1, ct.err_msg: "properties should not be None"},
+        )
+        collection_w.alter_index(
+            ct.default_index_name,
+            1000,
+            check_task=CheckTasks.err_res,
+            check_items={ct.err_code: 1, ct.err_msg: "<'int' object has no attribute 'items'"},
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("metric_type", ["L2", "COSINE", "   ", "invalid"])
@@ -1388,9 +1514,13 @@ class TestIndexInvalid(TestcaseBase):
         param = cf.get_index_params_params(index)
         params = {"index_type": index, "metric_type": metric_type, "params": param}
         error = {ct.err_code: 65535, ct.err_msg: "only IP&BM25 is the supported metric type for sparse index"}
-        index, _ = self.index_wrap.init_index(collection_w.collection, ct.default_sparse_vec_field_name, params,
-                                              check_task=CheckTasks.err_res,
-                                              check_items=error)
+        index, _ = self.index_wrap.init_index(
+            collection_w.collection,
+            ct.default_sparse_vec_field_name,
+            params,
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("ratio", [-0.5, 1, 3])
@@ -1407,11 +1537,17 @@ class TestIndexInvalid(TestcaseBase):
         data = cf.gen_default_list_sparse_data()
         collection_w.insert(data=data)
         params = {"index_type": index, "metric_type": "IP", "params": {"drop_ratio_build": ratio}}
-        error = {ct.err_code: 999,
-                 ct.err_msg: f"Out of range in json: param 'drop_ratio_build' ({ratio*1.0}) should be in range [0.000000, 1.000000)"}
-        index, _ = self.index_wrap.init_index(collection_w.collection, ct.default_sparse_vec_field_name, params,
-                                              check_task=CheckTasks.err_res,
-                                              check_items=error)
+        error = {
+            ct.err_code: 999,
+            ct.err_msg: f"Out of range in json: param 'drop_ratio_build' ({ratio * 1.0}) should be in range [0.000000, 1.000000)",
+        }
+        index, _ = self.index_wrap.init_index(
+            collection_w.collection,
+            ct.default_sparse_vec_field_name,
+            params,
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("inverted_index_algo", ["INVALID_ALGO"])
@@ -1428,12 +1564,18 @@ class TestIndexInvalid(TestcaseBase):
         data = cf.gen_default_list_sparse_data()
         collection_w.insert(data=data)
         params = {"index_type": index, "metric_type": "IP", "params": {"inverted_index_algo": inverted_index_algo}}
-        error = {ct.err_code: 999,
-                 ct.err_msg: f"sparse inverted index algo {inverted_index_algo} not found or not supported, "
-                             f"supported: [TAAT_NAIVE DAAT_WAND DAAT_MAXSCORE]"}
-        index, _ = self.index_wrap.init_index(collection_w.collection, ct.default_sparse_vec_field_name, params,
-                                              check_task=CheckTasks.err_res,
-                                              check_items=error)
+        error = {
+            ct.err_code: 999,
+            ct.err_msg: f"sparse inverted index algo {inverted_index_algo} not found or not supported, "
+            f"supported: [TAAT_NAIVE DAAT_WAND DAAT_MAXSCORE]",
+        }
+        index, _ = self.index_wrap.init_index(
+            collection_w.collection,
+            ct.default_sparse_vec_field_name,
+            params,
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
 
 @pytest.mark.tags(CaseLabel.GPU)
@@ -1462,8 +1604,9 @@ class TestNewIndexAsync(TestcaseBase):
         collection_w = self.init_collection_wrap(c_name)
         data = cf.gen_default_list_data()
         collection_w.insert(data=data)
-        res, _ = collection_w.create_index(ct.default_float_vec_field_name, default_index_params,
-                                           index_name=ct.default_index_name, _async=_async)
+        res, _ = collection_w.create_index(
+            ct.default_float_vec_field_name, default_index_params, index_name=ct.default_index_name, _async=_async
+        )
         if _async:
             res.done()
             assert len(collection_w.indexes) == 1
@@ -1480,8 +1623,9 @@ class TestNewIndexAsync(TestcaseBase):
         collection_w = self.init_collection_wrap(c_name)
         data = cf.gen_default_list_data()
         collection_w.insert(data=data)
-        res, _ = collection_w.create_index(ct.default_float_vec_field_name, default_index_params,
-                                           index_name=ct.default_index_name, _async=_async)
+        res, _ = collection_w.create_index(
+            ct.default_float_vec_field_name, default_index_params, index_name=ct.default_index_name, _async=_async
+        )
 
         # load and search
         if _async:
@@ -1489,8 +1633,9 @@ class TestNewIndexAsync(TestcaseBase):
             assert len(collection_w.indexes) == 1
         collection_w.load()
         vectors_s = [[random.random() for _ in range(ct.default_dim)] for _ in range(ct.default_nq)]
-        search_res, _ = collection_w.search(vectors_s[:ct.default_nq], ct.default_float_vec_field_name,
-                                            ct.default_search_params, ct.default_limit)
+        search_res, _ = collection_w.search(
+            vectors_s[: ct.default_nq], ct.default_float_vec_field_name, ct.default_search_params, ct.default_limit
+        )
         assert len(search_res) == ct.default_nq
         assert len(search_res[0]) == ct.default_limit
 
@@ -1513,9 +1658,13 @@ class TestNewIndexAsync(TestcaseBase):
         collection_w = self.init_collection_wrap(c_name)
         data = cf.gen_default_list_data()
         collection_w.insert(data=data)
-        res, _ = collection_w.create_index(ct.default_float_vec_field_name, default_index_params,
-                                           index_name=ct.default_index_name, _async=True,
-                                           _callback=self.call_back())
+        res, _ = collection_w.create_index(
+            ct.default_float_vec_field_name,
+            default_index_params,
+            index_name=ct.default_index_name,
+            _async=True,
+            _callback=self.call_back(),
+        )
 
 
 @pytest.mark.tags(CaseLabel.GPU)
@@ -1538,8 +1687,9 @@ class TestIndexString(TestcaseBase):
         collection_w = self.init_collection_wrap(name=c_name)
         data = cf.gen_default_list_data()
         collection_w.insert(data=data)
-        index, _ = self.index_wrap.init_index(collection_w.collection, default_string_field_name,
-                                              default_string_index_params)
+        index, _ = self.index_wrap.init_index(
+            collection_w.collection, default_string_field_name, default_string_index_params
+        )
         cf.assert_equal_index(index, collection_w.indexes[0])
 
     @pytest.mark.tags(CaseLabel.L1)
@@ -1554,11 +1704,13 @@ class TestIndexString(TestcaseBase):
         collection_w = self.init_collection_wrap(name=c_name)
         data = cf.gen_default_list_data(ct.default_nb)
         collection_w.insert(data=data)
-        index, _ = self.index_wrap.init_index(collection_w.collection, default_string_field_name,
-                                              default_string_index_params)
+        index, _ = self.index_wrap.init_index(
+            collection_w.collection, default_string_field_name, default_string_index_params
+        )
         cf.assert_equal_index(index, collection_w.indexes[0])
-        collection_w.create_index(ct.default_float_vec_field_name, index_params=ct.default_flat_index,
-                                  index_name="vector_flat")
+        collection_w.create_index(
+            ct.default_float_vec_field_name, index_params=ct.default_flat_index, index_name="vector_flat"
+        )
         collection_w.load()
         assert collection_w.num_entities == default_nb
 
@@ -1574,10 +1726,12 @@ class TestIndexString(TestcaseBase):
         collection_w = self.init_collection_wrap(name=c_name)
         data = cf.gen_default_list_data(ct.default_nb)
         collection_w.insert(data=data)
-        collection_w.create_index(ct.default_float_vec_field_name, index_params=ct.default_flat_index,
-                                  index_name="vector_flat")
-        index, _ = self.index_wrap.init_index(collection_w.collection, default_string_field_name,
-                                              default_string_index_params)
+        collection_w.create_index(
+            ct.default_float_vec_field_name, index_params=ct.default_flat_index, index_name="vector_flat"
+        )
+        index, _ = self.index_wrap.init_index(
+            collection_w.collection, default_string_field_name, default_string_index_params
+        )
         collection_w.load()
         cf.assert_equal_index(index, collection_w.indexes[0])
         assert collection_w.num_entities == default_nb
@@ -1596,8 +1750,9 @@ class TestIndexString(TestcaseBase):
         collection_w = self.init_collection_wrap(name=c_name, schema=schema)
         data = cf.gen_default_list_data()
         collection_w.insert(data=data)
-        index, _ = self.index_wrap.init_index(collection_w.collection, default_string_field_name,
-                                              default_string_index_params)
+        index, _ = self.index_wrap.init_index(
+            collection_w.collection, default_string_field_name, default_string_index_params
+        )
         cf.assert_equal_index(index, collection_w.indexes[0])
 
     @pytest.mark.tags(CaseLabel.L1)
@@ -1631,10 +1786,13 @@ class TestIndexString(TestcaseBase):
         data = cf.gen_default_list_data()
         collection_w.insert(data=data)
         collection_w.create_index(default_string_field_name, default_string_index_params, index_name=index_name2)
-        collection_w.create_index(default_float_vec_field_name, default_index_params,
-                                  index_name=index_name2,
-                                  check_task=CheckTasks.err_res,
-                                  check_items={ct.err_code: 1, ct.err_msg: "CreateIndex failed"})
+        collection_w.create_index(
+            default_float_vec_field_name,
+            default_index_params,
+            index_name=index_name2,
+            check_task=CheckTasks.err_res,
+            check_items={ct.err_code: 1, ct.err_msg: "CreateIndex failed"},
+        )
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_create_different_index_fields(self):
@@ -1650,9 +1808,9 @@ class TestIndexString(TestcaseBase):
         data = cf.gen_default_list_data()
         collection_w.insert(data=data)
         collection_w.create_index(default_float_vec_field_name, default_index_params, index_name=index_name1)
-        assert collection_w.has_index(index_name=index_name1)[0] == True
+        assert collection_w.has_index(index_name=index_name1)[0]
         collection_w.create_index(default_string_field_name, default_string_index_params, index_name=index_name2)
-        assert collection_w.has_index(index_name=index_name2)[0] == True
+        assert collection_w.has_index(index_name=index_name2)[0]
         assert len(collection_w.indexes) == 2
 
     @pytest.mark.tags(CaseLabel.L1)
@@ -1669,9 +1827,9 @@ class TestIndexString(TestcaseBase):
         df, _ = cf.gen_default_binary_dataframe_data()
         collection_w.insert(data=df)
         collection_w.create_index(default_string_field_name, default_string_index_params, index_name=index_name2)
-        assert collection_w.has_index(index_name=index_name2)[0] == True
+        assert collection_w.has_index(index_name=index_name2)[0]
         collection_w.create_index(default_binary_vec_field_name, default_binary_index_params, index_name=index_name3)
-        assert collection_w.has_index(index_name=index_name3)[0] == True
+        assert collection_w.has_index(index_name=index_name3)[0]
         assert len(collection_w.indexes) == 2
 
     @pytest.mark.tags(CaseLabel.L1)
@@ -1686,8 +1844,9 @@ class TestIndexString(TestcaseBase):
         collection_w = self.init_collection_wrap(name=c_name)
         data = cf.gen_default_list_data()
         collection_w.insert(data=data)
-        index, _ = self.index_wrap.init_index(collection_w.collection, default_string_field_name,
-                                              default_string_index_params)
+        index, _ = self.index_wrap.init_index(
+            collection_w.collection, default_string_field_name, default_string_index_params
+        )
         cf.assert_equal_index(index, collection_w.indexes[0])
         self.index_wrap.drop()
         assert len(collection_w.indexes) == 0
@@ -1725,7 +1884,7 @@ class TestIndexString(TestcaseBase):
         collection_w.insert(data=data)
 
         collection_w.create_index(default_string_field_name, default_string_index_params, index_name=index_name2)
-        assert collection_w.has_index(index_name=index_name2)[0] == True
+        assert collection_w.has_index(index_name=index_name2)[0]
         collection_w.drop_index(index_name=index_name2)
         assert len(collection_w.indexes) == 0
 
@@ -1759,18 +1918,22 @@ class TestIndexDiskann(TestcaseBase):
         data = cf.gen_default_list_data()
         collection_w.insert(data=data)
         assert collection_w.num_entities == default_nb
-        index, _ = self.index_wrap.init_index(collection_w.collection, default_float_vec_field_name,
-                                              ct.default_diskann_index)
+        index, _ = self.index_wrap.init_index(
+            collection_w.collection, default_float_vec_field_name, ct.default_diskann_index
+        )
         log.info(self.index_wrap.params)
         cf.assert_equal_index(index, collection_w.indexes[0])
         collection_w.load()
         vectors = [[random.random() for _ in range(default_dim)] for _ in range(default_nq)]
-        search_res, _ = collection_w.search(vectors[:default_nq], default_search_field,
-                                            ct.default_diskann_search_params, default_limit,
-                                            default_search_exp,
-                                            check_task=CheckTasks.check_search_results,
-                                            check_items={"nq": default_nq,
-                                                         "limit": default_limit})
+        search_res, _ = collection_w.search(
+            vectors[:default_nq],
+            default_search_field,
+            ct.default_diskann_search_params,
+            default_limit,
+            default_search_exp,
+            check_task=CheckTasks.check_search_results,
+            check_items={"nq": default_nq, "limit": default_limit},
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("dim", [ct.min_dim, ct.max_dim])
@@ -1799,21 +1962,28 @@ class TestIndexDiskann(TestcaseBase):
         data = cf.gen_default_list_data()
         collection_w.insert(data=data)
         assert collection_w.num_entities == default_nb
-        res, _ = collection_w.create_index(ct.default_float_vec_field_name, ct.default_diskann_index,
-                                           index_name=ct.default_index_name, _async=_async,
-                                           _callback=self.call_back())
+        res, _ = collection_w.create_index(
+            ct.default_float_vec_field_name,
+            ct.default_diskann_index,
+            index_name=ct.default_index_name,
+            _async=_async,
+            _callback=self.call_back(),
+        )
 
         if _async:
             res.done()
             assert len(collection_w.indexes) == 1
         collection_w.load()
         vectors = [[random.random() for _ in range(default_dim)] for _ in range(default_nq)]
-        search_res, _ = collection_w.search(vectors[:default_nq], default_search_field,
-                                            ct.default_diskann_search_params, default_limit,
-                                            default_search_exp,
-                                            check_task=CheckTasks.check_search_results,
-                                            check_items={"nq": default_nq,
-                                                         "limit": default_limit})
+        search_res, _ = collection_w.search(
+            vectors[:default_nq],
+            default_search_field,
+            ct.default_diskann_search_params,
+            default_limit,
+            default_search_exp,
+            check_task=CheckTasks.check_search_results,
+            check_items={"nq": default_nq, "limit": default_limit},
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_create_diskann_index_drop_with_async(self, _async):
@@ -1827,8 +1997,9 @@ class TestIndexDiskann(TestcaseBase):
         data = cf.gen_default_list_data()
         collection_w.insert(data=data)
         assert collection_w.num_entities == default_nb
-        res, _ = collection_w.create_index(ct.default_float_vec_field_name, ct.default_diskann_index,
-                                           index_name=ct.default_index_name, _async=_async)
+        res, _ = collection_w.create_index(
+            ct.default_float_vec_field_name, ct.default_diskann_index, index_name=ct.default_index_name, _async=_async
+        )
         if _async:
             res.done()
             assert len(collection_w.indexes) == 1
@@ -1853,8 +2024,7 @@ class TestIndexDiskann(TestcaseBase):
         df = cf.gen_default_list_data(ct.default_nb)
         ins_res, _ = partition_w.insert(df)
         assert len(ins_res.primary_keys) == ct.default_nb
-        collection_w.create_index(default_float_vec_field_name, ct.default_diskann_index,
-                                  index_name=field_name)
+        collection_w.create_index(default_float_vec_field_name, ct.default_diskann_index, index_name=field_name)
         collection_w.load()
         assert collection_w.has_index(index_name=field_name)[0] is True
         assert len(collection_w.indexes) == 1
@@ -1918,12 +2088,12 @@ class TestIndexDiskann(TestcaseBase):
         collection_w.insert(data=data)
         assert collection_w.num_entities == default_nb
         collection_w.create_index(default_float_vec_field_name, ct.default_diskann_index, index_name="a")
-        assert collection_w.has_index(index_name="a")[0] == True
+        assert collection_w.has_index(index_name="a")[0]
         collection_w.create_index(default_string_field_name, default_string_index_params, index_name="b")
-        assert collection_w.has_index(index_name="b")[0] == True
+        assert collection_w.has_index(index_name="b")[0]
         default_params = {}
         collection_w.create_index("float", default_params, index_name="c")
-        assert collection_w.has_index(index_name="c")[0] == True
+        assert collection_w.has_index(index_name="c")[0]
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_drop_diskann_index_with_partition(self):
@@ -1959,10 +2129,13 @@ class TestIndexDiskann(TestcaseBase):
         collection_w = self.init_collection_wrap(name=c_name, schema=default_binary_schema)
         df, _ = cf.gen_default_binary_dataframe_data()
         collection_w.insert(data=df)
-        collection_w.create_index(default_binary_vec_field_name, ct.default_diskann_index, index_name=binary_field_name,
-                                  check_task=CheckTasks.err_res,
-                                  check_items={ct.err_code: 1100,
-                                               ct.err_msg: "binary vector index does not support metric type: COSINE"})
+        collection_w.create_index(
+            default_binary_vec_field_name,
+            ct.default_diskann_index,
+            index_name=binary_field_name,
+            check_task=CheckTasks.err_res,
+            check_items={ct.err_code: 1100, ct.err_msg: "binary vector index does not support metric type: COSINE"},
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_create_diskann_index_multithread(self):
@@ -2001,21 +2174,24 @@ class TestIndexDiskann(TestcaseBase):
         c_name = cf.gen_unique_str(prefix)
         collection_w = self.init_collection_wrap(c_name, schema=default_schema)
         collection_w.insert(cf.gen_default_list_data())
-        collection_w.create_index(default_float_vec_field_name, ct.default_diskann_index,
-                                  index_name=ct.default_index_name)
-        collection_w.set_properties({'mmap.enabled': True})
+        collection_w.create_index(
+            default_float_vec_field_name, ct.default_diskann_index, index_name=ct.default_index_name
+        )
+        collection_w.set_properties({"mmap.enabled": True})
         desc, _ = collection_w.describe()
         pro = desc.get("properties")
-        assert pro["mmap.enabled"] == 'True'
-        collection_w.alter_index(ct.default_index_name, {'mmap.enabled': True},
-                                 check_task=CheckTasks.err_res,
-                                 check_items={ct.err_code: 104,
-                                              ct.err_msg: f"index type DISKANN does not support mmap"})
+        assert pro["mmap.enabled"] == "True"
+        collection_w.alter_index(
+            ct.default_index_name,
+            {"mmap.enabled": True},
+            check_task=CheckTasks.err_res,
+            check_items={ct.err_code: 104, ct.err_msg: "index type DISKANN does not support mmap"},
+        )
 
 
 @pytest.mark.tags(CaseLabel.GPU)
 class TestAutoIndex(TestcaseBase):
-    """ Test case of Auto index """
+    """Test case of Auto index"""
 
     @pytest.mark.tags(CaseLabel.L0)
     def test_create_autoindex_with_no_params(self):
@@ -2043,7 +2219,7 @@ class TestAutoIndex(TestcaseBase):
         log.info(collection_w.index()[0].params)
         expect_autoindex_params = copy.copy(default_autoindex_params)
         if index_params.get("index_type"):
-            if index_params["index_type"] != 'AUTOINDEX':
+            if index_params["index_type"] != "AUTOINDEX":
                 expect_autoindex_params = index_params
         if index_params.get("metric_type"):
             expect_autoindex_params["metric_type"] = index_params["metric_type"]
@@ -2058,11 +2234,12 @@ class TestAutoIndex(TestcaseBase):
         """
         collection_w = self.init_collection_general(prefix, is_index=False)[0]
         index_params = {"metric_type": "L2", "nlist": "1024", "M": "100"}
-        collection_w.create_index(field_name, index_params,
-                                  check_task=CheckTasks.err_res,
-                                  check_items={"err_code": 1,
-                                               "err_msg": "only metric type can be "
-                                                          "passed when use AutoIndex"})
+        collection_w.create_index(
+            field_name,
+            index_params,
+            check_task=CheckTasks.err_res,
+            check_items={"err_code": 1, "err_msg": "only metric type can be passed when use AutoIndex"},
+        )
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_create_autoindex_on_binary_vectors(self):
@@ -2073,7 +2250,7 @@ class TestAutoIndex(TestcaseBase):
         """
         collection_w = self.init_collection_general(prefix, is_binary=True, is_index=False)[0]
         collection_w.create_index(binary_field_name, {})
-        assert collection_w.index()[0].params == {'index_type': 'AUTOINDEX', 'metric_type': 'HAMMING'}
+        assert collection_w.index()[0].params == {"index_type": "AUTOINDEX", "metric_type": "HAMMING"}
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_create_autoindex_on_all_vector_type(self):
@@ -2082,27 +2259,33 @@ class TestAutoIndex(TestcaseBase):
         method: create index on all vector type
         expected: raise exception
         """
-        fields = [cf.gen_int64_field(is_primary=True), cf.gen_float16_vec_field("fp16"),
-                  cf.gen_bfloat16_vec_field("bf16"), cf.gen_sparse_vec_field("sparse")]
+        fields = [
+            cf.gen_int64_field(is_primary=True),
+            cf.gen_float16_vec_field("fp16"),
+            cf.gen_bfloat16_vec_field("bf16"),
+            cf.gen_sparse_vec_field("sparse"),
+        ]
         schema = cf.gen_collection_schema(fields=fields)
         collection_w = self.init_collection_wrap(schema=schema)
 
         collection_w.create_index("fp16", index_name="fp16")
-        assert all(item in default_autoindex_params.items() for item in
-                   collection_w.index()[0].params.items())
+        assert all(item in default_autoindex_params.items() for item in collection_w.index()[0].params.items())
 
         collection_w.create_index("bf16", index_name="bf16")
-        assert all(item in default_autoindex_params.items() for item in
-                   collection_w.index(index_name="bf16")[0].params.items())
+        assert all(
+            item in default_autoindex_params.items() for item in collection_w.index(index_name="bf16")[0].params.items()
+        )
 
         collection_w.create_index("sparse", index_name="sparse")
-        assert all(item in default_sparse_autoindex_params.items() for item in
-                   collection_w.index(index_name="sparse")[0].params.items())
+        assert all(
+            item in default_sparse_autoindex_params.items()
+            for item in collection_w.index(index_name="sparse")[0].params.items()
+        )
 
 
 @pytest.mark.tags(CaseLabel.GPU)
 class TestScaNNIndex(TestcaseBase):
-    """ Test case of Auto index """
+    """Test case of Auto index"""
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_create_scann_index(self):
@@ -2112,8 +2295,7 @@ class TestScaNNIndex(TestcaseBase):
         expected: create successfully
         """
         collection_w = self.init_collection_general(prefix, is_index=False)[0]
-        index_params = {"index_type": "SCANN", "metric_type": "L2",
-                        "params": {"nlist": 1024, "with_raw_data": True}}
+        index_params = {"index_type": "SCANN", "metric_type": "L2", "params": {"nlist": 1024, "with_raw_data": True}}
         collection_w.create_index(default_field_name, index_params)
         assert collection_w.has_index()[0] is True
 
@@ -2127,9 +2309,11 @@ class TestScaNNIndex(TestcaseBase):
         """
         collection_w = self.init_collection_general(prefix, is_index=False)[0]
         index_params = {"index_type": "SCANN", "metric_type": "L2", "params": {"nlist": nlist}}
-        error = {ct.err_code: 999, ct.err_msg: f"Out of range in json: param 'nlist' ({nlist}) should be in range [1, 65536]"}
-        collection_w.create_index(default_field_name, index_params,
-                                  check_task=CheckTasks.err_res, check_items=error)
+        error = {
+            ct.err_code: 999,
+            ct.err_msg: f"Out of range in json: param 'nlist' ({nlist}) should be in range [1, 65536]",
+        }
+        collection_w.create_index(default_field_name, index_params, check_task=CheckTasks.err_res, check_items=error)
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("dim", [3, 127])
@@ -2141,11 +2325,12 @@ class TestScaNNIndex(TestcaseBase):
         """
         collection_w = self.init_collection_general(prefix, is_index=False, dim=dim)[0]
         index_params = {"index_type": "SCANN", "metric_type": "L2", "params": {"nlist": 1024}}
-        error = {ct.err_code: 1100,
-                 ct.err_msg: f"The dimension of a vector (dim) should be a multiple of sub_dim. "
-                             f"Dimension:{dim}, sub_dim:2: invalid parameter"}
-        collection_w.create_index(default_field_name, index_params,
-                                  check_task=CheckTasks.err_res, check_items=error)
+        error = {
+            ct.err_code: 1100,
+            ct.err_msg: f"The dimension of a vector (dim) should be a multiple of sub_dim. "
+            f"Dimension:{dim}, sub_dim:2: invalid parameter",
+        }
+        collection_w.create_index(default_field_name, index_params, check_task=CheckTasks.err_res, check_items=error)
 
 
 @pytest.mark.tags(CaseLabel.GPU)
@@ -2163,10 +2348,19 @@ class TestInvertedIndexValid(TestcaseBase):
         yield request.param
 
     @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.parametrize("scalar_field_name", [ct.default_int8_field_name, ct.default_int16_field_name,
-                                                   ct.default_int32_field_name, ct.default_int64_field_name,
-                                                   ct.default_float_field_name, ct.default_double_field_name,
-                                                   ct.default_string_field_name, ct.default_bool_field_name])
+    @pytest.mark.parametrize(
+        "scalar_field_name",
+        [
+            ct.default_int8_field_name,
+            ct.default_int16_field_name,
+            ct.default_int32_field_name,
+            ct.default_int64_field_name,
+            ct.default_float_field_name,
+            ct.default_double_field_name,
+            ct.default_string_field_name,
+            ct.default_bool_field_name,
+        ],
+    )
     def test_create_inverted_index_on_all_supported_scalar_field(self, scalar_field_name):
         """
         target: test create scalar index all supported scalar field
@@ -2181,16 +2375,16 @@ class TestInvertedIndexValid(TestcaseBase):
         index_list = self.utility_wrap.list_indexes(collection_w.name)[0]
         assert index_name in index_list
         collection_w.flush()
-        result = self.utility_wrap.index_building_progress(collection_w.name, index_name)[0]
+        self.utility_wrap.index_building_progress(collection_w.name, index_name)[0]
         # assert False
         start = time.time()
         while True:
             time.sleep(1)
             res, _ = self.utility_wrap.index_building_progress(collection_w.name, index_name)
-            if 0 < res['indexed_rows'] <= default_nb:
+            if 0 < res["indexed_rows"] <= default_nb:
                 break
             if time.time() - start > 5:
-                raise MilvusException(1, f"Index build completed in more than 5s")
+                raise MilvusException(1, "Index build completed in more than 5s")
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_create_multiple_inverted_index(self):
@@ -2217,10 +2411,16 @@ class TestInvertedIndexValid(TestcaseBase):
         """
         collection_w = self.init_collection_general(prefix, is_index=False, is_all_data_type=True)[0]
         scalar_index_params = {"index_type": "INVERTED"}
-        scalar_fields = [ct.default_int8_field_name, ct.default_int16_field_name,
-                         ct.default_int32_field_name, ct.default_int64_field_name,
-                         ct.default_float_field_name, ct.default_double_field_name,
-                         ct.default_string_field_name, ct.default_bool_field_name]
+        scalar_fields = [
+            ct.default_int8_field_name,
+            ct.default_int16_field_name,
+            ct.default_int32_field_name,
+            ct.default_int64_field_name,
+            ct.default_float_field_name,
+            ct.default_double_field_name,
+            ct.default_string_field_name,
+            ct.default_bool_field_name,
+        ]
         for i in range(len(scalar_fields)):
             index_name = f"scalar_index_name_{i}"
             collection_w.create_index(scalar_fields[i], index_params=scalar_index_params, index_name=index_name)
@@ -2235,8 +2435,7 @@ class TestInvertedIndexValid(TestcaseBase):
         """
         collection_w = self.init_collection_general(prefix, is_index=False, is_all_data_type=True)[0]
         scalar_index = ["Trie", "STL_SORT", "INVERTED"]
-        scalar_fields = [ct.default_string_field_name, ct.default_int16_field_name,
-                         ct.default_int32_field_name]
+        scalar_fields = [ct.default_string_field_name, ct.default_int16_field_name, ct.default_int32_field_name]
         for i in range(len(scalar_fields)):
             index_name = f"scalar_index_name_{i}"
             scalar_index_params = {"index_type": f"{scalar_index[i]}"}
@@ -2246,9 +2445,9 @@ class TestInvertedIndexValid(TestcaseBase):
     @pytest.mark.tags(CaseLabel.L0)
     def test_binary_arith_expr_on_inverted_index(self):
         prefix = "test_binary_arith_expr_on_inverted_index"
-        nb = 5000
-        collection_w, _, _, insert_ids, _ = self.init_collection_general(prefix, insert_data=True, is_index=True,
-                                                                         is_all_data_type=True)
+        collection_w, _, _, insert_ids, _ = self.init_collection_general(
+            prefix, insert_data=True, is_index=True, is_all_data_type=True
+        )
         index_name = "test_binary_arith_expr_on_inverted_index"
         scalar_index_params = {"index_type": "INVERTED"}
         collection_w.release()
@@ -2296,14 +2495,18 @@ class TestBitmapIndex(TestcaseBase):
             schema=cf.set_collection_schema(
                 fields=[primary_field, DataType.FLOAT_VECTOR.name],
                 field_params={primary_field: FieldParams(is_primary=True).to_dict},
-                auto_id=auto_id
-            )
+                auto_id=auto_id,
+            ),
         )
 
         # build `BITMAP` index on primary key field
         self.collection_wrap.create_index(
-            field_name=primary_field, index_params={"index_type": IndexName.BITMAP}, index_name=primary_field,
-            check_task=CheckTasks.err_res, check_items={ct.err_code: 1100, ct.err_msg: iem.CheckBitmapOnPK})
+            field_name=primary_field,
+            index_params={"index_type": IndexName.BITMAP},
+            index_name=primary_field,
+            check_task=CheckTasks.err_res,
+            check_items={ct.err_code: 1100, ct.err_msg: iem.CheckBitmapOnPK},
+        )
 
     @pytest.mark.tags(CaseLabel.L0)
     def test_bitmap_on_not_supported_fields(self, request):
@@ -2325,8 +2528,8 @@ class TestBitmapIndex(TestcaseBase):
             name=collection_name,
             schema=cf.set_collection_schema(
                 fields=[primary_field, DataType.SPARSE_FLOAT_VECTOR.name, *self.bitmap_not_support_dtype_names],
-                field_params={primary_field: FieldParams(is_primary=True).to_dict}
-            )
+                field_params={primary_field: FieldParams(is_primary=True).to_dict},
+            ),
         )
 
         # build `BITMAP` index on sparse vector field
@@ -2334,18 +2537,23 @@ class TestBitmapIndex(TestcaseBase):
             iem.VectorMetricTypeExist: IndexPrams(index_type=IndexName.BITMAP),
             iem.SparseFloatVectorMetricType: IndexPrams(index_type=IndexName.BITMAP, metric_type=MetricType.L2),
             iem.CheckVectorIndex.format("SparseFloatVector", IndexName.BITMAP): IndexPrams(
-                index_type=IndexName.BITMAP, metric_type=MetricType.IP)
+                index_type=IndexName.BITMAP, metric_type=MetricType.IP
+            ),
         }.items():
             self.collection_wrap.create_index(
-                field_name=DataType.SPARSE_FLOAT_VECTOR.name, index_params=index_params.to_dict,
-                check_task=CheckTasks.err_res, check_items={ct.err_code: 1100, ct.err_msg: msg}
+                field_name=DataType.SPARSE_FLOAT_VECTOR.name,
+                index_params=index_params.to_dict,
+                check_task=CheckTasks.err_res,
+                check_items={ct.err_code: 1100, ct.err_msg: msg},
             )
 
         # build `BITMAP` index on not supported scalar fields
         for _field_name in self.bitmap_not_support_dtype_names:
             self.collection_wrap.create_index(
-                field_name=_field_name, index_params=IndexPrams(index_type=IndexName.BITMAP).to_dict,
-                check_task=CheckTasks.err_res, check_items={ct.err_code: 1100, ct.err_msg: iem.CheckBitmapIndex}
+                field_name=_field_name,
+                index_params=IndexPrams(index_type=IndexName.BITMAP).to_dict,
+                check_task=CheckTasks.err_res,
+                check_items={ct.err_code: 1100, ct.err_msg: iem.CheckBitmapIndex},
             )
 
     @pytest.mark.tags(CaseLabel.L0)
@@ -2367,7 +2575,7 @@ class TestBitmapIndex(TestcaseBase):
             3. can drop index on loaded collection
         """
         # init params
-        collection_name, nb = f"{request.function.__name__}_{primary_field}_{auto_id}", 3000
+        collection_name, _nb = f"{request.function.__name__}_{primary_field}_{auto_id}", 3000
 
         # create a collection with fields that can build `BITMAP` index
         self.collection_wrap.init_collection(
@@ -2375,14 +2583,14 @@ class TestBitmapIndex(TestcaseBase):
             schema=cf.set_collection_schema(
                 fields=[primary_field, DataType.FLOAT_VECTOR.name, *self.bitmap_support_dtype_names],
                 field_params={primary_field: FieldParams(is_primary=True).to_dict},
-                auto_id=auto_id
-            )
+                auto_id=auto_id,
+            ),
         )
 
         # build `BITMAP` index on empty collection
         index_params = {
             **DefaultVectorIndexParams.HNSW(DataType.FLOAT_VECTOR.name),
-            **DefaultScalarIndexParams.list_bitmap(self.bitmap_support_dtype_names)
+            **DefaultScalarIndexParams.list_bitmap(self.bitmap_support_dtype_names),
         }
         self.build_multi_index(index_params=index_params)
         assert sorted([n.field_name for n in self.collection_wrap.indexes]) == sorted(index_params.keys())
@@ -2407,10 +2615,15 @@ class TestBitmapIndex(TestcaseBase):
         self.build_multi_index(index_params=index_params)
 
     @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.parametrize("index_obj, field_name", [(DefaultScalarIndexParams.Default, 'INT64_hybrid_index'),
-                                                       (DefaultScalarIndexParams.INVERTED, 'INT64_inverted'),
-                                                       (DefaultScalarIndexParams.STL_SORT, 'INT64_stl_sort'),
-                                                       (DefaultScalarIndexParams.Trie, 'VARCHAR_trie')])
+    @pytest.mark.parametrize(
+        "index_obj, field_name",
+        [
+            (DefaultScalarIndexParams.Default, "INT64_hybrid_index"),
+            (DefaultScalarIndexParams.INVERTED, "INT64_inverted"),
+            (DefaultScalarIndexParams.STL_SORT, "INT64_stl_sort"),
+            (DefaultScalarIndexParams.Trie, "VARCHAR_trie"),
+        ],
+    )
     def test_bitmap_offset_cache_on_not_bitmap_fields(self, request, index_obj, field_name):
         """
         target:
@@ -2422,7 +2635,7 @@ class TestBitmapIndex(TestcaseBase):
             1. alter index raises expected error
         """
         # init params
-        collection_name, primary_field = f"{request.function.__name__}_{field_name}", 'INT64_pk'
+        collection_name, primary_field = f"{request.function.__name__}_{field_name}", "INT64_pk"
 
         # create a collection with fields
         self.collection_wrap.init_collection(
@@ -2430,21 +2643,20 @@ class TestBitmapIndex(TestcaseBase):
             schema=cf.set_collection_schema(
                 fields=[primary_field, DataType.FLOAT_VECTOR.name, field_name],
                 field_params={primary_field: FieldParams(is_primary=True).to_dict},
-            )
+            ),
         )
 
         # build scalar index on empty collection
-        index_params = {
-            **DefaultVectorIndexParams.HNSW(DataType.FLOAT_VECTOR.name),
-            **index_obj(field_name)
-        }
+        index_params = {**DefaultVectorIndexParams.HNSW(DataType.FLOAT_VECTOR.name), **index_obj(field_name)}
         self.build_multi_index(index_params=index_params)
         assert sorted([n.field_name for n in self.collection_wrap.indexes]) == sorted(index_params.keys())
 
         # enable offset cache and raises error
         self.collection_wrap.alter_index(
-            index_name=field_name, extra_params=AlterIndexParams.index_offset_cache(),
-            check_task=CheckTasks.err_res, check_items={ct.err_code: 1100, ct.err_msg: iem.InvalidOffsetCache}
+            index_name=field_name,
+            extra_params=AlterIndexParams.index_offset_cache(),
+            check_task=CheckTasks.err_res,
+            check_items={ct.err_code: 1100, ct.err_msg: iem.InvalidOffsetCache},
         )
 
     @pytest.mark.tags(CaseLabel.L1)
@@ -2459,7 +2671,7 @@ class TestBitmapIndex(TestcaseBase):
             1. alter index raises expected error
         """
         # init params
-        collection_name, primary_field = f"{request.function.__name__}", 'INT64_pk'
+        collection_name, primary_field = f"{request.function.__name__}", "INT64_pk"
 
         # create a collection with fields
         self.collection_wrap.init_collection(
@@ -2467,7 +2679,7 @@ class TestBitmapIndex(TestcaseBase):
             schema=cf.set_collection_schema(
                 fields=[primary_field, DataType.FLOAT_VECTOR.name],
                 field_params={primary_field: FieldParams(is_primary=True).to_dict},
-            )
+            ),
         )
 
         # build index on empty collection
@@ -2477,8 +2689,10 @@ class TestBitmapIndex(TestcaseBase):
 
         # enable offset cache and raises error
         self.collection_wrap.alter_index(
-            index_name=DataType.FLOAT_VECTOR.name, extra_params=AlterIndexParams.index_offset_cache(),
-            check_task=CheckTasks.err_res, check_items={ct.err_code: 1100, ct.err_msg: iem.InvalidOffsetCache}
+            index_name=DataType.FLOAT_VECTOR.name,
+            extra_params=AlterIndexParams.index_offset_cache(),
+            check_task=CheckTasks.err_res,
+            check_items={ct.err_code: 1100, ct.err_msg: iem.InvalidOffsetCache},
         )
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -2496,7 +2710,7 @@ class TestBitmapIndex(TestcaseBase):
             1. alter index raises expected error after loading collection
         """
         # init params
-        collection_name, primary_field = f"{request.function.__name__}", 'INT64_pk'
+        collection_name, primary_field = f"{request.function.__name__}", "INT64_pk"
 
         # create a collection with fields
         self.collection_wrap.init_collection(
@@ -2504,13 +2718,13 @@ class TestBitmapIndex(TestcaseBase):
             schema=cf.set_collection_schema(
                 fields=[primary_field, DataType.FLOAT_VECTOR.name, *self.bitmap_support_dtype_names],
                 field_params={primary_field: FieldParams(is_primary=True).to_dict},
-            )
+            ),
         )
 
         # build scalar index on empty collection
         index_params = {
             **DefaultVectorIndexParams.HNSW(DataType.FLOAT_VECTOR.name),
-            **DefaultScalarIndexParams.list_bitmap(self.bitmap_support_dtype_names)
+            **DefaultScalarIndexParams.list_bitmap(self.bitmap_support_dtype_names),
         }
         self.build_multi_index(index_params=index_params)
         assert sorted([n.field_name for n in self.collection_wrap.indexes]) == sorted(index_params.keys())
@@ -2524,8 +2738,11 @@ class TestBitmapIndex(TestcaseBase):
         # enable offset cache on loaded collection
         for n in self.bitmap_support_dtype_names:
             self.collection_wrap.alter_index(
-                index_name=n, extra_params=AlterIndexParams.index_offset_cache(),
-                check_task=CheckTasks.err_res, check_items={ct.err_code: 104, ct.err_msg: iem.AlterOnLoadedCollection})
+                index_name=n,
+                extra_params=AlterIndexParams.index_offset_cache(),
+                check_task=CheckTasks.err_res,
+                check_items={ct.err_code: 104, ct.err_msg: iem.AlterOnLoadedCollection},
+            )
 
     @pytest.mark.tags(CaseLabel.L1)
     @pytest.mark.parametrize("auto_id", [True, False])
@@ -2553,14 +2770,14 @@ class TestBitmapIndex(TestcaseBase):
             schema=cf.set_collection_schema(
                 fields=[primary_field, DataType.FLOAT16_VECTOR.name, *self.bitmap_support_dtype_names],
                 field_params={primary_field: FieldParams(is_primary=True).to_dict},
-                auto_id=auto_id
-            )
+                auto_id=auto_id,
+            ),
         )
 
         # build `BITMAP` index on empty collection
         index_params = {
             **DefaultVectorIndexParams.IVF_SQ8(DataType.FLOAT16_VECTOR.name),
-            **DefaultScalarIndexParams.list_bitmap(self.bitmap_support_dtype_names)
+            **DefaultScalarIndexParams.list_bitmap(self.bitmap_support_dtype_names),
         }
         self.build_multi_index(index_params=index_params)
         assert sorted([n.field_name for n in self.collection_wrap.indexes]) == sorted(index_params.keys())
@@ -2569,8 +2786,9 @@ class TestBitmapIndex(TestcaseBase):
         self.collection_wrap.load()
 
         # prepare 3k data (> 1024 triggering index building)
-        self.collection_wrap.insert(data=cf.gen_values(self.collection_wrap.schema, nb=nb),
-                                    check_task=CheckTasks.check_insert_result)
+        self.collection_wrap.insert(
+            data=cf.gen_values(self.collection_wrap.schema, nb=nb), check_task=CheckTasks.check_insert_result
+        )
 
         # check no indexed segments
         res, _ = self.utility_wrap.get_query_segment_info(collection_name=collection_name)
@@ -2613,9 +2831,9 @@ class TestBitmapIndex(TestcaseBase):
             schema=cf.set_collection_schema(
                 fields=[primary_field, DataType.BFLOAT16_VECTOR.name, *self.bitmap_support_dtype_names],
                 field_params={primary_field: FieldParams(is_primary=True).to_dict},
-                auto_id=auto_id
+                auto_id=auto_id,
             ),
-            shards_num=shards_num
+            shards_num=shards_num,
         )
 
         # prepare data (> 1024 triggering index building)
@@ -2623,7 +2841,7 @@ class TestBitmapIndex(TestcaseBase):
         default_values = {} if auto_id else {primary_field: [eval(f"{pk_type}({n})") for n in range(nb)]}
         self.collection_wrap.insert(
             data=cf.gen_values(self.collection_wrap.schema, nb=nb, default_values=default_values),
-            check_task=CheckTasks.check_insert_result
+            check_task=CheckTasks.check_insert_result,
         )
 
         # flush collection, segment sealed
@@ -2632,7 +2850,7 @@ class TestBitmapIndex(TestcaseBase):
         # build `BITMAP` index
         index_params = {
             **DefaultVectorIndexParams.DISKANN(DataType.BFLOAT16_VECTOR.name),
-            **DefaultScalarIndexParams.list_bitmap(self.bitmap_support_dtype_names)
+            **DefaultScalarIndexParams.list_bitmap(self.bitmap_support_dtype_names),
         }
         self.build_multi_index(index_params=index_params)
         assert sorted([n.field_name for n in self.collection_wrap.indexes]) == sorted(index_params.keys())
@@ -2677,15 +2895,16 @@ class TestBitmapIndex(TestcaseBase):
                 fields=[primary_field, DataType.BINARY_VECTOR.name, *self.bitmap_support_dtype_names],
                 field_params={primary_field: FieldParams(is_primary=True).to_dict},
             ),
-            shards_num=shards_num
+            shards_num=shards_num,
         )
 
         # prepare data (> 1024 triggering index building)
         pk_key = str(shards_num) if primary_field.startswith(DataType.VARCHAR.name.lower()) else shards_num
         self.collection_wrap.insert(
-            data=cf.gen_values(self.collection_wrap.schema, nb=nb,
-                               default_values={primary_field: [pk_key for _ in range(nb)]}),
-            check_task=CheckTasks.check_insert_result
+            data=cf.gen_values(
+                self.collection_wrap.schema, nb=nb, default_values={primary_field: [pk_key for _ in range(nb)]}
+            ),
+            check_task=CheckTasks.check_insert_result,
         )
 
         # flush collection, segment sealed
@@ -2694,7 +2913,7 @@ class TestBitmapIndex(TestcaseBase):
         # build `BITMAP` index
         index_params = {
             **DefaultVectorIndexParams.BIN_IVF_FLAT(DataType.BINARY_VECTOR.name),
-            **DefaultScalarIndexParams.list_bitmap(self.bitmap_support_dtype_names)
+            **DefaultScalarIndexParams.list_bitmap(self.bitmap_support_dtype_names),
         }
         self.build_multi_index(index_params=index_params)
         assert sorted([n.field_name for n in self.collection_wrap.indexes]) == sorted(index_params.keys())
@@ -2740,15 +2959,18 @@ class TestBitmapIndex(TestcaseBase):
                 fields=[primary_field, DataType.BINARY_VECTOR.name, *self.bitmap_support_dtype_names],
                 field_params={primary_field: FieldParams(is_primary=True).to_dict},
             ),
-            shards_num=shards_num
+            shards_num=shards_num,
         )
 
         # prepare data (> 1024 triggering index building)
         pk_type = "str" if primary_field.startswith(DataType.VARCHAR.name.lower()) else "int"
         self.collection_wrap.insert(
-            data=cf.gen_values(self.collection_wrap.schema, nb=nb,
-                               default_values={primary_field: [eval(f"{pk_type}({n})") for n in range(nb)]}),
-            check_task=CheckTasks.check_insert_result
+            data=cf.gen_values(
+                self.collection_wrap.schema,
+                nb=nb,
+                default_values={primary_field: [eval(f"{pk_type}({n})") for n in range(nb)]},
+            ),
+            check_task=CheckTasks.check_insert_result,
         )
 
         # flush collection, segment sealed
@@ -2757,7 +2979,7 @@ class TestBitmapIndex(TestcaseBase):
         # build `BITMAP` index on empty collection
         index_params = {
             **DefaultVectorIndexParams.BIN_IVF_FLAT(DataType.BINARY_VECTOR.name),
-            **DefaultScalarIndexParams.list_bitmap(self.bitmap_support_dtype_names)
+            **DefaultScalarIndexParams.list_bitmap(self.bitmap_support_dtype_names),
         }
         self.build_multi_index(index_params=index_params)
         assert sorted([n.field_name for n in self.collection_wrap.indexes]) == sorted(index_params.keys())
@@ -2781,10 +3003,15 @@ class TestBitmapIndex(TestcaseBase):
         assert sum(counts) == nb, f"`{collection_name}` Segment row count:{sum(counts)} != insert:{nb}"
 
     @pytest.mark.tags(CaseLabel.L2)
-    @pytest.mark.parametrize("extra_params, name", [(AlterIndexParams.index_offset_cache(), 'offset_cache_true'),
-                                                    (AlterIndexParams.index_offset_cache(False), 'offset_cache_false'),
-                                                    (AlterIndexParams.index_mmap(), 'mmap_true'),
-                                                    (AlterIndexParams.index_mmap(False), 'mmap_false')])
+    @pytest.mark.parametrize(
+        "extra_params, name",
+        [
+            (AlterIndexParams.index_offset_cache(), "offset_cache_true"),
+            (AlterIndexParams.index_offset_cache(False), "offset_cache_false"),
+            (AlterIndexParams.index_mmap(), "mmap_true"),
+            (AlterIndexParams.index_mmap(False), "mmap_false"),
+        ],
+    )
     def test_bitmap_alter_index(self, request, extra_params, name):
         """
         target:
@@ -2813,13 +3040,13 @@ class TestBitmapIndex(TestcaseBase):
             schema=cf.set_collection_schema(
                 fields=[primary_field, DataType.FLOAT_VECTOR.name, *self.bitmap_support_dtype_names],
                 field_params={primary_field: FieldParams(is_primary=True).to_dict},
-            )
+            ),
         )
 
         # build `BITMAP` index on empty collection
         index_params = {
             **DefaultVectorIndexParams.IVF_SQ8(DataType.FLOAT_VECTOR.name),
-            **DefaultScalarIndexParams.list_bitmap(self.bitmap_support_dtype_names)
+            **DefaultScalarIndexParams.list_bitmap(self.bitmap_support_dtype_names),
         }
         self.build_multi_index(index_params=index_params)
         assert sorted([n.field_name for n in self.collection_wrap.indexes]) == sorted(index_params.keys())
@@ -2829,8 +3056,9 @@ class TestBitmapIndex(TestcaseBase):
             self.collection_wrap.alter_index(index_name=index_name, extra_params=extra_params)
 
         # prepare data (> 1024 triggering index building)
-        self.collection_wrap.insert(data=cf.gen_values(self.collection_wrap.schema, nb=nb),
-                                    check_task=CheckTasks.check_insert_result)
+        self.collection_wrap.insert(
+            data=cf.gen_values(self.collection_wrap.schema, nb=nb), check_task=CheckTasks.check_insert_result
+        )
 
         # flush collection, segment sealed
         self.collection_wrap.flush()
@@ -2838,14 +3066,17 @@ class TestBitmapIndex(TestcaseBase):
         # rebuild `BITMAP` index
         index_params = {
             **DefaultVectorIndexParams.IVF_SQ8(DataType.FLOAT_VECTOR.name),
-            **DefaultScalarIndexParams.list_bitmap(self.bitmap_support_dtype_names)
+            **DefaultScalarIndexParams.list_bitmap(self.bitmap_support_dtype_names),
         }
         self.build_multi_index(index_params=index_params)
         assert sorted([n.field_name for n in self.collection_wrap.indexes]) == sorted(index_params.keys())
 
         # check alter index
-        scalar_indexes = [{i.field_name: i.params} for i in self.collection_wrap.indexes if
-                          i.field_name in self.bitmap_support_dtype_names]
+        scalar_indexes = [
+            {i.field_name: i.params}
+            for i in self.collection_wrap.indexes
+            if i.field_name in self.bitmap_support_dtype_names
+        ]
         msg = f"Scalar indexes: {scalar_indexes}, expected all to contain {extra_params}"
         assert len([i for i in scalar_indexes for v in i.values() if not cf.check_key_exist(extra_params, v)]) == 0, msg
 
@@ -2865,7 +3096,7 @@ class TestBitmapIndex(TestcaseBase):
             1. alter index failed with param `bitmap_cardinality_limit`
         """
         # init params
-        collection_name, primary_field, nb = f"{request.function.__name__}", "int64_pk", 3000
+        collection_name, primary_field, _nb = f"{request.function.__name__}", "int64_pk", 3000
 
         # create a collection with fields that can build `BITMAP` index
         self.collection_wrap.init_collection(
@@ -2873,13 +3104,13 @@ class TestBitmapIndex(TestcaseBase):
             schema=cf.set_collection_schema(
                 fields=[primary_field, DataType.FLOAT_VECTOR.name, *self.bitmap_support_dtype_names],
                 field_params={primary_field: FieldParams(is_primary=True).to_dict},
-            )
+            ),
         )
 
         # build `BITMAP` index on empty collection
         index_params = {
             **DefaultVectorIndexParams.IVF_SQ8(DataType.FLOAT_VECTOR.name),
-            **DefaultScalarIndexParams.list_bitmap(self.bitmap_support_dtype_names)
+            **DefaultScalarIndexParams.list_bitmap(self.bitmap_support_dtype_names),
         }
         self.build_multi_index(index_params=index_params)
         assert sorted([n.field_name for n in self.collection_wrap.indexes]) == sorted(index_params.keys())
@@ -2887,8 +3118,11 @@ class TestBitmapIndex(TestcaseBase):
         # alter `bitmap_cardinality_limit` failed
         for index_name in self.bitmap_support_dtype_names:
             self.collection_wrap.alter_index(
-                index_name=index_name, extra_params={"bitmap_cardinality_limit": 10}, check_task=CheckTasks.err_res,
-                check_items={ct.err_code: 1100, ct.err_msg: iem.NotConfigable.format("bitmap_cardinality_limit")})
+                index_name=index_name,
+                extra_params={"bitmap_cardinality_limit": 10},
+                check_task=CheckTasks.err_res,
+                check_items={ct.err_code: 1100, ct.err_msg: iem.NotConfigable.format("bitmap_cardinality_limit")},
+            )
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("bitmap_cardinality_limit", [-10, 0, 1001])
@@ -2905,7 +3139,7 @@ class TestBitmapIndex(TestcaseBase):
         """
         # init params
         collection_name = f"{request.function.__name__}_{str(bitmap_cardinality_limit).replace('-', '_')}"
-        primary_field, nb = "int64_pk", 3000
+        primary_field, _nb = "int64_pk", 3000
 
         # create a collection with fields that can build `BITMAP` index
         self.collection_wrap.init_collection(
@@ -2913,15 +3147,19 @@ class TestBitmapIndex(TestcaseBase):
             schema=cf.set_collection_schema(
                 fields=[primary_field, DataType.FLOAT_VECTOR.name, DataType.INT64.name],
                 field_params={primary_field: FieldParams(is_primary=True).to_dict},
-            )
+            ),
         )
 
         # build scalar index and check failed
         self.collection_wrap.create_index(
-            field_name=DataType.INT64.name, index_name=DataType.INT64.name,
-            index_params={"index_type": IndexName.AUTOINDEX, "bitmap_cardinality_limit": bitmap_cardinality_limit})
-        assert self.collection_wrap.index()[0].params == {'bitmap_cardinality_limit': str(bitmap_cardinality_limit),
-                                                          'index_type': IndexName.AUTOINDEX}
+            field_name=DataType.INT64.name,
+            index_name=DataType.INT64.name,
+            index_params={"index_type": IndexName.AUTOINDEX, "bitmap_cardinality_limit": bitmap_cardinality_limit},
+        )
+        assert self.collection_wrap.index()[0].params == {
+            "bitmap_cardinality_limit": str(bitmap_cardinality_limit),
+            "index_type": IndexName.AUTOINDEX,
+        }
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("index_params, name", [({"index_type": IndexName.AUTOINDEX}, "AUTOINDEX"), ({}, "None")])
@@ -2948,26 +3186,35 @@ class TestBitmapIndex(TestcaseBase):
             schema=cf.set_collection_schema(
                 fields=[primary_field, DataType.FLOAT_VECTOR.name, *self.bitmap_support_dtype_names],
                 field_params={primary_field: FieldParams(is_primary=True).to_dict},
-            )
+            ),
         )
 
         for scalar_field in self.bitmap_support_dtype_names:
             # build scalar index
-            self.collection_wrap.create_index(field_name=scalar_field, index_name=scalar_field,
-                                              index_params={**index_params, "bitmap_cardinality_limit": 200})
+            self.collection_wrap.create_index(
+                field_name=scalar_field,
+                index_name=scalar_field,
+                index_params={**index_params, "bitmap_cardinality_limit": 200},
+            )
 
             # build scalar index with different `bitmap_cardinality_limit`
-            self.collection_wrap.create_index(field_name=scalar_field, index_name=scalar_field,
-                                              index_params={**index_params, "bitmap_cardinality_limit": 300},
-                                              check_task=CheckTasks.err_res,
-                                              check_items={ct.err_code: 65535, ct.err_msg: iem.OneIndexPerField})
+            self.collection_wrap.create_index(
+                field_name=scalar_field,
+                index_name=scalar_field,
+                index_params={**index_params, "bitmap_cardinality_limit": 300},
+                check_task=CheckTasks.err_res,
+                check_items={ct.err_code: 65535, ct.err_msg: iem.OneIndexPerField},
+            )
 
         self.drop_multi_index(self.bitmap_support_dtype_names)
 
         # re-build scalar index
         for scalar_field in self.bitmap_support_dtype_names:
-            self.collection_wrap.create_index(field_name=scalar_field, index_name=scalar_field,
-                                              index_params={**index_params, "bitmap_cardinality_limit": 300})
+            self.collection_wrap.create_index(
+                field_name=scalar_field,
+                index_name=scalar_field,
+                index_params={**index_params, "bitmap_cardinality_limit": 300},
+            )
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("bitmap_cardinality_limit", [1, 100, 1000])
@@ -3000,12 +3247,13 @@ class TestBitmapIndex(TestcaseBase):
             schema=cf.set_collection_schema(
                 fields=[primary_field, DataType.FLOAT_VECTOR.name, *self.bitmap_support_dtype_names],
                 field_params={primary_field: FieldParams(is_primary=True).to_dict},
-            )
+            ),
         )
 
         # prepare data (> 1024 triggering index building)
-        self.collection_wrap.insert(data=cf.gen_values(self.collection_wrap.schema, nb=nb),
-                                    check_task=CheckTasks.check_insert_result)
+        self.collection_wrap.insert(
+            data=cf.gen_values(self.collection_wrap.schema, nb=nb), check_task=CheckTasks.check_insert_result
+        )
 
         # flush collection, segment sealed
         self.collection_wrap.flush()
@@ -3016,17 +3264,24 @@ class TestBitmapIndex(TestcaseBase):
         # build scalar index
         for scalar_field in self.bitmap_support_dtype_names:
             self.collection_wrap.create_index(
-                field_name=scalar_field, index_name=scalar_field,
-                index_params={**index_params, "bitmap_cardinality_limit": bitmap_cardinality_limit})
+                field_name=scalar_field,
+                index_name=scalar_field,
+                index_params={**index_params, "bitmap_cardinality_limit": bitmap_cardinality_limit},
+            )
 
         # load collection
         self.collection_wrap.load()
 
     @pytest.mark.tags(CaseLabel.L2)
-    @pytest.mark.parametrize("config, cardinality_data_range, name",
-                             [({"bitmap_cardinality_limit": 1000}, (-128, 127), 1000),
-                              ({"bitmap_cardinality_limit": 100}, (-128, 127), 100),
-                              ({}, (1, 100), "None_100"), ({}, (1, 99), "None_99")])
+    @pytest.mark.parametrize(
+        "config, cardinality_data_range, name",
+        [
+            ({"bitmap_cardinality_limit": 1000}, (-128, 127), 1000),
+            ({"bitmap_cardinality_limit": 100}, (-128, 127), 100),
+            ({}, (1, 100), "None_100"),
+            ({}, (1, 99), "None_99"),
+        ],
+    )
     def test_bitmap_cardinality_limit_low_data(self, request, config, name, cardinality_data_range):
         """
         target:
@@ -3054,27 +3309,33 @@ class TestBitmapIndex(TestcaseBase):
             schema=cf.set_collection_schema(
                 fields=[primary_field, DataType.FLOAT_VECTOR.name, *self.bitmap_support_dtype_names],
                 field_params={primary_field: FieldParams(is_primary=True).to_dict},
-            )
+            ),
         )
 
         # prepare data (> 1024 triggering index building)
         low_cardinality = [random.randint(*cardinality_data_range) for _ in range(nb)]
         self.collection_wrap.insert(
             data=cf.gen_values(
-                self.collection_wrap.schema, nb=nb,
+                self.collection_wrap.schema,
+                nb=nb,
                 default_values={
                     # set all INT values
-                    **{k.name: low_cardinality for k in
-                       [DataType.INT8, DataType.INT16, DataType.INT32, DataType.INT64]},
+                    **{
+                        k.name: low_cardinality for k in [DataType.INT8, DataType.INT16, DataType.INT32, DataType.INT64]
+                    },
                     # set VARCHAR value
                     DataType.VARCHAR.name: [str(i) for i in low_cardinality],
                     # set all ARRAY + INT values
-                    **{f"{DataType.ARRAY.name}_{k.name}": [[i] for i in low_cardinality] for k in
-                       [DataType.INT8, DataType.INT16, DataType.INT32, DataType.INT64]},
+                    **{
+                        f"{DataType.ARRAY.name}_{k.name}": [[i] for i in low_cardinality]
+                        for k in [DataType.INT8, DataType.INT16, DataType.INT32, DataType.INT64]
+                    },
                     # set ARRAY + VARCHAR values
                     f"{DataType.ARRAY.name}_{DataType.VARCHAR.name}": [[str(i)] for i in low_cardinality],
-                }),
-            check_task=CheckTasks.check_insert_result)
+                },
+            ),
+            check_task=CheckTasks.check_insert_result,
+        )
 
         # flush collection, segment sealed
         self.collection_wrap.flush()
@@ -3085,8 +3346,10 @@ class TestBitmapIndex(TestcaseBase):
         # build scalar index
         for scalar_field in self.bitmap_support_dtype_names:
             self.collection_wrap.create_index(
-                field_name=scalar_field, index_name=scalar_field,
-                index_params={"index_type": IndexName.AUTOINDEX, **config})
+                field_name=scalar_field,
+                index_name=scalar_field,
+                index_params={"index_type": IndexName.AUTOINDEX, **config},
+            )
 
         # load collection
         self.collection_wrap.load()


### PR DESCRIPTION
## Summary

- Mechanical cleanup of accumulated ruff lint debt in two
  `tests/python_client/` files so future PRs that touch them aren't
  blocked by file-scope lint failures unrelated to their actual change.
- Both files now pass `ruff check` and `ruff format --check` against
  `tests/ruff.toml`.
- No behavior change. `pytest --collect-only` still collects the
  same 265 tests in `test_index.py`.

issue: #49543

First follow-up cleanup for the framework introduced in #49130, which
intentionally deferred mass-reformatting the existing 316 `.py` files
under `tests/` ("will be cleaned up incrementally in follow-up PRs per
sub-directory").

## What changed

`tests/python_client/check/func_check.py` (25 errors)
- `ruff --fix --unsafe-fixes` handles `UP032` (`.format()` → f-string),
  `F541` (empty-placeholder f-strings), `F841` (one unused
  `error_code` local), `I001` (import order), `F401` (unused imports).
- Four `UP031` percent-format strings hand-converted to f-strings.
- One orphan subscript expression left behind by the unsafe-fix pass
  removed.

`tests/python_client/testcases/test_index.py` (60+ errors)
- Same auto-fix sweep, plus `E712` (`== True` → truthy check).
- Star imports made explicit:
  - `from common.constants import *` → dropped (only
    `default_entities` was referenced, and only inside a commented-out
    line).
  - `from utils.util_pymilvus import *` → narrowed to `MyThread`,
    `default_dim`, `default_float_vec_field_name`,
    `default_binary_vec_field_name`.
- The `time` module that the star import used to re-export is now
  imported directly.

## Test plan

- [x] `ruff check --config tests/ruff.toml` passes on both files.
- [x] `ruff format --check --config tests/ruff.toml` passes on both
      files.
- [x] `pytest --collect-only tests/python_client/testcases/test_index.py`
      collects 265 tests (unchanged).
- [ ] CI's `Python Lint (tests/)` job goes green (was the original
      block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
