### PR TITLE
fix: [2.6] make packed writer close idempotent

### DIFF
--- a/internal/datanode/compactor/merge_sort.go
+++ b/internal/datanode/compactor/merge_sort.go
@@ -121,7 +121,9 @@ func mergeSortMultipleSegments(ctx context.Context,
 	}
 
 	if _, err = storage.MergeSort(compactionParams.BinLogMaxSize, plan.GetSchema(), segmentReaders, writer, predicate, sortByFields); err != nil {
-		writer.Close()
+		if closeErr := writer.Close(); closeErr != nil {
+			log.Warn("failed to close writer after merge sort error", zap.Error(closeErr))
+		}
 		return nil, err
 	}
 

--- a/internal/datanode/compactor/multi_segment_writer_test.go
+++ b/internal/datanode/compactor/multi_segment_writer_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/atomic"
@@ -52,6 +53,43 @@ type MultiSegmentWriterSuite struct {
 	channel      string
 	batchSize    int
 	params       compaction.Params
+}
+
+type testCompactionAllocator struct {
+	next           int64
+	allocOneCalls  int
+	failAllocOneAt int
+}
+
+type closeErrSerializeWriter struct {
+	err error
+}
+
+func (w closeErrSerializeWriter) WriteValue(*storage.Value) error {
+	return nil
+}
+
+func (w closeErrSerializeWriter) Flush() error {
+	return nil
+}
+
+func (w closeErrSerializeWriter) Close() error {
+	return w.err
+}
+
+func (a *testCompactionAllocator) Alloc(count uint32) (int64, int64, error) {
+	start := a.next
+	a.next += int64(count)
+	return start, a.next, nil
+}
+
+func (a *testCompactionAllocator) AllocOne() (int64, error) {
+	a.allocOneCalls++
+	if a.failAllocOneAt > 0 && a.allocOneCalls == a.failAllocOneAt {
+		return 0, errors.New("ID is exhausted")
+	}
+	a.next++
+	return a.next, nil
 }
 
 func (s *MultiSegmentWriterSuite) SetupSuite() {
@@ -345,6 +383,58 @@ func (s *MultiSegmentWriterSuite) TestSegmentRotation() {
 	// Should have multiple segments
 	finalSegments := writer.GetCompactionSegments()
 	s.GreaterOrEqual(len(finalSegments), 2)
+}
+
+func (s *MultiSegmentWriterSuite) TestCloseAfterRotateAllocFailureDoesNotRecloseClosedWriter() {
+	schema := s.genSimpleSchema()
+	segmentAlloc := &testCompactionAllocator{next: 1000, failAllocOneAt: 2}
+	logAlloc := &testCompactionAllocator{next: 2000}
+	allocator := NewCompactionAllocator(segmentAlloc, logAlloc)
+
+	writer, err := NewMultiSegmentWriter(
+		context.Background(),
+		s.mockBinlogIO,
+		allocator,
+		1,
+		schema,
+		s.params,
+		1000,
+		s.partitionID,
+		s.collectionID,
+		s.channel,
+		1,
+		storage.WithStorageConfig(s.params.StorageConfig),
+	)
+	s.Require().NoError(err)
+
+	err = writer.WriteValue(s.genTestValue(1))
+	s.Require().NoError(err)
+	err = writer.WriteValue(s.genTestValue(2))
+	s.Require().Error(err)
+	s.Contains(err.Error(), "ID is exhausted")
+	s.Nil(writer.writer)
+	s.Len(writer.GetCompactionSegments(), 1)
+
+	err = writer.Close()
+	s.NoError(err)
+	s.Len(writer.GetCompactionSegments(), 1)
+}
+
+func (s *MultiSegmentWriterSuite) TestCloseFailureClearsWriter() {
+	closeErr := errors.New("close failed")
+	writer := &MultiSegmentWriter{
+		writer: &storage.BinlogValueWriter{
+			SerializeWriter: closeErrSerializeWriter{err: closeErr},
+		},
+	}
+
+	err := writer.closeWriter()
+	s.ErrorIs(err, closeErr)
+	s.Nil(writer.writer)
+	s.Empty(writer.GetCompactionSegments())
+
+	err = writer.Close()
+	s.NoError(err)
 }
 
 func (s *MultiSegmentWriterSuite) TestWriterMethods() {

--- a/internal/datanode/compactor/segment_writer.go
+++ b/internal/datanode/compactor/segment_writer.go
@@ -115,17 +115,21 @@ func NewMultiSegmentWriter(ctx context.Context, binlogIO io.BinlogIO, allocator 
 
 func (w *MultiSegmentWriter) closeWriter() error {
 	if w.writer != nil {
-		if err := w.writer.Close(); err != nil {
+		writer := w.writer
+		w.writer = nil
+		if err := writer.Close(); err != nil {
 			return err
 		}
 
-		fieldBinlogs, statsLog, bm25Logs, manifest := w.writer.GetLogs()
+		fieldBinlogs, statsLog, bm25Logs, manifest := writer.GetLogs()
+		rowNum := writer.GetRowNum()
+		writtenUncompressed := writer.GetWrittenUncompressed()
 
 		result := &datapb.CompactionSegment{
 			SegmentID:           w.currentSegmentID,
 			InsertLogs:          storage.SortFieldBinlogs(fieldBinlogs),
 			Field2StatslogPaths: []*datapb.FieldBinlog{statsLog},
-			NumOfRows:           w.writer.GetRowNum(),
+			NumOfRows:           rowNum,
 			Channel:             w.channel,
 			Bm25Logs:            lo.Values(bm25Logs),
 			StorageVersion:      w.storageVersion,
@@ -137,8 +141,8 @@ func (w *MultiSegmentWriter) closeWriter() error {
 		log.Info("created new segment",
 			zap.Int64("segmentID", w.currentSegmentID),
 			zap.String("channel", w.channel),
-			zap.Int64("totalRows", w.writer.GetRowNum()),
-			zap.Uint64("totalSize", w.writer.GetWrittenUncompressed()),
+			zap.Int64("totalRows", rowNum),
+			zap.Uint64("totalSize", writtenUncompressed),
 			zap.Int64("expected segment size", w.segmentSize),
 			zap.Int64("storageVersion", w.storageVersion))
 	}

--- a/internal/storagev2/packed/packed_test.go
+++ b/internal/storagev2/packed/packed_test.go
@@ -171,3 +171,16 @@ func randomString(length int) string {
 	}
 	return string(result)
 }
+
+func (suite *PackedTestSuite) TestCloseIsIdempotent() {
+	paths := []string{"/tmp/close_idempotent"}
+	columnGroups := []storagecommon.ColumnGroup{{Columns: []int{0, 1, 2}, GroupID: storagecommon.DefaultShortColumnGroupID}}
+	pw, err := NewPackedWriter(paths, suite.schema, int64(10*1024*1024), 0, columnGroups, nil, nil)
+	suite.NoError(err)
+	err = pw.WriteRecordBatch(suite.rec)
+	suite.NoError(err)
+	err = pw.Close()
+	suite.NoError(err)
+	err = pw.Close()
+	suite.NoError(err)
+}

--- a/internal/storagev2/packed/packed_writer.go
+++ b/internal/storagev2/packed/packed_writer.go
@@ -131,6 +131,13 @@ func NewPackedWriter(filePaths []string, schema *arrow.Schema, bufferSize int64,
 }
 
 func (pw *PackedWriter) WriteRecordBatch(recordBatch arrow.Record) error {
+	if recordBatch == nil || recordBatch.NumCols() == 0 {
+		return nil
+	}
+	if pw.cPackedWriter == nil {
+		return errors.New("packed writer is closed")
+	}
+
 	cArrays := make([]CArrowArray, recordBatch.NumCols())
 	cSchemas := make([]CArrowSchema, recordBatch.NumCols())
 
@@ -155,7 +162,12 @@ func (pw *PackedWriter) WriteRecordBatch(recordBatch arrow.Record) error {
 }
 
 func (pw *PackedWriter) Close() error {
-	status := C.CloseWriter(pw.cPackedWriter)
+	if pw.cPackedWriter == nil {
+		return nil
+	}
+	cPackedWriter := pw.cPackedWriter
+	pw.cPackedWriter = nil
+	status := C.CloseWriter(cPackedWriter)
 	if err := ConsumeCStatusIntoError(&status); err != nil {
 		return err
 	}


### PR DESCRIPTION
Cherry-pick from master
pr: #49813
Related to #49790

Packed writer close transfers ownership of the C++ wrapper to C, which deletes the wrapper before returning. Clear the Go-side C pointer before calling Close/CloseAndTell so cleanup paths cannot pass a freed pointer back into C.

Also clear MultiSegmentWriter state after a successful close, preserve the original merge-sort error when cleanup close fails, and add regression coverage for repeated close and rotate allocation failure cleanup.