### PR TITLE
fix: support streaming node rg rolling upgrade

### DIFF
--- a/internal/mocks/streamingnode/client/mock_manager/mock_ManagerClient.go
+++ b/internal/mocks/streamingnode/client/mock_manager/mock_ManagerClient.go
@@ -102,9 +102,9 @@ func (_c *MockManagerClient_Close_Call) RunAndReturn(run func()) *MockManagerCli
 	return _c
 }
 
-// CollectAllStatus provides a mock function with given fields: ctx, resourceGroup
-func (_m *MockManagerClient) CollectAllStatus(ctx context.Context, resourceGroup string) (map[int64]*types.StreamingNodeStatus, error) {
-	ret := _m.Called(ctx, resourceGroup)
+// CollectAllStatus provides a mock function with given fields: ctx, resourceGroupHint
+func (_m *MockManagerClient) CollectAllStatus(ctx context.Context, resourceGroupHint string) (map[int64]*types.StreamingNodeStatus, error) {
+	ret := _m.Called(ctx, resourceGroupHint)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CollectAllStatus")
@@ -113,10 +113,10 @@ func (_m *MockManagerClient) CollectAllStatus(ctx context.Context, resourceGroup
 	var r0 map[int64]*types.StreamingNodeStatus
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, string) (map[int64]*types.StreamingNodeStatus, error)); ok {
-		return rf(ctx, resourceGroup)
+		return rf(ctx, resourceGroupHint)
 	}
 	if rf, ok := ret.Get(0).(func(context.Context, string) map[int64]*types.StreamingNodeStatus); ok {
-		r0 = rf(ctx, resourceGroup)
+		r0 = rf(ctx, resourceGroupHint)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[int64]*types.StreamingNodeStatus)
@@ -124,7 +124,7 @@ func (_m *MockManagerClient) CollectAllStatus(ctx context.Context, resourceGroup
 	}
 
 	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(ctx, resourceGroup)
+		r1 = rf(ctx, resourceGroupHint)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -139,12 +139,12 @@ type MockManagerClient_CollectAllStatus_Call struct {
 
 // CollectAllStatus is a helper method to define mock.On call
 //   - ctx context.Context
-//   - resourceGroup string
-func (_e *MockManagerClient_Expecter) CollectAllStatus(ctx interface{}, resourceGroup interface{}) *MockManagerClient_CollectAllStatus_Call {
-	return &MockManagerClient_CollectAllStatus_Call{Call: _e.mock.On("CollectAllStatus", ctx, resourceGroup)}
+//   - resourceGroupHint string
+func (_e *MockManagerClient_Expecter) CollectAllStatus(ctx interface{}, resourceGroupHint interface{}) *MockManagerClient_CollectAllStatus_Call {
+	return &MockManagerClient_CollectAllStatus_Call{Call: _e.mock.On("CollectAllStatus", ctx, resourceGroupHint)}
 }
 
-func (_c *MockManagerClient_CollectAllStatus_Call) Run(run func(ctx context.Context, resourceGroup string)) *MockManagerClient_CollectAllStatus_Call {
+func (_c *MockManagerClient_CollectAllStatus_Call) Run(run func(ctx context.Context, resourceGroupHint string)) *MockManagerClient_CollectAllStatus_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(context.Context), args[1].(string))
 	})

--- a/internal/querycoordv2/meta/replica_manager.go
+++ b/internal/querycoordv2/meta/replica_manager.go
@@ -790,30 +790,48 @@ func (m *ReplicaManager) RecoverSQNodesInCollection(ctx context.Context, collect
 
 // buildSQNodeAssignmentHelpers builds assignment helpers for streaming query node recovery.
 // If streaming node resource groups cover all replica resource groups, creates one helper per RG (isolation mode).
+// During rolling upgrades, old StreamingNodes may not carry RG labels and are reported in DefaultResourceGroupName.
+// In that case, replicas whose RG is not covered by labeled StreamingNodes share the default legacy pool, while
+// covered replicas still use RG isolation.
 // Otherwise, behavior depends on streaming.strictResourceGroupIsolation.enabled config:
 //   - If enabled (strict isolation mode): skip replicas without matching streaming node resource groups.
-//   - If disabled (default): pool all nodes together into a single helper (flat allocation mode).
+//   - If disabled and no default legacy pool exists: pool all nodes together into a single helper (flat allocation mode).
 func (m *ReplicaManager) buildSQNodeAssignmentHelpers(
 	replicas []*Replica,
 	sqnNodesByRG map[string]typeutil.UniqueSet,
 ) map[string]*replicasInSameRGAssignmentHelper {
 	// Group replicas by resource group and check coverage.
 	rgToReplicas := make(map[string][]*Replica)
-	hasUncoveredReplicas := false
+	uncoveredReplicas := make([]*Replica, 0)
 	for _, replica := range replicas {
 		rgName := replica.GetResourceGroup()
 		if _, ok := sqnNodesByRG[rgName]; ok {
 			rgToReplicas[rgName] = append(rgToReplicas[rgName], replica)
 		} else {
-			hasUncoveredReplicas = true
+			uncoveredReplicas = append(uncoveredReplicas, replica)
 		}
 	}
 
 	helpers := make(map[string]*replicasInSameRGAssignmentHelper)
+	strictIsolation := paramtable.Get().StreamingCfg.StrictResourceGroupIsolationEnabled.GetAsBool()
+
+	if len(uncoveredReplicas) > 0 && !strictIsolation {
+		if _, ok := sqnNodesByRG[DefaultResourceGroupName]; ok {
+			// Compatibility mode for rolling upgrades from old StreamingNodes without RG labels:
+			// uncovered replicas keep using the default legacy pool, while covered replicas keep
+			// their isolated pools. If there are also replicas explicitly in the default RG, they
+			// share the same default pool with uncovered legacy replicas.
+			rgToReplicas[DefaultResourceGroupName] = append(rgToReplicas[DefaultResourceGroupName], uncoveredReplicas...)
+			for rgName, rgReplicas := range rgToReplicas {
+				helpers[rgName] = newReplicaSQNAssignmentHelper(rgName, rgReplicas, sqnNodesByRG[rgName])
+			}
+			return helpers
+		}
+	}
 
 	// Check if we should use fallback mode (flat allocation).
 	// Fallback mode is used when there are uncovered replicas and isolation is disabled.
-	useFallbackMode := hasUncoveredReplicas && !paramtable.Get().StreamingCfg.StrictResourceGroupIsolationEnabled.GetAsBool()
+	useFallbackMode := len(uncoveredReplicas) > 0 && !strictIsolation
 
 	if useFallbackMode {
 		// Fallback: pool all nodes together for ALL replicas.

--- a/internal/querycoordv2/meta/replica_manager_test.go
+++ b/internal/querycoordv2/meta/replica_manager_test.go
@@ -704,7 +704,40 @@ func TestSQNodeResourceGroupIsolation(t *testing.T) {
 	allExpectedNodes := []int64{101, 102, 201, 202, 203, 301}
 	assert.ElementsMatch(t, allExpectedNodes, allNodes)
 
-	// Test case 3: Strict isolation mode (with config enabled).
+	// Test case 3: Rolling upgrade compatibility mode.
+	// Old StreamingNodes without RG labels are reported under the default RG. Replicas
+	// in old/uncovered RGs should use only that legacy default pool, while replicas in
+	// newly covered RGs should keep strict RG isolation.
+	replica8 := newReplica(&querypb.Replica{
+		ID:            8,
+		CollectionID:  250,
+		ResourceGroup: "RG_OLD_REPLICA", // Not covered by labeled streaming nodes.
+		Nodes:         []int64{},
+	})
+	replica9 := newReplica(&querypb.Replica{
+		ID:            9,
+		CollectionID:  250,
+		ResourceGroup: "RG1",
+		Nodes:         []int64{},
+	})
+
+	err = mgr.put(ctx, replica8, replica9)
+	assert.NoError(t, err)
+
+	rollingUpgradeSQNodesByRG := map[string]typeutil.UniqueSet{
+		DefaultResourceGroupName: typeutil.NewUniqueSet(901, 902),
+		"RG1":                    typeutil.NewUniqueSet(101, 102),
+	}
+
+	err = mgr.RecoverSQNodesInCollection(ctx, 250, rollingUpgradeSQNodesByRG)
+	assert.NoError(t, err)
+
+	updatedReplica8 := mgr.Get(ctx, 8)
+	updatedReplica9 := mgr.Get(ctx, 9)
+	assert.ElementsMatch(t, []int64{901, 902}, updatedReplica8.GetRWSQNodes())
+	assert.ElementsMatch(t, []int64{101, 102}, updatedReplica9.GetRWSQNodes())
+
+	// Test case 4: Strict isolation mode (with config enabled).
 	// When streaming.queryNodeResourceGroupIsolation.enabled is true, uncovered replicas
 	// should not get any streaming query nodes.
 	paramtable.Get().Save(paramtable.Get().StreamingCfg.StrictResourceGroupIsolationEnabled.Key, "true")

--- a/internal/streamingcoord/server/balancer/balancer_impl.go
+++ b/internal/streamingcoord/server/balancer/balancer_impl.go
@@ -539,7 +539,7 @@ func (b *balancerImpl) balance(ctx context.Context) (bool, error) {
 	pchannelView := b.channelMetaManager.CurrentPChannelsView()
 
 	rgName := paramtable.Get().StreamingCfg.PrimaryResourceGroup.GetValue()
-	b.Logger().Info("collect all status...", zap.String("resourceGroup", rgName))
+	b.Logger().Info("collect all status...", zap.String("resourceGroupHint", rgName))
 	nodeStatus, err := b.fetchStreamingNodeStatus(ctx, rgName)
 	if err != nil {
 		return false, err

--- a/internal/streamingcoord/server/balancer/balancer_test.go
+++ b/internal/streamingcoord/server/balancer/balancer_test.go
@@ -295,7 +295,7 @@ func TestBalancer_WithRecoveryLag(t *testing.T) {
 	streamingNodeManager.EXPECT().WatchNodeChanged(mock.Anything).Return(make(chan struct{}), nil)
 	streamingNodeManager.EXPECT().Assign(mock.Anything, mock.Anything).Return(nil)
 	streamingNodeManager.EXPECT().Remove(mock.Anything, mock.Anything).Return(nil)
-	streamingNodeManager.EXPECT().CollectAllStatus(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, resourceGroup string) (map[int64]*types.StreamingNodeStatus, error) {
+	streamingNodeManager.EXPECT().CollectAllStatus(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, resourceGroupHint string) (map[int64]*types.StreamingNodeStatus, error) {
 		now := time.Now()
 		mvccTimeTick := tsoutil.ComposeTSByTime(now, 0)
 		recoveryTimeTick := tsoutil.ComposeTSByTime(now.Add(-time.Second*10), 0)

--- a/internal/streamingnode/client/manager/manager_client.go
+++ b/internal/streamingnode/client/manager/manager_client.go
@@ -35,10 +35,9 @@ type ManagerClient interface {
 	// The resource group is obtained from the session's ServerLabels.
 	GetAllStreamingNodes(ctx context.Context) (map[int64]*types.StreamingNodeInfoWithResourceGroup, error)
 
-	// CollectAllStatus collects status of all streamingnode, such as load balance attributes.
-	// The result is fetch from service discovery and make a broadcast rpc call to all streamingnode.
-	// If resourceGroup is not empty, only nodes with matching resource group will be collected.
-	CollectAllStatus(ctx context.Context, resourceGroup string) (map[int64]*types.StreamingNodeStatus, error)
+	// CollectAllStatus collects status of selected streamingnode, such as load balance attributes.
+	// The resourceGroupHint is preferred when it has discovered nodes; otherwise another resource group is selected before RPC.
+	CollectAllStatus(ctx context.Context, resourceGroupHint string) (map[int64]*types.StreamingNodeStatus, error)
 
 	// Assign a wal instance for the channel on streaming node of given server id.
 	Assign(ctx context.Context, pchannel types.PChannelInfoAssigned) error

--- a/internal/streamingnode/client/manager/manager_client_impl.go
+++ b/internal/streamingnode/client/manager/manager_client_impl.go
@@ -83,8 +83,9 @@ func (c *managerClientImpl) GetAllStreamingNodes(ctx context.Context) (map[int64
 	return result, nil
 }
 
-// CollectAllStatus collects status in all underlying streamingnode.
+// CollectAllStatus collects status in underlying streamingnodes.
 // If resourceGroup is not empty, only nodes with matching resource group will be collected.
+// If resourceGroup is empty and default resource group exists, only default resource group nodes will be collected.
 func (c *managerClientImpl) CollectAllStatus(ctx context.Context, resourceGroup string) (map[int64]*types.StreamingNodeStatus, error) {
 	if !c.lifetime.Add(typeutil.LifetimeStateWorking) {
 		return nil, status.NewOnShutdownError("manager client is closing")
@@ -99,6 +100,7 @@ func (c *managerClientImpl) CollectAllStatus(ctx context.Context, resourceGroup 
 	if len(state.State.Addresses) == 0 {
 		return make(map[int64]*types.StreamingNodeStatus), nil
 	}
+	resourceGroup = effectiveResourceGroupForCollectAllStatus(state, resourceGroup)
 
 	// Collect status of all streamingnode.
 	result, err := c.getAllStreamingNodeStatus(ctx, state, resourceGroup)
@@ -122,6 +124,19 @@ func (c *managerClientImpl) CollectAllStatus(ctx context.Context, resourceGroup 
 		}
 	}
 	return result, nil
+}
+
+func effectiveResourceGroupForCollectAllStatus(state discoverer.VersionedState, resourceGroup string) string {
+	if resourceGroup != "" {
+		return resourceGroup
+	}
+	for _, session := range state.Sessions() {
+		rg := session.GetResourceGroupName()
+		if rg == "" || rg == common.DefaultResourceGroupName {
+			return common.DefaultResourceGroupName
+		}
+	}
+	return ""
 }
 
 func (c *managerClientImpl) getAllStreamingNodeStatus(ctx context.Context, state discoverer.VersionedState, resourceGroup string) (map[int64]*types.StreamingNodeStatus, error) {

--- a/internal/streamingnode/client/manager/manager_client_impl.go
+++ b/internal/streamingnode/client/manager/manager_client_impl.go
@@ -84,9 +84,9 @@ func (c *managerClientImpl) GetAllStreamingNodes(ctx context.Context) (map[int64
 }
 
 // CollectAllStatus collects status in underlying streamingnodes.
-// If resourceGroup is not empty, only nodes with matching resource group will be collected.
-// If resourceGroup is empty and default resource group exists, only default resource group nodes will be collected.
-func (c *managerClientImpl) CollectAllStatus(ctx context.Context, resourceGroup string) (map[int64]*types.StreamingNodeStatus, error) {
+// If resourceGroupHint has discovered nodes, only nodes in that resource group are collected.
+// Otherwise, it falls back to another discovered resource group.
+func (c *managerClientImpl) CollectAllStatus(ctx context.Context, resourceGroupHint string) (map[int64]*types.StreamingNodeStatus, error) {
 	if !c.lifetime.Add(typeutil.LifetimeStateWorking) {
 		return nil, status.NewOnShutdownError("manager client is closing")
 	}
@@ -100,10 +100,12 @@ func (c *managerClientImpl) CollectAllStatus(ctx context.Context, resourceGroup 
 	if len(state.State.Addresses) == 0 {
 		return make(map[int64]*types.StreamingNodeStatus), nil
 	}
-	resourceGroup = effectiveResourceGroupForCollectAllStatus(state, resourceGroup)
+	resourceGroupHint = filterStreamingNodeStatusByResourceGroupHint(state, resourceGroupHint)
 
-	// Collect status of all streamingnode.
-	result, err := c.getAllStreamingNodeStatus(ctx, state, resourceGroup)
+	// Collect status from the selected resource group only. The hint fallback
+	// is decided from service discovery before RPC to avoid broadcasting to
+	// resource groups that will not be used for WAL balance.
+	result, err := c.getAllStreamingNodeStatus(ctx, state, resourceGroupHint)
 	if err != nil {
 		return nil, err
 	}
@@ -126,9 +128,24 @@ func (c *managerClientImpl) CollectAllStatus(ctx context.Context, resourceGroup 
 	return result, nil
 }
 
-func effectiveResourceGroupForCollectAllStatus(state discoverer.VersionedState, resourceGroup string) string {
-	if resourceGroup != "" {
-		return resourceGroup
+func filterStreamingNodeStatusByResourceGroupHint(state discoverer.VersionedState, resourceGroupHint string) string {
+	resourceGroupHint = effectiveResourceGroupHintForCollectAllStatus(state, resourceGroupHint)
+	if resourceGroupHint == "" {
+		return ""
+	}
+	statsByRG := groupStreamingNodeSessionStatsByResourceGroup(state)
+	if _, ok := statsByRG[resourceGroupHint]; ok {
+		return resourceGroupHint
+	}
+	if fallbackRG, ok := chooseFallbackResourceGroup(statsByRG); ok {
+		return fallbackRG
+	}
+	return ""
+}
+
+func effectiveResourceGroupHintForCollectAllStatus(state discoverer.VersionedState, resourceGroupHint string) string {
+	if resourceGroupHint != "" {
+		return resourceGroupHint
 	}
 	for _, session := range state.Sessions() {
 		rg := session.GetResourceGroupName()
@@ -137,6 +154,45 @@ func effectiveResourceGroupForCollectAllStatus(state discoverer.VersionedState, 
 		}
 	}
 	return ""
+}
+
+type resourceGroupSessionStats struct {
+	count       int
+	maxServerID int64
+}
+
+func groupStreamingNodeSessionStatsByResourceGroup(state discoverer.VersionedState) map[string]resourceGroupSessionStats {
+	statsByRG := make(map[string]resourceGroupSessionStats)
+	for serverID, session := range state.Sessions() {
+		rg := session.GetResourceGroupName()
+		if rg == "" {
+			rg = common.DefaultResourceGroupName
+		}
+		stats := statsByRG[rg]
+		stats.count++
+		if serverID > stats.maxServerID {
+			stats.maxServerID = serverID
+		}
+		statsByRG[rg] = stats
+	}
+	return statsByRG
+}
+
+func chooseFallbackResourceGroup(statsByRG map[string]resourceGroupSessionStats) (string, bool) {
+	var selectedRG string
+	var selectedCount int
+	var selectedMaxServerID int64
+	for rg, stats := range statsByRG {
+		if stats.count == 0 {
+			continue
+		}
+		if selectedRG == "" || stats.count > selectedCount || (stats.count == selectedCount && stats.maxServerID > selectedMaxServerID) {
+			selectedRG = rg
+			selectedCount = stats.count
+			selectedMaxServerID = stats.maxServerID
+		}
+	}
+	return selectedRG, selectedRG != ""
 }
 
 func (c *managerClientImpl) getAllStreamingNodeStatus(ctx context.Context, state discoverer.VersionedState, resourceGroup string) (map[int64]*types.StreamingNodeStatus, error) {
@@ -159,7 +215,6 @@ func (c *managerClientImpl) getAllStreamingNodeStatus(ctx context.Context, state
 			rg = common.DefaultResourceGroupName
 		}
 		if resourceGroup != "" && rg != resourceGroup {
-			// skip the streaming node if the resource group is not matched.
 			continue
 		}
 		g.Go(func() error {

--- a/internal/streamingnode/client/manager/manager_test.go
+++ b/internal/streamingnode/client/manager/manager_test.go
@@ -257,6 +257,13 @@ func TestCollectAllStatusWithResourceGroupFilter(t *testing.T) {
 	assert.NotContains(t, nodes, int64(3))
 	assert.NotContains(t, nodes, int64(4))
 
+	// Empty resource group falls back to __default_resource_group when unlabeled legacy nodes exist.
+	callCount = 0
+	nodes, err = m.CollectAllStatus(context.Background(), "")
+	assert.NoError(t, err)
+	assert.Len(t, nodes, 1)
+	assert.Contains(t, nodes, int64(4))
+
 	// Filter by __default_resource_group - should only collect status from server 4
 	callCount = 0
 	nodes, err = m.CollectAllStatus(context.Background(), "__default_resource_group")
@@ -269,6 +276,86 @@ func TestCollectAllStatusWithResourceGroupFilter(t *testing.T) {
 	nodes, err = m.CollectAllStatus(context.Background(), "non_existent_rg")
 	assert.NoError(t, err)
 	assert.Len(t, nodes, 0)
+
+	managerService.EXPECT().Close().Return()
+	rb.EXPECT().Close().Return()
+	m.Close()
+}
+
+func TestCollectAllStatusWithEmptyResourceGroupAndExplicitDefaultRG(t *testing.T) {
+	rb := mock_resolver.NewMockBuilder(t)
+	managerService := mock_lazygrpc.NewMockService[streamingpb.StreamingNodeManagerServiceClient](t)
+	m := &managerClientImpl{
+		lifetime: typeutil.NewLifetime(),
+		stopped:  make(chan struct{}),
+		rb:       rb,
+		service:  managerService,
+	}
+	r := mock_resolver.NewMockResolver(t)
+	rb.EXPECT().Resolver().Return(r)
+
+	managerServiceClient := mock_streamingpb.NewMockStreamingNodeManagerServiceClient(t)
+	managerService.EXPECT().GetService(mock.Anything).RunAndReturn(func(ctx context.Context) (streamingpb.StreamingNodeManagerServiceClient, error) {
+		return managerServiceClient, nil
+	})
+	managerServiceClient.EXPECT().CollectStatus(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, snmcsr *streamingpb.StreamingNodeManagerCollectStatusRequest, co ...grpc.CallOption) (*streamingpb.StreamingNodeManagerCollectStatusResponse, error) {
+		return &streamingpb.StreamingNodeManagerCollectStatusResponse{}, nil
+	})
+
+	callCount := 0
+	r.EXPECT().GetLatestState(mock.Anything).RunAndReturn(func(ctx context.Context) (discoverer.VersionedState, error) {
+		callCount++
+		return newVersionedStateWithRG(int64(callCount), map[uint64]serverInfo{
+			1: {resourceGroup: "__default_resource_group"},
+			2: {resourceGroup: "rg_a"},
+		}), nil
+	})
+
+	nodes, err := m.CollectAllStatus(context.Background(), "")
+	assert.NoError(t, err)
+	assert.Len(t, nodes, 1)
+	assert.Contains(t, nodes, int64(1))
+	assert.NotContains(t, nodes, int64(2))
+
+	managerService.EXPECT().Close().Return()
+	rb.EXPECT().Close().Return()
+	m.Close()
+}
+
+func TestCollectAllStatusWithEmptyResourceGroupAndDefaultRGAbsent(t *testing.T) {
+	rb := mock_resolver.NewMockBuilder(t)
+	managerService := mock_lazygrpc.NewMockService[streamingpb.StreamingNodeManagerServiceClient](t)
+	m := &managerClientImpl{
+		lifetime: typeutil.NewLifetime(),
+		stopped:  make(chan struct{}),
+		rb:       rb,
+		service:  managerService,
+	}
+	r := mock_resolver.NewMockResolver(t)
+	rb.EXPECT().Resolver().Return(r)
+
+	managerServiceClient := mock_streamingpb.NewMockStreamingNodeManagerServiceClient(t)
+	managerService.EXPECT().GetService(mock.Anything).RunAndReturn(func(ctx context.Context) (streamingpb.StreamingNodeManagerServiceClient, error) {
+		return managerServiceClient, nil
+	})
+	managerServiceClient.EXPECT().CollectStatus(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, snmcsr *streamingpb.StreamingNodeManagerCollectStatusRequest, co ...grpc.CallOption) (*streamingpb.StreamingNodeManagerCollectStatusResponse, error) {
+		return &streamingpb.StreamingNodeManagerCollectStatusResponse{}, nil
+	})
+
+	callCount := 0
+	r.EXPECT().GetLatestState(mock.Anything).RunAndReturn(func(ctx context.Context) (discoverer.VersionedState, error) {
+		callCount++
+		return newVersionedStateWithRG(int64(callCount), map[uint64]serverInfo{
+			1: {resourceGroup: "rg_a"},
+			2: {resourceGroup: "rg_b"},
+		}), nil
+	})
+
+	nodes, err := m.CollectAllStatus(context.Background(), "")
+	assert.NoError(t, err)
+	assert.Len(t, nodes, 2)
+	assert.Contains(t, nodes, int64(1))
+	assert.Contains(t, nodes, int64(2))
 
 	managerService.EXPECT().Close().Return()
 	rb.EXPECT().Close().Return()

--- a/internal/streamingnode/client/manager/manager_test.go
+++ b/internal/streamingnode/client/manager/manager_test.go
@@ -3,6 +3,7 @@ package manager
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -248,7 +249,7 @@ func TestCollectAllStatusWithResourceGroupFilter(t *testing.T) {
 		}), nil
 	})
 
-	// Filter by rg_a - should only collect status from servers 1 and 2
+	// Hint rg_a - should only return status from servers 1 and 2 while rg_a is available.
 	nodes, err := m.CollectAllStatus(context.Background(), "rg_a")
 	assert.NoError(t, err)
 	assert.Len(t, nodes, 2)
@@ -264,18 +265,108 @@ func TestCollectAllStatusWithResourceGroupFilter(t *testing.T) {
 	assert.Len(t, nodes, 1)
 	assert.Contains(t, nodes, int64(4))
 
-	// Filter by __default_resource_group - should only collect status from server 4
+	// Hint __default_resource_group - should only return status from server 4.
 	callCount = 0
 	nodes, err = m.CollectAllStatus(context.Background(), "__default_resource_group")
 	assert.NoError(t, err)
 	assert.Len(t, nodes, 1)
 	assert.Contains(t, nodes, int64(4))
 
-	// Filter by non-existent RG - should return empty
+	// Unavailable hint falls back to the RG with the most available nodes.
 	callCount = 0
 	nodes, err = m.CollectAllStatus(context.Background(), "non_existent_rg")
 	assert.NoError(t, err)
-	assert.Len(t, nodes, 0)
+	assert.Len(t, nodes, 2)
+	assert.Contains(t, nodes, int64(1))
+	assert.Contains(t, nodes, int64(2))
+
+	managerService.EXPECT().Close().Return()
+	rb.EXPECT().Close().Return()
+	m.Close()
+}
+
+func TestCollectAllStatusFallbackWhenHintUnavailable(t *testing.T) {
+	rb := mock_resolver.NewMockBuilder(t)
+	managerService := mock_lazygrpc.NewMockService[streamingpb.StreamingNodeManagerServiceClient](t)
+	m := &managerClientImpl{
+		lifetime: typeutil.NewLifetime(),
+		stopped:  make(chan struct{}),
+		rb:       rb,
+		service:  managerService,
+	}
+	r := mock_resolver.NewMockResolver(t)
+	rb.EXPECT().Resolver().Return(r)
+
+	managerServiceClient := mock_streamingpb.NewMockStreamingNodeManagerServiceClient(t)
+	managerService.EXPECT().GetService(mock.Anything).RunAndReturn(func(ctx context.Context) (streamingpb.StreamingNodeManagerServiceClient, error) {
+		return managerServiceClient, nil
+	})
+	var mu sync.Mutex
+	pickedServerIDs := make([]int64, 0, 2)
+	managerServiceClient.EXPECT().CollectStatus(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, snmcsr *streamingpb.StreamingNodeManagerCollectStatusRequest, co ...grpc.CallOption) (*streamingpb.StreamingNodeManagerCollectStatusResponse, error) {
+		serverID, ok := contextutil.GetPickServerID(ctx)
+		assert.True(t, ok)
+		mu.Lock()
+		pickedServerIDs = append(pickedServerIDs, serverID)
+		mu.Unlock()
+		return &streamingpb.StreamingNodeManagerCollectStatusResponse{}, nil
+	})
+
+	callCount := 0
+	r.EXPECT().GetLatestState(mock.Anything).RunAndReturn(func(ctx context.Context) (discoverer.VersionedState, error) {
+		callCount++
+		return newVersionedStateWithRG(int64(callCount), map[uint64]serverInfo{
+			2: {resourceGroup: "rg_a"},
+			3: {resourceGroup: "rg_a"},
+			4: {resourceGroup: "rg_b"},
+		}), nil
+	})
+
+	nodes, err := m.CollectAllStatus(context.Background(), "rg_primary")
+	assert.NoError(t, err)
+	assert.Len(t, nodes, 2)
+	assert.Contains(t, nodes, int64(2))
+	assert.Contains(t, nodes, int64(3))
+	assert.ElementsMatch(t, []int64{2, 3}, pickedServerIDs)
+
+	managerService.EXPECT().Close().Return()
+	rb.EXPECT().Close().Return()
+	m.Close()
+}
+
+func TestCollectAllStatusFallbackTieBreakByMaxServerID(t *testing.T) {
+	rb := mock_resolver.NewMockBuilder(t)
+	managerService := mock_lazygrpc.NewMockService[streamingpb.StreamingNodeManagerServiceClient](t)
+	m := &managerClientImpl{
+		lifetime: typeutil.NewLifetime(),
+		stopped:  make(chan struct{}),
+		rb:       rb,
+		service:  managerService,
+	}
+	r := mock_resolver.NewMockResolver(t)
+	rb.EXPECT().Resolver().Return(r)
+
+	managerServiceClient := mock_streamingpb.NewMockStreamingNodeManagerServiceClient(t)
+	managerService.EXPECT().GetService(mock.Anything).RunAndReturn(func(ctx context.Context) (streamingpb.StreamingNodeManagerServiceClient, error) {
+		return managerServiceClient, nil
+	})
+	managerServiceClient.EXPECT().CollectStatus(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, snmcsr *streamingpb.StreamingNodeManagerCollectStatusRequest, co ...grpc.CallOption) (*streamingpb.StreamingNodeManagerCollectStatusResponse, error) {
+		return &streamingpb.StreamingNodeManagerCollectStatusResponse{}, nil
+	})
+
+	callCount := 0
+	r.EXPECT().GetLatestState(mock.Anything).RunAndReturn(func(ctx context.Context) (discoverer.VersionedState, error) {
+		callCount++
+		return newVersionedStateWithRG(int64(callCount), map[uint64]serverInfo{
+			1: {resourceGroup: "rg_a"},
+			5: {resourceGroup: "rg_b"},
+		}), nil
+	})
+
+	nodes, err := m.CollectAllStatus(context.Background(), "non_existent_rg")
+	assert.NoError(t, err)
+	assert.Len(t, nodes, 1)
+	assert.Contains(t, nodes, int64(5))
 
 	managerService.EXPECT().Close().Return()
 	rb.EXPECT().Close().Return()


### PR DESCRIPTION
issue: #47314

During rolling upgrades, old StreamingNodes may not carry resource group labels and are reported as __default_resource_group. Keep uncovered replicas on that legacy default SQN pool while preserving RG-isolated assignment for replicas whose RGs are already covered by labeled StreamingNodes.

Also update CollectAllStatus empty-resource-group semantics to prefer __default_resource_group when it exists. This keeps newly prepared labeled StreamingNodes out of WAL balance until streaming.primaryResourceGroup is explicitly configured, while preserving the previous collect-all behavior for deployments that have no default RG nodes.