### PR TITLE
test: Update Python client test expectations for server behavior changes

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_collection.py
+++ b/tests/python_client/milvus_client/test_milvus_client_collection.py
@@ -4261,6 +4261,7 @@ class TestMilvusClientDescribeCollectionValid(TestMilvusClientV2Base):
             "functions": [],
             "aliases": [],
             "consistency_level": 0,
+            "consistency_level_name": "Strong",
             "properties": {"timezone": "UTC"},
             "num_partitions": 1,
             "enable_dynamic_field": True,

--- a/tests/python_client/milvus_client/test_milvus_client_search.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search.py
@@ -1264,14 +1264,34 @@ class TestSearchInvalidIndependent(TestMilvusClientV2Base):
         expressions = [ct.default_bool_field_name, "true", "false"]
         for expression in expressions:
             log.debug(f"search with expression: {expression}")
-            self.search(client, collection_name,
-                        data=vectors[:default_nq], anns_field=default_search_field,
-                        search_params=default_search_params, limit=default_limit,
-                        filter=expression,
-                        check_task=CheckTasks.err_res,
-                        check_items={"err_code": 1100,
-                                     "err_msg": "failed to create query plan: predicate is not a "
-                                                "boolean expression: %s, data type: Bool" % expression})
+            if expression == "true":
+                self.search(client, collection_name,
+                            data=vectors[:default_nq], anns_field=default_search_field,
+                            search_params=default_search_params, limit=default_limit,
+                            filter=expression,
+                            check_task=CheckTasks.check_search_results,
+                            check_items={"nq": default_nq, "limit": default_limit,
+                                         "metric": "COSINE", "enable_milvus_client_api": True,
+                                         "pk_name": ct.default_int64_field_name})
+            elif expression == "false":
+                self.search(client, collection_name,
+                            data=vectors[:default_nq], anns_field=default_search_field,
+                            search_params=default_search_params, limit=default_limit,
+                            filter=expression,
+                            check_task=CheckTasks.check_search_results,
+                            check_items={"nq": default_nq, "limit": 0,
+                                         "metric": "COSINE", "enable_milvus_client_api": True,
+                                         "pk_name": ct.default_int64_field_name})
+            else:
+                self.search(client, collection_name,
+                            data=vectors[:default_nq], anns_field=default_search_field,
+                            search_params=default_search_params, limit=default_limit,
+                            filter=expression,
+                            check_task=CheckTasks.err_res,
+                            check_items={"err_code": 1100,
+                                         "err_msg": "failed to create query plan: predicate is not a "
+                                                    "boolean expression: %s, data type: Bool" % expression})
+
         expression = f"!{ct.default_bool_field_name}"
         log.debug(f"search with expression: {expression}")
         self.search(client, collection_name,
@@ -1292,16 +1312,6 @@ class TestSearchInvalidIndependent(TestMilvusClientV2Base):
                     check_items={"err_code": 1100,
                                  "err_msg": f"cannot parse expression: {ct.default_int64_field_name} > 0 and {ct.default_bool_field_name}, "
                                             "error: 'and' can only be used between boolean expressions"})
-        expression = f"{ct.default_int64_field_name} > 0 or false"
-        log.debug(f"search with expression: {expression}")
-        self.search(client, collection_name,
-                    data=vectors[:default_nq], anns_field=default_search_field,
-                    search_params=default_search_params, limit=default_limit,
-                    filter=expression,
-                    check_task=CheckTasks.err_res,
-                    check_items={"err_code": 1100,
-                                 "err_msg": f"cannot parse expression: {ct.default_int64_field_name} > 0 or false, "
-                                            "error: 'or' can only be used between boolean expressions"})
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_search_with_expression_invalid_array_one(self):


### PR DESCRIPTION
## Summary

Update Python client test assertions to align with recent server-side behavior changes observed in nightly CI.

**Related issue**: #49671

### Changes

**`tests/python_client/milvus_client/test_milvus_client_collection.py`**
- `test_milvus_client_collection_describe`: Add `"consistency_level_name": "Strong"` to the expected `describe_collection` response dict, as the server now returns this additional field.

**`tests/python_client/milvus_client/test_milvus_client_search.py`**
- `test_search_with_expression_invalid_bool`:
  - `"true"` and `"false"` are now treated as valid boolean literal expressions by the server. Updated assertions to verify their correct behavior:
    - `"true"` returns `limit` results (tautology)
    - `"false"` returns `0` results (contradiction)
  - Removed the assertion for `{int64} > 0 or false`, as `false` being a valid boolean literal makes this entire expression valid.

### Test Plan

- [x] `test_milvus_client_collection_describe` passes locally
- [x] `test_search_with_expression_invalid_bool` passes locally