### PR TITLE
test: fix CI flaky TestPartitionsNumExceedsMax and stale sparse index assertion

### DIFF
--- a/tests/go_client/testcases/helper/test_setup.go
+++ b/tests/go_client/testcases/helper/test_setup.go
@@ -1,8 +1,14 @@
 package helper
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 	"testing"
 	"time"
 
@@ -113,6 +119,56 @@ func teardown() {
 			_ = mc.DropDatabase(ctx, client.NewDropDatabaseOption(db))
 		}
 	}
+}
+
+// managementBaseURL returns the Milvus management API base URL (port 9091)
+// derived from the gRPC addr flag (e.g. http://host:19530 -> http://host:9091).
+func managementBaseURL() string {
+	u, err := url.Parse(*addr)
+	if err != nil {
+		return "http://localhost:9091"
+	}
+	host := u.Hostname()
+	if host == "" {
+		host = "localhost"
+	}
+	return fmt.Sprintf("http://%s:9091", host)
+}
+
+// AlterServerConfig changes a Milvus server config via the management HTTP API.
+// It returns the previous value so the caller can restore it.
+// If the management API is unreachable, it returns ("", error).
+func AlterServerConfig(key, value string) (string, error) {
+	// Get current value first
+	prev, _ := GetServerConfig(key)
+
+	body, _ := json.Marshal(map[string]string{"key": key, "value": value})
+	resp, err := http.Post(managementBaseURL()+"/management/config/alter",
+		"application/json", bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("management API unreachable: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("alter config failed (HTTP %d): %s", resp.StatusCode, string(respBody))
+	}
+	log.Info("AlterServerConfig", zap.String("key", key), zap.String("value", value), zap.String("prev", prev))
+	return prev, nil
+}
+
+// GetServerConfig reads a config value from the management API.
+func GetServerConfig(key string) (string, error) {
+	resp, err := http.Get(managementBaseURL() + "/management/config/get?key=" + url.QueryEscape(key))
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("get config failed (HTTP %d): %s", resp.StatusCode, string(respBody))
+	}
+	return string(respBody), nil
 }
 
 func RunTests(m *testing.M) int {

--- a/tests/go_client/testcases/partition_test.go
+++ b/tests/go_client/testcases/partition_test.go
@@ -1,6 +1,7 @@
 package testcases
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -110,17 +111,48 @@ func TestCreatePartitionInvalid(t *testing.T) {
 }
 
 func TestPartitionsNumExceedsMax(t *testing.T) {
-	// 1023 sequential CreatePartition calls serialize on a per-collection lock in rootcoord;
-	// keep this test serial so it isn't starved by other parallel tests' DDL load.
-	ctx := hp.CreateContext(t, time.Second*300)
-	mc := hp.CreateDefaultMilvusClient(ctx, t)
+	// Temporarily lower maxPartitionNum via management API so we only need a
+	// handful of CreatePartition calls instead of 1023, avoiding CI timeouts.
+	const testMaxPartitions = 10
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 
-	// create collection
+	prev, err := hp.AlterServerConfig("rootCoord.maxPartitionNum", fmt.Sprintf("%d", testMaxPartitions))
+	if err != nil {
+		// Management API unreachable — fall back to original approach with generous timeout.
+		t.Logf("management API unavailable (%v), falling back to full partition creation", err)
+		ctx = hp.CreateContext(t, time.Second*600)
+		testPartitionsNumExceedsMaxFull(t, ctx)
+		return
+	}
+	t.Cleanup(func() {
+		_, _ = hp.AlterServerConfig("rootCoord.maxPartitionNum", prev)
+	})
+
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
 	_, schema := hp.CollPrepare.CreateCollection(ctx, t, mc, hp.NewCreateCollectionParams(hp.Int64Vec), hp.TNewFieldsOption(), hp.TNewSchemaOption())
 
-	// create multi partitions
+	// create partitions up to the (lowered) limit; _default counts as 1
+	for i := 0; i < testMaxPartitions-1; i++ {
+		parName := fmt.Sprintf("par_%d", i)
+		err := mc.CreatePartition(ctx, client.NewCreatePartitionOption(schema.CollectionName, parName))
+		common.CheckErr(t, err, true)
+	}
+	pars, errList := mc.ListPartitions(ctx, client.NewListPartitionOption(schema.CollectionName))
+	common.CheckErr(t, errList, true)
+	require.Len(t, pars, testMaxPartitions)
+
+	// one more should fail
+	parName := common.GenRandomString("par", 4)
+	err = mc.CreatePartition(ctx, client.NewCreatePartitionOption(schema.CollectionName, parName))
+	common.CheckErr(t, err, false, fmt.Sprintf("exceeds max configuration (%d)", testMaxPartitions))
+}
+
+// testPartitionsNumExceedsMaxFull is the fallback when the management API is not available.
+func testPartitionsNumExceedsMaxFull(t *testing.T, ctx context.Context) {
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+	_, schema := hp.CollPrepare.CreateCollection(ctx, t, mc, hp.NewCreateCollectionParams(hp.Int64Vec), hp.TNewFieldsOption(), hp.TNewSchemaOption())
+
 	for i := 0; i < common.MaxPartitionNum-1; i++ {
-		// create par
 		parName := fmt.Sprintf("par_%d", i)
 		err := mc.CreatePartition(ctx, client.NewCreatePartitionOption(schema.CollectionName, parName))
 		common.CheckErr(t, err, true)
@@ -129,7 +161,6 @@ func TestPartitionsNumExceedsMax(t *testing.T) {
 	common.CheckErr(t, errList, true)
 	require.Len(t, pars, common.MaxPartitionNum)
 
-	// create partition exceed max
 	parName := common.GenRandomString("par", 4)
 	err := mc.CreatePartition(ctx, client.NewCreatePartitionOption(schema.CollectionName, parName))
 	common.CheckErr(t, err, false, fmt.Sprintf("exceeds max configuration (%d)", common.MaxPartitionNum))

--- a/tests/python_client/common/common_type.py
+++ b/tests/python_client/common/common_type.py
@@ -341,7 +341,7 @@ all_index_types = [
 
 all_dense_float_index_types = ["FLAT", "IVF_FLAT", "IVF_SQ8", "IVF_PQ", "IVF_RABITQ", "HNSW", "SCANN", "DISKANN"]
 
-inverted_index_algo = ["TAAT_NAIVE", "DAAT_WAND", "DAAT_MAXSCORE", "BLOCK_MAX_MAXSCORE", "BLOCK_MAX_WAND", "SINDI"]
+inverted_index_algo = ["TAAT_NAIVE", "DAAT_WAND", "DAAT_MAXSCORE"]
 
 int8_vector_index = ["HNSW"]
 

--- a/tests/python_client/common/common_type.py
+++ b/tests/python_client/common/common_type.py
@@ -341,7 +341,7 @@ all_index_types = [
 
 all_dense_float_index_types = ["FLAT", "IVF_FLAT", "IVF_SQ8", "IVF_PQ", "IVF_RABITQ", "HNSW", "SCANN", "DISKANN"]
 
-inverted_index_algo = ["TAAT_NAIVE", "DAAT_WAND", "DAAT_MAXSCORE"]
+inverted_index_algo = ["TAAT_NAIVE", "DAAT_WAND", "DAAT_MAXSCORE", "BLOCK_MAX_MAXSCORE", "BLOCK_MAX_WAND", "SINDI"]
 
 int8_vector_index = ["HNSW"]
 

--- a/tests/python_client/testcases/test_index.py
+++ b/tests/python_client/testcases/test_index.py
@@ -1565,7 +1565,7 @@ class TestIndexInvalid(TestcaseBase):
         collection_w.insert(data=data)
         params = {"index_type": index, "metric_type": "IP", "params": {"inverted_index_algo": inverted_index_algo}}
         error = {
-            ct.err_code: 999,
+            ct.err_code: 1100,
             ct.err_msg: f"sparse inverted index algo {inverted_index_algo} not found or not supported",
         }
         index, _ = self.index_wrap.init_index(


### PR DESCRIPTION
## Summary

- **TestPartitionsNumExceedsMax**: Use management API (`POST :9091/management/config/alter`) to temporarily lower `rootCoord.maxPartitionNum` to 10 during the test, reducing 1023 serial `CreatePartition` RPCs to 9. This eliminates the ~50% timeout failure rate on branch triggers. Falls back to original behavior with 600s timeout if management API is unavailable.
- **test_invalid_sparse_inverted_index_algo**: Update expected error code from 999 to 1100 (`ErrParameterInvalid`) and add three new sparse index algorithms (`BLOCK_MAX_MAXSCORE`, `BLOCK_MAX_WAND`, `SINDI`) added in #49041 but never reflected in the test assertion. This test is L2 (nightly-only) and has been 100% failing since Apr 20.
- **common_type.py**: Sync `inverted_index_algo` list to match server-side `SparseInvertedIndexAlgos`.

issue: https://github.com/milvus-io/milvus/issues/49135

## Test plan

- [ ] `go test -tags dynamic,test -gcflags="all=-N -l" ./tests/go_client/testcases/... -run TestPartitionsNumExceedsMax` passes consistently
- [ ] CI go-sdk pipeline passes without flaky timeout
- [ ] Python test_invalid_sparse_inverted_index_algo assertion matches server response

Signed-off-by: Li Liu <li.liu@zilliz.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>