### PR TITLE
build(deps): update 3.0 GPU build env to CUDA 12.9

### DIFF
--- a/.env
+++ b/.env
@@ -8,8 +8,8 @@ OS_NAME=ubuntu22.04
 DATE_VERSION=20260419-63b9f9f
 LATEST_DATE_VERSION=20260419-63b9f9f
 # for services.gpubuilder.image in docker-compose.yml
-GPU_DATE_VERSION=20260419-63b9f9f
-LATEST_GPU_DATE_VERSION=20260419-63b9f9f
+GPU_DATE_VERSION=20260506-b5f57d9
+LATEST_GPU_DATE_VERSION=20260506-b5f57d9
 
 # for other services in docker-compose.yml
 MINIO_ADDRESS=minio:9000
@@ -17,4 +17,3 @@ PULSAR_ADDRESS=pulsar://pulsar:6650
 ETCD_ENDPOINTS=etcd:2379
 AZURITE_CONNECTION_STRING="DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;"
 ENABLE_GCP_NATIVE=ON
-


### PR DESCRIPTION
pr: #49514 

## What
- Update the 3.0 GPU build env tag to 20260506-b5f57d9.
- Align the GPU build environment with master PR #49514, which moved GPU images to CUDA 12.9.

## Why
- The v3.0-beta GPU release image build still used gpu-ubuntu22.04-20260419-63b9f9f with CUDA 11.8.
- That build env fails CMake CUDA compiler checks requiring CUDA20.

## Test
- git diff --check