### PR TITLE
fix: [3.0] use default filesystem for JSON stats load (#49721)

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -3007,8 +3007,7 @@ ChunkedSegmentSealedImpl::LoadJsonKeyIndex(
     auto remote_chunk_manager =
         milvus::storage::RemoteChunkManagerSingleton::GetInstance()
             .GetRemoteChunkManager();
-    auto fs = milvus_storage::ArrowFileSystemSingleton::GetInstance()
-                  .GetArrowFileSystem();
+    auto fs = milvus::segcore::GetDefaultArrowFileSystem();
     AssertInfo(fs != nullptr, "arrow file system is null");
 
     milvus::Config config;


### PR DESCRIPTION
Cherry-pick from master
pr: #49721
Related to #49592 #49521

Branching introduced by those two PRs.

Resolve the Arrow filesystem for JSON stats loading through the shared segcore default filesystem helper, matching the rest of sealed segment load paths and avoiding reliance on the legacy ArrowFileSystemSingleton.