### PR TITLE
enhance: [loaddiff] use schema as source of truth for segment load

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -5009,17 +5009,10 @@ ChunkedSegmentSealedImpl::LoadBatchFieldData(
         LoadFieldDataInfo load_field_data_info;
         load_field_data_info.storage_version =
             load_info_snapshot->GetStorageVersion();
-        // when child fields specified, field id is group id, child field ids are actual id values here
-        if (field_binlog.child_fields_size() > 0) {
-            field_ids.reserve(field_binlog.child_fields_size());
-            for (auto field_id : field_binlog.child_fields()) {
-                field_ids.emplace_back(field_id);
-            }
-        } else {
-            field_ids.emplace_back(field_binlog.fieldid());
-        }
-        AssertInfo(!field_ids.empty(), "load field data with empty field list");
-        for (const auto& field_id : field_ids) {
+        auto fields_to_load = field_ids;
+        AssertInfo(!fields_to_load.empty(),
+                   "load field data with empty field list");
+        for (const auto& field_id : fields_to_load) {
             AssertInfo(field_exists_in_schema(schema_, field_id),
                        "field {} not found in schema when loading field data",
                        field_id.get());
@@ -5032,7 +5025,7 @@ ChunkedSegmentSealedImpl::LoadBatchFieldData(
 
         bool has_warmup_setting = false;
         std::string aggregated_warmup_policy = "disable";
-        for (const auto& child_field_id : field_ids) {
+        for (const auto& child_field_id : fields_to_load) {
             auto& field_meta = schema_->operator[](child_field_id);
             if (IsVectorDataType(field_meta.get_data_type())) {
                 is_vector = true;

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -164,6 +164,25 @@ get_bit(const BitsetType& bitset, FieldId field_id) {
     return bitset[pos];
 }
 
+static inline bool
+field_exists_in_schema(const SchemaPtr& schema, FieldId field_id) {
+    return field_id.get() < START_USER_FIELDID ||
+           schema->get_fields().find(field_id) != schema->get_fields().end();
+}
+
+static inline bool
+has_bit_position(const BitsetType& bitset, FieldId field_id) {
+    auto pos = field_id.get() - START_USER_FIELDID;
+    return pos >= 0 && static_cast<size_t>(pos) < bitset.size();
+}
+
+static inline void
+clear_bit_if_present(BitsetType& bitset, FieldId field_id) {
+    if (has_bit_position(bitset, field_id)) {
+        set_bit(bitset, field_id, false);
+    }
+}
+
 static inline void
 cancel_warmup(const index::CacheIndexBasePtr& index) {
     if (index) {
@@ -1796,29 +1815,27 @@ ChunkedSegmentSealedImpl::DropFieldData(const FieldId field_id) {
                "Dropping system field is not supported, field id: {}",
                field_id.get());
     std::unique_lock<std::shared_mutex> lck(mutex_);
-    if (get_bit(field_data_ready_bitset_, field_id)) {
-        auto column = get_column(field_id);
-        // PK field: skip drop because insert record reload depends on PK data
-        if (schema_->get_primary_field_id().has_value() &&
-            schema_->get_primary_field_id().value() == field_id) {
-            LOG_INFO(
-                "Skip dropping pk field {} in segment {}", field_id.get(), id_);
-            // Still drop binlog index if present
-            if (get_bit(binlog_index_bitset_, field_id)) {
-                set_bit(binlog_index_bitset_, field_id, false);
-                vector_indexings_.drop_field_indexing(field_id);
-            }
-            return;
+    auto schema_has_field = field_exists_in_schema(schema_, field_id);
+    auto column = get_column(field_id);
+    if (schema_has_field && schema_->get_primary_field_id().has_value() &&
+        schema_->get_primary_field_id().value() == field_id) {
+        LOG_INFO(
+            "Skip dropping pk field {} in segment {}", field_id.get(), id_);
+        if (has_bit_position(binlog_index_bitset_, field_id) &&
+            get_bit(binlog_index_bitset_, field_id)) {
+            clear_bit_if_present(binlog_index_bitset_, field_id);
+            vector_indexings_.drop_field_indexing(field_id);
         }
-        // Single-field column: fully erase + clear bitset
-        if (column) {
-            column->CancelWarmup();
-        }
-        fields_.wlock()->erase(field_id);
-        set_bit(field_data_ready_bitset_, field_id, false);
+        return;
     }
-    if (get_bit(binlog_index_bitset_, field_id)) {
-        set_bit(binlog_index_bitset_, field_id, false);
+    if (column) {
+        column->CancelWarmup();
+        fields_.wlock()->erase(field_id);
+    }
+    clear_bit_if_present(field_data_ready_bitset_, field_id);
+    if (has_bit_position(binlog_index_bitset_, field_id) &&
+        get_bit(binlog_index_bitset_, field_id)) {
+        clear_bit_if_present(binlog_index_bitset_, field_id);
         vector_indexings_.drop_field_indexing(field_id);
     }
 }
@@ -1828,16 +1845,19 @@ ChunkedSegmentSealedImpl::DropIndex(const FieldId field_id) {
     AssertInfo(!SystemProperty::Instance().IsSystem(field_id),
                "Field id:" + std::to_string(field_id.get()) +
                    " isn't one of system type when drop index");
-    auto& field_meta = schema_->operator[](field_id);
-    AssertInfo(!field_meta.is_vector(), "vector field cannot drop index");
+    if (field_exists_in_schema(schema_, field_id)) {
+        auto& field_meta = schema_->operator[](field_id);
+        AssertInfo(!field_meta.is_vector(), "vector field cannot drop index");
+    }
 
     std::unique_lock lck(mutex_);
     auto [scalar_indexings, ngram_fields] =
         lock(folly::wlock(scalar_indexings_), folly::wlock(ngram_fields_));
     cancel_and_erase_scalar_index(*scalar_indexings, field_id);
     ngram_fields->erase(field_id);
+    vector_indexings_.drop_field_indexing(field_id);
 
-    set_bit(index_ready_bitset_, field_id, false);
+    clear_bit_if_present(index_ready_bitset_, field_id);
 }
 
 void
@@ -3110,6 +3130,9 @@ ChunkedSegmentSealedImpl::LoadBatchJsonKeyIndexes(
         std::shared_ptr<milvus::proto::indexcgo::LoadJsonKeyIndexInfo>>&
         infos) {
     for (const auto& [field_id, info_proto] : infos) {
+        AssertInfo(field_exists_in_schema(schema_, field_id),
+                   "field {} not found in schema when loading json stats",
+                   field_id.get());
         LoadJsonKeyIndex(op_ctx, info_proto);
     }
 }
@@ -4724,8 +4747,16 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
     bool is_replace) {
     AssertInfo(index < column_groups->size(),
                "load column group index out of range");
+    AssertInfo(!milvus_field_ids.empty(),
+               "load column group with empty field list");
     auto column_group = column_groups->at(index);
     auto load_info = std::atomic_load(&segment_load_info_);
+
+    for (const auto& field_id : milvus_field_ids) {
+        AssertInfo(field_exists_in_schema(schema_, field_id),
+                   "field {} not found in schema when loading column group",
+                   field_id.get());
+    }
 
     auto field_metas = schema_->get_field_metas(milvus_field_ids);
 
@@ -4896,6 +4927,9 @@ ChunkedSegmentSealedImpl::LoadBatchTextIndexes(
 
     load_index_futures.reserve(text_indexes_to_load.size());
     for (auto& [field_id, load_text_index_info] : text_indexes_to_load) {
+        AssertInfo(field_exists_in_schema(schema_, field_id),
+                   "field {} not found in schema when loading text index",
+                   field_id.get());
         auto future = pool.Submit(
             [this, op_ctx, info = std::move(load_text_index_info)]() mutable
             -> void { LoadTextIndex(op_ctx, std::move(info)); });
@@ -4918,6 +4952,9 @@ ChunkedSegmentSealedImpl::LoadBatchIndexes(
 
     for (auto& pair : field_id_to_index_info) {
         auto field_id = pair.first;
+        AssertInfo(field_exists_in_schema(schema_, field_id),
+                   "field {} not found in schema when loading index",
+                   field_id.get());
         auto& index_infos = pair.second;
         for (auto& load_index_info : index_infos) {
             auto* load_index_info_ptr = &load_index_info;
@@ -4980,6 +5017,12 @@ ChunkedSegmentSealedImpl::LoadBatchFieldData(
             }
         } else {
             field_ids.emplace_back(field_binlog.fieldid());
+        }
+        AssertInfo(!field_ids.empty(), "load field data with empty field list");
+        for (const auto& field_id : field_ids) {
+            AssertInfo(field_exists_in_schema(schema_, field_id),
+                       "field {} not found in schema when loading field data",
+                       field_id.get());
         }
 
         bool index_has_raw_data = true;
@@ -5117,7 +5160,7 @@ ChunkedSegmentSealedImpl::Load(milvus::tracer::TraceContext& trace_ctx,
     auto num_rows = snapshot->GetNumOfRows();
     LOG_INFO("Loading segment {} with {} rows", id_, num_rows);
 
-    SegmentLoadInfo mutable_copy(*snapshot);
+    SegmentLoadInfo mutable_copy(snapshot->GetProto(), schema_);
     auto diff = mutable_copy.GetLoadDiff();
     LOG_WARN("Load segment {} with diff {}", id_, diff.ToString());
     ApplyLoadDiff(op_ctx, mutable_copy, diff);

--- a/internal/core/src/segcore/SegmentLoadInfo.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfo.cpp
@@ -273,9 +273,11 @@ SegmentLoadInfo::ComputeDiffIndexes(LoadDiff& diff, SegmentLoadInfo& new_info) {
 
     // Find indexes to drop: fields that have indexes in current but not in new_info
     for (const auto& load_index_info : converted_index_infos_) {
-        if (new_index_ids.find(load_index_info.index_id) ==
-            new_index_ids.end()) {
-            diff.indexes_to_drop.insert(FieldId(load_index_info.field_id));
+        auto field_id = FieldId(load_index_info.field_id);
+        if (!new_info.HasFieldInSchema(field_id) ||
+            new_index_ids.find(load_index_info.index_id) ==
+                new_index_ids.end()) {
+            diff.indexes_to_drop.insert(field_id);
         }
     }
 }
@@ -339,6 +341,10 @@ SegmentLoadInfo::ComputeDiffBinlogs(LoadDiff& diff, SegmentLoadInfo& new_info) {
             !same_binlog_files(*cur_field_binlog, new_field_binlog);
 
         for (auto child_id : child_fields) {
+            auto child_field_id = FieldId(child_id);
+            if (!new_info.HasFieldInSchema(child_field_id)) {
+                continue;
+            }
             new_binlog_fields[child_id] = new_field_binlog.fieldid();
             // current_fields is keyed by child field id, so look up the
             // child — keying by new_field_binlog.fieldid() misses multi-
@@ -359,7 +365,7 @@ SegmentLoadInfo::ComputeDiffBinlogs(LoadDiff& diff, SegmentLoadInfo& new_info) {
             // Pre-existing children go to replace (to evict stale cached
             // columns); genuinely new children go to load.
             if (current_fields.find(child_id) != current_fields.end() ||
-                fields_filled_with_default_.count(FieldId(child_id)) > 0) {
+                fields_filled_with_default_.count(child_field_id) > 0) {
                 ids_to_replace.emplace_back(child_id);
             } else {
                 ids_to_load.emplace_back(child_id);
@@ -376,9 +382,14 @@ SegmentLoadInfo::ComputeDiffBinlogs(LoadDiff& diff, SegmentLoadInfo& new_info) {
 
     // Find field data to drop: fields in current but not in new_info
     for (const auto& [field_id, group_id] : current_fields) {
+        auto fid = FieldId(field_id);
+        if (!new_info.HasFieldInSchema(fid)) {
+            diff.field_data_to_drop.emplace(field_id);
+            continue;
+        }
         if (new_binlog_fields.find(field_id) == new_binlog_fields.end()) {
-            if (prefer_field_data && new_info.field_index_has_raw_data_.count(
-                                         FieldId(field_id)) > 0) {
+            if (prefer_field_data &&
+                new_info.field_index_has_raw_data_.count(fid) > 0) {
                 continue;
             }
             diff.field_data_to_drop.emplace(field_id);
@@ -448,11 +459,15 @@ SegmentLoadInfo::ComputeDiffColumnGroups(LoadDiff& diff,
         std::vector<FieldId> lazy_replace_fields;
         for (const auto& column : cg->columns) {
             auto field_id = std::stoll(column);
+            auto fid = FieldId(field_id);
+            if (!new_info.HasFieldInSchema(fid)) {
+                continue;
+            }
             new_seen_field_ids.emplace(field_id);
 
             auto cur_iter = cur_field_to_files.find(field_id);
             bool was_default_filled =
-                fields_filled_with_default_.count(FieldId(field_id)) > 0;
+                fields_filled_with_default_.count(fid) > 0;
             bool is_new_field =
                 cur_iter == cur_field_to_files.end() && !was_default_filled;
             // A field that was present in current must go to replace when
@@ -464,12 +479,12 @@ SegmentLoadInfo::ComputeDiffColumnGroups(LoadDiff& diff,
                                  !same_files(*cur_iter->second, cg->files);
             bool is_replace_field = was_default_filled || files_changed;
             bool index_has_raw_data =
-                new_info.field_index_has_raw_data_.count(FieldId(field_id)) > 0;
+                new_info.field_index_has_raw_data_.count(fid) > 0;
             // Eager-load when: system field, OR schema says load AND
             // (we want to keep field data alongside index, OR index can't serve raw).
             bool should_eager_load =
                 field_id < START_USER_FIELDID ||
-                (schema_->ShouldLoadField(FieldId(field_id)) &&
+                (new_info.schema_->ShouldLoadField(fid) &&
                  (prefer_field_data || !index_has_raw_data));
             if (is_new_field) {
                 // Field not in current and not default-filled → new load
@@ -520,9 +535,14 @@ SegmentLoadInfo::ComputeDiffColumnGroups(LoadDiff& diff,
 
     // Find field data to drop: fields in current but not in new
     for (const auto& [field_id, files_ptr] : cur_field_to_files) {
+        auto fid = FieldId(field_id);
+        if (!new_info.HasFieldInSchema(fid)) {
+            diff.field_data_to_drop.emplace(field_id);
+            continue;
+        }
         if (new_seen_field_ids.find(field_id) == new_seen_field_ids.end()) {
-            if (prefer_field_data && new_info.field_index_has_raw_data_.count(
-                                         FieldId(field_id)) > 0) {
+            if (prefer_field_data &&
+                new_info.field_index_has_raw_data_.count(fid) > 0) {
                 continue;
             }
             diff.field_data_to_drop.emplace(field_id);
@@ -541,6 +561,9 @@ SegmentLoadInfo::ComputeDiffReloadFields(LoadDiff& diff,
     // Collect fields that need reload (index no longer has raw data)
     std::set<FieldId> fields_to_reload;
     for (const auto& field_id : field_index_has_raw_data_) {
+        if (!new_info.HasFieldInSchema(field_id)) {
+            continue;
+        }
         if (new_info.field_index_has_raw_data_.find(field_id) ==
             new_info.field_index_has_raw_data_.end()) {
             fields_to_reload.emplace(field_id);
@@ -651,8 +674,8 @@ SegmentLoadInfo::ComputeDiffDefaultFields(LoadDiff& diff,
     current_handled.insert(fields_filled_with_default_.begin(),
                            fields_filled_with_default_.end());
 
-    // Compute: schema_fields - new_info_fields - current_handled
-    for (const auto& [field_id, field_meta] : schema_->get_fields()) {
+    // Compute: new schema fields - new_info_fields - current_handled
+    for (const auto& [field_id, field_meta] : new_info.schema_->get_fields()) {
         if (field_id.get() < START_USER_FIELDID) {
             continue;
         }
@@ -725,6 +748,9 @@ SegmentLoadInfo::ComputeDiffTextIndexes(LoadDiff& diff,
         new_text_indexed;
     for (const auto& [field_id, stats] : new_info.GetTextStatsLogs()) {
         auto fid = FieldId(field_id);
+        if (!new_info.HasFieldInSchema(fid)) {
+            continue;
+        }
         auto it = new_text_indexed.find(fid);
         if (it == new_text_indexed.end() ||
             stats.version() > it->second->version()) {
@@ -743,7 +769,7 @@ SegmentLoadInfo::ComputeDiffTextIndexes(LoadDiff& diff,
     }
 
     // Find text indexes to create: enable_match fields without pre-built index
-    for (const auto& [field_id, field_meta] : schema_->get_fields()) {
+    for (const auto& [field_id, field_meta] : new_info.schema_->get_fields()) {
         if (!field_meta.enable_match()) {
             continue;
         }
@@ -785,6 +811,9 @@ SegmentLoadInfo::ComputeDiffJsonKeyStats(LoadDiff& diff,
     std::set<FieldId> new_fields;
     for (const auto& [field_id, stats] : new_info.GetJsonKeyStatsLogs()) {
         auto fid = FieldId(field_id);
+        if (!new_info.HasFieldInSchema(fid)) {
+            continue;
+        }
         new_fields.insert(fid);
         auto current_stats = GetJsonKeyStatsLog(field_id);
         if (stats.json_key_stats_data_format() != expected_format) {

--- a/internal/core/src/segcore/SegmentLoadInfo.h
+++ b/internal/core/src/segcore/SegmentLoadInfo.h
@@ -564,6 +564,13 @@ class SegmentLoadInfo {
         return info_.use_take_for_output();
     }
 
+    [[nodiscard]] bool
+    HasFieldInSchema(FieldId field_id) const {
+        return field_id.get() < START_USER_FIELDID ||
+               schema_->get_fields().find(field_id) !=
+                   schema_->get_fields().end();
+    }
+
     [[nodiscard]] int64_t
     GetEstimatedBytesPerRow() const {
         return info_.estimated_bytes_per_row();
@@ -1043,10 +1050,13 @@ class SegmentLoadInfo {
             if (index_info.index_file_paths_size() == 0) {
                 continue;
             }
+            auto field_id = FieldId(index_info.fieldid());
+            if (!HasFieldInSchema(field_id)) {
+                continue;
+            }
             auto load_index_info = ConvertFieldIndexInfoToLoadIndexInfo(
                 &index_info, info_.segmentid());
             converted_index_infos_.push_back(load_index_info);
-            auto field_id = FieldId(index_info.fieldid());
             // Check if index has raw data before moving
             if (CheckIndexHasRawData(load_index_info)) {
                 field_index_has_raw_data_.insert(field_id);

--- a/internal/core/src/segcore/SegmentLoadInfoTest.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfoTest.cpp
@@ -2718,6 +2718,34 @@ TEST_F(SegmentLoadInfoTest, ComputeDiffSkipsNewBinlogForDroppedField) {
     EXPECT_TRUE(diff.binlogs_to_replace.empty());
 }
 
+TEST_F(SegmentLoadInfoTest,
+       ComputeDiffFiltersDroppedChildFromMixedBinlogGroup) {
+    proto::segcore::SegmentLoadInfo current_proto;
+    current_proto.set_segmentid(100);
+    current_proto.set_num_of_rows(1000);
+
+    proto::segcore::SegmentLoadInfo new_proto;
+    new_proto.set_segmentid(100);
+    new_proto.set_num_of_rows(1000);
+    auto* mixed_binlog = new_proto.add_binlog_paths();
+    mixed_binlog->set_fieldid(104);
+    mixed_binlog->add_child_fields(105);
+    mixed_binlog->add_child_fields(106);
+    auto* log = mixed_binlog->add_binlogs();
+    log->set_log_path("/path/to/mixed_binlog");
+    log->set_entries_num(1000);
+
+    auto latest_schema = MakeSchemaWithFieldIds({100, 105});
+    SegmentLoadInfo current_info(current_proto, latest_schema);
+    SegmentLoadInfo new_info(new_proto, latest_schema);
+    auto diff = current_info.ComputeDiff(new_info);
+
+    ASSERT_EQ(diff.binlogs_to_load.size(), 1);
+    ASSERT_EQ(diff.binlogs_to_load[0].first.size(), 1);
+    EXPECT_EQ(diff.binlogs_to_load[0].first[0].get(), 105);
+    EXPECT_TRUE(diff.binlogs_to_replace.empty());
+}
+
 TEST_F(SegmentLoadInfoTest, ComputeDiffSkipsNewManifestColumnForDroppedField) {
     auto latest_schema = MakeSchemaWithFieldIds({100, 101});
     SegmentLoadInfo current_info(MakeManifestProto("/manifest/old"),

--- a/internal/core/src/segcore/SegmentLoadInfoTest.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfoTest.cpp
@@ -11,8 +11,11 @@
 
 #include <gtest/gtest.h>
 #include <stdint.h>
+#include <algorithm>
+#include <initializer_list>
 #include <iostream>
 #include <memory>
+#include <optional>
 #include <set>
 #include <string>
 #include <unordered_map>
@@ -2656,7 +2659,151 @@ MakeManifestProto(const std::string& manifest_path) {
     return p;
 }
 
+SchemaPtr
+MakeSchemaWithFieldIds(std::initializer_list<int64_t> field_ids) {
+    auto schema = std::make_shared<Schema>();
+    for (auto field_id : field_ids) {
+        schema->AddField(FieldName("field_" + std::to_string(field_id)),
+                         FieldId(field_id),
+                         DataType::INT64,
+                         false,
+                         std::nullopt);
+    }
+    if (std::find(field_ids.begin(), field_ids.end(), 100) != field_ids.end()) {
+        schema->set_primary_field_id(FieldId(100));
+    }
+    return schema;
+}
+
 }  // namespace
+
+TEST_F(SegmentLoadInfoTest, ConstructSkipsIndexInfoForDroppedField) {
+    proto::segcore::SegmentLoadInfo p;
+    p.set_segmentid(100);
+    p.set_num_of_rows(1000);
+    auto* index_info = p.add_index_infos();
+    index_info->set_fieldid(102);
+    index_info->set_indexid(1002);
+    index_info->add_index_file_paths("/path/to/stale_index");
+    auto* index_param = index_info->add_index_params();
+    index_param->set_key("index_type");
+    index_param->set_value(milvus::index::INVERTED_INDEX_TYPE);
+
+    SegmentLoadInfo info(p, MakeSchemaWithFieldIds({100, 101}));
+
+    EXPECT_FALSE(info.HasIndexInfo(FieldId(102)));
+    EXPECT_TRUE(info.GetIndexedFieldIds().empty());
+}
+
+TEST_F(SegmentLoadInfoTest, ComputeDiffSkipsNewBinlogForDroppedField) {
+    proto::segcore::SegmentLoadInfo current_proto;
+    current_proto.set_segmentid(100);
+    current_proto.set_num_of_rows(1000);
+
+    proto::segcore::SegmentLoadInfo new_proto;
+    new_proto.set_segmentid(100);
+    new_proto.set_num_of_rows(1000);
+    auto* stale_binlog = new_proto.add_binlog_paths();
+    stale_binlog->set_fieldid(102);
+    auto* log = stale_binlog->add_binlogs();
+    log->set_log_path("/path/to/stale_binlog");
+    log->set_entries_num(1000);
+
+    auto latest_schema = MakeSchemaWithFieldIds({100, 101});
+    SegmentLoadInfo current_info(current_proto, latest_schema);
+    SegmentLoadInfo new_info(new_proto, latest_schema);
+    auto diff = current_info.ComputeDiff(new_info);
+
+    EXPECT_TRUE(diff.binlogs_to_load.empty());
+    EXPECT_TRUE(diff.binlogs_to_replace.empty());
+}
+
+TEST_F(SegmentLoadInfoTest, ComputeDiffSkipsNewManifestColumnForDroppedField) {
+    auto latest_schema = MakeSchemaWithFieldIds({100, 101});
+    SegmentLoadInfo current_info(MakeManifestProto("/manifest/old"),
+                                 latest_schema);
+    current_info.SetColumnGroupsForTesting(MakeColumnGroups({}));
+    SegmentLoadInfo new_info(MakeManifestProto("/manifest/new"), latest_schema);
+    new_info.SetColumnGroupsForTesting(
+        MakeColumnGroups({{{102}, {"/path/to/stale.parquet"}}}));
+
+    auto diff = current_info.ComputeDiff(new_info);
+
+    EXPECT_TRUE(diff.column_groups_to_load.empty());
+    EXPECT_TRUE(diff.column_groups_to_replace.empty());
+    EXPECT_TRUE(diff.column_groups_to_lazyload.empty());
+    EXPECT_TRUE(diff.column_groups_to_lazyreplace.empty());
+}
+
+TEST_F(SegmentLoadInfoTest, ComputeDiffDropsManifestFieldRemovedFromSchema) {
+    auto current_schema = MakeSchemaWithFieldIds({100, 102});
+    auto latest_schema = MakeSchemaWithFieldIds({100});
+    SegmentLoadInfo current_info(MakeManifestProto("/manifest/old"),
+                                 current_schema);
+    current_info.SetColumnGroupsForTesting(
+        MakeColumnGroups({{{102}, {"/path/to/old.parquet"}}}));
+    SegmentLoadInfo new_info(MakeManifestProto("/manifest/new"), latest_schema);
+    new_info.SetColumnGroupsForTesting(
+        MakeColumnGroups({{{102}, {"/path/to/stale.parquet"}}}));
+
+    auto diff = current_info.ComputeDiff(new_info);
+
+    EXPECT_TRUE(diff.field_data_to_drop.count(FieldId(102)) > 0);
+    EXPECT_TRUE(diff.column_groups_to_load.empty());
+    EXPECT_TRUE(diff.column_groups_to_replace.empty());
+    EXPECT_TRUE(diff.column_groups_to_lazyload.empty());
+    EXPECT_TRUE(diff.column_groups_to_lazyreplace.empty());
+}
+
+TEST_F(SegmentLoadInfoTest, ComputeDiffDefaultFieldsUsesNewSchema) {
+    proto::segcore::SegmentLoadInfo current_proto;
+    current_proto.set_segmentid(100);
+    current_proto.set_num_of_rows(1000);
+    auto* current_binlog = current_proto.add_binlog_paths();
+    current_binlog->set_fieldid(100);
+    auto* current_log = current_binlog->add_binlogs();
+    current_log->set_log_path("/path/to/pk");
+    current_log->set_entries_num(1000);
+
+    proto::segcore::SegmentLoadInfo new_proto = current_proto;
+
+    SegmentLoadInfo current_info(current_proto, MakeSchemaWithFieldIds({100}));
+    SegmentLoadInfo new_info(new_proto, MakeSchemaWithFieldIds({100, 101}));
+    auto diff = current_info.ComputeDiff(new_info);
+
+    EXPECT_EQ(diff.fields_to_fill_default.size(), 1);
+    EXPECT_EQ(diff.fields_to_fill_default[0].get(), 101);
+}
+
+TEST_F(SegmentLoadInfoTest,
+       ComputeDiffDropsResourcesForFieldRemovedFromSchema) {
+    proto::segcore::SegmentLoadInfo current_proto;
+    current_proto.set_segmentid(100);
+    current_proto.set_num_of_rows(1000);
+    auto* index_info = current_proto.add_index_infos();
+    index_info->set_fieldid(102);
+    index_info->set_indexid(1002);
+    index_info->add_index_file_paths("/path/to/stale_index");
+    auto* index_param = index_info->add_index_params();
+    index_param->set_key("index_type");
+    index_param->set_value(milvus::index::INVERTED_INDEX_TYPE);
+    auto* binlog = current_proto.add_binlog_paths();
+    binlog->set_fieldid(102);
+    auto* log = binlog->add_binlogs();
+    log->set_log_path("/path/to/stale_binlog");
+    log->set_entries_num(1000);
+
+    proto::segcore::SegmentLoadInfo new_proto = current_proto;
+    SegmentLoadInfo current_info(current_proto,
+                                 MakeSchemaWithFieldIds({100, 102}));
+    SegmentLoadInfo new_info(new_proto, MakeSchemaWithFieldIds({100}));
+    auto diff = current_info.ComputeDiff(new_info);
+
+    EXPECT_TRUE(diff.indexes_to_drop.count(FieldId(102)) > 0);
+    EXPECT_TRUE(diff.field_data_to_drop.count(FieldId(102)) > 0);
+    EXPECT_TRUE(diff.indexes_to_load.empty());
+    EXPECT_TRUE(diff.binlogs_to_load.empty());
+}
 
 TEST_F(SegmentLoadInfoTest,
        ComputeDiffColumnGroupSameIndexDifferentFilesTriggersReplace) {


### PR DESCRIPTION
Related to #46358 #48983

Make sealed segment loading compute load diffs against the latest schema as the single source of truth. New-side stale metadata for dropped fields is ignored for loading, while existing field data and indexes for fields removed from schema are scheduled for drop.

Update ChunkedSegmentSealedImpl to assert if schema-absent fields reach load paths, and make drop cleanup tolerate schema-shrunk bitsets. Add SegmentLoadInfo coverage for stale binlog, manifest, and index metadata after drop-field schema evolution.