### PR TITLE
enhance: remove schema version consistency gate

### DIFF
--- a/internal/datacoord/compaction_policy_clustering.go
+++ b/internal/datacoord/compaction_policy_clustering.go
@@ -191,18 +191,6 @@ func (policy *clusteringCompactionPolicy) triggerOneCollection(ctx context.Conte
 			}
 		}
 
-		// Intentionally check internal consistency (all segments share the same schema version)
-		// rather than requiring segments to match the collection schema version.
-		// Clustering before backfill is more efficient: merging N segments first reduces
-		// N separate backfill tasks to 1 backfill task on the merged result.
-		if !policy.checkGroupSchemaVersionInternallyConsistent(group) {
-			log.Debug("segments in group have inconsistent schema versions, skip clustering compaction for this group",
-				zap.Int64("collectionID", group.collectionID),
-				zap.Int64("partitionID", group.partitionID),
-				zap.String("channel", group.channelName))
-			continue
-		}
-
 		segmentViews := GetViewsByInfo(group.segments...)
 		view := &ClusteringSegmentsView{
 			label:              segmentViews[0].label,
@@ -216,19 +204,6 @@ func (policy *clusteringCompactionPolicy) triggerOneCollection(ctx context.Conte
 
 	log.Info("finish trigger collection clustering compaction", zap.Int("viewNum", len(views)))
 	return views, newTriggerID, nil
-}
-
-func (policy *clusteringCompactionPolicy) checkGroupSchemaVersionInternallyConsistent(group *chanPartSegments) bool {
-	if len(group.segments) == 0 {
-		return true
-	}
-	firstSchemaVersion := group.segments[0].GetSchemaVersion()
-	for _, segment := range group.segments {
-		if segment.GetSchemaVersion() != firstSchemaVersion {
-			return false
-		}
-	}
-	return true
 }
 
 func (policy *clusteringCompactionPolicy) collectionIsClusteringCompacting(collectionID UniqueID) (bool, int64) {

--- a/internal/datacoord/compaction_policy_clustering_test.go
+++ b/internal/datacoord/compaction_policy_clustering_test.go
@@ -361,38 +361,7 @@ func (s *ClusteringCompactionPolicySuite) TestTriggerOneCollectionNormal() {
 	s.Equal(testLabel, view[0].GetGroupLabel())
 }
 
-func (s *ClusteringCompactionPolicySuite) TestCheckGroupSchemaVersionInternallyConsistent() {
-	// empty group is trivially consistent
-	s.True(s.clusteringCompactionPolicy.checkGroupSchemaVersionInternallyConsistent(
-		&chanPartSegments{segments: nil},
-	))
-
-	// single segment is trivially consistent
-	s.True(s.clusteringCompactionPolicy.checkGroupSchemaVersionInternallyConsistent(
-		&chanPartSegments{segments: []*SegmentInfo{
-			{SegmentInfo: &datapb.SegmentInfo{SchemaVersion: 3}},
-		}},
-	))
-
-	// all segments with the same schema version → consistent
-	s.True(s.clusteringCompactionPolicy.checkGroupSchemaVersionInternallyConsistent(
-		&chanPartSegments{segments: []*SegmentInfo{
-			{SegmentInfo: &datapb.SegmentInfo{SchemaVersion: 5}},
-			{SegmentInfo: &datapb.SegmentInfo{SchemaVersion: 5}},
-			{SegmentInfo: &datapb.SegmentInfo{SchemaVersion: 5}},
-		}},
-	))
-
-	// segments with different schema versions → inconsistent
-	s.False(s.clusteringCompactionPolicy.checkGroupSchemaVersionInternallyConsistent(
-		&chanPartSegments{segments: []*SegmentInfo{
-			{SegmentInfo: &datapb.SegmentInfo{SchemaVersion: 5}},
-			{SegmentInfo: &datapb.SegmentInfo{SchemaVersion: 6}},
-		}},
-	))
-}
-
-func (s *ClusteringCompactionPolicySuite) TestTriggerOneCollectionSkipsInconsistentSchemaGroup() {
+func (s *ClusteringCompactionPolicySuite) TestTriggerOneCollectionAllowsMixedSchemaVersionGroup() {
 	paramtable.Get().Save(Params.DataCoordCfg.ClusteringCompactionNewDataSizeThreshold.Key, "0")
 	defer paramtable.Get().Reset(Params.DataCoordCfg.ClusteringCompactionNewDataSizeThreshold.Key)
 
@@ -408,7 +377,6 @@ func (s *ClusteringCompactionPolicySuite) TestTriggerOneCollectionSkipsInconsist
 	})
 
 	segments := genSegmentsForMeta(testLabel)
-	// Force all segments to have mixed schema versions so the group is internally inconsistent
 	versionCounter := int32(0)
 	for id, segment := range segments {
 		versionCounter++
@@ -427,10 +395,10 @@ func (s *ClusteringCompactionPolicySuite) TestTriggerOneCollectionSkipsInconsist
 		return nil, nil
 	})
 
-	// Because the group has mixed schema versions, triggerOneCollection should skip it
 	view, _, err := s.clusteringCompactionPolicy.triggerOneCollection(context.TODO(), 1, false)
 	s.NoError(err)
-	s.Equal(0, len(view))
+	s.Len(view, 1)
+	s.Equal(testLabel, view[0].GetGroupLabel())
 }
 
 func (s *ClusteringCompactionPolicySuite) TestGetExpectedSegmentSize() {

--- a/internal/datacoord/compaction_trigger.go
+++ b/internal/datacoord/compaction_trigger.go
@@ -230,20 +230,6 @@ func (t *compactionTrigger) getCollection(collectionID UniqueID) (*collectionInf
 	return coll, nil
 }
 
-// filterSegmentsWithMatchingSchemaVersion removes segments whose schema version does not match the
-// collection's current schema version. This allows mix compaction to proceed on the matching subset
-// rather than blocking the entire group (collection + partition + channel) during backfill.
-func filterSegmentsWithMatchingSchemaVersion(segments []*SegmentInfo, coll *collectionInfo) []*SegmentInfo {
-	collectionSchemaVersion := coll.Schema.GetVersion()
-	result := make([]*SegmentInfo, 0, len(segments))
-	for _, segment := range segments {
-		if segment.GetSchemaVersion() == collectionSchemaVersion {
-			result = append(result, segment)
-		}
-	}
-	return result
-}
-
 func isCollectionAutoCompactionEnabled(coll *collectionInfo) bool {
 	if coll == nil {
 		return false
@@ -385,15 +371,6 @@ func (t *compactionTrigger) handleSignal(signal *compactionSignal) error {
 			if signal.collectionID != 0 {
 				return err
 			}
-			continue
-		}
-
-		group.segments = filterSegmentsWithMatchingSchemaVersion(group.segments, coll)
-		if len(group.segments) == 0 {
-			log.Debug("no segments with matching schema version in group, skip mix compaction",
-				zap.Int64("collectionID", group.collectionID),
-				zap.Int64("partitionID", group.partitionID),
-				zap.String("channel", group.channelName))
 			continue
 		}
 

--- a/internal/datacoord/compaction_trigger_test.go
+++ b/internal/datacoord/compaction_trigger_test.go
@@ -2003,39 +2003,65 @@ func Test_compactionTrigger_new(t *testing.T) {
 	}
 }
 
-func TestFilterSegmentsWithMatchingSchemaVersion(t *testing.T) {
-	coll := &collectionInfo{
-		ID:     1,
-		Schema: &schemapb.CollectionSchema{Version: 5},
+func TestCompactionTriggerKeepsMixedSchemaVersionSegments(t *testing.T) {
+	paramtable.Init()
+
+	collectionID := int64(1)
+	partitionID := int64(10)
+	channel := "ch-1"
+	schema := newTestSchema()
+	schema.Version = 5
+	mt := &meta{
+		segments:    NewSegmentsInfo(),
+		indexMeta:   newSegmentIndexMeta(nil),
+		collections: typeutil.NewConcurrentMap[UniqueID, *collectionInfo](),
+	}
+	mt.collections.Insert(collectionID, &collectionInfo{ID: collectionID, Schema: schema})
+
+	for _, item := range []struct {
+		id            int64
+		schemaVersion int32
+	}{
+		{id: 101, schemaVersion: 3},
+		{id: 102, schemaVersion: 5},
+		{id: 103, schemaVersion: 4},
+	} {
+		mt.segments.SetSegment(item.id, &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{
+			ID:            item.id,
+			CollectionID:  collectionID,
+			PartitionID:   partitionID,
+			InsertChannel: channel,
+			State:         commonpb.SegmentState_Flushed,
+			Level:         datapb.SegmentLevel_L1,
+			IsSorted:      true,
+			NumOfRows:     10,
+			MaxRowNum:     100,
+			SchemaVersion: item.schemaVersion,
+			Binlogs:       []*datapb.FieldBinlog{{FieldID: 1, Binlogs: []*datapb.Binlog{{EntriesNum: 10, MemorySize: 1}}}},
+		}})
 	}
 
-	// empty input → empty output
-	result := filterSegmentsWithMatchingSchemaVersion(nil, coll)
-	assert.Empty(t, result)
+	inspector := &spyCompactionInspector{t: t, spyChan: make(chan *datapb.CompactionPlan, 1), meta: mt}
+	trigger := newCompactionTrigger(mt, inspector, newMock0Allocator(t), newMockHandlerWithMeta(mt), newMockVersionManager())
+	err := trigger.handleSignal(&compactionSignal{
+		id:           1,
+		collectionID: collectionID,
+		partitionID:  partitionID,
+		channel:      channel,
+		isForce:      true,
+	})
+	assert.NoError(t, err)
 
-	// all segments match → all returned
-	result = filterSegmentsWithMatchingSchemaVersion([]*SegmentInfo{
-		{SegmentInfo: &datapb.SegmentInfo{SchemaVersion: 5}},
-		{SegmentInfo: &datapb.SegmentInfo{SchemaVersion: 5}},
-	}, coll)
-	assert.Equal(t, 2, len(result))
-
-	// mixed versions → only matching segments returned
-	result = filterSegmentsWithMatchingSchemaVersion([]*SegmentInfo{
-		{SegmentInfo: &datapb.SegmentInfo{ID: 1, SchemaVersion: 5}},
-		{SegmentInfo: &datapb.SegmentInfo{ID: 2, SchemaVersion: 4}},
-		{SegmentInfo: &datapb.SegmentInfo{ID: 3, SchemaVersion: 5}},
-	}, coll)
-	assert.Equal(t, 2, len(result))
-	assert.Equal(t, int64(1), result[0].GetID())
-	assert.Equal(t, int64(3), result[1].GetID())
-
-	// all segments outdated → empty output
-	result = filterSegmentsWithMatchingSchemaVersion([]*SegmentInfo{
-		{SegmentInfo: &datapb.SegmentInfo{SchemaVersion: 0}},
-		{SegmentInfo: &datapb.SegmentInfo{SchemaVersion: 4}},
-	}, coll)
-	assert.Empty(t, result)
+	select {
+	case plan := <-inspector.spyChan:
+		var got []int64
+		for _, segment := range plan.GetSegmentBinlogs() {
+			got = append(got, segment.GetSegmentID())
+		}
+		assert.ElementsMatch(t, []int64{101, 102, 103}, got)
+	case <-time.After(time.Second):
+		assert.Fail(t, "expected compaction plan for mixed schema version segments")
+	}
 }
 
 func Test_compactionTrigger_getCompactTime(t *testing.T) {

--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -1979,7 +1979,7 @@ func (m *meta) completeClusterCompactionMutation(t *datapb.CompactionTask, resul
 			StorageVersion: seg.GetStorageVersion(),
 			ManifestPath:   seg.GetManifest(),
 			ExpirQuantiles: seg.GetExpirQuantiles(),
-			SchemaVersion:  compactFromSegInfos[0].GetSchemaVersion(),
+			SchemaVersion:  t.GetSchema().GetVersion(),
 		}
 		segment := NewSegmentInfo(segmentInfo)
 		compactToSegInfos = append(compactToSegInfos, segment)
@@ -2097,7 +2097,7 @@ func (m *meta) completeMixCompactionMutation(
 				ManifestPath:        compactToSegment.GetManifest(),
 				IsSortedByNamespace: compactToSegment.GetIsSortedByNamespace(),
 				ExpirQuantiles:      compactToSegment.GetExpirQuantiles(),
-				SchemaVersion:       compactFromSegInfos[0].GetSchemaVersion(),
+				SchemaVersion:       t.GetSchema().GetVersion(),
 			})
 
 		if compactToSegmentInfo.GetNumOfRows() == 0 {

--- a/internal/datacoord/meta_test.go
+++ b/internal/datacoord/meta_test.go
@@ -601,6 +601,116 @@ func (suite *MetaBasicSuite) TestCompleteCompactionMutation() {
 		suite.EqualValues(2, droppedCount)
 	})
 
+	suite.Run("mixed schema version mix compaction uses task schema version", func() {
+		latestSegments := NewSegmentsInfo()
+		for segID, segment := range map[UniqueID]*SegmentInfo{
+			1: {SegmentInfo: &datapb.SegmentInfo{
+				ID:            1,
+				CollectionID:  100,
+				PartitionID:   10,
+				State:         commonpb.SegmentState_Flushed,
+				Level:         datapb.SegmentLevel_L1,
+				Binlogs:       []*datapb.FieldBinlog{getFieldBinlogIDs(0, 10000)},
+				Statslogs:     []*datapb.FieldBinlog{getFieldBinlogIDs(0, 20000)},
+				Deltalogs:     []*datapb.FieldBinlog{getFieldBinlogIDs(0, 30000)},
+				NumOfRows:     2,
+				SchemaVersion: 1,
+			}},
+			2: {SegmentInfo: &datapb.SegmentInfo{
+				ID:            2,
+				CollectionID:  100,
+				PartitionID:   10,
+				State:         commonpb.SegmentState_Flushed,
+				Level:         datapb.SegmentLevel_L1,
+				Binlogs:       []*datapb.FieldBinlog{getFieldBinlogIDs(0, 11000)},
+				Statslogs:     []*datapb.FieldBinlog{getFieldBinlogIDs(0, 21000)},
+				Deltalogs:     []*datapb.FieldBinlog{getFieldBinlogIDs(0, 31000)},
+				NumOfRows:     2,
+				SchemaVersion: 4,
+			}},
+		} {
+			latestSegments.SetSegment(segID, segment)
+		}
+
+		result := &datapb.CompactionPlanResult{
+			Segments: []*datapb.CompactionSegment{{
+				SegmentID:           3,
+				InsertLogs:          []*datapb.FieldBinlog{getFieldBinlogIDs(0, 50000)},
+				Field2StatslogPaths: []*datapb.FieldBinlog{getFieldBinlogIDs(0, 50001)},
+				NumOfRows:           4,
+			}},
+		}
+		task := &datapb.CompactionTask{
+			InputSegments: []UniqueID{1, 2},
+			Type:          datapb.CompactionType_MixCompaction,
+			Schema:        &schemapb.CollectionSchema{Version: 9},
+		}
+		m := &meta{
+			catalog:      &datacoord.Catalog{MetaKv: NewMetaMemoryKV()},
+			segments:     latestSegments,
+			chunkManager: mockChMgr,
+		}
+
+		infos, _, err := m.CompleteCompactionMutation(context.TODO(), task, result)
+		suite.NoError(err)
+		suite.Len(infos, 1)
+		suite.EqualValues(9, infos[0].GetSchemaVersion())
+	})
+
+	suite.Run("mixed schema version clustering compaction uses task schema version", func() {
+		latestSegments := NewSegmentsInfo()
+		for segID, segment := range map[UniqueID]*SegmentInfo{
+			1: {SegmentInfo: &datapb.SegmentInfo{
+				ID:            1,
+				CollectionID:  100,
+				PartitionID:   10,
+				State:         commonpb.SegmentState_Flushed,
+				Level:         datapb.SegmentLevel_L1,
+				Binlogs:       []*datapb.FieldBinlog{getFieldBinlogIDs(0, 10000)},
+				Statslogs:     []*datapb.FieldBinlog{getFieldBinlogIDs(0, 20000)},
+				NumOfRows:     2,
+				SchemaVersion: 1,
+			}},
+			2: {SegmentInfo: &datapb.SegmentInfo{
+				ID:            2,
+				CollectionID:  100,
+				PartitionID:   10,
+				State:         commonpb.SegmentState_Flushed,
+				Level:         datapb.SegmentLevel_L1,
+				Binlogs:       []*datapb.FieldBinlog{getFieldBinlogIDs(0, 11000)},
+				Statslogs:     []*datapb.FieldBinlog{getFieldBinlogIDs(0, 21000)},
+				NumOfRows:     2,
+				SchemaVersion: 4,
+			}},
+		} {
+			latestSegments.SetSegment(segID, segment)
+		}
+
+		result := &datapb.CompactionPlanResult{
+			Segments: []*datapb.CompactionSegment{{
+				SegmentID:           3,
+				InsertLogs:          []*datapb.FieldBinlog{getFieldBinlogIDs(0, 50000)},
+				Field2StatslogPaths: []*datapb.FieldBinlog{getFieldBinlogIDs(0, 50001)},
+				NumOfRows:           4,
+			}},
+		}
+		task := &datapb.CompactionTask{
+			InputSegments: []UniqueID{1, 2},
+			Type:          datapb.CompactionType_ClusteringCompaction,
+			Schema:        &schemapb.CollectionSchema{Version: 9},
+		}
+		m := &meta{
+			catalog:      &datacoord.Catalog{MetaKv: NewMetaMemoryKV()},
+			segments:     latestSegments,
+			chunkManager: mockChMgr,
+		}
+
+		infos, _, err := m.CompleteCompactionMutation(context.TODO(), task, result)
+		suite.NoError(err)
+		suite.Len(infos, 1)
+		suite.EqualValues(9, infos[0].GetSchemaVersion())
+	})
+
 	suite.Run("test L2 sort", func() {
 		getLatestSegments := func() *SegmentsInfo {
 			latestSegments := NewSegmentsInfo()

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -977,25 +977,6 @@ func (node *Proxy) AddCollectionField(ctx context.Context, request *milvuspb.Add
 			"add field operation is not supported for external collection %s", request.GetCollectionName())), nil
 	}
 
-	// Prevent concurrent schema-change requests (AddCollectionField / AlterCollectionSchema)
-	// on the same collection from racing past the schema version consistency gate.
-	collKey := request.GetDbName() + "/" + request.GetCollectionName()
-	if _, loaded := node.alterSchemaInFlight.LoadOrStore(collKey, struct{}{}); loaded {
-		return merr.Status(merr.WrapErrParameterInvalidMsg(
-			"another schema-change request is already in progress for collection %s", request.GetCollectionName())), nil
-	}
-	defer node.alterSchemaInFlight.Delete(collKey)
-
-	// TEMP: SDKs do not consistently retry retryable DDL errors yet.
-	// Retry the schema consistency gate in Proxy first to hide short backfill
-	// convergence windows from clients until SDK retry handling is fixed.
-	if err := retry.Handle(ctx, func() (bool, error) {
-		err := node.checkSchemaVersionConsistency(ctx, request.DbName, request.CollectionName)
-		return merr.IsRetryableErr(err), err
-	}); err != nil {
-		return merr.Status(err), nil
-	}
-
 	task := &addCollectionFieldTask{
 		ctx:                       ctx,
 		Condition:                 NewTaskCondition(ctx),
@@ -1070,30 +1051,6 @@ func (node *Proxy) AlterCollectionSchema(ctx context.Context, request *milvuspb.
 		}, nil
 	}
 
-	// Prevent concurrent AlterCollectionSchema requests on the same collection from
-	// racing past the schema version consistency gate. Only one request per collection
-	// is allowed to proceed at a time; others are rejected immediately.
-	collKey := request.GetDbName() + "/" + request.GetCollectionName()
-	if _, loaded := node.alterSchemaInFlight.LoadOrStore(collKey, struct{}{}); loaded {
-		return &milvuspb.AlterCollectionSchemaResponse{
-			AlterStatus: merr.Status(merr.WrapErrParameterInvalidMsg(
-				"another AlterCollectionSchema request is already in progress for collection %s", request.GetCollectionName())),
-		}, nil
-	}
-	defer node.alterSchemaInFlight.Delete(collKey)
-
-	// TEMP: SDKs do not consistently retry retryable DDL errors yet.
-	// Retry the schema consistency gate in Proxy first to hide short backfill
-	// convergence windows from clients until SDK retry handling is fixed.
-	if err := retry.Handle(ctx, func() (bool, error) {
-		err := node.checkSchemaVersionConsistency(ctx, request.DbName, request.CollectionName)
-		return merr.IsRetryableErr(err), err
-	}); err != nil {
-		return &milvuspb.AlterCollectionSchemaResponse{
-			AlterStatus: merr.Status(err),
-		}, nil
-	}
-
 	task := &alterCollectionSchemaTask{
 		ctx:                          ctx,
 		Condition:                    NewTaskCondition(ctx),
@@ -1143,95 +1100,6 @@ func (node *Proxy) AlterCollectionSchema(ctx context.Context, request *milvuspb.
 	metrics.ProxyReqLatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), method).Observe(float64(tr.ElapseSpan().Milliseconds()))
 
 	return task.AlterCollectionSchemaResponse, nil
-}
-
-// checkSchemaVersionConsistency checks if all segments have consistent schema version
-// Returns error if schema version consistency proportion is less than 100%.
-//
-// NOTE: this is a Proxy-local fast-path check only. The `alterSchemaInFlight` map
-// on the Proxy is per-instance, so in a multi-Proxy deployment two concurrent
-// schema-change requests routed to different Proxy instances each see their own
-// empty local map and both pass this check before either has bumped the schema
-// version, allowing the race through. The authoritative cluster-wide consistency
-// gate lives at RootCoord and is enforced after acquiring the collection resource
-// key lock — see checkSchemaVersionConsistencyAtRootCoord in rootcoord, added by
-// companion PR #48989. This Proxy-side check remains as a cheap early reject to
-// avoid unnecessary RootCoord round-trips on the common single-Proxy path.
-func (node *Proxy) checkSchemaVersionConsistency(ctx context.Context, dbName, collectionName string) error {
-	log := log.Ctx(ctx).With(
-		zap.String("role", typeutil.ProxyRole),
-		zap.String("db", dbName),
-		zap.String("collection", collectionName))
-
-	// Get collection statistics to check schema version consistency
-	statsResp, err := node.GetCollectionStatistics(ctx, &milvuspb.GetCollectionStatisticsRequest{
-		Base:           commonpbutil.NewMsgBase(),
-		DbName:         dbName,
-		CollectionName: collectionName,
-	})
-	if err := merr.CheckRPCCall(statsResp, err); err != nil {
-		log.Warn("failed to get collection statistics for schema version consistency check", zap.Error(err))
-		return err
-	}
-
-	// Find schema_version_consistent_segments and schema_version_total_segments from Stats.
-	// DataCoord emits these two integer keys only when the collection's schema version > 0
-	// (i.e. AlterCollectionSchema has been called at least once).  Absent keys mean the
-	// schema version is still 0 — no function field has ever been added — so there is no
-	// in-flight backfill and no DDL can be racing with one.  This does NOT open a window
-	// for concurrent DDL to slip through: RootCoord serializes all schema-change DDLs through
-	// a single DDL queue, so a second AlterCollectionSchema call can only enter this check
-	// after the first has already bumped the schema version and DataCoord has started reporting
-	// the count keys.
-	//
-	// Integer counts are used instead of a floating-point proportion to avoid the rounding
-	// hazard where e.g. 99999/100000 = 99.999% would format as "100.00" with "%.2f" and
-	// falsely satisfy the 100% gate check.
-	consistentSegments := -1
-	totalSegments := -1
-	for _, stat := range statsResp.GetStats() {
-		switch stat.GetKey() {
-		case common.SchemaVersionConsistentSegmentsKey:
-			v, err := strconv.Atoi(stat.GetValue())
-			if err != nil || v < 0 {
-				log.Warn("failed to parse schema_version_consistent_segments",
-					zap.String("value", stat.GetValue()), zap.Error(err))
-				return merr.WrapErrParameterInvalidMsg(
-					"invalid schema_version_consistent_segments value: %s", stat.GetValue())
-			}
-			consistentSegments = v
-		case common.SchemaVersionTotalSegmentsKey:
-			v, err := strconv.Atoi(stat.GetValue())
-			if err != nil || v < 0 {
-				log.Warn("failed to parse schema_version_total_segments",
-					zap.String("value", stat.GetValue()), zap.Error(err))
-				return merr.WrapErrParameterInvalidMsg(
-					"invalid schema_version_total_segments value: %s", stat.GetValue())
-			}
-			totalSegments = v
-		}
-	}
-
-	log.Info("checked schema version consistency",
-		zap.Int("consistentSegments", consistentSegments),
-		zap.Int("totalSegments", totalSegments))
-
-	if consistentSegments < 0 && totalSegments < 0 {
-		// Both keys absent: schema version is 0, no backfill has ever been triggered.
-		return nil
-	}
-	if consistentSegments < 0 || totalSegments < 0 {
-		// Exactly one key present — should never happen since DataCoord emits both atomically.
-		// Treat as a data corruption signal and block the DDL rather than silently passing.
-		log.Warn("incomplete schema version consistency stats, blocking DDL",
-			zap.Int("consistentSegments", consistentSegments),
-			zap.Int("totalSegments", totalSegments))
-		return merr.WrapErrParameterInvalidMsg("incomplete schema version consistency stats from DataCoord")
-	}
-	if consistentSegments < totalSegments {
-		return merr.WrapErrCollectionSchemaVersionNotReady(collectionName, consistentSegments, totalSegments)
-	}
-	return nil
 }
 
 // GetStatistics get the statistics, such as `num_rows`.

--- a/internal/proxy/impl_test.go
+++ b/internal/proxy/impl_test.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/apache/pulsar-client-go/pulsar"
 	"github.com/bytedance/mockey"
@@ -2398,9 +2398,9 @@ func TestProxy_AddCollectionField_ExternalCollection(t *testing.T) {
 	assert.Contains(t, resp.GetReason(), "add field operation is not supported for external collection")
 }
 
-func TestProxy_AddCollectionField_SchemaVersionGate(t *testing.T) {
-	t.Run("consistency check fails", func(t *testing.T) {
-		mockey.PatchConvey("consistency check blocks AddCollectionField", t, func() {
+func TestProxy_AddCollectionField_DoesNotBlockOnSchemaVersion(t *testing.T) {
+	t.Run("does not query schema version stats before enqueue", func(t *testing.T) {
+		mockey.PatchConvey("AddCollectionField skips schema version stats gate", t, func() {
 			node := createTestProxy()
 			defer node.sched.Close()
 
@@ -2408,46 +2408,15 @@ func TestProxy_AddCollectionField_SchemaVersionGate(t *testing.T) {
 				Status: merr.Success(),
 				Schema: &schemapb.CollectionSchema{Name: "test_coll"},
 			}, nil).Build()
-
-			mockey.Mock((*Proxy).checkSchemaVersionConsistency).Return(
-				merr.WrapErrCollectionSchemaVersionNotReady("test_coll", 1, 3),
-			).Build()
-
-			ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
-			defer cancel()
-
-			resp, err := node.AddCollectionField(ctx, &milvuspb.AddCollectionFieldRequest{
-				DbName:         "default",
-				CollectionName: "test_coll",
-			})
-			assert.NoError(t, err)
-			assert.ErrorIs(t, merr.Error(resp), merr.ErrCollectionSchemaVersionNotReady)
-			assert.True(t, resp.GetRetriable())
-			assert.Equal(t, commonpb.ErrorCode_NotReadyServe, resp.GetErrorCode())
-		})
-	})
-
-	t.Run("consistency check retries until success", func(t *testing.T) {
-		mockey.PatchConvey("consistency check retries AddCollectionField", t, func() {
-			node := createTestProxy()
-			defer node.sched.Close()
-
-			mockey.Mock((*Proxy).DescribeCollection).Return(&milvuspb.DescribeCollectionResponse{
-				Status: merr.Success(),
-				Schema: &schemapb.CollectionSchema{Name: "test_coll"},
-			}, nil).Build()
-
-			attempt := 0
-			mockey.Mock((*Proxy).checkSchemaVersionConsistency).To(func(*Proxy, context.Context, string, string) error {
-				attempt++
-				if attempt == 1 {
-					return merr.WrapErrCollectionSchemaVersionNotReady("test_coll", 1, 3)
-				}
-				return nil
-			}).Build()
-
+			mockey.Mock((*Proxy).GetCollectionStatistics).To(
+				func(*Proxy, context.Context, *milvuspb.GetCollectionStatisticsRequest) (*milvuspb.GetCollectionStatisticsResponse, error) {
+					require.FailNow(t, "AddCollectionField should not query collection statistics")
+					return nil, errors.New("unexpected GetCollectionStatistics call")
+				}).Build()
 			mockey.Mock((*ddTaskQueue).Enqueue).To(func(_ *ddTaskQueue, t task) error {
 				_ = t.OnEnqueue()
+				addTask := t.(*addCollectionFieldTask)
+				addTask.result = merr.Success()
 				return nil
 			}).Build()
 			mockey.Mock((*TaskCondition).WaitToFinish).Return(nil).Build()
@@ -2458,12 +2427,11 @@ func TestProxy_AddCollectionField_SchemaVersionGate(t *testing.T) {
 			})
 			assert.NoError(t, err)
 			assert.True(t, merr.Ok(resp))
-			assert.Equal(t, 2, attempt)
 		})
 	})
 
-	t.Run("concurrent request rejected", func(t *testing.T) {
-		mockey.PatchConvey("in-flight gate blocks concurrent AddCollectionField", t, func() {
+	t.Run("allows overlapping requests for same collection", func(t *testing.T) {
+		mockey.PatchConvey("AddCollectionField has no proxy-local in-flight gate", t, func() {
 			node := createTestProxy()
 			defer node.sched.Close()
 
@@ -2471,20 +2439,48 @@ func TestProxy_AddCollectionField_SchemaVersionGate(t *testing.T) {
 				Status: merr.Success(),
 				Schema: &schemapb.CollectionSchema{Name: "test_coll"},
 			}, nil).Build()
+			mockey.Mock((*Proxy).GetCollectionStatistics).Return(&milvuspb.GetCollectionStatisticsResponse{
+				Status: merr.Success(),
+			}, nil).Build()
+			mockey.Mock((*ddTaskQueue).Enqueue).To(func(_ *ddTaskQueue, t task) error {
+				_ = t.OnEnqueue()
+				addTask := t.(*addCollectionFieldTask)
+				addTask.result = merr.Success()
+				return nil
+			}).Build()
 
-			// Simulate an in-flight schema change on the same collection
-			collKey := "default/test_coll"
-			node.alterSchemaInFlight.Store(collKey, struct{}{})
+			firstWaitStarted := make(chan struct{})
+			releaseFirst := make(chan struct{})
+			var waitCalls atomic.Int32
+			mockey.Mock((*TaskCondition).WaitToFinish).To(func(*TaskCondition) error {
+				if waitCalls.Add(1) == 1 {
+					close(firstWaitStarted)
+					<-releaseFirst
+				}
+				return nil
+			}).Build()
+
+			firstDone := make(chan *commonpb.Status, 1)
+			go func() {
+				resp, err := node.AddCollectionField(context.Background(), &milvuspb.AddCollectionFieldRequest{
+					DbName:         "default",
+					CollectionName: "test_coll",
+				})
+				require.NoError(t, err)
+				firstDone <- resp
+			}()
+			<-firstWaitStarted
 
 			resp, err := node.AddCollectionField(context.Background(), &milvuspb.AddCollectionFieldRequest{
 				DbName:         "default",
 				CollectionName: "test_coll",
 			})
 			assert.NoError(t, err)
-			assert.Error(t, merr.Error(resp))
-			assert.Contains(t, resp.GetReason(), "another schema-change request is already in progress")
+			assert.True(t, merr.Ok(resp))
+			assert.Equal(t, int32(2), waitCalls.Load())
 
-			node.alterSchemaInFlight.Delete(collKey)
+			close(releaseFirst)
+			assert.True(t, merr.Ok(<-firstDone))
 		})
 	})
 }
@@ -2754,8 +2750,8 @@ func TestProxy_AlterCollectionSchema(t *testing.T) {
 		})
 	})
 
-	t.Run("schema version consistency check fails", func(t *testing.T) {
-		mockey.PatchConvey("consistency check fails", t, func() {
+	t.Run("does not query schema version stats before enqueue", func(t *testing.T) {
+		mockey.PatchConvey("AlterCollectionSchema skips schema version stats gate", t, func() {
 			node := createTestProxy()
 			defer node.sched.Close()
 
@@ -2763,21 +2759,79 @@ func TestProxy_AlterCollectionSchema(t *testing.T) {
 				Status: merr.Success(),
 				Schema: &schemapb.CollectionSchema{Name: "test_coll"},
 			}, nil).Build()
+			mockey.Mock((*Proxy).GetCollectionStatistics).To(
+				func(*Proxy, context.Context, *milvuspb.GetCollectionStatisticsRequest) (*milvuspb.GetCollectionStatisticsResponse, error) {
+					require.FailNow(t, "AlterCollectionSchema should not query collection statistics")
+					return nil, errors.New("unexpected GetCollectionStatistics call")
+				}).Build()
+			mockey.Mock((*ddTaskQueue).Enqueue).To(func(_ *ddTaskQueue, t task) error {
+				_ = t.OnEnqueue()
+				alterTask := t.(*alterCollectionSchemaTask)
+				alterTask.AlterCollectionSchemaResponse = &milvuspb.AlterCollectionSchemaResponse{AlterStatus: merr.Success()}
+				return nil
+			}).Build()
+			mockey.Mock((*TaskCondition).WaitToFinish).Return(nil).Build()
 
-			mockey.Mock((*Proxy).checkSchemaVersionConsistency).Return(
-				merr.WrapErrCollectionSchemaVersionNotReady("test_coll", 1, 3),
-			).Build()
-
-			ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
-			defer cancel()
-
-			resp, err := node.AlterCollectionSchema(ctx, &milvuspb.AlterCollectionSchemaRequest{
+			resp, err := node.AlterCollectionSchema(context.Background(), &milvuspb.AlterCollectionSchemaRequest{
+				DbName:         "default",
 				CollectionName: "test_coll",
 			})
 			assert.NoError(t, err)
-			assert.ErrorIs(t, merr.Error(resp.GetAlterStatus()), merr.ErrCollectionSchemaVersionNotReady)
-			assert.True(t, resp.GetAlterStatus().GetRetriable())
-			assert.Equal(t, commonpb.ErrorCode_NotReadyServe, resp.GetAlterStatus().GetErrorCode())
+			assert.True(t, merr.Ok(resp.GetAlterStatus()))
+		})
+	})
+
+	t.Run("allows overlapping requests for same collection", func(t *testing.T) {
+		mockey.PatchConvey("AlterCollectionSchema has no proxy-local in-flight gate", t, func() {
+			node := createTestProxy()
+			defer node.sched.Close()
+
+			mockey.Mock((*Proxy).DescribeCollection).Return(&milvuspb.DescribeCollectionResponse{
+				Status: merr.Success(),
+				Schema: &schemapb.CollectionSchema{Name: "test_coll"},
+			}, nil).Build()
+			mockey.Mock((*Proxy).GetCollectionStatistics).Return(&milvuspb.GetCollectionStatisticsResponse{
+				Status: merr.Success(),
+			}, nil).Build()
+			mockey.Mock((*ddTaskQueue).Enqueue).To(func(_ *ddTaskQueue, t task) error {
+				_ = t.OnEnqueue()
+				alterTask := t.(*alterCollectionSchemaTask)
+				alterTask.AlterCollectionSchemaResponse = &milvuspb.AlterCollectionSchemaResponse{AlterStatus: merr.Success()}
+				return nil
+			}).Build()
+
+			firstWaitStarted := make(chan struct{})
+			releaseFirst := make(chan struct{})
+			var waitCalls atomic.Int32
+			mockey.Mock((*TaskCondition).WaitToFinish).To(func(*TaskCondition) error {
+				if waitCalls.Add(1) == 1 {
+					close(firstWaitStarted)
+					<-releaseFirst
+				}
+				return nil
+			}).Build()
+
+			firstDone := make(chan *milvuspb.AlterCollectionSchemaResponse, 1)
+			go func() {
+				resp, err := node.AlterCollectionSchema(context.Background(), &milvuspb.AlterCollectionSchemaRequest{
+					DbName:         "default",
+					CollectionName: "test_coll",
+				})
+				require.NoError(t, err)
+				firstDone <- resp
+			}()
+			<-firstWaitStarted
+
+			resp, err := node.AlterCollectionSchema(context.Background(), &milvuspb.AlterCollectionSchemaRequest{
+				DbName:         "default",
+				CollectionName: "test_coll",
+			})
+			assert.NoError(t, err)
+			assert.True(t, merr.Ok(resp.GetAlterStatus()))
+			assert.Equal(t, int32(2), waitCalls.Load())
+
+			close(releaseFirst)
+			assert.True(t, merr.Ok((<-firstDone).GetAlterStatus()))
 		})
 	})
 
@@ -2790,8 +2844,6 @@ func TestProxy_AlterCollectionSchema(t *testing.T) {
 				Status: merr.Success(),
 				Schema: &schemapb.CollectionSchema{Name: "test_coll"},
 			}, nil).Build()
-
-			mockey.Mock((*Proxy).checkSchemaVersionConsistency).Return(nil).Build()
 
 			mockey.Mock((*ddTaskQueue).Enqueue).To(func(_ *ddTaskQueue, _ task) error {
 				return errors.New("queue full")
@@ -2814,8 +2866,6 @@ func TestProxy_AlterCollectionSchema(t *testing.T) {
 				Status: merr.Success(),
 				Schema: &schemapb.CollectionSchema{Name: "test_coll"},
 			}, nil).Build()
-
-			mockey.Mock((*Proxy).checkSchemaVersionConsistency).Return(nil).Build()
 
 			// Call OnEnqueue so task.Base is initialized (BeginTs/EndTs are logged after Enqueue).
 			mockey.Mock((*ddTaskQueue).Enqueue).To(func(_ *ddTaskQueue, t task) error {
@@ -2843,8 +2893,6 @@ func TestProxy_AlterCollectionSchema(t *testing.T) {
 				Schema: &schemapb.CollectionSchema{Name: "test_coll"},
 			}, nil).Build()
 
-			mockey.Mock((*Proxy).checkSchemaVersionConsistency).Return(nil).Build()
-
 			// Call OnEnqueue so task.Base is initialized (BeginTs/EndTs are logged after Enqueue).
 			mockey.Mock((*ddTaskQueue).Enqueue).To(func(_ *ddTaskQueue, t task) error {
 				_ = t.OnEnqueue()
@@ -2857,189 +2905,6 @@ func TestProxy_AlterCollectionSchema(t *testing.T) {
 				CollectionName: "test_coll",
 			})
 			assert.NoError(t, err)
-		})
-	})
-}
-
-func TestCheckSchemaVersionConsistency(t *testing.T) {
-	t.Run("GetCollectionStatistics returns error", func(t *testing.T) {
-		mockey.PatchConvey("error from GetCollectionStatistics", t, func() {
-			node := createTestProxy()
-			defer node.sched.Close()
-
-			mockey.Mock((*Proxy).GetCollectionStatistics).To(
-				func(_ *Proxy, ctx context.Context, req *milvuspb.GetCollectionStatisticsRequest) (*milvuspb.GetCollectionStatisticsResponse, error) {
-					return nil, errors.New("rpc error")
-				}).Build()
-
-			err := node.checkSchemaVersionConsistency(context.Background(), "db", "coll")
-			assert.Error(t, err)
-		})
-	})
-
-	t.Run("GetCollectionStatistics returns RPC error status", func(t *testing.T) {
-		mockey.PatchConvey("rpc status error", t, func() {
-			node := createTestProxy()
-			defer node.sched.Close()
-
-			mockey.Mock((*Proxy).GetCollectionStatistics).To(
-				func(_ *Proxy, ctx context.Context, req *milvuspb.GetCollectionStatisticsRequest) (*milvuspb.GetCollectionStatisticsResponse, error) {
-					return &milvuspb.GetCollectionStatisticsResponse{
-						Status: merr.Status(merr.ErrCollectionNotFound),
-					}, nil
-				}).Build()
-
-			err := node.checkSchemaVersionConsistency(context.Background(), "db", "coll")
-			assert.Error(t, err)
-		})
-	})
-
-	t.Run("both keys absent returns nil", func(t *testing.T) {
-		mockey.PatchConvey("no keys present", t, func() {
-			node := createTestProxy()
-			defer node.sched.Close()
-
-			mockey.Mock((*Proxy).GetCollectionStatistics).To(
-				func(_ *Proxy, ctx context.Context, req *milvuspb.GetCollectionStatisticsRequest) (*milvuspb.GetCollectionStatisticsResponse, error) {
-					return &milvuspb.GetCollectionStatisticsResponse{
-						Status: merr.Success(),
-						Stats:  []*commonpb.KeyValuePair{},
-					}, nil
-				}).Build()
-
-			err := node.checkSchemaVersionConsistency(context.Background(), "db", "coll")
-			assert.NoError(t, err)
-		})
-	})
-
-	t.Run("only consistent key present total absent returns error", func(t *testing.T) {
-		mockey.PatchConvey("consistent only", t, func() {
-			node := createTestProxy()
-			defer node.sched.Close()
-
-			mockey.Mock((*Proxy).GetCollectionStatistics).To(
-				func(_ *Proxy, ctx context.Context, req *milvuspb.GetCollectionStatisticsRequest) (*milvuspb.GetCollectionStatisticsResponse, error) {
-					return &milvuspb.GetCollectionStatisticsResponse{
-						Status: merr.Success(),
-						Stats: []*commonpb.KeyValuePair{
-							{Key: common.SchemaVersionConsistentSegmentsKey, Value: "5"},
-						},
-					}, nil
-				}).Build()
-
-			err := node.checkSchemaVersionConsistency(context.Background(), "db", "coll")
-			assert.Error(t, err)
-			assert.Contains(t, err.Error(), "incomplete schema version consistency stats")
-		})
-	})
-
-	t.Run("only total key present consistent absent returns error", func(t *testing.T) {
-		mockey.PatchConvey("total only", t, func() {
-			node := createTestProxy()
-			defer node.sched.Close()
-
-			mockey.Mock((*Proxy).GetCollectionStatistics).To(
-				func(_ *Proxy, ctx context.Context, req *milvuspb.GetCollectionStatisticsRequest) (*milvuspb.GetCollectionStatisticsResponse, error) {
-					return &milvuspb.GetCollectionStatisticsResponse{
-						Status: merr.Success(),
-						Stats: []*commonpb.KeyValuePair{
-							{Key: common.SchemaVersionTotalSegmentsKey, Value: "10"},
-						},
-					}, nil
-				}).Build()
-
-			err := node.checkSchemaVersionConsistency(context.Background(), "db", "coll")
-			assert.Error(t, err)
-			assert.Contains(t, err.Error(), "incomplete schema version consistency stats")
-		})
-	})
-
-	t.Run("consistent less than total returns error with counts", func(t *testing.T) {
-		mockey.PatchConvey("consistent < total", t, func() {
-			node := createTestProxy()
-			defer node.sched.Close()
-
-			mockey.Mock((*Proxy).GetCollectionStatistics).To(
-				func(_ *Proxy, ctx context.Context, req *milvuspb.GetCollectionStatisticsRequest) (*milvuspb.GetCollectionStatisticsResponse, error) {
-					return &milvuspb.GetCollectionStatisticsResponse{
-						Status: merr.Success(),
-						Stats: []*commonpb.KeyValuePair{
-							{Key: common.SchemaVersionConsistentSegmentsKey, Value: "5"},
-							{Key: common.SchemaVersionTotalSegmentsKey, Value: "10"},
-						},
-					}, nil
-				}).Build()
-
-			err := node.checkSchemaVersionConsistency(context.Background(), "db", "coll")
-			assert.ErrorIs(t, err, merr.ErrCollectionSchemaVersionNotReady)
-			assert.Contains(t, err.Error(), "5")
-			assert.Contains(t, err.Error(), "10")
-			status := merr.Status(err)
-			assert.True(t, status.GetRetriable())
-			assert.Equal(t, commonpb.ErrorCode_NotReadyServe, status.GetErrorCode())
-		})
-	})
-
-	t.Run("consistent equals total returns nil", func(t *testing.T) {
-		mockey.PatchConvey("consistent == total", t, func() {
-			node := createTestProxy()
-			defer node.sched.Close()
-
-			mockey.Mock((*Proxy).GetCollectionStatistics).To(
-				func(_ *Proxy, ctx context.Context, req *milvuspb.GetCollectionStatisticsRequest) (*milvuspb.GetCollectionStatisticsResponse, error) {
-					return &milvuspb.GetCollectionStatisticsResponse{
-						Status: merr.Success(),
-						Stats: []*commonpb.KeyValuePair{
-							{Key: common.SchemaVersionConsistentSegmentsKey, Value: "10"},
-							{Key: common.SchemaVersionTotalSegmentsKey, Value: "10"},
-						},
-					}, nil
-				}).Build()
-
-			err := node.checkSchemaVersionConsistency(context.Background(), "db", "coll")
-			assert.NoError(t, err)
-		})
-	})
-
-	t.Run("malformed consistent value returns parse error", func(t *testing.T) {
-		mockey.PatchConvey("bad consistent value", t, func() {
-			node := createTestProxy()
-			defer node.sched.Close()
-
-			mockey.Mock((*Proxy).GetCollectionStatistics).To(
-				func(_ *Proxy, ctx context.Context, req *milvuspb.GetCollectionStatisticsRequest) (*milvuspb.GetCollectionStatisticsResponse, error) {
-					return &milvuspb.GetCollectionStatisticsResponse{
-						Status: merr.Success(),
-						Stats: []*commonpb.KeyValuePair{
-							{Key: common.SchemaVersionConsistentSegmentsKey, Value: "not-a-number"},
-							{Key: common.SchemaVersionTotalSegmentsKey, Value: "10"},
-						},
-					}, nil
-				}).Build()
-
-			err := node.checkSchemaVersionConsistency(context.Background(), "db", "coll")
-			assert.Error(t, err)
-		})
-	})
-
-	t.Run("malformed total value returns parse error", func(t *testing.T) {
-		mockey.PatchConvey("bad total value", t, func() {
-			node := createTestProxy()
-			defer node.sched.Close()
-
-			mockey.Mock((*Proxy).GetCollectionStatistics).To(
-				func(_ *Proxy, ctx context.Context, req *milvuspb.GetCollectionStatisticsRequest) (*milvuspb.GetCollectionStatisticsResponse, error) {
-					return &milvuspb.GetCollectionStatisticsResponse{
-						Status: merr.Success(),
-						Stats: []*commonpb.KeyValuePair{
-							{Key: common.SchemaVersionConsistentSegmentsKey, Value: "5"},
-							{Key: common.SchemaVersionTotalSegmentsKey, Value: "bad-value"},
-						},
-					}, nil
-				}).Build()
-
-			err := node.checkSchemaVersionConsistency(context.Background(), "db", "coll")
-			assert.Error(t, err)
 		})
 	})
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -116,11 +116,6 @@ type Proxy struct {
 	enableComplexDeleteLimit bool
 
 	slowQueries *expirable.LRU[Timestamp, *metricsinfo.SlowQuery]
-
-	// alterSchemaInFlight tracks collections that have an AlterCollectionSchema
-	// request in progress, keyed by "dbName/collectionName". Prevents concurrent
-	// requests from racing past the schema version consistency gate.
-	alterSchemaInFlight sync.Map
 }
 
 // NewProxy returns a Proxy struct.


### PR DESCRIPTION
## Summary
- Remove proxy-side schema version consistency gate for schema-change DDLs.
- Allow mix and clustering compaction to process mixed schema-version segments.

issue: #49475

## Test plan
- [x] git diff --check
- [ ] go test -tags dynamic,test -gcflags=\"all=-N -l\" -count=1 ./internal/proxy -run 'TestProxy_AddCollectionField_DoesNotBlockOnSchemaVersion|TestProxy_AlterCollectionSchema'
- [ ] go test -tags dynamic,test -gcflags=\"all=-N -l\" -count=1 ./internal/datacoord -run 'TestCompactionTriggerKeepsMixedSchemaVersionSegments|TestClusteringCompactionPolicySuite/TestTriggerOneCollectionAllowsMixedSchemaVersionGroup|TestMetaBasicSuite/TestCompleteCompactionMutation/(mixed schema version mix compaction uses task schema version|mixed schema version clustering compaction uses task schema version)'

Note: Go test commands were blocked locally because pkg-config could not find milvus_core / milvus-storage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)