### PR TITLE
fix: [cp3.0]constrain max index version for old query nodes

### DIFF
--- a/internal/datacoord/index_engine_version_manager.go
+++ b/internal/datacoord/index_engine_version_manager.go
@@ -233,11 +233,15 @@ func (m *versionManagerImpl) getMaximumVersion() int32 {
 
 	maximum := int32(math.MaxInt32)
 	for _, version := range m.versions {
-		if version.MaximumIndexVersion == 0 {
+		// Old QueryNodes do not report MaximumIndexVersion. In that case, use
+		// CurrentIndexVersion as the conservative upper bound; maxVersion should
+		// never be lower than the current version that the node already supports.
+		maxVersion := max(version.CurrentIndexVersion, version.MaximumIndexVersion)
+		if maxVersion == 0 {
 			continue
 		}
-		if version.MaximumIndexVersion < maximum {
-			maximum = version.MaximumIndexVersion
+		if maxVersion < maximum {
+			maximum = maxVersion
 		}
 	}
 	return maximum

--- a/internal/datacoord/index_engine_version_manager_test.go
+++ b/internal/datacoord/index_engine_version_manager_test.go
@@ -388,7 +388,7 @@ func Test_IndexEngineVersionManager_GetMaximumIndexEngineVersion(t *testing.T) {
 	// empty - returns MaxInt32 (no upper bound)
 	assert.Equal(t, int32(math.MaxInt32), m.GetMaximumIndexEngineVersion())
 
-	// all nodes report Maximum=0 (old QNs) - returns MaxInt32
+	// all nodes report Maximum=0 (old QNs) - falls back to current version as max
 	m.Startup(map[string]*sessionutil.Session{
 		"1": {
 			SessionRaw: sessionutil.SessionRaw{
@@ -397,28 +397,32 @@ func Test_IndexEngineVersionManager_GetMaximumIndexEngineVersion(t *testing.T) {
 			},
 		},
 	})
-	assert.Equal(t, int32(math.MaxInt32), m.GetMaximumIndexEngineVersion())
+	assert.Equal(t, int32(20), m.GetMaximumIndexEngineVersion())
 
-	// mix of old QN (Max=0) and new QN (Max=30) - skip old, return 30
+	// mix of old QN (Max=0) and new QN (Max=30) - old QN current constrains cluster max
 	m.AddNode(&sessionutil.Session{
 		SessionRaw: sessionutil.SessionRaw{
 			ServerID:           2,
 			IndexEngineVersion: sessionutil.IndexEngineVersion{CurrentIndexVersion: 15, MaximumIndexVersion: 30},
 		},
 	})
-	assert.Equal(t, int32(30), m.GetMaximumIndexEngineVersion())
+	assert.Equal(t, int32(20), m.GetMaximumIndexEngineVersion())
 
-	// add another new QN with lower Max - returns MIN
+	// add another new QN with lower Max - old QN current still constrains cluster max
 	m.AddNode(&sessionutil.Session{
 		SessionRaw: sessionutil.SessionRaw{
 			ServerID:           3,
 			IndexEngineVersion: sessionutil.IndexEngineVersion{CurrentIndexVersion: 18, MaximumIndexVersion: 25},
 		},
 	})
-	assert.Equal(t, int32(25), m.GetMaximumIndexEngineVersion())
+	assert.Equal(t, int32(20), m.GetMaximumIndexEngineVersion())
 
-	// remove the node with lower Max - returns 30
+	// remove the node with lower Max - old QN current still constrains cluster max
 	m.RemoveNode(&sessionutil.Session{SessionRaw: sessionutil.SessionRaw{ServerID: 3}})
+	assert.Equal(t, int32(20), m.GetMaximumIndexEngineVersion())
+
+	// remove old QN - remaining new QN reports max directly
+	m.RemoveNode(&sessionutil.Session{SessionRaw: sessionutil.SessionRaw{ServerID: 1}})
 	assert.Equal(t, int32(30), m.GetMaximumIndexEngineVersion())
 }
 
@@ -584,8 +588,8 @@ func Test_IndexEngineVersionManager_ResolveVecIndexVersion(t *testing.T) {
 		Params.Save("dataCoord.targetVecIndexVersion", "15")
 		Params.Save("dataCoord.forceRebuildSegmentIndex", "false")
 
-		// old QN (Max=0) => GetMaximum returns MaxInt32, no upper clamp
-		assert.Equal(t, int32(15), m.ResolveVecIndexVersion())
+		// old QN (Max=0) => use CurrentIndexVersion as upper clamp
+		assert.Equal(t, int32(10), m.ResolveVecIndexVersion())
 	})
 }
 


### PR DESCRIPTION
Cherry-pick from master
pr: #49674

## Summary

When a QueryNode does not report `MaximumIndexVersion`, use its `CurrentIndexVersion` as the conservative maximum for cluster-wide vector index version resolution. This prevents `targetVecIndexVersion` from advancing beyond old QueryNodes during rolling upgrade.

issue: #48470

## Tests

- `source ./scripts/setenv.sh && make SKIP_3RDPARTY=1 build-cpp-with-unittest`
- `source ./scripts/setenv.sh && make build-go`
- `source ./scripts/setenv.sh && LOCAL_STORAGE_SIZE=100 go test -v -gcflags="all=-N -l" -tags dynamic,test ./internal/datacoord -run "Test_IndexEngineVersionManager_(GetMaximumIndexEngineVersion|ResolveVecIndexVersion)" -count=1 -ldflags="-r ${RPATH}"`
- `LOCAL_STORAGE_SIZE=100 ./scripts/run_go_unittest.sh -t datacoord`