### PR TITLE
test: [cp3.0]Update Python client test expectations for server behavior changes

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_collection.py
+++ b/tests/python_client/milvus_client/test_milvus_client_collection.py
@@ -4261,6 +4261,7 @@ class TestMilvusClientDescribeCollectionValid(TestMilvusClientV2Base):
             "functions": [],
             "aliases": [],
             "consistency_level": 0,
+            "consistency_level_name": "Strong",
             "properties": {"timezone": "UTC"},
             "num_partitions": 1,
             "enable_dynamic_field": True,


### PR DESCRIPTION
pr: #49672

## Summary

Cherry-pick the test_milvus_client_collection_describe fix from master PR #49672 to 3.0 branch.

The server now returns `consistency_level_name: "Strong"` in `describe_collection` response. Update the expected result dict in the test to include this field.

### Changes

- `tests/python_client/milvus_client/test_milvus_client_collection.py`
  - Add `"consistency_level_name": "Strong"` to expected describe result.

issue: #49671