### PR TITLE
fix: duplicated words in kafka scanner and paramtable Doc strings

### DIFF
--- a/pkg/streaming/walimpls/impls/kafka/scanner.go
+++ b/pkg/streaming/walimpls/impls/kafka/scanner.go
@@ -52,7 +52,7 @@ func (s *scannerImpl) executeConsume() {
 		msg, err := s.consumer.ReadMessage(200 * time.Millisecond)
 		if err != nil {
 			if s.Context().Err() != nil {
-				// context canceled, means the the scanner is closed.
+				// context canceled, means the scanner is closed.
 				s.Finish(nil)
 				return
 			}

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -1936,7 +1936,7 @@ Segments with smaller size than this parameter will not be indexed, and will be 
 		Key:          "rootCoord.maxGeneralCapacity",
 		Version:      "2.3.5",
 		DefaultValue: "65536",
-		Doc:          "upper limit for the sum of of product of partitionNumber and shardNumber",
+		Doc:          "upper limit for the sum of product of partitionNumber and shardNumber",
 		Export:       true,
 		Formatter: func(v string) string {
 			if getAsInt(v) < 512 {

--- a/pkg/util/paramtable/service_param.go
+++ b/pkg/util/paramtable/service_param.go
@@ -1125,7 +1125,7 @@ Default value applies when Pulsar is running on the same network with Milvus.`,
 		Key:          "pulsar.webport",
 		Version:      "2.0.0",
 		DefaultValue: "80",
-		Doc:          "Web port of of Pulsar service. If you connect direcly without proxy, should use 8080.",
+		Doc:          "Web port of Pulsar service. If you connect direcly without proxy, should use 8080.",
 		Export:       true,
 	}
 	p.WebPort.Init(base.mgr)


### PR DESCRIPTION
Three one-line typo fixes for duplicated words:
- `pkg/streaming/walimpls/impls/kafka/scanner.go` — "// context canceled, means the the scanner is closed." → "// context canceled, means the scanner is closed."
- `pkg/util/paramtable/component_param.go` — Doc string `"upper limit for the sum of of product of partitionNumber and shardNumber"` → `"upper limit for the sum of product of partitionNumber and shardNumber"`
- `pkg/util/paramtable/service_param.go` — Doc string `"Web port of of Pulsar service. ..."` → `"Web port of Pulsar service. ..."`

No code/behavior change.