### PR TITLE
enhance: make PK index warmup configurable

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -496,7 +496,7 @@ queryNode:
         # - "disable": data will not be proactively loaded into the cache, and loaded only if needed by search/query tasks.
         # Defaults to "sync", except for vector field which defaults to "disable".
         scalarField: sync
-        scalarIndex: sync
+        scalarIndex: sync # cache warmup for scalar indexes and the system PK index.
         vectorField: disable # cache warmup for vector field raw data is by default disabled.
         vectorIndex: sync
       # If evictionEnabled is true, a background thread will run every evictionIntervalMs to determine if an

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -496,7 +496,10 @@ queryNode:
         # - "disable": data will not be proactively loaded into the cache, and loaded only if needed by search/query tasks.
         # Defaults to "sync", except for vector field which defaults to "disable".
         scalarField: sync
-        scalarIndex: sync # cache warmup for scalar indexes and the system PK index.
+        # options: sync, async, disable.
+        # Cache warmup for scalar indexes and the system PK index.
+        # Defaults to "sync".
+        scalarIndex: sync
         vectorField: disable # cache warmup for vector field raw data is by default disabled.
         vectorIndex: sync
       # If evictionEnabled is true, a background thread will run every evictionIntervalMs to determine if an

--- a/internal/core/src/segcore/storagev2translator/SystemIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/SystemIndexTranslator.cpp
@@ -233,7 +233,9 @@ PkIndexTranslator::PkIndexTranslator(
       meta_(milvus::cachinglayer::StorageType::MEMORY,
             milvus::cachinglayer::CellIdMappingMode::ALWAYS_ZERO,
             milvus::cachinglayer::CellDataType::OTHER,
-            CacheWarmupPolicy::CacheWarmupPolicy_Sync,
+            milvus::segcore::getCacheWarmupPolicy(/* warmup_policy */ "",
+                                                  /* is_vector */ false,
+                                                  /* is_index */ true),
             /* support_eviction */ true) {
 }
 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3644,7 +3644,10 @@ Defaults to "sync", except for vector field which defaults to "disable".`,
 		Key:          "queryNode.segcore.tieredStorage.warmup.scalarIndex",
 		Version:      "2.6.0",
 		DefaultValue: "sync",
-		Export:       true,
+		Doc: `options: sync, async, disable.
+Cache warmup for scalar indexes and the system PK index.
+Defaults to "sync".`,
+		Export: true,
 	}
 	p.TieredWarmupScalarIndex.Init(base.mgr)
 


### PR DESCRIPTION
## Summary
Make the StorageV2 system PK index use the configurable scalar index warmup policy instead of a hardcoded sync policy. The default remains sync, while deployments can set `queryNode.segcore.tieredStorage.warmup.scalarIndex` to disable or async for the PK index as well.

## Issue
issue: #49665