### PR TITLE
fix: [3.0] tighten two-stage search thresholds

### DIFF
--- a/internal/querynodev2/delegator/delegator_twostage_test.go
+++ b/internal/querynodev2/delegator/delegator_twostage_test.go
@@ -179,7 +179,7 @@ func (s *TwoStageSearchSuite) TestShouldUseTwoStageSearch() {
 		s.False(result, "should return false when both segments and topk are below threshold")
 	})
 
-	s.Run("segments_above_threshold", func() {
+	s.Run("topk_below_threshold", func() {
 		paramtable.Get().Save(paramtable.Get().AutoIndexConfig.TwoStageSearchEnabled.Key, "true")
 		paramtable.Get().Save(paramtable.Get().AutoIndexConfig.TwoStageSearchMinTopk.Key, "2000")
 		paramtable.Get().Save(paramtable.Get().AutoIndexConfig.TwoStageSearchMinNumSegments.Key, "5")
@@ -195,12 +195,12 @@ func (s *TwoStageSearchSuite) TestShouldUseTwoStageSearch() {
 				SearchType: internalpb.SearchType_PURE_ANN_SEARCH_WITH_FILTER,
 			},
 		}
-		// sealedNum=10 is above min segments (5), so it should pass even if topk is below threshold
+		// topk=1000 is below min topk (2000), so it should not pass even if sealedNum is above threshold
 		result := optimizers.ShouldUseTwoStageSearch(req, 10)
-		s.True(result, "should return true when segments are above threshold")
+		s.False(result, "should return false when topk is below threshold")
 	})
 
-	s.Run("topk_above_threshold", func() {
+	s.Run("segments_below_threshold", func() {
 		paramtable.Get().Save(paramtable.Get().AutoIndexConfig.TwoStageSearchEnabled.Key, "true")
 		paramtable.Get().Save(paramtable.Get().AutoIndexConfig.TwoStageSearchMinTopk.Key, "2000")
 		paramtable.Get().Save(paramtable.Get().AutoIndexConfig.TwoStageSearchMinNumSegments.Key, "5")
@@ -216,9 +216,9 @@ func (s *TwoStageSearchSuite) TestShouldUseTwoStageSearch() {
 				SearchType: internalpb.SearchType_PURE_ANN_SEARCH_WITH_FILTER,
 			},
 		}
-		// topk=3000 is above min topk (2000), so it should pass even if segments are below threshold
+		// sealedNum=3 is below min segments (5), so it should not pass even if topk is above threshold
 		result := optimizers.ShouldUseTwoStageSearch(req, 3)
-		s.True(result, "should return true when topk is above threshold")
+		s.False(result, "should return false when segments are below threshold")
 	})
 
 	s.Run("wrong_search_type_no_filter", func() {
@@ -886,7 +886,7 @@ func (s *TwoStageSearchSuite) TestTwoStageSearchWithMultipleSegments() {
 }
 
 func (s *TwoStageSearchSuite) TestShouldUseTwoStageSearchEdgeCases() {
-	s.Run("exact_threshold_segments", func() {
+	s.Run("topk_below_threshold_at_exact_segments", func() {
 		paramtable.Get().Save(paramtable.Get().AutoIndexConfig.TwoStageSearchEnabled.Key, "true")
 		paramtable.Get().Save(paramtable.Get().AutoIndexConfig.TwoStageSearchMinTopk.Key, "2000")
 		paramtable.Get().Save(paramtable.Get().AutoIndexConfig.TwoStageSearchMinNumSegments.Key, "5")
@@ -902,12 +902,12 @@ func (s *TwoStageSearchSuite) TestShouldUseTwoStageSearchEdgeCases() {
 				SearchType: internalpb.SearchType_PURE_ANN_SEARCH_WITH_FILTER,
 			},
 		}
-		// sealedNum=5 is exactly at threshold
+		// sealedNum=5 is exactly at threshold, but topk is below threshold
 		result := optimizers.ShouldUseTwoStageSearch(req, 5)
-		s.True(result, "should return true when segments equal threshold")
+		s.False(result, "should return false when topk is below threshold")
 	})
 
-	s.Run("exact_threshold_topk", func() {
+	s.Run("segments_below_threshold_at_exact_topk", func() {
 		paramtable.Get().Save(paramtable.Get().AutoIndexConfig.TwoStageSearchEnabled.Key, "true")
 		paramtable.Get().Save(paramtable.Get().AutoIndexConfig.TwoStageSearchMinTopk.Key, "2000")
 		paramtable.Get().Save(paramtable.Get().AutoIndexConfig.TwoStageSearchMinNumSegments.Key, "5")
@@ -923,9 +923,9 @@ func (s *TwoStageSearchSuite) TestShouldUseTwoStageSearchEdgeCases() {
 				SearchType: internalpb.SearchType_PURE_ANN_SEARCH_WITH_FILTER,
 			},
 		}
-		// sealedNum=4 is below threshold
+		// topk=2000 is exactly at threshold, but sealedNum=4 is below threshold
 		result := optimizers.ShouldUseTwoStageSearch(req, 4)
-		s.True(result, "should return true when topk equals threshold")
+		s.False(result, "should return false when segments are below threshold")
 	})
 
 	s.Run("zero_segments", func() {
@@ -964,9 +964,9 @@ func (s *TwoStageSearchSuite) TestShouldUseTwoStageSearchEdgeCases() {
 				SearchType: internalpb.SearchType_PURE_ANN_SEARCH_WITH_FILTER,
 			},
 		}
-		// sealedNum=10 is above threshold, so it should pass
+		// topk=0 is below threshold, so it should not pass even if sealedNum is above threshold
 		result := optimizers.ShouldUseTwoStageSearch(req, 10)
-		s.True(result, "should return true when segments above threshold even with zero topk")
+		s.False(result, "should return false when topk is below threshold")
 	})
 }
 

--- a/internal/util/searchutil/optimizers/query_hook.go
+++ b/internal/util/searchutil/optimizers/query_hook.go
@@ -146,7 +146,7 @@ func ShouldUseTwoStageSearch(req *querypb.SearchRequest, effectiveSegmentNum int
 	if !paramtable.Get().AutoIndexConfig.TwoStageSearchEnabled.GetAsBool() {
 		return false
 	}
-	if effectiveSegmentNum < paramtable.Get().AutoIndexConfig.TwoStageSearchMinNumSegments.GetAsInt() && req.GetReq().GetTopk() < paramtable.Get().AutoIndexConfig.TwoStageSearchMinTopk.GetAsInt64() {
+	if effectiveSegmentNum < paramtable.Get().AutoIndexConfig.TwoStageSearchMinNumSegments.GetAsInt() || req.GetReq().GetTopk() < paramtable.Get().AutoIndexConfig.TwoStageSearchMinTopk.GetAsInt64() {
 		return false
 	}
 	return req.GetReq().GetSearchType() == internalpb.SearchType_PURE_ANN_SEARCH_WITH_FILTER

--- a/internal/util/searchutil/optimizers/query_hook_test.go
+++ b/internal/util/searchutil/optimizers/query_hook_test.go
@@ -402,6 +402,92 @@ func (suite *QueryHookSuite) TestOptimizeSearchParam() {
 	})
 }
 
+func TestShouldUseTwoStageSearch(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().AutoIndexConfig.TwoStageSearchEnabled.Key, "true")
+	paramtable.Get().Save(paramtable.Get().AutoIndexConfig.TwoStageSearchMinTopk.Key, "2000")
+	paramtable.Get().Save(paramtable.Get().AutoIndexConfig.TwoStageSearchMinNumSegments.Key, "5")
+	t.Cleanup(func() {
+		paramtable.Get().Reset(paramtable.Get().AutoIndexConfig.TwoStageSearchEnabled.Key)
+		paramtable.Get().Reset(paramtable.Get().AutoIndexConfig.TwoStageSearchMinTopk.Key)
+		paramtable.Get().Reset(paramtable.Get().AutoIndexConfig.TwoStageSearchMinNumSegments.Key)
+	})
+
+	tests := []struct {
+		name                string
+		twoStageEnabled     string
+		topk                int64
+		effectiveSegmentNum int
+		searchType          internalpb.SearchType
+		want                bool
+	}{
+		{
+			name:                "disabled",
+			twoStageEnabled:     "false",
+			topk:                3000,
+			effectiveSegmentNum: 10,
+			searchType:          internalpb.SearchType_PURE_ANN_SEARCH_WITH_FILTER,
+			want:                false,
+		},
+		{
+			name:                "segments_below_threshold",
+			topk:                3000,
+			effectiveSegmentNum: 3,
+			searchType:          internalpb.SearchType_PURE_ANN_SEARCH_WITH_FILTER,
+			want:                false,
+		},
+		{
+			name:                "topk_below_threshold",
+			topk:                1000,
+			effectiveSegmentNum: 10,
+			searchType:          internalpb.SearchType_PURE_ANN_SEARCH_WITH_FILTER,
+			want:                false,
+		},
+		{
+			name:                "thresholds_met_exactly",
+			topk:                2000,
+			effectiveSegmentNum: 5,
+			searchType:          internalpb.SearchType_PURE_ANN_SEARCH_WITH_FILTER,
+			want:                true,
+		},
+		{
+			name:                "thresholds_exceeded",
+			topk:                3000,
+			effectiveSegmentNum: 10,
+			searchType:          internalpb.SearchType_PURE_ANN_SEARCH_WITH_FILTER,
+			want:                true,
+		},
+		{
+			name:                "wrong_search_type",
+			topk:                3000,
+			effectiveSegmentNum: 10,
+			searchType:          internalpb.SearchType_PURE_ANN_SEARCH_NO_FILTER,
+			want:                false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.twoStageEnabled != "" {
+				paramtable.Get().Save(paramtable.Get().AutoIndexConfig.TwoStageSearchEnabled.Key, test.twoStageEnabled)
+				t.Cleanup(func() {
+					paramtable.Get().Save(paramtable.Get().AutoIndexConfig.TwoStageSearchEnabled.Key, "true")
+				})
+			}
+
+			req := &querypb.SearchRequest{
+				Req: &internalpb.SearchRequest{
+					Topk:       test.topk,
+					SearchType: test.searchType,
+				},
+			}
+			if got := ShouldUseTwoStageSearch(req, test.effectiveSegmentNum); got != test.want {
+				t.Fatalf("ShouldUseTwoStageSearch() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
 func (suite *QueryHookSuite) verifyQueryInfo(req *querypb.SearchRequest, topK int64, isTopkReduce bool, isRecallEvaluation bool, param string) {
 	queryInfo := suite.getQueryInfo(req)
 	suite.Equal(topK, queryInfo.GetTopk())


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/47218
pr: https://github.com/milvus-io/milvus/pull/49772

## What changed
- Require both effective segment count and topk to meet their two-stage search thresholds before enabling two-stage search.
- Add table-driven coverage for ShouldUseTwoStageSearch threshold behavior.
- Update delegator two-stage search expectations for the stricter threshold logic.
