### PR TITLE
fix: avoid distribution update after close

### DIFF
--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -1229,6 +1229,9 @@ func (sd *shardDelegator) Close() {
 	sd.tsCond.L.Unlock()
 	sd.lifetime.Wait()
 
+	// Mark distribution closed before refunding candidates so stale updates are ignored.
+	sd.distribution.Close()
+
 	// Refund all sealed segment candidates in distribution
 	sd.distribution.RefundAllCandidates()
 

--- a/internal/querynodev2/delegator/distribution.go
+++ b/internal/querynodev2/delegator/distribution.go
@@ -122,6 +122,9 @@ type distribution struct {
 	// protects current & segments
 	mut sync.RWMutex
 
+	closed    *atomic.Bool
+	closeOnce sync.Once
+
 	// distribution info
 	channelName string
 	queryView   *channelQueryView
@@ -152,6 +155,7 @@ func NewDistribution(channelName string, queryView *channelQueryView) *distribut
 		snapshots:       typeutil.NewConcurrentMap[int64, *snapshot](),
 		current:         atomic.NewPointer[snapshot](nil),
 		queryView:       queryView,
+		closed:          atomic.NewBool(false),
 	}
 	dist.genSnapshot()
 	dist.updateServiceable("NewDistribution")
@@ -335,9 +339,19 @@ func (d *distribution) updateServiceable(triggerAction string) {
 
 // AddDistributions add multiple segment entries.
 func (d *distribution) AddDistributions(entries ...SegmentEntry) {
-	d.mut.Lock()
 	var toRefund []pkoracle.Candidate
 
+	d.mut.Lock()
+	if d.closed.Load() {
+		d.mut.Unlock()
+		for _, entry := range entries {
+			if entry.Candidate != nil {
+				toRefund = append(toRefund, entry.Candidate)
+			}
+		}
+		refundCandidates(toRefund)
+		return
+	}
 	for _, entry := range entries {
 		oldEntry, ok := d.sealedSegments[entry.SegmentID]
 		if ok && oldEntry.Version >= entry.Version {
@@ -693,6 +707,15 @@ func BatchGetFromSegments(pks []storage.PrimaryKey, partitionID int64, sealed []
 	}
 
 	return result
+}
+
+// Close marks the distribution closed so stale updates can be ignored.
+func (d *distribution) Close() {
+	d.closeOnce.Do(func() {
+		d.mut.Lock()
+		defer d.mut.Unlock()
+		d.closed.Store(true)
+	})
 }
 
 // RefundAllCandidates refunds resources for all sealed segment candidates.

--- a/internal/querynodev2/delegator/distribution_test.go
+++ b/internal/querynodev2/delegator/distribution_test.go
@@ -826,6 +826,27 @@ func TestDistribution_NewDistribution(t *testing.T) {
 	assert.NotNil(t, dist.current)
 }
 
+func TestDistribution_NotifyAfterClose(t *testing.T) {
+	dist := NewDistribution("test_channel", NewChannelQueryView(nil, nil, []int64{1}, initialTargetVersion))
+	dist.Close()
+	refunded := false
+
+	assert.NotPanics(t, func() {
+		dist.AddDistributions(SegmentEntry{
+			NodeID:      1,
+			SegmentID:   1,
+			PartitionID: 1,
+			Version:     1,
+			Candidate: &refundTrackingCandidate{
+				mockCandidate: mockCandidate{id: 1, partition: 1},
+				refunded:      &refunded,
+			},
+		})
+	})
+	assert.True(t, refunded)
+	assert.False(t, dist.SealedSegmentExists(1))
+}
+
 func TestDistribution_UpdateServiceable(t *testing.T) {
 	channelName := "test_channel"
 	growings := []int64{1, 2, 3}
@@ -1700,6 +1721,15 @@ func (m *mockCandidate) GetMinPk() *storage.PrimaryKey            { return nil }
 func (m *mockCandidate) GetMaxPk() *storage.PrimaryKey            { return nil }
 func (m *mockCandidate) Charge()                                  {}
 func (m *mockCandidate) Refund()                                  {}
+
+type refundTrackingCandidate struct {
+	mockCandidate
+	refunded *bool
+}
+
+func (m *refundTrackingCandidate) Refund() {
+	*m.refunded = true
+}
 
 func TestBatchGetFromSegments(t *testing.T) {
 	t.Run("basic_sealed_segments", func(t *testing.T) {


### PR DESCRIPTION
issue: #49694
pr: #49725

- delegator distribution: mark distribution closed before refunding candidates and ignore stale updates after close
- stale distribution updates: refund incoming sealed candidates instead of accepting them after close