### PR TITLE
fix: limit delegator post-load concurrency

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -583,6 +583,7 @@ queryNode:
   levelZeroForwardPolicy: FilterByBF # delegator level zero deletion forward policy, possible option["FilterByBF", "RemoteLoad"]
   streamingDeltaForwardPolicy: FilterByBF # delegator streaming deletion forward policy, possible option["FilterByBF", "Direct"]
   forwardBatchSize: 4194304 # the batch size delegator uses for forwarding stream delete in loading procedure
+  delegatorPostLoadConcurrencyFactor: 1 # delegator post-load concurrency factor after worker LoadSegments returns. Concurrency is hardware.GetCPUNum * factor
   exprCache:
     enabled: false # enable expression result cache
     capacityBytes: 268435456 # max capacity in bytes for expression result cache

--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -48,6 +48,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/shallowcopy"
 	"github.com/milvus-io/milvus/internal/util/streamrpc"
 	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/config"
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
@@ -170,6 +171,10 @@ type shardDelegator struct {
 	// schema version
 	schemaChangeMutex sync.RWMutex
 	schemaVersion     uint64
+
+	// limits delegator-side post-load work after worker LoadSegments returns.
+	postLoadSem           *syncutil.Semaphore
+	postLoadConfigHandler config.EventHandler
 
 	// streaming data catch-up state
 	catchingUpStreamingData *atomic.Bool
@@ -1278,6 +1283,9 @@ func (sd *shardDelegator) Close() {
 
 	metrics.QueryNodeDeleteBufferSize.DeleteLabelValues(paramtable.GetStringNodeID(), sd.vchannelName)
 	metrics.QueryNodeDeleteBufferRowNum.DeleteLabelValues(paramtable.GetStringNodeID(), sd.vchannelName)
+	if sd.postLoadConfigHandler != nil {
+		paramtable.Get().Unwatch(paramtable.Get().QueryNodeCfg.DelegatorPostLoadConcurrencyFactor.Key, sd.postLoadConfigHandler)
+	}
 }
 
 // As partition stats is an optimization for search/query which is not mandatory for milvus instance,
@@ -1352,6 +1360,14 @@ func NewShardDelegator(ctx context.Context, collectionID UniqueID, replicaID Uni
 
 	policy := paramtable.Get().QueryNodeCfg.LevelZeroForwardPolicy.GetValue()
 	log.Info("shard delegator setup l0 forward policy", zap.String("policy", policy))
+	postLoadSem := syncutil.NewSemaphore(paramtable.Get().QueryNodeCfg.DelegatorPostLoadConcurrencyFactor.GetAsInt())
+	postLoadConfigHandler := config.NewHandler(fmt.Sprintf("qn.delegator.postload.%s.%p", channel, postLoadSem), func(event *config.Event) {
+		if event.HasUpdated {
+			concurrency := paramtable.Get().QueryNodeCfg.DelegatorPostLoadConcurrencyFactor.GetAsInt()
+			postLoadSem.SetCapacity(concurrency)
+			log.Info("resize delegator post-load concurrency", zap.Int("concurrency", concurrency))
+		}
+	})
 
 	sd := &shardDelegator{
 		collectionID:   collectionID,
@@ -1375,6 +1391,8 @@ func NewShardDelegator(ctx context.Context, collectionID UniqueID, replicaID Uni
 		analyzerRunners:            make(map[UniqueID]function.Analyzer),
 		functionFieldType:          make(map[int64]schemapb.FunctionType),
 		l0ForwardPolicy:            policy,
+		postLoadSem:                postLoadSem,
+		postLoadConfigHandler:      postLoadConfigHandler,
 		catchingUpStreamingData:    atomic.NewBool(true),
 		latestRequiredMVCCTimeTick: atomic.NewUint64(0),
 	}
@@ -1442,6 +1460,7 @@ func NewShardDelegator(ctx context.Context, collectionID UniqueID, replicaID Uni
 	}
 
 	sd.tsCond = syncutil.NewContextCond(&sync.Mutex{})
+	paramtable.Get().Watch(paramtable.Get().QueryNodeCfg.DelegatorPostLoadConcurrencyFactor.Key, postLoadConfigHandler)
 	log.Info("finish build new shardDelegator")
 	return sd, nil
 }

--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -618,59 +618,79 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 		return nil
 	}
 
-	infos := lo.Filter(req.GetInfos(), func(info *querypb.SegmentLoadInfo, _ int) bool {
-		return !sd.distribution.SealedSegmentExistsOnNode(info.GetSegmentID(), targetNodeID)
-	})
+	return sd.withPostLoadLimit(ctx, func() error {
+		infos := lo.Filter(req.GetInfos(), func(info *querypb.SegmentLoadInfo, _ int) bool {
+			return !sd.distribution.SealedSegmentExistsOnNode(info.GetSegmentID(), targetNodeID)
+		})
 
-	candidates, err := sd.loader.LoadBloomFilterSet(ctx, req.GetCollectionID(), infos...)
-	if err != nil {
-		log.Warn("failed to load bloom filter set for segment", zap.Error(err))
-		return err
-	}
-
-	// Load BM25 stats BEFORE loadStreamDelete so stats are ready before segment becomes visible
-	err = sd.loadBM25Stats(ctx, infos, req)
-	if err != nil {
-		log.Warn("failed to load BM25 stats", zap.Error(err))
-		return err
-	}
-
-	// Build a map from segmentID to BloomFilterSet
-	bfMap := make(map[int64]pkoracle.Candidate)
-	for _, candidate := range candidates {
-		log.Info("loaded bloom filter set for sealed segment",
-			zap.Int64("segmentID", candidate.ID()),
-		)
-		bfMap[candidate.ID()] = candidate
-	}
-
-	// Build entries with Candidate before loadStreamDelete, which will atomically add them to distribution
-	entries := make([]SegmentEntry, 0, len(infos))
-	for _, info := range infos {
-		entry := SegmentEntry{
-			SegmentID:   info.GetSegmentID(),
-			PartitionID: info.GetPartitionID(),
-			NodeID:      req.GetDstNodeID(),
-			Version:     req.GetVersion(),
-			Level:       info.GetLevel(),
-			Candidate:   bfMap[info.GetSegmentID()],
+		candidates, err := sd.loader.LoadBloomFilterSet(ctx, req.GetCollectionID(), infos...)
+		if err != nil {
+			log.Warn("failed to load bloom filter set for segment", zap.Error(err))
+			return err
 		}
-		entries = append(entries, entry)
+
+		// Load BM25 stats BEFORE loadStreamDelete so stats are ready before segment becomes visible
+		err = sd.loadBM25Stats(ctx, infos, req)
+		if err != nil {
+			log.Warn("failed to load BM25 stats", zap.Error(err))
+			return err
+		}
+
+		// Build a map from segmentID to BloomFilterSet
+		bfMap := make(map[int64]pkoracle.Candidate)
+		for _, candidate := range candidates {
+			log.Info("loaded bloom filter set for sealed segment",
+				zap.Int64("segmentID", candidate.ID()),
+			)
+			bfMap[candidate.ID()] = candidate
+		}
+
+		// Build entries with Candidate before loadStreamDelete, which will atomically add them to distribution
+		entries := make([]SegmentEntry, 0, len(infos))
+		for _, info := range infos {
+			entries = append(entries, SegmentEntry{
+				SegmentID:   info.GetSegmentID(),
+				PartitionID: info.GetPartitionID(),
+				NodeID:      req.GetDstNodeID(),
+				Version:     req.GetVersion(),
+				Level:       info.GetLevel(),
+				Candidate:   bfMap[info.GetSegmentID()],
+			})
+		}
+
+		log.Debug("load delete...")
+		// loadStreamDelete now handles distribution add atomically in Phase 3
+		err = sd.loadStreamDelete(ctx, candidates, infos, req, targetNodeID, worker,
+			entries, req.GetLoadMeta().GetSchemaVersion())
+		if err != nil {
+			log.Warn("load stream delete failed", zap.Error(err))
+			// BM25 stats already loaded into idf oracle will be cleaned up
+			// automatically by SyncDistribution when the segment is not in target.
+			return err
+		}
+		log.Debug("load stream delete done")
+
+		return nil
+	})
+}
+
+func (sd *shardDelegator) withPostLoadLimit(ctx context.Context, fn func() error) error {
+	if sd.postLoadSem == nil {
+		return fn()
 	}
 
-	log.Debug("load delete...")
-	// loadStreamDelete now handles distribution add atomically in Phase 3
-	err = sd.loadStreamDelete(ctx, candidates, infos, req, targetNodeID, worker,
-		entries, req.GetLoadMeta().GetSchemaVersion())
-	if err != nil {
-		log.Warn("load stream delete failed", zap.Error(err))
-		// BM25 stats already loaded into idf oracle will be cleaned up
-		// automatically by SyncDistribution when the segment is not in target.
+	start := time.Now()
+	if err := sd.postLoadSem.Acquire(ctx); err != nil {
 		return err
 	}
-	log.Debug("load stream delete done")
+	defer sd.postLoadSem.Release()
 
-	return nil
+	log.Ctx(ctx).Debug("delegator acquired post-load slot",
+		zap.Duration("wait", time.Since(start)),
+		zap.Int("capacity", sd.postLoadSem.Cap()),
+		zap.Int("current", sd.postLoadSem.Current()))
+
+	return fn()
 }
 
 func (sd *shardDelegator) addDistributionIfVersionOK(version uint64, entries ...SegmentEntry) error {

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -60,6 +60,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/metautil"
 	"github.com/milvus-io/milvus/pkg/v3/util/metric"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v3/util/syncutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/tsoutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
@@ -989,6 +990,65 @@ func (s *DelegatorDataSuite) TestLoadSegmentsWithoutBloomFilter() {
 	s.Require().Equal(1, len(sealed[0].Segments))
 	s.NotNil(sealed[0].Segments[0].Candidate)
 	s.False(sealed[0].Segments[0].Candidate.PkCandidateExist())
+}
+
+func (s *DelegatorDataSuite) TestPostLoadLimiter() {
+	s.Run("serializes_post_load_work", func() {
+		sd := &shardDelegator{
+			postLoadSem: syncutil.NewSemaphore(1),
+		}
+		var current int32
+		var maxConcurrent int32
+		start := make(chan struct{})
+		errCh := make(chan error, 8)
+		wg := sync.WaitGroup{}
+		for i := 0; i < 8; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				err := sd.withPostLoadLimit(context.Background(), func() error {
+					running := atomic.AddInt32(&current, 1)
+					for {
+						maxValue := atomic.LoadInt32(&maxConcurrent)
+						if running <= maxValue || atomic.CompareAndSwapInt32(&maxConcurrent, maxValue, running) {
+							break
+						}
+					}
+					time.Sleep(5 * time.Millisecond)
+					atomic.AddInt32(&current, -1)
+					return nil
+				})
+				errCh <- err
+			}()
+		}
+		close(start)
+		wg.Wait()
+		close(errCh)
+		for err := range errCh {
+			s.NoError(err)
+		}
+		s.Equal(int32(1), maxConcurrent)
+		s.Equal(0, sd.postLoadSem.Current())
+	})
+
+	s.Run("returns_context_error_while_waiting", func() {
+		sd := &shardDelegator{
+			postLoadSem: syncutil.NewSemaphore(1),
+		}
+		s.NoError(sd.postLoadSem.Acquire(context.Background()))
+		defer sd.postLoadSem.Release()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+		defer cancel()
+		called := false
+		err := sd.withPostLoadLimit(ctx, func() error {
+			called = true
+			return nil
+		})
+		s.ErrorIs(err, context.DeadlineExceeded)
+		s.False(called)
+	})
 }
 
 func (s *DelegatorDataSuite) waitTargetVersion(targetVersion int64) {

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3513,9 +3513,10 @@ type queryNodeConfig struct {
 	DeleteBufferBlockSize  ParamItem `refreshable:"false"`
 
 	// delta forward
-	LevelZeroForwardPolicy      ParamItem `refreshable:"true"`
-	StreamingDeltaForwardPolicy ParamItem `refreshable:"true"`
-	ForwardBatchSize            ParamItem `refreshable:"true"`
+	LevelZeroForwardPolicy             ParamItem `refreshable:"true"`
+	StreamingDeltaForwardPolicy        ParamItem `refreshable:"true"`
+	ForwardBatchSize                   ParamItem `refreshable:"true"`
+	DelegatorPostLoadConcurrencyFactor ParamItem `refreshable:"true"`
 
 	// loader
 	DeltaDataExpansionRate      ParamItem `refreshable:"true"`
@@ -4557,6 +4558,23 @@ Max read concurrency must greater than or equal to 1, and less than or equal to 
 		Export:       true,
 	}
 	p.ForwardBatchSize.Init(base.mgr)
+
+	p.DelegatorPostLoadConcurrencyFactor = ParamItem{
+		Key:          "queryNode.delegatorPostLoadConcurrencyFactor",
+		Version:      "2.6.16",
+		Doc:          "delegator post-load concurrency factor after worker LoadSegments returns. Concurrency is hardware.GetCPUNum * factor",
+		DefaultValue: "1",
+		Formatter: func(v string) string {
+			factor := getAsInt(v)
+			if factor < 1 {
+				factor = 1
+			}
+			concurrency := hardware.GetCPUNum() * factor
+			return strconv.FormatInt(int64(concurrency), 10)
+		},
+		Export: true,
+	}
+	p.DelegatorPostLoadConcurrencyFactor.Init(base.mgr)
 
 	p.DeltaDataExpansionRate = ParamItem{
 		Key:          "querynode.deltaDataExpansionRate",

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -512,6 +512,13 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, int64(70*1024*1024), Params.DiskCacheCapacityLimit.GetAsSize())
 
 		assert.Equal(t, 2, Params.BloomFilterApplyParallelFactor.GetAsInt())
+		assert.Equal(t, hardware.GetCPUNum(), Params.DelegatorPostLoadConcurrencyFactor.GetAsInt())
+		params.Save(Params.DelegatorPostLoadConcurrencyFactor.Key, "2")
+		assert.Equal(t, hardware.GetCPUNum()*2, Params.DelegatorPostLoadConcurrencyFactor.GetAsInt())
+		params.Save(Params.DelegatorPostLoadConcurrencyFactor.Key, "0")
+		assert.Equal(t, hardware.GetCPUNum(), Params.DelegatorPostLoadConcurrencyFactor.GetAsInt())
+		params.Reset(Params.DelegatorPostLoadConcurrencyFactor.Key)
+
 		assert.Equal(t, true, Params.SkipGrowingSegmentBF.GetAsBool())
 		assert.Equal(t, true, Params.EnableSegmentFilter.GetAsBool())
 


### PR DESCRIPTION
issue: #49767

## What changed

This patch adds a request-level CPU-factor limiter for QueryNode delegator post-load work after worker `LoadSegments` returns.

The worker `LoadSegments` fan-out remains unchanged. The limiter covers the delegator-side follow-up stages before the segment becomes visible:

- `LoadBloomFilterSet`
- `loadBM25Stats`
- `loadStreamDelete`
- distribution update

A refreshable config is added:

```text
queryNode.delegatorPostLoadConcurrencyFactor
```

Default factor is `1`, so the effective concurrency is CPU cores * 1.

## Why

Delegator post-load work can spike CPU when many load requests complete around the same time. This is especially expensive when delete buffer rows, loading segments, and historical BF entries multiply the amount of BF work.

## Validation

- `git diff --check`
- `CONAN_CMD=/Users/wei.liu/Library/Python/3.9/bin/conan make build-cpp`
- `go test -tags dynamic,test github.com/milvus-io/milvus/pkg/v3/util/paramtable -run 'TestComponentParam' -count=1 -v`
- `go test -gcflags="all=-N -l" -tags dynamic,test github.com/milvus-io/milvus/internal/querynodev2/delegator -run 'TestDelegatorDataSuite/TestPostLoadLimiter' -count=1 -v -ldflags="-r ${RPATH}"`

