### PR TITLE
fix: bypass knowhere thread control for iterators

### DIFF
--- a/internal/core/src/index/VectorDiskIndex.cpp
+++ b/internal/core/src/index/VectorDiskIndex.cpp
@@ -485,7 +485,7 @@ knowhere::expected<std::vector<knowhere::IndexNode::IteratorPtr>>
 VectorDiskAnnIndex<T>::VectorIterators(const DatasetPtr dataset,
                                        const knowhere::Json& conf,
                                        const BitsetView& bitset) const {
-    return this->index_.AnnIterator(dataset, conf, bitset);
+    return this->index_.AnnIterator(dataset, conf, bitset, false);
 }
 
 template <typename T>

--- a/internal/core/src/index/VectorMemIndex.cpp
+++ b/internal/core/src/index/VectorMemIndex.cpp
@@ -148,7 +148,7 @@ knowhere::expected<std::vector<knowhere::IndexNode::IteratorPtr>>
 VectorMemIndex<T>::VectorIterators(const milvus::DatasetPtr dataset,
                                    const knowhere::Json& conf,
                                    const milvus::BitsetView& bitset) const {
-    return this->index_.AnnIterator(dataset, conf, bitset);
+    return this->index_.AnnIterator(dataset, conf, bitset, false);
 }
 
 template <typename T>

--- a/internal/core/src/query/SearchBruteForce.cpp
+++ b/internal/core/src/query/SearchBruteForce.cpp
@@ -308,23 +308,23 @@ DispatchBruteForceIteratorByDataType(const knowhere::DataSetPtr& base_dataset,
     switch (data_type) {
         case DataType::VECTOR_FLOAT:
             return knowhere::BruteForce::AnnIterator<float>(
-                base_dataset, query_dataset, config, bitset);
+                base_dataset, query_dataset, config, bitset, false);
         case DataType::VECTOR_FLOAT16:
             return knowhere::BruteForce::AnnIterator<float16>(
-                base_dataset, query_dataset, config, bitset);
+                base_dataset, query_dataset, config, bitset, false);
         case DataType::VECTOR_BFLOAT16:
             return knowhere::BruteForce::AnnIterator<bfloat16>(
-                base_dataset, query_dataset, config, bitset);
+                base_dataset, query_dataset, config, bitset, false);
         case DataType::VECTOR_SPARSE_U32_F32:
             return knowhere::BruteForce::AnnIterator<
                 knowhere::sparse::SparseRow<SparseValueType>>(
-                base_dataset, query_dataset, config, bitset);
+                base_dataset, query_dataset, config, bitset, false);
         case DataType::VECTOR_INT8:
             return knowhere::BruteForce::AnnIterator<int8>(
-                base_dataset, query_dataset, config, bitset);
+                base_dataset, query_dataset, config, bitset, false);
         case DataType::VECTOR_BINARY:
             return knowhere::BruteForce::AnnIterator<bin1>(
-                base_dataset, query_dataset, config, bitset);
+                base_dataset, query_dataset, config, bitset, false);
         default:
             ThrowInfo(ErrorCode::Unsupported,
                       "Unsupported dataType for chunk brute force iterator:{}",


### PR DESCRIPTION
## Summary

Disable Knowhere search-pool scheduling for vector iterators created by Milvus. Milvus consumes these iterators from its own execution threads, and the extra Knowhere thread control adds per-Next scheduling overhead for iterator-heavy group-by search paths.

issue: #42132