### PR TITLE
fix: stabilize wal recovery alter wal path

### DIFF
--- a/internal/streamingnode/server/wal/adaptor/opener.go
+++ b/internal/streamingnode/server/wal/adaptor/opener.go
@@ -318,10 +318,11 @@ func (o *openerAdaptorImpl) handleAlterWALFlushingStage(ctx context.Context, opt
 		f.Set(roWAL)
 		roWAL.ForceRecovery(true)
 		flusher = flusherimpl.RecoverWALFlusher(&flusherimpl.RecoverWALFlusherParam{
-			WAL:              f,
-			RecoveryStorage:  rs,
-			ChannelInfo:      roWAL.Channel(),
-			RecoverySnapshot: snapshot,
+			WAL:                f,
+			RecoveryStorage:    rs,
+			ChannelInfo:        roWAL.Channel(),
+			RecoverySnapshot:   snapshot,
+			RateLimitComponent: roWAL.WALRateLimitComponent,
 		})
 	}
 

--- a/internal/streamingnode/server/wal/adaptor/opener.go
+++ b/internal/streamingnode/server/wal/adaptor/opener.go
@@ -318,11 +318,10 @@ func (o *openerAdaptorImpl) handleAlterWALFlushingStage(ctx context.Context, opt
 		f.Set(roWAL)
 		roWAL.ForceRecovery(true)
 		flusher = flusherimpl.RecoverWALFlusher(&flusherimpl.RecoverWALFlusherParam{
-			WAL:                f,
-			RecoveryStorage:    rs,
-			ChannelInfo:        roWAL.Channel(),
-			RecoverySnapshot:   snapshot,
-			RateLimitComponent: roWAL.WALRateLimitComponent,
+			WAL:              f,
+			RecoveryStorage:  rs,
+			ChannelInfo:      roWAL.Channel(),
+			RecoverySnapshot: snapshot,
 		})
 	}
 

--- a/internal/streamingnode/server/wal/adaptor/wal_test.go
+++ b/internal/streamingnode/server/wal/adaptor/wal_test.go
@@ -54,6 +54,7 @@ func TestFencedError(t *testing.T) {
 }
 
 func TestWAL(t *testing.T) {
+	walimplstest.Reset()
 	initResourceForTest(t)
 	b := registry.MustGetBuilder(message.WALNameTest,
 		redo.NewInterceptorBuilder(),
@@ -178,9 +179,9 @@ func (f *testOneWALFramework) Run() {
 			MustBuildMutable()
 
 		result, err := rwWAL.Append(ctx, createMsg)
+		walimplstest.DisableFenced(pChannel.Name)
 		require.Nil(f.t, result)
 		require.True(f.t, status.AsStreamingError(err).IsFenced())
-		walimplstest.DisableFenced(pChannel.Name)
 		rwWAL.Close()
 	}
 }

--- a/pkg/streaming/walimpls/impls/walimplstest/wal.go
+++ b/pkg/streaming/walimpls/impls/walimplstest/wal.go
@@ -24,6 +24,13 @@ var (
 	enableFenceError                   = atomic.NewBool(true)
 )
 
+// Reset clears global state of the in-memory WAL test implementation.
+func Reset() {
+	logs = typeutil.NewConcurrentMap[string, *messageLog]()
+	fenced = typeutil.NewConcurrentSet[string]()
+	enableFenceError.Store(true)
+}
+
 // EnableFenced enables fenced mode for the given channel.
 func EnableFenced(channel string) {
 	fenced.Insert(channel)
@@ -50,7 +57,7 @@ func (w *walImpls) Append(ctx context.Context, msg message.MutableMessage) (mess
 	if fenced.Contain(w.Channel().Name) {
 		return nil, errors.Mark(errors.New("err"), walimpls.ErrFenced)
 	}
-	if enableFenceError.Load() && rand.Int31n(30) == 0 {
+	if enableFenceError.Load() && msg.MessageType() != message.MessageTypeTimeTick && rand.Int31n(30) == 0 {
 		return nil, errors.New("random error")
 	}
 	return w.datas.Append(ctx, msg)


### PR DESCRIPTION
issue: #49634
pr: #49696

Backport WAL recovery fast-fail follow-up fixes and related WAL test stabilization.