### PR TITLE
fix: Forward GetReplicateConfiguration in proxy service

### DIFF
--- a/internal/distributed/proxy/service.go
+++ b/internal/distributed/proxy/service.go
@@ -1186,6 +1186,11 @@ func (s *Server) UpdateReplicateConfiguration(ctx context.Context, req *milvuspb
 	return s.proxy.UpdateReplicateConfiguration(ctx, req)
 }
 
+// GetReplicateConfiguration retrieves the current cross-cluster replication topology.
+func (s *Server) GetReplicateConfiguration(ctx context.Context, req *milvuspb.GetReplicateConfigurationRequest) (*milvuspb.GetReplicateConfigurationResponse, error) {
+	return s.proxy.GetReplicateConfiguration(ctx, req)
+}
+
 // GetReplicateInfo retrieves replication-related metadata from a target Milvus cluster.
 func (s *Server) GetReplicateInfo(ctx context.Context, req *milvuspb.GetReplicateInfoRequest) (*milvuspb.GetReplicateInfoResponse, error) {
 	return s.proxy.GetReplicateInfo(ctx, req)

--- a/internal/distributed/proxy/service_test.go
+++ b/internal/distributed/proxy/service_test.go
@@ -723,6 +723,23 @@ func Test_NewServer(t *testing.T) {
 	})
 }
 
+func TestServer_GetReplicateConfiguration(t *testing.T) {
+	ctx := context.Background()
+	req := &milvuspb.GetReplicateConfigurationRequest{}
+	expectedResp := &milvuspb.GetReplicateConfigurationResponse{
+		Status:        &commonpb.Status{ErrorCode: commonpb.ErrorCode_Success},
+		Configuration: &commonpb.ReplicateConfiguration{},
+	}
+	mockProxy := mocks.NewMockProxy(t)
+	mockProxy.EXPECT().GetReplicateConfiguration(mock.Anything, req).Return(expectedResp, nil)
+
+	server := &Server{proxy: mockProxy}
+	resp, err := server.GetReplicateConfiguration(ctx, req)
+
+	assert.NoError(t, err)
+	assert.Same(t, expectedResp, resp)
+}
+
 func TestServer_Check(t *testing.T) {
 	ctx := context.Background()
 	server := getServer(t)


### PR DESCRIPTION
## Summary

Forward the public GetReplicateConfiguration RPC from the distributed proxy service to the proxy implementation, matching the existing UpdateReplicateConfiguration and GetReplicateInfo forwarding paths.

Fixes #47392

## What changed

- Add Server.GetReplicateConfiguration in internal/distributed/proxy/service.go.
- Add a regression test to ensure the distributed proxy delegates the request instead of using UnimplementedMilvusServiceServer.

## Test plan

- [x] go test -tags test -gcflags='all=-N -l' ./internal/distributed/proxy -run '^TestServer_GetReplicateConfiguration$' -count=1
- [x] make static-check