### PR TITLE
fix: keep nullable vector bitsets alive

### DIFF
--- a/internal/core/src/common/QueryResult.h
+++ b/internal/core/src/common/QueryResult.h
@@ -27,9 +27,11 @@
 #include <boost/dynamic_bitset.hpp>
 #include <NamedType/named_type.hpp>
 
+#include "common/BitsetView.h"
 #include "common/FieldMeta.h"
 #include "common/ArrayOffsets.h"
 #include "common/OffsetMapping.h"
+#include "common/Types.h"
 #include "pb/schema.pb.h"
 #include "knowhere/index/index_node.h"
 
@@ -277,6 +279,14 @@ struct SearchResult {
         this->vector_iterators_ = vector_iterators;
     }
 
+    BitsetView
+    PinBitset(TargetBitmap&& bitset) {
+        auto pinned = std::make_unique<TargetBitmap>(std::move(bitset));
+        auto view = BitsetView(*pinned);
+        pinned_bitsets_.emplace_back(std::move(pinned));
+        return view;
+    }
+
  public:
     int64_t total_nq_;
     int64_t unity_topK_;
@@ -322,6 +332,7 @@ struct SearchResult {
         element_iterators_;
     std::shared_ptr<const IArrayOffsets> array_offsets_{nullptr};
     std::vector<std::unique_ptr<uint8_t[]>> chunk_buffers_{};
+    std::vector<TargetBitmapPtr> pinned_bitsets_{};
 
     bool
     HasIterators() const {

--- a/internal/core/src/query/SearchOnGrowing.cpp
+++ b/internal/core/src/query/SearchOnGrowing.cpp
@@ -186,7 +186,6 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
         BitsetView search_bitset = bitset;
         if (offset_mapping.IsEnabled()) {
             transformed_bitset = TransformBitset(bitset, offset_mapping);
-            search_bitset = BitsetView(transformed_bitset);
         }
 
         auto active_count = offset_mapping.IsEnabled()
@@ -204,6 +203,10 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
             search_result.unity_topK_ = info.topk_;
             return;
         }
+        if (offset_mapping.IsEnabled()) {
+            search_bitset =
+                search_result.PinBitset(std::move(transformed_bitset));
+        }
 
         // Element-level search (embedding-search-embedding): knowhere sees
         // a scalar vector type and the per-chunk size must be measured in
@@ -216,6 +219,7 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
             info.array_offsets_ != nullptr;
         const auto iter_data_type =
             is_element_level_search ? element_type : data_type;
+        const bool use_vector_iterator = milvus::exec::UseVectorIterator(info);
 
         if (info.iterator_v2_info_.has_value()) {
             AssertInfo(iter_data_type != DataType::VECTOR_ARRAY,
@@ -304,7 +308,7 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
                 }
             }
 
-            if (milvus::exec::UseVectorIterator(info)) {
+            if (use_vector_iterator) {
                 AssertInfo(iter_data_type != DataType::VECTOR_ARRAY,
                            "vector array(embedding list) is not supported for "
                            "vector iterator");
@@ -333,7 +337,7 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
                 final_qr.merge(sub_qr);
             }
         }
-        if (milvus::exec::UseVectorIterator(info)) {
+        if (use_vector_iterator) {
             bool larger_is_closer = PositivelyRelated(info.metric_type_);
             // Element-level search skips row-level mapping (element IDs are
             // not row-aligned); see ChunkMergeIterator ctor.

--- a/internal/core/src/query/SearchOnIndex.cpp
+++ b/internal/core/src/query/SearchOnIndex.cpp
@@ -50,7 +50,6 @@ SearchOnIndex(const dataset::SearchDataset& search_dataset,
     BitsetView search_bitset = bitset;
     if (offset_mapping.IsEnabled()) {
         transformed_bitset = TransformBitset(bitset, offset_mapping);
-        search_bitset = BitsetView(transformed_bitset);
         if (offset_mapping.GetValidCount() == 0) {
             // All vectors are null, return empty result
             auto total_num = num_queries * search_conf.topk_;
@@ -60,6 +59,7 @@ SearchOnIndex(const dataset::SearchDataset& search_dataset,
             search_result.unity_topK_ = search_conf.topk_;
             return;
         }
+        search_bitset = search_result.PinBitset(std::move(transformed_bitset));
     }
 
     if (milvus::exec::PrepareVectorIteratorsFromIndex(search_conf,

--- a/internal/core/src/query/SearchOnSealed.cpp
+++ b/internal/core/src/query/SearchOnSealed.cpp
@@ -100,7 +100,6 @@ SearchOnSealedIndex(const Schema& schema,
     BitsetView search_bitset = bitset;
     if (offset_mapping.IsEnabled()) {
         transformed_bitset = TransformBitset(bitset, offset_mapping);
-        search_bitset = BitsetView(transformed_bitset);
         if (offset_mapping.GetValidCount() == 0) {
             auto total_num = num_queries * topK;
             search_result.seg_offsets_.resize(total_num, INVALID_SEG_OFFSET);
@@ -109,6 +108,7 @@ SearchOnSealedIndex(const Schema& schema,
             search_result.unity_topK_ = topK;
             return;
         }
+        search_bitset = search_result.PinBitset(std::move(transformed_bitset));
     }
 
     if (search_info.iterator_v2_info_.has_value()) {
@@ -188,7 +188,6 @@ SearchOnSealedColumn(const Schema& schema,
             column->EnsureChunkOffsetMapping(c, op_context);
         }
         transformed_bitset = TransformBitset(bitview, offset_mapping);
-        search_bitview = BitsetView(transformed_bitset);
         if (offset_mapping.GetValidCount() == 0) {
             // All vectors are null, return empty result
             auto total_num = num_queries * search_info.topk_;
@@ -198,6 +197,7 @@ SearchOnSealedColumn(const Schema& schema,
             result.unity_topK_ = search_info.topk_;
             return;
         }
+        search_bitview = result.PinBitset(std::move(transformed_bitset));
     }
 
     // For element-level search (embedding-search-embedding), the underlying
@@ -231,6 +231,8 @@ SearchOnSealedColumn(const Schema& schema,
         return;
     }
 
+    const bool use_vector_iterator =
+        milvus::exec::UseVectorIterator(search_info);
     auto num_chunk = column->num_chunks();
 
     SubSearchResult final_qr(num_queries,
@@ -269,7 +271,7 @@ SearchOnSealedColumn(const Schema& schema,
             raw_dataset.raw_data_offsets = offsets_pw.get();
         }
 
-        if (milvus::exec::UseVectorIterator(search_info)) {
+        if (use_vector_iterator) {
             AssertInfo(data_type != DataType::VECTOR_ARRAY,
                        "vector array(embedding list) is not supported for "
                        "vector iterator");
@@ -294,7 +296,7 @@ SearchOnSealedColumn(const Schema& schema,
         }
         offset += chunk_size;
     }
-    if (milvus::exec::UseVectorIterator(search_info)) {
+    if (use_vector_iterator) {
         bool larger_is_closer = PositivelyRelated(search_info.metric_type_);
         // Element-level search skips row-level mapping (element IDs are
         // not row-aligned); see ChunkMergeIterator ctor.

--- a/internal/core/src/query/SearchOnSealedIndexBitsetLifetimeTest.cpp
+++ b/internal/core/src/query/SearchOnSealedIndexBitsetLifetimeTest.cpp
@@ -1,0 +1,366 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "common/BitsetView.h"
+#include "common/Chunk.h"
+#include "common/IndexMeta.h"
+#include "common/QueryInfo.h"
+#include "common/QueryResult.h"
+#include "common/Schema.h"
+#include "common/Types.h"
+#include "index/IndexFactory.h"
+#include "index/VectorIndex.h"
+#include "knowhere/comp/index_param.h"
+#include "knowhere/dataset.h"
+#include "mmap/ChunkedColumn.h"
+#include "query/SearchOnGrowing.h"
+#include "query/SearchOnSealed.h"
+#include "segcore/SegmentGrowing.h"
+#include "segcore/SegmentGrowingImpl.h"
+#include "segcore/SealedIndexingRecord.h"
+#include "test_utils/DataGen.h"
+#include "test_utils/cachinglayer_test_utils.h"
+
+namespace milvus::query {
+namespace {
+
+constexpr int64_t kDim = 36;
+constexpr int64_t kTopK = 15;
+
+std::vector<uint8_t>
+MakeLogicalBitsetBytes(int64_t total_count) {
+    std::vector<uint8_t> logical_bitset_bytes((total_count + 7) / 8, 0);
+    for (int64_t i = 0; i < total_count; i += 7) {
+        logical_bitset_bytes[i >> 3] |= 1U << (i & 0x07);
+    }
+    return logical_bitset_bytes;
+}
+
+std::unique_ptr<bool[]>
+MakeValidData(int64_t total_count, int64_t& valid_count) {
+    std::unique_ptr<bool[]> valid_data(new bool[total_count]);
+    valid_count = 0;
+    for (int64_t i = 0; i < total_count; ++i) {
+        valid_data[i] = i % 10 != 9;
+        if (valid_data[i]) {
+            ++valid_count;
+        }
+    }
+    return valid_data;
+}
+
+std::vector<float>
+MakeCompactVectors(int64_t valid_count, int64_t dim) {
+    std::vector<float> vectors(static_cast<size_t>(valid_count * dim));
+    for (size_t i = 0; i < vectors.size(); ++i) {
+        vectors[i] = static_cast<float>((i % 97) + 1) / 97.0F;
+    }
+    return vectors;
+}
+
+SearchInfo
+MakeGroupBySearchInfo(FieldId vector_field,
+                      FieldId group_by_field,
+                      const MetricType& metric_type) {
+    SearchInfo search_info;
+    search_info.field_id_ = vector_field;
+    search_info.topk_ = kTopK;
+    search_info.round_decimal_ = -1;
+    search_info.metric_type_ = metric_type;
+    search_info.search_params_ = knowhere::Json{
+        {knowhere::indexparam::NPROBE, "32"},
+    };
+    search_info.group_by_field_ids_.push_back(group_by_field);
+    return search_info;
+}
+
+void
+AssertVectorIteratorUsableAfterSearchReturns(SearchResult& search_result,
+                                             int64_t max_results) {
+    ASSERT_EQ(search_result.pinned_bitsets_.size(), 1);
+    ASSERT_TRUE(search_result.vector_iterators_.has_value());
+    ASSERT_FALSE(search_result.vector_iterators_->empty());
+
+    auto iterator = search_result.vector_iterators_->at(0);
+    ASSERT_NE(iterator, nullptr);
+
+    int64_t result_count = 0;
+    while (iterator->HasNext() && result_count < max_results) {
+        auto result = iterator->Next();
+        ASSERT_TRUE(result.has_value());
+        ++result_count;
+    }
+    ASSERT_GT(result_count, 0);
+}
+
+const DataArray&
+FindFieldData(const segcore::GeneratedData& dataset, FieldId field_id) {
+    for (const auto& field_data : dataset.raw_->fields_data()) {
+        if (field_data.field_id() == field_id.get()) {
+            return field_data;
+        }
+    }
+    ThrowInfo(FieldIDInvalid, "field id not found: {}", field_id.get());
+}
+
+int64_t
+CountValidRows(const DataArray& data, int64_t total_count) {
+    if (data.valid_data_size() == 0) {
+        return total_count;
+    }
+    return std::count(data.valid_data().begin(), data.valid_data().end(), true);
+}
+
+std::shared_ptr<ChunkedColumn>
+BuildNullableFloatVectorColumn(const FieldMeta& field_meta,
+                               int64_t total_count,
+                               int64_t dim,
+                               const bool* valid_data,
+                               const std::vector<float>& vectors,
+                               std::vector<std::vector<char>>& chunk_buffers) {
+    std::vector<std::unique_ptr<Chunk>> chunks;
+    std::vector<int64_t> num_rows_per_chunk;
+    num_rows_per_chunk.push_back(total_count);
+
+    auto null_bitmap_bytes = (total_count + 7) / 8;
+    auto vector_data_bytes = vectors.size() * sizeof(float);
+    auto buffer_size = null_bitmap_bytes + vector_data_bytes;
+    chunk_buffers.emplace_back(buffer_size, 0);
+    char* buffer = chunk_buffers.back().data();
+
+    for (int64_t i = 0; i < total_count; ++i) {
+        if (valid_data[i]) {
+            buffer[i >> 3] |= 1U << (i & 0x07);
+        }
+    }
+    std::memcpy(buffer + null_bitmap_bytes, vectors.data(), vector_data_bytes);
+
+    auto chunk_mmap_guard = std::make_shared<ChunkMmapGuard>(nullptr, 0, "");
+    chunks.emplace_back(std::make_unique<FixedWidthChunk>(total_count,
+                                                          dim,
+                                                          buffer,
+                                                          buffer_size,
+                                                          sizeof(float),
+                                                          true,
+                                                          chunk_mmap_guard));
+
+    auto translator = std::make_unique<TestChunkTranslator>(
+        num_rows_per_chunk, "", std::move(chunks));
+    auto slot =
+        cachinglayer::Manager::GetInstance().CreateCacheSlot<milvus::Chunk>(
+            std::move(translator), nullptr);
+    auto column = std::make_shared<ChunkedColumn>(std::move(slot), field_meta);
+    column->BuildValidRowIds(nullptr);
+    return column;
+}
+
+std::unique_ptr<index::IndexBase>
+BuildNullableVectorIndex(int64_t total_count,
+                         int64_t dim,
+                         const bool* valid_data,
+                         const std::vector<float>& vectors) {
+    index::CreateIndexInfo create_index_info;
+    create_index_info.field_type = DataType::VECTOR_FLOAT;
+    create_index_info.metric_type = knowhere::metric::COSINE;
+    create_index_info.index_type = knowhere::IndexEnum::INDEX_FAISS_IVFFLAT;
+    create_index_info.index_engine_version =
+        knowhere::Version::GetCurrentVersion().VersionNumber();
+
+    auto index_base = index::IndexFactory::GetInstance().CreateIndex(
+        create_index_info, storage::FileManagerContext());
+    auto* vector_index = dynamic_cast<index::VectorIndex*>(index_base.get());
+    if (vector_index == nullptr) {
+        ADD_FAILURE() << "failed to create vector index";
+        return index_base;
+    }
+
+    auto build_dataset =
+        knowhere::GenDataSet(vectors.size() / dim, dim, vectors.data());
+    auto build_conf = knowhere::Json{
+        {knowhere::meta::METRIC_TYPE, knowhere::metric::COSINE},
+        {knowhere::meta::DIM, std::to_string(dim)},
+        {knowhere::indexparam::NLIST, "128"},
+    };
+    index_base->BuildWithDataset(build_dataset, build_conf);
+    vector_index->BuildValidData(valid_data, total_count);
+    return index_base;
+}
+
+}  // namespace
+
+TEST(SearchOnSealedIndexBitsetLifetime,
+     GroupByIteratorMustNotKeepDanglingTransformedBitset) {
+    constexpr int64_t total_count = 10000;
+
+    int64_t valid_count = 0;
+    auto valid_data = MakeValidData(total_count, valid_count);
+    auto vectors = MakeCompactVectors(valid_count, kDim);
+
+    auto schema = std::make_shared<Schema>();
+    auto vector_field = schema->AddDebugField(
+        "vector", DataType::VECTOR_FLOAT, kDim, knowhere::metric::COSINE, true);
+    auto group_by_field = schema->AddDebugField("group_by", DataType::INT8);
+    schema->set_primary_field_id(group_by_field);
+
+    auto index_base =
+        BuildNullableVectorIndex(total_count, kDim, valid_data.get(), vectors);
+    auto* vector_index = dynamic_cast<index::VectorIndex*>(index_base.get());
+    ASSERT_NE(vector_index, nullptr);
+    ASSERT_TRUE(vector_index->GetOffsetMapping().IsEnabled());
+
+    segcore::SealedIndexingRecord indexing_record;
+    indexing_record.append_field_indexing(
+        vector_field,
+        knowhere::metric::COSINE,
+        CreateTestCacheIndex("nullable-vector-bitset-lifetime",
+                             std::move(index_base)));
+
+    auto logical_bitset_bytes = MakeLogicalBitsetBytes(total_count);
+    BitsetView logical_bitset(logical_bitset_bytes.data(), total_count);
+
+    std::vector<float> query(vectors.begin(), vectors.begin() + kDim);
+    auto search_info = MakeGroupBySearchInfo(
+        vector_field, group_by_field, knowhere::metric::COSINE);
+
+    SearchResult search_result;
+    SearchOnSealedIndex(*schema,
+                        indexing_record,
+                        search_info,
+                        query.data(),
+                        nullptr,
+                        1,
+                        logical_bitset,
+                        nullptr,
+                        search_result);
+
+    AssertVectorIteratorUsableAfterSearchReturns(search_result, valid_count);
+}
+
+TEST(SearchOnGrowingBitsetLifetime,
+     GroupByIteratorMustNotKeepDanglingTransformedBitset) {
+    constexpr int64_t total_count = 512;
+
+    auto schema = std::make_shared<Schema>();
+    auto vector_field = schema->AddDebugField(
+        "vector", DataType::VECTOR_FLOAT, kDim, knowhere::metric::L2, true);
+    auto group_by_field = schema->AddDebugField("group_by", DataType::INT64);
+    schema->set_primary_field_id(group_by_field);
+
+    auto dataset = segcore::DataGen(schema,
+                                    total_count,
+                                    /*seed=*/42,
+                                    /*ts_offset=*/0,
+                                    /*repeat_count=*/1,
+                                    /*array_len=*/10,
+                                    /*group_count=*/1,
+                                    /*random_pk=*/false,
+                                    /*random_val=*/true,
+                                    /*random_valid=*/false,
+                                    /*null_percent=*/10);
+    const auto& vector_data = FindFieldData(dataset, vector_field);
+    auto valid_count = CountValidRows(vector_data, total_count);
+    ASSERT_GT(valid_count, 0);
+
+    auto segment = segcore::CreateGrowingSegment(schema, empty_index_meta);
+    auto reserved_offset = segment->PreInsert(total_count);
+    segment->Insert(reserved_offset,
+                    total_count,
+                    dataset.row_ids_.data(),
+                    dataset.timestamps_.data(),
+                    dataset.raw_);
+    auto* growing_segment =
+        dynamic_cast<segcore::SegmentGrowingImpl*>(segment.get());
+    ASSERT_NE(growing_segment, nullptr);
+
+    auto logical_bitset_bytes = MakeLogicalBitsetBytes(total_count);
+    BitsetView logical_bitset(logical_bitset_bytes.data(), total_count);
+
+    const auto& vectors = vector_data.vectors().float_vector().data();
+    ASSERT_GE(vectors.size(), kDim);
+    auto search_info = MakeGroupBySearchInfo(
+        vector_field, group_by_field, knowhere::metric::L2);
+
+    SearchResult search_result;
+    SearchOnGrowing(*growing_segment,
+                    search_info,
+                    vectors.data(),
+                    nullptr,
+                    1,
+                    MAX_TIMESTAMP,
+                    logical_bitset,
+                    nullptr,
+                    search_result);
+
+    AssertVectorIteratorUsableAfterSearchReturns(search_result, valid_count);
+}
+
+TEST(SearchOnSealedColumnBitsetLifetime,
+     GroupByIteratorMustNotKeepDanglingTransformedBitset) {
+    constexpr int64_t total_count = 512;
+
+    int64_t valid_count = 0;
+    auto valid_data = MakeValidData(total_count, valid_count);
+    auto vectors = MakeCompactVectors(valid_count, kDim);
+
+    auto schema = std::make_shared<Schema>();
+    auto vector_field = schema->AddDebugField(
+        "vector", DataType::VECTOR_FLOAT, kDim, knowhere::metric::L2, true);
+    auto group_by_field = schema->AddDebugField("group_by", DataType::INT8);
+    schema->set_primary_field_id(group_by_field);
+
+    std::vector<std::vector<char>> chunk_buffers;
+    auto column = BuildNullableFloatVectorColumn((*schema)[vector_field],
+                                                 total_count,
+                                                 kDim,
+                                                 valid_data.get(),
+                                                 vectors,
+                                                 chunk_buffers);
+    ASSERT_TRUE(column->GetOffsetMapping().IsEnabled());
+    ASSERT_EQ(column->GetOffsetMapping().GetValidCount(), valid_count);
+
+    auto logical_bitset_bytes = MakeLogicalBitsetBytes(total_count);
+    BitsetView logical_bitset(logical_bitset_bytes.data(), total_count);
+
+    auto search_info = MakeGroupBySearchInfo(
+        vector_field, group_by_field, knowhere::metric::L2);
+
+    SearchResult search_result;
+    SearchOnSealedColumn(*schema,
+                         column.get(),
+                         search_info,
+                         std::map<std::string, std::string>{},
+                         vectors.data(),
+                         nullptr,
+                         1,
+                         total_count,
+                         logical_bitset,
+                         nullptr,
+                         search_result);
+
+    AssertVectorIteratorUsableAfterSearchReturns(search_result, valid_count);
+}
+
+}  // namespace milvus::query

--- a/tests/python_client/milvus_client/test_milvus_client_search_group_by.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search_group_by.py
@@ -1,20 +1,17 @@
 import json
-import numpy as np
-from pymilvus import AnnSearchRequest, RRFRanker, WeightedRanker
-from pymilvus import (
-    FieldSchema, CollectionSchema, DataType
-)
-from utils.util_pymilvus import *
-from common.common_type import CaseLabel, CheckTasks
-from common import common_type as ct
-from common import common_func as cf
-from utils.util_log import test_log as log
-from base.client_v2_base import TestMilvusClientV2Base
 import random
+
+import numpy as np
 import pytest
+from base.client_v2_base import TestMilvusClientV2Base
+from common import common_func as cf
+from common import common_type as ct
+from common.common_type import CaseLabel, CheckTasks
+from pymilvus import AnnSearchRequest, CollectionSchema, DataType, FieldSchema, RRFRanker, WeightedRanker
+from utils.util_log import test_log as log
+from utils.util_pymilvus import *  # noqa: F403
 
 epsilon = 0.001
-
 
 
 @pytest.mark.xdist_group("TestGroupSearch")
@@ -28,6 +25,7 @@ class TestGroupSearch(TestMilvusClientV2Base):
           scalar values constant within each batch for group-by testing
     Index: IVF_FLAT/COSINE, DISKANN/L2, SPARSE_INVERTED_INDEX/IP, BIN_IVF_FLAT/JACCARD
     """
+
     def setup_class(self):
         super().setup_class(self)
         self.collection_name = "TestGroupSearch" + cf.gen_unique_str("group_by")
@@ -37,13 +35,16 @@ class TestGroupSearch(TestMilvusClientV2Base):
         self.bfloat16_vector_field_name = "bfloat16_vector"
         self.sparse_vector_field_name = "sparse_vector"
         self.binary_vector_field_name = "binary_vector"
-        self.vector_fields = [self.float_vector_field_name, self.bfloat16_vector_field_name,
-                              self.sparse_vector_field_name, self.binary_vector_field_name]
+        self.vector_fields = [
+            self.float_vector_field_name,
+            self.bfloat16_vector_field_name,
+            self.sparse_vector_field_name,
+            self.binary_vector_field_name,
+        ]
         self.float_vector_dim = 36
         self.bf16_vector_dim = 35
         self.binary_vector_dim = 32
-        self.dims = [self.float_vector_dim, self.bf16_vector_dim,
-                     128, self.binary_vector_dim]
+        self.dims = [self.float_vector_dim, self.bf16_vector_dim, 128, self.binary_vector_dim]
         self.float_vector_metric = "COSINE"
         self.bf16_vector_metric = "L2"
         self.sparse_vector_metric = "IP"
@@ -52,10 +53,18 @@ class TestGroupSearch(TestMilvusClientV2Base):
         self.bf16_vector_index = "DISKANN"
         self.sparse_vector_index = "SPARSE_INVERTED_INDEX"
         self.binary_vector_index = "BIN_IVF_FLAT"
-        self.index_types = [self.float_vector_index, self.bf16_vector_index,
-                            self.sparse_vector_index, self.binary_vector_index]
-        self.metric_types = [self.float_vector_metric, self.bf16_vector_metric,
-                             self.sparse_vector_metric, self.binary_vector_metric]
+        self.index_types = [
+            self.float_vector_index,
+            self.bf16_vector_index,
+            self.sparse_vector_index,
+            self.binary_vector_index,
+        ]
+        self.metric_types = [
+            self.float_vector_metric,
+            self.bf16_vector_metric,
+            self.sparse_vector_metric,
+            self.binary_vector_metric,
+        ]
         self.inverted_string_field = "varchar_inverted"
         self.indexed_json_field = "indexed_json"
         self.enable_dynamic_field = True
@@ -74,7 +83,8 @@ class TestGroupSearch(TestMilvusClientV2Base):
         fields = []
         fields.append(FieldSchema(name=self.primary_field, dtype=DataType.INT64, is_primary=True, auto_id=True))
         fields.append(
-            FieldSchema(name=self.float_vector_field_name, dtype=DataType.FLOAT_VECTOR, dim=self.float_vector_dim))
+            FieldSchema(name=self.float_vector_field_name, dtype=DataType.FLOAT_VECTOR, dim=self.float_vector_dim)
+        )
 
         for data_type in ct.all_scalar_data_types:
             fields.append(cf.gen_scalar_field(data_type, name=data_type.name, nullable=True))
@@ -154,24 +164,32 @@ class TestGroupSearch(TestMilvusClientV2Base):
 
         # Create index
         index_params = self.prepare_index_params(client)[0]
-        index_params.add_index(field_name=self.float_vector_field_name,
-                               metric_type=self.float_vector_metric,
-                               index_type=self.float_vector_index,
-                               params={"nlist": 128})
-        index_params.add_index(field_name=self.bfloat16_vector_field_name,
-                               metric_type=self.bf16_vector_metric,
-                               index_type=self.bf16_vector_index,
-                               params={})
-        index_params.add_index(field_name=self.sparse_vector_field_name,
-                               metric_type=self.sparse_vector_metric,
-                               index_type=self.sparse_vector_index,
-                               params={})
-        index_params.add_index(field_name=self.binary_vector_field_name,
-                               metric_type=self.binary_vector_metric,
-                               index_type=self.binary_vector_index,
-                               params={"nlist": 128})
+        index_params.add_index(
+            field_name=self.float_vector_field_name,
+            metric_type=self.float_vector_metric,
+            index_type=self.float_vector_index,
+            params={"nlist": 128},
+        )
+        index_params.add_index(
+            field_name=self.bfloat16_vector_field_name,
+            metric_type=self.bf16_vector_metric,
+            index_type=self.bf16_vector_index,
+            params={},
+        )
+        index_params.add_index(
+            field_name=self.sparse_vector_field_name,
+            metric_type=self.sparse_vector_metric,
+            index_type=self.sparse_vector_index,
+            params={},
+        )
+        index_params.add_index(
+            field_name=self.binary_vector_field_name,
+            metric_type=self.binary_vector_metric,
+            index_type=self.binary_vector_index,
+            params={"nlist": 128},
+        )
         index_params.add_index(field_name=self.inverted_string_field, index_type="INVERTED")
-        index_params.add_index(field_name=self.indexed_json_field, index_type="INVERTED", json_cast_type='json')
+        index_params.add_index(field_name=self.indexed_json_field, index_type="INVERTED", json_cast_type="json")
         self.create_index(client, self.collection_name, index_params=index_params)
         self.wait_for_index_ready(client, self.collection_name, index_name=self.float_vector_field_name)
         self.wait_for_index_ready(client, self.collection_name, index_name=self.bfloat16_vector_field_name)
@@ -185,15 +203,18 @@ class TestGroupSearch(TestMilvusClientV2Base):
         request.addfinalizer(teardown)
 
     @pytest.mark.tags(CaseLabel.L0)
-    @pytest.mark.parametrize("group_by_field, output_field", [
-        (DataType.VARCHAR.name, DataType.VARCHAR.name),
-        ("varchar_inverted", "varchar_inverted"),
-        (DataType.JSON.name, DataType.JSON.name),
-        ("indexed_json", "indexed_json"),
-        (f"{DataType.JSON.name}['number']", DataType.JSON.name),
-        ("dyna_field_name1", "dyna_field_name1"),
-        ("dyna_field_name2['string']", "dyna_field_name2"),
-    ])
+    @pytest.mark.parametrize(
+        "group_by_field, output_field",
+        [
+            (DataType.VARCHAR.name, DataType.VARCHAR.name),
+            ("varchar_inverted", "varchar_inverted"),
+            (DataType.JSON.name, DataType.JSON.name),
+            ("indexed_json", "indexed_json"),
+            (f"{DataType.JSON.name}['number']", DataType.JSON.name),
+            ("dyna_field_name1", "dyna_field_name1"),
+            ("dyna_field_name2['string']", "dyna_field_name2"),
+        ],
+    )
     def test_search_group_size(self, group_by_field, output_field):
         """
         target:
@@ -209,16 +230,24 @@ class TestGroupSearch(TestMilvusClientV2Base):
         for field, dim, idx_type, metric in zip(self.vector_fields, self.dims, self.index_types, self.metric_types):
             if field == self.binary_vector_field_name:
                 continue
-            search_vectors = cf.gen_vectors(nq, dim=dim,
-                                            vector_data_type=cf.get_field_dtype_by_field_name(collection_info,
-                                                                                              field))
+            search_vectors = cf.gen_vectors(
+                nq, dim=dim, vector_data_type=cf.get_field_dtype_by_field_name(collection_info, field)
+            )
             search_params = {"params": cf.get_search_params_params(idx_type), "metric_type": metric}
             # when strict_group_size=true, it shall return results with entities = limit * group_size
-            res1 = self.search(client, self.collection_name, data=search_vectors, anns_field=field,
-                               search_params=search_params, limit=limit,
-                               group_by_field=group_by_field, filter=f"{output_field} is not null",
-                               group_size=group_size, strict_group_size=True,
-                               output_fields=[output_field])[0]
+            res1 = self.search(
+                client,
+                self.collection_name,
+                data=search_vectors,
+                anns_field=field,
+                search_params=search_params,
+                limit=limit,
+                group_by_field=group_by_field,
+                filter=f"{output_field} is not null",
+                group_size=group_size,
+                strict_group_size=True,
+                output_fields=[output_field],
+            )[0]
             for i in range(nq):
                 assert len(res1[i]) == limit * group_size
                 for idx in range(limit):
@@ -230,13 +259,19 @@ class TestGroupSearch(TestMilvusClientV2Base):
                     assert len(set(group_values)) == 1
 
             # when strict_group_size=false, it shall return results with group counts = limit
-            res1 = self.search(client, self.collection_name,
-                               data=search_vectors,
-                               anns_field=field,
-                               search_params=search_params, limit=limit,
-                               group_by_field=group_by_field, filter=f"{output_field} is not null",
-                               group_size=group_size, strict_group_size=False,
-                               output_fields=[output_field])[0]
+            res1 = self.search(
+                client,
+                self.collection_name,
+                data=search_vectors,
+                anns_field=field,
+                search_params=search_params,
+                limit=limit,
+                group_by_field=group_by_field,
+                filter=f"{output_field} is not null",
+                group_size=group_size,
+                strict_group_size=False,
+                output_fields=[output_field],
+            )[0]
             for i in range(nq):
                 group_values = []
                 for idx in range(len(res1[i])):
@@ -261,23 +296,32 @@ class TestGroupSearch(TestMilvusClientV2Base):
             if field == self.binary_vector_field_name:
                 continue  # not support group by search on binary vector
             search_params = {
-                "data": cf.gen_vectors(nq, dim=dim,
-                                       vector_data_type=cf.get_field_dtype_by_field_name(collection_info,
-                                                                                         field)),
+                "data": cf.gen_vectors(
+                    nq, dim=dim, vector_data_type=cf.get_field_dtype_by_field_name(collection_info, field)
+                ),
                 "anns_field": field,
                 "param": {"params": cf.get_search_params_params(idx_type), "metric_type": metric},
                 "limit": limit,
-                "expr": f"{self.primary_field} > 0"}
+                "expr": f"{self.primary_field} > 0",
+            }
             req = AnnSearchRequest(**search_params)
             req_list.append(req)
         # 4. hybrid search group by
-        #rank_scorers = ["max", "avg", "sum"]
+        # rank_scorers = ["max", "avg", "sum"]
         rank_scorers = ["max"]
         for scorer in rank_scorers:
-            res = self.hybrid_search(client, self.collection_name, reqs=req_list, ranker=WeightedRanker(0.1, 0.3, 0.6),
-                                     limit=limit, group_by_field=DataType.VARCHAR.name, group_size=group_size,
-                                     rank_group_scorer=scorer, output_fields=[DataType.VARCHAR.name],
-                                     pipeline_trace=True)[0]
+            res = self.hybrid_search(
+                client,
+                self.collection_name,
+                reqs=req_list,
+                ranker=WeightedRanker(0.1, 0.3, 0.6),
+                limit=limit,
+                group_by_field=DataType.VARCHAR.name,
+                group_size=group_size,
+                rank_group_scorer=scorer,
+                output_fields=[DataType.VARCHAR.name],
+                pipeline_trace=True,
+            )[0]
             for i in range(nq):
                 group_values = []
                 for idx in range(len(res[i])):
@@ -293,9 +337,9 @@ class TestGroupSearch(TestMilvusClientV2Base):
                     if curr_group_value == next_group_value:
                         group_distances.append(res[i][idx + 1].distance)
                     else:
-                        if scorer == 'sum':
+                        if scorer == "sum":
                             assert np.sum(group_distances) <= np.sum(tmp_distances)
-                        elif scorer == 'avg':
+                        elif scorer == "avg":
                             assert np.mean(group_distances) <= np.mean(tmp_distances)
                         else:  # default max
                             assert np.max(group_distances) <= np.max(tmp_distances)
@@ -316,21 +360,28 @@ class TestGroupSearch(TestMilvusClientV2Base):
             if field == self.binary_vector_field_name:
                 continue  # not support group by search on binary vector
             search_param = {
-                "data": cf.gen_vectors(ct.default_nq, dim=dim,
-                                       vector_data_type=cf.get_field_dtype_by_field_name(collection_info,
-                                                                                         field)),
+                "data": cf.gen_vectors(
+                    ct.default_nq, dim=dim, vector_data_type=cf.get_field_dtype_by_field_name(collection_info, field)
+                ),
                 "anns_field": field,
                 "param": {"metric_type": metric},
                 "limit": ct.default_limit,
-                "expr": f"{self.primary_field} > 0"}
+                "expr": f"{self.primary_field} > 0",
+            }
             req = AnnSearchRequest(**search_param)
             req_list.append(req)
         # 4. hybrid search group by
-        res = self.hybrid_search(client, self.collection_name, reqs=req_list, ranker=WeightedRanker(0.1, 0.9, 0.3),
-                                 limit=ct.default_limit, group_by_field=DataType.VARCHAR.name,
-                                 output_fields=[DataType.VARCHAR.name],
-                                 check_task=CheckTasks.check_search_results,
-                                 check_items={"nq": ct.default_nq, "limit": ct.default_limit})[0]
+        res = self.hybrid_search(
+            client,
+            self.collection_name,
+            reqs=req_list,
+            ranker=WeightedRanker(0.1, 0.9, 0.3),
+            limit=ct.default_limit,
+            group_by_field=DataType.VARCHAR.name,
+            output_fields=[DataType.VARCHAR.name],
+            check_task=CheckTasks.check_search_results,
+            check_items={"nq": ct.default_nq, "limit": ct.default_limit},
+        )[0]
         for i in range(ct.default_nq):
             group_values = []
             for idx in range(ct.default_limit):
@@ -339,24 +390,33 @@ class TestGroupSearch(TestMilvusClientV2Base):
 
         # 5. hybrid search with RRFRanker on one vector field with group by
         req_list = []
-        for field, dim, idx_type, metric in zip(self.vector_fields[1:], self.dims[1:], self.index_types[1:], self.metric_types[1:]):
+        for field, dim, idx_type, metric in zip(
+            self.vector_fields[1:], self.dims[1:], self.index_types[1:], self.metric_types[1:]
+        ):
             if field == self.binary_vector_field_name:
                 continue  # not support group by search on binary vector
             search_param = {
-                "data": cf.gen_vectors(ct.default_nq, dim=dim,
-                                       vector_data_type=cf.get_field_dtype_by_field_name(collection_info,
-                                                                                         field)),
+                "data": cf.gen_vectors(
+                    ct.default_nq, dim=dim, vector_data_type=cf.get_field_dtype_by_field_name(collection_info, field)
+                ),
                 "anns_field": field,
                 "param": {"metric_type": metric},
                 "limit": ct.default_limit,
-                "expr": f"{self.primary_field} > 0"}
+                "expr": f"{self.primary_field} > 0",
+            }
             req = AnnSearchRequest(**search_param)
             req_list.append(req)
-            self.hybrid_search(client, self.collection_name, reqs=req_list, ranker=RRFRanker(),
-                               limit=ct.default_limit, group_by_field=self.inverted_string_field,
-                               output_fields=[self.inverted_string_field],
-                               check_task=CheckTasks.check_search_results,
-                               check_items={"nq": ct.default_nq, "limit": ct.default_limit})
+            self.hybrid_search(
+                client,
+                self.collection_name,
+                reqs=req_list,
+                ranker=RRFRanker(),
+                limit=ct.default_limit,
+                group_by_field=self.inverted_string_field,
+                output_fields=[self.inverted_string_field],
+                check_task=CheckTasks.check_search_results,
+                check_items={"nq": ct.default_nq, "limit": ct.default_limit},
+            )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_hybrid_search_group_by_empty_results(self):
@@ -371,21 +431,28 @@ class TestGroupSearch(TestMilvusClientV2Base):
             if field == self.binary_vector_field_name:
                 continue  # not support group by search on binary vector
             search_param = {
-                "data": cf.gen_vectors(ct.default_nq, dim=dim,
-                                       vector_data_type=cf.get_field_dtype_by_field_name(collection_info,
-                                                                                         field)),
+                "data": cf.gen_vectors(
+                    ct.default_nq, dim=dim, vector_data_type=cf.get_field_dtype_by_field_name(collection_info, field)
+                ),
                 "anns_field": field,
                 "param": {"metric_type": metric},
                 "limit": ct.default_limit,
-                "expr": f"{self.primary_field} < 0"}  # make sure return empty results
+                "expr": f"{self.primary_field} < 0",
+            }  # make sure return empty results
             req = AnnSearchRequest(**search_param)
             req_list.append(req)
         # 4. hybrid search group by empty results
-        self.hybrid_search(client, self.collection_name, reqs=req_list, ranker=WeightedRanker(0.1, 0.9, 0.3),
-                           limit=ct.default_limit, group_by_field=DataType.VARCHAR.name,
-                           output_fields=[DataType.VARCHAR.name],
-                           check_task=CheckTasks.check_search_results,
-                           check_items={"nq": ct.default_nq, "limit": 0})
+        self.hybrid_search(
+            client,
+            self.collection_name,
+            reqs=req_list,
+            ranker=WeightedRanker(0.1, 0.9, 0.3),
+            limit=ct.default_limit,
+            group_by_field=DataType.VARCHAR.name,
+            output_fields=[DataType.VARCHAR.name],
+            check_task=CheckTasks.check_search_results,
+            check_items={"nq": ct.default_nq, "limit": 0},
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_search_group_by_supported_binary_vector(self):
@@ -393,21 +460,28 @@ class TestGroupSearch(TestMilvusClientV2Base):
         verify search group by works with supported binary vector
         """
         client = self._client()
-        search_vectors = cf.gen_vectors(1, dim=self.binary_vector_dim,
-                                        vector_data_type=DataType.BINARY_VECTOR)
+        search_vectors = cf.gen_vectors(1, dim=self.binary_vector_dim, vector_data_type=DataType.BINARY_VECTOR)
         search_params = {"metric_type": self.binary_vector_metric}
         limit = 1
-        error = {ct.err_code: 999,
-                 ct.err_msg: "not support search_group_by operation based on binary vector"}
-        self.search(client, self.collection_name, data=search_vectors, anns_field=self.binary_vector_field_name,
-                    search_params=search_params, limit=limit, group_by_field=DataType.VARCHAR.name,
-                    output_fields=[DataType.VARCHAR.name],
-                    check_task=CheckTasks.err_res, check_items=error)
+        error = {ct.err_code: 999, ct.err_msg: "not support search_group_by operation based on binary vector"}
+        self.search(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            anns_field=self.binary_vector_field_name,
+            search_params=search_params,
+            limit=limit,
+            group_by_field=DataType.VARCHAR.name,
+            output_fields=[DataType.VARCHAR.name],
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     @pytest.mark.tags(CaseLabel.L0)
-    @pytest.mark.parametrize("support_field", [DataType.INT8.name, DataType.INT64.name,
-                                               DataType.BOOL.name, DataType.VARCHAR.name,
-                                               DataType.TIMESTAMPTZ.name])
+    @pytest.mark.parametrize(
+        "support_field",
+        [DataType.INT8.name, DataType.INT64.name, DataType.BOOL.name, DataType.VARCHAR.name, DataType.TIMESTAMPTZ.name],
+    )
     def test_search_group_by_supported_scalars(self, support_field):
         """
         verify search group by works with supported scalar fields
@@ -419,15 +493,21 @@ class TestGroupSearch(TestMilvusClientV2Base):
         for field, dim, idx_type, metric in zip(self.vector_fields, self.dims, self.index_types, self.metric_types):
             if field == self.binary_vector_field_name:
                 continue  # not support group by search on binary vector
-            search_vectors = cf.gen_vectors(nq, dim=dim,
-                                            vector_data_type=cf.get_field_dtype_by_field_name(collection_info,
-                                                                                              field))
+            search_vectors = cf.gen_vectors(
+                nq, dim=dim, vector_data_type=cf.get_field_dtype_by_field_name(collection_info, field)
+            )
             search_params = {"params": cf.get_search_params_params(idx_type), "metric_type": metric}
-            res1 = self.search(client, self.collection_name, data=search_vectors, anns_field=field,
-                               search_params=search_params, limit=limit,
-                               filter=f"{support_field} is not null",
-                               group_by_field=support_field,
-                               output_fields=[support_field])[0]
+            res1 = self.search(
+                client,
+                self.collection_name,
+                data=search_vectors,
+                anns_field=field,
+                search_params=search_params,
+                limit=limit,
+                filter=f"{support_field} is not null",
+                group_by_field=support_field,
+                output_fields=[support_field],
+            )[0]
             for i in range(nq):
                 grpby_values = []
                 mismatch = 0
@@ -445,17 +525,25 @@ class TestGroupSearch(TestMilvusClientV2Base):
                     if support_field == DataType.TIMESTAMPTZ.name:
                         filter_expr = f"{support_field}== ISO '{top1_grpby_value}'"
                     grpby_values.append(top1_grpby_value)
-                    res_tmp = self.search(client, self.collection_name, data=[search_vectors[i]],
-                                          anns_field=field,
-                                          search_params=search_params, limit=1, filter=filter_expr,
-                                          output_fields=[support_field])[0]
+                    res_tmp = self.search(
+                        client,
+                        self.collection_name,
+                        data=[search_vectors[i]],
+                        anns_field=field,
+                        search_params=search_params,
+                        limit=1,
+                        filter=filter_expr,
+                        output_fields=[support_field],
+                    )[0]
                     top1_expr_pk = res_tmp[0][0].id
                     if top1_grpby_pk != top1_expr_pk:
                         mismatch += 1
                         log.info(
-                            f"{support_field} on {field} mismatch_item, top1_grpby_dis: {top1.distance}, top1_expr_dis: {res_tmp[0][0].distance}")
+                            f"{support_field} on {field} mismatch_item, top1_grpby_dis: {top1.distance}, top1_expr_dis: {res_tmp[0][0].distance}"
+                        )
                 log.info(
-                    f"{support_field} on {field}  top1_mismatch_num: {mismatch}, results_num: {results_num}, mismatch_rate: {mismatch / results_num}")
+                    f"{support_field} on {field}  top1_mismatch_num: {mismatch}, results_num: {results_num}, mismatch_rate: {mismatch / results_num}"
+                )
                 baseline = 1 if support_field == DataType.BOOL.name else 0.2  # skip baseline check for boolean
                 assert results_num > 0, "results_num should be greater than 0"
                 assert mismatch / results_num <= baseline
@@ -463,9 +551,10 @@ class TestGroupSearch(TestMilvusClientV2Base):
                 assert len(grpby_values) == len(set(grpby_values))
 
     @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.parametrize("grpby_unsupported_field", [DataType.FLOAT.name, DataType.DOUBLE.name,
-                                                         DataType.GEOMETRY.name,
-                                                         ct.default_float_vec_field_name])
+    @pytest.mark.parametrize(
+        "grpby_unsupported_field",
+        [DataType.FLOAT.name, DataType.DOUBLE.name, DataType.GEOMETRY.name, ct.default_float_vec_field_name],
+    )
     def test_search_group_by_unsupported_field(self, grpby_unsupported_field):
         """
         target: test search group by with the unsupported field
@@ -475,19 +564,24 @@ class TestGroupSearch(TestMilvusClientV2Base):
                 verify: the error code and msg
         """
         client = self._client()
-        search_vectors = cf.gen_vectors(1, dim=self.float_vector_dim,
-                                        vector_data_type=DataType.FLOAT_VECTOR)
+        search_vectors = cf.gen_vectors(1, dim=self.float_vector_dim, vector_data_type=DataType.FLOAT_VECTOR)
         search_params = {"metric_type": self.float_vector_metric}
         limit = 1
-        error = {ct.err_code: 999,
-                 ct.err_msg: f"unsupported data type {grpby_unsupported_field} for group by operator"}
+        error = {ct.err_code: 999, ct.err_msg: f"unsupported data type {grpby_unsupported_field} for group by operator"}
         if grpby_unsupported_field == ct.default_float_vec_field_name:
-            error = {ct.err_code: 999,
-                     ct.err_msg: f"unsupported data type VECTOR_FLOAT for group by operator"}
-        self.search(client, self.collection_name, data=search_vectors, anns_field=self.float_vector_field_name,
-                    search_params=search_params, limit=limit, group_by_field=grpby_unsupported_field,
-                    output_fields=[grpby_unsupported_field],
-                    check_task=CheckTasks.err_res, check_items=error)
+            error = {ct.err_code: 999, ct.err_msg: "unsupported data type VECTOR_FLOAT for group by operator"}
+        self.search(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            anns_field=self.float_vector_field_name,
+            search_params=search_params,
+            limit=limit,
+            group_by_field=grpby_unsupported_field,
+            output_fields=[grpby_unsupported_field],
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_search_pagination_group_by(self):
@@ -502,32 +596,47 @@ class TestGroupSearch(TestMilvusClientV2Base):
         default_search_exp = f"{self.primary_field} >= 0"
         grpby_field = self.inverted_string_field
         default_search_field = self.vector_fields[1]
-        search_vectors = cf.gen_vectors(1, dim=self.dims[1],
-                                        vector_data_type=cf.get_field_dtype_by_field_name(collection_info,
-                                                                                          self.vector_fields[1]))
+        search_vectors = cf.gen_vectors(
+            1,
+            dim=self.dims[1],
+            vector_data_type=cf.get_field_dtype_by_field_name(collection_info, self.vector_fields[1]),
+        )
         all_pages_ids = []
         all_pages_grpby_field_values = []
         for r in range(page_rounds):
-            page_res = self.search(client, self.collection_name, data=search_vectors, anns_field=default_search_field,
-                                   search_params=search_param, limit=limit, offset=limit * r,
-                                   filter=default_search_exp, group_by_field=grpby_field,
-                                   output_fields=[grpby_field],
-                                   check_task=CheckTasks.check_search_results,
-                                   check_items={"nq": 1, "limit": limit},
-                                   )[0]
+            page_res = self.search(
+                client,
+                self.collection_name,
+                data=search_vectors,
+                anns_field=default_search_field,
+                search_params=search_param,
+                limit=limit,
+                offset=limit * r,
+                filter=default_search_exp,
+                group_by_field=grpby_field,
+                output_fields=[grpby_field],
+                check_task=CheckTasks.check_search_results,
+                check_items={"nq": 1, "limit": limit},
+            )[0]
             for j in range(limit):
                 all_pages_grpby_field_values.append(page_res[0][j].get(grpby_field))
             all_pages_ids += page_res[0].ids
         hit_rate = round(len(set(all_pages_grpby_field_values)) / len(all_pages_grpby_field_values), 3)
         assert hit_rate >= 0.8
 
-        total_res = self.search(client, self.collection_name, data=search_vectors, anns_field=default_search_field,
-                                search_params=search_param, limit=limit * page_rounds,
-                                filter=default_search_exp, group_by_field=grpby_field,
-                                output_fields=[grpby_field],
-                                check_task=CheckTasks.check_search_results,
-                                check_items={"nq": 1, "limit": limit * page_rounds}
-                                )[0]
+        total_res = self.search(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            anns_field=default_search_field,
+            search_params=search_param,
+            limit=limit * page_rounds,
+            filter=default_search_exp,
+            group_by_field=grpby_field,
+            output_fields=[grpby_field],
+            check_task=CheckTasks.check_search_results,
+            check_items={"nq": 1, "limit": limit * page_rounds},
+        )[0]
         hit_num = len(set(total_res[0].ids).intersection(set(all_pages_ids)))
         hit_rate = round(hit_num / (limit * page_rounds), 3)
         assert hit_rate >= 0.8
@@ -553,9 +662,11 @@ class TestGroupSearch(TestMilvusClientV2Base):
         grpby_field = self.inverted_string_field
         default_search_field = self.vector_fields[1]
         ids_to_search = None
-        search_vectors = cf.gen_vectors(1, dim=self.dims[1],
-                                        vector_data_type=cf.get_field_dtype_by_field_name(collection_info,
-                                                                                          self.vector_fields[1]))
+        search_vectors = cf.gen_vectors(
+            1,
+            dim=self.dims[1],
+            vector_data_type=cf.get_field_dtype_by_field_name(collection_info, self.vector_fields[1]),
+        )
         if search_by_pk is True:
             query_res = self.query(client, self.collection_name, limit=1, output_fields=[self.primary_field])[0]
             ids_to_search = [query_res[0].get(self.primary_field)]
@@ -564,42 +675,53 @@ class TestGroupSearch(TestMilvusClientV2Base):
         all_pages_grpby_field_values = []
         res_count = limit * group_size
         for r in range(page_rounds):
-            page_res = self.search(client, self.collection_name,
-                                   data=search_vectors,
-                                   ids=ids_to_search,
-                                   anns_field=default_search_field,
-                                   search_params=search_param, limit=limit, offset=limit * r,
-                                   filter=default_search_exp,
-                                   group_by_field=grpby_field, group_size=group_size,
-                                   strict_group_size=True,
-                                   output_fields=[grpby_field],
-                                   check_task=CheckTasks.check_search_results,
-                                   check_items={"nq": 1, "limit": res_count},
-                                   )[0]
+            page_res = self.search(
+                client,
+                self.collection_name,
+                data=search_vectors,
+                ids=ids_to_search,
+                anns_field=default_search_field,
+                search_params=search_param,
+                limit=limit,
+                offset=limit * r,
+                filter=default_search_exp,
+                group_by_field=grpby_field,
+                group_size=group_size,
+                strict_group_size=True,
+                output_fields=[grpby_field],
+                check_task=CheckTasks.check_search_results,
+                check_items={"nq": 1, "limit": res_count},
+            )[0]
             for j in range(res_count):
                 all_pages_grpby_field_values.append(page_res[0][j].get(grpby_field))
             all_pages_ids += page_res[0].ids
 
         hit_rate = round(len(set(all_pages_grpby_field_values)) / len(all_pages_grpby_field_values), 3)
         expect_hit_rate = round(1 / group_size, 3) * 0.7
-        log.info(f"expect_hit_rate :{expect_hit_rate}, hit_rate:{hit_rate}, "
-                 f"unique_group_by_value_count:{len(set(all_pages_grpby_field_values))},"
-                 f"total_group_by_value_count:{len(all_pages_grpby_field_values)}")
+        log.info(
+            f"expect_hit_rate :{expect_hit_rate}, hit_rate:{hit_rate}, "
+            f"unique_group_by_value_count:{len(set(all_pages_grpby_field_values))},"
+            f"total_group_by_value_count:{len(all_pages_grpby_field_values)}"
+        )
         assert hit_rate >= expect_hit_rate
 
         total_count = limit * group_size * page_rounds
-        total_res = self.search(client, self.collection_name,
-                                data=search_vectors,
-                                ids=ids_to_search,
-                                anns_field=default_search_field,
-                                search_params=search_param, limit=limit * page_rounds,
-                                filter=default_search_exp,
-                                group_by_field=grpby_field, group_size=group_size,
-                                strict_group_size=True,
-                                output_fields=[grpby_field],
-                                check_task=CheckTasks.check_search_results,
-                                check_items={"nq": 1, "limit": total_count}
-                                )[0]
+        total_res = self.search(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            ids=ids_to_search,
+            anns_field=default_search_field,
+            search_params=search_param,
+            limit=limit * page_rounds,
+            filter=default_search_exp,
+            group_by_field=grpby_field,
+            group_size=group_size,
+            strict_group_size=True,
+            output_fields=[grpby_field],
+            check_task=CheckTasks.check_search_results,
+            check_items={"nq": 1, "limit": total_count},
+        )[0]
         hit_num = len(set(total_res[0].ids).intersection(set(all_pages_ids)))
         hit_rate = round(hit_num / (limit * page_rounds), 3)
         assert hit_rate >= 0.8
@@ -619,53 +741,92 @@ class TestGroupSearch(TestMilvusClientV2Base):
         collection_info = self.describe_collection(client, self.collection_name)[0]
         group_by_field = self.inverted_string_field
         default_search_field = self.vector_fields[1]
-        search_vectors = cf.gen_vectors(1, dim=self.dims[1],
-                                        vector_data_type=cf.get_field_dtype_by_field_name(collection_info,
-                                                                                          self.vector_fields[1]))
+        search_vectors = cf.gen_vectors(
+            1,
+            dim=self.dims[1],
+            vector_data_type=cf.get_field_dtype_by_field_name(collection_info, self.vector_fields[1]),
+        )
         search_params = {"metric_type": self.bf16_vector_metric}
         limit = 10
         max_group_size = 10
-        self.search(client, self.collection_name, data=search_vectors, anns_field=default_search_field,
-                    search_params=search_params, limit=limit,
-                    group_by_field=group_by_field,
-                    group_size=max_group_size, strict_group_size=True,
-                    output_fields=[group_by_field])
+        self.search(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            anns_field=default_search_field,
+            search_params=search_params,
+            limit=limit,
+            group_by_field=group_by_field,
+            group_size=max_group_size,
+            strict_group_size=True,
+            output_fields=[group_by_field],
+        )
         exceed_max_group_size = max_group_size + 1
-        error = {ct.err_code: 999,
-                 ct.err_msg: f"input group size:{exceed_max_group_size} exceeds configured max "
-                             f"group size:{max_group_size}"}
-        self.search(client, self.collection_name, data=search_vectors, anns_field=default_search_field,
-                    search_params=search_params, limit=limit,
-                    group_by_field=group_by_field,
-                    group_size=exceed_max_group_size, strict_group_size=True,
-                    output_fields=[group_by_field],
-                    check_task=CheckTasks.err_res, check_items=error)
+        error = {
+            ct.err_code: 999,
+            ct.err_msg: f"input group size:{exceed_max_group_size} exceeds configured max group size:{max_group_size}",
+        }
+        self.search(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            anns_field=default_search_field,
+            search_params=search_params,
+            limit=limit,
+            group_by_field=group_by_field,
+            group_size=exceed_max_group_size,
+            strict_group_size=True,
+            output_fields=[group_by_field],
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
         min_group_size = 1
-        self.search(client, self.collection_name, data=search_vectors, anns_field=default_search_field,
-                    search_params=search_params, limit=limit,
-                    group_by_field=group_by_field,
-                    group_size=max_group_size, strict_group_size=True,
-                    output_fields=[group_by_field])
+        self.search(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            anns_field=default_search_field,
+            search_params=search_params,
+            limit=limit,
+            group_by_field=group_by_field,
+            group_size=max_group_size,
+            strict_group_size=True,
+            output_fields=[group_by_field],
+        )
         below_min_group_size = min_group_size - 1
-        error = {ct.err_code: 999,
-                 ct.err_msg: f"input group size:{below_min_group_size} is negative"}
-        self.search(client, self.collection_name, data=search_vectors, anns_field=default_search_field,
-                    search_params=search_params, limit=limit,
-                    group_by_field=group_by_field,
-                    group_size=below_min_group_size, strict_group_size=True,
-                    output_fields=[group_by_field],
-                    check_task=CheckTasks.err_res, check_items=error)
+        error = {ct.err_code: 999, ct.err_msg: f"input group size:{below_min_group_size} is negative"}
+        self.search(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            anns_field=default_search_field,
+            search_params=search_params,
+            limit=limit,
+            group_by_field=group_by_field,
+            group_size=below_min_group_size,
+            strict_group_size=True,
+            output_fields=[group_by_field],
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
         below_min_group_size = min_group_size - 10
-        error = {ct.err_code: 999,
-                 ct.err_msg: f"input group size:{below_min_group_size} is negative"}
-        self.search(client, self.collection_name, data=search_vectors, anns_field=default_search_field,
-                    search_params=search_params, limit=limit,
-                    group_by_field=group_by_field,
-                    group_size=below_min_group_size, strict_group_size=True,
-                    output_fields=[group_by_field],
-                    check_task=CheckTasks.err_res, check_items=error)
+        error = {ct.err_code: 999, ct.err_msg: f"input group size:{below_min_group_size} is negative"}
+        self.search(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            anns_field=default_search_field,
+            search_params=search_params,
+            limit=limit,
+            group_by_field=group_by_field,
+            group_size=below_min_group_size,
+            strict_group_size=True,
+            output_fields=[group_by_field],
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_search_iterator_not_support_group_by(self):
@@ -678,17 +839,22 @@ class TestGroupSearch(TestMilvusClientV2Base):
                 verify: error code and msg
         """
         client = self._client()
-        search_vectors = cf.gen_vectors(1, dim=self.float_vector_dim,
-                                        vector_data_type=DataType.FLOAT_VECTOR)
+        search_vectors = cf.gen_vectors(1, dim=self.float_vector_dim, vector_data_type=DataType.FLOAT_VECTOR)
         search_params = {"metric_type": self.float_vector_metric}
         grpby_field = DataType.VARCHAR.name
-        error = {ct.err_code: 1100,
-                 ct.err_msg: "Not allowed to do groupBy when doing iteration"}
-        self.search_iterator(client, self.collection_name, data=search_vectors,
-                             anns_field=self.float_vector_field_name,
-                             search_params=search_params, batch_size=10, limit=100,
-                             group_by_field=grpby_field,
-                             check_task=CheckTasks.err_res, check_items=error)
+        error = {ct.err_code: 1100, ct.err_msg: "Not allowed to do groupBy when doing iteration"}
+        self.search_iterator(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            anns_field=self.float_vector_field_name,
+            search_params=search_params,
+            batch_size=10,
+            limit=100,
+            group_by_field=grpby_field,
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_range_search_not_support_group_by(self):
@@ -700,17 +866,21 @@ class TestGroupSearch(TestMilvusClientV2Base):
                 verify: the error code and msg
         """
         client = self._client()
-        search_vectors = cf.gen_vectors(1, dim=self.float_vector_dim,
-                                        vector_data_type=DataType.FLOAT_VECTOR)
+        search_vectors = cf.gen_vectors(1, dim=self.float_vector_dim, vector_data_type=DataType.FLOAT_VECTOR)
         grpby_field = DataType.VARCHAR.name
-        error = {ct.err_code: 1100,
-                 ct.err_msg: "Not allowed to do range-search when doing search-group-by"}
+        error = {ct.err_code: 1100, ct.err_msg: "Not allowed to do range-search when doing search-group-by"}
         range_search_params = {"metric_type": "COSINE", "params": {"radius": 0.1, "range_filter": 0.5}}
-        self.search(client, self.collection_name, data=search_vectors,
-                    anns_field=self.float_vector_field_name,
-                    search_params=range_search_params, limit=5,
-                    group_by_field=grpby_field,
-                    check_task=CheckTasks.err_res, check_items=error)
+        self.search(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            anns_field=self.float_vector_field_name,
+            search_params=range_search_params,
+            limit=5,
+            group_by_field=grpby_field,
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_search_group_by_nonexistent_field_on_dynamic_enabled_collection(self):
@@ -722,15 +892,19 @@ class TestGroupSearch(TestMilvusClientV2Base):
         """
         client = self._client()
         nq = 2
-        search_vectors = cf.gen_vectors(nq, dim=self.float_vector_dim,
-                                        vector_data_type=DataType.FLOAT_VECTOR)
+        search_vectors = cf.gen_vectors(nq, dim=self.float_vector_dim, vector_data_type=DataType.FLOAT_VECTOR)
         search_params = {"metric_type": self.float_vector_metric}
-        self.search(client, self.collection_name, data=search_vectors,
-                    anns_field=self.float_vector_field_name,
-                    search_params=search_params, limit=100,
-                    group_by_field="nonexist_field",
-                    check_task=CheckTasks.check_search_results,
-                    check_items={"nq": nq, "limit": 1})
+        self.search(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            anns_field=self.float_vector_field_name,
+            search_params=search_params,
+            limit=100,
+            group_by_field="nonexist_field",
+            check_task=CheckTasks.check_search_results,
+            check_items={"nq": nq, "limit": 1},
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_search_group_by_invalid_field_type(self):
@@ -740,16 +914,20 @@ class TestGroupSearch(TestMilvusClientV2Base):
         verify: server returns error
         """
         client = self._client()
-        search_vectors = cf.gen_vectors(1, dim=self.float_vector_dim,
-                                        vector_data_type=DataType.FLOAT_VECTOR)
+        search_vectors = cf.gen_vectors(1, dim=self.float_vector_dim, vector_data_type=DataType.FLOAT_VECTOR)
         search_params = {"metric_type": self.float_vector_metric}
-        error = {ct.err_code: 65535,
-                 ct.err_msg: "cannot parse identifier"}
-        self.search(client, self.collection_name, data=search_vectors,
-                    anns_field=self.float_vector_field_name,
-                    search_params=search_params, limit=100,
-                    group_by_field=21,
-                    check_task=CheckTasks.err_res, check_items=error)
+        error = {ct.err_code: 65535, ct.err_msg: "cannot parse identifier"}
+        self.search(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            anns_field=self.float_vector_field_name,
+            search_params=search_params,
+            limit=100,
+            group_by_field=21,
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
 
 @pytest.mark.xdist_group("TestGroupSearchInvalid")
@@ -761,6 +939,7 @@ class TestGroupSearchInvalid(TestMilvusClientV2Base):
     Data: 2000 rows
     Index: FLAT/L2, HNSW/COSINE
     """
+
     def setup_class(self):
         super().setup_class(self)
         self.collection_name = "TestGroupSearchInvalid" + cf.gen_unique_str("group_by")
@@ -789,7 +968,8 @@ class TestGroupSearchInvalid(TestMilvusClientV2Base):
         fields = []
         fields.append(FieldSchema(name=self.primary_field, dtype=DataType.INT64, is_primary=True, auto_id=True))
         fields.append(
-            FieldSchema(name=self.float_vector_field_name, dtype=DataType.FLOAT_VECTOR, dim=self.float_vector_dim))
+            FieldSchema(name=self.float_vector_field_name, dtype=DataType.FLOAT_VECTOR, dim=self.float_vector_dim)
+        )
 
         for data_type in ct.all_scalar_data_types:
             fields.append(cf.gen_scalar_field(data_type, name=data_type.name, nullable=True))
@@ -811,12 +991,16 @@ class TestGroupSearchInvalid(TestMilvusClientV2Base):
 
         # Create index
         index_params = self.prepare_index_params(client)[0]
-        index_params.add_index(field_name=self.float_vector_field_name,
-                               metric_type=self.float_vector_metric,
-                               index_type=self.float_vector_index)
-        index_params.add_index(field_name=self.int8_vector_field_name,
-                               metric_type=self.int8_vector_metric,
-                               index_type=self.int8_vector_index)
+        index_params.add_index(
+            field_name=self.float_vector_field_name,
+            metric_type=self.float_vector_metric,
+            index_type=self.float_vector_index,
+        )
+        index_params.add_index(
+            field_name=self.int8_vector_field_name,
+            metric_type=self.int8_vector_metric,
+            index_type=self.int8_vector_index,
+        )
         self.create_index(client, self.collection_name, index_params=index_params)
         self.wait_for_index_ready(client, self.collection_name, index_name=self.float_vector_field_name)
         self.wait_for_index_ready(client, self.collection_name, index_name=self.int8_vector_field_name)
@@ -840,17 +1024,21 @@ class TestGroupSearchInvalid(TestMilvusClientV2Base):
         """
         client = self._client()
         search_params = {"metric_type": self.float_vector_metric}
-        search_vectors = cf.gen_vectors(1, dim=self.float_vector_dim,
-                                        vector_data_type=DataType.FLOAT_VECTOR)
+        search_vectors = cf.gen_vectors(1, dim=self.float_vector_dim, vector_data_type=DataType.FLOAT_VECTOR)
         # verify
-        error = {ct.err_code: 1700,
-                 ct.err_msg: f"groupBy field not found in schema"}
-        self.search(client, self.collection_name, data=search_vectors,
-                    anns_field=self.float_vector_field_name,
-                    search_params=search_params, limit=10,
-                    group_by_field=[DataType.VARCHAR.name, DataType.INT32.name],
-                    output_fields=[DataType.VARCHAR.name, DataType.INT32.name],
-                    check_task=CheckTasks.err_res, check_items=error)
+        error = {ct.err_code: 1700, ct.err_msg: "groupBy field not found in schema"}
+        self.search(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            anns_field=self.float_vector_field_name,
+            search_params=search_params,
+            limit=10,
+            group_by_field=[DataType.VARCHAR.name, DataType.INT32.name],
+            output_fields=[DataType.VARCHAR.name, DataType.INT32.name],
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("grpby_nonexist_field", ["nonexist_field", 21])
@@ -863,20 +1051,90 @@ class TestGroupSearchInvalid(TestMilvusClientV2Base):
                 verify: the error code and msg
         """
         client = self._client()
-        search_vectors = cf.gen_vectors(1, dim=self.float_vector_dim,
-                                        vector_data_type=DataType.FLOAT_VECTOR)
+        search_vectors = cf.gen_vectors(1, dim=self.float_vector_dim, vector_data_type=DataType.FLOAT_VECTOR)
         search_params = {"metric_type": self.float_vector_metric}
         limit = 1
-        error = {ct.err_code: 1700,
-                 ct.err_msg: f"groupBy field not found in schema: field not found[field={grpby_nonexist_field}]"}
-        self.search(client, self.collection_name, data=search_vectors,
-                    anns_field=self.float_vector_field_name,
-                    search_params=search_params, limit=limit,
-                    group_by_field=grpby_nonexist_field,
-                    check_task=CheckTasks.err_res, check_items=error)
+        error = {
+            ct.err_code: 1700,
+            ct.err_msg: f"groupBy field not found in schema: field not found[field={grpby_nonexist_field}]",
+        }
+        self.search(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            anns_field=self.float_vector_field_name,
+            search_params=search_params,
+            limit=limit,
+            group_by_field=grpby_nonexist_field,
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
 
 class TestSearchGroupByIndependent(TestMilvusClientV2Base):
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_search_group_by_nullable_vector(self):
+        """
+        target: test group-by search on an indexed nullable vector field
+        method: create collection with nullable FLOAT_VECTOR, insert mixed null/non-null vectors,
+                build IVF_FLAT index, search with INT8 group-by and is-not-null scalar filter
+        expected: search returns grouped results from non-null scalar groups
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        dim = 36
+        nb = 10000
+        vector_field = ct.default_float_vec_field_name
+        group_by_field = DataType.INT8.name
+
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        schema.add_field(field_name=ct.default_primary_field_name, datatype=DataType.INT64, is_primary=True)
+        schema.add_field(field_name=vector_field, datatype=DataType.FLOAT_VECTOR, dim=dim, nullable=True)
+        schema.add_field(field_name=group_by_field, datatype=DataType.INT8, nullable=True)
+        self.create_collection(client, collection_name, schema=schema)
+
+        vectors = cf.gen_vectors(nb, dim=dim, vector_data_type=DataType.FLOAT_VECTOR)
+        rows = [
+            {
+                ct.default_primary_field_name: i,
+                vector_field: None if i % 10 == 9 else vectors[i],
+                group_by_field: None if i % 5 == 0 else i % 100,
+            }
+            for i in range(nb)
+        ]
+        self.insert(client, collection_name, data=rows)
+        self.flush(client, collection_name)
+
+        index_params = self.prepare_index_params(client)[0]
+        index_params.add_index(
+            field_name=vector_field, metric_type="COSINE", index_type="IVF_FLAT", params={"nlist": 128}
+        )
+        self.create_index(client, collection_name, index_params=index_params)
+        self.wait_for_index_ready(client, collection_name, index_name=vector_field)
+        self.load_collection(client, collection_name)
+
+        nq = 2
+        limit = 15
+        search_vectors = cf.gen_vectors(nq, dim=dim, vector_data_type=DataType.FLOAT_VECTOR)
+        search_params = {"params": {"nprobe": 32}, "metric_type": "COSINE"}
+        res = self.search(
+            client,
+            collection_name,
+            data=search_vectors,
+            anns_field=vector_field,
+            search_params=search_params,
+            limit=limit,
+            filter=f"{group_by_field} is not null",
+            group_by_field=group_by_field,
+            output_fields=[group_by_field],
+        )[0]
+
+        for hits in res:
+            group_values = [hit.get(group_by_field) for hit in hits]
+            assert len(group_values) == limit
+            assert None not in group_values
+            assert len(group_values) == len(set(group_values))
+
     @pytest.mark.tags(CaseLabel.L1)
     @pytest.mark.parametrize("metric", ["L2", "IP", "COSINE"])
     def test_search_group_by_flat_index_correctness(self, metric):
@@ -904,11 +1162,14 @@ class TestSearchGroupByIndependent(TestMilvusClientV2Base):
 
         for _ in range(10):
             all_vectors = cf.gen_vectors(ct.default_nb, dim=ct.default_dim)
-            rows = [{
-                ct.default_primary_field_name: i,
-                ct.default_float_vec_field_name: all_vectors[i],
-                ct.default_int32_field_name: i,
-            } for i in range(ct.default_nb)]
+            rows = [
+                {
+                    ct.default_primary_field_name: i,
+                    ct.default_float_vec_field_name: all_vectors[i],
+                    ct.default_int32_field_name: i,
+                }
+                for i in range(ct.default_nb)
+            ]
             self.insert(client, collection_name, data=rows)
         self.flush(client, collection_name)
 
@@ -920,18 +1181,28 @@ class TestSearchGroupByIndependent(TestMilvusClientV2Base):
         search_params = {"metric_type": metric}
 
         # normal search to get the best result
-        normal_res = self.search(client, collection_name, data=search_vectors,
-                                 search_params=search_params, limit=limit,
-                                 output_fields=[grpby_field],
-                                 check_task=CheckTasks.check_search_results,
-                                 check_items={"nq": nq, "limit": limit})[0]
+        normal_res = self.search(
+            client,
+            collection_name,
+            data=search_vectors,
+            search_params=search_params,
+            limit=limit,
+            output_fields=[grpby_field],
+            check_task=CheckTasks.check_search_results,
+            check_items={"nq": nq, "limit": limit},
+        )[0]
         # group_by search
-        groupby_res = self.search(client, collection_name, data=search_vectors,
-                                  search_params=search_params, limit=limit,
-                                  group_by_field=grpby_field,
-                                  output_fields=[grpby_field],
-                                  check_task=CheckTasks.check_search_results,
-                                  check_items={"nq": nq, "limit": limit})[0]
+        groupby_res = self.search(
+            client,
+            collection_name,
+            data=search_vectors,
+            search_params=search_params,
+            limit=limit,
+            group_by_field=grpby_field,
+            output_fields=[grpby_field],
+            check_task=CheckTasks.check_search_results,
+            check_items={"nq": nq, "limit": limit},
+        )[0]
         # verify that the top result from group_by search matches the normal search
         # for the same group value, group_by should return the best (closest) result
         normal_top_distance = normal_res[0][0].distance
@@ -946,9 +1217,11 @@ class TestSearchGroupByIndependent(TestMilvusClientV2Base):
         # because group_by returns the best result per group
         if metric == "L2":
             # For L2, smaller is better
-            assert groupby_top_distance <= normal_top_distance + epsilon, \
-                f"GroupBy search should return result with distance <= normal search for L2 metric"
+            assert groupby_top_distance <= normal_top_distance + epsilon, (
+                "GroupBy search should return result with distance <= normal search for L2 metric"
+            )
         else:
             # For IP/COSINE, larger is better
-            assert groupby_top_distance >= normal_top_distance - epsilon, \
+            assert groupby_top_distance >= normal_top_distance - epsilon, (
                 f"GroupBy search should return result with distance >= normal search for {metric} metric"
+            )


### PR DESCRIPTION
## Summary
- Keep transformed nullable-vector bitsets pinned for the lifetime of search results so vector iterators do not hold dangling bitset views.
- Add regression coverage for indexed nullable vector group-by search while preserving the existing non-nullable group-by test fixture.

issue: #49660

## Test plan
- [x] `make cppcheck`
- [x] `ruff check tests/python_client/milvus_client/test_milvus_client_search_group_by.py`
- [x] `ruff format --check --diff tests/python_client/milvus_client/test_milvus_client_search_group_by.py`
- [x] `git diff --check HEAD~1..HEAD`
- [x] `python3 -m py_compile tests/python_client/milvus_client/test_milvus_client_search_group_by.py`
- [x] `python3 -m pytest milvus_client/test_milvus_client_search_group_by.py::TestSearchGroupByIndependent::test_search_group_by_nullable_vector milvus_client/test_milvus_client_search_group_by.py::TestGroupSearch::test_search_group_by_supported_scalars --collect-only -q -o addopts='-p no:locust -v'`