### PR TITLE
feat: impl StructArray -- support hybrid search for element-level search

### DIFF
--- a/internal/proxy/search_pipeline.go
+++ b/internal/proxy/search_pipeline.go
@@ -45,6 +45,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/planpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/commonpbutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/metric"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
@@ -115,16 +116,17 @@ func (n *Node) Run(ctx context.Context, span trace.Span, msg opMsg) (opMsg, erro
 const aggOp = "search_agg"
 
 const (
-	searchReduceOp       = "search_reduce"
-	hybridSearchReduceOp = "hybrid_search_reduce"
-	rerankOp             = "rerank"
-	requeryOp            = "requery"
-	organizeOp           = "organize"
-	hybridAssembleOp     = "hybrid_assemble"
-	endOp                = "end"
-	lambdaOp             = "lambda"
-	highlightOp          = "highlight"
-	orderByOp            = "order_by"
+	searchReduceOp        = "search_reduce"
+	hybridSearchReduceOp  = "hybrid_search_reduce"
+	rerankOp              = "rerank"
+	requeryOp             = "requery"
+	organizeOp            = "organize"
+	elementBestCollapseOp = "element_best_collapse"
+	hybridAssembleOp      = "hybrid_assemble"
+	endOp                 = "end"
+	lambdaOp              = "lambda"
+	highlightOp           = "highlight"
+	orderByOp             = "order_by"
 )
 
 const (
@@ -134,17 +136,18 @@ const (
 )
 
 var opFactory = map[string]func(t *searchTask, params map[string]any) (operator, error){
-	searchReduceOp:       newSearchReduceOperator,
-	hybridSearchReduceOp: newHybridSearchReduceOperator,
-	aggOp:                newAggregateOperator,
-	rerankOp:             newRerankOperator,
-	organizeOp:           newOrganizeOperator,
-	hybridAssembleOp:     newHybridAssembleOperator,
-	requeryOp:            newRequeryOperator,
-	lambdaOp:             newLambdaOperator,
-	endOp:                newEndOperator,
-	highlightOp:          newHighlightOperator,
-	orderByOp:            newOrderByOperator,
+	searchReduceOp:        newSearchReduceOperator,
+	hybridSearchReduceOp:  newHybridSearchReduceOperator,
+	aggOp:                 newAggregateOperator,
+	rerankOp:              newRerankOperator,
+	organizeOp:            newOrganizeOperator,
+	elementBestCollapseOp: newElementBestCollapseOperator,
+	hybridAssembleOp:      newHybridAssembleOperator,
+	requeryOp:             newRequeryOperator,
+	lambdaOp:              newLambdaOperator,
+	endOp:                 newEndOperator,
+	highlightOp:           newHighlightOperator,
+	orderByOp:             newOrderByOperator,
 }
 
 func NewNode(info *nodeDef, t *searchTask) (*Node, error) {
@@ -281,6 +284,194 @@ func (op *hybridSearchReduceOperator) run(ctx context.Context, span trace.Span, 
 		multipleMilvusResults[index] = result
 	}
 	return []any{multipleMilvusResults, searchMetrics}, nil
+}
+
+type elementBestCollapseOperator struct{}
+
+func newElementBestCollapseOperator(_ *searchTask, _ map[string]any) (operator, error) {
+	return &elementBestCollapseOperator{}, nil
+}
+
+// elementBestCollapseOperator normalizes element-level hybrid sub-search
+// results into row-level results before rerank. For each query chunk, duplicate
+// PKs keep the best element score under that sub-search metric direction.
+func (op *elementBestCollapseOperator) run(ctx context.Context, span trace.Span, inputs ...any) ([]any, error) {
+	if len(inputs) < 2 {
+		return nil, merr.WrapErrServiceInternal("element best collapse: missing inputs")
+	}
+	results, ok := inputs[0].([]*milvuspb.SearchResults)
+	if !ok {
+		return nil, merr.WrapErrParameterInvalidMsg("element best collapse: inputs[0] must be []*SearchResults, got %T", inputs[0])
+	}
+	metrics, ok := inputs[1].([]string)
+	if !ok {
+		return nil, merr.WrapErrParameterInvalidMsg("element best collapse: inputs[1] must be []string, got %T", inputs[1])
+	}
+	if len(metrics) != len(results) {
+		return nil, merr.WrapErrServiceInternal(fmt.Sprintf("element best collapse: metrics length (%d) does not match results length (%d)", len(metrics), len(results)))
+	}
+
+	collapsed := make([]*milvuspb.SearchResults, len(results))
+	for i, result := range results {
+		metricType := metrics[i]
+		if result != nil && result.GetResults() != nil && result.GetResults().GetElementIndices() != nil && strings.TrimSpace(metricType) == "" {
+			totalRows := int64(0)
+			for _, topk := range result.GetResults().GetTopks() {
+				totalRows += topk
+			}
+			if totalRows > 0 {
+				return nil, merr.WrapErrServiceInternal(fmt.Sprintf("element best collapse: missing metric type for element-level result[%d]", i))
+			}
+		}
+		var err error
+		collapsed[i], err = collapseElementLevelResultByBestScore(result, metric.PositivelyRelated(metricType))
+		if err != nil {
+			return nil, err
+		}
+	}
+	return []any{collapsed}, nil
+}
+
+type bestElementHit struct {
+	rowIdx int64
+	score  float32
+	order  int
+}
+
+func collapseElementLevelResultByBestScore(result *milvuspb.SearchResults, largerScoreIsBetter bool) (*milvuspb.SearchResults, error) {
+	if result == nil || result.GetResults() == nil || result.GetResults().GetElementIndices() == nil {
+		return result, nil
+	}
+
+	data := result.GetResults()
+	topks := data.GetTopks()
+	totalRows := int64(0)
+	for _, topk := range topks {
+		totalRows += topk
+	}
+	if totalRows == 0 {
+		return copySearchResultsWithData(result, &schemapb.SearchResultData{
+			NumQueries:              data.GetNumQueries(),
+			TopK:                    0,
+			Topks:                   append([]int64(nil), topks...),
+			FieldsData:              []*schemapb.FieldData{},
+			Scores:                  []float32{},
+			OutputFields:            append([]string(nil), data.GetOutputFields()...),
+			AllSearchCount:          data.GetAllSearchCount(),
+			PrimaryFieldName:        data.GetPrimaryFieldName(),
+			SearchIteratorV2Results: data.GetSearchIteratorV2Results(),
+		}), nil
+	}
+
+	if typeutil.GetSizeOfIDs(data.GetIds()) < int(totalRows) {
+		return nil, merr.WrapErrServiceInternal(fmt.Sprintf("element best collapse: ids length (%d) is less than total rows (%d)",
+			typeutil.GetSizeOfIDs(data.GetIds()), totalRows))
+	}
+	if int64(len(data.GetScores())) < totalRows {
+		return nil, merr.WrapErrServiceInternal(fmt.Sprintf("element best collapse: scores length (%d) is less than total rows (%d)",
+			len(data.GetScores()), totalRows))
+	}
+	if int64(len(data.GetElementIndices().GetData())) < totalRows {
+		return nil, merr.WrapErrServiceInternal(fmt.Sprintf("element best collapse: element_indices length (%d) is less than total rows (%d)",
+			len(data.GetElementIndices().GetData()), totalRows))
+	}
+	if len(data.GetDistances()) > 0 && int64(len(data.GetDistances())) < totalRows {
+		return nil, merr.WrapErrServiceInternal(fmt.Sprintf("element best collapse: distances length (%d) is less than total rows (%d)",
+			len(data.GetDistances()), totalRows))
+	}
+	if len(data.GetRecalls()) > 0 && int64(len(data.GetRecalls())) < totalRows {
+		return nil, merr.WrapErrServiceInternal(fmt.Sprintf("element best collapse: recalls length (%d) is less than total rows (%d)",
+			len(data.GetRecalls()), totalRows))
+	}
+
+	output := &schemapb.SearchResultData{
+		NumQueries:              data.GetNumQueries(),
+		Topks:                   make([]int64, 0, len(topks)),
+		FieldsData:              typeutil.PrepareResultFieldData(data.GetFieldsData(), totalRows),
+		Scores:                  make([]float32, 0, totalRows),
+		Ids:                     &schemapb.IDs{},
+		OutputFields:            append([]string(nil), data.GetOutputFields()...),
+		AllSearchCount:          data.GetAllSearchCount(),
+		PrimaryFieldName:        data.GetPrimaryFieldName(),
+		SearchIteratorV2Results: data.GetSearchIteratorV2Results(),
+	}
+	if len(data.GetDistances()) > 0 {
+		output.Distances = make([]float32, 0, totalRows)
+	}
+	if len(data.GetRecalls()) > 0 {
+		output.Recalls = make([]float32, 0, totalRows)
+	}
+
+	idxComputer := typeutil.NewFieldDataIdxComputer(data.GetFieldsData())
+	offset := int64(0)
+	for _, topk := range topks {
+		selected := make(map[any]bestElementHit)
+		for i := int64(0); i < topk; i++ {
+			rowIdx := offset + i
+			pk := typeutil.GetPK(data.GetIds(), rowIdx)
+			if pk == nil {
+				continue
+			}
+			score := data.GetScores()[rowIdx]
+			hit, ok := selected[pk]
+			if !ok || isBetterElementScore(score, hit.score, largerScoreIsBetter) {
+				selected[pk] = bestElementHit{
+					rowIdx: rowIdx,
+					score:  score,
+					order:  int(i),
+				}
+			}
+		}
+
+		hits := make([]bestElementHit, 0, len(selected))
+		for _, hit := range selected {
+			hits = append(hits, hit)
+		}
+		sort.SliceStable(hits, func(i, j int) bool {
+			if hits[i].score != hits[j].score {
+				return isBetterElementScore(hits[i].score, hits[j].score, largerScoreIsBetter)
+			}
+			return hits[i].order < hits[j].order
+		})
+
+		output.Topks = append(output.Topks, int64(len(hits)))
+		if int64(len(hits)) > output.TopK {
+			output.TopK = int64(len(hits))
+		}
+		for _, hit := range hits {
+			typeutil.AppendIDs(output.Ids, data.GetIds(), int(hit.rowIdx))
+			output.Scores = append(output.Scores, data.GetScores()[hit.rowIdx])
+			if len(data.GetDistances()) > 0 {
+				output.Distances = append(output.Distances, data.GetDistances()[hit.rowIdx])
+			}
+			if len(data.GetRecalls()) > 0 {
+				output.Recalls = append(output.Recalls, data.GetRecalls()[hit.rowIdx])
+			}
+			if len(data.GetFieldsData()) > 0 {
+				fieldIdxs := idxComputer.Compute(hit.rowIdx)
+				typeutil.AppendFieldData(output.FieldsData, data.GetFieldsData(), hit.rowIdx, fieldIdxs...)
+			}
+		}
+		offset += topk
+	}
+
+	return copySearchResultsWithData(result, output), nil
+}
+
+func isBetterElementScore(candidate, current float32, largerScoreIsBetter bool) bool {
+	if largerScoreIsBetter {
+		return candidate > current
+	}
+	return candidate < current
+}
+
+func copySearchResultsWithData(src *milvuspb.SearchResults, data *schemapb.SearchResultData) *milvuspb.SearchResults {
+	return &milvuspb.SearchResults{
+		Status:         src.GetStatus(),
+		Results:        data,
+		CollectionName: src.GetCollectionName(),
+		SessionTs:      src.GetSessionTs(),
+	}
 }
 
 type aggregateOperator struct {
@@ -1082,8 +1273,9 @@ func (op *hybridAssembleOperator) run(ctx context.Context, span trace.Span, inpu
 		return []any{rankResult}, nil
 	}
 
-	// Build PK → (resultIdx, rowIdx) index across all sub-search results.
 	type pkLoc struct{ resultIdx, rowIdx int }
+
+	// Build PK -> (resultIdx, rowIdx) index across all sub-search results.
 	pkIndex := make(map[any]pkLoc)
 	for rIdx, result := range reducedResults {
 		ids := result.GetResults().GetIds()
@@ -2448,14 +2640,20 @@ var hybridSearchPipe = &pipelineDef{
 			opName:  hybridSearchReduceOp,
 		},
 		{
-			name:    "rerank",
+			name:    "element_best_collapse",
 			inputs:  []string{"reduced", "metrics"},
+			outputs: []string{"collapsed"},
+			opName:  elementBestCollapseOp,
+		},
+		{
+			name:    "rerank",
+			inputs:  []string{"collapsed", "metrics"},
 			outputs: []string{"rank_result"},
 			opName:  rerankOp,
 		},
 		{
 			name:    "assemble",
-			inputs:  []string{"reduced", "rank_result"},
+			inputs:  []string{"collapsed", "rank_result"},
 			outputs: []string{"result"},
 			opName:  hybridAssembleOp,
 		},
@@ -2472,8 +2670,14 @@ var hybridSearchWithRequeryAndRerankByFieldDataPipe = &pipelineDef{
 			opName:  hybridSearchReduceOp,
 		},
 		{
+			name:    "element_best_collapse",
+			inputs:  []string{"reduced", "metrics"},
+			outputs: []string{"collapsed"},
+			opName:  elementBestCollapseOp,
+		},
+		{
 			name:    "merge_ids",
-			inputs:  []string{"reduced"},
+			inputs:  []string{"collapsed"},
 			outputs: []string{"ids"},
 			opName:  lambdaOp,
 			params: map[string]any{
@@ -2488,7 +2692,7 @@ var hybridSearchWithRequeryAndRerankByFieldDataPipe = &pipelineDef{
 		},
 		{
 			name:    "parse_ids",
-			inputs:  []string{"reduced"},
+			inputs:  []string{"collapsed"},
 			outputs: []string{"id_list"},
 			opName:  lambdaOp,
 			params: map[string]any{
@@ -2509,7 +2713,7 @@ var hybridSearchWithRequeryAndRerankByFieldDataPipe = &pipelineDef{
 		},
 		{
 			name:    "gen_rank_data",
-			inputs:  []string{"reduced", "organized_fields"},
+			inputs:  []string{"collapsed", "organized_fields"},
 			outputs: []string{"rank_data"},
 			opName:  lambdaOp,
 			params: map[string]any{
@@ -2573,8 +2777,14 @@ var hybridSearchWithRequeryPipe = &pipelineDef{
 			opName:  hybridSearchReduceOp,
 		},
 		{
-			name:    "rerank",
+			name:    "element_best_collapse",
 			inputs:  []string{"reduced", "metrics"},
+			outputs: []string{"collapsed"},
+			opName:  elementBestCollapseOp,
+		},
+		{
+			name:    "rerank",
+			inputs:  []string{"collapsed", "metrics"},
 			outputs: []string{"rank_result"},
 			opName:  rerankOp,
 		},

--- a/internal/proxy/search_pipeline_test.go
+++ b/internal/proxy/search_pipeline_test.go
@@ -54,6 +54,12 @@ type SearchPipelineSuite struct {
 	span trace.Span
 }
 
+type searchPipelineTestOperator func(ctx context.Context, span trace.Span, inputs ...any) ([]any, error)
+
+func (op searchPipelineTestOperator) run(ctx context.Context, span trace.Span, inputs ...any) ([]any, error) {
+	return op(ctx, span, inputs...)
+}
+
 func (s *SearchPipelineSuite) SetupTest() {
 	_, sp := otel.Tracer("test").Start(context.Background(), "Proxy-Search-PostExecute")
 	s.span = sp
@@ -243,6 +249,364 @@ func (s *SearchPipelineSuite) TestRerankOp() {
 
 	_, err = op.run(context.Background(), s.span, reduced[0], []string{"IP"})
 	s.NoError(err)
+}
+
+func (s *SearchPipelineSuite) TestElementBestCollapseOp_CollapsesElementLevelResultsByRowID() {
+	input := &milvuspb.SearchResults{
+		Status: merr.Success(),
+		Results: &schemapb.SearchResultData{
+			NumQueries: 1,
+			TopK:       4,
+			Topks:      []int64{4},
+			Ids: &schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{
+					IntId: &schemapb.LongArray{Data: []int64{1, 1, 2, 3}},
+				},
+			},
+			Scores:         []float32{0.72, 0.85, 0.60, 0.95},
+			Distances:      []float32{7.2, 8.5, 6.0, 9.5},
+			ElementIndices: &schemapb.LongArray{Data: []int64{0, 3, 1, 0}},
+			FieldsData: []*schemapb.FieldData{
+				{
+					Type:      schemapb.DataType_Int64,
+					FieldName: "value",
+					FieldId:   101,
+					Field: &schemapb.FieldData_Scalars{
+						Scalars: &schemapb.ScalarField{
+							Data: &schemapb.ScalarField_LongData{
+								LongData: &schemapb.LongArray{Data: []int64{10, 30, 20, 90}},
+							},
+						},
+					},
+				},
+			},
+			AllSearchCount: 4,
+		},
+	}
+
+	op := &elementBestCollapseOperator{}
+	out, err := op.run(context.Background(), s.span, []*milvuspb.SearchResults{input}, []string{"IP"})
+	s.Require().NoError(err)
+
+	results := out[0].([]*milvuspb.SearchResults)
+	s.Require().Len(results, 1)
+	result := results[0].GetResults()
+
+	s.Nil(result.GetElementIndices())
+	s.Equal(int64(1), result.GetNumQueries())
+	s.Equal(int64(3), result.GetTopK())
+	s.Equal([]int64{3}, result.GetTopks())
+	s.Equal([]int64{3, 1, 2}, result.GetIds().GetIntId().GetData())
+	s.Equal([]float32{0.95, 0.85, 0.60}, result.GetScores())
+	s.Equal([]float32{9.5, 8.5, 6.0}, result.GetDistances())
+	s.Equal([]int64{90, 30, 20}, result.GetFieldsData()[0].GetScalars().GetLongData().GetData())
+	s.Equal(int64(4), result.GetAllSearchCount())
+}
+
+func (s *SearchPipelineSuite) TestElementBestCollapseOp_CollapsesEachQueryChunkIndependently() {
+	input := &milvuspb.SearchResults{
+		Status: merr.Success(),
+		Results: &schemapb.SearchResultData{
+			NumQueries: 2,
+			TopK:       3,
+			Topks:      []int64{3, 3},
+			Ids: &schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{
+					IntId: &schemapb.LongArray{Data: []int64{1, 1, 2, 1, 2, 2}},
+				},
+			},
+			Scores:         []float32{0.30, 0.90, 0.70, 0.80, 0.20, 0.60},
+			ElementIndices: &schemapb.LongArray{Data: []int64{0, 2, 0, 1, 0, 3}},
+			FieldsData: []*schemapb.FieldData{
+				{
+					Type:      schemapb.DataType_Int64,
+					FieldName: "value",
+					FieldId:   101,
+					Field: &schemapb.FieldData_Scalars{
+						Scalars: &schemapb.ScalarField{
+							Data: &schemapb.ScalarField_LongData{
+								LongData: &schemapb.LongArray{Data: []int64{10, 11, 20, 30, 40, 41}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	op := &elementBestCollapseOperator{}
+	out, err := op.run(context.Background(), s.span, []*milvuspb.SearchResults{input}, []string{"IP"})
+	s.Require().NoError(err)
+
+	results := out[0].([]*milvuspb.SearchResults)
+	result := results[0].GetResults()
+
+	s.Nil(result.GetElementIndices())
+	s.Equal(int64(2), result.GetNumQueries())
+	s.Equal(int64(2), result.GetTopK())
+	s.Equal([]int64{2, 2}, result.GetTopks())
+	s.Equal([]int64{1, 2, 1, 2}, result.GetIds().GetIntId().GetData())
+	s.Equal([]float32{0.90, 0.70, 0.80, 0.60}, result.GetScores())
+	s.Equal([]int64{11, 20, 30, 41}, result.GetFieldsData()[0].GetScalars().GetLongData().GetData())
+}
+
+func (s *SearchPipelineSuite) TestElementBestCollapseOp_CollapsesStringPrimaryKeys() {
+	input := &milvuspb.SearchResults{
+		Status: merr.Success(),
+		Results: &schemapb.SearchResultData{
+			NumQueries: 1,
+			TopK:       3,
+			Topks:      []int64{3},
+			Ids: &schemapb.IDs{
+				IdField: &schemapb.IDs_StrId{
+					StrId: &schemapb.StringArray{Data: []string{"row-a", "row-a", "row-b"}},
+				},
+			},
+			Scores:         []float32{0.10, 0.60, 0.40},
+			ElementIndices: &schemapb.LongArray{Data: []int64{0, 2, 1}},
+		},
+	}
+
+	op := &elementBestCollapseOperator{}
+	out, err := op.run(context.Background(), s.span, []*milvuspb.SearchResults{input}, []string{"IP"})
+	s.Require().NoError(err)
+
+	results := out[0].([]*milvuspb.SearchResults)
+	result := results[0].GetResults()
+
+	s.Nil(result.GetElementIndices())
+	s.Equal([]string{"row-a", "row-b"}, result.GetIds().GetStrId().GetData())
+	s.Equal([]float32{0.60, 0.40}, result.GetScores())
+}
+
+func (s *SearchPipelineSuite) TestElementBestCollapseOp_PassesRowLevelResultsThrough() {
+	input := &milvuspb.SearchResults{
+		Status: merr.Success(),
+		Results: &schemapb.SearchResultData{
+			NumQueries: 1,
+			TopK:       2,
+			Topks:      []int64{2},
+			Ids: &schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{
+					IntId: &schemapb.LongArray{Data: []int64{10, 20}},
+				},
+			},
+			Scores: []float32{0.90, 0.80},
+		},
+	}
+
+	op := &elementBestCollapseOperator{}
+	out, err := op.run(context.Background(), s.span, []*milvuspb.SearchResults{input}, []string{""})
+	s.Require().NoError(err)
+
+	results := out[0].([]*milvuspb.SearchResults)
+	s.Require().Len(results, 1)
+	s.Same(input, results[0])
+}
+
+func (s *SearchPipelineSuite) TestElementBestCollapseOp_AllowsEmptyElementLevelResultWithoutMetric() {
+	input := &milvuspb.SearchResults{
+		Status: merr.Success(),
+		Results: &schemapb.SearchResultData{
+			NumQueries:     1,
+			TopK:           0,
+			Topks:          []int64{0},
+			ElementIndices: &schemapb.LongArray{},
+			AllSearchCount: 10,
+		},
+	}
+
+	op := &elementBestCollapseOperator{}
+	out, err := op.run(context.Background(), s.span, []*milvuspb.SearchResults{input}, []string{""})
+	s.Require().NoError(err)
+
+	results := out[0].([]*milvuspb.SearchResults)
+	result := results[0].GetResults()
+
+	s.Nil(result.GetElementIndices())
+	s.Equal(int64(1), result.GetNumQueries())
+	s.Equal(int64(0), result.GetTopK())
+	s.Equal([]int64{0}, result.GetTopks())
+	s.Empty(result.GetScores())
+	s.Equal(int64(10), result.GetAllSearchCount())
+}
+
+func (s *SearchPipelineSuite) TestElementBestCollapseOp_DeduplicatesEqualScoreElementsByRowID() {
+	input := &milvuspb.SearchResults{
+		Status: merr.Success(),
+		Results: &schemapb.SearchResultData{
+			NumQueries: 1,
+			TopK:       3,
+			Topks:      []int64{3},
+			Ids: &schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{
+					IntId: &schemapb.LongArray{Data: []int64{1, 1, 2}},
+				},
+			},
+			Scores:         []float32{0.50, 0.50, 0.40},
+			ElementIndices: &schemapb.LongArray{Data: []int64{0, 1, 0}},
+		},
+	}
+
+	op := &elementBestCollapseOperator{}
+	out, err := op.run(context.Background(), s.span, []*milvuspb.SearchResults{input}, []string{"IP"})
+	s.Require().NoError(err)
+
+	results := out[0].([]*milvuspb.SearchResults)
+	result := results[0].GetResults()
+
+	s.Nil(result.GetElementIndices())
+	s.Equal([]int64{1, 2}, result.GetIds().GetIntId().GetData())
+	s.Equal([]float32{0.50, 0.40}, result.GetScores())
+}
+
+func (s *SearchPipelineSuite) TestHybridSearchPipe_RerankReceivesCollapsedRowLevelResults() {
+	input := &milvuspb.SearchResults{
+		Status: merr.Success(),
+		Results: &schemapb.SearchResultData{
+			NumQueries: 1,
+			TopK:       3,
+			Topks:      []int64{3},
+			Ids: &schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{
+					IntId: &schemapb.LongArray{Data: []int64{1, 1, 2}},
+				},
+			},
+			Scores:         []float32{0.40, 0.60, 0.90},
+			ElementIndices: &schemapb.LongArray{Data: []int64{0, 1, 0}},
+		},
+	}
+
+	originalReduceFactory := opFactory[hybridSearchReduceOp]
+	originalRerankFactory := opFactory[rerankOp]
+	originalAssembleFactory := opFactory[hybridAssembleOp]
+	defer func() {
+		opFactory[hybridSearchReduceOp] = originalReduceFactory
+		opFactory[rerankOp] = originalRerankFactory
+		opFactory[hybridAssembleOp] = originalAssembleFactory
+	}()
+
+	opFactory[hybridSearchReduceOp] = func(_ *searchTask, _ map[string]any) (operator, error) {
+		return searchPipelineTestOperator(func(ctx context.Context, span trace.Span, inputs ...any) ([]any, error) {
+			return []any{[]*milvuspb.SearchResults{input}, []string{"IP"}}, nil
+		}), nil
+	}
+
+	rerankCalled := false
+	opFactory[rerankOp] = func(_ *searchTask, _ map[string]any) (operator, error) {
+		return searchPipelineTestOperator(func(ctx context.Context, span trace.Span, inputs ...any) ([]any, error) {
+			rerankCalled = true
+
+			collapsed, ok := inputs[0].([]*milvuspb.SearchResults)
+			s.Require().True(ok)
+			metrics, ok := inputs[1].([]string)
+			s.Require().True(ok)
+			s.Equal([]string{"IP"}, metrics)
+			s.Require().Len(collapsed, 1)
+
+			data := collapsed[0].GetResults()
+			s.Nil(data.GetElementIndices())
+			s.Equal([]int64{2, 1}, data.GetIds().GetIntId().GetData())
+			s.Equal([]float32{0.90, 0.60}, data.GetScores())
+
+			return []any{&milvuspb.SearchResults{
+				Status: merr.Success(),
+				Results: &schemapb.SearchResultData{
+					NumQueries: data.GetNumQueries(),
+					TopK:       data.GetTopK(),
+					Topks:      append([]int64(nil), data.GetTopks()...),
+					Ids:        data.GetIds(),
+					Scores:     append([]float32(nil), data.GetScores()...),
+				},
+			}}, nil
+		}), nil
+	}
+
+	opFactory[hybridAssembleOp] = func(_ *searchTask, _ map[string]any) (operator, error) {
+		return searchPipelineTestOperator(func(ctx context.Context, span trace.Span, inputs ...any) ([]any, error) {
+			collapsed, ok := inputs[0].([]*milvuspb.SearchResults)
+			s.Require().True(ok)
+			s.Require().Len(collapsed, 1)
+			s.Nil(collapsed[0].GetResults().GetElementIndices())
+
+			rankResult, ok := inputs[1].(*milvuspb.SearchResults)
+			s.Require().True(ok)
+			return []any{rankResult}, nil
+		}), nil
+	}
+
+	pipeline, err := newPipeline(hybridSearchPipe, &searchTask{})
+	s.Require().NoError(err)
+	err = pipeline.AddNodes(&searchTask{}, &nodeDef{
+		name:    "finish",
+		inputs:  []string{"result"},
+		outputs: []string{pipelineOutput},
+		opName:  lambdaOp,
+		params: map[string]any{
+			lambdaParamKey: func(ctx context.Context, span trace.Span, inputs ...any) ([]any, error) {
+				return []any{inputs[0]}, nil
+			},
+		},
+	})
+	s.Require().NoError(err)
+
+	result, _, err := pipeline.Run(context.Background(), s.span, nil, segcore.StorageCost{})
+	s.Require().NoError(err)
+	s.True(rerankCalled)
+	s.Equal([]int64{2, 1}, result.GetResults().GetIds().GetIntId().GetData())
+	s.Equal([]float32{0.90, 0.60}, result.GetResults().GetScores())
+}
+
+func (s *SearchPipelineSuite) TestElementBestCollapseOp_UsesMetricDirection() {
+	input := &milvuspb.SearchResults{
+		Status: merr.Success(),
+		Results: &schemapb.SearchResultData{
+			NumQueries: 1,
+			TopK:       3,
+			Topks:      []int64{3},
+			Ids: &schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{
+					IntId: &schemapb.LongArray{Data: []int64{1, 1, 2}},
+				},
+			},
+			Scores:         []float32{0.8, 0.2, 0.5},
+			ElementIndices: &schemapb.LongArray{Data: []int64{0, 3, 1}},
+		},
+	}
+
+	op := &elementBestCollapseOperator{}
+	out, err := op.run(context.Background(), s.span, []*milvuspb.SearchResults{input}, []string{"L2"})
+	s.Require().NoError(err)
+
+	results := out[0].([]*milvuspb.SearchResults)
+	result := results[0].GetResults()
+
+	s.Nil(result.GetElementIndices())
+	s.Equal([]int64{1, 2}, result.GetIds().GetIntId().GetData())
+	s.Equal([]float32{0.2, 0.5}, result.GetScores())
+}
+
+func (s *SearchPipelineSuite) TestElementBestCollapseOp_RejectsEmptyMetricForElementLevelResult() {
+	input := &milvuspb.SearchResults{
+		Status: merr.Success(),
+		Results: &schemapb.SearchResultData{
+			NumQueries: 1,
+			TopK:       1,
+			Topks:      []int64{1},
+			Ids: &schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{
+					IntId: &schemapb.LongArray{Data: []int64{1}},
+				},
+			},
+			Scores:         []float32{0.8},
+			ElementIndices: &schemapb.LongArray{Data: []int64{0}},
+		},
+	}
+
+	op := &elementBestCollapseOperator{}
+	_, err := op.run(context.Background(), s.span, []*milvuspb.SearchResults{input}, []string{""})
+	s.Error(err)
+	s.Contains(err.Error(), "missing metric type")
 }
 
 // TestHybridAssembleOp_MixedFieldsDataLayoutErrors verifies that hybrid

--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -545,11 +545,11 @@ func (t *searchTask) initAdvancedSearchRequest(ctx context.Context) error {
 			return err
 		}
 
-		// Hybrid search does not yet support vector array (embedding list) fields:
-		// placeholder type is per sub-request and element-level vs embedding-list-level
-		// differentiation is not wired up on this path. Reject range search / iterator /
-		// group by on such fields here; plain top-K stays allowed for now (unchanged
-		// behavior).
+		// Hybrid search supports plain top-K on ArrayOfVector fields, including
+		// EmbList row-level search. This path does not yet use the per-sub-request
+		// placeholder type to distinguish EmbList from element-level search for
+		// advanced features, so reject range search / iterator / group by on
+		// ArrayOfVector here.
 		annsField := typeutil.GetField(t.schema.CollectionSchema, queryInfo.GetQueryFieldId())
 		if annsField != nil && annsField.GetDataType() == schemapb.DataType_ArrayOfVector {
 			if gjson.Get(queryInfo.GetSearchParams(), radiusKey).Exists() {

--- a/internal/proxy/task_search_test.go
+++ b/internal/proxy/task_search_test.go
@@ -6183,10 +6183,11 @@ func TestSearchTask_ArrayOfVectorSimpleSearch(t *testing.T) {
 	})
 }
 
-// TestSearchTask_ArrayOfVectorHybridSearch verifies that hybrid search rejects
-// range search, search iterator, and group-by on ArrayOfVector fields directly
-// at the initAdvancedSearchRequest layer (hybrid does not yet support the
-// element-level/embedding-list-level split, so all three are rejected).
+// TestSearchTask_ArrayOfVectorHybridSearch verifies that hybrid search allows
+// plain top-K on ArrayOfVector fields while rejecting range search, search
+// iterator, and group-by at the initAdvancedSearchRequest layer. Hybrid does
+// not yet apply the element-level/embedding-list-level split to these advanced
+// features, so all three are rejected for ArrayOfVector.
 func TestSearchTask_ArrayOfVectorHybridSearch(t *testing.T) {
 	paramtable.Init()
 	ctx := context.Background()
@@ -6214,13 +6215,13 @@ func TestSearchTask_ArrayOfVectorHybridSearch(t *testing.T) {
 	// rangeRadius != "" attaches a radius param to the sub-request; withIterator
 	// appends the iterator flag; groupByField != "" adds GroupByFieldKey to the
 	// outer rank params.
-	buildHybridTask := func(annsField string, rangeRadius string, withIterator bool, groupByField string) *searchTask {
+	buildHybridTaskWithMetric := func(annsField string, metricType string, rangeRadius string, withIterator bool, groupByField string) *searchTask {
 		paramsJSON := `{"nprobe": 10}`
 		if rangeRadius != "" {
 			paramsJSON = `{"nprobe": 10, "radius": ` + rangeRadius + `}`
 		}
 		subParams := []*commonpb.KeyValuePair{
-			{Key: common.MetricTypeKey, Value: metric.L2},
+			{Key: common.MetricTypeKey, Value: metricType},
 			{Key: ParamsKey, Value: paramsJSON},
 			{Key: AnnsFieldKey, Value: annsField},
 			{Key: TopKKey, Value: "10"},
@@ -6259,6 +6260,16 @@ func TestSearchTask_ArrayOfVectorHybridSearch(t *testing.T) {
 			tr:     timerecord.NewTimeRecorder("test"),
 		}
 	}
+
+	buildHybridTask := func(annsField string, rangeRadius string, withIterator bool, groupByField string) *searchTask {
+		return buildHybridTaskWithMetric(annsField, metric.L2, rangeRadius, withIterator, groupByField)
+	}
+
+	t.Run("hybrid with ArrayOfVector EmbList metric plain topK should succeed", func(t *testing.T) {
+		qt := buildHybridTaskWithMetric("emb_vec", metric.MaxSimCosine, "", false, "")
+		err := qt.initAdvancedSearchRequest(ctx)
+		assert.NoError(t, err)
+	})
 
 	t.Run("hybrid with ArrayOfVector range search should fail", func(t *testing.T) {
 		qt := buildHybridTask("emb_vec", "0.2", false, "")


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/42148
design doc: https://github.com/milvus-io/milvus-design-docs/blob/main/design_docs/20260306-struct.md

For hybrid search, we now support:
- plain topk emblist search
- plain topk element-level search where the search results will dedup with row id and rerank with others

Not yet support:
- range search
- iterator search
- group by