### PR TITLE
Filtered ANN search can skip scalar filter when visibility filter is disabled

### DIFF
--- a/internal/core/src/exec/operator/MvccNode.cpp
+++ b/internal/core/src/exec/operator/MvccNode.cpp
@@ -75,14 +75,19 @@ PhyMvccNode::GetOutput() {
 
     tracer::AddEvent(fmt::format("input_rows: {}", active_count_));
 
-    // Visibility filtering disabled globally: skip all filtering.
+    // Visibility filtering disabled globally: skip MVCC masks only.
+    // When an upstream FilterBitsNode is present, preserve its scalar filter
+    // bitset for downstream vector search; only the source-node case may
+    // promote to all_rows_visible=true.
     if (!segcore::SegcoreConfig::default_config()
              .get_visibility_filter_enabled()) {
         auto col_input = is_source_node_ ? std::make_shared<ColumnVector>(
                                                TargetBitmap(active_count_),
                                                TargetBitmap(active_count_))
                                          : GetColumnVector(input_);
-        query_context->set_all_rows_visible(true);
+        if (is_source_node_) {
+            query_context->set_all_rows_visible(true);
+        }
         is_finished_ = true;
         return std::make_shared<RowVector>(std::vector<VectorPtr>{col_input});
     }

--- a/internal/core/unittest/test_mvcc_fast_path.cpp
+++ b/internal/core/unittest/test_mvcc_fast_path.cpp
@@ -410,3 +410,69 @@ TEST_F(MvccFastPathTest, VisibilityFilterDisabled_GrowingSegment) {
         << "visibilityFilterEnabled=false should skip filtering on growing "
            "segments too";
 }
+
+// ---------------------------------------------------------------------------
+// Regression for issue #49735.
+// visibilityFilterEnabled=false with an upstream FilterBitsNode (scalar
+// predicate) MUST preserve the scalar filter bitset for downstream vector
+// search.  In particular, MvccNode must NOT set all_rows_visible=true when it
+// has an input source — otherwise VectorSearchNode passes an empty BitsetView
+// and scalar filtering is silently dropped.
+// ---------------------------------------------------------------------------
+TEST_F(MvccFastPathTest,
+       VisibilityFilterDisabled_PreservesScalarFilter_WithFilterBitsNode) {
+    VisibilityFilterGuard guard(false);
+    auto segment = CreateSealedSegment();
+
+    // counter < 100 → first 100 rows match the predicate.
+    proto::plan::GenericValue value;
+    value.set_int64_val(100);
+    auto filter_expr = std::make_shared<expr::UnaryRangeFilterExpr>(
+        expr::ColumnInfo(int64_fid_, DataType::INT64),
+        proto::plan::OpType::LessThan,
+        value,
+        std::vector<proto::plan::GenericValue>{});
+
+    auto filter_node = std::make_shared<plan::FilterBitsNode>(
+        "filter_1", filter_expr, std::vector<plan::PlanNodePtr>{});
+    auto mvcc_node = std::make_shared<plan::MvccNode>(
+        "mvcc_1", std::vector<plan::PlanNodePtr>{filter_node});
+    auto plan = plan::PlanFragment(mvcc_node);
+
+    auto query_context = std::make_shared<QueryContext>(
+        "test_filter_preserved",
+        segment.get(),
+        N_,
+        MAX_TIMESTAMP,
+        0,
+        0,
+        query::PlanOptions{false},
+        std::make_shared<QueryConfig>(
+            std::unordered_map<std::string, std::string>{}));
+
+    auto task = Task::Create("task_filter_preserved", plan, 0, query_context);
+    RowVectorPtr last_output;
+    for (;;) {
+        auto output = task->Next();
+        if (!output) {
+            break;
+        }
+        last_output = output;
+    }
+
+    // Must NOT promote to all_rows_visible — the FilterBitsNode bitset has to
+    // be honored by VectorSearchNode downstream.
+    EXPECT_FALSE(query_context->get_all_rows_visible())
+        << "MvccNode with upstream FilterBitsNode must NOT set "
+           "all_rows_visible=true, even when visibilityFilterEnabled=false";
+
+    // The bitmap emitted by MvccNode (a "filter-out" bitmap: 1 = excluded)
+    // must reflect the scalar predicate, not be all zeros.  counter < 100
+    // matches 100 rows, so the filter-out count is N_ - 100.
+    ASSERT_NE(last_output, nullptr);
+    auto col = std::dynamic_pointer_cast<ColumnVector>(last_output->child(0));
+    ASSERT_NE(col, nullptr);
+    TargetBitmapView view(col->GetRawData(), col->size());
+    EXPECT_EQ(view.count(), N_ - 100)
+        << "MvccNode must pass through the upstream scalar filter bitset";
+}


### PR DESCRIPTION
## Summary
Root cause: `PhyMvccNode::GetOutput` unconditionally called `query_context->set_all_rows_visible(true)` in the `visibilityFilterEnabled=false` branch, so when an upstream `FilterBitsNode` had supplied a scalar filter bitset, `PhyVectorSearchNode` saw `all_rows_visible=true` and passed an empty `BitsetView` to vector search, silently dropping the scalar predicate. Change: In `internal/core/src/exec/operator/MvccNode.cpp`, gate the `set_all_rows_visible(true)` call inside the disabled-visibility branch on `is_source_node_`, so an MvccNode with an upstream filter input now forwards the scalar bitset unchanged instead of promoting to all-visible. Closes https://github.com/milvus-io/milvus/issues/49735