### PR TITLE
enhance: Expose Arrow reader config

### DIFF
--- a/internal/core/src/common/type_c.h
+++ b/internal/core/src/common/type_c.h
@@ -112,6 +112,11 @@ typedef struct CDiskWriteConfig {
     CDiskWriteRateLimiterConfig rate_limiter_config;
 } CDiskWriteConfig;
 
+typedef struct CArrowReaderConfig {
+    int64_t hole_size_limit_bytes;
+    int64_t range_size_limit_bytes;
+} CArrowReaderConfig;
+
 typedef struct CMmapConfig {
     const char* cache_read_ahead_policy;
     const char* mmap_path;

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -868,7 +868,8 @@ LoadGroupChunkMetadata(const std::vector<std::string>& insert_files,
                 fs,
                 file,
                 milvus_storage::DEFAULT_READ_BUFFER_SIZE,
-                storage::GetReaderProperties());
+                storage::GetReaderProperties(),
+                storage::GetArrowReaderProperties());
             AssertInfo(result.ok(),
                        "[StorageV2] Failed to create file row group reader: " +
                            result.status().ToString());

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -910,7 +910,8 @@ SegmentGrowingImpl::load_column_group_data_internal(
                 fs,
                 file,
                 milvus_storage::DEFAULT_READ_BUFFER_SIZE,
-                storage::GetReaderProperties());
+                storage::GetReaderProperties(),
+                storage::GetArrowReaderProperties());
             AssertInfo(result.ok(),
                        "[StorageV2] Failed to create file row group reader: " +
                            result.status().ToString());

--- a/internal/core/src/segcore/memory_planner.cpp
+++ b/internal/core/src/segcore/memory_planner.cpp
@@ -198,7 +198,8 @@ LoadWithStrategy(const std::vector<std::string>& remote_files,
                             file,
                             schema,
                             reader_memory_limit,
-                            milvus::storage::GetReaderProperties());
+                            milvus::storage::GetReaderProperties(),
+                            milvus::storage::GetArrowReaderProperties());
                         AssertInfo(
                             result.ok(),
                             "[StorageV2] Failed to create row group reader: {}",
@@ -409,7 +410,8 @@ MakeFileReaderFactory(std::vector<std::string> remote_files,
                                   (*files)[batch_key],
                                   nullptr,
                                   reader_memory_limit,
-                                  milvus::storage::GetReaderProperties()));
+                                  milvus::storage::GetReaderProperties(),
+                                  milvus::storage::GetArrowReaderProperties()));
         auto close_guard =
             folly::makeGuard([&reader]() { (void)reader->Close(); });
         ARROW_RETURN_NOT_OK(

--- a/internal/core/src/segcore/packed_reader_c.cpp
+++ b/internal/core/src/segcore/packed_reader_c.cpp
@@ -92,7 +92,8 @@ NewPackedReaderWithStorageConfig(char** paths,
             truePaths,
             trueSchema,
             buffer_size,
-            milvus::storage::GetReaderProperties());
+            milvus::storage::GetReaderProperties(),
+            milvus::storage::GetArrowReaderProperties());
         *c_packed_reader = reader.release();
         return milvus::SuccessCStatus();
     } catch (std::exception& e) {
@@ -132,7 +133,8 @@ NewPackedReader(char** paths,
             truePaths,
             trueSchema,
             buffer_size,
-            milvus::storage::GetReaderProperties());
+            milvus::storage::GetReaderProperties(),
+            milvus::storage::GetArrowReaderProperties());
         *c_packed_reader = reader.release();
         return milvus::SuccessCStatus();
     } catch (std::exception& e) {

--- a/internal/core/src/storage/KeyRetriever.cpp
+++ b/internal/core/src/storage/KeyRetriever.cpp
@@ -3,8 +3,10 @@
 #include <cstdlib>
 #include <cstring>
 #include <exception>
+#include <mutex>
 
 #include "PluginInterface.h"
+#include "arrow/io/caching.h"
 #include "common/EasyAssert.h"
 #include "fmt/format.h"
 #include "glog/logging.h"
@@ -13,6 +15,11 @@
 #include "storage/PluginLoader.h"
 
 namespace milvus::storage {
+namespace {
+std::mutex arrow_reader_properties_mutex;
+parquet::ArrowReaderProperties arrow_reader_properties =
+    parquet::default_arrow_reader_properties();
+}  // namespace
 
 std::string
 KeyRetriever::GetKey(const std::string& key_metadata) {
@@ -37,6 +44,34 @@ GetReaderProperties() {
             ->plaintext_files_allowed()
             ->build());
     return reader_properties;
+}
+
+parquet::ArrowReaderProperties
+GetArrowReaderProperties() {
+    std::lock_guard<std::mutex> lock(arrow_reader_properties_mutex);
+    return arrow_reader_properties;
+}
+
+void
+ConfigureArrowReaderProperties(int64_t hole_size_limit_bytes,
+                               int64_t range_size_limit_bytes) {
+    auto properties = parquet::default_arrow_reader_properties();
+    auto cache_options = properties.cache_options();
+    if (hole_size_limit_bytes > 0) {
+        cache_options.hole_size_limit = hole_size_limit_bytes;
+    }
+    if (range_size_limit_bytes > 0) {
+        cache_options.range_size_limit = range_size_limit_bytes;
+    }
+    AssertInfo(cache_options.range_size_limit > cache_options.hole_size_limit,
+               "arrow reader range size limit must be greater than hole size "
+               "limit, range_size_limit={}, hole_size_limit={}",
+               cache_options.range_size_limit,
+               cache_options.hole_size_limit);
+    properties.set_cache_options(cache_options);
+
+    std::lock_guard<std::mutex> lock(arrow_reader_properties_mutex);
+    arrow_reader_properties = properties;
 }
 
 std::string

--- a/internal/core/src/storage/KeyRetriever.h
+++ b/internal/core/src/storage/KeyRetriever.h
@@ -11,6 +11,7 @@
 
 #include "common/type_c.h"
 #include "parquet/encryption/encryption.h"
+#include "parquet/properties.h"
 
 namespace milvus::storage {
 
@@ -22,6 +23,13 @@ class KeyRetriever : public parquet::DecryptionKeyRetriever {
 
 parquet::ReaderProperties
 GetReaderProperties();
+
+parquet::ArrowReaderProperties
+GetArrowReaderProperties();
+
+void
+ConfigureArrowReaderProperties(int64_t hole_size_limit_bytes,
+                               int64_t range_size_limit_bytes);
 
 std::string
 EncodeKeyMetadata(int64_t ez_id, int64_t collection_id, std::string key);

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -1451,7 +1451,8 @@ GetFieldDatasFromStorageV2(std::vector<std::vector<std::string>>& remote_files,
             fs,
             column_group_file,
             milvus_storage::DEFAULT_READ_BUFFER_SIZE,
-            GetReaderProperties());
+            GetReaderProperties(),
+            GetArrowReaderProperties());
         AssertInfo(result.ok(),
                    "[StorageV2] Failed to create file row group reader: " +
                        result.status().ToString());
@@ -1699,7 +1700,8 @@ GetFieldIDList(FieldId column_group_id,
         filepath,
         arrow_schema,
         milvus_storage::DEFAULT_READ_BUFFER_SIZE,
-        GetReaderProperties());
+        GetReaderProperties(),
+        GetArrowReaderProperties());
     AssertInfo(result.ok(),
                "[StorageV2] Failed to create file row group reader: " +
                    result.status().ToString());

--- a/internal/core/src/storage/loon_ffi/property_singleton.h
+++ b/internal/core/src/storage/loon_ffi/property_singleton.h
@@ -14,9 +14,12 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
+#include <string>
+#include <utility>
 
 #include "common/type_c.h"
 #include "milvus-storage/properties.h"
@@ -42,6 +45,7 @@ class LoonFFIPropertiesSingleton {
         if (properties_ == nullptr) {
             properties_ =
                 MakeInternalPropertiesFromStorageConfig(c_storage_config);
+            ApplyArrowReaderConfig(*properties_);
         }
     }
 
@@ -51,6 +55,21 @@ class LoonFFIPropertiesSingleton {
 
         if (properties_ == nullptr) {
             properties_ = MakeInternalLocalProperies(root_path);
+            ApplyArrowReaderConfig(*properties_);
+        }
+    }
+
+    void
+    SetArrowReaderConfig(int64_t hole_size_limit_bytes,
+                         int64_t range_size_limit_bytes) {
+        std::unique_lock lck(mutex_);
+        arrow_reader_hole_size_limit_bytes_ = hole_size_limit_bytes;
+        arrow_reader_range_size_limit_bytes_ = range_size_limit_bytes;
+        if (properties_ != nullptr) {
+            auto properties =
+                std::make_shared<milvus_storage::api::Properties>(*properties_);
+            ApplyArrowReaderConfig(*properties);
+            properties_ = std::move(properties);
         }
     }
 
@@ -61,8 +80,22 @@ class LoonFFIPropertiesSingleton {
     }
 
  private:
+    void
+    ApplyArrowReaderConfig(milvus_storage::api::Properties& properties) const {
+        milvus_storage::api::SetValue(
+            properties,
+            PROPERTY_READER_PARQUET_PREBUFFER_HOLE_SIZE_LIMIT,
+            std::to_string(arrow_reader_hole_size_limit_bytes_).c_str());
+        milvus_storage::api::SetValue(
+            properties,
+            PROPERTY_READER_PARQUET_PREBUFFER_RANGE_SIZE_LIMIT,
+            std::to_string(arrow_reader_range_size_limit_bytes_).c_str());
+    }
+
     mutable std::shared_mutex mutex_;
     std::shared_ptr<milvus_storage::api::Properties> properties_ = nullptr;
+    int64_t arrow_reader_hole_size_limit_bytes_ = 0;
+    int64_t arrow_reader_range_size_limit_bytes_ = 0;
 };
 
 }  // namespace milvus::storage

--- a/internal/core/src/storage/storage_c.cpp
+++ b/internal/core/src/storage/storage_c.cpp
@@ -30,7 +30,9 @@
 #include "storage/PluginLoader.h"
 #include "storage/RemoteChunkManagerSingleton.h"
 #include "storage/ThreadPools.h"
+#include "storage/KeyRetriever.h"
 #include "storage/Types.h"
+#include "storage/loon_ffi/property_singleton.h"
 
 CStatus
 GetLocalUsedSize(const char* c_dir, int64_t* size) {
@@ -166,6 +168,31 @@ InitDiskFileWriterConfig(CDiskWriteConfig c_disk_write_config) {
             c_disk_write_config.rate_limiter_config.high_priority_ratio,
             c_disk_write_config.rate_limiter_config.middle_priority_ratio,
             c_disk_write_config.rate_limiter_config.low_priority_ratio);
+        return milvus::SuccessCStatus();
+    } catch (std::exception& e) {
+        return milvus::FailureCStatus(&e);
+    }
+}
+
+CStatus
+InitArrowReaderConfig(CArrowReaderConfig c_arrow_reader_config) {
+    try {
+        if (c_arrow_reader_config.hole_size_limit_bytes < 0) {
+            return milvus::FailureCStatus(
+                milvus::ConfigInvalid,
+                "arrow reader hole size limit must be non-negative");
+        }
+        if (c_arrow_reader_config.range_size_limit_bytes < 0) {
+            return milvus::FailureCStatus(
+                milvus::ConfigInvalid,
+                "arrow reader range size limit must be non-negative");
+        }
+        milvus::storage::ConfigureArrowReaderProperties(
+            c_arrow_reader_config.hole_size_limit_bytes,
+            c_arrow_reader_config.range_size_limit_bytes);
+        milvus::storage::LoonFFIPropertiesSingleton::GetInstance()
+            .SetArrowReaderConfig(c_arrow_reader_config.hole_size_limit_bytes,
+                                  c_arrow_reader_config.range_size_limit_bytes);
         return milvus::SuccessCStatus();
     } catch (std::exception& e) {
         return milvus::FailureCStatus(&e);

--- a/internal/core/src/storage/storage_c.h
+++ b/internal/core/src/storage/storage_c.h
@@ -45,6 +45,9 @@ ResizeTheadPool(int64_t priority, float ratio);
 CStatus
 InitDiskFileWriterConfig(CDiskWriteConfig c_disk_write_config);
 
+CStatus
+InitArrowReaderConfig(CArrowReaderConfig c_arrow_reader_config);
+
 // Plugin related APIs
 CStatus
 InitPluginLoader(const char* plugin_path);

--- a/internal/core/unittest/test_storage.cpp
+++ b/internal/core/unittest/test_storage.cpp
@@ -13,6 +13,7 @@
 #include <boost/filesystem/path.hpp>
 #include <gtest/gtest.h>
 #include <chrono>
+#include <cstdlib>
 #include <cstdint>
 #include <iosfwd>
 #include <memory>
@@ -27,11 +28,13 @@
 #include "gtest/gtest.h"
 #include "storage/ChunkManager.h"
 #include "storage/FileManager.h"
+#include "storage/KeyRetriever.h"
 #include "storage/LocalChunkManager.h"
 #include "storage/LocalChunkManagerSingleton.h"
 #include "storage/RemoteChunkManagerSingleton.h"
 #include "storage/Types.h"
 #include "storage/Util.h"
+#include "storage/loon_ffi/property_singleton.h"
 #include "storage/storage_c.h"
 #include "test_utils/Constants.h"
 
@@ -40,6 +43,14 @@ using namespace milvus;
 using namespace milvus::storage;
 
 string bucketName = "a-bucket";
+
+void
+FreeErrorStatus(CStatus& status) {
+    if (status.error_msg != nullptr && status.error_msg[0] != '\0') {
+        free(const_cast<char*>(status.error_msg));
+        status.error_msg = nullptr;
+    }
+}
 
 CStorageConfig
 get_azure_storage_config() {
@@ -121,6 +132,50 @@ TEST_F(StorageTest, InitRemoteChunkManagerSingleton) {
 
 TEST_F(StorageTest, CleanRemoteChunkManagerSingleton) {
     CleanRemoteChunkManagerSingleton();
+}
+
+TEST_F(StorageTest, InitArrowReaderConfig) {
+    auto default_cache_options =
+        parquet::default_arrow_reader_properties().cache_options();
+
+    auto status = InitArrowReaderConfig(CArrowReaderConfig{-1, 0});
+    EXPECT_EQ(status.error_code, ConfigInvalid);
+    FreeErrorStatus(status);
+    status = InitArrowReaderConfig(CArrowReaderConfig{0, -1});
+    EXPECT_EQ(status.error_code, ConfigInvalid);
+    FreeErrorStatus(status);
+    status = InitArrowReaderConfig(CArrowReaderConfig{64 * 1024, 32 * 1024});
+    EXPECT_NE(status.error_code, Success);
+    FreeErrorStatus(status);
+
+    status =
+        InitArrowReaderConfig(CArrowReaderConfig{32 * 1024, 4 * 1024 * 1024});
+    ASSERT_EQ(status.error_code, Success) << status.error_msg;
+
+    auto cache_options = GetArrowReaderProperties().cache_options();
+    EXPECT_EQ(cache_options.hole_size_limit, 32 * 1024);
+    EXPECT_EQ(cache_options.range_size_limit, 4 * 1024 * 1024);
+
+    auto properties = LoonFFIPropertiesSingleton::GetInstance().GetProperties();
+    ASSERT_NE(properties, nullptr);
+
+    auto hole_size_limit = milvus_storage::api::GetValue<int64_t>(
+        *properties, PROPERTY_READER_PARQUET_PREBUFFER_HOLE_SIZE_LIMIT);
+    ASSERT_TRUE(hole_size_limit.ok()) << hole_size_limit.status().ToString();
+    EXPECT_EQ(hole_size_limit.ValueOrDie(), 32 * 1024);
+
+    auto range_size_limit = milvus_storage::api::GetValue<int64_t>(
+        *properties, PROPERTY_READER_PARQUET_PREBUFFER_RANGE_SIZE_LIMIT);
+    ASSERT_TRUE(range_size_limit.ok()) << range_size_limit.status().ToString();
+    EXPECT_EQ(range_size_limit.ValueOrDie(), 4 * 1024 * 1024);
+
+    status = InitArrowReaderConfig(CArrowReaderConfig{0, 0});
+    ASSERT_EQ(status.error_code, Success) << status.error_msg;
+    cache_options = GetArrowReaderProperties().cache_options();
+    EXPECT_EQ(cache_options.hole_size_limit,
+              default_cache_options.hole_size_limit);
+    EXPECT_EQ(cache_options.range_size_limit,
+              default_cache_options.range_size_limit);
 }
 
 class StorageUtilTest : public testing::Test {

--- a/internal/querynodev2/server.go
+++ b/internal/querynodev2/server.go
@@ -248,6 +248,18 @@ func (node *QueryNode) ReconfigDiskFileWriterParams(evt *config.Event) {
 	}
 }
 
+func (node *QueryNode) ReconfigArrowReaderParams(evt *config.Event) {
+	if evt.HasUpdated {
+		if err := initcore.InitArrowReaderConfig(paramtable.Get()); err != nil {
+			log.Ctx(node.ctx).Warn("QueryNode failed to reconfigure arrow reader params", zap.Error(err))
+			return
+		}
+		log.Ctx(node.ctx).Info("QueryNode reconfig arrow reader params successfully",
+			zap.Int64("holeSizeLimitBytes", paramtable.Get().CommonCfg.ArrowReaderHoleSizeLimitBytes.GetAsInt64()),
+			zap.Int64("rangeSizeLimitBytes", paramtable.Get().CommonCfg.ArrowReaderRangeSizeLimitBytes.GetAsInt64()))
+	}
+}
+
 func (node *QueryNode) RegisterSegcoreConfigWatcher() {
 	pt := paramtable.Get()
 	pt.Watch(pt.CommonCfg.HighPriorityThreadCoreCoefficient.Key,
@@ -304,6 +316,10 @@ func (node *QueryNode) RegisterSegcoreConfigWatcher() {
 			log.Info("queryNode.segcore.storageV2.cellTargetSizeBytes updated",
 				zap.Int64("bytes", newBytes))
 		}))
+	pt.Watch(pt.CommonCfg.ArrowReaderHoleSizeLimitBytes.Key,
+		config.NewHandler(pt.CommonCfg.ArrowReaderHoleSizeLimitBytes.Key, node.ReconfigArrowReaderParams))
+	pt.Watch(pt.CommonCfg.ArrowReaderRangeSizeLimitBytes.Key,
+		config.NewHandler(pt.CommonCfg.ArrowReaderRangeSizeLimitBytes.Key, node.ReconfigArrowReaderParams))
 }
 
 func getIndexEngineVersion() (minimal, current, maximum int32) {

--- a/internal/querynodev2/server_test.go
+++ b/internal/querynodev2/server_test.go
@@ -276,6 +276,8 @@ func TestRegisterSegcoreConfigWatcher(t *testing.T) {
 	pt := paramtable.Get()
 	node := &QueryNode{}
 
+	assert.NotPanics(t, func() { node.ReconfigArrowReaderParams(&config.Event{HasUpdated: false}) })
+	assert.NotPanics(t, func() { node.ReconfigArrowReaderParams(&config.Event{HasUpdated: true}) })
 	assert.NotPanics(t, func() { node.RegisterSegcoreConfigWatcher() })
 
 	// verify watchers are triggered by saving config values
@@ -290,6 +292,12 @@ func TestRegisterSegcoreConfigWatcher(t *testing.T) {
 	})
 	assert.NotPanics(t, func() {
 		pt.Save(pt.CommonCfg.ThreadPoolMaxThreadsSize.Key, "32")
+	})
+	assert.NotPanics(t, func() {
+		pt.Save(pt.CommonCfg.ArrowReaderHoleSizeLimitBytes.Key, "32768")
+	})
+	assert.NotPanics(t, func() {
+		pt.Save(pt.CommonCfg.ArrowReaderRangeSizeLimitBytes.Key, "1048576")
 	})
 }
 

--- a/internal/util/initcore/init_core.go
+++ b/internal/util/initcore/init_core.go
@@ -502,6 +502,15 @@ func InitDiskFileWriterConfig(params *paramtable.ComponentParam) error {
 	return HandleCStatus(&status, "InitDiskFileWriterConfig failed")
 }
 
+func InitArrowReaderConfig(params *paramtable.ComponentParam) error {
+	arrowReaderConfig := C.CArrowReaderConfig{
+		hole_size_limit_bytes:  C.int64_t(params.CommonCfg.ArrowReaderHoleSizeLimitBytes.GetAsInt64()),
+		range_size_limit_bytes: C.int64_t(params.CommonCfg.ArrowReaderRangeSizeLimitBytes.GetAsInt64()),
+	}
+	status := C.InitArrowReaderConfig(arrowReaderConfig)
+	return HandleCStatus(&status, "InitArrowReaderConfig failed")
+}
+
 var coreParamCallbackInitOnce sync.Once
 
 func SetupCoreConfigChangelCallback() {

--- a/internal/util/initcore/init_core_test.go
+++ b/internal/util/initcore/init_core_test.go
@@ -66,6 +66,17 @@ func TestSetupCoreConfigChangeCallback(t *testing.T) {
 	assert.Equal(t, "32", pt.CommonCfg.ThreadPoolMaxThreadsSize.GetValue())
 }
 
+func TestInitArrowReaderConfig(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+
+	assert.NoError(t, InitArrowReaderConfig(pt))
+
+	assert.NoError(t, pt.Save(pt.CommonCfg.ArrowReaderHoleSizeLimitBytes.Key, "32768"))
+	assert.NoError(t, pt.Save(pt.CommonCfg.ArrowReaderRangeSizeLimitBytes.Key, "1048576"))
+	assert.NoError(t, InitArrowReaderConfig(pt))
+}
+
 func TestInitStorageV2FileSystem(t *testing.T) {
 	// init local storage
 	paramtable.Init()

--- a/internal/util/initcore/query_node.go
+++ b/internal/util/initcore/query_node.go
@@ -168,13 +168,18 @@ func doInitQueryNodeOnce(ctx context.Context) error {
 	enableParquetStatsSkipIndex := paramtable.Get().CommonCfg.ParquetStatsSkipIndex.GetAsBool()
 	C.SetDefaultEnableParquetStatsSkipIndex(C.bool(enableParquetStatsSkipIndex))
 
+	err := InitArrowReaderConfig(paramtable.Get())
+	if err != nil {
+		return err
+	}
+
 	localDataRootPath := pathutil.GetPath(pathutil.LocalChunkPath, nodeID)
 
 	if err := InitLocalChunkManager(localDataRootPath); err != nil {
 		return err
 	}
 
-	err := InitRemoteChunkManager(paramtable.Get())
+	err = InitRemoteChunkManager(paramtable.Get())
 	if err != nil {
 		return err
 	}

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -234,6 +234,8 @@ type commonConfig struct {
 	ThreadPoolMaxThreadsSize            ParamItem `refreshable:"true"`
 	ArrowIOThreadPoolCoefficient        ParamItem `refreshable:"true"`
 	ArrowIOThreadPoolMaxCapacity        ParamItem `refreshable:"true"`
+	ArrowReaderHoleSizeLimitBytes       ParamItem `refreshable:"true"`
+	ArrowReaderRangeSizeLimitBytes      ParamItem `refreshable:"true"`
 	EnableMaterializedView              ParamItem `refreshable:"false"`
 	BuildIndexThreadPoolRatio           ParamItem `refreshable:"false"`
 	MaxDegree                           ParamItem `refreshable:"true"`
@@ -737,6 +739,28 @@ This configuration is only used by querynode and indexnode, it selects CPU instr
 		Export: false,
 	}
 	p.ArrowIOThreadPoolMaxCapacity.Init(base.mgr)
+
+	p.ArrowReaderHoleSizeLimitBytes = ParamItem{
+		Key:          "common.arrow.reader.holeSizeLimitBytes",
+		Version:      "2.6.14",
+		DefaultValue: "0",
+		Doc: `Maximum byte gap between adjacent Arrow read ranges that can be coalesced. ` +
+			`0 keeps Arrow's default. Increasing this can reduce remote object-store GET ` +
+			`count by reading small holes between Parquet column chunk ranges.`,
+		Export: false,
+	}
+	p.ArrowReaderHoleSizeLimitBytes.Init(base.mgr)
+
+	p.ArrowReaderRangeSizeLimitBytes = ParamItem{
+		Key:          "common.arrow.reader.rangeSizeLimitBytes",
+		Version:      "2.6.14",
+		DefaultValue: "0",
+		Doc: `Maximum size in bytes of a coalesced Arrow read range. 0 keeps Arrow's ` +
+			`default. Increase this with holeSizeLimitBytes when larger remote reads ` +
+			`are needed to amortize object-store request latency.`,
+		Export: false,
+	}
+	p.ArrowReaderRangeSizeLimitBytes.Init(base.mgr)
 
 	p.DiskWriteMode = ParamItem{
 		Key:          "common.diskWriteMode",

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -742,7 +742,7 @@ This configuration is only used by querynode and indexnode, it selects CPU instr
 
 	p.ArrowReaderHoleSizeLimitBytes = ParamItem{
 		Key:          "common.arrow.reader.holeSizeLimitBytes",
-		Version:      "2.6.14",
+		Version:      "2.6.16",
 		DefaultValue: "0",
 		Doc: `Maximum byte gap between adjacent Arrow read ranges that can be coalesced. ` +
 			`0 keeps Arrow's default. Increasing this can reduce remote object-store GET ` +
@@ -753,7 +753,7 @@ This configuration is only used by querynode and indexnode, it selects CPU instr
 
 	p.ArrowReaderRangeSizeLimitBytes = ParamItem{
 		Key:          "common.arrow.reader.rangeSizeLimitBytes",
-		Version:      "2.6.14",
+		Version:      "2.6.16",
 		DefaultValue: "0",
 		Doc: `Maximum size in bytes of a coalesced Arrow read range. 0 keeps Arrow's ` +
 			`default. Increase this with holeSizeLimitBytes when larger remote reads ` +

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -55,6 +55,13 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, Params.IndexSliceSize.GetAsInt64(), int64(DefaultIndexSliceSize))
 		t.Logf("knowhere index slice size = %d", Params.IndexSliceSize.GetAsInt64())
 
+		assert.Equal(t, int64(0), Params.ArrowReaderHoleSizeLimitBytes.GetAsInt64())
+		assert.Equal(t, int64(0), Params.ArrowReaderRangeSizeLimitBytes.GetAsInt64())
+		params.Save(Params.ArrowReaderHoleSizeLimitBytes.Key, "1048576")
+		params.Save(Params.ArrowReaderRangeSizeLimitBytes.Key, "67108864")
+		assert.Equal(t, int64(1048576), Params.ArrowReaderHoleSizeLimitBytes.GetAsInt64())
+		assert.Equal(t, int64(67108864), Params.ArrowReaderRangeSizeLimitBytes.GetAsInt64())
+
 		assert.Equal(t, Params.GracefulTime.GetAsInt64(), int64(DefaultGracefulTime))
 		t.Logf("default grafeful time = %d", Params.GracefulTime.GetAsInt64())
 


### PR DESCRIPTION
issue: #49616

- Expose Arrow reader range coalescing options through `common.arrow.reader.holeSizeLimitBytes` and `common.arrow.reader.rangeSizeLimitBytes`.
- Pass the configured Arrow reader properties into StorageV2 `FileRowGroupReader` paths.
- Propagate the same config into StorageV3 milvus-storage reader properties (`reader.parquet.prebuffer.*`).
- Update milvus-storage to the official main revision that supports the reader hole and range size options.
