### PR TITLE
enhance: Reuse storage FFI property keys in Milvus

### DIFF
--- a/internal/storagev2/filesystem_metrics.go
+++ b/internal/storagev2/filesystem_metrics.go
@@ -76,28 +76,27 @@ func getMetricsFromHandle(cFilesystem C.FileSystemHandle) (*FilesystemMetrics, e
 	return fsMetrics, nil
 }
 
-// Property keys matching milvus-storage/properties.h.
-// Duplicated from packed.PropertyFS* because cgo types are package-scoped.
-const (
-	propAddress             = "fs.address"
-	propBucketName          = "fs.bucket_name"
-	propAccessKeyID         = "fs.access_key_id"
-	propAccessKeyValue      = "fs.access_key_value"
-	propRootPath            = "fs.root_path"
-	propStorageType         = "fs.storage_type"
-	propCloudProvider       = "fs.cloud_provider"
-	propIAMEndpoint         = "fs.iam_endpoint"
-	propLogLevel            = "fs.log_level"
-	propRegion              = "fs.region"
-	propSSLCACert           = "fs.ssl_ca_cert"
-	propGCPCredentialJSON   = "fs.gcp_credential_json"
-	propUseSSL              = "fs.use_ssl"
-	propUseIAM              = "fs.use_iam"
-	propUseVirtualHost      = "fs.use_virtual_host"
-	propUseCustomPartUpload = "fs.use_custom_part_upload"
-	propRequestTimeoutMS    = "fs.request_timeout_ms"
-	propTLSMinVersion       = "fs.tls_min_version"
-	propUseCRC32CChecksum   = "fs.use_crc32c_checksum"
+// Property keys exported by milvus-storage/ffi_c.h.
+var (
+	propAddress             = C.GoString(C.loon_properties_fs_address)
+	propBucketName          = C.GoString(C.loon_properties_fs_bucket_name)
+	propAccessKeyID         = C.GoString(C.loon_properties_fs_access_key_id)
+	propAccessKeyValue      = C.GoString(C.loon_properties_fs_access_key_value)
+	propRootPath            = C.GoString(C.loon_properties_fs_root_path)
+	propStorageType         = C.GoString(C.loon_properties_fs_storage_type)
+	propCloudProvider       = C.GoString(C.loon_properties_fs_cloud_provider)
+	propIAMEndpoint         = C.GoString(C.loon_properties_fs_iam_endpoint)
+	propLogLevel            = C.GoString(C.loon_properties_fs_log_level)
+	propRegion              = C.GoString(C.loon_properties_fs_region)
+	propSSLCACert           = C.GoString(C.loon_properties_fs_ssl_ca_cert)
+	propGCPCredentialJSON   = C.GoString(C.loon_properties_fs_gcp_credential_json)
+	propUseSSL              = C.GoString(C.loon_properties_fs_use_ssl)
+	propUseIAM              = C.GoString(C.loon_properties_fs_use_iam)
+	propUseVirtualHost      = C.GoString(C.loon_properties_fs_use_virtual_host)
+	propUseCustomPartUpload = C.GoString(C.loon_properties_fs_use_custom_part_upload)
+	propRequestTimeoutMS    = C.GoString(C.loon_properties_fs_request_timeout_ms)
+	propTLSMinVersion       = C.GoString(C.loon_properties_fs_tls_min_version)
+	propUseCRC32CChecksum   = C.GoString(C.loon_properties_fs_use_crc32c_checksum)
 )
 
 // makePropertiesFromConfig builds C.LoonProperties from a StorageConfig.

--- a/internal/storagev2/packed/ffi_common.go
+++ b/internal/storagev2/packed/ffi_common.go
@@ -35,37 +35,37 @@ import (
 // let other errors propagate immediately as retry.Unrecoverable.
 var ErrLoonTransient = errors.New("loon FFI transient error")
 
-// Property keys - matching milvus-storage/properties.h
-const (
-	PropertyFSAddress             = "fs.address"
-	PropertyFSBucketName          = "fs.bucket_name"
-	PropertyFSAccessKeyID         = "fs.access_key_id"
-	PropertyFSAccessKeyValue      = "fs.access_key_value"
-	PropertyFSRootPath            = "fs.root_path"
-	PropertyFSStorageType         = "fs.storage_type"
-	PropertyFSCloudProvider       = "fs.cloud_provider"
-	PropertyFSIAMEndpoint         = "fs.iam_endpoint"
-	PropertyFSLogLevel            = "fs.log_level"
-	PropertyFSRegion              = "fs.region"
-	PropertyFSUseSSL              = "fs.use_ssl"
-	PropertyFSSSLCACert           = "fs.ssl_ca_cert"
-	PropertyFSUseIAM              = "fs.use_iam"
-	PropertyFSUseVirtualHost      = "fs.use_virtual_host"
-	PropertyFSRequestTimeoutMS    = "fs.request_timeout_ms"
-	PropertyFSGCPCredentialJSON   = "fs.gcp_credential_json"
-	PropertyFSUseCustomPartUpload = "fs.use_custom_part_upload"
-	PropertyFSMaxConnections      = "fs.max_connections"
-	PropertyFSTLSMinVersion       = "fs.tls_min_version"
-	PropertyFSUseCRC32CChecksum   = "fs.use_crc32c_checksum"
+// Property keys exported by milvus-storage/ffi_c.h.
+var (
+	PropertyFSAddress             = C.GoString(C.loon_properties_fs_address)
+	PropertyFSBucketName          = C.GoString(C.loon_properties_fs_bucket_name)
+	PropertyFSAccessKeyID         = C.GoString(C.loon_properties_fs_access_key_id)
+	PropertyFSAccessKeyValue      = C.GoString(C.loon_properties_fs_access_key_value)
+	PropertyFSRootPath            = C.GoString(C.loon_properties_fs_root_path)
+	PropertyFSStorageType         = C.GoString(C.loon_properties_fs_storage_type)
+	PropertyFSCloudProvider       = C.GoString(C.loon_properties_fs_cloud_provider)
+	PropertyFSIAMEndpoint         = C.GoString(C.loon_properties_fs_iam_endpoint)
+	PropertyFSLogLevel            = C.GoString(C.loon_properties_fs_log_level)
+	PropertyFSRegion              = C.GoString(C.loon_properties_fs_region)
+	PropertyFSUseSSL              = C.GoString(C.loon_properties_fs_use_ssl)
+	PropertyFSSSLCACert           = C.GoString(C.loon_properties_fs_ssl_ca_cert)
+	PropertyFSUseIAM              = C.GoString(C.loon_properties_fs_use_iam)
+	PropertyFSUseVirtualHost      = C.GoString(C.loon_properties_fs_use_virtual_host)
+	PropertyFSRequestTimeoutMS    = C.GoString(C.loon_properties_fs_request_timeout_ms)
+	PropertyFSGCPCredentialJSON   = C.GoString(C.loon_properties_fs_gcp_credential_json)
+	PropertyFSUseCustomPartUpload = C.GoString(C.loon_properties_fs_use_custom_part_upload)
+	PropertyFSMaxConnections      = C.GoString(C.loon_properties_fs_max_connections)
+	PropertyFSTLSMinVersion       = C.GoString(C.loon_properties_fs_tls_min_version)
+	PropertyFSUseCRC32CChecksum   = C.GoString(C.loon_properties_fs_use_crc32c_checksum)
 
-	PropertyWriterPolicy             = "writer.policy"
-	PropertyWriterSchemaBasedPattern = "writer.split.schema_based.patterns"
+	PropertyWriterPolicy             = C.GoString(C.loon_properties_writer_policy)
+	PropertyWriterSchemaBasedPattern = C.GoString(C.loon_properties_writer_schema_base_patterns)
 
 	// CMEK (Customer Managed Encryption Keys) writer properties
-	PropertyWriterEncEnable = "writer.enc.enable"    // Enable encryption for written data
-	PropertyWriterEncKey    = "writer.enc.key"       // Encryption key for data encryption
-	PropertyWriterEncMeta   = "writer.enc.meta"      // Encoded metadata containing zone ID, collection ID, and key version
-	PropertyWriterEncAlgo   = "writer.enc.algorithm" // Encryption algorithm (e.g., "AES_GCM_V1")
+	PropertyWriterEncEnable = C.GoString(C.loon_properties_writer_enc_enable)    // Enable encryption for written data
+	PropertyWriterEncKey    = C.GoString(C.loon_properties_writer_enc_key)       // Encryption key for data encryption
+	PropertyWriterEncMeta   = C.GoString(C.loon_properties_writer_enc_meta)      // Encoded metadata containing zone ID, collection ID, and key version
+	PropertyWriterEncAlgo   = C.GoString(C.loon_properties_writer_enc_algorithm) // Encryption algorithm (e.g., "AES_GCM_V1")
 )
 
 // ensureHTTPScheme prepends http:// or https:// to a bare address so it stays


### PR DESCRIPTION
issue: #49789

Milvus and milvus-storage were both defining the same property keys, which made it easy for the two sides to drift apart. This changes Milvus to read those keys directly from the const char* values exported by milvus-storage, so the Go side stays aligned with the storage FFI contract.

These values need to be Go vars instead of consts because C.GoString reads from cgo-exported C symbols at init time. Go consts must be compile-time constants, and a C const char* symbol is not a Go compile-time string.