### PR TITLE
fix: [3.0] retry retriable shard errors without blacklisting replicas (#49740)

### DIFF
--- a/internal/proxy/shardclient/lb_policy.go
+++ b/internal/proxy/shardclient/lb_policy.go
@@ -237,10 +237,36 @@ func (lb *LBPolicyImpl) ExecuteWithRetry(ctx context.Context, workload ChannelWo
 		zap.String("channelName", workload.Channel),
 	)
 	var lastErr error
+	var err error
+	var shardLeaders []NodeInfo
+	requestExcludedNodes := typeutil.NewUniqueSet()
 	tryExecute := func() (bool, error) {
 		// Get fresh blacklist on each retry to include newly blacklisted nodes
 		blacklist := lb.blacklist.GetBlacklistedNodes(workload.Channel)
+		if len(shardLeaders) > 0 && requestExcludedNodes.Len() >= len(shardLeaders) {
+			shardLeaders, err = lb.GetShard(ctx, workload.Db, workload.CollectionName, workload.CollectionID, workload.Channel, false)
+			if err != nil {
+				log.Warn("failed to refresh shard leaders", zap.Error(err))
+				if lastErr != nil {
+					return true, lastErr
+				}
+				return true, err
+			}
+
+			allReplicaExcluded := len(shardLeaders) > 0
+			for _, node := range shardLeaders {
+				if !requestExcludedNodes.Contain(node.NodeID) {
+					allReplicaExcluded = false
+					break
+				}
+			}
+			if allReplicaExcluded {
+				log.Warn("all replicas are request-level excluded after refresh, clear it and retry")
+				requestExcludedNodes.Clear()
+			}
+		}
 		excludeNodes := typeutil.NewUniqueSet(blacklist...)
+		excludeNodes.Insert(requestExcludedNodes.Collect()...)
 		balancer := lb.getBalancer()
 		targetNode, err := lb.selectNode(ctx, balancer, workload, &excludeNodes)
 		if err != nil {
@@ -273,7 +299,11 @@ func (lb *LBPolicyImpl) ExecuteWithRetry(ctx context.Context, workload ChannelWo
 			log.Warn("search/query channel failed",
 				zap.Int64("nodeID", targetNode.NodeID),
 				zap.Error(err))
-			lb.blacklist.Add(workload.Channel, targetNode.NodeID)
+			if merr.IsRetryableErr(err) {
+				requestExcludedNodes.Insert(targetNode.NodeID)
+			} else {
+				lb.blacklist.Add(workload.Channel, targetNode.NodeID)
+			}
 			lastErr = errors.Wrapf(err, "failed to search/query delegator %d for channel %s", targetNode.NodeID, workload.Channel)
 			return true, lastErr
 		}
@@ -281,12 +311,13 @@ func (lb *LBPolicyImpl) ExecuteWithRetry(ctx context.Context, workload ChannelWo
 		return true, nil
 	}
 
-	shardLeaders, err := lb.GetShard(ctx, workload.Db, workload.CollectionName, workload.CollectionID, workload.Channel, true)
+	shardLeaders, err = lb.GetShard(ctx, workload.Db, workload.CollectionName, workload.CollectionID, workload.Channel, true)
 	if err != nil {
 		log.Warn("failed to get shard leaders", zap.Error(err))
 		return err
 	}
-	retryTimes := max(lb.retryOnReplica, len(shardLeaders))
+	// Sweep all shard leaders once, then allow configured request-level retries after every leader returns a retriable error.
+	retryTimes := len(shardLeaders) + max(lb.retryOnReplica, 1)
 	err = retry.Handle(ctx, tryExecute, retry.Attempts(uint(retryTimes)))
 	if err != nil {
 		log.Warn("failed to execute",

--- a/internal/proxy/shardclient/lb_policy_test.go
+++ b/internal/proxy/shardclient/lb_policy_test.go
@@ -326,6 +326,174 @@ func (s *LBPolicySuite) TestExecuteWithRetry() {
 	s.True(merr.IsCanceledOrTimeout(err))
 }
 
+func (s *LBPolicySuite) TestExecuteWithRetryRetriableErrorUsesRequestLevelRetry() {
+	ctx := context.Background()
+	channel := s.channels[0]
+	nodes := []NodeInfo{
+		{NodeID: 1, Address: "localhost:9000", Serviceable: true},
+		{NodeID: 2, Address: "localhost:9001", Serviceable: true},
+	}
+	s.lbPolicy.retryOnReplica = 2
+
+	s.mgr.ExpectedCalls = nil
+	s.lbBalancer.ExpectedCalls = nil
+	s.mgr.EXPECT().GetShard(mock.Anything, true, s.dbName, s.collectionName, s.collectionID, channel).Return(nodes, nil)
+	s.mgr.EXPECT().GetShard(mock.Anything, false, s.dbName, s.collectionName, s.collectionID, channel).Return(nodes, nil).Maybe()
+	s.mgr.EXPECT().GetClient(mock.Anything, mock.Anything).Return(s.qn, nil)
+	s.lbBalancer.EXPECT().RegisterNodeInfo(mock.Anything)
+	s.lbBalancer.EXPECT().SelectNode(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, availableNodes []int64, nq int64) (int64, error) {
+			return availableNodes[0], nil
+		})
+	s.lbBalancer.EXPECT().CancelWorkload(mock.Anything, mock.Anything)
+
+	executedNodes := make([]int64, 0, 3)
+	err := s.lbPolicy.ExecuteWithRetry(ctx, ChannelWorkload{
+		Db:             s.dbName,
+		CollectionName: s.collectionName,
+		CollectionID:   s.collectionID,
+		Channel:        channel,
+		Nq:             1,
+		Exec: func(ctx context.Context, nodeID UniqueID, qn types.QueryNodeClient, channel string) error {
+			executedNodes = append(executedNodes, nodeID)
+			if len(executedNodes) <= len(nodes) {
+				return errors.Wrapf(merr.ErrServiceUnavailable, "fail on QueryNode %d", nodeID)
+			}
+			return nil
+		},
+	})
+
+	s.NoError(err)
+	s.Len(executedNodes, 3)
+	s.NotEqual(executedNodes[0], executedNodes[1])
+	s.Empty(s.lbPolicy.blacklist.GetBlacklistedNodes(channel))
+}
+
+func (s *LBPolicySuite) TestExecuteWithRetryRetriableErrorRetriesAfterAllReplicasFail() {
+	ctx := context.Background()
+	channel := s.channels[0]
+	nodes := []NodeInfo{
+		{NodeID: 1, Address: "localhost:9000", Serviceable: true},
+		{NodeID: 2, Address: "localhost:9001", Serviceable: true},
+	}
+	s.lbPolicy.retryOnReplica = 2
+
+	s.mgr.ExpectedCalls = nil
+	s.lbBalancer.ExpectedCalls = nil
+	s.mgr.EXPECT().GetShard(mock.Anything, true, s.dbName, s.collectionName, s.collectionID, channel).Return(nodes, nil)
+	s.mgr.EXPECT().GetShard(mock.Anything, false, s.dbName, s.collectionName, s.collectionID, channel).Return(nodes, nil).Maybe()
+	s.mgr.EXPECT().GetClient(mock.Anything, mock.Anything).Return(s.qn, nil)
+	s.lbBalancer.EXPECT().RegisterNodeInfo(mock.Anything)
+	s.lbBalancer.EXPECT().SelectNode(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, availableNodes []int64, nq int64) (int64, error) {
+			return availableNodes[0], nil
+		})
+	s.lbBalancer.EXPECT().CancelWorkload(mock.Anything, mock.Anything)
+
+	executedNodes := make([]int64, 0, 4)
+	err := s.lbPolicy.ExecuteWithRetry(ctx, ChannelWorkload{
+		Db:             s.dbName,
+		CollectionName: s.collectionName,
+		CollectionID:   s.collectionID,
+		Channel:        channel,
+		Nq:             1,
+		Exec: func(ctx context.Context, nodeID UniqueID, qn types.QueryNodeClient, channel string) error {
+			executedNodes = append(executedNodes, nodeID)
+			if len(executedNodes) <= len(nodes)+1 {
+				return errors.Wrapf(merr.ErrServiceUnavailable, "fail on QueryNode %d", nodeID)
+			}
+			return nil
+		},
+	})
+
+	s.NoError(err)
+	s.Len(executedNodes, 4)
+	s.ElementsMatch([]int64{int64(1), int64(2)}, executedNodes[:2])
+	s.NotEqual(executedNodes[2], executedNodes[3])
+	s.Empty(s.lbPolicy.blacklist.GetBlacklistedNodes(channel))
+}
+
+func (s *LBPolicySuite) TestExecuteWithRetryRetriableErrorRefreshesStaleShardLeaderCache() {
+	ctx := context.Background()
+	channel := s.channels[0]
+	cachedNodes := []NodeInfo{{NodeID: 1, Address: "localhost:9000", Serviceable: true}}
+	freshNodes := []NodeInfo{
+		{NodeID: 1, Address: "localhost:9000", Serviceable: true},
+		{NodeID: 2, Address: "localhost:9001", Serviceable: true},
+	}
+	shardLeaders := cachedNodes
+	s.lbPolicy.retryOnReplica = 2
+
+	s.mgr.ExpectedCalls = nil
+	s.lbBalancer.ExpectedCalls = nil
+	s.mgr.EXPECT().GetShard(mock.Anything, true, s.dbName, s.collectionName, s.collectionID, channel).RunAndReturn(
+		func(context.Context, bool, string, string, int64, string) ([]NodeInfo, error) {
+			return shardLeaders, nil
+		})
+	s.mgr.EXPECT().GetShard(mock.Anything, false, s.dbName, s.collectionName, s.collectionID, channel).RunAndReturn(
+		func(context.Context, bool, string, string, int64, string) ([]NodeInfo, error) {
+			shardLeaders = freshNodes
+			return shardLeaders, nil
+		}).Once()
+	s.mgr.EXPECT().GetClient(mock.Anything, mock.Anything).Return(s.qn, nil)
+	s.lbBalancer.EXPECT().RegisterNodeInfo(mock.Anything)
+	s.lbBalancer.EXPECT().SelectNode(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, availableNodes []int64, nq int64) (int64, error) {
+			return availableNodes[0], nil
+		})
+	s.lbBalancer.EXPECT().CancelWorkload(mock.Anything, mock.Anything)
+
+	executedNodes := make([]int64, 0, 2)
+	err := s.lbPolicy.ExecuteWithRetry(ctx, ChannelWorkload{
+		Db:             s.dbName,
+		CollectionName: s.collectionName,
+		CollectionID:   s.collectionID,
+		Channel:        channel,
+		Nq:             1,
+		Exec: func(ctx context.Context, nodeID UniqueID, qn types.QueryNodeClient, channel string) error {
+			executedNodes = append(executedNodes, nodeID)
+			if nodeID == cachedNodes[0].NodeID {
+				return errors.Wrapf(merr.ErrServiceUnavailable, "fail on QueryNode %d", nodeID)
+			}
+			return nil
+		},
+	})
+
+	s.NoError(err)
+	s.Equal([]int64{1, 2}, executedNodes)
+	s.Empty(s.lbPolicy.blacklist.GetBlacklistedNodes(channel))
+}
+
+func (s *LBPolicySuite) TestExecuteWithRetryNonRetriableErrorUsesBlacklist() {
+	ctx := context.Background()
+	channel := s.channels[0]
+	nodes := []NodeInfo{{NodeID: 1, Address: "localhost:9000", Serviceable: true}}
+	s.lbPolicy.retryOnReplica = 1
+
+	s.mgr.ExpectedCalls = nil
+	s.lbBalancer.ExpectedCalls = nil
+	s.mgr.EXPECT().GetShard(mock.Anything, true, s.dbName, s.collectionName, s.collectionID, channel).Return(nodes, nil)
+	s.mgr.EXPECT().GetShard(mock.Anything, false, s.dbName, s.collectionName, s.collectionID, channel).Return(nodes, nil).Maybe()
+	s.mgr.EXPECT().GetClient(mock.Anything, mock.Anything).Return(s.qn, nil)
+	s.lbBalancer.EXPECT().RegisterNodeInfo(mock.Anything)
+	s.lbBalancer.EXPECT().SelectNode(mock.Anything, mock.Anything, mock.Anything).Return(int64(1), nil)
+	s.lbBalancer.EXPECT().CancelWorkload(mock.Anything, mock.Anything)
+
+	err := s.lbPolicy.ExecuteWithRetry(ctx, ChannelWorkload{
+		Db:             s.dbName,
+		CollectionName: s.collectionName,
+		CollectionID:   s.collectionID,
+		Channel:        channel,
+		Nq:             1,
+		Exec: func(ctx context.Context, nodeID UniqueID, qn types.QueryNodeClient, channel string) error {
+			return errors.Wrapf(merr.ErrParameterInvalid, "fail on QueryNode %d", nodeID)
+		},
+	})
+
+	s.Error(err)
+	s.Contains(s.lbPolicy.blacklist.GetBlacklistedNodes(channel), int64(1))
+}
+
 func (s *LBPolicySuite) TestExecuteOneChannel() {
 	ctx := context.Background()
 	mockErr := errors.New("mock error")
@@ -394,6 +562,7 @@ func (s *LBPolicySuite) TestExecute() {
 	s.NoError(err)
 
 	// test some channel failed
+	s.lbPolicy.retryOnReplica = 1
 	s.mgr.ExpectedCalls = nil
 	s.lbBalancer.ExpectedCalls = nil
 	s.mgr.EXPECT().GetShardLeaderList(mock.Anything, s.dbName, s.collectionName, s.collectionID, true).Return(s.channels, nil)
@@ -421,7 +590,7 @@ func (s *LBPolicySuite) TestExecute() {
 		},
 	})
 	s.Error(err)
-	s.Equal(int64(6), counter.Load())
+	s.Equal(int64(7), counter.Load())
 
 	// test get shard leader failed
 	s.mgr.ExpectedCalls = nil

--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -1068,7 +1068,7 @@ func (sd *shardDelegator) waitTSafe(ctx context.Context, ts uint64) (uint64, err
 			zap.Duration("lag", lag),
 			zap.Duration("maxTsLag", maxLag),
 		)
-		return 0, WrapErrTsLagTooLarge(lag, maxLag)
+		return 0, WrapErrTsLagTooLarge(sd.vchannelName, lag, maxLag)
 	}
 
 	// Stall detection: if tSafe does not advance within stallTimeout, return
@@ -1094,7 +1094,7 @@ func (sd *shardDelegator) waitTSafe(ctx context.Context, ts uint64) (uint64, err
 				zap.Uint64("targetTs", ts),
 				zap.Duration("stallTimeout", stallTimeout),
 			)
-			return 0, WrapErrTsLagTooLarge(gt.Sub(st), stallTimeout)
+			return 0, WrapErrTsLagTooLarge(sd.vchannelName, gt.Sub(st), stallTimeout)
 		}
 		// Woken by broadcast with lock re-acquired, loop back to re-check condition.
 	}

--- a/internal/querynodev2/delegator/delegator_test.go
+++ b/internal/querynodev2/delegator/delegator_test.go
@@ -638,6 +638,16 @@ func (s *DelegatorSuite) TestSearch() {
 		})
 
 		s.Error(err)
+		s.ErrorIs(err, merr.ErrChannelTSafeStalled)
+		s.True(merr.IsRetryableErr(err))
+
+		status := merr.Status(err)
+		s.True(status.GetRetriable())
+		s.Equal(commonpb.ErrorCode_TimeTickLongDelay, status.GetErrorCode())
+
+		roundTripErr := merr.Error(status)
+		s.ErrorIs(roundTripErr, merr.ErrChannelTSafeStalled)
+		s.True(merr.IsRetryableErr(roundTripErr))
 	})
 
 	s.Run("downgrade_tsafe", func() {
@@ -1049,6 +1059,8 @@ func (s *DelegatorSuite) TestQueryStream() {
 			DmlChannels: []string{s.vchannelName},
 		}, server)
 		s.Error(err)
+		s.ErrorIs(err, merr.ErrChannelTSafeStalled)
+		s.True(merr.IsRetryableErr(err))
 	})
 
 	s.Run("get_worker_failed", func() {

--- a/internal/querynodev2/delegator/types.go
+++ b/internal/querynodev2/delegator/types.go
@@ -4,9 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -51,9 +50,9 @@ type TSafeUpdater interface {
 }
 
 // ErrTsLagTooLarge serviceable and guarantee lag too large.
-var ErrTsLagTooLarge = errors.New("Timestamp lag too large")
+var ErrTsLagTooLarge = merr.ErrChannelTSafeStalled
 
 // WrapErrTsLagTooLarge wraps ErrTsLagTooLarge with lag and max value.
-func WrapErrTsLagTooLarge(duration time.Duration, maxLag time.Duration) error {
-	return fmt.Errorf("%w lag(%s) max(%s)", ErrTsLagTooLarge, duration, maxLag)
+func WrapErrTsLagTooLarge(channel string, duration time.Duration, maxLag time.Duration) error {
+	return merr.WrapErrChannelTSafeStalled(channel, fmt.Sprintf("lag(%s) max(%s)", duration, maxLag))
 }

--- a/pkg/util/merr/errors.go
+++ b/pkg/util/merr/errors.go
@@ -101,6 +101,7 @@ var (
 	ErrChannelReduplicate      = newMilvusError("channel reduplicates", 502, false)
 	ErrChannelNotAvailable     = newMilvusError("channel not available", 503, false)
 	ErrChannelCPExceededMaxLag = newMilvusError("channel checkpoint exceed max lag", 504, false)
+	ErrChannelTSafeStalled     = newMilvusError("channel tsafe stalled", 505, true)
 
 	// Segment related
 	ErrSegmentNotFound    = newMilvusError("segment not found", 600, false)

--- a/pkg/util/merr/utils.go
+++ b/pkg/util/merr/utils.go
@@ -57,8 +57,9 @@ func Code(err error) int32 {
 }
 
 func IsRetryableErr(err error) bool {
-	if err, ok := err.(milvusError); ok {
-		return err.retriable
+	var milvusErr milvusError
+	if errors.As(err, &milvusErr) {
+		return milvusErr.retriable
 	}
 
 	return false
@@ -199,7 +200,7 @@ func oldCode(code int32) commonpb.ErrorCode {
 	case ErrServiceDiskLimitExceeded.code():
 		return commonpb.ErrorCode_DiskQuotaExhausted
 
-	case ErrServiceTimeTickLongDelay.code():
+	case ErrServiceTimeTickLongDelay.code(), ErrChannelTSafeStalled.code():
 		return commonpb.ErrorCode_TimeTickLongDelay
 
 	case ErrServiceRateLimit.code():
@@ -756,6 +757,10 @@ func WrapErrChannelNotFound(name string, msg ...string) error {
 
 func WrapErrChannelCPExceededMaxLag(name string, msg ...string) error {
 	return warpChannelErr(ErrChannelCPExceededMaxLag, name, msg...)
+}
+
+func WrapErrChannelTSafeStalled(name string, msg ...string) error {
+	return warpChannelErr(ErrChannelTSafeStalled, name, msg...)
 }
 
 func WrapErrChannelLack(name string, msg ...string) error {

--- a/pkg/util/merr/utils_test.go
+++ b/pkg/util/merr/utils_test.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 )
 
 func TestIsNonRetryableErr(t *testing.T) {
@@ -73,6 +75,28 @@ func TestIsNonRetryableErr_WrappedErrors(t *testing.T) {
 
 	wrappedRetryable := fmt.Errorf("network issue: %w", ErrIoUnexpectEOF)
 	assert.False(t, IsNonRetryableErr(wrappedRetryable))
+}
+
+func TestIsRetryableErrWrapped(t *testing.T) {
+	err := errors.Wrap(ErrServiceUnavailable, "proxy task wrapper")
+	assert.True(t, IsRetryableErr(err))
+
+	nonRetryableErr := errors.Wrap(ErrParameterInvalid, "proxy task wrapper")
+	assert.False(t, IsRetryableErr(nonRetryableErr))
+}
+
+func TestChannelTSafeStalledStatus(t *testing.T) {
+	err := WrapErrChannelTSafeStalled("channel-1", "lag 3s")
+	assert.ErrorIs(t, err, ErrChannelTSafeStalled)
+	assert.True(t, IsRetryableErr(err))
+
+	status := Status(err)
+	assert.True(t, status.GetRetriable())
+	assert.Equal(t, commonpb.ErrorCode_TimeTickLongDelay, status.GetErrorCode())
+
+	roundTripErr := Error(status)
+	assert.ErrorIs(t, roundTripErr, ErrChannelTSafeStalled)
+	assert.True(t, IsRetryableErr(roundTripErr))
 }
 
 func TestIsMilvusError_WrappedChain(t *testing.T) {


### PR DESCRIPTION
Cherry-pick from master
pr: #49740
Related to #49435

Use request-scoped replica exclusion for retriable shard execution errors, while keeping non-retriable failures on the channel blacklist. Add a retriable tSafe-stalled channel error so waitTSafe stalls can fail over through the generic retry path.

---------