### PR TITLE
build(deps): update 2.6 build env image

### DIFF
--- a/.env
+++ b/.env
@@ -5,11 +5,11 @@ IMAGE_ARCH=amd64
 OS_NAME=ubuntu22.04
 
 # for services.builder.image in docker-compose.yml
-DATE_VERSION=20260318-39568a2
-LATEST_DATE_VERSION=20260318-39568a2
+DATE_VERSION=20260506-b5f57d9
+LATEST_DATE_VERSION=20260506-b5f57d9
 # for services.gpubuilder.image in docker-compose.yml
-GPU_DATE_VERSION=20260318-39568a2
-LATEST_GPU_DATE_VERSION=20260318-39568a2
+GPU_DATE_VERSION=20260506-b5f57d9
+LATEST_GPU_DATE_VERSION=20260506-b5f57d9
 
 # for other services in docker-compose.yml
 MINIO_ADDRESS=minio:9000
@@ -17,4 +17,3 @@ PULSAR_ADDRESS=pulsar://pulsar:6650
 ETCD_ENDPOINTS=etcd:2379
 AZURITE_CONNECTION_STRING="DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;"
 ENABLE_GCP_NATIVE=ON
-


### PR DESCRIPTION
pr: #49514

This PR updates the 2.6 branch `.env` build environment image tags to match the latest master image tag:

- `DATE_VERSION=20260506-b5f57d9`
- `LATEST_DATE_VERSION=20260506-b5f57d9`
- `GPU_DATE_VERSION=20260506-b5f57d9`
- `LATEST_GPU_DATE_VERSION=20260506-b5f57d9`

The change is intended as a focused CI probe for whether the 2.6 branch can build and test with the latest build environment image. This mirrors the `.env` update already tried on `hotfix-2.6.16`.

Note: 2.6 source still uses the Conan 1 build flow. This PR only updates the build image tags and does not migrate 2.6 to Conan 2.

Test:

- `git diff --check upstream/2.6..HEAD`
