### PR TITLE
enhance: [2.6] parallelize text match index load

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -1775,8 +1775,6 @@ ChunkedSegmentSealedImpl::LoadTextIndex(
     // Check for cancellation before starting
     CheckCancellation(op_ctx, id_, "ChunkedSegmentSealedImpl::LoadTextIndex()");
 
-    std::unique_lock lck(mutex_);
-
     milvus::storage::FieldDataMeta field_data_meta{info_proto->collectionid(),
                                                    info_proto->partitionid(),
                                                    this->get_segment_id(),
@@ -1825,6 +1823,11 @@ ChunkedSegmentSealedImpl::LoadTextIndex(
     auto cache_slot =
         milvus::cachinglayer::Manager::GetInstance().CreateCacheSlot(
             std::move(translator), op_ctx);
+
+    // CreateCacheSlot may synchronously warm up the text index. Keep that work
+    // outside the segment mutex so multiple text indexes can load in parallel.
+    CheckCancellation(op_ctx, id_, "ChunkedSegmentSealedImpl::LoadTextIndex()");
+    std::unique_lock lck(mutex_);
     text_indexes_[field_id] = std::move(cache_slot);
 }
 

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -820,6 +820,7 @@ CreateTextIndex(CSegmentInterface c_segment,
     try {
         auto segment_interface =
             reinterpret_cast<milvus::segcore::SegmentInterface*>(c_segment);
+        AssertInfo(segment_interface != nullptr, "segment conversion failed");
         if (source) {
             auto cancellation_source =
                 static_cast<folly::CancellationSource*>(source);

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -1206,6 +1206,13 @@ func (s *LocalSegment) innerLoadIndex(ctx context.Context,
 }
 
 func (s *LocalSegment) LoadTextIndex(ctx context.Context, textLogs *datapb.TextIndexStats, schemaHelper *typeutil.SchemaHelper) error {
+	_, err := GetLoadPool().Submit(func() (any, error) {
+		return nil, s.loadTextIndexCgo(ctx, textLogs, schemaHelper)
+	}).Await()
+	return err
+}
+
+func (s *LocalSegment) loadTextIndexCgo(ctx context.Context, textLogs *datapb.TextIndexStats, schemaHelper *typeutil.SchemaHelper) error {
 	log.Ctx(ctx).Info("load text index", zap.Int64("field id", textLogs.GetFieldID()), zap.Any("text logs", textLogs))
 
 	if !s.ptrLock.PinIf(state.IsNotReleased) {
@@ -1244,11 +1251,7 @@ func (s *LocalSegment) LoadTextIndex(ctx context.Context, textLogs *datapb.TextI
 	guard := segcore.NewCancellationGuard(ctx)
 	defer guard.Close()
 
-	var status C.CStatus
-	_, _ = GetLoadPool().Submit(func() (any, error) {
-		status = C.LoadTextIndex(s.ptr, (*C.uint8_t)(unsafe.Pointer(&marshaled[0])), (C.uint64_t)(len(marshaled)), (C.CLoadCancellationSource)(guard.Source()))
-		return nil, nil
-	}).Await()
+	status := C.LoadTextIndex(s.ptr, (*C.uint8_t)(unsafe.Pointer(&marshaled[0])), (C.uint64_t)(len(marshaled)), (C.CLoadCancellationSource)(guard.Source()))
 
 	return HandleCStatus(ctx, &status, "LoadTextIndex failed")
 }
@@ -1383,16 +1386,23 @@ func (s *LocalSegment) UpdateFieldRawDataSize(ctx context.Context, numRows int64
 }
 
 func (s *LocalSegment) CreateTextIndex(ctx context.Context, fieldID int64) error {
-	var status C.CStatus
 	log.Ctx(ctx).Info("create text index for segment", zap.Int64("segmentID", s.ID()), zap.Int64("fieldID", fieldID))
+
+	if !s.ptrLock.PinIf(state.IsNotReleased) {
+		return merr.WrapErrSegmentNotLoaded(s.ID(), "segment released")
+	}
+	defer s.ptrLock.Unpin()
 
 	guard := segcore.NewCancellationGuard(ctx)
 	defer guard.Close()
 
-	GetLoadPool().Submit(func() (any, error) {
+	var status C.CStatus
+	if _, err := GetLoadPool().Submit(func() (any, error) {
 		status = C.CreateTextIndex(s.ptr, C.int64_t(fieldID), (C.CLoadCancellationSource)(guard.Source()))
 		return nil, nil
-	}).Await()
+	}).Await(); err != nil {
+		return err
+	}
 
 	if err := HandleCStatus(ctx, &status, "CreateTextIndex failed"); err != nil {
 		return err

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -958,11 +958,16 @@ func (loader *segmentLoader) loadSealedSegment(ctx context.Context, loadInfo *qu
 		})
 	}
 
-	// load text indexes.
+	// Load text indexes in parallel through LoadPool.
+	futures := make([]*conc.Future[any], 0, len(textIndexes))
 	for _, info := range textIndexes {
-		if err := segment.LoadTextIndex(ctx, info, schemaHelper); err != nil {
-			return err
-		}
+		textIndexInfo := info
+		futures = append(futures, GetLoadPool().Submit(func() (any, error) {
+			return nil, segment.loadTextIndexCgo(ctx, textIndexInfo, schemaHelper)
+		}))
+	}
+	if err := conc.BlockOnAll(futures...); err != nil {
+		return err
 	}
 	loadTextIndexesSpan := tr.RecordSpan()
 


### PR DESCRIPTION
pr: #46536 
issue: #49603

- Load indexed text match indexes in parallel through the QueryNode load pool.
- Keep text index cache-slot creation and warmup outside the segment mutex.