### PR TITLE
fix: Allow MinIO external source without region

### DIFF
--- a/internal/core/unittest/test_external_take.cpp
+++ b/internal/core/unittest/test_external_take.cpp
@@ -1900,6 +1900,25 @@ TEST(InjectExtfsAllowlist, ExplicitCloudProviderRequiredForAwsFormSwap) {
     }
 }
 
+TEST(InjectExtfsAllowlist, MinIOSchemeUsesMilvusFormDefaults) {
+    milvus_storage::api::Properties props;
+    const int64_t coll_id = 42;
+    std::string spec =
+        R"({"format":"parquet","extfs":{"access_key_id":"AK","access_key_value":"SK"}})";
+
+    ::InjectExternalSpecProperties(
+        props, coll_id, "minio://localhost:9000/bucket/key", spec);
+
+    EXPECT_EQ(std::get<std::string>(props.at("extfs.42.address")),
+              "http://localhost:9000");
+    EXPECT_EQ(std::get<std::string>(props.at("extfs.42.bucket_name")),
+              "bucket");
+    EXPECT_EQ(std::get<std::string>(props.at("extfs.42.use_ssl")), "false");
+    EXPECT_EQ(std::get<std::string>(props.at("extfs.42.access_key_id")), "AK");
+    EXPECT_EQ(props.count("extfs.42.cloud_provider"), 0u);
+    EXPECT_EQ(props.count("extfs.42.region"), 0u);
+}
+
 // milvus-storage's fs.* property registry does not yet declare
 // PROPERTY_FS_ANONYMOUS. Until upstream registers the key,
 // InjectExternalSpecProperties must not zero-init extfs.{cid}.anonymous

--- a/pkg/util/externalspec/external_spec.go
+++ b/pkg/util/externalspec/external_spec.go
@@ -273,6 +273,9 @@ func sortedKeys(m map[string]bool) []string {
 // allowlisted scheme (SSRF guard), non-empty host, no embedded userinfo.
 // Accepts two URI shapes — Milvus form (host=endpoint, path[0]=bucket) and
 // AWS form (host=bucket, endpoint from spec.extfs).
+//
+// For minio://, URI.host is treated as the endpoint; callers should use
+// minio://<endpoint>/<bucket>/<key>.
 func ValidateExternalSource(source string) error {
 	if source == "" {
 		return fmt.Errorf("external_source is empty")
@@ -293,7 +296,7 @@ func ValidateExternalSource(source string) error {
 		return fmt.Errorf("external_source must not embed credentials in the URL (use extfs.access_key_id / extfs.access_key_value instead)")
 	}
 	if u.Host == "" {
-		return fmt.Errorf("external_source must have a non-empty host (e.g. s3://bucket/key or s3://endpoint/bucket/key)")
+		return fmt.Errorf("external_source must have a non-empty host (e.g. s3://bucket/key, s3://endpoint/bucket/key, or minio://endpoint/bucket/key)")
 	}
 	return nil
 }
@@ -320,18 +323,30 @@ func ValidateSourceAndSpec(externalSource, externalSpec string) error {
 // anonymous=true), and region for AWS-family schemes. role_arn subsumes
 // use_iam (do not double-count). No inheritance from Milvus fs.* config.
 func ValidateExtfsComplete(externalSource string, extfs map[string]string) error {
-	// extfs.cloud_provider is required and must be from the allowed set.
-	// Inferring cloud_provider from URI scheme is ambiguous (s3:// matches
-	// AWS S3 and self-hosted MinIO; no scheme-only signal can pick the
-	// correct URI parsing form, auth protocol, or default endpoint). Force
-	// the caller to be explicit so misconfiguration fails at the API
-	// boundary instead of silently routing to the wrong backend.
+	// Parse once; caller's ValidateExternalSource has already guaranteed a scheme.
+	u, err := url.Parse(externalSource)
+	scheme := ""
+	if err == nil {
+		scheme = strings.ToLower(u.Scheme)
+	}
+
+	// extfs.cloud_provider is required and must be from the allowed set, except
+	// for minio:// where the scheme selects MinIO validation semantics. This is
+	// a local classification only; it is not written back to external_spec.
+	// Inferring cloud_provider from s3:// is ambiguous (AWS S3 vs self-hosted
+	// MinIO), so s3-family URIs still require the caller to be explicit.
 	cp := strings.ToLower(extfs[ExtfsKeyCloudProvider])
+	if scheme == SchemeMinIO && cp == "" {
+		cp = CloudProviderMinIO
+	}
 	if cp == "" {
 		return fmt.Errorf("extfs.cloud_provider is required: one of [aws, gcp, aliyun, tencent, huawei, azure, minio]; inferring from URI scheme is ambiguous (e.g. s3:// matches both AWS S3 and self-hosted MinIO)")
 	}
 	if !validCloudProviders[cp] {
 		return fmt.Errorf("extfs.cloud_provider=%q is not supported: must be one of [aws, gcp, aliyun, tencent, huawei, azure, minio]", cp)
+	}
+	if scheme == SchemeMinIO && cp != CloudProviderMinIO {
+		return fmt.Errorf("scheme=minio requires extfs.cloud_provider=%q, got %q", CloudProviderMinIO, cp)
 	}
 
 	hasAKSK := extfs[ExtfsKeyAccessKeyID] != "" && extfs[ExtfsKeyAccessKeyValue] != ""
@@ -356,13 +371,6 @@ func ValidateExtfsComplete(externalSource string, extfs map[string]string) error
 	}
 	if modes > 1 {
 		return fmt.Errorf("extfs credential modes are mutually exclusive: set exactly one of AK/SK, role_arn, use_iam=true, gcp_target_service_account, or anonymous=true")
-	}
-
-	// Parse once; caller's ValidateExternalSource has already guaranteed a scheme.
-	u, err := url.Parse(externalSource)
-	scheme := ""
-	if err == nil {
-		scheme = strings.ToLower(u.Scheme)
 	}
 
 	if hasGCPImpersonation {

--- a/pkg/util/externalspec/external_spec_test.go
+++ b/pkg/util/externalspec/external_spec_test.go
@@ -113,7 +113,7 @@ func TestValidateExternalSource(t *testing.T) {
 			"s3://bucket/prefix",
 			"s3a://bucket/prefix",
 			"aws://bucket/prefix",
-			"minio://bucket/prefix",
+			"minio://localhost:9000/bucket/prefix",
 			"oss://bucket/prefix",
 			"gs://bucket/prefix",
 			"gcs://bucket/prefix",
@@ -143,6 +143,12 @@ func TestValidateExternalSource(t *testing.T) {
 
 	t.Run("empty_host_rejected", func(t *testing.T) {
 		err := ValidateExternalSource("s3:///bucket/path")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "non-empty host")
+	})
+
+	t.Run("minio_empty_endpoint_rejected", func(t *testing.T) {
+		err := ValidateExternalSource("minio:///bucket/path")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "non-empty host")
 	})
@@ -206,6 +212,19 @@ func TestValidateSourceAndSpec(t *testing.T) {
 		err := ValidateSourceAndSpec("s3://localhost:9000/mybucket/path",
 			`{"format":"parquet","extfs":{"access_key_id":"AK","access_key_value":"SK","region":"us-east-1","cloud_provider":"minio"}}`)
 		assert.NoError(t, err)
+	})
+
+	t.Run("minio_scheme_selects_minio_validation_semantics", func(t *testing.T) {
+		err := ValidateSourceAndSpec("minio://localhost:9000/mybucket/path",
+			`{"format":"parquet","extfs":{"access_key_id":"AK","access_key_value":"SK"}}`)
+		assert.NoError(t, err)
+	})
+
+	t.Run("minio_scheme_rejects_non_minio_cloud_provider", func(t *testing.T) {
+		err := ValidateSourceAndSpec("minio://localhost:9000/mybucket/path",
+			`{"format":"parquet","extfs":{"access_key_id":"AK","access_key_value":"SK","region":"us-east-1","cloud_provider":"aws"}}`)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "scheme=minio requires")
 	})
 
 	t.Run("gcs_scheme_does_not_require_region", func(t *testing.T) {

--- a/tests/go_client/testcases/external_table_iceberg_e2e_test.go
+++ b/tests/go_client/testcases/external_table_iceberg_e2e_test.go
@@ -31,14 +31,15 @@ type icebergTableInfo struct {
 	Dim              int    `json:"dim"`
 }
 
-// toMilvusURI converts an Iceberg-native URI (s3://bucket/key) to Milvus format (s3://host/bucket/key).
-func toMilvusURI(icebergURI, host string) string {
+// toMilvusMinIOURI converts an Iceberg-native URI (s3://bucket/key) to
+// Milvus MinIO URI format (minio://host/bucket/key).
+func toMilvusMinIOURI(icebergURI, host string) string {
 	u, err := url.Parse(icebergURI)
 	if err != nil || u.Scheme == "" {
 		return icebergURI
 	}
-	// s3://bucket/key → bucket = u.Host, key = u.Path
-	return fmt.Sprintf("%s://%s/%s%s", u.Scheme, host, u.Host, u.Path)
+	// s3://bucket/key -> bucket = u.Host, key = u.Path
+	return fmt.Sprintf("minio://%s/%s%s", host, u.Host, u.Path)
 }
 
 // TestExternalTableIcebergE2E tests the full Iceberg external table pipeline:
@@ -46,8 +47,8 @@ func toMilvusURI(icebergURI, host string) string {
 //	Create Iceberg table on MinIO → CreateCollection (format=iceberg-table) →
 //	Refresh (with snapshot_id) → Load → Search → Query → Drop.
 //
-// The externalSource uses Milvus standard URI format (s3://host/bucket/path/metadata.json),
-// same as parquet and lance external tables. MinIO connection details are passed via extfs.
+// The externalSource uses minio://host/bucket/path/metadata.json. The scheme
+// carries MinIO routing defaults, so extfs only needs credentials.
 //
 // Run:
 //
@@ -74,12 +75,11 @@ func TestExternalTableIcebergE2E(t *testing.T) {
 	t.Logf("[Phase 0] Iceberg table created: metadata=%s, snapshot_id=%d, rows=%d",
 		tableInfo.MetadataLocation, tableInfo.SnapshotID, tableInfo.NumRows)
 
-	// Convert Iceberg-native URI (s3://bucket/key) to Milvus format (s3://host/bucket/key)
-	// to match the URI convention used by parquet/lance external tables.
+	// Convert Iceberg-native URI (s3://bucket/key) to Milvus MinIO URI format.
 	minioHost := strings.TrimPrefix(strings.TrimPrefix(minioEndpoint, "http://"), "https://")
-	externalSource := toMilvusURI(tableInfo.MetadataLocation, minioHost)
+	externalSource := toMilvusMinIOURI(tableInfo.MetadataLocation, minioHost)
 
-	// Build ExternalSpec with extfs for MinIO access (same pattern as cross-bucket parquet E2E)
+	// Build ExternalSpec with the minimal extfs needed for MinIO access.
 	type externalSpecJSON struct {
 		Format     string            `json:"format"`
 		SnapshotID int64             `json:"snapshot_id,string"`
@@ -89,11 +89,6 @@ func TestExternalTableIcebergE2E(t *testing.T) {
 		Format:     "iceberg-table",
 		SnapshotID: tableInfo.SnapshotID,
 		Extfs: map[string]string{
-			"bucket_name":      bucket,
-			"region":           "us-east-1",
-			"use_ssl":          "false",
-			"use_virtual_host": "false",
-			"cloud_provider":   "minio",
 			"access_key_id":    minioAccessKey,
 			"access_key_value": minioSecretKey,
 		},
@@ -233,7 +228,7 @@ func TestExternalTableIcebergRefreshFailsOnSchemaTypeMismatch(t *testing.T) {
 		bucket, tablePath, "16", "4")
 
 	minioHost := strings.TrimPrefix(strings.TrimPrefix(minioEndpoint, "http://"), "https://")
-	externalSource := toMilvusURI(tableInfo.MetadataLocation, minioHost)
+	externalSource := toMilvusMinIOURI(tableInfo.MetadataLocation, minioHost)
 
 	type externalSpecJSON struct {
 		Format     string            `json:"format"`
@@ -244,11 +239,6 @@ func TestExternalTableIcebergRefreshFailsOnSchemaTypeMismatch(t *testing.T) {
 		Format:     "iceberg-table",
 		SnapshotID: tableInfo.SnapshotID,
 		Extfs: map[string]string{
-			"bucket_name":      bucket,
-			"region":           "us-east-1",
-			"use_ssl":          "false",
-			"use_virtual_host": "false",
-			"cloud_provider":   "minio",
 			"access_key_id":    minioAccessKey,
 			"access_key_value": minioSecretKey,
 		},
@@ -409,7 +399,7 @@ func TestExternalCollectionMultipleDataTypesIceberg(t *testing.T) {
 		minioSecretKey, bucket, tablePath, numRows, testVecDim, testBinVecDim)
 
 	minioHost := strings.TrimPrefix(strings.TrimPrefix(minioEndpoint, "http://"), "https://")
-	externalSource := toMilvusURI(tableInfo.MetadataLocation, minioHost)
+	externalSource := toMilvusMinIOURI(tableInfo.MetadataLocation, minioHost)
 
 	type externalSpecJSON struct {
 		Format     string            `json:"format"`
@@ -420,16 +410,6 @@ func TestExternalCollectionMultipleDataTypesIceberg(t *testing.T) {
 		Format:     "iceberg-table",
 		SnapshotID: tableInfo.SnapshotID,
 		Extfs: map[string]string{
-			"bucket_name":      bucket,
-			"region":           "us-east-1",
-			"use_ssl":          "false",
-			"use_virtual_host": "false",
-			// `minio` sentinel: tells milvus to treat URI host as
-			// endpoint instead of swapping for AWS canonical endpoint.
-			// `aws` would derive s3.us-east-1.amazonaws.com and fail
-			// the (address, bucket) lookup against the URI host
-			// `localhost:9000`.
-			"cloud_provider":   "minio",
 			"access_key_id":    minioAccessKey,
 			"access_key_value": minioSecretKey,
 		},

--- a/tests/go_client/testcases/external_table_refresh_test.go
+++ b/tests/go_client/testcases/external_table_refresh_test.go
@@ -65,25 +65,20 @@ func newMinIOClient(cfg minioConfig) (*miniogo.Client, error) {
 	})
 }
 
-// extTestURI wraps a MinIO-relative object path into a full Milvus-form URI
-// pointing at the configured bucket. External-table tests that used to pass
-// bare relative paths (e.g. "external-e2e-test/foo") must now construct a
-// fully qualified URI because the new validator rejects bare paths — extfs
-// is isolated from the fs.* baseline, so the endpoint+bucket must appear in
-// the URI or explicitly in spec.extfs. This helper keeps the test call-site
-// succinct while staying close to the original dataPath variable.
+// extTestURI wraps a MinIO-relative object path into a full MinIO URI pointing
+// at the configured bucket. The minio:// scheme is unambiguous, so tests do
+// not need to carry AWS-family region or provider fields just to disambiguate
+// s3:// from AWS S3.
 func extTestURI(cfg minioConfig, relPath string) string {
-	return fmt.Sprintf("s3://%s/%s/%s", cfg.address, cfg.bucket, relPath)
+	return fmt.Sprintf("minio://%s/%s/%s", cfg.address, cfg.bucket, relPath)
 }
 
 // extTestSpec returns an ExternalSpec JSON fragment for external-table tests
-// that target Milvus's own MinIO. It carries the real MinIO credentials and
-// region (required by ValidateExtfsComplete for s3-family schemes). No
-// cloud_provider: MinIO is not AWS, and cloud_provider=aws would trigger
-// Tier-2 endpoint derivation that redirects the URI at AWS S3.
+// that target Milvus's own MinIO. The URI scheme already selects MinIO, so the
+// spec only needs the file format plus credentials.
 func extTestSpec(cfg minioConfig, format string) string {
 	return fmt.Sprintf(
-		`{"format":%q,"extfs":{"access_key_id":%q,"access_key_value":%q,"region":"us-east-1","use_ssl":"false","use_virtual_host":"false","cloud_provider":"minio"}}`,
+		`{"format":%q,"extfs":{"access_key_id":%q,"access_key_value":%q}}`,
 		format, cfg.accessKey, cfg.secretKey)
 }
 
@@ -2667,14 +2662,14 @@ func TestExternalCollectionDifferentBucket(t *testing.T) {
 	})
 
 	// ---------------------------------------------------------------
-	// Step 2: Create external collection with s3://external-bucket/path URI
+	// Step 2: Create external collection with minio://external-bucket/path URI
 	// ---------------------------------------------------------------
-	// The key difference: ExternalSource uses a full s3:// URI pointing to
+	// The key difference: ExternalSource uses a full minio:// URI pointing to
 	// a different bucket than Milvus's own bucket (a-bucket).
-	// URI format: s3://host:port/bucket/path — post-refactor validator
+	// URI format: minio://host:port/bucket/path — post-refactor validator
 	// requires explicit non-empty scheme + host. Empty-host shorthand
 	// (s3:///bucket/path) was dropped.
-	externalSource := fmt.Sprintf("s3://%s/%s/%s", minioCfg.address, externalBucket, extPath)
+	externalSource := fmt.Sprintf("minio://%s/%s/%s", minioCfg.address, externalBucket, extPath)
 	t.Logf("ExternalSource: %s (Milvus bucket: %s)", externalSource, minioCfg.bucket)
 
 	schema := entity.NewSchema().
@@ -2843,7 +2838,7 @@ func TestRefreshExternalCollectionUpdatesSchema(t *testing.T) {
 	require.Contains(t, coll.Schema.ExternalSpec, `"format":"parquet"`)
 	require.Contains(t, coll.Schema.ExternalSpec, `"access_key_id":"***"`)
 	require.Contains(t, coll.Schema.ExternalSpec, `"access_key_value":"***"`)
-	require.Contains(t, coll.Schema.ExternalSpec, `"region":"us-east-1"`)
+	require.NotContains(t, coll.Schema.ExternalSpec, `"region":`)
 
 	// ---------------------------------------------------------------
 	// Step 2: First refresh (with default source/spec) — establishes baseline
@@ -2881,7 +2876,7 @@ func TestRefreshExternalCollectionUpdatesSchema(t *testing.T) {
 	require.Contains(t, coll2.Schema.ExternalSpec, `"format":"parquet"`)
 	require.Contains(t, coll2.Schema.ExternalSpec, `"access_key_id":"***"`)
 	require.Contains(t, coll2.Schema.ExternalSpec, `"access_key_value":"***"`)
-	require.Contains(t, coll2.Schema.ExternalSpec, `"region":"us-east-1"`)
+	require.NotContains(t, coll2.Schema.ExternalSpec, `"region":`)
 	t.Logf("Verified: schema updated — source=%s, spec=%s", coll2.Schema.ExternalSource, coll2.Schema.ExternalSpec)
 	_ = specV2 // value used to drive the refresh; final spec compared structurally above.
 }
@@ -2922,18 +2917,10 @@ func TestExternalSourceFormats(t *testing.T) {
 	const rowsPerFile = int64(100)
 	const numRows = 100
 
-	// Build extfs credentials JSON fragment once — all subtests share the
-	// same MinIO credentials and region. Required by ValidateExtfsComplete.
-	//
-	// Deliberately do NOT set cloud_provider: MinIO is not AWS. Setting
-	// cloud_provider=aws would activate Tier-2 derivation and point
-	// effectiveAddr at `https://s3.us-east-1.amazonaws.com`, which then
-	// causes NormalizeExternalSource to rewrite the localhost MinIO URI
-	// into an AWS S3 URI with localhost:9000 as a path segment. Region is
-	// still required by ValidateExtfsComplete for s3-family schemes, but
-	// the endpoint must come from the URI host (Milvus form).
+	// Build extfs credentials JSON fragment once. The minio:// external source
+	// carries the endpoint and bucket, so tests only need credentials here.
 	extfsFragment := fmt.Sprintf(
-		`"extfs":{"access_key_id":%q,"access_key_value":%q,"region":"us-east-1","use_ssl":"false","use_virtual_host":"false","cloud_provider":"minio"}`,
+		`"extfs":{"access_key_id":%q,"access_key_value":%q}`,
 		minioCfg.accessKey, minioCfg.secretKey)
 
 	type testCase struct {
@@ -2964,7 +2951,7 @@ func TestExternalSourceFormats(t *testing.T) {
 			// Fully qualified URI (scheme://endpoint/bucket/key) targeting
 			// the dedicated external bucket.
 			targetBucket := externalBucket
-			externalSource := fmt.Sprintf("s3://%s/%s/%s", minioCfg.address, externalBucket, dataPath)
+			externalSource := fmt.Sprintf("minio://%s/%s/%s", minioCfg.address, externalBucket, dataPath)
 
 			// Generate and upload test data
 			switch tc.format {
@@ -3441,7 +3428,7 @@ func TestDescribeExternalCollectionRedactsCredentials(t *testing.T) {
 	// Embed secret credentials in extfs; they are persisted into etcd and
 	// must NOT flow back out unredacted through DescribeCollection.
 	rawSpec := fmt.Sprintf(
-		`{"format":"parquet","extfs":{"access_key_id":%q,"access_key_value":%q,"region":"us-east-1","use_ssl":"false","use_virtual_host":"false","cloud_provider":"minio"}}`,
+		`{"format":"parquet","extfs":{"access_key_id":%q,"access_key_value":%q}}`,
 		"AKIAEXAMPLELEAKME", "supersecretvaluemustnotleak")
 
 	schema := entity.NewSchema().
@@ -3473,8 +3460,8 @@ func TestDescribeExternalCollectionRedactsCredentials(t *testing.T) {
 	require.Contains(t, returnedSpec, `"access_key_value":"***"`,
 		"access_key_value must be redacted to ***")
 	// Non-secret values remain visible for operator troubleshooting.
-	require.Contains(t, returnedSpec, `"region":"us-east-1"`,
-		"non-secret extfs values must remain readable")
+	require.Contains(t, returnedSpec, `"format":"parquet"`,
+		"non-secret spec values must remain readable")
 }
 
 // Regression for issue #49335: a refresh_external_collection call carrying


### PR DESCRIPTION
## Issue

issue: https://github.com/milvus-io/milvus/issues/45881

## What changed

This PR makes the MinIO external-table configuration use one explicit URI form:

- Allows `minio://<endpoint>/<bucket>/<key>` with minimal `external_spec.extfs` credentials.
- Lets `minio://` select MinIO validation semantics without requiring `extfs.cloud_provider` or `extfs.region`.
- Keeps `s3://`/`s3a://`/`aws://` conservative: AWS-family schemes still require explicit `cloud_provider` and `region`.
- Updates Go client external-table E2E examples to use `minio://` and credential-only extfs.
- Adds Go validator coverage for `minio://` classification and provider mismatch.
- Adds C++ injection-layer coverage proving `minio://localhost:9000/bucket/key` injects MinIO defaults without forwarding `cloud_provider` or `region` to milvus-storage.

## Why

For MinIO external sources, the endpoint and bucket are already encoded in `minio://<endpoint>/<bucket>/<key>`. Requiring AWS-family provider and region fields for that URI form adds noise and can imply AWS endpoint derivation where none is needed.

This PR intentionally does not infer MinIO semantics from `s3://... + cloud_provider=minio`; that path remains explicit and region-checked to avoid changing the AWS-family URI contract in the same patch.

## Validation

- Reset local dependencies with `/Users/wei.liu/docker-compose-apple-silicon.yml` before Go validation; standalone was not started because this worktree has no `bin/milvus`.
- `gofmt` on changed Go files
- `clang-format-12` on changed C++ test file
- `git diff --check`
- `go test -tags dynamic,test github.com/milvus-io/milvus/pkg/v3/util/externalspec -count=1 -v`
- `go test -c -tags dynamic,test -o /tmp/milvus-go-client-testcases.test ./testcases`

Live standalone/E2E validation was not run locally because this worktree does not have a built `bin/milvus`.
