### PR TITLE
enhance:[3.0] bump storage to 9f52b3b

### DIFF
--- a/.env
+++ b/.env
@@ -5,8 +5,8 @@ IMAGE_ARCH=amd64
 OS_NAME=ubuntu22.04
 
 # for services.builder.image in docker-compose.yml
-DATE_VERSION=20260419-63b9f9f
-LATEST_DATE_VERSION=20260419-63b9f9f
+DATE_VERSION=20260506-b5f57d9
+LATEST_DATE_VERSION=20260506-b5f57d9
 # for services.gpubuilder.image in docker-compose.yml
 GPU_DATE_VERSION=20260506-b5f57d9
 LATEST_GPU_DATE_VERSION=20260506-b5f57d9

--- a/internal/core/thirdparty/milvus-storage/CMakeLists.txt
+++ b/internal/core/thirdparty/milvus-storage/CMakeLists.txt
@@ -15,7 +15,7 @@
 milvus_add_pkg_config("milvus-storage")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
 
-set( milvus-storage_VERSION 23399cf)
+set( milvus-storage_VERSION 9f52b3b)
 set( GIT_REPOSITORY  "https://github.com/milvus-io/milvus-storage.git")
 message(STATUS "milvus-storage repo: ${GIT_REPOSITORY}")
 message(STATUS "milvus-storage version: ${milvus-storage_VERSION}")


### PR DESCRIPTION
pr: #49615

#49589 missing change the DATE_VERSION and LATEST_DATE_VERSION which make rust version in CI have not been updated in 3.0 branch 