### PR TITLE
enhance: optimize querycoord target readiness check

### DIFF
--- a/internal/querycoordv2/observers/target_observer.go
+++ b/internal/querycoordv2/observers/target_observer.go
@@ -466,14 +466,16 @@ func (ob *TargetObserver) shouldUpdateCurrentTarget(ctx context.Context, collect
 		readyDelegatorsInCollection = append(readyDelegatorsInCollection, readyDelegatorsInReplica...)
 	}
 
-	// segment data satisfies next target spec
-	segmentDataReady := !paramtable.Get().QueryCoordCfg.UpdateTargetNeedSegmentDataReady.GetAsBool() ||
-		utils.CheckSegmentDataReady(ctx, collectionID, ob.distMgr, ob.targetMgr, meta.NextTarget) == nil
-
 	syncSuccess := ob.syncNextTargetToDelegator(ctx, collectionID, readyDelegatorsInCollection, newVersion)
 	syncedChannelNames := lo.Uniq(lo.Map(readyDelegatorsInCollection, func(ch *meta.DmChannel, _ int) string { return ch.ChannelName }))
 	// only after all channel are synced, we can consider the current target is ready
-	return syncSuccess && lo.Every(syncedChannelNames, lo.Keys(channelNames)) && segmentDataReady
+	if !syncSuccess || !lo.Every(syncedChannelNames, lo.Keys(channelNames)) {
+		return false
+	}
+
+	// segment data satisfies next target spec
+	return !paramtable.Get().QueryCoordCfg.UpdateTargetNeedSegmentDataReady.GetAsBool() ||
+		utils.CheckSegmentDataReady(ctx, collectionID, ob.distMgr, ob.targetMgr, meta.NextTarget) == nil
 }
 
 // sync next target info to delegator as readable snapshot

--- a/internal/querycoordv2/utils/util.go
+++ b/internal/querycoordv2/utils/util.go
@@ -95,8 +95,14 @@ func CheckSegmentDataReady(ctx context.Context, collectionID int64, distManager 
 
 	// Check whether segments are fully loaded
 	segmentDist := targetMgr.GetSealedSegmentsByCollection(ctx, collectionID, scope)
+	distSegments := distManager.SegmentDistManager.GetByFilter(meta.WithCollectionID(collectionID))
+	distBySegmentID := make(map[int64][]*meta.Segment, len(distSegments))
+	for _, segment := range distSegments {
+		distBySegmentID[segment.GetID()] = append(distBySegmentID[segment.GetID()], segment)
+	}
+
 	for segmentID, segmentInfo := range segmentDist {
-		segments := distManager.SegmentDistManager.GetByFilter(meta.WithCollectionID(collectionID), meta.WithSegmentID(segmentID))
+		segments := distBySegmentID[segmentID]
 		if len(segments) == 0 {
 			log.RatedInfo(10, "segment is not available", zap.Int64("segmentID", segmentID))
 			return merr.WrapErrSegmentLack(segmentID)


### PR DESCRIPTION
## Summary
Optimize QueryCoord target readiness checks so segment data readiness is evaluated only after target sync succeeds and all target channels are synced. This avoids advancing current target readiness based on incomplete channel or segment distribution during target update/rebalance.

## Issue
issue: #49666