### PR TITLE
fix: recover import reader from premature EOF

### DIFF
--- a/internal/storage/gcp_native_object_storage.go
+++ b/internal/storage/gcp_native_object_storage.go
@@ -58,7 +58,11 @@ func (gcs *GcpNativeObjectStorage) GetObject(ctx context.Context, bucketName, ob
 	if offset == 0 && size == 0 {
 		reader, err = obj.NewReader(ctx)
 	} else {
-		reader, err = obj.NewRangeReader(ctx, offset, size)
+		length := size
+		if offset > 0 && size == 0 {
+			length = -1
+		}
+		reader, err = obj.NewRangeReader(ctx, offset, length)
 	}
 
 	if err != nil {

--- a/internal/storage/local_chunk_manager.go
+++ b/internal/storage/local_chunk_manager.go
@@ -80,6 +80,23 @@ func (lcm *LocalChunkManager) Reader(ctx context.Context, filePath string) (File
 	}, nil
 }
 
+func (lcm *LocalChunkManager) ReaderAtOffset(ctx context.Context, filePath string, offset int64) (FileReader, error) {
+	if offset < 0 {
+		return nil, io.EOF
+	}
+	reader, err := lcm.Reader(ctx, filePath)
+	if err != nil {
+		return nil, err
+	}
+	if offset > 0 {
+		if _, err = reader.Seek(offset, io.SeekStart); err != nil {
+			_ = reader.Close()
+			return nil, err
+		}
+	}
+	return reader, nil
+}
+
 // Write writes the data to local storage.
 func (lcm *LocalChunkManager) Write(ctx context.Context, filePath string, content []byte) error {
 	dir := path.Dir(filePath)

--- a/internal/storage/minio_object_storage.go
+++ b/internal/storage/minio_object_storage.go
@@ -57,7 +57,11 @@ func newMinioObjectStorageWithConfig(ctx context.Context, c *objectstorage.Confi
 func (minioObjectStorage *MinioObjectStorage) GetObject(ctx context.Context, bucketName, objectName string, offset int64, size int64) (FileReader, error) {
 	opts := minio.GetObjectOptions{}
 	if offset > 0 {
-		err := opts.SetRange(offset, offset+size-1)
+		end := int64(0)
+		if size > 0 {
+			end = offset + size - 1
+		}
+		err := opts.SetRange(offset, end)
 		if err != nil {
 			log.Warn("failed to set range", zap.String("bucket", bucketName), zap.String("path", objectName), zap.Error(err))
 			return nil, mapObjectStorageError(objectName, err)

--- a/internal/storage/remote_chunk_manager.go
+++ b/internal/storage/remote_chunk_manager.go
@@ -144,6 +144,19 @@ func (mcm *RemoteChunkManager) Reader(ctx context.Context, filePath string) (Fil
 	return reader, nil
 }
 
+func (mcm *RemoteChunkManager) ReaderAtOffset(ctx context.Context, filePath string, offset int64) (FileReader, error) {
+	if offset < 0 {
+		return nil, io.EOF
+	}
+
+	reader, err := mcm.getObject(ctx, mcm.bucketName, filePath, offset, int64(0))
+	if err != nil {
+		log.Warn("failed to get object", zap.String("bucket", mcm.bucketName), zap.String("path", filePath), zap.Int64("offset", offset), zap.Error(err))
+		return nil, err
+	}
+	return reader, nil
+}
+
 func (mcm *RemoteChunkManager) Size(ctx context.Context, filePath string) (int64, error) {
 	var objectInfo int64
 	var err error

--- a/internal/util/importutilv2/common/mock_reader.go
+++ b/internal/util/importutilv2/common/mock_reader.go
@@ -56,6 +56,48 @@ func CustomMockReader(reader io.Reader) storage.FileReader {
 	}
 }
 
+type prematureEOFReader struct {
+	*strings.Reader
+	limit        int
+	read         int
+	reportedSize int64
+}
+
+// NewPrematureEOFReader creates a test reader that returns EOF before the reported object size is reached.
+func NewPrematureEOFReader(content string, limit int) storage.FileReader {
+	return NewPrematureEOFReaderWithSize(content, limit, int64(len(content)))
+}
+
+// NewPrematureEOFReaderWithSize creates a test reader that reports a custom object size.
+func NewPrematureEOFReaderWithSize(content string, limit int, reportedSize int64) storage.FileReader {
+	reader := strings.NewReader(content)
+	return &prematureEOFReader{
+		Reader:       reader,
+		limit:        limit,
+		reportedSize: reportedSize,
+	}
+}
+
+func (r *prematureEOFReader) Read(p []byte) (int, error) {
+	if r.read >= r.limit {
+		return 0, io.EOF
+	}
+	if remaining := r.limit - r.read; len(p) > remaining {
+		p = p[:remaining]
+	}
+	n, err := r.Reader.Read(p)
+	r.read += n
+	return n, err
+}
+
+func (r *prematureEOFReader) Close() error {
+	return nil
+}
+
+func (r *prematureEOFReader) Size() (int64, error) {
+	return r.reportedSize, nil
+}
+
 func newErrorMockReader(content string, err error, errCount int) storage.FileReader {
 	reader := strings.NewReader(content)
 	return &mockFileReader{

--- a/internal/util/importutilv2/common/retryable_reader.go
+++ b/internal/util/importutilv2/common/retryable_reader.go
@@ -37,8 +37,10 @@ type RetryableReader interface {
 	Read(p []byte) (n int, err error)
 }
 
-type ReopenReaderFunc func(context.Context, string) (storage.FileReader, error)
-type ReaderSizeFunc func(context.Context, string) (int64, error)
+type (
+	ReopenReaderFunc func(context.Context, string) (storage.FileReader, error)
+	ReaderSizeFunc   func(context.Context, string) (int64, error)
+)
 
 // retryableReader is the implementation of RetryableReader.
 type retryableReader struct {
@@ -82,7 +84,7 @@ func newRetryableReader(ctx context.Context, path string, reader storage.FileRea
 }
 
 func (r *retryableReader) objectSize() (int64, bool) {
-	if r.size > 0 || (r.size == 0 && r.offset == 0) {
+	if r.size > 0 {
 		return r.size, true
 	}
 	if r.sizeFunc == nil {
@@ -97,6 +99,7 @@ func (r *retryableReader) objectSize() (int64, bool) {
 		return 0, false
 	}
 	r.size = size
+	r.sizeFunc = nil
 	return size, true
 }
 
@@ -105,7 +108,8 @@ func (r *retryableReader) reopenAtOffset() error {
 		return nil
 	}
 	if r.FileReader != nil {
-		_ = r.FileReader.Close()
+		_ = r.Close()
+		r.FileReader = nil
 	}
 	reader, err := r.reopen(r.ctx, r.path)
 	if err != nil {
@@ -126,6 +130,15 @@ func (r *retryableReader) Read(p []byte) (int, error) {
 	var n int
 	var err error
 	err = retry.Handle(r.ctx, func() (bool, error) {
+		if r.FileReader == nil {
+			if reopenErr := r.reopenAtOffset(); reopenErr != nil {
+				return !merr.IsNonRetryableErr(reopenErr), reopenErr
+			}
+			if r.FileReader == nil {
+				err = storage.ToMilvusIoError(r.path, io.ErrClosedPipe)
+				return false, err
+			}
+		}
 		n, err = r.FileReader.Read(p)
 		if n > 0 {
 			r.offset += int64(n)

--- a/internal/util/importutilv2/common/retryable_reader.go
+++ b/internal/util/importutilv2/common/retryable_reader.go
@@ -38,9 +38,33 @@ type RetryableReader interface {
 }
 
 type (
-	ReopenReaderFunc func(context.Context, string) (storage.FileReader, error)
+	ReopenReaderFunc func(context.Context, string, int64) (storage.FileReader, error)
 	ReaderSizeFunc   func(context.Context, string) (int64, error)
 )
+
+type offsetReader interface {
+	ReaderAtOffset(context.Context, string, int64) (storage.FileReader, error)
+}
+
+// NewChunkManagerReopenReaderFunc creates a reopen function that resumes reading at the given offset.
+func NewChunkManagerReopenReaderFunc(cm storage.ChunkManager) ReopenReaderFunc {
+	return func(ctx context.Context, path string, offset int64) (storage.FileReader, error) {
+		if reader, ok := cm.(offsetReader); ok {
+			return reader.ReaderAtOffset(ctx, path, offset)
+		}
+		reader, err := cm.Reader(ctx, path)
+		if err != nil {
+			return nil, err
+		}
+		if offset > 0 {
+			if _, err = reader.Seek(offset, io.SeekStart); err != nil {
+				_ = reader.Close()
+				return nil, err
+			}
+		}
+		return reader, nil
+	}
+}
 
 // retryableReader is the implementation of RetryableReader.
 type retryableReader struct {
@@ -111,15 +135,9 @@ func (r *retryableReader) reopenAtOffset() error {
 		_ = r.Close()
 		r.FileReader = nil
 	}
-	reader, err := r.reopen(r.ctx, r.path)
+	reader, err := r.reopen(r.ctx, r.path, r.offset)
 	if err != nil {
 		return storage.ToMilvusIoError(r.path, err)
-	}
-	if r.offset > 0 {
-		if _, err = reader.Seek(r.offset, io.SeekStart); err != nil {
-			_ = reader.Close()
-			return storage.ToMilvusIoError(r.path, err)
-		}
 	}
 	r.FileReader = reader
 	return nil
@@ -142,6 +160,8 @@ func (r *retryableReader) Read(p []byte) (int, error) {
 		n, err = r.FileReader.Read(p)
 		if n > 0 {
 			r.offset += int64(n)
+			// Preserve io.Reader semantics: return buffered bytes first.
+			// Any accompanying error is handled by a following Read, which may reopen.
 			return false, nil
 		}
 		if err == nil {

--- a/internal/util/importutilv2/common/retryable_reader.go
+++ b/internal/util/importutilv2/common/retryable_reader.go
@@ -38,6 +38,7 @@ type RetryableReader interface {
 }
 
 type ReopenReaderFunc func(context.Context, string) (storage.FileReader, error)
+type ReaderSizeFunc func(context.Context, string) (int64, error)
 
 // retryableReader is the implementation of RetryableReader.
 type retryableReader struct {
@@ -46,20 +47,21 @@ type retryableReader struct {
 	path          string
 	retryAttempts uint
 	reopen        ReopenReaderFunc
+	sizeFunc      ReaderSizeFunc
 	offset        int64
 	size          int64
 }
 
 // NewRetryableReader creates a new RetryableReader.
 func NewRetryableReader(ctx context.Context, path string, reader storage.FileReader) RetryableReader {
-	return newRetryableReader(ctx, path, reader, nil)
+	return newRetryableReader(ctx, path, reader, nil, nil)
 }
 
-func NewRetryableReaderWithReopen(ctx context.Context, path string, reader storage.FileReader, reopen ReopenReaderFunc) RetryableReader {
-	return newRetryableReader(ctx, path, reader, reopen)
+func NewRetryableReaderWithReopen(ctx context.Context, path string, reader storage.FileReader, reopen ReopenReaderFunc, sizeFunc ReaderSizeFunc) RetryableReader {
+	return newRetryableReader(ctx, path, reader, reopen, sizeFunc)
 }
 
-func newRetryableReader(ctx context.Context, path string, reader storage.FileReader, reopen ReopenReaderFunc) RetryableReader {
+func newRetryableReader(ctx context.Context, path string, reader storage.FileReader, reopen ReopenReaderFunc, sizeFunc ReaderSizeFunc) RetryableReader {
 	size := int64(-1)
 	if reader != nil {
 		var err error
@@ -74,8 +76,28 @@ func newRetryableReader(ctx context.Context, path string, reader storage.FileRea
 		path:          path,
 		retryAttempts: paramtable.Get().CommonCfg.StorageReadRetryAttempts.GetAsUint(),
 		reopen:        reopen,
+		sizeFunc:      sizeFunc,
 		size:          size,
 	}
+}
+
+func (r *retryableReader) objectSize() (int64, bool) {
+	if r.size > 0 || (r.size == 0 && r.offset == 0) {
+		return r.size, true
+	}
+	if r.sizeFunc == nil {
+		return r.size, r.size >= 0
+	}
+	size, err := r.sizeFunc(r.ctx, r.path)
+	if err != nil {
+		log.Ctx(r.ctx).Warn("retryable reader failed to get object size",
+			zap.String("path", r.path),
+			zap.Error(err),
+		)
+		return 0, false
+	}
+	r.size = size
+	return size, true
 }
 
 func (r *retryableReader) reopenAtOffset() error {
@@ -113,11 +135,12 @@ func (r *retryableReader) Read(p []byte) (int, error) {
 			return false, nil
 		}
 		if errors.Is(err, io.EOF) {
-			if r.size >= 0 && r.offset < r.size && r.reopen != nil {
+			if size, ok := r.objectSize(); ok && r.offset < size && r.reopen != nil {
+				err = storage.ToMilvusIoError(r.path, io.ErrUnexpectedEOF)
 				log.Ctx(r.ctx).Warn("retryable reader got premature EOF",
 					zap.String("path", r.path),
 					zap.Int64("offset", r.offset),
-					zap.Int64("size", r.size),
+					zap.Int64("size", size),
 				)
 				if reopenErr := r.reopenAtOffset(); reopenErr != nil {
 					return !merr.IsNonRetryableErr(reopenErr), reopenErr

--- a/internal/util/importutilv2/common/retryable_reader.go
+++ b/internal/util/importutilv2/common/retryable_reader.go
@@ -37,22 +37,66 @@ type RetryableReader interface {
 	Read(p []byte) (n int, err error)
 }
 
+type ReopenReaderFunc func(context.Context, string) (storage.FileReader, error)
+
 // retryableReader is the implementation of RetryableReader.
 type retryableReader struct {
 	storage.FileReader
 	ctx           context.Context
 	path          string
 	retryAttempts uint
+	reopen        ReopenReaderFunc
+	offset        int64
+	size          int64
 }
 
 // NewRetryableReader creates a new RetryableReader.
 func NewRetryableReader(ctx context.Context, path string, reader storage.FileReader) RetryableReader {
+	return newRetryableReader(ctx, path, reader, nil)
+}
+
+func NewRetryableReaderWithReopen(ctx context.Context, path string, reader storage.FileReader, reopen ReopenReaderFunc) RetryableReader {
+	return newRetryableReader(ctx, path, reader, reopen)
+}
+
+func newRetryableReader(ctx context.Context, path string, reader storage.FileReader, reopen ReopenReaderFunc) RetryableReader {
+	size := int64(-1)
+	if reader != nil {
+		var err error
+		size, err = reader.Size()
+		if err != nil {
+			size = -1
+		}
+	}
 	return &retryableReader{
 		FileReader:    reader,
 		ctx:           ctx,
 		path:          path,
 		retryAttempts: paramtable.Get().CommonCfg.StorageReadRetryAttempts.GetAsUint(),
+		reopen:        reopen,
+		size:          size,
 	}
+}
+
+func (r *retryableReader) reopenAtOffset() error {
+	if r.reopen == nil {
+		return nil
+	}
+	if r.FileReader != nil {
+		_ = r.FileReader.Close()
+	}
+	reader, err := r.reopen(r.ctx, r.path)
+	if err != nil {
+		return storage.ToMilvusIoError(r.path, err)
+	}
+	if r.offset > 0 {
+		if _, err = reader.Seek(r.offset, io.SeekStart); err != nil {
+			_ = reader.Close()
+			return storage.ToMilvusIoError(r.path, err)
+		}
+	}
+	r.FileReader = reader
+	return nil
 }
 
 // Read reads from the underlying FileReader and retries on errors.
@@ -61,11 +105,25 @@ func (r *retryableReader) Read(p []byte) (int, error) {
 	var err error
 	err = retry.Handle(r.ctx, func() (bool, error) {
 		n, err = r.FileReader.Read(p)
+		if n > 0 {
+			r.offset += int64(n)
+			return false, nil
+		}
 		if err == nil {
 			return false, nil
 		}
-		// EOF is not an error - don't retry
 		if errors.Is(err, io.EOF) {
+			if r.size >= 0 && r.offset < r.size && r.reopen != nil {
+				log.Ctx(r.ctx).Warn("retryable reader got premature EOF",
+					zap.String("path", r.path),
+					zap.Int64("offset", r.offset),
+					zap.Int64("size", r.size),
+				)
+				if reopenErr := r.reopenAtOffset(); reopenErr != nil {
+					return !merr.IsNonRetryableErr(reopenErr), reopenErr
+				}
+				return true, err
+			}
 			return false, err
 		}
 		// Context canceled or deadline exceeded - don't retry
@@ -80,6 +138,9 @@ func (r *retryableReader) Read(p []byte) (int, error) {
 		// Denylist check - don't retry permanent/validation errors
 		if merr.IsNonRetryableErr(err) {
 			return false, err
+		}
+		if reopenErr := r.reopenAtOffset(); reopenErr != nil {
+			return !merr.IsNonRetryableErr(reopenErr), reopenErr
 		}
 		// Retry everything else (network errors, timeouts, 500s, etc.)
 		return true, err

--- a/internal/util/importutilv2/common/retryable_reader_test.go
+++ b/internal/util/importutilv2/common/retryable_reader_test.go
@@ -20,12 +20,14 @@ import (
 	"context"
 	"io"
 	"math"
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/errors"
 	"github.com/minio/minio-go/v7"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
@@ -119,6 +121,101 @@ func (m *customMockReader) Seek(offset int64, whence int) (int64, error) {
 
 func (m *customMockReader) ReadAt(p []byte, off int64) (int, error) {
 	return 0, nil
+}
+
+type prematureEOFReader struct {
+	*strings.Reader
+	limit int
+	read  int
+}
+
+func newPrematureEOFReader(content string, limit int) storage.FileReader {
+	return &prematureEOFReader{
+		Reader: strings.NewReader(content),
+		limit:  limit,
+	}
+}
+
+func (r *prematureEOFReader) Read(p []byte) (int, error) {
+	if r.read >= r.limit {
+		return 0, io.EOF
+	}
+	if remaining := r.limit - r.read; len(p) > remaining {
+		p = p[:remaining]
+	}
+	n, err := r.Reader.Read(p)
+	r.read += n
+	return n, err
+}
+
+func (r *prematureEOFReader) Close() error {
+	return nil
+}
+
+func (r *prematureEOFReader) Size() (int64, error) {
+	return int64(r.Reader.Len()) + int64(r.read), nil
+}
+
+func TestRetryableReader_ReopenOnPrematureEOF(t *testing.T) {
+	ctx := context.Background()
+	path := "/test/path"
+	content := "hello world"
+	openCount := 0
+	reopen := func(context.Context, string) (storage.FileReader, error) {
+		openCount++
+		return NewMockReader(content), nil
+	}
+
+	reader := NewRetryableReaderWithReopen(ctx, path, newPrematureEOFReader(content, 5), reopen)
+	buf := make([]byte, len(content))
+	n, err := io.ReadFull(reader, buf)
+
+	assert.NoError(t, err)
+	assert.Equal(t, len(content), n)
+	assert.Equal(t, content, string(buf))
+	assert.Equal(t, 1, openCount)
+}
+
+func TestRetryableReader_FinalEOFIsNotRetried(t *testing.T) {
+	ctx := context.Background()
+	path := "/test/path"
+	content := "done"
+	openCount := 0
+	reopen := func(context.Context, string) (storage.FileReader, error) {
+		openCount++
+		return NewMockReader(content), nil
+	}
+
+	reader := NewRetryableReaderWithReopen(ctx, path, NewMockReader(content), reopen)
+	buf := make([]byte, len(content))
+	n, err := io.ReadFull(reader, buf)
+	assert.NoError(t, err)
+	assert.Equal(t, len(content), n)
+
+	n, err = reader.Read(buf)
+	assert.ErrorIs(t, err, io.EOF)
+	assert.Equal(t, 0, n)
+	assert.Equal(t, 0, openCount)
+}
+
+func TestRetryableReader_ReopenOnRetryableError(t *testing.T) {
+	ctx := context.Background()
+	path := "/test/path"
+	content := "data after retry"
+	openCount := 0
+	reopen := func(context.Context, string) (storage.FileReader, error) {
+		openCount++
+		return NewMockReader(content), nil
+	}
+
+	reader := NewRetryableReaderWithReopen(ctx, path, newErrorMockReader(content, errors.New("network timeout"), 1), reopen)
+	buf := make([]byte, len(content))
+	n, err := reader.Read(buf)
+
+	assert.NoError(t, err)
+	assert.Equal(t, len(content), n)
+	assert.Equal(t, content, string(buf))
+	assert.Equal(t, 1, openCount)
 }
 
 func TestRetryableReader_DenylistRetry_NonRetryableErrors(t *testing.T) {

--- a/internal/util/importutilv2/common/retryable_reader_test.go
+++ b/internal/util/importutilv2/common/retryable_reader_test.go
@@ -125,14 +125,20 @@ func (m *customMockReader) ReadAt(p []byte, off int64) (int, error) {
 
 type prematureEOFReader struct {
 	*strings.Reader
-	limit int
-	read  int
+	limit        int
+	read         int
+	reportedSize int64
 }
 
 func newPrematureEOFReader(content string, limit int) storage.FileReader {
+	return newPrematureEOFReaderWithSize(content, limit, int64(len(content)))
+}
+
+func newPrematureEOFReaderWithSize(content string, limit int, reportedSize int64) storage.FileReader {
 	return &prematureEOFReader{
-		Reader: strings.NewReader(content),
-		limit:  limit,
+		Reader:       strings.NewReader(content),
+		limit:        limit,
+		reportedSize: reportedSize,
 	}
 }
 
@@ -153,7 +159,13 @@ func (r *prematureEOFReader) Close() error {
 }
 
 func (r *prematureEOFReader) Size() (int64, error) {
-	return int64(r.Reader.Len()) + int64(r.read), nil
+	return r.reportedSize, nil
+}
+
+func newSizeFunc(size int64) ReaderSizeFunc {
+	return func(context.Context, string) (int64, error) {
+		return size, nil
+	}
 }
 
 func TestRetryableReader_ReopenOnPrematureEOF(t *testing.T) {
@@ -166,7 +178,7 @@ func TestRetryableReader_ReopenOnPrematureEOF(t *testing.T) {
 		return NewMockReader(content), nil
 	}
 
-	reader := NewRetryableReaderWithReopen(ctx, path, newPrematureEOFReader(content, 5), reopen)
+	reader := NewRetryableReaderWithReopen(ctx, path, newPrematureEOFReader(content, 5), reopen, newSizeFunc(int64(len(content))))
 	buf := make([]byte, len(content))
 	n, err := io.ReadFull(reader, buf)
 
@@ -186,7 +198,7 @@ func TestRetryableReader_FinalEOFIsNotRetried(t *testing.T) {
 		return NewMockReader(content), nil
 	}
 
-	reader := NewRetryableReaderWithReopen(ctx, path, NewMockReader(content), reopen)
+	reader := NewRetryableReaderWithReopen(ctx, path, NewMockReader(content), reopen, newSizeFunc(int64(len(content))))
 	buf := make([]byte, len(content))
 	n, err := io.ReadFull(reader, buf)
 	assert.NoError(t, err)
@@ -208,9 +220,54 @@ func TestRetryableReader_ReopenOnRetryableError(t *testing.T) {
 		return NewMockReader(content), nil
 	}
 
-	reader := NewRetryableReaderWithReopen(ctx, path, newErrorMockReader(content, errors.New("network timeout"), 1), reopen)
+	reader := NewRetryableReaderWithReopen(ctx, path, newErrorMockReader(content, errors.New("network timeout"), 1), reopen, newSizeFunc(int64(len(content))))
 	buf := make([]byte, len(content))
 	n, err := reader.Read(buf)
+
+	assert.NoError(t, err)
+	assert.Equal(t, len(content), n)
+	assert.Equal(t, content, string(buf))
+	assert.Equal(t, 1, openCount)
+}
+
+func TestRetryableReader_ExhaustedPrematureEOFReturnsUnexpectedEOF(t *testing.T) {
+	ctx := context.Background()
+	path := "/test/path"
+	content := "hello world"
+	reopen := func(context.Context, string) (storage.FileReader, error) {
+		return newPrematureEOFReader(content, 0), nil
+	}
+
+	reader := &retryableReader{
+		FileReader:    newPrematureEOFReader(content, 5),
+		ctx:           ctx,
+		path:          path,
+		retryAttempts: 2,
+		reopen:        reopen,
+		sizeFunc:      newSizeFunc(int64(len(content))),
+		size:          -1,
+	}
+	buf := make([]byte, len(content))
+	n, err := io.ReadFull(reader, buf)
+
+	assert.ErrorIs(t, err, merr.ErrIoUnexpectEOF)
+	assert.False(t, errors.Is(err, io.EOF))
+	assert.Equal(t, 5, n)
+}
+
+func TestRetryableReader_UsesSizeFuncForPrematureEOF(t *testing.T) {
+	ctx := context.Background()
+	path := "/test/path"
+	content := "hello world"
+	openCount := 0
+	reopen := func(context.Context, string) (storage.FileReader, error) {
+		openCount++
+		return NewMockReader(content), nil
+	}
+
+	reader := NewRetryableReaderWithReopen(ctx, path, newPrematureEOFReaderWithSize(content, 5, 0), reopen, newSizeFunc(int64(len(content))))
+	buf := make([]byte, len(content))
+	n, err := io.ReadFull(reader, buf)
 
 	assert.NoError(t, err)
 	assert.Equal(t, len(content), n)

--- a/internal/util/importutilv2/common/retryable_reader_test.go
+++ b/internal/util/importutilv2/common/retryable_reader_test.go
@@ -162,6 +162,25 @@ func (r *prematureEOFReader) Size() (int64, error) {
 	return r.reportedSize, nil
 }
 
+type closeAwareReader struct {
+	storage.FileReader
+	closed         bool
+	readAfterClose int
+}
+
+func (r *closeAwareReader) Read(p []byte) (int, error) {
+	if r.closed {
+		r.readAfterClose++
+		return 0, errors.New("read after close")
+	}
+	return r.FileReader.Read(p)
+}
+
+func (r *closeAwareReader) Close() error {
+	r.closed = true
+	return r.FileReader.Close()
+}
+
 func newSizeFunc(size int64) ReaderSizeFunc {
 	return func(context.Context, string) (int64, error) {
 		return size, nil
@@ -273,6 +292,59 @@ func TestRetryableReader_UsesSizeFuncForPrematureEOF(t *testing.T) {
 	assert.Equal(t, len(content), n)
 	assert.Equal(t, content, string(buf))
 	assert.Equal(t, 1, openCount)
+}
+
+func TestRetryableReader_UsesSizeFuncForImmediateEOF(t *testing.T) {
+	ctx := context.Background()
+	path := "/test/path"
+	content := "hello world"
+	openCount := 0
+	reopen := func(context.Context, string) (storage.FileReader, error) {
+		openCount++
+		return NewMockReader(content), nil
+	}
+
+	reader := NewRetryableReaderWithReopen(ctx, path, newPrematureEOFReaderWithSize(content, 0, 0), reopen, newSizeFunc(int64(len(content))))
+	buf := make([]byte, len(content))
+	n, err := io.ReadFull(reader, buf)
+
+	assert.NoError(t, err)
+	assert.Equal(t, len(content), n)
+	assert.Equal(t, content, string(buf))
+	assert.Equal(t, 1, openCount)
+}
+
+func TestRetryableReader_DoesNotReadClosedReaderAfterFailedReopen(t *testing.T) {
+	ctx := context.Background()
+	path := "/test/path"
+	content := "hello world"
+	initialReader := &closeAwareReader{FileReader: newPrematureEOFReader(content, 0)}
+	openCount := 0
+	reopen := func(context.Context, string) (storage.FileReader, error) {
+		openCount++
+		if openCount == 1 {
+			return nil, errors.New("temporary reopen failure")
+		}
+		return NewMockReader(content), nil
+	}
+
+	reader := &retryableReader{
+		FileReader:    initialReader,
+		ctx:           ctx,
+		path:          path,
+		retryAttempts: 3,
+		reopen:        reopen,
+		sizeFunc:      newSizeFunc(int64(len(content))),
+		size:          -1,
+	}
+	buf := make([]byte, len(content))
+	n, err := io.ReadFull(reader, buf)
+
+	assert.NoError(t, err)
+	assert.Equal(t, len(content), n)
+	assert.Equal(t, content, string(buf))
+	assert.Equal(t, 2, openCount)
+	assert.Equal(t, 0, initialReader.readAfterClose)
 }
 
 func TestRetryableReader_DenylistRetry_NonRetryableErrors(t *testing.T) {

--- a/internal/util/importutilv2/common/retryable_reader_test.go
+++ b/internal/util/importutilv2/common/retryable_reader_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"io"
 	"math"
-	"strings"
 	"testing"
 
 	"github.com/cockroachdb/errors"
@@ -123,45 +122,6 @@ func (m *customMockReader) ReadAt(p []byte, off int64) (int, error) {
 	return 0, nil
 }
 
-type prematureEOFReader struct {
-	*strings.Reader
-	limit        int
-	read         int
-	reportedSize int64
-}
-
-func newPrematureEOFReader(content string, limit int) storage.FileReader {
-	return newPrematureEOFReaderWithSize(content, limit, int64(len(content)))
-}
-
-func newPrematureEOFReaderWithSize(content string, limit int, reportedSize int64) storage.FileReader {
-	return &prematureEOFReader{
-		Reader:       strings.NewReader(content),
-		limit:        limit,
-		reportedSize: reportedSize,
-	}
-}
-
-func (r *prematureEOFReader) Read(p []byte) (int, error) {
-	if r.read >= r.limit {
-		return 0, io.EOF
-	}
-	if remaining := r.limit - r.read; len(p) > remaining {
-		p = p[:remaining]
-	}
-	n, err := r.Reader.Read(p)
-	r.read += n
-	return n, err
-}
-
-func (r *prematureEOFReader) Close() error {
-	return nil
-}
-
-func (r *prematureEOFReader) Size() (int64, error) {
-	return r.reportedSize, nil
-}
-
 type closeAwareReader struct {
 	storage.FileReader
 	closed         bool
@@ -187,17 +147,30 @@ func newSizeFunc(size int64) ReaderSizeFunc {
 	}
 }
 
+func newReopenFunc(content string, openCount *int, offsets *[]int64) ReopenReaderFunc {
+	return func(_ context.Context, _ string, offset int64) (storage.FileReader, error) {
+		if openCount != nil {
+			*openCount = *openCount + 1
+		}
+		if offsets != nil {
+			*offsets = append(*offsets, offset)
+		}
+		if offset < 0 || offset > int64(len(content)) {
+			return nil, io.EOF
+		}
+		return NewMockReader(content[offset:]), nil
+	}
+}
+
 func TestRetryableReader_ReopenOnPrematureEOF(t *testing.T) {
 	ctx := context.Background()
 	path := "/test/path"
 	content := "hello world"
 	openCount := 0
-	reopen := func(context.Context, string) (storage.FileReader, error) {
-		openCount++
-		return NewMockReader(content), nil
-	}
+	offsets := make([]int64, 0, 1)
+	reopen := newReopenFunc(content, &openCount, &offsets)
 
-	reader := NewRetryableReaderWithReopen(ctx, path, newPrematureEOFReader(content, 5), reopen, newSizeFunc(int64(len(content))))
+	reader := NewRetryableReaderWithReopen(ctx, path, NewPrematureEOFReader(content, 5), reopen, newSizeFunc(int64(len(content))))
 	buf := make([]byte, len(content))
 	n, err := io.ReadFull(reader, buf)
 
@@ -205,6 +178,7 @@ func TestRetryableReader_ReopenOnPrematureEOF(t *testing.T) {
 	assert.Equal(t, len(content), n)
 	assert.Equal(t, content, string(buf))
 	assert.Equal(t, 1, openCount)
+	assert.Equal(t, []int64{5}, offsets)
 }
 
 func TestRetryableReader_FinalEOFIsNotRetried(t *testing.T) {
@@ -212,10 +186,7 @@ func TestRetryableReader_FinalEOFIsNotRetried(t *testing.T) {
 	path := "/test/path"
 	content := "done"
 	openCount := 0
-	reopen := func(context.Context, string) (storage.FileReader, error) {
-		openCount++
-		return NewMockReader(content), nil
-	}
+	reopen := newReopenFunc(content, &openCount, nil)
 
 	reader := NewRetryableReaderWithReopen(ctx, path, NewMockReader(content), reopen, newSizeFunc(int64(len(content))))
 	buf := make([]byte, len(content))
@@ -234,10 +205,7 @@ func TestRetryableReader_ReopenOnRetryableError(t *testing.T) {
 	path := "/test/path"
 	content := "data after retry"
 	openCount := 0
-	reopen := func(context.Context, string) (storage.FileReader, error) {
-		openCount++
-		return NewMockReader(content), nil
-	}
+	reopen := newReopenFunc(content, &openCount, nil)
 
 	reader := NewRetryableReaderWithReopen(ctx, path, newErrorMockReader(content, errors.New("network timeout"), 1), reopen, newSizeFunc(int64(len(content))))
 	buf := make([]byte, len(content))
@@ -253,12 +221,15 @@ func TestRetryableReader_ExhaustedPrematureEOFReturnsUnexpectedEOF(t *testing.T)
 	ctx := context.Background()
 	path := "/test/path"
 	content := "hello world"
-	reopen := func(context.Context, string) (storage.FileReader, error) {
-		return newPrematureEOFReader(content, 0), nil
+	reopen := func(_ context.Context, _ string, offset int64) (storage.FileReader, error) {
+		if offset < 0 || offset > int64(len(content)) {
+			return nil, io.EOF
+		}
+		return NewPrematureEOFReader(content[offset:], 0), nil
 	}
 
 	reader := &retryableReader{
-		FileReader:    newPrematureEOFReader(content, 5),
+		FileReader:    NewPrematureEOFReader(content, 5),
 		ctx:           ctx,
 		path:          path,
 		retryAttempts: 2,
@@ -279,12 +250,9 @@ func TestRetryableReader_UsesSizeFuncForPrematureEOF(t *testing.T) {
 	path := "/test/path"
 	content := "hello world"
 	openCount := 0
-	reopen := func(context.Context, string) (storage.FileReader, error) {
-		openCount++
-		return NewMockReader(content), nil
-	}
+	reopen := newReopenFunc(content, &openCount, nil)
 
-	reader := NewRetryableReaderWithReopen(ctx, path, newPrematureEOFReaderWithSize(content, 5, 0), reopen, newSizeFunc(int64(len(content))))
+	reader := NewRetryableReaderWithReopen(ctx, path, NewPrematureEOFReaderWithSize(content, 5, 0), reopen, newSizeFunc(int64(len(content))))
 	buf := make([]byte, len(content))
 	n, err := io.ReadFull(reader, buf)
 
@@ -299,12 +267,9 @@ func TestRetryableReader_UsesSizeFuncForImmediateEOF(t *testing.T) {
 	path := "/test/path"
 	content := "hello world"
 	openCount := 0
-	reopen := func(context.Context, string) (storage.FileReader, error) {
-		openCount++
-		return NewMockReader(content), nil
-	}
+	reopen := newReopenFunc(content, &openCount, nil)
 
-	reader := NewRetryableReaderWithReopen(ctx, path, newPrematureEOFReaderWithSize(content, 0, 0), reopen, newSizeFunc(int64(len(content))))
+	reader := NewRetryableReaderWithReopen(ctx, path, NewPrematureEOFReaderWithSize(content, 0, 0), reopen, newSizeFunc(int64(len(content))))
 	buf := make([]byte, len(content))
 	n, err := io.ReadFull(reader, buf)
 
@@ -318,14 +283,14 @@ func TestRetryableReader_DoesNotReadClosedReaderAfterFailedReopen(t *testing.T) 
 	ctx := context.Background()
 	path := "/test/path"
 	content := "hello world"
-	initialReader := &closeAwareReader{FileReader: newPrematureEOFReader(content, 0)}
+	initialReader := &closeAwareReader{FileReader: NewPrematureEOFReader(content, 0)}
 	openCount := 0
-	reopen := func(context.Context, string) (storage.FileReader, error) {
+	reopen := func(_ context.Context, _ string, offset int64) (storage.FileReader, error) {
 		openCount++
 		if openCount == 1 {
 			return nil, errors.New("temporary reopen failure")
 		}
-		return NewMockReader(content), nil
+		return NewMockReader(content[offset:]), nil
 	}
 
 	reader := &retryableReader{

--- a/internal/util/importutilv2/csv/reader.go
+++ b/internal/util/importutilv2/csv/reader.go
@@ -54,7 +54,7 @@ func NewReader(ctx context.Context, cm storage.ChunkManager, schema *schemapb.Co
 	if err != nil {
 		return nil, merr.WrapErrImportFailed(fmt.Sprintf("read csv file failed, path=%s, err=%s", path, err.Error()))
 	}
-	retryableReader := common.NewRetryableReaderWithReopen(ctx, path, cmReader, cm.Reader)
+	retryableReader := common.NewRetryableReaderWithReopen(ctx, path, cmReader, cm.Reader, cm.Size)
 	count, err := common.EstimateReadCountPerBatch(bufferSize, schema)
 	if err != nil {
 		return nil, err

--- a/internal/util/importutilv2/csv/reader.go
+++ b/internal/util/importutilv2/csv/reader.go
@@ -54,7 +54,7 @@ func NewReader(ctx context.Context, cm storage.ChunkManager, schema *schemapb.Co
 	if err != nil {
 		return nil, merr.WrapErrImportFailed(fmt.Sprintf("read csv file failed, path=%s, err=%s", path, err.Error()))
 	}
-	retryableReader := common.NewRetryableReaderWithReopen(ctx, path, cmReader, cm.Reader, cm.Size)
+	retryableReader := common.NewRetryableReaderWithReopen(ctx, path, cmReader, common.NewChunkManagerReopenReaderFunc(cm), cm.Size)
 	count, err := common.EstimateReadCountPerBatch(bufferSize, schema)
 	if err != nil {
 		return nil, err

--- a/internal/util/importutilv2/csv/reader.go
+++ b/internal/util/importutilv2/csv/reader.go
@@ -54,7 +54,7 @@ func NewReader(ctx context.Context, cm storage.ChunkManager, schema *schemapb.Co
 	if err != nil {
 		return nil, merr.WrapErrImportFailed(fmt.Sprintf("read csv file failed, path=%s, err=%s", path, err.Error()))
 	}
-	retryableReader := common.NewRetryableReader(ctx, path, cmReader)
+	retryableReader := common.NewRetryableReaderWithReopen(ctx, path, cmReader, cm.Reader)
 	count, err := common.EstimateReadCountPerBatch(bufferSize, schema)
 	if err != nil {
 		return nil, err

--- a/internal/util/importutilv2/csv/reader_test.go
+++ b/internal/util/importutilv2/csv/reader_test.go
@@ -59,39 +59,6 @@ func (suite *ReaderSuite) SetupTest() {
 	suite.vecDataType = schemapb.DataType_FloatVector
 }
 
-type prematureEOFFileReader struct {
-	*strings.Reader
-	limit int
-	read  int
-}
-
-func newPrematureEOFFileReader(content string, limit int) storage.FileReader {
-	return &prematureEOFFileReader{
-		Reader: strings.NewReader(content),
-		limit:  limit,
-	}
-}
-
-func (r *prematureEOFFileReader) Read(p []byte) (int, error) {
-	if r.read >= r.limit {
-		return 0, io.EOF
-	}
-	if remaining := r.limit - r.read; len(p) > remaining {
-		p = p[:remaining]
-	}
-	n, err := r.Reader.Read(p)
-	r.read += n
-	return n, err
-}
-
-func (r *prematureEOFFileReader) Close() error {
-	return nil
-}
-
-func (r *prematureEOFFileReader) Size() (int64, error) {
-	return int64(r.Len()) + int64(r.read), nil
-}
-
 func (suite *ReaderSuite) run(dataType schemapb.DataType, elemType schemapb.DataType, nullable bool, nullPercent int) {
 	schema := &schemapb.CollectionSchema{
 		Fields: []*schemapb.FieldSchema{
@@ -397,14 +364,19 @@ func (suite *ReaderSuite) TestReadRecoversFromPrematureEOF() {
 			},
 		},
 	}
-	content := "pk,int32\n1,10\n2,20\n3,30\n"
+	var contentBuilder strings.Builder
+	contentBuilder.WriteString("pk,int32\n")
+	for i := 1; i <= 100; i++ {
+		fmt.Fprintf(&contentBuilder, "%d,%d\n", i, i*10)
+	}
+	content := contentBuilder.String()
 	openCount := 0
 
 	cm := mocks.NewChunkManager(suite.T())
 	cm.EXPECT().Reader(mock.Anything, "dummy path").RunAndReturn(func(ctx context.Context, path string) (storage.FileReader, error) {
 		openCount++
 		if openCount == 1 {
-			return newPrematureEOFFileReader(content, len(content)-2), nil
+			return importcommon.NewPrematureEOFReader(content, 18), nil
 		}
 		return importcommon.NewMockReader(content), nil
 	})
@@ -415,9 +387,9 @@ func (suite *ReaderSuite) TestReadRecoversFromPrematureEOF() {
 
 	data, err := reader.Read()
 	suite.NoError(err)
-	suite.Equal(3, data.GetRowNum())
+	suite.Equal(100, data.GetRowNum())
 	suite.Equal(int64(1), data.Data[100].GetRow(0))
-	suite.Equal(int32(30), data.Data[101].GetRow(2))
+	suite.Equal(int32(1000), data.Data[101].GetRow(99))
 	suite.GreaterOrEqual(openCount, 2)
 }
 

--- a/internal/util/importutilv2/csv/reader_test.go
+++ b/internal/util/importutilv2/csv/reader_test.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"math/rand"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
@@ -56,6 +57,39 @@ func (suite *ReaderSuite) SetupTest() {
 	suite.numRows = 100
 	suite.pkDataType = schemapb.DataType_Int64
 	suite.vecDataType = schemapb.DataType_FloatVector
+}
+
+type prematureEOFFileReader struct {
+	*strings.Reader
+	limit int
+	read  int
+}
+
+func newPrematureEOFFileReader(content string, limit int) storage.FileReader {
+	return &prematureEOFFileReader{
+		Reader: strings.NewReader(content),
+		limit:  limit,
+	}
+}
+
+func (r *prematureEOFFileReader) Read(p []byte) (int, error) {
+	if r.read >= r.limit {
+		return 0, io.EOF
+	}
+	if remaining := r.limit - r.read; len(p) > remaining {
+		p = p[:remaining]
+	}
+	n, err := r.Reader.Read(p)
+	r.read += n
+	return n, err
+}
+
+func (r *prematureEOFFileReader) Close() error {
+	return nil
+}
+
+func (r *prematureEOFFileReader) Size() (int64, error) {
+	return int64(r.Len()) + int64(r.read), nil
 }
 
 func (suite *ReaderSuite) run(dataType schemapb.DataType, elemType schemapb.DataType, nullable bool, nullPercent int) {
@@ -246,6 +280,7 @@ func (suite *ReaderSuite) TestError() {
 				return r, nil
 			}
 		})
+		cm.EXPECT().Size(mock.Anything, "dummy path").Return(int64(len(content)), nil).Maybe()
 
 		reader, err := NewReader(context.Background(), cm, schema, "dummy path", bufferSize, ',', "")
 		suite.Error(err)
@@ -344,6 +379,46 @@ func (suite *ReaderSuite) TestReadLoop() {
 	data, err = reader.Read()
 	suite.EqualError(io.EOF, err.Error())
 	suite.Nil(data)
+}
+
+func (suite *ReaderSuite) TestReadRecoversFromPrematureEOF() {
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{
+				FieldID:      100,
+				Name:         "pk",
+				IsPrimaryKey: true,
+				DataType:     schemapb.DataType_Int64,
+			},
+			{
+				FieldID:  101,
+				Name:     "int32",
+				DataType: schemapb.DataType_Int32,
+			},
+		},
+	}
+	content := "pk,int32\n1,10\n2,20\n3,30\n"
+	openCount := 0
+
+	cm := mocks.NewChunkManager(suite.T())
+	cm.EXPECT().Reader(mock.Anything, "dummy path").RunAndReturn(func(ctx context.Context, path string) (storage.FileReader, error) {
+		openCount++
+		if openCount == 1 {
+			return newPrematureEOFFileReader(content, len(content)-2), nil
+		}
+		return importcommon.NewMockReader(content), nil
+	})
+
+	reader, err := NewReader(context.Background(), cm, schema, "dummy path", 1024, ',', "")
+	suite.NoError(err)
+	defer reader.Close()
+
+	data, err := reader.Read()
+	suite.NoError(err)
+	suite.Equal(3, data.GetRowNum())
+	suite.Equal(int64(1), data.Data[100].GetRow(0))
+	suite.Equal(int32(30), data.Data[101].GetRow(2))
+	suite.GreaterOrEqual(openCount, 2)
 }
 
 func TestCsvReader(t *testing.T) {

--- a/internal/util/importutilv2/json/reader.go
+++ b/internal/util/importutilv2/json/reader.go
@@ -60,7 +60,7 @@ func newReader(ctx context.Context, cm storage.ChunkManager, schema *schemapb.Co
 	if err != nil {
 		return nil, merr.WrapErrImportFailed(fmt.Sprintf("read json file failed, path=%s, err=%s", path, err.Error()))
 	}
-	retryableReader := common.NewRetryableReaderWithReopen(ctx, path, r, cm.Reader, cm.Size)
+	retryableReader := common.NewRetryableReaderWithReopen(ctx, path, r, common.NewChunkManagerReopenReaderFunc(cm), cm.Size)
 	count, err := common.EstimateReadCountPerBatch(bufferSize, schema)
 	if err != nil {
 		return nil, err

--- a/internal/util/importutilv2/json/reader.go
+++ b/internal/util/importutilv2/json/reader.go
@@ -60,7 +60,7 @@ func newReader(ctx context.Context, cm storage.ChunkManager, schema *schemapb.Co
 	if err != nil {
 		return nil, merr.WrapErrImportFailed(fmt.Sprintf("read json file failed, path=%s, err=%s", path, err.Error()))
 	}
-	retryableReader := common.NewRetryableReaderWithReopen(ctx, path, r, cm.Reader)
+	retryableReader := common.NewRetryableReaderWithReopen(ctx, path, r, cm.Reader, cm.Size)
 	count, err := common.EstimateReadCountPerBatch(bufferSize, schema)
 	if err != nil {
 		return nil, err

--- a/internal/util/importutilv2/json/reader.go
+++ b/internal/util/importutilv2/json/reader.go
@@ -60,7 +60,7 @@ func newReader(ctx context.Context, cm storage.ChunkManager, schema *schemapb.Co
 	if err != nil {
 		return nil, merr.WrapErrImportFailed(fmt.Sprintf("read json file failed, path=%s, err=%s", path, err.Error()))
 	}
-	retryableReader := common.NewRetryableReader(ctx, path, r)
+	retryableReader := common.NewRetryableReaderWithReopen(ctx, path, r, cm.Reader)
 	count, err := common.EstimateReadCountPerBatch(bufferSize, schema)
 	if err != nil {
 		return nil, err

--- a/internal/util/importutilv2/json/reader_test.go
+++ b/internal/util/importutilv2/json/reader_test.go
@@ -19,9 +19,7 @@ package json
 import (
 	"context"
 	"encoding/json"
-	"io"
 	"math"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
@@ -56,39 +54,6 @@ func (suite *ReaderSuite) SetupTest() {
 	suite.numRows = 100
 	suite.pkDataType = schemapb.DataType_Int64
 	suite.vecDataType = schemapb.DataType_FloatVector
-}
-
-type prematureEOFFileReader struct {
-	*strings.Reader
-	limit int
-	read  int
-}
-
-func newPrematureEOFFileReader(content string, limit int) storage.FileReader {
-	return &prematureEOFFileReader{
-		Reader: strings.NewReader(content),
-		limit:  limit,
-	}
-}
-
-func (r *prematureEOFFileReader) Read(p []byte) (int, error) {
-	if r.read >= r.limit {
-		return 0, io.EOF
-	}
-	if remaining := r.limit - r.read; len(p) > remaining {
-		p = p[:remaining]
-	}
-	n, err := r.Reader.Read(p)
-	r.read += n
-	return n, err
-}
-
-func (r *prematureEOFFileReader) Close() error {
-	return nil
-}
-
-func (r *prematureEOFFileReader) Size() (int64, error) {
-	return int64(r.Len()) + int64(r.read), nil
 }
 
 func (suite *ReaderSuite) run(dataType schemapb.DataType, elemType schemapb.DataType, nullable bool, nullPercent int) {
@@ -508,7 +473,7 @@ func (suite *ReaderSuite) TestReadRecoversFromPrematureEOF() {
 	cm.EXPECT().Reader(mock.Anything, "mockPath").RunAndReturn(func(ctx context.Context, path string) (storage.FileReader, error) {
 		openCount++
 		if openCount == 1 {
-			return newPrematureEOFFileReader(jsonContent, 10), nil
+			return importcommon.NewPrematureEOFReader(jsonContent, 10), nil
 		}
 		return importcommon.NewMockReader(jsonContent), nil
 	})

--- a/internal/util/importutilv2/json/reader_test.go
+++ b/internal/util/importutilv2/json/reader_test.go
@@ -88,7 +88,7 @@ func (r *prematureEOFFileReader) Close() error {
 }
 
 func (r *prematureEOFFileReader) Size() (int64, error) {
-	return int64(r.Reader.Len()) + int64(r.read), nil
+	return int64(r.Len()) + int64(r.read), nil
 }
 
 func (suite *ReaderSuite) run(dataType schemapb.DataType, elemType schemapb.DataType, nullable bool, nullPercent int) {
@@ -374,6 +374,7 @@ func (suite *ReaderSuite) TestDecodeError() {
 			r := importcommon.NewMockReader(jsonContent)
 			return r, nil
 		})
+		cm.EXPECT().Size(mock.Anything, "mockPath").Return(int64(len(jsonContent)), nil).Maybe()
 		var reader *reader
 		var err error
 		if isLinesFormat {

--- a/internal/util/importutilv2/json/reader_test.go
+++ b/internal/util/importutilv2/json/reader_test.go
@@ -19,7 +19,9 @@ package json
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"math"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
@@ -54,6 +56,39 @@ func (suite *ReaderSuite) SetupTest() {
 	suite.numRows = 100
 	suite.pkDataType = schemapb.DataType_Int64
 	suite.vecDataType = schemapb.DataType_FloatVector
+}
+
+type prematureEOFFileReader struct {
+	*strings.Reader
+	limit int
+	read  int
+}
+
+func newPrematureEOFFileReader(content string, limit int) storage.FileReader {
+	return &prematureEOFFileReader{
+		Reader: strings.NewReader(content),
+		limit:  limit,
+	}
+}
+
+func (r *prematureEOFFileReader) Read(p []byte) (int, error) {
+	if r.read >= r.limit {
+		return 0, io.EOF
+	}
+	if remaining := r.limit - r.read; len(p) > remaining {
+		p = p[:remaining]
+	}
+	n, err := r.Reader.Read(p)
+	r.read += n
+	return n, err
+}
+
+func (r *prematureEOFFileReader) Close() error {
+	return nil
+}
+
+func (r *prematureEOFFileReader) Size() (int64, error) {
+	return int64(r.Reader.Len()) + int64(r.read), nil
 }
 
 func (suite *ReaderSuite) run(dataType schemapb.DataType, elemType schemapb.DataType, nullable bool, nullPercent int) {
@@ -452,6 +487,39 @@ func (suite *ReaderSuite) TestReadCount() {
 	data, err = reader.Read()
 	suite.NoError(err)
 	suite.Equal(20, data.GetRowNum())
+}
+
+func (suite *ReaderSuite) TestReadRecoversFromPrematureEOF() {
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{
+				FieldID:      100,
+				Name:         "pk",
+				IsPrimaryKey: true,
+				DataType:     schemapb.DataType_Int64,
+			},
+		},
+	}
+	jsonContent := `[{"pk":1},{"pk":2},{"pk":3}]`
+	openCount := 0
+
+	cm := mocks.NewChunkManager(suite.T())
+	cm.EXPECT().Reader(mock.Anything, "mockPath").RunAndReturn(func(ctx context.Context, path string) (storage.FileReader, error) {
+		openCount++
+		if openCount == 1 {
+			return newPrematureEOFFileReader(jsonContent, 10), nil
+		}
+		return importcommon.NewMockReader(jsonContent), nil
+	})
+
+	reader, err := NewReader(context.Background(), cm, schema, "mockPath", math.MaxInt)
+	suite.NoError(err)
+	defer reader.Close()
+
+	data, err := reader.Read()
+	suite.NoError(err)
+	suite.Equal(3, data.GetRowNum())
+	suite.GreaterOrEqual(openCount, 2)
 }
 
 func TestJsonReader(t *testing.T) {

--- a/internal/util/importutilv2/numpy/reader_test.go
+++ b/internal/util/importutilv2/numpy/reader_test.go
@@ -126,39 +126,6 @@ func createReader(fieldData storage.FieldData, dataType schemapb.DataType) (io.R
 	return strings.NewReader(buf.String()), nil
 }
 
-type prematureEOFFileReader struct {
-	*strings.Reader
-	limit int
-	read  int
-}
-
-func newPrematureEOFFileReader(content string, limit int) storage.FileReader {
-	return &prematureEOFFileReader{
-		Reader: strings.NewReader(content),
-		limit:  limit,
-	}
-}
-
-func (r *prematureEOFFileReader) Read(p []byte) (int, error) {
-	if r.read >= r.limit {
-		return 0, io.EOF
-	}
-	if remaining := r.limit - r.read; len(p) > remaining {
-		p = p[:remaining]
-	}
-	n, err := r.Reader.Read(p)
-	r.read += n
-	return n, err
-}
-
-func (r *prematureEOFFileReader) Close() error {
-	return nil
-}
-
-func (r *prematureEOFFileReader) Size() (int64, error) {
-	return int64(r.Len()) + int64(r.read), nil
-}
-
 func (suite *ReaderSuite) run(dt schemapb.DataType) {
 	schema := &schemapb.CollectionSchema{
 		Fields: []*schemapb.FieldSchema{
@@ -489,36 +456,62 @@ func (suite *ReaderSuite) TestReadRecoversFromPrematureEOF() {
 				IsPrimaryKey: true,
 				DataType:     schemapb.DataType_Int64,
 			},
+			{
+				FieldID:    101,
+				Name:       "varchar",
+				DataType:   schemapb.DataType_VarChar,
+				TypeParams: []*commonpb.KeyValuePair{{Key: common.MaxLengthKey, Value: "128"}},
+			},
+			{
+				FieldID:    102,
+				Name:       "vec",
+				DataType:   schemapb.DataType_FloatVector,
+				TypeParams: []*commonpb.KeyValuePair{{Key: common.DimKey, Value: fmt.Sprintf("%d", dim)}},
+			},
 		},
 	}
 	insertData, err := testutil.CreateInsertData(schema, 3)
 	suite.NoError(err)
-	npyReader, err := createReader(insertData.Data[100], schemapb.DataType_Int64)
-	suite.NoError(err)
-	contentBytes, err := io.ReadAll(npyReader)
-	suite.NoError(err)
-	content := string(contentBytes)
-	openCount := 0
+	files := map[int64]string{
+		100: "pk.npy",
+		101: "varchar.npy",
+		102: "vec.npy",
+	}
+	contents := make(map[string]string)
+	for _, field := range schema.GetFields() {
+		npyReader, err := createReader(insertData.Data[field.GetFieldID()], field.GetDataType())
+		suite.NoError(err)
+		contentBytes, err := io.ReadAll(npyReader)
+		suite.NoError(err)
+		contents[files[field.GetFieldID()]] = string(contentBytes)
+	}
+	openCount := make(map[string]int)
 
 	cm := mocks.NewChunkManager(suite.T())
-	cm.EXPECT().Reader(mock.Anything, "pk.npy").RunAndReturn(func(ctx context.Context, path string) (storage.FileReader, error) {
-		openCount++
-		if openCount == 1 {
-			return newPrematureEOFFileReader(content, len(content)-2), nil
-		}
-		return importcommon.NewMockReader(content), nil
-	})
+	for _, path := range files {
+		path := path
+		cm.EXPECT().Reader(mock.Anything, path).RunAndReturn(func(ctx context.Context, path string) (storage.FileReader, error) {
+			openCount[path]++
+			if openCount[path] == 1 {
+				return importcommon.NewPrematureEOFReader(contents[path], len(contents[path])-2), nil
+			}
+			return importcommon.NewMockReader(contents[path]), nil
+		})
+	}
 
-	reader, err := NewReader(context.Background(), cm, schema, []string{"pk.npy"}, math.MaxInt)
+	reader, err := NewReader(context.Background(), cm, schema, lo.Values(files), math.MaxInt)
 	suite.NoError(err)
 	defer reader.Close()
 
 	data, err := reader.Read()
 	suite.NoError(err)
 	suite.Equal(3, data.GetRowNum())
-	suite.Equal(insertData.Data[100].GetRow(0), data.Data[100].GetRow(0))
-	suite.Equal(insertData.Data[100].GetRow(2), data.Data[100].GetRow(2))
-	suite.GreaterOrEqual(openCount, 2)
+	for _, field := range schema.GetFields() {
+		for i := 0; i < data.GetRowNum(); i++ {
+			suite.Equal(insertData.Data[field.GetFieldID()].GetRow(i), data.Data[field.GetFieldID()].GetRow(i))
+		}
+		suite.GreaterOrEqual(openCount[files[field.GetFieldID()]], 2)
+	}
 }
 
 func TestNumpyCreateReaders(t *testing.T) {

--- a/internal/util/importutilv2/numpy/reader_test.go
+++ b/internal/util/importutilv2/numpy/reader_test.go
@@ -126,6 +126,39 @@ func createReader(fieldData storage.FieldData, dataType schemapb.DataType) (io.R
 	return strings.NewReader(buf.String()), nil
 }
 
+type prematureEOFFileReader struct {
+	*strings.Reader
+	limit int
+	read  int
+}
+
+func newPrematureEOFFileReader(content string, limit int) storage.FileReader {
+	return &prematureEOFFileReader{
+		Reader: strings.NewReader(content),
+		limit:  limit,
+	}
+}
+
+func (r *prematureEOFFileReader) Read(p []byte) (int, error) {
+	if r.read >= r.limit {
+		return 0, io.EOF
+	}
+	if remaining := r.limit - r.read; len(p) > remaining {
+		p = p[:remaining]
+	}
+	n, err := r.Reader.Read(p)
+	r.read += n
+	return n, err
+}
+
+func (r *prematureEOFFileReader) Close() error {
+	return nil
+}
+
+func (r *prematureEOFFileReader) Size() (int64, error) {
+	return int64(r.Len()) + int64(r.read), nil
+}
+
 func (suite *ReaderSuite) run(dt schemapb.DataType) {
 	schema := &schemapb.CollectionSchema{
 		Fields: []*schemapb.FieldSchema{
@@ -445,6 +478,47 @@ func (suite *ReaderSuite) TestVector() {
 		suite.vecDataType = dataType
 		suite.run(schemapb.DataType_Int32)
 	}
+}
+
+func (suite *ReaderSuite) TestReadRecoversFromPrematureEOF() {
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{
+				FieldID:      100,
+				Name:         "pk",
+				IsPrimaryKey: true,
+				DataType:     schemapb.DataType_Int64,
+			},
+		},
+	}
+	insertData, err := testutil.CreateInsertData(schema, 3)
+	suite.NoError(err)
+	npyReader, err := createReader(insertData.Data[100], schemapb.DataType_Int64)
+	suite.NoError(err)
+	contentBytes, err := io.ReadAll(npyReader)
+	suite.NoError(err)
+	content := string(contentBytes)
+	openCount := 0
+
+	cm := mocks.NewChunkManager(suite.T())
+	cm.EXPECT().Reader(mock.Anything, "pk.npy").RunAndReturn(func(ctx context.Context, path string) (storage.FileReader, error) {
+		openCount++
+		if openCount == 1 {
+			return newPrematureEOFFileReader(content, len(content)-2), nil
+		}
+		return importcommon.NewMockReader(content), nil
+	})
+
+	reader, err := NewReader(context.Background(), cm, schema, []string{"pk.npy"}, math.MaxInt)
+	suite.NoError(err)
+	defer reader.Close()
+
+	data, err := reader.Read()
+	suite.NoError(err)
+	suite.Equal(3, data.GetRowNum())
+	suite.Equal(insertData.Data[100].GetRow(0), data.Data[100].GetRow(0))
+	suite.Equal(insertData.Data[100].GetRow(2), data.Data[100].GetRow(2))
+	suite.GreaterOrEqual(openCount, 2)
 }
 
 func TestNumpyCreateReaders(t *testing.T) {

--- a/internal/util/importutilv2/numpy/util.go
+++ b/internal/util/importutilv2/numpy/util.go
@@ -97,7 +97,7 @@ func CreateReaders(ctx context.Context, cm storage.ChunkManager, schema *schemap
 			return nil, merr.WrapErrImportFailed(
 				fmt.Sprintf("failed to read the file '%s', error: %s", path, err.Error()))
 		}
-		retryableReader := common.NewRetryableReaderWithReopen(ctx, path, reader, cm.Reader, cm.Size)
+		retryableReader := common.NewRetryableReaderWithReopen(ctx, path, reader, common.NewChunkManagerReopenReaderFunc(cm), cm.Size)
 		readers[field.GetFieldID()] = retryableReader
 		readFields[field.GetName()] = field.GetFieldID()
 	}

--- a/internal/util/importutilv2/numpy/util.go
+++ b/internal/util/importutilv2/numpy/util.go
@@ -97,7 +97,7 @@ func CreateReaders(ctx context.Context, cm storage.ChunkManager, schema *schemap
 			return nil, merr.WrapErrImportFailed(
 				fmt.Sprintf("failed to read the file '%s', error: %s", path, err.Error()))
 		}
-		retryableReader := common.NewRetryableReader(ctx, path, reader)
+		retryableReader := common.NewRetryableReaderWithReopen(ctx, path, reader, cm.Reader)
 		readers[field.GetFieldID()] = retryableReader
 		readFields[field.GetName()] = field.GetFieldID()
 	}

--- a/internal/util/importutilv2/numpy/util.go
+++ b/internal/util/importutilv2/numpy/util.go
@@ -97,7 +97,7 @@ func CreateReaders(ctx context.Context, cm storage.ChunkManager, schema *schemap
 			return nil, merr.WrapErrImportFailed(
 				fmt.Sprintf("failed to read the file '%s', error: %s", path, err.Error()))
 		}
-		retryableReader := common.NewRetryableReaderWithReopen(ctx, path, reader, cm.Reader)
+		retryableReader := common.NewRetryableReaderWithReopen(ctx, path, reader, cm.Reader, cm.Size)
 		readers[field.GetFieldID()] = retryableReader
 		readFields[field.GetName()] = field.GetFieldID()
 	}

--- a/internal/util/importutilv2/parquet/reader.go
+++ b/internal/util/importutilv2/parquet/reader.go
@@ -59,7 +59,7 @@ func NewReader(ctx context.Context, cm storage.ChunkManager, schema *schemapb.Co
 	if err != nil {
 		return nil, err
 	}
-	retryableReader := common.NewRetryableReaderWithReopen(ctx, path, cmReader, cm.Reader)
+	retryableReader := common.NewRetryableReader(ctx, path, cmReader)
 
 	allFields := typeutil.GetAllFieldSchemas(schema)
 	// Each ColumnReader consumes ReaderProperties.BufferSize memory independently.

--- a/internal/util/importutilv2/parquet/reader.go
+++ b/internal/util/importutilv2/parquet/reader.go
@@ -59,7 +59,7 @@ func NewReader(ctx context.Context, cm storage.ChunkManager, schema *schemapb.Co
 	if err != nil {
 		return nil, err
 	}
-	retryableReader := common.NewRetryableReader(ctx, path, cmReader)
+	retryableReader := common.NewRetryableReaderWithReopen(ctx, path, cmReader, cm.Reader)
 
 	allFields := typeutil.GetAllFieldSchemas(schema)
 	// Each ColumnReader consumes ReaderProperties.BufferSize memory independently.


### PR DESCRIPTION
## Summary

Fixes #49645

Bulk import can hit `unexpected EOF` when a remote object stream stays idle during function execution and the object-store reader returns a premature EOF. This PR makes sequential import readers recover by reopening the object reader at the last successful offset when EOF happens before the known object size.

## Changes

- Add reopen-and-retry support to `RetryableReader` for retryable read errors and premature EOF.
- Use `ChunkManager.Size` as a fallback object-size source for readers whose `Size()` is lazy or unreliable before reading.
- Return unexpected EOF, not clean EOF, when premature EOF retries are exhausted.
- Enable the reopen path for JSON, CSV, and Numpy import readers.
- Keep Parquet unchanged because Arrow uses `ReadAt`/`Seek`, which this sequential wrapper does not cover.

## Test Plan

- [x] `make static-check`
- [x] `git diff --check`
- [x] `go test ./internal/util/importutilv2/common ./internal/util/importutilv2/json ./internal/util/importutilv2/csv ./internal/util/importutilv2/numpy ./internal/util/importutilv2/parquet -count=1 -ldflags="-r ${RPATH}"`
