### PR TITLE
fix: prevent create snapshot drop race

### DIFF
--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -2190,6 +2190,21 @@ func (s *Server) CreateSnapshot(ctx context.Context, req *datapb.CreateSnapshotR
 	}
 	defer broadcaster.Close()
 
+	// Re-check collection availability while holding the collection resource
+	// lock. DropCollection may win the race between the pre-lock collection
+	// resolution above and lock acquisition; in that case this request must
+	// terminate before broadcasting a CreateSnapshot message whose ack callback
+	// can no longer generate a valid snapshot.
+	hasCollection, err := s.broker.HasCollection(ctx, req.GetCollectionId())
+	if err != nil {
+		log.Warn("CreateSnapshot: failed to re-check collection existence after lock", zap.Error(err))
+		return merr.Status(err), nil
+	}
+	if !hasCollection {
+		log.Warn("CreateSnapshot: collection not found after lock")
+		return merr.Status(merr.WrapErrCollectionNotFound(req.GetCollectionId())), nil
+	}
+
 	// Double-check after acquiring lock — another goroutine may have created it.
 	// Same error-handling discipline as the pre-lock check above: only treat
 	// ErrSnapshotNotFound as "good to proceed"; surface every other error.

--- a/internal/datacoord/services_test.go
+++ b/internal/datacoord/services_test.go
@@ -3276,9 +3276,14 @@ func TestServer_CreateSnapshot_AdditionalCases(t *testing.T) {
 			}).Build()
 		defer mockBroadcast.UnPatch()
 
+		fakeBroker := &struct{ broker.Broker }{}
+		mockHasCollection := mockey.Mock((*struct{ broker.Broker }).HasCollection).Return(true, nil).Build()
+		defer mockHasCollection.UnPatch()
+
 		server := &Server{
 			snapshotManager: NewSnapshotManager(nil, nil, nil, nil, nil, nil, nil, nil),
 			handler:         fakeHandler,
+			broker:          fakeBroker,
 		}
 		server.stateCode.Store(commonpb.StateCode_Healthy)
 
@@ -3292,6 +3297,127 @@ func TestServer_CreateSnapshot_AdditionalCases(t *testing.T) {
 		assert.Error(t, merr.Error(resp))
 		assert.Contains(t, resp.GetReason(), "etcd decode failure")
 		assert.Equal(t, 2, callCount, "GetSnapshot should be invoked twice (pre-lock + post-lock)")
+	})
+
+	t.Run("collection_dropped_after_lock_acquisition", func(t *testing.T) {
+		ctx := context.Background()
+
+		mockGet := mockey.Mock((*snapshotManager).GetSnapshot).Return(
+			nil, merr.WrapErrSnapshotNotFound("race_snapshot", "not found"),
+		).Build()
+		defer mockGet.UnPatch()
+
+		fakeHandler := &struct{ Handler }{}
+		mockGetColl := mockey.Mock((*struct{ Handler }).GetCollection).Return(
+			&collectionInfo{
+				ID:           100,
+				DatabaseName: "default",
+				Schema:       &schemapb.CollectionSchema{Name: "test_collection"},
+			}, nil,
+		).Build()
+		defer mockGetColl.UnPatch()
+
+		broadcastCalled := false
+		mockBroadcaster := &struct{ broadcaster.BroadcastAPI }{}
+		mockClose := mockey.Mock((*struct{ broadcaster.BroadcastAPI }).Close).Return().Build()
+		defer mockClose.UnPatch()
+		mockDoBroadcast := mockey.Mock((*struct{ broadcaster.BroadcastAPI }).Broadcast).To(
+			func(_ *struct{ broadcaster.BroadcastAPI }, _ context.Context, _ message.BroadcastMutableMessage) (*types2.BroadcastAppendResult, error) {
+				broadcastCalled = true
+				return &types2.BroadcastAppendResult{}, nil
+			}).Build()
+		defer mockDoBroadcast.UnPatch()
+		mockStartBroadcast := mockey.Mock(broadcast.StartBroadcastWithResourceKeys).To(
+			func(ctx context.Context, keys ...message.ResourceKey) (broadcaster.BroadcastAPI, error) {
+				return mockBroadcaster, nil
+			}).Build()
+		defer mockStartBroadcast.UnPatch()
+
+		hasCollectionCalled := false
+		fakeBroker := &struct{ broker.Broker }{}
+		mockHasCollection := mockey.Mock((*struct{ broker.Broker }).HasCollection).To(
+			func(_ *struct{ broker.Broker }, _ context.Context, collectionID int64) (bool, error) {
+				hasCollectionCalled = true
+				assert.Equal(t, int64(100), collectionID)
+				return false, nil
+			}).Build()
+		defer mockHasCollection.UnPatch()
+
+		server := &Server{
+			snapshotManager: NewSnapshotManager(nil, nil, nil, nil, nil, nil, nil, nil),
+			handler:         fakeHandler,
+			broker:          fakeBroker,
+		}
+		server.stateCode.Store(commonpb.StateCode_Healthy)
+
+		resp, err := server.CreateSnapshot(ctx, &datapb.CreateSnapshotRequest{
+			Name:         "race_snapshot",
+			CollectionId: 100,
+		})
+
+		assert.NoError(t, err)
+		assert.Error(t, merr.Error(resp))
+		assert.True(t, errors.Is(merr.Error(resp), merr.ErrCollectionNotFound))
+		assert.True(t, hasCollectionCalled, "collection availability must be checked under the resource lock")
+		assert.False(t, broadcastCalled, "CreateSnapshot must not broadcast after DropCollection wins the lock race")
+	})
+
+	t.Run("collection_recheck_error_after_lock", func(t *testing.T) {
+		ctx := context.Background()
+
+		mockGet := mockey.Mock((*snapshotManager).GetSnapshot).Return(
+			nil, merr.WrapErrSnapshotNotFound("race_snapshot", "not found"),
+		).Build()
+		defer mockGet.UnPatch()
+
+		fakeHandler := &struct{ Handler }{}
+		mockGetColl := mockey.Mock((*struct{ Handler }).GetCollection).Return(
+			&collectionInfo{
+				ID:           100,
+				DatabaseName: "default",
+				Schema:       &schemapb.CollectionSchema{Name: "test_collection"},
+			}, nil,
+		).Build()
+		defer mockGetColl.UnPatch()
+
+		broadcastCalled := false
+		mockBroadcaster := &struct{ broadcaster.BroadcastAPI }{}
+		mockClose := mockey.Mock((*struct{ broadcaster.BroadcastAPI }).Close).Return().Build()
+		defer mockClose.UnPatch()
+		mockDoBroadcast := mockey.Mock((*struct{ broadcaster.BroadcastAPI }).Broadcast).To(
+			func(_ *struct{ broadcaster.BroadcastAPI }, _ context.Context, _ message.BroadcastMutableMessage) (*types2.BroadcastAppendResult, error) {
+				broadcastCalled = true
+				return &types2.BroadcastAppendResult{}, nil
+			}).Build()
+		defer mockDoBroadcast.UnPatch()
+		mockStartBroadcast := mockey.Mock(broadcast.StartBroadcastWithResourceKeys).To(
+			func(ctx context.Context, keys ...message.ResourceKey) (broadcaster.BroadcastAPI, error) {
+				return mockBroadcaster, nil
+			}).Build()
+		defer mockStartBroadcast.UnPatch()
+
+		fakeBroker := &struct{ broker.Broker }{}
+		mockHasCollection := mockey.Mock((*struct{ broker.Broker }).HasCollection).Return(
+			false, errors.New("rootcoord unavailable"),
+		).Build()
+		defer mockHasCollection.UnPatch()
+
+		server := &Server{
+			snapshotManager: NewSnapshotManager(nil, nil, nil, nil, nil, nil, nil, nil),
+			handler:         fakeHandler,
+			broker:          fakeBroker,
+		}
+		server.stateCode.Store(commonpb.StateCode_Healthy)
+
+		resp, err := server.CreateSnapshot(ctx, &datapb.CreateSnapshotRequest{
+			Name:         "race_snapshot",
+			CollectionId: 100,
+		})
+
+		assert.NoError(t, err)
+		assert.Error(t, merr.Error(resp))
+		assert.Contains(t, resp.GetReason(), "rootcoord unavailable")
+		assert.False(t, broadcastCalled, "CreateSnapshot must not broadcast if the lock-held collection recheck fails")
 	})
 }
 


### PR DESCRIPTION
## What changed

- Re-check collection availability while holding the CreateSnapshot collection resource lock.
- Stop broadcasting CreateSnapshot when DropCollection has already made the collection unavailable.
- Add regression tests for the service race path.

## Root cause

CreateSnapshot resolved collection info before acquiring the broadcast resource lock. If DropCollection won the race before CreateSnapshot acquired the lock, CreateSnapshot could still broadcast with stale collection information. The ack callback then failed to generate a snapshot and the scheduler retried indefinitely.

## Issue

issue: #49761

## Verification

```bash
git diff --check
```

```bash
source ~/.profile && source scripts/setenv.sh && go test \
  -gcflags="all=-N -l" \
  -ldflags="-r ${RPATH}" \
  -tags dynamic,test \
  github.com/milvus-io/milvus/internal/datacoord \
  -run 'TestServer_CreateSnapshot_AdditionalCases' \
  -v -count=1
```
