### PR TITLE
enhance: parallelize text match index load

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -2995,6 +2995,9 @@ ChunkedSegmentSealedImpl::LoadTextIndex(
         milvus::cachinglayer::Manager::GetInstance().CreateCacheSlot(
             std::move(translator), op_ctx);
 
+    // CreateCacheSlot may synchronously warm up the text index. Keep that work
+    // outside the segment mutex so multiple text indexes can load in parallel.
+    CheckCancellation(op_ctx, id_, "ChunkedSegmentSealedImpl::LoadTextIndex()");
     std::unique_lock lck(mutex_);
     text_indexes_[field_id] = std::move(cache_slot);
 }

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -664,6 +664,38 @@ UpdateSealedSegmentIndex(CSegmentInterface c_segment,
 }
 
 CStatus
+LoadTextIndex(CSegmentInterface c_segment,
+              const uint8_t* serialized_load_text_index_info,
+              const uint64_t len,
+              CLoadCancellationSource source) {
+    SCOPE_CGO_CALL_METRIC();
+
+    try {
+        auto segment_interface =
+            reinterpret_cast<milvus::segcore::SegmentInterface*>(c_segment);
+        auto segment =
+            dynamic_cast<milvus::segcore::SegmentSealed*>(segment_interface);
+        AssertInfo(segment != nullptr, "segment conversion failed");
+
+        auto info_proto =
+            std::make_shared<milvus::proto::indexcgo::LoadTextIndexInfo>();
+        info_proto->ParseFromArray(serialized_load_text_index_info, len);
+
+        if (source) {
+            auto cancellation_source =
+                static_cast<folly::CancellationSource*>(source);
+            milvus::OpContext op_ctx(cancellation_source->getToken());
+            segment->LoadTextIndex(&op_ctx, std::move(info_proto));
+        } else {
+            segment->LoadTextIndex(nullptr, std::move(info_proto));
+        }
+        return milvus::SuccessCStatus();
+    } catch (std::exception& e) {
+        return milvus::FailureCStatus(&e);
+    }
+}
+
+CStatus
 LoadJsonKeyIndex(CTraceContext c_trace,
                  CSegmentInterface c_segment,
                  const uint8_t* serialized_load_json_key_index_info,
@@ -839,6 +871,32 @@ RemoveFieldFile(CSegmentInterface c_segment, int64_t field_id) {
 
     auto segment = reinterpret_cast<milvus::segcore::SegmentSealed*>(c_segment);
     segment->RemoveFieldFile(milvus::FieldId(field_id));
+}
+
+CStatus
+CreateTextIndex(CSegmentInterface c_segment,
+                int64_t field_id,
+                CLoadCancellationSource source) {
+    SCOPE_CGO_CALL_METRIC();
+
+    try {
+        auto segment_interface =
+            reinterpret_cast<milvus::segcore::SegmentInterface*>(c_segment);
+        AssertInfo(segment_interface != nullptr, "segment conversion failed");
+        if (source) {
+            auto cancellation_source =
+                static_cast<folly::CancellationSource*>(source);
+            milvus::OpContext op_ctx(cancellation_source->getToken());
+            segment_interface->CreateTextIndex(milvus::FieldId(field_id),
+                                               &op_ctx);
+        } else {
+            segment_interface->CreateTextIndex(milvus::FieldId(field_id),
+                                               nullptr);
+        }
+        return milvus::SuccessCStatus();
+    } catch (std::exception& e) {
+        return milvus::FailureCStatus(&e);
+    }
 }
 
 CStatus

--- a/internal/core/src/segcore/segment_c.h
+++ b/internal/core/src/segcore/segment_c.h
@@ -237,6 +237,12 @@ UpdateSealedSegmentIndex(CSegmentInterface c_segment,
                          CLoadIndexInfo c_load_index_info);
 
 CStatus
+LoadTextIndex(CSegmentInterface c_segment,
+              const uint8_t* serialized_load_text_index_info,
+              const uint64_t len,
+              CLoadCancellationSource source);
+
+CStatus
 LoadJsonKeyIndex(CTraceContext c_trace,
                  CSegmentInterface c_segment,
                  const uint8_t* serialied_load_json_key_index_info,
@@ -278,6 +284,11 @@ Delete(CSegmentInterface c_segment,
 
 void
 RemoveFieldFile(CSegmentInterface c_segment, int64_t field_id);
+
+CStatus
+CreateTextIndex(CSegmentInterface c_segment,
+                int64_t field_id,
+                CLoadCancellationSource source);
 
 CStatus
 ExprResCacheEraseSegment(int64_t segment_id);

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -1191,6 +1191,58 @@ func (s *LocalSegment) innerLoadIndex(ctx context.Context,
 	return err
 }
 
+func (s *LocalSegment) LoadTextIndex(ctx context.Context, textLogs *datapb.TextIndexStats, schemaHelper *typeutil.SchemaHelper) error {
+	_, err := GetLoadPool().Submit(func() (any, error) {
+		return nil, s.loadTextIndexCgo(ctx, textLogs, schemaHelper)
+	}).Await()
+	return err
+}
+
+func (s *LocalSegment) loadTextIndexCgo(ctx context.Context, textLogs *datapb.TextIndexStats, schemaHelper *typeutil.SchemaHelper) error {
+	log.Ctx(ctx).Info("load text index", zap.Int64("field id", textLogs.GetFieldID()), zap.Any("text logs", textLogs))
+
+	if !s.ptrLock.PinIf(state.IsNotReleased) {
+		return merr.WrapErrSegmentNotLoaded(s.ID(), "segment released")
+	}
+	defer s.ptrLock.Unpin()
+
+	f, err := schemaHelper.GetFieldFromID(textLogs.GetFieldID())
+	if err != nil {
+		return err
+	}
+
+	// Text match index mmap config is based on the raw data mmap.
+	enableMmap := isDataMmapEnable(f)
+	// Text match index should based on scala field's warmup policy like mmap
+	warmupPolicy := getScalarDataWarmupPolicy(f)
+	cgoProto := &indexcgopb.LoadTextIndexInfo{
+		FieldID:      textLogs.GetFieldID(),
+		Version:      textLogs.GetVersion(),
+		BuildID:      textLogs.GetBuildID(),
+		Files:        textLogs.GetFiles(),
+		Schema:       f,
+		CollectionID: s.Collection(),
+		PartitionID:  s.Partition(),
+		LoadPriority: s.LoadInfo().GetPriority(),
+		EnableMmap:   enableMmap,
+		IndexSize:    textLogs.GetMemorySize(),
+		WarmupPolicy: warmupPolicy,
+	}
+
+	marshaled, err := proto.Marshal(cgoProto)
+	if err != nil {
+		return err
+	}
+
+	guard := segcore.NewCancellationGuard(ctx)
+	defer guard.Close()
+
+	var status C.CStatus
+	status = C.LoadTextIndex(s.ptr, (*C.uint8_t)(unsafe.Pointer(&marshaled[0])), (C.uint64_t)(len(marshaled)), (C.CLoadCancellationSource)(guard.Source()))
+
+	return HandleCStatus(ctx, &status, "LoadTextIndex failed")
+}
+
 func (s *LocalSegment) LoadJSONKeyIndex(ctx context.Context, jsonKeyStats *datapb.JsonKeyStats, schemaHelper *typeutil.SchemaHelper, basePath string) error {
 	if !s.ptrLock.PinIf(state.IsNotReleased) {
 		return merr.WrapErrSegmentNotLoaded(s.ID(), "segment released")
@@ -1318,6 +1370,33 @@ func (s *LocalSegment) UpdateFieldRawDataSize(ctx context.Context, numRows int64
 
 	log.Ctx(ctx).Info("updateFieldRawDataSize done", zap.Int64("segmentID", s.ID()))
 
+	return nil
+}
+
+func (s *LocalSegment) CreateTextIndex(ctx context.Context, fieldID int64) error {
+	log.Ctx(ctx).Info("create text index for segment", zap.Int64("segmentID", s.ID()), zap.Int64("fieldID", fieldID))
+
+	if !s.ptrLock.PinIf(state.IsNotReleased) {
+		return merr.WrapErrSegmentNotLoaded(s.ID(), "segment released")
+	}
+	defer s.ptrLock.Unpin()
+
+	guard := segcore.NewCancellationGuard(ctx)
+	defer guard.Close()
+
+	var status C.CStatus
+	if _, err := GetLoadPool().Submit(func() (any, error) {
+		status = C.CreateTextIndex(s.ptr, C.int64_t(fieldID), (C.CLoadCancellationSource)(guard.Source()))
+		return nil, nil
+	}).Await(); err != nil {
+		return err
+	}
+
+	if err := HandleCStatus(ctx, &status, "CreateTextIndex failed"); err != nil {
+		return err
+	}
+
+	log.Ctx(ctx).Info("create text index for segment done", zap.Int64("segmentID", s.ID()), zap.Int64("fieldID", fieldID))
 	return nil
 }
 

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -55,6 +55,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
+	"github.com/milvus-io/milvus/pkg/v3/util/conc"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/hardware"
 	"github.com/milvus-io/milvus/pkg/v3/util/indexparams"
@@ -1069,6 +1070,26 @@ func (loader *segmentLoader) loadSealedSegment(ctx context.Context, loadInfo *qu
 		})
 	}
 
+	// Load text indexes in parallel through LoadPool.
+	futures := make([]*conc.Future[any], 0, len(textIndexes))
+	for _, info := range textIndexes {
+		textIndexInfo := info
+		futures = append(futures, GetLoadPool().Submit(func() (any, error) {
+			return nil, segment.loadTextIndexCgo(ctx, textIndexInfo, schemaHelper)
+		}))
+	}
+	if err := conc.BlockOnAll(futures...); err != nil {
+		return err
+	}
+	loadTextIndexesSpan := tr.RecordSpan()
+
+	// create index for unindexed text fields.
+	for fieldID := range unindexedTextFields {
+		if err := segment.CreateTextIndex(ctx, fieldID); err != nil {
+			return err
+		}
+	}
+
 	for fieldID, info := range jsonKeyStats {
 		if err := segment.LoadJSONKeyIndex(ctx, info, schemaHelper, jsonBasePaths[fieldID]); err != nil {
 			return err
@@ -1085,6 +1106,7 @@ func (loader *segmentLoader) loadSealedSegment(ctx context.Context, loadInfo *qu
 	patchEntryNumberSpan := tr.RecordSpan()
 	log.Info("Finish loading segment",
 		zap.Duration("patchEntryNumberSpan", patchEntryNumberSpan),
+		zap.Duration("loadTextIndexesSpan", loadTextIndexesSpan),
 		zap.Duration("loadJsonKeyIndexSpan", loadJSONKeyIndexesSpan),
 	)
 	return nil


### PR DESCRIPTION
issue: #49603

- Load indexed text match indexes in parallel through the QueryNode load pool.
- Add Go/C wrappers for LoadTextIndex and CreateTextIndex against the current segcore API.
- Keep text index cache-slot creation and warmup outside the segment mutex, and lock only when publishing text_indexes_.