### PR TITLE
fix: avoid panic for non-point WKT validation

### DIFF
--- a/internal/parser/planparserv2/utils.go
+++ b/internal/parser/planparserv2/utils.go
@@ -868,7 +868,7 @@ func checkValidPoint(wktStr string) error {
 	if err != nil {
 		return err
 	}
-	if g.(*geom.Point) == nil {
+	if _, ok := g.(*geom.Point); !ok {
 		return fmt.Errorf("only supports POINT geometry: %s", wktStr)
 	}
 	return nil

--- a/internal/parser/planparserv2/utils_test.go
+++ b/internal/parser/planparserv2/utils_test.go
@@ -1029,6 +1029,12 @@ func Test_checkValidPoint(t *testing.T) {
 		err := checkValidPoint("POINT( 1  2 )")
 		assert.NoError(t, err)
 	})
+
+	t.Run("valid non-point WKT", func(t *testing.T) {
+		err := checkValidPoint("POLYGON((0 0, 1 0, 1 1, 0 0))")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "only supports POINT geometry")
+	})
 }
 
 // Test_convertHanToASCII_FastPath tests the Chinese character to Unicode escape conversion


### PR DESCRIPTION
relate: #49692

## Summary
Return a validation error instead of panicking when ST_DWITHIN point validation receives valid non-POINT WKT. Add coverage for POLYGON WKT passed to checkValidPoint.