### PR TITLE
fix: [2.6] Preserve array op rows on null payload

### DIFF
--- a/internal/proxy/task_upsert.go
+++ b/internal/proxy/task_upsert.go
@@ -420,6 +420,17 @@ func (it *upsertTask) queryPreExecute(ctx context.Context) error {
 		existByName := lo.SliceToMap(existFieldData, func(f *schemapb.FieldData) (string, *schemapb.FieldData) {
 			return f.GetFieldName(), f
 		})
+		genericUpdateFieldData := it.upsertMsg.InsertMsg.GetFieldsData()
+		if fieldOpMap != nil {
+			genericUpdateFieldData = make([]*schemapb.FieldData, 0, len(genericUpdateFieldData))
+			for _, fieldData := range it.upsertMsg.InsertMsg.GetFieldsData() {
+				op, ok := fieldOpMap[fieldData.GetFieldName()]
+				if ok && op != schemapb.FieldPartialUpdateOp_REPLACE {
+					continue
+				}
+				genericUpdateFieldData = append(genericUpdateFieldData, fieldData)
+			}
+		}
 
 		baseIdx := 0
 		for _, idx := range updateIdxInUpsert {
@@ -430,13 +441,14 @@ func (it *upsertTask) queryPreExecute(ctx context.Context) error {
 				return merr.WrapErrParameterInvalidMsg("primary key not found in exist data mapping")
 			}
 			typeutil.AppendFieldData(it.insertFieldData, existFieldData, int64(existIndex))
-			if err := typeutil.UpdateFieldData(it.insertFieldData, it.upsertMsg.InsertMsg.GetFieldsData(), int64(baseIdx), int64(idx)); err != nil {
+			if err := typeutil.UpdateFieldData(it.insertFieldData, genericUpdateFieldData, int64(baseIdx), int64(idx)); err != nil {
 				log.Info("update field data failed", zap.Error(err))
 				return err
 			}
-			// Per-row Array partial-op: dstField just got REPLACE'd with the
-			// upsert row above; overwrite it with ApplyArrayRowOp(existing
-			// row, upsert row) for any field carrying a non-REPLACE op.
+			// Per-row Array partial-op: generic REPLACE intentionally
+			// skipped non-REPLACE op fields, so dstField still carries the
+			// existing row appended above. Overwrite it with
+			// ApplyArrayRowOp(existing row, upsert row).
 			if fieldOpMap != nil {
 				for _, dstField := range it.insertFieldData {
 					op, ok := fieldOpMap[dstField.GetFieldName()]

--- a/internal/proxy/task_upsert_partial_op.go
+++ b/internal/proxy/task_upsert_partial_op.go
@@ -30,8 +30,8 @@ import (
 // applyArrayPartialOpOnRow overwrites dstField[baseIdx] with
 // ApplyArrayRowOp(existField[existIdx], upsertField[upsertIdx]) using the
 // given op + elementType + maxCapacity. dstField is assumed to already carry
-// a scalar Array layout at baseIdx (placed there by AppendFieldData +
-// UpdateFieldData in the per-row merge loop).
+// the existing row at baseIdx, placed there by AppendFieldData in the per-row
+// merge loop.
 func applyArrayPartialOpOnRow(
 	dstField, existField, upsertField *schemapb.FieldData,
 	baseIdx, existIdx, upsertIdx int64,

--- a/internal/proxy/task_upsert_test.go
+++ b/internal/proxy/task_upsert_test.go
@@ -1383,6 +1383,109 @@ func TestUpsertTask_queryPreExecute_PureUpdate(t *testing.T) {
 	assert.Equal(t, []int32{600, 700}, valueField.GetScalars().GetIntData().GetData())
 }
 
+func TestUpsertTask_queryPreExecute_ArrayPartialOpSkipsGenericReplace(t *testing.T) {
+	schema := newSchemaInfo(&schemapb.CollectionSchema{
+		Name: "test_array_partial_op_skip_replace",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "id", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+			{
+				FieldID:     101,
+				Name:        "tags",
+				DataType:    schemapb.DataType_Array,
+				ElementType: schemapb.DataType_Int64,
+				Nullable:    true,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.MaxCapacityKey, Value: "16"},
+				},
+			},
+			{FieldID: 102, Name: "note", DataType: schemapb.DataType_VarChar, Nullable: true},
+		},
+	})
+
+	upsertTags := arrayLongFieldData("tags", [][]int64{{3}})
+	upsertTags.FieldId = 101
+	upsertTags.ValidData = []bool{true, false}
+	upsertData := []*schemapb.FieldData{
+		{
+			FieldName: "id", FieldId: 100, Type: schemapb.DataType_Int64,
+			Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{1, 2}}}}},
+		},
+		upsertTags,
+		{
+			FieldName: "note", FieldId: 102, Type: schemapb.DataType_VarChar,
+			Field:     &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"new1"}}}}},
+			ValidData: []bool{true, false},
+		},
+	}
+	numRows := uint64(2)
+
+	existingTags := arrayLongFieldData("tags", [][]int64{{10, 20}, {100, 200}})
+	existingTags.FieldId = 101
+	existingTags.ValidData = []bool{true, true}
+	mockQueryResult := &milvuspb.QueryResults{
+		Status: merr.Success(),
+		FieldsData: []*schemapb.FieldData{
+			{
+				FieldName: "id", FieldId: 100, Type: schemapb.DataType_Int64,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{1, 2}}}}},
+			},
+			existingTags,
+			{
+				FieldName: "note", FieldId: 102, Type: schemapb.DataType_VarChar,
+				Field:     &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"old1", "old2"}}}}},
+				ValidData: []bool{true, true},
+			},
+		},
+	}
+
+	task := &upsertTask{
+		ctx:    context.Background(),
+		schema: schema,
+		req: &milvuspb.UpsertRequest{
+			FieldsData:    upsertData,
+			NumRows:       uint32(numRows),
+			PartialUpdate: true,
+			FieldOps:      []*schemapb.FieldPartialUpdateOp{op("tags", schemapb.FieldPartialUpdateOp_ARRAY_APPEND)},
+		},
+		upsertMsg: &msgstream.UpsertMsg{
+			InsertMsg: &msgstream.InsertMsg{
+				InsertRequest: &msgpb.InsertRequest{
+					FieldsData: upsertData,
+					NumRows:    numRows,
+					Version:    msgpb.InsertDataVersion_ColumnBased,
+				},
+			},
+		},
+		node: &Proxy{},
+	}
+
+	mockRetrieve := mockey.Mock(retrieveByPKs).Return(mockQueryResult, segcore.StorageCost{}, nil).Build()
+	defer mockRetrieve.UnPatch()
+
+	err := task.queryPreExecute(context.Background())
+	assert.NoError(t, err)
+
+	var tagsField *schemapb.FieldData
+	var noteField *schemapb.FieldData
+	for _, f := range task.insertFieldData {
+		switch f.GetFieldName() {
+		case "tags":
+			tagsField = f
+		case "note":
+			noteField = f
+		}
+	}
+	assert.NotNil(t, tagsField)
+	assert.Equal(t, []bool{true, true}, tagsField.ValidData)
+	tagRows := tagsField.GetScalars().GetArrayData().GetData()
+	assert.Equal(t, []int64{10, 20, 3}, tagRows[0].GetLongData().GetData())
+	assert.Equal(t, []int64{100, 200}, tagRows[1].GetLongData().GetData())
+
+	assert.NotNil(t, noteField)
+	assert.Equal(t, []bool{true, false}, noteField.ValidData)
+	assert.Equal(t, []string{"new1"}, noteField.GetScalars().GetStringData().GetData())
+}
+
 // Test ToCompressedFormatNullable for Geometry and Timestamptz types
 func TestToCompressedFormatNullable_GeometryAndTimestamptz(t *testing.T) {
 	t.Run("timestamptz with null values", func(t *testing.T) {


### PR DESCRIPTION
issue: #49746
pr: #49251
## What changed

This fixes the 2.6 row-level partial-update merge path for Array fields
that use `ARRAY_APPEND` or `ARRAY_REMOVE`.

For non-`REPLACE` Array field ops, the proxy now skips generic
`UpdateFieldData` replacement and lets the Array op path merge directly
from the existing row and the payload row. This prevents a null payload
row from marking the destination row invalid before the op path decides
that null means "leave the existing row unchanged".

## Why

Related feature issue: [#49241](https://github.com/milvus-io/milvus/issues/49241)

Bug report: [#49746](https://github.com/milvus-io/milvus/issues/49746)

On 2.6, the row-level merge first appended the existing row, then ran
generic replace for every payload field. When an `ARRAY_APPEND` payload
row was null, generic replace set `ValidData=false`; the later Array op
helper skipped the null payload and left that invalid bit in place.

## Validation

- `git diff --check`
- `go test -tags dynamic,test github.com/milvus-io/milvus/pkg/v2/util/typeutil -run 'TestUpdateArrayFieldByColumnWithOp_SkipsNullUpdatePayload|TestUpdateArrayFieldByColumnWithOp_FlipsValidDataOnMerge' -v -count=1`

`internal/proxy` targeted test was not run locally because this worktree
has no `internal/core/output`, and `make build-cpp` is blocked by the
local Conan binary not reporting Conan 1.x.
