### PR TITLE
test: [cp2.6]update Python client nightly expectations

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_insert.py
+++ b/tests/python_client/milvus_client/test_milvus_client_insert.py
@@ -1,12 +1,13 @@
-import pytest
-import numpy as np
+import random
 
+import numpy as np
+import pytest
 from base.client_v2_base import TestMilvusClientV2Base
-from utils.util_log import test_log as log
 from common import common_func as cf
 from common import common_type as ct
 from common.common_type import CaseLabel, CheckTasks
-from utils.util_pymilvus import *
+from pymilvus import DataType
+from utils.util_log import test_log as log
 
 prefix = "client_insert"
 epsilon = ct.epsilon
@@ -132,7 +133,7 @@ class TestMilvusClientInsertInvalid(TestMilvusClientV2Base):
         rng = np.random.default_rng(seed=19530)
         rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
                  default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(default_nb)]
-        error = {ct.err_code: 1100, ct.err_msg: f"the length of a collection name must be less than 255 characters"}
+        error = {ct.err_code: 1100, ct.err_msg: "the length of a collection name must be less than 255 characters"}
         self.insert(client, collection_name, rows,
                     check_task=CheckTasks.err_res, check_items=error)
 
@@ -182,12 +183,11 @@ class TestMilvusClientInsertInvalid(TestMilvusClientV2Base):
         # 1. create collection
         self.create_collection(client, collection_name, default_dim, consistency_level="Strong")
         # 2. insert
-        rng = np.random.default_rng(seed=19530)
         rows = [{default_primary_key_field_name: i,
                  default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(default_nb)]
         error = {ct.err_code: 1,
-                 ct.err_msg: f"Insert missed an field `vector` to collection "
-                             f"without set nullable==true or set default_value"}
+                 ct.err_msg: "Insert missed an field `vector` to collection "
+                             "without set nullable==true or set default_value"}
         self.insert(client, collection_name, data=rows,
                     check_task=CheckTasks.err_res, check_items=error)
 
@@ -207,7 +207,7 @@ class TestMilvusClientInsertInvalid(TestMilvusClientV2Base):
         rows = [{default_vector_field_name: list(rng.random((1, default_dim))[0]),
                  default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(default_nb)]
         error = {ct.err_code: 1,
-                 ct.err_msg: f"Insert missed an field `id` to collection without set nullable==true or set default_value"}
+                 ct.err_msg: "Insert missed an field `id` to collection without set nullable==true or set default_value"}
         self.insert(client, collection_name, data=rows,
                     check_task=CheckTasks.err_res, check_items=error)
 
@@ -227,7 +227,7 @@ class TestMilvusClientInsertInvalid(TestMilvusClientV2Base):
         rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
                  default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(default_nb)]
         error = {ct.err_code: 1,
-                 ct.err_msg: f"Attempt to insert an unexpected field `float` to collection without enabling dynamic field"}
+                 ct.err_msg: "Attempt to insert an unexpected field `float` to collection without enabling dynamic field"}
         self.insert(client, collection_name, data=rows,
                     check_task=CheckTasks.err_res, check_items=error)
 
@@ -268,8 +268,8 @@ class TestMilvusClientInsertInvalid(TestMilvusClientV2Base):
             {default_primary_key_field_name: str(i), default_vector_field_name: list(rng.random((1, default_dim))[0]),
              default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(default_nb)]
         error = {ct.err_code: 1,
-                 ct.err_msg: f"The Input data type is inconsistent with defined schema, "
-                             f"{{id}} field should be a int64"}
+                 ct.err_msg: "The Input data type is inconsistent with defined schema, "
+                             "{id} field should be a int64"}
         self.insert(client, collection_name, data=rows,
                     check_task=CheckTasks.err_res, check_items=error)
 
@@ -291,7 +291,7 @@ class TestMilvusClientInsertInvalid(TestMilvusClientV2Base):
                  default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(default_nb)]
         error = {ct.err_code: 65535, ct.err_msg: f"Invalid partition name: {partition_name}."}
         if partition_name == " ":
-            error = {ct.err_code: 1, ct.err_msg: f"Invalid partition name: . Partition name should not be empty."}
+            error = {ct.err_code: 1, ct.err_msg: "Invalid partition name: . Partition name should not be empty."}
         self.insert(client, collection_name, data=rows, partition_name=partition_name,
                     check_task=CheckTasks.err_res, check_items=error)
 
@@ -386,7 +386,6 @@ class TestMilvusClientInsertValid(TestMilvusClientV2Base):
         index_params.add_index(default_vector_field_name, metric_type="COSINE")
         self.create_collection(client, collection_name, dimension=dim, schema=schema, index_params=index_params)
         # 2. insert
-        rng = np.random.default_rng(seed=19530)
         vectors = cf.gen_vectors(default_nb, dim, vector_data_type=vector_type)
         rows = [{default_primary_key_field_name: i, default_vector_field_name: vectors[i],
                  default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(default_nb)]
@@ -581,7 +580,7 @@ class TestMilvusClientInsertValid(TestMilvusClientV2Base):
                                  "pk_name": default_primary_key_field_name,
                                  "limit": default_limit})
         self.search(client, collection_name, vectors_to_search,
-                    filter=f"field_new=='field_new'",
+                    filter="field_new=='field_new'",
                     check_task=CheckTasks.check_search_results,
                     check_items={"enable_milvus_client_api": True,
                                  "nq": len(vectors_to_search),
@@ -622,7 +621,7 @@ class TestInsertOperation(TestMilvusClientV2Base):
         collection_name = cf.gen_collection_name_by_testcase_name()
         self.create_collection(client, collection_name, default_dim)
         self.close(client)
-        
+
         rng = np.random.default_rng(seed=19530)
         rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
                  default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(10)]
@@ -639,10 +638,10 @@ class TestInsertOperation(TestMilvusClientV2Base):
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
         partition_name = cf.gen_unique_str("partition")
-        
+
         self.create_collection(client, collection_name, default_dim)
         self.create_partition(client, collection_name, partition_name)
-        
+
         rng = np.random.default_rng(seed=19530)
         rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
                  default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(ct.default_nb)]
@@ -659,12 +658,12 @@ class TestInsertOperation(TestMilvusClientV2Base):
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
         self.create_collection(client, collection_name, default_dim)
-        
+
         rng = np.random.default_rng(seed=19530)
         rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
                  default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(10)]
         error = {ct.err_code: 200, ct.err_msg: "partition not found[partition=p]"}
-        self.insert(client, collection_name, rows, partition_name="p", 
+        self.insert(client, collection_name, rows, partition_name="p",
                    check_task=CheckTasks.err_res, check_items=error)
         self.drop_collection(client, collection_name)
 
@@ -679,11 +678,11 @@ class TestInsertOperation(TestMilvusClientV2Base):
         collection_name = cf.gen_unique_str(prefix)
         partition_name_1 = cf.gen_unique_str("partition1")
         partition_name_2 = cf.gen_unique_str("partition2")
-        
+
         self.create_collection(client, collection_name, default_dim)
         self.create_partition(client, collection_name, partition_name_1)
         self.create_partition(client, collection_name, partition_name_2)
-        
+
         rng = np.random.default_rng(seed=19530)
         rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
                  default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(ct.default_nb)]
@@ -703,10 +702,10 @@ class TestInsertOperation(TestMilvusClientV2Base):
         client = self._client()
         collection_name = cf.gen_unique_str(prefix)
         partition_name = cf.gen_unique_str("partition")
-        
+
         self.create_collection(client, collection_name, default_dim)
         self.create_partition(client, collection_name, partition_name)
-        
+
         rng = np.random.default_rng(seed=19530)
         rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
                  default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(ct.default_nb)]
@@ -723,16 +722,16 @@ class TestInsertOperation(TestMilvusClientV2Base):
         """
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
-        
+
         # Create schema with varchar limit
         schema = self.create_schema(client, auto_id=True, enable_dynamic_field=False)[0]
         schema.add_field("id", DataType.INT64, is_primary=True, auto_id=True)
         schema.add_field("vector", DataType.FLOAT_VECTOR, dim=ct.default_dim)
         schema.add_field("small_limit", DataType.VARCHAR, max_length=2)
         schema.add_field("big_limit", DataType.VARCHAR, max_length=65530)
-        
+
         self.create_collection(client, collection_name, dimension=ct.default_dim, schema=schema)
-        
+
         # Insert data exceeding varchar limit
         rows = [
             {"vector": list(cf.gen_vectors(1, ct.default_dim)[0]), "small_limit": "limit_1___________", "big_limit": "1"},
@@ -752,12 +751,11 @@ class TestInsertOperation(TestMilvusClientV2Base):
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
         self.create_collection(client, collection_name, default_dim)
-        
+
         # Generate data without vector field
-        rng = np.random.default_rng(seed=19530)
         rows = [{default_primary_key_field_name: i,
                  default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(10)]
-        error = {ct.err_code: 1, ct.err_msg: f"Insert missed an field `vector` to collection"}
+        error = {ct.err_code: 1, ct.err_msg: "Insert missed an field `vector` to collection"}
         self.insert(client, collection_name, rows, check_task=CheckTasks.err_res, check_items=error)
         self.drop_collection(client, collection_name)
 
@@ -771,7 +769,7 @@ class TestInsertOperation(TestMilvusClientV2Base):
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
         self.create_collection(client, collection_name, default_dim)
-        
+
         # Generate data with wrong vector type (scalar instead of list)
         rows = [{default_primary_key_field_name: 0, default_vector_field_name: 0.0001,
                  default_float_field_name: 0.0, default_string_field_name: "0"}]
@@ -789,15 +787,15 @@ class TestInsertOperation(TestMilvusClientV2Base):
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
         self.create_collection(client, collection_name, default_dim)
-        
+
         collections = self.list_collections(client)[0]
         assert collection_name in collections
-        
+
         rng = np.random.default_rng(seed=19530)
         rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
                  default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(ct.default_nb)]
         self.insert(client, collection_name, rows)
-        
+
         self.drop_collection(client, collection_name)
         collections = self.list_collections(client)[0]
         assert collection_name not in collections
@@ -812,7 +810,7 @@ class TestInsertOperation(TestMilvusClientV2Base):
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
         self.create_collection(client, collection_name, default_dim)
-        
+
         rng = np.random.default_rng(seed=19530)
         rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
                  default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(ct.default_nb)]
@@ -821,12 +819,12 @@ class TestInsertOperation(TestMilvusClientV2Base):
 
         num_entities = self.get_collection_stats(client, collection_name)[0]
         assert num_entities.get("row_count", None) == ct.default_nb
-        
+
         # Create index (note: quick setup collection already has index)
         index_params = self.prepare_index_params(client)[0]
         index_params.add_index(default_vector_field_name, index_type="AUTOINDEX")
         self.create_index(client, collection_name, index_params)
-        
+
         indexes = self.list_indexes(client, collection_name)[0]
         assert default_vector_field_name in indexes
         self.drop_collection(client, collection_name)
@@ -841,21 +839,21 @@ class TestInsertOperation(TestMilvusClientV2Base):
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
         self.create_collection(client, collection_name, default_dim)
-        
+
         # Create index first
         index_params = self.prepare_index_params(client)[0]
         index_params.add_index(default_vector_field_name, index_type="AUTOINDEX")
         self.create_index(client, collection_name, index_params)
-        
+
         indexes = self.list_indexes(client, collection_name)[0]
         assert default_vector_field_name in indexes
-        
+
         # Then insert data
         rng = np.random.default_rng(seed=19530)
         rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
                  default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(ct.default_nb)]
         self.insert(client, collection_name, rows)
-        
+
         self.flush(client, collection_name)
         num_entities = self.get_collection_stats(client, collection_name)[0]
         assert num_entities.get("row_count", None) == ct.default_nb
@@ -870,26 +868,26 @@ class TestInsertOperation(TestMilvusClientV2Base):
         """
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
-        
+
         # Create binary vector collection
         schema = self.create_schema(client, enable_dynamic_field=True)[0]
         schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
         schema.add_field(ct.default_binary_vec_field_name, DataType.BINARY_VECTOR, dim=default_dim)
         schema.add_field(default_float_field_name, DataType.FLOAT)
         schema.add_field(default_string_field_name, DataType.VARCHAR, max_length=ct.default_length)
-        
+
         index_params = self.prepare_index_params(client)[0]
         index_params.add_index(ct.default_binary_vec_field_name, index_type="BIN_IVF_FLAT", metric_type="HAMMING")
-        
+
         self.create_collection(client, collection_name, dimension=default_dim, schema=schema, index_params=index_params)
-        
+
         indexes = self.list_indexes(client, collection_name)[0]
         assert ct.default_binary_vec_field_name in indexes
-        
+
         # Insert binary data
         rows = cf.gen_row_data_by_schema(nb=ct.default_nb, schema=schema)
         self.insert(client, collection_name, rows)
-        
+
         self.flush(client, collection_name)
         num_entities = self.get_collection_stats(client, collection_name)[0]
         assert num_entities.get("row_count", None) == ct.default_nb
@@ -905,31 +903,31 @@ class TestInsertOperation(TestMilvusClientV2Base):
         """
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
-        
+
         # Create schema with auto_id=True
         schema = self.create_schema(client, auto_id=True, enable_dynamic_field=True)[0]
         schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=True)
         schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
         schema.add_field(default_float_field_name, DataType.FLOAT)
         schema.add_field(default_string_field_name, DataType.VARCHAR, max_length=ct.default_length)
-        
+
         index_params = self.prepare_index_params(client)[0]
         index_params.add_index(default_vector_field_name, index_type="AUTOINDEX")
-        
-        self.create_collection(client, collection_name, dimension=default_dim, schema=schema, 
+
+        self.create_collection(client, collection_name, dimension=default_dim, schema=schema,
                               index_params=index_params, auto_id=True)
-        
+
         # Insert without primary key (auto_id)
         rng = np.random.default_rng(seed=19530)
         rows = [{default_vector_field_name: list(rng.random((1, default_dim))[0]),
                  default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(ct.default_nb)]
         results = self.insert(client, collection_name, rows)[0]
         assert results['insert_count'] == ct.default_nb
-        
+
         self.flush(client, collection_name)
         num_entities = self.get_collection_stats(client, collection_name)[0]
         assert num_entities.get("row_count", None) == ct.default_nb
-        
+
         indexes = self.list_indexes(client, collection_name)[0]
         assert default_vector_field_name in indexes
         self.drop_collection(client, collection_name)
@@ -943,7 +941,7 @@ class TestInsertOperation(TestMilvusClientV2Base):
         """
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
-        
+
         # Create schema with auto_id=True and specific primary field
         schema = self.create_schema(client, auto_id=True, enable_dynamic_field=True)[0]
         if pk_field == ct.default_int64_field_name:
@@ -954,9 +952,9 @@ class TestInsertOperation(TestMilvusClientV2Base):
         schema.add_field(default_float_field_name, DataType.FLOAT)
         if pk_field != ct.default_string_field_name:
             schema.add_field(default_string_field_name, DataType.VARCHAR, max_length=ct.default_length)
-        
+
         self.create_collection(client, collection_name, dimension=default_dim, schema=schema, auto_id=True)
-        
+
         # Insert without primary key (auto_id)
         rng = np.random.default_rng(seed=19530)
         rows = [{default_vector_field_name: list(rng.random((1, default_dim))[0]),
@@ -964,10 +962,10 @@ class TestInsertOperation(TestMilvusClientV2Base):
         if pk_field != ct.default_string_field_name:
             for i, row in enumerate(rows):
                 row[default_string_field_name] = str(i)
-        
+
         results = self.insert(client, collection_name, rows)[0]
         assert results['insert_count'] == ct.default_nb
-        
+
         self.flush(client, collection_name)
         num_entities = self.get_collection_stats(client, collection_name)[0]
         assert num_entities.get("row_count", None) == ct.default_nb
@@ -983,7 +981,7 @@ class TestInsertOperation(TestMilvusClientV2Base):
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
         nb = 10
-        
+
         # Create schema with auto_id=True and specific primary field
         schema = self.create_schema(client, auto_id=True, enable_dynamic_field=True)[0]
         if pk_field == ct.default_int64_field_name:
@@ -994,9 +992,9 @@ class TestInsertOperation(TestMilvusClientV2Base):
         schema.add_field(default_float_field_name, DataType.FLOAT)
         if pk_field != ct.default_string_field_name:
             schema.add_field(default_string_field_name, DataType.VARCHAR, max_length=ct.default_length)
-        
+
         self.create_collection(client, collection_name, dimension=default_dim, schema=schema, auto_id=True)
-        
+
         # Insert twice
         rng = np.random.default_rng(seed=19530)
         rows = [{default_vector_field_name: list(rng.random((1, default_dim))[0]),
@@ -1004,13 +1002,13 @@ class TestInsertOperation(TestMilvusClientV2Base):
         if pk_field != ct.default_string_field_name:
             for i, row in enumerate(rows):
                 row[default_string_field_name] = str(i)
-        
+
         results_1 = self.insert(client, collection_name, rows)[0]
         assert results_1['insert_count'] == nb
-        
+
         results_2 = self.insert(client, collection_name, rows)[0]
         assert results_2['insert_count'] == nb
-        
+
         self.flush(client, collection_name)
         num_entities = self.get_collection_stats(client, collection_name)[0]
         assert num_entities.get("row_count", None) == nb * 2
@@ -1025,7 +1023,7 @@ class TestInsertOperation(TestMilvusClientV2Base):
         """
         client = self._client()
         collection_name = cf.gen_unique_str(prefix)
-        
+
         # Create schema with auto_id=True and specific primary field
         schema = self.create_schema(client, auto_id=True, enable_dynamic_field=True)[0]
         if pk_field == ct.default_int64_field_name:
@@ -1036,9 +1034,9 @@ class TestInsertOperation(TestMilvusClientV2Base):
         schema.add_field(default_float_field_name, DataType.FLOAT)
         if pk_field != ct.default_string_field_name:
             schema.add_field(default_string_field_name, DataType.VARCHAR, max_length=ct.default_length)
-        
+
         self.create_collection(client, collection_name, dimension=default_dim, schema=schema, auto_id=True)
-        
+
         # Insert without primary key (auto_id)
         rng = np.random.default_rng(seed=19530)
         rows = [{default_vector_field_name: list(rng.random((1, default_dim))[0]),
@@ -1046,10 +1044,10 @@ class TestInsertOperation(TestMilvusClientV2Base):
         if pk_field != ct.default_string_field_name:
             for i, row in enumerate(rows):
                 row[default_string_field_name] = str(i)
-        
+
         results = self.insert(client, collection_name, rows)[0]
         assert results['insert_count'] == ct.default_nb
-        
+
         self.flush(client, collection_name)
         num_entities = self.get_collection_stats(client, collection_name)[0]
         assert num_entities.get("row_count", None) == ct.default_nb
@@ -1064,7 +1062,7 @@ class TestInsertOperation(TestMilvusClientV2Base):
         """
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
-        
+
         # Create schema with auto_id=True
         schema = self.create_schema(client, auto_id=True, enable_dynamic_field=True)[0]
         if pk_field == ct.default_int64_field_name:
@@ -1075,13 +1073,13 @@ class TestInsertOperation(TestMilvusClientV2Base):
         schema.add_field(default_float_field_name, DataType.FLOAT)
         if pk_field != ct.default_string_field_name:
             schema.add_field(default_string_field_name, DataType.VARCHAR, max_length=ct.default_length)
-        
+
         self.create_collection(client, collection_name, dimension=default_dim, schema=schema, auto_id=True)
-        
+
         # Try to insert with primary key included (should fail)
         df = cf.gen_default_dataframe_data(nb=100, auto_id=True)
         error = {ct.err_code: 999,
-                 ct.err_msg: f"wrong type of argument 'data',expected 'Dict' or list of 'Dict', got 'DataFrame'"}
+                 ct.err_msg: "wrong type of argument 'data',expected 'Dict' or list of 'Dict', got 'DataFrame'"}
         self.insert(client, collection_name, df, check_task=CheckTasks.err_res, check_items=error)
 
         self.flush(client, collection_name)
@@ -1099,7 +1097,7 @@ class TestInsertOperation(TestMilvusClientV2Base):
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
         nb = 100
-        
+
         # Create schema with auto_id=True
         schema = self.create_schema(client, auto_id=True, enable_dynamic_field=True)[0]
         if pk_field == ct.default_int64_field_name:
@@ -1110,9 +1108,9 @@ class TestInsertOperation(TestMilvusClientV2Base):
         schema.add_field(default_float_field_name, DataType.FLOAT)
         if pk_field != ct.default_string_field_name:
             schema.add_field(default_string_field_name, DataType.VARCHAR, max_length=ct.default_length)
-        
+
         self.create_collection(client, collection_name, dimension=default_dim, schema=schema, auto_id=True)
-        
+
         # Insert without primary key (auto_id)
         rng = np.random.default_rng(seed=19530)
         rows = [{default_vector_field_name: list(rng.random((1, default_dim))[0]),
@@ -1120,7 +1118,7 @@ class TestInsertOperation(TestMilvusClientV2Base):
         if pk_field != ct.default_string_field_name:
             for i, row in enumerate(rows):
                 row[default_string_field_name] = str(i)
-        
+
         self.insert(client, collection_name, rows)
         self.flush(client, collection_name)
         num_entities = self.get_collection_stats(client, collection_name)[0]
@@ -1137,9 +1135,9 @@ class TestInsertOperation(TestMilvusClientV2Base):
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
         nb = 100
-        
+
         self.create_collection(client, collection_name, default_dim, auto_id=False)
-        
+
         # Insert with same primary key values
         rng = np.random.default_rng(seed=19530)
         rows = [{default_primary_key_field_name: 1, default_vector_field_name: list(rng.random((1, default_dim))[0]),
@@ -1158,9 +1156,9 @@ class TestInsertOperation(TestMilvusClientV2Base):
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
         nb = 100
-        
+
         self.create_collection(client, collection_name, default_dim, auto_id=False)
-        
+
         # Insert with negative primary key values
         rng = np.random.default_rng(seed=19530)
         rows = [{default_primary_key_field_name: -i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
@@ -1182,11 +1180,11 @@ class TestInsertOperation(TestMilvusClientV2Base):
         expected: verify num entities
         """
         import threading
-        
+
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
         self.create_collection(client, collection_name, default_dim, consistency_level="Strong")
-        
+
         thread_num = 4
         threads = []
         rng = np.random.default_rng(seed=19530)
@@ -1209,7 +1207,7 @@ class TestInsertOperation(TestMilvusClientV2Base):
             x.start()
         for t in threads:
             t.join()
-        
+
         self.flush(client, collection_name)
         num_entities = self.get_collection_stats(client, collection_name)[0]
         assert num_entities.get("row_count", None) == ct.default_nb * thread_num
@@ -1226,14 +1224,14 @@ class TestInsertOperation(TestMilvusClientV2Base):
         collection_name = cf.gen_collection_name_by_testcase_name()
         step = 120
         nb = 12000
-        
+
         self.create_collection(client, collection_name, dim, auto_id=False)
-        
+
         rng = np.random.default_rng(seed=19530)
         start_id = 0
         for _ in range(nb // step):
             rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, dim))[0]),
-                     default_float_field_name: i * 1.0, default_string_field_name: str(i)} 
+                     default_float_field_name: i * 1.0, default_string_field_name: str(i)}
                     for i in range(start_id, start_id + step)]
             results = self.insert(client, collection_name, rows)[0]
             assert results['insert_count'] == step
@@ -1266,14 +1264,14 @@ class TestInsertOperation(TestMilvusClientV2Base):
         collection_name = cf.gen_collection_name_by_testcase_name()
         # nb = 127583 without json field
         nb = 108993
-        
+
         self.create_collection(client, collection_name, default_dim, auto_id=False)
-        
+
         rng = np.random.default_rng(seed=19530)
         rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
                  default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(nb)]
         self.insert(client, collection_name, rows)
-        
+
         self.flush(client, collection_name)
         num_entities = self.get_collection_stats(client, collection_name)[0]
         assert num_entities.get("row_count", None) == nb
@@ -1291,7 +1289,7 @@ class TestInsertOperation(TestMilvusClientV2Base):
         """
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
-        
+
         # Create schema with default value field
         schema = self.create_schema(client, auto_id=auto_id, enable_dynamic_field=False)[0]
         if not auto_id:
@@ -1299,12 +1297,12 @@ class TestInsertOperation(TestMilvusClientV2Base):
         else:
             schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=True)
         schema.add_field(default_float_field_name, DataType.FLOAT)
-        schema.add_field(default_string_field_name, DataType.VARCHAR, max_length=ct.default_length, 
+        schema.add_field(default_string_field_name, DataType.VARCHAR, max_length=ct.default_length,
                         default_value="abc", nullable=nullable)
         schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
-        
+
         self.create_collection(client, collection_name, dimension=default_dim, schema=schema, auto_id=auto_id)
-        
+
         # Insert data with None or omitting the default value field
         rng = np.random.default_rng(seed=19530)
         rows = []
@@ -1317,7 +1315,7 @@ class TestInsertOperation(TestMilvusClientV2Base):
                 row[default_string_field_name] = None
             # If default_value_type == "empty", we don't include the field at all
             rows.append(row)
-        
+
         self.insert(client, collection_name, rows)
         self.flush(client, collection_name)
         num_entities = self.get_collection_stats(client, collection_name)[0]
@@ -1345,7 +1343,7 @@ class TestInsertOperation(TestMilvusClientV2Base):
         schema.add_field('float_array', datatype=DataType.ARRAY, element_type=DataType.FLOAT,   max_capacity=20, nullable=True)
         schema.add_field('string_array', datatype=DataType.ARRAY, element_type=DataType.VARCHAR, max_capacity=20, max_length=100, nullable=True)
         schema.add_field('json', DataType.JSON,  nullable=True)
-        schema.add_field(default_float_vec_field_name, DataType.FLOAT_VECTOR, dim=dim)
+        schema.add_field(ct.default_float_vec_field_name, DataType.FLOAT_VECTOR, dim=dim)
         self.create_collection(client, collection_name, schema=schema)
 
         rows = [{
@@ -1357,7 +1355,7 @@ class TestInsertOperation(TestMilvusClientV2Base):
             'float_array': None,
             'string_array': None,
             'json': None,
-            default_float_vec_field_name: cf.gen_vectors(1, dim=dim)[0]
+            ct.default_float_vec_field_name: cf.gen_vectors(1, dim=dim)[0]
         } for i in range(nb)]
         self.insert(client, collection_name, rows)
         self.flush(client, collection_name)
@@ -1366,7 +1364,7 @@ class TestInsertOperation(TestMilvusClientV2Base):
 
         # build index and load
         index_params = self.prepare_index_params(client)[0]
-        index_params.add_index(default_float_vec_field_name, metric_type="L2")
+        index_params.add_index(ct.default_float_vec_field_name, metric_type="L2")
         self.create_index(client, collection_name, index_params)
         self.load_collection(client, collection_name)
 
@@ -1379,10 +1377,10 @@ class TestInsertOperation(TestMilvusClientV2Base):
         assert len(res) == nb
 
         # try to query None value entities on json field, should not be empty
-        res, _ = self.query(client, collection_name, filter=f"json is null")
+        res, _ = self.query(client, collection_name, filter="json is null")
         assert len(res) == nb
 
-        res, _ = self.query(client, collection_name, filter=f"int32_array is null")
+        res, _ = self.query(client, collection_name, filter="int32_array is null")
         assert len(res) == nb
 
         self.drop_collection(client, collection_name)

--- a/tests/python_client/milvus_client/test_milvus_client_insert.py
+++ b/tests/python_client/milvus_client/test_milvus_client_insert.py
@@ -437,13 +437,13 @@ class TestMilvusClientInsertValid(TestMilvusClientV2Base):
         results = self.insert(client, collection_name, rows)[0]
         assert results['insert_count'] == default_nb
         # 3. insert diff fields
-        rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
+        rows = [{default_primary_key_field_name: i + default_nb, default_vector_field_name: list(rng.random((1, default_dim))[0]),
                  default_float_field_name: i * 1.0, "new_diff_str_field": str(i)} for i in range(default_nb)]
         results = self.insert(client, collection_name, rows)[0]
         assert results['insert_count'] == default_nb
         # 3. search
         vectors_to_search = rng.random((1, default_dim))
-        insert_ids = [i for i in range(default_nb)]
+        insert_ids = [i for i in range(default_nb * 2)]
         self.search(client, collection_name, vectors_to_search,
                     check_task=CheckTasks.check_search_results,
                     check_items={"enable_milvus_client_api": True,

--- a/tests/python_client/milvus_client/test_milvus_client_insert.py
+++ b/tests/python_client/milvus_client/test_milvus_client_insert.py
@@ -18,10 +18,10 @@ default_dim = ct.default_dim
 default_limit = ct.default_limit
 default_search_exp = "id >= 0"
 exp_res = "exp_res"
-default_search_string_exp = "varchar >= \"0\""
-default_search_mix_exp = "int64 >= 0 && varchar >= \"0\""
+default_search_string_exp = 'varchar >= "0"'
+default_search_mix_exp = 'int64 >= 0 && varchar >= "0"'
 default_invaild_string_exp = "varchar >= 0"
-default_json_search_exp = "json_field[\"number\"] >= 0"
+default_json_search_exp = 'json_field["number"] >= 0'
 perfix_expr = 'varchar like "0%"'
 default_search_field = ct.default_float_vec_field_name
 default_search_params = ct.default_search_params
@@ -36,8 +36,9 @@ default_string_array_field_name = ct.default_string_array_field_name
 default_int32_field_name = ct.default_int32_field_name
 default_int32_value = ct.default_int32_value
 
+
 class TestMilvusClientInsertInvalid(TestMilvusClientV2Base):
-    """ Test case of search interface """
+    """Test case of search interface"""
 
     @pytest.fixture(scope="function", params=[False, True])
     def auto_id(self, request):
@@ -52,6 +53,7 @@ class TestMilvusClientInsertInvalid(TestMilvusClientV2Base):
     #  The following are invalid base cases
     ******************************************************************
     """
+
     @pytest.mark.tags(CaseLabel.L2)
     def test_milvus_client_insert_after_client_closed(self):
         """
@@ -59,13 +61,13 @@ class TestMilvusClientInsertInvalid(TestMilvusClientV2Base):
         method: insert after client is closed
         expected: raise exception
         """
-        client = self._client(alias='my_client')
+        client = self._client(alias="my_client")
         collection_name = cf.gen_collection_name_by_testcase_name()
         self.create_collection(client, collection_name, default_dim)
         self.close(client)
 
         data = cf.gen_default_list_data(10)
-        error = {ct.err_code: 999, ct.err_msg: 'should create connection first'}
+        error = {ct.err_code: 999, ct.err_msg: "should create connection first"}
         self.insert(client, collection_name, data, check_task=CheckTasks.err_res, check_items=error)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -82,10 +84,11 @@ class TestMilvusClientInsertInvalid(TestMilvusClientV2Base):
         # 2. insert
         vectors = [[random.random() for _ in range(default_dim)] for _ in range(default_nb)]
         data = [[i for i in range(default_nb)], vectors]
-        error = {ct.err_code: 999,
-                 ct.err_msg: "The Input data type is inconsistent with defined schema, please check it."}
-        self.insert(client, collection_name, data,
-                    check_task=CheckTasks.err_res, check_items=error)
+        error = {
+            ct.err_code: 999,
+            ct.err_msg: "The Input data type is inconsistent with defined schema, please check it.",
+        }
+        self.insert(client, collection_name, data, check_task=CheckTasks.err_res, check_items=error)
         self.drop_collection(client, collection_name)
 
     @pytest.mark.tags(CaseLabel.L1)
@@ -98,11 +101,17 @@ class TestMilvusClientInsertInvalid(TestMilvusClientV2Base):
         client = self._client()
         collection_name = ""
         rng = np.random.default_rng(seed=19530)
-        rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
-                 default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(default_nb)]
+        rows = [
+            {
+                default_primary_key_field_name: i,
+                default_vector_field_name: list(rng.random((1, default_dim))[0]),
+                default_float_field_name: i * 1.0,
+                default_string_field_name: str(i),
+            }
+            for i in range(default_nb)
+        ]
         error = {ct.err_code: 1, ct.err_msg: f"`collection_name` value {collection_name} is illegal"}
-        self.insert(client, collection_name, rows,
-                    check_task=CheckTasks.err_res, check_items=error)
+        self.insert(client, collection_name, rows, check_task=CheckTasks.err_res, check_items=error)
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("collection_name", ["12-s", "12 s", "(mn)", "中文", "%$#"])
@@ -114,12 +123,21 @@ class TestMilvusClientInsertInvalid(TestMilvusClientV2Base):
         """
         client = self._client()
         rng = np.random.default_rng(seed=19530)
-        rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
-                 default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(default_nb)]
-        error = {ct.err_code: 1100, ct.err_msg: f"Invalid collection name: {collection_name}. the first character of a "
-                                                f"collection name must be an underscore or letter: invalid parameter"}
-        self.insert(client, collection_name, rows,
-                    check_task=CheckTasks.err_res, check_items=error)
+        rows = [
+            {
+                default_primary_key_field_name: i,
+                default_vector_field_name: list(rng.random((1, default_dim))[0]),
+                default_float_field_name: i * 1.0,
+                default_string_field_name: str(i),
+            }
+            for i in range(default_nb)
+        ]
+        error = {
+            ct.err_code: 1100,
+            ct.err_msg: f"Invalid collection name: {collection_name}. the first character of a "
+            f"collection name must be an underscore or letter: invalid parameter",
+        }
+        self.insert(client, collection_name, rows, check_task=CheckTasks.err_res, check_items=error)
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_milvus_client_insert_collection_name_over_max_length(self):
@@ -131,11 +149,17 @@ class TestMilvusClientInsertInvalid(TestMilvusClientV2Base):
         client = self._client()
         collection_name = "a".join("a" for i in range(256))
         rng = np.random.default_rng(seed=19530)
-        rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
-                 default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(default_nb)]
+        rows = [
+            {
+                default_primary_key_field_name: i,
+                default_vector_field_name: list(rng.random((1, default_dim))[0]),
+                default_float_field_name: i * 1.0,
+                default_string_field_name: str(i),
+            }
+            for i in range(default_nb)
+        ]
         error = {ct.err_code: 1100, ct.err_msg: "the length of a collection name must be less than 255 characters"}
-        self.insert(client, collection_name, rows,
-                    check_task=CheckTasks.err_res, check_items=error)
+        self.insert(client, collection_name, rows, check_task=CheckTasks.err_res, check_items=error)
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_milvus_client_insert_not_exist_collection_name(self):
@@ -147,11 +171,17 @@ class TestMilvusClientInsertInvalid(TestMilvusClientV2Base):
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
         rng = np.random.default_rng(seed=19530)
-        rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
-                 default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(default_nb)]
+        rows = [
+            {
+                default_primary_key_field_name: i,
+                default_vector_field_name: list(rng.random((1, default_dim))[0]),
+                default_float_field_name: i * 1.0,
+                default_string_field_name: str(i),
+            }
+            for i in range(default_nb)
+        ]
         error = {ct.err_code: 100, ct.err_msg: f"can't find collection[database=default][collection={collection_name}]"}
-        self.insert(client, collection_name, rows,
-                    check_task=CheckTasks.err_res, check_items=error)
+        self.insert(client, collection_name, rows, check_task=CheckTasks.err_res, check_items=error)
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("data", ["12-s", "中文", "%$#", " ", ""])
@@ -166,10 +196,11 @@ class TestMilvusClientInsertInvalid(TestMilvusClientV2Base):
         # 1. create collection
         self.create_collection(client, collection_name, default_dim, consistency_level="Strong")
         # 2. insert
-        error = {ct.err_code: 999,
-                 ct.err_msg: "wrong type of argument 'data',expected 'Dict' or list of 'Dict', got 'str'"}
-        self.insert(client, collection_name, data,
-                    check_task=CheckTasks.err_res, check_items=error)
+        error = {
+            ct.err_code: 999,
+            ct.err_msg: "wrong type of argument 'data',expected 'Dict' or list of 'Dict', got 'str'",
+        }
+        self.insert(client, collection_name, data, check_task=CheckTasks.err_res, check_items=error)
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_milvus_client_insert_data_vector_field_missing(self):
@@ -183,13 +214,15 @@ class TestMilvusClientInsertInvalid(TestMilvusClientV2Base):
         # 1. create collection
         self.create_collection(client, collection_name, default_dim, consistency_level="Strong")
         # 2. insert
-        rows = [{default_primary_key_field_name: i,
-                 default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(default_nb)]
-        error = {ct.err_code: 1,
-                 ct.err_msg: "Insert missed an field `vector` to collection "
-                             "without set nullable==true or set default_value"}
-        self.insert(client, collection_name, data=rows,
-                    check_task=CheckTasks.err_res, check_items=error)
+        rows = [
+            {default_primary_key_field_name: i, default_float_field_name: i * 1.0, default_string_field_name: str(i)}
+            for i in range(default_nb)
+        ]
+        error = {
+            ct.err_code: 1,
+            ct.err_msg: "Insert missed an field `vector` to collection without set nullable==true or set default_value",
+        }
+        self.insert(client, collection_name, data=rows, check_task=CheckTasks.err_res, check_items=error)
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_milvus_client_insert_data_id_field_missing(self):
@@ -204,12 +237,19 @@ class TestMilvusClientInsertInvalid(TestMilvusClientV2Base):
         self.create_collection(client, collection_name, default_dim, consistency_level="Strong")
         # 2. insert
         rng = np.random.default_rng(seed=19530)
-        rows = [{default_vector_field_name: list(rng.random((1, default_dim))[0]),
-                 default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(default_nb)]
-        error = {ct.err_code: 1,
-                 ct.err_msg: "Insert missed an field `id` to collection without set nullable==true or set default_value"}
-        self.insert(client, collection_name, data=rows,
-                    check_task=CheckTasks.err_res, check_items=error)
+        rows = [
+            {
+                default_vector_field_name: list(rng.random((1, default_dim))[0]),
+                default_float_field_name: i * 1.0,
+                default_string_field_name: str(i),
+            }
+            for i in range(default_nb)
+        ]
+        error = {
+            ct.err_code: 1,
+            ct.err_msg: "Insert missed an field `id` to collection without set nullable==true or set default_value",
+        }
+        self.insert(client, collection_name, data=rows, check_task=CheckTasks.err_res, check_items=error)
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_milvus_client_insert_data_extra_field(self):
@@ -224,12 +264,20 @@ class TestMilvusClientInsertInvalid(TestMilvusClientV2Base):
         self.create_collection(client, collection_name, default_dim, enable_dynamic_field=False)
         # 2. insert
         rng = np.random.default_rng(seed=19530)
-        rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
-                 default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(default_nb)]
-        error = {ct.err_code: 1,
-                 ct.err_msg: "Attempt to insert an unexpected field `float` to collection without enabling dynamic field"}
-        self.insert(client, collection_name, data=rows,
-                    check_task=CheckTasks.err_res, check_items=error)
+        rows = [
+            {
+                default_primary_key_field_name: i,
+                default_vector_field_name: list(rng.random((1, default_dim))[0]),
+                default_float_field_name: i * 1.0,
+                default_string_field_name: str(i),
+            }
+            for i in range(default_nb)
+        ]
+        error = {
+            ct.err_code: 1,
+            ct.err_msg: "Attempt to insert an unexpected field `float` to collection without enabling dynamic field",
+        }
+        self.insert(client, collection_name, data=rows, check_task=CheckTasks.err_res, check_items=error)
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_milvus_client_insert_data_dim_not_match(self):
@@ -245,11 +293,16 @@ class TestMilvusClientInsertInvalid(TestMilvusClientV2Base):
         # 2. insert
         rng = np.random.default_rng(seed=19530)
         rows = [
-            {default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim + 1))[0]),
-             default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(default_nb)]
+            {
+                default_primary_key_field_name: i,
+                default_vector_field_name: list(rng.random((1, default_dim + 1))[0]),
+                default_float_field_name: i * 1.0,
+                default_string_field_name: str(i),
+            }
+            for i in range(default_nb)
+        ]
         error = {ct.err_code: 65536, ct.err_msg: f"of float data should divide the dim({default_dim})"}
-        self.insert(client, collection_name, data=rows,
-                    check_task=CheckTasks.err_res, check_items=error)
+        self.insert(client, collection_name, data=rows, check_task=CheckTasks.err_res, check_items=error)
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_milvus_client_insert_not_matched_data(self):
@@ -265,13 +318,19 @@ class TestMilvusClientInsertInvalid(TestMilvusClientV2Base):
         # 2. insert
         rng = np.random.default_rng(seed=19530)
         rows = [
-            {default_primary_key_field_name: str(i), default_vector_field_name: list(rng.random((1, default_dim))[0]),
-             default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(default_nb)]
-        error = {ct.err_code: 1,
-                 ct.err_msg: "The Input data type is inconsistent with defined schema, "
-                             "{id} field should be a int64"}
-        self.insert(client, collection_name, data=rows,
-                    check_task=CheckTasks.err_res, check_items=error)
+            {
+                default_primary_key_field_name: str(i),
+                default_vector_field_name: list(rng.random((1, default_dim))[0]),
+                default_float_field_name: i * 1.0,
+                default_string_field_name: str(i),
+            }
+            for i in range(default_nb)
+        ]
+        error = {
+            ct.err_code: 1,
+            ct.err_msg: "The Input data type is inconsistent with defined schema, {id} field should be a int64",
+        }
+        self.insert(client, collection_name, data=rows, check_task=CheckTasks.err_res, check_items=error)
 
     @pytest.mark.tags(CaseLabel.L1)
     @pytest.mark.parametrize("partition_name", ["12 s", "(mn)", "中文", "%$#", " "])
@@ -287,13 +346,26 @@ class TestMilvusClientInsertInvalid(TestMilvusClientV2Base):
         self.create_collection(client, collection_name, default_dim)
         # 2. insert
         rng = np.random.default_rng(seed=19530)
-        rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
-                 default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(default_nb)]
+        rows = [
+            {
+                default_primary_key_field_name: i,
+                default_vector_field_name: list(rng.random((1, default_dim))[0]),
+                default_float_field_name: i * 1.0,
+                default_string_field_name: str(i),
+            }
+            for i in range(default_nb)
+        ]
         error = {ct.err_code: 65535, ct.err_msg: f"Invalid partition name: {partition_name}."}
         if partition_name == " ":
             error = {ct.err_code: 1, ct.err_msg: "Invalid partition name: . Partition name should not be empty."}
-        self.insert(client, collection_name, data=rows, partition_name=partition_name,
-                    check_task=CheckTasks.err_res, check_items=error)
+        self.insert(
+            client,
+            collection_name,
+            data=rows,
+            partition_name=partition_name,
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_milvus_client_insert_not_exist_partition_name(self):
@@ -308,12 +380,25 @@ class TestMilvusClientInsertInvalid(TestMilvusClientV2Base):
         self.create_collection(client, collection_name, default_dim)
         # 2. insert
         rng = np.random.default_rng(seed=19530)
-        rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
-                 default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(default_nb)]
+        rows = [
+            {
+                default_primary_key_field_name: i,
+                default_vector_field_name: list(rng.random((1, default_dim))[0]),
+                default_float_field_name: i * 1.0,
+                default_string_field_name: str(i),
+            }
+            for i in range(default_nb)
+        ]
         partition_name = cf.gen_unique_str("partition_not_exist")
         error = {ct.err_code: 200, ct.err_msg: f"partition not found[partition={partition_name}]"}
-        self.insert(client, collection_name, data=rows, partition_name=partition_name,
-                    check_task=CheckTasks.err_res, check_items=error)
+        self.insert(
+            client,
+            collection_name,
+            data=rows,
+            partition_name=partition_name,
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_milvus_client_insert_collection_partition_not_match(self):
@@ -332,15 +417,28 @@ class TestMilvusClientInsertInvalid(TestMilvusClientV2Base):
         self.create_partition(client, another_collection_name, partition_name)
         # 2. insert
         rng = np.random.default_rng(seed=19530)
-        rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
-                 default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(default_nb)]
+        rows = [
+            {
+                default_primary_key_field_name: i,
+                default_vector_field_name: list(rng.random((1, default_dim))[0]),
+                default_float_field_name: i * 1.0,
+                default_string_field_name: str(i),
+            }
+            for i in range(default_nb)
+        ]
         error = {ct.err_code: 200, ct.err_msg: f"partition not found[partition={partition_name}]"}
-        self.insert(client, collection_name, data=rows, partition_name=partition_name,
-                    check_task=CheckTasks.err_res, check_items=error)
+        self.insert(
+            client,
+            collection_name,
+            data=rows,
+            partition_name=partition_name,
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
 
 class TestMilvusClientInsertValid(TestMilvusClientV2Base):
-    """ Test case of search interface """
+    """Test case of search interface"""
 
     @pytest.fixture(scope="function", params=[False, True])
     def auto_id(self, request):
@@ -354,8 +452,10 @@ class TestMilvusClientInsertValid(TestMilvusClientV2Base):
     def nullable(self, request):
         yield request.param
 
-    @pytest.fixture(scope="function", params=[DataType.FLOAT_VECTOR, DataType.FLOAT16_VECTOR,
-                                              DataType.BFLOAT16_VECTOR, DataType.INT8_VECTOR])
+    @pytest.fixture(
+        scope="function",
+        params=[DataType.FLOAT_VECTOR, DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR, DataType.INT8_VECTOR],
+    )
     def vector_type(self, request):
         yield request.param
 
@@ -387,27 +487,46 @@ class TestMilvusClientInsertValid(TestMilvusClientV2Base):
         self.create_collection(client, collection_name, dimension=dim, schema=schema, index_params=index_params)
         # 2. insert
         vectors = cf.gen_vectors(default_nb, dim, vector_data_type=vector_type)
-        rows = [{default_primary_key_field_name: i, default_vector_field_name: vectors[i],
-                 default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(default_nb)]
+        rows = [
+            {
+                default_primary_key_field_name: i,
+                default_vector_field_name: vectors[i],
+                default_float_field_name: i * 1.0,
+                default_string_field_name: str(i),
+            }
+            for i in range(default_nb)
+        ]
         results = self.insert(client, collection_name, rows)[0]
-        assert results['insert_count'] == default_nb
+        assert results["insert_count"] == default_nb
         # 3. search
         vectors_to_search = [vectors[0]]
         insert_ids = [i for i in range(default_nb)]
-        self.search(client, collection_name, vectors_to_search,
-                    check_task=CheckTasks.check_search_results,
-                    check_items={"enable_milvus_client_api": True,
-                                 "nq": len(vectors_to_search),
-                                 "ids": insert_ids,
-                                 "limit": default_limit,
-                                 "pk_name": default_primary_key_field_name})
+        self.search(
+            client,
+            collection_name,
+            vectors_to_search,
+            check_task=CheckTasks.check_search_results,
+            check_items={
+                "enable_milvus_client_api": True,
+                "nq": len(vectors_to_search),
+                "ids": insert_ids,
+                "limit": default_limit,
+                "pk_name": default_primary_key_field_name,
+            },
+        )
         # 4. query
-        self.query(client, collection_name, filter=default_search_exp,
-                   check_task=CheckTasks.check_query_results,
-                   check_items={exp_res: rows,
-                                "with_vec": True,
-                                "pk_name": default_primary_key_field_name,
-                                "vector_type": vector_type})
+        self.query(
+            client,
+            collection_name,
+            filter=default_search_exp,
+            check_task=CheckTasks.check_query_results,
+            check_items={
+                exp_res: rows,
+                "with_vec": True,
+                "pk_name": default_primary_key_field_name,
+                "vector_type": vector_type,
+            },
+        )
         self.release_collection(client, collection_name)
         self.drop_collection(client, collection_name)
 
@@ -424,32 +543,53 @@ class TestMilvusClientInsertValid(TestMilvusClientV2Base):
         self.create_collection(client, collection_name, default_dim, consistency_level="Strong")
         collections = self.list_collections(client)[0]
         assert collection_name in collections
-        self.describe_collection(client, collection_name,
-                                 check_task=CheckTasks.check_describe_collection_property,
-                                 check_items={"collection_name": collection_name,
-                                              "dim": default_dim,
-                                              "consistency_level": 0})
+        self.describe_collection(
+            client,
+            collection_name,
+            check_task=CheckTasks.check_describe_collection_property,
+            check_items={"collection_name": collection_name, "dim": default_dim, "consistency_level": 0},
+        )
         # 2. insert
         rng = np.random.default_rng(seed=19530)
-        rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
-                 default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(default_nb)]
+        rows = [
+            {
+                default_primary_key_field_name: i,
+                default_vector_field_name: list(rng.random((1, default_dim))[0]),
+                default_float_field_name: i * 1.0,
+                default_string_field_name: str(i),
+            }
+            for i in range(default_nb)
+        ]
         results = self.insert(client, collection_name, rows)[0]
-        assert results['insert_count'] == default_nb
+        assert results["insert_count"] == default_nb
         # 3. insert diff fields
-        rows = [{default_primary_key_field_name: i + default_nb, default_vector_field_name: list(rng.random((1, default_dim))[0]),
-                 default_float_field_name: i * 1.0, "new_diff_str_field": str(i)} for i in range(default_nb)]
+        rows = [
+            {
+                default_primary_key_field_name: i + default_nb,
+                default_vector_field_name: list(rng.random((1, default_dim))[0]),
+                default_float_field_name: i * 1.0,
+                "new_diff_str_field": str(i),
+            }
+            for i in range(default_nb)
+        ]
         results = self.insert(client, collection_name, rows)[0]
-        assert results['insert_count'] == default_nb
+        assert results["insert_count"] == default_nb
         # 3. search
         vectors_to_search = rng.random((1, default_dim))
         insert_ids = [i for i in range(default_nb * 2)]
-        self.search(client, collection_name, vectors_to_search,
-                    check_task=CheckTasks.check_search_results,
-                    check_items={"enable_milvus_client_api": True,
-                                 "nq": len(vectors_to_search),
-                                 "ids": insert_ids,
-                                 "limit": default_limit,
-                                 "pk_name": default_primary_key_field_name})
+        self.search(
+            client,
+            collection_name,
+            vectors_to_search,
+            check_task=CheckTasks.check_search_results,
+            check_items={
+                "enable_milvus_client_api": True,
+                "nq": len(vectors_to_search),
+                "ids": insert_ids,
+                "limit": default_limit,
+                "pk_name": default_primary_key_field_name,
+            },
+        )
         self.drop_collection(client, collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -466,17 +606,23 @@ class TestMilvusClientInsertValid(TestMilvusClientV2Base):
         # 2. insert
         rows = []
         results = self.insert(client, collection_name, rows)[0]
-        assert results['insert_count'] == 0
+        assert results["insert_count"] == 0
         # 3. search
         rng = np.random.default_rng(seed=19530)
         vectors_to_search = rng.random((1, default_dim))
-        self.search(client, collection_name, vectors_to_search,
-                    check_task=CheckTasks.check_search_results,
-                    check_items={"enable_milvus_client_api": True,
-                                 "nq": len(vectors_to_search),
-                                 "ids": [],
-                                 "pk_name": default_primary_key_field_name,
-                                 "limit": 0})
+        self.search(
+            client,
+            collection_name,
+            vectors_to_search,
+            check_task=CheckTasks.check_search_results,
+            check_items={
+                "enable_milvus_client_api": True,
+                "nq": len(vectors_to_search),
+                "ids": [],
+                "pk_name": default_primary_key_field_name,
+                "limit": 0,
+            },
+        )
         self.drop_collection(client, collection_name)
 
     @pytest.mark.tags(CaseLabel.L1)
@@ -488,7 +634,7 @@ class TestMilvusClientInsertValid(TestMilvusClientV2Base):
         """
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
-        partition_name = cf.gen_unique_str('partition')
+        partition_name = cf.gen_unique_str("partition")
         # 1. create collection
         self.create_collection(client, collection_name, default_dim, consistency_level="Strong")
         # 2. create partition
@@ -496,24 +642,37 @@ class TestMilvusClientInsertValid(TestMilvusClientV2Base):
         partitions = self.list_partitions(client, collection_name)[0]
         assert partition_name in partitions
         index = self.list_indexes(client, collection_name)[0]
-        assert index == ['vector']
+        assert index == ["vector"]
         # load_state = self.get_load_state(collection_name)[0]
         # 3. insert
         rng = np.random.default_rng(seed=19530)
-        rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
-                 default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(default_nb)]
+        rows = [
+            {
+                default_primary_key_field_name: i,
+                default_vector_field_name: list(rng.random((1, default_dim))[0]),
+                default_float_field_name: i * 1.0,
+                default_string_field_name: str(i),
+            }
+            for i in range(default_nb)
+        ]
         results = self.insert(client, collection_name, rows, partition_name=partition_name)[0]
-        assert results['insert_count'] == default_nb
+        assert results["insert_count"] == default_nb
         # 3. search
         vectors_to_search = rng.random((1, default_dim))
         insert_ids = [i for i in range(default_nb)]
-        self.search(client, collection_name, vectors_to_search,
-                    check_task=CheckTasks.check_search_results,
-                    check_items={"enable_milvus_client_api": True,
-                                 "nq": len(vectors_to_search),
-                                 "ids": insert_ids,
-                                 "limit": default_limit,
-                                 "pk_name": default_primary_key_field_name})
+        self.search(
+            client,
+            collection_name,
+            vectors_to_search,
+            check_task=CheckTasks.check_search_results,
+            check_items={
+                "enable_milvus_client_api": True,
+                "nq": len(vectors_to_search),
+                "ids": insert_ids,
+                "limit": default_limit,
+                "pk_name": default_primary_key_field_name,
+            },
+        )
         # partition_number = self.get_partition_stats(client, collection_name, "_default")[0]
         # assert partition_number == default_nb
         # partition_number = self.get_partition_stats(client, collection_name, partition_name)[0]
@@ -546,47 +705,86 @@ class TestMilvusClientInsertValid(TestMilvusClientV2Base):
         self.create_collection(client, collection_name, dimension=dim, schema=schema, index_params=index_params)
         # 2. insert before add field
         vectors = cf.gen_vectors(default_nb * 2, dim, vector_data_type=DataType.FLOAT_VECTOR)
-        rows = [{default_primary_key_field_name: i, default_vector_field_name: vectors[i],
-                 default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(default_nb)]
+        rows = [
+            {
+                default_primary_key_field_name: i,
+                default_vector_field_name: vectors[i],
+                default_float_field_name: i * 1.0,
+                default_string_field_name: str(i),
+            }
+            for i in range(default_nb)
+        ]
         results = self.insert(client, collection_name, rows)[0]
-        assert results['insert_count'] == default_nb
+        assert results["insert_count"] == default_nb
         # 3. add new field
-        self.add_collection_field(client, collection_name, field_name="field_new", data_type=DataType.VARCHAR,
-                                  nullable=True, default_value=default_value, max_length=64)
+        self.add_collection_field(
+            client,
+            collection_name,
+            field_name="field_new",
+            data_type=DataType.VARCHAR,
+            nullable=True,
+            default_value=default_value,
+            max_length=64,
+        )
         vectors_to_search = [vectors[0]]
         insert_ids = [i for i in range(default_nb)]
         # 4. check old dynamic data search is not impacted after add new field
-        self.search(client, collection_name, vectors_to_search,
-                    check_task=CheckTasks.check_search_results,
-                    check_items={"enable_milvus_client_api": True,
-                                 "nq": len(vectors_to_search),
-                                 "ids": insert_ids,
-                                 "pk_name": default_primary_key_field_name,
-                                 "limit": default_limit})
+        self.search(
+            client,
+            collection_name,
+            vectors_to_search,
+            check_task=CheckTasks.check_search_results,
+            check_items={
+                "enable_milvus_client_api": True,
+                "nq": len(vectors_to_search),
+                "ids": insert_ids,
+                "pk_name": default_primary_key_field_name,
+                "limit": default_limit,
+            },
+        )
         # 5. insert data(old + new field)
-        rows_t = [{default_primary_key_field_name: i, default_vector_field_name: vectors[i],
-                  default_float_field_name: i * 1.0, default_string_field_name: str(i),
-                  "field_new": "field_new"} for i in range(default_nb, default_nb * 2)]
+        rows_t = [
+            {
+                default_primary_key_field_name: i,
+                default_vector_field_name: vectors[i],
+                default_float_field_name: i * 1.0,
+                default_string_field_name: str(i),
+                "field_new": "field_new",
+            }
+            for i in range(default_nb, default_nb * 2)
+        ]
         results = self.insert(client, collection_name, rows_t)[0]
-        assert results['insert_count'] == default_nb
+        assert results["insert_count"] == default_nb
         insert_ids_after_add_field = [i for i in range(default_nb, default_nb * 2)]
         # 6. search filtered with the new field
-        self.search(client, collection_name, vectors_to_search,
-                    filter=f'field_new=="{default_value}"',
-                    check_task=CheckTasks.check_search_results,
-                    check_items={"enable_milvus_client_api": True,
-                                 "nq": len(vectors_to_search),
-                                 "ids": insert_ids,
-                                 "pk_name": default_primary_key_field_name,
-                                 "limit": default_limit})
-        self.search(client, collection_name, vectors_to_search,
-                    filter="field_new=='field_new'",
-                    check_task=CheckTasks.check_search_results,
-                    check_items={"enable_milvus_client_api": True,
-                                 "nq": len(vectors_to_search),
-                                 "ids": insert_ids_after_add_field,
-                                 "pk_name": default_primary_key_field_name,
-                                 "limit": default_limit})
+        self.search(
+            client,
+            collection_name,
+            vectors_to_search,
+            filter=f'field_new=="{default_value}"',
+            check_task=CheckTasks.check_search_results,
+            check_items={
+                "enable_milvus_client_api": True,
+                "nq": len(vectors_to_search),
+                "ids": insert_ids,
+                "pk_name": default_primary_key_field_name,
+                "limit": default_limit,
+            },
+        )
+        self.search(
+            client,
+            collection_name,
+            vectors_to_search,
+            filter="field_new=='field_new'",
+            check_task=CheckTasks.check_search_results,
+            check_items={
+                "enable_milvus_client_api": True,
+                "nq": len(vectors_to_search),
+                "ids": insert_ids_after_add_field,
+                "pk_name": default_primary_key_field_name,
+                "limit": default_limit,
+            },
+        )
         self.release_collection(client, collection_name)
         self.drop_collection(client, collection_name)
 
@@ -623,9 +821,16 @@ class TestInsertOperation(TestMilvusClientV2Base):
         self.close(client)
 
         rng = np.random.default_rng(seed=19530)
-        rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
-                 default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(10)]
-        error = {ct.err_code: 999, ct.err_msg: 'should create connection first'}
+        rows = [
+            {
+                default_primary_key_field_name: i,
+                default_vector_field_name: list(rng.random((1, default_dim))[0]),
+                default_float_field_name: i * 1.0,
+                default_string_field_name: str(i),
+            }
+            for i in range(10)
+        ]
+        error = {ct.err_code: 999, ct.err_msg: "should create connection first"}
         self.insert(client, collection_name, rows, check_task=CheckTasks.err_res, check_items=error)
 
     @pytest.mark.tags(CaseLabel.L1)
@@ -643,10 +848,17 @@ class TestInsertOperation(TestMilvusClientV2Base):
         self.create_partition(client, collection_name, partition_name)
 
         rng = np.random.default_rng(seed=19530)
-        rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
-                 default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(ct.default_nb)]
+        rows = [
+            {
+                default_primary_key_field_name: i,
+                default_vector_field_name: list(rng.random((1, default_dim))[0]),
+                default_float_field_name: i * 1.0,
+                default_string_field_name: str(i),
+            }
+            for i in range(ct.default_nb)
+        ]
         results = self.insert(client, collection_name, rows, partition_name=partition_name)[0]
-        assert results['insert_count'] == ct.default_nb
+        assert results["insert_count"] == ct.default_nb
         self.drop_collection(client, collection_name)
 
     def test_insert_partition_not_existed(self):
@@ -660,11 +872,17 @@ class TestInsertOperation(TestMilvusClientV2Base):
         self.create_collection(client, collection_name, default_dim)
 
         rng = np.random.default_rng(seed=19530)
-        rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
-                 default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(10)]
+        rows = [
+            {
+                default_primary_key_field_name: i,
+                default_vector_field_name: list(rng.random((1, default_dim))[0]),
+                default_float_field_name: i * 1.0,
+                default_string_field_name: str(i),
+            }
+            for i in range(10)
+        ]
         error = {ct.err_code: 200, ct.err_msg: "partition not found[partition=p]"}
-        self.insert(client, collection_name, rows, partition_name="p",
-                   check_task=CheckTasks.err_res, check_items=error)
+        self.insert(client, collection_name, rows, partition_name="p", check_task=CheckTasks.err_res, check_items=error)
         self.drop_collection(client, collection_name)
 
     @pytest.mark.tags(CaseLabel.L1)
@@ -684,12 +902,19 @@ class TestInsertOperation(TestMilvusClientV2Base):
         self.create_partition(client, collection_name, partition_name_2)
 
         rng = np.random.default_rng(seed=19530)
-        rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
-                 default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(ct.default_nb)]
+        rows = [
+            {
+                default_primary_key_field_name: i,
+                default_vector_field_name: list(rng.random((1, default_dim))[0]),
+                default_float_field_name: i * 1.0,
+                default_string_field_name: str(i),
+            }
+            for i in range(ct.default_nb)
+        ]
         result_1 = self.insert(client, collection_name, rows, partition_name=partition_name_1)[0]
         result_2 = self.insert(client, collection_name, rows, partition_name=partition_name_2)[0]
-        assert result_1['insert_count'] == ct.default_nb
-        assert result_2['insert_count'] == ct.default_nb
+        assert result_1["insert_count"] == ct.default_nb
+        assert result_2["insert_count"] == ct.default_nb
         self.drop_collection(client, collection_name)
 
     @pytest.mark.tags(CaseLabel.L0)
@@ -707,10 +932,17 @@ class TestInsertOperation(TestMilvusClientV2Base):
         self.create_partition(client, collection_name, partition_name)
 
         rng = np.random.default_rng(seed=19530)
-        rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
-                 default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(ct.default_nb)]
+        rows = [
+            {
+                default_primary_key_field_name: i,
+                default_vector_field_name: list(rng.random((1, default_dim))[0]),
+                default_float_field_name: i * 1.0,
+                default_string_field_name: str(i),
+            }
+            for i in range(ct.default_nb)
+        ]
         results = self.insert(client, collection_name, rows, partition_name=partition_name)[0]
-        assert results['insert_count'] == ct.default_nb
+        assert results["insert_count"] == ct.default_nb
         self.drop_collection(client, collection_name)
 
     @pytest.mark.tags(CaseLabel.L1)
@@ -734,8 +966,16 @@ class TestInsertOperation(TestMilvusClientV2Base):
 
         # Insert data exceeding varchar limit
         rows = [
-            {"vector": list(cf.gen_vectors(1, ct.default_dim)[0]), "small_limit": "limit_1___________", "big_limit": "1"},
-            {"vector": list(cf.gen_vectors(1, ct.default_dim)[0]), "small_limit": "limit_2___________", "big_limit": "2"}
+            {
+                "vector": list(cf.gen_vectors(1, ct.default_dim)[0]),
+                "small_limit": "limit_1___________",
+                "big_limit": "1",
+            },
+            {
+                "vector": list(cf.gen_vectors(1, ct.default_dim)[0]),
+                "small_limit": "limit_2___________",
+                "big_limit": "2",
+            },
         ]
         error = {ct.err_code: 999, ct.err_msg: "length of varchar field small_limit exceeds max length"}
         self.insert(client, collection_name, rows, check_task=CheckTasks.err_res, check_items=error)
@@ -753,8 +993,10 @@ class TestInsertOperation(TestMilvusClientV2Base):
         self.create_collection(client, collection_name, default_dim)
 
         # Generate data without vector field
-        rows = [{default_primary_key_field_name: i,
-                 default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(10)]
+        rows = [
+            {default_primary_key_field_name: i, default_float_field_name: i * 1.0, default_string_field_name: str(i)}
+            for i in range(10)
+        ]
         error = {ct.err_code: 1, ct.err_msg: "Insert missed an field `vector` to collection"}
         self.insert(client, collection_name, rows, check_task=CheckTasks.err_res, check_items=error)
         self.drop_collection(client, collection_name)
@@ -771,8 +1013,14 @@ class TestInsertOperation(TestMilvusClientV2Base):
         self.create_collection(client, collection_name, default_dim)
 
         # Generate data with wrong vector type (scalar instead of list)
-        rows = [{default_primary_key_field_name: 0, default_vector_field_name: 0.0001,
-                 default_float_field_name: 0.0, default_string_field_name: "0"}]
+        rows = [
+            {
+                default_primary_key_field_name: 0,
+                default_vector_field_name: 0.0001,
+                default_float_field_name: 0.0,
+                default_string_field_name: "0",
+            }
+        ]
         error = {ct.err_code: 1, ct.err_msg: "The Input data type is inconsistent with defined schema"}
         self.insert(client, collection_name, rows, check_task=CheckTasks.err_res, check_items=error)
         self.drop_collection(client, collection_name)
@@ -792,8 +1040,15 @@ class TestInsertOperation(TestMilvusClientV2Base):
         assert collection_name in collections
 
         rng = np.random.default_rng(seed=19530)
-        rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
-                 default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(ct.default_nb)]
+        rows = [
+            {
+                default_primary_key_field_name: i,
+                default_vector_field_name: list(rng.random((1, default_dim))[0]),
+                default_float_field_name: i * 1.0,
+                default_string_field_name: str(i),
+            }
+            for i in range(ct.default_nb)
+        ]
         self.insert(client, collection_name, rows)
 
         self.drop_collection(client, collection_name)
@@ -812,8 +1067,15 @@ class TestInsertOperation(TestMilvusClientV2Base):
         self.create_collection(client, collection_name, default_dim)
 
         rng = np.random.default_rng(seed=19530)
-        rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
-                 default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(ct.default_nb)]
+        rows = [
+            {
+                default_primary_key_field_name: i,
+                default_vector_field_name: list(rng.random((1, default_dim))[0]),
+                default_float_field_name: i * 1.0,
+                default_string_field_name: str(i),
+            }
+            for i in range(ct.default_nb)
+        ]
         self.insert(client, collection_name, rows)
         self.flush(client, collection_name)
 
@@ -850,8 +1112,15 @@ class TestInsertOperation(TestMilvusClientV2Base):
 
         # Then insert data
         rng = np.random.default_rng(seed=19530)
-        rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
-                 default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(ct.default_nb)]
+        rows = [
+            {
+                default_primary_key_field_name: i,
+                default_vector_field_name: list(rng.random((1, default_dim))[0]),
+                default_float_field_name: i * 1.0,
+                default_string_field_name: str(i),
+            }
+            for i in range(ct.default_nb)
+        ]
         self.insert(client, collection_name, rows)
 
         self.flush(client, collection_name)
@@ -914,15 +1183,22 @@ class TestInsertOperation(TestMilvusClientV2Base):
         index_params = self.prepare_index_params(client)[0]
         index_params.add_index(default_vector_field_name, index_type="AUTOINDEX")
 
-        self.create_collection(client, collection_name, dimension=default_dim, schema=schema,
-                              index_params=index_params, auto_id=True)
+        self.create_collection(
+            client, collection_name, dimension=default_dim, schema=schema, index_params=index_params, auto_id=True
+        )
 
         # Insert without primary key (auto_id)
         rng = np.random.default_rng(seed=19530)
-        rows = [{default_vector_field_name: list(rng.random((1, default_dim))[0]),
-                 default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(ct.default_nb)]
+        rows = [
+            {
+                default_vector_field_name: list(rng.random((1, default_dim))[0]),
+                default_float_field_name: i * 1.0,
+                default_string_field_name: str(i),
+            }
+            for i in range(ct.default_nb)
+        ]
         results = self.insert(client, collection_name, rows)[0]
-        assert results['insert_count'] == ct.default_nb
+        assert results["insert_count"] == ct.default_nb
 
         self.flush(client, collection_name)
         num_entities = self.get_collection_stats(client, collection_name)[0]
@@ -957,14 +1233,16 @@ class TestInsertOperation(TestMilvusClientV2Base):
 
         # Insert without primary key (auto_id)
         rng = np.random.default_rng(seed=19530)
-        rows = [{default_vector_field_name: list(rng.random((1, default_dim))[0]),
-                 default_float_field_name: i * 1.0} for i in range(ct.default_nb)]
+        rows = [
+            {default_vector_field_name: list(rng.random((1, default_dim))[0]), default_float_field_name: i * 1.0}
+            for i in range(ct.default_nb)
+        ]
         if pk_field != ct.default_string_field_name:
             for i, row in enumerate(rows):
                 row[default_string_field_name] = str(i)
 
         results = self.insert(client, collection_name, rows)[0]
-        assert results['insert_count'] == ct.default_nb
+        assert results["insert_count"] == ct.default_nb
 
         self.flush(client, collection_name)
         num_entities = self.get_collection_stats(client, collection_name)[0]
@@ -997,17 +1275,19 @@ class TestInsertOperation(TestMilvusClientV2Base):
 
         # Insert twice
         rng = np.random.default_rng(seed=19530)
-        rows = [{default_vector_field_name: list(rng.random((1, default_dim))[0]),
-                 default_float_field_name: i * 1.0} for i in range(nb)]
+        rows = [
+            {default_vector_field_name: list(rng.random((1, default_dim))[0]), default_float_field_name: i * 1.0}
+            for i in range(nb)
+        ]
         if pk_field != ct.default_string_field_name:
             for i, row in enumerate(rows):
                 row[default_string_field_name] = str(i)
 
         results_1 = self.insert(client, collection_name, rows)[0]
-        assert results_1['insert_count'] == nb
+        assert results_1["insert_count"] == nb
 
         results_2 = self.insert(client, collection_name, rows)[0]
-        assert results_2['insert_count'] == nb
+        assert results_2["insert_count"] == nb
 
         self.flush(client, collection_name)
         num_entities = self.get_collection_stats(client, collection_name)[0]
@@ -1039,14 +1319,16 @@ class TestInsertOperation(TestMilvusClientV2Base):
 
         # Insert without primary key (auto_id)
         rng = np.random.default_rng(seed=19530)
-        rows = [{default_vector_field_name: list(rng.random((1, default_dim))[0]),
-                 default_float_field_name: i * 1.0} for i in range(ct.default_nb)]
+        rows = [
+            {default_vector_field_name: list(rng.random((1, default_dim))[0]), default_float_field_name: i * 1.0}
+            for i in range(ct.default_nb)
+        ]
         if pk_field != ct.default_string_field_name:
             for i, row in enumerate(rows):
                 row[default_string_field_name] = str(i)
 
         results = self.insert(client, collection_name, rows)[0]
-        assert results['insert_count'] == ct.default_nb
+        assert results["insert_count"] == ct.default_nb
 
         self.flush(client, collection_name)
         num_entities = self.get_collection_stats(client, collection_name)[0]
@@ -1078,8 +1360,10 @@ class TestInsertOperation(TestMilvusClientV2Base):
 
         # Try to insert with primary key included (should fail)
         df = cf.gen_default_dataframe_data(nb=100, auto_id=True)
-        error = {ct.err_code: 999,
-                 ct.err_msg: "wrong type of argument 'data',expected 'Dict' or list of 'Dict', got 'DataFrame'"}
+        error = {
+            ct.err_code: 999,
+            ct.err_msg: "wrong type of argument 'data',expected 'Dict' or list of 'Dict', got 'DataFrame'",
+        }
         self.insert(client, collection_name, df, check_task=CheckTasks.err_res, check_items=error)
 
         self.flush(client, collection_name)
@@ -1113,8 +1397,10 @@ class TestInsertOperation(TestMilvusClientV2Base):
 
         # Insert without primary key (auto_id)
         rng = np.random.default_rng(seed=19530)
-        rows = [{default_vector_field_name: list(rng.random((1, default_dim))[0]),
-                 default_float_field_name: i * 1.0} for i in range(nb)]
+        rows = [
+            {default_vector_field_name: list(rng.random((1, default_dim))[0]), default_float_field_name: i * 1.0}
+            for i in range(nb)
+        ]
         if pk_field != ct.default_string_field_name:
             for i, row in enumerate(rows):
                 row[default_string_field_name] = str(i)
@@ -1140,10 +1426,17 @@ class TestInsertOperation(TestMilvusClientV2Base):
 
         # Insert with same primary key values
         rng = np.random.default_rng(seed=19530)
-        rows = [{default_primary_key_field_name: 1, default_vector_field_name: list(rng.random((1, default_dim))[0]),
-                 default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(nb)]
+        rows = [
+            {
+                default_primary_key_field_name: 1,
+                default_vector_field_name: list(rng.random((1, default_dim))[0]),
+                default_float_field_name: i * 1.0,
+                default_string_field_name: str(i),
+            }
+            for i in range(nb)
+        ]
         results = self.insert(client, collection_name, rows)[0]
-        assert results['insert_count'] == nb
+        assert results["insert_count"] == nb
         self.drop_collection(client, collection_name)
 
     @pytest.mark.tags(CaseLabel.L1)
@@ -1161,10 +1454,17 @@ class TestInsertOperation(TestMilvusClientV2Base):
 
         # Insert with negative primary key values
         rng = np.random.default_rng(seed=19530)
-        rows = [{default_primary_key_field_name: -i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
-                 default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(nb)]
+        rows = [
+            {
+                default_primary_key_field_name: -i,
+                default_vector_field_name: list(rng.random((1, default_dim))[0]),
+                default_float_field_name: i * 1.0,
+                default_string_field_name: str(i),
+            }
+            for i in range(nb)
+        ]
         results = self.insert(client, collection_name, rows)[0]
-        assert results['insert_count'] == nb
+        assert results["insert_count"] == nb
 
         self.flush(client, collection_name)
         num_entities = self.get_collection_stats(client, collection_name)[0]
@@ -1188,18 +1488,30 @@ class TestInsertOperation(TestMilvusClientV2Base):
         thread_num = 4
         threads = []
         rng = np.random.default_rng(seed=19530)
-        rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
-                 default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(ct.default_nb)]
+        rows = [
+            {
+                default_primary_key_field_name: i,
+                default_vector_field_name: list(rng.random((1, default_dim))[0]),
+                default_float_field_name: i * 1.0,
+                default_string_field_name: str(i),
+            }
+            for i in range(ct.default_nb)
+        ]
 
         def insert(thread_i):
-            log.debug(f'In thread-{thread_i}')
+            log.debug(f"In thread-{thread_i}")
             # Adjust primary keys to be unique per thread
-            thread_rows = [{default_primary_key_field_name: i + thread_i * ct.default_nb,
-                           default_vector_field_name: row[default_vector_field_name],
-                           default_float_field_name: row[default_float_field_name],
-                           default_string_field_name: row[default_string_field_name]} for i, row in enumerate(rows)]
+            thread_rows = [
+                {
+                    default_primary_key_field_name: i + thread_i * ct.default_nb,
+                    default_vector_field_name: row[default_vector_field_name],
+                    default_float_field_name: row[default_float_field_name],
+                    default_string_field_name: row[default_string_field_name],
+                }
+                for i, row in enumerate(rows)
+            ]
             results = self.insert(client, collection_name, thread_rows)[0]
-            assert results['insert_count'] == ct.default_nb
+            assert results["insert_count"] == ct.default_nb
 
         for i in range(thread_num):
             x = threading.Thread(target=insert, args=(i,))
@@ -1230,11 +1542,17 @@ class TestInsertOperation(TestMilvusClientV2Base):
         rng = np.random.default_rng(seed=19530)
         start_id = 0
         for _ in range(nb // step):
-            rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, dim))[0]),
-                     default_float_field_name: i * 1.0, default_string_field_name: str(i)}
-                    for i in range(start_id, start_id + step)]
+            rows = [
+                {
+                    default_primary_key_field_name: i,
+                    default_vector_field_name: list(rng.random((1, dim))[0]),
+                    default_float_field_name: i * 1.0,
+                    default_string_field_name: str(i),
+                }
+                for i in range(start_id, start_id + step)
+            ]
             results = self.insert(client, collection_name, rows)[0]
-            assert results['insert_count'] == step
+            assert results["insert_count"] == step
             start_id += step
 
         self.flush(client, collection_name)
@@ -1268,8 +1586,15 @@ class TestInsertOperation(TestMilvusClientV2Base):
         self.create_collection(client, collection_name, default_dim, auto_id=False)
 
         rng = np.random.default_rng(seed=19530)
-        rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
-                 default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(nb)]
+        rows = [
+            {
+                default_primary_key_field_name: i,
+                default_vector_field_name: list(rng.random((1, default_dim))[0]),
+                default_float_field_name: i * 1.0,
+                default_string_field_name: str(i),
+            }
+            for i in range(nb)
+        ]
         self.insert(client, collection_name, rows)
 
         self.flush(client, collection_name)
@@ -1297,8 +1622,13 @@ class TestInsertOperation(TestMilvusClientV2Base):
         else:
             schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=True)
         schema.add_field(default_float_field_name, DataType.FLOAT)
-        schema.add_field(default_string_field_name, DataType.VARCHAR, max_length=ct.default_length,
-                        default_value="abc", nullable=nullable)
+        schema.add_field(
+            default_string_field_name,
+            DataType.VARCHAR,
+            max_length=ct.default_length,
+            default_value="abc",
+            nullable=nullable,
+        )
         schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
 
         self.create_collection(client, collection_name, dimension=default_dim, schema=schema, auto_id=auto_id)
@@ -1307,8 +1637,7 @@ class TestInsertOperation(TestMilvusClientV2Base):
         rng = np.random.default_rng(seed=19530)
         rows = []
         for i in range(ct.default_nb):
-            row = {default_float_field_name: float(i),
-                   default_vector_field_name: list(rng.random((1, default_dim))[0])}
+            row = {default_float_field_name: float(i), default_vector_field_name: list(rng.random((1, default_dim))[0])}
             if not auto_id:
                 row[default_primary_key_field_name] = i
             if default_value_type == "none":
@@ -1338,25 +1667,41 @@ class TestInsertOperation(TestMilvusClientV2Base):
         schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True)
         schema.add_field(default_int32_field_name, DataType.INT32, default_value=np.int32(1), nullable=True)
         schema.add_field(default_float_field_name, DataType.FLOAT, default_value=np.float32(1.0), nullable=True)
-        schema.add_field(default_string_field_name, DataType.VARCHAR, default_value="abc", max_length=100, nullable=True)
-        schema.add_field('int32_array', datatype=DataType.ARRAY, element_type=DataType.INT32,  max_capacity=20, nullable=True)
-        schema.add_field('float_array', datatype=DataType.ARRAY, element_type=DataType.FLOAT,   max_capacity=20, nullable=True)
-        schema.add_field('string_array', datatype=DataType.ARRAY, element_type=DataType.VARCHAR, max_capacity=20, max_length=100, nullable=True)
-        schema.add_field('json', DataType.JSON,  nullable=True)
+        schema.add_field(
+            default_string_field_name, DataType.VARCHAR, default_value="abc", max_length=100, nullable=True
+        )
+        schema.add_field(
+            "int32_array", datatype=DataType.ARRAY, element_type=DataType.INT32, max_capacity=20, nullable=True
+        )
+        schema.add_field(
+            "float_array", datatype=DataType.ARRAY, element_type=DataType.FLOAT, max_capacity=20, nullable=True
+        )
+        schema.add_field(
+            "string_array",
+            datatype=DataType.ARRAY,
+            element_type=DataType.VARCHAR,
+            max_capacity=20,
+            max_length=100,
+            nullable=True,
+        )
+        schema.add_field("json", DataType.JSON, nullable=True)
         schema.add_field(ct.default_float_vec_field_name, DataType.FLOAT_VECTOR, dim=dim)
         self.create_collection(client, collection_name, schema=schema)
 
-        rows = [{
-            default_primary_key_field_name: i,
-            default_int32_field_name: None,
-            default_float_field_name: None,
-            default_string_field_name: None,
-            'int32_array': None,
-            'float_array': None,
-            'string_array': None,
-            'json': None,
-            ct.default_float_vec_field_name: cf.gen_vectors(1, dim=dim)[0]
-        } for i in range(nb)]
+        rows = [
+            {
+                default_primary_key_field_name: i,
+                default_int32_field_name: None,
+                default_float_field_name: None,
+                default_string_field_name: None,
+                "int32_array": None,
+                "float_array": None,
+                "string_array": None,
+                "json": None,
+                ct.default_float_vec_field_name: cf.gen_vectors(1, dim=dim)[0],
+            }
+            for i in range(nb)
+        ]
         self.insert(client, collection_name, rows)
         self.flush(client, collection_name)
         num_entities = self.get_collection_stats(client, collection_name)[0]

--- a/tests/python_client/milvus_client_v2/test_milvus_client_hybrid_search_v2.py
+++ b/tests/python_client/milvus_client_v2/test_milvus_client_hybrid_search_v2.py
@@ -1268,7 +1268,7 @@ class TestMilvusClientHybridSearch(TestMilvusClientV2Base):
         ranker = RRFRanker(k)
         # TODO: #29867, the error msg is not good enough, but as it is for now.
         err_msg = {"err_code": 65535,
-                   "err_msg": "The rank params k should be in range (0, 16384)"}
+                   "err_msg": "rank params k should be in range (0, 16384)"}
         self.hybrid_search(client, self.collection_name,
                            reqs=req_list,
                            ranker=ranker,

--- a/tests/python_client/milvus_client_v2/test_milvus_client_hybrid_search_v2.py
+++ b/tests/python_client/milvus_client_v2/test_milvus_client_hybrid_search_v2.py
@@ -71,7 +71,7 @@ class TestMilvusClientHybridSearch(TestMilvusClientV2Base):
             self.text_field_name2,
             self.json_field_name,
             self.string_field_name,
-            self.int64_field_name
+            self.int64_field_name,
         ]
 
         self.float_vector_dim = 128
@@ -97,10 +97,20 @@ class TestMilvusClientHybridSearch(TestMilvusClientV2Base):
         collection_schema.add_field(self.float_vector_field_name2, DataType.FLOAT_VECTOR, dim=self.float_vector_dim)
         collection_schema.add_field(self.sparse_vector_field_name1, DataType.SPARSE_FLOAT_VECTOR)
         collection_schema.add_field(self.sparse_vector_field_name2, DataType.SPARSE_FLOAT_VECTOR)
-        collection_schema.add_field(self.text_field_name1, DataType.VARCHAR, max_length=6553,
-                                    enable_analyzer=True, analyzer_params=analyzer_params)
-        collection_schema.add_field(self.text_field_name2, DataType.VARCHAR, max_length=6553,
-                                    enable_analyzer=True, analyzer_params=analyzer_params)
+        collection_schema.add_field(
+            self.text_field_name1,
+            DataType.VARCHAR,
+            max_length=6553,
+            enable_analyzer=True,
+            analyzer_params=analyzer_params,
+        )
+        collection_schema.add_field(
+            self.text_field_name2,
+            DataType.VARCHAR,
+            max_length=6553,
+            enable_analyzer=True,
+            analyzer_params=analyzer_params,
+        )
         collection_schema.add_field(self.int64_field_name, DataType.INT64)
         collection_schema.add_field(self.json_field_name, DataType.JSON)
         collection_schema.add_field(self.string_field_name, DataType.VARCHAR, max_length=256)
@@ -120,8 +130,7 @@ class TestMilvusClientHybridSearch(TestMilvusClientV2Base):
         )
         collection_schema.add_function(bm25_function1)
         collection_schema.add_function(bm25_function2)
-        self.create_collection(client, self.collection_name, schema=collection_schema,
-                               force_teardown=False)
+        self.create_collection(client, self.collection_name, schema=collection_schema, force_teardown=False)
         for partition_name in self.partition_names:
             self.create_partition(client, self.collection_name, partition_name=partition_name)
 
@@ -129,10 +138,12 @@ class TestMilvusClientHybridSearch(TestMilvusClientV2Base):
         insert_times = 2
 
         # Generate vectors for each type and store in self
-        float_vectors = cf.gen_vectors(default_nb * insert_times, dim=self.float_vector_dim,
-                                       vector_data_type=DataType.FLOAT_VECTOR)
-        float_vectors2 = cf.gen_vectors(default_nb * insert_times, dim=self.float_vector_dim,
-                                        vector_data_type=DataType.FLOAT_VECTOR)
+        float_vectors = cf.gen_vectors(
+            default_nb * insert_times, dim=self.float_vector_dim, vector_data_type=DataType.FLOAT_VECTOR
+        )
+        float_vectors2 = cf.gen_vectors(
+            default_nb * insert_times, dim=self.float_vector_dim, vector_data_type=DataType.FLOAT_VECTOR
+        )
         texts1 = cf.gen_varchar_data(length=10, nb=default_nb * insert_times, text_mode=True)
         texts2 = cf.gen_varchar_data(length=10, nb=default_nb * insert_times, text_mode=True)
 
@@ -182,22 +193,16 @@ class TestMilvusClientHybridSearch(TestMilvusClientV2Base):
 
         # Create index
         index_params = self.prepare_index_params(client)[0]
-        index_params.add_index(field_name=self.float_vector_field_name1,
-                               metric_type="COSINE",
-                               index_type="IVF_FLAT",
-                               params={"nlist": 128})
-        index_params.add_index(field_name=self.float_vector_field_name2,
-                               metric_type="L2",
-                               index_type="HNSW",
-                               params={})
-        index_params.add_index(field_name=self.sparse_vector_field_name1,
-                               metric_type="BM25",
-                               index_type="SPARSE_INVERTED_INDEX",
-                               params={})
-        index_params.add_index(field_name=self.sparse_vector_field_name2,
-                               metric_type="BM25",
-                               index_type="SPARSE_INVERTED_INDEX",
-                               params={})
+        index_params.add_index(
+            field_name=self.float_vector_field_name1, metric_type="COSINE", index_type="IVF_FLAT", params={"nlist": 128}
+        )
+        index_params.add_index(field_name=self.float_vector_field_name2, metric_type="L2", index_type="HNSW", params={})
+        index_params.add_index(
+            field_name=self.sparse_vector_field_name1, metric_type="BM25", index_type="SPARSE_INVERTED_INDEX", params={}
+        )
+        index_params.add_index(
+            field_name=self.sparse_vector_field_name2, metric_type="BM25", index_type="SPARSE_INVERTED_INDEX", params={}
+        )
         self.create_index(client, self.collection_name, index_params=index_params, timeout=300)
 
         # Load collection
@@ -233,27 +238,34 @@ class TestMilvusClientHybridSearch(TestMilvusClientV2Base):
         # generate hybrid search request list
         req_list = []
         for field_name in field_names:
-            req = AnnSearchRequest(**{
-                "data": search_data,
-                "anns_field": field_name,
-                "param": {},
-                "limit": default_limit,
-            })
+            req = AnnSearchRequest(
+                **{
+                    "data": search_data,
+                    "anns_field": field_name,
+                    "param": {},
+                    "limit": default_limit,
+                }
+            )
             req_list.append(req)
 
         # perform hybrid search
-        self.hybrid_search(client, self.collection_name, reqs=req_list,
-                           ranker=WeightedRanker(*[0.6, 0.4]),
-                           limit=default_limit,
-                           output_fields=[self.primary_key_field_name, self.string_field_name],
-                           check_task=CheckTasks.check_search_results,
-                           check_items={"nq": nq,
-                                        "ids": self.primary_keys,
-                                        "limit": default_limit,
-                                        "pk_name": self.primary_key_field_name,
-                                        "original_entities": self.datas,
-                                        "output_fields": [self.primary_key_field_name,
-                                                          self.string_field_name]})
+        self.hybrid_search(
+            client,
+            self.collection_name,
+            reqs=req_list,
+            ranker=WeightedRanker(*[0.6, 0.4]),
+            limit=default_limit,
+            output_fields=[self.primary_key_field_name, self.string_field_name],
+            check_task=CheckTasks.check_search_results,
+            check_items={
+                "nq": nq,
+                "ids": self.primary_keys,
+                "limit": default_limit,
+                "pk_name": self.primary_key_field_name,
+                "original_entities": self.datas,
+                "output_fields": [self.primary_key_field_name, self.string_field_name],
+            },
+        )
 
     @pytest.mark.tags(CaseLabel.L1)
     @pytest.mark.parametrize("req_limit_ratio", [1, 2])
@@ -276,42 +288,54 @@ class TestMilvusClientHybridSearch(TestMilvusClientV2Base):
                 search_data = cf.gen_vectors(nq, self.float_vector_dim, vector_data_type=DataType.FLOAT_VECTOR)
             else:
                 search_data = cf.gen_varchar_data(length=10, nb=nq, text_mode=True)
-            req = AnnSearchRequest(**{
-                "data": search_data,
-                "anns_field": field_name,
-                "param": {},
-                "limit": default_limit * req_limit_ratio,
-            })
+            req = AnnSearchRequest(
+                **{
+                    "data": search_data,
+                    "anns_field": field_name,
+                    "param": {},
+                    "limit": default_limit * req_limit_ratio,
+                }
+            )
             req_list.append(req)
-        hybrid_search_0 = self.hybrid_search(client, self.collection_name, reqs=req_list,
-                                             ranker=WeightedRanker(*[0.6, 0.4]),
-                                             limit=default_limit,
-                                             filter=f"{self.int64_field_name} > 1000",
-                                             output_fields=[self.primary_key_field_name, self.string_field_name],
-                                             check_task=CheckTasks.check_search_results,
-                                             check_items={"nq": nq,
-                                                          "ids": self.primary_keys,
-                                                          "limit": default_limit,
-                                                          "enable_milvus_client_api": True,
-                                                          "pk_name": self.primary_key_field_name,
-                                                          "original_entities": self.datas,
-                                                          "output_fields": [self.primary_key_field_name,
-                                                                            self.string_field_name]})[0]
+        hybrid_search_0 = self.hybrid_search(
+            client,
+            self.collection_name,
+            reqs=req_list,
+            ranker=WeightedRanker(*[0.6, 0.4]),
+            limit=default_limit,
+            filter=f"{self.int64_field_name} > 1000",
+            output_fields=[self.primary_key_field_name, self.string_field_name],
+            check_task=CheckTasks.check_search_results,
+            check_items={
+                "nq": nq,
+                "ids": self.primary_keys,
+                "limit": default_limit,
+                "enable_milvus_client_api": True,
+                "pk_name": self.primary_key_field_name,
+                "original_entities": self.datas,
+                "output_fields": [self.primary_key_field_name, self.string_field_name],
+            },
+        )[0]
 
-        hybrid_search_1 = self.hybrid_search(client, self.collection_name, reqs=req_list,
-                                             ranker=WeightedRanker(*[0.6, 0.4]),
-                                             limit=default_limit,
-                                             filter=f"{self.int64_field_name} > 1000",
-                                             output_fields=[self.primary_key_field_name, self.string_field_name],
-                                             check_task=CheckTasks.check_search_results,
-                                             check_items={"nq": nq,
-                                                          "ids": self.primary_keys,
-                                                          "limit": default_limit,
-                                                          "enable_milvus_client_api": True,
-                                                          "pk_name": self.primary_key_field_name,
-                                                          "original_entities": self.datas,
-                                                          "output_fields": [self.primary_key_field_name,
-                                                                            self.string_field_name]})[0]
+        hybrid_search_1 = self.hybrid_search(
+            client,
+            self.collection_name,
+            reqs=req_list,
+            ranker=WeightedRanker(*[0.6, 0.4]),
+            limit=default_limit,
+            filter=f"{self.int64_field_name} > 1000",
+            output_fields=[self.primary_key_field_name, self.string_field_name],
+            check_task=CheckTasks.check_search_results,
+            check_items={
+                "nq": nq,
+                "ids": self.primary_keys,
+                "limit": default_limit,
+                "enable_milvus_client_api": True,
+                "pk_name": self.primary_key_field_name,
+                "original_entities": self.datas,
+                "output_fields": [self.primary_key_field_name, self.string_field_name],
+            },
+        )[0]
         # verify the hybrid search results are consistent
         for i in range(nq):
             assert hybrid_search_0[i].ids == hybrid_search_1[i].ids
@@ -336,29 +360,36 @@ class TestMilvusClientHybridSearch(TestMilvusClientV2Base):
         filter_min_value = 800
         filter_max_value = 1800
         for field_name in [self.float_vector_field_name1, self.float_vector_field_name2]:
-            req = AnnSearchRequest(**{
-                "data": search_data,
-                "anns_field": field_name,
-                "param": {},
-                "limit": default_limit,
-                "expr": f"{filter_min_value} < {self.primary_key_field_name} <= {filter_max_value}"
-            })
+            req = AnnSearchRequest(
+                **{
+                    "data": search_data,
+                    "anns_field": field_name,
+                    "param": {},
+                    "limit": default_limit,
+                    "expr": f"{filter_min_value} < {self.primary_key_field_name} <= {filter_max_value}",
+                }
+            )
             req_list.append(req)
 
         ranker = WeightedRanker(*[0.5, 0.5])
-        res = self.hybrid_search(client, self.collection_name, reqs=req_list,
-                                 ranker=ranker,
-                                 limit=default_limit,
-                                 # fitler=f"{default_primary_key_field_name} <= {filter_max_value}",
-                                 output_fields=[self.primary_key_field_name, self.string_field_name],
-                                 check_task=CheckTasks.check_search_results,
-                                 check_items={"nq": nq,
-                                              "ids": self.primary_keys,
-                                              "limit": default_limit,
-                                              "pk_name": self.primary_key_field_name,
-                                              "original_entities": self.datas,
-                                              "output_fields": [self.primary_key_field_name,
-                                                                self.string_field_name]})[0]
+        res = self.hybrid_search(
+            client,
+            self.collection_name,
+            reqs=req_list,
+            ranker=ranker,
+            limit=default_limit,
+            # fitler=f"{default_primary_key_field_name} <= {filter_max_value}",
+            output_fields=[self.primary_key_field_name, self.string_field_name],
+            check_task=CheckTasks.check_search_results,
+            check_items={
+                "nq": nq,
+                "ids": self.primary_keys,
+                "limit": default_limit,
+                "pk_name": self.primary_key_field_name,
+                "original_entities": self.datas,
+                "output_fields": [self.primary_key_field_name, self.string_field_name],
+            },
+        )[0]
 
         # verify the hybrid search results meet the filter
         for i in range(nq):
@@ -368,19 +399,24 @@ class TestMilvusClientHybridSearch(TestMilvusClientV2Base):
         # hybrid search again with filter
         filter_max_value2 = np.mean(res[0].ids)
         filter = f"{self.primary_key_field_name} <= {filter_max_value2}"
-        res2 = self.hybrid_search(client, self.collection_name, reqs=req_list,
-                                  ranker=ranker,
-                                  limit=default_limit,
-                                  fitler=filter,
-                                  output_fields=[self.primary_key_field_name, self.string_field_name],
-                                  check_task=CheckTasks.check_search_results,
-                                  check_items={"nq": nq,
-                                               "ids": self.primary_keys,
-                                               "limit": default_limit,
-                                               "pk_name": self.primary_key_field_name,
-                                               "original_entities": self.datas,
-                                               "output_fields": [self.primary_key_field_name,
-                                                                 self.string_field_name]})[0]
+        res2 = self.hybrid_search(
+            client,
+            self.collection_name,
+            reqs=req_list,
+            ranker=ranker,
+            limit=default_limit,
+            fitler=filter,
+            output_fields=[self.primary_key_field_name, self.string_field_name],
+            check_task=CheckTasks.check_search_results,
+            check_items={
+                "nq": nq,
+                "ids": self.primary_keys,
+                "limit": default_limit,
+                "pk_name": self.primary_key_field_name,
+                "original_entities": self.datas,
+                "output_fields": [self.primary_key_field_name, self.string_field_name],
+            },
+        )[0]
         # verify filter in hybrid search is not effective
         assert max(res2[i].ids) > filter_max_value2
 
@@ -403,35 +439,42 @@ class TestMilvusClientHybridSearch(TestMilvusClientV2Base):
         req_list = []
         for _ in range(req_num):
             search_data = cf.gen_vectors(nq, self.float_vector_dim, vector_data_type=DataType.FLOAT_VECTOR)
-            req = AnnSearchRequest(**{
-                "data": search_data,
-                "anns_field": self.float_vector_field_name1,  # on the same anns field
-                "param": {},
-                "limit": default_limit,
-                "expr": f"{self.int64_field_name} > 100"
-            })
+            req = AnnSearchRequest(
+                **{
+                    "data": search_data,
+                    "anns_field": self.float_vector_field_name1,  # on the same anns field
+                    "param": {},
+                    "limit": default_limit,
+                    "expr": f"{self.int64_field_name} > 100",
+                }
+            )
             req_list.append(req)
 
         ranker = RRFRanker()
 
         if req_num > ct.max_hybrid_search_req_num:
             check_task = CheckTasks.err_res
-            check_items = {"err_code": 65535,
-                           "err_msg": "maximum of ann search requests is 1024"}
+            check_items = {"err_code": 65535, "err_msg": "maximum of ann search requests is 1024"}
         else:
             check_task = CheckTasks.check_search_results
-            check_items = {"nq": nq,
-                           "ids": self.primary_keys,
-                           "limit": default_limit,
-                           "pk_name": self.primary_key_field_name,
-                           "original_entities": self.datas,
-                           "output_fields": [self.primary_key_field_name, self.string_field_name]}
-        self.hybrid_search(client, self.collection_name, reqs=req_list,
-                           ranker=ranker,
-                           limit=default_limit,
-                           output_fields=[self.primary_key_field_name, self.string_field_name],
-                           check_task=check_task,
-                           check_items=check_items)
+            check_items = {
+                "nq": nq,
+                "ids": self.primary_keys,
+                "limit": default_limit,
+                "pk_name": self.primary_key_field_name,
+                "original_entities": self.datas,
+                "output_fields": [self.primary_key_field_name, self.string_field_name],
+            }
+        self.hybrid_search(
+            client,
+            self.collection_name,
+            reqs=req_list,
+            ranker=ranker,
+            limit=default_limit,
+            output_fields=[self.primary_key_field_name, self.string_field_name],
+            check_task=check_task,
+            check_items=check_items,
+        )
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_hybrid_search_over_max_limit(self):
@@ -461,11 +504,20 @@ class TestMilvusClientHybridSearch(TestMilvusClientV2Base):
             req_list1.append(req)
 
         # hybrid search with over max limit
-        error = {"err_code": 65535, "err_msg": f"invalid max query result window, (offset+limit) "
-                                               f"should be in range [1, 16384], but got {over_max_limit}"}
-        self.hybrid_search(client, self.collection_name, reqs=req_list1,
-                           ranker=ranker, limit=over_max_limit,
-                           check_task=CheckTasks.err_res, check_items=error)
+        error = {
+            "err_code": 65535,
+            "err_msg": f"invalid max query result window, (offset+limit) "
+            f"should be in range [1, 16384], but got {over_max_limit}",
+        }
+        self.hybrid_search(
+            client,
+            self.collection_name,
+            reqs=req_list1,
+            ranker=ranker,
+            limit=over_max_limit,
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
         # hybrid search with over max limit in sub requests
         req_list = []
@@ -479,11 +531,20 @@ class TestMilvusClientHybridSearch(TestMilvusClientV2Base):
             }
             req = AnnSearchRequest(**search_param)
             req_list.append(req)
-        error = {"err_code": 65535, "err_msg": f"topk [{over_max_limit}] is invalid, "
-                                               f"it should be in range [1, 16384], but got {over_max_limit}"}
-        self.hybrid_search(client, self.collection_name, reqs=req_list,
-                           ranker=ranker, limit=default_limit,
-                           check_task=CheckTasks.err_res, check_items=error)
+        error = {
+            "err_code": 65535,
+            "err_msg": f"topk [{over_max_limit}] is invalid, "
+            f"it should be in range [1, 16384], but got {over_max_limit}",
+        }
+        self.hybrid_search(
+            client,
+            self.collection_name,
+            reqs=req_list,
+            ranker=ranker,
+            limit=default_limit,
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
         # TODO: hybrid search with over max limit+offset in sub requests after #45939 fixed
         # req_list = []
@@ -521,18 +582,25 @@ class TestMilvusClientHybridSearch(TestMilvusClientV2Base):
         limit = ct.min_limit - 1
         for i in range(len(vector_name_list)):
             search_data = cf.gen_vectors(1, self.float_vector_dim, vector_data_type=DataType.FLOAT_VECTOR)
-            req = AnnSearchRequest(**{
-                "data": search_data,
-                "anns_field": vector_name_list[i],
-                "param": {},
-                "limit": ct.default_limit,
-            })
+            req = AnnSearchRequest(
+                **{
+                    "data": search_data,
+                    "anns_field": vector_name_list[i],
+                    "param": {},
+                    "limit": ct.default_limit,
+                }
+            )
             req_list.append(req)
-        error = {"err_code": 1,
-                 "err_msg": f"`limit` value {limit} is illegal"}
-        self.hybrid_search(client, self.collection_name, reqs=req_list,
-                           ranker=ranker, limit=limit,
-                           check_task=CheckTasks.err_res, check_items=error)
+        error = {"err_code": 1, "err_msg": f"`limit` value {limit} is illegal"}
+        self.hybrid_search(
+            client,
+            self.collection_name,
+            reqs=req_list,
+            ranker=ranker,
+            limit=limit,
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
         # 4. hybrid search with less than minimum limit in sub request
         req_list = []
@@ -540,18 +608,28 @@ class TestMilvusClientHybridSearch(TestMilvusClientV2Base):
         limit = ct.min_limit - 1
         for i in range(len(vector_name_list)):
             search_data = cf.gen_vectors(1, self.float_vector_dim, vector_data_type=DataType.FLOAT_VECTOR)
-            req = AnnSearchRequest(**{
-                "data": search_data,
-                "anns_field": vector_name_list[i],
-                "param": {},
-                "limit": limit,
-            })
+            req = AnnSearchRequest(
+                **{
+                    "data": search_data,
+                    "anns_field": vector_name_list[i],
+                    "param": {},
+                    "limit": limit,
+                }
+            )
             req_list.append(req)
-        error = {"err_code": 1,
-                 "err_msg": f"topk [{limit}] is invalid, it should be in range [1, 16384], but got {limit}"}
-        self.hybrid_search(client, self.collection_name, reqs=req_list,
-                           ranker=ranker, limit=ct.default_limit,
-                           check_task=CheckTasks.err_res, check_items=error)
+        error = {
+            "err_code": 1,
+            "err_msg": f"topk [{limit}] is invalid, it should be in range [1, 16384], but got {limit}",
+        }
+        self.hybrid_search(
+            client,
+            self.collection_name,
+            reqs=req_list,
+            ranker=ranker,
+            limit=ct.default_limit,
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     @pytest.mark.tags(CaseLabel.L1)
     @pytest.mark.parametrize("req_limit", [None, 1, ct.default_limit * 2, ct.max_limit])
@@ -570,29 +648,29 @@ class TestMilvusClientHybridSearch(TestMilvusClientV2Base):
         # generate hybrid search request list
         req_list = []
         for field_name in [self.float_vector_field_name1, self.float_vector_field_name2]:
-            req = AnnSearchRequest(**{
-                "data": search_data,
-                "anns_field": field_name,
-                "param": {},
-                "limit": req_limit
-            })
+            req = AnnSearchRequest(**{"data": search_data, "anns_field": field_name, "param": {}, "limit": req_limit})
             req_list.append(req)
 
         ranker = WeightedRanker(*[0.5, 0.5])
         expected_limit = ct.default_limit if req_limit is None else min(req_limit * len(req_list), ct.default_limit)
-        self.hybrid_search(client, self.collection_name, reqs=req_list,
-                           ranker=ranker,
-                           limit=ct.default_limit,
-                           fitler=f"{self.int64_field_name} <= 18000",
-                           output_fields=[self.primary_key_field_name, self.string_field_name],
-                           check_task=CheckTasks.check_search_results,
-                           check_items={"nq": nq,
-                                        "ids": self.primary_keys,
-                                        "limit": expected_limit,
-                                        "pk_name": self.primary_key_field_name,
-                                        "original_entities": self.datas,
-                                        "output_fields": [self.primary_key_field_name,
-                                                          self.string_field_name]})
+        self.hybrid_search(
+            client,
+            self.collection_name,
+            reqs=req_list,
+            ranker=ranker,
+            limit=ct.default_limit,
+            fitler=f"{self.int64_field_name} <= 18000",
+            output_fields=[self.primary_key_field_name, self.string_field_name],
+            check_task=CheckTasks.check_search_results,
+            check_items={
+                "nq": nq,
+                "ids": self.primary_keys,
+                "limit": expected_limit,
+                "pk_name": self.primary_key_field_name,
+                "original_entities": self.datas,
+                "output_fields": [self.primary_key_field_name, self.string_field_name],
+            },
+        )
 
     @pytest.mark.tags(CaseLabel.L0)
     def test_hybrid_search_as_search(self):
@@ -612,41 +690,53 @@ class TestMilvusClientHybridSearch(TestMilvusClientV2Base):
             else:
                 search_data = cf.gen_varchar_data(length=10, nb=nq, text_mode=True)
             req_list = []
-            req = AnnSearchRequest(**{
-                "data": search_data,
-                "anns_field": field_name,
-                "param": {},
-                "limit": default_limit,
-            })
+            req = AnnSearchRequest(
+                **{
+                    "data": search_data,
+                    "anns_field": field_name,
+                    "param": {},
+                    "limit": default_limit,
+                }
+            )
             req_list.append(req)
             # hybrid search
-            hybrid_res = self.hybrid_search(client, self.collection_name, reqs=req_list,
-                                            ranker=WeightedRanker(1),
-                                            limit=default_limit,
-                                            output_fields=[self.primary_key_field_name, self.string_field_name],
-                                            check_task=CheckTasks.check_search_results,
-                                            check_items={"nq": nq,
-                                                         "ids": self.primary_keys,
-                                                         "limit": default_limit,
-                                                         "pk_name": self.primary_key_field_name,
-                                                         "enable_milvus_client_api": True,
-                                                         "original_entities": self.datas,
-                                                         "output_fields": [self.primary_key_field_name,
-                                                                           self.string_field_name]})[0]
-            search_res = self.search(client, self.collection_name, data=search_data,
-                                     anns_field=field_name,
-                                     search_params={},
-                                     limit=default_limit,
-                                     output_fields=[self.primary_key_field_name, self.string_field_name],
-                                     check_task=CheckTasks.check_search_results,
-                                     check_items={"nq": nq,
-                                                  "ids": self.primary_keys,
-                                                  "limit": default_limit,
-                                                  "enable_milvus_client_api": True,
-                                                  "pk_name": self.primary_key_field_name,
-                                                  "original_entities": self.datas,
-                                                  "output_fields": [self.primary_key_field_name,
-                                                                    self.string_field_name]})[0]
+            hybrid_res = self.hybrid_search(
+                client,
+                self.collection_name,
+                reqs=req_list,
+                ranker=WeightedRanker(1),
+                limit=default_limit,
+                output_fields=[self.primary_key_field_name, self.string_field_name],
+                check_task=CheckTasks.check_search_results,
+                check_items={
+                    "nq": nq,
+                    "ids": self.primary_keys,
+                    "limit": default_limit,
+                    "pk_name": self.primary_key_field_name,
+                    "enable_milvus_client_api": True,
+                    "original_entities": self.datas,
+                    "output_fields": [self.primary_key_field_name, self.string_field_name],
+                },
+            )[0]
+            search_res = self.search(
+                client,
+                self.collection_name,
+                data=search_data,
+                anns_field=field_name,
+                search_params={},
+                limit=default_limit,
+                output_fields=[self.primary_key_field_name, self.string_field_name],
+                check_task=CheckTasks.check_search_results,
+                check_items={
+                    "nq": nq,
+                    "ids": self.primary_keys,
+                    "limit": default_limit,
+                    "enable_milvus_client_api": True,
+                    "pk_name": self.primary_key_field_name,
+                    "original_entities": self.datas,
+                    "output_fields": [self.primary_key_field_name, self.string_field_name],
+                },
+            )[0]
             for i in range(nq):
                 assert hybrid_res[i].ids == search_res[i].ids
 
@@ -679,20 +769,27 @@ class TestMilvusClientHybridSearch(TestMilvusClientV2Base):
                 "anns_field": field_name,
                 "param": {},
                 "limit": default_limit,
-                "expr": f"{self.int64_field_name} > 0"}
+                "expr": f"{self.int64_field_name} > 0",
+            }
             req = AnnSearchRequest(**search_param)
             req_list.append(req)
             # search for get the baseline of hybrid_search
-            search_res = self.search(client, self.collection_name, data=search_data,
-                                     anns_field=field_name,
-                                     search_params={},
-                                     limit=default_limit,
-                                     filter=f"{self.int64_field_name} > 0",
-                                     check_task=CheckTasks.check_search_results,
-                                     check_items={"nq": 1,
-                                                  "ids": self.primary_keys,
-                                                  "limit": default_limit,
-                                                  "pk_name": self.primary_key_field_name})[0]
+            search_res = self.search(
+                client,
+                self.collection_name,
+                data=search_data,
+                anns_field=field_name,
+                search_params={},
+                limit=default_limit,
+                filter=f"{self.int64_field_name} > 0",
+                check_task=CheckTasks.check_search_results,
+                check_items={
+                    "nq": 1,
+                    "ids": self.primary_keys,
+                    "limit": default_limit,
+                    "pk_name": self.primary_key_field_name,
+                },
+            )[0]
             ids = search_res[0].ids
             for j in range(len(ids)):
                 search_res_dict[ids[j]] = 1 / (j + 60 + 1)
@@ -700,26 +797,38 @@ class TestMilvusClientHybridSearch(TestMilvusClientV2Base):
         # 4. calculate hybrid search baseline for RRFRanker
         ids_answer, score_answer = cf.get_hybrid_search_base_results_rrf(search_res_dict_array)
         # 5. hybrid search
-        hybrid_search_0 = self.hybrid_search(client, self.collection_name, reqs=req_list,
-                                             ranker=RRFRanker(),
-                                             limit=default_limit,
-                                             check_task=CheckTasks.check_search_results,
-                                             check_items={"nq": 1,
-                                                          "ids": self.primary_keys,
-                                                          "limit": default_limit,
-                                                          "pk_name": self.primary_key_field_name})[0]
+        hybrid_search_0 = self.hybrid_search(
+            client,
+            self.collection_name,
+            reqs=req_list,
+            ranker=RRFRanker(),
+            limit=default_limit,
+            check_task=CheckTasks.check_search_results,
+            check_items={
+                "nq": 1,
+                "ids": self.primary_keys,
+                "limit": default_limit,
+                "pk_name": self.primary_key_field_name,
+            },
+        )[0]
         # 6. compare results through the re-calculated distances
         for i in range(len(score_answer[:default_limit])):
             assert score_answer[i] - hybrid_search_0[0].distances[i] < hybrid_search_epsilon
         # 7. run hybrid search with the same parameters twice, and compare the results
-        hybrid_search_1 = self.hybrid_search(client, self.collection_name, reqs=req_list,
-                                             ranker=RRFRanker(),
-                                             limit=default_limit,
-                                             check_task=CheckTasks.check_search_results,
-                                             check_items={"nq": 1,
-                                                          "ids": self.primary_keys,
-                                                          "limit": default_limit,
-                                                          "pk_name": self.primary_key_field_name})[0]
+        hybrid_search_1 = self.hybrid_search(
+            client,
+            self.collection_name,
+            reqs=req_list,
+            ranker=RRFRanker(),
+            limit=default_limit,
+            check_task=CheckTasks.check_search_results,
+            check_items={
+                "nq": 1,
+                "ids": self.primary_keys,
+                "limit": default_limit,
+                "pk_name": self.primary_key_field_name,
+            },
+        )[0]
 
         assert hybrid_search_0[0].ids == hybrid_search_1[0].ids
         assert hybrid_search_0[0].distances == hybrid_search_1[0].distances
@@ -748,41 +857,51 @@ class TestMilvusClientHybridSearch(TestMilvusClientV2Base):
             id_list_nq.append([])
         # search the data1 and data2 separately
         for i in range(len(vector_filed_names)):
-            search_res = self.search(client, self.collection_name, data=search_data_list[i],
-                                     anns_field=vector_filed_names[i],
-                                     search_params={},
-                                     limit=limit,
-                                     output_fields=[self.primary_key_field_name, self.string_field_name],
-                                     check_task=CheckTasks.check_search_results,
-                                     check_items={"nq": nq,
-                                                  "ids": self.primary_keys,
-                                                  "limit": limit,
-                                                  "pk_name": self.primary_key_field_name,
-                                                  "output_fields": [self.primary_key_field_name,
-                                                                    self.string_field_name]})[0]
+            search_res = self.search(
+                client,
+                self.collection_name,
+                data=search_data_list[i],
+                anns_field=vector_filed_names[i],
+                search_params={},
+                limit=limit,
+                output_fields=[self.primary_key_field_name, self.string_field_name],
+                check_task=CheckTasks.check_search_results,
+                check_items={
+                    "nq": nq,
+                    "ids": self.primary_keys,
+                    "limit": limit,
+                    "pk_name": self.primary_key_field_name,
+                    "output_fields": [self.primary_key_field_name, self.string_field_name],
+                },
+            )[0]
             for j in range(nq):
                 id_list_nq[j].extend(search_res[j].ids)
 
         # generate hybrid search request list
         req_list = []
         for i in range(len(vector_filed_names)):
-            req = AnnSearchRequest(**{
-                "data": search_data_list[i],
-                "anns_field": vector_filed_names[i],
-                "param": {},
-                "limit": limit,
-            })
+            req = AnnSearchRequest(
+                **{
+                    "data": search_data_list[i],
+                    "anns_field": vector_filed_names[i],
+                    "param": {},
+                    "limit": limit,
+                }
+            )
             req_list.append(req)
         ranker = WeightedRanker(*[0.6, 0.4])
         # hybrid search
         larger_limit = limit * len(req_list) + 1
-        hybrid_search_res = self.hybrid_search(client, self.collection_name, reqs=req_list,
-                                               ranker=ranker,
-                                               limit=larger_limit,
-                                               output_fields=[self.primary_key_field_name,
-                                                              self.string_field_name],
-                                               check_task=CheckTasks.check_search_results,
-                                               check_items={"nq": nq})[0]
+        hybrid_search_res = self.hybrid_search(
+            client,
+            self.collection_name,
+            reqs=req_list,
+            ranker=ranker,
+            limit=larger_limit,
+            output_fields=[self.primary_key_field_name, self.string_field_name],
+            check_task=CheckTasks.check_search_results,
+            check_items={"nq": nq},
+        )[0]
         # verify the hybrid search results are consistent
         for i in range(nq):
             assert len(hybrid_search_res[i].ids) == len(list(set(id_list_nq[i])))
@@ -805,9 +924,9 @@ class TestMilvusClientHybridSearch(TestMilvusClientV2Base):
         mid_distances = []
         for i in range(len(field_names)):
             field_name = field_names[i]
-            res_search = self.search(client, self.collection_name, data=search_data,
-                                     anns_field=field_name,
-                                     limit=limit)[0]
+            res_search = self.search(
+                client, self.collection_name, data=search_data, anns_field=field_name, limit=limit
+            )[0]
             field_mid_distances = []
             for j in range(nq):
                 field_mid_distances.append(res_search[j].distances[limit // 2 - 1])
@@ -816,45 +935,62 @@ class TestMilvusClientHybridSearch(TestMilvusClientV2Base):
         # 1. hybrid search without range search
         req_list = []
         for field_name in field_names:
-            req = AnnSearchRequest(**{
-                "data": search_data,
-                "anns_field": field_name,
-                "param": {},
-                "limit": limit,
-            })
+            req = AnnSearchRequest(
+                **{
+                    "data": search_data,
+                    "anns_field": field_name,
+                    "param": {},
+                    "limit": limit,
+                }
+            )
             req_list.append(req)
-        res1 = self.hybrid_search(client, self.collection_name, reqs=req_list,
-                                  ranker=WeightedRanker(0.5, 0.5),
-                                  limit=limit,
-                                  output_fields=[self.primary_key_field_name, self.string_field_name],
-                                  check_task=CheckTasks.check_search_results,
-                                  check_items={"nq": nq, "ids": self.primary_keys, "limit": limit,
-                                               "pk_name": self.primary_key_field_name,
-                                               "output_fields": [self.primary_key_field_name,
-                                                                 self.string_field_name]})[0]
+        res1 = self.hybrid_search(
+            client,
+            self.collection_name,
+            reqs=req_list,
+            ranker=WeightedRanker(0.5, 0.5),
+            limit=limit,
+            output_fields=[self.primary_key_field_name, self.string_field_name],
+            check_task=CheckTasks.check_search_results,
+            check_items={
+                "nq": nq,
+                "ids": self.primary_keys,
+                "limit": limit,
+                "pk_name": self.primary_key_field_name,
+                "output_fields": [self.primary_key_field_name, self.string_field_name],
+            },
+        )[0]
 
         # 2. hybrid search with range search one nq by one nq
         for i in range(nq):
             req_list2 = []
             for j in range(len(field_names)):
                 field_name = field_names[j]
-                req = AnnSearchRequest(**{
-                    "data": [search_data[i]],
-                    "anns_field": field_name,
-                    "param": {"params": {"radius": float(mid_distances[j]), "range_filter": 9999}},
-                    "limit": limit // 2,
-                })
+                req = AnnSearchRequest(
+                    **{
+                        "data": [search_data[i]],
+                        "anns_field": field_name,
+                        "param": {"params": {"radius": float(mid_distances[j]), "range_filter": 9999}},
+                        "limit": limit // 2,
+                    }
+                )
                 req_list2.append(req)
-            res2 = self.hybrid_search(client, self.collection_name, reqs=req_list2,
-                                      ranker=WeightedRanker(0.5, 0.5),
-                                      limit=limit // 2,
-                                      output_fields=[self.primary_key_field_name, self.string_field_name],
-                                      check_task=CheckTasks.check_search_results,
-                                      check_items={"nq": 1, "ids": self.primary_keys,  # "limit": limit // 2,
-                                                   "pk_name": self.primary_key_field_name,
-                                                   "output_fields": [self.primary_key_field_name,
-                                                                     self.string_field_name]})[0]
-            hit_rate = len(set(res2[0].ids).intersection(set(res1[i].ids[:limit // 2]))) / len(res2[0].ids)
+            res2 = self.hybrid_search(
+                client,
+                self.collection_name,
+                reqs=req_list2,
+                ranker=WeightedRanker(0.5, 0.5),
+                limit=limit // 2,
+                output_fields=[self.primary_key_field_name, self.string_field_name],
+                check_task=CheckTasks.check_search_results,
+                check_items={
+                    "nq": 1,
+                    "ids": self.primary_keys,  # "limit": limit // 2,
+                    "pk_name": self.primary_key_field_name,
+                    "output_fields": [self.primary_key_field_name, self.string_field_name],
+                },
+            )[0]
+            hit_rate = len(set(res2[0].ids).intersection(set(res1[i].ids[: limit // 2]))) / len(res2[0].ids)
             # log.debug(f"hybrid search with range nq={i} hit hybrid search without range, hit rate: {hit_rate}")
             assert hit_rate >= 0.7, f"failed in nq={i}"
 
@@ -872,64 +1008,117 @@ class TestMilvusClientHybridSearch(TestMilvusClientV2Base):
         vector_filed_names = [self.float_vector_field_name1, self.float_vector_field_name2]
         req_list = []
         for i in range(len(vector_filed_names)):
-            req = AnnSearchRequest(**{
-                "data": search_data,
-                "anns_field": vector_filed_names[i],
-                "param": {},
-                "limit": limit,
-            })
+            req = AnnSearchRequest(
+                **{
+                    "data": search_data,
+                    "anns_field": vector_filed_names[i],
+                    "param": {},
+                    "limit": limit,
+                }
+            )
             req_list.append(req)
 
         # output all fields with wildcard '*'
         output_fields = ["*"]
         # sparse fields cannot be output, so specify the expected output fields
-        expected_output_fields = [field_name for field_name in self.all_fields
-                                  if field_name not in [self.sparse_vector_field_name1, self.sparse_vector_field_name2]]
-        self.hybrid_search(client, self.collection_name, reqs=req_list,
-                           ranker=WeightedRanker(0.5, 0.5),
-                           limit=limit, output_fields=output_fields,
-                           check_task=CheckTasks.check_search_results,
-                           check_items={"nq": nq, "ids": self.primary_keys, "limit": limit,
-                                        "pk_name": self.primary_key_field_name,
-                                        "output_fields": expected_output_fields})[0]
+        expected_output_fields = [
+            field_name
+            for field_name in self.all_fields
+            if field_name not in [self.sparse_vector_field_name1, self.sparse_vector_field_name2]
+        ]
+        self.hybrid_search(
+            client,
+            self.collection_name,
+            reqs=req_list,
+            ranker=WeightedRanker(0.5, 0.5),
+            limit=limit,
+            output_fields=output_fields,
+            check_task=CheckTasks.check_search_results,
+            check_items={
+                "nq": nq,
+                "ids": self.primary_keys,
+                "limit": limit,
+                "pk_name": self.primary_key_field_name,
+                "output_fields": expected_output_fields,
+            },
+        )[0]
         output_fields = self.all_fields
         # verify the error message when output sparse vector field
-        err_msg = {"err_code": 999,
-                   "err_msg": "not allowed to retrieve raw data of field sparse_vector1"}
-        self.hybrid_search(client, self.collection_name, reqs=req_list,
-                           ranker=WeightedRanker(0.5, 0.5),
-                           limit=limit, output_fields=output_fields,
-                           check_task=CheckTasks.err_res,
-                           check_items=err_msg)
+        err_msg = {"err_code": 999, "err_msg": "not allowed to retrieve raw data of field sparse_vector1"}
+        self.hybrid_search(
+            client,
+            self.collection_name,
+            reqs=req_list,
+            ranker=WeightedRanker(0.5, 0.5),
+            limit=limit,
+            output_fields=output_fields,
+            check_task=CheckTasks.err_res,
+            check_items=err_msg,
+        )
         # output all listed fields
         output_fields = expected_output_fields
-        self.hybrid_search(client, self.collection_name, reqs=req_list,
-                           ranker=WeightedRanker(0.5, 0.5),
-                           limit=limit, output_fields=output_fields,
-                           check_task=CheckTasks.check_search_results,
-                           check_items={"nq": nq, "ids": self.primary_keys, "limit": limit,
-                                        "pk_name": self.primary_key_field_name,
-                                        "output_fields": expected_output_fields})
+        self.hybrid_search(
+            client,
+            self.collection_name,
+            reqs=req_list,
+            ranker=WeightedRanker(0.5, 0.5),
+            limit=limit,
+            output_fields=output_fields,
+            check_task=CheckTasks.check_search_results,
+            check_items={
+                "nq": nq,
+                "ids": self.primary_keys,
+                "limit": limit,
+                "pk_name": self.primary_key_field_name,
+                "output_fields": expected_output_fields,
+            },
+        )
         # output some fields
-        output_fields = [self.primary_key_field_name, self.string_field_name, self.float_vector_field_name1,
-                         self.float_vector_field_name2]
-        self.hybrid_search(client, self.collection_name, reqs=req_list,
-                           ranker=WeightedRanker(0.5, 0.5),
-                           limit=limit, output_fields=output_fields,
-                           check_task=CheckTasks.check_search_results,
-                           check_items={"nq": nq, "ids": self.primary_keys, "limit": limit,
-                                        "pk_name": self.primary_key_field_name,
-                                        "output_fields": output_fields})
+        output_fields = [
+            self.primary_key_field_name,
+            self.string_field_name,
+            self.float_vector_field_name1,
+            self.float_vector_field_name2,
+        ]
+        self.hybrid_search(
+            client,
+            self.collection_name,
+            reqs=req_list,
+            ranker=WeightedRanker(0.5, 0.5),
+            limit=limit,
+            output_fields=output_fields,
+            check_task=CheckTasks.check_search_results,
+            check_items={
+                "nq": nq,
+                "ids": self.primary_keys,
+                "limit": limit,
+                "pk_name": self.primary_key_field_name,
+                "output_fields": output_fields,
+            },
+        )
         # output with dynamic field
-        output_fields = [self.primary_key_field_name, self.string_field_name, self.dynamic_field_name1,
-                         self.dynamic_field_name2]
-        self.hybrid_search(client, self.collection_name, reqs=req_list,
-                           ranker=WeightedRanker(0.5, 0.5),
-                           limit=limit, output_fields=output_fields,
-                           check_task=CheckTasks.check_search_results,
-                           check_items={"nq": nq, "ids": self.primary_keys, "limit": limit,
-                                        "pk_name": self.primary_key_field_name,
-                                        "output_fields": output_fields})
+        output_fields = [
+            self.primary_key_field_name,
+            self.string_field_name,
+            self.dynamic_field_name1,
+            self.dynamic_field_name2,
+        ]
+        self.hybrid_search(
+            client,
+            self.collection_name,
+            reqs=req_list,
+            ranker=WeightedRanker(0.5, 0.5),
+            limit=limit,
+            output_fields=output_fields,
+            check_task=CheckTasks.check_search_results,
+            check_items={
+                "nq": nq,
+                "ids": self.primary_keys,
+                "limit": limit,
+                "pk_name": self.primary_key_field_name,
+                "output_fields": output_fields,
+            },
+        )
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_hybrid_search_result_always_descending_order(self):
@@ -946,43 +1135,61 @@ class TestMilvusClientHybridSearch(TestMilvusClientV2Base):
         search_data = cf.gen_vectors(nq, self.float_vector_dim, vector_data_type=DataType.FLOAT_VECTOR)
         req_list = []
         for i in range(len(vector_filed_names)):
-            req = AnnSearchRequest(**{
-                "data": search_data,
-                "anns_field": vector_filed_names[i],
-                "param": {},
-                "limit": limit,
-            })
+            req = AnnSearchRequest(
+                **{
+                    "data": search_data,
+                    "anns_field": vector_filed_names[i],
+                    "param": {},
+                    "limit": limit,
+                }
+            )
             req_list.append(req)
         descend_metric = "IP"  # here only impacts the distance verification in descending order or not
-        self.hybrid_search(client, self.collection_name, reqs=req_list,
-                           ranker=WeightedRanker(0.5, 0.5),
-                           limit=limit,
-                           check_task=CheckTasks.check_search_results,
-                           check_items={"nq": nq, "ids": self.primary_keys,
-                                        "limit": limit,
-                                        "pk_name": self.primary_key_field_name,
-                                        "metric": descend_metric})
+        self.hybrid_search(
+            client,
+            self.collection_name,
+            reqs=req_list,
+            ranker=WeightedRanker(0.5, 0.5),
+            limit=limit,
+            check_task=CheckTasks.check_search_results,
+            check_items={
+                "nq": nq,
+                "ids": self.primary_keys,
+                "limit": limit,
+                "pk_name": self.primary_key_field_name,
+                "metric": descend_metric,
+            },
+        )
 
         # test with sparse vector field
         vector_filed_names = [self.sparse_vector_field_name1, self.sparse_vector_field_name2]
         search_data = cf.gen_varchar_data(length=10, nb=nq, text_mode=True)
         req_list = []
         for i in range(len(vector_filed_names)):
-            req = AnnSearchRequest(**{
-                "data": search_data,
-                "anns_field": vector_filed_names[i],
-                "param": {},
-                "limit": limit,
-            })
+            req = AnnSearchRequest(
+                **{
+                    "data": search_data,
+                    "anns_field": vector_filed_names[i],
+                    "param": {},
+                    "limit": limit,
+                }
+            )
             req_list.append(req)
-        self.hybrid_search(client, self.collection_name, reqs=req_list,
-                           ranker=WeightedRanker(0.5, 0.5),
-                           limit=limit,
-                           check_task=CheckTasks.check_search_results,
-                           check_items={"nq": nq, "ids": self.primary_keys,
-                                        "limit": limit,
-                                        "pk_name": self.primary_key_field_name,
-                                        "metric": descend_metric})
+        self.hybrid_search(
+            client,
+            self.collection_name,
+            reqs=req_list,
+            ranker=WeightedRanker(0.5, 0.5),
+            limit=limit,
+            check_task=CheckTasks.check_search_results,
+            check_items={
+                "nq": nq,
+                "ids": self.primary_keys,
+                "limit": limit,
+                "pk_name": self.primary_key_field_name,
+                "metric": descend_metric,
+            },
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     # @pytest.mark.parametrize("k", [1, 60, 1000])
@@ -1017,17 +1224,23 @@ class TestMilvusClientHybridSearch(TestMilvusClientV2Base):
             req = AnnSearchRequest(**search_param)
             req_list.append(req)
             # search for get the baseline of hybrid_search
-            search_res = self.search(client, self.collection_name, data=search_data,
-                                     anns_field=vector_name_list[i],
-                                     limit=default_limit, offset=offset,
-                                     output_fields=[self.primary_key_field_name, self.string_field_name],
-                                     check_task=CheckTasks.check_search_results,
-                                     check_items={"nq": nq,
-                                                  "ids": self.primary_keys,
-                                                  "limit": default_limit,
-                                                  "pk_name": self.primary_key_field_name,
-                                                  "output_fields": [self.primary_key_field_name,
-                                                                    self.string_field_name]})[0]
+            search_res = self.search(
+                client,
+                self.collection_name,
+                data=search_data,
+                anns_field=vector_name_list[i],
+                limit=default_limit,
+                offset=offset,
+                output_fields=[self.primary_key_field_name, self.string_field_name],
+                check_task=CheckTasks.check_search_results,
+                check_items={
+                    "nq": nq,
+                    "ids": self.primary_keys,
+                    "limit": default_limit,
+                    "pk_name": self.primary_key_field_name,
+                    "output_fields": [self.primary_key_field_name, self.string_field_name],
+                },
+            )[0]
             ids = search_res[0].ids
             for j in range(len(ids)):
                 search_res_dict[ids[j]] = 1 / (j + k + 1)
@@ -1035,18 +1248,23 @@ class TestMilvusClientHybridSearch(TestMilvusClientV2Base):
         # 4. calculate hybrid search baseline for RRFRanker
         ids_answer, score_answer = cf.get_hybrid_search_base_results_rrf(search_res_dict_array)
         # 5. hybrid search
-        hybrid_res = self.hybrid_search(client, self.collection_name, reqs=req_list,
-                                        ranker=RRFRanker(k),
-                                        limit=default_limit,
-                                        offset=offset,
-                                        output_fields=[self.primary_key_field_name, self.string_field_name],
-                                        check_task=CheckTasks.check_search_results,
-                                        check_items={"nq": nq,
-                                                     "ids": self.primary_keys,
-                                                     "limit": default_limit,
-                                                     "pk_name": self.primary_key_field_name,
-                                                     "output_fields": [self.primary_key_field_name,
-                                                                       self.string_field_name]})[0]
+        hybrid_res = self.hybrid_search(
+            client,
+            self.collection_name,
+            reqs=req_list,
+            ranker=RRFRanker(k),
+            limit=default_limit,
+            offset=offset,
+            output_fields=[self.primary_key_field_name, self.string_field_name],
+            check_task=CheckTasks.check_search_results,
+            check_items={
+                "nq": nq,
+                "ids": self.primary_keys,
+                "limit": default_limit,
+                "pk_name": self.primary_key_field_name,
+                "output_fields": [self.primary_key_field_name, self.string_field_name],
+            },
+        )[0]
         # 6. compare results through the re-calculated distances
         for i in range(len(score_answer[:default_limit])):
             assert score_answer[i] - hybrid_res[0].distances[i] < hybrid_search_epsilon * 2, f"failed in topk={i}"
@@ -1083,14 +1301,15 @@ class TestMilvusClientHybridSearch(TestMilvusClientV2Base):
             req_list.append(req)
             metrics.append("BM25")
             # search to get the baseline of hybrid_search
-            search_res = self.search(client, self.collection_name, data=search_data,
-                                     anns_field=vector_name_list[i],
-                                     limit=limit,
-                                     check_task=CheckTasks.check_search_results,
-                                     check_items={"nq": 1,
-                                                  "ids": self.primary_keys,
-                                                  "limit": limit,
-                                                  "pk_name": self.primary_key_field_name})[0]
+            search_res = self.search(
+                client,
+                self.collection_name,
+                data=search_data,
+                anns_field=vector_name_list[i],
+                limit=limit,
+                check_task=CheckTasks.check_search_results,
+                check_items={"nq": 1, "ids": self.primary_keys, "limit": limit, "pk_name": self.primary_key_field_name},
+            )[0]
             ids = search_res[0].ids
             distance_array = search_res[0].distances
             for j in range(len(ids)):
@@ -1099,14 +1318,15 @@ class TestMilvusClientHybridSearch(TestMilvusClientV2Base):
         # 4. calculate hybrid search baseline
         ids_answer, score_answer = cf.get_hybrid_search_base_results(search_res_dict_array, weights, metrics, 5)
         # 5. hybrid search
-        hybrid_res = self.hybrid_search(client, self.collection_name, reqs=req_list,
-                                        ranker=WeightedRanker(*weights),
-                                        limit=limit,
-                                        check_task=CheckTasks.check_search_results,
-                                        check_items={"nq": 1,
-                                                     "ids": self.primary_keys,
-                                                     "limit": limit,
-                                                     "pk_name": self.primary_key_field_name})[0]
+        hybrid_res = self.hybrid_search(
+            client,
+            self.collection_name,
+            reqs=req_list,
+            ranker=WeightedRanker(*weights),
+            limit=limit,
+            check_task=CheckTasks.check_search_results,
+            check_items={"nq": 1, "ids": self.primary_keys, "limit": limit, "pk_name": self.primary_key_field_name},
+        )[0]
         # 6. compare results through the re-calculated distances
         for i in range(len(score_answer[:limit])):
             delta = math.fabs(score_answer[i] - hybrid_res[0].distances[i])
@@ -1117,7 +1337,8 @@ class TestMilvusClientHybridSearch(TestMilvusClientV2Base):
                     log.info(f"answer id: {ids_answer[i1]:d}, distance: {score_answer[i1]:f}")
                 for i2 in range(len(hybrid_res[0].ids)):
                     log.info(
-                        f"hybrid search res id: {hybrid_res[0].ids[i2]:d}, distance: {hybrid_res[0].distances[i2]:f}")
+                        f"hybrid search res id: {hybrid_res[0].ids[i2]:d}, distance: {hybrid_res[0].distances[i2]:f}"
+                    )
             assert delta < hybrid_search_epsilon
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -1137,48 +1358,58 @@ class TestMilvusClientHybridSearch(TestMilvusClientV2Base):
         req_list = []
         search_data = cf.gen_vectors(nq, self.float_vector_dim, vector_data_type=DataType.FLOAT_VECTOR)
         for field_name in [self.float_vector_field_name1, self.float_vector_field_name2]:
-            req = AnnSearchRequest(**{
-                "data": search_data,
-                "anns_field": field_name,
-                "param": {"offset": offset},
-                "limit": ct.default_limit,
-            })
+            req = AnnSearchRequest(
+                **{
+                    "data": search_data,
+                    "anns_field": field_name,
+                    "param": {"offset": offset},
+                    "limit": ct.default_limit,
+                }
+            )
             req_list.append(req)
-        hybrid_res_inside = self.hybrid_search(client, self.collection_name, reqs=req_list,
-                                               ranker=rerank,
-                                               limit=ct.default_limit,
-                                               output_fields=[self.primary_key_field_name,
-                                                              self.string_field_name],
-                                               check_task=CheckTasks.check_search_results,
-                                               check_items={"nq": nq})[0]
+        hybrid_res_inside = self.hybrid_search(
+            client,
+            self.collection_name,
+            reqs=req_list,
+            ranker=rerank,
+            limit=ct.default_limit,
+            output_fields=[self.primary_key_field_name, self.string_field_name],
+            check_task=CheckTasks.check_search_results,
+            check_items={"nq": nq},
+        )[0]
         req_list = []
         for field_name in [self.float_vector_field_name1, self.float_vector_field_name2]:
-            req = AnnSearchRequest(**{
-                "data": search_data,
-                "anns_field": field_name,
-                "param": {},
-                "limit": ct.default_limit
-            })
+            req = AnnSearchRequest(
+                **{"data": search_data, "anns_field": field_name, "param": {}, "limit": ct.default_limit}
+            )
             req_list.append(req)
-        hybrid_res_outside = self.hybrid_search(client, self.collection_name, reqs=req_list,
-                                                ranker=rerank,
-                                                limit=ct.default_limit,
-                                                offset=offset,
-                                                output_fields=[self.primary_key_field_name,
-                                                               self.string_field_name],
-                                                check_task=CheckTasks.check_search_results,
-                                                check_items={"nq": nq})[0]
-        hybrid_res_no_offset = self.hybrid_search(client, self.collection_name, reqs=req_list,
-                                                  ranker=rerank,
-                                                  limit=ct.default_limit,
-                                                  output_fields=[self.primary_key_field_name,
-                                                                 self.string_field_name],
-                                                  check_task=CheckTasks.check_search_results,
-                                                  check_items={"nq": nq})[0]
+        hybrid_res_outside = self.hybrid_search(
+            client,
+            self.collection_name,
+            reqs=req_list,
+            ranker=rerank,
+            limit=ct.default_limit,
+            offset=offset,
+            output_fields=[self.primary_key_field_name, self.string_field_name],
+            check_task=CheckTasks.check_search_results,
+            check_items={"nq": nq},
+        )[0]
+        hybrid_res_no_offset = self.hybrid_search(
+            client,
+            self.collection_name,
+            reqs=req_list,
+            ranker=rerank,
+            limit=ct.default_limit,
+            output_fields=[self.primary_key_field_name, self.string_field_name],
+            check_task=CheckTasks.check_search_results,
+            check_items={"nq": nq},
+        )[0]
         for i in range(nq):
-            assert hybrid_res_inside[i].ids[offset:] == \
-                   hybrid_res_outside[i].ids[:-offset] == \
-                   hybrid_res_no_offset[i].ids[offset:]
+            assert (
+                hybrid_res_inside[i].ids[offset:]
+                == hybrid_res_outside[i].ids[:-offset]
+                == hybrid_res_no_offset[i].ids[offset:]
+            )
             # TODO: verify the offset working, uncomment the assertion below after #45939 fixed
             # assert hybrid_res_inside[i].ids != hybrid_res_no_offset[i]
 
@@ -1193,16 +1424,21 @@ class TestMilvusClientHybridSearch(TestMilvusClientV2Base):
             - Hybrid search failed with error message
         """
         client = self._client()
-        err_msg = {"err_code": 65535,
-                   "err_msg": "nq [0] is invalid, nq (number of search vector per search request) "
-                              "should be in range [1, 16384], but got 0"}
-        self.hybrid_search(client, self.collection_name,
-                           reqs=[],
-                           ranker=ranker,
-                           limit=default_limit,
-                           output_fields=[self.primary_key_field_name, self.string_field_name],
-                           check_task=CheckTasks.err_res,
-                           check_items=err_msg)
+        err_msg = {
+            "err_code": 65535,
+            "err_msg": "nq [0] is invalid, nq (number of search vector per search request) "
+            "should be in range [1, 16384], but got 0",
+        }
+        self.hybrid_search(
+            client,
+            self.collection_name,
+            reqs=[],
+            ranker=ranker,
+            limit=default_limit,
+            output_fields=[self.primary_key_field_name, self.string_field_name],
+            check_task=CheckTasks.err_res,
+            check_items=err_msg,
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("ranker_param", [[0.1, 2], [0.2, 0.4, 0.8]])
@@ -1219,28 +1455,35 @@ class TestMilvusClientHybridSearch(TestMilvusClientV2Base):
         nq = 1
         search_data = cf.gen_vectors(nq, self.float_vector_dim, vector_data_type=DataType.FLOAT_VECTOR)
         for field_name in [self.float_vector_field_name1, self.float_vector_field_name2]:
-            req = AnnSearchRequest(**{
-                "data": search_data,
-                "anns_field": field_name,
-                "param": {},
-                "limit": ct.default_limit,
-            })
+            req = AnnSearchRequest(
+                **{
+                    "data": search_data,
+                    "anns_field": field_name,
+                    "param": {},
+                    "limit": ct.default_limit,
+                }
+            )
             req_list.append(req)
 
         err_msg = {"err_code": 999, "err_msg": "rank param weight should be in range [0, 1]"}
         if ranker_param == [0.2, 0.4, 0.8]:
-            err_msg = {"err_code": 999,
-                       "err_msg": "the length of weights param mismatch with ann search requests: "
-                                  "invalid parameter[expected=2][actual=3]"}
+            err_msg = {
+                "err_code": 999,
+                "err_msg": "the length of weights param mismatch with ann search requests: "
+                "invalid parameter[expected=2][actual=3]",
+            }
 
         ranker = WeightedRanker(*ranker_param)
-        self.hybrid_search(client, self.collection_name,
-                           reqs=req_list,
-                           ranker=ranker,
-                           limit=default_limit,
-                           output_fields=[self.primary_key_field_name, self.string_field_name],
-                           check_task=CheckTasks.err_res,
-                           check_items=err_msg)
+        self.hybrid_search(
+            client,
+            self.collection_name,
+            reqs=req_list,
+            ranker=ranker,
+            limit=default_limit,
+            output_fields=[self.primary_key_field_name, self.string_field_name],
+            check_task=CheckTasks.err_res,
+            check_items=err_msg,
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("k", [0, 16385])
@@ -1258,25 +1501,29 @@ class TestMilvusClientHybridSearch(TestMilvusClientV2Base):
         nq = 2
         search_data = cf.gen_vectors(nq, self.float_vector_dim, vector_data_type=DataType.FLOAT_VECTOR)
         for field_name in [self.float_vector_field_name1, self.float_vector_field_name2]:
-            req = AnnSearchRequest(**{
-                "data": search_data,
-                "anns_field": field_name,
-                "param": {},
-                "limit": default_limit,
-            })
+            req = AnnSearchRequest(
+                **{
+                    "data": search_data,
+                    "anns_field": field_name,
+                    "param": {},
+                    "limit": default_limit,
+                }
+            )
             req_list.append(req)
 
         ranker = RRFRanker(k)
         # TODO: #29867, the error msg is not good enough, but as it is for now.
-        err_msg = {"err_code": 65535,
-                   "err_msg": "rank params k should be in range (0, 16384)"}
-        self.hybrid_search(client, self.collection_name,
-                           reqs=req_list,
-                           ranker=ranker,
-                           limit=default_limit,
-                           output_fields=[self.primary_key_field_name, self.string_field_name],
-                           check_task=CheckTasks.err_res,
-                           check_items=err_msg)
+        err_msg = {"err_code": 65535, "err_msg": "rank params k should be in range (0, 16384)"}
+        self.hybrid_search(
+            client,
+            self.collection_name,
+            reqs=req_list,
+            ranker=ranker,
+            limit=default_limit,
+            output_fields=[self.primary_key_field_name, self.string_field_name],
+            check_task=CheckTasks.err_res,
+            check_items=err_msg,
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("nq", [ct.max_nq, ct.max_nq + 1])
@@ -1295,35 +1542,45 @@ class TestMilvusClientHybridSearch(TestMilvusClientV2Base):
         # generate hybrid search request list
         req_list = []
         for field_name in [self.float_vector_field_name1, self.float_vector_field_name2]:
-            req = AnnSearchRequest(**{
-                "data": search_data,
-                "anns_field": field_name,
-                "param": {},
-                "limit": default_limit,
-            })
+            req = AnnSearchRequest(
+                **{
+                    "data": search_data,
+                    "anns_field": field_name,
+                    "param": {},
+                    "limit": default_limit,
+                }
+            )
             req_list.append(req)
 
         if nq == ct.max_nq + 1:
             check_task = CheckTasks.err_res
-            check_items = {"err_code": 65535,
-                           "err_msg": "nq (number of search vector per search request) should be in range [1, 16384]"}
+            check_items = {
+                "err_code": 65535,
+                "err_msg": "nq (number of search vector per search request) should be in range [1, 16384]",
+            }
         else:
             check_task = CheckTasks.check_search_results
-            check_items = {"nq": nq,
-                           "ids": self.primary_keys,
-                           "limit": default_limit,
-                           "pk_name": self.primary_key_field_name,
-                           "output_fields": [self.primary_key_field_name, self.string_field_name]}
-        self.hybrid_search(client, self.collection_name, reqs=req_list,
-                           ranker=WeightedRanker(*[0.6, 0.4]),
-                           limit=default_limit,
-                           output_fields=[self.primary_key_field_name, self.string_field_name],
-                           check_task=check_task,
-                           check_items=check_items)
+            check_items = {
+                "nq": nq,
+                "ids": self.primary_keys,
+                "limit": default_limit,
+                "pk_name": self.primary_key_field_name,
+                "output_fields": [self.primary_key_field_name, self.string_field_name],
+            }
+        self.hybrid_search(
+            client,
+            self.collection_name,
+            reqs=req_list,
+            ranker=WeightedRanker(*[0.6, 0.4]),
+            limit=default_limit,
+            output_fields=[self.primary_key_field_name, self.string_field_name],
+            check_task=check_task,
+            check_items=check_items,
+        )
 
 
 class TestCollectionHybridSearch(TestcaseBase):
-    """ Test case of search interface """
+    """Test case of search interface"""
 
     @pytest.fixture(scope="function", params=["JACCARD", "HAMMING"])
     def metrics(self, request):
@@ -1376,12 +1633,17 @@ class TestCollectionHybridSearch(TestcaseBase):
         dim = 64
         enable_dynamic_field = True
         multiple_dim_array = [dim, dim]
-        collection_w, _, _, insert_ids, time_stamp = \
-            self.init_collection_general("", True, dim=dim, is_flush=is_flush,
-                                         primary_field=primary_field, enable_dynamic_field=enable_dynamic_field,
-                                         multiple_dim_array=multiple_dim_array,
-                                         vector_data_type=vector_data_type,
-                                         nullable_fields={ct.default_float_field_name: 1})[0:5]
+        collection_w, _, _, insert_ids, time_stamp = self.init_collection_general(
+            "",
+            True,
+            dim=dim,
+            is_flush=is_flush,
+            primary_field=primary_field,
+            enable_dynamic_field=enable_dynamic_field,
+            multiple_dim_array=multiple_dim_array,
+            vector_data_type=vector_data_type,
+            nullable_fields={ct.default_float_field_name: 1},
+        )[0:5]
         # 2. extract vector field name
         vector_name_list = cf.extract_vector_field_name_list(collection_w)
         vector_name_list.append(ct.default_float_vec_field_name)
@@ -1400,7 +1662,8 @@ class TestCollectionHybridSearch(TestcaseBase):
                 "anns_field": vector_name_list[i],
                 "param": {"metric_type": "COSINE"},
                 "limit": default_limit,
-                "expr": "int64 > 0"}
+                "expr": "int64 > 0",
+            }
             req = AnnSearchRequest(**search_param)
             req_list.append(req)
             metrics.append("COSINE")
@@ -1413,13 +1676,19 @@ class TestCollectionHybridSearch(TestcaseBase):
                 search_res_dict_array = []
                 vectors_search = vectors[k]
                 # 5. search to get the baseline of hybrid_search
-                search_res = collection_w.search([vectors_search], vector_name_list[i],
-                                                 single_search_param, default_limit,
-                                                 check_task=CheckTasks.check_search_results,
-                                                 check_items={"nq": 1,
-                                                              "ids": insert_ids,
-                                                              "pk_name": ct.default_int64_field_name,
-                                                              "limit": default_limit})[0]
+                search_res = collection_w.search(
+                    [vectors_search],
+                    vector_name_list[i],
+                    single_search_param,
+                    default_limit,
+                    check_task=CheckTasks.check_search_results,
+                    check_items={
+                        "nq": 1,
+                        "ids": insert_ids,
+                        "pk_name": ct.default_int64_field_name,
+                        "limit": default_limit,
+                    },
+                )[0]
                 ids = search_res[0].ids
                 distance_array = search_res[0].distances
                 for j in range(len(ids)):
@@ -1433,13 +1702,14 @@ class TestCollectionHybridSearch(TestcaseBase):
             ids_answer, score_answer = cf.get_hybrid_search_base_results(search_res_dict_array_nq[k], weights, metrics)
             score_answer_nq.append(score_answer)
         # 7. hybrid search
-        hybrid_res = collection_w.hybrid_search(req_list, WeightedRanker(*weights), default_limit,
-                                                offset=offset,
-                                                check_task=CheckTasks.check_search_results,
-                                                check_items={"nq": nq,
-                                                             "ids": insert_ids,
-                                                             "limit": default_limit,
-                                                             "pk_name": ct.default_int64_field_name})[0]
+        hybrid_res = collection_w.hybrid_search(
+            req_list,
+            WeightedRanker(*weights),
+            default_limit,
+            offset=offset,
+            check_task=CheckTasks.check_search_results,
+            check_items={"nq": nq, "ids": insert_ids, "limit": default_limit, "pk_name": ct.default_int64_field_name},
+        )[0]
         # 8. compare results through the re-calculated distances
         for k in range(len(score_answer_nq)):
             for i in range(len(score_answer_nq[k][:default_limit])):
@@ -1460,10 +1730,16 @@ class TestCollectionHybridSearch(TestcaseBase):
         # 1. initialize collection with data
         dim = 128
         nq = 3
-        collection_w, _, _, insert_ids, time_stamp = \
-            self.init_collection_general("", True, dim=dim, is_flush=is_flush, is_index=False,
-                                         primary_field=primary_field,
-                                         enable_dynamic_field=False, multiple_dim_array=[dim, dim])[0:5]
+        collection_w, _, _, insert_ids, time_stamp = self.init_collection_general(
+            "",
+            True,
+            dim=dim,
+            is_flush=is_flush,
+            is_index=False,
+            primary_field=primary_field,
+            enable_dynamic_field=False,
+            multiple_dim_array=[dim, dim],
+        )[0:5]
         # 2. extract vector field name
         vector_name_list = cf.extract_vector_field_name_list(collection_w)
         vector_name_list.append(ct.default_float_vec_field_name)
@@ -1479,16 +1755,18 @@ class TestCollectionHybridSearch(TestcaseBase):
                 "anns_field": vector_name,
                 "param": {},
                 "limit": default_limit,
-                "expr": "int64 > 0"}
+                "expr": "int64 > 0",
+            }
             req = AnnSearchRequest(**search_param)
             req_list.append(req)
         # 4. hybrid search
-        collection_w.hybrid_search(req_list, WeightedRanker(0.1, 0.9, 1), default_limit,
-                                   check_task=CheckTasks.check_search_results,
-                                   check_items={"nq": nq,
-                                                "ids": insert_ids,
-                                                "limit": default_limit,
-                                                "pk_name": ct.default_int64_field_name})
+        collection_w.hybrid_search(
+            req_list,
+            WeightedRanker(0.1, 0.9, 1),
+            default_limit,
+            check_task=CheckTasks.check_search_results,
+            check_items={"nq": nq, "ids": insert_ids, "limit": default_limit, "pk_name": ct.default_int64_field_name},
+        )
 
     @pytest.mark.tags(CaseLabel.L1)
     @pytest.mark.parametrize("primary_field", [ct.default_int64_field_name])
@@ -1501,10 +1779,16 @@ class TestCollectionHybridSearch(TestcaseBase):
         # 1. initialize collection with data
         dim = 91
         nq = 4
-        collection_w, _, _, insert_ids, time_stamp = \
-            self.init_collection_general("", True, dim=dim, is_flush=is_flush, is_index=False,
-                                         primary_field=primary_field,
-                                         enable_dynamic_field=False, multiple_dim_array=[dim, dim])[0:5]
+        collection_w, _, _, insert_ids, time_stamp = self.init_collection_general(
+            "",
+            True,
+            dim=dim,
+            is_flush=is_flush,
+            is_index=False,
+            primary_field=primary_field,
+            enable_dynamic_field=False,
+            multiple_dim_array=[dim, dim],
+        )[0:5]
         # 2. extract vector field name
         vector_name_list = cf.extract_vector_field_name_list(collection_w)
         vector_name_list.append(ct.default_float_vec_field_name)
@@ -1522,7 +1806,8 @@ class TestCollectionHybridSearch(TestcaseBase):
             "anns_field": vector_name_list[0],
             "param": {"metric_type": "L2"},
             "limit": default_limit,
-            "expr": "int64 > 0"}
+            "expr": "int64 > 0",
+        }
         req = AnnSearchRequest(**search_param)
         req_list.append(req)
         search_param = {
@@ -1530,7 +1815,8 @@ class TestCollectionHybridSearch(TestcaseBase):
             "anns_field": vector_name_list[1],
             "param": {"metric_type": "IP"},
             "limit": default_limit,
-            "expr": "int64 > 0"}
+            "expr": "int64 > 0",
+        }
         req = AnnSearchRequest(**search_param)
         req_list.append(req)
         search_param = {
@@ -1538,16 +1824,18 @@ class TestCollectionHybridSearch(TestcaseBase):
             "anns_field": vector_name_list[2],
             "param": {"metric_type": "COSINE"},
             "limit": default_limit,
-            "expr": "int64 > 0"}
+            "expr": "int64 > 0",
+        }
         req = AnnSearchRequest(**search_param)
         req_list.append(req)
         # 4. hybrid search
-        collection_w.hybrid_search(req_list, WeightedRanker(0.1, 0.9, 1), default_limit,
-                                   check_task=CheckTasks.check_search_results,
-                                   check_items={"nq": nq,
-                                                "ids": insert_ids,
-                                                "limit": default_limit,
-                                                "pk_name": ct.default_int64_field_name})
+        collection_w.hybrid_search(
+            req_list,
+            WeightedRanker(0.1, 0.9, 1),
+            default_limit,
+            check_task=CheckTasks.check_search_results,
+            check_items={"nq": nq, "ids": insert_ids, "limit": default_limit, "pk_name": ct.default_int64_field_name},
+        )
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_hybrid_search_WeightedRanker_different_parameters(self):
@@ -1572,8 +1860,9 @@ class TestCollectionHybridSearch(TestcaseBase):
         expected: Raise exception
         """
         # 1. initialize collection with data
-        collection_w, _, _, insert_ids, time_stamp = \
-            self.init_collection_general("", True, multiple_dim_array=[default_dim, default_dim])[0:5]
+        collection_w, _, _, insert_ids, time_stamp = self.init_collection_general(
+            "", True, multiple_dim_array=[default_dim, default_dim]
+        )[0:5]
         # 2. extract vector field name
         vector_name_list = cf.extract_vector_field_name_list(collection_w)
         vector_name_list.append(ct.default_float_vec_field_name)
@@ -1590,13 +1879,15 @@ class TestCollectionHybridSearch(TestcaseBase):
                 "anns_field": vector_name_list[i],
                 "param": {"metric_type": "COSINE", "offset": 0},
                 "limit": default_limit,
-                "expr": "int64 > 0"}
+                "expr": "int64 > 0",
+            }
             req = AnnSearchRequest(**search_param)
             req_list.append(req)
         # 4. hybrid search with offset inside the params
         error = {ct.err_code: 1, ct.err_msg: "Provide offset both in kwargs and param, expect just one"}
-        collection_w.hybrid_search(req_list, rerank, default_limit, offset=2,
-                                   check_task=CheckTasks.err_res, check_items=error)
+        collection_w.hybrid_search(
+            req_list, rerank, default_limit, offset=2, check_task=CheckTasks.err_res, check_items=error
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("limit", [1, 100, 16384])
@@ -1609,11 +1900,14 @@ class TestCollectionHybridSearch(TestcaseBase):
         """
         nq = 2
         # 1. initialize collection with data
-        collection_w, _, _, insert_ids, time_stamp = \
-            self.init_collection_general("", True, primary_field=primary_field,
-                                         multiple_dim_array=[default_dim, default_dim],
-                                         vector_data_type=vector_data_type,
-                                         is_partition_key=ct.default_float_field_name)[0:5]
+        collection_w, _, _, insert_ids, time_stamp = self.init_collection_general(
+            "",
+            True,
+            primary_field=primary_field,
+            multiple_dim_array=[default_dim, default_dim],
+            vector_data_type=vector_data_type,
+            is_partition_key=ct.default_float_field_name,
+        )[0:5]
         # 2. extract vector field name
         vector_name_list = cf.extract_vector_field_name_list(collection_w)
         vector_name_list.append(ct.default_float_vec_field_name)
@@ -1632,7 +1926,8 @@ class TestCollectionHybridSearch(TestcaseBase):
                 "anns_field": vector_name_list[i],
                 "param": {"metric_type": "COSINE"},
                 "limit": default_limit,
-                "expr": "int64 > 0"}
+                "expr": "int64 > 0",
+            }
             req = AnnSearchRequest(**search_param)
             req_list.append(req)
             metrics.append("COSINE")
@@ -1645,13 +1940,19 @@ class TestCollectionHybridSearch(TestcaseBase):
                 search_res_dict_array = []
                 vectors_search = vectors[k]
                 # 5. search to get the base line of hybrid_search
-                search_res = collection_w.search([vectors_search], vector_name_list[i],
-                                                 single_search_param, default_limit,
-                                                 check_task=CheckTasks.check_search_results,
-                                                 check_items={"nq": 1,
-                                                              "ids": insert_ids,
-                                                              "limit": default_limit,
-                                                              "pk_name": ct.default_int64_field_name})[0]
+                search_res = collection_w.search(
+                    [vectors_search],
+                    vector_name_list[i],
+                    single_search_param,
+                    default_limit,
+                    check_task=CheckTasks.check_search_results,
+                    check_items={
+                        "nq": 1,
+                        "ids": insert_ids,
+                        "limit": default_limit,
+                        "pk_name": ct.default_int64_field_name,
+                    },
+                )[0]
                 ids = search_res[0].ids
                 distance_array = search_res[0].distances
                 for j in range(len(ids)):
@@ -1665,12 +1966,13 @@ class TestCollectionHybridSearch(TestcaseBase):
             ids_answer, score_answer = cf.get_hybrid_search_base_results(search_res_dict_array_nq[k], weights, metrics)
             score_answer_nq.append(score_answer)
         # 7. hybrid search
-        hybrid_res = collection_w.hybrid_search(req_list, WeightedRanker(*weights), default_limit,
-                                                check_task=CheckTasks.check_search_results,
-                                                check_items={"nq": nq,
-                                                             "ids": insert_ids,
-                                                             "limit": default_limit,
-                                                             "pk_name": ct.default_int64_field_name})[0]
+        hybrid_res = collection_w.hybrid_search(
+            req_list,
+            WeightedRanker(*weights),
+            default_limit,
+            check_task=CheckTasks.check_search_results,
+            check_items={"nq": nq, "ids": insert_ids, "limit": default_limit, "pk_name": ct.default_int64_field_name},
+        )[0]
         # 8. compare results through the re-calculated distances
         for k in range(len(score_answer_nq)):
             for i in range(len(score_answer_nq[k][:default_limit])):
@@ -1685,9 +1987,14 @@ class TestCollectionHybridSearch(TestcaseBase):
         """
         nb, dim = 20000, 768
         # 1. init collection
-        collection_w, insert_vectors, _, insert_ids = \
-            self.init_collection_general("", True, nb=nb, multiple_dim_array=[dim, dim * 2],
-                                         with_json=False, vector_data_type=DataType.SPARSE_FLOAT_VECTOR)[0:4]
+        collection_w, insert_vectors, _, insert_ids = self.init_collection_general(
+            "",
+            True,
+            nb=nb,
+            multiple_dim_array=[dim, dim * 2],
+            with_json=False,
+            vector_data_type=DataType.SPARSE_FLOAT_VECTOR,
+        )[0:4]
         # 2. extract vector field name
         vector_name_list = cf.extract_vector_field_name_list(collection_w)
         # 3. prepare search params
@@ -1704,14 +2011,12 @@ class TestCollectionHybridSearch(TestcaseBase):
                 "anns_field": vector_name_list[i],
                 "param": {"metric_type": "IP", "offset": 0},
                 "limit": default_limit,
-                "expr": "int64 > 0"}
+                "expr": "int64 > 0",
+            }
             req = AnnSearchRequest(**search_param)
             req_list.append(req)
             # search for get the baseline of hybrid_search
-            search_res = collection_w.search(vector, vector_name_list[i],
-                                             param={},
-                                             limit=default_limit
-                                             )[0]
+            search_res = collection_w.search(vector, vector_name_list[i], param={}, limit=default_limit)[0]
             ids = search_res[0].ids
             for j in range(len(ids)):
                 search_res_dict[ids[j]] = 1 / (j + k + 1)
@@ -1719,12 +2024,13 @@ class TestCollectionHybridSearch(TestcaseBase):
         # 4. calculate hybrid search baseline for RRFRanker
         ids_answer, score_answer = cf.get_hybrid_search_base_results_rrf(search_res_dict_array)
         # 5. hybrid search
-        hybrid_res = collection_w.hybrid_search(req_list, RRFRanker(k), default_limit,
-                                                check_task=CheckTasks.check_search_results,
-                                                check_items={"nq": 1,
-                                                             "ids": insert_ids,
-                                                             "limit": default_limit,
-                                                             "pk_name": ct.default_int64_field_name})[0]
+        hybrid_res = collection_w.hybrid_search(
+            req_list,
+            RRFRanker(k),
+            default_limit,
+            check_task=CheckTasks.check_search_results,
+            check_items={"nq": 1, "ids": insert_ids, "limit": default_limit, "pk_name": ct.default_int64_field_name},
+        )[0]
         # 6. compare results through the re-calculated distances
         for i in range(len(score_answer[:default_limit])):
             delta = math.fabs(score_answer[i] - hybrid_res[0].distances[i])
@@ -1747,8 +2053,7 @@ class TestCollectionHybridSearch(TestcaseBase):
             "ids": ids_to_search,
             "anns_field": ct.default_float_vec_field_name,
             "param": {},
-            "limit": req_limit
+            "limit": req_limit,
         }
-        with pytest.raises(TypeError,
-                           match="AnnSearchRequest.__init__.*got an unexpected keyword argument 'ids'"):
+        with pytest.raises(TypeError, match="AnnSearchRequest.__init__.*got an unexpected keyword argument 'ids'"):
             AnnSearchRequest(**sub_params)

--- a/tests/python_client/milvus_client_v2/test_milvus_client_hybrid_search_v2.py
+++ b/tests/python_client/milvus_client_v2/test_milvus_client_hybrid_search_v2.py
@@ -1,24 +1,25 @@
-import numpy as np
-from pymilvus.orm.types import CONSISTENCY_STRONG, CONSISTENCY_BOUNDED, CONSISTENCY_SESSION, CONSISTENCY_EVENTUALLY
-from pymilvus import AnnSearchRequest, RRFRanker, WeightedRanker
-from pymilvus import (
-    FieldSchema, CollectionSchema, DataType,
-    Collection, Function, FunctionType, FunctionScore
-)
+import math
+import random
 
-from utils.util_pymilvus import *
-from common.common_type import CaseLabel, CheckTasks
-from common import common_type as ct
-from common import common_func as cf
-from utils.util_log import test_log as log
+import numpy as np
+import pandas as pd
+import pytest
 from base.client_base import TestcaseBase
 from base.client_v2_base import TestMilvusClientV2Base
-
-import random
-import math
-import pytest
-import pandas as pd
+from common import common_func as cf
+from common import common_type as ct
+from common.common_type import CaseLabel, CheckTasks
 from faker import Faker
+from pymilvus import (
+    AnnSearchRequest,
+    DataType,
+    Function,
+    FunctionType,
+    RRFRanker,
+    WeightedRanker,
+)
+from utils.util_log import test_log as log
+from utils.util_pymilvus import default_dim, default_nb
 
 Faker.seed(19530)
 fake_en = Faker("en_US")
@@ -359,7 +360,7 @@ class TestMilvusClientHybridSearch(TestMilvusClientV2Base):
                                               "output_fields": [self.primary_key_field_name,
                                                                 self.string_field_name]})[0]
 
-        # verify the hybrid search results meet the filter                                          
+        # verify the hybrid search results meet the filter
         for i in range(nq):
             assert max(res[i].ids) <= filter_max_value
             assert min(res[i].ids) > filter_min_value
@@ -557,7 +558,7 @@ class TestMilvusClientHybridSearch(TestMilvusClientV2Base):
     def test_hybrid_search_diff_limits_in_search_req(self, req_limit):
         """
         Test case: Hybrid search where individual search requests omit 'limit'
-        Scenario: 
+        Scenario:
             - Create connection, collection, and insert data.
             - Perform hybrid search with search requests with different 'limit' parameters.
         Expected:
@@ -884,13 +885,13 @@ class TestMilvusClientHybridSearch(TestMilvusClientV2Base):
         # sparse fields cannot be output, so specify the expected output fields
         expected_output_fields = [field_name for field_name in self.all_fields
                                   if field_name not in [self.sparse_vector_field_name1, self.sparse_vector_field_name2]]
-        res1 = self.hybrid_search(client, self.collection_name, reqs=req_list,
-                                  ranker=WeightedRanker(0.5, 0.5),
-                                  limit=limit, output_fields=output_fields,
-                                  check_task=CheckTasks.check_search_results,
-                                  check_items={"nq": nq, "ids": self.primary_keys, "limit": limit,
-                                               "pk_name": self.primary_key_field_name,
-                                               "output_fields": expected_output_fields})[0]
+        self.hybrid_search(client, self.collection_name, reqs=req_list,
+                           ranker=WeightedRanker(0.5, 0.5),
+                           limit=limit, output_fields=output_fields,
+                           check_task=CheckTasks.check_search_results,
+                           check_items={"nq": nq, "ids": self.primary_keys, "limit": limit,
+                                        "pk_name": self.primary_key_field_name,
+                                        "output_fields": expected_output_fields})[0]
         output_fields = self.all_fields
         # verify the error message when output sparse vector field
         err_msg = {"err_code": 999,
@@ -1113,10 +1114,10 @@ class TestMilvusClientHybridSearch(TestMilvusClientV2Base):
                 # print id and distance for debug
                 # answer and hybrid search result
                 for i1 in range(len(score_answer)):
-                    log.info("answer id: %d, distance: %f" % (ids_answer[i1], score_answer[i1]))
+                    log.info(f"answer id: {ids_answer[i1]:d}, distance: {score_answer[i1]:f}")
                 for i2 in range(len(hybrid_res[0].ids)):
                     log.info(
-                        "hybrid search res id: %d, distance: %f" % (hybrid_res[0].ids[i2], hybrid_res[0].distances[i2]))
+                        f"hybrid search res id: {hybrid_res[0].ids[i2]:d}, distance: {hybrid_res[0].distances[i2]:f}")
             assert delta < hybrid_search_epsilon
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -1682,7 +1683,7 @@ class TestCollectionHybridSearch(TestcaseBase):
         method: Test hybrid search after loading sparse vectors
         expected: hybrid search successfully with limit(topK)
         """
-        nb, auto_id, dim, enable_dynamic_field = 20000, False, 768, False
+        nb, dim = 20000, 768
         # 1. init collection
         collection_w, insert_vectors, _, insert_ids = \
             self.init_collection_general("", True, nb=nb, multiple_dim_array=[dim, dim * 2],
@@ -1739,7 +1740,6 @@ class TestCollectionHybridSearch(TestcaseBase):
         Expected:
             - Hybrid search failed with error msg
         """
-        nq = 2
         req_limit = 10
         ids_to_search = [0, 1]
         # generate hybrid search request list
@@ -1751,4 +1751,4 @@ class TestCollectionHybridSearch(TestcaseBase):
         }
         with pytest.raises(TypeError,
                            match="AnnSearchRequest.__init__.*got an unexpected keyword argument 'ids'"):
-            req = AnnSearchRequest(**sub_params)
+            AnnSearchRequest(**sub_params)

--- a/tests/python_client/testcases/indexes/test_ngram.py
+++ b/tests/python_client/testcases/indexes/test_ngram.py
@@ -8,10 +8,10 @@ from pymilvus import DataType
 
 index_type = "NGRAM"
 success = "success"
-pk_field_name = 'id'
-vector_field_name = 'vector'
-content_field_name = 'content_ngram'
-json_field_name = 'json_field'
+pk_field_name = "id"
+vector_field_name = "vector"
+content_field_name = "content_ngram"
+json_field_name = "json_field"
 dim = 32
 default_nb = ct.default_nb
 default_build_params = {"min_gram": 2, "max_gram": 3}
@@ -33,8 +33,7 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
 
         # Check if this test case requires JSON field
         build_params = params.get("params", None)
-        has_json_params = (build_params is not None and
-                           ("json_path" in build_params or "json_cast_type" in build_params))
+        has_json_params = build_params is not None and ("json_path" in build_params or "json_cast_type" in build_params)
 
         target_field_name = content_field_name  # Default to VARCHAR field
 
@@ -59,7 +58,7 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
                 row[json_field_name] = {
                     "body": f"This is a {keyword} building",
                     "title": f"Location {i}",
-                    "description": f"Description for {keyword} number {i}"
+                    "description": f"Description for {keyword} number {i}",
                 }
         else:
             # Generate VARCHAR test data with varied content
@@ -72,34 +71,34 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
         # Insert data in batches for better performance
         batch_size = 1000
         for i in range(0, nb, batch_size):
-            batch_rows = rows[i:i + batch_size]
+            batch_rows = rows[i : i + batch_size]
             self.insert(client, collection_name, batch_rows)
         self.flush(client, collection_name)
 
         # Create index
         index_params = self.prepare_index_params(client)[0]
         index_name = cf.gen_str_by_length(10, letters_only=True)
-        index_params.add_index(field_name=target_field_name,
-                               index_name=index_name,
-                               index_type=index_type,
-                               params=build_params)
+        index_params.add_index(
+            field_name=target_field_name, index_name=index_name, index_type=index_type, params=build_params
+        )
 
         # Build index
         if params.get("expected", None) != success:
-            self.create_index(client, collection_name, index_params,
-                              check_task=CheckTasks.err_res,
-                              check_items=params.get("expected"))
+            self.create_index(
+                client, collection_name, index_params, check_task=CheckTasks.err_res, check_items=params.get("expected")
+            )
         else:
             self.create_index(client, collection_name, index_params)
             self.wait_for_index_ready(client, collection_name, index_name=index_name)
 
             # Create vector index before loading collection
             vector_index_params = self.prepare_index_params(client)[0]
-            vector_index_params.add_index(field_name=vector_field_name,
-                                          metric_type=cf.get_default_metric_for_vector_type(
-                                              vector_type=DataType.FLOAT_VECTOR),
-                                          index_type="IVF_FLAT",
-                                          params={"nlist": 128})
+            vector_index_params.add_index(
+                field_name=vector_field_name,
+                metric_type=cf.get_default_metric_for_vector_type(vector_type=DataType.FLOAT_VECTOR),
+                index_type="IVF_FLAT",
+                params={"nlist": 128},
+            )
             self.create_index(client, collection_name, vector_index_params)
             self.wait_for_index_ready(client, collection_name, index_name=vector_field_name)
 
@@ -116,11 +115,14 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
             # Each keyword appears 2000/8 = 250 times
             expected_count = default_nb // 8  # 250 matches for "stadium"
 
-            self.query(client, collection_name, filter=filter_expr,
-                       output_fields=["count(*)"],
-                       check_task=CheckTasks.check_query_results,
-                       check_items={"enable_milvus_client_api": True,
-                                    "count(*)": expected_count})
+            self.query(
+                client,
+                collection_name,
+                filter=filter_expr,
+                output_fields=["count(*)"],
+                check_task=CheckTasks.check_query_results,
+                check_items={"enable_milvus_client_api": True, "count(*)": expected_count},
+            )
 
             # Verify the index params are persisted
             idx_info = client.describe_index(collection_name, index_name)
@@ -146,8 +148,13 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
         if scalar_field_type == DataType.VARCHAR:
             schema.add_field("scalar_field", datatype=scalar_field_type, max_length=1000)
         elif scalar_field_type == DataType.ARRAY:
-            schema.add_field("scalar_field", datatype=scalar_field_type,
-                             element_type=DataType.VARCHAR, max_capacity=10, max_length=100)
+            schema.add_field(
+                "scalar_field",
+                datatype=scalar_field_type,
+                element_type=DataType.VARCHAR,
+                max_capacity=10,
+                max_length=100,
+            )
         else:
             schema.add_field("scalar_field", datatype=scalar_field_type)
 
@@ -174,7 +181,7 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
                 row["scalar_field"] = {
                     "body": f"This is a {keyword}",
                     "title": f"Location {i}",
-                    "category": f"Category {keyword_idx}"
+                    "category": f"Category {keyword_idx}",
                 }
         elif scalar_field_type == DataType.ARRAY:
             # Generate varied ARRAY data for better testing
@@ -189,7 +196,7 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
         # Insert data in batches for better performance
         batch_size = 1000
         for i in range(0, nb, batch_size):
-            batch_rows = rows[i:i + batch_size]
+            batch_rows = rows[i : i + batch_size]
             self.insert(client, collection_name, batch_rows)
         self.flush(client, collection_name)
 
@@ -198,38 +205,38 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
         index_params = self.prepare_index_params(client)[0]
         if scalar_field_type == DataType.JSON:
             # JSON field requires json_path and json_cast_type
-            index_params.add_index(field_name="scalar_field",
-                                   index_name=index_name,
-                                   index_type=index_type,
-                                   params={
-                                       "min_gram": 2,
-                                       "max_gram": 3,
-                                       "json_path": "scalar_field['body']",
-                                       "json_cast_type": "varchar"
-                                   })
+            index_params.add_index(
+                field_name="scalar_field",
+                index_name=index_name,
+                index_type=index_type,
+                params={"min_gram": 2, "max_gram": 3, "json_path": "scalar_field['body']", "json_cast_type": "varchar"},
+            )
         else:
-            index_params.add_index(field_name="scalar_field",
-                                   index_name=index_name,
-                                   index_type=index_type,
-                                   params=default_build_params)
+            index_params.add_index(
+                field_name="scalar_field", index_name=index_name, index_type=index_type, params=default_build_params
+            )
 
         # Check if the field type is supported for NGRAM index
         if scalar_field_type not in NGRAM.supported_field_types:
-            self.create_index(client, collection_name, index_params,
-                              check_task=CheckTasks.err_res,
-                              check_items={"err_code": 999,
-                                           "err_msg": "ngram index can only be created on VARCHAR or JSON field"})
+            self.create_index(
+                client,
+                collection_name,
+                index_params,
+                check_task=CheckTasks.err_res,
+                check_items={"err_code": 999, "err_msg": "ngram index can only be created on VARCHAR or JSON field"},
+            )
         else:
             self.create_index(client, collection_name, index_params)
             self.wait_for_index_ready(client, collection_name, index_name=index_name)
 
             # Create vector index before loading collection
             vector_index_params = self.prepare_index_params(client)[0]
-            vector_index_params.add_index(field_name=vector_field_name,
-                                          metric_type=cf.get_default_metric_for_vector_type(
-                                              vector_type=DataType.FLOAT_VECTOR),
-                                          index_type="IVF_FLAT",
-                                          params={"nlist": 128})
+            vector_index_params.add_index(
+                field_name=vector_field_name,
+                metric_type=cf.get_default_metric_for_vector_type(vector_type=DataType.FLOAT_VECTOR),
+                index_type="IVF_FLAT",
+                params={"nlist": 128},
+            )
             self.create_index(client, collection_name, vector_index_params)
             self.wait_for_index_ready(client, collection_name, index_name=vector_field_name)
 
@@ -241,21 +248,27 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
                 # Each keyword appears 2000/8 = 250 times
                 expected_count = default_nb // 8  # 250 matches for "stadium"
                 filter_expr = 'scalar_field LIKE "%stadium%"'
-                self.query(client, collection_name, filter=filter_expr,
-                           output_fields=["count(*)"],
-                           check_task=CheckTasks.check_query_results,
-                           check_items={"enable_milvus_client_api": True,
-                                        "count(*)": expected_count})
+                self.query(
+                    client,
+                    collection_name,
+                    filter=filter_expr,
+                    output_fields=["count(*)"],
+                    check_task=CheckTasks.check_query_results,
+                    check_items={"enable_milvus_client_api": True, "count(*)": expected_count},
+                )
             elif scalar_field_type == DataType.JSON:
                 # Calculate expected count: 2000 data points with 8 keywords cycling
                 # Each keyword appears 2000/8 = 250 times
                 expected_count = default_nb // 8  # 250 matches for "school"
                 filter_expr = "scalar_field['body'] LIKE \"%school%\""
-                self.query(client, collection_name, filter=filter_expr,
-                           output_fields=["count(*)"],
-                           check_task=CheckTasks.check_query_results,
-                           check_items={"enable_milvus_client_api": True,
-                                        "count(*)": expected_count})
+                self.query(
+                    client,
+                    collection_name,
+                    filter=filter_expr,
+                    output_fields=["count(*)"],
+                    check_task=CheckTasks.check_query_results,
+                    check_items={"enable_milvus_client_api": True, "count(*)": expected_count},
+                )
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.skip(reason="skip for issue #44164")
@@ -281,40 +294,51 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
 
         # Create index
         index_params = self.prepare_index_params(client)[0]
-        index_params.add_index(field_name="content_ngram",
-                               index_name="content_ngram",
-                               index_type=index_type,
-                               params={"min_gram": 2, "max_gram": 3})
-        index_params.add_index(field_name=vector_field_name,
-                               index_type="IVF_FLAT",
-                               metric_type="COSINE",
-                               params={"nlist": 128})
+        index_params.add_index(
+            field_name="content_ngram",
+            index_name="content_ngram",
+            index_type=index_type,
+            params={"min_gram": 2, "max_gram": 3},
+        )
+        index_params.add_index(
+            field_name=vector_field_name, index_type="IVF_FLAT", metric_type="COSINE", params={"nlist": 128}
+        )
         self.create_index(client, collection_name, index_params)
         self.wait_for_index_ready(client, collection_name, index_name="content_ngram")
         self.wait_for_index_ready(client, collection_name, index_name=vector_field_name)
         self.load_collection(client, collection_name)
         # Query to check if the index is created
-        res = self.query(client, collection_name, filter="content_ngram LIKE 'stad_%'",
-                         output_fields=["id", "content_ngram"])[0]
+        res = self.query(
+            client, collection_name, filter="content_ngram LIKE 'stad_%'", output_fields=["id", "content_ngram"]
+        )[0]
         assert len(res) == default_nb // len(content_keywords)
 
         # Release collection before alter ngram index
         self.release_collection(client, collection_name)
         # Alter index mmap properties
-        self.alter_index_properties(client, collection_name, index_name="content_ngram", properties={"mmap.enabled": True})
+        self.alter_index_properties(
+            client, collection_name, index_name="content_ngram", properties={"mmap.enabled": True}
+        )
         res = self.describe_index(client, collection_name, index_name="content_ngram")[0]
-        assert res.get('mmap.enabled', None) == 'True'
+        assert res.get("mmap.enabled", None) == "True"
         # Load the collection and query again
         self.load_collection(client, collection_name)
-        res = self.query(client, collection_name, filter="content_ngram LIKE 'stad_%'",
-                         output_fields=["id", "content_ngram"])[0]
+        res = self.query(
+            client, collection_name, filter="content_ngram LIKE 'stad_%'", output_fields=["id", "content_ngram"]
+        )[0]
         assert len(res) == default_nb // len(content_keywords)
 
         # Alter index gram value properties is not supported
         self.release_collection(client, collection_name)
         error = {ct.err_code: 1, ct.err_msg: "invalid mmap.enabled value: True, expected: true, false"}
-        self.alter_index_properties(client, collection_name, index_name="content_ngram", properties={"min_gram": 3, "max_gram": 4},
-                                    check_task=CheckTasks.err_res, check_items=error)
+        self.alter_index_properties(
+            client,
+            collection_name,
+            index_name="content_ngram",
+            properties={"min_gram": 3, "max_gram": 4},
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_ngram_search_with_diff_length_of_filter_value(self):
@@ -344,105 +368,88 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
 
         # Create vector index before loading collection
         index_params = self.prepare_index_params(client)[0]
-        index_params.add_index(field_name=vector_field_name,
-                               metric_type="COSINE",
-                               index_type="IVF_FLAT",
-                               params={"nlist": 128})
+        index_params.add_index(
+            field_name=vector_field_name, metric_type="COSINE", index_type="IVF_FLAT", params={"nlist": 128}
+        )
         min_gram = 2
         max_gram = 4
-        index_params.add_index(field_name="content_ngram",
-                               index_type=index_type,
-                               params={"min_gram": min_gram, "max_gram": max_gram})
+        index_params.add_index(
+            field_name="content_ngram", index_type=index_type, params={"min_gram": min_gram, "max_gram": max_gram}
+        )
         self.create_index(client, collection_name, index_params)
         self.wait_for_index_ready(client, collection_name, index_name=vector_field_name)
         self.wait_for_index_ready(client, collection_name, index_name="content_ngram")
         self.load_collection(client, collection_name)
 
         # Test query 0: filter value length is less than min_gram
-        filter_expr = f'content_ngram LIKE "{content_keywords[0][:min_gram - 1]}%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
+        filter_expr = f'content_ngram LIKE "{content_keywords[0][: min_gram - 1]}%"'
+        res_ngram = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_ngram) >= insert_times * default_nb // len(content_keywords)
-        filter_expr = f'content_no_index LIKE "{content_keywords[0][:min_gram - 1]}%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
+        filter_expr = f'content_no_index LIKE "{content_keywords[0][: min_gram - 1]}%"'
+        res_no_index = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_no_index) >= insert_times * default_nb // len(content_keywords)
         assert res_ngram == res_no_index
 
         # Test query 1: filter value length is equal to min_gram
         filter_expr = f'content_ngram LIKE "{content_keywords[0][:min_gram]}%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
+        res_ngram = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_ngram) >= insert_times * default_nb // len(content_keywords)
         filter_expr = f'content_no_index LIKE "{content_keywords[0][:min_gram]}%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
+        res_no_index = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_no_index) >= insert_times * default_nb // len(content_keywords)
         assert res_ngram == res_no_index
 
         # Test query 2: filter value length is less than max_gram
-        filter_expr = f'content_ngram LIKE "{content_keywords[0][:max_gram - 1]}%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
+        filter_expr = f'content_ngram LIKE "{content_keywords[0][: max_gram - 1]}%"'
+        res_ngram = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_ngram) >= insert_times * default_nb // len(content_keywords)
-        filter_expr = f'content_no_index LIKE "{content_keywords[0][:max_gram - 1]}%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
+        filter_expr = f'content_no_index LIKE "{content_keywords[0][: max_gram - 1]}%"'
+        res_no_index = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_no_index) >= insert_times * default_nb // len(content_keywords)
         assert res_ngram == res_no_index
 
         # Test query 3: filter value length is equal to max_gram
         filter_expr = f'content_ngram LIKE "{content_keywords[0][:max_gram]}%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
+        res_ngram = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_ngram) >= insert_times * default_nb // len(content_keywords)
         filter_expr = f'content_no_index LIKE "{content_keywords[0][:max_gram]}%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
+        res_no_index = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_no_index) >= insert_times * default_nb // len(content_keywords)
         assert res_ngram == res_no_index
 
         # Test query 4: filter value length is greater than max_gram
-        filter_expr = f'content_ngram LIKE "{content_keywords[0][:max_gram + 1]}%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
+        filter_expr = f'content_ngram LIKE "{content_keywords[0][: max_gram + 1]}%"'
+        res_ngram = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_ngram) >= insert_times * default_nb // len(content_keywords)
-        filter_expr = f'content_no_index LIKE "{content_keywords[0][:max_gram + 1]}%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
+        filter_expr = f'content_no_index LIKE "{content_keywords[0][: max_gram + 1]}%"'
+        res_no_index = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_no_index) >= insert_times * default_nb // len(content_keywords)
         assert res_ngram == res_no_index
 
         # Test query with suffix match
         filter_expr = f'content_ngram LIKE "%{content_keywords[0][4:]}"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
+        res_ngram = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_ngram) >= insert_times * default_nb // len(content_keywords)
         filter_expr = f'content_no_index LIKE "%{content_keywords[0][4:]}"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
+        res_no_index = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_no_index) >= insert_times * default_nb // len(content_keywords)
         assert res_ngram == res_no_index
 
         # Test query with infix match
         filter_expr = f'content_ngram LIKE "%{content_keywords[0][2:4]}%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
+        res_ngram = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_ngram) >= insert_times * default_nb // len(content_keywords)
         filter_expr = f'content_no_index LIKE "%{content_keywords[0][2:4]}%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
+        res_no_index = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_no_index) >= insert_times * default_nb // len(content_keywords)
         assert res_ngram == res_no_index
 
         # Test query with Mixed Wildcard Match
         filter_expr = 'content_ngram LIKE "%st_d_um%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
+        res_ngram = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_ngram) >= insert_times * default_nb // len(content_keywords)
         filter_expr = 'content_no_index LIKE "%st_d_um%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
+        res_no_index = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_no_index) >= insert_times * default_nb // len(content_keywords)
         assert res_ngram == res_no_index
 
@@ -463,22 +470,22 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
 
         # Multilingual test data with various UTF-8 characters
         multilingual_keywords = [
-            "北京大学",           # Chinese
-            "東京大学",           # Japanese
-            "Московский",        # Russian
-            "café",              # French with accent
-            "naïve",             # French with diaeresis
-            "München",           # German with umlaut
-            "🏫学校🎓",           # Chinese with emojis
-            "🌟star⭐",          # English with emojis
-            "مدرسة",             # Arabic
-            "Γειά",              # Greek
-            "प्रविष्टि",           # Hindi/Devanagari
-            "한국어",             # Korean
-            "español",           # Spanish
-            "português",         # Portuguese
-            "中英mix英文",        # Mixed Chinese-English
-            "café☕北京🏙️"        # Mixed with emojis and multiple languages
+            "北京大学",  # Chinese
+            "東京大学",  # Japanese
+            "Московский",  # Russian
+            "café",  # French with accent
+            "naïve",  # French with diaeresis
+            "München",  # German with umlaut
+            "🏫学校🎓",  # Chinese with emojis
+            "🌟star⭐",  # English with emojis
+            "مدرسة",  # Arabic
+            "Γειά",  # Greek
+            "प्रविष्टि",  # Hindi/Devanagari
+            "한국어",  # Korean
+            "español",  # Spanish
+            "português",  # Portuguese
+            "中英mix英文",  # Mixed Chinese-English
+            "café☕北京🏙️",  # Mixed with emojis and multiple languages
         ]
 
         # Insert test data
@@ -491,199 +498,173 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
                 row["content_no_index"] = {
                     "body": f"This is a {keyword} building",
                     "title": f"Location {i}",
-                    "description": f"Description for {keyword} number {i}"
+                    "description": f"Description for {keyword} number {i}",
                 }
                 row["content_ngram"] = {
                     "body": f"This is a {keyword} building",
                     "title": f"Location {i}",
-                    "description": f"Description for {keyword} number {i}"
+                    "description": f"Description for {keyword} number {i}",
                 }
             self.insert(client, collection_name, rows)
         self.flush(client, collection_name)
 
         # Create vector index before loading collection
         index_params = self.prepare_index_params(client)[0]
-        index_params.add_index(field_name=vector_field_name,
-                               metric_type="COSINE",
-                               index_type="IVF_FLAT",
-                               params={"nlist": 128})
+        index_params.add_index(
+            field_name=vector_field_name, metric_type="COSINE", index_type="IVF_FLAT", params={"nlist": 128}
+        )
 
         # Create NGRAM index with appropriate parameters for multilingual content
         min_gram = 1  # Use 1 for better multilingual support
         max_gram = 3
-        index_params.add_index(field_name="content_ngram",
-                               index_name="content_ngram",
-                               index_type=index_type,
-                               params={"min_gram": min_gram, "max_gram": max_gram,
-                                       "json_path": "content_ngram['body']", "json_cast_type": "varchar"})
+        index_params.add_index(
+            field_name="content_ngram",
+            index_name="content_ngram",
+            index_type=index_type,
+            params={
+                "min_gram": min_gram,
+                "max_gram": max_gram,
+                "json_path": "content_ngram['body']",
+                "json_cast_type": "varchar",
+            },
+        )
         self.create_index(client, collection_name, index_params)
         self.wait_for_index_ready(client, collection_name, index_name=vector_field_name)
         self.wait_for_index_ready(client, collection_name, index_name="content_ngram")
         self.load_collection(client, collection_name)
 
-
         # Test 1: Chinese character search
         chinese_keyword = "北京"
         filter_expr = f'content_ngram["body"] LIKE "%{chinese_keyword}%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
+        res_ngram = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         filter_expr = f'content_no_index["body"] LIKE "%{chinese_keyword}%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
+        res_no_index = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_ngram) > 0
         assert sorted(res_ngram, key=lambda item: item["id"]) == sorted(res_no_index, key=lambda item: item["id"])
 
         # Test 2: Japanese character search
         japanese_keyword = "東京"
         filter_expr = f'content_ngram["body"] LIKE "%{japanese_keyword}%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
+        res_ngram = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         filter_expr = f'content_no_index["body"] LIKE "%{japanese_keyword}%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
+        res_no_index = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_ngram) > 0
         assert sorted(res_ngram, key=lambda item: item["id"]) == sorted(res_no_index, key=lambda item: item["id"])
 
         # Test 3: Russian Cyrillic character search
         russian_keyword = "Моск"
         filter_expr = f'content_ngram["body"] LIKE "%{russian_keyword}%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
+        res_ngram = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         filter_expr = f'content_no_index["body"] LIKE "%{russian_keyword}%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
+        res_no_index = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_ngram) > 0
         assert sorted(res_ngram, key=lambda item: item["id"]) == sorted(res_no_index, key=lambda item: item["id"])
 
         # Test 4: French accent character search
         french_keyword = "café"
         filter_expr = f'content_ngram["body"] LIKE "%{french_keyword}%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
+        res_ngram = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         filter_expr = f'content_no_index["body"] LIKE "%{french_keyword}%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
+        res_no_index = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_ngram) > 0
         assert sorted(res_ngram, key=lambda item: item["id"]) == sorted(res_no_index, key=lambda item: item["id"])
 
         # Test 5: Emoji character search
         emoji_keyword = "🏫"
         filter_expr = f'content_ngram["body"] LIKE "%{emoji_keyword}%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
+        res_ngram = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         filter_expr = f'content_no_index["body"] LIKE "%{emoji_keyword}%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
+        res_no_index = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_ngram) > 0
         assert sorted(res_ngram, key=lambda item: item["id"]) == sorted(res_no_index, key=lambda item: item["id"])
 
         # Test 6: Star emoji search
         star_keyword = "⭐"
         filter_expr = f'content_ngram["body"] LIKE "%{star_keyword}%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
+        res_ngram = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         filter_expr = f'content_no_index["body"] LIKE "%{star_keyword}%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
+        res_no_index = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_ngram) > 0
         assert sorted(res_ngram, key=lambda item: item["id"]) == sorted(res_no_index, key=lambda item: item["id"])
 
         # Test 7: Arabic character search
         arabic_keyword = "مدرسة"
         filter_expr = f'content_ngram["body"] LIKE "%{arabic_keyword}%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
+        res_ngram = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         filter_expr = f'content_no_index["body"] LIKE "%{arabic_keyword}%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
+        res_no_index = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_ngram) > 0
         assert sorted(res_ngram, key=lambda item: item["id"]) == sorted(res_no_index, key=lambda item: item["id"])
 
         # Test 8: Korean character search
         korean_keyword = "한국"
         filter_expr = f'content_ngram["body"] LIKE "%{korean_keyword}%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
+        res_ngram = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         filter_expr = f'content_no_index["body"] LIKE "%{korean_keyword}%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
+        res_no_index = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_ngram) > 0
         assert sorted(res_ngram, key=lambda item: item["id"]) == sorted(res_no_index, key=lambda item: item["id"])
 
         # Test 9: German umlaut character search
         german_keyword = "München"
         filter_expr = f'content_ngram["body"] LIKE "%{german_keyword}%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
+        res_ngram = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         filter_expr = f'content_no_index["body"] LIKE "%{german_keyword}%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
+        res_no_index = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_ngram) > 0
         assert sorted(res_ngram, key=lambda item: item["id"]) == sorted(res_no_index, key=lambda item: item["id"])
 
         # Test 10: Mixed language search
         mixed_keyword = "mix"
         filter_expr = f'content_ngram["body"] LIKE "%{mixed_keyword}%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
+        res_ngram = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         filter_expr = f'content_no_index["body"] LIKE "%{mixed_keyword}%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
+        res_no_index = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_ngram) > 0
         assert sorted(res_ngram, key=lambda item: item["id"]) == sorted(res_no_index, key=lambda item: item["id"])
 
         # Test 11: Complex multilingual with emojis prefix search
         complex_keyword = "café☕"
         filter_expr = f'content_ngram["body"] LIKE "%{complex_keyword}%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
+        res_ngram = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         filter_expr = f'content_no_index["body"] LIKE "%{complex_keyword}%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
+        res_no_index = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_ngram) > 0
         assert sorted(res_ngram, key=lambda item: item["id"]) == sorted(res_no_index, key=lambda item: item["id"])
 
         # Test 12: Hindi/Devanagari character search
         hindi_keyword = "प्रविष्टि"
         filter_expr = f'content_ngram["body"] LIKE "%{hindi_keyword}%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
+        res_ngram = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         filter_expr = f'content_no_index["body"] LIKE "%{hindi_keyword}%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
+        res_no_index = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_ngram) > 0
         assert sorted(res_ngram, key=lambda item: item["id"]) == sorted(res_no_index, key=lambda item: item["id"])
 
         # Test 13: Greek character search
         greek_keyword = "Γειά"
         filter_expr = f'content_ngram["body"] LIKE "%{greek_keyword}%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
+        res_ngram = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         filter_expr = f'content_no_index["body"] LIKE "%{greek_keyword}%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
+        res_no_index = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_ngram) > 0
         assert sorted(res_ngram, key=lambda item: item["id"]) == sorted(res_no_index, key=lambda item: item["id"])
 
         # Test 14: Portuguese with tilde character search
         portuguese_keyword = "português"
         filter_expr = f'content_ngram["body"] LIKE "%{portuguese_keyword}%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
+        res_ngram = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         filter_expr = f'content_no_index["body"] LIKE "%{portuguese_keyword}%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
+        res_no_index = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         assert len(res_ngram) > 0
         assert sorted(res_ngram, key=lambda item: item["id"]) == sorted(res_no_index, key=lambda item: item["id"])
 
         # Test 15: Test single character search (especially important for CJK)
         single_char_keyword = "学"
         filter_expr = f'content_ngram["body"] LIKE "%{single_char_keyword}%"'
-        res_ngram = self.query(client, collection_name, filter=filter_expr,
-                               output_fields=["id", "content_ngram"])[0]
+        res_ngram = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         filter_expr = f'content_no_index["body"] LIKE "%{single_char_keyword}%"'
-        res_no_index = self.query(client, collection_name, filter=filter_expr,
-                                  output_fields=["id", "content_ngram"])[0]
+        res_no_index = self.query(client, collection_name, filter=filter_expr, output_fields=["id", "content_ngram"])[0]
         # Should match both "北京大学" and "🏫学校🎓"
         assert len(res_ngram) > 0
         assert sorted(res_ngram, key=lambda item: item["id"]) == sorted(res_no_index, key=lambda item: item["id"])

--- a/tests/python_client/testcases/indexes/test_ngram.py
+++ b/tests/python_client/testcases/indexes/test_ngram.py
@@ -1,12 +1,10 @@
-import logging
-import time
-from utils.util_pymilvus import *
-from common.common_type import CaseLabel, CheckTasks
-from common import common_type as ct
-from common import common_func as cf
-from base.client_v2_base import TestMilvusClientV2Base
 import pytest
+from base.client_v2_base import TestMilvusClientV2Base
+from common import common_func as cf
+from common import common_type as ct
+from common.common_type import CaseLabel, CheckTasks
 from idx_ngram import NGRAM
+from pymilvus import DataType
 
 index_type = "NGRAM"
 success = "success"
@@ -438,11 +436,11 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
         assert res_ngram == res_no_index
 
         # Test query with Mixed Wildcard Match
-        filter_expr = f'content_ngram LIKE "%st_d_um%"'
+        filter_expr = 'content_ngram LIKE "%st_d_um%"'
         res_ngram = self.query(client, collection_name, filter=filter_expr,
                                output_fields=["id", "content_ngram"])[0]
         assert len(res_ngram) >= insert_times * default_nb // len(content_keywords)
-        filter_expr = f'content_no_index LIKE "%st_d_um%"'
+        filter_expr = 'content_no_index LIKE "%st_d_um%"'
         res_no_index = self.query(client, collection_name, filter=filter_expr,
                                   output_fields=["id", "content_ngram"])[0]
         assert len(res_no_index) >= insert_times * default_nb // len(content_keywords)
@@ -466,7 +464,7 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
         # Multilingual test data with various UTF-8 characters
         multilingual_keywords = [
             "北京大学",           # Chinese
-            "東京大学",           # Japanese  
+            "東京大学",           # Japanese
             "Московский",        # Russian
             "café",              # French with accent
             "naïve",             # French with diaeresis
@@ -509,14 +507,14 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
                                metric_type="COSINE",
                                index_type="IVF_FLAT",
                                params={"nlist": 128})
-        
+
         # Create NGRAM index with appropriate parameters for multilingual content
         min_gram = 1  # Use 1 for better multilingual support
         max_gram = 3
         index_params.add_index(field_name="content_ngram",
                                index_name="content_ngram",
                                index_type=index_type,
-                               params={"min_gram": min_gram, "max_gram": max_gram, 
+                               params={"min_gram": min_gram, "max_gram": max_gram,
                                        "json_path": "content_ngram['body']", "json_cast_type": "varchar"})
         self.create_index(client, collection_name, index_params)
         self.wait_for_index_ready(client, collection_name, index_name=vector_field_name)

--- a/tests/python_client/testcases/indexes/test_ngram.py
+++ b/tests/python_client/testcases/indexes/test_ngram.py
@@ -485,7 +485,6 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
 
         # Insert test data
         insert_times = 2
-        total_records = insert_times * default_nb
         for i in range(insert_times):
             rows = cf.gen_row_data_by_schema(nb=default_nb, schema=schema, start=i * default_nb)
             for j, row in enumerate(rows):
@@ -524,7 +523,6 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
         self.wait_for_index_ready(client, collection_name, index_name="content_ngram")
         self.load_collection(client, collection_name)
 
-        expected_count_per_keyword = total_records // len(multilingual_keywords)
 
         # Test 1: Chinese character search
         chinese_keyword = "北京"
@@ -534,8 +532,8 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
         filter_expr = f'content_no_index["body"] LIKE "%{chinese_keyword}%"'
         res_no_index = self.query(client, collection_name, filter=filter_expr,
                                   output_fields=["id", "content_ngram"])[0]
-        assert len(res_ngram) >= expected_count_per_keyword
-        assert res_ngram == res_no_index
+        assert len(res_ngram) > 0
+        assert sorted(res_ngram, key=lambda item: item["id"]) == sorted(res_no_index, key=lambda item: item["id"])
 
         # Test 2: Japanese character search
         japanese_keyword = "東京"
@@ -545,8 +543,8 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
         filter_expr = f'content_no_index["body"] LIKE "%{japanese_keyword}%"'
         res_no_index = self.query(client, collection_name, filter=filter_expr,
                                   output_fields=["id", "content_ngram"])[0]
-        assert len(res_ngram) >= expected_count_per_keyword
-        assert res_ngram == res_no_index
+        assert len(res_ngram) > 0
+        assert sorted(res_ngram, key=lambda item: item["id"]) == sorted(res_no_index, key=lambda item: item["id"])
 
         # Test 3: Russian Cyrillic character search
         russian_keyword = "Моск"
@@ -556,8 +554,8 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
         filter_expr = f'content_no_index["body"] LIKE "%{russian_keyword}%"'
         res_no_index = self.query(client, collection_name, filter=filter_expr,
                                   output_fields=["id", "content_ngram"])[0]
-        assert len(res_ngram) >= expected_count_per_keyword
-        assert res_ngram == res_no_index
+        assert len(res_ngram) > 0
+        assert sorted(res_ngram, key=lambda item: item["id"]) == sorted(res_no_index, key=lambda item: item["id"])
 
         # Test 4: French accent character search
         french_keyword = "café"
@@ -567,8 +565,8 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
         filter_expr = f'content_no_index["body"] LIKE "%{french_keyword}%"'
         res_no_index = self.query(client, collection_name, filter=filter_expr,
                                   output_fields=["id", "content_ngram"])[0]
-        assert len(res_ngram) >= expected_count_per_keyword
-        assert res_ngram == res_no_index
+        assert len(res_ngram) > 0
+        assert sorted(res_ngram, key=lambda item: item["id"]) == sorted(res_no_index, key=lambda item: item["id"])
 
         # Test 5: Emoji character search
         emoji_keyword = "🏫"
@@ -578,8 +576,8 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
         filter_expr = f'content_no_index["body"] LIKE "%{emoji_keyword}%"'
         res_no_index = self.query(client, collection_name, filter=filter_expr,
                                   output_fields=["id", "content_ngram"])[0]
-        assert len(res_ngram) >= expected_count_per_keyword
-        assert res_ngram == res_no_index
+        assert len(res_ngram) > 0
+        assert sorted(res_ngram, key=lambda item: item["id"]) == sorted(res_no_index, key=lambda item: item["id"])
 
         # Test 6: Star emoji search
         star_keyword = "⭐"
@@ -589,8 +587,8 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
         filter_expr = f'content_no_index["body"] LIKE "%{star_keyword}%"'
         res_no_index = self.query(client, collection_name, filter=filter_expr,
                                   output_fields=["id", "content_ngram"])[0]
-        assert len(res_ngram) >= expected_count_per_keyword
-        assert res_ngram == res_no_index
+        assert len(res_ngram) > 0
+        assert sorted(res_ngram, key=lambda item: item["id"]) == sorted(res_no_index, key=lambda item: item["id"])
 
         # Test 7: Arabic character search
         arabic_keyword = "مدرسة"
@@ -600,8 +598,8 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
         filter_expr = f'content_no_index["body"] LIKE "%{arabic_keyword}%"'
         res_no_index = self.query(client, collection_name, filter=filter_expr,
                                   output_fields=["id", "content_ngram"])[0]
-        assert len(res_ngram) >= expected_count_per_keyword
-        assert res_ngram == res_no_index
+        assert len(res_ngram) > 0
+        assert sorted(res_ngram, key=lambda item: item["id"]) == sorted(res_no_index, key=lambda item: item["id"])
 
         # Test 8: Korean character search
         korean_keyword = "한국"
@@ -611,8 +609,8 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
         filter_expr = f'content_no_index["body"] LIKE "%{korean_keyword}%"'
         res_no_index = self.query(client, collection_name, filter=filter_expr,
                                   output_fields=["id", "content_ngram"])[0]
-        assert len(res_ngram) >= expected_count_per_keyword
-        assert res_ngram == res_no_index
+        assert len(res_ngram) > 0
+        assert sorted(res_ngram, key=lambda item: item["id"]) == sorted(res_no_index, key=lambda item: item["id"])
 
         # Test 9: German umlaut character search
         german_keyword = "München"
@@ -622,8 +620,8 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
         filter_expr = f'content_no_index["body"] LIKE "%{german_keyword}%"'
         res_no_index = self.query(client, collection_name, filter=filter_expr,
                                   output_fields=["id", "content_ngram"])[0]
-        assert len(res_ngram) >= expected_count_per_keyword
-        assert res_ngram == res_no_index
+        assert len(res_ngram) > 0
+        assert sorted(res_ngram, key=lambda item: item["id"]) == sorted(res_no_index, key=lambda item: item["id"])
 
         # Test 10: Mixed language search
         mixed_keyword = "mix"
@@ -633,8 +631,8 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
         filter_expr = f'content_no_index["body"] LIKE "%{mixed_keyword}%"'
         res_no_index = self.query(client, collection_name, filter=filter_expr,
                                   output_fields=["id", "content_ngram"])[0]
-        assert len(res_ngram) >= expected_count_per_keyword
-        assert res_ngram == res_no_index
+        assert len(res_ngram) > 0
+        assert sorted(res_ngram, key=lambda item: item["id"]) == sorted(res_no_index, key=lambda item: item["id"])
 
         # Test 11: Complex multilingual with emojis prefix search
         complex_keyword = "café☕"
@@ -644,8 +642,8 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
         filter_expr = f'content_no_index["body"] LIKE "%{complex_keyword}%"'
         res_no_index = self.query(client, collection_name, filter=filter_expr,
                                   output_fields=["id", "content_ngram"])[0]
-        assert len(res_ngram) >= expected_count_per_keyword
-        assert res_ngram == res_no_index
+        assert len(res_ngram) > 0
+        assert sorted(res_ngram, key=lambda item: item["id"]) == sorted(res_no_index, key=lambda item: item["id"])
 
         # Test 12: Hindi/Devanagari character search
         hindi_keyword = "प्रविष्टि"
@@ -655,8 +653,8 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
         filter_expr = f'content_no_index["body"] LIKE "%{hindi_keyword}%"'
         res_no_index = self.query(client, collection_name, filter=filter_expr,
                                   output_fields=["id", "content_ngram"])[0]
-        assert len(res_ngram) >= expected_count_per_keyword
-        assert res_ngram == res_no_index
+        assert len(res_ngram) > 0
+        assert sorted(res_ngram, key=lambda item: item["id"]) == sorted(res_no_index, key=lambda item: item["id"])
 
         # Test 13: Greek character search
         greek_keyword = "Γειά"
@@ -666,8 +664,8 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
         filter_expr = f'content_no_index["body"] LIKE "%{greek_keyword}%"'
         res_no_index = self.query(client, collection_name, filter=filter_expr,
                                   output_fields=["id", "content_ngram"])[0]
-        assert len(res_ngram) >= expected_count_per_keyword
-        assert res_ngram == res_no_index
+        assert len(res_ngram) > 0
+        assert sorted(res_ngram, key=lambda item: item["id"]) == sorted(res_no_index, key=lambda item: item["id"])
 
         # Test 14: Portuguese with tilde character search
         portuguese_keyword = "português"
@@ -677,8 +675,8 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
         filter_expr = f'content_no_index["body"] LIKE "%{portuguese_keyword}%"'
         res_no_index = self.query(client, collection_name, filter=filter_expr,
                                   output_fields=["id", "content_ngram"])[0]
-        assert len(res_ngram) >= expected_count_per_keyword
-        assert res_ngram == res_no_index
+        assert len(res_ngram) > 0
+        assert sorted(res_ngram, key=lambda item: item["id"]) == sorted(res_no_index, key=lambda item: item["id"])
 
         # Test 15: Test single character search (especially important for CJK)
         single_char_keyword = "学"
@@ -689,5 +687,5 @@ class TestNgramBuildParams(TestMilvusClientV2Base):
         res_no_index = self.query(client, collection_name, filter=filter_expr,
                                   output_fields=["id", "content_ngram"])[0]
         # Should match both "北京大学" and "🏫学校🎓"
-        assert len(res_ngram) >= expected_count_per_keyword * 2
-        assert res_ngram == res_no_index
+        assert len(res_ngram) > 0
+        assert sorted(res_ngram, key=lambda item: item["id"]) == sorted(res_no_index, key=lambda item: item["id"])

--- a/tests/python_client/testcases/test_text_embedding_function_e2e.py
+++ b/tests/python_client/testcases/test_text_embedding_function_e2e.py
@@ -1,22 +1,22 @@
 import random
-import uuid
+
+import numpy as np
+import pandas as pd
+import pytest
+from base.client_base import TestcaseBase
+from common import common_func as cf
+from common.common_type import CaseLabel, CheckTasks
+from faker import Faker
 from pymilvus import (
-    FieldSchema,
+    AnnSearchRequest,
     CollectionSchema,
     DataType,
+    FieldSchema,
     Function,
     FunctionType,
-    AnnSearchRequest,
     WeightedRanker,
 )
-from common.common_type import CaseLabel, CheckTasks
-from common import common_func as cf
 from utils.util_log import test_log as log
-from base.client_base import TestcaseBase
-import numpy as np
-import pytest
-import pandas as pd
-from faker import Faker
 
 fake_zh = Faker("zh_CN")
 fake_jp = Faker("ja_JP")

--- a/tests/python_client/testcases/test_text_embedding_function_e2e.py
+++ b/tests/python_client/testcases/test_text_embedding_function_e2e.py
@@ -1989,7 +1989,7 @@ class TestTextEmbeddingFunctionCURDNegative(TestcaseBase):
         except Exception as e:
             log.info(f"Expected error: {e}")
             assert e.code == 65535
-            assert "Check function" in str(e) and "failed" in str(e)
+            assert "check function" in str(e).lower() and "failed" in str(e).lower()
 
     # ==================== drop_collection_function negative tests ====================
 

--- a/tests/python_client/testcases/test_text_embedding_function_e2e.py
+++ b/tests/python_client/testcases/test_text_embedding_function_e2e.py
@@ -31,6 +31,7 @@ prefix = "text_embedding_collection"
 # model id:BAAI/bge-base-en-v1.5
 # dim: 768
 
+
 @pytest.mark.tags(CaseLabel.L1)
 class TestCreateCollectionWithTextEmbedding(TestcaseBase):
     """
@@ -61,19 +62,15 @@ class TestCreateCollectionWithTextEmbedding(TestcaseBase):
             params={
                 "provider": "TEI",
                 "endpoint": tei_endpoint,
-            }
+            },
         )
         schema.add_function(text_embedding_function)
 
-        collection_w = self.init_collection_wrap(
-            name=cf.gen_unique_str(prefix), schema=schema
-        )
+        collection_w = self.init_collection_wrap(name=cf.gen_unique_str(prefix), schema=schema)
         res, _ = collection_w.describe()
         assert len(res["functions"]) == 1
 
-    def test_create_collection_with_text_embedding_twice_with_same_schema(
-            self, tei_endpoint
-    ):
+    def test_create_collection_with_text_embedding_twice_with_same_schema(self, tei_endpoint):
         """
         target: test create collection with text embedding twice with same schema
         method: create collection with text embedding function, then create again
@@ -219,9 +216,7 @@ class TestInsertWithTextEmbedding(TestcaseBase):
         )
         schema.add_function(text_embedding_function)
 
-        collection_w = self.init_collection_wrap(
-            name=cf.gen_unique_str(prefix), schema=schema
-        )
+        collection_w = self.init_collection_wrap(name=cf.gen_unique_str(prefix), schema=schema)
 
         # prepare data
         nb = 10
@@ -277,31 +272,17 @@ class TestInsertWithTextEmbedding(TestcaseBase):
                 "provider": "TEI",
                 "endpoint": tei_endpoint,
                 "truncate": truncate,
-                "truncation_direction": truncation_direction
+                "truncation_direction": truncation_direction,
             },
         )
         schema.add_function(text_embedding_function)
 
-        collection_w = self.init_collection_wrap(
-            name=cf.gen_unique_str(prefix), schema=schema
-        )
+        collection_w = self.init_collection_wrap(name=cf.gen_unique_str(prefix), schema=schema)
 
         # prepare data
         left = " ".join([fake_en.word() for _ in range(512)])
         right = " ".join([fake_en.word() for _ in range(512)])
-        data = [
-            {
-                "id": 0,
-                "document": left + " " + right
-            },
-            {
-                "id": 1,
-                "document": left
-            },
-            {
-                "id": 2,
-                "document": right
-            }]
+        data = [{"id": 0, "document": left + " " + right}, {"id": 1, "document": left}, {"id": 2, "document": right}]
         res, result = collection_w.insert(data, check_task=CheckTasks.check_nothing)
 
         if not truncate:
@@ -324,13 +305,16 @@ class TestInsertWithTextEmbedding(TestcaseBase):
         )
         # compare similarity between left and right using cosine similarity
         import numpy as np
+
         # Calculate cosine similarity: cos(θ) = A·B / (||A|| * ||B||)
         # when direction is left, right part is reversed
         similarity_left = np.dot(res[0]["dense"], res[1]["dense"]) / (
-                    np.linalg.norm(res[0]["dense"]) * np.linalg.norm(res[1]["dense"]))
+            np.linalg.norm(res[0]["dense"]) * np.linalg.norm(res[1]["dense"])
+        )
         # when direction is right, left part is reversed
         similarity_right = np.dot(res[0]["dense"], res[2]["dense"]) / (
-                    np.linalg.norm(res[0]["dense"]) * np.linalg.norm(res[2]["dense"]))
+            np.linalg.norm(res[0]["dense"]) * np.linalg.norm(res[2]["dense"])
+        )
         if truncation_direction == "Left":
             assert similarity_left < similarity_right
         else:
@@ -373,9 +357,7 @@ class TestInsertWithTextEmbeddingNegative(TestcaseBase):
         )
         schema.add_function(text_embedding_function)
 
-        collection_w = self.init_collection_wrap(
-            name=cf.gen_unique_str(prefix), schema=schema
-        )
+        collection_w = self.init_collection_wrap(name=cf.gen_unique_str(prefix), schema=schema)
 
         # prepare data with empty document
         empty_data = [{"id": 1, "document": ""}]
@@ -417,9 +399,7 @@ class TestInsertWithTextEmbeddingNegative(TestcaseBase):
         )
         schema.add_function(text_embedding_function)
 
-        collection_w = self.init_collection_wrap(
-            name=cf.gen_unique_str(prefix), schema=schema
-        )
+        collection_w = self.init_collection_wrap(name=cf.gen_unique_str(prefix), schema=schema)
 
         # prepare data with empty document
         long_data = [{"id": 1, "document": " ".join([fake_en.word() for _ in range(8192)])}]
@@ -473,9 +453,7 @@ class TestUpsertWithTextEmbedding(TestcaseBase):
         )
         schema.add_function(text_embedding_function)
 
-        collection_w = self.init_collection_wrap(
-            name=cf.gen_unique_str(prefix), schema=schema
-        )
+        collection_w = self.init_collection_wrap(name=cf.gen_unique_str(prefix), schema=schema)
         # create index and load
         index_params = {
             "index_type": "AUTOINDEX",
@@ -506,9 +484,7 @@ class TestUpsertWithTextEmbedding(TestcaseBase):
         # verify embeddings are different
         assert not np.allclose(old_embedding, new_embedding)
         # caculate cosine similarity
-        sim = np.dot(old_embedding, new_embedding) / (
-                np.linalg.norm(old_embedding) * np.linalg.norm(new_embedding)
-        )
+        sim = np.dot(old_embedding, new_embedding) / (np.linalg.norm(old_embedding) * np.linalg.norm(new_embedding))
         log.info(f"cosine similarity: {sim}")
         assert sim < 0.99
 
@@ -549,9 +525,7 @@ class TestDeleteWithTextEmbedding(TestcaseBase):
         )
         schema.add_function(text_embedding_function)
 
-        collection_w = self.init_collection_wrap(
-            name=cf.gen_unique_str(prefix), schema=schema
-        )
+        collection_w = self.init_collection_wrap(name=cf.gen_unique_str(prefix), schema=schema)
 
         # insert data
         nb = 3
@@ -618,9 +592,7 @@ class TestSearchWithTextEmbedding(TestcaseBase):
         )
         schema.add_function(text_embedding_function)
 
-        collection_w = self.init_collection_wrap(
-            name=cf.gen_unique_str(prefix), schema=schema
-        )
+        collection_w = self.init_collection_wrap(name=cf.gen_unique_str(prefix), schema=schema)
 
         # prepare data
         nb = 10
@@ -689,16 +661,11 @@ class TestSearchWithTextEmbeddingNegative(TestcaseBase):
             function_type=FunctionType.TEXTEMBEDDING,
             input_field_names=["document"],
             output_field_names="dense",
-            params={
-                "provider": "TEI",
-                "endpoint": tei_endpoint
-            }
+            params={"provider": "TEI", "endpoint": tei_endpoint},
         )
         schema.add_function(text_embedding_function)
 
-        collection_w = self.init_collection_wrap(
-            name=cf.gen_unique_str(prefix), schema=schema
-        )
+        collection_w = self.init_collection_wrap(name=cf.gen_unique_str(prefix), schema=schema)
 
         # prepare data
         nb = 10
@@ -767,10 +734,7 @@ class TestHybridSearch(TestcaseBase):
             function_type=FunctionType.TEXTEMBEDDING,
             input_field_names=["document"],
             output_field_names="dense",
-            params={
-                "provider": "TEI",
-                "endpoint": tei_endpoint
-            }
+            params={"provider": "TEI", "endpoint": tei_endpoint},
         )
         schema.add_function(text_embedding_function)
 
@@ -784,16 +748,14 @@ class TestHybridSearch(TestcaseBase):
         )
         schema.add_function(bm25_function)
 
-        collection_w = self.init_collection_wrap(
-            name=cf.gen_unique_str(prefix), schema=schema
-        )
+        collection_w = self.init_collection_wrap(name=cf.gen_unique_str(prefix), schema=schema)
 
         # insert test data
         data_size = 1000
         data = [{"id": i, "document": fake_en.text()} for i in range(data_size)]
 
         for batch in range(0, data_size, 100):
-            collection_w.insert(data[batch: batch + 100])
+            collection_w.insert(data[batch : batch + 100])
 
         # create index and load
         dense_index_params = {
@@ -880,12 +842,9 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
             function_type=FunctionType.TEXTEMBEDDING,
             input_field_names=["document"],
             output_field_names="dense",
-            params={"provider": "TEI", "endpoint": tei_endpoint}
+            params={"provider": "TEI", "endpoint": tei_endpoint},
         )
-        self.client.add_collection_function(
-            collection_name=c_name,
-            function=embedding_function
-        )
+        self.client.add_collection_function(collection_name=c_name, function=embedding_function)
 
         # Verify function is added
         res, _ = collection_w.describe()
@@ -915,12 +874,9 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
             function_type=FunctionType.TEXTEMBEDDING,
             input_field_names=["document"],
             output_field_names="dense",
-            params={"provider": "TEI", "endpoint": tei_endpoint}
+            params={"provider": "TEI", "endpoint": tei_endpoint},
         )
-        self.client.add_collection_function(
-            collection_name=c_name,
-            function=embedding_function
-        )
+        self.client.add_collection_function(collection_name=c_name, function=embedding_function)
 
         # === INSERT ===
         nb = 10
@@ -1023,12 +979,9 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
             function_type=FunctionType.TEXTEMBEDDING,
             input_field_names=["title"],
             output_field_names="title_vector",
-            params={"provider": "TEI", "endpoint": tei_endpoint}
+            params={"provider": "TEI", "endpoint": tei_endpoint},
         )
-        self.client.add_collection_function(
-            collection_name=c_name,
-            function=title_embedding_function
-        )
+        self.client.add_collection_function(collection_name=c_name, function=title_embedding_function)
 
         # Add text embedding function for content
         content_embedding_function = Function(
@@ -1036,12 +989,9 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
             function_type=FunctionType.TEXTEMBEDDING,
             input_field_names=["content"],
             output_field_names="content_vector",
-            params={"provider": "TEI", "endpoint": tei_endpoint}
+            params={"provider": "TEI", "endpoint": tei_endpoint},
         )
-        self.client.add_collection_function(
-            collection_name=c_name,
-            function=content_embedding_function
-        )
+        self.client.add_collection_function(collection_name=c_name, function=content_embedding_function)
 
         # Verify both functions are added
         res, _ = collection_w.describe()
@@ -1109,7 +1059,7 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
             function_type=FunctionType.TEXTEMBEDDING,
             input_field_names=["document"],
             output_field_names="dense",
-            params={"provider": "TEI", "endpoint": tei_endpoint}
+            params={"provider": "TEI", "endpoint": tei_endpoint},
         )
         schema.add_function(text_embedding_function)
 
@@ -1122,13 +1072,9 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
             function_type=FunctionType.TEXTEMBEDDING,
             input_field_names=["document"],
             output_field_names="dense",
-            params={"provider": "TEI", "endpoint": tei_endpoint}
+            params={"provider": "TEI", "endpoint": tei_endpoint},
         )
-        self.client.alter_collection_function(
-            collection_name=c_name,
-            function_name="tei",
-            function=new_function
-        )
+        self.client.alter_collection_function(collection_name=c_name, function_name="tei", function=new_function)
 
         # Verify function still exists and params are correct
         res, _ = collection_w.describe()
@@ -1158,7 +1104,7 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
             function_type=FunctionType.TEXTEMBEDDING,
             input_field_names=["document"],
             output_field_names="dense",
-            params={"provider": "TEI", "endpoint": tei_endpoint}
+            params={"provider": "TEI", "endpoint": tei_endpoint},
         )
         schema.add_function(text_embedding_function)
 
@@ -1171,18 +1117,9 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
             function_type=FunctionType.TEXTEMBEDDING,
             input_field_names=["document"],
             output_field_names="dense",
-            params={
-                "provider": "TEI",
-                "endpoint": tei_endpoint,
-                "truncate": True,
-                "truncation_direction": "Left"
-            }
+            params={"provider": "TEI", "endpoint": tei_endpoint, "truncate": True, "truncation_direction": "Left"},
         )
-        self.client.alter_collection_function(
-            collection_name=c_name,
-            function_name="tei",
-            function=new_function
-        )
+        self.client.alter_collection_function(collection_name=c_name, function_name="tei", function=new_function)
 
         # Verify function params are updated correctly
         res, _ = collection_w.describe()
@@ -1215,7 +1152,7 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
             function_type=FunctionType.TEXTEMBEDDING,
             input_field_names=["document"],
             output_field_names="dense",
-            params={"provider": "TEI", "endpoint": tei_endpoint}
+            params={"provider": "TEI", "endpoint": tei_endpoint},
         )
         schema.add_function(text_embedding_function)
 
@@ -1245,17 +1182,9 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
             function_type=FunctionType.TEXTEMBEDDING,
             input_field_names=["document"],
             output_field_names="dense",
-            params={
-                "provider": "TEI",
-                "endpoint": tei_endpoint,
-                "truncate": True
-            }
+            params={"provider": "TEI", "endpoint": tei_endpoint, "truncate": True},
         )
-        self.client.alter_collection_function(
-            collection_name=c_name,
-            function_name="tei",
-            function=new_function
-        )
+        self.client.alter_collection_function(collection_name=c_name, function_name="tei", function=new_function)
 
         # === INSERT after alter ===
         data2 = [{"id": i + 5, "document": f"Document after alter {i}"} for i in range(5)]
@@ -1339,7 +1268,7 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
             function_type=FunctionType.TEXTEMBEDDING,
             input_field_names=["document"],
             output_field_names="dense",
-            params={"provider": "TEI", "endpoint": tei_endpoint}
+            params={"provider": "TEI", "endpoint": tei_endpoint},
         )
         schema.add_function(text_embedding_function)
 
@@ -1361,13 +1290,9 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
             function_type=FunctionType.TEXTEMBEDDING,
             input_field_names=["document"],
             output_field_names="dense",
-            params={"provider": "TEI", "endpoint": tei_endpoint_2}
+            params={"provider": "TEI", "endpoint": tei_endpoint_2},
         )
-        self.client.alter_collection_function(
-            collection_name=c_name,
-            function_name="tei",
-            function=new_function
-        )
+        self.client.alter_collection_function(collection_name=c_name, function_name="tei", function=new_function)
 
         # Insert data with new endpoint
         data2 = [{"id": i + 10, "document": f"Document with endpoint2 {i}"} for i in range(3)]
@@ -1414,7 +1339,7 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
             function_type=FunctionType.TEXTEMBEDDING,
             input_field_names=["document"],
             output_field_names="dense",
-            params={"provider": "TEI", "endpoint": tei_endpoint}
+            params={"provider": "TEI", "endpoint": tei_endpoint},
         )
         schema.add_function(text_embedding_function)
 
@@ -1441,10 +1366,7 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
             assert len(row["dense"]) == dim
 
         # === DROP FUNCTION ===
-        self.client.drop_collection_function(
-            collection_name=c_name,
-            function_name="tei"
-        )
+        self.client.drop_collection_function(collection_name=c_name, function_name="tei")
 
         # Verify function is removed
         res, _ = collection_w.describe()
@@ -1524,7 +1446,7 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
             function_type=FunctionType.TEXTEMBEDDING,
             input_field_names=["title"],
             output_field_names="title_vector",
-            params={"provider": "TEI", "endpoint": tei_endpoint}
+            params={"provider": "TEI", "endpoint": tei_endpoint},
         )
         schema.add_function(title_embedding)
 
@@ -1533,7 +1455,7 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
             function_type=FunctionType.TEXTEMBEDDING,
             input_field_names=["content"],
             output_field_names="content_vector",
-            params={"provider": "TEI", "endpoint": tei_endpoint}
+            params={"provider": "TEI", "endpoint": tei_endpoint},
         )
         schema.add_function(content_embedding)
 
@@ -1562,10 +1484,7 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
             assert len(row["content_vector"]) == dim
 
         # === DROP one function (title_embedding) ===
-        self.client.drop_collection_function(
-            collection_name=c_name,
-            function_name="title_embedding"
-        )
+        self.client.drop_collection_function(collection_name=c_name, function_name="title_embedding")
 
         # Verify only content_embedding remains
         res, _ = collection_w.describe()
@@ -1574,12 +1493,9 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
 
         # === INSERT after drop - content_vector auto-generated, title_vector manual ===
         manual_title_vector = [random.random() for _ in range(dim)]
-        data_after_drop = [{
-            "id": 10,
-            "title": "New title",
-            "content": "New content",
-            "title_vector": manual_title_vector
-        }]
+        data_after_drop = [
+            {"id": 10, "title": "New title", "content": "New content", "title_vector": manual_title_vector}
+        ]
         collection_w.insert(data_after_drop)
         assert collection_w.num_entities == 4
 
@@ -1610,12 +1526,9 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
 
         # === UPSERT - content function still works ===
         upsert_title_vector = [random.random() for _ in range(dim)]
-        upsert_data = [{
-            "id": 0,
-            "title": "Updated title",
-            "content": "Updated content",
-            "title_vector": upsert_title_vector
-        }]
+        upsert_data = [
+            {"id": 0, "title": "Updated title", "content": "Updated content", "title_vector": upsert_title_vector}
+        ]
         collection_w.upsert(upsert_data)
 
         res, _ = collection_w.query(expr="id == 0", output_fields=["title_vector", "content_vector"])
@@ -1646,7 +1559,7 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
             function_type=FunctionType.TEXTEMBEDDING,
             input_field_names=["document"],
             output_field_names="dense",
-            params={"provider": "TEI", "endpoint": tei_endpoint}
+            params={"provider": "TEI", "endpoint": tei_endpoint},
         )
         schema.add_function(text_embedding_function)
 
@@ -1654,10 +1567,7 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
         collection_w = self.init_collection_wrap(name=c_name, schema=schema)
 
         # Drop function
-        self.client.drop_collection_function(
-            collection_name=c_name,
-            function_name="tei"
-        )
+        self.client.drop_collection_function(collection_name=c_name, function_name="tei")
 
         # Verify function is removed
         res, _ = collection_w.describe()
@@ -1669,12 +1579,9 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
             function_type=FunctionType.TEXTEMBEDDING,
             input_field_names=["document"],
             output_field_names="dense",
-            params={"provider": "TEI", "endpoint": tei_endpoint}
+            params={"provider": "TEI", "endpoint": tei_endpoint},
         )
-        self.client.add_collection_function(
-            collection_name=c_name,
-            function=new_function
-        )
+        self.client.add_collection_function(collection_name=c_name, function=new_function)
 
         # Verify function is added
         res, _ = collection_w.describe()
@@ -1704,13 +1611,12 @@ class TestTextEmbeddingFunctionCURDNegative(TestcaseBase):
             function_type=FunctionType.TEXTEMBEDDING,
             input_field_names=["document"],
             output_field_names="dense",
-            params={"provider": "TEI", "endpoint": tei_endpoint}
+            params={"provider": "TEI", "endpoint": tei_endpoint},
         )
 
         try:
             self.client.add_collection_function(
-                collection_name="nonexistent_collection_12345",
-                function=embedding_function
+                collection_name="nonexistent_collection_12345", function=embedding_function
             )
             assert False, "Expected exception for nonexistent collection"
         except Exception as e:
@@ -1739,7 +1645,7 @@ class TestTextEmbeddingFunctionCURDNegative(TestcaseBase):
             function_type=FunctionType.TEXTEMBEDDING,
             input_field_names=["document"],
             output_field_names="dense",
-            params={"provider": "TEI", "endpoint": tei_endpoint}
+            params={"provider": "TEI", "endpoint": tei_endpoint},
         )
         schema.add_function(text_embedding_function)
 
@@ -1752,14 +1658,11 @@ class TestTextEmbeddingFunctionCURDNegative(TestcaseBase):
             function_type=FunctionType.TEXTEMBEDDING,
             input_field_names=["document"],
             output_field_names="dense",
-            params={"provider": "TEI", "endpoint": tei_endpoint}
+            params={"provider": "TEI", "endpoint": tei_endpoint},
         )
 
         try:
-            self.client.add_collection_function(
-                collection_name=c_name,
-                function=duplicate_function
-            )
+            self.client.add_collection_function(collection_name=c_name, function=duplicate_function)
             assert False, "Expected exception for duplicate function name"
         except Exception as e:
             log.info(f"Expected error: {e}")
@@ -1789,14 +1692,11 @@ class TestTextEmbeddingFunctionCURDNegative(TestcaseBase):
             function_type=FunctionType.TEXTEMBEDDING,
             input_field_names=["nonexistent_field"],
             output_field_names="dense",
-            params={"provider": "TEI", "endpoint": tei_endpoint}
+            params={"provider": "TEI", "endpoint": tei_endpoint},
         )
 
         try:
-            self.client.add_collection_function(
-                collection_name=c_name,
-                function=embedding_function
-            )
+            self.client.add_collection_function(collection_name=c_name, function=embedding_function)
             assert False, "Expected exception for missing input field"
         except Exception as e:
             log.info(f"Expected error: {e}")
@@ -1826,14 +1726,11 @@ class TestTextEmbeddingFunctionCURDNegative(TestcaseBase):
             function_type=FunctionType.TEXTEMBEDDING,
             input_field_names=["document"],
             output_field_names="nonexistent_vector_field",
-            params={"provider": "TEI", "endpoint": tei_endpoint}
+            params={"provider": "TEI", "endpoint": tei_endpoint},
         )
 
         try:
-            self.client.add_collection_function(
-                collection_name=c_name,
-                function=embedding_function
-            )
+            self.client.add_collection_function(collection_name=c_name, function=embedding_function)
             assert False, "Expected exception for missing output field"
         except Exception as e:
             log.info(f"Expected error: {e}")
@@ -1863,14 +1760,11 @@ class TestTextEmbeddingFunctionCURDNegative(TestcaseBase):
             function_type=FunctionType.TEXTEMBEDDING,
             input_field_names=["document"],
             output_field_names="dense",
-            params={"provider": "TEI", "endpoint": tei_endpoint}
+            params={"provider": "TEI", "endpoint": tei_endpoint},
         )
 
         try:
-            self.client.add_collection_function(
-                collection_name=c_name,
-                function=embedding_function
-            )
+            self.client.add_collection_function(collection_name=c_name, function=embedding_function)
             assert False, "Expected exception for dimension mismatch"
         except Exception as e:
             log.info(f"Expected error: {e}")
@@ -1891,14 +1785,12 @@ class TestTextEmbeddingFunctionCURDNegative(TestcaseBase):
             function_type=FunctionType.TEXTEMBEDDING,
             input_field_names=["document"],
             output_field_names="dense",
-            params={"provider": "TEI", "endpoint": tei_endpoint}
+            params={"provider": "TEI", "endpoint": tei_endpoint},
         )
 
         try:
             self.client.alter_collection_function(
-                collection_name="nonexistent_collection_12345",
-                function_name="tei",
-                function=new_function
+                collection_name="nonexistent_collection_12345", function_name="tei", function=new_function
             )
             assert False, "Expected exception for nonexistent collection"
         except Exception as e:
@@ -1928,14 +1820,12 @@ class TestTextEmbeddingFunctionCURDNegative(TestcaseBase):
             function_type=FunctionType.TEXTEMBEDDING,
             input_field_names=["document"],
             output_field_names="dense",
-            params={"provider": "TEI", "endpoint": tei_endpoint}
+            params={"provider": "TEI", "endpoint": tei_endpoint},
         )
 
         try:
             self.client.alter_collection_function(
-                collection_name=c_name,
-                function_name="nonexistent_function",
-                function=new_function
+                collection_name=c_name, function_name="nonexistent_function", function=new_function
             )
             assert False, "Expected exception for nonexistent function"
         except Exception as e:
@@ -1963,7 +1853,7 @@ class TestTextEmbeddingFunctionCURDNegative(TestcaseBase):
             function_type=FunctionType.TEXTEMBEDDING,
             input_field_names=["document"],
             output_field_names="dense",
-            params={"provider": "TEI", "endpoint": tei_endpoint}
+            params={"provider": "TEI", "endpoint": tei_endpoint},
         )
         schema.add_function(text_embedding_function)
 
@@ -1976,15 +1866,11 @@ class TestTextEmbeddingFunctionCURDNegative(TestcaseBase):
             function_type=FunctionType.TEXTEMBEDDING,
             input_field_names=["document"],
             output_field_names="dense",
-            params={"provider": "TEI", "endpoint": "http://invalid_endpoint_12345"}
+            params={"provider": "TEI", "endpoint": "http://invalid_endpoint_12345"},
         )
 
         try:
-            self.client.alter_collection_function(
-                collection_name=c_name,
-                function_name="tei",
-                function=new_function
-            )
+            self.client.alter_collection_function(collection_name=c_name, function_name="tei", function=new_function)
             assert False, "Expected exception for invalid endpoint"
         except Exception as e:
             log.info(f"Expected error: {e}")
@@ -2002,10 +1888,7 @@ class TestTextEmbeddingFunctionCURDNegative(TestcaseBase):
         self._connect()
 
         try:
-            self.client.drop_collection_function(
-                collection_name="nonexistent_collection_12345",
-                function_name="tei"
-            )
+            self.client.drop_collection_function(collection_name="nonexistent_collection_12345", function_name="tei")
             assert False, "Expected exception for nonexistent collection"
         except Exception as e:
             log.info(f"Expected error: {e}")
@@ -2030,10 +1913,7 @@ class TestTextEmbeddingFunctionCURDNegative(TestcaseBase):
         self.init_collection_wrap(name=c_name, schema=schema)
 
         # Drop nonexistent function should not raise error (idempotent)
-        self.client.drop_collection_function(
-            collection_name=c_name,
-            function_name="nonexistent_function"
-        )
+        self.client.drop_collection_function(collection_name=c_name, function_name="nonexistent_function")
         log.info("Drop nonexistent function succeeded (idempotent behavior)")
 
     def test_drop_collection_function_empty_name(self):
@@ -2054,8 +1934,5 @@ class TestTextEmbeddingFunctionCURDNegative(TestcaseBase):
         self.init_collection_wrap(name=c_name, schema=schema)
 
         # Drop with empty name should not raise error (idempotent)
-        self.client.drop_collection_function(
-            collection_name=c_name,
-            function_name=""
-        )
+        self.client.drop_collection_function(collection_name=c_name, function_name="")
         log.info("Drop with empty function name succeeded (idempotent behavior)")


### PR DESCRIPTION
pr: #49642
pr: #49454

## Summary
- Backport Python client nightly expectation updates from master PR #49642 for dynamic-field insert coverage, RRFRanker error text, and TEI error message casing.
- Backport NGRAM multilingual assertion fix from master PR #49454.
- Clean up Ruff violations and apply Ruff formatting in the changed Python test files for the 2.6 PR lint gate.

issue: #49509
issue: #49341
issue: #48917
issue: #49191

## Test plan
- [x] `uvx ruff==0.15.11 format --check --diff tests/python_client/milvus_client/test_milvus_client_insert.py tests/python_client/milvus_client_v2/test_milvus_client_hybrid_search_v2.py tests/python_client/testcases/indexes/test_ngram.py tests/python_client/testcases/test_text_embedding_function_e2e.py` — passed
- [x] `uvx ruff==0.15.11 check tests/python_client/milvus_client/test_milvus_client_insert.py tests/python_client/milvus_client_v2/test_milvus_client_hybrid_search_v2.py tests/python_client/testcases/indexes/test_ngram.py tests/python_client/testcases/test_text_embedding_function_e2e.py` — passed
- [x] `source /Users/zilliz/virtual-environment/branch2.6/bin/activate && cd /Users/zilliz/nico/release/milvus/tests/python_client && python -m pytest -vv --tb=short --host 10.104.20.144 --port 19530 milvus_client/test_milvus_client_insert.py::TestMilvusClientInsertValid::test_milvus_client_insert_different_fields milvus_client_v2/test_milvus_client_hybrid_search_v2.py::TestMilvusClientHybridSearch::test_hybrid_search_RRFRanker_k_out_of_range testcases/indexes/test_ngram.py::TestNgramBuildParams::test_ngram_search_with_multilingual_utf8_strings testcases/test_text_embedding_function_e2e.py::TestTextEmbeddingFunctionCURDNegative::test_alter_collection_function_invalid_new_endpoint` — 5 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)