### PR TITLE
enhance: [3.0] support field ops in REST upsert

### DIFF
--- a/internal/distributed/proxy/httpserver/handler_v1.go
+++ b/internal/distributed/proxy/httpserver/handler_v1.go
@@ -832,6 +832,7 @@ func (h *HandlersV1) upsert(c *gin.Context) {
 		httpReq.CollectionName = singleUpsertReq.CollectionName
 		httpReq.Data = []map[string]interface{}{singleUpsertReq.Data}
 		httpReq.PartialUpdate = singleUpsertReq.PartialUpdate
+		httpReq.FieldOps = singleUpsertReq.FieldOps
 	}
 	if httpReq.CollectionName == "" || httpReq.Data == nil {
 		log.Warn("high level restful api, upsert require parameter: [collectionName, data], but miss")
@@ -847,6 +848,15 @@ func (h *HandlersV1) upsert(c *gin.Context) {
 		NumRows:        uint32(len(httpReq.Data)),
 		PartialUpdate:  httpReq.PartialUpdate,
 	}
+	fieldOps, err := buildFieldPartialUpdateOps(httpReq.FieldOps)
+	if err != nil {
+		HTTPAbortReturn(c, http.StatusOK, gin.H{
+			HTTPReturnCode:    merr.Code(err),
+			HTTPReturnMessage: err.Error(),
+		})
+		return
+	}
+	req.FieldOps = fieldOps
 	c.Set(ContextRequest, req)
 	username, _ := c.Get(ContextUsername)
 	ctx := proxy.NewContextWithMetadata(c, username.(string), req.DbName)

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -1326,6 +1326,15 @@ func (h *HandlersV2) upsert(ctx context.Context, c *gin.Context, anyReq any, dbN
 		PartialUpdate:  httpReq.PartialUpdate,
 		// PartitionName:  "_default",
 	}
+	fieldOps, err := buildFieldPartialUpdateOps(httpReq.FieldOps)
+	if err != nil {
+		HTTPAbortReturn(c, http.StatusOK, gin.H{
+			HTTPReturnCode:    merr.Code(err),
+			HTTPReturnMessage: err.Error(),
+		})
+		return nil, err
+	}
+	req.FieldOps = fieldOps
 	c.Set(ContextRequest, req)
 
 	collSchema, err := h.GetCollectionSchema(ctx, c, dbName, httpReq.CollectionName)

--- a/internal/distributed/proxy/httpserver/request.go
+++ b/internal/distributed/proxy/httpserver/request.go
@@ -68,17 +68,19 @@ type SingleInsertReq struct {
 }
 
 type UpsertReq struct {
-	DbName         string                   `json:"dbName"`
-	CollectionName string                   `json:"collectionName" validate:"required"`
-	Data           []map[string]interface{} `json:"data" validate:"required"`
-	PartialUpdate  bool                     `json:"partialUpdate"`
+	DbName         string                    `json:"dbName"`
+	CollectionName string                    `json:"collectionName" validate:"required"`
+	Data           []map[string]interface{}  `json:"data" validate:"required"`
+	PartialUpdate  bool                      `json:"partialUpdate"`
+	FieldOps       []FieldPartialUpdateOpReq `json:"fieldOps"`
 }
 
 type SingleUpsertReq struct {
-	DbName         string                 `json:"dbName"`
-	CollectionName string                 `json:"collectionName" validate:"required"`
-	Data           map[string]interface{} `json:"data" validate:"required"`
-	PartialUpdate  bool                   `json:"partialUpdate"`
+	DbName         string                    `json:"dbName"`
+	CollectionName string                    `json:"collectionName" validate:"required"`
+	Data           map[string]interface{}    `json:"data" validate:"required"`
+	PartialUpdate  bool                      `json:"partialUpdate"`
+	FieldOps       []FieldPartialUpdateOpReq `json:"fieldOps"`
 }
 
 type SearchReq struct {

--- a/internal/distributed/proxy/httpserver/request_v2.go
+++ b/internal/distributed/proxy/httpserver/request_v2.go
@@ -19,6 +19,7 @@ package httpserver
 import (
 	"context"
 	"strconv"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
@@ -325,15 +326,54 @@ func (req *CollectionFilterReq) GetDbName() string         { return req.DbName }
 func (req *CollectionFilterReq) GetCollectionName() string { return req.CollectionName }
 
 type CollectionDataReq struct {
-	DbName         string                   `json:"dbName"`
-	CollectionName string                   `json:"collectionName" binding:"required"`
-	PartitionName  string                   `json:"partitionName"`
-	Data           []map[string]interface{} `json:"data" binding:"required"`
-	PartialUpdate  bool                     `json:"partialUpdate"`
+	DbName         string                    `json:"dbName"`
+	CollectionName string                    `json:"collectionName" binding:"required"`
+	PartitionName  string                    `json:"partitionName"`
+	Data           []map[string]interface{}  `json:"data" binding:"required"`
+	PartialUpdate  bool                      `json:"partialUpdate"`
+	FieldOps       []FieldPartialUpdateOpReq `json:"fieldOps"`
 }
 
 func (req *CollectionDataReq) GetDbName() string         { return req.DbName }
 func (req *CollectionDataReq) GetCollectionName() string { return req.CollectionName }
+
+type FieldPartialUpdateOpReq struct {
+	FieldName string `json:"fieldName"`
+	Op        string `json:"op"`
+}
+
+func buildFieldPartialUpdateOps(fieldOps []FieldPartialUpdateOpReq) ([]*schemapb.FieldPartialUpdateOp, error) {
+	if len(fieldOps) == 0 {
+		return nil, nil
+	}
+
+	ops := make([]*schemapb.FieldPartialUpdateOp, 0, len(fieldOps))
+	for _, fieldOp := range fieldOps {
+		op, err := parseFieldPartialUpdateOp(fieldOp.Op)
+		if err != nil {
+			return nil, err
+		}
+		ops = append(ops, &schemapb.FieldPartialUpdateOp{
+			FieldName: fieldOp.FieldName,
+			Op:        op,
+		})
+	}
+	return ops, nil
+}
+
+func parseFieldPartialUpdateOp(op string) (schemapb.FieldPartialUpdateOp_OpType, error) {
+	switch strings.ToUpper(strings.TrimSpace(op)) {
+	case "REPLACE":
+		return schemapb.FieldPartialUpdateOp_REPLACE, nil
+	case "ARRAY_APPEND":
+		return schemapb.FieldPartialUpdateOp_ARRAY_APPEND, nil
+	case "ARRAY_REMOVE":
+		return schemapb.FieldPartialUpdateOp_ARRAY_REMOVE, nil
+	default:
+		return schemapb.FieldPartialUpdateOp_REPLACE,
+			merr.WrapErrParameterInvalidMsg("unsupported partial update op: " + op)
+	}
+}
 
 type SearchReqV2 struct {
 	DbName           string                 `json:"dbName"`

--- a/internal/distributed/proxy/httpserver/request_v2_test.go
+++ b/internal/distributed/proxy/httpserver/request_v2_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/util/requestutil"
 )
 
@@ -49,4 +50,25 @@ func TestRequestV2_GetCollectionName(t *testing.T) {
 			assert.Equal(t, tt.want, tt.req.GetCollectionName())
 		})
 	}
+}
+
+func TestBuildFieldPartialUpdateOps(t *testing.T) {
+	ops, err := buildFieldPartialUpdateOps([]FieldPartialUpdateOpReq{
+		{FieldName: "tags", Op: "ARRAY_APPEND"},
+		{FieldName: "scores", Op: "ARRAY_REMOVE"},
+	})
+	assert.NoError(t, err)
+	assert.Len(t, ops, 2)
+	assert.Equal(t, "tags", ops[0].GetFieldName())
+	assert.Equal(t, schemapb.FieldPartialUpdateOp_ARRAY_APPEND, ops[0].GetOp())
+	assert.Equal(t, "scores", ops[1].GetFieldName())
+	assert.Equal(t, schemapb.FieldPartialUpdateOp_ARRAY_REMOVE, ops[1].GetOp())
+}
+
+func TestBuildFieldPartialUpdateOps_RejectsUnknownOp(t *testing.T) {
+	_, err := buildFieldPartialUpdateOps([]FieldPartialUpdateOpReq{
+		{FieldName: "tags", Op: "ARRAY_EXTEND"},
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported partial update op")
 }


### PR DESCRIPTION
pr: #49722
issue: #49241

Cherry-pick of the REST upsert fieldOps support for 3.0.

This exposes partial update field operations through REST upsert so
ARRAY_APPEND and ARRAY_REMOVE requests can reach proxy validation.

Validation:
- Cherry-pick applied cleanly on milvus/3.0.
- git diff --check cp/49241-restful-partial-update-op-3.0~1..cp/49241-restful-partial-update-op-3.0
