### PR TITLE
fix: [2.6] clamp scalar target index version by old QN current

### DIFF
--- a/internal/datacoord/index_engine_version_manager.go
+++ b/internal/datacoord/index_engine_version_manager.go
@@ -253,11 +253,15 @@ func (m *versionManagerImpl) getMaximumScalarVersion() int32 {
 
 	maximum := int32(math.MaxInt32)
 	for _, version := range m.scalarIndexVersions {
-		if version.MaximumIndexVersion == 0 {
+		// Old QueryNodes do not report MaximumIndexVersion. In that case, use
+		// CurrentIndexVersion as the conservative upper bound; maxVersion should
+		// never be lower than the current version that the node already supports.
+		maxVersion := max(version.CurrentIndexVersion, version.MaximumIndexVersion)
+		if maxVersion == 0 {
 			continue
 		}
-		if version.MaximumIndexVersion < maximum {
-			maximum = version.MaximumIndexVersion
+		if maxVersion < maximum {
+			maximum = maxVersion
 		}
 	}
 	return maximum

--- a/internal/datacoord/index_engine_version_manager_test.go
+++ b/internal/datacoord/index_engine_version_manager_test.go
@@ -369,7 +369,7 @@ func Test_IndexEngineVersionManager_GetMaximumScalarIndexEngineVersion(t *testin
 	// empty - returns MaxInt32
 	assert.Equal(t, int32(math.MaxInt32), m.GetMaximumScalarIndexEngineVersion())
 
-	// all nodes report Maximum=0 (old QNs)
+	// all nodes report Maximum=0 (old QNs) - falls back to current version as max
 	m.Startup(map[string]*sessionutil.Session{
 		"1": {
 			SessionRaw: sessionutil.SessionRaw{
@@ -378,24 +378,28 @@ func Test_IndexEngineVersionManager_GetMaximumScalarIndexEngineVersion(t *testin
 			},
 		},
 	})
-	assert.Equal(t, int32(math.MaxInt32), m.GetMaximumScalarIndexEngineVersion())
+	assert.Equal(t, int32(2), m.GetMaximumScalarIndexEngineVersion())
 
-	// new QN with Maximum set
+	// new QN with Maximum set - old QN current constrains cluster max
 	m.AddNode(&sessionutil.Session{
 		SessionRaw: sessionutil.SessionRaw{
 			ServerID:                 2,
 			ScalarIndexEngineVersion: sessionutil.IndexEngineVersion{CurrentIndexVersion: 2, MaximumIndexVersion: 5},
 		},
 	})
-	assert.Equal(t, int32(5), m.GetMaximumScalarIndexEngineVersion())
+	assert.Equal(t, int32(2), m.GetMaximumScalarIndexEngineVersion())
 
-	// another QN with lower Maximum
+	// another QN with lower Maximum - old QN current still constrains cluster max
 	m.AddNode(&sessionutil.Session{
 		SessionRaw: sessionutil.SessionRaw{
 			ServerID:                 3,
 			ScalarIndexEngineVersion: sessionutil.IndexEngineVersion{CurrentIndexVersion: 2, MaximumIndexVersion: 3},
 		},
 	})
+	assert.Equal(t, int32(2), m.GetMaximumScalarIndexEngineVersion())
+
+	// remove old QN - remaining new QNs report max directly
+	m.RemoveNode(&sessionutil.Session{SessionRaw: sessionutil.SessionRaw{ServerID: 1}})
 	assert.Equal(t, int32(3), m.GetMaximumScalarIndexEngineVersion())
 }
 
@@ -627,6 +631,27 @@ func Test_IndexEngineVersionManager_ResolveScalarIndexVersion(t *testing.T) {
 
 		// force rebuild: target=1 < clusterMinimal=2, clamped to 2
 		// clusterCurrent = MIN(3,4) = 3, clusterMax = MIN(5,6) = 5
+		assert.Equal(t, int32(2), m.ResolveScalarIndexVersion())
+	})
+
+	t.Run("old QN without maximum constrains target by current", func(t *testing.T) {
+		m := newIndexEngineVersionManager()
+		m.AddNode(&sessionutil.Session{
+			SessionRaw: sessionutil.SessionRaw{
+				ServerID:                 1,
+				ScalarIndexEngineVersion: sessionutil.IndexEngineVersion{MinimalIndexVersion: 0, CurrentIndexVersion: 2, MaximumIndexVersion: 0},
+			},
+		})
+		m.AddNode(&sessionutil.Session{
+			SessionRaw: sessionutil.SessionRaw{
+				ServerID:                 2,
+				ScalarIndexEngineVersion: sessionutil.IndexEngineVersion{MinimalIndexVersion: 0, CurrentIndexVersion: 3, MaximumIndexVersion: 3},
+			},
+		})
+		Params.Save("dataCoord.targetScalarIndexVersion", "3")
+		Params.Save("dataCoord.forceRebuildScalarSegmentIndex", "true")
+
+		// old QN (Max=0) => use CurrentIndexVersion as upper clamp
 		assert.Equal(t, int32(2), m.ResolveScalarIndexVersion())
 	})
 }


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/47417
pr: #49801