### PR TITLE
fix: [3.0] harden scalar v3 index load paths

### DIFF
--- a/internal/core/src/index/StringIndexMarisa.cpp
+++ b/internal/core/src/index/StringIndexMarisa.cpp
@@ -40,6 +40,7 @@
 #include "common/Types.h"
 #include "common/Utils.h"
 #include "fmt/core.h"
+#include "folly/ScopeGuard.h"
 #include "index/Meta.h"
 #include "index/StringIndexMarisa.h"
 #include "index/Utils.h"
@@ -731,6 +732,7 @@ StringIndexMarisa::WriteEntries(storage::IndexEntryWriter* writer) {
                    O_RDWR | O_CREAT | O_EXCL | O_CLOEXEC,
                    S_IRUSR | S_IWUSR | S_IXUSR);
     AssertInfo(fd != -1, "open file failed: {}", file);
+    auto close_fd = folly::makeGuard([fd]() { close(fd); });
 
     // Immediately unlink the file so it will be deleted when fd is closed,
     // even if an exception occurs or the process crashes
@@ -741,8 +743,6 @@ StringIndexMarisa::WriteEntries(storage::IndexEntryWriter* writer) {
     auto size = get_file_size(fd);
     lseek(fd, 0, SEEK_SET);
     writer->WriteEntry(MARISA_TRIE_INDEX, fd, size);
-
-    close(fd);
 
     // Write str_ids
     auto str_ids_len = str_ids_.size() * sizeof(size_t);

--- a/internal/core/src/index/StringIndexSort.cpp
+++ b/internal/core/src/index/StringIndexSort.cpp
@@ -563,6 +563,11 @@ StringIndexSort::LoadEntries(storage::IndexEntryReader& reader,
     idx_to_offsets_.resize(total_num_rows_);
 
     auto valid_bitset_entry = reader.ReadEntry("valid_bitset");
+    auto expected_valid_bitset_size = (total_num_rows_ + 7) / 8;
+    AssertInfo(valid_bitset_entry.data.size() >= expected_valid_bitset_size,
+               "invalid valid_bitset size: expected at least {}, got {}",
+               expected_valid_bitset_size,
+               valid_bitset_entry.data.size());
     valid_bitset_ = TargetBitmap(total_num_rows_, false);
     for (size_t i = 0; i < total_num_rows_; ++i) {
         uint8_t byte = valid_bitset_entry.data[i / 8];

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -2926,6 +2926,7 @@ ChunkedSegmentSealedImpl::LoadTextIndex(
     config[milvus::index::INDEX_FILES] = files;
     config[milvus::LOAD_PRIORITY] = info_proto->load_priority();
     config[milvus::index::ENABLE_MMAP] = info_proto->enable_mmap();
+    config[milvus::index::COLLECTION_ID] = info_proto->collectionid();
     if (info_proto->warmup_policy() != "") {
         config[milvus::index::WARMUP] = info_proto->warmup_policy();
     }

--- a/internal/core/src/storage/IndexEntryEncryptedLocalWriter.cpp
+++ b/internal/core/src/storage/IndexEntryEncryptedLocalWriter.cpp
@@ -28,6 +28,7 @@
 #include <boost/uuid/uuid_io.hpp>
 
 #include "common/EasyAssert.h"
+#include "folly/ScopeGuard.h"
 #include "nlohmann/json.hpp"
 #include "storage/Crc32cUtil.h"
 #include "storage/RemoteOutputStream.h"
@@ -253,9 +254,10 @@ IndexEntryEncryptedLocalWriter::Finish() {
     total_bytes_written_ = MILVUS_V3_MAGIC_SIZE + current_offset_ +
                            dir_str.size() + MILVUS_V3_FOOTER_SIZE;
 
+    auto cleanup_local_file =
+        folly::makeGuard([this]() { ::unlink(local_path_.c_str()); });
     UploadLocalFile();
 
-    ::unlink(local_path_.c_str());
     finished_ = true;
 }
 
@@ -271,6 +273,7 @@ IndexEntryEncryptedLocalWriter::UploadLocalFile() {
     int read_fd = ::open(local_path_.c_str(), O_RDONLY);
     AssertInfo(
         read_fd != -1, "Failed to open local file for upload: {}", local_path_);
+    auto close_read_fd = folly::makeGuard([read_fd]() { ::close(read_fd); });
 
     constexpr size_t kBufSize = 16 * 1024 * 1024;
     std::vector<char> buf(kBufSize);
@@ -284,14 +287,12 @@ IndexEntryEncryptedLocalWriter::UploadLocalFile() {
             if (errno == EINTR) {
                 continue;
             }
-            ::close(read_fd);
             ThrowInfo(ErrorCode::UnexpectedError,
                       fmt::format("Failed to read local file {}: {}",
                                   local_path_,
                                   strerror(errno)));
         }
     }
-    ::close(read_fd);
     remote_stream->Close();
 }
 

--- a/internal/core/src/storage/IndexEntryReader.cpp
+++ b/internal/core/src/storage/IndexEntryReader.cpp
@@ -300,7 +300,7 @@ IndexEntryReader::ReadEncryptedEntry(const EntryMeta& meta) {
         cur_output_offset += plain_len;
 
         futures.push_back(
-            pool.Submit([this, &slice, dest, this_output_offset, plain_len]() {
+            pool.Submit([this, slice, dest, this_output_offset, plain_len]() {
                 std::vector<uint8_t> cipher(slice.size);
                 size_t n = input_->ReadAt(cipher.data(),
                                           MILVUS_V3_MAGIC_SIZE + slice.offset,

--- a/internal/util/segcore/segment.go
+++ b/internal/util/segcore/segment.go
@@ -580,13 +580,14 @@ func convertTextIndexStats(src map[int64]*datapb.TextIndexStats, basePaths map[i
 		)
 
 		result[k] = &segcorepb.TextIndexStats{
-			FieldID:    v.GetFieldID(),
-			Version:    v.GetVersion(),
-			Files:      files,
-			LogSize:    v.GetLogSize(),
-			MemorySize: v.GetMemorySize(),
-			BuildID:    v.GetBuildID(),
-			BasePath:   basePath,
+			FieldID:                   v.GetFieldID(),
+			Version:                   v.GetVersion(),
+			Files:                     files,
+			LogSize:                   v.GetLogSize(),
+			MemorySize:                v.GetMemorySize(),
+			BuildID:                   v.GetBuildID(),
+			CurrentScalarIndexVersion: v.GetCurrentScalarIndexVersion(),
+			BasePath:                  basePath,
 		}
 	}
 	return result


### PR DESCRIPTION
## What

Cherry-pick scalar index V3 load-path hardening from #49652 to the 3.0 branch.

This includes:

- passing collection id when loading V3 text indexes
- propagating `CurrentScalarIndexVersion` through text index stats conversion
- cleaning encrypted V3 writer temp files and upload read fds on exception paths
- closing the Marisa trie temp fd on exception paths
- validating string sort V3 valid-bitset entry size before reading
- capturing encrypted entry slices by value in async reads

Cherry-picked from `8af1f2a8011bf79b48cda9aef5f1c43099e67924`.

## Validation

- `git diff --check HEAD~1..HEAD`
- `make fmt`

`go test ./internal/util/segcore -count=1` did not reach tests in the local cgo environment: `C.executor_set_load_thread_num` and `C.executor_set_search_thread_num` could not be resolved.

pr: https://github.com/milvus-io/milvus/pull/49652
issue: #47417