### PR TITLE
feat: impl StructArray -- support element-level search for array of vector [2.6]

### DIFF
--- a/client/go.mod
+++ b/client/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/cockroachdb/errors v1.9.1
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
-	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.17
+	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.18-0.20260514122006-2a015eed650c
 	github.com/milvus-io/milvus/pkg/v2 v2.6.7-0.20251201120310-af64f2acba38
 	github.com/quasilyte/go-ruleguard/dsl v0.3.23
 	github.com/samber/lo v1.27.0

--- a/client/go.sum
+++ b/client/go.sum
@@ -331,8 +331,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/mediocregopher/radix/v3 v3.4.2/go.mod h1:8FL3F6UQRXHXIBSPUs5h0RybMF8i4n7wVopoX3x7Bv8=
 github.com/microcosm-cc/bluemonday v1.0.2/go.mod h1:iVP4YcDBq+n/5fb23BhYFvIMq/leAFZyRl6bYmGDlGc=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
-github.com/milvus-io/milvus-proto/go-api/v2 v2.6.17 h1:Gh96W9hESA0P1q4iQnG2MXWPm0J6mwurEOAxHaAWVD8=
-github.com/milvus-io/milvus-proto/go-api/v2 v2.6.17/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.18-0.20260514122006-2a015eed650c h1:3sY5oyIDjLftXpPEPKMizhy3K1jSiuh6ISNAUNs6XVM=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.18-0.20260514122006-2a015eed650c/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
 github.com/milvus-io/milvus/pkg/v2 v2.6.7-0.20251201120310-af64f2acba38 h1:75pdNz8Ln9jdBxlkUQRJu+P8tz4q+G48XAybS3O30FQ=
 github.com/milvus-io/milvus/pkg/v2 v2.6.7-0.20251201120310-af64f2acba38/go.mod h1:ak5nlCCbtImG4/WWcI/csU5ht6EyF/9QQ/tmivMzF4c=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/klauspost/compress v1.18.0
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
-	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.17
+	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.18-0.20260514122006-2a015eed650c
 	github.com/minio/minio-go/v7 v7.0.73
 	github.com/panjf2000/ants/v2 v2.11.3 // indirect
 	github.com/pingcap/log v1.1.1-0.20221015072633-39906604fb81 // indirect

--- a/go.sum
+++ b/go.sum
@@ -799,6 +799,8 @@ github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b h1:TfeY0NxYxZz
 github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b/go.mod h1:iwW+9cWfIzzDseEBCCeDSN5SD16Tidvy8cwQ7ZY8Qj4=
 github.com/milvus-io/milvus-proto/go-api/v2 v2.6.17 h1:Gh96W9hESA0P1q4iQnG2MXWPm0J6mwurEOAxHaAWVD8=
 github.com/milvus-io/milvus-proto/go-api/v2 v2.6.17/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.18-0.20260514122006-2a015eed650c h1:3sY5oyIDjLftXpPEPKMizhy3K1jSiuh6ISNAUNs6XVM=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.18-0.20260514122006-2a015eed650c/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
 github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-beta h1:1dRO3ctqYYSTFqL0Tl2m+e9vB1OK9tRpReZbEOB7K80=
 github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-beta/go.mod h1:rbKpv5JToISTKTTLl0duL5r6wbYnjJ9SsD0QgXMzKy0=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 h1:AMFGa4R4MiIpspGNG7Z948v4n35fFGB3RR3G/ry4FWs=

--- a/internal/core/src/common/ArrayOffsets.cpp
+++ b/internal/core/src/common/ArrayOffsets.cpp
@@ -1,0 +1,415 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "common/ArrayOffsets.h"
+
+#include <algorithm>
+#include <cassert>
+#include <iterator>
+#include <mutex>
+
+#include "common/EasyAssert.h"
+#include "log/Log.h"
+#include "segcore/SegmentInterface.h"
+
+namespace milvus {
+
+std::pair<int32_t, int32_t>
+ArrayOffsetsSealed::ElementIDToRowID(int32_t elem_id) const {
+    assert(elem_id >= 0 && elem_id < GetTotalElementCount());
+
+    auto it = std::upper_bound(
+        row_to_element_start_.begin(), row_to_element_start_.end(), elem_id);
+    int32_t row_id = static_cast<int32_t>(
+        std::distance(row_to_element_start_.begin(), it) - 1);
+    int32_t elem_idx = elem_id - row_to_element_start_[row_id];
+    return {row_id, elem_idx};
+}
+
+std::pair<int32_t, int32_t>
+ArrayOffsetsSealed::ElementIDRangeOfRow(int32_t row_id) const {
+    int32_t row_count = GetRowCount();
+    assert(row_id >= 0 && row_id <= row_count);
+
+    if (row_id == row_count) {
+        auto total = row_to_element_start_[row_count];
+        return {total, total};
+    }
+    return {row_to_element_start_[row_id], row_to_element_start_[row_id + 1]};
+}
+
+std::pair<TargetBitmap, TargetBitmap>
+ArrayOffsetsSealed::RowBitsetToElementBitset(
+    const TargetBitmapView& row_bitset,
+    const TargetBitmapView& valid_row_bitset,
+    int64_t row_start) const {
+    int64_t row_count = row_bitset.size();
+    AssertInfo(row_start >= 0 && row_start + row_count <= GetRowCount(),
+               "row range out of bounds: row_start={}, row_count={}, "
+               "total_rows={}",
+               row_start,
+               row_count,
+               GetRowCount());
+
+    int64_t element_start = row_to_element_start_[row_start];
+    int64_t element_end = row_to_element_start_[row_start + row_count];
+    int64_t element_count = element_end - element_start;
+
+    TargetBitmap element_bitset(element_count);
+    TargetBitmap valid_element_bitset(element_count);
+
+    for (int64_t i = 0; i < row_count; ++i) {
+        int64_t row_id = row_start + i;
+        int64_t start = row_to_element_start_[row_id] - element_start;
+        int64_t end = row_to_element_start_[row_id + 1] - element_start;
+        if (start < end) {
+            element_bitset.set(start, end - start, row_bitset[i]);
+            valid_element_bitset.set(start, end - start, valid_row_bitset[i]);
+        }
+    }
+
+    return {std::move(element_bitset), std::move(valid_element_bitset)};
+}
+
+FixedVector<int32_t>
+ArrayOffsetsSealed::RowBitsetToElementOffsets(
+    const TargetBitmapView& row_bitset, int64_t row_start) const {
+    int64_t row_count = row_bitset.size();
+    AssertInfo(row_start >= 0 && row_start + row_count <= GetRowCount(),
+               "row range out of bounds: row_start={}, row_count={}, "
+               "total_rows={}",
+               row_start,
+               row_count,
+               GetRowCount());
+
+    int64_t selected_rows = row_bitset.count();
+    FixedVector<int32_t> element_offsets;
+    if (selected_rows == 0) {
+        return element_offsets;
+    }
+
+    int64_t avg_elem_per_row = GetTotalElementCount() / GetRowCount();
+    element_offsets.reserve(selected_rows * avg_elem_per_row);
+
+    for (int64_t i = 0; i < row_count; ++i) {
+        if (row_bitset[i]) {
+            int64_t row_id = row_start + i;
+            int32_t first_elem = row_to_element_start_[row_id];
+            int32_t last_elem = row_to_element_start_[row_id + 1];
+            for (int32_t elem_id = first_elem; elem_id < last_elem; ++elem_id) {
+                element_offsets.push_back(elem_id);
+            }
+        }
+    }
+
+    return element_offsets;
+}
+
+FixedVector<int32_t>
+ArrayOffsetsSealed::RowOffsetsToElementOffsets(
+    const FixedVector<int32_t>& row_offsets) const {
+    FixedVector<int32_t> element_offsets;
+    if (row_offsets.empty()) {
+        return element_offsets;
+    }
+
+    int32_t row_count = GetRowCount();
+    int64_t avg_elem_per_row =
+        row_count > 0 ? GetTotalElementCount() / row_count : 1;
+    element_offsets.reserve(row_offsets.size() * avg_elem_per_row);
+    for (auto row_id : row_offsets) {
+        assert(row_id >= 0 && row_id < row_count);
+        int32_t first_elem = row_to_element_start_[row_id];
+        int32_t last_elem = row_to_element_start_[row_id + 1];
+        for (int32_t elem_id = first_elem; elem_id < last_elem; ++elem_id) {
+            element_offsets.push_back(elem_id);
+        }
+    }
+
+    return element_offsets;
+}
+
+std::shared_ptr<ArrayOffsetsSealed>
+ArrayOffsetsSealed::BuildFromSegment(const void* segment,
+                                     const FieldMeta& field_meta) {
+    auto seg = static_cast<const segcore::SegmentInternalInterface*>(segment);
+
+    int64_t row_count = seg->get_row_count();
+    if (row_count == 0) {
+        return std::make_shared<ArrayOffsetsSealed>(std::vector<int32_t>{0});
+    }
+
+    FieldId field_id = field_meta.get_id();
+    auto data_type = field_meta.get_data_type();
+    std::vector<int32_t> row_to_element_start(row_count + 1);
+
+    auto temp_op_ctx = std::make_unique<OpContext>();
+    auto op_ctx_ptr = temp_op_ctx.get();
+
+    int64_t num_chunks = seg->num_chunk(field_id);
+    int32_t current_row_id = 0;
+    int32_t total_elements = 0;
+    if (data_type == DataType::VECTOR_ARRAY) {
+        for (int64_t chunk_id = 0; chunk_id < num_chunks; ++chunk_id) {
+            auto pin_wrapper = seg->chunk_view<VectorArrayView>(
+                op_ctx_ptr, field_id, chunk_id);
+            const auto& [vector_array_views, valid_flags] = pin_wrapper.get();
+
+            for (size_t i = 0; i < vector_array_views.size(); ++i) {
+                int32_t array_len = 0;
+                if (valid_flags.empty() || valid_flags[i]) {
+                    array_len = vector_array_views[i].length();
+                }
+
+                row_to_element_start[current_row_id] = total_elements;
+                total_elements += array_len;
+                current_row_id++;
+            }
+        }
+    } else {
+        for (int64_t chunk_id = 0; chunk_id < num_chunks; ++chunk_id) {
+            auto pin_wrapper =
+                seg->chunk_view<ArrayView>(op_ctx_ptr, field_id, chunk_id);
+            const auto& [array_views, valid_flags] = pin_wrapper.get();
+
+            for (size_t i = 0; i < array_views.size(); ++i) {
+                int32_t array_len = 0;
+                if (valid_flags.empty() || valid_flags[i]) {
+                    array_len = array_views[i].length();
+                }
+
+                row_to_element_start[current_row_id] = total_elements;
+                total_elements += array_len;
+                current_row_id++;
+            }
+        }
+    }
+
+    row_to_element_start[row_count] = total_elements;
+    AssertInfo(current_row_id == row_count,
+               "Row count mismatch: expected {}, got {}",
+               row_count,
+               current_row_id);
+
+    LOG_INFO(
+        "Build VectorArray offsets, field_id={}, row_count={}, "
+        "total_elements={}",
+        field_meta.get_id().get(),
+        row_count,
+        total_elements);
+
+    auto result =
+        std::make_shared<ArrayOffsetsSealed>(std::move(row_to_element_start));
+    result->resource_size_ = 4 * (row_count + 1);
+    cachinglayer::Manager::GetInstance().ChargeLoadedResource(
+        cachinglayer::ResourceUsage{result->resource_size_, 0});
+    return result;
+}
+
+std::pair<int32_t, int32_t>
+ArrayOffsetsGrowing::ElementIDToRowID(int32_t elem_id) const {
+    std::shared_lock lock(mutex_);
+    assert(elem_id >= 0 && elem_id < row_to_element_start_.back());
+
+    auto it = std::upper_bound(
+        row_to_element_start_.begin(), row_to_element_start_.end(), elem_id);
+    int32_t row_id = static_cast<int32_t>(
+        std::distance(row_to_element_start_.begin(), it) - 1);
+    int32_t elem_idx = elem_id - row_to_element_start_[row_id];
+    return {row_id, elem_idx};
+}
+
+std::pair<int32_t, int32_t>
+ArrayOffsetsGrowing::ElementIDRangeOfRow(int32_t row_id) const {
+    std::shared_lock lock(mutex_);
+    assert(row_id >= 0 && row_id <= committed_row_count_);
+
+    if (row_id == committed_row_count_) {
+        auto total = row_to_element_start_[committed_row_count_];
+        return {total, total};
+    }
+    return {row_to_element_start_[row_id], row_to_element_start_[row_id + 1]};
+}
+
+std::pair<TargetBitmap, TargetBitmap>
+ArrayOffsetsGrowing::RowBitsetToElementBitset(
+    const TargetBitmapView& row_bitset,
+    const TargetBitmapView& valid_row_bitset,
+    int64_t row_start) const {
+    std::shared_lock lock(mutex_);
+
+    int64_t row_count = row_bitset.size();
+    AssertInfo(row_start >= 0 && row_start + row_count <= committed_row_count_,
+               "row range out of bounds: row_start={}, row_count={}, "
+               "committed_rows={}",
+               row_start,
+               row_count,
+               committed_row_count_);
+
+    int64_t element_start = row_to_element_start_[row_start];
+    int64_t element_end = row_to_element_start_[row_start + row_count];
+    int64_t element_count = element_end - element_start;
+
+    TargetBitmap element_bitset(element_count);
+    TargetBitmap valid_element_bitset(element_count);
+
+    for (int64_t i = 0; i < row_count; ++i) {
+        int64_t row_id = row_start + i;
+        int64_t start = row_to_element_start_[row_id] - element_start;
+        int64_t end = row_to_element_start_[row_id + 1] - element_start;
+        if (start < end) {
+            element_bitset.set(start, end - start, row_bitset[i]);
+            valid_element_bitset.set(start, end - start, valid_row_bitset[i]);
+        }
+    }
+
+    return {std::move(element_bitset), std::move(valid_element_bitset)};
+}
+
+FixedVector<int32_t>
+ArrayOffsetsGrowing::RowBitsetToElementOffsets(
+    const TargetBitmapView& row_bitset, int64_t row_start) const {
+    std::shared_lock lock(mutex_);
+
+    int64_t row_count = row_bitset.size();
+    AssertInfo(row_start >= 0 && row_start + row_count <= committed_row_count_,
+               "row range out of bounds: row_start={}, row_count={}, "
+               "committed_rows={}",
+               row_start,
+               row_count,
+               committed_row_count_);
+
+    int64_t selected_rows = row_bitset.count();
+    FixedVector<int32_t> element_offsets;
+    if (selected_rows == 0) {
+        return element_offsets;
+    }
+    int64_t avg_elem_per_row =
+        row_to_element_start_.back() / committed_row_count_;
+    element_offsets.reserve(selected_rows * avg_elem_per_row);
+
+    for (int64_t i = 0; i < row_count; ++i) {
+        if (row_bitset[i]) {
+            int64_t row_id = row_start + i;
+            int32_t first_elem = row_to_element_start_[row_id];
+            int32_t last_elem = row_to_element_start_[row_id + 1];
+            for (int32_t elem_id = first_elem; elem_id < last_elem; ++elem_id) {
+                element_offsets.push_back(elem_id);
+            }
+        }
+    }
+
+    return element_offsets;
+}
+
+FixedVector<int32_t>
+ArrayOffsetsGrowing::RowOffsetsToElementOffsets(
+    const FixedVector<int32_t>& row_offsets) const {
+    std::shared_lock lock(mutex_);
+
+    FixedVector<int32_t> element_offsets;
+    if (row_offsets.empty()) {
+        return element_offsets;
+    }
+
+    int64_t avg_elem_per_row =
+        committed_row_count_ > 0
+            ? row_to_element_start_.back() / committed_row_count_
+            : 1;
+    element_offsets.reserve(row_offsets.size() * avg_elem_per_row);
+
+    for (auto row_id : row_offsets) {
+        assert(row_id >= 0 && row_id < committed_row_count_);
+        int32_t first_elem = row_to_element_start_[row_id];
+        int32_t last_elem = row_to_element_start_[row_id + 1];
+        for (int32_t elem_id = first_elem; elem_id < last_elem; ++elem_id) {
+            element_offsets.push_back(elem_id);
+        }
+    }
+
+    return element_offsets;
+}
+
+void
+ArrayOffsetsGrowing::Insert(int64_t row_id_start,
+                            const int32_t* array_lengths,
+                            int64_t count) {
+    std::unique_lock lock(mutex_);
+
+    row_to_element_start_.reserve(row_id_start + count + 1);
+    for (int64_t i = 0; i < count; ++i) {
+        int32_t row_id = row_id_start + i;
+        int32_t array_len = array_lengths[i];
+
+        if (row_id == committed_row_count_) {
+            int32_t current_total = row_to_element_start_.back();
+
+            if (row_to_element_start_.size() >
+                static_cast<size_t>(committed_row_count_)) {
+                row_to_element_start_[committed_row_count_] = current_total;
+            } else {
+                row_to_element_start_.push_back(current_total);
+            }
+
+            int32_t new_total = current_total + array_len;
+            if (row_to_element_start_.size() >
+                static_cast<size_t>(committed_row_count_ + 1)) {
+                row_to_element_start_[committed_row_count_ + 1] = new_total;
+            } else {
+                row_to_element_start_.push_back(new_total);
+            }
+
+            committed_row_count_++;
+        } else {
+            pending_rows_[row_id] = {row_id, array_len};
+        }
+    }
+
+    DrainPendingRows();
+}
+
+void
+ArrayOffsetsGrowing::DrainPendingRows() {
+    while (true) {
+        auto it = pending_rows_.find(committed_row_count_);
+        if (it == pending_rows_.end()) {
+            break;
+        }
+
+        const auto& pending = it->second;
+        int32_t current_total = row_to_element_start_[committed_row_count_];
+
+        if (row_to_element_start_.size() >
+            static_cast<size_t>(committed_row_count_)) {
+            row_to_element_start_[committed_row_count_] = current_total;
+        } else {
+            row_to_element_start_.push_back(current_total);
+        }
+
+        int32_t new_total = current_total + pending.array_len;
+        if (row_to_element_start_.size() >
+            static_cast<size_t>(committed_row_count_ + 1)) {
+            row_to_element_start_[committed_row_count_ + 1] = new_total;
+        } else {
+            row_to_element_start_.push_back(new_total);
+        }
+
+        committed_row_count_++;
+        pending_rows_.erase(it);
+    }
+}
+
+}  // namespace milvus

--- a/internal/core/src/common/ArrayOffsets.h
+++ b/internal/core/src/common/ArrayOffsets.h
@@ -1,0 +1,170 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <map>
+#include <memory>
+#include <shared_mutex>
+#include <utility>
+#include <vector>
+
+#include "cachinglayer/Manager.h"
+#include "common/BitsetView.h"
+#include "common/EasyAssert.h"
+#include "common/FieldMeta.h"
+#include "common/Types.h"
+
+namespace milvus {
+
+class IArrayOffsets {
+ public:
+    virtual ~IArrayOffsets() = default;
+
+    virtual int64_t
+    GetRowCount() const = 0;
+
+    virtual int64_t
+    GetTotalElementCount() const = 0;
+
+    virtual std::pair<int32_t, int32_t>
+    ElementIDToRowID(int32_t elem_id) const = 0;
+
+    virtual std::pair<int32_t, int32_t>
+    ElementIDRangeOfRow(int32_t row_id) const = 0;
+
+    virtual std::pair<TargetBitmap, TargetBitmap>
+    RowBitsetToElementBitset(const TargetBitmapView& row_bitset,
+                             const TargetBitmapView& valid_row_bitset,
+                             int64_t row_start) const = 0;
+
+    virtual FixedVector<int32_t>
+    RowBitsetToElementOffsets(const TargetBitmapView& row_bitset,
+                              int64_t row_start) const = 0;
+
+    virtual FixedVector<int32_t>
+    RowOffsetsToElementOffsets(
+        const FixedVector<int32_t>& row_offsets) const = 0;
+};
+
+class ArrayOffsetsSealed : public IArrayOffsets {
+ public:
+    ArrayOffsetsSealed() : row_to_element_start_({0}) {
+    }
+
+    explicit ArrayOffsetsSealed(std::vector<int32_t> row_to_element_start)
+        : row_to_element_start_(std::move(row_to_element_start)) {
+        AssertInfo(!row_to_element_start_.empty(),
+                   "row_to_element_start must have at least one element");
+    }
+
+    ~ArrayOffsetsSealed() override {
+        cachinglayer::Manager::GetInstance().RefundLoadedResource(
+            {resource_size_, 0});
+    }
+
+    int64_t
+    GetRowCount() const override {
+        return static_cast<int64_t>(row_to_element_start_.size()) - 1;
+    }
+
+    int64_t
+    GetTotalElementCount() const override {
+        return row_to_element_start_.back();
+    }
+
+    std::pair<int32_t, int32_t>
+    ElementIDToRowID(int32_t elem_id) const override;
+
+    std::pair<int32_t, int32_t>
+    ElementIDRangeOfRow(int32_t row_id) const override;
+
+    std::pair<TargetBitmap, TargetBitmap>
+    RowBitsetToElementBitset(const TargetBitmapView& row_bitset,
+                             const TargetBitmapView& valid_row_bitset,
+                             int64_t row_start) const override;
+
+    FixedVector<int32_t>
+    RowBitsetToElementOffsets(const TargetBitmapView& row_bitset,
+                              int64_t row_start) const override;
+
+    FixedVector<int32_t>
+    RowOffsetsToElementOffsets(
+        const FixedVector<int32_t>& row_offsets) const override;
+
+    static std::shared_ptr<ArrayOffsetsSealed>
+    BuildFromSegment(const void* segment, const FieldMeta& field_meta);
+
+ private:
+    const std::vector<int32_t> row_to_element_start_;
+    int64_t resource_size_{0};
+};
+
+class ArrayOffsetsGrowing : public IArrayOffsets {
+ public:
+    ArrayOffsetsGrowing() = default;
+
+    void
+    Insert(int64_t row_id_start, const int32_t* array_lengths, int64_t count);
+
+    int64_t
+    GetRowCount() const override {
+        std::shared_lock lock(mutex_);
+        return committed_row_count_;
+    }
+
+    int64_t
+    GetTotalElementCount() const override {
+        std::shared_lock lock(mutex_);
+        return row_to_element_start_.back();
+    }
+
+    std::pair<int32_t, int32_t>
+    ElementIDToRowID(int32_t elem_id) const override;
+
+    std::pair<int32_t, int32_t>
+    ElementIDRangeOfRow(int32_t row_id) const override;
+
+    std::pair<TargetBitmap, TargetBitmap>
+    RowBitsetToElementBitset(const TargetBitmapView& row_bitset,
+                             const TargetBitmapView& valid_row_bitset,
+                             int64_t row_start) const override;
+
+    FixedVector<int32_t>
+    RowBitsetToElementOffsets(const TargetBitmapView& row_bitset,
+                              int64_t row_start) const override;
+
+    FixedVector<int32_t>
+    RowOffsetsToElementOffsets(
+        const FixedVector<int32_t>& row_offsets) const override;
+
+ private:
+    struct PendingRow {
+        int64_t row_id;
+        int32_t array_len;
+    };
+
+    void
+    DrainPendingRows();
+
+ private:
+    std::vector<int32_t> row_to_element_start_{0};
+    int32_t committed_row_count_ = 0;
+    std::map<int64_t, PendingRow> pending_rows_;
+    mutable std::shared_mutex mutex_;
+};
+
+}  // namespace milvus

--- a/internal/core/src/common/ArrayOffsetsTest.cpp
+++ b/internal/core/src/common/ArrayOffsetsTest.cpp
@@ -1,0 +1,440 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <thread>
+#include <vector>
+
+#include "common/ArrayOffsets.h"
+
+using namespace milvus;
+
+TEST(ArrayOffsetsSealed, Basic) {
+    ArrayOffsetsSealed offsets({0, 2, 5, 6});
+
+    EXPECT_EQ(offsets.GetRowCount(), 3);
+    EXPECT_EQ(offsets.GetTotalElementCount(), 6);
+
+    {
+        auto [row_id, elem_idx] = offsets.ElementIDToRowID(0);
+        EXPECT_EQ(row_id, 0);
+        EXPECT_EQ(elem_idx, 0);
+    }
+    {
+        auto [row_id, elem_idx] = offsets.ElementIDToRowID(1);
+        EXPECT_EQ(row_id, 0);
+        EXPECT_EQ(elem_idx, 1);
+    }
+    {
+        auto [row_id, elem_idx] = offsets.ElementIDToRowID(2);
+        EXPECT_EQ(row_id, 1);
+        EXPECT_EQ(elem_idx, 0);
+    }
+    {
+        auto [row_id, elem_idx] = offsets.ElementIDToRowID(4);
+        EXPECT_EQ(row_id, 1);
+        EXPECT_EQ(elem_idx, 2);
+    }
+    {
+        auto [row_id, elem_idx] = offsets.ElementIDToRowID(5);
+        EXPECT_EQ(row_id, 2);
+        EXPECT_EQ(elem_idx, 0);
+    }
+
+    EXPECT_EQ(offsets.ElementIDRangeOfRow(0), std::make_pair(0, 2));
+    EXPECT_EQ(offsets.ElementIDRangeOfRow(1), std::make_pair(2, 5));
+    EXPECT_EQ(offsets.ElementIDRangeOfRow(2), std::make_pair(5, 6));
+    EXPECT_EQ(offsets.ElementIDRangeOfRow(3), std::make_pair(6, 6));
+}
+
+TEST(ArrayOffsetsSealed, EmptyArrays) {
+    ArrayOffsetsSealed offsets({0, 2, 2, 5, 5});
+
+    EXPECT_EQ(offsets.GetRowCount(), 4);
+    EXPECT_EQ(offsets.GetTotalElementCount(), 5);
+    EXPECT_EQ(offsets.ElementIDRangeOfRow(1), std::make_pair(2, 2));
+    EXPECT_EQ(offsets.ElementIDRangeOfRow(3), std::make_pair(5, 5));
+
+    auto [row_id, elem_idx] = offsets.ElementIDToRowID(2);
+    EXPECT_EQ(row_id, 2);
+    EXPECT_EQ(elem_idx, 0);
+}
+
+TEST(ArrayOffsetsSealed, RowBitsetToElementBitset) {
+    ArrayOffsetsSealed offsets({0, 2, 5, 6});
+
+    TargetBitmap row_bitset(3);
+    row_bitset[0] = true;
+    row_bitset[1] = false;
+    row_bitset[2] = true;
+
+    TargetBitmap valid_row_bitset(3, true);
+
+    TargetBitmapView row_view(row_bitset.data(), row_bitset.size());
+    TargetBitmapView valid_view(valid_row_bitset.data(),
+                                valid_row_bitset.size());
+
+    auto [elem_bitset, valid_elem_bitset] =
+        offsets.RowBitsetToElementBitset(row_view, valid_view, 0);
+
+    EXPECT_EQ(elem_bitset.size(), 6);
+    EXPECT_TRUE(elem_bitset[0]);
+    EXPECT_TRUE(elem_bitset[1]);
+    EXPECT_FALSE(elem_bitset[2]);
+    EXPECT_FALSE(elem_bitset[3]);
+    EXPECT_FALSE(elem_bitset[4]);
+    EXPECT_TRUE(elem_bitset[5]);
+
+    EXPECT_EQ(valid_elem_bitset.size(), 6);
+    EXPECT_TRUE(valid_elem_bitset.all());
+}
+
+TEST(ArrayOffsetsGrowing, BasicInsert) {
+    ArrayOffsetsGrowing offsets;
+
+    std::vector<int32_t> lens1 = {2};
+    offsets.Insert(0, lens1.data(), 1);
+
+    std::vector<int32_t> lens2 = {3};
+    offsets.Insert(1, lens2.data(), 1);
+
+    std::vector<int32_t> lens3 = {1};
+    offsets.Insert(2, lens3.data(), 1);
+
+    EXPECT_EQ(offsets.GetRowCount(), 3);
+    EXPECT_EQ(offsets.GetTotalElementCount(), 6);
+
+    EXPECT_EQ(offsets.ElementIDRangeOfRow(0), std::make_pair(0, 2));
+    EXPECT_EQ(offsets.ElementIDRangeOfRow(1), std::make_pair(2, 5));
+    EXPECT_EQ(offsets.ElementIDRangeOfRow(2), std::make_pair(5, 6));
+    EXPECT_EQ(offsets.ElementIDRangeOfRow(3), std::make_pair(6, 6));
+
+    {
+        auto [row_id, elem_idx] = offsets.ElementIDToRowID(5);
+        EXPECT_EQ(row_id, 2);
+        EXPECT_EQ(elem_idx, 0);
+    }
+}
+
+TEST(ArrayOffsetsGrowing, BatchInsertAndEmptyArrays) {
+    ArrayOffsetsGrowing offsets;
+
+    std::vector<int32_t> lens = {2, 0, 3, 0};
+    offsets.Insert(0, lens.data(), 4);
+
+    EXPECT_EQ(offsets.GetRowCount(), 4);
+    EXPECT_EQ(offsets.GetTotalElementCount(), 5);
+    EXPECT_EQ(offsets.ElementIDRangeOfRow(0), std::make_pair(0, 2));
+    EXPECT_EQ(offsets.ElementIDRangeOfRow(1), std::make_pair(2, 2));
+    EXPECT_EQ(offsets.ElementIDRangeOfRow(2), std::make_pair(2, 5));
+    EXPECT_EQ(offsets.ElementIDRangeOfRow(3), std::make_pair(5, 5));
+    EXPECT_EQ(offsets.ElementIDRangeOfRow(4), std::make_pair(5, 5));
+
+    auto [row_id, elem_idx] = offsets.ElementIDToRowID(4);
+    EXPECT_EQ(row_id, 2);
+    EXPECT_EQ(elem_idx, 2);
+}
+
+TEST(ArrayOffsetsGrowing, OutOfOrderInsert) {
+    ArrayOffsetsGrowing offsets;
+
+    std::vector<int32_t> lens0 = {2};
+    offsets.Insert(0, lens0.data(), 1);
+
+    std::vector<int32_t> lens2 = {1};
+    offsets.Insert(2, lens2.data(), 1);
+
+    EXPECT_EQ(offsets.GetRowCount(), 1);
+    EXPECT_EQ(offsets.GetTotalElementCount(), 2);
+
+    std::vector<int32_t> lens1 = {3};
+    offsets.Insert(1, lens1.data(), 1);
+
+    EXPECT_EQ(offsets.GetRowCount(), 3);
+    EXPECT_EQ(offsets.GetTotalElementCount(), 6);
+    EXPECT_EQ(offsets.ElementIDRangeOfRow(0), std::make_pair(0, 2));
+    EXPECT_EQ(offsets.ElementIDRangeOfRow(1), std::make_pair(2, 5));
+    EXPECT_EQ(offsets.ElementIDRangeOfRow(2), std::make_pair(5, 6));
+}
+
+TEST(ArrayOffsetsGrowing, PurePendingThenDrain) {
+    ArrayOffsetsGrowing offsets;
+
+    std::vector<int32_t> lens1 = {3, 2, 4};
+    offsets.Insert(2, lens1.data(), 3);
+
+    EXPECT_EQ(offsets.GetRowCount(), 0);
+    EXPECT_EQ(offsets.GetTotalElementCount(), 0);
+
+    std::vector<int32_t> lens2 = {2, 3};
+    offsets.Insert(0, lens2.data(), 2);
+
+    EXPECT_EQ(offsets.GetRowCount(), 5);
+    EXPECT_EQ(offsets.GetTotalElementCount(), 14);
+
+    std::vector<std::pair<int32_t, int32_t>> expected = {
+        {0, 0},
+        {0, 1},
+        {1, 0},
+        {1, 1},
+        {1, 2},
+        {2, 0},
+        {2, 1},
+        {2, 2},
+        {3, 0},
+        {3, 1},
+        {4, 0},
+        {4, 1},
+        {4, 2},
+        {4, 3},
+    };
+
+    for (int32_t elem_id = 0; elem_id < 14; ++elem_id) {
+        auto [row_id, elem_idx] = offsets.ElementIDToRowID(elem_id);
+        EXPECT_EQ(row_id, expected[elem_id].first);
+        EXPECT_EQ(elem_idx, expected[elem_id].second);
+    }
+}
+
+TEST(ArrayOffsetsGrowing, MultiplePendingBatches) {
+    ArrayOffsetsGrowing offsets;
+
+    std::vector<int32_t> lens5 = {2};
+    offsets.Insert(5, lens5.data(), 1);
+    EXPECT_EQ(offsets.GetRowCount(), 0);
+
+    std::vector<int32_t> lens3 = {3};
+    offsets.Insert(3, lens3.data(), 1);
+    EXPECT_EQ(offsets.GetRowCount(), 0);
+
+    std::vector<int32_t> lens1 = {1};
+    offsets.Insert(1, lens1.data(), 1);
+    EXPECT_EQ(offsets.GetRowCount(), 0);
+
+    std::vector<int32_t> lens0 = {2};
+    offsets.Insert(0, lens0.data(), 1);
+    EXPECT_EQ(offsets.GetRowCount(), 2);
+    EXPECT_EQ(offsets.GetTotalElementCount(), 3);
+
+    std::vector<int32_t> lens2 = {1};
+    offsets.Insert(2, lens2.data(), 1);
+    EXPECT_EQ(offsets.GetRowCount(), 4);
+    EXPECT_EQ(offsets.GetTotalElementCount(), 7);
+
+    std::vector<int32_t> lens4 = {2};
+    offsets.Insert(4, lens4.data(), 1);
+    EXPECT_EQ(offsets.GetRowCount(), 6);
+    EXPECT_EQ(offsets.GetTotalElementCount(), 11);
+
+    EXPECT_EQ(offsets.ElementIDToRowID(0), std::make_pair(0, 0));
+    EXPECT_EQ(offsets.ElementIDToRowID(2), std::make_pair(1, 0));
+    EXPECT_EQ(offsets.ElementIDToRowID(4), std::make_pair(3, 0));
+    EXPECT_EQ(offsets.ElementIDToRowID(7), std::make_pair(4, 0));
+    EXPECT_EQ(offsets.ElementIDToRowID(10), std::make_pair(5, 1));
+}
+
+TEST(ArrayOffsetsGrowing, RowBitsetToElementBitset) {
+    ArrayOffsetsGrowing offsets;
+
+    std::vector<int32_t> lens = {2, 3, 1};
+    offsets.Insert(0, lens.data(), 3);
+
+    TargetBitmap row_bitset(3);
+    row_bitset[0] = true;
+    row_bitset[1] = false;
+    row_bitset[2] = true;
+
+    TargetBitmap valid_row_bitset(3, true);
+
+    TargetBitmapView row_view(row_bitset.data(), row_bitset.size());
+    TargetBitmapView valid_view(valid_row_bitset.data(),
+                                valid_row_bitset.size());
+
+    auto [elem_bitset, valid_elem_bitset] =
+        offsets.RowBitsetToElementBitset(row_view, valid_view, 0);
+
+    EXPECT_EQ(elem_bitset.size(), 6);
+    EXPECT_TRUE(elem_bitset[0]);
+    EXPECT_TRUE(elem_bitset[1]);
+    EXPECT_FALSE(elem_bitset[2]);
+    EXPECT_FALSE(elem_bitset[3]);
+    EXPECT_FALSE(elem_bitset[4]);
+    EXPECT_TRUE(elem_bitset[5]);
+    EXPECT_TRUE(valid_elem_bitset.all());
+}
+
+TEST(ArrayOffsetsGrowing, ConcurrentRead) {
+    ArrayOffsetsGrowing offsets;
+
+    std::vector<int32_t> lens = {2, 3, 1};
+    offsets.Insert(0, lens.data(), 3);
+
+    std::vector<std::thread> threads;
+    for (int t = 0; t < 4; ++t) {
+        threads.emplace_back([&offsets]() {
+            for (int i = 0; i < 1000; ++i) {
+                auto row_count = offsets.GetRowCount();
+                auto elem_count = offsets.GetTotalElementCount();
+                EXPECT_GE(row_count, 0);
+                EXPECT_GE(elem_count, 0);
+
+                if (row_count > 0) {
+                    auto [start, end] = offsets.ElementIDRangeOfRow(0);
+                    EXPECT_GE(start, 0);
+                    EXPECT_GE(end, start);
+                }
+
+                if (elem_count > 0) {
+                    auto [row_id, elem_idx] = offsets.ElementIDToRowID(0);
+                    EXPECT_GE(row_id, 0);
+                    EXPECT_GE(elem_idx, 0);
+                }
+            }
+        });
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+}
+
+TEST(ArrayOffsetsGrowing, LargeArrayLength) {
+    ArrayOffsetsGrowing offsets;
+
+    std::vector<int32_t> lens = {10000};
+    offsets.Insert(0, lens.data(), 1);
+
+    EXPECT_EQ(offsets.GetRowCount(), 1);
+    EXPECT_EQ(offsets.GetTotalElementCount(), 10000);
+    EXPECT_EQ(offsets.ElementIDToRowID(0), std::make_pair(0, 0));
+    EXPECT_EQ(offsets.ElementIDToRowID(5000), std::make_pair(0, 5000));
+    EXPECT_EQ(offsets.ElementIDToRowID(9999), std::make_pair(0, 9999));
+    EXPECT_EQ(offsets.ElementIDRangeOfRow(0), std::make_pair(0, 10000));
+}
+
+TEST(ArrayOffsetsSealed, RowOffsetsToElementOffsets) {
+    ArrayOffsetsSealed offsets({0, 2, 5, 6});
+
+    FixedVector<int32_t> row_offsets = {0, 2};
+    auto elem_offsets = offsets.RowOffsetsToElementOffsets(row_offsets);
+
+    ASSERT_EQ(elem_offsets.size(), 3);
+    EXPECT_EQ(elem_offsets[0], 0);
+    EXPECT_EQ(elem_offsets[1], 1);
+    EXPECT_EQ(elem_offsets[2], 5);
+
+    FixedVector<int32_t> empty_rows;
+    EXPECT_TRUE(offsets.RowOffsetsToElementOffsets(empty_rows).empty());
+}
+
+TEST(ArrayOffsetsSealed, RowBitsetToElementOffsetsWithRowStart) {
+    ArrayOffsetsSealed offsets({0, 2, 5, 6, 8});
+
+    TargetBitmap row_bitset(3);
+    row_bitset[0] = true;   // row 1
+    row_bitset[1] = false;  // row 2
+    row_bitset[2] = true;   // row 3
+
+    TargetBitmapView view(row_bitset.data(), row_bitset.size());
+    auto elem_offsets = offsets.RowBitsetToElementOffsets(view, 1);
+
+    ASSERT_EQ(elem_offsets.size(), 5);
+    EXPECT_EQ(elem_offsets[0], 2);
+    EXPECT_EQ(elem_offsets[1], 3);
+    EXPECT_EQ(elem_offsets[2], 4);
+    EXPECT_EQ(elem_offsets[3], 6);
+    EXPECT_EQ(elem_offsets[4], 7);
+}
+
+TEST(ArrayOffsetsSealed, RowBitsetToElementBitsetWithRowStartAndInvalidRows) {
+    ArrayOffsetsSealed offsets({0, 2, 5, 6, 8});
+
+    TargetBitmap row_bitset(3);
+    row_bitset[0] = true;  // row 1
+    row_bitset[1] = true;  // row 2
+    row_bitset[2] = true;  // row 3
+
+    TargetBitmap valid_row_bitset(3);
+    valid_row_bitset[0] = true;
+    valid_row_bitset[1] = false;
+    valid_row_bitset[2] = true;
+
+    TargetBitmapView row_view(row_bitset.data(), row_bitset.size());
+    TargetBitmapView valid_view(valid_row_bitset.data(),
+                                valid_row_bitset.size());
+    auto [elem_bitset, valid_elem_bitset] =
+        offsets.RowBitsetToElementBitset(row_view, valid_view, 1);
+
+    ASSERT_EQ(elem_bitset.size(), 6);
+    EXPECT_TRUE(elem_bitset.all());
+    EXPECT_TRUE(valid_elem_bitset[0]);
+    EXPECT_TRUE(valid_elem_bitset[1]);
+    EXPECT_TRUE(valid_elem_bitset[2]);
+    EXPECT_FALSE(valid_elem_bitset[3]);
+    EXPECT_TRUE(valid_elem_bitset[4]);
+    EXPECT_TRUE(valid_elem_bitset[5]);
+}
+
+TEST(ArrayOffsetsGrowing, RowOffsetsAndBitsetToElementOffsets) {
+    ArrayOffsetsGrowing offsets;
+    std::vector<int32_t> lens = {2, 3, 1};
+    offsets.Insert(0, lens.data(), 3);
+
+    FixedVector<int32_t> row_offsets = {0, 2};
+    auto elem_offsets = offsets.RowOffsetsToElementOffsets(row_offsets);
+    ASSERT_EQ(elem_offsets.size(), 3);
+    EXPECT_EQ(elem_offsets[0], 0);
+    EXPECT_EQ(elem_offsets[1], 1);
+    EXPECT_EQ(elem_offsets[2], 5);
+
+    TargetBitmap row_bitset(3);
+    row_bitset[0] = true;
+    row_bitset[1] = false;
+    row_bitset[2] = true;
+
+    TargetBitmapView view(row_bitset.data(), row_bitset.size());
+    auto elem_offsets_from_bitset = offsets.RowBitsetToElementOffsets(view, 0);
+    EXPECT_EQ(elem_offsets_from_bitset, elem_offsets);
+}
+
+TEST(ArrayOffsetsGrowing, RowBitsetToElementBitsetWithRowStart) {
+    ArrayOffsetsGrowing offsets;
+    std::vector<int32_t> lens = {2, 3, 1, 2};
+    offsets.Insert(0, lens.data(), 4);
+
+    TargetBitmap row_bitset(3);
+    row_bitset[0] = true;   // row 1
+    row_bitset[1] = false;  // row 2
+    row_bitset[2] = true;   // row 3
+
+    TargetBitmap valid_row_bitset(3, true);
+
+    TargetBitmapView row_view(row_bitset.data(), row_bitset.size());
+    TargetBitmapView valid_view(valid_row_bitset.data(),
+                                valid_row_bitset.size());
+    auto [elem_bitset, valid_elem_bitset] =
+        offsets.RowBitsetToElementBitset(row_view, valid_view, 1);
+
+    ASSERT_EQ(elem_bitset.size(), 6);
+    EXPECT_TRUE(elem_bitset[0]);
+    EXPECT_TRUE(elem_bitset[1]);
+    EXPECT_TRUE(elem_bitset[2]);
+    EXPECT_FALSE(elem_bitset[3]);
+    EXPECT_TRUE(elem_bitset[4]);
+    EXPECT_TRUE(elem_bitset[5]);
+    EXPECT_TRUE(valid_elem_bitset.all());
+}

--- a/internal/core/src/common/QueryInfo.h
+++ b/internal/core/src/common/QueryInfo.h
@@ -18,6 +18,7 @@
 
 #include <memory>
 
+#include "common/ArrayOffsets.h"
 #include "common/Tracer.h"
 #include "common/Types.h"
 #include "knowhere/config.h"
@@ -46,6 +47,12 @@ struct SearchInfo {
     std::optional<std::string> json_path_;
     std::optional<milvus::DataType> json_type_;
     bool strict_cast_{false};
+    std::shared_ptr<const IArrayOffsets> array_offsets_{nullptr};
+
+    bool
+    element_level() const {
+        return array_offsets_ != nullptr;
+    }
 };
 
 using SearchInfoPtr = std::shared_ptr<SearchInfo>;

--- a/internal/core/src/common/QueryResult.h
+++ b/internal/core/src/common/QueryResult.h
@@ -29,6 +29,7 @@
 
 #include "common/BitsetView.h"
 #include "common/FieldMeta.h"
+#include "common/ArrayOffsets.h"
 #include "common/OffsetMapping.h"
 #include "common/Types.h"
 #include "pb/schema.pb.h"
@@ -317,6 +318,10 @@ struct SearchResult {
     // record the storage usage in search
     StorageCost search_storage_cost_;
     std::vector<TargetBitmapPtr> pinned_bitsets_{};
+
+    bool element_level_{false};
+    std::vector<int32_t> element_indices_;
+    std::vector<std::unique_ptr<uint8_t[]>> chunk_buffers_{};
 };
 
 using SearchResultPtr = std::shared_ptr<SearchResult>;

--- a/internal/core/src/common/VectorArray.h
+++ b/internal/core/src/common/VectorArray.h
@@ -458,6 +458,11 @@ class VectorArrayView {
         }
     }
 
+    int
+    length() const {
+        return length_;
+    }
+
  private:
     char* data_{nullptr};
     int64_t dim_ = 0;

--- a/internal/core/src/exec/QueryContext.h
+++ b/internal/core/src/exec/QueryContext.h
@@ -28,6 +28,7 @@
 #include "common/Common.h"
 #include "common/Types.h"
 #include "common/Exception.h"
+#include "common/ArrayOffsets.h"
 #include "common/OpContext.h"
 #include "segcore/SegmentInterface.h"
 
@@ -304,6 +305,36 @@ class QueryContext : public Context {
     }
 
     void
+    set_array_offsets(std::shared_ptr<const IArrayOffsets> offsets) {
+        array_offsets_ = std::move(offsets);
+    }
+
+    std::shared_ptr<const IArrayOffsets>
+    get_array_offsets() const {
+        return array_offsets_;
+    }
+
+    void
+    set_active_element_count(int64_t count) {
+        active_element_count_ = count;
+    }
+
+    int64_t
+    get_active_element_count() const {
+        return active_element_count_;
+    }
+
+    void
+    set_bitset_is_element_level(bool is_element_level) {
+        bitset_is_element_level_ = is_element_level;
+    }
+
+    bool
+    bitset_is_element_level() const {
+        return bitset_is_element_level_;
+    }
+
+    void
     set_all_rows_visible(bool v) {
         all_rows_visible_ = v;
     }
@@ -341,6 +372,10 @@ class QueryContext : public Context {
     int32_t consistency_level_ = 0;
 
     query::PlanOptions plan_options_;
+
+    std::shared_ptr<const IArrayOffsets> array_offsets_{nullptr};
+    int64_t active_element_count_{0};
+    bool bitset_is_element_level_{false};
 
     // Set by MvccNode when no filtering is needed (sealed, no filter,
     // no deletes, no TTL). VectorSearchNode checks this to pass empty

--- a/internal/core/src/exec/operator/Utils.h
+++ b/internal/core/src/exec/operator/Utils.h
@@ -118,6 +118,12 @@ sort_search_result(milvus::SearchResult& result, bool large_is_better) {
     new_distances.reserve(size);
     new_seg_offsets.reserve(size);
 
+    bool has_element_indices = !result.element_indices_.empty();
+    std::vector<int32_t> new_element_indices;
+    if (has_element_indices) {
+        new_element_indices.reserve(size);
+    }
+
     std::vector<size_t> idx(topk);
 
     for (size_t start = 0; start < size; start += topk) {
@@ -141,11 +147,17 @@ sort_search_result(milvus::SearchResult& result, bool large_is_better) {
         for (auto i : idx) {
             new_distances.push_back(result.distances_[i]);
             new_seg_offsets.push_back(result.seg_offsets_[i]);
+            if (has_element_indices) {
+                new_element_indices.push_back(result.element_indices_[i]);
+            }
         }
     }
 
-    result.distances_ = new_distances;
-    result.seg_offsets_ = new_seg_offsets;
+    result.distances_ = std::move(new_distances);
+    result.seg_offsets_ = std::move(new_seg_offsets);
+    if (has_element_indices) {
+        result.element_indices_ = std::move(new_element_indices);
+    }
 }
 
 }  // namespace exec

--- a/internal/core/src/exec/operator/VectorSearchNode.cpp
+++ b/internal/core/src/exec/operator/VectorSearchNode.cpp
@@ -15,7 +15,9 @@
 // limitations under the License.
 
 #include "VectorSearchNode.h"
+#include "common/ArrayOffsets.h"
 #include "common/Tracer.h"
+#include "common/Vector.h"
 #include "fmt/format.h"
 
 #include "monitor/Monitor.h"
@@ -23,11 +25,12 @@ namespace milvus {
 namespace exec {
 
 static milvus::SearchResult
-empty_search_result(int64_t num_queries) {
+empty_search_result(int64_t num_queries, bool element_level) {
     milvus::SearchResult final_result;
     final_result.total_nq_ = num_queries;
     final_result.unity_topK_ = 0;  // no result
     final_result.total_data_cnt_ = 0;
+    final_result.element_level_ = element_level;
     return final_result;
 }
 
@@ -80,23 +83,48 @@ PhyVectorSearchNode::GetOutput() {
     auto src_data = ph.get_blob();
     auto src_offsets = ph.get_offsets();
     auto num_queries = ph.num_of_queries_;
+    int64_t data_cnt = active_count_;
+    std::shared_ptr<const IArrayOffsets> array_offsets = nullptr;
+    if (ph.element_level_) {
+        array_offsets = segment_->GetArrayOffsets(search_info_.field_id_);
+        AssertInfo(array_offsets != nullptr, "Array offsets not available");
+        query_context_->set_array_offsets(array_offsets);
+        search_info_.array_offsets_ = array_offsets;
+
+        if (!query_context_->bitset_is_element_level()) {
+            auto col_input = GetColumnVector(input_);
+            TargetBitmapView view(col_input->GetRawData(), col_input->size());
+            TargetBitmapView valid_view(col_input->GetValidRawData(),
+                                        col_input->size());
+
+            auto [element_bitset, valid_element_bitset] =
+                array_offsets->RowBitsetToElementBitset(view, valid_view, 0);
+            data_cnt = element_bitset.size();
+            query_context_->set_active_element_count(data_cnt);
+
+            std::vector<VectorPtr> col_res;
+            col_res.push_back(std::make_shared<ColumnVector>(
+                std::move(element_bitset), std::move(valid_element_bitset)));
+            input_ = std::make_shared<RowVector>(col_res);
+        }
+    }
+
     auto col_input = GetColumnVector(input_);
 
     // Prepare BitsetView for search.
-    // Fast path: all_rows_visible → empty BitsetView
+    // Fast path: all_rows_visible + non-element-level -> empty BitsetView
     //            (IDSelectorAll in Knowhere, skips per-vector bit test).
     // Normal path: build BitsetView from the bitmap produced upstream.
     milvus::BitsetView search_view;
-    int64_t data_cnt = active_count_;
 
-    if (query_context_->get_all_rows_visible()) {
+    if (query_context_->get_all_rows_visible() && !ph.element_level_) {
         // search_view stays default-constructed (empty)
     } else {
         TargetBitmapView view(col_input->GetRawData(), col_input->size());
 
         if (view.all()) {
             query_context_->set_search_result(
-                std::move(empty_search_result(num_queries)));
+                std::move(empty_search_result(num_queries, ph.element_level_)));
             return input_;
         }
 
@@ -119,6 +147,7 @@ PhyVectorSearchNode::GetOutput() {
                             search_result);
 
     search_result.total_data_cnt_ = data_cnt;
+    search_result.element_level_ = ph.element_level_;
 
     span.GetSpan()->SetAttribute(
         "result_count", static_cast<int>(search_result.seg_offsets_.size()));

--- a/internal/core/src/query/ExecPlanNodeVisitor.cpp
+++ b/internal/core/src/query/ExecPlanNodeVisitor.cpp
@@ -28,11 +28,12 @@
 namespace milvus::query {
 
 static SearchResult
-empty_search_result(int64_t num_queries) {
+empty_search_result(int64_t num_queries, bool element_level) {
     SearchResult final_result;
     final_result.total_nq_ = num_queries;
     final_result.unity_topK_ = 0;  // no result
     final_result.total_data_cnt_ = 0;
+    final_result.element_level_ = element_level;
     return final_result;
 }
 
@@ -56,7 +57,12 @@ ExecPlanNodeVisitor::ExecuteTask(
     for (;;) {
         auto result = task->Next();
         if (!result) {
-            Assert(processed_num == query_context->get_active_count());
+            if (query_context->get_active_element_count() > 0) {
+                Assert(processed_num ==
+                       query_context->get_active_element_count());
+            } else {
+                Assert(processed_num == query_context->get_active_count());
+            }
             break;
         }
         const auto& childrens = result->childrens();
@@ -166,8 +172,9 @@ ExecPlanNodeVisitor::visit(VectorPlanNode& node) {
 
     // PreExecute: skip all calculation
     if (active_count == 0) {
+        auto& ph = placeholder_group_->at(0);
         search_result_opt_ = std::move(
-            empty_search_result(placeholder_group_->at(0).num_of_queries_));
+            empty_search_result(ph.num_of_queries_, ph.element_level_));
         return;
     }
 

--- a/internal/core/src/query/Plan.cpp
+++ b/internal/core/src/query/Plan.cpp
@@ -17,6 +17,7 @@
 #include "Plan.h"
 #include "common/Utils.h"
 #include "PlanProto.h"
+#include "knowhere/emb_list_utils.h"
 
 namespace milvus::query {
 
@@ -30,30 +31,63 @@ ParsePlaceholderGroup(const Plan* plan,
         placeholder_group_blob.size());
 }
 
+static bool
+is_emb_list_placeholder(milvus::proto::common::PlaceholderType type) {
+    using PHType = milvus::proto::common::PlaceholderType;
+    return type == PHType::EmbListFloatVector ||
+           type == PHType::EmbListFloat16Vector ||
+           type == PHType::EmbListBFloat16Vector ||
+           type == PHType::EmbListBinaryVector ||
+           type == PHType::EmbListInt8Vector;
+}
+
 bool
-check_data_type(const FieldMeta& field_meta,
-                const milvus::proto::common::PlaceholderType type) {
+check_data_type(
+    const FieldMeta& field_meta,
+    const milvus::proto::common::PlaceholderValue& placeholder_value,
+    bool element_level) {
     if (field_meta.get_data_type() == DataType::VECTOR_ARRAY) {
         if (field_meta.get_element_type() == DataType::VECTOR_FLOAT) {
-            return type ==
+            if (element_level) {
+                return placeholder_value.type() ==
+                       milvus::proto::common::PlaceholderType::FloatVector;
+            }
+            return placeholder_value.type() ==
                    milvus::proto::common::PlaceholderType::EmbListFloatVector;
         } else if (field_meta.get_element_type() == DataType::VECTOR_FLOAT16) {
-            return type ==
+            if (element_level) {
+                return placeholder_value.type() ==
+                       milvus::proto::common::PlaceholderType::Float16Vector;
+            }
+            return placeholder_value.type() ==
                    milvus::proto::common::PlaceholderType::EmbListFloat16Vector;
         } else if (field_meta.get_element_type() == DataType::VECTOR_BFLOAT16) {
-            return type == milvus::proto::common::PlaceholderType::
-                               EmbListBFloat16Vector;
+            if (element_level) {
+                return placeholder_value.type() ==
+                       milvus::proto::common::PlaceholderType::BFloat16Vector;
+            }
+            return placeholder_value.type() ==
+                   milvus::proto::common::PlaceholderType::
+                       EmbListBFloat16Vector;
         } else if (field_meta.get_element_type() == DataType::VECTOR_BINARY) {
-            return type ==
+            if (element_level) {
+                return placeholder_value.type() ==
+                       milvus::proto::common::PlaceholderType::BinaryVector;
+            }
+            return placeholder_value.type() ==
                    milvus::proto::common::PlaceholderType::EmbListBinaryVector;
         } else if (field_meta.get_element_type() == DataType::VECTOR_INT8) {
-            return type ==
+            if (element_level) {
+                return placeholder_value.type() ==
+                       milvus::proto::common::PlaceholderType::Int8Vector;
+            }
+            return placeholder_value.type() ==
                    milvus::proto::common::PlaceholderType::EmbListInt8Vector;
         }
         return false;
     }
     return static_cast<int>(field_meta.get_data_type()) ==
-           static_cast<int>(type);
+           static_cast<int>(placeholder_value.type());
 }
 
 std::unique_ptr<PlaceholderGroup>
@@ -70,7 +104,30 @@ ParsePlaceholderGroup(const Plan* plan,
         Assert(plan->tag2field_.count(element.tag_));
         auto field_id = plan->tag2field_.at(element.tag_);
         auto& field_meta = plan->schema_->operator[](field_id);
-        AssertInfo(check_data_type(field_meta, info.type()),
+
+        if (field_meta.get_data_type() == DataType::VECTOR_ARRAY) {
+            auto& metric = plan->plan_node_->search_info_.metric_type_;
+            bool emb_list_metric =
+                knowhere::get_el_metric_type(metric).has_value();
+            bool emb_list_ph = is_emb_list_placeholder(info.type());
+            if (emb_list_metric != emb_list_ph) {
+                ThrowInfo(
+                    DataTypeInvalid,
+                    fmt::format(
+                        "search type mismatch for VECTOR_ARRAY field {}: "
+                        "metric_type {} {} embedding list search, but search "
+                        "data is {}",
+                        field_meta.get_name().get(),
+                        metric,
+                        emb_list_metric ? "requires" : "does not support",
+                        emb_list_ph ? "embedding list" : "plain vector"));
+            }
+            element.element_level_ = !emb_list_metric;
+        } else {
+            element.element_level_ = false;
+        }
+
+        AssertInfo(check_data_type(field_meta, info, element.element_level_),
                    "vector type must be the same, field {} - type {}, search "
                    "info type {}",
                    field_meta.get_name().get(),
@@ -86,14 +143,26 @@ ParsePlaceholderGroup(const Plan* plan,
             auto line_size = info.values().Get(0).size();
             auto& target = element.blob_;
 
-            if (field_meta.get_data_type() != DataType::VECTOR_ARRAY) {
-                if (field_meta.get_sizeof() != line_size) {
+            if (field_meta.get_data_type() != DataType::VECTOR_ARRAY ||
+                element.element_level_) {
+                if (element.element_level_ &&
+                    field_meta.get_data_type() == DataType::VECTOR_ARRAY) {
+                    auto bytes_per_vec = milvus::vector_bytes_per_element(
+                        field_meta.get_element_type(), field_meta.get_dim());
+                    AssertInfo(line_size == bytes_per_vec,
+                               "vector dimension mismatch, expected vector "
+                               "size(byte) {}, actual {}.",
+                               bytes_per_vec,
+                               line_size);
+                }
+                if (field_meta.get_data_type() != DataType::VECTOR_ARRAY &&
+                    field_meta.get_sizeof() != line_size) {
                     ThrowInfo(DimNotMatch,
-                              fmt::format(
-                                  "vector dimension mismatch, expected vector "
-                                  "size(byte) {}, actual {}.",
-                                  field_meta.get_sizeof(),
-                                  line_size));
+                              fmt::format("vector dimension mismatch, "
+                                          "expected vector size(byte) {}, "
+                                          "actual {}.",
+                                          field_meta.get_sizeof(),
+                                          line_size));
                 }
                 target.reserve(line_size * element.num_of_queries_);
                 for (auto& line : info.values()) {

--- a/internal/core/src/query/PlanImpl.h
+++ b/internal/core/src/query/PlanImpl.h
@@ -85,6 +85,7 @@ struct Placeholder {
         sparse_matrix_;
     // offsets for embedding list
     aligned_vector<size_t> offsets_;
+    bool element_level_{false};
 
     const void*
     get_blob() const {
@@ -104,11 +105,17 @@ struct Placeholder {
 
     const size_t*
     get_offsets() const {
+        if (offsets_.empty()) {
+            return nullptr;
+        }
         return offsets_.data();
     }
 
     size_t*
     get_offsets() {
+        if (offsets_.empty()) {
+            return nullptr;
+        }
         return offsets_.data();
     }
 };

--- a/internal/core/src/query/SearchOnGrowing.cpp
+++ b/internal/core/src/query/SearchOnGrowing.cpp
@@ -203,22 +203,29 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
 
         auto vec_size_per_chunk = vec_ptr->get_size_per_chunk();
         auto max_chunk = upper_div(active_count, vec_size_per_chunk);
+        bool element_level_search = data_type == DataType::VECTOR_ARRAY &&
+                                    info.array_offsets_ != nullptr;
+        AssertInfo(
+            !element_level_search || !milvus::exec::UseVectorIterator(info),
+            "element-level search is not supported for vector iterator");
+
+        int64_t cumulative_element_offset = 0;
 
         std::vector<size_t> offsets;
         for (int chunk_id = current_chunk_id; chunk_id < max_chunk;
              ++chunk_id) {
             auto chunk_data = vec_ptr->get_chunk_data(chunk_id);
 
-            auto element_begin = chunk_id * vec_size_per_chunk;
-            auto element_end =
+            auto row_begin = chunk_id * vec_size_per_chunk;
+            auto row_end =
                 std::min(active_count, (chunk_id + 1) * vec_size_per_chunk);
-            auto size_per_chunk = element_end - element_begin;
+            auto size_per_chunk = row_end - row_begin;
 
             query::dataset::RawDataset sub_data;
             std::unique_ptr<uint8_t[]> buf = nullptr;
             if (data_type != DataType::VECTOR_ARRAY) {
                 sub_data = query::dataset::RawDataset{
-                    element_begin, dim, size_per_chunk, chunk_data};
+                    row_begin, dim, size_per_chunk, chunk_data};
             } else {
                 // TODO(SpadeA): For VectorArray(Embedding List), data is
                 // discreted stored in FixedVector which means we will copy the
@@ -231,44 +238,60 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
                 }
 
                 buf = std::make_unique<uint8_t[]>(size);
-                offsets.clear();
-                offsets.reserve(size_per_chunk + 1);
-                offsets.push_back(0);
 
-                auto offset = 0;
-                auto ptr = buf.get();
-                for (int i = 0; i < size_per_chunk; ++i) {
-                    memcpy(ptr, vec_ptr[i].data(), vec_ptr[i].byte_size());
-                    ptr += vec_ptr[i].byte_size();
+                if (element_level_search) {
+                    int64_t count = 0;
+                    auto ptr = buf.get();
+                    for (int i = 0; i < size_per_chunk; ++i) {
+                        memcpy(ptr, vec_ptr[i].data(), vec_ptr[i].byte_size());
+                        ptr += vec_ptr[i].byte_size();
+                        count += vec_ptr[i].length();
+                    }
+                    sub_data = query::dataset::RawDataset{
+                        cumulative_element_offset, dim, count, buf.get()};
+                    cumulative_element_offset += count;
+                } else {
+                    offsets.clear();
+                    offsets.reserve(size_per_chunk + 1);
+                    offsets.push_back(0);
 
-                    offset += vec_ptr[i].length();
-                    offsets.push_back(offset);
+                    int64_t offset = 0;
+                    auto ptr = buf.get();
+                    for (int i = 0; i < size_per_chunk; ++i) {
+                        memcpy(ptr, vec_ptr[i].data(), vec_ptr[i].byte_size());
+                        ptr += vec_ptr[i].byte_size();
+
+                        offset += vec_ptr[i].length();
+                        offsets.push_back(offset);
+                    }
+                    sub_data = query::dataset::RawDataset{row_begin,
+                                                          dim,
+                                                          size_per_chunk,
+                                                          buf.get(),
+                                                          offsets.data()};
                 }
-                sub_data = query::dataset::RawDataset{element_begin,
-                                                      dim,
-                                                      size_per_chunk,
-                                                      buf.get(),
-                                                      offsets.data()};
             }
 
-            if (data_type == DataType::VECTOR_ARRAY) {
+            if (data_type == DataType::VECTOR_ARRAY && !element_level_search) {
                 AssertInfo(
                     query_offsets != nullptr,
                     "query_offsets is nullptr, but data_type is vector array");
             }
 
+            auto search_data_type =
+                element_level_search ? element_type : data_type;
             if (milvus::exec::UseVectorIterator(info)) {
-                AssertInfo(data_type != DataType::VECTOR_ARRAY,
+                AssertInfo(search_data_type != DataType::VECTOR_ARRAY,
                            "vector array(embedding list) is not supported for "
                            "vector iterator");
 
-                auto sub_qr =
-                    PackBruteForceSearchIteratorsIntoSubResult(search_dataset,
-                                                               sub_data,
-                                                               info,
-                                                               index_info,
-                                                               search_bitset,
-                                                               data_type);
+                auto sub_qr = PackBruteForceSearchIteratorsIntoSubResult(
+                    search_dataset,
+                    sub_data,
+                    info,
+                    index_info,
+                    search_bitset,
+                    search_data_type);
                 final_qr.merge(sub_qr);
             } else {
                 auto sub_qr = BruteForceSearch(search_dataset,
@@ -276,7 +299,7 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
                                                info,
                                                index_info,
                                                search_bitset,
-                                               data_type,
+                                               search_data_type,
                                                element_type,
                                                op_context);
                 final_qr.merge(sub_qr);
@@ -296,12 +319,21 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
                 offset_mapping,
                 larger_is_closer);
         } else {
-            search_result.distances_ = std::move(final_qr.mutable_distances());
-            search_result.seg_offsets_ =
-                std::move(final_qr.mutable_seg_offsets());
-            if (offset_mapping.IsEnabled()) {
-                TransformOffset(search_result.seg_offsets_, offset_mapping);
+            if (element_level_search) {
+                auto [seg_offsets, element_indices] =
+                    final_qr.convert_to_element_offsets(
+                        info.array_offsets_.get());
+                search_result.seg_offsets_ = std::move(seg_offsets);
+                search_result.element_indices_ = std::move(element_indices);
+                search_result.element_level_ = true;
+            } else {
+                search_result.seg_offsets_ =
+                    std::move(final_qr.mutable_seg_offsets());
+                if (offset_mapping.IsEnabled()) {
+                    TransformOffset(search_result.seg_offsets_, offset_mapping);
+                }
             }
+            search_result.distances_ = std::move(final_qr.mutable_distances());
         }
         search_result.unity_topK_ = topk;
         search_result.total_nq_ = num_queries;

--- a/internal/core/src/query/SearchOnSealed.cpp
+++ b/internal/core/src/query/SearchOnSealed.cpp
@@ -95,12 +95,18 @@ SearchOnSealedIndex(const Schema& schema,
     }
 
     if (search_info.iterator_v2_info_.has_value()) {
+        AssertInfo(search_info.array_offsets_ == nullptr,
+                   "element-level search is not supported for search iterator");
         CachedSearchIterator cached_iter(
             *vec_index, dataset, search_info, search_bitset);
         cached_iter.NextBatch(search_info, search_result);
         TransformOffset(search_result.seg_offsets_, offset_mapping);
         return;
     }
+
+    AssertInfo(search_info.array_offsets_ == nullptr ||
+                   !milvus::exec::UseVectorIterator(search_info),
+               "element-level search is not supported for vector iterator");
 
     bool use_iterator =
         milvus::exec::PrepareVectorIteratorsFromIndex(search_info,
@@ -121,8 +127,29 @@ SearchOnSealedIndex(const Schema& schema,
                     std::round(distances[i] * multiplier) / multiplier;
             }
         }
+        if (search_info.array_offsets_ != nullptr) {
+            std::vector<int64_t> element_ids =
+                std::move(search_result.seg_offsets_);
+            search_result.seg_offsets_.resize(element_ids.size());
+            search_result.element_indices_.resize(element_ids.size());
+            for (size_t i = 0; i < element_ids.size(); i++) {
+                if (element_ids[i] == INVALID_SEG_OFFSET) {
+                    search_result.seg_offsets_[i] = INVALID_SEG_OFFSET;
+                    search_result.element_indices_[i] = -1;
+                } else {
+                    auto [doc_id, elem_index] =
+                        search_info.array_offsets_->ElementIDToRowID(
+                            element_ids[i]);
+                    search_result.seg_offsets_[i] = doc_id;
+                    search_result.element_indices_[i] = elem_index;
+                }
+            }
+            search_result.element_level_ = true;
+        }
     }
-    TransformOffset(search_result.seg_offsets_, offset_mapping);
+    if (!search_result.element_level_) {
+        TransformOffset(search_result.seg_offsets_, offset_mapping);
+    }
     search_result.total_nq_ = num_queries;
     search_result.unity_topK_ = topK;
 }
@@ -208,13 +235,23 @@ SearchOnSealedColumn(const Schema& schema,
                              search_info.metric_type_,
                              search_info.round_decimal_);
 
-    auto offset = 0;
+    bool is_element_level_search = data_type == DataType::VECTOR_ARRAY &&
+                                   search_info.array_offsets_ != nullptr;
+    if (is_element_level_search) {
+        data_type = element_type;
+    }
+    AssertInfo(!is_element_level_search ||
+                   !milvus::exec::UseVectorIterator(search_info),
+               "element-level search is not supported for vector iterator");
+
+    int64_t offset = 0;
     auto vector_chunks = column->GetAllChunks(op_context);
     const auto& valid_count_per_chunk = column->GetValidCountPerChunk();
     for (int i = 0; i < num_chunk; ++i) {
         auto pw = vector_chunks[i];
         auto vec_data = pw.get()->Data();
-        auto chunk_size = column->chunk_row_nums(i);
+        auto row_count_in_chunk = column->chunk_row_nums(i);
+        auto chunk_size = row_count_in_chunk;
         if (offset_mapping.IsEnabled() && !valid_count_per_chunk.empty()) {
             chunk_size = valid_count_per_chunk[i];
         }
@@ -222,6 +259,14 @@ SearchOnSealedColumn(const Schema& schema,
             query::dataset::RawDataset{offset, dim, chunk_size, vec_data};
 
         PinWrapper<const size_t*> offsets_pw;
+        if (is_element_level_search) {
+            offsets_pw = column->VectorArrayOffsets(op_context, i);
+            auto elem_offsets = offsets_pw.get();
+            chunk_size = elem_offsets[row_count_in_chunk];
+            raw_dataset =
+                query::dataset::RawDataset{offset, dim, chunk_size, vec_data};
+        }
+
         if (data_type == DataType::VECTOR_ARRAY) {
             AssertInfo(
                 query_offsets != nullptr,
@@ -265,11 +310,20 @@ SearchOnSealedColumn(const Schema& schema,
                                             offset_mapping,
                                             larger_is_closer);
     } else {
-        result.distances_ = std::move(final_qr.mutable_distances());
-        result.seg_offsets_ = std::move(final_qr.mutable_seg_offsets());
-        if (offset_mapping.IsEnabled()) {
-            TransformOffset(result.seg_offsets_, offset_mapping);
+        if (is_element_level_search) {
+            auto [seg_offsets, element_indices] =
+                final_qr.convert_to_element_offsets(
+                    search_info.array_offsets_.get());
+            result.seg_offsets_ = std::move(seg_offsets);
+            result.element_indices_ = std::move(element_indices);
+            result.element_level_ = true;
+        } else {
+            result.seg_offsets_ = std::move(final_qr.mutable_seg_offsets());
+            if (offset_mapping.IsEnabled()) {
+                TransformOffset(result.seg_offsets_, offset_mapping);
+            }
         }
+        result.distances_ = std::move(final_qr.mutable_distances());
     }
     result.unity_topK_ = query_dataset.topk;
     result.total_nq_ = query_dataset.num_queries;

--- a/internal/core/src/query/SubSearchResult.h
+++ b/internal/core/src/query/SubSearchResult.h
@@ -17,6 +17,7 @@
 
 #include "common/Types.h"
 #include "common/Utils.h"
+#include "common/ArrayOffsets.h"
 #include "knowhere/index/index_node.h"
 
 namespace milvus::query {
@@ -114,6 +115,27 @@ class SubSearchResult {
     const std::vector<knowhere::IndexNode::IteratorPtr>&
     chunk_iterators() {
         return this->chunk_iterators_;
+    }
+
+    std::pair<std::vector<int64_t>, std::vector<int32_t>>
+    convert_to_element_offsets(const IArrayOffsets* array_offsets) {
+        std::vector<int64_t> doc_offsets;
+        std::vector<int32_t> element_indices;
+        doc_offsets.reserve(seg_offsets_.size());
+        element_indices.reserve(seg_offsets_.size());
+        for (size_t i = 0; i < seg_offsets_.size(); i++) {
+            if (seg_offsets_[i] == INVALID_SEG_OFFSET) {
+                doc_offsets.push_back(INVALID_SEG_OFFSET);
+                element_indices.push_back(-1);
+            } else {
+                auto [doc_id, elem_index] =
+                    array_offsets->ElementIDToRowID(seg_offsets_[i]);
+                doc_offsets.push_back(doc_id);
+                element_indices.push_back(elem_index);
+            }
+        }
+        return std::make_pair(std::move(doc_offsets),
+                              std::move(element_indices));
     }
 
  private:

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -813,6 +813,16 @@ ChunkedSegmentSealedImpl::GetNgramIndexForJson(
     });
 }
 
+std::shared_ptr<const IArrayOffsets>
+ChunkedSegmentSealedImpl::GetArrayOffsets(FieldId field_id) const {
+    std::shared_lock lck(mutex_);
+    auto it = array_offsets_map_.find(field_id);
+    if (it != array_offsets_map_.end()) {
+        return it->second;
+    }
+    return nullptr;
+}
+
 int64_t
 ChunkedSegmentSealedImpl::get_row_count() const {
     std::shared_lock lck(mutex_);
@@ -2700,27 +2710,67 @@ ChunkedSegmentSealedImpl::load_field_data_common(
     }
 
     bool generated_interim_index = generate_interim_index(field_id, num_rows);
+    std::string struct_name;
+    const FieldMeta* field_meta_ptr = nullptr;
+    bool should_drop_field_data = false;
 
-    std::unique_lock lck(mutex_);
-    AssertInfo(!get_bit(field_data_ready_bitset_, field_id),
-               "field {} data already loaded",
-               field_id.get());
-    set_bit(field_data_ready_bitset_, field_id, true);
-    update_row_count(num_rows);
-    // Only drop field data when the interim index has raw data.
-    // If the interim index doesn't have raw data, we need to keep the field data
-    // because the data cannot be retrieved from the index.
-    auto iter = index_has_raw_data_.find(field_id);
-    const bool keep_nullable_vector_field_data =
-        column->IsNullable() && IsVectorDataType(data_type);
-    if (generated_interim_index && iter != index_has_raw_data_.end() &&
-        iter->second && !keep_nullable_vector_field_data) {
-        drop_field_data_locked(field_id);
+    {
+        std::unique_lock lck(mutex_);
+        AssertInfo(!get_bit(field_data_ready_bitset_, field_id),
+                   "field {} data already loaded",
+                   field_id.get());
+        set_bit(field_data_ready_bitset_, field_id, true);
+        update_row_count(num_rows);
+        // Only drop field data when the interim index has raw data.
+        // If the interim index doesn't have raw data, we need to keep the field data
+        // because the data cannot be retrieved from the index.
+        auto iter = index_has_raw_data_.find(field_id);
+        const bool keep_nullable_vector_field_data =
+            column->IsNullable() && IsVectorDataType(data_type);
+        should_drop_field_data =
+            generated_interim_index && iter != index_has_raw_data_.end() &&
+            iter->second && !keep_nullable_vector_field_data;
+        if (data_type == DataType::GEOMETRY &&
+            segcore_config_.get_enable_geometry_cache()) {
+            // Construct GeometryCache for the entire field
+            LoadGeometryCache(field_id, column);
+        }
+
+        if (data_type == DataType::ARRAY ||
+            data_type == DataType::VECTOR_ARRAY) {
+            auto& field_meta = schema_->operator[](field_id);
+            const std::string& field_name = field_meta.get_name().get();
+            if (field_name.find('[') != std::string::npos &&
+                field_name.find(']') != std::string::npos) {
+                struct_name = field_name.substr(0, field_name.find('['));
+
+                auto it = struct_to_array_offsets_.find(struct_name);
+                if (it != struct_to_array_offsets_.end()) {
+                    array_offsets_map_[field_id] = it->second;
+                } else {
+                    field_meta_ptr = &field_meta;
+                }
+            }
+        }
     }
-    if (data_type == DataType::GEOMETRY &&
-        segcore_config_.get_enable_geometry_cache()) {
-        // Construct GeometryCache for the entire field
-        LoadGeometryCache(field_id, column);
+
+    if (field_meta_ptr) {
+        auto new_offsets =
+            ArrayOffsetsSealed::BuildFromSegment(this, *field_meta_ptr);
+
+        std::unique_lock lck(mutex_);
+        auto it = struct_to_array_offsets_.find(struct_name);
+        if (it == struct_to_array_offsets_.end()) {
+            struct_to_array_offsets_[struct_name] = new_offsets;
+            array_offsets_map_[field_id] = new_offsets;
+        } else {
+            array_offsets_map_[field_id] = it->second;
+        }
+    }
+
+    if (should_drop_field_data) {
+        std::unique_lock lck(mutex_);
+        drop_field_data_locked(field_id);
     }
 }
 

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -25,6 +25,7 @@
 #include "DeletedRecord.h"
 #include "SealedIndexingRecord.h"
 #include "SegmentSealed.h"
+#include "common/ArrayOffsets.h"
 #include "common/EasyAssert.h"
 #include "common/Schema.h"
 #include "folly/Synchronized.h"
@@ -170,6 +171,9 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     GetNgramIndexForJson(milvus::OpContext* op_ctx,
                          FieldId field_id,
                          const std::string& nested_path) const override;
+
+    std::shared_ptr<const IArrayOffsets>
+    GetArrayOffsets(FieldId field_id) const override;
 
     void
     BulkGetJsonData(milvus::OpContext* op_ctx,
@@ -1123,6 +1127,11 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
 
     // milvus storage internal api reader instance
     std::unique_ptr<milvus_storage::api::Reader> reader_;
+
+    mutable std::unordered_map<FieldId, std::shared_ptr<ArrayOffsetsSealed>>
+        array_offsets_map_;
+    std::unordered_map<std::string, std::shared_ptr<ArrayOffsetsSealed>>
+        struct_to_array_offsets_;
 };
 
 inline SegmentSealedUPtr

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -57,6 +57,123 @@ namespace milvus::segcore {
 
 using namespace milvus::cachinglayer;
 
+namespace {
+
+void
+ExtractArrayLengthsFromFieldData(const std::vector<FieldDataPtr>& field_data,
+                                 const FieldMeta& field_meta,
+                                 int32_t* array_lengths) {
+    auto data_type = field_meta.get_data_type();
+    int64_t offset = 0;
+    for (const auto& data : field_data) {
+        auto num_rows = data->get_num_rows();
+        if (data_type == DataType::VECTOR_ARRAY) {
+            auto* raw_data = static_cast<const VectorArray*>(data->Data());
+            for (int64_t i = 0; i < num_rows; ++i) {
+                array_lengths[offset + i] =
+                    data->is_valid(i) ? raw_data[i].length() : 0;
+            }
+        } else {
+            auto* raw_data = static_cast<const ArrayView*>(data->Data());
+            for (int64_t i = 0; i < num_rows; ++i) {
+                array_lengths[offset + i] =
+                    data->is_valid(i) ? raw_data[i].length() : 0;
+            }
+        }
+        offset += num_rows;
+    }
+}
+
+void
+ExtractArrayLengths(const proto::schema::FieldData& field_data,
+                    const FieldMeta& field_meta,
+                    int64_t num_rows,
+                    int32_t* array_lengths) {
+    auto data_type = field_meta.get_data_type();
+    if (data_type == DataType::VECTOR_ARRAY) {
+        const auto& vector_array = field_data.vectors().vector_array();
+        int64_t dim = field_meta.get_dim();
+        auto element_type = field_meta.get_element_type();
+
+        for (int i = 0; i < num_rows; ++i) {
+            const auto& vec_field = vector_array.data(i);
+            int32_t array_len = 0;
+
+            switch (element_type) {
+                case DataType::VECTOR_FLOAT:
+                    array_len = vec_field.float_vector().data_size() / dim;
+                    break;
+                case DataType::VECTOR_FLOAT16:
+                    array_len = vec_field.float16_vector().size() / (dim * 2);
+                    break;
+                case DataType::VECTOR_BFLOAT16:
+                    array_len = vec_field.bfloat16_vector().size() / (dim * 2);
+                    break;
+                case DataType::VECTOR_BINARY:
+                    array_len = vec_field.binary_vector().size() / (dim / 8);
+                    break;
+                case DataType::VECTOR_INT8:
+                    array_len = vec_field.int8_vector().size() / dim;
+                    break;
+                default:
+                    ThrowInfo(ErrorCode::UnexpectedError,
+                              "Unexpected VECTOR_ARRAY element type: {}",
+                              element_type);
+            }
+
+            array_lengths[i] = array_len;
+        }
+    } else {
+        const auto& array_data = field_data.scalars().array_data();
+        auto element_type = field_meta.get_element_type();
+
+        for (int i = 0; i < num_rows; ++i) {
+            int32_t array_len = 0;
+
+            switch (element_type) {
+                case DataType::BOOL:
+                    array_len = array_data.data(i).bool_data().data_size();
+                    break;
+                case DataType::INT8:
+                case DataType::INT16:
+                case DataType::INT32:
+                    array_len = array_data.data(i).int_data().data_size();
+                    break;
+                case DataType::INT64:
+                    array_len = array_data.data(i).long_data().data_size();
+                    break;
+                case DataType::FLOAT:
+                    array_len = array_data.data(i).float_data().data_size();
+                    break;
+                case DataType::DOUBLE:
+                    array_len = array_data.data(i).double_data().data_size();
+                    break;
+                case DataType::STRING:
+                case DataType::VARCHAR:
+                    array_len = array_data.data(i).string_data().data_size();
+                    break;
+                default:
+                    ThrowInfo(ErrorCode::UnexpectedError,
+                              "Unexpected array type: {}",
+                              element_type);
+            }
+
+            array_lengths[i] = array_len;
+        }
+    }
+
+    if (field_meta.is_nullable() && field_data.valid_data_size() > 0) {
+        const auto& valid_data = field_data.valid_data();
+        for (int i = 0; i < num_rows; ++i) {
+            if (!valid_data[i]) {
+                array_lengths[i] = 0;
+            }
+        }
+    }
+}
+
+}  // namespace
+
 int64_t
 SegmentGrowingImpl::PreInsert(int64_t size) {
     auto reserved_begin = insert_record_.reserved.fetch_add(size);
@@ -84,6 +201,35 @@ SegmentGrowingImpl::try_remove_chunks(FieldId fieldId) {
                 chunk_mutex_.unlock();
             }
         }
+    }
+}
+
+void
+SegmentGrowingImpl::InitializeArrayOffsets() {
+    std::unordered_map<std::string, std::vector<FieldId>> struct_fields;
+    for (const auto& [field_id, field_meta] : schema_->get_fields()) {
+        const auto& field_name = field_meta.get_name().get();
+
+        auto bracket_pos = field_name.find('[');
+        if (bracket_pos != std::string::npos && bracket_pos > 0) {
+            std::string struct_name = field_name.substr(0, bracket_pos);
+            struct_fields[struct_name].push_back(field_id);
+        }
+    }
+
+    for (const auto& [struct_name, field_ids] : struct_fields) {
+        auto array_offsets = std::make_shared<ArrayOffsetsGrowing>();
+        FieldId representative_field = field_ids[0];
+        for (auto field_id : field_ids) {
+            array_offsets_map_[field_id] = array_offsets;
+        }
+        struct_representative_fields_.insert(representative_field);
+        LOG_INFO(
+            "Created ArrayOffsetsGrowing for struct '{}' with {} fields, "
+            "representative field_id={}",
+            struct_name,
+            field_ids.size(),
+            representative_field.get());
     }
 }
 
@@ -381,6 +527,20 @@ SegmentGrowingImpl::Insert(int64_t reserved_offset,
                 field_meta);
         }
 
+        if (struct_representative_fields_.count(field_id) > 0) {
+            auto offsets_it = array_offsets_map_.find(field_id);
+            if (offsets_it != array_offsets_map_.end()) {
+                std::vector<int32_t> array_lengths(num_rows);
+                ExtractArrayLengths(
+                    insert_record_proto->fields_data(data_offset),
+                    field_meta,
+                    num_rows,
+                    array_lengths.data());
+                offsets_it->second->Insert(
+                    reserved_offset, array_lengths.data(), num_rows);
+            }
+        }
+
         // index text.
         if (field_meta.enable_match()) {
             // TODO: iterate texts and call `AddText` instead of `AddTexts`. This may cost much more memory.
@@ -594,6 +754,17 @@ SegmentGrowingImpl::load_field_data_common(
         index->Commit();
         // Reload reader so that the index can be read immediately
         index->Reload();
+    }
+
+    if (struct_representative_fields_.count(field_id) > 0) {
+        auto offsets_it = array_offsets_map_.find(field_id);
+        if (offsets_it != array_offsets_map_.end()) {
+            std::vector<int32_t> array_lengths(num_rows);
+            ExtractArrayLengthsFromFieldData(
+                field_data, field_meta, array_lengths.data());
+            offsets_it->second->Insert(
+                reserved_offset, array_lengths.data(), num_rows);
+        }
     }
 
     // update the mem size

--- a/internal/core/src/segcore/SegmentGrowingImpl.h
+++ b/internal/core/src/segcore/SegmentGrowingImpl.h
@@ -16,6 +16,8 @@
 #include <mutex>
 #include <shared_mutex>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
 #include <tbb/concurrent_priority_queue.h>
 #include <tbb/concurrent_unordered_map.h>
 #include <tbb/concurrent_vector.h>
@@ -32,6 +34,7 @@
 #include "SealedIndexingRecord.h"
 #include "SegmentGrowing.h"
 #include "common/EasyAssert.h"
+#include "common/ArrayOffsets.h"
 #include "common/IndexMeta.h"
 #include "common/Types.h"
 #include "query/PlanNode.h"
@@ -345,6 +348,7 @@ class SegmentGrowingImpl : public SegmentGrowing {
               },
               segment_id) {
         this->CreateTextIndexes();
+        this->InitializeArrayOffsets();
         this->UpdateResourceTracking();
     }
 
@@ -392,6 +396,15 @@ class SegmentGrowingImpl : public SegmentGrowing {
 
     DataType
     GetFieldDataType(FieldId fieldId) const override;
+
+    std::shared_ptr<const IArrayOffsets>
+    GetArrayOffsets(FieldId field_id) const override {
+        auto it = array_offsets_map_.find(field_id);
+        if (it != array_offsets_map_.end()) {
+            return it->second;
+        }
+        return nullptr;
+    }
 
  public:
     void
@@ -624,6 +637,9 @@ class SegmentGrowingImpl : public SegmentGrowing {
     void
     CreateTextIndexes();
 
+    void
+    InitializeArrayOffsets();
+
     /**
      * @brief Load all column groups from a manifest file path
      *
@@ -675,6 +691,11 @@ class SegmentGrowingImpl : public SegmentGrowing {
 
     // milvus storage internal api reader instance
     std::unique_ptr<milvus_storage::api::Reader> reader_;
+
+    std::unordered_map<FieldId, std::shared_ptr<ArrayOffsetsGrowing>>
+        array_offsets_map_;
+
+    std::unordered_set<FieldId> struct_representative_fields_;
 
     // Tracked resource usage for refund-then-charge pattern
     // This stores the last estimated resource usage that was charged to the cache manager

--- a/internal/core/src/segcore/SegmentGrowingTest.cpp
+++ b/internal/core/src/segcore/SegmentGrowingTest.cpp
@@ -17,6 +17,7 @@
 #include "common/Types.h"
 #include "common/IndexMeta.h"
 #include "knowhere/comp/index_param.h"
+#include "query/Plan.h"
 #include "segcore/SegmentGrowing.h"
 #include "segcore/SegmentGrowingImpl.h"
 #include "pb/schema.pb.h"
@@ -993,8 +994,8 @@ TEST(GrowingTest, SearchVectorArray) {
                                   "MAX_SIM",    // metric_type
                                   R"({"nprobe": 10})",  // search_params
                                   3);                   // round_decimal
-    auto plan =
-        CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
+    auto plan = milvus::query::CreateSearchPlanByExpr(
+        schema, plan_str.data(), plan_str.size());
 
     // Use CreatePlaceholderGroupFromBlob for VectorArray
     auto ph_group_raw = CreatePlaceholderGroupFromBlob<EmbListFloatVector>(
@@ -1007,6 +1008,93 @@ TEST(GrowingTest, SearchVectorArray) {
     auto sr = segment->Search(plan.get(), ph_group.get(), timestamp);
     auto sr_parsed = SearchResultToJson(*sr);
     std::cout << sr_parsed.dump(1) << std::endl;
+}
+
+TEST(Growing, ReopenKeepsStructArrayOffsets) {
+    int dim = 4;
+    auto schema = std::make_shared<Schema>();
+    schema->set_schema_version(1);
+    auto array_vec = schema->AddDebugVectorArrayField("structA[array_vec]",
+                                                      DataType::VECTOR_FLOAT,
+                                                      dim,
+                                                      knowhere::metric::L2);
+    schema->AddDebugArrayField("structA[price_array]", DataType::INT32, false);
+    auto pk = schema->AddDebugField("id", DataType::INT64);
+    schema->set_primary_field_id(pk);
+
+    auto segment = CreateGrowingSegment(schema, empty_index_meta);
+    auto* growing = dynamic_cast<SegmentGrowingImpl*>(segment.get());
+    ASSERT_NE(growing, nullptr);
+
+    int64_t row_count = 16;
+    int array_len = 3;
+    auto dataset = DataGen(schema, row_count, 42, 0, 1, array_len);
+    segment->PreInsert(row_count);
+    segment->Insert(0,
+                    row_count,
+                    dataset.row_ids_.data(),
+                    dataset.timestamps_.data(),
+                    dataset.raw_);
+
+    auto offsets_before = growing->GetArrayOffsets(array_vec);
+    ASSERT_NE(offsets_before, nullptr);
+    EXPECT_EQ(offsets_before->GetRowCount(), row_count);
+    EXPECT_EQ(offsets_before->GetTotalElementCount(), row_count * array_len);
+
+    auto reopened_schema = std::make_shared<Schema>(*schema);
+    reopened_schema->set_schema_version(2);
+    growing->Reopen(reopened_schema);
+
+    auto offsets_after = growing->GetArrayOffsets(array_vec);
+    ASSERT_NE(offsets_after, nullptr);
+    EXPECT_EQ(offsets_after, offsets_before);
+    EXPECT_EQ(offsets_after->GetRowCount(), row_count);
+    EXPECT_EQ(offsets_after->GetTotalElementCount(), row_count * array_len);
+    EXPECT_EQ(offsets_after->ElementIDToRowID(5), std::make_pair(1, 2));
+}
+
+TEST(Growing, ElementLevelSearchVectorArrayCountsElements) {
+    int dim = 4;
+    auto schema = std::make_shared<Schema>();
+    auto array_vec = schema->AddDebugVectorArrayField("structA[array_vec]",
+                                                      DataType::VECTOR_FLOAT,
+                                                      dim,
+                                                      knowhere::metric::COSINE);
+    auto pk = schema->AddDebugField("id", DataType::INT64);
+    schema->set_primary_field_id(pk);
+
+    int64_t row_count = 32;
+    int array_len = 3;
+    auto dataset = DataGen(schema, row_count, 42, 0, 1, array_len);
+    auto segment = CreateGrowingSegment(schema, empty_index_meta);
+    segment->PreInsert(row_count);
+    segment->Insert(0,
+                    row_count,
+                    dataset.row_ids_.data(),
+                    dataset.timestamps_.data(),
+                    dataset.raw_);
+
+    ScopedSchemaHandle handle(*schema);
+    auto plan_str = handle.ParseSearch(
+        "", "structA[array_vec]", 5, "COSINE", R"({"nprobe": 10})", 3);
+    auto plan = milvus::query::CreateSearchPlanByExpr(
+        schema, plan_str.data(), plan_str.size());
+
+    int num_queries = 2;
+    auto query_vec = generate_float_vector(num_queries, dim);
+    auto ph_group_raw =
+        CreatePlaceholderGroupFromBlob(num_queries, dim, query_vec.data());
+    auto ph_group =
+        ParsePlaceholderGroup(plan.get(), ph_group_raw.SerializeAsString());
+
+    auto sr = segment->Search(plan.get(), ph_group.get(), 1000000);
+    ASSERT_TRUE(sr->element_level_);
+    EXPECT_EQ(sr->total_data_cnt_, row_count * array_len);
+    ASSERT_EQ(sr->element_indices_.size(), sr->seg_offsets_.size());
+    for (auto elem_idx : sr->element_indices_) {
+        EXPECT_GE(elem_idx, 0);
+        EXPECT_LT(elem_idx, array_len);
+    }
 }
 
 // Resource tracking tests for growing segments

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -24,6 +24,7 @@
 #include <index/ScalarIndex.h>
 
 #include "cachinglayer/CacheSlot.h"
+#include "common/ArrayOffsets.h"
 #include "common/EasyAssert.h"
 #include "common/Json.h"
 #include "common/OpContext.h"
@@ -252,6 +253,9 @@ class SegmentInterface {
     virtual void
     Load(milvus::tracer::TraceContext& trace_ctx,
          milvus::OpContext* op_ctx = nullptr) = 0;
+
+    virtual std::shared_ptr<const IArrayOffsets>
+    GetArrayOffsets(FieldId field_id) const = 0;
 };
 
 // internal API for DSL calculation

--- a/internal/core/src/segcore/reduce/GroupReduce.cpp
+++ b/internal/core/src/segcore/reduce/GroupReduce.cpp
@@ -58,6 +58,9 @@ GroupReduceHelper::RefreshSingleSearchResult(SearchResult* search_result,
                "primary_keys_.size:{}",
                search_result->group_by_values_.value().size(),
                search_result->primary_keys_.size());
+    CheckElementIndicesSize(search_result,
+                            search_result->primary_keys_.size(),
+                            "group refresh search result");
 
     uint32_t size = 0;
     for (int j = 0; j < total_nq_; j++) {
@@ -67,6 +70,10 @@ GroupReduceHelper::RefreshSingleSearchResult(SearchResult* search_result,
     std::vector<float> distances(size);
     std::vector<int64_t> seg_offsets(size);
     std::vector<GroupByValueType> group_by_values(size);
+    std::vector<int32_t> element_indices;
+    if (search_result->element_level_) {
+        element_indices.resize(size);
+    }
 
     uint32_t index = 0;
     for (int j = 0; j < total_nq_; j++) {
@@ -77,6 +84,10 @@ GroupReduceHelper::RefreshSingleSearchResult(SearchResult* search_result,
             seg_offsets[index] = search_result->seg_offsets_[offset];
             group_by_values[index] =
                 std::move(search_result->group_by_values_.value()[offset]);
+            if (search_result->element_level_) {
+                element_indices[index] =
+                    search_result->element_indices_[offset];
+            }
             index++;
             real_topks[j]++;
         }
@@ -85,6 +96,9 @@ GroupReduceHelper::RefreshSingleSearchResult(SearchResult* search_result,
     search_result->distances_.swap(distances);
     search_result->seg_offsets_.swap(seg_offsets);
     search_result->group_by_values_.value().swap(group_by_values);
+    if (search_result->element_level_) {
+        search_result->element_indices_.swap(element_indices);
+    }
     AssertInfo(search_result->primary_keys_.size() ==
                    search_result->group_by_values_.value().size(),
                "Wrong size for group_by_values size after refresh:{}, "
@@ -98,6 +112,9 @@ void
 GroupReduceHelper::FilterInvalidSearchResult(SearchResult* search_result) {
     //do nothing, for group-by reduce, as we calculate prefix_sum for nq when doing group by and no padding invalid results
     //so there's no need to filter search_result
+    CheckElementIndicesSize(search_result,
+                            search_result->seg_offsets_.size(),
+                            "group filter invalid result");
 }
 
 int64_t
@@ -109,6 +126,7 @@ GroupReduceHelper::ReduceSearchResultForOneNQ(int64_t qi,
                         SearchResultPairComparator>
         heap;
     pk_set_.clear();
+    element_result_set_.clear();
     pairs_.clear();
     pairs_.reserve(num_segments_);
     for (int i = 0; i < num_segments_; i++) {
@@ -149,15 +167,41 @@ GroupReduceHelper::ReduceSearchResultForOneNQ(int64_t qi,
     auto start = offset;
     std::unordered_map<GroupByValueType, int64_t> group_by_map;
 
-    auto should_filtered = [&](const PkType& pk,
+    auto should_filtered = [&](const SearchResultPair& result,
                                const GroupByValueType& group_by_val) {
-        if (pk_set_.count(pk) != 0)
+        auto search_result = result.search_result_;
+        ElementSearchResultKey element_key{result.primary_key_, -1};
+        if (search_result->element_level_) {
+            AssertInfo(result.offset_ >= 0 &&
+                           static_cast<size_t>(result.offset_) <
+                               search_result->element_indices_.size(),
+                       "invalid element-level search result offset {}, "
+                       "element_indices size {}",
+                       result.offset_,
+                       search_result->element_indices_.size());
+            element_key.element_index =
+                search_result->element_indices_[result.offset_];
+            if (element_result_set_.count(element_key) != 0) {
+                return true;
+            }
+        } else if (pk_set_.count(result.primary_key_) != 0) {
             return true;
-        if (group_by_map.size() >= topk &&
-            group_by_map.count(group_by_val) == 0)
+        }
+
+        auto [it, inserted] = group_by_map.try_emplace(group_by_val, 0);
+        if (inserted && static_cast<int64_t>(group_by_map.size()) > topk) {
+            group_by_map.erase(it);
             return true;
-        if (group_by_map[group_by_val] >= group_size)
+        }
+        if (it->second >= group_size) {
             return true;
+        }
+        it->second += 1;
+        if (search_result->element_level_) {
+            element_result_set_.insert(std::move(element_key));
+        } else {
+            pk_set_.insert(result.primary_key_);
+        }
         return false;
     };
 
@@ -173,11 +217,9 @@ GroupReduceHelper::ReduceSearchResultForOneNQ(int64_t qi,
         auto group_by_val = pilot->group_by_value_.value();
 
         //judge filter
-        if (!should_filtered(pk, group_by_val)) {
+        if (!should_filtered(*pilot, group_by_val)) {
             pilot->search_result_->result_offsets_.push_back(offset++);
             final_search_records_[index][qi].push_back(pilot->offset_);
-            pk_set_.insert(pk);
-            group_by_map[group_by_val] += 1;
         } else {
             filtered_count++;
         }

--- a/internal/core/src/segcore/reduce/Reduce.cpp
+++ b/internal/core/src/segcore/reduce/Reduce.cpp
@@ -82,6 +82,22 @@ ReduceHelper::Marshal() {
 }
 
 void
+ReduceHelper::CheckElementIndicesSize(const SearchResult* search_result,
+                                      size_t expected_size,
+                                      const char* context) const {
+    if (!search_result->element_level_) {
+        return;
+    }
+
+    AssertInfo(search_result->element_indices_.size() == expected_size,
+               "wrong element_indices size in {}, size = {}, expected size = "
+               "{}",
+               context,
+               search_result->element_indices_.size(),
+               expected_size);
+}
+
+void
 ReduceHelper::FilterInvalidSearchResult(SearchResult* search_result) {
     auto nq = search_result->total_nq_;
     auto topK = search_result->unity_topK_;
@@ -93,6 +109,8 @@ ReduceHelper::FilterInvalidSearchResult(SearchResult* search_result) {
                "wrong distances size, size = {}, expected size = {}",
                search_result->distances_.size(),
                nq * topK);
+    CheckElementIndicesSize(
+        search_result, static_cast<size_t>(nq * topK), "filter invalid result");
     std::vector<int64_t> real_topks(nq, 0);
     uint32_t valid_index = 0;
     auto segment = static_cast<SegmentInterface*>(search_result->segment_);
@@ -117,12 +135,19 @@ ReduceHelper::FilterInvalidSearchResult(SearchResult* search_result) {
                 real_topks[i]++;
                 offsets[valid_index] = offsets[index];
                 distances[valid_index] = distances[index];
+                if (search_result->element_level_) {
+                    search_result->element_indices_[valid_index] =
+                        search_result->element_indices_[index];
+                }
                 valid_index++;
             }
         }
     }
     offsets.resize(valid_index);
     distances.resize(valid_index);
+    if (search_result->element_level_) {
+        search_result->element_indices_.resize(valid_index);
+    }
     search_result->topk_per_nq_prefix_sum_.resize(nq + 1);
     std::partial_sum(real_topks.begin(),
                      real_topks.end(),
@@ -158,6 +183,9 @@ ReduceHelper::SortEqualScoresByPks() {
     tracer::AutoSpan span("ReduceHelper::SortEqualScoresByPks",
                           tracer::GetRootSpan());
     for (auto& search_result : search_results_) {
+        CheckElementIndicesSize(search_result,
+                                search_result->seg_offsets_.size(),
+                                "sort equal scores");
         for (int64_t i = 0; i < search_result->total_nq_; i++) {
             auto nq_begin = search_result->topk_per_nq_prefix_sum_[i];
             auto nq_end = search_result->topk_per_nq_prefix_sum_[i + 1];
@@ -209,6 +237,10 @@ ReduceHelper::SortEqualScoresOneNQ(size_t nq_begin,
                 PkType temp_pk =
                     std::move(search_result->primary_keys_[start + i]);
                 int64_t temp_offset = search_result->seg_offsets_[start + i];
+                int32_t temp_element_index =
+                    search_result->element_level_
+                        ? search_result->element_indices_[start + i]
+                        : -1;
 
                 size_t curr = i;
                 while (indices[curr] != i) {
@@ -217,12 +249,20 @@ ReduceHelper::SortEqualScoresOneNQ(size_t nq_begin,
                         std::move(search_result->primary_keys_[start + next]);
                     search_result->seg_offsets_[start + curr] =
                         search_result->seg_offsets_[start + next];
+                    if (search_result->element_level_) {
+                        search_result->element_indices_[start + curr] =
+                            search_result->element_indices_[start + next];
+                    }
                     indices[curr] = curr;  // Mark as processed
                     curr = next;
                 }
 
                 search_result->primary_keys_[start + curr] = std::move(temp_pk);
                 search_result->seg_offsets_[start + curr] = temp_offset;
+                if (search_result->element_level_) {
+                    search_result->element_indices_[start + curr] =
+                        temp_element_index;
+                }
                 indices[curr] = curr;
             }
         }
@@ -249,6 +289,9 @@ void
 ReduceHelper::RefreshSingleSearchResult(SearchResult* search_result,
                                         int seg_res_idx,
                                         std::vector<int64_t>& real_topks) {
+    CheckElementIndicesSize(search_result,
+                            search_result->primary_keys_.size(),
+                            "refresh search result");
     uint32_t index = 0;
     for (int j = 0; j < total_nq_; j++) {
         for (auto offset : final_search_records_[seg_res_idx][j]) {
@@ -258,6 +301,10 @@ ReduceHelper::RefreshSingleSearchResult(SearchResult* search_result,
                 search_result->distances_[offset];
             search_result->seg_offsets_[index] =
                 search_result->seg_offsets_[offset];
+            if (search_result->element_level_) {
+                search_result->element_indices_[index] =
+                    search_result->element_indices_[offset];
+            }
             index++;
             real_topks[j]++;
         }
@@ -265,6 +312,9 @@ ReduceHelper::RefreshSingleSearchResult(SearchResult* search_result,
     search_result->primary_keys_.resize(index);
     search_result->distances_.resize(index);
     search_result->seg_offsets_.resize(index);
+    if (search_result->element_level_) {
+        search_result->element_indices_.resize(index);
+    }
 }
 
 void
@@ -287,6 +337,27 @@ ReduceHelper::FillEntryData() {
     }
 }
 
+bool
+ReduceHelper::TryAcceptSearchResult(const SearchResultPair& result) {
+    auto search_result = result.search_result_;
+    if (!search_result->element_level_) {
+        return pk_set_.insert(result.primary_key_).second;
+    }
+
+    AssertInfo(
+        result.offset_ >= 0 && static_cast<size_t>(result.offset_) <
+                                   search_result->element_indices_.size(),
+        "invalid element-level search result offset {}, element_indices size "
+        "{}",
+        result.offset_,
+        search_result->element_indices_.size());
+
+    return element_result_set_
+        .insert({result.primary_key_,
+                 search_result->element_indices_[result.offset_]})
+        .second;
+}
+
 int64_t
 ReduceHelper::ReduceSearchResultForOneNQ(int64_t qi,
                                          int64_t topk,
@@ -296,6 +367,7 @@ ReduceHelper::ReduceSearchResultForOneNQ(int64_t qi,
                         SearchResultPairComparator>
         heap;
     pk_set_.clear();
+    element_result_set_.clear();
     pairs_.clear();
 
     pairs_.reserve(num_segments_);
@@ -330,11 +402,12 @@ ReduceHelper::ReduceSearchResultForOneNQ(int64_t qi,
         if (pk == INVALID_PK) {
             break;
         }
-        // remove duplicates
-        if (pk_set_.count(pk) == 0) {
+
+        // Row-level search is deduplicated by PK. Element-level search has
+        // multiple result identities per row, so use (PK, element_index).
+        if (TryAcceptSearchResult(*pilot)) {
             pilot->search_result_->result_offsets_.push_back(offset++);
             final_search_records_[index][qi].push_back(pilot->offset_);
-            pk_set_.insert(pk);
         } else {
             // skip entity with same primary key
             dup_cnt++;
@@ -362,6 +435,8 @@ ReduceHelper::ReduceResultData() {
                    "incorrect search result seg offset size");
         AssertInfo(search_result->primary_keys_.size() == result_count,
                    "incorrect search result primary key size");
+        CheckElementIndicesSize(
+            search_result, result_count, "reduce search result");
     }
 
     int64_t filtered_count = 0;
@@ -402,6 +477,9 @@ ReduceHelper::GetSearchResultDataSlice(const int slice_index,
         AssertInfo(search_result->topk_per_nq_prefix_sum_.size() ==
                        search_result->total_nq_ + 1,
                    "incorrect topk_per_nq_prefix_sum_ size in search result");
+        CheckElementIndicesSize(search_result,
+                                search_result->seg_offsets_.size(),
+                                "marshal search result");
         result_count += search_result->topk_per_nq_prefix_sum_[nq_end] -
                         search_result->topk_per_nq_prefix_sum_[nq_begin];
         all_search_count += search_result->total_data_cnt_;
@@ -451,6 +529,14 @@ ReduceHelper::GetSearchResultDataSlice(const int slice_index,
 
     // reserve space for distances
     search_result_data->mutable_scores()->Resize(result_count, 0);
+    for (auto search_result : search_results_) {
+        if (search_result->element_level_) {
+            search_result_data->mutable_element_indices()
+                ->mutable_data()
+                ->Resize(result_count, -1);
+            break;
+        }
+    }
 
     // fill pks and distances
     for (auto qi = nq_begin; qi < nq_end; qi++) {
@@ -501,6 +587,11 @@ ReduceHelper::GetSearchResultDataSlice(const int slice_index,
 
                 search_result_data->mutable_scores()->Set(
                     loc, search_result->distances_[ki]);
+                if (search_result->element_level_) {
+                    search_result_data->mutable_element_indices()
+                        ->mutable_data()
+                        ->Set(loc, search_result->element_indices_[ki]);
+                }
                 // set result offset to fill output fields data
                 result_pairs[loc] = {&search_result->output_fields_data_, ki};
 

--- a/internal/core/src/segcore/reduce/Reduce.h
+++ b/internal/core/src/segcore/reduce/Reduce.h
@@ -13,6 +13,8 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <cstddef>
+#include <functional>
 #include <memory>
 #include <vector>
 #include <queue>
@@ -31,6 +33,26 @@ namespace milvus::segcore {
 struct SearchResultDataBlobs {
     std::vector<std::vector<char>> blobs;  // the marshal blobs of each slice
     std::vector<StorageCost> costs;        // the cost of each slice
+};
+
+struct ElementSearchResultKey {
+    milvus::PkType pk;
+    int32_t element_index;
+
+    bool
+    operator==(const ElementSearchResultKey& other) const {
+        return pk == other.pk && element_index == other.element_index;
+    }
+};
+
+struct ElementSearchResultKeyHash {
+    size_t
+    operator()(const ElementSearchResultKey& key) const {
+        auto seed = std::hash<milvus::PkType>{}(key.pk);
+        seed ^= std::hash<int32_t>{}(key.element_index) + 0x9e3779b9 +
+                (seed << 6) + (seed >> 2);
+        return seed;
+    }
 };
 
 class ReduceHelper {
@@ -61,6 +83,11 @@ class ReduceHelper {
     }
 
  protected:
+    void
+    CheckElementIndicesSize(const SearchResult* search_result,
+                            size_t expected_size,
+                            const char* context) const;
+
     virtual void
     FilterInvalidSearchResult(SearchResult* search_result);
 
@@ -105,6 +132,9 @@ class ReduceHelper {
     void
     FillEntryData();
 
+    bool
+    TryAcceptSearchResult(const SearchResultPair& result);
+
     std::pair<std::vector<char>, StorageCost>
     GetSearchResultDataSlice(const int slice_index,
                              const StorageCost& total_cost);
@@ -123,6 +153,8 @@ class ReduceHelper {
     // define these here to avoid allocating them for each query
     std::vector<SearchResultPair> pairs_;
     std::unordered_set<milvus::PkType> pk_set_;
+    std::unordered_set<ElementSearchResultKey, ElementSearchResultKeyHash>
+        element_result_set_;
     // dim0: num_segments_; dim1: total_nq_; dim2: offset
     std::vector<std::vector<std::vector<int64_t>>> final_search_records_;
     std::vector<int64_t> slice_nqs_;

--- a/internal/core/src/segcore/reduce/ReduceElementLevelTest.cpp
+++ b/internal/core/src/segcore/reduce/ReduceElementLevelTest.cpp
@@ -1,0 +1,288 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "exec/operator/Utils.h"
+#include "segcore/reduce/GroupReduce.h"
+#include "segcore/reduce/Reduce.h"
+#include "segcore/reduce/StreamReduce.h"
+
+using namespace milvus;
+using namespace milvus::segcore;
+
+namespace {
+
+class TestReduceHelper : public ReduceHelper {
+ public:
+    using ReduceHelper::FilterInvalidSearchResult;
+    using ReduceHelper::ReduceHelper;
+    using ReduceHelper::ReduceResultData;
+
+    const std::vector<std::vector<std::vector<int64_t>>>&
+    FinalSearchRecordsForTest() const {
+        return final_search_records_;
+    }
+};
+
+class TestGroupReduceHelper : public GroupReduceHelper {
+ public:
+    using GroupReduceHelper::FilterInvalidSearchResult;
+    using GroupReduceHelper::GroupReduceHelper;
+    using GroupReduceHelper::ReduceResultData;
+
+    const std::vector<std::vector<std::vector<int64_t>>>&
+    FinalSearchRecordsForTest() const {
+        return final_search_records_;
+    }
+};
+
+class TestStreamReducerHelper : public StreamReducerHelper {
+ public:
+    using StreamReducerHelper::InitializeReduceRecords;
+    using StreamReducerHelper::ReduceResultData;
+    using StreamReducerHelper::StreamReducerHelper;
+
+    MergedSearchResult*
+    MutableMergedResultForTest() {
+        return merged_search_result.get();
+    }
+};
+
+SearchResult
+MakeElementLevelSearchResult() {
+    SearchResult result;
+    result.total_nq_ = 1;
+    result.topk_per_nq_prefix_sum_ = {0, 4};
+    result.primary_keys_ = {
+        int64_t(5),
+        int64_t(5),
+        int64_t(5),
+        int64_t(6),
+    };
+    result.distances_ = {0.99f, 0.98f, 0.97f, 0.96f};
+    result.seg_offsets_ = {10, 10, 10, 11};
+    result.element_level_ = true;
+    result.element_indices_ = {0, 1, 1, 0};
+    return result;
+}
+
+GroupByValueType
+MakeInt64GroupValue(int64_t value) {
+    return GroupByValueType(std::in_place, value);
+}
+
+}  // namespace
+
+TEST(ReduceElementLevel, KeepsDistinctElementHitsWithSamePK) {
+    auto seg0 = MakeElementLevelSearchResult();
+
+    std::vector<SearchResult*> search_results{&seg0};
+    std::vector<int64_t> slice_nqs{1};
+    std::vector<int64_t> slice_topks{4};
+    TestReduceHelper helper(search_results,
+                            nullptr,
+                            slice_nqs.data(),
+                            slice_topks.data(),
+                            slice_nqs.size(),
+                            nullptr);
+
+    helper.ReduceResultData();
+
+    EXPECT_EQ(seg0.result_offsets_, std::vector<int64_t>({0, 1, 2}));
+    ASSERT_EQ(helper.FinalSearchRecordsForTest().size(), 1);
+    ASSERT_EQ(helper.FinalSearchRecordsForTest()[0].size(), 1);
+    EXPECT_EQ(helper.FinalSearchRecordsForTest()[0][0],
+              std::vector<int64_t>({0, 1, 3}));
+}
+
+TEST(ReduceElementLevel, RejectsMismatchedElementIndicesBeforeFiltering) {
+    auto seg0 = MakeElementLevelSearchResult();
+    seg0.total_nq_ = 1;
+    seg0.unity_topK_ = 4;
+    seg0.element_indices_.pop_back();
+
+    std::vector<SearchResult*> search_results{&seg0};
+    std::vector<int64_t> slice_nqs{1};
+    std::vector<int64_t> slice_topks{4};
+    TestReduceHelper helper(search_results,
+                            nullptr,
+                            slice_nqs.data(),
+                            slice_topks.data(),
+                            slice_nqs.size(),
+                            nullptr);
+
+    EXPECT_ANY_THROW(helper.FilterInvalidSearchResult(&seg0));
+}
+
+TEST(ReduceElementLevel, RejectsMismatchedElementIndicesBeforeReducing) {
+    auto seg0 = MakeElementLevelSearchResult();
+    seg0.element_indices_.pop_back();
+
+    std::vector<SearchResult*> search_results{&seg0};
+    std::vector<int64_t> slice_nqs{1};
+    std::vector<int64_t> slice_topks{4};
+    TestReduceHelper helper(search_results,
+                            nullptr,
+                            slice_nqs.data(),
+                            slice_topks.data(),
+                            slice_nqs.size(),
+                            nullptr);
+
+    EXPECT_ANY_THROW(helper.ReduceResultData());
+}
+
+TEST(ReduceElementLevel, GroupReduceRejectsMismatchedElementIndices) {
+    auto seg0 = MakeElementLevelSearchResult();
+    seg0.element_indices_.pop_back();
+
+    std::vector<SearchResult*> search_results{&seg0};
+    std::vector<int64_t> slice_nqs{1};
+    std::vector<int64_t> slice_topks{4};
+    TestGroupReduceHelper helper(search_results,
+                                 nullptr,
+                                 slice_nqs.data(),
+                                 slice_topks.data(),
+                                 slice_nqs.size(),
+                                 nullptr);
+
+    EXPECT_ANY_THROW(helper.FilterInvalidSearchResult(&seg0));
+}
+
+TEST(ReduceElementLevel, GroupReduceKeepsDistinctElementHitsWithSamePK) {
+    auto seg0 = MakeElementLevelSearchResult();
+    seg0.group_size_ = 2;
+    seg0.group_by_values_ = std::vector<GroupByValueType>{
+        MakeInt64GroupValue(5),
+        MakeInt64GroupValue(5),
+        MakeInt64GroupValue(5),
+        MakeInt64GroupValue(6),
+    };
+
+    std::vector<SearchResult*> search_results{&seg0};
+    std::vector<int64_t> slice_nqs{1};
+    std::vector<int64_t> slice_topks{2};
+    TestGroupReduceHelper helper(search_results,
+                                 nullptr,
+                                 slice_nqs.data(),
+                                 slice_topks.data(),
+                                 slice_nqs.size(),
+                                 nullptr);
+
+    helper.ReduceResultData();
+
+    EXPECT_EQ(seg0.result_offsets_, std::vector<int64_t>({0, 1, 2}));
+    ASSERT_EQ(helper.FinalSearchRecordsForTest().size(), 1);
+    ASSERT_EQ(helper.FinalSearchRecordsForTest()[0].size(), 1);
+    EXPECT_EQ(helper.FinalSearchRecordsForTest()[0][0],
+              std::vector<int64_t>({0, 1, 3}));
+}
+
+TEST(ReduceElementLevel, RescoreSortKeepsElementIndicesAligned) {
+    SearchResult result;
+    result.total_nq_ = 2;
+    result.unity_topK_ = 3;
+    result.distances_ = {0.2f, 0.9f, 0.5f, 0.1f, 0.8f, 0.7f};
+    result.seg_offsets_ = {10, 11, 12, -1, 20, 21};
+    result.element_indices_ = {2, 0, 1, -1, 5, 4};
+
+    milvus::exec::sort_search_result(result, true);
+
+    EXPECT_EQ(result.seg_offsets_,
+              std::vector<int64_t>({11, 12, 10, 20, 21, -1}));
+    EXPECT_EQ(result.element_indices_,
+              std::vector<int32_t>({0, 1, 2, 5, 4, -1}));
+    EXPECT_EQ(result.distances_,
+              std::vector<float>({0.9f, 0.5f, 0.2f, 0.8f, 0.7f, 0.1f}));
+}
+
+TEST(ReduceElementLevel, StreamReduceKeepsDistinctElementHitsWithSamePK) {
+    SearchResult seg0;
+    seg0.total_nq_ = 1;
+    seg0.topk_per_nq_prefix_sum_ = {0, 2};
+    seg0.primary_keys_ = {
+        int64_t(5),
+        int64_t(6),
+    };
+    seg0.distances_ = {0.99f, 0.96f};
+    seg0.seg_offsets_ = {10, 11};
+    seg0.element_level_ = true;
+    seg0.element_indices_ = {0, 0};
+
+    SearchResult seg1;
+    seg1.total_nq_ = 1;
+    seg1.topk_per_nq_prefix_sum_ = {0, 3};
+    seg1.primary_keys_ = {
+        int64_t(5),
+        int64_t(5),
+        int64_t(6),
+    };
+    seg1.distances_ = {0.98f, 0.97f, 0.95f};
+    seg1.seg_offsets_ = {20, 20, 21};
+    seg1.element_level_ = true;
+    seg1.element_indices_ = {1, 1, 0};
+
+    std::vector<SearchResult*> search_results{&seg0, &seg1};
+    std::vector<int64_t> slice_nqs{1};
+    std::vector<int64_t> slice_topks{5};
+    TestStreamReducerHelper helper(
+        nullptr, slice_nqs.data(), slice_topks.data(), slice_nqs.size());
+    helper.SetSearchResultsToMerge(search_results);
+
+    helper.InitializeReduceRecords();
+    helper.ReduceResultData();
+
+    EXPECT_EQ(seg0.result_offsets_, std::vector<int64_t>({0, 2}));
+    EXPECT_EQ(seg1.result_offsets_, std::vector<int64_t>({1}));
+}
+
+TEST(ReduceElementLevel, StreamReduceDedupsMergedResultsByElementIdentity) {
+    SearchResult seg0;
+    seg0.total_nq_ = 1;
+    seg0.topk_per_nq_prefix_sum_ = {0, 2};
+    seg0.primary_keys_ = {
+        int64_t(5),
+        int64_t(5),
+    };
+    seg0.distances_ = {0.98f, 0.97f};
+    seg0.seg_offsets_ = {20, 20};
+    seg0.element_level_ = true;
+    seg0.element_indices_ = {1, 0};
+
+    std::vector<SearchResult*> search_results{&seg0};
+    std::vector<int64_t> slice_nqs{1};
+    std::vector<int64_t> slice_topks{4};
+    TestStreamReducerHelper helper(
+        nullptr, slice_nqs.data(), slice_topks.data(), slice_nqs.size());
+    helper.SetSearchResultsToMerge(search_results);
+
+    auto merged = helper.MutableMergedResultForTest();
+    merged->has_result_ = true;
+    merged->element_level_ = true;
+    merged->topk_per_nq_prefix_sum_ = {0, 2};
+    merged->primary_keys_ = {
+        int64_t(5),
+        int64_t(6),
+    };
+    merged->distances_ = {0.99f, 0.95f};
+    merged->element_indices_ = {0, 0};
+
+    helper.InitializeReduceRecords();
+    helper.ReduceResultData();
+
+    EXPECT_EQ(merged->reduced_offsets_, std::vector<int64_t>({0, 2}));
+    EXPECT_EQ(seg0.result_offsets_, std::vector<int64_t>({1}));
+}

--- a/internal/core/src/segcore/reduce/StreamReduce.cpp
+++ b/internal/core/src/segcore/reduce/StreamReduce.cpp
@@ -60,9 +60,15 @@ StreamReducerHelper::AssembleMergedResult() {
             std::make_unique<MergedSearchResult>();
         std::vector<PkType> new_merged_pks;
         std::vector<float> new_merged_distances;
+        std::vector<int32_t> new_merged_element_indices;
         std::vector<GroupByValueType> new_merged_groupBy_vals;
         std::vector<MergeBase> merge_output_data_bases;
         std::vector<int64_t> new_result_offsets;
+        bool element_level = merged_search_result->has_result_ &&
+                             merged_search_result->element_level_;
+        for (auto search_result : search_results_to_merge_) {
+            element_level = element_level || search_result->element_level_;
+        }
         bool need_handle_groupBy =
             plan_->plan_node_->search_info_.group_by_field_id_.has_value();
         int valid_size = 0;
@@ -89,6 +95,9 @@ StreamReducerHelper::AssembleMergedResult() {
             valid_size += result_count;
             new_merged_pks.resize(valid_size);
             new_merged_distances.resize(valid_size);
+            if (element_level) {
+                new_merged_element_indices.resize(valid_size);
+            }
             merge_output_data_bases.resize(valid_size);
             new_result_offsets.resize(valid_size);
             if (need_handle_groupBy) {
@@ -118,6 +127,21 @@ StreamReducerHelper::AssembleMergedResult() {
                             search_result->primary_keys_[ki];
                         new_merged_distances[nq_base_offset + loc] =
                             search_result->distances_[ki];
+                        if (element_level) {
+                            AssertInfo(
+                                search_result->element_level_,
+                                "mixed element-level and row-level search "
+                                "results in stream reduce");
+                            AssertInfo(
+                                static_cast<size_t>(ki) <
+                                    search_result->element_indices_.size(),
+                                "invalid element-level search result offset "
+                                "{}, element_indices size {}",
+                                ki,
+                                search_result->element_indices_.size());
+                            new_merged_element_indices[nq_base_offset + loc] =
+                                search_result->element_indices_[ki];
+                        }
                         if (need_handle_groupBy) {
                             new_merged_groupBy_vals[nq_base_offset + loc] =
                                 search_result->group_by_values_.value()[ki];
@@ -150,6 +174,23 @@ StreamReducerHelper::AssembleMergedResult() {
                             merged_search_result->primary_keys_[ki];
                         new_merged_distances[nq_base_offset + loc] =
                             merged_search_result->distances_[ki];
+                        if (element_level) {
+                            AssertInfo(
+                                merged_search_result->element_level_,
+                                "mixed element-level and row-level merged "
+                                "search results in stream reduce");
+                            AssertInfo(
+                                static_cast<size_t>(ki) <
+                                    merged_search_result->element_indices_
+                                        .size(),
+                                "invalid element-level merged search "
+                                "result offset {}, element_indices "
+                                "size {}",
+                                ki,
+                                merged_search_result->element_indices_.size());
+                            new_merged_element_indices[nq_base_offset + loc] =
+                                merged_search_result->element_indices_[ki];
+                        }
                         if (need_handle_groupBy) {
                             new_merged_groupBy_vals[nq_base_offset + loc] =
                                 merged_search_result->group_by_values_
@@ -169,6 +210,11 @@ StreamReducerHelper::AssembleMergedResult() {
         }
         new_merged_result->primary_keys_ = std::move(new_merged_pks);
         new_merged_result->distances_ = std::move(new_merged_distances);
+        new_merged_result->element_level_ = element_level;
+        if (element_level) {
+            new_merged_result->element_indices_ =
+                std::move(new_merged_element_indices);
+        }
         if (need_handle_groupBy) {
             new_merged_result->group_by_values_ =
                 std::move(new_merged_groupBy_vals);
@@ -316,11 +362,18 @@ StreamReducerHelper::FilterInvalidSearchResult(SearchResult* search_result) {
                "wrong distances size, size = " +
                    std::to_string(search_result->distances_.size()) +
                    ", expected size = " + std::to_string(total_nq * topK));
+    if (search_result->element_level_) {
+        AssertInfo(search_result->element_indices_.size() == total_nq * topK,
+                   "wrong element_indices size, size = " +
+                       std::to_string(search_result->element_indices_.size()) +
+                       ", expected size = " + std::to_string(total_nq * topK));
+    }
     std::vector<int64_t> real_topKs(total_nq, 0);
     uint32_t valid_index = 0;
     auto segment = static_cast<SegmentInterface*>(search_result->segment_);
     auto& offsets = search_result->seg_offsets_;
     auto& distances = search_result->distances_;
+    auto& element_indices = search_result->element_indices_;
     if (search_result->group_by_values_.has_value()) {
         AssertInfo(search_result->distances_.size() ==
                        search_result->group_by_values_.value().size(),
@@ -343,6 +396,9 @@ StreamReducerHelper::FilterInvalidSearchResult(SearchResult* search_result) {
                 real_topKs[i]++;
                 offsets[valid_index] = offsets[index];
                 distances[valid_index] = distances[index];
+                if (search_result->element_level_) {
+                    element_indices[valid_index] = element_indices[index];
+                }
                 if (search_result->group_by_values_.has_value())
                     search_result->group_by_values_.value()[valid_index] =
                         search_result->group_by_values_.value()[index];
@@ -352,6 +408,9 @@ StreamReducerHelper::FilterInvalidSearchResult(SearchResult* search_result) {
     }
     offsets.resize(valid_index);
     distances.resize(valid_index);
+    if (search_result->element_level_) {
+        element_indices.resize(valid_index);
+    }
     if (search_result->group_by_values_.has_value())
         search_result->group_by_values_.value().resize(valid_index);
 
@@ -359,6 +418,17 @@ StreamReducerHelper::FilterInvalidSearchResult(SearchResult* search_result) {
     std::partial_sum(real_topKs.begin(),
                      real_topKs.end(),
                      search_result->topk_per_nq_prefix_sum_.begin() + 1);
+}
+
+bool
+StreamReducerHelper::TryAcceptSearchResult(
+    const StreamSearchResultPair& result) {
+    if (!result.IsElementLevel()) {
+        return pk_set_.insert(result.primary_key_).second;
+    }
+    return element_result_set_
+        .insert({result.primary_key_, result.element_index_})
+        .second;
 }
 
 void
@@ -370,6 +440,7 @@ StreamReducerHelper::StreamReduceSearchResultForOneNQ(int64_t qi,
         heap_.pop();
     }
     pk_set_.clear();
+    element_result_set_.clear();
     group_by_val_set_.clear();
 
     //2. push new search results into sort-heap
@@ -407,10 +478,6 @@ StreamReducerHelper::StreamReduceSearchResultForOneNQ(int64_t qi,
                 : std::nullopt);
         heap_.push(result_pair);
     }
-    if (heap_.empty()) {
-        return;
-    }
-
     //3. if the merged_search_result has previous data
     //push merged search result into the heap
     if (merged_search_result->has_result_) {
@@ -441,6 +508,9 @@ StreamReducerHelper::StreamReduceSearchResultForOneNQ(int64_t qi,
             heap_.push(merged_result_pair);
         }
     }
+    if (heap_.empty()) {
+        return;
+    }
 
     //3. pop heap to sort
     int count = 0;
@@ -452,7 +522,14 @@ StreamReducerHelper::StreamReduceSearchResultForOneNQ(int64_t qi,
         if (pk == INVALID_PK) {
             break;  // valid search result for this nq has been run out, break to next
         }
-        if (pk_set_.count(pk) == 0) {
+        bool duplicate = false;
+        if (pilot->IsElementLevel()) {
+            duplicate = element_result_set_.count(
+                            {pilot->primary_key_, pilot->element_index_}) > 0;
+        } else {
+            duplicate = pk_set_.count(pk) > 0;
+        }
+        if (!duplicate) {
             bool skip_for_group_by = false;
             if (pilot->group_by_value_.has_value()) {
                 if (group_by_val_set_.count(pilot->group_by_value_.value()) >
@@ -467,7 +544,9 @@ StreamReducerHelper::StreamReduceSearchResultForOneNQ(int64_t qi,
                 } else {
                     merged_search_result->reduced_offsets_.push_back(offset++);
                 }
-                pk_set_.insert(pk);
+                auto inserted = TryAcceptSearchResult(*pilot);
+                AssertInfo(inserted,
+                           "duplicated result accepted in stream reduce");
                 if (pilot->group_by_value_.has_value()) {
                     group_by_val_set_.insert(pilot->group_by_value_.value());
                 }
@@ -496,6 +575,10 @@ StreamReducerHelper::RefreshSearchResult() {
             std::vector<float> reduced_distances(final_size);
             std::vector<int64_t> reduced_seg_offsets(final_size);
             std::vector<GroupByValueType> reduced_group_by_values(final_size);
+            std::vector<int32_t> reduced_element_indices;
+            if (search_result->element_level_) {
+                reduced_element_indices.resize(final_size);
+            }
 
             uint32_t final_index = 0;
             for (int j = 0; j < total_nq_; j++) {
@@ -509,6 +592,16 @@ StreamReducerHelper::RefreshSearchResult() {
                     if (search_result->group_by_values_.has_value())
                         reduced_group_by_values[final_index] =
                             search_result->group_by_values_.value()[offset];
+                    if (search_result->element_level_) {
+                        AssertInfo(static_cast<size_t>(offset) <
+                                       search_result->element_indices_.size(),
+                                   "invalid element-level search result offset "
+                                   "{}, element_indices size {}",
+                                   offset,
+                                   search_result->element_indices_.size());
+                        reduced_element_indices[final_index] =
+                            search_result->element_indices_[offset];
+                    }
                     final_index++;
                     real_topKs[j]++;
                 }
@@ -519,6 +612,9 @@ StreamReducerHelper::RefreshSearchResult() {
             if (search_result->group_by_values_.has_value()) {
                 search_result->group_by_values_.value().swap(
                     reduced_group_by_values);
+            }
+            if (search_result->element_level_) {
+                search_result->element_indices_.swap(reduced_element_indices);
             }
         }
         std::partial_sum(real_topKs.begin(),
@@ -535,6 +631,10 @@ StreamReducerHelper::RefreshSearchResult() {
             std::vector<float> reduced_distances(final_size);
             std::vector<int64_t> reduced_seg_offsets(final_size);
             std::vector<GroupByValueType> reduced_group_by_values(final_size);
+            std::vector<int32_t> reduced_element_indices;
+            if (merged_search_result->element_level_) {
+                reduced_element_indices.resize(final_size);
+            }
 
             uint32_t final_index = 0;
             for (int j = 0; j < total_nq_; j++) {
@@ -547,6 +647,17 @@ StreamReducerHelper::RefreshSearchResult() {
                         reduced_group_by_values[final_index] =
                             merged_search_result->group_by_values_
                                 .value()[offset];
+                    if (merged_search_result->element_level_) {
+                        AssertInfo(
+                            static_cast<size_t>(offset) <
+                                merged_search_result->element_indices_.size(),
+                            "invalid element-level merged search result offset "
+                            "{}, element_indices size {}",
+                            offset,
+                            merged_search_result->element_indices_.size());
+                        reduced_element_indices[final_index] =
+                            merged_search_result->element_indices_[offset];
+                    }
                     final_index++;
                     real_topKs[j]++;
                 }
@@ -556,6 +667,10 @@ StreamReducerHelper::RefreshSearchResult() {
             if (merged_search_result->group_by_values_.has_value()) {
                 merged_search_result->group_by_values_.value().swap(
                     reduced_group_by_values);
+            }
+            if (merged_search_result->element_level_) {
+                merged_search_result->element_indices_.swap(
+                    reduced_element_indices);
             }
         }
         std::partial_sum(
@@ -629,6 +744,11 @@ StreamReducerHelper::GetSearchResultDataSlice(int slice_index,
 
     // reserve space for distances
     search_result_data->mutable_scores()->Resize(result_count, 0);
+    if (merged_search_result->has_result_ &&
+        merged_search_result->element_level_) {
+        search_result_data->mutable_element_indices()->mutable_data()->Resize(
+            result_count, -1);
+    }
 
     //reserve space for group_by_values
     std::vector<GroupByValueType> group_by_values;
@@ -686,6 +806,17 @@ StreamReducerHelper::GetSearchResultDataSlice(int slice_index,
 
             search_result_data->mutable_scores()->Set(
                 loc, merged_search_result->distances_[ki]);
+            if (merged_search_result->element_level_) {
+                AssertInfo(static_cast<size_t>(ki) <
+                               merged_search_result->element_indices_.size(),
+                           "invalid element-level merged search result offset "
+                           "{}, element_indices size {}",
+                           ki,
+                           merged_search_result->element_indices_.size());
+                search_result_data->mutable_element_indices()
+                    ->mutable_data()
+                    ->Set(loc, merged_search_result->element_indices_[ki]);
+            }
             // set group by values
             if (merged_search_result->group_by_values_.has_value() &&
                 ki < merged_search_result->group_by_values_.value().size())

--- a/internal/core/src/segcore/reduce/StreamReduce.h
+++ b/internal/core/src/segcore/reduce/StreamReduce.h
@@ -21,13 +21,16 @@
 #include "segcore/ReduceStructure.h"
 #include "segcore/Utils.h"
 #include "common/EasyAssert.h"
+#include "segcore/reduce/Reduce.h"
 
 namespace milvus::segcore {
 class MergedSearchResult {
  public:
-    bool has_result_;
+    bool has_result_{false};
+    bool element_level_{false};
     std::vector<PkType> primary_keys_;
     std::vector<float> distances_;
+    std::vector<int32_t> element_indices_;
     std::optional<std::vector<GroupByValueType>> group_by_values_;
 
     // set output fields data when filling target entity
@@ -48,6 +51,7 @@ struct StreamSearchResultPair {
     int64_t segment_index_;
     int64_t offset_;
     int64_t offset_rb_;
+    int32_t element_index_{-1};
     std::optional<milvus::GroupByValueType> group_by_value_;
 
     StreamSearchResultPair(milvus::PkType primary_key,
@@ -87,6 +91,41 @@ struct StreamSearchResultPair {
             search_result_ != nullptr || merged_result_ != nullptr,
             "For a valid StreamSearchResult pair, "
             "at least one of merged_result_ or search_result_ is not nullptr");
+        element_index_ = CurrentElementIndex();
+    }
+
+    bool
+    IsElementLevel() const {
+        if (search_result_ != nullptr) {
+            return search_result_->element_level_;
+        }
+        return merged_result_->element_level_;
+    }
+
+    int32_t
+    CurrentElementIndex() const {
+        if (!IsElementLevel()) {
+            return -1;
+        }
+        AssertInfo(offset_ >= 0,
+                   "invalid element-level stream reduce offset {}",
+                   offset_);
+        if (search_result_ != nullptr) {
+            AssertInfo(static_cast<size_t>(offset_) <
+                           search_result_->element_indices_.size(),
+                       "invalid element-level search result offset {}, "
+                       "element_indices size {}",
+                       offset_,
+                       search_result_->element_indices_.size());
+            return search_result_->element_indices_[offset_];
+        }
+        AssertInfo(static_cast<size_t>(offset_) <
+                       merged_result_->element_indices_.size(),
+                   "invalid element-level merged search result offset {}, "
+                   "element_indices size {}",
+                   offset_,
+                   merged_result_->element_indices_.size());
+        return merged_result_->element_indices_[offset_];
     }
 
     bool
@@ -104,6 +143,7 @@ struct StreamSearchResultPair {
             if (search_result_ != nullptr) {
                 primary_key_ = search_result_->primary_keys_.at(offset_);
                 distance_ = search_result_->distances_.at(offset_);
+                group_by_value_ = std::nullopt;
                 if (search_result_->group_by_values_.has_value() &&
                     offset_ < search_result_->group_by_values_.value().size()) {
                     group_by_value_ =
@@ -112,15 +152,19 @@ struct StreamSearchResultPair {
             } else {
                 primary_key_ = merged_result_->primary_keys_.at(offset_);
                 distance_ = merged_result_->distances_.at(offset_);
+                group_by_value_ = std::nullopt;
                 if (merged_result_->group_by_values_.has_value() &&
                     offset_ < merged_result_->group_by_values_.value().size()) {
                     group_by_value_ =
                         merged_result_->group_by_values_.value().at(offset_);
                 }
             }
+            element_index_ = CurrentElementIndex();
         } else {
             primary_key_ = INVALID_PK;
             distance_ = std::numeric_limits<float>::min();
+            element_index_ = -1;
+            group_by_value_ = std::nullopt;
         }
     }
 };
@@ -208,6 +252,9 @@ class StreamReducerHelper {
     void
     CleanReduceStatus();
 
+    bool
+    TryAcceptSearchResult(const StreamSearchResultPair& result);
+
     void
     SetNullableVectorValidDataOffsets(
         const std::map<FieldId, std::unique_ptr<milvus::DataArray>>&
@@ -215,7 +262,10 @@ class StreamReducerHelper {
         int64_t ki,
         MergeBase& merge_base);
 
+ protected:
     std::unique_ptr<MergedSearchResult> merged_search_result;
+
+ private:
     milvus::query::Plan* plan_;
     std::vector<int64_t> slice_nqs_;
     std::vector<int64_t> slice_topKs_;
@@ -228,6 +278,8 @@ class StreamReducerHelper {
                         StreamSearchResultPairComparator>
         heap_;
     std::unordered_set<milvus::PkType> pk_set_;
+    std::unordered_set<ElementSearchResultKey, ElementSearchResultKeyHash>
+        element_result_set_;
     std::unordered_set<milvus::GroupByValueType> group_by_val_set_;
     std::vector<std::vector<std::vector<int64_t>>> final_search_records_;
     int64_t total_nq_{0};

--- a/internal/core/unittest/test_query.cpp
+++ b/internal/core/unittest/test_query.cpp
@@ -820,3 +820,59 @@ TEST(Query, ExecWithPredicateBinary) {
     std::cout << json.dump(2);
     // ASSERT_EQ(json.dump(2), ref.dump(2));
 }
+
+TEST(Query, VectorArrayElementLevelInference) {
+    auto dim = 32;
+
+    auto make_plan = [&](const std::string& metric) {
+        auto schema = std::make_shared<Schema>();
+        auto int64_field = schema->AddDebugField("int64", DataType::INT64);
+        schema->AddDebugVectorArrayField(
+            "array_vec", DataType::VECTOR_FLOAT, dim, metric);
+        schema->set_primary_field_id(int64_field);
+
+        ScopedSchemaHandle handle(*schema);
+        auto plan_str =
+            handle.ParseSearch("", "array_vec", 5, metric, R"({"nprobe": 10})");
+        return CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
+    };
+
+    int num_queries = 2;
+    std::vector<float> query_vec = generate_float_vector(num_queries, dim);
+
+    {
+        auto plan = make_plan("MAX_SIM");
+        std::vector<size_t> offsets = {0, 1, 2};
+        auto ph_raw = CreatePlaceholderGroupFromBlob<EmbListFloatVector>(
+            num_queries, dim, query_vec.data(), offsets);
+        auto ph = ParsePlaceholderGroup(plan.get(), ph_raw.SerializeAsString());
+        EXPECT_FALSE(ph->at(0).element_level_);
+    }
+
+    {
+        auto plan = make_plan("COSINE");
+        auto ph_raw =
+            CreatePlaceholderGroupFromBlob(num_queries, dim, query_vec.data());
+        auto ph = ParsePlaceholderGroup(plan.get(), ph_raw.SerializeAsString());
+        EXPECT_TRUE(ph->at(0).element_level_);
+    }
+
+    {
+        auto plan = make_plan("MAX_SIM");
+        auto ph_raw =
+            CreatePlaceholderGroupFromBlob(num_queries, dim, query_vec.data());
+        EXPECT_THROW(
+            ParsePlaceholderGroup(plan.get(), ph_raw.SerializeAsString()),
+            std::exception);
+    }
+
+    {
+        auto plan = make_plan("COSINE");
+        std::vector<size_t> offsets = {0, 1, 2};
+        auto ph_raw = CreatePlaceholderGroupFromBlob<EmbListFloatVector>(
+            num_queries, dim, query_vec.data(), offsets);
+        EXPECT_THROW(
+            ParsePlaceholderGroup(plan.get(), ph_raw.SerializeAsString()),
+            std::exception);
+    }
+}

--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -2309,6 +2309,44 @@ TEST_P(SealedVectorArrayTest, QueryVectorArrayAllFields) {
     EXPECT_EQ(array_vector_result->valid_data_size(), 0);
 }
 
+TEST(Sealed, ElementLevelSearchVectorArrayCountsElements) {
+    int dim = 4;
+    auto schema = std::make_shared<Schema>();
+    auto int64_field = schema->AddDebugField("int64", DataType::INT64);
+    auto array_vec = schema->AddDebugVectorArrayField("structA[array_vec]",
+                                                      DataType::VECTOR_FLOAT,
+                                                      dim,
+                                                      knowhere::metric::COSINE);
+    schema->set_primary_field_id(int64_field);
+
+    int64_t row_count = 64;
+    int array_len = 3;
+    auto dataset = DataGen(schema, row_count, 42, 0, 1, array_len);
+    auto sealed_segment = CreateSealedWithFieldDataLoaded(schema, dataset);
+
+    ScopedSchemaHandle handle(*schema);
+    auto plan_str = handle.ParseSearch(
+        "", "structA[array_vec]", 5, "COSINE", R"({"nprobe": 10})", 3);
+    auto plan =
+        CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
+
+    int num_queries = 2;
+    auto query_vec = generate_float_vector(num_queries, dim);
+    auto ph_group_raw =
+        CreatePlaceholderGroupFromBlob(num_queries, dim, query_vec.data());
+    auto ph_group =
+        ParsePlaceholderGroup(plan.get(), ph_group_raw.SerializeAsString());
+
+    auto sr = sealed_segment->Search(plan.get(), ph_group.get(), 1000000);
+    ASSERT_TRUE(sr->element_level_);
+    EXPECT_EQ(sr->total_data_cnt_, row_count * array_len);
+    ASSERT_EQ(sr->element_indices_.size(), sr->seg_offsets_.size());
+    for (auto elem_idx : sr->element_indices_) {
+        EXPECT_GE(elem_idx, 0);
+        EXPECT_LT(elem_idx, array_len);
+    }
+}
+
 TEST_P(SealedVectorArrayTest, SearchVectorArray) {
     int64_t collection_id = 1;
     int64_t partition_id = 2;

--- a/internal/proxy/search_reduce_util.go
+++ b/internal/proxy/search_reduce_util.go
@@ -22,6 +22,38 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
+func checkElementIndices(subSearchResultData []*schemapb.SearchResultData) (bool, error) {
+	if len(subSearchResultData) == 0 {
+		return false, nil
+	}
+
+	hasElementIndices := false
+	for _, data := range subSearchResultData {
+		if data.GetElementIndices() != nil {
+			hasElementIndices = true
+			break
+		}
+	}
+	if !hasElementIndices {
+		return false, nil
+	}
+
+	for i, data := range subSearchResultData {
+		if data.GetElementIndices() == nil {
+			if ids := data.GetIds(); ids == nil || typeutil.GetSizeOfIDs(ids) == 0 {
+				data.ElementIndices = &schemapb.LongArray{Data: []int64{}}
+				continue
+			}
+			return false, fmt.Errorf("inconsistent element-level search result: result[%d] has hits but misses element indices", i)
+		}
+		if len(data.GetElementIndices().GetData()) != len(data.GetScores()) {
+			return false, fmt.Errorf("invalid element-level search result: element indices length %d does not match scores length %d",
+				len(data.GetElementIndices().GetData()), len(data.GetScores()))
+		}
+	}
+	return true, nil
+}
+
 func reduceSearchResult(ctx context.Context, subSearchResultData []*schemapb.SearchResultData, reduceInfo *reduce.ResultInfo) (*milvuspb.SearchResults, error) {
 	if reduceInfo.GetGroupByFieldId() > 0 {
 		if reduceInfo.GetIsAdvance() {
@@ -113,6 +145,13 @@ func reduceAdvanceGroupBy(ctx context.Context, subSearchResultData []*schemapb.S
 	if err := setupIdListForSearchResult(ret, pkType, limit); err != nil {
 		return ret, nil
 	}
+	hasElementIndices, err := checkElementIndices(subSearchResultData)
+	if err != nil {
+		return ret, err
+	}
+	if hasElementIndices {
+		ret.Results.ElementIndices = &schemapb.LongArray{Data: make([]int64, 0, limit)}
+	}
 
 	var (
 		subSearchNum = len(subSearchResultData)
@@ -150,6 +189,9 @@ func reduceAdvanceGroupBy(ctx context.Context, subSearchResultData []*schemapb.S
 				gpFieldBuilder.Add(groupByVal)
 				typeutil.AppendPKs(ret.Results.Ids, pk)
 				ret.Results.Scores = append(ret.Results.Scores, score)
+				if hasElementIndices {
+					ret.Results.ElementIndices.Data = append(ret.Results.ElementIndices.Data, subData.GetElementIndices().GetData()[innerIdx])
+				}
 				dataCount += 1
 			}
 		}
@@ -215,6 +257,13 @@ func reduceSearchResultDataWithGroupBy(ctx context.Context, subSearchResultData 
 		return ret, err
 	} else {
 		ret.GetResults().AllSearchCount = allSearchCount
+	}
+	hasElementIndices, err := checkElementIndices(subSearchResultData)
+	if err != nil {
+		return ret, err
+	}
+	if hasElementIndices {
+		ret.Results.ElementIndices = &schemapb.LongArray{Data: make([]int64, 0, groupBound)}
 	}
 
 	// Find the first non-empty FieldsData as template
@@ -314,6 +363,9 @@ func reduceSearchResultDataWithGroupBy(ctx context.Context, subSearchResultData 
 				}
 				typeutil.AppendPKs(ret.Results.Ids, groupEntity.id)
 				ret.Results.Scores = append(ret.Results.Scores, groupEntity.score)
+				if hasElementIndices {
+					ret.Results.ElementIndices.Data = append(ret.Results.ElementIndices.Data, subResData.GetElementIndices().GetData()[groupEntity.resultIdx])
+				}
 				gpFieldBuilder.Add(groupVal)
 			}
 		}
@@ -374,6 +426,13 @@ func reduceSearchResultDataNoGroupBy(ctx context.Context, subSearchResultData []
 		return ret, err
 	} else {
 		ret.GetResults().AllSearchCount = allSearchCount
+	}
+	hasElementIndices, err := checkElementIndices(subSearchResultData)
+	if err != nil {
+		return ret, err
+	}
+	if hasElementIndices {
+		ret.Results.ElementIndices = &schemapb.LongArray{Data: make([]int64, 0, limit)}
 	}
 
 	// Find the first non-empty FieldsData as template
@@ -450,6 +509,9 @@ func reduceSearchResultDataNoGroupBy(ctx context.Context, subSearchResultData []
 				}
 				typeutil.CopyPk(ret.Results.Ids, subSearchResultData[subSearchIdx].GetIds(), int(resultDataIdx))
 				ret.Results.Scores = append(ret.Results.Scores, score)
+				if hasElementIndices {
+					ret.Results.ElementIndices.Data = append(ret.Results.ElementIndices.Data, subSearchResultData[subSearchIdx].GetElementIndices().GetData()[resultDataIdx])
+				}
 				cursors[subSearchIdx]++
 			}
 			if realTopK != -1 && realTopK != j {

--- a/internal/proxy/search_reduce_util_test.go
+++ b/internal/proxy/search_reduce_util_test.go
@@ -61,6 +61,88 @@ func (struts *SearchReduceUtilTestSuite) TestReduceSearchResult() {
 	}
 }
 
+func (struts *SearchReduceUtilTestSuite) TestReduceSearchResultElementIndices() {
+	ctx := context.Background()
+	nq := int64(1)
+	topK := int64(3)
+	offset := int64(0)
+
+	searchResultData1 := &schemapb.SearchResultData{
+		Ids: &schemapb.IDs{
+			IdField: &schemapb.IDs_IntId{
+				IntId: &schemapb.LongArray{Data: []int64{1, 2}},
+			},
+		},
+		Scores:         []float32{0.9, 0.7},
+		Topks:          []int64{2},
+		NumQueries:     nq,
+		TopK:           topK,
+		FieldsData:     []*schemapb.FieldData{},
+		ElementIndices: &schemapb.LongArray{Data: []int64{0, 1}},
+	}
+
+	searchResultData2 := &schemapb.SearchResultData{
+		Ids: &schemapb.IDs{
+			IdField: &schemapb.IDs_IntId{
+				IntId: &schemapb.LongArray{Data: []int64{3}},
+			},
+		},
+		Scores:         []float32{0.8},
+		Topks:          []int64{1},
+		NumQueries:     nq,
+		TopK:           topK,
+		FieldsData:     []*schemapb.FieldData{},
+		ElementIndices: &schemapb.LongArray{Data: []int64{2}},
+	}
+
+	results, err := reduceSearchResultDataNoGroupBy(ctx,
+		[]*schemapb.SearchResultData{searchResultData1, searchResultData2},
+		nq, topK, "MAX_SIM", schemapb.DataType_Int64, offset)
+	struts.NoError(err)
+	struts.Equal([]int64{1, 3, 2}, results.Results.GetIds().GetIntId().GetData())
+	struts.Equal([]int64{0, 2, 1}, results.Results.GetElementIndices().GetData())
+
+	searchResultData2.ElementIndices = &schemapb.LongArray{Data: []int64{}}
+	_, err = reduceSearchResultDataNoGroupBy(ctx,
+		[]*schemapb.SearchResultData{searchResultData1, searchResultData2},
+		nq, topK, "MAX_SIM", schemapb.DataType_Int64, offset)
+	struts.Error(err)
+
+	emptySearchResultData := &schemapb.SearchResultData{
+		Ids:        nil,
+		Scores:     []float32{},
+		Topks:      []int64{0},
+		NumQueries: nq,
+		TopK:       topK,
+		FieldsData: []*schemapb.FieldData{},
+	}
+	searchResultData2 = &schemapb.SearchResultData{
+		Ids: &schemapb.IDs{
+			IdField: &schemapb.IDs_IntId{
+				IntId: &schemapb.LongArray{Data: []int64{3}},
+			},
+		},
+		Scores:         []float32{0.8},
+		Topks:          []int64{1},
+		NumQueries:     nq,
+		TopK:           topK,
+		FieldsData:     []*schemapb.FieldData{},
+		ElementIndices: &schemapb.LongArray{Data: []int64{2}},
+	}
+	results, err = reduceSearchResultDataNoGroupBy(ctx,
+		[]*schemapb.SearchResultData{emptySearchResultData, searchResultData2},
+		nq, topK, "MAX_SIM", schemapb.DataType_Int64, offset)
+	struts.NoError(err)
+	struts.Equal([]int64{3}, results.Results.GetIds().GetIntId().GetData())
+	struts.Equal([]int64{2}, results.Results.GetElementIndices().GetData())
+
+	searchResultData2.ElementIndices = nil
+	_, err = reduceSearchResultDataNoGroupBy(ctx,
+		[]*schemapb.SearchResultData{searchResultData1, searchResultData2},
+		nq, topK, "MAX_SIM", schemapb.DataType_Int64, offset)
+	struts.ErrorContains(err, "misses element indices")
+}
+
 func (struts *SearchReduceUtilTestSuite) TestReduceSearchResultWithEmtpyGroupData() {
 	nq := int64(1)
 	topk := int64(1)

--- a/internal/proxy/task_index.go
+++ b/internal/proxy/task_index.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
@@ -531,10 +532,22 @@ func (cit *createIndexTask) parseIndexParams(ctx context.Context) error {
 				return merr.WrapErrParameterInvalid("valid index params", "invalid index params", "int vector index does not support metric type: "+metricType)
 			}
 		} else if typeutil.IsArrayOfVectorType(cit.fieldSchema.DataType) {
-			// TODO(SpadeA): adjust it when more metric types are supported. Especially, when different metric types
-			// are supported for different element types.
 			if !funcutil.SliceContain(indexparamcheck.EmbListMetrics, metricType) {
-				return merr.WrapErrParameterInvalid("valid index params", "invalid index params", "array of vector index does not support metric type: "+metricType)
+				if typeutil.IsDenseFloatVectorType(cit.fieldSchema.ElementType) {
+					if !funcutil.SliceContain(indexparamcheck.FloatVectorMetrics, metricType) {
+						return merr.WrapErrParameterInvalid("valid index params", "invalid index params", "array of vector with float element type does not support metric type: "+metricType)
+					}
+				} else if typeutil.IsBinaryVectorType(cit.fieldSchema.ElementType) {
+					if !funcutil.SliceContain(indexparamcheck.BinaryVectorMetrics, metricType) {
+						return merr.WrapErrParameterInvalid("valid index params", "invalid index params", "array of vector with binary element type does not support metric type: "+metricType)
+					}
+				} else if typeutil.IsIntVectorType(cit.fieldSchema.ElementType) {
+					if !funcutil.SliceContain(indexparamcheck.IntVectorMetrics, metricType) {
+						return merr.WrapErrParameterInvalid("valid index params", "invalid index params", "array of vector with int element type does not support metric type: "+metricType)
+					}
+				} else {
+					return merr.WrapErrParameterInvalid("valid index params", "invalid index params", "array of vector index does not support metric type: "+metricType)
+				}
 			}
 		}
 	}
@@ -642,8 +655,16 @@ func checkTrain(ctx context.Context, field *schemapb.FieldSchema, indexParams ma
 		return fmt.Errorf("invalid index type: %s", indexType)
 	}
 
+	effectiveDataType := field.DataType
+	effectiveElementType := field.ElementType
+	if typeutil.IsArrayOfVectorType(field.DataType) &&
+		!funcutil.SliceContain(indexparamcheck.EmbListMetrics, indexParams[common.MetricTypeKey]) {
+		effectiveDataType = field.ElementType
+		effectiveElementType = schemapb.DataType_None
+	}
+
 	if typeutil.IsVectorType(field.DataType) && indexType != indexparamcheck.AutoIndex {
-		exist := CheckVecIndexWithDataTypeExist(indexType, field.DataType, field.ElementType)
+		exist := CheckVecIndexWithDataTypeExist(indexType, effectiveDataType, effectiveElementType)
 		if !exist {
 			return fmt.Errorf("data type %s can't build with this index %s", schemapb.DataType_name[int32(field.GetDataType())], indexType)
 		}
@@ -657,12 +678,19 @@ func checkTrain(ctx context.Context, field *schemapb.FieldSchema, indexParams ma
 		}
 	}
 
-	if err := checker.CheckValidDataType(indexType, field); err != nil {
+	effectiveField := field
+	if effectiveDataType != field.DataType {
+		effectiveField = proto.Clone(field).(*schemapb.FieldSchema)
+		effectiveField.DataType = effectiveDataType
+		effectiveField.ElementType = effectiveElementType
+	}
+
+	if err := checker.CheckValidDataType(indexType, effectiveField); err != nil {
 		log.Ctx(ctx).Info("create index with invalid data type", zap.Error(err), zap.String("data_type", field.GetDataType().String()))
 		return err
 	}
 
-	if err := checker.CheckTrain(field.DataType, field.ElementType, indexParams); err != nil {
+	if err := checker.CheckTrain(effectiveDataType, effectiveElementType, indexParams); err != nil {
 		log.Ctx(ctx).Info("create index with invalid parameters", zap.Error(err))
 		return err
 	}

--- a/internal/proxy/task_index_test.go
+++ b/internal/proxy/task_index_test.go
@@ -1256,7 +1256,7 @@ func Test_checkEmbeddingListIndex(t *testing.T) {
 					},
 					{
 						Key:   common.MetricTypeKey,
-						Value: metric.L2,
+						Value: metric.HAMMING,
 					},
 				},
 				IndexName: "",
@@ -1273,7 +1273,7 @@ func Test_checkEmbeddingListIndex(t *testing.T) {
 			},
 		}
 		err := cit.parseIndexParams(context.TODO())
-		assert.True(t, strings.Contains(err.Error(), "array of vector index does not support metric type: L2"))
+		assert.True(t, strings.Contains(err.Error(), "array of vector with float element type does not support metric type: HAMMING"))
 	})
 
 	t.Run("metric type wrong", func(t *testing.T) {
@@ -1304,6 +1304,75 @@ func Test_checkEmbeddingListIndex(t *testing.T) {
 		}
 		err := cit.parseIndexParams(context.TODO())
 		assert.True(t, strings.Contains(err.Error(), "float vector index does not support metric type: MAX_SIM"))
+	})
+}
+
+func Test_arrayOfVector_nonEmbListMetric_indexCompat(t *testing.T) {
+	t.Run("ArrayOfVector with COSINE should accept IVF_FLAT", func(t *testing.T) {
+		cit := &createIndexTask{
+			req: &milvuspb.CreateIndexRequest{
+				ExtraParams: []*commonpb.KeyValuePair{
+					{Key: common.IndexTypeKey, Value: "IVF_FLAT"},
+					{Key: common.MetricTypeKey, Value: metric.COSINE},
+					{Key: "nlist", Value: "128"},
+				},
+			},
+			fieldSchema: &schemapb.FieldSchema{
+				FieldID:     101,
+				Name:        "vec_field",
+				DataType:    schemapb.DataType_ArrayOfVector,
+				ElementType: schemapb.DataType_FloatVector,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.DimKey, Value: "128"},
+				},
+			},
+		}
+		err := cit.parseIndexParams(context.TODO())
+		assert.NoError(t, err)
+	})
+
+	t.Run("ArrayOfVector with COSINE should accept HNSW", func(t *testing.T) {
+		cit := &createIndexTask{
+			req: &milvuspb.CreateIndexRequest{
+				ExtraParams: []*commonpb.KeyValuePair{
+					{Key: common.IndexTypeKey, Value: "HNSW"},
+					{Key: common.MetricTypeKey, Value: metric.COSINE},
+				},
+			},
+			fieldSchema: &schemapb.FieldSchema{
+				FieldID:     101,
+				Name:        "vec_field",
+				DataType:    schemapb.DataType_ArrayOfVector,
+				ElementType: schemapb.DataType_FloatVector,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.DimKey, Value: "128"},
+				},
+			},
+		}
+		err := cit.parseIndexParams(context.TODO())
+		assert.NoError(t, err)
+	})
+
+	t.Run("ArrayOfVector with MaxSimCosine should accept HNSW", func(t *testing.T) {
+		cit := &createIndexTask{
+			req: &milvuspb.CreateIndexRequest{
+				ExtraParams: []*commonpb.KeyValuePair{
+					{Key: common.IndexTypeKey, Value: "HNSW"},
+					{Key: common.MetricTypeKey, Value: metric.MaxSimCosine},
+				},
+			},
+			fieldSchema: &schemapb.FieldSchema{
+				FieldID:     101,
+				Name:        "vec_field",
+				DataType:    schemapb.DataType_ArrayOfVector,
+				ElementType: schemapb.DataType_FloatVector,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.DimKey, Value: "128"},
+				},
+			},
+		}
+		err := cit.parseIndexParams(context.TODO())
+		assert.NoError(t, err)
 	})
 }
 

--- a/internal/querynodev2/segments/search_reduce.go
+++ b/internal/querynodev2/segments/search_reduce.go
@@ -21,6 +21,58 @@ type SearchReduce interface {
 
 type SearchCommonReduce struct{}
 
+type elementSearchResultKey struct {
+	pk           interface{}
+	elementIndex int64
+}
+
+func checkElementIndices(searchResultData []*schemapb.SearchResultData) (bool, error) {
+	if len(searchResultData) == 0 {
+		return false, nil
+	}
+
+	hasElementIndices := false
+	for _, data := range searchResultData {
+		if data.GetElementIndices() != nil {
+			hasElementIndices = true
+			break
+		}
+	}
+	if !hasElementIndices {
+		return false, nil
+	}
+
+	for i, data := range searchResultData {
+		if data.GetElementIndices() == nil {
+			if ids := data.GetIds(); ids == nil || typeutil.GetSizeOfIDs(ids) == 0 {
+				data.ElementIndices = &schemapb.LongArray{Data: []int64{}}
+				continue
+			}
+			return false, fmt.Errorf("inconsistent element-level search result: result[%d] has hits but misses element indices", i)
+		}
+		if len(data.GetElementIndices().GetData()) != len(data.GetScores()) {
+			return false, fmt.Errorf("invalid element-level search result: element indices length %d does not match scores length %d",
+				len(data.GetElementIndices().GetData()), len(data.GetScores()))
+		}
+	}
+	return true, nil
+}
+
+func getSearchResultDedupKey(data *schemapb.SearchResultData, idx int64, id interface{}, hasElementIndices bool) (interface{}, error) {
+	if !hasElementIndices {
+		return id, nil
+	}
+
+	elementIndices := data.GetElementIndices()
+	if elementIndices == nil || idx < 0 || idx >= int64(len(elementIndices.GetData())) {
+		return nil, fmt.Errorf("element-level search result missing element index at offset %d", idx)
+	}
+	return elementSearchResultKey{
+		pk:           id,
+		elementIndex: elementIndices.GetData()[idx],
+	}, nil
+}
+
 func (scr *SearchCommonReduce) ReduceSearchResultData(ctx context.Context, searchResultData []*schemapb.SearchResultData, info *reduce.ResultInfo) (*schemapb.SearchResultData, error) {
 	ctx, sp := otel.Tracer(typeutil.QueryNodeRole).Start(ctx, "ReduceSearchResultData")
 	defer sp.End()
@@ -43,6 +95,13 @@ func (scr *SearchCommonReduce) ReduceSearchResultData(ctx context.Context, searc
 		Scores:     make([]float32, 0),
 		Ids:        &schemapb.IDs{},
 		Topks:      make([]int64, 0),
+	}
+	hasElementIndices, err := checkElementIndices(searchResultData)
+	if err != nil {
+		return nil, err
+	}
+	if hasElementIndices {
+		ret.ElementIndices = &schemapb.LongArray{Data: make([]int64, 0)}
 	}
 
 	resultOffsets := make([][]int64, len(searchResultData))
@@ -77,13 +136,20 @@ func (scr *SearchCommonReduce) ReduceSearchResultData(ctx context.Context, searc
 			score := searchResultData[sel].Scores[idx]
 
 			// remove duplicates
-			if _, ok := idSet[id]; !ok {
+			key, err := getSearchResultDedupKey(searchResultData[sel], idx, id, hasElementIndices)
+			if err != nil {
+				return nil, err
+			}
+			if _, ok := idSet[key]; !ok {
 				fieldsData := searchResultData[sel].FieldsData
 				fieldIdxs := idxComputers[sel].Compute(idx)
 				retSize += typeutil.AppendFieldData(ret.FieldsData, fieldsData, idx, fieldIdxs...)
 				typeutil.AppendPKs(ret.Ids, id)
 				ret.Scores = append(ret.Scores, score)
-				idSet[id] = struct{}{}
+				if hasElementIndices {
+					ret.ElementIndices.Data = append(ret.ElementIndices.Data, searchResultData[sel].GetElementIndices().GetData()[idx])
+				}
+				idSet[key] = struct{}{}
 				j++
 			} else {
 				// skip entity with same id
@@ -133,6 +199,13 @@ func (sbr *SearchGroupByReduce) ReduceSearchResultData(ctx context.Context, sear
 		Ids:        &schemapb.IDs{},
 		Topks:      make([]int64, 0),
 	}
+	hasElementIndices, err := checkElementIndices(searchResultData)
+	if err != nil {
+		return nil, err
+	}
+	if hasElementIndices {
+		ret.ElementIndices = &schemapb.LongArray{Data: make([]int64, 0)}
+	}
 
 	resultOffsets := make([][]int64, len(searchResultData))
 	groupByValIterator := make([]func(int) any, len(searchResultData))
@@ -180,7 +253,11 @@ func (sbr *SearchGroupByReduce) ReduceSearchResultData(ctx context.Context, sear
 			id := typeutil.GetPK(searchResultData[sel].GetIds(), idx)
 			groupByVal := groupByValIterator[sel](int(idx))
 			score := searchResultData[sel].Scores[idx]
-			if _, ok := idSet[id]; !ok {
+			key, err := getSearchResultDedupKey(searchResultData[sel], idx, id, hasElementIndices)
+			if err != nil {
+				return nil, err
+			}
+			if _, ok := idSet[key]; !ok {
 				groupCount := groupByValueMap[groupByVal]
 				if groupCount == 0 && int64(len(groupByValueMap)) >= info.GetTopK() {
 					// exceed the limit for group count, filter this entity
@@ -194,9 +271,12 @@ func (sbr *SearchGroupByReduce) ReduceSearchResultData(ctx context.Context, sear
 					retSize += typeutil.AppendFieldData(ret.FieldsData, fieldsData, idx, fieldIdxs...)
 					typeutil.AppendPKs(ret.Ids, id)
 					ret.Scores = append(ret.Scores, score)
+					if hasElementIndices {
+						ret.ElementIndices.Data = append(ret.ElementIndices.Data, searchResultData[sel].GetElementIndices().GetData()[idx])
+					}
 					gpFieldBuilder.Add(groupByVal)
 					groupByValueMap[groupByVal] += 1
-					idSet[id] = struct{}{}
+					idSet[key] = struct{}{}
 					j++
 				}
 			} else {

--- a/internal/querynodev2/segments/search_reduce_test.go
+++ b/internal/querynodev2/segments/search_reduce_test.go
@@ -55,6 +55,40 @@ func (suite *SearchReduceSuite) TestResult_ReduceSearchResultData() {
 		suite.Nil(err)
 		suite.ElementsMatch([]int64{1, 5, 2, 3}, res.Ids.GetIntId().Data)
 	})
+	suite.Run("element_level_dedup_by_pk_and_element_index", func() {
+		ids1 := []int64{1, 1, 2}
+		scores1 := []float32{-1.0, -2.0, -3.0}
+		topks1 := []int64{int64(len(ids1))}
+		data1 := mock_segcore.GenSearchResultData(nq, topk, ids1, scores1, topks1)
+		data1.ElementIndices = &schemapb.LongArray{Data: []int64{0, 1, 0}}
+
+		ids2 := []int64{1, 3}
+		scores2 := []float32{-0.5, -4.0}
+		topks2 := []int64{int64(len(ids2))}
+		data2 := mock_segcore.GenSearchResultData(nq, topk, ids2, scores2, topks2)
+		data2.ElementIndices = &schemapb.LongArray{Data: []int64{0, 0}}
+
+		reduceInfo := reduce.NewReduceSearchResultInfo(nq, topk).WithGroupSize(1)
+		searchReduce := InitSearchReducer(reduceInfo)
+		res, err := searchReduce.ReduceSearchResultData(
+			context.TODO(), []*schemapb.SearchResultData{data1, data2}, reduceInfo)
+		suite.Nil(err)
+		suite.Equal([]int64{1, 1, 2, 3}, res.Ids.GetIntId().Data)
+		suite.Equal([]int64{0, 1, 0, 0}, res.GetElementIndices().GetData())
+	})
+	suite.Run("element_indices_length_mismatch", func() {
+		ids := []int64{1, 2}
+		scores := []float32{-1.0, -2.0}
+		topks := []int64{int64(len(ids))}
+		data := mock_segcore.GenSearchResultData(nq, topk, ids, scores, topks)
+		data.ElementIndices = &schemapb.LongArray{Data: []int64{0}}
+
+		reduceInfo := reduce.NewReduceSearchResultInfo(nq, topk).WithGroupSize(1)
+		searchReduce := InitSearchReducer(reduceInfo)
+		_, err := searchReduce.ReduceSearchResultData(
+			context.TODO(), []*schemapb.SearchResultData{data}, reduceInfo)
+		suite.Error(err)
+	})
 }
 
 func (suite *SearchReduceSuite) TestResult_SearchGroupByResult() {
@@ -252,6 +286,139 @@ func (suite *SearchReduceSuite) TestResult_SearchGroupByResult() {
 		suite.Equal(int64(topk), res.GetTopK())
 		suite.Equal(0, len(res.GetFieldsData()))
 	})
+}
+
+func (suite *SearchReduceSuite) TestElementIndices_BackfillNilForEmptyResult() {
+	const (
+		nq   = 1
+		topk = 4
+	)
+
+	suite.Run("common_reduce", func() {
+		data1 := mock_segcore.GenSearchResultData(nq, topk,
+			[]int64{1, 2, 3, 4},
+			[]float32{-1.0, -2.0, -3.0, -4.0},
+			[]int64{4},
+		)
+		data1.ElementIndices = &schemapb.LongArray{Data: []int64{0, 1, 2, 3}}
+
+		data2 := mock_segcore.GenSearchResultData(nq, topk,
+			[]int64{},
+			[]float32{},
+			[]int64{0},
+		)
+		data2.Ids = nil
+		data2.ElementIndices = nil
+
+		reduceInfo := reduce.NewReduceSearchResultInfo(nq, topk).WithGroupSize(1)
+		searchReduce := &SearchCommonReduce{}
+		res, err := searchReduce.ReduceSearchResultData(context.TODO(), []*schemapb.SearchResultData{data1, data2}, reduceInfo)
+		suite.NoError(err)
+		suite.NotNil(res.GetElementIndices())
+		suite.Equal([]int64{0, 1, 2, 3}, res.GetElementIndices().GetData())
+		suite.Equal([]int64{1, 2, 3, 4}, res.GetIds().GetIntId().GetData())
+	})
+
+	suite.Run("common_reduce_empty_first", func() {
+		data1 := mock_segcore.GenSearchResultData(nq, topk,
+			[]int64{},
+			[]float32{},
+			[]int64{0},
+		)
+		data1.Ids = nil
+		data1.ElementIndices = nil
+
+		data2 := mock_segcore.GenSearchResultData(nq, topk,
+			[]int64{1, 2},
+			[]float32{-1.0, -2.0},
+			[]int64{2},
+		)
+		data2.ElementIndices = &schemapb.LongArray{Data: []int64{5, 6}}
+
+		reduceInfo := reduce.NewReduceSearchResultInfo(nq, topk).WithGroupSize(1)
+		searchReduce := &SearchCommonReduce{}
+		res, err := searchReduce.ReduceSearchResultData(context.TODO(), []*schemapb.SearchResultData{data1, data2}, reduceInfo)
+		suite.NoError(err)
+		suite.NotNil(res.GetElementIndices())
+		suite.Equal([]int64{5, 6}, res.GetElementIndices().GetData())
+	})
+
+	suite.Run("group_by_reduce", func() {
+		data1 := mock_segcore.GenSearchResultData(nq, topk,
+			[]int64{1, 2},
+			[]float32{-1.0, -2.0},
+			[]int64{2},
+		)
+		data1.ElementIndices = &schemapb.LongArray{Data: []int64{10, 11}}
+		data1.GroupByFieldValue = &schemapb.FieldData{
+			Type: schemapb.DataType_Int64,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{100, 200}}},
+				},
+			},
+		}
+
+		data2 := mock_segcore.GenSearchResultData(nq, topk,
+			[]int64{},
+			[]float32{},
+			[]int64{0},
+		)
+		data2.Ids = nil
+		data2.ElementIndices = nil
+		data2.GroupByFieldValue = &schemapb.FieldData{
+			Type: schemapb.DataType_Int64,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{}}},
+				},
+			},
+		}
+
+		reduceInfo := reduce.NewReduceSearchResultInfo(nq, topk).WithGroupSize(1).WithGroupByField(101)
+		searchReduce := &SearchGroupByReduce{}
+		res, err := searchReduce.ReduceSearchResultData(context.TODO(), []*schemapb.SearchResultData{data1, data2}, reduceInfo)
+		suite.NoError(err)
+		suite.NotNil(res.GetElementIndices())
+		suite.Equal([]int64{10, 11}, res.GetElementIndices().GetData())
+	})
+}
+
+func (suite *SearchReduceSuite) TestElementIndices_NoElementLevel() {
+	const (
+		nq   = 1
+		topk = 4
+	)
+	data1 := mock_segcore.GenSearchResultData(nq, topk,
+		[]int64{1, 2}, []float32{-1.0, -2.0}, []int64{2})
+	data2 := mock_segcore.GenSearchResultData(nq, topk,
+		[]int64{3, 4}, []float32{-3.0, -4.0}, []int64{2})
+
+	reduceInfo := reduce.NewReduceSearchResultInfo(nq, topk).WithGroupSize(1)
+	searchReduce := &SearchCommonReduce{}
+	res, err := searchReduce.ReduceSearchResultData(context.TODO(), []*schemapb.SearchResultData{data1, data2}, reduceInfo)
+	suite.NoError(err)
+	suite.Nil(res.GetElementIndices())
+}
+
+func (suite *SearchReduceSuite) TestElementIndices_InconsistentWithData() {
+	const (
+		nq   = 1
+		topk = 4
+	)
+	data1 := mock_segcore.GenSearchResultData(nq, topk,
+		[]int64{1, 2}, []float32{-1.0, -2.0}, []int64{2})
+	data1.ElementIndices = &schemapb.LongArray{Data: []int64{0, 1}}
+
+	data2 := mock_segcore.GenSearchResultData(nq, topk,
+		[]int64{3, 4}, []float32{-3.0, -4.0}, []int64{2})
+	data2.ElementIndices = nil
+
+	reduceInfo := reduce.NewReduceSearchResultInfo(nq, topk).WithGroupSize(1)
+	searchReduce := &SearchCommonReduce{}
+	_, err := searchReduce.ReduceSearchResultData(context.TODO(), []*schemapb.SearchResultData{data1, data2}, reduceInfo)
+	suite.Error(err)
+	suite.Contains(err.Error(), "misses element indices")
 }
 
 func TestSearchReduce(t *testing.T) {

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/jolestar/go-commons-pool/v2 v2.1.2
 	github.com/json-iterator/go v1.1.13-0.20220915233716-71ac16282d12
 	github.com/klauspost/compress v1.18.0
-	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.17
+	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.18-0.20260514122006-2a015eed650c
 	github.com/minio/minio-go/v7 v7.0.73
 	github.com/panjf2000/ants/v2 v2.11.3
 	github.com/prometheus/client_golang v1.20.5

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -480,8 +480,8 @@ github.com/milvus-io/cgosymbolizer v0.0.0-20250318084424-114f4050c3a6 h1:YHMFI6L
 github.com/milvus-io/cgosymbolizer v0.0.0-20250318084424-114f4050c3a6/go.mod h1:DvXTE/K/RtHehxU8/GtDs4vFtfw64jJ3PaCnFri8CRg=
 github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b h1:TfeY0NxYxZzUfIfYe5qYDBzt4ZYRqzUjTR6CvUzjat8=
 github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b/go.mod h1:iwW+9cWfIzzDseEBCCeDSN5SD16Tidvy8cwQ7ZY8Qj4=
-github.com/milvus-io/milvus-proto/go-api/v2 v2.6.17 h1:Gh96W9hESA0P1q4iQnG2MXWPm0J6mwurEOAxHaAWVD8=
-github.com/milvus-io/milvus-proto/go-api/v2 v2.6.17/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.18-0.20260514122006-2a015eed650c h1:3sY5oyIDjLftXpPEPKMizhy3K1jSiuh6ISNAUNs6XVM=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.18-0.20260514122006-2a015eed650c/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=
 github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEpN+20RM=
 github.com/minio/minio-go/v7 v7.0.73 h1:qr2vi96Qm7kZ4v7LLebjte+MQh621fFWnv93p12htEo=

--- a/pkg/util/typeutil/schema_test.go
+++ b/pkg/util/typeutil/schema_test.go
@@ -5639,32 +5639,6 @@ func TestUpdateFieldDataByColumn(t *testing.T) {
 	})
 }
 
-func TestIsClusteringKeyType(t *testing.T) {
-	// Supported scalar types
-	assert.True(t, IsClusteringKeyType(schemapb.DataType_Int8))
-	assert.True(t, IsClusteringKeyType(schemapb.DataType_Int16))
-	assert.True(t, IsClusteringKeyType(schemapb.DataType_Int32))
-	assert.True(t, IsClusteringKeyType(schemapb.DataType_Int64))
-	assert.True(t, IsClusteringKeyType(schemapb.DataType_Float))
-	assert.True(t, IsClusteringKeyType(schemapb.DataType_Double))
-	assert.True(t, IsClusteringKeyType(schemapb.DataType_VarChar))
-	assert.True(t, IsClusteringKeyType(schemapb.DataType_String))
-
-	// Supported vector types
-	assert.True(t, IsClusteringKeyType(schemapb.DataType_FloatVector))
-
-	// Unsupported types
-	assert.False(t, IsClusteringKeyType(schemapb.DataType_JSON))
-	assert.False(t, IsClusteringKeyType(schemapb.DataType_Bool))
-	assert.False(t, IsClusteringKeyType(schemapb.DataType_Array))
-	assert.False(t, IsClusteringKeyType(schemapb.DataType_Geometry))
-	assert.False(t, IsClusteringKeyType(schemapb.DataType_Text))
-	assert.False(t, IsClusteringKeyType(schemapb.DataType_Timestamptz))
-	assert.False(t, IsClusteringKeyType(schemapb.DataType_BinaryVector))
-	assert.False(t, IsClusteringKeyType(schemapb.DataType_Float16Vector))
-	assert.False(t, IsClusteringKeyType(schemapb.DataType_BFloat16Vector))
-}
-
 func newArrayOfVectorFieldData(fieldID int64, fieldName string, dim int64, elementType schemapb.DataType, rowCount int) *schemapb.FieldData {
 	data := make([]*schemapb.VectorField, rowCount)
 	for i := 0; i < rowCount; i++ {

--- a/tests/go_client/go.mod
+++ b/tests/go_client/go.mod
@@ -3,7 +3,7 @@ module github.com/milvus-io/milvus/tests/go_client
 go 1.25.8
 
 require (
-	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.17
+	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.18-0.20260514122006-2a015eed650c
 	github.com/milvus-io/milvus/client/v2 v2.0.0-20241125024034-0b9edb62a92d
 	github.com/milvus-io/milvus/pkg/v2 v2.6.7-0.20251202033909-b71a123d25ad
 	github.com/peterstace/simplefeatures v0.54.0

--- a/tests/go_client/go.sum
+++ b/tests/go_client/go.sum
@@ -333,8 +333,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/mediocregopher/radix/v3 v3.4.2/go.mod h1:8FL3F6UQRXHXIBSPUs5h0RybMF8i4n7wVopoX3x7Bv8=
 github.com/microcosm-cc/bluemonday v1.0.2/go.mod h1:iVP4YcDBq+n/5fb23BhYFvIMq/leAFZyRl6bYmGDlGc=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
-github.com/milvus-io/milvus-proto/go-api/v2 v2.6.17 h1:Gh96W9hESA0P1q4iQnG2MXWPm0J6mwurEOAxHaAWVD8=
-github.com/milvus-io/milvus-proto/go-api/v2 v2.6.17/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.18-0.20260514122006-2a015eed650c h1:3sY5oyIDjLftXpPEPKMizhy3K1jSiuh6ISNAUNs6XVM=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.18-0.20260514122006-2a015eed650c/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
 github.com/milvus-io/milvus/pkg/v2 v2.6.7-0.20251202033909-b71a123d25ad h1:pjSurtVnX3VLLdjUg3HKMpILDv/ZEfSI1rZLsTd+h1U=
 github.com/milvus-io/milvus/pkg/v2 v2.6.7-0.20251202033909-b71a123d25ad/go.mod h1:ak5nlCCbtImG4/WWcI/csU5ht6EyF/9QQ/tmivMzF4c=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/42148
pr: https://github.com/milvus-io/milvus/pull/45830
design doc: docs/design-docs/design_docs/20260306-struct.md

It cherry picks element-level search only with out element-level filter.