### PR TITLE
fix: use default filesystem for JSON stats load

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -3044,8 +3044,7 @@ ChunkedSegmentSealedImpl::LoadJsonKeyIndex(
     auto remote_chunk_manager =
         milvus::storage::RemoteChunkManagerSingleton::GetInstance()
             .GetRemoteChunkManager();
-    auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
-                  .GetArrowFileSystem();
+    auto fs = milvus::segcore::GetDefaultArrowFileSystem();
     AssertInfo(fs != nullptr, "arrow file system is null");
 
     milvus::Config config;


### PR DESCRIPTION
Related to #49592 #49521

Branching introduced by those two PRs.

Resolve the Arrow filesystem for JSON stats loading through the shared segcore default filesystem helper, matching the rest of sealed segment load paths and avoiding reliance on the legacy ArrowFileSystemSingleton.