### PR TITLE
test: bound TestAzureObjectStorage/test_useIAM with a context timeout

### DIFF
--- a/internal/storage/azure_object_storage_test.go
+++ b/internal/storage/azure_object_storage_test.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
@@ -193,15 +194,29 @@ func TestAzureObjectStorage(t *testing.T) {
 	})
 
 	t.Run("test useIAM", func(t *testing.T) {
+		// newAzureObjectStorageWithConfig probes the Azure managed-identity
+		// IMDS endpoint (link-local 169.254.169.254). On hosts without an
+		// IMDS responder (bare-metal dev machines) the SDK blocks on the
+		// TCP connect until the 10min testing.M timeout. Bound each call
+		// with a short context so it fail-fast regardless of environment;
+		// the test only asserts that an error is returned.
 		var err error
 		config.UseIAM = true
-		_, err = newAzureObjectStorageWithConfig(ctx, &config)
+
+		cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		_, err = newAzureObjectStorageWithConfig(cctx, &config)
+		cancel()
 		assert.Error(t, err)
+
 		os.Setenv("AZURE_CLIENT_ID", "00000000-0000-0000-0000-00000000000")
 		os.Setenv("AZURE_TENANT_ID", "00000000-0000-0000-0000-00000000000")
 		os.Setenv("AZURE_FEDERATED_TOKEN_FILE", "/var/run/secrets/tokens/azure-identity-token")
-		_, err = newAzureObjectStorageWithConfig(ctx, &config)
+
+		cctx, cancel = context.WithTimeout(ctx, 5*time.Second)
+		_, err = newAzureObjectStorageWithConfig(cctx, &config)
+		cancel()
 		assert.Error(t, err)
+
 		config.UseIAM = false
 	})
 


### PR DESCRIPTION
### What

Wrap each `newAzureObjectStorageWithConfig` call in `TestAzureObjectStorage/test_useIAM` with a 5s `context.WithTimeout`.

### Why

The subtest validates that `newAzureObjectStorageWithConfig` returns an error for invalid managed-identity / federated-token credentials. It probes the Azure managed-identity IMDS endpoint (link-local `http://169.254.169.254`). On hosts without an IMDS responder (bare-metal Linux dev boxes) the SDK blocks on the TCP connect for ~290s, and `retry.Do(..., Attempts(CheckBucketRetryAttempts=20))` drags the whole `internal/storage` package out to the 10-min `testing.M` timeout. CI passes only by accident — cloud-VM hosts have an IMDS listener (AWS/Azure) that answers that IP, so any HTTP error returns in ms.

### How

Go's dialer honors the context deadline on the IMDS TCP connect, so a short per-call context makes it fail-fast **regardless of environment, with no sudo / network mock / opt-in flag**, and identically whether the test is run via `go test`, an IDE, `run_go_unittest.sh`, or CI. The test only asserts that an error is returned, which still holds (deadline error off-CI, auth error on CI).

Measured on bare-metal Linux: `TestAzureObjectStorage/test_useIAM` goes from the 10-min package timeout to **~9.5s**.

Single-file change; no script/CI/infra changes.
