### PR TITLE
enhance: unify filesystem access through FilesystemCache, remove ArrowFileSystemSingleton

### DIFF
--- a/internal/core/src/common/VectorArrayStorageV2Test.cpp
+++ b/internal/core/src/common/VectorArrayStorageV2Test.cpp
@@ -36,6 +36,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include "segcore/default_fs.h"
 
 #include "NamedType/named_type_impl.hpp"
 #include "common/Consts.h"
@@ -108,8 +109,7 @@ class TestVectorArrayStorageV2 : public testing::Test {
             segcore::SegcoreConfig::default_config(),
             true);
 
-        auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
-                      .GetArrowFileSystem();
+        auto fs = milvus::segcore::GetDefaultArrowFileSystem();
 
         // Prepare paths and column groups
         std::vector<std::string> paths = {"test_data/0/10000.parquet",
@@ -265,8 +265,7 @@ class TestVectorArrayStorageV2 : public testing::Test {
 
     void
     TearDown() override {
-        auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
-                      .GetArrowFileSystem();
+        auto fs = milvus::segcore::GetDefaultArrowFileSystem();
         (void)fs->DeleteDir("test_data");
     }
 
@@ -289,8 +288,7 @@ TEST_F(TestVectorArrayStorageV2, BuildEmbListHNSWIndex) {
     std::vector<std::string> paths = {"test_data/101/10001.parquet"};
 
     // Use the existing Arrow file system from SetUp
-    auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
-                  .GetArrowFileSystem();
+    auto fs = milvus::segcore::GetDefaultArrowFileSystem();
 
     // Prepare for index building
     int64_t collection_id = 1;
@@ -403,8 +401,7 @@ TEST_F(TestVectorArrayStorageV2, BuildEmbListHNSWIndexWithMmap) {
     std::vector<std::string> paths = {"test_data/101/10001.parquet"};
 
     // Use the existing Arrow file system from SetUp
-    auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
-                  .GetArrowFileSystem();
+    auto fs = milvus::segcore::GetDefaultArrowFileSystem();
 
     // Prepare for index building
     int64_t collection_id = 1;

--- a/internal/core/src/index/NgramInvertedIndexTest.cpp
+++ b/internal/core/src/index/NgramInvertedIndexTest.cpp
@@ -120,11 +120,6 @@ test_ngram_with_data(const boost::container::vector<std::string>& data,
     auto cm = CreateChunkManager(storage_config);
     auto fs = storage::InitArrowFileSystem(storage_config);
 
-    auto arrow_fs_conf = milvus_storage::ArrowFileSystemConfig();
-    arrow_fs_conf.storage_type = "local";
-    arrow_fs_conf.root_path = root_path;
-    milvus_storage::ArrowFileSystemSingleton::GetInstance().Init(arrow_fs_conf);
-
     size_t nb = data.size();
 
     auto field_data =
@@ -443,11 +438,6 @@ TEST(NgramIndex, TestNonLikeExpressionsWithNgram) {
     auto storage_config = gen_local_storage_config(root_path);
     auto cm = CreateChunkManager(storage_config);
     auto fs = storage::InitArrowFileSystem(storage_config);
-
-    auto arrow_fs_conf = milvus_storage::ArrowFileSystemConfig();
-    arrow_fs_conf.storage_type = "local";
-    arrow_fs_conf.root_path = root_path;
-    milvus_storage::ArrowFileSystemSingleton::GetInstance().Init(arrow_fs_conf);
 
     size_t nb = data.size();
 
@@ -1607,11 +1597,6 @@ TEST(NgramBenchmark, NgramVsTantivyVsBruteForce) {
     auto cm = CreateChunkManager(storage_config);
     auto fs = storage::InitArrowFileSystem(storage_config);
 
-    auto arrow_fs_conf = milvus_storage::ArrowFileSystemConfig();
-    arrow_fs_conf.storage_type = "local";
-    arrow_fs_conf.root_path = root_path;
-    milvus_storage::ArrowFileSystemSingleton::GetInstance().Init(arrow_fs_conf);
-
     auto field_data =
         storage::CreateFieldData(DataType::VARCHAR, DataType::NONE, false);
     field_data->FillFieldData(data.data(), data.size());
@@ -1888,11 +1873,6 @@ TEST(NgramBenchmark, NgramFilteringEffectiveness) {
     auto storage_config = gen_local_storage_config(root_path);
     auto cm = CreateChunkManager(storage_config);
     auto fs = storage::InitArrowFileSystem(storage_config);
-
-    auto arrow_fs_conf = milvus_storage::ArrowFileSystemConfig();
-    arrow_fs_conf.storage_type = "local";
-    arrow_fs_conf.root_path = root_path;
-    milvus_storage::ArrowFileSystemSingleton::GetInstance().Init(arrow_fs_conf);
 
     auto field_data =
         storage::CreateFieldData(DataType::VARCHAR, DataType::NONE, false);

--- a/internal/core/src/index/json_stats/JsonKeyStats.cpp
+++ b/internal/core/src/index/json_stats/JsonKeyStats.cpp
@@ -24,6 +24,7 @@
 #include <iosfwd>
 #include <unordered_set>
 #include <variant>
+#include "segcore/default_fs.h"
 
 #include "NamedType/named_type_impl.hpp"
 #include "NamedType/underlying_functionalities.hpp"
@@ -119,8 +120,7 @@ JsonKeyStats::JsonKeyStats(const storage::FileManagerContext& ctx,
         auto trueFs = ctx.fs;
         // try singleton if possible
         if (!trueFs) {
-            trueFs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
-                         .GetArrowFileSystem();
+            trueFs = milvus::segcore::GetDefaultArrowFileSystem();
         }
         if (!trueFs) {
             ThrowInfo(ErrorCode::UnexpectedError, "Failed to get filesystem");
@@ -812,8 +812,7 @@ JsonKeyStats::BuildWithFieldData(const std::vector<FieldDataPtr>& field_datas,
 void
 JsonKeyStats::GetColumnSchemaFromParquet(int64_t column_group_id,
                                          const std::string& file) {
-    auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
-                  .GetArrowFileSystem();
+    auto fs = milvus::segcore::GetDefaultArrowFileSystem();
     auto result = milvus_storage::FileRowGroupReader::Make(fs, file);
     AssertInfo(result.ok(),
                "[StorageV2] Failed to create file row group reader: {}",
@@ -876,8 +875,7 @@ JsonKeyStats::GetCommonMetaFromParquet(const std::string& file) {
              file,
              segment_id_);
 
-    auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
-                  .GetArrowFileSystem();
+    auto fs = milvus::segcore::GetDefaultArrowFileSystem();
     auto result = milvus_storage::FileRowGroupReader::Make(fs, file);
     AssertInfo(result.ok(),
                "[StorageV2] Failed to create file row group reader: {}",
@@ -984,8 +982,7 @@ JsonKeyStats::LoadColumnGroup(int64_t column_group_id,
             remote_prefix, column_group_id, file_id));
     }
 
-    auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
-                  .GetArrowFileSystem();
+    auto fs = milvus::segcore::GetDefaultArrowFileSystem();
     auto result = milvus_storage::FileRowGroupReader::Make(fs, files[0]);
     AssertInfo(result.ok(),
                "[StorageV2] Failed to create file row group reader: {}",

--- a/internal/core/src/segcore/ArrowFsCTest.cpp
+++ b/internal/core/src/segcore/ArrowFsCTest.cpp
@@ -22,14 +22,17 @@
 #include "segcore/arrow_fs_c.h"
 #include "test_utils/Constants.h"
 
-TEST(ArrowFileSystemSingleton, LocalArrowFileSystemSingleton) {
-    const char* path = TestLocalPath.c_str();
-    CStatus status = InitLocalArrowFileSystemSingleton(path);
+TEST(ArrowFileSystem, InitAndClean) {
+    CStorageConfig config = {};
+    config.root_path = TestLocalPath.c_str();
+    config.storage_type = "local";
+
+    CStatus status = InitArrowFileSystem(config);
     EXPECT_EQ(status.error_code, 0);
 
-    CleanArrowFileSystemSingleton();
+    CleanArrowFileSystem();
 
-    // Reinitialize the singleton so subsequent tests can use it
-    status = InitLocalArrowFileSystemSingleton(path);
+    // Reinitialize so subsequent tests can use it
+    status = InitArrowFileSystem(config);
     EXPECT_EQ(status.error_code, 0);
 }

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -10,6 +10,7 @@
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
 #include "ChunkedSegmentSealedImpl.h"
+#include "segcore/default_fs.h"
 
 #include <cxxabi.h>
 #include <fmt/core.h>
@@ -830,8 +831,7 @@ LoadedGroupChunkMetadata
 LoadGroupChunkMetadata(const std::vector<std::string>& insert_files,
                        const std::vector<FieldId>& field_ids_for_stats,
                        const std::string& debug_key) {
-    auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
-                  .GetArrowFileSystem();
+    auto fs = milvus::segcore::GetDefaultArrowFileSystem();
     auto& pool = ThreadPools::GetThreadPool(ThreadPoolPriority::HIGH);
 
     std::vector<std::future<FileMetadataLoadResult>> futures;
@@ -953,8 +953,7 @@ ChunkedSegmentSealedImpl::load_column_group_data_internal(
         auto column_group_id = FieldId(id);
         auto insert_files = info.insert_files;
         storage::SortByPath(insert_files);
-        auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
-                      .GetArrowFileSystem();
+        auto fs = milvus::segcore::GetDefaultArrowFileSystem();
 
         milvus_storage::FieldIDList field_id_list;
         if (info.child_field_ids.size() == 0) {
@@ -2720,8 +2719,7 @@ ChunkedSegmentSealedImpl::bulk_subscript_text_impl(
 
     auto properties = milvus::storage::LoonFFIPropertiesSingleton::GetInstance()
                           .GetProperties();
-    auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
-                  .GetArrowFileSystem();
+    auto fs = milvus::segcore::GetDefaultArrowFileSystem();
 
     auto& cache = GetGlobalTextColumnCache();
     auto texts = cache.ReadBatch(lob_base_path, fs, *properties, encoded_refs);
@@ -2915,8 +2913,7 @@ ChunkedSegmentSealedImpl::LoadTextIndex(
     auto remote_chunk_manager =
         milvus::storage::RemoteChunkManagerSingleton::GetInstance()
             .GetRemoteChunkManager();
-    auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
-                  .GetArrowFileSystem();
+    auto fs = milvus::segcore::GetDefaultArrowFileSystem();
     AssertInfo(fs != nullptr, "arrow file system is null");
 
     milvus::Config config;

--- a/internal/core/src/segcore/ChunkedSegmentSealedStorageV2Test.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedStorageV2Test.cpp
@@ -34,6 +34,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include "segcore/default_fs.h"
 
 #include "NamedType/named_type_impl.hpp"
 #include "cachinglayer/CacheSlot.h"
@@ -97,8 +98,7 @@ class TestChunkSegmentStorageV2 : public testing::TestWithParam<bool> {
         schema_ = segcore::GenChunkedSegmentTestSchema(pk_is_string);
 
         // Use globally initialized ArrowFileSystem
-        auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
-                      .GetArrowFileSystem();
+        auto fs = milvus::segcore::GetDefaultArrowFileSystem();
 
         // Prepare paths and column groups
         std::vector<std::string> paths = {"test_data/0/10000.parquet",
@@ -225,8 +225,7 @@ class TestChunkSegmentStorageV2 : public testing::TestWithParam<bool> {
     void
     TearDown() override {
         // Clean up test data directory
-        auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
-                      .GetArrowFileSystem();
+        auto fs = milvus::segcore::GetDefaultArrowFileSystem();
         auto status = fs->DeleteDir("test_data");
         ASSERT_TRUE(status.ok());
     }

--- a/internal/core/src/segcore/FieldIndexing.cpp
+++ b/internal/core/src/segcore/FieldIndexing.cpp
@@ -18,6 +18,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include "segcore/default_fs.h"
 
 #include "IndexConfigGenerator.h"
 #include "common/EasyAssert.h"
@@ -585,8 +586,7 @@ ScalarFieldIndexing<T>::recreate_index(const FieldMeta& field_meta,
             auto chunk_manager =
                 milvus::storage::LocalChunkManagerSingleton::GetInstance()
                     .GetChunkManager();
-            auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
-                          .GetArrowFileSystem();
+            auto fs = milvus::segcore::GetDefaultArrowFileSystem();
 
             // Create FieldDataMeta for RTree index
             storage::FieldDataMeta field_data_meta;

--- a/internal/core/src/segcore/PackedReaderWriterTest.cpp
+++ b/internal/core/src/segcore/PackedReaderWriterTest.cpp
@@ -32,7 +32,6 @@
 #include "common/common_type_c.h"
 #include "gtest/gtest.h"
 #include "milvus-storage/common/constants.h"
-#include "segcore/arrow_fs_c.h"
 #include "segcore/column_groups_c.h"
 #include "segcore/packed_reader_c.h"
 #include "segcore/packed_writer_c.h"
@@ -75,17 +74,15 @@ TEST(CPackedTest, PackedWriterAndReader) {
     int group[] = {0};
     AddCColumnSplit(cgs, group, 1);
 
-    auto c_status = InitLocalArrowFileSystemSingleton(path);
-    EXPECT_EQ(c_status.error_code, 0);
     CPackedWriter c_packed_writer = nullptr;
-    c_status = NewPackedWriter(&c_write_schema,
-                               buffer_size,
-                               paths,
-                               1,
-                               part_upload_size,
-                               cgs,
-                               &c_packed_writer,
-                               nullptr);
+    auto c_status = NewPackedWriter(&c_write_schema,
+                                    buffer_size,
+                                    paths,
+                                    1,
+                                    part_upload_size,
+                                    cgs,
+                                    &c_packed_writer,
+                                    nullptr);
     EXPECT_EQ(c_status.error_code, 0);
     EXPECT_NE(c_packed_writer, nullptr);
 

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -27,6 +27,7 @@
 #include <type_traits>
 #include <unordered_map>
 #include <variant>
+#include "segcore/default_fs.h"
 
 #include "NamedType/named_type_impl.hpp"
 #include "arrow/api.h"
@@ -887,8 +888,7 @@ SegmentGrowingImpl::load_column_group_data_internal(
         auto column_group_id = FieldId(id);
         auto insert_files = info.insert_files;
         storage::SortByPath(insert_files);
-        auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
-                      .GetArrowFileSystem();
+        auto fs = milvus::segcore::GetDefaultArrowFileSystem();
         auto column_group_info =
             FieldDataInfo(column_group_id.get(), num_rows, "");
         column_group_info.arrow_reader_channel->set_capacity(parallel_degree);
@@ -1244,8 +1244,7 @@ SegmentGrowingImpl::bulk_subscript_text_impl(FieldId field_id,
         auto properties =
             milvus::storage::LoonFFIPropertiesSingleton::GetInstance()
                 .GetProperties();
-        auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
-                      .GetArrowFileSystem();
+        auto fs = milvus::segcore::GetDefaultArrowFileSystem();
         google::protobuf::RepeatedPtrField<std::string> resolved;
         resolved.Reserve(encoded_refs.size());
         for (size_t j = 0; j < encoded_refs.size(); ++j) {

--- a/internal/core/src/segcore/SegmentGrowingStorageV2Test.cpp
+++ b/internal/core/src/segcore/SegmentGrowingStorageV2Test.cpp
@@ -31,6 +31,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include "segcore/default_fs.h"
 
 #include "arrow/type_fwd.h"
 #include "common/ArrowDataWrapper.h"
@@ -64,8 +65,7 @@ using namespace milvus::segcore;
 class TestGrowingStorageV2 : public ::testing::Test {
     void
     SetUp() override {
-        fs_ = milvus_storage::ArrowFileSystemSingleton::GetInstance()
-                  .GetArrowFileSystem();
+        fs_ = milvus::segcore::GetDefaultArrowFileSystem();
         SetUpCommonData();
     }
 

--- a/internal/core/src/segcore/Utils.cpp
+++ b/internal/core/src/segcore/Utils.cpp
@@ -10,6 +10,7 @@
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
 #include "segcore/Utils.h"
+#include "segcore/default_fs.h"
 
 #include <cxxabi.h>
 #include <folly/ExceptionWrapper.h>
@@ -1481,8 +1482,7 @@ LoadIndexData(milvus::tracer::TraceContext& ctx,
     auto remote_chunk_manager =
         milvus::storage::RemoteChunkManagerSingleton::GetInstance()
             .GetRemoteChunkManager();
-    auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
-                  .GetArrowFileSystem();
+    auto fs = milvus::segcore::GetDefaultArrowFileSystem();
     AssertInfo(fs != nullptr, "arrow file system is nullptr");
     milvus::storage::FileManagerContext file_manager_context(
         field_meta, index_meta, remote_chunk_manager, fs);

--- a/internal/core/src/segcore/arrow_fs_c.cpp
+++ b/internal/core/src/segcore/arrow_fs_c.cpp
@@ -1,19 +1,3 @@
-// Licensed to the LF AI & Data foundation under one
-// or more contributor license agreements. See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership. The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License. You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 #include "segcore/arrow_fs_c.h"
 
 #include <exception>
@@ -25,15 +9,22 @@
 #include "storage/loon_ffi/property_singleton.h"
 
 CStatus
-InitLocalArrowFileSystemSingleton(const char* c_path) {
+InitArrowFileSystem(CStorageConfig c_storage_config) {
     try {
-        std::string path(c_path);
-        milvus_storage::ArrowFileSystemConfig conf;
-        conf.root_path = path;
-        conf.storage_type = "local";
-        milvus_storage::ArrowFileSystemSingleton::GetInstance().Init(conf);
+        milvus::storage::LoonFFIPropertiesSingleton::GetInstance().Init(
+            c_storage_config);
 
-        milvus::storage::LoonFFIPropertiesSingleton::GetInstance().Init(c_path);
+        auto props = milvus::storage::LoonFFIPropertiesSingleton::GetInstance()
+                         .GetProperties();
+        if (props) {
+            auto result =
+                milvus_storage::FilesystemCache::getInstance().get(*props, "");
+            if (!result.ok()) {
+                throw std::runtime_error(
+                    "Failed to populate FilesystemCache: " +
+                    result.status().ToString());
+            }
+        }
 
         return milvus::SuccessCStatus();
     } catch (std::exception& e) {
@@ -42,45 +33,6 @@ InitLocalArrowFileSystemSingleton(const char* c_path) {
 }
 
 void
-CleanArrowFileSystemSingleton() {
-    milvus_storage::ArrowFileSystemSingleton::GetInstance().Release();
-}
-
-CStatus
-InitRemoteArrowFileSystemSingleton(CStorageConfig c_storage_config) {
-    try {
-        milvus_storage::ArrowFileSystemConfig conf;
-        conf.address = std::string(c_storage_config.address);
-        conf.bucket_name = std::string(c_storage_config.bucket_name);
-        conf.access_key_id = std::string(c_storage_config.access_key_id);
-        conf.access_key_value = std::string(c_storage_config.access_key_value);
-        conf.root_path = std::string(c_storage_config.root_path);
-        conf.storage_type = std::string(c_storage_config.storage_type);
-        conf.cloud_provider = std::string(c_storage_config.cloud_provider);
-        conf.iam_endpoint = std::string(c_storage_config.iam_endpoint);
-        conf.log_level = std::string(c_storage_config.log_level);
-        conf.region = std::string(c_storage_config.region);
-        conf.use_ssl = c_storage_config.useSSL;
-        conf.ssl_ca_cert = std::string(c_storage_config.sslCACert);
-        conf.use_iam = c_storage_config.useIAM;
-        conf.use_virtual_host = c_storage_config.useVirtualHost;
-        conf.request_timeout_ms = c_storage_config.requestTimeoutMs;
-        conf.gcp_credential_json =
-            std::string(c_storage_config.gcp_credential_json);
-        conf.use_custom_part_upload = c_storage_config.use_custom_part_upload;
-        conf.max_connections = c_storage_config.max_connections;
-        if (c_storage_config.tls_min_version != nullptr) {
-            conf.tls_min_version =
-                std::string(c_storage_config.tls_min_version);
-        }
-        conf.use_crc32c_checksum = c_storage_config.use_crc32c_checksum;
-        milvus_storage::ArrowFileSystemSingleton::GetInstance().Init(conf);
-
-        milvus::storage::LoonFFIPropertiesSingleton::GetInstance().Init(
-            c_storage_config);
-
-        return milvus::SuccessCStatus();
-    } catch (std::exception& e) {
-        return milvus::FailureCStatus(&e);
-    }
+CleanArrowFileSystem() {
+    milvus_storage::FilesystemCache::getInstance().clean();
 }

--- a/internal/core/src/segcore/default_fs.cpp
+++ b/internal/core/src/segcore/default_fs.cpp
@@ -1,0 +1,29 @@
+#include "segcore/default_fs.h"
+
+#include <stdexcept>
+
+#include "milvus-storage/filesystem/fs.h"
+#include "storage/loon_ffi/property_singleton.h"
+
+namespace milvus::segcore {
+
+milvus_storage::ArrowFileSystemPtr
+GetDefaultArrowFileSystem() {
+    auto props =
+        storage::LoonFFIPropertiesSingleton::GetInstance().GetProperties();
+    if (!props) {
+        throw std::runtime_error(
+            "GetDefaultArrowFileSystem: LoonFFIPropertiesSingleton not "
+            "initialized");
+    }
+    auto result =
+        milvus_storage::FilesystemCache::getInstance().get(*props, "");
+    if (!result.ok()) {
+        throw std::runtime_error(
+            "GetDefaultArrowFileSystem: FilesystemCache lookup failed: " +
+            result.status().ToString());
+    }
+    return result.ValueOrDie();
+}
+
+}  // namespace milvus::segcore

--- a/internal/core/src/segcore/default_fs.h
+++ b/internal/core/src/segcore/default_fs.h
@@ -11,18 +11,14 @@
 
 #pragma once
 
-#include "common/type_c.h"
+#include "milvus-storage/filesystem/fs.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+namespace milvus::segcore {
 
-CStatus
-InitArrowFileSystem(CStorageConfig c_storage_config);
+// Returns the default ArrowFileSystem from FilesystemCache.
+// Uses LoonFFIPropertiesSingleton to look up the cached instance.
+// Throws if properties singleton is not initialized or cache lookup fails.
+milvus_storage::ArrowFileSystemPtr
+GetDefaultArrowFileSystem();
 
-void
-CleanArrowFileSystem();
-
-#ifdef __cplusplus
-}
-#endif
+}  // namespace milvus::segcore

--- a/internal/core/src/segcore/flush_growing_segment_test.cpp
+++ b/internal/core/src/segcore/flush_growing_segment_test.cpp
@@ -33,11 +33,7 @@ class FlushGrowingSegmentTest : public ::testing::Test {
         test_dir_ = "/tmp/flush_growing_test_" + std::to_string(time(nullptr));
         fs::create_directories(test_dir_);
 
-        // initialize Arrow filesystem singleton (local filesystem for testing)
-        milvus_storage::ArrowFileSystemConfig fs_config;
-        fs_config.storage_type = "local";
-        fs_config.root_path = test_dir_;
-        milvus_storage::ArrowFileSystemSingleton::GetInstance().Init(fs_config);
+        // Arrow filesystem is initialized by init_gtest.cpp
     }
 
     void

--- a/internal/core/src/segcore/flush_growing_segment_test.cpp
+++ b/internal/core/src/segcore/flush_growing_segment_test.cpp
@@ -13,6 +13,7 @@
 #include <algorithm>
 #include <filesystem>
 
+#include "segcore/default_fs.h"
 #include "segcore/segment_c.h"
 #include "segcore/SegmentGrowingImpl.h"
 #include "test_utils/c_api_test_utils.h"
@@ -50,8 +51,7 @@ class FlushGrowingSegmentTest : public ::testing::Test {
     AssertManifestHasColumn(const std::string& segment_path,
                             int64_t version,
                             FieldId field_id) {
-        auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
-                      .GetArrowFileSystem();
+        auto fs = GetDefaultArrowFileSystem();
         ASSERT_NE(fs, nullptr);
 
         auto txn_result = milvus_storage::api::transaction::Transaction::Open(

--- a/internal/core/src/segcore/packed_reader_c.cpp
+++ b/internal/core/src/segcore/packed_reader_c.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "segcore/packed_reader_c.h"
+#include "segcore/default_fs.h"
 
 #include <arrow/c/bridge.h>
 #include <arrow/status.h>
@@ -110,8 +111,7 @@ NewPackedReader(char** paths,
 
     try {
         auto truePaths = std::vector<std::string>(paths, paths + num_paths);
-        auto trueFs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
-                          .GetArrowFileSystem();
+        auto trueFs = milvus::segcore::GetDefaultArrowFileSystem();
         if (!trueFs) {
             return milvus::FailureCStatus(
                 milvus::ErrorCode::FileReadFailed,

--- a/internal/core/src/segcore/packed_writer_c.cpp
+++ b/internal/core/src/segcore/packed_writer_c.cpp
@@ -20,6 +20,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include "segcore/default_fs.h"
 
 #include "arrow/array/array_base.h"
 #include "arrow/c/abi.h"
@@ -158,8 +159,7 @@ NewPackedWriter(struct ArrowSchema* schema,
         auto conf = milvus_storage::StorageConfig();
         conf.part_size = part_upload_size;
 
-        auto trueFs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
-                          .GetArrowFileSystem();
+        auto trueFs = milvus::segcore::GetDefaultArrowFileSystem();
         if (!trueFs) {
             return milvus::FailureCStatus(
                 milvus::ErrorCode::FileWriteFailed,

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -10,6 +10,7 @@
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
 #include "segcore/segment_c.h"
+#include "segcore/default_fs.h"
 
 #include <folly/CancellationToken.h>
 #include <folly/ExceptionWrapper.h>
@@ -708,8 +709,7 @@ LoadJsonKeyIndex(CTraceContext c_trace,
         auto remote_chunk_manager =
             milvus::storage::RemoteChunkManagerSingleton::GetInstance()
                 .GetRemoteChunkManager();
-        auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
-                      .GetArrowFileSystem();
+        auto fs = milvus::segcore::GetDefaultArrowFileSystem();
         AssertInfo(fs != nullptr, "arrow file system is null");
 
         milvus::Config config;
@@ -1391,8 +1391,7 @@ FlushGrowingSegmentData(CSegmentInterface c_segment,
         }
 
         // get filesystem from singleton
-        auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
-                      .GetArrowFileSystem();
+        auto fs = milvus::segcore::GetDefaultArrowFileSystem();
         if (!fs) {
             return milvus::FailureCStatus(milvus::UnexpectedError,
                                           "filesystem not initialized");

--- a/internal/core/src/segcore/storagev1translator/V1SealedIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/V1SealedIndexTranslator.cpp
@@ -1,4 +1,5 @@
 #include "segcore/storagev1translator/V1SealedIndexTranslator.h"
+#include "segcore/default_fs.h"
 
 #include <exception>
 #include <optional>
@@ -137,8 +138,7 @@ V1SealedIndexTranslator::LoadVecIndex() {
         auto remote_chunk_manager =
             milvus::storage::RemoteChunkManagerSingleton::GetInstance()
                 .GetRemoteChunkManager();
-        auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
-                      .GetArrowFileSystem();
+        auto fs = milvus::segcore::GetDefaultArrowFileSystem();
 
         auto config = milvus::index::ParseConfigFromIndexParams(
             index_load_info_.index_params);

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "segcore/storagev2translator/GroupChunkTranslator.h"
+#include "segcore/default_fs.h"
 
 #include <assert.h>
 #include <algorithm>
@@ -358,8 +359,7 @@ GroupChunkTranslator::get_cells(milvus::OpContext* ctx,
     auto channel = std::make_shared<milvus::segcore::CellReaderChannel>(
         static_cast<size_t>(pool.GetMaxThreadNum() *
                             milvus::segcore::kChannelCapacityMultiplier));
-    auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
-                  .GetArrowFileSystem();
+    auto fs = milvus::segcore::GetDefaultArrowFileSystem();
 
     auto factory = milvus::segcore::MakeFileReaderFactory(insert_files_, fs);
     auto load_futures =

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslatorTest.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslatorTest.cpp
@@ -26,6 +26,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include "segcore/default_fs.h"
 
 #include "NamedType/underlying_functionalities.hpp"
 #include "cachinglayer/Utils.h"
@@ -60,8 +61,7 @@ using namespace milvus::segcore::storagev2translator;
 class GroupChunkTranslatorTest : public ::testing::TestWithParam<bool> {
     void
     SetUp() override {
-        fs_ = milvus_storage::ArrowFileSystemSingleton::GetInstance()
-                  .GetArrowFileSystem();
+        fs_ = milvus::segcore::GetDefaultArrowFileSystem();
         schema_ = CreateTestSchema();
         arrow_schema_ = schema_->ConvertToArrowSchema();
         int64_t per_batch = 1000;

--- a/internal/core/src/storage/StorageV2FSCache.cpp
+++ b/internal/core/src/storage/StorageV2FSCache.cpp
@@ -30,7 +30,12 @@ StorageV2FSCache::Get(const Key& key) {
     // Convert Key to api::Properties and delegate to FilesystemCache
     // This ensures all filesystems are managed by a single cache with metrics support
     milvus_storage::api::Properties props;
-    props[PROPERTY_FS_ADDRESS] = key.address;
+    std::string address = key.address;
+    if (!key.useSSL && !address.empty() &&
+        address.find("://") == std::string::npos) {
+        address = "http://" + address;
+    }
+    props[PROPERTY_FS_ADDRESS] = address;
     props[PROPERTY_FS_BUCKET_NAME] = key.bucket_name;
     props[PROPERTY_FS_ACCESS_KEY_ID] = key.access_key_id;
     props[PROPERTY_FS_ACCESS_KEY_VALUE] = key.access_key_value;

--- a/internal/core/unittest/init_gtest.cpp
+++ b/internal/core/unittest/init_gtest.cpp
@@ -23,6 +23,7 @@
 #include "exec/expression/function/init_c.h"
 #include "folly/init/Init.h"
 #include "milvus-storage/filesystem/fs.h"
+#include "segcore/arrow_fs_c.h"
 #include "pb/cgo_msg.pb.h"
 #include "pb/clustering.pb.h"
 #include "pb/common.pb.h"
@@ -102,10 +103,13 @@ main(int argc, char** argv) {
         get_default_local_storage_config());
     milvus::storage::MmapManager::GetInstance().Init(get_default_mmap_config());
 
-    milvus_storage::ArrowFileSystemConfig arrow_conf;
-    arrow_conf.storage_type = "local";
-    arrow_conf.root_path = TestLocalPath;
-    milvus_storage::ArrowFileSystemSingleton::GetInstance().Init(arrow_conf);
+    CStorageConfig arrow_fs_config = {};
+    arrow_fs_config.root_path = TestLocalPath.c_str();
+    arrow_fs_config.storage_type = "local";
+    auto c_status = InitArrowFileSystem(arrow_fs_config);
+    if (c_status.error_code != 0) {
+        throw std::runtime_error("Failed to init arrow filesystem");
+    }
 
     static const int64_t mb = 1024 * 1024;
 

--- a/internal/core/unittest/test_json_stats/test_json_key_stats.cpp
+++ b/internal/core/unittest/test_json_stats/test_json_key_stats.cpp
@@ -24,6 +24,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include "segcore/default_fs.h"
 
 #include "bitset/bitset.h"
 #include "cachinglayer/CacheSlot.h"
@@ -213,8 +214,7 @@ class JsonKeyStatsTest : public ::testing::TestWithParam<bool> {
         storage_config.root_path = TestLocalPath;
         chunk_manager_ = storage::CreateChunkManager(storage_config);
 
-        fs_ = milvus_storage::ArrowFileSystemSingleton::GetInstance()
-                  .GetArrowFileSystem();
+        fs_ = milvus::segcore::GetDefaultArrowFileSystem();
 
         Init(collection_id,
              partition_id,
@@ -361,8 +361,7 @@ class JsonKeyStatsUploadLoadTest : public ::testing::Test {
         storage_config.root_path = root_path_;
         chunk_manager_ = storage::CreateChunkManager(storage_config);
 
-        fs_ = milvus_storage::ArrowFileSystemSingleton::GetInstance()
-                  .GetArrowFileSystem();
+        fs_ = milvus::segcore::GetDefaultArrowFileSystem();
     }
 
     void

--- a/internal/core/unittest/test_utils/ManifestTestUtil.h
+++ b/internal/core/unittest/test_utils/ManifestTestUtil.h
@@ -22,6 +22,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include "segcore/default_fs.h"
 
 #include "arrow/record_batch.h"
 #include "common/FieldMeta.h"
@@ -147,8 +148,7 @@ class V3SegmentTestData {
         auto column_groups = std::move(close_result).ValueOrDie();
 
         // Commit manifest via Transaction
-        auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
-                      .GetArrowFileSystem();
+        auto fs = milvus::segcore::GetDefaultArrowFileSystem();
         auto txn_result =
             milvus_storage::api::transaction::Transaction::Open(fs, base_path_);
         AssertInfo(txn_result.ok(),

--- a/internal/datanode/compactor/backfill_compactor_test.go
+++ b/internal/datanode/compactor/backfill_compactor_test.go
@@ -130,7 +130,7 @@ func (s *BackfillCompactionTaskSuite) TearDownTest() {
 	paramtable.Get().Reset(paramtable.Get().CommonCfg.UseLoonFFI.Key)
 	paramtable.Get().Reset(paramtable.Get().LocalStorageCfg.Path.Key)
 	paramtable.Get().Reset("common.storage.enablev2")
-	initcore.CleanArrowFileSystemSingleton()
+	initcore.CleanArrowFileSystem()
 }
 
 func (s *BackfillCompactionTaskSuite) prepareBackfillCompaction() {

--- a/internal/datanode/compactor/mix_compactor_storage_v2_test.go
+++ b/internal/datanode/compactor/mix_compactor_storage_v2_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/milvus-io/milvus/internal/flushcommon/syncmgr"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/storagecommon"
+	"github.com/milvus-io/milvus/internal/storagev2"
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/internal/util/initcore"
 	"github.com/milvus-io/milvus/pkg/v3/common"
@@ -71,7 +72,7 @@ func (s *MixCompactionTaskStorageV2Suite) TearDownTest() {
 	os.RemoveAll(paramtable.Get().LocalStorageCfg.Path.GetValue() + "insert_log")
 	os.RemoveAll(paramtable.Get().LocalStorageCfg.Path.GetValue() + "delta_log")
 	os.RemoveAll(paramtable.Get().LocalStorageCfg.Path.GetValue() + "stats_log")
-	initcore.CleanArrowFileSystemSingleton()
+	initcore.CleanArrowFileSystem()
 }
 
 func (s *MixCompactionTaskStorageV2Suite) TestCompactDupPK() {
@@ -84,6 +85,26 @@ func (s *MixCompactionTaskStorageV2Suite) TestCompactDupPK() {
 	s.Equal(1, len(result.GetSegments()))
 	s.Equal(7, len(result.GetSegments()[0].GetInsertLogs()))
 	s.Equal(1, len(result.GetSegments()[0].GetField2StatslogPaths()))
+}
+
+func (s *MixCompactionTaskStorageV2Suite) TestCompactMetrics() {
+	s.prepareCompactDupPKSegments()
+
+	storageConfig := s.task.GetStorageConfig()
+	beforeMetrics, err := storagev2.GetFilesystemMetricsWithConfig(storageConfig)
+	s.NoError(err)
+	s.NotNil(beforeMetrics)
+
+	result, err := s.task.Compact()
+	s.NoError(err)
+	s.NotNil(result)
+
+	afterMetrics, err := storagev2.GetFilesystemMetricsWithConfig(storageConfig)
+	s.NoError(err)
+	s.NotNil(afterMetrics)
+
+	s.Greater(afterMetrics.WriteBytes, beforeMetrics.WriteBytes,
+		"write bytes should increase after compaction")
 }
 
 func (s *MixCompactionTaskStorageV2Suite) TestCompactDupPK_MixToV2Format() {

--- a/internal/datanode/compactor/namespace_compactor_test.go
+++ b/internal/datanode/compactor/namespace_compactor_test.go
@@ -75,7 +75,7 @@ func (s *NamespaceCompactorTestSuite) SetupSuite() {
 
 func (s *NamespaceCompactorTestSuite) TearDownSuite() {
 	paramtable.Get().Reset(paramtable.Get().CommonCfg.StorageType.Key)
-	initcore.CleanArrowFileSystemSingleton()
+	initcore.CleanArrowFileSystem()
 }
 
 func (s *NamespaceCompactorTestSuite) setupSortedSegments() {

--- a/internal/datanode/compactor/sort_compaction_test.go
+++ b/internal/datanode/compactor/sort_compaction_test.go
@@ -105,7 +105,7 @@ func (s *SortCompactionTaskSuite) TearDownTest() {
 	paramtable.Get().Reset(paramtable.Get().CommonCfg.StorageType.Key)
 	paramtable.Get().Reset(paramtable.Get().CommonCfg.UseLoonFFI.Key)
 	paramtable.Get().Reset(paramtable.Get().LocalStorageCfg.Path.Key)
-	initcore.CleanArrowFileSystemSingleton()
+	initcore.CleanArrowFileSystem()
 }
 
 func (s *SortCompactionTaskSuite) TestNewSortCompactionTask() {

--- a/internal/datanode/index/scheduler.go
+++ b/internal/datanode/index/scheduler.go
@@ -255,15 +255,10 @@ func (sched *TaskScheduler) processTask(t Task) {
 	t.SetState(indexpb.JobState_JobStateFinished, "")
 
 	// Publish filesystem metrics after index task completion
-	// Only publish for index build tasks (not stats or analyze tasks)
 	if indexTask, ok := t.(*indexBuildTask); ok {
-		// Extract storage config from task to get the filesystem key
-		var fsKey string
 		if indexTask.req != nil && indexTask.req.GetStorageConfig() != nil {
-			fsKey = storagev2.GetFilesystemKeyFromStorageConfig(indexTask.req.GetStorageConfig())
+			storagev2.PublishFilesystemMetricsWithConfig(indexTask.req.GetStorageConfig())
 		}
-		// If no storage config or empty key, use default filesystem (empty key)
-		storagev2.PublishCachedFilesystemMetrics(fsKey)
 	}
 }
 

--- a/internal/flushcommon/syncmgr/pack_writer_v3_test.go
+++ b/internal/flushcommon/syncmgr/pack_writer_v3_test.go
@@ -71,7 +71,7 @@ func (s *PackWriterV3Suite) SetupTest() {
 	s.ctx = context.Background()
 	s.logIDAlloc = allocator.NewLocalAllocator(1, math.MaxInt64)
 	s.rootPath = s.T().TempDir()
-	initcore.CleanArrowFileSystemSingleton()
+	initcore.CleanArrowFileSystem()
 	initcore.InitLocalArrowFileSystem(s.rootPath)
 	paramtable.Get().Init(paramtable.NewBaseTable())
 	paramtable.Get().Save(paramtable.Get().MinioCfg.RootPath.Key, "/tmp")

--- a/internal/storagev2/filesystem_metrics.go
+++ b/internal/storagev2/filesystem_metrics.go
@@ -28,6 +28,8 @@ import "C"
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 	"unsafe"
 
 	"go.uber.org/zap"
@@ -50,51 +52,15 @@ type FilesystemMetrics struct {
 	MultiPartUploadFinished int64
 }
 
-// GetCachedFilesystemMetrics retrieves metrics from a cached filesystem.
-// If key is empty, returns metrics from the singleton filesystem.
-// If key is provided, looks up the filesystem in the cache by that key.
-// The key format must match what's used by the C++ cache (from ArrowFileSystemConfig::GetCacheKey):
-// - Local storage (type="local"): root_path
-// - Object storage (type="minio", "s3", "aws", "gcp", etc.): address/bucket_name
-func GetCachedFilesystemMetrics(key string) (*FilesystemMetrics, error) {
-	var cFilesystem C.FileSystemHandle
-
-	if key == "" {
-		result := C.loon_get_filesystem_singleton_handle(&cFilesystem)
-		if err := HandleLoonFFIResult(result); err != nil {
-			return nil, fmt.Errorf("failed to get filesystem singleton: %w", err)
-		}
-	} else {
-		cKey := C.CString(key)
-		defer C.free(unsafe.Pointer(cKey))
-		keyLen := C.uint32_t(len(key))
-
-		// Create an empty properties struct - this is a cache lookup only
-		var properties C.LoonProperties
-		properties.properties = nil
-		properties.count = 0
-
-		result := C.loon_filesystem_get(&properties, cKey, keyLen, &cFilesystem)
-		if err := HandleLoonFFIResult(result); err != nil {
-			return nil, fmt.Errorf("failed to get cached filesystem for key %q: %w", key, err)
-		}
-	}
-
-	return getMetricsFromHandle(cFilesystem)
-}
-
 // getMetricsFromHandle retrieves metrics from a filesystem handle
 func getMetricsFromHandle(cFilesystem C.FileSystemHandle) (*FilesystemMetrics, error) {
-	// Get metrics from the filesystem
 	var cMetrics C.LoonFilesystemMetricsSnapshot
 	metricsResult := C.loon_filesystem_get_metrics(cFilesystem, &cMetrics)
 	if err := HandleLoonFFIResult(metricsResult); err != nil {
-		// Clean up filesystem handle
 		C.loon_filesystem_destroy(cFilesystem)
 		return nil, fmt.Errorf("failed to get filesystem metrics: %w", err)
 	}
 
-	// Extract the 8 metrics from C struct
 	fsMetrics := &FilesystemMetrics{
 		ReadCount:               int64(cMetrics.read_count),
 		WriteCount:              int64(cMetrics.write_count),
@@ -106,10 +72,162 @@ func getMetricsFromHandle(cFilesystem C.FileSystemHandle) (*FilesystemMetrics, e
 		MultiPartUploadFinished: int64(cMetrics.multi_part_upload_finished),
 	}
 
-	// Clean up C resources
 	C.loon_filesystem_destroy(cFilesystem)
-
 	return fsMetrics, nil
+}
+
+// Property keys matching milvus-storage/properties.h.
+// Duplicated from packed.PropertyFS* because cgo types are package-scoped.
+const (
+	propAddress             = "fs.address"
+	propBucketName          = "fs.bucket_name"
+	propAccessKeyID         = "fs.access_key_id"
+	propAccessKeyValue      = "fs.access_key_value"
+	propRootPath            = "fs.root_path"
+	propStorageType         = "fs.storage_type"
+	propCloudProvider       = "fs.cloud_provider"
+	propIAMEndpoint         = "fs.iam_endpoint"
+	propLogLevel            = "fs.log_level"
+	propRegion              = "fs.region"
+	propSSLCACert           = "fs.ssl_ca_cert"
+	propGCPCredentialJSON   = "fs.gcp_credential_json"
+	propUseSSL              = "fs.use_ssl"
+	propUseIAM              = "fs.use_iam"
+	propUseVirtualHost      = "fs.use_virtual_host"
+	propUseCustomPartUpload = "fs.use_custom_part_upload"
+	propRequestTimeoutMS    = "fs.request_timeout_ms"
+	propTLSMinVersion       = "fs.tls_min_version"
+	propUseCRC32CChecksum   = "fs.use_crc32c_checksum"
+)
+
+// makePropertiesFromConfig builds C.LoonProperties from a StorageConfig.
+// Mirrors packed.MakePropertiesFromStorageConfig (cgo types not shareable across packages).
+func makePropertiesFromConfig(storageConfig *indexpb.StorageConfig) (C.LoonProperties, error) {
+	var keys []string
+	var values []string
+
+	if addr := storageConfig.GetAddress(); addr != "" {
+		if !storageConfig.GetUseSSL() && !strings.Contains(addr, "://") {
+			addr = "http://" + addr
+		}
+		keys = append(keys, propAddress)
+		values = append(values, addr)
+	}
+	if v := storageConfig.GetBucketName(); v != "" {
+		keys = append(keys, propBucketName)
+		values = append(values, v)
+	}
+	if v := storageConfig.GetAccessKeyID(); v != "" {
+		keys = append(keys, propAccessKeyID)
+		values = append(values, v)
+	}
+	if v := storageConfig.GetSecretAccessKey(); v != "" {
+		keys = append(keys, propAccessKeyValue)
+		values = append(values, v)
+	}
+	if v := storageConfig.GetRootPath(); v != "" {
+		keys = append(keys, propRootPath)
+		values = append(values, v)
+	}
+	if v := storageConfig.GetStorageType(); v != "" {
+		keys = append(keys, propStorageType)
+		values = append(values, v)
+	}
+	if v := storageConfig.GetCloudProvider(); v != "" {
+		keys = append(keys, propCloudProvider)
+		values = append(values, v)
+	}
+	if v := storageConfig.GetIAMEndpoint(); v != "" {
+		keys = append(keys, propIAMEndpoint)
+		values = append(values, v)
+	}
+	keys = append(keys, propLogLevel)
+	values = append(values, "warn")
+	if v := storageConfig.GetRegion(); v != "" {
+		keys = append(keys, propRegion)
+		values = append(values, v)
+	}
+	if v := storageConfig.GetSslCACert(); v != "" {
+		keys = append(keys, propSSLCACert)
+		values = append(values, v)
+	}
+	if v := storageConfig.GetGcpCredentialJSON(); v != "" {
+		keys = append(keys, propGCPCredentialJSON)
+		values = append(values, v)
+	}
+
+	keys = append(keys, propUseSSL)
+	values = append(values, strconv.FormatBool(storageConfig.GetUseSSL()))
+	keys = append(keys, propUseIAM)
+	values = append(values, strconv.FormatBool(storageConfig.GetUseIAM()))
+	keys = append(keys, propUseVirtualHost)
+	values = append(values, strconv.FormatBool(storageConfig.GetUseVirtualHost()))
+	keys = append(keys, propUseCustomPartUpload)
+	values = append(values, "true")
+
+	keys = append(keys, propRequestTimeoutMS)
+	values = append(values, strconv.FormatInt(storageConfig.GetRequestTimeoutMs(), 10))
+
+	if v := storageConfig.GetSslTlsMinVersion(); v != "" && v != "default" {
+		keys = append(keys, propTLSMinVersion)
+		values = append(values, v)
+	}
+	keys = append(keys, propUseCRC32CChecksum)
+	values = append(values, strconv.FormatBool(storageConfig.GetUseCrc32CChecksum()))
+
+	count := len(keys)
+	if count == 0 {
+		return C.LoonProperties{}, nil
+	}
+
+	cKeys := make([]*C.char, count)
+	cValues := make([]*C.char, count)
+	for i := 0; i < count; i++ {
+		cKeys[i] = C.CString(keys[i])
+		cValues[i] = C.CString(values[i])
+	}
+	defer func() {
+		for i := 0; i < count; i++ {
+			C.free(unsafe.Pointer(cKeys[i]))
+			C.free(unsafe.Pointer(cValues[i]))
+		}
+	}()
+
+	var props C.LoonProperties
+	result := C.loon_properties_create(
+		(**C.char)(unsafe.Pointer(&cKeys[0])),
+		(**C.char)(unsafe.Pointer(&cValues[0])),
+		C.size_t(count),
+		&props,
+	)
+
+	if err := HandleLoonFFIResult(result); err != nil {
+		return C.LoonProperties{}, fmt.Errorf("failed to create properties: %w", err)
+	}
+
+	return props, nil
+}
+
+// GetFilesystemMetricsWithConfig retrieves metrics from a cached filesystem
+// using full storage config properties for proper cache resolution.
+func GetFilesystemMetricsWithConfig(storageConfig *indexpb.StorageConfig) (*FilesystemMetrics, error) {
+	if storageConfig == nil {
+		return nil, fmt.Errorf("storageConfig is required")
+	}
+
+	props, err := makePropertiesFromConfig(storageConfig)
+	if err != nil {
+		return nil, err
+	}
+	defer C.loon_properties_free(&props)
+
+	var cFilesystem C.FileSystemHandle
+	result := C.loon_filesystem_get(&props, nil, 0, &cFilesystem)
+	if err := HandleLoonFFIResult(result); err != nil {
+		return nil, fmt.Errorf("failed to get cached filesystem: %w", err)
+	}
+
+	return getMetricsFromHandle(cFilesystem)
 }
 
 // HandleLoonFFIResult handles the result from loon FFI calls
@@ -127,9 +245,6 @@ func HandleLoonFFIResult(ffiResult C.LoonFFIResult) error {
 }
 
 // GetFilesystemKeyFromStorageConfig extracts filesystem cache key from StorageConfig.
-// Must match the key format used by C++ ArrowFileSystemConfig::GetCacheKey():
-// - Local storage (type="local"): root_path
-// - Object storage (type="minio", "s3", "aws", "gcp", etc.): address/bucket_name
 func GetFilesystemKeyFromStorageConfig(storageConfig *indexpb.StorageConfig) string {
 	if storageConfig == nil {
 		return ""
@@ -140,7 +255,6 @@ func GetFilesystemKeyFromStorageConfig(storageConfig *indexpb.StorageConfig) str
 		return storageConfig.GetRootPath()
 	}
 
-	// Object storage (minio, s3, aws, gcp, etc.)
 	address := storageConfig.GetAddress()
 	bucketName := storageConfig.GetBucketName()
 	if address == "" || bucketName == "" {
@@ -150,21 +264,16 @@ func GetFilesystemKeyFromStorageConfig(storageConfig *indexpb.StorageConfig) str
 }
 
 // PublishDefaultFilesystemMetrics retrieves and publishes metrics from the default filesystem.
-// It builds a StorageConfig using the same logic as compaction.CreateStorageConfig() to ensure
-// the cache key matches the filesystem used by compaction and other components.
 func PublishDefaultFilesystemMetrics() (*FilesystemMetrics, error) {
-	// Build storage config matching compaction.CreateStorageConfig() logic
 	params := paramtable.Get()
 	var storageConfig *indexpb.StorageConfig
 
 	if params.CommonCfg.StorageType.GetValue() == "local" {
-		// For local storage, use LocalStorageCfg.Path as RootPath (same as compaction.CreateStorageConfig)
 		storageConfig = &indexpb.StorageConfig{
 			RootPath:    params.LocalStorageCfg.Path.GetValue(),
 			StorageType: params.CommonCfg.StorageType.GetValue(),
 		}
 	} else {
-		// For remote storage, use full MinioCfg (same as compaction.CreateStorageConfig)
 		storageConfig = &indexpb.StorageConfig{
 			Address:           params.MinioCfg.Address.GetValue(),
 			AccessKeyID:       params.MinioCfg.AccessKeyID.GetValue(),
@@ -190,19 +299,13 @@ func PublishDefaultFilesystemMetrics() (*FilesystemMetrics, error) {
 
 // PublishFilesystemMetricsWithConfig retrieves and publishes filesystem metrics using storage config.
 func PublishFilesystemMetricsWithConfig(storageConfig *indexpb.StorageConfig) (*FilesystemMetrics, error) {
-	key := GetFilesystemKeyFromStorageConfig(storageConfig)
-	return PublishCachedFilesystemMetrics(key)
-}
-
-// PublishCachedFilesystemMetrics retrieves and publishes metrics from a cached filesystem.
-func PublishCachedFilesystemMetrics(key string) (*FilesystemMetrics, error) {
-	metricSnapshot, err := GetCachedFilesystemMetrics(key)
+	metricSnapshot, err := GetFilesystemMetricsWithConfig(storageConfig)
 	if err != nil {
-		log.Warn("failed to get cached filesystem metrics", zap.String("key", key), zap.Error(err))
+		log.Warn("failed to get filesystem metrics with config", zap.Error(err))
 		return nil, err
 	}
 
-	fsKey := key
+	fsKey := GetFilesystemKeyFromStorageConfig(storageConfig)
 	if fsKey == "" {
 		fsKey = "default"
 	}
@@ -217,6 +320,5 @@ func PublishCachedFilesystemMetrics(key string) (*FilesystemMetrics, error) {
 		metricSnapshot.MultiPartUploadCreated,
 		metricSnapshot.MultiPartUploadFinished,
 	)
-
 	return metricSnapshot, nil
 }

--- a/internal/storagev2/filesystem_metrics_test.go
+++ b/internal/storagev2/filesystem_metrics_test.go
@@ -166,9 +166,8 @@ func TestGetFilesystemKeyFromStorageConfigWithOtherFields(t *testing.T) {
 	assert.Equal(t, "/var/lib/milvus/data", result)
 }
 
-// TestGetCachedFilesystemMetricsDefault tests GetCachedFilesystemMetrics with empty key (default filesystem)
-func TestGetCachedFilesystemMetricsDefault(t *testing.T) {
-	// Set up local storage for testing
+// TestGetFilesystemMetricsWithConfig tests GetFilesystemMetricsWithConfig with local storage
+func TestGetFilesystemMetricsWithConfig(t *testing.T) {
 	dir := t.TempDir()
 	pt := paramtable.Get()
 	pt.Save(pt.CommonCfg.StorageType.Key, "local")
@@ -179,22 +178,20 @@ func TestGetCachedFilesystemMetricsDefault(t *testing.T) {
 		pt.Reset(pt.LocalStorageCfg.Path.Key)
 	})
 
-	// Initialize local arrow filesystem
 	err := initcore.InitLocalArrowFileSystem(dir)
 	require.NoError(t, err, "Failed to initialize local arrow filesystem")
 
-	// Test getting metrics from default filesystem (empty key)
-	metrics, err := GetCachedFilesystemMetrics("")
+	localConfig := &indexpb.StorageConfig{
+		StorageType: "local",
+		RootPath:    dir,
+	}
+	metrics, err := GetFilesystemMetricsWithConfig(localConfig)
 	if err != nil {
-		// If CGO libraries aren't available, skip the test
 		t.Skipf("Skipping CGO test: %v", err)
 		return
 	}
 
-	// Verify metrics struct is not nil
 	require.NotNil(t, metrics, "Metrics should not be nil")
-
-	// Verify all 8 metrics fields are present (values may be 0 or positive)
 	assert.GreaterOrEqual(t, metrics.ReadCount, int64(0))
 	assert.GreaterOrEqual(t, metrics.WriteCount, int64(0))
 	assert.GreaterOrEqual(t, metrics.ReadBytes, int64(0))
@@ -205,9 +202,8 @@ func TestGetCachedFilesystemMetricsDefault(t *testing.T) {
 	assert.GreaterOrEqual(t, metrics.MultiPartUploadFinished, int64(0))
 }
 
-// TestPublishCachedFilesystemMetrics tests PublishCachedFilesystemMetrics function
-func TestPublishCachedFilesystemMetrics(t *testing.T) {
-	// Set up local storage for testing
+// TestPublishFilesystemMetricsWithLocalConfig tests PublishFilesystemMetricsWithConfig
+func TestPublishFilesystemMetricsWithLocalConfig(t *testing.T) {
 	dir := t.TempDir()
 	pt := paramtable.Get()
 	pt.Save(pt.CommonCfg.StorageType.Key, "local")
@@ -218,22 +214,20 @@ func TestPublishCachedFilesystemMetrics(t *testing.T) {
 		pt.Reset(pt.LocalStorageCfg.Path.Key)
 	})
 
-	// Initialize local arrow filesystem
 	err := initcore.InitLocalArrowFileSystem(dir)
 	require.NoError(t, err, "Failed to initialize local arrow filesystem")
 
-	// Test with empty key (default filesystem)
-	metrics, err := PublishCachedFilesystemMetrics("")
+	localConfig := &indexpb.StorageConfig{
+		StorageType: "local",
+		RootPath:    dir,
+	}
+	metrics, err := PublishFilesystemMetricsWithConfig(localConfig)
 	if err != nil {
-		// If CGO libraries aren't available, skip the test
 		t.Skipf("Skipping CGO test: %v", err)
 		return
 	}
 
-	// Verify metrics struct is not nil
 	require.NotNil(t, metrics, "Metrics should not be nil")
-
-	// Verify all 8 metrics fields are present
 	assert.GreaterOrEqual(t, metrics.ReadCount, int64(0))
 	assert.GreaterOrEqual(t, metrics.WriteCount, int64(0))
 	assert.GreaterOrEqual(t, metrics.ReadBytes, int64(0))
@@ -284,29 +278,6 @@ func TestPublishFilesystemMetricsWithConfig(t *testing.T) {
 	assert.GreaterOrEqual(t, metrics.MultiPartUploadFinished, int64(0))
 }
 
-// TestPublishFilesystemMetricsWithNilConfig tests PublishFilesystemMetricsWithConfig with nil config
-func TestPublishFilesystemMetricsWithNilConfig(t *testing.T) {
-	// Set up local storage for testing
-	dir := t.TempDir()
-	pt := paramtable.Get()
-	pt.Save(pt.CommonCfg.StorageType.Key, "local")
-	pt.Save(pt.LocalStorageCfg.Path.Key, dir)
-
-	t.Cleanup(func() {
-		pt.Reset(pt.CommonCfg.StorageType.Key)
-		pt.Reset(pt.LocalStorageCfg.Path.Key)
-	})
-
-	// Initialize local arrow filesystem
-	err := initcore.InitLocalArrowFileSystem(dir)
-	require.NoError(t, err, "Failed to initialize local arrow filesystem")
-
-	// Test with nil config - should use empty key (default filesystem)
-	metrics, err := PublishFilesystemMetricsWithConfig(nil)
-	assert.NoError(t, err)
-	assert.NotNil(t, metrics, "Metrics should not be nil")
-}
-
 // TestPublishDefaultFilesystemMetrics tests PublishDefaultFilesystemMetrics function
 func TestPublishDefaultFilesystemMetrics(t *testing.T) {
 	// Set up local storage for testing
@@ -330,29 +301,12 @@ func TestPublishDefaultFilesystemMetrics(t *testing.T) {
 	assert.NotNil(t, metrics, "Metrics should not be nil")
 }
 
-// TestGetCachedFilesystemMetricsWithInvalidKey tests error handling for non-existent cache key
-func TestInvalidKey(t *testing.T) {
-	// Set up local storage for testing
-	dir := t.TempDir()
-	pt := paramtable.Get()
-	pt.Save(pt.CommonCfg.StorageType.Key, "local")
-	pt.Save(pt.LocalStorageCfg.Path.Key, dir)
-
-	t.Cleanup(func() {
-		pt.Reset(pt.CommonCfg.StorageType.Key)
-		pt.Reset(pt.LocalStorageCfg.Path.Key)
-	})
-
-	// Initialize local arrow filesystem
-	err := initcore.InitLocalArrowFileSystem(dir)
-	require.NoError(t, err, "Failed to initialize local arrow filesystem")
-
-	// Test with a key that doesn't exist in cache
-	// FIXME: FilesystemCache::get from milvus-storage will return default filesystem if the key is not in cache and path is schemeless.
-	_, err = GetCachedFilesystemMetrics("s3://non-existent-key")
+// TestNilConfig tests error handling for nil config
+func TestNilConfig(t *testing.T) {
+	_, err := GetFilesystemMetricsWithConfig(nil)
 	assert.Error(t, err)
 
-	_, err = PublishCachedFilesystemMetrics("s3://non-existent-key")
+	_, err = PublishFilesystemMetricsWithConfig(nil)
 	assert.Error(t, err)
 }
 

--- a/internal/storagev2/packed/packed_test.go
+++ b/internal/storagev2/packed/packed_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/milvus-io/milvus/internal/storagecommon"
 	"github.com/milvus-io/milvus/internal/storagev2"
 	"github.com/milvus-io/milvus/internal/util/initcore"
+	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -242,11 +243,14 @@ func (suite *PackedTestSuite) TestCloseAndTellMultiGroups() {
 }
 
 func (suite *PackedTestSuite) TestFilesystemMetrics() {
-	// Get baseline metrics
-	beforeMetrics, err := storagev2.GetCachedFilesystemMetrics("")
+	localConfig := &indexpb.StorageConfig{
+		StorageType: "local",
+		RootPath:    "/tmp",
+	}
+
+	beforeMetrics, err := storagev2.GetFilesystemMetricsWithConfig(localConfig)
 	suite.NoError(err)
 
-	// Write data
 	paths := []string{"/tmp/metrics_test"}
 	columnGroups := []storagecommon.ColumnGroup{{Columns: []int{0, 1, 2}, GroupID: storagecommon.DefaultShortColumnGroupID}}
 	pw, err := NewPackedWriter(paths, suite.schema, 10*1024*1024, 0, columnGroups, nil, nil)
@@ -258,20 +262,17 @@ func (suite *PackedTestSuite) TestFilesystemMetrics() {
 	err = pw.Close()
 	suite.NoError(err)
 
-	// Verify write metrics increased
-	afterWrite, err := storagev2.GetCachedFilesystemMetrics("")
+	afterWrite, err := storagev2.GetFilesystemMetricsWithConfig(localConfig)
 	suite.NoError(err)
 	suite.Greater(afterWrite.WriteBytes, beforeMetrics.WriteBytes, "write bytes should increase")
 
-	// Read data back
 	reader, err := NewPackedReader(paths, suite.schema, 10*1024*1024, nil, nil)
 	suite.NoError(err)
 	rr, err := reader.ReadNext()
 	suite.NoError(err)
 	rr.Release()
 
-	// Verify read metrics increased
-	afterRead, err := storagev2.GetCachedFilesystemMetrics("")
+	afterRead, err := storagev2.GetFilesystemMetricsWithConfig(localConfig)
 	suite.NoError(err)
 	suite.Greater(afterRead.ReadBytes, afterWrite.ReadBytes, "read bytes should increase")
 }

--- a/internal/util/initcore/init_core.go
+++ b/internal/util/initcore/init_core.go
@@ -155,10 +155,16 @@ func InitStorageV2FileSystem(params *paramtable.ComponentParam) error {
 }
 
 func InitLocalArrowFileSystem(path string) error {
-	CLocalRootPath := C.CString(path)
-	defer C.free(unsafe.Pointer(CLocalRootPath))
-	status := C.InitLocalArrowFileSystemSingleton(CLocalRootPath)
-	return HandleCStatus(&status, "InitLocalArrowFileSystemSingleton failed")
+	cRootPath := C.CString(path)
+	cStorageType := C.CString("local")
+	defer C.free(unsafe.Pointer(cRootPath))
+	defer C.free(unsafe.Pointer(cStorageType))
+	storageConfig := C.CStorageConfig{
+		root_path:    cRootPath,
+		storage_type: cStorageType,
+	}
+	status := C.InitArrowFileSystem(storageConfig)
+	return HandleCStatus(&status, "InitArrowFileSystem failed")
 }
 
 func InitRemoteArrowFileSystem(params *paramtable.ComponentParam) error {
@@ -211,8 +217,8 @@ func InitRemoteArrowFileSystem(params *paramtable.ComponentParam) error {
 		use_crc32c_checksum:    C.bool(params.MinioCfg.UseCRC32C.GetAsBool()),
 	}
 
-	status := C.InitRemoteArrowFileSystemSingleton(storageConfig)
-	return HandleCStatus(&status, "InitRemoteArrowFileSystemSingleton failed")
+	status := C.InitArrowFileSystem(storageConfig)
+	return HandleCStatus(&status, "InitArrowFileSystem failed")
 }
 
 func InitRemoteChunkManager(params *paramtable.ComponentParam) error {

--- a/internal/util/initcore/test_util.go
+++ b/internal/util/initcore/test_util.go
@@ -30,7 +30,7 @@ package initcore
 */
 import "C"
 
-// CleanArrowFileSystemSingleton is an utility clean internal segcore fs singleton
-func CleanArrowFileSystemSingleton() {
-	C.CleanArrowFileSystemSingleton()
+// CleanArrowFileSystem cleans the filesystem cache
+func CleanArrowFileSystem() {
+	C.CleanArrowFileSystem()
 }


### PR DESCRIPTION
pr: #49521

Cherry-pick of #49521 to 3.0 branch.

Eliminate ArrowFileSystemSingleton from milvus so all filesystem access
goes through FilesystemCache. This unifies I/O metrics across C++ segcore
and Go FFI paths, fixing the issue where metrics showed all zeros for
the default filesystem because I/O went through the singleton while
metrics were read from the cache (a different FS instance).