### PR TITLE
fix: avoid distribution update after close

### DIFF
--- a/internal/querynodev2/delegator/distribution.go
+++ b/internal/querynodev2/delegator/distribution.go
@@ -125,7 +125,9 @@ type distribution struct {
 
 	// async snapshot generation
 	snapshotNotifier chan struct{} // capacity 1, notify background goroutine to regenerate snapshot
+	snapshotClose    chan struct{} // closed to stop background goroutine
 	snapshotDone     chan struct{} // closed when background goroutine exits
+	closed           *atomic.Bool
 	closeOnce        sync.Once
 
 	// distribution info
@@ -159,7 +161,9 @@ func NewDistribution(channelName string, queryView *channelQueryView) *distribut
 		current:          atomic.NewPointer[snapshot](nil),
 		queryView:        queryView,
 		snapshotNotifier: make(chan struct{}, 1),
+		snapshotClose:    make(chan struct{}),
 		snapshotDone:     make(chan struct{}),
+		closed:           atomic.NewBool(false),
 	}
 	// generate initial snapshot synchronously
 	dist.genSnapshot()
@@ -171,6 +175,9 @@ func NewDistribution(channelName string, queryView *channelQueryView) *distribut
 
 // notifySnapshotUpdate sends a non-blocking notification to regenerate snapshot.
 func (d *distribution) notifySnapshotUpdate() {
+	if d.closed.Load() {
+		return
+	}
 	select {
 	case d.snapshotNotifier <- struct{}{}:
 	default:
@@ -180,11 +187,16 @@ func (d *distribution) notifySnapshotUpdate() {
 // snapshotLoop runs in a background goroutine, regenerating snapshot on notification.
 func (d *distribution) snapshotLoop() {
 	defer close(d.snapshotDone)
-	for range d.snapshotNotifier {
-		d.mut.Lock()
-		d.genSnapshot()
-		d.updateServiceable("snapshotLoop")
-		d.mut.Unlock()
+	for {
+		select {
+		case <-d.snapshotClose:
+			return
+		case <-d.snapshotNotifier:
+			d.mut.Lock()
+			d.genSnapshot()
+			d.updateServiceable("snapshotLoop")
+			d.mut.Unlock()
+		}
 	}
 }
 
@@ -366,6 +378,16 @@ func (d *distribution) updateServiceable(triggerAction string) {
 // AddDistributions add multiple segment entries.
 func (d *distribution) AddDistributions(entries ...SegmentEntry) {
 	var toRefund []pkoracle.Candidate
+
+	if d.closed.Load() {
+		for _, entry := range entries {
+			if entry.Candidate != nil {
+				toRefund = append(toRefund, entry.Candidate)
+			}
+		}
+		refundCandidates(toRefund)
+		return
+	}
 
 	d.mut.Lock()
 	for _, entry := range entries {
@@ -776,7 +798,8 @@ func (d *distribution) Flush() {
 // Close stops the background snapshot loop and waits for it to exit.
 func (d *distribution) Close() {
 	d.closeOnce.Do(func() {
-		close(d.snapshotNotifier)
+		d.closed.Store(true)
+		close(d.snapshotClose)
 	})
 	<-d.snapshotDone
 }

--- a/internal/querynodev2/delegator/distribution_test.go
+++ b/internal/querynodev2/delegator/distribution_test.go
@@ -829,6 +829,28 @@ func TestDistribution_NewDistribution(t *testing.T) {
 	assert.NotNil(t, dist.current)
 }
 
+func TestDistribution_NotifyAfterClose(t *testing.T) {
+	dist := NewDistribution("test_channel", NewChannelQueryView(nil, nil, []int64{1}, initialTargetVersion))
+	dist.Close()
+	refunded := false
+
+	assert.NotPanics(t, func() {
+		dist.notifySnapshotUpdate()
+		dist.AddDistributions(SegmentEntry{
+			NodeID:      1,
+			SegmentID:   1,
+			PartitionID: 1,
+			Version:     1,
+			Candidate: &refundTrackingCandidate{
+				mockCandidate: mockCandidate{id: 1, partition: 1},
+				refunded:      &refunded,
+			},
+		})
+	})
+	assert.True(t, refunded)
+	assert.False(t, dist.SealedSegmentExists(1))
+}
+
 func TestDistribution_UpdateServiceable(t *testing.T) {
 	channelName := "test_channel"
 	growings := []int64{1, 2, 3}
@@ -1723,6 +1745,15 @@ func (m *mockCandidate) GetMinPk() *storage.PrimaryKey            { return nil }
 func (m *mockCandidate) GetMaxPk() *storage.PrimaryKey            { return nil }
 func (m *mockCandidate) Charge()                                  {}
 func (m *mockCandidate) Refund()                                  {}
+
+type refundTrackingCandidate struct {
+	mockCandidate
+	refunded *bool
+}
+
+func (m *refundTrackingCandidate) Refund() {
+	*m.refunded = true
+}
 
 func TestBatchGetFromSegments(t *testing.T) {
 	t.Run("basic_sealed_segments", func(t *testing.T) {


### PR DESCRIPTION
issue: #49694

- delegator distribution: stop closing the snapshot notifier channel and use a dedicated close signal for the snapshot loop
- stale distribution updates: ignore updates after close and refund incoming sealed candidates