### PR TITLE
enhance: [2.6] Expose Arrow reader config

### DIFF
--- a/internal/core/src/common/type_c.h
+++ b/internal/core/src/common/type_c.h
@@ -112,6 +112,11 @@ typedef struct CDiskWriteConfig {
     CDiskWriteRateLimiterConfig rate_limiter_config;
 } CDiskWriteConfig;
 
+typedef struct CArrowReaderConfig {
+    int64_t hole_size_limit_bytes;
+    int64_t range_size_limit_bytes;
+} CArrowReaderConfig;
+
 typedef struct CMmapConfig {
     const char* cache_read_ahead_policy;
     const char* mmap_path;

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -641,7 +641,8 @@ SegmentGrowingImpl::load_column_group_data_internal(
                 fs,
                 file,
                 milvus_storage::DEFAULT_READ_BUFFER_SIZE,
-                storage::GetReaderProperties());
+                storage::GetReaderProperties(),
+                storage::GetArrowReaderProperties());
             AssertInfo(result.ok(),
                        "[StorageV2] Failed to create file row group reader: " +
                            result.status().ToString());

--- a/internal/core/src/segcore/memory_planner.cpp
+++ b/internal/core/src/segcore/memory_planner.cpp
@@ -196,7 +196,8 @@ LoadWithStrategy(const std::vector<std::string>& remote_files,
                             file,
                             schema,
                             reader_memory_limit,
-                            milvus::storage::GetReaderProperties());
+                            milvus::storage::GetReaderProperties(),
+                            milvus::storage::GetArrowReaderProperties());
                         AssertInfo(
                             result.ok(),
                             "[StorageV2] Failed to create row group reader: {}",
@@ -407,7 +408,8 @@ MakeFileReaderFactory(std::vector<std::string> remote_files,
                                   (*files)[batch_key],
                                   nullptr,
                                   reader_memory_limit,
-                                  milvus::storage::GetReaderProperties()));
+                                  milvus::storage::GetReaderProperties(),
+                                  milvus::storage::GetArrowReaderProperties()));
         auto close_guard =
             folly::makeGuard([&reader]() { (void)reader->Close(); });
         ARROW_RETURN_NOT_OK(

--- a/internal/core/src/segcore/packed_reader_c.cpp
+++ b/internal/core/src/segcore/packed_reader_c.cpp
@@ -84,7 +84,8 @@ NewPackedReaderWithStorageConfig(char** paths,
             truePaths,
             trueSchema,
             buffer_size,
-            milvus::storage::GetReaderProperties());
+            milvus::storage::GetReaderProperties(),
+            milvus::storage::GetArrowReaderProperties());
         *c_packed_reader = reader.release();
         return milvus::SuccessCStatus();
     } catch (std::exception& e) {
@@ -125,7 +126,8 @@ NewPackedReader(char** paths,
             truePaths,
             trueSchema,
             buffer_size,
-            milvus::storage::GetReaderProperties());
+            milvus::storage::GetReaderProperties(),
+            milvus::storage::GetArrowReaderProperties());
         *c_packed_reader = reader.release();
         return milvus::SuccessCStatus();
     } catch (std::exception& e) {

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
@@ -125,7 +125,8 @@ GroupChunkTranslator::GroupChunkTranslator(
             fs,
             file,
             milvus_storage::DEFAULT_READ_BUFFER_SIZE,
-            storage::GetReaderProperties());
+            storage::GetReaderProperties(),
+            storage::GetArrowReaderProperties());
         AssertInfo(result.ok(),
                    "[StorageV2] Failed to create file row group reader: " +
                        result.status().ToString());

--- a/internal/core/src/storage/KeyRetriever.cpp
+++ b/internal/core/src/storage/KeyRetriever.cpp
@@ -1,4 +1,9 @@
 #include "storage/KeyRetriever.h"
+
+#include <exception>
+#include <mutex>
+
+#include "arrow/io/caching.h"
 #include "common/EasyAssert.h"
 #include "fmt/format.h"
 #include "log/Log.h"
@@ -6,6 +11,11 @@
 #include "storage/PluginLoader.h"
 
 namespace milvus::storage {
+namespace {
+std::mutex arrow_reader_properties_mutex;
+parquet::ArrowReaderProperties arrow_reader_properties =
+    parquet::default_arrow_reader_properties();
+}  // namespace
 
 std::string
 KeyRetriever::GetKey(const std::string& key_metadata) {
@@ -30,6 +40,34 @@ GetReaderProperties() {
             ->plaintext_files_allowed()
             ->build());
     return reader_properties;
+}
+
+parquet::ArrowReaderProperties
+GetArrowReaderProperties() {
+    std::lock_guard<std::mutex> lock(arrow_reader_properties_mutex);
+    return arrow_reader_properties;
+}
+
+void
+ConfigureArrowReaderProperties(int64_t hole_size_limit_bytes,
+                               int64_t range_size_limit_bytes) {
+    auto properties = parquet::default_arrow_reader_properties();
+    auto cache_options = properties.cache_options();
+    if (hole_size_limit_bytes > 0) {
+        cache_options.hole_size_limit = hole_size_limit_bytes;
+    }
+    if (range_size_limit_bytes > 0) {
+        cache_options.range_size_limit = range_size_limit_bytes;
+    }
+    AssertInfo(cache_options.range_size_limit > cache_options.hole_size_limit,
+               "arrow reader range size limit must be greater than hole size "
+               "limit, range_size_limit={}, hole_size_limit={}",
+               cache_options.range_size_limit,
+               cache_options.hole_size_limit);
+    properties.set_cache_options(cache_options);
+
+    std::lock_guard<std::mutex> lock(arrow_reader_properties_mutex);
+    arrow_reader_properties = properties;
 }
 
 std::string

--- a/internal/core/src/storage/KeyRetriever.h
+++ b/internal/core/src/storage/KeyRetriever.h
@@ -11,6 +11,7 @@
 
 #include "common/type_c.h"
 #include "parquet/encryption/encryption.h"
+#include "parquet/properties.h"
 
 namespace milvus::storage {
 
@@ -22,6 +23,13 @@ class KeyRetriever : public parquet::DecryptionKeyRetriever {
 
 parquet::ReaderProperties
 GetReaderProperties();
+
+parquet::ArrowReaderProperties
+GetArrowReaderProperties();
+
+void
+ConfigureArrowReaderProperties(int64_t hole_size_limit_bytes,
+                               int64_t range_size_limit_bytes);
 
 std::string
 EncodeKeyMetadata(int64_t ez_id, int64_t collection_id, std::string key);

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -1304,7 +1304,8 @@ GetFieldDatasFromStorageV2(std::vector<std::vector<std::string>>& remote_files,
             fs,
             column_group_file,
             milvus_storage::DEFAULT_READ_BUFFER_SIZE,
-            GetReaderProperties());
+            GetReaderProperties(),
+            GetArrowReaderProperties());
         AssertInfo(result.ok(),
                    "[StorageV2] Failed to create file row group reader: " +
                        result.status().ToString());
@@ -1533,7 +1534,8 @@ GetFieldIDList(FieldId column_group_id,
         filepath,
         arrow_schema,
         milvus_storage::DEFAULT_READ_BUFFER_SIZE,
-        GetReaderProperties());
+        GetReaderProperties(),
+        GetArrowReaderProperties());
     AssertInfo(result.ok(),
                "[StorageV2] Failed to create file row group reader: " +
                    result.status().ToString());

--- a/internal/core/src/storage/storage_c.cpp
+++ b/internal/core/src/storage/storage_c.cpp
@@ -24,6 +24,7 @@
 #include "storage/ThreadPools.h"
 #include "monitor/scope_metric.h"
 #include "common/EasyAssert.h"
+#include "storage/KeyRetriever.h"
 
 CStatus
 GetLocalUsedSize(const char* c_dir, int64_t* size) {
@@ -155,6 +156,28 @@ InitDiskFileWriterConfig(CDiskWriteConfig c_disk_write_config) {
             c_disk_write_config.rate_limiter_config.high_priority_ratio,
             c_disk_write_config.rate_limiter_config.middle_priority_ratio,
             c_disk_write_config.rate_limiter_config.low_priority_ratio);
+        return milvus::SuccessCStatus();
+    } catch (std::exception& e) {
+        return milvus::FailureCStatus(&e);
+    }
+}
+
+CStatus
+InitArrowReaderConfig(CArrowReaderConfig c_arrow_reader_config) {
+    try {
+        if (c_arrow_reader_config.hole_size_limit_bytes < 0) {
+            return milvus::FailureCStatus(
+                milvus::ConfigInvalid,
+                "arrow reader hole size limit must be non-negative");
+        }
+        if (c_arrow_reader_config.range_size_limit_bytes < 0) {
+            return milvus::FailureCStatus(
+                milvus::ConfigInvalid,
+                "arrow reader range size limit must be non-negative");
+        }
+        milvus::storage::ConfigureArrowReaderProperties(
+            c_arrow_reader_config.hole_size_limit_bytes,
+            c_arrow_reader_config.range_size_limit_bytes);
         return milvus::SuccessCStatus();
     } catch (std::exception& e) {
         return milvus::FailureCStatus(&e);

--- a/internal/core/src/storage/storage_c.h
+++ b/internal/core/src/storage/storage_c.h
@@ -42,6 +42,9 @@ ResizeTheadPool(int64_t priority, float ratio);
 CStatus
 InitDiskFileWriterConfig(CDiskWriteConfig c_disk_write_config);
 
+CStatus
+InitArrowReaderConfig(CArrowReaderConfig c_arrow_reader_config);
+
 // Plugin related APIs
 CStatus
 InitPluginLoader(const char* plugin_path);

--- a/internal/core/thirdparty/milvus-storage/CMakeLists.txt
+++ b/internal/core/thirdparty/milvus-storage/CMakeLists.txt
@@ -14,7 +14,7 @@
 # Update milvus-storage_VERSION for the first occurrence
 milvus_add_pkg_config("milvus-storage")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( milvus-storage_VERSION e159050)
+set( milvus-storage_VERSION ddc6ec7)
 set( GIT_REPOSITORY  "https://github.com/milvus-io/milvus-storage.git")
 message(STATUS "milvus-storage repo: ${GIT_REPOSITORY}")
 message(STATUS "milvus-storage version: ${milvus-storage_VERSION}")

--- a/internal/querynodev2/server.go
+++ b/internal/querynodev2/server.go
@@ -237,6 +237,18 @@ func (node *QueryNode) ReconfigDiskFileWriterParams(evt *config.Event) {
 	}
 }
 
+func (node *QueryNode) ReconfigArrowReaderParams(evt *config.Event) {
+	if evt.HasUpdated {
+		if err := initcore.InitArrowReaderConfig(paramtable.Get()); err != nil {
+			log.Ctx(node.ctx).Warn("QueryNode failed to reconfigure arrow reader params", zap.Error(err))
+			return
+		}
+		log.Ctx(node.ctx).Info("QueryNode reconfig arrow reader params successfully",
+			zap.Int64("holeSizeLimitBytes", paramtable.Get().CommonCfg.ArrowReaderHoleSizeLimitBytes.GetAsInt64()),
+			zap.Int64("rangeSizeLimitBytes", paramtable.Get().CommonCfg.ArrowReaderRangeSizeLimitBytes.GetAsInt64()))
+	}
+}
+
 func (node *QueryNode) RegisterSegcoreConfigWatcher() {
 	pt := paramtable.Get()
 	pt.Watch(pt.CommonCfg.HighPriorityThreadCoreCoefficient.Key,
@@ -283,6 +295,10 @@ func (node *QueryNode) RegisterSegcoreConfigWatcher() {
 	pt.Watch(pt.CommonCfg.ArrowIOThreadPoolMaxCapacity.Key,
 		config.NewHandler(pt.CommonCfg.ArrowIOThreadPoolMaxCapacity.Key,
 			arrowIOThreadHandler(pt.CommonCfg.ArrowIOThreadPoolMaxCapacity.Key)))
+	pt.Watch(pt.CommonCfg.ArrowReaderHoleSizeLimitBytes.Key,
+		config.NewHandler(pt.CommonCfg.ArrowReaderHoleSizeLimitBytes.Key, node.ReconfigArrowReaderParams))
+	pt.Watch(pt.CommonCfg.ArrowReaderRangeSizeLimitBytes.Key,
+		config.NewHandler(pt.CommonCfg.ArrowReaderRangeSizeLimitBytes.Key, node.ReconfigArrowReaderParams))
 }
 
 func getIndexEngineVersion() (minimal, current, maximum int32) {

--- a/internal/util/initcore/init_core.go
+++ b/internal/util/initcore/init_core.go
@@ -482,6 +482,15 @@ func InitDiskFileWriterConfig(params *paramtable.ComponentParam) error {
 	return HandleCStatus(&status, "InitDiskFileWriterConfig failed")
 }
 
+func InitArrowReaderConfig(params *paramtable.ComponentParam) error {
+	arrowReaderConfig := C.CArrowReaderConfig{
+		hole_size_limit_bytes:  C.int64_t(params.CommonCfg.ArrowReaderHoleSizeLimitBytes.GetAsInt64()),
+		range_size_limit_bytes: C.int64_t(params.CommonCfg.ArrowReaderRangeSizeLimitBytes.GetAsInt64()),
+	}
+	status := C.InitArrowReaderConfig(arrowReaderConfig)
+	return HandleCStatus(&status, "InitArrowReaderConfig failed")
+}
+
 var coreParamCallbackInitOnce sync.Once
 
 func SetupCoreConfigChangelCallback() {

--- a/internal/util/initcore/query_node.go
+++ b/internal/util/initcore/query_node.go
@@ -147,11 +147,16 @@ func doInitQueryNodeOnce(ctx context.Context) error {
 
 	C.SetArrowIOThreadPoolCapacity(C.int(ResolveArrowIOThreadPoolCapacity()))
 
+	err := InitArrowReaderConfig(paramtable.Get())
+	if err != nil {
+		return err
+	}
+
 	localDataRootPath := pathutil.GetPath(pathutil.LocalChunkPath, nodeID)
 
 	InitLocalChunkManager(localDataRootPath)
 
-	err := InitRemoteChunkManager(paramtable.Get())
+	err = InitRemoteChunkManager(paramtable.Get())
 	if err != nil {
 		return err
 	}

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -754,7 +754,7 @@ This configuration is only used by querynode and indexnode, it selects CPU instr
 
 	p.ArrowReaderHoleSizeLimitBytes = ParamItem{
 		Key:          "common.arrow.reader.holeSizeLimitBytes",
-		Version:      "2.6.14",
+		Version:      "2.6.16",
 		DefaultValue: "0",
 		Doc: `Maximum byte gap between adjacent Arrow read ranges that can be coalesced. ` +
 			`0 keeps Arrow's default. Increasing this can reduce remote object-store GET ` +
@@ -765,7 +765,7 @@ This configuration is only used by querynode and indexnode, it selects CPU instr
 
 	p.ArrowReaderRangeSizeLimitBytes = ParamItem{
 		Key:          "common.arrow.reader.rangeSizeLimitBytes",
-		Version:      "2.6.14",
+		Version:      "2.6.16",
 		DefaultValue: "0",
 		Doc: `Maximum size in bytes of a coalesced Arrow read range. 0 keeps Arrow's ` +
 			`default. Increase this with holeSizeLimitBytes when larger remote reads ` +

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -235,6 +235,8 @@ type commonConfig struct {
 	ThreadPoolMaxThreadsSize            ParamItem `refreshable:"true"`
 	ArrowIOThreadPoolCoefficient        ParamItem `refreshable:"true"`
 	ArrowIOThreadPoolMaxCapacity        ParamItem `refreshable:"true"`
+	ArrowReaderHoleSizeLimitBytes       ParamItem `refreshable:"true"`
+	ArrowReaderRangeSizeLimitBytes      ParamItem `refreshable:"true"`
 	EnableMaterializedView              ParamItem `refreshable:"false"`
 	BuildIndexThreadPoolRatio           ParamItem `refreshable:"false"`
 	MaxDegree                           ParamItem `refreshable:"true"`
@@ -749,6 +751,28 @@ This configuration is only used by querynode and indexnode, it selects CPU instr
 		Export: false,
 	}
 	p.ArrowIOThreadPoolMaxCapacity.Init(base.mgr)
+
+	p.ArrowReaderHoleSizeLimitBytes = ParamItem{
+		Key:          "common.arrow.reader.holeSizeLimitBytes",
+		Version:      "2.6.14",
+		DefaultValue: "0",
+		Doc: `Maximum byte gap between adjacent Arrow read ranges that can be coalesced. ` +
+			`0 keeps Arrow's default. Increasing this can reduce remote object-store GET ` +
+			`count by reading small holes between Parquet column chunk ranges.`,
+		Export: false,
+	}
+	p.ArrowReaderHoleSizeLimitBytes.Init(base.mgr)
+
+	p.ArrowReaderRangeSizeLimitBytes = ParamItem{
+		Key:          "common.arrow.reader.rangeSizeLimitBytes",
+		Version:      "2.6.14",
+		DefaultValue: "0",
+		Doc: `Maximum size in bytes of a coalesced Arrow read range. 0 keeps Arrow's ` +
+			`default. Increase this with holeSizeLimitBytes when larger remote reads ` +
+			`are needed to amortize object-store request latency.`,
+		Export: false,
+	}
+	p.ArrowReaderRangeSizeLimitBytes.Init(base.mgr)
 
 	p.DiskWriteMode = ParamItem{
 		Key:          "common.diskWriteMode",

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -59,6 +59,13 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, Params.IndexSliceSize.GetAsInt64(), int64(DefaultIndexSliceSize))
 		t.Logf("knowhere index slice size = %d", Params.IndexSliceSize.GetAsInt64())
 
+		assert.Equal(t, int64(0), Params.ArrowReaderHoleSizeLimitBytes.GetAsInt64())
+		assert.Equal(t, int64(0), Params.ArrowReaderRangeSizeLimitBytes.GetAsInt64())
+		params.Save(Params.ArrowReaderHoleSizeLimitBytes.Key, "1048576")
+		params.Save(Params.ArrowReaderRangeSizeLimitBytes.Key, "67108864")
+		assert.Equal(t, int64(1048576), Params.ArrowReaderHoleSizeLimitBytes.GetAsInt64())
+		assert.Equal(t, int64(67108864), Params.ArrowReaderRangeSizeLimitBytes.GetAsInt64())
+
 		assert.Equal(t, Params.GracefulTime.GetAsInt64(), int64(DefaultGracefulTime))
 		t.Logf("default grafeful time = %d", Params.GracefulTime.GetAsInt64())
 


### PR DESCRIPTION
pr: #49620
issue: #49616

- Expose Arrow reader range coalescing options through `common.arrow.reader.holeSizeLimitBytes` and `common.arrow.reader.rangeSizeLimitBytes`.
- Pass the configured Arrow reader properties into StorageV2 `FileRowGroupReader` paths.
- Update milvus-storage to official 2.6 revision `ddc6ec7`.