### PR TITLE
fix: Reject array element access with IS NULL/IS NOT NULL at parse time

### DIFF
--- a/internal/parser/planparserv2/parser_visitor.go
+++ b/internal/parser/planparserv2/parser_visitor.go
@@ -1598,6 +1598,9 @@ func (v *ParserVisitor) VisitIsNotNull(ctx *parser.IsNotNullContext) interface{}
 	}
 
 	if len(column.NestedPath) != 0 {
+		if typeutil.IsArrayType(column.GetDataType()) {
+			return merr.WrapErrParameterInvalidMsg("IsNull/IsNotNull operations are not supported on array element access, got: %s", ctx.GetText())
+		}
 		// convert json not null expr to exists expr, eg: json['a'] is not null -> exists json['a']
 		expr := &planpb.Expr{
 			Expr: &planpb.Expr_ExistsExpr{
@@ -1642,6 +1645,9 @@ func (v *ParserVisitor) VisitIsNull(ctx *parser.IsNullContext) interface{} {
 	}
 
 	if len(column.NestedPath) != 0 {
+		if typeutil.IsArrayType(column.GetDataType()) {
+			return merr.WrapErrParameterInvalidMsg("IsNull/IsNotNull operations are not supported on array element access, got: %s", ctx.GetText())
+		}
 		// convert json is null expr to not exists expr, eg: json['a'] is null -> not exists json['a']
 		expr := &planpb.Expr{
 			Expr: &planpb.Expr_ExistsExpr{

--- a/internal/parser/planparserv2/plan_parser_v2_test.go
+++ b/internal/parser/planparserv2/plan_parser_v2_test.go
@@ -641,6 +641,8 @@ func TestExpr_IsNull(t *testing.T) {
 	exprStrs := []string{
 		`VarCharField is null`,
 		`VarCharField IS NULL`,
+		`ArrayField is null`,
+		`StringArrayField IS NULL`,
 	}
 	for _, exprStr := range exprStrs {
 		assertValidExpr(t, helper, exprStr)
@@ -654,6 +656,12 @@ func TestExpr_IsNull(t *testing.T) {
 		`BFloat16VectorField is null`,
 		`SparseFloatVectorField is null`,
 		`Int8VectorField is null`,
+		// issue #48904: array element access with IS NULL should be
+		// rejected at parse time rather than raising an internal error
+		// at execution time.
+		`ArrayField[0] is null`,
+		`ArrayField[1] IS NULL`,
+		`StringArrayField[0] is null`,
 	}
 	for _, exprStr := range unsupported {
 		assertInvalidExpr(t, helper, exprStr)
@@ -668,6 +676,8 @@ func TestExpr_IsNotNull(t *testing.T) {
 	exprStrs := []string{
 		`VarCharField is not null`,
 		`VarCharField IS NOT NULL`,
+		`ArrayField is not null`,
+		`StringArrayField IS NOT NULL`,
 	}
 	for _, exprStr := range exprStrs {
 		assertValidExpr(t, helper, exprStr)
@@ -681,6 +691,12 @@ func TestExpr_IsNotNull(t *testing.T) {
 		`BFloat16VectorField is not null`,
 		`SparseFloatVectorField is not null`,
 		`Int8VectorField is not null`,
+		// issue #48904: array element access with IS NOT NULL should be
+		// rejected at parse time rather than raising an internal error
+		// at execution time.
+		`ArrayField[0] is not null`,
+		`ArrayField[1] IS NOT NULL`,
+		`StringArrayField[0] is not null`,
 	}
 	for _, exprStr := range unsupported {
 		assertInvalidExpr(t, helper, exprStr)

--- a/tests/python_client/milvus_client/test_milvus_client_search.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search.py
@@ -401,8 +401,10 @@ class TestMilvusClientSearchInvalid(TestMilvusClientV2Base):
             self.insert(client, collection_name, rows)
             # 3. search
             null_expr = nullable_field_name + "[0]" + " " + null_expr_op
-            error = {ct.err_code: 65535,
-                    ct.err_msg: "unsupported data type: ARRAY"}
+            error = {
+                ct.err_code: 1100,
+                ct.err_msg: "IsNull/IsNotNull operations are not supported on array element access",
+            }
             self.search(client, collection_name, [vectors[0]],
                         filter=null_expr,
                         check_task=CheckTasks.err_res, check_items=error)


### PR DESCRIPTION
## Summary
This PR adds validation to reject array element access expressions used with `IS NULL` and `IS NOT NULL` operators at parse time, preventing internal errors that would occur during execution.

## Key Changes
- Added validation in `VisitIsNull()` and `VisitIsNotNull()` methods in `parser_visitor.go` to detect and reject array element access patterns (e.g., `ArrayField[0] IS NULL`)
- The validation checks if a column has a nested path and is of array type, returning a clear error message instead of allowing invalid expressions to proceed
- Extended test coverage in `plan_parser_v2_test.go` to verify:
  - Valid expressions: direct array field null checks (e.g., `ArrayField IS NULL`)
  - Invalid expressions: array element access with null checks (e.g., `ArrayField[0] IS NULL`)
  - Both `IS NULL` and `IS NOT NULL` operators with various array field types

## Implementation Details
- The fix leverages the existing `typeutil.IsArrayType()` utility to identify array-typed columns
- Error messages are consistent and reference the issue (#48904) for context
- The validation mirrors the existing pattern used for JSON field handling, ensuring consistency with the codebase

issue: #48904