### PR TITLE
test: [cp3.0] fix CI flaky tests, stale sparse index assertion, and ngram multilingual

### DIFF
--- a/tests/go_client/testcases/helper/test_setup.go
+++ b/tests/go_client/testcases/helper/test_setup.go
@@ -1,8 +1,14 @@
 package helper
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 	"testing"
 	"time"
 
@@ -113,6 +119,56 @@ func teardown() {
 			_ = mc.DropDatabase(ctx, client.NewDropDatabaseOption(db))
 		}
 	}
+}
+
+// managementBaseURL returns the Milvus management API base URL (port 9091)
+// derived from the gRPC addr flag (e.g. http://host:19530 -> http://host:9091).
+func managementBaseURL() string {
+	u, err := url.Parse(*addr)
+	if err != nil {
+		return "http://localhost:9091"
+	}
+	host := u.Hostname()
+	if host == "" {
+		host = "localhost"
+	}
+	return fmt.Sprintf("http://%s:9091", host)
+}
+
+// AlterServerConfig changes a Milvus server config via the management HTTP API.
+// It returns the previous value so the caller can restore it.
+// If the management API is unreachable, it returns ("", error).
+func AlterServerConfig(key, value string) (string, error) {
+	// Get current value first
+	prev, _ := GetServerConfig(key)
+
+	body, _ := json.Marshal(map[string]string{"key": key, "value": value})
+	resp, err := http.Post(managementBaseURL()+"/management/config/alter",
+		"application/json", bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("management API unreachable: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("alter config failed (HTTP %d): %s", resp.StatusCode, string(respBody))
+	}
+	log.Info("AlterServerConfig", zap.String("key", key), zap.String("value", value), zap.String("prev", prev))
+	return prev, nil
+}
+
+// GetServerConfig reads a config value from the management API.
+func GetServerConfig(key string) (string, error) {
+	resp, err := http.Get(managementBaseURL() + "/management/config/get?key=" + url.QueryEscape(key))
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("get config failed (HTTP %d): %s", resp.StatusCode, string(respBody))
+	}
+	return string(respBody), nil
 }
 
 func RunTests(m *testing.M) int {

--- a/tests/go_client/testcases/partition_test.go
+++ b/tests/go_client/testcases/partition_test.go
@@ -1,6 +1,7 @@
 package testcases
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -110,17 +111,48 @@ func TestCreatePartitionInvalid(t *testing.T) {
 }
 
 func TestPartitionsNumExceedsMax(t *testing.T) {
-	// 1023 sequential CreatePartition calls serialize on a per-collection lock in rootcoord;
-	// keep this test serial so it isn't starved by other parallel tests' DDL load.
-	ctx := hp.CreateContext(t, time.Second*300)
-	mc := hp.CreateDefaultMilvusClient(ctx, t)
+	// Temporarily lower maxPartitionNum via management API so we only need a
+	// handful of CreatePartition calls instead of 1023, avoiding CI timeouts.
+	const testMaxPartitions = 10
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 
-	// create collection
+	prev, err := hp.AlterServerConfig("rootCoord.maxPartitionNum", fmt.Sprintf("%d", testMaxPartitions))
+	if err != nil {
+		// Management API unreachable — fall back to original approach with generous timeout.
+		t.Logf("management API unavailable (%v), falling back to full partition creation", err)
+		ctx = hp.CreateContext(t, time.Second*600)
+		testPartitionsNumExceedsMaxFull(t, ctx)
+		return
+	}
+	t.Cleanup(func() {
+		_, _ = hp.AlterServerConfig("rootCoord.maxPartitionNum", prev)
+	})
+
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
 	_, schema := hp.CollPrepare.CreateCollection(ctx, t, mc, hp.NewCreateCollectionParams(hp.Int64Vec), hp.TNewFieldsOption(), hp.TNewSchemaOption())
 
-	// create multi partitions
+	// create partitions up to the (lowered) limit; _default counts as 1
+	for i := 0; i < testMaxPartitions-1; i++ {
+		parName := fmt.Sprintf("par_%d", i)
+		err := mc.CreatePartition(ctx, client.NewCreatePartitionOption(schema.CollectionName, parName))
+		common.CheckErr(t, err, true)
+	}
+	pars, errList := mc.ListPartitions(ctx, client.NewListPartitionOption(schema.CollectionName))
+	common.CheckErr(t, errList, true)
+	require.Len(t, pars, testMaxPartitions)
+
+	// one more should fail
+	parName := common.GenRandomString("par", 4)
+	err = mc.CreatePartition(ctx, client.NewCreatePartitionOption(schema.CollectionName, parName))
+	common.CheckErr(t, err, false, fmt.Sprintf("exceeds max configuration (%d)", testMaxPartitions))
+}
+
+// testPartitionsNumExceedsMaxFull is the fallback when the management API is not available.
+func testPartitionsNumExceedsMaxFull(t *testing.T, ctx context.Context) {
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+	_, schema := hp.CollPrepare.CreateCollection(ctx, t, mc, hp.NewCreateCollectionParams(hp.Int64Vec), hp.TNewFieldsOption(), hp.TNewSchemaOption())
+
 	for i := 0; i < common.MaxPartitionNum-1; i++ {
-		// create par
 		parName := fmt.Sprintf("par_%d", i)
 		err := mc.CreatePartition(ctx, client.NewCreatePartitionOption(schema.CollectionName, parName))
 		common.CheckErr(t, err, true)
@@ -129,7 +161,6 @@ func TestPartitionsNumExceedsMax(t *testing.T) {
 	common.CheckErr(t, errList, true)
 	require.Len(t, pars, common.MaxPartitionNum)
 
-	// create partition exceed max
 	parName := common.GenRandomString("par", 4)
 	err := mc.CreatePartition(ctx, client.NewCreatePartitionOption(schema.CollectionName, parName))
 	common.CheckErr(t, err, false, fmt.Sprintf("exceeds max configuration (%d)", common.MaxPartitionNum))

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -36,7 +36,7 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401", "F403"]
 "conftest.py" = ["F401", "F811"]
-"**/testcases/**/*.py" = ["E402"]
+"**/testcases/**/*.py" = ["E402", "F403", "F405"]
 "**/chaos/**/*.py" = ["E402"]
 
 [tool.ruff.format]

--- a/tests/python_client/common/common_type.py
+++ b/tests/python_client/common/common_type.py
@@ -90,7 +90,7 @@ all_scalar_data_types = [
     DataType.DOUBLE,
     DataType.VARCHAR,
     DataType.ARRAY,
-    DataType.JSON, 
+    DataType.JSON,
     DataType.GEOMETRY,
     DataType.TIMESTAMPTZ
     ]

--- a/tests/python_client/common/common_type.py
+++ b/tests/python_client/common/common_type.py
@@ -301,7 +301,7 @@ all_index_types = ["FLAT", "IVF_FLAT", "IVF_SQ8", "IVF_PQ",
 all_dense_float_index_types = ["FLAT", "IVF_FLAT", "IVF_SQ8", "IVF_PQ",
                                "IVF_RABITQ", "HNSW", "SCANN", "DISKANN"]
 
-inverted_index_algo = ['TAAT_NAIVE', 'DAAT_WAND', 'DAAT_MAXSCORE']
+inverted_index_algo = ["TAAT_NAIVE", "DAAT_WAND", "DAAT_MAXSCORE", "BLOCK_MAX_MAXSCORE", "BLOCK_MAX_WAND", "SINDI"]
 
 int8_vector_index = ["HNSW"]
 

--- a/tests/python_client/testcases/indexes/test_ngram.py
+++ b/tests/python_client/testcases/indexes/test_ngram.py
@@ -1,19 +1,17 @@
-import logging
-import time
-from utils.util_pymilvus import *
-from common.common_type import CaseLabel, CheckTasks
-from common import common_type as ct
-from common import common_func as cf
-from base.client_v2_base import TestMilvusClientV2Base
 import pytest
+from base.client_v2_base import TestMilvusClientV2Base
+from common import common_func as cf
+from common import common_type as ct
+from common.common_type import CaseLabel, CheckTasks
 from idx_ngram import NGRAM
+from pymilvus import DataType
 
 index_type = "NGRAM"
 success = "success"
-pk_field_name = 'id'
-vector_field_name = 'vector'
-content_field_name = 'content_ngram'
-json_field_name = 'json_field'
+pk_field_name = "id"
+vector_field_name = "vector"
+content_field_name = "content_ngram"
+json_field_name = "json_field"
 dim = 32
 default_nb = ct.default_nb
 default_build_params = {"min_gram": 2, "max_gram": 3}
@@ -35,8 +33,7 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
 
         # Check if this test case requires JSON field
         build_params = params.get("params", None)
-        has_json_params = (build_params is not None and
-                           ("json_path" in build_params or "json_cast_type" in build_params))
+        has_json_params = build_params is not None and ("json_path" in build_params or "json_cast_type" in build_params)
 
         target_field_name = content_field_name  # Default to VARCHAR field
 
@@ -61,7 +58,7 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
                 row[json_field_name] = {
                     "body": f"This is a {keyword} building",
                     "title": f"Location {i}",
-                    "description": f"Description for {keyword} number {i}"
+                    "description": f"Description for {keyword} number {i}",
                 }
         else:
             # Generate VARCHAR test data with varied content
@@ -74,34 +71,34 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
         # Insert data in batches for better performance
         batch_size = 1000
         for i in range(0, nb, batch_size):
-            batch_rows = rows[i:i + batch_size]
+            batch_rows = rows[i : i + batch_size]
             self.insert(client, collection_name, batch_rows)
         self.flush(client, collection_name)
 
         # Create index
         index_params = self.prepare_index_params(client)[0]
         index_name = cf.gen_str_by_length(10, letters_only=True)
-        index_params.add_index(field_name=target_field_name,
-                               index_name=index_name,
-                               index_type=index_type,
-                               params=build_params)
+        index_params.add_index(
+            field_name=target_field_name, index_name=index_name, index_type=index_type, params=build_params
+        )
 
         # Build index
         if params.get("expected", None) != success:
-            self.create_index(client, collection_name, index_params,
-                              check_task=CheckTasks.err_res,
-                              check_items=params.get("expected"))
+            self.create_index(
+                client, collection_name, index_params, check_task=CheckTasks.err_res, check_items=params.get("expected")
+            )
         else:
             self.create_index(client, collection_name, index_params)
             self.wait_for_index_ready(client, collection_name, index_name=index_name)
 
             # Create vector index before loading collection
             vector_index_params = self.prepare_index_params(client)[0]
-            vector_index_params.add_index(field_name=vector_field_name,
-                                          metric_type=cf.get_default_metric_for_vector_type(
-                                              vector_type=DataType.FLOAT_VECTOR),
-                                          index_type="IVF_FLAT",
-                                          params={"nlist": 128})
+            vector_index_params.add_index(
+                field_name=vector_field_name,
+                metric_type=cf.get_default_metric_for_vector_type(vector_type=DataType.FLOAT_VECTOR),
+                index_type="IVF_FLAT",
+                params={"nlist": 128},
+            )
             self.create_index(client, collection_name, vector_index_params)
             self.wait_for_index_ready(client, collection_name, index_name=vector_field_name)
 
@@ -118,11 +115,14 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
             # Each keyword appears 2000/8 = 250 times
             expected_count = default_nb // 8  # 250 matches for "stadium"
 
-            self.query(client, collection_name, filter=filter_expr,
-                       output_fields=["count(*)"],
-                       check_task=CheckTasks.check_query_results,
-                       check_items={"enable_milvus_client_api": True,
-                                    "count(*)": expected_count})
+            self.query(
+                client,
+                collection_name,
+                filter=filter_expr,
+                output_fields=["count(*)"],
+                check_task=CheckTasks.check_query_results,
+                check_items={"enable_milvus_client_api": True, "count(*)": expected_count},
+            )
 
             # Verify the index params are persisted
             idx_info = client.describe_index(collection_name, index_name)
@@ -148,8 +148,13 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
         if scalar_field_type == DataType.VARCHAR:
             schema.add_field("scalar_field", datatype=scalar_field_type, max_length=1000, nullable=True)
         elif scalar_field_type == DataType.ARRAY:
-            schema.add_field("scalar_field", datatype=scalar_field_type,
-                             element_type=DataType.VARCHAR, max_capacity=10, max_length=100)
+            schema.add_field(
+                "scalar_field",
+                datatype=scalar_field_type,
+                element_type=DataType.VARCHAR,
+                max_capacity=10,
+                max_length=100,
+            )
         else:
             schema.add_field("scalar_field", datatype=scalar_field_type)
 
@@ -176,7 +181,7 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
                 row["scalar_field"] = {
                     "body": f"This is a {keyword}",
                     "title": f"Location {i}",
-                    "category": f"Category {keyword_idx}"
+                    "category": f"Category {keyword_idx}",
                 }
         elif scalar_field_type == DataType.ARRAY:
             # Generate varied ARRAY data for better testing
@@ -191,7 +196,7 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
         # Insert data in batches for better performance
         batch_size = 1000
         for i in range(0, nb, batch_size):
-            batch_rows = rows[i:i + batch_size]
+            batch_rows = rows[i : i + batch_size]
             self.insert(client, collection_name, batch_rows)
         self.flush(client, collection_name)
 
@@ -200,38 +205,38 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
         index_params = self.prepare_index_params(client)[0]
         if scalar_field_type == DataType.JSON:
             # JSON field requires json_path and json_cast_type
-            index_params.add_index(field_name="scalar_field",
-                                   index_name=index_name,
-                                   index_type=index_type,
-                                   params={
-                                       "min_gram": 2,
-                                       "max_gram": 3,
-                                       "json_path": "scalar_field['body']",
-                                       "json_cast_type": "varchar"
-                                   })
+            index_params.add_index(
+                field_name="scalar_field",
+                index_name=index_name,
+                index_type=index_type,
+                params={"min_gram": 2, "max_gram": 3, "json_path": "scalar_field['body']", "json_cast_type": "varchar"},
+            )
         else:
-            index_params.add_index(field_name="scalar_field",
-                                   index_name=index_name,
-                                   index_type=index_type,
-                                   params=default_build_params)
+            index_params.add_index(
+                field_name="scalar_field", index_name=index_name, index_type=index_type, params=default_build_params
+            )
 
         # Check if the field type is supported for NGRAM index
         if scalar_field_type not in NGRAM.supported_field_types:
-            self.create_index(client, collection_name, index_params,
-                              check_task=CheckTasks.err_res,
-                              check_items={"err_code": 999,
-                                           "err_msg": "ngram index can only be created on VARCHAR or JSON field"})
+            self.create_index(
+                client,
+                collection_name,
+                index_params,
+                check_task=CheckTasks.err_res,
+                check_items={"err_code": 999, "err_msg": "ngram index can only be created on VARCHAR or JSON field"},
+            )
         else:
             self.create_index(client, collection_name, index_params)
             self.wait_for_index_ready(client, collection_name, index_name=index_name)
 
             # Create vector index before loading collection
             vector_index_params = self.prepare_index_params(client)[0]
-            vector_index_params.add_index(field_name=vector_field_name,
-                                          metric_type=cf.get_default_metric_for_vector_type(
-                                              vector_type=DataType.FLOAT_VECTOR),
-                                          index_type="IVF_FLAT",
-                                          params={"nlist": 128})
+            vector_index_params.add_index(
+                field_name=vector_field_name,
+                metric_type=cf.get_default_metric_for_vector_type(vector_type=DataType.FLOAT_VECTOR),
+                index_type="IVF_FLAT",
+                params={"nlist": 128},
+            )
             self.create_index(client, collection_name, vector_index_params)
             self.wait_for_index_ready(client, collection_name, index_name=vector_field_name)
 
@@ -243,21 +248,27 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
                 # Each keyword appears 2000/8 = 250 times
                 expected_count = default_nb // 8  # 250 matches for "stadium"
                 filter_expr = 'scalar_field LIKE "%stadium%"'
-                self.query(client, collection_name, filter=filter_expr,
-                           output_fields=["count(*)"],
-                           check_task=CheckTasks.check_query_results,
-                           check_items={"enable_milvus_client_api": True,
-                                        "count(*)": expected_count})
+                self.query(
+                    client,
+                    collection_name,
+                    filter=filter_expr,
+                    output_fields=["count(*)"],
+                    check_task=CheckTasks.check_query_results,
+                    check_items={"enable_milvus_client_api": True, "count(*)": expected_count},
+                )
             elif scalar_field_type == DataType.JSON:
                 # Calculate expected count: 2000 data points with 8 keywords cycling
                 # Each keyword appears 2000/8 = 250 times
                 expected_count = default_nb // 8  # 250 matches for "school"
                 filter_expr = "scalar_field['body'] LIKE \"%school%\""
-                self.query(client, collection_name, filter=filter_expr,
-                           output_fields=["count(*)"],
-                           check_task=CheckTasks.check_query_results,
-                           check_items={"enable_milvus_client_api": True,
-                                        "count(*)": expected_count})
+                self.query(
+                    client,
+                    collection_name,
+                    filter=filter_expr,
+                    output_fields=["count(*)"],
+                    check_task=CheckTasks.check_query_results,
+                    check_items={"enable_milvus_client_api": True, "count(*)": expected_count},
+                )
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.skip(reason="skip for issue #44164")
@@ -283,40 +294,51 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
 
         # Create index
         index_params = self.prepare_index_params(client)[0]
-        index_params.add_index(field_name="content_ngram",
-                               index_name="content_ngram",
-                               index_type=index_type,
-                               params={"min_gram": 2, "max_gram": 3})
-        index_params.add_index(field_name=vector_field_name,
-                               index_type="IVF_FLAT",
-                               metric_type="COSINE",
-                               params={"nlist": 128})
+        index_params.add_index(
+            field_name="content_ngram",
+            index_name="content_ngram",
+            index_type=index_type,
+            params={"min_gram": 2, "max_gram": 3},
+        )
+        index_params.add_index(
+            field_name=vector_field_name, index_type="IVF_FLAT", metric_type="COSINE", params={"nlist": 128}
+        )
         self.create_index(client, collection_name, index_params)
         self.wait_for_index_ready(client, collection_name, index_name="content_ngram")
         self.wait_for_index_ready(client, collection_name, index_name=vector_field_name)
         self.load_collection(client, collection_name)
         # Query to check if the index is created
-        res = self.query(client, collection_name, filter="content_ngram LIKE 'stad_%'",
-                         output_fields=["id", "content_ngram"])[0]
+        res = self.query(
+            client, collection_name, filter="content_ngram LIKE 'stad_%'", output_fields=["id", "content_ngram"]
+        )[0]
         assert len(res) == default_nb // len(content_keywords)
 
         # Release collection before alter ngram index
         self.release_collection(client, collection_name)
         # Alter index mmap properties
-        self.alter_index_properties(client, collection_name, index_name="content_ngram", properties={"mmap.enabled": True})
+        self.alter_index_properties(
+            client, collection_name, index_name="content_ngram", properties={"mmap.enabled": True}
+        )
         res = self.describe_index(client, collection_name, index_name="content_ngram")[0]
-        assert res.get('mmap.enabled', None) == 'True'
+        assert res.get("mmap.enabled", None) == "True"
         # Load the collection and query again
         self.load_collection(client, collection_name)
-        res = self.query(client, collection_name, filter="content_ngram LIKE 'stad_%'",
-                         output_fields=["id", "content_ngram"])[0]
+        res = self.query(
+            client, collection_name, filter="content_ngram LIKE 'stad_%'", output_fields=["id", "content_ngram"]
+        )[0]
         assert len(res) == default_nb // len(content_keywords)
 
         # Alter index gram value properties is not supported
         self.release_collection(client, collection_name)
         error = {ct.err_code: 1, ct.err_msg: "invalid mmap.enabled value: True, expected: true, false"}
-        self.alter_index_properties(client, collection_name, index_name="content_ngram", properties={"min_gram": 3, "max_gram": 4},
-                                    check_task=CheckTasks.err_res, check_items=error)
+        self.alter_index_properties(
+            client,
+            collection_name,
+            index_name="content_ngram",
+            properties={"min_gram": 3, "max_gram": 4},
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_ngram_search_with_diff_length_of_filter_value(self):
@@ -346,105 +368,88 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
 
         # Create vector index before loading collection
         index_params = self.prepare_index_params(client)[0]
-        index_params.add_index(field_name=vector_field_name,
-                               metric_type="COSINE",
-                               index_type="IVF_FLAT",
-                               params={"nlist": 128})
+        index_params.add_index(
+            field_name=vector_field_name, metric_type="COSINE", index_type="IVF_FLAT", params={"nlist": 128}
+        )
         min_gram = 2
         max_gram = 4
-        index_params.add_index(field_name="content_ngram",
-                               index_type=index_type,
-                               params={"min_gram": min_gram, "max_gram": max_gram})
+        index_params.add_index(
+            field_name="content_ngram", index_type=index_type, params={"min_gram": min_gram, "max_gram": max_gram}
+        )
         self.create_index(client, collection_name, index_params)
         self.wait_for_index_ready(client, collection_name, index_name=vector_field_name)
         self.wait_for_index_ready(client, collection_name, index_name="content_ngram")
         self.load_collection(client, collection_name)
 
         # Test query 0: filter value length is less than min_gram
-        filter_expr = f'content_ngram LIKE "{content_keywords[0][:min_gram - 1]}%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
+        filter_expr = f'content_ngram LIKE "{content_keywords[0][: min_gram - 1]}%"'
+        res_ngram = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_ngram) >= insert_times * default_nb // len(content_keywords)
-        filter_expr = f'content_no_index LIKE "{content_keywords[0][:min_gram - 1]}%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
+        filter_expr = f'content_no_index LIKE "{content_keywords[0][: min_gram - 1]}%"'
+        res_no_index = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_no_index) >= insert_times * default_nb // len(content_keywords)
         assert res_ngram == res_no_index
 
         # Test query 1: filter value length is equal to min_gram
         filter_expr = f'content_ngram LIKE "{content_keywords[0][:min_gram]}%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
+        res_ngram = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_ngram) >= insert_times * default_nb // len(content_keywords)
         filter_expr = f'content_no_index LIKE "{content_keywords[0][:min_gram]}%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
+        res_no_index = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_no_index) >= insert_times * default_nb // len(content_keywords)
         assert res_ngram == res_no_index
 
         # Test query 2: filter value length is less than max_gram
-        filter_expr = f'content_ngram LIKE "{content_keywords[0][:max_gram - 1]}%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
+        filter_expr = f'content_ngram LIKE "{content_keywords[0][: max_gram - 1]}%"'
+        res_ngram = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_ngram) >= insert_times * default_nb // len(content_keywords)
-        filter_expr = f'content_no_index LIKE "{content_keywords[0][:max_gram - 1]}%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
+        filter_expr = f'content_no_index LIKE "{content_keywords[0][: max_gram - 1]}%"'
+        res_no_index = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_no_index) >= insert_times * default_nb // len(content_keywords)
         assert res_ngram == res_no_index
 
         # Test query 3: filter value length is equal to max_gram
         filter_expr = f'content_ngram LIKE "{content_keywords[0][:max_gram]}%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
+        res_ngram = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_ngram) >= insert_times * default_nb // len(content_keywords)
         filter_expr = f'content_no_index LIKE "{content_keywords[0][:max_gram]}%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
+        res_no_index = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_no_index) >= insert_times * default_nb // len(content_keywords)
         assert res_ngram == res_no_index
 
         # Test query 4: filter value length is greater than max_gram
-        filter_expr = f'content_ngram LIKE "{content_keywords[0][:max_gram + 1]}%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
+        filter_expr = f'content_ngram LIKE "{content_keywords[0][: max_gram + 1]}%"'
+        res_ngram = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_ngram) >= insert_times * default_nb // len(content_keywords)
-        filter_expr = f'content_no_index LIKE "{content_keywords[0][:max_gram + 1]}%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
+        filter_expr = f'content_no_index LIKE "{content_keywords[0][: max_gram + 1]}%"'
+        res_no_index = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_no_index) >= insert_times * default_nb // len(content_keywords)
         assert res_ngram == res_no_index
 
         # Test query with suffix match
         filter_expr = f'content_ngram LIKE "%{content_keywords[0][4:]}"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
+        res_ngram = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_ngram) >= insert_times * default_nb // len(content_keywords)
         filter_expr = f'content_no_index LIKE "%{content_keywords[0][4:]}"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
+        res_no_index = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_no_index) >= insert_times * default_nb // len(content_keywords)
         assert res_ngram == res_no_index
 
         # Test query with infix match
         filter_expr = f'content_ngram LIKE "%{content_keywords[0][2:4]}%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
+        res_ngram = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_ngram) >= insert_times * default_nb // len(content_keywords)
         filter_expr = f'content_no_index LIKE "%{content_keywords[0][2:4]}%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
+        res_no_index = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_no_index) >= insert_times * default_nb // len(content_keywords)
         assert res_ngram == res_no_index
 
         # Test query with Mixed Wildcard Match
-        filter_expr = f'content_ngram LIKE "%st_d_um%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
+        filter_expr = 'content_ngram LIKE "%st_d_um%"'
+        res_ngram = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_ngram) >= insert_times * default_nb // len(content_keywords)
-        filter_expr = f'content_no_index LIKE "%st_d_um%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
+        filter_expr = 'content_no_index LIKE "%st_d_um%"'
+        res_no_index = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_no_index) >= insert_times * default_nb // len(content_keywords)
         assert res_ngram == res_no_index
 
@@ -465,27 +470,26 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
 
         # Multilingual test data with various UTF-8 characters
         multilingual_keywords = [
-            "北京大学",           # Chinese
-            "東京大学",           # Japanese  
-            "Московский",        # Russian
-            "café",              # French with accent
-            "naïve",             # French with diaeresis
-            "München",           # German with umlaut
-            "🏫学校🎓",           # Chinese with emojis
-            "🌟star⭐",          # English with emojis
-            "مدرسة",             # Arabic
-            "Γειά",              # Greek
-            "प्रविष्टि",           # Hindi/Devanagari
-            "한국어",             # Korean
-            "español",           # Spanish
-            "português",         # Portuguese
-            "中英mix英文",        # Mixed Chinese-English
-            "café☕北京🏙️"        # Mixed with emojis and multiple languages
+            "北京大学",  # Chinese
+            "東京大学",  # Japanese
+            "Московский",  # Russian
+            "café",  # French with accent
+            "naïve",  # French with diaeresis
+            "München",  # German with umlaut
+            "🏫学校🎓",  # Chinese with emojis
+            "🌟star⭐",  # English with emojis
+            "مدرسة",  # Arabic
+            "Γειά",  # Greek
+            "प्रविष्टि",  # Hindi/Devanagari
+            "한국어",  # Korean
+            "español",  # Spanish
+            "português",  # Portuguese
+            "中英mix英文",  # Mixed Chinese-English
+            "café☕北京🏙️",  # Mixed with emojis and multiple languages
         ]
 
         # Insert test data
         insert_times = 2
-        total_records = insert_times * default_nb
         for i in range(insert_times):
             rows = cf.gen_row_data_by_schema(nb=default_nb, schema=schema, start=i * default_nb)
             for j, row in enumerate(rows):
@@ -494,200 +498,68 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
                 row["content_no_index"] = {
                     "body": f"This is a {keyword} building",
                     "title": f"Location {i}",
-                    "description": f"Description for {keyword} number {i}"
+                    "description": f"Description for {keyword} number {i}",
                 }
                 row["content_ngram"] = {
                     "body": f"This is a {keyword} building",
                     "title": f"Location {i}",
-                    "description": f"Description for {keyword} number {i}"
+                    "description": f"Description for {keyword} number {i}",
                 }
             self.insert(client, collection_name, rows)
         self.flush(client, collection_name)
 
         # Create vector index before loading collection
         index_params = self.prepare_index_params(client)[0]
-        index_params.add_index(field_name=vector_field_name,
-                               metric_type="COSINE",
-                               index_type="IVF_FLAT",
-                               params={"nlist": 128})
-        
+        index_params.add_index(
+            field_name=vector_field_name, metric_type="COSINE", index_type="IVF_FLAT", params={"nlist": 128}
+        )
+
         # Create NGRAM index with appropriate parameters for multilingual content
         min_gram = 1  # Use 1 for better multilingual support
         max_gram = 3
-        index_params.add_index(field_name="content_ngram",
-                               index_name="content_ngram",
-                               index_type=index_type,
-                               params={"min_gram": min_gram, "max_gram": max_gram, 
-                                       "json_path": "content_ngram['body']", "json_cast_type": "varchar"})
+        index_params.add_index(
+            field_name="content_ngram",
+            index_name="content_ngram",
+            index_type=index_type,
+            params={
+                "min_gram": min_gram,
+                "max_gram": max_gram,
+                "json_path": "content_ngram['body']",
+                "json_cast_type": "varchar",
+            },
+        )
         self.create_index(client, collection_name, index_params)
         self.wait_for_index_ready(client, collection_name, index_name=vector_field_name)
         self.wait_for_index_ready(client, collection_name, index_name="content_ngram")
         self.load_collection(client, collection_name)
 
-        expected_count_per_keyword = total_records // len(multilingual_keywords)
+        test_keywords = [
+            "北京",  # Chinese
+            "東京",  # Japanese
+            "Моск",  # Russian Cyrillic
+            "café",  # French accent
+            "🏫",  # Emoji
+            "⭐",  # Star emoji
+            "مدرسة",  # Arabic
+            "한국",  # Korean
+            "München",  # German umlaut
+            "mix",  # Mixed language
+            "café☕",  # Complex multilingual with emoji prefix
+            "प्रविष्टि",  # Hindi/Devanagari
+            "Γειά",  # Greek
+            "português",  # Portuguese with tilde
+            "学",  # Single CJK character
+        ]
 
-        # Test 1: Chinese character search
-        chinese_keyword = "北京"
-        filter_expr = f'content_ngram["body"] LIKE "%{chinese_keyword}%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
-        filter_expr = f'content_no_index["body"] LIKE "%{chinese_keyword}%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
-        assert len(res_ngram) >= expected_count_per_keyword
-        assert res_ngram == res_no_index
+        for keyword in test_keywords:
+            filter_expr = f'content_ngram["body"] LIKE "%{keyword}%"'
+            res_ngram = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[
+                0
+            ]
+            filter_expr = f'content_no_index["body"] LIKE "%{keyword}%"'
+            res_no_index = self.query(
+                client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"]
+            )[0]
 
-        # Test 2: Japanese character search
-        japanese_keyword = "東京"
-        filter_expr = f'content_ngram["body"] LIKE "%{japanese_keyword}%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
-        filter_expr = f'content_no_index["body"] LIKE "%{japanese_keyword}%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
-        assert len(res_ngram) >= expected_count_per_keyword
-        assert res_ngram == res_no_index
-
-        # Test 3: Russian Cyrillic character search
-        russian_keyword = "Моск"
-        filter_expr = f'content_ngram["body"] LIKE "%{russian_keyword}%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
-        filter_expr = f'content_no_index["body"] LIKE "%{russian_keyword}%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
-        assert len(res_ngram) >= expected_count_per_keyword
-        assert res_ngram == res_no_index
-
-        # Test 4: French accent character search
-        french_keyword = "café"
-        filter_expr = f'content_ngram["body"] LIKE "%{french_keyword}%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
-        filter_expr = f'content_no_index["body"] LIKE "%{french_keyword}%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
-        assert len(res_ngram) >= expected_count_per_keyword
-        assert res_ngram == res_no_index
-
-        # Test 5: Emoji character search
-        emoji_keyword = "🏫"
-        filter_expr = f'content_ngram["body"] LIKE "%{emoji_keyword}%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
-        filter_expr = f'content_no_index["body"] LIKE "%{emoji_keyword}%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
-        assert len(res_ngram) >= expected_count_per_keyword
-        assert res_ngram == res_no_index
-
-        # Test 6: Star emoji search
-        star_keyword = "⭐"
-        filter_expr = f'content_ngram["body"] LIKE "%{star_keyword}%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
-        filter_expr = f'content_no_index["body"] LIKE "%{star_keyword}%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
-        assert len(res_ngram) >= expected_count_per_keyword
-        assert res_ngram == res_no_index
-
-        # Test 7: Arabic character search
-        arabic_keyword = "مدرسة"
-        filter_expr = f'content_ngram["body"] LIKE "%{arabic_keyword}%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
-        filter_expr = f'content_no_index["body"] LIKE "%{arabic_keyword}%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
-        assert len(res_ngram) >= expected_count_per_keyword
-        assert res_ngram == res_no_index
-
-        # Test 8: Korean character search
-        korean_keyword = "한국"
-        filter_expr = f'content_ngram["body"] LIKE "%{korean_keyword}%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
-        filter_expr = f'content_no_index["body"] LIKE "%{korean_keyword}%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
-        assert len(res_ngram) >= expected_count_per_keyword
-        assert res_ngram == res_no_index
-
-        # Test 9: German umlaut character search
-        german_keyword = "München"
-        filter_expr = f'content_ngram["body"] LIKE "%{german_keyword}%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
-        filter_expr = f'content_no_index["body"] LIKE "%{german_keyword}%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
-        assert len(res_ngram) >= expected_count_per_keyword
-        assert res_ngram == res_no_index
-
-        # Test 10: Mixed language search
-        mixed_keyword = "mix"
-        filter_expr = f'content_ngram["body"] LIKE "%{mixed_keyword}%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
-        filter_expr = f'content_no_index["body"] LIKE "%{mixed_keyword}%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
-        assert len(res_ngram) >= expected_count_per_keyword
-        assert res_ngram == res_no_index
-
-        # Test 11: Complex multilingual with emojis prefix search
-        complex_keyword = "café☕"
-        filter_expr = f'content_ngram["body"] LIKE "%{complex_keyword}%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
-        filter_expr = f'content_no_index["body"] LIKE "%{complex_keyword}%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
-        assert len(res_ngram) >= expected_count_per_keyword
-        assert res_ngram == res_no_index
-
-        # Test 12: Hindi/Devanagari character search
-        hindi_keyword = "प्रविष्टि"
-        filter_expr = f'content_ngram["body"] LIKE "%{hindi_keyword}%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
-        filter_expr = f'content_no_index["body"] LIKE "%{hindi_keyword}%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
-        assert len(res_ngram) >= expected_count_per_keyword
-        assert res_ngram == res_no_index
-
-        # Test 13: Greek character search
-        greek_keyword = "Γειά"
-        filter_expr = f'content_ngram["body"] LIKE "%{greek_keyword}%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
-        filter_expr = f'content_no_index["body"] LIKE "%{greek_keyword}%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
-        assert len(res_ngram) >= expected_count_per_keyword
-        assert res_ngram == res_no_index
-
-        # Test 14: Portuguese with tilde character search
-        portuguese_keyword = "português"
-        filter_expr = f'content_ngram["body"] LIKE "%{portuguese_keyword}%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
-        filter_expr = f'content_no_index["body"] LIKE "%{portuguese_keyword}%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
-        assert len(res_ngram) >= expected_count_per_keyword
-        assert res_ngram == res_no_index
-
-        # Test 15: Test single character search (especially important for CJK)
-        single_char_keyword = "学"
-        filter_expr = f'content_ngram["body"] LIKE "%{single_char_keyword}%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
-        filter_expr = f'content_no_index["body"] LIKE "%{single_char_keyword}%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
-        # Should match both "北京大学" and "🏫学校🎓"
-        assert len(res_ngram) >= expected_count_per_keyword * 2
-        assert res_ngram == res_no_index
+            assert len(res_ngram) > 0
+            assert sorted(res_ngram, key=lambda item: item["id"]) == sorted(res_no_index, key=lambda item: item["id"])

--- a/tests/python_client/testcases/test_index.py
+++ b/tests/python_client/testcases/test_index.py
@@ -1,27 +1,28 @@
-import random
-from time import sleep
-
-import numpy as np
-import pytest
 import copy
+import random
 
+import pytest
 from base.client_base import TestcaseBase
 from base.index_wrapper import ApiIndexWrapper
-from base.collection_wrapper import ApiCollectionWrapper
-from utils.util_log import test_log as log
 from common import common_func as cf
 from common import common_type as ct
-from common.common_type import CaseLabel, CheckTasks
 from common.code_mapping import CollectionErrorMessage as clem
 from common.code_mapping import IndexErrorMessage as iem
 from common.common_params import (
-    IndexName, FieldParams, IndexPrams, DefaultVectorIndexParams, DefaultScalarIndexParams, MetricType, AlterIndexParams
+    AlterIndexParams,
+    DefaultScalarIndexParams,
+    DefaultVectorIndexParams,
+    FieldParams,
+    IndexName,
+    IndexPrams,
+    MetricType,
 )
-
-from utils.util_pymilvus import *
+from common.common_type import CaseLabel, CheckTasks
 from common.constants import *
-from pymilvus.exceptions import MilvusException
 from pymilvus import DataType
+from pymilvus.exceptions import MilvusException
+from utils.util_log import test_log as log
+from utils.util_pymilvus import *
 
 prefix = "index"
 default_schema = cf.gen_default_collection_schema()
@@ -178,7 +179,6 @@ class TestIndexParams(TestcaseBase):
         expected: raise exception
         """
         c_name = cf.gen_unique_str(prefix)
-        index_name = get_invalid_index_name
         collection_w = self.init_collection_wrap(name=c_name)
         self.index_wrap.init_index(collection_w.collection, default_field_name, default_index_params,
                                    index_name=get_invalid_index_name,
@@ -1198,7 +1198,7 @@ class TestIndexInvalid(TestcaseBase):
         collection_w.create_index(ct.default_float_vec_field_name, index_params=scalar_index_params,
                                   check_task=CheckTasks.err_res,
                                   check_items={ct.err_code: 1100,
-                                               ct.err_msg: f"invalid index params"})
+                                               ct.err_msg: "invalid index params"})
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_create_scalar_index_on_binary_vector_field(self, scalar_index):
@@ -1294,7 +1294,7 @@ class TestIndexInvalid(TestcaseBase):
         collection_w.alter_index("random_index_345", {'mmap.enabled': True},
                                  check_task=CheckTasks.err_res,
                                  check_items={ct.err_code: 65535,
-                                              ct.err_msg: f"index not found"})
+                                              ct.err_msg: "index not found"})
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_load_mmap_index(self):
@@ -1314,7 +1314,7 @@ class TestIndexInvalid(TestcaseBase):
         collection_w.alter_index(binary_field_name, {'mmap.enabled': True},
                                  check_task=CheckTasks.err_res,
                                  check_items={ct.err_code: 104,
-                                              ct.err_msg: f"can't alter index on loaded collection"})
+                                              ct.err_msg: "can't alter index on loaded collection"})
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_turning_on_mmap_for_scalar_index(self):
@@ -1353,7 +1353,7 @@ class TestIndexInvalid(TestcaseBase):
         collection_w.alter_index(ct.default_index_name, {'mmap.enabled': "error_value"},
                                  check_task=CheckTasks.err_res,
                                  check_items={ct.err_code: 65535,
-                                              ct.err_msg: f"invalid mmap.enabled value"})
+                                              ct.err_msg: "invalid mmap.enabled value"})
         collection_w.alter_index(ct.default_index_name, {"error_param_key": 123},
                                  check_task=CheckTasks.err_res,
                                  check_items={ct.err_code: 1100,
@@ -1361,7 +1361,7 @@ class TestIndexInvalid(TestcaseBase):
         collection_w.alter_index(ct.default_index_name, ["error_param_type"],
                                  check_task=CheckTasks.err_res,
                                  check_items={ct.err_code: 1,
-                                              ct.err_msg: f"Unexpected error"})
+                                              ct.err_msg: "Unexpected error"})
         collection_w.alter_index(ct.default_index_name, None,
                                  check_task=CheckTasks.err_res,
                                  check_items={ct.err_code: 1,
@@ -1369,7 +1369,7 @@ class TestIndexInvalid(TestcaseBase):
         collection_w.alter_index(ct.default_index_name, 1000,
                                  check_task=CheckTasks.err_res,
                                  check_items={ct.err_code: 1,
-                                              ct.err_msg: f"<'int' object has no attribute 'items'"})
+                                              ct.err_msg: "<'int' object has no attribute 'items'"})
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("metric_type", ["L2", "COSINE", "   ", "invalid"])
@@ -1650,9 +1650,9 @@ class TestIndexString(TestcaseBase):
         data = cf.gen_default_list_data()
         collection_w.insert(data=data)
         collection_w.create_index(default_float_vec_field_name, default_index_params, index_name=index_name1)
-        assert collection_w.has_index(index_name=index_name1)[0] == True
+        assert collection_w.has_index(index_name=index_name1)[0]
         collection_w.create_index(default_string_field_name, default_string_index_params, index_name=index_name2)
-        assert collection_w.has_index(index_name=index_name2)[0] == True
+        assert collection_w.has_index(index_name=index_name2)[0]
         assert len(collection_w.indexes) == 2
 
     @pytest.mark.tags(CaseLabel.L1)
@@ -1669,9 +1669,9 @@ class TestIndexString(TestcaseBase):
         df, _ = cf.gen_default_binary_dataframe_data()
         collection_w.insert(data=df)
         collection_w.create_index(default_string_field_name, default_string_index_params, index_name=index_name2)
-        assert collection_w.has_index(index_name=index_name2)[0] == True
+        assert collection_w.has_index(index_name=index_name2)[0]
         collection_w.create_index(default_binary_vec_field_name, default_binary_index_params, index_name=index_name3)
-        assert collection_w.has_index(index_name=index_name3)[0] == True
+        assert collection_w.has_index(index_name=index_name3)[0]
         assert len(collection_w.indexes) == 2
 
     @pytest.mark.tags(CaseLabel.L1)
@@ -1725,7 +1725,7 @@ class TestIndexString(TestcaseBase):
         collection_w.insert(data=data)
 
         collection_w.create_index(default_string_field_name, default_string_index_params, index_name=index_name2)
-        assert collection_w.has_index(index_name=index_name2)[0] == True
+        assert collection_w.has_index(index_name=index_name2)[0]
         collection_w.drop_index(index_name=index_name2)
         assert len(collection_w.indexes) == 0
 
@@ -1918,12 +1918,12 @@ class TestIndexDiskann(TestcaseBase):
         collection_w.insert(data=data)
         assert collection_w.num_entities == default_nb
         collection_w.create_index(default_float_vec_field_name, ct.default_diskann_index, index_name="a")
-        assert collection_w.has_index(index_name="a")[0] == True
+        assert collection_w.has_index(index_name="a")[0]
         collection_w.create_index(default_string_field_name, default_string_index_params, index_name="b")
-        assert collection_w.has_index(index_name="b")[0] == True
+        assert collection_w.has_index(index_name="b")[0]
         default_params = {}
         collection_w.create_index("float", default_params, index_name="c")
-        assert collection_w.has_index(index_name="c")[0] == True
+        assert collection_w.has_index(index_name="c")[0]
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_drop_diskann_index_with_partition(self):
@@ -2010,7 +2010,7 @@ class TestIndexDiskann(TestcaseBase):
         collection_w.alter_index(ct.default_index_name, {'mmap.enabled': True},
                                  check_task=CheckTasks.err_res,
                                  check_items={ct.err_code: 104,
-                                              ct.err_msg: f"index type DISKANN does not support mmap"})
+                                              ct.err_msg: "index type DISKANN does not support mmap"})
 
 
 @pytest.mark.tags(CaseLabel.GPU)
@@ -2181,7 +2181,7 @@ class TestInvertedIndexValid(TestcaseBase):
         index_list = self.utility_wrap.list_indexes(collection_w.name)[0]
         assert index_name in index_list
         collection_w.flush()
-        result = self.utility_wrap.index_building_progress(collection_w.name, index_name)[0]
+        self.utility_wrap.index_building_progress(collection_w.name, index_name)[0]
         # assert False
         start = time.time()
         while True:
@@ -2190,7 +2190,7 @@ class TestInvertedIndexValid(TestcaseBase):
             if 0 < res['indexed_rows'] <= default_nb:
                 break
             if time.time() - start > 5:
-                raise MilvusException(1, f"Index build completed in more than 5s")
+                raise MilvusException(1, "Index build completed in more than 5s")
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_create_multiple_inverted_index(self):
@@ -2246,7 +2246,6 @@ class TestInvertedIndexValid(TestcaseBase):
     @pytest.mark.tags(CaseLabel.L0)
     def test_binary_arith_expr_on_inverted_index(self):
         prefix = "test_binary_arith_expr_on_inverted_index"
-        nb = 5000
         collection_w, _, _, insert_ids, _ = self.init_collection_general(prefix, insert_data=True, is_index=True,
                                                                          is_all_data_type=True)
         index_name = "test_binary_arith_expr_on_inverted_index"
@@ -2367,7 +2366,7 @@ class TestBitmapIndex(TestcaseBase):
             3. can drop index on loaded collection
         """
         # init params
-        collection_name, nb = f"{request.function.__name__}_{primary_field}_{auto_id}", 3000
+        collection_name, _nb = f"{request.function.__name__}_{primary_field}_{auto_id}", 3000
 
         # create a collection with fields that can build `BITMAP` index
         self.collection_wrap.init_collection(
@@ -2865,7 +2864,7 @@ class TestBitmapIndex(TestcaseBase):
             1. alter index failed with param `bitmap_cardinality_limit`
         """
         # init params
-        collection_name, primary_field, nb = f"{request.function.__name__}", "int64_pk", 3000
+        collection_name, primary_field, _nb = f"{request.function.__name__}", "int64_pk", 3000
 
         # create a collection with fields that can build `BITMAP` index
         self.collection_wrap.init_collection(
@@ -2905,7 +2904,7 @@ class TestBitmapIndex(TestcaseBase):
         """
         # init params
         collection_name = f"{request.function.__name__}_{str(bitmap_cardinality_limit).replace('-', '_')}"
-        primary_field, nb = "int64_pk", 3000
+        primary_field, _nb = "int64_pk", 3000
 
         # create a collection with fields that can build `BITMAP` index
         self.collection_wrap.init_collection(

--- a/tests/python_client/testcases/test_index.py
+++ b/tests/python_client/testcases/test_index.py
@@ -1428,9 +1428,9 @@ class TestIndexInvalid(TestcaseBase):
         data = cf.gen_default_list_sparse_data()
         collection_w.insert(data=data)
         params = {"index_type": index, "metric_type": "IP", "params": {"inverted_index_algo": inverted_index_algo}}
-        error = {ct.err_code: 999,
+        error = {ct.err_code: 1100,
                  ct.err_msg: f"sparse inverted index algo {inverted_index_algo} not found or not supported, "
-                             f"supported: [TAAT_NAIVE DAAT_WAND DAAT_MAXSCORE]"}
+                             f"supported: [TAAT_NAIVE DAAT_WAND DAAT_MAXSCORE BLOCK_MAX_MAXSCORE BLOCK_MAX_WAND SINDI]"}
         index, _ = self.index_wrap.init_index(collection_w.collection, ct.default_sparse_vec_field_name, params,
                                               check_task=CheckTasks.err_res,
                                               check_items=error)


### PR DESCRIPTION
## Summary

Cherry-pick to 3.0 branch of master fixes + ngram test fix:

1. **TestPartitionsNumExceedsMax**: Use management API to temporarily lower `rootCoord.maxPartitionNum` to 10, eliminating timeout flakiness (from master PR)
2. **test_invalid_sparse_inverted_index_algo**: Update error code 999→1100 and add 3 new sparse algorithms to match server after #49041 (from master PR)
3. **test_ngram_search_with_multilingual_utf8_strings**: Cherry-pick #49454 assertion fix (merged to master Apr 30, never cherry-picked to 3.0)

pr: #49599

## Test plan

- [ ] CI go-sdk pipeline on 3.0 passes without flaky timeout
- [ ] Nightly e2e test_index sparse algo assertion passes
- [ ] Nightly e2e test_ngram multilingual assertion passes

Signed-off-by: Li Liu <li.liu@zilliz.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>