### PR TITLE
fix: [cp2.6]seal growing segments on blocking l0 pressure

### DIFF
--- a/internal/streamingnode/server/wal/interceptors/shard/policy/seal_policy.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/policy/seal_policy.go
@@ -17,6 +17,7 @@ var (
 	PolicyNameIdle                   PolicyName = "idle"
 	PolicyNameGrowingSegmentBytesHWM PolicyName = "growing_bytes_hwm"
 	PolicyNameNodeMemory             PolicyName = "node_memory"
+	PolicyNameBlockingL0             PolicyName = "blocking_l0"
 )
 
 // PolicyPartitionNotFound returns a SealPolicy for partition not found.
@@ -103,6 +104,19 @@ func PolicyNodeMemory(usedRatio float64) SealPolicy {
 	}
 }
 
+// PolicyBlockingL0 returns a SealPolicy for blocking l0.
+func PolicyBlockingL0(blockingRows, blockingBytes uint64, rowLimit, sizeLimit int64) SealPolicy {
+	return SealPolicy{
+		Policy: PolicyNameBlockingL0,
+		Extra: sealByBlockingL0ExtraInfo{
+			BlockingRows:  blockingRows,
+			BlockingBytes: blockingBytes,
+			RowLimit:      rowLimit,
+			SizeLimit:     sizeLimit,
+		},
+	}
+}
+
 // PolicyRecover returns a SealPolicy for recover.
 type SealPolicy struct {
 	Policy PolicyName
@@ -131,6 +145,13 @@ type sealByGrowingSegmentBytesHWM struct {
 // nodeMemory is the extra info of the seal by node memory policy.
 type nodeMemory struct {
 	UsedRatio float64
+}
+
+type sealByBlockingL0ExtraInfo struct {
+	BlockingRows  uint64
+	BlockingBytes uint64
+	RowLimit      int64
+	SizeLimit     int64
 }
 
 // sealByIdleTimeExtraInfo is the extra info of the seal by idle time policy.

--- a/internal/streamingnode/server/wal/interceptors/shard/policy/seal_policy_test.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/policy/seal_policy_test.go
@@ -138,3 +138,26 @@ func TestPolicyNodeMemory(t *testing.T) {
 		t.Errorf("expected used ratio %f, got %f", usedRatio, extra.UsedRatio)
 	}
 }
+
+func TestPolicyBlockingL0(t *testing.T) {
+	p := PolicyBlockingL0(10, 20, 100, 200)
+	if p.Policy != PolicyNameBlockingL0 {
+		t.Errorf("expected policy name %s, got %s", PolicyNameBlockingL0, p.Policy)
+	}
+	extra, ok := p.Extra.(sealByBlockingL0ExtraInfo)
+	if !ok {
+		t.Fatalf("expected extra to be of type sealByBlockingL0ExtraInfo, got %T", p.Extra)
+	}
+	if extra.BlockingRows != 10 {
+		t.Errorf("expected blocking rows %d, got %d", uint64(10), extra.BlockingRows)
+	}
+	if extra.BlockingBytes != 20 {
+		t.Errorf("expected blocking bytes %d, got %d", uint64(20), extra.BlockingBytes)
+	}
+	if extra.RowLimit != 100 {
+		t.Errorf("expected row limit %d, got %d", int64(100), extra.RowLimit)
+	}
+	if extra.SizeLimit != 200 {
+		t.Errorf("expected size limit %d, got %d", int64(200), extra.SizeLimit)
+	}
+}

--- a/internal/streamingnode/server/wal/interceptors/shard/shard_interceptor_test.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shard_interceptor_test.go
@@ -20,6 +20,36 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/streaming/walimpls/impls/rmq"
 )
 
+func TestShardInterceptorDeleteAppliesBeforeAppend(t *testing.T) {
+	b := NewInterceptorBuilder()
+	shardManager := mock_shards.NewMockShardManager(t)
+	shardManager.EXPECT().Logger().Return(log.With()).Maybe()
+	i := b.Build(&interceptors.InterceptorBuildParam{
+		ShardManager: shardManager,
+	})
+	defer i.Close()
+
+	msg := message.NewDeleteMessageBuilderV1().
+		WithVChannel("vchannel").
+		WithHeader(&messagespb.DeleteMessageHeader{
+			CollectionId: 1,
+			Rows:         10,
+		}).
+		WithBody(&msgpb.DeleteRequest{}).
+		MustBuildMutable().WithTimeTick(1)
+
+	shardManager.EXPECT().CheckIfCollectionExists(int64(1)).Return(nil)
+	shardManager.EXPECT().ApplyDelete(mock.MatchedBy(func(deleteMsg message.MutableDeleteMessageV1) bool {
+		return deleteMsg.Header().GetCollectionId() == int64(1) && deleteMsg.Header().GetRows() == uint64(10)
+	})).Return(nil)
+
+	msgID, err := i.DoAppend(context.Background(), msg, func(ctx context.Context, msg message.MutableMessage) (message.MessageID, error) {
+		return nil, errors.New("append failed")
+	})
+	assert.Error(t, err)
+	assert.Nil(t, msgID)
+}
+
 func TestShardInterceptor(t *testing.T) {
 	mockErr := errors.New("mock error")
 

--- a/internal/streamingnode/server/wal/interceptors/shard/shards/shard_manager_segment.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shards/shard_manager_segment.go
@@ -4,6 +4,7 @@ import (
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
 
+	"github.com/milvus-io/milvus/internal/streamingnode/server/resource"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/shard/stats"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/shard/utils"
 	"github.com/milvus-io/milvus/pkg/v2/log"
@@ -146,7 +147,9 @@ func (m *shardManagerImpl) ApplyDelete(msg message.MutableDeleteMessageV1) error
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	m.metrics.ObserveDelete(msg.Header().GetRows())
+	rows := msg.Header().GetRows()
+	m.metrics.ObserveDelete(rows)
+	resource.Resource().SegmentStatsManager().RecordDelete(m.pchannel.Name, msg.VChannel(), msg.TimeTick(), rows, uint64(msg.EstimateSize()))
 	return nil
 }
 

--- a/internal/streamingnode/server/wal/interceptors/shard/stats/config.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/stats/config.go
@@ -23,6 +23,8 @@ func newStatsConfig() statsConfig {
 	l1MinSizeFromIdleTime := paramtable.Get().DataCoordCfg.SegmentMinSizeFromIdleToSealed.GetAsInt64() * 1024 * 1024
 
 	l0MaxLifetime := params.StreamingCfg.FlushL0MaxLifetime.GetAsDurationByParse()
+	blockingL0EntryNum := params.DataCoordCfg.BlockingL0EntryNum.GetAsInt64()
+	blockingL0SizeBytes := params.DataCoordCfg.BlockingL0SizeInMB.GetAsInt64() * 1024 * 1024
 	return statsConfig{
 		maxBinlogFileNum:      segmentMaxBinlogFileNum,
 		memoryThreshold:       memoryTheshold,
@@ -32,6 +34,8 @@ func newStatsConfig() statsConfig {
 		l1MaxIdleTime:         l1MaxIdleTime,
 		l1MinSizeFromIdleTime: l1MinSizeFromIdleTime,
 		l0MaxLifetime:         l0MaxLifetime,
+		blockingL0EntryNum:    blockingL0EntryNum,
+		blockingL0SizeBytes:   blockingL0SizeBytes,
 	}
 }
 
@@ -45,6 +49,8 @@ type statsConfig struct {
 	l1MaxIdleTime         time.Duration
 	l1MinSizeFromIdleTime int64
 	l0MaxLifetime         time.Duration
+	blockingL0EntryNum    int64
+	blockingL0SizeBytes   int64
 }
 
 // Validate checks if the config is valid.

--- a/internal/streamingnode/server/wal/interceptors/shard/stats/config_test.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/stats/config_test.go
@@ -20,6 +20,20 @@ func TestNewStatConfig(t *testing.T) {
 	assert.Greater(t, cfg.l1MinSizeFromIdleTime, int64(0))
 }
 
+func TestStatsConfigBlockingL0(t *testing.T) {
+	paramtable.Init()
+	params := paramtable.Get()
+	params.Save(params.DataCoordCfg.BlockingL0EntryNum.Key, "12345")
+	params.Save(params.DataCoordCfg.BlockingL0SizeInMB.Key, "7")
+	defer params.Reset(params.DataCoordCfg.BlockingL0EntryNum.Key)
+	defer params.Reset(params.DataCoordCfg.BlockingL0SizeInMB.Key)
+
+	cfg := newStatsConfig()
+
+	assert.Equal(t, int64(12345), cfg.blockingL0EntryNum)
+	assert.Equal(t, int64(7*1024*1024), cfg.blockingL0SizeBytes)
+}
+
 func TestStatsConfig_Validate(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/streamingnode/server/wal/interceptors/shard/stats/stats_manager.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/stats/stats_manager.go
@@ -33,17 +33,29 @@ var (
 // If there will be a lock contention, we can optimize it by apply lock per segment.
 type StatsManager struct {
 	log.Binder
-	worker        *sealWorker
-	mu            sync.Mutex
-	cfg           statsConfig
-	totalStats    *aggregatedMetrics
-	pchannelStats map[string]*aggregatedMetrics
-	vchannelStats map[string]*aggregatedMetrics
-	segmentStats  map[int64]*SegmentStats       // map[SegmentID]SegmentStats
-	segmentIndex  map[int64]SegmentBelongs      // map[SegmentID]channels
-	pchannelIndex map[string]map[int64]struct{} // map[PChannel]SegmentID
-	sealOperators map[string]SealOperator
-	metricHelper  *metricsHelper
+	worker                     *sealWorker
+	mu                         sync.Mutex
+	cfg                        statsConfig
+	totalStats                 *aggregatedMetrics
+	pchannelStats              map[string]*aggregatedMetrics
+	vchannelStats              map[string]*aggregatedMetrics
+	segmentStats               map[int64]*SegmentStats       // map[SegmentID]SegmentStats
+	segmentIndex               map[int64]SegmentBelongs      // map[SegmentID]channels
+	pchannelIndex              map[string]map[int64]struct{} // map[PChannel]SegmentID
+	growingL1SegmentsByChannel map[channelKey]map[int64]struct{}
+	segmentDeletePressures     map[int64]deletePressure // map[SegmentID]aggregated delete pressure
+	sealOperators              map[string]SealOperator
+	metricHelper               *metricsHelper
+}
+
+type channelKey struct {
+	pchannel string
+	vchannel string
+}
+
+type deletePressure struct {
+	rows  uint64
+	bytes uint64
 }
 
 // sealSegmentIDWithPolicy is the struct that contains the segment ID and the seal policy.
@@ -59,16 +71,18 @@ func NewStatsManager() *StatsManager {
 		panic(err)
 	}
 	m := &StatsManager{
-		mu:            sync.Mutex{},
-		cfg:           cfg,
-		totalStats:    newAggregatedMetrics(),
-		pchannelStats: make(map[string]*aggregatedMetrics),
-		vchannelStats: make(map[string]*aggregatedMetrics),
-		segmentStats:  make(map[int64]*SegmentStats),
-		segmentIndex:  make(map[int64]SegmentBelongs),
-		pchannelIndex: make(map[string]map[int64]struct{}),
-		sealOperators: make(map[string]SealOperator),
-		metricHelper:  newMetricsHelper(),
+		mu:                         sync.Mutex{},
+		cfg:                        cfg,
+		totalStats:                 newAggregatedMetrics(),
+		pchannelStats:              make(map[string]*aggregatedMetrics),
+		vchannelStats:              make(map[string]*aggregatedMetrics),
+		segmentStats:               make(map[int64]*SegmentStats),
+		segmentIndex:               make(map[int64]SegmentBelongs),
+		pchannelIndex:              make(map[string]map[int64]struct{}),
+		growingL1SegmentsByChannel: make(map[channelKey]map[int64]struct{}),
+		segmentDeletePressures:     make(map[int64]deletePressure),
+		sealOperators:              make(map[string]SealOperator),
+		metricHelper:               newMetricsHelper(),
 	}
 	m.worker = newSealWorker(m)
 	go m.worker.loop()
@@ -156,6 +170,13 @@ func (m *StatsManager) registerNewGrowingSegment(belongs SegmentBelongs, stats *
 		m.pchannelIndex[belongs.PChannel] = make(map[int64]struct{})
 	}
 	m.pchannelIndex[belongs.PChannel][segmentID] = struct{}{}
+	if stats.Level == datapb.SegmentLevel_L1 {
+		key := channelKey{pchannel: belongs.PChannel, vchannel: belongs.VChannel}
+		if _, ok := m.growingL1SegmentsByChannel[key]; !ok {
+			m.growingL1SegmentsByChannel[key] = make(map[int64]struct{})
+		}
+		m.growingL1SegmentsByChannel[key][segmentID] = struct{}{}
+	}
 	m.totalStats.Collect(stats.Level, stats.Modified)
 	if _, ok := m.pchannelStats[belongs.PChannel]; !ok {
 		m.pchannelStats[belongs.PChannel] = newAggregatedMetrics()
@@ -221,6 +242,28 @@ func (m *StatsManager) allocRows(segmentID int64, insert ModifiedMetrics) (bool,
 		return false, ErrTooLargeInsert
 	}
 	return stat.ShouldBeSealed(), ErrNotEnoughSpace
+}
+
+// RecordDelete records local delete metrics on matching growing L1 segments.
+func (m *StatsManager) RecordDelete(pchannel string, vchannel string, timeTick uint64, rows uint64, bytes uint64) {
+	if pchannel == "" || vchannel == "" || timeTick == 0 || (rows == 0 && bytes == 0) {
+		return
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := channelKey{pchannel: pchannel, vchannel: vchannel}
+	for segmentID := range m.growingL1SegmentsByChannel[key] {
+		stat := m.segmentStats[segmentID]
+		if stat.CreateSegmentTimeTick == 0 || timeTick < stat.CreateSegmentTimeTick {
+			continue
+		}
+		pressure := m.segmentDeletePressures[segmentID]
+		pressure.rows += rows
+		pressure.bytes += bytes
+		m.segmentDeletePressures[segmentID] = pressure
+	}
 }
 
 // notifyIfTotalGrowingBytesOverHWM notifies if the total bytes is over the high water mark.
@@ -303,6 +346,14 @@ func (m *StatsManager) unregisterSealedSegment(segmentID int64) *SegmentStats {
 	m.totalStats.Subtract(stats.Level, stats.Modified)
 	delete(m.segmentStats, segmentID)
 	delete(m.segmentIndex, segmentID)
+	delete(m.segmentDeletePressures, segmentID)
+	if stats.Level == datapb.SegmentLevel_L1 {
+		key := channelKey{pchannel: info.PChannel, vchannel: info.VChannel}
+		delete(m.growingL1SegmentsByChannel[key], segmentID)
+		if len(m.growingL1SegmentsByChannel[key]) == 0 {
+			delete(m.growingL1SegmentsByChannel, key)
+		}
+	}
 	if _, ok := m.pchannelIndex[info.PChannel]; ok {
 		delete(m.pchannelIndex[info.PChannel], segmentID)
 		if len(m.pchannelIndex[info.PChannel]) == 0 {
@@ -353,6 +404,67 @@ func (m *StatsManager) selectSegmentsWithTimePolicy() map[int64]policy.SealPolic
 		}
 	}
 	return sealSegmentIDs
+}
+
+// selectSegmentsWithBlockingL0Policy selects the earliest L1 growing segment per vchannel
+// when local deletes blocked by that segment reach the configured threshold.
+func (m *StatsManager) selectSegmentsWithBlockingL0Policy() map[int64]policy.SealPolicy {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.cfg.blockingL0EntryNum < 0 && m.cfg.blockingL0SizeBytes < 0 {
+		return nil
+	}
+
+	type pressureScope struct {
+		pchannel string
+		vchannel string
+	}
+	type earliestSegment struct {
+		segmentID int64
+		timeTick  uint64
+	}
+
+	earliestByScope := make(map[pressureScope]earliestSegment)
+	for segmentID, stat := range m.segmentStats {
+		if stat.Level != datapb.SegmentLevel_L1 || stat.CreateSegmentTimeTick == 0 {
+			continue
+		}
+		belongs := m.segmentIndex[segmentID]
+		scope := pressureScope{
+			pchannel: belongs.PChannel,
+			vchannel: belongs.VChannel,
+		}
+		earliest, ok := earliestByScope[scope]
+		if !ok || stat.CreateSegmentTimeTick < earliest.timeTick {
+			earliestByScope[scope] = earliestSegment{
+				segmentID: segmentID,
+				timeTick:  stat.CreateSegmentTimeTick,
+			}
+		}
+	}
+
+	sealSegmentIDs := make(map[int64]policy.SealPolicy)
+	for _, earliest := range earliestByScope {
+		pressure := m.segmentDeletePressures[earliest.segmentID]
+		if m.reachBlockingL0Threshold(pressure.rows, pressure.bytes) {
+			sealSegmentIDs[earliest.segmentID] = policy.PolicyBlockingL0(pressure.rows, pressure.bytes, m.cfg.blockingL0EntryNum, m.cfg.blockingL0SizeBytes)
+		}
+	}
+	if len(sealSegmentIDs) == 0 {
+		return nil
+	}
+	return sealSegmentIDs
+}
+
+func (m *StatsManager) reachBlockingL0Threshold(rows uint64, bytes uint64) bool {
+	if m.cfg.blockingL0EntryNum >= 0 && rows >= uint64(m.cfg.blockingL0EntryNum) {
+		return true
+	}
+	if m.cfg.blockingL0SizeBytes >= 0 && bytes >= uint64(m.cfg.blockingL0SizeBytes) {
+		return true
+	}
+	return false
 }
 
 // selectSegmentsUntilLessThanLWM selects segments until the total size is less than the threshold.

--- a/internal/streamingnode/server/wal/interceptors/shard/stats/stats_manager_test.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/stats/stats_manager_test.go
@@ -9,9 +9,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 
 	"github.com/milvus-io/milvus/internal/mocks/streamingnode/server/wal/interceptors/shard/mock_utils"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/shard/policy"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/shard/utils"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/types"
@@ -240,6 +242,296 @@ func TestConcurrentStasManager(t *testing.T) {
 	assert.Empty(t, m.pchannelStats)
 	assert.Empty(t, m.segmentIndex)
 	assert.NotEmpty(t, m.sealOperators)
+}
+
+func TestStatsManagerSelectSegmentsWithBlockingL0PolicyRows(t *testing.T) {
+	paramtable.Init()
+	params := paramtable.Get()
+	params.Save(params.DataCoordCfg.BlockingL0EntryNum.Key, "100")
+	defer params.Reset(params.DataCoordCfg.BlockingL0EntryNum.Key)
+	params.Save(params.DataCoordCfg.BlockingL0SizeInMB.Key, "-1")
+	defer params.Reset(params.DataCoordCfg.BlockingL0SizeInMB.Key)
+
+	m := NewStatsManager()
+	m.cfg = newStatsConfig()
+
+	sealOperator := mock_utils.NewMockSealOperator(t)
+	sealOperator.EXPECT().Channel().Return(types.PChannelInfo{Name: "pchannel"}).Maybe()
+	sealOperator.EXPECT().AsyncFlushSegment(mock.Anything).Return().Maybe()
+	m.RegisterSealOperator(sealOperator, nil, nil)
+
+	segment10 := createSegmentStats(100, 100, 300)
+	segment10.CreateSegmentTimeTick = 100
+	m.RegisterNewGrowingSegment(SegmentBelongs{PChannel: "pchannel", VChannel: "vchannel", CollectionID: 1, PartitionID: 2, SegmentID: 10}, segment10)
+
+	segment11 := createSegmentStats(100, 100, 300)
+	segment11.CreateSegmentTimeTick = 200
+	m.RegisterNewGrowingSegment(SegmentBelongs{PChannel: "pchannel", VChannel: "vchannel", CollectionID: 1, PartitionID: 2, SegmentID: 11}, segment11)
+
+	m.RecordDelete("pchannel", "vchannel", 50, 1000, 10)
+	m.RecordDelete("pchannel", "vchannel", 120, 60, 10)
+	m.RecordDelete("pchannel", "vchannel", 140, 30, 10)
+
+	selected := m.selectSegmentsWithBlockingL0Policy()
+	require.Empty(t, selected)
+
+	m.RecordDelete("pchannel", "vchannel", 160, 10, 10)
+	selected = m.selectSegmentsWithBlockingL0Policy()
+
+	require.Len(t, selected, 1)
+	assert.Contains(t, selected, int64(10))
+	assert.Equal(t, policy.PolicyNameBlockingL0, selected[10].Policy)
+}
+
+func TestStatsManagerSelectSegmentsWithBlockingL0PolicySizeOnly(t *testing.T) {
+	paramtable.Init()
+	params := paramtable.Get()
+	params.Save(params.DataCoordCfg.BlockingL0EntryNum.Key, "-1")
+	defer params.Reset(params.DataCoordCfg.BlockingL0EntryNum.Key)
+	params.Save(params.DataCoordCfg.BlockingL0SizeInMB.Key, "1")
+	defer params.Reset(params.DataCoordCfg.BlockingL0SizeInMB.Key)
+
+	m := NewStatsManager()
+	m.cfg = newStatsConfig()
+
+	sealOperator := mock_utils.NewMockSealOperator(t)
+	sealOperator.EXPECT().Channel().Return(types.PChannelInfo{Name: "pchannel"}).Maybe()
+	sealOperator.EXPECT().AsyncFlushSegment(mock.Anything).Return().Maybe()
+	m.RegisterSealOperator(sealOperator, nil, nil)
+
+	segment10 := createSegmentStats(100, 100, 300)
+	segment10.CreateSegmentTimeTick = 100
+	m.RegisterNewGrowingSegment(SegmentBelongs{PChannel: "pchannel", VChannel: "vchannel", CollectionID: 1, PartitionID: 2, SegmentID: 10}, segment10)
+
+	m.RecordDelete("pchannel", "vchannel", 120, 0, 1024*1024)
+
+	selected := m.selectSegmentsWithBlockingL0Policy()
+
+	require.Len(t, selected, 1)
+	assert.Contains(t, selected, int64(10))
+	assert.Equal(t, policy.PolicyNameBlockingL0, selected[10].Policy)
+}
+
+func TestStatsManagerSelectSegmentsWithBlockingL0PolicyDisabled(t *testing.T) {
+	paramtable.Init()
+	params := paramtable.Get()
+	params.Save(params.DataCoordCfg.BlockingL0EntryNum.Key, "-1")
+	defer params.Reset(params.DataCoordCfg.BlockingL0EntryNum.Key)
+	params.Save(params.DataCoordCfg.BlockingL0SizeInMB.Key, "-1")
+	defer params.Reset(params.DataCoordCfg.BlockingL0SizeInMB.Key)
+
+	m := NewStatsManager()
+	m.cfg = newStatsConfig()
+
+	sealOperator := mock_utils.NewMockSealOperator(t)
+	sealOperator.EXPECT().Channel().Return(types.PChannelInfo{Name: "pchannel"}).Maybe()
+	sealOperator.EXPECT().AsyncFlushSegment(mock.Anything).Return().Maybe()
+	m.RegisterSealOperator(sealOperator, nil, nil)
+
+	segment10 := createSegmentStats(100, 100, 300)
+	segment10.CreateSegmentTimeTick = 100
+	m.RegisterNewGrowingSegment(SegmentBelongs{PChannel: "pchannel", VChannel: "vchannel", CollectionID: 1, PartitionID: 2, SegmentID: 10}, segment10)
+
+	m.RecordDelete("pchannel", "vchannel", 120, 1024*1024, 1024*1024*1024)
+
+	selected := m.selectSegmentsWithBlockingL0Policy()
+
+	require.Empty(t, selected)
+}
+
+func TestStatsManagerSelectSegmentsWithBlockingL0PolicySkipsUnknownCreateTimeTick(t *testing.T) {
+	paramtable.Init()
+	params := paramtable.Get()
+	params.Save(params.DataCoordCfg.BlockingL0EntryNum.Key, "100")
+	defer params.Reset(params.DataCoordCfg.BlockingL0EntryNum.Key)
+	params.Save(params.DataCoordCfg.BlockingL0SizeInMB.Key, "-1")
+	defer params.Reset(params.DataCoordCfg.BlockingL0SizeInMB.Key)
+
+	m := NewStatsManager()
+	m.cfg = newStatsConfig()
+
+	sealOperator := mock_utils.NewMockSealOperator(t)
+	sealOperator.EXPECT().Channel().Return(types.PChannelInfo{Name: "pchannel"}).Maybe()
+	sealOperator.EXPECT().AsyncFlushSegment(mock.Anything).Return().Maybe()
+	m.RegisterSealOperator(sealOperator, nil, nil)
+
+	segment10 := createSegmentStats(100, 100, 300)
+	segment10.CreateSegmentTimeTick = 0
+	m.RegisterNewGrowingSegment(SegmentBelongs{PChannel: "pchannel", VChannel: "vchannel", CollectionID: 1, PartitionID: 2, SegmentID: 10}, segment10)
+
+	segment11 := createSegmentStats(100, 100, 300)
+	segment11.CreateSegmentTimeTick = 100
+	m.RegisterNewGrowingSegment(SegmentBelongs{PChannel: "pchannel", VChannel: "vchannel", CollectionID: 1, PartitionID: 2, SegmentID: 11}, segment11)
+
+	m.RecordDelete("pchannel", "vchannel", 50, 1000, 1)
+	m.RecordDelete("pchannel", "vchannel", 120, 100, 1)
+
+	selected := m.selectSegmentsWithBlockingL0Policy()
+
+	require.Len(t, selected, 1)
+	assert.NotContains(t, selected, int64(10))
+	assert.Contains(t, selected, int64(11))
+	assert.Equal(t, policy.PolicyNameBlockingL0, selected[11].Policy)
+}
+
+func TestStatsManagerAdvanceDeleteWindowOnUnregister(t *testing.T) {
+	paramtable.Init()
+
+	m := NewStatsManager()
+
+	sealOperator := mock_utils.NewMockSealOperator(t)
+	sealOperator.EXPECT().Channel().Return(types.PChannelInfo{Name: "pchannel"}).Maybe()
+	sealOperator.EXPECT().AsyncFlushSegment(mock.Anything).Return().Maybe()
+	m.RegisterSealOperator(sealOperator, nil, nil)
+
+	segment10 := createSegmentStats(100, 100, 300)
+	segment10.CreateSegmentTimeTick = 100
+	m.RegisterNewGrowingSegment(SegmentBelongs{PChannel: "pchannel", VChannel: "vchannel", CollectionID: 1, PartitionID: 2, SegmentID: 10}, segment10)
+
+	segment11 := createSegmentStats(100, 100, 300)
+	segment11.CreateSegmentTimeTick = 200
+	m.RegisterNewGrowingSegment(SegmentBelongs{PChannel: "pchannel", VChannel: "vchannel", CollectionID: 1, PartitionID: 2, SegmentID: 11}, segment11)
+
+	m.RecordDelete("pchannel", "vchannel", 120, 1, 10)
+	m.RecordDelete("pchannel", "vchannel", 220, 1, 10)
+
+	m.UnregisterSealedSegment(10)
+
+	assert.NotContains(t, m.segmentDeletePressures, int64(10))
+	require.Contains(t, m.segmentDeletePressures, int64(11))
+	assert.Equal(t, deletePressure{rows: 1, bytes: 10}, m.segmentDeletePressures[11])
+}
+
+func TestStatsManagerClearDeleteWindowWhenNoGrowingL1(t *testing.T) {
+	paramtable.Init()
+
+	m := NewStatsManager()
+
+	sealOperator := mock_utils.NewMockSealOperator(t)
+	sealOperator.EXPECT().Channel().Return(types.PChannelInfo{Name: "pchannel"}).Maybe()
+	sealOperator.EXPECT().AsyncFlushSegment(mock.Anything).Return().Maybe()
+	m.RegisterSealOperator(sealOperator, nil, nil)
+
+	segment10 := createSegmentStats(100, 100, 300)
+	segment10.CreateSegmentTimeTick = 100
+	m.RegisterNewGrowingSegment(SegmentBelongs{PChannel: "pchannel", VChannel: "vchannel", CollectionID: 1, PartitionID: 2, SegmentID: 10}, segment10)
+
+	m.RecordDelete("pchannel", "vchannel", 120, 1, 10)
+
+	m.UnregisterSealedSegment(10)
+
+	assert.Empty(t, m.segmentDeletePressures)
+}
+
+func TestStatsManagerClearDeleteWindowOnUnregisterSealOperatorWithoutL1(t *testing.T) {
+	paramtable.Init()
+
+	m := NewStatsManager()
+
+	sealOperator := mock_utils.NewMockSealOperator(t)
+	sealOperator.EXPECT().Channel().Return(types.PChannelInfo{Name: "pchannel"}).Maybe()
+	sealOperator.EXPECT().AsyncFlushSegment(mock.Anything).Return().Maybe()
+	m.RegisterSealOperator(sealOperator, nil, nil)
+
+	segment10 := createSegmentStats(100, 100, 300)
+	segment10.Level = datapb.SegmentLevel_L0
+	m.RegisterNewGrowingSegment(SegmentBelongs{PChannel: "pchannel", VChannel: "vchannel", CollectionID: 1, PartitionID: 2, SegmentID: 10}, segment10)
+
+	m.RecordDelete("pchannel", "vchannel", 120, 1, 10)
+
+	m.UnregisterSealOperator(sealOperator)
+
+	assert.Empty(t, m.segmentDeletePressures)
+}
+
+func TestStatsManagerBlockingL0PolicyScopesDeletePressureByPChannel(t *testing.T) {
+	paramtable.Init()
+	params := paramtable.Get()
+	params.Save(params.DataCoordCfg.BlockingL0EntryNum.Key, "100")
+	defer params.Reset(params.DataCoordCfg.BlockingL0EntryNum.Key)
+	params.Save(params.DataCoordCfg.BlockingL0SizeInMB.Key, "-1")
+	defer params.Reset(params.DataCoordCfg.BlockingL0SizeInMB.Key)
+
+	m := NewStatsManager()
+	m.cfg = newStatsConfig()
+
+	sealOperator1 := mock_utils.NewMockSealOperator(t)
+	sealOperator1.EXPECT().Channel().Return(types.PChannelInfo{Name: "pchannel1"}).Maybe()
+	sealOperator1.EXPECT().AsyncFlushSegment(mock.Anything).Return().Maybe()
+	m.RegisterSealOperator(sealOperator1, nil, nil)
+
+	sealOperator2 := mock_utils.NewMockSealOperator(t)
+	sealOperator2.EXPECT().Channel().Return(types.PChannelInfo{Name: "pchannel2"}).Maybe()
+	sealOperator2.EXPECT().AsyncFlushSegment(mock.Anything).Return().Maybe()
+	m.RegisterSealOperator(sealOperator2, nil, nil)
+
+	segment10 := createSegmentStats(100, 100, 300)
+	segment10.CreateSegmentTimeTick = 100
+	m.RegisterNewGrowingSegment(SegmentBelongs{PChannel: "pchannel1", VChannel: "vchannel", CollectionID: 1, PartitionID: 2, SegmentID: 10}, segment10)
+
+	segment20 := createSegmentStats(100, 100, 300)
+	segment20.CreateSegmentTimeTick = 100
+	m.RegisterNewGrowingSegment(SegmentBelongs{PChannel: "pchannel2", VChannel: "vchannel", CollectionID: 1, PartitionID: 2, SegmentID: 20}, segment20)
+
+	m.RecordDelete("pchannel1", "vchannel", 120, 100, 1)
+	selected := m.selectSegmentsWithBlockingL0Policy()
+
+	require.Len(t, selected, 1)
+	assert.Contains(t, selected, int64(10))
+	assert.NotContains(t, selected, int64(20))
+}
+
+func TestStatsManagerRecordDeleteWithoutGrowingL1DoesNotCreateOrphanPressure(t *testing.T) {
+	paramtable.Init()
+
+	m := NewStatsManager()
+
+	sealOperator := mock_utils.NewMockSealOperator(t)
+	sealOperator.EXPECT().Channel().Return(types.PChannelInfo{Name: "pchannel"}).Maybe()
+	sealOperator.EXPECT().AsyncFlushSegment(mock.Anything).Return().Maybe()
+	m.RegisterSealOperator(sealOperator, nil, nil)
+
+	m.RecordDelete("pchannel", "vchannel", 120, 1, 10)
+	assert.Empty(t, m.segmentDeletePressures)
+
+	m.UnregisterSealOperator(sealOperator)
+	assert.Empty(t, m.segmentDeletePressures)
+}
+
+func TestStatsManagerIndexesGrowingL1SegmentsByChannel(t *testing.T) {
+	paramtable.Init()
+
+	m := NewStatsManager()
+
+	sealOperator := mock_utils.NewMockSealOperator(t)
+	sealOperator.EXPECT().Channel().Return(types.PChannelInfo{Name: "pchannel"}).Maybe()
+	sealOperator.EXPECT().AsyncFlushSegment(mock.Anything).Return().Maybe()
+	m.RegisterSealOperator(sealOperator, nil, nil)
+
+	segment10 := createSegmentStats(100, 100, 300)
+	segment10.CreateSegmentTimeTick = 100
+	m.RegisterNewGrowingSegment(SegmentBelongs{PChannel: "pchannel", VChannel: "vchannel", CollectionID: 1, PartitionID: 2, SegmentID: 10}, segment10)
+
+	segment11 := createSegmentStats(100, 100, 300)
+	segment11.CreateSegmentTimeTick = 100
+	m.RegisterNewGrowingSegment(SegmentBelongs{PChannel: "pchannel", VChannel: "vchannel2", CollectionID: 1, PartitionID: 2, SegmentID: 11}, segment11)
+
+	segment12 := createSegmentStats(100, 100, 300)
+	segment12.Level = datapb.SegmentLevel_L0
+	m.RegisterNewGrowingSegment(SegmentBelongs{PChannel: "pchannel", VChannel: "vchannel", CollectionID: 1, PartitionID: 2, SegmentID: 12}, segment12)
+
+	key := channelKey{pchannel: "pchannel", vchannel: "vchannel"}
+	require.Contains(t, m.growingL1SegmentsByChannel, key)
+	assert.Contains(t, m.growingL1SegmentsByChannel[key], int64(10))
+	assert.NotContains(t, m.growingL1SegmentsByChannel[key], int64(12))
+
+	m.RecordDelete("pchannel", "vchannel", 120, 1, 10)
+	assert.Equal(t, deletePressure{rows: 1, bytes: 10}, m.segmentDeletePressures[10])
+	assert.NotContains(t, m.segmentDeletePressures, int64(11))
+	assert.NotContains(t, m.segmentDeletePressures, int64(12))
+
+	m.UnregisterSealedSegment(10)
+	assert.NotContains(t, m.growingL1SegmentsByChannel, key)
 }
 
 func createSegmentStats(row uint64, binarySize uint64, maxBinarSize uint64) *SegmentStats {

--- a/internal/streamingnode/server/wal/interceptors/shard/stats/stats_seal_worker.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/stats/stats_seal_worker.go
@@ -82,6 +82,7 @@ func (m *sealWorker) loop() {
 		case <-timer.C:
 			m.statsManager.updateConfig()
 			m.notifyToSealSegmentWithTimePolicy()
+			m.notifyToSealSegmentWithBlockingL0Policy()
 		case policy := <-memoryNotifier:
 			m.statsManager.updateConfig()
 			m.notifyToSealSegmentUntilLessThanLWM(policy)
@@ -97,6 +98,17 @@ func (m *sealWorker) notifyToSealSegmentWithTimePolicy() {
 	sealSegmentIDs := m.statsManager.selectSegmentsWithTimePolicy()
 	if len(sealSegmentIDs) != 0 {
 		m.Logger().Info("notify to seal segments with time policy", zap.Int("segmentNum", len(sealSegmentIDs)))
+		for segmentID, sealPolicy := range sealSegmentIDs {
+			m.asyncMustSealSegment(segmentID, sealPolicy)
+		}
+	}
+}
+
+// notifyToSealSegmentWithBlockingL0Policy notifies to seal segments with blocking l0 policy.
+func (m *sealWorker) notifyToSealSegmentWithBlockingL0Policy() {
+	sealSegmentIDs := m.statsManager.selectSegmentsWithBlockingL0Policy()
+	if len(sealSegmentIDs) != 0 {
+		m.Logger().Info("notify to seal segments with blocking l0 policy", zap.Int("segmentNum", len(sealSegmentIDs)))
 		for segmentID, sealPolicy := range sealSegmentIDs {
 			m.asyncMustSealSegment(segmentID, sealPolicy)
 		}

--- a/internal/streamingnode/server/wal/interceptors/shard/utils/stats.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/utils/stats.go
@@ -40,15 +40,16 @@ func (s *SegmentBelongs) PartitionUniqueKey() PartitionUniqueKey {
 
 // SegmentStats is the usage stats of a segment.
 type SegmentStats struct {
-	Modified          ModifiedMetrics
-	MaxRows           uint64    // MaxRows of current segment should be assigned, it's a fixed value when segment is transfer int growing.
-	MaxBinarySize     uint64    // MaxBinarySize of current segment should be assigned, it's a fixed value when segment is transfer int growing.
-	CreateTime        time.Time // created timestamp of this segment, it's a fixed value when segment is created, not a tso.
-	LastModifiedTime  time.Time // LastWriteTime is the last write time of this segment, it's not a tso, just a local time.
-	BinLogCounter     uint64    // BinLogCounter is the counter of binlog (equal to the binlog file count of primary key), it's an async stat not real time.
-	BinLogFileCounter uint64    // BinLogFileCounter is the counter of binlog files, it's an async stat not real time.
-	ReachLimit        bool      // ReachLimit is a flag to indicate the segment reach the limit once.
-	Level             datapb.SegmentLevel
+	Modified              ModifiedMetrics
+	MaxRows               uint64    // MaxRows of current segment should be assigned, it's a fixed value when segment is transfer int growing.
+	MaxBinarySize         uint64    // MaxBinarySize of current segment should be assigned, it's a fixed value when segment is transfer int growing.
+	CreateTime            time.Time // created timestamp of this segment, it's a fixed value when segment is created, not a tso.
+	LastModifiedTime      time.Time // LastWriteTime is the last write time of this segment, it's not a tso, just a local time.
+	CreateSegmentTimeTick uint64
+	BinLogCounter         uint64 // BinLogCounter is the counter of binlog (equal to the binlog file count of primary key), it's an async stat not real time.
+	BinLogFileCounter     uint64 // BinLogFileCounter is the counter of binlog files, it's an async stat not real time.
+	ReachLimit            bool   // ReachLimit is a flag to indicate the segment reach the limit once.
+	Level                 datapb.SegmentLevel
 }
 
 // NewSegmentStatFromProto creates a new segment assignment stat from proto.
@@ -72,12 +73,13 @@ func NewSegmentStatFromProto(statProto *streamingpb.SegmentAssignmentStat) *Segm
 			Rows:       statProto.ModifiedRows,
 			BinarySize: statProto.ModifiedBinarySize,
 		},
-		MaxRows:          maxRows,
-		MaxBinarySize:    statProto.MaxBinarySize,
-		CreateTime:       time.Unix(statProto.CreateTimestamp, 0),
-		BinLogCounter:    statProto.BinlogCounter,
-		LastModifiedTime: time.Unix(statProto.LastModifiedTimestamp, 0),
-		Level:            lv,
+		MaxRows:               maxRows,
+		MaxBinarySize:         statProto.MaxBinarySize,
+		CreateTime:            time.Unix(statProto.CreateTimestamp, 0),
+		CreateSegmentTimeTick: statProto.CreateSegmentTimeTick,
+		BinLogCounter:         statProto.BinlogCounter,
+		LastModifiedTime:      time.Unix(statProto.LastModifiedTimestamp, 0),
+		Level:                 lv,
 	}
 }
 
@@ -92,6 +94,7 @@ func NewProtoFromSegmentStat(stat *SegmentStats) *streamingpb.SegmentAssignmentS
 		ModifiedRows:          stat.Modified.Rows,
 		ModifiedBinarySize:    stat.Modified.BinarySize,
 		CreateTimestamp:       stat.CreateTime.Unix(),
+		CreateSegmentTimeTick: stat.CreateSegmentTimeTick,
 		BinlogCounter:         stat.BinLogCounter,
 		LastModifiedTimestamp: stat.LastModifiedTime.Unix(),
 		Level:                 stat.Level,

--- a/internal/streamingnode/server/wal/interceptors/shard/utils/stats_test.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/utils/stats_test.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/pkg/v2/proto/streamingpb"
 )
 
 func TestStatsConvention(t *testing.T) {
@@ -61,6 +63,18 @@ func TestStatsConvention(t *testing.T) {
 
 	stat4 := NewSegmentStatFromProto(nil)
 	assert.Nil(t, stat4)
+}
+
+func TestNewSegmentStatFromProtoPreservesCreateSegmentTimeTick(t *testing.T) {
+	pb := &streamingpb.SegmentAssignmentStat{
+		CreateSegmentTimeTick: 10086,
+	}
+
+	stat := NewSegmentStatFromProto(pb)
+	assert.Equal(t, uint64(10086), stat.CreateSegmentTimeTick)
+
+	roundTrip := NewProtoFromSegmentStat(stat)
+	assert.Equal(t, uint64(10086), roundTrip.GetCreateSegmentTimeTick())
 }
 
 func TestSegmentStats(t *testing.T) {


### PR DESCRIPTION
Cherry-pick from master (PR still open)

pr: #49653
issue: #49647

## Summary

Cherry-picked from master PR #49653 (open - preemptive backport)

**Note**: Original PR is still open. This CP PR should be updated if the original PR changes.

## Verification

- [x] File count and line count match original PR
- [x] Code changes verified against master PR diff; branch-specific imports normalized from `pkg/v3` to `pkg/v2`
- [x] No conflict markers
- [x] Focused tests passed: `go test ./internal/streamingnode/server/wal/interceptors/shard/utils ./internal/streamingnode/server/wal/interceptors/shard/policy ./internal/streamingnode/server/wal/interceptors/shard/stats -count=1`
- [ ] `make static-check` could not complete locally: existing C++ pkg-config artifacts are missing/stale for release worktree; initial rerun also hit parallel `golangci-lint` guard
