### PR TITLE
test: stabilize WAL flusher parameter capture

### DIFF
--- a/internal/streamingnode/server/wal/adaptor/opener_test.go
+++ b/internal/streamingnode/server/wal/adaptor/opener_test.go
@@ -151,7 +151,8 @@ func TestHandleAlterWALFlushingStagePassesRateLimitComponent(t *testing.T) {
 	var capturedParam *flusherimpl.RecoverWALFlusherParam
 	mockRecoverFlusher := mockey.Mock(flusherimpl.RecoverWALFlusher).
 		To(func(param *flusherimpl.RecoverWALFlusherParam) *flusherimpl.WALFlusherImpl {
-			capturedParam = param
+			captured := *param
+			capturedParam = &captured
 			return &flusherimpl.WALFlusherImpl{}
 		}).
 		Build()
@@ -171,6 +172,8 @@ func TestHandleAlterWALFlushingStagePassesRateLimitComponent(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, capturedParam)
+	require.NotNil(t, capturedParam.RateLimitComponent)
+	require.NotNil(t, capturedParam.WAL)
 	assert.Same(t, rateLimitComponent, capturedParam.RateLimitComponent)
 	assert.Same(t, roWAL, capturedParam.WAL.Get())
 	assert.Same(t, rs, capturedParam.RecoveryStorage)


### PR DESCRIPTION
issue: #49634

This fixes a flaky WAL adaptor unit test introduced by #49696.

The test mocks RecoverWALFlusher and stores the parameter for assertions after handleAlterWALFlushingStage returns. The real call passes a non-escaping RecoverWALFlusherParam composite literal, so keeping the pointer in the mock can read unstable stack data. Copy the parameter value inside the mock callback before asserting on it.

Validation:
- go test -v -count=1 -tags dynamic,test -gcflags="all=-N -l" -ldflags="-r <artifact>/cmake_build/lib -r <artifact>/internal/core/output/lib" ./internal/streamingnode/server/wal/adaptor -run ^TestHandleAlterWALFlushingStagePassesRateLimitComponent$ -timeout 300s
- go test -v -count=1 -tags dynamic,test -gcflags="all=-N -l" -ldflags="-r <artifact>/cmake_build/lib -r <artifact>/internal/core/output/lib" ./internal/streamingnode/server/wal/adaptor -timeout 300s
- gofumpt -l internal/streamingnode/server/wal/adaptor/opener_test.go
- git diff --check