### PR TITLE
fix: bound streaming release wait

### DIFF
--- a/cmd/roles/roles.go
+++ b/cmd/roles/roles.go
@@ -473,7 +473,11 @@ func (mr *MilvusRoles) Run() {
 	if mr.ServerType == typeutil.StandaloneRole || !mr.EnableDataNode {
 		// only datanode does not init streaming service
 		streaming.Init()
-		defer streaming.Release()
+		defer func() {
+			if err := streaming.Release(); err != nil {
+				log.Warn("release streaming service failed", zap.Error(err))
+			}
+		}()
 	}
 
 	local := mr.Local

--- a/internal/distributed/streaming/streaming.go
+++ b/internal/distributed/streaming/streaming.go
@@ -2,6 +2,9 @@ package streaming
 
 import (
 	"context"
+	"time"
+
+	"github.com/cockroachdb/errors"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
@@ -15,6 +18,11 @@ import (
 )
 
 var singleton WALAccesser = nil
+
+var (
+	ErrWALReleaseTimeout = errors.New("wal release timeout")
+	releaseTimeout       = 5 * time.Second
+)
 
 // Init initializes the wal accesser with the given etcd client.
 // should be called before any other operations.
@@ -30,10 +38,26 @@ func Init() {
 }
 
 // Release releases the resources of the wal accesser.
-func Release() {
+func Release() error {
 	if w, ok := singleton.(*walAccesserImpl); ok && w != nil {
-		w.Close()
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			w.Close()
+		}()
+
+		if releaseTimeout <= 0 {
+			<-done
+			return nil
+		}
+		select {
+		case <-done:
+			return nil
+		case <-time.After(releaseTimeout):
+			return errors.Wrapf(ErrWALReleaseTimeout, "timeout=%s", releaseTimeout)
+		}
 	}
+	return nil
 }
 
 // WAL is the entrance to interact with the milvus write ahead log.

--- a/internal/distributed/streaming/wal_test.go
+++ b/internal/distributed/streaming/wal_test.go
@@ -150,6 +150,48 @@ func TestWAL(t *testing.T) {
 	assert.Error(t, resp.UnwrapFirstError())
 }
 
+func TestReleaseTimeout(t *testing.T) {
+	oldTimeout := releaseTimeout
+	oldSingleton := singleton
+	releaseTimeout = 10 * time.Millisecond
+	defer func() {
+		releaseTimeout = oldTimeout
+		singleton = oldSingleton
+	}()
+
+	coordClient := mock_client.NewMockClient(t)
+	closeDone := make(chan struct{})
+	coordClient.EXPECT().Close().Run(func() {
+		close(closeDone)
+	}).Return()
+	handler := mock_handler.NewMockHandlerClient(t)
+	handler.EXPECT().Close().Return().Maybe()
+	w := &walAccesserImpl{
+		lifetime:             typeutil.NewLifetime(),
+		streamingCoordClient: coordClient,
+		handlerClient:        handler,
+		producerMutex:        sync.Mutex{},
+		producers:            make(map[string]*producer.ResumableProducer),
+	}
+	assert.True(t, w.lifetime.Add(typeutil.LifetimeStateWorking))
+	singleton = w
+
+	start := time.Now()
+	err := Release()
+	assert.ErrorIs(t, err, ErrWALReleaseTimeout)
+	assert.Less(t, time.Since(start), time.Second)
+
+	w.lifetime.Done()
+	assert.Eventually(t, func() bool {
+		select {
+		case <-closeDone:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+}
+
 func newInsertMessage(vChannel string) message.MutableMessage {
 	msg, err := message.NewInsertMessageBuilderV1().
 		WithVChannel(vChannel).


### PR DESCRIPTION
issue: #49609
pr: #49624

This bounds `streaming.Release()` with a fixed 5s timeout so shutdown can return `ErrWALReleaseTimeout` instead of waiting forever when WAL release is blocked by an in-flight local metrics path.

Validation:
- `go test -tags test ./internal/distributed/streaming -run TestReleaseTimeout -count=1`