### PR TITLE
fix: strip UTF-8 BOM from analyzer word files

### DIFF
--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/filter/stop_word_filter.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/filter/stop_word_filter.rs
@@ -2,7 +2,7 @@ use super::filter::FilterBuilder;
 use super::stop_words::fetch_language_stop_words;
 use super::util::*;
 use crate::analyzer::options::FileResourcePathHelper;
-use crate::error::{Result, TantivyBindingError};
+use crate::error::Result;
 use serde_json as json;
 use tantivy::tokenizer::StopWordFilter;
 
@@ -97,5 +97,40 @@ mod tests {
                 .collect::<HashSet<&str>>(),
             HashSet::from(["simple", "test", "stop", "words", "filter", "indexing", "system"])
         );
+    }
+
+    #[test]
+    fn test_stop_words_filter_with_utf8_bom_and_crlf_file() {
+        init_log();
+        let dir = tempfile::tempdir().unwrap();
+        let stop_words_path = dir.path().join("stop_words.txt");
+        std::fs::write(&stop_words_path, b"\xEF\xBB\xBFthe\r\nand\r\n").unwrap();
+        let stop_words_path_str = stop_words_path.to_string_lossy().to_string();
+        let params = format!(
+            r#"{{
+                "type": "stop_words",
+                "stop_words_file": {{
+                    "type": "local",
+                    "path": "{stop_words_path_str}"
+                }}
+            }}"#
+        );
+
+        let json_params = json::from_str::<json::Value>(&params).unwrap();
+        let mut helper = FileResourcePathHelper::new(Arc::new(ResourceInfo::new()));
+        let filter = StopWordFilter::from_json(json_params.as_object().unwrap(), &mut helper);
+        assert!(filter.is_ok(), "error: {}", filter.err().unwrap());
+
+        let builder = standard_builder().filter(filter.unwrap());
+        let mut analyzer = builder.build();
+        let mut stream = analyzer.token_stream("the quick and steady");
+
+        let mut results = Vec::<String>::new();
+        while stream.advance() {
+            let token = stream.token();
+            results.push(token.text.clone());
+        }
+
+        assert_eq!(results, vec!["quick".to_string(), "steady".to_string()]);
     }
 }

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/filter/util.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/filter/util.rs
@@ -35,16 +35,47 @@ pub(crate) fn read_line_file(
     let path = get_resource_path(helper, params, key)?;
     let file = std::fs::File::open(path)?;
     let reader = std::io::BufReader::new(file);
-    for line in reader.lines() {
-        if let Ok(row_data) = line {
-            dict.push(row_data);
-        } else {
-            return Err(TantivyBindingError::InternalError(format!(
+    for (line_index, line) in reader.lines().enumerate() {
+        let mut row_data = line.map_err(|err| {
+            TantivyBindingError::InternalError(format!(
                 "read {} file failed, error: {}",
                 key,
-                line.unwrap_err().to_string()
-            )));
+                err.to_string()
+            ))
+        })?;
+        if line_index == 0 {
+            row_data = row_data
+                .strip_prefix('\u{feff}')
+                .unwrap_or(&row_data)
+                .to_string();
         }
+        dict.push(row_data);
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::read_line_file;
+    use crate::analyzer::options::{FileResourcePathHelper, ResourceInfo};
+    use serde_json as json;
+    use std::sync::Arc;
+
+    #[test]
+    fn test_read_line_file_strips_utf8_bom_from_first_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("stop_words.txt");
+        std::fs::write(&file_path, b"\xEF\xBB\xBFthe\r\nand\r\n").unwrap();
+
+        let params = json::json!({
+            "type": "local",
+            "path": file_path.to_string_lossy()
+        });
+        let mut helper = FileResourcePathHelper::new(Arc::new(ResourceInfo::new()));
+        let mut dict = Vec::new();
+
+        read_line_file(&mut helper, &mut dict, &params, "test dict file").unwrap();
+
+        assert_eq!(dict, vec!["the".to_string(), "and".to_string()]);
+    }
 }


### PR DESCRIPTION
relate: #49684

## Summary
Strip a UTF-8 BOM from the first line when loading analyzer word files so BOM-prefixed stop words are matched correctly. Add coverage for BOM + CRLF stop word files.