### PR TITLE
fix: [cp2.6]Forward GetReplicateConfiguration in proxy service

### DIFF
--- a/internal/distributed/proxy/service.go
+++ b/internal/distributed/proxy/service.go
@@ -1181,6 +1181,11 @@ func (s *Server) UpdateReplicateConfiguration(ctx context.Context, req *milvuspb
 	return s.proxy.UpdateReplicateConfiguration(ctx, req)
 }
 
+// GetReplicateConfiguration retrieves the current cross-cluster replication topology.
+func (s *Server) GetReplicateConfiguration(ctx context.Context, req *milvuspb.GetReplicateConfigurationRequest) (*milvuspb.GetReplicateConfigurationResponse, error) {
+	return s.proxy.GetReplicateConfiguration(ctx, req)
+}
+
 // GetReplicateInfo retrieves replication-related metadata from a target Milvus cluster.
 func (s *Server) GetReplicateInfo(ctx context.Context, req *milvuspb.GetReplicateInfoRequest) (*milvuspb.GetReplicateInfoResponse, error) {
 	return s.proxy.GetReplicateInfo(ctx, req)

--- a/internal/distributed/proxy/service_test.go
+++ b/internal/distributed/proxy/service_test.go
@@ -722,6 +722,23 @@ func Test_NewServer(t *testing.T) {
 	})
 }
 
+func TestServer_GetReplicateConfiguration(t *testing.T) {
+	ctx := context.Background()
+	req := &milvuspb.GetReplicateConfigurationRequest{}
+	expectedResp := &milvuspb.GetReplicateConfigurationResponse{
+		Status:        &commonpb.Status{ErrorCode: commonpb.ErrorCode_Success},
+		Configuration: &commonpb.ReplicateConfiguration{},
+	}
+	mockProxy := mocks.NewMockProxy(t)
+	mockProxy.EXPECT().GetReplicateConfiguration(mock.Anything, req).Return(expectedResp, nil)
+
+	server := &Server{proxy: mockProxy}
+	resp, err := server.GetReplicateConfiguration(ctx, req)
+
+	assert.NoError(t, err)
+	assert.Same(t, expectedResp, resp)
+}
+
 func TestServer_Check(t *testing.T) {
 	ctx := context.Background()
 	server := getServer(t)


### PR DESCRIPTION
Cherry-pick from master (PR still open)

pr: #49809
issue: #47392

## Summary

Cherry-picked from master PR #49809 (open - preemptive backport)

**Note**: Original PR is still open. This CP PR should be updated if the original PR changes.

## Verification

- [x] File count matches original PR
- [x] Code changes verified
- [x] No conflict markers
- [ ] make static-check (skipped by cherry-pick workflow)
