### PR TITLE
fix: skip loading BM25 sparse vector fields

### DIFF
--- a/internal/core/src/common/FieldMetaTest.cpp
+++ b/internal/core/src/common/FieldMetaTest.cpp
@@ -135,4 +135,32 @@ TEST(FieldMetaTest, ShouldLoadFieldExternalFieldIgnoredByLoadFields) {
     EXPECT_FALSE(schema->ShouldLoadField(FieldId(101)));
 }
 
+TEST(FieldMetaTest, ShouldLoadFieldReturnsFalseForBM25FunctionOutput) {
+    milvus::proto::schema::CollectionSchema schema_proto;
+
+    auto* pk_field = schema_proto.add_fields();
+    pk_field->set_fieldid(100);
+    pk_field->set_name("pk");
+    pk_field->set_data_type(milvus::proto::schema::DataType::Int64);
+    pk_field->set_is_primary_key(true);
+
+    auto* bm25_vector = schema_proto.add_fields();
+    bm25_vector->set_fieldid(101);
+    bm25_vector->set_name("sparse");
+    bm25_vector->set_data_type(
+        milvus::proto::schema::DataType::SparseFloatVector);
+
+    auto* function = schema_proto.add_functions();
+    function->set_type(milvus::proto::schema::BM25);
+    function->add_output_field_ids(101);
+
+    auto schema = Schema::ParseFrom(schema_proto);
+
+    EXPECT_TRUE(schema->ShouldLoadField(FieldId(100)));
+    EXPECT_FALSE(schema->ShouldLoadField(FieldId(101)));
+
+    schema->UpdateLoadFields({101});
+    EXPECT_FALSE(schema->ShouldLoadField(FieldId(101)));
+}
+
 }  // namespace milvus

--- a/internal/core/src/common/Schema.cpp
+++ b/internal/core/src/common/Schema.cpp
@@ -88,6 +88,15 @@ Schema::ParseFrom(const milvus::proto::schema::CollectionSchema& schema_proto) {
         }
     }
 
+    for (const auto& function : schema_proto.functions()) {
+        if (function.type() != milvus::proto::schema::BM25) {
+            continue;
+        }
+        for (const auto output_field_id : function.output_field_ids()) {
+            schema->bm25_function_output_fields_.emplace(output_field_id);
+        }
+    }
+
     std::tie(schema->has_mmap_setting_, schema->mmap_enabled_) =
         GetBoolFromRepeatedKVs(schema_proto.properties(), MMAP_ENABLED_KEY);
 

--- a/internal/core/src/common/Schema.h
+++ b/internal/core/src/common/Schema.h
@@ -426,6 +426,9 @@ class Schema {
 
     bool
     ShouldLoadField(FieldId field_id) {
+        if (bm25_function_output_fields_.count(field_id) > 0) {
+            return false;
+        }
         auto it = fields_.find(field_id);
         if (it != fields_.end() && !it->second.NeedLoad()) {
             return false;
@@ -560,6 +563,7 @@ class Schema {
     // field partial load list
     // work as hint now
     std::unordered_set<FieldId> load_fields_;
+    std::unordered_set<FieldId> bm25_function_output_fields_;
 
     // schema_version_, currently marked with update timestamp
     uint64_t schema_version_;


### PR DESCRIPTION
relate: #49650

## Summary
Skip BM25 sparse vector fields in segcore ShouldLoadField decisions so BM25 function outputs are not treated as loadable raw field data. Cover both BM25 function output fields and vector fields whose metric type is BM25 with unit tests.