### PR TITLE
fix: correct panic message in ModifiedMetrics.Subtract

### DIFF
--- a/internal/streamingnode/server/wal/interceptors/shard/utils/stats.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/utils/stats.go
@@ -169,7 +169,7 @@ func (m *ModifiedMetrics) Subtract(other ModifiedMetrics) {
 		panic(fmt.Sprintf("rows cannot be less than zero, current: %d, target: %d", m.Rows, other.Rows))
 	}
 	if m.BinarySize < other.BinarySize {
-		panic(fmt.Sprintf("binary size cannot be less than zero, current: %d, target: %d", m.Rows, other.Rows))
+		panic(fmt.Sprintf("binary size cannot be less than zero, current: %d, target: %d", m.BinarySize, other.BinarySize))
 	}
 	m.Rows -= other.Rows
 	m.BinarySize -= other.BinarySize


### PR DESCRIPTION
## Description

Correct the panic message in `ModifiedMetrics.Subtract()` which incorrectly printed `Rows` fields instead of `BinarySize` fields in the BinarySize underflow panic.

### What problem was fixed and how it was fixed

**Problem:** In `internal/streamingnode/server/wal/interceptors/shard/utils/stats.go`, line 172, the panic message for BinarySize underflow referenced `m.Rows` and `other.Rows` instead of `m.BinarySize` and `other.BinarySize`. This is a copy-paste error from the Rows check above it.

```go
// Before (wrong):
panic(fmt.Sprintf("binary size cannot be less than zero, current: %d, target: %d", m.Rows, other.Rows))

// After (correct):
panic(fmt.Sprintf("binary size cannot be less than zero, current: %d, target: %d", m.BinarySize, other.BinarySize))
```

**How it was fixed:** Changed the format arguments from `m.Rows, other.Rows` to `m.BinarySize, other.BinarySize`.

### Which behaviors were modified

**Previous behavior:** When BinarySize underflow occurred, the panic message would incorrectly report Rows values instead of BinarySize values, making debugging confusing.

**Current behavior:** The panic message correctly reports BinarySize values.

### Closes

Closes: #49488