### PR TITLE
enhance: [2.6] adds dimensions support for TEI text embedding.

### DIFF
--- a/internal/util/function/embedding/mock_embedding_service.go
+++ b/internal/util/function/embedding/mock_embedding_service.go
@@ -259,7 +259,11 @@ func CreateTEIEmbeddingServer(dim int) *httptest.Server {
 		body, _ := io.ReadAll(r.Body)
 		defer r.Body.Close()
 		json.Unmarshal(body, &req)
-		embs := mockEmbedding[float32](req.Inputs, dim)
+		embeddingDim := dim
+		if req.Dimensions != 0 {
+			embeddingDim = req.Dimensions
+		}
+		embs := mockEmbedding[float32](req.Inputs, embeddingDim)
 		w.WriteHeader(http.StatusOK)
 		data, _ := json.Marshal(embs)
 		w.Write(data)

--- a/internal/util/function/embedding/tei_embedding_provider.go
+++ b/internal/util/function/embedding/tei_embedding_provider.go
@@ -38,6 +38,7 @@ type TeiEmbeddingProvider struct {
 
 	ingestionPrompt     string
 	searchPrompt        string
+	embedDimParam       int64
 	truncate            bool
 	truncationDirection string
 
@@ -57,6 +58,8 @@ func NewTEIEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSchema *
 	truncate := false
 	// TEI default is right
 	truncationDirection := ""
+	// 0 means dimensions is omitted and TEI uses the model's default dimension.
+	var dim int64
 
 	for _, param := range functionSchema.Params {
 		switch strings.ToLower(param.Key) {
@@ -66,6 +69,11 @@ func NewTEIEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSchema *
 			ingestionPrompt = param.Value
 		case models.SearchPromptParamKey:
 			searchPrompt = param.Value
+		case models.DimParamKey:
+			dim, err = models.ParseAndCheckFieldDim(param.Value, fieldDim, fieldSchema.Name)
+			if err != nil {
+				return nil, err
+			}
 		case models.MaxClientBatchSizeParamKey:
 			if maxBatch, err = strconv.Atoi(param.Value); err != nil {
 				return nil, fmt.Errorf("[%s param's value: %s] is not a valid number", models.MaxClientBatchSizeParamKey, param.Value)
@@ -97,6 +105,7 @@ func NewTEIEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSchema *
 
 		ingestionPrompt:     ingestionPrompt,
 		searchPrompt:        searchPrompt,
+		embedDimParam:       dim,
 		truncationDirection: truncationDirection,
 		maxBatch:            maxBatch,
 		truncate:            truncate,
@@ -129,7 +138,7 @@ func (provider *TeiEmbeddingProvider) CallEmbedding(ctx context.Context, texts [
 		if end > numRows {
 			end = numRows
 		}
-		resp, err := provider.client.Embedding(texts[i:end], provider.truncate, provider.truncationDirection, prompt, provider.timeoutSec)
+		resp, err := provider.client.Embedding(texts[i:end], provider.truncate, provider.truncationDirection, prompt, int(provider.embedDimParam), provider.timeoutSec)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/util/function/embedding/tei_embedding_provider_test.go
+++ b/internal/util/function/embedding/tei_embedding_provider_test.go
@@ -158,23 +158,40 @@ func (s *TEITextEmbeddingProviderSuite) TestNewTEIEmbeddingProvider() {
 		Params: []*commonpb.KeyValuePair{
 			{Key: models.CredentialParamKey, Value: "mock"},
 			{Key: models.EndpointParamKey, Value: "http://mymock.com"},
+			{Key: models.DimParamKey, Value: "4"},
 		},
 	}
 	batchFactor := 5
 	provider, err := NewTEIEmbeddingProvider(s.schema.Fields[2], functionSchema, map[string]string{}, credentials.NewCredentials(map[string]string{"mock.apikey": "mock"}), &models.ModelExtraInfo{BatchFactor: batchFactor})
 	s.NoError(err)
 	s.Equal(provider.FieldDim(), int64(4))
+	s.Equal(int64(4), provider.embedDimParam)
 	s.True(provider.MaxBatch() == 32*batchFactor)
+
+	// Invalid dim
+	{
+		functionSchema.Params[2] = &commonpb.KeyValuePair{Key: models.DimParamKey, Value: "Invalid"}
+		_, err := NewTEIEmbeddingProvider(s.schema.Fields[2], functionSchema, map[string]string{}, credentials.NewCredentials(map[string]string{"mock.apikey": "mock"}), &models.ModelExtraInfo{})
+		s.Error(err)
+	}
+
+	// Mismatched dim
+	{
+		functionSchema.Params[2] = &commonpb.KeyValuePair{Key: models.DimParamKey, Value: "8"}
+		_, err := NewTEIEmbeddingProvider(s.schema.Fields[2], functionSchema, map[string]string{}, credentials.NewCredentials(map[string]string{"mock.apikey": "mock"}), &models.ModelExtraInfo{})
+		s.Error(err)
+	}
 
 	// Invalid truncate
 	{
+		functionSchema.Params[2] = &commonpb.KeyValuePair{Key: models.DimParamKey, Value: "4"}
 		functionSchema.Params = append(functionSchema.Params, &commonpb.KeyValuePair{Key: models.TruncateParamKey, Value: "Invalid"})
 		_, err := NewTEIEmbeddingProvider(s.schema.Fields[2], functionSchema, map[string]string{}, credentials.NewCredentials(map[string]string{"mock.apikey": "mock"}), &models.ModelExtraInfo{})
 		s.Error(err)
 	}
 	// Invalid truncationDirection
 	{
-		functionSchema.Params[2] = &commonpb.KeyValuePair{Key: models.TruncateParamKey, Value: "true"}
+		functionSchema.Params[3] = &commonpb.KeyValuePair{Key: models.TruncateParamKey, Value: "true"}
 		functionSchema.Params = append(functionSchema.Params, &commonpb.KeyValuePair{Key: models.TruncationDirectionParamKey, Value: "Invalid"})
 		_, err := NewTEIEmbeddingProvider(s.schema.Fields[2], functionSchema, map[string]string{}, credentials.NewCredentials(map[string]string{"mock.apikey": "mock"}), &models.ModelExtraInfo{})
 		s.Error(err)
@@ -182,7 +199,7 @@ func (s *TEITextEmbeddingProviderSuite) TestNewTEIEmbeddingProvider() {
 
 	// truncationDirection
 	{
-		functionSchema.Params[3] = &commonpb.KeyValuePair{Key: models.TruncationDirectionParamKey, Value: "Left"}
+		functionSchema.Params[4] = &commonpb.KeyValuePair{Key: models.TruncationDirectionParamKey, Value: "Left"}
 		_, err := NewTEIEmbeddingProvider(s.schema.Fields[2], functionSchema, map[string]string{}, credentials.NewCredentials(map[string]string{"mock.apikey": "mock"}), &models.ModelExtraInfo{})
 		s.NoError(err)
 	}
@@ -196,7 +213,7 @@ func (s *TEITextEmbeddingProviderSuite) TestNewTEIEmbeddingProvider() {
 
 	// Valid max batch
 	{
-		functionSchema.Params[4] = &commonpb.KeyValuePair{Key: models.MaxClientBatchSizeParamKey, Value: "128"}
+		functionSchema.Params[5] = &commonpb.KeyValuePair{Key: models.MaxClientBatchSizeParamKey, Value: "128"}
 		pv, err := NewTEIEmbeddingProvider(s.schema.Fields[2], functionSchema, map[string]string{}, credentials.NewCredentials(map[string]string{"mock.apikey": "mock"}), &models.ModelExtraInfo{BatchFactor: batchFactor})
 		s.NoError(err)
 		s.True(pv.MaxBatch() == 128*batchFactor)

--- a/internal/util/function/models/tei/tei.go
+++ b/internal/util/function/models/tei/tei.go
@@ -46,12 +46,12 @@ func (c *TEIClient) headers() map[string]string {
 	return headers
 }
 
-func (c *TEIClient) Embedding(texts []string, truncate bool, truncationDirection string, prompt string, timeoutSec int64) (*EmbeddingResponse, error) {
+func (c *TEIClient) Embedding(texts []string, truncate bool, truncationDirection string, prompt string, dimensions int, timeoutSec int64) (*EmbeddingResponse, error) {
 	embClient, err := newTEIEmbedding(c.apiKey, c.endpoint)
 	if err != nil {
 		return nil, err
 	}
-	return embClient.embedding(texts, truncate, truncationDirection, prompt, c.headers(), timeoutSec)
+	return embClient.embedding(texts, truncate, truncationDirection, prompt, dimensions, c.headers(), timeoutSec)
 }
 
 func (c *TEIClient) Rerank(query string, texts []string, params map[string]any, timeoutSec int64) (*RerankResponse, error) {
@@ -64,6 +64,7 @@ func (c *TEIClient) Rerank(query string, texts []string, params map[string]any, 
 
 type EmbeddingRequest struct {
 	Inputs              []string `json:"inputs"`
+	Dimensions          int      `json:"dimensions,omitempty"`
 	Truncate            bool     `json:"truncate,omitempty"`
 	TruncationDirection string   `json:"truncation_direction,omitempty"`
 	PromptName          string   `json:"prompt_name,omitempty"`
@@ -89,7 +90,7 @@ func newTEIEmbedding(apiKey string, endpoint string) (*teiEmbedding, error) {
 	}, nil
 }
 
-func (c *teiEmbedding) embedding(texts []string, truncate bool, truncationDirection string, prompt string, headers map[string]string, timeoutSec int64) (*EmbeddingResponse, error) {
+func (c *teiEmbedding) embedding(texts []string, truncate bool, truncationDirection string, prompt string, dimensions int, headers map[string]string, timeoutSec int64) (*EmbeddingResponse, error) {
 	var r EmbeddingRequest
 	if prompt != "" {
 		var newTexts []string
@@ -101,6 +102,9 @@ func (c *teiEmbedding) embedding(texts []string, truncate bool, truncationDirect
 		r.Inputs = texts
 	}
 
+	if dimensions != 0 {
+		r.Dimensions = dimensions
+	}
 	r.Truncate = truncate
 	if truncationDirection != "" {
 		r.TruncationDirection = truncationDirection

--- a/internal/util/function/models/tei/tei_test.go
+++ b/internal/util/function/models/tei/tei_test.go
@@ -46,14 +46,14 @@ func TestEmbeddingOK(t *testing.T) {
 
 	{
 		c, _ := NewTEIClient("mock_key", url)
-		ret, err := c.Embedding([]string{"sentence"}, true, "left", "query", 0)
+		ret, err := c.Embedding([]string{"sentence"}, true, "left", "query", 2, 0)
 		assert.True(t, err == nil)
 		assert.Equal(t, ret, &EmbeddingResponse{{0.0, 0.1}, {1.0, 1.1}, {2.0, 2.1}})
 	}
 
 	{
 		c, _ := NewTEIClient("mock_key", url)
-		ret, err := c.Embedding([]string{"sentence"}, false, "", "", 0)
+		ret, err := c.Embedding([]string{"sentence"}, false, "", "", 0, 0)
 		assert.True(t, err == nil)
 		assert.Equal(t, ret, &EmbeddingResponse{{0.0, 0.1}, {1.0, 1.1}, {2.0, 2.1}})
 	}
@@ -69,7 +69,7 @@ func TestEmbeddingFailed(t *testing.T) {
 
 	{
 		c, _ := NewTEIClient("mock_key", url)
-		_, err := c.Embedding([]string{"sentence"}, true, "left", "query", 0)
+		_, err := c.Embedding([]string{"sentence"}, true, "left", "query", 0, 0)
 		assert.True(t, err != nil)
 	}
 }


### PR DESCRIPTION
pr: #49654
issue: #49644

Changes:
- Parse Function param "dim" in TEI embedding provider.
- Pass it to TEI /embed request as JSON field "dimensions".
- Keep existing behavior when dim is not specified.
- Add unit tests for request serialization and provider dim parsing.

Tests:
- go test ./internal/util/function/models/tei -count=1 -v
- go test -tags test ./internal/util/function/embedding -run TestTEITextEmbeddingProvider -count=1 -v